### PR TITLE
fix(api): admin onError preserves CORS+CSP headers for typed-response throws

### DIFF
--- a/packages/api/src/api/__tests__/ee-error-handler.test.ts
+++ b/packages/api/src/api/__tests__/ee-error-handler.test.ts
@@ -27,6 +27,35 @@ describe("eeOnError", () => {
     expect(body.error).toBe("enterprise_required");
   });
 
+  test("preserves upstream c.header() values when surfacing HTTPException.res (CORS regression)", async () => {
+    // Upstream middleware queues CORS + security headers via c.header(...) before the
+    // handler runs. Returning `err.res` directly used to drop them — the response
+    // would reach the network but the browser would reject it as "Failed to fetch"
+    // for cross-origin requests, breaking the /admin/semantic/raw YAML view.
+    // Routing through c.newResponse merges the queued headers in.
+    const app = createApp();
+    app.use("*", async (c, next) => {
+      c.header("Access-Control-Allow-Origin", "https://app.example.com");
+      c.header("X-Frame-Options", "DENY");
+      await next();
+    });
+    app.get("/raw", () => {
+      throw new HTTPException(200, {
+        res: new Response("table: users\n", {
+          status: 200,
+          headers: { "Content-Type": "text/plain; charset=utf-8" },
+        }),
+      });
+    });
+    const res = await app.request("/raw");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("https://app.example.com");
+    expect(res.headers.get("X-Frame-Options")).toBe("DENY");
+    // Original Content-Type from err.res must survive the merge.
+    expect(res.headers.get("Content-Type")).toContain("text/plain");
+    expect(await res.text()).toBe("table: users\n");
+  });
+
   test("maps framework 400 to bad_request JSON", async () => {
     const app = createApp();
     app.get("/test", () => {

--- a/packages/api/src/api/routes/admin.ts
+++ b/packages/api/src/api/routes/admin.ts
@@ -11,6 +11,7 @@ import * as fs from "fs";
 import * as path from "path";
 import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
 import { validationHook } from "./validation-hook";
+import { eeOnError } from "./ee-error-handler";
 import type { Context } from "hono";
 import { HTTPException } from "hono/http-exception";
 import { createLogger, withRequestContext, getRequestContext } from "@atlas/api/lib/logger";
@@ -237,13 +238,7 @@ async function verifyOrgMembership(
   }
 }
 
-admin.onError((err, c) => {
-  if (err instanceof HTTPException) {
-    if (err.res) return err.res;
-    if (err.status === 400) return c.json({ error: "bad_request", message: "Invalid JSON body." }, 400);
-  }
-  throw err;
-});
+admin.onError(eeOnError);
 
 admin.use(withRequestId);
 

--- a/packages/api/src/api/routes/ee-error-handler.ts
+++ b/packages/api/src/api/routes/ee-error-handler.ts
@@ -20,10 +20,19 @@ import { HTTPException } from "hono/http-exception";
  * framework validation). Bare 400s without a response body get a generic
  * JSON body for malformed-JSON errors. Everything else re-throws to
  * Hono's default handler.
+ *
+ * Typed responses (`err.res`) go through `c.newResponse` so the queued
+ * middleware headers — CORS, CSP, X-Frame-Options, etc. set by
+ * `app.use("/api/*", ...)` upstream — merge into the response. Returning
+ * `err.res` directly bypasses Hono's header pipeline, which strips CORS
+ * from any cross-origin response built via `throw new HTTPException(status,
+ * { res })`. #2037 fixed the same gap for streaming chat; this fix closes
+ * it for every admin/platform route that uses the throw-typed-response
+ * pattern (e.g. `/admin/semantic/raw/{file}`).
  */
 export function eeOnError(err: Error, c: Context): Response {
   if (err instanceof HTTPException) {
-    if (err.res) return err.res;
+    if (err.res) return c.newResponse(err.res.body, err.res);
     if (err.status === 400) {
       return c.json({ error: "bad_request", message: "Invalid JSON body." }, 400);
     }


### PR DESCRIPTION
## Summary

- `eeOnError` returned `err.res` directly when a handler threw `HTTPException(status, { res })`, bypassing Hono's header pipeline. Every header queued by upstream `/api/*` middleware (CORS, CSP, X-Frame-Options, etc.) was dropped.
- Same-origin dev proxy hid this. Cross-origin browsers rejected the response with `TypeError: Failed to fetch`, which surfaced as "Failed to load: Failed to fetch" when clicking the **YAML** toggle on `/admin/semantic` — `GET /admin/semantic/raw/{file}` builds its 200 body via `throw new HTTPException(200, { res })` and that's the call site that exposed the gap.
- Route the typed response through `c.newResponse(err.res.body, err.res)` so Hono merges the queued headers in. #2037 fixed the same pattern for streaming chat by setting CORS inside the handler — this closes it for every admin/platform route that uses the throw-typed-response shape without each handler having to copy CORS manually.
- Collapse the inline `admin.onError` in `admin.ts` to share `eeOnError` (duplicate logic, same fix needed).

## Verification

Before (no Origin header) — already missing CORS:
```
HTTP/1.1 200 OK
Content-Type: text/plain; charset=utf-8
Content-Length: 6370
(no other headers)
```

After:
```
HTTP/1.1 200 OK
Strict-Transport-Security: max-age=31536000; ...
X-Content-Type-Options: nosniff
X-Frame-Options: DENY
Content-Security-Policy: default-src 'none'; ...
Access-Control-Allow-Headers: Content-Type, Authorization
Access-Control-Expose-Headers: Retry-After, x-conversation-id
Access-Control-Allow-Origin: *
Content-Type: text/plain; charset=utf-8
Content-Length: 6370
```

401/404 paths still pass through with full security headers.

## Test plan

- [x] `bun test src/api/__tests__/ee-error-handler.test.ts` (new regression test covers the CORS-preservation contract)
- [x] `bun test src/api/__tests__/cors.test.ts`
- [x] `bun test src/api/routes/__tests__/admin-router.test.ts`
- [x] `bun run scripts/test-isolated.ts --affected` — 102/102 pass
- [x] Live curl against dev API confirms CORS+security headers present on the success path