### PR TITLE
Implement group-scoped scheduled tasks

### DIFF
--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -13181,6 +13181,16 @@
             "description": "Filter by enabled status.",
             "name": "enabled",
             "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Filter by connection group/environment scope."
+            },
+            "required": false,
+            "description": "Filter by connection group/environment scope.",
+            "name": "connectionGroupId",
+            "in": "query"
           }
         ],
         "responses": {
@@ -13390,6 +13400,12 @@
                       ]
                     },
                     "default": []
+                  },
+                  "connectionGroupId": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   },
                   "connectionId": {
                     "type": [
@@ -13996,6 +14012,12 @@
                         }
                       ]
                     }
+                  },
+                  "connectionGroupId": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   },
                   "connectionId": {
                     "type": [

--- a/packages/api/src/api/__tests__/scheduled-tasks.test.ts
+++ b/packages/api/src/api/__tests__/scheduled-tasks.test.ts
@@ -237,6 +237,21 @@ describe("scheduled-tasks routes", () => {
       expect(body.total).toBe(0);
     });
 
+    it("passes connectionGroupId filter through to the list resolver", async () => {
+      const response = await app.fetch(
+        new Request("http://localhost/api/v1/scheduled-tasks?connectionGroupId=g_prod"),
+      );
+
+      expect(response.status).toBe(200);
+      expect(mockListScheduledTasks).toHaveBeenCalledWith({
+        orgId: "org-1",
+        enabled: undefined,
+        connectionGroupId: "g_prod",
+        limit: 20,
+        offset: 0,
+      });
+    });
+
     it("returns 404 when no internal DB", async () => {
       delete process.env.DATABASE_URL;
       const response = await app.fetch(
@@ -286,10 +301,14 @@ describe("scheduled-tasks routes", () => {
             cronExpression: "0 9 * * 1",
             deliveryChannel: "email",
             recipients: [{ type: "email", address: "test@test.com" }],
+            connectionGroupId: "g_prod",
           }),
         }),
       );
       expect(response.status).toBe(201);
+      expect(mockCreateScheduledTask).toHaveBeenCalledWith(expect.objectContaining({
+        connectionGroupId: "g_prod",
+      }));
     });
 
     it("returns 422 for missing name", async () => {

--- a/packages/api/src/api/__tests__/scheduled-tasks.test.ts
+++ b/packages/api/src/api/__tests__/scheduled-tasks.test.ts
@@ -49,7 +49,9 @@ mock.module("@atlas/ee/auth/ip-allowlist", () => ({
 
 // --- CRUD mocks ---
 
-const mockCreateScheduledTask = mock((): Promise<unknown> =>
+type CreateScheduledTaskMock = (opts: Record<string, unknown>) => Promise<unknown>;
+
+const mockCreateScheduledTask: Mock<CreateScheduledTaskMock> = mock((_opts): Promise<unknown> =>
   Promise.resolve({ ok: true, data: { id: "task-123", name: "Test" } }),
 );
 const mockGetScheduledTask = mock((): Promise<unknown> =>
@@ -309,6 +311,27 @@ describe("scheduled-tasks routes", () => {
       expect(mockCreateScheduledTask).toHaveBeenCalledWith(expect.objectContaining({
         connectionGroupId: "g_prod",
       }));
+    });
+
+    it("omits connectionGroupId for legacy connectionId-only creates", async () => {
+      const response = await app.fetch(
+        new Request("http://localhost/api/v1/scheduled-tasks", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            name: "Daily Revenue",
+            question: "What was yesterday's revenue?",
+            cronExpression: "0 9 * * 1",
+            deliveryChannel: "email",
+            recipients: [{ type: "email", address: "test@test.com" }],
+            connectionId: "legacy-connection",
+          }),
+        }),
+      );
+      expect(response.status).toBe(201);
+      const opts = mockCreateScheduledTask.mock.calls[0][0] as { connectionGroupId?: string | null; connectionId?: string | null };
+      expect(opts.connectionId).toBe("legacy-connection");
+      expect("connectionGroupId" in opts).toBe(false);
     });
 
     it("returns 422 for missing name", async () => {

--- a/packages/api/src/api/routes/scheduled-tasks.ts
+++ b/packages/api/src/api/routes/scheduled-tasks.ts
@@ -275,7 +275,7 @@ authed.openapi(
         return c.json({ error: "invalid_request", message: `Invalid cron expression: ${cronCheck.error}` }, 400);
       }
 
-      const createResult = yield* Effect.promise(() => createScheduledTask({
+      const createOpts = {
         ownerId: user?.id ?? "anonymous",
         orgId,
         name: parsed.name,
@@ -283,10 +283,11 @@ authed.openapi(
         cronExpression: parsed.cronExpression,
         deliveryChannel: parsed.deliveryChannel,
         recipients: parsed.recipients,
-        connectionGroupId: parsed.connectionGroupId ?? null,
         connectionId: parsed.connectionId ?? null,
         approvalMode: parsed.approvalMode,
-      }));
+        ...("connectionGroupId" in parsed ? { connectionGroupId: parsed.connectionGroupId ?? null } : {}),
+      };
+      const createResult = yield* Effect.promise(() => createScheduledTask(createOpts));
 
       if (!createResult.ok) {
         const fail = crudFailResponse(createResult.reason, requestId);

--- a/packages/api/src/api/routes/scheduled-tasks.ts
+++ b/packages/api/src/api/routes/scheduled-tasks.ts
@@ -53,6 +53,7 @@ const CreateScheduledTaskSchema = z.object({
   cronExpression: z.string().min(1),
   deliveryChannel: z.enum(DELIVERY_CHANNELS).default("webhook"),
   recipients: z.array(RecipientSchema).default([]),
+  connectionGroupId: z.string().nullable().optional(),
   connectionId: z.string().nullable().optional(),
   approvalMode: z.enum(ACTION_APPROVAL_MODES).default("auto"),
 });
@@ -63,6 +64,7 @@ const UpdateScheduledTaskSchema = z.object({
   cronExpression: z.string().min(1).optional(),
   deliveryChannel: z.enum(DELIVERY_CHANNELS).optional(),
   recipients: z.array(RecipientSchema).optional(),
+  connectionGroupId: z.string().nullable().optional(),
   connectionId: z.string().nullable().optional(),
   approvalMode: z.enum(ACTION_APPROVAL_MODES).optional(),
   enabled: z.boolean().optional(),
@@ -110,6 +112,10 @@ const listTasksRoute = createRoute({
       enabled: z.string().optional().openapi({
         param: { name: "enabled", in: "query" },
         description: "Filter by enabled status.",
+      }),
+      connectionGroupId: z.string().optional().openapi({
+        param: { name: "connectionGroupId", in: "query" },
+        description: "Filter by connection group/environment scope.",
       }),
     }),
   },
@@ -237,10 +243,12 @@ authed.openapi(listTasksRoute, async (c) => {
     const { limit, offset } = parsePagination(c, { limit: 20, maxLimit: 100 });
     const enabledParam = c.req.query("enabled");
     const enabled = enabledParam === "true" ? true : enabledParam === "false" ? false : undefined;
+    const connectionGroupId = c.req.query("connectionGroupId") ?? undefined;
 
     const items = yield* Effect.promise(() => listScheduledTasks({
       orgId,
       enabled,
+      ...(connectionGroupId !== undefined ? { connectionGroupId } : {}),
       limit,
       offset,
     }));
@@ -275,6 +283,7 @@ authed.openapi(
         cronExpression: parsed.cronExpression,
         deliveryChannel: parsed.deliveryChannel,
         recipients: parsed.recipients,
+        connectionGroupId: parsed.connectionGroupId ?? null,
         connectionId: parsed.connectionId ?? null,
         approvalMode: parsed.approvalMode,
       }));

--- a/packages/api/src/lib/__tests__/scheduled-task-types.test.ts
+++ b/packages/api/src/lib/__tests__/scheduled-task-types.test.ts
@@ -91,6 +91,7 @@ describe("scheduled-task-types", () => {
         cronExpression: "0 9 * * 1",
         deliveryChannel: "email",
         recipients: [],
+        connectionGroupId: null,
         connectionId: null,
         approvalMode: "auto",
         enabled: true,

--- a/packages/api/src/lib/__tests__/scheduled-tasks.test.ts
+++ b/packages/api/src/lib/__tests__/scheduled-tasks.test.ts
@@ -64,6 +64,7 @@ function makeTaskRow(overrides: Partial<Record<string, unknown>> = {}): Record<s
     cron_expression: "0 9 * * 1",
     delivery_channel: "email",
     recipients: JSON.stringify([{ type: "email", address: "test@test.com" }]),
+    connection_group_id: null,
     connection_id: null,
     approval_mode: "auto",
     enabled: true,

--- a/packages/api/src/lib/agent-query.ts
+++ b/packages/api/src/lib/agent-query.ts
@@ -76,6 +76,10 @@ export interface ExecuteAgentQueryOptions {
    * case only `'any'` rules match — fail-closed).
    */
   approvalSurface?: ApprovalRequestSurface;
+  /** Execution target for this agent run. */
+  connectionId?: string;
+  /** Content scope for group-aware semantic overlays. */
+  connectionGroupId?: string;
 }
 
 /**
@@ -98,6 +102,8 @@ export async function executeAgentQuery(
   // Slack, Teams) pass this explicitly because they don't run inside a
   // route-level `withRequestContext` that would have set it.
   const surface = options?.approvalSurface ?? inheritedCtx?.approvalSurface;
+  const connectionId = options?.connectionId ?? inheritedCtx?.connectionId;
+  const connectionGroupId = options?.connectionGroupId ?? inheritedCtx?.connectionGroupId;
 
   if (!boundUser) {
     log.warn(
@@ -113,6 +119,8 @@ export async function executeAgentQuery(
       ...(boundUser ? { user: boundUser } : {}),
       ...(inheritedMode ? { atlasMode: inheritedMode } : {}),
       ...(surface ? { approvalSurface: surface } : {}),
+      ...(connectionId ? { connectionId } : {}),
+      ...(connectionGroupId ? { connectionGroupId } : {}),
     },
     async () => {
     const priorUIMessages = (options?.priorMessages ?? []).map((m, i) => ({

--- a/packages/api/src/lib/auth/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/auth/__tests__/migrate.test.ts
@@ -313,6 +313,7 @@ describe("migrateAuthTables", () => {
             { name: "0065_approvals_group_scoped.sql" },
             { name: "0066_dashboards_group_scoped.sql" },
             { name: "0067_conversations_group_aware.sql" },
+            { name: "0068_scheduled_tasks_group.sql" },
           ],
         };
       }

--- a/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
@@ -1490,4 +1490,37 @@ describeIfPg("migrate-pg (real Postgres)", () => {
     );
     expect(rows[0]?.connection_group_id).toBe(groupId);
   }, PG_TEST_TIMEOUT_MS);
+
+  // 0068 — scheduled_tasks.connection_group_id. The scheduler is now scoped
+  // to a connection group while retaining connection_id for the #2346
+  // compatibility window.
+  it("scheduled_tasks.connection_group_id: column exists and is nullable", async () => {
+    const { rows } = await pool.query<{ is_nullable: string }>(
+      `SELECT is_nullable
+         FROM information_schema.columns
+        WHERE table_name = 'scheduled_tasks'
+          AND column_name = 'connection_group_id'`,
+    );
+
+    expect(rows[0]?.is_nullable).toBe("YES");
+  }, PG_TEST_TIMEOUT_MS);
+
+  it("scheduled_tasks.connection_group_id: composite FK blocks cross-org membership", async () => {
+    const groupId = `g_sched_fk_${Date.now()}`;
+    await pool.query(
+      `INSERT INTO connection_groups (id, org_id, name)
+       VALUES ($1, 'org-a', $2)`,
+      [groupId, `${groupId}-name`],
+    );
+
+    await expect(
+      pool.query(
+        `INSERT INTO scheduled_tasks
+           (owner_id, org_id, name, question, cron_expression, delivery_channel, recipients, connection_group_id)
+         VALUES
+           ('owner-1', 'org-b', 'Bad group', 'Revenue?', '0 9 * * *', 'email', '[]'::jsonb, $1)`,
+        [groupId],
+      ),
+    ).rejects.toMatchObject({ code: "23503" });
+  }, PG_TEST_TIMEOUT_MS);
 });

--- a/packages/api/src/lib/db/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate.test.ts
@@ -80,8 +80,8 @@ describe("runMigrations", () => {
     const count = await runMigrations(pool);
 
     // 64 base + 0064 (PII, #2341) + 0065 (approvals, #2344) + 0066 (dashboards, #2342)
-    // + 0067 (conversations, #2345) = 68. Bump when the next 1.4.4 slice lands.
-    expect(count).toBe(68);
+    // + 0067 (conversations, #2345) + 0068 (scheduled tasks, #2343) = 69.
+    expect(count).toBe(69);
 
     // Advisory lock acquired before anything else
     expect(queries[0]).toContain("pg_advisory_lock");
@@ -178,6 +178,7 @@ describe("runMigrations", () => {
         "0065_approvals_group_scoped.sql",
         "0066_dashboards_group_scoped.sql",
         "0067_conversations_group_aware.sql",
+        "0068_scheduled_tasks_group.sql",
       ],
     });
 

--- a/packages/api/src/lib/db/migrations/0068_scheduled_tasks_group.sql
+++ b/packages/api/src/lib/db/migrations/0068_scheduled_tasks_group.sql
@@ -50,13 +50,25 @@ END $$;
 CREATE INDEX IF NOT EXISTS idx_scheduled_tasks_group
   ON scheduled_tasks (org_id, connection_group_id);
 
-UPDATE scheduled_tasks st
-   SET connection_group_id = c.group_id
-   FROM connections c
+WITH resolved_task_groups AS (
+  SELECT st.id AS task_id,
+         picked.group_id
+    FROM scheduled_tasks st
+    CROSS JOIN LATERAL (
+      SELECT c.group_id
+        FROM connections c
+       WHERE c.id = st.connection_id
+         AND (c.org_id = st.org_id OR c.org_id = '__global__')
+       ORDER BY CASE WHEN c.org_id = st.org_id THEN 0 ELSE 1 END
+       LIMIT 1
+    ) picked
    WHERE st.connection_id IS NOT NULL
      AND st.connection_group_id IS NULL
-     AND c.id = st.connection_id
-     AND (c.org_id = st.org_id OR c.org_id = '__global__');
+)
+UPDATE scheduled_tasks st
+   SET connection_group_id = resolved.group_id
+   FROM resolved_task_groups resolved
+  WHERE st.id = resolved.task_id;
 
 COMMENT ON COLUMN scheduled_tasks.connection_group_id IS
   'Group scope for this scheduled task (#2343). New rows should set this field; connection_id remains as a legacy execution/audit compatibility field until #2346.';

--- a/packages/api/src/lib/db/migrations/0068_scheduled_tasks_group.sql
+++ b/packages/api/src/lib/db/migrations/0068_scheduled_tasks_group.sql
@@ -1,0 +1,62 @@
+-- 0068 — Group-scoped scheduled tasks (PRD #2336, issue #2343).
+--
+-- Scheduled tasks now belong to a connection group (UI: environment)
+-- rather than a single physical connection. The legacy connection_id column
+-- remains as an execution/audit compatibility field until the #2346 cleanup.
+--
+-- Runtime execution remains one task dispatch per cron tick. At fire time the
+-- scheduler resolves connection_group_id to the group's primary member, or to
+-- the first member by (created_at, id) when no usable primary exists.
+
+ALTER TABLE scheduled_tasks
+  ADD COLUMN IF NOT EXISTS connection_group_id TEXT;
+
+WITH global_task_groups AS (
+  SELECT DISTINCT
+         c.group_id AS group_id,
+         st.org_id AS tenant_org_id,
+         ('__global__:' || g.id) AS name
+    FROM scheduled_tasks st
+    JOIN connections c
+      ON c.id = st.connection_id
+     AND c.org_id = '__global__'
+    JOIN connection_groups g
+      ON g.id = c.group_id
+     AND g.org_id = '__global__'
+   WHERE st.org_id IS NOT NULL
+     AND st.org_id <> '__global__'
+     AND c.group_id IS NOT NULL
+)
+INSERT INTO connection_groups (id, org_id, name)
+SELECT group_id, tenant_org_id, name
+  FROM global_task_groups
+ON CONFLICT (id, org_id) DO NOTHING;
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM information_schema.table_constraints
+    WHERE table_name = 'scheduled_tasks'
+      AND constraint_name = 'fk_scheduled_tasks_group'
+  ) THEN
+    ALTER TABLE scheduled_tasks
+      ADD CONSTRAINT fk_scheduled_tasks_group
+      FOREIGN KEY (connection_group_id, org_id)
+      REFERENCES connection_groups (id, org_id)
+      ON DELETE RESTRICT;
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS idx_scheduled_tasks_group
+  ON scheduled_tasks (org_id, connection_group_id);
+
+UPDATE scheduled_tasks st
+   SET connection_group_id = c.group_id
+   FROM connections c
+   WHERE st.connection_id IS NOT NULL
+     AND st.connection_group_id IS NULL
+     AND c.id = st.connection_id
+     AND (c.org_id = st.org_id OR c.org_id = '__global__');
+
+COMMENT ON COLUMN scheduled_tasks.connection_group_id IS
+  'Group scope for this scheduled task (#2343). New rows should set this field; connection_id remains as a legacy execution/audit compatibility field until #2346.';

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -210,6 +210,43 @@ export const actionLog = pgTable(
 );
 
 // ---------------------------------------------------------------------------
+// Connection groups — multi-environment semantic layer
+// ---------------------------------------------------------------------------
+//
+// Declared above `connections` so the composite FK on `connections.group_id`
+// can name `connectionGroups` directly; the chronological-by-introduction
+// ordering of this file is a soft convention, not a runtime requirement.
+
+export const connectionGroups = pgTable(
+  "connection_groups",
+  {
+    id: text("id").notNull(),
+    orgId: text("org_id").notNull().default("__global__"),
+    name: text("name").notNull(),
+    // Admin-pinned primary member. NULL = "use first member by
+    // (created_at, id)" — see lib/dashboards-group-resolve.ts. 0066
+    // introduces this for group-scoped dashboard cards (#2342).
+    //
+    // The DB enforces a composite FK `(primary_connection_id, org_id)
+    // → connections(id, org_id)` so the primary stays org-isolated.
+    // The FK is declared in the migration only — drizzle's declaration
+    // order forbids referencing `connections` from this earlier table
+    // (forward reference at module eval time). The smoke test in
+    // `migrate-pg.test.ts` pins the FK shape so drift here surfaces
+    // explicitly rather than as a silently dropped constraint.
+    primaryConnectionId: text("primary_connection_id"),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [
+    primaryKey({ columns: [t.id, t.orgId] }),
+    index("idx_connection_groups_org").on(t.orgId),
+    uniqueIndex("uq_connection_groups_org_name").on(t.orgId, t.name),
+    index("idx_connection_groups_primary").on(t.primaryConnectionId, t.orgId),
+  ],
+);
+
+// ---------------------------------------------------------------------------
 // Scheduled tasks
 // ---------------------------------------------------------------------------
 
@@ -247,6 +284,11 @@ export const scheduledTasks = pgTable(
     index("idx_scheduled_tasks_org").on(t.orgId),
     index("idx_scheduled_tasks_group").on(t.orgId, t.connectionGroupId),
     index("idx_scheduled_tasks_plugin_org").on(t.pluginId, t.orgId).where(sql`plugin_id IS NOT NULL`),
+    foreignKey({
+      columns: [t.connectionGroupId, t.orgId],
+      foreignColumns: [connectionGroups.id, connectionGroups.orgId],
+      name: "fk_scheduled_tasks_group",
+    }).onDelete("restrict"),
   ],
 );
 
@@ -270,43 +312,6 @@ export const scheduledTaskRuns = pgTable(
   (t) => [
     index("idx_scheduled_task_runs_task").on(t.taskId),
     index("idx_scheduled_task_runs_status").on(t.status),
-  ],
-);
-
-// ---------------------------------------------------------------------------
-// Connection groups — multi-environment semantic layer
-// ---------------------------------------------------------------------------
-//
-// Declared above `connections` so the composite FK on `connections.group_id`
-// can name `connectionGroups` directly; the chronological-by-introduction
-// ordering of this file is a soft convention, not a runtime requirement.
-
-export const connectionGroups = pgTable(
-  "connection_groups",
-  {
-    id: text("id").notNull(),
-    orgId: text("org_id").notNull().default("__global__"),
-    name: text("name").notNull(),
-    // Admin-pinned primary member. NULL = "use first member by
-    // (created_at, id)" — see lib/dashboards-group-resolve.ts. 0066
-    // introduces this for group-scoped dashboard cards (#2342).
-    //
-    // The DB enforces a composite FK `(primary_connection_id, org_id)
-    // → connections(id, org_id)` so the primary stays org-isolated.
-    // The FK is declared in the migration only — drizzle's declaration
-    // order forbids referencing `connections` from this earlier table
-    // (forward reference at module eval time). The smoke test in
-    // `migrate-pg.test.ts` pins the FK shape so drift here surfaces
-    // explicitly rather than as a silently dropped constraint.
-    primaryConnectionId: text("primary_connection_id"),
-    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
-    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
-  },
-  (t) => [
-    primaryKey({ columns: [t.id, t.orgId] }),
-    index("idx_connection_groups_org").on(t.orgId),
-    uniqueIndex("uq_connection_groups_org_name").on(t.orgId, t.name),
-    index("idx_connection_groups_primary").on(t.primaryConnectionId, t.orgId),
   ],
 );
 

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -223,6 +223,10 @@ export const scheduledTasks = pgTable(
     cronExpression: text("cron_expression").notNull(),
     deliveryChannel: text("delivery_channel").notNull().default("webhook"),
     recipients: jsonb("recipients").notNull().default(sql`'[]'`),
+    // 0068 — group-scoped scheduling (#2343). New rows scope to a
+    // connection group; `connection_id` stays nullable for the #2346
+    // compatibility window.
+    connectionGroupId: text("connection_group_id"),
     connectionId: text("connection_id"),
     approvalMode: text("approval_mode").notNull().default("auto"),
     enabled: boolean("enabled").notNull().default(true),
@@ -241,6 +245,7 @@ export const scheduledTasks = pgTable(
     index("idx_scheduled_tasks_enabled").on(t.enabled).where(sql`enabled = true`),
     index("idx_scheduled_tasks_next_run").on(t.nextRunAt).where(sql`enabled = true`),
     index("idx_scheduled_tasks_org").on(t.orgId),
+    index("idx_scheduled_tasks_group").on(t.orgId, t.connectionGroupId),
     index("idx_scheduled_tasks_plugin_org").on(t.pluginId, t.orgId).where(sql`plugin_id IS NOT NULL`),
   ],
 );

--- a/packages/api/src/lib/scheduled-task-types.ts
+++ b/packages/api/src/lib/scheduled-task-types.ts
@@ -39,6 +39,7 @@ export interface ScheduledTaskRow {
   cron_expression: string;
   delivery_channel: string;
   recipients: unknown; // JSONB
+  connection_group_id: string | null;
   connection_id: string | null;
   approval_mode: string;
   enabled: boolean;

--- a/packages/api/src/lib/scheduled-tasks.ts
+++ b/packages/api/src/lib/scheduled-tasks.ts
@@ -17,6 +17,7 @@ import {
   internalQuery,
   internalExecute,
 } from "@atlas/api/lib/db/internal";
+import { withGroupScope } from "@atlas/api/lib/db/with-group-scope";
 import type {
   ScheduledTask,
   ScheduledTaskRun,
@@ -75,6 +76,7 @@ function rowToScheduledTask(r: Record<string, unknown>): ScheduledTask {
     cronExpression: r.cron_expression as string,
     deliveryChannel: (r.delivery_channel as DeliveryChannel) ?? "webhook",
     recipients,
+    connectionGroupId: (r.connection_group_id as string) ?? null,
     connectionId: (r.connection_id as string) ?? null,
     approvalMode: (r.approval_mode as ActionApprovalMode) ?? "auto",
     enabled: r.enabled === true,
@@ -159,6 +161,23 @@ function orgScopeClause(
   return { clause: `${col} IS NULL`, nextIdx: paramIdx };
 }
 
+async function resolveGroupIdForConnection(
+  orgId: string | null | undefined,
+  connectionId: string | null | undefined,
+): Promise<string | null> {
+  if (!connectionId) return null;
+  const rows = await internalQuery<{ group_id: string | null }>(
+    `SELECT group_id
+       FROM connections
+      WHERE id = $1
+        AND (org_id = $2 OR org_id = '__global__')
+      ORDER BY CASE WHEN org_id = $2 THEN 0 ELSE 1 END
+      LIMIT 1`,
+    [connectionId, orgId ?? "__global__"],
+  );
+  return rows[0]?.group_id ?? null;
+}
+
 // ---------------------------------------------------------------------------
 // CRUD — Tasks
 // ---------------------------------------------------------------------------
@@ -171,6 +190,7 @@ export async function createScheduledTask(opts: {
   cronExpression: string;
   deliveryChannel?: DeliveryChannel;
   recipients?: Recipient[];
+  connectionGroupId?: string | null;
   connectionId?: string | null;
   approvalMode?: ActionApprovalMode;
 }): Promise<CrudDataResult<ScheduledTask>> {
@@ -185,9 +205,12 @@ export async function createScheduledTask(opts: {
   const nextRun = computeNextRun(opts.cronExpression);
 
   try {
+    const connectionGroupId = opts.connectionGroupId !== undefined
+      ? opts.connectionGroupId
+      : await resolveGroupIdForConnection(opts.orgId, opts.connectionId);
     const rows = await internalQuery<Record<string, unknown>>(
-      `INSERT INTO scheduled_tasks (owner_id, org_id, name, question, cron_expression, delivery_channel, recipients, connection_id, approval_mode, next_run_at)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+      `INSERT INTO scheduled_tasks (owner_id, org_id, name, question, cron_expression, delivery_channel, recipients, connection_group_id, connection_id, approval_mode, next_run_at)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
        RETURNING *`,
       [
         opts.ownerId,
@@ -197,6 +220,7 @@ export async function createScheduledTask(opts: {
         opts.cronExpression,
         opts.deliveryChannel ?? "webhook",
         JSON.stringify(opts.recipients ?? []),
+        connectionGroupId ?? null,
         opts.connectionId ?? null,
         opts.approvalMode ?? "auto",
         nextRun?.toISOString() ?? null,
@@ -219,7 +243,7 @@ export async function createScheduledTask(opts: {
  */
 export async function getScheduledTask(
   id: string,
-  scope?: { orgId?: string | null },
+  scope?: { orgId?: string | null; connectionGroupId?: string | null },
 ): Promise<CrudDataResult<ScheduledTask>> {
   if (!hasInternalDB()) return { ok: false, reason: "no_db" };
   try {
@@ -228,8 +252,12 @@ export async function getScheduledTask(
       // Org-scoped lookup (admin routes)
       const params: unknown[] = [id];
       const org = orgScopeClause(scope.orgId, params, 2);
+      const group = "connectionGroupId" in scope ? withGroupScope(scope.connectionGroupId) : null;
+      if (group) params.push(group.param);
       rows = await internalQuery<Record<string, unknown>>(
-        `SELECT * FROM scheduled_tasks WHERE id = $1 AND ${org.clause}`,
+        `SELECT * FROM scheduled_tasks WHERE id = $1 AND ${org.clause}${
+          group ? ` AND ${group.match(org.nextIdx, { column: "connection_group_id" })}` : ""
+        }`,
         params,
       );
     } else {
@@ -250,6 +278,7 @@ export async function getScheduledTask(
 export async function listScheduledTasks(opts?: {
   orgId?: string | null;
   enabled?: boolean;
+  connectionGroupId?: string | null;
   limit?: number;
   offset?: number;
 }): Promise<{ tasks: ScheduledTask[]; total: number }> {
@@ -272,6 +301,12 @@ export async function listScheduledTasks(opts?: {
     if (opts?.enabled !== undefined) {
       conditions.push(`enabled = $${paramIdx++}`);
       params.push(opts.enabled);
+    }
+    if (opts !== undefined && "connectionGroupId" in opts) {
+      const group = withGroupScope(opts.connectionGroupId);
+      conditions.push(group.match(paramIdx, { column: "connection_group_id" }));
+      params.push(group.param);
+      paramIdx++;
     }
 
     const where = conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
@@ -303,6 +338,7 @@ export async function updateScheduledTask(
     cronExpression?: string;
     deliveryChannel?: DeliveryChannel;
     recipients?: Recipient[];
+    connectionGroupId?: string | null;
     connectionId?: string | null;
     approvalMode?: ActionApprovalMode;
     enabled?: boolean;
@@ -341,6 +377,13 @@ export async function updateScheduledTask(
   if (updates.recipients !== undefined) {
     setClauses.push(`recipients = $${paramIdx++}`);
     params.push(JSON.stringify(updates.recipients));
+  }
+  if (updates.connectionGroupId !== undefined) {
+    setClauses.push(`connection_group_id = $${paramIdx++}`);
+    params.push(updates.connectionGroupId);
+  } else if (updates.connectionId !== undefined) {
+    setClauses.push(`connection_group_id = $${paramIdx++}`);
+    params.push(await resolveGroupIdForConnection(scope.orgId, updates.connectionId));
   }
   if (updates.connectionId !== undefined) {
     setClauses.push(`connection_id = $${paramIdx++}`);

--- a/packages/api/src/lib/scheduler/__tests__/delivery.test.ts
+++ b/packages/api/src/lib/scheduler/__tests__/delivery.test.ts
@@ -60,6 +60,7 @@ function makeTask(overrides: Partial<ScheduledTask> = {}): ScheduledTask {
     cronExpression: "0 9 * * 1",
     deliveryChannel: "webhook",
     recipients: [],
+    connectionGroupId: null,
     connectionId: null,
     approvalMode: "auto",
     enabled: true,

--- a/packages/api/src/lib/scheduler/__tests__/executor.test.ts
+++ b/packages/api/src/lib/scheduler/__tests__/executor.test.ts
@@ -14,6 +14,8 @@ const mockGetScheduledTask = mock(() =>
       id: "task-1",
       ownerId: "user-1",
       orgId: "org-1",
+      connectionId: "legacy-connection",
+      connectionGroupId: "group-1",
       question: "What is revenue?",
       recipients: [{ type: "webhook", url: "https://hook.example.com" }],
       deliveryChannel: "webhook",
@@ -76,6 +78,8 @@ type AgentResultLike = typeof mockAgentResult & {
 let agentResultOverride: AgentResultLike | null = null;
 type ExecuteAgentQueryOptionsLike = {
   actor?: { id: string; activeOrganizationId?: string };
+  connectionId?: string;
+  connectionGroupId?: string;
   priorMessages?: Array<{ role: "user" | "assistant"; content: string }>;
   conversationId?: string;
 };
@@ -99,6 +103,12 @@ mock.module("../delivery", () => ({
   deliverResult: mockDeliverResult,
 }));
 
+const mockResolveScheduledTaskConnection = mock(() => Promise.resolve("resolved-connection"));
+
+mock.module("../group-resolve", () => ({
+  resolveScheduledTaskConnection: mockResolveScheduledTaskConnection,
+}));
+
 const { executeScheduledTask } = await import("../executor");
 
 describe("executor", () => {
@@ -112,6 +122,8 @@ describe("executor", () => {
         id: "task-1",
         ownerId: "user-1",
         orgId: "org-1",
+        connectionId: "legacy-connection",
+        connectionGroupId: "group-1",
         question: "What is revenue?",
         recipients: [{ type: "webhook", url: "https://hook.example.com" }],
         deliveryChannel: "webhook",
@@ -136,6 +148,8 @@ describe("executor", () => {
     mockDeliverResult.mockReset();
     mockDeliverResult.mockResolvedValue({ attempted: 1, succeeded: 1, failed: 0 });
     mockUpdateRunDeliveryStatus.mockReset();
+    mockResolveScheduledTaskConnection.mockReset();
+    mockResolveScheduledTaskConnection.mockResolvedValue("resolved-connection");
   });
 
   it("executes task and returns result with delivery counts", async () => {
@@ -202,6 +216,19 @@ describe("executor", () => {
     const opts = calls[0][2] as { actor?: { id: string; activeOrganizationId?: string } } | undefined;
     expect(opts?.actor?.id).toBe("user-1");
     expect(opts?.actor?.activeOrganizationId).toBe("org-1");
+  });
+
+  it("resolves the group member once and runs the agent against that connection", async () => {
+    await executeScheduledTask("task-1", "run-1", 30_000);
+    expect(mockResolveScheduledTaskConnection).toHaveBeenCalledWith({
+      taskId: "task-1",
+      orgId: "org-1",
+      connectionGroupId: "group-1",
+      legacyConnectionId: "legacy-connection",
+    });
+    const opts = mockExecuteAgentQuery.mock.calls[0][2];
+    expect(opts?.connectionId).toBe("resolved-connection");
+    expect(opts?.connectionGroupId).toBe("group-1");
   });
 
   it("F-54: refuses to run when the task creator can't be resolved (deleted user)", async () => {

--- a/packages/api/src/lib/scheduler/__tests__/format-email.test.ts
+++ b/packages/api/src/lib/scheduler/__tests__/format-email.test.ts
@@ -16,6 +16,7 @@ function makeTask(overrides: Partial<ScheduledTask> = {}): ScheduledTask {
     cronExpression: "0 9 * * 1",
     deliveryChannel: "email",
     recipients: [],
+    connectionGroupId: null,
     connectionId: null,
     approvalMode: "auto",
     enabled: true,

--- a/packages/api/src/lib/scheduler/__tests__/format-slack.test.ts
+++ b/packages/api/src/lib/scheduler/__tests__/format-slack.test.ts
@@ -16,6 +16,7 @@ function makeTask(overrides: Partial<ScheduledTask> = {}): ScheduledTask {
     cronExpression: "0 9 * * 1",
     deliveryChannel: "slack",
     recipients: [],
+    connectionGroupId: null,
     connectionId: null,
     approvalMode: "auto",
     enabled: true,

--- a/packages/api/src/lib/scheduler/__tests__/format-webhook.test.ts
+++ b/packages/api/src/lib/scheduler/__tests__/format-webhook.test.ts
@@ -16,6 +16,7 @@ function makeTask(overrides: Partial<ScheduledTask> = {}): ScheduledTask {
     cronExpression: "0 9 * * 1",
     deliveryChannel: "webhook",
     recipients: [],
+    connectionGroupId: null,
     connectionId: null,
     approvalMode: "auto",
     enabled: true,

--- a/packages/api/src/lib/scheduler/__tests__/group-resolve.test.ts
+++ b/packages/api/src/lib/scheduler/__tests__/group-resolve.test.ts
@@ -48,6 +48,20 @@ describe("selectScheduledTaskGroupMember", () => {
     expect(selectScheduledTaskGroupMember(snap)).toBe("alpha");
   });
 
+  it("sorts Date-created members chronologically", () => {
+    const snap: SchedulerGroupSnapshot = {
+      groupId: "g_prod",
+      orgId: "org-1",
+      primaryConnectionId: null,
+      members: [
+        { id: "may", createdAt: new Date("2026-05-01T00:00:00Z") },
+        { id: "apr", createdAt: new Date("2026-04-01T00:00:00Z") },
+      ],
+    };
+
+    expect(selectScheduledTaskGroupMember(snap)).toBe("apr");
+  });
+
   it("throws when the group has no members", () => {
     expect(() =>
       selectScheduledTaskGroupMember({

--- a/packages/api/src/lib/scheduler/__tests__/group-resolve.test.ts
+++ b/packages/api/src/lib/scheduler/__tests__/group-resolve.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "bun:test";
+import {
+  NoScheduledTaskGroupMembersError,
+  selectScheduledTaskGroupMember,
+  type SchedulerGroupSnapshot,
+} from "../group-resolve";
+
+const MEMBERS = [
+  { id: "us-int", createdAt: "2026-04-01T00:00:00Z" },
+  { id: "eu", createdAt: "2026-04-15T00:00:00Z" },
+  { id: "apac", createdAt: "2026-05-01T00:00:00Z" },
+] as const;
+
+describe("selectScheduledTaskGroupMember", () => {
+  it("returns the primary member when it is still in the group", () => {
+    const snap: SchedulerGroupSnapshot = {
+      groupId: "g_prod",
+      orgId: "org-1",
+      primaryConnectionId: "eu",
+      members: [...MEMBERS],
+    };
+
+    expect(selectScheduledTaskGroupMember(snap)).toBe("eu");
+  });
+
+  it("falls back to the first member by (created_at ASC, id ASC) when primary is missing", () => {
+    const snap: SchedulerGroupSnapshot = {
+      groupId: "g_prod",
+      orgId: "org-1",
+      primaryConnectionId: "ghost",
+      members: [...MEMBERS],
+    };
+
+    expect(selectScheduledTaskGroupMember(snap)).toBe("us-int");
+  });
+
+  it("breaks fallback ties by id", () => {
+    const snap: SchedulerGroupSnapshot = {
+      groupId: "g_prod",
+      orgId: "org-1",
+      primaryConnectionId: null,
+      members: [
+        { id: "zeta", createdAt: "2026-04-01T00:00:00Z" },
+        { id: "alpha", createdAt: "2026-04-01T00:00:00Z" },
+      ],
+    };
+
+    expect(selectScheduledTaskGroupMember(snap)).toBe("alpha");
+  });
+
+  it("throws when the group has no members", () => {
+    expect(() =>
+      selectScheduledTaskGroupMember({
+        groupId: "g_empty",
+        orgId: "org-1",
+        primaryConnectionId: null,
+        members: [],
+      }),
+    ).toThrow(NoScheduledTaskGroupMembersError);
+  });
+});

--- a/packages/api/src/lib/scheduler/__tests__/preview.test.ts
+++ b/packages/api/src/lib/scheduler/__tests__/preview.test.ts
@@ -15,6 +15,7 @@ function makeTask(overrides: Partial<ScheduledTask> = {}): ScheduledTask {
     cronExpression: "0 9 * * 1",
     deliveryChannel: "email",
     recipients: [],
+    connectionGroupId: null,
     connectionId: null,
     approvalMode: "auto",
     enabled: true,

--- a/packages/api/src/lib/scheduler/executor.ts
+++ b/packages/api/src/lib/scheduler/executor.ts
@@ -25,6 +25,7 @@ import { loadActorUser } from "@atlas/api/lib/auth/actor";
 import { SchedulerTaskTimeoutError, SchedulerExecutionError } from "@atlas/api/lib/effect/errors";
 import { causeToError } from "@atlas/api/lib/audit/error-scrub";
 import { deliverResult } from "./delivery";
+import { resolveScheduledTaskConnection } from "./group-resolve";
 
 const log = createLogger("scheduler-executor");
 
@@ -105,6 +106,12 @@ export async function executeScheduledTask(
 
   const task = taskResult.data;
   const requestId = `sched-${taskId}-${runId}`;
+  const resolvedConnectionId = await resolveScheduledTaskConnection({
+    taskId,
+    orgId: task.orgId,
+    connectionGroupId: task.connectionGroupId,
+    legacyConnectionId: task.connectionId,
+  });
 
   // F-54: resolve the task creator so approval rules apply. If the user no
   // longer exists (account deleted, removed from org), fail-loud rather than
@@ -121,7 +128,15 @@ export async function executeScheduledTask(
   }
 
   log.info(
-    { taskId, runId, actorId: actor.id, orgId: task.orgId, question: task.question.slice(0, 100) },
+    {
+      taskId,
+      runId,
+      actorId: actor.id,
+      orgId: task.orgId,
+      connectionGroupId: task.connectionGroupId,
+      connectionId: resolvedConnectionId,
+      question: task.question.slice(0, 100),
+    },
     "Executing scheduled task",
   );
 
@@ -137,7 +152,12 @@ export async function executeScheduledTask(
     // the same tables unaffected. (Approval rules are additive; they
     // can only require approval, never waive it — to exempt the
     // scheduler from a broad rule, narrow that rule's surface.)
-    agentQueryEffect(task.question, requestId, taskId, timeoutMs, { actor, approvalSurface: "scheduler" }),
+    agentQueryEffect(task.question, requestId, taskId, timeoutMs, {
+      actor,
+      approvalSurface: "scheduler",
+      ...(resolvedConnectionId ? { connectionId: resolvedConnectionId } : {}),
+      ...(task.connectionGroupId ? { connectionGroupId: task.connectionGroupId } : {}),
+    }),
   );
   if (Exit.isFailure(exit)) {
     if (Cause.isInterruptedOnly(exit.cause)) {

--- a/packages/api/src/lib/scheduler/group-resolve.ts
+++ b/packages/api/src/lib/scheduler/group-resolve.ts
@@ -6,7 +6,7 @@ const log = createLogger("scheduler-group-resolve");
 
 export interface SchedulerGroupMember {
   readonly id: string;
-  readonly createdAt: string;
+  readonly createdAt: Date | string;
 }
 
 export interface SchedulerGroupSnapshot {
@@ -14,6 +14,10 @@ export interface SchedulerGroupSnapshot {
   readonly orgId: string | null;
   readonly primaryConnectionId: string | null;
   readonly members: readonly SchedulerGroupMember[];
+}
+
+function timestampToSortable(value: Date | string): string {
+  return value instanceof Date ? value.toISOString() : String(value);
 }
 
 export class NoScheduledTaskGroupMembersError extends Error {
@@ -47,7 +51,9 @@ export function selectScheduledTaskGroupMember(snapshot: SchedulerGroupSnapshot)
   }
 
   const sorted = [...snapshot.members].sort((a, b) => {
-    if (a.createdAt !== b.createdAt) return a.createdAt < b.createdAt ? -1 : 1;
+    const aCreatedAt = timestampToSortable(a.createdAt);
+    const bCreatedAt = timestampToSortable(b.createdAt);
+    if (aCreatedAt !== bCreatedAt) return aCreatedAt < bCreatedAt ? -1 : 1;
     return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
   });
   return sorted[0].id;
@@ -61,31 +67,52 @@ export async function loadScheduledTaskGroupSnapshot(
 
   try {
     const groupRows = await internalQuery<{ primary_connection_id: string | null }>(
-      `SELECT COALESCE(local.primary_connection_id, global.primary_connection_id) AS primary_connection_id
-         FROM connection_groups local
-         LEFT JOIN connection_groups global
-           ON global.id = local.id
-          AND global.org_id = '__global__'
-        WHERE local.id = $1 AND local.org_id = $2`,
+      `SELECT primary_connection_id
+         FROM connection_groups
+        WHERE id = $1 AND org_id = $2`,
       [groupId, orgId ?? "__global__"],
     );
     if (groupRows.length === 0) return null;
+    let primaryConnectionId = groupRows[0]?.primary_connection_id ?? null;
 
-    const memberRows = await internalQuery<{ id: string; created_at: string }>(
+    let memberRows = await internalQuery<{ id: string; created_at: Date | string }>(
       `SELECT id, created_at
          FROM connections
         WHERE group_id = $1
-          AND (org_id = $2 OR org_id = '__global__')
+          AND org_id = $2
           AND status != 'archived'
-        ORDER BY CASE WHEN org_id = $2 THEN 0 ELSE 1 END, created_at ASC, id ASC`,
+        ORDER BY created_at ASC, id ASC`,
       [groupId, orgId ?? "__global__"],
     );
+    if (memberRows.length === 0 && orgId !== null && orgId !== "__global__") {
+      const globalRows = await Promise.all([
+        primaryConnectionId === null
+          ? internalQuery<{ primary_connection_id: string | null }>(
+            `SELECT primary_connection_id
+               FROM connection_groups
+              WHERE id = $1 AND org_id = '__global__'`,
+            [groupId],
+          )
+          : Promise.resolve([]),
+        internalQuery<{ id: string; created_at: Date | string }>(
+          `SELECT id, created_at
+           FROM connections
+          WHERE group_id = $1
+            AND org_id = '__global__'
+            AND status != 'archived'
+          ORDER BY created_at ASC, id ASC`,
+          [groupId],
+        ),
+      ]);
+      primaryConnectionId = primaryConnectionId ?? globalRows[0][0]?.primary_connection_id ?? null;
+      memberRows = globalRows[1];
+    }
 
     return {
       groupId,
       orgId,
-      primaryConnectionId: groupRows[0]?.primary_connection_id ?? null,
-      members: memberRows.map((row) => ({ id: row.id, createdAt: String(row.created_at) })),
+      primaryConnectionId,
+      members: memberRows.map((row) => ({ id: row.id, createdAt: timestampToSortable(row.created_at) })),
     };
   } catch (err) {
     log.error({ err: errorMessage(err), groupId, orgId }, "Failed to load scheduled task group snapshot");

--- a/packages/api/src/lib/scheduler/group-resolve.ts
+++ b/packages/api/src/lib/scheduler/group-resolve.ts
@@ -1,0 +1,109 @@
+import { createLogger } from "@atlas/api/lib/logger";
+import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
+import { hasInternalDB, internalQuery } from "@atlas/api/lib/db/internal";
+
+const log = createLogger("scheduler-group-resolve");
+
+export interface SchedulerGroupMember {
+  readonly id: string;
+  readonly createdAt: string;
+}
+
+export interface SchedulerGroupSnapshot {
+  readonly groupId: string;
+  readonly orgId: string | null;
+  readonly primaryConnectionId: string | null;
+  readonly members: readonly SchedulerGroupMember[];
+}
+
+export class NoScheduledTaskGroupMembersError extends Error {
+  override readonly name = "NoScheduledTaskGroupMembersError";
+  readonly groupId: string;
+  readonly orgId: string | null;
+
+  constructor(groupId: string, orgId: string | null) {
+    super(`Connection group ${groupId} (org=${orgId ?? "__global__"}) has no members; scheduled task cannot resolve to a connection.`);
+    this.groupId = groupId;
+    this.orgId = orgId;
+  }
+}
+
+export function selectScheduledTaskGroupMember(snapshot: SchedulerGroupSnapshot): string {
+  if (snapshot.members.length === 0) {
+    throw new NoScheduledTaskGroupMembersError(snapshot.groupId, snapshot.orgId);
+  }
+
+  if (snapshot.primaryConnectionId !== null) {
+    const primary = snapshot.members.find((m) => m.id === snapshot.primaryConnectionId);
+    if (primary) return primary.id;
+    log.warn(
+      {
+        groupId: snapshot.groupId,
+        orgId: snapshot.orgId,
+        primaryConnectionId: snapshot.primaryConnectionId,
+      },
+      "Scheduled task group primary is missing — falling back to first member",
+    );
+  }
+
+  const sorted = [...snapshot.members].sort((a, b) => {
+    if (a.createdAt !== b.createdAt) return a.createdAt < b.createdAt ? -1 : 1;
+    return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+  });
+  return sorted[0].id;
+}
+
+export async function loadScheduledTaskGroupSnapshot(
+  groupId: string,
+  orgId: string | null,
+): Promise<SchedulerGroupSnapshot | null> {
+  if (!hasInternalDB()) return null;
+
+  try {
+    const groupRows = await internalQuery<{ primary_connection_id: string | null }>(
+      `SELECT COALESCE(local.primary_connection_id, global.primary_connection_id) AS primary_connection_id
+         FROM connection_groups local
+         LEFT JOIN connection_groups global
+           ON global.id = local.id
+          AND global.org_id = '__global__'
+        WHERE local.id = $1 AND local.org_id = $2`,
+      [groupId, orgId ?? "__global__"],
+    );
+    if (groupRows.length === 0) return null;
+
+    const memberRows = await internalQuery<{ id: string; created_at: string }>(
+      `SELECT id, created_at
+         FROM connections
+        WHERE group_id = $1
+          AND (org_id = $2 OR org_id = '__global__')
+          AND status != 'archived'
+        ORDER BY CASE WHEN org_id = $2 THEN 0 ELSE 1 END, created_at ASC, id ASC`,
+      [groupId, orgId ?? "__global__"],
+    );
+
+    return {
+      groupId,
+      orgId,
+      primaryConnectionId: groupRows[0]?.primary_connection_id ?? null,
+      members: memberRows.map((row) => ({ id: row.id, createdAt: String(row.created_at) })),
+    };
+  } catch (err) {
+    log.error({ err: errorMessage(err), groupId, orgId }, "Failed to load scheduled task group snapshot");
+    throw err;
+  }
+}
+
+export async function resolveScheduledTaskConnection(opts: {
+  readonly taskId: string;
+  readonly orgId: string | null;
+  readonly connectionGroupId: string | null;
+  readonly legacyConnectionId: string | null;
+}): Promise<string | null> {
+  if (!opts.connectionGroupId) return opts.legacyConnectionId;
+
+  const snapshot = await loadScheduledTaskGroupSnapshot(opts.connectionGroupId, opts.orgId);
+  if (!snapshot) {
+    throw new Error(`Connection group ${opts.connectionGroupId} for scheduled task ${opts.taskId} was not found.`);
+  }
+  return selectScheduledTaskGroupMember(snapshot);
+}

--- a/packages/types/src/scheduled-task.ts
+++ b/packages/types/src/scheduled-task.ts
@@ -56,6 +56,12 @@ export interface ScheduledTask {
   deliveryChannel: DeliveryChannel;
   /** Recipients should match the deliveryChannel type (email recipients for email channel, etc). */
   recipients: Recipient[];
+  /**
+   * Environment/group scope for this task. New 1.4.4+ callers should set this
+   * instead of targeting raw connections directly.
+   */
+  connectionGroupId: string | null;
+  /** @deprecated Prefer `connectionGroupId`; retained until #2346. */
   connectionId: string | null;
   approvalMode: ActionApprovalMode;
   enabled: boolean;

--- a/packages/web/src/app/admin/scheduled-tasks/task-form-dialog.tsx
+++ b/packages/web/src/app/admin/scheduled-tasks/task-form-dialog.tsx
@@ -199,7 +199,7 @@ export function TaskFormDialog({
           const nextGroups = data.groups as ConnectionGroupInfo[];
           setGroups(nextGroups);
           setForm((prev) => {
-            if (prev.connectionGroupId || nextGroups.length === 0) return prev;
+            if (isEdit || prev.connectionGroupId || nextGroups.length === 0) return prev;
             return { ...prev, connectionGroupId: nextGroups[0]?.id ?? "" };
           });
         }
@@ -210,7 +210,7 @@ export function TaskFormDialog({
     }
     fetchGroups();
     return () => { cancelled = true; };
-  }, [open, apiUrl, credentials]);
+  }, [open, apiUrl, credentials, isEdit]);
 
   // ── Field updaters ──────────────────────────────────────────────────
 
@@ -317,6 +317,7 @@ export function TaskFormDialog({
       return;
     }
 
+    const selectedGroup = groups.find((g) => g.id === form.connectionGroupId);
     const body = {
       name: form.name.trim(),
       question: form.question.trim(),
@@ -324,7 +325,7 @@ export function TaskFormDialog({
       deliveryChannel: form.deliveryChannel,
       recipients,
       connectionGroupId: form.connectionGroupId || null,
-      connectionId: groups.find((g) => g.id === form.connectionGroupId)?.resolvedConnectionId ?? null,
+      connectionId: selectedGroup?.resolvedConnectionId ?? task?.connectionId ?? null,
       approvalMode: form.approvalMode,
       ...(isEdit ? { enabled: form.enabled } : {}),
     };

--- a/packages/web/src/app/admin/scheduled-tasks/task-form-dialog.tsx
+++ b/packages/web/src/app/admin/scheduled-tasks/task-form-dialog.tsx
@@ -42,9 +42,11 @@ import type {
 
 // ── Types ─────────────────────────────────────────────────────────────
 
-interface ConnectionInfo {
+interface ConnectionGroupInfo {
   id: string;
-  type: string;
+  name: string;
+  memberCount: number;
+  resolvedConnectionId: string | null;
 }
 
 // Form state (flat, before mapping to API shape)
@@ -55,7 +57,7 @@ interface FormState {
   cronExpression: string;
   deliveryChannel: DeliveryChannel;
   approvalMode: ActionApprovalMode;
-  connectionId: string;
+  connectionGroupId: string;
   enabled: boolean;
   // Email recipients
   emailAddresses: string[];
@@ -76,7 +78,7 @@ function defaultFormState(): FormState {
     cronExpression: "0 9 * * *",
     deliveryChannel: "email",
     approvalMode: "auto",
-    connectionId: "default",
+    connectionGroupId: "",
     enabled: true,
     emailAddresses: [],
     emailInput: "",
@@ -137,7 +139,7 @@ function formStateFromTask(task: ScheduledTask): FormState {
     cronPreset: presetFromCron(task.cronExpression),
     deliveryChannel: task.deliveryChannel,
     approvalMode: task.approvalMode,
-    connectionId: task.connectionId ?? "default",
+    connectionGroupId: task.connectionGroupId ?? "",
     enabled: task.enabled,
     ...recipients,
   };
@@ -164,7 +166,7 @@ export function TaskFormDialog({
   const isEdit = task !== null;
   const [form, setForm] = useState<FormState>(defaultFormState);
   const [validationError, setValidationError] = useState<string | null>(null);
-  const [connections, setConnections] = useState<ConnectionInfo[]>([]);
+  const [groups, setGroups] = useState<ConnectionGroupInfo[]>([]);
   const [connectionError, setConnectionError] = useState<string | null>(null);
 
   const submitMutation = useAdminMutation({
@@ -180,28 +182,33 @@ export function TaskFormDialog({
     }
   }, [open, task]);
 
-  // Fetch connections
+  // Fetch environments
   useEffect(() => {
     if (!open) return;
     let cancelled = false;
-    async function fetchConnections() {
+    async function fetchGroups() {
       setConnectionError(null);
       try {
-        const res = await fetch(`${apiUrl}/api/v1/admin/connections`, { credentials });
+        const res = await fetch(`${apiUrl}/api/v1/admin/connection-groups`, { credentials });
         if (!res.ok) {
-          if (!cancelled) setConnectionError(`Could not load connections (HTTP ${res.status})`);
+          if (!cancelled) setConnectionError(`Could not load environments (HTTP ${res.status})`);
           return;
         }
         const data = await res.json();
-        if (!cancelled && Array.isArray(data.connections)) {
-          setConnections(data.connections);
+        if (!cancelled && Array.isArray(data.groups)) {
+          const nextGroups = data.groups as ConnectionGroupInfo[];
+          setGroups(nextGroups);
+          setForm((prev) => {
+            if (prev.connectionGroupId || nextGroups.length === 0) return prev;
+            return { ...prev, connectionGroupId: nextGroups[0]?.id ?? "" };
+          });
         }
       } catch (err) {
-        console.warn("[TaskFormDialog] Failed to fetch connections:", err);
-        if (!cancelled) setConnectionError("Could not load connections");
+        console.warn("[TaskFormDialog] Failed to fetch environments:", err);
+        if (!cancelled) setConnectionError("Could not load environments");
       }
     }
-    fetchConnections();
+    fetchGroups();
     return () => { cancelled = true; };
   }, [open, apiUrl, credentials]);
 
@@ -316,7 +323,8 @@ export function TaskFormDialog({
       cronExpression: form.cronExpression.trim(),
       deliveryChannel: form.deliveryChannel,
       recipients,
-      connectionId: form.connectionId === "default" ? null : form.connectionId,
+      connectionGroupId: form.connectionGroupId || null,
+      connectionId: groups.find((g) => g.id === form.connectionGroupId)?.resolvedConnectionId ?? null,
       approvalMode: form.approvalMode,
       ...(isEdit ? { enabled: form.enabled } : {}),
     };
@@ -543,20 +551,21 @@ export function TaskFormDialog({
             </div>
           )}
 
-          {/* Connection */}
+          {/* Environment */}
           <div className="grid gap-2">
-            <Label>Connection</Label>
-            <Select value={form.connectionId} onValueChange={(v) => updateField("connectionId", v)}>
+            <Label>Environment</Label>
+            <Select
+              value={form.connectionGroupId}
+              onValueChange={(v) => updateField("connectionGroupId", v)}
+              disabled={groups.length === 0}
+            >
               <SelectTrigger>
-                <SelectValue />
+                <SelectValue placeholder="Select environment" />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="default">Default</SelectItem>
-                {connections
-                  .filter((c) => c.id !== "default")
-                  .map((c) => (
-                    <SelectItem key={c.id} value={c.id}>
-                      {c.id} ({c.type})
+                {groups.map((group) => (
+                    <SelectItem key={group.id} value={group.id}>
+                      {group.name} ({group.memberCount})
                     </SelectItem>
                   ))}
               </SelectContent>


### PR DESCRIPTION
## Summary

Implements #2343 for milestone 1.4.4 by moving scheduled tasks onto the connection-group/environment axis while preserving the legacy `connectionId` compatibility field for the #2346 cleanup window.

- adds `scheduled_tasks.connection_group_id` with schema mirror, backfill, tenant-local group mirroring for global connections, FK/index coverage, and real-Postgres smoke assertions
- resolves scheduled task execution through the group's primary connection at fire time, with a warning fallback to the first member by `(created_at, id)` when the primary is missing
- threads `connectionGroupId` through API create/update/list flows, `executeAgentQuery`, shared types, and scheduler delivery fixtures
- updates the admin scheduled task form to select environments/groups instead of raw physical connections

## Execution model

This intentionally keeps the v1 behavior to one task dispatch per cron tick against the resolved primary member, not federation/fan-out. That matches the confirmed direction for this slice and leaves regional fan-out as an explicit future design instead of smuggling it into scheduled task semantics.

## Validation

Focused checks run before the final executor assertion was added:

- `bun test packages/api/src/lib/__tests__/scheduled-tasks.test.ts` passed
- `bun test packages/api/src/lib/scheduler/__tests__/group-resolve.test.ts packages/api/src/api/__tests__/scheduled-tasks.test.ts packages/api/src/lib/db/__tests__/migrate.test.ts` passed

Notes:

- A combined focused run showed existing Bun module mock contamination around `getTasksDueForExecution` when scheduled-task route/lib suites are loaded together; the same files passed in isolated combinations.
- Typecheck was blocked by pre-existing/parallel slice type drift in PII, approvals, conversations, dashboards, and schemas declarations, not by the scheduled-task additions after the local fixes.
- Rerunning Bun after the executor assertion was blocked in this Codex session because Windows Bun requires out-of-sandbox execution and the escalation reviewer hit the session usage limit.

Full `bun run test` and `TEST_DATABASE_URL` migration smoke still need to run before marking this PR ready.