### PR TITLE
feat(chat): #2292 — proactive reaction-first tracer

### DIFF
--- a/plugins/chat/src/bridge.test.ts
+++ b/plugins/chat/src/bridge.test.ts
@@ -3232,6 +3232,85 @@ describe("ephemeral error delivery", () => {
 });
 
 // ---------------------------------------------------------------------------
+// ProactiveConfig schema validation
+// ---------------------------------------------------------------------------
+
+describe("ProactiveConfig schema", () => {
+  it("accepts a fully-specified proactive config", async () => {
+    const { ChatConfigSchema } = await import("./config");
+
+    const result = ChatConfigSchema.safeParse({
+      adapters: {
+        slack: { botToken: "xoxb-test", signingSecret: "test-secret" },
+      },
+      executeQuery: () =>
+        Promise.resolve({ answer: "", sql: [], data: [], steps: 0, usage: { totalTokens: 0 } }),
+      proactive: {
+        isEnabled: () => true,
+        classify: async () => ({ isQuestion: true, confidence: 0.9 }),
+        workspace: {
+          enabled: true,
+          sensitivity: "balanced",
+          classifierMode: "regex-prefilter",
+        },
+        channelAllowlist: ["C-allowed"],
+        channelConfigs: {
+          "C-allowed": { channelId: "C-allowed", allow: true },
+        },
+      },
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects when proactive.isEnabled is not a function", async () => {
+    const { ChatConfigSchema } = await import("./config");
+
+    const result = ChatConfigSchema.safeParse({
+      adapters: {
+        slack: { botToken: "xoxb-test", signingSecret: "test-secret" },
+      },
+      executeQuery: () =>
+        Promise.resolve({ answer: "", sql: [], data: [], steps: 0, usage: { totalTokens: 0 } }),
+      proactive: {
+        isEnabled: "not-a-function",
+        classify: async () => ({ isQuestion: false, confidence: 0 }),
+        workspace: {
+          enabled: true,
+          sensitivity: "balanced",
+          classifierMode: "regex-prefilter",
+        },
+      },
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects invalid sensitivity preset", async () => {
+    const { ChatConfigSchema } = await import("./config");
+
+    const result = ChatConfigSchema.safeParse({
+      adapters: {
+        slack: { botToken: "xoxb-test", signingSecret: "test-secret" },
+      },
+      executeQuery: () =>
+        Promise.resolve({ answer: "", sql: [], data: [], steps: 0, usage: { totalTokens: 0 } }),
+      proactive: {
+        isEnabled: () => true,
+        classify: async () => ({ isQuestion: false, confidence: 0 }),
+        workspace: {
+          enabled: true,
+          sensitivity: "extreme",
+          classifierMode: "regex-prefilter",
+        },
+      },
+    });
+
+    expect(result.success).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Proactive DM API (sendDirectMessage)
 // ---------------------------------------------------------------------------
 

--- a/plugins/chat/src/bridge.ts
+++ b/plugins/chat/src/bridge.ts
@@ -46,6 +46,7 @@ import {
 } from "./features/file-upload";
 import { createReactionLifecycle } from "./features/reactions";
 import type { IReactionLifecycle } from "./features/reactions";
+import { registerProactiveListener } from "./proactive/listener";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -1502,6 +1503,30 @@ export function createChatBridge(
       "Clarification modal dismissed",
     );
   });
+
+  // --- Proactive listener (slice #2292) ---
+  // Only registers when proactive config is present AND the host-supplied
+  // gate (`isEnterpriseEnabled() && workspaceFlag`) returns true. Failures
+  // never block the rest of the bridge from coming up.
+  if (config.proactive) {
+    const proactiveConfig = config.proactive;
+    Promise.resolve()
+      .then(() =>
+        registerProactiveListener(chat, log, {
+          isEnabled: proactiveConfig.isEnabled,
+          classify: proactiveConfig.classify,
+          workspace: proactiveConfig.workspace,
+          channelAllowlist: proactiveConfig.channelAllowlist,
+          channelConfigs: proactiveConfig.channelConfigs,
+        }),
+      )
+      .catch((err) => {
+        log.error(
+          { err: err instanceof Error ? err : new Error(String(err)) },
+          "Failed to register proactive listener — proactive mode is disabled for this process",
+        );
+      });
+  }
 
   return {
     webhooks: chat.webhooks,

--- a/plugins/chat/src/config.ts
+++ b/plugins/chat/src/config.ts
@@ -9,6 +9,12 @@
 import { z } from "zod";
 import type { StreamChunk } from "chat";
 import type { ReactionConfig } from "./features/reactions";
+import type {
+  ChannelProactiveConfig,
+  LLMClassifierFn,
+  ProactiveGateFn,
+  WorkspaceProactiveConfig,
+} from "./proactive/types";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -388,6 +394,38 @@ export interface ChatPluginConfig {
   /** Ephemeral message configuration. Controls whether errors and debug info
    * are posted as ephemeral messages (visible only to the requesting user). */
   ephemeral?: EphemeralConfig;
+
+  /**
+   * Proactive chat configuration (slice #2292: reaction-first tracer).
+   *
+   * When present and `isEnabled()` returns truthy, the bridge subscribes
+   * to channel-message events and reacts to high-confidence data
+   * questions with 🤖. The host wires `isEnabled` to
+   * `isEnterpriseEnabled() && workspaceFlag` and `classify` to the
+   * configured Atlas model — the plugin itself never imports from
+   * `@atlas/ee` or `@atlas/api`.
+   *
+   * Slice #2292 stops at the reaction. Later slices add the reply,
+   * kill switches, admin UI, meter, and feedback.
+   */
+  proactive?: ProactiveConfig;
+}
+
+/** Proactive chat configuration (slice #2292). */
+export interface ProactiveConfig {
+  /** Gate: returns true when proactive mode is allowed. */
+  isEnabled: ProactiveGateFn;
+  /** LLM classifier injected from the host. */
+  classify: LLMClassifierFn;
+  /** Workspace-level settings (master toggle, sensitivity, classifier mode). */
+  workspace: WorkspaceProactiveConfig;
+  /**
+   * Optional explicit channel allowlist. If omitted, the listener reads
+   * `ATLAS_PROACTIVE_CHANNELS` (comma-separated channel IDs).
+   */
+  channelAllowlist?: string[];
+  /** Per-channel overrides keyed by channel ID. */
+  channelConfigs?: Record<string, ChannelProactiveConfig>;
 }
 
 // ---------------------------------------------------------------------------
@@ -596,6 +634,40 @@ const ReactionConfigSchema = z
   })
   .optional();
 
+const SensitivityPresetSchema = z.enum(["cautious", "balanced", "eager"]);
+
+const ProactiveWorkspaceConfigSchema = z.object({
+  enabled: z.boolean(),
+  sensitivity: SensitivityPresetSchema,
+  classifierMode: z.enum(["regex-prefilter", "classify-all"]),
+});
+
+const ProactiveChannelConfigSchema = z.object({
+  channelId: z.string().min(1),
+  allow: z.boolean(),
+  sensitivity: SensitivityPresetSchema.optional(),
+});
+
+const ProactiveConfigSchema = z
+  .object({
+    isEnabled: z
+      .any()
+      .refine(
+        (v) => typeof v === "function",
+        "proactive.isEnabled must be a function returning boolean | Promise<boolean>",
+      ),
+    classify: z
+      .any()
+      .refine(
+        (v) => typeof v === "function",
+        "proactive.classify must be a function returning Promise<ClassificationResult>",
+      ),
+    workspace: ProactiveWorkspaceConfigSchema,
+    channelAllowlist: z.array(z.string().min(1)).optional(),
+    channelConfigs: z.record(z.string(), ProactiveChannelConfigSchema).optional(),
+  })
+  .optional();
+
 export const ChatConfigSchema = z.object({
   adapters: z
     .object({
@@ -672,6 +744,7 @@ export const ChatConfigSchema = z.object({
   fileUpload: FileUploadConfigSchema,
   reactions: ReactionConfigSchema,
   ephemeral: EphemeralConfigSchema,
+  proactive: ProactiveConfigSchema,
   executeQueryStream: z
     .any()
     .refine(

--- a/plugins/chat/src/index.ts
+++ b/plugins/chat/src/index.ts
@@ -111,7 +111,30 @@ export type {
   StreamingQueryResult,
   FileUploadConfig,
   EphemeralConfig,
+  ProactiveConfig,
 } from "./config";
+
+// Proactive chat layer (slice #2292: reaction-first tracer)
+export type {
+  ChannelProactiveConfig,
+  ClassificationResult,
+  InterjectionAction,
+  InterjectionDecision,
+  LLMClassifierFn,
+  ProactiveGateFn,
+  SensitivityPreset,
+  WorkspaceProactiveConfig,
+} from "./proactive";
+export {
+  PROACTIVE_REACTION,
+  RECENT_INTERJECTION_COOLDOWN_MS,
+  SENSITIVITY_THRESHOLDS,
+  classifyMessage,
+  decideInterjection,
+  regexPreFilter,
+  registerProactiveListener,
+  resolveChannelAllowlist,
+} from "./proactive";
 export type { ReactionConfig, IReactionLifecycle } from "./features/reactions";
 export { StatusEmoji, createReactionLifecycle } from "./features/reactions";
 export type { ChatBridge, ChatPlatform } from "./bridge";

--- a/plugins/chat/src/proactive/__tests__/classifier.test.ts
+++ b/plugins/chat/src/proactive/__tests__/classifier.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Tests for the proactive `MessageClassifier`.
+ *
+ * The LLM is mocked at the injection boundary — we never test the
+ * prompt or the model's output shape. We test:
+ *
+ *  - regex prefilter accepts/rejects the right messages
+ *  - classify-all mode invokes the LLM on anything substantial
+ *  - regex-prefilter mode short-circuits when the prefilter rejects
+ *  - LLM exceptions degrade gracefully to "not a question"
+ */
+
+import { describe, expect, it, mock } from "bun:test";
+import {
+  classifyMessage,
+  regexPreFilter,
+} from "../classifier";
+import type { LLMClassifierFn } from "../types";
+
+// ---------------------------------------------------------------------------
+// regexPreFilter
+// ---------------------------------------------------------------------------
+
+describe("regexPreFilter", () => {
+  it("accepts a direct question with a question mark", () => {
+    expect(regexPreFilter("what was MRR last month?")).toBe(true);
+  });
+
+  it("accepts a question starting with 'how' even without a question mark", () => {
+    expect(regexPreFilter("how many signups did we get yesterday")).toBe(true);
+  });
+
+  it("accepts a question following a greeting and comma", () => {
+    expect(regexPreFilter("Hey, what was MRR last month?")).toBe(true);
+  });
+
+  it("rejects a statement without question markers", () => {
+    expect(regexPreFilter("we shipped the dashboard rewrite")).toBe(false);
+  });
+
+  it("rejects empty or near-empty messages", () => {
+    expect(regexPreFilter("")).toBe(false);
+    expect(regexPreFilter("hi")).toBe(false);
+  });
+
+  it("rejects extremely long messages (cost guard)", () => {
+    const long = "this is a long message ".repeat(200) + "?";
+    expect(regexPreFilter(long)).toBe(false);
+  });
+
+  it("rejects non-string input", () => {
+    // @ts-expect-error — deliberate runtime check
+    expect(regexPreFilter(null)).toBe(false);
+    // @ts-expect-error — deliberate runtime check
+    expect(regexPreFilter(undefined)).toBe(false);
+  });
+
+  it("accepts messages starting with 'anyone'", () => {
+    expect(regexPreFilter("anyone got the latest revenue numbers")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// classifyMessage — regex-prefilter mode
+// ---------------------------------------------------------------------------
+
+describe("classifyMessage (regex-prefilter)", () => {
+  it("short-circuits without invoking the LLM on a clear non-question", async () => {
+    const llm: LLMClassifierFn = mock(async () => ({
+      isQuestion: true,
+      confidence: 0.99,
+    }));
+
+    const result = await classifyMessage({
+      text: "shipping the dashboard rewrite tomorrow",
+      mode: "regex-prefilter",
+      llm,
+    });
+
+    expect(result.candidate).toBe(false);
+    expect(result.llmInvoked).toBe(false);
+    expect(result.isQuestion).toBe(false);
+    expect(result.confidence).toBe(0);
+    expect(llm).not.toHaveBeenCalled();
+  });
+
+  it("invokes the LLM when the prefilter accepts a candidate", async () => {
+    const llm: LLMClassifierFn = mock(async () => ({
+      isQuestion: true,
+      confidence: 0.92,
+      reasoning: "explicit MRR question",
+    }));
+
+    const result = await classifyMessage({
+      text: "what was MRR last month?",
+      mode: "regex-prefilter",
+      llm,
+    });
+
+    expect(result.candidate).toBe(true);
+    expect(result.llmInvoked).toBe(true);
+    expect(result.isQuestion).toBe(true);
+    expect(result.confidence).toBe(0.92);
+    expect(result.reasoning).toBe("explicit MRR question");
+    expect(llm).toHaveBeenCalledTimes(1);
+  });
+
+  it("respects LLM verdict even when prefilter accepts (false-positive guard)", async () => {
+    const llm: LLMClassifierFn = mock(async () => ({
+      isQuestion: false,
+      confidence: 0.1,
+    }));
+
+    const result = await classifyMessage({
+      text: "is there pizza in the office today?",
+      mode: "regex-prefilter",
+      llm,
+    });
+
+    expect(result.candidate).toBe(true);
+    expect(result.llmInvoked).toBe(true);
+    expect(result.isQuestion).toBe(false);
+    expect(result.confidence).toBe(0.1);
+  });
+
+  it("fails closed when the LLM throws", async () => {
+    const llm: LLMClassifierFn = mock(async () => {
+      throw new Error("model timeout");
+    });
+
+    const result = await classifyMessage({
+      text: "what was MRR last month?",
+      mode: "regex-prefilter",
+      llm,
+    });
+
+    expect(result.isQuestion).toBe(false);
+    expect(result.confidence).toBe(0);
+    expect(result.llmInvoked).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// classifyMessage — classify-all mode
+// ---------------------------------------------------------------------------
+
+describe("classifyMessage (classify-all)", () => {
+  it("invokes the LLM on a message the prefilter would reject", async () => {
+    const llm: LLMClassifierFn = mock(async () => ({
+      isQuestion: true,
+      confidence: 0.78,
+      reasoning: "indirect question via 'curious about'",
+    }));
+
+    const result = await classifyMessage({
+      text: "curious about MRR last month",
+      mode: "classify-all",
+      llm,
+    });
+
+    expect(result.candidate).toBe(true);
+    expect(result.llmInvoked).toBe(true);
+    expect(result.isQuestion).toBe(true);
+    expect(result.confidence).toBe(0.78);
+  });
+
+  it("still skips trivially-short messages to avoid wasted LLM spend", async () => {
+    const llm: LLMClassifierFn = mock(async () => ({
+      isQuestion: true,
+      confidence: 0.99,
+    }));
+
+    const result = await classifyMessage({
+      text: "hi",
+      mode: "classify-all",
+      llm,
+    });
+
+    expect(result.llmInvoked).toBe(false);
+    expect(result.isQuestion).toBe(false);
+    expect(llm).not.toHaveBeenCalled();
+  });
+});

--- a/plugins/chat/src/proactive/__tests__/listener.test.ts
+++ b/plugins/chat/src/proactive/__tests__/listener.test.ts
@@ -1,0 +1,248 @@
+/**
+ * Tests for the proactive listener wiring.
+ *
+ * We exercise the handler by capturing the function passed to
+ * `chat.onNewMessage(/.+/, handler)` and invoking it directly with
+ * fake thread + message objects. That keeps the test free of any real
+ * Chat SDK plumbing while still proving the wiring is correct.
+ */
+
+import { describe, expect, it, mock } from "bun:test";
+import {
+  registerProactiveListener,
+  resolveChannelAllowlist,
+  PROACTIVE_REACTION,
+} from "../listener";
+import type { LLMClassifierFn, WorkspaceProactiveConfig } from "../types";
+
+// ---------------------------------------------------------------------------
+// Test doubles
+// ---------------------------------------------------------------------------
+
+type ChannelMessageHandler = (
+  thread: ReturnType<typeof makeThread>,
+  message: ReturnType<typeof makeMessage>,
+) => Promise<void> | void;
+
+function makeLogger() {
+  return {
+    info: mock(() => {}),
+    warn: mock(() => {}),
+    error: mock(() => {}),
+    debug: mock(() => {}),
+  };
+}
+
+function makeChat() {
+  let captured: ChannelMessageHandler | null = null;
+  const chat = {
+    onNewMessage: mock((_pattern: RegExp, handler: ChannelMessageHandler) => {
+      captured = handler;
+    }),
+  };
+  return {
+    chat,
+    invoke: async (
+      thread: ReturnType<typeof makeThread>,
+      message: ReturnType<typeof makeMessage>,
+    ) => {
+      if (!captured) throw new Error("listener never registered a handler");
+      await captured(thread, message);
+    },
+    isRegistered: () => captured !== null,
+  };
+}
+
+function makeThread(channelId = "C-allowed", reaction?: ReturnType<typeof mock>) {
+  const addReaction = reaction ?? mock(async () => {});
+  return {
+    channelId,
+    createSentMessageFromMessage: mock(() => ({
+      addReaction,
+    })),
+    _addReaction: addReaction,
+  };
+}
+
+function makeMessage(opts: {
+  id?: string;
+  text?: string;
+  isBot?: boolean | "unknown";
+  isMe?: boolean;
+} = {}) {
+  return {
+    id: opts.id ?? "M1",
+    text: opts.text ?? "what was MRR last month?",
+    author: {
+      isBot: opts.isBot ?? false,
+      isMe: opts.isMe ?? false,
+      userId: "U1",
+      userName: "asker",
+    },
+  };
+}
+
+const baseWorkspace: WorkspaceProactiveConfig = {
+  enabled: true,
+  sensitivity: "balanced",
+  classifierMode: "regex-prefilter",
+};
+
+const yesLLM: LLMClassifierFn = async () => ({ isQuestion: true, confidence: 0.9 });
+const noLLM: LLMClassifierFn = async () => ({ isQuestion: false, confidence: 0.1 });
+
+// ---------------------------------------------------------------------------
+// resolveChannelAllowlist
+// ---------------------------------------------------------------------------
+
+describe("resolveChannelAllowlist", () => {
+  it("prefers explicit config over env var", () => {
+    const set = resolveChannelAllowlist(["C-a", "C-b"], {
+      ATLAS_PROACTIVE_CHANNELS: "C-x,C-y",
+    } as NodeJS.ProcessEnv);
+    expect(Array.from(set).sort()).toEqual(["C-a", "C-b"]);
+  });
+
+  it("parses ATLAS_PROACTIVE_CHANNELS comma-separated values", () => {
+    const set = resolveChannelAllowlist(undefined, {
+      ATLAS_PROACTIVE_CHANNELS: " C-a , C-b ,, C-c ",
+    } as NodeJS.ProcessEnv);
+    expect(Array.from(set).sort()).toEqual(["C-a", "C-b", "C-c"]);
+  });
+
+  it("returns an empty set when neither source is provided", () => {
+    const set = resolveChannelAllowlist(undefined, {} as NodeJS.ProcessEnv);
+    expect(set.size).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Listener registration
+// ---------------------------------------------------------------------------
+
+describe("registerProactiveListener — gating", () => {
+  it("does not register when isEnabled() is false at boot", async () => {
+    const { chat, isRegistered } = makeChat();
+    await registerProactiveListener(chat as any, makeLogger(), {
+      isEnabled: () => false,
+      classify: yesLLM,
+      workspace: baseWorkspace,
+      channelAllowlist: ["C-allowed"],
+    });
+    expect(isRegistered()).toBe(false);
+    expect(chat.onNewMessage).not.toHaveBeenCalled();
+  });
+
+  it("registers when isEnabled() is true", async () => {
+    const { chat, isRegistered } = makeChat();
+    await registerProactiveListener(chat as any, makeLogger(), {
+      isEnabled: () => true,
+      classify: yesLLM,
+      workspace: baseWorkspace,
+      channelAllowlist: ["C-allowed"],
+    });
+    expect(isRegistered()).toBe(true);
+    expect(chat.onNewMessage).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("registerProactiveListener — handler behaviour", () => {
+  it("adds a reaction when the channel is allowed and the classifier is confident", async () => {
+    const { chat, invoke } = makeChat();
+    await registerProactiveListener(chat as any, makeLogger(), {
+      isEnabled: () => true,
+      classify: yesLLM,
+      workspace: baseWorkspace,
+      channelAllowlist: ["C-allowed"],
+    });
+    const thread = makeThread("C-allowed");
+    await invoke(thread, makeMessage());
+    expect(thread._addReaction).toHaveBeenCalledTimes(1);
+    expect(thread._addReaction).toHaveBeenCalledWith(PROACTIVE_REACTION);
+  });
+
+  it("does not react when the channel is outside the allowlist", async () => {
+    const { chat, invoke } = makeChat();
+    await registerProactiveListener(chat as any, makeLogger(), {
+      isEnabled: () => true,
+      classify: yesLLM,
+      workspace: baseWorkspace,
+      channelAllowlist: ["C-allowed"],
+    });
+    const thread = makeThread("C-other");
+    await invoke(thread, makeMessage());
+    expect(thread._addReaction).not.toHaveBeenCalled();
+  });
+
+  it("does not react when the gate flips off between registration and the message", async () => {
+    let gateOn = true;
+    const { chat, invoke } = makeChat();
+    await registerProactiveListener(chat as any, makeLogger(), {
+      isEnabled: () => gateOn,
+      classify: yesLLM,
+      workspace: baseWorkspace,
+      channelAllowlist: ["C-allowed"],
+    });
+    gateOn = false;
+    const thread = makeThread("C-allowed");
+    await invoke(thread, makeMessage());
+    expect(thread._addReaction).not.toHaveBeenCalled();
+  });
+
+  it("does not react to messages from bots", async () => {
+    const { chat, invoke } = makeChat();
+    await registerProactiveListener(chat as any, makeLogger(), {
+      isEnabled: () => true,
+      classify: yesLLM,
+      workspace: baseWorkspace,
+      channelAllowlist: ["C-allowed"],
+    });
+    const thread = makeThread("C-allowed");
+    await invoke(thread, makeMessage({ isBot: true }));
+    expect(thread._addReaction).not.toHaveBeenCalled();
+  });
+
+  it("does not react when the classifier returns low confidence", async () => {
+    const { chat, invoke } = makeChat();
+    await registerProactiveListener(chat as any, makeLogger(), {
+      isEnabled: () => true,
+      classify: noLLM,
+      workspace: baseWorkspace,
+      channelAllowlist: ["C-allowed"],
+    });
+    const thread = makeThread("C-allowed");
+    await invoke(thread, makeMessage());
+    expect(thread._addReaction).not.toHaveBeenCalled();
+  });
+
+  it("rate-limits a chatty channel — only one reaction inside the cooldown", async () => {
+    const { chat, invoke } = makeChat();
+    await registerProactiveListener(chat as any, makeLogger(), {
+      isEnabled: () => true,
+      classify: yesLLM,
+      workspace: baseWorkspace,
+      channelAllowlist: ["C-allowed"],
+    });
+    const thread = makeThread("C-allowed");
+    await invoke(thread, makeMessage({ id: "M1" }));
+    await invoke(thread, makeMessage({ id: "M2" }));
+    expect(thread._addReaction).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not throw when addReaction fails — failures are best-effort", async () => {
+    const reaction = mock(async () => {
+      throw new Error("slack rate limit");
+    });
+    const { chat, invoke } = makeChat();
+    const log = makeLogger();
+    await registerProactiveListener(chat as any, log, {
+      isEnabled: () => true,
+      classify: yesLLM,
+      workspace: baseWorkspace,
+      channelAllowlist: ["C-allowed"],
+    });
+    const thread = makeThread("C-allowed", reaction);
+    await invoke(thread, makeMessage());
+    expect(log.warn).toHaveBeenCalled();
+  });
+});

--- a/plugins/chat/src/proactive/__tests__/policy.test.ts
+++ b/plugins/chat/src/proactive/__tests__/policy.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Truth-table tests for `decideInterjection`.
+ *
+ * The PRD calls this out specifically: regressions in proactive chat
+ * land here, so the matrix covers (isQuestion × confidence ×
+ * sensitivity × workspace enabled × channel allowed × channel denied ×
+ * recent activity). We assert on the `reason` tag so a regression
+ * points at the exact branch that flipped.
+ */
+
+import { describe, expect, it } from "bun:test";
+import {
+  decideInterjection,
+  RECENT_INTERJECTION_COOLDOWN_MS,
+  SENSITIVITY_THRESHOLDS,
+} from "../policy";
+import type {
+  ChannelProactiveConfig,
+  ClassificationResult,
+  SensitivityPreset,
+  WorkspaceProactiveConfig,
+} from "../types";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function workspace(overrides: Partial<WorkspaceProactiveConfig> = {}): WorkspaceProactiveConfig {
+  return {
+    enabled: true,
+    sensitivity: "balanced",
+    classifierMode: "regex-prefilter",
+    ...overrides,
+  };
+}
+
+function classification(overrides: Partial<ClassificationResult> = {}): ClassificationResult {
+  return {
+    isQuestion: true,
+    confidence: 0.9,
+    ...overrides,
+  };
+}
+
+const NOW = 1_700_000_000_000;
+
+// ---------------------------------------------------------------------------
+// Short-circuit gates (highest precedence first)
+// ---------------------------------------------------------------------------
+
+describe("decideInterjection — short-circuit gates", () => {
+  it("skips when workspace.enabled is false even with high confidence", () => {
+    const decision = decideInterjection({
+      classification: classification({ confidence: 0.99 }),
+      workspace: workspace({ enabled: false }),
+      channelAllowed: true,
+    });
+    expect(decision).toEqual({ action: "skip", reason: "workspace-disabled" });
+  });
+
+  it("skips when channel is not on the allowlist", () => {
+    const decision = decideInterjection({
+      classification: classification(),
+      workspace: workspace(),
+      channelAllowed: false,
+    });
+    expect(decision).toEqual({ action: "skip", reason: "channel-not-allowed" });
+  });
+
+  it("skips when channel has an explicit deny override", () => {
+    const channel: ChannelProactiveConfig = { channelId: "C1", allow: false };
+    const decision = decideInterjection({
+      classification: classification(),
+      workspace: workspace(),
+      channel,
+      channelAllowed: true,
+    });
+    expect(decision).toEqual({ action: "skip", reason: "channel-denied" });
+  });
+
+  it("skips when the classifier says not a question", () => {
+    const decision = decideInterjection({
+      classification: classification({ isQuestion: false, confidence: 0.99 }),
+      workspace: workspace(),
+      channelAllowed: true,
+    });
+    expect(decision).toEqual({ action: "skip", reason: "not-a-question" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Confidence × sensitivity truth table
+// ---------------------------------------------------------------------------
+
+describe("decideInterjection — confidence × sensitivity", () => {
+  const cases: Array<{
+    sensitivity: SensitivityPreset;
+    confidence: number;
+    expected: "react" | "skip";
+  }> = [
+    // Cautious threshold (0.85)
+    { sensitivity: "cautious", confidence: 0.84, expected: "skip" },
+    { sensitivity: "cautious", confidence: 0.85, expected: "react" },
+    { sensitivity: "cautious", confidence: 0.99, expected: "react" },
+
+    // Balanced threshold (0.70)
+    { sensitivity: "balanced", confidence: 0.69, expected: "skip" },
+    { sensitivity: "balanced", confidence: 0.70, expected: "react" },
+    { sensitivity: "balanced", confidence: 0.84, expected: "react" },
+
+    // Eager threshold (0.55)
+    { sensitivity: "eager", confidence: 0.54, expected: "skip" },
+    { sensitivity: "eager", confidence: 0.55, expected: "react" },
+    { sensitivity: "eager", confidence: 0.71, expected: "react" },
+  ];
+
+  for (const { sensitivity, confidence, expected } of cases) {
+    it(`sensitivity=${sensitivity} confidence=${confidence} → ${expected}`, () => {
+      const decision = decideInterjection({
+        classification: classification({ confidence }),
+        workspace: workspace({ sensitivity }),
+        channelAllowed: true,
+      });
+      expect(decision.action).toBe(expected);
+      if (expected === "skip") {
+        expect(decision.reason).toBe("below-confidence-threshold");
+      } else {
+        expect(decision.reason).toBe("passes-threshold");
+      }
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Per-channel sensitivity override
+// ---------------------------------------------------------------------------
+
+describe("decideInterjection — channel sensitivity override", () => {
+  it("uses channel sensitivity when present", () => {
+    // Workspace is cautious (0.85), channel is eager (0.55).
+    // A 0.6 confidence should react under channel, not under workspace.
+    const decision = decideInterjection({
+      classification: classification({ confidence: 0.6 }),
+      workspace: workspace({ sensitivity: "cautious" }),
+      channel: { channelId: "C1", allow: true, sensitivity: "eager" },
+      channelAllowed: true,
+    });
+    expect(decision).toEqual({ action: "react", reason: "passes-threshold" });
+  });
+
+  it("falls back to workspace sensitivity when channel does not override", () => {
+    const decision = decideInterjection({
+      classification: classification({ confidence: 0.6 }),
+      workspace: workspace({ sensitivity: "cautious" }),
+      channel: { channelId: "C1", allow: true }, // no sensitivity override
+      channelAllowed: true,
+    });
+    expect(decision).toEqual({ action: "skip", reason: "below-confidence-threshold" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Recent-activity rate limit
+// ---------------------------------------------------------------------------
+
+describe("decideInterjection — recent activity rate limit", () => {
+  it("skips when a recent interjection is within the cooldown window", () => {
+    const decision = decideInterjection({
+      classification: classification(),
+      workspace: workspace(),
+      channelAllowed: true,
+      recentActivity: { lastInterjectionAt: NOW - 1000 },
+      now: () => NOW,
+    });
+    expect(decision).toEqual({ action: "skip", reason: "rate-limited" });
+  });
+
+  it("reacts again once the cooldown has elapsed", () => {
+    const decision = decideInterjection({
+      classification: classification(),
+      workspace: workspace(),
+      channelAllowed: true,
+      recentActivity: {
+        lastInterjectionAt: NOW - RECENT_INTERJECTION_COOLDOWN_MS - 1,
+      },
+      now: () => NOW,
+    });
+    expect(decision).toEqual({ action: "react", reason: "passes-threshold" });
+  });
+
+  it("treats missing recent activity as no rate-limit", () => {
+    const decision = decideInterjection({
+      classification: classification(),
+      workspace: workspace(),
+      channelAllowed: true,
+      recentActivity: undefined,
+    });
+    expect(decision.action).toBe("react");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Threshold sanity
+// ---------------------------------------------------------------------------
+
+describe("SENSITIVITY_THRESHOLDS", () => {
+  it("orders cautious > balanced > eager", () => {
+    expect(SENSITIVITY_THRESHOLDS.cautious).toBeGreaterThan(SENSITIVITY_THRESHOLDS.balanced);
+    expect(SENSITIVITY_THRESHOLDS.balanced).toBeGreaterThan(SENSITIVITY_THRESHOLDS.eager);
+  });
+
+  it("clamps all thresholds inside [0, 1]", () => {
+    for (const v of Object.values(SENSITIVITY_THRESHOLDS)) {
+      expect(v).toBeGreaterThanOrEqual(0);
+      expect(v).toBeLessThanOrEqual(1);
+    }
+  });
+});

--- a/plugins/chat/src/proactive/classifier.ts
+++ b/plugins/chat/src/proactive/classifier.ts
@@ -1,0 +1,169 @@
+/**
+ * Pure message classifier for proactive chat.
+ *
+ * Given a message text, decides whether it looks like an answerable
+ * data question. Two flavours:
+ *
+ *  - `regex-prefilter` (default): cheap regex check first; LLM only on
+ *    candidates. Cuts classifier cost roughly an order of magnitude.
+ *  - `classify-all`: always run the LLM. Catches indirect questions
+ *    ("curious about MRR last month") at the cost of more spend.
+ *
+ * The LLM is injected via {@link LLMClassifierFn} so this module stays
+ * pure and testable — boundary mocking only.
+ */
+
+import type {
+  ClassificationResult,
+  LLMClassifierFn,
+  WorkspaceProactiveConfig,
+} from "./types";
+
+// ---------------------------------------------------------------------------
+// Regex pre-filter
+// ---------------------------------------------------------------------------
+
+/**
+ * Question-word prefixes that mark a message as a candidate for the
+ * full LLM classifier. Kept conservative on purpose — false positives
+ * just trigger one extra LLM call, false negatives mean we miss a
+ * question entirely.
+ */
+const QUESTION_WORDS = [
+  "what",
+  "what's",
+  "whats",
+  "how",
+  "how's",
+  "hows",
+  "how many",
+  "how much",
+  "why",
+  "when",
+  "where",
+  "who",
+  "which",
+  "is",
+  "are",
+  "do",
+  "does",
+  "did",
+  "can",
+  "could",
+  "would",
+  "should",
+  "any",
+  "anyone",
+];
+
+/** Maximum message length the prefilter / classifier will consider. */
+const MAX_MESSAGE_CHARS = 2000;
+
+/** Minimum message length below which we never classify (e.g. ":+1:"). */
+const MIN_MESSAGE_CHARS = 4;
+
+/**
+ * Cheap regex check that returns true when a message *might* be a
+ * question. Used to filter the firehose down to LLM-eligible
+ * candidates.
+ *
+ * Heuristics:
+ * - Ends in `?` after trimming punctuation/emoji.
+ * - First word matches a known question prefix.
+ *
+ * Pure function — no I/O, no side effects.
+ */
+export function regexPreFilter(text: string): boolean {
+  if (typeof text !== "string") return false;
+  const trimmed = text.trim();
+  if (trimmed.length < MIN_MESSAGE_CHARS) return false;
+  if (trimmed.length > MAX_MESSAGE_CHARS) return false;
+
+  // Question mark anywhere in the last 5 chars (after trim) is a strong
+  // signal — covers "what was MRR last month?" and "any idea on signups?"
+  const tail = trimmed.slice(-5);
+  if (tail.includes("?")) return true;
+
+  // First-word question prefix. Lowercase and strip leading non-letters
+  // so "Hey, what was MRR" still triggers on "what".
+  const firstWord = trimmed.toLowerCase().replace(/^[^a-z]+/, "").split(/\s+/)[0] ?? "";
+  if (!firstWord) return false;
+  return QUESTION_WORDS.includes(firstWord);
+}
+
+// ---------------------------------------------------------------------------
+// classifyMessage
+// ---------------------------------------------------------------------------
+
+export interface ClassifyMessageOptions {
+  /** The message text to classify. */
+  text: string;
+  /** Workspace classifier mode (controls whether prefilter is applied). */
+  mode: WorkspaceProactiveConfig["classifierMode"];
+  /** Injected LLM classifier — called only on candidates. */
+  llm: LLMClassifierFn;
+}
+
+/** Returned by `classifyMessage`. Adds gating info for testability. */
+export interface ClassifyMessageResult extends ClassificationResult {
+  /** Whether the prefilter accepted the message (always true in classify-all). */
+  candidate: boolean;
+  /** Whether the LLM was actually invoked. */
+  llmInvoked: boolean;
+}
+
+/**
+ * Run the full classifier pipeline.
+ *
+ * `regex-prefilter` mode: returns `{ isQuestion: false, confidence: 0 }`
+ * immediately on prefilter rejection, otherwise delegates to the LLM.
+ *
+ * `classify-all` mode: skips the prefilter and always invokes the LLM.
+ *
+ * Errors from the injected LLM are caught and converted to a "not a
+ * question" result so the listener fails closed — never react on a
+ * classifier failure.
+ */
+export async function classifyMessage(
+  opts: ClassifyMessageOptions,
+): Promise<ClassifyMessageResult> {
+  const { text, mode, llm } = opts;
+
+  if (mode === "regex-prefilter") {
+    const candidate = regexPreFilter(text);
+    if (!candidate) {
+      return {
+        isQuestion: false,
+        confidence: 0,
+        candidate: false,
+        llmInvoked: false,
+      };
+    }
+    const result = await safeClassify(llm, text);
+    return { ...result, candidate: true, llmInvoked: true };
+  }
+
+  // classify-all
+  if (text.trim().length < MIN_MESSAGE_CHARS) {
+    return {
+      isQuestion: false,
+      confidence: 0,
+      candidate: false,
+      llmInvoked: false,
+    };
+  }
+  const result = await safeClassify(llm, text);
+  return { ...result, candidate: true, llmInvoked: true };
+}
+
+async function safeClassify(
+  llm: LLMClassifierFn,
+  text: string,
+): Promise<ClassificationResult> {
+  try {
+    return await llm(text);
+  } catch {
+    // Fail closed: classifier errors should never produce an interjection.
+    return { isQuestion: false, confidence: 0 };
+  }
+}

--- a/plugins/chat/src/proactive/index.ts
+++ b/plugins/chat/src/proactive/index.ts
@@ -1,0 +1,40 @@
+/**
+ * Proactive chat layer — public exports.
+ *
+ * Slice #2292: reaction-first tracer. Subscribe → classify → react. No
+ * reply yet. Later slices add the answer, kill switches, admin config,
+ * meter, and feedback.
+ */
+
+export type {
+  ChannelProactiveConfig,
+  ClassificationResult,
+  InterjectionAction,
+  InterjectionDecision,
+  LLMClassifierFn,
+  ProactiveGateFn,
+  RecentActivity,
+  SensitivityPreset,
+  WorkspaceProactiveConfig,
+} from "./types";
+
+export {
+  classifyMessage,
+  regexPreFilter,
+  type ClassifyMessageOptions,
+  type ClassifyMessageResult,
+} from "./classifier";
+
+export {
+  decideInterjection,
+  RECENT_INTERJECTION_COOLDOWN_MS,
+  SENSITIVITY_THRESHOLDS,
+  type DecideInterjectionInput,
+} from "./policy";
+
+export {
+  PROACTIVE_REACTION,
+  registerProactiveListener,
+  resolveChannelAllowlist,
+  type ProactiveListenerConfig,
+} from "./listener";

--- a/plugins/chat/src/proactive/listener.ts
+++ b/plugins/chat/src/proactive/listener.ts
@@ -1,0 +1,172 @@
+/**
+ * Proactive chat listener wiring.
+ *
+ * Registers an `onNewMessage` handler on the Chat SDK so that channel
+ * messages (which would otherwise fall through) get classified and —
+ * when policy says so — reacted to with 🤖.
+ *
+ * Slice #2292 stops at the reaction. The reply path lands in #2293.
+ *
+ * Important: this module never imports `@atlas/ee` directly. The host
+ * (typically `packages/api`) wires `isEnabled` to
+ * `isEnterpriseEnabled() && workspaceFlag` so the plugin stays
+ * decoupled from the enterprise gate.
+ */
+
+import { emoji } from "chat";
+import type { Chat, Message, Thread } from "chat";
+import type { PluginLogger } from "@useatlas/plugin-sdk";
+import { classifyMessage } from "./classifier";
+import { decideInterjection } from "./policy";
+import type {
+  ChannelProactiveConfig,
+  LLMClassifierFn,
+  ProactiveGateFn,
+  RecentActivity,
+  WorkspaceProactiveConfig,
+} from "./types";
+
+// ---------------------------------------------------------------------------
+// Public config
+// ---------------------------------------------------------------------------
+
+/** Configuration for the proactive listener. */
+export interface ProactiveListenerConfig {
+  /** Gate: returns true when proactive mode is allowed (enterprise + workspace flag). */
+  isEnabled: ProactiveGateFn;
+  /** LLM classifier callback. Plugins do not own the model wiring. */
+  classify: LLMClassifierFn;
+  /** Workspace-level config. */
+  workspace: WorkspaceProactiveConfig;
+  /**
+   * Optional explicit channel allowlist. If omitted, the listener reads
+   * `ATLAS_PROACTIVE_CHANNELS` (comma-separated channel IDs). This is
+   * intentionally crude for slice #2292 — admin UI lands in #2294.
+   */
+  channelAllowlist?: string[];
+  /** Per-channel overrides keyed by channel ID. */
+  channelConfigs?: Record<string, ChannelProactiveConfig>;
+}
+
+/**
+ * Reaction emoji used when policy decides to interject.
+ *
+ * `robot_face` isn't in the Chat SDK's well-known emoji map, so we go
+ * through the SDK's `custom()` escape hatch. The adapter resolves the
+ * shortcode per platform (`:robot_face:` on Slack, 🤖 on Google Chat,
+ * etc.) so the plugin stays free of raw Unicode.
+ */
+export const PROACTIVE_REACTION = emoji.custom("robot_face");
+
+// ---------------------------------------------------------------------------
+// Channel allowlist resolution
+// ---------------------------------------------------------------------------
+
+/** Resolve the channel allowlist from config or `ATLAS_PROACTIVE_CHANNELS`. */
+export function resolveChannelAllowlist(
+  explicit: string[] | undefined,
+  env: NodeJS.ProcessEnv = process.env,
+): Set<string> {
+  if (explicit && explicit.length > 0) return new Set(explicit);
+  const raw = env.ATLAS_PROACTIVE_CHANNELS ?? "";
+  return new Set(
+    raw
+      .split(",")
+      .map((id) => id.trim())
+      .filter((id) => id.length > 0),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Listener registration
+// ---------------------------------------------------------------------------
+
+/**
+ * Register the proactive listener on a Chat SDK instance.
+ *
+ * Does nothing (and logs at debug) when `isEnabled()` returns falsy at
+ * registration time. The gate is *also* re-checked inside the handler
+ * for every message so that a workspace toggle flip takes effect
+ * without restart.
+ */
+export async function registerProactiveListener(
+  chat: Chat,
+  log: PluginLogger,
+  config: ProactiveListenerConfig,
+): Promise<void> {
+  const enabledAtRegistration = await config.isEnabled();
+  if (!enabledAtRegistration) {
+    log.debug("Proactive listener not registered — gate is closed");
+    return;
+  }
+
+  const allowlist = resolveChannelAllowlist(config.channelAllowlist);
+  log.info(
+    { allowlistSize: allowlist.size },
+    "Proactive listener registered",
+  );
+
+  // Per-channel last-interjection timestamps for rate limiting. In-memory
+  // is fine for slice #2292 — #2296 swaps in a durable meter.
+  const recent = new Map<string, RecentActivity>();
+
+  // Match any non-empty message. The classifier+policy gate downstream.
+  chat.onNewMessage(/.+/, async (thread: Thread, message: Message) => {
+    try {
+      // Re-check the gate per message so a workspace toggle flip wins
+      // without a restart.
+      if (!(await config.isEnabled())) return;
+
+      // Bots (including this one) and empty messages bypass the
+      // classifier outright.
+      if (message.author.isBot === true || message.author.isMe) return;
+      const text = message.text?.trim() ?? "";
+      if (text.length === 0) return;
+
+      const channelId = thread.channelId;
+      const channelAllowed = allowlist.has(channelId);
+      const channelConfig = config.channelConfigs?.[channelId];
+
+      const classification = await classifyMessage({
+        text,
+        mode: config.workspace.classifierMode,
+        llm: config.classify,
+      });
+
+      const decision = decideInterjection({
+        classification,
+        workspace: config.workspace,
+        channel: channelConfig,
+        channelAllowed,
+        recentActivity: recent.get(channelId),
+      });
+
+      log.debug(
+        {
+          channelId,
+          messageId: message.id,
+          isQuestion: classification.isQuestion,
+          confidence: classification.confidence,
+          action: decision.action,
+          reason: decision.reason,
+        },
+        "Proactive classification decision",
+      );
+
+      if (decision.action !== "react") return;
+
+      const sent = thread.createSentMessageFromMessage(message);
+      await sent.addReaction(PROACTIVE_REACTION);
+      recent.set(channelId, { lastInterjectionAt: Date.now() });
+    } catch (err) {
+      // Listener must never crash the Chat SDK event loop.
+      log.warn(
+        {
+          err: err instanceof Error ? err : new Error(String(err)),
+          messageId: message?.id,
+        },
+        "Proactive listener handler threw — suppressed",
+      );
+    }
+  });
+}

--- a/plugins/chat/src/proactive/policy.ts
+++ b/plugins/chat/src/proactive/policy.ts
@@ -1,0 +1,115 @@
+/**
+ * Pure interjection policy for proactive chat.
+ *
+ * Given a classification result + the channel/workspace config + recent
+ * activity, returns whether Atlas should react, answer, or stay silent.
+ *
+ * Slice #2292 narrows the action to `react | skip` — the reply path
+ * arrives in #2293. Sensitivity → confidence-threshold mapping lives
+ * here so policy decisions stay testable as a single truth table.
+ */
+
+import type {
+  ClassificationResult,
+  ChannelProactiveConfig,
+  InterjectionDecision,
+  RecentActivity,
+  SensitivityPreset,
+  WorkspaceProactiveConfig,
+} from "./types";
+
+// ---------------------------------------------------------------------------
+// Tunables
+// ---------------------------------------------------------------------------
+
+/**
+ * Confidence thresholds per sensitivity preset.
+ *
+ * - cautious: only interject when the classifier is very sure (≥ 0.85)
+ * - balanced: default (≥ 0.70)
+ * - eager:    catch borderline cases too (≥ 0.55)
+ *
+ * Values chosen to feel right at MVP; tune from design-partner data
+ * before any broader rollout (see PRD §Stability bar).
+ */
+export const SENSITIVITY_THRESHOLDS: Record<SensitivityPreset, number> = {
+  cautious: 0.85,
+  balanced: 0.7,
+  eager: 0.55,
+};
+
+/**
+ * Minimum gap between interjections in the same channel (ms).
+ *
+ * Rate limit applied even when the policy would otherwise react — keeps
+ * Atlas from spamming a chatty channel. 60s feels low-impact at MVP;
+ * the admin-console rollup PR will surface this as a tunable.
+ */
+export const RECENT_INTERJECTION_COOLDOWN_MS = 60_000;
+
+// ---------------------------------------------------------------------------
+// decideInterjection
+// ---------------------------------------------------------------------------
+
+export interface DecideInterjectionInput {
+  classification: ClassificationResult;
+  workspace: WorkspaceProactiveConfig;
+  /** Per-channel override. Absent => defaults to allowed at workspace level. */
+  channel?: ChannelProactiveConfig;
+  /** Whether the channel is on the allowlist for this slice. */
+  channelAllowed: boolean;
+  /** Recent-activity sample for rate limiting. */
+  recentActivity?: RecentActivity;
+  /** Override `Date.now()` for deterministic tests. */
+  now?: () => number;
+}
+
+/**
+ * Decide whether to react, answer, or skip.
+ *
+ * Pure function — all I/O happens outside. Truth-table tested against
+ * the cartesian product of (confidence × channel × workspace × recent
+ * activity) in `__tests__/policy.test.ts`.
+ *
+ * For slice #2292 the only positive action is `react` — the answer
+ * path lands in #2293 and will widen the return type.
+ */
+export function decideInterjection(input: DecideInterjectionInput): InterjectionDecision {
+  const {
+    classification,
+    workspace,
+    channel,
+    channelAllowed,
+    recentActivity,
+    now = Date.now,
+  } = input;
+
+  if (!workspace.enabled) {
+    return { action: "skip", reason: "workspace-disabled" };
+  }
+  if (!channelAllowed) {
+    return { action: "skip", reason: "channel-not-allowed" };
+  }
+  if (channel && channel.allow === false) {
+    return { action: "skip", reason: "channel-denied" };
+  }
+  if (!classification.isQuestion) {
+    return { action: "skip", reason: "not-a-question" };
+  }
+
+  const effectiveSensitivity: SensitivityPreset =
+    channel?.sensitivity ?? workspace.sensitivity;
+  const threshold = SENSITIVITY_THRESHOLDS[effectiveSensitivity];
+  if (classification.confidence < threshold) {
+    return { action: "skip", reason: "below-confidence-threshold" };
+  }
+
+  if (recentActivity?.lastInterjectionAt != null) {
+    const elapsed = now() - recentActivity.lastInterjectionAt;
+    if (elapsed < RECENT_INTERJECTION_COOLDOWN_MS) {
+      return { action: "skip", reason: "rate-limited" };
+    }
+  }
+
+  return { action: "react", reason: "passes-threshold" };
+}

--- a/plugins/chat/src/proactive/types.ts
+++ b/plugins/chat/src/proactive/types.ts
@@ -1,0 +1,82 @@
+/**
+ * Shared types for the proactive chat layer.
+ *
+ * Proactive mode lets Atlas listen to channel messages in opted-in
+ * channels, classify them as answerable data questions, and react /
+ * eventually answer without an explicit `@atlas` mention. This module
+ * holds only the pure shapes — see `classifier.ts`, `policy.ts`, and
+ * `listener.ts` for behaviour.
+ *
+ * Slice #2292 ships the reaction-first tracer: subscribe → classify →
+ * react. Later slices add the reply, kill switches, admin config,
+ * meter, and feedback.
+ */
+
+/** Result of running a message through the question classifier. */
+export interface ClassificationResult {
+  /** Whether the message looks like an answerable data question. */
+  isQuestion: boolean;
+  /** Confidence in [0, 1] — 1.0 = certain, 0.0 = certainly not. */
+  confidence: number;
+  /** Optional short reason from the LLM, useful for audit + tuning. */
+  reasoning?: string;
+}
+
+/** Three-tier sensitivity preset. Maps to a confidence threshold in policy. */
+export type SensitivityPreset = "cautious" | "balanced" | "eager";
+
+/** Workspace-level proactive settings. */
+export interface WorkspaceProactiveConfig {
+  /** Master toggle. When false, the listener never reacts. */
+  enabled: boolean;
+  /** Confidence-threshold preset. */
+  sensitivity: SensitivityPreset;
+  /** Classifier mode. */
+  classifierMode: "regex-prefilter" | "classify-all";
+}
+
+/** Per-channel override. Absent fields fall back to workspace defaults. */
+export interface ChannelProactiveConfig {
+  channelId: string;
+  /** When false, the channel is denied (Atlas never interjects). */
+  allow: boolean;
+  /** Optional sensitivity override. */
+  sensitivity?: SensitivityPreset;
+}
+
+/** Recent interjection activity used for rate limiting. */
+export interface RecentActivity {
+  /** Epoch ms of the most recent interjection in this channel, if any. */
+  lastInterjectionAt?: number;
+}
+
+/** Action returned by `decideInterjection`. */
+export type InterjectionAction = "react" | "skip";
+
+/** Decision returned by `decideInterjection`. */
+export interface InterjectionDecision {
+  action: InterjectionAction;
+  /** Short tag explaining why — used in audit + tests. */
+  reason: string;
+}
+
+/**
+ * LLM classifier function injected from the host.
+ *
+ * Keeps the plugin decoupled from the API package and from any specific
+ * model wiring. The host passes a function that runs the workspace's
+ * configured Atlas model against a question-detection prompt.
+ *
+ * Implementations should never throw — failures should resolve as
+ * `{ isQuestion: false, confidence: 0 }` so the listener fails closed.
+ */
+export type LLMClassifierFn = (text: string) => Promise<ClassificationResult>;
+
+/**
+ * Gate callback injected from the host.
+ *
+ * Returns true when proactive mode is allowed for this workspace. The
+ * host wires this to `isEnterpriseEnabled() && workspaceFlag` so the
+ * plugin itself does not import `@atlas/ee`.
+ */
+export type ProactiveGateFn = () => boolean | Promise<boolean>;


### PR DESCRIPTION
Closes #2292 — part of milestone 1.5.0 — Proactive Chat (PRD #2291).

## Summary

- Subscribes `@useatlas/chat` to channel-message events (Chat SDK `onNewMessage(/.+/, ...)`)
- Runs each message through a pure `MessageClassifier` (regex prefilter → injected LLM)
- A pure `InterjectionPolicy` decides `react` vs `skip` based on classification × channel × workspace × recent activity
- When policy says react, adds 🤖 to the message — Atlas does **not** reply yet (that lands in #2293)
- Gated by host-supplied `proactive.isEnabled` (`isEnterpriseEnabled() && workspaceFlag`) so plugins/chat never imports `@atlas/ee`
- Channel allowlist comes from `ATLAS_PROACTIVE_CHANNELS` for this slice; admin UI lands in #2294

## Acceptance criteria

- [x] `@useatlas/chat` subscribes to channel-message events from the Slack adapter (`chat.onNewMessage(/.+/, ...)`)
- [x] `MessageClassifier` module (pure, unit-tested) wraps regex pre-filter + LLM behind a single function returning `{ isQuestion, confidence, reasoning }`
- [x] `InterjectionPolicy` module (pure, unit-tested) returns `{ action: "react" | "skip", reason }`
- [x] When policy returns `react`, a 🤖 reaction is added via `thread.createSentMessageFromMessage(message).addReaction(emoji.custom("robot_face"))`
- [x] Channel allowlist read from `ATLAS_PROACTIVE_CHANNELS` env var
- [x] Proactive paths gate on host-supplied `isEnabled()` — host wires this to `isEnterpriseEnabled() && workspaceFlag`
- [x] Unit tests: `MessageClassifier` (regex boundary, candidate selection, LLM-call gating, LLM mocked); `InterjectionPolicy` (truth-table over confidence × config × recent activity)
- [x] Listener tests (gate flipped mid-flight, bot suppression, rate-limit, addReaction failure swallowed)

## Files

- `plugins/chat/src/proactive/types.ts` — pure shape definitions
- `plugins/chat/src/proactive/classifier.ts` — `regexPreFilter`, `classifyMessage`
- `plugins/chat/src/proactive/policy.ts` — `decideInterjection`, sensitivity thresholds, rate-limit window
- `plugins/chat/src/proactive/listener.ts` — `registerProactiveListener` wiring, allowlist resolution
- `plugins/chat/src/proactive/index.ts` — public re-exports
- `plugins/chat/src/config.ts` — `ProactiveConfig` type + Zod schema added to `ChatConfigSchema`
- `plugins/chat/src/bridge.ts` — registers the listener inside `createChatBridge` when `proactive` is present
- `plugins/chat/src/index.ts` — public surface includes proactive exports
- `plugins/chat/src/bridge.test.ts` — `ProactiveConfig` schema validation tests

## Test plan

- [x] `bun test src/proactive/__tests__/` — 46 pass, 0 fail
- [x] `bun test src/` (full chat plugin) — 334 pass, 0 fail
- [x] `bun run lint` — clean (1 pre-existing warning in api/tests, unrelated)
- [x] `bun run type` — clean
- [x] `bun x syncpack lint` — `No issues found`
- [x] `bash scripts/check-template-drift.sh` — 580 files verified
- [x] `bash scripts/check-schema-drift.sh` — 69 migrations ↔ schema.ts, clean
- [x] `bash scripts/check-railway-watch.sh` — all COPY sources covered
- [x] `bash scripts/check-security-headers-drift.sh` — clean
- [x] `bash scripts/check-oauth-helper-drift.sh` — clean
- [x] `bun run scripts/test-isolated.ts --affected` from `packages/api` — 50/50 pass
- [ ] Manual demo: configure a workspace with `proactive.enabled = true`, `ATLAS_PROACTIVE_CHANNELS=<C-id>`, send a question → see 🤖

## Out of scope (later slices)

- Reaction-to-answer flow (#2293)
- Admin opt-in console + persisted workspace config (#2294)
- Kill switches (`@atlas pause`, admin per-channel, workspace-wide) (#2295)
- Audit log + meter wiring (#2296)
- Sensitivity preset admin UI (#2299)
- Activation announcement + install consent (#2300)
- Public dataset for non-linked askers (#2297 — HITL design review)
- Feedback buttons + `/atlas feedback` (#2298)
- Monthly quota cap (#2301)