### PR TITLE
fix: build local sdk before react publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -86,8 +86,8 @@ jobs:
       - name: Build and publish @useatlas/react
         if: startsWith(github.ref, 'refs/tags/react-v')
         run: |
-          bun install @useatlas/sdk@latest
-          cd packages/react && bun run build && npm publish --access public --provenance
+          cd packages/sdk && bun run build
+          cd ../react && bun run build && npm publish --access public --provenance
 
       # Plugins — ship raw TypeScript, no build step needed
       # Tests are already run by CI on every push to main; tags are always cut from main

--- a/bun.lock
+++ b/bun.lock
@@ -297,7 +297,7 @@
       },
       "peerDependencies": {
         "@ai-sdk/react": ">=3.0.0",
-        "@useatlas/sdk": ">=0.0.13",
+        "@useatlas/sdk": ">=0.1.0",
         "ai": ">=6.0.0",
         "exceljs": ">=4.0.0",
         "lucide-react": ">=0.400.0",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -53,7 +53,7 @@
   },
   "peerDependencies": {
     "@ai-sdk/react": ">=3.0.0",
-    "@useatlas/sdk": ">=0.0.13",
+    "@useatlas/sdk": ">=0.1.0",
     "ai": ">=6.0.0",
     "lucide-react": ">=0.400.0",
     "react": ">=18.0.0",


### PR DESCRIPTION
## Summary

- Build the workspace SDK before publishing `@useatlas/react` instead of running `bun install @useatlas/sdk@latest` inside the monorepo.
- Tighten `@useatlas/react`'s peer dependency floor to `@useatlas/sdk >=0.1.0` for the 0.1 wire-format wave.

## Context

`react-v0.1.0` was pushed from `4c029fa7`, but the publish workflow failed before build/publish with Bun `DependencyLoop` while trying to install `@useatlas/sdk@latest` into a checkout that already has the workspace SDK.

After this merges, recreate or move `react-v0.1.0` to the merged commit and rerun the publish tag flow.

## Verification

- `bun run --filter '@useatlas/sdk' build`
- `bun run --filter '@useatlas/react' build`