### PR TITLE
fix(web): #2502 — useAdminFetch guards against empty path

### DIFF
--- a/packages/web/src/app/platform/page.tsx
+++ b/packages/web/src/app/platform/page.tsx
@@ -196,7 +196,7 @@ function PlatformPageContent() {
   const [detailId, setDetailId] = useState<string | null>(null);
   const { data: detailData, loading: detailLoading, error: detailError } = useAdminFetch(
     detailId ? `/api/v1/platform/workspaces/${detailId}` : "",
-    { schema: PlatformWorkspaceDetailResponseSchema, deps: [detailId] },
+    { schema: PlatformWorkspaceDetailResponseSchema, deps: [detailId], enabled: !!detailId },
   );
 
   // Confirmation dialog

--- a/packages/web/src/app/platform/sla/page.tsx
+++ b/packages/web/src/app/platform/sla/page.tsx
@@ -158,7 +158,7 @@ function SLAPageContent() {
   const [detailId, setDetailId] = useState<string | null>(null);
   const { data: detailData, loading: detailLoading, error: detailError } = useAdminFetch(
     detailId ? `/api/v1/platform/sla/${detailId}` : "",
-    { schema: WorkspaceSLADetailSchema, deps: [detailId] },
+    { schema: WorkspaceSLADetailSchema, deps: [detailId], enabled: !!detailId },
   );
 
   // Threshold edit dialog

--- a/packages/web/src/ui/__tests__/use-admin-fetch.test.ts
+++ b/packages/web/src/ui/__tests__/use-admin-fetch.test.ts
@@ -650,6 +650,28 @@ describe("useAdminFetch", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  // Pins the AND semantics (`enabled && !!path`) against a future refactor
+  // to `?? !!path` (which would let an explicit `enabled: true` override the
+  // path check and let the empty-path bug back in). The "short-circuits"
+  // test above happens to cover this via the default-true case, but only
+  // implicitly — this one asserts it explicitly.
+  test("explicit enabled: true with empty path still short-circuits", async () => {
+    const fetchMock = mock(() =>
+      Promise.resolve(new Response(JSON.stringify({ value: 42 }), { status: 200 })),
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const { result } = renderHook(
+      () => useAdminFetch<{ value: number }>("", { enabled: true }),
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   test("empty path flips to a real path to fire the request", async () => {
     const fetchMock = mock(() =>
       Promise.resolve(new Response(JSON.stringify({ value: 7 }), { status: 200 })),

--- a/packages/web/src/ui/__tests__/use-admin-fetch.test.ts
+++ b/packages/web/src/ui/__tests__/use-admin-fetch.test.ts
@@ -628,10 +628,9 @@ describe("useAdminFetch", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  // #2502 — `/platform` page issued two CORS-blocked fetches to the bare API
-  // origin per load because a detail-dialog `useAdminFetch` passed an empty
-  // path when `detailId` was null. The hook now short-circuits on falsy path
-  // so this whole class of "conditional-empty-path" bugs can't escape.
+  // #2502 — empty path used to resolve to the bare API origin and emit a
+  // CORS error per render. The hook now short-circuits on falsy path so any
+  // "conditional-empty-path" caller pattern (`id ? "/api/..." : ""`) is safe.
   test("empty path short-circuits the request (no fetch, loading=false)", async () => {
     const fetchMock = mock(() =>
       Promise.resolve(new Response(JSON.stringify({ value: 42 }), { status: 200 })),

--- a/packages/web/src/ui/__tests__/use-admin-fetch.test.ts
+++ b/packages/web/src/ui/__tests__/use-admin-fetch.test.ts
@@ -628,6 +628,50 @@ describe("useAdminFetch", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  // #2502 — `/platform` page issued two CORS-blocked fetches to the bare API
+  // origin per load because a detail-dialog `useAdminFetch` passed an empty
+  // path when `detailId` was null. The hook now short-circuits on falsy path
+  // so this whole class of "conditional-empty-path" bugs can't escape.
+  test("empty path short-circuits the request (no fetch, loading=false)", async () => {
+    const fetchMock = mock(() =>
+      Promise.resolve(new Response(JSON.stringify({ value: 42 }), { status: 200 })),
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const { result } = renderHook(
+      () => useAdminFetch<{ value: number }>(""),
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+    expect(result.current.data).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("empty path flips to a real path to fire the request", async () => {
+    const fetchMock = mock(() =>
+      Promise.resolve(new Response(JSON.stringify({ value: 7 }), { status: 200 })),
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const { result, rerender } = renderHook(
+      ({ path }: { path: string }) => useAdminFetch<{ value: number }>(path),
+      { wrapper, initialProps: { path: "" } },
+    );
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(result.current.loading).toBe(false);
+
+    rerender({ path: "/api/test" });
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual({ value: 7 });
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
   test("enabled flips from false to true to fire the request", async () => {
     const fetchMock = mock(() =>
       Promise.resolve(new Response(JSON.stringify({ value: 7 }), { status: 200 })),

--- a/packages/web/src/ui/hooks/use-admin-fetch.ts
+++ b/packages/web/src/ui/hooks/use-admin-fetch.ts
@@ -59,9 +59,16 @@ export function useAdminFetch<T>(
   // Manual error override — exposed via setError for backward compatibility.
   const [errorOverride, setErrorOverride] = useState<FetchError | null>(null);
 
+  // Short-circuit when path is empty/falsy. Callers often pass a conditional
+  // path (`id ? `/api/.../${id}` : ""`) for a detail-dialog query that's only
+  // valid once an id is picked. Without this guard the empty path resolves to
+  // the bare API origin (`https://api.useatlas.dev/`), which has no CORS
+  // headers and produces a console error per render. #2502.
+  const enabledOption = (opts?.enabled ?? true) && !!path;
+
   const query = useQuery<T, FetchError>({
     queryKey: [ADMIN_FETCH_QUERY_KEY, path, ...(opts?.deps ?? [])],
-    enabled: opts?.enabled ?? true,
+    enabled: enabledOption,
     queryFn: async ({ signal }) => {
       // Clear any manual error override when a real fetch starts.
       setErrorOverride(null);
@@ -125,11 +132,11 @@ export function useAdminFetch<T>(
 
   // Derive the return value to match the original interface exactly.
   const error = errorOverride ?? query.error ?? null;
-  // When `enabled: false`, react-query keeps `isPending` true even though no
-  // fetch is in flight — that would render an infinite spinner in callers
-  // that gate on `loading`. Treat the disabled query as idle so the caller
-  // can render its own empty / placeholder state.
-  const enabledOption = opts?.enabled ?? true;
+  // When `enabled: false` (explicit or via the empty-path short-circuit),
+  // react-query keeps `isPending` true even though no fetch is in flight —
+  // that would render an infinite spinner in callers that gate on `loading`.
+  // Treat the disabled query as idle so the caller can render its own empty /
+  // placeholder state.
   const loading = enabledOption ? query.isPending : false;
 
   return {

--- a/packages/web/src/ui/hooks/use-admin-fetch.ts
+++ b/packages/web/src/ui/hooks/use-admin-fetch.ts
@@ -59,11 +59,11 @@ export function useAdminFetch<T>(
   // Manual error override — exposed via setError for backward compatibility.
   const [errorOverride, setErrorOverride] = useState<FetchError | null>(null);
 
-  // Short-circuit when path is empty/falsy. Callers often pass a conditional
-  // path (`id ? `/api/.../${id}` : ""`) for a detail-dialog query that's only
-  // valid once an id is picked. Without this guard the empty path resolves to
-  // the bare API origin (`https://api.useatlas.dev/`), which has no CORS
-  // headers and produces a console error per render. #2502.
+  // Short-circuit when path is empty/falsy. Without this guard, an empty path
+  // would resolve to `fetch(\`${apiUrl}\`)` — the bare API origin — which has
+  // no CORS headers and logs a console error per render. The pattern that
+  // triggers it: a conditional path expression like `id ? "/api/.../" + id : ""`
+  // for a detail dialog that's only valid once an id is picked. #2502.
   const enabledOption = (opts?.enabled ?? true) && !!path;
 
   const query = useQuery<T, FetchError>({


### PR DESCRIPTION
Closes #2502.

## Summary

- **Hook guard** (`useAdminFetch`): combine `opts.enabled` with `!!path` so any empty/falsy path disables the query. Stops the bare-origin fetch at the source for any future call site that forgets the gate.
- **Call sites** (`/platform`, `/platform/sla`): pass `enabled: !!detailId` on the detail-dialog `useAdminFetch` calls so the intent (don't fetch until a workspace is picked) is explicit at the caller.
- Test: `empty path short-circuits the request` + `empty path flips to a real path to fire the request`.

`useAdminMutation` already guards against missing path and only fires on user action, so no change there.

## Why two layers

Issue acknowledged the trade-off — fix the upstream condition (preferred) vs. just rely on the hook guard (cheap). I did both: the hook guard catches future regressions of the same pattern, the call-site `enabled` makes the gate explicit and surfaces it in code review.

## Test plan

- [x] `bun test packages/web/src/ui/__tests__/use-admin-fetch.test.ts` — 40/40 pass (38 prior + 2 new)
- [x] `bun run type` — clean
- [x] `bun run lint` — no new warnings
- [ ] Manual: open `/platform`, confirm no `https://api.useatlas.dev/` requests in network tab and no CORS errors in console
- [ ] Manual: open a workspace detail dialog — request to `/api/v1/platform/workspaces/<id>` fires once, dialog populates