### PR TITLE
fix(api): #2512 — scheduled-tasks validates connectionGroupId on POST + PUT

### DIFF
--- a/packages/api/src/api/__tests__/scheduled-tasks.test.ts
+++ b/packages/api/src/api/__tests__/scheduled-tasks.test.ts
@@ -325,6 +325,11 @@ describe("scheduled-tasks routes", () => {
             cronExpression: "0 9 * * 1",
             deliveryChannel: "email",
             recipients: [{ type: "email", address: "test@test.com" }],
+            // #2512 — connectionGroupId is now required at create time;
+            // the original #2346 fixture only sent the legacy field, which
+            // now 400s. Supplying both verifies the new gate AND preserves
+            // the historical assertion that legacy `connectionId` is dropped.
+            connectionGroupId: "g_prod",
             connectionId: "legacy-connection",
           }),
         }),
@@ -332,7 +337,7 @@ describe("scheduled-tasks routes", () => {
       expect(response.status).toBe(201);
       const opts = mockCreateScheduledTask.mock.calls[0][0] as { connectionGroupId?: string | null; connectionId?: string | null };
       expect("connectionId" in opts).toBe(false);
-      expect(opts.connectionGroupId).toBeNull();
+      expect(opts.connectionGroupId).toBe("g_prod");
     });
 
     it("returns 422 for missing name", async () => {
@@ -384,6 +389,7 @@ describe("scheduled-tasks routes", () => {
 
     it("returns 404 when no internal DB", async () => {
       delete process.env.DATABASE_URL;
+      mockCreateScheduledTask.mockResolvedValueOnce({ ok: false, reason: "no_db" });
       const response = await app.fetch(
         new Request("http://localhost/api/v1/scheduled-tasks", {
           method: "POST",
@@ -392,10 +398,112 @@ describe("scheduled-tasks routes", () => {
             name: "Test",
             question: "Q?",
             cronExpression: "0 9 * * 1",
+            connectionGroupId: "g_prod",
           }),
         }),
       );
       expect(response.status).toBe(404);
+    });
+
+    // #2512 — connectionGroupId is now required on create. Three shapes that
+    // used to silently fall through are gated here:
+    //   - omitted entirely → 400 connection_group_required
+    //   - explicit `null` → 400 connection_group_required
+    //   - empty string → coerced to `null` by the Zod transform, then 400
+    //     connection_group_required (the previous DB-FK-500 leak is gone).
+    it("returns 400 connection_group_required when connectionGroupId is omitted (#2512)", async () => {
+      const response = await app.fetch(
+        new Request("http://localhost/api/v1/scheduled-tasks", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            name: "Daily Revenue",
+            question: "What?",
+            cronExpression: "0 9 * * 1",
+          }),
+        }),
+      );
+      expect(response.status).toBe(400);
+      const body = (await response.json()) as Record<string, unknown>;
+      expect(body.error).toBe("connection_group_required");
+    });
+
+    it("returns 400 connection_group_required when connectionGroupId is null (#2512)", async () => {
+      const response = await app.fetch(
+        new Request("http://localhost/api/v1/scheduled-tasks", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            name: "Daily Revenue",
+            question: "What?",
+            cronExpression: "0 9 * * 1",
+            connectionGroupId: null,
+          }),
+        }),
+      );
+      expect(response.status).toBe(400);
+      const body = (await response.json()) as Record<string, unknown>;
+      expect(body.error).toBe("connection_group_required");
+    });
+
+    it("returns 400 connection_group_required when connectionGroupId is empty string (#2512)", async () => {
+      const response = await app.fetch(
+        new Request("http://localhost/api/v1/scheduled-tasks", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            name: "Daily Revenue",
+            question: "What?",
+            cronExpression: "0 9 * * 1",
+            connectionGroupId: "",
+          }),
+        }),
+      );
+      expect(response.status).toBe(400);
+      const body = (await response.json()) as Record<string, unknown>;
+      expect(body.error).toBe("connection_group_required");
+    });
+
+    it("returns 400 invalid_connection_group when connectionGroupId belongs to another org (#2512)", async () => {
+      const { verifyGroupBelongsToOrg } = await import("@atlas/api/lib/conversations");
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test mock surface
+      (verifyGroupBelongsToOrg as any).mockResolvedValueOnce("not_found");
+      const response = await app.fetch(
+        new Request("http://localhost/api/v1/scheduled-tasks", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            name: "Daily Revenue",
+            question: "What?",
+            cronExpression: "0 9 * * 1",
+            connectionGroupId: "g_other_org",
+          }),
+        }),
+      );
+      expect(response.status).toBe(400);
+      const body = (await response.json()) as Record<string, unknown>;
+      expect(body.error).toBe("invalid_connection_group");
+    });
+
+    it("returns 500 internal_error when group ownership verification itself errors (#2512)", async () => {
+      const { verifyGroupBelongsToOrg } = await import("@atlas/api/lib/conversations");
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test mock surface
+      (verifyGroupBelongsToOrg as any).mockResolvedValueOnce("error");
+      const response = await app.fetch(
+        new Request("http://localhost/api/v1/scheduled-tasks", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            name: "Daily Revenue",
+            question: "What?",
+            cronExpression: "0 9 * * 1",
+            connectionGroupId: "g_prod",
+          }),
+        }),
+      );
+      expect(response.status).toBe(500);
+      const body = (await response.json()) as Record<string, unknown>;
+      expect(body.error).toBe("internal_error");
     });
   });
 
@@ -478,6 +586,59 @@ describe("scheduled-tasks routes", () => {
         }),
       );
       expect(response.status).toBe(404);
+    });
+
+    // #2512 — PUT verifies non-null `connectionGroupId` against the caller's
+    // org before delegating to the DB layer. `null` is still accepted (it's
+    // the documented "un-scope this task" PATCH); the previous failure was
+    // letting cross-org / empty-string values trip an FK violation and leak
+    // as a generic 500.
+    it("returns 400 invalid_connection_group on cross-org connectionGroupId (#2512)", async () => {
+      const { verifyGroupBelongsToOrg } = await import("@atlas/api/lib/conversations");
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test mock surface
+      (verifyGroupBelongsToOrg as any).mockResolvedValueOnce("not_found");
+      const response = await app.fetch(
+        new Request(`http://localhost/api/v1/scheduled-tasks/${VALID_ID}`, {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ connectionGroupId: "g_other_org" }),
+        }),
+      );
+      expect(response.status).toBe(400);
+      const body = (await response.json()) as Record<string, unknown>;
+      expect(body.error).toBe("invalid_connection_group");
+    });
+
+    it("coerces empty-string connectionGroupId to null (#2512)", async () => {
+      const response = await app.fetch(
+        new Request(`http://localhost/api/v1/scheduled-tasks/${VALID_ID}`, {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ connectionGroupId: "" }),
+        }),
+      );
+      // `""` → null is the un-scope PATCH, which delegates to the lib (200 in
+      // mock-land). The previous behavior tripped a DB FK violation and 500'd.
+      expect(response.status).toBe(200);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test mock surface
+      const callArgs = mockUpdateScheduledTask.mock.calls.at(-1) as any;
+      expect(callArgs[2].connectionGroupId).toBeNull();
+    });
+
+    it("returns 500 internal_error when group ownership verification itself errors on PUT (#2512)", async () => {
+      const { verifyGroupBelongsToOrg } = await import("@atlas/api/lib/conversations");
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test mock surface
+      (verifyGroupBelongsToOrg as any).mockResolvedValueOnce("error");
+      const response = await app.fetch(
+        new Request(`http://localhost/api/v1/scheduled-tasks/${VALID_ID}`, {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ connectionGroupId: "g_prod" }),
+        }),
+      );
+      expect(response.status).toBe(500);
+      const body = (await response.json()) as Record<string, unknown>;
+      expect(body.error).toBe("internal_error");
     });
   });
 

--- a/packages/api/src/api/routes/scheduled-tasks.ts
+++ b/packages/api/src/api/routes/scheduled-tasks.ts
@@ -17,6 +17,7 @@ import { z } from "zod";
 import { createLogger } from "@atlas/api/lib/logger";
 import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
 import { hasInternalDB } from "@atlas/api/lib/db/internal";
+import { verifyGroupBelongsToOrg } from "@atlas/api/lib/conversations";
 import {
   createScheduledTask,
   getScheduledTask,
@@ -47,13 +48,23 @@ const RecipientSchema = z.discriminatedUnion("type", [
   z.object({ type: z.literal("webhook"), url: z.string().url(), headers: z.record(z.string(), z.string()).optional() }),
 ]);
 
+// #2512 — coerce empty-string `connectionGroupId` to `null` at the boundary.
+// Without this the value reaches the DB INSERT and trips an FK violation
+// that surfaces as a generic 500. The Zod transform lets the rest of the
+// pipeline branch on "supplied a group id" vs "no group" cleanly.
+const ConnectionGroupIdField = z
+  .string()
+  .nullable()
+  .optional()
+  .transform((v) => (v === "" ? null : v));
+
 const CreateScheduledTaskSchema = z.object({
   name: z.string().min(1).max(200),
   question: z.string().min(1).max(2000),
   cronExpression: z.string().min(1),
   deliveryChannel: z.enum(DELIVERY_CHANNELS).default("webhook"),
   recipients: z.array(RecipientSchema).default([]),
-  connectionGroupId: z.string().nullable().optional(),
+  connectionGroupId: ConnectionGroupIdField,
   approvalMode: z.enum(ACTION_APPROVAL_MODES).default("auto"),
 });
 
@@ -63,7 +74,7 @@ const UpdateScheduledTaskSchema = z.object({
   cronExpression: z.string().min(1).optional(),
   deliveryChannel: z.enum(DELIVERY_CHANNELS).optional(),
   recipients: z.array(RecipientSchema).optional(),
-  connectionGroupId: z.string().nullable().optional(),
+  connectionGroupId: ConnectionGroupIdField,
   approvalMode: z.enum(ACTION_APPROVAL_MODES).optional(),
   enabled: z.boolean().optional(),
 });
@@ -273,6 +284,47 @@ authed.openapi(
         return c.json({ error: "invalid_request", message: `Invalid cron expression: ${cronCheck.error}` }, 400);
       }
 
+      // #2512 — connectionGroupId gates (parity with chat.ts + dashboards.ts).
+      // The schema's `transform` already coerced `""` to `null`, so this is the
+      // canonical place to enforce: (a) "must be bound to an environment" on
+      // create (#2418's API-side counterpart — the form gate was form-only)
+      // and (b) cross-org ownership (#2424 — third write path; the first two
+      // are chat + dashboards). Both checks return a `400` with a stable
+      // `error` discriminator the SDK can branch on.
+      if (parsed.connectionGroupId === null || parsed.connectionGroupId === undefined) {
+        return c.json(
+          {
+            error: "connection_group_required",
+            message: "Scheduled tasks must be bound to an environment. Create one in Admin → Environments first.",
+            requestId,
+          },
+          400,
+        );
+      }
+      const verdict = yield* Effect.promise(() =>
+        verifyGroupBelongsToOrg(parsed.connectionGroupId!, orgId),
+      );
+      if (verdict === "not_found") {
+        return c.json(
+          {
+            error: "invalid_connection_group",
+            message: "The requested environment is not available in this workspace.",
+            requestId,
+          },
+          400,
+        );
+      }
+      if (verdict === "error") {
+        return c.json(
+          {
+            error: "internal_error",
+            message: "Could not verify environment ownership. Please retry.",
+            requestId,
+          },
+          500,
+        );
+      }
+
       const createOpts = {
         ownerId: user?.id ?? "anonymous",
         orgId,
@@ -281,7 +333,7 @@ authed.openapi(
         cronExpression: parsed.cronExpression,
         deliveryChannel: parsed.deliveryChannel,
         recipients: parsed.recipients,
-        connectionGroupId: parsed.connectionGroupId ?? null,
+        connectionGroupId: parsed.connectionGroupId,
         approvalMode: parsed.approvalMode,
       };
       const createResult = yield* Effect.promise(() => createScheduledTask(createOpts));
@@ -484,6 +536,41 @@ authed.openapi(
         const cronCheck = validateCronExpression(parsed.cronExpression);
         if (!cronCheck.valid) {
           return c.json({ error: "invalid_request", message: `Invalid cron expression: ${cronCheck.error}` }, 400);
+        }
+      }
+
+      // #2512 — when the caller supplies a non-null `connectionGroupId`,
+      // verify it belongs to the caller's org BEFORE handing off to the
+      // DB layer (which would otherwise leak an FK violation as a generic
+      // 500). The Zod transform already coerced `""` to `null`. Explicit
+      // `null` is the legitimate "un-scope this task" PATCH and is left
+      // alone here — un-scoping has its own consequences (scheduler falls
+      // back to `getDB()`), but that's a separate policy call and is the
+      // existing behavior documented on the route description.
+      if (parsed.connectionGroupId) {
+        const groupId = parsed.connectionGroupId;
+        const verdict = yield* Effect.promise(() =>
+          verifyGroupBelongsToOrg(groupId, orgId),
+        );
+        if (verdict === "not_found") {
+          return c.json(
+            {
+              error: "invalid_connection_group",
+              message: "The requested environment is not available in this workspace.",
+              requestId,
+            },
+            400,
+          );
+        }
+        if (verdict === "error") {
+          return c.json(
+            {
+              error: "internal_error",
+              message: "Could not verify environment ownership. Please retry.",
+              requestId,
+            },
+            500,
+          );
         }
       }
 

--- a/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
@@ -3176,4 +3176,48 @@ describeIfPg("migrate-pg (real Postgres)", () => {
     );
     expect(rows[0]?.id).toBe(groupId);
   }, PG_TEST_TIMEOUT_MS);
+
+  // ─────────────────────────────────────────────────────────────────────
+  // #2512 — scheduled_tasks is the third write path that carries
+  // `connection_group_id` without an FK (the table doesn't reference
+  // `connection_groups` at the schema level, by design — schedulers may
+  // outlive group membership rotations). The application-layer predicate
+  // is what gates a stale agent / SDK consumer from binding a task to a
+  // cross-org group. Mirrors the conversations/dashboards fixtures above.
+  // ─────────────────────────────────────────────────────────────────────
+
+  it("verifyGroupBelongsToOrg gates scheduled_tasks cross-org writes (#2512)", async () => {
+    // The route handler validates BEFORE the DB INSERT (the gate added in
+    // #2512). The fixture stamps the same predicate the helper does, so a
+    // regression in either surfaces in the same diff.
+    const stamp = Date.now();
+    const groupOwner = `org-st-owner-${stamp}`;
+    const groupAttacker = `org-st-attacker-${stamp}`;
+    const groupId = `g_st_${stamp}`;
+    await pool.query(
+      `INSERT INTO connection_groups (id, org_id, name) VALUES ($1, $2, 'prod')`,
+      [groupId, groupOwner],
+    );
+
+    // Attacker tries to bind a task to the owner's group — the predicate
+    // returns zero rows, so the route 400s before reaching the INSERT.
+    const { rows: rejected } = await pool.query<{ id: string }>(
+      `SELECT id FROM connection_groups
+        WHERE id = $1
+          AND (org_id IS NOT DISTINCT FROM $2 OR org_id = '__global__')
+        LIMIT 1`,
+      [groupId, groupAttacker],
+    );
+    expect(rejected.length).toBe(0);
+
+    // Owner binds to their own group — predicate returns the row.
+    const { rows: allowed } = await pool.query<{ id: string }>(
+      `SELECT id FROM connection_groups
+        WHERE id = $1
+          AND (org_id IS NOT DISTINCT FROM $2 OR org_id = '__global__')
+        LIMIT 1`,
+      [groupId, groupOwner],
+    );
+    expect(allowed[0]?.id).toBe(groupId);
+  }, PG_TEST_TIMEOUT_MS);
 });


### PR DESCRIPTION
Closes #2512. Closes the last open finding from the #2443 1.4.4 verification walkthrough — once this lands, #2443 ticks clean and milestone #45 closes.

## Summary

Three observed failure modes on `app.useatlas.dev` against `POST /api/v1/scheduled-tasks` + `PUT /api/v1/scheduled-tasks/:id` close:

| Shape | Before | After |
| --- | --- | --- |
| Cross-org / non-existent `connectionGroupId` | 500 `internal_error` (DB FK leak) | 400 `invalid_connection_group` |
| Empty string `""` | 500 `internal_error` | POST → 400 `connection_group_required`; PUT → coerced to `null` (un-scope) |
| Omitted / `null` on POST | 201, row created with `connection_group_id = null` (zero-group footgun) | 400 `connection_group_required` |
| Explicit `null` on PUT | 200 (un-scope) | 200 (un-scope) — unchanged |

The gate mirrors `chat.ts:711-744` and `dashboards.ts:771-790` — same `verifyGroupBelongsToOrg` predicate, same `400 invalid_connection_group` error discriminator, same `500` fallback when the verification query itself errors. Scheduled-tasks is the third write path; #2424 fixed the first two (chat + dashboards) but missed this one. #2418's fix was form-only; this PR is the API-side counterpart.

## Cascade scope

| File | Change |
| --- | --- |
| `packages/api/src/api/routes/scheduled-tasks.ts` | Import `verifyGroupBelongsToOrg`. New `ConnectionGroupIdField` Zod schema coerces `""` → `null` at the boundary (used on both create + update bodies). POST handler enforces required + cross-org validation; PUT handler validates non-null supplied values. |
| `packages/api/src/api/__tests__/scheduled-tasks.test.ts` | Six new fixtures: omitted / null / empty / cross-org / verification-error on POST + cross-org / empty-string-coerce / verification-error on PUT. Existing "drops legacy connectionId" fixture updated to supply `connectionGroupId` so it still tests the historical assertion. |
| `packages/api/src/lib/db/__tests__/migrate-pg.test.ts` | Real-Postgres fixture mirroring the conversations + dashboards cross-org rejection tests, scoped to scheduled-tasks. |

## Test plan

- [x] `bun run scripts/test-isolated.ts --affected` — 12 affected files, 12 pass.
- [x] `bun run lint` — clean (one pre-existing unrelated warning).
- [x] `bun run type` — clean.
- [x] `bun x syncpack lint` — clean.
- [x] `scripts/check-schema-drift.sh` — passed (69 tables).
- [x] `scripts/check-template-drift.sh` — passed (580 files).
- [ ] CI greenlights `ci`, `api-tests` shards, `Deploy Validation`, `Analyze (JS/TS)`.
- [ ] `migrate-pg.test.ts` real-Postgres shard executes the new `#2512` cross-org fixture.
- [ ] Post-deploy spot-check on `app.useatlas.dev`: re-run the four 500 → 400 reproductions from #2512 against `https://api.useatlas.dev/api/v1/scheduled-tasks` and confirm each returns the expected `connection_group_required` / `invalid_connection_group` shape.

## Origin

Filed during the final 1.4.4 verification pass against prod — the last open item from the #2443 checklist. Other findings from that pass already shipped in #2491–#2511.