### PR TITLE
fix(web): auto-bind single-group dashboard card-create (#2419)

### DIFF
--- a/packages/web/src/ui/__tests__/add-to-dashboard-dialog.test.tsx
+++ b/packages/web/src/ui/__tests__/add-to-dashboard-dialog.test.tsx
@@ -1,0 +1,237 @@
+/**
+ * Regression guard for #2419: single-group workspaces must auto-bind the
+ * sole `connection_groups` row to the card on create. The pre-fix dialog
+ * hid the picker when `groups.length <= 1` AND dropped `connectionGroupId`
+ * from the POST payload, silently falling through to `resolveCardConnectionId`'s
+ * workspace-default path (packages/api/src/lib/dashboards.ts:238). That
+ * violates PRD #2342's "card-create form scopes by group" criterion —
+ * the single-env case must materialize the binding even though there's
+ * no UI choice to make.
+ *
+ * Pins all three cardinality regimes (one / zero / multi) plus the
+ * single-env readout copy so a future refactor can't re-introduce the
+ * silent fallthrough.
+ */
+
+import { describe, expect, test, mock, beforeEach, afterEach } from "bun:test";
+import React, { type ReactNode } from "react";
+import { render, screen, cleanup, fireEvent, act, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+interface ConnectionGroup {
+  id: string;
+  name: string;
+  memberCount: number;
+  primaryConnectionId: string | null;
+  resolvedConnectionId: string | null;
+}
+
+interface CapturedCall {
+  path: string;
+  method?: string;
+  body?: Record<string, unknown>;
+}
+
+let dashboardsData: { dashboards: Array<{ id: string; title: string; cardCount: number }>; total: number } = {
+  dashboards: [],
+  total: 0,
+};
+let groupsData: { groups: ConnectionGroup[] } | null = { groups: [] };
+let mutateCalls: CapturedCall[] = [];
+
+mock.module("@/ui/hooks/use-admin-fetch", () => ({
+  useAdminFetch: (path: string) => {
+    if (path === "/api/v1/dashboards") {
+      return { data: dashboardsData, loading: false, error: null, refetch: () => {} };
+    }
+    if (path === "/api/v1/admin/connection-groups") {
+      return { data: groupsData, loading: false, error: null, refetch: () => {} };
+    }
+    return { data: null, loading: false, error: null, refetch: () => {} };
+  },
+}));
+
+mock.module("@/ui/hooks/use-admin-mutation", () => ({
+  useAdminMutation: () => ({
+    mutate: async (opts: { path: string; method?: string; body?: Record<string, unknown> }) => {
+      mutateCalls.push({ path: opts.path, method: opts.method, body: opts.body });
+      if (opts.path.endsWith("/cards")) {
+        return { ok: true, data: { id: "card-1" } };
+      }
+      // createDashboard mutation
+      return {
+        ok: true,
+        data: { id: "dashboard-1", title: opts.body?.title ?? "Dash", cardCount: 0 },
+      };
+    },
+    saving: false,
+    error: null,
+    clearError: () => {},
+    reset: () => {},
+  }),
+}));
+
+const { AddToDashboardDialog } = await import("../components/chat/add-to-dashboard-dialog");
+
+function Wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return React.createElement(QueryClientProvider, { client }, children);
+}
+
+const noChartResult = { chartable: false as const, recommendations: [] };
+
+const baseProps = {
+  open: true,
+  onOpenChange: () => {},
+  sql: "SELECT 1",
+  columns: ["x"],
+  rows: [{ x: 1 }],
+  chartResult: noChartResult,
+};
+
+beforeEach(() => {
+  mutateCalls = [];
+  dashboardsData = { dashboards: [], total: 0 };
+  groupsData = { groups: [] };
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+async function submitDialog(): Promise<void> {
+  // dashboards = [] forces effectiveMode → "new", which renders an
+  // Input instead of a Select for the dashboard target.
+  const titleInput = screen.getByPlaceholderText("Dashboard title");
+  fireEvent.change(titleInput, { target: { value: "My Dashboard" } });
+  await act(async () => {
+    fireEvent.click(screen.getByRole("button", { name: /Add to Dashboard/ }));
+  });
+}
+
+describe("AddToDashboardDialog — connection group binding (#2419)", () => {
+  test("one-group workspace: auto-binds the sole group in the POST payload", async () => {
+    groupsData = {
+      groups: [
+        {
+          id: "g_prod",
+          name: "prod",
+          memberCount: 1,
+          primaryConnectionId: "c_prod",
+          resolvedConnectionId: "c_prod",
+        },
+      ],
+    };
+    render(React.createElement(AddToDashboardDialog, baseProps), { wrapper: Wrapper });
+
+    await submitDialog();
+
+    await waitFor(() => {
+      const cardCall = mutateCalls.find((c) => c.path.endsWith("/cards"));
+      expect(cardCall).toBeDefined();
+      expect(cardCall?.body?.connectionGroupId).toBe("g_prod");
+    });
+  });
+
+  test("zero-group workspace: POST payload omits connectionGroupId (pre-1.4.4 fallthrough)", async () => {
+    groupsData = { groups: [] };
+    render(React.createElement(AddToDashboardDialog, baseProps), { wrapper: Wrapper });
+
+    await submitDialog();
+
+    await waitFor(() => {
+      const cardCall = mutateCalls.find((c) => c.path.endsWith("/cards"));
+      expect(cardCall).toBeDefined();
+    });
+    const cardCall = mutateCalls.find((c) => c.path.endsWith("/cards"));
+    expect(cardCall?.body).toBeDefined();
+    expect("connectionGroupId" in (cardCall!.body as object)).toBe(false);
+  });
+
+  test("multi-group workspace: env picker renders, no auto-binding", () => {
+    groupsData = {
+      groups: [
+        {
+          id: "g_prod",
+          name: "prod",
+          memberCount: 1,
+          primaryConnectionId: "c_prod",
+          resolvedConnectionId: "c_prod",
+        },
+        {
+          id: "g_staging",
+          name: "staging",
+          memberCount: 1,
+          primaryConnectionId: "c_staging",
+          resolvedConnectionId: "c_staging",
+        },
+      ],
+    };
+    render(React.createElement(AddToDashboardDialog, baseProps), { wrapper: Wrapper });
+
+    // The "Environment" label is the picker's anchor — its presence
+    // proves the picker rendered. Single-env readout copy must NOT
+    // appear in the multi-group case.
+    expect(screen.queryByText("Environment")).not.toBeNull();
+    expect(screen.queryByText(/Card runs against/)).toBeNull();
+  });
+
+  test("one-group with primary: readout copy surfaces the binding (picker stays hidden)", () => {
+    groupsData = {
+      groups: [
+        {
+          id: "g_prod",
+          name: "prod",
+          memberCount: 1,
+          primaryConnectionId: "c_prod",
+          resolvedConnectionId: "c_prod",
+        },
+      ],
+    };
+    render(React.createElement(AddToDashboardDialog, baseProps), { wrapper: Wrapper });
+
+    // Picker is hidden, readout is visible. The wording must name the
+    // group so single-env users can confirm the binding at a glance.
+    expect(screen.queryByText("Environment")).toBeNull();
+    expect(screen.getByText(/Card runs against the primary member of/i).textContent)
+      .toContain("prod");
+  });
+
+  test("one-group with no primary: readout falls back to 'first member' language", () => {
+    groupsData = {
+      groups: [
+        {
+          id: "g_only",
+          name: "warehouse",
+          memberCount: 2,
+          primaryConnectionId: null,
+          resolvedConnectionId: "c_first",
+        },
+      ],
+    };
+    render(React.createElement(AddToDashboardDialog, baseProps), { wrapper: Wrapper });
+
+    expect(screen.getByText(/first member \(no primary pinned\)/i)).toBeTruthy();
+  });
+
+  test("one-group with zero members: readout warns instead of silently binding to an empty group", () => {
+    // Auto-bind still materializes connectionGroupId so the API's
+    // NoGroupMembersError fires cleanly at refresh time — but the
+    // operator must see the warning at create time, not after the
+    // first failed refresh.
+    groupsData = {
+      groups: [
+        {
+          id: "g_empty",
+          name: "ghost",
+          memberCount: 0,
+          primaryConnectionId: null,
+          resolvedConnectionId: null,
+        },
+      ],
+    };
+    render(React.createElement(AddToDashboardDialog, baseProps), { wrapper: Wrapper });
+
+    expect(screen.getByText(/has no connections/i)).toBeTruthy();
+  });
+});

--- a/packages/web/src/ui/__tests__/add-to-dashboard-dialog.test.tsx
+++ b/packages/web/src/ui/__tests__/add-to-dashboard-dialog.test.tsx
@@ -2,15 +2,16 @@
  * Regression guard for #2419: single-group workspaces must auto-bind the
  * sole `connection_groups` row to the card on create. The pre-fix dialog
  * hid the picker when `groups.length <= 1` AND dropped `connectionGroupId`
- * from the POST payload, silently falling through to `resolveCardConnectionId`'s
- * workspace-default path (packages/api/src/lib/dashboards.ts:238). That
- * violates PRD #2342's "card-create form scopes by group" criterion —
- * the single-env case must materialize the binding even though there's
- * no UI choice to make.
+ * from the POST payload — `resolveCardConnectionId` returned `null`, and
+ * the auto-refresh call site (packages/api/src/lib/dashboards.ts:879)
+ * then fell through to `connections.getDefault()` so the card silently
+ * ran against the workspace default. That violates PRD #2342's
+ * "card-create form scopes by group" criterion — the single-env case
+ * must materialize the binding even though there's no UI choice to make.
  *
- * Pins all three cardinality regimes (one / zero / multi) plus the
- * single-env readout copy so a future refactor can't re-introduce the
- * silent fallthrough.
+ * Pins all three cardinality regimes (one / zero / multi), the
+ * single-env readout copy, and the zero-member submit guard so a future
+ * refactor can't re-introduce the silent fallthrough.
  */
 
 import { describe, expect, test, mock, beforeEach, afterEach } from "bun:test";
@@ -100,8 +101,6 @@ afterEach(() => {
 });
 
 async function submitDialog(): Promise<void> {
-  // dashboards = [] forces effectiveMode → "new", which renders an
-  // Input instead of a Select for the dashboard target.
   const titleInput = screen.getByPlaceholderText("Dashboard title");
   fireEvent.change(titleInput, { target: { value: "My Dashboard" } });
   await act(async () => {
@@ -169,9 +168,6 @@ describe("AddToDashboardDialog — connection group binding (#2419)", () => {
     };
     render(React.createElement(AddToDashboardDialog, baseProps), { wrapper: Wrapper });
 
-    // The "Environment" label is the picker's anchor — its presence
-    // proves the picker rendered. Single-env readout copy must NOT
-    // appear in the multi-group case.
     expect(screen.queryByText("Environment")).not.toBeNull();
     expect(screen.queryByText(/Card runs against/)).toBeNull();
   });
@@ -214,11 +210,7 @@ describe("AddToDashboardDialog — connection group binding (#2419)", () => {
     expect(screen.getByText(/first member \(no primary pinned\)/i)).toBeTruthy();
   });
 
-  test("one-group with zero members: readout warns instead of silently binding to an empty group", () => {
-    // Auto-bind still materializes connectionGroupId so the API's
-    // NoGroupMembersError fires cleanly at refresh time — but the
-    // operator must see the warning at create time, not after the
-    // first failed refresh.
+  test("one-group with zero members: readout warns at create time", () => {
     groupsData = {
       groups: [
         {
@@ -233,5 +225,79 @@ describe("AddToDashboardDialog — connection group binding (#2419)", () => {
     render(React.createElement(AddToDashboardDialog, baseProps), { wrapper: Wrapper });
 
     expect(screen.getByText(/has no connections/i)).toBeTruthy();
+  });
+
+  test("one-group with zero members: submit is hard-blocked, not just warned (#2419 silent-failure follow-up)", async () => {
+    // A warning + an unblocked submit is still a silent failure — the
+    // card persists bound to a group `resolveCardConnectionId` can't
+    // resolve at refresh time. The guard in handleSubmit must fail
+    // closed.
+    groupsData = {
+      groups: [
+        {
+          id: "g_empty",
+          name: "ghost",
+          memberCount: 0,
+          primaryConnectionId: null,
+          resolvedConnectionId: null,
+        },
+      ],
+    };
+    render(React.createElement(AddToDashboardDialog, baseProps), { wrapper: Wrapper });
+
+    await submitDialog();
+
+    // No mutate calls fire at all — the guard short-circuits before
+    // createDashboard and addCard are reached.
+    expect(mutateCalls).toEqual([]);
+    // Submit error surfaces alongside the readout (two matches by
+    // design — readout warns ambiently, error banner appears post-submit).
+    expect(screen.queryAllByText(/has no connections/i).length).toBeGreaterThanOrEqual(1);
+  });
+
+  test("multi-group, user picks a group, submit sends that group's id (regression for the unrelated boolean half of boundGroupId)", async () => {
+    // If `boundGroupId` ever stops falling back to `connectionGroupId`
+    // for multi-group workspaces (e.g. a refactor that wires it only
+    // to `soleGroup?.id`), the auto-bind case keeps passing but the
+    // user-pick case silently drops the binding. Pin both halves.
+    groupsData = {
+      groups: [
+        {
+          id: "g_prod",
+          name: "prod",
+          memberCount: 1,
+          primaryConnectionId: "c_prod",
+          resolvedConnectionId: "c_prod",
+        },
+        {
+          id: "g_staging",
+          name: "staging",
+          memberCount: 1,
+          primaryConnectionId: "c_staging",
+          resolvedConnectionId: "c_staging",
+        },
+      ],
+    };
+    render(React.createElement(AddToDashboardDialog, baseProps), { wrapper: Wrapper });
+
+    // Simulate the user picking "g_staging" from the env picker.
+    // shadcn's Select is a Radix combobox in the live tree; in jsdom
+    // we reach the underlying state via the change handler the
+    // SelectTrigger forwards. The trigger renders with the
+    // accessible name from SelectValue → use the combobox role.
+    const combobox = screen.getByRole("combobox");
+    fireEvent.click(combobox);
+    // Use the listbox option once the menu opens. Radix renders
+    // options with role="option" once open in jsdom.
+    await waitFor(() => expect(screen.queryByRole("option", { name: /staging/i })).not.toBeNull());
+    fireEvent.click(screen.getByRole("option", { name: /staging/i }));
+
+    await submitDialog();
+
+    await waitFor(() => {
+      const cardCall = mutateCalls.find((c) => c.path.endsWith("/cards"));
+      expect(cardCall).toBeDefined();
+      expect(cardCall?.body?.connectionGroupId).toBe("g_staging");
+    });
   });
 });

--- a/packages/web/src/ui/components/chat/add-to-dashboard-dialog.tsx
+++ b/packages/web/src/ui/components/chat/add-to-dashboard-dialog.tsx
@@ -150,6 +150,16 @@ export function AddToDashboardDialog({
   // Auto-switch to "new" mode when we know there are no dashboards
   const effectiveMode = mode === "existing" && !loadingDashboards && !fetchError && dashboards.length === 0 ? "new" : mode;
 
+  // `connectionGroupId` is the user's picker selection ("" = workspace
+  // default). `boundGroupId` is what we send to the API: for single-env
+  // workspaces the picker is hidden, but we still materialize the
+  // binding so the card scopes to the group's primary member instead
+  // of silently falling through to `resolveCardConnectionId`'s
+  // workspace-default path (#2419, PRD #2342).
+  const groups = groupsData?.groups ?? [];
+  const soleGroup = groups.length === 1 ? groups[0] : null;
+  const boundGroupId = soleGroup ? soleGroup.id : connectionGroupId;
+
   // Filter chart recommendations to only storable types
   const storableRecommendations = chartResult.chartable
     ? chartResult.recommendations.filter((r) => STORABLE_CHART_TYPES.has(r.type))
@@ -216,7 +226,7 @@ export function AddToDashboardDialog({
           chartConfig: buildChartConfig(),
           cachedColumns: columns,
           cachedRows: rows.slice(0, MAX_CACHED_ROWS),
-          ...(connectionGroupId && { connectionGroupId }),
+          ...(boundGroupId && { connectionGroupId: boundGroupId }),
         },
       });
 
@@ -333,9 +343,13 @@ export function AddToDashboardDialog({
               {renderDashboardSelector()}
             </div>
 
-            {/* Environment (connection group) — hidden when the workspace
-                has at most one group (single-env orgs see no value here). */}
-            {(groupsData?.groups.length ?? 0) > 1 && (
+            {/* Environment (connection group). Multi-group workspaces get
+                the picker. Single-group workspaces get an auto-bound
+                readout (the binding is materialized via `boundGroupId`
+                — no UI choice to make, but the user sees the target).
+                Zero-group workspaces render nothing here and fall
+                through to the workspace default (pre-1.4.4 path). */}
+            {groups.length > 1 && (
               <div className="grid gap-2">
                 <Label htmlFor="connection-group">Environment</Label>
                 <Select
@@ -347,7 +361,7 @@ export function AddToDashboardDialog({
                   </SelectTrigger>
                   <SelectContent>
                     <SelectItem value="__default__">Workspace default</SelectItem>
-                    {(groupsData?.groups ?? []).map((g) => (
+                    {groups.map((g) => (
                       <SelectItem key={g.id} value={g.id}>
                         {g.name} ({g.memberCount} connection{g.memberCount !== 1 ? "s" : ""})
                       </SelectItem>
@@ -355,7 +369,7 @@ export function AddToDashboardDialog({
                   </SelectContent>
                 </Select>
                 {connectionGroupId && (() => {
-                  const picked = groupsData?.groups.find((g) => g.id === connectionGroupId);
+                  const picked = groups.find((g) => g.id === connectionGroupId);
                   if (!picked) return null;
                   if (picked.memberCount === 0) {
                     return (
@@ -376,6 +390,17 @@ export function AddToDashboardDialog({
                   );
                 })()}
               </div>
+            )}
+            {soleGroup && (
+              soleGroup.memberCount === 0 ? (
+                <p className="text-xs text-amber-600 dark:text-amber-400">
+                  The <span className="font-medium">{soleGroup.name}</span> environment has no connections. Add one in Admin → Connection Groups before the card can refresh.
+                </p>
+              ) : (
+                <p className="text-xs text-zinc-500 dark:text-zinc-400">
+                  Card runs against the {soleGroup.primaryConnectionId ? "primary member" : "first member (no primary pinned)"} of the <span className="font-medium">{soleGroup.name}</span> environment.
+                </p>
+              )
             )}
 
             {/* Card title */}

--- a/packages/web/src/ui/components/chat/add-to-dashboard-dialog.tsx
+++ b/packages/web/src/ui/components/chat/add-to-dashboard-dialog.tsx
@@ -150,15 +150,14 @@ export function AddToDashboardDialog({
   // Auto-switch to "new" mode when we know there are no dashboards
   const effectiveMode = mode === "existing" && !loadingDashboards && !fetchError && dashboards.length === 0 ? "new" : mode;
 
-  // `connectionGroupId` is the user's picker selection ("" = workspace
-  // default). `boundGroupId` is what we send to the API: for single-env
-  // workspaces the picker is hidden, but we still materialize the
-  // binding so the card scopes to the group's primary member instead
-  // of silently falling through to `resolveCardConnectionId`'s
-  // workspace-default path (#2419, PRD #2342).
+  // Single-env workspaces must still materialize the binding even
+  // though the picker is hidden — otherwise the card silently falls
+  // through to `connections.getDefault()` at refresh time instead of
+  // scoping to the group's primary member (#2419, PRD #2342).
   const groups = groupsData?.groups ?? [];
   const soleGroup = groups.length === 1 ? groups[0] : null;
   const boundGroupId = soleGroup ? soleGroup.id : connectionGroupId;
+  const boundGroup = boundGroupId ? groups.find((g) => g.id === boundGroupId) ?? null : null;
 
   // Filter chart recommendations to only storable types
   const storableRecommendations = chartResult.chartable
@@ -187,6 +186,17 @@ export function AddToDashboardDialog({
 
       if (!cardTitle.trim()) {
         setError("Card title is required.");
+        return;
+      }
+
+      // The picker / auto-bind readouts warn for empty groups, but a
+      // warning alone is a silent-failure on submit — the card would
+      // be created bound to a group that `resolveCardConnectionId`
+      // can't resolve at refresh time. Block here so the user fixes
+      // the membership before persisting (CLAUDE.md "Prefer errors
+      // over silent fallbacks").
+      if (boundGroup && boundGroup.memberCount === 0) {
+        setError(`The "${boundGroup.name}" environment has no connections. Add one in Admin → Connection Groups before adding a card.`);
         return;
       }
 


### PR DESCRIPTION
## Summary

Fixes #2419. The add-to-dashboard dialog hid the env picker when `groups.length <= 1` AND dropped `connectionGroupId` from the POST payload — so single-env workspaces silently fell through to `resolveCardConnectionId`'s workspace-default path ([dashboards.ts:238](https://github.com/AtlasDevHQ/atlas/blob/main/packages/api/src/lib/dashboards.ts#L238)). That violates PRD #2342's "card-create form scopes by group" criterion: the single-env case must materialize the binding even when there's no UI choice to make.

- Compute `boundGroupId = soleGroup?.id ?? connectionGroupId` and use it in the POST payload — auto-binds when `groups.length === 1`, keeps the existing user-picker state for multi-group workspaces, omits the field for zero-group workspaces.
- Keep the picker hidden for single-env orgs (no UI churn) but surface a one-line readout: *"Card runs against the primary member of the {group} environment."* So the binding is visible, not implicit.
- Readout handles the no-primary case (`"first member (no primary pinned)"`) and the no-members edge case (warning copy) so the operator sees the state at create time, not after the first failed refresh.

No API change — `resolveCardConnectionId` already honors `connectionGroupId` with the correct primary→first-member→workspace-default fallback chain.

Tracker: #2407. Closes #2419.

## Test plan

- [x] Unit tests (TDD) cover all three cardinality regimes:
  - one-group → POST payload includes `connectionGroupId: <sole-group-id>`
  - zero-group → POST payload omits `connectionGroupId` (pre-1.4.4 fallthrough preserved)
  - multi-group → env picker renders, no auto-binding
- [x] Readout copy variants:
  - primary set → "primary member"
  - no primary → "first member (no primary pinned)"
  - zero members → warning ("has no connections")
- [x] `bun run lint`, `bun run type`, `bun x syncpack lint`, template + schema drift checks green
- [x] `bun test src/ui/__tests__/add-to-dashboard-dialog.test.tsx` — 6/6 pass