### PR TITLE
fix(api,web): surface explicit reason in /me/connection-groups (#2422)

### DIFF
--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -8104,10 +8104,22 @@
                           "members"
                         ]
                       }
+                    },
+                    "reason": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "enum": [
+                        "no_active_org",
+                        "no_internal_db",
+                        null
+                      ]
                     }
                   },
                   "required": [
-                    "groups"
+                    "groups",
+                    "reason"
                   ]
                 }
               }

--- a/packages/api/src/api/routes/__tests__/me-connection-groups.test.ts
+++ b/packages/api/src/api/routes/__tests__/me-connection-groups.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Tests for `GET /api/v1/me/connection-groups` — the empty-list reason
+ * surface added for #2422. The route returns `{ groups: [], reason }`
+ * with `reason` populated when the empty list is the consequence of a
+ * known degraded state (no active org, or no internal DB). A workspace
+ * that genuinely has no groups configured returns `reason: null` so the
+ * picker stays hidden instead of displaying explanatory copy.
+ */
+
+import { describe, it, expect, beforeEach, mock } from "bun:test";
+import type { AuthResult } from "@atlas/api/lib/auth/types";
+
+// ── Auth mock ──────────────────────────────────────────────────────────────
+
+let fakeAuth: (AuthResult & { authenticated: true }) | null = null;
+
+mock.module("@atlas/api/lib/auth/middleware", () => ({
+  authenticateRequest: () =>
+    Promise.resolve(
+      fakeAuth ?? { authenticated: false, status: 401 as const, error: "anonymous" },
+    ),
+  checkRateLimit: () => ({ allowed: true }),
+  getClientIP: () => null,
+  resetRateLimits: () => {},
+  rateLimitCleanupTick: () => {},
+}));
+
+mock.module("@atlas/api/lib/residency/misrouting", () => ({
+  detectMisrouting: async () => null,
+  isStrictRoutingEnabled: () => false,
+}));
+
+mock.module("@atlas/api/lib/residency/readonly", () => ({
+  isWorkspaceMigrating: async () => false,
+}));
+
+mock.module("@atlas/api/lib/logger", () => {
+  const noop = () => {};
+  const logger = { info: noop, warn: noop, error: noop, debug: noop, child: () => logger };
+  return {
+    createLogger: () => logger,
+    getLogger: () => logger,
+    withRequestContext: (_ctx: unknown, fn: () => unknown) => fn(),
+    getRequestContext: () => undefined,
+    redactPaths: [],
+  };
+});
+
+// ── DB mock ────────────────────────────────────────────────────────────────
+
+let dbAvailable = true;
+type GroupRow = {
+  group_id: string;
+  group_name: string;
+  connection_id: string | null;
+  db_type: string | null;
+  description: string | null;
+};
+let rowsForOrg: Record<string, GroupRow[]> = {};
+
+mock.module("@atlas/api/lib/db/internal", () => {
+  const notUsed = () => {
+    throw new Error("internal.ts helper not used in this route");
+  };
+  return {
+    hasInternalDB: () => dbAvailable,
+    internalQuery: async (_sql: string, params: unknown[]) => {
+      const [orgId] = params as [string];
+      return rowsForOrg[orgId] ?? [];
+    },
+    getInternalDB: () => null,
+    queryEffect: notUsed,
+    internalExecute: () => {},
+    closeInternalDB: async () => {},
+    encryptSecret: (s: string) => s,
+    decryptSecret: (s: string) => s,
+    isPlaintextUrl: () => false,
+    isInternalCircuitOpen: () => false,
+    _resetPool: () => {},
+    _resetCircuitBreaker: () => {},
+    _setInternalCircuitOpenForTests: () => {},
+    getAutoApproveThreshold: () => 1,
+    getAutoApproveTypes: () => new Set<string>(),
+    MANAGED_AUTH_MIGRATIONS: [],
+    InternalDB: { Service: Symbol("InternalDB") },
+    makeInternalDBLive: notUsed,
+    makeInternalDBShimLayer: notUsed,
+    createInternalDBTestLayer: notUsed,
+    migrateInternalDB: async () => {},
+    loadSavedConnections: async () => 0,
+    findPatternBySQL: async () => null,
+    insertLearnedPattern: () => {},
+    insertSemanticAmendment: async () => {},
+    getPendingAmendmentCount: async () => 0,
+    getPendingAmendments: async () => [],
+    reviewSemanticAmendment: async () => {},
+    incrementPatternCount: () => {},
+    getApprovedPatterns: async () => [],
+    upsertSuggestion: async () => {},
+    getSuggestionsByTables: async () => [],
+    getPopularSuggestions: async () => [],
+    incrementSuggestionClick: () => {},
+    deleteSuggestion: async () => {},
+    getAuditLogQueries: async () => [],
+    getWorkspaceStatus: async () => null,
+    getWorkspaceNamesByIds: async () => new Map<string, string>(),
+    getWorkspaceDetails: async () => null,
+    updateWorkspaceStatus: async () => {},
+    updateWorkspacePlanTier: async () => {},
+    getWorkspaceRegion: async () => null,
+    setWorkspaceRegion: async () => {},
+    cascadeWorkspaceDelete: async () => ({}),
+    getWorkspaceHealthSummary: async () => ({}),
+    updateWorkspaceByot: async () => {},
+    setWorkspaceStripeCustomerId: async () => {},
+    setWorkspaceTrialEndsAt: async () => {},
+    hardDeleteWorkspace: async () => ({}),
+  };
+});
+
+// ── Imports (after mocks) ──────────────────────────────────────────────────
+
+const { meConnectionGroups } = await import("../me-connection-groups");
+
+function userAuth(
+  opts: { orgId: string | null } = { orgId: "org-1" },
+): AuthResult & { authenticated: true } {
+  return {
+    authenticated: true,
+    mode: "managed",
+    user: {
+      id: "user-1",
+      mode: "managed",
+      label: "user@test.dev",
+      role: "member",
+      activeOrganizationId: opts.orgId ?? undefined,
+    },
+  };
+}
+
+async function getJson(res: Response) {
+  return (await res.json()) as {
+    groups: Array<{ id: string; name: string; members: unknown[] }>;
+    reason: "no_active_org" | "no_internal_db" | null;
+  };
+}
+
+beforeEach(() => {
+  fakeAuth = null;
+  dbAvailable = true;
+  rowsForOrg = {};
+});
+
+describe("GET /api/v1/me/connection-groups — reason field (#2422)", () => {
+  it("returns 401 when unauthenticated", async () => {
+    fakeAuth = null;
+    const res = await meConnectionGroups.request("/", { method: "GET" });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns reason: 'no_active_org' when the user has no active organization", async () => {
+    fakeAuth = userAuth({ orgId: null });
+    const res = await meConnectionGroups.request("/", { method: "GET" });
+    expect(res.status).toBe(200);
+    const body = await getJson(res);
+    expect(body.groups).toEqual([]);
+    expect(body.reason).toBe("no_active_org");
+  });
+
+  it("returns reason: 'no_internal_db' when the internal database is unavailable (self-hosted)", async () => {
+    fakeAuth = userAuth();
+    dbAvailable = false;
+    const res = await meConnectionGroups.request("/", { method: "GET" });
+    expect(res.status).toBe(200);
+    const body = await getJson(res);
+    expect(body.groups).toEqual([]);
+    expect(body.reason).toBe("no_internal_db");
+  });
+
+  it("prefers 'no_internal_db' over 'no_active_org' when both apply (single signal, not a state machine)", async () => {
+    // The frontend is binary — either it shows an explanation or it
+    // doesn't. Picking one canonical reason avoids two callers
+    // disagreeing about which copy to render. `no_internal_db` is the
+    // more useful diagnostic because it points at the operator-side
+    // fix; an unassigned user can also see it in their topbar.
+    fakeAuth = userAuth({ orgId: null });
+    dbAvailable = false;
+    const res = await meConnectionGroups.request("/", { method: "GET" });
+    expect(res.status).toBe(200);
+    const body = await getJson(res);
+    expect(body.reason).toBe("no_internal_db");
+  });
+
+  it("returns reason: null when the workspace simply has no groups configured", async () => {
+    fakeAuth = userAuth();
+    rowsForOrg["org-1"] = [];
+    const res = await meConnectionGroups.request("/", { method: "GET" });
+    expect(res.status).toBe(200);
+    const body = await getJson(res);
+    expect(body.groups).toEqual([]);
+    expect(body.reason).toBeNull();
+  });
+
+  it("returns reason: null when the workspace has groups", async () => {
+    fakeAuth = userAuth();
+    rowsForOrg["org-1"] = [
+      {
+        group_id: "g_prod",
+        group_name: "prod",
+        connection_id: "us-int",
+        db_type: "postgres",
+        description: null,
+      },
+    ];
+    const res = await meConnectionGroups.request("/", { method: "GET" });
+    expect(res.status).toBe(200);
+    const body = await getJson(res);
+    expect(body.groups).toHaveLength(1);
+    expect(body.groups[0]).toMatchObject({ id: "g_prod", name: "prod" });
+    expect(body.reason).toBeNull();
+  });
+});

--- a/packages/api/src/api/routes/me-connection-groups.ts
+++ b/packages/api/src/api/routes/me-connection-groups.ts
@@ -13,9 +13,11 @@
  *     header picker, conversation create dialog). It cannot grow new
  *     verbs — non-admin users must not be able to mutate group state.
  *
- * Empty workspaces (no groups configured yet) return `{ groups: [] }`;
- * the picker then renders nothing and the chat falls back to the
- * legacy single-connection path.
+ * `reason` distinguishes "empty because the workspace genuinely has no
+ * groups" (null — picker stays hidden, chat falls back to the legacy
+ * single-connection path) from "empty because the request can't reach a
+ * usable state" (`no_internal_db` / `no_active_org` — picker renders
+ * explanatory copy instead of silently disappearing). See #2422.
  */
 
 import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
@@ -39,6 +41,25 @@ const ConnectionGroupSchema = z.object({
   members: z.array(ConnectionGroupMemberSchema),
 });
 
+/**
+ * Why an empty `groups` list. `null` ⇒ the workspace genuinely has no
+ * groups configured (picker stays hidden, legacy single-connection
+ * routing kicks in). Anything else is a degraded state the user should
+ * see explained instead of a silent empty picker.
+ *
+ * Extending: keep this as a discriminated string union (not a free-form
+ * `string`) so the frontend's exhaustive switch stays a compile-time
+ * check. New reasons require a matching branch in `env-picker.tsx`.
+ */
+export type MeConnectionGroupsEmptyReason = "no_active_org" | "no_internal_db";
+
+const ResponseSchema = z.object({
+  groups: z.array(ConnectionGroupSchema),
+  reason: z.enum(["no_active_org", "no_internal_db"]).nullable(),
+});
+
+export type MeConnectionGroupsResponse = z.infer<typeof ResponseSchema>;
+
 const listRoute = createRoute({
   method: "get",
   path: "/",
@@ -51,7 +72,7 @@ const listRoute = createRoute({
       description: "Connection group list",
       content: {
         "application/json": {
-          schema: z.object({ groups: z.array(ConnectionGroupSchema) }),
+          schema: ResponseSchema,
         },
       },
     },
@@ -74,13 +95,23 @@ meConnectionGroups.openapi(listRoute, async (c) => {
   const auth = c.get("authResult");
   const orgId = auth?.user?.activeOrganizationId;
   const requestId = c.get("requestId");
-  if (!hasInternalDB() || !orgId) {
-    // No internal DB or no org context — return empty rather than 500.
-    // The picker UI treats `[]` as "no groups configured" and falls back
-    // to the legacy single-connection routing. Surfacing a 500 here
-    // would block chat for self-hosted users on the legacy single-
-    // connection path.
-    return c.json({ groups: [] as Array<z.infer<typeof ConnectionGroupSchema>> }, 200);
+  // Pick the most operator-actionable diagnostic when both signals are
+  // degraded. `no_internal_db` points at the deploy-side fix (set
+  // DATABASE_URL); `no_active_org` is the per-user case the topbar
+  // surfaces anyway. See the dedicated test in
+  // `me-connection-groups.test.ts` for why this is a single signal and
+  // not a state machine.
+  if (!hasInternalDB()) {
+    return c.json(
+      { groups: [], reason: "no_internal_db" as const },
+      200,
+    );
+  }
+  if (!orgId) {
+    return c.json(
+      { groups: [], reason: "no_active_org" as const },
+      200,
+    );
   }
   try {
     // One round-trip via a left-join so groups with zero non-archived
@@ -124,7 +155,12 @@ meConnectionGroups.openapi(listRoute, async (c) => {
         });
       }
     }
-    return c.json({ groups: Array.from(byGroup.values()) }, 200);
+    // `reason: null` covers both "workspace has groups" and the
+    // ordinary "workspace has no groups configured yet" — the picker
+    // treats null as "no banner; just hide if the array is empty". A
+    // populated `reason` is reserved for genuinely degraded states the
+    // caller couldn't reach a usable query for.
+    return c.json({ groups: Array.from(byGroup.values()), reason: null }, 200);
   } catch (err) {
     log.error(
       { err: errorMessage(err), requestId, orgId },

--- a/packages/api/src/api/routes/me-connection-groups.ts
+++ b/packages/api/src/api/routes/me-connection-groups.ts
@@ -98,9 +98,9 @@ meConnectionGroups.openapi(listRoute, async (c) => {
   // Pick the most operator-actionable diagnostic when both signals are
   // degraded. `no_internal_db` points at the deploy-side fix (set
   // DATABASE_URL); `no_active_org` is the per-user case the topbar
-  // surfaces anyway. See the dedicated test in
-  // `me-connection-groups.test.ts` for why this is a single signal and
-  // not a state machine.
+  // surfaces anyway. See `me-connection-groups.test.ts` →
+  // "prefers 'no_internal_db' over 'no_active_org' when both apply"
+  // for the load-bearing test on this precedence.
   if (!hasInternalDB()) {
     return c.json(
       { groups: [], reason: "no_internal_db" as const },
@@ -108,6 +108,14 @@ meConnectionGroups.openapi(listRoute, async (c) => {
     );
   }
   if (!orgId) {
+    // Leave a breadcrumb so support can correlate "empty picker" user
+    // reports to a real auth-state issue without having to repro the
+    // mid-org-switch race. Debug-level: this is expected during normal
+    // org switches and would flood at info.
+    log.debug(
+      { requestId, userId: auth?.user?.id, reason: "no_active_org" },
+      "me/connection-groups: no active organization for user",
+    );
     return c.json(
       { groups: [], reason: "no_active_org" as const },
       200,

--- a/packages/web/src/ui/__tests__/env-picker.test.tsx
+++ b/packages/web/src/ui/__tests__/env-picker.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, test, mock, beforeEach } from "bun:test";
+import { describe, expect, test, mock, beforeEach, afterEach } from "bun:test";
 import React, { type ReactNode } from "react";
 
 // Mock the dropdown-menu primitives so portal'd content renders inline.
@@ -32,8 +32,12 @@ mock.module("@/components/ui/dropdown-menu", () => {
   };
 });
 
-import { render, cleanup } from "@testing-library/react";
-import { ChatEnvPicker, type ChatEnvGroup } from "../components/chat/env-picker";
+import { render, renderHook, waitFor, cleanup } from "@testing-library/react";
+import {
+  ChatEnvPicker,
+  useChatEnvGroups,
+  type ChatEnvGroup,
+} from "../components/chat/env-picker";
 
 beforeEach(() => {
   cleanup();
@@ -401,5 +405,116 @@ describe("ChatEnvPicker chip label collapse (#2408)", () => {
       '[data-testid="chat-env-picker-label"]',
     );
     expect(label?.textContent).toBe("prod / us-int");
+  });
+});
+
+// ── useChatEnvGroups hook ────────────────────────────────────────────
+//
+// `useChatEnvGroups` is the only place the wire `reason` actually
+// enters the web app. The component-layer tests above lock the render
+// branches, but the hook itself has three behaviors a regression could
+// quietly break: echoing a known reason through to state, falling back
+// to null when the server omits the field (forward-compat with older
+// API), and resetting reason to null on transport failure so a flaky
+// network can't pin a stale chip on screen. See #2422.
+
+const originalFetch = globalThis.fetch;
+
+function mockFetch(
+  handler: () => Response | Promise<Response>,
+): () => number {
+  let calls = 0;
+  globalThis.fetch = mock(async () => {
+    calls += 1;
+    return await handler();
+  }) as unknown as typeof fetch;
+  return () => calls;
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("useChatEnvGroups (#2422)", () => {
+  const opts = {
+    apiUrl: "http://atlas.test",
+    enabled: true,
+    getHeaders: () => ({}),
+    getCredentials: () => "same-origin" as RequestCredentials,
+  };
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    cleanup();
+  });
+
+  test("echoes a known reason through to state on a successful empty response", async () => {
+    mockFetch(() => jsonResponse({ groups: [], reason: "no_internal_db" }));
+    const { result } = renderHook(() => useChatEnvGroups(opts));
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+    expect(result.current.groups).toEqual([]);
+    expect(result.current.reason).toBe("no_internal_db");
+    expect(result.current.error).toBeNull();
+  });
+
+  test("falls back to reason: null when the server omits the field (forward-compat with older API)", async () => {
+    mockFetch(() => jsonResponse({ groups: [] }));
+    const { result } = renderHook(() => useChatEnvGroups(opts));
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+    expect(result.current.reason).toBeNull();
+  });
+
+  test("narrows an unrecognized reason to null instead of leaking it to the chip", async () => {
+    // A server bug or a forward-version drift could emit a reason the
+    // frontend hasn't been built to render. Indexing into the copy
+    // table with that value would render `undefined` as visible text.
+    // The hook must narrow before passing it on.
+    mockFetch(() =>
+      jsonResponse({ groups: [], reason: "no_active_token" /* not in union */ }),
+    );
+    const { result } = renderHook(() => useChatEnvGroups(opts));
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+    expect(result.current.reason).toBeNull();
+  });
+
+  test("resets reason to null on transport failure so a flaky network can't pin a stale chip", async () => {
+    // Silence the console.warn we now emit on transport failure; the
+    // test is asserting state shape, not log output, and an
+    // unexpected warn would flag a CLAUDE.md "no silent swallows"
+    // regression elsewhere.
+    const originalWarn = console.warn;
+    console.warn = () => {};
+    try {
+      mockFetch(() => {
+        throw new Error("network down");
+      });
+      const { result } = renderHook(() => useChatEnvGroups(opts));
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+      expect(result.current.groups).toEqual([]);
+      expect(result.current.reason).toBeNull();
+      expect(result.current.error).toContain("network down");
+    } finally {
+      console.warn = originalWarn;
+    }
+  });
+
+  test("does not fetch when enabled is false (signed-out / auth not resolved)", async () => {
+    const callCount = mockFetch(() => jsonResponse({ groups: [], reason: null }));
+    renderHook(() => useChatEnvGroups({ ...opts, enabled: false }));
+    // Microtask flush — give the effect a chance to fire if it were
+    // going to.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(callCount()).toBe(0);
   });
 });

--- a/packages/web/src/ui/__tests__/env-picker.test.tsx
+++ b/packages/web/src/ui/__tests__/env-picker.test.tsx
@@ -205,6 +205,110 @@ describe("ChatEnvPicker singleton-only footer hint (#2408)", () => {
   });
 });
 
+describe("ChatEnvPicker emptyReason (#2422)", () => {
+  test("renders an inline 'no active workspace' chip when groups is empty and emptyReason is 'no_active_org'", () => {
+    const { container } = render(
+      <ChatEnvPicker
+        groups={[]}
+        emptyReason="no_active_org"
+        activeGroupId={null}
+        activeConnectionId={null}
+        onSelect={noop}
+      />,
+    );
+    const chip = container.querySelector(
+      '[data-testid="chat-env-picker-empty-reason"]',
+    );
+    expect(chip).not.toBeNull();
+    expect(chip?.getAttribute("data-reason")).toBe("no_active_org");
+    expect(chip?.textContent).toContain("No active workspace");
+    // The chip must not be hidden — it replaces the silent-fallback
+    // behavior that motivated #2422.
+    expect(
+      container.querySelector('[data-testid="chat-env-picker-trigger"]'),
+    ).toBeNull();
+  });
+
+  test("renders an inline 'set DATABASE_URL' chip when groups is empty and emptyReason is 'no_internal_db'", () => {
+    const { container } = render(
+      <ChatEnvPicker
+        groups={[]}
+        emptyReason="no_internal_db"
+        activeGroupId={null}
+        activeConnectionId={null}
+        onSelect={noop}
+      />,
+    );
+    const chip = container.querySelector(
+      '[data-testid="chat-env-picker-empty-reason"]',
+    );
+    expect(chip).not.toBeNull();
+    expect(chip?.getAttribute("data-reason")).toBe("no_internal_db");
+    expect(chip?.textContent).toContain("internal database");
+    expect(chip?.textContent).toContain("DATABASE_URL");
+  });
+
+  test("stays hidden when groups is empty and emptyReason is null (workspace with no groups configured)", () => {
+    const { container } = render(
+      <ChatEnvPicker
+        groups={[]}
+        emptyReason={null}
+        activeGroupId={null}
+        activeConnectionId={null}
+        onSelect={noop}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  test("stays hidden when groups is empty and emptyReason is omitted (defaults to null)", () => {
+    // Locks the default-prop contract — callers that haven't been
+    // updated to thread `emptyReason` should keep the original silent
+    // behavior.
+    const { container } = render(
+      <ChatEnvPicker
+        groups={[]}
+        activeGroupId={null}
+        activeConnectionId={null}
+        onSelect={noop}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  test("ignores emptyReason when groups is non-empty (server saw groups; chip would be a lie)", () => {
+    const groups: ChatEnvGroup[] = [
+      {
+        id: "g_prod",
+        name: "prod",
+        members: [
+          { connectionId: "us-int", dbType: "postgres", description: null },
+          { connectionId: "eu-int", dbType: "postgres", description: null },
+        ],
+      },
+    ];
+    const { container } = render(
+      <ChatEnvPicker
+        groups={groups}
+        // A server bug or future state could theoretically send both —
+        // the picker takes the groups as ground truth and ignores the
+        // reason. Locks the precedence so the chip can never overlay a
+        // populated picker.
+        emptyReason="no_internal_db"
+        activeGroupId="g_prod"
+        activeConnectionId="us-int"
+        onSelect={noop}
+      />,
+    );
+    expect(
+      container.querySelector('[data-testid="chat-env-picker-empty-reason"]'),
+    ).toBeNull();
+    expect(
+      container.querySelector('[data-testid="chat-env-picker-trigger"]'),
+    ).not.toBeNull();
+  });
+});
+
 describe("ChatEnvPicker chip label collapse (#2408)", () => {
   test("renders just the member id when stripped group name equals member id", () => {
     // Common 0062 backfill shape: group `g_warehouse` with one member

--- a/packages/web/src/ui/components/atlas-chat.tsx
+++ b/packages/web/src/ui/components/atlas-chat.tsx
@@ -543,6 +543,7 @@ export function AtlasChat() {
                       deploy) so the header is byte-identical pre-1.4.4. */}
                   <ChatEnvPicker
                     groups={envGroupsQuery.groups}
+                    emptyReason={envGroupsQuery.reason}
                     activeGroupId={selectedGroupId}
                     activeConnectionId={selectedConnectionId}
                     onSelect={({ groupId, connectionId }) => {

--- a/packages/web/src/ui/components/chat/env-picker.tsx
+++ b/packages/web/src/ui/components/chat/env-picker.tsx
@@ -79,6 +79,17 @@ const EMPTY_REASON_COPY: Record<MeConnectionGroupsEmptyReason, string> = {
     "Multi-environment features require an internal database. Self-hosters: set DATABASE_URL.",
 };
 
+/**
+ * Runtime narrow against the closed reason union. A server emitting an
+ * unrecognized value (forward-compat scenario, or a bug) would
+ * otherwise index into `EMPTY_REASON_COPY` and render `undefined` as
+ * visible chip text. Treat unknowns as "no reason" so the picker
+ * falls back to its hide-on-empty default.
+ */
+function isKnownEmptyReason(value: unknown): value is MeConnectionGroupsEmptyReason {
+  return typeof value === "string" && value in EMPTY_REASON_COPY;
+}
+
 export function ChatEnvPicker({
   groups,
   emptyReason = null,
@@ -87,9 +98,9 @@ export function ChatEnvPicker({
   onSelect,
 }: ChatEnvPickerProps): React.ReactElement | null {
   // Empty list + a reason ⇒ render a diagnostic chip instead of
-  // silently hiding. This is the #2422 fix: a mid-org-switch or
-  // unassigned user used to see a blank picker, hiding the 1.4.4
-  // multi-env feature behind a silent fallback.
+  // silently hiding. Hiding here would conceal a real degraded state
+  // (org switch in flight, self-host missing DATABASE_URL) and is
+  // exactly the failure mode #2422 traced.
   if (groups.length === 0 && emptyReason) {
     return (
       <div
@@ -276,16 +287,24 @@ export function useChatEnvGroups(
         }
         const body = (await res.json()) as {
           groups?: ChatEnvGroup[];
-          reason?: MeConnectionGroupsEmptyReason | null;
+          reason?: unknown;
         };
         if (!cancelled) {
           setGroups(body.groups ?? []);
-          setReason(body.reason ?? null);
+          // Narrow unknown / unrecognized reason values to `null` —
+          // never index into `EMPTY_REASON_COPY` with a value the
+          // frontend hasn't been built to render.
+          setReason(isKnownEmptyReason(body.reason) ? body.reason : null);
         }
       })
       .catch((err: unknown) => {
         if (!cancelled) {
           const msg = err instanceof Error ? err.message : String(err);
+          // Surface to the console so a persistent 5xx or CORS
+          // regression leaves a breadcrumb. CLAUDE.md: every catch
+          // must log or rethrow — silent swallowing is what #2422
+          // existed to fix.
+          console.warn("[atlas-chat] failed to load connection groups", msg);
           setError(msg);
           setGroups([]);
           // Don't synthesize a `reason` on transport failure — the

--- a/packages/web/src/ui/components/chat/env-picker.tsx
+++ b/packages/web/src/ui/components/chat/env-picker.tsx
@@ -24,7 +24,7 @@
  */
 
 import { useEffect, useState } from "react";
-import { Layers } from "lucide-react";
+import { Layers, AlertCircle } from "lucide-react";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -35,6 +35,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Button } from "@/components/ui/button";
 import { stripGroupPrefix } from "@/ui/lib/strip-group-prefix";
+import type { MeConnectionGroupsEmptyReason } from "@/ui/lib/types";
 
 export interface ChatEnvMember {
   readonly connectionId: string;
@@ -51,6 +52,14 @@ export interface ChatEnvGroup {
 export interface ChatEnvPickerProps {
   /** Resolved groups from `/api/v1/me/connection-groups`. */
   readonly groups: ReadonlyArray<ChatEnvGroup>;
+  /**
+   * When `groups` is empty, this explains why. `null` ⇒ empty list is a
+   * normal "workspace has no group config yet" state (picker stays
+   * hidden, chat falls back to single-connection routing). A populated
+   * reason swaps the silent hide for an inline diagnostic chip. See
+   * #2422.
+   */
+  readonly emptyReason?: MeConnectionGroupsEmptyReason | null;
   /** Currently active group id. `null` ⇒ no group context yet. */
   readonly activeGroupId: string | null;
   /** Currently active member (execution target). `null` ⇒ inherit from group's first member. */
@@ -64,12 +73,37 @@ export interface ChatEnvPickerProps {
   readonly onSelect: (next: { groupId: string; connectionId: string }) => void;
 }
 
+const EMPTY_REASON_COPY: Record<MeConnectionGroupsEmptyReason, string> = {
+  no_active_org: "No active workspace — select one in the top bar.",
+  no_internal_db:
+    "Multi-environment features require an internal database. Self-hosters: set DATABASE_URL.",
+};
+
 export function ChatEnvPicker({
   groups,
+  emptyReason = null,
   activeGroupId,
   activeConnectionId,
   onSelect,
 }: ChatEnvPickerProps): React.ReactElement | null {
+  // Empty list + a reason ⇒ render a diagnostic chip instead of
+  // silently hiding. This is the #2422 fix: a mid-org-switch or
+  // unassigned user used to see a blank picker, hiding the 1.4.4
+  // multi-env feature behind a silent fallback.
+  if (groups.length === 0 && emptyReason) {
+    return (
+      <div
+        className="flex h-8 items-center gap-1.5 rounded-full border border-amber-200 bg-amber-50 px-2.5 text-xs font-medium text-amber-900 dark:border-amber-900/40 dark:bg-amber-950/30 dark:text-amber-200"
+        role="status"
+        data-testid="chat-env-picker-empty-reason"
+        data-reason={emptyReason}
+      >
+        <AlertCircle className="size-3.5" aria-hidden />
+        <span>{EMPTY_REASON_COPY[emptyReason]}</span>
+      </div>
+    );
+  }
+
   // Hide only the truly trivial 1×1 case: one group with one member.
   // The 0062 1:1 backfill emits N singleton groups for N legacy
   // connections, so anything ≥ 2 groups (even all singletons) is a
@@ -205,6 +239,7 @@ export interface UseChatEnvGroupsOptions {
 
 export interface UseChatEnvGroupsResult {
   readonly groups: ReadonlyArray<ChatEnvGroup>;
+  readonly reason: MeConnectionGroupsEmptyReason | null;
   readonly loading: boolean;
   readonly error: string | null;
 }
@@ -213,13 +248,14 @@ export interface UseChatEnvGroupsResult {
  * Fetches the user's accessible connection groups + members from
  * `/api/v1/me/connection-groups`. Defensive: a network or 5xx failure
  * surfaces as an empty list so the chat still renders, just without the
- * picker. The picker only hides itself when there's a single
- * single-member group — see {@link ChatEnvPicker} for the predicate.
+ * picker. `reason` mirrors the wire field so a known degraded state can
+ * render an explanatory chip instead of a silent hide — see #2422.
  */
 export function useChatEnvGroups(
   opts: UseChatEnvGroupsOptions,
 ): UseChatEnvGroupsResult {
   const [groups, setGroups] = useState<ReadonlyArray<ChatEnvGroup>>([]);
+  const [reason, setReason] = useState<MeConnectionGroupsEmptyReason | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -238,9 +274,13 @@ export function useChatEnvGroups(
           // list ⇒ picker hides itself.
           throw new Error(`HTTP ${res.status}`);
         }
-        const body = (await res.json()) as { groups?: ChatEnvGroup[] };
+        const body = (await res.json()) as {
+          groups?: ChatEnvGroup[];
+          reason?: MeConnectionGroupsEmptyReason | null;
+        };
         if (!cancelled) {
           setGroups(body.groups ?? []);
+          setReason(body.reason ?? null);
         }
       })
       .catch((err: unknown) => {
@@ -248,6 +288,11 @@ export function useChatEnvGroups(
           const msg = err instanceof Error ? err.message : String(err);
           setError(msg);
           setGroups([]);
+          // Don't synthesize a `reason` on transport failure — the
+          // server is the only source of truth for "empty because of
+          // X". A flaky network reading as "no_internal_db" would be
+          // misleading.
+          setReason(null);
         }
       })
       .finally(() => {
@@ -258,5 +303,5 @@ export function useChatEnvGroups(
     };
   }, [opts.apiUrl, opts.enabled, opts.getHeaders, opts.getCredentials]);
 
-  return { groups, loading, error };
+  return { groups, reason, loading, error };
 }

--- a/packages/web/src/ui/lib/types.ts
+++ b/packages/web/src/ui/lib/types.ts
@@ -188,3 +188,13 @@ export { parseChatError } from "@useatlas/types/errors";
 export type ShareStatus =
   | { shared: false }
   | { shared: true; token: string; url: string; expiresAt: string | null; shareMode: ShareMode };
+
+/**
+ * Wire shape of `GET /api/v1/me/connection-groups` (#2422). Mirrored
+ * here — not bumped into `@useatlas/types` — because there's no
+ * cross-package consumer yet (web is the only caller). If the SDK or
+ * another package starts consuming this, promote the type to
+ * `@useatlas/types` and re-export it via this file. See CLAUDE.md
+ * "Frontend is a pure HTTP client" and the user note on prompt 3.
+ */
+export type MeConnectionGroupsEmptyReason = "no_active_org" | "no_internal_db";

--- a/packages/web/src/ui/lib/types.ts
+++ b/packages/web/src/ui/lib/types.ts
@@ -195,6 +195,6 @@ export type ShareStatus =
  * cross-package consumer yet (web is the only caller). If the SDK or
  * another package starts consuming this, promote the type to
  * `@useatlas/types` and re-export it via this file. See CLAUDE.md
- * "Frontend is a pure HTTP client" and the user note on prompt 3.
+ * "Frontend is a pure HTTP client".
  */
 export type MeConnectionGroupsEmptyReason = "no_active_org" | "no_internal_db";


### PR DESCRIPTION
Closes #2422. Tracker #2407.

## Summary

`GET /api/v1/me/connection-groups` silently returned `{ groups: [] }` when:
1. The caller had no `activeOrganizationId` (mid-org-switch or unassigned user).
2. The internal DB wasn't configured (self-hosted without `DATABASE_URL`).

The chat fetches on `isSignedIn` (which doesn't check active org), so the env picker rendered nothing in both cases — hiding the 1.4.4 marquee multi-environment feature behind a silent empty state. Combined with #2408 (fixed), this was the last silent-empty path.

## Change

- API: route now returns `reason: "no_active_org" | "no_internal_db" | null`. Populated only for genuinely degraded empty states. A workspace with no groups configured returns `reason: null` (preserves the legacy single-connection fallback).
- Web: `useChatEnvGroups` plumbs `reason` through; `ChatEnvPicker` renders an inline diagnostic chip when `groups.length === 0 && reason` is set. Stays hidden when `reason === null`.
- Wire type lives in `packages/web/src/ui/lib/types.ts` (mirrored from the API route's exported `MeConnectionGroupsEmptyReason`). Not bumped into `@useatlas/types` — no cross-package consumer yet.
- OpenAPI spec regenerated; new field appears as `reason: "no_active_org" | "no_internal_db" | null`.

When both signals are degraded, `no_internal_db` wins — it's the more actionable diagnostic (deploy-side fix) and an unassigned user already sees the active-org cue in the top bar. Locked in a test.

## Test plan

- [x] `bun run test` — full API + web suites (148 web pass, all affected API pass)
- [x] `bun run type` — tsgo zero errors
- [x] `bun x syncpack lint` — clean
- [x] `bash scripts/check-template-drift.sh` / `check-schema-drift.sh` / `check-railway-watch.sh` / `check-security-headers-drift.sh` / `check-oauth-helper-drift.sh` — all pass
- [x] OpenAPI regen — `bun packages/api/scripts/extract-openapi.ts` produces clean diff with the new field
- [x] Unit tests — 6 route branch tests covering `no_active_org`, `no_internal_db`, precedence, `null` empty, populated groups, 401
- [x] RTL tests — 5 picker tests covering both reason renders, hidden when null, default-prop fallback, and ignore-reason-when-groups-non-empty precedence