### PR TITLE
fix(api,react,types): cross-env review follow-up — FK race, react re-exports, RoutingReason→OTel, NULL→pin resolver

### DIFF
--- a/.claude/research/architecture-wins.md
+++ b/.claude/research/architecture-wins.md
@@ -1716,11 +1716,11 @@ A new `boot-smoke` job in `.github/workflows/deploy-validation.yml` builds `depl
 - **Unknown-member fallback degrades, doesn't fault.** When the agent emits a `scope` string that doesn't match any member (a prompt drift or model hallucination), the planner falls back to the group's primary with a warning rather than 500-ing the tool call. The audit warning surfaces the divergence to the operator.
 
 **What got unbundled:**
-- **The routing rules became a single named function call.** Slice 2's agent-prompt change and slice 3's picker can both call `resolveRoutingPlan` with their respective inputs and trust the policy is consistent. Without this module, the prompt prompt would need its own logic for "what does `scope: 'all'` mean" and the picker would need its own logic for "what does `pickerMode: 'pin'` mean," and the two would inevitably drift.
-- **The reason discriminator is the audit attribute.** `RoutingReason` values (`agent-all`, `picker-pin`, `1x1-group`, etc.) feed directly into the `atlas.routing_mode` OTel span attribute slated for slice 4. Pinning the reason in tests means the audit dimension can't silently change.
+- **The routing rules became a single named function call.** Slice 2's agent-prompt change and slice 3's picker can both call `resolveRoutingPlan` with their respective inputs and trust the policy is consistent. Without this module, the agent prompt would need its own logic for "what does `scope: 'all'` mean" and the picker would need its own logic for "what does `pickerMode: 'pin'` mean," and the two would inevitably drift.
+- **The reason discriminator is an audit + OTel attribute.** `RoutingReason` values (`agent-all`, `picker-pin`, `1x1-group`, etc.) flow into the `atlas.routing_reason` OTel span attribute on every `atlas.sql.execute` span (single + fanout legs). Pinning the reason in tests means the trace dimension can't silently change. The follow-up to milestone 1.4.5 wired this end-to-end after the original slice shipped — the reason had been generated but not consumed.
 
 **Impact:**
-- **One pure module** (~165 lines including JSDoc) holds every routing decision.
+- **One pure module** holds every routing decision; the run-time logic is ~110 effective lines (the rest is structured JSDoc).
 - **18 unit tests** in `env-routing/__tests__/index.test.ts` cover the full decision table.
 - **Zero pre-existing call sites changed.** `executeSQL` was the first consumer; slices 2 + 3 wire the agent prompt and picker.
 
@@ -1749,9 +1749,9 @@ A new `boot-smoke` job in `.github/workflows/deploy-validation.yml` builds `depl
 - **Empty / degenerate / fanout-of-one all collapse to the same shape.** Zero members → `{ columns: [__env__], rows: [], envContributions: [] }`; single-member fanout → same shape as the multi-member case. Downstream code (UI, SDK, audit) handles one branch.
 
 **Impact:**
-- **One pure module** (~130 lines including JSDoc) holds every merge rule.
+- **One pure module** holds every merge rule (run-time logic ~70 effective lines; the rest is structured JSDoc).
 - **13 unit tests** in `multi-env-merger/__tests__/index.test.ts` cover same-schema, schema-divergence, partial failure, all-failure, all-empty, type coercion, ordering, and the `__env__` collision case.
-- **`executeSQL`'s fanout dispatch** (`executeSqlFanout`) is ~45 lines — orchestration only, no merge logic inline.
+- **`executeSQL`'s fanout dispatch** (`executeSqlFanout`) is orchestration only — the merge logic stays in the pure module.
 
 **Category:** Pure data-transformation module extracted ahead of the behaviour-flipping slice. The merger's interface (`MemberExecutionResult[]` → `MergedResult`) is the same shape slice 4 ships on the wire, so the type contract from the merger flows straight through to the SDK without a translation step.
 

--- a/e2e/browser/multi-env-routing-happy.spec.ts
+++ b/e2e/browser/multi-env-routing-happy.spec.ts
@@ -129,11 +129,13 @@ test.describe("multi-env routing — happy path @llm", () => {
     await input.fill(COMPARATIVE_QUESTION);
     await input.press("Enter");
 
-    // Look for an executeSQL tool-call result — single-env path keeps the
-    // legacy `{columns, rows}` shape (no `__env__` prepend).
+    // Anchor on the response actually rendering — a fixed sleep lets
+    // this test pass vacuously against slow providers (cold-start
+    // latency > sleep length means the table never gets a chance to
+    // render, so the negative assertion succeeds for the wrong reason).
+    const firstRow = page.locator('table tbody tr').first();
+    await firstRow.waitFor({ state: "visible", timeout: 120_000 });
     const noEnvHeader = page.locator('table thead th', { hasText: "__env__" });
-    // Wait a bit for the response; assert the merged shape never appears.
-    await page.waitForTimeout(20_000);
     expect(await noEnvHeader.count(), "Pin mode must not produce a merged __env__ table").toBe(0);
   });
 

--- a/e2e/browser/multi-env-routing-mode-picker.spec.ts
+++ b/e2e/browser/multi-env-routing-mode-picker.spec.ts
@@ -26,7 +26,12 @@ import {
  * `@llm` suite exercises.
  */
 
-test.describe("multi-env routing-mode picker @llm", () => {
+// Previously tagged `@llm` because the picker renders inside an
+// auth-gated chat shell — but the spec sends no messages, so a real
+// model isn't required. Re-tagged so the picker UI smoke runs in the
+// default browser-tests matrix and not just the LLM-budgeted job; a
+// picker-regression should surface on every PR, not only LLM CI.
+test.describe("multi-env routing-mode picker", () => {
   test.use({ storageState: "e2e/browser/multi-env-storage.json" });
 
   let request: APIRequestContext;

--- a/e2e/browser/multi-env-routing-partial-failure.spec.ts
+++ b/e2e/browser/multi-env-routing-partial-failure.spec.ts
@@ -68,14 +68,14 @@ test.describe("multi-env routing — partial failure @llm", () => {
     const probe = await request.get(`${API_URL}/api/v1/admin/connections/${FAILED_ENV_ID}`, {
       headers: { origin: API_URL, "x-atlas-mode": "developer" },
     });
-    if (probe.status() === 200) {
-      const body = (await probe.json()) as { url?: string } | null;
-      originalUrlBackup = body?.url ?? ORIGINAL_URL;
-    } else {
-      originalUrlBackup = ORIGINAL_URL;
-    }
+    const snapshotUrl: string = probe.status() === 200
+      ? ((await probe.json()) as { url?: string } | null)?.url ?? ORIGINAL_URL
+      : ORIGINAL_URL;
 
-    // Corrupt the connection URL so the fanout sees one failure.
+    // Corrupt the connection URL so the fanout sees one failure. Only
+    // record the snapshot in `originalUrlBackup` AFTER the corruption
+    // PATCH succeeds — that way a failure here doesn't trigger a
+    // restore in afterAll that overwrites a URL we never touched.
     const patch = await request.patch(`${API_URL}/api/v1/admin/connections/${FAILED_ENV_ID}`, {
       headers: { origin: API_URL, "x-atlas-mode": "developer", "content-type": "application/json" },
       data: { url: BROKEN_URL },
@@ -85,17 +85,29 @@ test.describe("multi-env routing — partial failure @llm", () => {
         true,
         `Could not corrupt ${FAILED_ENV_ID} URL (${patch.status()}) — partial-failure spec needs admin write access.`,
       );
+      return;
     }
+    originalUrlBackup = snapshotUrl;
   });
 
   test.afterAll(async () => {
     if (request && originalUrlBackup != null) {
       // Restore the original URL so a partial failure here doesn't poison
-      // every subsequent test run.
-      await request.patch(`${API_URL}/api/v1/admin/connections/${FAILED_ENV_ID}`, {
+      // every subsequent test run. Log a non-200 response so CI surfaces
+      // "manual cleanup required" instead of silently leaving a broken
+      // seed in place for the next invocation.
+      const restore = await request.patch(`${API_URL}/api/v1/admin/connections/${FAILED_ENV_ID}`, {
         headers: { origin: API_URL, "x-atlas-mode": "developer", "content-type": "application/json" },
         data: { url: originalUrlBackup },
       });
+      if (restore.status() !== 200) {
+        // eslint-disable-next-line no-console -- diagnostic for the next CI run
+        console.error(
+          `[multi-env-routing-partial-failure] MANUAL CLEANUP REQUIRED: ` +
+            `failed to restore ${FAILED_ENV_ID} URL (status ${restore.status()}). ` +
+            `Re-seed via 'bun scripts/seed-multi-env.ts' before retrying.`,
+        );
+      }
     }
     await request?.dispose();
   });

--- a/packages/api/src/__mocks__/api-test-mocks.ts
+++ b/packages/api/src/__mocks__/api-test-mocks.ts
@@ -619,6 +619,13 @@ export function createApiTestMocks(
     // exercise the picker toggle path, and they override locally when
     // they do.
     updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
+    // NULL → "pin" back-compat default helper used by the chat route to
+    // resolve a conversation's persisted `routing_mode`. Mocked as a pure
+    // pass-through so tests can simulate either an explicit mode or the
+    // legacy NULL → "pin" coercion without further wiring.
+    resolveRoutingMode: mock(
+      (m: "auto" | "pin" | "all" | null | undefined = null) => m ?? "pin",
+    ),
   }));
 
   // ── Security ──────────────────────────────────────────────────

--- a/packages/api/src/api/__tests__/actions.test.ts
+++ b/packages/api/src/api/__tests__/actions.test.ts
@@ -138,6 +138,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   resolveGroupForConnection: mock(() => Promise.resolve(null)),
   verifyGroupBelongsToOrg: mock(() => Promise.resolve("ok")),
   updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
+  resolveRoutingMode: mock((m: "auto" | "pin" | "all" | null | undefined = null) => m ?? "pin"),
 }));
 
 mock.module("@atlas/api/lib/semantic", () => ({

--- a/packages/api/src/api/__tests__/admin-email-provider-route.test.ts
+++ b/packages/api/src/api/__tests__/admin-email-provider-route.test.ts
@@ -305,6 +305,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   resolveGroupForConnection: mock(() => Promise.resolve(null)),
   verifyGroupBelongsToOrg: mock(() => Promise.resolve("ok")),
   updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
+  resolveRoutingMode: mock((m: "auto" | "pin" | "all" | null | undefined = null) => m ?? "pin"),
 }));
 
 mock.module("@atlas/api/lib/auth/server", () => ({

--- a/packages/api/src/api/__tests__/admin-integrations-byot.test.ts
+++ b/packages/api/src/api/__tests__/admin-integrations-byot.test.ts
@@ -361,6 +361,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   resolveGroupForConnection: mock(() => Promise.resolve(null)),
   verifyGroupBelongsToOrg: mock(() => Promise.resolve("ok")),
   updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
+  resolveRoutingMode: mock((m: "auto" | "pin" | "all" | null | undefined = null) => m ?? "pin"),
 }));
 
 mock.module("@atlas/api/lib/auth/server", () => ({

--- a/packages/api/src/api/__tests__/admin-integrations.test.ts
+++ b/packages/api/src/api/__tests__/admin-integrations.test.ts
@@ -285,6 +285,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   resolveGroupForConnection: mock(() => Promise.resolve(null)),
   verifyGroupBelongsToOrg: mock(() => Promise.resolve("ok")),
   updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
+  resolveRoutingMode: mock((m: "auto" | "pin" | "all" | null | undefined = null) => m ?? "pin"),
 }));
 
 mock.module("@atlas/api/lib/auth/server", () => ({

--- a/packages/api/src/api/__tests__/admin-invitations.test.ts
+++ b/packages/api/src/api/__tests__/admin-invitations.test.ts
@@ -273,6 +273,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   resolveGroupForConnection: mock(() => Promise.resolve(null)),
   verifyGroupBelongsToOrg: mock(() => Promise.resolve("ok")),
   updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
+  resolveRoutingMode: mock((m: "auto" | "pin" | "all" | null | undefined = null) => m ?? "pin"),
 }));
 
 // Import app after all mocks are registered

--- a/packages/api/src/api/__tests__/admin-password.test.ts
+++ b/packages/api/src/api/__tests__/admin-password.test.ts
@@ -226,6 +226,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   resolveGroupForConnection: mock(() => Promise.resolve(null)),
   verifyGroupBelongsToOrg: mock(() => Promise.resolve("ok")),
   updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
+  resolveRoutingMode: mock((m: "auto" | "pin" | "all" | null | undefined = null) => m ?? "pin"),
 }));
 
 // Mock auth/server for the password-change dynamic import

--- a/packages/api/src/api/__tests__/admin.test.ts
+++ b/packages/api/src/api/__tests__/admin.test.ts
@@ -542,6 +542,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   resolveGroupForConnection: mock(() => Promise.resolve(null)),
   verifyGroupBelongsToOrg: mock(() => Promise.resolve("ok")),
   updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
+  resolveRoutingMode: mock((m: "auto" | "pin" | "all" | null | undefined = null) => m ?? "pin"),
 }));
 
 // Import app after all mocks are registered

--- a/packages/api/src/api/__tests__/chat.test.ts
+++ b/packages/api/src/api/__tests__/chat.test.ts
@@ -164,6 +164,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   resolveGroupForConnection: mock(() => Promise.resolve(null)),
   verifyGroupBelongsToOrg: mockVerifyGroupBelongsToOrg,
   updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
+  resolveRoutingMode: mock((m: "auto" | "pin" | "all" | null | undefined = null) => m ?? "pin"),
 }));
 
 const mockGetPluginTools: Mock<() => unknown> = mock(() => undefined);

--- a/packages/api/src/api/__tests__/conversations.test.ts
+++ b/packages/api/src/api/__tests__/conversations.test.ts
@@ -148,6 +148,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   // success — tests that exercise the picker write path override
   // locally.
   updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
+  resolveRoutingMode: mock((m: "auto" | "pin" | "all" | null | undefined = null) => m ?? "pin"),
   // Type exports (no runtime value — needed so mock.module doesn't break re-exports)
 }));
 

--- a/packages/api/src/api/__tests__/dashboards.test.ts
+++ b/packages/api/src/api/__tests__/dashboards.test.ts
@@ -298,6 +298,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   resolveGroupForConnection: mock(() => Promise.resolve(null)),
   verifyGroupBelongsToOrg: mockVerifyGroupBelongsToOrg,
   updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
+  resolveRoutingMode: mock((m: "auto" | "pin" | "all" | null | undefined = null) => m ?? "pin"),
 }));
 
 mock.module("@atlas/api/lib/semantic", () => ({

--- a/packages/api/src/api/__tests__/health-plugin.test.ts
+++ b/packages/api/src/api/__tests__/health-plugin.test.ts
@@ -130,6 +130,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   resolveGroupForConnection: mock(() => Promise.resolve(null)),
   verifyGroupBelongsToOrg: mock(() => Promise.resolve("ok")),
   updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
+  resolveRoutingMode: mock((m: "auto" | "pin" | "all" | null | undefined = null) => m ?? "pin"),
 }));
 
 mock.module("@atlas/api/lib/auth/middleware", () => ({

--- a/packages/api/src/api/__tests__/health.test.ts
+++ b/packages/api/src/api/__tests__/health.test.ts
@@ -135,6 +135,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   resolveGroupForConnection: mock(() => Promise.resolve(null)),
   verifyGroupBelongsToOrg: mock(() => Promise.resolve("ok")),
   updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
+  resolveRoutingMode: mock((m: "auto" | "pin" | "all" | null | undefined = null) => m ?? "pin"),
 }));
 
 mock.module("@atlas/api/lib/auth/middleware", () => ({

--- a/packages/api/src/api/__tests__/query.test.ts
+++ b/packages/api/src/api/__tests__/query.test.ts
@@ -159,6 +159,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   resolveGroupForConnection: mock(() => Promise.resolve(null)),
   verifyGroupBelongsToOrg: mock(() => Promise.resolve("ok")),
   updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
+  resolveRoutingMode: mock((m: "auto" | "pin" | "all" | null | undefined = null) => m ?? "pin"),
 }));
 
 // Import after mocks are registered

--- a/packages/api/src/api/__tests__/scheduled-tasks.test.ts
+++ b/packages/api/src/api/__tests__/scheduled-tasks.test.ts
@@ -121,6 +121,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   resolveGroupForConnection: mock(() => Promise.resolve(null)),
   verifyGroupBelongsToOrg: mock(() => Promise.resolve("ok")),
   updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
+  resolveRoutingMode: mock((m: "auto" | "pin" | "all" | null | undefined = null) => m ?? "pin"),
 }));
 
 mock.module("@atlas/api/lib/semantic", () => ({

--- a/packages/api/src/api/__tests__/semantic-overlay.test.ts
+++ b/packages/api/src/api/__tests__/semantic-overlay.test.ts
@@ -342,6 +342,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   resolveGroupForConnection: mock(() => Promise.resolve(null)),
   verifyGroupBelongsToOrg: mock(() => Promise.resolve("ok")),
   updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
+  resolveRoutingMode: mock((m: "auto" | "pin" | "all" | null | undefined = null) => m ?? "pin"),
 }));
 
 const { app } = await import("../index");

--- a/packages/api/src/api/__tests__/semantic.test.ts
+++ b/packages/api/src/api/__tests__/semantic.test.ts
@@ -269,6 +269,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   resolveGroupForConnection: mock(() => Promise.resolve(null)),
   verifyGroupBelongsToOrg: mock(() => Promise.resolve("ok")),
   updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
+  resolveRoutingMode: mock((m: "auto" | "pin" | "all" | null | undefined = null) => m ?? "pin"),
 }));
 
 // Import app after all mocks are registered

--- a/packages/api/src/api/__tests__/slack.test.ts
+++ b/packages/api/src/api/__tests__/slack.test.ts
@@ -207,6 +207,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   resolveGroupForConnection: mock(() => Promise.resolve(null)),
   verifyGroupBelongsToOrg: mock(() => Promise.resolve("ok")),
   updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
+  resolveRoutingMode: mock((m: "auto" | "pin" | "all" | null | undefined = null) => m ?? "pin"),
 }));
 
 const mockCheckRateLimit: Mock<(key: string) => { allowed: boolean; retryAfterMs?: number }> = mock(() =>

--- a/packages/api/src/api/routes/chat.ts
+++ b/packages/api/src/api/routes/chat.ts
@@ -42,6 +42,7 @@ import {
   resolveGroupForConnection,
   settleConversationSteps,
   updateConversationRoutingMode,
+  resolveRoutingMode,
 } from "@atlas/api/lib/conversations";
 import type { ConversationRoutingMode } from "@useatlas/types/conversation";
 import {
@@ -1154,7 +1155,7 @@ chat.openapi(chatRoute, async (c) => {
               // pre-#2518 chats. The tool's own default ('auto') only
               // kicks in for non-chat callers (MCP / scheduler / direct
               // tool tests).
-              routingMode: effectiveRoutingMode ?? "pin",
+              routingMode: resolveRoutingMode(effectiveRoutingMode),
             },
             () =>
               runAgent({

--- a/packages/api/src/lib/__tests__/agent-cross-env-routing.test.ts
+++ b/packages/api/src/lib/__tests__/agent-cross-env-routing.test.ts
@@ -138,6 +138,7 @@ mock.module("@atlas/api/lib/cache/index", () => ({
 // ---------------------------------------------------------------------------
 
 const { runAgent } = await import("@atlas/api/lib/agent");
+const { withRequestContext } = await import("@atlas/api/lib/logger");
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -451,4 +452,70 @@ describe("agent cross-env routing — executeSQL `scope`", () => {
     // Only the default connection's handler ran
     expect(memberCallCounts.get("default")).toBe(1);
   });
+
+  // -----------------------------------------------------------------------
+  // 5. All-failure fanout — every member errors, agent gets success: false
+  //    with a summary message that names every failed env.
+  // -----------------------------------------------------------------------
+
+  it("scope: 'all' with every member failing → success=false summary + envContributions error per env", async () => {
+    setMemberHandler("us-int", async () => {
+      throw new Error("pg: relation does not exist");
+    });
+    setMemberHandler("eu", async () => {
+      throw new Error("ECONNREFUSED");
+    });
+    setMemberHandler("apac", async () => {
+      throw new Error("timeout");
+    });
+
+    let streamIdx = 0;
+    mockModel = new MockLanguageModelV3({
+      doStream: async () => {
+        const allSteps: LanguageModelV3StreamPart[][] = [
+          makeToolStepChunks("executeSQL", {
+            sql: "SELECT region FROM orders",
+            explanation: "Compare across regions",
+            scope: "all",
+          }),
+          [
+            { type: "text-delta", id: "text-0", delta: "All envs failed." },
+            { type: "finish", usage: MOCK_USAGE, finishReason: { unified: "stop", raw: "end_turn" } },
+          ],
+        ];
+        if (streamIdx >= allSteps.length) {
+          return { stream: convertArrayToReadableStream(allSteps[allSteps.length - 1]) };
+        }
+        return { stream: convertArrayToReadableStream(allSteps[streamIdx++]) };
+      },
+    });
+
+    const result = await withRequestContext(
+      { requestId: "test-all-fail", connectionId: "us-int", connectionGroupId: "prod" },
+      () => runAgent({ messages: userMessages("Compare across regions") }),
+    );
+    const steps = await result.steps;
+    const sqlResults = findToolResults(steps, "executeSQL") as SQLOutput[];
+
+    expect(sqlResults).toHaveLength(1);
+    const first = sqlResults[0]!;
+    // The agent's recovery loop hinges on success=false for all-failure.
+    expect(first.success).toBe(false);
+    expect(first.error).toContain("All 3 environments failed");
+    expect(first.error).toContain("us-int");
+    expect(first.error).toContain("eu");
+    expect(first.error).toContain("apac");
+    // envContributions still describes each env so SDK consumers /
+    // downstream UI can render per-env error chips.
+    expect(first.envContributions).toHaveLength(3);
+    for (const contrib of first.envContributions ?? []) {
+      expect(contrib.error).not.toBeNull();
+      expect(contrib.rowCount).toBe(0);
+    }
+  });
+
+  // Unknown-member fallback is covered exhaustively in the pure-module
+  // unit tests (`env-routing/__tests__/index.test.ts` — "scope:
+  // '<unknown id>' → fall back to primary with warning"). The
+  // integration end-to-end here would duplicate that coverage.
 });

--- a/packages/api/src/lib/__tests__/agent-scope-prompt.test.ts
+++ b/packages/api/src/lib/__tests__/agent-scope-prompt.test.ts
@@ -208,6 +208,12 @@ describe("buildSystemParam — scope guidance section (slice 2)", () => {
     expect(prompt).toContain("scope: \"all\"");
     expect(prompt).toContain("scope: \"this\"");
     expect(prompt).toContain("Conservative-by-default");
+    // Three category headers must appear — guards against a future prompt
+    // trim silently dropping the comparative-intent heuristics that
+    // drive fanout decisions.
+    expect(prompt).toContain("Comparative intent");
+    expect(prompt).toContain("Single-environment cue");
+    expect(prompt).toContain("ambiguous");
   });
 
   it("omits the scope guidance section when routingContext is absent", () => {

--- a/packages/api/src/lib/auth/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/auth/__tests__/migrate.test.ts
@@ -327,6 +327,7 @@ describe("migrateAuthTables", () => {
             { name: "0079_dashboard_user_drafts.sql" },
             { name: "0080_proactive_public_dataset.sql" },
             { name: "0081_workspace_proactive_announcement_posted_at.sql" },
+            { name: "0082_audit_log_parent_audit_id_deferrable.sql" },
           ],
         };
       }

--- a/packages/api/src/lib/conversations.ts
+++ b/packages/api/src/lib/conversations.ts
@@ -97,6 +97,28 @@ export type CrudDataResult<T> = { ok: true; data: T } | { ok: false; reason: Cru
 // Helpers
 // ---------------------------------------------------------------------------
 
+/**
+ * Resolve a persisted `routing_mode` value into the runtime three-state
+ * union, applying the documented NULL → `"pin"` back-compat default.
+ *
+ * Centralises the default in one place — pre-fix, the chat route resolved
+ * NULL → "pin" while `tools/sql.ts` resolved missing-routingMode → "auto",
+ * which is a real correctness gap for any caller that didn't go through
+ * the chat route's stamping step (MCP, scheduler, unit tests).
+ *
+ * Web's `effectiveMode` helper in `chat/env-picker.tsx` must mirror this
+ * default — the picker UI converts NULL → "pin" for the trigger label
+ * and the mode-row highlight. Drift between them is a UX bug, not a
+ * correctness bug, so the duplication is acceptable until web can import
+ * api-internal helpers (which it deliberately cannot per CLAUDE.md
+ * "frontend is a pure HTTP client").
+ */
+export function resolveRoutingMode(
+  stored: import("@useatlas/types/conversation").ConversationRoutingMode | null | undefined,
+): import("@useatlas/types/conversation").ConversationRoutingMode {
+  return stored ?? "pin";
+}
+
 function rowToConversation(r: Record<string, unknown>): Conversation {
   return {
     id: r.id as string,

--- a/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
@@ -1521,6 +1521,70 @@ describeIfPg("migrate-pg (real Postgres)", () => {
     expect(rows[0]?.routing_mode).toBeNull();
   }, PG_TEST_TIMEOUT_MS);
 
+  it("audit_log.parent_audit_id: column exists, is nullable uuid, and FK is DEFERRABLE INITIALLY DEFERRED", async () => {
+    // Slice 4 (#2519) acceptance criterion: parent_audit_id column +
+    // self-FK to audit_log(id). Slice's follow-up (this PR) makes the FK
+    // DEFERRABLE INITIALLY DEFERRED so the fanout's fire-and-forget
+    // parent + child INSERTs can race without 23503 violations.
+    const { rows: colRows } = await pool.query<{ data_type: string; is_nullable: string }>(
+      `SELECT data_type, is_nullable FROM information_schema.columns
+        WHERE table_name = 'audit_log' AND column_name = 'parent_audit_id'`,
+    );
+    expect(colRows[0]?.data_type).toBe("uuid");
+    expect(colRows[0]?.is_nullable).toBe("YES");
+
+    // Partial index for fanout-only lookups exists.
+    const { rows: idxRows } = await pool.query<{ indexname: string }>(
+      `SELECT indexname FROM pg_indexes
+        WHERE tablename = 'audit_log' AND indexname = 'idx_audit_log_parent_audit_id'`,
+    );
+    expect(idxRows.length).toBe(1);
+
+    // FK is deferrable. `pg_constraint.condeferrable` is true for
+    // DEFERRABLE constraints; `condeferred` is true for INITIALLY
+    // DEFERRED. Both must hold for the fanout's race-free linkage to
+    // work without explicit `SET CONSTRAINTS ALL DEFERRED`.
+    const { rows: fkRows } = await pool.query<{ condeferrable: boolean; condeferred: boolean }>(
+      `SELECT condeferrable, condeferred FROM pg_constraint
+        WHERE conname = 'audit_log_parent_audit_id_fkey'`,
+    );
+    expect(fkRows[0]?.condeferrable).toBe(true);
+    expect(fkRows[0]?.condeferred).toBe(true);
+  }, PG_TEST_TIMEOUT_MS);
+
+  it("audit_log.parent_audit_id: child INSERT BEFORE parent INSERT in same transaction succeeds (deferrability proof)", async () => {
+    // Pre-DEFERRABLE behaviour: this race produced 23503. After 0079 the
+    // FK only checks at COMMIT, so the ordering invariant the fanout's
+    // fire-and-forget audit writers depend on is structurally enforced.
+    const parentId = "00000000-0000-0000-0000-000000000099";
+    const childId = "00000000-0000-0000-0000-000000000098";
+    await pool.query("BEGIN");
+    try {
+      // Child first — would fail with 23503 if FK were immediate.
+      await pool.query(
+        `INSERT INTO audit_log (id, sql, duration_ms, success, auth_mode, parent_audit_id)
+          VALUES ($1, 'SELECT 1', 0, true, 'none', $2)`,
+        [childId, parentId],
+      );
+      // Parent after child.
+      await pool.query(
+        `INSERT INTO audit_log (id, sql, duration_ms, success, auth_mode)
+          VALUES ($1, 'parent', 0, true, 'none')`,
+        [parentId],
+      );
+      await pool.query("COMMIT");
+    } catch (err) {
+      await pool.query("ROLLBACK");
+      throw err;
+    }
+    const { rows } = await pool.query<{ id: string; parent_audit_id: string | null }>(
+      `SELECT id, parent_audit_id FROM audit_log WHERE id IN ($1, $2) ORDER BY id`,
+      [parentId, childId],
+    );
+    expect(rows).toHaveLength(2);
+    expect(rows.find((r) => r.id === childId)?.parent_audit_id).toBe(parentId);
+  }, PG_TEST_TIMEOUT_MS);
+
   it("conversations: connection_id and connection_group_id can hold independent values (per-turn override shape)", async () => {
     // The slice's core invariant: a conversation can pin its content
     // scope to a multi-member "prod" group while its execution target

--- a/packages/api/src/lib/db/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate.test.ts
@@ -93,8 +93,9 @@ describe("runMigrations", () => {
     // + 0078 (proactive_meter_events, #2296)
     // + 0079 (dashboard_user_drafts, #2364)
     // + 0080 (proactive_public_dataset + public_refused meter, #2297)
-    // + 0081 (workspace_proactive_config.announcement_posted_at, #2300) = 82.
-    expect(count).toBe(82);
+    // + 0081 (workspace_proactive_config.announcement_posted_at, #2300)
+    // + 0082 (audit_log.parent_audit_id FK → DEFERRABLE) = 83.
+    expect(count).toBe(83);
 
     // Advisory lock acquired before anything else
     expect(queries[0]).toContain("pg_advisory_lock");
@@ -205,6 +206,7 @@ describe("runMigrations", () => {
         "0079_dashboard_user_drafts.sql",
         "0080_proactive_public_dataset.sql",
         "0081_workspace_proactive_announcement_posted_at.sql",
+        "0082_audit_log_parent_audit_id_deferrable.sql",
       ],
     });
 

--- a/packages/api/src/lib/db/migrations/0082_audit_log_parent_audit_id_deferrable.sql
+++ b/packages/api/src/lib/db/migrations/0082_audit_log_parent_audit_id_deferrable.sql
@@ -1,0 +1,19 @@
+-- Make `audit_log.parent_audit_id` FK DEFERRABLE INITIALLY DEFERRED so the
+-- cross-env fanout's fire-and-forget parent + child INSERTs can land in any
+-- order within a transaction without `23503 foreign_key_violation`. Migration
+-- 0074 declared the FK as immediate; under load the child INSERTs can reach
+-- PG before the parent commits and get silently dropped by
+-- `internalExecute`'s fire-and-forget error path.
+--
+-- Postgres allows altering a constraint's deferrability without rewriting the
+-- table when the constraint is already in the `not valid` or `validated`
+-- state. The ALTER takes an ACCESS EXCLUSIVE briefly but does not scan rows.
+ALTER TABLE audit_log
+  DROP CONSTRAINT IF EXISTS audit_log_parent_audit_id_fkey;
+
+ALTER TABLE audit_log
+  ADD CONSTRAINT audit_log_parent_audit_id_fkey
+  FOREIGN KEY (parent_audit_id)
+  REFERENCES audit_log(id)
+  ON DELETE SET NULL
+  DEFERRABLE INITIALLY DEFERRED;

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -82,6 +82,11 @@ export const auditLog = pgTable(
       .where(sql`actor_kind IS NOT NULL`),
     index("idx_audit_log_client_id").on(t.clientId).where(sql`client_id IS NOT NULL`),
     index("idx_audit_log_parent_audit_id").on(t.parentAuditId).where(sql`parent_audit_id IS NOT NULL`),
+    // Migration 0079 makes this FK DEFERRABLE INITIALLY DEFERRED so the
+    // fanout's fire-and-forget parent + child INSERTs can race without
+    // 23503 violations. drizzle-orm does not expose deferrability as a
+    // first-class option; the deferrability is declared in the SQL
+    // migration and verified by `migrate-pg.test.ts`.
     foreignKey({
       columns: [t.parentAuditId],
       foreignColumns: [t.id],

--- a/packages/api/src/lib/env-routing/__tests__/lookup.test.ts
+++ b/packages/api/src/lib/env-routing/__tests__/lookup.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Unit tests for the impure `loadGroupRoutingContext` helper. The pure
+ * `resolveRoutingPlan` module is covered exhaustively in `./index.test.ts`;
+ * this file pins the lookup's failure-mode → 1×1-fallback semantics so
+ * the routing module never sees an inconsistent input.
+ *
+ * `internalQuery` and `hasInternalDB` are mocked so the test exercises
+ * the helper's branching without spinning up a real internal Postgres.
+ */
+
+import { describe, it, expect, beforeEach, mock } from "bun:test";
+
+// Per-test mock state for the internal-DB module.
+let mockHasInternalDB = true;
+let mockConnRows: { group_id: string | null }[] = [];
+let mockMemberRows: { id: string }[] = [];
+let mockGroupRows: { primary_connection_id: string | null }[] = [];
+let mockShouldThrow: Error | null = null;
+let mockQueryCalls: { sql: string; params: unknown[] | undefined }[] = [];
+
+mock.module("@atlas/api/lib/db/internal", () => ({
+  hasInternalDB: () => mockHasInternalDB,
+  internalQuery: async (sql: string, params?: unknown[]) => {
+    mockQueryCalls.push({ sql, params });
+    if (mockShouldThrow) throw mockShouldThrow;
+    // Step 1 fetches `group_id` from `connections`.
+    if (sql.includes("FROM connections") && sql.includes("group_id") && !sql.includes("WHERE group_id")) {
+      return mockConnRows;
+    }
+    // Step 2a fetches member ids.
+    if (sql.includes("FROM connections") && sql.includes("WHERE group_id")) {
+      return mockMemberRows;
+    }
+    // Step 2b fetches the group's primary.
+    if (sql.includes("FROM connection_groups")) {
+      return mockGroupRows;
+    }
+    return [];
+  },
+}));
+
+const { loadGroupRoutingContext } = await import("../lookup");
+
+describe("loadGroupRoutingContext — 1×1 fallback paths", () => {
+  beforeEach(() => {
+    mockHasInternalDB = true;
+    mockConnRows = [];
+    mockMemberRows = [];
+    mockGroupRows = [];
+    mockShouldThrow = null;
+    mockQueryCalls = [];
+  });
+
+  it("missing orgId → 1×1 fallback, no DB queries", async () => {
+    const ctx = await loadGroupRoutingContext(undefined, "conn-a");
+    expect(ctx).toEqual({
+      members: ["conn-a"],
+      primaryMember: "conn-a",
+      currentMember: "conn-a",
+    });
+    expect(mockQueryCalls).toHaveLength(0);
+  });
+
+  it("internal DB not configured → 1×1 fallback, no DB queries", async () => {
+    mockHasInternalDB = false;
+    const ctx = await loadGroupRoutingContext("org-1", "conn-a");
+    expect(ctx).toEqual({
+      members: ["conn-a"],
+      primaryMember: "conn-a",
+      currentMember: "conn-a",
+    });
+    expect(mockQueryCalls).toHaveLength(0);
+  });
+
+  it("connection ungrouped (group_id IS NULL) → 1×1 fallback + warn log", async () => {
+    mockConnRows = [{ group_id: null }];
+    const ctx = await loadGroupRoutingContext("org-1", "conn-a");
+    expect(ctx).toEqual({
+      members: ["conn-a"],
+      primaryMember: "conn-a",
+      currentMember: "conn-a",
+    });
+    // The step-1 connection lookup ran but the step-2 queries didn't.
+    expect(mockQueryCalls).toHaveLength(1);
+  });
+
+  it("connection not found (zero rows) → 1×1 fallback + suspect-grade warn", async () => {
+    mockConnRows = [];
+    const ctx = await loadGroupRoutingContext("org-1", "conn-archived");
+    expect(ctx).toEqual({
+      members: ["conn-archived"],
+      primaryMember: "conn-archived",
+      currentMember: "conn-archived",
+    });
+    expect(mockQueryCalls).toHaveLength(1);
+  });
+
+  it("internalQuery throws → 1×1 fallback (catch-and-warn)", async () => {
+    mockShouldThrow = new Error("internal DB unreachable");
+    const ctx = await loadGroupRoutingContext("org-1", "conn-a");
+    expect(ctx.members).toEqual(["conn-a"]);
+    expect(ctx.primaryMember).toBe("conn-a");
+  });
+});
+
+describe("loadGroupRoutingContext — multi-member resolution", () => {
+  beforeEach(() => {
+    mockHasInternalDB = true;
+    mockConnRows = [];
+    mockMemberRows = [];
+    mockGroupRows = [];
+    mockShouldThrow = null;
+    mockQueryCalls = [];
+  });
+
+  it("3-member group with explicit primary → returns all 3 + named primary", async () => {
+    mockConnRows = [{ group_id: "g-prod" }];
+    mockMemberRows = [{ id: "apac" }, { id: "eu" }, { id: "us-int" }];
+    mockGroupRows = [{ primary_connection_id: "us-int" }];
+    const ctx = await loadGroupRoutingContext("org-1", "eu");
+    expect(ctx.groupId).toBe("g-prod");
+    expect(ctx.members).toEqual(["apac", "eu", "us-int"]);
+    expect(ctx.primaryMember).toBe("us-int");
+    expect(ctx.currentMember).toBe("eu");
+  });
+
+  it("primary_connection_id NOT in members (stale FK) → first member becomes primary", async () => {
+    mockConnRows = [{ group_id: "g-prod" }];
+    mockMemberRows = [{ id: "apac" }, { id: "eu" }];
+    mockGroupRows = [{ primary_connection_id: "us-int" }]; // not in members
+    const ctx = await loadGroupRoutingContext("org-1", "eu");
+    expect(ctx.primaryMember).toBe("apac"); // first member
+  });
+
+  it("group row missing (race with delete) → first member becomes primary", async () => {
+    mockConnRows = [{ group_id: "g-prod" }];
+    mockMemberRows = [{ id: "us-int" }, { id: "eu" }];
+    mockGroupRows = []; // connection_groups deleted before lookup completed
+    const ctx = await loadGroupRoutingContext("org-1", "eu");
+    expect(ctx.members).toEqual(["us-int", "eu"]);
+    expect(ctx.primaryMember).toBe("us-int");
+  });
+
+  it("step-2 returns empty members (paranoid) → fallback to currentConnectionId", async () => {
+    mockConnRows = [{ group_id: "g-prod" }];
+    mockMemberRows = []; // empty even though step 1 said grouped
+    mockGroupRows = [{ primary_connection_id: "us-int" }];
+    const ctx = await loadGroupRoutingContext("org-1", "eu");
+    expect(ctx.members).toEqual(["eu"]);
+    expect(ctx.primaryMember).toBe("eu"); // primaryFromGroup not in [], falls to currentMember
+  });
+});

--- a/packages/api/src/lib/env-routing/lookup.ts
+++ b/packages/api/src/lib/env-routing/lookup.ts
@@ -65,6 +65,17 @@ export async function loadGroupRoutingContext(
     );
     const groupId = connRows[0]?.group_id ?? null;
     if (!groupId) {
+      // Distinguish "connection ungrouped" (expected for legacy 1×1
+      // installs) from "connection not found / archived" (suspect — the
+      // agent rendered a multi-member prompt but the runtime sees no
+      // matching row, so the agent's `scope: "all"` is silently
+      // downgraded to single-env). Log loudly per CLAUDE.md "Never
+      // silently swallow errors".
+      const reason = connRows.length === 0 ? "connection-not-found" : "connection-ungrouped";
+      log.warn(
+        { orgId, currentConnectionId, reason },
+        "Group routing context degraded to 1×1 — agent's scope hint may be silently downgraded",
+      );
       return fallback;
     }
 

--- a/packages/api/src/lib/tools/__tests__/action-permissions.test.ts
+++ b/packages/api/src/lib/tools/__tests__/action-permissions.test.ts
@@ -142,6 +142,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   resolveGroupForConnection: mock(() => Promise.resolve(null)),
   verifyGroupBelongsToOrg: mock(() => Promise.resolve("ok")),
   updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
+  resolveRoutingMode: mock((m: "auto" | "pin" | "all" | null | undefined = null) => m ?? "pin"),
 }));
 
 mock.module("@atlas/api/lib/semantic", () => ({

--- a/packages/api/src/lib/tools/sql.ts
+++ b/packages/api/src/lib/tools/sql.ts
@@ -36,7 +36,7 @@ import {
   RLSError, PluginRejectedError,
 } from "@atlas/api/lib/effect/errors";
 import { EXECUTE_SQL_TOOL_DESCRIPTION } from "./descriptions";
-import { resolveRoutingPlan } from "@atlas/api/lib/env-routing";
+import { resolveRoutingPlan, type RoutingMode, type RoutingReason } from "@atlas/api/lib/env-routing";
 import { loadGroupRoutingContext } from "@atlas/api/lib/env-routing/lookup";
 import { mergeMemberResults } from "@atlas/api/lib/multi-env-merger";
 
@@ -757,11 +757,7 @@ function applyRLSEffect(
 }
 
 /**
- * Execute a validated query with tracing, cache write, audit logging, plugin hooks,
- * and error filtering. Called inside withSourceSlot — concurrency release is automatic.
- */
-/**
- * Build the OTel attribute set for the `atlas.sql.execute` span (#2519).
+ * Build the OTel attribute set for the `atlas.sql.execute` span.
  *
  * Exported for unit testing: capturing live spans requires wiring an
  * `InMemorySpanExporter` into the global tracer provider, which is
@@ -774,15 +770,20 @@ function applyRLSEffect(
  *   - `atlas.connection_id` — which member ran the query.
  *   - `atlas.routing_mode` — `auto` | `pin` | `all` (defaults to `auto`).
  *
- * Conditionally emits `atlas.connection_group_id` when the caller passed
- * one (typically the fanout path, where the group lookup already
- * resolved the id).
+ * Conditionally emits:
+ *   - `atlas.connection_group_id` when the caller passed one (typically
+ *     the fanout path, where the group lookup already resolved the id).
+ *   - `atlas.routing_reason` when the caller threaded the planner's
+ *     `RoutingReason` discriminator (single-env back-compat callers
+ *     don't have one). Lets observers attribute fanout vs single-env
+ *     decisions without joining audit rows.
  */
 export function buildSqlExecuteSpanAttrs(opts: {
   dbType: string;
   connectionId: string;
-  routingMode?: "auto" | "pin" | "all";
+  routingMode?: RoutingMode;
   connectionGroupId?: string;
+  routingReason?: RoutingReason;
 }): Record<string, string | number | boolean> {
   const attrs: Record<string, string | number | boolean> = {
     "db.system": opts.dbType,
@@ -791,6 +792,9 @@ export function buildSqlExecuteSpanAttrs(opts: {
   };
   if (opts.connectionGroupId) {
     attrs["atlas.connection_group_id"] = opts.connectionGroupId;
+  }
+  if (opts.routingReason) {
+    attrs["atlas.routing_reason"] = opts.routingReason;
   }
   return attrs;
 }
@@ -809,17 +813,19 @@ function executeAndAuditEffect(opts: {
   cacheKey: string | null;
   hookMetadata: Record<string, unknown>;
   dispatchHook: (event: "afterQuery", ctx: Record<string, unknown>) => Promise<void>;
-  /** Parent audit row id when this execution is one leg of a fanout (#2519). */
+  /** Parent audit row id when this execution is one leg of a fanout. */
   parentAuditId?: string;
-  /** Routing mode for the parent `executeSQL` call ("auto" | "pin" | "all"). Stamped on the OTel span (#2519). */
-  routingMode?: "auto" | "pin" | "all";
-  /** Connection group id (for the OTel `atlas.connection_group_id` attribute, #2519). */
+  /** Routing mode for the parent `executeSQL` call. Stamped on the OTel span. */
+  routingMode?: RoutingMode;
+  /** Connection group id (for the OTel `atlas.connection_group_id` attribute). */
   connectionGroupId?: string;
+  /** Planner reason that picked this connection (for the OTel `atlas.routing_reason` attribute). */
+  routingReason?: RoutingReason;
 }): Effect.Effect<Record<string, unknown>, QueryExecutionError> {
   const {
     db, dbType, connId, orgId, targetHost, querySql, queryTimeout,
     rowLimit, explanation, classification, cacheKey, hookMetadata, dispatchHook,
-    parentAuditId, routingMode, connectionGroupId,
+    parentAuditId, routingMode, connectionGroupId, routingReason,
   } = opts;
 
   const start = performance.now();
@@ -832,6 +838,7 @@ function executeAndAuditEffect(opts: {
     connectionId: connId,
     routingMode,
     connectionGroupId,
+    routingReason,
   });
 
   return Effect.tryPromise({
@@ -871,7 +878,10 @@ function executeAndAuditEffect(opts: {
           parentAuditId,
         });
       } catch (auditErr) {
-        log.warn({ err: auditErr }, "Failed to write query audit log");
+        log.warn(
+          { err: auditErr instanceof Error ? auditErr.message : String(auditErr) },
+          "Failed to write query audit log",
+        );
       }
 
       // Filter sensitive errors before returning to the agent
@@ -931,7 +941,10 @@ function executeAndAuditEffect(opts: {
               parentAuditId,
             });
           } catch (auditErr) {
-            log.warn({ err: auditErr }, "Failed to write query audit log");
+            log.warn(
+              { err: auditErr instanceof Error ? auditErr.message : String(auditErr) },
+              "Failed to write query audit log",
+            );
           }
 
           try {
@@ -1346,22 +1359,30 @@ async function executeSqlForConnection({
   connId,
   parentAuditId,
   routingMode,
+  routingReason,
 }: {
   readonly sql: string;
   readonly explanation: string;
   readonly connId: string;
   /**
    * Parent audit row id when this execution is one leg of a cross-environment
-   * fanout (#2519). Threaded through every `logQueryAudit` call below so each
-   * audit row carries the linkage. Undefined for single-env executions.
+   * fanout. Threaded through every `logQueryAudit` call below so each audit
+   * row carries the linkage. Undefined for single-env executions.
    */
   readonly parentAuditId?: string;
   /**
-   * Routing mode for the parent `executeSQL` call ("auto" | "pin" | "all").
-   * Stamped on the OTel span so traces can attribute fanout behavior
-   * without joining audit rows. Defaults to "auto" when not threaded.
+   * Routing mode for the parent `executeSQL` call. Stamped on the OTel
+   * span so traces can attribute fanout behavior without joining audit
+   * rows. Defaults to "auto" when not threaded.
    */
-  readonly routingMode?: "auto" | "pin" | "all";
+  readonly routingMode?: RoutingMode;
+  /**
+   * Planner reason that picked this connection (e.g. `agent-all`,
+   * `picker-pin`, `1x1-group`). Stamped on the OTel span as
+   * `atlas.routing_reason` so observers can distinguish fanout-by-agent
+   * from fanout-by-picker without joining audit rows.
+   */
+  readonly routingReason?: RoutingReason;
 }): Promise<Record<string, unknown>> {
     // The full pipeline runs as an Effect.gen program. Tagged errors flow through
     // the error channel; expected rejections (validation, approval, cache) return
@@ -1654,7 +1675,7 @@ async function executeSqlForConnection({
           return yield* executeAndAuditEffect({
             db, dbType, connId, orgId, targetHost, querySql, queryTimeout,
             rowLimit, explanation, classification, cacheKey: cacheKey ?? null,
-            hookMetadata, dispatchHook, parentAuditId, routingMode,
+            hookMetadata, dispatchHook, parentAuditId, routingMode, routingReason,
           });
         }),
       ).pipe(
@@ -1705,9 +1726,16 @@ async function executeSqlFanout(args: {
   readonly sql: string;
   readonly explanation: string;
   readonly connectionIds: readonly string[];
-  readonly connectionGroupId?: string;
+  /**
+   * Planner reason that picked this fanout (one of `agent-all` /
+   * `picker-all`). Threaded into each leg's OTel span as
+   * `atlas.routing_reason` so observers can distinguish "agent decided
+   * to fan out" from "user forced fanout via picker" without joining
+   * audit rows.
+   */
+  readonly fanoutReason: RoutingReason;
 }): Promise<Record<string, unknown>> {
-  const { sql, explanation, connectionIds, connectionGroupId } = args;
+  const { sql, explanation, connectionIds, fanoutReason } = args;
 
   // Write the parent audit row up front so each leg's audit insert can
   // reference it. The parent carries no per-environment metadata
@@ -1721,16 +1749,25 @@ async function executeSqlFanout(args: {
   // column default so the value is in scope locally for the children.
   const parentAuditId = crypto.randomUUID();
   try {
+    // `source_id` is intentionally omitted on the parent row: every other
+    // audit_log row stamps source_id with a connection id, so overloading
+    // it with a connection_group_id would silently drop the parent from
+    // forensic queries that JOIN against `connections.id` or filter by
+    // `source_id IN (<connection ids>)`. The children carry the real
+    // connection ids; the group dimension is recoverable by JOINing
+    // children's `source_id` back to `connections.group_id`.
     logQueryAudit({
       id: parentAuditId,
       sql: sql.slice(0, 2000),
       durationMs: 0,
       rowCount: connectionIds.length,
       success: true,
-      sourceId: connectionGroupId,
     });
   } catch (auditErr) {
-    log.warn({ err: auditErr }, "Failed to write fanout parent audit row");
+    log.warn(
+      { err: auditErr instanceof Error ? auditErr.message : String(auditErr) },
+      "Failed to write fanout parent audit row",
+    );
   }
 
   const startTimes = new Map<string, number>();
@@ -1743,6 +1780,7 @@ async function executeSqlFanout(args: {
         connId,
         parentAuditId,
         routingMode: "all",
+        routingReason: fanoutReason,
       });
     }),
   );
@@ -1776,8 +1814,9 @@ async function executeSqlFanout(args: {
   });
 
   const merged = mergeMemberResults(memberResults);
-  const failedCount = merged.envContributions.filter((c: { error: string | null }) => c.error !== null).length;
-  const successCount = merged.envContributions.length - failedCount;
+  const successCount = merged.envContributions.filter(
+    (c: { error: string | null }) => c.error === null,
+  ).length;
   const totalExecutionMs = merged.envContributions.reduce(
     (acc: number, c: { durationMs: number }) => Math.max(acc, c.durationMs),
     0,
@@ -1901,6 +1940,7 @@ export const executeSQL = tool({
         explanation,
         connId: plan.connectionId,
         routingMode,
+        routingReason: plan.reason,
       });
       return attachSingleEnvContribution(result, plan.connectionId);
     }
@@ -1908,16 +1948,24 @@ export const executeSQL = tool({
       sql,
       explanation,
       connectionIds: plan.connectionIds,
-      connectionGroupId: ctx.groupId,
+      fanoutReason: plan.reason,
     });
   },
 });
 
 /**
  * Wrap a single-env executeSQL result with a 1-element `envContributions`
- * array so SDK consumers see the same wire shape for both single and
- * fanout responses (#2519). Mutates a copy of the input; never overwrites
- * a contribution the leaf may have already provided.
+ * array so SDK consumers see the same wire shape for single and fanout
+ * responses — they branch on length, not presence.
+ *
+ * Pure — returns a new object via spread; the input is not mutated.
+ * Never overwrites a contribution the leaf may have already provided.
+ *
+ * Failure-shape coercion: when the leaf returned `success: false` and
+ * its `error` field is not a string (e.g. a future code path that uses
+ * `message` instead of `error`), we surface a sentinel rather than
+ * letting the contribution claim `error: null`, which would falsely
+ * present the failed execution as a success row to SDK consumers.
  */
 function attachSingleEnvContribution(
   result: Record<string, unknown>,
@@ -1934,9 +1982,12 @@ function attachSingleEnvContribution(
   const durationMs = typeof result["executionMs"] === "number"
     ? (result["executionMs"] as number)
     : 0;
-  const error = result["success"] === false && typeof result["error"] === "string"
-    ? (result["error"] as string)
-    : null;
+  let error: string | null = null;
+  if (result["success"] === false) {
+    error = typeof result["error"] === "string"
+      ? (result["error"] as string)
+      : "Execution failed (no error message available)";
+  }
   return {
     ...result,
     envContributions: [{ connectionId, rowCount, error, durationMs }],

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -60,3 +60,18 @@ export type {
   StarterPromptsResponse,
   FavoriteStarterPrompt,
 } from "@useatlas/types/starter-prompt";
+
+// Cross-environment routing wire types — re-exported from @useatlas/types
+// so embedders writing a custom `executeSQL` tool renderer can read
+// `envContributions[]` (per-env row count + error + durationMs) from
+// both single-env and fanout responses with the same wire shape.
+export type {
+  ConnectionContribution,
+  ExecuteSqlResult,
+  ExecuteSqlSuccessResult,
+  ExecuteSqlFailureResult,
+} from "@useatlas/types/execute-sql";
+
+// Conversation routing-mode wire type so embedders can render the
+// three-state Auto/Pin/All picker against the persisted column.
+export type { ConversationRoutingMode } from "@useatlas/types/conversation";

--- a/packages/react/src/lib/tool-renderer-types.ts
+++ b/packages/react/src/lib/tool-renderer-types.ts
@@ -1,4 +1,5 @@
 import type { ComponentType } from "react";
+import type { ConnectionContribution } from "@useatlas/types/execute-sql";
 
 /** Props passed to custom tool renderers. */
 export interface ToolRendererProps<T = unknown> {
@@ -16,7 +17,12 @@ export interface ToolRendererProps<T = unknown> {
 /*  Known tool result types                                            */
 /* ------------------------------------------------------------------ */
 
-/** Result shape from the executeSQL tool. Subset covering fields most useful for rendering. */
+/**
+ * Result shape from the executeSQL tool. Subset covering fields most
+ * useful for rendering, including `envContributions` (single-env
+ * executions emit a 1-element array; fanout emits N) so a custom
+ * renderer can show per-env row counts + errors uniformly.
+ */
 export type SQLToolResult =
   | {
       success: true;
@@ -25,10 +31,12 @@ export type SQLToolResult =
       truncated?: boolean;
       explanation?: string;
       row_count?: number;
+      envContributions?: readonly ConnectionContribution[];
     }
   | {
       success: false;
       error: string;
+      envContributions?: readonly ConnectionContribution[];
     };
 
 /** Result shape from the explore tool (semantic layer exploration output). */


### PR DESCRIPTION
## Summary

Single follow-up PR addressing every actionable finding from the multi-agent PR review on milestone 1.4.5 (PRs #2522 / #2524 / #2527 / #2532 / #2535). All five slices already shipped; this PR closes the gaps surfaced during review so they don't carry into 1.4.6.

## Critical (3)

- **Audit FK race** — migration 0079 makes `audit_log.parent_audit_id_fkey` `DEFERRABLE INITIALLY DEFERRED`. Without this the fanout's fire-and-forget parent + child INSERTs race on independent pool connections; a child reaching PG before the parent commits gets `23503` and is silently dropped by `internalExecute`'s error path. Two new `migrate-pg.test.ts` smoke tests pin the deferrability via `pg_constraint.condeferrable` and prove the child-before-parent ordering succeeds inside a transaction.
- **Parent audit `source_id` overload** — fanout parent rows now omit `source_id` instead of stamping it with a `connection_group_id`. Forensic queries that filter or JOIN on `source_id` no longer see a dangling reference; per-env data is still attributable via the children.
- **`packages/react` missing wire types** — re-exports `ConnectionContribution`, `ExecuteSqlResult`, `ConversationRoutingMode`; `SQLToolResult` widened to include `envContributions`. Embedders writing custom executeSQL renderers can now read per-env metadata with the canonical type.

## Important (5)

- **`RoutingReason` → OTel** — threaded `plan.reason` through to `buildSqlExecuteSpanAttrs` as a new `atlas.routing_reason` span attribute. The win-prose claimed this; the wiring now matches.
- **`resolveRoutingMode()` resolver** — one helper in `packages/api/src/lib/conversations.ts` centralises the NULL→`"pin"` default. The chat-route's "pin" default and the non-chat tool's "auto" default are now explicit and documented.
- **`loadGroupRoutingContext` no longer silently degrades** — structured warn log distinguishing `connection-not-found` (suspect) from `connection-ungrouped` (legacy). 9 new dedicated unit tests in `env-routing/__tests__/lookup.test.ts` covering every fallback path.
- **PG smoke for `parent_audit_id`** — asserts column shape, partial index existence, and FK deferrability.
- **All-failure fanout integration test** — every member errors → `success: false` summary message includes every failed env id. The agent's recovery loop depends on this exact shape.

## Minor cleanups

- Orphan JSDoc above `buildSqlExecuteSpanAttrs` deleted.
- `attachSingleEnvContribution` JSDoc corrected (was claiming "Mutates a copy" of a function that returns a new object via spread) + sentinel error so a leaf returning `success: false` with no string `error` doesn't render as a success row.
- `RoutingMode` literal `"auto" | "pin" | "all"` deduplicated across `tools/sql.ts` — every site imports the canonical type from `@atlas/api/lib/env-routing`.
- Unused `failedCount` variable + unused `connectionGroupId` arg removed from `executeSqlFanout`.
- `log.warn({ err: <unknown> }, ...)` audit-log sites in `executeAndAuditEffect` type-narrow per CLAUDE.md.
- 3 new substring assertions on `agent-scope-prompt.test.ts` guard `Comparative intent` / `Single-environment cue` / `ambiguous` category headers against future prompt trims.
- `multi-env-routing-mode-picker.spec.ts` re-tagged from `@llm` to default (the spec sends no chat messages — wrongly excluded from default CI).
- `multi-env-routing-happy.spec.ts` Pin assertion anchors on the response table rendering, not a 20s sleep that could pass vacuously against slow providers.
- `multi-env-routing-partial-failure.spec.ts` only snapshots the URL after corruption-PATCH succeeds; non-200 restore logs `MANUAL CLEANUP REQUIRED`.
- Architecture-wins #61/#62 corrected: removed wrong line counts, fixed `the prompt prompt` typo, updated win #61's "reason discriminator is the audit attribute" prose now that the wiring exists.

## Deferred (intentional, not gaps)

- **Aggregate fanout timeout** — PRD #2515 explicitly defers this to v2.
- **New-conversation Auto-mode persistence** — needs a careful picker-state-machine audit; cross-cutting change, out of scope for a review cleanup PR.
- **`updateConversationRoutingMode` SSE feedback** — adds new wire frames.
- **`MemberExecutionResult` discriminator refactor** — touches merger + fanout + every test fixture; dedicated typing PR.
- **`AgentScope` brand drop + issue-ref scrub** — cosmetic; large surface, low signal.

## Test plan

- [x] `bun run lint` (pre-existing unrelated warning only)
- [x] `bun run type` — zero errors
- [x] `bun run scripts/test-isolated.ts --since main` — 128/128 affected pass
- [x] `bash scripts/check-schema-drift.sh` — passes (migration 0079 + matching schema.ts comment)
- [x] `bash scripts/check-template-drift.sh` — passes
- [x] `bash scripts/check-railway-watch.sh` — passes
- [x] `bash scripts/check-oauth-helper-drift.sh` — passes
- [x] `bun x syncpack lint` — no issues