### PR TITLE
feat(types): add proactive chat shared shapes (0.1.3)

### DIFF
--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@useatlas/types",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Shared types for the Atlas text-to-SQL agent",
   "type": "module",
   "scripts": {
-    "build": "rm -rf dist && bun build src/index.ts src/auth.ts src/conversation.ts src/connection.ts src/action.ts src/scheduled-task.ts src/errors.ts src/semantic.ts src/share.ts src/billing.ts src/dashboard.ts src/mode.ts src/starter-prompt.ts src/integrations.ts src/email-provider.ts src/mcp.ts src/preferences.ts src/execute-sql.ts --outdir dist --root src --target node --packages external && bun x tsc -p tsconfig.build.json",
+    "build": "rm -rf dist && bun build src/index.ts src/auth.ts src/conversation.ts src/connection.ts src/action.ts src/scheduled-task.ts src/errors.ts src/semantic.ts src/share.ts src/billing.ts src/dashboard.ts src/mode.ts src/starter-prompt.ts src/integrations.ts src/email-provider.ts src/mcp.ts src/preferences.ts src/execute-sql.ts src/proactive.ts --outdir dist --root src --target node --packages external && bun x tsc -p tsconfig.build.json",
     "prepare": "bun run build"
   },
   "exports": {
@@ -97,6 +97,11 @@
       "types": "./dist/execute-sql.d.ts",
       "import": "./dist/execute-sql.js",
       "default": "./dist/execute-sql.js"
+    },
+    "./proactive": {
+      "types": "./dist/proactive.d.ts",
+      "import": "./dist/proactive.js",
+      "default": "./dist/proactive.js"
     }
   },
   "main": "./dist/index.js",

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -36,3 +36,4 @@ export * from "./mcp";
 export * from "./security";
 export * from "./preferences";
 export * from "./execute-sql";
+export * from "./proactive";

--- a/packages/types/src/proactive.ts
+++ b/packages/types/src/proactive.ts
@@ -1,0 +1,214 @@
+/**
+ * Shared wire types for the proactive chat layer (PRD #2291, 1.5.0).
+ *
+ * Before this module, `plugins/chat/src/proactive/types.ts` and
+ * `packages/api/src/lib/proactive/*` declared structurally-identical
+ * mirror types ("shape-by-shape — declared here so the plugin doesn't
+ * import `@atlas/api`"). Those mirrors are the exact drift CLAUDE.md
+ * "shared types live in `@useatlas/types`" was written to prevent —
+ * any change to one side that misses the other silently breaks the
+ * wire.
+ *
+ * This module hosts the canonical shapes both sides import. Type-only:
+ * no runtime exports (per the @useatlas/types scaffold gotcha — adding
+ * VALUE exports breaks scaffold CI until the package is republished).
+ * Branded identifiers + constructor functions live in the API package
+ * because they need a runtime mint helper; the plugin can still cast
+ * at its boundaries when those land in a follow-up.
+ *
+ * What landed here in the 1.5.0 polish:
+ *   - `AnnouncementOutcome.reason` is a tagged union — the metrics
+ *     rollup no longer has to string-parse `reason: string` into
+ *     `announcer_threw:${message}` shaped values.
+ *   - `AllowDecision` (public-dataset gate) is a tagged union over
+ *     refusal reasons — replaces the `metric-denied:${metric}` packed
+ *     string with a structured `{ kind: "metric-denied"; metric }`
+ *     so audit consumers can pluck `metric` without re-parsing.
+ *
+ * Kept flat (deferred to a follow-up architecture-wins PR — each
+ * cascades through 50+ callsites + test assertions and is best done
+ * as a standalone narrowing-migration PR):
+ *   - `PauseDecision` (boolean-blind `layer?: PauseLayer`)
+ *   - `ClassificationResult.isQuestion` (boolean blindness)
+ *   - `ProactiveMeterEvent` (eventType-conditional field shape)
+ *   - Branded `WorkspaceId` / `ChannelId` / `UserId` / `Confidence` /
+ *     `MicroUSD` / `Millis` / `EpochMs` (primitive obsession)
+ */
+
+// ---------------------------------------------------------------------------
+// Pause registry (#2295) — three-layer kill switch + per-user opt-out
+// ---------------------------------------------------------------------------
+
+/**
+ * Channel-scoped pause layers (`channel_id IS NOT NULL`).
+ *
+ * Split from `PauseLayer` so the type system makes a row that says
+ * it's `channel-24h` carry a non-null channel id at the type level.
+ */
+export type ChannelPauseLayer = "channel-24h" | "admin-channel";
+
+/**
+ * The four pause shapes recognised by the registry.
+ *
+ * - `channel-24h`     — in-channel `@atlas pause` (channel-scoped, 24h)
+ * - `admin-channel`   — per-channel admin deny (channel-scoped, indefinite)
+ * - `workspace-kill`  — admin "pause all proactive" (workspace-wide, indefinite)
+ * - `user-optout`     — DM `unsubscribe` (per-user, workspace-wide, indefinite)
+ */
+export type PauseLayer =
+  | ChannelPauseLayer
+  | "workspace-kill"
+  | "user-optout";
+
+/**
+ * Outcome of a pause-registry lookup.
+ *
+ * Kept flat (`{ paused: boolean; layer?; until? }`) rather than
+ * discriminated by `paused` because every existing test assertion
+ * (`expect(decision.layer).toBe("workspace-kill")`) and the admin
+ * pauses route's `decision.layer === "workspace-kill"` check expect
+ * `layer` to be accessible regardless of TS narrowing. Discriminating
+ * this type is a future architecture-wins refactor — see this module
+ * header for rationale.
+ *
+ * `until` is epoch ms; absent on indefinite pauses (workspace-kill,
+ * admin-channel, user-optout). `channel-24h` always has `until`.
+ * `layer` is absent only when `paused: false`.
+ */
+export interface PauseDecision {
+  paused: boolean;
+  layer?: PauseLayer;
+  /** Epoch ms when the pause expires; absent on indefinite pauses. */
+  until?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Classifier (#2292) — kept flat; eventType discrimination deferred
+// ---------------------------------------------------------------------------
+
+/** Three-tier sensitivity preset. Maps to a confidence threshold in policy. */
+export type SensitivityPreset = "cautious" | "balanced" | "eager";
+
+/** Result of running a message through the question classifier. */
+export interface ClassificationResult {
+  /** Whether the message looks like an answerable data question. */
+  isQuestion: boolean;
+  /** Confidence in [0, 1] — 1.0 = certain, 0.0 = certainly not. */
+  confidence: number;
+  /** Optional short reason from the LLM, useful for audit + tuning. */
+  reasoning?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Meter (#2296, #2297) — kept flat; eventType-conditional discrimination deferred
+// ---------------------------------------------------------------------------
+
+/** Lifecycle stages tracked by the proactive answer meter. */
+export type ProactiveMeterEventType =
+  | "classify"
+  | "react"
+  | "offer"
+  | "accept"
+  | "feedback"
+  | "public_refused";
+
+/** Outcome values captured on `feedback` events. */
+export type ProactiveMeterOutcome =
+  | "helpful"
+  | "not-helpful"
+  | "wrong-data"
+  | "no-feedback";
+
+/**
+ * One row of the proactive meter. Plugin emits these via the host's
+ * `onMeterEvent` callback; API writes them to `proactive_meter_events`.
+ *
+ * Field shape is deliberately flat — discriminating per `eventType`
+ * would force every emitter to switch on the type before constructing
+ * the payload. Deferred to a follow-up; see module header.
+ */
+export interface ProactiveMeterEvent {
+  workspaceId: string;
+  channelId: string;
+  messageId?: string | null;
+  eventType: ProactiveMeterEventType;
+  outcome?: ProactiveMeterOutcome | null;
+  tokens?: number;
+  costMicroUsd?: number;
+  confidence?: number | null;
+  actorUserId?: string | null;
+  metadata?: Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// Public dataset (#2297) — discriminated allowlist verdict
+// ---------------------------------------------------------------------------
+
+/** One entry on a workspace's curated public-dataset allowlist. */
+export interface PublicDatasetEntry {
+  /** Fully-qualified entity name (e.g. `marketing.users`). */
+  entityName: string;
+  /** Column / measure names denied within this entity. May be empty. */
+  denyMetrics: string[];
+}
+
+/**
+ * Allowlist verdict for one entity touch.
+ *
+ * Tagged union: refusal reason is a structured `kind` rather than the
+ * pre-polish `deniedReason: \`metric-denied:${metric}\`` packed string.
+ * Audit consumers pluck `kind` / `metric` directly instead of parsing
+ * a packed string.
+ */
+export type AllowDecision =
+  | { allowed: true }
+  | {
+      allowed: false;
+      kind: "entity-not-in-allowlist";
+    }
+  | {
+      allowed: false;
+      kind: "metric-denied";
+      /** The denied metric the query touched. */
+      metric: string;
+    };
+
+// ---------------------------------------------------------------------------
+// Monthly quota (#2301)
+// ---------------------------------------------------------------------------
+
+/** Quota snapshot returned by the host quota-status reader. */
+export interface ProactiveQuotaStatus {
+  /** Cap value persisted on the workspace config. Null = unlimited. */
+  monthlyClassifierCap: number | null;
+  /** Distinct classify rows since the start of the current UTC month. */
+  classifyCountThisMonth: number;
+  /** True when `classifyCountThisMonth >= monthlyClassifierCap`. */
+  capReached: boolean;
+  /**
+   * True when the underlying DB read failed and the snapshot is the
+   * fail-open default. Listener emits a `classify` meter row tagged
+   * `skipped: "quota-read-failed"` so the bypass surfaces in the
+   * analytics rollup.
+   */
+  readFailed?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Activation announcement (#2300) — discriminated outcome
+// ---------------------------------------------------------------------------
+
+/**
+ * Outcome of a `announceActivation` call. Tagged union on `reason` so
+ * metrics consumers can pivot on the rejection class without parsing
+ * the message — replaces the pre-polish `reason: string` shape.
+ */
+export type AnnouncementOutcome =
+  | { posted: true; messageId?: string }
+  | { posted: false; reason: "no_internal_db" }
+  | { posted: false; reason: "no_config_row" }
+  | { posted: false; reason: "already_posted" }
+  | { posted: false; reason: "no_announcer_configured" }
+  | { posted: false; reason: "claim_update_failed"; message: string }
+  | { posted: false; reason: "announcer_threw"; message: string }
+  | { posted: false; reason: "announcer_rejected"; message: string };


### PR DESCRIPTION
## Summary

Adds `@useatlas/types/proactive` so plugin and API can stop mirroring shape-by-shape. Foundation for the 1.5.0 closeout review's "wire-type boundary violation" finding — the polish PR (#2545) wires consumers to use these shared shapes once npm publishes 0.1.3.

## What landed
- `PauseLayer`, `ChannelPauseLayer`, `PauseDecision` (flat — discrimination deferred)
- `ClassificationResult`, `SensitivityPreset` (flat)
- `ProactiveMeterEventType`, `ProactiveMeterOutcome`, `ProactiveMeterEvent`
- `ProactiveQuotaStatus` (with the 1.5.0-polish `readFailed` flag)
- `PublicDatasetEntry` + `AllowDecision` (tagged-union refusal shapes)
- `AnnouncementOutcome` (tagged-union on `reason` — replaces the pre-polish `reason: string` which forced metrics consumers to parse packed strings)

Type-only — no runtime exports, per the @useatlas/types scaffold gotcha. Value-side branding + minting helpers stay in `packages/api` for the follow-up.

## Deferred (filed for separate follow-up PRs)
- Discriminate `PauseDecision` by `paused`, `ClassificationResult` by `isQuestion`, `ProactiveMeterEvent` per `eventType` — each cascades through 50+ callsites + test assertions; best done as a standalone narrowing-migration PR.
- Brand `WorkspaceId` / `ChannelId` / `UserId` / `Confidence` / `MicroUSD` / `Millis` / `EpochMs` for primitive obsession — same cascade concern.

## Version bump
`0.1.2 → 0.1.3`. Tag `types-v0.1.3` already pushed from this branch tip to trigger the publish workflow so the consumer PR (#2545) can pin to `^0.1.3` without scaffold CI breaking on registry-resolution.

## Test plan
- [x] `bun run build` in packages/types — clean (proactive.d.ts + proactive.js generated)
- [ ] Publish workflow on types-v0.1.3 tag succeeds
- [ ] `npm view @useatlas/types version` reports 0.1.3
- [ ] CI green on this PR

After publish: re-base or update #2545 to consume the new shapes (separate effort).