### PR TITLE
[codex] delete archived connections before environment delete

### DIFF
--- a/packages/api/src/api/routes/admin-connection-groups.ts
+++ b/packages/api/src/api/routes/admin-connection-groups.ts
@@ -589,14 +589,22 @@ adminConnectionGroups.openapi(deleteGroupRoute, async (c) =>
 
     try {
       await internalQuery(
-        `DELETE FROM connection_groups WHERE id = $1 AND org_id = $2`,
+        `WITH deleted_archived_connections AS (
+           DELETE FROM connections
+            WHERE group_id = $1
+              AND org_id = $2
+              AND status = 'archived'
+              AND url <> ''
+           RETURNING id
+         )
+         DELETE FROM connection_groups WHERE id = $1 AND org_id = $2`,
         [id, orgId],
       );
     } catch (err) {
       const meta = pgErrorMeta(err);
       if (meta.code === "23503") {
         const message = meta.constraint === CONNECTIONS_GROUP_FK
-          ? `Group "${id}" is still referenced by connection rows. Restore or permanently remove those connections before deleting it.`
+          ? `Group "${id}" is still referenced by hidden connection rows. Restore or unhide those connections before deleting it.`
           : `Group "${id}" is still referenced by workspace content. Remove or update those references before deleting it.`;
         return c.json(
           {


### PR DESCRIPTION
## Summary
- delete real archived connection rows in the target environment before deleting an otherwise-empty connection group
- preserve archived tombstone rows (`url = ''`) so hiding a global connection is not accidentally undone
- keep active/non-archived members blocked with the existing 409
- preserve the FK-to-409 fallback for tombstones and other content references

## Root cause
The original endpoint checked only live members, but the database FK still blocks deletion when archived connection rows reference the group. Real archived internal-test rows can be removed during environment cleanup; tombstones must remain because they suppress global fallback visibility.

## Validation
- bun run type
- bun x eslint packages/api/src/api/routes/admin-connection-groups.ts -f json
- cd packages/api && bun run scripts/test-isolated.ts --affected
