### PR TITLE
fix(api,web): #2503 — reconcile entity counts across admin surfaces

### DIFF
--- a/packages/api/src/api/routes/__tests__/admin-semantic-improve.test.ts
+++ b/packages/api/src/api/routes/__tests__/admin-semantic-improve.test.ts
@@ -220,12 +220,15 @@ describe("admin-semantic-improve", () => {
     // load-bearing assertion is "loadEntitiesForOrg wins when both are
     // present", above.
 
-    it("entityCount surfaces what loadEntitiesForOrg returned (parity with Overview)", async () => {
+    it("entityCount surfaces the merged entities count, totalRows surfaces DB rows (parity with Overview)", async () => {
       // #2503: the Health card's "X entities" caption must match the count
       // the file tree above it renders. Both flow from `listAdminEntities`'s
       // DB+disk merge; `loadEntitiesForOrg` is the route's adapter to that
-      // same shape. If a future refactor swaps it for a DB-only loader the
-      // Health caption silently drifts again — this test fails first.
+      // same shape. The two numbers below are deliberately distinct: 10 DB
+      // rows + 36 disk-mirror entries = 46 merged entities. The route must
+      // surface entityCount=46 (merged → user-facing) and totalRows=10
+      // (DB-only → corrupt-discriminator denominator). A refactor that
+      // collapses either side fails here first.
       mockHasInternalDB = true;
       mock.module("@atlas/api/lib/semantic/expert/context-loader", () => ({
         loadEntitiesForOrg: async () => ({
@@ -237,7 +240,7 @@ describe("admin-semantic-improve", () => {
             joins: [],
             query_patterns: [],
           })),
-          totalRows: 46,
+          totalRows: 10,
           parseFailures: 0,
         }),
         loadEntitiesFromDisk: async () => [],
@@ -247,7 +250,39 @@ describe("admin-semantic-improve", () => {
       expect(res.status).toBe(200);
       const body = (await res.json()) as { entityCount: number; totalRows: number };
       expect(body.entityCount).toBe(46);
-      expect(body.totalRows).toBe(46);
+      expect(body.totalRows).toBe(10);
+    });
+
+    it("corrupt status still fires when disk mirror has entries but all DB rows failed parse", async () => {
+      // #2503 review (silent-failure-hunter): pre-fix, the route's `corrupt`
+      // discriminator compared `parseFailures === entities.length`. A
+      // workspace whose every DB row was unparseable but whose disk mirror
+      // had healthy entries would have `entities.length > parseFailures` →
+      // status degraded to `ok`, hiding the corruption. The route now gates
+      // `corrupt` on `totalRows` (DB-rows-considered), so the disk fill-in
+      // can't mask the signal.
+      mockHasInternalDB = true;
+      mock.module("@atlas/api/lib/semantic/expert/context-loader", () => ({
+        loadEntitiesForOrg: async () => ({
+          // 5 disk entries merged in despite all DB rows being corrupt.
+          entities: Array.from({ length: 5 }, (_, i) => ({
+            name: `d${i}`,
+            table: `d${i}`,
+            dimensions: [],
+            measures: [],
+            joins: [],
+            query_patterns: [],
+          })),
+          totalRows: 3,
+          parseFailures: 3,
+        }),
+        loadEntitiesFromDisk: async () => [],
+        loadGlossaryFromDisk: async () => [],
+      }));
+      const res = await adminSemanticImprove.request("/health");
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { status: string };
+      expect(body.status).toBe("corrupt");
     });
 
     it("response includes a status discriminator distinguishing empty from corrupt", async () => {

--- a/packages/api/src/api/routes/__tests__/admin-semantic-improve.test.ts
+++ b/packages/api/src/api/routes/__tests__/admin-semantic-improve.test.ts
@@ -165,17 +165,20 @@ describe("admin-semantic-improve", () => {
 
   describe("GET /health — DB vs disk source selection", () => {
     // Pin the load-bearing branch: when there's an org context + internal
-    // DB the endpoint must read from `loadEntitiesFromDB`. A refactor that
-    // flips back to disk would silently restore the conflation that made
-    // empty-DB SaaS workspaces show "13 entities, 100% coverage".
-    let dbCalls = 0;
+    // DB the endpoint must read from `loadEntitiesForOrg` (which merges DB
+    // rows with the per-org disk mirror under the same dedup `listAdminEntities`
+    // applies). A refactor that flips back to a DB-only or bundled-disk source
+    // would either restore the "13 entities, 100% coverage" conflation that
+    // hid empty-DB SaaS workspaces from operators, or re-open the #2503
+    // divergence between the Health card and the file tree it lives next to.
+    let orgCalls = 0;
     let diskCalls = 0;
     beforeEach(() => {
-      dbCalls = 0;
+      orgCalls = 0;
       diskCalls = 0;
       mock.module("@atlas/api/lib/semantic/expert/context-loader", () => ({
-        loadEntitiesFromDB: async () => {
-          dbCalls++;
+        loadEntitiesForOrg: async () => {
+          orgCalls++;
           return { entities: [], totalRows: 0, parseFailures: 0 };
         },
         loadEntitiesFromDisk: async () => {
@@ -185,25 +188,27 @@ describe("admin-semantic-improve", () => {
         loadGlossaryFromDisk: async () => [],
       }));
       mock.module("@atlas/api/lib/semantic/expert/health", () => ({
-        computeSemanticHealth: () => ({
+        computeSemanticHealth: (ctx: { entities: unknown[]; glossary: unknown[] }) => ({
           overall: 0,
           coverage: 0,
           descriptionQuality: 0,
           measureCoverage: 0,
           joinCoverage: 0,
-          entityCount: 0,
+          // Pass through the merged entity count so the parity guard below
+          // can assert it against `loadEntitiesForOrg`'s output.
+          entityCount: ctx.entities.length,
           dimensionCount: 0,
           measureCount: 0,
-          glossaryTermCount: 0,
+          glossaryTermCount: ctx.glossary.length,
         }),
       }));
     });
 
-    it("prefers loadEntitiesFromDB when org context + internal DB present", async () => {
+    it("prefers loadEntitiesForOrg when org context + internal DB present", async () => {
       mockHasInternalDB = true;
       const res = await adminSemanticImprove.request("/health");
       expect(res.status).toBe(200);
-      expect(dbCalls).toBe(1);
+      expect(orgCalls).toBe(1);
       expect(diskCalls).toBe(0);
     });
 
@@ -211,14 +216,45 @@ describe("admin-semantic-improve", () => {
     // routing past requireOrgContext which itself depends on the internal
     // DB — exercising that path needs deeper middleware mocking than this
     // suite carries. The branch is small enough that the type system + the
-    // single conditional in admin-semantic-improve.ts:923 keeps it honest;
-    // the load-bearing assertion is "DB wins when both are present", above.
+    // single conditional in admin-semantic-improve.ts keeps it honest; the
+    // load-bearing assertion is "loadEntitiesForOrg wins when both are
+    // present", above.
+
+    it("entityCount surfaces what loadEntitiesForOrg returned (parity with Overview)", async () => {
+      // #2503: the Health card's "X entities" caption must match the count
+      // the file tree above it renders. Both flow from `listAdminEntities`'s
+      // DB+disk merge; `loadEntitiesForOrg` is the route's adapter to that
+      // same shape. If a future refactor swaps it for a DB-only loader the
+      // Health caption silently drifts again — this test fails first.
+      mockHasInternalDB = true;
+      mock.module("@atlas/api/lib/semantic/expert/context-loader", () => ({
+        loadEntitiesForOrg: async () => ({
+          entities: Array.from({ length: 46 }, (_, i) => ({
+            name: `e${i}`,
+            table: `t${i}`,
+            dimensions: [],
+            measures: [],
+            joins: [],
+            query_patterns: [],
+          })),
+          totalRows: 46,
+          parseFailures: 0,
+        }),
+        loadEntitiesFromDisk: async () => [],
+        loadGlossaryFromDisk: async () => [],
+      }));
+      const res = await adminSemanticImprove.request("/health");
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { entityCount: number; totalRows: number };
+      expect(body.entityCount).toBe(46);
+      expect(body.totalRows).toBe(46);
+    });
 
     it("response includes a status discriminator distinguishing empty from corrupt", async () => {
       mockHasInternalDB = true;
       // Override loader to return totalRows=2, parseFailures=2 (full corruption)
       mock.module("@atlas/api/lib/semantic/expert/context-loader", () => ({
-        loadEntitiesFromDB: async () => ({ entities: [], totalRows: 2, parseFailures: 2 }),
+        loadEntitiesForOrg: async () => ({ entities: [], totalRows: 2, parseFailures: 2 }),
         loadEntitiesFromDisk: async () => [],
         loadGlossaryFromDisk: async () => [],
       }));

--- a/packages/api/src/api/routes/admin-semantic-improve.ts
+++ b/packages/api/src/api/routes/admin-semantic-improve.ts
@@ -914,20 +914,26 @@ adminSemanticImprove.openapi(reviewAmendmentRoute, async (c) =>
 adminSemanticImprove.openapi(healthScoreRoute, async (c) =>
   runHandler(c, "semantic-health-score", async () => {
     const { orgId } = c.get("orgContext");
-    const { loadEntitiesFromDB, loadEntitiesFromDisk, loadGlossaryFromDisk } =
+    const { loadEntitiesForOrg, loadEntitiesFromDisk, loadGlossaryFromDisk } =
       await import("@atlas/api/lib/semantic/expert/context-loader");
     const { hasInternalDB } = await import("@atlas/api/lib/db/internal");
     const { computeSemanticHealth } = await import("@atlas/api/lib/semantic/expert/health");
 
-    // Prefer DB-backed entities when we have an org context + internal DB.
-    // Reading bundled YAML for every workspace would show "13 entities,
-    // 100% coverage" for orgs whose `semantic_entities` is empty — a
-    // misleading score that hides broken workspaces from operators.
+    // `loadEntitiesForOrg` merges DB rows with the per-org disk mirror under
+    // the same `(name, connection_group_id)` dedup the Overview tile + chat
+    // empty state + semantic file tree all read through (#2503). Reading only
+    // DB rows here used to drop the disk-mirror half of the merge, leaving the
+    // Health caption "23 entities" next to a file tree showing 46.
+    //
+    // The no-DB / no-orgId branch still falls back to bundled YAML — the
+    // self-hosted stdio loop and bare CLI scenario. On SaaS this path can't
+    // trigger: an authenticated admin request always carries an orgId, and
+    // SaaS always runs with an internal DB.
     let entities: Awaited<ReturnType<typeof loadEntitiesFromDisk>>;
     let parseFailures = 0;
     let totalRows: number;
     if (orgId && hasInternalDB()) {
-      const dbResult = await loadEntitiesFromDB(orgId, "published");
+      const dbResult = await loadEntitiesForOrg(orgId, "published");
       entities = dbResult.entities;
       parseFailures = dbResult.parseFailures;
       totalRows = dbResult.totalRows;

--- a/packages/api/src/api/routes/admin-semantic-improve.ts
+++ b/packages/api/src/api/routes/admin-semantic-improve.ts
@@ -955,9 +955,17 @@ adminSemanticImprove.openapi(healthScoreRoute, async (c) =>
     // empty case (`no_entities`) from the corruption case (`corrupt` —
     // every entity row failed parse) instead of conflating both with a
     // 0% score that gives no actionable signal.
+    //
+    // `corrupt` gates on `totalRows` (DB-rows-considered) so a workspace
+    // whose every DB row fails YAML parse still trips the signal even when
+    // the disk mirror has healthy entries that would otherwise pad
+    // `entities.length` past `parseFailures`. `no_entities` gates on the
+    // merged `entities.length` because a workspace with 0 DB rows but a
+    // populated disk mirror genuinely has entities to query — flagging it
+    // empty would be the same misleading signal in reverse (#2503 review).
     const status = parseFailures > 0 && parseFailures === totalRows && totalRows > 0
       ? ("corrupt" as const)
-      : totalRows === 0
+      : entities.length === 0
         ? ("no_entities" as const)
         : ("ok" as const);
 

--- a/packages/api/src/lib/semantic/admin-source.ts
+++ b/packages/api/src/lib/semantic/admin-source.ts
@@ -30,6 +30,7 @@ import {
 import { getSemanticRoot as resolveSemanticRoot } from "./sync";
 import { hasInternalDB } from "@atlas/api/lib/db/internal";
 import { EntityShape, type EntityShapeT } from "./shapes";
+import { dedupKey } from "./dedup-key";
 
 const log = createLogger("semantic-admin-source");
 
@@ -270,11 +271,9 @@ function diskToAdminSummary(e: EntitySummary): AdminEntitySummary {
  * left-to-right in a stable order; disk entries (null group) sort before
  * any named group when names match.
  */
-function dedupKey(name: string, groupId: string | null): string {
-  // `\0` is illegal in YAML names and connection-group ids, so it's a safe
-  // delimiter — `users` + `g_users` cannot collide with another row.
-  return `${name}\0${groupId ?? ""}`;
-}
+// The `(name, connection_group_id)` dedup key now lives in `dedup-key.ts`
+// so `loadEntitiesForOrg` can import it without pulling the larger admin-
+// source surface into its test fixtures (#2503 review).
 
 export function mergeAdminEntities(input: {
   readonly dbRows: readonly SemanticEntityRow[];

--- a/packages/api/src/lib/semantic/dedup-key.ts
+++ b/packages/api/src/lib/semantic/dedup-key.ts
@@ -1,0 +1,20 @@
+/**
+ * `(name, connection_group_id)` dedup key — used by every admin-side entity
+ * merge (#2412 / #2503).
+ *
+ * Lives in its own module so consumers (`mergeAdminEntities` in
+ * `admin-source.ts`, `loadEntitiesForOrg` in `expert/context-loader.ts`) can
+ * import the same formula without dragging the larger admin-source surface
+ * into each other's test fixtures. Keeping the formula in one place is the
+ * mechanical guarantee that the Health card's entity count can't silently
+ * drift from the Overview tile / file tree.
+ */
+
+/**
+ * Build the dedup key. `\0` is illegal in YAML names and connection-group
+ * ids, so it's a safe delimiter — `users` + `g_users` cannot collide with
+ * another row.
+ */
+export function dedupKey(name: string, groupId: string | null): string {
+  return `${name}\0${groupId ?? ""}`;
+}

--- a/packages/api/src/lib/semantic/expert/__tests__/load-entities-for-org.test.ts
+++ b/packages/api/src/lib/semantic/expert/__tests__/load-entities-for-org.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Unit test for `loadEntitiesForOrg` (#2503).
+ *
+ * Pins the load-bearing contract: the loader feeding the Semantic Health
+ * card must produce the same `(name, connection_group_id)` dedup behavior
+ * as `listAdminEntities` (the source-of-truth for the Overview tile + the
+ * `/admin/semantic` file tree + the chat empty state). If a future refactor
+ * forks the merge logic, this test fails before the count divergence reaches
+ * a user.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it, mock } from "bun:test";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+// ---------------------------------------------------------------------------
+// Shared switches
+// ---------------------------------------------------------------------------
+
+let internalDBAvailable = true;
+
+interface FakeDBRow {
+  readonly name: string;
+  readonly table: string;
+  readonly description?: string;
+  readonly connection_group_id?: string | null;
+  readonly status?: "published" | "draft";
+  readonly dimensions?: number;
+  readonly measures?: number;
+  readonly joins?: number;
+}
+
+let publishedRows: FakeDBRow[] = [];
+let overlayRows: FakeDBRow[] = [];
+// Escape hatch for tests that need a specific malformed `yaml_content` —
+// when populated, takes precedence over `publishedRows`. Cleared each test.
+let publishedRowsOverride: ReturnType<typeof toSemanticRow>[] | null = null;
+
+function toSemanticRow(r: FakeDBRow) {
+  // YAML array syntax for dimensions so `Array.isArray(parsed.dimensions)`
+  // in `loadEntitiesForOrg` accepts it. Matches the shape `ParsedEntity`
+  // expects (array of `{name, sql, type, ...}` objects) rather than the
+  // object-map alternative the discover-layer also accepts.
+  const dims = Array.from({ length: r.dimensions ?? 0 }, (_, i) =>
+    `  - name: d${i}\n    sql: d${i}\n    type: string\n`,
+  ).join("");
+  const measures = Array.from({ length: r.measures ?? 0 }, (_, i) =>
+    `  - name: m${i}\n    sql: COUNT(*)\n    type: count\n`,
+  ).join("");
+  const joins = Array.from({ length: r.joins ?? 0 }, (_, i) =>
+    `  - name: j${i}\n    sql: a = b\n`,
+  ).join("");
+  const yamlContent =
+    `table: ${r.table}\n` +
+    (r.description ? `description: ${r.description}\n` : "") +
+    (dims ? `dimensions:\n${dims}` : "") +
+    (measures ? `measures:\n${measures}` : "") +
+    (joins ? `joins:\n${joins}` : "");
+  return {
+    id: `id-${r.name}-${r.connection_group_id ?? "null"}`,
+    org_id: "org-1",
+    entity_type: "entity" as const,
+    name: r.name,
+    yaml_content: yamlContent,
+    connection_group_id: r.connection_group_id ?? null,
+    status: r.status ?? ("published" as const),
+    created_at: "2026-01-01",
+    updated_at: "2026-01-02",
+  };
+}
+
+mock.module("@atlas/api/lib/db/internal", () => ({
+  hasInternalDB: () => internalDBAvailable,
+}));
+
+mock.module("@atlas/api/lib/semantic/entities", () => ({
+  listEntityRows: async (_orgId: string, _type: string, _status: string) =>
+    publishedRowsOverride ?? publishedRows.map(toSemanticRow),
+  listEntitiesWithOverlay: async (_orgId: string, _type: string) =>
+    overlayRows.map(toSemanticRow),
+}));
+
+// ---------------------------------------------------------------------------
+// Disk fixture — org-scoped under `.orgs/<orgId>/entities/`
+// ---------------------------------------------------------------------------
+
+const ORG_ID = "org-1";
+let tmpRoot: string;
+const ORIGINAL_SEMANTIC_ROOT = process.env.ATLAS_SEMANTIC_ROOT;
+
+beforeAll(() => {
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "atlas-load-entities-for-org-"));
+  process.env.ATLAS_SEMANTIC_ROOT = tmpRoot;
+});
+
+afterAll(() => {
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+  if (ORIGINAL_SEMANTIC_ROOT === undefined) delete process.env.ATLAS_SEMANTIC_ROOT;
+  else process.env.ATLAS_SEMANTIC_ROOT = ORIGINAL_SEMANTIC_ROOT;
+});
+
+beforeEach(() => {
+  internalDBAvailable = true;
+  publishedRows = [];
+  overlayRows = [];
+  publishedRowsOverride = null;
+  // Reset the org-scoped disk fixture each test.
+  const orgRoot = path.join(tmpRoot, ".orgs", ORG_ID);
+  fs.rmSync(orgRoot, { recursive: true, force: true });
+});
+
+function writeDiskEntity(name: string, body: string): void {
+  const dir = path.join(tmpRoot, ".orgs", ORG_ID, "entities");
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, `${name}.yml`), body);
+}
+
+// Re-import per test file (matches the pattern used by sibling semantic tests).
+const mod = (await import(`../context-loader.ts?t=${Date.now()}`)) as typeof import("../context-loader");
+const loadEntitiesForOrg = mod.loadEntitiesForOrg;
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("loadEntitiesForOrg", () => {
+  it("returns empty when no internal DB is configured", async () => {
+    internalDBAvailable = false;
+    publishedRows = [{ name: "users", table: "users" }];
+    writeDiskEntity("orders", "table: orders\n");
+    const result = await loadEntitiesForOrg(ORG_ID, "published");
+    expect(result).toEqual({ entities: [], totalRows: 0, parseFailures: 0 });
+  });
+
+  it("DB row in named group + disk-mirror with null group both appear (matches listAdminEntities dedup)", async () => {
+    // This is the #2503 shape: 1.4.4 backfill put `connection_group_id`
+    // on the DB row, the dual-write sync wrote a disk mirror under the
+    // null group, and `mergeAdminEntities` keys dedup on (name, group).
+    // The Health loader must mirror that — otherwise its count drops
+    // below what the file tree above it renders.
+    publishedRows = [{ name: "users", table: "users", connection_group_id: "g_prod" }];
+    writeDiskEntity("users", "table: users\ndescription: From disk\n");
+
+    const result = await loadEntitiesForOrg(ORG_ID, "published");
+    expect(result.totalRows).toBe(2);
+    expect(result.entities.map((e) => e.name).toSorted()).toEqual(["users", "users"]);
+  });
+
+  it("DB row with null group shadows the disk mirror (legacy null-scope case)", async () => {
+    // The single-group pre-#2503 scenario: DB row and disk row both
+    // null-scoped → same dedup key → DB wins, disk is dropped. Confirms
+    // we don't break the count for orgs that haven't migrated to groups.
+    publishedRows = [{ name: "users", table: "users", connection_group_id: null, description: "From DB" }];
+    writeDiskEntity("users", "table: users\ndescription: From disk\n");
+
+    const result = await loadEntitiesForOrg(ORG_ID, "published");
+    expect(result.entities).toHaveLength(1);
+    expect(result.totalRows).toBe(1);
+    expect(result.entities[0].description).toBe("From DB");
+  });
+
+  it("multi-group: same name in two named groups both survive, disk mirror also appears", async () => {
+    // Multi-environment case from #2412: `users` in `g_us` AND `g_eu`
+    // are genuinely distinct (different replicas). The disk mirror's
+    // null-group entry doesn't collide with either named-group key.
+    publishedRows = [
+      { name: "users", table: "users", connection_group_id: "g_us", description: "US" },
+      { name: "users", table: "users", connection_group_id: "g_eu", description: "EU" },
+    ];
+    writeDiskEntity("users", "table: users\ndescription: From disk\n");
+
+    const result = await loadEntitiesForOrg(ORG_ID, "published");
+    expect(result.totalRows).toBe(3);
+    const descriptions = result.entities.map((e) => e.description).toSorted();
+    expect(descriptions).toEqual(["EU", "From disk", "US"]);
+  });
+
+  it("counts dimensions, measures, and joins on each entity for computeSemanticHealth", async () => {
+    // Health coverage / measureCoverage / joinCoverage all sum these fields
+    // across entities. If the loader returned them empty the score would
+    // collapse even when the YAML carries real definitions.
+    publishedRows = [
+      { name: "users", table: "users", connection_group_id: null, dimensions: 3, measures: 2, joins: 1 },
+    ];
+    const result = await loadEntitiesForOrg(ORG_ID, "published");
+    expect(result.entities).toHaveLength(1);
+    expect(result.entities[0].dimensions).toHaveLength(3);
+    expect(result.entities[0].measures).toHaveLength(2);
+    expect(result.entities[0].joins).toHaveLength(1);
+  });
+
+  it("developer mode reads the overlay (drafts shadow published)", async () => {
+    // Pins that the mode parameter actually swaps DB sources. A regression
+    // that hardcoded `listEntityRows` would silently never surface drafts
+    // in the Health card.
+    overlayRows = [{ name: "users", table: "users", status: "draft", description: "Draft only" }];
+    publishedRows = [{ name: "users", table: "users", description: "Published" }];
+
+    const dev = await loadEntitiesForOrg(ORG_ID, "developer");
+    expect(dev.entities.map((e) => e.description)).toEqual(["Draft only"]);
+  });
+
+  it("counts unparseable DB rows in parseFailures, leaves entities clean", async () => {
+    // The `corrupt` discriminator on the route response distinguishes
+    // empty workspace from data-rot. parseFailures must reflect ONLY DB
+    // rows (not disk parse errors, which surface via the logger) so
+    // operators get the same signal post-#2503 as they did pre-#2503.
+    publishedRowsOverride = [
+      toSemanticRow({ name: "good", table: "good" }),
+      { ...toSemanticRow({ name: "bad", table: "bad" }), yaml_content: "{{{ not yaml" },
+    ];
+
+    const result = await loadEntitiesForOrg(ORG_ID, "published");
+    expect(result.entities.map((e) => e.name)).toEqual(["good"]);
+    expect(result.parseFailures).toBe(1);
+  });
+});

--- a/packages/api/src/lib/semantic/expert/__tests__/load-entities-for-org.test.ts
+++ b/packages/api/src/lib/semantic/expert/__tests__/load-entities-for-org.test.ts
@@ -21,8 +21,14 @@ import * as path from "path";
 let internalDBAvailable = true;
 
 interface FakeDBRow {
+  /** Row `name` column — also the default display name unless `yamlName` overrides. */
   readonly name: string;
   readonly table: string;
+  /** Optional explicit `name:` line in the YAML content. When set and distinct
+   * from `table`, the parser surfaces a divergent display name (the case the
+   * disk-dedup test exercises). When omitted, the YAML has no `name:` field
+   * so the display name falls back to `table` — matching the common case. */
+  readonly yamlName?: string;
   readonly description?: string;
   readonly connection_group_id?: string | null;
   readonly status?: "published" | "draft";
@@ -53,6 +59,7 @@ function toSemanticRow(r: FakeDBRow) {
   ).join("");
   const yamlContent =
     `table: ${r.table}\n` +
+    (r.yamlName ? `name: ${r.yamlName}\n` : "") +
     (r.description ? `description: ${r.description}\n` : "") +
     (dims ? `dimensions:\n${dims}` : "") +
     (measures ? `measures:\n${measures}` : "") +
@@ -143,7 +150,13 @@ describe("loadEntitiesForOrg", () => {
     writeDiskEntity("users", "table: users\ndescription: From disk\n");
 
     const result = await loadEntitiesForOrg(ORG_ID, "published");
-    expect(result.totalRows).toBe(2);
+    // `entities.length` is the merged count (DB + disk after dedup); the
+    // 1 DB row + 1 disk-mirror entry survive as 2 distinct entries because
+    // the named-group DB key doesn't collide with the null-group disk key.
+    expect(result.entities).toHaveLength(2);
+    // `totalRows` is DB-rows-considered (#2503 review) — kept distinct from
+    // `entities.length` so the route's `corrupt` discriminator stays sound.
+    expect(result.totalRows).toBe(1);
     expect(result.entities.map((e) => e.name).toSorted()).toEqual(["users", "users"]);
   });
 
@@ -171,9 +184,62 @@ describe("loadEntitiesForOrg", () => {
     writeDiskEntity("users", "table: users\ndescription: From disk\n");
 
     const result = await loadEntitiesForOrg(ORG_ID, "published");
-    expect(result.totalRows).toBe(3);
+    expect(result.entities).toHaveLength(3);
+    expect(result.totalRows).toBe(2); // 2 DB rows considered
     const descriptions = result.entities.map((e) => e.description).toSorted();
     expect(descriptions).toEqual(["EU", "From disk", "US"]);
+  });
+
+  it("disk entries dedup on `parsed.table` not `parsed.name` (matches diskToAdminSummary)", async () => {
+    // #2503 review: a disk YAML with `name: mrr` over `table: subscription_events`
+    // and a DB row with the same YAML are genuinely different things in
+    // `mergeAdminEntities`'s book — DB keys on (`mrr`, group), disk keys on
+    // (`subscription_events`, null). They don't collide and both appear.
+    // The earlier draft of this loader keyed disk on `parsed.name` and would
+    // have falsely collapsed them in a single-group null-scope workspace.
+    publishedRows = [{
+      name: "mrr",
+      yamlName: "mrr",
+      table: "subscription_events",
+      connection_group_id: null,
+      description: "From DB",
+    }];
+    writeDiskEntity(
+      "subscription_events",
+      "table: subscription_events\nname: mrr\ndescription: From disk\n",
+    );
+
+    const result = await loadEntitiesForOrg(ORG_ID, "published");
+    // DB key = (`mrr`, null). Disk key = (`subscription_events`, null).
+    // Different keys → both appear. (Same outcome as `mergeAdminEntities`'s
+    // "dedup key is summary `name`, not DB row `name`" test.)
+    expect(result.entities).toHaveLength(2);
+    const descriptions = result.entities.map((e) => e.description).toSorted();
+    expect(descriptions).toEqual(["From DB", "From disk"]);
+  });
+
+  it("walks per-source disk subdirectories (matches discoverEntities traversal)", async () => {
+    // `mergeAdminEntities` reads disk via `discoverEntities`, which walks
+    // both `entities/` AND `{source}/entities/` subdirectories (#2503 review).
+    // A loader that only walked flat `entities/` would silently undercount
+    // when an admin manually places per-source files.
+    const orgDir = path.join(tmpRoot, ".orgs", ORG_ID);
+    fs.mkdirSync(path.join(orgDir, "entities"), { recursive: true });
+    fs.writeFileSync(
+      path.join(orgDir, "entities", "users.yml"),
+      "table: users\n",
+    );
+    fs.mkdirSync(path.join(orgDir, "warehouse", "entities"), { recursive: true });
+    fs.writeFileSync(
+      path.join(orgDir, "warehouse", "entities", "fact_orders.yml"),
+      "table: fact_orders\n",
+    );
+
+    const result = await loadEntitiesForOrg(ORG_ID, "published");
+    expect(result.entities.map((e) => e.name).toSorted()).toEqual([
+      "fact_orders",
+      "users",
+    ]);
   });
 
   it("counts dimensions, measures, and joins on each entity for computeSemanticHealth", async () => {
@@ -214,5 +280,26 @@ describe("loadEntitiesForOrg", () => {
     const result = await loadEntitiesForOrg(ORG_ID, "published");
     expect(result.entities.map((e) => e.name)).toEqual(["good"]);
     expect(result.parseFailures).toBe(1);
+  });
+
+  it("disk parse failures do NOT increment parseFailures (DB-only contract)", async () => {
+    // #2503 review (test-analyzer): the previous `parseFailures` test
+    // exercised only the DB-corruption path. Without a disk-corruption case
+    // a regression that adds `parseFailures++` to the disk catch block
+    // would silently flip the `corrupt` discriminator's semantics and the
+    // existing tests would still pass. Pin the asymmetry explicitly.
+    publishedRows = [{ name: "good", table: "good", connection_group_id: null }];
+    writeDiskEntity("bad", "{{{ not yaml at all");
+    writeDiskEntity("also_bad", "- just\n- a\n- list\n"); // parses but not an object
+
+    const result = await loadEntitiesForOrg(ORG_ID, "published");
+    expect(result.entities.map((e) => e.name)).toEqual(["good"]);
+    // Disk parse failure (`scanEntities` returns it in `warnings`, the
+    // file simply doesn't appear in `entities`) does not increment
+    // parseFailures.
+    expect(result.parseFailures).toBe(0);
+    // `totalRows` stays the DB-rows-considered count (just the one healthy
+    // DB row), confirming the disk side never contributes to it.
+    expect(result.totalRows).toBe(1);
   });
 });

--- a/packages/api/src/lib/semantic/expert/context-loader.ts
+++ b/packages/api/src/lib/semantic/expert/context-loader.ts
@@ -21,9 +21,10 @@ function getSemanticRoot(): string {
   return process.env.ATLAS_SEMANTIC_ROOT ?? path.resolve(process.cwd(), "semantic");
 }
 
-/** Outcome of {@link loadEntitiesFromDB} — a discriminator so callers can tell
- * "no entities" from "every entity row failed to parse" (the latter signals
- * data corruption and should drive a different UI signal than "0% coverage"). */
+/** Outcome of {@link loadEntitiesFromDB} / {@link loadEntitiesForOrg} — a
+ * discriminator so callers can tell "no entities" from "every entity row failed
+ * to parse" (the latter signals data corruption and should drive a different UI
+ * signal than "0% coverage"). */
 export interface LoadEntitiesFromDBResult {
   entities: ParsedEntity[];
   totalRows: number;
@@ -96,6 +97,145 @@ export async function loadEntitiesFromDB(
   }
 
   return { entities, totalRows: rows.length, parseFailures };
+}
+
+/**
+ * Load entities for an org, merging DB rows with the per-org disk mirror
+ * under the same `(name, connection_group_id)` dedup rule that
+ * `listAdminEntities` uses (#2503).
+ *
+ * The Health card's entity count must agree with the Overview tile, the chat
+ * empty state, and the `/admin/semantic` file tree — those three all read
+ * through `listAdminEntities`. Reading only DB rows (`loadEntitiesFromDB`)
+ * left the Health card displaying a smaller number when the org's DB rows
+ * carry a non-null `connection_group_id` (post-1.4.4 backfill) and the disk-
+ * mirror entries — written with no group scope — no longer share the dedup
+ * key. Result was visible drift: file tree showed 46 rows, Health caption
+ * read "23 entities."
+ *
+ * This helper mirrors `listAdminEntities`'s merge logic but returns the full
+ * `ParsedEntity[]` `computeSemanticHealth` needs. DB rows are parsed once
+ * here (no extra YAML pass); disk entries are read from the org-scoped
+ * `.orgs/<orgId>/entities/` directory so a SaaS pod never falls through to
+ * the image's bundled fixture.
+ *
+ * Dedup is `(name, connection_group_id)` — same key `mergeAdminEntities`
+ * uses, so the count matches by construction. Multi-group orgs surface the
+ * same name once per group; disk entries (group = `null`) survive only when
+ * no DB row already covers `(name, null)`.
+ *
+ * `parseFailures` counts only DB rows that failed YAML parsing — disk parse
+ * failures bubble through the file-level `try/catch` and are surfaced via
+ * the logger, matching `loadEntitiesFromDisk`'s existing contract.
+ */
+export async function loadEntitiesForOrg(
+  orgId: string,
+  mode: "published" | "developer" = "published",
+): Promise<LoadEntitiesFromDBResult> {
+  const { hasInternalDB } = await import("@atlas/api/lib/db/internal");
+  if (!hasInternalDB()) return { entities: [], totalRows: 0, parseFailures: 0 };
+
+  const { listEntityRows, listEntitiesWithOverlay } = await import("@atlas/api/lib/semantic/entities");
+  const { getSemanticRoot: getOrgSemanticRoot } = await import("@atlas/api/lib/semantic/sync");
+
+  const rows = mode === "developer"
+    ? await listEntitiesWithOverlay(orgId, "entity")
+    : await listEntityRows(orgId, "entity", "published");
+
+  const entities: ParsedEntity[] = [];
+  // Dedup key matches `mergeAdminEntities` (`packages/api/src/lib/semantic/
+  // admin-source.ts`): `${name}\0${groupId ?? ""}`. `\0` is illegal in both
+  // YAML names and connection-group ids, so it can't collide with a real key.
+  const seen = new Set<string>();
+  let parseFailures = 0;
+
+  for (const row of rows) {
+    try {
+      const parsed = yaml.load(row.yaml_content) as Record<string, unknown> | null;
+      if (!parsed || typeof parsed !== "object") {
+        parseFailures++;
+        continue;
+      }
+      const nameField = typeof parsed.name === "string" && parsed.name
+        ? parsed.name
+        : String(parsed.table ?? row.name);
+      const groupId = row.connection_group_id ?? null;
+      const key = `${nameField}\0${groupId ?? ""}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      entities.push({
+        name: nameField,
+        table: String(parsed.table ?? row.name),
+        description: typeof parsed.description === "string" ? parsed.description : undefined,
+        dimensions: Array.isArray(parsed.dimensions) ? parsed.dimensions as ParsedEntity["dimensions"] : [],
+        measures: Array.isArray(parsed.measures) ? parsed.measures as ParsedEntity["measures"] : [],
+        joins: Array.isArray(parsed.joins) ? parsed.joins as ParsedEntity["joins"] : [],
+        query_patterns: Array.isArray(parsed.query_patterns) ? parsed.query_patterns as ParsedEntity["query_patterns"] : [],
+        connection: typeof parsed.connection === "string" ? parsed.connection : (groupId ?? undefined),
+      });
+    } catch (err) {
+      parseFailures++;
+      log.warn(
+        { err: err instanceof Error ? err.message : String(err), entity: row.name, orgId },
+        "Failed to parse entity YAML from DB",
+      );
+    }
+  }
+
+  // Disk mirror — org-scoped under `.orgs/<orgId>/entities/`. `discoverEntities`
+  // walks the per-source subdirectories too, but the dual-write sync writes flat
+  // under `entities/` regardless of group, so disk entries always key on the
+  // null group. Matches `diskToAdminSummary` in `admin-source.ts`.
+  const diskRoot = getOrgSemanticRoot(orgId);
+  const entitiesDir = path.join(diskRoot, "entities");
+  if (fs.existsSync(entitiesDir)) {
+    for (const file of fs.readdirSync(entitiesDir)) {
+      if (!file.endsWith(".yml") && !file.endsWith(".yaml")) continue;
+      try {
+        const content = fs.readFileSync(path.join(entitiesDir, file), "utf-8");
+        const parsed = yaml.load(content) as Record<string, unknown> | null;
+        if (!parsed || typeof parsed !== "object") continue;
+
+        const baseName = file.replace(/\.ya?ml$/, "");
+        const nameField = typeof parsed.name === "string" && parsed.name
+          ? parsed.name
+          : String(parsed.table ?? baseName);
+        const key = `${nameField}\0`;
+        if (seen.has(key)) continue;
+        seen.add(key);
+        entities.push({
+          name: nameField,
+          table: String(parsed.table ?? baseName),
+          description: typeof parsed.description === "string" ? parsed.description : undefined,
+          dimensions: Array.isArray(parsed.dimensions) ? parsed.dimensions as ParsedEntity["dimensions"] : [],
+          measures: Array.isArray(parsed.measures) ? parsed.measures as ParsedEntity["measures"] : [],
+          joins: Array.isArray(parsed.joins) ? parsed.joins as ParsedEntity["joins"] : [],
+          query_patterns: Array.isArray(parsed.query_patterns) ? parsed.query_patterns as ParsedEntity["query_patterns"] : [],
+          connection: typeof parsed.connection === "string" ? parsed.connection : undefined,
+        });
+      } catch (err) {
+        log.warn(
+          { err: err instanceof Error ? err.message : String(err), file, orgId },
+          "Failed to parse entity YAML from disk",
+        );
+      }
+    }
+  }
+
+  if (parseFailures > 0 && parseFailures === rows.length) {
+    log.error(
+      { orgId, totalRows: rows.length, parseFailures },
+      "All org entity rows failed YAML parse — semantic layer is corrupt",
+    );
+  }
+
+  // `totalRows` is the count of merged entities (DB + disk after dedup) — the
+  // canonical "what the user sees" number that lines up with `listAdminEntities`.
+  // `parseFailures` is still rows-scoped (DB only) so the existing `corrupt`
+  // discriminator in the route stays meaningful: a workspace whose DB rows all
+  // fail parse is `parseFailures === rows.length && rows.length > 0`, regardless
+  // of how many disk entries merged in.
+  return { entities, totalRows: entities.length, parseFailures };
 }
 
 /**

--- a/packages/api/src/lib/semantic/expert/context-loader.ts
+++ b/packages/api/src/lib/semantic/expert/context-loader.ts
@@ -32,6 +32,45 @@ export interface LoadEntitiesFromDBResult {
 }
 
 /**
+ * Project a parsed YAML record into a `ParsedEntity`. Shared by every entity
+ * loader (DB, disk, merged) so the three views always agree on field shape
+ * and fallback ordering. `fallbackName` covers rows/files where the YAML
+ * itself omits `name` (DB → `row.name`, disk → filename without extension);
+ * `fallbackConnection` is the DB-row `connection_group_id` carried through
+ * when the YAML doesn't carry an explicit `connection:` field.
+ */
+function projectParsedEntity(
+  parsed: Record<string, unknown>,
+  opts: { fallbackName: string; fallbackConnection?: string | null },
+): ParsedEntity {
+  const name = typeof parsed.name === "string" && parsed.name
+    ? parsed.name
+    : String(parsed.table ?? opts.fallbackName);
+  return {
+    name,
+    table: String(parsed.table ?? opts.fallbackName),
+    description: typeof parsed.description === "string" ? parsed.description : undefined,
+    dimensions: Array.isArray(parsed.dimensions) ? parsed.dimensions as ParsedEntity["dimensions"] : [],
+    measures: Array.isArray(parsed.measures) ? parsed.measures as ParsedEntity["measures"] : [],
+    joins: Array.isArray(parsed.joins) ? parsed.joins as ParsedEntity["joins"] : [],
+    query_patterns: Array.isArray(parsed.query_patterns) ? parsed.query_patterns as ParsedEntity["query_patterns"] : [],
+    connection: typeof parsed.connection === "string" ? parsed.connection : (opts.fallbackConnection ?? undefined),
+  };
+}
+
+/** Log the "all rows failed parse" diagnostic when every DB row was corrupt.
+ * Kept as a helper so `loadEntitiesFromDB` and `loadEntitiesForOrg` log the
+ * same shape — operators see one consistent signal. */
+function logIfAllRowsCorrupt(orgId: string, totalRows: number, parseFailures: number): void {
+  if (parseFailures > 0 && parseFailures === totalRows) {
+    log.error(
+      { orgId, totalRows, parseFailures },
+      "All org entity rows failed YAML parse — semantic layer is corrupt",
+    );
+  }
+}
+
+/**
  * Load entities for an org from the internal DB.
  *
  * Preferred whenever the caller has both an org context and an internal DB
@@ -70,6 +109,10 @@ export async function loadEntitiesFromDB(
         parseFailures++;
         continue;
       }
+      // NOTE: ignores `parsed.name` (keys off `parsed.table ?? row.name`) —
+      // preserved verbatim from pre-#2503 to avoid changing the schedule-tick
+      // semantics. `loadEntitiesForOrg` honors `parsed.name` because the
+      // admin merge path keys dedup by it.
       entities.push({
         name: String(parsed.table ?? row.name),
         table: String(parsed.table ?? row.name),
@@ -89,13 +132,7 @@ export async function loadEntitiesFromDB(
     }
   }
 
-  if (parseFailures > 0 && parseFailures === rows.length) {
-    log.error(
-      { orgId, totalRows: rows.length, parseFailures },
-      "All org entity rows failed YAML parse — semantic layer is corrupt",
-    );
-  }
-
+  logIfAllRowsCorrupt(orgId, rows.length, parseFailures);
   return { entities, totalRows: rows.length, parseFailures };
 }
 
@@ -147,6 +184,7 @@ export async function loadEntitiesForOrg(
   // admin-source.ts`): `${name}\0${groupId ?? ""}`. `\0` is illegal in both
   // YAML names and connection-group ids, so it can't collide with a real key.
   const seen = new Set<string>();
+  const dedupKey = (name: string, groupId: string | null): string => `${name}\0${groupId ?? ""}`;
   let parseFailures = 0;
 
   for (const row of rows) {
@@ -156,23 +194,15 @@ export async function loadEntitiesForOrg(
         parseFailures++;
         continue;
       }
-      const nameField = typeof parsed.name === "string" && parsed.name
-        ? parsed.name
-        : String(parsed.table ?? row.name);
       const groupId = row.connection_group_id ?? null;
-      const key = `${nameField}\0${groupId ?? ""}`;
+      const entity = projectParsedEntity(parsed, {
+        fallbackName: row.name,
+        fallbackConnection: groupId,
+      });
+      const key = dedupKey(entity.name, groupId);
       if (seen.has(key)) continue;
       seen.add(key);
-      entities.push({
-        name: nameField,
-        table: String(parsed.table ?? row.name),
-        description: typeof parsed.description === "string" ? parsed.description : undefined,
-        dimensions: Array.isArray(parsed.dimensions) ? parsed.dimensions as ParsedEntity["dimensions"] : [],
-        measures: Array.isArray(parsed.measures) ? parsed.measures as ParsedEntity["measures"] : [],
-        joins: Array.isArray(parsed.joins) ? parsed.joins as ParsedEntity["joins"] : [],
-        query_patterns: Array.isArray(parsed.query_patterns) ? parsed.query_patterns as ParsedEntity["query_patterns"] : [],
-        connection: typeof parsed.connection === "string" ? parsed.connection : (groupId ?? undefined),
-      });
+      entities.push(entity);
     } catch (err) {
       parseFailures++;
       log.warn(
@@ -196,23 +226,13 @@ export async function loadEntitiesForOrg(
         const parsed = yaml.load(content) as Record<string, unknown> | null;
         if (!parsed || typeof parsed !== "object") continue;
 
-        const baseName = file.replace(/\.ya?ml$/, "");
-        const nameField = typeof parsed.name === "string" && parsed.name
-          ? parsed.name
-          : String(parsed.table ?? baseName);
-        const key = `${nameField}\0`;
+        const entity = projectParsedEntity(parsed, {
+          fallbackName: file.replace(/\.ya?ml$/, ""),
+        });
+        const key = dedupKey(entity.name, null);
         if (seen.has(key)) continue;
         seen.add(key);
-        entities.push({
-          name: nameField,
-          table: String(parsed.table ?? baseName),
-          description: typeof parsed.description === "string" ? parsed.description : undefined,
-          dimensions: Array.isArray(parsed.dimensions) ? parsed.dimensions as ParsedEntity["dimensions"] : [],
-          measures: Array.isArray(parsed.measures) ? parsed.measures as ParsedEntity["measures"] : [],
-          joins: Array.isArray(parsed.joins) ? parsed.joins as ParsedEntity["joins"] : [],
-          query_patterns: Array.isArray(parsed.query_patterns) ? parsed.query_patterns as ParsedEntity["query_patterns"] : [],
-          connection: typeof parsed.connection === "string" ? parsed.connection : undefined,
-        });
+        entities.push(entity);
       } catch (err) {
         log.warn(
           { err: err instanceof Error ? err.message : String(err), file, orgId },
@@ -222,12 +242,7 @@ export async function loadEntitiesForOrg(
     }
   }
 
-  if (parseFailures > 0 && parseFailures === rows.length) {
-    log.error(
-      { orgId, totalRows: rows.length, parseFailures },
-      "All org entity rows failed YAML parse — semantic layer is corrupt",
-    );
-  }
+  logIfAllRowsCorrupt(orgId, rows.length, parseFailures);
 
   // `totalRows` is the count of merged entities (DB + disk after dedup) — the
   // canonical "what the user sees" number that lines up with `listAdminEntities`.

--- a/packages/api/src/lib/semantic/expert/context-loader.ts
+++ b/packages/api/src/lib/semantic/expert/context-loader.ts
@@ -145,21 +145,30 @@ export async function loadEntitiesFromDB(
  * empty state, and the `/admin/semantic` file tree — those three all read
  * through `listAdminEntities`. Reading only DB rows (`loadEntitiesFromDB`)
  * left the Health card displaying a smaller number when the org's DB rows
- * carry a non-null `connection_group_id` (post-1.4.4 backfill) and the disk-
- * mirror entries — written with no group scope — no longer share the dedup
- * key. Result was visible drift: file tree showed 46 rows, Health caption
- * read "23 entities."
+ * carry a non-null `connection_group_id` (introduced by migration 0063 /
+ * #2412) and the disk-mirror entries — written with no group scope — no
+ * longer share the dedup key. Result was visible drift: file tree showed
+ * roughly twice the row count the Health caption did.
  *
- * This helper mirrors `listAdminEntities`'s merge logic but returns the full
- * `ParsedEntity[]` `computeSemanticHealth` needs. DB rows are parsed once
- * here (no extra YAML pass); disk entries are read from the org-scoped
- * `.orgs/<orgId>/entities/` directory so a SaaS pod never falls through to
- * the image's bundled fixture.
+ * Three invariants this helper holds in lockstep with `mergeAdminEntities`
+ * (#2503 review):
+ *   1. Dedup key is built via `dedupKey()` re-exported from `admin-source.ts`
+ *      — not a hand-maintained copy — so the formula can never silently drift.
+ *   2. Disk entries key on `(parsed.table, null)`, mirroring
+ *      `diskToAdminSummary` which ignores YAML `name:` for disk rows. DB rows
+ *      key on `(parsed.name ?? parsed.table, group)`, mirroring
+ *      `parseRowToAdminSummary`.
+ *   3. Disk traversal goes through `scanEntities` so per-source
+ *      `{source}/entities/` subdirectories are walked (matches
+ *      `discoverEntities`). The dual-write sync writes flat under
+ *      `entities/` today, but the file tree also surfaces per-source files,
+ *      and the Health count must include them or the gap reopens.
  *
- * Dedup is `(name, connection_group_id)` — same key `mergeAdminEntities`
- * uses, so the count matches by construction. Multi-group orgs surface the
- * same name once per group; disk entries (group = `null`) survive only when
- * no DB row already covers `(name, null)`.
+ * `totalRows` stays DB-rows-scoped (matches `loadEntitiesFromDB`'s contract)
+ * so the route's `corrupt` discriminator (`parseFailures === totalRows &&
+ * totalRows > 0`) still fires when every DB row fails parse, even if the
+ * disk mirror has healthy entries that would otherwise mask the corruption.
+ * `entities.length` is the merged user-facing count.
  *
  * `parseFailures` counts only DB rows that failed YAML parsing — disk parse
  * failures bubble through the file-level `try/catch` and are surfaced via
@@ -174,17 +183,15 @@ export async function loadEntitiesForOrg(
 
   const { listEntityRows, listEntitiesWithOverlay } = await import("@atlas/api/lib/semantic/entities");
   const { getSemanticRoot: getOrgSemanticRoot } = await import("@atlas/api/lib/semantic/sync");
+  const { scanEntities } = await import("@atlas/api/lib/semantic/scanner");
+  const { dedupKey } = await import("@atlas/api/lib/semantic/dedup-key");
 
   const rows = mode === "developer"
     ? await listEntitiesWithOverlay(orgId, "entity")
     : await listEntityRows(orgId, "entity", "published");
 
   const entities: ParsedEntity[] = [];
-  // Dedup key matches `mergeAdminEntities` (`packages/api/src/lib/semantic/
-  // admin-source.ts`): `${name}\0${groupId ?? ""}`. `\0` is illegal in both
-  // YAML names and connection-group ids, so it can't collide with a real key.
   const seen = new Set<string>();
-  const dedupKey = (name: string, groupId: string | null): string => `${name}\0${groupId ?? ""}`;
   let parseFailures = 0;
 
   for (const row of rows) {
@@ -199,6 +206,8 @@ export async function loadEntitiesForOrg(
         fallbackName: row.name,
         fallbackConnection: groupId,
       });
+      // DB rows key on the YAML display name (matches
+      // `parseRowToAdminSummary` in admin-source.ts).
       const key = dedupKey(entity.name, groupId);
       if (seen.has(key)) continue;
       seen.add(key);
@@ -212,45 +221,42 @@ export async function loadEntitiesForOrg(
     }
   }
 
-  // Disk mirror — org-scoped under `.orgs/<orgId>/entities/`. `discoverEntities`
-  // walks the per-source subdirectories too, but the dual-write sync writes flat
-  // under `entities/` regardless of group, so disk entries always key on the
-  // null group. Matches `diskToAdminSummary` in `admin-source.ts`.
+  // Disk mirror — org-scoped under `.orgs/<orgId>/entities/` (and any
+  // `{source}/entities/` subdirectories scanEntities walks). `scanEntities`
+  // is the same traversal `discoverEntities` uses, so the Health count
+  // includes every file the admin file tree renders.
   const diskRoot = getOrgSemanticRoot(orgId);
-  const entitiesDir = path.join(diskRoot, "entities");
-  if (fs.existsSync(entitiesDir)) {
-    for (const file of fs.readdirSync(entitiesDir)) {
-      if (!file.endsWith(".yml") && !file.endsWith(".yaml")) continue;
-      try {
-        const content = fs.readFileSync(path.join(entitiesDir, file), "utf-8");
-        const parsed = yaml.load(content) as Record<string, unknown> | null;
-        if (!parsed || typeof parsed !== "object") continue;
-
-        const entity = projectParsedEntity(parsed, {
-          fallbackName: file.replace(/\.ya?ml$/, ""),
-        });
-        const key = dedupKey(entity.name, null);
-        if (seen.has(key)) continue;
-        seen.add(key);
-        entities.push(entity);
-      } catch (err) {
-        log.warn(
-          { err: err instanceof Error ? err.message : String(err), file, orgId },
-          "Failed to parse entity YAML from disk",
-        );
-      }
+  if (fs.existsSync(diskRoot)) {
+    const { entities: scanned } = scanEntities(diskRoot);
+    for (const { raw, filePath } of scanned) {
+      // `scanEntities` already filtered out files whose YAML failed to
+      // parse or didn't produce an object — those surface via its
+      // `warnings`. We additionally require a `table:` field so we match
+      // `discoverEntities`'s "skip files missing required `table`" gate
+      // (files.ts:88), keeping the disk count in lockstep with the
+      // admin file tree.
+      if (typeof raw.table !== "string" || !raw.table) continue;
+      const entity = projectParsedEntity(raw, {
+        fallbackName: path.basename(filePath).replace(/\.ya?ml$/, ""),
+      });
+      // Disk entries key on `parsed.table` (not the display name).
+      // `diskToAdminSummary` in admin-source.ts produces
+      // `summary.name = e.table` for disk entries — keying on `entity.name`
+      // here would diverge when a disk file authors a distinct YAML `name:`.
+      const key = dedupKey(String(raw.table), null);
+      if (seen.has(key)) continue;
+      seen.add(key);
+      entities.push(entity);
     }
   }
 
   logIfAllRowsCorrupt(orgId, rows.length, parseFailures);
 
-  // `totalRows` is the count of merged entities (DB + disk after dedup) — the
-  // canonical "what the user sees" number that lines up with `listAdminEntities`.
-  // `parseFailures` is still rows-scoped (DB only) so the existing `corrupt`
-  // discriminator in the route stays meaningful: a workspace whose DB rows all
-  // fail parse is `parseFailures === rows.length && rows.length > 0`, regardless
-  // of how many disk entries merged in.
-  return { entities, totalRows: entities.length, parseFailures };
+  // `totalRows = rows.length` (DB-only) — see header comment. Merged count
+  // is `entities.length`, available to the caller via the entities array;
+  // `computeSemanticHealth` derives `entityCount` from `entities.length` so
+  // the user-facing number is still the merged total.
+  return { entities, totalRows: rows.length, parseFailures };
 }
 
 /**


### PR DESCRIPTION
## Summary

Closes #2503.

- `/admin/semantic` Health card was rendering "23 entities" right next to a file tree showing 46 rows. Same workspace, same minute, different number.
- Root cause: the `/api/v1/admin/semantic-improve/health` route called `loadEntitiesFromDB(orgId, "published")`, which returned only `semantic_entities` rows. Overview tile, chat empty state, and the file tree all read via `listAdminEntities`, which merges DB rows with the per-org disk mirror and dedupes on `(name, connection_group_id)`. 1.4.4's `connection_group_id` backfill put the DB rows in a named group; the disk-mirror entries are written with no group scope, so the merge keys never collide and both halves get counted.
- Health card saw the DB half only (~23). Overview / chat / file tree saw both halves (~46).

## Change

New `loadEntitiesForOrg(orgId, mode)` in `packages/api/src/lib/semantic/expert/context-loader.ts` mirrors `mergeAdminEntities`'s merge + `(name, group)` dedup but returns `ParsedEntity[]` (the shape `computeSemanticHealth` needs). The health route swaps `loadEntitiesFromDB` → `loadEntitiesForOrg`. Disk fallback for the no-orgId / no-DB branch (self-hosted stdio, bare CLI) is unchanged.

`parseFailures` stays DB-rows-scoped so the existing `status: "corrupt"` discriminator on the response keeps distinguishing "data rot" from "empty workspace" — only the disk-mirror entries get rolled into `totalRows`, which is what the user sees.

## Surfaces, before vs after

| Surface | Source | Before | After |
|---|---|---|---|
| `/admin` Overview tile "Entities" | `listAdminEntities` | 46 | 46 |
| Chat empty state "N tables ready to query" | `/api/v1/semantic/entities` → `listAdminEntities` | 46 | 46 |
| `/admin/semantic` file tree row count | `/api/v1/admin/semantic/entities` → `listAdminEntities` | 46 | 46 |
| `/admin/semantic` Health card "N entities" | `/api/v1/admin/semantic-improve/health` | **23** | **46** |
| `/platform` Overview "Entities (bundled)" | filesystem `discoverEntities(root)` | 13 | 13 (unchanged — deployment-image scaffold, intentionally separate) |

## What NOT changed

- `listAdminEntities` and `mergeAdminEntities` semantics: converged on, not forked. The dedup-on-`(name, group)` invariant from #2412 still holds — multi-group orgs still surface one row per group.
- The platform-side "13 bundled" count stays filesystem-sourced.
- Disk-mirror behavior in the file tree: this PR doesn't reshape what the tree renders for orgs whose DB rows have non-null `connection_group_id`. If those duplicate-looking rows are themselves a UX problem in a single-group org, that's a separate fix.

## Test plan

- [x] `bun run lint` — clean
- [x] `bun run type` — clean
- [x] `cd packages/api && bun run scripts/test-isolated.ts --affected` — 3 files / 11 tests pass
- [x] `bash scripts/check-template-drift.sh` — pass
- [x] `bash scripts/check-schema-drift.sh` — pass
- [x] `bash scripts/check-railway-watch.sh` — pass
- [x] `bash scripts/check-security-headers-drift.sh` — pass
- [x] `bash scripts/check-oauth-helper-drift.sh` — pass
- [x] New unit suite `load-entities-for-org.test.ts` pins: DB+named-group + disk-null both survive (#2503 shape), DB-null shadows disk-null (legacy case), multi-group orgs preserve per-group rows + add the disk mirror, dimensions/measures/joins propagate to `ParsedEntity`, developer-mode reads the overlay, unparseable DB rows count toward `parseFailures` only.
- [x] Updated parity guard in `admin-semantic-improve.test.ts`: the route's `entityCount` matches what `loadEntitiesForOrg` returned. A future refactor that swaps the loader silently fails first.