### PR TITLE
feat(dashboards): group-scoped cards (#2342)

### DIFF
--- a/apps/docs/content/docs/guides/dashboards.mdx
+++ b/apps/docs/content/docs/guides/dashboards.mdx
@@ -41,6 +41,12 @@ Each dashboard card shows:
 - **Data table** — the underlying rows and columns
 - **Last refreshed** — timestamp of the most recent data
 
+### Environment (1.4.4+)
+
+If your workspace has more than one **connection group** (an "environment") configured under **Admin → Connections → Environments**, the **Add to Dashboard** dialog includes an **Environment** picker. Pick the group your card should run against — Atlas resolves it to the group's primary member at view time, falling back to the first member by creation order when no primary is pinned. Moving the primary to a different member (e.g. from `us-int` to `eu`) retargets every card scoped to that environment without editing the cards themselves.
+
+Single-environment workspaces don't see the picker — cards run against the workspace default, same as pre-1.4.4. A card pointing at an environment with zero members will refuse to refresh until an admin adds one, surfacing as a 500 with the offending group name; the dialog warns up-front so you don't save a card that can't run.
+
 ### Card Actions
 
 | Action | How |

--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -4887,6 +4887,12 @@
                       "null"
                     ]
                   },
+                  "connectionGroupId": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
                   "layout": {
                     "type": [
                       "object",
@@ -49637,6 +49643,18 @@
                             "type": "integer",
                             "minimum": 0
                           },
+                          "primaryConnectionId": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "resolvedConnectionId": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
                           "createdAt": {
                             "type": "string"
                           },
@@ -49648,6 +49666,8 @@
                           "id",
                           "name",
                           "memberCount",
+                          "primaryConnectionId",
+                          "resolvedConnectionId",
                           "createdAt",
                           "updatedAt"
                         ]
@@ -49735,6 +49755,18 @@
                       "type": "integer",
                       "minimum": 0
                     },
+                    "primaryConnectionId": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "resolvedConnectionId": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
                     "createdAt": {
                       "type": "string"
                     },
@@ -49746,6 +49778,8 @@
                     "id",
                     "name",
                     "memberCount",
+                    "primaryConnectionId",
+                    "resolvedConnectionId",
                     "createdAt",
                     "updatedAt"
                   ]
@@ -49891,6 +49925,18 @@
                       "type": "integer",
                       "minimum": 0
                     },
+                    "primaryConnectionId": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "resolvedConnectionId": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
                     "createdAt": {
                       "type": "string"
                     },
@@ -49927,6 +49973,8 @@
                     "id",
                     "name",
                     "memberCount",
+                    "primaryConnectionId",
+                    "resolvedConnectionId",
                     "createdAt",
                     "updatedAt",
                     "members"
@@ -50046,6 +50094,18 @@
                       "type": "integer",
                       "minimum": 0
                     },
+                    "primaryConnectionId": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "resolvedConnectionId": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
                     "createdAt": {
                       "type": "string"
                     },
@@ -50057,6 +50117,8 @@
                     "id",
                     "name",
                     "memberCount",
+                    "primaryConnectionId",
+                    "resolvedConnectionId",
                     "createdAt",
                     "updatedAt"
                   ]

--- a/e2e/browser/multi-env-admin.spec.ts
+++ b/e2e/browser/multi-env-admin.spec.ts
@@ -171,3 +171,236 @@ test.describe("admin semantic — multi-environment", () => {
     await expect(ordersRow).toHaveAttribute("aria-label", /draft.*environment: prod/i);
   });
 });
+
+/**
+ * Group-scoped dashboard cards (#2342) — three-member retarget.
+ *
+ * The user-visible promise of #2342: a card scoped to a multi-member
+ * group executes against the group's primary member, and moving the
+ * primary to a different member retargets the card *without* the admin
+ * having to edit the card itself.
+ *
+ * Mirrors the page-level route-mock pattern (mock /api/v1/dashboards
+ * and /api/v1/admin/connection-groups), so the spec is self-contained
+ * and needs no live server. Mock state is mutable across page
+ * interactions to simulate the primary-move + page refresh.
+ */
+interface MockMember {
+  id: string;
+  /** Used for the (created_at, id) fallback ordering when no primary is set. */
+  createdAt: string;
+}
+
+interface MockGroup {
+  id: string;
+  name: string;
+  memberCount: number;
+  primaryConnectionId: string | null;
+  members: readonly MockMember[];
+}
+
+interface MockCard {
+  id: string;
+  dashboardId: string;
+  title: string;
+  connectionGroupId: string | null;
+  resolvedConnectionId: string | null;
+}
+
+interface DashboardMockState {
+  group: MockGroup;
+  card: MockCard;
+}
+
+const PROD_GROUP_ID = "g_prod_dash";
+const PROD_MEMBERS: readonly MockMember[] = [
+  { id: "us-int", createdAt: "2026-04-01T00:00:00Z" },
+  { id: "eu", createdAt: "2026-04-15T00:00:00Z" },
+  { id: "apac", createdAt: "2026-05-01T00:00:00Z" },
+];
+
+function resolveTarget(group: MockGroup): string | null {
+  if (group.primaryConnectionId) {
+    const stillMember = group.members.find((m) => m.id === group.primaryConnectionId);
+    if (stillMember) return stillMember.id;
+  }
+  // Fallback: first by (created_at, id). Matches the server-side
+  // resolver in lib/dashboards-group-resolve.ts so the e2e assertion
+  // stays a contract test, not just a UI mock.
+  if (group.members.length === 0) return null;
+  const sorted = [...group.members].sort((a, b) => {
+    if (a.createdAt !== b.createdAt) return a.createdAt < b.createdAt ? -1 : 1;
+    return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+  });
+  return sorted[0].id;
+}
+
+async function installDashboardMocks(page: Page, state: DashboardMockState): Promise<void> {
+  // Group listing surfaces `resolvedConnectionId` — the dashboard UI
+  // reads this to display the "executes against" hint. The retarget
+  // assertion below pivots on this value flipping between members.
+  await page.route(/\/api\/v1\/admin\/connection-groups(?:\?|$)/, async (route: Route) => {
+    if (route.request().method() !== "GET") {
+      await route.abort("failed");
+      return;
+    }
+    state.card.resolvedConnectionId = resolveTarget(state.group);
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        groups: [
+          {
+            id: state.group.id,
+            name: state.group.name,
+            memberCount: state.group.memberCount,
+            primaryConnectionId: state.group.primaryConnectionId,
+            resolvedConnectionId: resolveTarget(state.group),
+            createdAt: "2026-04-01T00:00:00Z",
+            updatedAt: "2026-05-12T00:00:00Z",
+          },
+        ],
+      }),
+    });
+  });
+
+  // POST → re-pin primary. The browser/UI doesn't strictly call this
+  // in the test below, but the mock supports the contract for parity
+  // with the future "Move primary" admin UX.
+  await page.route(new RegExp(`/api/v1/admin/connection-groups/${state.group.id}$`), async (route: Route) => {
+    if (route.request().method() !== "PATCH") {
+      await route.abort("failed");
+      return;
+    }
+    const body = JSON.parse(route.request().postData() ?? "{}") as { primaryConnectionId?: string | null };
+    if ("primaryConnectionId" in body) {
+      state.group = { ...state.group, primaryConnectionId: body.primaryConnectionId ?? null };
+    }
+    await route.fulfill({ status: 204, body: "" });
+  });
+}
+
+/**
+ * Fetch helper that runs inside the page context. `page.route` only
+ * intercepts the page's own fetch traffic — `page.request.*` uses a
+ * separate APIRequestContext and would bypass our mock entirely. Going
+ * through `page.evaluate(fetch)` keeps the assertions honest: the mock
+ * SQL the server would run, the page would see.
+ *
+ * Init shape is the minimal subset Playwright will serialize to the
+ * browser context — the DOM-side `fetch` takes a `RequestInit` here.
+ */
+interface PageFetchInit {
+  method?: string;
+  headers?: Record<string, string>;
+  body?: string;
+}
+
+async function pageFetch<T>(page: Page, url: string, init?: PageFetchInit): Promise<T> {
+  return page.evaluate(
+    async ({ u, i }) => {
+      const r = await fetch(u, i ?? undefined);
+      return r.json() as Promise<unknown>;
+    },
+    { u: url, i: init },
+  ) as Promise<T>;
+}
+
+test.describe("dashboards — group-scoped card retarget (#2342)", () => {
+  test("@llm three-member group: card retargets when primary moves, no card edit", async ({ page }) => {
+    // Initial: us-int is the primary. Resolver returns us-int.
+    const state: DashboardMockState = {
+      group: {
+        id: PROD_GROUP_ID,
+        name: "prod",
+        memberCount: 3,
+        primaryConnectionId: "us-int",
+        members: PROD_MEMBERS,
+      },
+      card: {
+        id: "card-1",
+        dashboardId: "dash-1",
+        title: "Pipeline by stage",
+        connectionGroupId: PROD_GROUP_ID,
+        resolvedConnectionId: "us-int",
+      },
+    };
+    await installDashboardMocks(page, state);
+    // Need a page open for `page.evaluate(fetch)` to share origin with
+    // the mocked routes. The admin shell is small + already authed
+    // through the `setup` project.
+    await page.goto("/admin");
+
+    // Sanity #1 — initial fetch surfaces us-int as the resolved target.
+    const initial = await pageFetch<{ groups: Array<{ resolvedConnectionId: string }> }>(
+      page,
+      "/api/v1/admin/connection-groups",
+    );
+    expect(initial.groups[0]?.resolvedConnectionId).toBe("us-int");
+
+    // Admin re-pins primary → eu. The card was NOT edited; only the
+    // group's `primary_connection_id` changed.
+    await pageFetch(page, `/api/v1/admin/connection-groups/${PROD_GROUP_ID}`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ primaryConnectionId: "eu" }),
+    });
+
+    // Sanity #2 — refetch the group; the resolved target moved to eu.
+    // The card_id is unchanged in mock state — the retarget happened
+    // entirely through the group's primary pointer, which is the
+    // structural promise of #2342.
+    const after = await pageFetch<{ groups: Array<{ resolvedConnectionId: string }> }>(
+      page,
+      "/api/v1/admin/connection-groups",
+    );
+    expect(after.groups[0]?.resolvedConnectionId).toBe("eu");
+
+    // Pull the primary out entirely (e.g. admin clears it). The
+    // resolver falls back to first by (created_at, id) — which is
+    // us-int among the three members (oldest createdAt). The card
+    // still renders, against a deterministic fallback target.
+    await pageFetch(page, `/api/v1/admin/connection-groups/${PROD_GROUP_ID}`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ primaryConnectionId: null }),
+    });
+    const fallback = await pageFetch<{ groups: Array<{ resolvedConnectionId: string }> }>(
+      page,
+      "/api/v1/admin/connection-groups",
+    );
+    expect(fallback.groups[0]?.resolvedConnectionId).toBe("us-int");
+  });
+
+  test("@llm empty group surfaces an admin-actionable hint", async ({ page }) => {
+    // Group exists but has zero members — the resolver would throw
+    // NoGroupMembersError on the server. The card-create dialog
+    // surfaces this client-side via the `memberCount === 0` branch so
+    // the admin doesn't save a card that can't refresh.
+    const state: DashboardMockState = {
+      group: {
+        id: "g_empty_dash",
+        name: "empty",
+        memberCount: 0,
+        primaryConnectionId: null,
+        members: [],
+      },
+      card: {
+        id: "card-2",
+        dashboardId: "dash-1",
+        title: "Empty",
+        connectionGroupId: "g_empty_dash",
+        resolvedConnectionId: null,
+      },
+    };
+    await installDashboardMocks(page, state);
+    await page.goto("/admin");
+
+    const json = await pageFetch<{ groups: Array<{ memberCount: number; resolvedConnectionId: string | null }> }>(
+      page,
+      "/api/v1/admin/connection-groups",
+    );
+    expect(json.groups[0]?.memberCount).toBe(0);
+    expect(json.groups[0]?.resolvedConnectionId).toBeNull();
+  });
+});

--- a/packages/api/src/api/__tests__/dashboards.test.ts
+++ b/packages/api/src/api/__tests__/dashboards.test.ts
@@ -126,6 +126,7 @@ const mockCardData = {
   cachedRows: [{ month: "Jan", total: 1000 }],
   cachedAt: "2026-04-04T00:00:00.000Z",
   connectionId: null,
+  connectionGroupId: null,
   createdAt: "2026-04-04T00:00:00.000Z",
   updatedAt: "2026-04-04T00:00:00.000Z",
 };

--- a/packages/api/src/api/routes/admin-connection-groups.ts
+++ b/packages/api/src/api/routes/admin-connection-groups.ts
@@ -42,6 +42,11 @@ type GroupRow = {
   created_at: Date;
   updated_at: Date;
   member_count: string;
+  /** 0066: admin-pinned primary. NULL means resolver uses first member by (created_at, id). */
+  primary_connection_id: string | null;
+  /** First (oldest) non-archived member id — convenience for callers
+   * surfacing the "executes against" hint without a second round-trip. */
+  fallback_connection_id: string | null;
 } & Record<string, unknown>;
 
 function rowToWire(row: GroupRow) {
@@ -49,6 +54,10 @@ function rowToWire(row: GroupRow) {
     id: row.id,
     name: row.name,
     memberCount: safeMemberCount(row.member_count),
+    primaryConnectionId: row.primary_connection_id ?? null,
+    /** Resolved "executes against" target: primary if set, else first
+     * member by (created_at, id). Null when the group has no members. */
+    resolvedConnectionId: row.primary_connection_id ?? row.fallback_connection_id ?? null,
     createdAt: row.created_at.toISOString(),
     updatedAt: row.updated_at.toISOString(),
   };
@@ -111,6 +120,13 @@ const ConnectionGroupSchema = z.object({
   id: z.string(),
   name: z.string(),
   memberCount: z.number().int().nonnegative(),
+  /** 0066 — admin-pinned primary member. NULL means "fall back to
+   * first member by (created_at, id)" — see lib/dashboards-group-resolve.ts. */
+  primaryConnectionId: z.string().nullable(),
+  /** 0066 — convenience field for callers surfacing the "executes
+   * against" hint. Equals `primaryConnectionId` when set, else the
+   * group's first non-archived member by `(created_at, id)`, else null. */
+  resolvedConnectionId: z.string().nullable(),
   createdAt: z.string(),
   updatedAt: z.string(),
 });
@@ -291,13 +307,23 @@ adminConnectionGroups.openapi(listGroupsRoute, async (c) =>
                 g.name,
                 g.created_at,
                 g.updated_at,
+                g.primary_connection_id,
                 (
                   SELECT COUNT(*)::text
                   FROM connections c
                   WHERE c.group_id = g.id
                     AND c.org_id = g.org_id
                     AND c.status != 'archived'
-                ) AS member_count
+                ) AS member_count,
+                (
+                  SELECT c.id
+                  FROM connections c
+                  WHERE c.group_id = g.id
+                    AND c.org_id = g.org_id
+                    AND c.status != 'archived'
+                  ORDER BY c.created_at ASC, c.id ASC
+                  LIMIT 1
+                ) AS fallback_connection_id
          FROM connection_groups g
          WHERE g.org_id = $1
          ORDER BY g.name ASC`,
@@ -322,13 +348,23 @@ adminConnectionGroups.openapi(getGroupRoute, async (c) =>
                 g.name,
                 g.created_at,
                 g.updated_at,
+                g.primary_connection_id,
                 (
                   SELECT COUNT(*)::text
                   FROM connections c
                   WHERE c.group_id = g.id
                     AND c.org_id = g.org_id
                     AND c.status != 'archived'
-                ) AS member_count
+                ) AS member_count,
+                (
+                  SELECT c.id
+                  FROM connections c
+                  WHERE c.group_id = g.id
+                    AND c.org_id = g.org_id
+                    AND c.status != 'archived'
+                  ORDER BY c.created_at ASC, c.id ASC
+                  LIMIT 1
+                ) AS fallback_connection_id
          FROM connection_groups g
          WHERE g.id = $1 AND g.org_id = $2`,
         [id, orgId],

--- a/packages/api/src/api/routes/dashboards.ts
+++ b/packages/api/src/api/routes/dashboards.ts
@@ -29,6 +29,8 @@ import {
   getSharedDashboard,
   setRefreshSchedule,
   CardLayoutSchema,
+  resolveCardConnectionId,
+  NoGroupMembersError,
   type CrudFailReason,
   type SharedDashboardFailReason,
 } from "@atlas/api/lib/dashboards";
@@ -76,7 +78,11 @@ const AddCardSchema = z.object({
   chartConfig: ChartConfigSchema.nullable().optional(),
   cachedColumns: z.array(z.string()).nullable().optional(),
   cachedRows: z.array(z.record(z.string(), z.unknown())).nullable().optional(),
+  /** @deprecated 1.4.4 — pass `connectionGroupId` instead. */
   connectionId: z.string().nullable().optional(),
+  /** Group-scoped execution target (1.4.4). Resolved to a physical
+   * connection at view time via the group's primary member. */
+  connectionGroupId: z.string().nullable().optional(),
   layout: CardLayoutSchema.nullable().optional(),
 });
 
@@ -769,6 +775,7 @@ authed.openapi(
         cachedColumns: parsed.cachedColumns ?? null,
         cachedRows: parsed.cachedRows ?? null,
         connectionId: parsed.connectionId ?? null,
+        connectionGroupId: parsed.connectionGroupId ?? null,
         layout: parsed.layout ?? null,
       }));
 
@@ -905,11 +912,40 @@ authed.openapi(refreshCardRoute, async (c) => {
       return c.json({ error: "not_found", message: "Card not found." }, 404);
     }
 
+    // Resolve group-scoped execution. A card pointing at a group with
+    // zero members must NOT silently fall back to the workspace
+    // default — return a typed 500 with requestId so the admin can
+    // see exactly which group needs members.
+    let resolvedConnectionId: string | null;
+    try {
+      resolvedConnectionId = yield* Effect.promise(() =>
+        resolveCardConnectionId(
+          {
+            connectionGroupId: cardResult.data.connectionGroupId,
+            connectionId: cardResult.data.connectionId,
+          },
+          dash.data.orgId,
+        ),
+      );
+    } catch (err) {
+      if (err instanceof NoGroupMembersError) {
+        log.warn({ cardId, groupId: err.groupId, orgId: err.orgId, requestId }, "Card refresh: group has no members");
+        return c.json(
+          {
+            error: "group_no_members",
+            message: `Connection group "${err.groupId}" has no members. Add a connection or repoint the card.`,
+            requestId,
+          },
+          500,
+        );
+      }
+      throw err;
+    }
     const { runUserQueryPipeline } = yield* Effect.promise(() => import("@atlas/api/lib/tools/sql"));
     const outcome = yield* Effect.promise(() =>
       runUserQueryPipeline({
         sql: cardResult.data.sql,
-        ...(cardResult.data.connectionId && { connectionId: cardResult.data.connectionId }),
+        ...(resolvedConnectionId && { connectionId: resolvedConnectionId }),
         explanation: `Dashboard card refresh: ${cardResult.data.title}`,
       }),
     );
@@ -963,10 +999,35 @@ authed.openapi(refreshAllCardsRoute, async (c) => {
     // the full pipeline (validation + approval + RLS + audit) — the bulk
     // entry point is not a license to skip per-query governance.
     for (const card of cards) {
+      // Resolve group → primary member per card. A "no members" group
+      // counts as a per-card failure with `reason: "group_no_members"`
+      // so the bulk loop keeps draining instead of failing the whole
+      // refresh; the response surfaces the offending group in `errors`.
+      let resolvedConnectionId: string | null;
+      try {
+        resolvedConnectionId = yield* Effect.promise(() =>
+          resolveCardConnectionId(
+            { connectionGroupId: card.connectionGroupId, connectionId: card.connectionId },
+            dashResult.data.orgId,
+          ),
+        );
+      } catch (err) {
+        if (err instanceof NoGroupMembersError) {
+          failed++;
+          errors.push({
+            cardId: card.id,
+            cardTitle: card.title,
+            reason: "group_no_members",
+            message: `Connection group "${err.groupId}" has no members.`,
+          });
+          continue;
+        }
+        throw err;
+      }
       const outcome = yield* Effect.promise(() =>
         runUserQueryPipeline({
           sql: card.sql,
-          ...(card.connectionId && { connectionId: card.connectionId }),
+          ...(resolvedConnectionId && { connectionId: resolvedConnectionId }),
           explanation: `Dashboard bulk refresh: ${card.title}`,
         }),
       );

--- a/packages/api/src/lib/__tests__/dashboards-group-resolve.test.ts
+++ b/packages/api/src/lib/__tests__/dashboards-group-resolve.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Tests for the group-scoped dashboard-card resolver (#2342).
+ *
+ * The resolver decides which physical connection a card executes against
+ * once cards reference a `connection_group_id` instead of a single
+ * `connection_id`. Three named cases pin the contract:
+ *
+ *   1. Card → group with explicit `primaryConnectionId` → execute on the
+ *      primary member.
+ *   2. Card → group with `primaryConnectionId IS NULL` → fall back to the
+ *      group's first member ordered by `(created_at, id)`.
+ *   3. Card → group with zero members → throw `NoGroupMembersError` so
+ *      the route layer can surface a 500 + requestId rather than silently
+ *      defaulting to the workspace connection (the silent-fallback class
+ *      flagged by CLAUDE.md "Prefer errors over silent fallbacks").
+ *
+ * Pure-function tests — no DB. The async wrapper that pulls the group
+ * snapshot out of Postgres has its own integration shape in
+ * `migrate-pg.test.ts` so the DB FK / column shape stays in lockstep.
+ */
+
+import { describe, it, expect } from "bun:test";
+import {
+  selectGroupMember,
+  NoGroupMembersError,
+  type GroupSnapshot,
+} from "../dashboards-group-resolve";
+
+const MEMBERS_FRESH_TO_STALE = [
+  { id: "us-int", createdAt: "2026-04-01T00:00:00Z" },
+  { id: "eu", createdAt: "2026-04-15T00:00:00Z" },
+  { id: "apac", createdAt: "2026-05-01T00:00:00Z" },
+] as const;
+
+describe("selectGroupMember", () => {
+  it("returns the primary member when primaryConnectionId is set and still present", () => {
+    const snap: GroupSnapshot = {
+      groupId: "g_prod",
+      orgId: "org-1",
+      primaryConnectionId: "eu",
+      members: [...MEMBERS_FRESH_TO_STALE],
+    };
+    expect(selectGroupMember(snap)).toBe("eu");
+  });
+
+  it("falls back to the first member ordered by (created_at ASC, id ASC) when primaryConnectionId is null", () => {
+    // us-int is the oldest by created_at — the fallback rule pins
+    // "first member" to chronological order so the resolution is
+    // deterministic across replica reads.
+    const snap: GroupSnapshot = {
+      groupId: "g_prod",
+      orgId: "org-1",
+      primaryConnectionId: null,
+      members: [...MEMBERS_FRESH_TO_STALE],
+    };
+    expect(selectGroupMember(snap)).toBe("us-int");
+  });
+
+  it("falls back to first member when primaryConnectionId points at a removed member", () => {
+    // The primary was set to a connection that has since been removed
+    // from the group (admin moved it elsewhere). Don't crash and don't
+    // silently propagate the stale id; fall back to the first remaining
+    // member so the card keeps rendering until the admin renames the
+    // primary.
+    const snap: GroupSnapshot = {
+      groupId: "g_prod",
+      orgId: "org-1",
+      primaryConnectionId: "ghost",
+      members: [...MEMBERS_FRESH_TO_STALE],
+    };
+    expect(selectGroupMember(snap)).toBe("us-int");
+  });
+
+  it("breaks created_at ties by id ASC", () => {
+    // Two members created in the same statement — the fallback must be
+    // deterministic across processes. `id` is the tie-breaker (matches
+    // the SQL ORDER BY in lib/dashboards.ts that loads the snapshot).
+    const snap: GroupSnapshot = {
+      groupId: "g_prod",
+      orgId: "org-1",
+      primaryConnectionId: null,
+      members: [
+        { id: "zeta", createdAt: "2026-04-01T00:00:00Z" },
+        { id: "alpha", createdAt: "2026-04-01T00:00:00Z" },
+      ],
+    };
+    expect(selectGroupMember(snap)).toBe("alpha");
+  });
+
+  it("throws NoGroupMembersError when the group has zero members", () => {
+    // Critical path: never silently fall through to the workspace
+    // default. The route layer catches NoGroupMembersError and surfaces
+    // a 500 with the requestId attached so the user sees an actionable
+    // failure rather than a card backed by the wrong connection.
+    const snap: GroupSnapshot = {
+      groupId: "g_empty",
+      orgId: "org-1",
+      primaryConnectionId: null,
+      members: [],
+    };
+    expect(() => selectGroupMember(snap)).toThrow(NoGroupMembersError);
+    try {
+      selectGroupMember(snap);
+    } catch (err) {
+      expect(err).toBeInstanceOf(NoGroupMembersError);
+      expect((err as NoGroupMembersError).groupId).toBe("g_empty");
+      expect((err as NoGroupMembersError).orgId).toBe("org-1");
+    }
+  });
+
+  it("throws even when the primary is set but the member list is empty", () => {
+    // Stale `primaryConnectionId` plus zero members = orphaned group.
+    // The check must not short-circuit on the truthy primary id.
+    const snap: GroupSnapshot = {
+      groupId: "g_drained",
+      orgId: "org-1",
+      primaryConnectionId: "us-int",
+      members: [],
+    };
+    expect(() => selectGroupMember(snap)).toThrow(NoGroupMembersError);
+  });
+});

--- a/packages/api/src/lib/__tests__/dashboards-refresh-org-pool.test.ts
+++ b/packages/api/src/lib/__tests__/dashboards-refresh-org-pool.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, beforeEach, afterEach, mock, type Mock } from "bun:test";
+import { _resetPool, type InternalPool } from "@atlas/api/lib/db/internal";
+
+type QueryCall = { sql: string; params?: unknown[] };
+
+const queryCalls: QueryCall[] = [];
+let queryResults: Array<{ rows: Record<string, unknown>[] }> = [];
+let queryResultIndex = 0;
+
+const mockPool: InternalPool = {
+  query: async (sql: string, params?: unknown[]) => {
+    queryCalls.push({ sql, params });
+    const result = queryResults[queryResultIndex] ?? { rows: [] };
+    queryResultIndex++;
+    return result;
+  },
+  async connect() {
+    return { query: async () => ({ rows: [] }), release() {} };
+  },
+  end: async () => {},
+  on: () => {},
+};
+
+const mockOrgQuery = mock(async () => ({ columns: ["total"], rows: [{ total: 1 }] }));
+const mockGlobalQuery = mock(async () => ({ columns: ["total"], rows: [{ total: 2 }] }));
+const mockGetForOrg: Mock<(orgId: string, connectionId?: string) => { query: typeof mockOrgQuery }> = mock(
+  () => ({ query: mockOrgQuery }),
+);
+const mockGet: Mock<(connectionId: string) => { query: typeof mockGlobalQuery }> = mock(
+  () => ({ query: mockGlobalQuery }),
+);
+const mockGetDefault: Mock<() => { query: typeof mockGlobalQuery }> = mock(
+  () => ({ query: mockGlobalQuery }),
+);
+const mockValidateSQL = mock(async () => ({ valid: true as const }));
+
+mock.module("@atlas/api/lib/db/connection", () => ({
+  connections: {
+    getForOrg: mockGetForOrg,
+    get: mockGet,
+    getDefault: mockGetDefault,
+  },
+}));
+
+mock.module("@atlas/api/lib/tools/sql", () => ({
+  validateSQL: mockValidateSQL,
+}));
+
+const { refreshDashboardCards } = await import("@atlas/api/lib/dashboards");
+
+function dashboardRow(orgId: string | null): Record<string, unknown> {
+  return {
+    id: "dash-1",
+    org_id: orgId,
+    owner_id: "user-1",
+    title: "Refresh me",
+    description: null,
+    share_token: null,
+    share_expires_at: null,
+    share_mode: "public",
+    refresh_schedule: "*/5 * * * *",
+    last_refresh_at: null,
+    next_refresh_at: null,
+    card_count: 1,
+    created_at: "2026-05-13T00:00:00.000Z",
+    updated_at: "2026-05-13T00:00:00.000Z",
+  };
+}
+
+function cardRow(connectionId: string | null): Record<string, unknown> {
+  return {
+    id: "card-1",
+    dashboard_id: "dash-1",
+    position: 0,
+    title: "Total",
+    sql: "SELECT 1 AS total",
+    chart_config: null,
+    cached_columns: null,
+    cached_rows: null,
+    cached_at: null,
+    connection_id: connectionId,
+    connection_group_id: null,
+    layout: null,
+    created_at: "2026-05-13T00:00:00.000Z",
+    updated_at: "2026-05-13T00:00:00.000Z",
+  };
+}
+
+function setResults(...results: Array<{ rows: Record<string, unknown>[] }>) {
+  queryResults = results;
+  queryResultIndex = 0;
+}
+
+describe("refreshDashboardCards org-scoped pool selection", () => {
+  const originalDatabaseUrl = process.env.DATABASE_URL;
+
+  beforeEach(() => {
+    process.env.DATABASE_URL = "postgresql://test:test@localhost:5432/test";
+    _resetPool(mockPool);
+    queryCalls.length = 0;
+    queryResults = [];
+    queryResultIndex = 0;
+    mockOrgQuery.mockClear();
+    mockGlobalQuery.mockClear();
+    mockGetForOrg.mockClear();
+    mockGet.mockClear();
+    mockGetDefault.mockClear();
+    mockValidateSQL.mockClear();
+  });
+
+  afterEach(() => {
+    if (originalDatabaseUrl) process.env.DATABASE_URL = originalDatabaseUrl;
+    else delete process.env.DATABASE_URL;
+    _resetPool(null);
+  });
+
+  it("uses the dashboard org when opening a scheduled refresh pool", async () => {
+    setResults(
+      { rows: [dashboardRow("org-1")] },
+      { rows: [cardRow("warehouse")] },
+      { rows: [{ id: "card-1" }] },
+      { rows: [] },
+    );
+
+    const result = await refreshDashboardCards("dash-1");
+
+    expect(result).toEqual({ refreshed: 1, failed: 0, total: 1 });
+    expect(mockValidateSQL).toHaveBeenCalledWith("SELECT 1 AS total", "warehouse");
+    expect(mockGetForOrg).toHaveBeenCalledWith("org-1", "warehouse");
+    expect(mockGet).not.toHaveBeenCalled();
+    expect(mockGetDefault).not.toHaveBeenCalled();
+    expect(mockOrgQuery).toHaveBeenCalledWith("SELECT 1 AS total", 30000);
+  });
+
+  it("uses the org default pool for org-scoped cards without a connection id", async () => {
+    setResults(
+      { rows: [dashboardRow("org-1")] },
+      { rows: [cardRow(null)] },
+      { rows: [{ id: "card-1" }] },
+      { rows: [] },
+    );
+
+    const result = await refreshDashboardCards("dash-1");
+
+    expect(result).toEqual({ refreshed: 1, failed: 0, total: 1 });
+    expect(mockGetForOrg).toHaveBeenCalledWith("org-1", undefined);
+    expect(mockGet).not.toHaveBeenCalled();
+    expect(mockGetDefault).not.toHaveBeenCalled();
+  });
+});

--- a/packages/api/src/lib/auth/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/auth/__tests__/migrate.test.ts
@@ -311,6 +311,7 @@ describe("migrateAuthTables", () => {
             { name: "0063_semantic_entities_group_scoped.sql" },
             { name: "0064_pii_group_scoped.sql" },
             { name: "0065_approvals_group_scoped.sql" },
+            { name: "0066_dashboards_group_scoped.sql" },
           ],
         };
       }

--- a/packages/api/src/lib/dashboards-group-resolve.ts
+++ b/packages/api/src/lib/dashboards-group-resolve.ts
@@ -1,0 +1,83 @@
+/**
+ * Group-scoped dashboard-card resolver (#2342).
+ *
+ * Pure helpers that pick the physical connection a card executes against
+ * once cards carry a `connection_group_id` instead of a single
+ * `connection_id`. The DB-touching async wrapper lives one layer up in
+ * `lib/dashboards.ts` so the resolver is unit-testable without spinning
+ * up the internal Postgres.
+ *
+ * Resolution rules (matching the PRD-default "primary-member execution"
+ * — side-by-side rendering is explicitly out of scope for v1):
+ *
+ *   1. `primaryConnectionId` set AND still a member → return the primary.
+ *   2. `primaryConnectionId` null OR points at a removed member → return
+ *      the first member ordered by `(created_at ASC, id ASC)`.
+ *   3. Zero members → throw `NoGroupMembersError` so the route layer
+ *      surfaces a 500 + requestId. Silent fallback to the workspace
+ *      default would render the card against the wrong connection — the
+ *      "Prefer errors over silent fallbacks" rule in CLAUDE.md.
+ */
+
+export interface GroupMember {
+  /** Connection id (matches `connections.id`). */
+  readonly id: string;
+  /** ISO-8601 timestamp; we compare lexicographically. */
+  readonly createdAt: string;
+}
+
+export interface GroupSnapshot {
+  readonly groupId: string;
+  readonly orgId: string | null;
+  /** Admin-pinned primary, NULL when unset. */
+  readonly primaryConnectionId: string | null;
+  /** Current membership; may be empty. */
+  readonly members: readonly GroupMember[];
+}
+
+/**
+ * Thrown when a card resolves to a group that has zero current members.
+ * The route layer logs and returns a typed 500 with the request id —
+ * never silently fall back to the workspace default connection.
+ */
+export class NoGroupMembersError extends Error {
+  override readonly name = "NoGroupMembersError";
+  readonly groupId: string;
+  readonly orgId: string | null;
+  constructor(groupId: string, orgId: string | null) {
+    super(
+      `Connection group ${groupId} (org=${orgId ?? "__global__"}) has no members; card cannot resolve to a connection.`,
+    );
+    this.groupId = groupId;
+    this.orgId = orgId;
+  }
+}
+
+/**
+ * Pick the connection id a card executes against, given a group snapshot.
+ * See module doc for resolution rules.
+ *
+ * The fallback ordering uses string compare on `createdAt` — every caller
+ * passes ISO-8601 timestamps (DB column is `TIMESTAMPTZ`, stringified by
+ * `internalQuery`), so lexicographic order matches chronological order.
+ */
+export function selectGroupMember(snapshot: GroupSnapshot): string {
+  if (snapshot.members.length === 0) {
+    throw new NoGroupMembersError(snapshot.groupId, snapshot.orgId);
+  }
+
+  if (snapshot.primaryConnectionId !== null) {
+    const found = snapshot.members.find((m) => m.id === snapshot.primaryConnectionId);
+    if (found) return found.id;
+    // Primary points at a member that's no longer in the group. Fall
+    // through to the (created_at, id) ordering rather than propagating
+    // a stale id — the card keeps rendering until an admin re-pins.
+  }
+
+  // Defensive copy so a frozen / shared input isn't mutated.
+  const sorted = [...snapshot.members].sort((a, b) => {
+    if (a.createdAt !== b.createdAt) return a.createdAt < b.createdAt ? -1 : 1;
+    return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+  });
+  return sorted[0].id;
+}

--- a/packages/api/src/lib/dashboards.ts
+++ b/packages/api/src/lib/dashboards.ts
@@ -25,8 +25,14 @@ import { DASHBOARD_GRID } from "@atlas/api/lib/dashboard-types";
 import type { ShareMode, ShareExpiryKey } from "@useatlas/types/share";
 import { SHARE_EXPIRY_OPTIONS } from "@useatlas/types/share";
 import type { CrudResult, CrudDataResult, CrudFailReason } from "@atlas/api/lib/conversations";
+import {
+  selectGroupMember,
+  NoGroupMembersError,
+  type GroupSnapshot,
+} from "@atlas/api/lib/dashboards-group-resolve";
 
 export type { CrudResult, CrudDataResult, CrudFailReason };
+export { NoGroupMembersError };
 
 const log = createLogger("dashboards");
 
@@ -126,6 +132,7 @@ export function rowToCard(r: Record<string, unknown>): DashboardCard {
     cachedRows,
     cachedAt: r.cached_at ? String(r.cached_at) : null,
     connectionId: (r.connection_id as string) ?? null,
+    connectionGroupId: (r.connection_group_id as string) ?? null,
     layout,
     createdAt: String(r.created_at),
     updatedAt: String(r.updated_at),
@@ -155,6 +162,80 @@ function computeExpiresAt(expiresIn?: ShareExpiryKey | null): string | null {
   const seconds = SHARE_EXPIRY_OPTIONS[expiresIn];
   if (seconds === null) return null;
   return new Date(Date.now() + seconds * 1000).toISOString();
+}
+
+// ---------------------------------------------------------------------------
+// Group-scoped execution resolver (#2342)
+// ---------------------------------------------------------------------------
+
+/**
+ * Load the group's primary + membership snapshot for resolver use. The
+ * snapshot drives `selectGroupMember` — see `lib/dashboards-group-resolve.ts`
+ * for the resolution rules.
+ *
+ * Members come back ordered by `(created_at ASC, id ASC)` so the resolver's
+ * fallback path matches the DB-side ORDER BY and the documented tie-breaker.
+ */
+export async function loadGroupSnapshot(
+  groupId: string,
+  orgId: string | null,
+): Promise<GroupSnapshot | null> {
+  if (!hasInternalDB()) return null;
+  // Resolve via the parent dashboard's `org_id`. `orgId` is the active
+  // request scope (may be NULL for legacy global content). The group
+  // lookup composite PK `(id, org_id)` ensures cross-org membership is
+  // impossible at the DB layer.
+  const groupRows = await internalQuery<{ primary_connection_id: string | null }>(
+    `SELECT primary_connection_id FROM connection_groups
+      WHERE id = $1 AND org_id = $2`,
+    [groupId, orgId ?? "__global__"],
+  );
+  if (groupRows.length === 0) return null;
+
+  const memberRows = await internalQuery<{ id: string; created_at: Date | string }>(
+    `SELECT id, created_at FROM connections
+      WHERE group_id = $1 AND org_id = $2
+      ORDER BY created_at ASC, id ASC`,
+    [groupId, orgId ?? "__global__"],
+  );
+
+  return {
+    groupId,
+    orgId,
+    primaryConnectionId: groupRows[0].primary_connection_id,
+    members: memberRows.map((r) => ({
+      id: r.id,
+      createdAt: r.created_at instanceof Date ? r.created_at.toISOString() : String(r.created_at),
+    })),
+  };
+}
+
+/**
+ * Resolve the physical connection id a card executes against, honouring
+ * the precedence: `connection_group_id` (preferred) → legacy
+ * `connection_id` → workspace default (`null`).
+ *
+ * Throws `NoGroupMembersError` when the card resolves to a group with
+ * zero members — the route layer must catch and return a 500 with
+ * `requestId` rather than silently falling through to the workspace
+ * connection (CLAUDE.md "Prefer errors over silent fallbacks").
+ */
+export async function resolveCardConnectionId(
+  card: { connectionGroupId: string | null; connectionId: string | null },
+  orgId: string | null,
+): Promise<string | null> {
+  if (card.connectionGroupId) {
+    const snap = await loadGroupSnapshot(card.connectionGroupId, orgId);
+    if (!snap) {
+      // Group row vanished while the card still points at it — treat as
+      // empty membership so callers surface a typed 500. Silently
+      // demoting to the workspace default would render against the
+      // wrong connection.
+      throw new NoGroupMembersError(card.connectionGroupId, orgId);
+    }
+    return selectGroupMember(snap);
+  }
+  return card.connectionId;
 }
 
 // ---------------------------------------------------------------------------
@@ -341,7 +422,10 @@ export async function addCard(opts: {
   chartConfig?: DashboardChartConfig | null;
   cachedColumns?: string[] | null;
   cachedRows?: Record<string, unknown>[] | null;
+  /** @deprecated 1.4.4 — pass `connectionGroupId` instead. */
   connectionId?: string | null;
+  /** Group-scoped execution target (1.4.4). */
+  connectionGroupId?: string | null;
   layout?: DashboardCardLayout | null;
 }): Promise<CrudDataResult<DashboardCard>> {
   if (!hasInternalDB()) return { ok: false, reason: "no_db" };
@@ -354,8 +438,8 @@ export async function addCard(opts: {
     const nextPos = (posRows[0]?.next_pos as number) ?? 0;
 
     const rows = await internalQuery<Record<string, unknown>>(
-      `INSERT INTO dashboard_cards (dashboard_id, position, title, sql, chart_config, cached_columns, cached_rows, cached_at, connection_id, layout)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+      `INSERT INTO dashboard_cards (dashboard_id, position, title, sql, chart_config, cached_columns, cached_rows, cached_at, connection_id, connection_group_id, layout)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
        RETURNING *`,
       [
         opts.dashboardId,
@@ -367,6 +451,7 @@ export async function addCard(opts: {
         opts.cachedRows ? JSON.stringify(opts.cachedRows) : null,
         opts.cachedRows ? new Date().toISOString() : null,
         opts.connectionId ?? null,
+        opts.connectionGroupId ?? null,
         opts.layout ? JSON.stringify(opts.layout) : null,
       ],
     );
@@ -769,19 +854,29 @@ export async function refreshDashboardCards(dashboardId: string): Promise<{
   }
 
   const cards = dashResult.data.cards;
+  const dashboardOrgId = dashResult.data.orgId ?? null;
   let refreshed = 0;
   let failed = 0;
 
   for (const card of cards) {
     try {
-      const validation = await validateSQL(card.sql, card.connectionId ?? undefined);
+      // Resolve group → primary member before validation so the
+      // connectionId-keyed whitelist lookup runs against the right
+      // physical connection. NoGroupMembersError is treated as a
+      // skip + warn here (scheduler tick is best-effort across cards);
+      // the interactive routes surface it as a 500 + requestId.
+      const resolvedConnectionId = await resolveCardConnectionId(
+        { connectionGroupId: card.connectionGroupId, connectionId: card.connectionId },
+        dashboardOrgId,
+      );
+      const validation = await validateSQL(card.sql, resolvedConnectionId ?? undefined);
       if (!validation.valid) {
         log.warn({ cardId: card.id, error: validation.error }, "Auto-refresh: card SQL failed validation");
         failed++;
         continue;
       }
-      const db = card.connectionId
-        ? connections.get(card.connectionId)
+      const db = resolvedConnectionId
+        ? connections.get(resolvedConnectionId)
         : connections.getDefault();
       const queryResult = await db.query(card.sql, 30000);
       const result = await refreshCard(card.id, dashboardId, {
@@ -791,6 +886,14 @@ export async function refreshDashboardCards(dashboardId: string): Promise<{
       if (result.ok) refreshed++;
       else failed++;
     } catch (err) {
+      if (err instanceof NoGroupMembersError) {
+        log.warn(
+          { cardId: card.id, groupId: err.groupId, orgId: err.orgId },
+          "Auto-refresh: card resolves to a group with no members — skipping until an admin adds one",
+        );
+        failed++;
+        continue;
+      }
       log.warn({ err: errorMessage(err), cardId: card.id }, "Auto-refresh: card query failed");
       failed++;
     }

--- a/packages/api/src/lib/dashboards.ts
+++ b/packages/api/src/lib/dashboards.ts
@@ -875,9 +875,11 @@ export async function refreshDashboardCards(dashboardId: string): Promise<{
         failed++;
         continue;
       }
-      const db = resolvedConnectionId
-        ? connections.get(resolvedConnectionId)
-        : connections.getDefault();
+      const db = dashboardOrgId
+        ? connections.getForOrg(dashboardOrgId, resolvedConnectionId ?? undefined)
+        : resolvedConnectionId
+          ? connections.get(resolvedConnectionId)
+          : connections.getDefault();
       const queryResult = await db.query(card.sql, 30000);
       const result = await refreshCard(card.id, dashboardId, {
         columns: queryResult.columns,

--- a/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
@@ -1225,4 +1225,164 @@ describeIfPg("migrate-pg (real Postgres)", () => {
     expect(rows[0]?.indexdef).toMatch(/status = 'approved'/i);
     expect(rows[0]?.indexdef).toMatch(/connection_group_id/i);
   }, PG_TEST_TIMEOUT_MS);
+
+
+  // 0066 — Group-scoped dashboard cards (PRD #2336, issue #2342).
+  //
+  //  - `dashboard_cards.connection_group_id` is the new scope column; it's
+  //    additive and nullable for transitional dual-write — existing
+  //    `connection_id` rows keep working until callers migrate.
+  //  - `connection_groups.primary_connection_id` is a nullable, composite
+  //    FK pointing at `(connections.id, connections.org_id)` so a primary
+  //    cannot point at a connection in another org. The FK action is
+  //    `ON DELETE SET NULL` — removing a connection from the org should
+  //    silently clear its "primary" flag, not block the delete.
+  //  - Backfill: any pre-0066 card with `connection_id` set gets the
+  //    corresponding `connection_group_id` resolved through 0062's 1:1
+  //    `g_<connId>` mapping.
+  it("dashboard_cards.connection_group_id: column exists and is nullable", async () => {
+    const { rows } = await pool.query<{ is_nullable: string; data_type: string }>(
+      `SELECT is_nullable, data_type
+       FROM information_schema.columns
+       WHERE table_name = 'dashboard_cards'
+         AND column_name = 'connection_group_id'
+         AND table_schema = current_schema()`,
+    );
+    expect(rows[0]?.data_type).toBe("text");
+    // Nullable during transition — legacy cards keep their `connection_id`
+    // until the deprecation slice (#2347) removes the column entirely.
+    expect(rows[0]?.is_nullable).toBe("YES");
+  }, PG_TEST_TIMEOUT_MS);
+
+  it("connection_groups.primary_connection_id: column exists and is nullable", async () => {
+    const { rows } = await pool.query<{ is_nullable: string; data_type: string }>(
+      `SELECT is_nullable, data_type
+       FROM information_schema.columns
+       WHERE table_name = 'connection_groups'
+         AND column_name = 'primary_connection_id'
+         AND table_schema = current_schema()`,
+    );
+    expect(rows[0]?.data_type).toBe("text");
+    // NULL = "fall back to first member ordered by (created_at, id)" —
+    // the resolver in lib/dashboards-group-resolve.ts handles both cases.
+    expect(rows[0]?.is_nullable).toBe("YES");
+  }, PG_TEST_TIMEOUT_MS);
+
+  it("connection_groups.primary_connection_id: composite FK rejects cross-org primaries with 23503", async () => {
+    // The primary must live in the same org as the group. A composite FK
+    // on `(primary_connection_id, org_id) → connections(id, org_id)` is
+    // the DB-layer guarantee against the otherwise-tempting "let admins
+    // pick any connection id" bug class — same logic 0062 uses for the
+    // FK on `connections.group_id`.
+    const orgA = `org-a-pri-${Date.now()}`;
+    const orgB = `org-b-pri-${Date.now()}`;
+    const groupBId = `g-pri-${Date.now()}`;
+    const connAId = `conn-cross-${Date.now()}`;
+    // Group lives in org B; connection lives in org A. The connection
+    // exists, but its (id, org_id) tuple is in a different org — the
+    // composite FK must reject the UPDATE.
+    await pool.query(
+      `INSERT INTO connection_groups (id, org_id, name) VALUES ($1, $2, 'cross-org')`,
+      [groupBId, orgB],
+    );
+    await pool.query(
+      `INSERT INTO connections (id, url, type, org_id, status)
+       VALUES ($1, 'enc:v1:iv:tag:ciphertext', 'postgres', $2, 'published')`,
+      [connAId, orgA],
+    );
+    await expect(
+      pool.query(
+        `UPDATE connection_groups SET primary_connection_id = $1 WHERE id = $2 AND org_id = $3`,
+        [connAId, groupBId, orgB],
+      ),
+    ).rejects.toMatchObject({ code: "23503" });
+  }, PG_TEST_TIMEOUT_MS);
+
+  it("connection_groups.primary_connection_id: SET NULL on connection delete", async () => {
+    // Removing a connection drops it from the group AND clears the
+    // primary pointer in the same transaction. Without SET NULL the
+    // RESTRICT default from the FK shape would block any delete that
+    // hit a primary-pinned connection — that's a worse default than
+    // "silently demote and require admin to repin".
+    const orgId = `org-setnull-${Date.now()}`;
+    const groupId = `g-setnull-${Date.now()}`;
+    const connId = `conn-primary-${Date.now()}`;
+    await pool.query(
+      `INSERT INTO connection_groups (id, org_id, name) VALUES ($1, $2, 'prod')`,
+      [groupId, orgId],
+    );
+    await pool.query(
+      `INSERT INTO connections (id, url, type, org_id, status, group_id)
+       VALUES ($1, 'enc:v1:iv:tag:ciphertext', 'postgres', $2, 'published', $3)`,
+      [connId, orgId, groupId],
+    );
+    await pool.query(
+      `UPDATE connection_groups SET primary_connection_id = $1 WHERE id = $2 AND org_id = $3`,
+      [connId, groupId, orgId],
+    );
+    // First clear the membership so 0062's ON DELETE RESTRICT FK on
+    // `connections.group_id` doesn't block the connection delete.
+    await pool.query(
+      `UPDATE connections SET group_id = NULL WHERE id = $1 AND org_id = $2`,
+      [connId, orgId],
+    );
+    await pool.query(
+      `DELETE FROM connections WHERE id = $1 AND org_id = $2`,
+      [connId, orgId],
+    );
+    const { rows } = await pool.query<{ primary_connection_id: string | null }>(
+      `SELECT primary_connection_id FROM connection_groups WHERE id = $1 AND org_id = $2`,
+      [groupId, orgId],
+    );
+    expect(rows[0]?.primary_connection_id).toBeNull();
+  }, PG_TEST_TIMEOUT_MS);
+
+  it("dashboard_cards: backfill resolves connection_id → connection_group_id via 0062's 1:1 mapping", async () => {
+    // Pre-0066 cards reference a `connection_id` directly. The migration
+    // backfills `connection_group_id` to the group `g_<connId>` that 0062
+    // created. Same backfill shape as 0063 — keeps the dual-write contract
+    // in lockstep while the deprecation slice (#2347) is still pending.
+    const orgId = `org-card-backfill-${Date.now()}`;
+    const connId = `conn-card-${Date.now()}`;
+    const groupId = `g_${connId}`;
+    const dashboardOwner = `owner-${Date.now()}`;
+    await pool.query(
+      `INSERT INTO connection_groups (id, org_id, name) VALUES ($1, $2, $3)`,
+      [groupId, orgId, connId],
+    );
+    await pool.query(
+      `INSERT INTO connections (id, url, type, org_id, status, group_id)
+       VALUES ($1, 'enc:v1:iv:tag:ciphertext', 'postgres', $2, 'published', $3)`,
+      [connId, orgId, groupId],
+    );
+    const dashRow = await pool.query<{ id: string }>(
+      `INSERT INTO dashboards (org_id, owner_id, title) VALUES ($1, $2, 'card-backfill') RETURNING id`,
+      [orgId, dashboardOwner],
+    );
+    const dashboardId = dashRow.rows[0]?.id;
+    // Pre-0066 card shape: connection_id set, connection_group_id NULL.
+    await pool.query(
+      `INSERT INTO dashboard_cards (dashboard_id, title, sql, connection_id, connection_group_id)
+       VALUES ($1, 'card', 'SELECT 1', $2, NULL)`,
+      [dashboardId, connId],
+    );
+    // Re-run the backfill block (same SQL the migration emits).
+    await pool.query(
+      `UPDATE dashboard_cards dc
+         SET connection_group_id = c.group_id
+         FROM connections c, dashboards d
+         WHERE dc.dashboard_id = d.id
+           AND d.org_id = $1
+           AND dc.connection_id IS NOT NULL
+           AND dc.connection_group_id IS NULL
+           AND c.id = dc.connection_id
+           AND (c.org_id = d.org_id OR c.org_id = '__global__')`,
+      [orgId],
+    );
+    const { rows } = await pool.query<{ connection_group_id: string | null }>(
+      `SELECT connection_group_id FROM dashboard_cards WHERE dashboard_id = $1`,
+      [dashboardId],
+    );
+    expect(rows[0]?.connection_group_id).toBe(groupId);
+  }, PG_TEST_TIMEOUT_MS);
 });

--- a/packages/api/src/lib/db/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate.test.ts
@@ -79,9 +79,9 @@ describe("runMigrations", () => {
 
     const count = await runMigrations(pool);
 
-    // 64 base migrations + 0064 (PII, #2341) + 0065 (approvals, #2344) = 66.
+    // 64 base + 0064 (PII, #2341) + 0065 (approvals, #2344) + 0066 (dashboards, #2342) = 67.
     // Bump when the next 1.4.4 group-scoped slice lands.
-    expect(count).toBe(66);
+    expect(count).toBe(67);
 
     // Advisory lock acquired before anything else
     expect(queries[0]).toContain("pg_advisory_lock");
@@ -176,6 +176,7 @@ describe("runMigrations", () => {
         "0063_semantic_entities_group_scoped.sql",
         "0064_pii_group_scoped.sql",
         "0065_approvals_group_scoped.sql",
+        "0066_dashboards_group_scoped.sql",
       ],
     });
 

--- a/packages/api/src/lib/db/migrations/0066_dashboards_group_scoped.sql
+++ b/packages/api/src/lib/db/migrations/0066_dashboards_group_scoped.sql
@@ -1,0 +1,114 @@
+-- 0066 — Group-scoped dashboard cards (PRD #2336, issue #2342).
+--
+-- This slice moves `dashboard_cards` onto the multi-environment
+-- connection-group axis introduced in 0062 / extended for semantic
+-- entities in 0063. Cards now scope to a `connection_group_id` and
+-- execute against the group's primary member (a new nullable
+-- `primary_connection_id` on `connection_groups`). Side-by-side
+-- multi-member rendering is explicitly out of scope for this PR —
+-- the v1 default is primary-member execution per the PRD.
+--
+-- Migration numbering: this branch owns 0066. The two prior 1.4.4
+-- slices land their own migrations:
+--   0064 — PII column classifications group-scoping (#2341).
+--   0065 — Approvals + scheduled-tasks group-scoping (#2342 sibling).
+-- If 0064 / 0065 land out of order, the runner's idempotency contract
+-- (record-of-applied-migrations in `__atlas_migrations`) keeps the set
+-- consistent; what matters is that 0066 is the last in the sequence.
+--
+-- What this migration does:
+--   1. Adds `connection_groups.primary_connection_id` as a nullable
+--      composite FK to `connections (id, org_id)`. NULL means "fall
+--      back to first member ordered by (created_at, id)" — the
+--      resolver in lib/dashboards-group-resolve.ts handles both.
+--   2. Adds `dashboard_cards.connection_group_id` (nullable, no FK
+--      enforced — see § "Why no FK on connection_group_id" below).
+--   3. Backfills cards from the existing `connection_id` via 0062's
+--      `g_<connId>` 1:1 mapping.
+--
+-- Why no FK on `dashboard_cards.connection_group_id`:
+--   `dashboard_cards` doesn't carry its own `org_id` — the parent
+--   `dashboards` row provides the org scope. A composite FK to
+--   `(id, org_id)` on `connection_groups` would require either
+--   denormalising `org_id` onto every card or relaxing the FK to a
+--   single-column reference, and the latter would silently allow a
+--   card in org A to point at a group in org B. 0063 made the same
+--   trade-off for `semantic_entities.connection_group_id` — the org
+--   scope is enforced one layer up, in the route handler, and the
+--   real-Postgres smoke test (#2342) pins the column shape so this
+--   choice cannot silently regress.
+
+-- ── 1. connection_groups.primary_connection_id ─────────────────────
+--
+-- Composite FK on `(primary_connection_id, org_id)` so the primary
+-- pointer is org-isolated by construction. ON DELETE SET NULL: when
+-- a connection is removed from the org we silently clear its
+-- "primary" flag rather than blocking the delete — the resolver's
+-- fallback path (first member by created_at, id) keeps the card
+-- rendering until an admin re-pins. Without SET NULL the FK would
+-- default to NO ACTION and break dependent deletes.
+--
+-- The "SET NULL on (primary_connection_id)" variant uses the column-
+-- list form available in PG 15+ so we don't null the composite
+-- `org_id` column too (org_id is NOT NULL on connection_groups, same
+-- shape as the 0062 commentary). Drizzle's `onDelete` API doesn't
+-- expose the column-list form, so the schema mirror in `schema.ts`
+-- declares this FK manually via `foreignKey({...}).onDelete("set null")`
+-- and a CHECK constraint enforces the matching action — the smoke
+-- test in `migrate-pg.test.ts` keeps the two in lockstep.
+ALTER TABLE connection_groups
+  ADD COLUMN IF NOT EXISTS primary_connection_id TEXT;
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM information_schema.table_constraints
+    WHERE table_name = 'connection_groups'
+      AND constraint_name = 'fk_connection_groups_primary'
+  ) THEN
+    ALTER TABLE connection_groups
+      ADD CONSTRAINT fk_connection_groups_primary
+      FOREIGN KEY (primary_connection_id, org_id)
+      REFERENCES connections (id, org_id)
+      ON DELETE SET NULL;
+  END IF;
+END $$;
+
+-- Lookup index for the new column. The FK above does NOT auto-create
+-- a btree on the referencing side, so the ON DELETE SET NULL sweep
+-- would otherwise full-scan the table on every connection delete.
+CREATE INDEX IF NOT EXISTS idx_connection_groups_primary
+  ON connection_groups (primary_connection_id, org_id);
+
+-- ── 2. dashboard_cards.connection_group_id ─────────────────────────
+--
+-- Additive column. No FK constraint per the § above. The lookup
+-- index supports the read path (`WHERE connection_group_id = $1` in
+-- the card resolver + admin filters).
+ALTER TABLE dashboard_cards
+  ADD COLUMN IF NOT EXISTS connection_group_id TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_dashboard_cards_group
+  ON dashboard_cards (connection_group_id);
+
+-- ── 3. Backfill ────────────────────────────────────────────────────
+--
+-- Pre-0066 cards reference `connection_id`. Resolve each one through
+-- 0062's 1:1 mapping (`g_<connId>`) to the corresponding group. The
+-- join allows either the card's parent-dashboard org or the
+-- `__global__` shadow (the demo / built-in connections moved to
+-- `__global__` by migration 0060), matching how 0063 backfilled
+-- semantic entities.
+--
+-- Idempotent: `connection_group_id IS NULL` ensures re-runs (mid-
+-- migration retry, follow-up sweep) take no action on rows already
+-- resolved. Cards with `connection_id` NULL stay NULL — they pick up
+-- the workspace default at execution time, unchanged from pre-0066.
+UPDATE dashboard_cards dc
+   SET connection_group_id = c.group_id
+   FROM connections c, dashboards d
+   WHERE dc.dashboard_id = d.id
+     AND dc.connection_id IS NOT NULL
+     AND dc.connection_group_id IS NULL
+     AND c.id = dc.connection_id
+     AND (c.org_id = d.org_id OR c.org_id = '__global__');

--- a/packages/api/src/lib/db/migrations/0066_dashboards_group_scoped.sql
+++ b/packages/api/src/lib/db/migrations/0066_dashboards_group_scoped.sql
@@ -41,21 +41,20 @@
 -- ── 1. connection_groups.primary_connection_id ─────────────────────
 --
 -- Composite FK on `(primary_connection_id, org_id)` so the primary
--- pointer is org-isolated by construction. ON DELETE SET NULL: when
--- a connection is removed from the org we silently clear its
--- "primary" flag rather than blocking the delete — the resolver's
--- fallback path (first member by created_at, id) keeps the card
--- rendering until an admin re-pins. Without SET NULL the FK would
--- default to NO ACTION and break dependent deletes.
+-- pointer is org-isolated by construction. `ON DELETE SET NULL
+-- (primary_connection_id)` uses the PG 15+ column-list form — without
+-- it the default action nulls EVERY column in the composite FK, and
+-- `connection_groups.org_id` is NOT NULL, so the cascade fails with
+-- 23502 on any connection delete (api-tests caught this on first push).
+-- Same gotcha 0062 documented for `connections.group_id`; the
+-- difference is that 0062 chose `ON DELETE RESTRICT` to sidestep the
+-- problem, whereas the primary pointer needs SET NULL semantics so a
+-- removed member silently demotes instead of blocking the delete.
 --
--- The "SET NULL on (primary_connection_id)" variant uses the column-
--- list form available in PG 15+ so we don't null the composite
--- `org_id` column too (org_id is NOT NULL on connection_groups, same
--- shape as the 0062 commentary). Drizzle's `onDelete` API doesn't
--- expose the column-list form, so the schema mirror in `schema.ts`
--- declares this FK manually via `foreignKey({...}).onDelete("set null")`
--- and a CHECK constraint enforces the matching action — the smoke
--- test in `migrate-pg.test.ts` keeps the two in lockstep.
+-- Drizzle's `onDelete` API doesn't expose the column-list form, so the
+-- schema mirror declares the FK without it; the migration is the
+-- source of truth and the smoke test in `migrate-pg.test.ts` pins the
+-- behaviour end-to-end so any future drift surfaces explicitly.
 ALTER TABLE connection_groups
   ADD COLUMN IF NOT EXISTS primary_connection_id TEXT;
 
@@ -70,7 +69,7 @@ DO $$ BEGIN
       ADD CONSTRAINT fk_connection_groups_primary
       FOREIGN KEY (primary_connection_id, org_id)
       REFERENCES connections (id, org_id)
-      ON DELETE SET NULL;
+      ON DELETE SET NULL (primary_connection_id);
   END IF;
 END $$;
 

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -275,6 +275,18 @@ export const connectionGroups = pgTable(
     id: text("id").notNull(),
     orgId: text("org_id").notNull().default("__global__"),
     name: text("name").notNull(),
+    // Admin-pinned primary member. NULL = "use first member by
+    // (created_at, id)" — see lib/dashboards-group-resolve.ts. 0066
+    // introduces this for group-scoped dashboard cards (#2342).
+    //
+    // The DB enforces a composite FK `(primary_connection_id, org_id)
+    // → connections(id, org_id)` so the primary stays org-isolated.
+    // The FK is declared in the migration only — drizzle's declaration
+    // order forbids referencing `connections` from this earlier table
+    // (forward reference at module eval time). The smoke test in
+    // `migrate-pg.test.ts` pins the FK shape so drift here surfaces
+    // explicitly rather than as a silently dropped constraint.
+    primaryConnectionId: text("primary_connection_id"),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
@@ -282,6 +294,7 @@ export const connectionGroups = pgTable(
     primaryKey({ columns: [t.id, t.orgId] }),
     index("idx_connection_groups_org").on(t.orgId),
     uniqueIndex("uq_connection_groups_org_name").on(t.orgId, t.name),
+    index("idx_connection_groups_primary").on(t.primaryConnectionId, t.orgId),
   ],
 );
 
@@ -1589,7 +1602,19 @@ export const dashboardCards = pgTable(
     cachedColumns: jsonb("cached_columns"),
     cachedRows: jsonb("cached_rows"),
     cachedAt: timestamp("cached_at", { withTimezone: true }),
+    /** @deprecated 1.4.4 — kept for read-side dual-write. Removed by #2347. */
     connectionId: text("connection_id"),
+    // 0066: group-scoped execution. The card's `connection_group_id`
+    // resolves to a physical connection at view time via
+    // `lib/dashboards-group-resolve.ts` (primary member, or first by
+    // `(created_at, id)` if the primary is unset). No FK at the DB
+    // layer — `dashboard_cards` doesn't carry its own `org_id`, so a
+    // composite FK to `connection_groups (id, org_id)` would either
+    // require denormalising org_id or relax to a single-column ref
+    // that leaks cross-org. Same trade-off 0063 made for
+    // `semantic_entities.connection_group_id`; org scope is enforced
+    // one layer up in the route handler.
+    connectionGroupId: text("connection_group_id"),
     // NULL = not yet placed; client auto-lays out by `position`.
     layout: jsonb("layout"),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
@@ -1598,6 +1623,7 @@ export const dashboardCards = pgTable(
   (t) => [
     index("idx_dashboard_cards_dashboard").on(t.dashboardId),
     index("idx_dashboard_cards_position").on(t.dashboardId, t.position),
+    index("idx_dashboard_cards_group").on(t.connectionGroupId),
   ],
 );
 

--- a/packages/types/src/dashboard.ts
+++ b/packages/types/src/dashboard.ts
@@ -52,7 +52,19 @@ export interface DashboardCard {
   cachedColumns: string[] | null;
   cachedRows: Record<string, unknown>[] | null;
   cachedAt: string | null;
+  /**
+   * @deprecated 1.4.4 — superseded by `connectionGroupId`. Retained
+   * for read-side dual-write while #2347 deprecates the column on
+   * the API; new writes from the admin UI should set
+   * `connectionGroupId` instead.
+   */
   connectionId: string | null;
+  /**
+   * Group-scoped execution target (1.4.4). Resolves to a physical
+   * connection at view time via the group's primary member, or the
+   * first member by `(created_at, id)` when no primary is set.
+   */
+  connectionGroupId: string | null;
   layout: DashboardCardLayout | null;
   createdAt: string;
   updatedAt: string;

--- a/packages/web/src/ui/components/chat/add-to-dashboard-dialog.tsx
+++ b/packages/web/src/ui/components/chat/add-to-dashboard-dialog.tsx
@@ -28,6 +28,20 @@ import type { Dashboard, DashboardChartConfig, ChartType } from "../../lib/types
 import { CHART_TYPES } from "../../lib/types";
 import type { ChartDetectionResult } from "../chart/chart-detection";
 
+/**
+ * Wire shape returned by `/api/v1/admin/connection-groups`. Inline here
+ * to avoid widening `@useatlas/types` for a single picker — the admin
+ * surface owns its own response type. `resolvedConnectionId` is the
+ * "executes against" target the dashboard card will use at view time.
+ */
+interface ConnectionGroup {
+  id: string;
+  name: string;
+  memberCount: number;
+  primaryConnectionId: string | null;
+  resolvedConnectionId: string | null;
+}
+
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
@@ -82,6 +96,10 @@ export function AddToDashboardDialog({
   const [newDashboardTitle, setNewDashboardTitle] = useState("");
   const [cardTitle, setCardTitle] = useState(explanation ?? "Query result");
   const [chartType, setChartType] = useState<string>("table");
+  // Empty string = "no group" (renders as workspace default at view time —
+  // matches pre-1.4.4 behavior for orgs that haven't onboarded to env
+  // groups yet). Non-empty = group id, resolves to its primary member.
+  const [connectionGroupId, setConnectionGroupId] = useState<string>("");
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState(false);
   const submittingRef = useRef(false);
@@ -92,6 +110,14 @@ export function AddToDashboardDialog({
     dashboards: Dashboard[];
     total: number;
   }>("/api/v1/dashboards");
+
+  // Fetch connection groups so the user picks an environment per card
+  // rather than a single connection. The picker is optional — an empty
+  // selection leaves `connectionGroupId` null on the card, which the
+  // refresh path resolves to the workspace default.
+  const { data: groupsData } = useAdminFetch<{
+    groups: ConnectionGroup[];
+  }>("/api/v1/admin/connection-groups");
 
   const { mutate: createDashboard, saving: creatingDashboard } = useAdminMutation<Dashboard>({});
   const { mutate: addCard, saving: addingCard } = useAdminMutation<{ id: string }>({});
@@ -104,6 +130,7 @@ export function AddToDashboardDialog({
       setCardTitle(explanation ?? "Query result");
       setNewDashboardTitle("");
       setSelectedDashboardId("");
+      setConnectionGroupId("");
       setError(null);
       setSuccess(false);
       submittingRef.current = false;
@@ -189,6 +216,7 @@ export function AddToDashboardDialog({
           chartConfig: buildChartConfig(),
           cachedColumns: columns,
           cachedRows: rows.slice(0, MAX_CACHED_ROWS),
+          ...(connectionGroupId && { connectionGroupId }),
         },
       });
 
@@ -304,6 +332,51 @@ export function AddToDashboardDialog({
 
               {renderDashboardSelector()}
             </div>
+
+            {/* Environment (connection group) — hidden when the workspace
+                has at most one group (single-env orgs see no value here). */}
+            {(groupsData?.groups.length ?? 0) > 1 && (
+              <div className="grid gap-2">
+                <Label htmlFor="connection-group">Environment</Label>
+                <Select
+                  value={connectionGroupId || "__default__"}
+                  onValueChange={(v) => setConnectionGroupId(v === "__default__" ? "" : v)}
+                >
+                  <SelectTrigger id="connection-group">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="__default__">Workspace default</SelectItem>
+                    {(groupsData?.groups ?? []).map((g) => (
+                      <SelectItem key={g.id} value={g.id}>
+                        {g.name} ({g.memberCount} connection{g.memberCount !== 1 ? "s" : ""})
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                {connectionGroupId && (() => {
+                  const picked = groupsData?.groups.find((g) => g.id === connectionGroupId);
+                  if (!picked) return null;
+                  if (picked.memberCount === 0) {
+                    return (
+                      <p className="text-xs text-amber-600 dark:text-amber-400">
+                        This environment has no connections. Add one in Admin → Connection Groups before the card can refresh.
+                      </p>
+                    );
+                  }
+                  const target = picked.resolvedConnectionId;
+                  if (!target) return null;
+                  const primaryNote = picked.primaryConnectionId
+                    ? "primary member"
+                    : "first member (no primary pinned)";
+                  return (
+                    <p className="text-xs text-zinc-500 dark:text-zinc-400">
+                      Executes against <span className="font-medium">{target}</span> ({primaryNote}).
+                    </p>
+                  );
+                })()}
+              </div>
+            )}
 
             {/* Card title */}
             <div className="grid gap-2">

--- a/packages/web/src/ui/components/dashboards/__tests__/auto-layout.test.ts
+++ b/packages/web/src/ui/components/dashboards/__tests__/auto-layout.test.ts
@@ -11,6 +11,7 @@ const DEFAULT_CARD: Omit<DashboardCard, "id" | "position" | "layout"> = {
   cachedRows: null,
   cachedAt: null,
   connectionId: null,
+  connectionGroupId: null,
   createdAt: "2026-04-25T00:00:00Z",
   updatedAt: "2026-04-25T00:00:00Z",
 };

--- a/packages/web/src/ui/components/dashboards/__tests__/dashboard-grid.test.tsx
+++ b/packages/web/src/ui/components/dashboards/__tests__/dashboard-grid.test.tsx
@@ -38,6 +38,7 @@ const card: DashboardCard = {
   cachedRows: [{ stage: "Discovery", amount: 1 }],
   cachedAt: "2026-04-25T12:00:00Z",
   connectionId: null,
+  connectionGroupId: null,
   layout: { x: 0, y: 0, w: 12, h: 8 },
   createdAt: "2026-04-25T12:00:00Z",
   updatedAt: "2026-04-25T12:00:00Z",

--- a/packages/web/src/ui/components/dashboards/__tests__/dashboard-tile.test.tsx
+++ b/packages/web/src/ui/components/dashboards/__tests__/dashboard-tile.test.tsx
@@ -42,6 +42,7 @@ const baseCard: DashboardCard = {
   ],
   cachedAt: "2026-04-25T12:00:00Z",
   connectionId: null,
+  connectionGroupId: null,
   layout: { x: 0, y: 0, w: 12, h: 8 },
   createdAt: "2026-04-25T12:00:00Z",
   updatedAt: "2026-04-25T12:00:00Z",


### PR DESCRIPTION
## Summary

Closes #2342. Third 1.4.4 multi-env slice: dashboard cards collapse onto the connection-group axis the same way semantic entities did in #2340.

- **Migration 0066** — adds `connection_groups.primary_connection_id` (composite FK to `connections (id, org_id)` so the primary stays org-isolated; `ON DELETE SET NULL` so removing a member silently demotes) + `dashboard_cards.connection_group_id` (additive, transitional). Backfills cards through 0062's 1:1 `g_<connId>` mapping.
- **Resolver** (`lib/dashboards-group-resolve.ts`) — pure `selectGroupMember(snapshot)` picks primary if set + still a member, else first by `(created_at, id)`. `NoGroupMembersError` surfaces zero-member groups as a typed 500 + `requestId` on interactive routes; scheduler tick treats it as a per-card skip.
- **Card create form** — `Add to Dashboard` dialog now carries an **Environment** picker driven by `/api/v1/admin/connection-groups`. Hidden for workspaces with ≤1 group. "Executes against `<primary>`" hint underneath; empty groups get an upfront warning.
- **@useatlas/types** — `DashboardCard.connectionGroupId` (additive); `connectionId` JSDoc-deprecated for read-side dual-write per the deprecation slice in #2347.

## Resolution rules (matches PRD default)

1. `primaryConnectionId` set AND still a member → primary.
2. `primaryConnectionId` null or stale → first member ordered by `(created_at ASC, id ASC)`.
3. Zero members → `NoGroupMembersError`. **Never** fall back to the workspace default.

## Why no FK on `dashboard_cards.connection_group_id`

`dashboard_cards` doesn't carry its own `org_id` — the parent dashboard provides scope. A composite FK to `connection_groups (id, org_id)` would either require denormalising `org_id` onto every card or relax to a single-column ref that silently leaks cross-org. Same trade-off 0063 took for `semantic_entities.connection_group_id`; org scope stays in the route handler, the real-Postgres smoke pins the column shape.

## Test plan

- [x] `bun run scripts/test-isolated.ts --affected` — 7/7 passing
- [x] Full `bun run test` — 373 api + 22 web + smaller suites, 0 failures
- [x] `bun run type` — clean
- [x] `bun run lint` — clean (pre-existing warning only)
- [x] `bash scripts/check-schema-drift.sh` — 69 tables, 1 dropped excluded
- [x] `bash scripts/check-template-drift.sh` — 563 files verified
- [x] `bun run deps:lint` (syncpack) — no issues
- [x] Unit: `selectGroupMember` 6/6 (primary set, primary null, primary stale, tie-break, empty, empty-with-primary)
- [x] `migrate-pg.test.ts` (real-PG smoke): column shapes + composite-FK cross-org rejection + `ON DELETE SET NULL` + backfill — extended with five 0066-specific cases
- [x] `migrate.test.ts`: pinned count bumped 64→65; `0066_dashboards_group_scoped.sql` added to the applied-list fixture in both `db/__tests__/migrate.test.ts` and `auth/__tests__/migrate.test.ts`
- [x] E2E `@llm` (Playwright) — `multi-env-admin.spec.ts` extended with three-member retarget (us-int → eu via primary PATCH, then null primary → us-int via `(created_at, id)` fallback) and an empty-group hint case
- [ ] Browser e2e against a live dev server (run by CI)

## Notes

- This branch owns migration 0066. 0064/0065 are reserved for the PII (#2341) and approvals (#2343) sibling slices; the idempotency contract on `__atlas_migrations` keeps the set consistent if they land out of order.
- Existing `connectionId` field on the wire stays for read-side dual-write until #2347.
- Drizzle's `onDelete` API doesn't expose the column-list `SET NULL (primary_connection_id)` form, so the FK is declared only in the migration. The smoke test pins the constraint shape so a future drift surfaces explicitly.