### PR TITLE
fix(web): stop rendering "user-configured" on /admin/model-config (#2468)

### DIFF
--- a/packages/web/src/app/admin/model-config/page.tsx
+++ b/packages/web/src/app/admin/model-config/page.tsx
@@ -44,6 +44,11 @@ export default function ModelConfigPage() {
   // failure behind "Platform default" copy.
   const billingFailed = !!billingError && !billingMissing;
   const platformModel = billing?.currentModel ?? billing?.plan.defaultModel ?? null;
+  // Free-tier workspaces with no ATLAS_MODEL setting fall through to the
+  // `"user-configured"` placeholder from `plans.ts`. Render an actionable CTA
+  // instead of leaking the placeholder string into the title.
+  const freeTierUnconfigured =
+    billing?.plan.tier === "free" && platformModel === "user-configured";
 
   return (
     <div className="p-6">
@@ -78,6 +83,13 @@ export default function ModelConfigPage() {
                     Retry
                   </Button>
                 }
+              />
+            ) : freeTierUnconfigured ? (
+              <CompactRow
+                icon={Cpu}
+                title="No default model configured"
+                description="Set ATLAS_MODEL in your environment or pick a model below."
+                status="disconnected"
               />
             ) : (
               <CompactRow


### PR DESCRIPTION
## Summary

- Free-tier workspaces with no `ATLAS_MODEL` setting fall through to the `"user-configured"` placeholder defined in [`plans.ts:75`](https://github.com/AtlasDevHQ/atlas/blob/main/packages/api/src/lib/billing/plans.ts#L75). The model-config page rendered that string as the platform-baseline title, leaking internal config-system shorthand into user-facing copy.
- Detect the free-tier + placeholder case in `/admin/model-config` and render an actionable CTA instead: title **"No default model configured"** with description **"Set ATLAS_MODEL in your environment or pick a model below."**
- `plans.ts` is intentionally unchanged — the constant is the contract; the UI owns the translation.

Closes #2468. Slice 4/4 of PRD #2464 (slices 1+2 already shipped via #2469 / #2470).

## Test plan

- [x] `grep "user-configured"` across `packages/web/src/app/admin/model-config/` — no rendered substring (only a comment + comparison literal)
- [x] `git diff packages/api/src/lib/billing/plans.ts` empty — constant untouched
- [x] `bun run type` clean
- [x] `bun run lint` clean (1 pre-existing warning in `detect.test.ts` unrelated)
- [x] `/ci` clean — lint, type, full test, syncpack, template/security/railway/schema/oauth drift all pass
- [ ] Manual: on a self-hosted dev workspace with `plan.tier = "free"` and no `ATLAS_MODEL` set, the model-config page shows the actionable message, not "user-configured"