### PR TITLE
fix(web,api): #2506 — clean up orphan empty env groups + prevent recurrence

### DIFF
--- a/packages/api/src/api/__tests__/admin-connection-groups-name-collision.test.ts
+++ b/packages/api/src/api/__tests__/admin-connection-groups-name-collision.test.ts
@@ -1,34 +1,20 @@
 /**
  * Name-collision guard (#2506) — wire contract tests.
  *
- * Every user-initiated path that names (or renames) a connection group
- * must refuse a name that matches an existing connection id in the same
- * org. The original orphan that surfaced this bug — empty `g_us-prod`
- * group with name `us-prod` colliding with the `us-prod` connection
- * already living inside the `prod` group — is the exact shape a future
- * inline-create or rename could re-introduce at no benefit. The env
- * combobox in the Add Connection dialog cannot distinguish a real env
- * from a connection-id-shaped label, so the surface defence is at the
- * route layer where the literal name is known.
+ * Five routes thread the same `connectionNameCollidesWithGroup` helper.
+ * The non-obvious pieces this file pins:
  *
- * Coverage matrix:
- *   - POST  /admin/connection-groups           — refused on collision
- *   - PATCH /admin/connection-groups/:id       — refused on collision
- *   - POST  /admin/connection-groups/merge     — refused only when the
- *                                                 target name would
- *                                                 CREATE a new group;
- *                                                 reusing an existing
- *                                                 same-named group is
- *                                                 the documented wizard
- *                                                 ergonomic and must
- *                                                 stay supported.
- *
- * The POST /admin/connections and PUT /admin/connections/:id inline
- * `newGroupName` paths reuse the same `connectionNameCollidesWithGroup`
- * helper; their wire contract is exercised by the helper-level pin
- * below — the per-route SQL surface is the existing connection-create
- * test bed, which is too large to recreate just for the collision
- * check.
+ *   - POST /admin/connection-groups/merge refuses only when the target
+ *     would CREATE; reuse of an existing same-named active group is the
+ *     documented wizard ergonomic.
+ *   - POST /admin/connections has an `id === newGroupName` carve-out so
+ *     a user creating "warehouse" + "warehouse" env in one round trip
+ *     isn't blocked by the in-flight connection.
+ *   - PUT /admin/connections/:id deliberately omits that carve-out — on
+ *     update the connection already exists and a self-named group is
+ *     the exact #2506 confusion shape.
+ *   - A DB error from the helper MUST surface as 500, not silently 201
+ *     (fail-closed contract — see helper docstring).
  */
 
 import {
@@ -37,6 +23,7 @@ import {
   expect,
   beforeEach,
   afterAll,
+  mock,
 } from "bun:test";
 import { createApiTestMocks } from "@atlas/api/testing/api-test-mocks";
 
@@ -54,6 +41,25 @@ const mocks = createApiTestMocks({
     activeOrganizationId: "org-alpha",
   },
   authMode: "managed",
+  connection: {
+    connections: {
+      get: () => null,
+      getDefault: () => null,
+      describe: () => [{ id: "default", dbType: "postgres" }],
+      healthCheck: mock(() =>
+        Promise.resolve({ status: "healthy", latencyMs: 1, checkedAt: new Date() }),
+      ),
+      register: mock(() => {}),
+      unregister: mock(() => {}),
+      has: mock(() => false),
+      getForOrg: () => null,
+    },
+    resolveDatasourceUrl: () => "postgresql://stub",
+  },
+  internal: {
+    encryptSecret: (url: string) => `encrypted:${url}`,
+    decryptSecret: (url: string) => (url as string).replace(/^encrypted:/, ""),
+  },
 });
 
 const { app } = await import("../index");
@@ -342,5 +348,142 @@ describe("POST /api/v1/admin/connection-groups/merge — name-collision guard (#
     expect(
       stateChangingCalls().some((sql) => sql.includes("WITH target AS")),
     ).toBe(true);
+  });
+});
+
+describe("name-collision guard — fail-closed on DB error (#2506)", () => {
+  beforeEach(() => {
+    mocks.hasInternalDB = true;
+    mocks.mockInternalQuery.mockReset();
+    mocks.setOrgAdmin("org-alpha");
+  });
+
+  it("propagates a helper DB rejection as 500 — guard MUST NOT fail-open", async () => {
+    // The fail-closed contract documented on `connectionNameCollidesWithGroup`.
+    // A future refactor that wrapped the helper in `catch { return false }`
+    // would silently bypass the security guard; this test pins that 500 is
+    // the correct response, not a 201 with the group created anyway.
+    mocks.mockInternalQuery.mockImplementation((sql: string) => {
+      if (sql.includes("SELECT id FROM connections")) {
+        return Promise.reject(new Error("simulated connection refused"));
+      }
+      return Promise.resolve([]);
+    });
+
+    const res = await app.fetch(
+      adminRequest("/api/v1/admin/connection-groups", "POST", { name: "us-prod" }),
+    );
+    expect(res.status).toBe(500);
+    // Critically: no INSERT INTO connection_groups fired. A fail-open
+    // regression would skip the guard and INSERT the row.
+    expect(
+      stateChangingCalls().some((sql) => sql.includes("INSERT INTO connection_groups")),
+    ).toBe(false);
+  });
+});
+
+describe("POST /api/v1/admin/connections — inline newGroupName (#2506)", () => {
+  beforeEach(() => {
+    mocks.hasInternalDB = true;
+    mocks.mockInternalQuery.mockReset();
+    mocks.setOrgAdmin("org-alpha");
+  });
+
+  it("self-name carve-out: inline newGroupName matching the in-flight id succeeds", async () => {
+    // Pins the carve-out documented on the POST route — creating
+    // connection `warehouse` with a new env named `warehouse` in one
+    // round trip is a legitimate wizard flow. Without the
+    // `trimmedNewGroupName !== id` skip, the helper would see no row
+    // (connection doesn't exist yet) and the path would silently
+    // succeed only by coincidence; we pin that the carve-out is
+    // explicit rather than incidental.
+    mocks.mockInternalQuery.mockImplementation((sql: string) => {
+      if (sql.includes("SELECT id FROM connections")) {
+        // Sanity: even if the helper fired, no collision exists.
+        return Promise.resolve([]);
+      }
+      return Promise.resolve([]);
+    });
+
+    const res = await app.fetch(
+      adminRequest("/api/v1/admin/connections", "POST", {
+        id: "warehouse",
+        url: "postgresql://user:pass@host/warehouse",
+        newGroupName: "warehouse",
+      }),
+    );
+    expect(res.status).toBe(201);
+  });
+
+  it("refuses when newGroupName matches a DIFFERENT existing connection id", async () => {
+    // The carve-out is narrow: same-name as the in-flight id is fine;
+    // matching some OTHER existing connection is the bug shape.
+    mocks.mockInternalQuery.mockImplementation((sql: string) => {
+      if (sql.includes("SELECT id FROM connections")) {
+        return Promise.resolve([{ id: "us-prod" }]);
+      }
+      return Promise.resolve([]);
+    });
+
+    const res = await app.fetch(
+      adminRequest("/api/v1/admin/connections", "POST", {
+        id: "warehouse",
+        url: "postgresql://user:pass@host/warehouse",
+        newGroupName: "us-prod",
+      }),
+    );
+    expect(res.status).toBe(409);
+    // No INSERT INTO connections fired (guard blocked before the create).
+    expect(
+      stateChangingCalls().some((sql) => sql.includes("INSERT INTO connections")),
+    ).toBe(false);
+  });
+});
+
+describe("PUT /api/v1/admin/connections/:id — inline newGroupName (#2506)", () => {
+  beforeEach(() => {
+    mocks.hasInternalDB = true;
+    mocks.mockInternalQuery.mockReset();
+    mocks.setOrgAdmin("org-alpha");
+  });
+
+  it("no self-name carve-out: refuses newGroupName matching the connection's own id", async () => {
+    // On update the connection already exists; a same-named group is
+    // the #2506 confusion shape. Pin that PUT does NOT mirror POST's
+    // carve-out — a refactor that "consistency-fixed" the asymmetry
+    // would silently re-open the bug.
+    mocks.mockInternalQuery.mockImplementation((sql: string) => {
+      if (sql.includes("SELECT id FROM connections")) {
+        // The connection (us-prod) exists for the lookup AND for the
+        // collision check — same SELECT shape against `connections`.
+        return Promise.resolve([{ id: "us-prod" }]);
+      }
+      // The pre-fetch SELECT for the current connection row.
+      if (sql.includes("SELECT") && sql.includes("connections")) {
+        return Promise.resolve([
+          {
+            id: "us-prod",
+            url: "encrypted:postgresql://stub",
+            type: "postgres",
+            description: null,
+            schema_name: null,
+          },
+        ]);
+      }
+      return Promise.resolve([]);
+    });
+
+    const res = await app.fetch(
+      adminRequest("/api/v1/admin/connections/us-prod", "PUT", {
+        description: "Updated",
+        newGroupName: "us-prod",
+      }),
+    );
+    expect(res.status).toBe(409);
+    expect(
+      stateChangingCalls().some(
+        (sql) => sql.includes("UPDATE connections") || sql.includes("INSERT INTO connection_groups"),
+      ),
+    ).toBe(false);
   });
 });

--- a/packages/api/src/api/__tests__/admin-connection-groups-name-collision.test.ts
+++ b/packages/api/src/api/__tests__/admin-connection-groups-name-collision.test.ts
@@ -1,0 +1,346 @@
+/**
+ * Name-collision guard (#2506) — wire contract tests.
+ *
+ * Every user-initiated path that names (or renames) a connection group
+ * must refuse a name that matches an existing connection id in the same
+ * org. The original orphan that surfaced this bug — empty `g_us-prod`
+ * group with name `us-prod` colliding with the `us-prod` connection
+ * already living inside the `prod` group — is the exact shape a future
+ * inline-create or rename could re-introduce at no benefit. The env
+ * combobox in the Add Connection dialog cannot distinguish a real env
+ * from a connection-id-shaped label, so the surface defence is at the
+ * route layer where the literal name is known.
+ *
+ * Coverage matrix:
+ *   - POST  /admin/connection-groups           — refused on collision
+ *   - PATCH /admin/connection-groups/:id       — refused on collision
+ *   - POST  /admin/connection-groups/merge     — refused only when the
+ *                                                 target name would
+ *                                                 CREATE a new group;
+ *                                                 reusing an existing
+ *                                                 same-named group is
+ *                                                 the documented wizard
+ *                                                 ergonomic and must
+ *                                                 stay supported.
+ *
+ * The POST /admin/connections and PUT /admin/connections/:id inline
+ * `newGroupName` paths reuse the same `connectionNameCollidesWithGroup`
+ * helper; their wire contract is exercised by the helper-level pin
+ * below — the per-route SQL surface is the existing connection-create
+ * test bed, which is too large to recreate just for the collision
+ * check.
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterAll,
+} from "bun:test";
+import { createApiTestMocks } from "@atlas/api/testing/api-test-mocks";
+
+// ── Mocks ──────────────────────────────────────────────────────────────
+//
+// `us-prod` is the connection the orphan was named after on prod. The
+// describe() output makes it the canonical collision target across
+// every test in this file.
+const mocks = createApiTestMocks({
+  authUser: {
+    id: "admin-1",
+    mode: "managed",
+    label: "admin@test.com",
+    role: "admin",
+    activeOrganizationId: "org-alpha",
+  },
+  authMode: "managed",
+});
+
+const { app } = await import("../index");
+
+afterAll(() => {
+  mocks.cleanup();
+});
+
+// ── Helpers ────────────────────────────────────────────────────────────
+
+function adminRequest(urlPath: string, method = "POST", body?: unknown): Request {
+  return new Request(`http://localhost${urlPath}`, {
+    method,
+    headers: {
+      Authorization: "Bearer test-key",
+      "Content-Type": "application/json",
+    },
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+}
+
+/** Returns the SQL of every internalQuery call so a test can assert
+ * that no state-changing INSERT/UPDATE fired after a refused collision. */
+function stateChangingCalls(): string[] {
+  return mocks.mockInternalQuery.mock.calls
+    .map(([sql]) => (typeof sql === "string" ? sql : ""))
+    .filter((sql) => /\b(INSERT|UPDATE|DELETE)\b/i.test(sql));
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────
+
+describe("POST /api/v1/admin/connection-groups — name-collision guard (#2506)", () => {
+  beforeEach(() => {
+    mocks.hasInternalDB = true;
+    mocks.mockInternalQuery.mockReset();
+    mocks.setOrgAdmin("org-alpha");
+  });
+
+  it("returns 409 when the group name matches an existing connection id", async () => {
+    // Pre-check SELECT returns a row — `us-prod` is a live connection.
+    mocks.mockInternalQuery.mockImplementation((sql: string) => {
+      if (sql.includes("SELECT id FROM connections")) {
+        return Promise.resolve([{ id: "us-prod" }]);
+      }
+      return Promise.resolve([]);
+    });
+
+    const res = await app.fetch(
+      adminRequest("/api/v1/admin/connection-groups", "POST", { name: "us-prod" }),
+    );
+    expect(res.status).toBe(409);
+    const body = (await res.json()) as { error: string; message: string; requestId: string };
+    expect(body.error).toBe("conflict");
+    expect(body.message).toContain("us-prod");
+    expect(typeof body.requestId).toBe("string");
+    // No INSERT INTO connection_groups should fire after the guard.
+    expect(
+      stateChangingCalls().some((sql) => sql.includes("INSERT INTO connection_groups")),
+    ).toBe(false);
+  });
+
+  it("allows a group name that does not match any existing connection id", async () => {
+    // Pre-check SELECT returns no rows — `Production` does not match
+    // any connection id, so the INSERT must run.
+    mocks.mockInternalQuery.mockImplementation((sql: string) => {
+      if (sql.includes("SELECT id FROM connections")) {
+        return Promise.resolve([]);
+      }
+      if (sql.includes("INSERT INTO connection_groups")) {
+        return Promise.resolve([]);
+      }
+      if (sql.includes("SELECT id, name, status")) {
+        // Final SELECT returning the created row for the wire shape.
+        return Promise.resolve([
+          {
+            id: "g_abc123",
+            name: "Production",
+            status: "active",
+            created_at: new Date(),
+            updated_at: new Date(),
+            primary_connection_id: null,
+            member_count: "0",
+          },
+        ]);
+      }
+      return Promise.resolve([]);
+    });
+
+    const res = await app.fetch(
+      adminRequest("/api/v1/admin/connection-groups", "POST", { name: "Production" }),
+    );
+    expect(res.status).toBe(201);
+    expect(
+      stateChangingCalls().some((sql) => sql.includes("INSERT INTO connection_groups")),
+    ).toBe(true);
+  });
+
+  it("scopes the collision check to the caller's org (B2B isolation)", async () => {
+    // The pre-check SELECT must filter by org_id so a SaaS tenant
+    // sharing a connection id like `default` with another tenant
+    // never sees a foreign-org collision.
+    mocks.mockInternalQuery.mockImplementation((sql: string) => {
+      if (sql.includes("SELECT id FROM connections")) {
+        return Promise.resolve([]);
+      }
+      if (sql.includes("INSERT INTO connection_groups")) {
+        return Promise.resolve([]);
+      }
+      if (sql.includes("SELECT id, name, status")) {
+        return Promise.resolve([
+          {
+            id: "g_def456",
+            name: "default",
+            status: "active",
+            created_at: new Date(),
+            updated_at: new Date(),
+            primary_connection_id: null,
+            member_count: "0",
+          },
+        ]);
+      }
+      return Promise.resolve([]);
+    });
+
+    await app.fetch(
+      adminRequest("/api/v1/admin/connection-groups", "POST", { name: "default" }),
+    );
+    const checkCall = mocks.mockInternalQuery.mock.calls.find(
+      ([sql]) => typeof sql === "string" && sql.includes("SELECT id FROM connections"),
+    );
+    expect(checkCall).toBeDefined();
+    expect(checkCall![0]).toContain("org_id = $1");
+    expect(checkCall![1]).toEqual(["org-alpha", "default"]);
+  });
+});
+
+describe("PATCH /api/v1/admin/connection-groups/:id — name-collision guard (#2506)", () => {
+  beforeEach(() => {
+    mocks.hasInternalDB = true;
+    mocks.mockInternalQuery.mockReset();
+    mocks.setOrgAdmin("org-alpha");
+  });
+
+  it("returns 409 when the new name matches an existing connection id", async () => {
+    mocks.mockInternalQuery.mockImplementation((sql: string) => {
+      if (sql.includes("SELECT id FROM connections")) {
+        return Promise.resolve([{ id: "us-prod" }]);
+      }
+      return Promise.resolve([]);
+    });
+
+    const res = await app.fetch(
+      adminRequest("/api/v1/admin/connection-groups/g_existing", "PATCH", {
+        name: "us-prod",
+      }),
+    );
+    expect(res.status).toBe(409);
+    expect(
+      stateChangingCalls().some((sql) => sql.includes("UPDATE connection_groups")),
+    ).toBe(false);
+  });
+
+  it("allows a rename that does not collide", async () => {
+    mocks.mockInternalQuery.mockImplementation((sql: string) => {
+      if (sql.includes("SELECT id FROM connections")) {
+        return Promise.resolve([]);
+      }
+      if (sql.includes("UPDATE connection_groups")) {
+        return Promise.resolve([
+          {
+            id: "g_existing",
+            name: "Production",
+            status: "active",
+            created_at: new Date(),
+            updated_at: new Date(),
+            primary_connection_id: null,
+            member_count: "2",
+          },
+        ]);
+      }
+      return Promise.resolve([]);
+    });
+
+    const res = await app.fetch(
+      adminRequest("/api/v1/admin/connection-groups/g_existing", "PATCH", {
+        name: "Production",
+      }),
+    );
+    expect(res.status).toBe(200);
+  });
+});
+
+describe("POST /api/v1/admin/connection-groups/merge — name-collision guard (#2506)", () => {
+  beforeEach(() => {
+    mocks.hasInternalDB = true;
+    mocks.mockInternalQuery.mockReset();
+    mocks.setOrgAdmin("org-alpha");
+  });
+
+  it("returns 409 when CREATING a new merged group whose name matches a connection id", async () => {
+    // Source pre-validate passes (both connections exist); archived
+    // target check passes (nothing archived); existing-target check
+    // returns no row (so the merge would CREATE); collision check
+    // returns a matching connection id. Refused.
+    mocks.mockInternalQuery.mockImplementation((sql: string) => {
+      if (sql.includes("SELECT id, org_id, group_id FROM connections")) {
+        return Promise.resolve([
+          { id: "us-int", org_id: "org-alpha", group_id: "g_us-int" },
+          { id: "eu-int", org_id: "org-alpha", group_id: "g_eu-int" },
+        ]);
+      }
+      if (sql.includes("FROM connection_groups") && sql.includes("status = 'archived'")) {
+        return Promise.resolve([]);
+      }
+      if (sql.includes("FROM connection_groups") && sql.includes("status = 'active'")) {
+        // No existing same-named group → the merge would CREATE
+        // → the collision guard runs.
+        return Promise.resolve([]);
+      }
+      if (sql.includes("SELECT id FROM connections")) {
+        // The collision-check helper. Returns a hit.
+        return Promise.resolve([{ id: "us-prod" }]);
+      }
+      return Promise.resolve([]);
+    });
+
+    const res = await app.fetch(
+      adminRequest("/api/v1/admin/connection-groups/merge", "POST", {
+        targetName: "us-prod",
+        sourceConnectionIds: ["us-int", "eu-int"],
+      }),
+    );
+    expect(res.status).toBe(409);
+    expect(
+      stateChangingCalls().some((sql) => sql.includes("WITH target AS")),
+    ).toBe(false);
+  });
+
+  it("allows REUSING an existing same-named group even when name matches a connection id", async () => {
+    // Wizard ergonomic: a same-named active group already exists, so
+    // the merge will reuse it via ON CONFLICT — the collision guard
+    // must skip this case so a real-world rename-then-merge flow
+    // ("oops, I want this to land in the existing 'prod' group")
+    // still succeeds.
+    mocks.mockInternalQuery.mockImplementation((sql: string) => {
+      if (sql.includes("SELECT id, org_id, group_id FROM connections")) {
+        return Promise.resolve([
+          { id: "us-int", org_id: "org-alpha", group_id: "g_us-int" },
+          { id: "eu-int", org_id: "org-alpha", group_id: "g_eu-int" },
+        ]);
+      }
+      if (sql.includes("FROM connection_groups") && sql.includes("status = 'archived'")) {
+        return Promise.resolve([]);
+      }
+      if (sql.includes("FROM connection_groups") && sql.includes("status = 'active'")) {
+        // Existing same-named group → reuse path, guard skips.
+        return Promise.resolve([{ id: "g_existing_prod" }]);
+      }
+      if (sql.includes("WITH target AS")) {
+        return Promise.resolve([
+          {
+            target: {
+              id: "g_existing_prod",
+              name: "us-prod",
+              primaryConnectionId: "us-int",
+              createdAt: new Date().toISOString(),
+              updatedAt: new Date().toISOString(),
+              created: false,
+            },
+            moved_connection_ids: ["us-int", "eu-int"],
+            deleted_group_ids: [],
+            skipped_group_ids: [],
+          },
+        ]);
+      }
+      return Promise.resolve([]);
+    });
+
+    const res = await app.fetch(
+      adminRequest("/api/v1/admin/connection-groups/merge", "POST", {
+        targetName: "us-prod",
+        sourceConnectionIds: ["us-int", "eu-int"],
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect(
+      stateChangingCalls().some((sql) => sql.includes("WITH target AS")),
+    ).toBe(true);
+  });
+});

--- a/packages/api/src/api/routes/admin-connection-groups.ts
+++ b/packages/api/src/api/routes/admin-connection-groups.ts
@@ -29,6 +29,7 @@ import {
 import {
   GROUP_NAME_PATTERN,
   UNIQUE_NAME_CONSTRAINT,
+  connectionNameCollidesWithGroup,
   generateGroupId,
   pgErrorMeta,
 } from "@atlas/api/lib/db/connection-groups-helpers";
@@ -432,6 +433,22 @@ adminConnectionGroups.openapi(createGroupRoute, async (c) =>
     }
     const trimmedName = name.trim();
 
+    // Name-collision guard (#2506). A literal match against an existing
+    // connection id in this org is refused — the env combobox would
+    // otherwise render a real connection id as a selectable environment
+    // label, indistinguishable from the legacy backfill orphans this
+    // guard exists to prevent.
+    if (await connectionNameCollidesWithGroup(orgId, trimmedName)) {
+      return c.json(
+        {
+          error: "conflict",
+          message: `A connection named "${trimmedName}" already exists in this workspace. Choose a different environment name.`,
+          requestId,
+        },
+        409,
+      );
+    }
+
     const id = generateGroupId();
     try {
       await internalQuery(
@@ -499,6 +516,20 @@ adminConnectionGroups.openapi(renameGroupRoute, async (c) =>
       );
     }
     const trimmedName = name.trim();
+
+    // Name-collision guard (#2506). Same rationale as POST /; refusing
+    // here as well so an admin can't rename an existing group into the
+    // backfill-orphan shape after the fact.
+    if (await connectionNameCollidesWithGroup(orgId, trimmedName)) {
+      return c.json(
+        {
+          error: "conflict",
+          message: `A connection named "${trimmedName}" already exists in this workspace. Choose a different environment name.`,
+          requestId,
+        },
+        409,
+      );
+    }
 
     let updated: GroupRow[];
     try {
@@ -1003,6 +1034,30 @@ adminConnectionGroups.openapi(mergeGroupsRoute, async (c) =>
         {
           error: "conflict",
           message: `An archived environment named "${trimmedTargetName}" already exists. Choose a different name.`,
+          requestId,
+        },
+        409,
+      );
+    }
+
+    // Name-collision guard (#2506). The wizard intentionally allows
+    // reusing an existing active group by name (`ON CONFLICT (org_id,
+    // name) DO UPDATE` in the merge CTE); the guard fires only when
+    // the merge would CREATE a new group whose label matches an
+    // existing connection id. Skipping the check when a same-named
+    // group already exists preserves the documented "reuse if present"
+    // wizard ergonomic.
+    const existingTarget = await internalQuery<{ id: string }>(
+      `SELECT id FROM connection_groups
+        WHERE org_id = $1 AND name = $2 AND status = 'active'
+        LIMIT 1`,
+      [orgId, trimmedTargetName],
+    );
+    if (existingTarget.length === 0 && (await connectionNameCollidesWithGroup(orgId, trimmedTargetName))) {
+      return c.json(
+        {
+          error: "conflict",
+          message: `A connection named "${trimmedTargetName}" already exists in this workspace. Choose a different environment name.`,
           requestId,
         },
         409,

--- a/packages/api/src/api/routes/admin-connections.ts
+++ b/packages/api/src/api/routes/admin-connections.ts
@@ -23,6 +23,7 @@ import { checkResourceLimit } from "@atlas/api/lib/billing/enforcement";
 import {
   GROUP_NAME_PATTERN,
   UNIQUE_NAME_CONSTRAINT,
+  connectionNameCollidesWithGroup,
   generateGroupId,
   pgErrorMeta,
 } from "@atlas/api/lib/db/connection-groups-helpers";
@@ -735,6 +736,26 @@ adminConnections.openapi(createConnectionRoute, async (c) => runHandler(c, "crea
     trimmedNewGroupName = newGroupName.trim();
   }
 
+  // Name-collision guard (#2506) on the inline-create path. Refuses a
+  // newGroupName that matches an existing connection id in this org.
+  // Skipped when `id === trimmedNewGroupName` because the connection
+  // doesn't exist yet — we're still creating it — and would otherwise
+  // double-count the in-flight create as its own collision.
+  if (
+    trimmedNewGroupName !== null &&
+    trimmedNewGroupName !== id &&
+    (await connectionNameCollidesWithGroup(orgId, trimmedNewGroupName))
+  ) {
+    return c.json(
+      {
+        error: "conflict",
+        message: `A connection named "${trimmedNewGroupName}" already exists in this workspace. Choose a different environment name.`,
+        requestId,
+      },
+      409,
+    );
+  }
+
   // Pre-validate cross-org so a foreign-org id surfaces as 404 here
   // rather than a 23503 FK violation inside the CTE. Mirrors the
   // merge-route source-row pre-validation in admin-connection-groups.ts.
@@ -1012,6 +1033,27 @@ adminConnections.openapi(updateConnectionRoute, async (c) => runHandler(c, "upda
     }
     trimmedNewGroupName = newGroupName.trim();
   }
+
+  // Name-collision guard (#2506). On update, `id` is the existing
+  // connection being edited — a self-named group ("Production") for
+  // a same-named connection ("Production") is still a collision the
+  // env combobox would surface confusingly, so we don't carve out a
+  // self-match here (in contrast to POST, where the connection
+  // doesn't exist yet).
+  if (
+    trimmedNewGroupName !== null &&
+    (await connectionNameCollidesWithGroup(orgId, trimmedNewGroupName))
+  ) {
+    return c.json(
+      {
+        error: "conflict",
+        message: `A connection named "${trimmedNewGroupName}" already exists in this workspace. Choose a different environment name.`,
+        requestId,
+      },
+      409,
+    );
+  }
+
   if (typeof connectionGroupId === "string") {
     const groupRows = await internalQuery<{ id: string; status: string }>(
       `SELECT id, status FROM connection_groups WHERE id = $1 AND org_id = $2`,

--- a/packages/api/src/lib/auth/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/auth/__tests__/migrate.test.ts
@@ -317,6 +317,7 @@ describe("migrateAuthTables", () => {
             { name: "0069_drop_legacy_connection_id_scope.sql" },
             { name: "0070_rename_synthetic_global_group_names.sql" },
             { name: "0071_connection_groups_status.sql" },
+            { name: "0072_cleanup_empty_synthetic_groups.sql" },
           ],
         };
       }

--- a/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
@@ -773,9 +773,9 @@ describeIfPg("migrate-pg (real Postgres)", () => {
       [liveConn, orgId],
     );
     await pool.query(
-      `INSERT INTO scheduled_tasks (owner_id, name, question, cron_expression, connection_id, connection_group_id, org_id)
-       VALUES ('admin-1', 'legacy task', 'select 1', '0 0 * * *', $1, 'g_legacy-task', $2)`,
-      [liveConn, orgId],
+      `INSERT INTO scheduled_tasks (owner_id, name, question, cron_expression, connection_group_id, org_id)
+       VALUES ('admin-1', 'legacy task', 'select 1', '0 0 * * *', 'g_legacy-task', $1)`,
+      [orgId],
     );
 
     // Apply the migration body. The smoke runs the full migration set

--- a/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
@@ -811,9 +811,10 @@ describeIfPg("migrate-pg (real Postgres)", () => {
 
   it("0072: is idempotent — re-running after the sweep is a no-op", async () => {
     const orgId = `org-0072-idemp-${Date.now()}`;
+    const ghostId = `g_ghost-${Date.now()}`;
     await pool.query(
-      `INSERT INTO connection_groups (id, org_id, name) VALUES ('g_ghost-${Date.now()}', $1, 'ghost-${Date.now()}')`,
-      [orgId],
+      `INSERT INTO connection_groups (id, org_id, name) VALUES ($1, $2, $3)`,
+      [ghostId, orgId, ghostId.slice(2)],
     );
 
     const migrationStatement = readFileSync(
@@ -821,16 +822,28 @@ describeIfPg("migrate-pg (real Postgres)", () => {
       "utf8",
     );
 
-    // First pass — should delete the ghost row we just inserted.
-    const first = await pool.query(migrationStatement);
-    expect(first.rowCount ?? 0).toBeGreaterThanOrEqual(1);
+    // The migration body is a `DO $$ ... $$` anonymous PL/pgSQL block,
+    // so `pool.query()` returns no rowCount for the inner DELETE (DO is
+    // a procedural statement, not DML). Assert idempotency via a SELECT
+    // against the seeded ghost — first pass deletes it, second is a
+    // no-op against an empty candidate set.
+    async function ghostExists(): Promise<boolean> {
+      const { rows } = await pool.query<{ id: string }>(
+        `SELECT id FROM connection_groups WHERE id = $1 AND org_id = $2`,
+        [ghostId, orgId],
+      );
+      return rows.length > 0;
+    }
 
-    // Second pass against the now-cleaned set returns zero rows. The
+    expect(await ghostExists()).toBe(true);
+    await pool.query(migrationStatement);
+    expect(await ghostExists()).toBe(false);
+    // Second pass against the now-cleaned set is a 0-row DELETE. The
     // production migration is run once but the test runs the body
     // twice; idempotency is the contract that lets a re-run during a
     // partial-deploy retry land safely.
-    const second = await pool.query(migrationStatement);
-    expect(second.rowCount ?? 0).toBe(0);
+    await pool.query(migrationStatement);
+    expect(await ghostExists()).toBe(false);
   }, PG_TEST_TIMEOUT_MS);
 
   // 0063 — semantic_entities.connection_group_id. Adds the group-scoped

--- a/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
@@ -726,6 +726,113 @@ describeIfPg("migrate-pg (real Postgres)", () => {
     expect(rows[0].target.primaryConnectionId).toBe(conn1);
   }, PG_TEST_TIMEOUT_MS);
 
+  // 0072 — empty-backfill-orphan sweep (#2506).
+  //
+  // The migration deletes connection_groups whose id/name match the
+  // 0062 backfill shape AND have zero non-archived references across
+  // the seven content tables. Validated end-to-end here because the
+  // mock-pool tests cannot exercise the seven `NOT EXISTS` subqueries
+  // against real schemas.
+  it("0072: sweeps empty backfill orphans but preserves curated and live groups (#2506)", async () => {
+    const orgId = `org-0072-sweep-${Date.now()}`;
+
+    // Seed five canary groups covering every branch the migration must
+    // discriminate. Each row is constructed against the row state the
+    // production migration meets.
+    //
+    //   orphan       — id=g_us-prod, name=us-prod, 0 members, no refs.
+    //                  Migration MUST delete.
+    //   live         — id=g_warehouse, name=warehouse, 1 member.
+    //                  Migration MUST preserve (member exists).
+    //   renamed      — id=g_billing, name='Billing', 0 members.
+    //                  Migration MUST preserve (name diverged from id).
+    //   user         — id=g_abc123def4, name='Production', 0 members.
+    //                  Migration MUST preserve (user-shaped id, custom
+    //                  name).
+    //   ref-task     — id=g_legacy-task, name=legacy-task, 0 members,
+    //                  carries an enabled scheduled_tasks reference.
+    //                  Migration MUST preserve (live content reference).
+    //
+    // All five share the same orgId so the predicate is exercised
+    // against a heterogeneous candidate set rather than five
+    // independent runs.
+    const liveConn = `conn-live-0072-${Date.now()}`;
+
+    await pool.query(
+      `INSERT INTO connection_groups (id, org_id, name) VALUES
+         ('g_us-prod', $1, 'us-prod'),
+         ('g_warehouse', $1, 'warehouse'),
+         ('g_billing', $1, 'Billing'),
+         ('g_abc123def4', $1, 'Production'),
+         ('g_legacy-task', $1, 'legacy-task')`,
+      [orgId],
+    );
+    await pool.query(
+      `INSERT INTO connections (id, url, type, org_id, status, group_id) VALUES
+         ($1, 'postgresql://stub', 'postgres', $2, 'published', 'g_warehouse')`,
+      [liveConn, orgId],
+    );
+    await pool.query(
+      `INSERT INTO scheduled_tasks (owner_id, name, question, cron_expression, connection_id, connection_group_id, org_id)
+       VALUES ('admin-1', 'legacy task', 'select 1', '0 0 * * *', $1, 'g_legacy-task', $2)`,
+      [liveConn, orgId],
+    );
+
+    // Apply the migration body. The smoke runs the full migration set
+    // up front (see "runs every migration end-to-end" above), so this
+    // test re-runs the predicate via the same SQL text the migration
+    // file ships — keeping the test idempotent under repeated runs in
+    // the same schema and verifying the SQL is still the load-bearing
+    // predicate post-deploy.
+    // node-pg accepts comments inline — the migration is one DELETE
+    // statement so a verbatim pool.query() against the file body is the
+    // tightest pin between test and migration.
+    const migrationStatement = readFileSync(
+      join(import.meta.dir, "..", "migrations", "0072_cleanup_empty_synthetic_groups.sql"),
+      "utf8",
+    );
+    await pool.query(migrationStatement);
+
+    const survivors = await pool.query<{ id: string }>(
+      `SELECT id FROM connection_groups WHERE org_id = $1 ORDER BY id`,
+      [orgId],
+    );
+    const survivingIds = survivors.rows.map((r) => r.id);
+
+    expect(survivingIds).toEqual([
+      "g_abc123def4",
+      "g_billing",
+      "g_legacy-task",
+      "g_warehouse",
+    ]);
+    // g_us-prod is gone — that's the whole point.
+    expect(survivingIds).not.toContain("g_us-prod");
+  }, PG_TEST_TIMEOUT_MS);
+
+  it("0072: is idempotent — re-running after the sweep is a no-op", async () => {
+    const orgId = `org-0072-idemp-${Date.now()}`;
+    await pool.query(
+      `INSERT INTO connection_groups (id, org_id, name) VALUES ('g_ghost-${Date.now()}', $1, 'ghost-${Date.now()}')`,
+      [orgId],
+    );
+
+    const migrationStatement = readFileSync(
+      join(import.meta.dir, "..", "migrations", "0072_cleanup_empty_synthetic_groups.sql"),
+      "utf8",
+    );
+
+    // First pass — should delete the ghost row we just inserted.
+    const first = await pool.query(migrationStatement);
+    expect(first.rowCount ?? 0).toBeGreaterThanOrEqual(1);
+
+    // Second pass against the now-cleaned set returns zero rows. The
+    // production migration is run once but the test runs the body
+    // twice; idempotency is the contract that lets a re-run during a
+    // partial-deploy retry land safely.
+    const second = await pool.query(migrationStatement);
+    expect(second.rowCount ?? 0).toBe(0);
+  }, PG_TEST_TIMEOUT_MS);
+
   // 0063 — semantic_entities.connection_group_id. Adds the group-scoped
   // natural key the multi-environment semantic layer (#2336 / #2340) lives
   // on. The three partial unique indexes from 0028 are dropped and recreated

--- a/packages/api/src/lib/db/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate.test.ts
@@ -83,8 +83,9 @@ describe("runMigrations", () => {
     // + 0067 (conversations, #2345) + 0068 (scheduled tasks, #2343)
     // + 0069 (drop legacy connection_id scopes, #2347)
     // + 0070 (rename synthetic __global__ group names, #2417)
-    // + 0071 (connection_groups.status enum, Phase 4 archive cascade, #2413) = 72.
-    expect(count).toBe(72);
+    // + 0071 (connection_groups.status enum, Phase 4 archive cascade, #2413)
+    // + 0072 (cleanup empty synthetic group orphans, #2506) = 73.
+    expect(count).toBe(73);
 
     // Advisory lock acquired before anything else
     expect(queries[0]).toContain("pg_advisory_lock");
@@ -185,6 +186,7 @@ describe("runMigrations", () => {
         "0069_drop_legacy_connection_id_scope.sql",
         "0070_rename_synthetic_global_group_names.sql",
         "0071_connection_groups_status.sql",
+        "0072_cleanup_empty_synthetic_groups.sql",
       ],
     });
 

--- a/packages/api/src/lib/db/connection-groups-helpers.ts
+++ b/packages/api/src/lib/db/connection-groups-helpers.ts
@@ -7,6 +7,8 @@
  * api/routes/").
  */
 
+import { internalQuery } from "@atlas/api/lib/db/internal";
+
 /**
  * Validation regex matching the existing connection-id rule. Reused so a
  * group renamed to a value that would later collide with a connection id
@@ -51,6 +53,62 @@ export function generateGroupId(): string {
  * silently degrades to a generic 500. Depth-bounded at 5 to defend
  * against pathological cycles.
  */
+/**
+ * True iff `name` would collide with an existing connection id in this org.
+ * Centralised so every group-name entry surface refuses the same shape:
+ *   - POST   /admin/connection-groups
+ *   - PATCH  /admin/connection-groups/:id
+ *   - POST   /admin/connection-groups/merge (only when the target name is
+ *            new — reuse of an existing group by name is the documented
+ *            wizard ergonomic and must not surface a collision error)
+ *   - POST   /admin/connections             (inline `newGroupName`)
+ *   - PUT    /admin/connections/:id         (inline `newGroupName`)
+ *
+ * Rationale (#2506): the 0062 1:1 backfill creates groups shaped
+ * `id = 'g_' || conn.id`, `name = conn.id`. When such a group is folded
+ * into a multi-region env via the merge wizard and the cleanup CTE later
+ * leaves the source group behind as a zero-member orphan (the two paths
+ * documented in migration 0072), the env combobox surfaces a ghost
+ * environment labelled identically to a real connection id. A
+ * user-initiated create that lands the same literal collision would
+ * re-introduce the same confusion at no benefit — the schema-vs-display
+ * vocabulary divide ("connection group" ↔ "environment") means an admin
+ * is not consciously typing a connection id into the env name field;
+ * matches are typo-grade.
+ *
+ * Scope is intentionally narrow:
+ *   - Only refuses LITERAL equality with an existing connection id.
+ *     A group named "Production" with members `us-prod` / `eu-prod` is
+ *     fine — the name does not match any connection id.
+ *   - Org-scoped via `connections.org_id`. The composite-PK shape
+ *     `(id, org_id)` means a SaaS tenant can share an id like `default`
+ *     with another tenant; this check only sees the caller's own
+ *     connections.
+ *   - Does NOT touch existing rows. Pre-fix groups that already collide
+ *     (i.e. the orphan this guard exists to prevent) are cleaned up by
+ *     migration 0072. Retroactively renaming or refusing them would
+ *     break legitimate single-region setups where the admin has
+ *     deliberately given a connection-named group a meaningful display
+ *     label.
+ *
+ * Returns true when a collision exists. Callers map true → 409 with a
+ * friendly message; false → continue.
+ */
+export async function connectionNameCollidesWithGroup(
+  orgId: string,
+  name: string,
+): Promise<boolean> {
+  const rows = await internalQuery<{ id: string }>(
+    `SELECT id FROM connections
+      WHERE org_id = $1
+        AND id = $2
+        AND status != 'archived'
+      LIMIT 1`,
+    [orgId, name],
+  );
+  return rows.length > 0;
+}
+
 export function pgErrorMeta(err: unknown): { code?: string; constraint?: string } {
   let cursor: unknown = err;
   for (let depth = 0; depth < 5 && cursor instanceof Error; depth++) {

--- a/packages/api/src/lib/db/connection-groups-helpers.ts
+++ b/packages/api/src/lib/db/connection-groups-helpers.ts
@@ -41,35 +41,18 @@ export function generateGroupId(): string {
 }
 
 /**
- * Narrow a thrown Postgres error to its `code` + `constraint` fields
- * without leaking `any`. `pg` populates both on driver-thrown errors;
- * non-driver throws come through with neither set, and the caller falls
- * through to its generic 500 path.
- *
- * Walks `.cause` chains so a wrapped pg error (Effect `Cause.fail`,
- * `new Error(msg, { cause: pgErr })`, retry-wrapping `internalQuery`)
- * still surfaces its driver fields — without this, the moment any
- * caller wraps the query, every 23505 disambiguation in this codebase
- * silently degrades to a generic 500. Depth-bounded at 5 to defend
- * against pathological cycles.
- */
-/**
  * True iff `name` would collide with an existing connection id in this org.
- * Centralised so every group-name entry surface refuses the same shape:
- *   - POST   /admin/connection-groups
- *   - PATCH  /admin/connection-groups/:id
- *   - POST   /admin/connection-groups/merge (only when the target name is
- *            new — reuse of an existing group by name is the documented
- *            wizard ergonomic and must not surface a collision error)
- *   - POST   /admin/connections             (inline `newGroupName`)
- *   - PUT    /admin/connections/:id         (inline `newGroupName`)
+ * Centralised so every group-name entry surface refuses the same shape;
+ * see the call-site enumeration in the test file
+ * (`admin-connection-groups-name-collision.test.ts`) for the canonical
+ * coverage matrix, including the merge-route reuse carve-out and the
+ * POST `/admin/connections` self-name carve-out.
  *
  * Rationale (#2506): the 0062 1:1 backfill creates groups shaped
- * `id = 'g_' || conn.id`, `name = conn.id`. When such a group is folded
- * into a multi-region env via the merge wizard and the cleanup CTE later
- * leaves the source group behind as a zero-member orphan (the two paths
- * documented in migration 0072), the env combobox surfaces a ghost
- * environment labelled identically to a real connection id. A
+ * `id = 'g_' || conn.id`, `name = conn.id`. Two production paths
+ * (documented in migration 0072) can leave one of those rows behind
+ * with zero members, surfacing in the env combobox as a ghost
+ * environment whose label collides with a real connection id. A
  * user-initiated create that lands the same literal collision would
  * re-introduce the same confusion at no benefit — the schema-vs-display
  * vocabulary divide ("connection group" ↔ "environment") means an admin
@@ -91,6 +74,16 @@ export function generateGroupId(): string {
  *     deliberately given a connection-named group a meaningful display
  *     label.
  *
+ * Error-propagation contract: callers MUST run inside `runHandler` (or
+ * an equivalent Effect → HTTP bridge). The helper deliberately does NOT
+ * try/catch a thrown `internalQuery` rejection — a local `catch { return
+ * false }` would silently fail-open, bypassing the guard on any DB
+ * blip. Letting the throw bubble produces a 500 with `requestId` and a
+ * structured log line, which is the right answer for a soft security
+ * check (CLAUDE.md "Prefer errors over silent fallbacks"). The
+ * fail-closed contract is pinned by a dedicated test in
+ * `admin-connection-groups-name-collision.test.ts`.
+ *
  * Returns true when a collision exists. Callers map true → 409 with a
  * friendly message; false → continue.
  */
@@ -109,6 +102,19 @@ export async function connectionNameCollidesWithGroup(
   return rows.length > 0;
 }
 
+/**
+ * Narrow a thrown Postgres error to its `code` + `constraint` fields
+ * without leaking `any`. `pg` populates both on driver-thrown errors;
+ * non-driver throws come through with neither set, and the caller falls
+ * through to its generic 500 path.
+ *
+ * Walks `.cause` chains so a wrapped pg error (Effect `Cause.fail`,
+ * `new Error(msg, { cause: pgErr })`, retry-wrapping `internalQuery`)
+ * still surfaces its driver fields — without this, the moment any
+ * caller wraps the query, every 23505 disambiguation in this codebase
+ * silently degrades to a generic 500. Depth-bounded at 5 to defend
+ * against pathological cycles.
+ */
 export function pgErrorMeta(err: unknown): { code?: string; constraint?: string } {
   let cursor: unknown = err;
   for (let depth = 0; depth < 5 && cursor instanceof Error; depth++) {

--- a/packages/api/src/lib/db/migrations/0072_cleanup_empty_synthetic_groups.sql
+++ b/packages/api/src/lib/db/migrations/0072_cleanup_empty_synthetic_groups.sql
@@ -1,0 +1,92 @@
+-- 0072 — Drop empty `g_<connId>` backfill orphans (#2506).
+--
+-- The 0062 1:1 backfill creates `connection_groups` rows shaped
+-- `id = 'g_' || conn.id`, `name = conn.id` for every existing connection.
+-- When an admin later folds those singletons into a multi-region group via
+-- the merge wizard (POST /admin/connection-groups/merge), the inline cleanup
+-- CTE in `MERGE_CONNECTIONS_INTO_GROUP_SQL` deletes the now-empty source
+-- groups in the same statement. Two paths leave a `g_<connId>` row behind
+-- with zero members:
+--
+--   1. The merge ran before the codex #2437 fix landed. Pre-#2437 the
+--      cleanup CTE's `EXISTS` guard against `connections` could not see the
+--      sibling `moved` CTE's UPDATE (data-modifying CTEs share one
+--      snapshot), so it concluded the source group was still occupied and
+--      skipped the DELETE. The `moved` UPDATE still landed; the source
+--      group survived as a 0-member orphan.
+--
+--   2. The merge fired a `NOT EXISTS` guard against one of the seven
+--      content reference tables (approval_queue, scheduled_tasks,
+--      dashboard_cards, semantic_entities, pii_column_classifications,
+--      conversations — `connections` is path 1). That reference has since
+--      been cleared (approval expired, task disabled, etc.) but the now-
+--      empty source group was never re-swept.
+--
+-- Symptom on prod: `/admin/connections?groupBy=environment` surfaces a
+-- ghost `us-prod` group with "No connections yet"; the same name pollutes
+-- the env combobox in the Add Connection dialog as a selectable
+-- environment alongside the real `prod` group that already contains the
+-- `us-prod` connection.
+--
+-- This migration is a one-time sweep that mirrors the merge CTE's cleanup
+-- predicate exactly:
+--
+--   `id LIKE 'g\_%' ESCAPE '\' AND name = SUBSTRING(id FROM 3)`
+--     — only auto-backfill shapes. User-created `g_<random>` groups (whose
+--       `name` was set explicitly by the admin) and admin-renamed groups
+--       are preserved even when empty.
+--
+--   `NOT EXISTS` against every reference table that carries a
+--   `connection_group_id` column today, plus `connections.group_id`.
+--   `dashboard_cards` is the lone reference without its own `org_id`
+--   (see 0066 "Why no FK on connection_group_id" — cards inherit org
+--   scope from their parent `dashboards` row). The global-cg.id collision
+--   risk is the same trade documented in `MERGE_CONNECTIONS_INTO_GROUP_SQL`.
+--
+-- Idempotent: a second pass against a freshly-cleaned schema is a 0-row
+-- DELETE. The `LIKE 'g\_%'` predicate prevents the migration from ever
+-- touching admin-curated groups.
+--
+-- Prevention for path 1 is already in place (codex #2437 landed in 1.4.4).
+-- Prevention for path 2 (a stale reference clearing without re-sweeping the
+-- group) is out of scope for this slice — adding a cleanup hook to every
+-- reference-table delete would couple six surfaces to the group lifecycle.
+-- Acceptable: backfill-shape orphans are a one-time historical artifact,
+-- not a steady-state production occurrence — new groups are user-created
+-- with `g_<random>` ids that this migration's predicate ignores by design.
+--
+-- The follow-up surface defence (env combobox skips empty backfill
+-- orphans, name-collision guard refuses new groups whose name matches an
+-- existing connection id) ships alongside this migration.
+
+DELETE FROM connection_groups cg
+ WHERE cg.id LIKE 'g\_%' ESCAPE '\'
+   AND cg.name = SUBSTRING(cg.id FROM 3)
+   AND NOT EXISTS (
+     SELECT 1 FROM connections c
+      WHERE c.group_id = cg.id AND c.org_id = cg.org_id
+   )
+   AND NOT EXISTS (
+     SELECT 1 FROM approval_queue aq
+      WHERE aq.connection_group_id = cg.id AND aq.org_id = cg.org_id
+   )
+   AND NOT EXISTS (
+     SELECT 1 FROM scheduled_tasks st
+      WHERE st.connection_group_id = cg.id AND st.org_id = cg.org_id
+   )
+   AND NOT EXISTS (
+     SELECT 1 FROM dashboard_cards dc
+      WHERE dc.connection_group_id = cg.id
+   )
+   AND NOT EXISTS (
+     SELECT 1 FROM semantic_entities se
+      WHERE se.connection_group_id = cg.id AND se.org_id = cg.org_id
+   )
+   AND NOT EXISTS (
+     SELECT 1 FROM pii_column_classifications pc
+      WHERE pc.connection_group_id = cg.id AND pc.org_id = cg.org_id
+   )
+   AND NOT EXISTS (
+     SELECT 1 FROM conversations cv
+      WHERE cv.connection_group_id = cg.id AND cv.org_id = cg.org_id
+   );

--- a/packages/api/src/lib/db/migrations/0072_cleanup_empty_synthetic_groups.sql
+++ b/packages/api/src/lib/db/migrations/0072_cleanup_empty_synthetic_groups.sql
@@ -2,25 +2,32 @@
 --
 -- The 0062 1:1 backfill creates `connection_groups` rows shaped
 -- `id = 'g_' || conn.id`, `name = conn.id` for every existing connection.
--- When an admin later folds those singletons into a multi-region group via
--- the merge wizard (POST /admin/connection-groups/merge), the inline cleanup
--- CTE in `MERGE_CONNECTIONS_INTO_GROUP_SQL` deletes the now-empty source
--- groups in the same statement. Two paths leave a `g_<connId>` row behind
--- with zero members:
+-- Two production code paths can re-parent the connection out of that
+-- backfill group without cleaning up the now-empty source row:
 --
---   1. The merge ran before the codex #2437 fix landed. Pre-#2437 the
---      cleanup CTE's `EXISTS` guard against `connections` could not see the
---      sibling `moved` CTE's UPDATE (data-modifying CTEs share one
---      snapshot), so it concluded the source group was still occupied and
---      skipped the DELETE. The `moved` UPDATE still landed; the source
---      group survived as a 0-member orphan.
+--   A. Merge wizard skip-and-cleared (`MERGE_CONNECTIONS_INTO_GROUP_SQL`):
+--      the inline cleanup CTE in the merge route deletes auto-backfilled
+--      source groups in the same statement, but skips any source group
+--      that anchors a row in one of the seven content reference tables
+--      (`connections`, `approval_queue`, `scheduled_tasks`,
+--      `dashboard_cards`, `semantic_entities`, `pii_column_classifications`,
+--      `conversations`). The skipped id is surfaced in
+--      `skipped_group_ids` on the wire so the wizard can show what it
+--      preserved. If that reference is later cleared (approval expired,
+--      task disabled, semantic entity archived, dashboard card removed)
+--      no path re-evaluates the now-empty source group, and it survives
+--      indefinitely.
 --
---   2. The merge fired a `NOT EXISTS` guard against one of the seven
---      content reference tables (approval_queue, scheduled_tasks,
---      dashboard_cards, semantic_entities, pii_column_classifications,
---      conversations — `connections` is path 1). That reference has since
---      been cleared (approval expired, task disabled, etc.) but the now-
---      empty source group was never re-swept.
+--   B. Member-move endpoints with no cascade cleanup
+--      (`POST /admin/connection-groups/:id/members` and the
+--      `connectionGroupId` branch of `PUT /admin/connections/:id`):
+--      both re-parent a connection's `group_id` and stop there. When
+--      the connection's prior group was the 0062 backfill row, the
+--      source row stays in `connection_groups` with zero members. The
+--      merge wizard avoids this by re-parenting via the same CTE that
+--      sweeps the source; the member-move routes are simpler one-shot
+--      UPDATEs that predate the group lifecycle work and never picked
+--      up an equivalent cleanup.
 --
 -- Symptom on prod: `/admin/connections?groupBy=environment` surfaces a
 -- ghost `us-prod` group with "No connections yet"; the same name pollutes
@@ -47,46 +54,62 @@
 -- DELETE. The `LIKE 'g\_%'` predicate prevents the migration from ever
 -- touching admin-curated groups.
 --
--- Prevention for path 1 is already in place (codex #2437 landed in 1.4.4).
--- Prevention for path 2 (a stale reference clearing without re-sweeping the
--- group) is out of scope for this slice — adding a cleanup hook to every
--- reference-table delete would couple six surfaces to the group lifecycle.
--- Acceptable: backfill-shape orphans are a one-time historical artifact,
--- not a steady-state production occurrence — new groups are user-created
--- with `g_<random>` ids that this migration's predicate ignores by design.
+-- Permanent path-B prevention (cascading cleanup into the member-move
+-- endpoints, and likewise into the merge route's `skipped_group_ids`
+-- after the reference clears) is out of scope for this slice — adding
+-- the hook to every reference-table delete plus both member-move call
+-- sites would couple eight surfaces to the group lifecycle. Tracked as
+-- a follow-up at https://github.com/AtlasDevHQ/atlas/issues/2506
+-- comment thread; this migration sweeps existing orphans and the
+-- route-layer name-collision guard prevents new ones from being
+-- intentionally created.
 --
--- The follow-up surface defence (env combobox skips empty backfill
--- orphans, name-collision guard refuses new groups whose name matches an
--- existing connection id) ships alongside this migration.
+-- The surface defence (env combobox skips empty backfill orphans,
+-- name-collision guard refuses new groups whose name matches an existing
+-- connection id) ships alongside this migration.
+--
+-- Wrapped in a DO block so `RAISE NOTICE` emits a deleted-count line into
+-- the migration runner's Railway log. Destructive migrations without an
+-- audit signal are debugging hell when prod surfaces an unexpected drop.
 
-DELETE FROM connection_groups cg
- WHERE cg.id LIKE 'g\_%' ESCAPE '\'
-   AND cg.name = SUBSTRING(cg.id FROM 3)
-   AND NOT EXISTS (
-     SELECT 1 FROM connections c
-      WHERE c.group_id = cg.id AND c.org_id = cg.org_id
-   )
-   AND NOT EXISTS (
-     SELECT 1 FROM approval_queue aq
-      WHERE aq.connection_group_id = cg.id AND aq.org_id = cg.org_id
-   )
-   AND NOT EXISTS (
-     SELECT 1 FROM scheduled_tasks st
-      WHERE st.connection_group_id = cg.id AND st.org_id = cg.org_id
-   )
-   AND NOT EXISTS (
-     SELECT 1 FROM dashboard_cards dc
-      WHERE dc.connection_group_id = cg.id
-   )
-   AND NOT EXISTS (
-     SELECT 1 FROM semantic_entities se
-      WHERE se.connection_group_id = cg.id AND se.org_id = cg.org_id
-   )
-   AND NOT EXISTS (
-     SELECT 1 FROM pii_column_classifications pc
-      WHERE pc.connection_group_id = cg.id AND pc.org_id = cg.org_id
-   )
-   AND NOT EXISTS (
-     SELECT 1 FROM conversations cv
-      WHERE cv.connection_group_id = cg.id AND cv.org_id = cg.org_id
-   );
+DO $$
+DECLARE
+  deleted_count integer;
+BEGIN
+  WITH deleted AS (
+    DELETE FROM connection_groups cg
+     WHERE cg.id LIKE 'g\_%' ESCAPE '\'
+       AND cg.name = SUBSTRING(cg.id FROM 3)
+       AND NOT EXISTS (
+         SELECT 1 FROM connections c
+          WHERE c.group_id = cg.id AND c.org_id = cg.org_id
+       )
+       AND NOT EXISTS (
+         SELECT 1 FROM approval_queue aq
+          WHERE aq.connection_group_id = cg.id AND aq.org_id = cg.org_id
+       )
+       AND NOT EXISTS (
+         SELECT 1 FROM scheduled_tasks st
+          WHERE st.connection_group_id = cg.id AND st.org_id = cg.org_id
+       )
+       AND NOT EXISTS (
+         SELECT 1 FROM dashboard_cards dc
+          WHERE dc.connection_group_id = cg.id
+       )
+       AND NOT EXISTS (
+         SELECT 1 FROM semantic_entities se
+          WHERE se.connection_group_id = cg.id AND se.org_id = cg.org_id
+       )
+       AND NOT EXISTS (
+         SELECT 1 FROM pii_column_classifications pc
+          WHERE pc.connection_group_id = cg.id AND pc.org_id = cg.org_id
+       )
+       AND NOT EXISTS (
+         SELECT 1 FROM conversations cv
+          WHERE cv.connection_group_id = cg.id AND cv.org_id = cg.org_id
+       )
+     RETURNING cg.id, cg.org_id
+  )
+  SELECT count(*) INTO deleted_count FROM deleted;
+  RAISE NOTICE '[0072] cleanup_empty_synthetic_groups: deleted % orphan backfill group(s)', deleted_count;
+END $$;

--- a/packages/web/src/app/admin/connections/page.tsx
+++ b/packages/web/src/app/admin/connections/page.tsx
@@ -40,7 +40,7 @@ import {
 import { useDemoReadonly } from "@/ui/hooks/use-demo-readonly";
 import { DemoBadge, DraftBadge } from "@/ui/components/admin/mode-badges";
 import { DEMO_CONNECTION_ID } from "./columns";
-import { stripGroupPrefix, isAutoBackfilledSingleton } from "@/ui/lib/strip-group-prefix";
+import { stripGroupPrefix, isAutoBackfilledSingleton, isEmptyBackfillOrphan } from "@/ui/lib/strip-group-prefix";
 import Link from "next/link";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -258,9 +258,16 @@ function ConnectionFormDialog({
   // Env dropdown only surfaces user-named envs. Auto-`g_<id>` singletons
   // are hidden so the dropdown doesn't leak migration-0062's
   // implementation detail to single-DB admins. Same predicate the
-  // Environments tab uses to collapse the auto-detected noise.
+  // Environments tab uses to collapse the auto-detected noise. Empty
+  // backfill orphans (#2506) are also hidden — a ghost `g_<connId>`
+  // group with zero members and a name matching a real connection id
+  // is the exact confusion this dialog must not surface; migration
+  // 0072 sweeps existing rows, this guards new surfaces.
   const selectableEnvs = envGroups.filter(
-    (g) => g.status !== "archived" && !isAutoBackfilledSingleton(g),
+    (g) =>
+      g.status !== "archived" &&
+      !isAutoBackfilledSingleton(g) &&
+      !isEmptyBackfillOrphan(g),
   );
 
   // Default env selection:

--- a/packages/web/src/ui/__tests__/strip-group-prefix.test.ts
+++ b/packages/web/src/ui/__tests__/strip-group-prefix.test.ts
@@ -13,6 +13,7 @@ import { describe, it, expect } from "bun:test";
 import {
   stripGroupPrefix,
   isAutoBackfilledSingleton,
+  isEmptyBackfillOrphan,
 } from "@/ui/lib/strip-group-prefix";
 
 describe("stripGroupPrefix", () => {
@@ -88,6 +89,65 @@ describe("isAutoBackfilledSingleton", () => {
       isAutoBackfilledSingleton({
         id: "g_warehouse",
         name: "warehouse",
+        memberCount: 0,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("isEmptyBackfillOrphan", () => {
+  it("returns true for the exact #2506 ghost shape (g_<connId>, name=connId, 0 members)", () => {
+    // This is the prod orphan that pollutes the env combobox: the
+    // `us-prod` connection has been merged into the `prod` group, but
+    // its source backfill row survived as a 0-member group whose label
+    // still collides with the live connection id.
+    expect(
+      isEmptyBackfillOrphan({
+        id: "g_us-prod",
+        name: "us-prod",
+        memberCount: 0,
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false when membership is non-zero (live or singleton)", () => {
+    expect(
+      isEmptyBackfillOrphan({ id: "g_us-prod", name: "us-prod", memberCount: 1 }),
+    ).toBe(false);
+    expect(
+      isEmptyBackfillOrphan({ id: "g_us-prod", name: "us-prod", memberCount: 3 }),
+    ).toBe(false);
+  });
+
+  it("returns false for a user-created `g_<random>` group whose admin emptied it", () => {
+    // A user-created group that's been emptied (every member moved out)
+    // still has a meaningful name the admin assigned — preserve so the
+    // wizard can rehydrate it. Disambiguation is the same `name == id
+    // suffix` rule that gates `isAutoBackfilledSingleton`.
+    expect(
+      isEmptyBackfillOrphan({
+        id: "g_abc123def",
+        name: "Production",
+        memberCount: 0,
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false for an admin-renamed singleton emptied to zero members", () => {
+    expect(
+      isEmptyBackfillOrphan({
+        id: "g_warehouse",
+        name: "Warehouse",
+        memberCount: 0,
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false for groups whose id does not match the g_ backfill prefix", () => {
+    expect(
+      isEmptyBackfillOrphan({
+        id: "prod",
+        name: "prod",
         memberCount: 0,
       }),
     ).toBe(false);

--- a/packages/web/src/ui/lib/strip-group-prefix.ts
+++ b/packages/web/src/ui/lib/strip-group-prefix.ts
@@ -47,3 +47,36 @@ export function isAutoBackfilledSingleton(group: {
   if (!group.id.startsWith("g_")) return false;
   return group.name === group.id.slice(2);
 }
+
+/**
+ * True when a group is the empty residue of a merged-out backfill
+ * singleton (#2506): id matches the `g_<connId>` backfill shape, name
+ * still equals the bare connection id, and the group has zero
+ * non-archived members. Two paths produce this shape in the wild:
+ *
+ *   1. A merge wizard run pre-#2437 whose cleanup CTE couldn't see the
+ *      sibling `moved` UPDATE (shared snapshot) and skipped the DELETE.
+ *   2. A merge whose cleanup CTE fired a `NOT EXISTS` guard against
+ *      one of the seven content reference tables — the reference has
+ *      since been cleared but the now-empty source group was never
+ *      re-swept.
+ *
+ * Migration 0072 sweeps existing rows; this helper hides any orphan that
+ * survives until then from the env combobox (Add / Edit Connection
+ * dialog) so the admin cannot accidentally re-anchor a new connection
+ * to a ghost group whose label collides with a real connection id.
+ *
+ * Distinct from `isAutoBackfilledSingleton` (member-count 1) so the
+ * Environments tab's "auto-detected singletons" toggle keeps its
+ * literal meaning — empty orphans surface in the curated list with the
+ * "No connections yet" affordance the admin can act on.
+ */
+export function isEmptyBackfillOrphan(group: {
+  id: string;
+  name: string;
+  memberCount: number;
+}): boolean {
+  if (group.memberCount !== 0) return false;
+  if (!group.id.startsWith("g_")) return false;
+  return group.name === group.id.slice(2);
+}

--- a/packages/web/src/ui/lib/strip-group-prefix.ts
+++ b/packages/web/src/ui/lib/strip-group-prefix.ts
@@ -52,14 +52,10 @@ export function isAutoBackfilledSingleton(group: {
  * True when a group is the empty residue of a merged-out backfill
  * singleton (#2506): id matches the `g_<connId>` backfill shape, name
  * still equals the bare connection id, and the group has zero
- * non-archived members. Two paths produce this shape in the wild:
- *
- *   1. A merge wizard run pre-#2437 whose cleanup CTE couldn't see the
- *      sibling `moved` UPDATE (shared snapshot) and skipped the DELETE.
- *   2. A merge whose cleanup CTE fired a `NOT EXISTS` guard against
- *      one of the seven content reference tables — the reference has
- *      since been cleared but the now-empty source group was never
- *      re-swept.
+ * non-archived members. These survive when the merge wizard's cleanup
+ * CTE was blocked by a content reference that later cleared, or when
+ * a non-cascading member-move re-parented the connection out. See
+ * migration 0072 for the full path enumeration.
  *
  * Migration 0072 sweeps existing rows; this helper hides any orphan that
  * survives until then from the env combobox (Add / Edit Connection


### PR DESCRIPTION
Closes #2506.

## Root cause

The orphan `us-prod` env group on prod is a **migration 0062 backfill residue**, not a seed or merge-wizard bug. Migration 0062's 1:1 backfill creates one `connection_groups` row per existing connection, shaped `id = 'g_' || conn.id`, `name = conn.id`. When the `us-prod` connection was later re-parented into the `prod` group via the merge wizard, the merge CTE's inline cleanup either:

1. Ran before the codex #2437 fix landed — pre-fix, the cleanup `NOT EXISTS` against `connections` couldn't see the sibling `moved` UPDATE (data-modifying CTEs share one snapshot), so cleanup concluded the source group was still occupied and skipped the DELETE; OR
2. Fired a `NOT EXISTS` guard against one of the seven content reference tables (approval_queue / scheduled_tasks / dashboard_cards / semantic_entities / pii_column_classifications / conversations / connections), the reference was later cleared (approval expired, task disabled, etc.) but the now-empty source group was never re-swept.

Either path leaves a `g_<connId>` row with zero members and a name colliding with the live connection id. The UI filter `isAutoBackfilledSingleton` correctly hides single-member backfill rows but its `memberCount !== 1` guard means **empty** orphans pass through into the env combobox.

The dogfood seed (`internal/run.sh` doesn't exist in this repo) is not implicated.

## Changes

### One-time cleanup

- **Migration `0072_cleanup_empty_synthetic_groups.sql`** — DELETEs any `connection_groups` row matching the 0062 backfill shape (`id LIKE 'g\_%' ESCAPE '\' AND name = SUBSTRING(id FROM 3)`) with zero non-archived references across all seven reference tables. Mirrors the merge CTE's cleanup predicate exactly, so a row preserved by the merge stays preserved here. Idempotent; safe re-run is a 0-row DELETE.

### Prevention (route layer)

- **`connectionNameCollidesWithGroup(orgId, name)`** in `packages/api/src/lib/db/connection-groups-helpers.ts` — async helper that checks for a literal connection-id match in the caller's org. Centralised so every entry point uses the same predicate.
- Wired into **`POST /admin/connection-groups`** and **`PATCH /admin/connection-groups/:id`** (refuses any matching name with 409).
- Wired into **`POST /admin/connection-groups/merge`** but **only when CREATING a new group** — the documented wizard ergonomic of reusing an existing same-named group via `ON CONFLICT` is preserved; if a same-named active group already exists, the merge proceeds (collision check skipped).
- Wired into **`POST /admin/connections`** and **`PUT /admin/connections/:id`** inline `newGroupName` paths. POST carves out `name === id` (the connection doesn't exist yet); PUT does not (the connection already exists and a same-name collision is real).

### Prevention (UI)

- **`isEmptyBackfillOrphan(group)`** in `packages/web/src/ui/lib/strip-group-prefix.ts` — true for `g_<connId>` / `name=connId` / `memberCount === 0`. Distinct from `isAutoBackfilledSingleton` (member-count 1) so the Environments tab's "auto-detected singletons" toggle keeps its literal meaning.
- Env combobox in **Add/Edit Connection dialog** now filters out empty backfill orphans alongside archived + auto-singletons.

### What I deliberately did NOT do

- Did not drop the `connection_groups` table.
- Did not auto-merge empty groups into existing same-named groups.
- Did not change the GROUP_NAME_PATTERN in `connection-groups-sql.ts` — the regex is shared with the legitimate 0062 backfill and tightening it retroactively would block legal migrations. The collision check is route-only, so existing rows are untouched.
- Did not add an auto-archive-after-N-hours sweep for empty groups — too aggressive; user-created `g_<random>` groups intentionally start empty before the admin attaches a connection.

## Test plan

- [x] `bun run --filter '@atlas/api' test` — 386/386 files pass (collision test: 7 new wire-contract pins across POST / PATCH / merge)
- [x] `bun run --filter '@atlas/web' test` — 158/158 files pass (5 new pins on `isEmptyBackfillOrphan`)
- [x] `bun run test:others` — all 27 sibling packages green
- [x] `bun run lint` + `bun run type` clean
- [x] `bash scripts/check-schema-drift.sh` — 69 tables verified (0072 is data-only, no schema change)
- [x] `bash scripts/check-template-drift.sh` + `bash scripts/check-railway-watch.sh` clean
- [x] `bun x syncpack lint` — no issues
- [x] Migration body validated end-to-end against real Postgres (manual canary in a scratch schema): only `g_us-prod`-shaped orphan deleted; renamed singleton, live multi-member group, user-created `g_<random>` group, and a group with an active scheduled-task reference all preserved
- [x] Per-migration smoke tests added in `migrate-pg.test.ts`: 0072 sweep + idempotency (real Postgres required, runs in CI api-tests job)
- [ ] **Pending in prod after merge:** verify orphan `us-prod` is gone from `/admin/connections?groupBy=environment` and from the Add Connection env combobox