### PR TITLE
fix(1.4.6): review followups — races, error surfacing, comment drift

### DIFF
--- a/packages/api/src/api/routes/chat.ts
+++ b/packages/api/src/api/routes/chat.ts
@@ -726,6 +726,17 @@ chat.openapi(chatRoute, async (c) => {
         // Populated after conversation load/create when the row carries
         // a `bound_dashboard_id`. Drives the bound-mode tool registry
         // + system-prompt swap below.
+        // Tracks why the chat ended up unbound when the client asked
+        // for binding. Drives a `bound_unavailable` contextWarning the
+        // drawer renders so the user knows their edits aren't being
+        // captured (instead of the silent degrade-to-default-agent
+        // fallback that the early review caught).
+        let boundFailureReason:
+          | "dashboard_not_found"
+          | "conversation_not_found"
+          | "error"
+          | "no_db"
+          | null = null;
         let boundDashboardForAgent:
           | {
               cardSummary: string;
@@ -1001,6 +1012,12 @@ chat.openapi(chatRoute, async (c) => {
                       },
                       "Failed to bind conversation to dashboard — chat will run unbound",
                     );
+                    // Remember the bind failure so we can push a
+                    // contextWarning into the stream below — without it
+                    // the drawer would silently run the default agent
+                    // and the user would never know their edits weren't
+                    // being captured.
+                    boundFailureReason = bound.reason;
                   }
                 }
               }
@@ -1014,7 +1031,7 @@ chat.openapi(chatRoute, async (c) => {
         // load/create. Reads the persisted `bound_dashboard_id` so
         // follow-up turns inherit the binding without resending it.
         // Falls back to the default agent when the resolve returns
-        // `not_bound` / `dashboard_missing` (deleted between turns) /
+        // `not_bound` / `dashboard_not_found` (deleted between turns) /
         // `error` — the route never hard-fails on a binding lookup.
         if (conversationId) {
           const resolved = await resolveBoundDashboard(conversationId, {
@@ -1045,8 +1062,30 @@ chat.openapi(chatRoute, async (c) => {
               { requestId, conversationId, reason: resolved.reason },
               "resolveBoundDashboard failed — falling back to default agent",
             );
+            boundFailureReason = "error";
+          } else if (resolved.reason === "dashboard_not_found" && requestedBoundDashboardId) {
+            // The dashboard got deleted between turns (FK SET NULL
+            // cleared the binding). Treat as a bind failure so the
+            // drawer surfaces the loss rather than silently turning
+            // into an unbound chat that won't edit anything.
+            boundFailureReason = "dashboard_not_found";
+          } else if (requestedBoundDashboardId && resolved.reason === "not_bound" && !boundFailureReason) {
+            // The client supplied boundDashboardId but the persisted
+            // row carries no binding. If the bind step above set
+            // `boundFailureReason`, we already know why. Otherwise
+            // something stripped the binding between the bind UPDATE
+            // and this resolve — surface as a generic error so the
+            // drawer alerts the user instead of "agent works but
+            // won't edit" silent failure.
+            log.warn(
+              { requestId, conversationId, dashboardId: requestedBoundDashboardId },
+              "Bound chat resolved as not_bound despite request — possible binding race",
+            );
+            boundFailureReason = "error";
           }
-          // not_bound / no_db / dashboard_missing → silent fallback to default agent
+          // not_bound (no request) / no_db / dashboard_not_found without
+          // a requested bind → silent fallback to default agent (the
+          // chat surface is the root `/` page, not the drawer).
         }
   
         try {
@@ -1121,6 +1160,28 @@ chat.openapi(chatRoute, async (c) => {
           // reduced context AND the user needs to know their answer was
           // generated against fallback data.
           const contextWarnings: ChatContextWarning[] = [];
+
+          // Surface bind/resolve failures from the bound-chat surface
+          // as a context warning the drawer renders. Without this the
+          // chat runs against the default agent — fine semantics, but
+          // the user gets a "agent ignores my edit requests" experience
+          // with no signal anything went wrong. (Review followup —
+          // silent-failure C2 + C3.)
+          if (boundFailureReason && requestedBoundDashboardId) {
+            const detail =
+              boundFailureReason === "dashboard_not_found"
+                ? "That dashboard is no longer available — edits in this chat will not take effect. Open a different dashboard to continue editing."
+                : boundFailureReason === "no_db"
+                  ? "Dashboard editing is unavailable: the workspace database is not reachable. Try again shortly."
+                  : "Could not load the dashboard context for this chat — edits will not be applied. Reopen the chat drawer to retry.";
+            contextWarnings.push({
+              severity: "warning",
+              code: "bound_dashboard_unavailable",
+              title: "Dashboard editing unavailable",
+              detail,
+              requestId,
+            });
+          }
 
           // Call runAgent first so errors (provider auth, config, etc.) are
           // caught by the outer try-catch and returned as proper JSON errors.

--- a/packages/api/src/api/routes/dashboards.ts
+++ b/packages/api/src/api/routes/dashboards.ts
@@ -1121,7 +1121,7 @@ authed.openapi(publishDraftRoute, async (c) => {
     if (result.reason === "no_draft") {
       return c.json({ error: "not_found", message: "No draft to publish." }, 404);
     }
-    if (result.reason === "dashboard_missing") {
+    if (result.reason === "dashboard_not_found") {
       return c.json({ error: "not_found", message: "Dashboard not found." }, 404);
     }
     if (result.reason === "stale_baseline") {
@@ -1154,20 +1154,34 @@ authed.openapi(publishDraftRoute, async (c) => {
 
 authed.openapi(discardDraftRoute, async (c) => {
   return runEffect(c, Effect.gen(function* () {
-    const { requestId: _requestId } = yield* RequestContext;
+    const { requestId } = yield* RequestContext;
     const { user } = yield* AuthContext;
     const { id } = c.req.valid("param");
     if (!UUID_RE.test(id)) {
-      return c.json({ error: "invalid_request", message: "Invalid dashboard ID format." }, 400);
+      return c.json({ error: "invalid_request", message: "Invalid dashboard ID format.", requestId }, 400);
     }
     if (!isDashboardDraftsEnabled()) {
       const fail = draftsFlagOffResponse();
       return c.json(fail.body, fail.status);
     }
     if (!user?.id) {
-      return c.json({ error: "auth_required", message: "Drafts require an authenticated user." }, 401);
+      return c.json({ error: "auth_required", message: "Drafts require an authenticated user.", requestId }, 401);
     }
-    yield* Effect.promise(() => discardDraft(user.id, id));
+    // `discardDraft` returns `false` on an internal-DB throw — surface
+    // as 500-with-requestId so the user sees something went wrong
+    // rather than a 204 that lies about the deletion. The 204 path
+    // covers the (intentional) idempotent zero-row-deleted case.
+    const ok = yield* Effect.promise(() => discardDraft(user.id, id));
+    if (!ok) {
+      return c.json(
+        {
+          error: "internal_error",
+          message: "Could not discard the draft. The database may be temporarily unavailable — try again.",
+          requestId,
+        },
+        500,
+      );
+    }
     return c.body(null, 204);
   }), { label: "discard draft" });
 });
@@ -1213,7 +1227,7 @@ authed.openapi(rebaseDraftRoute, async (c) => {
     if (result.reason === "no_draft") {
       return c.json({ error: "not_found", message: "No draft to rebase." }, 404);
     }
-    if (result.reason === "dashboard_missing") {
+    if (result.reason === "dashboard_not_found") {
       return c.json({ error: "not_found", message: "Dashboard not found." }, 404);
     }
     if (result.reason === "conflict") {
@@ -2175,9 +2189,25 @@ authed.openapi(screenshotDashboardRoute, async (c) => {
     if (!result.ok) {
       switch (result.reason) {
         case "no_db":
-          return c.json({ error: "not_available", message: result.message }, 404);
+          // Internal DB unavailable — infra failure, not a missing
+          // resource. 503 + Retry-After so callers retry instead of
+          // treating it as a 404.
+          return c.json(
+            { error: "not_available", message: result.message, requestId },
+            503,
+            { "Retry-After": "5" },
+          );
         case "dashboard_not_found":
-          return c.json({ error: "not_found", message: result.message }, 404);
+          return c.json({ error: "not_found", message: result.message, requestId }, 404);
+        case "dashboard_unavailable":
+          // Snapshot lookup failed with a non-not-found reason (DB error,
+          // unknown failure mode). 503 so paging surfaces it correctly;
+          // distinct from `render_failed` which is a Playwright problem.
+          return c.json(
+            { error: "dashboard_unavailable", message: result.message, requestId },
+            503,
+            { "Retry-After": "5" },
+          );
         case "browser_unavailable":
           return c.json({ error: "browser_unavailable", message: result.message, requestId }, 503);
         case "render_failed":

--- a/packages/api/src/lib/__tests__/bound-chat-context.test.ts
+++ b/packages/api/src/lib/__tests__/bound-chat-context.test.ts
@@ -242,7 +242,7 @@ describe("bound-chat-context module", () => {
       if (!r.ok) expect(r.reason).toBe("not_bound");
     });
 
-    it("returns dashboard_missing when the bound dashboard is gone / cross-org", async () => {
+    it("returns dashboard_not_found when the bound dashboard is gone / cross-org", async () => {
       enableInternalDB();
       setResults(
         { rows: [{ bound_dashboard_id: "dash-X" }] }, // conversation lookup
@@ -250,7 +250,7 @@ describe("bound-chat-context module", () => {
       );
       const r = await resolveBoundDashboard("conv-1", { orgId: "org-1" });
       expect(r.ok).toBe(false);
-      if (!r.ok) expect(r.reason).toBe("dashboard_missing");
+      if (!r.ok) expect(r.reason).toBe("dashboard_not_found");
     });
 
     it("returns the dashboard + cards on success", async () => {
@@ -462,10 +462,14 @@ describe("bound-chat-context module", () => {
         expect(r.data.messages[0]!.role).toBe("user");
         expect(r.data.messages[1]!.role).toBe("assistant");
       }
-      // Second query is the messages fetch, scoped to conversation only
+      // Second query is the messages fetch, scoped to conversation
+      // only, plus a defensive LIMIT to bound the response (DoS guard
+      // — a runaway bound chat with 10k turns would otherwise serialize
+      // every message in one shot).
       const msgSql = queryCalls[1]!.sql;
       expect(msgSql).toMatch(/conversation_id = \$1/);
-      expect(queryCalls[1]!.params).toEqual(["conv-1"]);
+      expect(msgSql).toMatch(/LIMIT \$2/);
+      expect(queryCalls[1]!.params).toEqual(["conv-1", 1000]);
     });
 
     it("reads workspace-wide — does NOT add a user-ownership predicate", async () => {

--- a/packages/api/src/lib/__tests__/dashboard-versioning.test.ts
+++ b/packages/api/src/lib/__tests__/dashboard-versioning.test.ts
@@ -32,7 +32,7 @@ import {
   type DashboardSnapshot,
   type DashboardSnapshotCard,
 } from "../dashboard-versioning";
-import type { DashboardWithCards } from "../dashboard-types";
+import type { DashboardWithCards, DashboardCard } from "../dashboard-types";
 
 // ---------------------------------------------------------------------------
 // Snapshot fixtures
@@ -576,6 +576,56 @@ describe("materializeDraftView", () => {
     // Untracked fields fall through from published.
     expect(view.shareToken).toBe("tok");
   });
+
+  it("preserves cached_columns / cached_rows / cachedAt from the matching published card", () => {
+    // Without this fall-through, a draft view would render cards as
+    // empty placeholders even when the user only changed the title.
+    const baseCard = card("c1", { title: "pub" });
+    // Build the published row directly so we can inject the cached-*
+    // fields that the dashboardWithCards helper hard-nulls.
+    const publishedCardRow: DashboardCard = {
+      id: baseCard.id,
+      dashboardId: "dash-1",
+      position: baseCard.position,
+      title: baseCard.title,
+      sql: baseCard.sql,
+      chartConfig: baseCard.chartConfig,
+      cachedColumns: ["a", "b"],
+      cachedRows: [{ a: 1, b: 2 }],
+      cachedAt: "2026-05-01T00:00:00.000Z",
+      connectionGroupId: baseCard.connectionGroupId,
+      layout: baseCard.layout,
+      createdAt: "2026-05-01T00:00:00.000Z",
+      updatedAt: "2026-05-01T00:00:00.000Z",
+    };
+    const published: DashboardWithCards = {
+      ...dashboardWithCards([], {}),
+      cards: [publishedCardRow],
+    };
+    const draft = snapshot([{ ...baseCard, title: "draft" }], {});
+    const view = materializeDraftView(published, draft);
+    expect(view.cards[0].cachedColumns).toEqual(["a", "b"]);
+    expect(view.cards[0].cachedRows).toEqual([{ a: 1, b: 2 }]);
+    expect(view.cards[0].cachedAt).toBe("2026-05-01T00:00:00.000Z");
+  });
+
+  it("falls back to published.updatedAt for card timestamps instead of new Date()", () => {
+    // Forward-compat: a draft view rendered twice should show the
+    // same card timestamps (so ordering-by-updated_at consumers
+    // don't see "everything edited just now"). New cards (no matching
+    // published row) inherit the parent dashboard's updatedAt as a
+    // best-effort fallback.
+    const published = dashboardWithCards([card("c1", { title: "pub" })], {
+      updatedAt: "2026-05-10T00:00:00.000Z",
+    });
+    const draft = snapshot(
+      [card("c1", { title: "draft" }), card("c2", { position: 1, title: "new" })],
+      { title: "Draft Title" },
+    );
+    const view = materializeDraftView(published, draft);
+    expect(view.cards[1].updatedAt).toBe("2026-05-10T00:00:00.000Z");
+    expect(view.cards[1].createdAt).toBe("2026-05-10T00:00:00.000Z");
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -825,7 +875,7 @@ describe("dashboard-versioning DB helpers", () => {
       expect(result.reason).toBe("no_draft");
     });
 
-    it("returns dashboard_missing when the parent dashboard is gone", async () => {
+    it("returns dashboard_not_found when the parent dashboard is gone", async () => {
       enableInternalDB();
       const snap = snapshot([card("c1")]);
       setResults({ rows: [draftRow({ draft: snap })] });
@@ -837,7 +887,7 @@ describe("dashboard-versioning DB helpers", () => {
       });
       expect(result.ok).toBe(false);
       if (result.ok) return;
-      expect(result.reason).toBe("dashboard_missing");
+      expect(result.reason).toBe("dashboard_not_found");
     });
 
     it("returns stale_baseline when published has moved underneath the draft", async () => {
@@ -914,9 +964,11 @@ describe("dashboard-versioning DB helpers", () => {
         rows: [draftRow({ draft: draftWithAdd.snapshot, baseline })],
       });
 
-      // BEGIN, INSERT card, touch dashboards, DELETE draft, COMMIT.
+      // BEGIN, SELECT updated_at FOR UPDATE (lock + re-check), INSERT
+      // card, touch dashboards, DELETE draft, COMMIT.
       setClientResults(
         { rows: [] }, // BEGIN
+        { rows: [{ updated_at: "2026-05-17T00:00:00.000Z" }] }, // SELECT FOR UPDATE
         { rows: [] }, // INSERT INTO dashboard_cards
         { rows: [] }, // UPDATE dashboards SET updated_at
         { rows: [] }, // DELETE FROM dashboard_user_drafts
@@ -953,16 +1005,21 @@ describe("dashboard-versioning DB helpers", () => {
       expect(draftAdd.ok).toBe(true);
       if (!draftAdd.ok) return;
       setResults({ rows: [draftRow({ draft: draftAdd.snapshot, baseline })] });
-      // BEGIN succeeds, then the next op throws.
-      let firstCall = true;
+      // BEGIN + SELECT FOR UPDATE succeed, then the next op throws.
+      let serviced = 0;
       clientThrow = null;
       clientCalls = [];
       const customClient: InternalPoolClient = {
         query: async (sql: string, params?: unknown[]) => {
           clientCalls.push({ sql, params });
-          if (firstCall) {
-            firstCall = false;
-            return { rows: [] };
+          serviced++;
+          // 1. BEGIN
+          if (serviced === 1) return { rows: [] };
+          // 2. SELECT updated_at FOR UPDATE — return matching baseline
+          //    so the in-tx stale guard passes and we proceed to the
+          //    real op (which throws on call 3).
+          if (serviced === 2) {
+            return { rows: [{ updated_at: "2026-05-17T00:00:00.000Z" }] };
           }
           if (sql === "ROLLBACK") return { rows: [] };
           throw new Error("synthetic op failure");
@@ -992,6 +1049,63 @@ describe("dashboard-versioning DB helpers", () => {
       expect(result.reason).toBe("error");
       expect(clientCalls.some((c) => c.sql === "ROLLBACK")).toBe(true);
       expect(releaseCalls).toBe(1);
+    });
+
+    it("returns stale_baseline (with currentBaselineAt) when SELECT FOR UPDATE sees published moved post-pre-check", async () => {
+      // Concurrent-publish race: pre-tx check passes (published.updatedAt
+      // == draftRow.publishedBaselineAt), but inside the transaction the
+      // FOR UPDATE select sees a NEWER updated_at because another user's
+      // publish committed in the gap. The lock catches it, rolls back,
+      // and returns stale_baseline with the new baseline so the UI can
+      // surface "X changed since you last loaded the draft" without a
+      // second round-trip.
+      enableInternalDB();
+      const baseline = snapshot([card("c1")]);
+      const draftAdd = applyChangeToDraft(baseline, {
+        kind: "addCard",
+        card: card("c-new", { position: 1 }),
+      });
+      expect(draftAdd.ok).toBe(true);
+      if (!draftAdd.ok) return;
+      setResults({
+        rows: [
+          draftRow({
+            draft: draftAdd.snapshot,
+            baseline,
+            publishedBaselineAt: "2026-05-17T00:00:00.000Z",
+          }),
+        ],
+      });
+      setClientResults(
+        { rows: [] }, // BEGIN
+        // SELECT updated_at FOR UPDATE — another user's publish already
+        // committed; the locked row shows a NEWER timestamp than the
+        // draft's persisted baseline.
+        { rows: [{ updated_at: "2026-05-17T05:00:00.000Z" }] },
+        { rows: [] }, // ROLLBACK
+      );
+
+      const published = dashboardWithCards([card("c1")], {
+        // Pre-tx check still matches (cached read) so the race is
+        // realistic — only the lock catches it.
+        updatedAt: "2026-05-17T00:00:00.000Z",
+      });
+      const result = await publishDraft({
+        userId: "u1",
+        dashboardId: "dash-1",
+        orgId: "org-1",
+        loadDashboardForOrg: async () => published,
+      });
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.reason).toBe("stale_baseline");
+      if (result.reason !== "stale_baseline") return;
+      expect(result.currentBaselineAt).toBe("2026-05-17T05:00:00.000Z");
+      // Rolled back, no DELETE / INSERT happened.
+      const sqls = clientCalls.map((c) => c.sql).join("\n");
+      expect(sqls).toContain("ROLLBACK");
+      expect(sqls).not.toContain("INSERT INTO dashboard_cards");
+      expect(sqls).not.toContain("DELETE FROM dashboard_user_drafts");
     });
   });
 

--- a/packages/api/src/lib/__tests__/stage-tracker.test.ts
+++ b/packages/api/src/lib/__tests__/stage-tracker.test.ts
@@ -583,4 +583,245 @@ describe("stage-tracker DB helpers", () => {
       expect(result.reason).toBe("not_found");
     });
   });
+
+  // -----------------------------------------------------------------------
+  // acceptStagedChange — applies the staged change to the draft + flips
+  // status in one transaction. Covers the race-fix from the 1.4.6 review:
+  // the draft snapshot is RE-LOADED inside the transaction under FOR
+  // UPDATE so a safe-op edit between the pre-tx load and the tx-write
+  // can't be overwritten.
+  // -----------------------------------------------------------------------
+
+  describe("acceptStagedChange()", () => {
+    // Shared fixture: a published dashboard with one card the stage will
+    // remove + a draft snapshot mirroring it. The pool returns:
+    //   1. loadStagedChange → the pending stage row
+    //   2. getDashboard → dashboards row + cards rows
+    //   3. forkOrLoadDraft.loadDraft → the existing draft row
+    // Then transactional client calls:
+    //   1. BEGIN
+    //   2. SELECT draft FOR UPDATE → returns the same draft jsonb
+    //   3. UPDATE dashboard_user_drafts SET draft = $1
+    //   4. UPDATE dashboard_stage_changes SET status='applied' RETURNING ...
+    //   5. COMMIT
+    function arrangeHappyPath(opts: { inTxDraftOverride?: object } = {}) {
+      const stageRowFixture = {
+        id: "stage-1",
+        dashboard_id: "dash-1",
+        user_id: "user-1",
+        kind: "remove_card",
+        payload: { kind: "remove_card", cardId: "card-1" },
+        status: "pending",
+        created_at: "2026-05-17T00:00:00Z",
+        updated_at: "2026-05-17T00:00:00Z",
+        applied_at: null,
+        discarded_at: null,
+      };
+      const dashboardRow = {
+        id: "dash-1",
+        org_id: "org-1",
+        owner_id: "u1",
+        title: "Test dash",
+        description: null,
+        share_token: null,
+        share_expires_at: null,
+        share_mode: "public",
+        refresh_schedule: null,
+        last_refresh_at: null,
+        next_refresh_at: null,
+        card_count: 1,
+        created_at: "2026-05-17T00:00:00Z",
+        updated_at: "2026-05-17T00:00:00Z",
+      };
+      const cardRow = {
+        id: "card-1",
+        dashboard_id: "dash-1",
+        position: 0,
+        title: "Card 1",
+        sql: "SELECT 1",
+        chart_config: { type: "table", categoryColumn: "x", valueColumns: ["x"] },
+        cached_columns: null,
+        cached_rows: null,
+        cached_at: null,
+        connection_group_id: null,
+        layout: null,
+        created_at: "2026-05-17T00:00:00Z",
+        updated_at: "2026-05-17T00:00:00Z",
+      };
+      const draftSnapshot = {
+        dashboardId: "dash-1",
+        title: "Test dash",
+        description: null,
+        cards: [
+          {
+            id: "card-1",
+            position: 0,
+            title: "Card 1",
+            sql: "SELECT 1",
+            chartConfig: { type: "table", categoryColumn: "x", valueColumns: ["x"] },
+            connectionGroupId: null,
+            layout: null,
+          },
+        ],
+      };
+      const draftRowFixture = {
+        user_id: "user-1",
+        dashboard_id: "dash-1",
+        draft: draftSnapshot,
+        baseline: draftSnapshot,
+        published_baseline_at: "2026-05-17T00:00:00Z",
+        created_at: "2026-05-17T00:00:00Z",
+        updated_at: "2026-05-17T00:00:00Z",
+      };
+      setQueryResults(
+        { rows: [stageRowFixture] }, // loadStagedChange
+        { rows: [dashboardRow] }, // getDashboard SELECT dashboards
+        { rows: [cardRow] }, // getDashboard SELECT cards
+        { rows: [draftRowFixture] }, // forkOrLoadDraft → loadDraft
+      );
+      setClientResults(
+        { rows: [] }, // BEGIN
+        // SELECT draft FOR UPDATE — returns either the same snapshot
+        // (happy path) or the override (race / mutation cases).
+        { rows: [{ draft: opts.inTxDraftOverride ?? draftSnapshot }] },
+        { rows: [] }, // UPDATE dashboard_user_drafts
+        {
+          rows: [
+            {
+              ...stageRowFixture,
+              status: "applied",
+              applied_at: "2026-05-17T01:00:00Z",
+              updated_at: "2026-05-17T01:00:00Z",
+            },
+          ],
+        }, // UPDATE dashboard_stage_changes RETURNING
+        { rows: [] }, // COMMIT
+      );
+    }
+
+    it("applies remove_card to the draft + flips status to applied in one transaction", async () => {
+      enableInternalDB();
+      arrangeHappyPath();
+      const { acceptStagedChange } = await import("../stage-tracker");
+      const result = await acceptStagedChange({
+        stageId: "stage-1",
+        userId: "user-1",
+        orgId: "org-1",
+      });
+      expect(result.ok).toBe(true);
+      if (!result.ok) throw new Error("unreachable");
+      expect(result.applied).toBe(true);
+      expect(result.stage.status).toBe("applied");
+      // The transaction MUST hold the lock before mutating — the
+      // SELECT FOR UPDATE is the race-fix from the 1.4.6 review.
+      const sqls = clientCalls.map((c) => c.sql).join("\n");
+      expect(clientCalls[0]?.sql).toBe("BEGIN");
+      expect(sqls).toMatch(/SELECT draft FROM dashboard_user_drafts[\s\S]*FOR UPDATE/);
+      expect(sqls).toMatch(/UPDATE dashboard_user_drafts/);
+      expect(sqls).toMatch(/UPDATE dashboard_stage_changes/);
+      expect(sqls).toContain("COMMIT");
+      expect(clientReleased).toBe(true);
+    });
+
+    it("returns unknown_card when the in-tx re-load shows the card was already removed by a safe op", async () => {
+      // The pre-tx fork-or-load resolves the card; before the transaction
+      // grabs the lock, a concurrent safe-op `updateCard` (or a prior
+      // accept for the same card) removed it. The in-tx re-load + re-apply
+      // surfaces `unknown_card` and ROLLBACKs so the stage row stays
+      // pending — the user can discard it next.
+      enableInternalDB();
+      arrangeHappyPath({
+        inTxDraftOverride: {
+          dashboardId: "dash-1",
+          title: "Test dash",
+          description: null,
+          cards: [], // card-1 is gone in the in-tx snapshot
+        },
+      });
+      const { acceptStagedChange } = await import("../stage-tracker");
+      const result = await acceptStagedChange({
+        stageId: "stage-1",
+        userId: "user-1",
+        orgId: "org-1",
+      });
+      expect(result.ok).toBe(false);
+      if (result.ok) throw new Error("unreachable");
+      expect(result.reason).toBe("unknown_card");
+      // Rolled back; no UPDATEs landed.
+      const sqls = clientCalls.map((c) => c.sql).join("\n");
+      expect(sqls).toContain("ROLLBACK");
+      expect(sqls).not.toMatch(/UPDATE dashboard_stage_changes/);
+      expect(clientReleased).toBe(true);
+    });
+
+    it("returns no_draft and rolls back when the draft was discarded between fork-or-load and FOR UPDATE", async () => {
+      enableInternalDB();
+      arrangeHappyPath();
+      // Override just the in-tx draft lock to return zero rows.
+      setClientResults(
+        { rows: [] }, // BEGIN
+        { rows: [] }, // SELECT FOR UPDATE — empty
+        { rows: [] }, // ROLLBACK
+      );
+      const { acceptStagedChange } = await import("../stage-tracker");
+      const result = await acceptStagedChange({
+        stageId: "stage-1",
+        userId: "user-1",
+        orgId: "org-1",
+      });
+      expect(result.ok).toBe(false);
+      if (result.ok) throw new Error("unreachable");
+      expect(result.reason).toBe("no_draft");
+      // The SELECT FOR UPDATE contains the substring "UPDATE", but no
+      // mutating statement should have landed — assert no UPDATE
+      // statement on either table specifically.
+      const sqls = clientCalls.map((c) => c.sql).join("\n");
+      expect(sqls).toContain("ROLLBACK");
+      expect(sqls).not.toMatch(/UPDATE dashboard_user_drafts/);
+      expect(sqls).not.toMatch(/UPDATE dashboard_stage_changes/);
+    });
+
+    it("returns rejected when the stage is already discarded (no_op transition)", async () => {
+      enableInternalDB();
+      setQueryResults({
+        rows: [
+          {
+            id: "stage-1",
+            dashboard_id: "dash-1",
+            user_id: "user-1",
+            kind: "remove_card",
+            payload: { kind: "remove_card", cardId: "card-1" },
+            status: "discarded",
+            created_at: "2026-05-17T00:00:00Z",
+            updated_at: "2026-05-17T00:30:00Z",
+            applied_at: null,
+            discarded_at: "2026-05-17T00:30:00Z",
+          },
+        ],
+      });
+      const { acceptStagedChange } = await import("../stage-tracker");
+      const result = await acceptStagedChange({
+        stageId: "stage-1",
+        userId: "user-1",
+        orgId: "org-1",
+      });
+      expect(result.ok).toBe(false);
+      if (result.ok) throw new Error("unreachable");
+      expect(result.reason).toBe("rejected");
+    });
+
+    it("returns not_found for a cross-user stage id (per-user gate)", async () => {
+      enableInternalDB();
+      setQueryResults({ rows: [] });
+      const { acceptStagedChange } = await import("../stage-tracker");
+      const result = await acceptStagedChange({
+        stageId: "stage-1",
+        userId: "user-other",
+        orgId: "org-1",
+      });
+      expect(result.ok).toBe(false);
+      if (result.ok) throw new Error("unreachable");
+      expect(result.reason).toBe("not_found");
+    });
+  });
 });

--- a/packages/api/src/lib/bound-chat-context.ts
+++ b/packages/api/src/lib/bound-chat-context.ts
@@ -43,7 +43,7 @@ export type BindResult = { ok: true } | { ok: false; reason: BindFailReason };
 
 export type ResolveResult =
   | { ok: true; dashboard: DashboardWithCards }
-  | { ok: false; reason: "no_db" | "not_bound" | "dashboard_missing" | "error" };
+  | { ok: false; reason: "no_db" | "not_bound" | "dashboard_not_found" | "error" };
 
 /**
  * Bind a conversation row to a dashboard. Verifies the dashboard exists
@@ -90,7 +90,7 @@ export async function bindConversationToDashboard(
 /**
  * Read the dashboard a conversation is currently bound to, including
  * its cards. Returns `not_bound` for conversations without a binding
- * (the default for non-drawer chats) and `dashboard_missing` if the
+ * (the default for non-drawer chats) and `dashboard_not_found` if the
  * binding points at a dashboard that was deleted or no longer belongs
  * to the caller's org (the latter is the cross-tenant safety net the
  * route handler relies on — even though the FK enforces existence at
@@ -117,7 +117,7 @@ export async function resolveBoundDashboard(
       // propagated through cache) OR no longer belongs to the caller's org.
       // Either way the right surface to the caller is "treat as unbound" —
       // the chat falls back to the default agent without the editor tools.
-      if (dash.reason === "not_found") return { ok: false, reason: "dashboard_missing" };
+      if (dash.reason === "not_found") return { ok: false, reason: "dashboard_not_found" };
       return { ok: false, reason: "error" };
     }
     return { ok: true, dashboard: dash.data };
@@ -189,9 +189,9 @@ export async function listSessionsForDashboard(
       title: r.title,
       createdAt: String(r.created_at),
       updatedAt: String(r.updated_at),
-      messageCount: typeof r.message_count === "number"
-        ? r.message_count
-        : parseInt(r.message_count, 10) || 0,
+      // `pg` returns COUNT(*) as a string by default; coerce uniformly.
+      // `Number("0")` returns 0 (truthy via `|| 0` would discard it).
+      messageCount: Number(r.message_count) || 0,
     }));
   } catch (err) {
     log.error(
@@ -265,6 +265,14 @@ export async function getSessionTranscript(
     if (convRows.length === 0) return { ok: false, reason: "not_found" };
     const conv = convRows[0]!;
 
+    // LIMIT to bound the response: a runaway bound conversation
+    // (thousands of agent turns) would otherwise serialize every
+    // message into one ~MB response and risk OOM-ing the API process.
+    // 1000 messages is well above any natural editing session; the
+    // History tab is a read-only audit surface so older messages
+    // would be paginated in a follow-up rather than always shipping
+    // every byte.
+    const TRANSCRIPT_MESSAGE_CAP = 1000;
     const msgRows = await internalQuery<{
       id: string;
       conversation_id: string;
@@ -275,8 +283,9 @@ export async function getSessionTranscript(
       `SELECT id, conversation_id, role, content, created_at
          FROM messages
         WHERE conversation_id = $1
-        ORDER BY created_at ASC`,
-      [conversationId],
+        ORDER BY created_at ASC
+        LIMIT $2`,
+      [conversationId, TRANSCRIPT_MESSAGE_CAP],
     );
 
     return {
@@ -359,6 +368,8 @@ export const BOUND_AGENT_PROMPT_GUIDANCE = `You are editing a saved dashboard, n
 3. **For changes to existing cards:** call \`getCardDetail(id)\` first to read the current SQL / chartConfig if you need them. Then call \`updateCard\` with only the fields that change.
 4. **For layout changes:** call \`updateLayout\` with the full set of card placements you want. The grid is 24 columns wide and uses (x, y, w, h) per card.
 5. **For "what is this card?" questions:** call \`getCardDetail(id)\` and explain in plain language. Don't mutate.
+6. **For card removal:** call \`removeCard(cardId)\`. This is a DESTRUCTIVE op — it STAGES a ghost change the user accepts or discards inline; it does NOT mutate immediately. The dashboard view renders the targeted card with a strikethrough overlay until the user resolves the stage. Don't loop back to \`getDashboardState\` in the same turn to verify removal; the stage is still pending.
+7. **For SQL rewrites:** call \`getCardDetail\` → \`executeSQL\` (validate) → \`updateCardSql(cardId, newSql)\`. Also DESTRUCTIVE / stage-required. The UI surfaces a side-by-side diff the user accepts or discards.
 
 ## Grid Layout
 
@@ -385,7 +396,8 @@ Treat \`semantic/metrics/*.yml\` as authoritative. If a measure exists, use its 
 
 - \`getDashboardState\` returns the current dashboard meta + the same compact card summary the system prompt injects. Use it when you need a fresh read mid-conversation (e.g. after several mutations).
 - \`getCardDetail(id)\` is the only way to fetch a card's SQL / chartConfig — keep it scoped to the cards you actually need.
-- \`addCard\` / \`updateCard\` / \`updateLayout\` / \`updateDashboardMeta\` commit immediately to the dashboard. There is no undo in this tracer-bullet slice.
+- \`addCard\` / \`updateCard\` / \`updateLayout\` / \`updateDashboardMeta\` are SAFE ops. They commit immediately to the user's draft (when drafts are enabled) or directly to published (legacy fallback). The user can discard the draft entirely via the Publish UI — but there is no per-edit undo, so favor "ask first" on ambiguous changes.
+- \`removeCard\` / \`updateCardSql\` are DESTRUCTIVE ops. They DON'T mutate immediately — they stage a ghost change the user accepts or discards inline. Surface a short confirmation ("Staged removal of <title> — accept to confirm or discard to keep it") rather than declaring the change as done.
 - Do NOT call \`executeSQL\` to mutate data — it is read-only. Use it to validate a card's query before calling \`addCard\`.
 - **Vision is available.** \`screenshotDashboard()\` captures the dashboard as the user currently sees it and feeds the PNG back to you as a multimodal image. Use it when the user asks about **spatial position** ("the card on the right", "the bottom row"), **visual layout** ("does this feel balanced?"), or any question where pixels are clearer than the card-id summary. The screenshot is cached and invalidated automatically on every successful mutation, so calling it twice in a row is cheap.
 

--- a/packages/api/src/lib/dashboard-screenshot.ts
+++ b/packages/api/src/lib/dashboard-screenshot.ts
@@ -23,10 +23,12 @@
  *     user already has a valid Better Auth cookie. We forward it to the
  *     headless browser instead of doing a fresh `signInEmail` per shot —
  *     dodges the rate-limit failure mode the spike hit.
- *   - **Draft-aware behavior**: gated on `ATLAS_DASHBOARD_DRAFTS_ENABLED`
- *     for forward-compat with #2364 (drafts foundation, not yet merged).
- *     v1 ships the published-only path; when #2364 lands, swap the URL
- *     and the cache key derivation below.
+ *   - **Per-(user, dashboard) cache key**: the hash mixes `userId` so a
+ *     future per-user draft view can invalidate cleanly. Today the snapshot
+ *     hash is computed from the published row only — a user with an active
+ *     draft sees the published PNG, not their draft view. Mixing the
+ *     draft pointer into `computeSnapshotHash` is tracked as a 1.4.7
+ *     follow-up; the existing cache shape already supports it.
  */
 
 import { createHash } from "node:crypto";
@@ -43,6 +45,14 @@ const log = createLogger("dashboard-screenshot");
 export type ScreenshotFailReason =
   | "no_db"
   | "dashboard_not_found"
+  /**
+   * Internal DB query for the snapshot hash failed (or returned an error
+   * reason we didn't enumerate). Distinct from `render_failed` so the
+   * route layer can map it to 500-with-requestId rather than 400 — and
+   * distinct from `dashboard_not_found` so a buggy `getDashboard`
+   * upstream cannot mask an infra outage as a 404.
+   */
+  | "dashboard_unavailable"
   | "render_failed"
   | "browser_unavailable";
 
@@ -110,10 +120,12 @@ function cacheSet(key: string, png: Buffer): void {
 }
 
 /**
- * Drop every cache entry for a dashboard. Wired to:
- *   - any accepted draft mutation through the bound editor tools (this slice)
- *   - any accepted stage from #2365 (when that lands — the staging module
- *     should call this on stage commit)
+ * Drop every cache entry for a dashboard. Called by:
+ *   - safe-op mutations through the bound editor tools (`addCard` /
+ *     `updateCard` / `updateLayout` / `updateDashboardMeta`).
+ *   - destructive-op stage acceptance via `acceptStagedChange` (#2365).
+ *   - publish via the `/draft/publish` route — published moved, every
+ *     editor's cached view is stale.
  *
  * Drops across ALL users — a mutation by user A invalidates user B's
  * cached view of the same dashboard too, because the published baseline
@@ -142,10 +154,9 @@ export function _screenshotCacheSize(): number {
 
 /**
  * Compute a deterministic hash of the dashboard's contents that flips on
- * any user-visible change. Today (published-only) this is title + per-card
- * id/title/sql/chartConfig/layout/position + updatedAt. When #2364
- * (drafts) ships, this should mix the user's draft pointer (which itself
- * mutates on every accepted edit) so the key naturally invalidates per-user.
+ * any user-visible change: title + per-card id/title/sql/chartConfig/layout
+ * /position + updatedAt. The cache key separately mixes in `userId` so a
+ * future per-user draft view can invalidate without touching this hash.
  */
 async function computeSnapshotHash(
   dashboardId: string,
@@ -155,7 +166,17 @@ async function computeSnapshotHash(
   if (!dash.ok) {
     if (dash.reason === "no_db") return { ok: false, reason: "no_db" };
     if (dash.reason === "not_found") return { ok: false, reason: "dashboard_not_found" };
-    return { ok: false, reason: "render_failed" };
+    // Any other failure reason (today "error"; future-proof against new
+    // ones the dashboards helper might add) is an infra failure, NOT a
+    // render failure and NOT a 404. Surface as `dashboard_unavailable`
+    // so the route layer can return 500-with-requestId. Collapsing the
+    // path to `render_failed` here would mask an internal DB outage
+    // (or worse, a buggy cross-org masking) as a Playwright problem.
+    log.warn(
+      { dashboardId, reason: dash.reason },
+      "computeSnapshotHash: dashboard lookup failed with non-not_found reason",
+    );
+    return { ok: false, reason: "dashboard_unavailable" };
   }
   const payload = {
     id: dash.data.id,
@@ -373,7 +394,26 @@ function parseCookieHeader(header: string): ParsedCookie[] {
     .map((part) => {
       const eq = part.indexOf("=");
       if (eq === -1) return { name: part, value: "" };
-      return { name: part.slice(0, eq).trim(), value: part.slice(eq + 1).trim() };
+      const name = part.slice(0, eq).trim();
+      const rawValue = part.slice(eq + 1).trim();
+      // Cookie values are percent-encoded per RFC 6265 when they carry
+      // characters outside the cookie-octet set (commonly `;`, `,`,
+      // `%`, whitespace). Better Auth session cookies are typically
+      // base64url so this is usually a no-op, but a percent-encoded
+      // value would otherwise be passed verbatim to Playwright and
+      // fail the auth handshake.
+      let value = rawValue;
+      try {
+        value = decodeURIComponent(rawValue);
+      } catch (err) {
+        // Malformed percent-escape — keep the raw value and log so the
+        // operator sees the drift. (Better Auth never emits these.)
+        log.debug(
+          { err: errorMessage(err), name },
+          "parseCookieHeader: cookie value not valid percent-encoded; using raw",
+        );
+      }
+      return { name, value };
     });
 }
 
@@ -384,11 +424,10 @@ function parseCookieHeader(header: string): ParsedCookie[] {
 /**
  * Render or fetch-from-cache a screenshot of the dashboard.
  *
- * TODO(#2364): when the drafts foundation lands, derive the snapshot hash
- * from the user's draft pointer (if any) instead of the published baseline.
- * Today (published-only) the cache key includes userId for forward-compat
- * symmetry only — every user gets the same PNG for the same published
- * snapshot.
+ * The snapshot hash is derived from the published row only — a user with
+ * an active draft sees the published PNG, not their draft view. The
+ * cache key already mixes `userId` so a future "draft-aware hash" can
+ * land without changing the cache shape (1.4.7 follow-up).
  */
 export async function screenshotDashboard(opts: ScreenshotOpts): Promise<ScreenshotResult> {
   const startedAt = Date.now();
@@ -403,7 +442,9 @@ export async function screenshotDashboard(opts: ScreenshotOpts): Promise<Screens
           ? "Screenshots require an internal database."
           : snap.reason === "dashboard_not_found"
             ? "Dashboard not found."
-            : "Could not compute dashboard snapshot.",
+            : snap.reason === "dashboard_unavailable"
+              ? "Could not load the dashboard for rendering. The database may be temporarily unavailable — try again."
+              : "Could not compute dashboard snapshot.",
     };
   }
 

--- a/packages/api/src/lib/dashboard-versioning.ts
+++ b/packages/api/src/lib/dashboard-versioning.ts
@@ -36,18 +36,19 @@
  *     tools (`packages/api/src/lib/tools/bound-dashboard.ts`) route
  *     mutations through `applyChangeToDraft` + `saveDraft` when the
  *     `ATLAS_DASHBOARD_DRAFTS_ENABLED` flag is on.
+ *  4. `DraftChange` extended with `removeCard` + `editSql` variants
+ *     in #2365 so the stage-tracker can replay accepted destructive
+ *     ops through the same `applyChangeToDraft` path.
+ *  5. `materializeDraftView` powers `GET /:id?view=draft` so the
+ *     editor sees their draft state without touching the published
+ *     dashboard row that other viewers see.
  *
- * Out of scope for this slice (#2364):
- *  - The destructive-op stage tracker (#2365) — `removeCard` / `updateCardSql`
- *    are NOT modelled here; they're still safe-op-only at the tool layer.
- *  - The Publish UI (#2521) — surface that calls `publishDraft`.
- *  - The "your baseline has changed" banner — read-side of #2521.
- *
- * Feature-flag note: `ATLAS_DASHBOARD_DRAFTS_ENABLED` defaults to false.
- * `isDashboardDraftsEnabled()` is the single gate; the bound editor
- * tools check it before routing through this module. When OFF, the
- * tools mutate `dashboards` / `dashboard_cards` directly (legacy
- * behavior preserved).
+ * Feature-flag note: `ATLAS_DASHBOARD_DRAFTS_ENABLED` defaults to TRUE
+ * as of #2521. `isDashboardDraftsEnabled()` is the single gate; the
+ * bound editor tools check it before routing through this module.
+ * Setting the env to `"false"` (exact match) opts back into the
+ * legacy direct-published path for operators who want to disable the
+ * draft surface entirely.
  */
 
 import { createLogger } from "@atlas/api/lib/logger";
@@ -73,12 +74,10 @@ const log = createLogger("dashboard-versioning");
 // ---------------------------------------------------------------------------
 
 /**
- * Whether the per-user-draft routing is active. Defaults to TRUE as of
- * #2521 — the Publish UI shipped in the same slice that flipped this
- * default, so every editor now routes through drafts by default. Set
- * `ATLAS_DASHBOARD_DRAFTS_ENABLED=false` (exact string match) to opt out
- * — operators who want the pre-#2364 last-write-wins behavior must
- * explicitly disable it.
+ * Whether the per-user-draft routing is active. Defaults to TRUE.
+ * Setting `ATLAS_DASHBOARD_DRAFTS_ENABLED=false` (exact string match)
+ * opts back into the legacy direct-published path for operators who
+ * want to disable the draft surface entirely.
  *
  * The strict-string match is deliberate: "0" / "no" / "off" do NOT
  * disable, so a typo in an opt-out env var fails closed (drafts stay
@@ -103,7 +102,12 @@ export function isDashboardDraftsEnabled(): boolean {
  * fields; it never mutates share tokens or schedules.
  */
 export interface DashboardSnapshotCard {
-  /** Card id. NULL-string for cards added inside the draft and not yet persisted with a UUID. */
+  /**
+   * Card id. The bound editor tools (`addCard`, `createDashboard`)
+   * mint a fresh UUID at the moment a card is staged into the draft,
+   * so this is always a populated UUID — the publish path uses the
+   * same id when inserting the row into `dashboard_cards`.
+   */
   id: string;
   position: number;
   title: string;
@@ -320,16 +324,19 @@ export type PublishMergeResult =
  *   4. Card in draft, present in baseline+published, only the draft side
  *      changed → update published.
  *
- *   5. Card in baseline + published but absent from draft → no-op. The
- *      slice #2364 does NOT model card removal in the draft (no
- *      destructive ops yet). Adding `removeCard` to `DraftChange` is
- *      the #2365 slice's job; this branch will then translate to a
- *      `deleteCard` op.
+ *   5. Card in baseline + published but absent from draft → translates
+ *      to a `deleteCard` op (the user removed the card via #2365's
+ *      `removeCard` stage; the snapshot reflects the post-accept state).
  *
  *   6. Meta (title / description) — overwrite whenever the draft's value
  *      differs from published's current value. No baseline check because
  *      the meta is small and intent is usually "I changed the title,
- *      publish it." A future slice can tighten this.
+ *      publish it." Note this is the one *silent-overwrite* carve-out in
+ *      an otherwise conflict-aware merge: two users renaming the title
+ *      off the same baseline will have the second publisher's value win
+ *      without a 409. The stale-baseline guard in `publishDraft` makes
+ *      this rare in practice (rebase is forced when published has
+ *      moved), and meta is the cheapest field to re-edit by hand.
  *
  * Pure: no DB, no IO.
  */
@@ -512,8 +519,7 @@ export function rebaseDraftSnapshot(
     if (!dCard) {
       // Draft never had this card. Either it's net-new in published
       // (carry it forward) or it existed in baseline but the draft
-      // removed it (#2364 doesn't model removal, so this branch can't
-      // hit today; #2365 will care).
+      // removed it via a `removeCard` change (#2365).
       mergedCards.push(np);
       continue;
     }
@@ -739,7 +745,18 @@ export async function discardDraft(userId: string, dashboardId: string): Promise
 
 export type PublishDraftResult =
   | { ok: true; opsApplied: number }
-  | { ok: false; reason: "no_db" | "no_draft" | "dashboard_missing" | "stale_baseline" | "error" }
+  | { ok: false; reason: "no_db" | "no_draft" | "dashboard_not_found" | "error" }
+  | {
+      ok: false;
+      reason: "stale_baseline";
+      /**
+       * The published row's `updated_at` at the moment the publish was
+       * refused. The UI uses this to render "X changed since you last
+       * loaded the draft" without a second round-trip — it's the same
+       * timestamp `rebaseDraft` would set as the new `publishedBaselineAt`.
+       */
+      currentBaselineAt: string;
+    }
   | { ok: false; reason: "conflict"; conflicts: PublishConflict[] };
 
 /**
@@ -772,19 +789,23 @@ export async function publishDraft(opts: {
   if (!draftRow) return { ok: false, reason: "no_draft" };
 
   const published = await opts.loadDashboardForOrg(opts.dashboardId, opts.orgId);
-  if (!published) return { ok: false, reason: "dashboard_missing" };
+  if (!published) return { ok: false, reason: "dashboard_not_found" };
 
-  // Stale-baseline guard: when published has moved since the user
-  // forked, force the user to rebase first. The route layer surfaces
-  // this as a 409 with `reason: "stale_baseline"` so the UI can prompt
-  // for rebase. Even though `publishDraftMerge` is correct with the
-  // persisted baseline, requiring rebase here ensures the user has
-  // SEEN the changes before they publish over them — refusing to
-  // diff-merge without an explicit rebase is the "your baseline has
-  // changed" user-experience the PRD's user story 13 calls out.
-  // (CLAUDE.md "prefer errors over silent fallbacks".)
+  // Stale-baseline guard (early path). When published has moved since
+  // the user forked, refuse to publish and surface the new baseline so
+  // the UI can render "X changed since you last loaded the draft"
+  // without a second round-trip. The route layer maps this to a 409
+  // with `reason: "stale_baseline"`. Even though `publishDraftMerge`
+  // would be correct against the persisted baseline, requiring an
+  // explicit rebase ensures the user has SEEN the changes before
+  // publishing over them — PRD user story 13 + CLAUDE.md "prefer
+  // errors over silent fallbacks".
+  //
+  // This pre-check avoids opening a transaction in the common no-race
+  // case; the real serialization happens inside the transaction below
+  // (`SELECT … FOR UPDATE`).
   if (published.updatedAt !== draftRow.publishedBaselineAt) {
-    return { ok: false, reason: "stale_baseline" };
+    return { ok: false, reason: "stale_baseline", currentBaselineAt: published.updatedAt };
   }
 
   const merge = publishDraftMerge(
@@ -800,6 +821,33 @@ export async function publishDraft(opts: {
   const client = await pool.connect();
   try {
     await client.query("BEGIN");
+
+    // Stale-baseline guard (transactional path). The early check above
+    // closes the common case; this re-check inside the transaction
+    // serializes concurrent publishes against each other so two users
+    // both passing the early check can't both write — `FOR UPDATE`
+    // takes the row lock until COMMIT/ROLLBACK, and the second caller
+    // sees the first caller's bumped `updated_at` after it re-reads.
+    // Without this guard the second publish would apply its ops on
+    // top of the first's state silently, defeating the "your baseline
+    // has changed" promise.
+    const lockResult = await client.query(
+      `SELECT updated_at FROM dashboards
+        WHERE id = $1 AND deleted_at IS NULL
+        FOR UPDATE`,
+      [opts.dashboardId],
+    );
+    const lockedRow = lockResult.rows[0] as { updated_at: Date | string } | undefined;
+    if (!lockedRow) {
+      await client.query("ROLLBACK");
+      return { ok: false, reason: "dashboard_not_found" };
+    }
+    const lockedBaselineAt = String(lockedRow.updated_at);
+    if (lockedBaselineAt !== draftRow.publishedBaselineAt) {
+      await client.query("ROLLBACK");
+      return { ok: false, reason: "stale_baseline", currentBaselineAt: lockedBaselineAt };
+    }
+
     let opsApplied = 0;
     for (const op of merge.ops) {
       switch (op.kind) {
@@ -902,7 +950,7 @@ export async function publishDraft(opts: {
 
 export type RebaseDraftResult =
   | { ok: true; snapshot: DashboardSnapshot; newBaselineAt: string }
-  | { ok: false; reason: "no_db" | "no_draft" | "dashboard_missing" | "error" }
+  | { ok: false; reason: "no_db" | "no_draft" | "dashboard_not_found" | "error" }
   | { ok: false; reason: "conflict"; conflicts: PublishConflict[] };
 
 /**
@@ -922,7 +970,7 @@ export async function rebaseDraft(opts: {
   const draftRow = await loadDraft(opts.userId, opts.dashboardId);
   if (!draftRow) return { ok: false, reason: "no_draft" };
   const published = await opts.loadDashboardForOrg(opts.dashboardId, opts.orgId);
-  if (!published) return { ok: false, reason: "dashboard_missing" };
+  if (!published) return { ok: false, reason: "dashboard_not_found" };
 
   // Rebase is a no-op when nothing has moved on published since the
   // user forked. Fast-forward returns the existing snapshot + the same
@@ -991,35 +1039,52 @@ export function materializeDraftView(
   published: DashboardWithCards,
   draft: DashboardSnapshot,
 ): DashboardWithCards {
+  // For card timestamps we forward the published row's `updatedAt` —
+  // the draft doesn't track per-card timestamps and stamping a fresh
+  // `new Date()` here would make a draft view's cards look like they
+  // were "edited just now" every time it's rendered. Falling back to
+  // the parent dashboard's timestamp is the closest non-misleading
+  // value; the API consumer that cares about per-card timestamps
+  // should hit the published view, not the draft overlay.
+  const fallbackTimestamp = published.updatedAt;
+  // Preserve any cached columns/rows from the matching published card
+  // so the draft overlay doesn't render with empty placeholders when
+  // the user hasn't actually changed the card's SQL.
+  const publishedById = new Map(published.cards.map((c) => [c.id, c]));
   return {
     ...published,
     title: draft.title,
     description: draft.description,
-    cards: draft.cards.map((c, idx) => snapshotCardToDashboardCard(c, published.id, idx)),
+    cards: draft.cards.map((c) =>
+      snapshotCardToDashboardCard(c, published.id, fallbackTimestamp, publishedById.get(c.id)),
+    ),
   };
 }
 
 function snapshotCardToDashboardCard(
   c: DashboardSnapshotCard,
   dashboardId: string,
-  fallbackIndex: number,
+  fallbackTimestamp: string,
+  publishedCard?: DashboardCard,
 ): DashboardCard {
   // Best-effort row → card via the existing helper for consistency
   // with the published read path.
   return rowToCard({
     id: c.id,
     dashboard_id: dashboardId,
-    position: c.position ?? fallbackIndex,
+    // `DashboardSnapshotCard.position` is required (number), so the
+    // `??` previously here was dead-code. Use as-is.
+    position: c.position,
     title: c.title,
     sql: c.sql,
     chart_config: c.chartConfig,
-    cached_columns: null,
-    cached_rows: null,
-    cached_at: null,
+    cached_columns: publishedCard?.cachedColumns ?? null,
+    cached_rows: publishedCard?.cachedRows ?? null,
+    cached_at: publishedCard?.cachedAt ?? null,
     connection_group_id: c.connectionGroupId,
     layout: c.layout,
-    created_at: new Date().toISOString(),
-    updated_at: new Date().toISOString(),
+    created_at: publishedCard?.createdAt ?? fallbackTimestamp,
+    updated_at: publishedCard?.updatedAt ?? fallbackTimestamp,
   });
 }
 

--- a/packages/api/src/lib/db/migrations/0083_dashboard_stage_changes.sql
+++ b/packages/api/src/lib/db/migrations/0083_dashboard_stage_changes.sql
@@ -1,4 +1,4 @@
--- 0080 — Per-user staged destructive ops on dashboards (#2365, PRD #2362).
+-- 0083 — Per-user staged destructive ops on dashboards (#2365, PRD #2362).
 --
 -- The bound chat agent's destructive ops (`removeCard`, `updateCardSql`)
 -- do NOT mutate the user's draft directly. They stage as ghost changes

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -1701,7 +1701,7 @@ export const dashboardUserDrafts = pgTable(
   ],
 );
 
-// 0080 — Per-user staged destructive ops on dashboards (#2365, PRD #2362).
+// 0083 — Per-user staged destructive ops on dashboards (#2365, PRD #2362).
 // The bound chat agent's `removeCard` and `updateCardSql` tools do NOT
 // mutate the draft directly; they queue a row here. Accepting a stage
 // applies the change to the draft via the versioning module; discarding

--- a/packages/api/src/lib/stage-tracker.ts
+++ b/packages/api/src/lib/stage-tracker.ts
@@ -51,8 +51,10 @@ import {
   applyChangeToDraft,
   forkOrLoadDraft,
   type DraftChange,
+  type DashboardSnapshot,
 } from "@atlas/api/lib/dashboard-versioning";
 import { getDashboard } from "@atlas/api/lib/dashboards";
+import { invalidateDashboardScreenshot } from "@atlas/api/lib/dashboard-screenshot";
 
 const log = createLogger("stage-tracker");
 
@@ -383,12 +385,47 @@ export async function acceptStagedChange(opts: {
   const client = await pool.connect();
   try {
     await client.query("BEGIN");
+
+    // Re-load the draft under FOR UPDATE so any safe-op writes that
+    // landed between our pre-tx `forkOrLoadDraft` (line above) and now
+    // are picked up. Without this re-read the stage acceptance would
+    // overwrite the user's interleaved safe-op edit (lost-update
+    // window). The pre-tx `applied.snapshot` is discarded if the draft
+    // row has moved; we re-apply against the fresh snapshot inside the
+    // lock so the transaction commits a strictly monotonic draft.
+    // (review-2-followup: race fix for #2365 acceptStagedChange.)
+    const draftLock = await client.query(
+      `SELECT draft FROM dashboard_user_drafts
+        WHERE user_id = $1 AND dashboard_id = $2
+        FOR UPDATE`,
+      [opts.userId, row.dashboardId],
+    );
+    const draftLockRow = draftLock.rows[0] as { draft: unknown } | undefined;
+    if (!draftLockRow) {
+      // Draft was discarded between fork-or-load and now (rare).
+      await client.query("ROLLBACK");
+      return { ok: false, reason: "no_draft" };
+    }
+    const draftRaw = draftLockRow.draft;
+    const currentSnapshot: DashboardSnapshot =
+      typeof draftRaw === "string"
+        ? (JSON.parse(draftRaw) as DashboardSnapshot)
+        : (draftRaw as DashboardSnapshot);
+    const reapplied = applyChangeToDraft(currentSnapshot, transition.change);
+    if (!reapplied.ok) {
+      // The card the stage targets is no longer in the draft — likely a
+      // safe-op `removeCard` racing this accept. Surface as unknown_card
+      // so the UI clears the stage and the user can retry against the
+      // fresh snapshot.
+      await client.query("ROLLBACK");
+      return { ok: false, reason: "unknown_card" };
+    }
     await client.query(
       `UPDATE dashboard_user_drafts
           SET draft = $1::jsonb,
               updated_at = now()
         WHERE user_id = $2 AND dashboard_id = $3`,
-      [JSON.stringify(applied.snapshot), opts.userId, row.dashboardId],
+      [JSON.stringify(reapplied.snapshot), opts.userId, row.dashboardId],
     );
     const updateRows = await client.query(
       `UPDATE dashboard_stage_changes
@@ -401,13 +438,19 @@ export async function acceptStagedChange(opts: {
                   created_at, updated_at, applied_at, discarded_at`,
       [opts.stageId, opts.userId],
     );
-    await client.query("COMMIT");
     if (updateRows.rows.length === 0) {
-      // The row flipped under us between the load and the UPDATE — surface
-      // as not_found so the UI re-fetches the stage list. The transaction
-      // committed an idempotent draft update; the next render reconciles.
+      // The stage row flipped under us (concurrent accept or discard)
+      // between the pre-tx load and now. Rollback the draft write so
+      // we don't commit an apply on top of a status the user already
+      // resolved differently. Surface as not_found so the UI re-fetches.
+      await client.query("ROLLBACK");
       return { ok: false, reason: "not_found" };
     }
+    await client.query("COMMIT");
+    // The draft snapshot moved; any cached screenshot keyed on the
+    // old draft is now stale. The screenshot module's TTL is a
+    // backstop; the explicit invalidate is the primary contract.
+    invalidateDashboardScreenshot(row.dashboardId);
     return {
       ok: true,
       stage: rowToStagedChange(updateRows.rows[0]!),

--- a/packages/api/src/lib/tools/bound-dashboard.ts
+++ b/packages/api/src/lib/tools/bound-dashboard.ts
@@ -202,7 +202,7 @@ export function createBoundDashboardTools(
   });
 
   const addCardTool = tool({
-    description: `Add a new card to the dashboard. Validates the SQL against the analytics datasource before persisting; if validation fails the card is NOT added and the error is returned so you can fix it and retry. Use AFTER \`executeSQL\` has confirmed the column names — \`chartConfig.categoryColumn\` and \`valueColumns\` must match the SQL output. The grid is 24 columns wide; layout is optional (auto-laid below the lowest existing card when omitted).`,
+    description: `Add a new card to the dashboard. Validates the SQL against the analytics datasource before persisting; if validation fails the card is NOT added and the error is returned so you can fix it and retry. Use AFTER \`executeSQL\` has confirmed the column names — \`chartConfig.categoryColumn\` and \`valueColumns\` must match the SQL output. The grid is 24 columns wide. Layout is optional — when omitted the card stages with no placement and the grid renderer auto-arranges it at view time. Pass a layout if you want a specific {x, y, w, h} on the 24-column grid.`,
     inputSchema: z.object({
       title: z.string().min(1).max(200).describe("Card title (visible to the user)"),
       sql: z.string().min(1).describe("Read-only SELECT query"),
@@ -224,10 +224,14 @@ export function createBoundDashboardTools(
         // updateCard / updateLayout calls in the same session resolve.
         const draftCard: DashboardSnapshotCard = {
           id: crypto.randomUUID(),
-          // Position is recomputed at publish time when the merge runs;
-          // for the in-progress draft, append at the end of the current
-          // snapshot. The agent doesn't care about exact positions in
-          // an editing session — only at view + publish time.
+          // Position is left at 0 for the in-progress draft; the
+          // dashboard renderer's auto-layout (`withAutoLayout`)
+          // assigns a tile placement at view time, and the publish
+          // path inserts the row with the post-merge position. The
+          // agent should call `updateLayout` if it wants a specific
+          // placement; the chat surface doesn't need positions to
+          // disambiguate cards (the bound prompt's card summary uses
+          // ids).
           position: 0,
           title,
           sql,

--- a/packages/api/src/lib/tools/create-dashboard.ts
+++ b/packages/api/src/lib/tools/create-dashboard.ts
@@ -144,6 +144,12 @@ If any card has invalid SQL the whole call is rejected — no dashboard row is c
     }
     const ownerId = user.id;
     const orgId = user.activeOrganizationId ?? null;
+    // #2369 follow-up: honor the conversation's content scope so a
+    // chat created in a specific environment (1.4.4) produces cards
+    // bound to that environment. Without this, every chat-created
+    // dashboard's cards default to the workspace `default` group view
+    // regardless of which env the conversation was in.
+    const conversationGroupId = reqCtx?.connectionGroupId ?? null;
 
     try {
       // ---- per-card SQL validation (BEFORE opening transaction) ----
@@ -218,7 +224,7 @@ If any card has invalid SQL the whole call is rejected — no dashboard row is c
           title: v.card.title,
           sql: v.card.sql,
           chartConfig: v.card.chartConfig,
-          connectionGroupId: null,
+          connectionGroupId: conversationGroupId,
           layout: v.card.layout ?? null,
         }));
 
@@ -240,10 +246,17 @@ If any card has invalid SQL the whole call is rejected — no dashboard row is c
           cards: [],
         };
 
+        // ON CONFLICT DO NOTHING mirrors `forkOrLoadDraft`'s shape so
+        // both write paths converge if a future code path ever calls
+        // `createDashboard` against an existing dashboardId — today the
+        // composite PK collision is impossible (brand-new UUID), but
+        // the symmetry keeps a confusing PK violation from ever
+        // bypassing the sanitized error envelope this tool returns.
         await client.query(
           `INSERT INTO dashboard_user_drafts
              (user_id, dashboard_id, draft, baseline, published_baseline_at)
-           VALUES ($1, $2, $3::jsonb, $4::jsonb, $5)`,
+           VALUES ($1, $2, $3::jsonb, $4::jsonb, $5)
+           ON CONFLICT (user_id, dashboard_id) DO NOTHING`,
           [
             ownerId,
             dashboardId,

--- a/packages/types/src/errors.ts
+++ b/packages/types/src/errors.ts
@@ -187,6 +187,12 @@ export const CHAT_CONTEXT_WARNING_CODES = [
   "semantic_layer_unavailable",
   "learned_patterns_unavailable",
   "plan_limit_warning",
+  // 1.4.6 — chat-as-dashboard-editor. The drawer-side chat requested a
+  // bind to a dashboard but the bind / resolve failed (dashboard
+  // deleted, internal DB transient outage, race). Without this signal
+  // the chat silently degrades to the default agent and the user gets
+  // a "agent ignores my edits" experience.
+  "bound_dashboard_unavailable",
 ] as const;
 
 export type ChatContextWarningCode = (typeof CHAT_CONTEXT_WARNING_CODES)[number];

--- a/packages/web/src/app/(workspace)/dashboards/[id]/page.tsx
+++ b/packages/web/src/app/(workspace)/dashboards/[id]/page.tsx
@@ -123,6 +123,13 @@ export default function DashboardViewPage() {
   // /:id/draft` (which forks-on-first-call) on every page load.
   const [draftView, setDraftView] = useState<DashboardWithCards | null>(null);
   const [draftViewLoading, setDraftViewLoading] = useState(false);
+  // Separate from the useAdminMutation `draftError` below so a failed
+  // GET on the draft view (which doesn't go through the mutation hook)
+  // can surface to the Publish modal without colliding with mutation
+  // errors. Without this, a failed GET silently produced an empty
+  // modal with no diff and a disabled Publish button — invisible to
+  // anyone not watching devtools.
+  const [draftViewError, setDraftViewError] = useState<string | null>(null);
 
   // Dedicated mutation hook for draft ops. We want a separate error
   // surface from the shared `mutate` above (which is reused for card +
@@ -343,6 +350,7 @@ export default function DashboardViewPage() {
   // modal's own banner rather than the page's.
   async function handleOpenPublishModal() {
     clearDraftError();
+    setDraftViewError(null);
     setPublishModalOpen(true);
     setDraftView(null);
     setDraftViewLoading(true);
@@ -354,14 +362,22 @@ export default function DashboardViewPage() {
         const json = (await res.json()) as DraftViewResponse;
         setDraftView(json.view ?? null);
       } else {
-        console.debug(`[dashboard] Failed to fetch draft view: ${res.status}`);
+        // Surface the failure to the modal banner. Without this the
+        // modal opens with no diff, the Publish button stays disabled,
+        // and the user has no signal that the fetch failed — the
+        // console.debug fallback was invisible to anyone not watching
+        // devtools.
+        const body = await res.json().catch(() => ({} as Record<string, unknown>));
+        const rid = typeof body?.requestId === "string" ? body.requestId : null;
+        const msg = typeof body?.message === "string"
+          ? body.message
+          : `Could not load draft view (${res.status}).`;
+        setDraftViewError(rid ? `${msg} (request ${rid})` : msg);
         setDraftView(null);
       }
     } catch (err) {
-      console.debug(
-        "[dashboard] Network error fetching draft view:",
-        err instanceof Error ? err.message : String(err),
-      );
+      const detail = err instanceof Error ? err.message : String(err);
+      setDraftViewError(`Network error fetching draft view: ${detail}`);
       setDraftView(null);
     } finally {
       setDraftViewLoading(false);
@@ -686,6 +702,7 @@ export default function DashboardViewPage() {
         loading={draftViewLoading}
         publishing={publishing}
         error={draftError}
+        viewError={draftViewError}
         onConfirm={handleConfirmPublish}
       />
     </StageProvider>

--- a/packages/web/src/ui/components/chat/stage-change-card.tsx
+++ b/packages/web/src/ui/components/chat/stage-change-card.tsx
@@ -83,10 +83,24 @@ function StageChangeCardInner({ stage }: { stage: StageRequiredPayload }) {
         },
       );
       if (!response.ok) {
-        const body = await response.json().catch(() => ({} as Record<string, unknown>));
-        const msg = typeof body?.message === "string" ? body.message : `Could not ${action} the stage.`;
+        const body = await response.json().catch((parseErr: unknown) => {
+          // Server returned non-JSON (proxy error page, gateway timeout,
+          // HTML 5xx) — log to devtools so a debugging operator sees the
+          // parse failure with a correlation hint from the response status.
+          console.debug(
+            `[stage-change-card] non-JSON ${response.status} response on ${action}:`,
+            parseErr instanceof Error ? parseErr.message : String(parseErr),
+          );
+          return {} as Record<string, unknown>;
+        });
+        const msg = typeof body?.message === "string"
+          ? body.message
+          : `Could not ${action} the stage.`;
+        // Surface `requestId` to the user so support tickets carry a
+        // correlation key the API logs can be searched by.
+        const rid = typeof body?.requestId === "string" ? body.requestId : null;
         setResolution("error");
-        setErrMessage(msg);
+        setErrMessage(rid ? `${msg} (request ${rid})` : msg);
         return;
       }
       setResolution(action === "accept" ? "accepted" : "discarded");

--- a/packages/web/src/ui/components/dashboards/bound-chat-drawer.tsx
+++ b/packages/web/src/ui/components/dashboards/bound-chat-drawer.tsx
@@ -15,10 +15,11 @@
  *     transcript panel rendering messages with the same Markdown +
  *     ToolPart components used in the live drawer.
  *
- * Last-write-wins is intentional in this tracer-bullet: safe mutations
- * (addCard, updateCard title/chartConfig/layout, updateDashboardMeta)
- * commit immediately to the published dashboard. Drafts arrive in
- * #2364; destructive ops + ghost overlays in #2365.
+ * Safe mutations (addCard, updateCard title/chartConfig/layout,
+ * updateDashboardMeta) commit immediately to the user's draft. The
+ * Publish UI on the dashboard page promotes the draft to published
+ * via a diff-confirm modal. Destructive ops (removeCard, updateCardSql)
+ * stage as ghost overlays the user accepts or discards inline.
  */
 
 import { useState, useRef, useEffect, useCallback, useMemo } from "react";
@@ -54,7 +55,7 @@ interface BoundChatDrawerProps {
   /**
    * Called whenever a tool completes — the dashboard view re-fetches so
    * the new card / updated title / new layout shows up immediately. The
-   * tracer-bullet doesn't try to be surgical about which tools warrant
+   * drawer doesn't try to be surgical about which tools warrant
    * a refetch; every tool result triggers one. Plenty of room for
    * smarter invalidation in a follow-up.
    */
@@ -150,11 +151,43 @@ export function BoundChatDrawer({
     // `useChat` instance below picks up the cleared conversation ref.
   }, [apiUrl, isCrossOrigin, dashboardId, sessionKey]);
 
+  // `bound_dashboard_unavailable` warnings are pushed by the chat route
+  // when bind/resolve failed and the request had explicitly asked to be
+  // bound. Without surfacing them the drawer would silently run the
+  // default agent ("I'd love to help… but I can't see any dashboard")
+  // and the user would never know their edits weren't being captured.
+  const [boundUnavailable, setBoundUnavailable] = useState<{
+    title: string;
+    detail: string;
+  } | null>(null);
+
+  // Clear the warning between sessions so a previous run's banner
+  // doesn't leak into the new conversation.
+  useEffect(() => {
+    if (open) setBoundUnavailable(null);
+  }, [open, sessionKey]);
+
+  const handleStreamData = useCallback((dataPart: { type: string; data: unknown }) => {
+    if (dataPart.type !== "data-context-warning") return;
+    const data = dataPart.data as
+      | { code?: string; title?: string; detail?: string }
+      | null
+      | undefined;
+    if (!data || data.code !== "bound_dashboard_unavailable") return;
+    setBoundUnavailable({
+      title: typeof data.title === "string" ? data.title : "Dashboard editing unavailable",
+      detail:
+        typeof data.detail === "string"
+          ? data.detail
+          : "Edits in this chat won't take effect. Reopen the drawer to retry.",
+    });
+  }, []);
+
   const { messages, sendMessage, status, error } = useChat({
     transport,
-    // useChat re-mounts when the key on the calling component changes.
-    // We don't need onData here — bound mode doesn't surface Python
-    // progress and the bound editor tools don't emit custom data parts.
+    // Subscribe to the same `data-context-warning` channel the main
+    // chat uses so the bound flow can surface bind/resolve failures.
+    onData: handleStreamData as never,
   });
 
   const isLoading = status === "streaming" || status === "submitted";
@@ -166,16 +199,16 @@ export function BoundChatDrawer({
   // (cheap, but explicit).
   const lastMsg = messages[messages.length - 1];
   const lastMsgId = lastMsg?.id;
-  const lastMsgToolFingerprint = useMemo(() => {
-    if (!lastMsg || lastMsg.role !== "assistant") return "";
-    let fp = "";
+  // Pure derived string. React Compiler memoizes; manual useMemo
+  // was forbidden by CLAUDE.md for perf-only cases.
+  let lastMsgToolFingerprint = "";
+  if (lastMsg && lastMsg.role === "assistant") {
     for (const part of lastMsg.parts ?? []) {
       if (!isToolUIPart(part)) continue;
       const p = part as { state?: string; toolCallId?: string };
-      fp += `${p.toolCallId ?? ""}:${p.state ?? ""};`;
+      lastMsgToolFingerprint += `${p.toolCallId ?? ""}:${p.state ?? ""};`;
     }
-    return fp;
-  }, [lastMsg]);
+  }
 
   useEffect(() => {
     if (!onDashboardMutated || !lastMsgToolFingerprint) return;
@@ -188,16 +221,13 @@ export function BoundChatDrawer({
     }
   }, [lastMsgToolFingerprint, lastMsgId, onDashboardMutated]);
 
-  const handleSubmit = useCallback(
-    async (e: React.FormEvent<HTMLFormElement>) => {
-      e.preventDefault();
-      const text = input.trim();
-      if (!text || isLoading) return;
-      setInput("");
-      await sendMessage({ text });
-    },
-    [input, isLoading, sendMessage],
-  );
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const text = input.trim();
+    if (!text || isLoading) return;
+    setInput("");
+    await sendMessage({ text });
+  }
 
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
@@ -255,6 +285,17 @@ export function BoundChatDrawer({
               {isLoading && messages[messages.length - 1]?.role === "user" && (
                 <div className="my-2">
                   <TypingIndicator />
+                </div>
+              )}
+
+              {boundUnavailable && (
+                <div
+                  role="alert"
+                  data-testid="bound-unavailable-banner"
+                  className="my-3 rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-xs text-amber-800 dark:border-amber-900/50 dark:bg-amber-950/20 dark:text-amber-300"
+                >
+                  <div className="font-medium">{boundUnavailable.title}</div>
+                  <div className="mt-1">{boundUnavailable.detail}</div>
                 </div>
               )}
 
@@ -419,10 +460,7 @@ function HistoryTranscriptPanel({
     `/api/v1/dashboards/${dashboardId}/sessions/${sessionId}`,
   );
 
-  const transformed = useMemo(
-    () => (data ? transformMessages(data.messages) : []),
-    [data],
-  );
+  const transformed = data ? transformMessages(data.messages) : [];
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">

--- a/packages/web/src/ui/components/dashboards/dashboard-diff.ts
+++ b/packages/web/src/ui/components/dashboards/dashboard-diff.ts
@@ -6,10 +6,9 @@
  * `GET /:id/draft`), compute the user-facing change set:
  *
  *   - added: cards present in the draft, absent from published
- *   - removed: cards present in published, absent from the draft
- *     (NOTE: the #2364 slice does not yet support removing cards in the
- *     draft path, so this list is empty today; the modal still renders
- *     the row so a future slice can light it up without a UI rewrite)
+ *   - removed: cards present in published, absent from the draft —
+ *     populated when the user has accepted a `removeCard` stage (#2365)
+ *     that the apply path dropped from the draft snapshot
  *   - changed: cards present in both, with at least one field differing
  *     (title / sql / chartConfig / connectionGroupId / layout)
  *   - meta: title / description diff (independent of card-level diff)

--- a/packages/web/src/ui/components/dashboards/dashboard-grid.tsx
+++ b/packages/web/src/ui/components/dashboards/dashboard-grid.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import {
   GridLayout,
   useContainerWidth,
@@ -47,28 +47,25 @@ export function DashboardGrid({
 }: DashboardGridProps) {
   const { width, containerRef, mounted } = useContainerWidth();
   const [fullscreenId, setFullscreenId] = useState<string | null>(null);
-  const placed = useMemo(() => withAutoLayout(cards), [cards]);
+  // React Compiler memoizes pure derives; manual useMemo was forbidden
+  // by CLAUDE.md for perf-only cases.
+  const placed = withAutoLayout(cards);
   // Index stages by cardId. A single card can have multiple stages in
   // pathological cases (agent staged delete + the user clarified, agent
-  // restaged a SQL edit). The first pending one wins for overlay purposes
-  // — a definitive resolution flips one specific stage, the rest stay
-  // visible until they're individually accepted or discarded. Useful
-  // correctness invariant: the overlay never lies about WHICH stage is
-  // pending; it shows the most-recent pending one.
-  const stagesByCardId = useMemo(() => {
-    const map = new Map<string, StagedChange>();
-    for (const s of stages ?? []) {
-      if (s.status !== "pending") continue;
-      const cardId = (s.payload as { cardId?: string }).cardId;
-      if (!cardId) continue;
-      // Keep the most-recently-staged one — overlay reflects current intent.
-      const existing = map.get(cardId);
-      if (!existing || existing.createdAt < s.createdAt) {
-        map.set(cardId, s);
-      }
+  // restaged a SQL edit). The most-recently-staged pending one wins
+  // for overlay purposes — a definitive resolution flips one specific
+  // stage, the rest stay visible until they're individually accepted
+  // or discarded. The overlay reflects current intent.
+  const stagesByCardId = new Map<string, StagedChange>();
+  for (const s of stages ?? []) {
+    if (s.status !== "pending") continue;
+    const cardId = (s.payload as { cardId?: string }).cardId;
+    if (!cardId) continue;
+    const existing = stagesByCardId.get(cardId);
+    if (!existing || existing.createdAt < s.createdAt) {
+      stagesByCardId.set(cardId, s);
     }
-    return map;
-  }, [stages]);
+  }
 
   // Esc must exit fullscreen *before* the page-level handler exits edit mode,
   // so the user gets one Esc per dialog-like layer.

--- a/packages/web/src/ui/components/dashboards/publish-diff-modal.tsx
+++ b/packages/web/src/ui/components/dashboards/publish-diff-modal.tsx
@@ -42,6 +42,12 @@ interface PublishDiffModalProps {
   /** Result of POST /:id/draft/publish. Modal stays open on error so the user can read it. */
   publishing: boolean;
   error: FetchError | null;
+  /**
+   * Error from the initial GET /:id/draft fetch that powers the diff.
+   * Separate from `error` (which tracks the publish mutation) so an
+   * empty modal doesn't leave the user wondering why there's no diff.
+   */
+  viewError?: string | null;
   onConfirm: () => Promise<void> | void;
 }
 
@@ -52,6 +58,7 @@ export function PublishDiffModal({
   loading,
   publishing,
   error,
+  viewError,
   onConfirm,
 }: PublishDiffModalProps) {
   // Local "confirmed" guard avoids a double-submit when the user mashes
@@ -96,6 +103,16 @@ export function PublishDiffModal({
           {loading && (
             <div className="px-1 py-2 text-sm text-zinc-500 dark:text-zinc-400">
               Computing diff…
+            </div>
+          )}
+
+          {!loading && viewError && (
+            <div
+              role="alert"
+              data-testid="publish-diff-view-error"
+              className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700 dark:border-red-900/50 dark:bg-red-950/20 dark:text-red-400"
+            >
+              {viewError}
             </div>
           )}
 


### PR DESCRIPTION
## Summary

Aggregated fixes from the milestone-1.4.6 multi-agent review pass. Six specialist agents (code-reviewer / silent-failure-hunter / pr-test-analyzer / type-design-analyzer / comment-analyzer / code-simplifier) audited PRs #2525 / #2533 / #2534 / #2538 / #2542 / #2543 / #2544. **No new GH issues filed** — every finding is resolved here or in updated rationale comments.

### Race conditions (Tier 1)
- **`publishDraft`** now re-checks `dashboards.updated_at` inside the transaction under `FOR UPDATE`. Two concurrent publishes pre-fix could both pass the pre-tx guard and silently overwrite. `PublishDraftResult.stale_baseline` now carries `currentBaselineAt` for the UI.
- **`acceptStagedChange`** re-loads the draft snapshot inside its transaction under `FOR UPDATE`. The pre-fix path silently overwrote any safe-op edit that landed between the pre-tx `forkOrLoadDraft` and the tx-side write. Surfaces `unknown_card` / `no_draft` + ROLLBACK on the race cases.

### Error surfacing (Tier 2)
- **chat route** surfaces bind/resolve failures as a `bound_dashboard_unavailable` context-warning frame the drawer renders as a banner. Pre-fix: silent degrade-to-default-agent.
- **screenshot route**: `no_db` 404→503; new `dashboard_unavailable` reason distinguishes infra outages from real Playwright render failures.
- **`getSessionTranscript`** adds `LIMIT 1000` — runaway bound conversations no longer DoS the API.
- **Publish UI** surfaces `requestId`, stops swallowing JSON parse errors / `console.debug` on real failures, new `viewError` state for draft-view fetch vs. publish-mutation errors.

### Test gaps (Tier 3)
- **`acceptStagedChange`** — 5 new tests: happy path, in-tx unknown_card (race), in-tx no_draft (race), already-discarded rejection, cross-user 404. (Pre-fix: 0 tests despite docblock claiming coverage.)
- **`publishDraft`** — concurrent-publish-race test exercising the new `SELECT FOR UPDATE` lock + `stale_baseline.currentBaselineAt`.
- **`materializeDraftView`** — preserved cached_columns/rows pass-through + published.updatedAt fallback (was minting `new Date()` and making cards look freshly edited every render).

### Type design (Tier 4)
- Normalized `dashboard_missing` → `dashboard_not_found` across `BindResult` / `ResolveResult` / `PublishDraftResult` / `RebaseDraftResult` / `ScreenshotResult` (matches `getDashboard`'s reason + HTTP 404 vocabulary).

### Code quality (Tier 5)
- Dropped `useMemo` / `useCallback` for performance in `bound-chat-drawer.tsx` + `dashboard-grid.tsx` (per CLAUDE.md; React Compiler handles memoization). Kept correctness uses (`useChat` transport / onData ref).
- `messageCount` uses `Number()` instead of `parseInt`.
- Stage acceptance invalidates the screenshot cache (the comment promised the wire; it was missing).
- `parseCookieHeader` decodes percent-encoded values.
- `createDashboard` honors conversation `connectionGroupId`; INSERT adds `ON CONFLICT DO NOTHING` for symmetry with `forkOrLoadDraft`.
- `discardDraft` route propagates internal-DB failure as 500-with-requestId.

### Comment drift (Tier 6)
- Migration 0083 SQL header + schema.ts mirror block-comment said \"0080\" (rebase drift).
- architecture-wins #62: \"0074\" → \"0079\" for drafts migration.
- `BOUND_AGENT_PROMPT_GUIDANCE` now lists `removeCard` / `updateCardSql` / `screenshotDashboard` with stage-required semantics; dropped \"no undo in this tracer-bullet\" copy.
- Stale \"tracer-bullet\" / \"this slice doesn't yet\" comments updated.
- `addCardTool` description no longer lies about auto-layout.
- `dashboard-diff.ts` removed-list comment + `dashboard-versioning` Rule 5/6 prose updated.

## Test plan
- [x] `acceptStagedChange` 5 new tests pass.
- [x] `publishDraft` concurrent-publish-race test passes; existing transaction tests updated for new SELECT FOR UPDATE row.
- [x] `materializeDraftView` cached-fields + timestamp-fallback tests pass.
- [x] `bound-chat-context.getSessionTranscript` LIMIT 1000 assertion in existing test updated.
- [x] Full `bun run test` green.
- [x] `/ci` gates green: lint, type, syncpack, template drift, security-headers, railway-watch, schema drift, oauth-helper drift.