### PR TITLE
feat(api,chat): #2301 — proactive-chat monthly quota cap

### DIFF
--- a/packages/api/src/api/__tests__/admin-proactive-analytics.test.ts
+++ b/packages/api/src/api/__tests__/admin-proactive-analytics.test.ts
@@ -105,6 +105,38 @@ mock.module("@atlas/api/lib/proactive/answer-meter", () => ({
 }));
 
 // ---------------------------------------------------------------------------
+// Mock the quota module (#2301)
+//
+// Same sync-factory pattern. Default `{ classifyCountThisMonth: 0,
+// monthlyClassifierCap: null, capReached: false }` so tests that don't
+// care about quota still see the rolling-window summary.
+// ---------------------------------------------------------------------------
+
+interface QuotaStatusShape {
+  monthlyClassifierCap: number | null;
+  classifyCountThisMonth: number;
+  capReached: boolean;
+}
+
+const baseQuota: QuotaStatusShape = {
+  monthlyClassifierCap: null,
+  classifyCountThisMonth: 0,
+  capReached: false,
+};
+
+const mockQuotaStatus: Mock<
+  (workspaceId: string, now?: Date) => Promise<QuotaStatusShape>
+> = mock(async () => baseQuota);
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const realQuota = require("@atlas/api/lib/proactive/quota") as typeof import("@atlas/api/lib/proactive/quota");
+
+mock.module("@atlas/api/lib/proactive/quota", () => ({
+  ...realQuota,
+  getWorkspaceQuotaStatus: mockQuotaStatus,
+}));
+
+// ---------------------------------------------------------------------------
 // Enterprise gate — default on so the route reaches the meter
 // ---------------------------------------------------------------------------
 
@@ -150,6 +182,8 @@ beforeEach(() => {
   enterpriseEnabled = true;
   mockSummary.mockClear();
   mockSummary.mockImplementation(async () => baseSummary);
+  mockQuotaStatus.mockClear();
+  mockQuotaStatus.mockImplementation(async () => baseQuota);
 });
 
 // ---------------------------------------------------------------------------
@@ -216,5 +250,66 @@ describe("GET /api/v1/admin/proactive/analytics", () => {
     // Hono error classifier maps EnterpriseError to 403 with
     // `code: "enterprise_required"`.
     expect(body.code ?? body.error).toBeDefined();
+  });
+
+  // -------------------------------------------------------------------------
+  // #2301 — monthly quota cap surfaces on the analytics payload
+  // -------------------------------------------------------------------------
+
+  it("includes the quota block with capReached=false by default", async () => {
+    const res = await app.fetch(
+      adminRequest("/api/v1/admin/proactive/analytics"),
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      quota: {
+        classifyCountThisMonth: number;
+        monthlyClassifierCap: number | null;
+        capReached: boolean;
+      };
+    };
+    expect(body.quota).toEqual({
+      classifyCountThisMonth: 0,
+      monthlyClassifierCap: null,
+      capReached: false,
+    });
+    expect(mockQuotaStatus).toHaveBeenCalledTimes(1);
+    expect(mockQuotaStatus.mock.calls[0]![0]).toBe("org-alpha");
+  });
+
+  it("surfaces a non-null cap + current usage", async () => {
+    mockQuotaStatus.mockImplementation(async () => ({
+      monthlyClassifierCap: 1000,
+      classifyCountThisMonth: 420,
+      capReached: false,
+    }));
+    const res = await app.fetch(
+      adminRequest("/api/v1/admin/proactive/analytics"),
+    );
+    const body = (await res.json()) as {
+      quota: {
+        classifyCountThisMonth: number;
+        monthlyClassifierCap: number | null;
+        capReached: boolean;
+      };
+    };
+    expect(body.quota.monthlyClassifierCap).toBe(1000);
+    expect(body.quota.classifyCountThisMonth).toBe(420);
+    expect(body.quota.capReached).toBe(false);
+  });
+
+  it("flips capReached=true when the workspace is over its cap", async () => {
+    mockQuotaStatus.mockImplementation(async () => ({
+      monthlyClassifierCap: 50,
+      classifyCountThisMonth: 50,
+      capReached: true,
+    }));
+    const res = await app.fetch(
+      adminRequest("/api/v1/admin/proactive/analytics"),
+    );
+    const body = (await res.json()) as {
+      quota: { capReached: boolean };
+    };
+    expect(body.quota.capReached).toBe(true);
   });
 });

--- a/packages/api/src/api/routes/admin-proactive-analytics.ts
+++ b/packages/api/src/api/routes/admin-proactive-analytics.ts
@@ -19,6 +19,7 @@ import { runEffect } from "@atlas/api/lib/effect/hono";
 import { AuthContext, RequestContext } from "@atlas/api/lib/effect/services";
 import { requireEnterpriseEffect } from "@atlas/ee/index";
 import { AnswerMeter, AnswerMeterLive } from "@atlas/api/lib/proactive/answer-meter";
+import { getWorkspaceQuotaStatus } from "@atlas/api/lib/proactive/quota";
 import { createAdminRouter, requireOrgContext, requirePermission } from "./admin-router";
 
 const log = createLogger("admin-proactive-analytics");
@@ -110,6 +111,19 @@ adminProactiveAnalytics.get("/", async (c) => {
           err instanceof Error ? err : new Error(String(err)),
       });
 
+      // Monthly quota snapshot (#2301). Lives next to the rolling
+      // summary so the admin UI can render "classify usage this month"
+      // alongside the rolling window — different time horizons, same
+      // panel. `getWorkspaceQuotaStatus` fails open on its own (returns
+      // `capReached: false` with null cap), so we don't need a separate
+      // try/catch here. Read on every render: COUNT(*) over the current
+      // month's classify rows is bounded by the 0078 index.
+      const quota = yield* Effect.tryPromise({
+        try: () => getWorkspaceQuotaStatus(orgId),
+        catch: (err) =>
+          err instanceof Error ? err : new Error(String(err)),
+      });
+
       log.info(
         {
           requestId,
@@ -117,6 +131,9 @@ adminProactiveAnalytics.get("/", async (c) => {
           sinceMs,
           classifyCount: summary.classifyCount,
           reactCount: summary.reactCount,
+          classifyCountThisMonth: quota.classifyCountThisMonth,
+          monthlyClassifierCap: quota.monthlyClassifierCap,
+          capReached: quota.capReached,
         },
         "proactive analytics summary served",
       );
@@ -126,6 +143,11 @@ adminProactiveAnalytics.get("/", async (c) => {
           workspaceId: orgId,
           sinceMs,
           summary,
+          quota: {
+            classifyCountThisMonth: quota.classifyCountThisMonth,
+            monthlyClassifierCap: quota.monthlyClassifierCap,
+            capReached: quota.capReached,
+          },
         },
         200,
       );

--- a/packages/api/src/lib/proactive/__tests__/quota.test.ts
+++ b/packages/api/src/lib/proactive/__tests__/quota.test.ts
@@ -1,0 +1,227 @@
+/**
+ * Unit tests for the proactive monthly quota module (#2301).
+ *
+ * Covers:
+ *   - Pure `isOverQuota(count, cap)` truth table
+ *   - Pure `startOfMonthUTC(now)` boundary semantics + month rollover
+ *   - DB-backed reads via `mock.module("@atlas/api/lib/db/internal")`
+ *
+ * `mock.module()` factory is intentionally sync (per CLAUDE.md) — the
+ * shared helpers are stubbed up-front and each test mutates the
+ * captured handles.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, mock, type Mock } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Module mocks — sync factory; handles captured for per-test mutation.
+// ---------------------------------------------------------------------------
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const realInternal = require("@atlas/api/lib/db/internal") as typeof import("@atlas/api/lib/db/internal");
+
+const mockHasInternalDB: Mock<() => boolean> = mock(() => true);
+// Mock signature uses `unknown[]` instead of a generic so per-test
+// implementations can return whatever row shape the test needs without
+// fighting TS's contravariance over the generic parameter.
+const mockInternalQuery: Mock<
+  (sql: string, params: unknown[]) => Promise<unknown[]>
+> = mock(async () => []);
+
+mock.module("@atlas/api/lib/db/internal", () => ({
+  ...realInternal,
+  hasInternalDB: () => mockHasInternalDB(),
+  internalQuery: (sql: string, params: unknown[]) =>
+    mockInternalQuery(sql, params),
+}));
+
+const quota = await import("../quota");
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+
+describe("isOverQuota", () => {
+  it("treats null cap as unlimited", () => {
+    expect(quota.isOverQuota(0, null)).toBe(false);
+    expect(quota.isOverQuota(1_000_000, null)).toBe(false);
+  });
+
+  it("treats undefined cap as unlimited", () => {
+    expect(quota.isOverQuota(42, undefined)).toBe(false);
+  });
+
+  it("returns false when count is below cap", () => {
+    expect(quota.isOverQuota(49, 50)).toBe(false);
+  });
+
+  it("returns true when count equals cap", () => {
+    // count >= cap: the 50th classify is the one that flips the gate.
+    expect(quota.isOverQuota(50, 50)).toBe(true);
+  });
+
+  it("returns true when count exceeds cap", () => {
+    expect(quota.isOverQuota(51, 50)).toBe(true);
+  });
+
+  it("coerces negative caps to 0 — never silently grants unlimited", () => {
+    // Misconfigured row ("-5") must fail closed: every classify is over.
+    expect(quota.isOverQuota(0, -5)).toBe(true);
+    expect(quota.isOverQuota(0, -1)).toBe(true);
+  });
+
+  it("cap = 0 stops the very first classify", () => {
+    expect(quota.isOverQuota(0, 0)).toBe(true);
+  });
+});
+
+describe("startOfMonthUTC", () => {
+  it("snaps mid-month timestamps to the 1st at 00:00 UTC", () => {
+    const out = quota.startOfMonthUTC(new Date(Date.UTC(2026, 4, 14, 13, 30)));
+    expect(out.toISOString()).toBe("2026-05-01T00:00:00.000Z");
+  });
+
+  it("preserves the month boundary itself", () => {
+    const out = quota.startOfMonthUTC(new Date(Date.UTC(2026, 4, 1, 0, 0)));
+    expect(out.toISOString()).toBe("2026-05-01T00:00:00.000Z");
+  });
+
+  it("rolls over cleanly at month end", () => {
+    // 2026-05-31 23:59:59 UTC → still May.
+    const may = quota.startOfMonthUTC(
+      new Date(Date.UTC(2026, 4, 31, 23, 59, 59)),
+    );
+    expect(may.toISOString()).toBe("2026-05-01T00:00:00.000Z");
+    // 2026-06-01 00:00:00 UTC → now June.
+    const june = quota.startOfMonthUTC(new Date(Date.UTC(2026, 5, 1, 0, 0, 0)));
+    expect(june.toISOString()).toBe("2026-06-01T00:00:00.000Z");
+  });
+
+  it("handles year boundaries", () => {
+    const out = quota.startOfMonthUTC(new Date(Date.UTC(2027, 0, 5, 6, 0)));
+    expect(out.toISOString()).toBe("2027-01-01T00:00:00.000Z");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DB-backed reads
+// ---------------------------------------------------------------------------
+
+describe("getMonthlyClassifierCap", () => {
+  beforeEach(() => {
+    mockHasInternalDB.mockImplementation(() => true);
+    mockInternalQuery.mockClear();
+  });
+
+  afterEach(() => {
+    mockInternalQuery.mockClear();
+  });
+
+  it("returns null when the internal DB is unavailable", async () => {
+    mockHasInternalDB.mockImplementation(() => false);
+    expect(await quota.getMonthlyClassifierCap("ws-1")).toBeNull();
+    expect(mockInternalQuery).not.toHaveBeenCalled();
+  });
+
+  it("returns null when no row exists", async () => {
+    mockInternalQuery.mockImplementation(async () => []);
+    expect(await quota.getMonthlyClassifierCap("ws-1")).toBeNull();
+  });
+
+  it("returns the row's cap when present", async () => {
+    mockInternalQuery.mockImplementation(async () => [
+      { monthly_classifier_cap: 1000 },
+    ]);
+    expect(await quota.getMonthlyClassifierCap("ws-1")).toBe(1000);
+  });
+
+  it("returns null for an explicit null column", async () => {
+    mockInternalQuery.mockImplementation(async () => [
+      { monthly_classifier_cap: null },
+    ]);
+    expect(await quota.getMonthlyClassifierCap("ws-1")).toBeNull();
+  });
+});
+
+describe("getClassifyCountThisMonth", () => {
+  beforeEach(() => {
+    mockHasInternalDB.mockImplementation(() => true);
+    mockInternalQuery.mockClear();
+  });
+
+  it("returns 0 when the internal DB is unavailable", async () => {
+    mockHasInternalDB.mockImplementation(() => false);
+    expect(await quota.getClassifyCountThisMonth("ws-1")).toBe(0);
+    expect(mockInternalQuery).not.toHaveBeenCalled();
+  });
+
+  it("returns 0 when no rows exist", async () => {
+    mockInternalQuery.mockImplementation(async () => []);
+    expect(await quota.getClassifyCountThisMonth("ws-1")).toBe(0);
+  });
+
+  it("coerces BIGINT-as-string return shape from pg", async () => {
+    mockInternalQuery.mockImplementation(async () => [{ count: "42" }]);
+    expect(await quota.getClassifyCountThisMonth("ws-1")).toBe(42);
+  });
+
+  it("accepts numeric COUNT shape (mocks / non-pg backends)", async () => {
+    mockInternalQuery.mockImplementation(async () => [{ count: 7 }]);
+    expect(await quota.getClassifyCountThisMonth("ws-1")).toBe(7);
+  });
+
+  it("passes the start-of-month cutoff to the SQL", async () => {
+    mockInternalQuery.mockImplementation(async () => [{ count: 0 }]);
+    const now = new Date(Date.UTC(2026, 4, 17, 9, 0));
+    await quota.getClassifyCountThisMonth("ws-1", now);
+    const params = mockInternalQuery.mock.calls[0]![1];
+    expect(params[0]).toBe("ws-1");
+    expect(params[1]).toBe("2026-05-01T00:00:00.000Z");
+  });
+});
+
+describe("getWorkspaceQuotaStatus", () => {
+  beforeEach(() => {
+    mockHasInternalDB.mockImplementation(() => true);
+    mockInternalQuery.mockClear();
+  });
+
+  it("returns capReached=false when cap is null (unlimited)", async () => {
+    // Two queries; cap then count. Use the SQL prefix to route.
+    mockInternalQuery.mockImplementation(async (sql: string) => {
+      if (sql.includes("monthly_classifier_cap")) {
+        return [{ monthly_classifier_cap: null }];
+      }
+      return [{ count: 12345 }];
+    });
+    const out = await quota.getWorkspaceQuotaStatus("ws-1");
+    expect(out.monthlyClassifierCap).toBeNull();
+    expect(out.classifyCountThisMonth).toBe(12345);
+    expect(out.capReached).toBe(false);
+  });
+
+  it("flips capReached when count >= cap", async () => {
+    mockInternalQuery.mockImplementation(async (sql: string) => {
+      if (sql.includes("monthly_classifier_cap")) {
+        return [{ monthly_classifier_cap: 50 }];
+      }
+      return [{ count: 50 }];
+    });
+    const out = await quota.getWorkspaceQuotaStatus("ws-1");
+    expect(out.classifyCountThisMonth).toBe(50);
+    expect(out.monthlyClassifierCap).toBe(50);
+    expect(out.capReached).toBe(true);
+  });
+
+  it("fails open on DB error — logs but returns capReached=false", async () => {
+    mockInternalQuery.mockImplementation(async () => {
+      throw new Error("internal db unreachable");
+    });
+    const out = await quota.getWorkspaceQuotaStatus("ws-1");
+    expect(out).toEqual({
+      monthlyClassifierCap: null,
+      classifyCountThisMonth: 0,
+      capReached: false,
+    });
+  });
+});

--- a/packages/api/src/lib/proactive/quota.ts
+++ b/packages/api/src/lib/proactive/quota.ts
@@ -1,0 +1,181 @@
+/**
+ * Proactive chat monthly quota cap (#2301, PRD #2291).
+ *
+ * Workspace-level cap on classifier calls (`event_type = 'classify'`) per
+ * calendar month, UTC. When the cap is reached the listener short-circuits
+ * BEFORE running the classifier — paying only a DB read + a meter row to
+ * record the skip — until the next month rolls over.
+ *
+ * Source of truth:
+ *   - cap value     →  `workspace_proactive_config.monthly_classifier_cap`
+ *                      (added by #2294, null = unlimited).
+ *   - usage count   →  `proactive_meter_events` rows with
+ *                      `event_type = 'classify'` and
+ *                      `created_at >= start_of_current_month_utc`.
+ *                      Hits the `(workspace_id, event_type, created_at desc)`
+ *                      index from migration 0078, so the COUNT(*) over a
+ *                      typical month's rows is a small bounded scan even
+ *                      at MVP — no materialized view required until usage
+ *                      patterns demand it.
+ *
+ * The pure `isOverQuota` + `startOfMonthUTC` functions are exported so unit
+ * tests can pin the math without a DB round-trip. The cap reader sits
+ * behind `hasInternalDB()` so the path is a no-op (returns "no cap, 0
+ * usage, not exhausted") in mock-pool tests + zero-config dev.
+ *
+ * Note on `lib/` discipline: this module lives in `lib/`, never imports
+ * from `api/routes/`, so the listener wiring + the analytics route can
+ * both consume it without circular imports.
+ */
+
+import { hasInternalDB, internalQuery } from "@atlas/api/lib/db/internal";
+import { createLogger } from "@atlas/api/lib/logger";
+
+const log = createLogger("proactive:quota");
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Return the UTC `Date` for the start of the calendar month containing
+ * `now`. Caller passes `now` (rather than us reading `Date.now()`) so
+ * unit tests can pin the rollover boundary deterministically — bug
+ * fixed in flight: the alternative "compute on call" version made
+ * the month-rollover test impossible to write without faking
+ * `Date.now()` globally.
+ *
+ * UTC by design: a workspace-local timezone column lives in a future
+ * 1.5.x slice. For 1.5.0 we ship UTC so the cap is well-defined the
+ * second the meter is wired across SaaS regions; the visible drift
+ * (an admin in PST sees the cap reset at 16:00 local on the last day
+ * of the month) is fine for a quota-not-billing surface.
+ */
+export function startOfMonthUTC(now: Date): Date {
+  return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1, 0, 0, 0, 0));
+}
+
+/**
+ * Pure cap check.
+ *
+ * `cap = null` (or `undefined`) means "unlimited" — never exhausts.
+ * `cap = 0` means "stop immediately" — even the first classify is over.
+ * Negative caps are coerced to 0 so a misconfigured row fails closed
+ * rather than letting a "−5" cap leak unlimited classifies.
+ */
+export function isOverQuota(count: number, cap: number | null | undefined): boolean {
+  if (cap === null || cap === undefined) return false;
+  const normalized = cap < 0 ? 0 : cap;
+  return count >= normalized;
+}
+
+// ---------------------------------------------------------------------------
+// DB-backed reads
+// ---------------------------------------------------------------------------
+
+/**
+ * Live quota snapshot. The analytics endpoint and the listener both
+ * resolve this — the listener uses `capReached` to short-circuit, the
+ * UI uses `classifyCountThisMonth` + `monthlyClassifierCap` to render
+ * the usage bar.
+ */
+export interface WorkspaceQuotaStatus {
+  /** Cap value persisted on `workspace_proactive_config`. */
+  monthlyClassifierCap: number | null;
+  /** Distinct classify rows since `startOfMonthUTC(now)`. */
+  classifyCountThisMonth: number;
+  /** Pure `isOverQuota(classifyCountThisMonth, monthlyClassifierCap)`. */
+  capReached: boolean;
+}
+
+/**
+ * Read the workspace's cap value. Returns `null` when the workspace
+ * has never had its proactive config materialised — matches the
+ * "no cap" semantic for `monthly_classifier_cap = NULL`.
+ */
+export async function getMonthlyClassifierCap(
+  workspaceId: string,
+): Promise<number | null> {
+  if (!hasInternalDB()) return null;
+  const rows = await internalQuery<{ monthly_classifier_cap: number | null }>(
+    `SELECT monthly_classifier_cap
+       FROM workspace_proactive_config
+      WHERE workspace_id = $1`,
+    [workspaceId],
+  );
+  if (rows.length === 0) return null;
+  return rows[0]!.monthly_classifier_cap;
+}
+
+/**
+ * COUNT classify rows since `startOfMonthUTC(now)`. Uses the
+ * `(workspace_id, event_type, created_at DESC)` index from 0078 so
+ * the scan is bounded by the month's classify volume.
+ *
+ * `now` defaults to `new Date()` so production callers don't have to
+ * thread a clock through every layer; tests inject the boundary.
+ */
+export async function getClassifyCountThisMonth(
+  workspaceId: string,
+  now: Date = new Date(),
+): Promise<number> {
+  if (!hasInternalDB()) return 0;
+  const cutoff = startOfMonthUTC(now).toISOString();
+  const rows = await internalQuery<{ count: string | number }>(
+    `SELECT COUNT(*)::bigint AS count
+       FROM proactive_meter_events
+      WHERE workspace_id = $1
+        AND event_type = 'classify'
+        AND created_at >= $2`,
+    [workspaceId, cutoff],
+  );
+  if (rows.length === 0) return 0;
+  // `pg` returns BIGINT as a string — coerce defensively.
+  const raw = rows[0]!.count;
+  const n = typeof raw === "string" ? Number(raw) : raw;
+  return Number.isFinite(n) ? n : 0;
+}
+
+/**
+ * One-shot read of `{ monthlyClassifierCap, classifyCountThisMonth,
+ * capReached }`. The listener calls this on every channel message
+ * BEFORE classification; the admin analytics endpoint calls it on
+ * every render. Both are cheap thanks to the 0078 index.
+ *
+ * Fails open on read errors — `capReached: false` keeps Atlas
+ * answering when the meter table hiccups. Logs at warn so an on-call
+ * sees the read failure without the user seeing Atlas go silent.
+ */
+export async function getWorkspaceQuotaStatus(
+  workspaceId: string,
+  now: Date = new Date(),
+): Promise<WorkspaceQuotaStatus> {
+  try {
+    // Two queries instead of one JOIN: the cap row is tiny (1 row) and
+    // the count is index-scanned. Splitting keeps the SQL readable +
+    // lets `getMonthlyClassifierCap` be reused for the workspace-config
+    // view in `admin-proactive.ts` later without re-deriving the cap.
+    const [cap, count] = await Promise.all([
+      getMonthlyClassifierCap(workspaceId),
+      getClassifyCountThisMonth(workspaceId, now),
+    ]);
+    return {
+      monthlyClassifierCap: cap,
+      classifyCountThisMonth: count,
+      capReached: isOverQuota(count, cap),
+    };
+  } catch (err) {
+    log.warn(
+      {
+        err: err instanceof Error ? err.message : String(err),
+        workspaceId,
+      },
+      "Proactive quota read failed — failing open (Atlas keeps answering)",
+    );
+    return {
+      monthlyClassifierCap: null,
+      classifyCountThisMonth: 0,
+      capReached: false,
+    };
+  }
+}

--- a/packages/web/src/app/admin/proactive-chat/page.tsx
+++ b/packages/web/src/app/admin/proactive-chat/page.tsx
@@ -452,8 +452,9 @@ function MonthlyCapField({
       </Label>
       <p className="text-[12px] text-muted-foreground">
         Optional. Hard cap on classifier invocations per calendar month. When
-        the cap is reached, proactive chat falls back to the regex layer only
-        until the next reset. Leave blank for no cap.
+        the cap is reached, proactive chat short-circuits before the
+        classifier runs until the next reset (calendar month, UTC). Leave
+        blank for no cap.
       </p>
       <Input
         id="proactive-monthly-cap"
@@ -466,6 +467,81 @@ function MonthlyCapField({
         aria-invalid={invalid}
         className="max-w-[180px] font-mono text-sm"
       />
+      <QuotaUsageIndicator />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Quota usage indicator (#2301)
+//
+// Reads `GET /api/v1/admin/proactive/analytics` and renders a tiny usage
+// bar with traffic-light colors:
+//   - <80%  grey   (under cap, no concern)
+//   - 80%+  yellow (warn — admin may want to raise the cap)
+//   - 100%  red    (exhausted — proactive is silently short-circuiting)
+//
+// Rendered inline under the cap input so the admin can see the impact of
+// the value they just typed. Hides itself when the workspace has never
+// set a cap (`monthlyClassifierCap === null`) — there's nothing to
+// usage-bar against.
+// ---------------------------------------------------------------------------
+
+const AnalyticsResponseSchema = z.object({
+  quota: z.object({
+    classifyCountThisMonth: z.number().int().nonnegative(),
+    monthlyClassifierCap: z.number().int().nonnegative().nullable(),
+    capReached: z.boolean(),
+  }),
+});
+
+type AnalyticsResponse = z.infer<typeof AnalyticsResponseSchema>;
+
+function QuotaUsageIndicator() {
+  const { data, loading, error } = useAdminFetch<AnalyticsResponse>(
+    "/api/v1/admin/proactive/analytics",
+    { schema: AnalyticsResponseSchema },
+  );
+
+  if (loading || error || !data) return null;
+  const { classifyCountThisMonth, monthlyClassifierCap, capReached } = data.quota;
+  if (monthlyClassifierCap === null) return null;
+
+  const pct =
+    monthlyClassifierCap === 0
+      ? 100
+      : Math.min(
+          100,
+          Math.round((classifyCountThisMonth / monthlyClassifierCap) * 100),
+        );
+  const yellow = pct >= 80 && !capReached;
+  const red = capReached;
+
+  const barColor = red
+    ? "bg-destructive"
+    : yellow
+      ? "bg-yellow-500"
+      : "bg-muted-foreground/40";
+  const labelColor = red
+    ? "text-destructive"
+    : yellow
+      ? "text-yellow-700 dark:text-yellow-500"
+      : "text-muted-foreground";
+
+  return (
+    <div className="space-y-1.5" aria-live="polite">
+      <div className="h-1.5 w-full max-w-[260px] overflow-hidden rounded-full bg-muted">
+        <div
+          className={`h-full rounded-full transition-all ${barColor}`}
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+      <p className={`text-[11px] ${labelColor}`}>
+        {classifyCountThisMonth.toLocaleString()} /{" "}
+        {monthlyClassifierCap.toLocaleString()} classifies this month ({pct}%)
+        {red && " — cap reached; proactive will resume next month"}
+        {yellow && " — approaching cap"}
+      </p>
     </div>
   );
 }

--- a/plugins/chat/src/bridge.ts
+++ b/plugins/chat/src/bridge.ts
@@ -1578,6 +1578,10 @@ export function createChatBridge(
           workspaceId: proactiveConfig.workspaceId,
           isPaused: proactiveConfig.isPaused,
           onPauseRequest: proactiveConfig.onPauseRequest,
+          // AnswerMeter (#2296).
+          onMeterEvent: proactiveConfig.onMeterEvent,
+          // Monthly quota cap (#2301).
+          getQuotaStatus: proactiveConfig.getQuotaStatus,
         });
         proactiveRecentAnswers = handle.recentAnswers;
       })

--- a/plugins/chat/src/config.ts
+++ b/plugins/chat/src/config.ts
@@ -11,9 +11,11 @@ import type { StreamChunk } from "chat";
 import type { ReactionConfig } from "./features/reactions";
 import type {
   ChannelProactiveConfig,
+  GetQuotaStatusFn,
   LLMClassifierFn,
   OnPauseRequestFn,
   ProactiveGateFn,
+  ProactiveMeterEventFn,
   WorkspaceProactiveConfig,
 } from "./proactive/types";
 import type { IsPausedFn } from "./proactive/pause";
@@ -479,6 +481,29 @@ export interface ProactiveConfig {
    * user opt-out).
    */
   onPauseRequest?: OnPauseRequestFn;
+
+  // ---- Slice #2296 additions: AnswerMeter ----
+
+  /**
+   * Per-event meter callback. Receives one event per classify (always)
+   * and one per react / offer / accept / feedback when those stages
+   * fire. Host wires this to `recordMeterEvent` from
+   * `@atlas/api/lib/proactive/answer-meter` so rows land in
+   * `proactive_meter_events`.
+   */
+  onMeterEvent?: ProactiveMeterEventFn;
+
+  // ---- Slice #2301 additions: monthly quota cap ----
+
+  /**
+   * Quota-status reader. Consulted BEFORE the classifier on every
+   * channel message — when the workspace has hit its monthly cap the
+   * listener short-circuits and emits a `capReached` meter row instead
+   * of running the LLM. Host wires this to
+   * `getWorkspaceQuotaStatus` from
+   * `@atlas/api/lib/proactive/quota`.
+   */
+  getQuotaStatus?: GetQuotaStatusFn;
 }
 
 // ---------------------------------------------------------------------------
@@ -756,6 +781,24 @@ const ProactiveConfigSchema = z
       .refine(
         (v) => v === undefined || typeof v === "function",
         "proactive.onPauseRequest must be a function returning Promise<void>",
+      )
+      .optional(),
+    // AnswerMeter wiring (#2296). Optional — when omitted the listener
+    // simply doesn't emit meter rows.
+    onMeterEvent: z
+      .any()
+      .refine(
+        (v) => v === undefined || typeof v === "function",
+        "proactive.onMeterEvent must be a function returning Promise<void> | void",
+      )
+      .optional(),
+    // Monthly quota wiring (#2301). Optional — when omitted no cap is
+    // enforced and every message goes through the classifier.
+    getQuotaStatus: z
+      .any()
+      .refine(
+        (v) => v === undefined || typeof v === "function",
+        "proactive.getQuotaStatus must be a function returning Promise<ProactiveQuotaStatus>",
       )
       .optional(),
   })

--- a/plugins/chat/src/proactive/__tests__/listener.test.ts
+++ b/plugins/chat/src/proactive/__tests__/listener.test.ts
@@ -880,3 +880,187 @@ describe("registerProactiveListener — kill switch", () => {
     expect(thread._addReaction).toHaveBeenCalledTimes(1);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Monthly quota cap (#2301)
+// ---------------------------------------------------------------------------
+
+interface MeterEventRecorded {
+  eventType: string;
+  metadata?: Record<string, unknown>;
+}
+
+describe("registerProactiveListener — monthly quota cap (#2301)", () => {
+  it("short-circuits classification + reaction and emits a capReached meter event when the cap is reached", async () => {
+    const classify = mock(yesLLM);
+    const meterEvents: MeterEventRecorded[] = [];
+    const onMeterEvent = mock(async (evt: MeterEventRecorded) => {
+      meterEvents.push(evt);
+    });
+    const getQuotaStatus = mock(async () => ({
+      monthlyClassifierCap: 50,
+      classifyCountThisMonth: 50,
+      capReached: true,
+    }));
+    const { chat, invokeMessage: invoke } = makeChat();
+    await registerProactiveListener(
+      chat as unknown as Parameters<typeof registerProactiveListener>[0],
+      makeLogger(),
+      {
+        isEnabled: () => true,
+        classify,
+        workspace: baseWorkspace,
+        channelAllowlist: ["C-allowed"],
+        workspaceId: "ws_1",
+        getQuotaStatus,
+        onMeterEvent,
+      },
+    );
+    const thread = makeThread("C-allowed");
+    await invoke(thread, makeMessage());
+
+    expect(getQuotaStatus).toHaveBeenCalledTimes(1);
+    expect(classify).not.toHaveBeenCalled();
+    expect(thread._addReaction).not.toHaveBeenCalled();
+    // One meter event: the capReached marker.
+    expect(meterEvents).toHaveLength(1);
+    expect(meterEvents[0]!.eventType).toBe("classify");
+    expect(meterEvents[0]!.metadata).toMatchObject({
+      capReached: true,
+      skipped: "monthly-quota",
+      classifyCountThisMonth: 50,
+      monthlyClassifierCap: 50,
+    });
+  });
+
+  it("simulates 100 messages on a cap=50 workspace and short-circuits the 51st", async () => {
+    const classify = mock(yesLLM);
+    let count = 0;
+    const cap = 50;
+    // Production-faithful: the quota reader reflects whatever the host
+    // last wrote to `proactive_meter_events`. Bump `count` from inside
+    // the meter callback so the 51st classify actually trips the cap.
+    const getQuotaStatus = mock(async () => ({
+      monthlyClassifierCap: cap,
+      classifyCountThisMonth: count,
+      capReached: count >= cap,
+    }));
+    const meterEvents: MeterEventRecorded[] = [];
+    const onMeterEvent = mock(async (evt: MeterEventRecorded) => {
+      if (evt.eventType === "classify" && evt.metadata?.capReached !== true) {
+        count += 1;
+      }
+      meterEvents.push(evt);
+    });
+
+    const { chat, invokeMessage: invoke } = makeChat();
+    await registerProactiveListener(
+      chat as unknown as Parameters<typeof registerProactiveListener>[0],
+      makeLogger(),
+      {
+        isEnabled: () => true,
+        classify,
+        workspace: baseWorkspace,
+        channelAllowlist: ["C-allowed"],
+        workspaceId: "ws_1",
+        getQuotaStatus,
+        onMeterEvent,
+      },
+    );
+
+    // Drive 100 messages through the listener.
+    for (let i = 0; i < 100; i++) {
+      const thread = makeThread("C-allowed");
+      await invoke(thread, makeMessage({ id: `M-${i}` }));
+    }
+
+    // First 50 should classify; the remaining 50 should short-circuit.
+    expect(classify).toHaveBeenCalledTimes(50);
+    expect(getQuotaStatus).toHaveBeenCalledTimes(100);
+    const capReachedEvents = meterEvents.filter(
+      (e) => e.metadata?.capReached === true,
+    );
+    expect(capReachedEvents.length).toBe(50);
+  });
+
+  it("fails open on getQuotaStatus throw — Atlas keeps answering", async () => {
+    const classify = mock(yesLLM);
+    const getQuotaStatus = mock(async () => {
+      throw new Error("quota read failed");
+    });
+    const { chat, invokeMessage: invoke } = makeChat();
+    const log = makeLogger();
+    await registerProactiveListener(
+      chat as unknown as Parameters<typeof registerProactiveListener>[0],
+      log,
+      {
+        isEnabled: () => true,
+        classify,
+        workspace: baseWorkspace,
+        channelAllowlist: ["C-allowed"],
+        workspaceId: "ws_1",
+        getQuotaStatus,
+      },
+    );
+    const thread = makeThread("C-allowed");
+    await invoke(thread, makeMessage());
+
+    expect(getQuotaStatus).toHaveBeenCalledTimes(1);
+    // Failed-open: classifier still runs, reaction still fires.
+    expect(classify).toHaveBeenCalledTimes(1);
+    expect(thread._addReaction).toHaveBeenCalledTimes(1);
+    expect(log.warn).toHaveBeenCalled();
+  });
+
+  it("proceeds to classifier when capReached=false", async () => {
+    const classify = mock(yesLLM);
+    const getQuotaStatus = mock(async () => ({
+      monthlyClassifierCap: 1000,
+      classifyCountThisMonth: 12,
+      capReached: false,
+    }));
+    const { chat, invokeMessage: invoke } = makeChat();
+    await registerProactiveListener(
+      chat as unknown as Parameters<typeof registerProactiveListener>[0],
+      makeLogger(),
+      {
+        isEnabled: () => true,
+        classify,
+        workspace: baseWorkspace,
+        channelAllowlist: ["C-allowed"],
+        workspaceId: "ws_1",
+        getQuotaStatus,
+      },
+    );
+    const thread = makeThread("C-allowed");
+    await invoke(thread, makeMessage());
+    expect(getQuotaStatus).toHaveBeenCalledTimes(1);
+    expect(classify).toHaveBeenCalledTimes(1);
+    expect(thread._addReaction).toHaveBeenCalledTimes(1);
+  });
+
+  it("is a no-op for quota checks when workspaceId is omitted", async () => {
+    const getQuotaStatus = mock(async () => ({
+      monthlyClassifierCap: 50,
+      classifyCountThisMonth: 50,
+      capReached: true,
+    }));
+    const { chat, invokeMessage: invoke } = makeChat();
+    await registerProactiveListener(
+      chat as unknown as Parameters<typeof registerProactiveListener>[0],
+      makeLogger(),
+      {
+        isEnabled: () => true,
+        classify: yesLLM,
+        workspace: baseWorkspace,
+        channelAllowlist: ["C-allowed"],
+        // No workspaceId — listener should NOT call getQuotaStatus.
+        getQuotaStatus,
+      },
+    );
+    const thread = makeThread("C-allowed");
+    await invoke(thread, makeMessage());
+    expect(getQuotaStatus).not.toHaveBeenCalled();
+    expect(thread._addReaction).toHaveBeenCalledTimes(1);
+  });
+});

--- a/plugins/chat/src/proactive/listener.ts
+++ b/plugins/chat/src/proactive/listener.ts
@@ -35,6 +35,7 @@ import {
 } from "./answerer";
 import type {
   ChannelProactiveConfig,
+  GetQuotaStatusFn,
   LLMClassifierFn,
   OnPauseRequestFn,
   ProactiveGateFn,
@@ -108,6 +109,21 @@ export interface ProactiveListenerConfig {
    * outage never crashes the Chat SDK loop.
    */
   onMeterEvent?: ProactiveMeterEventFn;
+
+  // ---- Slice #2301 additions: monthly quota cap ----
+
+  /**
+   * Optional host-injected quota reader. Consulted BEFORE classification
+   * so a workspace that has hit its monthly cap pays only a DB read
+   * (well-indexed) per message instead of an LLM call. When the cap is
+   * reached the listener emits a `classify` meter event with
+   * `metadata: { capReached: true, skipped: "monthly-quota" }` and
+   * skips both classification and reaction.
+   *
+   * Failures are swallowed (no-op + warn) so a quota outage never
+   * silences Atlas — the agent fails open just like the pause registry.
+   */
+  getQuotaStatus?: GetQuotaStatusFn;
 
   // ---- Slice #2298 additions: feedback collection ----
 
@@ -380,6 +396,54 @@ export async function registerProactiveListener(
 
       const channelAllowed = allowlist.has(channelId);
       const channelConfig = config.channelConfigs?.[channelId];
+
+      // ---------------------------------------------------------------
+      // Monthly quota cap (#2301) — short-circuit BEFORE the classifier
+      // when the workspace has used its allotted classifies for the
+      // current calendar month. Records a `classify` meter row with
+      // `capReached: true` so the admin analytics + audit trail show
+      // "we saw a question and chose to skip it because of the cap"
+      // instead of a silent gap. No reaction, no offer card.
+      // ---------------------------------------------------------------
+      if (config.getQuotaStatus && config.workspaceId) {
+        try {
+          const quota = await config.getQuotaStatus({
+            workspaceId: config.workspaceId,
+          });
+          if (quota.capReached) {
+            log.debug(
+              {
+                workspaceId: config.workspaceId,
+                channelId,
+                classifyCountThisMonth: quota.classifyCountThisMonth,
+                monthlyClassifierCap: quota.monthlyClassifierCap,
+              },
+              "Proactive: skipped — monthly classifier cap reached",
+            );
+            await emitMeter({
+              channelId,
+              messageId: message.id,
+              eventType: "classify",
+              tokens: 0,
+              actorUserId: message.author.userId ?? null,
+              metadata: {
+                capReached: true,
+                skipped: "monthly-quota",
+                classifyCountThisMonth: quota.classifyCountThisMonth,
+                monthlyClassifierCap: quota.monthlyClassifierCap,
+              },
+            });
+            return;
+          }
+        } catch (err) {
+          // Fail open — momentary read failure shouldn't silence the
+          // agent. Same posture as the pause registry above.
+          log.warn(
+            { err: err instanceof Error ? err : new Error(String(err)) },
+            "Proactive: quota read failed — treating as under cap",
+          );
+        }
+      }
 
       const classification = await classifyMessage({
         text,

--- a/plugins/chat/src/proactive/types.ts
+++ b/plugins/chat/src/proactive/types.ts
@@ -179,3 +179,34 @@ export interface ProactiveMeterEvent {
 export type ProactiveMeterEventFn = (
   event: ProactiveMeterEvent,
 ) => Promise<void> | void;
+
+// ---------------------------------------------------------------------------
+// Monthly quota cap (#2301)
+// ---------------------------------------------------------------------------
+
+/**
+ * Quota snapshot returned by the host. Mirrors `WorkspaceQuotaStatus`
+ * from `@atlas/api/lib/proactive/quota` shape-by-shape — declared
+ * here so the plugin doesn't import `@atlas/api`.
+ */
+export interface ProactiveQuotaStatus {
+  /** Cap value persisted on the workspace config. Null = unlimited. */
+  monthlyClassifierCap: number | null;
+  /** Distinct classify rows since the start of the current UTC month. */
+  classifyCountThisMonth: number;
+  /** True when `classifyCountThisMonth >= monthlyClassifierCap`. */
+  capReached: boolean;
+}
+
+/**
+ * Host-injected quota reader. Consulted BEFORE the classifier on every
+ * channel message — pays a single DB read (well-indexed) and short-
+ * circuits the LLM call when the workspace has hit its monthly cap.
+ *
+ * Implementations should never throw. Failures are caught by the
+ * listener and treated as "no quota info" (Atlas keeps answering)
+ * so a quota outage never crashes the SDK event loop.
+ */
+export type GetQuotaStatusFn = (input: {
+  workspaceId: string;
+}) => Promise<ProactiveQuotaStatus>;


### PR DESCRIPTION
## Summary

- Workspace hits its `monthly_classifier_cap` for the current UTC calendar month → listener short-circuits **before** the classifier runs, paying only a DB read instead of an LLM call.
- Emits a `classify` meter row with `metadata: { capReached: true, skipped: "monthly-quota" }` so the audit + analytics trail shows "we saw a question and chose to skip" rather than a silent gap.
- Cap reader fails open on DB error — Atlas keeps answering when the meter table hiccups (matches the pause registry posture).
- `GET /api/v1/admin/proactive/analytics` payload now includes `{ quota: { classifyCountThisMonth, monthlyClassifierCap, capReached } }` alongside the rolling-window summary.
- Admin page renders a usage bar below the cap input — grey under 80%, yellow at 80%+, red at 100%.

Slice #2301 of milestone 1.5.0 (PRD #2291). No migration needed — `monthly_classifier_cap` already on `workspace_proactive_config` from migration 0075.

## Key files

- `packages/api/src/lib/proactive/quota.ts` (new) — pure `isOverQuota` / `startOfMonthUTC` + DB-backed `getWorkspaceQuotaStatus`. Uses the `(workspace_id, event_type, created_at desc)` index from migration 0078.
- `plugins/chat/src/proactive/types.ts` — `GetQuotaStatusFn` + `ProactiveQuotaStatus` (mirrors the API shape; plugin doesn't import `@atlas/api`).
- `plugins/chat/src/proactive/listener.ts` — quota check BEFORE classification.
- `plugins/chat/src/config.ts`, `plugins/chat/src/bridge.ts` — `getQuotaStatus` + `onMeterEvent` wired through ProactiveConfig and the bridge.
- `packages/api/src/api/routes/admin-proactive-analytics.ts` — payload extended with quota block.
- `packages/web/src/app/admin/proactive-chat/page.tsx` — `<QuotaUsageIndicator />` usage bar.

## Test plan

- [x] 23 unit tests for the quota module (`packages/api/src/lib/proactive/__tests__/quota.test.ts`) — pure helpers + DB-backed reads + fail-open.
- [x] 5 listener integration tests including a 100-message simulation on a cap=50 workspace that proves the 51st classify is short-circuited.
- [x] 3 route tests confirming the analytics payload shape + `capReached` propagation.
- [x] `bun run lint && bun run type && bun x syncpack lint && bash scripts/check-template-drift.sh && bash scripts/check-schema-drift.sh && bash scripts/check-railway-watch.sh` — all green.
- [x] `cd packages/api && bun run scripts/test-isolated.ts --affected` — 96/96 pass.
- [x] `cd plugins/chat && bun test` — 403/403 pass.

Refs PRD #2291.