### PR TITLE
fix(api): scheduler must not cross tenant→__global__ org on empty group (#2416)

### DIFF
--- a/packages/api/src/lib/scheduler/__tests__/executor.empty-group.test.ts
+++ b/packages/api/src/lib/scheduler/__tests__/executor.empty-group.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Executor empty-group test (#2416).
+ *
+ * Pair with `executor.test.ts`, which mocks `../group-resolve` to keep the
+ * existing tests focused on executor behavior. This file is intentionally
+ * separate so we can run executor against the REAL `loadScheduledTaskGroupSnapshot`
+ * — `mock.module()` is file-scoped in `bun:test`, so we can't selectively
+ * unmock the group-resolve module for a single test within `executor.test.ts`.
+ *
+ * The contract being verified: when a tenant's connection group has zero
+ * non-archived members, the executor must log + skip the tick without firing
+ * the agent. No SQL must touch the `__global__` org for a tenant caller —
+ * that was the pre-#2416 silent cross-tenant boundary leak this fix closes.
+ */
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { _resetPool, type InternalPool } from "@atlas/api/lib/db/internal";
+
+// ── Mocks: everything EXCEPT ../group-resolve ────────────────────────
+
+const mockGetScheduledTask = mock(() =>
+  Promise.resolve({
+    ok: true,
+    data: {
+      id: "task-1",
+      ownerId: "user-1",
+      orgId: "org-1",
+      connectionId: null,
+      connectionGroupId: "g_prod",
+      question: "What is revenue?",
+      recipients: [],
+      deliveryChannel: "webhook",
+    },
+  }),
+);
+const mockUpdateRunDeliveryStatus = mock((): void => {});
+
+mock.module("@atlas/api/lib/scheduled-tasks", () => ({
+  getScheduledTask: mockGetScheduledTask,
+  updateRunDeliveryStatus: mockUpdateRunDeliveryStatus,
+  getTasksDueForExecution: mock(() => Promise.resolve([])),
+  lockTaskForExecution: mock(() => Promise.resolve(true)),
+  createTaskRun: mock(() => Promise.resolve("run-1")),
+  completeTaskRun: mock(() => {}),
+  computeNextRun: mock(() => null),
+  validateCronExpression: mock(() => ({ valid: true })),
+  listScheduledTasks: mock(() => Promise.resolve({ tasks: [], total: 0 })),
+  updateScheduledTask: mock(() => Promise.resolve({ ok: true })),
+  deleteScheduledTask: mock(() => Promise.resolve({ ok: true })),
+  listTaskRuns: mock(() => Promise.resolve([])),
+  listAllRuns: mock(() => Promise.resolve({ runs: [], total: 0 })),
+  _resetScheduledTasksForTest: mock(() => {}),
+}));
+
+type ActorUserLike = {
+  id: string;
+  mode: "managed";
+  label: string;
+  role: "admin";
+  activeOrganizationId: string;
+};
+const mockLoadActorUser = mock<(userId: string, orgId: string | null) => Promise<ActorUserLike | null>>(() =>
+  Promise.resolve({
+    id: "user-1",
+    mode: "managed",
+    label: "user-1@example.com",
+    role: "admin",
+    activeOrganizationId: "org-1",
+  }),
+);
+mock.module("@atlas/api/lib/auth/actor", () => ({
+  loadActorUser: mockLoadActorUser,
+  botActorUser: mock(() => ({ id: "bot", mode: "simple-key", label: "bot" })),
+}));
+
+// Agent + delivery are mocked purely so we can assert NOT-called.
+const mockExecuteAgentQuery = mock(() => Promise.resolve({
+  answer: "should never run",
+  sql: [],
+  data: [],
+  steps: 0,
+  usage: { totalTokens: 0 },
+}));
+mock.module("@atlas/api/lib/agent-query", () => ({
+  executeAgentQuery: mockExecuteAgentQuery,
+}));
+
+const mockDeliverResult = mock(() =>
+  Promise.resolve({ attempted: 0, succeeded: 0, failed: 0 }),
+);
+mock.module("../delivery", () => ({
+  deliverResult: mockDeliverResult,
+}));
+
+// NOTE: ../group-resolve intentionally NOT mocked.
+
+// ── Mock internal pool — captures every SQL call ─────────────────────
+
+interface CapturedQuery {
+  readonly sql: string;
+  readonly params?: unknown[];
+}
+
+let queryCalls: CapturedQuery[] = [];
+let queryResults: Array<{ rows: Record<string, unknown>[] }> = [];
+let queryResultIndex = 0;
+
+const mockPool: InternalPool = {
+  query: async (sql: string, params?: unknown[]) => {
+    queryCalls.push({ sql, params });
+    const result = queryResults[queryResultIndex] ?? { rows: [] };
+    queryResultIndex++;
+    return result;
+  },
+  async connect() {
+    return { query: async () => ({ rows: [] }), release() {} };
+  },
+  end: async () => {},
+  on: () => {},
+};
+
+const origDbUrl = process.env.DATABASE_URL;
+
+const { executeScheduledTask } = await import("../executor");
+
+beforeEach(() => {
+  queryCalls = [];
+  queryResults = [];
+  queryResultIndex = 0;
+  process.env.DATABASE_URL = "postgresql://test:test@localhost:5432/test";
+  _resetPool(mockPool);
+
+  mockGetScheduledTask.mockReset();
+  mockGetScheduledTask.mockResolvedValue({
+    ok: true,
+    data: {
+      id: "task-1",
+      ownerId: "user-1",
+      orgId: "org-1",
+      connectionId: null,
+      connectionGroupId: "g_prod",
+      question: "What is revenue?",
+      recipients: [],
+      deliveryChannel: "webhook",
+    },
+  });
+
+  mockLoadActorUser.mockReset();
+  mockLoadActorUser.mockResolvedValue({
+    id: "user-1",
+    mode: "managed",
+    label: "user-1@example.com",
+    role: "admin",
+    activeOrganizationId: "org-1",
+  });
+
+  mockExecuteAgentQuery.mockReset();
+  mockDeliverResult.mockReset();
+  mockUpdateRunDeliveryStatus.mockReset();
+});
+
+afterEach(() => {
+  if (origDbUrl) process.env.DATABASE_URL = origDbUrl;
+  else delete process.env.DATABASE_URL;
+  _resetPool(null);
+});
+
+describe("executor — empty connection group (#2416)", () => {
+  it("when the tenant's group has zero non-archived members, the executor throws WITHOUT firing the agent and WITHOUT crossing into __global__", async () => {
+    // Real loadScheduledTaskGroupSnapshot runs against this mock pool.
+    // First query: connection_groups row exists (tenant owns the group).
+    // Second query: zero non-archived members (every connection archived).
+    queryResults = [
+      { rows: [{ primary_connection_id: null }] },
+      { rows: [] },
+    ];
+    queryResultIndex = 0;
+
+    await expect(executeScheduledTask("task-1", "run-1", 30_000)).rejects.toThrow(
+      /no non-archived members/i,
+    );
+
+    // The agent must NOT have been invoked. This is the multi-tenant
+    // isolation guarantee — pre-#2416 the executor would silently fire
+    // the agent against a __global__ connection here.
+    expect(mockExecuteAgentQuery).not.toHaveBeenCalled();
+    expect(mockDeliverResult).not.toHaveBeenCalled();
+    expect(mockUpdateRunDeliveryStatus).not.toHaveBeenCalled();
+
+    // Real SQL path was exercised — exactly the two scoped queries ran
+    // (group row + member rows), both bound to org-1, never __global__.
+    expect(queryCalls.length).toBe(2);
+    for (const call of queryCalls) {
+      expect(call.params).toContain("org-1");
+      expect(call.params).not.toContain("__global__");
+      expect(call.sql).not.toContain("'__global__'");
+    }
+  });
+});

--- a/packages/api/src/lib/scheduler/__tests__/executor.test.ts
+++ b/packages/api/src/lib/scheduler/__tests__/executor.test.ts
@@ -111,6 +111,7 @@ const mockResolveScheduledTaskConnection = mock(() => Promise.resolve("resolved-
 // empty-group path — `executor.empty-group.test.ts` covers that against
 // the real group-resolve module.
 class NoScheduledTaskGroupMembersErrorStub extends Error {
+  override readonly name = "NoScheduledTaskGroupMembersError";
   readonly groupId: string;
   readonly orgId: string | null;
   constructor(groupId: string, orgId: string | null) {

--- a/packages/api/src/lib/scheduler/__tests__/executor.test.ts
+++ b/packages/api/src/lib/scheduler/__tests__/executor.test.ts
@@ -105,8 +105,24 @@ mock.module("../delivery", () => ({
 
 const mockResolveScheduledTaskConnection = mock(() => Promise.resolve("resolved-connection"));
 
+// Stub mirrors the real error class so executor.ts's
+// `err instanceof NoScheduledTaskGroupMembersError` check stays compilable
+// under the mocked module. None of the tests in this file exercise the
+// empty-group path — `executor.empty-group.test.ts` covers that against
+// the real group-resolve module.
+class NoScheduledTaskGroupMembersErrorStub extends Error {
+  readonly groupId: string;
+  readonly orgId: string | null;
+  constructor(groupId: string, orgId: string | null) {
+    super(`stub: group ${groupId} (org=${orgId ?? "__global__"}) empty`);
+    this.groupId = groupId;
+    this.orgId = orgId;
+  }
+}
+
 mock.module("../group-resolve", () => ({
   resolveScheduledTaskConnection: mockResolveScheduledTaskConnection,
+  NoScheduledTaskGroupMembersError: NoScheduledTaskGroupMembersErrorStub,
 }));
 
 const { executeScheduledTask } = await import("../executor");

--- a/packages/api/src/lib/scheduler/__tests__/group-resolve.test.ts
+++ b/packages/api/src/lib/scheduler/__tests__/group-resolve.test.ts
@@ -1,6 +1,9 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { _resetPool, type InternalPool } from "@atlas/api/lib/db/internal";
 import {
   NoScheduledTaskGroupMembersError,
+  loadScheduledTaskGroupSnapshot,
+  resolveScheduledTaskConnection,
   selectScheduledTaskGroupMember,
   type SchedulerGroupSnapshot,
 } from "../group-resolve";
@@ -71,5 +74,210 @@ describe("selectScheduledTaskGroupMember", () => {
         members: [],
       }),
     ).toThrow(NoScheduledTaskGroupMembersError);
+  });
+});
+
+// ── SQL-path coverage (#2416) ────────────────────────────────────────
+//
+// The in-memory picker tests above don't exercise loadScheduledTaskGroupSnapshot —
+// the function that actually issues SQL through internalQuery. PR #2398 shipped a
+// cross-org fallback there (silently widening the org filter to '__global__'
+// when a tenant's group had zero non-archived members) that no test caught
+// because the only callers in tests mocked the SQL-touching function away.
+// These tests run the real SQL builder against a captured mock pool so we can
+// assert tenant isolation: NO __global__ parameter ever flows to the DB for a
+// tenant caller, regardless of group/member state.
+
+interface CapturedQuery {
+  readonly sql: string;
+  readonly params?: unknown[];
+}
+
+let queryCalls: CapturedQuery[] = [];
+let queryResults: Array<{ rows: Record<string, unknown>[] }> = [];
+let queryResultIndex = 0;
+
+const mockPool: InternalPool = {
+  query: async (sql: string, params?: unknown[]) => {
+    queryCalls.push({ sql, params });
+    const result = queryResults[queryResultIndex] ?? { rows: [] };
+    queryResultIndex++;
+    return result;
+  },
+  async connect() {
+    return { query: async () => ({ rows: [] }), release() {} };
+  },
+  end: async () => {},
+  on: () => {},
+};
+
+function enableInternalDB(): void {
+  process.env.DATABASE_URL = "postgresql://test:test@localhost:5432/test";
+  _resetPool(mockPool);
+}
+
+function setResults(...results: Array<{ rows: Record<string, unknown>[] }>): void {
+  queryResults = results;
+  queryResultIndex = 0;
+}
+
+const origDbUrl = process.env.DATABASE_URL;
+
+describe("loadScheduledTaskGroupSnapshot (SQL path)", () => {
+  beforeEach(() => {
+    queryCalls = [];
+    queryResults = [];
+    queryResultIndex = 0;
+    delete process.env.DATABASE_URL;
+    _resetPool(null);
+  });
+
+  afterEach(() => {
+    if (origDbUrl) process.env.DATABASE_URL = origDbUrl;
+    else delete process.env.DATABASE_URL;
+    _resetPool(null);
+  });
+
+  it("returns null when no internal DB is configured", async () => {
+    const snap = await loadScheduledTaskGroupSnapshot("g_prod", "org-1");
+    expect(snap).toBeNull();
+    expect(queryCalls.length).toBe(0);
+  });
+
+  it("returns a snapshot with all non-archived members for a tenant group", async () => {
+    enableInternalDB();
+    setResults(
+      { rows: [{ primary_connection_id: "us-int" }] },
+      {
+        rows: [
+          { id: "us-int", created_at: "2026-04-01T00:00:00Z" },
+          { id: "eu", created_at: "2026-04-15T00:00:00Z" },
+        ],
+      },
+    );
+
+    const snap = await loadScheduledTaskGroupSnapshot("g_prod", "org-1");
+    expect(snap).not.toBeNull();
+    expect(snap!.orgId).toBe("org-1");
+    expect(snap!.primaryConnectionId).toBe("us-int");
+    expect(snap!.members.map((m) => m.id)).toEqual(["us-int", "eu"]);
+
+    // Every query must scope to the tenant org. NO __global__ widening.
+    expect(queryCalls.length).toBe(2);
+    for (const call of queryCalls) {
+      expect(call.params).toContain("org-1");
+      expect(call.params).not.toContain("__global__");
+      expect(call.sql).not.toContain("'__global__'");
+    }
+  });
+
+  it("returns an empty-members snapshot when a tenant's group has zero non-archived members — does NOT cross into __global__", async () => {
+    enableInternalDB();
+    setResults(
+      { rows: [{ primary_connection_id: null }] },
+      { rows: [] }, // every member archived in this tenant
+    );
+
+    const snap = await loadScheduledTaskGroupSnapshot("g_prod", "org-1");
+    expect(snap).not.toBeNull();
+    expect(snap!.orgId).toBe("org-1");
+    expect(snap!.members).toEqual([]);
+
+    // Critical multi-tenant isolation check: only the two scoped queries
+    // ran. The previous code path issued an additional Promise.all of
+    // __global__-bound queries here — those must NOT execute.
+    expect(queryCalls.length).toBe(2);
+    for (const call of queryCalls) {
+      expect(call.params).not.toContain("__global__");
+      expect(call.sql).not.toContain("'__global__'");
+    }
+  });
+
+  it("selectScheduledTaskGroupMember on an empty-members snapshot throws NoScheduledTaskGroupMembersError", async () => {
+    enableInternalDB();
+    setResults(
+      { rows: [{ primary_connection_id: null }] },
+      { rows: [] },
+    );
+
+    const snap = await loadScheduledTaskGroupSnapshot("g_prod", "org-1");
+    expect(snap).not.toBeNull();
+    expect(() => selectScheduledTaskGroupMember(snap!)).toThrow(NoScheduledTaskGroupMembersError);
+  });
+
+  it("resolveScheduledTaskConnection throws NoScheduledTaskGroupMembersError when the tenant's group is empty (no __global__ peek)", async () => {
+    enableInternalDB();
+    setResults(
+      { rows: [{ primary_connection_id: null }] },
+      { rows: [] },
+    );
+
+    let captured: unknown = null;
+    try {
+      await resolveScheduledTaskConnection({
+        taskId: "task-1",
+        orgId: "org-1",
+        connectionGroupId: "g_prod",
+      });
+    } catch (err) {
+      captured = err;
+    }
+    expect(captured).toBeInstanceOf(NoScheduledTaskGroupMembersError);
+    expect(queryCalls.length).toBe(2);
+    for (const call of queryCalls) {
+      expect(call.params).not.toContain("__global__");
+    }
+  });
+
+  it("falls back to first-member (created_at ASC, id ASC) when primary_connection_id is null — in-org fallback", async () => {
+    enableInternalDB();
+    setResults(
+      { rows: [{ primary_connection_id: null }] },
+      {
+        rows: [
+          { id: "us-int", created_at: "2026-04-01T00:00:00Z" },
+          { id: "eu", created_at: "2026-04-15T00:00:00Z" },
+        ],
+      },
+    );
+
+    const resolved = await resolveScheduledTaskConnection({
+      taskId: "task-1",
+      orgId: "org-1",
+      connectionGroupId: "g_prod",
+    });
+    expect(resolved).toBe("us-int");
+
+    for (const call of queryCalls) {
+      expect(call.params).toContain("org-1");
+      expect(call.params).not.toContain("__global__");
+    }
+  });
+
+  it("__global__ caller (orgId = null) reads __global__ group rows directly — the legitimate path", async () => {
+    enableInternalDB();
+    setResults(
+      { rows: [{ primary_connection_id: "g-conn" }] },
+      { rows: [{ id: "g-conn", created_at: "2026-04-01T00:00:00Z" }] },
+    );
+
+    const snap = await loadScheduledTaskGroupSnapshot("g_global", null);
+    expect(snap).not.toBeNull();
+    expect(snap!.orgId).toBeNull();
+    expect(snap!.members.map((m) => m.id)).toEqual(["g-conn"]);
+    expect(queryCalls.length).toBe(2);
+    for (const call of queryCalls) {
+      expect(call.params).toContain("__global__");
+    }
+  });
+
+  it("returns null when the group does not exist for this org — no cross-org peek", async () => {
+    enableInternalDB();
+    setResults({ rows: [] });
+
+    const snap = await loadScheduledTaskGroupSnapshot("g_missing", "org-1");
+    expect(snap).toBeNull();
+    expect(queryCalls.length).toBe(1);
+    expect(queryCalls[0].params).not.toContain("__global__");
   });
 });

--- a/packages/api/src/lib/scheduler/__tests__/group-resolve.test.ts
+++ b/packages/api/src/lib/scheduler/__tests__/group-resolve.test.ts
@@ -80,13 +80,13 @@ describe("selectScheduledTaskGroupMember", () => {
 // ── SQL-path coverage (#2416) ────────────────────────────────────────
 //
 // The in-memory picker tests above don't exercise loadScheduledTaskGroupSnapshot —
-// the function that actually issues SQL through internalQuery. PR #2398 shipped a
-// cross-org fallback there (silently widening the org filter to '__global__'
-// when a tenant's group had zero non-archived members) that no test caught
-// because the only callers in tests mocked the SQL-touching function away.
-// These tests run the real SQL builder against a captured mock pool so we can
-// assert tenant isolation: NO __global__ parameter ever flows to the DB for a
-// tenant caller, regardless of group/member state.
+// the function that issues SQL through internalQuery. An earlier cross-org
+// fallback widened the org filter to '__global__' when a tenant's group had
+// zero non-archived members; no test caught it because callers mocked the
+// SQL-touching function away. These tests run the real SQL builder against a
+// captured mock pool so tenant isolation is asserted on actual SQL: NO
+// __global__ parameter ever flows to the DB for a tenant caller, regardless
+// of group/member state.
 
 interface CapturedQuery {
   readonly sql: string;
@@ -183,9 +183,7 @@ describe("loadScheduledTaskGroupSnapshot (SQL path)", () => {
     expect(snap!.orgId).toBe("org-1");
     expect(snap!.members).toEqual([]);
 
-    // Critical multi-tenant isolation check: only the two scoped queries
-    // ran. The previous code path issued an additional Promise.all of
-    // __global__-bound queries here — those must NOT execute.
+    // Tenant isolation check: exactly two scoped queries — no __global__ peek.
     expect(queryCalls.length).toBe(2);
     for (const call of queryCalls) {
       expect(call.params).not.toContain("__global__");
@@ -264,6 +262,28 @@ describe("loadScheduledTaskGroupSnapshot (SQL path)", () => {
     const snap = await loadScheduledTaskGroupSnapshot("g_global", null);
     expect(snap).not.toBeNull();
     expect(snap!.orgId).toBeNull();
+    expect(snap!.members.map((m) => m.id)).toEqual(["g-conn"]);
+    expect(queryCalls.length).toBe(2);
+    for (const call of queryCalls) {
+      expect(call.params).toContain("__global__");
+    }
+  });
+
+  it("__global__ caller passing the literal string is identical to passing null", async () => {
+    // Production code coalesces orgId via `orgId ?? "__global__"`, so a
+    // caller that already holds the literal "__global__" string flows through
+    // the same SQL as a null caller. Asserting both shapes match prevents a
+    // future refactor (e.g. replacing the ?? with a strict null check) from
+    // silently splitting the global-org path in two.
+    enableInternalDB();
+    setResults(
+      { rows: [{ primary_connection_id: "g-conn" }] },
+      { rows: [{ id: "g-conn", created_at: "2026-04-01T00:00:00Z" }] },
+    );
+
+    const snap = await loadScheduledTaskGroupSnapshot("g_global", "__global__");
+    expect(snap).not.toBeNull();
+    expect(snap!.orgId).toBe("__global__");
     expect(snap!.members.map((m) => m.id)).toEqual(["g-conn"]);
     expect(queryCalls.length).toBe(2);
     for (const call of queryCalls) {

--- a/packages/api/src/lib/scheduler/executor.ts
+++ b/packages/api/src/lib/scheduler/executor.ts
@@ -25,7 +25,7 @@ import { loadActorUser } from "@atlas/api/lib/auth/actor";
 import { SchedulerTaskTimeoutError, SchedulerExecutionError } from "@atlas/api/lib/effect/errors";
 import { causeToError } from "@atlas/api/lib/audit/error-scrub";
 import { deliverResult } from "./delivery";
-import { resolveScheduledTaskConnection } from "./group-resolve";
+import { NoScheduledTaskGroupMembersError, resolveScheduledTaskConnection } from "./group-resolve";
 
 const log = createLogger("scheduler-executor");
 
@@ -106,11 +106,37 @@ export async function executeScheduledTask(
 
   const task = taskResult.data;
   const requestId = `sched-${taskId}-${runId}`;
-  const resolvedConnectionId = await resolveScheduledTaskConnection({
-    taskId,
-    orgId: task.orgId,
-    connectionGroupId: task.connectionGroupId,
-  });
+  let resolvedConnectionId: string | null;
+  try {
+    resolvedConnectionId = await resolveScheduledTaskConnection({
+      taskId,
+      orgId: task.orgId,
+      connectionGroupId: task.connectionGroupId,
+    });
+  } catch (err) {
+    // #2416 — when the tenant's group has zero non-archived members,
+    // group-resolve refuses to widen the org filter into __global__.
+    // Skip the tick (don't fire the agent blind) and surface a clear
+    // run-row error. The next admin action — add a member, archive the
+    // task, or unarchive a member — recovers automatically.
+    if (err instanceof NoScheduledTaskGroupMembersError) {
+      log.warn(
+        {
+          taskId,
+          runId,
+          groupId: err.groupId,
+          orgId: err.orgId,
+        },
+        "Scheduled task group has no non-archived members — skipping tick",
+      );
+      throw new Error(
+        `Connection group ${err.groupId} has no non-archived members. ` +
+          `Add a connection to the group or unarchive an existing member before this task can run.`,
+        { cause: err },
+      );
+    }
+    throw err;
+  }
 
   // F-54: resolve the task creator so approval rules apply. If the user no
   // longer exists (account deleted, removed from org), fail-loud rather than

--- a/packages/api/src/lib/scheduler/group-resolve.ts
+++ b/packages/api/src/lib/scheduler/group-resolve.ts
@@ -73,9 +73,9 @@ export async function loadScheduledTaskGroupSnapshot(
       [groupId, orgId ?? "__global__"],
     );
     if (groupRows.length === 0) return null;
-    let primaryConnectionId = groupRows[0]?.primary_connection_id ?? null;
+    const primaryConnectionId = groupRows[0]?.primary_connection_id ?? null;
 
-    let memberRows = await internalQuery<{ id: string; created_at: Date | string }>(
+    const memberRows = await internalQuery<{ id: string; created_at: Date | string }>(
       `SELECT id, created_at
          FROM connections
         WHERE group_id = $1
@@ -84,29 +84,14 @@ export async function loadScheduledTaskGroupSnapshot(
         ORDER BY created_at ASC, id ASC`,
       [groupId, orgId ?? "__global__"],
     );
-    if (memberRows.length === 0 && orgId !== null && orgId !== "__global__") {
-      const globalRows = await Promise.all([
-        primaryConnectionId === null
-          ? internalQuery<{ primary_connection_id: string | null }>(
-            `SELECT primary_connection_id
-               FROM connection_groups
-              WHERE id = $1 AND org_id = '__global__'`,
-            [groupId],
-          )
-          : Promise.resolve([]),
-        internalQuery<{ id: string; created_at: Date | string }>(
-          `SELECT id, created_at
-           FROM connections
-          WHERE group_id = $1
-            AND org_id = '__global__'
-            AND status != 'archived'
-          ORDER BY created_at ASC, id ASC`,
-          [groupId],
-        ),
-      ]);
-      primaryConnectionId = primaryConnectionId ?? globalRows[0][0]?.primary_connection_id ?? null;
-      memberRows = globalRows[1];
-    }
+    // #2416 — previously this point widened the org filter to '__global__'
+    // when a tenant's group had zero non-archived members. That silently
+    // crossed a tenant→__global__ boundary and could fire the next scheduler
+    // tick against a connection the tenant doesn't own. The contract is
+    // strictly in-org: an empty member set surfaces upstream as
+    // NoScheduledTaskGroupMembersError so the executor can log + skip the
+    // tick. The next admin action (add a member, archive the task, or
+    // unarchive a member) recovers.
 
     return {
       groupId,


### PR DESCRIPTION
## Summary

Closes #2416. Tracker: #2407.

Closes the multi-tenant isolation hole introduced by PR #2398 (Codex-authored slice for #2343). `loadScheduledTaskGroupSnapshot` previously fell back to reading members AND `primary_connection_id` from the `__global__` org whenever a tenant's group had zero non-archived members. The acceptance criteria in #2343 specified *"missing primary → first member"* as the fallback — not *"cross the org boundary into the global pool."* If a tenant archived every connection in a group, the next scheduler tick would fire against a `__global__` connection the tenant might not own.

The SQL-touching path had zero test coverage — `executor.test.ts` mocked the whole `../group-resolve` module out, and `group-resolve.test.ts` only exercised the in-memory `selectScheduledTaskGroupMember` picker.

## Changes

- **`packages/api/src/lib/scheduler/group-resolve.ts`** — removed the `if (memberRows.length === 0 && orgId !== null && orgId !== '__global__') { ... }` block. Empty membership now surfaces as `NoScheduledTaskGroupMembersError` (the typed error already thrown by `selectScheduledTaskGroupMember`).
- **`packages/api/src/lib/scheduler/executor.ts`** — wraps `resolveScheduledTaskConnection` in a try/catch. On `NoScheduledTaskGroupMembersError`, logs warn with `taskId` + `runId` + `groupId` + `orgId`, then re-throws with an actionable message so `engine.ts` records the run as failed without firing the agent. The next admin action (add a member, archive the task, unarchive a member) recovers automatically.
- **`packages/api/src/lib/scheduler/__tests__/group-resolve.test.ts`** — adds real SQL-path coverage via the `_resetPool` mock-pool pattern (matches the established `conversations-group-routing.test.ts` style). Every test asserts no `__global__` parameter flows to SQL for a tenant caller. Covers: tenant N-member case, tenant zero-member case (the critical isolation assertion), missing primary in-org fallback, `__global__` caller (legitimate path), missing group returns `null`.
- **`packages/api/src/lib/scheduler/__tests__/executor.empty-group.test.ts`** *(new file)* — runs the executor against the REAL `loadScheduledTaskGroupSnapshot` (not a module-mocked stub). `mock.module()` is file-scoped in `bun:test`, so the only honest way to "drop the mock for one new test" is a sibling file. Asserts: agent NOT called, delivery NOT called, no `__global__` SQL issued.
- **`packages/api/src/lib/scheduler/__tests__/executor.test.ts`** — adds a stub `NoScheduledTaskGroupMembersError` to the `../group-resolve` mock to satisfy executor's new import (per CLAUDE.md "Mock all exports").

## Why no feature flag

The cross-org fallback was wrong on its face (per the acceptance criteria) and uncovered by any test. Keeping it behind a kill switch would just delay the cleanup — the right fix is to remove it now and let the typed error path surface the empty-group state to operators honestly.

## Test plan

- [x] `bun run scripts/test-isolated.ts --affected` — scheduler tests all green (group-resolve, executor, executor.empty-group, engine).
- [x] `bun run test` — full suite green.
- [x] `bun run lint` — 0 errors.
- [x] `bun run type` — 0 errors.
- [x] `bun x syncpack lint` — no issues.
- [x] Template drift, security-headers drift, railway-watch, schema drift, oauth-helper drift — all pass.

## Multi-tenant isolation assertion

Every new test in `group-resolve.test.ts` and the new `executor.empty-group.test.ts` asserts that for a tenant caller (`orgId !== null && orgId !== '__global__'`):
- No SQL parameter equals `'__global__'`.
- No SQL string contains the literal `'__global__'`.

This is verified at the captured-pool level, not by mocking the function's return value — exactly the production code path runs, and we observe its DB calls.