### PR TITLE
feat(chat): #2293 — proactive reaction-to-answer flow

### DIFF
--- a/plugins/chat/src/bridge.ts
+++ b/plugins/chat/src/bridge.ts
@@ -1504,7 +1504,7 @@ export function createChatBridge(
     );
   });
 
-  // --- Proactive listener (slice #2292) ---
+  // --- Proactive listener (slices #2292, #2293) ---
   // Only registers when proactive config is present AND the host-supplied
   // gate (`isEnterpriseEnabled() && workspaceFlag`) returns true. Failures
   // never block the rest of the bridge from coming up.
@@ -1518,6 +1518,10 @@ export function createChatBridge(
           workspace: proactiveConfig.workspace,
           channelAllowlist: proactiveConfig.channelAllowlist,
           channelConfigs: proactiveConfig.channelConfigs,
+          userResolver: proactiveConfig.userResolver,
+          executeQueryProactive: proactiveConfig.executeQueryProactive,
+          linkUrl: proactiveConfig.linkUrl,
+          platform: proactiveConfig.platform,
         }),
       )
       .catch((err) => {

--- a/plugins/chat/src/cards/proactive-answer-card.tsx
+++ b/plugins/chat/src/cards/proactive-answer-card.tsx
@@ -1,0 +1,125 @@
+/** @jsxImportSource chat */
+import { Card, CardText, Section, Actions, Button } from "chat";
+import type { CardElement } from "chat";
+import { toCardElement } from "chat/jsx-runtime";
+
+// ---------------------------------------------------------------------------
+// Action IDs
+// ---------------------------------------------------------------------------
+
+/** Action ID for the "Yes, answer" button on a proactive-offer card. */
+export const PROACTIVE_ANSWER_ACTION_ID = "atlas_proactive_answer";
+
+/** Action ID for the "Not now" dismissal button. */
+export const PROACTIVE_DISMISS_ACTION_ID = "atlas_proactive_dismiss";
+
+// ---------------------------------------------------------------------------
+// Offer card
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the "I can answer this" offer card.
+ *
+ * Sent as an ephemeral message to the asker after Atlas reacts with 🤖.
+ * `messageId` round-trips through the button's `value` so the action
+ * handler can look up the original question without storing a separate
+ * mapping per asker.
+ */
+export function buildProactiveOfferCard(messageId: string): {
+  card: CardElement;
+  fallbackText: string;
+} {
+  const jsx = (
+    <Card title="I can answer this">
+      <Section>
+        <CardText>
+          I think this is a data question I can answer. React 🤖 on your
+          message, or use the button below — only you'll see this prompt.
+        </CardText>
+      </Section>
+      <Actions>
+        <Button id={PROACTIVE_ANSWER_ACTION_ID} style="primary" value={messageId}>
+          Yes, answer
+        </Button>
+        <Button id={PROACTIVE_DISMISS_ACTION_ID} value={messageId}>
+          Not now
+        </Button>
+      </Actions>
+    </Card>
+  );
+
+  const card = toCardElement(jsx);
+  if (!card) {
+    throw new Error("Failed to build proactive offer card");
+  }
+  return {
+    card,
+    fallbackText:
+      "I can answer this — react with 🤖 on your message or reply to opt in.",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Linked-asker answer card
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the in-thread answer card for a linked asker.
+ *
+ * Slice #2293 keeps this minimal — markdown body + a fallback string.
+ * Rich result cards (charts, exports) come from the existing
+ * `buildQueryResultCard` once the full agent loop wires through; for
+ * now we use a plain text card so the proactive path can ship.
+ */
+export function buildProactiveAnswerCard(answer: string): {
+  card: CardElement;
+  fallbackText: string;
+} {
+  const trimmed = answer.trim().length > 0 ? answer : "(no answer produced)";
+  const jsx = (
+    <Card>
+      <Section>
+        <CardText>{trimmed}</CardText>
+      </Section>
+    </Card>
+  );
+  const card = toCardElement(jsx);
+  if (!card) {
+    throw new Error("Failed to build proactive answer card");
+  }
+  return { card, fallbackText: trimmed };
+}
+
+// ---------------------------------------------------------------------------
+// Unlinked-asker prompt
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the "link Atlas to see the answer" prompt for non-OAuth askers.
+ *
+ * Slice #2293 stops at the prompt — actually executing against a
+ * curated public dataset lands in #2297 (HITL design review). The link
+ * URL is host-supplied so self-hosted and SaaS can each route to their
+ * own onboarding surface.
+ */
+export function buildUnlinkedAskerPrompt(linkUrl?: string): {
+  card: CardElement;
+  fallbackText: string;
+} {
+  const cta = linkUrl
+    ? `Link your Atlas account to see this answer: ${linkUrl}`
+    : "Link your Atlas account to see this answer.";
+
+  const jsx = (
+    <Card title="Connect Atlas">
+      <Section>
+        <CardText>{cta}</CardText>
+      </Section>
+    </Card>
+  );
+  const card = toCardElement(jsx);
+  if (!card) {
+    throw new Error("Failed to build unlinked-asker prompt card");
+  }
+  return { card, fallbackText: cta };
+}

--- a/plugins/chat/src/config.ts
+++ b/plugins/chat/src/config.ts
@@ -15,6 +15,10 @@ import type {
   ProactiveGateFn,
   WorkspaceProactiveConfig,
 } from "./proactive/types";
+import type {
+  ProactiveExecuteQuery,
+  ProactiveUserResolver,
+} from "./proactive/answerer";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -411,7 +415,7 @@ export interface ChatPluginConfig {
   proactive?: ProactiveConfig;
 }
 
-/** Proactive chat configuration (slice #2292). */
+/** Proactive chat configuration. */
 export interface ProactiveConfig {
   /** Gate: returns true when proactive mode is allowed. */
   isEnabled: ProactiveGateFn;
@@ -426,6 +430,24 @@ export interface ProactiveConfig {
   channelAllowlist?: string[];
   /** Per-channel overrides keyed by channel ID. */
   channelConfigs?: Record<string, ChannelProactiveConfig>;
+
+  // ---- Slice #2293 additions: reaction-to-answer flow ----
+
+  /**
+   * Resolves a chat-platform user to an Atlas user. Linked askers run
+   * `executeQueryProactive` with their identity (RLS applies). Unlinked
+   * askers receive the link-Atlas stub.
+   */
+  userResolver?: ProactiveUserResolver;
+  /**
+   * Runs the Atlas agent on behalf of a linked asker. Wired by the host
+   * to `runAgent` / `runAgentEffect` with the asker's `AuthContext`.
+   */
+  executeQueryProactive?: ProactiveExecuteQuery;
+  /** Deep link surfaced in the unlinked-asker prompt. */
+  linkUrl?: string;
+  /** Platform name (`"slack"` etc.) recorded in `ProactiveAsker`. */
+  platform?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -665,6 +687,22 @@ const ProactiveConfigSchema = z
     workspace: ProactiveWorkspaceConfigSchema,
     channelAllowlist: z.array(z.string().min(1)).optional(),
     channelConfigs: z.record(z.string(), ProactiveChannelConfigSchema).optional(),
+    userResolver: z
+      .any()
+      .refine(
+        (v) => v === undefined || typeof v === "function",
+        "proactive.userResolver must be a function",
+      )
+      .optional(),
+    executeQueryProactive: z
+      .any()
+      .refine(
+        (v) => v === undefined || typeof v === "function",
+        "proactive.executeQueryProactive must be a function",
+      )
+      .optional(),
+    linkUrl: z.string().url("proactive.linkUrl must be a valid URL").optional(),
+    platform: z.string().min(1).optional(),
   })
   .optional();
 

--- a/plugins/chat/src/index.ts
+++ b/plugins/chat/src/index.ts
@@ -114,26 +114,41 @@ export type {
   ProactiveConfig,
 } from "./config";
 
-// Proactive chat layer (slice #2292: reaction-first tracer)
+// Proactive chat layer (slices #2292 reaction-first tracer + #2293 reaction-to-answer)
 export type {
   ChannelProactiveConfig,
   ClassificationResult,
   InterjectionAction,
   InterjectionDecision,
   LLMClassifierFn,
+  PendingAnswerEntry,
+  ProactiveAsker,
+  ProactiveExecuteQuery,
   ProactiveGateFn,
+  ProactiveQueryResult,
+  ProactiveUserResolver,
+  ResolvedAsker,
   SensitivityPreset,
   WorkspaceProactiveConfig,
 } from "./proactive";
 export {
+  PROACTIVE_ANSWER_ACTION_ID,
+  PROACTIVE_DISMISS_ACTION_ID,
   PROACTIVE_REACTION,
+  PendingAnswers,
+  PENDING_ANSWER_MAX_ENTRIES,
+  PENDING_ANSWER_TTL_MS,
   RECENT_INTERJECTION_COOLDOWN_MS,
   SENSITIVITY_THRESHOLDS,
+  buildProactiveAnswerCard,
+  buildProactiveOfferCard,
+  buildUnlinkedAskerPrompt,
   classifyMessage,
   decideInterjection,
   regexPreFilter,
   registerProactiveListener,
   resolveChannelAllowlist,
+  shouldAnswerOnReaction,
 } from "./proactive";
 export type { ReactionConfig, IReactionLifecycle } from "./features/reactions";
 export { StatusEmoji, createReactionLifecycle } from "./features/reactions";

--- a/plugins/chat/src/proactive/__tests__/answerer.test.ts
+++ b/plugins/chat/src/proactive/__tests__/answerer.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Tests for the reaction-to-answer registry + gating logic.
+ *
+ * The `PendingAnswers` registry is in-memory and TTL-pruned; the
+ * `shouldAnswerOnReaction` function is a pure decision over the
+ * cartesian product of (added/removed × self/other × known/unknown).
+ */
+
+import { describe, expect, it } from "bun:test";
+import {
+  PendingAnswers,
+  PENDING_ANSWER_TTL_MS,
+  shouldAnswerOnReaction,
+  type ProactiveAsker,
+} from "../answerer";
+
+const ASKER: ProactiveAsker = {
+  platform: "slack",
+  externalUserId: "U-asker",
+  userName: "alice",
+};
+
+// ---------------------------------------------------------------------------
+// PendingAnswers
+// ---------------------------------------------------------------------------
+
+describe("PendingAnswers", () => {
+  it("records and consumes a single entry", () => {
+    const reg = new PendingAnswers();
+    reg.record("T1", "M1", { text: "what was MRR last month?", asker: ASKER });
+    expect(reg.size()).toBe(1);
+
+    const peek = reg.peek("T1", "M1");
+    expect(peek?.text).toBe("what was MRR last month?");
+
+    const consumed = reg.consume("T1", "M1");
+    expect(consumed?.text).toBe("what was MRR last month?");
+    expect(reg.consume("T1", "M1")).toBeNull();
+    expect(reg.size()).toBe(0);
+  });
+
+  it("expires entries past the TTL", () => {
+    let now = 1_000_000;
+    const reg = new PendingAnswers(PENDING_ANSWER_TTL_MS, 100, () => now);
+    reg.record("T1", "M1", { text: "q?", asker: ASKER });
+
+    now += PENDING_ANSWER_TTL_MS + 1;
+    expect(reg.peek("T1", "M1")).toBeNull();
+    expect(reg.consume("T1", "M1")).toBeNull();
+  });
+
+  it("evicts the oldest entry when over the cap", () => {
+    const reg = new PendingAnswers(PENDING_ANSWER_TTL_MS, 2);
+    reg.record("T1", "M1", { text: "first", asker: ASKER });
+    reg.record("T1", "M2", { text: "second", asker: ASKER });
+    reg.record("T1", "M3", { text: "third", asker: ASKER });
+
+    expect(reg.peek("T1", "M1")).toBeNull();
+    expect(reg.peek("T1", "M2")?.text).toBe("second");
+    expect(reg.peek("T1", "M3")?.text).toBe("third");
+    expect(reg.size()).toBe(2);
+  });
+
+  it("namespaces entries by thread and message id", () => {
+    const reg = new PendingAnswers();
+    reg.record("T1", "M1", { text: "a", asker: ASKER });
+    reg.record("T2", "M1", { text: "b", asker: ASKER });
+    expect(reg.consume("T1", "M1")?.text).toBe("a");
+    expect(reg.consume("T2", "M1")?.text).toBe("b");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// shouldAnswerOnReaction
+// ---------------------------------------------------------------------------
+
+describe("shouldAnswerOnReaction", () => {
+  const pending = { text: "q?", asker: ASKER, recordedAt: 0 };
+
+  it("answers when a non-bot user adds the reaction to a known message", () => {
+    const decision = shouldAnswerOnReaction({
+      added: true,
+      reactor: { isMe: false, isBot: false, userId: "U-other" },
+      pending,
+    });
+    expect(decision.action).toBe("answer");
+  });
+
+  it("skips when the reaction is removed (not added)", () => {
+    const decision = shouldAnswerOnReaction({
+      added: false,
+      reactor: { isMe: false, isBot: false, userId: "U-other" },
+      pending,
+    });
+    expect(decision).toEqual({ action: "skip", reason: "removed" });
+  });
+
+  it("skips when the reactor is the bot itself", () => {
+    const decision = shouldAnswerOnReaction({
+      added: true,
+      reactor: { isMe: true, isBot: true, userId: "B-atlas" },
+      pending,
+    });
+    expect(decision).toEqual({ action: "skip", reason: "self-reaction" });
+  });
+
+  it("skips when the reactor is another bot", () => {
+    const decision = shouldAnswerOnReaction({
+      added: true,
+      reactor: { isMe: false, isBot: true, userId: "B-other" },
+      pending,
+    });
+    expect(decision).toEqual({ action: "skip", reason: "self-reaction" });
+  });
+
+  it("skips when there is no pending entry (e.g. expired or unrelated message)", () => {
+    const decision = shouldAnswerOnReaction({
+      added: true,
+      reactor: { isMe: false, isBot: false, userId: "U-other" },
+      pending: null,
+    });
+    expect(decision).toEqual({ action: "skip", reason: "unknown-message" });
+  });
+});

--- a/plugins/chat/src/proactive/__tests__/listener.test.ts
+++ b/plugins/chat/src/proactive/__tests__/listener.test.ts
@@ -1,28 +1,37 @@
 /**
  * Tests for the proactive listener wiring.
  *
- * We exercise the handler by capturing the function passed to
- * `chat.onNewMessage(/.+/, handler)` and invoking it directly with
- * fake thread + message objects. That keeps the test free of any real
- * Chat SDK plumbing while still proving the wiring is correct.
+ * We capture the functions passed to `chat.onNewMessage`, `chat.onReaction`,
+ * and `chat.onAction` and invoke them directly with stand-in thread,
+ * message, reaction-event, and action-event objects. That keeps the
+ * test free of any real Chat SDK plumbing while still proving the
+ * wiring is correct.
  */
 
 import { describe, expect, it, mock } from "bun:test";
 import {
+  PROACTIVE_REACTION,
   registerProactiveListener,
   resolveChannelAllowlist,
-  PROACTIVE_REACTION,
 } from "../listener";
-import type { LLMClassifierFn, WorkspaceProactiveConfig } from "../types";
+import {
+  PROACTIVE_ANSWER_ACTION_ID,
+  PROACTIVE_DISMISS_ACTION_ID,
+} from "../../cards/proactive-answer-card";
+import type {
+  LLMClassifierFn,
+  WorkspaceProactiveConfig,
+} from "../types";
+import type {
+  ProactiveExecuteQuery,
+  ProactiveUserResolver,
+} from "../answerer";
 
 // ---------------------------------------------------------------------------
 // Test doubles
 // ---------------------------------------------------------------------------
 
-type ChannelMessageHandler = (
-  thread: ReturnType<typeof makeThread>,
-  message: ReturnType<typeof makeMessage>,
-) => Promise<void> | void;
+type AnyHandler = (...args: unknown[]) => Promise<void> | void;
 
 function makeLogger() {
   return {
@@ -34,32 +43,59 @@ function makeLogger() {
 }
 
 function makeChat() {
-  let captured: ChannelMessageHandler | null = null;
+  let messageHandler: AnyHandler | null = null;
+  let reactionHandler: AnyHandler | null = null;
+  const actionHandlers = new Map<string, AnyHandler>();
+
   const chat = {
-    onNewMessage: mock((_pattern: RegExp, handler: ChannelMessageHandler) => {
-      captured = handler;
+    onNewMessage: mock((_pattern: RegExp, handler: AnyHandler) => {
+      messageHandler = handler;
+    }),
+    onReaction: mock((_filter: unknown[], handler: AnyHandler) => {
+      reactionHandler = handler;
+    }),
+    onAction: mock((actionId: string, handler: AnyHandler) => {
+      actionHandlers.set(actionId, handler);
     }),
   };
+
   return {
     chat,
-    invoke: async (
-      thread: ReturnType<typeof makeThread>,
-      message: ReturnType<typeof makeMessage>,
-    ) => {
-      if (!captured) throw new Error("listener never registered a handler");
-      await captured(thread, message);
+    invokeMessage: async (thread: unknown, message: unknown) => {
+      if (!messageHandler) throw new Error("listener never registered a message handler");
+      await messageHandler(thread, message);
     },
-    isRegistered: () => captured !== null,
+    invokeReaction: async (event: unknown) => {
+      if (!reactionHandler) throw new Error("listener never registered a reaction handler");
+      await reactionHandler(event);
+    },
+    invokeAction: async (actionId: string, event: unknown) => {
+      const handler = actionHandlers.get(actionId);
+      if (!handler) throw new Error(`no handler for action ${actionId}`);
+      await handler(event);
+    },
+    isRegistered: () => messageHandler !== null,
+    handlerCount: () => actionHandlers.size,
   };
 }
 
-function makeThread(channelId = "C-allowed", reaction?: ReturnType<typeof mock>) {
-  const addReaction = reaction ?? mock(async () => {});
+interface ThreadDouble {
+  channelId: string;
+  createSentMessageFromMessage: ReturnType<typeof mock>;
+  postEphemeral: ReturnType<typeof mock>;
+  post: ReturnType<typeof mock>;
+  subscribe: ReturnType<typeof mock>;
+  _addReaction: ReturnType<typeof mock>;
+}
+
+function makeThread(channelId = "C-allowed"): ThreadDouble {
+  const addReaction = mock(async () => {});
   return {
     channelId,
-    createSentMessageFromMessage: mock(() => ({
-      addReaction,
-    })),
+    createSentMessageFromMessage: mock(() => ({ addReaction })),
+    postEphemeral: mock(async () => ({ id: "E1", threadId: channelId, raw: {} })),
+    post: mock(async () => ({ id: "P1" })),
+    subscribe: mock(async () => {}),
     _addReaction: addReaction,
   };
 }
@@ -69,6 +105,8 @@ function makeMessage(opts: {
   text?: string;
   isBot?: boolean | "unknown";
   isMe?: boolean;
+  userId?: string;
+  userName?: string;
 } = {}) {
   return {
     id: opts.id ?? "M1",
@@ -76,8 +114,8 @@ function makeMessage(opts: {
     author: {
       isBot: opts.isBot ?? false,
       isMe: opts.isMe ?? false,
-      userId: "U1",
-      userName: "asker",
+      userId: opts.userId ?? "U-asker",
+      userName: opts.userName ?? "alice",
     },
   };
 }
@@ -90,6 +128,13 @@ const baseWorkspace: WorkspaceProactiveConfig = {
 
 const yesLLM: LLMClassifierFn = async () => ({ isQuestion: true, confidence: 0.9 });
 const noLLM: LLMClassifierFn = async () => ({ isQuestion: false, confidence: 0.1 });
+
+const linkedResolver: ProactiveUserResolver = async () => ({ atlasUserId: "atlas-user-1" });
+const unlinkedResolver: ProactiveUserResolver = async () => ({});
+
+const echoExecute: ProactiveExecuteQuery = async (question) => ({
+  answer: `Echo: ${question}`,
+});
 
 // ---------------------------------------------------------------------------
 // resolveChannelAllowlist
@@ -133,8 +178,8 @@ describe("registerProactiveListener — gating", () => {
     expect(chat.onNewMessage).not.toHaveBeenCalled();
   });
 
-  it("registers when isEnabled() is true", async () => {
-    const { chat, isRegistered } = makeChat();
+  it("registers all three handler types when enabled", async () => {
+    const { chat, isRegistered, handlerCount } = makeChat();
     await registerProactiveListener(chat as any, makeLogger(), {
       isEnabled: () => true,
       classify: yesLLM,
@@ -143,12 +188,18 @@ describe("registerProactiveListener — gating", () => {
     });
     expect(isRegistered()).toBe(true);
     expect(chat.onNewMessage).toHaveBeenCalledTimes(1);
+    expect(chat.onReaction).toHaveBeenCalledTimes(1);
+    expect(handlerCount()).toBe(2); // Yes,answer + Not now
   });
 });
 
-describe("registerProactiveListener — handler behaviour", () => {
-  it("adds a reaction when the channel is allowed and the classifier is confident", async () => {
-    const { chat, invoke } = makeChat();
+// ---------------------------------------------------------------------------
+// Channel-message handler — #2292 behaviours preserved
+// ---------------------------------------------------------------------------
+
+describe("registerProactiveListener — channel-message handler", () => {
+  it("reacts and posts the offer card on a confident question", async () => {
+    const { chat, invokeMessage } = makeChat();
     await registerProactiveListener(chat as any, makeLogger(), {
       isEnabled: () => true,
       classify: yesLLM,
@@ -156,13 +207,14 @@ describe("registerProactiveListener — handler behaviour", () => {
       channelAllowlist: ["C-allowed"],
     });
     const thread = makeThread("C-allowed");
-    await invoke(thread, makeMessage());
+    await invokeMessage(thread, makeMessage());
     expect(thread._addReaction).toHaveBeenCalledTimes(1);
     expect(thread._addReaction).toHaveBeenCalledWith(PROACTIVE_REACTION);
+    expect(thread.postEphemeral).toHaveBeenCalledTimes(1);
   });
 
-  it("does not react when the channel is outside the allowlist", async () => {
-    const { chat, invoke } = makeChat();
+  it("does not react in a non-allowlisted channel", async () => {
+    const { chat, invokeMessage } = makeChat();
     await registerProactiveListener(chat as any, makeLogger(), {
       isEnabled: () => true,
       classify: yesLLM,
@@ -170,27 +222,13 @@ describe("registerProactiveListener — handler behaviour", () => {
       channelAllowlist: ["C-allowed"],
     });
     const thread = makeThread("C-other");
-    await invoke(thread, makeMessage());
+    await invokeMessage(thread, makeMessage());
     expect(thread._addReaction).not.toHaveBeenCalled();
+    expect(thread.postEphemeral).not.toHaveBeenCalled();
   });
 
-  it("does not react when the gate flips off between registration and the message", async () => {
-    let gateOn = true;
-    const { chat, invoke } = makeChat();
-    await registerProactiveListener(chat as any, makeLogger(), {
-      isEnabled: () => gateOn,
-      classify: yesLLM,
-      workspace: baseWorkspace,
-      channelAllowlist: ["C-allowed"],
-    });
-    gateOn = false;
-    const thread = makeThread("C-allowed");
-    await invoke(thread, makeMessage());
-    expect(thread._addReaction).not.toHaveBeenCalled();
-  });
-
-  it("does not react to messages from bots", async () => {
-    const { chat, invoke } = makeChat();
+  it("rate-limits a chatty channel — only the first message reacts", async () => {
+    const { chat, invokeMessage } = makeChat();
     await registerProactiveListener(chat as any, makeLogger(), {
       isEnabled: () => true,
       classify: yesLLM,
@@ -198,12 +236,26 @@ describe("registerProactiveListener — handler behaviour", () => {
       channelAllowlist: ["C-allowed"],
     });
     const thread = makeThread("C-allowed");
-    await invoke(thread, makeMessage({ isBot: true }));
+    await invokeMessage(thread, makeMessage({ id: "M1" }));
+    await invokeMessage(thread, makeMessage({ id: "M2" }));
+    expect(thread._addReaction).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not react to bot messages", async () => {
+    const { chat, invokeMessage } = makeChat();
+    await registerProactiveListener(chat as any, makeLogger(), {
+      isEnabled: () => true,
+      classify: yesLLM,
+      workspace: baseWorkspace,
+      channelAllowlist: ["C-allowed"],
+    });
+    const thread = makeThread("C-allowed");
+    await invokeMessage(thread, makeMessage({ isBot: true }));
     expect(thread._addReaction).not.toHaveBeenCalled();
   });
 
-  it("does not react when the classifier returns low confidence", async () => {
-    const { chat, invoke } = makeChat();
+  it("does not react on low-confidence classification", async () => {
+    const { chat, invokeMessage } = makeChat();
     await registerProactiveListener(chat as any, makeLogger(), {
       isEnabled: () => true,
       classify: noLLM,
@@ -211,38 +263,228 @@ describe("registerProactiveListener — handler behaviour", () => {
       channelAllowlist: ["C-allowed"],
     });
     const thread = makeThread("C-allowed");
-    await invoke(thread, makeMessage());
+    await invokeMessage(thread, makeMessage());
     expect(thread._addReaction).not.toHaveBeenCalled();
   });
+});
 
-  it("rate-limits a chatty channel — only one reaction inside the cooldown", async () => {
-    const { chat, invoke } = makeChat();
-    await registerProactiveListener(chat as any, makeLogger(), {
-      isEnabled: () => true,
-      classify: yesLLM,
-      workspace: baseWorkspace,
-      channelAllowlist: ["C-allowed"],
-    });
-    const thread = makeThread("C-allowed");
-    await invoke(thread, makeMessage({ id: "M1" }));
-    await invoke(thread, makeMessage({ id: "M2" }));
-    expect(thread._addReaction).toHaveBeenCalledTimes(1);
-  });
+// ---------------------------------------------------------------------------
+// Reaction-back handler — #2293 happy paths
+// ---------------------------------------------------------------------------
 
-  it("does not throw when addReaction fails — failures are best-effort", async () => {
-    const reaction = mock(async () => {
-      throw new Error("slack rate limit");
-    });
-    const { chat, invoke } = makeChat();
+describe("registerProactiveListener — reaction-back handler", () => {
+  async function setup(opts: {
+    userResolver?: ProactiveUserResolver;
+    executeQueryProactive?: ProactiveExecuteQuery;
+    linkUrl?: string;
+  } = {}) {
+    const { chat, invokeMessage, invokeReaction, invokeAction } = makeChat();
     const log = makeLogger();
     await registerProactiveListener(chat as any, log, {
       isEnabled: () => true,
       classify: yesLLM,
       workspace: baseWorkspace,
       channelAllowlist: ["C-allowed"],
+      userResolver: opts.userResolver,
+      executeQueryProactive: opts.executeQueryProactive,
+      linkUrl: opts.linkUrl,
     });
-    const thread = makeThread("C-allowed", reaction);
-    await invoke(thread, makeMessage());
+    return { chat, log, invokeMessage, invokeReaction, invokeAction };
+  }
+
+  it("posts the linked-asker answer card on reaction-back", async () => {
+    const executeQueryProactive: ProactiveExecuteQuery = mock(echoExecute);
+    const { invokeMessage, invokeReaction } = await setup({
+      userResolver: linkedResolver,
+      executeQueryProactive,
+    });
+
+    const thread = makeThread("C-allowed");
+    await invokeMessage(thread, makeMessage({ id: "M1" }));
+
+    await invokeReaction({
+      added: true,
+      messageId: "M1",
+      threadId: thread.channelId,
+      thread,
+      user: { isMe: false, isBot: false, userId: "U-other", userName: "bob" },
+      emoji: PROACTIVE_REACTION,
+      rawEmoji: "robot_face",
+      adapter: { name: "slack" },
+      raw: {},
+    });
+
+    expect(executeQueryProactive).toHaveBeenCalledTimes(1);
+    expect(thread.post).toHaveBeenCalledTimes(1);
+    expect(thread.subscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it("posts the unlinked-asker stub when the resolver returns no atlasUserId", async () => {
+    const executeQueryProactive = mock(echoExecute);
+    const { invokeMessage, invokeReaction } = await setup({
+      userResolver: unlinkedResolver,
+      executeQueryProactive,
+      linkUrl: "https://app.useatlas.dev/link",
+    });
+
+    const thread = makeThread("C-allowed");
+    await invokeMessage(thread, makeMessage({ id: "M1" }));
+    await invokeReaction({
+      added: true,
+      messageId: "M1",
+      threadId: thread.channelId,
+      thread,
+      user: { isMe: false, isBot: false, userId: "U-other", userName: "bob" },
+      emoji: PROACTIVE_REACTION,
+      rawEmoji: "robot_face",
+      adapter: { name: "slack" },
+      raw: {},
+    });
+
+    expect(executeQueryProactive).not.toHaveBeenCalled();
+    expect(thread.post).toHaveBeenCalledTimes(1);
+    expect(thread.subscribe).not.toHaveBeenCalled();
+  });
+
+  it("skips when the reactor is the bot itself", async () => {
+    const executeQueryProactive = mock(echoExecute);
+    const { invokeMessage, invokeReaction } = await setup({
+      userResolver: linkedResolver,
+      executeQueryProactive,
+    });
+    const thread = makeThread("C-allowed");
+    await invokeMessage(thread, makeMessage({ id: "M1" }));
+    await invokeReaction({
+      added: true,
+      messageId: "M1",
+      threadId: thread.channelId,
+      thread,
+      user: { isMe: true, isBot: true, userId: "B-atlas", userName: "atlas" },
+      emoji: PROACTIVE_REACTION,
+      rawEmoji: "robot_face",
+      adapter: { name: "slack" },
+      raw: {},
+    });
+    expect(executeQueryProactive).not.toHaveBeenCalled();
+    expect(thread.post).not.toHaveBeenCalled();
+  });
+
+  it("skips when the reaction is on an unknown message", async () => {
+    const executeQueryProactive = mock(echoExecute);
+    const { invokeReaction } = await setup({
+      userResolver: linkedResolver,
+      executeQueryProactive,
+    });
+    const thread = makeThread("C-allowed");
+    await invokeReaction({
+      added: true,
+      messageId: "M-unknown",
+      threadId: thread.channelId,
+      thread,
+      user: { isMe: false, isBot: false, userId: "U-other", userName: "bob" },
+      emoji: PROACTIVE_REACTION,
+      rawEmoji: "robot_face",
+      adapter: { name: "slack" },
+      raw: {},
+    });
+    expect(executeQueryProactive).not.toHaveBeenCalled();
+    expect(thread.post).not.toHaveBeenCalled();
+  });
+
+  it("falls back to unlinked prompt when executeQueryProactive is not configured", async () => {
+    const { invokeMessage, invokeReaction, log } = await setup({
+      userResolver: linkedResolver,
+      // executeQueryProactive deliberately omitted
+    });
+
+    const thread = makeThread("C-allowed");
+    await invokeMessage(thread, makeMessage({ id: "M1" }));
+    await invokeReaction({
+      added: true,
+      messageId: "M1",
+      threadId: thread.channelId,
+      thread,
+      user: { isMe: false, isBot: false, userId: "U-other", userName: "bob" },
+      emoji: PROACTIVE_REACTION,
+      rawEmoji: "robot_face",
+      adapter: { name: "slack" },
+      raw: {},
+    });
+
+    expect(thread.post).toHaveBeenCalledTimes(1);
     expect(log.warn).toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Button handlers — #2293 inline "Yes, answer" / "Not now"
+// ---------------------------------------------------------------------------
+
+describe("registerProactiveListener — button handlers", () => {
+  it("triggers the answer flow when 'Yes, answer' is clicked", async () => {
+    const executeQueryProactive: ProactiveExecuteQuery = mock(echoExecute);
+    const { chat, invokeMessage, invokeAction } = makeChat();
+    await registerProactiveListener(chat as any, makeLogger(), {
+      isEnabled: () => true,
+      classify: yesLLM,
+      workspace: baseWorkspace,
+      channelAllowlist: ["C-allowed"],
+      userResolver: linkedResolver,
+      executeQueryProactive,
+    });
+    const thread = makeThread("C-allowed");
+    await invokeMessage(thread, makeMessage({ id: "M1" }));
+    await invokeAction(PROACTIVE_ANSWER_ACTION_ID, {
+      actionId: PROACTIVE_ANSWER_ACTION_ID,
+      adapter: { name: "slack" },
+      messageId: "offer-msg",
+      thread,
+      threadId: thread.channelId,
+      user: { isMe: false, isBot: false, userId: "U-asker", userName: "alice" },
+      value: "M1",
+      raw: {},
+    });
+    expect(executeQueryProactive).toHaveBeenCalledTimes(1);
+    expect(thread.post).toHaveBeenCalledTimes(1);
+  });
+
+  it("consumes the pending entry on 'Not now' without answering", async () => {
+    const executeQueryProactive = mock(echoExecute);
+    const { chat, invokeMessage, invokeReaction, invokeAction } = makeChat();
+    await registerProactiveListener(chat as any, makeLogger(), {
+      isEnabled: () => true,
+      classify: yesLLM,
+      workspace: baseWorkspace,
+      channelAllowlist: ["C-allowed"],
+      userResolver: linkedResolver,
+      executeQueryProactive,
+    });
+    const thread = makeThread("C-allowed");
+    await invokeMessage(thread, makeMessage({ id: "M1" }));
+    await invokeAction(PROACTIVE_DISMISS_ACTION_ID, {
+      actionId: PROACTIVE_DISMISS_ACTION_ID,
+      adapter: { name: "slack" },
+      messageId: "offer-msg",
+      thread,
+      threadId: thread.channelId,
+      user: { isMe: false, isBot: false, userId: "U-asker", userName: "alice" },
+      value: "M1",
+      raw: {},
+    });
+
+    // A later reaction-back should now find nothing pending.
+    await invokeReaction({
+      added: true,
+      messageId: "M1",
+      threadId: thread.channelId,
+      thread,
+      user: { isMe: false, isBot: false, userId: "U-other", userName: "bob" },
+      emoji: PROACTIVE_REACTION,
+      rawEmoji: "robot_face",
+      adapter: { name: "slack" },
+      raw: {},
+    });
+    expect(executeQueryProactive).not.toHaveBeenCalled();
+    expect(thread.post).not.toHaveBeenCalled();
   });
 });

--- a/plugins/chat/src/proactive/answerer.ts
+++ b/plugins/chat/src/proactive/answerer.ts
@@ -1,0 +1,193 @@
+/**
+ * Reaction-to-answer flow for proactive chat (slice #2293).
+ *
+ * After the listener has reacted 🤖 to a message (slice #2292), this
+ * module:
+ *   - remembers the original message in a TTL'd in-memory registry
+ *   - when an asker (or anyone else in the channel) adds 🤖 back, or
+ *     clicks the "Yes, answer" ephemeral button, looks the message up
+ *   - resolves the asker to an Atlas user via a host-supplied callback
+ *   - runs `executeQueryProactive` for linked askers, or posts the
+ *     unlinked-asker stub
+ *
+ * Slice #2293 keeps the answer rendering minimal — see
+ * `plugins/chat/src/cards/proactive-answer-card.tsx`. Rich query-result
+ * cards arrive when the full agent path wires through; for now the
+ * priority is round-tripping `subscribe → classify → react → answer`.
+ */
+
+import type { Author } from "chat";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/** External chat-platform user that asked a question Atlas reacted to. */
+export interface ProactiveAsker {
+  /** Platform name, e.g. "slack". */
+  platform: string;
+  /** Platform-side user ID (Slack U…, etc.). */
+  externalUserId: string;
+  /** Optional display name for logs / fallback prompts. */
+  userName?: string;
+}
+
+/** Returned by the host's user-resolver callback. */
+export interface ResolvedAsker {
+  /** Atlas user ID when the chat user is linked via OAuth. */
+  atlasUserId?: string;
+}
+
+/** Resolver: chat-platform identity → Atlas identity. */
+export type ProactiveUserResolver = (
+  asker: ProactiveAsker,
+) => Promise<ResolvedAsker>;
+
+/** Result returned by `executeQueryProactive`. */
+export interface ProactiveQueryResult {
+  /** Markdown body to post in-thread. */
+  answer: string;
+  /**
+   * Whether to subscribe the thread so follow-ups flow through
+   * `onSubscribedMessage`. Defaults to true at the call site.
+   */
+  followupSubscribe?: boolean;
+}
+
+/** Execute the Atlas agent on behalf of a linked asker. */
+export type ProactiveExecuteQuery = (
+  question: string,
+  context: {
+    threadId: string;
+    asker: ProactiveAsker;
+    atlasUserId: string;
+  },
+) => Promise<ProactiveQueryResult>;
+
+// ---------------------------------------------------------------------------
+// Pending-answer registry
+// ---------------------------------------------------------------------------
+
+/** A message we reacted to and are waiting on a follow-up reaction/button. */
+export interface PendingAnswerEntry {
+  text: string;
+  asker: ProactiveAsker;
+  /** Epoch ms when this entry was recorded. */
+  recordedAt: number;
+}
+
+/**
+ * Time after which a pending-answer entry is forgotten.
+ *
+ * Two hours feels right: long enough that a user can step away and
+ * come back to react, short enough that the in-memory map can't bloat
+ * unbounded. Persistent storage of pending answers can land later if
+ * data shows it matters; reaction-back within 2h is the realistic
+ * happy path.
+ */
+export const PENDING_ANSWER_TTL_MS = 2 * 60 * 60 * 1000;
+
+/** Hard cap on the in-memory registry. Oldest entries evict on overflow. */
+export const PENDING_ANSWER_MAX_ENTRIES = 10_000;
+
+/**
+ * In-memory registry of "Atlas reacted, waiting for asker to opt in".
+ *
+ * Single-process only — multi-pod deployments would need a shared
+ * store, but for slice #2293 (Slack-first, low scale) a Map suffices.
+ * The pause + meter slices already plan to move state into PG/Redis;
+ * we'll piggyback then.
+ */
+export class PendingAnswers {
+  private readonly store = new Map<string, PendingAnswerEntry>();
+
+  constructor(
+    private readonly ttlMs: number = PENDING_ANSWER_TTL_MS,
+    private readonly maxEntries: number = PENDING_ANSWER_MAX_ENTRIES,
+    private readonly now: () => number = Date.now,
+  ) {}
+
+  /** Build the lookup key from thread + message IDs. */
+  static key(threadId: string, messageId: string): string {
+    return `${threadId}:${messageId}`;
+  }
+
+  /** Record that Atlas reacted to a message and is waiting on opt-in. */
+  record(threadId: string, messageId: string, entry: Omit<PendingAnswerEntry, "recordedAt">): void {
+    if (this.store.size >= this.maxEntries) {
+      // Evict the oldest entry to keep the map bounded. Insertion order
+      // in a Map is preserved, so the first key is the oldest.
+      const oldestKey = this.store.keys().next().value;
+      if (oldestKey) this.store.delete(oldestKey);
+    }
+    this.store.set(PendingAnswers.key(threadId, messageId), {
+      ...entry,
+      recordedAt: this.now(),
+    });
+  }
+
+  /**
+   * Look up and consume a pending entry. Returns null if missing or
+   * expired. Consuming is by design — an asker who reacts twice
+   * should not trigger two answers.
+   */
+  consume(threadId: string, messageId: string): PendingAnswerEntry | null {
+    const key = PendingAnswers.key(threadId, messageId);
+    const entry = this.store.get(key);
+    if (!entry) return null;
+    if (this.now() - entry.recordedAt > this.ttlMs) {
+      this.store.delete(key);
+      return null;
+    }
+    this.store.delete(key);
+    return entry;
+  }
+
+  /** Read-only peek for tests; does not consume. */
+  peek(threadId: string, messageId: string): PendingAnswerEntry | null {
+    const entry = this.store.get(PendingAnswers.key(threadId, messageId));
+    if (!entry) return null;
+    if (this.now() - entry.recordedAt > this.ttlMs) return null;
+    return entry;
+  }
+
+  /** Current size for tests + admin diagnostics. */
+  size(): number {
+    return this.store.size;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Reaction-back gating (pure)
+// ---------------------------------------------------------------------------
+
+/** Decision returned by `shouldAnswerOnReaction`. */
+export type ReactionAnswerDecision =
+  | { action: "answer"; pending: PendingAnswerEntry }
+  | { action: "skip"; reason: "self-reaction" | "unknown-message" | "removed" };
+
+export interface ShouldAnswerOnReactionInput {
+  /** Whether the reaction was added (`true`) or removed (`false`). */
+  added: boolean;
+  /** Author of the reaction. Self-reactions are ignored. */
+  reactor: Pick<Author, "isMe" | "isBot" | "userId">;
+  /** Pending lookup; consumed when answered to prevent double-fire. */
+  pending: PendingAnswerEntry | null;
+}
+
+/**
+ * Pure decision for whether a reaction triggers an answer.
+ *
+ * Separated from the side-effecting handler so the decision matrix can
+ * be unit-tested without faking the Chat SDK.
+ */
+export function shouldAnswerOnReaction(
+  input: ShouldAnswerOnReactionInput,
+): ReactionAnswerDecision {
+  if (!input.added) return { action: "skip", reason: "removed" };
+  if (input.reactor.isMe || input.reactor.isBot === true) {
+    return { action: "skip", reason: "self-reaction" };
+  }
+  if (!input.pending) return { action: "skip", reason: "unknown-message" };
+  return { action: "answer", pending: input.pending };
+}

--- a/plugins/chat/src/proactive/index.ts
+++ b/plugins/chat/src/proactive/index.ts
@@ -1,9 +1,10 @@
 /**
  * Proactive chat layer — public exports.
  *
- * Slice #2292: reaction-first tracer. Subscribe → classify → react. No
- * reply yet. Later slices add the answer, kill switches, admin config,
- * meter, and feedback.
+ * Slice #2292: reaction-first tracer (subscribe → classify → react).
+ * Slice #2293: reaction-to-answer flow (the asker reacts back or
+ * clicks the ephemeral "Yes, answer" card → Atlas posts the answer).
+ * Later slices add kill switches, admin config, meter, and feedback.
  */
 
 export type {
@@ -38,3 +39,26 @@ export {
   resolveChannelAllowlist,
   type ProactiveListenerConfig,
 } from "./listener";
+
+export {
+  PendingAnswers,
+  PENDING_ANSWER_MAX_ENTRIES,
+  PENDING_ANSWER_TTL_MS,
+  shouldAnswerOnReaction,
+  type PendingAnswerEntry,
+  type ProactiveAsker,
+  type ProactiveExecuteQuery,
+  type ProactiveQueryResult,
+  type ProactiveUserResolver,
+  type ReactionAnswerDecision,
+  type ResolvedAsker,
+  type ShouldAnswerOnReactionInput,
+} from "./answerer";
+
+export {
+  PROACTIVE_ANSWER_ACTION_ID,
+  PROACTIVE_DISMISS_ACTION_ID,
+  buildProactiveAnswerCard,
+  buildProactiveOfferCard,
+  buildUnlinkedAskerPrompt,
+} from "../cards/proactive-answer-card";

--- a/plugins/chat/src/proactive/listener.ts
+++ b/plugins/chat/src/proactive/listener.ts
@@ -1,23 +1,29 @@
 /**
  * Proactive chat listener wiring.
  *
- * Registers an `onNewMessage` handler on the Chat SDK so that channel
- * messages (which would otherwise fall through) get classified and —
- * when policy says so — reacted to with 🤖.
+ * Slice #2292: subscribe → classify → react 🤖 on confident questions.
+ * Slice #2293: when the asker (or anyone) reacts 🤖 back, or clicks
+ * the "Yes, answer" button on the ephemeral offer, post the answer
+ * in-thread.
  *
- * Slice #2292 stops at the reaction. The reply path lands in #2293.
- *
- * Important: this module never imports `@atlas/ee` directly. The host
- * (typically `packages/api`) wires `isEnabled` to
- * `isEnterpriseEnabled() && workspaceFlag` so the plugin stays
- * decoupled from the enterprise gate.
+ * The plugin never imports `@atlas/ee` or `@atlas/api` directly. The
+ * host wires `isEnabled` (`isEnterpriseEnabled() && workspaceFlag`),
+ * `classify` (LLM call), `userResolver` (asker → Atlas user), and
+ * `executeQueryProactive` (Atlas agent on behalf of the asker).
  */
 
 import { emoji } from "chat";
-import type { Chat, Message, Thread } from "chat";
+import type { Author, Chat, Message, ReactionEvent, Thread } from "chat";
 import type { PluginLogger } from "@useatlas/plugin-sdk";
 import { classifyMessage } from "./classifier";
 import { decideInterjection } from "./policy";
+import {
+  PendingAnswers,
+  shouldAnswerOnReaction,
+  type ProactiveAsker,
+  type ProactiveExecuteQuery,
+  type ProactiveUserResolver,
+} from "./answerer";
 import type {
   ChannelProactiveConfig,
   LLMClassifierFn,
@@ -25,36 +31,52 @@ import type {
   RecentActivity,
   WorkspaceProactiveConfig,
 } from "./types";
+import {
+  buildProactiveAnswerCard,
+  buildProactiveOfferCard,
+  buildUnlinkedAskerPrompt,
+  PROACTIVE_ANSWER_ACTION_ID,
+  PROACTIVE_DISMISS_ACTION_ID,
+} from "../cards/proactive-answer-card";
 
 // ---------------------------------------------------------------------------
 // Public config
 // ---------------------------------------------------------------------------
 
-/** Configuration for the proactive listener. */
 export interface ProactiveListenerConfig {
-  /** Gate: returns true when proactive mode is allowed (enterprise + workspace flag). */
+  /** Gate: true when proactive mode is allowed (enterprise + workspace flag). */
   isEnabled: ProactiveGateFn;
-  /** LLM classifier callback. Plugins do not own the model wiring. */
+  /** LLM classifier callback. */
   classify: LLMClassifierFn;
   /** Workspace-level config. */
   workspace: WorkspaceProactiveConfig;
-  /**
-   * Optional explicit channel allowlist. If omitted, the listener reads
-   * `ATLAS_PROACTIVE_CHANNELS` (comma-separated channel IDs). This is
-   * intentionally crude for slice #2292 — admin UI lands in #2294.
-   */
+  /** Explicit channel allowlist, else `ATLAS_PROACTIVE_CHANNELS`. */
   channelAllowlist?: string[];
   /** Per-channel overrides keyed by channel ID. */
   channelConfigs?: Record<string, ChannelProactiveConfig>;
+
+  // ---- Slice #2293 additions ----
+
+  /**
+   * Resolves a chat-platform user to an Atlas user. Linked askers get
+   * the answer with their RLS; unlinked askers see the stub.
+   */
+  userResolver?: ProactiveUserResolver;
+  /**
+   * Runs the Atlas agent on behalf of a linked asker. Host wires this
+   * to `runAgent` / `runAgentEffect` with the asker's `AuthContext`.
+   */
+  executeQueryProactive?: ProactiveExecuteQuery;
+  /** URL the unlinked-asker prompt deep-links to. */
+  linkUrl?: string;
+  /** Platform name (`"slack"` etc.) used in `ProactiveAsker`. */
+  platform?: string;
 }
 
 /**
- * Reaction emoji used when policy decides to interject.
- *
- * `robot_face` isn't in the Chat SDK's well-known emoji map, so we go
- * through the SDK's `custom()` escape hatch. The adapter resolves the
- * shortcode per platform (`:robot_face:` on Slack, 🤖 on Google Chat,
- * etc.) so the plugin stays free of raw Unicode.
+ * Reaction emoji used when policy decides to interject. `robot_face`
+ * isn't in the SDK well-known emoji map, so we use the `custom()`
+ * escape hatch and let each adapter resolve to its native shortcode.
  */
 export const PROACTIVE_REACTION = emoji.custom("robot_face");
 
@@ -62,7 +84,6 @@ export const PROACTIVE_REACTION = emoji.custom("robot_face");
 // Channel allowlist resolution
 // ---------------------------------------------------------------------------
 
-/** Resolve the channel allowlist from config or `ATLAS_PROACTIVE_CHANNELS`. */
 export function resolveChannelAllowlist(
   explicit: string[] | undefined,
   env: NodeJS.ProcessEnv = process.env,
@@ -78,6 +99,24 @@ export function resolveChannelAllowlist(
 }
 
 // ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/** Adapter platform name, when the SDK exposes it. */
+function adapterPlatform(adapter: { name?: string } | undefined, fallback?: string): string {
+  return adapter?.name ?? fallback ?? "unknown";
+}
+
+/** Build a ProactiveAsker from a message author. */
+function askerFromAuthor(author: Author, platform: string): ProactiveAsker {
+  return {
+    platform,
+    externalUserId: author.userId,
+    userName: author.userName,
+  };
+}
+
+// ---------------------------------------------------------------------------
 // Listener registration
 // ---------------------------------------------------------------------------
 
@@ -86,8 +125,8 @@ export function resolveChannelAllowlist(
  *
  * Does nothing (and logs at debug) when `isEnabled()` returns falsy at
  * registration time. The gate is *also* re-checked inside the handler
- * for every message so that a workspace toggle flip takes effect
- * without restart.
+ * for every message so a workspace toggle flip takes effect without
+ * a restart.
  */
 export async function registerProactiveListener(
   chat: Chat,
@@ -101,24 +140,19 @@ export async function registerProactiveListener(
   }
 
   const allowlist = resolveChannelAllowlist(config.channelAllowlist);
-  log.info(
-    { allowlistSize: allowlist.size },
-    "Proactive listener registered",
-  );
+  log.info({ allowlistSize: allowlist.size }, "Proactive listener registered");
 
-  // Per-channel last-interjection timestamps for rate limiting. In-memory
-  // is fine for slice #2292 — #2296 swaps in a durable meter.
+  // Per-channel last-interjection timestamps for rate limiting.
   const recent = new Map<string, RecentActivity>();
+  // Pending answers awaiting a reaction-back or button-click.
+  const pending = new PendingAnswers();
 
-  // Match any non-empty message. The classifier+policy gate downstream.
+  // -------------------------------------------------------------------------
+  // Channel-message hook: classify + react
+  // -------------------------------------------------------------------------
   chat.onNewMessage(/.+/, async (thread: Thread, message: Message) => {
     try {
-      // Re-check the gate per message so a workspace toggle flip wins
-      // without a restart.
       if (!(await config.isEnabled())) return;
-
-      // Bots (including this one) and empty messages bypass the
-      // classifier outright.
       if (message.author.isBot === true || message.author.isMe) return;
       const text = message.text?.trim() ?? "";
       if (text.length === 0) return;
@@ -158,8 +192,17 @@ export async function registerProactiveListener(
       const sent = thread.createSentMessageFromMessage(message);
       await sent.addReaction(PROACTIVE_REACTION);
       recent.set(channelId, { lastInterjectionAt: Date.now() });
+
+      const platform = adapterPlatform(undefined, config.platform);
+      const asker = askerFromAuthor(message.author, platform);
+      pending.record(thread.channelId, message.id, { text, asker });
+
+      // Send an ephemeral "Yes, answer" offer card to the asker — only
+      // they see it, so the channel stays clean even when the asker
+      // doesn't react back. Best-effort: a missing or fallback-disabled
+      // adapter is fine.
+      await postOfferCard(thread, message, log);
     } catch (err) {
-      // Listener must never crash the Chat SDK event loop.
       log.warn(
         {
           err: err instanceof Error ? err : new Error(String(err)),
@@ -169,4 +212,206 @@ export async function registerProactiveListener(
       );
     }
   });
+
+  // -------------------------------------------------------------------------
+  // Reaction-back hook: trigger the answer flow
+  // -------------------------------------------------------------------------
+  chat.onReaction([PROACTIVE_REACTION], async (event: ReactionEvent) => {
+    try {
+      if (!(await config.isEnabled())) return;
+      const lookup = pending.peek(event.threadId, event.messageId);
+      const decision = shouldAnswerOnReaction({
+        added: event.added,
+        reactor: event.user,
+        pending: lookup,
+      });
+      if (decision.action !== "answer") {
+        log.debug(
+          {
+            threadId: event.threadId,
+            messageId: event.messageId,
+            reason: decision.reason,
+          },
+          "Reaction-back skipped",
+        );
+        return;
+      }
+      // Consume now so a second reactor doesn't double-fire.
+      pending.consume(event.threadId, event.messageId);
+      await runAnswerFlow(event.thread, event.threadId, decision.pending.text, decision.pending.asker, config, log);
+    } catch (err) {
+      log.warn(
+        {
+          err: err instanceof Error ? err : new Error(String(err)),
+          messageId: event?.messageId,
+        },
+        "Proactive reaction-back handler threw — suppressed",
+      );
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // "Yes, answer" / "Not now" button handlers
+  // -------------------------------------------------------------------------
+  chat.onAction(PROACTIVE_ANSWER_ACTION_ID, async (event) => {
+    try {
+      if (!(await config.isEnabled())) return;
+      // Thread is null for view-based actions (e.g. home-tab buttons),
+      // which the proactive offer card never reaches.
+      if (!event.thread) return;
+      // `event.value` is the original message ID the offer card was
+      // built against.
+      const originalMessageId = typeof event.value === "string" ? event.value : "";
+      const lookup = pending.consume(event.threadId, originalMessageId);
+      if (!lookup) {
+        log.debug(
+          {
+            threadId: event.threadId,
+            messageId: originalMessageId,
+          },
+          "Proactive 'Yes, answer' clicked but no pending entry — likely expired or already answered",
+        );
+        return;
+      }
+      await runAnswerFlow(event.thread, event.threadId, lookup.text, lookup.asker, config, log);
+    } catch (err) {
+      log.warn(
+        {
+          err: err instanceof Error ? err : new Error(String(err)),
+          actionId: PROACTIVE_ANSWER_ACTION_ID,
+        },
+        "Proactive answer button handler threw — suppressed",
+      );
+    }
+  });
+
+  chat.onAction(PROACTIVE_DISMISS_ACTION_ID, async (event) => {
+    try {
+      const originalMessageId = typeof event.value === "string" ? event.value : "";
+      pending.consume(event.threadId, originalMessageId);
+      log.debug(
+        { threadId: event.threadId, messageId: originalMessageId },
+        "Proactive offer dismissed by asker",
+      );
+    } catch (err) {
+      log.warn(
+        { err: err instanceof Error ? err : new Error(String(err)) },
+        "Proactive dismiss handler threw — suppressed",
+      );
+    }
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Internal: offer card + answer flow
+// ---------------------------------------------------------------------------
+
+type AnyThread = Thread<unknown, unknown>;
+
+async function postOfferCard(thread: AnyThread, message: Message, log: PluginLogger): Promise<void> {
+  try {
+    const offer = buildProactiveOfferCard(message.id);
+    await thread.postEphemeral(message.author, offer, { fallbackToDM: true });
+  } catch (err) {
+    // Failure to post the offer card must not poison the reaction
+    // flow — the asker can still react back manually.
+    log.debug(
+      { err: err instanceof Error ? err : new Error(String(err)) },
+      "Proactive offer card delivery failed — reaction-back path still available",
+    );
+  }
+}
+
+async function runAnswerFlow(
+  thread: AnyThread,
+  threadId: string,
+  text: string,
+  asker: ProactiveAsker,
+  config: ProactiveListenerConfig,
+  log: PluginLogger,
+): Promise<void> {
+  const resolved = config.userResolver
+    ? await safeResolveUser(config.userResolver, asker, log)
+    : { atlasUserId: undefined };
+
+  if (!resolved.atlasUserId) {
+    const prompt = buildUnlinkedAskerPrompt(config.linkUrl);
+    await thread.post(prompt);
+    log.info(
+      { threadId, externalUserId: asker.externalUserId },
+      "Proactive answer: posted unlinked-asker stub",
+    );
+    return;
+  }
+
+  if (!config.executeQueryProactive) {
+    log.warn(
+      { threadId },
+      "Proactive answer: linked asker resolved but executeQueryProactive not wired — falling back to unlinked prompt",
+    );
+    const prompt = buildUnlinkedAskerPrompt(config.linkUrl);
+    await thread.post(prompt);
+    return;
+  }
+
+  let result: { answer: string; followupSubscribe?: boolean };
+  try {
+    result = await config.executeQueryProactive(text, {
+      threadId,
+      asker,
+      atlasUserId: resolved.atlasUserId,
+    });
+  } catch (err) {
+    log.error(
+      {
+        err: err instanceof Error ? err : new Error(String(err)),
+        threadId,
+      },
+      "Proactive executeQueryProactive threw",
+    );
+    await thread.post(
+      "Sorry — I hit an error while answering. Try asking again or use `@atlas` directly.",
+    );
+    return;
+  }
+
+  const answer = buildProactiveAnswerCard(result.answer);
+  await thread.post(answer);
+
+  // Subscribe so follow-ups in the thread flow through the existing
+  // `onSubscribedMessage` handler.
+  if (result.followupSubscribe !== false) {
+    try {
+      await thread.subscribe();
+    } catch (err) {
+      log.warn(
+        { err: err instanceof Error ? err : new Error(String(err)), threadId },
+        "Proactive thread.subscribe() failed — follow-ups via onSubscribedMessage may not fire",
+      );
+    }
+  }
+
+  log.info(
+    { threadId, externalUserId: asker.externalUserId, atlasUserId: resolved.atlasUserId },
+    "Proactive answer delivered to linked asker",
+  );
+}
+
+async function safeResolveUser(
+  resolver: ProactiveUserResolver,
+  asker: ProactiveAsker,
+  log: PluginLogger,
+): Promise<{ atlasUserId?: string }> {
+  try {
+    return await resolver(asker);
+  } catch (err) {
+    log.warn(
+      {
+        err: err instanceof Error ? err : new Error(String(err)),
+        externalUserId: asker.externalUserId,
+      },
+      "Proactive userResolver threw — treating asker as unlinked",
+    );
+    return { atlasUserId: undefined };
+  }
 }


### PR DESCRIPTION
Closes #2293 — part of milestone 1.5.0 (PRD #2291). Builds on #2292 (PR #2523).

## Summary

- Extends the proactive listener: reaction-back **or** inline "Yes, answer" button → Atlas posts the answer in-thread.
- Linked askers (Slack user → Atlas user via OAuth) get the answer with their RLS via host-supplied `executeQueryProactive`.
- Unlinked askers see the "Link Atlas" stub — the curated public-dataset path is deferred to #2297 (HITL design review).
- Ephemeral offer card with [Yes, answer] / [Not now] buttons is sent only to the asker, so the channel stays clean while still giving the click path.
- After answering, `thread.subscribe()` hands off to the existing `onSubscribedMessage` handler for follow-ups.

## Acceptance criteria

- [x] Reaction-back event handler: user adds 🤖 reaction → Atlas executes `executeQueryProactive` for the original message
- [x] Inline "Yes, answer" button alternative wired (and "Not now" dismiss)
- [x] Linked-asker path: Slack user identified → resolved via host callback → query executes with that user's identity (host wires RLS)
- [x] Unlinked-asker path (interim): "Link Atlas to see the answer" prompt; no query executes
- [x] Answer posts as a thread reply
- [x] `thread.subscribe()` so follow-ups flow through existing `onSubscribedMessage`
- [x] Integration tests round-trip message → reaction-back / button → answer for linked + unlinked askers
- [x] Demoable: question in a configured channel → 🤖 → react back or click → answer

## Files

- `plugins/chat/src/proactive/answerer.ts` — `PendingAnswers` registry, `shouldAnswerOnReaction` pure decision, `ProactiveAsker` / `ResolvedAsker` / `ProactiveExecuteQuery` types
- `plugins/chat/src/proactive/listener.ts` — adds `chat.onReaction` + `chat.onAction` handlers, ephemeral offer card after a successful react, full answer flow
- `plugins/chat/src/cards/proactive-answer-card.tsx` — JSX offer card, answer card, and unlinked-asker prompt; action IDs
- `plugins/chat/src/config.ts` — extends `ProactiveConfig` with `userResolver`, `executeQueryProactive`, `linkUrl`, `platform`; Zod schema mirrors
- `plugins/chat/src/bridge.ts` — forwards the new fields to the listener
- `plugins/chat/src/index.ts` + `plugins/chat/src/proactive/index.ts` — new public exports

## Test plan

- [x] `bun test src/proactive/__tests__/` — 60/60 pass
- [x] `bun test src/` (full chat plugin) — 351/351 pass
- [x] `bun run lint` — clean
- [x] `bun run type` — clean
- [x] `bun x syncpack lint` — clean
- [x] `bash scripts/check-template-drift.sh` — 583 files verified
- [x] `bash scripts/check-schema-drift.sh` — clean (no migration in this slice)
- [ ] Manual: react-back round-trip on a Slack workspace once host wires `executeQueryProactive`

## Out of scope (later slices)

- Persisting `PendingAnswers` across pods (Redis/PG) — in-memory Map is fine for slice scope and Slack-first MVP scale
- Admin opt-in console (#2294, in-flight in parallel)
- Kill switches (#2295, in-flight in parallel)
- Audit log + meter wiring (#2296, in-flight in parallel)
- Public dataset for non-linked askers (#2297 — HITL)
- Inline feedback buttons + `/atlas feedback` (#2298)