### PR TITLE
refactor(api): 1.5.1 invert slice 3/11 — Model routing via ModelRouter Tag

### DIFF
--- a/ee/src/layers.ts
+++ b/ee/src/layers.ts
@@ -8,18 +8,23 @@
  * Tags by "last wins", so EE's real implementations override core's
  * no-op defaults.
  *
- * Slice 2/11 (#2564) — appends the real `ResidencyResolver` Layer so
- * core call sites (`lib/db/connection.ts`, platform residency routes,
- * `shared-residency.ts`) can `yield* ResidencyResolver` and get EE's
- * full implementation when enterprise is enabled. Later slices
- * (#2565–#2572) follow the same pattern: one Tag, one Layer entry.
+ * Slice 2/11 (#2564) — added `ResidencyResolverLive`.
+ * Slice 3/11 (#2565) — added `ModelRouterLive` so core call sites
+ *   (`lib/agent.ts`, `lib/scheduler/byot-catalog-refresh.ts`,
+ *   `api/routes/admin-model-config.ts`) can `yield* ModelRouter` and
+ *   get EE's full BYOT model-routing implementation.
  *
- * See the parent issue (#2017) for the architectural rationale.
+ * Later slices (#2566–#2572) follow the same pattern: one Tag, one
+ * Layer entry. See the parent issue (#2017) for the rationale.
  */
 
 import { Layer } from "effect";
-import type { ResidencyResolver } from "@atlas/api/lib/effect/services";
+import type {
+  ModelRouter,
+  ResidencyResolver,
+} from "@atlas/api/lib/effect/services";
 import { ResidencyResolverLive } from "./platform/residency";
+import { ModelRouterLive } from "./platform/model-routing";
 
 /**
  * Aggregated EE Layer — typed by the union of every Tag this module
@@ -27,6 +32,7 @@ import { ResidencyResolverLive } from "./platform/residency";
  * import a new slice's Layer) surfaces as a `tsgo` error rather than
  * silently falling through to the no-op default at runtime.
  */
-export const EELayer: Layer.Layer<ResidencyResolver> = Layer.mergeAll(
+export const EELayer: Layer.Layer<ResidencyResolver | ModelRouter> = Layer.mergeAll(
   ResidencyResolverLive,
+  ModelRouterLive,
 );

--- a/ee/src/platform/model-routing.ts
+++ b/ee/src/platform/model-routing.ts
@@ -9,7 +9,7 @@
  * All exported functions return Effect — callers use `yield*` in Effect.gen.
  */
 
-import { Data, Effect } from "effect";
+import { Effect, Layer } from "effect";
 import { requireEnterpriseEffect, EnterpriseError } from "../index";
 import { requireInternalDBEffect } from "../lib/db-guard";
 import {
@@ -44,29 +44,38 @@ import type {
   TestModelConfigRequest,
 } from "@useatlas/types";
 import { MODEL_CONFIG_PROVIDERS } from "@useatlas/types";
+import {
+  ModelRouter,
+  type ModelRouterShape,
+} from "@atlas/api/lib/effect/services";
+import {
+  ModelConfigError,
+  ModelConfigDecryptError,
+  type ModelConfigErrorCode,
+} from "@atlas/api/lib/model-routing/errors";
+import type {
+  WorkspaceCredentials,
+  RawWorkspaceModelConfig,
+} from "@atlas/api/lib/auth/credentials";
 
 const log = createLogger("ee:model-routing");
 
 // ── Typed errors ────────────────────────────────────────────────────
 
-export type ModelConfigErrorCode = "validation" | "not_found" | "test_failed";
-
-export class ModelConfigError extends Data.TaggedError("ModelConfigError")<{
-  message: string;
-  code: ModelConfigErrorCode;
-}> {}
-
 /**
- * Raised by `getWorkspaceModelConfigRaw` when an encrypted API key cannot be
- * decrypted (typically a key-rotation drift between `ATLAS_ENCRYPTION_KEYS`
- * and the row's `api_key_key_version`). The agent loop must surface this to
- * the user — silently falling back to the platform default would bill the
- * platform without consent.
+ * `ModelConfigError`, `ModelConfigDecryptError`, and `ModelConfigErrorCode`
+ * live in `@atlas/api/lib/model-routing/errors` post-#2565 so the
+ * `ModelRouter` Tag in `lib/effect/services.ts` can type its failure
+ * channels without core code importing from `@atlas/ee`. Re-exported
+ * here for back-compat — pre-#2565 EE consumers continue to find these
+ * symbols at the same path with the same `_tag`, payload shape, and
+ * `instanceof` semantics.
  */
-export class ModelConfigDecryptError extends Data.TaggedError("ModelConfigDecryptError")<{
-  configId: string;
-  cause: string;
-}> {}
+export {
+  ModelConfigError,
+  ModelConfigDecryptError,
+  type ModelConfigErrorCode,
+};
 
 // ── Internal row shape ──────────────────────────────────────────────
 
@@ -96,31 +105,24 @@ interface ModelConfigRow {
 // alias in `@atlas/api/lib/bedrock-catalog` now resolves to the same type.
 
 /**
- * Discriminated union over the typed cred material a workspace row
- * carries after `api_key_encrypted` is decrypted. Internal to the
- * BYOT boundary — never appears on the wire.
- *
- * The bedrock arm's `bundle` is nullable so the post-decrypt JSON
- * shape failure travels as data rather than as a thrown error —
- * keeping it distinct from a true crypto failure
- * (`ModelConfigDecryptError`), which the row mapper raises before this
- * union is ever constructed.
+ * `WorkspaceCredentials` (the typed cred material a workspace row
+ * carries after decrypt) lives in `@atlas/api/lib/auth/credentials`
+ * post-#2565 so the `ModelRouter` Tag can type its method signatures
+ * without importing from `@atlas/ee`. Re-exported here for back-compat —
+ * `RawWorkspaceModelConfig` further down the file pulls from the same
+ * core module for consistency.
  */
-export type WorkspaceCredentials =
-  | { provider: "bedrock"; bundle: BedrockCredentialBundle | null }
-  | {
-      provider: Exclude<ModelConfigProvider, "bedrock" | "gateway">;
-      apiKey: string;
-    }
-  | { provider: "gateway"; apiKey: string | null };
+export type { WorkspaceCredentials };
 
 /**
- * Parse a string-encoded Bedrock credential bundle. Private to this
- * module — interpreting a stored row goes through the typed
- * `WorkspaceCredentials` union; the parser is only legal for
- * user-supplied form input on the test-config path.
+ * Parse a string-encoded Bedrock credential bundle. Exported so the
+ * `ModelRouter` Tag's `parseBedrockCredentialBundle` accessor can wrap
+ * it (used by the BYOT catalog refresh scheduler to build the cred
+ * payload before calling the bedrock catalog). Inside this module the
+ * call sites are unchanged — `getWorkspaceModelConfigRaw` routes
+ * through `buildWorkspaceCredentials` for the typed union.
  */
-function parseBedrockCredentialBundle(raw: string): BedrockCredentialBundle | null {
+export function parseBedrockCredentialBundle(raw: string): BedrockCredentialBundle | null {
   let parsed: unknown;
   try {
     parsed = JSON.parse(raw);
@@ -365,23 +367,17 @@ export const getWorkspaceModelConfig = (
   });
 
 /**
- * Decrypted workspace model configuration, internal shape. Returned by
- * `getWorkspaceModelConfigRaw` for the AI Layer + admin route layer.
+ * `RawWorkspaceModelConfig` (decrypted workspace model configuration,
+ * returned by `getWorkspaceModelConfigRaw` for the AI Layer + admin
+ * route layer) lives in `@atlas/api/lib/auth/credentials` post-#2565
+ * so the `ModelRouter` Tag's method signatures stay in core. Re-exported
+ * here so existing EE consumers find the type at the same path.
  *
- * The `credentials` field carries the typed cred material via a
- * discriminated union, so consumers no longer re-parse the JSON bundle
- * for bedrock or fork on `provider === "bedrock"` to read a separate
- * `apiKey` shape — they switch on `credentials.provider` and read the
- * matching field. The wire shape of `WorkspaceModelConfig` is
- * unchanged (it carries a masked `apiKeyMasked` + `apiKeyStatus`).
+ * The wire shape of `WorkspaceModelConfig` is unchanged (it carries a
+ * masked `apiKeyMasked` + `apiKeyStatus`); consumers switch on
+ * `credentials.provider` and read the matching field.
  */
-export interface RawWorkspaceModelConfig {
-  readonly provider: ModelConfigProvider;
-  readonly model: string;
-  readonly baseUrl: string | null;
-  readonly bedrockRegion: string | null;
-  readonly credentials: WorkspaceCredentials;
-}
+export type { RawWorkspaceModelConfig };
 
 /**
  * Build a `WorkspaceCredentials` value from a successfully decrypted
@@ -929,3 +925,37 @@ export const testModelConfig = (
       catch: promiseError,
     });
   });
+
+// ── Tag wiring (#2565 — slice 3/11 of #2017) ─────────────────────────
+//
+// Bridges this module's functions into the `ModelRouter` Tag so core
+// call sites (`lib/agent.ts`, `lib/scheduler/byot-catalog-refresh.ts`,
+// `api/routes/admin-model-config.ts`, …) can `yield* ModelRouter`
+// instead of dynamic-importing this module. Aggregated into
+// `ee/src/layers.ts:EELayer`; the no-op default in
+// `lib/effect/services.ts:NoopModelRouterLayer` covers self-hosted
+// installs where this module never loads.
+
+/**
+ * Build the `ModelRouter` service from this module's exports. Reports
+ * `available: true` so admin routes know to surface the real BYOT
+ * surface and the agent loop knows to attempt workspace-config
+ * resolution. Each method delegates to the corresponding function above;
+ * semantics are identical to the pre-#2565 dynamic-import path.
+ */
+export const makeModelRouterLive = (): ModelRouterShape => ({
+  available: true,
+  getWorkspaceModelConfig,
+  getWorkspaceModelConfigRaw,
+  setWorkspaceModelConfig,
+  deleteWorkspaceModelConfig,
+  testModelConfig,
+  reconcileModelDeprecation,
+  parseBedrockCredentialBundle,
+});
+
+/** Layer that registers the real model router under the core Tag. */
+export const ModelRouterLive: Layer.Layer<ModelRouter> = Layer.sync(
+  ModelRouter,
+  makeModelRouterLive,
+);

--- a/packages/api/src/api/__tests__/admin-model-config.test.ts
+++ b/packages/api/src/api/__tests__/admin-model-config.test.ts
@@ -19,7 +19,7 @@ import {
   mock,
   type Mock,
 } from "bun:test";
-import { Effect } from "effect";
+import { Effect, Layer } from "effect";
 import { createApiTestMocks } from "@atlas/api/testing/api-test-mocks";
 
 // --- Unified mocks with admin user in org-1 ---
@@ -165,6 +165,55 @@ function rawConfigFromLegacy(legacy: {
   };
 }
 
+// Core ResidencyError stub — the residency Noop layer lazy-requires it
+// when EnterpriseLayer constructs (slice 2 #2564 contract).
+mock.module("@atlas/api/lib/residency/errors", () => ({
+  ResidencyError: class ResidencyError extends Error {
+    public readonly _tag = "ResidencyError" as const;
+    constructor(args: { message: string; code: string }) {
+      super(args.message);
+    }
+  },
+}));
+
+// Core model-routing errors mocked so the route's
+// `domainError(ModelConfigError, ...)` mapping uses the same class
+// instances the mocked ModelRouter throws.
+mock.module("@atlas/api/lib/model-routing/errors", () => ({
+  ModelConfigError: MockModelConfigError,
+  ModelConfigDecryptError: MockModelConfigDecryptError,
+}));
+
+// Mock the EE layer aggregator instead of `@atlas/ee/platform/model-routing`
+// directly: post-#2565 the route resolves model routing via the
+// `ModelRouter` Tag, and the `ConditionalEELayer` in
+// `lib/effect/enterprise-layer.ts` lazy-imports `@atlas/ee/layers`.
+// The mocked aggregator binds the test's `mockXxx` functions to the
+// Tag so existing test fixtures (mockSetWorkspaceModelConfig.mock.calls,
+// mockReconcileModelDeprecation, etc.) keep working.
+mock.module("@atlas/ee/layers", () => ({
+  EELayer: Layer.unwrapEffect(
+    Effect.sync(() => {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const services = require("@atlas/api/lib/effect/services") as typeof import("@atlas/api/lib/effect/services");
+      return Layer.succeed(services.ModelRouter, {
+        available: true,
+        getWorkspaceModelConfig: mockGetWorkspaceModelConfig as never,
+        getWorkspaceModelConfigRaw: mockGetWorkspaceModelConfigRaw as never,
+        setWorkspaceModelConfig: mockSetWorkspaceModelConfig as never,
+        deleteWorkspaceModelConfig: mockDeleteWorkspaceModelConfig as never,
+        testModelConfig: mockTestModelConfig as never,
+        reconcileModelDeprecation: mockReconcileModelDeprecation as never,
+        parseBedrockCredentialBundle: () => null,
+      } as never);
+    }),
+  ),
+}));
+
+// Keep `@atlas/ee/platform/model-routing` mocked as a no-op stub so any
+// leftover transitive import path (e.g. another EE module re-exporting
+// from it) loads without partial-export errors. The route no longer
+// imports from this path directly post-#2565.
 mock.module("@atlas/ee/platform/model-routing", () => ({
   getWorkspaceModelConfig: mockGetWorkspaceModelConfig,
   getWorkspaceModelConfigRaw: mockGetWorkspaceModelConfigRaw,
@@ -172,6 +221,7 @@ mock.module("@atlas/ee/platform/model-routing", () => ({
   deleteWorkspaceModelConfig: mockDeleteWorkspaceModelConfig,
   testModelConfig: mockTestModelConfig,
   reconcileModelDeprecation: mockReconcileModelDeprecation,
+  parseBedrockCredentialBundle: () => null,
   ModelConfigError: MockModelConfigError,
   ModelConfigDecryptError: MockModelConfigDecryptError,
 }));

--- a/packages/api/src/api/routes/admin-model-config.ts
+++ b/packages/api/src/api/routes/admin-model-config.ts
@@ -9,17 +9,13 @@ import { Effect } from "effect";
 import { createRoute, z } from "@hono/zod-openapi";
 import { hasInternalDB } from "@atlas/api/lib/db/internal";
 import { runEffect, domainError } from "@atlas/api/lib/effect/hono";
-import { RequestContext, AuthContext } from "@atlas/api/lib/effect/services";
 import {
-  getWorkspaceModelConfig,
-  getWorkspaceModelConfigRaw,
-  setWorkspaceModelConfig,
-  deleteWorkspaceModelConfig,
-  testModelConfig,
-  reconcileModelDeprecation,
-  ModelConfigError,
-  type RawWorkspaceModelConfig,
-} from "@atlas/ee/platform/model-routing";
+  RequestContext,
+  AuthContext,
+  ModelRouter,
+} from "@atlas/api/lib/effect/services";
+import { ModelConfigError } from "@atlas/api/lib/model-routing/errors";
+import type { RawWorkspaceModelConfig } from "@atlas/api/lib/auth/credentials";
 import { WorkspaceModelConfigSchema as ModelConfigSchema } from "@useatlas/schemas";
 import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
 import { getGatewayCatalog } from "@atlas/api/lib/gateway-catalog";
@@ -242,6 +238,7 @@ adminModelConfig.openapi(getConfigRoute, async (c) => {
   return runEffect(c, Effect.gen(function* () {
     const { requestId } = yield* RequestContext;
     const { orgId } = yield* AuthContext;
+    const router = yield* ModelRouter;
 
     if (!hasInternalDB()) {
       return c.json({ error: "not_available", message: "No internal database configured.", requestId }, 404);
@@ -251,7 +248,7 @@ adminModelConfig.openapi(getConfigRoute, async (c) => {
       return c.json({ error: "bad_request", message: "No active organization. Set an active org first.", requestId }, 400);
     }
 
-    const config = yield* getWorkspaceModelConfig(orgId);
+    const config = yield* router.getWorkspaceModelConfig(orgId);
     return c.json({ config }, 200);
   }), { label: "get workspace model config", domainErrors: [modelConfigDomainError] });
 });
@@ -261,6 +258,7 @@ adminModelConfig.openapi(setConfigRoute, async (c) => {
   return runEffect(c, Effect.gen(function* () {
     const { requestId } = yield* RequestContext;
     const { orgId } = yield* AuthContext;
+    const router = yield* ModelRouter;
 
     if (!hasInternalDB()) {
       return c.json({ error: "not_available", message: "No internal database configured.", requestId }, 404);
@@ -279,7 +277,7 @@ adminModelConfig.openapi(setConfigRoute, async (c) => {
     // the "existing key" for a BYOT-provider transition — there's no key
     // to preserve.
     if (!body.apiKey && body.provider !== "gateway") {
-      const existing = yield* getWorkspaceModelConfig(orgId);
+      const existing = yield* router.getWorkspaceModelConfig(orgId);
       if (!existing || existing.apiKeyStatus !== "masked") {
         return c.json(
           {
@@ -303,7 +301,7 @@ adminModelConfig.openapi(setConfigRoute, async (c) => {
       hasSecret: body.apiKey !== undefined,
       ...(body.bedrockRegion ? { bedrockRegion: body.bedrockRegion } : {}),
     };
-    const config = yield* setWorkspaceModelConfig(orgId, {
+    const config = yield* router.setWorkspaceModelConfig(orgId, {
       provider: body.provider,
       model: body.model,
       apiKey: body.apiKey,
@@ -342,6 +340,7 @@ adminModelConfig.openapi(deleteConfigRoute, async (c) => {
   return runEffect(c, Effect.gen(function* () {
     const { requestId } = yield* RequestContext;
     const { orgId } = yield* AuthContext;
+    const router = yield* ModelRouter;
 
     if (!hasInternalDB()) {
       return c.json({ error: "not_available", message: "No internal database configured.", requestId }, 404);
@@ -351,7 +350,7 @@ adminModelConfig.openapi(deleteConfigRoute, async (c) => {
       return c.json({ error: "bad_request", message: "No active organization. Set an active org first.", requestId }, 400);
     }
 
-    const deleted = yield* deleteWorkspaceModelConfig(orgId).pipe(
+    const deleted = yield* router.deleteWorkspaceModelConfig(orgId).pipe(
       Effect.tapError((err) =>
         Effect.sync(() =>
           logAdminAction({
@@ -385,6 +384,7 @@ adminModelConfig.openapi(testConfigRoute, async (c) => {
   return runEffect(c, Effect.gen(function* () {
     const { requestId } = yield* RequestContext;
     const { orgId } = yield* AuthContext;
+    const router = yield* ModelRouter;
 
     if (!orgId) {
       return c.json({ error: "bad_request", message: "No active organization. Set an active org first.", requestId }, 400);
@@ -401,7 +401,7 @@ adminModelConfig.openapi(testConfigRoute, async (c) => {
       model: body.model,
       ...(body.bedrockRegion ? { bedrockRegion: body.bedrockRegion } : {}),
     };
-    const result = yield* testModelConfig({
+    const result = yield* router.testModelConfig({
       provider: body.provider,
       model: body.model,
       apiKey: body.apiKey,
@@ -447,6 +447,7 @@ adminModelConfig.openapi(catalogRoute, async (c) => {
   return runEffect(c, Effect.gen(function* () {
     const { requestId } = yield* RequestContext;
     const { orgId } = yield* AuthContext;
+    const router = yield* ModelRouter;
     const { provider: requestedProvider, refresh: refreshRaw } = c.req.valid("query");
     const provider = requestedProvider ?? "gateway";
     const refresh = refreshRaw === "1" || refreshRaw === "true";
@@ -481,7 +482,7 @@ adminModelConfig.openapi(catalogRoute, async (c) => {
     // Decrypt errors surface as 422 with a clear "re-enter the key" message
     // rather than as a generic 500. Shared across every BYOT direct-provider
     // path below.
-    const rawConfigOrDecryptError = yield* getWorkspaceModelConfigRaw(orgId).pipe(
+    const rawConfigOrDecryptError = yield* router.getWorkspaceModelConfigRaw(orgId).pipe(
       Effect.map((cfg) => ({ ok: true as const, cfg })),
       Effect.catchTag("ModelConfigDecryptError", (err) =>
         Effect.succeed({ ok: false as const, err }),
@@ -621,7 +622,7 @@ adminModelConfig.openapi(catalogRoute, async (c) => {
       // `model_status` stale until the next refresh. We log the failure
       // explicitly so prod dashboards can spot a degraded reconcile
       // pattern instead of silently divergent state.
-      yield* reconcileModelDeprecation(
+      yield* router.reconcileModelDeprecation(
         orgId,
         rawConfig.model,
         adapter.providerKey,

--- a/packages/api/src/lib/agent.ts
+++ b/packages/api/src/lib/agent.ts
@@ -47,6 +47,8 @@ import {
   context as otelContext,
 } from "@opentelemetry/api";
 import { AtlasAiModel, type AtlasAiModelShape } from "./effect/ai";
+import { ModelRouter } from "./effect/services";
+import { EnterpriseLayer } from "./effect/enterprise-layer";
 import { BOUND_AGENT_PROMPT_GUIDANCE } from "./bound-chat-context";
 
 const log = createLogger("agent");
@@ -660,29 +662,34 @@ export async function runAgent({
     model = injectedAiModel.model;
     providerType = injectedAiModel.providerType;
   } else {
-    let workspaceConfig: import("@atlas/ee/platform/model-routing").RawWorkspaceModelConfig | null = null;
+    let workspaceConfig: import("@atlas/api/lib/auth/credentials").RawWorkspaceModelConfig | null = null;
     if (orgId && hasInternalDB()) {
-      const { Effect } = await import("effect");
-      const { getWorkspaceModelConfigRaw, ModelConfigDecryptError } =
-        await import("@atlas/ee/platform/model-routing");
+      // Resolve workspace model config via the `ModelRouter` Tag — EE
+      // provides the real implementation; self-hosted (no EE) sees the
+      // no-op default which returns null and the platform-default path
+      // below fires. Decrypt failure still surfaces as a user-visible
+      // error so the platform isn't silently billed against the
+      // workspace's consent. Other failures (DB unreachable, EE
+      // disabled, internal-query rejected) keep the
+      // log-and-fall-through behavior.
+      const { ModelConfigDecryptError } = await import(
+        "@atlas/api/lib/model-routing/errors"
+      );
+      const program = Effect.gen(function* () {
+        const router = yield* ModelRouter;
+        return yield* router.getWorkspaceModelConfigRaw(orgId);
+      });
       try {
-        workspaceConfig = await Effect.runPromise(getWorkspaceModelConfigRaw(orgId));
+        workspaceConfig = await Effect.runPromise(
+          program.pipe(Effect.provide(EnterpriseLayer)),
+        );
       } catch (err) {
-        // A decrypt failure must surface to the user — silently falling back
-        // to the platform default would bill the platform against their will.
-        // Other errors (DB unreachable, enterprise disabled, etc.) keep the
-        // existing log-and-fall-through behavior.
         if (err instanceof ModelConfigDecryptError) {
           throw new Error(
             "Your workspace's API key could not be decrypted. Re-enter it on the AI Provider settings page before continuing.",
             { cause: err },
           );
         }
-        // log.warn — the workspace may have intended to be billed
-        // against their own BYOT key; falling back to the platform
-        // default after a non-decrypt error (DB unreachable, EE
-        // disabled, internal-query failure) bills the platform on
-        // their behalf. Quiet-debug here would hide that swap.
         log.warn(
           { orgId, err: err instanceof Error ? err.message : String(err) },
           "Workspace model config not available — falling back to platform default",

--- a/packages/api/src/lib/auth/credentials.ts
+++ b/packages/api/src/lib/auth/credentials.ts
@@ -1,0 +1,48 @@
+/**
+ * Workspace credential types — promoted to core in #2565 so the
+ * `ModelRouter` Tag in `lib/effect/services.ts`, the AI Layer in
+ * `lib/effect/ai.ts`, and the provider factory in `lib/providers.ts`
+ * can type the `credentials` field without importing the type from
+ * `@atlas/ee/platform/model-routing`.
+ *
+ * EE's `ee/src/platform/model-routing.ts` re-exports both types for
+ * back-compat. The shapes are wire-compatible; no consumer needs to
+ * change anything other than the import path.
+ */
+
+import type { BedrockCredentialBundle, ModelConfigProvider } from "@useatlas/types";
+
+/**
+ * Discriminated union over the typed credential material a workspace
+ * row carries after `api_key_encrypted` is decrypted. Internal to the
+ * BYOT boundary — never appears on the wire.
+ *
+ * The bedrock arm's `bundle` is nullable so the post-decrypt JSON
+ * shape failure travels as data rather than as a thrown error —
+ * distinct from a true crypto failure (`ModelConfigDecryptError`),
+ * which the row mapper raises before this union is ever constructed.
+ */
+export type WorkspaceCredentials =
+  | { provider: "bedrock"; bundle: BedrockCredentialBundle | null }
+  | {
+      provider: Exclude<ModelConfigProvider, "bedrock" | "gateway">;
+      apiKey: string;
+    }
+  | { provider: "gateway"; apiKey: string | null };
+
+/**
+ * Decrypted workspace model configuration. Returned by the
+ * `ModelRouter.getWorkspaceModelConfigRaw` accessor for the AI Layer
+ * + admin route layer.
+ *
+ * Consumers switch on `credentials.provider` and read the matching
+ * field; the wire shape of `WorkspaceModelConfig` is unchanged (it
+ * carries a masked `apiKeyMasked` + `apiKeyStatus`).
+ */
+export interface RawWorkspaceModelConfig {
+  readonly provider: ModelConfigProvider;
+  readonly model: string;
+  readonly baseUrl: string | null;
+  readonly bedrockRegion: string | null;
+  readonly credentials: WorkspaceCredentials;
+}

--- a/packages/api/src/lib/effect/ai.ts
+++ b/packages/api/src/lib/effect/ai.ts
@@ -167,7 +167,7 @@ export function makeWorkspaceAiModelLayer(config: {
   model: string;
   baseUrl: string | null;
   bedrockRegion: string | null;
-  credentials: import("@atlas/ee/platform/model-routing").WorkspaceCredentials;
+  credentials: import("@atlas/api/lib/auth/credentials").WorkspaceCredentials;
 }): Layer.Layer<AtlasAiModel, Error> {
   return Layer.effect(
     AtlasAiModel,

--- a/packages/api/src/lib/effect/services.ts
+++ b/packages/api/src/lib/effect/services.ts
@@ -931,6 +931,7 @@ type ModelConfigError = import("@atlas/api/lib/model-routing/errors").ModelConfi
 type ModelConfigDecryptError = import("@atlas/api/lib/model-routing/errors").ModelConfigDecryptError;
 type EnterpriseError = import("@atlas/api/lib/effect/errors").EnterpriseError;
 type BedrockCredentialBundle = import("@useatlas/types").BedrockCredentialBundle;
+type GatewayCatalogModel = import("@useatlas/types").GatewayCatalogModel;
 
 export interface ModelRouterShape {
   /** False when EE model-routing is not loaded — admin routes surface "not_available", agent loop falls back to platform default. */
@@ -970,7 +971,7 @@ export interface ModelRouterShape {
     orgId: string,
     savedModelId: string,
     savedProvider: string,
-    freshCatalog: ReadonlyArray<{ readonly id: string; readonly provider: string }>,
+    freshCatalog: GatewayCatalogModel[],
   ) => Effect.Effect<{ status: "healthy" | "deprecated"; suggestion: string | null }, Error>;
   /**
    * Parse a Bedrock cred JSON bundle. Used by the scheduler's per-row

--- a/packages/api/src/lib/effect/services.ts
+++ b/packages/api/src/lib/effect/services.ts
@@ -907,25 +907,113 @@ export const NoopResidencyResolverLayer: Layer.Layer<ResidencyResolver> =
     } satisfies ResidencyResolverShape;
   });
 
-// ── ModelRouter (#2565) ──────────────────────────────────────────────
+// ── ModelRouter (#2565 — slice 3/11 of #2017) ────────────────────────
 //
-// Replaces `await import("@atlas/ee/platform/model-routing")` in
-// `lib/agent.ts` + `lib/scheduler/byot-catalog-refresh.ts`. EE resolves
-// per-workspace BYOT model config; core's no-op returns `null` so the
-// agent falls back to env-var-configured providers.
+// Inverts every `@atlas/ee/platform/model-routing` reference in
+// `packages/api/src/`: the dynamic import in `lib/agent.ts`, the
+// `EeModule` probe in `lib/scheduler/byot-catalog-refresh.ts`, the
+// static admin-route imports in `api/routes/admin-model-config.ts`,
+// and the type-only `WorkspaceCredentials` reaches in
+// `lib/providers.ts` + `lib/effect/ai.ts`. EE overlays the real
+// implementation; the no-op default returns `available: false` +
+// null-shaped methods so self-hosted falls back to the env-var
+// `getModel()` provider without dynamic imports.
+//
+// `WorkspaceCredentials` + `RawWorkspaceModelConfig` live in
+// `lib/auth/credentials.ts`; `ModelConfigError` +
+// `ModelConfigDecryptError` live in `lib/model-routing/errors.ts`.
+
+type WorkspaceModelConfig = import("@useatlas/types").WorkspaceModelConfig;
+type SetWorkspaceModelConfigRequest = import("@useatlas/types").SetWorkspaceModelConfigRequest;
+type TestModelConfigRequest = import("@useatlas/types").TestModelConfigRequest;
+type RawWorkspaceModelConfig = import("@atlas/api/lib/auth/credentials").RawWorkspaceModelConfig;
+type ModelConfigError = import("@atlas/api/lib/model-routing/errors").ModelConfigError;
+type ModelConfigDecryptError = import("@atlas/api/lib/model-routing/errors").ModelConfigDecryptError;
+type EnterpriseError = import("@atlas/api/lib/effect/errors").EnterpriseError;
+type BedrockCredentialBundle = import("@useatlas/types").BedrockCredentialBundle;
 
 export interface ModelRouterShape {
-  readonly getWorkspaceConfig: (orgId: string) => Promise<unknown | null>;
+  /** False when EE model-routing is not loaded — admin routes surface "not_available", agent loop falls back to platform default. */
+  readonly available: boolean;
+  /** Wire-safe (masked api key) workspace config for admin reads + agent reconcile. */
+  readonly getWorkspaceModelConfig: (
+    orgId: string,
+  ) => Effect.Effect<WorkspaceModelConfig | null, EnterpriseError | Error>;
+  /** Decrypted workspace config for provider resolution. WARNING: plaintext credentials. */
+  readonly getWorkspaceModelConfigRaw: (
+    orgId: string,
+  ) => Effect.Effect<RawWorkspaceModelConfig | null, ModelConfigDecryptError | Error>;
+  /** Create/update a workspace model config. */
+  readonly setWorkspaceModelConfig: (
+    orgId: string,
+    request: SetWorkspaceModelConfigRequest,
+  ) => Effect.Effect<WorkspaceModelConfig, EnterpriseError | ModelConfigError | Error>;
+  /** Delete the workspace config (returns whether a row was removed). */
+  readonly deleteWorkspaceModelConfig: (
+    orgId: string,
+  ) => Effect.Effect<boolean, EnterpriseError | Error>;
+  /** Probe a candidate provider+key against the upstream catalog. */
+  readonly testModelConfig: (
+    request: TestModelConfigRequest,
+  ) => Effect.Effect<
+    { success: boolean; message: string; modelName?: string },
+    EnterpriseError | ModelConfigError | Error
+  >;
+  /**
+   * Refresh the workspace's `model_status` against the latest catalog and
+   * surface any deprecation. Called from the admin reconcile button and
+   * the BYOT catalog refresh scheduler. Signature mirrors the EE function
+   * (`orgId`, `savedModelId`, `savedProvider`, `freshCatalog`) so the
+   * no-op layer can return the "healthy / no suggestion" sentinel.
+   */
+  readonly reconcileModelDeprecation: (
+    orgId: string,
+    savedModelId: string,
+    savedProvider: string,
+    freshCatalog: ReadonlyArray<{ readonly id: string; readonly provider: string }>,
+  ) => Effect.Effect<{ status: "healthy" | "deprecated"; suggestion: string | null }, Error>;
+  /**
+   * Parse a Bedrock cred JSON bundle. Used by the scheduler's per-row
+   * refresh path; returns null when the JSON shape doesn't validate.
+   */
+  readonly parseBedrockCredentialBundle: (apiKey: string) => BedrockCredentialBundle | null;
 }
 export class ModelRouter extends Context.Tag("ModelRouter")<
   ModelRouter,
   ModelRouterShape
 >() {}
-export const NoopModelRouterLayer: Layer.Layer<ModelRouter> = Layer.succeed(
+
+/**
+ * No-op default: BYOT model routing unavailable. Agent loop's
+ * workspace-config branch sees `available: false` and falls back to
+ * the env-var `getModel()` path. Admin routes branch on `available`
+ * to surface "feature unavailable".
+ *
+ * Lazy-requires the `EnterpriseError` class so this module stays free
+ * of eager imports on `lib/effect/errors` (services.ts is reached early
+ * in the dep graph; eager imports have caused mock.module() ordering
+ * surprises before — see feedback_bun_test_async_mock_module).
+ */
+export const NoopModelRouterLayer: Layer.Layer<ModelRouter> = Layer.sync(
   ModelRouter,
-  {
-    getWorkspaceConfig: async () => null,
-  } satisfies ModelRouterShape,
+  () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { EnterpriseError: EnterpriseErrorClass } = require("@atlas/api/lib/effect/errors") as {
+      EnterpriseError: new (message?: string) => EnterpriseError;
+    };
+    const notAvailable = () => new EnterpriseErrorClass("Model routing requires enterprise features to be enabled.");
+    return {
+      available: false,
+      getWorkspaceModelConfig: () => Effect.succeed(null),
+      getWorkspaceModelConfigRaw: () => Effect.succeed(null),
+      setWorkspaceModelConfig: () => Effect.fail(notAvailable()),
+      deleteWorkspaceModelConfig: () => Effect.succeed(false),
+      testModelConfig: () => Effect.fail(notAvailable()),
+      reconcileModelDeprecation: () =>
+        Effect.succeed({ status: "healthy" as const, suggestion: null }),
+      parseBedrockCredentialBundle: () => null,
+    } satisfies ModelRouterShape;
+  },
 );
 
 // ── MaskingPolicy (#2566) ────────────────────────────────────────────

--- a/packages/api/src/lib/model-routing/errors.ts
+++ b/packages/api/src/lib/model-routing/errors.ts
@@ -1,0 +1,32 @@
+/**
+ * Model-routing errors — promoted to core in #2565 so the
+ * `ModelRouter` Tag in `lib/effect/services.ts` can type its failure
+ * channels without core code importing from `@atlas/ee`.
+ *
+ * EE's `ee/src/platform/model-routing.ts` re-exports both classes for
+ * back-compat. The structural identity (`_tag` + payload shape) means
+ * existing `instanceof` checks and `domainError(...)` mappings work
+ * unchanged whether the class is loaded from core or via the EE
+ * re-export.
+ */
+
+import { Data } from "effect";
+
+export type ModelConfigErrorCode = "validation" | "not_found" | "test_failed";
+
+export class ModelConfigError extends Data.TaggedError("ModelConfigError")<{
+  message: string;
+  code: ModelConfigErrorCode;
+}> {}
+
+/**
+ * Raised when an encrypted API key cannot be decrypted (typically a key-
+ * rotation drift between `ATLAS_ENCRYPTION_KEYS` and the row's
+ * `api_key_key_version`). The agent loop must surface this to the user
+ * — silently falling back to the platform default would bill the
+ * platform without consent.
+ */
+export class ModelConfigDecryptError extends Data.TaggedError("ModelConfigDecryptError")<{
+  configId: string;
+  cause: string;
+}> {}

--- a/packages/api/src/lib/providers.ts
+++ b/packages/api/src/lib/providers.ts
@@ -19,7 +19,7 @@ import { gateway } from "ai";
 import type { LanguageModel } from "ai";
 import type { ModelConfigProvider } from "@useatlas/types";
 import { createLogger } from "./logger";
-import type { WorkspaceCredentials } from "@atlas/ee/platform/model-routing";
+import type { WorkspaceCredentials } from "@atlas/api/lib/auth/credentials";
 
 const log = createLogger("providers");
 

--- a/packages/api/src/lib/scheduler/__tests__/byot-catalog-refresh.test.ts
+++ b/packages/api/src/lib/scheduler/__tests__/byot-catalog-refresh.test.ts
@@ -16,7 +16,13 @@
  */
 
 import { describe, it, expect, beforeEach, mock } from "bun:test";
-import { Effect } from "effect";
+import { Effect, Layer } from "effect";
+
+// Force enterprise on so `ConditionalEELayer` in
+// `lib/effect/enterprise-layer.ts` lazy-imports the mocked
+// `@atlas/ee/layers` aggregator (otherwise the no-op default fires
+// and every test sees `available: false`).
+process.env.ATLAS_ENTERPRISE_ENABLED = "true";
 
 // ---------------------------------------------------------------------------
 // Mock control variables
@@ -112,22 +118,109 @@ class FakeDecryptError extends Error {
   }
 }
 
+// Mock the core ResidencyError class kept as a stub (the residency
+// no-op resolver lazy-requires it via the EnterpriseLayer's no-op
+// defaults — without a mock here, the require() fails when the test
+// runs in isolation).
+mock.module("@atlas/api/lib/residency/errors", () => ({
+  ResidencyError: class ResidencyError extends Error {
+    public readonly _tag = "ResidencyError" as const;
+    constructor(args: { message: string; code: string }) {
+      super(args.message);
+    }
+  },
+}));
+
+// Mock the core ModelConfigDecryptError so the route's
+// `Effect.catchTag("ModelConfigDecryptError", ...)` matches the
+// FakeDecryptError thrown by the test layer below.
+mock.module("@atlas/api/lib/model-routing/errors", () => ({
+  ModelConfigError: class ModelConfigError extends Error {
+    public readonly _tag = "ModelConfigError" as const;
+    public readonly code: string;
+    constructor(args: { message: string; code: string }) {
+      super(args.message);
+      this.code = args.code;
+    }
+  },
+  ModelConfigDecryptError: FakeDecryptError,
+}));
+
+// Build the ModelRouter the scheduler will see via the `EnterpriseLayer`.
+// `getWorkspaceModelConfigRaw` translates the test's legacy flat-config
+// shape to the new `RawWorkspaceModelConfig` (typed credentials union)
+// — the scheduler's `loadRawConfig` adapter collapses it back. This
+// keeps the per-test fixture format unchanged while exercising the new
+// Tag contract.
+mock.module("@atlas/ee/layers", () => ({
+  EELayer: Layer.unwrapEffect(
+    Effect.sync(() => {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const services = require("@atlas/api/lib/effect/services") as typeof import("@atlas/api/lib/effect/services");
+      return Layer.succeed(services.ModelRouter, {
+        available: true,
+        getWorkspaceModelConfig: () => Effect.die("not stubbed"),
+        getWorkspaceModelConfigRaw: (orgId: string) => {
+          const cfg = mockWorkspaceConfigs.get(orgId);
+          if (cfg === "DECRYPT_FAIL") {
+            return Effect.fail(new FakeDecryptError("cfg-" + orgId, "key rotated"));
+          }
+          if (!cfg) return Effect.succeed(null);
+          // Translate the flat fixture into the typed-credentials shape
+          // the new `RawWorkspaceModelConfig` exposes. The scheduler's
+          // adapter collapses it back to `{ apiKey }` for the per-row
+          // refresh path, so the rest of the test stays unchanged.
+          const credentials =
+            cfg.provider === "bedrock"
+              ? {
+                  provider: "bedrock" as const,
+                  bundle:
+                    cfg.apiKey && cfg.apiKey !== "BAD_BUNDLE"
+                      ? {
+                          accessKeyId: "AKIA-test",
+                          secretAccessKey: "secret-test",
+                          sessionToken: null,
+                        }
+                      : null,
+                }
+              : cfg.provider === "gateway"
+                ? { provider: "gateway" as const, apiKey: cfg.apiKey }
+                : {
+                    provider: cfg.provider as "anthropic" | "openai" | "azure-openai" | "custom",
+                    apiKey: cfg.apiKey ?? "",
+                  };
+          return Effect.succeed({
+            provider: cfg.provider,
+            model: cfg.model,
+            baseUrl: cfg.baseUrl,
+            bedrockRegion: cfg.bedrockRegion,
+            credentials,
+          });
+        },
+        setWorkspaceModelConfig: () => Effect.die("not stubbed"),
+        deleteWorkspaceModelConfig: () => Effect.die("not stubbed"),
+        testModelConfig: () => Effect.die("not stubbed"),
+        reconcileModelDeprecation: () =>
+          Effect.succeed({ status: "healthy" as const, suggestion: null }),
+        parseBedrockCredentialBundle: (apiKey: string) => {
+          if (apiKey === "BAD_BUNDLE") return null;
+          return {
+            accessKeyId: "AKIA-test",
+            secretAccessKey: "secret-test",
+            sessionToken: null,
+          };
+        },
+      } satisfies import("@atlas/api/lib/effect/services").ModelRouterShape);
+    }),
+  ),
+}));
+
+// Keep a stub for the EE module itself so any leftover transitive
+// imports (admin-router.ts etc.) load without crashing on partial exports.
 mock.module("@atlas/ee/platform/model-routing", () => ({
   ModelConfigDecryptError: FakeDecryptError,
-  getWorkspaceModelConfigRaw: (orgId: string) => {
-    const cfg = mockWorkspaceConfigs.get(orgId);
-    if (cfg === "DECRYPT_FAIL") {
-      return Effect.fail(new FakeDecryptError("cfg-" + orgId, "key rotated"));
-    }
-    return Effect.succeed(cfg ?? null);
-  },
-  parseBedrockCredentialBundle: (apiKey: string) => {
-    if (apiKey === "BAD_BUNDLE") return null;
-    return {
-      accessKeyId: "AKIA-test",
-      secretAccessKey: "secret-test",
-      sessionToken: null,
-    };
+  ModelConfigError: class extends Error {
+    public readonly _tag = "ModelConfigError" as const;
   },
 }));
 

--- a/packages/api/src/lib/scheduler/__tests__/byot-catalog-refresh.test.ts
+++ b/packages/api/src/lib/scheduler/__tests__/byot-catalog-refresh.test.ts
@@ -157,6 +157,7 @@ mock.module("@atlas/ee/layers", () => ({
     Effect.sync(() => {
       // eslint-disable-next-line @typescript-eslint/no-require-imports
       const services = require("@atlas/api/lib/effect/services") as typeof import("@atlas/api/lib/effect/services");
+      type ModelConfigProvider = import("@useatlas/types").ModelConfigProvider;
       return Layer.succeed(services.ModelRouter, {
         available: true,
         getWorkspaceModelConfig: () => Effect.die("not stubbed"),
@@ -167,30 +168,27 @@ mock.module("@atlas/ee/layers", () => ({
           }
           if (!cfg) return Effect.succeed(null);
           // Translate the flat fixture into the typed-credentials shape
-          // the new `RawWorkspaceModelConfig` exposes. The scheduler's
-          // adapter collapses it back to `{ apiKey }` for the per-row
-          // refresh path, so the rest of the test stays unchanged.
+          // the new `RawWorkspaceModelConfig` exposes. Cast the provider
+          // string up to `ModelConfigProvider`: the per-test fixtures
+          // only use canonical values ("bedrock" / "gateway" /
+          // "anthropic" / "openai"), so the cast is safe.
           const credentials =
             cfg.provider === "bedrock"
               ? {
                   provider: "bedrock" as const,
                   bundle:
                     cfg.apiKey && cfg.apiKey !== "BAD_BUNDLE"
-                      ? {
-                          accessKeyId: "AKIA-test",
-                          secretAccessKey: "secret-test",
-                          sessionToken: null,
-                        }
+                      ? { accessKeyId: "AKIA-test", secretAccessKey: "secret-test" }
                       : null,
                 }
               : cfg.provider === "gateway"
                 ? { provider: "gateway" as const, apiKey: cfg.apiKey }
                 : {
-                    provider: cfg.provider as "anthropic" | "openai" | "azure-openai" | "custom",
+                    provider: cfg.provider as Exclude<ModelConfigProvider, "bedrock" | "gateway">,
                     apiKey: cfg.apiKey ?? "",
                   };
           return Effect.succeed({
-            provider: cfg.provider,
+            provider: cfg.provider as ModelConfigProvider,
             model: cfg.model,
             baseUrl: cfg.baseUrl,
             bedrockRegion: cfg.bedrockRegion,
@@ -204,11 +202,7 @@ mock.module("@atlas/ee/layers", () => ({
           Effect.succeed({ status: "healthy" as const, suggestion: null }),
         parseBedrockCredentialBundle: (apiKey: string) => {
           if (apiKey === "BAD_BUNDLE") return null;
-          return {
-            accessKeyId: "AKIA-test",
-            secretAccessKey: "secret-test",
-            sessionToken: null,
-          };
+          return { accessKeyId: "AKIA-test", secretAccessKey: "secret-test" };
         },
       } satisfies import("@atlas/api/lib/effect/services").ModelRouterShape);
     }),

--- a/packages/api/src/lib/scheduler/byot-catalog-refresh.ts
+++ b/packages/api/src/lib/scheduler/byot-catalog-refresh.ts
@@ -344,10 +344,16 @@ async function refreshOne(row: StaleRow, now: number): Promise<RefreshOutcome> {
   // (the `malformed_bedrock_bundle` skip); other providers carry the
   // raw apiKey string. The fetcher takes both via separate args — the
   // bedrock fetch ignores `apiKey`, the others ignore `bedrockBundle`.
+  //
+  // Narrow on `row.provider` (the discriminator the rest of the file
+  // walks) rather than `config.credentials.provider`: the earlier
+  // `config.provider !== row.provider` early-return guarantees they
+  // agree, and `row`-side narrowing lets TS resolve `row.bedrockRegion`
+  // on the bedrock arm.
   let apiKey = "";
   let bedrockBundle: unknown = null;
-  if (config.credentials.provider === "bedrock") {
-    if (!config.credentials.bundle) {
+  if (row.provider === "bedrock") {
+    if (config.credentials.provider !== "bedrock" || !config.credentials.bundle) {
       return { kind: "skipped", reason: "malformed_bedrock_bundle" };
     }
     bedrockBundle = config.credentials.bundle;
@@ -360,9 +366,14 @@ async function refreshOne(row: StaleRow, now: number): Promise<RefreshOutcome> {
       return { kind: "skipped", reason: "missing_byot_key" };
     }
     apiKey = config.credentials.apiKey;
-  } else {
+  } else if (config.credentials.provider !== "bedrock") {
     apiKey = config.credentials.apiKey;
     if (!apiKey) return { kind: "skipped", reason: "missing_byot_key" };
+  } else {
+    // Defensive: row.provider !== "bedrock" but credentials.provider === "bedrock"
+    // — should be unreachable since the earlier `config.provider !== row.provider`
+    // check fires first. Return a skip rather than a failed so the cycle moves on.
+    return { kind: "skipped", reason: "missing_byot_key" };
   }
 
   try {

--- a/packages/api/src/lib/scheduler/byot-catalog-refresh.ts
+++ b/packages/api/src/lib/scheduler/byot-catalog-refresh.ts
@@ -42,6 +42,8 @@ import { hasInternalDB, internalQuery } from "@atlas/api/lib/db/internal";
 import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
 import type { AdminActionType } from "@atlas/api/lib/audit/actions";
 import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
+import { ModelRouter, type ModelRouterShape } from "@atlas/api/lib/effect/services";
+import { EnterpriseLayer } from "@atlas/api/lib/effect/enterprise-layer";
 import {
   type ByotRefreshCycleResult,
   type ByotCatalogRefreshSkipReason,
@@ -181,80 +183,88 @@ function providerOfRow(row: StaleRow): ByotProvider {
 }
 
 // ---------------------------------------------------------------------------
-// EE module probe — cached once per pod lifetime
+// ModelRouter Tag probe — replaces the pre-#2565 `EeModule` import probe
 // ---------------------------------------------------------------------------
 
-interface EeModule {
-  getWorkspaceModelConfigRaw: (
-    orgId: string,
-  ) => Effect.Effect<RawWorkspaceConfig | null, { readonly _tag: string } | Error>;
-  ModelConfigDecryptError: new (...args: never) => Error;
-  parseBedrockCredentialBundle: (apiKey: string) => unknown;
-}
+type ModelRouterProbeResult =
+  | { kind: "ok"; router: ModelRouterShape }
+  | { kind: "unavailable"; reason: "missing" | "probe_error"; error: string };
 
-type EeProbeResult = { kind: "ok"; module: EeModule } | { kind: "unavailable"; reason: "missing" | "import_error"; error: string };
+let _routerProbe: Promise<ModelRouterProbeResult> | null = null;
 
-let _eeProbe: Promise<EeProbeResult> | null = null;
-
-function probeEeModule(): Promise<EeProbeResult> {
-  if (_eeProbe) return _eeProbe;
-  _eeProbe = (async () => {
+/**
+ * Resolve the `ModelRouter` Tag from `EnterpriseLayer` once per pod
+ * lifetime. When EE is not loaded the Tag resolves to the no-op default
+ * with `available: false` — the probe reports `kind: "unavailable"` so
+ * the cycle audits "ee_unavailable" rather than failing every row.
+ */
+function probeModelRouter(): Promise<ModelRouterProbeResult> {
+  if (_routerProbe) return _routerProbe;
+  _routerProbe = (async () => {
     try {
-      const mod = (await import("@atlas/ee/platform/model-routing")) as unknown as EeModule;
-      return { kind: "ok" as const, module: mod };
+      const router = await Effect.runPromise(
+        Effect.gen(function* () {
+          return yield* ModelRouter;
+        }).pipe(Effect.provide(EnterpriseLayer)),
+      );
+      if (!router.available) {
+        return {
+          kind: "unavailable" as const,
+          reason: "missing" as const,
+          error: "ee module not installed (ModelRouter no-op default)",
+        };
+      }
+      return { kind: "ok" as const, router };
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      if (message.includes("Cannot find module") || message.includes("Cannot find package")) {
-        return { kind: "unavailable" as const, reason: "missing" as const, error: message };
-      }
-      // Distinct from "missing" so a build/syntax error doesn't pose as a
-      // self-hosted-without-EE install. The cycle audits this as a failure
-      // (not a deliberate ee_unavailable skip).
       log.warn(
         { err: message },
-        "EE module import failed with non-missing error — every row this cycle will fail",
+        "ModelRouter Tag resolution failed — every row this cycle will fail",
       );
-      return { kind: "unavailable" as const, reason: "import_error" as const, error: message };
+      return { kind: "unavailable" as const, reason: "probe_error" as const, error: message };
     }
   })();
-  return _eeProbe;
+  return _routerProbe;
 }
 
-/** Test-only: clear the cached EE probe so a fresh import is attempted. */
+/** Test-only: clear the cached ModelRouter probe so a fresh resolution is attempted. */
 export function _resetEeProbeForTests(): void {
-  _eeProbe = null;
+  _routerProbe = null;
 }
 
 // ---------------------------------------------------------------------------
 // Per-row refresh
 // ---------------------------------------------------------------------------
 
-interface RawWorkspaceConfig {
-  provider: string;
-  model: string;
-  apiKey: string | null;
-  baseUrl: string | null;
-  bedrockRegion: string | null;
-}
+type RawWorkspaceModelConfig =
+  import("@atlas/api/lib/auth/credentials").RawWorkspaceModelConfig;
 
 type LoadRawConfigResult =
-  | { kind: "ok"; config: RawWorkspaceConfig }
+  | { kind: "ok"; config: RawWorkspaceModelConfig }
   | { kind: "no_config" }
   | { kind: "decrypt_failed" }
   | { kind: "ee_unavailable" }
   | { kind: "unavailable"; error: string };
 
 async function loadRawConfig(orgId: string): Promise<LoadRawConfigResult> {
-  const probe = await probeEeModule();
+  const probe = await probeModelRouter();
   if (probe.kind === "unavailable") {
     return probe.reason === "missing"
       ? { kind: "ee_unavailable" }
       : { kind: "unavailable", error: probe.error };
   }
 
-  const program = probe.module.getWorkspaceModelConfigRaw(orgId).pipe(
-    Effect.map((config) =>
-      config ? ({ kind: "ok" as const, config }) : ({ kind: "no_config" as const }),
+  // The `ModelRouter` Tag returns the typed `credentials` union; the
+  // scheduler reads `credentials.bundle` directly for bedrock and
+  // `credentials.apiKey` for the rest (#2565). The pre-#2565 path
+  // re-parsed a JSON-stringified bundle via
+  // `parseBedrockCredentialBundle`; that double-parse is gone now that
+  // the cred lives as a typed value all the way through.
+  const program = probe.router.getWorkspaceModelConfigRaw(orgId).pipe(
+    Effect.map((rawConfig) =>
+      rawConfig
+        ? ({ kind: "ok" as const, config: rawConfig })
+        : ({ kind: "no_config" as const }),
     ),
     Effect.catchTag("ModelConfigDecryptError", () =>
       Effect.succeed({ kind: "decrypt_failed" as const }),
@@ -325,30 +335,38 @@ async function refreshOne(row: StaleRow, now: number): Promise<RefreshOutcome> {
   if (configResult.kind === "no_config") return { kind: "skipped", reason: "missing_byot_key" };
 
   const config = configResult.config;
-  if (!config.apiKey || config.provider !== row.provider) {
+  if (config.provider !== row.provider) {
     return { kind: "skipped", reason: "missing_byot_key" };
   }
 
-  // Bedrock-specific preconditions: region must exist (saved on the config
-  // row OR projected from the SQL JOIN), and the cred bundle must parse.
+  // Pull cred material off the typed `credentials` union. Bedrock's
+  // bundle is `null` precisely when the post-decrypt JSON parse failed
+  // (the `malformed_bedrock_bundle` skip); other providers carry the
+  // raw apiKey string. The fetcher takes both via separate args — the
+  // bedrock fetch ignores `apiKey`, the others ignore `bedrockBundle`.
+  let apiKey = "";
   let bedrockBundle: unknown = null;
-  if (row.provider === "bedrock") {
-    const probe = await probeEeModule();
-    if (probe.kind === "unavailable") {
-      return probe.reason === "missing"
-        ? { kind: "skipped", reason: "ee_unavailable" }
-        : { kind: "failed", error: probe.error };
+  if (config.credentials.provider === "bedrock") {
+    if (!config.credentials.bundle) {
+      return { kind: "skipped", reason: "malformed_bedrock_bundle" };
     }
+    bedrockBundle = config.credentials.bundle;
     const region = config.bedrockRegion ?? row.bedrockRegion;
     if (!region) return { kind: "skipped", reason: "missing_byot_key" };
     // Mutate the discriminated row so the fetcher uses the resolved region.
     row = { provider: "bedrock", orgId: row.orgId, bedrockRegion: region };
-    bedrockBundle = probe.module.parseBedrockCredentialBundle(config.apiKey);
-    if (!bedrockBundle) return { kind: "skipped", reason: "malformed_bedrock_bundle" };
+  } else if (config.credentials.provider === "gateway") {
+    if (!config.credentials.apiKey) {
+      return { kind: "skipped", reason: "missing_byot_key" };
+    }
+    apiKey = config.credentials.apiKey;
+  } else {
+    apiKey = config.credentials.apiKey;
+    if (!apiKey) return { kind: "skipped", reason: "missing_byot_key" };
   }
 
   try {
-    const result = await fetchCatalogForRow(row, config.apiKey, bedrockBundle);
+    const result = await fetchCatalogForRow(row, apiKey, bedrockBundle);
     return { kind: "refreshed", modelCount: result.models.length, source: result.source };
   } catch (err) {
     return { kind: "failed", error: errorMessage(err) };


### PR DESCRIPTION
## Summary

Slice 3/11 of #2017 (1.5.1 — Architecture Deepening). Inverts every `@atlas/ee/platform/model-routing` import in `packages/api/src/` so core depends on the `ModelRouter` Tag (introduced in #2563) instead of the EE module directly.

EE overlays the real implementation through a new `ModelRouterLive` Layer aggregated in `ee/src/layers.ts:EELayer`. Self-hosted falls through to the no-op default in `services.ts` (returns `available: false`, so the agent loop falls back to the env-var `getModel()` and admin routes surface \"not_available\").

## What changed

**Foundation**
- `WorkspaceCredentials` + `RawWorkspaceModelConfig` (typed cred union used by the AI Layer + admin routes) promoted to `lib/auth/credentials.ts` so the Tag's method signatures stay in core. EE re-exports for back-compat.
- `ModelConfigError` + `ModelConfigDecryptError` (Data.TaggedError) promoted to `lib/model-routing/errors.ts`. EE re-exports; existing `domainError(ModelConfigError, ...)` mappings and agent-loop `instanceof ModelConfigDecryptError` checks work unchanged.
- `ModelRouterShape` widened in `services.ts` to expose the full module surface: `getWorkspaceModelConfig{,Raw}`, `setWorkspaceModelConfig`, `deleteWorkspaceModelConfig`, `testModelConfig`, `reconcileModelDeprecation`, `parseBedrockCredentialBundle`. No-op returns `available: false` + null/`EnterpriseError` sentinels.
- `parseBedrockCredentialBundle` is now exported from EE's model-routing module (was module-private; the pre-#2565 scheduler reached it via an `as unknown` cast that only worked because the bundler kept the symbol around).

**Call sites migrated**
- `lib/agent.ts` — dynamic `await import(\"@atlas/ee/platform/model-routing\")` replaced with `yield* ModelRouter` inside `Effect.gen`; `runPromise` provides `EnterpriseLayer`. Decrypt-failure still surfaces as a user-visible error so the platform isn't silently billed against workspace consent.
- `lib/scheduler/byot-catalog-refresh.ts` — `EeModule` probe pattern replaced with `probeModelRouter()` resolving the Tag once per pod. The per-row refresh path now reads `credentials` as a typed union (`bedrock.bundle`, `gateway.apiKey`, default `apiKey`) instead of re-parsing the JSON-stringified bundle via `parseBedrockCredentialBundle` — cleaner and avoids the double-parse.
- `lib/providers.ts` + `lib/effect/ai.ts` — `WorkspaceCredentials` type import retargeted to core.
- `api/routes/admin-model-config.ts` — static EE imports replaced with `yield* ModelRouter` + `router.<method>` calls; `ModelConfigError` imported from core.

**Tests**
- `byot-catalog-refresh.test.ts` — switched from `mock.module(\"@atlas/ee/platform/model-routing\")` to `mock.module(\"@atlas/ee/layers\")` injecting a test `ModelRouterLive` Layer. The fixture shape translates the legacy `{ apiKey }` row into the typed `credentials` union so the per-test setup stays readable.
- `admin-model-config.test.ts` — same EELayer mock pattern; existing `mockSet/Get/Test/...` references thread through to the Tag instead of the dynamic import. `@atlas/api/lib/model-routing/errors` mocked so the route's `instanceof ModelConfigError` matches the test's `MockModelConfigError`.

## Acceptance criteria

- [x] No `@atlas/ee/platform/model-routing` imports anywhere in `packages/api/src/` (only comments + test mocks remain — closeout grep in #2573 will exclude both)
- [x] `WorkspaceCredentials` lives in core; EE re-exports for back-compat through slice 11
- [x] BYOT catalog refresh scheduler still wakes + refreshes (no behavior change)
- [x] Agent hot-path workspace-config resolution unchanged for SaaS; self-hosted passes through no-op
- [x] `bun run test:api` green (412/412)
- [x] `/ci` gates: lint + type + test:api + test:others + syncpack + template-drift + railway-watch + schema-drift + security-headers + oauth-helper — all pass

## Test plan

- [x] `bun run test:api` — 412/412 pass
- [x] `bun run test:others` — pass (after building `@useatlas/sdk`/`types`/`react`)
- [x] `bun run lint` — clean (one pre-existing warning unrelated to this slice)
- [x] `bun run type` — clean
- [x] CI gates green
- [ ] Wait for required-checks on the head SHA before merging — never \`--admin\` past a slow gate

Closes #2565