### PR TITLE
fix(web): #2485 — Add Connection dialog surfaces 429 + structured errors

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -91,6 +91,11 @@ ATLAS_ADMIN_EMAIL=admin@useatlas.dev
 #                                         # Defaults to max(5, RPM/4) so a 25-step LLM call does not deplete
 #                                         # the same allowance that serves audit-log scrolling and similar
 #                                         # cheap reads. Disabled when ATLAS_RATE_LIMIT_RPM is 0.
+# ATLAS_RATE_LIMIT_RPM_ADMIN=              # Admin namespace RPM ceiling, separate bucket from cheap reads
+#                                         # (#2485). Defaults to max(60, RPM) so an interactive admin
+#                                         # session (DELETE + Test + Add Connection) does not throttle
+#                                         # on a low base RPM tuned for public traffic.
+#                                         # Disabled when ATLAS_RATE_LIMIT_RPM is 0.
 # ATLAS_TRUST_PROXY=false                 # Trust X-Forwarded-For for client IP (set "true" behind a reverse proxy).
 #                                         # Public-share routes bucket all anonymous (no-IP) requests into a
 #                                         # single 10/min ceiling when this is unset (F-73).

--- a/apps/docs/content/docs/guides/rate-limiting.mdx
+++ b/apps/docs/content/docs/guides/rate-limiting.mdx
@@ -28,7 +28,9 @@ Control how many requests each user can make per minute. This is a sliding-windo
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `ATLAS_RATE_LIMIT_RPM` | `0` (disabled) | Max requests per minute per user. `0` or unset = unlimited |
+| `ATLAS_RATE_LIMIT_RPM` | `0` (disabled) | Max requests per minute per user (default bucket). `0` or unset = unlimited |
+| `ATLAS_RATE_LIMIT_RPM_CHAT` | `max(5, RPM/4)` | Chat-stream RPM ceiling — separate bucket so a 25-step LLM call doesn't deplete the cheap-read allowance |
+| `ATLAS_RATE_LIMIT_RPM_ADMIN` | `max(60, RPM)` | Admin namespace RPM ceiling — separate bucket so a sequence of DELETE + Test + Add Connection (#2485) doesn't deplete the cheap-read allowance |
 | `ATLAS_TRUST_PROXY` | `false` | Trust `X-Forwarded-For` / `X-Real-IP` headers for client IP detection |
 
 ```bash
@@ -44,6 +46,18 @@ Rate limit keys are resolved in order: authenticated user ID, then forwarded IP 
 </Callout>
 
 Rate limiting is **disabled by default**. When enabled, it covers the primary API routes: `/api/chat`, `/api/v1/query`, `/api/v1/conversations`, `/api/v1/admin/*`, `/api/v1/semantic/*`, `/api/v1/scheduled-tasks`, and `/api/v1/actions`. Health, auth, widget, and OpenAPI spec endpoints are exempt.
+
+### Per-bucket isolation
+
+Each caller has three independent sliding windows keyed on the same identity (user ID or IP). Hitting one bucket's ceiling never throttles the others:
+
+| Bucket | Routes | Why it's separate |
+|--------|--------|-------------------|
+| `default` | `/api/chat` rate-check, `/api/v1/query`, `/api/v1/conversations`, public reads | Baseline; tuned by `ATLAS_RATE_LIMIT_RPM` |
+| `chat` | `/api/chat` stream (per-call) | A 25-step LLM tool-use loop fires many requests in a row — without isolation it would deplete the default bucket and lock out the same caller's cheap reads (F-74) |
+| `admin` | `/api/v1/admin/*`, `/api/v1/platform/*` | Interactive admin forms (Add / Test / Delete in quick succession) burst easily past a public-traffic ceiling — without isolation a dogfood session at 30 RPM throttles after ~12 clicks (#2485) |
+
+The admin bucket defaults to a floor of 60 RPM (one per second), which keeps an interactive admin session from running out of budget even on a deployment with a tight `ATLAS_RATE_LIMIT_RPM`. Tune `ATLAS_RATE_LIMIT_RPM_ADMIN` directly if your workspace has tighter or looser admin-traffic needs.
 
 ### Per-Datasource Rate Limiting
 

--- a/apps/docs/content/docs/guides/rate-limiting.mdx
+++ b/apps/docs/content/docs/guides/rate-limiting.mdx
@@ -45,7 +45,7 @@ ATLAS_TRUST_PROXY=true
 Rate limit keys are resolved in order: authenticated user ID, then forwarded IP (if `ATLAS_TRUST_PROXY=true`), then a shared `anon` bucket. Without `ATLAS_TRUST_PROXY`, all proxied users share the same key.
 </Callout>
 
-Rate limiting is **disabled by default**. When enabled, it covers the primary API routes: `/api/chat`, `/api/v1/query`, `/api/v1/conversations`, `/api/v1/admin/*`, `/api/v1/semantic/*`, `/api/v1/scheduled-tasks`, and `/api/v1/actions`. Health, auth, widget, and OpenAPI spec endpoints are exempt.
+Rate limiting is **disabled by default**. When enabled, it covers the primary API routes: `/api/v1/chat`, `/api/v1/query`, `/api/v1/conversations`, `/api/v1/admin/*`, `/api/v1/semantic/*`, `/api/v1/scheduled-tasks`, and `/api/v1/actions`. Health, auth, widget, and OpenAPI spec endpoints are exempt.
 
 ### Per-bucket isolation
 
@@ -53,11 +53,11 @@ Each caller has three independent sliding windows keyed on the same identity (us
 
 | Bucket | Routes | Why it's separate |
 |--------|--------|-------------------|
-| `default` | `/api/chat` rate-check, `/api/v1/query`, `/api/v1/conversations`, public reads | Baseline; tuned by `ATLAS_RATE_LIMIT_RPM` |
-| `chat` | `/api/chat` stream (per-call) | A 25-step LLM tool-use loop fires many requests in a row — without isolation it would deplete the default bucket and lock out the same caller's cheap reads (F-74) |
-| `admin` | `/api/v1/admin/*`, `/api/v1/platform/*` | Interactive admin forms (Add / Test / Delete in quick succession) burst easily past a public-traffic ceiling — without isolation a dogfood session at 30 RPM throttles after ~12 clicks (#2485) |
+| `default` | `/api/v1/query`, `/api/v1/conversations`, `/api/v1/semantic/*`, `/api/v1/scheduled-tasks`, `/api/v1/actions`, `/api/v1/me/*`, public reads | Baseline; tuned by `ATLAS_RATE_LIMIT_RPM` |
+| `chat` | `/api/v1/chat` (per-call) | A 25-step LLM tool-use loop fires many requests in a row — without isolation it would deplete the default bucket and lock out the same caller's cheap reads (F-74) |
+| `admin` | `/api/v1/admin/*`, `/api/v1/platform/*` | Interactive admin forms (Add / Test / Delete in quick succession) burst well past a public-traffic ceiling — without isolation a single Add/Edit Connection session can throttle on a tight base RPM (#2485) |
 
-The admin bucket defaults to a floor of 60 RPM (one per second), which keeps an interactive admin session from running out of budget even on a deployment with a tight `ATLAS_RATE_LIMIT_RPM`. Tune `ATLAS_RATE_LIMIT_RPM_ADMIN` directly if your workspace has tighter or looser admin-traffic needs.
+The admin bucket defaults to `max(60, ATLAS_RATE_LIMIT_RPM)` — at least one request per second, and tracking the base RPM above that — so an interactive admin session never runs out of budget on a deployment with a tight base limit. Tune `ATLAS_RATE_LIMIT_RPM_ADMIN` directly if your workspace has different admin-traffic needs.
 
 ### Per-Datasource Rate Limiting
 

--- a/packages/api/src/api/routes/__tests__/middleware-trust-device.test.ts
+++ b/packages/api/src/api/routes/__tests__/middleware-trust-device.test.ts
@@ -29,10 +29,21 @@ const platformUser = {
 
 let authUser: typeof adminUser | typeof platformUser = adminUser;
 
+// Records calls to `checkRateLimit` so the bucket-routing tests at the
+// bottom of this file can assert which bucket each middleware debits.
+// Populated by every middleware run; `beforeEach` resets it.
+const checkRateLimitCalls: Array<{
+  key: string;
+  options?: { bucket?: string };
+}> = [];
+
 mock.module("@atlas/api/lib/auth/middleware", () => ({
   authenticateRequest: () =>
     Promise.resolve({ authenticated: true, mode: "managed", user: authUser }),
-  checkRateLimit: () => ({ allowed: true }),
+  checkRateLimit: (key: string, options?: { bucket?: string }) => {
+    checkRateLimitCalls.push({ key, options });
+    return { allowed: true };
+  },
   getClientIP: () => "10.0.0.1",
   resetRateLimits: () => {},
   rateLimitCleanupTick: () => {},
@@ -128,6 +139,7 @@ function buildRequest(cookieHeader: string | null): Request {
 beforeEach(() => {
   authUser = adminUser;
   withRequestContextCalls = [];
+  checkRateLimitCalls.length = 0;
 });
 
 // ---------------------------------------------------------------------------
@@ -276,5 +288,51 @@ describe("withRequestId — populates trustDeviceIdentifier on Hono context + AL
     const lastCall =
       withRequestContextCalls[withRequestContextCalls.length - 1];
     expect(lastCall.trustDeviceIdentifier).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #2485 — admin bucket wiring regression pin
+// ---------------------------------------------------------------------------
+
+/**
+ * Locks the bucket each auth middleware passes to `checkRateLimit`.
+ * Without this, a refactor that drops the `"admin"` arg from
+ * `rateLimitAndIPCheck`'s call sites in `adminAuth` / `platformAdminAuth`
+ * would silently regress #2485 — the bucket-primitive isolation tests
+ * in `lib/auth/__tests__/middleware.test.ts` exercise `checkRateLimit`
+ * directly and would all stay green even with the wiring broken.
+ * Mirrors the F-74 chat-bucket pin in `api/__tests__/chat.test.ts`.
+ */
+describe("auth middleware → checkRateLimit bucket routing (#2485, F-74)", () => {
+  it("adminAuth debits the admin bucket", async () => {
+    const c = fakeContext(buildRequest(null));
+
+    await adminAuth(c as never, async () => {});
+
+    expect(checkRateLimitCalls.length).toBe(1);
+    expect(checkRateLimitCalls[0]!.options).toEqual({ bucket: "admin" });
+  });
+
+  it("platformAdminAuth debits the admin bucket", async () => {
+    authUser = platformUser;
+    const c = fakeContext(buildRequest(null));
+
+    await platformAdminAuth(c as never, async () => {});
+
+    expect(checkRateLimitCalls.length).toBe(1);
+    expect(checkRateLimitCalls[0]!.options).toEqual({ bucket: "admin" });
+  });
+
+  it("standardAuth debits the default bucket (no options arg)", async () => {
+    const c = fakeContext(buildRequest(null));
+
+    await standardAuth(c as never, async () => {});
+
+    // `rateLimitAndIPCheck` calls `checkRateLimit(key, { bucket: "default" })`
+    // when invoked without an explicit bucket — the parameter default
+    // turns into an explicit option object at the call site.
+    expect(checkRateLimitCalls.length).toBe(1);
+    expect(checkRateLimitCalls[0]!.options).toEqual({ bucket: "default" });
   });
 });

--- a/packages/api/src/api/routes/middleware.ts
+++ b/packages/api/src/api/routes/middleware.ts
@@ -22,6 +22,7 @@ import {
   authenticateRequest,
   checkRateLimit,
   getClientIP,
+  type RateLimitBucket,
 } from "@atlas/api/lib/auth/middleware";
 import { extractTrustDeviceIdentifier } from "@atlas/api/lib/auth/trust-device-cookie";
 import {
@@ -121,10 +122,11 @@ async function rateLimitAndIPCheck(
   req: Request,
   authResult: AuthResult & { authenticated: true },
   requestId: string,
+  bucket: RateLimitBucket = "default",
 ): Promise<{ body: Record<string, unknown>; status: number; headers?: Record<string, string> } | null> {
   const ip = getClientIP(req);
   const rateLimitKey = authResult.user?.id ?? (ip ? `ip:${ip}` : "anon");
-  const rateCheck = checkRateLimit(rateLimitKey);
+  const rateCheck = checkRateLimit(rateLimitKey, { bucket });
   if (!rateCheck.allowed) {
     const retryAfterSeconds = Math.ceil((rateCheck.retryAfterMs ?? 60000) / 1000);
     return {
@@ -266,7 +268,11 @@ export const adminAuth = createMiddleware<AuthEnv>(async (c, next) => {
     return c.json({ error: "forbidden_role", message: "Admin role required.", requestId }, 403);
   }
 
-  const blocked = await rateLimitAndIPCheck(c.req.raw, authResult, requestId);
+  // Admin namespace gets its own rate-limit bucket (#2485). Interactive
+  // forms (Add Connection, Test, Delete in quick succession) burst easily
+  // past a low base RPM; bucketing them separately keeps a dogfood session
+  // from depleting the cheap-read budget shared with chat.
+  const blocked = await rateLimitAndIPCheck(c.req.raw, authResult, requestId, "admin");
   if (blocked) {
     return c.json(blocked.body, blocked.status as 429, blocked.headers);
   }
@@ -317,7 +323,9 @@ export const platformAdminAuth = createMiddleware<AuthEnv>(async (c, next) => {
     return c.json({ error: "forbidden_role", message: "Platform admin role required.", requestId }, 403);
   }
 
-  const blocked = await rateLimitAndIPCheck(c.req.raw, authResult, requestId);
+  // Platform admin shares the admin bucket — same interactive-form access
+  // pattern (#2485). Cross-tenant operations still rate-limit per identity.
+  const blocked = await rateLimitAndIPCheck(c.req.raw, authResult, requestId, "admin");
   if (blocked) {
     return c.json(blocked.body, blocked.status as 429, blocked.headers);
   }

--- a/packages/api/src/lib/auth/__tests__/middleware.test.ts
+++ b/packages/api/src/lib/auth/__tests__/middleware.test.ts
@@ -772,6 +772,145 @@ describe("checkRateLimit() — chat bucket (F-74)", () => {
 });
 
 // ---------------------------------------------------------------------------
+// #2485 — admin bucket isolation
+// ---------------------------------------------------------------------------
+
+describe("checkRateLimit() — admin bucket (#2485)", () => {
+  const origRpm = process.env.ATLAS_RATE_LIMIT_RPM;
+  const origAdminRpm = process.env.ATLAS_RATE_LIMIT_RPM_ADMIN;
+
+  beforeEach(() => {
+    resetRateLimits();
+    process.env.ATLAS_RATE_LIMIT_RPM = "30";
+  });
+
+  afterEach(() => {
+    if (origRpm !== undefined) process.env.ATLAS_RATE_LIMIT_RPM = origRpm;
+    else delete process.env.ATLAS_RATE_LIMIT_RPM;
+    if (origAdminRpm !== undefined) process.env.ATLAS_RATE_LIMIT_RPM_ADMIN = origAdminRpm;
+    else delete process.env.ATLAS_RATE_LIMIT_RPM_ADMIN;
+    resetRateLimits();
+  });
+
+  it("derives default admin ceiling as max(60, RPM) when override unset", () => {
+    delete process.env.ATLAS_RATE_LIMIT_RPM_ADMIN;
+    // RPM=30 — admin ceiling lifts to 60 so an interactive admin form
+    // (DELETE + Test + Add, ~12 calls per session) doesn't burn through
+    // a budget tuned for cheap public reads.
+    process.env.ATLAS_RATE_LIMIT_RPM = "30";
+    resetRateLimits();
+
+    for (let i = 0; i < 60; i++) {
+      expect(checkRateLimit("u", { bucket: "admin" }).allowed).toBe(true);
+    }
+    expect(checkRateLimit("u", { bucket: "admin" }).allowed).toBe(false);
+  });
+
+  it("admin ceiling tracks RPM when RPM > 60", () => {
+    delete process.env.ATLAS_RATE_LIMIT_RPM_ADMIN;
+    process.env.ATLAS_RATE_LIMIT_RPM = "120";
+    resetRateLimits();
+
+    for (let i = 0; i < 120; i++) {
+      expect(checkRateLimit("u", { bucket: "admin" }).allowed).toBe(true);
+    }
+    expect(checkRateLimit("u", { bucket: "admin" }).allowed).toBe(false);
+  });
+
+  it("ATLAS_RATE_LIMIT_RPM_ADMIN override wins over the derived default", () => {
+    process.env.ATLAS_RATE_LIMIT_RPM = "30";
+    process.env.ATLAS_RATE_LIMIT_RPM_ADMIN = "3";
+    resetRateLimits();
+
+    expect(checkRateLimit("u", { bucket: "admin" }).allowed).toBe(true);
+    expect(checkRateLimit("u", { bucket: "admin" }).allowed).toBe(true);
+    expect(checkRateLimit("u", { bucket: "admin" }).allowed).toBe(true);
+    expect(checkRateLimit("u", { bucket: "admin" }).allowed).toBe(false);
+  });
+
+  it("disables admin bucket when ATLAS_RATE_LIMIT_RPM=0", () => {
+    process.env.ATLAS_RATE_LIMIT_RPM = "0";
+    process.env.ATLAS_RATE_LIMIT_RPM_ADMIN = "5";
+    resetRateLimits();
+
+    // When the global limit is off the admin bucket inherits "off" too —
+    // matches the chat-bucket semantics so self-hosted deployments don't
+    // need to also clear ATLAS_RATE_LIMIT_RPM_ADMIN to fully opt out.
+    for (let i = 0; i < 50; i++) {
+      expect(checkRateLimit("u", { bucket: "admin" }).allowed).toBe(true);
+    }
+  });
+
+  it("invalid ATLAS_RATE_LIMIT_RPM_ADMIN falls back to derived default", () => {
+    process.env.ATLAS_RATE_LIMIT_RPM = "30";
+    process.env.ATLAS_RATE_LIMIT_RPM_ADMIN = "abc";
+    resetRateLimits();
+
+    // Falls back to max(60, RPM) = 60.
+    for (let i = 0; i < 60; i++) {
+      expect(checkRateLimit("u", { bucket: "admin" }).allowed).toBe(true);
+    }
+    expect(checkRateLimit("u", { bucket: "admin" }).allowed).toBe(false);
+  });
+
+  // The whole point of #2485 — admin requests must not deplete the
+  // default bucket (and vice versa). Without isolation a dogfood session
+  // of admin clicks throttles the same caller's cheap reads / chat.
+  it("admin bucket exhaustion does not lock out the default bucket for the same key", () => {
+    process.env.ATLAS_RATE_LIMIT_RPM = "20";
+    process.env.ATLAS_RATE_LIMIT_RPM_ADMIN = "2";
+    resetRateLimits();
+
+    // Burn the admin ceiling.
+    expect(checkRateLimit("u", { bucket: "admin" }).allowed).toBe(true);
+    expect(checkRateLimit("u", { bucket: "admin" }).allowed).toBe(true);
+    expect(checkRateLimit("u", { bucket: "admin" }).allowed).toBe(false);
+
+    // Default bucket on the same key still has its full allowance.
+    for (let i = 0; i < 20; i++) {
+      expect(checkRateLimit("u").allowed).toBe(true);
+    }
+    expect(checkRateLimit("u").allowed).toBe(false);
+  });
+
+  it("default bucket exhaustion does not lock out the admin bucket for the same key", () => {
+    process.env.ATLAS_RATE_LIMIT_RPM = "2";
+    process.env.ATLAS_RATE_LIMIT_RPM_ADMIN = "5";
+    resetRateLimits();
+
+    // Burn the default ceiling.
+    expect(checkRateLimit("u").allowed).toBe(true);
+    expect(checkRateLimit("u").allowed).toBe(true);
+    expect(checkRateLimit("u").allowed).toBe(false);
+
+    // Admin bucket is unaffected — an admin can still complete the form
+    // even if their cheap-read budget has been spent elsewhere.
+    for (let i = 0; i < 5; i++) {
+      expect(checkRateLimit("u", { bucket: "admin" }).allowed).toBe(true);
+    }
+    expect(checkRateLimit("u", { bucket: "admin" }).allowed).toBe(false);
+  });
+
+  it("admin and chat buckets are independent", () => {
+    process.env.ATLAS_RATE_LIMIT_RPM = "20";
+    process.env.ATLAS_RATE_LIMIT_RPM_ADMIN = "3";
+    process.env.ATLAS_RATE_LIMIT_RPM_CHAT = "2";
+    resetRateLimits();
+
+    // Burn admin
+    expect(checkRateLimit("u", { bucket: "admin" }).allowed).toBe(true);
+    expect(checkRateLimit("u", { bucket: "admin" }).allowed).toBe(true);
+    expect(checkRateLimit("u", { bucket: "admin" }).allowed).toBe(true);
+    expect(checkRateLimit("u", { bucket: "admin" }).allowed).toBe(false);
+
+    // Chat still has its full allowance.
+    expect(checkRateLimit("u", { bucket: "chat" }).allowed).toBe(true);
+    expect(checkRateLimit("u", { bucket: "chat" }).allowed).toBe(true);
+    expect(checkRateLimit("u", { bucket: "chat" }).allowed).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // rateLimitCleanupTick
 // ---------------------------------------------------------------------------
 

--- a/packages/api/src/lib/auth/__tests__/middleware.test.ts
+++ b/packages/api/src/lib/auth/__tests__/middleware.test.ts
@@ -795,8 +795,8 @@ describe("checkRateLimit() — admin bucket (#2485)", () => {
   it("derives default admin ceiling as max(60, RPM) when override unset", () => {
     delete process.env.ATLAS_RATE_LIMIT_RPM_ADMIN;
     // RPM=30 — admin ceiling lifts to 60 so an interactive admin form
-    // (DELETE + Test + Add, ~12 calls per session) doesn't burn through
-    // a budget tuned for cheap public reads.
+    // (DELETE + Test + Add in quick succession) doesn't burn through a
+    // budget tuned for cheap public reads.
     process.env.ATLAS_RATE_LIMIT_RPM = "30";
     resetRateLimits();
 

--- a/packages/api/src/lib/auth/middleware.ts
+++ b/packages/api/src/lib/auth/middleware.ts
@@ -33,6 +33,7 @@ const windows = new Map<string, number[]>();
 
 let lastWarnedRpmValue: string | undefined;
 let lastWarnedChatRpmValue: string | undefined;
+let lastWarnedAdminRpmValue: string | undefined;
 
 function getRpmLimit(): number {
   const raw = getSetting("ATLAS_RATE_LIMIT_RPM");
@@ -58,8 +59,15 @@ function getRpmLimit(): number {
  * `max(5, RPM/4)` from the default. The carve-out keeps a 25-step LLM
  * call from depleting the same budget that serves trivial reads (F-74).
  *
+ * `admin` reads `ATLAS_RATE_LIMIT_RPM_ADMIN` when set, otherwise derives
+ * `max(60, RPM)` from the default — interactive admin forms (Add /
+ * Edit / Test Connection, etc.) burst easily past a low base RPM during
+ * a single dogfood session (#2485). Admin requests bucket separately so
+ * a sequence of DELETE + Test + Add doesn't deplete the same budget that
+ * serves chat / cheap reads.
+ *
  * Returning 0 means "disabled" (matching the existing semantics on the
- * default bucket); when the global limit is disabled the chat bucket is
+ * default bucket); when the global limit is disabled all sub-buckets are
  * also disabled regardless of override.
  */
 function getRpmLimitForBucket(bucket: RateLimitBucket): number {
@@ -67,28 +75,50 @@ function getRpmLimitForBucket(bucket: RateLimitBucket): number {
   if (bucket === "default") return baseLimit;
   if (baseLimit === 0) return 0;
 
-  const raw = getSetting("ATLAS_RATE_LIMIT_RPM_CHAT");
+  if (bucket === "chat") {
+    const raw = getSetting("ATLAS_RATE_LIMIT_RPM_CHAT");
+    if (raw === undefined || raw === "") {
+      // Default: cap at 1/4 of the global RPM, with a floor of 5/min so a
+      // very low ATLAS_RATE_LIMIT_RPM doesn't push the chat ceiling to 0.
+      return Math.max(5, Math.floor(baseLimit / 4));
+    }
+    const n = Number(raw);
+    if (!Number.isFinite(n) || n <= 0) {
+      if (raw !== lastWarnedChatRpmValue) {
+        log.warn(
+          { value: raw },
+          "Invalid ATLAS_RATE_LIMIT_RPM_CHAT; falling back to derived default max(5, RPM/4)",
+        );
+        lastWarnedChatRpmValue = raw;
+      }
+      return Math.max(5, Math.floor(baseLimit / 4));
+    }
+    return Math.floor(n);
+  }
+
+  // bucket === "admin"
+  const raw = getSetting("ATLAS_RATE_LIMIT_RPM_ADMIN");
   if (raw === undefined || raw === "") {
-    // Default: cap at 1/4 of the global RPM, with a floor of 5/min so a
-    // very low ATLAS_RATE_LIMIT_RPM doesn't push the chat ceiling to 0.
-    return Math.max(5, Math.floor(baseLimit / 4));
+    // Default: at least 60/min — one request per second — so interactive
+    // admin forms aren't throttled at a base RPM tuned for public traffic.
+    return Math.max(60, baseLimit);
   }
   const n = Number(raw);
   if (!Number.isFinite(n) || n <= 0) {
-    if (raw !== lastWarnedChatRpmValue) {
+    if (raw !== lastWarnedAdminRpmValue) {
       log.warn(
         { value: raw },
-        "Invalid ATLAS_RATE_LIMIT_RPM_CHAT; falling back to derived default max(5, RPM/4)",
+        "Invalid ATLAS_RATE_LIMIT_RPM_ADMIN; falling back to derived default max(60, RPM)",
       );
-      lastWarnedChatRpmValue = raw;
+      lastWarnedAdminRpmValue = raw;
     }
-    return Math.max(5, Math.floor(baseLimit / 4));
+    return Math.max(60, baseLimit);
   }
   return Math.floor(n);
 }
 
 /** Bucket categories for `checkRateLimit`. */
-export type RateLimitBucket = "default" | "chat";
+export type RateLimitBucket = "default" | "chat" | "admin";
 
 // `\x00` is illegal in user ids, IPs, and the "anon" fallback used by
 // chat.ts — so the chat-bucket prefix can never collide with a
@@ -97,6 +127,7 @@ export type RateLimitBucket = "default" | "chat";
 const BUCKET_PREFIX: Record<RateLimitBucket, string> = {
   default: "",
   chat: "\x00chat:",
+  admin: "\x00admin:",
 };
 
 /**
@@ -127,7 +158,7 @@ export function getClientIP(req: Request): string | null {
  * `{ allowed: false, retryAfterMs }` when the caller should back off.
  * Always allows when ATLAS_RATE_LIMIT_RPM is unset or "0".
  *
- * The optional `bucket` parameter selects between two independent
+ * The optional `bucket` parameter selects between three independent
  * sliding windows keyed on the same caller identity (user id or IP):
  *
  *   - `"default"` (omitted) — the original cheap-read bucket. Ceiling
@@ -136,6 +167,10 @@ export function getClientIP(req: Request): string | null {
  *     `ATLAS_RATE_LIMIT_RPM_CHAT`, defaulting to `max(5, RPM/4)`. A 25-step
  *     chat run debiting the chat bucket no longer drains the cheap-read
  *     allowance for the same caller.
+ *   - `"admin"` — the interactive admin-form carve-out (#2485). Ceiling
+ *     comes from `ATLAS_RATE_LIMIT_RPM_ADMIN`, defaulting to
+ *     `max(60, RPM)`. A burst of DELETE + Test + Add Connection no longer
+ *     depletes the cheap-read budget shared with chat.
  *
  * Note: this still limits API *requests*, not agent steps. Per-conversation
  * step accounting (F-77) is enforced separately on the chat handler.
@@ -181,6 +216,7 @@ export function resetRateLimits(): void {
   windows.clear();
   lastWarnedRpmValue = undefined;
   lastWarnedChatRpmValue = undefined;
+  lastWarnedAdminRpmValue = undefined;
 }
 
 /**

--- a/packages/api/src/lib/auth/middleware.ts
+++ b/packages/api/src/lib/auth/middleware.ts
@@ -96,25 +96,34 @@ function getRpmLimitForBucket(bucket: RateLimitBucket): number {
     return Math.floor(n);
   }
 
-  // bucket === "admin"
-  const raw = getSetting("ATLAS_RATE_LIMIT_RPM_ADMIN");
-  if (raw === undefined || raw === "") {
-    // Default: at least 60/min — one request per second — so interactive
-    // admin forms aren't throttled at a base RPM tuned for public traffic.
-    return Math.max(60, baseLimit);
-  }
-  const n = Number(raw);
-  if (!Number.isFinite(n) || n <= 0) {
-    if (raw !== lastWarnedAdminRpmValue) {
-      log.warn(
-        { value: raw },
-        "Invalid ATLAS_RATE_LIMIT_RPM_ADMIN; falling back to derived default max(60, RPM)",
-      );
-      lastWarnedAdminRpmValue = raw;
+  if (bucket === "admin") {
+    const raw = getSetting("ATLAS_RATE_LIMIT_RPM_ADMIN");
+    if (raw === undefined || raw === "") {
+      // Default: at least 60/min — one request per second — so interactive
+      // admin forms aren't throttled at a base RPM tuned for public traffic.
+      return Math.max(60, baseLimit);
     }
-    return Math.max(60, baseLimit);
+    const n = Number(raw);
+    if (!Number.isFinite(n) || n <= 0) {
+      if (raw !== lastWarnedAdminRpmValue) {
+        log.warn(
+          { value: raw },
+          "Invalid ATLAS_RATE_LIMIT_RPM_ADMIN; falling back to derived default max(60, RPM)",
+        );
+        lastWarnedAdminRpmValue = raw;
+      }
+      return Math.max(60, baseLimit);
+    }
+    return Math.floor(n);
   }
-  return Math.floor(n);
+
+  // Exhaustiveness gate — adding a fourth bucket to `RateLimitBucket`
+  // without adding an arm here is a TS error. Without it the new bucket
+  // would silently fall through to whatever the last branch happened to
+  // return (the admin path used to be a comment-only fall-through; this
+  // closes that door).
+  const _exhaustive: never = bucket;
+  throw new Error(`Unhandled rate-limit bucket: ${String(_exhaustive)}`);
 }
 
 /** Bucket categories for `checkRateLimit`. */

--- a/packages/api/src/lib/settings.ts
+++ b/packages/api/src/lib/settings.ts
@@ -119,6 +119,16 @@ const SETTINGS_REGISTRY: SettingDefinition[] = [
     envVar: "ATLAS_RATE_LIMIT_RPM_CHAT",
     scope: "workspace",
   },
+  {
+    key: "ATLAS_RATE_LIMIT_RPM_ADMIN",
+    section: "Rate Limiting",
+    label: "Admin Rate Limit (RPM)",
+    description:
+      "Max admin requests per minute per user (defaults to max(60, RPM) so a burst of DELETE + Test + Add Connection during an interactive admin session does not throttle on a low base RPM tuned for public traffic)",
+    type: "number",
+    envVar: "ATLAS_RATE_LIMIT_RPM_ADMIN",
+    scope: "workspace",
+  },
 
   // Security
   {

--- a/packages/web/src/app/admin/connections/__tests__/format-dialog-error.test.ts
+++ b/packages/web/src/app/admin/connections/__tests__/format-dialog-error.test.ts
@@ -36,15 +36,34 @@ describe("formatDialogError — #2485 dialog error surfacing", () => {
     expect(out).toContain("Request ID: abc-123");
   });
 
-  test("plan_limit_exceeded (also 429) substitutes retry guidance — same status, same surfacing", () => {
-    // Both rate-limited and plan-limit-exceeded come back as 429.
-    // The admin sees consistent copy regardless of the underlying cause —
-    // the structured `code` is still on the error for downstream surfaces
-    // that need to branch (e.g. an upsell CTA later).
+  test("plan_limit_exceeded (also 429) surfaces the server's structured upgrade message verbatim", () => {
+    // Both rate-limited and plan-limit-exceeded come back as 429, but
+    // the recovery action is different: rate-limited admins wait,
+    // plan-limited admins upgrade. Collapsing both to wait-and-retry
+    // would tell a plan-limited admin to wait for a budget refresh
+    // that never comes. The 429 substitution gates on `code` so the
+    // structured "Upgrade to add more" copy from billing/enforcement
+    // reaches the user.
     const err: FetchError = {
       status: 429,
       code: "plan_limit_exceeded",
-      message: "Workspace exceeded its connection limit.",
+      message: "Your free plan allows up to 1 connections. Upgrade to add more.",
+    };
+    const out = formatDialogError(err);
+    expect(out).toContain("Your free plan allows up to 1 connections");
+    expect(out).toContain("Upgrade to add more");
+    // The wait-and-retry copy must NOT appear — that would mislead a
+    // plan-limited admin into waiting instead of upgrading.
+    expect(out).not.toContain("Wait a few seconds");
+  });
+
+  test("429 without a code (defensive) substitutes retry guidance", () => {
+    // Belt-and-suspenders: a 429 from an upstream layer that forgot to
+    // populate `code` should still get the wait-and-retry copy, because
+    // the most common cause of 429 in this surface is rate-limiting.
+    const err: FetchError = {
+      status: 429,
+      message: "Too many requests.",
     };
     const out = formatDialogError(err);
     expect(out).toBe("Too many requests. Wait a few seconds and try again.");

--- a/packages/web/src/app/admin/connections/__tests__/format-dialog-error.test.ts
+++ b/packages/web/src/app/admin/connections/__tests__/format-dialog-error.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Unit tests for the Add / Edit Connection dialog error formatter (#2485).
+ *
+ * Locks the 429 retry-guidance carve-out so the server's stock "Please
+ * wait before trying again" copy can't silently re-displace the admin-
+ * facing "Wait a few seconds" guidance the issue closed on. The non-429
+ * cases bind the verbatim structured-body contract so a future
+ * "friendly default" doesn't collapse `connection_failed` / `conflict`
+ * back into a generic banner.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { formatDialogError } from "../format-dialog-error";
+import type { FetchError } from "@/ui/lib/fetch-error";
+
+describe("formatDialogError — #2485 dialog error surfacing", () => {
+  test("429 substitutes admin-facing retry guidance, not server stock copy", () => {
+    const err: FetchError = {
+      status: 429,
+      code: "rate_limited",
+      message: "Too many requests. Please wait before trying again.",
+    };
+    const out = formatDialogError(err);
+    expect(out).toBe("Too many requests. Wait a few seconds and try again.");
+  });
+
+  test("429 appends Request ID when present", () => {
+    const err: FetchError = {
+      status: 429,
+      code: "rate_limited",
+      message: "Too many requests. Please wait before trying again.",
+      requestId: "abc-123",
+    };
+    const out = formatDialogError(err);
+    expect(out).toContain("Wait a few seconds and try again.");
+    expect(out).toContain("Request ID: abc-123");
+  });
+
+  test("plan_limit_exceeded (also 429) substitutes retry guidance — same status, same surfacing", () => {
+    // Both rate-limited and plan-limit-exceeded come back as 429.
+    // The admin sees consistent copy regardless of the underlying cause —
+    // the structured `code` is still on the error for downstream surfaces
+    // that need to branch (e.g. an upsell CTA later).
+    const err: FetchError = {
+      status: 429,
+      code: "plan_limit_exceeded",
+      message: "Workspace exceeded its connection limit.",
+    };
+    const out = formatDialogError(err);
+    expect(out).toBe("Too many requests. Wait a few seconds and try again.");
+  });
+
+  test("400 connection_failed surfaces the server's structured error body verbatim", () => {
+    // The server hands back actionable copy ("Fix the URL and try
+    // again.") — the dialog must not collapse it into a generic banner.
+    const err: FetchError = {
+      status: 400,
+      code: "connection_failed",
+      message: "Connection test failed: bad credentials. Fix the URL and try again.",
+    };
+    const out = formatDialogError(err);
+    expect(out).toContain("Connection test failed: bad credentials");
+    expect(out).toContain("Fix the URL and try again");
+  });
+
+  test("409 conflict surfaces the server message verbatim", () => {
+    const err: FetchError = {
+      status: 409,
+      code: "conflict",
+      message: 'Connection "warehouse" already exists.',
+    };
+    const out = formatDialogError(err);
+    expect(out).toContain('Connection "warehouse" already exists');
+  });
+
+  test("500 internal_error preserves the structured body — no 'Something went wrong' substitution", () => {
+    const err: FetchError = {
+      status: 500,
+      code: "internal_error",
+      message: "Failed to save connection.",
+      requestId: "req-789",
+    };
+    const out = formatDialogError(err);
+    expect(out).toContain("Failed to save connection");
+    expect(out).toContain("req-789");
+  });
+});

--- a/packages/web/src/app/admin/connections/format-dialog-error.ts
+++ b/packages/web/src/app/admin/connections/format-dialog-error.ts
@@ -1,0 +1,23 @@
+import { friendlyError, type FetchError } from "@/ui/lib/fetch-error";
+
+/**
+ * Format a save-mutation error for the Add / Edit Connection dialog (#2485).
+ *
+ * 429 gets explicit retry guidance because the server's stock copy ("Too
+ * many requests. Please wait before trying again.") is easy for admins to
+ * miss next to the submit spinner — admins who didn't see the inline
+ * banner filed #2485 thinking the form was broken.
+ *
+ * Every other 4xx/5xx is rendered verbatim from the structured error body
+ * via `friendlyError`. We deliberately do NOT collapse the message to
+ * "Something went wrong" — the route hands back `connection_failed`,
+ * `conflict`, `plan_limit_exceeded` etc with actionable copy and we want
+ * the admin to see it.
+ */
+export function formatDialogError(err: FetchError): string {
+  if (err.status === 429) {
+    const base = "Too many requests. Wait a few seconds and try again.";
+    return err.requestId ? `${base} (Request ID: ${err.requestId})` : base;
+  }
+  return friendlyError(err);
+}

--- a/packages/web/src/app/admin/connections/format-dialog-error.ts
+++ b/packages/web/src/app/admin/connections/format-dialog-error.ts
@@ -3,19 +3,26 @@ import { friendlyError, type FetchError } from "@/ui/lib/fetch-error";
 /**
  * Format a save-mutation error for the Add / Edit Connection dialog (#2485).
  *
- * 429 gets explicit retry guidance because the server's stock copy ("Too
- * many requests. Please wait before trying again.") is easy for admins to
- * miss next to the submit spinner — admins who didn't see the inline
- * banner filed #2485 thinking the form was broken.
+ * `rate_limited` 429s get explicit retry guidance because the server's
+ * stock copy ("Too many requests. Please wait before trying again.") is
+ * generic — the inline banner that #2485 introduced needs to tell the
+ * admin exactly what action recovers the form, not just that something
+ * rate-limited.
  *
- * Every other 4xx/5xx is rendered verbatim from the structured error body
- * via `friendlyError`. We deliberately do NOT collapse the message to
- * "Something went wrong" — the route hands back `connection_failed`,
- * `conflict`, `plan_limit_exceeded` etc with actionable copy and we want
- * the admin to see it.
+ * Every other 4xx/5xx — including `plan_limit_exceeded` (which also
+ * comes back as 429 but with actionable "Upgrade to add more" copy
+ * from billing/enforcement.ts) — is rendered verbatim from the
+ * structured error body via `friendlyError`. We deliberately do NOT
+ * collapse messages to "Something went wrong" or wait-and-retry: the
+ * route hands back `connection_failed`, `conflict`, `plan_limit_exceeded`
+ * etc with actionable copy and we want the admin to see it.
  */
 export function formatDialogError(err: FetchError): string {
-  if (err.status === 429) {
+  // Branch on `code` so a 429 with a non-rate-limited code (today:
+  // `plan_limit_exceeded`; tomorrow: anything else 429 might carry)
+  // keeps its server-typed message instead of being collapsed into
+  // wait-and-retry guidance that does not apply.
+  if (err.status === 429 && (err.code === "rate_limited" || err.code === undefined)) {
     const base = "Too many requests. Wait a few seconds and try again.";
     return err.requestId ? `${base} (Request ID: ${err.requestId})` : base;
   }

--- a/packages/web/src/app/admin/connections/page.tsx
+++ b/packages/web/src/app/admin/connections/page.tsx
@@ -68,6 +68,7 @@ import {
 import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
 import { formatDialogError } from "./format-dialog-error";
+import type { FetchError } from "@/ui/lib/fetch-error";
 import { ErrorBoundary } from "@/ui/components/error-boundary";
 import {
   FormDialog,
@@ -153,6 +154,15 @@ function ConnectionFormDialog({
   const isEdit = !!editId;
   const [showUrl, setShowUrl] = useState(false);
   const [testResult, setTestResult] = useState<{ ok: boolean; message: string } | null>(null);
+  // Captures the most recent failed-submit error as an authoritative
+  // fallback to `saveMutation.error`. If the user closes mid-flight and
+  // re-opens the dialog before the request settles, `handleOpenChange`
+  // calls `saveMutation.reset()` (bumping the hook's generation) and the
+  // late catch in `use-admin-mutation.ts` skips its `setError` write —
+  // which would otherwise leave the dialog open with no banner. Reading
+  // the discriminant from the `mutate()` return value is independent of
+  // that generation gate, so the banner still renders.
+  const [submitError, setSubmitError] = useState<FetchError | null>(null);
 
   const testMutation = useAdminMutation<{ status: string; latencyMs?: number; message?: string }>({
     path: "/api/v1/admin/connections/test",
@@ -178,6 +188,7 @@ function ConnectionFormDialog({
       setTestResult(null);
       testMutation.reset();
       saveMutation.reset();
+      setSubmitError(null);
     }
     onOpenChange(nextOpen);
   }
@@ -200,15 +211,17 @@ function ConnectionFormDialog({
       body.schema = values.schema || undefined;
     }
 
-    // Gate close-on-success on `result.ok` — explicit so a non-2xx leaves
-    // the dialog open with `saveMutation.error` populated (#2485). The
-    // hook already only fires `onSuccess` on 2xx, but threading the close
-    // through the result discriminant keeps the success path readable and
-    // forecloses a regression where the close-callback shape silently
-    // shifts behind the curtain.
+    // Gate close-on-success on `result.ok` so a non-2xx leaves the
+    // dialog open with the error inline (#2485). Capture `result.error`
+    // into local state so the banner renders even when a close-then-
+    // reopen race clears the hook-level slot before the request settles
+    // (use-admin-mutation.ts:370 swallows the late `setError` write).
+    setSubmitError(null);
     const result = await saveMutation.mutate({ path, method, body });
     if (result.ok) {
       onOpenChange(false);
+    } else {
+      setSubmitError(result.error);
     }
   }
 
@@ -250,7 +263,16 @@ function ConnectionFormDialog({
       onSubmit={handleSubmit}
       submitLabel={isEdit ? "Save Changes" : "Add Connection"}
       saving={saveMutation.saving}
-      serverError={saveMutation.error ? formatDialogError(saveMutation.error) : null}
+      serverError={
+        // Prefer the hook-level slot (covers concurrent retries cleanly)
+        // and fall back to the locally-captured discriminant for the
+        // close-then-reopen race documented on `submitError`.
+        saveMutation.error
+          ? formatDialogError(saveMutation.error)
+          : submitError
+            ? formatDialogError(submitError)
+            : null
+      }
       className="sm:max-w-md"
       extraFooter={(form) => (
         <Button

--- a/packages/web/src/app/admin/connections/page.tsx
+++ b/packages/web/src/app/admin/connections/page.tsx
@@ -67,7 +67,7 @@ import {
 } from "lucide-react";
 import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
-import { friendlyError } from "@/ui/lib/fetch-error";
+import { formatDialogError } from "./format-dialog-error";
 import { ErrorBoundary } from "@/ui/components/error-boundary";
 import {
   FormDialog,
@@ -200,12 +200,16 @@ function ConnectionFormDialog({
       body.schema = values.schema || undefined;
     }
 
-    await saveMutation.mutate({
-      path,
-      method,
-      body,
-      onSuccess: () => onOpenChange(false),
-    });
+    // Gate close-on-success on `result.ok` — explicit so a non-2xx leaves
+    // the dialog open with `saveMutation.error` populated (#2485). The
+    // hook already only fires `onSuccess` on 2xx, but threading the close
+    // through the result discriminant keeps the success path readable and
+    // forecloses a regression where the close-callback shape silently
+    // shifts behind the curtain.
+    const result = await saveMutation.mutate({ path, method, body });
+    if (result.ok) {
+      onOpenChange(false);
+    }
   }
 
   async function handleTest(url: string, schemaVal: string) {
@@ -246,7 +250,7 @@ function ConnectionFormDialog({
       onSubmit={handleSubmit}
       submitLabel={isEdit ? "Save Changes" : "Add Connection"}
       saving={saveMutation.saving}
-      serverError={saveMutation.error ? friendlyError(saveMutation.error) : null}
+      serverError={saveMutation.error ? formatDialogError(saveMutation.error) : null}
       className="sm:max-w-md"
       extraFooter={(form) => (
         <Button


### PR DESCRIPTION
## Summary

Closes #2485. Two-part fix for the Add Connection dialog silently swallowing 429 rate-limit errors during the 1.4.4 dogfood pass.

**Web (`packages/web`)**
- `handleSubmit` now gates `onOpenChange(false)` on `result.ok` — explicit so a non-2xx leaves the dialog open with the structured error inline. The hook already only fires the `onSuccess` callback on 2xx; threading the close through the `MutateResult` discriminant forecloses a regression where the close-callback shape silently shifts behind the curtain.
- Extracted `formatDialogError` to a sibling module. 429 substitutes admin-facing retry guidance (`"Too many requests. Wait a few seconds and try again."`) — the server's stock copy was easy for admins to miss next to the submit spinner. Every other 4xx/5xx renders verbatim from the server's structured body via `friendlyError`; we deliberately do not collapse to "Something went wrong" since the route hands back actionable `connection_failed` / `conflict` / `plan_limit_exceeded` copy.

**API (`packages/api`)**
- Split the admin namespace into its own rate-limit bucket. Pre-fix `adminAuth` + `platformAdminAuth` checked the same `default` bucket as cheap reads and queries, so a sequence of DELETE + Test + Add Connection during an interactive admin session burned through a budget tuned for public traffic.
- New `ATLAS_RATE_LIMIT_RPM_ADMIN` setting, defaults to `max(60, RPM)` — at least one admin request per second regardless of how tight the base RPM is. Mirrors the F-74 chat bucket pattern.
- Updated `.env.example` and `apps/docs/content/docs/guides/rate-limiting.mdx` to document the bucket and the per-bucket isolation contract.

## Test plan

- [x] `bun test src/app/admin/connections/__tests__/format-dialog-error.test.ts` (`@atlas/web`) — 6 pass, covers 429 substitution + verbatim 400/409/500
- [x] `bun run scripts/test-isolated.ts src/lib/auth/__tests__/middleware.test.ts` (`@atlas/api`) — 57 pass, 9 new admin-bucket isolation tests
- [x] `bun run scripts/test-isolated.ts src/api/__tests__/admin-connections.test.ts src/api/routes/__tests__/admin-router.test.ts src/lib/effect/__tests__/saas-guards.test.ts src/lib/effect/__tests__/layers.test.ts src/lib/__tests__/settings.test.ts src/lib/__tests__/settings-saas.test.ts src/lib/effect/__tests__/saas-env.test.ts` — all pass
- [x] `bun run scripts/test-isolated.ts --affected` (api) — 83 files, all pass
- [x] `bun run type` and `bun run lint` clean
- [x] `bash scripts/check-schema-drift.sh` and `bash scripts/check-template-drift.sh` pass