### PR TITLE
test(e2e): #2441 — multi-group Playwright coverage for deferred 1.4.4 paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ plugins/mcp/src/_oauth-helper/
 packages/api/src/lib/db/migrations/meta/
 routeTree.gen.ts
 e2e/browser/storage-state.json
+e2e/browser/multi-env-storage.json
 e2e/browser/test-results/
 # Playwright dumps test-results/ at cwd when run from repo root.
 /test-results/

--- a/e2e/browser/lib/multi-env-helpers.ts
+++ b/e2e/browser/lib/multi-env-helpers.ts
@@ -1,0 +1,231 @@
+/**
+ * Shared scaffolding for the multi-env content-routing specs (#2441 follow-on
+ * to #2443's deferred multi-group checklist items).
+ *
+ * Each spec needs the same three things: an MFA-satisfied admin
+ * `APIRequestContext`, typed accessors for the admin/list endpoints we touch,
+ * and a soft-delete sweep so a failed spec doesn't poison the next run.
+ * Everything here is API-only — the existing `multi-env-tracer.spec.ts` already
+ * carries the canonical UI gate for `/admin/connections`, and that's the only
+ * page where the wire shape and the rendered tree diverge meaningfully.
+ *
+ * Why not `globalSetup`: spec files run in their own workers; sharing setup
+ * across them would force serial execution. The helper instead does a fresh
+ * sign-in per spec (cheap — the seed has already rotated to the known
+ * tracer password) and resolves groups by name.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import type { APIRequestContext, APIResponse, PlaywrightWorkerArgs } from "@playwright/test";
+import { request as playwrightRequest, test } from "@playwright/test";
+import {
+  signInWithPassword,
+  satisfyTotpChallenge,
+  type HttpRequestInit,
+  type HttpReply,
+} from "./admin-auth";
+
+export const API_URL = process.env.ATLAS_API_URL ?? "http://localhost:3001";
+const SECRET_FILE = resolve(process.cwd(), ".atlas", "mfa-secret");
+
+// Mirror the seed's rotated password first.
+const PASSWORDS = [
+  process.env.ATLAS_ADMIN_PASSWORD,
+  "atlas-multi-env-tracer!",
+  "atlas-dev",
+].filter((p): p is string => typeof p === "string" && p.length > 0);
+
+// Draft-content surfaces 404 in published mode (#2412 + 1.4.4 publish model).
+// All admin calls here go through with `x-atlas-mode: developer` for the same
+// reason the tracer spec does — we're exercising content the tests just
+// created, which is unpublished.
+const DEV_MODE_HEADERS = { "x-atlas-mode": "developer" } as const;
+
+function buildShim(request: APIRequestContext) {
+  return async <T = unknown>(path: string, init: HttpRequestInit): Promise<HttpReply<T>> => {
+    const url = `${API_URL}${path}`;
+    const headers = { origin: API_URL, ...(init.headers ?? {}) };
+    let res: APIResponse;
+    if (init.method === "GET") {
+      res = await request.get(url, { headers });
+    } else {
+      res = await request.post(url, {
+        headers: { ...headers, "content-type": "application/json" },
+        data: init.body,
+      });
+    }
+    const text = await res.text();
+    let body: T | null = null;
+    if (text.length > 0) {
+      try {
+        body = JSON.parse(text) as T;
+      } catch {
+        // Non-JSON 5xx error pages aren't actionable — surface status only.
+      }
+    }
+    return { status: res.status(), body, rawText: text };
+  };
+}
+
+/**
+ * Drive Better Auth sign-in + TOTP for `admin@useatlas.dev`. Skips the
+ * caller's test if the seed hasn't been run (no `.atlas/mfa-secret`).
+ *
+ * Each call burns one against Better Auth's sign-in budget (10/60s per
+ * identifier across the deploy), so prefer `createAdminRequestContext` for
+ * spec-level `beforeAll`: it authenticates a brand-new APIRequestContext
+ * once and returns it for reuse across every test in the file.
+ */
+export async function signInMultiEnvAdmin(request: APIRequestContext): Promise<void> {
+  if (!existsSync(SECRET_FILE)) {
+    test.skip(
+      true,
+      `MFA secret not found at ${SECRET_FILE}. Run \`bun scripts/seed-multi-env.ts\` first.`,
+    );
+    return;
+  }
+  const secret = readFileSync(SECRET_FILE, "utf8").trim();
+  const shim = buildShim(request);
+  await signInWithPassword(shim, "admin@useatlas.dev", PASSWORDS);
+  await satisfyTotpChallenge(shim, secret);
+}
+
+/** Storage file written by `multi-env-setup.ts` after the one-time auth. */
+const MULTI_ENV_STORAGE_STATE = resolve(__dirname, "..", "multi-env-storage.json");
+
+/**
+ * Create an admin-authenticated `APIRequestContext` by replaying the
+ * cookie jar that `multi-env-setup.ts` saved on its single sign-in.
+ * Specs call this from `beforeAll`; the returned context survives every
+ * test in the file. Re-using one storage state across all multi-env specs
+ * keeps total Better Auth sign-ins per `playwright test` invocation at 1
+ * — required to stay under the 10/60s budget.
+ *
+ * Falls back to an inline sign-in if the storage state isn't there yet
+ * (lets you run a single spec in isolation without the project dep). The
+ * fallback path still goes through the same rate-limited endpoints, so
+ * it's only safe for ad-hoc one-spec invocations.
+ */
+export async function createAdminRequestContext(
+  playwright: PlaywrightWorkerArgs["playwright"] | typeof playwrightRequest,
+): Promise<APIRequestContext> {
+  const factory: { newContext: typeof playwrightRequest.newContext } =
+    "request" in playwright ? playwright.request : (playwright as typeof playwrightRequest);
+  if (existsSync(MULTI_ENV_STORAGE_STATE)) {
+    return factory.newContext({
+      baseURL: API_URL,
+      storageState: MULTI_ENV_STORAGE_STATE,
+    });
+  }
+  const request = await factory.newContext({ baseURL: API_URL });
+  await signInMultiEnvAdmin(request);
+  return request;
+}
+
+export interface AdminCallOpts {
+  /** Body payload — encoded as JSON. Ignored for GET / DELETE. */
+  body?: unknown;
+  /** Extra query string to append (without leading `?`). */
+  query?: string;
+}
+
+export interface AdminReply<T> {
+  status: number;
+  body: T | null;
+  rawText: string;
+}
+
+async function adminCall<T>(
+  request: APIRequestContext,
+  method: "GET" | "POST" | "PUT" | "PATCH" | "DELETE",
+  path: string,
+  opts: AdminCallOpts = {},
+): Promise<AdminReply<T>> {
+  const url = `${API_URL}${path}${opts.query ? `?${opts.query}` : ""}`;
+  const headers = { origin: API_URL, ...DEV_MODE_HEADERS } as Record<string, string>;
+  let res: APIResponse;
+  if (method === "GET") {
+    res = await request.get(url, { headers });
+  } else if (method === "DELETE") {
+    res = await request.delete(url, { headers });
+  } else {
+    res = await request.fetch(url, {
+      method,
+      headers: { ...headers, "content-type": "application/json" },
+      data: opts.body ?? {},
+    });
+  }
+  const text = await res.text();
+  let body: T | null = null;
+  if (text.length > 0) {
+    try {
+      body = JSON.parse(text) as T;
+    } catch {
+      body = null;
+    }
+  }
+  return { status: res.status(), body, rawText: text };
+}
+
+export const adminGet = <T>(req: APIRequestContext, path: string, opts?: AdminCallOpts) =>
+  adminCall<T>(req, "GET", path, opts);
+export const adminPost = <T>(req: APIRequestContext, path: string, body?: unknown, opts?: AdminCallOpts) =>
+  adminCall<T>(req, "POST", path, { ...opts, body });
+export const adminPut = <T>(req: APIRequestContext, path: string, body?: unknown) =>
+  adminCall<T>(req, "PUT", path, { body });
+export const adminPatch = <T>(req: APIRequestContext, path: string, body?: unknown) =>
+  adminCall<T>(req, "PATCH", path, { body });
+export const adminDelete = <T>(req: APIRequestContext, path: string) =>
+  adminCall<T>(req, "DELETE", path);
+
+// ── Group resolution ────────────────────────────────────────────────
+
+export interface GroupRow {
+  id: string;
+  name: string;
+  status?: string;
+  primaryConnectionId?: string | null;
+  resolvedConnectionId?: string | null;
+}
+interface GroupsResp { groups: GroupRow[] }
+
+/**
+ * Resolve a group id by name. The seed provisions `dev`, `staging`, `prod`;
+ * any other name is treated as a spec-created throwaway and `null` is a
+ * legitimate result (so the caller can decide between create-or-skip).
+ */
+export async function findGroupByName(
+  request: APIRequestContext,
+  name: string,
+): Promise<GroupRow | null> {
+  const r = await adminGet<GroupsResp>(request, "/api/v1/admin/connection-groups", { query: "includeArchived=true" });
+  if (r.status !== 200 || !r.body) return null;
+  return r.body.groups.find((g) => g.name === name) ?? null;
+}
+
+/**
+ * Guard against running on a workspace that hasn't been multi-env-seeded.
+ * Returns the resolved `dev`, `staging`, `prod` rows or skips the test if
+ * any are missing.
+ */
+export async function requireSeededGroups(request: APIRequestContext): Promise<{
+  dev: GroupRow;
+  staging: GroupRow;
+  prod: GroupRow;
+}> {
+  const [dev, staging, prod] = await Promise.all([
+    findGroupByName(request, "dev"),
+    findGroupByName(request, "staging"),
+    findGroupByName(request, "prod"),
+  ]);
+  if (!dev || !staging || !prod) {
+    test.skip(
+      true,
+      `Multi-env seed missing: dev=${!!dev} staging=${!!staging} prod=${!!prod}. ` +
+        `Run \`bun run db:multi-env:up && bun scripts/seed-multi-env.ts\`.`,
+    );
+    throw new Error("unreachable");
+  }
+  return { dev, staging, prod };
+}

--- a/e2e/browser/multi-env-approvals.spec.ts
+++ b/e2e/browser/multi-env-approvals.spec.ts
@@ -1,0 +1,124 @@
+import { test, expect, type APIRequestContext } from "@playwright/test";
+import { Client } from "pg";
+import {
+  adminGet,
+  createAdminRequestContext,
+  requireSeededGroups,
+} from "./lib/multi-env-helpers";
+
+/**
+ * Real-API e2e — approvals per-group bleed (#2344, #2443 deferred item).
+ *
+ * The current GET `/admin/approval/queue` route doesn't take a
+ * `connectionGroupId` query filter — it surfaces every pending request
+ * for the org and the FE filters client-side. What we CAN assert here:
+ *
+ *   - Each row in the queue carries its `connectionGroupId` on the wire
+ *     so a client-side filter has the data it needs (PRD #2336 acceptance).
+ *   - Two pending requests, one per group, both surface with their
+ *     correct `connectionGroupId` (no row collapses or null-coalesces).
+ *
+ * If the route grows a server-side group filter later, this spec is the
+ * right place to extend it. Track that work via the open issue (#2441 if
+ * not separated out) — out of scope for this PR.
+ */
+
+const INTERNAL_DATABASE_URL =
+  process.env.DATABASE_URL ?? "postgresql://atlas:atlas@localhost:5432/atlas";
+const SYNTH_PREFIX = "rt_appr_";
+
+interface QueueResp {
+  requests: Array<{ id: string; ruleName: string; connectionGroupId: string | null; status: string }>;
+}
+
+async function withInternalDb<T>(fn: (c: Client) => Promise<T>): Promise<T> {
+  const client = new Client({ connectionString: INTERNAL_DATABASE_URL, connectionTimeoutMillis: 2000 });
+  try {
+    await client.connect();
+  } catch (err) {
+    test.skip(true, `Internal Postgres not reachable: ${err instanceof Error ? err.message : String(err)}`);
+    throw new Error("unreachable");
+  }
+  try {
+    return await fn(client);
+  } finally {
+    // intentionally ignored: best-effort socket teardown.
+    await client.end().catch(() => {});
+  }
+}
+
+test.describe("multi-env approvals — group pointer round-trips through queue read path", () => {
+  test.use({ baseURL: undefined });
+
+  let request: APIRequestContext;
+
+  test.beforeAll(async ({ playwright }) => {
+    request = await createAdminRequestContext(playwright);
+  });
+
+  test.afterAll(async () => {
+    await request?.dispose();
+  });
+
+  test("two pending requests in different groups both surface with their connectionGroupId", async () => {
+    const { dev, staging } = await requireSeededGroups(request);
+
+    const stamp = Date.now();
+    const ruleNameDev = `${SYNTH_PREFIX}rule_${stamp}_dev`;
+    const ruleNameStaging = `${SYNTH_PREFIX}rule_${stamp}_staging`;
+
+    const orgRow = await withInternalDb(async (c) => {
+      const { rows } = await c.query<{ org_id: string }>(
+        `SELECT org_id FROM connection_groups WHERE id = $1 LIMIT 1`,
+        [dev.id],
+      );
+      return rows[0];
+    });
+    expect(orgRow?.org_id).toBeTruthy();
+    const orgId = orgRow!.org_id;
+
+    const ids = await withInternalDb(async (c) => {
+      // Insert two pending approvals — one per group. ruleId is a
+      // placeholder UUID; the queue read path doesn't dereference it,
+      // it surfaces the stored rule_name verbatim. Migration 0069 dropped
+      // the legacy `connection_id` column — the row keys on
+      // `connection_group_id` only.
+      const { rows } = await c.query<{ id: string }>(
+        `INSERT INTO approval_queue
+           (org_id, rule_id, rule_name, requester_id, requester_email,
+            query_sql, connection_group_id, status)
+         VALUES
+           ($1, gen_random_uuid(), $2, 'test-user', 'rt@example.com',
+            'SELECT 1', $3, 'pending'),
+           ($1, gen_random_uuid(), $4, 'test-user', 'rt@example.com',
+            'SELECT 1', $5, 'pending')
+         RETURNING id`,
+        [orgId, ruleNameDev, dev.id, ruleNameStaging, staging.id],
+      );
+      return rows.map((r) => r.id);
+    });
+
+    try {
+      const queue = await adminGet<QueueResp>(
+        request,
+        "/api/v1/admin/approval/queue",
+        { query: "status=pending" },
+      );
+      expect(queue.status, queue.rawText).toBe(200);
+      const ours = (queue.body?.requests ?? []).filter((r) => ids.includes(r.id));
+      expect(ours.length, "both synthetic rows must surface in the queue").toBe(2);
+
+      const byRule = new Map(ours.map((r) => [r.ruleName, r]));
+      expect(byRule.get(ruleNameDev)?.connectionGroupId, "dev request keeps its group pointer").toBe(dev.id);
+      expect(byRule.get(ruleNameStaging)?.connectionGroupId, "staging request keeps its group pointer").toBe(
+        staging.id,
+      );
+    } finally {
+      if (ids.length > 0) {
+        await withInternalDb(async (c) => {
+          await c.query(`DELETE FROM approval_queue WHERE id = ANY($1::uuid[])`, [ids]);
+        });
+      }
+    }
+  });
+});

--- a/e2e/browser/multi-env-dashboards.spec.ts
+++ b/e2e/browser/multi-env-dashboards.spec.ts
@@ -1,0 +1,175 @@
+import { test, expect, type APIRequestContext } from "@playwright/test";
+import {
+  adminDelete,
+  adminGet,
+  adminPost,
+  createAdminRequestContext,
+  requireSeededGroups,
+} from "./lib/multi-env-helpers";
+
+/**
+ * Real-API e2e — multi-group dashboard card flow (#2443 deferred item).
+ *
+ * Asserts the post-1.4.4 contract that #2443's manual walkthrough couldn't
+ * meaningfully exercise on a single-group env:
+ *
+ *   1. Card add on a multi-group workspace requires `connectionGroupId`;
+ *      the value round-trips to the persisted row.
+ *   2. Cards bound to a group survive that group's archive (PR #2440 made
+ *      this intentional — cards keep their pointer and the group's archived
+ *      state surfaces at view time rather than mass-flipping rows).
+ *   3. The cross-org write gate (#2424) returns the documented
+ *      `invalid_connection_group` discriminator, not a 5xx FK leak.
+ *
+ * Companion to the unit coverage in `dashboards.test.ts`; the value of this
+ * layer is "everything wired together" — auth + admin route + DB + the
+ * archived-state-at-view-time read path are exercised in one sweep.
+ */
+
+const TEST_DASHBOARD_TITLE = "rt-multi-env-dashboards";
+
+interface DashboardRow {
+  id: string;
+  title: string;
+}
+interface ListDashboardsResp { dashboards: DashboardRow[] }
+interface CardRow {
+  id: string;
+  dashboardId: string;
+  title: string;
+  connectionGroupId: string | null;
+}
+
+test.describe("multi-env dashboards — group-scoped cards + archive read-path", () => {
+  test.use({ baseURL: undefined });
+
+  // Sign in once per file (Better Auth's 10/60s sign-in budget would
+  // otherwise rate-limit a per-test auth). Shared `request` carries the
+  // admin's cookies for every test below.
+  let request: APIRequestContext;
+
+  test.beforeAll(async ({ playwright }) => {
+    request = await createAdminRequestContext(playwright);
+  });
+
+  test.afterAll(async () => {
+    await request?.dispose();
+  });
+
+  test.beforeEach(async () => {
+    // Clean any stale rows from a previous run — best-effort, never throws.
+    const list = await adminGet<ListDashboardsResp>(request, "/api/v1/dashboards");
+    for (const d of list.body?.dashboards ?? []) {
+      if (d.title === TEST_DASHBOARD_TITLE) {
+        await adminDelete(request, `/api/v1/dashboards/${d.id}`);
+      }
+    }
+  });
+
+  test("card-create binds to the picked group and the value round-trips (#2419)", async () => {
+    const { prod } = await requireSeededGroups(request);
+
+    const created = await adminPost<DashboardRow>(request, "/api/v1/dashboards", {
+      title: TEST_DASHBOARD_TITLE,
+    });
+    expect(created.status, created.rawText).toBe(201);
+    const dashId = created.body!.id;
+
+    try {
+      const card = await adminPost<CardRow>(request, `/api/v1/dashboards/${dashId}/cards`, {
+        title: "Customers — prod",
+        sql: "SELECT COUNT(*) AS c FROM customers",
+        connectionGroupId: prod.id,
+      });
+      expect(card.status, card.rawText).toBe(201);
+      expect(card.body?.connectionGroupId, "card must persist its group pointer").toBe(prod.id);
+    } finally {
+      await adminDelete(request, `/api/v1/dashboards/${dashId}`);
+    }
+  });
+
+  test("cross-org connectionGroupId rejected with 400 invalid_connection_group (#2424)", async () => {
+    await requireSeededGroups(request);
+
+    const created = await adminPost<DashboardRow>(request, "/api/v1/dashboards", {
+      title: TEST_DASHBOARD_TITLE,
+    });
+    expect(created.status).toBe(201);
+    const dashId = created.body!.id;
+
+    try {
+      const card = await adminPost<{ error: string }>(request, `/api/v1/dashboards/${dashId}/cards`, {
+        title: "spoofed",
+        sql: "SELECT 1",
+        connectionGroupId: "g_does_not_exist_other_org",
+      });
+      expect(card.status, "cross-org pointer must 400 not 500").toBe(400);
+      expect(card.body?.error).toBe("invalid_connection_group");
+    } finally {
+      await adminDelete(request, `/api/v1/dashboards/${dashId}`);
+    }
+  });
+
+  test("archive cascade intentionally preserves card pointer for view-time surfacing (PR #2440)", async () => {
+    // PR #2440 explicitly skipped `dashboard_cards` from the archive cascade
+    // (the read path renders the archived state instead). Assert the
+    // post-archive card row still carries its `connectionGroupId` so the
+    // dashboards view layer has the signal it needs to render the
+    // "environment archived" state. A regression that mass-flipped cards
+    // or null'd their pointer would surface here.
+
+    const throwawayName = `rt-arc-${Date.now()}`;
+    const group = await adminPost<{ id: string; name: string }>(
+      request,
+      "/api/v1/admin/connection-groups",
+      { name: throwawayName },
+    );
+    expect(group.status, group.rawText).toBe(201);
+    const groupId = group.body!.id;
+
+    const created = await adminPost<DashboardRow>(request, "/api/v1/dashboards", {
+      title: TEST_DASHBOARD_TITLE,
+    });
+    expect(created.status).toBe(201);
+    const dashId = created.body!.id;
+
+    let cardId: string | null = null;
+    try {
+      const card = await adminPost<CardRow>(request, `/api/v1/dashboards/${dashId}/cards`, {
+        title: "card-bound-to-archived",
+        sql: "SELECT 1",
+        connectionGroupId: groupId,
+      });
+      expect(card.status, card.rawText).toBe(201);
+      cardId = card.body!.id;
+      expect(card.body?.connectionGroupId).toBe(groupId);
+
+      // Archive the group — the cascade body documents the intentional skip
+      // for dashboard_cards. We assert the API call succeeds AND the card
+      // row still carries the pointer afterwards.
+      const archived = await adminPost<{ archivedCounts?: Record<string, number> }>(
+        request,
+        `/api/v1/admin/connection-groups/${groupId}/archive`,
+        {},
+      );
+      expect(archived.status, archived.rawText).toBe(200);
+
+      const refetched = await adminGet<DashboardRow & { cards: CardRow[] }>(
+        request,
+        `/api/v1/dashboards/${dashId}`,
+      );
+      expect(refetched.status).toBe(200);
+      const cards = refetched.body?.cards ?? [];
+      const ours = cards.find((c) => c.id === cardId);
+      expect(ours, "card must still exist post-archive (PR #2440 contract)").toBeDefined();
+      expect(ours?.connectionGroupId, "pointer preserved so view-layer can surface 'archived'")
+        .toBe(groupId);
+    } finally {
+      if (cardId) {
+        await adminDelete(request, `/api/v1/dashboards/${dashId}/cards/${cardId}`);
+      }
+      await adminDelete(request, `/api/v1/dashboards/${dashId}`);
+      await adminDelete(request, `/api/v1/admin/connection-groups/${groupId}`);
+    }
+  });
+});

--- a/e2e/browser/multi-env-pii-bleed.spec.ts
+++ b/e2e/browser/multi-env-pii-bleed.spec.ts
@@ -1,0 +1,135 @@
+import { test, expect, type APIRequestContext } from "@playwright/test";
+import { Client } from "pg";
+import {
+  adminGet,
+  createAdminRequestContext,
+  requireSeededGroups,
+} from "./lib/multi-env-helpers";
+
+/**
+ * Real-API e2e — PII per-group bleed (#2341, #2443 deferred item).
+ *
+ * The masking layer has no public POST route — classifications come from
+ * the auto-detection pipeline. To exercise the per-group filter on the
+ * read path (`?connectionGroupId=<group>`) we INSERT two rows directly
+ * into `pii_column_classifications`, one bound to `dev` and one to
+ * `staging`, then assert each filter returns exactly its row. The
+ * cross-tenant FK story is covered by the migrate-pg smoke; this layer
+ * proves the route honors the filter end-to-end so the admin UI can rely
+ * on it.
+ */
+
+const INTERNAL_DATABASE_URL =
+  process.env.DATABASE_URL ?? "postgresql://atlas:atlas@localhost:5432/atlas";
+const SYNTH_PREFIX = "rt_pii_";
+
+interface ClassificationRow {
+  id: string;
+  tableName: string;
+  columnName: string;
+  connectionGroupId: string | null;
+}
+interface ClassificationsResp { classifications: ClassificationRow[] }
+
+async function withInternalDb<T>(fn: (c: Client) => Promise<T>): Promise<T> {
+  const client = new Client({ connectionString: INTERNAL_DATABASE_URL, connectionTimeoutMillis: 2000 });
+  try {
+    await client.connect();
+  } catch (err) {
+    test.skip(
+      true,
+      `Internal Postgres not reachable at ${INTERNAL_DATABASE_URL} (${err instanceof Error ? err.message : String(err)}). ` +
+        `Run \`bun run db:up\` and retry.`,
+    );
+    throw new Error("unreachable");
+  }
+  try {
+    return await fn(client);
+  } finally {
+    // intentionally ignored: best-effort teardown; the test result is
+    // already decided by this point.
+    await client.end().catch(() => {});
+  }
+}
+
+test.describe("multi-env PII — per-group filter does not bleed across groups", () => {
+  test.use({ baseURL: undefined });
+
+  let request: APIRequestContext;
+
+  test.beforeAll(async ({ playwright }) => {
+    request = await createAdminRequestContext(playwright);
+  });
+
+  test.afterAll(async () => {
+    await request?.dispose();
+  });
+
+  test("classifications filtered by connectionGroupId surface exactly the matching scope", async () => {
+    const { dev, staging } = await requireSeededGroups(request);
+
+    // Resolve the org of the signed-in admin so the synthetic rows are
+    // visible to the same caller. The connection-groups list already
+    // surfaces only the caller's-org rows, so any seeded group id we
+    // hand to the INSERT is by definition this admin's.
+    const stamp = Date.now();
+    const tableDev = `${SYNTH_PREFIX}t_${stamp}_dev`;
+    const tableStaging = `${SYNTH_PREFIX}t_${stamp}_staging`;
+
+    // Grab the org id off the group row — `connection_groups` carries it,
+    // and we've already resolved both target groups in this org.
+    const orgRow = await withInternalDb(async (c) => {
+      const { rows } = await c.query<{ org_id: string }>(
+        `SELECT org_id FROM connection_groups WHERE id = $1 LIMIT 1`,
+        [dev.id],
+      );
+      return rows[0];
+    });
+    expect(orgRow?.org_id, "couldn't resolve org id off dev group").toBeTruthy();
+    const orgId = orgRow!.org_id;
+
+    await withInternalDb(async (c) => {
+      // Plant one row per group. Migration 0069 dropped the legacy
+      // `connection_id` column — the natural key is now (org_id,
+      // table_name, column_name, COALESCE(connection_group_id,
+      // '__default__')) per 0064's partial unique index.
+      await c.query(
+        `INSERT INTO pii_column_classifications
+           (org_id, table_name, column_name, category, confidence, masking_strategy, connection_group_id)
+         VALUES ($1, $2, 'email', 'email', 'high', 'full', $3),
+                ($1, $4, 'email', 'email', 'high', 'full', $5)`,
+        [orgId, tableDev, dev.id, tableStaging, staging.id],
+      );
+    });
+
+    try {
+      const devOnly = await adminGet<ClassificationsResp>(
+        request,
+        "/api/v1/admin/compliance/classifications",
+        { query: `connectionGroupId=${encodeURIComponent(dev.id)}` },
+      );
+      expect(devOnly.status, devOnly.rawText).toBe(200);
+      const devNames = (devOnly.body?.classifications ?? []).map((c) => c.tableName);
+      expect(devNames, `dev filter returned: ${JSON.stringify(devNames)}`).toContain(tableDev);
+      expect(devNames, "dev filter must NOT surface staging row").not.toContain(tableStaging);
+
+      const stagingOnly = await adminGet<ClassificationsResp>(
+        request,
+        "/api/v1/admin/compliance/classifications",
+        { query: `connectionGroupId=${encodeURIComponent(staging.id)}` },
+      );
+      expect(stagingOnly.status).toBe(200);
+      const stagingNames = (stagingOnly.body?.classifications ?? []).map((c) => c.tableName);
+      expect(stagingNames).toContain(tableStaging);
+      expect(stagingNames, "staging filter must NOT surface dev row").not.toContain(tableDev);
+    } finally {
+      await withInternalDb(async (c) => {
+        await c.query(
+          `DELETE FROM pii_column_classifications
+            WHERE org_id = $1 AND table_name = ANY($2::text[])`,
+          [orgId, [tableDev, tableStaging]],
+        );
+      });
+    }
+  });
+});

--- a/e2e/browser/multi-env-scheduled-runonce.spec.ts
+++ b/e2e/browser/multi-env-scheduled-runonce.spec.ts
@@ -1,0 +1,122 @@
+import { test, expect, type APIRequestContext } from "@playwright/test";
+import {
+  adminDelete,
+  adminGet,
+  adminPost,
+  createAdminRequestContext,
+  requireSeededGroups,
+} from "./lib/multi-env-helpers";
+
+/**
+ * Real-API e2e — scheduled tasks run-once correctness (#2343 + #2418 / #2512
+ * counterpart, #2443 deferred item).
+ *
+ * Creates a task scoped to `prod`, triggers `/run`, and asserts the dispatch
+ * succeeds. We deliberately stop short of waiting for the agent loop to
+ * complete — the LLM call is variable-duration and would flake the suite.
+ * The unit + route layer (`scheduled-tasks.test.ts`, `executor.test.ts`,
+ * `migrate-pg.test.ts`) already cover the resolveScheduledTaskConnection
+ * → primary-member dispatch + result persistence; this layer's value is
+ * "wired together with the post-#2512 validation gate so the dispatch
+ * actually runs against the right group."
+ */
+
+interface CreatedTask {
+  id: string;
+  connectionGroupId: string | null;
+}
+
+interface TaskWithRuns extends CreatedTask {
+  recentRuns: Array<{ id: string; startedAt: string; status: string }>;
+}
+
+test.describe("multi-env scheduled tasks — run-once dispatches against the bound group", () => {
+  test.use({ baseURL: undefined });
+
+  let request: APIRequestContext;
+
+  test.beforeAll(async ({ playwright }) => {
+    request = await createAdminRequestContext(playwright);
+  });
+
+  test.afterAll(async () => {
+    await request?.dispose();
+  });
+
+  test("task scoped to prod accepts /run; group pointer round-trips on the row", async () => {
+    const { prod } = await requireSeededGroups(request);
+
+    const stamp = Date.now();
+    const taskName = `rt_sched_${stamp}`;
+
+    const created = await adminPost<CreatedTask>(request, "/api/v1/scheduled-tasks", {
+      name: taskName,
+      question: "select 1",
+      // Cron is required by the schema; the schedule won't fire during
+      // the test window — we trigger explicitly via /run.
+      cronExpression: "0 9 * * 1",
+      deliveryChannel: "webhook",
+      recipients: [{ type: "webhook", url: "https://example.invalid/rt" }],
+      connectionGroupId: prod.id,
+    });
+    expect(created.status, created.rawText).toBe(201);
+    const taskId = created.body!.id;
+    expect(created.body?.connectionGroupId, "task must persist its group binding").toBe(prod.id);
+
+    try {
+      // Trigger immediate execution. The dispatch path internally resolves
+      // the group's primary member via resolveScheduledTaskConnection.
+      const triggered = await adminPost<{ message: string; taskId: string }>(
+        request,
+        `/api/v1/scheduled-tasks/${taskId}/run`,
+      );
+      expect(triggered.status, triggered.rawText).toBe(200);
+      expect(triggered.body?.taskId).toBe(taskId);
+
+      // GET the task — the engine appends to recentRuns asynchronously.
+      // Poll up to a few seconds, then accept either "run row materialized"
+      // OR "dispatch acknowledged but run not yet flushed" — the second
+      // shape still proves the routing gate passed (a cross-group / bad
+      // group would have surfaced as a 4xx on /run).
+      let runAppeared = false;
+      for (let attempt = 0; attempt < 6 && !runAppeared; attempt++) {
+        const fetched = await adminGet<TaskWithRuns>(request, `/api/v1/scheduled-tasks/${taskId}`);
+        expect(fetched.status).toBe(200);
+        expect(fetched.body?.connectionGroupId).toBe(prod.id);
+        if ((fetched.body?.recentRuns?.length ?? 0) > 0) {
+          runAppeared = true;
+          break;
+        }
+        await new Promise((r) => setTimeout(r, 500));
+      }
+      // Either signal is acceptable — see comment above.
+      if (!runAppeared) {
+        console.warn(
+          `[multi-env-scheduled-runonce] no run row after 3s; dispatch was acknowledged but persistence ` +
+            `hadn't flushed. Group binding verified at create + GET; deeper run-row assertions live in ` +
+            `executor.test.ts.`,
+        );
+      }
+    } finally {
+      await adminDelete(request, `/api/v1/scheduled-tasks/${taskId}`);
+    }
+  });
+
+  test("post-#2512 cross-org connectionGroupId rejected at create time", async () => {
+    // Sanity: the cross-org gate that #2513 shipped must still hold on
+    // a multi-group workspace. Mirrors the unit fixture but proves the
+    // wire contract end-to-end against the running API.
+    await requireSeededGroups(request);
+
+    const created = await adminPost<{ error: string }>(request, "/api/v1/scheduled-tasks", {
+      name: `rt_sched_cross_${Date.now()}`,
+      question: "select 1",
+      cronExpression: "0 9 * * 1",
+      deliveryChannel: "webhook",
+      recipients: [{ type: "webhook", url: "https://example.invalid/rt" }],
+      connectionGroupId: "g_does_not_exist_other_org",
+    });
+    expect(created.status, "cross-org pointer must 400 not 500 (#2512)").toBe(400);
+    expect(created.body?.error).toBe("invalid_connection_group");
+  });
+});

--- a/e2e/browser/multi-env-semantic-ambiguity.spec.ts
+++ b/e2e/browser/multi-env-semantic-ambiguity.spec.ts
@@ -1,0 +1,148 @@
+import { existsSync, unlinkSync } from "node:fs";
+import { resolve } from "node:path";
+import { test, expect, type APIRequestContext } from "@playwright/test";
+import { Client } from "pg";
+import {
+  adminGet,
+  createAdminRequestContext,
+  requireSeededGroups,
+} from "./lib/multi-env-helpers";
+
+const INTERNAL_DATABASE_URL =
+  process.env.DATABASE_URL ?? "postgresql://atlas:atlas@localhost:5432/atlas";
+
+async function withInternalDb<T>(fn: (c: Client) => Promise<T>): Promise<T> {
+  const client = new Client({ connectionString: INTERNAL_DATABASE_URL });
+  await client.connect();
+  try {
+    return await fn(client);
+  } finally {
+    // intentionally ignored: best-effort teardown.
+    await client.end().catch(() => {});
+  }
+}
+
+/**
+ * Real-API e2e — multi-group semantic 409 ambiguity surface (#2412).
+ *
+ * #2443's deferred item: when the same entity name exists at two different
+ * `connection_group_id`s in the same org, a fetch without a `?connectionGroupId`
+ * disambiguator returns 409 with the candidate groups listed. The unit
+ * coverage (`semantic-entities.test.ts`) asserts the lib function; this layer
+ * asserts the route surfaces the error with the documented payload shape
+ * (`error: "entity_ambiguous"`, `groups: [...]`) so the FE has the data it
+ * needs to render the picker.
+ */
+
+// Per-run name so a prior run's synced-to-disk entity (`syncEntityToDisk`
+// in the route handler writes the file alongside the DB row) doesn't
+// shadow this run's DB-only state and force the GET into a single-result
+// disk read. Combined with the cleanup below, this keeps the suite
+// re-runnable without manual DB / FS surgery.
+const ENTITY_NAME = `rt_ambig_users_${Date.now()}`;
+
+interface AmbigResp {
+  error: string;
+  message: string;
+  groups: Array<string | null>;
+  requestId: string;
+}
+interface EntityDetailResp { entity?: unknown }
+
+test.describe("multi-env semantic — 409 ambiguity surface", () => {
+  test.use({ baseURL: undefined });
+
+  let request: APIRequestContext;
+
+  test.beforeAll(async ({ playwright }) => {
+    request = await createAdminRequestContext(playwright);
+  });
+
+  test.afterAll(async () => {
+    await request?.dispose();
+  });
+
+  test("two same-name entities in different groups → GET without scope returns 409 entity_ambiguous", async () => {
+    const { dev, staging } = await requireSeededGroups(request);
+
+    // Plant draft rows directly in `semantic_entities`. The PUT route's
+    // semantics around scope are intentionally read-oriented (#2412: the
+    // body's `connectionGroupId` is the read-scope for the version
+    // snapshot fetch, not the write-scope — which resolves from
+    // `connectionId` via the connections 1:1 map). For an e2e that wants
+    // to assert the 409 surface specifically, planting two rows directly
+    // is the most reliable way to set up the ambiguity precondition.
+    // The route's read-path 409 contract is then exercised by the GET.
+    const orgRow = await withInternalDb(async (c) => {
+      const { rows } = await c.query<{ org_id: string }>(
+        `SELECT org_id FROM connection_groups WHERE id = $1 LIMIT 1`,
+        [dev.id],
+      );
+      return rows[0];
+    });
+    expect(orgRow?.org_id).toBeTruthy();
+    const orgId = orgRow!.org_id;
+
+    const yaml = `table: ${ENTITY_NAME}\ndimensions:\n  - name: id\n    sql: id\n    type: number\n`;
+    try {
+      await withInternalDb(async (c) => {
+        await c.query(
+          `INSERT INTO semantic_entities (org_id, entity_type, name, yaml_content, connection_group_id, status)
+           VALUES ($1, 'entity', $2, $3, $4, 'draft'),
+                  ($1, 'entity', $2, $3, $5, 'draft')
+           ON CONFLICT DO NOTHING`,
+          [orgId, ENTITY_NAME, yaml, dev.id, staging.id],
+        );
+      });
+
+      // Fetch WITHOUT the disambiguator. Backend should 409 with both
+      // candidate groups listed so the FE picker has the data to ask.
+      const ambiguous = await adminGet<AmbigResp>(
+        request,
+        `/api/v1/admin/semantic/entities/${ENTITY_NAME}`,
+      );
+      expect(ambiguous.status, ambiguous.rawText).toBe(409);
+      expect(ambiguous.body?.error).toBe("entity_ambiguous");
+      const surfaced = new Set(ambiguous.body?.groups ?? []);
+      expect(surfaced.has(dev.id), "dev group must appear in candidates").toBe(true);
+      expect(surfaced.has(staging.id), "staging group must appear in candidates").toBe(true);
+
+      // Sanity: scoping the same fetch to one group resolves cleanly.
+      const scoped = await adminGet<EntityDetailResp>(
+        request,
+        `/api/v1/admin/semantic/entities/${ENTITY_NAME}`,
+        { query: `connectionGroupId=${encodeURIComponent(dev.id)}` },
+      );
+      expect(scoped.status, "scoped fetch must resolve").toBe(200);
+    } finally {
+      // Direct sweep — the route's DELETE is scope-aware and would itself
+      // 409 on the ambiguous state we just plant. Also unlink the disk
+      // file the PUT route would normally maintain; this spec bypasses
+      // that route, but a leftover from a prior attempt would silently
+      // shadow the DB state on the next run.
+      await withInternalDb(async (c) => {
+        await c.query(
+          `DELETE FROM semantic_entities
+            WHERE org_id = $1 AND entity_type = 'entity' AND name = $2`,
+          [orgId, ENTITY_NAME],
+        );
+      });
+      const diskPath = resolve(
+        process.cwd(),
+        "semantic",
+        ".orgs",
+        orgId,
+        "entities",
+        `${ENTITY_NAME}.yml`,
+      );
+      if (existsSync(diskPath)) {
+        try {
+          unlinkSync(diskPath);
+        } catch {
+          // intentionally ignored: a missing-on-disk after our test
+          // wouldn't shadow the next run, so cleanup is best-effort.
+        }
+      }
+    }
+  });
+});

--- a/e2e/browser/multi-env-setup.ts
+++ b/e2e/browser/multi-env-setup.ts
@@ -1,0 +1,37 @@
+import { test as setup, request as playwrightRequest } from "@playwright/test";
+import path from "path";
+import { API_URL, signInMultiEnvAdmin } from "./lib/multi-env-helpers";
+
+/**
+ * Setup project for the multi-env content-routing specs (#2441 follow-on).
+ *
+ * Each spec in the `multi-env` project would otherwise authenticate on its
+ * own — six sign-ins + 18 TOTP attempts per `playwright test` invocation,
+ * which busts Better Auth's per-identifier rate limit (10 sign-ins / 60s
+ * AND 10 2FA verifies / 60s — surfaces as `429 Too many requests`). This
+ * setup authenticates once, persists the cookie jar to a dedicated storage
+ * state file, and every spec loads it via `test.use({ storageState })`.
+ *
+ * Why a project-scoped setup (not `globalSetup`):
+ *   - `globalSetup` is a single function that runs before all projects and
+ *     doesn't have access to Playwright fixtures the same way a setup spec
+ *     does. The project-dep setup pattern is what the chromium project
+ *     already uses for its own admin sign-in.
+ *   - Keeping setup as a spec keeps its skip / error reporting consistent
+ *     with the rest of the suite (you see the auth failure in the same
+ *     reporter, not as a swallowed `globalSetup` exception).
+ */
+
+const STORAGE_STATE = path.join(__dirname, "multi-env-storage.json");
+
+export { STORAGE_STATE };
+
+setup("authenticate multi-env admin", async () => {
+  const request = await playwrightRequest.newContext({ baseURL: API_URL });
+  try {
+    await signInMultiEnvAdmin(request);
+    await request.storageState({ path: STORAGE_STATE });
+  } finally {
+    await request.dispose();
+  }
+});

--- a/e2e/browser/playwright.config.ts
+++ b/e2e/browser/playwright.config.ts
@@ -26,7 +26,12 @@ export default defineConfig({
       name: "setup",
       testMatch: /global-setup\.ts/,
     },
-    // Local tests (require dev server on :3000/:3001)
+    // Local tests (require dev server on :3000/:3001). Multi-env content-
+    // routing specs (`multi-env-tracer` + the five group-scoped specs added
+    // for #2441) are excluded — they each do their own MFA-aware sign-in
+    // and run via the `multi-env` project below. The route-mock UI
+    // integration spec (`multi-env-admin.integration.spec.ts`) DOES belong
+    // here — it relies on the chromium project's storage state.
     {
       name: "chromium",
       use: {
@@ -34,16 +39,36 @@ export default defineConfig({
         storageState: STORAGE_STATE,
       },
       dependencies: ["setup"],
-      testIgnore: [/production\.spec\.ts/, /multi-env-tracer\.spec\.ts/],
+      testIgnore: [
+        /production\.spec\.ts/,
+        /multi-env-tracer\.spec\.ts/,
+        /multi-env-dashboards\.spec\.ts/,
+        /multi-env-semantic-ambiguity\.spec\.ts/,
+        /multi-env-pii-bleed\.spec\.ts/,
+        /multi-env-approvals\.spec\.ts/,
+        /multi-env-scheduled-runonce\.spec\.ts/,
+      ],
     },
-    // Multi-env tracer — does its own sign-in (incl. MFA via .atlas/mfa-secret)
-    // so it doesn't depend on the storage-state shared by `chromium`. Lets the
-    // tracer run standalone after `bun run db:multi-env:up` + `seed-multi-env`
-    // without requiring the web dev server to be up for global-setup to pass.
+    // Setup for the multi-env project — one-time MFA-aware sign-in that
+    // persists cookies to `multi-env-storage.json`. Avoids burning Better
+    // Auth's sign-in + 2FA verify rate limits per spec.
+    {
+      name: "multi-env-setup",
+      testMatch: /multi-env-setup\.ts/,
+    },
+    // Multi-env content-routing specs — real API + real Postgres. Each spec
+    // loads the shared storage state from `multi-env-setup` so total
+    // sign-ins per `playwright test` invocation = 1. Specs that touch
+    // internal-DB rows (PII, approvals) additionally connect to
+    // `DATABASE_URL` directly via `pg.Client`. The original tracer spec
+    // (`multi-env-tracer.spec.ts`) keeps its own in-test sign-in flow
+    // because it deliberately validates the auth contract end-to-end.
     {
       name: "multi-env",
       use: { ...devices["Desktop Chrome"] },
-      testMatch: /multi-env-tracer\.spec\.ts/,
+      testMatch: /multi-env-(tracer|dashboards|semantic-ambiguity|pii-bleed|approvals|scheduled-runonce)\.spec\.ts/,
+      dependencies: ["multi-env-setup"],
+      workers: 1,
     },
     // Production smoke tests (no auth, uses absolute URLs from env vars)
     {


### PR DESCRIPTION
Closes #2441. The integration-layer counterpart to the route-level unit coverage that landed across the 1.4.4 verification batch (#2491–#2511, #2513). Exercises the multi-group content-routing paths #2443's manual walkthrough couldn't reach on a single-group env.

## Summary

Five new specs + shared scaffolding under `e2e/browser/`, all running in the `multi-env` project alongside the existing `multi-env-tracer.spec.ts`. Each spec does real-API + real-Postgres (no `page.route` mocks):

| Spec | What it asserts |
| --- | --- |
| `multi-env-dashboards.spec.ts` | Card create + group binding round-trip · cross-org `connectionGroupId` → `400 invalid_connection_group` (#2424) · archive cascade preserves card pointer for view-time surfacing (PR #2440 contract) |
| `multi-env-semantic-ambiguity.spec.ts` | Two same-name entities at different group scopes → GET without disambiguator → `409 entity_ambiguous` with both groups listed (#2412) |
| `multi-env-pii-bleed.spec.ts` | `?connectionGroupId=` filter on `/admin/compliance/classifications` returns exactly the scope's rows; no group bleed (#2341) |
| `multi-env-approvals.spec.ts` | Queue rows carry `connectionGroupId` on the wire; two rows in different groups both surface (#2344) |
| `multi-env-scheduled-runonce.spec.ts` | Task scoped to prod accepts `/run` dispatch + group pointer round-trips · cross-org create rejected with the post-#2512 `invalid_connection_group` shape |

## Shared infra

| File | Role |
| --- | --- |
| `e2e/browser/lib/multi-env-helpers.ts` | Typed admin API client (`adminGet`/`adminPost`/`adminPut`/`adminDelete`), dev-mode header wiring, `findGroupByName` / `requireSeededGroups`, and `createAdminRequestContext` which replays the storage state to keep auth count at 1 per `playwright test` invocation. |
| `e2e/browser/multi-env-setup.ts` + `multi-env-setup` project | One-time MFA-aware sign-in; persists cookies to `multi-env-storage.json` (gitignored). The `multi-env` project depends on it and runs `workers: 1`. |

## Why one auth per run

Better Auth's per-identifier rate limits (10 sign-ins / 60s AND 10 2FA verifies / 60s) make per-spec auth flaky once you add more than a couple of multi-env specs. The setup project + shared storage state pattern brings total auths to 1 regardless of how many multi-env specs we add later.

## Direct-DB writes

PII, approvals, and the semantic-ambiguity precondition need rows inserted that the public route layer doesn't expose (no PII POST; ambiguity needs two same-name rows at different scopes; approvals come from the agent loop, not user CRUD). Those specs connect to `DATABASE_URL` via `pg.Client` and clean up in `finally`. The ambiguity spec also unlinks the disk file the PUT route would normally maintain — a leftover from a prior run would silently shadow the DB state on the next run.

## Why each spec uses `test.use({ baseURL: undefined })`

The chromium project's `baseURL = http://localhost:3000` is the web app; our specs talk to `http://localhost:3001` via `page.request` using the API_URL constant. Disabling the default baseURL keeps the multi-env project independent of whether the web dev server is up.

## Test plan

- [x] `bun run lint` — clean (one pre-existing unrelated warning).
- [x] `bun run type` — clean.
- [x] `bun run db:up && bun run db:multi-env:up && bun scripts/seed-multi-env.ts`.
- [x] `ATLAS_DEPLOY_MODE=self-hosted ATLAS_SCHEDULER_ENABLED=true bun run dev:api` running on :3001.
- [x] `bun x playwright test --config=e2e/browser/playwright.config.ts --project=multi-env` — **11/11 pass** in ~18s.
- [ ] CI greenlights `ci`, `api-tests` shards, `Deploy Validation`, `Analyze (JS/TS)`. Note: the multi-env project runs locally only (it needs the multi-env Docker overlay + seed); CI doesn't spin those up. The existing tracer spec follows the same pattern — these specs share its skip-if-not-reachable shape.

## Out of scope

- Adding a CI workflow that brings up the multi-env Docker overlay and runs these specs — separate piece of infra work, not required for the e2e coverage gap #2441 tracks.
- Server-side `connectionGroupId` filter on `/admin/approval/queue` — the approvals spec asserts row-level scoping which is what the current contract guarantees. If a route-level filter ships later, this spec is the right place to extend.

## Origin

Filed during the 1.4.4 closeout pass after the manual walkthrough (#2443) flagged six deferred items that required ≥2 groups. PR #2513 closed the last route-level bug; this PR closes the remaining e2e coverage gap (#2441).