### PR TITLE
fix(api): #2483 — gate default connection fallback by deploy mode on SaaS

### DIFF
--- a/packages/api/src/api/__tests__/admin-connections.test.ts
+++ b/packages/api/src/api/__tests__/admin-connections.test.ts
@@ -67,6 +67,17 @@ const mocks = createApiTestMocks({
   },
 });
 
+// `getConfig` is `null` by default in the test factory. Override here so
+// tests can flip deployMode for the #2483 SaaS-gate branch on the
+// `default` connection fallback. Default `null` preserves the original
+// self-hosted-style behavior.
+let mockConfigOverride: { deployMode?: "saas" | "self-hosted" } | null = null;
+
+mock.module("@atlas/api/lib/config", () => ({
+  getConfig: () => mockConfigOverride,
+  defineConfig: (c: unknown) => c,
+}));
+
 // --- Import app after mocks ---
 
 const { app } = await import("../index");
@@ -106,6 +117,7 @@ describe("admin connections — org scoping", () => {
     mocks.mockInternalQuery.mockReset();
     mocks.mockInternalQuery.mockResolvedValue([]);
     mockHealthCheck.mockClear();
+    mockConfigOverride = null;
     setOrgAdmin("org-alpha");
   });
 
@@ -605,6 +617,38 @@ describe("admin connections — org scoping", () => {
       const body = (await res.json()) as any;
       const ids = body.connections.map((c: { id: string }) => c.id);
       expect(ids).toContain("default");
+    });
+
+    it("self-hosted (explicit deployMode) still surfaces 'default' when org owns no connections (#2483)", async () => {
+      // Same scenario as above, but with an explicit `deployMode: "self-hosted"`
+      // config so the SaaS-gate branch is exercised on the negative side.
+      mockConfigOverride = { deployMode: "self-hosted" };
+      mocks.mockInternalQuery.mockResolvedValue([]);
+
+      const res = await app.fetch(adminRequest("/api/v1/admin/connections"));
+      expect(res.status).toBe(200);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test convenience
+      const body = (await res.json()) as any;
+      const ids = body.connections.map((c: { id: string }) => c.id);
+      expect(ids).toEqual(["default"]);
+    });
+
+    it("SaaS suppresses the 'default' fallback for a fresh-signup workspace (#2483)", async () => {
+      // SaaS smoking gun: a freshly-signed-up workspace has zero `connections`
+      // rows. The runtime registry has `default` bound to the shared
+      // ATLAS_DATASOURCE_URL demo service. Without the SaaS gate, that demo
+      // surfaces as "your default Atlas connection" in every fresh-signup
+      // workspace — a tenant-isolation smell and a chat-routing risk.
+      mockConfigOverride = { deployMode: "saas" };
+      mocks.mockInternalQuery.mockResolvedValue([]);
+
+      const res = await app.fetch(adminRequest("/api/v1/admin/connections"));
+      expect(res.status).toBe(200);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test convenience
+      const body = (await res.json()) as any;
+      const ids = body.connections.map((c: { id: string }) => c.id);
+      expect(ids).not.toContain("default");
+      expect(ids).toEqual([]);
     });
 
     it("suppresses 'default' once the org has its own connections", async () => {

--- a/packages/api/src/api/__tests__/admin-connections.test.ts
+++ b/packages/api/src/api/__tests__/admin-connections.test.ts
@@ -651,6 +651,28 @@ describe("admin connections — org scoping", () => {
       expect(ids).toEqual([]);
     });
 
+    it("SaaS gate is orthogonal to owned-rows — owned connections still surface on SaaS (#2483)", async () => {
+      // Closes the gate × owned-rows matrix: confirms the SaaS gate only
+      // suppresses the `visible.size === 0` fallback branch and does not
+      // interfere with the org's own connections. Guards against an inverted-
+      // boolean regression (e.g. `if (visible.size === 0 || !isSaas)`) that
+      // would accidentally drop owned rows on SaaS.
+      mockConfigOverride = { deployMode: "saas" };
+      mocks.mockInternalQuery.mockImplementation((sql: string) => {
+        if (sql.includes("SELECT c.id FROM connections c WHERE c.org_id")) {
+          return Promise.resolve([{ id: "warehouse" }]);
+        }
+        return Promise.resolve([]);
+      });
+
+      const res = await app.fetch(adminRequest("/api/v1/admin/connections"));
+      expect(res.status).toBe(200);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test convenience
+      const body = (await res.json()) as any;
+      const ids = body.connections.map((c: { id: string }) => c.id);
+      expect(ids).toEqual(["warehouse"]);
+    });
+
     it("suppresses 'default' once the org has its own connections", async () => {
       // SaaS path: dhamra owns __demo__ (or wizard-created), so the runtime-
       // registered `default` should not surface alongside it.

--- a/packages/api/src/api/routes/admin-connections.ts
+++ b/packages/api/src/api/routes/admin-connections.ts
@@ -56,12 +56,12 @@ function getAtlasMode(c: { get(key: string): unknown }): import("@useatlas/types
  * onboarded org owns either `__demo__` or a wizard-created connection that
  * aliases the same physical DB as `default`, so seeding `default`
  * unconditionally produced a phantom duplicate in the Connections list and
- * the Semantic page connection picker. The SaaS gate further protects
- * fresh-signup workspaces that skip the demo step from seeing the shared
- * `ATLAS_DATASOURCE_URL` service as "their default Atlas connection"
- * (#2483 — single-tenant lazy-registration leaking into multi-tenant). Self-
- * hosted single-tenant deployments still see `default` because they have no
- * `connections` rows at all.
+ * the Semantic page connection picker. The SaaS gate further protects any
+ * SaaS workspace whose `connections` rowset is empty (#2483) — without it,
+ * the shared `ATLAS_DATASOURCE_URL` service rendered as "their default
+ * Atlas connection," a single-tenant lazy-registration leaking into
+ * multi-tenant. Self-hosted single-tenant deployments still see `default`
+ * because they have no `connections` rows at all.
  *
  * @param mode - Atlas mode. Published mode sees only published connections;
  *   developer mode additionally sees drafts. Archived connections are hidden
@@ -103,10 +103,9 @@ export async function getVisibleConnectionIds(
     }
   }
 
-  // SaaS gate: never auto-surface the runtime-registered `default` to a
-  // fresh-signup workspace. On SaaS the `default` registration is the shared
-  // demo service from `ATLAS_DATASOURCE_URL`, not a per-org connection — see
-  // #2483. Self-hosted deployments retain the single-tenant fallback.
+  // SaaS gate: on SaaS the `default` registration is the shared demo service
+  // from `ATLAS_DATASOURCE_URL`, not a per-org connection, so never auto-
+  // surface it (#2483).
   const isSaas = getConfig()?.deployMode === "saas";
   if (visible.size === 0 && connections.has("default") && !isSaas) {
     visible.add("default");

--- a/packages/api/src/api/routes/admin-connections.ts
+++ b/packages/api/src/api/routes/admin-connections.ts
@@ -12,6 +12,7 @@ import { createRoute, z } from "@hono/zod-openapi";
 import { createLogger } from "@atlas/api/lib/logger";
 import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
 import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
+import { getConfig } from "@atlas/api/lib/config";
 import { connections, detectDBType } from "@atlas/api/lib/db/connection";
 import { hasInternalDB, internalQuery, encryptSecret, decryptSecret, type URLSecret } from "@atlas/api/lib/db/internal";
 import { activeKeyVersion } from "@atlas/api/lib/db/encryption-keys";
@@ -51,11 +52,15 @@ function getAtlasMode(c: { get(key: string): unknown }): import("@useatlas/types
  *
  * The runtime-registered `default` connection (sourced from
  * `ATLAS_DATASOURCE_URL`) is only surfaced when the org has zero rows of its
- * own in `connections`. On SaaS every onboarded org owns either `__demo__` or
- * a wizard-created connection that aliases the same physical DB as `default`,
- * so seeding `default` unconditionally produced a phantom duplicate in the
- * Connections list and the Semantic page connection picker. Self-hosted
- * single-tenant deployments still see `default` because they have no
+ * own in `connections` AND the deployment is not SaaS. On SaaS every
+ * onboarded org owns either `__demo__` or a wizard-created connection that
+ * aliases the same physical DB as `default`, so seeding `default`
+ * unconditionally produced a phantom duplicate in the Connections list and
+ * the Semantic page connection picker. The SaaS gate further protects
+ * fresh-signup workspaces that skip the demo step from seeing the shared
+ * `ATLAS_DATASOURCE_URL` service as "their default Atlas connection"
+ * (#2483 — single-tenant lazy-registration leaking into multi-tenant). Self-
+ * hosted single-tenant deployments still see `default` because they have no
  * `connections` rows at all.
  *
  * @param mode - Atlas mode. Published mode sees only published connections;
@@ -98,7 +103,12 @@ export async function getVisibleConnectionIds(
     }
   }
 
-  if (visible.size === 0 && connections.has("default")) {
+  // SaaS gate: never auto-surface the runtime-registered `default` to a
+  // fresh-signup workspace. On SaaS the `default` registration is the shared
+  // demo service from `ATLAS_DATASOURCE_URL`, not a per-org connection — see
+  // #2483. Self-hosted deployments retain the single-tenant fallback.
+  const isSaas = getConfig()?.deployMode === "saas";
+  if (visible.size === 0 && connections.has("default") && !isSaas) {
     visible.add("default");
   }
 


### PR DESCRIPTION
Closes #2483.

## Summary

- `getVisibleConnectionIds` (admin-connections.ts) lazy-added the runtime-registered `default` connection whenever an org had zero rows in `connections`. On SaaS that `default` is the shared `ATLAS_DATASOURCE_URL` demo service (NovaMart), so every fresh-signup workspace saw "your default Atlas connection" pointing at the multi-tenant demo. Tenant-isolation smell + chat-routing risk (agent runtime would happily query NovaMart if the workspace skipped the demo step).
- Gate the fallback on `getConfig()?.deployMode !== "saas"`. Self-hosted single-tenant deployments still see `default` when they have no `connections` rows; SaaS workspaces with no rows now see an empty list.
- Added two test cases parametrizing the existing `getVisibleConnectionIds` block on deploy mode: SaaS suppresses the fallback, self-hosted (explicit) still surfaces it. The original `null`-config case (test factory default) is preserved unchanged.

## Out of scope (intentionally)

- Reframing the demo as a labeled shared sample dataset — separate larger conversation (fix candidate #2 in the dogfood notes).
- Removing the unused `_isPlatformAdmin` param on `getVisibleConnectionIds` (post-#2303 dead arg) — keeping the diff surgical.
- Touching the lazy default-registration in `ConnectionRegistry` or the demo data itself.

## Test plan

- [x] `bun test packages/api/src/api/__tests__/admin-connections.test.ts` — 46/46 pass (44 existing + 2 new SaaS/self-hosted parametrized cases)
- [x] `bun run lint` — clean
- [x] `bun run type` — clean
- [x] `bun run test` — all packages green (one flaky DuckDB profiler timeout in `@atlas/cli` `fatal-error-propagation.test.ts` — passed cleanly on re-run, unrelated to this PR)
- [x] Syncpack, template drift, security headers drift, railway watch, schema drift, oauth helper drift — all green
- [ ] Manual verification on SaaS prod: a freshly-signed-up workspace at /admin/connections returns an empty list instead of the shared `default`/NovaMart row.