### PR TITLE
feat(types)!: drop legacy connectionId — major bump to 0.1.0 (#2346)

### DIFF
--- a/apps/docs/content/docs/sdk/meta.json
+++ b/apps/docs/content/docs/sdk/meta.json
@@ -4,6 +4,7 @@
   "icon": "Code",
   "pages": [
     "starter-prompts",
-    "mcp"
+    "mcp",
+    "migration-0.1"
   ]
 }

--- a/apps/docs/content/docs/sdk/migration-0.1.mdx
+++ b/apps/docs/content/docs/sdk/migration-0.1.mdx
@@ -1,0 +1,188 @@
+---
+title: Migrating to 0.1
+description: Drop the legacy `connectionId` field — the 1.4.4 multi-environment slice (#2336) replaces it with `connectionGroupId` on every wire shape it touched.
+---
+
+`@useatlas/types@0.1.0` is the first major bump on the `0.x` line. It
+removes the deprecated `connectionId` field that #2340–#2345 dual-wrote
+alongside the new `connectionGroupId` while the multi-environment
+semantic layer rolled out. `@useatlas/sdk` and `@useatlas/react` follow
+the major in a coordinated second wave.
+
+## Why this exists
+
+Atlas 1.4.4 made every piece of content (semantic entities, PII rules,
+dashboards, scheduled tasks, approvals) scope to a **connection group**
+instead of a single connection. The migration shipped additively:
+existing rows kept `connection_id`, new rows started populating
+`connection_group_id`, and every response shape exposed both. That
+overlap is what `@useatlas/types@0.1.0` clears.
+
+The legacy database columns survive one more slice. They're dropped in
+#2347 once self-hosted consumers have rolled forward. The wire format
+moves first so SDK consumers don't conditionally branch on a column
+that's already been removed underneath them.
+
+## Field-by-field changes
+
+The shapes below now expose `connectionGroupId` only — read it directly,
+or fall back to `null` when no group is set (the SDK no longer ships a
+legacy fallback).
+
+### `ScheduledTask`
+
+```ts
+// 0.0.x
+const task: ScheduledTask = {
+  // …
+  connectionGroupId: "g_prod",
+  connectionId: "warehouse-prod-1", // ← removed
+};
+
+// 0.1.0
+const task: ScheduledTask = {
+  // …
+  connectionGroupId: "g_prod",
+};
+```
+
+`POST /api/v1/scheduled-tasks` and `PUT /api/v1/scheduled-tasks/:id` no
+longer accept `connectionId` in the body. Pass `connectionGroupId`
+instead — the scheduler resolves it to a physical connection (the
+group's `primary_connection_id`, or first member by
+`(created_at, id)`) at run time.
+
+### `DashboardCard`
+
+```ts
+// 0.0.x
+const card: DashboardCard = {
+  // …
+  connectionGroupId: "g_prod",
+  connectionId: "warehouse-prod-1", // ← removed
+};
+
+// 0.1.0
+const card: DashboardCard = {
+  // …
+  connectionGroupId: "g_prod",
+};
+```
+
+`POST /api/v1/dashboards/:id/cards` drops the legacy `connectionId`
+field. The dashboard refresh resolver no longer falls back to it; cards
+with `connectionGroupId: null` execute against the workspace default.
+
+`/api/v1/dashboards/preview-card` keeps its `connectionId` body field —
+that's an *execution-target override* for the preview, not a stored
+card property. Same semantics as `Conversation.connectionId`, which is
+also retained.
+
+### `ApprovalRequest` (approval queue)
+
+```ts
+// 0.0.x
+const req: ApprovalRequest = {
+  // …
+  connectionGroupId: "g_prod",
+  connectionId: "warehouse-prod-1", // ← removed
+};
+
+// 0.1.0
+const req: ApprovalRequest = {
+  // …
+  connectionGroupId: "g_prod",
+};
+```
+
+#2344 already routed lookups through `connectionGroupId`; the legacy
+field only survived for admin-UI display copy. The admin queue now
+shows the group as the canonical scope.
+
+### `ExportedSemanticEntity` (migration bundles)
+
+```ts
+// 0.0.x
+const entity: ExportedSemanticEntity = {
+  name: "users",
+  entityType: "entity",
+  yamlContent: "…",
+  connectionGroupId: "g_prod",
+  connectionId: "warehouse-prod-1", // ← removed
+};
+
+// 0.1.0
+const entity: ExportedSemanticEntity = {
+  name: "users",
+  entityType: "entity",
+  yamlContent: "…",
+  connectionGroupId: "g_prod",
+};
+```
+
+Export bundles produced by `atlas export` (CLI) and
+`/api/v1/admin/migrate/export` (API) now exclusively carry
+`connectionGroupId`. Pre-1.4.4 bundles that only have `connectionId`
+need to be re-exported from a 1.4.4+ instance before they can be
+imported into 0.1.0 consumers — the `0066` backfill populates the new
+column from the legacy one during a one-time migration.
+
+### `PIIColumnClassification`
+
+```ts
+// 0.0.x
+const cls: PIIColumnClassification = {
+  // …
+  connectionGroupId: "g_prod",
+  connectionId: "warehouse-prod-1", // ← removed
+};
+
+// 0.1.0
+const cls: PIIColumnClassification = {
+  // …
+  connectionGroupId: "g_prod",
+};
+```
+
+The PII detection write path still accepts a source `connectionId`
+parameter — it's used internally to resolve the connection's group via
+0062's 1:1 mapping, then stored on `connection_group_id`. That's an
+input to `savePIIClassification()`, not a field on the response shape.
+
+## Fields that did NOT change
+
+These keep `connectionId` because the field is the **execution target**
+(which physical connection a query runs against), not a deprecated
+scope identifier:
+
+- `Conversation.connectionId` — the per-conversation execution target,
+  optionally overridden per-turn by the chat header.
+- `ExportedConversation.connectionId` — carried into export bundles so
+  imports preserve the execution target.
+- `PoolMetrics.connectionId` / `ConnectionGroupMember.connectionId` —
+  identity of a single connection.
+- `ProposedCard.connectionId` — agent-side proposal for which
+  connection a card should run against. The matching saved
+  `DashboardCard` now stores a group; agents that want to target a
+  specific connection should emit `connectionGroupId` instead.
+- `validateSQL(sql, connectionId)` — execution-target argument.
+
+## Coordinating the SDK + React bump
+
+`@useatlas/types@0.1.0` ships ahead of `@useatlas/sdk` and
+`@useatlas/react`. Once the types tag publishes to npm, the
+follow-up release coordinates the SDK + react majors so consumers can
+upgrade all three in one step.
+
+If your project pins `@useatlas/sdk@^0.0.x` you keep getting the old
+types until you bump the SDK explicitly. The wire format is
+forward-compatible: a 0.1.0 server's responses still satisfy an
+0.0.x SDK's parsing (it just ignores the missing field).
+
+## Rollback
+
+If you need to revert: pin `@useatlas/types@0.0.29` in your
+`package.json` and reinstall. The 0.1.0 wire shapes don't carry the
+legacy field, so an 0.0.29 SDK reading a 0.1.0 server will see
+`connectionId === undefined` on the affected shapes — code paths that
+read the field will need a `?? null` fallback while pinned.

--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -4901,12 +4901,6 @@
                       "additionalProperties": {}
                     }
                   },
-                  "connectionId": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
                   "connectionGroupId": {
                     "type": [
                       "string",
@@ -13407,12 +13401,6 @@
                       "null"
                     ]
                   },
-                  "connectionId": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
                   "approvalMode": {
                     "type": "string",
                     "enum": [
@@ -14014,12 +14002,6 @@
                     }
                   },
                   "connectionGroupId": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "connectionId": {
                     "type": [
                       "string",
                       "null"
@@ -34469,12 +34451,6 @@
                                   "null"
                                 ]
                               },
-                              "connectionId": {
-                                "type": [
-                                  "string",
-                                  "null"
-                                ]
-                              },
                               "connectionGroupId": {
                                 "type": [
                                   "string",
@@ -34542,7 +34518,6 @@
                               "requesterEmail",
                               "querySql",
                               "explanation",
-                              "connectionId",
                               "connectionGroupId",
                               "tablesAccessed",
                               "columnsAccessed",
@@ -34584,12 +34559,6 @@
                                 "type": "string"
                               },
                               "explanation": {
-                                "type": [
-                                  "string",
-                                  "null"
-                                ]
-                              },
-                              "connectionId": {
                                 "type": [
                                   "string",
                                   "null"
@@ -34668,7 +34637,6 @@
                               "requesterEmail",
                               "querySql",
                               "explanation",
-                              "connectionId",
                               "connectionGroupId",
                               "tablesAccessed",
                               "columnsAccessed",
@@ -34710,12 +34678,6 @@
                                 "type": "string"
                               },
                               "explanation": {
-                                "type": [
-                                  "string",
-                                  "null"
-                                ]
-                              },
-                              "connectionId": {
                                 "type": [
                                   "string",
                                   "null"
@@ -34794,7 +34756,6 @@
                               "requesterEmail",
                               "querySql",
                               "explanation",
-                              "connectionId",
                               "connectionGroupId",
                               "tablesAccessed",
                               "columnsAccessed",
@@ -34836,12 +34797,6 @@
                                 "type": "string"
                               },
                               "explanation": {
-                                "type": [
-                                  "string",
-                                  "null"
-                                ]
-                              },
-                              "connectionId": {
                                 "type": [
                                   "string",
                                   "null"
@@ -34914,7 +34869,6 @@
                               "requesterEmail",
                               "querySql",
                               "explanation",
-                              "connectionId",
                               "connectionGroupId",
                               "tablesAccessed",
                               "columnsAccessed",
@@ -35115,12 +35069,6 @@
                                 "null"
                               ]
                             },
-                            "connectionId": {
-                              "type": [
-                                "string",
-                                "null"
-                              ]
-                            },
                             "connectionGroupId": {
                               "type": [
                                 "string",
@@ -35188,7 +35136,6 @@
                             "requesterEmail",
                             "querySql",
                             "explanation",
-                            "connectionId",
                             "connectionGroupId",
                             "tablesAccessed",
                             "columnsAccessed",
@@ -35230,12 +35177,6 @@
                               "type": "string"
                             },
                             "explanation": {
-                              "type": [
-                                "string",
-                                "null"
-                              ]
-                            },
-                            "connectionId": {
                               "type": [
                                 "string",
                                 "null"
@@ -35314,7 +35255,6 @@
                             "requesterEmail",
                             "querySql",
                             "explanation",
-                            "connectionId",
                             "connectionGroupId",
                             "tablesAccessed",
                             "columnsAccessed",
@@ -35356,12 +35296,6 @@
                               "type": "string"
                             },
                             "explanation": {
-                              "type": [
-                                "string",
-                                "null"
-                              ]
-                            },
-                            "connectionId": {
                               "type": [
                                 "string",
                                 "null"
@@ -35440,7 +35374,6 @@
                             "requesterEmail",
                             "querySql",
                             "explanation",
-                            "connectionId",
                             "connectionGroupId",
                             "tablesAccessed",
                             "columnsAccessed",
@@ -35482,12 +35415,6 @@
                               "type": "string"
                             },
                             "explanation": {
-                              "type": [
-                                "string",
-                                "null"
-                              ]
-                            },
-                            "connectionId": {
                               "type": [
                                 "string",
                                 "null"
@@ -35560,7 +35487,6 @@
                             "requesterEmail",
                             "querySql",
                             "explanation",
-                            "connectionId",
                             "connectionGroupId",
                             "tablesAccessed",
                             "columnsAccessed",
@@ -35762,12 +35688,6 @@
                                 "null"
                               ]
                             },
-                            "connectionId": {
-                              "type": [
-                                "string",
-                                "null"
-                              ]
-                            },
                             "connectionGroupId": {
                               "type": [
                                 "string",
@@ -35835,7 +35755,6 @@
                             "requesterEmail",
                             "querySql",
                             "explanation",
-                            "connectionId",
                             "connectionGroupId",
                             "tablesAccessed",
                             "columnsAccessed",
@@ -35877,12 +35796,6 @@
                               "type": "string"
                             },
                             "explanation": {
-                              "type": [
-                                "string",
-                                "null"
-                              ]
-                            },
-                            "connectionId": {
                               "type": [
                                 "string",
                                 "null"
@@ -35961,7 +35874,6 @@
                             "requesterEmail",
                             "querySql",
                             "explanation",
-                            "connectionId",
                             "connectionGroupId",
                             "tablesAccessed",
                             "columnsAccessed",
@@ -36003,12 +35915,6 @@
                               "type": "string"
                             },
                             "explanation": {
-                              "type": [
-                                "string",
-                                "null"
-                              ]
-                            },
-                            "connectionId": {
                               "type": [
                                 "string",
                                 "null"
@@ -36087,7 +35993,6 @@
                             "requesterEmail",
                             "querySql",
                             "explanation",
-                            "connectionId",
                             "connectionGroupId",
                             "tablesAccessed",
                             "columnsAccessed",
@@ -36129,12 +36034,6 @@
                               "type": "string"
                             },
                             "explanation": {
-                              "type": [
-                                "string",
-                                "null"
-                              ]
-                            },
-                            "connectionId": {
                               "type": [
                                 "string",
                                 "null"
@@ -36207,7 +36106,6 @@
                             "requesterEmail",
                             "querySql",
                             "explanation",
-                            "connectionId",
                             "connectionGroupId",
                             "tablesAccessed",
                             "columnsAccessed",
@@ -36398,16 +36296,6 @@
             "description": "Filter by connection group (environment) ID",
             "name": "connectionGroupId",
             "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "description": "Legacy: filter by connection ID — resolved to the connection's group via 0062's 1:1 mapping. Prefer `connectionGroupId` for new callers."
-            },
-            "required": false,
-            "description": "Legacy: filter by connection ID — resolved to the connection's group via 0062's 1:1 mapping. Prefer `connectionGroupId` for new callers.",
-            "name": "connectionId",
-            "in": "query"
           }
         ],
         "responses": {
@@ -36434,12 +36322,6 @@
                           },
                           "columnName": {
                             "type": "string"
-                          },
-                          "connectionId": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
                           },
                           "connectionGroupId": {
                             "type": [
@@ -36500,7 +36382,7 @@
                           "orgId",
                           "tableName",
                           "columnName",
-                          "connectionId",
+                          "connectionGroupId",
                           "category",
                           "confidence",
                           "maskingStrategy",
@@ -36700,12 +36582,6 @@
                         "columnName": {
                           "type": "string"
                         },
-                        "connectionId": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
                         "connectionGroupId": {
                           "type": [
                             "string",
@@ -36765,7 +36641,7 @@
                         "orgId",
                         "tableName",
                         "columnName",
-                        "connectionId",
+                        "connectionGroupId",
                         "category",
                         "confidence",
                         "maskingStrategy",
@@ -50977,12 +50853,6 @@
                           "label": {
                             "type": "string"
                           },
-                          "connectionId": {
-                            "type": [
-                              "string",
-                              "null"
-                            ]
-                          },
                           "connectionGroupId": {
                             "type": [
                               "string",
@@ -50997,7 +50867,6 @@
                         "required": [
                           "id",
                           "label",
-                          "connectionId",
                           "connectionGroupId",
                           "updatedAt"
                         ]

--- a/bun.lock
+++ b/bun.lock
@@ -342,7 +342,7 @@
     },
     "packages/types": {
       "name": "@useatlas/types",
-      "version": "0.0.29",
+      "version": "0.1.0",
     },
     "packages/web": {
       "name": "@atlas/web",

--- a/ee/src/compliance/masking.test.ts
+++ b/ee/src/compliance/masking.test.ts
@@ -555,7 +555,6 @@ describe("savePIIClassification", () => {
       org_id: "org-1",
       table_name: "users",
       column_name: "email",
-      connection_id: null,
       connection_group_id: null,
       category: "email",
       confidence: "high",
@@ -568,7 +567,6 @@ describe("savePIIClassification", () => {
     const result = await run(savePIIClassification(
       "org-1", "users", "email", null, "email", "high", "partial",
     ));
-    expect(result.connectionId).toBeNull();
     expect(result.connectionGroupId).toBeNull();
   });
 });

--- a/ee/src/compliance/masking.ts
+++ b/ee/src/compliance/masking.ts
@@ -115,9 +115,6 @@ interface PIIClassificationRow {
   org_id: string;
   table_name: string;
   column_name: string;
-  /** Legacy connection scope. Nullable post-0064. Dual-written by the
-   *  save path during the transitional slice; final removal in #2346. */
-  connection_id: string | null;
   /** Group scope (#2341). One row per (org, table, column, group). */
   connection_group_id: string | null;
   category: string;
@@ -136,7 +133,6 @@ function rowToClassification(row: PIIClassificationRow): PIIColumnClassification
     orgId: row.org_id,
     tableName: row.table_name,
     columnName: row.column_name,
-    connectionId: row.connection_id,
     connectionGroupId: row.connection_group_id,
     category: row.category as PIICategory,
     confidence: row.confidence as PIIConfidence,
@@ -150,20 +146,11 @@ function rowToClassification(row: PIIClassificationRow): PIIColumnClassification
 
 /**
  * Resolve the `connection_group_id` for a given connection via 0062's
- * 1:1 backfill. Returns `null` for unknown connections and for the
- * legacy NULL-scope (caller passed `undefined` / `null`).
- *
- * Mirrors `resolveGroupIdForConnection` in `semantic/entities.ts` so
- * write paths can dual-set `connection_id` + `connection_group_id`
- * atomically. The lookup tolerates connections living at
- * `org_id = '__global__'` (demo / built-in connections moved by 0060)
- * so demo writes resolve to the demo group.
+ * 1:1 backfill. Used by `savePIIClassification` to map the auto-
+ * detection caller's source connection to its group. Tolerates
+ * connections living at `org_id = '__global__'` (demo / built-in
+ * connections moved by 0060) so demo writes resolve to the demo group.
  */
-export const resolveConnectionGroupForFilter = (
-  orgId: string,
-  connectionId: string | null | undefined,
-): Effect.Effect<string | null> => resolveGroupIdForConnection(orgId, connectionId);
-
 const resolveGroupIdForConnection = (
   orgId: string,
   connectionId: string | null | undefined,
@@ -266,19 +253,19 @@ export const savePIIClassification = (
     validateCategory(category);
     validateStrategy(maskingStrategy);
 
-    // Dual-write: legacy `connection_id` stays populated for transitional
-    // SDK compatibility (#2336 §"Migration sequencing"). The natural key
-    // is `connection_group_id` — ON CONFLICT targets the group-keyed
-    // partial index from 0064.
+    // The auto-detection caller passes the source `connectionId` so we
+    // can resolve its group via 0062's 1:1 mapping; the row itself is
+    // keyed on `connection_group_id` (the legacy column is no-op writes
+    // until #2347 drops it).
     const groupId = yield* resolveGroupIdForConnection(orgId, connectionId);
 
     const rows = yield* Effect.promise(() => internalQuery<PIIClassificationRow>(
-      `INSERT INTO ${TABLE_NAME} (org_id, table_name, column_name, connection_id, connection_group_id, category, confidence, masking_strategy)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+      `INSERT INTO ${TABLE_NAME} (org_id, table_name, column_name, connection_group_id, category, confidence, masking_strategy)
+       VALUES ($1, $2, $3, $4, $5, $6, $7)
        ON CONFLICT (org_id, table_name, column_name, ${coalescedScopeColumn({ column: "connection_group_id" })})
-       DO UPDATE SET category = $6, confidence = $7, masking_strategy = $8, updated_at = now(), dismissed = false
+       DO UPDATE SET category = $5, confidence = $6, masking_strategy = $7, updated_at = now(), dismissed = false
        RETURNING *`,
-      [orgId, tableName, columnName, connectionId ?? null, groupId, category, confidence, maskingStrategy],
+      [orgId, tableName, columnName, groupId, category, confidence, maskingStrategy],
     ));
     return rowToClassification(rows[0]);
   });

--- a/packages/api/src/api/__tests__/admin-migrate.test.ts
+++ b/packages/api/src/api/__tests__/admin-migrate.test.ts
@@ -44,7 +44,7 @@ function validBundle(overrides?: Partial<ExportBundle>): ExportBundle {
       },
     ],
     semanticEntities: [
-      { name: "users", entityType: "entity", yamlContent: "table: users\n", connectionId: null },
+      { name: "users", entityType: "entity", yamlContent: "table: users\n", connectionGroupId: null },
     ],
     learnedPatterns: [
       { patternSql: "SELECT COUNT(*) FROM users", description: "User count", sourceEntity: "users", confidence: 0.9, status: "approved" },

--- a/packages/api/src/api/__tests__/scheduled-tasks.test.ts
+++ b/packages/api/src/api/__tests__/scheduled-tasks.test.ts
@@ -313,7 +313,7 @@ describe("scheduled-tasks routes", () => {
       }));
     });
 
-    it("omits connectionGroupId for legacy connectionId-only creates", async () => {
+    it("silently drops legacy connectionId from the create body (#2346)", async () => {
       const response = await app.fetch(
         new Request("http://localhost/api/v1/scheduled-tasks", {
           method: "POST",
@@ -330,8 +330,8 @@ describe("scheduled-tasks routes", () => {
       );
       expect(response.status).toBe(201);
       const opts = mockCreateScheduledTask.mock.calls[0][0] as { connectionGroupId?: string | null; connectionId?: string | null };
-      expect(opts.connectionId).toBe("legacy-connection");
-      expect("connectionGroupId" in opts).toBe(false);
+      expect("connectionId" in opts).toBe(false);
+      expect(opts.connectionGroupId).toBeNull();
     });
 
     it("returns 422 for missing name", async () => {

--- a/packages/api/src/api/routes/admin-compliance.ts
+++ b/packages/api/src/api/routes/admin-compliance.ts
@@ -24,7 +24,6 @@ import {
   updatePIIClassification,
   deletePIIClassification,
   invalidateClassificationCache,
-  resolveConnectionGroupForFilter,
   ComplianceError,
 } from "@atlas/ee/compliance/masking";
 import {
@@ -81,7 +80,6 @@ const listRoute = createRoute({
   request: {
     query: z.object({
       connectionGroupId: z.string().optional().openapi({ description: "Filter by connection group (environment) ID" }),
-      connectionId: z.string().optional().openapi({ description: "Legacy: filter by connection ID — resolved to the connection's group via 0062's 1:1 mapping. Prefer `connectionGroupId` for new callers." }),
     }),
   },
   responses: {
@@ -137,17 +135,9 @@ adminCompliance.use(requireOrgContext());
 adminCompliance.openapi(listRoute, async (c) => {
   return runEffect(c, Effect.gen(function* () {
     const { orgId } = yield* AuthContext;
-    const { connectionGroupId, connectionId } = c.req.valid("query");
+    const { connectionGroupId } = c.req.valid("query");
 
-    // Prefer explicit group filter. Legacy `connectionId` is resolved to
-    // the connection's group via 0062's 1:1 mapping (the row is keyed on
-    // the group post-0064, so filtering by connection_id would never
-    // match the new shape). Omitting both returns all classifications
-    // for the org.
-    const groupFilter = connectionGroupId
-      ?? (connectionId ? yield* resolveConnectionGroupForFilter(orgId!, connectionId) : undefined);
-
-    const classifications = yield* listPIIClassifications(orgId!, groupFilter ?? undefined);
+    const classifications = yield* listPIIClassifications(orgId!, connectionGroupId ?? undefined);
     return c.json({ classifications }, 200);
   }), { label: "list PII classifications", domainErrors: [complianceDomainError, reportDomainError] });
 });

--- a/packages/api/src/api/routes/admin-migrate.ts
+++ b/packages/api/src/api/routes/admin-migrate.ts
@@ -226,9 +226,9 @@ export async function importBundle(
     }
 
     await client.query(
-      `INSERT INTO semantic_entities (org_id, entity_type, name, yaml_content, connection_id)
+      `INSERT INTO semantic_entities (org_id, entity_type, name, yaml_content, connection_group_id)
        VALUES ($1, $2, $3, $4, $5)`,
-      [orgId, entity.entityType, entity.name, entity.yamlContent, entity.connectionId],
+      [orgId, entity.entityType, entity.name, entity.yamlContent, entity.connectionGroupId],
     );
     result.semanticEntities.imported++;
   }

--- a/packages/api/src/api/routes/admin-publish-preview.ts
+++ b/packages/api/src/api/routes/admin-publish-preview.ts
@@ -49,12 +49,6 @@ const EntityEditRowSchema = z.object({
   /** Entity name; the published row sharing the same `connection_group_id` will be replaced. */
   label: z.string(),
   /**
-   * Legacy connection scope. Retained for SDK compatibility during the
-   * dual-write transition (#2336). `null` matches NULL-scope entities.
-   * Removed when `connection_id` drops in a follow-on slice.
-   */
-  connectionId: z.string().nullable(),
-  /**
    * Group scope (#2340) — the environment the entity belongs to. `null`
    * for legacy `__global__` rows whose backfill did not resolve a group.
    */
@@ -246,7 +240,6 @@ adminPublishPreview.openapi(previewRoute, async (c) =>
       entityEdits: entityEditRows.map((r) => ({
         id: r.id,
         label: r.label,
-        connectionId: r.connection_id ?? null,
         connectionGroupId: r.connection_group_id ?? null,
         updatedAt: toIso(r.updated_at),
       })),

--- a/packages/api/src/api/routes/dashboards.ts
+++ b/packages/api/src/api/routes/dashboards.ts
@@ -78,8 +78,6 @@ const AddCardSchema = z.object({
   chartConfig: ChartConfigSchema.nullable().optional(),
   cachedColumns: z.array(z.string()).nullable().optional(),
   cachedRows: z.array(z.record(z.string(), z.unknown())).nullable().optional(),
-  /** @deprecated 1.4.4 — pass `connectionGroupId` instead. */
-  connectionId: z.string().nullable().optional(),
   /** Group-scoped execution target (1.4.4). Resolved to a physical
    * connection at view time via the group's primary member. */
   connectionGroupId: z.string().nullable().optional(),
@@ -774,7 +772,6 @@ authed.openapi(
         chartConfig: parsed.chartConfig ?? null,
         cachedColumns: parsed.cachedColumns ?? null,
         cachedRows: parsed.cachedRows ?? null,
-        connectionId: parsed.connectionId ?? null,
         connectionGroupId: parsed.connectionGroupId ?? null,
         layout: parsed.layout ?? null,
       }));
@@ -920,10 +917,7 @@ authed.openapi(refreshCardRoute, async (c) => {
     try {
       resolvedConnectionId = yield* Effect.promise(() =>
         resolveCardConnectionId(
-          {
-            connectionGroupId: cardResult.data.connectionGroupId,
-            connectionId: cardResult.data.connectionId,
-          },
+          { connectionGroupId: cardResult.data.connectionGroupId },
           dash.data.orgId,
         ),
       );
@@ -1007,7 +1001,7 @@ authed.openapi(refreshAllCardsRoute, async (c) => {
       try {
         resolvedConnectionId = yield* Effect.promise(() =>
           resolveCardConnectionId(
-            { connectionGroupId: card.connectionGroupId, connectionId: card.connectionId },
+            { connectionGroupId: card.connectionGroupId },
             dashResult.data.orgId,
           ),
         );

--- a/packages/api/src/api/routes/scheduled-tasks.ts
+++ b/packages/api/src/api/routes/scheduled-tasks.ts
@@ -54,7 +54,6 @@ const CreateScheduledTaskSchema = z.object({
   deliveryChannel: z.enum(DELIVERY_CHANNELS).default("webhook"),
   recipients: z.array(RecipientSchema).default([]),
   connectionGroupId: z.string().nullable().optional(),
-  connectionId: z.string().nullable().optional(),
   approvalMode: z.enum(ACTION_APPROVAL_MODES).default("auto"),
 });
 
@@ -65,7 +64,6 @@ const UpdateScheduledTaskSchema = z.object({
   deliveryChannel: z.enum(DELIVERY_CHANNELS).optional(),
   recipients: z.array(RecipientSchema).optional(),
   connectionGroupId: z.string().nullable().optional(),
-  connectionId: z.string().nullable().optional(),
   approvalMode: z.enum(ACTION_APPROVAL_MODES).optional(),
   enabled: z.boolean().optional(),
 });
@@ -283,9 +281,8 @@ authed.openapi(
         cronExpression: parsed.cronExpression,
         deliveryChannel: parsed.deliveryChannel,
         recipients: parsed.recipients,
-        connectionId: parsed.connectionId ?? null,
+        connectionGroupId: parsed.connectionGroupId ?? null,
         approvalMode: parsed.approvalMode,
-        ...("connectionGroupId" in parsed ? { connectionGroupId: parsed.connectionGroupId ?? null } : {}),
       };
       const createResult = yield* Effect.promise(() => createScheduledTask(createOpts));
 

--- a/packages/api/src/lib/__tests__/dashboards-refresh-org-pool.test.ts
+++ b/packages/api/src/lib/__tests__/dashboards-refresh-org-pool.test.ts
@@ -67,7 +67,7 @@ function dashboardRow(orgId: string | null): Record<string, unknown> {
   };
 }
 
-function cardRow(connectionId: string | null): Record<string, unknown> {
+function cardRow(connectionGroupId: string | null): Record<string, unknown> {
   return {
     id: "card-1",
     dashboard_id: "dash-1",
@@ -78,12 +78,24 @@ function cardRow(connectionId: string | null): Record<string, unknown> {
     cached_columns: null,
     cached_rows: null,
     cached_at: null,
-    connection_id: connectionId,
-    connection_group_id: null,
+    connection_group_id: connectionGroupId,
     layout: null,
     created_at: "2026-05-13T00:00:00.000Z",
     updated_at: "2026-05-13T00:00:00.000Z",
   };
+}
+
+/** Two rows the group snapshot loader expects: a primary lookup, then a member list. */
+function groupSnapshotRows(primaryConnectionId: string, memberIds: string[]): Array<{ rows: Record<string, unknown>[] }> {
+  return [
+    { rows: [{ primary_connection_id: primaryConnectionId }] },
+    {
+      rows: memberIds.map((id, idx) => ({
+        id,
+        created_at: `2026-05-13T00:00:0${idx}.000Z`,
+      })),
+    },
+  ];
 }
 
 function setResults(...results: Array<{ rows: Record<string, unknown>[] }>) {
@@ -114,10 +126,11 @@ describe("refreshDashboardCards org-scoped pool selection", () => {
     _resetPool(null);
   });
 
-  it("uses the dashboard org when opening a scheduled refresh pool", async () => {
+  it("resolves the group's primary member when opening a scheduled refresh pool", async () => {
     setResults(
       { rows: [dashboardRow("org-1")] },
-      { rows: [cardRow("warehouse")] },
+      { rows: [cardRow("g-warehouse")] },
+      ...groupSnapshotRows("warehouse", ["warehouse"]),
       { rows: [{ id: "card-1" }] },
       { rows: [] },
     );
@@ -132,7 +145,7 @@ describe("refreshDashboardCards org-scoped pool selection", () => {
     expect(mockOrgQuery).toHaveBeenCalledWith("SELECT 1 AS total", 30000);
   });
 
-  it("uses the org default pool for org-scoped cards without a connection id", async () => {
+  it("uses the org default pool for org-scoped cards without a connection group", async () => {
     setResults(
       { rows: [dashboardRow("org-1")] },
       { rows: [cardRow(null)] },

--- a/packages/api/src/lib/__tests__/scheduled-task-types.test.ts
+++ b/packages/api/src/lib/__tests__/scheduled-task-types.test.ts
@@ -92,7 +92,6 @@ describe("scheduled-task-types", () => {
         deliveryChannel: "email",
         recipients: [],
         connectionGroupId: null,
-        connectionId: null,
         approvalMode: "auto",
         enabled: true,
         lastRunAt: null,

--- a/packages/api/src/lib/dashboards.ts
+++ b/packages/api/src/lib/dashboards.ts
@@ -131,7 +131,6 @@ export function rowToCard(r: Record<string, unknown>): DashboardCard {
     cachedColumns,
     cachedRows,
     cachedAt: r.cached_at ? String(r.cached_at) : null,
-    connectionId: (r.connection_id as string) ?? null,
     connectionGroupId: (r.connection_group_id as string) ?? null,
     layout,
     createdAt: String(r.created_at),
@@ -211,9 +210,14 @@ export async function loadGroupSnapshot(
 }
 
 /**
- * Resolve the physical connection id a card executes against, honouring
- * the precedence: `connection_group_id` (preferred) → legacy
- * `connection_id` → workspace default (`null`).
+ * Resolve the physical connection id a card executes against.
+ *
+ * Cards with `connectionGroupId` resolve to the group's primary member
+ * (or first-by-(created_at, id) when no primary is set). Cards without
+ * a group fall through to the workspace default (`null`). The 0066
+ * backfill populated `connection_group_id` from the legacy `connection_id`
+ * via 0062's 1:1 mapping, so post-1.4.4 cards always carry a group when
+ * they had a legacy connection.
  *
  * Throws `NoGroupMembersError` when the card resolves to a group with
  * zero members — the route layer must catch and return a 500 with
@@ -221,21 +225,17 @@ export async function loadGroupSnapshot(
  * connection (CLAUDE.md "Prefer errors over silent fallbacks").
  */
 export async function resolveCardConnectionId(
-  card: { connectionGroupId: string | null; connectionId: string | null },
+  card: { connectionGroupId: string | null },
   orgId: string | null,
 ): Promise<string | null> {
   if (card.connectionGroupId) {
     const snap = await loadGroupSnapshot(card.connectionGroupId, orgId);
     if (!snap) {
-      // Group row vanished while the card still points at it — treat as
-      // empty membership so callers surface a typed 500. Silently
-      // demoting to the workspace default would render against the
-      // wrong connection.
       throw new NoGroupMembersError(card.connectionGroupId, orgId);
     }
     return selectGroupMember(snap);
   }
-  return card.connectionId;
+  return null;
 }
 
 // ---------------------------------------------------------------------------
@@ -422,8 +422,6 @@ export async function addCard(opts: {
   chartConfig?: DashboardChartConfig | null;
   cachedColumns?: string[] | null;
   cachedRows?: Record<string, unknown>[] | null;
-  /** @deprecated 1.4.4 — pass `connectionGroupId` instead. */
-  connectionId?: string | null;
   /** Group-scoped execution target (1.4.4). */
   connectionGroupId?: string | null;
   layout?: DashboardCardLayout | null;
@@ -438,8 +436,8 @@ export async function addCard(opts: {
     const nextPos = (posRows[0]?.next_pos as number) ?? 0;
 
     const rows = await internalQuery<Record<string, unknown>>(
-      `INSERT INTO dashboard_cards (dashboard_id, position, title, sql, chart_config, cached_columns, cached_rows, cached_at, connection_id, connection_group_id, layout)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+      `INSERT INTO dashboard_cards (dashboard_id, position, title, sql, chart_config, cached_columns, cached_rows, cached_at, connection_group_id, layout)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
        RETURNING *`,
       [
         opts.dashboardId,
@@ -450,7 +448,6 @@ export async function addCard(opts: {
         opts.cachedColumns ? JSON.stringify(opts.cachedColumns) : null,
         opts.cachedRows ? JSON.stringify(opts.cachedRows) : null,
         opts.cachedRows ? new Date().toISOString() : null,
-        opts.connectionId ?? null,
         opts.connectionGroupId ?? null,
         opts.layout ? JSON.stringify(opts.layout) : null,
       ],
@@ -866,7 +863,7 @@ export async function refreshDashboardCards(dashboardId: string): Promise<{
       // skip + warn here (scheduler tick is best-effort across cards);
       // the interactive routes surface it as a 500 + requestId.
       const resolvedConnectionId = await resolveCardConnectionId(
-        { connectionGroupId: card.connectionGroupId, connectionId: card.connectionId },
+        { connectionGroupId: card.connectionGroupId },
         dashboardOrgId,
       );
       const validation = await validateSQL(card.sql, resolvedConnectionId ?? undefined);

--- a/packages/api/src/lib/residency/__tests__/export.test.ts
+++ b/packages/api/src/lib/residency/__tests__/export.test.ts
@@ -135,8 +135,8 @@ describe("exportWorkspaceBundle", () => {
   it("exports semantic entities", async () => {
     mockPoolQueryResults["FROM semantic_entities"] = {
       rows: [
-        { name: "users", entity_type: "entity", yaml_content: "table: users\n", connection_id: null },
-        { name: "orders", entity_type: "entity", yaml_content: "table: orders\n", connection_id: "conn-1" },
+        { name: "users", entity_type: "entity", yaml_content: "table: users\n", connection_group_id: null },
+        { name: "orders", entity_type: "entity", yaml_content: "table: orders\n", connection_group_id: "g-prod" },
       ],
     };
 
@@ -144,7 +144,7 @@ describe("exportWorkspaceBundle", () => {
 
     expect(bundle.semanticEntities).toHaveLength(2);
     expect(bundle.semanticEntities[0].name).toBe("users");
-    expect(bundle.semanticEntities[1].connectionId).toBe("conn-1");
+    expect(bundle.semanticEntities[1].connectionGroupId).toBe("g-prod");
     expect(bundle.manifest.counts.semanticEntities).toBe(2);
   });
 

--- a/packages/api/src/lib/residency/export.ts
+++ b/packages/api/src/lib/residency/export.ts
@@ -97,12 +97,11 @@ export async function exportWorkspaceBundle(
   }
 
   // --- 2. Semantic entities ---
-  // Both `connection_id` and `connection_group_id` are exported during
-  // the dual-write window (#2340). Bundles produced pre-1.4.4 omit the
-  // group field; consumers fall back to `connectionId` (additive wire
-  // shape — see `ExportedSemanticEntity` in `@useatlas/types`).
+  // Group-scoped wire shape (#2340 → #2346). The legacy `connection_id`
+  // column survives until #2347 drops it; bundles exclusively carry the
+  // group identifier now.
   const entityResult = await pool.query(
-    `SELECT name, entity_type, yaml_content, connection_id, connection_group_id
+    `SELECT name, entity_type, yaml_content, connection_group_id
      FROM semantic_entities WHERE org_id = $1
      ORDER BY entity_type, name`,
     [orgId],
@@ -112,7 +111,6 @@ export async function exportWorkspaceBundle(
     name: e.name as string,
     entityType: e.entity_type as string,
     yamlContent: e.yaml_content as string,
-    connectionId: (e.connection_id as string | null) ?? null,
     connectionGroupId: (e.connection_group_id as string | null) ?? null,
   }));
 

--- a/packages/api/src/lib/scheduled-tasks.ts
+++ b/packages/api/src/lib/scheduled-tasks.ts
@@ -77,7 +77,6 @@ function rowToScheduledTask(r: Record<string, unknown>): ScheduledTask {
     deliveryChannel: (r.delivery_channel as DeliveryChannel) ?? "webhook",
     recipients,
     connectionGroupId: (r.connection_group_id as string) ?? null,
-    connectionId: (r.connection_id as string) ?? null,
     approvalMode: (r.approval_mode as ActionApprovalMode) ?? "auto",
     enabled: r.enabled === true,
     lastRunAt: r.last_run_at ? String(r.last_run_at) : null,
@@ -161,23 +160,6 @@ function orgScopeClause(
   return { clause: `${col} IS NULL`, nextIdx: paramIdx };
 }
 
-async function resolveGroupIdForConnection(
-  orgId: string | null | undefined,
-  connectionId: string | null | undefined,
-): Promise<string | null> {
-  if (!connectionId) return null;
-  const rows = await internalQuery<{ group_id: string | null }>(
-    `SELECT group_id
-       FROM connections
-      WHERE id = $1
-        AND (org_id = $2 OR org_id = '__global__')
-      ORDER BY CASE WHEN org_id = $2 THEN 0 ELSE 1 END
-      LIMIT 1`,
-    [connectionId, orgId ?? "__global__"],
-  );
-  return rows[0]?.group_id ?? null;
-}
-
 // ---------------------------------------------------------------------------
 // CRUD — Tasks
 // ---------------------------------------------------------------------------
@@ -191,7 +173,6 @@ export async function createScheduledTask(opts: {
   deliveryChannel?: DeliveryChannel;
   recipients?: Recipient[];
   connectionGroupId?: string | null;
-  connectionId?: string | null;
   approvalMode?: ActionApprovalMode;
 }): Promise<CrudDataResult<ScheduledTask>> {
   if (!hasInternalDB()) return { ok: false, reason: "no_db" };
@@ -205,12 +186,9 @@ export async function createScheduledTask(opts: {
   const nextRun = computeNextRun(opts.cronExpression);
 
   try {
-    const connectionGroupId = opts.connectionGroupId !== undefined
-      ? opts.connectionGroupId
-      : await resolveGroupIdForConnection(opts.orgId, opts.connectionId);
     const rows = await internalQuery<Record<string, unknown>>(
-      `INSERT INTO scheduled_tasks (owner_id, org_id, name, question, cron_expression, delivery_channel, recipients, connection_group_id, connection_id, approval_mode, next_run_at)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+      `INSERT INTO scheduled_tasks (owner_id, org_id, name, question, cron_expression, delivery_channel, recipients, connection_group_id, approval_mode, next_run_at)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
        RETURNING *`,
       [
         opts.ownerId,
@@ -220,8 +198,7 @@ export async function createScheduledTask(opts: {
         opts.cronExpression,
         opts.deliveryChannel ?? "webhook",
         JSON.stringify(opts.recipients ?? []),
-        connectionGroupId ?? null,
-        opts.connectionId ?? null,
+        opts.connectionGroupId ?? null,
         opts.approvalMode ?? "auto",
         nextRun?.toISOString() ?? null,
       ],
@@ -339,7 +316,6 @@ export async function updateScheduledTask(
     deliveryChannel?: DeliveryChannel;
     recipients?: Recipient[];
     connectionGroupId?: string | null;
-    connectionId?: string | null;
     approvalMode?: ActionApprovalMode;
     enabled?: boolean;
   },
@@ -381,13 +357,6 @@ export async function updateScheduledTask(
   if (updates.connectionGroupId !== undefined) {
     setClauses.push(`connection_group_id = $${paramIdx++}`);
     params.push(updates.connectionGroupId);
-  } else if (updates.connectionId !== undefined) {
-    setClauses.push(`connection_group_id = $${paramIdx++}`);
-    params.push(await resolveGroupIdForConnection(scope.orgId, updates.connectionId));
-  }
-  if (updates.connectionId !== undefined) {
-    setClauses.push(`connection_id = $${paramIdx++}`);
-    params.push(updates.connectionId);
   }
   if (updates.approvalMode !== undefined) {
     setClauses.push(`approval_mode = $${paramIdx++}`);

--- a/packages/api/src/lib/scheduler/__tests__/delivery.test.ts
+++ b/packages/api/src/lib/scheduler/__tests__/delivery.test.ts
@@ -61,7 +61,6 @@ function makeTask(overrides: Partial<ScheduledTask> = {}): ScheduledTask {
     deliveryChannel: "webhook",
     recipients: [],
     connectionGroupId: null,
-    connectionId: null,
     approvalMode: "auto",
     enabled: true,
     lastRunAt: null,

--- a/packages/api/src/lib/scheduler/__tests__/executor.test.ts
+++ b/packages/api/src/lib/scheduler/__tests__/executor.test.ts
@@ -224,7 +224,6 @@ describe("executor", () => {
       taskId: "task-1",
       orgId: "org-1",
       connectionGroupId: "group-1",
-      legacyConnectionId: "legacy-connection",
     });
     const opts = mockExecuteAgentQuery.mock.calls[0][2];
     expect(opts?.connectionId).toBe("resolved-connection");

--- a/packages/api/src/lib/scheduler/__tests__/format-email.test.ts
+++ b/packages/api/src/lib/scheduler/__tests__/format-email.test.ts
@@ -17,7 +17,6 @@ function makeTask(overrides: Partial<ScheduledTask> = {}): ScheduledTask {
     deliveryChannel: "email",
     recipients: [],
     connectionGroupId: null,
-    connectionId: null,
     approvalMode: "auto",
     enabled: true,
     lastRunAt: null,

--- a/packages/api/src/lib/scheduler/__tests__/format-slack.test.ts
+++ b/packages/api/src/lib/scheduler/__tests__/format-slack.test.ts
@@ -17,7 +17,6 @@ function makeTask(overrides: Partial<ScheduledTask> = {}): ScheduledTask {
     deliveryChannel: "slack",
     recipients: [],
     connectionGroupId: null,
-    connectionId: null,
     approvalMode: "auto",
     enabled: true,
     lastRunAt: null,

--- a/packages/api/src/lib/scheduler/__tests__/format-webhook.test.ts
+++ b/packages/api/src/lib/scheduler/__tests__/format-webhook.test.ts
@@ -17,7 +17,6 @@ function makeTask(overrides: Partial<ScheduledTask> = {}): ScheduledTask {
     deliveryChannel: "webhook",
     recipients: [],
     connectionGroupId: null,
-    connectionId: null,
     approvalMode: "auto",
     enabled: true,
     lastRunAt: null,

--- a/packages/api/src/lib/scheduler/__tests__/preview.test.ts
+++ b/packages/api/src/lib/scheduler/__tests__/preview.test.ts
@@ -16,7 +16,6 @@ function makeTask(overrides: Partial<ScheduledTask> = {}): ScheduledTask {
     deliveryChannel: "email",
     recipients: [],
     connectionGroupId: null,
-    connectionId: null,
     approvalMode: "auto",
     enabled: true,
     lastRunAt: null,

--- a/packages/api/src/lib/scheduler/executor.ts
+++ b/packages/api/src/lib/scheduler/executor.ts
@@ -110,7 +110,6 @@ export async function executeScheduledTask(
     taskId,
     orgId: task.orgId,
     connectionGroupId: task.connectionGroupId,
-    legacyConnectionId: task.connectionId,
   });
 
   // F-54: resolve the task creator so approval rules apply. If the user no

--- a/packages/api/src/lib/scheduler/group-resolve.ts
+++ b/packages/api/src/lib/scheduler/group-resolve.ts
@@ -124,9 +124,8 @@ export async function resolveScheduledTaskConnection(opts: {
   readonly taskId: string;
   readonly orgId: string | null;
   readonly connectionGroupId: string | null;
-  readonly legacyConnectionId: string | null;
 }): Promise<string | null> {
-  if (!opts.connectionGroupId) return opts.legacyConnectionId;
+  if (!opts.connectionGroupId) return null;
 
   const snapshot = await loadScheduledTaskGroupSnapshot(opts.connectionGroupId, opts.orgId);
   if (!snapshot) {

--- a/packages/cli/src/commands/export.ts
+++ b/packages/cli/src/commands/export.ts
@@ -84,7 +84,7 @@ export async function handleExport(args: string[]): Promise<void> {
 
     // 2. Semantic entities (DB-backed)
     const entRows = await pool.query(
-      `SELECT name, entity_type, yaml_content, connection_id
+      `SELECT name, entity_type, yaml_content, connection_group_id
        FROM semantic_entities
        WHERE ${orgClause}
        ORDER BY entity_type, name`,
@@ -95,7 +95,7 @@ export async function handleExport(args: string[]): Promise<void> {
         name: r.name as string,
         entityType: r.entity_type as string,
         yamlContent: r.yaml_content as string,
-        connectionId: (r.connection_id as string) ?? null,
+        connectionGroupId: (r.connection_group_id as string) ?? null,
       }),
     );
     console.log(`  Entities:      ${semanticEntities.length}`);

--- a/packages/schemas/src/__tests__/admin-config.test.ts
+++ b/packages/schemas/src/__tests__/admin-config.test.ts
@@ -45,7 +45,7 @@ const validPII = {
   orgId: "org_1",
   tableName: "users",
   columnName: "email",
-  connectionId: "conn_1",
+  connectionGroupId: "g_prod",
   category: "email" as const,
   confidence: "high" as const,
   maskingStrategy: "partial" as const,
@@ -230,20 +230,12 @@ describe("PIIColumnClassificationSchema", () => {
     }
   });
 
-  test("connectionId accepts null (post-0064 nullable)", () => {
-    // Migration 0064 dropped the legacy `NOT NULL DEFAULT 'default'`.
-    // Bundles emitted post-#2341 may carry `connectionId: null` for
-    // rows whose source connection was deleted.
-    const nullScoped = { ...validPII, connectionId: null };
+  test("connectionGroupId accepts null (un-scoped / cross-env rows)", () => {
+    // Rows whose originating connection was deleted (and so no longer
+    // resolve to a live group) carry `connectionGroupId: null`. The
+    // legacy `connectionId` was dropped from the wire shape in #2346.
+    const nullScoped = { ...validPII, connectionGroupId: null };
     expect(PIIColumnClassificationSchema.parse(nullScoped)).toEqual(nullScoped);
-  });
-
-  test("connectionGroupId is additive — optional with null allowed", () => {
-    // #2341 added the field. Legacy bundles omit it; new bundles populate
-    // either a group id or null (for un-scoped / cross-env rows).
-    expect(() => PIIColumnClassificationSchema.parse(validPII)).not.toThrow();
-    expect(() => PIIColumnClassificationSchema.parse({ ...validPII, connectionGroupId: "g_prod" })).not.toThrow();
-    expect(() => PIIColumnClassificationSchema.parse({ ...validPII, connectionGroupId: null })).not.toThrow();
   });
 });
 

--- a/packages/schemas/src/__tests__/approval.test.ts
+++ b/packages/schemas/src/__tests__/approval.test.ts
@@ -43,7 +43,6 @@ const pendingRequest = {
   requesterEmail: "alice@example.com",
   querySql: "SELECT * FROM users",
   explanation: "Quarterly audit",
-  connectionId: "conn_1",
   // #2344 — group scope. Asserts the additive field parses on the
   // happy path; null is the legacy / unstamped shape.
   connectionGroupId: "g_prod",

--- a/packages/schemas/src/admin-config.ts
+++ b/packages/schemas/src/admin-config.ts
@@ -145,13 +145,9 @@ export const PIIColumnClassificationSchema = z.object({
   orgId: z.string(),
   tableName: z.string(),
   columnName: z.string(),
-  // Legacy connection scope. Nullable post-0064 (the migration dropped
-  // the `NOT NULL DEFAULT 'default'`). Prefer `connectionGroupId` for
-  // new callers. See PRD #2336 §"Migration sequencing".
-  connectionId: z.string().nullable(),
-  // Group scope (#2341). Optional during the wire-format transition —
-  // bundles exported by pre-1.4.4 instances omit the field.
-  connectionGroupId: z.string().nullable().optional(),
+  // Group scope (#2341). Nullable for legacy rows whose originating
+  // connection no longer resolves to a live group.
+  connectionGroupId: z.string().nullable(),
   category: z.enum(PII_CATEGORIES),
   confidence: z.enum(PII_CONFIDENCE_LEVELS),
   maskingStrategy: z.enum(MASKING_STRATEGIES),

--- a/packages/schemas/src/approval.ts
+++ b/packages/schemas/src/approval.ts
@@ -96,8 +96,8 @@ const ApprovalRequestBaseShape = {
   requesterEmail: z.string().nullable(),
   querySql: z.string(),
   explanation: z.string().nullable(),
-  // #2344 — connectionId now nullable; lookup keys on connectionGroupId.
-  connectionId: z.string().nullable(),
+  // #2344 — lookup keys on connectionGroupId. Legacy `connectionId`
+  // dropped from the wire shape in #2346.
   connectionGroupId: z.string().nullable(),
   tablesAccessed: z.array(z.string()),
   columnsAccessed: z.array(z.string()),

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useatlas/types",
-  "version": "0.0.29",
+  "version": "0.1.0",
   "description": "Shared types for the Atlas text-to-SQL agent",
   "type": "module",
   "scripts": {

--- a/packages/types/src/__tests__/migration.test.ts
+++ b/packages/types/src/__tests__/migration.test.ts
@@ -41,7 +41,7 @@ describe("migration types", () => {
         },
       ],
       semanticEntities: [
-        { name: "users", entityType: "entity", yamlContent: "table: users", connectionId: null },
+        { name: "users", entityType: "entity", yamlContent: "table: users", connectionGroupId: null },
       ],
       learnedPatterns: [],
       settings: [],

--- a/packages/types/src/approval.ts
+++ b/packages/types/src/approval.ts
@@ -107,13 +107,6 @@ interface ApprovalRequestBase {
   querySql: string;
   explanation: string | null;
   /**
-   * Originating connection id (audit trail). Nullable post-#2344 — the
-   * approval lookup keys on {@link connectionGroupId}; this column
-   * survives so reviewers can see which group member submitted the
-   * request. Removed in a follow-up slice once SDK consumers settle.
-   */
-  connectionId: string | null;
-  /**
    * Group scope for this approval (#2344). NULL for legacy pre-#2344
    * rows and for callers that don't have a group context yet; new
    * rows resolve via the connection's `group_id`. One approval covers

--- a/packages/types/src/compliance.ts
+++ b/packages/types/src/compliance.ts
@@ -68,32 +68,14 @@ export interface PIIColumnClassification {
   /** Column name within the table. */
   columnName: string;
   /**
-   * Legacy connection scope. Retained for compatibility with classifications
-   * stored before #2341; new rows also populate `connectionGroupId`
-   * (additive). Final removal lives in the #2346 deprecation tail.
-   *
-   * Nullable post-0064 — the migration dropped the legacy `NOT NULL
-   * DEFAULT 'default'`. Read sites should treat NULL as "no connection
-   * scope" (a global / cross-env classification) and prefer the group
-   * column for resolution.
-   *
-   * @deprecated Prefer `connectionGroupId` when reading from 1.4.4+ instances.
-   */
-  connectionId: string | null;
-  /**
    * Group scope (#2341). One classification row per (org, table, column,
    * group) — multi-member groups share the same row (replicas inside a
    * group share schema, so the column's PII category is the same across
-   * all members). Nullable for legacy rows whose `connectionId` no
-   * longer resolves to a live connection; those classifications apply
+   * all members). Nullable for legacy rows whose original connection no
+   * longer resolves to a live group; those classifications apply
    * globally within the org (the COALESCE sentinel bucket).
-   *
-   * Optional during the wire-format transition: instances exported
-   * before #2341 omit the field. Consumers should resolve
-   * `connectionGroupId ?? null` and fall back to `connectionId` for
-   * legacy rows.
    */
-  connectionGroupId?: string | null;
+  connectionGroupId: string | null;
   /** Detected or manually assigned PII category. */
   category: PIICategory;
   /** Detection confidence level. */

--- a/packages/types/src/dashboard.ts
+++ b/packages/types/src/dashboard.ts
@@ -53,13 +53,6 @@ export interface DashboardCard {
   cachedRows: Record<string, unknown>[] | null;
   cachedAt: string | null;
   /**
-   * @deprecated 1.4.4 — superseded by `connectionGroupId`. Retained
-   * for read-side dual-write while #2347 deprecates the column on
-   * the API; new writes from the admin UI should set
-   * `connectionGroupId` instead.
-   */
-  connectionId: string | null;
-  /**
    * Group-scoped execution target (1.4.4). Resolves to a physical
    * connection at view time via the group's primary member, or the
    * first member by `(created_at, id)` when no primary is set.

--- a/packages/types/src/migration.ts
+++ b/packages/types/src/migration.ts
@@ -60,24 +60,13 @@ export interface ExportedSemanticEntity {
   entityType: string;
   yamlContent: string;
   /**
-   * Legacy connection scope. Retained for compatibility with bundles
-   * exported before #2340; new exports also populate
-   * `connectionGroupId` (additive). Removed alongside the column
-   * itself in a follow-on slice — see PRD #2336 §"Migration sequencing".
-   *
-   * @deprecated Prefer `connectionGroupId` when reading bundles from
-   *   1.4.4+ instances.
-   */
-  connectionId: string | null;
-  /**
    * Group scope (multi-environment semantic layer, #2340). One entity
    * row per group — multi-member groups share the same definition.
-   * Optional during the wire-format transition: bundles exported by
-   * pre-1.4.4 instances omit the field. Consumers should resolve
-   * `connectionGroupId ?? null` and fall back to `connectionId` for
-   * legacy bundles.
+   * Nullable for global / unscoped entities and for bundles exported
+   * by pre-1.4.4 instances whose legacy `connectionId` no longer
+   * resolves to a live group.
    */
-  connectionGroupId?: string | null;
+  connectionGroupId: string | null;
 }
 
 /** Exported learned pattern. */

--- a/packages/types/src/scheduled-task.ts
+++ b/packages/types/src/scheduled-task.ts
@@ -57,12 +57,10 @@ export interface ScheduledTask {
   /** Recipients should match the deliveryChannel type (email recipients for email channel, etc). */
   recipients: Recipient[];
   /**
-   * Environment/group scope for this task. New 1.4.4+ callers should set this
-   * instead of targeting raw connections directly.
+   * Environment/group scope for this task. Resolves to a physical
+   * connection at run time via the group's primary member.
    */
   connectionGroupId: string | null;
-  /** @deprecated Prefer `connectionGroupId`; retained until #2346. */
-  connectionId: string | null;
   approvalMode: ActionApprovalMode;
   enabled: boolean;
   lastRunAt: string | null;

--- a/packages/web/src/app/(workspace)/dashboards/[id]/page.tsx
+++ b/packages/web/src/app/(workspace)/dashboards/[id]/page.tsx
@@ -168,7 +168,7 @@ export default function DashboardViewPage() {
         chartConfig: card.chartConfig,
         cachedColumns: card.cachedColumns,
         cachedRows: card.cachedRows,
-        connectionId: card.connectionId,
+        connectionGroupId: card.connectionGroupId,
         layout: nextTileLayout(placed),
       },
     });

--- a/packages/web/src/app/admin/approval/page.tsx
+++ b/packages/web/src/app/admin/approval/page.tsx
@@ -585,7 +585,7 @@ function QueueSection() {
   // each is its own environment.
   const pendingGroupBuckets = new Map<string, ApprovalRequest[]>();
   for (const req of pendingRequests) {
-    const env = req.connectionGroupId ?? req.connectionId ?? "__no-env__";
+    const env = req.connectionGroupId ?? "__no-env__";
     const key = `${env} ${req.querySql}`;
     const bucket = pendingGroupBuckets.get(key);
     if (bucket) bucket.push(req);
@@ -594,7 +594,7 @@ function QueueSection() {
   const dupBuckets = [...pendingGroupBuckets.values()].filter((b) => b.length > 1);
   const dupCount = dupBuckets.reduce((sum, b) => sum + (b.length - 1), 0);
   const distinctEnvCount = new Set(
-    pendingRequests.map((r) => r.connectionGroupId ?? r.connectionId ?? "__no-env__"),
+    pendingRequests.map((r) => r.connectionGroupId ?? "__no-env__"),
   ).size;
 
   function toggleSelect(id: string) {
@@ -1069,19 +1069,13 @@ function ExpandedRequestDetails({
       {/* #2344 — surface the environment context. Approvals are now
           group-wide: one greenlight covers any member of the same
           environment running the same query, so reviewers need to see
-          which group they're approving for. Legacy pre-#2344 rows fall
-          back to the originating connection id. */}
-      {(req.connectionGroupId || req.connectionId) && (
+          which group they're approving for. */}
+      {req.connectionGroupId && (
         <div className="flex flex-wrap items-center gap-1.5">
           <span className="text-xs text-muted-foreground">Environment:</span>
           <Badge variant="outline" className="text-xs font-mono">
-            {req.connectionGroupId ?? req.connectionId}
+            {req.connectionGroupId}
           </Badge>
-          {!req.connectionGroupId && req.connectionId && (
-            <span className="text-[10px] text-muted-foreground/70">
-              (legacy — pre-environment-grouping)
-            </span>
-          )}
         </div>
       )}
 

--- a/packages/web/src/app/admin/scheduled-tasks/task-form-dialog.tsx
+++ b/packages/web/src/app/admin/scheduled-tasks/task-form-dialog.tsx
@@ -317,7 +317,6 @@ export function TaskFormDialog({
       return;
     }
 
-    const selectedGroup = groups.find((g) => g.id === form.connectionGroupId);
     const body = {
       name: form.name.trim(),
       question: form.question.trim(),
@@ -325,7 +324,6 @@ export function TaskFormDialog({
       deliveryChannel: form.deliveryChannel,
       recipients,
       connectionGroupId: form.connectionGroupId || null,
-      connectionId: selectedGroup?.resolvedConnectionId ?? task?.connectionId ?? null,
       approvalMode: form.approvalMode,
       ...(isEdit ? { enabled: form.enabled } : {}),
     };

--- a/packages/web/src/ui/components/admin/publish-modal.tsx
+++ b/packages/web/src/ui/components/admin/publish-modal.tsx
@@ -34,7 +34,7 @@ interface DraftRow {
 }
 
 interface EntityEditRow extends DraftRow {
-  readonly connectionId: string | null;
+  readonly connectionGroupId: string | null;
 }
 
 interface PublishPreviewData {
@@ -258,7 +258,7 @@ function buildSections(data: PublishPreviewData): Section[] {
   const entityRows: SectionRow[] = [];
   for (const r of data.entities) entityRows.push({ ...r, intent: "create" });
   for (const r of data.entityEdits) {
-    const suffix = r.connectionId ? ` · ${r.connectionId}` : "";
+    const suffix = r.connectionGroupId ? ` · ${r.connectionGroupId}` : "";
     entityRows.push({
       id: r.id,
       label: `${r.label}${suffix}`,

--- a/packages/web/src/ui/components/dashboards/__tests__/auto-layout.test.ts
+++ b/packages/web/src/ui/components/dashboards/__tests__/auto-layout.test.ts
@@ -10,7 +10,6 @@ const DEFAULT_CARD: Omit<DashboardCard, "id" | "position" | "layout"> = {
   cachedColumns: null,
   cachedRows: null,
   cachedAt: null,
-  connectionId: null,
   connectionGroupId: null,
   createdAt: "2026-04-25T00:00:00Z",
   updatedAt: "2026-04-25T00:00:00Z",

--- a/packages/web/src/ui/components/dashboards/__tests__/dashboard-grid.test.tsx
+++ b/packages/web/src/ui/components/dashboards/__tests__/dashboard-grid.test.tsx
@@ -37,7 +37,6 @@ const card: DashboardCard = {
   cachedColumns: ["stage", "amount"],
   cachedRows: [{ stage: "Discovery", amount: 1 }],
   cachedAt: "2026-04-25T12:00:00Z",
-  connectionId: null,
   connectionGroupId: null,
   layout: { x: 0, y: 0, w: 12, h: 8 },
   createdAt: "2026-04-25T12:00:00Z",

--- a/packages/web/src/ui/components/dashboards/__tests__/dashboard-tile.test.tsx
+++ b/packages/web/src/ui/components/dashboards/__tests__/dashboard-tile.test.tsx
@@ -41,7 +41,6 @@ const baseCard: DashboardCard = {
     { stage: "Closed Won", amount: 1920000 },
   ],
   cachedAt: "2026-04-25T12:00:00Z",
-  connectionId: null,
   connectionGroupId: null,
   layout: { x: 0, y: 0, w: 12, h: 8 },
   createdAt: "2026-04-25T12:00:00Z",

--- a/packages/web/src/ui/components/dashboards/dashboard-canvas.tsx
+++ b/packages/web/src/ui/components/dashboards/dashboard-canvas.tsx
@@ -188,7 +188,6 @@ export function DashboardCanvas({ apiUrl, getHeaders, getCredentials }: Dashboar
               sql: card.sql,
               chartConfig: card.chartConfig,
               layout: card.layout ?? null,
-              connectionId: card.connectionId ?? null,
               ...cached,
             }),
           });


### PR DESCRIPTION
## Summary

Wave 1 of #2346 — drop the deprecated `connectionId` field from the
five wire shapes that #2340–#2345 dual-wrote during the 1.4.4
multi-environment semantic-layer rollout, and ship the
`@useatlas/types` major bump (`0.0.29` → `0.1.0`).

Closes a chunk of acceptance criteria on #2346. **Wave 2** (`@useatlas/sdk`
+ `@useatlas/react` major bumps, dual-prop deprecation wind-down,
template ref bumps) follows in a separate PR once the `types-v0.1.0`
tag publishes to npm — per `feedback_version_bump_ordering`, sdk/react
ref bumps cannot ship before wave-1's tag is live (Deploy Validation
scaffolds run `npm install` against the registry).

### Why two waves

`@useatlas/sdk` and `@useatlas/react` depend on `^0.0.28` of
`@useatlas/types` from npm — `0.0.x` semver is exact-match, so they
keep using the published 0.0.28 until we explicitly bump their
deps. Atlas's workspace consumers (`@atlas/api`, `@atlas/web`,
`@atlas/mcp`, `@atlas/cli`, `@useatlas/schemas`, `@atlas/ee`) depend
on `workspace:*` and receive `0.1.0` immediately — those updates are
all in this PR.

### Stabilization-window override

The issue spec proposes a 2-week SaaS soak across every content slice
before this major lands. There are no real customers yet, so that gate
doesn't apply — flagged explicitly here so future-me doesn't wonder
why the soak was skipped.

## What changed

### Removed `connectionId` from wire shapes
- `ScheduledTask` — group execution target (`connectionGroupId`) is the canonical scope.
- `DashboardCard` — same.
- `ApprovalRequest` ("ApprovalQueueEntry") — approval lookup keys on group.
- `ExportedSemanticEntity` — migration bundle field.
- `PIIColumnClassification` — masking rule scope.
- `admin-publish-preview.EntityEditRow` — staged-entity preview field.

### Retained `connectionId` (execution targets, NOT deprecated)
- `Conversation.connectionId` — per-conversation execution target.
- `ExportedConversation.connectionId` — exported execution target.
- `ProposedCard.connectionId` — agent-emitted proposal spec.
- `PoolMetrics.connectionId` / `ConnectionGroupMember.connectionId` — canonical IDs.

### Plugin SDK
McpToolContext exposes both `connectionId` (exec target) and
`connectionGroupId` (content scope) by design — there's no
"temporarily duplicated legacy field" to drop here.

### Behavior changes
- Dashboard refresh resolver (`resolveCardConnectionId`) no longer
  reads the legacy column. Cards without a `connectionGroupId` fall
  through to the workspace default. Migration 0066 already backfilled
  `connection_group_id` from `connection_id` for every card with a
  legacy pointer; the only cards affected are orphans whose source
  connection was already deleted.
- `POST /api/v1/scheduled-tasks` + `POST /api/v1/dashboards/:id/cards`
  silently strip the legacy `connectionId` body field via Zod's
  default strip behavior. Clients pinned to `@useatlas/sdk@0.0.x`
  continue to send the field; the server ignores it.
- `GET /api/v1/admin/compliance/classifications` drops the legacy
  `connectionId` query param. Callers must use `connectionGroupId`.

### Migration guide
`apps/docs/content/docs/sdk/migration-0.1.mdx` — field-by-field
before/after, plus the SDK + react wave-2 follow-up sequencing.

## Test plan

- [x] `bun run type` — workspace tsgo: 0 errors
- [x] `bun run lint` — 0 errors (1 pre-existing warning unrelated)
- [x] `cd packages/api && bun run scripts/test-isolated.ts --affected` — 30/30 pass
- [x] `bun run test:others` — all workspace test suites green
- [x] `bun x syncpack lint` — no issues
- [x] `SKIP_SYNCPACK=1 bash scripts/check-template-drift.sh` — pass
- [x] `bash scripts/check-schema-drift.sh` — pass
- [x] `bash scripts/check-security-headers-drift.sh` — pass
- [x] `bash scripts/check-railway-watch.sh` — pass
- [x] `bash scripts/check-oauth-helper-drift.sh` — pass
- [ ] After merge: push `types-v0.1.0` tag, verify npm publish, open wave-2 PR (`@useatlas/sdk` + `@useatlas/react` major bumps + dep-ref + template-ref updates)

Refs: #2346, parent PRD #2336.