### PR TITLE
feat(api): assign trial on SaaS signup (#2465)

### DIFF
--- a/packages/api/src/lib/auth/__tests__/assign-saas-trial.test.ts
+++ b/packages/api/src/lib/auth/__tests__/assign-saas-trial.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Regression coverage for the SaaS-signup trial assignment hook
+ * ({@link assignSaasTrial}).
+ *
+ * Without this hook, every SaaS workspace lands on `plan_tier='free'`
+ * (the DB column default) and `/admin/model-config` renders the literal
+ * `"user-configured"` sentinel from `plans.ts`. The hook's contract:
+ *
+ *   - SaaS + new org with default tier → flip to `'trial'` + set
+ *     `trial_ends_at = NOW() + 14d`.
+ *   - Self-hosted → no-op (free is the legitimate self-hosted tier).
+ *   - No internal DB → no-op, no throw (auth should still work).
+ *   - Already on a non-default tier → no-op (preserve platform-admin
+ *     pre-seeded orgs and re-invocation safety).
+ *   - SELECT or UPDATE throws → log + swallow (mirror
+ *     `promoteOrgOwnerToAdmin`; never block org creation).
+ *
+ * Same caveat as `org-owner-promotion.test.ts`: this test exercises the
+ * function in isolation. It cannot catch a refactor that deletes the
+ * `afterCreateOrganization` composition in `buildPlugins()` — Better
+ * Auth closes over plugin options, so the wiring isn't introspectable.
+ */
+
+import { describe, it, expect, beforeEach, afterAll } from "bun:test";
+import { _resetPool, type InternalPool } from "@atlas/api/lib/db/internal";
+import { _setConfigForTest, type ResolvedConfig } from "@atlas/api/lib/config";
+import { TRIAL_DAYS } from "@atlas/api/lib/billing/plans";
+import { assignSaasTrial } from "../server";
+
+const USER = { id: "user_test_123" };
+const ORG = { id: "org_test_456" };
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+const ORIGINAL_DATABASE_URL = process.env.DATABASE_URL;
+
+interface MockPool {
+  pool: InternalPool;
+  queries: Array<{ sql: string; params?: unknown[] }>;
+}
+
+function makeMockPool(opts: {
+  selectTier?: string | null;
+  selectThrows?: boolean;
+  updateThrows?: boolean;
+}): MockPool {
+  const queries: Array<{ sql: string; params?: unknown[] }> = [];
+  const pool = {
+    query: async (sql: string, params?: unknown[]) => {
+      queries.push({ sql, params });
+      const isSelect = /^\s*SELECT\b/i.test(sql);
+      if (isSelect) {
+        if (opts.selectThrows) throw new Error("connection refused");
+        return {
+          rows: opts.selectTier === undefined
+            ? [{ plan_tier: "free" }]
+            : opts.selectTier === null
+              ? []
+              : [{ plan_tier: opts.selectTier }],
+          rowCount: 1,
+        };
+      }
+      if (opts.updateThrows) throw new Error("UPDATE failed");
+      return { rows: [], rowCount: 1 };
+    },
+  } as unknown as InternalPool;
+  return { pool, queries };
+}
+
+function configWithDeployMode(deployMode: "saas" | "self-hosted"): ResolvedConfig {
+  return {
+    datasources: {},
+    tools: ["explore", "executeSQL"],
+    auth: "managed",
+    semanticLayer: "./semantic",
+    maxTotalConnections: 100,
+    source: "file",
+    deployMode,
+  };
+}
+
+describe("assignSaasTrial — body", () => {
+  beforeEach(() => {
+    process.env.DATABASE_URL = "postgresql://test/test";
+    _setConfigForTest(configWithDeployMode("saas"));
+  });
+
+  afterAll(() => {
+    _resetPool(null);
+    _setConfigForTest(null);
+    if (ORIGINAL_DATABASE_URL === undefined) {
+      delete process.env.DATABASE_URL;
+    } else {
+      process.env.DATABASE_URL = ORIGINAL_DATABASE_URL;
+    }
+  });
+
+  it("flips a free SaaS workspace to trial with a 14-day expiry", async () => {
+    const { pool, queries } = makeMockPool({ selectTier: "free" });
+    _resetPool(pool);
+
+    const before = Date.now();
+    await assignSaasTrial({ user: USER, organization: ORG });
+    const after = Date.now();
+
+    expect(queries).toHaveLength(2);
+    expect(queries[0].sql).toMatch(/SELECT plan_tier FROM organization/);
+    expect(queries[1].sql).toMatch(
+      /UPDATE organization SET plan_tier = 'trial', trial_ends_at/,
+    );
+    // Belt-and-suspenders: the UPDATE re-asserts the free guard.
+    expect(queries[1].sql).toMatch(/AND plan_tier = 'free'/);
+
+    const [trialEndsAtParam, orgIdParam] = queries[1].params ?? [];
+    expect(orgIdParam).toBe(ORG.id);
+    const trialEndsAt = new Date(String(trialEndsAtParam)).getTime();
+    const target = before + TRIAL_DAYS * DAY_MS;
+    expect(trialEndsAt).toBeGreaterThanOrEqual(target);
+    expect(trialEndsAt).toBeLessThanOrEqual(after + TRIAL_DAYS * DAY_MS);
+  });
+
+  it("skips on self-hosted — no SELECT, no UPDATE", async () => {
+    _setConfigForTest(configWithDeployMode("self-hosted"));
+    const { pool, queries } = makeMockPool({ selectTier: "free" });
+    _resetPool(pool);
+
+    await assignSaasTrial({ user: USER, organization: ORG });
+
+    expect(queries).toHaveLength(0);
+  });
+
+  it("skips when deployMode is missing (auto-resolves to self-hosted)", async () => {
+    _setConfigForTest(null);
+    const { pool, queries } = makeMockPool({ selectTier: "free" });
+    _resetPool(pool);
+
+    await assignSaasTrial({ user: USER, organization: ORG });
+
+    expect(queries).toHaveLength(0);
+  });
+
+  it("skips when the internal DB is unavailable", async () => {
+    delete process.env.DATABASE_URL;
+    const { pool, queries } = makeMockPool({ selectTier: "free" });
+    _resetPool(pool);
+
+    await assignSaasTrial({ user: USER, organization: ORG });
+
+    expect(queries).toHaveLength(0);
+  });
+
+  it("is idempotent — does not re-assign an existing trial", async () => {
+    const { pool, queries } = makeMockPool({ selectTier: "trial" });
+    _resetPool(pool);
+
+    await assignSaasTrial({ user: USER, organization: ORG });
+
+    expect(queries).toHaveLength(1);
+    expect(queries[0].sql).toMatch(/SELECT/);
+  });
+
+  it("does not clobber a paid tier (platform-admin pre-seeded org)", async () => {
+    const { pool, queries } = makeMockPool({ selectTier: "pro" });
+    _resetPool(pool);
+
+    await assignSaasTrial({ user: USER, organization: ORG });
+
+    expect(queries).toHaveLength(1);
+    expect(queries[0].sql).toMatch(/SELECT/);
+  });
+
+  it("does not throw when the SELECT fails — failure is logged, signup continues", async () => {
+    const { pool } = makeMockPool({ selectThrows: true });
+    _resetPool(pool);
+
+    // Throwing here would block org creation — strictly worse than
+    // landing in a recoverable state where plan_tier stays "free".
+    await expect(
+      assignSaasTrial({ user: USER, organization: ORG }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("does not throw when the UPDATE fails", async () => {
+    const { pool } = makeMockPool({ selectTier: "free", updateThrows: true });
+    _resetPool(pool);
+
+    await expect(
+      assignSaasTrial({ user: USER, organization: ORG }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/packages/api/src/lib/auth/server.ts
+++ b/packages/api/src/lib/auth/server.ts
@@ -38,8 +38,9 @@ import { onVerificationCreated } from "@atlas/api/lib/auth/trusted-device-hook";
 import { isEnterpriseEnabled } from "@atlas/ee/index";
 import { ac, owner as ownerRole, admin as adminRole, member as memberRole } from "@atlas/api/lib/auth/org-permissions";
 import { adminAccessControl, adminRole as adminUserRole, platformAdminRole } from "@atlas/api/lib/auth/admin-permissions";
-import { getStripePlans, resolvePlanTierFromPriceId } from "@atlas/api/lib/billing/plans";
+import { getStripePlans, resolvePlanTierFromPriceId, TRIAL_DAYS } from "@atlas/api/lib/billing/plans";
 import { invalidatePlanCache, checkResourceLimit } from "@atlas/api/lib/billing/enforcement";
+import { getConfig } from "@atlas/api/lib/config";
 
 /**
  * Build the socialProviders config from environment variables.
@@ -152,6 +153,75 @@ export async function promoteOrgOwnerToAdmin(args: {
     log.error(
       { err: errorMessage(err), userId: user.id, orgId: org.id },
       "Failed to promote org owner to admin — Better Auth admin APIs will return 403",
+    );
+  }
+}
+
+/**
+ * Flip a newly-created SaaS workspace from the DB default `plan_tier='free'`
+ * onto `'trial'` with `trial_ends_at = NOW() + TRIAL_DAYS`. Self-hosted
+ * orgs stay on `'free'` — the deploy-mode guard is the only thing
+ * separating "Atlas as the free self-hosted product" from "Atlas as the
+ * hosted SaaS trial". Without this hook, every SaaS workspace lands on
+ * the free-tier definition and `/admin/model-config` renders the literal
+ * `"user-configured"` sentinel from `plans.ts`.
+ *
+ * Wired alongside {@link promoteOrgOwnerToAdmin} into
+ * `organizationHooks.afterCreateOrganization` in {@link buildPlugins}.
+ * Better Auth runs hooks sequentially via the composed `async` wrapper —
+ * each hook catches its own errors so a failure in either doesn't poison
+ * org creation.
+ *
+ * Idempotent: SELECT-then-UPDATE pattern with a guard that re-asserts
+ * `plan_tier = 'free'` in the WHERE clause. Re-invocations on an already-
+ * promoted org are a no-op. A platform-admin override that pre-seeded the
+ * org with a non-default tier is also preserved.
+ *
+ * Exported for direct unit testing — the org plugin closes over its
+ * options, so the only way to assert this hook's contract from outside
+ * the plugin is to test the function in isolation.
+ *
+ * @internal
+ */
+export async function assignSaasTrial(args: {
+  user: { id: string };
+  organization: { id: string };
+}): Promise<void> {
+  const { user, organization: org } = args;
+  try {
+    if (!hasInternalDB()) return;
+    if (getConfig()?.deployMode !== "saas") return;
+
+    // Re-check current tier before writing. A pre-seeded non-default tier
+    // (test fixtures, platform-admin provisioning) wins — we don't clobber
+    // it back to 'trial'. The WHERE clause on the UPDATE is belt-and-
+    // suspenders so a TOCTOU race between SELECT and UPDATE can't downgrade
+    // a paid org.
+    const existing = await internalQuery<{ plan_tier: PlanTier }>(
+      `SELECT plan_tier FROM organization WHERE id = $1 LIMIT 1`,
+      [org.id],
+    );
+    if (existing[0]?.plan_tier !== "free") return;
+
+    const trialEndsAt = new Date(Date.now() + TRIAL_DAYS * 24 * 60 * 60 * 1000);
+    await internalQuery(
+      `UPDATE organization SET plan_tier = 'trial', trial_ends_at = $1
+       WHERE id = $2 AND plan_tier = 'free'`,
+      [trialEndsAt.toISOString(), org.id],
+    );
+    log.info(
+      { userId: user.id, orgId: org.id, trialEndsAt: trialEndsAt.toISOString() },
+      "Assigned SaaS trial to new workspace",
+    );
+  } catch (err) {
+    // log.error parallels promoteOrgOwnerToAdmin — sustained failures
+    // indicate a regression in the hook contract (Better Auth option
+    // rename, DB connectivity loss, etc.). Org creation continues; the
+    // workspace just stays on plan_tier='free' until the next signup
+    // hook fires or an operator runs the backfill manually.
+    log.error(
+      { err: errorMessage(err), userId: user.id, orgId: org.id },
+      "Failed to assign SaaS trial — workspace stays on plan_tier='free'",
     );
   }
 }
@@ -888,7 +958,14 @@ export function buildPlugins() {
         // because the org plugin inserts the initial owner-member through
         // its own internal context, which bypasses user-defined
         // `databaseHooks` — the previous wiring fired zero times in prod.
-        afterCreateOrganization: promoteOrgOwnerToAdmin,
+        //
+        // Better Auth accepts a single function. Both hooks catch their
+        // own errors so sequencing them is safe — neither will throw
+        // back into org creation.
+        afterCreateOrganization: async (args) => {
+          await promoteOrgOwnerToAdmin(args);
+          await assignSaasTrial(args);
+        },
       },
       async sendInvitationEmail(data) {
         log.warn(


### PR DESCRIPTION
## Summary

- New SaaS workspaces no longer land on `plan_tier='free'`. A new `assignSaasTrial` hook composed alongside `promoteOrgOwnerToAdmin` in `organizationHooks.afterCreateOrganization` flips brand-new orgs to `plan_tier='trial'` + `trial_ends_at = NOW() + 14d` when `deployMode === 'saas'`.
- Self-hosted is untouched — the deploy-mode guard short-circuits before any DB write.
- Idempotent: SELECT-then-UPDATE, plus `AND plan_tier='free'` belt-and-suspenders on the UPDATE. Platform-admin pre-seeded orgs (already on starter/pro/etc.) and re-invocations are no-ops.
- 8 unit tests modeled on `org-owner-promotion.test.ts` cover the contract; the sibling owner-promote test still passes.

## Why

Surfaced during the 2026-05-16 internal dogfood pass (#2456): the free tier's `defaultModel` is the sentinel `"user-configured"`, which rendered verbatim on `/admin/model-config`. Root cause was a missing signup-time write — the schema, enforcement.ts trial-expiry branch, `plans.ts` `'trial'` tier (`TRIAL_DAYS = 14`), and Stripe-side `freeTrial` config were all already in place.

## PRD context

[PRD #2464](https://github.com/AtlasDevHQ/atlas/issues/2464) — slice 1/4.

- This PR — slice 1 (signup-time hook)
- #2466 — slice 2 (one-shot backfill of existing 'free' SaaS workspaces)
- #2467 — slice 3 (`/admin/billing` countdown banner)
- #2468 — slice 4 (`/admin/model-config` copy fix)

Upstream dependency: #2455 (billing endpoint 404 on prod). If `hasInternalDB()` is failing in prod, this hook short-circuits — slice ships regardless; prod effect lights up after #2455.

## Test plan

- [x] `bun test src/lib/auth/__tests__/assign-saas-trial.test.ts` — 8 pass, 0 fail
- [x] `bun test src/lib/auth/__tests__/org-owner-promotion.test.ts` — 7 pass, 0 fail (sibling didn't regress)
- [x] Full `/ci` locally: lint, type, test, syncpack, template-drift, security-headers-drift, railway-watch, schema-drift, oauth-helper-drift — all green
- [ ] After merge: spin up a fresh SaaS-mode dev signup and confirm new org lands on `plan_tier='trial'` with `trial_ends_at` ≈ now + 14d