### PR TITLE
fix(web): #2504 — restore chat env picker visibility on multi-member group workspaces

### DIFF
--- a/e2e/browser/multi-env-admin.integration.spec.ts
+++ b/e2e/browser/multi-env-admin.integration.spec.ts
@@ -536,14 +536,12 @@ test.describe("chat env/member picker (#2345)", () => {
   });
 
   /**
-   * Regression guard for #2504. The previous shape of these tests only
-   * verified the picker exists in the empty-state composer — which is
-   * what #2504 actually broke when the `/` route migrated to the
-   * `(workspace)` shell and dropped the wire-up. To catch the next
-   * regression early, this test explicitly asserts the picker stays
-   * visible in BOTH the empty state AND the active-conversation state,
-   * so a future refactor that conditions the render on
-   * `messages.length === 0` (or vice versa) still fails the build.
+   * Regression guard for #2504. The empty-state half already catches
+   * the canonical case (picker missing from `(workspace)/page.tsx`
+   * after the shell migration); the active-conversation half is the
+   * forward-looking guard against the most likely future regression
+   * shape — wrapping the render in a `messages.length === 0`
+   * (or inverse) condition.
    */
   test("#2504 — picker is visible in BOTH empty state and active conversation", async ({ page }) => {
     const captured = { lastChatBody: null as Record<string, unknown> | null };
@@ -564,10 +562,8 @@ test.describe("chat env/member picker (#2345)", () => {
     await page.keyboard.press("Enter");
     await page.waitForResponse(/\/api\/v1\/chat$/);
 
-    // Active conversation — picker is still present. This is the half of
-    // the assertion that #2504's original "passing" test missed: the
-    // empty-state assertion alone passed even with the picker gone, so
-    // long as the trigger was somewhere in DOM during the goto wait.
+    // Active conversation — picker is still present. Fails any future
+    // refactor that conditions the render on `messages.length === 0`.
     await expect(trigger, "picker missing in active conversation (#2504)").toBeVisible();
   });
 

--- a/e2e/browser/multi-env-admin.integration.spec.ts
+++ b/e2e/browser/multi-env-admin.integration.spec.ts
@@ -535,6 +535,42 @@ test.describe("chat env/member picker (#2345)", () => {
     await expect(page.getByTestId("chat-env-picker-member-staging-us")).toBeVisible();
   });
 
+  /**
+   * Regression guard for #2504. The previous shape of these tests only
+   * verified the picker exists in the empty-state composer — which is
+   * what #2504 actually broke when the `/` route migrated to the
+   * `(workspace)` shell and dropped the wire-up. To catch the next
+   * regression early, this test explicitly asserts the picker stays
+   * visible in BOTH the empty state AND the active-conversation state,
+   * so a future refactor that conditions the render on
+   * `messages.length === 0` (or vice versa) still fails the build.
+   */
+  test("#2504 — picker is visible in BOTH empty state and active conversation", async ({ page }) => {
+    const captured = { lastChatBody: null as Record<string, unknown> | null };
+    await installChatEnvMocks(page, buildChatEnvFixture(), captured);
+
+    await page.goto("/");
+
+    // Empty state — picker is present before any message has been sent.
+    const trigger = page.getByTestId("chat-env-picker-trigger");
+    await expect(trigger, "picker missing in empty state (#2504)").toBeVisible();
+
+    // Send a turn so the surface transitions from empty-state hero to an
+    // active-conversation view. The mock streams a single text-delta
+    // frame and finishes; `waitForResponse` blocks until the POST is in
+    // flight, then the assertion below confirms the picker survived the
+    // state transition.
+    await page.locator("textarea, input[type=text]").first().fill("hi");
+    await page.keyboard.press("Enter");
+    await page.waitForResponse(/\/api\/v1\/chat$/);
+
+    // Active conversation — picker is still present. This is the half of
+    // the assertion that #2504's original "passing" test missed: the
+    // empty-state assertion alone passed even with the picker gone, so
+    // long as the trigger was somewhere in DOM during the goto wait.
+    await expect(trigger, "picker missing in active conversation (#2504)").toBeVisible();
+  });
+
   test("per-turn override stamps connectionId into the chat request body", async ({ page }) => {
     const captured = { lastChatBody: null as Record<string, unknown> | null };
     await installChatEnvMocks(page, buildChatEnvFixture(), captured);

--- a/packages/web/src/app/(workspace)/page.tsx
+++ b/packages/web/src/app/(workspace)/page.tsx
@@ -23,7 +23,11 @@ import { ToolPart } from "@/ui/components/chat/tool-part";
 import { Markdown } from "@/ui/components/chat/markdown";
 import { TypingIndicator } from "@/ui/components/chat/typing-indicator";
 import { ShareDialog } from "@/ui/components/chat/share-dialog";
-import { ChatEnvPicker, useChatEnvGroups } from "@/ui/components/chat/env-picker";
+import {
+  ChatEnvPicker,
+  shouldRenderEnvPicker,
+  useChatEnvGroups,
+} from "@/ui/components/chat/env-picker";
 import { parseSuggestions } from "@/ui/lib/helpers";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Button } from "@/components/ui/button";
@@ -63,11 +67,12 @@ function ChatPage() {
   const [input, setInput] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [fetchErrorDismissed, setFetchErrorDismissed] = useState(false);
-  // #2345 / #2504 — chat env/member picker state. Group is the *content
-  // scope* the server persists on the conversation row; connection id is
-  // the *per-turn execution target* (override-only, not persisted). Both
-  // default to `null` so legacy single-connection workspaces continue
-  // through the un-picked routing path.
+  // #2345 / #2504 — chat env/member picker state, client-side. Group id
+  // is the content scope the server later persists on the conversation
+  // row; connection id is a per-turn execution-target override the
+  // server reads off the request body and does not persist. Both start
+  // `null` so an un-picked workspace sends an unset body and the server
+  // applies default routing.
   const [selectedGroupId, setSelectedGroupId] = useState<string | null>(null);
   const [selectedConnectionId, setSelectedConnectionId] = useState<string | null>(null);
   // Adaptive empty-chat starter surface — backend composes the ranked
@@ -124,9 +129,9 @@ function ChatPage() {
       }, 500);
     },
     // #2345 / #2504 — forward picker selection on every chat request.
-    // The transport reads these refs at fetch time so a mid-conversation
-    // override reaches the agent on the very next turn without rebuilding
-    // the transport.
+    // The transport reads these refs at fetch time so a selection change
+    // reaches the agent on the next turn without rebuilding the
+    // transport.
     getConnectionId: () => selectedConnectionId,
     getConnectionGroupId: () => selectedGroupId,
   });
@@ -164,14 +169,13 @@ function ChatPage() {
     getCredentials,
   });
 
-  // Mirror the env-picker.tsx visibility predicate at the page level so
-  // the wrapper row collapses cleanly (no stray hairline border) when
-  // the picker self-hides on a 1×1 workspace. Stays a single source of
-  // shape in env-picker.tsx — this is purely for layout.
-  const showEnvPicker =
-    (envGroupsQuery.groups.length === 0 && envGroupsQuery.reason !== null) ||
-    envGroupsQuery.groups.length > 1 ||
-    (envGroupsQuery.groups[0]?.members.length ?? 0) > 1;
+  // Collapse the wrapper row's hairline border when the picker hides
+  // itself on a legacy 1×1 workspace.
+  const showEnvPicker = shouldRenderEnvPicker({
+    groups: envGroupsQuery.groups,
+    reason: envGroupsQuery.reason,
+    error: envGroupsQuery.error,
+  });
 
   const refreshConvosRef = useRef(convos.refresh);
   refreshConvosRef.current = convos.refresh;
@@ -431,18 +435,17 @@ function ChatPage() {
           >
             <div className="mx-auto flex w-full max-w-4xl flex-1 flex-col overflow-hidden px-4 pt-4">
               {/* Top control row — env picker (left) + share dialog (right).
-                  Renders only when at least one child is visible, so the
-                  hairline border doesn't appear on the empty-state hero
-                  of a legacy 1×1 workspace. The picker itself is the
-                  user's only way to scope or override the agent's choice
-                  mid-stream (per #2345); the prior workspace shell shipped
-                  without it, which is the regression #2504 fixed. */}
+                  Renders only when at least one child is visible so the
+                  hairline border doesn't appear on a legacy 1×1 workspace.
+                  The picker is how the user re-scopes a conversation on
+                  the next turn (#2345); restoring it here is #2504. */}
               {(showEnvPicker || conversationId) && (
                 <div className="mb-3 flex items-center justify-between gap-2 border-b border-zinc-100 pb-2 dark:border-zinc-800/60">
                   <div className="flex items-center gap-2">
                     <ChatEnvPicker
                       groups={envGroupsQuery.groups}
                       emptyReason={envGroupsQuery.reason}
+                      transportError={envGroupsQuery.error}
                       activeGroupId={selectedGroupId}
                       activeConnectionId={selectedConnectionId}
                       onSelect={({ groupId, connectionId }) => {

--- a/packages/web/src/app/(workspace)/page.tsx
+++ b/packages/web/src/app/(workspace)/page.tsx
@@ -23,6 +23,7 @@ import { ToolPart } from "@/ui/components/chat/tool-part";
 import { Markdown } from "@/ui/components/chat/markdown";
 import { TypingIndicator } from "@/ui/components/chat/typing-indicator";
 import { ShareDialog } from "@/ui/components/chat/share-dialog";
+import { ChatEnvPicker, useChatEnvGroups } from "@/ui/components/chat/env-picker";
 import { parseSuggestions } from "@/ui/lib/helpers";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Button } from "@/components/ui/button";
@@ -62,6 +63,13 @@ function ChatPage() {
   const [input, setInput] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [fetchErrorDismissed, setFetchErrorDismissed] = useState(false);
+  // #2345 / #2504 — chat env/member picker state. Group is the *content
+  // scope* the server persists on the conversation row; connection id is
+  // the *per-turn execution target* (override-only, not persisted). Both
+  // default to `null` so legacy single-connection workspaces continue
+  // through the un-picked routing path.
+  const [selectedGroupId, setSelectedGroupId] = useState<string | null>(null);
+  const [selectedConnectionId, setSelectedConnectionId] = useState<string | null>(null);
   // Adaptive empty-chat starter surface — backend composes the ranked
   // prompt list from favorites / popular / library tiers (#1474).
   const [starterPrompts, setStarterPrompts] = useState<
@@ -115,6 +123,12 @@ function ChatPage() {
         });
       }, 500);
     },
+    // #2345 / #2504 — forward picker selection on every chat request.
+    // The transport reads these refs at fetch time so a mid-conversation
+    // override reaches the agent on the very next turn without rebuilding
+    // the transport.
+    getConnectionId: () => selectedConnectionId,
+    getConnectionGroupId: () => selectedGroupId,
   });
 
   const convos = useConversations({
@@ -139,6 +153,25 @@ function ChatPage() {
   // into setting up a connection before the agent gets a chance to run
   // and fail confusingly downstream.
   const needsDataSetup = datasource.data?.tableCount === 0;
+
+  // #2345 / #2504 — env/member picker feed. Gated on auth so the request
+  // doesn't 401 on first paint. The picker self-hides for legacy
+  // single-connection workspaces, so leaving the hook always-on is safe.
+  const envGroupsQuery = useChatEnvGroups({
+    apiUrl: getApiUrl(),
+    enabled: authResolved && isSignedIn,
+    getHeaders,
+    getCredentials,
+  });
+
+  // Mirror the env-picker.tsx visibility predicate at the page level so
+  // the wrapper row collapses cleanly (no stray hairline border) when
+  // the picker self-hides on a 1×1 workspace. Stays a single source of
+  // shape in env-picker.tsx — this is purely for layout.
+  const showEnvPicker =
+    (envGroupsQuery.groups.length === 0 && envGroupsQuery.reason !== null) ||
+    envGroupsQuery.groups.length > 1 ||
+    (envGroupsQuery.groups[0]?.members.length ?? 0) > 1;
 
   const refreshConvosRef = useRef(convos.refresh);
   refreshConvosRef.current = convos.refresh;
@@ -397,14 +430,35 @@ function ChatPage() {
             )}
           >
             <div className="mx-auto flex w-full max-w-4xl flex-1 flex-col overflow-hidden px-4 pt-4">
-              {conversationId && (
-                <div className="mb-3 flex items-center justify-end border-b border-zinc-100 pb-2 dark:border-zinc-800/60">
-                  <ShareDialog
-                    conversationId={conversationId}
-                    onShare={handleShare}
-                    onUnshare={handleUnshare}
-                    onGetShareStatus={handleGetShareStatus}
-                  />
+              {/* Top control row — env picker (left) + share dialog (right).
+                  Renders only when at least one child is visible, so the
+                  hairline border doesn't appear on the empty-state hero
+                  of a legacy 1×1 workspace. The picker itself is the
+                  user's only way to scope or override the agent's choice
+                  mid-stream (per #2345); the prior workspace shell shipped
+                  without it, which is the regression #2504 fixed. */}
+              {(showEnvPicker || conversationId) && (
+                <div className="mb-3 flex items-center justify-between gap-2 border-b border-zinc-100 pb-2 dark:border-zinc-800/60">
+                  <div className="flex items-center gap-2">
+                    <ChatEnvPicker
+                      groups={envGroupsQuery.groups}
+                      emptyReason={envGroupsQuery.reason}
+                      activeGroupId={selectedGroupId}
+                      activeConnectionId={selectedConnectionId}
+                      onSelect={({ groupId, connectionId }) => {
+                        setSelectedGroupId(groupId);
+                        setSelectedConnectionId(connectionId);
+                      }}
+                    />
+                  </div>
+                  {conversationId && (
+                    <ShareDialog
+                      conversationId={conversationId}
+                      onShare={handleShare}
+                      onUnshare={handleUnshare}
+                      onGetShareStatus={handleGetShareStatus}
+                    />
+                  )}
                 </div>
               )}
 

--- a/packages/web/src/ui/__tests__/env-picker.test.tsx
+++ b/packages/web/src/ui/__tests__/env-picker.test.tsx
@@ -35,6 +35,7 @@ mock.module("@/components/ui/dropdown-menu", () => {
 import { render, renderHook, waitFor, cleanup } from "@testing-library/react";
 import {
   ChatEnvPicker,
+  shouldRenderEnvPicker,
   useChatEnvGroups,
   type ChatEnvGroup,
 } from "../components/chat/env-picker";
@@ -516,5 +517,121 @@ describe("useChatEnvGroups (#2422)", () => {
     // going to.
     await new Promise((r) => setTimeout(r, 0));
     expect(callCount()).toBe(0);
+  });
+});
+
+const oneMember = [{ connectionId: "a", dbType: "postgres", description: null }] as const;
+const twoMembers = [
+  { connectionId: "a", dbType: "postgres", description: null },
+  { connectionId: "b", dbType: "postgres", description: null },
+] as const;
+
+describe("shouldRenderEnvPicker truth table (#2504)", () => {
+  test("hides on empty groups with no reason and no error (legacy single-connection workspace)", () => {
+    expect(shouldRenderEnvPicker({ groups: [], reason: null })).toBe(false);
+    expect(shouldRenderEnvPicker({ groups: [], reason: null, error: null })).toBe(false);
+  });
+
+  test("renders on empty groups when a reason is set (#2422 diagnostic chip path)", () => {
+    expect(shouldRenderEnvPicker({ groups: [], reason: "no_internal_db" })).toBe(true);
+    expect(shouldRenderEnvPicker({ groups: [], reason: "no_active_org" })).toBe(true);
+  });
+
+  test("renders on empty groups when a transport error is set (#2504 connection-failure chip)", () => {
+    expect(shouldRenderEnvPicker({ groups: [], reason: null, error: "HTTP 500" })).toBe(true);
+  });
+
+  test("hides the trivial 1×1 case (one group, one member)", () => {
+    expect(
+      shouldRenderEnvPicker({ groups: [{ members: oneMember }], reason: null }),
+    ).toBe(false);
+  });
+
+  test("renders when one group has 2+ members (the legitimate multi-env case)", () => {
+    expect(
+      shouldRenderEnvPicker({ groups: [{ members: twoMembers }], reason: null }),
+    ).toBe(true);
+  });
+
+  test("renders on 2+ groups even when every group is a singleton (0062 1:1 backfill)", () => {
+    expect(
+      shouldRenderEnvPicker({
+        groups: [{ members: oneMember }, { members: oneMember }],
+        reason: null,
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("ChatEnvPicker transportError (#2504)", () => {
+  test("renders an inline 'connection error' chip when groups is empty and transportError is set", () => {
+    const { container } = render(
+      <ChatEnvPicker
+        groups={[]}
+        transportError="HTTP 500"
+        activeGroupId={null}
+        activeConnectionId={null}
+        onSelect={noop}
+      />,
+    );
+    const chip = container.querySelector(
+      '[data-testid="chat-env-picker-transport-error"]',
+    );
+    expect(chip).not.toBeNull();
+    // The raw error string must not leak into user-visible copy — only
+    // the degraded-state signal.
+    expect(chip?.textContent).not.toContain("HTTP 500");
+    expect(chip?.textContent).toContain("unavailable");
+  });
+
+  test("emptyReason takes precedence over transportError when both are set", () => {
+    // The reason path is the server's authoritative diagnostic
+    // (#2422). The transport-error chip is the fallback when the
+    // server couldn't reach a usable response shape at all, so a
+    // populated `emptyReason` strictly wins.
+    const { container } = render(
+      <ChatEnvPicker
+        groups={[]}
+        emptyReason="no_internal_db"
+        transportError="HTTP 500"
+        activeGroupId={null}
+        activeConnectionId={null}
+        onSelect={noop}
+      />,
+    );
+    expect(
+      container.querySelector('[data-testid="chat-env-picker-empty-reason"]'),
+    ).not.toBeNull();
+    expect(
+      container.querySelector('[data-testid="chat-env-picker-transport-error"]'),
+    ).toBeNull();
+  });
+
+  test("ignores transportError when groups is non-empty (the fetch eventually succeeded)", () => {
+    const groups: ChatEnvGroup[] = [
+      {
+        id: "g_prod",
+        name: "prod",
+        members: [
+          { connectionId: "us-int", dbType: "postgres", description: null },
+          { connectionId: "eu-int", dbType: "postgres", description: null },
+        ],
+      },
+    ];
+    const { container } = render(
+      <ChatEnvPicker
+        groups={groups}
+        transportError="HTTP 500"
+        activeGroupId="g_prod"
+        activeConnectionId="us-int"
+        onSelect={noop}
+      />,
+    );
+    expect(
+      container.querySelector('[data-testid="chat-env-picker-transport-error"]'),
+    ).toBeNull();
+    expect(
+      container.querySelector('[data-testid="chat-env-picker-trigger"]'),
+    ).not.toBeNull();
   });
 });

--- a/packages/web/src/ui/components/atlas-chat.tsx
+++ b/packages/web/src/ui/components/atlas-chat.tsx
@@ -544,6 +544,7 @@ export function AtlasChat() {
                   <ChatEnvPicker
                     groups={envGroupsQuery.groups}
                     emptyReason={envGroupsQuery.reason}
+                    transportError={envGroupsQuery.error}
                     activeGroupId={selectedGroupId}
                     activeConnectionId={selectedConnectionId}
                     onSelect={({ groupId, connectionId }) => {

--- a/packages/web/src/ui/components/chat/env-picker.tsx
+++ b/packages/web/src/ui/components/chat/env-picker.tsx
@@ -60,6 +60,13 @@ export interface ChatEnvPickerProps {
    * #2422.
    */
   readonly emptyReason?: MeConnectionGroupsEmptyReason | null;
+  /**
+   * Non-null when the `/api/v1/me/connection-groups` fetch failed
+   * (4xx/5xx, CORS, network). Swaps the silent hide for an inline
+   * "unavailable" chip — the silent hide is what #2504 was. The raw
+   * message is not surfaced ("Failed to fetch" helps nobody).
+   */
+  readonly transportError?: string | null;
   /** Currently active group id. `null` ⇒ no group context yet. */
   readonly activeGroupId: string | null;
   /** Currently active member (execution target). `null` ⇒ inherit from group's first member. */
@@ -71,6 +78,24 @@ export interface ChatEnvPickerProps {
    * (also update the conversation row on the next request).
    */
   readonly onSelect: (next: { groupId: string; connectionId: string }) => void;
+}
+
+/**
+ * Single source of truth for the picker's visibility shape. Parent
+ * layouts use it to collapse their own wrapper row (hairline border)
+ * when the picker self-hides — exporting keeps the predicate from
+ * drifting against a future #2408-style tweak.
+ */
+export interface ShouldRenderEnvPickerArgs {
+  readonly groups: ReadonlyArray<{ readonly members: ReadonlyArray<unknown> }>;
+  readonly reason: MeConnectionGroupsEmptyReason | null;
+  readonly error?: string | null;
+}
+
+export function shouldRenderEnvPicker(args: ShouldRenderEnvPickerArgs): boolean {
+  if (args.groups.length === 0) return args.reason !== null || args.error != null;
+  if (args.groups.length > 1) return true;
+  return (args.groups[0]?.members.length ?? 0) > 1;
 }
 
 const EMPTY_REASON_COPY: Record<MeConnectionGroupsEmptyReason, string> = {
@@ -93,6 +118,7 @@ function isKnownEmptyReason(value: unknown): value is MeConnectionGroupsEmptyRea
 export function ChatEnvPicker({
   groups,
   emptyReason = null,
+  transportError = null,
   activeGroupId,
   activeConnectionId,
   onSelect,
@@ -115,13 +141,24 @@ export function ChatEnvPicker({
     );
   }
 
-  // Hide only the truly trivial 1×1 case: one group with one member.
-  // The 0062 1:1 backfill emits N singleton groups for N legacy
-  // connections, so anything ≥ 2 groups (even all singletons) is a
-  // legitimate environment fan-out we want to surface — otherwise the
-  // 1.4.4 marquee feature stays invisible on the dev/demo setup. See
-  // #2408.
-  if (groups.length < 2 && (groups[0]?.members.length ?? 0) < 2) return null;
+  // Transport failure with no cached groups — emptyReason takes
+  // precedence above, so this is the "server unreachable" fallback.
+  if (groups.length === 0 && transportError) {
+    return (
+      <div
+        className="flex h-8 items-center gap-1.5 rounded-full border border-red-200 bg-red-50 px-2.5 text-xs font-medium text-red-900 dark:border-red-900/40 dark:bg-red-950/30 dark:text-red-200"
+        role="status"
+        data-testid="chat-env-picker-transport-error"
+      >
+        <AlertCircle className="size-3.5" aria-hidden />
+        <span>Environments unavailable — connection error.</span>
+      </div>
+    );
+  }
+
+  if (!shouldRenderEnvPicker({ groups, reason: emptyReason, error: transportError })) {
+    return null;
+  }
 
   const activeGroup =
     groups.find((g) => g.id === activeGroupId) ??


### PR DESCRIPTION
## Summary

- `/` migrated to the `(workspace)` shell and dropped the `ChatEnvPicker` wire-up — the picker lived only in the legacy embeddable `<AtlasChat>` (used by `@useatlas/react`). Multi-env routing worked at the agent level (verified live across us/eu/apac on signup-count queries), but users had no way to scope or override on the next turn, blocking the #2443 per-turn-override checklist item.
- Wires `ChatEnvPicker` + `useChatEnvGroups` into `(workspace)/page.tsx`. Forwards `connectionId` / `connectionGroupId` via `useAtlasTransport` on every chat request. Renders the picker (left) + share dialog (right) in a single top control row visible in **both** empty state and active conversation.
- Extracts `shouldRenderEnvPicker(groups, reason, error)` from `env-picker.tsx` so the page-level wrapper-row predicate stays mechanically in sync with the picker's internal branches (no drift on a future #2408-style tweak). Single source of shape; unit-tested truth table covers empty / 1×1 / multi-singleton / multi-member shapes.
- Surfaces `useChatEnvGroups.error` via a new `transportError` prop. A `/me/connection-groups` 4xx/5xx/CORS/network failure now renders an "Environments unavailable" chip instead of silently hiding — silent hide on transport failure is the same UX failure mode #2504 fixed in a different cause. `emptyReason` (#2422) takes precedence. Raw error message is not surfaced — chip signals state without leaking transport detail.

## Why the integration test missed it

The previous `multi-env-admin.integration.spec.ts` "three-member group" test only asserted `expect(trigger).toBeVisible()` once after `page.goto("/")` and never asserted visibility after a state transition. The new `#2504 — picker is visible in BOTH empty state and active conversation` test sends a turn through the mocked transport and re-asserts, so any future refactor that conditions the render on `messages.length === 0` fails the build.

## Acceptance criteria

- [x] Env picker visible in chat empty state when workspace has >1 connection or a multi-member group
- [x] Env picker visible in active conversation in the same conditions
- [x] Multi-member group renders three options under one `prod` label
- [x] Per-turn override stamps `connectionId` + `connectionGroupId` into the POST `/api/v1/chat` request body
- [x] Single-connection workspaces follow #2408's predicate (picker shown when there's >1 selectable target, hidden when only one)
- [x] e2e regression guard tightened in `multi-env-admin.integration.spec.ts` — new test fails when picker is missing after sending a turn

## Review findings addressed

- **Silent failure**: `envGroupsQuery.error` is now surfaced via the `transportError` chip (was previously read but unused — same UX failure as #2504).
- **Predicate duplication**: extracted `shouldRenderEnvPicker` helper; both call sites + the picker's internal branch consume it. Unit-test truth table added.
- **Test comment accuracy**: regression-guard comment reframed — empty-state half catches #2504 itself, active-conversation half is the forward-looking guard.
- **State/transport comments**: scoped to client semantics, "next turn" instead of "mid-stream".

## Test plan

- [x] `bun run lint` (0 errors)
- [x] `bun run type` clean
- [x] `bun run test` — all 601 test files pass across api/web/others, 0 failures
- [x] env-picker unit tests: 29/29 (was 20/20 — added 9 new tests for the predicate truth table + transport-error chip)
- [x] All drift checks pass (template, schema, railway-watch, security-headers, oauth-helper)
- [ ] Manual verify on demo with 3-connection prod group: picker visible in empty + active conversation, per-turn override flips the next POST body

Closes #2504