### PR TITLE
fix(web): #2487 — post-signup "Open Atlas" lands on workspace root

### DIFF
--- a/packages/web/src/app/login/page.tsx
+++ b/packages/web/src/app/login/page.tsx
@@ -247,6 +247,18 @@ export default function LoginPage() {
         setError(parseSignInError({ error: res.error, attemptedEmail: email }));
         return;
       }
+      // Force a session fetch before navigating so AuthGuard sees the
+      // just-established session on the next route; otherwise the in-memory
+      // store can still hold its pre-signin `null` snapshot and bounce us
+      // back to /login (#2487). The 2FA branch returns
+      // `twoFactorRedirect: true` (no session yet) — getSession is still safe
+      // there since it just returns null.
+      await authClient.getSession().catch((err: unknown) => {
+        console.debug(
+          "[login] getSession after signin failed:",
+          err instanceof Error ? err.message : String(err),
+        );
+      });
       router.push(getPostSignInRoute(res.data));
     } catch (err) {
       console.debug(

--- a/packages/web/src/app/login/page.tsx
+++ b/packages/web/src/app/login/page.tsx
@@ -247,19 +247,19 @@ export default function LoginPage() {
         setError(parseSignInError({ error: res.error, attemptedEmail: email }));
         return;
       }
-      // Force a session fetch before navigating so AuthGuard sees the
-      // just-established session on the next route; otherwise the in-memory
-      // store can still hold its pre-signin `null` snapshot and bounce us
-      // back to /login (#2487). The 2FA branch returns
-      // `twoFactorRedirect: true` (no session yet) — getSession is still safe
-      // there since it just returns null.
-      await authClient.getSession().catch((err: unknown) => {
-        console.debug(
-          "[login] getSession after signin failed:",
-          err instanceof Error ? err.message : String(err),
-        );
-      });
-      router.push(getPostSignInRoute(res.data));
+      const next = getPostSignInRoute(res.data);
+      // #2487: hydrate the Better Auth session store before navigating to a
+      // guarded route. Skip on the 2FA branch — no session exists yet and
+      // /login/two-factor doesn't gate on one.
+      if (next === "/") {
+        await authClient.getSession().catch((err: unknown) => {
+          console.warn(
+            "[login] getSession after signin failed:",
+            err instanceof Error ? err.message : String(err),
+          );
+        });
+      }
+      router.push(next);
     } catch (err) {
       console.debug(
         "Sign in failed:",

--- a/packages/web/src/app/signup/success/page.tsx
+++ b/packages/web/src/app/signup/success/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { authClient } from "@/lib/auth/client";
 import { Button } from "@/components/ui/button";
@@ -52,24 +51,20 @@ const STARTER_PROMPTS = [
 
 export default function SuccessPage() {
   const router = useRouter();
-  const [opening, setOpening] = useState(false);
 
-  // Force the Better Auth session store to fetch the just-established session
-  // before navigating to a guarded route. Without this, the in-memory store
-  // can hold the pre-signup `null` snapshot, AuthGuard reads `!isSignedIn`,
-  // and bounces the user to /login (#2487).
+  // #2487: hydrate the Better Auth session store before navigating to a
+  // guarded route. Without this, AuthGuard can read the pre-signup `null`
+  // snapshot and bounce the user back to /login.
   async function openAtlas(destination: string) {
-    setOpening(true);
     try {
       await authClient.getSession();
     } catch (err) {
-      console.debug(
+      console.warn(
         "[signup/success] getSession before navigate failed:",
         err instanceof Error ? err.message : String(err),
       );
-    } finally {
-      router.push(destination);
     }
+    router.push(destination);
   }
 
   return (
@@ -96,8 +91,7 @@ export default function SuccessPage() {
                   <button
                     type="button"
                     onClick={() => openAtlas(`/?prompt=${encodeURIComponent(prompt)}`)}
-                    disabled={opening}
-                    className="group flex w-full items-center justify-between gap-3 rounded-md border bg-card px-3 py-2.5 text-left text-sm transition-colors hover:border-primary/40 hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-60"
+                    className="group flex w-full items-center justify-between gap-3 rounded-md border bg-card px-3 py-2.5 text-left text-sm transition-colors hover:border-primary/40 hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                   >
                     <span>{prompt}</span>
                     <ArrowRight className="size-4 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5 group-hover:text-foreground" aria-hidden="true" />
@@ -107,13 +101,8 @@ export default function SuccessPage() {
             </ul>
           </section>
 
-          <Button
-            size="lg"
-            className="w-full"
-            disabled={opening}
-            onClick={() => openAtlas("/")}
-          >
-            {opening ? "Opening Atlas…" : "Open Atlas"}
+          <Button size="lg" className="w-full" onClick={() => openAtlas("/")}>
+            Open Atlas
           </Button>
 
           <section aria-labelledby="next-heading" className="space-y-3 border-t pt-6">

--- a/packages/web/src/app/signup/success/page.tsx
+++ b/packages/web/src/app/signup/success/page.tsx
@@ -1,6 +1,8 @@
 "use client";
 
+import { useState } from "react";
 import { useRouter } from "next/navigation";
+import { authClient } from "@/lib/auth/client";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -50,6 +52,25 @@ const STARTER_PROMPTS = [
 
 export default function SuccessPage() {
   const router = useRouter();
+  const [opening, setOpening] = useState(false);
+
+  // Force the Better Auth session store to fetch the just-established session
+  // before navigating to a guarded route. Without this, the in-memory store
+  // can hold the pre-signup `null` snapshot, AuthGuard reads `!isSignedIn`,
+  // and bounces the user to /login (#2487).
+  async function openAtlas(destination: string) {
+    setOpening(true);
+    try {
+      await authClient.getSession();
+    } catch (err) {
+      console.debug(
+        "[signup/success] getSession before navigate failed:",
+        err instanceof Error ? err.message : String(err),
+      );
+    } finally {
+      router.push(destination);
+    }
+  }
 
   return (
     <SignupShell step="done" width="wide">
@@ -74,8 +95,9 @@ export default function SuccessPage() {
                 <li key={prompt}>
                   <button
                     type="button"
-                    onClick={() => router.push(`/?prompt=${encodeURIComponent(prompt)}`)}
-                    className="group flex w-full items-center justify-between gap-3 rounded-md border bg-card px-3 py-2.5 text-left text-sm transition-colors hover:border-primary/40 hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                    onClick={() => openAtlas(`/?prompt=${encodeURIComponent(prompt)}`)}
+                    disabled={opening}
+                    className="group flex w-full items-center justify-between gap-3 rounded-md border bg-card px-3 py-2.5 text-left text-sm transition-colors hover:border-primary/40 hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-60"
                   >
                     <span>{prompt}</span>
                     <ArrowRight className="size-4 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5 group-hover:text-foreground" aria-hidden="true" />
@@ -85,8 +107,13 @@ export default function SuccessPage() {
             </ul>
           </section>
 
-          <Button size="lg" className="w-full" onClick={() => router.push("/")}>
-            Open Atlas
+          <Button
+            size="lg"
+            className="w-full"
+            disabled={opening}
+            onClick={() => openAtlas("/")}
+          >
+            {opening ? "Opening Atlas…" : "Open Atlas"}
           </Button>
 
           <section aria-labelledby="next-heading" className="space-y-3 border-t pt-6">


### PR DESCRIPTION
## Summary

Closes #2487. Two-line fix to a Better Auth client-store timing race:
the in-memory `useSession` store can hold its pre-mutation `null` snapshot for
one render after `signUp.email` / `signIn.email` succeeds, so `AuthGuard` sees
`!isSignedIn` on the next route and bounces the user to `/login`. Matt
reproduced this on both real-browser and Playwright sessions.

- **`/signup/success`** — wrap "Open Atlas" (and starter-prompt deep-links) in a handler that `await`s `authClient.getSession()` before `router.push("/")`, with a disabled / "Opening Atlas…" state while the round-trip is in flight.
- **`/login` email/password submit** — `await authClient.getSession()` between `signIn.email` resolving and `router.push(getPostSignInRoute(...))`. The same race was already documented for the 2FA branch in `post-sign-in-route.ts:4-9`; this generalises that fix.

Scope intentionally tight: the passkey and social-OAuth paths weren't called out in the bug report. They have the same structural shape and can get the same one-line treatment if they're observed in the wild.

## Test plan

- [ ] Fresh signup on a clean Chrome profile: enter the funnel, complete OTP, click "Open Atlas" on `/signup/success` → lands on `/` (no `/login` detour, no flash).
- [ ] Same flow but click a starter-prompt tile instead of "Open Atlas" → lands on `/?prompt=…` with the composer prefilled.
- [ ] Sign out, sign back in via email/password on `/login` → lands on `/` (no bounce back, no manual `/` navigation needed).
- [ ] 2FA-enrolled user signs in → still routes to `/login/two-factor` (the `twoFactorRedirect: true` branch is preserved; `getSession()` is a no-op there).
- [ ] `/ci` — lint, type, test, syncpack, template drift, security headers drift, railway watch, schema drift, oauth helper drift — all green locally.