### PR TITLE
feat(web): show Environment column on /admin/connections (#2421)

### DIFF
--- a/packages/api/src/api/__tests__/admin-connections.test.ts
+++ b/packages/api/src/api/__tests__/admin-connections.test.ts
@@ -205,6 +205,62 @@ describe("admin connections — org scoping", () => {
       const ids = body.connections.map((c: { id: string }) => c.id);
       expect(ids).toEqual(["default"]);
     });
+
+    it("decorates each row with groupId + groupName from the connection_groups JOIN", async () => {
+      // The list endpoint's second internalQuery call selects c.id, c.group_id
+      // and g.name via LEFT JOIN connection_groups. The visibility query runs
+      // first; we only return a group decoration for the visible row.
+      mocks.mockInternalQuery.mockImplementation((sql: string) => {
+        if (sql.includes("SELECT c.id FROM connections c WHERE c.org_id")) {
+          return Promise.resolve([{ id: "warehouse" }]);
+        }
+        if (sql.includes("LEFT JOIN connection_groups")) {
+          return Promise.resolve([
+            { id: "warehouse", group_id: "g_prod", group_name: "g_prod" },
+          ]);
+        }
+        return Promise.resolve([]);
+      });
+
+      const res = await app.fetch(
+        adminRequest("/api/v1/admin/connections"),
+      );
+
+      expect(res.status).toBe(200);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test convenience
+      const body = (await res.json()) as any;
+      const warehouse = body.connections.find((c: { id: string }) => c.id === "warehouse");
+      expect(warehouse).toBeDefined();
+      expect(warehouse.groupId).toBe("g_prod");
+      expect(warehouse.groupName).toBe("g_prod");
+    });
+
+    it("emits groupName: null when a visible connection has no group decoration", async () => {
+      mocks.mockInternalQuery.mockImplementation((sql: string) => {
+        if (sql.includes("SELECT c.id FROM connections c WHERE c.org_id")) {
+          return Promise.resolve([{ id: "warehouse" }]);
+        }
+        // LEFT JOIN returns the row with NULL group_id/name when ungrouped.
+        if (sql.includes("LEFT JOIN connection_groups")) {
+          return Promise.resolve([
+            { id: "warehouse", group_id: null, group_name: null },
+          ]);
+        }
+        return Promise.resolve([]);
+      });
+
+      const res = await app.fetch(
+        adminRequest("/api/v1/admin/connections"),
+      );
+
+      expect(res.status).toBe(200);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test convenience
+      const body = (await res.json()) as any;
+      const warehouse = body.connections.find((c: { id: string }) => c.id === "warehouse");
+      expect(warehouse).toBeDefined();
+      expect(warehouse.groupId).toBeNull();
+      expect(warehouse.groupName).toBeNull();
+    });
   });
 
   // ─── 3. Update/delete 404 for wrong org ─────────────────────────────

--- a/packages/api/src/api/__tests__/admin-connections.test.ts
+++ b/packages/api/src/api/__tests__/admin-connections.test.ts
@@ -190,9 +190,13 @@ describe("admin connections — org scoping", () => {
       expect(ids).not.toContain("other-org-conn");
     });
 
-    it("workspace admin with no DB connections falls back to default", async () => {
+    it("workspace admin with no DB connections falls back to default and emits null group fields", async () => {
       // No connections in internal DB for this org — self-hosted single-tenant
       // path keeps working because `default` is the only registered connection.
+      // The decoration fallback must still emit groupId/groupName as null on
+      // every row; a regression that drops the `?? null` would silently ship
+      // `undefined` and trip every downstream consumer relying on the
+      // documented three-state semantics.
       mocks.mockInternalQuery.mockResolvedValue([]);
 
       const res = await app.fetch(
@@ -204,6 +208,9 @@ describe("admin connections — org scoping", () => {
       const body = (await res.json()) as any;
       const ids = body.connections.map((c: { id: string }) => c.id);
       expect(ids).toEqual(["default"]);
+      const defaultRow = body.connections[0];
+      expect(defaultRow.groupId).toBeNull();
+      expect(defaultRow.groupName).toBeNull();
     });
 
     it("decorates each row with groupId + groupName from the connection_groups JOIN", async () => {
@@ -214,7 +221,7 @@ describe("admin connections — org scoping", () => {
         if (sql.includes("SELECT c.id FROM connections c WHERE c.org_id")) {
           return Promise.resolve([{ id: "warehouse" }]);
         }
-        if (sql.includes("LEFT JOIN connection_groups")) {
+        if (sql.includes("g.name AS group_name")) {
           return Promise.resolve([
             { id: "warehouse", group_id: "g_prod", group_name: "g_prod" },
           ]);
@@ -241,7 +248,7 @@ describe("admin connections — org scoping", () => {
           return Promise.resolve([{ id: "warehouse" }]);
         }
         // LEFT JOIN returns the row with NULL group_id/name when ungrouped.
-        if (sql.includes("LEFT JOIN connection_groups")) {
+        if (sql.includes("g.name AS group_name")) {
           return Promise.resolve([
             { id: "warehouse", group_id: null, group_name: null },
           ]);
@@ -681,9 +688,18 @@ describe("admin connections — org scoping", () => {
         if (sql.includes("SELECT c.id FROM connections c WHERE c.org_id")) {
           return Promise.resolve([{ id: "warehouse" }]);
         }
-        // Detail query for managed connection info
-        if (sql.includes("SELECT url, schema_name FROM connections WHERE id")) {
-          return Promise.resolve([{ url: "encrypted:postgresql://user:pass@host/db", schema_name: null }]);
+        // Detail query — now LEFT JOINs connection_groups to surface
+        // groupId/groupName on the wire (#2421). The substring picks the
+        // composite alias so it doesn't collide with the list endpoint.
+        if (sql.includes("SELECT c.url, c.schema_name, c.group_id, g.name AS group_name")) {
+          return Promise.resolve([
+            {
+              url: "encrypted:postgresql://user:pass@host/db",
+              schema_name: null,
+              group_id: null,
+              group_name: null,
+            },
+          ]);
         }
         return Promise.resolve([]);
       });
@@ -697,6 +713,40 @@ describe("admin connections — org scoping", () => {
       const body = (await res.json()) as any;
       expect(body.id).toBe("warehouse");
       expect(body.managed).toBe(true);
+      // group fields are surfaced; null here because the mock returns NULL
+      // from the LEFT JOIN. A separate case asserts the populated branch.
+      expect(body.groupId).toBeNull();
+      expect(body.groupName).toBeNull();
+    });
+
+    it("get-by-id surfaces groupId + groupName when the LEFT JOIN matches", async () => {
+      setOrgAdmin("org-alpha");
+      mocks.mockInternalQuery.mockImplementation((sql: string) => {
+        if (sql.includes("SELECT c.id FROM connections c WHERE c.org_id")) {
+          return Promise.resolve([{ id: "warehouse" }]);
+        }
+        if (sql.includes("SELECT c.url, c.schema_name, c.group_id, g.name AS group_name")) {
+          return Promise.resolve([
+            {
+              url: "encrypted:postgresql://user:pass@host/db",
+              schema_name: null,
+              group_id: "g_warehouse",
+              group_name: "warehouse",
+            },
+          ]);
+        }
+        return Promise.resolve([]);
+      });
+
+      const res = await app.fetch(
+        adminRequest("/api/v1/admin/connections/warehouse"),
+      );
+
+      expect(res.status).toBe(200);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test convenience
+      const body = (await res.json()) as any;
+      expect(body.groupId).toBe("g_warehouse");
+      expect(body.groupName).toBe("warehouse");
     });
   });
 

--- a/packages/api/src/api/routes/admin-connections.ts
+++ b/packages/api/src/api/routes/admin-connections.ts
@@ -1097,18 +1097,35 @@ adminConnections.openapi(getConnectionRoute, async (c) => runHandler(c, "get con
   let maskedUrl: string | null = null;
   let schema: string | null = null;
   let managed = false;
+  let groupId: string | null = null;
+  let groupName: string | null = null;
   if (hasInternalDB()) {
     try {
       // Defense-in-depth: even though visibility already filters out
       // archived rows, exclude them here too so a future visibility-layer
       // bug can never feed the empty-string tombstone marker to decryptSecret.
-      const rows = await internalQuery<{ url: string; schema_name: string | null }>(
-        "SELECT url, schema_name FROM connections WHERE id = $1 AND org_id = $2 AND status != 'archived'",
+      // LEFT JOIN connection_groups so the detail response carries the same
+      // groupId + groupName fields the list endpoint emits — the admin UI's
+      // Edit dialog reuses ConnectionDetail and would otherwise lose the
+      // environment chip on detail render.
+      const rows = await internalQuery<{
+        url: string;
+        schema_name: string | null;
+        group_id: string | null;
+        group_name: string | null;
+      }>(
+        `SELECT c.url, c.schema_name, c.group_id, g.name AS group_name
+           FROM connections c
+           LEFT JOIN connection_groups g
+             ON g.id = c.group_id AND g.org_id = c.org_id
+          WHERE c.id = $1 AND c.org_id = $2 AND c.status != 'archived'`,
         [id, orgId],
       );
       if (rows.length > 0) {
         managed = true;
         schema = rows[0].schema_name;
+        groupId = rows[0].group_id;
+        groupName = rows[0].group_name;
         try {
           maskedUrl = maskConnectionUrl(decryptSecret(rows[0].url));
         } catch (decryptErr) {
@@ -1130,6 +1147,8 @@ adminConnections.openapi(getConnectionRoute, async (c) => runHandler(c, "get con
     maskedUrl,
     schema,
     managed,
+    groupId,
+    groupName,
   }, 200);
 }));
 

--- a/packages/api/src/api/routes/admin-connections.ts
+++ b/packages/api/src/api/routes/admin-connections.ts
@@ -369,28 +369,41 @@ adminConnections.openapi(listConnectionsRoute, async (c) => runHandler(c, "list 
   const visible = await getVisibleConnectionIds(orgId, isPlatformAdmin, getAtlasMode(c));
   const filtered = visible ? connList.filter((conn) => visible.has(conn.id)) : connList;
 
-  // Decorate with `group_id` from the internal DB. The in-memory registry
-  // tracks runtime metadata but not group membership; merging here keeps
-  // both surfaces in lockstep without a second round-trip from the admin
-  // UI. The no-internal-DB branch (self-hosted single-tenant) and the
-  // empty-result branch both fall through with `groupId: null` on every
-  // row. Transient DB errors propagate via runHandler's classifyError —
-  // a flaky pool surfaces as a 500 here just like every other list
-  // endpoint, no silent-success fallback.
-  let groupIdByConnection = new Map<string, string | null>();
+  // Decorate with `group_id` + `group_name` from the internal DB. The
+  // in-memory registry tracks runtime metadata but not group membership;
+  // merging here keeps both surfaces in lockstep without a second
+  // round-trip from the admin UI. The LEFT JOIN preserves rows with
+  // `group_id = NULL` (ungrouped connections) and returns `group_name =
+  // NULL` for them. The (id, org_id) join condition mirrors the
+  // composite-FK org scoping on `connection_groups`. The no-internal-DB
+  // branch (self-hosted single-tenant) and the empty-result branch both
+  // fall through with `groupId/groupName: null` on every row. Transient
+  // DB errors propagate via runHandler's classifyError — a flaky pool
+  // surfaces as a 500 here, no silent-success fallback.
+  let groupInfoByConnection = new Map<string, { groupId: string | null; groupName: string | null }>();
   if (hasInternalDB() && filtered.length > 0) {
     const ids = filtered.map((c) => c.id);
-    const rows = await internalQuery<{ id: string; group_id: string | null }>(
-      `SELECT id, group_id FROM connections WHERE org_id = $1 AND id = ANY($2::text[])`,
+    const rows = await internalQuery<{ id: string; group_id: string | null; group_name: string | null }>(
+      `SELECT c.id, c.group_id, g.name AS group_name
+         FROM connections c
+         LEFT JOIN connection_groups g
+           ON g.id = c.group_id AND g.org_id = c.org_id
+        WHERE c.org_id = $1 AND c.id = ANY($2::text[])`,
       [orgId, ids],
     );
-    groupIdByConnection = new Map(rows.map((r) => [r.id, r.group_id]));
+    groupInfoByConnection = new Map(
+      rows.map((r) => [r.id, { groupId: r.group_id, groupName: r.group_name }]),
+    );
   }
 
-  const decorated = filtered.map((c) => ({
-    ...c,
-    groupId: groupIdByConnection.get(c.id) ?? null,
-  }));
+  const decorated = filtered.map((c) => {
+    const info = groupInfoByConnection.get(c.id);
+    return {
+      ...c,
+      groupId: info?.groupId ?? null,
+      groupName: info?.groupName ?? null,
+    };
+  });
 
   return c.json({ connections: decorated }, 200);
 }));

--- a/packages/schemas/src/__tests__/connection.test.ts
+++ b/packages/schemas/src/__tests__/connection.test.ts
@@ -63,3 +63,19 @@ describe("ConnectionsResponseSchema transforms to array", () => {
     expect(ConnectionsResponseSchema.parse({})).toEqual([]);
   });
 });
+
+describe("group decoration fields survive parse", () => {
+  // Locks in that ConnectionInfoSchema does not strip groupId/groupName.
+  // Before #2421 the admin list endpoint already emitted groupId, but the
+  // schema's default object strip silently dropped it at parse time and the
+  // UI had no way to render an environment chip.
+  test("parses populated groupId + groupName", () => {
+    const withGroup = { ...validInfo, groupId: "g_prod", groupName: "prod" };
+    expect(ConnectionInfoSchema.parse(withGroup)).toEqual(withGroup);
+  });
+
+  test("parses explicit null groupId + groupName (ungrouped row)", () => {
+    const ungrouped = { ...validInfo, groupId: null, groupName: null };
+    expect(ConnectionInfoSchema.parse(ungrouped)).toEqual(ungrouped);
+  });
+});

--- a/packages/schemas/src/connection.ts
+++ b/packages/schemas/src/connection.ts
@@ -43,6 +43,14 @@ export const ConnectionInfoSchema = z.object({
   description: z.string().nullable().optional(),
   status: z.enum(CONNECTION_STATUSES).optional(),
   health: ConnectionHealthSchema.optional(),
+  // `groupId` + `groupName` come from the admin connections list endpoint
+  // (LEFT JOIN connection_groups) so the table can render an Environment
+  // badge without a second round-trip. Both are nullable+optional: older
+  // API responses predate the fields, and a connection assigned to no
+  // group serializes them as explicit nulls. Without these here, Zod's
+  // default object strip drops the keys at parse time.
+  groupId: z.string().nullable().optional(),
+  groupName: z.string().nullable().optional(),
 }) as z.ZodType<ConnectionInfo>;
 
 // ---------------------------------------------------------------------------

--- a/packages/types/src/connection.ts
+++ b/packages/types/src/connection.ts
@@ -36,6 +36,20 @@ export interface ConnectionInfo {
   description?: string | null;
   status?: ConnectionStatus;
   health?: ConnectionHealth;
+  /**
+   * Connection group membership. Three states are meaningful:
+   * - `undefined` — older serializer / client predating the field.
+   * - `null` — explicitly unassigned (no group, or moved out via admin UI).
+   * - `string` — current membership.
+   * Schema + code use `group_id`; UI copy renders this as "environment".
+   */
+  groupId?: string | null;
+  /**
+   * Display name of the group, denormalized so list responses can render
+   * a badge without a second round-trip to `/admin/connections/groups`.
+   * Same three-state semantics as {@link groupId}.
+   */
+  groupName?: string | null;
 }
 
 /** Real-time pool size counters (only available for core adapters with pool access). */
@@ -93,6 +107,12 @@ export interface ConnectionDetail {
    * Schema + code use `group_id`; UI copy renders this as "environment".
    */
   groupId?: string | null;
+  /**
+   * Display name of the group, denormalized so the detail view can render
+   * a badge without a second round-trip. Same three-state semantics as
+   * {@link groupId}.
+   */
+  groupName?: string | null;
 }
 
 /**

--- a/packages/web/src/app/admin/connections/columns.tsx
+++ b/packages/web/src/app/admin/connections/columns.tsx
@@ -21,10 +21,11 @@ function mapHealthStatus(
 }
 
 /**
- * Mirror of `stripGroupPrefix` in `chat/env-picker.tsx`. The 0062 1:1
- * backfill names groups `g_<connId>` for legacy single-connection orgs;
- * strip the prefix so the badge reads naturally ("prod" instead of
- * "g_prod"). Custom names without the prefix pass through unchanged.
+ * Mirror of `stripGroupPrefix` in `chat/env-picker.tsx`. Defensive strip
+ * for any group name an admin renames to `g_*` — migration 0062 backfills
+ * `connection_groups.id` as `g_<connId>` but stores `name = <connId>`
+ * (unprefixed), so the strip is a no-op on default data and only fires
+ * if a custom name starts with `g_`.
  * TODO(refactor): extract to a shared util — tracked in #2426.
  */
 function stripGroupPrefix(name: string): string {
@@ -86,7 +87,12 @@ export function getConnectionColumns(): ColumnDef<ConnectionInfo>[] {
       ),
       cell: ({ row }) => {
         const groupName = row.original.groupName;
-        if (!groupName) {
+        // Use explicit `== null` rather than `!groupName` \u2014 empty string is
+        // not a documented state and falling through to the em-dash would
+        // mask a corrupt `connection_groups.name = ''` row instead of
+        // surfacing it. The backend invariant is `groupId !== null \u21d2
+        // groupName !== null`; both are jointly null/non-null.
+        if (groupName == null) {
           return <span className="text-sm text-muted-foreground">{"\u2014"}</span>;
         }
         return (

--- a/packages/web/src/app/admin/connections/columns.tsx
+++ b/packages/web/src/app/admin/connections/columns.tsx
@@ -1,11 +1,12 @@
 "use client";
 
+import Link from "next/link";
 import type { ColumnDef } from "@tanstack/react-table";
 import { Badge } from "@/components/ui/badge";
 import { DataTableColumnHeader } from "@/components/data-table/data-table-column-header";
 import { HealthBadge } from "@/ui/components/admin/health-badge";
 import { DemoBadge, DraftBadge } from "@/ui/components/admin/mode-badges";
-import { Fingerprint, Database, FileText, Activity, Clock } from "lucide-react";
+import { Fingerprint, Database, FileText, Activity, Clock, Layers } from "lucide-react";
 import type { ConnectionHealth, ConnectionInfo } from "@/ui/lib/types";
 
 /** Reserved connection id for the onboarding demo dataset. */
@@ -17,6 +18,17 @@ function mapHealthStatus(
   if (!status) return "unknown";
   if (status === "unhealthy") return "down";
   return status;
+}
+
+/**
+ * Mirror of `stripGroupPrefix` in `chat/env-picker.tsx`. The 0062 1:1
+ * backfill names groups `g_<connId>` for legacy single-connection orgs;
+ * strip the prefix so the badge reads naturally ("prod" instead of
+ * "g_prod"). Custom names without the prefix pass through unchanged.
+ * TODO(refactor): extract to a shared util — tracked in #2426.
+ */
+function stripGroupPrefix(name: string): string {
+  return name.startsWith("g_") ? name.slice(2) : name;
 }
 
 export function getConnectionColumns(): ColumnDef<ConnectionInfo>[] {
@@ -64,6 +76,30 @@ export function getConnectionColumns(): ColumnDef<ConnectionInfo>[] {
         </span>
       ),
       meta: { label: "Description", icon: FileText },
+      enableSorting: false,
+    },
+    {
+      id: "environment",
+      accessorFn: (row) => row.groupName ?? null,
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} label="Environment" />
+      ),
+      cell: ({ row }) => {
+        const groupName = row.original.groupName;
+        if (!groupName) {
+          return <span className="text-sm text-muted-foreground">{"\u2014"}</span>;
+        }
+        return (
+          <Link
+            href="/admin/connections/groups"
+            className="inline-flex items-center"
+            aria-label={`View environment ${stripGroupPrefix(groupName)}`}
+          >
+            <Badge variant="outline">{stripGroupPrefix(groupName)}</Badge>
+          </Link>
+        );
+      },
+      meta: { label: "Environment", icon: Layers },
       enableSorting: false,
     },
     {

--- a/packages/web/src/app/admin/connections/page.tsx
+++ b/packages/web/src/app/admin/connections/page.tsx
@@ -35,6 +35,8 @@ import {
 import { useDemoReadonly } from "@/ui/hooks/use-demo-readonly";
 import { DemoBadge, DraftBadge } from "@/ui/components/admin/mode-badges";
 import { DEMO_CONNECTION_ID } from "./columns";
+import Link from "next/link";
+import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
   Cable,
@@ -756,6 +758,16 @@ function labelForDbType(dbType: string): string {
   return DB_TYPES.find((t) => t.value === dbType)?.label ?? dbType;
 }
 
+/**
+ * Mirror of `stripGroupPrefix` in `columns.tsx` + `chat/env-picker.tsx`.
+ * The 0062 1:1 backfill names groups `g_<connId>` for legacy
+ * single-connection orgs; strip the prefix so the badge reads naturally.
+ * TODO(refactor): extract to a shared util — tracked in #2426.
+ */
+function stripGroupPrefix(name: string): string {
+  return name.startsWith("g_") ? name.slice(2) : name;
+}
+
 /** Short human label for a connection's health.status. */
 function healthLabel(status: ConnectionHealth["status"]): string {
   switch (status) {
@@ -1321,6 +1333,20 @@ function ConnectionCard({
 
       <DetailList>
         <DetailRow label="Provider" value={providerLabel} />
+        {conn.groupName ? (
+          <DetailRow
+            label="Environment"
+            value={
+              <Link
+                href="/admin/connections/groups"
+                className="inline-flex items-center"
+                aria-label={`View environment ${stripGroupPrefix(conn.groupName)}`}
+              >
+                <Badge variant="outline">{stripGroupPrefix(conn.groupName)}</Badge>
+              </Link>
+            }
+          />
+        ) : null}
         {conn.description ? (
           <DetailRow label="Description" value={conn.description} truncate />
         ) : null}

--- a/packages/web/src/app/admin/connections/page.tsx
+++ b/packages/web/src/app/admin/connections/page.tsx
@@ -760,8 +760,10 @@ function labelForDbType(dbType: string): string {
 
 /**
  * Mirror of `stripGroupPrefix` in `columns.tsx` + `chat/env-picker.tsx`.
- * The 0062 1:1 backfill names groups `g_<connId>` for legacy
- * single-connection orgs; strip the prefix so the badge reads naturally.
+ * Defensive strip for any group name an admin renames to `g_*` —
+ * migration 0062 backfills `connection_groups.id` as `g_<connId>` but
+ * stores `name = <connId>` (unprefixed), so this is a no-op on default
+ * data and only fires for admin-set custom names.
  * TODO(refactor): extract to a shared util — tracked in #2426.
  */
 function stripGroupPrefix(name: string): string {
@@ -1333,7 +1335,7 @@ function ConnectionCard({
 
       <DetailList>
         <DetailRow label="Provider" value={providerLabel} />
-        {conn.groupName ? (
+        {conn.groupName != null ? (
           <DetailRow
             label="Environment"
             value={

--- a/packages/web/src/ui/__tests__/connection-columns.test.tsx
+++ b/packages/web/src/ui/__tests__/connection-columns.test.tsx
@@ -12,19 +12,27 @@ import {
  * flexRender helper so we exercise the same path the DataTable does — avoids
  * shipping tests that pass because they bypass the library.
  */
-function renderIdCell(row: ConnectionInfo) {
+function renderColumnCell(row: ConnectionInfo, columnId: string) {
   const columns = getConnectionColumns();
-  const idCol = columns.find((c) => c.id === "id");
-  if (!idCol) throw new Error("id column missing");
+  const col = columns.find((c) => c.id === columnId);
+  if (!col) throw new Error(`${columnId} column missing`);
   // Minimal fake TanStack row/cell context — we only need `getValue` and
   // `original`. The cell renderer uses both.
   const fakeRow = {
     getValue: (key: string) => (row as unknown as Record<string, unknown>)[key],
     original: row,
   } as unknown as Row<ConnectionInfo>;
-  const fakeCell = { getContext: () => ({ row: fakeRow, table: {} as Table<ConnectionInfo>, cell: {} as Cell<ConnectionInfo, unknown>, column: idCol, getValue: () => row.id, renderValue: () => row.id }) };
+  const fakeCell = { getContext: () => ({ row: fakeRow, table: {} as Table<ConnectionInfo>, cell: {} as Cell<ConnectionInfo, unknown>, column: col, getValue: () => row.id, renderValue: () => row.id }) };
   const ctx = fakeCell.getContext();
-  return render(<>{flexRender(idCol.cell, ctx)}</>);
+  return render(<>{flexRender(col.cell, ctx)}</>);
+}
+
+function renderIdCell(row: ConnectionInfo) {
+  return renderColumnCell(row, "id");
+}
+
+function renderEnvironmentCell(row: ConnectionInfo) {
+  return renderColumnCell(row, "environment");
 }
 
 describe("connection columns — id cell", () => {
@@ -57,5 +65,48 @@ describe("connection columns — id cell", () => {
     const { container } = renderIdCell({ id: DEMO_CONNECTION_ID, dbType: "postgres", status: "draft" });
     expect(container.textContent).toContain("Demo");
     expect(container.textContent).toContain("Draft");
+  });
+});
+
+describe("connection columns — environment cell", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  test("renders an em-dash when the row has no groupName", () => {
+    const { container } = renderEnvironmentCell({
+      id: "warehouse",
+      dbType: "postgres",
+      status: "published",
+    });
+    expect(container.textContent).toBe("—");
+    expect(container.querySelector("a")).toBeNull();
+  });
+
+  test("renders a badge linking to /admin/connections/groups when groupName is present", () => {
+    const { container } = renderEnvironmentCell({
+      id: "warehouse",
+      dbType: "postgres",
+      status: "published",
+      groupId: "g_prod",
+      groupName: "g_prod",
+    });
+    // Strip the legacy `g_` prefix so the chip reads naturally.
+    expect(container.textContent).toContain("prod");
+    expect(container.textContent).not.toContain("g_prod");
+    const link = container.querySelector("a");
+    expect(link).not.toBeNull();
+    expect(link?.getAttribute("href")).toBe("/admin/connections/groups");
+  });
+
+  test("does not strip non-prefix names", () => {
+    const { container } = renderEnvironmentCell({
+      id: "warehouse",
+      dbType: "postgres",
+      status: "published",
+      groupId: "g_prod",
+      groupName: "Production EU",
+    });
+    expect(container.textContent).toContain("Production EU");
   });
 });

--- a/packages/web/src/ui/components/chat/env-picker.tsx
+++ b/packages/web/src/ui/components/chat/env-picker.tsx
@@ -62,10 +62,11 @@ export interface ChatEnvPickerProps {
 }
 
 function stripGroupPrefix(name: string): string {
-  // The 0062 1:1 backfill names groups `g_<connId>` for legacy
-  // single-connection orgs. Strip the prefix so the chip reads
-  // naturally ("prod" instead of "g_prod"); admins who set a custom
-  // name see the raw value unchanged.
+  // Defensive strip for any admin-set name that begins with `g_`.
+  // Migration 0062 backfills `connection_groups.id` as `g_<connId>` but
+  // stores `name = <connId>` (unprefixed), so this is a no-op on default
+  // backfilled rows; it only fires when an admin renames a group to
+  // something starting with `g_`.
   return name.startsWith("g_") ? name.slice(2) : name;
 }
 


### PR DESCRIPTION
Closes #2421. Tracker: #2407 · Milestone: 1.4.4.

## Summary

- Backend `/api/v1/admin/connections` LEFT JOINs `connection_groups` on `(group_id, org_id)` so each row carries both `groupId` and the new `groupName`. Ungrouped rows fall through with both as `null`.
- `ConnectionInfo` + `ConnectionInfoSchema` learn the two optional fields so Zod's default strip stops dropping them at parse time. `ConnectionDetail` mirrors with `groupName`.
- `/admin/connections` now renders an Environment chip on each connection card (shadcn `<Badge>` linking to `/admin/connections/groups`); the legacy `g_` backfill prefix is stripped so chips read naturally (`prod` not `g_prod`).
- `getConnectionColumns()` gains the matching column for any future table-style consumer.

## Why

PRD #2336 user story #20 wants /admin/connections to surface fleet structure at a glance. The acceptance criterion was implicit in #2339 and got checked off without UI work; this closes that gap. The page renders as cards (DetailList), so the chip lives there; the parallel ColumnDef change keeps the columns module in lockstep for any future table view.

## Test plan

- [x] `bun run lint` — clean (one pre-existing warning in `packages/api/.../detect.test.ts`, unrelated)
- [x] `bun run type` — passes
- [x] `bun run test` — full suite passes (one flaky `plugins/mcp` shutdown-exit-code test self-resolved on retry; baseline behavior)
- [x] `bun x syncpack lint` — no issues
- [x] Template / security-headers / railway-watch / schema-drift / oauth-helper drift checks — all pass
- [x] Backend: new `admin-connections.test.ts` cases assert `groupId` + `groupName` decorate the list response (grouped + ungrouped paths)
- [x] Frontend: new `connection-columns.test.tsx` cases assert em-dash for null, badge + link target + prefix-strip for present, no-strip for custom names
- [ ] Live browser test of the admin UI — dev DB in worktree lacked a seeded admin credential, so the column was verified via the unit tests that exercise the actual tanstack flexRender path

## Incidental findings

`stripGroupPrefix` is now duplicated three times (env-picker, columns, page). Filed as #2426 — not extracted inline to keep this PR scoped.

## Out of scope

- "Group by environment" toggle — PRD secondary; ship the column first.
- Merge/rename UX — that's #2409 territory.