### PR TITLE
fix(api): #2505 — gate `default` connection from agent tool context on SaaS

### DIFF
--- a/packages/api/src/lib/__tests__/agent-saas-default-gate.test.ts
+++ b/packages/api/src/lib/__tests__/agent-saas-default-gate.test.ts
@@ -101,6 +101,23 @@ describe("#2505 agent system prompt — default connection visibility by deployM
     expect(content).not.toContain("- **default**");
   });
 
+  test("SaaS [default + warehouse]: filter drops to one entry, single-source dialect path runs on the survivor", () => {
+    // Regression guard: filtering happens BEFORE the `meta.length <= 1`
+    // branch, so dropping `default` from a 2-entry registry routes the
+    // prompt through the single-source path. The dialect must come from
+    // the survivor (warehouse), not from `default`. Using mysql for the
+    // survivor here so the dialect guide is observable in the prompt.
+    mockConfigOverride = { deployMode: "saas" };
+    mockEntries.length = 0;
+    mockEntries.push({ id: "default", dbType: "postgres", description: "Shared demo" });
+    mockEntries.push({ id: "warehouse", dbType: "mysql", description: "User warehouse" });
+    const result = buildSystemParam("openai");
+    const content = typeof result === "string" ? result : result.content;
+    expect(content).not.toContain("- **default**");
+    expect(content).not.toContain("## Available Data Sources");
+    expect(content).toContain("SQL Dialect: MySQL");
+  });
+
   test("self-hosted (explicit): 'default' remains visible to the agent", () => {
     mockConfigOverride = { deployMode: "self-hosted" };
     const result = buildSystemParam("openai");

--- a/packages/api/src/lib/__tests__/agent-saas-default-gate.test.ts
+++ b/packages/api/src/lib/__tests__/agent-saas-default-gate.test.ts
@@ -1,0 +1,119 @@
+/**
+ * #2505 — The agent's tool context must not list the runtime-registered
+ * `default` connection on SaaS, where `default` sources from the shared
+ * `ATLAS_DATASOURCE_URL` demo (NovaMart). Self-hosted single-tenant
+ * deployments keep `default` because it IS their operator connection.
+ *
+ * The resolver-layer pair (`isConnectionVisibleInMode("default", …)`)
+ * is covered in `db-isconnectionvisible-default-saas.test.ts` — split out
+ * because that test cannot share this file's `connection.ts` module mock.
+ */
+import { describe, test, expect, beforeEach, mock } from "bun:test";
+import type { ConnectionMetadata } from "../db/connection";
+import { createConnectionMock } from "@atlas/api/testing/connection";
+
+let mockConfigOverride: { deployMode?: "saas" | "self-hosted" } | null = null;
+const mockEntries: ConnectionMetadata[] = [];
+
+function resetEntries() {
+  mockEntries.length = 0;
+  mockEntries.push({ id: "default", dbType: "postgres", description: "Shared demo" });
+  mockEntries.push({ id: "warehouse", dbType: "postgres", description: "User warehouse" });
+  mockEntries.push({ id: "sales", dbType: "mysql", description: "Sales DB" });
+}
+resetEntries();
+
+mock.module("@atlas/api/lib/config", () => ({
+  getConfig: () => mockConfigOverride,
+  defineConfig: (c: unknown) => c,
+}));
+
+mock.module("@atlas/api/lib/db/connection", () =>
+  createConnectionMock({
+    connections: {
+      list: () => mockEntries.map((e) => e.id),
+      describe: () =>
+        mockEntries.map((e) => ({
+          id: e.id,
+          dbType: e.dbType,
+          description: e.description,
+        })),
+    },
+  }),
+);
+
+mock.module("@atlas/api/lib/semantic", () => ({
+  getOrgWhitelistedTables: () => new Set(),
+  loadOrgWhitelist: async () => new Map(),
+  invalidateOrgWhitelist: () => {},
+  getOrgSemanticIndex: async () => "",
+  invalidateOrgSemanticIndex: () => {},
+  _resetOrgWhitelists: () => {},
+  _resetOrgSemanticIndexes: () => {},
+  getWhitelistedTables: () => new Set(),
+  _resetWhitelists: () => {},
+  getCrossSourceJoins: () => [],
+}));
+
+mock.module("@atlas/api/lib/plugins/tools", () => ({
+  getContextFragments: () => [],
+  getDialectHints: () => [],
+  setContextFragments: () => {},
+  setDialectHints: () => {},
+  setPluginTools: () => {},
+  getPluginTools: () => undefined,
+}));
+
+mock.module("@atlas/api/lib/learn/pattern-cache", () => ({
+  buildLearnedPatternsSection: async () => "",
+  getRelevantPatterns: async () => [],
+  invalidatePatternCache: () => {},
+  extractKeywords: () => new Set(),
+  _resetPatternCache: () => {},
+}));
+
+const { buildSystemParam } = await import("@atlas/api/lib/agent");
+
+describe("#2505 agent system prompt — default connection visibility by deployMode", () => {
+  beforeEach(() => {
+    mockConfigOverride = null;
+    resetEntries();
+  });
+
+  test("SaaS multi-source: 'default' is filtered, the rest of the list remains", () => {
+    mockConfigOverride = { deployMode: "saas" };
+    const result = buildSystemParam("openai");
+    const content = typeof result === "string" ? result : result.content;
+    // `default` line was the leak — must not appear in the multi-source section
+    expect(content).not.toContain("- **default**");
+    expect(content).toContain("- **warehouse**");
+    expect(content).toContain("- **sales**");
+  });
+
+  test("SaaS with only 'default' registered: prompt drops the multi-source section entirely", () => {
+    mockConfigOverride = { deployMode: "saas" };
+    mockEntries.length = 0;
+    mockEntries.push({ id: "default", dbType: "postgres", description: "Shared demo" });
+    const result = buildSystemParam("openai");
+    const content = typeof result === "string" ? result : result.content;
+    // Filtering reduces to zero sources — the multi-source heading must not appear
+    expect(content).not.toContain("## Available Data Sources");
+    expect(content).not.toContain("- **default**");
+  });
+
+  test("self-hosted (explicit): 'default' remains visible to the agent", () => {
+    mockConfigOverride = { deployMode: "self-hosted" };
+    const result = buildSystemParam("openai");
+    const content = typeof result === "string" ? result : result.content;
+    expect(content).toContain("- **default**");
+    expect(content).toContain("- **warehouse**");
+    expect(content).toContain("- **sales**");
+  });
+
+  test("self-hosted (null config — test default): 'default' remains visible", () => {
+    mockConfigOverride = null;
+    const result = buildSystemParam("openai");
+    const content = typeof result === "string" ? result : result.content;
+    expect(content).toContain("- **default**");
+  });
+});

--- a/packages/api/src/lib/__tests__/db-isconnectionvisible-default-saas.test.ts
+++ b/packages/api/src/lib/__tests__/db-isconnectionvisible-default-saas.test.ts
@@ -1,0 +1,47 @@
+/**
+ * #2505 resolver-layer pair — when the agent (or any caller using the
+ * `connectionId ?? "default"` fallback in `runUserQueryPipeline`) reaches
+ * `isConnectionVisibleInMode("default", …)`, the result must follow the
+ * deploy mode: self-hosted keeps the operator connection, SaaS refuses
+ * the shared demo. Companion to `agent-saas-default-gate.test.ts`.
+ */
+import { describe, test, expect, mock } from "bun:test";
+
+let mockConfigOverride: { deployMode?: "saas" | "self-hosted" } | null = null;
+
+mock.module("@atlas/api/lib/config", () => ({
+  getConfig: () => mockConfigOverride,
+  defineConfig: (c: unknown) => c,
+}));
+
+// `default` short-circuits BEFORE `hasInternalDB()` runs — no need to
+// stub internal.ts. Tests that exercise non-default branches must mock
+// every export of `@atlas/api/lib/db/internal` because partial module
+// mocks throw SyntaxError when other consumers re-export symbols.
+const { isConnectionVisibleInMode } = await import("@atlas/api/lib/db/connection");
+
+describe("#2505 isConnectionVisibleInMode — default gating by deployMode", () => {
+  test.each([
+    ["saas", false],
+    ["self-hosted", true],
+  ] as const)(
+    "deployMode=%s: `default` resolver gate returns %p",
+    async (deployMode, expected) => {
+      mockConfigOverride = { deployMode };
+      const visible = await isConnectionVisibleInMode("org_abc", "default", "published");
+      expect(visible).toBe(expected);
+    },
+  );
+
+  test("null config (test default): `default` remains visible (self-hosted-like)", async () => {
+    mockConfigOverride = null;
+    const visible = await isConnectionVisibleInMode("org_abc", "default", "published");
+    expect(visible).toBe(true);
+  });
+
+  test("SaaS gate is independent of mode (published or developer)", async () => {
+    mockConfigOverride = { deployMode: "saas" };
+    expect(await isConnectionVisibleInMode("org_abc", "default", "published")).toBe(false);
+    expect(await isConnectionVisibleInMode("org_abc", "default", "developer")).toBe(false);
+  });
+});

--- a/packages/api/src/lib/agent.ts
+++ b/packages/api/src/lib/agent.ts
@@ -152,6 +152,21 @@ function dialectName(dbType: DBType): string {
   return DIALECT_DISPLAY_NAMES[dbType] ?? dbType.charAt(0).toUpperCase() + dbType.slice(1);
 }
 
+/**
+ * Filter the connection registry to the set the agent should see in its tool
+ * context. On SaaS the runtime-registered `default` connection sources from
+ * the shared `ATLAS_DATASOURCE_URL` demo service (NovaMart), not a per-org
+ * connection — surfacing it to the agent let it run the workspace's first
+ * query against the demo and label demo data as the user's (#2505). #2483
+ * gated the admin VIEW; this is the agent-context half. Self-hosted single-
+ * tenant deployments keep `default` because it IS their operator connection.
+ */
+function filterAgentVisibleSources(sources: ConnectionMetadata[]): ConnectionMetadata[] {
+  const isSaas = getConfig()?.deployMode === "saas";
+  if (!isSaas) return sources;
+  return sources.filter((s) => s.id !== "default");
+}
+
 function buildMultiSourceSection(
   sources: ConnectionMetadata[],
 ): string {
@@ -246,7 +261,7 @@ function buildSystemPrompt(registry: ToolRegistry, orgSemanticIndex?: string, le
   if (fragments.length > 0) {
     base += "\n\n" + fragments.join("\n\n");
   }
-  const meta = connections.describe();
+  const meta = filterAgentVisibleSources(connections.describe());
 
   // Single-connection: identical to pre-v0.7 behavior
   if (meta.length <= 1) {

--- a/packages/api/src/lib/db/connection.ts
+++ b/packages/api/src/lib/db/connection.ts
@@ -22,6 +22,7 @@ import { createLogger } from "@atlas/api/lib/logger";
 import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
 import { _resetWhitelists } from "@atlas/api/lib/semantic";
 import { hasInternalDB, internalQuery } from "@atlas/api/lib/db/internal";
+import { getConfig } from "@atlas/api/lib/config";
 import type { HealthStatus } from "@atlas/api/lib/connection-types";
 
 export type { HealthStatus } from "@atlas/api/lib/connection-types";
@@ -1357,8 +1358,14 @@ export function getDB(): DBConnection {
  * Check whether a connection is visible to an org in the given atlas mode.
  *
  * Visibility rules:
- * - `"default"` — config-managed, not stored in the connections table;
- *   always visible regardless of mode.
+ * - `"default"` — config-managed, not stored in the connections table.
+ *   Self-hosted: always visible (it IS the operator's connection). SaaS:
+ *   never visible to an org session — the runtime-registered `default`
+ *   sources from the shared `ATLAS_DATASOURCE_URL` demo service, not a
+ *   per-org connection. Surfacing it to a workspace would let the agent
+ *   silently hit the demo with the `connectionId ?? "default"` fallback
+ *   in `runUserQueryPipeline` and return demo data labeled as the user's
+ *   (#2505 — paired with the agent-prompt filter in `agent.ts`).
  * - Published mode — only `status = 'published'` rows are visible.
  * - Developer mode — `status IN ('published', 'draft')` rows are visible;
  *   drafts appear alongside published connections.
@@ -1375,7 +1382,9 @@ export async function isConnectionVisibleInMode(
   connectionId: string,
   mode: AtlasMode,
 ): Promise<boolean> {
-  if (connectionId === "default") return true;
+  if (connectionId === "default") {
+    return getConfig()?.deployMode !== "saas";
+  }
   if (!hasInternalDB()) return true;
 
   const statusClause = mode === "developer"

--- a/packages/api/src/lib/db/connection.ts
+++ b/packages/api/src/lib/db/connection.ts
@@ -1365,7 +1365,7 @@ export function getDB(): DBConnection {
  *   per-org connection. Surfacing it to a workspace would let the agent
  *   silently hit the demo with the `connectionId ?? "default"` fallback
  *   in `runUserQueryPipeline` and return demo data labeled as the user's
- *   (#2505 — paired with the agent-prompt filter in `agent.ts`).
+ *   (#2505 — paired with `filterAgentVisibleSources` in `agent.ts`).
  * - Published mode — only `status = 'published'` rows are visible.
  * - Developer mode — `status IN ('published', 'draft')` rows are visible;
  *   drafts appear alongside published connections.


### PR DESCRIPTION
Closes #2505.

## Summary

- #2483 (PR #2491) gated the admin VIEW's `default` fallback by deploy mode, but the agent's tool context still surfaced `default`. `connections.describe()` walks the entire base registry, and on SaaS the runtime-registered `default` sources from the shared `ATLAS_DATASOURCE_URL` demo (NovaMart). Verified live: a fresh-signup workspace on app.useatlas.dev silently ran its first SQL against `default` and only got blocked because `"user"` isn't whitelisted there — if the question had named a NovaMart table (orders, customers, payments) the agent would have returned demo data labeled as the user's.
- **Prong 1 — `agent.ts`**: filter `connections.describe()` through `filterAgentVisibleSources` before the system prompt is built. On SaaS, `default` is dropped from the Available Data Sources list (and the single-source dialect path when no other sources remain). Self-hosted single-tenant deployments are unchanged — `default` IS the operator's connection there.
- **Prong 2 — `isConnectionVisibleInMode("default", …)`**: no longer unconditionally returns `true`. On SaaS it returns `false`, so the resolver-layer gate in `executeSQL` (`runUserQueryPipeline`'s `connectionId ?? "default"` fallback) refuses `default` even if a turn somehow proposes it despite the prompt filter. The table whitelist stays as the third line.

## Tests

- `agent-saas-default-gate.test.ts` parameterizes `buildSystemParam` on deployMode — SaaS strips `default` (verified both in the multi-source list and when no other sources remain), self-hosted (explicit and the null-config test default) keeps it.
- `db-isconnectionvisible-default-saas.test.ts` covers the resolver gate in isolation — split into its own file because the agent test's `connection.ts` module mock replaces the function under test. Also verifies the gate is mode-independent (rejects in both `published` and `developer`).

## Out of scope (intentionally — same scope discipline as #2483)

- The wider tenant-isolation question: `loadSavedConnections` registers one entry per unique connection ID across all orgs, so a `connectionId` like "warehouse" used by org A could reach the registry pool that was lazy-initialized with org B's URL. The `executeSQL` mode-visibility gate (`isConnectionVisibleInMode`) rejects connectionIds the caller's org doesn't own, but the system prompt still leaks every globally-unique connection ID across the customer base. Tracked separately — not enlarging this PR.
- Reframing the demo as a labeled shared sample dataset (the larger conversation from the dogfood notes).
- Touching the lazy `default` registration in `ConnectionRegistry` (explicitly excluded by the issue).
- Removing the now-unused `_isPlatformAdmin` param on `getVisibleConnectionIds` — same dead-arg deferral as #2483.

## Test plan

- [x] `bun test src/lib/__tests__/agent-saas-default-gate.test.ts` — 4/4 pass
- [x] `bun test src/lib/__tests__/db-isconnectionvisible-default-saas.test.ts` — 4/4 pass
- [x] `cd packages/api && bun run scripts/test-isolated.ts --affected` — 83/83 affected pass (includes existing `agent-dialect`, `connection`, `sql-mode-isolation`, `sql-connection-error`, `sql-connection-whitelist` suites)
- [x] `bun run lint` — clean (one pre-existing warning in `detect.test.ts` from c548cb63, unrelated)
- [x] `bun run type` — clean
- [x] `bun run test` — full monorepo suite passes
- [x] Syncpack, template drift, security headers drift, railway watch, schema drift, oauth helper drift — all green
- [ ] **Manual verification on SaaS prod**: fresh chat on a freshly-signed-up workspace at app.useatlas.dev, ask "how many orders are there" — the agent should surface that no data source is available (or only its own connections, if any) rather than silently running against `default`/NovaMart and falling out to the whitelist error.