### PR TITLE
refactor(api): #2482 — rebuild ConnectionRegistry from connections table on boot

### DIFF
--- a/packages/api/src/lib/auth/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/auth/__tests__/migrate.test.ts
@@ -115,8 +115,7 @@ describe("migrateAuthTables", () => {
     //   4. Execute baseline SQL
     //   5. INSERT migration record
     //   6. COMMIT
-    // Then seeds (prompt library, SLA thresholds, backup config) + loadPluginSettings + restoreAbuseState.
-    // loadSavedConnections moved to ConnectionsHydrateLive in lib/effect/layers.ts (#2482).
+    // Then seeds (prompt library, SLA thresholds, backup config) + loadPluginSettings + restoreAbuseState
     expect(queries.length).toBeGreaterThan(5);
 
     // Verify advisory lock acquired and tracking table created

--- a/packages/api/src/lib/auth/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/auth/__tests__/migrate.test.ts
@@ -115,7 +115,8 @@ describe("migrateAuthTables", () => {
     //   4. Execute baseline SQL
     //   5. INSERT migration record
     //   6. COMMIT
-    // Then seeds (prompt library, SLA thresholds, backup config) + loadSavedConnections + loadPluginSettings + restoreAbuseState
+    // Then seeds (prompt library, SLA thresholds, backup config) + loadPluginSettings + restoreAbuseState.
+    // loadSavedConnections moved to ConnectionsHydrateLive in lib/effect/layers.ts (#2482).
     expect(queries.length).toBeGreaterThan(5);
 
     // Verify advisory lock acquired and tracking table created

--- a/packages/api/src/lib/auth/migrate.ts
+++ b/packages/api/src/lib/auth/migrate.ts
@@ -95,13 +95,11 @@ export async function migrateAuthTables(): Promise<void> {
       // Don't block server start — audit will fall back to pino-only
     }
 
-    // 3. Load admin-managed connections (separate from migration so failures don't conflate)
-    try {
-      const { loadSavedConnections } = await import("@atlas/api/lib/db/internal");
-      await loadSavedConnections();
-    } catch (err) {
-      log.error({ err }, "Failed to load saved connections at startup — admin-managed connections unavailable");
-    }
+    // 3. Saved-connection hydrate moved to ConnectionsHydrateLive in
+    //    lib/effect/layers.ts (#2482). The Effect Layer DAG runs the
+    //    hydrate as a first-class boot phase after InternalDB +
+    //    Migration are up — keeping a duplicate call here would double-
+    //    fire decryption warnings on key-rotation errors.
 
     // Load plugin settings (enabled/disabled state from DB)
     try {

--- a/packages/api/src/lib/auth/migrate.ts
+++ b/packages/api/src/lib/auth/migrate.ts
@@ -36,7 +36,7 @@ export function getMigrationError(): string | null {
  *   1. Better Auth migrations — create `organization`, `user`, `session`, etc.
  *   2. Atlas internal DB migrations — can ALTER `organization` (e.g. 0027) now
  *      that Better Auth has created it.
- *   3. Load saved connections, plugin settings, abuse state.
+ *   3. Load plugin settings, abuse state.
  *   4. Bootstrap admin, seed dev user, backfill password-change flag.
  *
  * Step 1 must precede step 2 — see #1472. In non-managed mode step 1 is
@@ -94,12 +94,6 @@ export async function migrateAuthTables(): Promise<void> {
       _migrationError = "Connected to the internal database but migration failed. Check database permissions (CREATE TABLE, CREATE INDEX).";
       // Don't block server start — audit will fall back to pino-only
     }
-
-    // 3. Saved-connection hydrate moved to ConnectionsHydrateLive in
-    //    lib/effect/layers.ts (#2482). The Effect Layer DAG runs the
-    //    hydrate as a first-class boot phase after InternalDB +
-    //    Migration are up — keeping a duplicate call here would double-
-    //    fire decryption warnings on key-rotation errors.
 
     // Load plugin settings (enabled/disabled state from DB)
     try {

--- a/packages/api/src/lib/effect/__tests__/layers.test.ts
+++ b/packages/api/src/lib/effect/__tests__/layers.test.ts
@@ -7,7 +7,7 @@ import {
   Migration,
   MigrationLive,
   ConnectionsHydrate,
-  ConnectionsHydrateLive,
+  makeConnectionsHydrateLive,
   SemanticSync,
   SemanticSyncLive,
   Settings,
@@ -128,73 +128,82 @@ describe("MigrationLive", () => {
 // ── ConnectionsHydrate (#2482) ─────────────────────────────────────
 
 describe("ConnectionsHydrateLive", () => {
-  test("returns zero count when InternalDB is unavailable", async () => {
-    const testInternalDB = createInternalDBTestLayer({ available: false });
-    const testMigration = makeTestMigrationLayer({ migrated: true });
-
-    const result = await Effect.runPromise(
-      Effect.gen(function* () {
-        const hydrate = yield* ConnectionsHydrate;
-        return hydrate;
-      }).pipe(
-        Effect.provide(
-          ConnectionsHydrateLive.pipe(
-            Layer.provide(Layer.merge(testInternalDB, testMigration)),
-          ),
+  function runHydrate(
+    load: () => Promise<number>,
+    gates: { available: boolean; migrated: boolean },
+  ) {
+    const layer = makeConnectionsHydrateLive(load).pipe(
+      Layer.provide(
+        Layer.merge(
+          createInternalDBTestLayer({ available: gates.available }),
+          makeTestMigrationLayer({ migrated: gates.migrated }),
         ),
       ),
     );
+    return Effect.runPromise(
+      Effect.gen(function* () {
+        return yield* ConnectionsHydrate;
+      }).pipe(Effect.provide(layer)),
+    );
+  }
 
+  test("outcome 'skipped-gate' when InternalDB is unavailable", async () => {
+    const result = await runHydrate(
+      async () => {
+        throw new Error("load should not run when gates fail");
+      },
+      { available: false, migrated: true },
+    );
+    expect(result.outcome).toBe("skipped-gate");
     expect(result.count).toBe(0);
-    expect(typeof result.durationMs).toBe("number");
+    expect(result.error).toBeUndefined();
   });
 
-  test("returns zero count when Migration did not succeed", async () => {
-    const testInternalDB = createInternalDBTestLayer({ available: true });
-    const testMigration = makeTestMigrationLayer({ migrated: false });
-
-    const result = await Effect.runPromise(
-      Effect.gen(function* () {
-        const hydrate = yield* ConnectionsHydrate;
-        return hydrate;
-      }).pipe(
-        Effect.provide(
-          ConnectionsHydrateLive.pipe(
-            Layer.provide(Layer.merge(testInternalDB, testMigration)),
-          ),
-        ),
-      ),
+  test("outcome 'skipped-gate' when Migration did not succeed", async () => {
+    const result = await runHydrate(
+      async () => {
+        throw new Error("load should not run when gates fail");
+      },
+      { available: true, migrated: false },
     );
-
+    expect(result.outcome).toBe("skipped-gate");
     expect(result.count).toBe(0);
   });
 
-  test("invokes loadSavedConnections when upstream gates are satisfied", async () => {
-    // When InternalDB.available + Migration.migrated are both true, the
-    // Layer reaches the loadSavedConnections call. In this unit context
-    // there is no real DB so loadSavedConnections falls into its inner
-    // catch ("table may not exist yet") and returns 0 — the assertion
-    // we care about is "the layer ran end-to-end and produced a result".
-    const testInternalDB = createInternalDBTestLayer({ available: true });
-    const testMigration = makeTestMigrationLayer({ migrated: true });
+  test("outcome 'empty' when load returns zero rows", async () => {
+    const result = await runHydrate(async () => 0, {
+      available: true,
+      migrated: true,
+    });
+    expect(result.outcome).toBe("empty");
+    expect(result.count).toBe(0);
+    expect(result.error).toBeUndefined();
+  });
 
-    const result = await Effect.runPromise(
-      Effect.gen(function* () {
-        const hydrate = yield* ConnectionsHydrate;
-        return hydrate;
-      }).pipe(
-        Effect.provide(
-          ConnectionsHydrateLive.pipe(
-            Layer.provide(Layer.merge(testInternalDB, testMigration)),
-          ),
-        ),
-      ),
-    );
-
-    expect(typeof result.count).toBe("number");
-    expect(result.count).toBeGreaterThanOrEqual(0);
-    expect(typeof result.durationMs).toBe("number");
+  test("outcome 'registered' when load returns a positive count", async () => {
+    const result = await runHydrate(async () => 3, {
+      available: true,
+      migrated: true,
+    });
+    expect(result.outcome).toBe("registered");
+    expect(result.count).toBe(3);
     expect(result.durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  test("outcome 'error' when load throws — Effect.catchAll keeps boot non-fatal", async () => {
+    // Regression guard for the acceptance criterion "encryption-key rotation
+    // failures surface as logged warnings, not boot crash" — if a future
+    // refactor removes Effect.catchAll, this layer would fail and crash boot
+    // through buildAppLayer.
+    const result = await runHydrate(
+      async () => {
+        throw new Error("simulated hydrate failure");
+      },
+      { available: true, migrated: true },
+    );
+    expect(result.outcome).toBe("error");
+    expect(result.count).toBe(0);
+    expect(result.error).toContain("simulated hydrate failure");
   });
 });
 

--- a/packages/api/src/lib/effect/__tests__/layers.test.ts
+++ b/packages/api/src/lib/effect/__tests__/layers.test.ts
@@ -6,6 +6,8 @@ import {
   Config,
   Migration,
   MigrationLive,
+  ConnectionsHydrate,
+  ConnectionsHydrateLive,
   SemanticSync,
   SemanticSyncLive,
   Settings,
@@ -120,6 +122,79 @@ describe("MigrationLive", () => {
     );
 
     expect(result).toBe(false);
+  });
+});
+
+// ── ConnectionsHydrate (#2482) ─────────────────────────────────────
+
+describe("ConnectionsHydrateLive", () => {
+  test("returns zero count when InternalDB is unavailable", async () => {
+    const testInternalDB = createInternalDBTestLayer({ available: false });
+    const testMigration = makeTestMigrationLayer({ migrated: true });
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const hydrate = yield* ConnectionsHydrate;
+        return hydrate;
+      }).pipe(
+        Effect.provide(
+          ConnectionsHydrateLive.pipe(
+            Layer.provide(Layer.merge(testInternalDB, testMigration)),
+          ),
+        ),
+      ),
+    );
+
+    expect(result.count).toBe(0);
+    expect(typeof result.durationMs).toBe("number");
+  });
+
+  test("returns zero count when Migration did not succeed", async () => {
+    const testInternalDB = createInternalDBTestLayer({ available: true });
+    const testMigration = makeTestMigrationLayer({ migrated: false });
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const hydrate = yield* ConnectionsHydrate;
+        return hydrate;
+      }).pipe(
+        Effect.provide(
+          ConnectionsHydrateLive.pipe(
+            Layer.provide(Layer.merge(testInternalDB, testMigration)),
+          ),
+        ),
+      ),
+    );
+
+    expect(result.count).toBe(0);
+  });
+
+  test("invokes loadSavedConnections when upstream gates are satisfied", async () => {
+    // When InternalDB.available + Migration.migrated are both true, the
+    // Layer reaches the loadSavedConnections call. In this unit context
+    // there is no real DB so loadSavedConnections falls into its inner
+    // catch ("table may not exist yet") and returns 0 — the assertion
+    // we care about is "the layer ran end-to-end and produced a result".
+    const testInternalDB = createInternalDBTestLayer({ available: true });
+    const testMigration = makeTestMigrationLayer({ migrated: true });
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const hydrate = yield* ConnectionsHydrate;
+        return hydrate;
+      }).pipe(
+        Effect.provide(
+          ConnectionsHydrateLive.pipe(
+            Layer.provide(Layer.merge(testInternalDB, testMigration)),
+          ),
+        ),
+      ),
+    );
+
+    expect(typeof result.count).toBe("number");
+    expect(result.count).toBeGreaterThanOrEqual(0);
+    expect(typeof result.durationMs).toBe("number");
+    expect(result.durationMs).toBeGreaterThanOrEqual(0);
   });
 });
 
@@ -426,6 +501,7 @@ describe("buildAppLayer", () => {
         const telemetry = yield* Telemetry;
         const configSvc = yield* Config;
         const migration = yield* Migration;
+        const hydrate = yield* ConnectionsHydrate;
         const semanticSync = yield* SemanticSync;
         const settings = yield* Settings;
         const scheduler = yield* Scheduler;
@@ -433,6 +509,7 @@ describe("buildAppLayer", () => {
           hasTelemetry: typeof telemetry.shutdown === "function",
           hasConfig: configSvc.config != null,
           hasMigration: typeof migration.migrated === "boolean",
+          hasHydrate: typeof hydrate.count === "number",
           hasSync: typeof semanticSync.reconciled === "boolean",
           hasSettings: typeof settings.loaded === "number",
           hasScheduler: typeof scheduler.backend === "string",
@@ -443,6 +520,7 @@ describe("buildAppLayer", () => {
     expect(result.hasTelemetry).toBe(true);
     expect(result.hasConfig).toBe(true);
     expect(result.hasMigration).toBe(true);
+    expect(result.hasHydrate).toBe(true);
     expect(result.hasSync).toBe(true);
     expect(result.hasSettings).toBe(true);
     expect(result.hasScheduler).toBe(true);

--- a/packages/api/src/lib/effect/layers.ts
+++ b/packages/api/src/lib/effect/layers.ts
@@ -296,11 +296,28 @@ export const BackfillSaasTrialLive: Layer.Layer<
 // ██  Connections Hydrate Layer
 // ══════════════════════════════════════════════════════════════════════
 
+/**
+ * Discriminated outcome of the boot-time hydrate. Distinguishes
+ * "registry intentionally left empty" (skipped or no rows) from
+ * "hydrate threw and registry is empty when it shouldn't be" so a
+ * future `/health` or admin banner consumer can surface the latter
+ * without re-grepping logs.
+ */
+export type ConnectionsHydrateOutcome =
+  | "skipped-gate"
+  | "empty"
+  | "registered"
+  | "error";
+
 export interface ConnectionsHydrateShape {
-  /** Number of connections registered into the runtime registry at boot. */
+  /** Number of connections registered into the runtime registry. */
   readonly count: number;
-  /** Wall-clock duration in ms of the hydrate operation. */
+  /** Wall-clock duration in ms. */
   readonly durationMs: number;
+  /** Discriminates intentional zero (skip / empty) from a failure that produced zero. */
+  readonly outcome: ConnectionsHydrateOutcome;
+  /** Scrubbed error message when `outcome === "error"`. */
+  readonly error?: string;
 }
 
 export class ConnectionsHydrate extends Context.Tag("ConnectionsHydrate")<
@@ -309,21 +326,23 @@ export class ConnectionsHydrate extends Context.Tag("ConnectionsHydrate")<
 >() {}
 
 /**
+ * Production loader. The Layer body is testable by passing a stub via
+ * `makeConnectionsHydrateLive(load)`; the default loader does the real
+ * dynamic import + DB read.
+ */
+const defaultLoadSavedConnections = async (): Promise<number> => {
+  const { loadSavedConnections } = await import(
+    "@atlas/api/lib/db/internal"
+  );
+  return loadSavedConnections();
+};
+
+/**
  * Rebuild the runtime `ConnectionRegistry` from the internal `connections`
  * table at boot. Reads every non-archived row, decrypts the URL via
  * `decryptSecret`, and calls `connections.register(id, ...)` so that
  * immediately after a deploy the in-memory registry matches the DB
  * without any user PUT/onboarding round-trip.
- *
- * Without this Layer, every `connections.register(...)` site lives inside
- * a user-driven write path. After any API restart (Railway deploy,
- * region failover, autoscale event) the runtime registry stays empty
- * until users re-touch each connection one-by-one — meanwhile the rows
- * are still in the DB, `getVisibleConnectionIds` still returns them,
- * and `/admin/connections` shows "No datasource connections" because
- * visible-set ∩ in-memory-set is empty. Plausibly the root cause of
- * #2444; the defensive `Array.isArray` guard in #2445 papered over the
- * symptom, this fixes the underlying gap (#2482).
  *
  * Depends on `Migration` (so the `connections` table is guaranteed to
  * exist) and `InternalDB` (for the pool). Non-fatal: per-row decryption
@@ -332,61 +351,81 @@ export class ConnectionsHydrate extends Context.Tag("ConnectionsHydrate")<
  * `status != 'archived'` filter so the per-org tombstone rows from the
  * delete-as-hide flow in `admin-connections.ts` don't feed their
  * empty-string `url` marker to `decryptSecret`.
+ *
+ * Exposed as a factory so tests can inject a stub `load` to exercise
+ * the `Effect.catchAll` branch without module-level mocking. The
+ * exported `ConnectionsHydrateLive` binds the production loader.
  */
+export function makeConnectionsHydrateLive(
+  load: () => Promise<number> = defaultLoadSavedConnections,
+): Layer.Layer<ConnectionsHydrate, never, InternalDB | Migration> {
+  return Layer.effect(
+    ConnectionsHydrate,
+    Effect.gen(function* () {
+      const start = performance.now();
+      const db = yield* InternalDB;
+      const migration = yield* Migration;
+      if (!db.available || !migration.migrated) {
+        const durationMs = Math.round(performance.now() - start);
+        log.info(
+          { available: db.available, migrated: migration.migrated, durationMs },
+          "Connections hydrate skipped — upstream gate (InternalDB or Migration) not satisfied",
+        );
+        return {
+          count: 0,
+          durationMs,
+          outcome: "skipped-gate",
+        } satisfies ConnectionsHydrateShape;
+      }
+
+      const result = yield* Effect.tryPromise({
+        try: load,
+        catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+      }).pipe(
+        Effect.map((count) => ({ ok: true as const, count })),
+        Effect.catchAll((err) =>
+          Effect.sync(() => {
+            const message = errorMessage(err);
+            log.error({ err: message }, "Connections hydrate threw — runtime registry left empty");
+            return { ok: false as const, error: message };
+          }),
+        ),
+      );
+      const durationMs = Math.round(performance.now() - start);
+
+      if (!result.ok) {
+        return {
+          count: 0,
+          durationMs,
+          outcome: "error",
+          error: result.error,
+        } satisfies ConnectionsHydrateShape;
+      }
+
+      if (result.count > 0) {
+        log.info(
+          { count: result.count, durationMs },
+          "Hydrated runtime ConnectionRegistry from internal DB",
+        );
+        return {
+          count: result.count,
+          durationMs,
+          outcome: "registered",
+        } satisfies ConnectionsHydrateShape;
+      }
+
+      log.debug({ durationMs }, "Connections hydrate complete — no rows registered");
+      return { count: 0, durationMs, outcome: "empty" } satisfies ConnectionsHydrateShape;
+    }),
+  );
+}
+
+/** Production binding — uses the real `loadSavedConnections()` from `db/internal.ts`. */
 export const ConnectionsHydrateLive: Layer.Layer<
   ConnectionsHydrate,
   never,
   InternalDB | Migration
-> = Layer.effect(
-  ConnectionsHydrate,
-  Effect.gen(function* () {
-    const db = yield* InternalDB;
-    const migration = yield* Migration;
-    if (!db.available || !migration.migrated) {
-      log.info(
-        { available: db.available, migrated: migration.migrated },
-        "Connections hydrate skipped — upstream gate (InternalDB or Migration) not satisfied",
-      );
-      return { count: 0, durationMs: 0 } satisfies ConnectionsHydrateShape;
-    }
-
-    const start = performance.now();
-    const count = yield* Effect.tryPromise({
-      try: async () => {
-        const { loadSavedConnections } = await import(
-          "@atlas/api/lib/db/internal"
-        );
-        return await loadSavedConnections();
-      },
-      catch: (err) => (err instanceof Error ? err : new Error(String(err))),
-    }).pipe(
-      Effect.catchAll((err) =>
-        Effect.sync(() => {
-          log.error(
-            { err: errorMessage(err) },
-            "Connections hydrate threw — runtime registry left empty",
-          );
-          return 0;
-        }),
-      ),
-    );
-    const durationMs = Math.round(performance.now() - start);
-
-    if (count > 0) {
-      log.info(
-        { count, durationMs },
-        "Hydrated runtime ConnectionRegistry from internal DB",
-      );
-    } else {
-      log.debug(
-        { durationMs },
-        "Connections hydrate complete — no rows registered",
-      );
-    }
-
-    return { count, durationMs } satisfies ConnectionsHydrateShape;
-  }),
-);
+> = makeConnectionsHydrateLive();
 
 // ══════════════════════════════════════════════════════════════════════
 // ██  Semantic Sync Layer
@@ -1123,11 +1162,6 @@ export function buildAppLayer(config: ResolvedConfig): Layer.Layer<
     Layer.provide(Layer.merge(internalDBLayer, migrationLayer)),
   );
 
-  // ConnectionsHydrateLive depends on Migration (so the `connections`
-  // table is guaranteed to exist) and InternalDB. Rebuilds the runtime
-  // ConnectionRegistry from the internal DB so the registry mirrors the
-  // table after a deploy without waiting for users to re-touch each
-  // connection. See #2482.
   const connectionsHydrateLayer = ConnectionsHydrateLive.pipe(
     Layer.provide(Layer.merge(internalDBLayer, migrationLayer)),
   );

--- a/packages/api/src/lib/effect/layers.ts
+++ b/packages/api/src/lib/effect/layers.ts
@@ -10,13 +10,14 @@
  *
  *   InternalDBLayer         (no deps — creates pg.Pool via PgClient.layerFromPool)
  *   MigrationLayer          (depends on InternalDB — pool must be ready first)
+ *   ConnectionsHydrateLayer (depends on InternalDB + Migration — connections table must exist)
  *   TelemetryLayer          (no deps)
  *   ConfigLayer             (no deps — receives pre-resolved config via Layer.succeed)
  *   SemanticSyncLayer       (no deps)
  *   SettingsLayer           (no deps)
  *   SchedulerLayer          (no deps — receives config as function param)
  *
- *   AppLayer = mergeAll(Telemetry, Config, InternalDB, Migration, SemanticSync, Settings, Scheduler)
+ *   AppLayer = mergeAll(Telemetry, Config, InternalDB, Migration, ConnectionsHydrate, SemanticSync, Settings, Scheduler)
  *
  * Note: ConnectionLayer (P4) and PluginLayer (P5) live in services.ts
  * and are not yet part of AppLayer — they are wired imperatively in server.ts.
@@ -288,6 +289,102 @@ export const BackfillSaasTrialLive: Layer.Layer<
     );
 
     return { updatedCount: result.updatedCount } satisfies BackfillSaasTrialShape;
+  }),
+);
+
+// ══════════════════════════════════════════════════════════════════════
+// ██  Connections Hydrate Layer
+// ══════════════════════════════════════════════════════════════════════
+
+export interface ConnectionsHydrateShape {
+  /** Number of connections registered into the runtime registry at boot. */
+  readonly count: number;
+  /** Wall-clock duration in ms of the hydrate operation. */
+  readonly durationMs: number;
+}
+
+export class ConnectionsHydrate extends Context.Tag("ConnectionsHydrate")<
+  ConnectionsHydrate,
+  ConnectionsHydrateShape
+>() {}
+
+/**
+ * Rebuild the runtime `ConnectionRegistry` from the internal `connections`
+ * table at boot. Reads every non-archived row, decrypts the URL via
+ * `decryptSecret`, and calls `connections.register(id, ...)` so that
+ * immediately after a deploy the in-memory registry matches the DB
+ * without any user PUT/onboarding round-trip.
+ *
+ * Without this Layer, every `connections.register(...)` site lives inside
+ * a user-driven write path. After any API restart (Railway deploy,
+ * region failover, autoscale event) the runtime registry stays empty
+ * until users re-touch each connection one-by-one — meanwhile the rows
+ * are still in the DB, `getVisibleConnectionIds` still returns them,
+ * and `/admin/connections` shows "No datasource connections" because
+ * visible-set ∩ in-memory-set is empty. Plausibly the root cause of
+ * #2444; the defensive `Array.isArray` guard in #2445 papered over the
+ * symptom, this fixes the underlying gap (#2482).
+ *
+ * Depends on `Migration` (so the `connections` table is guaranteed to
+ * exist) and `InternalDB` (for the pool). Non-fatal: per-row decryption
+ * failures (key rotation, corrupted ciphertext) log a warning and skip
+ * the row — they never crash boot. The query also includes a
+ * `status != 'archived'` filter so the per-org tombstone rows from the
+ * delete-as-hide flow in `admin-connections.ts` don't feed their
+ * empty-string `url` marker to `decryptSecret`.
+ */
+export const ConnectionsHydrateLive: Layer.Layer<
+  ConnectionsHydrate,
+  never,
+  InternalDB | Migration
+> = Layer.effect(
+  ConnectionsHydrate,
+  Effect.gen(function* () {
+    const db = yield* InternalDB;
+    const migration = yield* Migration;
+    if (!db.available || !migration.migrated) {
+      log.info(
+        { available: db.available, migrated: migration.migrated },
+        "Connections hydrate skipped — upstream gate (InternalDB or Migration) not satisfied",
+      );
+      return { count: 0, durationMs: 0 } satisfies ConnectionsHydrateShape;
+    }
+
+    const start = performance.now();
+    const count = yield* Effect.tryPromise({
+      try: async () => {
+        const { loadSavedConnections } = await import(
+          "@atlas/api/lib/db/internal"
+        );
+        return await loadSavedConnections();
+      },
+      catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+    }).pipe(
+      Effect.catchAll((err) =>
+        Effect.sync(() => {
+          log.error(
+            { err: errorMessage(err) },
+            "Connections hydrate threw — runtime registry left empty",
+          );
+          return 0;
+        }),
+      ),
+    );
+    const durationMs = Math.round(performance.now() - start);
+
+    if (count > 0) {
+      log.info(
+        { count, durationMs },
+        "Hydrated runtime ConnectionRegistry from internal DB",
+      );
+    } else {
+      log.debug(
+        { durationMs },
+        "Connections hydrate complete — no rows registered",
+      );
+    }
+
+    return { count, durationMs } satisfies ConnectionsHydrateShape;
   }),
 );
 
@@ -1009,7 +1106,7 @@ export const MigrationGuardLive: Layer.Layer<never, MigrationsRequiredError, Con
  * Connection and plugin shutdown is handled imperatively in server.ts.
  */
 export function buildAppLayer(config: ResolvedConfig): Layer.Layer<
-  Telemetry | Config | InternalDB | Migration | BackfillSaasTrial | SemanticSync | Settings | Scheduler,
+  Telemetry | Config | InternalDB | Migration | BackfillSaasTrial | ConnectionsHydrate | SemanticSync | Settings | Scheduler,
   Error
 > {
   const configLayer = Layer.succeed(Config, { config });
@@ -1023,6 +1120,15 @@ export function buildAppLayer(config: ResolvedConfig): Layer.Layer<
   // the other layers — Effect's mergeAll doesn't order independent
   // siblings, so the only real ordering is the Migration dependency.
   const backfillSaasTrialLayer = BackfillSaasTrialLive.pipe(
+    Layer.provide(Layer.merge(internalDBLayer, migrationLayer)),
+  );
+
+  // ConnectionsHydrateLive depends on Migration (so the `connections`
+  // table is guaranteed to exist) and InternalDB. Rebuilds the runtime
+  // ConnectionRegistry from the internal DB so the registry mirrors the
+  // table after a deploy without waiting for users to re-touch each
+  // connection. See #2482.
+  const connectionsHydrateLayer = ConnectionsHydrateLive.pipe(
     Layer.provide(Layer.merge(internalDBLayer, migrationLayer)),
   );
 
@@ -1065,6 +1171,7 @@ export function buildAppLayer(config: ResolvedConfig): Layer.Layer<
     internalDBLayer,
     migrationLayer,
     backfillSaasTrialLayer,
+    connectionsHydrateLayer,
     semanticSyncLayer,
     settingsLayer,
     schedulerLayer,


### PR DESCRIPTION
## Summary

- Lift the saved-connection hydrate into a first-class Effect Layer (`ConnectionsHydrateLive`) in the boot DAG so that immediately after an API restart the runtime `ConnectionRegistry` matches the internal `connections` table — no user PUT/onboarding round-trip required.
- Depends on `InternalDB` + `Migration` so the `connections` table is guaranteed to exist before the hydrate runs. Per-row decryption failures (key rotation, corrupted ciphertext) log a warning and skip the row rather than crashing boot. Tombstone rows (`status = 'archived'`) are skipped by the existing query filter.
- Remove the previous `loadSavedConnections()` call from `migrateAuthTables()` — it was buried under the auth migration path and easy to miss in the AppLayer view. The new Layer is the single canonical caller; double-firing decryption warnings on key-rotation errors goes away.

Closes #2482.

## Why this matters

Every `connections.register(...)` site lives inside a user-driven write path (POST/PUT/onboarding). Without an explicit boot-time hydrate, after any API restart (Railway deploy, region failover, autoscale) the in-memory registry is empty until users re-touch each connection — meanwhile the DB still has the rows, `getVisibleConnectionIds` still returns them, and `/admin/connections` shows "No datasource connections" because the visible-set ∩ in-memory-set is empty.

## Test plan

- [x] `bun run scripts/test-isolated.ts --affected` — 15/15 affected tests pass
- [x] Full `packages/api` suite — 384/384 isolated tests pass
- [x] `bun run test:others` — all workspace test suites pass
- [x] `bun run lint` — no new errors
- [x] `bun run type` — clean
- [x] `bash scripts/check-template-drift.sh` — clean
- [x] `bash scripts/check-schema-drift.sh` — clean
- [x] `bun x syncpack lint` — no issues