### PR TITLE
feat(web): block chat + notebook AI when workspace has no data

### DIFF
--- a/packages/web/src/app/(workspace)/notebook/page.tsx
+++ b/packages/web/src/app/(workspace)/notebook/page.tsx
@@ -8,6 +8,7 @@ import { notebookSearchParams } from "./search-params";
 import { useNotebook } from "@/ui/components/notebook/use-notebook";
 import { NotebookShell } from "@/ui/components/notebook/notebook-shell";
 import { useConversations, transformMessages } from "@/ui/hooks/use-conversations";
+import { useDatasourceSummary } from "@/ui/hooks/use-datasource-summary";
 import { getApiUrl, isCrossOrigin } from "@/lib/api-url";
 import { useAtlasTransport } from "@/ui/hooks/use-atlas-transport";
 import { authClient } from "@/lib/auth/client";
@@ -85,6 +86,17 @@ function NotebookContent() {
     getHeaders,
     getCredentials,
   });
+
+  // Block the composer when the workspace has no queryable tables — same gate
+  // as the chat empty state so an agent never gets a chance to fail downstream
+  // for the "no data yet" case.
+  const datasource = useDatasourceSummary({
+    apiUrl: getApiUrl(),
+    isCrossOrigin: isCrossOrigin(),
+    getHeaders,
+    enabled: authResolved && isSignedIn,
+  });
+  const needsDataSetup = datasource.data?.tableCount === 0;
 
   const refreshConvosRef = useRef(convos.refresh);
   refreshConvosRef.current = convos.refresh;
@@ -329,6 +341,8 @@ function NotebookContent() {
           notebook={notebook}
           focusCellId={focusCellId}
           onShareAsReport={handleShareAsReport}
+          isAdmin={isAdmin}
+          needsDataSetup={needsDataSetup}
           starterPrompts={{
             apiUrl: getApiUrl(),
             isCrossOrigin: isCrossOrigin(),

--- a/packages/web/src/app/(workspace)/page.tsx
+++ b/packages/web/src/app/(workspace)/page.tsx
@@ -27,6 +27,7 @@ import { parseSuggestions } from "@/ui/lib/helpers";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Button } from "@/components/ui/button";
 import { AskComposer } from "@/ui/components/ask-composer";
+import { ConnectDataPrompt } from "@/ui/components/connect-data-prompt";
 import { EmptyAskHero } from "@/ui/components/empty-ask-hero";
 import { useDashboardCanvasStore, type ProposedDashboardSpec } from "@/lib/stores/dashboard-canvas-store";
 import { DashboardCanvas } from "@/ui/components/dashboards/dashboard-canvas";
@@ -131,6 +132,13 @@ function ChatPage() {
     getHeaders,
     enabled: authResolved && isSignedIn,
   });
+
+  // True only when the summary has resolved (not in-flight, not an error
+  // soft-fail to null) AND there are zero queryable tables. The composer
+  // and starter prompts are hidden in this state so the user is funneled
+  // into setting up a connection before the agent gets a chance to run
+  // and fail confusingly downstream.
+  const needsDataSetup = datasource.data?.tableCount === 0;
 
   const refreshConvosRef = useRef(convos.refresh);
   refreshConvosRef.current = convos.refresh;
@@ -422,38 +430,42 @@ function ChatPage() {
               <ScrollArea viewportRef={scrollRef} className="min-h-0 flex-1">
                 <div className="space-y-4 pb-4">
                   {messages.length === 0 && !chatError && (
-                    <EmptyAskHero
-                      heading="Ask Atlas about your data."
-                      subhead={
-                        datasource.data && datasource.data.tableCount > 0 ? (
-                          <>
-                            Grounded in your semantic layer —{" "}
-                            <span className="font-medium text-primary">
-                              {datasource.data.tableCount} table
-                              {datasource.data.tableCount === 1 ? "" : "s"}
-                            </span>{" "}
-                            ready to query.
-                          </>
-                        ) : (
-                          "Every answer cites the table it queried."
-                        )
-                      }
-                    >
-                      {starterPrompts.length > 0 && (
-                        <div className="grid w-full max-w-lg grid-cols-1 gap-2 sm:grid-cols-2">
-                          {starterPrompts.map((prompt) => (
-                            <Button
-                              key={prompt.id}
-                              variant="outline"
-                              onClick={() => handleSend(prompt.text)}
-                              className="h-auto whitespace-normal justify-start rounded-lg px-3 py-2.5 text-left text-sm"
-                            >
-                              {prompt.text}
-                            </Button>
-                          ))}
-                        </div>
-                      )}
-                    </EmptyAskHero>
+                    needsDataSetup ? (
+                      <ConnectDataPrompt isAdmin={isAdmin} />
+                    ) : (
+                      <EmptyAskHero
+                        heading="Ask Atlas about your data."
+                        subhead={
+                          datasource.data && datasource.data.tableCount > 0 ? (
+                            <>
+                              Grounded in your semantic layer —{" "}
+                              <span className="font-medium text-primary">
+                                {datasource.data.tableCount} table
+                                {datasource.data.tableCount === 1 ? "" : "s"}
+                              </span>{" "}
+                              ready to query.
+                            </>
+                          ) : (
+                            "Every answer cites the table it queried."
+                          )
+                        }
+                      >
+                        {starterPrompts.length > 0 && (
+                          <div className="grid w-full max-w-lg grid-cols-1 gap-2 sm:grid-cols-2">
+                            {starterPrompts.map((prompt) => (
+                              <Button
+                                key={prompt.id}
+                                variant="outline"
+                                onClick={() => handleSend(prompt.text)}
+                                className="h-auto whitespace-normal justify-start rounded-lg px-3 py-2.5 text-left text-sm"
+                              >
+                                {prompt.text}
+                              </Button>
+                            ))}
+                          </div>
+                        )}
+                      </EmptyAskHero>
+                    )
                   )}
 
                   {messages.map((m, msgIndex) => {
@@ -585,15 +597,18 @@ function ChatPage() {
                 />
               )}
 
-              {/* Input */}
-              <AskComposer
-                value={input}
-                onChange={setInput}
-                onSubmit={() => handleSend(input)}
-                disabled={isLoading}
-                placeholder="Ask a question about your data… ⌘K for commands"
-                inputAriaLabel="Chat message"
-              />
+              {/* Input — hidden when the workspace has no data so the user
+                   sets up a connection before the agent can run. */}
+              {!(needsDataSetup && messages.length === 0) && (
+                <AskComposer
+                  value={input}
+                  onChange={setInput}
+                  onSubmit={() => handleSend(input)}
+                  disabled={isLoading}
+                  placeholder="Ask a question about your data… ⌘K for commands"
+                  inputAriaLabel="Chat message"
+                />
+              )}
             </div>
           </div>
 

--- a/packages/web/src/ui/components/connect-data-prompt.tsx
+++ b/packages/web/src/ui/components/connect-data-prompt.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { EmptyAskHero } from "./empty-ask-hero";
+
+interface ConnectDataPromptProps {
+  /** When true, render the admin CTA button; otherwise render explanatory copy. */
+  isAdmin: boolean;
+}
+
+export function ConnectDataPrompt({ isAdmin }: ConnectDataPromptProps) {
+  return (
+    <EmptyAskHero
+      heading="Connect data to get started"
+      subhead="Atlas needs a database connection or our demo dataset before it can answer questions."
+    >
+      {isAdmin ? (
+        <Button asChild>
+          <Link href="/signup/connect">Set up a connection</Link>
+        </Button>
+      ) : (
+        <p className="max-w-sm text-sm text-zinc-500 dark:text-zinc-400">
+          Ask your workspace admin to connect a database — once it's set up, you&apos;ll be able to ask questions here.
+        </p>
+      )}
+    </EmptyAskHero>
+  );
+}

--- a/packages/web/src/ui/components/notebook/notebook-shell.tsx
+++ b/packages/web/src/ui/components/notebook/notebook-shell.tsx
@@ -8,6 +8,7 @@ import { NotebookCell } from "./notebook-cell";
 import { NotebookTextCell } from "./notebook-text-cell";
 import { NotebookEmptyState } from "./notebook-empty-state";
 import { AskComposer } from "../ask-composer";
+import { ConnectDataPrompt } from "../connect-data-prompt";
 import { DeleteCellDialog } from "./delete-cell-dialog";
 import { ForkBranchSelector } from "./fork-branch-selector";
 import { exportToMarkdown, exportToHTML, downloadFile } from "./notebook-export";
@@ -32,6 +33,14 @@ interface NotebookShellProps {
   focusCellId?: string;
   /** When provided, enables the "Share as Report" button. Returns the share token. */
   onShareAsReport?: () => Promise<string>;
+  /** Whether the current user has admin privileges — drives the no-data CTA. */
+  isAdmin?: boolean;
+  /**
+   * True only when the datasource summary has resolved with zero tables.
+   * In that state the empty state shows a "Connect data" CTA and the
+   * composer is hidden so the agent never gets a chance to fail downstream.
+   */
+  needsDataSetup?: boolean;
   /** Starter-prompts fetch config — forwarded to the empty-state query. */
   starterPrompts: {
     apiUrl: string;
@@ -41,7 +50,14 @@ interface NotebookShellProps {
   };
 }
 
-export function NotebookShell({ notebook, focusCellId, onShareAsReport, starterPrompts }: NotebookShellProps) {
+export function NotebookShell({
+  notebook,
+  focusCellId,
+  onShareAsReport,
+  isAdmin = false,
+  needsDataSetup = false,
+  starterPrompts,
+}: NotebookShellProps) {
   const scrollAreaRef = useRef<HTMLDivElement>(null);
   const anyRunning = notebook.cells.some((c) => c.status === "running");
   const editingCellId = notebook.cells.find((c) => c.editing)?.id ?? null;
@@ -262,13 +278,17 @@ export function NotebookShell({ notebook, focusCellId, onShareAsReport, starterP
           )}
 
           {notebook.cells.length === 0 ? (
-            <NotebookEmptyState
-              apiUrl={starterPrompts.apiUrl}
-              isCrossOrigin={starterPrompts.isCrossOrigin}
-              getHeaders={starterPrompts.getHeaders}
-              enabled={starterPrompts.enabled}
-              onSelectPrompt={(text) => notebook.appendCell(text)}
-            />
+            needsDataSetup ? (
+              <ConnectDataPrompt isAdmin={isAdmin} />
+            ) : (
+              <NotebookEmptyState
+                apiUrl={starterPrompts.apiUrl}
+                isCrossOrigin={starterPrompts.isCrossOrigin}
+                getHeaders={starterPrompts.getHeaders}
+                enabled={starterPrompts.enabled}
+                onSelectPrompt={(text) => notebook.appendCell(text)}
+              />
+            )
           ) : (
             <Sortable
               value={notebook.cells}
@@ -327,22 +347,24 @@ export function NotebookShell({ notebook, focusCellId, onShareAsReport, starterP
         </div>
       </div>
 
-      <div className="mx-auto w-full max-w-5xl px-4">
-        <AskComposer
-          value={notebook.input}
-          onChange={notebook.setInput}
-          onSubmit={() => {
-            if (notebook.input.trim()) {
-              notebook.appendCell(notebook.input.trim());
-            }
-          }}
-          disabled={anyRunning}
-          placeholder="Ask a question to add a new cell…"
-          multiline
-          helperText="Enter to send · Shift+Enter for newline"
-          inputAriaLabel="New cell question"
-        />
-      </div>
+      {!(needsDataSetup && notebook.cells.length === 0) && (
+        <div className="mx-auto w-full max-w-5xl px-4">
+          <AskComposer
+            value={notebook.input}
+            onChange={notebook.setInput}
+            onSubmit={() => {
+              if (notebook.input.trim()) {
+                notebook.appendCell(notebook.input.trim());
+              }
+            }}
+            disabled={anyRunning}
+            placeholder="Ask a question to add a new cell…"
+            multiline
+            helperText="Enter to send · Shift+Enter for newline"
+            inputAriaLabel="New cell question"
+          />
+        </div>
+      )}
 
       <DeleteCellDialog
         open={pendingDeleteIndex !== null}


### PR DESCRIPTION
## Summary

- A workspace with no database connection and no demo dataset has nothing for the agent to query — but the chat composer still rendered and let users send questions, which would then hit the agent loop and fail confusingly.
- Replace that \"type a question into the void\" state with an onboarding hero: admins get a \"Set up a connection\" CTA → \`/signup/connect\` (existing flow with both \"connect your own DB\" and \"explore demo data\" options); non-admins get explanatory copy directing them to their workspace admin.
- Both surfaces (chat \`/\`, notebook \`/notebook\`) gate identically via a new shared \`<ConnectDataPrompt>\` built on the \`<EmptyAskHero>\` primitive landed in #2451 — messaging stays in lockstep.
- Composer is hidden entirely in this state — strongest signal that the AI isn't ready to answer yet.
- Gate fires only when the datasource summary has resolved with zero tables. A fetch error (\`data === null\`) keeps the existing composer visible — we don't make a backend hiccup feel like \"your data is missing.\"
- Scope is intentionally the empty state (no messages on chat, no cells on notebook). An already-active conversation that somehow loses its data is left out of this pass.

## Test plan
- [x] \`bun run type\` — clean
- [x] \`bun run lint\` — clean (1 pre-existing warning in \`detect.test.ts\`, unrelated)
- [x] Notebook-shell tests pass after making the new props optional with defaults
- [x] Localhost verify (chat): empty semantic root → \"Connect data to get started\" + \"Set up a connection\" + composer hidden
- [x] Localhost verify (chat): normal semantic root → \"Ask Atlas about your data.\" + composer visible (regression check)
- [x] Localhost verify (notebook): empty → same CTA, composer hidden
- [ ] Visual verify on prod after deploy
- [ ] Non-admin verify: log in as a non-admin user with no workspace data → see \"Ask your workspace admin\" copy, no button