### PR TITLE
feat(api,web): #2363 — tracer-bullet chat drawer + bound dashboard editor tools

### DIFF
--- a/.claude/research/architecture-wins.md
+++ b/.claude/research/architecture-wins.md
@@ -1754,3 +1754,37 @@ A new `boot-smoke` job in `.github/workflows/deploy-validation.yml` builds `depl
 - **`executeSQL`'s fanout dispatch** (`executeSqlFanout`) is ~45 lines — orchestration only, no merge logic inline.
 
 **Category:** Pure data-transformation module extracted ahead of the behaviour-flipping slice. The merger's interface (`MemberExecutionResult[]` → `MergedResult`) is the same shape slice 4 ships on the wire, so the type contract from the merger flows straight through to the SDK without a translation step.
+
+## 63. `boundChatContext` — conversation↔dashboard binding as one module (#2363)
+
+**Date:** 2026-05-17
+**Issue:** #2363 (1.4.6 tracer-bullet for the chat-as-dashboard-editor PRD #2362)
+**Milestone:** 1.4.6 — Chat as dashboard editor
+**Branch:** `feat/2363-tracer-bullet-drawer`
+
+**Before:** the chat-as-dashboard-editor PRD #2362 needs a chat drawer on `/dashboards/[id]` that runs against a "bound" agent — narrower tool surface, different system prompt, a per-turn card summary, and a way for subsequent turns to know "this conversation is editing dashboard X." The naive shape would have been three separate things: a body field on `/api/v1/chat`, an ad-hoc branch in `chat.ts` to swap the registry, and another branch in `agent.ts` to swap the prompt — all reaching across modules to coordinate. Plus a separate read path for the history tab (#2368) that re-implements the dashboard-scoped conversation lookup.
+
+**The win:** `lib/bound-chat-context.ts` is the single module that owns the relationship.
+
+- **`bindConversationToDashboard(conversationId, dashboardId, { orgId })`** — verifies the dashboard exists in the caller's org via `getDashboard` BEFORE writing the FK, then stamps `conversations.bound_dashboard_id`. Mirrors #2424's connectionGroupId pre-write gate exactly — same shape: trusted DB FK + untrusted-input org check at the application layer.
+- **`resolveBoundDashboard(conversationId, { orgId })`** — the route's *only* read path. Returns the dashboard + cards or one of three failure reasons (`not_bound`, `dashboard_missing`, `error`); the route treats each as "fall back to the default agent" so a missing dashboard never hard-fails a chat turn.
+- **`listSessionsForDashboard(dashboardId, orgId)`** — workspace-scoped session listing for the #2368 history tab. Same module, same idiom — readers reuse the exact same column the writer stamps, no helper duplication.
+- **`buildCardSummary(cards)`** is PURE.** Pure: takes a card array, returns a string. No DB, no Effect, no logger. The bound system prompt that `agent.ts` injects gets the same string the `getDashboardState` tool returns, so the agent's mental model of "what cards exist" is always consistent across in-context summary vs. on-demand tool call.
+- **`BOUND_AGENT_PROMPT_GUIDANCE`** is a string constant — the dashboard-composition rules (grid is 24 wide; KPI rows tall=4; trend cards w=12/24, h=8; chart-type heuristics) live as data, exported once, swapped in by `agent.ts:buildSystemPrompt` when the optional `boundDashboardContext` param is set.
+
+**Tools follow the same factory shape.** `createBoundDashboardTools({ dashboardId, orgId })` returns the six safe-op tool definitions closed over the resolved ids — the LLM cannot supply `dashboardId` itself, which is the *whole point* of binding. `buildBoundDashboardRegistry` composes them with `explore` + `executeSQL` into a frozen registry. The chat route's bound-mode branch is one swap: `toolRegistry = buildBoundDashboardRegistry(boundDashboardForAgent.toolContext)`.
+
+**What got unbundled:**
+- **"Is this conversation bound?" is now a one-line resolve, not a join scattered across two routes.** `chat.ts` calls `resolveBoundDashboard(conversationId, { orgId })`; `dashboards/[id]/sessions` (slice #2368) calls `listSessionsForDashboard(dashboardId, orgId)`. Same column, same module, no cross-route SQL duplication.
+- **The bound-mode system prompt is data, not code.** `BOUND_AGENT_PROMPT_GUIDANCE` is an export; agent.ts just picks the suffix based on the presence of `boundDashboardContext`. A future slice changing the dashboard-composition rules edits one constant.
+- **Test surface stays narrow.** Pure `buildCardSummary` gets a unit test with no DB. `bind` / `resolve` / `listSessions` each get tests against an injected mock pool (`_resetPool(mockPool)` — same idiom as `conversations.test.ts`); no `mock.module()` (`bun:test` deadlocks on async mock factories per [[feedback_bun_test_async_mock_module]]).
+- **Schema mirror is one column + one partial index.** `0073_conversation_bound_dashboard.sql` + matching `schema.ts` entry (drift check enforces in same PR). FK is `ON DELETE SET NULL` because the audit trail (sessions list) should survive dashboard delete.
+
+**Impact:**
+- **1 new module** (`lib/bound-chat-context.ts`, ~200 lines including the prompt constant) + 1 module for the tool factory (`lib/tools/bound-dashboard.ts`) + 1 for the registry (`lib/tools/bound-dashboard-registry.ts`).
+- **`agent.ts` changes:** 3 small edits — one new optional param (`boundDashboardContext`), one branch in `buildSystemPrompt` (swap suffix + prepend cardSummary), threaded through `buildSystemParam` + `runAgent`.
+- **`chat.ts` changes:** 1 new body field (`boundDashboardId`), one block to `bindConversationToDashboard` on create, one block to `resolveBoundDashboard` after load/create, one ternary to swap the registry, one spread to forward `boundDashboardContext`. No re-architecting of the existing routing / budget / persistence layers.
+- **Tests:** 11 cases in `bound-chat-context.test.ts` (bind / resolve / list / pure summary / prompt constant), 9 in `bound-dashboard.test.ts` (factory shape + each tool's happy/sad path).
+- **One frontend file** (`bound-chat-drawer.tsx`) drives the entire UI — uses `useChat` directly with a slim `DefaultChatTransport` that always carries `boundDashboardId`. The existing heavyweight `AtlasChat` stays untouched.
+
+**Category:** Deep module that absorbs a binding relationship + its tool factory + its prompt constant + its listing query. Same pattern as the win #58 → win #59 → win #60 chain — when a module's contract is "this is the only place that knows X," every reader downstream can be a one-line call. The PRD #2362 follow-ups (#2364 drafts, #2365 stage tracker, #2368 history, #2369 createDashboard) all consume this module without re-deriving the relationship.

--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -90,6 +90,10 @@
                   },
                   "connectionGroupId": {
                     "type": "string"
+                  },
+                  "boundDashboardId": {
+                    "type": "string",
+                    "format": "uuid"
                   }
                 },
                 "required": [

--- a/packages/api/src/api/routes/chat.ts
+++ b/packages/api/src/api/routes/chat.ts
@@ -42,6 +42,16 @@ import {
   resolveGroupForConnection,
   settleConversationSteps,
 } from "@atlas/api/lib/conversations";
+import {
+  bindConversationToDashboard,
+  resolveBoundDashboard,
+  buildCardSummary,
+} from "@atlas/api/lib/bound-chat-context";
+// `buildBoundDashboardRegistry` is loaded lazily inside the request
+// handler — it statically imports `tools/explore`, and existing tests
+// (e.g. action-permissions.test.ts) partial-mock `tools/explore`.
+// Keeping it dynamic mirrors the pattern used for the default
+// `buildRegistry` below.
 import { setStreamWriter, clearStreamWriter } from "@atlas/api/lib/tools/python-stream";
 import { getSetting } from "@atlas/api/lib/settings";
 import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
@@ -356,6 +366,15 @@ export const ChatRequestSchema = z.object({
    * follow-up turn.
    */
   connectionGroupId: z.string().optional(),
+  /**
+   * #2363 — bound dashboard editor. When the chat drawer opens on
+   * `/dashboards/[id]` the client supplies the dashboard id once (on
+   * the conversation-creating turn). The route stamps
+   * `conversations.bound_dashboard_id` and subsequent turns inherit
+   * the binding from the persisted row, so the field is optional on
+   * follow-up turns.
+   */
+  boundDashboardId: z.string().uuid().optional(),
 });
 
 // ---------------------------------------------------------------------------
@@ -685,6 +704,18 @@ chat.openapi(chatRoute, async (c) => {
   
         const messages = parsed.data.messages as UIMessage[];
         let conversationId = parsed.data.conversationId;
+        // #2363 — bound dashboard editor. The id supplied by the client
+        // is honored only on the conversation-creating turn (and only
+        // after dashboard org-ownership is verified inside
+        // `bindConversationToDashboard`). Follow-up turns ignore the
+        // body field and inherit the binding from the conversation row.
+        const requestedBoundDashboardId = parsed.data.boundDashboardId;
+        // Populated after conversation load/create when the row carries
+        // a `bound_dashboard_id`. Drives the bound-mode tool registry
+        // + system-prompt swap below.
+        let boundDashboardForAgent:
+          | { cardSummary: string; toolContext: { dashboardId: string; orgId: string | null | undefined } }
+          | null = null;
         // F-77 — track the upfront reservation so the post-stream
         // settlement can refund any unused budget. `null` means no
         // reservation was charged (cap disabled, new conversation, or
@@ -874,11 +905,63 @@ chat.openapi(chatRoute, async (c) => {
                 if (firstUserMsg) {
                   addMessage({ conversationId, role: "user", content: firstUserMsg.parts });
                 }
+                // #2363 — stamp the bound-dashboard pointer immediately
+                // after creation, BEFORE the agent runs, so the first
+                // turn already sees the bound-mode registry. Best-effort:
+                // a bind failure (dashboard not found / cross-org / DB
+                // glitch) logs + falls back to the default agent loop.
+                // The drawer client will see the empty card summary on
+                // its next refresh and can prompt the user to retry.
+                if (requestedBoundDashboardId) {
+                  const bound = await bindConversationToDashboard(
+                    conversationId,
+                    requestedBoundDashboardId,
+                    { orgId: authResult.user?.activeOrganizationId },
+                  );
+                  if (!bound.ok) {
+                    log.warn(
+                      {
+                        requestId,
+                        conversationId,
+                        dashboardId: requestedBoundDashboardId,
+                        reason: bound.reason,
+                      },
+                      "Failed to bind conversation to dashboard — chat will run unbound",
+                    );
+                  }
+                }
               }
             } catch (err) {
               log.warn({ err: err instanceof Error ? err.message : String(err) }, "Failed to create conversation");
             }
           }
+        }
+
+        // #2363 — resolve the bound dashboard (if any) AFTER conversation
+        // load/create. Reads the persisted `bound_dashboard_id` so
+        // follow-up turns inherit the binding without resending it.
+        // Falls back to the default agent when the resolve returns
+        // `not_bound` / `dashboard_missing` (deleted between turns) /
+        // `error` — the route never hard-fails on a binding lookup.
+        if (conversationId) {
+          const resolved = await resolveBoundDashboard(conversationId, {
+            orgId: authResult.user?.activeOrganizationId,
+          });
+          if (resolved.ok) {
+            boundDashboardForAgent = {
+              cardSummary: buildCardSummary(resolved.dashboard.cards),
+              toolContext: {
+                dashboardId: resolved.dashboard.id,
+                orgId: authResult.user?.activeOrganizationId,
+              },
+            };
+          } else if (resolved.reason === "error") {
+            log.warn(
+              { requestId, conversationId, reason: resolved.reason },
+              "resolveBoundDashboard failed — falling back to default agent",
+            );
+          }
+          // not_bound / no_db / dashboard_missing → silent fallback to default agent
         }
   
         try {
@@ -904,27 +987,44 @@ chat.openapi(chatRoute, async (c) => {
             }
           }
   
-          // Merge plugin tools (if any) on top of the current registry
-          const prePluginRegistry = toolRegistry;
-          try {
-            const { getPluginTools } = await import("@atlas/api/lib/plugins/tools");
-            const pluginTools = getPluginTools();
-            if (pluginTools) {
-              const { ToolRegistry, defaultRegistry } = await import("@atlas/api/lib/tools/registry");
-              const base = toolRegistry ?? defaultRegistry;
-              toolRegistry = ToolRegistry.merge(base, pluginTools);
-              toolRegistry.freeze();
+          // Merge plugin tools (if any) on top of the current registry.
+          // #2363 — skip the merge entirely when the agent is bound to a
+          // dashboard. The bound editor surface is intentionally narrow
+          // (explore + executeSQL + 6 editor tools) and plugin / action
+          // tools just confuse the model mid-edit. The bound registry
+          // is built fresh below.
+          if (!boundDashboardForAgent) {
+            const prePluginRegistry = toolRegistry;
+            try {
+              const { getPluginTools } = await import("@atlas/api/lib/plugins/tools");
+              const pluginTools = getPluginTools();
+              if (pluginTools) {
+                const { ToolRegistry, defaultRegistry } = await import("@atlas/api/lib/tools/registry");
+                const base = toolRegistry ?? defaultRegistry;
+                toolRegistry = ToolRegistry.merge(base, pluginTools);
+                toolRegistry.freeze();
+              }
+            } catch (err) {
+              toolRegistry = prePluginRegistry;
+              const errObj = err instanceof Error ? err : new Error(String(err));
+              log.error(
+                { err: errObj },
+                "Failed to merge plugin tools — continuing without plugin tools",
+              );
+              warnings.push(
+                `Plugin tools failed to load: ${errObj.message}. Chat will continue without plugin tools. Inform the user that plugin-provided tools are unavailable for this session.`,
+              );
             }
-          } catch (err) {
-            toolRegistry = prePluginRegistry;
-            const errObj = err instanceof Error ? err : new Error(String(err));
-            log.error(
-              { err: errObj },
-              "Failed to merge plugin tools — continuing without plugin tools",
+          } else {
+            // Bound mode — replace the registry entirely with the
+            // dashboard editor toolset. Dropping action / plugin /
+            // python tools is the whole point of binding. Dynamic
+            // import keeps `tools/explore` out of chat.ts's static
+            // graph so partial-mock tests stay green.
+            const { buildBoundDashboardRegistry } = await import(
+              "@atlas/api/lib/tools/bound-dashboard-registry"
             );
-            warnings.push(
-              `Plugin tools failed to load: ${errObj.message}. Chat will continue without plugin tools. Inform the user that plugin-provided tools are unavailable for this session.`,
-            );
+            toolRegistry = buildBoundDashboardRegistry(boundDashboardForAgent.toolContext);
           }
   
           // #1988 B5 — out-array the agent's preflight loaders push into
@@ -968,6 +1068,9 @@ chat.openapi(chatRoute, async (c) => {
                 conversationId,
                 ...(warnings.length > 0 && { warnings }),
                 contextWarnings,
+                ...(boundDashboardForAgent && {
+                  boundDashboardContext: { cardSummary: boundDashboardForAgent.cardSummary },
+                }),
               }),
           );
   

--- a/packages/api/src/lib/__tests__/bound-chat-context.test.ts
+++ b/packages/api/src/lib/__tests__/bound-chat-context.test.ts
@@ -1,0 +1,380 @@
+/**
+ * Unit tests for the bound chat context module (#2363).
+ *
+ * Uses the `_resetPool(mockPool)` injection pattern (same as
+ * conversations.test.ts) — `mock.module()` deadlocks under bun's
+ * full suite (see feedback_bun_test_async_mock_module.md).
+ */
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { _resetPool, type InternalPool } from "../db/internal";
+import {
+  bindConversationToDashboard,
+  resolveBoundDashboard,
+  listSessionsForDashboard,
+  buildCardSummary,
+  BOUND_AGENT_PROMPT_GUIDANCE,
+} from "../bound-chat-context";
+import type { DashboardCard } from "../dashboard-types";
+
+// ---------------------------------------------------------------------------
+// Mock pool
+// ---------------------------------------------------------------------------
+
+interface QueryRecording {
+  sql: string;
+  params?: unknown[];
+}
+
+interface QueryResult {
+  rows: Record<string, unknown>[];
+}
+
+let queryCalls: QueryRecording[] = [];
+let queryResults: QueryResult[] = [];
+let queryResultIndex = 0;
+let queryThrow: Error | null = null;
+
+const mockPool: InternalPool = {
+  query: async (sql: string, params?: unknown[]) => {
+    if (queryThrow) throw queryThrow;
+    queryCalls.push({ sql, params });
+    const result = queryResults[queryResultIndex] ?? { rows: [] };
+    queryResultIndex++;
+    return result;
+  },
+  async connect() {
+    return { query: async () => ({ rows: [] }), release() {} };
+  },
+  end: async () => {},
+  on: () => {},
+};
+
+function enableInternalDB() {
+  process.env.DATABASE_URL = "postgresql://test:test@localhost:5432/test";
+  _resetPool(mockPool);
+}
+
+function setResults(...results: QueryResult[]) {
+  queryResults = results;
+  queryResultIndex = 0;
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+describe("bound-chat-context module", () => {
+  const origDbUrl = process.env.DATABASE_URL;
+
+  beforeEach(() => {
+    queryCalls = [];
+    queryResults = [];
+    queryResultIndex = 0;
+    queryThrow = null;
+    delete process.env.DATABASE_URL;
+    _resetPool(null);
+  });
+
+  afterEach(() => {
+    if (origDbUrl) process.env.DATABASE_URL = origDbUrl;
+    else delete process.env.DATABASE_URL;
+    _resetPool(null);
+  });
+
+  // -------------------------------------------------------------------
+  // buildCardSummary (pure)
+  // -------------------------------------------------------------------
+
+  describe("buildCardSummary", () => {
+    it("returns a no-cards hint when the list is empty", () => {
+      const summary = buildCardSummary([]);
+      expect(summary).toContain("no cards yet");
+      expect(summary).toContain("addCard");
+    });
+
+    it("lists each card with id, title, chart type, position, and layout", () => {
+      const cards: DashboardCard[] = [
+        {
+          id: "card-1",
+          dashboardId: "dash-1",
+          position: 0,
+          title: "Weekly signups",
+          sql: "SELECT 1",
+          chartConfig: { type: "line", categoryColumn: "week", valueColumns: ["count"] },
+          cachedColumns: null,
+          cachedRows: null,
+          cachedAt: null,
+          connectionGroupId: null,
+          layout: { x: 0, y: 0, w: 12, h: 8 },
+          createdAt: "2026-05-17",
+          updatedAt: "2026-05-17",
+        },
+        {
+          id: "card-2",
+          dashboardId: "dash-1",
+          position: 1,
+          title: "Active users",
+          sql: "SELECT 2",
+          chartConfig: null,
+          cachedColumns: null,
+          cachedRows: null,
+          cachedAt: null,
+          connectionGroupId: null,
+          layout: null,
+          createdAt: "2026-05-17",
+          updatedAt: "2026-05-17",
+        },
+      ];
+      const summary = buildCardSummary(cards);
+      expect(summary).toContain("[card-1] \"Weekly signups\" — line — pos=0 — x=0,y=0,w=12,h=8");
+      // Card without chartConfig falls back to "table"; without layout to "auto-laid"
+      expect(summary).toContain("[card-2] \"Active users\" — table — pos=1 — auto-laid");
+      expect(summary).toContain("2 cards");
+    });
+  });
+
+  // -------------------------------------------------------------------
+  // bindConversationToDashboard
+  // -------------------------------------------------------------------
+
+  describe("bindConversationToDashboard", () => {
+    it("returns no_db when internal DB is unavailable", async () => {
+      const result = await bindConversationToDashboard("conv-1", "dash-1", { orgId: "org-1" });
+      expect(result).toEqual({ ok: false, reason: "no_db" });
+    });
+
+    it("returns dashboard_not_found when org-scoped dashboard lookup misses", async () => {
+      enableInternalDB();
+      // getDashboard issues two queries (dashboard row, then cards). When the
+      // first returns zero rows the function short-circuits to not_found
+      // before the cards query runs, so a single empty result is enough.
+      setResults({ rows: [] });
+      const result = await bindConversationToDashboard("conv-1", "dash-1", { orgId: "org-1" });
+      expect(result).toEqual({ ok: false, reason: "dashboard_not_found" });
+    });
+
+    it("writes bound_dashboard_id when the org check passes", async () => {
+      enableInternalDB();
+      // Result 1: dashboard row (org-scoped). Result 2: cards. Result 3: UPDATE returning id.
+      setResults(
+        {
+          rows: [
+            {
+              id: "dash-1",
+              org_id: "org-1",
+              owner_id: "user-1",
+              title: "Demo",
+              description: null,
+              share_token: null,
+              share_expires_at: null,
+              share_mode: "public",
+              refresh_schedule: null,
+              last_refresh_at: null,
+              next_refresh_at: null,
+              card_count: 0,
+              created_at: "2026-05-17",
+              updated_at: "2026-05-17",
+            },
+          ],
+        },
+        { rows: [] },
+        { rows: [{ id: "conv-1" }] },
+      );
+      const result = await bindConversationToDashboard("conv-1", "dash-1", { orgId: "org-1" });
+      expect(result).toEqual({ ok: true });
+      // Last query is the UPDATE writing bound_dashboard_id
+      const updateCall = queryCalls[queryCalls.length - 1];
+      expect(updateCall.sql).toMatch(/UPDATE conversations/i);
+      expect(updateCall.sql).toMatch(/bound_dashboard_id/i);
+      expect(updateCall.params).toEqual(["dash-1", "conv-1"]);
+    });
+
+    it("returns conversation_not_found when the UPDATE matches zero rows", async () => {
+      enableInternalDB();
+      setResults(
+        {
+          rows: [
+            {
+              id: "dash-1",
+              org_id: "org-1",
+              owner_id: "user-1",
+              title: "Demo",
+              description: null,
+              share_token: null,
+              share_expires_at: null,
+              share_mode: "public",
+              refresh_schedule: null,
+              last_refresh_at: null,
+              next_refresh_at: null,
+              card_count: 0,
+              created_at: "2026-05-17",
+              updated_at: "2026-05-17",
+            },
+          ],
+        },
+        { rows: [] }, // cards
+        { rows: [] }, // UPDATE returned nothing — conversation row missing
+      );
+      const result = await bindConversationToDashboard("ghost-conv", "dash-1", { orgId: "org-1" });
+      expect(result).toEqual({ ok: false, reason: "conversation_not_found" });
+    });
+  });
+
+  // -------------------------------------------------------------------
+  // resolveBoundDashboard
+  // -------------------------------------------------------------------
+
+  describe("resolveBoundDashboard", () => {
+    it("returns not_bound when the conversation has no bound_dashboard_id", async () => {
+      enableInternalDB();
+      setResults({ rows: [{ bound_dashboard_id: null }] });
+      const r = await resolveBoundDashboard("conv-1", { orgId: "org-1" });
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.reason).toBe("not_bound");
+    });
+
+    it("returns not_bound when the conversation row is missing", async () => {
+      enableInternalDB();
+      setResults({ rows: [] });
+      const r = await resolveBoundDashboard("ghost", { orgId: "org-1" });
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.reason).toBe("not_bound");
+    });
+
+    it("returns dashboard_missing when the bound dashboard is gone / cross-org", async () => {
+      enableInternalDB();
+      setResults(
+        { rows: [{ bound_dashboard_id: "dash-X" }] }, // conversation lookup
+        { rows: [] }, // dashboard lookup misses
+      );
+      const r = await resolveBoundDashboard("conv-1", { orgId: "org-1" });
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.reason).toBe("dashboard_missing");
+    });
+
+    it("returns the dashboard + cards on success", async () => {
+      enableInternalDB();
+      setResults(
+        { rows: [{ bound_dashboard_id: "dash-1" }] },
+        {
+          rows: [
+            {
+              id: "dash-1",
+              org_id: "org-1",
+              owner_id: "user-1",
+              title: "Demo",
+              description: "Test",
+              share_token: null,
+              share_expires_at: null,
+              share_mode: "public",
+              refresh_schedule: null,
+              last_refresh_at: null,
+              next_refresh_at: null,
+              card_count: 1,
+              created_at: "2026-05-17",
+              updated_at: "2026-05-17",
+            },
+          ],
+        },
+        {
+          rows: [
+            {
+              id: "card-1",
+              dashboard_id: "dash-1",
+              position: 0,
+              title: "KPI",
+              sql: "SELECT 1",
+              chart_config: null,
+              cached_columns: null,
+              cached_rows: null,
+              cached_at: null,
+              connection_group_id: null,
+              layout: null,
+              created_at: "2026-05-17",
+              updated_at: "2026-05-17",
+            },
+          ],
+        },
+      );
+      const r = await resolveBoundDashboard("conv-1", { orgId: "org-1" });
+      expect(r.ok).toBe(true);
+      if (r.ok) {
+        expect(r.dashboard.id).toBe("dash-1");
+        expect(r.dashboard.cards).toHaveLength(1);
+        expect(r.dashboard.cards[0].id).toBe("card-1");
+      }
+    });
+  });
+
+  // -------------------------------------------------------------------
+  // listSessionsForDashboard
+  // -------------------------------------------------------------------
+
+  describe("listSessionsForDashboard", () => {
+    it("returns [] when internal DB is unavailable", async () => {
+      const rows = await listSessionsForDashboard("dash-1", "org-1");
+      expect(rows).toEqual([]);
+    });
+
+    it("scopes to (dashboardId, orgId-or-NULL) and maps row shape", async () => {
+      enableInternalDB();
+      setResults({
+        rows: [
+          {
+            id: "conv-1",
+            user_id: "user-1",
+            title: "First session",
+            created_at: "2026-05-17T10:00:00Z",
+            updated_at: "2026-05-17T10:30:00Z",
+            message_count: 4,
+          },
+          {
+            id: "conv-2",
+            user_id: null,
+            title: null,
+            created_at: "2026-05-17T11:00:00Z",
+            updated_at: "2026-05-17T11:00:00Z",
+            message_count: "0", // PG returns COALESCE(COUNT(*), 0) as text in some configs
+          },
+        ],
+      });
+      const rows = await listSessionsForDashboard("dash-1", "org-1");
+      expect(rows).toHaveLength(2);
+      expect(rows[0]).toMatchObject({
+        conversationId: "conv-1",
+        userId: "user-1",
+        title: "First session",
+        messageCount: 4,
+      });
+      expect(rows[1].messageCount).toBe(0); // string "0" coerced
+      // Predicate threads dashboardId + orgId + org-IS-NULL fallback
+      const sentSql = queryCalls[0].sql;
+      expect(sentSql).toMatch(/bound_dashboard_id = \$1/);
+      expect(sentSql).toMatch(/c\.org_id = \$2 OR c\.org_id IS NULL/);
+      expect(queryCalls[0].params).toEqual(["dash-1", "org-1"]);
+    });
+
+    it("omits the org clause when no orgId is supplied", async () => {
+      enableInternalDB();
+      setResults({ rows: [] });
+      await listSessionsForDashboard("dash-1", null);
+      const sentSql = queryCalls[0].sql;
+      expect(sentSql).not.toMatch(/c\.org_id/);
+      expect(queryCalls[0].params).toEqual(["dash-1"]);
+    });
+  });
+
+  // -------------------------------------------------------------------
+  // BOUND_AGENT_PROMPT_GUIDANCE — sanity check that the export carries
+  // the composition rules so the agent.ts swap is meaningful.
+  // -------------------------------------------------------------------
+
+  describe("BOUND_AGENT_PROMPT_GUIDANCE", () => {
+    it("contains the dashboard-composition rules", () => {
+      expect(BOUND_AGENT_PROMPT_GUIDANCE).toContain("24 columns wide");
+      expect(BOUND_AGENT_PROMPT_GUIDANCE).toContain("addCard");
+      expect(BOUND_AGENT_PROMPT_GUIDANCE).toContain("updateCard");
+      expect(BOUND_AGENT_PROMPT_GUIDANCE).toContain("Suggested Follow-ups");
+    });
+  });
+});

--- a/packages/api/src/lib/agent.ts
+++ b/packages/api/src/lib/agent.ts
@@ -47,6 +47,7 @@ import {
   context as otelContext,
 } from "@opentelemetry/api";
 import { AtlasAiModel, type AtlasAiModelShape } from "./effect/ai";
+import { BOUND_AGENT_PROMPT_GUIDANCE } from "./bound-chat-context";
 
 const log = createLogger("agent");
 const tracer = trace.getTracer("atlas");
@@ -296,13 +297,30 @@ const PYTHON_GUIDANCE = `
 
 **Chart guidance:** prefer \`_atlas_chart\` (interactive Recharts) for bar/line/pie charts. Use \`chart_path()\` only for advanced matplotlib visualizations that Recharts cannot render.`;
 
+/**
+ * #2363 — bound dashboard editor context. When supplied, the agent
+ * swaps the generic data-analyst suffix for the dashboard-composition
+ * guidance and prepends a compact per-turn card summary so the model
+ * can reason about the cards by id without a `getDashboardState`
+ * round trip.
+ */
+export interface BoundDashboardAgentContext {
+  /** Pre-built compact card summary string from `buildCardSummary`. */
+  cardSummary: string;
+}
+
 function buildSystemPrompt(
   registry: ToolRegistry,
   orgSemanticIndex?: string,
   learnedPatternsSection?: string,
   routingContext?: ScopeRoutingContext,
+  boundDashboardContext?: BoundDashboardAgentContext,
 ): string {
-  let base = SYSTEM_PROMPT_PREFIX + "\n\n" + registry.describe() + "\n\n" + SYSTEM_PROMPT_SUFFIX;
+  const suffix = boundDashboardContext ? BOUND_AGENT_PROMPT_GUIDANCE : SYSTEM_PROMPT_SUFFIX;
+  let base = SYSTEM_PROMPT_PREFIX + "\n\n" + registry.describe() + "\n\n" + suffix;
+  if (boundDashboardContext) {
+    base += "\n\n" + boundDashboardContext.cardSummary;
+  }
 
   // Add Python guidance only when the tool is available
   if (registry.get("executePython")) {
@@ -388,8 +406,9 @@ export function buildSystemParam(
   orgSemanticIndex?: string,
   learnedPatternsSection?: string,
   routingContext?: ScopeRoutingContext,
+  boundDashboardContext?: BoundDashboardAgentContext,
 ): string | SystemModelMessage {
-  let content = buildSystemPrompt(registry, orgSemanticIndex, learnedPatternsSection, routingContext);
+  let content = buildSystemPrompt(registry, orgSemanticIndex, learnedPatternsSection, routingContext, boundDashboardContext);
 
   if (warnings && warnings.length > 0) {
     content += "\n\n## Warnings\n\n" + warnings.map((w) => `- ${w}`).join("\n");
@@ -585,6 +604,7 @@ export async function runAgent({
   maxSteps: maxStepsOverride,
   /** Optional pre-resolved AI model. When provided, skips provider resolution. */
   aiModel: injectedAiModel,
+  boundDashboardContext,
 }: {
   messages: UIMessage[];
   tools?: ToolRegistry;
@@ -610,6 +630,13 @@ export async function runAgent({
   maxSteps?: number;
   /** Pre-resolved AI model from Effect Context (P10c). */
   aiModel?: AtlasAiModelShape;
+  /**
+   * #2363 — bound dashboard editor context. When set the agent swaps to
+   * the dashboard-composition prompt and injects a compact card summary.
+   * The chat route resolves this from `conversations.bound_dashboard_id`
+   * after the conversation is created / loaded.
+   */
+  boundDashboardContext?: BoundDashboardAgentContext;
 }) {
   // Capture context eagerly — AsyncLocalStorage may have exited by the time onFinish fires
   const reqCtx = getRequestContext();
@@ -801,7 +828,7 @@ export async function runAgent({
   try {
     result = otelContext.with(agentCtx, () => streamText({
       model,
-      system: buildSystemParam(providerType, toolRegistry, warnings, orgSemanticIndex, learnedPatternsSection, scopeRoutingContext),
+      system: buildSystemParam(providerType, toolRegistry, warnings, orgSemanticIndex, learnedPatternsSection, scopeRoutingContext, boundDashboardContext),
       messages: modelMessages,
       tools,
       temperature: 0.2,

--- a/packages/api/src/lib/auth/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/auth/__tests__/migrate.test.ts
@@ -318,6 +318,7 @@ describe("migrateAuthTables", () => {
             { name: "0070_rename_synthetic_global_group_names.sql" },
             { name: "0071_connection_groups_status.sql" },
             { name: "0072_cleanup_empty_synthetic_groups.sql" },
+            { name: "0073_conversation_bound_dashboard.sql" },
           ],
         };
       }

--- a/packages/api/src/lib/bound-chat-context.ts
+++ b/packages/api/src/lib/bound-chat-context.ts
@@ -1,0 +1,293 @@
+/**
+ * Bound chat context — conversation↔dashboard relationship for #2363.
+ *
+ * The chat-as-dashboard-editor drawer (PRD #2362) creates a fresh
+ * conversation bound to a dashboard. This module owns:
+ *
+ *   1. `bindConversationToDashboard` — stamps `conversations.bound_dashboard_id`
+ *      after verifying the dashboard belongs to the caller's org.
+ *   2. `resolveBoundDashboard` — reads the current bound dashboard for a
+ *      conversation, returning the dashboard row + cards. Used by chat.ts
+ *      to swap to the bound-mode tool registry and inject a per-turn card
+ *      summary.
+ *   3. `buildCardSummary` — pure helper. Compact id/title/chartType/position
+ *      string the system prompt injects so the agent can reason about cards
+ *      by natural reference ("the third card", "the bar chart") without a
+ *      round trip through `getDashboardState`.
+ *   4. `BOUND_AGENT_PROMPT_GUIDANCE` — system-prompt swap. The bound agent
+ *      is composing a dashboard, not answering an arbitrary question; the
+ *      generic data-analyst suffix gets replaced by composition rules
+ *      (grid is 24 wide; KPI rows tall=4; trend cards w=12/24, h=8;
+ *      chart-type heuristics).
+ *
+ * No HTTP / Hono concepts — the route layer wires this into chat.ts and
+ * `/api/v1/dashboards/[id]/sessions` (#2368).
+ */
+
+import { createLogger } from "@atlas/api/lib/logger";
+import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
+import { hasInternalDB, internalQuery } from "@atlas/api/lib/db/internal";
+import { getDashboard } from "@atlas/api/lib/dashboards";
+import type {
+  DashboardCard,
+  DashboardWithCards,
+} from "@atlas/api/lib/dashboard-types";
+
+const log = createLogger("bound-chat-context");
+
+/** Failure reasons callers may need to distinguish. */
+export type BindFailReason = "no_db" | "dashboard_not_found" | "conversation_not_found" | "error";
+
+export type BindResult = { ok: true } | { ok: false; reason: BindFailReason };
+
+export type ResolveResult =
+  | { ok: true; dashboard: DashboardWithCards }
+  | { ok: false; reason: "no_db" | "not_bound" | "dashboard_missing" | "error" };
+
+/**
+ * Bind a conversation row to a dashboard. Verifies the dashboard exists
+ * and belongs to `orgId` BEFORE writing — the FK in 0073 enforces dashboard
+ * existence at the row level, but the org check has to live here because
+ * `dashboards` and `conversations` share no org-scoping FK and a stale
+ * client could otherwise stamp a cross-org pointer.
+ */
+export async function bindConversationToDashboard(
+  conversationId: string,
+  dashboardId: string,
+  opts: { orgId?: string | null },
+): Promise<BindResult> {
+  if (!hasInternalDB()) return { ok: false, reason: "no_db" };
+
+  // Org-scoped dashboard existence check (mirrors #2424's connectionGroupId
+  // pre-write gate in the chat route).
+  const dash = await getDashboard(dashboardId, { orgId: opts.orgId ?? undefined });
+  if (!dash.ok) {
+    if (dash.reason === "not_found") return { ok: false, reason: "dashboard_not_found" };
+    if (dash.reason === "no_db") return { ok: false, reason: "no_db" };
+    return { ok: false, reason: "error" };
+  }
+
+  try {
+    const rows = await internalQuery<{ id: string }>(
+      `UPDATE conversations
+          SET bound_dashboard_id = $1
+        WHERE id = $2
+      RETURNING id`,
+      [dashboardId, conversationId],
+    );
+    if (rows.length === 0) return { ok: false, reason: "conversation_not_found" };
+    return { ok: true };
+  } catch (err) {
+    log.error(
+      { err: errorMessage(err), conversationId, dashboardId },
+      "bindConversationToDashboard failed",
+    );
+    return { ok: false, reason: "error" };
+  }
+}
+
+/**
+ * Read the dashboard a conversation is currently bound to, including
+ * its cards. Returns `not_bound` for conversations without a binding
+ * (the default for non-drawer chats) and `dashboard_missing` if the
+ * binding points at a dashboard that was deleted or no longer belongs
+ * to the caller's org (the latter is the cross-tenant safety net the
+ * route handler relies on — even though the FK enforces existence at
+ * the row level, ON DELETE SET NULL means the column eventually
+ * NULLs out and 'not_bound' is the expected state once it does).
+ */
+export async function resolveBoundDashboard(
+  conversationId: string,
+  opts: { orgId?: string | null },
+): Promise<ResolveResult> {
+  if (!hasInternalDB()) return { ok: false, reason: "no_db" };
+  try {
+    const rows = await internalQuery<{ bound_dashboard_id: string | null }>(
+      `SELECT bound_dashboard_id FROM conversations WHERE id = $1`,
+      [conversationId],
+    );
+    if (rows.length === 0) return { ok: false, reason: "not_bound" };
+    const boundId = rows[0]?.bound_dashboard_id ?? null;
+    if (!boundId) return { ok: false, reason: "not_bound" };
+
+    const dash = await getDashboard(boundId, { orgId: opts.orgId ?? undefined });
+    if (!dash.ok) {
+      // Dashboard either deleted between bind and read (FK SET NULL hasn't
+      // propagated through cache) OR no longer belongs to the caller's org.
+      // Either way the right surface to the caller is "treat as unbound" —
+      // the chat falls back to the default agent without the editor tools.
+      if (dash.reason === "not_found") return { ok: false, reason: "dashboard_missing" };
+      return { ok: false, reason: "error" };
+    }
+    return { ok: true, dashboard: dash.data };
+  } catch (err) {
+    log.error(
+      { err: errorMessage(err), conversationId },
+      "resolveBoundDashboard failed",
+    );
+    return { ok: false, reason: "error" };
+  }
+}
+
+/**
+ * List archived bound conversations for a dashboard, org-scoped.
+ *
+ * Powers the History tab in the drawer (#2368). Workspace-wide visibility
+ * matches the current dashboard ACL — anyone in the workspace who can
+ * view the dashboard sees the same sessions list.
+ */
+export interface BoundSessionSummary {
+  conversationId: string;
+  userId: string | null;
+  title: string | null;
+  createdAt: string;
+  updatedAt: string;
+  messageCount: number;
+}
+
+export async function listSessionsForDashboard(
+  dashboardId: string,
+  orgId: string | null | undefined,
+): Promise<BoundSessionSummary[]> {
+  if (!hasInternalDB()) return [];
+  try {
+    // org_id is allowed to be NULL on conversations (legacy / self-hosted
+    // single-tenant). Match the conventions in `scopeClause` from
+    // conversations.ts: `(org_id = $N OR org_id IS NULL)`.
+    const orgClause = orgId ? "AND (c.org_id = $2 OR c.org_id IS NULL)" : "";
+    const params: unknown[] = [dashboardId];
+    if (orgId) params.push(orgId);
+
+    const rows = await internalQuery<{
+      id: string;
+      user_id: string | null;
+      title: string | null;
+      created_at: Date | string;
+      updated_at: Date | string;
+      message_count: number | string;
+    }>(
+      `SELECT c.id, c.user_id, c.title, c.created_at, c.updated_at,
+              COALESCE(m.message_count, 0) AS message_count
+         FROM conversations c
+         LEFT JOIN (
+           SELECT conversation_id, COUNT(*) AS message_count
+             FROM messages
+            GROUP BY conversation_id
+         ) m ON m.conversation_id = c.id
+        WHERE c.bound_dashboard_id = $1
+          AND c.deleted_at IS NULL
+          ${orgClause}
+        ORDER BY c.created_at DESC
+        LIMIT 200`,
+      params,
+    );
+
+    return rows.map((r) => ({
+      conversationId: r.id,
+      userId: r.user_id,
+      title: r.title,
+      createdAt: String(r.created_at),
+      updatedAt: String(r.updated_at),
+      messageCount: typeof r.message_count === "number"
+        ? r.message_count
+        : parseInt(r.message_count, 10) || 0,
+    }));
+  } catch (err) {
+    log.error(
+      { err: errorMessage(err), dashboardId, orgId },
+      "listSessionsForDashboard failed",
+    );
+    return [];
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers — system prompt + per-turn card summary
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the compact per-turn card summary the bound agent sees in its
+ * system prompt. One line per card: id, title, chart type, grid position.
+ * Keeps the prompt small for dashboards with many cards — the agent
+ * calls `getCardDetail(id)` for the full SQL / chartConfig only when
+ * it needs to.
+ *
+ * Pure: takes cards in, returns a string. No DB, no Effect, no logger.
+ */
+export function buildCardSummary(cards: readonly DashboardCard[]): string {
+  if (cards.length === 0) {
+    return "## Current dashboard state\n\nThis dashboard has no cards yet. Use `addCard` to create the first one.";
+  }
+  const lines = cards.map((c) => {
+    const chartType = c.chartConfig?.type ?? "table";
+    const layout = c.layout
+      ? `x=${c.layout.x},y=${c.layout.y},w=${c.layout.w},h=${c.layout.h}`
+      : "auto-laid";
+    return `- [${c.id}] "${c.title}" — ${chartType} — pos=${c.position} — ${layout}`;
+  });
+  return [
+    "## Current dashboard state",
+    "",
+    `${cards.length} card${cards.length === 1 ? "" : "s"} — id, title, chart type, position, layout:`,
+    "",
+    ...lines,
+    "",
+    "Refer to cards by id when calling tools. The user may reference them naturally (\"the third card\", \"the bar chart\", \"the signups one\") — match against this list.",
+  ].join("\n");
+}
+
+/**
+ * Dashboard-composition guidance — replaces the generic
+ * data-analyst suffix when the agent is bound to a dashboard.
+ *
+ * The grid constants here mirror `DASHBOARD_GRID` in
+ * `packages/api/src/lib/dashboard-types.ts`. Hand-duplicated rather
+ * than imported to keep this string purely declarative — if the
+ * grid changes, this prompt has to be re-tuned anyway.
+ */
+export const BOUND_AGENT_PROMPT_GUIDANCE = `You are editing a saved dashboard, not answering an ad-hoc question. The user opened a chat drawer on this dashboard; every conversation turn should make a concrete edit (add a card, rename, change chart type, rearrange) or explain an existing card.
+
+## Editing Workflow
+
+1. **Identify what the user wants changed.** Use the compact card summary in the system prompt to map natural references ("card 3", "the bar chart", "the signups one") to card ids. If ambiguous, ask a short clarifying question before mutating.
+2. **For new cards:** use \`explore\` + \`executeSQL\` to verify the query shape against the semantic layer, THEN call \`addCard\` with title + sql + chartConfig. Never call \`addCard\` with SQL you haven't validated — the tool rejects invalid queries but the failure surfaces in the user's UI.
+3. **For changes to existing cards:** call \`getCardDetail(id)\` first to read the current SQL / chartConfig if you need them. Then call \`updateCard\` with only the fields that change.
+4. **For layout changes:** call \`updateLayout\` with the full set of card placements you want. The grid is 24 columns wide and uses (x, y, w, h) per card.
+5. **For "what is this card?" questions:** call \`getCardDetail(id)\` and explain in plain language. Don't mutate.
+
+## Grid Layout
+
+- Grid is 24 columns wide. Heights are unlimited but the canvas only renders rows the cards occupy.
+- **KPI / small metric cards:** width 6–8, height 4.
+- **Trend / time-series charts:** width 12 (half row) or 24 (full row), height 8.
+- **Tables:** width 12–24, height 8–12.
+- Stack KPIs across a row at y=0 to give the dashboard a strong top.
+- New cards default to position 0,0 with auto-layout — call \`updateLayout\` explicitly if you want a specific arrangement.
+
+## Chart Type Heuristics
+
+- **bar**: comparison across discrete categories (top regions, top accounts).
+- **line / area**: change over time. Always require a time-typed category column.
+- **pie**: parts of a whole — use sparingly, only when the count of categories is small (<= 6).
+- **scatter**: relationships between two numeric columns.
+- **table**: detail-level rows, or when the user asks for a raw breakdown.
+
+## Semantic Layer
+
+Treat \`semantic/metrics/*.yml\` as authoritative. If a measure exists, use its SQL verbatim — do NOT hand-craft an aggregate that duplicates a named metric. Use \`explore\` to find metrics before writing custom SQL.
+
+## Tool Rules
+
+- \`getDashboardState\` returns the current dashboard meta + the same compact card summary the system prompt injects. Use it when you need a fresh read mid-conversation (e.g. after several mutations).
+- \`getCardDetail(id)\` is the only way to fetch a card's SQL / chartConfig — keep it scoped to the cards you actually need.
+- \`addCard\` / \`updateCard\` / \`updateLayout\` / \`updateDashboardMeta\` commit immediately to the dashboard. There is no undo in this tracer-bullet slice.
+- Do NOT call \`executeSQL\` to mutate data — it is read-only. Use it to validate a card's query before calling \`addCard\`.
+
+## Suggested Follow-ups
+
+After each substantive edit, end your response with a <suggestions> block containing 2–3 next-step suggestions the user might want. Format:
+<suggestions>
+Add a regional breakdown card
+Stack the KPIs across the top
+Make the trend cards into a single row
+</suggestions>`;

--- a/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
@@ -3220,4 +3220,68 @@ describeIfPg("migrate-pg (real Postgres)", () => {
     );
     expect(allowed[0]?.id).toBe(groupId);
   }, PG_TEST_TIMEOUT_MS);
+
+  // ─────────────────────────────────────────────────────────────────────
+  // 0073 — conversations.bound_dashboard_id (#2363)
+  //
+  // The chat-as-dashboard-editor drawer (PRD #2362) stamps this FK on the
+  // conversation row so subsequent turns inherit the binding and the
+  // history tab (#2368) can list sessions per dashboard. Two real-PG
+  // assertions matter:
+  //   1. Column shape — nullable uuid with the right FK target.
+  //   2. ON DELETE SET NULL behavior — deleting the dashboard preserves
+  //      the audit trail by NULLing the pointer instead of cascading
+  //      the conversation row away.
+  // ─────────────────────────────────────────────────────────────────────
+
+  it("0073: conversations.bound_dashboard_id is a nullable uuid (#2363)", async () => {
+    const { rows } = await pool.query<{
+      data_type: string;
+      is_nullable: string;
+      udt_name: string;
+    }>(
+      `SELECT data_type, is_nullable, udt_name
+         FROM information_schema.columns
+        WHERE table_name = 'conversations'
+          AND column_name = 'bound_dashboard_id'
+          AND table_schema = current_schema()`,
+    );
+    expect(rows[0]?.udt_name).toBe("uuid");
+    expect(rows[0]?.is_nullable).toBe("YES");
+  }, PG_TEST_TIMEOUT_MS);
+
+  it("0073: ON DELETE SET NULL preserves the conversation when its dashboard is removed (#2363)", async () => {
+    const stamp = Date.now();
+    const orgId = `org-2363-${stamp}`;
+    const dashRows = await pool.query<{ id: string }>(
+      `INSERT INTO dashboards (org_id, owner_id, title) VALUES ($1, 'u-2363', 'Bound test') RETURNING id`,
+      [orgId],
+    );
+    const dashboardId = dashRows.rows[0]?.id as string;
+
+    const convRows = await pool.query<{ id: string }>(
+      `INSERT INTO conversations (user_id, org_id, bound_dashboard_id)
+       VALUES ('u-2363', $1, $2)
+       RETURNING id`,
+      [orgId, dashboardId],
+    );
+    const conversationId = convRows.rows[0]?.id as string;
+
+    // Sanity — binding stuck.
+    const bound = await pool.query<{ bound_dashboard_id: string | null }>(
+      `SELECT bound_dashboard_id FROM conversations WHERE id = $1`,
+      [conversationId],
+    );
+    expect(bound.rows[0]?.bound_dashboard_id).toBe(dashboardId);
+
+    // Hard-delete the dashboard. The FK is ON DELETE SET NULL, so the
+    // conversation row must survive with the pointer cleared.
+    await pool.query(`DELETE FROM dashboards WHERE id = $1`, [dashboardId]);
+    const after = await pool.query<{ bound_dashboard_id: string | null }>(
+      `SELECT bound_dashboard_id FROM conversations WHERE id = $1`,
+      [conversationId],
+    );
+    expect(after.rows.length).toBe(1);
+    expect(after.rows[0]?.bound_dashboard_id).toBeNull();
+  }, PG_TEST_TIMEOUT_MS);
 });

--- a/packages/api/src/lib/db/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate.test.ts
@@ -84,8 +84,9 @@ describe("runMigrations", () => {
     // + 0069 (drop legacy connection_id scopes, #2347)
     // + 0070 (rename synthetic __global__ group names, #2417)
     // + 0071 (connection_groups.status enum, Phase 4 archive cascade, #2413)
-    // + 0072 (cleanup empty synthetic group orphans, #2506) = 73.
-    expect(count).toBe(73);
+    // + 0072 (cleanup empty synthetic group orphans, #2506)
+    // + 0073 (conversations.bound_dashboard_id, #2363) = 74.
+    expect(count).toBe(74);
 
     // Advisory lock acquired before anything else
     expect(queries[0]).toContain("pg_advisory_lock");
@@ -187,6 +188,7 @@ describe("runMigrations", () => {
         "0070_rename_synthetic_global_group_names.sql",
         "0071_connection_groups_status.sql",
         "0072_cleanup_empty_synthetic_groups.sql",
+        "0073_conversation_bound_dashboard.sql",
       ],
     });
 

--- a/packages/api/src/lib/db/migrations/0073_conversation_bound_dashboard.sql
+++ b/packages/api/src/lib/db/migrations/0073_conversation_bound_dashboard.sql
@@ -1,0 +1,35 @@
+-- 0073 — Add `bound_dashboard_id` to `conversations` (#2363).
+--
+-- The chat-as-dashboard-editor feature (PRD #2362) opens a chat drawer
+-- on `/dashboards/[id]`. Every drawer-open creates a fresh conversation
+-- bound to that dashboard so subsequent /api/v1/chat turns:
+--
+--   1. Know which dashboard the agent is editing (route picks the
+--      bound-mode tool registry instead of the default agent loop).
+--   2. Surface a per-dashboard history tab (#2368 lists rows where
+--      `bound_dashboard_id = $1`).
+--
+-- The column is nullable — the value is only stamped at creation by
+-- the chat route when the request body supplies `boundDashboardId`.
+-- Existing rows stay NULL and behave exactly as they did pre-#2363.
+--
+-- `ON DELETE SET NULL` rather than CASCADE: deleting a dashboard
+-- should not erase the audit trail of how it was built. The history
+-- tab queries by `bound_dashboard_id`, so a NULLed-out row simply
+-- drops off the dashboard's history list — the conversation itself
+-- remains visible in the user's main chat sidebar. This mirrors the
+-- decision in 0034 / share_token's "preserve the row, scrub the
+-- link" handling for soft-deleted parents.
+--
+-- Index is a plain btree on `bound_dashboard_id` because the only
+-- access pattern is "list sessions for THIS dashboard" — the org
+-- scoping is already covered by `idx_conversations_org` for any
+-- query the API actually runs.
+
+ALTER TABLE conversations
+  ADD COLUMN IF NOT EXISTS bound_dashboard_id uuid
+    REFERENCES dashboards(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_conversations_bound_dashboard
+  ON conversations (bound_dashboard_id)
+  WHERE bound_dashboard_id IS NOT NULL;

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -113,6 +113,12 @@ export const conversations = pgTable(
     // with `conversation_budget_exceeded` and the UI surfaces a
     // start-a-new-conversation affordance.
     totalSteps: integer("total_steps").notNull().default(0),
+    // 0073 — #2363 chat-as-dashboard-editor. When the chat drawer opens on
+    // `/dashboards/[id]` the request body supplies `boundDashboardId` and
+    // the conversation is stamped to that dashboard for its lifetime.
+    // Nullable so existing rows + non-drawer chats stay untouched.
+    // ON DELETE SET NULL keeps the audit trail when a dashboard is removed.
+    boundDashboardId: uuid("bound_dashboard_id").references(() => dashboards.id, { onDelete: "set null" }),
   },
   (t) => [
     index("idx_conversations_user").on(t.userId),
@@ -123,6 +129,7 @@ export const conversations = pgTable(
     check("chk_org_scoped_share", sql`share_mode <> 'org' OR org_id IS NOT NULL`),
     index("idx_conversations_org").on(t.orgId),
     index("idx_conversations_group").on(t.connectionGroupId, t.orgId),
+    index("idx_conversations_bound_dashboard").on(t.boundDashboardId).where(sql`bound_dashboard_id IS NOT NULL`),
   ],
 );
 

--- a/packages/api/src/lib/tools/__tests__/bound-dashboard.test.ts
+++ b/packages/api/src/lib/tools/__tests__/bound-dashboard.test.ts
@@ -1,0 +1,348 @@
+/**
+ * Integration-shaped tests for the bound dashboard editor tool set (#2363).
+ *
+ * Mocks the SQL validator (sync — bun's mock.module deadlocks on async
+ * factories per feedback_bun_test_async_mock_module.md) and injects a
+ * stub Postgres pool so `lib/dashboards` calls land in our recorder
+ * instead of touching a real DB. The tools' execute() functions are
+ * exercised directly.
+ */
+import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
+import { _resetPool, type InternalPool } from "../../db/internal";
+
+// validateSQL is the only sync-mockable boundary into the SQL path;
+// the tools call it before persisting. Mock it before the tools import.
+const validateSQLMock = mock(async (sql: string, _connectionId?: string) => {
+  if (/drop|insert|update|delete/i.test(sql)) {
+    return { valid: false as const, error: "SQL must be SELECT-only." };
+  }
+  if (/forbidden_table/i.test(sql)) {
+    return { valid: false as const, error: 'Table "forbidden_table" not in semantic layer.' };
+  }
+  return { valid: true as const, classification: { tablesAccessed: [], columnsAccessed: [] } };
+});
+
+mock.module("@atlas/api/lib/tools/sql", () => ({
+  validateSQL: validateSQLMock,
+  // The bound-dashboard tools only import `validateSQL` — but other
+  // modules transitively imported by the dashboards lib pull in this
+  // module too. Re-export the rest as best-effort no-ops; if any
+  // codepath under test reaches them the test will fail loudly.
+  executeSQL: undefined as never,
+  runUserQueryPipeline: undefined as never,
+}));
+
+const { createBoundDashboardTools } = await import("../bound-dashboard");
+
+// ---------------------------------------------------------------------------
+// Mock pool — same shape as conversations.test.ts
+// ---------------------------------------------------------------------------
+
+interface QueryResult {
+  rows: Record<string, unknown>[];
+}
+
+let queryCalls: { sql: string; params?: unknown[] }[] = [];
+let queryResults: QueryResult[] = [];
+let queryResultIndex = 0;
+
+const mockPool: InternalPool = {
+  query: async (sql: string, params?: unknown[]) => {
+    queryCalls.push({ sql, params });
+    const result = queryResults[queryResultIndex] ?? { rows: [] };
+    queryResultIndex++;
+    return result;
+  },
+  async connect() {
+    return { query: async () => ({ rows: [] }), release() {} };
+  },
+  end: async () => {},
+  on: () => {},
+};
+
+function enableInternalDB() {
+  process.env.DATABASE_URL = "postgresql://test:test@localhost:5432/test";
+  _resetPool(mockPool);
+}
+
+function setResults(...results: QueryResult[]) {
+  queryResults = results;
+  queryResultIndex = 0;
+}
+
+const ctx = { dashboardId: "dash-1", orgId: "org-1" as string | null | undefined };
+
+const dashboardRow = {
+  id: "dash-1",
+  org_id: "org-1",
+  owner_id: "user-1",
+  title: "Demo",
+  description: null,
+  share_token: null,
+  share_expires_at: null,
+  share_mode: "public",
+  refresh_schedule: null,
+  last_refresh_at: null,
+  next_refresh_at: null,
+  card_count: 1,
+  created_at: "2026-05-17",
+  updated_at: "2026-05-17",
+};
+
+const cardRow = {
+  id: "card-1",
+  dashboard_id: "dash-1",
+  position: 0,
+  title: "Signups",
+  sql: "SELECT 1",
+  chart_config: null,
+  cached_columns: null,
+  cached_rows: null,
+  cached_at: null,
+  connection_group_id: null,
+  layout: null,
+  created_at: "2026-05-17",
+  updated_at: "2026-05-17",
+};
+
+// AI SDK's `Tool` type has a structural `execute` signature parameterized
+// over the inputSchema; calling it generically in tests requires escaping
+// the per-tool type. We `any`-cast at the boundary, then narrow via the
+// caller's generic. Same trade as proposeDashboard.test.ts.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function runTool<T = unknown>(tool: any, args: unknown): Promise<T> {
+  if (!tool?.execute) throw new Error("tool has no execute");
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return (await tool.execute(args, undefined as any)) as T;
+}
+
+describe("createBoundDashboardTools", () => {
+  const origDbUrl = process.env.DATABASE_URL;
+
+  beforeEach(() => {
+    queryCalls = [];
+    queryResults = [];
+    queryResultIndex = 0;
+    validateSQLMock.mockClear();
+    delete process.env.DATABASE_URL;
+    _resetPool(null);
+  });
+
+  afterEach(() => {
+    if (origDbUrl) process.env.DATABASE_URL = origDbUrl;
+    else delete process.env.DATABASE_URL;
+    _resetPool(null);
+  });
+
+  // -------------------------------------------------------------------
+  // Factory shape
+  // -------------------------------------------------------------------
+
+  it("returns the six safe-op editor tools and nothing else", () => {
+    const tools = createBoundDashboardTools(ctx);
+    const names = Object.keys(tools).sort();
+    expect(names).toEqual([
+      "addCard",
+      "getCardDetail",
+      "getDashboardState",
+      "updateCard",
+      "updateDashboardMeta",
+      "updateLayout",
+    ]);
+    // Critically: no removeCard / updateCardSql / executePython / actions.
+    expect(names).not.toContain("removeCard");
+    expect(names).not.toContain("updateCardSql");
+    expect(names).not.toContain("executePython");
+  });
+
+  // -------------------------------------------------------------------
+  // getDashboardState
+  // -------------------------------------------------------------------
+
+  it("getDashboardState returns dashboard meta + compact card summary", async () => {
+    enableInternalDB();
+    setResults({ rows: [dashboardRow] }, { rows: [cardRow] });
+    const tools = createBoundDashboardTools(ctx);
+    const result = await runTool<{
+      kind: "ok";
+      dashboard: { id: string; title: string; cardCount: number };
+      summary: string;
+    }>(tools.getDashboardState, {});
+    expect(result.kind).toBe("ok");
+    expect(result.dashboard).toMatchObject({ id: "dash-1", title: "Demo", cardCount: 1 });
+    expect(result.summary).toContain("[card-1]");
+    expect(result.summary).toContain("Signups");
+  });
+
+  // -------------------------------------------------------------------
+  // getCardDetail
+  // -------------------------------------------------------------------
+
+  it("getCardDetail returns the full card row including SQL", async () => {
+    enableInternalDB();
+    setResults({ rows: [cardRow] });
+    const tools = createBoundDashboardTools(ctx);
+    const result = await runTool<{ kind: "ok"; card: { id: string; sql: string } }>(
+      tools.getCardDetail,
+      { cardId: "card-1" },
+    );
+    expect(result.kind).toBe("ok");
+    expect(result.card.id).toBe("card-1");
+    expect(result.card.sql).toBe("SELECT 1");
+  });
+
+  // -------------------------------------------------------------------
+  // addCard
+  // -------------------------------------------------------------------
+
+  it("addCard validates SQL then inserts via lib/dashboards.addCard", async () => {
+    enableInternalDB();
+    // addCard issues two queries: MAX(position) + INSERT RETURNING *
+    setResults(
+      { rows: [{ next_pos: 1 }] },
+      {
+        rows: [
+          {
+            ...cardRow,
+            id: "card-2",
+            position: 1,
+            title: "Weekly signups",
+            sql: "SELECT COUNT(*) FROM users",
+            chart_config: { type: "line", categoryColumn: "week", valueColumns: ["count"] },
+          },
+        ],
+      },
+    );
+    const tools = createBoundDashboardTools(ctx);
+    const result = await runTool<{
+      kind: "ok";
+      card: { id: string; title: string; chartType: string; position: number };
+    }>(tools.addCard, {
+      title: "Weekly signups",
+      sql: "SELECT COUNT(*) FROM users",
+      chartConfig: { type: "line", categoryColumn: "week", valueColumns: ["count"] },
+    });
+    expect(validateSQLMock).toHaveBeenCalledTimes(1);
+    expect(result.kind).toBe("ok");
+    expect(result.card).toMatchObject({
+      id: "card-2",
+      title: "Weekly signups",
+      chartType: "line",
+      position: 1,
+    });
+  });
+
+  it("addCard refuses invalid SQL without persisting", async () => {
+    enableInternalDB();
+    const tools = createBoundDashboardTools(ctx);
+    const result = await runTool<{ kind: "err"; error: string }>(tools.addCard, {
+      title: "Bad",
+      sql: "DROP TABLE users",
+      chartConfig: { type: "table", categoryColumn: "x", valueColumns: ["x"] },
+    });
+    expect(result.kind).toBe("err");
+    expect(result.error).toMatch(/validation failed/i);
+    expect(queryCalls).toHaveLength(0); // no DB queries fired
+  });
+
+  // -------------------------------------------------------------------
+  // updateCard
+  // -------------------------------------------------------------------
+
+  it("updateCard refuses when no fields supplied", async () => {
+    enableInternalDB();
+    const tools = createBoundDashboardTools(ctx);
+    const result = await runTool<{ kind: "err"; error: string }>(tools.updateCard, {
+      cardId: "card-1",
+    });
+    expect(result.kind).toBe("err");
+    expect(result.error).toMatch(/No fields supplied/i);
+    expect(queryCalls).toHaveLength(0);
+  });
+
+  it("updateCard persists supplied fields", async () => {
+    enableInternalDB();
+    setResults({ rows: [{ id: "card-1" }] });
+    const tools = createBoundDashboardTools(ctx);
+    const result = await runTool<{ kind: "ok"; cardId: string; updated: string[] }>(
+      tools.updateCard,
+      { cardId: "card-1", title: "Renamed" },
+    );
+    expect(result.kind).toBe("ok");
+    expect(result.updated).toEqual(["title"]);
+    expect(queryCalls[0].sql).toMatch(/UPDATE dashboard_cards/);
+  });
+
+  // -------------------------------------------------------------------
+  // updateLayout
+  // -------------------------------------------------------------------
+
+  it("updateLayout applies per-card placements and reports partial failures", async () => {
+    enableInternalDB();
+    // Two updateCard calls — first succeeds, second card "card-9" misses
+    setResults(
+      { rows: [{ id: "card-1" }] }, // first updateCard succeeds
+      { rows: [] }, // second updateCard misses (not_found)
+    );
+    const tools = createBoundDashboardTools(ctx);
+    const result = await runTool<{
+      kind: "ok" | "partial";
+      results: { cardId: string; ok: boolean }[];
+      failedCount?: number;
+    }>(tools.updateLayout, {
+      layouts: [
+        { cardId: "card-1", x: 0, y: 0, w: 12, h: 8 },
+        { cardId: "card-9", x: 12, y: 0, w: 12, h: 8 },
+      ],
+    });
+    expect(result.kind).toBe("partial");
+    expect(result.results[0]).toEqual({ cardId: "card-1", ok: true });
+    expect(result.results[1].ok).toBe(false);
+    expect(result.failedCount).toBe(1);
+  });
+
+  it("updateLayout rejects out-of-bounds placements without hitting the DB", async () => {
+    enableInternalDB();
+    const tools = createBoundDashboardTools(ctx);
+    const result = await runTool<{
+      kind: "ok" | "partial";
+      results: { cardId: string; ok: boolean; reason?: string }[];
+    }>(tools.updateLayout, {
+      layouts: [
+        // x+w = 30, exceeds 24-col grid → rejected by CardLayoutSchema.refine
+        { cardId: "card-1", x: 12, y: 0, w: 18, h: 8 },
+      ],
+    });
+    expect(result.kind).toBe("partial");
+    expect(result.results[0].ok).toBe(false);
+    expect(queryCalls).toHaveLength(0);
+  });
+
+  // -------------------------------------------------------------------
+  // updateDashboardMeta
+  // -------------------------------------------------------------------
+
+  it("updateDashboardMeta persists supplied fields", async () => {
+    enableInternalDB();
+    setResults({ rows: [{ id: "dash-1" }] }); // UPDATE dashboards
+    const tools = createBoundDashboardTools(ctx);
+    const result = await runTool<{ kind: "ok"; updated: string[] }>(
+      tools.updateDashboardMeta,
+      { title: "New title" },
+    );
+    expect(result.kind).toBe("ok");
+    expect(result.updated).toEqual(["title"]);
+    expect(queryCalls[0].sql).toMatch(/UPDATE dashboards/);
+  });
+
+  it("updateDashboardMeta refuses when no fields supplied", async () => {
+    enableInternalDB();
+    const tools = createBoundDashboardTools(ctx);
+    const result = await runTool<{ kind: "err"; error: string }>(
+      tools.updateDashboardMeta,
+      {},
+    );
+    expect(result.kind).toBe("err");
+    expect(queryCalls).toHaveLength(0);
+  });
+});

--- a/packages/api/src/lib/tools/bound-dashboard-registry.ts
+++ b/packages/api/src/lib/tools/bound-dashboard-registry.ts
@@ -1,0 +1,66 @@
+/**
+ * Bound dashboard tool registry (#2363).
+ *
+ * The bound agent has a strict editor tool surface:
+ *   - explore + executeSQL — same as the default agent (needed to verify
+ *     SQL shape before `addCard`).
+ *   - getDashboardState, getCardDetail, addCard, updateCard, updateLayout,
+ *     updateDashboardMeta — the six safe editor tools.
+ *
+ * Explicitly NOT included:
+ *   - executePython — out of scope for dashboard editing; the bound agent
+ *     should not run arbitrary Python in the middle of an edit session.
+ *   - action plugins (createJiraTicket, sendEmailReport) — irrelevant to
+ *     dashboard composition; including them just confuses the model.
+ *   - proposeDashboard — superseded by the bound editor tools. The root-
+ *     chat flow keeps proposeDashboard until #2369 reframes it as
+ *     `createDashboard`; the bound flow drops it outright.
+ *
+ * Plugin tools are NOT merged here. Plugin-registered tools target the
+ * general agent loop; the bound surface is intentionally narrow. If a
+ * future plugin specifically targets dashboard editing it can opt-in
+ * via a separate hook.
+ */
+
+import { ToolRegistry, EXPLORE_DESCRIPTION, EXECUTE_SQL_DESCRIPTION } from "./registry";
+import { explore } from "./explore";
+import { executeSQL } from "./sql";
+import {
+  createBoundDashboardTools,
+  BOUND_DASHBOARD_TOOL_DESCRIPTIONS,
+  type BoundDashboardToolContext,
+} from "./bound-dashboard";
+
+/**
+ * Build a frozen tool registry for the bound-dashboard agent loop.
+ * Captures the dashboardId + orgId in the tools' closure — the LLM
+ * cannot redirect a turn at a different dashboard.
+ */
+export function buildBoundDashboardRegistry(
+  ctx: BoundDashboardToolContext,
+): ToolRegistry {
+  const registry = new ToolRegistry();
+
+  registry.register({
+    name: "explore",
+    description: EXPLORE_DESCRIPTION,
+    tool: explore,
+  });
+  registry.register({
+    name: "executeSQL",
+    description: EXECUTE_SQL_DESCRIPTION,
+    tool: executeSQL,
+  });
+
+  const editorTools = createBoundDashboardTools(ctx);
+  for (const [name, tool] of Object.entries(editorTools)) {
+    registry.register({
+      name,
+      description: BOUND_DASHBOARD_TOOL_DESCRIPTIONS[name] ?? `### ${name}\n(no description)`,
+      tool,
+    });
+  }
+
+  registry.freeze();
+  return registry;
+}

--- a/packages/api/src/lib/tools/bound-dashboard.ts
+++ b/packages/api/src/lib/tools/bound-dashboard.ts
@@ -1,0 +1,283 @@
+/**
+ * Bound dashboard editor tools (#2363).
+ *
+ * Six safe-op tools the bound agent gets when the chat is opened on a
+ * dashboard. The factory function `createBoundDashboardTools` closes the
+ * tools over the dashboardId + orgId resolved from the conversation's
+ * `bound_dashboard_id` — the LLM cannot supply the dashboard id itself,
+ * which is the whole point of binding (a turn cannot redirect mutations
+ * at a different dashboard than the one the user opened).
+ *
+ * Destructive ops (`removeCard`, `updateCardSql`) are intentionally OUT
+ * of this slice — they ship in #2365 as `stage_required` envelopes with
+ * ghost-overlay accept/discard. Including them here would defeat the
+ * tracer-bullet scope; last-write-wins to published is tolerable for
+ * the safe set but not for delete / SQL rewrite.
+ */
+
+import { tool, type ToolSet } from "ai";
+import { z } from "zod";
+import { CHART_TYPES } from "@useatlas/types";
+import { createLogger } from "@atlas/api/lib/logger";
+import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
+import { validateSQL } from "@atlas/api/lib/tools/sql";
+import {
+  addCard,
+  updateCard,
+  updateDashboard,
+  getCard,
+  getDashboard,
+  CardLayoutSchema,
+} from "@atlas/api/lib/dashboards";
+import type { DashboardCardLayout } from "@atlas/api/lib/dashboard-types";
+import { buildCardSummary } from "@atlas/api/lib/bound-chat-context";
+
+const log = createLogger("tool:bound-dashboard");
+
+const ChartConfigSchema = z.object({
+  type: z.enum(CHART_TYPES),
+  categoryColumn: z.string().min(1),
+  valueColumns: z.array(z.string().min(1)).min(1),
+});
+
+export interface BoundDashboardToolContext {
+  dashboardId: string;
+  orgId: string | null | undefined;
+}
+
+/**
+ * Build the editor tool set for a specific bound dashboard. The
+ * dashboardId / orgId are captured at request time and the tool
+ * registry consuming this is built per-request via
+ * `buildBoundDashboardRegistry`.
+ */
+export function createBoundDashboardTools(
+  ctx: BoundDashboardToolContext,
+): ToolSet {
+  const { dashboardId, orgId } = ctx;
+
+  const getDashboardState = tool({
+    description: `Read the current state of the dashboard you are editing. Returns the title, description, and a compact summary of every card (id, title, chart type, position, layout). Call this when you need a fresh read after several mutations. Card SQL is NOT returned — use \`getCardDetail\` for that.`,
+    inputSchema: z.object({}).describe("No arguments"),
+    execute: async () => {
+      const dash = await getDashboard(dashboardId, { orgId: orgId ?? undefined });
+      if (!dash.ok) {
+        return { kind: "err" as const, error: `Could not read dashboard: ${dash.reason}` };
+      }
+      return {
+        kind: "ok" as const,
+        dashboard: {
+          id: dash.data.id,
+          title: dash.data.title,
+          description: dash.data.description,
+          cardCount: dash.data.cards.length,
+        },
+        summary: buildCardSummary(dash.data.cards),
+      };
+    },
+  });
+
+  const getCardDetail = tool({
+    description: `Fetch the full detail (SQL, chartConfig, layout, cached columns) for a single card by its id. Use this when the user asks "what is this card counting?" or when you need to inspect the SQL before proposing a change. The compact card summary in your system prompt only shows id/title/chart-type/position.`,
+    inputSchema: z.object({
+      cardId: z.string().min(1).describe("Card id (from the compact summary)"),
+    }),
+    execute: async ({ cardId }) => {
+      const card = await getCard(cardId, dashboardId);
+      if (!card.ok) {
+        return { kind: "err" as const, error: `Could not read card ${cardId}: ${card.reason}` };
+      }
+      return {
+        kind: "ok" as const,
+        card: {
+          id: card.data.id,
+          title: card.data.title,
+          sql: card.data.sql,
+          chartConfig: card.data.chartConfig,
+          layout: card.data.layout,
+          position: card.data.position,
+          cachedColumns: card.data.cachedColumns,
+        },
+      };
+    },
+  });
+
+  const addCardTool = tool({
+    description: `Add a new card to the dashboard. Validates the SQL against the analytics datasource before persisting; if validation fails the card is NOT added and the error is returned so you can fix it and retry. Use AFTER \`executeSQL\` has confirmed the column names — \`chartConfig.categoryColumn\` and \`valueColumns\` must match the SQL output. The grid is 24 columns wide; layout is optional (auto-laid below the lowest existing card when omitted).`,
+    inputSchema: z.object({
+      title: z.string().min(1).max(200).describe("Card title (visible to the user)"),
+      sql: z.string().min(1).describe("Read-only SELECT query"),
+      chartConfig: ChartConfigSchema.describe("Chart type + column mapping"),
+      layout: CardLayoutSchema.optional().describe("Optional grid placement {x, y, w, h}"),
+    }),
+    execute: async ({ title, sql, chartConfig, layout }) => {
+      try {
+        const validation = await validateSQL(sql, undefined);
+        if (!validation.valid) {
+          return {
+            kind: "err" as const,
+            error: `SQL validation failed: ${validation.error}. Fix the query and retry.`,
+          };
+        }
+        const result = await addCard({
+          dashboardId,
+          title,
+          sql,
+          chartConfig,
+          ...(layout && { layout }),
+        });
+        if (!result.ok) {
+          return { kind: "err" as const, error: `Could not add card: ${result.reason}` };
+        }
+        return {
+          kind: "ok" as const,
+          card: {
+            id: result.data.id,
+            title: result.data.title,
+            chartType: result.data.chartConfig?.type ?? "table",
+            position: result.data.position,
+          },
+        };
+      } catch (err) {
+        log.warn({ err: errorMessage(err), dashboardId }, "addCard tool failed unexpectedly");
+        return { kind: "err" as const, error: "addCard failed unexpectedly. Try again or simplify the proposal." };
+      }
+    },
+  });
+
+  const updateCardTool = tool({
+    description: `Update a card's title, chart type, or layout. Pass only the fields you want to change. Does NOT support changing the SQL — that is a destructive op and arrives as a staged ghost change in a later slice. To change the SQL today, ask the user to remove and re-add the card.`,
+    inputSchema: z.object({
+      cardId: z.string().min(1).describe("Card id"),
+      title: z.string().min(1).max(200).optional(),
+      chartConfig: ChartConfigSchema.nullable().optional(),
+      layout: CardLayoutSchema.nullable().optional(),
+      position: z.number().int().min(0).optional(),
+    }),
+    execute: async ({ cardId, title, chartConfig, layout, position }) => {
+      try {
+        const updates: {
+          title?: string;
+          chartConfig?: z.infer<typeof ChartConfigSchema> | null;
+          layout?: DashboardCardLayout | null;
+          position?: number;
+        } = {};
+        if (title !== undefined) updates.title = title;
+        if (chartConfig !== undefined) updates.chartConfig = chartConfig;
+        if (layout !== undefined) updates.layout = layout;
+        if (position !== undefined) updates.position = position;
+
+        if (Object.keys(updates).length === 0) {
+          return { kind: "err" as const, error: "No fields supplied — pass at least one of title, chartConfig, layout, position." };
+        }
+
+        const result = await updateCard(cardId, dashboardId, updates);
+        if (!result.ok) {
+          return { kind: "err" as const, error: `Could not update card ${cardId}: ${result.reason}` };
+        }
+        return { kind: "ok" as const, cardId, updated: Object.keys(updates) };
+      } catch (err) {
+        log.warn({ err: errorMessage(err), dashboardId, cardId }, "updateCard tool failed unexpectedly");
+        return { kind: "err" as const, error: "updateCard failed unexpectedly. Try again." };
+      }
+    },
+  });
+
+  const updateLayoutTool = tool({
+    description: `Rearrange cards on the grid by supplying a layout for each card you want to move. Cards not listed keep their current layout. The grid is 24 columns wide; (x + w) must be <= 24. Each item in \`layouts\` is { cardId, x, y, w, h }.`,
+    inputSchema: z.object({
+      layouts: z
+        .array(
+          z.object({
+            cardId: z.string().min(1),
+            x: z.number().int().min(0),
+            y: z.number().int().min(0),
+            w: z.number().int().min(1),
+            h: z.number().int().min(1),
+          }),
+        )
+        .min(1)
+        .describe("Per-card grid placements"),
+    }),
+    execute: async ({ layouts }) => {
+      const results: { cardId: string; ok: boolean; reason?: string }[] = [];
+      for (const placement of layouts) {
+        const { cardId, x, y, w, h } = placement;
+        const parsed = CardLayoutSchema.safeParse({ x, y, w, h });
+        if (!parsed.success) {
+          results.push({ cardId, ok: false, reason: parsed.error.issues[0]?.message ?? "invalid layout" });
+          continue;
+        }
+        const r = await updateCard(cardId, dashboardId, { layout: parsed.data });
+        results.push(r.ok ? { cardId, ok: true } : { cardId, ok: false, reason: r.reason });
+      }
+      const failed = results.filter((r) => !r.ok);
+      if (failed.length > 0) {
+        return { kind: "partial" as const, results, failedCount: failed.length };
+      }
+      return { kind: "ok" as const, results };
+    },
+  });
+
+  const updateDashboardMetaTool = tool({
+    description: `Update the dashboard's title or description. Pass only the fields you want to change.`,
+    inputSchema: z.object({
+      title: z.string().min(1).max(200).optional(),
+      description: z.string().max(2000).nullable().optional(),
+    }),
+    execute: async ({ title, description }) => {
+      const updates: { title?: string; description?: string | null } = {};
+      if (title !== undefined) updates.title = title;
+      if (description !== undefined) updates.description = description;
+
+      if (Object.keys(updates).length === 0) {
+        return { kind: "err" as const, error: "No fields supplied — pass title or description." };
+      }
+
+      const result = await updateDashboard(dashboardId, { orgId: orgId ?? undefined }, updates);
+      if (!result.ok) {
+        return { kind: "err" as const, error: `Could not update dashboard: ${result.reason}` };
+      }
+      return { kind: "ok" as const, updated: Object.keys(updates) };
+    },
+  });
+
+  return {
+    getDashboardState,
+    getCardDetail,
+    addCard: addCardTool,
+    updateCard: updateCardTool,
+    updateLayout: updateLayoutTool,
+    updateDashboardMeta: updateDashboardMetaTool,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Workflow descriptions — concatenated into the bound system prompt by
+// `ToolRegistry.describe()` (see registry.ts).
+// ---------------------------------------------------------------------------
+
+export const BOUND_DASHBOARD_TOOL_DESCRIPTIONS: Record<string, string> = {
+  getDashboardState: `### Read the dashboard
+Use \`getDashboardState\` for a fresh read of the dashboard's title/description and a compact card summary. The summary lists every card by id, title, chart type, position, and layout — match natural references against this list.`,
+
+  getCardDetail: `### Inspect a card in detail
+Use \`getCardDetail(cardId)\` to fetch a card's full SQL, chartConfig, layout, and cached columns. The compact card summary in your system prompt only shows id/title/chart-type/position — call \`getCardDetail\` whenever you need the SQL or chartConfig to reason about, explain, or change a card.`,
+
+  addCard: `### Add a card
+Use \`addCard\` to create a new card. Always:
+1. Call \`explore\` + \`executeSQL\` first to confirm the SQL shape and column names.
+2. Build a chartConfig whose \`categoryColumn\` and \`valueColumns\` match the SQL output exactly.
+3. Optionally specify a layout {x, y, w, h} in the 24-col grid.
+
+The tool validates the SQL against the analytics datasource before persisting; if validation fails the card is NOT created.`,
+
+  updateCard: `### Rename / re-chart / re-place a card
+Use \`updateCard\` to change a card's title, chartConfig, layout, or position. Pass only the fields you want to change. Does NOT support SQL changes — those are destructive ops that arrive as staged ghost changes in a later slice.`,
+
+  updateLayout: `### Rearrange the grid
+Use \`updateLayout\` to move multiple cards at once. Supply the layouts array with one entry per card you want to place. Cards not listed stay where they are. Grid is 24 columns wide; (x + w) must be <= 24.`,
+
+  updateDashboardMeta: `### Rename the dashboard / edit its description
+Use \`updateDashboardMeta\` to change the dashboard's title or description. Pass only the fields you want to change.`,
+};

--- a/packages/web/src/app/(workspace)/dashboards/[id]/page.tsx
+++ b/packages/web/src/app/(workspace)/dashboards/[id]/page.tsx
@@ -3,8 +3,9 @@
 import { useEffect, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
 import Link from "next/link";
-import { Plus, Sparkles, XCircle } from "lucide-react";
+import { MessagesSquare, Plus, Sparkles, XCircle } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { BoundChatDrawer } from "@/ui/components/dashboards/bound-chat-drawer";
 import { Card } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
@@ -57,6 +58,8 @@ export default function DashboardViewPage() {
 
   const [editing, setEditing] = useState(false);
   const [density, setDensity] = useState<Density>("comfortable");
+  // #2363 — bound chat drawer state
+  const [chatOpen, setChatOpen] = useState(false);
 
   // Optimistic layout — applied on drop/resize end so the UI doesn't wait for
   // the PATCH round-trip. Dropped explicitly when the mutation settles. No
@@ -285,6 +288,17 @@ export default function DashboardViewPage() {
               suggesting={suggestingCards}
               onDelete={() => setDeleteDashboard(true)}
               shareSlot={<DashboardShareDialog dashboardId={id} />}
+              chatSlot={
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setChatOpen(true)}
+                  aria-label="Edit dashboard with chat"
+                >
+                  <MessagesSquare className="mr-1.5 size-3.5" aria-hidden="true" />
+                  Edit with chat
+                </Button>
+              }
               editing={editing}
               onEditingChange={setEditing}
               density={density}
@@ -426,6 +440,16 @@ export default function DashboardViewPage() {
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
+
+      {dashboard && (
+        <BoundChatDrawer
+          open={chatOpen}
+          onOpenChange={setChatOpen}
+          dashboardId={dashboard.id}
+          dashboardTitle={dashboard.title}
+          onDashboardMutated={refetch}
+        />
+      )}
 
       <AlertDialog open={deleteDashboard} onOpenChange={setDeleteDashboard}>
         <AlertDialogContent>

--- a/packages/web/src/ui/components/dashboards/bound-chat-drawer.tsx
+++ b/packages/web/src/ui/components/dashboards/bound-chat-drawer.tsx
@@ -1,0 +1,275 @@
+"use client";
+
+/**
+ * Bound chat drawer (#2363).
+ *
+ * Right-side Sheet that opens on `/dashboards/[id]` and runs a chat
+ * conversation bound to that dashboard. Each drawer-open creates a
+ * fresh conversation (a new `useChat` instance, new transport, new
+ * conversation row on the server) — past sessions for this dashboard
+ * are listed in the History tab in slice #2368.
+ *
+ * Last-write-wins is intentional in this tracer-bullet: safe mutations
+ * (addCard, updateCard title/chartConfig/layout, updateDashboardMeta)
+ * commit immediately to the published dashboard. Drafts arrive in
+ * #2364; destructive ops + ghost overlays in #2365.
+ */
+
+import { useState, useRef, useEffect, useCallback, useMemo } from "react";
+import { useChat } from "@ai-sdk/react";
+import { DefaultChatTransport, type UIMessage } from "ai";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Send, MessagesSquare } from "lucide-react";
+import { useAtlasConfig } from "@/ui/context";
+import { Markdown } from "@/ui/components/chat/markdown";
+import { ToolPart } from "@/ui/components/chat/tool-part";
+import { TypingIndicator } from "@/ui/components/chat/typing-indicator";
+import { parseSuggestions } from "@/ui/lib/helpers";
+import { isToolUIPart } from "ai";
+
+interface BoundChatDrawerProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  dashboardId: string;
+  dashboardTitle: string;
+  /**
+   * Called whenever a tool completes — the dashboard view re-fetches so
+   * the new card / updated title / new layout shows up immediately. The
+   * tracer-bullet doesn't try to be surgical about which tools warrant
+   * a refetch; every tool result triggers one. Plenty of room for
+   * smarter invalidation in a follow-up.
+   */
+  onDashboardMutated?: () => void;
+}
+
+export function BoundChatDrawer({
+  open,
+  onOpenChange,
+  dashboardId,
+  dashboardTitle,
+  onDashboardMutated,
+}: BoundChatDrawerProps) {
+  const { apiUrl, isCrossOrigin } = useAtlasConfig();
+  const [input, setInput] = useState("");
+  // Tracks the active server-side conversation row. `null` on first
+  // turn (the route creates one + binds it); subsequent turns pin to it.
+  const conversationIdRef = useRef<string | null>(null);
+  // Bumped whenever the user closes-and-reopens the drawer so each
+  // session is a fresh `useChat` instance with its own message list +
+  // its own server-side conversation row.
+  const [sessionKey, setSessionKey] = useState(0);
+
+  // Reset session id + conversation pointer on every drawer open. This
+  // matches the PRD's "fresh conversation per drawer-open" requirement
+  // (each open starts a new bound conversation; history accessible via
+  // the #2368 tab).
+  useEffect(() => {
+    if (open) {
+      conversationIdRef.current = null;
+      setSessionKey((k) => k + 1);
+    }
+  }, [open]);
+
+  const transport = useMemo(() => {
+    return new DefaultChatTransport({
+      api: `${apiUrl}/api/v1/chat`,
+      credentials: isCrossOrigin ? "include" : undefined,
+      body: () => {
+        const body: Record<string, string> = {
+          // #2363 — the route stamps this onto the conversation row on
+          // the conversation-creating turn. Sent on every turn for
+          // symmetry; the server ignores it once the row is bound.
+          boundDashboardId: dashboardId,
+        };
+        if (conversationIdRef.current) {
+          body.conversationId = conversationIdRef.current;
+        }
+        return body;
+      },
+      fetch: (async (input: RequestInfo | URL, init?: RequestInit) => {
+        const response = await globalThis.fetch(input, init);
+        const convId = response.headers.get("x-conversation-id");
+        if (convId && convId !== conversationIdRef.current) {
+          conversationIdRef.current = convId;
+        }
+        return response;
+      }) as typeof fetch,
+    });
+    // sessionKey forces a transport rebuild between sessions so the
+    // `useChat` instance below picks up the cleared conversation ref.
+  }, [apiUrl, isCrossOrigin, dashboardId, sessionKey]);
+
+  const { messages, sendMessage, status, error } = useChat({
+    transport,
+    // useChat re-mounts when the key on the calling component changes.
+    // We don't need onData here — bound mode doesn't surface Python
+    // progress and the bound editor tools don't emit custom data parts.
+  });
+
+  const isLoading = status === "streaming" || status === "submitted";
+
+  // Refetch the dashboard whenever a tool result lands. The bound editor
+  // tools mutate cards/title/layout — viewers expect the canvas to
+  // update without a manual reload. We watch the tool-part status on
+  // the latest assistant message rather than running on every render
+  // (cheap, but explicit).
+  const lastMsg = messages[messages.length - 1];
+  const lastMsgId = lastMsg?.id;
+  const lastMsgToolFingerprint = useMemo(() => {
+    if (!lastMsg || lastMsg.role !== "assistant") return "";
+    let fp = "";
+    for (const part of lastMsg.parts ?? []) {
+      if (!isToolUIPart(part)) continue;
+      const p = part as { state?: string; toolCallId?: string };
+      fp += `${p.toolCallId ?? ""}:${p.state ?? ""};`;
+    }
+    return fp;
+  }, [lastMsg]);
+
+  useEffect(() => {
+    if (!onDashboardMutated || !lastMsgToolFingerprint) return;
+    // The fingerprint changes when a tool transitions to a terminal
+    // state ("output-available" / "output-error"). Treat any change as
+    // potential dashboard mutation — false positives are cheap (an
+    // extra GET) and false negatives leave the canvas stale.
+    if (lastMsgToolFingerprint.includes("output-available")) {
+      onDashboardMutated();
+    }
+  }, [lastMsgToolFingerprint, lastMsgId, onDashboardMutated]);
+
+  const handleSubmit = useCallback(
+    async (e: React.FormEvent<HTMLFormElement>) => {
+      e.preventDefault();
+      const text = input.trim();
+      if (!text || isLoading) return;
+      setInput("");
+      await sendMessage({ text });
+    },
+    [input, isLoading, sendMessage],
+  );
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent
+        side="right"
+        className="flex w-full flex-col p-0 sm:max-w-[560px] lg:max-w-[640px]"
+      >
+        <SheetHeader className="border-b border-zinc-200 px-4 py-3 dark:border-zinc-800">
+          <div className="flex items-center gap-2">
+            <MessagesSquare className="size-4 text-primary" aria-hidden="true" />
+            <SheetTitle className="text-base font-semibold">Edit with chat</SheetTitle>
+          </div>
+          <SheetDescription className="text-xs text-zinc-500 dark:text-zinc-400">
+            Bound to <span className="font-medium text-zinc-700 dark:text-zinc-300">{dashboardTitle}</span> — safe edits commit immediately.
+          </SheetDescription>
+        </SheetHeader>
+
+        <ScrollArea className="flex-1 px-4 py-3">
+          {messages.length === 0 && (
+            <div className="space-y-3 py-6 text-sm text-zinc-500 dark:text-zinc-400">
+              <p>
+                Tell the agent what to change. Examples:
+              </p>
+              <ul className="space-y-1 pl-4">
+                <li>&ldquo;Add a card showing weekly signups&rdquo;</li>
+                <li>&ldquo;Rename card 2 to &lsquo;Active Users&rsquo;&rdquo;</li>
+                <li>&ldquo;Make card 3 a bar chart&rdquo;</li>
+                <li>&ldquo;What is card 1 counting?&rdquo;</li>
+              </ul>
+            </div>
+          )}
+
+          {messages.map((m: UIMessage) => (
+            <BoundChatMessage key={m.id} message={m} />
+          ))}
+
+          {isLoading && messages[messages.length - 1]?.role === "user" && (
+            <div className="my-2">
+              <TypingIndicator />
+            </div>
+          )}
+
+          {error && (
+            <div
+              role="alert"
+              className="my-3 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-700 dark:border-red-900/50 dark:bg-red-950/20 dark:text-red-400"
+            >
+              {error.message || "The agent hit an error. Try again."}
+            </div>
+          )}
+        </ScrollArea>
+
+        <form
+          onSubmit={handleSubmit}
+          className="border-t border-zinc-200 px-4 py-3 dark:border-zinc-800"
+        >
+          <div className="flex items-center gap-2">
+            <Input
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              placeholder="Ask the agent to edit this dashboard…"
+              disabled={isLoading}
+              autoFocus
+              className="flex-1"
+              aria-label="Message"
+            />
+            <Button type="submit" size="icon" disabled={!input.trim() || isLoading}>
+              <Send className="size-4" aria-hidden="true" />
+              <span className="sr-only">Send</span>
+            </Button>
+          </div>
+        </form>
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+function BoundChatMessage({ message }: { message: UIMessage }) {
+  const isUser = message.role === "user";
+  // Split text and tool parts so tool results render inline as cards
+  // between the assistant's text turns (matches the main AtlasChat
+  // layout convention).
+  const parts = message.parts ?? [];
+
+  if (isUser) {
+    const text = parts
+      .filter((p): p is { type: "text"; text: string } => p.type === "text")
+      .map((p) => p.text)
+      .join("");
+    return (
+      <div className="my-3 flex justify-end">
+        <div className="max-w-[80%] rounded-2xl bg-primary px-3 py-2 text-sm text-primary-foreground">
+          {text}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="my-3 space-y-2">
+      {parts.map((part, idx) => {
+        if (part.type === "text" && "text" in part) {
+          // parseSuggestions splits assistant text into the body + a
+          // trailing <suggestions> block. The bound prompt asks the
+          // agent to emit those; we render only the body in this slice
+          // — chips land in a polish pass.
+          const { text } = parseSuggestions(part.text);
+          return <Markdown key={`t-${idx}`} content={text} />;
+        }
+        if (isToolUIPart(part)) {
+          return <ToolPart key={`tool-${idx}`} part={part} />;
+        }
+        return null;
+      })}
+    </div>
+  );
+}

--- a/packages/web/src/ui/components/dashboards/dashboard-topbar.tsx
+++ b/packages/web/src/ui/components/dashboards/dashboard-topbar.tsx
@@ -43,6 +43,12 @@ interface DashboardTopBarProps {
   suggesting: boolean;
   onDelete: () => void;
   shareSlot: React.ReactNode;
+  /**
+   * #2363 — optional slot for the bound chat drawer trigger. Rendered
+   * next to `shareSlot` so the topbar layout is unchanged when the
+   * caller doesn't supply one.
+   */
+  chatSlot?: React.ReactNode;
   editing: boolean;
   onEditingChange: (next: boolean) => void;
   density: Density;
@@ -63,6 +69,7 @@ export function DashboardTopBar({
   suggesting,
   onDelete,
   shareSlot,
+  chatSlot,
   editing,
   onEditingChange,
   density,
@@ -225,6 +232,8 @@ export function DashboardTopBar({
             <SelectItem value="0 9 * * 1">Weekly (Mon 9am)</SelectItem>
           </SelectContent>
         </Select>
+
+        {chatSlot}
 
         {shareSlot}
 


### PR DESCRIPTION
## Summary
- Right-side chat drawer on `/dashboards/[id]` driven by a bound agent loop with a strict editor tool surface (explore + executeSQL + 6 safe ops).
- Drops `executePython` / action plugins / `proposeDashboard` in bound mode; swaps the system-prompt suffix for `BOUND_AGENT_PROMPT_GUIDANCE` and injects a per-turn compact card summary.
- New `lib/bound-chat-context.ts` owns the conversation↔dashboard relationship — bind / resolve / listSessions / pure `buildCardSummary`. Architecture-wins entry #61.

## Tracer-bullet scope (PRD #2362 follow-ups)
- Per-user drafts → **#2364**
- Destructive-op staging + ghost overlays → **#2365**
- History tab → **#2368**
- Publish UI + flag flip → **#2521**
- Screenshot spike + vision tool → **#2366** / **#2367**
- `createDashboard` reframe → **#2369**

This slice operates directly on the published dashboard with last-write-wins — explicitly tolerated per the issue, since drafts arrive in **#2364**.

## Schema
- New migration `0073_conversation_bound_dashboard.sql` adds `conversations.bound_dashboard_id uuid REFERENCES dashboards(id) ON DELETE SET NULL` + partial index.
- Mirrored in `packages/api/src/lib/db/schema.ts` (drift check passes).
- Real-PG `migrate-pg.test.ts` covers column shape + ON DELETE SET NULL behavior.

## Test plan
- [x] `bound-chat-context.test.ts` — 14 cases (bind / resolve / listSessions / `buildCardSummary` pure / prompt-guidance constant).
- [x] `bound-dashboard.test.ts` — 11 cases (factory shape + each tool's happy/sad path; validates `addCard` rejects invalid SQL without touching the DB; `updateLayout` partial failures; out-of-bounds layout rejection).
- [x] `migrate.test.ts` (db) — updated count to 74 + appended 0073 to applied-list fixture.
- [x] `migrate.test.ts` (auth) — appended 0073 to skip-list fixture.
- [x] `migrate-pg.test.ts` — added two real-PG assertions for 0073.
- [x] Full `bun run test` green.
- [x] `/ci` gates green: lint (0 errors), type, syncpack, template drift, security-headers drift, railway-watch, schema drift, oauth-helper drift.
- [ ] Manual smoke: open `/dashboards/[id]` → click "Edit with chat" → "Add a card showing weekly signups" → "Rename card 2" → "Make card 3 a bar chart" → "What is card 1 counting?".

Closes #2363.