### PR TITLE
fix(web): #2488 — cache headers prevent stale bundle sign-in failure

### DIFF
--- a/create-atlas/templates/docker/next.config.ts
+++ b/create-atlas/templates/docker/next.config.ts
@@ -91,10 +91,10 @@ const nextConfig: NextConfig = {
       {
         // App shell HTML (issue #2488): force revalidation so a new deploy
         // invalidates the bundle on the next navigation. The negative lookahead
-        // excludes `/_next/static/*` (handled below) and `/api/*` (owned by the
-        // Hono API — widget loader caches for a day, SSE streams set their own
-        // `no-cache, no-transform`). Path-to-regexp negative lookahead syntax;
-        // see Next.js headers() docs.
+        // excludes `/_next/static/*` (handled below) and `/api/*` (the Hono API
+        // owns its own Cache-Control on each route). Path-to-regexp lookahead
+        // anchors at position 0, so this only excludes paths *beginning with*
+        // `_next/static` or `api/` — not paths that merely contain them.
         source: "/((?!_next/static|api/).*)",
         headers: [
           {

--- a/create-atlas/templates/docker/next.config.ts
+++ b/create-atlas/templates/docker/next.config.ts
@@ -88,6 +88,35 @@ const nextConfig: NextConfig = {
           },
         ],
       },
+      {
+        // App shell HTML (issue #2488): force revalidation so a new deploy
+        // invalidates the bundle on the next navigation. The negative lookahead
+        // excludes `/_next/static/*` (handled below) and `/api/*` (owned by the
+        // Hono API — widget loader caches for a day, SSE streams set their own
+        // `no-cache, no-transform`). Path-to-regexp negative lookahead syntax;
+        // see Next.js headers() docs.
+        source: "/((?!_next/static|api/).*)",
+        headers: [
+          {
+            key: "Cache-Control",
+            value: "no-cache, must-revalidate",
+          },
+        ],
+      },
+      {
+        // Hashed asset URLs (`/_next/static/chunks/foo-<hash>.js`) are
+        // content-addressed and safe to cache forever. Next.js sets this by
+        // default for files it serves directly, but declaring it explicitly
+        // here keeps the policy stable regardless of how the standalone server
+        // is wrapped (Railway, Docker, reverse proxies).
+        source: "/_next/static/:path*",
+        headers: [
+          {
+            key: "Cache-Control",
+            value: "public, max-age=31536000, immutable",
+          },
+        ],
+      },
     ];
   },
   // SECURITY-HEADERS-END

--- a/create-atlas/templates/nextjs-standalone/next.config.ts
+++ b/create-atlas/templates/nextjs-standalone/next.config.ts
@@ -89,10 +89,10 @@ const nextConfig: NextConfig = {
       {
         // App shell HTML (issue #2488): force revalidation so a new deploy
         // invalidates the bundle on the next navigation. The negative lookahead
-        // excludes `/_next/static/*` (handled below) and `/api/*` (owned by the
-        // Hono API — widget loader caches for a day, SSE streams set their own
-        // `no-cache, no-transform`). Path-to-regexp negative lookahead syntax;
-        // see Next.js headers() docs.
+        // excludes `/_next/static/*` (handled below) and `/api/*` (the Hono API
+        // owns its own Cache-Control on each route). Path-to-regexp lookahead
+        // anchors at position 0, so this only excludes paths *beginning with*
+        // `_next/static` or `api/` — not paths that merely contain them.
         source: "/((?!_next/static|api/).*)",
         headers: [
           {

--- a/create-atlas/templates/nextjs-standalone/next.config.ts
+++ b/create-atlas/templates/nextjs-standalone/next.config.ts
@@ -86,6 +86,35 @@ const nextConfig: NextConfig = {
           },
         ],
       },
+      {
+        // App shell HTML (issue #2488): force revalidation so a new deploy
+        // invalidates the bundle on the next navigation. The negative lookahead
+        // excludes `/_next/static/*` (handled below) and `/api/*` (owned by the
+        // Hono API — widget loader caches for a day, SSE streams set their own
+        // `no-cache, no-transform`). Path-to-regexp negative lookahead syntax;
+        // see Next.js headers() docs.
+        source: "/((?!_next/static|api/).*)",
+        headers: [
+          {
+            key: "Cache-Control",
+            value: "no-cache, must-revalidate",
+          },
+        ],
+      },
+      {
+        // Hashed asset URLs (`/_next/static/chunks/foo-<hash>.js`) are
+        // content-addressed and safe to cache forever. Next.js sets this by
+        // default for files it serves directly, but declaring it explicitly
+        // here keeps the policy stable regardless of how the standalone server
+        // is wrapped (Railway, Docker, reverse proxies).
+        source: "/_next/static/:path*",
+        headers: [
+          {
+            key: "Cache-Control",
+            value: "public, max-age=31536000, immutable",
+          },
+        ],
+      },
     ];
   },
   // SECURITY-HEADERS-END

--- a/e2e/browser/production.spec.ts
+++ b/e2e/browser/production.spec.ts
@@ -49,6 +49,32 @@ test.describe("Production Smoke Tests", () => {
     await expect(page.getByRole("button", { name: /create account/i })).toBeVisible();
   });
 
+  test("app shell sets no-cache so deploys invalidate the bundle (#2488)", async ({ page }) => {
+    // Regression guard for #2488: without `no-cache, must-revalidate` on the
+    // entry HTML, tabs open across a Railway deploy still reference the old
+    // bundle's hashed chunks (which no longer exist) and sign-in breaks until
+    // a hard refresh. Asserts the runtime contract that the canonical
+    // `headers()` policy in packages/web/next.config.ts is meant to enforce.
+    const response = await page.goto(PROD_APP_URL);
+    expect(response).not.toBeNull();
+    const cacheControl = response!.headers()["cache-control"] ?? "";
+    expect(cacheControl).toMatch(/no-cache/);
+    expect(cacheControl).toMatch(/must-revalidate/);
+  });
+
+  test("hashed assets stay immutable (#2488)", async ({ request }) => {
+    // Companion to the no-cache assertion above: hashed chunks under
+    // /_next/static must remain long-cacheable. If a future config change
+    // accidentally widens the no-cache rule to cover them, page loads
+    // would balloon in download cost without any user-visible failure.
+    const shell = await request.get(PROD_APP_URL);
+    const html = await shell.text();
+    const match = html.match(/\/_next\/static\/[^"']+\.(?:js|css)/);
+    test.skip(!match, "no hashed asset reference found in shell");
+    const asset = await request.get(`${PROD_APP_URL}${match![0]}`);
+    expect(asset.headers()["cache-control"] ?? "").toMatch(/immutable/);
+  });
+
   test("API health endpoint returns ok", async ({ request }) => {
     const response = await request.get(`${PROD_API_URL}/api/health`);
     expect(response.status()).toBe(200);

--- a/examples/nextjs-standalone/next.config.ts
+++ b/examples/nextjs-standalone/next.config.ts
@@ -101,10 +101,10 @@ const nextConfig: NextConfig = {
       {
         // App shell HTML (issue #2488): force revalidation so a new deploy
         // invalidates the bundle on the next navigation. The negative lookahead
-        // excludes `/_next/static/*` (handled below) and `/api/*` (owned by the
-        // Hono API — widget loader caches for a day, SSE streams set their own
-        // `no-cache, no-transform`). Path-to-regexp negative lookahead syntax;
-        // see Next.js headers() docs.
+        // excludes `/_next/static/*` (handled below) and `/api/*` (the Hono API
+        // owns its own Cache-Control on each route). Path-to-regexp lookahead
+        // anchors at position 0, so this only excludes paths *beginning with*
+        // `_next/static` or `api/` — not paths that merely contain them.
         source: "/((?!_next/static|api/).*)",
         headers: [
           {

--- a/examples/nextjs-standalone/next.config.ts
+++ b/examples/nextjs-standalone/next.config.ts
@@ -98,6 +98,35 @@ const nextConfig: NextConfig = {
           },
         ],
       },
+      {
+        // App shell HTML (issue #2488): force revalidation so a new deploy
+        // invalidates the bundle on the next navigation. The negative lookahead
+        // excludes `/_next/static/*` (handled below) and `/api/*` (owned by the
+        // Hono API — widget loader caches for a day, SSE streams set their own
+        // `no-cache, no-transform`). Path-to-regexp negative lookahead syntax;
+        // see Next.js headers() docs.
+        source: "/((?!_next/static|api/).*)",
+        headers: [
+          {
+            key: "Cache-Control",
+            value: "no-cache, must-revalidate",
+          },
+        ],
+      },
+      {
+        // Hashed asset URLs (`/_next/static/chunks/foo-<hash>.js`) are
+        // content-addressed and safe to cache forever. Next.js sets this by
+        // default for files it serves directly, but declaring it explicitly
+        // here keeps the policy stable regardless of how the standalone server
+        // is wrapped (Railway, Docker, reverse proxies).
+        source: "/_next/static/:path*",
+        headers: [
+          {
+            key: "Cache-Control",
+            value: "public, max-age=31536000, immutable",
+          },
+        ],
+      },
     ];
   },
   // SECURITY-HEADERS-END

--- a/packages/web/next.config.ts
+++ b/packages/web/next.config.ts
@@ -49,7 +49,7 @@ const nextConfig: NextConfig = {
   typescript: { ignoreBuildErrors: true },
   transpilePackages: ["@useatlas/react"],
   turbopack: {},
-  // Security headers (issue #1984) — applied to all responses.
+  // Security + cache headers (issues #1984, #2488) — applied to all responses.
   //
   // - HSTS pins HTTPS for a year. `preload` advertises eligibility; submission
   //   is a separate operator decision.
@@ -66,7 +66,15 @@ const nextConfig: NextConfig = {
   // Browsers ignore X-Frame-Options when CSP `frame-ancestors` is present, so
   // setting both globally is safe — the embed override wins where it matches.
   //
-  // The `headers()` function below is the canonical security-header policy.
+  // Cache-Control (issue #2488): the entry HTML must never be served stale
+  // across deploys — a tab on the previous bundle would request hashed chunks
+  // that no longer exist, breaking sign-in until a hard refresh. Hashed asset
+  // URLs in `/_next/static/*` are content-addressed and stay `immutable`, so
+  // chunk caching is preserved. `/api/*` is excluded so the Hono API keeps
+  // ownership of its own Cache-Control (widget loader, SSE streams,
+  // `.well-known/openid-configuration`, etc.).
+  //
+  // The `headers()` function below is the canonical response-header policy.
   // It is mirrored byte-for-byte into the scaffold next.config.ts files —
   // see `scripts/check-security-headers-drift.sh`, which fails CI on drift.
   // SECURITY-HEADERS-START
@@ -125,6 +133,35 @@ const nextConfig: NextConfig = {
               }
               return replaced;
             })(),
+          },
+        ],
+      },
+      {
+        // App shell HTML (issue #2488): force revalidation so a new deploy
+        // invalidates the bundle on the next navigation. The negative lookahead
+        // excludes `/_next/static/*` (handled below) and `/api/*` (owned by the
+        // Hono API — widget loader caches for a day, SSE streams set their own
+        // `no-cache, no-transform`). Path-to-regexp negative lookahead syntax;
+        // see Next.js headers() docs.
+        source: "/((?!_next/static|api/).*)",
+        headers: [
+          {
+            key: "Cache-Control",
+            value: "no-cache, must-revalidate",
+          },
+        ],
+      },
+      {
+        // Hashed asset URLs (`/_next/static/chunks/foo-<hash>.js`) are
+        // content-addressed and safe to cache forever. Next.js sets this by
+        // default for files it serves directly, but declaring it explicitly
+        // here keeps the policy stable regardless of how the standalone server
+        // is wrapped (Railway, Docker, reverse proxies).
+        source: "/_next/static/:path*",
+        headers: [
+          {
+            key: "Cache-Control",
+            value: "public, max-age=31536000, immutable",
           },
         ],
       },

--- a/packages/web/next.config.ts
+++ b/packages/web/next.config.ts
@@ -139,10 +139,10 @@ const nextConfig: NextConfig = {
       {
         // App shell HTML (issue #2488): force revalidation so a new deploy
         // invalidates the bundle on the next navigation. The negative lookahead
-        // excludes `/_next/static/*` (handled below) and `/api/*` (owned by the
-        // Hono API — widget loader caches for a day, SSE streams set their own
-        // `no-cache, no-transform`). Path-to-regexp negative lookahead syntax;
-        // see Next.js headers() docs.
+        // excludes `/_next/static/*` (handled below) and `/api/*` (the Hono API
+        // owns its own Cache-Control on each route). Path-to-regexp lookahead
+        // anchors at position 0, so this only excludes paths *beginning with*
+        // `_next/static` or `api/` — not paths that merely contain them.
         source: "/((?!_next/static|api/).*)",
         headers: [
           {


### PR DESCRIPTION
## Summary

Fixes #2488. Tabs running a pre-deploy bundle fail to sign in after a Railway deploy until a hard refresh, because the entry HTML is cached and still references hashed chunks the new build no longer ships.

Two new rules added to the canonical `async headers()` in `packages/web/next.config.ts` (mirrored to all three scaffolds):

- `/((?!_next/static|api/).*)` → `Cache-Control: no-cache, must-revalidate` forces revalidation of the app shell on every navigation, so the next request after a deploy serves the fresh HTML that references the current chunk hashes. Negative lookahead excludes `/api/*` so the Hono API keeps ownership of its own Cache-Control (widget loader caches a day, SSE streams set their own no-cache, `.well-known/openid-configuration` has its own policy).
- `/_next/static/:path*` → `Cache-Control: public, max-age=31536000, immutable` keeps hashed assets long-cacheable. Next.js already sets this by default for files it serves directly; declaring it explicitly stabilises the policy regardless of how the standalone server is wrapped (Railway, Docker, reverse proxies).

The block stays inside the `SECURITY-HEADERS-START`/`-END` sentinels, so `scripts/check-security-headers-drift.sh` enforces parity across the canonical file and the three scaffold mirrors (`examples/nextjs-standalone`, `create-atlas/templates/docker`, `create-atlas/templates/nextjs-standalone`).

Service-worker alternative was rejected per the issue — mid-effort and changes the deploy mental model. `apps/www/next.config.ts` is `output: "export"` (static landing page, no sign-in) so it stays out of scope.

## Test plan

- [x] `bash scripts/check-security-headers-drift.sh` — all 3 mirrors match canonical
- [x] `bun run lint` / `bun run type` — clean
- [x] `bun run test` — full suite passes (api + web + others)
- [x] `bun run build` in `packages/web` — Next.js accepts the regex source pattern `/((?!_next/static|api/).*)`
- [x] Static eval of `headers()` returns the expected 4 rules in correct order (immutable rule positioned after the no-cache rule so later-rule-wins resolves any future overlap to immutable on `/_next/static/*`)
- [ ] **Manual on preview:** open the preview tab, push a follow-up commit to redeploy, attempt sign-in in the same tab — should succeed (the previous bundle's HTML revalidates and pulls the new chunk hashes).
- [ ] Confirm hashed asset responses still carry `Cache-Control: public, max-age=31536000, immutable` (DevTools Network panel).