### PR TITLE
feat(api): #2517 — agent system prompt teaches `executeSQL` scope decision

### DIFF
--- a/packages/api/src/lib/__tests__/agent-scope-prompt.test.ts
+++ b/packages/api/src/lib/__tests__/agent-scope-prompt.test.ts
@@ -1,0 +1,346 @@
+/**
+ * Slice 2 tests for the system-prompt scope-decision guidance
+ * (PRD #2515, slice 2 #2517).
+ *
+ * Two layers:
+ *   1. Prompt-content tests via `buildSystemParam`: assert the cross-env
+ *      routing section appears when `routingContext.members.length > 1` and
+ *      is absent otherwise (single-member workspaces / no routing context).
+ *      The "member ids surfaced" criterion is checked by asserting every
+ *      member id appears in the rendered prompt.
+ *   2. Mocked-LLM integration: assert the agent's executeSQL invocation
+ *      fans out for a comparative-emit, routes to a specific member for a
+ *      region-named-emit, and stays single for ambiguous-emit. The mock
+ *      emits the expected `scope` value (it doesn't actually decide based
+ *      on prompt content); the test verifies the END-TO-END behaviour that
+ *      slice 2 unlocks — system prompt → tool call → fanout/single.
+ */
+
+import { describe, expect, it, beforeEach, afterEach, mock } from "bun:test";
+import {
+  MockLanguageModelV3,
+  convertArrayToReadableStream,
+} from "ai/test";
+import type { LanguageModelV3StreamPart } from "@ai-sdk/provider";
+import type { UIMessage } from "ai";
+import { createConnectionMock } from "@atlas/api/testing/connection";
+
+process.env.ATLAS_DATASOURCE_URL = "postgresql://test:test@localhost:5432/test";
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+let mockModel: InstanceType<typeof MockLanguageModelV3>;
+let lastSystemPrompt: string | undefined;
+
+mock.module("@atlas/api/lib/providers", () => ({
+  getModel: () => mockModel,
+  getProviderType: () => "anthropic" as const,
+  getModelFromWorkspaceConfig: () => mockModel,
+  getWorkspaceProviderType: () => "anthropic" as const,
+  getDefaultProvider: () => "anthropic" as const,
+}));
+
+mock.module("@atlas/api/lib/semantic", () => ({
+  getOrgWhitelistedTables: () => new Set(),
+  loadOrgWhitelist: async () => new Map(),
+  invalidateOrgWhitelist: () => {},
+  getOrgSemanticIndex: async () => "",
+  invalidateOrgSemanticIndex: () => {},
+  _resetOrgWhitelists: () => {},
+  _resetOrgSemanticIndexes: () => {},
+  getWhitelistedTables: () => new Set(["orders"]),
+  _resetWhitelists: () => {},
+  getCrossSourceJoins: () => [],
+}));
+
+// Per-connection DB mock — distinct rows per member for the integration tests.
+const memberCallCounts = new Map<string, number>();
+function makeMockDB(id: string) {
+  return {
+    query: async () => {
+      memberCallCounts.set(id, (memberCallCounts.get(id) ?? 0) + 1);
+      return { columns: ["region"], rows: [{ region: id }] };
+    },
+    close: async () => {},
+  };
+}
+
+mock.module("@atlas/api/lib/db/connection", () =>
+  createConnectionMock({
+    getDB: () => makeMockDB("default"),
+    connections: {
+      get: (id: string) => makeMockDB(id ?? "default"),
+      getDefault: () => makeMockDB("default"),
+      getForOrg: (_orgId: string, id?: string) => makeMockDB(id ?? "default"),
+      getTargetHost: () => "localhost:5432",
+      describe: () => [
+        { id: "us-int", dbType: "postgres" as const },
+        { id: "eu", dbType: "postgres" as const },
+        { id: "apac", dbType: "postgres" as const },
+      ],
+    },
+  }),
+);
+
+// Inject a fixed routing context — three members, primary us-int.
+mock.module("@atlas/api/lib/env-routing/lookup", () => ({
+  loadGroupRoutingContext: async (_orgId: string | undefined, currentMember: string) => ({
+    groupId: "prod",
+    members: ["us-int", "eu", "apac"],
+    primaryMember: "us-int",
+    currentMember,
+  }),
+}));
+
+mock.module("@atlas/api/lib/cache/index", () => ({
+  getCache: () => ({ get: () => null, set: () => {}, stats: () => ({ hits: 0, misses: 0, entryCount: 0, maxSize: 1000, ttl: 300000 }) }),
+  buildCacheKey: () => "mock-key",
+  cacheEnabled: () => false,
+  getDefaultTtl: () => 300000,
+  flushCache: () => {},
+  setCacheBackend: () => {},
+  _resetCache: () => {},
+}));
+
+// Spy on the LLM `doStream` call so we can capture the rendered system prompt
+function makeSpyingModel(toolCallArgs: Record<string, unknown>): InstanceType<typeof MockLanguageModelV3> {
+  let streamIdx = 0;
+  const allSteps: LanguageModelV3StreamPart[][] = [
+    [
+      { type: "tool-call", toolCallId: "call-1", toolName: "executeSQL", input: JSON.stringify(toolCallArgs) },
+      {
+        type: "finish",
+        usage: {
+          inputTokens: { total: 10, noCache: 10, cacheRead: undefined, cacheWrite: undefined },
+          outputTokens: { total: 20, text: 20, reasoning: undefined },
+        },
+        finishReason: { unified: "tool-calls", raw: "tool_use" },
+      },
+    ],
+    [
+      { type: "text-delta", id: "text-0", delta: "Done." },
+      {
+        type: "finish",
+        usage: {
+          inputTokens: { total: 10, noCache: 10, cacheRead: undefined, cacheWrite: undefined },
+          outputTokens: { total: 20, text: 20, reasoning: undefined },
+        },
+        finishReason: { unified: "stop", raw: "end_turn" },
+      },
+    ],
+  ];
+  return new MockLanguageModelV3({
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    doStream: async (opts: any) => {
+      // Capture the first system message rendered into the LLM call so the
+      // prompt-content assertions can inspect it.
+      const systemMsg = opts?.prompt?.find((p: { role: string }) => p.role === "system");
+      if (systemMsg) {
+        const content = typeof systemMsg.content === "string"
+          ? systemMsg.content
+          : Array.isArray(systemMsg.content)
+            ? systemMsg.content.map((c: { text?: string }) => c.text ?? "").join("")
+            : "";
+        if (content) lastSystemPrompt = content;
+      }
+      if (streamIdx >= allSteps.length) {
+        return { stream: convertArrayToReadableStream(allSteps[allSteps.length - 1]) };
+      }
+      return { stream: convertArrayToReadableStream(allSteps[streamIdx++]) };
+    },
+  });
+}
+
+const { runAgent } = await import("@atlas/api/lib/agent");
+const { buildSystemParam } = await import("@atlas/api/lib/agent");
+const { withRequestContext } = await import("@atlas/api/lib/logger");
+
+function userMessages(content: string): UIMessage[] {
+  return [
+    {
+      id: "msg-1",
+      role: "user" as const,
+      parts: [{ type: "text" as const, text: content }],
+    },
+  ];
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function findToolResults(steps: any[], toolName: string): any[] {
+  const results: unknown[] = [];
+  for (const step of steps) {
+    if (!step.toolResults) continue;
+    for (const tr of step.toolResults) {
+      if (tr.toolName === toolName) results.push(tr.output);
+    }
+  }
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("buildSystemParam — scope guidance section (slice 2)", () => {
+  it("appends Cross-Environment Routing section when routingContext has >1 members", () => {
+    const result = buildSystemParam(
+      "openai",
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      {
+        members: ["us-int", "eu", "apac"],
+        currentMember: "us-int",
+        groupId: "prod",
+      },
+    );
+    expect(typeof result).toBe("string");
+    const prompt = result as string;
+    expect(prompt).toContain("Cross-Environment Routing");
+    // Every member id is surfaced so the agent can resolve regional names
+    expect(prompt).toContain("us-int");
+    expect(prompt).toContain("eu");
+    expect(prompt).toContain("apac");
+    // Scope semantics + conservative-default cue both make it into the prompt
+    expect(prompt).toContain("scope: \"all\"");
+    expect(prompt).toContain("scope: \"this\"");
+    expect(prompt).toContain("Conservative-by-default");
+  });
+
+  it("omits the scope guidance section when routingContext is absent", () => {
+    const result = buildSystemParam("openai");
+    expect(typeof result).toBe("string");
+    const prompt = result as string;
+    expect(prompt).not.toContain("Cross-Environment Routing");
+  });
+
+  it("omits the scope guidance section when routingContext has a single member", () => {
+    const result = buildSystemParam(
+      "openai",
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      { members: ["only"], currentMember: "only" },
+    );
+    const prompt = result as string;
+    expect(prompt).not.toContain("Cross-Environment Routing");
+  });
+
+  it("renders the current member as the anchor for `scope: \"this\"`", () => {
+    const result = buildSystemParam(
+      "openai",
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      {
+        members: ["us-int", "eu", "apac"],
+        currentMember: "eu",
+      },
+    );
+    const prompt = result as string;
+    expect(prompt).toMatch(/current member is `eu`/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Mocked-LLM integration — assert the wiring (prompt → tool-call → routing)
+// works end-to-end given each representative scope emission.
+// ---------------------------------------------------------------------------
+
+describe("agent integration — scope routing via mocked LLM (slice 2)", () => {
+  const savedSandboxUrl = process.env.ATLAS_SANDBOX_URL;
+
+  beforeEach(() => {
+    memberCallCounts.clear();
+    lastSystemPrompt = undefined;
+    process.env.ATLAS_DATASOURCE_URL = "postgresql://test:test@localhost:5432/test";
+    delete process.env.ATLAS_TABLE_WHITELIST;
+    delete process.env.ATLAS_SANDBOX_URL;
+  });
+
+  afterEach(() => {
+    if (savedSandboxUrl !== undefined) {
+      process.env.ATLAS_SANDBOX_URL = savedSandboxUrl;
+    }
+  });
+
+  it("comparative question + LLM emits scope: 'all' → fanout across every member, prompt carries the guidance", async () => {
+    mockModel = makeSpyingModel({
+      sql: "SELECT region FROM orders",
+      explanation: "Compare across regions",
+      scope: "all",
+    });
+
+    const result = await withRequestContext(
+      { requestId: "test-1", connectionId: "us-int", connectionGroupId: "prod" },
+      () => runAgent({ messages: userMessages("compare revenue across regions") }),
+    );
+    const steps = await result.steps;
+    const sqlResults = findToolResults(steps, "executeSQL");
+
+    expect(sqlResults).toHaveLength(1);
+    expect(sqlResults[0].success).toBe(true);
+    // Fanout exercised — every member ran exactly once
+    expect(memberCallCounts.get("us-int")).toBe(1);
+    expect(memberCallCounts.get("eu")).toBe(1);
+    expect(memberCallCounts.get("apac")).toBe(1);
+    // The system prompt rendered into the LLM call carries the scope guidance
+    expect(lastSystemPrompt).toContain("Cross-Environment Routing");
+    expect(lastSystemPrompt).toContain("us-int");
+    expect(lastSystemPrompt).toContain("eu");
+    expect(lastSystemPrompt).toContain("apac");
+  });
+
+  it("region-named question + LLM emits scope: 'eu' → single execution against eu", async () => {
+    mockModel = makeSpyingModel({
+      sql: "SELECT region FROM orders",
+      explanation: "EU sales last week",
+      scope: "eu",
+    });
+
+    const result = await withRequestContext(
+      { requestId: "test-2", connectionId: "us-int", connectionGroupId: "prod" },
+      () => runAgent({ messages: userMessages("EU sales last week") }),
+    );
+    const steps = await result.steps;
+    const sqlResults = findToolResults(steps, "executeSQL");
+
+    expect(sqlResults).toHaveLength(1);
+    expect(memberCallCounts.get("eu")).toBe(1);
+    expect(memberCallCounts.get("us-int") ?? 0).toBe(0);
+    expect(memberCallCounts.get("apac") ?? 0).toBe(0);
+  });
+
+  it("ambiguous question + LLM omits scope → single execution against the current member", async () => {
+    mockModel = makeSpyingModel({
+      sql: "SELECT region FROM orders",
+      explanation: "Show me orders",
+    });
+
+    const result = await withRequestContext(
+      { requestId: "test-3", connectionId: "us-int", connectionGroupId: "prod" },
+      () => runAgent({ messages: userMessages("show me orders") }),
+    );
+    const steps = await result.steps;
+    const sqlResults = findToolResults(steps, "executeSQL");
+
+    expect(sqlResults).toHaveLength(1);
+    // Only the current member ran (single-env path, no routing lookup)
+    expect(memberCallCounts.get("us-int")).toBe(1);
+    expect(memberCallCounts.get("eu") ?? 0).toBe(0);
+    expect(memberCallCounts.get("apac") ?? 0).toBe(0);
+  });
+
+  // Single-member coverage lives in the unit-test block above — asserting on
+  // the rendered prompt for the integration path would require swapping the
+  // module-level routing-context mock mid-suite, which doesn't compose with
+  // `runAgent` once it's been imported. The unit tests verify both
+  // `routingContext: undefined` and `routingContext.members: [x]` (current
+  // member only) omit the Cross-Environment Routing section, which is the
+  // same logical assertion at a stricter boundary.
+});

--- a/packages/api/src/lib/agent.ts
+++ b/packages/api/src/lib/agent.ts
@@ -36,6 +36,7 @@ import { getConfig } from "./config";
 import { createLogger, getRequestContext } from "./logger";
 import { getSetting } from "./settings";
 import { hasInternalDB, internalExecute } from "./db/internal";
+import { loadGroupRoutingContext } from "./env-routing/lookup";
 import { logUsageEvent } from "./metering";
 import { buildLearnedPatternsSection } from "./learn/pattern-cache";
 import { dispatchMutableHook } from "./plugins/hooks";
@@ -167,6 +168,68 @@ function filterAgentVisibleSources(sources: ConnectionMetadata[]): ConnectionMet
   return sources.filter((s) => s.id !== "default");
 }
 
+/**
+ * Active-group routing context passed into the system prompt builder so the
+ * agent can decide whether to set `scope` on `executeSQL` (PRD #2515 / slice 2
+ * #2517). When `members.length > 1`, the prompt gains a "Cross-Environment
+ * Routing" section listing every member id and the comparative-intent
+ * heuristics. Single-member groups see no prompt change — back-compat with
+ * pre-#2517 single-env workspaces.
+ */
+export interface ScopeRoutingContext {
+  /** Every member id of the conversation's active connection group. */
+  readonly members: readonly string[];
+  /** The conversation's currently-selected member id (anchors `scope: "this"`). */
+  readonly currentMember: string;
+  /** Active group id, for display only. */
+  readonly groupId?: string;
+}
+
+/**
+ * Build the "Cross-Environment Routing" prompt section. Returns an empty
+ * string when there's nothing to teach the agent (single-member groups,
+ * missing routing context). Pure — the upstream caller decides whether to
+ * append this to the system prompt.
+ *
+ * The guidance is conservative-by-default: single-environment cues collapse
+ * to `scope: "<that member>"`; ambiguous questions default to single
+ * execution against the current member. Fanout (`scope: "all"`) requires
+ * an explicit comparative cue so the agent doesn't burn N× tokens on a
+ * one-env question that happened to mention a region word.
+ */
+function buildScopeGuidanceSection(
+  routingContext: ScopeRoutingContext | undefined,
+): string {
+  if (!routingContext) return "";
+  const { members, currentMember } = routingContext;
+  if (members.length <= 1) return "";
+
+  const memberList = members.map((m) => `\`${m}\``).join(", ");
+  return `## Cross-Environment Routing (executeSQL \`scope\`)
+
+This conversation is in a multi-environment group with ${members.length} members: ${memberList}. The conversation's current member is \`${currentMember}\`.
+
+Each \`executeSQL\` call can carry a \`scope\` argument that decides which environment(s) the SQL runs against:
+
+- **\`scope: "this"\`** (or omitted) — runs against the current member \`${currentMember}\`. Default for single-environment questions.
+- **\`scope: "all"\`** — fans out across every member (${memberList}); the result merges all rows with a prepended \`__env__\` column so the agent can see per-environment values side by side.
+- **\`scope: "<member id>"\`** — routes to that specific member only. Use when the user names an environment.
+
+**When to set scope:**
+
+- **Comparative intent** — "trends across regions", "compare X by region", "side by side", "each environment", "all regions" — set \`scope: "all"\`.
+- **Single-environment cue** — "in EU", "production us-int", a region keyword used as the target — set \`scope: "<that member id>"\` (must match one of: ${memberList}).
+- **No routing cue / ambiguous** — be conservative: omit \`scope\` or set \`"this"\`. Single execution against the current member is the right default; you can ask a clarifying question if the question is genuinely ambiguous.
+
+**Conservative-by-default examples:**
+
+- "show me the EU schema for orders" → single execution (the user wants the EU schema, not a comparison). Use \`scope: "eu"\` if \`eu\` is a member, otherwise omit.
+- "compare order volume across regions" → \`scope: "all"\` (explicit comparative phrasing).
+- "show me orders" → omit \`scope\` (no routing cue — stick with the current member).
+
+The result of a fanned-out query carries an \`envContributions\` array describing each environment's row count, duration, and error (if any). Use it to surface partial failures to the user instead of silently treating a failed env as zero rows.`;
+}
+
 function buildMultiSourceSection(
   sources: ConnectionMetadata[],
 ): string {
@@ -233,7 +296,12 @@ const PYTHON_GUIDANCE = `
 
 **Chart guidance:** prefer \`_atlas_chart\` (interactive Recharts) for bar/line/pie charts. Use \`chart_path()\` only for advanced matplotlib visualizations that Recharts cannot render.`;
 
-function buildSystemPrompt(registry: ToolRegistry, orgSemanticIndex?: string, learnedPatternsSection?: string): string {
+function buildSystemPrompt(
+  registry: ToolRegistry,
+  orgSemanticIndex?: string,
+  learnedPatternsSection?: string,
+  routingContext?: ScopeRoutingContext,
+): string {
   let base = SYSTEM_PROMPT_PREFIX + "\n\n" + registry.describe() + "\n\n" + SYSTEM_PROMPT_SUFFIX;
 
   // Add Python guidance only when the tool is available
@@ -290,6 +358,12 @@ function buildSystemPrompt(registry: ToolRegistry, orgSemanticIndex?: string, le
   // Non-core dialects (clickhouse, snowflake, duckdb, salesforce, etc.)
   // are provided by plugins via appendDialectHints().
 
+  // Cross-environment routing guidance: only appears when the active group
+  // has >1 member (PRD #2515 / slice 2 #2517). Single-member groups omit
+  // the section so single-env workspaces see no prompt change.
+  const scopeGuidance = buildScopeGuidanceSection(routingContext);
+  if (scopeGuidance) prompt += "\n\n" + scopeGuidance;
+
   return appendDialectHints(prompt);
 }
 
@@ -313,8 +387,9 @@ export function buildSystemParam(
   warnings?: string[],
   orgSemanticIndex?: string,
   learnedPatternsSection?: string,
+  routingContext?: ScopeRoutingContext,
 ): string | SystemModelMessage {
-  let content = buildSystemPrompt(registry, orgSemanticIndex, learnedPatternsSection);
+  let content = buildSystemPrompt(registry, orgSemanticIndex, learnedPatternsSection, routingContext);
 
   if (warnings && warnings.length > 0) {
     content += "\n\n## Warnings\n\n" + warnings.map((w) => `- ${w}`).join("\n");
@@ -706,11 +781,27 @@ export async function runAgent({
   const rawTools = toolRegistry.getAll();
   const tools = wrapToolsWithHooks(rawTools, { userId: userId ?? undefined, conversationId });
 
+  // #2517 — load active-group routing context so the system prompt can
+  // teach the agent when to set `scope` on `executeSQL`. Falls back to
+  // a 1×1 result (no prompt section) when no group is bound or the
+  // lookup fails — single-env workspaces see no behavioural change.
+  let scopeRoutingContext: ScopeRoutingContext | undefined;
+  if (connectionId) {
+    const ctx = await loadGroupRoutingContext(orgId, connectionId);
+    if (ctx.members.length > 1) {
+      scopeRoutingContext = {
+        members: ctx.members,
+        currentMember: ctx.currentMember,
+        ...(ctx.groupId ? { groupId: ctx.groupId } : {}),
+      };
+    }
+  }
+
   let result;
   try {
     result = otelContext.with(agentCtx, () => streamText({
       model,
-      system: buildSystemParam(providerType, toolRegistry, warnings, orgSemanticIndex, learnedPatternsSection),
+      system: buildSystemParam(providerType, toolRegistry, warnings, orgSemanticIndex, learnedPatternsSection, scopeRoutingContext),
       messages: modelMessages,
       tools,
       temperature: 0.2,


### PR DESCRIPTION
## Summary

Slice 2/5 of [PRD #2515](https://github.com/AtlasDevHQ/atlas/issues/2515) — agent-decided cross-environment querying. This is the behaviour-flipping slice: after this lands, multi-member workspaces see the agent automatically route `executeSQL` based on the user's question.

Closes #2517.

## What changed

**System prompt — new "Cross-Environment Routing" section** (gated on `members.length > 1`)

- Lists every member id of the active group so the agent can resolve regional names.
- Documents the three `scope` modes (`"this"` / `"all"` / `"<member id>"`) with comparative-intent / single-environment-cue heuristics.
- Conservative-by-default cues: ambiguous questions stay single-execution; the prompt explicitly tells the agent to ask a clarifying question rather than burn N× tokens on a one-env question that mentions a region word.
- Single-member workspaces show no prompt change — `buildScopeGuidanceSection` returns an empty string when `routingContext` is absent or the group is 1×1.

**Wiring**

- `buildSystemPrompt` / `buildSystemParam` accept an optional `ScopeRoutingContext` parameter.
- `runAgent` calls `loadGroupRoutingContext` (slice 1) once at boot and threads the result through. Failures collapse to `undefined` → no prompt change.

**Tests**

- `agent-scope-prompt.test.ts`:
  - 4 unit tests over `buildSystemParam` (multi-member adds section, no context omits, single-member omits, current-member anchor renders correctly).
  - 3 mocked-LLM integration tests verify the END-TO-END wiring — `MockLanguageModelV3` emits the expected `scope` value, the agent's executeSQL pipeline routes accordingly, and the rendered system prompt is captured from `doStream` to assert content.
- All 38 affected isolated test files pass.

## Sequencing

After this PR merges, multi-member workspaces start seeing the agent emit `scope` automatically. Slice 3 (#2518) will wire the picker UI + `routing_mode` column to let users override; slice 4 (#2519) adds the audit linkage + `envContributions` wire format; slice 5 (#2520) closes the milestone with browser e2e.

## Test plan

- [x] `bun run lint` — pre-existing warning only (unrelated)
- [x] `bun run type` — zero errors
- [x] `cd packages/api && bun run scripts/test-isolated.ts --since main` — 38/38 pass
- [x] `bash scripts/check-schema-drift.sh` — passes (no migrations in this slice)
- [x] `bash scripts/check-template-drift.sh` — passes
- [x] `bash scripts/check-security-headers-drift.sh` — passes
- [x] `bash scripts/check-railway-watch.sh` — passes
- [x] `bash scripts/check-oauth-helper-drift.sh` — passes
- [x] `bun x syncpack lint` — no issues