### PR TITLE
chore(test,web): drop dead error hooks + redundant Retry spinner

### DIFF
--- a/packages/api/src/api/__tests__/admin-compliance.test.ts
+++ b/packages/api/src/api/__tests__/admin-compliance.test.ts
@@ -121,7 +121,6 @@ interface PIIClassification {
 }
 
 let mockGetClassification: PIIClassification | null = null;
-let mockGetClassificationError: Error | null = null;
 let mockUpdateResult: PIIClassification | null = null;
 let mockUpdateError: Error | null = null;
 let mockDeleteError: Error | null = null;
@@ -130,10 +129,7 @@ const mockInvalidate: Mock<(orgId: string) => void> = mock(() => {});
 mock.module("@atlas/ee/compliance/masking", () => ({
   ComplianceError: RealComplianceError,
   listPIIClassifications: () => Effect.succeed([]),
-  getPIIClassification: () => {
-    if (mockGetClassificationError) return Effect.fail(mockGetClassificationError);
-    return Effect.succeed(mockGetClassification);
-  },
+  getPIIClassification: () => Effect.succeed(mockGetClassification),
   updatePIIClassification: () => {
     if (mockUpdateError) return Effect.fail(mockUpdateError);
     return Effect.succeed(mockUpdateResult);
@@ -198,7 +194,6 @@ function makeClassification(
 
 function resetMocks(): void {
   mockGetClassification = null;
-  mockGetClassificationError = null;
   mockUpdateResult = null;
   mockUpdateError = null;
   mockDeleteError = null;

--- a/packages/api/src/lib/__tests__/startup-first-run.test.ts
+++ b/packages/api/src/lib/__tests__/startup-first-run.test.ts
@@ -8,7 +8,6 @@ import { createConnectionMock } from "@atlas/api/testing/connection";
 
 let mockDatasourceUrl: string | null = null;
 let mockSemanticFiles: string[] | Error = ["orders.yml"];
-let mockPgConnectError: Error | null = null;
 let mockMysqlConnectError: Error | null = null;
 let mockConfigResult: Record<string, unknown> | null = { source: "env" };
 let mockConfigLoadError: Error | null = null;
@@ -42,7 +41,6 @@ mock.module("@atlas/api/lib/providers", () => ({
 mock.module("pg", () => ({
   Pool: class MockPool {
     async connect() {
-      if (mockPgConnectError) throw mockPgConnectError;
       return {
         release: () => {},
         query: async () => ({ rows: [{ "?column?": 1 }] }),
@@ -125,7 +123,6 @@ beforeEach(() => {
   process.env.ATLAS_PROVIDER = "ollama";
   mockDatasourceUrl = null;
   mockSemanticFiles = ["orders.yml"];
-  mockPgConnectError = null;
   mockMysqlConnectError = null;
   mockConfigResult = { source: "env" };
   mockConfigLoadError = null;

--- a/packages/api/src/lib/residency/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/residency/__tests__/migrate.test.ts
@@ -11,7 +11,6 @@ import { describe, it, expect, beforeEach, mock, afterEach } from "bun:test";
 
 let mockHasInternalDB = true;
 let mockQueryResults: Record<string, unknown[]> = {};
-let mockQueryError: Error | null = null;
 // Per-SQL injection: when set, internalQuery rejects on the first call whose
 // SQL contains the pattern. Used to exercise transient-failure paths on a
 // specific statement without breaking unrelated queries.
@@ -39,7 +38,6 @@ mock.module("@atlas/api/lib/db/internal", () => ({
   }),
   internalQuery: (sql: string, params: unknown[]) => {
     capturedQueries.push({ sql, params });
-    if (mockQueryError) return Promise.reject(mockQueryError);
     if (mockInternalQueryRejectPattern && sql.includes(mockInternalQueryRejectPattern.pattern)) {
       return Promise.reject(mockInternalQueryRejectPattern.error);
     }
@@ -122,7 +120,6 @@ const {
 function resetMocks() {
   mockHasInternalDB = true;
   mockQueryResults = {};
-  mockQueryError = null;
   mockInternalQueryRejectPattern = null;
   mockPoolQueryResult = { rows: [{ id: "org-1" }] };
   mockPoolQueryError = null;

--- a/packages/mcp/src/__tests__/prompts/listing.test.ts
+++ b/packages/mcp/src/__tests__/prompts/listing.test.ts
@@ -17,7 +17,6 @@ import * as path from "path";
 let mockHasInternalDB = false;
 let mockInternalQueryRows: Record<string, unknown>[] = [];
 let mockInternalQueryError: Error | null = null;
-let mockSemanticRootError: Error | null = null;
 let mockScannedEntities: Array<{
   filePath: string;
   sourceName: string;
@@ -26,10 +25,7 @@ let mockScannedEntities: Array<{
 let mockSettings: Record<string, string | undefined> = {};
 
 mock.module("@atlas/api/lib/semantic/files", () => ({
-  getSemanticRoot: () => {
-    if (mockSemanticRootError) throw mockSemanticRootError;
-    return "/tmp/atlas-test-semantic";
-  },
+  getSemanticRoot: () => "/tmp/atlas-test-semantic",
 }));
 
 mock.module("@atlas/api/lib/semantic/scanner", () => ({
@@ -72,7 +68,6 @@ beforeEach(() => {
   mockHasInternalDB = false;
   mockInternalQueryRows = [];
   mockInternalQueryError = null;
-  mockSemanticRootError = null;
   mockScannedEntities = [];
   mockSettings = {};
 });

--- a/packages/web/src/app/platform/plugin-registry/page.tsx
+++ b/packages/web/src/app/platform/plugin-registry/page.tsx
@@ -404,9 +404,7 @@ function PluginRow({
               variant="outline"
               size="sm"
               onClick={() => void loadSchema()}
-              disabled={schemaLoading}
             >
-              {schemaLoading && <Loader2 className="mr-1.5 size-3.5 animate-spin" />}
               Retry
             </Button>
           </div>

--- a/packages/web/src/ui/__tests__/platform-security-page.test.tsx
+++ b/packages/web/src/ui/__tests__/platform-security-page.test.tsx
@@ -29,15 +29,14 @@ mock.module("next/navigation", () => ({
 }));
 
 let mockData: PlatformSecurityMetrics | null = null;
-let mockError: { message: string; status?: number; code?: string } | null = null;
 let mockLoading = false;
 let guardBlocked = false;
 
 mock.module("@/ui/hooks/use-admin-fetch", () => ({
   useAdminFetch: () => ({
-    data: mockError ? null : mockData,
+    data: mockData,
     loading: mockLoading,
-    error: mockError,
+    error: null,
     setError: () => {},
     refetch: () => Promise.resolve(),
   }),
@@ -89,7 +88,6 @@ function workspace(
 afterEach(() => {
   cleanup();
   mockData = null;
-  mockError = null;
   mockLoading = false;
   guardBlocked = false;
 });


### PR DESCRIPTION
## Summary
Cleanup of 6 always-false branches surfaced by static analysis (CodeQL `js/useless-conditional` from a local IDE scan — no GitHub alerts open).

- 5 test files had `mockError`-style hook variables declared, referenced in `mock.module(...)` factories, and reset in `beforeEach`, but never assigned a truthy value in any test. Sibling error vars in the same files (`mockMysqlConnectError`, `mockUpdateError`, `mockInternalQueryError`, …) are exercised, so these were leftover hooks for tests that never landed. Removed the var + the `if (...)` branch + the reset line.
- `packages/web/src/app/platform/plugin-registry/page.tsx` Retry button had `disabled={schemaLoading}` and a `{schemaLoading && <Loader2 />}` spinner inside a ternary branch the parent only enters when `schemaLoading === false`. Both dead — removed.

No behavior change.

## Test plan
- [x] `bun run type` clean
- [x] `bun run lint` clean (one pre-existing unrelated warning)
- [x] All 6 modified test/page files exercised: migrate, startup-first-run, admin-compliance, mcp listing, platform-security-page — all pass