### PR TITLE
feat(api,web): #2518 — Auto/Pin/All-envs picker + conversation routing_mode

### DIFF
--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -91,6 +91,14 @@
                   "connectionGroupId": {
                     "type": "string"
                   },
+                  "routingMode": {
+                    "type": "string",
+                    "enum": [
+                      "auto",
+                      "pin",
+                      "all"
+                    ]
+                  },
                   "boundDashboardId": {
                     "type": "string",
                     "format": "uuid"

--- a/e2e/browser/multi-env-routing-mode-picker.spec.ts
+++ b/e2e/browser/multi-env-routing-mode-picker.spec.ts
@@ -1,0 +1,78 @@
+import { test, expect, type APIRequestContext } from "@playwright/test";
+import {
+  createAdminRequestContext,
+  requireSeededGroups,
+} from "./lib/multi-env-helpers";
+
+/**
+ * Real-API e2e — three-state Auto/Pin/All routing-mode picker (PRD
+ * #2515, slice 3 issue #2518).
+ *
+ * Exercises the picker UI integration end-to-end against the multi-env
+ * seed. The unit coverage in `env-picker.test.tsx` locks the component
+ * behavior; this layer is the "everything wired together" smoke that
+ * catches:
+ *
+ *   - The picker actually surfaces the three modes in the dropdown
+ *     (data-testid hooks survive Tailwind / shadcn refactors).
+ *   - Toggling modes updates the trigger's `data-mode` attribute —
+ *     proof that the `routingMode` state flows back through `onSelect`.
+ *   - The 1×1-group hide-rule from #2408 isn't accidentally broken by
+ *     the slice's UI restructuring.
+ *
+ * Tagged `@llm` because the spec opens a real chat surface; the test
+ * doesn't send a message so we don't burn an LLM budget, but the
+ * picker only renders inside the same auth-gated chat shell the
+ * `@llm` suite exercises.
+ */
+
+test.describe("multi-env routing-mode picker @llm", () => {
+  test.use({ storageState: "e2e/browser/multi-env-storage.json" });
+
+  let request: APIRequestContext;
+
+  test.beforeAll(async ({ playwright }) => {
+    request = await createAdminRequestContext(playwright);
+  });
+
+  test.afterAll(async () => {
+    await request?.dispose();
+  });
+
+  test("picker exposes Auto / Pin / All-envs modes and the trigger reflects the selection", async ({ page }) => {
+    // Multi-env seed is the precondition — the picker hides on a 1×1
+    // workspace so without `prod` we can't assert anything meaningful.
+    await requireSeededGroups(request);
+
+    await page.goto("/");
+
+    // The picker only renders alongside the share dialog once a
+    // conversation exists OR when the env picker has multi-env data.
+    // Wait for the trigger to show up.
+    const trigger = page.locator('[data-testid="chat-env-picker-trigger"]');
+    await expect(trigger).toBeVisible({ timeout: 15_000 });
+
+    // Open the dropdown — all three mode rows must be present.
+    await trigger.click();
+    await expect(page.locator('[data-testid="chat-env-picker-mode-auto"]')).toBeVisible();
+    await expect(page.locator('[data-testid="chat-env-picker-mode-pin"]')).toBeVisible();
+    await expect(page.locator('[data-testid="chat-env-picker-mode-all"]')).toBeVisible();
+
+    // Pick Auto. The dropdown closes, the trigger's data-mode updates,
+    // and the chip label reads "Auto · <group>".
+    await page.locator('[data-testid="chat-env-picker-mode-auto"]').click();
+    await expect(trigger).toHaveAttribute("data-mode", "auto");
+    await expect(page.locator('[data-testid="chat-env-picker-label"]')).toContainText("Auto");
+
+    // Pick All envs.
+    await trigger.click();
+    await page.locator('[data-testid="chat-env-picker-mode-all"]').click();
+    await expect(trigger).toHaveAttribute("data-mode", "all");
+    await expect(page.locator('[data-testid="chat-env-picker-label"]')).toContainText("All");
+
+    // Pick Pin — back to the legacy single-member behavior.
+    await trigger.click();
+    await page.locator('[data-testid="chat-env-picker-mode-pin"]').click();
+    await expect(trigger).toHaveAttribute("data-mode", "pin");
+  });
+});

--- a/packages/api/src/__mocks__/api-test-mocks.ts
+++ b/packages/api/src/__mocks__/api-test-mocks.ts
@@ -614,6 +614,11 @@ export function createApiTestMocks(
     // exercise the routing override this mock locally via mock.module.
     resolveGroupForConnection: mock(() => Promise.resolve(null)),
   verifyGroupBelongsToOrg: mock(() => Promise.resolve("ok")),
+    // #2518 — three-state Auto/Pin/All picker write path. Default to a
+    // no-op success — chat-route tests don't write the row unless they
+    // exercise the picker toggle path, and they override locally when
+    // they do.
+    updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
   }));
 
   // ── Security ──────────────────────────────────────────────────

--- a/packages/api/src/api/__tests__/actions.test.ts
+++ b/packages/api/src/api/__tests__/actions.test.ts
@@ -137,6 +137,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   renameBranch: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
   resolveGroupForConnection: mock(() => Promise.resolve(null)),
   verifyGroupBelongsToOrg: mock(() => Promise.resolve("ok")),
+  updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
 }));
 
 mock.module("@atlas/api/lib/semantic", () => ({

--- a/packages/api/src/api/__tests__/admin-email-provider-route.test.ts
+++ b/packages/api/src/api/__tests__/admin-email-provider-route.test.ts
@@ -304,6 +304,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   renameBranch: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
   resolveGroupForConnection: mock(() => Promise.resolve(null)),
   verifyGroupBelongsToOrg: mock(() => Promise.resolve("ok")),
+  updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
 }));
 
 mock.module("@atlas/api/lib/auth/server", () => ({

--- a/packages/api/src/api/__tests__/admin-integrations-byot.test.ts
+++ b/packages/api/src/api/__tests__/admin-integrations-byot.test.ts
@@ -360,6 +360,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   renameBranch: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
   resolveGroupForConnection: mock(() => Promise.resolve(null)),
   verifyGroupBelongsToOrg: mock(() => Promise.resolve("ok")),
+  updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
 }));
 
 mock.module("@atlas/api/lib/auth/server", () => ({

--- a/packages/api/src/api/__tests__/admin-integrations.test.ts
+++ b/packages/api/src/api/__tests__/admin-integrations.test.ts
@@ -284,6 +284,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   renameBranch: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
   resolveGroupForConnection: mock(() => Promise.resolve(null)),
   verifyGroupBelongsToOrg: mock(() => Promise.resolve("ok")),
+  updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
 }));
 
 mock.module("@atlas/api/lib/auth/server", () => ({

--- a/packages/api/src/api/__tests__/admin-invitations.test.ts
+++ b/packages/api/src/api/__tests__/admin-invitations.test.ts
@@ -272,6 +272,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   renameBranch: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
   resolveGroupForConnection: mock(() => Promise.resolve(null)),
   verifyGroupBelongsToOrg: mock(() => Promise.resolve("ok")),
+  updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
 }));
 
 // Import app after all mocks are registered

--- a/packages/api/src/api/__tests__/admin-password.test.ts
+++ b/packages/api/src/api/__tests__/admin-password.test.ts
@@ -225,6 +225,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   renameBranch: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
   resolveGroupForConnection: mock(() => Promise.resolve(null)),
   verifyGroupBelongsToOrg: mock(() => Promise.resolve("ok")),
+  updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
 }));
 
 // Mock auth/server for the password-change dynamic import

--- a/packages/api/src/api/__tests__/admin.test.ts
+++ b/packages/api/src/api/__tests__/admin.test.ts
@@ -541,6 +541,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   renameBranch: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
   resolveGroupForConnection: mock(() => Promise.resolve(null)),
   verifyGroupBelongsToOrg: mock(() => Promise.resolve("ok")),
+  updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
 }));
 
 // Import app after all mocks are registered

--- a/packages/api/src/api/__tests__/chat.test.ts
+++ b/packages/api/src/api/__tests__/chat.test.ts
@@ -163,6 +163,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   renameBranch: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
   resolveGroupForConnection: mock(() => Promise.resolve(null)),
   verifyGroupBelongsToOrg: mockVerifyGroupBelongsToOrg,
+  updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
 }));
 
 const mockGetPluginTools: Mock<() => unknown> = mock(() => undefined);
@@ -353,6 +354,53 @@ describe("POST /api/v1/chat", () => {
     // the nested withRequestContext frame, this flips red.
     expect(capturedContext?.connectionId).toBe("eu-conn-id");
     expect(capturedContext?.connectionGroupId).toBe("g_prod");
+  });
+
+  // #2518 — three-state Auto/Pin/All picker. Body's `routingMode`
+  // lands in the `withRequestContext` frame so `executeSQL` can pass
+  // it to `resolveRoutingPlan` as `pickerMode`. Mirror of the #2414
+  // test above for the routing-mode plumbing.
+  it("propagates per-turn routingMode into the ALS frame the agent sees (#2518)", async () => {
+    const { getRequestContext } = await import("@atlas/api/lib/logger");
+    let capturedContext: ReturnType<typeof getRequestContext> | undefined;
+    mockRunAgent.mockImplementationOnce(() => {
+      capturedContext = getRequestContext();
+      return Promise.resolve({
+        toUIMessageStreamResponse: () => new Response("stream", { status: 200 }),
+        toUIMessageStream: () => new ReadableStream({ start(c) { c.close(); } }),
+        text: Promise.resolve("answer"),
+      } as unknown as Awaited<ReturnType<typeof mockRunAgent>>);
+    });
+    const response = await app.fetch(
+      makeRequest({
+        messages: [{ id: "1", role: "user", parts: [{ type: "text", text: "hi" }] }],
+        routingMode: "all",
+      }),
+    );
+    expect(response.status).toBe(200);
+    expect(capturedContext?.routingMode).toBe("all");
+  });
+
+  // #2518 — back-compat default. When neither the body nor the
+  // persisted conversation row carries a routing mode (pre-#2518
+  // chats), the chat route stamps 'pin' on the ALS frame so the
+  // agent's `scope: "all"` hints don't suddenly start fanning out on
+  // legacy chats. The tool's own default ('auto') only kicks in for
+  // non-chat callers (MCP / scheduler / direct tool tests).
+  it("stamps routingMode='pin' on the ALS frame when neither body nor conversation row supplies one (#2518)", async () => {
+    const { getRequestContext } = await import("@atlas/api/lib/logger");
+    let capturedContext: ReturnType<typeof getRequestContext> | undefined;
+    mockRunAgent.mockImplementationOnce(() => {
+      capturedContext = getRequestContext();
+      return Promise.resolve({
+        toUIMessageStreamResponse: () => new Response("stream", { status: 200 }),
+        toUIMessageStream: () => new ReadableStream({ start(c) { c.close(); } }),
+        text: Promise.resolve("answer"),
+      } as unknown as Awaited<ReturnType<typeof mockRunAgent>>);
+    });
+    const response = await app.fetch(makeRequest()); // No routingMode in body
+    expect(response.status).toBe(200);
+    expect(capturedContext?.routingMode).toBe("pin");
   });
 
   // F-74 regression pin: the chat handler MUST pass `bucket: "chat"` so the

--- a/packages/api/src/api/__tests__/conversations.test.ts
+++ b/packages/api/src/api/__tests__/conversations.test.ts
@@ -144,6 +144,10 @@ mock.module("@atlas/api/lib/conversations", () => ({
   // override this mock locally.
   resolveGroupForConnection: mock(() => Promise.resolve(null)),
   verifyGroupBelongsToOrg: mock(() => Promise.resolve("ok")),
+  // #2518 — three-state routing-mode picker. Default to a no-op
+  // success — tests that exercise the picker write path override
+  // locally.
+  updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
   // Type exports (no runtime value — needed so mock.module doesn't break re-exports)
 }));
 

--- a/packages/api/src/api/__tests__/dashboards.test.ts
+++ b/packages/api/src/api/__tests__/dashboards.test.ts
@@ -269,6 +269,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   settleConversationSteps: mock(() => {}),
   resolveGroupForConnection: mock(() => Promise.resolve(null)),
   verifyGroupBelongsToOrg: mockVerifyGroupBelongsToOrg,
+  updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
 }));
 
 mock.module("@atlas/api/lib/semantic", () => ({

--- a/packages/api/src/api/__tests__/health-plugin.test.ts
+++ b/packages/api/src/api/__tests__/health-plugin.test.ts
@@ -129,6 +129,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   renameBranch: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
   resolveGroupForConnection: mock(() => Promise.resolve(null)),
   verifyGroupBelongsToOrg: mock(() => Promise.resolve("ok")),
+  updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
 }));
 
 mock.module("@atlas/api/lib/auth/middleware", () => ({

--- a/packages/api/src/api/__tests__/health.test.ts
+++ b/packages/api/src/api/__tests__/health.test.ts
@@ -134,6 +134,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   renameBranch: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
   resolveGroupForConnection: mock(() => Promise.resolve(null)),
   verifyGroupBelongsToOrg: mock(() => Promise.resolve("ok")),
+  updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
 }));
 
 mock.module("@atlas/api/lib/auth/middleware", () => ({

--- a/packages/api/src/api/__tests__/query.test.ts
+++ b/packages/api/src/api/__tests__/query.test.ts
@@ -158,6 +158,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   renameBranch: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
   resolveGroupForConnection: mock(() => Promise.resolve(null)),
   verifyGroupBelongsToOrg: mock(() => Promise.resolve("ok")),
+  updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
 }));
 
 // Import after mocks are registered

--- a/packages/api/src/api/__tests__/scheduled-tasks.test.ts
+++ b/packages/api/src/api/__tests__/scheduled-tasks.test.ts
@@ -120,6 +120,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   renameBranch: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
   resolveGroupForConnection: mock(() => Promise.resolve(null)),
   verifyGroupBelongsToOrg: mock(() => Promise.resolve("ok")),
+  updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
 }));
 
 mock.module("@atlas/api/lib/semantic", () => ({

--- a/packages/api/src/api/__tests__/semantic-overlay.test.ts
+++ b/packages/api/src/api/__tests__/semantic-overlay.test.ts
@@ -341,6 +341,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   renameBranch: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
   resolveGroupForConnection: mock(() => Promise.resolve(null)),
   verifyGroupBelongsToOrg: mock(() => Promise.resolve("ok")),
+  updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
 }));
 
 const { app } = await import("../index");

--- a/packages/api/src/api/__tests__/semantic.test.ts
+++ b/packages/api/src/api/__tests__/semantic.test.ts
@@ -268,6 +268,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   renameBranch: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
   resolveGroupForConnection: mock(() => Promise.resolve(null)),
   verifyGroupBelongsToOrg: mock(() => Promise.resolve("ok")),
+  updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
 }));
 
 // Import app after all mocks are registered

--- a/packages/api/src/api/__tests__/slack.test.ts
+++ b/packages/api/src/api/__tests__/slack.test.ts
@@ -206,6 +206,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   renameBranch: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
   resolveGroupForConnection: mock(() => Promise.resolve(null)),
   verifyGroupBelongsToOrg: mock(() => Promise.resolve("ok")),
+  updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
 }));
 
 const mockCheckRateLimit: Mock<(key: string) => { allowed: boolean; retryAfterMs?: number }> = mock(() =>

--- a/packages/api/src/api/routes/chat.ts
+++ b/packages/api/src/api/routes/chat.ts
@@ -41,7 +41,9 @@ import {
   reserveConversationBudget,
   resolveGroupForConnection,
   settleConversationSteps,
+  updateConversationRoutingMode,
 } from "@atlas/api/lib/conversations";
+import type { ConversationRoutingMode } from "@useatlas/types/conversation";
 import {
   bindConversationToDashboard,
   resolveBoundDashboard,
@@ -366,6 +368,16 @@ export const ChatRequestSchema = z.object({
    * follow-up turn.
    */
   connectionGroupId: z.string().optional(),
+  /**
+   * #2518 — three-state Auto/Pin/All cross-environment picker mode.
+   * When supplied, the chat route persists it onto the conversation row
+   * AND uses it to drive `executeSQL` routing for this turn. Omitted
+   * turns inherit the conversation's stored value (or `"pin"` for
+   * pre-#2518 rows). The Zod enum is the single source of truth for
+   * acceptable values — there's no DB-layer CHECK constraint (see
+   * migration 0077).
+   */
+  routingMode: z.enum(["auto", "pin", "all"]).optional(),
   /**
    * #2363 — bound dashboard editor. When the chat drawer opens on
    * `/dashboards/[id]` the client supplies the dashboard id once (on
@@ -730,6 +742,11 @@ chat.openapi(chatRoute, async (c) => {
         //      changed by per-turn overrides.
         let effectiveConnectionId: string | undefined = parsed.data.connectionId;
         let effectiveConnectionGroupId: string | undefined = parsed.data.connectionGroupId;
+        // #2518 — three-state picker mode. Body value (this turn) >
+        // stored value on the row (back-compat default 'pin' if NULL).
+        // The runtime treats undefined here as 'pin' to preserve
+        // pre-#2518 single-execution semantics for legacy conversations.
+        let effectiveRoutingMode: ConversationRoutingMode | undefined = parsed.data.routingMode;
 
         // #2424 — when the body supplies `connectionGroupId`, verify it
         // belongs to the caller's active org BEFORE persisting it onto the
@@ -793,6 +810,40 @@ chat.openapi(chatRoute, async (c) => {
             }
             if (effectiveConnectionGroupId === undefined && existing.data.connectionGroupId) {
               effectiveConnectionGroupId = existing.data.connectionGroupId;
+            }
+            // #2518 — inherit picker mode from the conversation row when
+            // the body omits it. NULL on the row is read as 'pin' at the
+            // routing edge (executeSQL); we leave effectiveRoutingMode
+            // undefined here so the absence vs. explicit-pin distinction
+            // survives all the way to `withRequestContext`.
+            if (effectiveRoutingMode === undefined && existing.data.routingMode) {
+              effectiveRoutingMode = existing.data.routingMode;
+            }
+            // Persist the picker mode if the body explicitly set one for
+            // this turn. We compare against the stored value to avoid
+            // burning an UPDATE on every chat turn when nothing changed.
+            if (
+              parsed.data.routingMode !== undefined &&
+              parsed.data.routingMode !== existing.data.routingMode
+            ) {
+              // Fire-and-forget within the request lifetime: a transient
+              // write failure shouldn't block the chat turn (the runtime
+              // will still honor the body's routingMode for this turn).
+              // Note we don't await — the helper logs its own failures.
+              updateConversationRoutingMode(
+                conversationId,
+                parsed.data.routingMode,
+                authResult.user?.id,
+                authResult.user?.activeOrganizationId,
+              ).catch((err: unknown) => {
+                log.warn(
+                  {
+                    err: err instanceof Error ? err.message : String(err),
+                    conversationId,
+                  },
+                  "updateConversationRoutingMode rejected",
+                );
+              });
             }
             // F-77 — aggregate per-conversation step ceiling. The per-request
             // caps (stepCountIs(25), 180s wall-clock) bound a single agent
@@ -897,6 +948,11 @@ chat.openapi(chatRoute, async (c) => {
                 surface: "web",
                 connectionId: effectiveConnectionId ?? null,
                 connectionGroupId: effectiveConnectionGroupId ?? null,
+                // #2518 — persist the picker mode the user picked at
+                // creation. NULL on the row reads as 'pin' downstream
+                // for back-compat, so omitting this on legacy callers
+                // is structurally safe.
+                routingMode: effectiveRoutingMode ?? null,
                 orgId: authResult.user?.activeOrganizationId,
               });
               if (created) {
@@ -1060,6 +1116,17 @@ chat.openapi(chatRoute, async (c) => {
               ...(effectiveConnectionGroupId !== undefined && {
                 connectionGroupId: effectiveConnectionGroupId,
               }),
+              // #2518 — picker mode reaches `executeSQL` via the request
+              // context so the agent's `scope` parameter can be overridden
+              // before reaching `resolveRoutingPlan`. When neither the
+              // body nor the persisted row carries a value, the
+              // conversation predates the picker column (NULL on the row)
+              // — apply the back-compat default 'pin' here so the agent's
+              // scope hints don't suddenly start fanning out on
+              // pre-#2518 chats. The tool's own default ('auto') only
+              // kicks in for non-chat callers (MCP / scheduler / direct
+              // tool tests).
+              routingMode: effectiveRoutingMode ?? "pin",
             },
             () =>
               runAgent({

--- a/packages/api/src/lib/__tests__/agent-routing-mode.test.ts
+++ b/packages/api/src/lib/__tests__/agent-routing-mode.test.ts
@@ -293,9 +293,12 @@ describe("agent routing-mode picker — executeSQL `routingMode`", () => {
     expect(memberCallCounts.get("us-int") ?? 0).toBe(0);
     expect(memberCallCounts.get("eu")).toBe(1);
     expect(memberCallCounts.get("apac") ?? 0).toBe(0);
-    // Single-env shape: no __env__ prepend.
+    // Single-env shape: no __env__ prepend (per-row sentinel only on
+    // fanout). The single-env path post-#2519 still wraps the result
+    // with a 1-element `envContributions` array for wire symmetry.
     expect(first.columns).toEqual(["region", "revenue"]);
-    expect(first.envContributions).toBeUndefined();
+    expect(first.envContributions).toHaveLength(1);
+    expect(first.envContributions?.[0]?.connectionId).toBe("eu");
   });
 
   // -----------------------------------------------------------------------

--- a/packages/api/src/lib/__tests__/agent-routing-mode.test.ts
+++ b/packages/api/src/lib/__tests__/agent-routing-mode.test.ts
@@ -1,0 +1,440 @@
+/**
+ * Integration tests for the three-state Auto/Pin/All routing-mode
+ * picker (PRD #2515, slice 3 issue #2518).
+ *
+ * Exercises the full LLM → agent loop → executeSQL routing pipeline
+ * with `routingMode` stamped on RequestContext (mirroring what the
+ * chat route does from the persisted conversation row). The model
+ * emits a `scope` argument and the tests assert that the picker
+ * overrides it correctly:
+ *
+ *   - `routingMode='pin'` + agent emitting `scope: "all"` → single
+ *     execution against the conversation's pinned member regardless
+ *     of the agent's hint.
+ *   - `routingMode='all'` + agent emitting `scope: "this"` → fanout
+ *     across every member regardless of the agent's hint.
+ *   - `routingMode='auto'` + agent emitting `scope: "this"` → single
+ *     execution (same as legacy single-env behavior).
+ *
+ * Pattern follows `agent-cross-env-routing.test.ts`. The group-member
+ * lookup is mocked at the module boundary so the test is isolated
+ * from the internal Postgres pool.
+ */
+
+import { describe, expect, it, beforeEach, afterEach, mock } from "bun:test";
+import {
+  MockLanguageModelV3,
+  convertArrayToReadableStream,
+} from "ai/test";
+import type { LanguageModelV3StreamPart } from "@ai-sdk/provider";
+import type { UIMessage } from "ai";
+import { createConnectionMock } from "@atlas/api/testing/connection";
+
+// ---------------------------------------------------------------------------
+// Environment — must be set before module imports
+// ---------------------------------------------------------------------------
+
+process.env.ATLAS_DATASOURCE_URL = "postgresql://test:test@localhost:5432/test";
+
+// ---------------------------------------------------------------------------
+// Module-level mock model — each test assigns its own MockLanguageModelV3
+// ---------------------------------------------------------------------------
+
+let mockModel: InstanceType<typeof MockLanguageModelV3>;
+
+mock.module("@atlas/api/lib/providers", () => ({
+  getModel: () => mockModel,
+  getProviderType: () => "anthropic" as const,
+  getModelFromWorkspaceConfig: () => mockModel,
+  getWorkspaceProviderType: () => "anthropic" as const,
+  getDefaultProvider: () => "anthropic" as const,
+}));
+
+mock.module("@atlas/api/lib/semantic", () => ({
+  getOrgWhitelistedTables: () => new Set(),
+  loadOrgWhitelist: async () => new Map(),
+  invalidateOrgWhitelist: () => {},
+  getOrgSemanticIndex: async () => "",
+  invalidateOrgSemanticIndex: () => {},
+  _resetOrgWhitelists: () => {},
+  _resetOrgSemanticIndexes: () => {},
+  getWhitelistedTables: () => new Set(["orders"]),
+  _resetWhitelists: () => {},
+  getCrossSourceJoins: () => [],
+}));
+
+// ---------------------------------------------------------------------------
+// Per-connection mock DB — each member's queries return distinct rows so
+// the merged result is verifiable end-to-end.
+// ---------------------------------------------------------------------------
+
+type QueryResult = { columns: string[]; rows: Record<string, unknown>[] };
+type QueryStub = (sql: string, timeout?: number) => Promise<QueryResult>;
+
+const memberQueryHandlers = new Map<string, QueryStub>();
+const memberCallCounts = new Map<string, number>();
+
+function setMemberHandler(connId: string, handler: QueryStub): void {
+  memberQueryHandlers.set(connId, handler);
+}
+
+function makeMockDBConnectionFor(connId: string) {
+  return {
+    query: async (sql: string, timeout?: number) => {
+      memberCallCounts.set(connId, (memberCallCounts.get(connId) ?? 0) + 1);
+      const handler = memberQueryHandlers.get(connId);
+      if (!handler) {
+        return { columns: ["n"], rows: [{ n: 0 }] };
+      }
+      return handler(sql, timeout);
+    },
+    close: async () => {},
+  };
+}
+
+mock.module("@atlas/api/lib/db/connection", () =>
+  createConnectionMock({
+    getDB: () => makeMockDBConnectionFor("default"),
+    connections: {
+      get: (id: string) => makeMockDBConnectionFor(id ?? "default"),
+      getDefault: () => makeMockDBConnectionFor("default"),
+      getForOrg: (_orgId: string, id?: string) => makeMockDBConnectionFor(id ?? "default"),
+      getTargetHost: () => "localhost:5432",
+      describe: () => [
+        { id: "us-int", dbType: "postgres" as const },
+        { id: "eu", dbType: "postgres" as const },
+        { id: "apac", dbType: "postgres" as const },
+      ],
+    },
+  }),
+);
+
+// ---------------------------------------------------------------------------
+// Mock the impure group-member lookup so tests don't need a real internal DB
+// ---------------------------------------------------------------------------
+
+let mockGroupMembers: readonly string[] = ["us-int", "eu", "apac"];
+let mockPrimaryMember = "us-int";
+
+mock.module("@atlas/api/lib/env-routing/lookup", () => ({
+  loadGroupRoutingContext: async (_orgId: string | undefined, currentMember: string) => ({
+    groupId: "prod",
+    members: mockGroupMembers,
+    primaryMember: mockPrimaryMember,
+    currentMember,
+  }),
+}));
+
+mock.module("@atlas/api/lib/cache/index", () => ({
+  getCache: () => ({ get: () => null, set: () => {}, stats: () => ({ hits: 0, misses: 0, entryCount: 0, maxSize: 1000, ttl: 300000 }) }),
+  buildCacheKey: () => "mock-key",
+  cacheEnabled: () => false,
+  getDefaultTtl: () => 300000,
+  flushCache: () => {},
+  setCacheBackend: () => {},
+  _resetCache: () => {},
+}));
+
+// ---------------------------------------------------------------------------
+// Imports — after mocks so modules resolve to mocked versions
+// ---------------------------------------------------------------------------
+
+const { runAgent } = await import("@atlas/api/lib/agent");
+const { withRequestContext } = await import("@atlas/api/lib/logger");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+interface SQLOutput {
+  success: boolean;
+  error?: string;
+  row_count?: number;
+  columns?: string[];
+  rows?: Record<string, unknown>[];
+  envContributions?: { connectionId: string; rowCount: number; error: string | null; durationMs: number }[];
+}
+
+let callId = 0;
+function nextId(): string {
+  return `call-${++callId}`;
+}
+
+const MOCK_USAGE = {
+  inputTokens: { total: 10, noCache: 10, cacheRead: undefined, cacheWrite: undefined },
+  outputTokens: { total: 20, text: 20, reasoning: undefined },
+};
+
+function makeToolStepChunks(
+  toolName: string,
+  args: Record<string, unknown>,
+): LanguageModelV3StreamPart[] {
+  return [
+    { type: "tool-call", toolCallId: nextId(), toolName, input: JSON.stringify(args) },
+    { type: "finish", usage: MOCK_USAGE, finishReason: { unified: "tool-calls", raw: "tool_use" } },
+  ];
+}
+
+function userMessages(content: string): UIMessage[] {
+  return [
+    {
+      id: "msg-1",
+      role: "user" as const,
+      parts: [{ type: "text" as const, text: content }],
+    },
+  ];
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- AI SDK step types are generic
+function findToolResults(steps: any[], toolName: string): any[] {
+  const results: unknown[] = [];
+  for (const step of steps) {
+    if (!step.toolResults) continue;
+    for (const tr of step.toolResults) {
+      if (tr.toolName === toolName) {
+        results.push(tr.output);
+      }
+    }
+  }
+  return results;
+}
+
+/**
+ * Build an MLM that emits `executeSQL` with the supplied `scope` (or
+ * none, for the omitted case) and a trailing `finish` step.
+ */
+function modelWithScope(scope: string | undefined): InstanceType<typeof MockLanguageModelV3> {
+  let streamIdx = 0;
+  const args: Record<string, unknown> = {
+    sql: "SELECT region, revenue FROM orders",
+    explanation: "Routing-mode test",
+  };
+  if (scope !== undefined) args.scope = scope;
+  return new MockLanguageModelV3({
+    doStream: async () => {
+      const allSteps: LanguageModelV3StreamPart[][] = [
+        makeToolStepChunks("executeSQL", args),
+        [
+          { type: "text-delta", id: "text-0", delta: "Done." },
+          { type: "finish", usage: MOCK_USAGE, finishReason: { unified: "stop", raw: "end_turn" } },
+        ],
+      ];
+      if (streamIdx >= allSteps.length) {
+        return { stream: convertArrayToReadableStream(allSteps[allSteps.length - 1]) };
+      }
+      return { stream: convertArrayToReadableStream(allSteps[streamIdx++]) };
+    },
+  });
+}
+
+function seedAllMembers(): void {
+  setMemberHandler("us-int", async () => ({
+    columns: ["region", "revenue"],
+    rows: [{ region: "us", revenue: 100 }],
+  }));
+  setMemberHandler("eu", async () => ({
+    columns: ["region", "revenue"],
+    rows: [{ region: "eu", revenue: 80 }],
+  }));
+  setMemberHandler("apac", async () => ({
+    columns: ["region", "revenue"],
+    rows: [{ region: "apac", revenue: 60 }],
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("agent routing-mode picker — executeSQL `routingMode`", () => {
+  const savedSandboxUrl = process.env.ATLAS_SANDBOX_URL;
+
+  beforeEach(() => {
+    callId = 0;
+    memberQueryHandlers.clear();
+    memberCallCounts.clear();
+    mockGroupMembers = ["us-int", "eu", "apac"];
+    mockPrimaryMember = "us-int";
+    process.env.ATLAS_DATASOURCE_URL = "postgresql://test:test@localhost:5432/test";
+    delete process.env.ATLAS_TABLE_WHITELIST;
+    delete process.env.ATLAS_SANDBOX_URL;
+  });
+
+  afterEach(() => {
+    if (savedSandboxUrl !== undefined) {
+      process.env.ATLAS_SANDBOX_URL = savedSandboxUrl;
+    }
+  });
+
+  // -----------------------------------------------------------------------
+  // Pin overrides agent (acceptance criterion #1 on issue #2518)
+  // -----------------------------------------------------------------------
+
+  it("pin overrides agent: routingMode='pin' + connection_id='eu' + agent scope='all' → single execution against eu", async () => {
+    seedAllMembers();
+    mockModel = modelWithScope("all");
+
+    const result = await withRequestContext(
+      {
+        requestId: "test-pin-override",
+        connectionId: "eu",
+        routingMode: "pin",
+      },
+      () => runAgent({ messages: userMessages("EU revenue this month") }),
+    );
+    const steps = await result.steps;
+    const sqlResults = findToolResults(steps, "executeSQL") as SQLOutput[];
+
+    expect(sqlResults).toHaveLength(1);
+    const first = sqlResults[0]!;
+    expect(first.success).toBe(true);
+    // Only "eu" ran — agent's "all" hint is overridden by the user's
+    // pin selection.
+    expect(memberCallCounts.get("us-int") ?? 0).toBe(0);
+    expect(memberCallCounts.get("eu")).toBe(1);
+    expect(memberCallCounts.get("apac") ?? 0).toBe(0);
+    // Single-env shape: no __env__ prepend.
+    expect(first.columns).toEqual(["region", "revenue"]);
+    expect(first.envContributions).toBeUndefined();
+  });
+
+  // -----------------------------------------------------------------------
+  // All overrides agent (acceptance criterion #2 on issue #2518)
+  // -----------------------------------------------------------------------
+
+  it("all overrides agent: routingMode='all' + agent scope='this' → fanout across every member", async () => {
+    seedAllMembers();
+    mockModel = modelWithScope("this");
+
+    const result = await withRequestContext(
+      {
+        requestId: "test-all-override",
+        connectionId: "us-int",
+        routingMode: "all",
+      },
+      () => runAgent({ messages: userMessages("Compare across regions") }),
+    );
+    const steps = await result.steps;
+    const sqlResults = findToolResults(steps, "executeSQL") as SQLOutput[];
+
+    expect(sqlResults).toHaveLength(1);
+    const first = sqlResults[0]!;
+    expect(first.success).toBe(true);
+    // Every member ran exactly once despite the agent emitting
+    // scope="this" — the picker overrides the agent.
+    expect(memberCallCounts.get("us-int")).toBe(1);
+    expect(memberCallCounts.get("eu")).toBe(1);
+    expect(memberCallCounts.get("apac")).toBe(1);
+    expect(first.columns).toEqual(["__env__", "region", "revenue"]);
+    expect(first.envContributions).toHaveLength(3);
+  });
+
+  // -----------------------------------------------------------------------
+  // 'all' also overrides an omitted scope (the agent didn't pick fanout
+  // but the user did)
+  // -----------------------------------------------------------------------
+
+  it("all overrides absent scope: routingMode='all' + no agent scope → fanout", async () => {
+    seedAllMembers();
+    mockModel = modelWithScope(undefined);
+
+    const result = await withRequestContext(
+      {
+        requestId: "test-all-no-scope",
+        connectionId: "us-int",
+        routingMode: "all",
+      },
+      () => runAgent({ messages: userMessages("Compare across regions") }),
+    );
+    const steps = await result.steps;
+    const sqlResults = findToolResults(steps, "executeSQL") as SQLOutput[];
+
+    expect(sqlResults).toHaveLength(1);
+    expect(memberCallCounts.get("us-int")).toBe(1);
+    expect(memberCallCounts.get("eu")).toBe(1);
+    expect(memberCallCounts.get("apac")).toBe(1);
+    expect(sqlResults[0]!.columns).toEqual(["__env__", "region", "revenue"]);
+  });
+
+  // -----------------------------------------------------------------------
+  // Auto mode passes the agent's scope through unchanged
+  // -----------------------------------------------------------------------
+
+  it("auto passes agent through: routingMode='auto' + agent scope='all' → fanout", async () => {
+    seedAllMembers();
+    mockModel = modelWithScope("all");
+
+    const result = await withRequestContext(
+      {
+        requestId: "test-auto-all",
+        connectionId: "us-int",
+        routingMode: "auto",
+      },
+      () => runAgent({ messages: userMessages("Compare across regions") }),
+    );
+    const steps = await result.steps;
+    const sqlResults = findToolResults(steps, "executeSQL") as SQLOutput[];
+
+    expect(sqlResults).toHaveLength(1);
+    expect(memberCallCounts.get("us-int")).toBe(1);
+    expect(memberCallCounts.get("eu")).toBe(1);
+    expect(memberCallCounts.get("apac")).toBe(1);
+    expect(sqlResults[0]!.columns).toEqual(["__env__", "region", "revenue"]);
+  });
+
+  it("auto passes agent through: routingMode='auto' + agent scope='this' → single execution against current", async () => {
+    seedAllMembers();
+    mockModel = modelWithScope("this");
+
+    const result = await withRequestContext(
+      {
+        requestId: "test-auto-this",
+        connectionId: "eu",
+        routingMode: "auto",
+      },
+      () => runAgent({ messages: userMessages("EU revenue") }),
+    );
+    const steps = await result.steps;
+    const sqlResults = findToolResults(steps, "executeSQL") as SQLOutput[];
+
+    expect(sqlResults).toHaveLength(1);
+    // Only "eu" — auto + this routes to the conversation's current
+    // member, NOT a fanout.
+    expect(memberCallCounts.get("us-int") ?? 0).toBe(0);
+    expect(memberCallCounts.get("eu")).toBe(1);
+    expect(memberCallCounts.get("apac") ?? 0).toBe(0);
+    expect(sqlResults[0]!.columns).toEqual(["region", "revenue"]);
+  });
+
+  // -----------------------------------------------------------------------
+  // Tool default — when no `routingMode` is stamped on the request
+  // context (no chat route in the path), the tool defaults to 'auto'
+  // and the agent's scope decides. The chat route is responsible for
+  // applying the NULL→'pin' back-compat default before reaching here.
+  // -----------------------------------------------------------------------
+
+  it("tool default: routingMode unset + agent scope='all' → fanout (legacy 'agent decides' semantics)", async () => {
+    seedAllMembers();
+    mockModel = modelWithScope("all");
+
+    const result = await withRequestContext(
+      {
+        requestId: "test-tool-default",
+        connectionId: "us-int",
+        // No routingMode — the chat route is what stamps the per-
+        // conversation NULL→'pin' default. Tools / MCP / scheduler /
+        // direct unit tests fall through to the agent-decides default.
+      },
+      () => runAgent({ messages: userMessages("Compare across regions") }),
+    );
+    const steps = await result.steps;
+    const sqlResults = findToolResults(steps, "executeSQL") as SQLOutput[];
+
+    expect(sqlResults).toHaveLength(1);
+    // Auto semantics — agent's scope='all' produces a fanout.
+    expect(memberCallCounts.get("us-int")).toBe(1);
+    expect(memberCallCounts.get("eu")).toBe(1);
+    expect(memberCallCounts.get("apac")).toBe(1);
+    expect(sqlResults[0]!.columns).toEqual(["__env__", "region", "revenue"]);
+  });
+});

--- a/packages/api/src/lib/__tests__/conversations.test.ts
+++ b/packages/api/src/lib/__tests__/conversations.test.ts
@@ -132,8 +132,8 @@ describe("conversations module", () => {
       const result = await createConversation({ userId: "u1", title: "Test" });
       expect(result).toEqual({ id: "conv-123" });
       expect(queryCalls[0].sql).toContain("INSERT INTO conversations");
-      // [user_id, title, surface, connection_id, connection_group_id, org_id]
-      expect(queryCalls[0].params).toEqual(["u1", "Test", "web", null, null, null]);
+      // [user_id, title, surface, connection_id, connection_group_id, routing_mode, org_id]
+      expect(queryCalls[0].params).toEqual(["u1", "Test", "web", null, null, null, null]);
     });
 
     it("returns null when no DB", async () => {
@@ -154,7 +154,7 @@ describe("conversations module", () => {
       setResults({ rows: [{ id: "conv-456" }] });
 
       await createConversation({});
-      expect(queryCalls[0].params).toEqual([null, null, "web", null, null, null]);
+      expect(queryCalls[0].params).toEqual([null, null, "web", null, null, null, null]);
     });
 
     it("accepts custom surface and connectionId", async () => {
@@ -162,7 +162,7 @@ describe("conversations module", () => {
       setResults({ rows: [{ id: "conv-789" }] });
 
       await createConversation({ surface: "api", connectionId: "wh" });
-      expect(queryCalls[0].params).toEqual([null, null, "api", "wh", null, null]);
+      expect(queryCalls[0].params).toEqual([null, null, "api", "wh", null, null, null]);
     });
 
     it("includes orgId when provided", async () => {
@@ -171,7 +171,7 @@ describe("conversations module", () => {
 
       const result = await createConversation({ userId: "u1", orgId: "org-123" });
       expect(result).toEqual({ id: "conv-org" });
-      expect(queryCalls[0].params).toEqual(["u1", null, "web", null, null, "org-123"]);
+      expect(queryCalls[0].params).toEqual(["u1", null, "web", null, null, null, "org-123"]);
     });
 
     // #2345 — group-aware routing. Both columns are independent;
@@ -193,6 +193,7 @@ describe("conversations module", () => {
         "web",
         "us-int",
         "g_prod",
+        null,
         "org-1",
       ]);
     });
@@ -216,6 +217,7 @@ describe("conversations module", () => {
         "web",
         null,
         "g_prod",
+        null,
         "org-1",
       ]);
     });
@@ -1458,7 +1460,7 @@ describe("conversations module", () => {
         orgId: "org-B",
       });
       expect(result).toEqual({ ok: false, reason: "not_found" });
-      expect(queryCalls[0].sql).toContain("SELECT id, title, surface, connection_id, connection_group_id, org_id");
+      expect(queryCalls[0].sql).toContain("SELECT id, title, surface, connection_id, connection_group_id, routing_mode, org_id");
       expect(queryCalls[0].sql).toContain("(org_id = $3 OR org_id IS NULL)");
       expect(queryCalls[0].params).toEqual(["src-c1", "u1", "org-B"]);
     });
@@ -1473,7 +1475,7 @@ describe("conversations module", () => {
         orgId: "org-B",
       });
       expect(result).toEqual({ ok: false, reason: "not_found" });
-      expect(queryCalls[0].sql).toContain("SELECT id, title, surface, connection_id, connection_group_id, org_id");
+      expect(queryCalls[0].sql).toContain("SELECT id, title, surface, connection_id, connection_group_id, routing_mode, org_id");
       expect(queryCalls[0].sql).toContain("(org_id = $3 OR org_id IS NULL)");
       expect(queryCalls[0].params).toEqual(["src-c1", "u1", "org-B"]);
     });

--- a/packages/api/src/lib/audit/actions.ts
+++ b/packages/api/src/lib/audit/actions.ts
@@ -662,6 +662,8 @@ export const ADMIN_ACTIONS = {
     workspaceUpdate: "proactive.workspace_update",
     channelUpsert: "proactive.channel_upsert",
     channelDelete: "proactive.channel_delete",
+    workspaceKillEnable: "proactive.workspace_kill_enable",
+    workspaceKillDisable: "proactive.workspace_kill_disable",
   },
   /**
    * Compliance / PII-classification mutations. `pii_config_update` covers
@@ -757,18 +759,6 @@ export const ADMIN_ACTIONS = {
    */
   cache: {
     flush: "cache.flush",
-  },
-  /**
-   * Proactive chat kill-switch lifecycle (#2295, PRD #2291). The
-   * workspace-wide pause is the only proactive surface that lives
-   * under admin / owner (vs platform_admin) — per-channel and per-user
-   * layers are user-driven (`@atlas pause`, DM `unsubscribe`) so they
-   * don't go through this audit catalog. Enterprise-gated; emitted from
-   * `/api/v1/admin/proactive/pause` POST + DELETE handlers.
-   */
-  proactive: {
-    workspaceKillEnable: "proactive.workspace_kill_enable",
-    workspaceKillDisable: "proactive.workspace_kill_disable",
   },
 } as const;
 

--- a/packages/api/src/lib/auth/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/auth/__tests__/migrate.test.ts
@@ -322,6 +322,7 @@ describe("migrateAuthTables", () => {
             { name: "0074_audit_log_parent_audit_id.sql" },
             { name: "0075_proactive_chat_config.sql" },
             { name: "0076_proactive_pauses.sql" },
+            { name: "0077_conversations_routing_mode.sql" },
           ],
         };
       }

--- a/packages/api/src/lib/conversations.ts
+++ b/packages/api/src/lib/conversations.ts
@@ -105,6 +105,15 @@ function rowToConversation(r: Record<string, unknown>): Conversation {
     surface: (r.surface as Surface) ?? "web",
     connectionId: (r.connection_id as string) ?? null,
     connectionGroupId: (r.connection_group_id as string) ?? null,
+    // #2518 — three-state Auto/Pin/All picker state. Pre-0073 rows have
+    // a NULL `routing_mode` column; the runtime reads NULL as "pin"
+    // (see `ConversationRoutingMode` jsdoc). We surface the raw NULL
+    // here so the chat route can distinguish "user picked Auto" from
+    // "row predates the column"; the back-compat default lands at the
+    // routing edge, not at the read.
+    routingMode: isConversationRoutingMode(r.routing_mode)
+      ? r.routing_mode
+      : null,
     starred: r.starred === true,
     createdAt: String(r.created_at),
     updatedAt: String(r.updated_at),
@@ -112,6 +121,13 @@ function rowToConversation(r: Record<string, unknown>): Conversation {
       ? (r.notebook_state as Conversation["notebookState"])
       : null,
   };
+}
+
+/** Type guard — keeps an unknown DB string from leaking into a typed union. */
+function isConversationRoutingMode(
+  value: unknown,
+): value is import("@useatlas/types/conversation").ConversationRoutingMode {
+  return value === "auto" || value === "pin" || value === "all";
 }
 
 /** Generate a short title from the first user question. */
@@ -141,14 +157,21 @@ export async function createConversation(opts: {
    * `addMessage`-style fire-and-forget shape is preserved.
    */
   connectionGroupId?: string | null;
+  /**
+   * #2518 — three-state Auto/Pin/All picker state. NULL persists when
+   * the caller wants the read-side back-compat default ("pin") to
+   * apply (e.g. legacy chat-creation paths that predate the picker);
+   * explicit `"auto"` / `"pin"` / `"all"` opt into the new wiring.
+   */
+  routingMode?: import("@useatlas/types/conversation").ConversationRoutingMode | null;
   orgId?: string | null;
 }): Promise<{ id: string } | null> {
   if (!hasInternalDB()) return null;
   try {
     const rows = opts.id
       ? await internalQuery<{ id: string }>(
-          `INSERT INTO conversations (id, user_id, title, surface, connection_id, connection_group_id, org_id)
-           VALUES ($1, $2, $3, $4, $5, $6, $7)
+          `INSERT INTO conversations (id, user_id, title, surface, connection_id, connection_group_id, routing_mode, org_id)
+           VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
            RETURNING id`,
           [
             opts.id,
@@ -157,12 +180,13 @@ export async function createConversation(opts: {
             opts.surface ?? "web",
             opts.connectionId ?? null,
             opts.connectionGroupId ?? null,
+            opts.routingMode ?? null,
             opts.orgId ?? null,
           ],
         )
       : await internalQuery<{ id: string }>(
-          `INSERT INTO conversations (user_id, title, surface, connection_id, connection_group_id, org_id)
-           VALUES ($1, $2, $3, $4, $5, $6)
+          `INSERT INTO conversations (user_id, title, surface, connection_id, connection_group_id, routing_mode, org_id)
+           VALUES ($1, $2, $3, $4, $5, $6, $7)
            RETURNING id`,
           [
             opts.userId ?? null,
@@ -170,6 +194,7 @@ export async function createConversation(opts: {
             opts.surface ?? "web",
             opts.connectionId ?? null,
             opts.connectionGroupId ?? null,
+            opts.routingMode ?? null,
             opts.orgId ?? null,
           ],
         );
@@ -177,6 +202,35 @@ export async function createConversation(opts: {
   } catch (err) {
     log.error({ err: errorMessage(err) }, "createConversation failed");
     return null;
+  }
+}
+
+/**
+ * #2518 — update the conversation's `routing_mode`. Returns { ok: true }
+ * on a row update, `not_found` when the conversation doesn't belong to
+ * the caller (scoped via {@link scopeClause}). Fail-open semantics
+ * match the rest of this file: a no-DB / error result is logged but the
+ * chat turn still proceeds (the row stays at its previous value and the
+ * runtime falls back to its read-side default).
+ */
+export async function updateConversationRoutingMode(
+  id: string,
+  routingMode: import("@useatlas/types/conversation").ConversationRoutingMode,
+  userId?: string | null,
+  orgId?: string | null,
+): Promise<CrudResult> {
+  if (!hasInternalDB()) return { ok: false, reason: "no_db" };
+  try {
+    const scope = scopeClause(3, userId, orgId);
+    const rows = await internalQuery<{ id: string }>(
+      `UPDATE conversations SET routing_mode = $1, updated_at = now()
+       WHERE id = $2${scope.sql} RETURNING id`,
+      [routingMode, id, ...scope.params],
+    );
+    return rows.length > 0 ? { ok: true } : { ok: false, reason: "not_found" };
+  } catch (err) {
+    log.error({ err: errorMessage(err) }, "updateConversationRoutingMode failed");
+    return { ok: false, reason: "error" };
   }
 }
 
@@ -537,7 +591,7 @@ export async function getConversation(
   try {
     const scope = scopeClause(2, userId, orgId);
     const convRows = await internalQuery<Record<string, unknown>>(
-      `SELECT id, user_id, title, surface, connection_id, connection_group_id, starred, notebook_state, created_at, updated_at
+      `SELECT id, user_id, title, surface, connection_id, connection_group_id, routing_mode, starred, notebook_state, created_at, updated_at
        FROM conversations WHERE id = $1${scope.sql}`,
       [id, ...scope.params],
     );
@@ -609,7 +663,7 @@ export async function listConversations(opts?: {
       params,
     );
     const dataRows = await internalQuery<Record<string, unknown>>(
-      `SELECT id, user_id, title, surface, connection_id, connection_group_id, starred, created_at, updated_at
+      `SELECT id, user_id, title, surface, connection_id, connection_group_id, routing_mode, starred, created_at, updated_at
        FROM conversations ${where}
        ORDER BY updated_at DESC LIMIT $${paramIdx++} OFFSET $${paramIdx++}`,
       [...params, limit, offset],
@@ -686,7 +740,7 @@ export async function forkConversation(opts: {
     // source row's org_id; scopeClause rejects mismatches (NULL-safe for legacy rows).
     const sourceScope = scopeClause(2, opts.userId, opts.orgId);
     const sourceRows = await internalQuery<Record<string, unknown>>(
-      `SELECT id, title, surface, connection_id, connection_group_id, org_id FROM conversations WHERE id = $1${sourceScope.sql}`,
+      `SELECT id, title, surface, connection_id, connection_group_id, routing_mode, org_id FROM conversations WHERE id = $1${sourceScope.sql}`,
       [opts.sourceId, ...sourceScope.params],
     );
     if (sourceRows.length === 0) return { ok: false, reason: "not_found" };
@@ -722,14 +776,15 @@ export async function forkConversation(opts: {
     // the user keeps the same env context after branching.
     const orgId = opts.orgId ?? (source.org_id as string) ?? null;
     const newConv = await internalQuery<{ id: string }>(
-      `INSERT INTO conversations (user_id, title, surface, connection_id, connection_group_id, org_id)
-       VALUES ($1, $2, $3, $4, $5, $6) RETURNING id`,
+      `INSERT INTO conversations (user_id, title, surface, connection_id, connection_group_id, routing_mode, org_id)
+       VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING id`,
       [
         opts.userId ?? null,
         `${sourceTitle} (fork)`,
         (source.surface as string) ?? "web",
         (source.connection_id as string) ?? null,
         (source.connection_group_id as string) ?? null,
+        (source.routing_mode as string) ?? null,
         orgId,
       ],
     );
@@ -873,7 +928,7 @@ export async function convertToNotebook(opts: {
     // Verify source exists and caller has access in both the user + org dimensions.
     const sourceScope = scopeClause(2, opts.userId, opts.orgId);
     const sourceRows = await internalQuery<Record<string, unknown>>(
-      `SELECT id, title, surface, connection_id, connection_group_id, org_id FROM conversations WHERE id = $1${sourceScope.sql}`,
+      `SELECT id, title, surface, connection_id, connection_group_id, routing_mode, org_id FROM conversations WHERE id = $1${sourceScope.sql}`,
       [opts.sourceId, ...sourceScope.params],
     );
     if (sourceRows.length === 0) return { ok: false, reason: "not_found" };
@@ -883,17 +938,18 @@ export async function convertToNotebook(opts: {
     const orgId = opts.orgId ?? (source.org_id as string) ?? null;
 
     // Create new conversation with surface "notebook". Carries forward
-    // both routing columns so the notebook preserves the source's env
-    // context.
+    // both routing columns + the picker mode so the notebook preserves
+    // the source's env context end-to-end.
     const newConv = await internalQuery<{ id: string }>(
-      `INSERT INTO conversations (user_id, title, surface, connection_id, connection_group_id, org_id)
-       VALUES ($1, $2, $3, $4, $5, $6) RETURNING id`,
+      `INSERT INTO conversations (user_id, title, surface, connection_id, connection_group_id, routing_mode, org_id)
+       VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING id`,
       [
         opts.userId ?? null,
         `${sourceTitle} (notebook)`,
         "notebook",
         (source.connection_id as string) ?? null,
         (source.connection_group_id as string) ?? null,
+        (source.routing_mode as string) ?? null,
         orgId,
       ],
     );
@@ -1135,7 +1191,7 @@ export async function getSharedConversation(
   if (!hasInternalDB()) return { ok: false, reason: "no_db" };
   try {
     const convRows = await internalQuery<Record<string, unknown>>(
-      `SELECT id, user_id, org_id, title, surface, connection_id, connection_group_id, starred, share_expires_at, share_mode, notebook_state, created_at, updated_at
+      `SELECT id, user_id, org_id, title, surface, connection_id, connection_group_id, routing_mode, starred, share_expires_at, share_mode, notebook_state, created_at, updated_at
        FROM conversations
        WHERE share_token = $1`,
       [token],

--- a/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
@@ -1458,6 +1458,69 @@ describeIfPg("migrate-pg (real Postgres)", () => {
     expect(rows[0]?.connection_group_id).toBe(groupId);
   }, PG_TEST_TIMEOUT_MS);
 
+  // 0077 — conversations.routing_mode. Adds the three-state Auto/Pin/
+  // All picker column the cross-environment routing slice (#2518)
+  // lives on. What this set of assertions guards against:
+  //   - A future migration that flips `routing_mode` to NOT NULL
+  //     without a backfill — legacy conversations (pre-0077) must keep
+  //     booting with NULL on the column.
+  //   - A future migration that adds a too-strict CHECK constraint
+  //     that rejects the legitimate values. The Zod enum in the chat
+  //     route is the single source of truth; a DB-level CHECK is
+  //     intentionally omitted (see 0077).
+  it("conversations.routing_mode: column exists, is nullable, and accepts auto/pin/all", async () => {
+    const { rows } = await pool.query<{ is_nullable: string; data_type: string }>(
+      `SELECT is_nullable, data_type
+       FROM information_schema.columns
+       WHERE table_name = 'conversations'
+         AND column_name = 'routing_mode'
+         AND table_schema = current_schema()`,
+    );
+    expect(rows[0]?.data_type).toBe("text");
+    expect(rows[0]?.is_nullable).toBe("YES");
+
+    // The three documented values must all be writable. We probe with
+    // raw SQL (no application-layer validation) so a future CHECK
+    // constraint that diverges from the Zod enum fails this test
+    // loudly rather than silently dropping a picker selection.
+    const orgId = `org-rm-${Date.now()}`;
+    const userBase = `user-rm-${Date.now()}`;
+    for (const mode of ["auto", "pin", "all"] as const) {
+      await pool.query(
+        `INSERT INTO conversations (user_id, title, surface, routing_mode, org_id)
+         VALUES ($1, $2, 'web', $3, $4)`,
+        [`${userBase}-${mode}`, `Routing mode test (${mode})`, mode, orgId],
+      );
+    }
+    const persisted = await pool.query<{ routing_mode: string }>(
+      `SELECT routing_mode FROM conversations WHERE org_id = $1 ORDER BY routing_mode`,
+      [orgId],
+    );
+    expect(persisted.rows.map((r) => r.routing_mode)).toEqual(["all", "auto", "pin"]);
+  }, PG_TEST_TIMEOUT_MS);
+
+  it("conversations.routing_mode: pre-0077 rows stay readable as NULL (back-compat read-side default)", async () => {
+    // Legacy conversations (no routing_mode column when they were
+    // written) survive the migration with NULL on the new column.
+    // The runtime treats NULL as "pin" — pre-#2518 rows carry a
+    // single connection_id and the safest interpretation is "stay
+    // pinned to that member". This test inserts a row WITHOUT
+    // setting routing_mode (mimicking a pre-#2518 INSERT) and
+    // asserts the read surfaces NULL, not a synthetic default.
+    const orgId = `org-rm-legacy-${Date.now()}`;
+    const userId = `user-rm-legacy-${Date.now()}`;
+    await pool.query(
+      `INSERT INTO conversations (user_id, title, surface, connection_id, org_id)
+       VALUES ($1, 'Legacy pre-0077 row', 'web', 'us-int', $2)`,
+      [userId, orgId],
+    );
+    const { rows } = await pool.query<{ routing_mode: string | null }>(
+      `SELECT routing_mode FROM conversations WHERE user_id = $1`,
+      [userId],
+    );
+    expect(rows[0]?.routing_mode).toBeNull();
+  }, PG_TEST_TIMEOUT_MS);
+
   it("conversations: connection_id and connection_group_id can hold independent values (per-turn override shape)", async () => {
     // The slice's core invariant: a conversation can pin its content
     // scope to a multi-member "prod" group while its execution target

--- a/packages/api/src/lib/db/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate.test.ts
@@ -88,8 +88,9 @@ describe("runMigrations", () => {
     // + 0073 (conversations.bound_dashboard_id, #2363)
     // + 0074 (audit_log.parent_audit_id for cross-env fanout, #2519)
     // + 0075 (proactive chat admin config, #2294)
-    // + 0076 (proactive_pauses kill switch, #2295) = 77.
-    expect(count).toBe(77);
+    // + 0076 (proactive_pauses kill switch, #2295)
+    // + 0077 (conversations.routing_mode picker, #2518) = 78.
+    expect(count).toBe(78);
 
     // Advisory lock acquired before anything else
     expect(queries[0]).toContain("pg_advisory_lock");
@@ -195,6 +196,7 @@ describe("runMigrations", () => {
         "0074_audit_log_parent_audit_id.sql",
         "0075_proactive_chat_config.sql",
         "0076_proactive_pauses.sql",
+        "0077_conversations_routing_mode.sql",
       ],
     });
 

--- a/packages/api/src/lib/db/migrations/0077_conversations_routing_mode.sql
+++ b/packages/api/src/lib/db/migrations/0077_conversations_routing_mode.sql
@@ -23,3 +23,4 @@
 
 ALTER TABLE conversations
   ADD COLUMN IF NOT EXISTS routing_mode TEXT;
+

--- a/packages/api/src/lib/db/migrations/0077_conversations_routing_mode.sql
+++ b/packages/api/src/lib/db/migrations/0077_conversations_routing_mode.sql
@@ -1,0 +1,25 @@
+-- 0077 — Per-conversation routing-mode picker state (PRD #2515, issue #2518).
+--
+-- Adds `conversations.routing_mode` to record which of the three picker
+-- states the user pinned the conversation to:
+--
+--   - 'auto'  — agent decides per-turn (default for new conversations
+--               created via the Auto picker mode);
+--   - 'pin'   — force single-env execution against the row's stored
+--               `connection_id`; agent's `scope` override is ignored;
+--   - 'all'   — force fanout across every member of the active group;
+--               agent's `scope` override is ignored.
+--
+-- Nullable on purpose. Pre-#2518 rows have no concept of picker mode but
+-- carry a non-null `connection_id`. The runtime reads NULL as "pin"
+-- (back-compat — the conversation already names a single member; the
+-- safest interpretation is "stay pinned to that member") so existing
+-- chats behave unchanged after migration.
+--
+-- No CHECK constraint at the DB layer. Validation lives in the chat
+-- route's Zod schema (single source of truth); a CHECK here would only
+-- duplicate it while adding migration-ordering risk for future picker
+-- modes.
+
+ALTER TABLE conversations
+  ADD COLUMN IF NOT EXISTS routing_mode TEXT;

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -105,6 +105,12 @@ export const conversations = pgTable(
     // entities, dashboards, etc. resolve). Two columns, two purposes —
     // they are deliberately decoupled.
     connectionGroupId: text("connection_group_id"),
+    // 0077 — three-state Auto/Pin/All picker state (#2518). NULL is
+    // read as "pin" by the runtime so pre-#2518 conversations whose
+    // `connection_id` already names a single member keep their
+    // single-execution behavior. Validation lives in the chat route's
+    // Zod schema (single source of truth) rather than a CHECK here.
+    routingMode: text("routing_mode"),
     createdAt: timestamp("created_at", { withTimezone: true }).defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow(),
     // Saved/starred

--- a/packages/api/src/lib/logger.ts
+++ b/packages/api/src/lib/logger.ts
@@ -74,6 +74,16 @@ interface RequestContext {
    */
   connectionId?: string;
   connectionGroupId?: string;
+  /**
+   * #2518 — three-state Auto/Pin/All cross-environment picker state for
+   * the conversation. The chat route stamps this from the resolved
+   * conversation row (or the per-turn body override) so `executeSQL`
+   * can pass it to {@link resolveRoutingPlan} as `pickerMode`. NULL in
+   * the DB / undefined here is treated as `"pin"` for back-compat —
+   * pre-#2518 conversations whose `connection_id` already names a
+   * single member keep single-execution semantics.
+   */
+  routingMode?: import("@atlas/api/lib/env-routing").RoutingMode;
 }
 
 const requestStore = new AsyncLocalStorage<RequestContext>();

--- a/packages/api/src/lib/tools/__tests__/action-permissions.test.ts
+++ b/packages/api/src/lib/tools/__tests__/action-permissions.test.ts
@@ -141,6 +141,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   renameBranch: mock(() => Promise.resolve({ ok: false, reason: "not_found" })),
   resolveGroupForConnection: mock(() => Promise.resolve(null)),
   verifyGroupBelongsToOrg: mock(() => Promise.resolve("ok")),
+  updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
 }));
 
 mock.module("@atlas/api/lib/semantic", () => ({

--- a/packages/api/src/lib/tools/sql.ts
+++ b/packages/api/src/lib/tools/sql.ts
@@ -1840,37 +1840,56 @@ export const executeSQL = tool({
     // RequestContext. The model normally omits `connectionId`, so fall back to
     // that routed context before the legacy default to avoid executing against
     // the wrong environment while conversation metadata says otherwise.
-    const requestContextConnectionId = getRequestContext()?.connectionId;
+    const reqCtx = getRequestContext();
+    const requestContextConnectionId = reqCtx?.connectionId;
     const currentMember = connectionId ?? requestContextConnectionId ?? "default";
 
-    // Fast path: no agent-supplied scope (or explicit "this") preserves the
-    // pre-#2516 behaviour exactly — single execution, no group lookup.
+    // #2518 — three-state picker. `routingMode` reaches us via
+    // `RequestContext` (stamped by the chat route from the conversation
+    // row). The chat route applies the NULL→"pin" back-compat default
+    // before stamping; reaching this code with `routingMode === undefined`
+    // means the caller never went through the chat route (tools / MCP /
+    // scheduler / unit tests), and the legacy "agent decides" semantics
+    // are the right answer there.
+    const routingMode = reqCtx?.routingMode ?? "auto";
+
+    // Fast path — only valid when EVERY override path collapses to
+    // "single execution against currentMember". That is true when:
+    //   - the agent emitted no scope (or scope === "this"), AND
+    //   - the picker is NOT pinning the fanout case ('all').
+    // The 'pin' picker case ALSO collapses to single — pin always
+    // routes to `currentMember` regardless of the agent's hint — so we
+    // keep the fast path for it (no DB lookup needed). 'auto' with no
+    // agent scope is the same shape as legacy single-env execution.
     //
     // Wraps the leaf result with a 1-element `envContributions` array so
     // SDK consumers see the same wire shape for single-env and fanout
     // responses (#2519). The leaf result already carries `success`,
     // `columns`, `rows`, etc. — we only attach the contribution.
-    if (scope === undefined || scope === "this") {
+    if ((scope === undefined || scope === "this") && routingMode !== "all") {
       const result = await executeSqlForConnection({
         sql,
         explanation,
         connId: currentMember,
-        routingMode: "auto",
+        routingMode,
       });
       return attachSingleEnvContribution(result, currentMember);
     }
 
-    // Routing path: agent asked for fanout or a specific member. Resolve
-    // the active group's members + primary, then run the pure routing
-    // module. Failures collapse to a 1×1 fallback so the tool call still
-    // returns a useful result.
-    const orgId = getRequestContext()?.user?.activeOrganizationId;
+    // Routing path: either the agent asked for fanout / a specific
+    // member, or the picker is pinning 'all' (which overrides the
+    // agent's scope regardless of value). Resolve the active group's
+    // members + primary, then run the pure routing module. Failures
+    // collapse to a 1×1 fallback so the tool call still returns a
+    // useful result.
+    const orgId = reqCtx?.user?.activeOrganizationId;
     const ctx = await loadGroupRoutingContext(orgId, currentMember);
     const { plan, warnings } = resolveRoutingPlan({
       agentScope: scope,
       currentMember: ctx.currentMember,
       members: ctx.members,
       primaryMember: ctx.primaryMember,
+      pickerMode: routingMode,
     });
     for (const w of warnings) {
       log.warn({ connectionId: currentMember, scope, plan: plan.kind }, w);
@@ -1881,7 +1900,7 @@ export const executeSQL = tool({
         sql,
         explanation,
         connId: plan.connectionId,
-        routingMode: "auto",
+        routingMode,
       });
       return attachSingleEnvContribution(result, plan.connectionId);
     }

--- a/packages/types/src/conversation.ts
+++ b/packages/types/src/conversation.ts
@@ -3,6 +3,22 @@
 export type MessageRole = "user" | "assistant" | "system" | "tool";
 export type Surface = "web" | "api" | "mcp" | "slack" | "notebook";
 
+/**
+ * Three-state cross-environment routing picker for a conversation (#2518):
+ *
+ *   - `"auto"` — agent's `scope` decides per turn. Default for new
+ *     conversations created via the picker's Auto mode.
+ *   - `"pin"` — force single-env execution against the conversation's
+ *     stored `connectionId`; the agent's `scope` override is ignored.
+ *   - `"all"` — force fanout across every member of the active group;
+ *     the agent's `scope` override is ignored.
+ *
+ * `null` on a persisted row is read as `"pin"` (back-compat — pre-#2518
+ * rows carry a non-null `connectionId` and the safest interpretation
+ * is "stay pinned to that member").
+ */
+export type ConversationRoutingMode = "auto" | "pin" | "all";
+
 export interface Conversation {
   id: string;
   userId: string | null;
@@ -23,6 +39,19 @@ export interface Conversation {
    * runtime falls back to single-connection behavior in that case.
    */
   connectionGroupId: string | null;
+  /**
+   * Three-state Auto/Pin/All picker state (#2518). `null` on existing
+   * rows is read as `"pin"` by the runtime — pre-#2518 conversations
+   * carry a single `connectionId` and the safest interpretation is
+   * "stay pinned to that member". New conversations created via the
+   * Auto picker mode persist `"auto"`; explicit Pin / All selections
+   * persist their literal values.
+   *
+   * Optional in the type so pre-#2518 test fixtures and external
+   * SDK consumers can construct a `Conversation` without supplying
+   * the field; the runtime treats missing the same as `null`.
+   */
+  routingMode?: ConversationRoutingMode | null;
   starred: boolean;
   createdAt: string;
   updatedAt: string;

--- a/packages/web/src/app/(workspace)/page.tsx
+++ b/packages/web/src/app/(workspace)/page.tsx
@@ -27,6 +27,7 @@ import {
   ChatEnvPicker,
   shouldRenderEnvPicker,
   useChatEnvGroups,
+  type ConversationRoutingMode,
 } from "@/ui/components/chat/env-picker";
 import { parseSuggestions } from "@/ui/lib/helpers";
 import { ScrollArea } from "@/components/ui/scroll-area";
@@ -75,6 +76,13 @@ function ChatPage() {
   // applies default routing.
   const [selectedGroupId, setSelectedGroupId] = useState<string | null>(null);
   const [selectedConnectionId, setSelectedConnectionId] = useState<string | null>(null);
+  // #2518 — three-state Auto/Pin/All cross-environment routing picker.
+  // `null` until the user (or the server, on conversation load) picks a
+  // mode; the transport omits the field when `null` so the server
+  // applies its NULL→"pin" back-compat default for legacy
+  // conversations.
+  const [selectedRoutingMode, setSelectedRoutingMode] =
+    useState<ConversationRoutingMode | null>(null);
   // Adaptive empty-chat starter surface — backend composes the ranked
   // prompt list from favorites / popular / library tiers (#1474).
   const [starterPrompts, setStarterPrompts] = useState<
@@ -134,6 +142,7 @@ function ChatPage() {
     // transport.
     getConnectionId: () => selectedConnectionId,
     getConnectionGroupId: () => selectedGroupId,
+    getRoutingMode: () => selectedRoutingMode,
   });
 
   const convos = useConversations({
@@ -448,9 +457,11 @@ function ChatPage() {
                       transportError={envGroupsQuery.error}
                       activeGroupId={selectedGroupId}
                       activeConnectionId={selectedConnectionId}
-                      onSelect={({ groupId, connectionId }) => {
+                      activeRoutingMode={selectedRoutingMode}
+                      onSelect={({ groupId, connectionId, routingMode }) => {
                         setSelectedGroupId(groupId);
                         setSelectedConnectionId(connectionId);
+                        setSelectedRoutingMode(routingMode);
                       }}
                     />
                   </div>

--- a/packages/web/src/ui/__tests__/env-picker.test.tsx
+++ b/packages/web/src/ui/__tests__/env-picker.test.tsx
@@ -13,16 +13,41 @@ mock.module("@/components/ui/dropdown-menu", () => {
       React.createElement(tag, rest, children as React.ReactNode);
   const div = passthrough("div");
   const hr = () => React.createElement("hr");
+  // Items wire Radix's `onSelect` to a regular `onClick` so the
+  // testing-library `fireEvent.click` path triggers the same callback
+  // path the real Radix Item exposes. Without this bridge the
+  // mock-divs swallow `onSelect` and #2518's selection-flow tests
+  // can't observe the parent's `onSelect` reaction.
+  const itemWithSelect = ({
+    children,
+    onSelect,
+    asChild: _asChild,
+    ...rest
+  }: {
+    children?: ReactNode;
+    asChild?: boolean;
+    onSelect?: (e: unknown) => void;
+  } & Record<string, unknown>) =>
+    React.createElement(
+      "div",
+      {
+        ...rest,
+        onClick: () => {
+          if (typeof onSelect === "function") onSelect({});
+        },
+      },
+      children as React.ReactNode,
+    );
   return {
     DropdownMenu: div,
     DropdownMenuPortal: div,
     DropdownMenuTrigger: div,
     DropdownMenuContent: div,
     DropdownMenuGroup: div,
-    DropdownMenuItem: div,
-    DropdownMenuCheckboxItem: div,
+    DropdownMenuItem: itemWithSelect,
+    DropdownMenuCheckboxItem: itemWithSelect,
     DropdownMenuRadioGroup: div,
-    DropdownMenuRadioItem: div,
+    DropdownMenuRadioItem: itemWithSelect,
     DropdownMenuLabel: div,
     DropdownMenuSeparator: hr,
     DropdownMenuShortcut: passthrough("span"),
@@ -635,3 +660,217 @@ describe("ChatEnvPicker transportError (#2504)", () => {
     ).not.toBeNull();
   });
 });
+
+// ── #2518 — three-state Auto/Pin/All picker ──────────────────────────
+
+describe("ChatEnvPicker three-state routing mode (#2518)", () => {
+  const multiMemberGroup: ChatEnvGroup[] = [
+    {
+      id: "g_prod",
+      name: "prod",
+      members: [
+        { connectionId: "us-int", dbType: "postgres", description: null },
+        { connectionId: "eu", dbType: "postgres", description: null },
+        { connectionId: "apac", dbType: "postgres", description: null },
+      ],
+    },
+  ];
+
+  test("trigger reflects 'Pin' as the default when activeRoutingMode is null (back-compat)", () => {
+    const { container } = render(
+      <ChatEnvPicker
+        groups={multiMemberGroup}
+        activeGroupId="g_prod"
+        activeConnectionId="eu"
+        activeRoutingMode={null}
+        onSelect={noop}
+      />,
+    );
+    const trigger = container.querySelector('[data-testid="chat-env-picker-trigger"]');
+    expect(trigger?.getAttribute("data-mode")).toBe("pin");
+    expect(
+      container.querySelector('[data-testid="chat-env-picker-label"]')?.textContent,
+    ).toBe("prod / eu");
+  });
+
+  test("trigger reflects 'Auto' when activeRoutingMode='auto'", () => {
+    const { container } = render(
+      <ChatEnvPicker
+        groups={multiMemberGroup}
+        activeGroupId="g_prod"
+        activeConnectionId="eu"
+        activeRoutingMode="auto"
+        onSelect={noop}
+      />,
+    );
+    const trigger = container.querySelector('[data-testid="chat-env-picker-trigger"]');
+    expect(trigger?.getAttribute("data-mode")).toBe("auto");
+    expect(
+      container.querySelector('[data-testid="chat-env-picker-label"]')?.textContent,
+    ).toContain("Auto");
+  });
+
+  test("trigger reflects 'All' when activeRoutingMode='all'", () => {
+    const { container } = render(
+      <ChatEnvPicker
+        groups={multiMemberGroup}
+        activeGroupId="g_prod"
+        activeConnectionId="eu"
+        activeRoutingMode="all"
+        onSelect={noop}
+      />,
+    );
+    const trigger = container.querySelector('[data-testid="chat-env-picker-trigger"]');
+    expect(trigger?.getAttribute("data-mode")).toBe("all");
+    expect(
+      container.querySelector('[data-testid="chat-env-picker-label"]')?.textContent,
+    ).toContain("All");
+  });
+
+  test("dropdown renders all three modes with the current mode marked active", () => {
+    const { container } = render(
+      <ChatEnvPicker
+        groups={multiMemberGroup}
+        activeGroupId="g_prod"
+        activeConnectionId="eu"
+        activeRoutingMode="auto"
+        onSelect={noop}
+      />,
+    );
+    const auto = container.querySelector('[data-testid="chat-env-picker-mode-auto"]');
+    const pin = container.querySelector('[data-testid="chat-env-picker-mode-pin"]');
+    const all = container.querySelector('[data-testid="chat-env-picker-mode-all"]');
+    expect(auto).not.toBeNull();
+    expect(pin).not.toBeNull();
+    expect(all).not.toBeNull();
+    expect(auto?.getAttribute("data-active")).toBe("true");
+    expect(pin?.getAttribute("data-active")).toBe("false");
+    expect(all?.getAttribute("data-active")).toBe("false");
+  });
+
+  test("selecting Auto produces a triple with routingMode='auto' keeping the current member", () => {
+    let captured: { groupId: string; connectionId: string; routingMode: string } | null = null;
+    const { container } = render(
+      <ChatEnvPicker
+        groups={multiMemberGroup}
+        activeGroupId="g_prod"
+        activeConnectionId="eu"
+        activeRoutingMode="pin"
+        onSelect={(next) => {
+          captured = next;
+        }}
+      />,
+    );
+    const auto = container.querySelector<HTMLElement>(
+      '[data-testid="chat-env-picker-mode-auto"]',
+    );
+    auto?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(captured).not.toBeNull();
+    expect(captured!.routingMode).toBe("auto");
+    expect(captured!.groupId).toBe("g_prod");
+    expect(captured!.connectionId).toBe("eu");
+  });
+
+  test("selecting All produces a triple with routingMode='all' keeping the current member", () => {
+    let captured: { groupId: string; connectionId: string; routingMode: string } | null = null;
+    const { container } = render(
+      <ChatEnvPicker
+        groups={multiMemberGroup}
+        activeGroupId="g_prod"
+        activeConnectionId="eu"
+        activeRoutingMode="pin"
+        onSelect={(next) => {
+          captured = next;
+        }}
+      />,
+    );
+    const all = container.querySelector<HTMLElement>(
+      '[data-testid="chat-env-picker-mode-all"]',
+    );
+    all?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(captured).not.toBeNull();
+    expect(captured!.routingMode).toBe("all");
+  });
+
+  test("member-list selection forces routingMode='pin' implicitly", () => {
+    // The user picks a member from the per-group section while in Auto.
+    // The natural interpretation is "pin to that member" — you can't
+    // 'select a member' in fanout.
+    let captured: { groupId: string; connectionId: string; routingMode: string } | null = null;
+    const { container } = render(
+      <ChatEnvPicker
+        groups={multiMemberGroup}
+        activeGroupId="g_prod"
+        activeConnectionId="eu"
+        activeRoutingMode="auto"
+        onSelect={(next) => {
+          captured = next;
+        }}
+      />,
+    );
+    const apac = container.querySelector<HTMLElement>(
+      '[data-testid="chat-env-picker-member-apac"]',
+    );
+    apac?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(captured).not.toBeNull();
+    expect(captured!.routingMode).toBe("pin");
+    expect(captured!.connectionId).toBe("apac");
+    expect(captured!.groupId).toBe("g_prod");
+  });
+
+  test("1×1 group keeps the picker hidden even with activeRoutingMode set (acceptance criterion)", () => {
+    const groups: ChatEnvGroup[] = [
+      {
+        id: "g_only",
+        name: "only",
+        members: [{ connectionId: "only", dbType: "postgres", description: null }],
+      },
+    ];
+    const { container } = render(
+      <ChatEnvPicker
+        groups={groups}
+        activeGroupId="g_only"
+        activeConnectionId="only"
+        activeRoutingMode="auto"
+        onSelect={noop}
+      />,
+    );
+    expect(
+      container.querySelector('[data-testid="chat-env-picker-trigger"]'),
+    ).toBeNull();
+    expect(container.firstChild).toBeNull();
+  });
+
+  test("member highlight uses Pin mode only (Auto/All members don't show as the 'active target')", () => {
+    const { container: autoContainer } = render(
+      <ChatEnvPicker
+        groups={multiMemberGroup}
+        activeGroupId="g_prod"
+        activeConnectionId="eu"
+        activeRoutingMode="auto"
+        onSelect={noop}
+      />,
+    );
+    const euInAuto = autoContainer.querySelector(
+      '[data-testid="chat-env-picker-member-eu"]',
+    );
+    expect(euInAuto?.getAttribute("data-active")).toBe("false");
+
+    cleanup();
+
+    const { container: pinContainer } = render(
+      <ChatEnvPicker
+        groups={multiMemberGroup}
+        activeGroupId="g_prod"
+        activeConnectionId="eu"
+        activeRoutingMode="pin"
+        onSelect={noop}
+      />,
+    );
+    const euInPin = pinContainer.querySelector(
+      '[data-testid="chat-env-picker-member-eu"]',
+    );
+    expect(euInPin?.getAttribute("data-active")).toBe("true");
+  });
+});
+

--- a/packages/web/src/ui/components/atlas-chat.tsx
+++ b/packages/web/src/ui/components/atlas-chat.tsx
@@ -20,7 +20,11 @@ import { Markdown } from "./chat/markdown";
 import { FollowUpChips } from "./chat/follow-up-chips";
 import { SuggestionChips } from "./chat/suggestion-chips";
 import { DeveloperChatEmptyState } from "./chat/developer-empty-state";
-import { ChatEnvPicker, useChatEnvGroups } from "./chat/env-picker";
+import {
+  ChatEnvPicker,
+  useChatEnvGroups,
+  type ConversationRoutingMode,
+} from "./chat/env-picker";
 import { useDevModeNoDrafts } from "../hooks/use-dev-mode-no-drafts";
 import type { QuerySuggestion } from "@/ui/lib/types";
 import { ShareDialog } from "./chat/share-dialog";
@@ -125,6 +129,9 @@ export function AtlasChat() {
   // without a picker.
   const [selectedGroupId, setSelectedGroupId] = useState<string | null>(null);
   const [selectedConnectionId, setSelectedConnectionId] = useState<string | null>(null);
+  // #2518 — three-state Auto/Pin/All cross-environment routing picker.
+  const [selectedRoutingMode, setSelectedRoutingMode] =
+    useState<ConversationRoutingMode | null>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
 
   const {
@@ -157,6 +164,7 @@ export function AtlasChat() {
     // next turn without rebuilding the transport.
     getConnectionId: () => selectedConnectionId,
     getConnectionGroupId: () => selectedGroupId,
+    getRoutingMode: () => selectedRoutingMode,
   });
 
   const managedSession = authClient.useSession();
@@ -547,9 +555,11 @@ export function AtlasChat() {
                     transportError={envGroupsQuery.error}
                     activeGroupId={selectedGroupId}
                     activeConnectionId={selectedConnectionId}
-                    onSelect={({ groupId, connectionId }) => {
+                    activeRoutingMode={selectedRoutingMode}
+                    onSelect={({ groupId, connectionId, routingMode }) => {
                       setSelectedGroupId(groupId);
                       setSelectedConnectionId(connectionId);
+                      setSelectedRoutingMode(routingMode);
                     }}
                   />
                   <Button

--- a/packages/web/src/ui/components/chat/env-picker.tsx
+++ b/packages/web/src/ui/components/chat/env-picker.tsx
@@ -1,30 +1,40 @@
 "use client";
 
 /**
- * Chat header env/member picker (#2345).
+ * Chat header env/member picker (#2345, #2518).
  *
- * Shows the conversation's active group and member (e.g. "prod /
- * us-int"). Clicking opens a dropdown of every member in every group
- * the user has access to. Selecting a different member is a *per-turn*
- * override — the conversation's stored `connection_id` is unchanged;
- * the picker holds the override in component state and `useAtlasChat`
- * forwards it on the next request via the transport body.
+ * Three-state cross-environment routing picker (PRD #2515, slice 3
+ * issue #2518):
  *
- * Selecting a different group changes the *content scope*. Group
- * changes propagate to the conversation row on the next turn (the
- * server persists the new value when the body carries
- * `connectionGroupId`), so subsequent turns inherit the new scope
- * without the user having to re-pick.
+ *   - **Auto** (default for new conversations) — the agent's `scope`
+ *     argument on `executeSQL` decides per turn. Routes to the active
+ *     member by default and fans out only when the agent asks for it.
+ *   - **Pin to <member>** — force single-env execution against the
+ *     selected member; the agent's `scope` override is ignored.
+ *   - **All envs** — force fanout across every member of the active
+ *     group; the agent's `scope` override is ignored.
  *
- * Renders nothing only in the truly trivial 1×1 case: one group with
- * one member. Multi-singleton workspaces (the 0062 1:1 backfill shape)
- * still surface the picker so the 1.4.4 feature is discoverable; a
+ * The dropdown also lists every member of the active group below the
+ * three modes so the user can flip the pinned member without unpinning.
+ * Picking a member from that list implicitly switches the mode to
+ * `pin` (you can't "select a member" in fanout — it's structurally
+ * meaningless).
+ *
+ * 1×1 case (one group with one member): the picker stays hidden.
+ * Multi-singleton workspaces (the 0062 1:1 backfill shape) still
+ * surface the picker so the 1.4.4 feature is discoverable; a
  * dropdown footer hints that admins can merge connections into shared
  * environments. See #2408.
+ *
+ * Group changes propagate to the conversation row on the next turn
+ * (the server persists the new value when the body carries
+ * `connectionGroupId`), so subsequent turns inherit the new scope
+ * without the user having to re-pick. Routing-mode changes flow the
+ * same way via `routingMode`.
  */
 
 import { useEffect, useState } from "react";
-import { Layers, AlertCircle } from "lucide-react";
+import { Layers, AlertCircle, Sparkles, Pin, Globe2, Check } from "lucide-react";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -36,6 +46,9 @@ import {
 import { Button } from "@/components/ui/button";
 import { stripGroupPrefix } from "@/ui/lib/strip-group-prefix";
 import type { MeConnectionGroupsEmptyReason } from "@/ui/lib/types";
+import type { ConversationRoutingMode } from "@useatlas/types/conversation";
+
+export type { ConversationRoutingMode };
 
 export interface ChatEnvMember {
   readonly connectionId: string;
@@ -47,6 +60,18 @@ export interface ChatEnvGroup {
   readonly id: string;
   readonly name: string;
   readonly members: ReadonlyArray<ChatEnvMember>;
+}
+
+/**
+ * Payload for {@link ChatEnvPickerProps.onSelect}. The parent receives
+ * the full triple every time so it can persist any subset onto the
+ * conversation row without the picker having to know which fields the
+ * server treats as content-scope vs. per-turn execution-target.
+ */
+export interface ChatEnvSelection {
+  readonly groupId: string;
+  readonly connectionId: string;
+  readonly routingMode: ConversationRoutingMode;
 }
 
 export interface ChatEnvPickerProps {
@@ -72,12 +97,20 @@ export interface ChatEnvPickerProps {
   /** Currently active member (execution target). `null` ⇒ inherit from group's first member. */
   readonly activeConnectionId: string | null;
   /**
-   * Called when the user picks a new group + member pair from the
-   * dropdown. The parent component decides whether this is a per-turn
-   * override (just update local state) or a content-scope change
-   * (also update the conversation row on the next request).
+   * #2518 — three-state cross-environment routing mode for the active
+   * conversation. `null` (or omitted, for back-compat with pre-#2518
+   * call sites) is treated as `"pin"` — pre-#2518 conversations carry
+   * a single `connectionId` and the safest interpretation is "stay
+   * pinned to that member".
    */
-  readonly onSelect: (next: { groupId: string; connectionId: string }) => void;
+  readonly activeRoutingMode?: ConversationRoutingMode | null;
+  /**
+   * Called when the user picks a new group / member / mode triple from
+   * the dropdown. The parent decides whether this is a per-turn
+   * override (just update local state) or a persistent change (the
+   * server stamps the new value onto the conversation row).
+   */
+  readonly onSelect: (next: ChatEnvSelection) => void;
 }
 
 /**
@@ -115,12 +148,26 @@ function isKnownEmptyReason(value: unknown): value is MeConnectionGroupsEmptyRea
   return typeof value === "string" && value in EMPTY_REASON_COPY;
 }
 
+/**
+ * Back-compat default — NULL on the conversation row means "pin", not
+ * "auto". Pre-#2518 rows carry a non-null `connection_id` and the
+ * safest interpretation is "stay pinned to that member". The default
+ * lives behind a helper so chip-label / mode-state logic stays in
+ * lockstep.
+ */
+function effectiveMode(
+  mode: ConversationRoutingMode | null,
+): ConversationRoutingMode {
+  return mode ?? "pin";
+}
+
 export function ChatEnvPicker({
   groups,
   emptyReason = null,
   transportError = null,
   activeGroupId,
   activeConnectionId,
+  activeRoutingMode = null,
   onSelect,
 }: ChatEnvPickerProps): React.ReactElement | null {
   // Empty list + a reason ⇒ render a diagnostic chip instead of
@@ -168,18 +215,61 @@ export function ChatEnvPicker({
     activeGroup?.members.find((m) => m.connectionId === activeConnectionId) ??
     activeGroup?.members[0];
 
+  const mode = effectiveMode(activeRoutingMode);
   const groupLabel = activeGroup ? stripGroupPrefix(activeGroup.name) : "—";
   const memberLabel = activeMember?.connectionId ?? "—";
-  // Collapse "warehouse / warehouse" → "warehouse" when the stripped
-  // group name and the member id are the same value (the common 0062
-  // backfill shape: g_<connId> + one member named <connId>).
-  const chipLabel = groupLabel === memberLabel ? memberLabel : `${groupLabel} / ${memberLabel}`;
+
+  // Chip label tracks the picker's mode so the trigger always reflects
+  // the routing the next turn will use. The compact forms keep the
+  // chip readable when group/member names are long.
+  let chipLabel: string;
+  let ChipIcon: typeof Layers;
+  if (mode === "auto") {
+    chipLabel = `Auto · ${groupLabel}`;
+    ChipIcon = Sparkles;
+  } else if (mode === "all") {
+    chipLabel = `All · ${groupLabel}`;
+    ChipIcon = Globe2;
+  } else {
+    // Pin — show the member name. Collapse "warehouse / warehouse" →
+    // "warehouse" when the stripped group name and the member id match
+    // (the common 0062 backfill shape: g_<connId> + one member named
+    // <connId>).
+    chipLabel = groupLabel === memberLabel ? memberLabel : `${groupLabel} / ${memberLabel}`;
+    ChipIcon = Pin;
+  }
 
   // When every group has at most one member (the 0062 backfill shape,
   // or a defensive-empty group), the dropdown has no actual
   // multi-member choice to offer. Surface a hint so admins discover
   // that merging connections into a shared environment is possible.
   const allSingletons = groups.every((g) => g.members.length <= 1);
+
+  // The active group's member list is the source the Pin/Member rows
+  // render from. We re-resolve here (vs. consuming `activeGroup` directly)
+  // so a defensive-empty group renders an "empty" affordance rather than
+  // a silent zero-length list.
+  const activeMembers = activeGroup?.members ?? [];
+
+  // Mode dispatch — every selection produces the full triple so the
+  // parent can persist whichever subset matters. Implicit rules:
+  //   - Switching mode keeps the current member as the execution
+  //     target (pinned mode targets it; auto/all also need a sensible
+  //     `currentMember` for the server-side routing lookup).
+  //   - Selecting a member from the member list implies `pin` mode —
+  //     you can't "select a member" in fanout, and the most natural
+  //     interpretation is "pin to that one".
+  const handleModeSelect = (nextMode: ConversationRoutingMode) => {
+    if (!activeGroup || !activeMember) return;
+    onSelect({
+      groupId: activeGroup.id,
+      connectionId: activeMember.connectionId,
+      routingMode: nextMode,
+    });
+  };
+  const handleMemberSelect = (groupId: string, connectionId: string) => {
+    onSelect({ groupId, connectionId, routingMode: "pin" });
+  };
 
   return (
     <DropdownMenu>
@@ -189,22 +279,103 @@ export function ChatEnvPicker({
           size="sm"
           className="h-8 gap-1.5 rounded-full border border-zinc-200 px-2.5 text-xs font-medium text-zinc-700 hover:bg-zinc-50 dark:border-zinc-800 dark:text-zinc-300 dark:hover:bg-zinc-900"
           data-testid="chat-env-picker-trigger"
-          aria-label={`Active environment: ${groupLabel}, member: ${memberLabel}. Change.`}
+          data-mode={mode}
+          aria-label={`Cross-environment routing: ${chipLabel}. Change.`}
         >
-          <Layers className="size-3.5 text-zinc-500" aria-hidden />
+          <ChipIcon className="size-3.5 text-zinc-500" aria-hidden />
           <span data-testid="chat-env-picker-label">{chipLabel}</span>
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" className="w-64" data-testid="chat-env-picker-menu">
-        {groups.map((group, idx) => (
-          <ChatEnvGroupSection
-            key={group.id}
-            group={group}
-            activeConnectionId={activeMember?.connectionId ?? null}
-            onSelect={onSelect}
-            isLast={idx === groups.length - 1}
-          />
-        ))}
+      <DropdownMenuContent
+        align="end"
+        className="w-72"
+        data-testid="chat-env-picker-menu"
+      >
+        {/* Mode section — three states with the current mode marked. */}
+        <DropdownMenuLabel className="text-[10px] font-semibold uppercase tracking-wider text-zinc-500 dark:text-zinc-500">
+          Routing
+        </DropdownMenuLabel>
+        <ChatEnvModeItem
+          mode="auto"
+          active={mode === "auto"}
+          icon={Sparkles}
+          title="Auto"
+          subtitle="Agent decides per turn"
+          onSelect={() => handleModeSelect("auto")}
+        />
+        <ChatEnvModeItem
+          mode="pin"
+          active={mode === "pin"}
+          icon={Pin}
+          title={`Pin to ${memberLabel}`}
+          subtitle="Lock execution to one member"
+          onSelect={() => handleModeSelect("pin")}
+        />
+        <ChatEnvModeItem
+          mode="all"
+          active={mode === "all"}
+          icon={Globe2}
+          title="All envs"
+          subtitle="Fan out to every member"
+          onSelect={() => handleModeSelect("all")}
+        />
+
+        {activeGroup && activeMembers.length > 0 && (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuLabel className="text-[10px] font-semibold uppercase tracking-wider text-zinc-500 dark:text-zinc-500">
+              {stripGroupPrefix(activeGroup.name)} members
+            </DropdownMenuLabel>
+            {activeMembers.map((member) => {
+              // Pin highlight only when the current mode is pin AND we're
+              // on the member it pins to — otherwise highlighting the
+              // member would falsely suggest "this is the active target"
+              // while routing is in Auto/All.
+              const isActive =
+                mode === "pin" && member.connectionId === activeMember?.connectionId;
+              return (
+                <DropdownMenuItem
+                  key={member.connectionId}
+                  onSelect={() =>
+                    handleMemberSelect(activeGroup.id, member.connectionId)
+                  }
+                  className="flex items-center justify-between gap-2 text-xs"
+                  data-testid={`chat-env-picker-member-${member.connectionId}`}
+                  data-active={isActive}
+                >
+                  <span className="flex items-center gap-1.5 truncate">
+                    {isActive && <Check className="size-3 text-primary" aria-hidden />}
+                    <span className="truncate">{member.connectionId}</span>
+                  </span>
+                  <span className="text-[10px] uppercase tracking-wider text-zinc-400">
+                    {member.dbType}
+                  </span>
+                </DropdownMenuItem>
+              );
+            })}
+          </>
+        )}
+
+        {groups.length > 1 && (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuLabel className="text-[10px] font-semibold uppercase tracking-wider text-zinc-500 dark:text-zinc-500">
+              Other environments
+            </DropdownMenuLabel>
+            {groups
+              .filter((g) => g.id !== activeGroup?.id)
+              .map((group) => (
+                <ChatEnvOtherGroupItem
+                  key={group.id}
+                  group={group}
+                  onSelect={(connectionId) =>
+                    handleMemberSelect(group.id, connectionId)
+                  }
+                />
+              ))}
+          </>
+        )}
+
         {allSingletons && (
           <>
             <DropdownMenuSeparator />
@@ -225,53 +396,85 @@ export function ChatEnvPicker({
   );
 }
 
-function ChatEnvGroupSection({
-  group,
-  activeConnectionId,
+function ChatEnvModeItem({
+  mode,
+  active,
+  icon: Icon,
+  title,
+  subtitle,
   onSelect,
-  isLast,
+}: {
+  mode: ConversationRoutingMode;
+  active: boolean;
+  icon: typeof Layers;
+  title: string;
+  subtitle: string;
+  onSelect: () => void;
+}): React.ReactElement {
+  return (
+    <DropdownMenuItem
+      onSelect={onSelect}
+      className="flex items-start gap-2 text-xs"
+      data-testid={`chat-env-picker-mode-${mode}`}
+      data-active={active}
+    >
+      <Icon
+        className={`mt-0.5 size-3.5 ${active ? "text-primary" : "text-zinc-500"}`}
+        aria-hidden
+      />
+      <div className="flex min-w-0 flex-1 flex-col">
+        <span className={`truncate ${active ? "font-medium" : ""}`}>{title}</span>
+        <span className="truncate text-[10px] text-zinc-500 dark:text-zinc-400">
+          {subtitle}
+        </span>
+      </div>
+      {active && <Check className="size-3.5 shrink-0 text-primary" aria-hidden />}
+    </DropdownMenuItem>
+  );
+}
+
+/**
+ * Row for a member of a *different* group. Selecting it switches both
+ * the active group and pins to that member — the natural "I want to
+ * work in a different environment" gesture.
+ */
+function ChatEnvOtherGroupItem({
+  group,
+  onSelect,
 }: {
   group: ChatEnvGroup;
-  activeConnectionId: string | null;
-  onSelect: ChatEnvPickerProps["onSelect"];
-  isLast: boolean;
+  onSelect: (connectionId: string) => void;
 }): React.ReactElement {
   const label = stripGroupPrefix(group.name);
   return (
     <>
-      <DropdownMenuLabel className="text-[10px] font-semibold uppercase tracking-wider text-zinc-500 dark:text-zinc-500">
-        {label}
-      </DropdownMenuLabel>
       {group.members.length === 0 ? (
         <DropdownMenuItem
           disabled
           className="text-xs italic text-zinc-400"
           data-testid={`chat-env-picker-empty-${group.id}`}
         >
-          No members
+          {label} — no members
         </DropdownMenuItem>
       ) : (
-        group.members.map((member) => {
-          const active = member.connectionId === activeConnectionId;
-          return (
-            <DropdownMenuItem
-              key={member.connectionId}
-              onSelect={() =>
-                onSelect({ groupId: group.id, connectionId: member.connectionId })
-              }
-              className="flex items-center justify-between gap-2 text-xs"
-              data-testid={`chat-env-picker-member-${member.connectionId}`}
-              data-active={active}
-            >
+        group.members.map((member) => (
+          <DropdownMenuItem
+            key={`${group.id}:${member.connectionId}`}
+            onSelect={() => onSelect(member.connectionId)}
+            className="flex items-center justify-between gap-2 text-xs"
+            data-testid={`chat-env-picker-other-${group.id}-${member.connectionId}`}
+          >
+            <span className="flex min-w-0 items-center gap-1.5 truncate">
+              <span className="truncate text-zinc-500">{label}</span>
+              <span className="text-zinc-300">/</span>
               <span className="truncate">{member.connectionId}</span>
-              <span className="text-[10px] uppercase tracking-wider text-zinc-400">
-                {member.dbType}
-              </span>
-            </DropdownMenuItem>
-          );
-        })
+            </span>
+            <span className="text-[10px] uppercase tracking-wider text-zinc-400">
+              {member.dbType}
+            </span>
+          </DropdownMenuItem>
+        ))
       )}
-      {!isLast && <DropdownMenuSeparator />}
     </>
   );
 }

--- a/packages/web/src/ui/hooks/use-atlas-transport.ts
+++ b/packages/web/src/ui/hooks/use-atlas-transport.ts
@@ -33,6 +33,13 @@ export interface UseAtlasTransportOptions {
    * conversation row).
    */
   getConnectionGroupId?: () => string | null;
+  /**
+   * #2518 — three-state Auto/Pin/All cross-environment routing mode.
+   * Returns the picker's current selection or `null` to omit the field
+   * from the request body (server applies its NULL→"pin" back-compat
+   * default for legacy conversations).
+   */
+  getRoutingMode?: () => "auto" | "pin" | "all" | null;
 }
 
 export interface UseAtlasTransportReturn {
@@ -70,6 +77,13 @@ export function useAtlasTransport(
 
   const getConnectionGroupIdRef = useRef(opts.getConnectionGroupId);
   getConnectionGroupIdRef.current = opts.getConnectionGroupId;
+
+  // #2518 — routing-mode getter (Auto/Pin/All). Ref for the same reason
+  // the connection getters are refs: a picker change between turns
+  // reaches the next request without rebuilding `useChat`'s transport
+  // (which would cancel the in-flight stream).
+  const getRoutingModeRef = useRef(opts.getRoutingMode);
+  getRoutingModeRef.current = opts.getRoutingMode;
 
   // --- Auth state (seed from module cache to avoid flash on client-side nav) ---
   const [authMode, setAuthModeState] = useState<AuthMode | null>(_cachedAuthMode);
@@ -242,6 +256,13 @@ export function useAtlasTransport(
         const connectionGroupId = getConnectionGroupIdRef.current?.();
         if (connectionGroupId) {
           body.connectionGroupId = connectionGroupId;
+        }
+        // #2518 — Auto/Pin/All routing mode. Omitted when null so the
+        // server's NULL→"pin" back-compat default applies to legacy
+        // conversations that never went through the new picker.
+        const routingMode = getRoutingModeRef.current?.();
+        if (routingMode) {
+          body.routingMode = routingMode;
         }
         return body;
       },


### PR DESCRIPTION
Slice 3 of milestone 1.4.5 (PRD #2515). Builds on slice 1's `executeSQL` `scope` parameter + routing/merger deep modules. Replaces the conversation env-picker with a three-state Auto / Pin / All-envs control and persists the picker state on the `conversations` row.

## Summary

- Migration **0073** adds `conversations.routing_mode TEXT NULL`. NULL is read as `"pin"` for back-compat — pre-#2518 chats already carry a non-null `connection_id` and "stay pinned to that member" is the safest interpretation. New conversations created via the Auto picker mode persist `"auto"`; explicit Pin / All selections persist their literal values.
- **Chat route** (`packages/api/src/api/routes/chat.ts`): adds `routingMode` to the request schema, resolves the effective mode (body > conversation row > NULL→`"pin"` default), stamps it on the `withRequestContext` frame around `runAgent`, persists explicit changes via `updateConversationRoutingMode`.
- **`executeSQL`** (`packages/api/src/lib/tools/sql.ts`): reads `routingMode` off the request context and forwards it to `resolveRoutingPlan` as `pickerMode`. Fast-path single-execution still applies when (no scope OR scope==="this") AND mode !== "all". Mode `"all"` forces fanout regardless of the agent's hint; mode `"pin"` forces single execution against the conversation's pinned member.
- **Picker UI** (`packages/web/src/ui/components/chat/env-picker.tsx`): rebuilt with three Auto / Pin / All-envs mode rows + a per-group member-list selector below. Selecting a member from the list implicitly forces `pin`. 1×1 group still hides the picker entirely (acceptance criterion).
- **Drizzle schema** mirrors 0073 in the same PR (`schema.ts`); `check-schema-drift.sh` passes.

## Default-mode contract

The tool-level default for `routingMode` is `"auto"` so non-chat callers (MCP, scheduler, direct unit tests) preserve slice-1's "agent decides" semantics. The chat route is the single place the NULL→`"pin"` back-compat default fires. This avoids regressing the slice 1 `agent-cross-env-routing.test.ts` suite while still meeting the issue's "existing conversations behave unchanged" criterion.

## Test plan

- [x] Migration 0073 added to `packages/api/src/lib/db/migrations/` (idempotent — `ADD COLUMN IF NOT EXISTS`) and mirrored in `schema.ts`
- [x] `migrate-pg.test.ts` covers the column existence + nullability + `auto`/`pin`/`all` round-trip + pre-0073 rows surface as NULL
- [x] Pin-overrides-agent unit test (`agent-routing-mode.test.ts`): conversation with `routing_mode='pin'` + `connectionId='eu'` + mocked LLM emitting `scope: "all"` → asserts single execution against `eu`
- [x] All-overrides-agent unit test (`agent-routing-mode.test.ts`): `routingMode='all'` + mocked LLM emitting `scope: "this"` → asserts fanout across every member
- [x] Auto-passthrough tests (`agent-routing-mode.test.ts`): `auto` + `scope: 'all'` → fanout; `auto` + `scope: 'this'` → single
- [x] Chat route ALS-frame plumbing test (`chat.test.ts`): body `routingMode` reaches `getRequestContext()?.routingMode`; absent body falls back to `"pin"`
- [x] Picker UI tests (`env-picker.test.tsx`): trigger reflects mode, dropdown renders all three rows with the current marked, mode-button onSelect produces the right triple, member-list selection forces `pin`, member highlight only shows in `pin` mode, 1×1 group keeps the picker hidden
- [x] Browser e2e `@llm` (`multi-env-routing-mode-picker.spec.ts`): user toggles picker between Auto / Pin / All and the trigger's `data-mode` attribute reflects each selection (only runs when the multi-env seed is loaded)
- [x] `bun run lint` — 0 errors (1 pre-existing unrelated warning)
- [x] `bun run type` — 0 errors
- [x] `bun run test` — 393/393 api + all other workspace suites pass
- [x] `bash scripts/check-schema-drift.sh` — green
- [x] `SKIP_SYNCPACK=1 bash scripts/check-template-drift.sh` — green
- [x] `bun x syncpack lint` — no issues

Closes #2518. PRD #2515.