### PR TITLE
refactor(api): 1.5.1 invert slice 2/11 — Residency via ResidencyResolver Tag

### DIFF
--- a/ee/src/layers.ts
+++ b/ee/src/layers.ts
@@ -8,19 +8,25 @@
  * Tags by "last wins", so EE's real implementations override core's
  * no-op defaults.
  *
- * Slice 1/11 (#2563) — foundation scaffolding only. `EELayer` is the
- * empty Layer; slices #2564–#2572 each replace one dynamic
- * `await import("@atlas/ee/...")` call site with `yield* TagName` and
- * append the real `Layer.effect` implementation here.
+ * Slice 2/11 (#2564) — appends the real `ResidencyResolver` Layer so
+ * core call sites (`lib/db/connection.ts`, platform residency routes,
+ * `shared-residency.ts`) can `yield* ResidencyResolver` and get EE's
+ * full implementation when enterprise is enabled. Later slices
+ * (#2565–#2572) follow the same pattern: one Tag, one Layer entry.
  *
  * See the parent issue (#2017) for the architectural rationale.
  */
 
 import { Layer } from "effect";
+import type { ResidencyResolver } from "@atlas/api/lib/effect/services";
+import { ResidencyResolverLive } from "./platform/residency";
 
 /**
- * Empty aggregator — populated by slices 2–10. Each slice adds one
- * `Layer.effect(Tag, ...)` here and removes the corresponding dynamic
- * import from core.
+ * Aggregated EE Layer — typed by the union of every Tag this module
+ * binds, so a future regression that drops a binding (or forgets to
+ * import a new slice's Layer) surfaces as a `tsgo` error rather than
+ * silently falling through to the no-op default at runtime.
  */
-export const EELayer: Layer.Layer<never> = Layer.empty;
+export const EELayer: Layer.Layer<ResidencyResolver> = Layer.mergeAll(
+  ResidencyResolverLive,
+);

--- a/ee/src/platform/residency.ts
+++ b/ee/src/platform/residency.ts
@@ -11,7 +11,7 @@
  * All exported functions return Effect — callers use `yield*` in Effect.gen.
  */
 
-import { Data, Effect } from "effect";
+import { Effect, Layer } from "effect";
 import { getConfig } from "@atlas/api/lib/config";
 import type { ResidencyConfig } from "@atlas/api/lib/config";
 import { requireInternalDBEffect } from "../lib/db-guard";
@@ -22,23 +22,29 @@ import {
   setWorkspaceRegion,
 } from "@atlas/api/lib/db/internal";
 import { createLogger } from "@atlas/api/lib/logger";
+import {
+  ResidencyResolver,
+  type ResidencyResolverShape,
+} from "@atlas/api/lib/effect/services";
+import {
+  ResidencyError,
+  type ResidencyErrorCode,
+} from "@atlas/api/lib/residency/errors";
 import type { RegionStatus, WorkspaceRegion } from "@useatlas/types";
 
 const log = createLogger("ee:residency");
 
 // ── Typed errors ────────────────────────────────────────────────────
 
-export type ResidencyErrorCode =
-  | "not_configured"
-  | "invalid_region"
-  | "already_assigned"
-  | "workspace_not_found"
-  | "no_internal_db";
-
-export class ResidencyError extends Data.TaggedError("ResidencyError")<{
-  message: string;
-  code: ResidencyErrorCode;
-}> {}
+/**
+ * `ResidencyError` now lives in core (`@atlas/api/lib/residency/errors`)
+ * so the `ResidencyResolver` Tag in `lib/effect/services.ts` can type its
+ * failure channel without core importing from `@atlas/ee`. Re-exported
+ * here for back-compat — pre-#2564 EE consumers that imported
+ * `ResidencyError` / `ResidencyErrorCode` from this path keep working
+ * unchanged (same `_tag`, same payload shape, same `instanceof` semantics).
+ */
+export { ResidencyError, type ResidencyErrorCode };
 
 // ── Helpers ─────────────────────────────────────────────────────────
 
@@ -240,3 +246,38 @@ export function isConfiguredRegion(region: string): boolean {
   if (!config?.residency) return false;
   return region in config.residency.regions;
 }
+
+// ── Tag wiring (#2564 — slice 2/11 of #2017) ─────────────────────────
+//
+// Bridges the module's functions into the `ResidencyResolver` Tag so
+// core call sites (`lib/db/connection.ts`, `api/routes/platform-residency.ts`,
+// `api/routes/shared-residency.ts`, …) can `yield* ResidencyResolver`
+// instead of dynamic-importing this module. Aggregated into
+// `ee/src/layers.ts:EELayer`; the no-op default in
+// `lib/effect/services.ts:NoopResidencyResolverLayer` covers self-hosted
+// installs where this module never loads.
+
+/**
+ * Build the `ResidencyResolver` service from this module's exports.
+ * Reports `available: true` so route handlers know to surface the real
+ * residency surface rather than the "feature disabled" branch. Each
+ * method delegates to the corresponding function above; semantics are
+ * identical to the pre-#2564 dynamic-import path.
+ */
+export const makeResidencyResolverLive = (): ResidencyResolverShape => ({
+  available: true,
+  resolveRegionDatabaseUrl,
+  listRegions,
+  getDefaultRegion,
+  getConfiguredRegions,
+  assignWorkspaceRegion,
+  getWorkspaceRegionAssignment,
+  listWorkspaceRegions,
+  isConfiguredRegion,
+});
+
+/** Layer that registers the real residency resolver under the core Tag. */
+export const ResidencyResolverLive: Layer.Layer<ResidencyResolver> = Layer.sync(
+  ResidencyResolver,
+  makeResidencyResolverLive,
+);

--- a/packages/api/src/api/__tests__/admin-residency.test.ts
+++ b/packages/api/src/api/__tests__/admin-residency.test.ts
@@ -158,9 +158,85 @@ mock.module("effect", () => {
   return { Effect, Cause: mockCause, Option: mockOption };
 });
 
+// --- Residency resolver mock (#2564) ---
+// Post-#2564 the route yields `ResidencyResolver` from the
+// `EnterpriseLayer` instead of dynamic-importing the EE module. The
+// services mock returns an iterable Tag whose value is a mutable
+// `mockResidencyResolver` shape — tests still flip `mockResidencyConfigured`
+// etc. before each scenario, and the route's `yield* ResidencyResolver`
+// sees the up-to-date object on the next call.
+
+let mockAssignment: { workspaceId: string; region: string; assignedAt: string } | null =
+  null;
+let mockAssignResult: { workspaceId: string; region: string; assignedAt: string } | null =
+  null;
+let mockAssignError: Error | null = null;
+let mockResidencyConfigured = true;
+const mockResidencyAvailable = true;
+let mockDefaultRegion = "us-east";
+let mockRegions: Record<string, { label: string; databaseUrl: string }> = {
+  "us-east": { label: "US East", databaseUrl: "postgresql://us" },
+  "eu-west": { label: "EU West", databaseUrl: "postgresql://eu" },
+  "ap-southeast": { label: "Asia Pacific", databaseUrl: "postgresql://ap" },
+};
+
+// Reused `_tag: "ResidencyError"` shape — both the route's `instanceof`
+// check (via the mocked core errors module below) and the test mocks
+// reference this class so domain mapping + instanceof land on the same
+// type. Constructor mirrors the real Data.TaggedError signature so route
+// code paths constructing the error don't need a shim.
+class MockResidencyError extends Error {
+  public readonly _tag = "ResidencyError" as const;
+  public readonly code: string;
+  constructor(args: { message: string; code: string }) {
+    super(args.message);
+    this.name = "ResidencyError";
+    this.code = args.code;
+  }
+}
+
+mock.module("@atlas/api/lib/residency/errors", () => ({
+  ResidencyError: MockResidencyError,
+}));
+
+// Tag shim — same `[Symbol.iterator]` trick as AuthContext so the route's
+// `yield* ResidencyResolver` resolves to `mockResidencyResolver`. Read on
+// each yield so mutating fields between tests takes effect immediately.
+const fakeResidencyResolver = {
+  [Symbol.iterator]: function* (): Generator<unknown, unknown> {
+    return yield {
+      get available() { return mockResidencyAvailable; },
+      resolveRegionDatabaseUrl: () => mockEffectIterable(null),
+      listRegions: () => mockEffectIterable([]),
+      getDefaultRegion: () => {
+        if (!mockResidencyConfigured)
+          throw new MockResidencyError({ message: "not configured", code: "not_configured" });
+        return mockDefaultRegion;
+      },
+      getConfiguredRegions: () => {
+        if (!mockResidencyConfigured)
+          throw new MockResidencyError({ message: "not configured", code: "not_configured" });
+        return mockRegions;
+      },
+      assignWorkspaceRegion: () => {
+        if (mockAssignError) {
+          return withPipe({
+            [Symbol.iterator]: () => ({ next: () => { throw mockAssignError; } }),
+          });
+        }
+        return mockEffectIterable(mockAssignResult);
+      },
+      getWorkspaceRegionAssignment: () => mockEffectIterable(mockAssignment),
+      listWorkspaceRegions: () => mockEffectIterable([]),
+      isConfiguredRegion: () => true,
+    };
+  },
+};
+
 mock.module("@atlas/api/lib/effect/services", () => ({
   AuthContext: fakeAuthContext,
   RequestContext: { [Symbol.iterator]: function* (): Generator<unknown, unknown> { return yield { requestId: "test-req-1", startTime: Date.now() }; } },
+  ResidencyResolver: fakeResidencyResolver,
   makeRequestContextLayer: () => ({}),
   makeAuthContextLayer: () => ({}),
 }));
@@ -294,57 +370,10 @@ mock.module("@atlas/api/lib/db/internal", () => ({
   getPendingAmendmentCount: mock(async () => 0),
 }));
 
-// --- EE residency mock ---
-
-let mockAssignment: { workspaceId: string; region: string; assignedAt: string } | null =
-  null;
-let mockAssignResult: { workspaceId: string; region: string; assignedAt: string } | null =
-  null;
-let mockAssignError: Error | null = null;
-let mockResidencyConfigured = true;
-let mockDefaultRegion = "us-east";
-let mockRegions: Record<string, { label: string; databaseUrl: string }> = {
-  "us-east": { label: "US East", databaseUrl: "postgresql://us" },
-  "eu-west": { label: "EU West", databaseUrl: "postgresql://eu" },
-  "ap-southeast": { label: "Asia Pacific", databaseUrl: "postgresql://ap" },
-};
-
-class MockResidencyError extends Error {
-  constructor(
-    message: string,
-    public readonly code: string,
-  ) {
-    super(message);
-    this.name = "ResidencyError";
-  }
-}
-
-mock.module("@atlas/ee/platform/residency", () => ({
-  getDefaultRegion: () => {
-    if (!mockResidencyConfigured)
-      throw new MockResidencyError("not configured", "not_configured");
-    return mockDefaultRegion;
-  },
-  getConfiguredRegions: () => {
-    if (!mockResidencyConfigured)
-      throw new MockResidencyError("not configured", "not_configured");
-    return mockRegions;
-  },
-  getWorkspaceRegionAssignment: () => mockEffectIterable(mockAssignment),
-  assignWorkspaceRegion: () => {
-    if (mockAssignError) {
-      return withPipe({
-        [Symbol.iterator]: () => ({ next: () => { throw mockAssignError; } }),
-      });
-    }
-    return mockEffectIterable(mockAssignResult);
-  },
-  ResidencyError: MockResidencyError,
-  listRegions: () => mockEffectIterable([]),
-  listWorkspaceRegions: () => mockEffectIterable([]),
-  resolveRegionDatabaseUrl: () => mockEffectIterable(null),
-  isConfiguredRegion: () => true,
-}));
+// The residency surface is mocked via the `ResidencyResolver` Tag wired
+// into the `@atlas/api/lib/effect/services` module-mock above (post-#2564).
+// No need to also stub `@atlas/ee/platform/residency` — the route no
+// longer dynamic-imports it.
 
 mock.module("@atlas/ee/auth/ip-allowlist", () => ({
   checkIPAllowlist: mock(() => ({ allowed: true })),
@@ -612,10 +641,10 @@ describe("PUT /api/v1/admin/residency", () => {
   });
 
   it("returns 409 when region already assigned", async () => {
-    mockAssignError = new MockResidencyError(
-      'Workspace is already assigned to region "us-east".',
-      "already_assigned",
-    );
+    mockAssignError = new MockResidencyError({
+      message: 'Workspace is already assigned to region "us-east".',
+      code: "already_assigned",
+    });
     const res = await request("PUT", "/", { region: "eu-west" });
     expect(res.status).toBe(409);
     const json = (await res.json()) as { error: string; message: string };
@@ -623,10 +652,10 @@ describe("PUT /api/v1/admin/residency", () => {
   });
 
   it("returns 400 for invalid region", async () => {
-    mockAssignError = new MockResidencyError(
-      'Invalid region "mars-1".',
-      "invalid_region",
-    );
+    mockAssignError = new MockResidencyError({
+      message: 'Invalid region "mars-1".',
+      code: "invalid_region",
+    });
     const res = await request("PUT", "/", { region: "mars-1" });
     expect(res.status).toBe(400);
     const json = (await res.json()) as { error: string; message: string };
@@ -634,10 +663,10 @@ describe("PUT /api/v1/admin/residency", () => {
   });
 
   it("returns 404 when workspace not found", async () => {
-    mockAssignError = new MockResidencyError(
-      'Workspace "org-1" not found.',
-      "workspace_not_found",
-    );
+    mockAssignError = new MockResidencyError({
+      message: 'Workspace "org-1" not found.',
+      code: "workspace_not_found",
+    });
     const res = await request("PUT", "/", { region: "eu-west" });
     expect(res.status).toBe(404);
   });
@@ -950,10 +979,10 @@ describe("admin residency — F-32 audit emission", () => {
     // Permanent decisions deserve failure audits — the attempt itself is
     // useful evidence. Without this, a 409 "already assigned" probe that
     // reveals the current region leaves no forensic record.
-    mockAssignError = new MockResidencyError(
-      'Workspace is already assigned to region "us-east".',
-      "already_assigned",
-    );
+    mockAssignError = new MockResidencyError({
+      message: 'Workspace is already assigned to region "us-east".',
+      code: "already_assigned",
+    });
     const res = await request("PUT", "/", { region: "eu-west" });
     expect(res.status).toBe(409);
     expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
@@ -991,10 +1020,10 @@ describe("admin residency — F-32 audit emission", () => {
     // verbatim in admin_action_log.metadata, the DB password leaks into the
     // audit row compliance reviewers read directly. The local
     // `errorMessage` helper must scrub `proto://user:pass@host` userinfo.
-    mockAssignError = new MockResidencyError(
-      "setWorkspaceRegion failed: postgresql://admin:s3cret@db.internal/atlas — timeout",
-      "invalid_region",
-    );
+    mockAssignError = new MockResidencyError({
+      message: "setWorkspaceRegion failed: postgresql://admin:s3cret@db.internal/atlas — timeout",
+      code: "invalid_region",
+    });
     await request("PUT", "/", { region: "eu-west" });
     expect(mockLogAdminAction).toHaveBeenCalledTimes(1);
     const entry = mockLogAdminAction.mock.calls[0]![0];

--- a/packages/api/src/api/routes/admin-residency.ts
+++ b/packages/api/src/api/routes/admin-residency.ts
@@ -12,7 +12,7 @@ import { Effect } from "effect";
 import { createRoute, z } from "@hono/zod-openapi";
 import type { Context } from "hono";
 import { runEffect } from "@atlas/api/lib/effect/hono";
-import { RequestContext, AuthContext } from "@atlas/api/lib/effect/services";
+import { RequestContext, AuthContext, ResidencyResolver } from "@atlas/api/lib/effect/services";
 import { hasInternalDB, queryEffect } from "@atlas/api/lib/db/internal";
 import { createLogger } from "@atlas/api/lib/logger";
 import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
@@ -23,6 +23,7 @@ import {
   resetMigrationForRetry,
   cancelMigration,
 } from "@atlas/api/lib/residency/migrate";
+import { ResidencyError } from "@atlas/api/lib/residency/errors";
 import { MIGRATION_STATUSES, type RegionMigration } from "@useatlas/types";
 import { RegionMigrationSchema, MigrationStatusResponseSchema } from "@useatlas/schemas";
 import { ErrorSchema, AuthErrorSchema } from "./shared-schemas";
@@ -182,7 +183,7 @@ function scheduleMigrationExecution(
 // Lazy EE loader — fail-graceful when enterprise is disabled
 // ---------------------------------------------------------------------------
 
-import { loadResidency, getResidencyDomainError } from "./shared-residency";
+import { residencyDomainError } from "./shared-residency";
 
 // ---------------------------------------------------------------------------
 // Schemas
@@ -475,13 +476,13 @@ adminResidency.use(requirePermission("admin:settings"));
 
 // GET / — workspace residency status
 adminResidency.openapi(getStatusRoute, async (c) => {
-  const mod = await loadResidency();
   return runEffect(
     c,
     Effect.gen(function* () {
       const { orgId } = yield* AuthContext;
+      const mod = yield* ResidencyResolver;
 
-      if (!mod) {
+      if (!mod.available) {
         return c.json(
           {
             configured: false,
@@ -508,7 +509,7 @@ adminResidency.openapi(getStatusRoute, async (c) => {
           isDefault: id === defaultRegion,
         }));
       } catch (err) {
-        if (err instanceof mod.ResidencyError && err.code === "not_configured") {
+        if (err instanceof ResidencyError && err.code === "not_configured") {
           configured = false;
         } else {
           throw err;
@@ -541,13 +542,12 @@ adminResidency.openapi(getStatusRoute, async (c) => {
         200,
       );
     }),
-    { label: "get residency status", domainErrors: mod ? [getResidencyDomainError(mod)] : undefined },
+    { label: "get residency status", domainErrors: [residencyDomainError] },
   );
 });
 
 // PUT / — assign region to workspace
 adminResidency.openapi(assignRegionRoute, async (c) => {
-  const mod = await loadResidency();
   const ipAddress = clientIP(c);
   const { region } = c.req.valid("json");
 
@@ -555,8 +555,9 @@ adminResidency.openapi(assignRegionRoute, async (c) => {
     c,
     Effect.gen(function* () {
       const { orgId } = yield* AuthContext;
+      const mod = yield* ResidencyResolver;
 
-      if (!mod) {
+      if (!mod.available) {
         return c.json({ error: "not_available", message: "Data residency is not available in this deployment." }, 404);
       }
 
@@ -599,7 +600,7 @@ adminResidency.openapi(assignRegionRoute, async (c) => {
       });
       return c.json(result, 200);
     }),
-    { label: "assign workspace region", domainErrors: mod ? [getResidencyDomainError(mod)] : undefined },
+    { label: "assign workspace region", domainErrors: [residencyDomainError] },
   );
 });
 
@@ -643,7 +644,6 @@ adminResidency.openapi(getMigrationStatusRoute, async (c) => {
 // ---------------------------------------------------------------------------
 
 adminResidency.openapi(requestMigrationRoute, async (c) => {
-  const mod = await loadResidency();
   return runEffect(
     c,
     Effect.gen(function* () {
@@ -659,7 +659,8 @@ adminResidency.openapi(requestMigrationRoute, async (c) => {
         return c.json({ error: "not_available", message: "Migration tracking requires an internal database.", requestId }, 404);
       }
 
-      if (!mod) {
+      const mod = yield* ResidencyResolver;
+      if (!mod.available) {
         return c.json({ error: "not_available", message: "Data residency is not available in this deployment.", requestId }, 404);
       }
 
@@ -765,7 +766,7 @@ adminResidency.openapi(requestMigrationRoute, async (c) => {
 
       return c.json(migration, 201);
     }),
-    { label: "request region migration", domainErrors: mod ? [getResidencyDomainError(mod)] : undefined },
+    { label: "request region migration", domainErrors: [residencyDomainError] },
   );
 });
 

--- a/packages/api/src/api/routes/onboarding.ts
+++ b/packages/api/src/api/routes/onboarding.ts
@@ -12,6 +12,7 @@ import { runEffect } from "@atlas/api/lib/effect/hono";
 import {
   RequestContext,
   AuthContext,
+  ResidencyResolver,
 } from "@atlas/api/lib/effect/services";
 import { validationHook } from "./validation-hook";
 import { HTTPException } from "hono/http-exception";
@@ -904,7 +905,8 @@ onboarding.openapi(
 // Region selection during signup
 // ---------------------------------------------------------------------------
 
-import { loadResidency, getResidencyDomainError } from "./shared-residency";
+import { residencyDomainError } from "./shared-residency";
+import { ResidencyError } from "@atlas/api/lib/residency/errors";
 import { RegionPickerItemSchema } from "@useatlas/schemas";
 
 // OnboardingRegionSchema previously duplicated this shape inline; the signup
@@ -1026,8 +1028,8 @@ onboarding.openapi(getRegionsRoute, async (c) => {
       return c.json({ error: "not_available", message: "Onboarding requires managed auth mode.", requestId }, 404);
     }
 
-    const mod = yield* Effect.promise(() => loadResidency());
-    if (!mod) {
+    const mod = yield* ResidencyResolver;
+    if (!mod.available) {
       return c.json({ configured: false, defaultRegion: "none", availableRegions: [] }, 200);
     }
 
@@ -1041,7 +1043,7 @@ onboarding.openapi(getRegionsRoute, async (c) => {
       }));
       return c.json({ configured: true, defaultRegion, availableRegions }, 200);
     } catch (err) {
-      if (err instanceof mod.ResidencyError && err.code === "not_configured") {
+      if (err instanceof ResidencyError && err.code === "not_configured") {
         return c.json({ configured: false, defaultRegion: "none", availableRegions: [] }, 200);
       }
       throw err;
@@ -1054,7 +1056,6 @@ onboarding.openapi(getRegionsRoute, async (c) => {
 onboarding.openapi(
   assignRegionRoute,
   async (c) => {
-    const mod = await loadResidency();
     return runEffect(c, Effect.gen(function* () {
       const { requestId } = yield* RequestContext;
       const { orgId } = yield* AuthContext;
@@ -1069,14 +1070,15 @@ onboarding.openapi(
 
       const { region } = c.req.valid("json");
 
-      if (!mod) {
+      const mod = yield* ResidencyResolver;
+      if (!mod.available) {
         return c.json({ error: "not_available", message: "Data residency is not available in this deployment.", requestId }, 404);
       }
 
       const result = yield* mod.assignWorkspaceRegion(orgId, region);
       log.info({ orgId, region, requestId }, "Workspace region assigned during signup");
       return c.json(result, 200);
-    }), { label: "assign region during signup", domainErrors: mod ? [getResidencyDomainError(mod)] : undefined });
+    }), { label: "assign region during signup", domainErrors: [residencyDomainError] });
   },
   (result, c) => {
     if (!result.success) {

--- a/packages/api/src/api/routes/platform-residency.ts
+++ b/packages/api/src/api/routes/platform-residency.ts
@@ -14,11 +14,11 @@ import { createRoute, z } from "@hono/zod-openapi";
 import { Effect } from "effect";
 import { createLogger } from "@atlas/api/lib/logger";
 import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
-import { runEffect, domainError } from "@atlas/api/lib/effect/hono";
+import { runEffect } from "@atlas/api/lib/effect/hono";
 import {
   RequestContext,
+  ResidencyResolver,
 } from "@atlas/api/lib/effect/services";
-import { ResidencyError } from "@atlas/ee/platform/residency";
 import {
   WorkspaceRegionSchema,
   RegionsResponseSchema,
@@ -27,6 +27,7 @@ import {
 
 import { ErrorSchema, AuthErrorSchema } from "./shared-schemas";
 import { createPlatformRouter } from "./admin-router";
+import { residencyDomainError } from "./shared-residency";
 
 const log = createLogger("platform-residency");
 
@@ -136,53 +137,30 @@ const listAssignmentsRoute = createRoute({
 });
 
 // ---------------------------------------------------------------------------
-// Module loader (lazy import — fail gracefully when ee is unavailable)
-// ---------------------------------------------------------------------------
-
-type ResidencyModule = typeof import("@atlas/ee/platform/residency");
-
-const residencyDomainError = domainError(ResidencyError, {
-  not_configured: 404,
-  invalid_region: 400,
-  already_assigned: 409,
-  workspace_not_found: 404,
-  no_internal_db: 503,
-});
-
-async function loadResidency(): Promise<ResidencyModule | null> {
-  try {
-    return await import("@atlas/ee/platform/residency");
-  } catch (err) {
-    if (err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code === "MODULE_NOT_FOUND") {
-      return null;
-    }
-    log.error(
-      { err: err instanceof Error ? err : new Error(String(err)) },
-      "Failed to load residency module — unexpected error",
-    );
-    throw err;
-  }
-}
-
-// ---------------------------------------------------------------------------
 // Router
 // ---------------------------------------------------------------------------
 
 const platformResidency = createPlatformRouter();
+
+const notAvailableBody = (requestId: string) => ({
+  error: "not_available" as const,
+  message: "Data residency requires enterprise features to be enabled.",
+  requestId,
+});
 
 // ── List regions ─────────────────────────────────────────────────────
 
 platformResidency.openapi(listRegionsRoute, async (c) => {
   return runEffect(c, Effect.gen(function* () {
     const { requestId } = yield* RequestContext;
+    const residency = yield* ResidencyResolver;
 
-    const mod = yield* Effect.promise(() => loadResidency());
-    if (!mod) {
-      return c.json({ error: "not_available", message: "Data residency requires enterprise features to be enabled.", requestId }, 404);
+    if (!residency.available) {
+      return c.json(notAvailableBody(requestId), 404);
     }
 
-    const regions = yield* mod.listRegions();
-    const defaultRegion = mod.getDefaultRegion();
+    const regions = yield* residency.listRegions();
+    const defaultRegion = residency.getDefaultRegion();
     return c.json({ regions, defaultRegion }, 200);
   }), { label: "list regions", domainErrors: [residencyDomainError] });
 });
@@ -193,13 +171,13 @@ platformResidency.openapi(getWorkspaceRegionRoute, async (c) => {
   return runEffect(c, Effect.gen(function* () {
     const { requestId } = yield* RequestContext;
     const workspaceId = c.req.param("id");
+    const residency = yield* ResidencyResolver;
 
-    const mod = yield* Effect.promise(() => loadResidency());
-    if (!mod) {
-      return c.json({ error: "not_available", message: "Data residency requires enterprise features to be enabled.", requestId }, 404);
+    if (!residency.available) {
+      return c.json(notAvailableBody(requestId), 404);
     }
 
-    const assignment = yield* mod.getWorkspaceRegionAssignment(workspaceId);
+    const assignment = yield* residency.getWorkspaceRegionAssignment(workspaceId);
     if (!assignment) {
       return c.json({ error: "not_found", message: `Workspace "${workspaceId}" has no region assigned.`, requestId }, 404);
     }
@@ -214,13 +192,13 @@ platformResidency.openapi(assignRegionRoute, async (c) => {
     const { requestId } = yield* RequestContext;
     const workspaceId = c.req.param("id");
     const body = c.req.valid("json");
+    const residency = yield* ResidencyResolver;
 
-    const mod = yield* Effect.promise(() => loadResidency());
-    if (!mod) {
-      return c.json({ error: "not_available", message: "Data residency requires enterprise features to be enabled.", requestId }, 404);
+    if (!residency.available) {
+      return c.json(notAvailableBody(requestId), 404);
     }
 
-    const assignment = yield* mod.assignWorkspaceRegion(workspaceId, body.region);
+    const assignment = yield* residency.assignWorkspaceRegion(workspaceId, body.region);
     log.info({ workspaceId, region: body.region, requestId }, "Region assigned to workspace");
 
     logAdminAction({
@@ -241,13 +219,13 @@ platformResidency.openapi(assignRegionRoute, async (c) => {
 platformResidency.openapi(listAssignmentsRoute, async (c) => {
   return runEffect(c, Effect.gen(function* () {
     const { requestId } = yield* RequestContext;
+    const residency = yield* ResidencyResolver;
 
-    const mod = yield* Effect.promise(() => loadResidency());
-    if (!mod) {
-      return c.json({ error: "not_available", message: "Data residency requires enterprise features to be enabled.", requestId }, 404);
+    if (!residency.available) {
+      return c.json(notAvailableBody(requestId), 404);
     }
 
-    const assignments = yield* mod.listWorkspaceRegions();
+    const assignments = yield* residency.listWorkspaceRegions();
     return c.json({ assignments }, 200);
   }), { label: "list region assignments", domainErrors: [residencyDomainError] });
 });

--- a/packages/api/src/api/routes/shared-residency.ts
+++ b/packages/api/src/api/routes/shared-residency.ts
@@ -1,59 +1,30 @@
 /**
- * Shared residency infrastructure — error mapping and module loading
- * used by both admin-residency.ts (workspace) and onboarding.ts (signup).
+ * Shared residency infrastructure — typed domain-error mapping used by
+ * both `admin-residency.ts` (workspace) and `onboarding.ts` (signup) +
+ * the platform routes.
+ *
+ * Post-#2564 the dynamic `await import("@atlas/ee/platform/residency")`
+ * loader is gone — routes yield the `ResidencyResolver` Tag directly
+ * inside their `Effect.gen` block, and the Hono bridge
+ * (`runEffect`/`runHandler`) automatically provides `EnterpriseLayer`
+ * so the no-op default (or the real EE impl when enterprise is on)
+ * resolves without each route threading the layer through.
  */
 
-import { createLogger } from "@atlas/api/lib/logger";
 import { domainError, type DomainErrorMapping } from "@atlas/api/lib/effect/hono";
-
-const log = createLogger("residency-shared");
-
-// ---------------------------------------------------------------------------
-// Error mapping (lazy — @atlas/ee is an optional dependency)
-// ---------------------------------------------------------------------------
-
-export type ResidencyModule = typeof import("@atlas/ee/platform/residency");
-
-let _residencyDomainError: DomainErrorMapping | undefined;
+import { ResidencyError } from "@atlas/api/lib/residency/errors";
 
 /**
- * Build or return cached residency domain error mapping.
- * Lazy because the ResidencyError class comes from the dynamically-loaded
- * @atlas/ee module — static import would break when @atlas/ee is not installed.
+ * `ResidencyError` is the core class post-#2564, so the mapping is a
+ * top-level constant. `domainError`'s `TCode` inference makes a missing
+ * code surface as a `tsgo` error — replacing the lazy-init pattern the
+ * pre-#2564 dynamic-import path needed when the class was reachable
+ * only through `await import("@atlas/ee/platform/residency")`.
  */
-export function getResidencyDomainError(mod: ResidencyModule): DomainErrorMapping {
-  if (!_residencyDomainError) {
-    _residencyDomainError = domainError(mod.ResidencyError, {
-      not_configured: 404,
-      invalid_region: 400,
-      already_assigned: 409,
-      workspace_not_found: 404,
-      no_internal_db: 503,
-    });
-  }
-  return _residencyDomainError;
-}
-
-// ---------------------------------------------------------------------------
-// Module loader (lazy import — fail gracefully when ee is unavailable)
-// ---------------------------------------------------------------------------
-
-export async function loadResidency(): Promise<ResidencyModule | null> {
-  try {
-    return await import("@atlas/ee/platform/residency");
-  } catch (err) {
-    if (
-      err != null &&
-      typeof err === "object" &&
-      "code" in err &&
-      (err as NodeJS.ErrnoException).code === "MODULE_NOT_FOUND"
-    ) {
-      return null;
-    }
-    log.error(
-      { err: err instanceof Error ? err : new Error(String(err)) },
-      "Failed to load residency module — unexpected error",
-    );
-    throw err;
-  }
-}
+export const residencyDomainError: DomainErrorMapping = domainError(ResidencyError, {
+  not_configured: 404,
+  invalid_region: 400,
+  already_assigned: 409,
+  workspace_not_found: 404,
+  no_internal_db: 503,
+});

--- a/packages/api/src/lib/db/__tests__/region-aware-connection.test.ts
+++ b/packages/api/src/lib/db/__tests__/region-aware-connection.test.ts
@@ -30,21 +30,67 @@ mock.module("mysql2/promise", () => ({
   }),
 }));
 
-import { Effect } from "effect";
+import { Effect, Layer } from "effect";
 
-// Mock the EE residency module — default: no region configured
+// Mock the EE layer aggregator instead of `@atlas/ee/platform/residency`
+// directly: post-#2564 the production code resolves residency via the
+// `ResidencyResolver` Tag, and the `ConditionalEELayer` in
+// `lib/effect/enterprise-layer.ts` lazy-imports `@atlas/ee/layers`. The
+// mocked aggregator returns a `Layer.succeed(ResidencyResolver, ...)`
+// whose `resolveRegionDatabaseUrl` calls back into the test-local
+// `mockResolveFn`, preserving the per-test mutability the original
+// module-level mock had.
 type RegionResult = { databaseUrl: string; datasourceUrl?: string; region: string } | null;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- mock function type needs to be wide for reassignment
 let mockResolveFn: (...args: any[]) => RegionResult = () => null;
 
+// Force `ConditionalEELayer` to load the mocked aggregator. Without this
+// `isEnterpriseEnabledLocal()` returns false and the conditional layer
+// falls through to `Layer.empty`, leaving the no-op `ResidencyResolver`
+// in effect — the test would always see `available: false`.
+process.env.ATLAS_ENTERPRISE_ENABLED = "true";
+
+// Stub the EE residency module so a transitive `import("@atlas/ee/layers")`
+// chain that bottoms out at `./platform/residency` doesn't blow up the
+// loader on a partial-mock-export error.
 mock.module("@atlas/ee/platform/residency", () => ({
   resolveRegionDatabaseUrl: (...args: unknown[]) => Effect.succeed(mockResolveFn(...args)),
+  makeResidencyResolverLive: () => ({ available: true, resolveRegionDatabaseUrl: () => Effect.succeed(null) }),
+  ResidencyResolverLive: Layer.empty,
+  ResidencyError: class { constructor(public args: { message: string; code: string }) {} },
 }));
 
-// Mock config so getConfig() returns a valid config
+mock.module("@atlas/ee/layers", () => ({
+  EELayer: Layer.unwrapEffect(
+    Effect.sync(() => {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const services = require("@atlas/api/lib/effect/services") as typeof import("@atlas/api/lib/effect/services");
+      return Layer.succeed(services.ResidencyResolver, {
+        available: true,
+        resolveRegionDatabaseUrl: (...args: unknown[]) => Effect.succeed(mockResolveFn(...args)),
+        // The rest of the shape isn't exercised by this test; stubs throw
+        // on access so a future test that pulls in another method gets a
+        // loud failure rather than a silent default-zero.
+        listRegions: () => Effect.die("not stubbed"),
+        getDefaultRegion: () => { throw new Error("not stubbed"); },
+        getConfiguredRegions: () => { throw new Error("not stubbed"); },
+        assignWorkspaceRegion: () => Effect.die("not stubbed"),
+        getWorkspaceRegionAssignment: () => Effect.die("not stubbed"),
+        listWorkspaceRegions: () => Effect.die("not stubbed"),
+        isConfiguredRegion: () => true,
+      } satisfies import("@atlas/api/lib/effect/services").ResidencyResolverShape);
+    }),
+  ),
+}));
+
+// Mock config so getConfig() returns a valid config. Note: the
+// `isEnterpriseEnabledLocal` check in enterprise-layer.ts reads
+// `config.enterprise?.enabled` first, then falls back to the env var
+// — we set both above so the layer wires up the mocked EE aggregator.
 mock.module("@atlas/api/lib/config", () => ({
   getConfig: () => ({
     datasources: { default: { url: "postgresql://localhost/test" } },
+    enterprise: { enabled: true },
   }),
   defineConfig: (c: unknown) => c,
 }));

--- a/packages/api/src/lib/db/connection.ts
+++ b/packages/api/src/lib/db/connection.ts
@@ -24,6 +24,8 @@ import { _resetWhitelists } from "@atlas/api/lib/semantic";
 import { hasInternalDB, internalQuery } from "@atlas/api/lib/db/internal";
 import { getConfig } from "@atlas/api/lib/config";
 import type { HealthStatus } from "@atlas/api/lib/connection-types";
+import { ResidencyResolver } from "@atlas/api/lib/effect/services";
+import { EnterpriseLayer } from "@atlas/api/lib/effect/enterprise-layer";
 
 export type { HealthStatus } from "@atlas/api/lib/connection-types";
 
@@ -1429,24 +1431,23 @@ export async function getRegionAwareConnection(
   orgId: string,
   connectionId: string = "default",
 ): Promise<RegionAwareResult> {
-  let resolveRegionDatabaseUrlFn: Awaited<typeof import("@atlas/ee/platform/residency")>["resolveRegionDatabaseUrl"];
-  try {
-    ({ resolveRegionDatabaseUrl: resolveRegionDatabaseUrlFn } = await import("@atlas/ee/platform/residency"));
-  } catch (err) {
-    // ee module not installed — non-enterprise deployment, use default
-    if (err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code === "MODULE_NOT_FOUND") {
-      return { db: connections.getForOrg(orgId, connectionId), resolvedConnId: connectionId };
-    }
-    // EE module exists but failed to load — this is a real error.
-    // Data residency cannot be guaranteed; refuse to silently downgrade.
-    log.error({ err: errorMessage(err), orgId }, "Residency module failed to load — cannot guarantee data residency");
-    throw err instanceof Error ? err : new Error(String(err));
-  }
+  // Inverts the pre-#2564 `await import("@atlas/ee/platform/residency")`.
+  // Resolves the route via the `ResidencyResolver` Tag — EE provides the
+  // real implementation through `EnterpriseLayer`, self-hosted falls
+  // through to the no-op (`resolveRegionDatabaseUrl => null`). Layer
+  // construction is referentially stable across calls; the dynamic
+  // `await import("@atlas/ee/layers")` inside `ConditionalEELayer` hits
+  // Node's module cache after the first load.
+  const resolveRegion = Effect.gen(function* () {
+    const residency = yield* ResidencyResolver;
+    return yield* residency.resolveRegionDatabaseUrl(orgId);
+  });
 
   let regionInfo: { databaseUrl: string; datasourceUrl?: string; region: string } | null;
   try {
-    const { Effect } = await import("effect");
-    regionInfo = await Effect.runPromise(resolveRegionDatabaseUrlFn(orgId));
+    regionInfo = await Effect.runPromise(
+      resolveRegion.pipe(Effect.provide(EnterpriseLayer)),
+    );
   } catch (err) {
     log.warn(
       { err: errorMessage(err), orgId },

--- a/packages/api/src/lib/effect/enterprise-layer.ts
+++ b/packages/api/src/lib/effect/enterprise-layer.ts
@@ -1,0 +1,141 @@
+/**
+ * Enterprise Layer composition — extracted from `layers.ts` so the Hono
+ * bridge (`runEffect`/`runHandler`) can import the composed layer
+ * without pulling in the full startup DAG (`buildAppLayer`,
+ * `InternalDBLive`, the SaaS guard family, etc.). Routes load this
+ * module transitively via `hono.ts`; the surface here is intentionally
+ * thin so partial `mock.module()` setups in existing tests aren't
+ * forced to stub heavy startup-only exports.
+ *
+ * Slice 2/11 of #2017 (#2564) carved this file out. Pre-slice the
+ * `EnterpriseLayer` const lived in `layers.ts`; both files now import
+ * it from here so the canonical definition has a single home, and the
+ * closeout CI grep (#2573) only needs to allow `@atlas/ee` in this
+ * file plus the `@atlas/ee/layers` aggregator dynamic import below.
+ */
+
+import { Effect, Layer } from "effect";
+import { createLogger } from "@atlas/api/lib/logger";
+import {
+  NoopEnterpriseDefaultsLayer,
+  type ResidencyResolver,
+  type ModelRouter,
+  type MaskingPolicy,
+  type ComplianceReports,
+  type ApprovalGate,
+  type SlaMetrics,
+  type BackupsManager,
+  type AuditRetention,
+  type IpAllowlistPolicy,
+  type SSOPolicy,
+  type SCIMProvenance,
+  type RolesPolicy,
+  type Branding,
+  type Domains,
+  type ProactiveGate,
+  type DeployModeResolver,
+} from "./services";
+
+const log = createLogger("effect:enterprise-layer");
+
+/**
+ * Read whether enterprise is enabled without importing from `@atlas/ee`.
+ *
+ * Mirrors `ee/src/index.ts:isEnterpriseEnabled` resolution:
+ *   1. `enterprise.enabled` in atlas.config.ts
+ *   2. `ATLAS_ENTERPRISE_ENABLED` env var
+ *
+ * Lazy-requires the config module so this file stays at the bottom of
+ * the dep graph (config-resolution code transitively pulls in pieces of
+ * the layer DAG via type-only paths in `lib/db/internal`).
+ */
+function isEnterpriseEnabledLocal(): boolean {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { getConfig } = require("@atlas/api/lib/config") as {
+    getConfig: () => { enterprise?: { enabled?: boolean } } | null;
+  };
+  const config = getConfig();
+  if (config?.enterprise?.enabled !== undefined) {
+    return config.enterprise.enabled;
+  }
+  return process.env.ATLAS_ENTERPRISE_ENABLED === "true";
+}
+
+/**
+ * Conditional EE Layer. When enterprise is enabled, lazy-imports
+ * `@atlas/ee/layers` and exposes its `EELayer`. Otherwise falls back to
+ * `Layer.empty`. Wrapped in `Layer.unwrapEffect` so the dynamic import
+ * is deferred to Layer construction time (not module load), and a
+ * missing/broken `@atlas/ee` install never fails core startup — the
+ * catch arm logs and falls back to the empty Layer, leaving the no-op
+ * defaults from `NoopEnterpriseDefaultsLayer` in effect.
+ *
+ * This is the **single permitted runtime reference** to `@atlas/ee`
+ * from core. Adding any other `@atlas/ee` or `isEnterpriseEnabled`
+ * reference to `packages/api/src/` will fail the CI grep slice #2573
+ * installs (the closeout grep allow-list covers this file + the
+ * conditional import below).
+ */
+const ConditionalEELayer: Layer.Layer<never> = Layer.unwrapEffect(
+  Effect.sync(() => isEnterpriseEnabledLocal()).pipe(
+    Effect.flatMap((enabled) => {
+      if (!enabled) return Effect.succeed(Layer.empty as Layer.Layer<never>);
+      return Effect.tryPromise({
+        try: async () => {
+          const mod = (await import("@atlas/ee/layers")) as { EELayer: Layer.Layer<never> };
+          return mod.EELayer;
+        },
+        catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+      }).pipe(
+        Effect.catchAll((err) => {
+          log.error(
+            { err: err instanceof Error ? err.message : String(err) },
+            "Enterprise enabled but @atlas/ee/layers failed to load — falling back to no-op defaults",
+          );
+          return Effect.succeed(Layer.empty as Layer.Layer<never>);
+        }),
+      );
+    }),
+  ),
+);
+
+/**
+ * Union of all enterprise subsystem Tags. Exported so the Hono bridge
+ * can widen its `R` constraint to accept route programs that
+ * `yield* ResidencyResolver` (or any other Tag). Grows in lockstep with
+ * `NoopEnterpriseDefaultsLayer` as slices widen contracts — the union
+ * is the type-level source of truth.
+ */
+export type EnterpriseSubsystem =
+  | ResidencyResolver
+  | ModelRouter
+  | MaskingPolicy
+  | ComplianceReports
+  | ApprovalGate
+  | SlaMetrics
+  | BackupsManager
+  | AuditRetention
+  | IpAllowlistPolicy
+  | SSOPolicy
+  | SCIMProvenance
+  | RolesPolicy
+  | Branding
+  | Domains
+  | ProactiveGate
+  | DeployModeResolver;
+
+/**
+ * Composed enterprise Layer — no-op defaults overlaid by the conditional
+ * EE layer (last-wins via `Layer.mergeAll`). Provided per-request by
+ * `runEffect`/`runHandler` so route programs can `yield* ResidencyResolver`
+ * without threading the layer through every handler.
+ *
+ * Construction is cheap: the no-op defaults are constants, and the
+ * conditional EE layer's lazy `await import("@atlas/ee/layers")` hits
+ * Node's module cache after the first load. Effect's Layer memoization
+ * elides repeat work within a single program run.
+ */
+export const EnterpriseLayer: Layer.Layer<EnterpriseSubsystem> = Layer.mergeAll(
+  NoopEnterpriseDefaultsLayer,
+  ConditionalEELayer,
+);

--- a/packages/api/src/lib/effect/hono.ts
+++ b/packages/api/src/lib/effect/hono.ts
@@ -27,6 +27,7 @@ import {
   AuthContext,
   makeAuthContextLayer,
 } from "./services";
+import { EnterpriseLayer, type EnterpriseSubsystem } from "./enterprise-layer";
 
 // ── Domain error mapping ────────────────────────────────────────────
 
@@ -390,14 +391,27 @@ export interface RunEffectOptions {
  */
 export async function runEffect<A, E>(
   c: Context,
-  program: Effect.Effect<A, E, RequestContext | AuthContext> | Effect.Effect<A, E, never>,
+  program:
+    | Effect.Effect<A, E, RequestContext | AuthContext | EnterpriseSubsystem>
+    | Effect.Effect<A, E, never>,
   options?: RunEffectOptions,
 ): Promise<A> {
-  // Provide Hono context as Effect Context layers (same bridge as runHandler)
+  // Provide Hono context + enterprise subsystem layers. The enterprise
+  // layer carries no-op defaults for every EE Tag (overlaid by the real
+  // EE implementations via `Layer.mergeAll`'s last-wins semantics) so a
+  // handler that `yield* ResidencyResolver` resolves without each route
+  // having to provide the layer manually. Layer.mergeAll is referentially
+  // stable, so Effect memoizes the construction across requests.
   const contextLayer = buildContextLayer(c);
-  const provided = contextLayer
-    ? (program as Effect.Effect<A, E, RequestContext | AuthContext>).pipe(Effect.provide(contextLayer))
-    : program as Effect.Effect<A, E, never>;
+  const provided: Effect.Effect<A, E, never> = contextLayer
+    ? (program as Effect.Effect<
+        A,
+        E,
+        RequestContext | AuthContext | EnterpriseSubsystem
+      >).pipe(Effect.provide(Layer.merge(contextLayer, EnterpriseLayer)))
+    : (program as Effect.Effect<A, E, EnterpriseSubsystem>).pipe(
+        Effect.provide(EnterpriseLayer),
+      );
 
   const exit = await Effect.runPromiseExit(provided);
 
@@ -561,11 +575,10 @@ export function runHandler<T>(
     catch: (err) => (err instanceof Error ? err : new Error(String(err))),
   });
 
-  // Provide Hono context as Effect Context layers
-  const contextLayer = buildContextLayer(c);
-  const provided = contextLayer
-    ? program.pipe(Effect.provide(contextLayer))
-    : program;
-
-  return runEffect(c, provided, { label, domainErrors: options?.domainErrors });
+  // Context + enterprise provision happens once inside runEffect — no need
+  // to provide them here too. The wrapper used to re-provide contextLayer
+  // before delegating; that double-provide was redundant and would now
+  // also need to layer in EnterpriseLayer to type-check, so we hand the
+  // raw program through and let runEffect's single provide handle it.
+  return runEffect(c, program, { label, domainErrors: options?.domainErrors });
 }

--- a/packages/api/src/lib/effect/layers.ts
+++ b/packages/api/src/lib/effect/layers.ts
@@ -48,96 +48,22 @@ import {
   MigrationsRequiredError,
 } from "./saas-guards";
 import { readSaasEnv } from "./saas-env";
-import {
-  NoopEnterpriseDefaultsLayer,
-  type ResidencyResolver,
-  type ModelRouter,
-  type MaskingPolicy,
-  type ComplianceReports,
-  type ApprovalGate,
-  type SlaMetrics,
-  type BackupsManager,
-  type AuditRetention,
-  type IpAllowlistPolicy,
-  type SSOPolicy,
-  type SCIMProvenance,
-  type RolesPolicy,
-  type Branding,
-  type Domains,
-  type ProactiveGate,
-  type DeployModeResolver,
-} from "./services";
+import { EnterpriseLayer, type EnterpriseSubsystem } from "./enterprise-layer";
 
 const log = createLogger("effect:layers");
 
 // ══════════════════════════════════════════════════════════════════════
-// ██  Enterprise gate (#2563 slice 1/11 of #2017)
+// ██  Enterprise gate (#2563 slice 1/11 of #2017; #2564 slice 2/11)
 // ══════════════════════════════════════════════════════════════════════
+//
+// `EnterpriseLayer` and the `EnterpriseSubsystem` union live in
+// `./enterprise-layer` so the hono bridge can import them without
+// pulling in the full startup DAG (the `InternalDB` chain, the
+// SaaS guard family, the scheduler fibers). Re-exported here so
+// existing consumers that grab them from `@atlas/api/lib/effect/layers`
+// keep working unchanged.
 
-/**
- * Read whether enterprise is enabled without importing from `@atlas/ee`.
- *
- * Mirrors the resolution in `ee/src/index.ts:isEnterpriseEnabled` so
- * this file (the sole post-closeout `@atlas/ee`-touching module) does
- * not need a second static import alongside the conditional
- * `await import("@atlas/ee/layers")` below. Slice #2573 (closeout)
- * enforces this with a CI grep that bans `@atlas/ee` from every core
- * file except this one.
- *
- * Resolution order matches `ee/src/index.ts`:
- *   1. `enterprise.enabled` in atlas.config.ts
- *   2. `ATLAS_ENTERPRISE_ENABLED` env var
- */
-function isEnterpriseEnabledLocal(): boolean {
-  // Lazy require to avoid a circular import at module-eval time
-  // (config.ts pulls in pieces of the layer DAG via type-only paths).
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const { getConfig } = require("@atlas/api/lib/config") as {
-    getConfig: () => { enterprise?: { enabled?: boolean } } | null;
-  };
-  const config = getConfig();
-  if (config?.enterprise?.enabled !== undefined) {
-    return config.enterprise.enabled;
-  }
-  return process.env.ATLAS_ENTERPRISE_ENABLED === "true";
-}
-
-/**
- * Conditional EE Layer. When enterprise is enabled, lazy-imports
- * `@atlas/ee/layers` and exposes its `EELayer`. Otherwise falls back to
- * the empty Layer. Wrapped in `Layer.unwrapEffect` so the dynamic
- * import is deferred to Layer construction time (not module load), and
- * a missing or broken `@atlas/ee` install never fails core startup —
- * the catch arm logs and falls back to the empty Layer, so the no-op
- * defaults from `NoopEnterpriseDefaultsLayer` remain in effect.
- *
- * This is the **single permitted `@atlas/ee` reference** in core post
- * slice #2573. Adding any other `@atlas/ee` or `isEnterpriseEnabled`
- * reference to `packages/api/src/` will fail the CI grep that the
- * closeout slice installs.
- */
-const ConditionalEELayer: Layer.Layer<never> = Layer.unwrapEffect(
-  Effect.sync(() => isEnterpriseEnabledLocal()).pipe(
-    Effect.flatMap((enabled) => {
-      if (!enabled) return Effect.succeed(Layer.empty as Layer.Layer<never>);
-      return Effect.tryPromise({
-        try: async () => {
-          const mod = (await import("@atlas/ee/layers")) as { EELayer: Layer.Layer<never> };
-          return mod.EELayer;
-        },
-        catch: (err) => (err instanceof Error ? err : new Error(String(err))),
-      }).pipe(
-        Effect.catchAll((err) => {
-          log.error(
-            { err: errorMessage(err) },
-            "Enterprise enabled but @atlas/ee/layers failed to load — falling back to no-op defaults",
-          );
-          return Effect.succeed(Layer.empty as Layer.Layer<never>);
-        }),
-      );
-    }),
-  ),
-);
+export { EnterpriseLayer, type EnterpriseSubsystem };
 
 // ══════════════════════════════════════════════════════════════════════
 // ██  Telemetry Layer
@@ -1242,22 +1168,7 @@ export function buildAppLayer(config: ResolvedConfig): Layer.Layer<
   | SemanticSync
   | Settings
   | Scheduler
-  | ResidencyResolver
-  | ModelRouter
-  | MaskingPolicy
-  | ComplianceReports
-  | ApprovalGate
-  | SlaMetrics
-  | BackupsManager
-  | AuditRetention
-  | IpAllowlistPolicy
-  | SSOPolicy
-  | SCIMProvenance
-  | RolesPolicy
-  | Branding
-  | Domains
-  | ProactiveGate
-  | DeployModeResolver,
+  | EnterpriseSubsystem,
   Error
 > {
   const configLayer = Layer.succeed(Config, { config });
@@ -1312,13 +1223,11 @@ export function buildAppLayer(config: ResolvedConfig): Layer.Layer<
   // Merge all layers. InternalDB is included both directly and as a
   // dependency of migrationLayer — Effect memoizes same-reference Layers.
   //
-  // Enterprise subsystem composition (#2563 slice 1/11 of #2017):
-  //   NoopEnterpriseDefaultsLayer  — 16 Context.Tags with no-op default impls
-  //   ConditionalEELayer           — when enterprise enabled, lazy-loads
-  //                                  @atlas/ee/layers and overrides defaults
-  //                                  via "last wins" merge semantics.
-  // The conditional layer is appended LAST so its Tag bindings override
-  // the no-op defaults when present.
+  // Enterprise subsystem composition (#2563 slice 1/11, #2564 slice 2/11
+  // of #2017): `EnterpriseLayer` is the composed no-op-defaults +
+  // conditional-EE Layer from `./enterprise-layer`. Appended last so its
+  // Tag bindings override the no-op defaults when EE loads (Layer.mergeAll
+  // "last wins" semantics).
   return Layer.mergeAll(
     TelemetryLive,
     configLayer,
@@ -1337,7 +1246,6 @@ export function buildAppLayer(config: ResolvedConfig): Layer.Layer<
     regionGuardLayer,
     pluginConfigGuardLayer,
     migrationGuardLayer,
-    NoopEnterpriseDefaultsLayer,
-    ConditionalEELayer,
+    EnterpriseLayer,
   );
 }

--- a/packages/api/src/lib/effect/services.ts
+++ b/packages/api/src/lib/effect/services.ts
@@ -811,23 +811,101 @@ export function createAuthContextTestLayer(
 // change for a no-op default that already returns the "feature disabled"
 // sentinel.
 
-// ── ResidencyResolver (#2564) ────────────────────────────────────────
+// ── ResidencyResolver (#2564 — slice 2/11 of #2017) ──────────────────
 //
-// Replaces `await import("@atlas/ee/platform/residency")` in
-// `lib/db/connection.ts`. EE resolves an org's home region for
-// per-region pool routing; core's no-op returns `null` (single-region).
+// Inverts `await import("@atlas/ee/platform/residency")` across
+// `lib/db/connection.ts`, `api/routes/platform-residency.ts`, and
+// `api/routes/shared-residency.ts`. The Tag exposes the module's public
+// surface as Effect-returning methods (plus an `available` discriminator
+// for routes that need to render an "unavailable" branch). The no-op
+// default returns the "feature disabled" shape so self-hosted builds
+// without EE branch cleanly; EE's `ee/src/layers.ts` overlays the real
+// `Layer.effect`. `ResidencyError` lives in `lib/residency/errors.ts`
+// so this contract can be typed without pulling in `@atlas/ee`.
+
+type ResidencyRegionRoute = {
+  readonly databaseUrl: string;
+  readonly datasourceUrl?: string;
+  readonly region: string;
+};
+type RegionStatus = import("@useatlas/types").RegionStatus;
+type WorkspaceRegion = import("@useatlas/types").WorkspaceRegion;
+type ResidencyConfigRegions = import("@atlas/api/lib/config").ResidencyConfig["regions"];
+type ResidencyError = import("@atlas/api/lib/residency/errors").ResidencyError;
 
 export interface ResidencyResolverShape {
-  readonly resolveRegion: (orgId: string) => Promise<string | null>;
+  /** False when EE residency is not loaded — routes should surface "not_available". */
+  readonly available: boolean;
+  /** Region-route lookup used by `connection.ts` to overlay per-region datasources. */
+  readonly resolveRegionDatabaseUrl: (
+    workspaceId: string,
+  ) => Effect.Effect<ResidencyRegionRoute | null>;
+  /** Configured regions with workspace counts. Fails with `ResidencyError("not_configured")` when no-op. */
+  readonly listRegions: () => Effect.Effect<RegionStatus[], ResidencyError>;
+  /** Default region. Throws `ResidencyError("not_configured")` synchronously when no-op. */
+  readonly getDefaultRegion: () => string;
+  /** Region-id → config map. Throws `ResidencyError("not_configured")` synchronously when no-op. */
+  readonly getConfiguredRegions: () => ResidencyConfigRegions;
+  /** Assign a region to a workspace. Region is immutable once set. */
+  readonly assignWorkspaceRegion: (
+    workspaceId: string,
+    region: string,
+  ) => Effect.Effect<WorkspaceRegion, ResidencyError | Error>;
+  /** Get a workspace's region assignment, or null if unassigned. */
+  readonly getWorkspaceRegionAssignment: (
+    workspaceId: string,
+  ) => Effect.Effect<WorkspaceRegion | null, ResidencyError | Error>;
+  /** All workspace region assignments (admin view). */
+  readonly listWorkspaceRegions: () => Effect.Effect<WorkspaceRegion[], ResidencyError | Error>;
+  /** True when `region` is a configured region. */
+  readonly isConfiguredRegion: (region: string) => boolean;
 }
 export class ResidencyResolver extends Context.Tag("ResidencyResolver")<
   ResidencyResolver,
   ResidencyResolverShape
 >() {}
+
+/**
+ * No-op default: residency is unavailable. Effect-returning methods
+ * fail with `ResidencyError("not_configured")` or return null/empty
+ * sentinels — whichever matches the prior "EE module missing" behavior
+ * at the call site. Synchronous getters throw the same error so the
+ * existing `try { mod.getDefaultRegion() } catch (err instanceof mod.ResidencyError)`
+ * branch in routes still fires unchanged.
+ *
+ * Lazy-requires the error class to keep this module free of a hard
+ * import on `lib/residency/errors` — services.ts is reached very early
+ * in the dep graph and an eager import there has bitten us before with
+ * mock.module() ordering surprises (see feedback_bun_test_async_mock_module).
+ */
 export const NoopResidencyResolverLayer: Layer.Layer<ResidencyResolver> =
-  Layer.succeed(ResidencyResolver, {
-    resolveRegion: async () => null,
-  } satisfies ResidencyResolverShape);
+  Layer.sync(ResidencyResolver, () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { ResidencyError: ResidencyErrorClass } = require("@atlas/api/lib/residency/errors") as {
+      ResidencyError: new (args: { message: string; code: "not_configured" }) => ResidencyError;
+    };
+    const notConfigured = () =>
+      new ResidencyErrorClass({
+        message:
+          "Data residency is not configured. Add a 'residency' section to atlas.config.ts with region definitions.",
+        code: "not_configured",
+      });
+    return {
+      available: false,
+      resolveRegionDatabaseUrl: () => Effect.succeed(null),
+      listRegions: () => Effect.fail(notConfigured()),
+      getDefaultRegion: () => {
+        throw notConfigured();
+      },
+      getConfiguredRegions: () => {
+        throw notConfigured();
+      },
+      assignWorkspaceRegion: () => Effect.fail(notConfigured()),
+      getWorkspaceRegionAssignment: () => Effect.succeed(null),
+      listWorkspaceRegions: () => Effect.succeed([]),
+      isConfiguredRegion: () => false,
+    } satisfies ResidencyResolverShape;
+  });
 
 // ── ModelRouter (#2565) ──────────────────────────────────────────────
 //

--- a/packages/api/src/lib/residency/errors.ts
+++ b/packages/api/src/lib/residency/errors.ts
@@ -1,0 +1,25 @@
+/**
+ * Residency error class — promoted to core in #2564 so the
+ * `ResidencyResolver` Tag in `lib/effect/services.ts` can expose typed
+ * failure channels without core code needing to import from `@atlas/ee`.
+ *
+ * EE's `ee/src/platform/residency.ts` re-exports this same class for
+ * back-compat. The structural identity (`_tag === "ResidencyError"` +
+ * `{ message, code }` payload) means existing `instanceof` checks and
+ * `domainError(ResidencyError, ...)` mappings work unchanged whether the
+ * class is loaded from core or via the EE re-export.
+ */
+
+import { Data } from "effect";
+
+export type ResidencyErrorCode =
+  | "not_configured"
+  | "invalid_region"
+  | "already_assigned"
+  | "workspace_not_found"
+  | "no_internal_db";
+
+export class ResidencyError extends Data.TaggedError("ResidencyError")<{
+  message: string;
+  code: ResidencyErrorCode;
+}> {}


### PR DESCRIPTION
## Summary

Slice 2/11 of #2017 (1.5.1 — Architecture Deepening). Inverts every `await import(\"@atlas/ee/platform/residency\")` in `packages/api/src/` so core depends on the `ResidencyResolver` Tag (introduced in #2563) instead of the EE module directly.

EE overlays the real implementation through a new `ResidencyResolverLive` Layer aggregated in `ee/src/layers.ts:EELayer`. Self-hosted falls through to the no-op default in `services.ts` (returns `available: false`, so route handlers branch on the "feature unavailable" path without any dynamic-import gymnastics).

## What changed

**Foundation**
- `ResidencyError` (Data.TaggedError) promoted to `lib/residency/errors.ts` so the Tag can type its failure channel without core importing `@atlas/ee`. EE re-exports for back-compat (same `_tag`, same payload, same `instanceof` semantics).
- `ResidencyResolverShape` widened in `lib/effect/services.ts` to expose the full module surface routes need. No-op default returns \"not_configured\" sentinels matching the pre-#2564 behavior.
- `EnterpriseLayer` + `EnterpriseSubsystem` extracted to a new lightweight `lib/effect/enterprise-layer.ts` so the Hono bridge can import it without pulling the full startup DAG. Pulling it via `layers.ts` was breaking partial `mock.module()` setups in ~20 existing tests because the chain transitively required `makeInternalDBLive`, `isInternalCircuitOpen`, etc.
- `runEffect` / `runHandler` now always provide `EnterpriseLayer` per-request, so routes `yield* ResidencyResolver` without each handler threading the layer through manually. Construction is cheap (no-op defaults are constants, conditional EE load hits Node's module cache after the first request).

**Call sites migrated**
- `lib/db/connection.ts:getRegionAwareConnection` — one-shot `Effect.runPromise(... pipe(Effect.provide(EnterpriseLayer)))` since the caller (`sql.ts`) is plain async.
- `api/routes/platform-residency.ts` — `yield* ResidencyResolver` with `if (!residency.available)` branch for the 404 not_available path. Local `loadResidency`/`residencyDomainError` removed; uses shared.
- `api/routes/admin-residency.ts` + `api/routes/onboarding.ts` — same; `loadResidency()` (with the lazy-loader and lazy-init `getResidencyDomainError`) retired entirely. `residencyDomainError` is now a static top-level constant in `shared-residency.ts`.

**Tests**
- `region-aware-connection.test.ts` — switched from `mock.module(\"@atlas/ee/platform/residency\")` to `mock.module(\"@atlas/ee/layers\")` injecting a test `ResidencyResolverLive` so `ConditionalEELayer` picks it up. Enterprise is enabled in the test via env + config-mock so the conditional fires.
- `admin-residency.test.ts` — services module-mock now provides `ResidencyResolver` as an iterable Tag with a mutable `mockResidencyResolver` shape (tests still flip `mockResidencyConfigured` etc. between scenarios). `MockResidencyError` constructor adapted to the Data.TaggedError `{ message, code }` signature; `@atlas/api/lib/residency/errors` mocked so the route's `instanceof ResidencyError` check uses the same class the test throws.

## Acceptance criteria

- [x] No `@atlas/ee/platform/residency` imports anywhere in `packages/api/src/` (only comments + test mocks remain — closeout grep in #2573 will exclude both)
- [x] EE residency layer wired through `buildAppLayer()` aggregation in `ee/src/layers.ts`
- [x] Residency tests still pass (no behavior change for SaaS multi-region; self-hosted single-region behavior unchanged)
- [x] `bun run test:api` green (412/412)
- [x] `/ci` gates: lint + type + test + syncpack + template-drift + railway-watch + schema-drift + security-headers + oauth-helper — all pass

## Test plan

- [x] `bun run test:api` — 412/412 pass
- [x] `bun run test:others` — pass
- [x] `bun run lint` — clean (one pre-existing warning in `detect.test.ts` unrelated to this slice)
- [x] `bun run type` — clean
- [x] CI gates green
- [ ] Wait for required-checks (ci, api-tests 1/4–4/4, Deploy Validation, Analyze) on the head SHA before merging — never \`--admin\` past a slow gate

Closes #2564