### PR TITLE
feat(api): backfill free→trial SaaS workspaces at boot (#2466)

### DIFF
--- a/packages/api/src/lib/billing/__tests__/backfill-saas-trial.test.ts
+++ b/packages/api/src/lib/billing/__tests__/backfill-saas-trial.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Tests for the one-time SaaS trial backfill ({@link backfillSaasTrial}).
+ *
+ * Pairs with the signup-time {@link assignSaasTrial} hook from slice 1:
+ * the hook handles every new org, the backfill retires legacy 'free'
+ * rows the hook didn't run for. PRD #2464 slice 2/4.
+ *
+ * Contract under test:
+ *   - SaaS + free rows present → promotes them, returns the ids.
+ *   - Self-hosted → no SELECT, no UPDATE, no throw.
+ *   - No internal DB (DATABASE_URL unset) → no SELECT, no UPDATE.
+ *   - Re-run when there are no candidates → 0-count, no error.
+ *   - UPDATE throws → result is SKIPPED, no rethrow.
+ *
+ * Mocks `InternalPool` via `_resetPool` and `getConfig()` via
+ * `_setConfigForTest`. Same pattern as
+ * `auth/__tests__/assign-saas-trial.test.ts`.
+ */
+
+import { describe, it, expect, beforeEach, afterAll } from "bun:test";
+import { _resetPool, type InternalPool } from "@atlas/api/lib/db/internal";
+import { _setConfigForTest, type ResolvedConfig } from "@atlas/api/lib/config";
+import { TRIAL_DAYS } from "@atlas/api/lib/billing/plans";
+import { backfillSaasTrial } from "../backfill-saas-trial";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const ORIGINAL_DATABASE_URL = process.env.DATABASE_URL;
+
+interface MockPool {
+  pool: InternalPool;
+  queries: Array<{ sql: string; params?: unknown[] }>;
+}
+
+function makeMockPool(opts: {
+  updatedIds?: string[];
+  updateThrows?: boolean;
+}): MockPool {
+  const queries: Array<{ sql: string; params?: unknown[] }> = [];
+  const pool = {
+    query: async (sql: string, params?: unknown[]) => {
+      queries.push({ sql, params });
+      if (opts.updateThrows) throw new Error("UPDATE failed");
+      const rows = (opts.updatedIds ?? []).map((id) => ({ id }));
+      return { rows, rowCount: rows.length };
+    },
+  } as unknown as InternalPool;
+  return { pool, queries };
+}
+
+function configWithDeployMode(deployMode: "saas" | "self-hosted"): ResolvedConfig {
+  return {
+    datasources: {},
+    tools: ["explore", "executeSQL"],
+    auth: "managed",
+    semanticLayer: "./semantic",
+    maxTotalConnections: 100,
+    source: "file",
+    deployMode,
+  };
+}
+
+describe("backfillSaasTrial", () => {
+  beforeEach(() => {
+    process.env.DATABASE_URL = "postgresql://test/test";
+    _setConfigForTest(configWithDeployMode("saas"));
+  });
+
+  afterAll(() => {
+    _resetPool(null);
+    _setConfigForTest(null);
+    if (ORIGINAL_DATABASE_URL === undefined) {
+      delete process.env.DATABASE_URL;
+    } else {
+      process.env.DATABASE_URL = ORIGINAL_DATABASE_URL;
+    }
+  });
+
+  it("promotes free SaaS workspaces to trial with a fresh 14-day window", async () => {
+    const { pool, queries } = makeMockPool({
+      updatedIds: ["org_dogfood", "org_acme"],
+    });
+    _resetPool(pool);
+
+    const before = Date.now();
+    const result = await backfillSaasTrial();
+    const after = Date.now();
+
+    expect(result.updatedCount).toBe(2);
+    expect(result.orgIds).toEqual(["org_dogfood", "org_acme"]);
+    expect(queries).toHaveLength(1);
+    expect(queries[0].sql).toMatch(/UPDATE organization/);
+    // The idempotency guards must survive any future rewrite.
+    expect(queries[0].sql).toMatch(/plan_tier = 'free'/);
+    expect(queries[0].sql).toMatch(/trial_ends_at IS NULL/);
+
+    const [trialEndsAtParam] = queries[0].params ?? [];
+    const trialEndsAt = new Date(String(trialEndsAtParam)).getTime();
+    const target = before + TRIAL_DAYS * DAY_MS;
+    expect(trialEndsAt).toBeGreaterThanOrEqual(target);
+    expect(trialEndsAt).toBeLessThanOrEqual(after + TRIAL_DAYS * DAY_MS);
+  });
+
+  it("returns 0 with no error when there's nothing to backfill", async () => {
+    const { pool, queries } = makeMockPool({ updatedIds: [] });
+    _resetPool(pool);
+
+    const result = await backfillSaasTrial();
+
+    expect(result.updatedCount).toBe(0);
+    expect(result.orgIds).toEqual([]);
+    // The UPDATE still runs — RETURNING is what tells us there were
+    // zero candidates. Re-running on the next boot is the same no-op
+    // call shape.
+    expect(queries).toHaveLength(1);
+  });
+
+  it("skips on self-hosted — no UPDATE", async () => {
+    _setConfigForTest(configWithDeployMode("self-hosted"));
+    const { pool, queries } = makeMockPool({ updatedIds: ["org_should_not_move"] });
+    _resetPool(pool);
+
+    const result = await backfillSaasTrial();
+
+    expect(result.updatedCount).toBe(0);
+    expect(result.orgIds).toEqual([]);
+    expect(queries).toHaveLength(0);
+  });
+
+  it("skips when deployMode is missing (auto-resolves to self-hosted)", async () => {
+    _setConfigForTest(null);
+    const { pool, queries } = makeMockPool({ updatedIds: ["org_x"] });
+    _resetPool(pool);
+
+    const result = await backfillSaasTrial();
+
+    expect(result.updatedCount).toBe(0);
+    expect(queries).toHaveLength(0);
+  });
+
+  it("skips when the internal DB is unavailable", async () => {
+    delete process.env.DATABASE_URL;
+    const { pool, queries } = makeMockPool({ updatedIds: ["org_x"] });
+    _resetPool(pool);
+
+    const result = await backfillSaasTrial();
+
+    expect(result.updatedCount).toBe(0);
+    expect(queries).toHaveLength(0);
+  });
+
+  it("swallows UPDATE errors — startup must not fail", async () => {
+    const { pool } = makeMockPool({ updateThrows: true });
+    _resetPool(pool);
+
+    const result = await backfillSaasTrial();
+
+    expect(result.updatedCount).toBe(0);
+    expect(result.orgIds).toEqual([]);
+  });
+});

--- a/packages/api/src/lib/billing/__tests__/backfill-saas-trial.test.ts
+++ b/packages/api/src/lib/billing/__tests__/backfill-saas-trial.test.ts
@@ -1,20 +1,13 @@
 /**
- * Tests for the one-time SaaS trial backfill ({@link backfillSaasTrial}).
+ * Tests for the one-time SaaS trial backfill (`backfillSaasTrial`).
  *
- * Pairs with the signup-time {@link assignSaasTrial} hook from slice 1:
- * the hook handles every new org, the backfill retires legacy 'free'
- * rows the hook didn't run for. PRD #2464 slice 2/4.
- *
- * Contract under test:
- *   - SaaS + free rows present → promotes them, returns the ids.
- *   - Self-hosted → no SELECT, no UPDATE, no throw.
- *   - No internal DB (DATABASE_URL unset) → no SELECT, no UPDATE.
- *   - Re-run when there are no candidates → 0-count, no error.
- *   - UPDATE throws → result is SKIPPED, no rethrow.
+ * Pairs with the signup-time `assignSaasTrial` hook (#2465): the hook
+ * handles every new org, the backfill retires legacy 'free' rows the
+ * hook didn't run for. PRD #2464.
  *
  * Mocks `InternalPool` via `_resetPool` and `getConfig()` via
- * `_setConfigForTest`. Same pattern as
- * `auth/__tests__/assign-saas-trial.test.ts`.
+ * `_setConfigForTest`. Same pattern as the slice 1 sibling test for
+ * `assignSaasTrial`.
  */
 
 import { describe, it, expect, beforeEach, afterAll } from "bun:test";
@@ -112,6 +105,38 @@ describe("backfillSaasTrial", () => {
     // zero candidates. Re-running on the next boot is the same no-op
     // call shape.
     expect(queries).toHaveLength(1);
+  });
+
+  it("is idempotent across two boots — second call promotes zero rows", async () => {
+    // Simulates the real Postgres behaviour: first boot finds the
+    // legacy 'free' rows and updates them; second boot's UPDATE sees
+    // `trial_ends_at IS NOT NULL` and the WHERE clause matches nothing,
+    // so RETURNING is empty. End-to-end check on the PRD's hard
+    // idempotency requirement — the WHERE-clause regex elsewhere only
+    // asserts the clause is *present*.
+    let callCount = 0;
+    const queries: Array<{ sql: string; params?: unknown[] }> = [];
+    const pool = {
+      query: async (sql: string, params?: unknown[]) => {
+        queries.push({ sql, params });
+        callCount += 1;
+        const rows = callCount === 1
+          ? [{ id: "org_dogfood" }, { id: "org_acme" }]
+          : [];
+        return { rows, rowCount: rows.length };
+      },
+    } as unknown as InternalPool;
+    _resetPool(pool);
+
+    const first = await backfillSaasTrial();
+    expect(first.updatedCount).toBe(2);
+    expect(first.orgIds).toEqual(["org_dogfood", "org_acme"]);
+
+    const second = await backfillSaasTrial();
+    expect(second.updatedCount).toBe(0);
+    expect(second.orgIds).toEqual([]);
+
+    expect(queries).toHaveLength(2);
   });
 
   it("skips on self-hosted — no UPDATE", async () => {

--- a/packages/api/src/lib/billing/backfill-saas-trial.ts
+++ b/packages/api/src/lib/billing/backfill-saas-trial.ts
@@ -1,0 +1,80 @@
+/**
+ * One-time idempotent backfill: flip existing SaaS workspaces stuck on
+ * `plan_tier='free'` onto `'trial'` with a fresh 14-day window.
+ *
+ * Pairs with the signup-time {@link assignSaasTrial} hook (#2465). New
+ * orgs created after the hook lands take the happy path; this module
+ * exists to retire the legacy `'free'` rows the hook didn't run for —
+ * pre-launch this is the dogfood instance, but the pattern is safe for
+ * any SaaS deploy that picks up the new code with existing orgs.
+ *
+ * Guarded on `deployMode === 'saas'` because self-hosted's free tier is
+ * the legitimate free product — clobbering it would lock self-hosted
+ * users into a trial they never asked for.
+ *
+ * Idempotent via the `WHERE trial_ends_at IS NULL` clause: subsequent
+ * boots find zero candidates. Uses `NOW() + 14d` (not `createdAt + 14d`)
+ * so the dogfood workspace gets a fresh window instead of landing
+ * pre-expired the moment this code deploys.
+ *
+ * Wired through `BackfillSaasTrialLive` in
+ * `packages/api/src/lib/effect/layers.ts`, scheduled after migrations
+ * so the `organization` table is guaranteed to exist before the UPDATE.
+ */
+
+import { createLogger } from "@atlas/api/lib/logger";
+import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
+import { getConfig } from "@atlas/api/lib/config";
+import { hasInternalDB, internalQuery } from "@atlas/api/lib/db/internal";
+import { TRIAL_DAYS } from "@atlas/api/lib/billing/plans";
+
+const log = createLogger("billing.backfill-saas-trial");
+
+export interface BackfillResult {
+  /** Number of organization rows updated. Zero when skipped or already migrated. */
+  readonly updatedCount: number;
+  /** IDs of orgs flipped to trial. Empty when count is 0. */
+  readonly orgIds: ReadonlyArray<string>;
+}
+
+const SKIPPED: BackfillResult = { updatedCount: 0, orgIds: [] };
+
+/**
+ * Run the backfill UPDATE if conditions allow.
+ *
+ * Returns `SKIPPED` synchronously when deploy mode isn't SaaS or no
+ * internal DB is configured. Errors during the UPDATE are logged and
+ * swallowed — backfill failure must not block API startup.
+ */
+export async function backfillSaasTrial(): Promise<BackfillResult> {
+  if (getConfig()?.deployMode !== "saas") return SKIPPED;
+  if (!hasInternalDB()) return SKIPPED;
+
+  const trialEndsAt = new Date(Date.now() + TRIAL_DAYS * 24 * 60 * 60 * 1000);
+
+  try {
+    const rows = await internalQuery<{ id: string }>(
+      `UPDATE organization
+          SET plan_tier = 'trial',
+              trial_ends_at = $1
+        WHERE plan_tier = 'free'
+          AND trial_ends_at IS NULL
+        RETURNING id`,
+      [trialEndsAt.toISOString()],
+    );
+    const orgIds = rows.map((r) => r.id);
+    log.info(
+      { updatedCount: orgIds.length, orgIds, trialEndsAt: trialEndsAt.toISOString() },
+      orgIds.length === 0
+        ? "SaaS trial backfill: no free workspaces to promote"
+        : "SaaS trial backfill: promoted free workspaces to trial",
+    );
+    return { updatedCount: orgIds.length, orgIds };
+  } catch (err) {
+    log.error(
+      { err: errorMessage(err) },
+      "SaaS trial backfill failed — free workspaces remain on free until the next boot retries",
+    );
+    return SKIPPED;
+  }
+}

--- a/packages/api/src/lib/billing/backfill-saas-trial.ts
+++ b/packages/api/src/lib/billing/backfill-saas-trial.ts
@@ -2,11 +2,9 @@
  * One-time idempotent backfill: flip existing SaaS workspaces stuck on
  * `plan_tier='free'` onto `'trial'` with a fresh 14-day window.
  *
- * Pairs with the signup-time {@link assignSaasTrial} hook (#2465). New
- * orgs created after the hook lands take the happy path; this module
- * exists to retire the legacy `'free'` rows the hook didn't run for —
- * pre-launch this is the dogfood instance, but the pattern is safe for
- * any SaaS deploy that picks up the new code with existing orgs.
+ * Pairs with the signup-time `assignSaasTrial` hook (#2465). New orgs
+ * created after the hook lands take the happy path; this module retires
+ * the legacy `'free'` rows the hook didn't run for.
  *
  * Guarded on `deployMode === 'saas'` because self-hosted's free tier is
  * the legitimate free product — clobbering it would lock self-hosted
@@ -14,11 +12,11 @@
  *
  * Idempotent via the `WHERE trial_ends_at IS NULL` clause: subsequent
  * boots find zero candidates. Uses `NOW() + 14d` (not `createdAt + 14d`)
- * so the dogfood workspace gets a fresh window instead of landing
+ * so existing 'free' workspaces get a fresh window rather than landing
  * pre-expired the moment this code deploys.
  *
  * Wired through `BackfillSaasTrialLive` in
- * `packages/api/src/lib/effect/layers.ts`, scheduled after migrations
+ * `packages/api/src/lib/effect/layers.ts`, which depends on `Migration`
  * so the `organization` table is guaranteed to exist before the UPDATE.
  */
 

--- a/packages/api/src/lib/effect/layers.ts
+++ b/packages/api/src/lib/effect/layers.ts
@@ -220,6 +220,66 @@ export const MigrationLive: Layer.Layer<Migration, never, InternalDB> = Layer.ef
 );
 
 // ══════════════════════════════════════════════════════════════════════
+// ██  SaaS Trial Backfill Layer
+// ══════════════════════════════════════════════════════════════════════
+
+export interface BackfillSaasTrialShape {
+  /** Number of organization rows promoted from 'free' to 'trial' this boot. */
+  readonly updatedCount: number;
+}
+
+export class BackfillSaasTrial extends Context.Tag("BackfillSaasTrial")<
+  BackfillSaasTrial,
+  BackfillSaasTrialShape
+>() {}
+
+/**
+ * One-time idempotent backfill that promotes existing SaaS workspaces
+ * stuck on `plan_tier='free'` onto `'trial'` with `trial_ends_at = NOW()
+ * + 14d`. Pairs with the signup-time `assignSaasTrial` hook (#2465)
+ * which handles new orgs; this layer retires the legacy rows.
+ *
+ * Self-hosted is a no-op — the underlying function gates on
+ * `deployMode === 'saas'`. Idempotent: the `trial_ends_at IS NULL`
+ * clause makes subsequent boots find zero candidates.
+ *
+ * Depends on Migration so the `organization` table is guaranteed to
+ * exist before the UPDATE; depends on InternalDB to keep the pool
+ * ready. Non-fatal: errors logged but never fail the Layer.
+ */
+export const BackfillSaasTrialLive: Layer.Layer<
+  BackfillSaasTrial,
+  never,
+  InternalDB | Migration
+> = Layer.effect(
+  BackfillSaasTrial,
+  Effect.gen(function* () {
+    const db = yield* InternalDB;
+    const migration = yield* Migration;
+    if (!db.available || !migration.migrated) {
+      return { updatedCount: 0 } satisfies BackfillSaasTrialShape;
+    }
+
+    const result = yield* Effect.tryPromise({
+      try: async () => {
+        const { backfillSaasTrial } = await import(
+          "@atlas/api/lib/billing/backfill-saas-trial"
+        );
+        return await backfillSaasTrial();
+      },
+      catch: (err) => (err instanceof Error ? err.message : String(err)),
+    }).pipe(
+      Effect.catchAll((errMsg) => {
+        log.error({ err: new Error(errMsg) }, "SaaS trial backfill threw");
+        return Effect.succeed({ updatedCount: 0, orgIds: [] as ReadonlyArray<string> });
+      }),
+    );
+
+    return { updatedCount: result.updatedCount } satisfies BackfillSaasTrialShape;
+  }),
+);
+
+// ══════════════════════════════════════════════════════════════════════
 // ██  Semantic Sync Layer
 // ══════════════════════════════════════════════════════════════════════
 
@@ -937,7 +997,7 @@ export const MigrationGuardLive: Layer.Layer<never, MigrationsRequiredError, Con
  * Connection and plugin shutdown is handled imperatively in server.ts.
  */
 export function buildAppLayer(config: ResolvedConfig): Layer.Layer<
-  Telemetry | Config | InternalDB | Migration | SemanticSync | Settings | Scheduler,
+  Telemetry | Config | InternalDB | Migration | BackfillSaasTrial | SemanticSync | Settings | Scheduler,
   Error
 > {
   const configLayer = Layer.succeed(Config, { config });
@@ -945,6 +1005,13 @@ export function buildAppLayer(config: ResolvedConfig): Layer.Layer<
 
   // MigrationLive depends on InternalDB — provide it
   const migrationLayer = MigrationLive.pipe(Layer.provide(internalDBLayer));
+
+  // BackfillSaasTrialLive depends on Migration (so the `organization`
+  // table is guaranteed to exist) and InternalDB. Sits between
+  // migrations and scheduler in the boot DAG.
+  const backfillSaasTrialLayer = BackfillSaasTrialLive.pipe(
+    Layer.provide(Layer.merge(internalDBLayer, migrationLayer)),
+  );
 
   // Independent layers (no Effect-level deps)
   const semanticSyncLayer = SemanticSyncLive;
@@ -984,6 +1051,7 @@ export function buildAppLayer(config: ResolvedConfig): Layer.Layer<
     configLayer,
     internalDBLayer,
     migrationLayer,
+    backfillSaasTrialLayer,
     semanticSyncLayer,
     settingsLayer,
     schedulerLayer,

--- a/packages/api/src/lib/effect/layers.ts
+++ b/packages/api/src/lib/effect/layers.ts
@@ -257,6 +257,13 @@ export const BackfillSaasTrialLive: Layer.Layer<
     const db = yield* InternalDB;
     const migration = yield* Migration;
     if (!db.available || !migration.migrated) {
+      // Match MigrationLive's "logged-reason" pattern so an operator
+      // debugging "why didn't my SaaS region backfill?" can correlate
+      // without grepping for absences.
+      log.info(
+        { available: db.available, migrated: migration.migrated },
+        "SaaS trial backfill skipped — upstream gate (InternalDB or Migration) not satisfied",
+      );
       return { updatedCount: 0 } satisfies BackfillSaasTrialShape;
     }
 
@@ -267,11 +274,16 @@ export const BackfillSaasTrialLive: Layer.Layer<
         );
         return await backfillSaasTrial();
       },
-      catch: (err) => (err instanceof Error ? err.message : String(err)),
+      // Preserve the original Error (stack trace included) so pino's
+      // `err` serializer reports the throw site, not this catch site.
+      catch: (err) => (err instanceof Error ? err : new Error(String(err))),
     }).pipe(
-      Effect.catchAll((errMsg) => {
-        log.error({ err: new Error(errMsg) }, "SaaS trial backfill threw");
-        return Effect.succeed({ updatedCount: 0, orgIds: [] as ReadonlyArray<string> });
+      Effect.catchAll((err) => {
+        // Only reachable if the dynamic import itself rejects (e.g.
+        // bundle artefact missing) — `backfillSaasTrial` catches its
+        // own errors and never throws.
+        log.error({ err }, "SaaS trial backfill threw");
+        return Effect.succeed({ updatedCount: 0 } satisfies BackfillSaasTrialShape);
       }),
     );
 
@@ -1007,8 +1019,9 @@ export function buildAppLayer(config: ResolvedConfig): Layer.Layer<
   const migrationLayer = MigrationLive.pipe(Layer.provide(internalDBLayer));
 
   // BackfillSaasTrialLive depends on Migration (so the `organization`
-  // table is guaranteed to exist) and InternalDB. Sits between
-  // migrations and scheduler in the boot DAG.
+  // table is guaranteed to exist) and InternalDB. Independent peer of
+  // the other layers — Effect's mergeAll doesn't order independent
+  // siblings, so the only real ordering is the Migration dependency.
   const backfillSaasTrialLayer = BackfillSaasTrialLive.pipe(
     Layer.provide(Layer.merge(internalDBLayer, migrationLayer)),
   );


### PR DESCRIPTION
## Summary

- One-time, idempotent boot-time backfill that flips legacy SaaS workspaces stuck on `plan_tier='free'` onto `'trial'` with `trial_ends_at = NOW() + 14d`. Pre-launch this is the dogfood instance; the pattern is safe for any SaaS deploy with existing 'free' rows when it picks up the new code.
- Idempotent via `WHERE plan_tier='free' AND trial_ends_at IS NULL` — subsequent boots are no-ops.
- Uses `NOW() + 14d` (not `createdAt + 14d`) so the dogfood workspace gets a fresh trial window rather than landing pre-expired the moment this code deploys.
- New `BackfillSaasTrialLive` Effect Layer depends on `Migration` (organization table guaranteed to exist) and `InternalDB`. Sits between migrations and scheduler in the boot DAG. Non-fatal: a backfill failure logs `error` and the next boot retries; API startup is not blocked.
- Self-hosted is a no-op via `getConfig()?.deployMode !== 'saas'` — self-hosted's free tier is the legitimate free product, not a bug to backfill.
- 6 unit tests cover: SaaS+free→trial+orgIds+fresh-14d-window, no-op-when-nothing-to-do, self-hosted-skip, missing-deployMode-skip, no-DB-skip, UPDATE-throws→swallowed.

## Why

Pairs with the signup-time `assignSaasTrial` hook from slice 1 ([#2465](https://github.com/AtlasDevHQ/atlas/pull/2469)). The hook handles every brand-new org; this PR retires the legacy rows the hook didn't run for. Without it, `/admin/model-config` would keep rendering the `"user-configured"` sentinel on the dogfood workspace and the rest of the v1 UX (countdown banner, model-config copy fix) wouldn't have anything to render.

## PRD context

[PRD #2464](https://github.com/AtlasDevHQ/atlas/issues/2464) — slice 2/4.

- #2469 — slice 1 (signup-time hook, in CI)
- This PR — slice 2 (boot-time backfill)
- #2467 — slice 3 (`/admin/billing` countdown banner)
- #2468 — slice 4 (`/admin/model-config` copy fix)

Independent of slice 1 — both are gated on `deployMode='saas'`, both are idempotent. Order of landing doesn't matter; whichever lands first activates the rest of the v1 UX for the workspaces it touches.

## Test plan

- [x] `bun test src/lib/billing/__tests__/backfill-saas-trial.test.ts` — 6 pass, 0 fail
- [x] Full `/ci` locally: lint, type, test, syncpack, template-drift, security-headers-drift, railway-watch, schema-drift, oauth-helper-drift — all green
- [ ] After merge: verify on SaaS boot logs that the backfill emits `{ updatedCount, orgIds }` once, then `{ updatedCount: 0 }` on subsequent boots (idempotency)
- [ ] After merge: verify `/admin/billing` on the dogfood workspace now reflects `plan.tier === 'trial'` with `plan.trialEndsAt` set ~14 days out