### PR TITLE
refactor(types,api): make ExportedSemanticEntity.connectionGroupId optional (#2423)

### DIFF
--- a/apps/docs/content/docs/sdk/migration-0.1.mdx
+++ b/apps/docs/content/docs/sdk/migration-0.1.mdx
@@ -111,21 +111,37 @@ const entity: ExportedSemanticEntity = {
   connectionId: "warehouse-prod-1", // ← removed
 };
 
-// 0.1.0
+// 0.1.1
 const entity: ExportedSemanticEntity = {
   name: "users",
   entityType: "entity",
   yamlContent: "…",
-  connectionGroupId: "g_prod",
+  connectionGroupId: "g_prod", // optional — see below
 };
 ```
 
 Export bundles produced by `atlas export` (CLI) and
 `/api/v1/admin/migrate/export` (API) now exclusively carry
-`connectionGroupId`. Pre-1.4.4 bundles that only have `connectionId`
-need to be re-exported from a 1.4.4+ instance before they can be
-imported into 0.1.0 consumers — the `0066` backfill populates the new
-column from the legacy one during a one-time migration.
+`connectionGroupId`. The `0066` backfill populates the new column from
+the legacy `connectionId` during a one-time migration on the source
+instance.
+
+**`connectionGroupId` is optional on the wire (#2423, since `@useatlas/types@0.1.1`).**
+Three shapes are accepted by the import endpoint
+`/api/v1/admin/migrate/import`:
+
+| Producer | Wire shape | Imported as |
+| --- | --- | --- |
+| Pre-1.4.4 bundle | key omitted | `null` (legacy / unscoped row) |
+| Post-1.4.4 unscoped row | `connectionGroupId: null` | `null` |
+| Post-1.4.4 scoped row | `connectionGroupId: "g_prod"` | `"g_prod"` |
+
+`0.1.0` shipped the field as `string | null` (required). Older SDK
+consumers and bundles produced before the column existed couldn't
+satisfy that shape, so import failed strict validation. `0.1.1` widens
+the type to `string | null | undefined` and coalesces omitted to `null`
+on import — additive on the wire, behavior-preserving for 1.4.4+
+producers.
 
 ### `PIIColumnClassification`
 

--- a/apps/docs/content/docs/sdk/migration-0.1.mdx
+++ b/apps/docs/content/docs/sdk/migration-0.1.mdx
@@ -132,16 +132,22 @@ Three shapes are accepted by the import endpoint
 
 | Producer | Wire shape | Imported as |
 | --- | --- | --- |
-| Pre-1.4.4 bundle | key omitted | `null` (legacy / unscoped row) |
-| Post-1.4.4 unscoped row | `connectionGroupId: null` | `null` |
-| Post-1.4.4 scoped row | `connectionGroupId: "g_prod"` | `"g_prod"` |
+| Producer with no group concept (pre-1.4.4 bundle, older SDK) | key omitted | `null` |
+| 1.4.4+ author chose no group, or legacy `connectionId` did not resolve to a live group | `connectionGroupId: null` | `null` |
+| 1.4.4+ scoped row | `connectionGroupId: "g_prod"` | `"g_prod"` |
+
+The first two shapes land in the same column value (`null`) but encode
+different producer intents — preserved in the wire format so the
+distinction can be inspected at the boundary even though it's lost
+once the row is stored.
 
 `0.1.0` shipped the field as `string | null` (required). Older SDK
 consumers and bundles produced before the column existed couldn't
 satisfy that shape, so import failed strict validation. `0.1.1` widens
 the type to `string | null | undefined` and coalesces omitted to `null`
 on import — additive on the wire, behavior-preserving for 1.4.4+
-producers.
+producers. Non-string, non-null values (e.g. `42`, `{}`, `""`) are
+rejected with a 400 instead of slipping through to pg.
 
 ### `PIIColumnClassification`
 

--- a/packages/api/src/api/__tests__/admin-migrate.test.ts
+++ b/packages/api/src/api/__tests__/admin-migrate.test.ts
@@ -260,36 +260,44 @@ describe("bundle round-trip shape", () => {
 // ---------------------------------------------------------------------------
 // ExportedSemanticEntity.connectionGroupId optionality (#2423)
 // ---------------------------------------------------------------------------
-//
-// The wire shape accepts three forms — omitted (legacy pre-1.4.4 bundle),
-// explicit null (post-1.4.4 unscoped row), and an explicit string (group id).
-// The importer must coalesce all three into the same INSERT parameter so a
-// pre-1.4.4 producer that simply omits the key doesn't break strict shape
-// validation or insert `undefined` into pg.
 
-/** Build an empty bundle with a single semantic entity for importer probing. */
-function bundleWithEntity(entity: ExportedSemanticEntity): ExportBundle {
+function bundleWithEntities(entities: ExportedSemanticEntity[]): ExportBundle {
   return {
     manifest: {
       version: 1,
       exportedAt: "2026-05-15T00:00:00Z",
       source: { label: "test" },
-      counts: { conversations: 0, messages: 0, semanticEntities: 1, learnedPatterns: 0, settings: 0 },
+      counts: { conversations: 0, messages: 0, semanticEntities: entities.length, learnedPatterns: 0, settings: 0 },
     },
     conversations: [],
-    semanticEntities: [entity],
+    semanticEntities: entities,
     learnedPatterns: [],
     settings: [],
   };
 }
 
-/** Capturing in-memory InternalPoolClient — records every (sql, params) tuple. */
-function captureClient(): { client: InternalPoolClient; calls: Array<{ sql: string; params: unknown[] }> } {
+function bundleWithEntity(entity: ExportedSemanticEntity): ExportBundle {
+  return bundleWithEntities([entity]);
+}
+
+/**
+ * Capture-only in-memory pool client. The `existing` map gates which probes
+ * return a row (key = `${entityType}::${name}`) so we can drive the importer
+ * down both the insert and the idempotent-skip branches without spinning up
+ * pg.
+ */
+function captureClient(existing: Set<string> = new Set()): {
+  client: InternalPoolClient;
+  calls: Array<{ sql: string; params: unknown[] }>;
+} {
   const calls: Array<{ sql: string; params: unknown[] }> = [];
   const client: InternalPoolClient = {
     query: async (sql: string, params?: unknown[]) => {
       calls.push({ sql, params: params ?? [] });
-      // existing-row probes return empty so the importer always inserts
+      if (sql.includes("SELECT id FROM semantic_entities")) {
+        const [, entityType, name] = (params ?? []) as [string, string, string];
+        if (existing.has(`${entityType}::${name}`)) return { rows: [{ id: "existing" }] };
+      }
       return { rows: [] };
     },
     release: () => {},
@@ -299,49 +307,45 @@ function captureClient(): { client: InternalPoolClient; calls: Array<{ sql: stri
 
 describe("ExportedSemanticEntity.connectionGroupId — three import shapes", () => {
   it("accepts the omitted shape at compile time and at runtime", () => {
-    // Compile-time: this must type-check without `connectionGroupId`.
+    // Compile-time: must type-check without `connectionGroupId`. Without
+    // optionality on the type, this assignment would error at TS level.
     const legacyEntity: ExportedSemanticEntity = {
       name: "users",
       entityType: "entity",
       yamlContent: "table: users\n",
     };
 
-    const bundle = bundleWithEntity(legacyEntity);
-    const result = validateBundle(bundle);
+    const result = validateBundle(bundleWithEntity(legacyEntity));
     expect(result.ok).toBe(true);
   });
 
   it("accepts explicit null", () => {
-    const bundle = bundleWithEntity({
+    const result = validateBundle(bundleWithEntity({
       name: "users",
       entityType: "entity",
       yamlContent: "table: users\n",
       connectionGroupId: null,
-    });
-    const result = validateBundle(bundle);
+    }));
     expect(result.ok).toBe(true);
   });
 
   it("accepts an explicit string", () => {
-    const bundle = bundleWithEntity({
+    const result = validateBundle(bundleWithEntity({
       name: "users",
       entityType: "entity",
       yamlContent: "table: users\n",
       connectionGroupId: "g_prod_us",
-    });
-    const result = validateBundle(bundle);
+    }));
     expect(result.ok).toBe(true);
   });
 
   it("coalesces omitted connectionGroupId to null in the INSERT", async () => {
     const { client, calls } = captureClient();
-    const bundle = bundleWithEntity({
+    await importBundle(client, bundleWithEntity({
       name: "users",
       entityType: "entity",
       yamlContent: "table: users\n",
-    });
-
-    await importBundle(client, bundle, "org-test");
+    }), "org-test");
 
     const insert = calls.find((c) => c.sql.includes("INSERT INTO semantic_entities"));
     expect(insert).toBeDefined();
@@ -351,14 +355,12 @@ describe("ExportedSemanticEntity.connectionGroupId — three import shapes", () 
 
   it("preserves explicit null in the INSERT", async () => {
     const { client, calls } = captureClient();
-    const bundle = bundleWithEntity({
+    await importBundle(client, bundleWithEntity({
       name: "users",
       entityType: "entity",
       yamlContent: "table: users\n",
       connectionGroupId: null,
-    });
-
-    await importBundle(client, bundle, "org-test");
+    }), "org-test");
 
     const insert = calls.find((c) => c.sql.includes("INSERT INTO semantic_entities"));
     expect(insert?.params[4]).toBeNull();
@@ -366,16 +368,98 @@ describe("ExportedSemanticEntity.connectionGroupId — three import shapes", () 
 
   it("forwards an explicit group id into the INSERT", async () => {
     const { client, calls } = captureClient();
-    const bundle = bundleWithEntity({
+    await importBundle(client, bundleWithEntity({
       name: "users",
       entityType: "entity",
       yamlContent: "table: users\n",
       connectionGroupId: "g_prod_us",
-    });
-
-    await importBundle(client, bundle, "org-test");
+    }), "org-test");
 
     const insert = calls.find((c) => c.sql.includes("INSERT INTO semantic_entities"));
     expect(insert?.params[4]).toBe("g_prod_us");
+  });
+
+  it("emits one INSERT per entity for a mixed-shape bundle, in order", async () => {
+    const { client, calls } = captureClient();
+    await importBundle(client, bundleWithEntities([
+      { name: "users", entityType: "entity", yamlContent: "table: users\n" },
+      { name: "orders", entityType: "entity", yamlContent: "table: orders\n", connectionGroupId: null },
+      { name: "events", entityType: "entity", yamlContent: "table: events\n", connectionGroupId: "g_prod_us" },
+    ]), "org-test");
+
+    const inserts = calls.filter((c) => c.sql.includes("INSERT INTO semantic_entities"));
+    expect(inserts).toHaveLength(3);
+    expect(inserts[0].params[2]).toBe("users");
+    expect(inserts[0].params[4]).toBeNull();
+    expect(inserts[1].params[2]).toBe("orders");
+    expect(inserts[1].params[4]).toBeNull();
+    expect(inserts[2].params[2]).toBe("events");
+    expect(inserts[2].params[4]).toBe("g_prod_us");
+  });
+
+  it("skips re-import when the entity already exists, regardless of wire shape", async () => {
+    const { client, calls } = captureClient(new Set(["entity::users"]));
+    const result = await importBundle(client, bundleWithEntity({
+      name: "users",
+      entityType: "entity",
+      yamlContent: "table: users\n",
+      // omitted connectionGroupId — confirms the skip path doesn't depend
+      // on the field being present.
+    }), "org-test");
+
+    const inserts = calls.filter((c) => c.sql.includes("INSERT INTO semantic_entities"));
+    expect(inserts).toHaveLength(0);
+    expect(result.semanticEntities.skipped).toBe(1);
+    expect(result.semanticEntities.imported).toBe(0);
+  });
+});
+
+describe("validateBundle — connectionGroupId type guard", () => {
+  // Optionality widens the field to `string | null | undefined`. Anything
+  // else is a producer bug and must surface as a 400 — never reach pg.
+  function bundleWithRawEntity(entity: Record<string, unknown>): unknown {
+    return {
+      manifest: { version: 1, exportedAt: "x", source: { label: "x" }, counts: { conversations: 0, messages: 0, semanticEntities: 1, learnedPatterns: 0, settings: 0 } },
+      conversations: [],
+      semanticEntities: [entity],
+      learnedPatterns: [],
+      settings: [],
+    };
+  }
+
+  function rejected(value: unknown): string | undefined {
+    const result = validateBundle(bundleWithRawEntity({
+      name: "users",
+      entityType: "entity",
+      yamlContent: "table: users\n",
+      connectionGroupId: value,
+    }));
+    return result.ok ? undefined : result.error;
+  }
+
+  it("rejects a numeric connectionGroupId", () => {
+    const err = rejected(42);
+    expect(err).toBeDefined();
+    expect(err).toContain("semanticEntities[0].connectionGroupId");
+  });
+
+  it("rejects an object connectionGroupId", () => {
+    expect(rejected({})).toContain("semanticEntities[0].connectionGroupId");
+  });
+
+  it("rejects an array connectionGroupId", () => {
+    expect(rejected([])).toContain("semanticEntities[0].connectionGroupId");
+  });
+
+  it("rejects an empty-string connectionGroupId", () => {
+    // Empty string would silently insert "" and fail the FK lookup later.
+    // Reject upfront so the producer sees a clear 400.
+    expect(rejected("")).toContain("semanticEntities[0].connectionGroupId");
+  });
+
+  it("accepts undefined, null, and a non-empty string", () => {
+    expect(rejected(undefined)).toBeUndefined();
+    expect(rejected(null)).toBeUndefined();
+    expect(rejected("g_prod_us")).toBeUndefined();
   });
 });

--- a/packages/api/src/api/__tests__/admin-migrate.test.ts
+++ b/packages/api/src/api/__tests__/admin-migrate.test.ts
@@ -6,8 +6,9 @@
  */
 
 import { describe, it, expect } from "bun:test";
-import type { ExportBundle, ImportResult } from "@useatlas/types";
-import { validateBundle } from "../routes/admin-migrate";
+import type { ExportBundle, ExportedSemanticEntity, ImportResult } from "@useatlas/types";
+import type { InternalPoolClient } from "@atlas/api/lib/db/internal";
+import { importBundle, validateBundle } from "../routes/admin-migrate";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -253,5 +254,128 @@ describe("bundle round-trip shape", () => {
     expect(total(result.semanticEntities)).toBe(5);
     expect(total(result.learnedPatterns)).toBe(4);
     expect(total(result.settings)).toBe(8);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ExportedSemanticEntity.connectionGroupId optionality (#2423)
+// ---------------------------------------------------------------------------
+//
+// The wire shape accepts three forms — omitted (legacy pre-1.4.4 bundle),
+// explicit null (post-1.4.4 unscoped row), and an explicit string (group id).
+// The importer must coalesce all three into the same INSERT parameter so a
+// pre-1.4.4 producer that simply omits the key doesn't break strict shape
+// validation or insert `undefined` into pg.
+
+/** Build an empty bundle with a single semantic entity for importer probing. */
+function bundleWithEntity(entity: ExportedSemanticEntity): ExportBundle {
+  return {
+    manifest: {
+      version: 1,
+      exportedAt: "2026-05-15T00:00:00Z",
+      source: { label: "test" },
+      counts: { conversations: 0, messages: 0, semanticEntities: 1, learnedPatterns: 0, settings: 0 },
+    },
+    conversations: [],
+    semanticEntities: [entity],
+    learnedPatterns: [],
+    settings: [],
+  };
+}
+
+/** Capturing in-memory InternalPoolClient — records every (sql, params) tuple. */
+function captureClient(): { client: InternalPoolClient; calls: Array<{ sql: string; params: unknown[] }> } {
+  const calls: Array<{ sql: string; params: unknown[] }> = [];
+  const client: InternalPoolClient = {
+    query: async (sql: string, params?: unknown[]) => {
+      calls.push({ sql, params: params ?? [] });
+      // existing-row probes return empty so the importer always inserts
+      return { rows: [] };
+    },
+    release: () => {},
+  };
+  return { client, calls };
+}
+
+describe("ExportedSemanticEntity.connectionGroupId — three import shapes", () => {
+  it("accepts the omitted shape at compile time and at runtime", () => {
+    // Compile-time: this must type-check without `connectionGroupId`.
+    const legacyEntity: ExportedSemanticEntity = {
+      name: "users",
+      entityType: "entity",
+      yamlContent: "table: users\n",
+    };
+
+    const bundle = bundleWithEntity(legacyEntity);
+    const result = validateBundle(bundle);
+    expect(result.ok).toBe(true);
+  });
+
+  it("accepts explicit null", () => {
+    const bundle = bundleWithEntity({
+      name: "users",
+      entityType: "entity",
+      yamlContent: "table: users\n",
+      connectionGroupId: null,
+    });
+    const result = validateBundle(bundle);
+    expect(result.ok).toBe(true);
+  });
+
+  it("accepts an explicit string", () => {
+    const bundle = bundleWithEntity({
+      name: "users",
+      entityType: "entity",
+      yamlContent: "table: users\n",
+      connectionGroupId: "g_prod_us",
+    });
+    const result = validateBundle(bundle);
+    expect(result.ok).toBe(true);
+  });
+
+  it("coalesces omitted connectionGroupId to null in the INSERT", async () => {
+    const { client, calls } = captureClient();
+    const bundle = bundleWithEntity({
+      name: "users",
+      entityType: "entity",
+      yamlContent: "table: users\n",
+    });
+
+    await importBundle(client, bundle, "org-test");
+
+    const insert = calls.find((c) => c.sql.includes("INSERT INTO semantic_entities"));
+    expect(insert).toBeDefined();
+    // 5-tuple: org_id, entity_type, name, yaml_content, connection_group_id
+    expect(insert?.params[4]).toBeNull();
+  });
+
+  it("preserves explicit null in the INSERT", async () => {
+    const { client, calls } = captureClient();
+    const bundle = bundleWithEntity({
+      name: "users",
+      entityType: "entity",
+      yamlContent: "table: users\n",
+      connectionGroupId: null,
+    });
+
+    await importBundle(client, bundle, "org-test");
+
+    const insert = calls.find((c) => c.sql.includes("INSERT INTO semantic_entities"));
+    expect(insert?.params[4]).toBeNull();
+  });
+
+  it("forwards an explicit group id into the INSERT", async () => {
+    const { client, calls } = captureClient();
+    const bundle = bundleWithEntity({
+      name: "users",
+      entityType: "entity",
+      yamlContent: "table: users\n",
+      connectionGroupId: "g_prod_us",
+    });
+
+    await importBundle(client, bundle, "org-test");
+
+    const insert = calls.find((c) => c.sql.includes("INSERT INTO semantic_entities"));
+    expect(insert?.params[4]).toBe("g_prod_us");
   });
 });

--- a/packages/api/src/api/routes/admin-migrate.ts
+++ b/packages/api/src/api/routes/admin-migrate.ts
@@ -64,6 +64,14 @@ export function validateBundle(body: unknown): { ok: true; bundle: ExportBundle 
     if (!e || typeof e !== "object" || typeof e.name !== "string" || typeof e.entityType !== "string" || typeof e.yamlContent !== "string") {
       return { ok: false, error: `semanticEntities[${i}]: must have 'name', 'entityType', and 'yamlContent' (strings).` };
     }
+    // `connectionGroupId` is optional (#2423). When present it must be either
+    // null or a non-empty string — anything else (numbers, objects, "") would
+    // pass the `?? null` coalesce and reach pg as junk.
+    if ("connectionGroupId" in e && e.connectionGroupId !== null && e.connectionGroupId !== undefined) {
+      if (typeof e.connectionGroupId !== "string" || e.connectionGroupId.length === 0) {
+        return { ok: false, error: `semanticEntities[${i}].connectionGroupId: must be a non-empty string, null, or omitted.` };
+      }
+    }
   }
 
   // Validate required fields on each learned pattern
@@ -225,9 +233,9 @@ export async function importBundle(
       continue;
     }
 
-    // `connectionGroupId` is optional on the wire (#2423) — pre-1.4.4
-    // bundles omit the key entirely. Coalesce to null so the legacy /
-    // unscoped row is stored consistently regardless of producer.
+    // `connectionGroupId` is optional on the wire — bundles from producers
+    // that have no concept of the column omit the key entirely. Coalesce to
+    // null so omitted and explicit-null land in the same column shape.
     await client.query(
       `INSERT INTO semantic_entities (org_id, entity_type, name, yaml_content, connection_group_id)
        VALUES ($1, $2, $3, $4, $5)`,

--- a/packages/api/src/api/routes/admin-migrate.ts
+++ b/packages/api/src/api/routes/admin-migrate.ts
@@ -225,10 +225,13 @@ export async function importBundle(
       continue;
     }
 
+    // `connectionGroupId` is optional on the wire (#2423) — pre-1.4.4
+    // bundles omit the key entirely. Coalesce to null so the legacy /
+    // unscoped row is stored consistently regardless of producer.
     await client.query(
       `INSERT INTO semantic_entities (org_id, entity_type, name, yaml_content, connection_group_id)
        VALUES ($1, $2, $3, $4, $5)`,
-      [orgId, entity.entityType, entity.name, entity.yamlContent, entity.connectionGroupId],
+      [orgId, entity.entityType, entity.name, entity.yamlContent, entity.connectionGroupId ?? null],
     );
     result.semanticEntities.imported++;
   }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useatlas/types",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Shared types for the Atlas text-to-SQL agent",
   "type": "module",
   "scripts": {

--- a/packages/types/src/migration.ts
+++ b/packages/types/src/migration.ts
@@ -60,21 +60,18 @@ export interface ExportedSemanticEntity {
   entityType: string;
   yamlContent: string;
   /**
-   * Group scope (multi-environment semantic layer, #2340).
+   * Group scope (multi-environment semantic layer, #2340). Three accepted
+   * shapes:
+   * - **omitted** — producer with no group concept (pre-1.4.4 bundle).
+   *   Importers coalesce this to `null`.
+   * - **explicit `null`** — 1.4.4+ unscoped row (global / no binding), or a
+   *   bundle whose legacy `connectionId` no longer resolves to a live group.
+   * - **explicit string** — group id. One entity row per group; multi-member
+   *   groups share the same definition.
    *
-   * Three accepted shapes (#2423):
-   * - **omitted** — pre-1.4.4 bundle exported before the group column
-   *   existed. Importers coalesce this to `null`.
-   * - **explicit `null`** — post-1.4.4 unscoped row (global / no group
-   *   binding), or a bundle whose legacy `connectionId` no longer
-   *   resolves to a live group.
-   * - **explicit string** — group id. One entity row per group;
-   *   multi-member groups share the same definition.
-   *
-   * The field is optional because strict shape validation on import
-   * would otherwise reject pre-1.4.4 producers that have no concept
-   * of the column. Value-nullability alone wasn't enough — optionality
-   * is what makes the field additive on the wire.
+   * Optional because strict shape validation on import would otherwise reject
+   * producers that have no concept of the column. Value-nullability alone
+   * wasn't enough — optionality is what makes the field additive on the wire.
    */
   connectionGroupId?: string | null;
 }

--- a/packages/types/src/migration.ts
+++ b/packages/types/src/migration.ts
@@ -60,13 +60,23 @@ export interface ExportedSemanticEntity {
   entityType: string;
   yamlContent: string;
   /**
-   * Group scope (multi-environment semantic layer, #2340). One entity
-   * row per group — multi-member groups share the same definition.
-   * Nullable for global / unscoped entities and for bundles exported
-   * by pre-1.4.4 instances whose legacy `connectionId` no longer
-   * resolves to a live group.
+   * Group scope (multi-environment semantic layer, #2340).
+   *
+   * Three accepted shapes (#2423):
+   * - **omitted** — pre-1.4.4 bundle exported before the group column
+   *   existed. Importers coalesce this to `null`.
+   * - **explicit `null`** — post-1.4.4 unscoped row (global / no group
+   *   binding), or a bundle whose legacy `connectionId` no longer
+   *   resolves to a live group.
+   * - **explicit string** — group id. One entity row per group;
+   *   multi-member groups share the same definition.
+   *
+   * The field is optional because strict shape validation on import
+   * would otherwise reject pre-1.4.4 producers that have no concept
+   * of the column. Value-nullability alone wasn't enough — optionality
+   * is what makes the field additive on the wire.
    */
-  connectionGroupId: string | null;
+  connectionGroupId?: string | null;
 }
 
 /** Exported learned pattern. */


### PR DESCRIPTION
## Summary

- Widens `ExportedSemanticEntity.connectionGroupId` from `string | null` (required) to `string | null | undefined` (optional). Pre-1.4.4 producers that omit the key now satisfy strict shape validation on import — value-nullability alone wasn't enough; optionality is what makes the field additive on the wire.
- `importBundle` in `packages/api/src/api/routes/admin-migrate.ts` coalesces `entity.connectionGroupId ?? null` so omitted, explicit-null, and explicit-string producers all land in the same INSERT column shape.
- Bumps `@useatlas/types` 0.1.0 → 0.1.1 (patch — additive widening). **Consumer dep refs (sdk/react/templates) deferred to a follow-up PR after the npm tag publishes** per the [version-bump-ordering playbook](https://github.com/AtlasDevHQ/atlas/blob/main/.claude/CLAUDE.md). Bumping refs in this PR would break Deploy Validation scaffold (unpublished version).

## Why

PR #2400 claimed the field was "additive" by allowing `null`, but kept it required — so any bundle that simply omitted the key still failed strict shape validation. That broke import for older SDK consumers and bundles produced before 1.4.4. Tracker: #2407.

## Test plan

- [x] `bun test src/api/__tests__/admin-migrate.test.ts` — 24 pass / 0 fail (5 new tests covering the three shapes + INSERT param assertions)
- [x] `bun run type` — clean across workspace (was failing before the type widening)
- [x] `bun run lint` — clean (1 pre-existing warning in `detect.test.ts`, unrelated)
- [x] `bun run test` — full suite green
- [x] `bun x syncpack lint` — no issues (workspace consumers use `workspace:*`, so the `0.1.0` → `0.1.1` bump propagates without ref edits)
- [x] Template drift / railway-watch / schema-drift / oauth-helper / security-headers — all pass
- [ ] After merge: tag `types-v0.1.1`, wait for OIDC publish workflow, then open follow-up PR bumping `^0.1.0` → `^0.1.1` in `packages/sdk`, `packages/react`, `create-atlas/templates/*`

## Acceptance criteria (from prompt)

- [x] Type accepts entities with `connectionGroupId` omitted, explicitly null, or a string
- [x] Existing call sites continue to work (no behavior change for current producers — the API/CLI exporters always emit a concrete `string | null`)
- [x] Unit test covers all three import shapes against the import-side coalescing
- [x] `@useatlas/types` package.json bumped to 0.1.1 in this PR
- [x] Templates and SDK ref bumps NOT bumped here (deferred to follow-up post-publish)

Closes #2423.