### PR TITLE
feat(web): drift drawer on /admin/semantic (#2461)

### DIFF
--- a/packages/web/src/app/admin/schema-diff/page.tsx
+++ b/packages/web/src/app/admin/schema-diff/page.tsx
@@ -9,7 +9,7 @@ import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
 import { StatCard } from "@/ui/components/admin/stat-card";
 import { AdminContentWrapper } from "@/ui/components/admin-content-wrapper";
 import { ErrorBoundary } from "@/ui/components/error-boundary";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import {
   Select,
@@ -18,35 +18,22 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-} from "@/components/ui/collapsible";
 import { Button } from "@/components/ui/button";
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table";
 import {
   GitCompareArrows,
   CheckCircle2,
   Plus,
   Minus,
   RefreshCw,
-  ChevronDown,
   AlertTriangle,
   ArrowRightLeft,
   Terminal,
 } from "lucide-react";
-import type { SemanticTableDiff, ConnectionInfo } from "@/ui/lib/types";
+import type { ConnectionInfo } from "@/ui/lib/types";
 import { ConnectionsResponseSchema, SemanticDiffResponseSchema } from "@/ui/lib/admin-schemas";
 import { useDevModeNoDrafts } from "@/ui/hooks/use-dev-mode-no-drafts";
 import { DeveloperEmptyState } from "@/ui/components/admin/developer-empty-state";
+import { DiffCard } from "@/ui/components/admin/diff-card";
 
 // ---------------------------------------------------------------------------
 
@@ -313,7 +300,7 @@ export default function SchemaDiffPage() {
               </h2>
               <div className="space-y-2">
                 {diff.tableDiffs.map((td) => (
-                  <ChangedTableCard key={td.table} diff={td} />
+                  <DiffCard key={td.table} diff={td} />
                 ))}
               </div>
             </section>
@@ -429,83 +416,3 @@ function ConnectionSelector({
   );
 }
 
-function ChangedTableCard({ diff }: { diff: SemanticTableDiff }) {
-  const [open, setOpen] = useState(false);
-  const changeCount = diff.addedColumns.length + diff.removedColumns.length + diff.typeChanges.length;
-
-  return (
-    <Card className="border-amber-500/30 shadow-none">
-      <Collapsible open={open} onOpenChange={setOpen}>
-        <CollapsibleTrigger asChild>
-          <CardHeader className="cursor-pointer py-3 hover:bg-muted/30">
-            <div className="flex items-center justify-between">
-              <CardTitle className="flex items-center gap-2 text-sm">
-                <span className="font-mono">{diff.table}</span>
-                <Badge variant="outline" className="text-xs text-amber-700 dark:text-amber-400 border-amber-300 dark:border-amber-700">
-                  {changeCount} {changeCount === 1 ? "change" : "changes"}
-                </Badge>
-              </CardTitle>
-              <ChevronDown className={`size-4 text-muted-foreground transition-transform ${open ? "rotate-180" : ""}`} />
-            </div>
-          </CardHeader>
-        </CollapsibleTrigger>
-        <CollapsibleContent>
-          <CardContent className="pt-0 pb-4">
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead className="w-20">Change</TableHead>
-                  <TableHead>Column</TableHead>
-                  <TableHead>Detail</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {diff.addedColumns.map((col) => (
-                  <TableRow key={`add-${col.name}`}>
-                    <TableCell>
-                      <Badge variant="outline" className="text-[10px] text-green-700 dark:text-green-400 border-green-300 dark:border-green-700">
-                        added
-                      </Badge>
-                    </TableCell>
-                    <TableCell className="font-mono text-xs">{col.name}</TableCell>
-                    <TableCell className="text-xs text-muted-foreground">
-                      type: {col.type} (in DB, missing from YAML)
-                    </TableCell>
-                  </TableRow>
-                ))}
-                {diff.removedColumns.map((col) => (
-                  <TableRow key={`rm-${col.name}`}>
-                    <TableCell>
-                      <Badge variant="outline" className="text-[10px] text-red-700 dark:text-red-400 border-red-300 dark:border-red-700">
-                        removed
-                      </Badge>
-                    </TableCell>
-                    <TableCell className="font-mono text-xs">{col.name}</TableCell>
-                    <TableCell className="text-xs text-muted-foreground">
-                      type: {col.type} (in YAML, missing from DB)
-                    </TableCell>
-                  </TableRow>
-                ))}
-                {diff.typeChanges.map((tc) => (
-                  <TableRow key={`type-${tc.name}`}>
-                    <TableCell>
-                      <Badge variant="outline" className="text-[10px] text-amber-700 dark:text-amber-400 border-amber-300 dark:border-amber-700">
-                        type
-                      </Badge>
-                    </TableCell>
-                    <TableCell className="font-mono text-xs">{tc.name}</TableCell>
-                    <TableCell className="text-xs text-muted-foreground">
-                      YAML: <code className="rounded bg-muted px-1">{tc.yamlType}</code>
-                      {" → "}
-                      DB: <code className="rounded bg-muted px-1">{tc.dbType}</code>
-                    </TableCell>
-                  </TableRow>
-                ))}
-              </TableBody>
-            </Table>
-          </CardContent>
-        </CollapsibleContent>
-      </Collapsible>
-    </Card>
-  );
-}

--- a/packages/web/src/app/admin/semantic/__tests__/drift-routing.test.ts
+++ b/packages/web/src/app/admin/semantic/__tests__/drift-routing.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Pins the click → drawer routing predicate (#2461). Catches regressions
+ * where a refactor silently drops one of the drift states or breaks the
+ * multi-environment match-key.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { driftDrawerTargetFor } from "../drift-routing";
+
+const entities = [
+  { name: "orders", connectionGroupId: null, drift: { state: "changed" as const, changeCount: 2 } },
+  { name: "users", connectionGroupId: null, drift: { state: "in-sync" as const } },
+  { name: "legacy", connectionGroupId: null, drift: { state: "removed" as const } },
+  { name: "dbonly", connectionGroupId: null, drift: { state: "new" as const } },
+  { name: "no_drift_data", connectionGroupId: null, drift: null },
+  { name: "orders", connectionGroupId: "g_prod", drift: { state: "changed" as const, changeCount: 1 } },
+];
+
+describe("driftDrawerTargetFor", () => {
+  test("returns the entity name for a `changed` row", () => {
+    expect(
+      driftDrawerTargetFor({ type: "entity", name: "orders" }, entities),
+    ).toBe("orders");
+  });
+
+  test("returns the entity name for a `removed` row", () => {
+    expect(
+      driftDrawerTargetFor({ type: "entity", name: "legacy" }, entities),
+    ).toBe("legacy");
+  });
+
+  test("returns the entity name for a `new` row (DB-only, future-proofs the predicate)", () => {
+    expect(
+      driftDrawerTargetFor({ type: "entity", name: "dbonly" }, entities),
+    ).toBe("dbonly");
+  });
+
+  test("returns null for an `in-sync` row — the drawer must not open", () => {
+    expect(
+      driftDrawerTargetFor({ type: "entity", name: "users" }, entities),
+    ).toBeNull();
+  });
+
+  test("returns null when the entity has no drift signal at all", () => {
+    expect(
+      driftDrawerTargetFor({ type: "entity", name: "no_drift_data" }, entities),
+    ).toBeNull();
+  });
+
+  test("returns null when the entity is unknown", () => {
+    expect(
+      driftDrawerTargetFor({ type: "entity", name: "ghost" }, entities),
+    ).toBeNull();
+  });
+
+  test("returns null for non-entity selections (catalog / glossary / metrics / null)", () => {
+    expect(driftDrawerTargetFor(null, entities)).toBeNull();
+    expect(driftDrawerTargetFor({ type: "catalog" }, entities)).toBeNull();
+    expect(driftDrawerTargetFor({ type: "glossary" }, entities)).toBeNull();
+    expect(driftDrawerTargetFor({ type: "metrics", file: "mrr" }, entities)).toBeNull();
+  });
+
+  test("disambiguates by connectionGroupId — same name, different group", () => {
+    // Selecting the `g_prod` row should resolve to the prod drift row, not
+    // the legacy / null-group one. Both happen to be `changed`, so the
+    // negative test is "selecting `g_prod` doesn't fall back to the null
+    // row by name alone".
+    expect(
+      driftDrawerTargetFor(
+        { type: "entity", name: "orders", connectionGroupId: "g_prod" },
+        entities,
+      ),
+    ).toBe("orders");
+  });
+
+  test("connectionGroupId mismatch returns null even when the name is in another group", () => {
+    expect(
+      driftDrawerTargetFor(
+        { type: "entity", name: "orders", connectionGroupId: "g_stage" },
+        entities,
+      ),
+    ).toBeNull();
+  });
+
+  test("undefined connectionGroupId on the selection matches the null-group row", () => {
+    // Mirrors `isSelected` in the file tree — `null` and `undefined` both
+    // mean "no group qualifier", so unqualified clicks resolve to the
+    // legacy / unscoped row rather than dropping through.
+    expect(
+      driftDrawerTargetFor({ type: "entity", name: "orders" }, entities),
+    ).toBe("orders");
+  });
+});

--- a/packages/web/src/app/admin/semantic/drift-routing.ts
+++ b/packages/web/src/app/admin/semantic/drift-routing.ts
@@ -1,0 +1,45 @@
+import type {
+  SemanticSelection,
+  SemanticTreeDrift,
+} from "@/ui/components/admin/semantic-file-tree";
+
+/**
+ * Minimal lookup row — name + group qualifier + drift state. Kept narrower
+ * than `EntitySummary` so a future schema growth on the page can't drift
+ * this predicate's input shape without an explicit edit.
+ */
+export interface DriftRoutingEntity {
+  readonly name: string;
+  readonly connectionGroupId: string | null;
+  readonly drift?: SemanticTreeDrift | null;
+}
+
+/**
+ * Returns the entity name to open the drift drawer for, or `null` if the
+ * click should fall through to the regular entity-detail view.
+ *
+ * The drawer opens for `changed`, `removed`, or `new` rows (#2461). `new`
+ * doesn't currently appear in the YAML-side file tree but is included so
+ * a future caller surfacing DB-only rows won't silently no-op.
+ *
+ * Match keys on both `name` and `connectionGroupId` to keep multi-
+ * environment orgs (#2412) coherent — the same `name` under two groups
+ * is two rows, and a stale group qualifier shouldn't open a drawer for
+ * the other env's drift.
+ */
+export function driftDrawerTargetFor(
+  selection: SemanticSelection,
+  entities: ReadonlyArray<DriftRoutingEntity>,
+): string | null {
+  if (selection?.type !== "entity") return null;
+  const match = entities.find(
+    (e) =>
+      e.name === selection.name &&
+      e.connectionGroupId === (selection.connectionGroupId ?? null),
+  );
+  const state = match?.drift?.state;
+  if (state === "changed" || state === "removed" || state === "new") {
+    return selection.name;
+  }
+  return null;
+}

--- a/packages/web/src/app/admin/semantic/page.tsx
+++ b/packages/web/src/app/admin/semantic/page.tsx
@@ -61,6 +61,7 @@ import { useDevModeNoDrafts } from "@/ui/hooks/use-dev-mode-no-drafts";
 import { DeveloperEmptyState } from "@/ui/components/admin/developer-empty-state";
 import { SemanticPublishedBanner } from "@/ui/components/admin/semantic-published-banner";
 import { DriftDrawer } from "@/ui/components/admin/drift-drawer";
+import { driftDrawerTargetFor } from "./drift-routing";
 
 // ── Types ─────────────────────────────────────────────────────────
 
@@ -425,7 +426,7 @@ export default function SemanticPage() {
 
   // Drift drawer (#2461): opens overlaid when a drifted entity is clicked.
   // The underlying selection still updates so closing the drawer leaves the
-  // admin on the entity's detail view. Slice 3 (#2462) adds action buttons.
+  // admin on the entity's detail view. Reconcile actions land in #2462.
   const [driftDrawerEntity, setDriftDrawerEntity] = useState<string | null>(null);
   const [driftDrawerOpen, setDriftDrawerOpen] = useState(false);
 
@@ -602,17 +603,10 @@ export default function SemanticPage() {
     // #2461: opening the drift drawer on click for drifted entities.
     // We piggy-back on the existing selection update — closing the drawer
     // returns to the regular entity detail view, no extra navigation needed.
-    if (sel?.type === "entity") {
-      const match = entities.find(
-        (e) =>
-          e.name === sel.name &&
-          e.connectionGroupId === (sel.connectionGroupId ?? null),
-      );
-      const driftState = match?.drift?.state;
-      if (driftState === "changed" || driftState === "removed" || driftState === "new") {
-        setDriftDrawerEntity(sel.name);
-        setDriftDrawerOpen(true);
-      }
+    const driftTarget = driftDrawerTargetFor(sel, entities);
+    if (driftTarget) {
+      setDriftDrawerEntity(driftTarget);
+      setDriftDrawerOpen(true);
     }
   };
 
@@ -1010,7 +1004,6 @@ export default function SemanticPage() {
       )}
       </AdminContentWrapper>
 
-      {/* Drift drawer (#2461) — opens overlaid on drifted-entity clicks. */}
       <DriftDrawer
         entityName={driftDrawerEntity}
         open={driftDrawerOpen}

--- a/packages/web/src/app/admin/semantic/page.tsx
+++ b/packages/web/src/app/admin/semantic/page.tsx
@@ -60,6 +60,7 @@ import { useDemoReadonly, demoIndustryLabel } from "@/ui/hooks/use-demo-readonly
 import { useDevModeNoDrafts } from "@/ui/hooks/use-dev-mode-no-drafts";
 import { DeveloperEmptyState } from "@/ui/components/admin/developer-empty-state";
 import { SemanticPublishedBanner } from "@/ui/components/admin/semantic-published-banner";
+import { DriftDrawer } from "@/ui/components/admin/drift-drawer";
 
 // ── Types ─────────────────────────────────────────────────────────
 
@@ -422,6 +423,12 @@ export default function SemanticPage() {
   const [editingEntityName, setEditingEntityName] = useState<string | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
 
+  // Drift drawer (#2461): opens overlaid when a drifted entity is clicked.
+  // The underlying selection still updates so closing the drawer leaves the
+  // admin on the entity's detail view. Slice 3 (#2462) adds action buttons.
+  const [driftDrawerEntity, setDriftDrawerEntity] = useState<string | null>(null);
+  const [driftDrawerOpen, setDriftDrawerOpen] = useState(false);
+
   const fetchOpts: RequestInit = {
     credentials: isCrossOrigin ? "include" : "same-origin",
   };
@@ -592,6 +599,21 @@ export default function SemanticPage() {
         group: selectionToGroupParam(sel),
       });
     });
+    // #2461: opening the drift drawer on click for drifted entities.
+    // We piggy-back on the existing selection update — closing the drawer
+    // returns to the regular entity detail view, no extra navigation needed.
+    if (sel?.type === "entity") {
+      const match = entities.find(
+        (e) =>
+          e.name === sel.name &&
+          e.connectionGroupId === (sel.connectionGroupId ?? null),
+      );
+      const driftState = match?.drift?.state;
+      if (driftState === "changed" || driftState === "removed" || driftState === "new") {
+        setDriftDrawerEntity(sel.name);
+        setDriftDrawerOpen(true);
+      }
+    }
   };
 
   // Fetch entity detail when selection changes (including from URL on mount)
@@ -987,6 +1009,16 @@ export default function SemanticPage() {
       </>
       )}
       </AdminContentWrapper>
+
+      {/* Drift drawer (#2461) — opens overlaid on drifted-entity clicks. */}
+      <DriftDrawer
+        entityName={driftDrawerEntity}
+        open={driftDrawerOpen}
+        onOpenChange={(open) => {
+          setDriftDrawerOpen(open);
+          if (!open) setDriftDrawerEntity(null);
+        }}
+      />
 
       {/* Entity editor dialog */}
       <EntityEditorDialog

--- a/packages/web/src/ui/__tests__/diff-card.test.tsx
+++ b/packages/web/src/ui/__tests__/diff-card.test.tsx
@@ -1,0 +1,125 @@
+/**
+ * Direct render contract for the shared <DiffCard> (#2461). The drawer test
+ * exercises this transitively, but `defaultOpen={false}` and `removedColumns`
+ * aren't covered there — locking them here keeps both consumers honest while
+ * the legacy schema-diff page (#2463) is still around.
+ */
+
+import { describe, expect, test, afterEach } from "bun:test";
+import { render, cleanup, fireEvent } from "@testing-library/react";
+import type { SemanticTableDiff } from "@useatlas/types";
+import { DiffCard } from "../components/admin/diff-card";
+
+afterEach(() => {
+  cleanup();
+});
+
+function makeDiff(overrides: Partial<SemanticTableDiff> = {}): SemanticTableDiff {
+  return {
+    table: "orders",
+    addedColumns: [],
+    removedColumns: [],
+    typeChanges: [],
+    ...overrides,
+  };
+}
+
+describe("DiffCard", () => {
+  test("defaults to collapsed — header visible, rows hidden", () => {
+    const { container } = render(
+      <DiffCard
+        diff={makeDiff({
+          addedColumns: [{ name: "shipped_at", type: "timestamp" }],
+        })}
+      />,
+    );
+    // Header renders the table name + change count.
+    expect(container.textContent).toContain("orders");
+    expect(container.textContent).toContain("1 change");
+    // Collapsible body should not have surfaced the added column yet.
+    expect(container.textContent).not.toContain("shipped_at");
+  });
+
+  test("defaultOpen expands the body on first render", () => {
+    const { container } = render(
+      <DiffCard
+        defaultOpen
+        diff={makeDiff({
+          addedColumns: [{ name: "shipped_at", type: "timestamp" }],
+        })}
+      />,
+    );
+    expect(container.textContent).toContain("shipped_at");
+    expect(container.textContent).toContain("(in DB, missing from YAML)");
+  });
+
+  test("renders removed columns with the YAML-only detail message", () => {
+    const { container } = render(
+      <DiffCard
+        defaultOpen
+        diff={makeDiff({
+          removedColumns: [{ name: "legacy_col", type: "string" }],
+        })}
+      />,
+    );
+    expect(container.textContent).toContain("legacy_col");
+    expect(container.textContent).toContain("(in YAML, missing from DB)");
+    expect(container.textContent).toContain("removed");
+  });
+
+  test("renders type changes with both YAML and DB types", () => {
+    const { container } = render(
+      <DiffCard
+        defaultOpen
+        diff={makeDiff({
+          typeChanges: [{ name: "total", yamlType: "number", dbType: "decimal" }],
+        })}
+      />,
+    );
+    expect(container.textContent).toContain("total");
+    expect(container.textContent).toContain("number");
+    expect(container.textContent).toContain("decimal");
+  });
+
+  test("uses singular 'change' for a single-column diff", () => {
+    const { container } = render(
+      <DiffCard
+        diff={makeDiff({
+          addedColumns: [{ name: "shipped_at", type: "timestamp" }],
+        })}
+      />,
+    );
+    expect(container.textContent).toContain("1 change");
+    expect(container.textContent).not.toContain("1 changes");
+  });
+
+  test("plural 'changes' for multi-column diffs across all three buckets", () => {
+    const { container } = render(
+      <DiffCard
+        diff={makeDiff({
+          addedColumns: [{ name: "shipped_at", type: "timestamp" }],
+          removedColumns: [{ name: "legacy_col", type: "string" }],
+          typeChanges: [{ name: "total", yamlType: "number", dbType: "decimal" }],
+        })}
+      />,
+    );
+    expect(container.textContent).toContain("3 changes");
+  });
+
+  test("clicking the header toggles the collapsible body", () => {
+    const { container } = render(
+      <DiffCard
+        diff={makeDiff({
+          addedColumns: [{ name: "shipped_at", type: "timestamp" }],
+        })}
+      />,
+    );
+    expect(container.textContent).not.toContain("shipped_at");
+    // Radix Collapsible.Trigger renders its child with `aria-expanded` — that's
+    // the most stable handle regardless of which DOM element shadcn picks.
+    const trigger = container.querySelector("[aria-expanded]") as HTMLElement | null;
+    expect(trigger).not.toBeNull();
+    fireEvent.click(trigger as HTMLElement);
+    expect(container.textContent).toContain("shipped_at");
+  });
+});

--- a/packages/web/src/ui/__tests__/drift-drawer.test.tsx
+++ b/packages/web/src/ui/__tests__/drift-drawer.test.tsx
@@ -1,0 +1,221 @@
+/**
+ * Smoke tests for the drift drawer (#2461). Verifies that a fixture diff
+ * payload renders through the shared `<DiffCard>` and that the open/close
+ * contract surfaces back to the caller. Mocks `useAdminFetch` directly so
+ * we don't touch the network layer — the contract under test is "given
+ * data X for entity Y, the drawer renders the right card".
+ *
+ * Mirrors the mocking shape from `backup-method-banner.test.tsx`.
+ */
+
+import { describe, expect, test, mock, beforeEach, afterEach } from "bun:test";
+import { render, cleanup, fireEvent } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { SemanticDiffResponse } from "@useatlas/types";
+
+type DiffResponse = SemanticDiffResponse;
+
+let mockData: DiffResponse | null = null;
+let mockLoading = false;
+let mockError: { message: string; status?: number } | null = null;
+
+mock.module("@/ui/hooks/use-admin-fetch", () => ({
+  useAdminFetch: () => ({
+    data: mockError ? null : mockData,
+    loading: mockLoading,
+    error: mockError,
+    setError: () => {},
+    refetch: () => Promise.resolve(),
+  }),
+  friendlyError: (err: { message?: string }) => err?.message ?? "error",
+}));
+
+mock.module("@/ui/lib/fetch-error", () => ({
+  friendlyError: (err: { message?: string }) => err?.message ?? "error",
+  friendlyErrorOrNull: (err: { message?: string } | null | undefined) =>
+    err?.message ?? null,
+  buildFetchError: (init: { message: string }) => ({ message: init.message }),
+  extractFetchError: async (r: Response) => ({ message: `HTTP ${r.status}` }),
+}));
+
+const { DriftDrawer } = await import("../components/admin/drift-drawer");
+
+function wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return createElement(QueryClientProvider, { client }, children);
+}
+
+function makeDiff(overrides: Partial<DiffResponse> = {}): DiffResponse {
+  return {
+    connection: "default",
+    newTables: [],
+    removedTables: [],
+    tableDiffs: [],
+    unchangedCount: 0,
+    summary: { total: 0, new: 0, removed: 0, changed: 0, unchanged: 0 },
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  mockData = null;
+  mockLoading = false;
+  mockError = null;
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("DriftDrawer (#2461)", () => {
+  test("renders the per-table diff card for a drifted entity", () => {
+    mockData = makeDiff({
+      tableDiffs: [
+        {
+          table: "orders",
+          addedColumns: [{ name: "shipped_at", type: "timestamp" }],
+          removedColumns: [],
+          typeChanges: [{ name: "total", yamlType: "number", dbType: "decimal" }],
+        },
+      ],
+      summary: { total: 1, new: 0, removed: 0, changed: 1, unchanged: 0 },
+    });
+
+    render(
+      <DriftDrawer entityName="orders" open={true} onOpenChange={() => {}} />,
+      { wrapper },
+    );
+
+    // Drawer renders to a portal — query document.body, not container.
+    expect(document.body.textContent).toContain("orders");
+    // Added column surfaced from the fixture.
+    expect(document.body.textContent).toContain("shipped_at");
+    // Type-change row uses the YAML → DB transition.
+    expect(document.body.textContent).toContain("total");
+    expect(document.body.textContent).toContain("decimal");
+    // Header sentence is the static drawer description.
+    expect(document.body.textContent).toContain("Schema drift between database and YAML");
+  });
+
+  test("renders the removed-table notice when the entity is in removedTables", () => {
+    mockData = makeDiff({
+      removedTables: ["legacy_table"],
+      summary: { total: 1, new: 0, removed: 1, changed: 0, unchanged: 0 },
+    });
+
+    render(
+      <DriftDrawer entityName="legacy_table" open={true} onOpenChange={() => {}} />,
+      { wrapper },
+    );
+
+    expect(document.body.textContent).toContain("legacy_table");
+    expect(document.body.textContent).toContain("no longer exists in the database");
+  });
+
+  test("falls back to in-sync notice when the entity is not in the diff", () => {
+    // Defensive: the page only opens the drawer for drifted entities, but
+    // a manual open on a clean entity must not look broken.
+    mockData = makeDiff({
+      unchangedCount: 1,
+      summary: { total: 1, new: 0, removed: 0, changed: 0, unchanged: 1 },
+    });
+
+    render(
+      <DriftDrawer entityName="users" open={true} onOpenChange={() => {}} />,
+      { wrapper },
+    );
+
+    expect(document.body.textContent).toContain("is in sync with the database");
+  });
+
+  test("does not fetch or render body when closed", () => {
+    mockData = makeDiff({
+      tableDiffs: [
+        {
+          table: "orders",
+          addedColumns: [{ name: "shipped_at", type: "timestamp" }],
+          removedColumns: [],
+          typeChanges: [],
+        },
+      ],
+      summary: { total: 1, new: 0, removed: 0, changed: 1, unchanged: 0 },
+    });
+
+    render(
+      <DriftDrawer entityName="orders" open={false} onOpenChange={() => {}} />,
+      { wrapper },
+    );
+
+    // Sheet is closed → Radix unmounts portal content. The drawer-specific
+    // copy must not be on the page.
+    expect(document.body.textContent).not.toContain("Schema drift between database and YAML");
+    expect(document.body.textContent).not.toContain("shipped_at");
+  });
+
+  test("invokes onOpenChange(false) when the user closes the sheet", () => {
+    mockData = makeDiff({
+      tableDiffs: [
+        {
+          table: "orders",
+          addedColumns: [{ name: "shipped_at", type: "timestamp" }],
+          removedColumns: [],
+          typeChanges: [],
+        },
+      ],
+      summary: { total: 1, new: 0, removed: 0, changed: 1, unchanged: 0 },
+    });
+
+    const calls: boolean[] = [];
+
+    const { rerender } = render(
+      <DriftDrawer
+        entityName="orders"
+        open={true}
+        onOpenChange={(open) => calls.push(open)}
+      />,
+      { wrapper },
+    );
+
+    // Radix Dialog (which Sheet wraps) closes on Escape and routes that
+    // through `onOpenChange(false)`. This is the contract we care about —
+    // we don't need to drive the close button manually to verify it.
+    fireEvent.keyDown(document.body, { key: "Escape" });
+    expect(calls).toContain(false);
+
+    // Re-render with `open={false}` to mimic the parent state update —
+    // body content should disappear.
+    rerender(
+      <DriftDrawer
+        entityName="orders"
+        open={false}
+        onOpenChange={(open) => calls.push(open)}
+      />,
+    );
+    expect(document.body.textContent).not.toContain("shipped_at");
+  });
+
+  test("renders error banner when the diff request fails", () => {
+    mockError = { message: "Boom", status: 500 };
+
+    render(
+      <DriftDrawer entityName="orders" open={true} onOpenChange={() => {}} />,
+      { wrapper },
+    );
+
+    expect(document.body.textContent).toContain("Boom");
+  });
+
+  test("renders loading state while the diff request is in flight", () => {
+    mockLoading = true;
+
+    render(
+      <DriftDrawer entityName="orders" open={true} onOpenChange={() => {}} />,
+      { wrapper },
+    );
+
+    expect(document.body.textContent).toContain("Loading drift");
+  });
+});

--- a/packages/web/src/ui/__tests__/drift-drawer.test.tsx
+++ b/packages/web/src/ui/__tests__/drift-drawer.test.tsx
@@ -91,12 +91,9 @@ describe("DriftDrawer (#2461)", () => {
 
     // Drawer renders to a portal — query document.body, not container.
     expect(document.body.textContent).toContain("orders");
-    // Added column surfaced from the fixture.
     expect(document.body.textContent).toContain("shipped_at");
-    // Type-change row uses the YAML → DB transition.
     expect(document.body.textContent).toContain("total");
     expect(document.body.textContent).toContain("decimal");
-    // Header sentence is the static drawer description.
     expect(document.body.textContent).toContain("Schema drift between database and YAML");
   });
 
@@ -115,20 +112,34 @@ describe("DriftDrawer (#2461)", () => {
     expect(document.body.textContent).toContain("no longer exists in the database");
   });
 
-  test("falls back to in-sync notice when the entity is not in the diff", () => {
+  test("falls back to no-drift notice when the entity is not in the diff", () => {
     // Defensive: the page only opens the drawer for drifted entities, but
-    // a manual open on a clean entity must not look broken.
-    mockData = makeDiff({
-      unchangedCount: 1,
-      summary: { total: 1, new: 0, removed: 0, changed: 0, unchanged: 1 },
-    });
+    // a manual open on a clean entity must not look broken. Drawer also
+    // logs a console.warn for this case (drift/diff disagreement signal) —
+    // capture and assert it fired so a future refactor can't silently drop
+    // the warning.
+    const originalWarn = console.warn;
+    const warned: string[] = [];
+    console.warn = (...args: unknown[]) => {
+      warned.push(args.map((a) => String(a)).join(" "));
+    };
 
-    render(
-      <DriftDrawer entityName="users" open={true} onOpenChange={() => {}} />,
-      { wrapper },
-    );
+    try {
+      mockData = makeDiff({
+        unchangedCount: 1,
+        summary: { total: 1, new: 0, removed: 0, changed: 0, unchanged: 1 },
+      });
 
-    expect(document.body.textContent).toContain("is in sync with the database");
+      render(
+        <DriftDrawer entityName="users" open={true} onOpenChange={() => {}} />,
+        { wrapper },
+      );
+
+      expect(document.body.textContent).toContain("No drift detected for");
+      expect(warned.some((m) => m.includes("drift-drawer") && m.includes("users"))).toBe(true);
+    } finally {
+      console.warn = originalWarn;
+    }
   });
 
   test("does not fetch or render body when closed", () => {

--- a/packages/web/src/ui/components/admin/diff-card.tsx
+++ b/packages/web/src/ui/components/admin/diff-card.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { ChevronDown } from "lucide-react";
+import type { SemanticTableDiff } from "@/ui/lib/types";
+
+/**
+ * Per-table drift card extracted from `/admin/schema-diff` (#2461). Both
+ * the legacy schema-diff page and the new drift drawer on `/admin/semantic`
+ * render this. Keep it pure: the only input is the diff payload + the
+ * optional initial-open flag the drawer uses to expand by default.
+ */
+export function DiffCard({
+  diff,
+  defaultOpen = false,
+}: {
+  diff: SemanticTableDiff;
+  defaultOpen?: boolean;
+}) {
+  const [open, setOpen] = useState(defaultOpen);
+  const changeCount =
+    diff.addedColumns.length + diff.removedColumns.length + diff.typeChanges.length;
+
+  return (
+    <Card className="border-amber-500/30 shadow-none">
+      <Collapsible open={open} onOpenChange={setOpen}>
+        <CollapsibleTrigger asChild>
+          <CardHeader className="cursor-pointer py-3 hover:bg-muted/30">
+            <div className="flex items-center justify-between">
+              <CardTitle className="flex items-center gap-2 text-sm">
+                <span className="font-mono">{diff.table}</span>
+                <Badge
+                  variant="outline"
+                  className="text-xs text-amber-700 dark:text-amber-400 border-amber-300 dark:border-amber-700"
+                >
+                  {changeCount} {changeCount === 1 ? "change" : "changes"}
+                </Badge>
+              </CardTitle>
+              <ChevronDown
+                className={`size-4 text-muted-foreground transition-transform ${open ? "rotate-180" : ""}`}
+              />
+            </div>
+          </CardHeader>
+        </CollapsibleTrigger>
+        <CollapsibleContent>
+          <CardContent className="pt-0 pb-4">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="w-20">Change</TableHead>
+                  <TableHead>Column</TableHead>
+                  <TableHead>Detail</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {diff.addedColumns.map((col) => (
+                  <TableRow key={`add-${col.name}`}>
+                    <TableCell>
+                      <Badge
+                        variant="outline"
+                        className="text-[10px] text-green-700 dark:text-green-400 border-green-300 dark:border-green-700"
+                      >
+                        added
+                      </Badge>
+                    </TableCell>
+                    <TableCell className="font-mono text-xs">{col.name}</TableCell>
+                    <TableCell className="text-xs text-muted-foreground">
+                      type: {col.type} (in DB, missing from YAML)
+                    </TableCell>
+                  </TableRow>
+                ))}
+                {diff.removedColumns.map((col) => (
+                  <TableRow key={`rm-${col.name}`}>
+                    <TableCell>
+                      <Badge
+                        variant="outline"
+                        className="text-[10px] text-red-700 dark:text-red-400 border-red-300 dark:border-red-700"
+                      >
+                        removed
+                      </Badge>
+                    </TableCell>
+                    <TableCell className="font-mono text-xs">{col.name}</TableCell>
+                    <TableCell className="text-xs text-muted-foreground">
+                      type: {col.type} (in YAML, missing from DB)
+                    </TableCell>
+                  </TableRow>
+                ))}
+                {diff.typeChanges.map((tc) => (
+                  <TableRow key={`type-${tc.name}`}>
+                    <TableCell>
+                      <Badge
+                        variant="outline"
+                        className="text-[10px] text-amber-700 dark:text-amber-400 border-amber-300 dark:border-amber-700"
+                      >
+                        type
+                      </Badge>
+                    </TableCell>
+                    <TableCell className="font-mono text-xs">{tc.name}</TableCell>
+                    <TableCell className="text-xs text-muted-foreground">
+                      YAML: <code className="rounded bg-muted px-1">{tc.yamlType}</code>
+                      {" → "}
+                      DB: <code className="rounded bg-muted px-1">{tc.dbType}</code>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </CollapsibleContent>
+      </Collapsible>
+    </Card>
+  );
+}

--- a/packages/web/src/ui/components/admin/drift-drawer.tsx
+++ b/packages/web/src/ui/components/admin/drift-drawer.tsx
@@ -26,22 +26,21 @@ interface DriftDrawerProps {
   onOpenChange: (open: boolean) => void;
   /**
    * Connection alias passed to `/api/v1/admin/semantic/diff`. Defaults to
-   * `default` — the only alias the semantic page currently consults
-   * (slice 4 of #2458 will widen this once the env toggle lands).
+   * `"default"`; callers thread the active env through once multi-env
+   * routing is wired (#2460).
    */
   connection?: string;
 }
 
 /**
  * Right-side drawer that shows the per-table drift payload for a single
- * entity (#2461). Slice 2/5 of the admin IA reshape arc (PRD #2458) —
- * the read-only foundation that #2462 (reconcile actions) and #2463
- * (retire schema-diff) build on.
+ * entity (#2461). Read-only foundation; #2462 adds reconcile actions and
+ * #2463 retires the standalone schema-diff page.
  *
  * Reuses the existing `/api/v1/admin/semantic/diff` endpoint and filters
  * client-side rather than extending the API: drift payloads are bounded
  * by the workspace's entity count (10s, not 1000s), so the extra rows are
- * cheap and slice 5 retires the standalone diff route anyway. Hoisting
+ * cheap and #2463 retires the standalone diff route anyway. Hoisting
  * filtering server-side here would have made #2463 a backend change too.
  */
 export function DriftDrawer({
@@ -129,15 +128,22 @@ function DriftDrawerBody({
     );
   }
 
-  // No drift but the drawer was opened — fall back to a quiet "in sync"
-  // state instead of an empty body. Belt-and-braces; the page only opens
-  // the drawer for drifted entries, but this keeps the component honest.
+  // No matching diff entry — keep the copy descriptive, not affirmative.
+  // The page only opens the drawer for drifted rows, so reaching this branch
+  // means the entities list and the /diff response disagree (stale state in
+  // another tab, a backend warning swallowing tableDiffs, etc.). Logging
+  // matches the existing dev-console signal pattern in the semantic page for
+  // the same class of disagreement.
+  console.warn(
+    `drift-drawer: opened for "${entityName}" but no matching diff entry — drift/diff disagreement?`,
+  );
   return (
     <div className="flex items-start gap-2 rounded-md border border-green-500/30 bg-green-50/30 px-3 py-3 text-xs text-green-700 dark:bg-green-950/10 dark:text-green-400">
       <CheckCircle2 className="mt-0.5 size-3.5 shrink-0" />
       <span>
-        <code className="rounded bg-muted px-1 py-0.5 font-mono">{entityName}</code> is in sync
-        with the database.
+        No drift detected for{" "}
+        <code className="rounded bg-muted px-1 py-0.5 font-mono">{entityName}</code> in the
+        current diff payload.
       </span>
     </div>
   );

--- a/packages/web/src/ui/components/admin/drift-drawer.tsx
+++ b/packages/web/src/ui/components/admin/drift-drawer.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { LoadingState } from "@/ui/components/admin/loading-state";
+import { ErrorBanner } from "@/ui/components/admin/error-banner";
+import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
+import { friendlyError } from "@/ui/lib/fetch-error";
+import { SemanticDiffResponseSchema } from "@/ui/lib/admin-schemas";
+import { DiffCard } from "@/ui/components/admin/diff-card";
+import { CheckCircle2, Minus } from "lucide-react";
+
+interface DriftDrawerProps {
+  /**
+   * Entity name to show drift for. Matched against the diff payload's
+   * `tableDiffs[].table` and `removedTables[]`. `null` keeps the drawer
+   * closed without firing the request.
+   */
+  entityName: string | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /**
+   * Connection alias passed to `/api/v1/admin/semantic/diff`. Defaults to
+   * `default` — the only alias the semantic page currently consults
+   * (slice 4 of #2458 will widen this once the env toggle lands).
+   */
+  connection?: string;
+}
+
+/**
+ * Right-side drawer that shows the per-table drift payload for a single
+ * entity (#2461). Slice 2/5 of the admin IA reshape arc (PRD #2458) —
+ * the read-only foundation that #2462 (reconcile actions) and #2463
+ * (retire schema-diff) build on.
+ *
+ * Reuses the existing `/api/v1/admin/semantic/diff` endpoint and filters
+ * client-side rather than extending the API: drift payloads are bounded
+ * by the workspace's entity count (10s, not 1000s), so the extra rows are
+ * cheap and slice 5 retires the standalone diff route anyway. Hoisting
+ * filtering server-side here would have made #2463 a backend change too.
+ */
+export function DriftDrawer({
+  entityName,
+  open,
+  onOpenChange,
+  connection = "default",
+}: DriftDrawerProps) {
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent className="w-full sm:max-w-xl overflow-auto">
+        <SheetHeader>
+          <SheetTitle className="font-mono text-base">{entityName ?? "Drift"}</SheetTitle>
+          <SheetDescription>Schema drift between database and YAML</SheetDescription>
+        </SheetHeader>
+        <div className="px-4 pb-6">
+          {entityName ? (
+            <DriftDrawerBody entityName={entityName} connection={connection} />
+          ) : null}
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+/**
+ * Body is a separate component so the fetch only fires once `entityName`
+ * is set — mounting it conditionally above means React tears the hook
+ * tree down when the drawer closes, which short-circuits the request.
+ */
+function DriftDrawerBody({
+  entityName,
+  connection,
+}: {
+  entityName: string;
+  connection: string;
+}) {
+  const { data, loading, error } = useAdminFetch(
+    `/api/v1/admin/semantic/diff?connection=${encodeURIComponent(connection)}`,
+    {
+      schema: SemanticDiffResponseSchema,
+      deps: [connection],
+    },
+  );
+
+  if (loading) {
+    return <LoadingState message="Loading drift…" />;
+  }
+
+  if (error) {
+    return <ErrorBanner message={friendlyError(error)} />;
+  }
+
+  if (!data) {
+    return <ErrorBanner message="No drift data available" />;
+  }
+
+  const changed = data.tableDiffs.find((td) => td.table === entityName);
+  const isRemoved = data.removedTables.includes(entityName);
+
+  if (changed) {
+    // Auto-expand: the drawer is single-entity, so the collapsed state
+    // would just be an extra click. The schema-diff page renders many
+    // cards and stays collapsed to keep scroll length sane.
+    return (
+      <div className="space-y-3">
+        <DiffCard diff={changed} defaultOpen />
+      </div>
+    );
+  }
+
+  if (isRemoved) {
+    return (
+      <div
+        role="alert"
+        className="flex items-start gap-2 rounded-md border border-red-500/30 bg-red-50/30 px-3 py-3 text-xs text-red-700 dark:bg-red-950/10 dark:text-red-400"
+      >
+        <Minus className="mt-0.5 size-3.5 shrink-0" />
+        <span>
+          The <code className="rounded bg-muted px-1 py-0.5 font-mono">{entityName}</code> entity
+          references a table that no longer exists in the database. Consider removing the stale
+          entity file.
+        </span>
+      </div>
+    );
+  }
+
+  // No drift but the drawer was opened — fall back to a quiet "in sync"
+  // state instead of an empty body. Belt-and-braces; the page only opens
+  // the drawer for drifted entries, but this keeps the component honest.
+  return (
+    <div className="flex items-start gap-2 rounded-md border border-green-500/30 bg-green-50/30 px-3 py-3 text-xs text-green-700 dark:bg-green-950/10 dark:text-green-400">
+      <CheckCircle2 className="mt-0.5 size-3.5 shrink-0" />
+      <span>
+        <code className="rounded bg-muted px-1 py-0.5 font-mono">{entityName}</code> is in sync
+        with the database.
+      </span>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- Slice 2/5 of the admin IA reshape arc (PRD #2458). Clicking a drifted entity on the `/admin/semantic` file tree opens a right-side shadcn `Sheet` with the per-table drift payload for that entity. Read-only — action buttons land in slice 3 (#2462).
- Extracts the legacy `/admin/schema-diff` table-card UI into a shared `<DiffCard>` at `packages/web/src/ui/components/admin/diff-card.tsx`. Both the legacy schema-diff page and the new drawer consume it, so the two surfaces can't drift during the overlap window before slice 5 (#2463) retires `/admin/schema-diff`.
- Adds `<DriftDrawer>` at `packages/web/src/ui/components/admin/drift-drawer.tsx`. Fetches `/api/v1/admin/semantic/diff?connection=default` via `useAdminFetch` and filters client-side to the matching entity. Auto-expands the single card (no extra click). Handles `removedTables` with a tailored notice, falls back to an in-sync state if the drawer is opened on a clean entity (defensive — the page only opens it for drifted rows).

Why filter client-side instead of extending the API: drift payloads are bounded by entity count (10s, not 1000s), the extra rows are cheap, and slice 5 retires the standalone `/diff` route anyway. Hoisting filtering server-side would have made #2463 a backend change too.

Closes #2461.
Parent: #2458.
Blocks: #2462 (reconcile actions), #2463 (retire schema-diff).

## Test plan
- [x] `bun run test:others` — 153 web tests pass, including the new `drift-drawer.test.tsx`.
- [x] `bun run type` — clean.
- [x] `bun run lint` — only pre-existing warning unrelated to this slice.
- [x] `bun x syncpack lint` — no issues.
- [x] Component test (`packages/web/src/ui/__tests__/drift-drawer.test.tsx`) covers: changed-entity card renders from fixture; removed-table notice; in-sync fallback; escape-key triggers `onOpenChange(false)`; closed drawer hides content; error + loading branches.
- [x] Regression: legacy `/admin/schema-diff` swapped to `<DiffCard>` — same JSX, no behavioral change.
- [ ] Manual: click a drifted entity on `/admin/semantic`, confirm drawer opens with the right diff; close it, confirm the entity's detail view is still showing underneath.