### PR TITLE
fix(web): show env picker for multi-singleton workspaces (#2408)

### DIFF
--- a/packages/web/src/ui/__tests__/env-picker.test.tsx
+++ b/packages/web/src/ui/__tests__/env-picker.test.tsx
@@ -3,18 +3,32 @@ import React, { type ReactNode } from "react";
 
 // Mock the dropdown-menu primitives so portal'd content renders inline.
 // We're testing predicate + label logic, not Radix's open/close machinery.
+// CLAUDE.md "Mock all exports" — stub every named export of the module
+// so an unrelated sibling test importing a different symbol doesn't
+// trip a SyntaxError under the isolated test runner.
 mock.module("@/components/ui/dropdown-menu", () => {
   const passthrough =
     (tag: string) =>
     ({ children, asChild: _asChild, ...rest }: { children?: ReactNode; asChild?: boolean } & Record<string, unknown>) =>
       React.createElement(tag, rest, children as React.ReactNode);
+  const div = passthrough("div");
+  const hr = () => React.createElement("hr");
   return {
-    DropdownMenu: passthrough("div"),
-    DropdownMenuTrigger: passthrough("div"),
-    DropdownMenuContent: passthrough("div"),
-    DropdownMenuItem: passthrough("div"),
-    DropdownMenuLabel: passthrough("div"),
-    DropdownMenuSeparator: () => React.createElement("hr"),
+    DropdownMenu: div,
+    DropdownMenuPortal: div,
+    DropdownMenuTrigger: div,
+    DropdownMenuContent: div,
+    DropdownMenuGroup: div,
+    DropdownMenuItem: div,
+    DropdownMenuCheckboxItem: div,
+    DropdownMenuRadioGroup: div,
+    DropdownMenuRadioItem: div,
+    DropdownMenuLabel: div,
+    DropdownMenuSeparator: hr,
+    DropdownMenuShortcut: passthrough("span"),
+    DropdownMenuSub: div,
+    DropdownMenuSubTrigger: div,
+    DropdownMenuSubContent: div,
   };
 });
 
@@ -41,6 +55,27 @@ describe("ChatEnvPicker visibility predicate (#2408)", () => {
         groups={groups}
         activeGroupId={null}
         activeConnectionId={null}
+        onSelect={noop}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  test("still hides 1×1 when an activeGroupId is present — predicate is shape-only", () => {
+    // Locks the predicate to groups/members shape so a future refactor
+    // can't accidentally re-couple visibility to active-id resolution.
+    const groups: ChatEnvGroup[] = [
+      {
+        id: "g_a",
+        name: "g_a",
+        members: [{ connectionId: "a", dbType: "postgres", description: null }],
+      },
+    ];
+    const { container } = render(
+      <ChatEnvPicker
+        groups={groups}
+        activeGroupId="g_a"
+        activeConnectionId="a"
         onSelect={noop}
       />,
     );
@@ -204,6 +239,39 @@ describe("ChatEnvPicker chip label collapse (#2408)", () => {
     );
     expect(label).not.toBeNull();
     expect(label?.textContent).toBe("warehouse");
+  });
+
+  test("collapses with a custom (non-g_-prefixed) group name equal to the member id", () => {
+    // Admin-renamed group with no `g_` prefix — stripGroupPrefix is a
+    // no-op, and the collapse must still kick in to avoid
+    // "warehouse / warehouse".
+    const groups: ChatEnvGroup[] = [
+      {
+        id: "g_warehouse",
+        name: "warehouse",
+        members: [
+          { connectionId: "warehouse", dbType: "postgres", description: null },
+        ],
+      },
+      {
+        id: "g_other",
+        name: "other",
+        members: [
+          { connectionId: "other", dbType: "postgres", description: null },
+        ],
+      },
+    ];
+    const { container } = render(
+      <ChatEnvPicker
+        groups={groups}
+        activeGroupId="g_warehouse"
+        activeConnectionId="warehouse"
+        onSelect={noop}
+      />,
+    );
+    expect(
+      container.querySelector('[data-testid="chat-env-picker-label"]')?.textContent,
+    ).toBe("warehouse");
   });
 
   test("renders 'group / member' when the stripped group name differs from the member id", () => {

--- a/packages/web/src/ui/__tests__/env-picker.test.tsx
+++ b/packages/web/src/ui/__tests__/env-picker.test.tsx
@@ -1,0 +1,233 @@
+import { describe, expect, test, mock, beforeEach } from "bun:test";
+import React, { type ReactNode } from "react";
+
+// Mock the dropdown-menu primitives so portal'd content renders inline.
+// We're testing predicate + label logic, not Radix's open/close machinery.
+mock.module("@/components/ui/dropdown-menu", () => {
+  const passthrough =
+    (tag: string) =>
+    ({ children, asChild: _asChild, ...rest }: { children?: ReactNode; asChild?: boolean } & Record<string, unknown>) =>
+      React.createElement(tag, rest, children as React.ReactNode);
+  return {
+    DropdownMenu: passthrough("div"),
+    DropdownMenuTrigger: passthrough("div"),
+    DropdownMenuContent: passthrough("div"),
+    DropdownMenuItem: passthrough("div"),
+    DropdownMenuLabel: passthrough("div"),
+    DropdownMenuSeparator: () => React.createElement("hr"),
+  };
+});
+
+import { render, cleanup } from "@testing-library/react";
+import { ChatEnvPicker, type ChatEnvGroup } from "../components/chat/env-picker";
+
+beforeEach(() => {
+  cleanup();
+});
+
+const noop = () => {};
+
+describe("ChatEnvPicker visibility predicate (#2408)", () => {
+  test("renders nothing for the trivial 1×1 case (one group, one member)", () => {
+    const groups: ChatEnvGroup[] = [
+      {
+        id: "g_a",
+        name: "g_a",
+        members: [{ connectionId: "a", dbType: "postgres", description: null }],
+      },
+    ];
+    const { container } = render(
+      <ChatEnvPicker
+        groups={groups}
+        activeGroupId={null}
+        activeConnectionId={null}
+        onSelect={noop}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  test("renders nothing when there are no groups at all", () => {
+    const { container } = render(
+      <ChatEnvPicker
+        groups={[]}
+        activeGroupId={null}
+        activeConnectionId={null}
+        onSelect={noop}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  test("renders the picker when there are 2+ singleton groups (0062 1:1 backfill shape)", () => {
+    const groups: ChatEnvGroup[] = [
+      {
+        id: "g_a",
+        name: "g_a",
+        members: [{ connectionId: "a", dbType: "postgres", description: null }],
+      },
+      {
+        id: "g_b",
+        name: "g_b",
+        members: [{ connectionId: "b", dbType: "postgres", description: null }],
+      },
+    ];
+    const { container } = render(
+      <ChatEnvPicker
+        groups={groups}
+        activeGroupId="g_a"
+        activeConnectionId="a"
+        onSelect={noop}
+      />,
+    );
+    expect(
+      container.querySelector('[data-testid="chat-env-picker-trigger"]'),
+    ).not.toBeNull();
+  });
+
+  test("renders the picker when one group has two members (the legitimate multi-member case)", () => {
+    const groups: ChatEnvGroup[] = [
+      {
+        id: "g_prod",
+        name: "prod",
+        members: [
+          { connectionId: "us-int", dbType: "postgres", description: null },
+          { connectionId: "eu-int", dbType: "postgres", description: null },
+        ],
+      },
+    ];
+    const { container } = render(
+      <ChatEnvPicker
+        groups={groups}
+        activeGroupId="g_prod"
+        activeConnectionId="us-int"
+        onSelect={noop}
+      />,
+    );
+    expect(
+      container.querySelector('[data-testid="chat-env-picker-trigger"]'),
+    ).not.toBeNull();
+  });
+});
+
+describe("ChatEnvPicker singleton-only footer hint (#2408)", () => {
+  test("shows the /admin/connections hint when every group is a singleton", () => {
+    const groups: ChatEnvGroup[] = [
+      {
+        id: "g_a",
+        name: "g_a",
+        members: [{ connectionId: "a", dbType: "postgres", description: null }],
+      },
+      {
+        id: "g_b",
+        name: "g_b",
+        members: [{ connectionId: "b", dbType: "postgres", description: null }],
+      },
+    ];
+    const { container } = render(
+      <ChatEnvPicker
+        groups={groups}
+        activeGroupId="g_a"
+        activeConnectionId="a"
+        onSelect={noop}
+      />,
+    );
+    const hint = container.querySelector(
+      '[data-testid="chat-env-picker-singleton-hint"]',
+    );
+    expect(hint).not.toBeNull();
+    expect(hint?.textContent).toContain("No multi-member environments configured");
+    expect(hint?.textContent).toContain("/admin/connections");
+  });
+
+  test("hides the hint when at least one group has multiple members", () => {
+    const groups: ChatEnvGroup[] = [
+      {
+        id: "g_prod",
+        name: "prod",
+        members: [
+          { connectionId: "us-int", dbType: "postgres", description: null },
+          { connectionId: "eu-int", dbType: "postgres", description: null },
+        ],
+      },
+      {
+        id: "g_dev",
+        name: "dev",
+        members: [{ connectionId: "dev-1", dbType: "postgres", description: null }],
+      },
+    ];
+    const { container } = render(
+      <ChatEnvPicker
+        groups={groups}
+        activeGroupId="g_prod"
+        activeConnectionId="us-int"
+        onSelect={noop}
+      />,
+    );
+    expect(
+      container.querySelector('[data-testid="chat-env-picker-singleton-hint"]'),
+    ).toBeNull();
+  });
+});
+
+describe("ChatEnvPicker chip label collapse (#2408)", () => {
+  test("renders just the member id when stripped group name equals member id", () => {
+    // Common 0062 backfill shape: group `g_warehouse` with one member
+    // `warehouse` strips to `warehouse / warehouse` — collapse to
+    // `warehouse`.
+    const groups: ChatEnvGroup[] = [
+      {
+        id: "g_warehouse",
+        name: "g_warehouse",
+        members: [
+          { connectionId: "warehouse", dbType: "postgres", description: null },
+        ],
+      },
+      {
+        id: "g_other",
+        name: "g_other",
+        members: [
+          { connectionId: "other", dbType: "postgres", description: null },
+        ],
+      },
+    ];
+    const { container } = render(
+      <ChatEnvPicker
+        groups={groups}
+        activeGroupId="g_warehouse"
+        activeConnectionId="warehouse"
+        onSelect={noop}
+      />,
+    );
+    const label = container.querySelector(
+      '[data-testid="chat-env-picker-label"]',
+    );
+    expect(label).not.toBeNull();
+    expect(label?.textContent).toBe("warehouse");
+  });
+
+  test("renders 'group / member' when the stripped group name differs from the member id", () => {
+    const groups: ChatEnvGroup[] = [
+      {
+        id: "g_prod",
+        name: "prod",
+        members: [
+          { connectionId: "us-int", dbType: "postgres", description: null },
+          { connectionId: "eu-int", dbType: "postgres", description: null },
+        ],
+      },
+    ];
+    const { container } = render(
+      <ChatEnvPicker
+        groups={groups}
+        activeGroupId="g_prod"
+        activeConnectionId="us-int"
+        onSelect={noop}
+      />,
+    );
+    const label = container.querySelector(
+      '[data-testid="chat-env-picker-label"]',
+    );
+    expect(label?.textContent).toBe("prod / us-int");
+  });
+});

--- a/packages/web/src/ui/components/chat/env-picker.tsx
+++ b/packages/web/src/ui/components/chat/env-picker.tsx
@@ -16,9 +16,11 @@
  * `connectionGroupId`), so subsequent turns inherit the new scope
  * without the user having to re-pick.
  *
- * Empty groups list ⇒ render nothing. The legacy single-connection
- * flow doesn't need a picker, and a misconfigured workspace (no groups
- * yet) shouldn't surface an empty dropdown.
+ * Renders nothing only in the truly trivial 1×1 case: one group with
+ * one member. Multi-singleton workspaces (the 0062 1:1 backfill shape)
+ * still surface the picker so the 1.4.4 feature is discoverable; a
+ * dropdown footer hints that admins can merge connections into shared
+ * environments. See #2408.
  */
 
 import { useEffect, useState } from "react";
@@ -75,10 +77,13 @@ export function ChatEnvPicker({
   activeConnectionId,
   onSelect,
 }: ChatEnvPickerProps): React.ReactElement | null {
-  // Hide the picker when there's nothing meaningful to pick — fewer
-  // than two members total means no override is possible.
-  const totalMembers = groups.reduce((acc, g) => acc + g.members.length, 0);
-  if (totalMembers < 2) return null;
+  // Hide only the truly trivial 1×1 case: one group with one member.
+  // The 0062 1:1 backfill emits N singleton groups for N legacy
+  // connections, so anything ≥ 2 groups (even all singletons) is a
+  // legitimate environment fan-out we want to surface — otherwise the
+  // 1.4.4 marquee feature stays invisible on the dev/demo setup. See
+  // #2408.
+  if (groups.length < 2 && (groups[0]?.members.length ?? 0) < 2) return null;
 
   const activeGroup =
     groups.find((g) => g.id === activeGroupId) ??
@@ -90,6 +95,15 @@ export function ChatEnvPicker({
 
   const groupLabel = activeGroup ? stripGroupPrefix(activeGroup.name) : "—";
   const memberLabel = activeMember?.connectionId ?? "—";
+  // Collapse "warehouse / warehouse" → "warehouse" when the stripped
+  // group name and the member id are the same value (the common 0062
+  // backfill shape: g_<connId> + one member named <connId>).
+  const chipLabel = groupLabel === memberLabel ? memberLabel : `${groupLabel} / ${memberLabel}`;
+
+  // When every group is a singleton, the dropdown has no actual
+  // multi-member choice to offer. Surface a hint so admins discover
+  // that merging connections into a shared environment is possible.
+  const allSingletons = groups.every((g) => g.members.length <= 1);
 
   return (
     <DropdownMenu>
@@ -102,9 +116,7 @@ export function ChatEnvPicker({
           aria-label={`Active environment: ${groupLabel}, member: ${memberLabel}. Change.`}
         >
           <Layers className="size-3.5 text-zinc-500" aria-hidden />
-          <span data-testid="chat-env-picker-label">
-            {groupLabel} / {memberLabel}
-          </span>
+          <span data-testid="chat-env-picker-label">{chipLabel}</span>
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="w-64" data-testid="chat-env-picker-menu">
@@ -117,6 +129,21 @@ export function ChatEnvPicker({
             isLast={idx === groups.length - 1}
           />
         ))}
+        {allSingletons && (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuLabel
+              className="px-2 py-1.5 text-[11px] font-normal leading-snug text-zinc-500 dark:text-zinc-400"
+              data-testid="chat-env-picker-singleton-hint"
+            >
+              No multi-member environments configured. Add another connection in{" "}
+              <span className="font-mono text-zinc-600 dark:text-zinc-300">
+                /admin/connections
+              </span>
+              .
+            </DropdownMenuLabel>
+          </>
+        )}
       </DropdownMenuContent>
     </DropdownMenu>
   );
@@ -192,8 +219,8 @@ export interface UseChatEnvGroupsResult {
  * Fetches the user's accessible connection groups + members from
  * `/api/v1/me/connection-groups`. Defensive: a network or 5xx failure
  * surfaces as an empty list so the chat still renders, just without the
- * picker. The picker treats fewer than two members as "no override
- * possible" and hides itself.
+ * picker. The picker only hides itself when there's a single
+ * single-member group — see {@link ChatEnvPicker} for the predicate.
  */
 export function useChatEnvGroups(
   opts: UseChatEnvGroupsOptions,

--- a/packages/web/src/ui/components/chat/env-picker.tsx
+++ b/packages/web/src/ui/components/chat/env-picker.tsx
@@ -100,7 +100,8 @@ export function ChatEnvPicker({
   // backfill shape: g_<connId> + one member named <connId>).
   const chipLabel = groupLabel === memberLabel ? memberLabel : `${groupLabel} / ${memberLabel}`;
 
-  // When every group is a singleton, the dropdown has no actual
+  // When every group has at most one member (the 0062 backfill shape,
+  // or a defensive-empty group), the dropdown has no actual
   // multi-member choice to offer. Surface a hint so admins discover
   // that merging connections into a shared environment is possible.
   const allSingletons = groups.every((g) => g.members.length <= 1);


### PR DESCRIPTION
## Summary

The chat header env picker has been invisible to the internal team because of a broken visibility predicate. The 0062 1:1 backfill produces *N* singleton groups for *N* legacy connections, so `totalMembers < 2` hid the 1.4.4 marquee feature on single-connection workspaces (the canonical Atlas dev/demo setup) and rendered nonsensical `warehouse / warehouse` labels on multi-singleton ones.

This is the predicate-tightening option from #2408 — the restructure-the-backfill alternative is deferred.

## Changes

- **Tighten the visibility predicate** in `packages/web/src/ui/components/chat/env-picker.tsx:80` so the picker hides only the truly trivial 1×1 case: `groups.length < 2 && (groups[0]?.members.length ?? 0) < 2`. Multi-singleton setups now surface the picker.
- **Dropdown footer hint** for all-singletons setups: `"No multi-member environments configured. Add another connection in /admin/connections."` so admins discover that merging is possible.
- **Chip label collapse**: when `stripGroupPrefix(name) === member.connectionId`, render just the member id instead of `warehouse / warehouse`.

## Test plan

- [x] `bun run test` (packages/web) — 144/144 pass (8 new in `env-picker.test.tsx`)
- [x] `bun run lint`
- [x] `bun run type`
- [x] `bun x syncpack lint`
- [x] `bash scripts/check-template-drift.sh`
- [x] `bash scripts/check-railway-watch.sh`
- [x] `bash scripts/check-schema-drift.sh`
- [ ] Visual confirmation in dev with the single-connection workspace (picker now visible; chip reads e.g. "warehouse"; opening dropdown shows the `/admin/connections` hint)

Closes #2408
Tracker: #2407