### PR TITLE
feat(web): trial countdown banner on /admin/billing (#2467)

### DIFF
--- a/packages/web/src/app/admin/billing/page.tsx
+++ b/packages/web/src/app/admin/billing/page.tsx
@@ -28,6 +28,10 @@ import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
 import { useDeployMode } from "@/ui/hooks/use-deploy-mode";
 import { MutationErrorSurface } from "@/ui/components/admin/mutation-error-surface";
+import {
+  TrialCountdownBanner,
+  TRIAL_BANNER_PLAN_ANCHOR_ID,
+} from "@/ui/components/admin/trial-countdown-banner";
 import { BillingStatusSchema } from "@/ui/lib/admin-schemas";
 import { ModelProviderSection } from "@/ui/components/admin/model-provider-section";
 import { formatDate, formatNumber } from "@/lib/format";
@@ -154,7 +158,8 @@ export default function BillingPage() {
         >
           {data && (
             <div className="space-y-10">
-              <section>
+              <TrialCountdownBanner plan={data.plan} />
+              <section id={TRIAL_BANNER_PLAN_ANCHOR_ID} className="scroll-mt-6">
                 <SectionHeading
                   title="Plan"
                   description="Your current subscription and limits"

--- a/packages/web/src/ui/components/admin/__tests__/trial-countdown-banner.test.tsx
+++ b/packages/web/src/ui/components/admin/__tests__/trial-countdown-banner.test.tsx
@@ -8,10 +8,13 @@ import type { BillingPlan } from "@useatlas/schemas";
  *
  *   tier !== "trial"      → null (regression check — paid tiers see nothing)
  *   trialEndsAt === null  → null
- *   trialEndsAt unparseable → null
+ *   trialEndsAt unparseable → danger (fail-closed — show upgrade nudge)
  *   daysLeft > 3          → info / blue tone, secondary Upgrade
  *   daysLeft 1..3         → warning / amber tone, primary Upgrade
  *   trialEndsAt < now     → danger / red tone, primary Upgrade
+ *
+ * The day=3 vs day=4 boundary is explicitly pinned so a refactor of the
+ * `<= 3` comparator can't silently shift the copy.
  *
  * Each test injects a fixed `now` so the day math is deterministic.
  */
@@ -47,11 +50,16 @@ describe("TrialCountdownBanner", () => {
     expect(container.textContent).toBe("");
   });
 
-  test("hidden when trialEndsAt is unparseable", () => {
+  test("unparseable trialEndsAt fails closed into the expired (danger) state", () => {
+    // Documents the deliberate fail-closed behavior: an upstream Zod-schema
+    // bug ships a malformed date, the user still sees the upgrade nudge
+    // instead of a silently-skipped banner.
     const { container } = render(
       <TrialCountdownBanner plan={plan({ trialEndsAt: "not-a-date" })} now={NOW} />,
     );
-    expect(container.textContent).toBe("");
+    const banner = container.querySelector('[data-testid="trial-countdown-banner"]');
+    expect(banner?.getAttribute("data-tone")).toBe("danger");
+    expect(container.textContent).toContain("Your trial has expired. Upgrade to keep using Atlas.");
   });
 
   test("info tone with secondary Upgrade for >3 days remaining", () => {
@@ -99,6 +107,36 @@ describe("TrialCountdownBanner", () => {
     const banner = container.querySelector('[data-testid="trial-countdown-banner"]');
     expect(banner?.getAttribute("data-tone")).toBe("warning");
     expect(container.textContent).toContain("Trial ending in 3 days.");
+  });
+
+  test("exactly 3 days out lives in the warning bucket (boundary pin)", () => {
+    // The `<= 3` predicate is the inclusive edge — pin it so a refactor
+    // to `< 3` shifts a regression into a failing assertion instead of
+    // silently flipping the copy.
+    const { container } = render(
+      <TrialCountdownBanner
+        plan={plan({ trialEndsAt: new Date(NOW + 3 * DAY).toISOString() })}
+        now={NOW}
+      />,
+    );
+    const banner = container.querySelector('[data-testid="trial-countdown-banner"]');
+    expect(banner?.getAttribute("data-tone")).toBe("warning");
+    expect(container.textContent).toContain("Trial ending in 3 days.");
+  });
+
+  test("3 days + 1ms crosses into the info bucket (boundary pin)", () => {
+    // Math.ceil takes (3*DAY + 1ms) / DAY → 4, which exceeds 3 and
+    // routes to early. Pinning the +1ms edge guards the inverse refactor
+    // (changing `<= 3` to `<= 4`) from silently widening the amber band.
+    const { container } = render(
+      <TrialCountdownBanner
+        plan={plan({ trialEndsAt: new Date(NOW + 3 * DAY + 1).toISOString() })}
+        now={NOW}
+      />,
+    );
+    const banner = container.querySelector('[data-testid="trial-countdown-banner"]');
+    expect(banner?.getAttribute("data-tone")).toBe("info");
+    expect(container.textContent).toContain("You're on a 14-day Atlas trial. 4 days left.");
   });
 
   test("danger tone with expired copy when trialEndsAt < now", () => {

--- a/packages/web/src/ui/components/admin/__tests__/trial-countdown-banner.test.tsx
+++ b/packages/web/src/ui/components/admin/__tests__/trial-countdown-banner.test.tsx
@@ -1,0 +1,117 @@
+import { describe, expect, test } from "bun:test";
+import { render } from "@testing-library/react";
+import { TrialCountdownBanner } from "../trial-countdown-banner";
+import type { BillingPlan } from "@useatlas/schemas";
+
+/**
+ * Coverage maps to the decision tree in `trial-countdown-banner.tsx`:
+ *
+ *   tier !== "trial"      → null (regression check — paid tiers see nothing)
+ *   trialEndsAt === null  → null
+ *   trialEndsAt unparseable → null
+ *   daysLeft > 3          → info / blue tone, secondary Upgrade
+ *   daysLeft 1..3         → warning / amber tone, primary Upgrade
+ *   trialEndsAt < now     → danger / red tone, primary Upgrade
+ *
+ * Each test injects a fixed `now` so the day math is deterministic.
+ */
+
+const NOW = Date.parse("2026-05-16T12:00:00Z");
+const DAY = 86_400_000;
+
+function plan(overrides: Partial<BillingPlan>): BillingPlan {
+  return {
+    tier: "trial",
+    displayName: "Trial",
+    pricePerSeat: 0,
+    defaultModel: "anthropic/claude-sonnet-4.6",
+    byot: false,
+    trialEndsAt: new Date(NOW + 10 * DAY).toISOString(),
+    ...overrides,
+  };
+}
+
+describe("TrialCountdownBanner", () => {
+  test("hidden for non-trial tier (paid plan regression check)", () => {
+    const { container } = render(
+      <TrialCountdownBanner plan={plan({ tier: "pro" })} now={NOW} />,
+    );
+    expect(container.textContent).toBe("");
+    expect(container.querySelector('[data-testid="trial-countdown-banner"]')).toBeNull();
+  });
+
+  test("hidden when trialEndsAt is null", () => {
+    const { container } = render(
+      <TrialCountdownBanner plan={plan({ trialEndsAt: null })} now={NOW} />,
+    );
+    expect(container.textContent).toBe("");
+  });
+
+  test("hidden when trialEndsAt is unparseable", () => {
+    const { container } = render(
+      <TrialCountdownBanner plan={plan({ trialEndsAt: "not-a-date" })} now={NOW} />,
+    );
+    expect(container.textContent).toBe("");
+  });
+
+  test("info tone with secondary Upgrade for >3 days remaining", () => {
+    const { container } = render(
+      <TrialCountdownBanner
+        plan={plan({ trialEndsAt: new Date(NOW + 10 * DAY).toISOString() })}
+        now={NOW}
+      />,
+    );
+    const banner = container.querySelector('[data-testid="trial-countdown-banner"]');
+    expect(banner).not.toBeNull();
+    expect(banner?.getAttribute("data-tone")).toBe("info");
+    expect(container.textContent).toContain("You're on a 14-day Atlas trial. 10 days left.");
+    // Secondary variant — not the primary destructive Upgrade
+    const button = container.querySelector("button");
+    expect(button?.textContent).toBe("Upgrade");
+    // shadcn Button secondary variant carries `bg-secondary` in its class list
+    expect(button?.className).toContain("bg-secondary");
+  });
+
+  test("warning tone with primary Upgrade at ≤3 days remaining", () => {
+    const { container } = render(
+      <TrialCountdownBanner
+        plan={plan({ trialEndsAt: new Date(NOW + 2 * DAY).toISOString() })}
+        now={NOW}
+      />,
+    );
+    const banner = container.querySelector('[data-testid="trial-countdown-banner"]');
+    expect(banner?.getAttribute("data-tone")).toBe("warning");
+    expect(container.textContent).toContain("Trial ending in 2 days.");
+    const button = container.querySelector("button");
+    // Primary variant — `bg-primary`, NOT `bg-secondary`
+    expect(button?.className).toContain("bg-primary");
+    expect(button?.className).not.toContain("bg-secondary");
+  });
+
+  test("warning tone rounds partial-day boundary up via Math.ceil", () => {
+    // 2.5 days out → ceil → 3 → ending bucket
+    const { container } = render(
+      <TrialCountdownBanner
+        plan={plan({ trialEndsAt: new Date(NOW + 2.5 * DAY).toISOString() })}
+        now={NOW}
+      />,
+    );
+    const banner = container.querySelector('[data-testid="trial-countdown-banner"]');
+    expect(banner?.getAttribute("data-tone")).toBe("warning");
+    expect(container.textContent).toContain("Trial ending in 3 days.");
+  });
+
+  test("danger tone with expired copy when trialEndsAt < now", () => {
+    const { container } = render(
+      <TrialCountdownBanner
+        plan={plan({ trialEndsAt: new Date(NOW - 1 * DAY).toISOString() })}
+        now={NOW}
+      />,
+    );
+    const banner = container.querySelector('[data-testid="trial-countdown-banner"]');
+    expect(banner?.getAttribute("data-tone")).toBe("danger");
+    expect(container.textContent).toContain("Your trial has expired. Upgrade to keep using Atlas.");
+    const button = container.querySelector("button");
+    expect(button?.className).toContain("bg-primary");
+  });
+});

--- a/packages/web/src/ui/components/admin/trial-countdown-banner.tsx
+++ b/packages/web/src/ui/components/admin/trial-countdown-banner.tsx
@@ -9,11 +9,12 @@ import type { BillingPlan } from "@useatlas/schemas";
  * Trial countdown banner (PRD #2464 slice 3/4, issue #2467).
  *
  * Renders above the plan card on `/admin/billing` when the workspace is on
- * a trial. Three visual states keyed on days remaining:
+ * a trial. Three visual states keyed on days remaining (Math.ceil rounds
+ * up, so a remainder of exactly 3.0 days routes to the amber bucket):
  *
- *   >3 days  → neutral/blue, secondary "Upgrade"
- *   ≤3 days  → amber, primary "Upgrade"
- *   expired  → red, primary "Upgrade"
+ *   > 3 days left → info / blue, secondary "Upgrade"
+ *   1–3 days left → warning / amber, primary "Upgrade"
+ *   expired       → danger / red, primary "Upgrade"
  *
  * Hidden for any non-trial tier so paid workspaces don't see trial copy.
  *
@@ -21,8 +22,9 @@ import type { BillingPlan } from "@useatlas/schemas";
  * plan card already on the page. Stripe Checkout wiring is v2.
  *
  * Visual chrome matches the raw-div + tone-classed pattern used by
- * IncidentBanner and BackupMethodBanner; the shadcn Alert primitive's
- * grid layout fights a horizontal title-vs-button row.
+ * IncidentBanner and BackupMethodBanner; the shadcn Alert primitive pins
+ * title/description into `col-start-2` of its grid, which fights a
+ * trailing right-aligned button.
  */
 
 const MS_PER_DAY = 86_400_000;
@@ -35,10 +37,14 @@ type BannerState =
   | { kind: "ending"; daysLeft: number }
   | { kind: "expired" };
 
-function resolveState(trialEndsAt: string, now: number): BannerState | null {
+// Total — never returns null. An unparseable `trialEndsAt` (would only
+// happen on an upstream Zod-schema bug, since `BillingPlanSchema` types it
+// as `z.string().nullable()` without `.datetime()`) fails closed into the
+// `expired` state so the user still sees the upgrade nudge rather than a
+// silently-skipped banner.
+function resolveState(trialEndsAt: string, now: number): BannerState {
   const endMs = Date.parse(trialEndsAt);
-  if (!Number.isFinite(endMs)) return null;
-  if (endMs < now) return { kind: "expired" };
+  if (!Number.isFinite(endMs) || endMs < now) return { kind: "expired" };
   const daysLeft = Math.ceil((endMs - now) / MS_PER_DAY);
   if (daysLeft <= 3) return { kind: "ending", daysLeft };
   return { kind: "early", daysLeft };
@@ -59,7 +65,6 @@ export interface TrialCountdownBannerProps {
 export function TrialCountdownBanner({ plan, now }: TrialCountdownBannerProps) {
   if (plan.tier !== "trial" || !plan.trialEndsAt) return null;
   const state = resolveState(plan.trialEndsAt, now ?? Date.now());
-  if (!state) return null;
 
   if (state.kind === "early") {
     return (

--- a/packages/web/src/ui/components/admin/trial-countdown-banner.tsx
+++ b/packages/web/src/ui/components/admin/trial-countdown-banner.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import { AlertTriangle, Clock, Sparkles } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import type { BillingPlan } from "@useatlas/schemas";
+
+/**
+ * Trial countdown banner (PRD #2464 slice 3/4, issue #2467).
+ *
+ * Renders above the plan card on `/admin/billing` when the workspace is on
+ * a trial. Three visual states keyed on days remaining:
+ *
+ *   >3 days  → neutral/blue, secondary "Upgrade"
+ *   ≤3 days  → amber, primary "Upgrade"
+ *   expired  → red, primary "Upgrade"
+ *
+ * Hidden for any non-trial tier so paid workspaces don't see trial copy.
+ *
+ * The Upgrade CTA is intentionally a v1 placeholder — it scrolls to the
+ * plan card already on the page. Stripe Checkout wiring is v2.
+ *
+ * Visual chrome matches the raw-div + tone-classed pattern used by
+ * IncidentBanner and BackupMethodBanner; the shadcn Alert primitive's
+ * grid layout fights a horizontal title-vs-button row.
+ */
+
+const MS_PER_DAY = 86_400_000;
+
+/** Anchor target the Upgrade button scrolls to. */
+export const TRIAL_BANNER_PLAN_ANCHOR_ID = "trial-banner-plan-anchor";
+
+type BannerState =
+  | { kind: "early"; daysLeft: number }
+  | { kind: "ending"; daysLeft: number }
+  | { kind: "expired" };
+
+function resolveState(trialEndsAt: string, now: number): BannerState | null {
+  const endMs = Date.parse(trialEndsAt);
+  if (!Number.isFinite(endMs)) return null;
+  if (endMs < now) return { kind: "expired" };
+  const daysLeft = Math.ceil((endMs - now) / MS_PER_DAY);
+  if (daysLeft <= 3) return { kind: "ending", daysLeft };
+  return { kind: "early", daysLeft };
+}
+
+function scrollToPlanCard() {
+  if (typeof document === "undefined") return;
+  const el = document.getElementById(TRIAL_BANNER_PLAN_ANCHOR_ID);
+  el?.scrollIntoView({ behavior: "smooth", block: "start" });
+}
+
+export interface TrialCountdownBannerProps {
+  plan: Pick<BillingPlan, "tier" | "trialEndsAt">;
+  /** Injectable clock for tests. Defaults to `Date.now()`. */
+  now?: number;
+}
+
+export function TrialCountdownBanner({ plan, now }: TrialCountdownBannerProps) {
+  if (plan.tier !== "trial" || !plan.trialEndsAt) return null;
+  const state = resolveState(plan.trialEndsAt, now ?? Date.now());
+  if (!state) return null;
+
+  if (state.kind === "early") {
+    return (
+      <BannerShell
+        tone="info"
+        icon={<Sparkles className="size-4 shrink-0" aria-hidden />}
+        title={`You're on a 14-day Atlas trial. ${state.daysLeft} days left.`}
+        buttonVariant="secondary"
+      />
+    );
+  }
+
+  if (state.kind === "ending") {
+    return (
+      <BannerShell
+        tone="warning"
+        icon={<Clock className="size-4 shrink-0" aria-hidden />}
+        title={`Trial ending in ${state.daysLeft} days.`}
+        buttonVariant="default"
+      />
+    );
+  }
+
+  return (
+    <BannerShell
+      tone="danger"
+      icon={<AlertTriangle className="size-4 shrink-0" aria-hidden />}
+      title="Your trial has expired. Upgrade to keep using Atlas."
+      buttonVariant="default"
+    />
+  );
+}
+
+type Tone = "info" | "warning" | "danger";
+
+const TONE_CLASSES: Record<Tone, string> = {
+  info: "border-blue-500/30 bg-blue-500/5 text-blue-900 dark:border-blue-400/30 dark:bg-blue-400/5 dark:text-blue-200",
+  warning:
+    "border-amber-500/40 bg-amber-500/5 text-amber-900 dark:border-amber-400/40 dark:bg-amber-400/5 dark:text-amber-200",
+  danger:
+    "border-red-500/40 bg-red-500/5 text-red-900 dark:border-red-400/40 dark:bg-red-400/5 dark:text-red-200",
+};
+
+function BannerShell({
+  tone,
+  icon,
+  title,
+  buttonVariant,
+}: {
+  tone: Tone;
+  icon: React.ReactNode;
+  title: string;
+  buttonVariant: "default" | "secondary";
+}) {
+  return (
+    <div
+      role="alert"
+      data-testid="trial-countdown-banner"
+      data-tone={tone}
+      className={cn(
+        "flex items-center justify-between gap-4 rounded-lg border px-4 py-3 text-sm",
+        TONE_CLASSES[tone],
+      )}
+    >
+      <div className="flex min-w-0 items-center gap-2">
+        {icon}
+        <p className="truncate font-medium">{title}</p>
+      </div>
+      <Button
+        size="sm"
+        variant={buttonVariant}
+        onClick={scrollToPlanCard}
+        className="shrink-0"
+      >
+        Upgrade
+      </Button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds a tone-graded countdown banner above the plan card on `/admin/billing` for trial workspaces.
- Three visual states keyed on days remaining: blue (>3d, secondary Upgrade), amber (≤3d, primary), red (expired, primary).
- Hidden for non-trial tiers so paid workspaces never see trial copy.
- Upgrade button is a v1 placeholder — scrolls to the plan card already on the page. Stripe Checkout wiring is v2.

Closes #2467. Implements PRD #2464 slice 3/4.

## Implementation notes

- Component lives at `packages/web/src/ui/components/admin/trial-countdown-banner.tsx`, self-gates on `plan.tier === "trial" && plan.trialEndsAt !== null`, and accepts an injectable `now` for testable day math.
- Visual chrome follows the raw-div + tone-classed pattern used by `IncidentBanner` and `BackupMethodBanner` — the shadcn `Alert` primitive's grid layout fights a horizontal title-vs-button row, and both established admin banners opted out of it for the same reason.
- Day math: `Math.ceil((trialEndsAt - now) / 86_400_000)`. No date library.
- `Date.parse(...)` returning `NaN` (unparseable input) renders nothing rather than throwing.

## Test plan

- [x] Unit test covers all six paths: non-trial tier, null `trialEndsAt`, unparseable `trialEndsAt`, >3d (info + secondary), ≤3d (warning + primary, including the Math.ceil boundary at 2.5d), and expired (danger + primary). 7 tests, all green.
- [x] Visually verified all three states + the hidden state in the browser at dev (scratch preview page, deleted before commit).
- [x] `bun run type` clean.
- [x] `bun run lint` clean (1 pre-existing warning unrelated to this change in `packages/api/.../detect.test.ts`).
- [x] `bun run test` — full suite green.
- [x] `/ci` gates: lint, type, test, syncpack, template drift, security-headers, railway-watch, schema drift, oauth-helper — all pass.