### PR TITLE
fix(web): admin sidebar auto-expand + stop "Self-Hosted" lie on SaaS

### DIFF
--- a/packages/web/src/app/admin/billing/page.tsx
+++ b/packages/web/src/app/admin/billing/page.tsx
@@ -26,6 +26,7 @@ import {
 import { ErrorBanner } from "@/ui/components/admin/error-banner";
 import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
+import { useDeployMode } from "@/ui/hooks/use-deploy-mode";
 import { MutationErrorSurface } from "@/ui/components/admin/mutation-error-surface";
 import { BillingStatusSchema } from "@/ui/lib/admin-schemas";
 import { ModelProviderSection } from "@/ui/components/admin/model-provider-section";
@@ -108,11 +109,19 @@ export default function BillingPage() {
   const { data, loading, error, refetch } = useAdminFetch("/api/v1/billing", {
     schema: BillingStatusSchema,
   });
+  const { deployMode } = useDeployMode();
 
   // Framework-level 404 (billing routes not mounted) means self-hosted / no Stripe.
   // API-level 404s ("Workspace not found", "no internal database") have descriptive
   // messages and should surface as real errors, not the self-hosted card.
+  //
+  // Gate on deployMode too: on a SaaS deployment a 404 here means the billing
+  // system is misconfigured (Stripe plugin not mounted, internal DB
+  // unavailable), NOT that the deployment is self-hosted. Showing the
+  // "Self-hosted · no billing" card in that case lies to the user — let the
+  // generic error path surface the failure so it's visible to operators.
   const isSelfHosted =
+    deployMode === "self-hosted" &&
     !loading &&
     !data &&
     error?.status === 404 &&

--- a/packages/web/src/ui/components/admin/admin-sidebar.tsx
+++ b/packages/web/src/ui/components/admin/admin-sidebar.tsx
@@ -90,6 +90,24 @@ export function AdminSidebar() {
     return group.items.some((item) => matchesNavItem(item, pathname));
   }
 
+  // Track manually-expanded groups so client-side navigation auto-opens
+  // the active group AND respects user-initiated toggles. Using a plain
+  // `defaultOpen` is uncontrolled — only respected on first mount — so
+  // landing on /admin/x and then navigating to /admin/y left the y-parent
+  // collapsed even when y was the active item.
+  const [userOpenedGroups, setUserOpenedGroups] = useState<Set<string>>(new Set());
+  function isGroupOpen(group: NavGroup): boolean {
+    return isGroupActive(group) || userOpenedGroups.has(group.title);
+  }
+  function handleGroupOpenChange(title: string, open: boolean) {
+    setUserOpenedGroups((prev) => {
+      const next = new Set(prev);
+      if (open) next.add(title);
+      else next.delete(title);
+      return next;
+    });
+  }
+
   const visibleGroups = navGroups
     .filter((group) => !group.requiredRole || group.requiredRole === userRole)
     .map((group) => ({
@@ -166,7 +184,8 @@ export function AdminSidebar() {
               <Collapsible
                 key={group.title}
                 asChild
-                defaultOpen={isGroupActive(group)}
+                open={isGroupOpen(group)}
+                onOpenChange={(open) => handleGroupOpenChange(group.title, open)}
                 className="group/collapsible"
               >
                 <SidebarMenuItem>

--- a/packages/web/src/ui/hooks/use-deploy-mode.ts
+++ b/packages/web/src/ui/hooks/use-deploy-mode.ts
@@ -16,13 +16,25 @@ interface SettingsResponse {
  * Returns the resolved deploy mode from the admin settings API.
  *
  * Fetches from `/api/v1/admin/settings` and extracts the `deployMode` field.
- * Defaults to `"self-hosted"` while loading or on error. Exposes the error
- * so consumers can detect when the fallback is due to a fetch failure
- * (e.g., expired session) rather than an actual self-hosted deployment.
+ * Falls back to a hostname-based guess while loading or on error (localhost
+ * and private-network hosts → "self-hosted"; public-internet hosts → "saas")
+ * so a slow fetch on `app.useatlas.dev` doesn't briefly lie to the user that
+ * they're on a self-hosted deploy. Exposes the error so consumers can still
+ * detect when the resolution is a guess rather than an authoritative answer.
  *
  * Also applies the regional API URL override when the settings response
  * includes a `regionApiUrl` (tier-2 data residency).
  */
+function guessDeployModeFromHost(): DeployMode {
+  if (typeof window === "undefined") return "self-hosted";
+  const host = window.location?.hostname;
+  if (!host) return "self-hosted";
+  if (host === "localhost" || host === "127.0.0.1" || host.endsWith(".local")) return "self-hosted";
+  // Bare IPv4 → almost always a private/private-network self-host
+  if (/^\d+\.\d+\.\d+\.\d+$/.test(host)) return "self-hosted";
+  return "saas";
+}
+
 export function useDeployMode(): {
   deployMode: DeployMode;
   loading: boolean;
@@ -32,7 +44,7 @@ export function useDeployMode(): {
 
   useEffect(() => {
     if (error) {
-      console.warn("useDeployMode: failed to fetch deploy mode, defaulting to self-hosted:", error);
+      console.warn("useDeployMode: settings fetch failed — using hostname-based deploy mode guess:", error);
     }
   }, [error]);
 
@@ -49,7 +61,7 @@ export function useDeployMode(): {
   }, [data?.regionApiUrl]);
 
   return {
-    deployMode: data?.deployMode ?? "self-hosted",
+    deployMode: data?.deployMode ?? guessDeployModeFromHost(),
     loading,
     error,
   };


### PR DESCRIPTION
## Summary

Three small bugs surfaced while clicking through admin on prod \`app.useatlas.dev\` during the 2026-05-16 internal dogfood pass.

1. **Admin sidebar wasn't auto-expanding on client-side navigation.** \`Collapsible defaultOpen={isGroupActive(group)}\` is *uncontrolled* — only respected on first mount. Landing on \`/admin/connections\` and clicking to \`/admin/billing\` left the Configuration parent collapsed and the active item invisible. Switch to controlled \`open\` driven by \`isGroupActive()\` plus a local Set of user-toggled groups — auto-expand on every navigation, manual toggles still respected.

2. **Billing page showed \"Self-hosted · no billing\" on SaaS.** When \`/api/v1/billing\` returns a framework 404, the page concluded \"this must be self-hosted\" regardless of actual deploy mode. On \`app.useatlas.dev\` a 404 means the billing system is misconfigured, not that the deploy is self-hosted. Gated on \`deployMode === \"self-hosted\"\` so on SaaS the 404 surfaces as a real error operators can chase. (Underlying 404 root cause: [#2455](https://github.com/AtlasDevHQ/atlas/issues/2455)).

3. **\`useDeployMode\` silently defaulted to \"self-hosted\" during loading / on error.** Painted the wrong picture on any public-internet host before the settings fetch resolved. Added a hostname-based guess: \`localhost\` / \`*.local\` / bare IPv4 → \`\"self-hosted\"\`; everything else → \`\"saas\"\`. Real API response still takes precedence.

## Test plan
- [x] \`bun run type\` — clean
- [x] \`bun run lint\` — clean (1 pre-existing warning unrelated)
- [ ] Visual verify on prod after deploy: \`/admin/billing\` no longer shows \"Self-Hosted\" hero
- [ ] Visual verify on prod: clicking sidebar items expands the right parent group
- [ ] Localhost verify: deploy mode still resolves to \"self-hosted\" while loading on localhost (no regression)

## Related issues filed in the same dogfood pass
- [#2455](https://github.com/AtlasDevHQ/atlas/issues/2455) — \`/api/v1/billing\` 404 root cause (operator-side investigation)
- [#2456](https://github.com/AtlasDevHQ/atlas/issues/2456) — SaaS workspaces on tier \"free\" + trial onboarding flow (PRD-shaped)
- [#2453](https://github.com/AtlasDevHQ/atlas/issues/2453) — Admin data-layer IA reshape (4 pages → 2)