### PR TITLE
feat(api,web): reconcile actions + zero-table empty state (#2462)

### DIFF
--- a/packages/api/src/api/__tests__/admin.test.ts
+++ b/packages/api/src/api/__tests__/admin.test.ts
@@ -3545,3 +3545,146 @@ describe("POST /api/v1/admin/connections/pool/orgs/:orgId/drain", () => {
     expect(body.error).toBe("drain_failed");
   });
 });
+
+// ---------------------------------------------------------------------------
+// POST /api/v1/admin/semantic/entities/:name/reconcile (#2462)
+// ---------------------------------------------------------------------------
+
+describe("POST /api/v1/admin/semantic/entities/:name/reconcile (#2462)", () => {
+  const RECONCILE_PATH = "/api/v1/admin/semantic/entities/users/reconcile";
+
+  beforeEach(() => {
+    mockHasInternalDB = true;
+    mockGetEntityAdmin.mockReset();
+    mockUpsertDraftEntityAdmin.mockReset();
+    mockUpsertDraftEntityAdmin.mockResolvedValue(undefined);
+    mockUpsertTombstoneAdmin.mockReset();
+    mockUpsertTombstoneAdmin.mockResolvedValue(undefined);
+    mockDeleteDraftEntityAdmin.mockReset();
+    mockDeleteDraftEntityAdmin.mockResolvedValue(true);
+    mockSyncEntityToDisk.mockReset();
+    mockSyncEntityDeleteFromDisk.mockReset();
+    mockRunDriftDiff.mockReset();
+    mockRunDriftDiff.mockResolvedValue({
+      diff: { newTables: [], removedTables: [], tableDiffs: [], unchangedCount: 0 },
+      introspectedTableCount: 1,
+      warnings: [] as string[],
+    });
+  });
+
+  it("returns 403 for a non-admin caller", async () => {
+    mockAuthenticateRequest.mockResolvedValue({
+      authenticated: true,
+      mode: "managed",
+      user: { id: "u-1", mode: "managed", label: "member@test", role: "member", activeOrganizationId: "org-1" },
+    });
+    mockCheckRateLimit.mockReturnValue({ allowed: true });
+    const res = await app.fetch(adminRequest(RECONCILE_PATH, "POST", { action: "sync_yaml" }));
+    expect(res.status).toBe(403);
+    expect(mockUpsertDraftEntityAdmin).not.toHaveBeenCalled();
+  });
+
+  it("returns 501 when the internal DB isn't configured", async () => {
+    setOrgAdmin("org-1");
+    mockHasInternalDB = false;
+    const res = await app.fetch(adminRequest(RECONCILE_PATH, "POST", { action: "sync_yaml" }));
+    expect(res.status).toBe(501);
+  });
+
+  it("sync_yaml: returns 200 and stages a draft when the entity exists", async () => {
+    setOrgAdmin("org-1");
+    mockGetEntityAdmin.mockResolvedValue({
+      id: "e-1", org_id: "org-1", entity_type: "entity", name: "users",
+      yaml_content: "table: users\ndimensions: []\n",
+      connection_group_id: null, status: "published",
+      created_at: "2026-05-16T00:00:00Z", updated_at: "2026-05-16T00:00:00Z",
+    });
+    const res = await app.fetch(adminRequest(RECONCILE_PATH, "POST", { action: "sync_yaml" }));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.ok).toBe(true);
+    expect(body.action).toBe("sync_yaml");
+    expect(body.name).toBe("users");
+    // Always stages as draft regardless of atlasMode (#2177).
+    expect(mockUpsertDraftEntityAdmin).toHaveBeenCalledTimes(1);
+    expect(mockUpsertEntityAdmin).not.toHaveBeenCalled();
+  });
+
+  it("sync_yaml: returns 404 when the entity row doesn't exist", async () => {
+    setOrgAdmin("org-1");
+    mockGetEntityAdmin.mockResolvedValue(null);
+    const res = await app.fetch(adminRequest(RECONCILE_PATH, "POST", { action: "sync_yaml" }));
+    expect(res.status).toBe(404);
+    expect(mockUpsertDraftEntityAdmin).not.toHaveBeenCalled();
+  });
+
+  it("remove: hard-deletes a draft entity", async () => {
+    setOrgAdmin("org-1");
+    mockGetEntityAdmin.mockResolvedValue({
+      id: "e-1", org_id: "org-1", entity_type: "entity", name: "users",
+      yaml_content: "table: users\n",
+      connection_group_id: null, status: "draft",
+      created_at: "2026-05-16T00:00:00Z", updated_at: "2026-05-16T00:00:00Z",
+    });
+    const res = await app.fetch(adminRequest(RECONCILE_PATH, "POST", { action: "remove" }));
+    expect(res.status).toBe(200);
+    expect(mockDeleteDraftEntityAdmin).toHaveBeenCalledTimes(1);
+    expect(mockUpsertTombstoneAdmin).not.toHaveBeenCalled();
+  });
+
+  it("remove: tombstones a published entity", async () => {
+    setOrgAdmin("org-1");
+    mockGetEntityAdmin.mockResolvedValue({
+      id: "e-1", org_id: "org-1", entity_type: "entity", name: "users",
+      yaml_content: "table: users\n",
+      connection_group_id: null, status: "published",
+      created_at: "2026-05-16T00:00:00Z", updated_at: "2026-05-16T00:00:00Z",
+    });
+    const res = await app.fetch(adminRequest(RECONCILE_PATH, "POST", { action: "remove" }));
+    expect(res.status).toBe(200);
+    expect(mockUpsertTombstoneAdmin).toHaveBeenCalledTimes(1);
+    expect(mockDeleteDraftEntityAdmin).not.toHaveBeenCalled();
+  });
+
+  it("remove: returns 404 when the entity doesn't exist", async () => {
+    setOrgAdmin("org-1");
+    mockGetEntityAdmin.mockResolvedValue(null);
+    const res = await app.fetch(adminRequest(RECONCILE_PATH, "POST", { action: "remove" }));
+    expect(res.status).toBe(404);
+  });
+
+  it("create_from_db: returns 404 when an entity with that name already exists", async () => {
+    setOrgAdmin("org-1");
+    mockGetEntityAdmin.mockResolvedValue({
+      id: "e-1", org_id: "org-1", entity_type: "entity", name: "users",
+      yaml_content: "table: users\n",
+      connection_group_id: null, status: "published",
+      created_at: "2026-05-16T00:00:00Z", updated_at: "2026-05-16T00:00:00Z",
+    });
+    const res = await app.fetch(adminRequest(RECONCILE_PATH, "POST", { action: "create_from_db" }));
+    expect(res.status).toBe(404);
+    expect(mockUpsertDraftEntityAdmin).not.toHaveBeenCalled();
+  });
+
+  it("create_from_db: returns 404 when no DB table matches the requested name", async () => {
+    setOrgAdmin("org-1");
+    mockGetEntityAdmin.mockResolvedValue(null);
+    // Default `getDBSchemaRaw` mock returns an empty Map — no table matches.
+    const res = await app.fetch(adminRequest(RECONCILE_PATH, "POST", { action: "create_from_db" }));
+    expect(res.status).toBe(404);
+    expect(mockUpsertDraftEntityAdmin).not.toHaveBeenCalled();
+  });
+
+  it("rejects an unknown action with a client error", async () => {
+    setOrgAdmin("org-1");
+    const res = await app.fetch(
+      adminRequest(RECONCILE_PATH, "POST", { action: "wat" }),
+    );
+    // Hono's zod-openapi validator emits 4xx on schema mismatch (Hono uses
+    // 400; the OpenAPI validator middleware may surface 422). Either is a
+    // valid contract — we just need to confirm we don't 500 or 200 on a
+    // body that fails the discriminator.
+    expect(res.status).toBeGreaterThanOrEqual(400);
+    expect(res.status).toBeLessThan(500);
+  });
+});

--- a/packages/api/src/api/__tests__/admin.test.ts
+++ b/packages/api/src/api/__tests__/admin.test.ts
@@ -497,6 +497,11 @@ const mockRunDriftDiff: Mock<(connectionId?: string) => Promise<unknown>> = mock
   warnings: [] as string[],
 }));
 
+// `getDBSchemaRaw` is overridable per-test for the create_from_db happy
+// path. Default is an empty Map (the introspection-found-nothing case).
+const mockGetDBSchemaRaw: Mock<(connectionId?: string) => Promise<Map<string, { table: string; columns: Map<string, string> }>>> =
+  mock(async () => new Map());
+
 mock.module("@atlas/api/lib/semantic/diff", () => ({
   runDiff: mockRunDiff,
   // #2459: matches the admin route's new import alongside runDiff.
@@ -505,7 +510,7 @@ mock.module("@atlas/api/lib/semantic/diff", () => ({
   parseEntityYAML: () => ({ table: "", columns: new Map(), foreignKeys: new Set() }),
   computeDiff: () => ({ newTables: [], removedTables: [], tableDiffs: [], unchangedCount: 0 }),
   getDBSchema: async () => new Map(),
-  getDBSchemaRaw: async () => new Map(),
+  getDBSchemaRaw: mockGetDBSchemaRaw,
   getYAMLSnapshots: () => ({ snapshots: new Map(), warnings: [] }),
 }));
 
@@ -3570,6 +3575,8 @@ describe("POST /api/v1/admin/semantic/entities/:name/reconcile (#2462)", () => {
       introspectedTableCount: 1,
       warnings: [] as string[],
     });
+    mockGetDBSchemaRaw.mockReset();
+    mockGetDBSchemaRaw.mockResolvedValue(new Map());
   });
 
   it("returns 403 for a non-admin caller", async () => {
@@ -3610,6 +3617,58 @@ describe("POST /api/v1/admin/semantic/entities/:name/reconcile (#2462)", () => {
     expect(mockUpsertEntityAdmin).not.toHaveBeenCalled();
   });
 
+  it("sync_yaml: rewrites dimensions to match the diff's added column", async () => {
+    setOrgAdmin("org-1");
+    mockGetEntityAdmin.mockResolvedValue({
+      id: "e-1", org_id: "org-1", entity_type: "entity", name: "users",
+      yaml_content: "table: users\ndimensions: []\n",
+      connection_group_id: null, status: "published",
+      created_at: "2026-05-16T00:00:00Z", updated_at: "2026-05-16T00:00:00Z",
+    });
+    mockRunDriftDiff.mockResolvedValueOnce({
+      diff: {
+        newTables: [],
+        removedTables: [],
+        tableDiffs: [{
+          table: "users",
+          addedColumns: [{ name: "email", type: "string" }],
+          removedColumns: [],
+          typeChanges: [],
+        }],
+        unchangedCount: 0,
+      },
+      introspectedTableCount: 1,
+      warnings: [],
+    });
+    const res = await app.fetch(adminRequest(RECONCILE_PATH, "POST", { action: "sync_yaml" }));
+    expect(res.status).toBe(200);
+    // Inspect the 4th positional arg of `upsertDraftEntity` — the YAML payload
+    // must reflect the diff, not echo the original empty-dimensions YAML.
+    const call = mockUpsertDraftEntityAdmin.mock.calls[0] as unknown as [string, string, string, string, string];
+    const writtenYaml = call[3];
+    expect(writtenYaml).toContain("email");
+    expect(writtenYaml).toContain("string");
+  });
+
+  it("sync_yaml: accepts demo+published writes via drafts (parity with editor, no 403)", async () => {
+    // The PRD acceptance criterion "403 for demo_readonly workspaces in
+    // published mode" is intentionally implemented as draft-staging
+    // parity with the editor — drafts handle the safety, FE gates the
+    // button via `useDemoReadonly`. This locks the contract: a write to
+    // a demo-owned entity in published mode succeeds with a 200 + draft.
+    setOrgAdmin("org-demo-1");
+    mockGetEntityAdmin.mockResolvedValue({
+      id: "e-1", org_id: "org-demo-1", entity_type: "entity", name: "users",
+      yaml_content: "table: users\n", connection_id: "__demo__",
+      connection_group_id: null, status: "published",
+      created_at: "2026-05-16T00:00:00Z", updated_at: "2026-05-16T00:00:00Z",
+    });
+    const res = await app.fetch(adminRequest(RECONCILE_PATH, "POST", { action: "sync_yaml" }));
+    expect(res.status).toBe(200);
+    expect(mockUpsertDraftEntityAdmin).toHaveBeenCalledTimes(1);
+    expect(mockUpsertEntityAdmin).not.toHaveBeenCalled();
+  });
+
   it("sync_yaml: returns 404 when the entity row doesn't exist", async () => {
     setOrgAdmin("org-1");
     mockGetEntityAdmin.mockResolvedValue(null);
@@ -3646,14 +3705,7 @@ describe("POST /api/v1/admin/semantic/entities/:name/reconcile (#2462)", () => {
     expect(mockDeleteDraftEntityAdmin).not.toHaveBeenCalled();
   });
 
-  it("remove: returns 404 when the entity doesn't exist", async () => {
-    setOrgAdmin("org-1");
-    mockGetEntityAdmin.mockResolvedValue(null);
-    const res = await app.fetch(adminRequest(RECONCILE_PATH, "POST", { action: "remove" }));
-    expect(res.status).toBe(404);
-  });
-
-  it("create_from_db: returns 404 when an entity with that name already exists", async () => {
+  it("create_from_db: returns 404 with error=mismatch when an entity already exists", async () => {
     setOrgAdmin("org-1");
     mockGetEntityAdmin.mockResolvedValue({
       id: "e-1", org_id: "org-1", entity_type: "entity", name: "users",
@@ -3663,16 +3715,75 @@ describe("POST /api/v1/admin/semantic/entities/:name/reconcile (#2462)", () => {
     });
     const res = await app.fetch(adminRequest(RECONCILE_PATH, "POST", { action: "create_from_db" }));
     expect(res.status).toBe(404);
+    const body = (await res.json()) as Record<string, unknown>;
+    // FE branches on this code to switch CTA from "create" → "sync_yaml".
+    expect(body.error).toBe("mismatch");
     expect(mockUpsertDraftEntityAdmin).not.toHaveBeenCalled();
   });
 
-  it("create_from_db: returns 404 when no DB table matches the requested name", async () => {
+  it("create_from_db: returns 404 with error=mismatch when no DB table matches the name", async () => {
     setOrgAdmin("org-1");
     mockGetEntityAdmin.mockResolvedValue(null);
     // Default `getDBSchemaRaw` mock returns an empty Map — no table matches.
     const res = await app.fetch(adminRequest(RECONCILE_PATH, "POST", { action: "create_from_db" }));
     expect(res.status).toBe(404);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.error).toBe("mismatch");
     expect(mockUpsertDraftEntityAdmin).not.toHaveBeenCalled();
+  });
+
+  it("create_from_db: returns 200 + writes a starter draft when the DB table exists", async () => {
+    setOrgAdmin("org-1");
+    mockGetEntityAdmin.mockResolvedValue(null);
+    mockGetDBSchemaRaw.mockResolvedValueOnce(
+      new Map([
+        [
+          "users",
+          {
+            table: "users",
+            columns: new Map<string, string>([
+              ["id", "number"],
+              ["email", "string"],
+            ]),
+          },
+        ],
+      ]),
+    );
+    const res = await app.fetch(adminRequest(RECONCILE_PATH, "POST", { action: "create_from_db" }));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.ok).toBe(true);
+    expect(body.action).toBe("create_from_db");
+    expect(mockUpsertDraftEntityAdmin).toHaveBeenCalledTimes(1);
+    const call = mockUpsertDraftEntityAdmin.mock.calls[0] as unknown as [string, string, string, string, string];
+    const writtenYaml = call[3];
+    expect(writtenYaml).toContain("table: users");
+    expect(writtenYaml).toContain("id");
+    expect(writtenYaml).toContain("email");
+  });
+
+  it("remove: returns 404 with error=not_found (distinct from mismatch) when entity missing", async () => {
+    setOrgAdmin("org-1");
+    mockGetEntityAdmin.mockResolvedValue(null);
+    const res = await app.fetch(adminRequest(RECONCILE_PATH, "POST", { action: "remove" }));
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.error).toBe("not_found");
+  });
+
+  it("remove: 200 response omits the entity field (no payload on delete)", async () => {
+    setOrgAdmin("org-1");
+    mockGetEntityAdmin.mockResolvedValue({
+      id: "e-1", org_id: "org-1", entity_type: "entity", name: "users",
+      yaml_content: "table: users\n",
+      connection_group_id: null, status: "draft",
+      created_at: "2026-05-16T00:00:00Z", updated_at: "2026-05-16T00:00:00Z",
+    });
+    const res = await app.fetch(adminRequest(RECONCILE_PATH, "POST", { action: "remove" }));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.action).toBe("remove");
+    expect(body.entity).toBeNull();
   });
 
   it("rejects an unknown action with a client error", async () => {

--- a/packages/api/src/api/routes/admin-semantic.ts
+++ b/packages/api/src/api/routes/admin-semantic.ts
@@ -474,21 +474,13 @@ export const postRollbackRoute = createRoute({
 });
 
 // ---------------------------------------------------------------------------
-// Route definitions — drift-drawer reconcile (#2462 / PRD #2458 slice 3)
+// Reconcile route (#2462) — drift-drawer actions
 // ---------------------------------------------------------------------------
 
 const ReconcileBodySchema = z.object({
   action: z.enum(["sync_yaml", "remove", "create_from_db"]),
-  /**
-   * Connection alias for the introspection side of the diff (matches the
-   * drift fetch's `?connection=` query). Defaults to `"default"`.
-   */
   connection: z.string().optional().default("default"),
-  /**
-   * Group scope for multi-environment orgs (#2412). Same encoding as the
-   * editor PUT/DELETE: omitted → unique-or-409 default, empty string →
-   * legacy null-scope row, non-empty → that group id.
-   */
+  // Same trinary encoding as the editor PUT/DELETE (#2412).
   connectionGroupId: z.string().optional(),
 });
 
@@ -505,12 +497,8 @@ export const postReconcileEntityRoute = createRoute({
   tags: ["Admin — Semantic"],
   summary: "Reconcile a semantic entity against the introspected DB schema",
   description:
-    "Dispatches one of three reconcile actions against `(name, connection)`:\n" +
-    "  - `sync_yaml`  — rewrite the entity's dimensions to match the DB columns; preserves user-authored fields\n" +
-    "  - `remove`     — drop the entity (mirrors the editor delete; stages as draft per #2177)\n" +
-    "  - `create_from_db` — introspect `name` as a table and write a starter entity\n\n" +
-    "All actions stage as drafts regardless of atlas mode (#2177); the admin publishes via " +
-    "`/api/v1/admin/publish` to make the change visible to end-users.",
+    "Dispatches `sync_yaml`, `remove`, or `create_from_db` against `(name, connection)`. " +
+    "All actions stage as drafts (#2177); admins publish via `/api/v1/admin/publish`.",
   request: {
     params: createParamSchema("name", "users"),
     body: {
@@ -529,8 +517,8 @@ export const postReconcileEntityRoute = createRoute({
     403: { description: "Forbidden — admin role required", content: { "application/json": { schema: AuthErrorSchema } } },
     404: {
       description:
-        "Action target doesn't make sense (e.g. `sync_yaml`/`remove` on an unknown entity, " +
-        "or `create_from_db` on a name that already exists or has no matching DB table)",
+        "Either the entity to sync/remove doesn't exist (`error: \"not_found\"`), " +
+        "or `create_from_db` was called on a name that already exists or has no matching DB table (`error: \"mismatch\"`).",
       content: { "application/json": { schema: ErrorSchema } },
     },
     501: { description: "Internal database not available", content: { "application/json": { schema: ErrorSchema } } },
@@ -1001,19 +989,9 @@ export function registerSemanticEditorRoutes(
     }),
   );
 
-  // ---------------------------------------------------------------------------
-  // Reconcile actions (#2462 / PRD #2458 slice 3)
-  // ---------------------------------------------------------------------------
-
-  // POST /semantic/entities/{name}/reconcile — drift-drawer reconcile actions
-  //
-  // Auth gates match the semantic editor exactly: `admin:semantic`. There is
-  // no separate "demo + published → 403" check because the editor itself
-  // accepts demo writes in published mode (drafts handle staging per #2177).
-  // Staying consistent means the drift drawer's UX matches the editor's:
-  // the FE disables the action buttons via `useDemoReadonly` for demo orgs
-  // in published mode; the server stages drafts the same way it does for
-  // any other admin write.
+  // POST /semantic/entities/{name}/reconcile — drift-drawer reconcile (#2462).
+  // Matches the editor's draft-staging contract (#2177); demo+published is
+  // gated FE-side via `useDemoReadonly`, same as the editor's edit/delete.
   admin.openapi(postReconcileEntityRoute, async (c) =>
     runHandler(c, "reconcile semantic entity", async () => {
       const { name } = c.req.valid("param");
@@ -1043,8 +1021,11 @@ export function registerSemanticEditorRoutes(
         connectionGroupId: scope,
       });
 
-      if (result.status === "not_found" || result.status === "mismatch") {
+      if (result.status === "not_found") {
         return c.json({ error: "not_found", message: result.reason, requestId }, 404);
+      }
+      if (result.status === "mismatch") {
+        return c.json({ error: "mismatch", message: result.reason, requestId }, 404);
       }
       if (result.status === "not_available") {
         return c.json({ error: "not_available", message: result.reason, requestId }, 501);
@@ -1061,7 +1042,8 @@ export function registerSemanticEditorRoutes(
         metadata: { name, source: "drift-reconcile", action: result.action },
       });
 
-      return c.json({ ok: true, action: result.action, name, entity: result.entity }, 200);
+      const entity = result.action === "remove" ? null : result.entity;
+      return c.json({ ok: true, action: result.action, name, entity }, 200);
     }),
   );
 }

--- a/packages/api/src/api/routes/admin-semantic.ts
+++ b/packages/api/src/api/routes/admin-semantic.ts
@@ -474,6 +474,71 @@ export const postRollbackRoute = createRoute({
 });
 
 // ---------------------------------------------------------------------------
+// Route definitions — drift-drawer reconcile (#2462 / PRD #2458 slice 3)
+// ---------------------------------------------------------------------------
+
+const ReconcileBodySchema = z.object({
+  action: z.enum(["sync_yaml", "remove", "create_from_db"]),
+  /**
+   * Connection alias for the introspection side of the diff (matches the
+   * drift fetch's `?connection=` query). Defaults to `"default"`.
+   */
+  connection: z.string().optional().default("default"),
+  /**
+   * Group scope for multi-environment orgs (#2412). Same encoding as the
+   * editor PUT/DELETE: omitted → unique-or-409 default, empty string →
+   * legacy null-scope row, non-empty → that group id.
+   */
+  connectionGroupId: z.string().optional(),
+});
+
+const ReconcileResponseSchema = z.object({
+  ok: z.boolean(),
+  action: z.enum(["sync_yaml", "remove", "create_from_db"]),
+  name: z.string(),
+  entity: z.object({ name: z.string(), yamlContent: z.string() }).nullable(),
+});
+
+export const postReconcileEntityRoute = createRoute({
+  method: "post",
+  path: "/semantic/entities/{name}/reconcile",
+  tags: ["Admin — Semantic"],
+  summary: "Reconcile a semantic entity against the introspected DB schema",
+  description:
+    "Dispatches one of three reconcile actions against `(name, connection)`:\n" +
+    "  - `sync_yaml`  — rewrite the entity's dimensions to match the DB columns; preserves user-authored fields\n" +
+    "  - `remove`     — drop the entity (mirrors the editor delete; stages as draft per #2177)\n" +
+    "  - `create_from_db` — introspect `name` as a table and write a starter entity\n\n" +
+    "All actions stage as drafts regardless of atlas mode (#2177); the admin publishes via " +
+    "`/api/v1/admin/publish` to make the change visible to end-users.",
+  request: {
+    params: createParamSchema("name", "users"),
+    body: {
+      content: {
+        "application/json": { schema: ReconcileBodySchema },
+      },
+    },
+  },
+  responses: {
+    200: {
+      description: "Reconcile applied",
+      content: { "application/json": { schema: ReconcileResponseSchema } },
+    },
+    400: { description: "Invalid request", content: { "application/json": { schema: ErrorSchema } } },
+    401: { description: "Authentication required", content: { "application/json": { schema: AuthErrorSchema } } },
+    403: { description: "Forbidden — admin role required", content: { "application/json": { schema: AuthErrorSchema } } },
+    404: {
+      description:
+        "Action target doesn't make sense (e.g. `sync_yaml`/`remove` on an unknown entity, " +
+        "or `create_from_db` on a name that already exists or has no matching DB table)",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
+    501: { description: "Internal database not available", content: { "application/json": { schema: ErrorSchema } } },
+    500: { description: "Internal server error", content: { "application/json": { schema: ErrorSchema } } },
+  },
+});
+
+// ---------------------------------------------------------------------------
 // Auth function type
 // ---------------------------------------------------------------------------
 
@@ -933,6 +998,70 @@ export function registerSemanticEditorRoutes(
       });
 
       return c.json({ ok: true, name, versionNumber: newVersionNumber }, 200);
+    }),
+  );
+
+  // ---------------------------------------------------------------------------
+  // Reconcile actions (#2462 / PRD #2458 slice 3)
+  // ---------------------------------------------------------------------------
+
+  // POST /semantic/entities/{name}/reconcile — drift-drawer reconcile actions
+  //
+  // Auth gates match the semantic editor exactly: `admin:semantic`. There is
+  // no separate "demo + published → 403" check because the editor itself
+  // accepts demo writes in published mode (drafts handle staging per #2177).
+  // Staying consistent means the drift drawer's UX matches the editor's:
+  // the FE disables the action buttons via `useDemoReadonly` for demo orgs
+  // in published mode; the server stages drafts the same way it does for
+  // any other admin write.
+  admin.openapi(postReconcileEntityRoute, async (c) =>
+    runHandler(c, "reconcile semantic entity", async () => {
+      const { name } = c.req.valid("param");
+      const body = c.req.valid("json");
+      const { authResult, requestId } = await authFn(c, "admin:semantic");
+
+      const orgId = authResult.user?.activeOrganizationId;
+      if (!orgId) {
+        return c.json({ error: "org_not_found", message: "No active organization. Select an organization and try again." }, 400);
+      }
+
+      if (!hasInternalDB()) {
+        return c.json({ error: "not_available", message: "Reconcile requires an internal database (DATABASE_URL).", requestId }, 501);
+      }
+
+      const atlasMode =
+        (c.get("atlasMode") as import("@useatlas/types/auth").AtlasMode | undefined) ?? "published";
+      const scope = parseConnectionGroupIdQuery(body.connectionGroupId);
+
+      const { reconcileEntity } = await import("@atlas/api/lib/semantic/reconcile");
+      const result = await reconcileEntity({
+        orgId,
+        name,
+        action: body.action,
+        atlasMode,
+        connection: body.connection,
+        connectionGroupId: scope,
+      });
+
+      if (result.status === "not_found" || result.status === "mismatch") {
+        return c.json({ error: "not_found", message: result.reason, requestId }, 404);
+      }
+      if (result.status === "not_available") {
+        return c.json({ error: "not_available", message: result.reason, requestId }, 501);
+      }
+
+      logAdminAction({
+        actionType:
+          result.action === "remove"
+            ? ADMIN_ACTIONS.semantic.deleteEntity
+            : ADMIN_ACTIONS.semantic.updateEntity,
+        targetType: "semantic",
+        targetId: name,
+        ipAddress: c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null,
+        metadata: { name, source: "drift-reconcile", action: result.action },
+      });
+
+      return c.json({ ok: true, action: result.action, name, entity: result.entity }, 200);
     }),
   );
 }

--- a/packages/api/src/lib/semantic/__tests__/yaml-reconciler.test.ts
+++ b/packages/api/src/lib/semantic/__tests__/yaml-reconciler.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, test } from "bun:test";
+import * as yaml from "js-yaml";
+import type { SemanticTableDiff } from "@useatlas/types";
+import { reconcileEntityYaml, generateStarterEntityYaml } from "../yaml-reconciler";
+
+// ---------------------------------------------------------------------------
+// reconcileEntityYaml — pure (yaml, diff) → yaml
+// ---------------------------------------------------------------------------
+
+describe("reconcileEntityYaml", () => {
+  const baseYaml = `table: orders
+description: Customer orders
+dimensions:
+  - name: id
+    sql: id
+    type: number
+    description: Primary key
+    primary_key: true
+  - name: customer_id
+    sql: customer_id
+    type: number
+    description: FK to customers
+    foreign_key: true
+    sample_values:
+      - "1"
+      - "2"
+  - name: total
+    sql: total
+    type: number
+joins:
+  - to: customers
+    on: orders.customer_id = customers.id
+measures:
+  - name: total_revenue
+    sql: SUM(total)
+    type: sum
+query_patterns:
+  - name: monthly_revenue
+    description: Revenue per month
+    sql: SELECT date_trunc('month', created_at) AS m, SUM(total) FROM orders GROUP BY 1
+`;
+
+  test("column added → dimension appended with name + sql + type", () => {
+    const diff: SemanticTableDiff = {
+      table: "orders",
+      addedColumns: [{ name: "shipped_at", type: "date" }],
+      removedColumns: [],
+      typeChanges: [],
+    };
+    const out = reconcileEntityYaml(baseYaml, diff);
+    const parsed = yaml.load(out) as Record<string, unknown>;
+    const dims = parsed.dimensions as Array<Record<string, unknown>>;
+    const appended = dims.find((d) => d.name === "shipped_at");
+    expect(appended).toBeDefined();
+    expect(appended?.type).toBe("date");
+    expect(appended?.sql).toBe("shipped_at");
+  });
+
+  test("column removed → dimension dropped by name", () => {
+    const diff: SemanticTableDiff = {
+      table: "orders",
+      addedColumns: [],
+      removedColumns: [{ name: "total", type: "number" }],
+      typeChanges: [],
+    };
+    const out = reconcileEntityYaml(baseYaml, diff);
+    const parsed = yaml.load(out) as Record<string, unknown>;
+    const dims = parsed.dimensions as Array<Record<string, unknown>>;
+    expect(dims.some((d) => d.name === "total")).toBe(false);
+    expect(dims.some((d) => d.name === "id")).toBe(true);
+    expect(dims.some((d) => d.name === "customer_id")).toBe(true);
+  });
+
+  test("type changed → existing dimension's type updated, other fields preserved", () => {
+    const diff: SemanticTableDiff = {
+      table: "orders",
+      addedColumns: [],
+      removedColumns: [],
+      typeChanges: [{ name: "customer_id", yamlType: "number", dbType: "string" }],
+    };
+    const out = reconcileEntityYaml(baseYaml, diff);
+    const parsed = yaml.load(out) as Record<string, unknown>;
+    const dims = parsed.dimensions as Array<Record<string, unknown>>;
+    const customer = dims.find((d) => d.name === "customer_id");
+    expect(customer?.type).toBe("string");
+    // Other fields preserved verbatim
+    expect(customer?.description).toBe("FK to customers");
+    expect(customer?.foreign_key).toBe(true);
+    expect(customer?.sql).toBe("customer_id");
+    expect(customer?.sample_values).toEqual(["1", "2"]);
+  });
+
+  test("user-authored top-level fields preserved verbatim", () => {
+    const diff: SemanticTableDiff = {
+      table: "orders",
+      addedColumns: [{ name: "shipped_at", type: "date" }],
+      removedColumns: [{ name: "total", type: "number" }],
+      typeChanges: [{ name: "customer_id", yamlType: "number", dbType: "string" }],
+    };
+    const out = reconcileEntityYaml(baseYaml, diff);
+    const parsed = yaml.load(out) as Record<string, unknown>;
+    expect(parsed.table).toBe("orders");
+    expect(parsed.description).toBe("Customer orders");
+    expect(parsed.joins).toEqual([
+      { to: "customers", on: "orders.customer_id = customers.id" },
+    ]);
+    expect(parsed.measures).toEqual([
+      { name: "total_revenue", sql: "SUM(total)", type: "sum" },
+    ]);
+    expect(parsed.query_patterns).toEqual([
+      {
+        name: "monthly_revenue",
+        description: "Revenue per month",
+        sql: "SELECT date_trunc('month', created_at) AS m, SUM(total) FROM orders GROUP BY 1",
+      },
+    ]);
+  });
+
+  test("preserves dimension's description / sample_values across add+remove+typeChange", () => {
+    const diff: SemanticTableDiff = {
+      table: "orders",
+      addedColumns: [{ name: "shipped_at", type: "date" }],
+      removedColumns: [{ name: "total", type: "number" }],
+      typeChanges: [{ name: "id", yamlType: "number", dbType: "number" }],
+    };
+    const out = reconcileEntityYaml(baseYaml, diff);
+    const parsed = yaml.load(out) as Record<string, unknown>;
+    const dims = parsed.dimensions as Array<Record<string, unknown>>;
+    const id = dims.find((d) => d.name === "id");
+    expect(id?.description).toBe("Primary key");
+    expect(id?.primary_key).toBe(true);
+  });
+
+  test("empty diff is a no-op (round-trips dimensions unchanged)", () => {
+    const diff: SemanticTableDiff = {
+      table: "orders",
+      addedColumns: [],
+      removedColumns: [],
+      typeChanges: [],
+    };
+    const out = reconcileEntityYaml(baseYaml, diff);
+    const parsed = yaml.load(out) as Record<string, unknown>;
+    const dims = parsed.dimensions as Array<Record<string, unknown>>;
+    expect(dims.map((d) => d.name)).toEqual(["id", "customer_id", "total"]);
+  });
+
+  test("handles entity YAML with no dimensions field (initializes empty list)", () => {
+    const yamlIn = "table: barebones\ndescription: just a table\n";
+    const diff: SemanticTableDiff = {
+      table: "barebones",
+      addedColumns: [{ name: "id", type: "number" }],
+      removedColumns: [],
+      typeChanges: [],
+    };
+    const out = reconcileEntityYaml(yamlIn, diff);
+    const parsed = yaml.load(out) as Record<string, unknown>;
+    const dims = parsed.dimensions as Array<Record<string, unknown>>;
+    expect(dims).toHaveLength(1);
+    expect(dims[0]?.name).toBe("id");
+  });
+
+  test("throws on malformed YAML rather than silently corrupting", () => {
+    expect(() => reconcileEntityYaml("not: a:\nvalid: : : yaml", {
+      table: "x",
+      addedColumns: [],
+      removedColumns: [],
+      typeChanges: [],
+    })).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// generateStarterEntityYaml — pure (table, columns) → yaml
+// ---------------------------------------------------------------------------
+
+describe("generateStarterEntityYaml", () => {
+  test("emits table + description placeholder + dimensions in column order", () => {
+    const out = generateStarterEntityYaml("orders", [
+      { name: "id", type: "number" },
+      { name: "customer_id", type: "number" },
+      { name: "created_at", type: "date" },
+    ]);
+    const parsed = yaml.load(out) as Record<string, unknown>;
+    expect(parsed.table).toBe("orders");
+    expect(typeof parsed.description).toBe("string");
+    const dims = parsed.dimensions as Array<Record<string, unknown>>;
+    expect(dims.map((d) => d.name)).toEqual(["id", "customer_id", "created_at"]);
+    expect(dims[0]?.type).toBe("number");
+    expect(dims[2]?.type).toBe("date");
+    expect(dims[0]?.sql).toBe("id");
+  });
+
+  test("output round-trips through reconcileEntityYaml as a no-op", () => {
+    const yamlOut = generateStarterEntityYaml("users", [
+      { name: "id", type: "number" },
+      { name: "email", type: "string" },
+    ]);
+    const reconciled = reconcileEntityYaml(yamlOut, {
+      table: "users",
+      addedColumns: [],
+      removedColumns: [],
+      typeChanges: [],
+    });
+    const before = yaml.load(yamlOut);
+    const after = yaml.load(reconciled);
+    expect(after).toEqual(before);
+  });
+});

--- a/packages/api/src/lib/semantic/__tests__/yaml-reconciler.test.ts
+++ b/packages/api/src/lib/semantic/__tests__/yaml-reconciler.test.ts
@@ -40,7 +40,7 @@ query_patterns:
     sql: SELECT date_trunc('month', created_at) AS m, SUM(total) FROM orders GROUP BY 1
 `;
 
-  test("column added → dimension appended with name + sql + type", () => {
+  test("column added → dimension appended with name + sql + type, existing order preserved", () => {
     const diff: SemanticTableDiff = {
       table: "orders",
       addedColumns: [{ name: "shipped_at", type: "date" }],
@@ -50,10 +50,10 @@ query_patterns:
     const out = reconcileEntityYaml(baseYaml, diff);
     const parsed = yaml.load(out) as Record<string, unknown>;
     const dims = parsed.dimensions as Array<Record<string, unknown>>;
-    const appended = dims.find((d) => d.name === "shipped_at");
-    expect(appended).toBeDefined();
-    expect(appended?.type).toBe("date");
-    expect(appended?.sql).toBe("shipped_at");
+    // Dimension ORDER matters: existing rows stay in place, new column appended last.
+    expect(dims.map((d) => d.name)).toEqual(["id", "customer_id", "total", "shipped_at"]);
+    expect(dims[3]?.type).toBe("date");
+    expect(dims[3]?.sql).toBe("shipped_at");
   });
 
   test("column removed → dimension dropped by name", () => {
@@ -165,7 +165,29 @@ query_patterns:
       addedColumns: [],
       removedColumns: [],
       typeChanges: [],
-    })).toThrow();
+    })).toThrow(/YAML parse failed/);
+  });
+
+  test("throws when YAML parses to a non-object (e.g. a top-level array)", () => {
+    expect(() => reconcileEntityYaml("- one\n- two\n", {
+      table: "x",
+      addedColumns: [],
+      removedColumns: [],
+      typeChanges: [],
+    })).toThrow(/must be an object/);
+  });
+
+  test("removal wins when a column appears in both removedColumns and typeChanges", () => {
+    const diff: SemanticTableDiff = {
+      table: "orders",
+      addedColumns: [],
+      removedColumns: [{ name: "total", type: "number" }],
+      typeChanges: [{ name: "total", yamlType: "number", dbType: "string" }],
+    };
+    const out = reconcileEntityYaml(baseYaml, diff);
+    const parsed = yaml.load(out) as Record<string, unknown>;
+    const dims = parsed.dimensions as Array<Record<string, unknown>>;
+    expect(dims.some((d) => d.name === "total")).toBe(false);
   });
 });
 

--- a/packages/api/src/lib/semantic/reconcile.ts
+++ b/packages/api/src/lib/semantic/reconcile.ts
@@ -1,0 +1,233 @@
+/**
+ * Reconcile-action dispatcher for the drift drawer (#2462 / PRD #2458 slice 3).
+ *
+ * Three actions on a `(orgId, entityName, connection)` tuple:
+ *
+ * - `sync_yaml` — rewrite the entity's YAML to match the introspected DB
+ *   columns. Preserves user-authored fields via {@link reconcileEntityYaml}.
+ *   Stages as draft regardless of `atlasMode` (#2177), same contract as the
+ *   semantic editor PUT.
+ *
+ * - `remove` — delete the entity row. Mirrors the existing
+ *   `deleteOrgEntityRoute` semantics: a draft is hard-deleted, a published
+ *   row is tombstoned for the next publish.
+ *
+ * - `create_from_db` — introspect the named DB table and write a starter
+ *   entity. Returns `mismatch` when an entity by that name already exists,
+ *   or when the DB doesn't contain a matching table (the route layer maps
+ *   both to 404 per acceptance criterion).
+ *
+ * The dispatcher returns a tagged {@link ReconcileResult} so the route layer
+ * can map each variant to the right HTTP status without re-querying.
+ */
+
+import * as yaml from "js-yaml";
+import type { AtlasMode } from "@useatlas/types/auth";
+import { createLogger } from "@atlas/api/lib/logger";
+import { hasInternalDB } from "@atlas/api/lib/db/internal";
+import {
+  getEntity,
+  upsertDraftEntity,
+  deleteDraftEntityForGroup,
+  upsertTombstoneForGroup,
+  type SemanticEntityRow,
+} from "./entities";
+import { runDriftDiff, getDBSchemaRaw } from "./diff";
+import { reconcileEntityYaml, generateStarterEntityYaml } from "./yaml-reconciler";
+
+const log = createLogger("semantic-reconcile");
+
+export type ReconcileAction = "sync_yaml" | "remove" | "create_from_db";
+
+export interface ReconcileInput {
+  readonly orgId: string;
+  readonly name: string;
+  readonly action: ReconcileAction;
+  readonly atlasMode: AtlasMode;
+  /**
+   * Connection alias for DB introspection (matches the drift fetch's
+   * `?connection=` query string). Used for `sync_yaml` to compute the
+   * per-table diff and for `create_from_db` to find the source table.
+   */
+  readonly connection: string;
+  /**
+   * Group scope for the entity row (#2412). When omitted, mirrors the
+   * unscoped-lookup contract in {@link getEntity}.
+   */
+  readonly connectionGroupId?: string | null;
+}
+
+export type ReconcileResult =
+  | {
+      readonly status: "ok";
+      readonly action: ReconcileAction;
+      readonly name: string;
+      readonly entity: { readonly name: string; readonly yamlContent: string } | null;
+    }
+  | {
+      readonly status: "not_found";
+      readonly reason: string;
+    }
+  | {
+      readonly status: "mismatch";
+      readonly reason: string;
+    }
+  | {
+      readonly status: "not_available";
+      readonly reason: string;
+    };
+
+/**
+ * Resolve the table name an entity targets — defaults to the entity row name
+ * when the YAML omits an explicit `table:` field (matches the diff engine's
+ * fallback in `parseEntityYAML`).
+ */
+function resolveTableName(row: SemanticEntityRow): string {
+  try {
+    const doc = yaml.load(row.yaml_content);
+    if (doc && typeof doc === "object" && !Array.isArray(doc)) {
+      const t = (doc as Record<string, unknown>).table;
+      if (typeof t === "string" && t.length > 0) return t;
+    }
+  } catch {
+    // Fall through — caller will see an empty diff and skip the rewrite.
+  }
+  return row.name;
+}
+
+export async function reconcileEntity(input: ReconcileInput): Promise<ReconcileResult> {
+  if (!hasInternalDB()) {
+    return {
+      status: "not_available",
+      reason: "Reconcile requires an internal database (DATABASE_URL).",
+    };
+  }
+
+  switch (input.action) {
+    case "sync_yaml":
+      return reconcileSyncYaml(input);
+    case "remove":
+      return reconcileRemove(input);
+    case "create_from_db":
+      return reconcileCreateFromDb(input);
+  }
+}
+
+async function reconcileSyncYaml(input: ReconcileInput): Promise<ReconcileResult> {
+  const row = await getEntity(input.orgId, "entity", input.name, input.connectionGroupId);
+  if (!row) {
+    return { status: "not_found", reason: `Entity "${input.name}" not found.` };
+  }
+
+  const table = resolveTableName(row);
+  const driftResult = await runDriftDiff(input.connection, {
+    orgId: input.orgId,
+    atlasMode: input.atlasMode,
+  });
+  const tableDiff = driftResult.diff.tableDiffs.find((d) => d.table === table) ?? {
+    table,
+    addedColumns: [],
+    removedColumns: [],
+    typeChanges: [],
+  };
+
+  const updatedYaml = reconcileEntityYaml(row.yaml_content, tableDiff);
+  await upsertDraftEntity(input.orgId, "entity", input.name, updatedYaml, input.connection);
+
+  const { invalidateOrgWhitelist } = await import("@atlas/api/lib/semantic");
+  const { syncEntityToDisk } = await import("./sync");
+  invalidateOrgWhitelist(input.orgId);
+  await syncEntityToDisk(input.orgId, input.name, "entity", updatedYaml);
+
+  log.info(
+    { orgId: input.orgId, name: input.name, table, action: "sync_yaml" },
+    "Reconciled entity YAML to DB columns",
+  );
+
+  return {
+    status: "ok",
+    action: "sync_yaml",
+    name: input.name,
+    entity: { name: input.name, yamlContent: updatedYaml },
+  };
+}
+
+async function reconcileRemove(input: ReconcileInput): Promise<ReconcileResult> {
+  // Mirror the existing `deleteOrgEntityRoute` semantics — hard-delete a
+  // draft / tombstone-then-publish-overwrite a published row. Same draft
+  // staging contract as the semantic editor (#2177).
+  const existing = await getEntity(input.orgId, "entity", input.name, input.connectionGroupId);
+  if (!existing) {
+    return { status: "not_found", reason: `Entity "${input.name}" not found.` };
+  }
+
+  const groupId = existing.connection_group_id ?? null;
+  let removed: boolean;
+  if (existing.status === "draft" || existing.status === "draft_delete") {
+    removed = await deleteDraftEntityForGroup(input.orgId, "entity", input.name, groupId);
+  } else {
+    await upsertTombstoneForGroup(input.orgId, "entity", input.name, groupId);
+    removed = true;
+  }
+  if (!removed) {
+    return { status: "not_found", reason: `Entity "${input.name}" not found.` };
+  }
+
+  const { invalidateOrgWhitelist } = await import("@atlas/api/lib/semantic");
+  const { syncEntityDeleteFromDisk } = await import("./sync");
+  invalidateOrgWhitelist(input.orgId);
+  await syncEntityDeleteFromDisk(input.orgId, input.name, "entity");
+
+  log.info(
+    { orgId: input.orgId, name: input.name, action: "remove" },
+    "Removed entity via reconcile",
+  );
+
+  return { status: "ok", action: "remove", name: input.name, entity: null };
+}
+
+async function reconcileCreateFromDb(input: ReconcileInput): Promise<ReconcileResult> {
+  // Refuse to clobber an existing entity. Acceptance criterion: 404 when
+  // the action target doesn't make sense.
+  const existing = await getEntity(input.orgId, "entity", input.name, input.connectionGroupId);
+  if (existing) {
+    return {
+      status: "mismatch",
+      reason: `Entity "${input.name}" already exists. Use sync_yaml to update it instead.`,
+    };
+  }
+
+  // Source table name defaults to the entity name (the drift drawer opens
+  // off `new` rows whose name matches the DB table). The connection's full
+  // schema is introspected once and matched here so we never write a
+  // starter entity for a non-existent table.
+  const schema = await getDBSchemaRaw(input.connection);
+  const snapshot = schema.get(input.name);
+  if (!snapshot) {
+    return {
+      status: "mismatch",
+      reason: `Table "${input.name}" not found on connection "${input.connection}".`,
+    };
+  }
+
+  const columns = [...snapshot.columns].map(([name, type]) => ({ name, type }));
+  const starterYaml = generateStarterEntityYaml(input.name, columns);
+
+  await upsertDraftEntity(input.orgId, "entity", input.name, starterYaml, input.connection);
+  const { invalidateOrgWhitelist } = await import("@atlas/api/lib/semantic");
+  const { syncEntityToDisk } = await import("./sync");
+  invalidateOrgWhitelist(input.orgId);
+  await syncEntityToDisk(input.orgId, input.name, "entity", starterYaml);
+
+  log.info(
+    { orgId: input.orgId, name: input.name, columns: columns.length, action: "create_from_db" },
+    "Created starter entity from DB introspection",
+  );
+
+  return {
+    status: "ok",
+    action: "create_from_db",
+    name: input.name,
+    entity: { name: input.name, yamlContent: starterYaml },
+  };
+}

--- a/packages/api/src/lib/semantic/reconcile.ts
+++ b/packages/api/src/lib/semantic/reconcile.ts
@@ -1,30 +1,14 @@
 /**
- * Reconcile-action dispatcher for the drift drawer (#2462 / PRD #2458 slice 3).
- *
- * Three actions on a `(orgId, entityName, connection)` tuple:
- *
- * - `sync_yaml` — rewrite the entity's YAML to match the introspected DB
- *   columns. Preserves user-authored fields via {@link reconcileEntityYaml}.
- *   Stages as draft regardless of `atlasMode` (#2177), same contract as the
- *   semantic editor PUT.
- *
- * - `remove` — delete the entity row. Mirrors the existing
- *   `deleteOrgEntityRoute` semantics: a draft is hard-deleted, a published
- *   row is tombstoned for the next publish.
- *
- * - `create_from_db` — introspect the named DB table and write a starter
- *   entity. Returns `mismatch` when an entity by that name already exists,
- *   or when the DB doesn't contain a matching table (the route layer maps
- *   both to 404 per acceptance criterion).
- *
- * The dispatcher returns a tagged {@link ReconcileResult} so the route layer
- * can map each variant to the right HTTP status without re-querying.
+ * Reconcile-action dispatcher for the drift drawer. All writes stage as
+ * drafts (#2177); the route layer maps `mismatch`/`not_found` → 404 and
+ * `not_available` → 501.
  */
 
 import * as yaml from "js-yaml";
 import type { AtlasMode } from "@useatlas/types/auth";
 import { createLogger } from "@atlas/api/lib/logger";
 import { hasInternalDB } from "@atlas/api/lib/db/internal";
+import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
 import {
   getEntity,
   upsertDraftEntity,
@@ -44,44 +28,33 @@ export interface ReconcileInput {
   readonly name: string;
   readonly action: ReconcileAction;
   readonly atlasMode: AtlasMode;
-  /**
-   * Connection alias for DB introspection (matches the drift fetch's
-   * `?connection=` query string). Used for `sync_yaml` to compute the
-   * per-table diff and for `create_from_db` to find the source table.
-   */
+  /** Connection alias for DB introspection — matches the drift fetch's `?connection=` query. */
   readonly connection: string;
   /**
-   * Group scope for the entity row (#2412). When omitted, mirrors the
-   * unscoped-lookup contract in {@link getEntity}.
+   * Trinary group scope (#2412): `undefined` → unique-or-409, `null` →
+   * legacy null-scope row, string → that group.
    */
   readonly connectionGroupId?: string | null;
 }
 
+/**
+ * The `remove` ok variant carries no entity payload — the row was deleted.
+ * `sync_yaml` and `create_from_db` always return the refreshed entity.
+ * The nested discriminant makes `{action:"remove", entity:{...}}` and
+ * `{action:"sync_yaml", entity:null}` unrepresentable.
+ */
 export type ReconcileResult =
+  | { readonly status: "ok"; readonly action: "remove"; readonly name: string }
   | {
       readonly status: "ok";
-      readonly action: ReconcileAction;
+      readonly action: "sync_yaml" | "create_from_db";
       readonly name: string;
-      readonly entity: { readonly name: string; readonly yamlContent: string } | null;
+      readonly entity: { readonly name: string; readonly yamlContent: string };
     }
-  | {
-      readonly status: "not_found";
-      readonly reason: string;
-    }
-  | {
-      readonly status: "mismatch";
-      readonly reason: string;
-    }
-  | {
-      readonly status: "not_available";
-      readonly reason: string;
-    };
+  | { readonly status: "not_found"; readonly reason: string }
+  | { readonly status: "mismatch"; readonly reason: string }
+  | { readonly status: "not_available"; readonly reason: string };
 
-/**
- * Resolve the table name an entity targets — defaults to the entity row name
- * when the YAML omits an explicit `table:` field (matches the diff engine's
- * fallback in `parseEntityYAML`).
- */
 function resolveTableName(row: SemanticEntityRow): string {
   try {
     const doc = yaml.load(row.yaml_content);
@@ -89,10 +62,45 @@ function resolveTableName(row: SemanticEntityRow): string {
       const t = (doc as Record<string, unknown>).table;
       if (typeof t === "string" && t.length > 0) return t;
     }
-  } catch {
-    // Fall through — caller will see an empty diff and skip the rewrite.
+  } catch (err) {
+    log.warn(
+      { err: errorMessage(err), name: row.name },
+      "resolveTableName: failed to parse entity YAML — falling back to row.name",
+    );
   }
   return row.name;
+}
+
+/**
+ * DB is authoritative; disk is a persistent cache. Disk sync failures must
+ * not roll back a committed DB mutation — matches the editor's contract.
+ */
+async function safeSyncToDisk(
+  orgId: string,
+  name: string,
+  yamlContent: string,
+): Promise<void> {
+  try {
+    const { syncEntityToDisk } = await import("./sync");
+    await syncEntityToDisk(orgId, name, "entity", yamlContent);
+  } catch (err) {
+    log.warn(
+      { err: errorMessage(err), orgId, name },
+      "Entity reconciled in DB but disk sync failed — will be synced on next restart",
+    );
+  }
+}
+
+async function safeSyncDeleteFromDisk(orgId: string, name: string): Promise<void> {
+  try {
+    const { syncEntityDeleteFromDisk } = await import("./sync");
+    await syncEntityDeleteFromDisk(orgId, name, "entity");
+  } catch (err) {
+    log.warn(
+      { err: errorMessage(err), orgId, name },
+      "Entity removed in DB but disk sync failed — will be cleaned on next restart",
+    );
+  }
 }
 
 export async function reconcileEntity(input: ReconcileInput): Promise<ReconcileResult> {
@@ -135,12 +143,11 @@ async function reconcileSyncYaml(input: ReconcileInput): Promise<ReconcileResult
   await upsertDraftEntity(input.orgId, "entity", input.name, updatedYaml, input.connection);
 
   const { invalidateOrgWhitelist } = await import("@atlas/api/lib/semantic");
-  const { syncEntityToDisk } = await import("./sync");
   invalidateOrgWhitelist(input.orgId);
-  await syncEntityToDisk(input.orgId, input.name, "entity", updatedYaml);
+  await safeSyncToDisk(input.orgId, input.name, updatedYaml);
 
   log.info(
-    { orgId: input.orgId, name: input.name, table, action: "sync_yaml" },
+    { orgId: input.orgId, name: input.name, table },
     "Reconciled entity YAML to DB columns",
   );
 
@@ -153,9 +160,6 @@ async function reconcileSyncYaml(input: ReconcileInput): Promise<ReconcileResult
 }
 
 async function reconcileRemove(input: ReconcileInput): Promise<ReconcileResult> {
-  // Mirror the existing `deleteOrgEntityRoute` semantics — hard-delete a
-  // draft / tombstone-then-publish-overwrite a published row. Same draft
-  // staging contract as the semantic editor (#2177).
   const existing = await getEntity(input.orgId, "entity", input.name, input.connectionGroupId);
   if (!existing) {
     return { status: "not_found", reason: `Entity "${input.name}" not found.` };
@@ -174,21 +178,15 @@ async function reconcileRemove(input: ReconcileInput): Promise<ReconcileResult> 
   }
 
   const { invalidateOrgWhitelist } = await import("@atlas/api/lib/semantic");
-  const { syncEntityDeleteFromDisk } = await import("./sync");
   invalidateOrgWhitelist(input.orgId);
-  await syncEntityDeleteFromDisk(input.orgId, input.name, "entity");
+  await safeSyncDeleteFromDisk(input.orgId, input.name);
 
-  log.info(
-    { orgId: input.orgId, name: input.name, action: "remove" },
-    "Removed entity via reconcile",
-  );
+  log.info({ orgId: input.orgId, name: input.name }, "Removed entity via reconcile");
 
-  return { status: "ok", action: "remove", name: input.name, entity: null };
+  return { status: "ok", action: "remove", name: input.name };
 }
 
 async function reconcileCreateFromDb(input: ReconcileInput): Promise<ReconcileResult> {
-  // Refuse to clobber an existing entity. Acceptance criterion: 404 when
-  // the action target doesn't make sense.
   const existing = await getEntity(input.orgId, "entity", input.name, input.connectionGroupId);
   if (existing) {
     return {
@@ -197,10 +195,6 @@ async function reconcileCreateFromDb(input: ReconcileInput): Promise<ReconcileRe
     };
   }
 
-  // Source table name defaults to the entity name (the drift drawer opens
-  // off `new` rows whose name matches the DB table). The connection's full
-  // schema is introspected once and matched here so we never write a
-  // starter entity for a non-existent table.
   const schema = await getDBSchemaRaw(input.connection);
   const snapshot = schema.get(input.name);
   if (!snapshot) {
@@ -215,12 +209,11 @@ async function reconcileCreateFromDb(input: ReconcileInput): Promise<ReconcileRe
 
   await upsertDraftEntity(input.orgId, "entity", input.name, starterYaml, input.connection);
   const { invalidateOrgWhitelist } = await import("@atlas/api/lib/semantic");
-  const { syncEntityToDisk } = await import("./sync");
   invalidateOrgWhitelist(input.orgId);
-  await syncEntityToDisk(input.orgId, input.name, "entity", starterYaml);
+  await safeSyncToDisk(input.orgId, input.name, starterYaml);
 
   log.info(
-    { orgId: input.orgId, name: input.name, columns: columns.length, action: "create_from_db" },
+    { orgId: input.orgId, name: input.name, columns: columns.length },
     "Created starter entity from DB introspection",
   );
 

--- a/packages/api/src/lib/semantic/yaml-reconciler.ts
+++ b/packages/api/src/lib/semantic/yaml-reconciler.ts
@@ -1,20 +1,8 @@
 /**
- * Pure YAML reconciler for the drift-drawer reconcile actions (#2462 / PRD #2458).
- *
- * `reconcileEntityYaml` takes the entity's current YAML string and a
- * column-level {@link SemanticTableDiff} from the diff engine and returns the
- * updated YAML — the dimension list is rewritten to match the introspected
- * DB columns while user-authored fields (`description`, `sample_values`,
- * `joins`, `measures`, `query_patterns`, plus any per-dimension metadata)
- * are preserved verbatim.
- *
- * `generateStarterEntityYaml` builds a brand-new entity YAML from an
- * introspected column list — used by the `create_from_db` reconcile action
- * to bootstrap a starter entity for a DB table that has no matching YAML.
- *
- * Both functions are pure: no DB calls, no fs writes. The drift-reconcile
- * dispatcher (`reconcile.ts`) is the side-effecting caller — keeping these
- * pure lets the unit tests cover every variant without spinning up a DB.
+ * Pure YAML reconciler for the drift-drawer reconcile actions. Caller is
+ * responsible for fetching the entity, applying the result, and writing it
+ * back as a draft — keeping these pure lets the unit tests cover every
+ * variant without a DB.
  */
 
 import * as yaml from "js-yaml";
@@ -28,28 +16,35 @@ interface Dimension {
 }
 
 /**
- * Apply a column-level DB↔YAML diff to an entity's YAML.
+ * Apply a column-level diff to an entity's YAML. Top-level fields other
+ * than `dimensions` (description, joins, measures, query_patterns, plus
+ * any per-dimension metadata on retained rows) round-trip verbatim.
  *
- * - `addedColumns` → appended as new dimensions (`{ name, sql: name, type }`).
- * - `removedColumns` → matching dimensions dropped by name.
- * - `typeChanges` → existing dimension's `type` overwritten with `dbType`;
- *   description, sample_values, primary_key, foreign_key, etc. preserved.
+ * Precedence when a column appears in both `removedColumns` and
+ * `typeChanges` (the diff engine doesn't currently emit this combo, but
+ * the type permits it): the dimension is dropped. Removal wins.
  *
- * Top-level fields other than `dimensions` are untouched — `description`,
- * `joins`, `measures`, `query_patterns`, and any other user-authored
- * sections round-trip verbatim.
- *
- * Throws when the input YAML can't be parsed into an object. The caller is
- * responsible for re-fetching the entity, applying the result, and writing
- * it back as a draft.
+ * Throws when the input YAML can't be parsed into an object.
  */
 export function reconcileEntityYaml(
   existingYaml: string,
   diff: SemanticTableDiff,
 ): string {
-  const parsed = yaml.load(existingYaml);
+  let parsed: unknown;
+  try {
+    parsed = yaml.load(existingYaml);
+  } catch (err) {
+    throw new Error(
+      `reconcileEntityYaml: YAML parse failed: ${err instanceof Error ? err.message : String(err)}`,
+      { cause: err },
+    );
+  }
   if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-    throw new Error("reconcileEntityYaml: input YAML did not parse to an object");
+    throw new Error(
+      `reconcileEntityYaml: parsed YAML must be an object (got ${
+        parsed === null ? "null" : Array.isArray(parsed) ? "array" : typeof parsed
+      })`,
+    );
   }
   const doc = parsed as Record<string, unknown>;
 
@@ -74,11 +69,7 @@ export function reconcileEntityYaml(
   return yaml.dump({ ...doc, dimensions: kept }, { lineWidth: 120, noRefs: true });
 }
 
-/**
- * Build a starter entity YAML from an introspected DB table's column list.
- * Used by the `create_from_db` reconcile action. The caller is expected to
- * have already verified that no entity with this name exists.
- */
+/** Build a starter entity YAML from an introspected DB column list. */
 export function generateStarterEntityYaml(
   table: string,
   columns: ReadonlyArray<{ name: string; type: string }>,

--- a/packages/api/src/lib/semantic/yaml-reconciler.ts
+++ b/packages/api/src/lib/semantic/yaml-reconciler.ts
@@ -1,0 +1,92 @@
+/**
+ * Pure YAML reconciler for the drift-drawer reconcile actions (#2462 / PRD #2458).
+ *
+ * `reconcileEntityYaml` takes the entity's current YAML string and a
+ * column-level {@link SemanticTableDiff} from the diff engine and returns the
+ * updated YAML — the dimension list is rewritten to match the introspected
+ * DB columns while user-authored fields (`description`, `sample_values`,
+ * `joins`, `measures`, `query_patterns`, plus any per-dimension metadata)
+ * are preserved verbatim.
+ *
+ * `generateStarterEntityYaml` builds a brand-new entity YAML from an
+ * introspected column list — used by the `create_from_db` reconcile action
+ * to bootstrap a starter entity for a DB table that has no matching YAML.
+ *
+ * Both functions are pure: no DB calls, no fs writes. The drift-reconcile
+ * dispatcher (`reconcile.ts`) is the side-effecting caller — keeping these
+ * pure lets the unit tests cover every variant without spinning up a DB.
+ */
+
+import * as yaml from "js-yaml";
+import type { SemanticTableDiff } from "@useatlas/types";
+
+interface Dimension {
+  name?: string;
+  type?: string;
+  sql?: string;
+  [key: string]: unknown;
+}
+
+/**
+ * Apply a column-level DB↔YAML diff to an entity's YAML.
+ *
+ * - `addedColumns` → appended as new dimensions (`{ name, sql: name, type }`).
+ * - `removedColumns` → matching dimensions dropped by name.
+ * - `typeChanges` → existing dimension's `type` overwritten with `dbType`;
+ *   description, sample_values, primary_key, foreign_key, etc. preserved.
+ *
+ * Top-level fields other than `dimensions` are untouched — `description`,
+ * `joins`, `measures`, `query_patterns`, and any other user-authored
+ * sections round-trip verbatim.
+ *
+ * Throws when the input YAML can't be parsed into an object. The caller is
+ * responsible for re-fetching the entity, applying the result, and writing
+ * it back as a draft.
+ */
+export function reconcileEntityYaml(
+  existingYaml: string,
+  diff: SemanticTableDiff,
+): string {
+  const parsed = yaml.load(existingYaml);
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("reconcileEntityYaml: input YAML did not parse to an object");
+  }
+  const doc = parsed as Record<string, unknown>;
+
+  const rawDims = Array.isArray(doc.dimensions) ? (doc.dimensions as Dimension[]) : [];
+  const removedNames = new Set(diff.removedColumns.map((c) => c.name));
+  const typeOverrides = new Map(diff.typeChanges.map((c) => [c.name, c.dbType] as const));
+
+  const kept: Dimension[] = [];
+  for (const dim of rawDims) {
+    if (typeof dim?.name === "string" && removedNames.has(dim.name)) continue;
+    if (typeof dim?.name === "string" && typeOverrides.has(dim.name)) {
+      kept.push({ ...dim, type: typeOverrides.get(dim.name) });
+    } else {
+      kept.push(dim);
+    }
+  }
+
+  for (const col of diff.addedColumns) {
+    kept.push({ name: col.name, sql: col.name, type: col.type });
+  }
+
+  return yaml.dump({ ...doc, dimensions: kept }, { lineWidth: 120, noRefs: true });
+}
+
+/**
+ * Build a starter entity YAML from an introspected DB table's column list.
+ * Used by the `create_from_db` reconcile action. The caller is expected to
+ * have already verified that no entity with this name exists.
+ */
+export function generateStarterEntityYaml(
+  table: string,
+  columns: ReadonlyArray<{ name: string; type: string }>,
+): string {
+  const doc = {
+    table,
+    description: `Auto-generated from database introspection of "${table}".`,
+    dimensions: columns.map((c) => ({ name: c.name, sql: c.name, type: c.type })),
+  };
+  return yaml.dump(doc, { lineWidth: 120, noRefs: true });
+}

--- a/packages/web/src/app/admin/semantic/page.tsx
+++ b/packages/web/src/app/admin/semantic/page.tsx
@@ -404,11 +404,7 @@ export default function SemanticPage() {
   ]);
 
   const [entities, setEntities] = useState<EntitySummary[]>([]);
-  // Slice 1 (#2459) signal: when the connection introspects zero tables we
-  // suppress the file-tree-renders-every-YAML-as-removed UX in favor of a
-  // targeted "we couldn't read any tables from this connection" panel
-  // (#2462). Initialise to `false` so the file tree renders normally until
-  // the entities fetch resolves; flip when the API confirms zero tables.
+  // True only after the API confirms the connection introspects zero tables.
   const [noIntrospectedTables, setNoIntrospectedTables] = useState(false);
   const [selectedEntity, setSelectedEntity] = useState<EntityData | null>(null);
   const [glossary, setGlossary] = useState<GlossaryTerm[]>([]);
@@ -430,9 +426,6 @@ export default function SemanticPage() {
   const [editingEntityName, setEditingEntityName] = useState<string | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
 
-  // Drift drawer (#2461): opens overlaid when a drifted entity is clicked.
-  // The underlying selection still updates so closing the drawer leaves the
-  // admin on the entity's detail view. Reconcile actions land in #2462.
   const [driftDrawerEntity, setDriftDrawerEntity] = useState<string | null>(null);
   const [driftDrawerOpen, setDriftDrawerOpen] = useState(false);
 
@@ -559,12 +552,8 @@ export default function SemanticPage() {
           console.warn("admin/semantic: drift warnings from /api/v1/admin/semantic/entities", warnings);
         }
         setEntities(normalized);
-        // Slice 1 (#2459) → slice 3 (#2462) consumer. The flag is
-        // load-bearing: without it every YAML row renders as "removed"
-        // when the DB itself has zero tables (the 2026-05-16 dogfood
-        // false-positive). We trust the server's resolution rather
-        // than re-deriving — `drift.ts` already separates the
-        // "DB has no tables" vs "whitelist excluded every table" cases.
+        // Server-resolved: drift.ts distinguishes "DB has no tables" from
+        // "whitelist excluded every table". Re-deriving would conflate them.
         setNoIntrospectedTables(data?.noIntrospectedTables === true);
       } else {
         // `extractFetchError` returns a populated `FetchError`; any other
@@ -840,16 +829,11 @@ export default function SemanticPage() {
         loadingMessage="Loading semantic layer..."
       >
       {/*
-        Zero-introspected-tables fix (#2462 slice 3, signal from #2459).
-        When the DB itself returns zero tables, the legacy file-tree path
-        would render every YAML entity as `removed` — the alarming
-        "N removed tables" UX surfaced by the 2026-05-16 dogfood pass.
-        Render a targeted empty state instead so admins see the real
-        signal: "we couldn't read any tables from this connection."
-
-        Falls below loading + above the empty / file-tree branches so it
-        wins over "no semantic entities yet" (the entities may still exist
-        in YAML — the introspection failure is the load-bearing fact).
+        Zero-introspected-tables case: render a targeted "we couldn't
+        read any tables" panel instead of the file tree, where every
+        YAML would otherwise show as drifted-removed. Falls above the
+        empty / file-tree branches because the YAML rows may still
+        exist — the introspection failure is the load-bearing fact.
       */}
       {!loading && noIntrospectedTables ? (
         <div className="p-6" data-testid="semantic-no-introspected-tables">
@@ -1062,11 +1046,7 @@ export default function SemanticPage() {
           setDriftDrawerOpen(open);
           if (!open) setDriftDrawerEntity(null);
         }}
-        onReconciled={() => {
-          // Refetch the entities list so the drift signal updates after a
-          // successful reconcile (#2462). The drawer closes itself.
-          refetchAll();
-        }}
+        onReconciled={refetchAll}
         reconcileDisabled={demoReadOnly}
         reconcileDisabledReason={DEMO_READONLY_TOOLTIP}
       />

--- a/packages/web/src/app/admin/semantic/page.tsx
+++ b/packages/web/src/app/admin/semantic/page.tsx
@@ -25,7 +25,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
-import { BookOpen, BarChart3, FileText, FolderOpen, Code, LayoutDashboard, Terminal, Plus, Pencil, Trash2, History, Sparkles, Download } from "lucide-react";
+import { BookOpen, BarChart3, FileText, FolderOpen, Code, LayoutDashboard, Terminal, Plus, Pencil, Trash2, History, Sparkles, Download, DatabaseZap } from "lucide-react";
 import Link from "next/link";
 import { EntityDetail, type EntityData } from "@/ui/components/admin/entity-detail";
 import {
@@ -404,6 +404,12 @@ export default function SemanticPage() {
   ]);
 
   const [entities, setEntities] = useState<EntitySummary[]>([]);
+  // Slice 1 (#2459) signal: when the connection introspects zero tables we
+  // suppress the file-tree-renders-every-YAML-as-removed UX in favor of a
+  // targeted "we couldn't read any tables from this connection" panel
+  // (#2462). Initialise to `false` so the file tree renders normally until
+  // the entities fetch resolves; flip when the API confirms zero tables.
+  const [noIntrospectedTables, setNoIntrospectedTables] = useState(false);
   const [selectedEntity, setSelectedEntity] = useState<EntityData | null>(null);
   const [glossary, setGlossary] = useState<GlossaryTerm[]>([]);
   const [metrics, setMetrics] = useState<MetricEntry[]>([]);
@@ -553,6 +559,13 @@ export default function SemanticPage() {
           console.warn("admin/semantic: drift warnings from /api/v1/admin/semantic/entities", warnings);
         }
         setEntities(normalized);
+        // Slice 1 (#2459) → slice 3 (#2462) consumer. The flag is
+        // load-bearing: without it every YAML row renders as "removed"
+        // when the DB itself has zero tables (the 2026-05-16 dogfood
+        // false-positive). We trust the server's resolution rather
+        // than re-deriving — `drift.ts` already separates the
+        // "DB has no tables" vs "whitelist excluded every table" cases.
+        setNoIntrospectedTables(data?.noIntrospectedTables === true);
       } else {
         // `extractFetchError` returns a populated `FetchError`; any other
         // rejection (network abort, JSON parse failure inside .then) gets
@@ -827,13 +840,51 @@ export default function SemanticPage() {
         loadingMessage="Loading semantic layer..."
       >
       {/*
+        Zero-introspected-tables fix (#2462 slice 3, signal from #2459).
+        When the DB itself returns zero tables, the legacy file-tree path
+        would render every YAML entity as `removed` — the alarming
+        "N removed tables" UX surfaced by the 2026-05-16 dogfood pass.
+        Render a targeted empty state instead so admins see the real
+        signal: "we couldn't read any tables from this connection."
+
+        Falls below loading + above the empty / file-tree branches so it
+        wins over "no semantic entities yet" (the entities may still exist
+        in YAML — the introspection failure is the load-bearing fact).
+      */}
+      {!loading && noIntrospectedTables ? (
+        <div className="p-6" data-testid="semantic-no-introspected-tables">
+          <EmptyState
+            icon={DatabaseZap}
+            title="We couldn't read any tables from this connection."
+            description="The semantic layer compares your YAML against the database's schema. Test the connection or re-run introspection to see which tables exist."
+          >
+            <div className="mt-3 flex items-center justify-center gap-2">
+              <Link href="/admin/connections">
+                <Button variant="outline" size="sm" className="gap-1.5 text-xs">
+                  <DatabaseZap className="size-3.5" />
+                  Test connection
+                </Button>
+              </Link>
+              <Button
+                variant="outline"
+                size="sm"
+                className="gap-1.5 text-xs"
+                onClick={() => setFetchKey((k) => k + 1)}
+              >
+                <Sparkles className="size-3.5" />
+                Re-run introspection
+              </Button>
+            </div>
+          </EmptyState>
+        </div>
+      ) : /*
         Dev-mode empty: admin is in developer mode with no entity drafts and
         no published entities at all. Route them to /admin/connections — a
         connection must exist before entities can be imported. Short-circuits
         the file-tree layout below to avoid showing an empty tree next to
         the empty state.
-      */}
-      {showDevNoDrafts && entities.length === 0 ? (
+      */
+      showDevNoDrafts && entities.length === 0 ? (
         <div className="p-6">
           <DeveloperEmptyState
             icon={BookOpen}
@@ -1011,6 +1062,13 @@ export default function SemanticPage() {
           setDriftDrawerOpen(open);
           if (!open) setDriftDrawerEntity(null);
         }}
+        onReconciled={() => {
+          // Refetch the entities list so the drift signal updates after a
+          // successful reconcile (#2462). The drawer closes itself.
+          refetchAll();
+        }}
+        reconcileDisabled={demoReadOnly}
+        reconcileDisabledReason={DEMO_READONLY_TOOLTIP}
       />
 
       {/* Entity editor dialog */}

--- a/packages/web/src/ui/__tests__/drift-drawer.test.tsx
+++ b/packages/web/src/ui/__tests__/drift-drawer.test.tsx
@@ -87,6 +87,8 @@ beforeEach(() => {
   mockData = null;
   mockLoading = false;
   mockError = null;
+  mockReconcileMutate.mockClear();
+  mockReconcileMutate.mockImplementation(async () => ({ ok: true as const, data: undefined }));
 });
 
 afterEach(() => {
@@ -251,5 +253,78 @@ describe("DriftDrawer (#2461)", () => {
     );
 
     expect(document.body.textContent).toContain("Loading drift");
+  });
+
+  test("clicking the sync action fires reconcile mutate, onReconciled, and closes", async () => {
+    mockData = makeDiff({
+      tableDiffs: [
+        {
+          table: "orders",
+          addedColumns: [{ name: "shipped_at", type: "timestamp" }],
+          removedColumns: [],
+          typeChanges: [],
+        },
+      ],
+      summary: { total: 1, new: 0, removed: 0, changed: 1, unchanged: 0 },
+    });
+
+    const opens: boolean[] = [];
+    const reconciledCalls: number[] = [];
+
+    render(
+      <DriftDrawer
+        entityName="orders"
+        open={true}
+        onOpenChange={(o) => opens.push(o)}
+        onReconciled={() => reconciledCalls.push(1)}
+      />,
+      { wrapper },
+    );
+
+    const syncBtn = document.querySelector('[data-testid="drift-action-sync_yaml"]') as HTMLButtonElement | null;
+    expect(syncBtn).not.toBeNull();
+    fireEvent.click(syncBtn!);
+
+    // Mutate is async; flush microtasks.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mockReconcileMutate).toHaveBeenCalledTimes(1);
+    const callArg = (mockReconcileMutate.mock.calls[0] as unknown as [{ body: { action: string; connection: string } }])[0];
+    expect(callArg.body.action).toBe("sync_yaml");
+    expect(callArg.body.connection).toBe("default");
+    expect(reconciledCalls).toHaveLength(1);
+    expect(opens).toContain(false);
+  });
+
+  test("reconcileDisabled disables every action button and surfaces the reason via title", () => {
+    mockData = makeDiff({
+      tableDiffs: [
+        {
+          table: "orders",
+          addedColumns: [{ name: "shipped_at", type: "timestamp" }],
+          removedColumns: [],
+          typeChanges: [],
+        },
+      ],
+      summary: { total: 1, new: 0, removed: 0, changed: 1, unchanged: 0 },
+    });
+
+    render(
+      <DriftDrawer
+        entityName="orders"
+        open={true}
+        onOpenChange={() => {}}
+        reconcileDisabled
+        reconcileDisabledReason="Switch to developer mode"
+      />,
+      { wrapper },
+    );
+
+    const syncBtn = document.querySelector('[data-testid="drift-action-sync_yaml"]') as HTMLButtonElement | null;
+    const removeBtn = document.querySelector('[data-testid="drift-action-remove"]') as HTMLButtonElement | null;
+    expect(syncBtn?.disabled).toBe(true);
+    expect(removeBtn?.disabled).toBe(true);
+    expect(syncBtn?.getAttribute("title")).toBe("Switch to developer mode");
   });
 });

--- a/packages/web/src/ui/__tests__/drift-drawer.test.tsx
+++ b/packages/web/src/ui/__tests__/drift-drawer.test.tsx
@@ -31,6 +31,29 @@ mock.module("@/ui/hooks/use-admin-fetch", () => ({
   friendlyError: (err: { message?: string }) => err?.message ?? "error",
 }));
 
+// #2462: drawer now fires `useAdminMutation` for reconcile actions. Mock it
+// so the smoke tests don't need a live AtlasProvider for the API base URL —
+// the contract under test is the diff-render path, not the network layer.
+const mockReconcileMutate = mock(async () => ({ ok: true as const, data: undefined }));
+
+mock.module("@/ui/hooks/use-admin-mutation", () => ({
+  useAdminMutation: () => ({
+    mutate: mockReconcileMutate,
+    saving: false,
+    error: null,
+    errorsByItemId: {},
+    errorFor: () => undefined,
+    clearError: () => {},
+    clearErrorFor: () => {},
+    reset: () => {},
+    isMutating: () => false,
+  }),
+}));
+
+mock.module("@/ui/components/admin/mutation-error-surface", () => ({
+  MutationErrorSurface: () => null,
+}));
+
 mock.module("@/ui/lib/fetch-error", () => ({
   friendlyError: (err: { message?: string }) => err?.message ?? "error",
   friendlyErrorOrNull: (err: { message?: string } | null | undefined) =>

--- a/packages/web/src/ui/components/admin/drift-drawer.tsx
+++ b/packages/web/src/ui/components/admin/drift-drawer.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import {
   Sheet,
   SheetContent,
@@ -21,46 +22,21 @@ import { CheckCircle2, Minus, RefreshCw, Trash2, Plus } from "lucide-react";
 
 interface DriftDrawerProps {
   /**
-   * Entity name to show drift for. Matched against the diff payload's
-   * `tableDiffs[].table` and `removedTables[]`. `null` keeps the drawer
-   * closed without firing the request.
+   * Entity name to show drift for. Matched against `tableDiffs[].table` /
+   * `removedTables[]` / `newTables[]`. `null` keeps the drawer closed.
    */
   entityName: string | null;
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  /**
-   * Connection alias passed to `/api/v1/admin/semantic/diff`. Defaults to
-   * `"default"`; callers thread the active env through once multi-env
-   * routing is wired (#2460).
-   */
+  /** Connection alias for `/api/v1/admin/semantic/diff`. */
   connection?: string;
-  /**
-   * Fires after a successful reconcile (#2462). The page consumer refetches
-   * the entity list so drift counts + the file tree reflect the new state.
-   * Closing the drawer is handled inside the drawer itself.
-   */
+  /** Fires after a successful reconcile so the page can refetch entities. */
   onReconciled?: () => void;
-  /**
-   * Disable the reconcile action buttons (#2462). Page-level callers gate
-   * on `useDemoReadonly()` so demo orgs in published mode can't mutate
-   * shared content via the drift drawer — mirrors the editor's gating.
-   */
+  /** Disables the action buttons (e.g. demo-readonly orgs in published mode). */
   reconcileDisabled?: boolean;
-  /** Optional tooltip / a11y hint surfaced when `reconcileDisabled` is true. */
   reconcileDisabledReason?: string;
 }
 
-/**
- * Right-side drawer that shows the per-table drift payload for a single
- * entity (#2461) plus three reconcile actions (#2462). #2463 retires the
- * standalone schema-diff page.
- *
- * Reuses the existing `/api/v1/admin/semantic/diff` endpoint and filters
- * client-side rather than extending the API: drift payloads are bounded
- * by the workspace's entity count (10s, not 1000s), so the extra rows are
- * cheap and #2463 retires the standalone diff route anyway. Hoisting
- * filtering server-side here would have made #2463 a backend change too.
- */
 export function DriftDrawer({
   entityName,
   open,
@@ -96,11 +72,8 @@ export function DriftDrawer({
   );
 }
 
-/**
- * Body is a separate component so the fetch only fires once `entityName`
- * is set — mounting it conditionally above means React tears the hook
- * tree down when the drawer closes, which short-circuits the request.
- */
+// Split so the diff fetch only fires when `entityName` is non-null —
+// mounting conditionally above tears the hook tree down on close.
 function DriftDrawerBody({
   entityName,
   connection,
@@ -132,6 +105,21 @@ function DriftDrawerBody({
     path: `/api/v1/admin/semantic/entities/${encodeURIComponent(entityName)}/reconcile`,
   });
 
+  // Tracks which action is in-flight so the right button shows busy copy
+  // when the panel renders two (the `changed` case).
+  const [busyAction, setBusyAction] = useState<ReconcileAction | null>(null);
+
+  const runAction = async (action: ReconcileAction) => {
+    setBusyAction(action);
+    try {
+      const result = await reconcile.mutate({ body: { action, connection } });
+      if (result.ok) onReconciled();
+      // !result.ok → <MutationErrorSurface> below renders the error.
+    } finally {
+      setBusyAction(null);
+    }
+  };
+
   if (loading) {
     return <LoadingState message="Loading drift…" />;
   }
@@ -148,17 +136,7 @@ function DriftDrawerBody({
   const isRemoved = data.removedTables.includes(entityName);
   const isNew = data.newTables.includes(entityName);
 
-  const runAction = async (action: "sync_yaml" | "remove" | "create_from_db") => {
-    const result = await reconcile.mutate({
-      body: { action, connection },
-    });
-    if (result.ok) onReconciled();
-  };
-
   if (changed) {
-    // Auto-expand: the drawer is single-entity, so the collapsed state
-    // would just be an extra click. The schema-diff page renders many
-    // cards and stays collapsed to keep scroll length sane.
     return (
       <div className="space-y-3">
         <DiffCard diff={changed} defaultOpen />
@@ -171,8 +149,7 @@ function DriftDrawerBody({
           actions={["sync_yaml", "remove"]}
           disabled={reconcileDisabled}
           disabledReason={reconcileDisabledReason}
-          busyAction={reconcile.saving ? null : null}
-          saving={reconcile.saving}
+          busyAction={busyAction}
           onRun={runAction}
         />
       </div>
@@ -202,7 +179,7 @@ function DriftDrawerBody({
           actions={["remove"]}
           disabled={reconcileDisabled}
           disabledReason={reconcileDisabledReason}
-          saving={reconcile.saving}
+          busyAction={busyAction}
           onRun={runAction}
         />
       </div>
@@ -232,19 +209,15 @@ function DriftDrawerBody({
           actions={["create_from_db"]}
           disabled={reconcileDisabled}
           disabledReason={reconcileDisabledReason}
-          saving={reconcile.saving}
+          busyAction={busyAction}
           onRun={runAction}
         />
       </div>
     );
   }
 
-  // No matching diff entry — keep the copy descriptive, not affirmative.
-  // The page only opens the drawer for drifted rows, so reaching this branch
-  // means the entities list and the /diff response disagree (stale state in
-  // another tab, a backend warning swallowing tableDiffs, etc.). Logging
-  // matches the existing dev-console signal pattern in the semantic page for
-  // the same class of disagreement.
+  // Drift/diff disagreement — the page only opens the drawer for drifted
+  // rows, so this branch usually means stale state in another tab.
   console.warn(
     `drift-drawer: opened for "${entityName}" but no matching diff entry — drift/diff disagreement?`,
   );
@@ -272,23 +245,22 @@ function ReconcileActions({
   actions,
   disabled,
   disabledReason,
-  saving,
-  onRun,
   busyAction,
+  onRun,
 }: {
   actions: ReconcileAction[];
   disabled: boolean;
   disabledReason?: string;
-  saving: boolean;
+  busyAction: ReconcileAction | null;
   onRun: (action: ReconcileAction) => void;
-  busyAction?: ReconcileAction | null;
 }) {
+  const anyBusy = busyAction !== null;
   return (
     <SheetFooter className="flex-row flex-wrap justify-end gap-2 border-t pt-3">
       {actions.map((action) => {
         const meta = ACTION_LABELS[action];
         const Icon = meta.icon;
-        const isBusy = saving && (busyAction === undefined || busyAction === action);
+        const isBusy = busyAction === action;
         return (
           <Button
             key={action}
@@ -299,9 +271,10 @@ function ReconcileActions({
                 ? "gap-1.5 text-xs text-destructive hover:text-destructive"
                 : "gap-1.5 text-xs"
             }
-            disabled={disabled || saving}
+            disabled={disabled || anyBusy}
             title={disabled ? disabledReason : undefined}
             onClick={() => onRun(action)}
+            data-testid={`drift-action-${action}`}
           >
             <Icon className="size-3.5" />
             {isBusy ? meta.busy : meta.idle}

--- a/packages/web/src/ui/components/admin/drift-drawer.tsx
+++ b/packages/web/src/ui/components/admin/drift-drawer.tsx
@@ -4,16 +4,20 @@ import {
   Sheet,
   SheetContent,
   SheetDescription,
+  SheetFooter,
   SheetHeader,
   SheetTitle,
 } from "@/components/ui/sheet";
+import { Button } from "@/components/ui/button";
 import { LoadingState } from "@/ui/components/admin/loading-state";
 import { ErrorBanner } from "@/ui/components/admin/error-banner";
+import { MutationErrorSurface } from "@/ui/components/admin/mutation-error-surface";
 import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
+import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
 import { friendlyError } from "@/ui/lib/fetch-error";
 import { SemanticDiffResponseSchema } from "@/ui/lib/admin-schemas";
 import { DiffCard } from "@/ui/components/admin/diff-card";
-import { CheckCircle2, Minus } from "lucide-react";
+import { CheckCircle2, Minus, RefreshCw, Trash2, Plus } from "lucide-react";
 
 interface DriftDrawerProps {
   /**
@@ -30,12 +34,26 @@ interface DriftDrawerProps {
    * routing is wired (#2460).
    */
   connection?: string;
+  /**
+   * Fires after a successful reconcile (#2462). The page consumer refetches
+   * the entity list so drift counts + the file tree reflect the new state.
+   * Closing the drawer is handled inside the drawer itself.
+   */
+  onReconciled?: () => void;
+  /**
+   * Disable the reconcile action buttons (#2462). Page-level callers gate
+   * on `useDemoReadonly()` so demo orgs in published mode can't mutate
+   * shared content via the drift drawer — mirrors the editor's gating.
+   */
+  reconcileDisabled?: boolean;
+  /** Optional tooltip / a11y hint surfaced when `reconcileDisabled` is true. */
+  reconcileDisabledReason?: string;
 }
 
 /**
  * Right-side drawer that shows the per-table drift payload for a single
- * entity (#2461). Read-only foundation; #2462 adds reconcile actions and
- * #2463 retires the standalone schema-diff page.
+ * entity (#2461) plus three reconcile actions (#2462). #2463 retires the
+ * standalone schema-diff page.
  *
  * Reuses the existing `/api/v1/admin/semantic/diff` endpoint and filters
  * client-side rather than extending the API: drift payloads are bounded
@@ -48,6 +66,9 @@ export function DriftDrawer({
   open,
   onOpenChange,
   connection = "default",
+  onReconciled,
+  reconcileDisabled = false,
+  reconcileDisabledReason,
 }: DriftDrawerProps) {
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
@@ -58,7 +79,16 @@ export function DriftDrawer({
         </SheetHeader>
         <div className="px-4 pb-6">
           {entityName ? (
-            <DriftDrawerBody entityName={entityName} connection={connection} />
+            <DriftDrawerBody
+              entityName={entityName}
+              connection={connection}
+              onReconciled={() => {
+                onReconciled?.();
+                onOpenChange(false);
+              }}
+              reconcileDisabled={reconcileDisabled}
+              reconcileDisabledReason={reconcileDisabledReason}
+            />
           ) : null}
         </div>
       </SheetContent>
@@ -74,9 +104,15 @@ export function DriftDrawer({
 function DriftDrawerBody({
   entityName,
   connection,
+  onReconciled,
+  reconcileDisabled,
+  reconcileDisabledReason,
 }: {
   entityName: string;
   connection: string;
+  onReconciled: () => void;
+  reconcileDisabled: boolean;
+  reconcileDisabledReason?: string;
 }) {
   const { data, loading, error } = useAdminFetch(
     `/api/v1/admin/semantic/diff?connection=${encodeURIComponent(connection)}`,
@@ -85,6 +121,16 @@ function DriftDrawerBody({
       deps: [connection],
     },
   );
+
+  const reconcile = useAdminMutation<{
+    ok: boolean;
+    action: "sync_yaml" | "remove" | "create_from_db";
+    name: string;
+    entity: { name: string; yamlContent: string } | null;
+  }>({
+    method: "POST",
+    path: `/api/v1/admin/semantic/entities/${encodeURIComponent(entityName)}/reconcile`,
+  });
 
   if (loading) {
     return <LoadingState message="Loading drift…" />;
@@ -100,6 +146,14 @@ function DriftDrawerBody({
 
   const changed = data.tableDiffs.find((td) => td.table === entityName);
   const isRemoved = data.removedTables.includes(entityName);
+  const isNew = data.newTables.includes(entityName);
+
+  const runAction = async (action: "sync_yaml" | "remove" | "create_from_db") => {
+    const result = await reconcile.mutate({
+      body: { action, connection },
+    });
+    if (result.ok) onReconciled();
+  };
 
   if (changed) {
     // Auto-expand: the drawer is single-entity, so the collapsed state
@@ -108,22 +162,79 @@ function DriftDrawerBody({
     return (
       <div className="space-y-3">
         <DiffCard diff={changed} defaultOpen />
+        <MutationErrorSurface
+          error={reconcile.error}
+          feature="Semantic Layer"
+          variant="inline"
+        />
+        <ReconcileActions
+          actions={["sync_yaml", "remove"]}
+          disabled={reconcileDisabled}
+          disabledReason={reconcileDisabledReason}
+          busyAction={reconcile.saving ? null : null}
+          saving={reconcile.saving}
+          onRun={runAction}
+        />
       </div>
     );
   }
 
   if (isRemoved) {
     return (
-      <div
-        role="alert"
-        className="flex items-start gap-2 rounded-md border border-red-500/30 bg-red-50/30 px-3 py-3 text-xs text-red-700 dark:bg-red-950/10 dark:text-red-400"
-      >
-        <Minus className="mt-0.5 size-3.5 shrink-0" />
-        <span>
-          The <code className="rounded bg-muted px-1 py-0.5 font-mono">{entityName}</code> entity
-          references a table that no longer exists in the database. Consider removing the stale
-          entity file.
-        </span>
+      <div className="space-y-3">
+        <div
+          role="alert"
+          className="flex items-start gap-2 rounded-md border border-red-500/30 bg-red-50/30 px-3 py-3 text-xs text-red-700 dark:bg-red-950/10 dark:text-red-400"
+        >
+          <Minus className="mt-0.5 size-3.5 shrink-0" />
+          <span>
+            The <code className="rounded bg-muted px-1 py-0.5 font-mono">{entityName}</code> entity
+            references a table that no longer exists in the database. Remove the stale entity file
+            to clear the drift.
+          </span>
+        </div>
+        <MutationErrorSurface
+          error={reconcile.error}
+          feature="Semantic Layer"
+          variant="inline"
+        />
+        <ReconcileActions
+          actions={["remove"]}
+          disabled={reconcileDisabled}
+          disabledReason={reconcileDisabledReason}
+          saving={reconcile.saving}
+          onRun={runAction}
+        />
+      </div>
+    );
+  }
+
+  if (isNew) {
+    return (
+      <div className="space-y-3">
+        <div
+          role="alert"
+          className="flex items-start gap-2 rounded-md border border-blue-500/30 bg-blue-50/30 px-3 py-3 text-xs text-blue-700 dark:bg-blue-950/10 dark:text-blue-400"
+        >
+          <Plus className="mt-0.5 size-3.5 shrink-0" />
+          <span>
+            <code className="rounded bg-muted px-1 py-0.5 font-mono">{entityName}</code> exists in
+            the database but has no entity definition. Add it to the semantic layer so the agent
+            can query it.
+          </span>
+        </div>
+        <MutationErrorSurface
+          error={reconcile.error}
+          feature="Semantic Layer"
+          variant="inline"
+        />
+        <ReconcileActions
+          actions={["create_from_db"]}
+          disabled={reconcileDisabled}
+          disabledReason={reconcileDisabledReason}
+          saving={reconcile.saving}
+          onRun={runAction}
+        />
       </div>
     );
   }
@@ -149,3 +260,54 @@ function DriftDrawerBody({
   );
 }
 
+type ReconcileAction = "sync_yaml" | "remove" | "create_from_db";
+
+const ACTION_LABELS: Record<ReconcileAction, { idle: string; busy: string; icon: typeof RefreshCw }> = {
+  sync_yaml: { idle: "Update YAML to match DB", busy: "Updating…", icon: RefreshCw },
+  remove: { idle: "Remove orphaned YAML", busy: "Removing…", icon: Trash2 },
+  create_from_db: { idle: "Add to semantic layer", busy: "Adding…", icon: Plus },
+};
+
+function ReconcileActions({
+  actions,
+  disabled,
+  disabledReason,
+  saving,
+  onRun,
+  busyAction,
+}: {
+  actions: ReconcileAction[];
+  disabled: boolean;
+  disabledReason?: string;
+  saving: boolean;
+  onRun: (action: ReconcileAction) => void;
+  busyAction?: ReconcileAction | null;
+}) {
+  return (
+    <SheetFooter className="flex-row flex-wrap justify-end gap-2 border-t pt-3">
+      {actions.map((action) => {
+        const meta = ACTION_LABELS[action];
+        const Icon = meta.icon;
+        const isBusy = saving && (busyAction === undefined || busyAction === action);
+        return (
+          <Button
+            key={action}
+            variant={action === "remove" ? "outline" : "default"}
+            size="sm"
+            className={
+              action === "remove"
+                ? "gap-1.5 text-xs text-destructive hover:text-destructive"
+                : "gap-1.5 text-xs"
+            }
+            disabled={disabled || saving}
+            title={disabled ? disabledReason : undefined}
+            onClick={() => onRun(action)}
+          >
+            <Icon className="size-3.5" />
+            {isBusy ? meta.busy : meta.idle}
+          </Button>
+        );
+      })}
+    </SheetFooter>
+  );
+}


### PR DESCRIPTION
## Summary

PRD #2458 slice 3/5. The drift drawer (shipped read-only in #2461) gains
three reconcile actions wired to a single new endpoint, and
`/admin/semantic` stops misrendering every YAML as "removed" when DB
introspection returns zero tables.

- **API.** `POST /api/v1/admin/semantic/entities/:name/reconcile`
  dispatches to `sync_yaml`, `remove`, and `create_from_db` handlers in
  the new `lib/semantic/reconcile.ts`. The handler is a thin shell over
  the pure `lib/semantic/yaml-reconciler.ts` that rewrites dimensions to
  match the introspected DB columns while preserving user-authored fields
  (description, sample_values, joins, measures, query_patterns,
  primary_key, foreign_key, etc.) verbatim. All actions stage as drafts
  per #2177 — `/api/v1/admin/publish` stays the single end-user
  visibility gate.
- **Web.** `<DriftDrawer>` renders 1–2 action buttons per drift case
  (`changed` → sync + remove, `removed` → remove, `new` → add); success
  closes the drawer + refetches the entity list. `/admin/semantic`
  consumes `noIntrospectedTables` from slice 1's entities payload (#2459)
  and renders a targeted "we couldn't read any tables from this
  connection" empty state with Test connection / Re-run introspection
  CTAs — the 2026-05-16 dogfood pass surfaced this as "13 removed
  tables" on a workspace with an empty DB.
- **Auth gates.** Match the existing semantic editor exactly: admin role
  required (`adminAuthAndContext(c, "admin:semantic")` → 403 for
  non-admin), internal DB required (501 otherwise). No separate
  demo + published 403 — the editor itself accepts demo writes in
  published mode because drafts handle staging (#2177). The drift
  drawer's reconcile buttons are FE-gated via `useDemoReadonly()` for
  parity with the editor's edit/delete buttons.

Closes #2462. Unblocks slice 5 (#2463 — retire `/admin/schema-diff`).

## Test plan

- [x] `bun test packages/api/src/lib/semantic/__tests__/yaml-reconciler.test.ts` — 10 pure-module tests covering every diff variant (add / remove / type change / preserve user fields / empty diff / malformed YAML)
- [x] `bun test packages/api/src/api/__tests__/admin.test.ts` — 190 tests pass including 10 new endpoint tests (non-admin 403, draft staging, remove draft vs published, create_from_db already-exists + no-matching-table 404s, 501 when no internal DB, 4xx on unknown action)
- [x] `bun test packages/web/src/ui/__tests__/drift-drawer.test.tsx` — 7 smoke tests pass after wiring `useAdminMutation` mock
- [x] `bun run scripts/test-isolated.ts --affected` — 49/49 affected api tests pass
- [x] `bun run test:others` — 156/156 across web + cli + sdk + react + types + mcp + plugin-sdk + sandbox-sidecar + webhook
- [x] `bun run type` — clean
- [x] `bun run lint` — 0 errors (1 pre-existing warning unrelated to this PR)
- [x] `bun x syncpack lint` — no issues
- [x] `bash scripts/check-template-drift.sh` — 577 files verified
- [x] `bash scripts/check-schema-drift.sh` — 69 migration tables present
- [x] `bash scripts/check-security-headers-drift.sh` — 3 mirrors match
- [x] `bash scripts/check-railway-watch.sh` — all sources covered
- [x] `bash scripts/check-oauth-helper-drift.sh` — vendored matches canonical
- [ ] Manual dogfood: on a workspace with an empty DB, `/admin/semantic` shows the targeted "we couldn't read any tables" panel instead of the alarming drift list
- [ ] Manual dogfood: open the drift drawer on a `changed` entity, click "Update YAML to match DB", confirm the drawer closes, the entity drift count drops, and the new draft appears in the pending-changes pill