### PR TITLE
fix(web): review fixes for connections + env toggle (#2471 follow-up)

### DIFF
--- a/packages/web/src/app/admin/connections/columns.tsx
+++ b/packages/web/src/app/admin/connections/columns.tsx
@@ -9,6 +9,7 @@ import { DemoBadge, DraftBadge } from "@/ui/components/admin/mode-badges";
 import { Fingerprint, Database, FileText, Activity, Clock, Layers } from "lucide-react";
 import type { ConnectionHealth, ConnectionInfo } from "@/ui/lib/types";
 import { stripGroupPrefix } from "@/ui/lib/strip-group-prefix";
+import { ENVIRONMENT_VIEW_HREF } from "./group-by";
 
 /** Reserved connection id for the onboarding demo dataset. */
 export const DEMO_CONNECTION_ID = "__demo__";
@@ -86,7 +87,7 @@ export function getConnectionColumns(): ColumnDef<ConnectionInfo>[] {
         }
         return (
           <Link
-            href="/admin/connections?groupBy=environment"
+            href={ENVIRONMENT_VIEW_HREF}
             className="inline-flex items-center"
             aria-label={`View environment ${stripGroupPrefix(groupName)}`}
           >

--- a/packages/web/src/app/admin/connections/connection-groups-section.tsx
+++ b/packages/web/src/app/admin/connections/connection-groups-section.tsx
@@ -1,15 +1,16 @@
 "use client";
 
 /**
- * The environment / connection-groups admin surface, extracted so it can
- * render both at `/admin/connections?groupBy=environment` (the new home,
- * slice 4 of PRD #2458) and via the legacy `/admin/connections/groups`
- * server-side redirect that lands users on the same query string.
+ * The connection-groups / environments admin surface. Mounted under
+ * `/admin/connections?groupBy=environment` and reached via a server-side
+ * redirect from the legacy `/admin/connections/groups` URL.
  *
- * Every feature of the standalone page lives here unchanged — create,
- * rename, delete, archive (with cascade preview), member roster, merge
- * wizard, and the auto-detected-singleton / archived toggles. The IA
- * change is purely "where this lives", not "what this does".
+ * Receives the connection list and a refetch fn from the parent so the
+ * page can ship a single `/api/v1/admin/connections` request — wiring
+ * our own `useAdminFetch` against the same path would collide with the
+ * parent on React Query's `[path]` cache key while disagreeing on the
+ * cached shape (transformed array vs `{ connections: [...] }`), and the
+ * environments view would render empty member rosters.
  */
 
 import { useState } from "react";
@@ -54,7 +55,7 @@ import { MutationErrorSurface } from "@/ui/components/admin/mutation-error-surfa
 import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
 import { Loader2, Plus, Pencil, Trash2, Layers, GitMerge, Archive } from "lucide-react";
-import type { ConnectionGroup, GroupArchiveCounts } from "@/ui/lib/types";
+import type { ConnectionGroup, ConnectionInfo, GroupArchiveCounts } from "@/ui/lib/types";
 import {
   stripGroupPrefix,
   isAutoBackfilledSingleton,
@@ -83,30 +84,22 @@ const GroupListSchema = z.object({
   groups: z.array(GroupSchema),
 });
 
-const ConnectionListSchema = z.object({
-  connections: z.array(
-    z.object({
-      id: z.string(),
-      dbType: z.string().optional(),
-      description: z.string().nullable().optional(),
-      groupId: z.string().nullable().optional(),
-    }),
-  ),
-});
+interface ConnectionGroupsSectionProps {
+  /** Live connections list owned by the parent page so we share one fetch. */
+  connections: ReadonlyArray<ConnectionInfo>;
+  /** Re-runs the parent's connections fetch after a member assign / merge. */
+  refetchConnections: () => void;
+}
 
-export function ConnectionGroupsSection() {
+export function ConnectionGroupsSection({
+  connections,
+  refetchConnections,
+}: ConnectionGroupsSectionProps) {
   const { data, loading, error, refetch } = useAdminFetch(
     "/api/v1/admin/connection-groups",
     { schema: GroupListSchema },
   );
-  const {
-    data: connList,
-    refetch: refetchConnections,
-  } = useAdminFetch("/api/v1/admin/connections", {
-    schema: ConnectionListSchema,
-  });
   const groups = data?.groups ?? [];
-  const connections = connList?.connections ?? [];
 
   const [createOpen, setCreateOpen] = useState(false);
   const [mergeOpen, setMergeOpen] = useState(false);
@@ -276,7 +269,7 @@ function GroupCard({
   onArchive,
 }: {
   group: ConnectionGroup;
-  connections: Array<{ id: string; groupId?: string | null; dbType?: string; description?: string | null }>;
+  connections: ReadonlyArray<ConnectionInfo>;
   refetchGroups: () => void;
   refetchConnections: () => void;
   onRename: () => void;
@@ -776,13 +769,6 @@ function ArchiveGroupDialog({
 // Merge wizard (#2409)
 // ---------------------------------------------------------------------------
 
-interface MergeConnection {
-  id: string;
-  dbType?: string;
-  description?: string | null;
-  groupId?: string | null;
-}
-
 interface MergeResponse {
   target: ConnectionGroup & { created: boolean };
   movedConnectionIds: string[];
@@ -806,7 +792,7 @@ function MergeGroupsDialog({
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  connections: ReadonlyArray<MergeConnection>;
+  connections: ReadonlyArray<ConnectionInfo>;
   groups: ReadonlyArray<ConnectionGroup>;
   onMerged: (result: MergeResponse) => void;
 }) {

--- a/packages/web/src/app/admin/connections/group-by.ts
+++ b/packages/web/src/app/admin/connections/group-by.ts
@@ -1,33 +1,30 @@
 import type { ConnectionInfo } from "@useatlas/types/connection";
 
-/**
- * Dimension the connections list is bucketized by. URL-encoded via nuqs as
- * `?groupBy=type` (default) or `?groupBy=environment` so admins can deep-link
- * directly to either view. Kept as a separate string-literal union from the
- * nuqs parser so the bucketizer can be tested without a Next.js context.
- */
+/** Bucketization dimension for the connections list. Kept separate from
+ * the nuqs parser so the bucketizer is testable without a Next.js
+ * context. */
 export type GroupByDimension = "type" | "environment";
 
-/** Reserved key used when a connection has no `groupId` and the user has
- * picked the Environment dimension. Surfaced in the UI as "No environment"
- * so admins can see which connections are unassigned without filtering
- * them out. */
+/** Reserved bucket key for connections with no `groupId`. The UI
+ * renders this bucket as "No environment" so unassigned connections
+ * stay visible rather than filtered out. */
 export const NO_ENVIRONMENT_KEY = "__none__";
 
+/** Canonical deep link to the embedded environments view. Anything
+ * that links to the connection groups should import this rather than
+ * hand-rolling the URL — keeps the toggle, the per-row chip, and the
+ * scheduled-tasks empty state in lockstep. */
+export const ENVIRONMENT_VIEW_HREF = "/admin/connections?groupBy=environment";
+
 export interface ConnectionBucket {
-  /** Stable bucket key — `dbType` for `type`, `groupId` (or {@link NO_ENVIRONMENT_KEY}) for `environment`. */
   key: string;
-  /** Connections in this bucket, in input order. */
   connections: ConnectionInfo[];
 }
 
 /**
- * Bucketize a connection list by `dbType` or by `groupId`. Pure: no I/O,
- * no sort beyond input order, no fabrication of empty buckets — callers
- * decide what to render for missing providers.
- *
- * Stable across re-renders only when the input array is stable; React
- * callers should already be working off a memoized list.
+ * Bucketize a connection list by `dbType` or by `groupId`. Pure: no
+ * I/O, no sort beyond input order, no fabrication of empty buckets —
+ * callers decide what to render for missing providers.
  */
 export function bucketizeConnections(
   connections: ReadonlyArray<ConnectionInfo>,
@@ -45,8 +42,7 @@ export function bucketizeConnections(
 
 function bucketKey(conn: ConnectionInfo, dimension: GroupByDimension): string {
   if (dimension === "type") return conn.dbType;
-  // `groupId` is `null` (explicit unassign) or `undefined` (older serializer)
-  // — both collapse to the same "no environment" bucket so admins don't see
-  // two parallel empty groupings on the same page.
+  // `null` (explicit unassign) and `undefined` (older serializer) both
+  // collapse to the same no-environment bucket.
   return conn.groupId ?? NO_ENVIRONMENT_KEY;
 }

--- a/packages/web/src/app/admin/connections/groups/page.tsx
+++ b/packages/web/src/app/admin/connections/groups/page.tsx
@@ -1,17 +1,16 @@
 import { redirect } from "next/navigation";
+import { ENVIRONMENT_VIEW_HREF } from "../group-by";
 
 /**
- * Legacy URL for the connection-groups admin surface. As of slice 4 of
- * PRD #2458 the page is embedded under `/admin/connections` behind a
- * `Group by: [Type | Environment]` toggle — the standalone route is kept
- * solely so bookmarks issued before the IA reshape keep landing on the
- * right view.
+ * Legacy URL for the connection-groups admin surface, kept as a
+ * server-side redirect so pre-IA-reshape bookmarks land on the
+ * embedded environments view.
  *
- * Server-side redirect (Next.js `redirect()`), not a client-side
- * `useEffect`: admins with the old bookmark must never see a flash of
- * the legacy layout — the browser should arrive at
- * `/admin/connections?groupBy=environment` before any React renders.
+ * `redirect()` from `next/navigation` rather than a client `useEffect`:
+ * admins with the old bookmark must never see a flash of the legacy
+ * layout — the browser should arrive at the new URL before any React
+ * renders.
  */
 export default function ConnectionGroupsRedirect(): never {
-  redirect("/admin/connections?groupBy=environment");
+  redirect(ENVIRONMENT_VIEW_HREF);
 }

--- a/packages/web/src/app/admin/connections/page.tsx
+++ b/packages/web/src/app/admin/connections/page.tsx
@@ -8,11 +8,8 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
-import { connectionsSearchParams } from "./search-params";
-import {
-  bucketizeConnections,
-  type GroupByDimension,
-} from "./group-by";
+import { GROUP_BY_VALUES, connectionsSearchParams, isGroupByDimension } from "./search-params";
+import { ENVIRONMENT_VIEW_HREF, bucketizeConnections } from "./group-by";
 import { ConnectionGroupsSection } from "./connection-groups-section";
 import {
   Select,
@@ -838,10 +835,10 @@ export default function ConnectionsPage() {
   const credentials: RequestCredentials = isCrossOrigin ? "include" : "same-origin";
   const { readOnly: demoReadOnly } = useDemoReadonly();
 
-  // URL-encoded so admins can deep-link directly to the Environment view
-  // (or land here from the legacy `/admin/connections/groups` server-side
-  // redirect). `useQueryStates` keeps the toggle SSR-safe — the segmented
-  // control reflects whichever value the URL ships with on first paint.
+  // `useQueryStates` so the segmented control reflects whichever value
+  // the URL ships with on first paint — keeps the legacy
+  // `/admin/connections/groups` redirect landing on the right view and
+  // makes `?groupBy=environment` deep-linkable.
   const [{ groupBy }, setParams] = useQueryStates(connectionsSearchParams);
 
   const testMutation = useAdminMutation<ConnectionHealth>({ method: "POST" });
@@ -954,12 +951,11 @@ export default function ConnectionsPage() {
     refetch();
   }
 
-  // Bucketize by the selected dimension. For `type`, fold the resulting
-  // buckets back into a map keyed by `dbType` so the provider rendering
-  // below (which iterates over DB_TYPES to surface disconnected providers
-  // with a "Connect" CTA) still receives the same shape it always has.
-  // The pure module exists so the bucketization rule is unit-testable —
-  // see `connections-group-by.test.ts`.
+  // Always bucketize by type, even when the user picked Environment:
+  // the provider rendering walks DB_TYPES so disconnected providers can
+  // show a "Connect" CTA, and that loop needs a `dbType → connections`
+  // map shape regardless of the active grouping. The environment view
+  // is rendered by a separate component below.
   const typeBuckets = bucketizeConnections(displayConnections, "type");
   const byType = new Map<string, ConnectionInfo[]>(
     typeBuckets.map((b) => [b.key, b.connections]),
@@ -973,10 +969,6 @@ export default function ConnectionsPage() {
     live: displayConnections.filter((c) => c.health?.status === "healthy").length,
     total: displayConnections.length,
   };
-
-  function handleGroupByChange(next: GroupByDimension) {
-    void setParams({ groupBy: next });
-  }
 
   return (
     <div className="mx-auto max-w-3xl px-6 py-10">
@@ -1005,18 +997,26 @@ export default function ConnectionsPage() {
               type="single"
               size="sm"
               value={groupBy}
-              onValueChange={(v) => { if (v) handleGroupByChange(v as GroupByDimension); }}
+              // Radix emits "" when the active toggle is clicked to
+              // deselect; the type-predicate narrow drops that (and any
+              // future stray value) without an unchecked cast.
+              onValueChange={(v) => {
+                if (isGroupByDimension(v)) void setParams({ groupBy: v });
+              }}
               aria-label="Group connections by"
               data-testid="connections-group-by"
             >
-              <ToggleGroupItem value="type" className="gap-1.5 text-xs" data-testid="connections-group-by-type">
-                <Database className="size-3" />
-                Type
-              </ToggleGroupItem>
-              <ToggleGroupItem value="environment" className="gap-1.5 text-xs" data-testid="connections-group-by-environment">
-                <Layers className="size-3" />
-                Environment
-              </ToggleGroupItem>
+              {GROUP_BY_VALUES.map((value) => (
+                <ToggleGroupItem
+                  key={value}
+                  value={value}
+                  className="gap-1.5 text-xs"
+                  data-testid={`connections-group-by-${value}`}
+                >
+                  {value === "type" ? <Database className="size-3" /> : <Layers className="size-3" />}
+                  {value === "type" ? "Type" : "Environment"}
+                </ToggleGroupItem>
+              ))}
             </ToggleGroup>
           {demoReadOnly ? (
             <TooltipProvider>
@@ -1056,14 +1056,16 @@ export default function ConnectionsPage() {
           <PoolStatsSection onError={setMutationError} />
 
           {groupBy === "environment" ? (
-            // The Environments view embeds the connection-groups admin
-            // surface — same fetch (`/api/v1/admin/connection-groups`), every
-            // feature (create / rename / delete / archive cascade / merge
-            // wizard / auto-detected toggles) preserved. Per slice 4 of PRD
-            // #2458 this replaces the standalone `/admin/connections/groups`
-            // page as the canonical home; the old URL server-side-redirects
-            // here.
-            <ConnectionGroupsSection />
+            // The environments view reuses the parent's connections fetch
+            // — sharing one request avoids a React Query cache-key
+            // collision on `[path]` between two callers passing different
+            // schemas (transformed array vs `{ connections: [...] }`),
+            // which would otherwise read the wrong shape from cache and
+            // render empty member rosters.
+            <ConnectionGroupsSection
+              connections={displayConnections}
+              refetchConnections={refetch}
+            />
           ) : (
             <AdminContentWrapper
               loading={loading}
@@ -1392,7 +1394,7 @@ function ConnectionCard({
             label="Environment"
             value={
               <Link
-                href="/admin/connections?groupBy=environment"
+                href={ENVIRONMENT_VIEW_HREF}
                 className="inline-flex items-center"
                 aria-label={`View environment ${stripGroupPrefix(conn.groupName)}`}
               >

--- a/packages/web/src/app/admin/connections/search-params.ts
+++ b/packages/web/src/app/admin/connections/search-params.ts
@@ -1,12 +1,29 @@
 import { parseAsStringLiteral } from "nuqs";
 import type { GroupByDimension } from "./group-by";
 
-// The two legal grouping dimensions for /admin/connections. Encoded as a
-// string-literal union so an invalid `?groupBy=foo` falls back to "type"
-// instead of breaking the page. Default is "type" so the URL stays clean
-// for the common "provider-grouped" view.
-const GROUP_BY_VALUES = ["type", "environment"] as const satisfies readonly GroupByDimension[];
+/** Legal `?groupBy` values. Exported so the page can narrow Radix's
+ * `string | undefined` ToggleGroup callback against this tuple instead
+ * of an unchecked `as GroupByDimension` cast. */
+export const GROUP_BY_VALUES = ["type", "environment"] as const satisfies readonly GroupByDimension[];
+
+// Both directions of the union ↔ tuple bond should be enforced. The
+// `satisfies` above catches a tuple entry that isn't in the union; this
+// catches a union member missing from the tuple (which would make the
+// parser silently reject a legal value).
+type _GroupByExhaustive =
+  Exclude<GroupByDimension, (typeof GROUP_BY_VALUES)[number]> extends never ? true : never;
+type _AssertGroupByExhaustive = _GroupByExhaustive extends true ? true : never;
+const _exhaustivenessProof: _AssertGroupByExhaustive = true;
+
+/** Type predicate so callers (e.g. the ToggleGroup's `onValueChange`)
+ * can narrow Radix's untyped string callback against the same tuple
+ * the URL parser uses — keeping the rejection rules in one place. */
+export function isGroupByDimension(value: string): value is GroupByDimension {
+  return (GROUP_BY_VALUES as readonly string[]).includes(value);
+}
 
 export const connectionsSearchParams = {
+  // Falls back to "type" on an unknown value rather than throwing — admins
+  // hitting a hand-edited URL land on the default view.
   groupBy: parseAsStringLiteral(GROUP_BY_VALUES).withDefault("type"),
 };

--- a/packages/web/src/app/admin/scheduled-tasks/__tests__/task-form-dialog.test.tsx
+++ b/packages/web/src/app/admin/scheduled-tasks/__tests__/task-form-dialog.test.tsx
@@ -176,10 +176,9 @@ describe("TaskFormDialog — zero-environment guard (#2418)", () => {
     await waitFor(() => {
       expect(container.textContent).toContain("Create an environment first");
     });
-    // PRD #2458 slice 4 collapsed `/admin/connections/groups` into the
-    // `?groupBy=environment` deep link on the connections page — the
-    // empty-state CTA points directly at that view so the admin lands
-    // on the Environments tab, not the default Type tab.
+    // The CTA must point at the env grouping directly, not the bare
+    // `/admin/connections` URL — otherwise a first-time admin lands on
+    // the default Type tab and still can't see where to add an env.
     const link = container.querySelector<HTMLAnchorElement>(
       'a[href="/admin/connections?groupBy=environment"]',
     );

--- a/packages/web/src/app/admin/scheduled-tasks/task-form-dialog.tsx
+++ b/packages/web/src/app/admin/scheduled-tasks/task-form-dialog.tsx
@@ -28,6 +28,7 @@ import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import Link from "next/link";
 import { AlertTriangle, Loader2, Plus, X, Clock } from "lucide-react";
+import { ENVIRONMENT_VIEW_HREF } from "../connections/group-by";
 import {
   CRON_PRESETS,
   presetFromCron,
@@ -598,7 +599,7 @@ export function TaskFormDialog({
                   group). Add one before scheduling a task.
                   {" "}
                   <Link
-                    href="/admin/connections?groupBy=environment"
+                    href={ENVIRONMENT_VIEW_HREF}
                     className="font-medium underline underline-offset-2"
                   >
                     Go to Environments

--- a/packages/web/src/ui/__tests__/connection-columns.test.tsx
+++ b/packages/web/src/ui/__tests__/connection-columns.test.tsx
@@ -91,14 +91,15 @@ describe("connection columns — environment cell", () => {
       groupId: "g_prod",
       groupName: "g_prod",
     });
-    // Strip the legacy `g_` prefix so the chip reads naturally.
+    // `stripGroupPrefix` strips the legacy `g_` / `__global__:` backfill
+    // artifacts so the chip reads naturally.
     expect(container.textContent).toContain("prod");
     expect(container.textContent).not.toContain("g_prod");
     const link = container.querySelector("a");
     expect(link).not.toBeNull();
-    // PRD #2458 slice 4: the standalone /admin/connections/groups page is
-    // a server-side redirect; chips now deep-link directly to the
-    // embedded view to avoid a one-frame redirect flash.
+    // Chips deep-link straight to `?groupBy=environment` rather than the
+    // legacy `/admin/connections/groups` URL — the latter still works as
+    // a server-side redirect, but going direct avoids a one-frame flash.
     expect(link?.getAttribute("href")).toBe("/admin/connections?groupBy=environment");
   });
 

--- a/packages/web/src/ui/__tests__/connections-groups-redirect.test.ts
+++ b/packages/web/src/ui/__tests__/connections-groups-redirect.test.ts
@@ -2,15 +2,15 @@ import { describe, expect, mock, test } from "bun:test";
 
 mock.module("next/navigation", () => ({
   redirect: (url: string) => {
-    // Mirror Next.js semantics — `redirect` throws to interrupt
-    // rendering. We throw a tagged error the test asserts on.
+    // `next/navigation`'s redirect() throws to halt rendering — tag the
+    // thrown error with the URL so the test can assert on it.
     const err = new Error("NEXT_REDIRECT") as Error & { url: string };
     err.url = url;
     throw err;
   },
 }));
 
-// Imported after the mock so the page picks up the stubbed `redirect`.
+// Dynamic import after the mock so the page picks up the stub.
 const ConnectionGroupsRedirect = (
   await import("../../app/admin/connections/groups/page")
 ).default;
@@ -23,9 +23,8 @@ describe("/admin/connections/groups", () => {
     } catch (err) {
       captured = (err as { url?: string }).url;
     }
-    // PRD #2458 slice 4 — bookmarks issued before the IA reshape must
-    // land directly on the toggle's environment dimension, NOT on a
-    // client-side useEffect that briefly renders the old page first.
+    // Old bookmarks must land directly on the env tab, not a client
+    // useEffect that briefly renders the old page first.
     expect(captured).toBe("/admin/connections?groupBy=environment");
   });
 });

--- a/packages/web/src/ui/components/admin/admin-nav.ts
+++ b/packages/web/src/ui/components/admin/admin-nav.ts
@@ -34,10 +34,9 @@ export const navGroups: NavGroup[] = [
       { href: "/admin/semantic", label: "Semantic Layer" },
       { href: "/admin/semantic/improve", label: "Improve Layer" },
       { href: "/admin/schema-diff", label: "Schema Diff" },
-      // Connections covers both raw connections and the environment
-      // groupings via a `?groupBy=type|environment` toggle (PRD #2458
-      // slice 4). The old `/admin/connections/groups` URL still works as
-      // a server-side redirect for bookmarked deep links.
+      // One entry covers both raw connections and environment groupings —
+      // the page hosts a `?groupBy=type|environment` toggle and the legacy
+      // `/admin/connections/groups` URL server-side-redirects in.
       { href: "/admin/connections", label: "Connections" },
       { href: "/admin/cache", label: "Cache" },
     ],


### PR DESCRIPTION
## Summary

Follow-up to #2471. Five aspect reviews (code, types, comments, tests, silent-failures) ran after that PR landed. One critical bug + a handful of tightenings — bundled here so the IA reshape doesn't ship broken.

**Critical — environments view rendered empty.** `ConnectionsPage` and the new `ConnectionGroupsSection` both called `useAdminFetch("/api/v1/admin/connections", ...)` with different schemas. React Query's cache key is `[path]` only, so the second caller hit the cache and read the first caller's transformed shape (`ConnectionInfo[]` vs `{ connections: [...] }`), collapsing every downstream `connList?.connections` access to `[]`. Result: member rosters empty, "Merge connections" always disabled, "Add a connection" dropdowns always saying "No ungrouped connections", merge wizard always saying "No connections to merge". Fixed by lifting the fetch to the parent and threading `connections` + `refetchConnections` through as props — duplicate request gone, cache shape collision structurally impossible.

**Other fixes:**
- Replace `v as GroupByDimension` unchecked cast on the toggle callback with an `isGroupByDimension` type predicate that narrows through the same tuple the URL parser uses.
- Add a reverse exhaustiveness type-check in `search-params.ts` so a new `GroupByDimension` variant that forgets to land in `GROUP_BY_VALUES` is a build error.
- Extract duplicated `/admin/connections?groupBy=environment` href to a shared `ENVIRONMENT_VIEW_HREF` constant (chip + CTA + redirect all import it).
- Strip "slice 4 of PRD #2458" stamps from 7 sites; replace the "every feature ... unchanged" inventory in `ConnectionGroupsSection`'s JSDoc with the load-bearing rationale.
- Inline single-use wrapper; render ToggleGroupItems from `GROUP_BY_VALUES.map`.

Refs #2460, #2458, #2471.

## Test plan

- [x] `bun run type` — clean
- [x] `bun run lint` — clean (one pre-existing unrelated warning in `tools/backends/__tests__/detect.test.ts`)
- [x] Affected web tests (`connections-group-by`, `connections-groups-redirect`, `connection-columns`, `task-form-dialog`) — all pass
- [x] Syncpack lint, template drift, schema drift — all pass
- [ ] Manual: flip toggle on `/admin/connections`, verify member chips and merge wizard now populate against a real connection list
- [ ] Manual: hit `/admin/connections/groups` directly, confirm redirect lands on `?groupBy=environment` without flash