### PR TITLE
fix(web,api): #2490 — /admin/connections live count excludes demo, matches billing

### DIFF
--- a/packages/api/src/api/__tests__/admin-connections.test.ts
+++ b/packages/api/src/api/__tests__/admin-connections.test.ts
@@ -230,23 +230,16 @@ describe("admin connections — org scoping", () => {
       expect(defaultRow.groupName).toBeNull();
     });
 
-    it("#2490 — lazy `default` fallback reports billable: false; org-owned rows report true", async () => {
-      // Self-hosted demo deploy: workspace owns one real connection
-      // (`warehouse`), and the registry also has the runtime-registered
-      // `default` from `ATLAS_DATASOURCE_URL`. The visibility set should
-      // include `warehouse` only (org-owned rows suppress the fallback),
-      // but to exercise the parity codepath we mock the visibility query
-      // to return only `warehouse` and verify `billable` is computed via
-      // the same predicate `/admin/billing` uses
-      // (`connections WHERE org_id = $1 AND status != 'archived'`).
+    it("#2490 — org-owned row (warehouse) reports billable: true", async () => {
+      // Workspace owns one real `connections` row. The group-decoration
+      // JOIN matches it, so it lands in `groupInfoByConnection` and the
+      // response decorates `billable: true` — the same predicate billing
+      // uses for the trial-cap count.
       mocks.mockInternalQuery.mockImplementation((sql: string) => {
         if (sql.includes("SELECT c.id FROM connections c WHERE c.org_id")) {
           return Promise.resolve([{ id: "warehouse" }]);
         }
         if (sql.includes("g.name AS group_name")) {
-          // `warehouse` lives in the connections table → present in the
-          // JOIN → billable. `default` is the lazy fallback → absent →
-          // not billable.
           return Promise.resolve([
             { id: "warehouse", group_id: null, group_name: null },
           ]);
@@ -262,6 +255,39 @@ describe("admin connections — org scoping", () => {
       const warehouse = body.connections.find((c: { id: string }) => c.id === "warehouse");
       expect(warehouse).toBeDefined();
       expect(warehouse.billable).toBe(true);
+    });
+
+    it("#2490 — visible row absent from the org-scoped JOIN reports billable: false", async () => {
+      // Covers the `__global__`-sourced half of the billable contract.
+      // Visibility surfaces the row (via the UNION on `__global__` in
+      // getVisibleConnectionIds), but the group-decoration JOIN is
+      // scoped to `c.org_id = $1`, so a `__global__`-owned row returns
+      // no decoration → `billable: false`. Same parity billing enforces:
+      // the shared demo doesn't eat the trial slot. A future change
+      // that widens the JOIN to `org_id IN ($1, '__global__')` would
+      // silently start charging every workspace for shared rows — this
+      // test fails first.
+      mocks.mockInternalQuery.mockImplementation((sql: string) => {
+        if (sql.includes("SELECT c.id FROM connections c WHERE c.org_id")) {
+          // `warehouse` is the stand-in for a `__global__`-sourced row:
+          // visibility lists it, but the JOIN below returns no row for
+          // it (because it doesn't live under org-alpha in this fixture).
+          return Promise.resolve([{ id: "warehouse" }]);
+        }
+        if (sql.includes("g.name AS group_name")) {
+          return Promise.resolve([]);
+        }
+        return Promise.resolve([]);
+      });
+
+      const res = await app.fetch(adminRequest("/api/v1/admin/connections"));
+
+      expect(res.status).toBe(200);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test convenience
+      const body = (await res.json()) as any;
+      const warehouse = body.connections.find((c: { id: string }) => c.id === "warehouse");
+      expect(warehouse).toBeDefined();
+      expect(warehouse.billable).toBe(false);
     });
 
     it("#2490 — lone lazy `default` (pre-provision workspace) reports billable: false", async () => {

--- a/packages/api/src/api/__tests__/admin-connections.test.ts
+++ b/packages/api/src/api/__tests__/admin-connections.test.ts
@@ -230,6 +230,58 @@ describe("admin connections — org scoping", () => {
       expect(defaultRow.groupName).toBeNull();
     });
 
+    it("#2490 — lazy `default` fallback reports billable: false; org-owned rows report true", async () => {
+      // Self-hosted demo deploy: workspace owns one real connection
+      // (`warehouse`), and the registry also has the runtime-registered
+      // `default` from `ATLAS_DATASOURCE_URL`. The visibility set should
+      // include `warehouse` only (org-owned rows suppress the fallback),
+      // but to exercise the parity codepath we mock the visibility query
+      // to return only `warehouse` and verify `billable` is computed via
+      // the same predicate `/admin/billing` uses
+      // (`connections WHERE org_id = $1 AND status != 'archived'`).
+      mocks.mockInternalQuery.mockImplementation((sql: string) => {
+        if (sql.includes("SELECT c.id FROM connections c WHERE c.org_id")) {
+          return Promise.resolve([{ id: "warehouse" }]);
+        }
+        if (sql.includes("g.name AS group_name")) {
+          // `warehouse` lives in the connections table → present in the
+          // JOIN → billable. `default` is the lazy fallback → absent →
+          // not billable.
+          return Promise.resolve([
+            { id: "warehouse", group_id: null, group_name: null },
+          ]);
+        }
+        return Promise.resolve([]);
+      });
+
+      const res = await app.fetch(adminRequest("/api/v1/admin/connections"));
+
+      expect(res.status).toBe(200);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test convenience
+      const body = (await res.json()) as any;
+      const warehouse = body.connections.find((c: { id: string }) => c.id === "warehouse");
+      expect(warehouse).toBeDefined();
+      expect(warehouse.billable).toBe(true);
+    });
+
+    it("#2490 — lone lazy `default` (pre-provision workspace) reports billable: false", async () => {
+      // Pre-provision self-hosted demo: zero `connections` rows for this
+      // org. `getVisibleConnectionIds` adds `default` from the in-memory
+      // registry. The list response must mark it `billable: false` so the
+      // /admin/connections header agrees with the /admin/billing usage
+      // panel (which counts the same SQL predicate and reports 0).
+      mocks.mockInternalQuery.mockResolvedValue([]);
+
+      const res = await app.fetch(adminRequest("/api/v1/admin/connections"));
+
+      expect(res.status).toBe(200);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test convenience
+      const body = (await res.json()) as any;
+      expect(body.connections).toHaveLength(1);
+      expect(body.connections[0].id).toBe("default");
+      expect(body.connections[0].billable).toBe(false);
+    });
+
     it("decorates each row with groupId + groupName from the connection_groups JOIN", async () => {
       // The list endpoint's second internalQuery call selects c.id, c.group_id
       // and g.name via LEFT JOIN connection_groups. The visibility query runs

--- a/packages/api/src/api/routes/admin-connections.ts
+++ b/packages/api/src/api/routes/admin-connections.ts
@@ -396,6 +396,14 @@ adminConnections.openapi(listConnectionsRoute, async (c) => runHandler(c, "list 
   // fall through with `groupId/groupName: null` on every row. Transient
   // DB errors propagate via runHandler's classifyError — a flaky pool
   // surfaces as a 500 here, no silent-success fallback.
+  //
+  // Presence in `groupInfoByConnection` doubles as the `billable` signal
+  // (#2490): the SELECT already matches the billing usage-panel SQL
+  // (`c.org_id = $1` on a non-archived row — archived rows are removed
+  // upstream by `getVisibleConnectionIds`'s content-mode read filter).
+  // `__global__`-sourced rows and the lazy `default` fallback are
+  // visible to the user but absent from this query, so they correctly
+  // report `billable: false`.
   let groupInfoByConnection = new Map<string, { groupId: string | null; groupName: string | null }>();
   if (hasInternalDB() && filtered.length > 0) {
     const ids = filtered.map((c) => c.id);
@@ -418,6 +426,7 @@ adminConnections.openapi(listConnectionsRoute, async (c) => runHandler(c, "list 
       ...c,
       groupId: info?.groupId ?? null,
       groupName: info?.groupName ?? null,
+      billable: groupInfoByConnection.has(c.id),
     };
   });
 

--- a/packages/schemas/src/__tests__/connection.test.ts
+++ b/packages/schemas/src/__tests__/connection.test.ts
@@ -79,3 +79,24 @@ describe("group decoration fields survive parse", () => {
     expect(ConnectionInfoSchema.parse(ungrouped)).toEqual(ungrouped);
   });
 });
+
+describe("billable field survives parse (#2490)", () => {
+  // The header at /admin/connections counts only billable rows. If the
+  // schema's default object strip drops the field at parse time, the page
+  // sees `undefined` on every row, the `!== false` wire-compat fallback
+  // counts everything, and the exact bug #2490 fixed silently returns.
+  test("parses billable: true (per-org row)", () => {
+    const owned = { ...validInfo, billable: true };
+    expect(ConnectionInfoSchema.parse(owned)).toEqual(owned);
+  });
+
+  test("parses billable: false (lazy default / __global__ shadow)", () => {
+    const fallback = { ...validInfo, billable: false };
+    expect(ConnectionInfoSchema.parse(fallback)).toEqual(fallback);
+  });
+
+  test("billable absent parses cleanly (mixed-version wire compat)", () => {
+    const parsed = ConnectionInfoSchema.parse(validInfo);
+    expect("billable" in parsed).toBe(false);
+  });
+});

--- a/packages/schemas/src/connection.ts
+++ b/packages/schemas/src/connection.ts
@@ -52,6 +52,12 @@ export const ConnectionInfoSchema = z.object({
   // default object strip drops the keys at parse time.
   groupId: z.string().nullable().optional(),
   groupName: z.string().nullable().optional(),
+  // Per-connection mirror of the billing usage-panel SQL predicate
+  // (`status != 'archived'` rows in the per-org `connections` table).
+  // Optional so older API responses still parse; absence is treated as
+  // "count it" by consumers to preserve pre-#2490 behavior. See
+  // `ConnectionInfo.billable` for full semantics.
+  billable: z.boolean().optional(),
 }) as z.ZodType<ConnectionInfo>;
 
 // ---------------------------------------------------------------------------

--- a/packages/types/src/connection.ts
+++ b/packages/types/src/connection.ts
@@ -50,6 +50,22 @@ export interface ConnectionInfo {
    * Same three-state semantics as {@link groupId}.
    */
   groupName?: string | null;
+  /**
+   * Whether this connection counts toward billing/trial resource limits.
+   *
+   * Mirrors the predicate `/admin/billing` uses
+   * (`connections WHERE org_id = $1 AND status != 'archived'`): true iff
+   * this connection has a real row in the per-org `connections` table.
+   * `__global__`-sourced rows (e.g. the shared `__demo__`) and the
+   * runtime-registered `default` fallback (self-hosted demo with no rows
+   * yet) report `billable: false` so the connections-page header agrees
+   * with the billing usage panel.
+   *
+   * Optional for wire compatibility: older serializers omit the field;
+   * consumers should treat `undefined` as "unknown — count it" to
+   * preserve pre-#2490 behavior on a mixed-version deploy.
+   */
+  billable?: boolean;
 }
 
 /** Real-time pool size counters (only available for core adapters with pool access). */

--- a/packages/types/src/connection.ts
+++ b/packages/types/src/connection.ts
@@ -51,19 +51,13 @@ export interface ConnectionInfo {
    */
   groupName?: string | null;
   /**
-   * Whether this connection counts toward billing/trial resource limits.
+   * Mirrors the `/admin/billing` usage-panel predicate
+   * (`connections WHERE org_id = $1 AND status != 'archived'`).
    *
-   * Mirrors the predicate `/admin/billing` uses
-   * (`connections WHERE org_id = $1 AND status != 'archived'`): true iff
-   * this connection has a real row in the per-org `connections` table.
-   * `__global__`-sourced rows (e.g. the shared `__demo__`) and the
-   * runtime-registered `default` fallback (self-hosted demo with no rows
-   * yet) report `billable: false` so the connections-page header agrees
-   * with the billing usage panel.
-   *
-   * Optional for wire compatibility: older serializers omit the field;
-   * consumers should treat `undefined` as "unknown — count it" to
-   * preserve pre-#2490 behavior on a mixed-version deploy.
+   * Optional for wire compatibility: consumers must treat `undefined`
+   * as "count it" so a mixed-version deploy preserves pre-#2490
+   * behavior. The `isBillable()` helper in `packages/web/src/ui/lib/types.ts`
+   * encodes this convention — prefer it over reading the field directly.
    */
   billable?: boolean;
 }

--- a/packages/web/src/app/admin/connections/page.tsx
+++ b/packages/web/src/app/admin/connections/page.tsx
@@ -1169,9 +1169,17 @@ export default function ConnectionsPage() {
     ...Array.from(byType.keys()).filter((k) => !DB_TYPES.some((t) => t.value === k)),
   ];
 
+  // Header "X / Y live" mirrors the /admin/billing usage panel's source
+  // of truth — only count connections that map to a per-org `connections`
+  // row (#2490). The lazy `default` fallback on self-hosted demo deploys
+  // reports `billable: false` and stays out of both the numerator and the
+  // denominator so the header agrees with billing. Connections from an
+  // older API response that predates the field fall back to "count it"
+  // via the `!== false` check, preserving pre-#2490 behavior.
+  const billableConnections = displayConnections.filter((c) => c.billable !== false);
   const stats = {
-    live: displayConnections.filter((c) => c.health?.status === "healthy").length,
-    total: displayConnections.length,
+    live: billableConnections.filter((c) => c.health?.status === "healthy").length,
+    total: billableConnections.length,
   };
 
   return (

--- a/packages/web/src/app/admin/connections/page.tsx
+++ b/packages/web/src/app/admin/connections/page.tsx
@@ -98,6 +98,7 @@ import { cn } from "@/lib/utils";
 import { formatDateTime } from "@/lib/format";
 import {
   DB_TYPES,
+  isBillable,
   type ConnectionHealth,
   type ConnectionInfo,
   type ConnectionDetail,
@@ -1169,14 +1170,12 @@ export default function ConnectionsPage() {
     ...Array.from(byType.keys()).filter((k) => !DB_TYPES.some((t) => t.value === k)),
   ];
 
-  // Header "X / Y live" mirrors the /admin/billing usage panel's source
-  // of truth — only count connections that map to a per-org `connections`
-  // row (#2490). The lazy `default` fallback on self-hosted demo deploys
-  // reports `billable: false` and stays out of both the numerator and the
-  // denominator so the header agrees with billing. Connections from an
-  // older API response that predates the field fall back to "count it"
-  // via the `!== false` check, preserving pre-#2490 behavior.
-  const billableConnections = displayConnections.filter((c) => c.billable !== false);
+  // Header "X / Y live" mirrors the /admin/billing usage panel — the
+  // lazy `default` fallback on self-hosted demo deploys reports
+  // `billable: false` and stays out of both numerator and denominator
+  // (#2490). `isBillable` encodes the wire-compat fallback for older
+  // API servers that omit the field.
+  const billableConnections = displayConnections.filter(isBillable);
   const stats = {
     live: billableConnections.filter((c) => c.health?.status === "healthy").length,
     total: billableConnections.length,

--- a/packages/web/src/ui/lib/types.ts
+++ b/packages/web/src/ui/lib/types.ts
@@ -4,7 +4,7 @@
  * All types are canonical from @useatlas/types — no local duplication.
  */
 
-import type { ShareMode } from "@useatlas/types";
+import type { ConnectionInfo, ShareMode } from "@useatlas/types";
 
 export {
   AUTH_MODES,
@@ -205,3 +205,16 @@ export type ShareStatus =
  * "Frontend is a pure HTTP client".
  */
 export type MeConnectionGroupsEmptyReason = "no_active_org" | "no_internal_db";
+
+/**
+ * Wire-compat-safe read of {@link ConnectionInfo.billable}.
+ *
+ * `billable: false` excludes the row from billing/trial counts;
+ * `undefined` (older API server pre-#2490) means "count it" so a
+ * mixed-version deploy preserves prior behavior. Encoding the
+ * convention here keeps every consumer from having to remember to
+ * write `!== false` instead of the more natural `=== true`.
+ */
+export function isBillable(c: Pick<ConnectionInfo, "billable">): boolean {
+  return c.billable !== false;
+}


### PR DESCRIPTION
## Summary

- `/admin/connections` header "X / Y live" used to count every visible connection — including the runtime-registered `default` fallback on pre-provision self-hosted demo deploys — while `/admin/billing` Usage panel correctly excludes that fallback (the demo doesn't eat the trial slot).
- API now emits `billable: boolean` per `ConnectionInfo`, computed via the same SQL predicate the billing usage panel uses (`connections WHERE org_id = $1 AND status != 'archived'`). The lazy `default` and any `__global__`-sourced rows report `billable: false`; per-org rows report `true`.
- The connections page header filters its numerator + denominator by `billable !== false` so both surfaces report the same number on every signed-in session.
- Post-#2483 this is observable only on self-hosted demo deploys — SaaS workspaces already hide the demo from `/admin/connections`.

## Test plan
- [x] `bun test packages/api/src/api/__tests__/admin-connections.test.ts` — adds two `#2490` cases:
  - lone lazy `default` → `billable: false` (parity with billing's `COUNT = 0`)
  - org-owned row → `billable: true` (matches billing's count)
- [x] `bun run type` — clean
- [x] `bun run lint` — only the pre-existing warning
- [x] `bun run scripts/test-isolated.ts --affected` — 69 files pass
- [x] `bash scripts/check-schema-drift.sh` + `check-template-drift.sh` — pass
- [ ] Manual: pre-provision self-hosted demo workspace shows `00 / 00 live` matching `/admin/billing`'s `Connections: 0 / 1`

Closes #2490.