### PR TITLE
fix(api): env-delete also drops url='' tombstones (#2410)

### DIFF
--- a/packages/api/src/api/routes/admin-connection-groups.ts
+++ b/packages/api/src/api/routes/admin-connection-groups.ts
@@ -17,6 +17,7 @@ import { createLogger } from "@atlas/api/lib/logger";
 import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
 import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
 import { internalQuery } from "@atlas/api/lib/db/internal";
+import { DELETE_GROUP_AND_ARCHIVED_CONNECTIONS_SQL } from "@atlas/api/lib/db/connection-groups-sql";
 import { runHandler } from "@atlas/api/lib/effect/hono";
 import { ErrorSchema, AuthErrorSchema } from "./shared-schemas";
 import { createAdminRouter, requireOrgContext, requirePermission } from "./admin-router";
@@ -588,48 +589,59 @@ adminConnectionGroups.openapi(deleteGroupRoute, async (c) =>
     }
 
     try {
-      // Drop BOTH archived shapes in the same CTE before the group
-      // delete fires, otherwise the FK still blocks (23503) and the
-      // user has no recovery path — admin pages exclude archived rows
-      // entirely so tombstones aren't surfaceable.
+      // Atomic env-delete: clear every archived connection in the
+      // group, then drop the group. Both archived shapes must go,
+      // otherwise the FK blocks the group delete (23503) and the user
+      // has no recovery path — admin pages exclude `status = 'archived'`
+      // entirely, so tombstones aren't surfaceable.
       //
-      //   1. `url <> ''` — org-owned connection that the admin archived
-      //      in place via `admin-connections.ts` (DELETE /:id, ownRow
-      //      branch). The URL is the original encrypted value; the
-      //      status flip is the only difference. Real deletion is fine
-      //      because the row is org-scoped and the user explicitly
-      //      asked to drop its environment.
+      //   1. real archived row — org-owned connection the admin
+      //      archived in place via the `ownRow` branch of
+      //      `admin-connections.ts` DELETE /:id. URL stays the original
+      //      encrypted value; only the status flipped. Deleting is
+      //      safe because the row is org-scoped and the user
+      //      explicitly asked to drop the environment.
       //
-      //   2. `url = ''` — per-org `__global__` tombstone created by
-      //      the global-hide branch of `admin-connections.ts` DELETE
-      //      (line 1029). The empty URL is a marker that suppresses
-      //      the global row from this org's lists. Deleting the
-      //      tombstone here re-exposes the underlying global to this
-      //      org — that's the correct outcome when the operator is
-      //      explicitly tearing down the environment that owned it.
+      //   2. `url = ''` tombstone — per-org `__global__` hide row
+      //      written by the non-`ownRow` branch of
+      //      `admin-connections.ts` DELETE /:id. The empty URL is a
+      //      marker that suppresses the global from this org's lists.
+      //      Deleting it here re-exposes the underlying global to this
+      //      org — the correct outcome when the operator is explicitly
+      //      tearing down the environment that owned the hide.
       //
-      // #2410 is the third pass at this bug (#2405 added the archived
-      // delete; #2406 added the `url <> ''` filter to preserve
-      // tombstones outside env-delete). Inside env-delete, both shapes
-      // must go — keep this CTE in lockstep with any future archived-
-      // row shape we introduce.
-      await internalQuery(
-        `WITH deleted_archived_connections AS (
-           DELETE FROM connections
-            WHERE group_id = $1
-              AND org_id = $2
-              AND status = 'archived'
-           RETURNING id
-         )
-         DELETE FROM connection_groups WHERE id = $1 AND org_id = $2`,
-        [id, orgId],
-      );
+      // The canonical SQL lives in `lib/db/connection-groups-sql.ts`
+      // and is imported by the real-Postgres regression test so the
+      // route and the test cannot drift apart. #2410 is the third pass
+      // at this bug (#2405 added the cascading archived delete; #2406
+      // tightened it to `url <> ''` to preserve tombstones *outside*
+      // env-delete — which is still correct everywhere except inside
+      // env-delete itself). Keep this CTE in lockstep with any future
+      // archived-row shape we introduce.
+      await internalQuery(DELETE_GROUP_AND_ARCHIVED_CONNECTIONS_SQL, [id, orgId]);
     } catch (err) {
       const meta = pgErrorMeta(err);
       if (meta.code === "23503") {
+        // Post-#2410 the CTE drops every archived row, so the only
+        // residual paths to a 23503 are (a) a TOCTOU race with another
+        // admin inserting an active row into the group between the
+        // member-count check and the CTE, or (b) inward FKs from
+        // workspace content tables (approvals, scheduled_tasks,
+        // dashboards, semantic entities). Log the constraint name so
+        // ops can tell those apart without reproducing the failure —
+        // the user-facing 409 message is identical in (b).
+        log.warn(
+          {
+            requestId,
+            orgId,
+            groupId: id,
+            constraint: meta.constraint,
+          },
+          "Connection group delete blocked by FK (23503) — mapping to 409",
+        );
         const message = meta.constraint === CONNECTIONS_GROUP_FK
-          ? `Group "${id}" is still referenced by hidden connection rows. Restore or unhide those connections before deleting it.`
-          : `Group "${id}" is still referenced by workspace content. Remove or update those references before deleting it.`;
+          ? `Group "${id}" still has connection rows attached — another admin may have added one while you were deleting. Refresh and try again.`
+          : `Group "${id}" is still referenced by workspace content (approvals, scheduled tasks, dashboards, semantic entities). Remove or update those references before deleting it.`;
         return c.json(
           {
             error: "conflict",

--- a/packages/api/src/api/routes/admin-connection-groups.ts
+++ b/packages/api/src/api/routes/admin-connection-groups.ts
@@ -588,13 +588,37 @@ adminConnectionGroups.openapi(deleteGroupRoute, async (c) =>
     }
 
     try {
+      // Drop BOTH archived shapes in the same CTE before the group
+      // delete fires, otherwise the FK still blocks (23503) and the
+      // user has no recovery path — admin pages exclude archived rows
+      // entirely so tombstones aren't surfaceable.
+      //
+      //   1. `url <> ''` — org-owned connection that the admin archived
+      //      in place via `admin-connections.ts` (DELETE /:id, ownRow
+      //      branch). The URL is the original encrypted value; the
+      //      status flip is the only difference. Real deletion is fine
+      //      because the row is org-scoped and the user explicitly
+      //      asked to drop its environment.
+      //
+      //   2. `url = ''` — per-org `__global__` tombstone created by
+      //      the global-hide branch of `admin-connections.ts` DELETE
+      //      (line 1029). The empty URL is a marker that suppresses
+      //      the global row from this org's lists. Deleting the
+      //      tombstone here re-exposes the underlying global to this
+      //      org — that's the correct outcome when the operator is
+      //      explicitly tearing down the environment that owned it.
+      //
+      // #2410 is the third pass at this bug (#2405 added the archived
+      // delete; #2406 added the `url <> ''` filter to preserve
+      // tombstones outside env-delete). Inside env-delete, both shapes
+      // must go — keep this CTE in lockstep with any future archived-
+      // row shape we introduce.
       await internalQuery(
         `WITH deleted_archived_connections AS (
            DELETE FROM connections
             WHERE group_id = $1
               AND org_id = $2
               AND status = 'archived'
-              AND url <> ''
            RETURNING id
          )
          DELETE FROM connection_groups WHERE id = $1 AND org_id = $2`,

--- a/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
@@ -355,6 +355,83 @@ describeIfPg("migrate-pg (real Postgres)", () => {
     expect(rows.length).toBe(0);
   }, PG_TEST_TIMEOUT_MS);
 
+  // #2410 — env-delete CTE must drop both archived shapes. Reproduces
+  // the third-pass failure: PR #2405 added the cascading archived
+  // delete, PR #2406 tightened it to `url <> ''` to preserve global-hide
+  // tombstones (which it succeeded at — outside env-delete), but the
+  // env-delete path itself then 23503'd whenever the group contained a
+  // `url = ''` tombstone. The shape mirrors the per-org `__global__`
+  // hide INSERT at `admin-connections.ts:1022-1033`.
+  it("connections.group_id: env-delete CTE drops both archived shapes (#2410)", async () => {
+    const orgId = `org-tomb-${Date.now()}`;
+    const groupId = `g-tomb-${Date.now()}`;
+    const archivedOwnedConnId = `conn-archived-${Date.now()}`;
+    const tombstoneConnId = `conn-tomb-${Date.now()}`;
+
+    await pool.query(
+      `INSERT INTO connection_groups (id, org_id, name) VALUES ($1, $2, 'tombstone-env')`,
+      [groupId, orgId],
+    );
+
+    // Shape 1: archived in-place — org-owned row, real encrypted URL,
+    // `status = 'archived'`. This is what `admin-connections.ts:1009`
+    // produces when the admin deletes an org-owned connection.
+    await pool.query(
+      `INSERT INTO connections (id, url, type, org_id, status, group_id)
+       VALUES ($1, 'enc:v1:iv:tag:ciphertext', 'postgres', $2, 'archived', $3)`,
+      [archivedOwnedConnId, orgId, groupId],
+    );
+
+    // Shape 2: per-org `__global__` tombstone — `url = ''`,
+    // `status = 'archived'`, non-null `group_id`. This is what
+    // `admin-connections.ts:1022-1033` produces when the admin hides a
+    // global connection. Pre-fix the env-delete CTE filtered `url <> ''`,
+    // so this row stayed put and the trailing `DELETE FROM connection_groups`
+    // 23503'd against the connections_group_id FK.
+    await pool.query(
+      `INSERT INTO connections (id, url, url_key_version, type, description, org_id, status, group_id)
+       VALUES ($1, '', 1, 'postgres', 'Hidden from this workspace', $2, 'archived', $3)`,
+      [tombstoneConnId, orgId, groupId],
+    );
+
+    // Sanity: before the CTE, deleting the group directly explodes
+    // with 23503. This pins the failure mode the CTE is preventing.
+    await expect(
+      pool.query(
+        `DELETE FROM connection_groups WHERE id = $1 AND org_id = $2`,
+        [groupId, orgId],
+      ),
+    ).rejects.toMatchObject({ code: "23503" });
+
+    // The fixed CTE — mirrors `admin-connection-groups.ts` DELETE /:id.
+    // No `url <> ''` filter, so both archived shapes are dropped.
+    await pool.query(
+      `WITH deleted_archived_connections AS (
+         DELETE FROM connections
+          WHERE group_id = $1
+            AND org_id = $2
+            AND status = 'archived'
+         RETURNING id
+       )
+       DELETE FROM connection_groups WHERE id = $1 AND org_id = $2`,
+      [groupId, orgId],
+    );
+
+    // Group is gone.
+    const groupRows = await pool.query<{ id: string }>(
+      `SELECT id FROM connection_groups WHERE id = $1 AND org_id = $2`,
+      [groupId, orgId],
+    );
+    expect(groupRows.rows.length).toBe(0);
+
+    // Both archived rows are gone — no orphans, no FK violations.
+    const connRows = await pool.query<{ id: string }>(
+      `SELECT id FROM connections WHERE org_id = $1 AND id IN ($2, $3)`,
+      [orgId, archivedOwnedConnId, tombstoneConnId],
+    );
+    expect(connRows.rows.length).toBe(0);
+  }, PG_TEST_TIMEOUT_MS);
+
   // 0063 — semantic_entities.connection_group_id. Adds the group-scoped
   // natural key the multi-environment semantic layer (#2336 / #2340) lives
   // on. The three partial unique indexes from 0028 are dropped and recreated

--- a/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
@@ -2,6 +2,7 @@ import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import { Pool } from "pg";
 import { runMigrations } from "@atlas/api/lib/db/migrate";
 import { MANAGED_AUTH_MIGRATIONS } from "@atlas/api/lib/db/internal";
+import { DELETE_GROUP_AND_ARCHIVED_CONNECTIONS_SQL } from "@atlas/api/lib/db/connection-groups-sql";
 
 // Real-Postgres migration smoke. Skips cleanly when TEST_DATABASE_URL
 // is unset so local dev that hasn't run `bun run db:up` is unaffected.
@@ -361,7 +362,13 @@ describeIfPg("migrate-pg (real Postgres)", () => {
   // tombstones (which it succeeded at — outside env-delete), but the
   // env-delete path itself then 23503'd whenever the group contained a
   // `url = ''` tombstone. The shape mirrors the per-org `__global__`
-  // hide INSERT at `admin-connections.ts:1022-1033`.
+  // hide INSERT written by the non-`ownRow` branch of
+  // `admin-connections.ts` DELETE /:id.
+  //
+  // Imports `DELETE_GROUP_AND_ARCHIVED_CONNECTIONS_SQL` so this test and
+  // the production route share the same canonical SQL — a regression
+  // that tightens the WHERE clause shows up in both files in the same
+  // diff and can't sneak through.
   it("connections.group_id: env-delete CTE drops both archived shapes (#2410)", async () => {
     const orgId = `org-tomb-${Date.now()}`;
     const groupId = `g-tomb-${Date.now()}`;
@@ -374,8 +381,9 @@ describeIfPg("migrate-pg (real Postgres)", () => {
     );
 
     // Shape 1: archived in-place — org-owned row, real encrypted URL,
-    // `status = 'archived'`. This is what `admin-connections.ts:1009`
-    // produces when the admin deletes an org-owned connection.
+    // `status = 'archived'`. This is what the `ownRow` branch of
+    // `admin-connections.ts` DELETE /:id produces when the admin
+    // deletes an org-owned connection.
     await pool.query(
       `INSERT INTO connections (id, url, type, org_id, status, group_id)
        VALUES ($1, 'enc:v1:iv:tag:ciphertext', 'postgres', $2, 'archived', $3)`,
@@ -383,39 +391,43 @@ describeIfPg("migrate-pg (real Postgres)", () => {
     );
 
     // Shape 2: per-org `__global__` tombstone — `url = ''`,
-    // `status = 'archived'`, non-null `group_id`. This is what
-    // `admin-connections.ts:1022-1033` produces when the admin hides a
-    // global connection. Pre-fix the env-delete CTE filtered `url <> ''`,
-    // so this row stayed put and the trailing `DELETE FROM connection_groups`
-    // 23503'd against the connections_group_id FK.
+    // `status = 'archived'`, non-null `group_id`. This is what the
+    // non-`ownRow` branch of `admin-connections.ts` DELETE /:id
+    // produces when the admin hides a global connection. Pre-fix the
+    // env-delete CTE filtered `url <> ''`, so this row stayed put and
+    // the trailing `DELETE FROM connection_groups` 23503'd against the
+    // connections_group_id FK.
     await pool.query(
       `INSERT INTO connections (id, url, url_key_version, type, description, org_id, status, group_id)
        VALUES ($1, '', 1, 'postgres', 'Hidden from this workspace', $2, 'archived', $3)`,
       [tombstoneConnId, orgId, groupId],
     );
 
-    // Sanity: before the CTE, deleting the group directly explodes
-    // with 23503. This pins the failure mode the CTE is preventing.
+    // Sanity: run the *pre-fix* CTE (with `AND url <> ''`) and confirm
+    // it still 23503s with the tombstone present. This pins the exact
+    // regression mode — not the "raw delete fails" property of the FK
+    // (which has always been true and is already covered above by the
+    // 0062 RESTRICT test). If a future change accidentally tightens
+    // the production CTE again, the positive assertion below would
+    // catch the symptom; this sanity step locks the cause.
     await expect(
       pool.query(
-        `DELETE FROM connection_groups WHERE id = $1 AND org_id = $2`,
+        `WITH deleted_archived_connections AS (
+           DELETE FROM connections
+            WHERE group_id = $1
+              AND org_id = $2
+              AND status = 'archived'
+              AND url <> ''
+           RETURNING id
+         )
+         DELETE FROM connection_groups WHERE id = $1 AND org_id = $2`,
         [groupId, orgId],
       ),
     ).rejects.toMatchObject({ code: "23503" });
 
-    // The fixed CTE — mirrors `admin-connection-groups.ts` DELETE /:id.
-    // No `url <> ''` filter, so both archived shapes are dropped.
-    await pool.query(
-      `WITH deleted_archived_connections AS (
-         DELETE FROM connections
-          WHERE group_id = $1
-            AND org_id = $2
-            AND status = 'archived'
-         RETURNING id
-       )
-       DELETE FROM connection_groups WHERE id = $1 AND org_id = $2`,
-      [groupId, orgId],
-    );
+    // The fixed CTE — imported from the production module so the test
+    // and the route share one source of truth.
+    await pool.query(DELETE_GROUP_AND_ARCHIVED_CONNECTIONS_SQL, [groupId, orgId]);
 
     // Group is gone.
     const groupRows = await pool.query<{ id: string }>(
@@ -428,6 +440,44 @@ describeIfPg("migrate-pg (real Postgres)", () => {
     const connRows = await pool.query<{ id: string }>(
       `SELECT id FROM connections WHERE org_id = $1 AND id IN ($2, $3)`,
       [orgId, archivedOwnedConnId, tombstoneConnId],
+    );
+    expect(connRows.rows.length).toBe(0);
+  }, PG_TEST_TIMEOUT_MS);
+
+  // Adjacent shape: a group whose *only* archived row is a `url = ''`
+  // tombstone. This is the exact production path an admin hits when
+  // they hide a global into a fresh environment and then delete that
+  // environment without ever attaching an org-owned connection. The
+  // CTE handles it because the predicate is `status = 'archived'`, but
+  // a future "optimization" that reinstates `url <> ''` would let the
+  // multi-shape test above still pass on shape 1 while quietly failing
+  // closed on this one. The single-shape variant catches that drift.
+  it("connections.group_id: env-delete CTE drops a tombstone-only group (#2410)", async () => {
+    const orgId = `org-tomb-only-${Date.now()}`;
+    const groupId = `g-tomb-only-${Date.now()}`;
+    const tombstoneConnId = `conn-tomb-only-${Date.now()}`;
+
+    await pool.query(
+      `INSERT INTO connection_groups (id, org_id, name) VALUES ($1, $2, 'tombstone-only-env')`,
+      [groupId, orgId],
+    );
+    await pool.query(
+      `INSERT INTO connections (id, url, url_key_version, type, description, org_id, status, group_id)
+       VALUES ($1, '', 1, 'postgres', 'Hidden from this workspace', $2, 'archived', $3)`,
+      [tombstoneConnId, orgId, groupId],
+    );
+
+    await pool.query(DELETE_GROUP_AND_ARCHIVED_CONNECTIONS_SQL, [groupId, orgId]);
+
+    const groupRows = await pool.query<{ id: string }>(
+      `SELECT id FROM connection_groups WHERE id = $1 AND org_id = $2`,
+      [groupId, orgId],
+    );
+    expect(groupRows.rows.length).toBe(0);
+
+    const connRows = await pool.query<{ id: string }>(
+      `SELECT id FROM connections WHERE org_id = $1 AND id = $2`,
+      [orgId, tombstoneConnId],
     );
     expect(connRows.rows.length).toBe(0);
   }, PG_TEST_TIMEOUT_MS);

--- a/packages/api/src/lib/db/connection-groups-sql.ts
+++ b/packages/api/src/lib/db/connection-groups-sql.ts
@@ -1,0 +1,35 @@
+/**
+ * SQL fragments for connection-group deletion shared between the
+ * `admin-connection-groups` route and the real-Postgres migration smoke
+ * test. Centralised here because the same statement has now caused #2410
+ * three times (#2405 → #2406 → #2410) — drift between route and test was
+ * the root cause of #2410 going unnoticed under the #2406 patch.
+ *
+ * Keeping the canonical SQL here means a regression that re-introduces
+ * a too-tight WHERE clause (e.g. `AND url <> ''`) shows up in *both* the
+ * route and the test in the same diff, so it can't ship green.
+ */
+
+/**
+ * Atomic env-delete SQL: drop every archived connection in the group, then
+ * drop the group itself. Parameters are positional and shared across the
+ * two statements:
+ *   $1 = group id
+ *   $2 = org id
+ *
+ * MUST match `status = 'archived'` unconditionally — both archived shapes
+ * (real org-owned archived rows AND `url = ''` per-org global-hide
+ * tombstones) reference the group via `connections.group_id` and so must
+ * be cleared before `DELETE FROM connection_groups` to avoid a 23503
+ * against the `fk_connections_group` FK.
+ */
+export const DELETE_GROUP_AND_ARCHIVED_CONNECTIONS_SQL = `
+  WITH deleted_archived_connections AS (
+    DELETE FROM connections
+     WHERE group_id = $1
+       AND org_id = $2
+       AND status = 'archived'
+    RETURNING id
+  )
+  DELETE FROM connection_groups WHERE id = $1 AND org_id = $2
+`;


### PR DESCRIPTION
## Summary

- Third pass at the env-delete 23503 bug (#2407 tracker). #2405 added the cascading archived delete; #2406 tightened it to `url <> ''` to preserve global-hide tombstones — but the env-delete path itself still 23503'd against the connections_group_id FK whenever the group contained a per-org `__global__` tombstone (`url=''` + `status='archived'` + non-null `group_id`).
- Drop the `url <> ''` filter from the CTE so both archived shapes (real archived rows + tombstones) cascade out in the same statement. Re-exposing the underlying global to this org is the correct outcome when the operator is explicitly tearing down the environment that owned the tombstone.
- Add a `migrate-pg.test.ts` fixture that pins the failure (plain group delete → 23503) and proves the fixed CTE drops both shapes plus the group cleanly.

## Root cause

`admin-connections.ts:1022-1033` writes per-org `__global__` tombstones as `url = ''`, `status = 'archived'`, with a non-null `group_id`. The env-delete CTE at `admin-connection-groups.ts:592-602` filtered `url <> ''` to avoid undoing tombstones in unrelated env-delete flows (the goal of #2406), but inside an env-delete that filter strands the tombstone in a group that's about to be dropped — the trailing `DELETE FROM connection_groups` then fails the FK check.

Admin pages exclude `status = 'archived'` entirely, so the operator has no recovery path — the tombstone is invisible.

## Why the comment matters

I left an explicit comment in the CTE listing both archived shapes (real archived + `url=''` tombstone) and why this delete is the right place to drop both. Grep'd for any other production path that creates archived rows — the only INSERT-with-archived path is the tombstone one in `admin-connections.ts`, and the two UPDATE-to-archived paths (`admin-connections.ts:1009`, `entities.ts:1137`) flip in-place on org-owned rows that keep their original `url`, so they fall under the "real archived" shape already covered. If a fourth shape lands later, the comment is the breadcrumb for the next person.

## Validation

- `bun run lint` — 0 errors (one pre-existing warning in an unrelated test file)
- `bun run type` — clean
- `TEST_DATABASE_URL=postgresql://atlas:atlas@localhost:5432/atlas_migrate_test bun run test` — full suite green; `migrate-pg.test.ts` passes 47/47 including the new `connections.group_id: env-delete CTE drops both archived shapes (#2410)` fixture
- `bun x syncpack lint` — clean
- `bash scripts/check-template-drift.sh` — clean
- `bash scripts/check-railway-watch.sh` — clean
- `bash scripts/check-schema-drift.sh` — clean
- `bash scripts/check-security-headers-drift.sh` — clean
- `bash scripts/check-oauth-helper-drift.sh` — clean

## Test plan

- [ ] CI green (all required checks)
- [ ] Manual: hide a global connection → confirm tombstone created → delete environment containing the tombstone → assert 200, group + tombstone both gone, and the global is visible again in the workspace

## Refs

- Closes #2410
- Tracker: #2407
- Prior fixes: #2405 (cascading archived delete), #2406 (`url <> ''` filter to preserve tombstones outside env-delete)