### PR TITLE
roadmap: open 1.5.1 — Architecture Deepening + park SaaS Trust cluster

### DIFF
--- a/.claude/research/ROADMAP.md
+++ b/.claude/research/ROADMAP.md
@@ -144,11 +144,15 @@ Full detail archived in [`ROADMAP-archive.md`](./ROADMAP-archive.md). Issues + P
 
 ## Active
 
-_No active milestone. 1.4.5 + 1.4.6 + 1.5.0 all closed 2026-05-17. Next milestone selection lives in `/next`._
+- **1.5.1 — Architecture Deepening** ([milestone #48](https://github.com/AtlasDevHQ/atlas/milestones/48), 3 issues) — internal refactors, no user-facing feature; each shippable independently. Pattern matches 0.9.3 + 0.9.4. Scope: invert core→ee dependency ([#2017](https://github.com/AtlasDevHQ/atlas/issues/2017) — 23 files import from `@atlas/ee`, hot path included), agent-auth provider on OAuth 2.1 ([#2058](https://github.com/AtlasDevHQ/atlas/issues/2058)), explore tool refactor ([#2123](https://github.com/AtlasDevHQ/atlas/issues/2123), unblocked now that multi-source shipped). [#2109](https://github.com/AtlasDevHQ/atlas/issues/2109) (durable MCP session store) + [#2055](https://github.com/AtlasDevHQ/atlas/issues/2055) (Redis-shaped perf) stay out of this milestone — both are trigger-gated by traffic, not scheduled work.
 
 ## Planned
 
 _None queued. See `/next` for candidates._
+
+## Parked
+
+- **SaaS Trust & Compliance** — clustered candidate ([#1928](https://github.com/AtlasDevHQ/atlas/issues/1928) SOC 2 + ISO 27001 + pen test + IR drills, [#1922](https://github.com/AtlasDevHQ/atlas/issues/1922) DPA PDF, [#1936](https://github.com/AtlasDevHQ/atlas/issues/1936) OpenStatus Starter). Not milestoned yet — promote when enterprise pipeline signals adoption pressure.
 
 ---
 


### PR DESCRIPTION
## Summary

Follow-up to the #2549 closeout: surface the new active milestone and a parked candidate.

- **Active: 1.5.1 — Architecture Deepening** ([milestone #48](https://github.com/AtlasDevHQ/atlas/milestone/48)) — scope is #2017 (invert core→ee dependency — 23 files import from `@atlas/ee`, hot path included), #2058 (agent-auth provider on OAuth 2.1), #2123 (explore tool refactor — unblocked now that multi-source shipped in 1.4.4).
- **Intentionally excluded from 1.5.1:** #2109 (durable MCP session store) + #2055 (Redis-shaped perf). Both are trigger-gated by traffic per their issue bodies, not scheduled work — putting them in a milestone would imply an unconditional start.
- **Parked: SaaS Trust & Compliance** — #1928 (SOC 2 + ISO 27001 + pen test + IR drills) + #1922 (DPA PDF) + #1936 (OpenStatus Starter). Promote to a milestone when enterprise pipeline signals adoption pressure.

Also created the `marketing-pass` label and applied to #2114 + #2550 + #2551 so the three useatlas.dev / docs surface items cluster on the board without inventing a milestone.

## Test plan

- [x] Milestone #48 created on GitHub with 3 issues assigned
- [x] `marketing-pass` label created and applied to 3 issues
- [ ] CI green