### PR TITLE
refactor(api): 1.5.1 invert slice 4/11 — PII masking + compliance reports via Tags

### DIFF
--- a/ee/src/compliance/masking.ts
+++ b/ee/src/compliance/masking.ts
@@ -16,7 +16,7 @@
  * All exported functions return Effect — callers use `yield*` in Effect.gen.
  */
 
-import { Data, Effect } from "effect";
+import { Effect, Layer } from "effect";
 import { isEnterpriseEnabled } from "../index";
 import { requireEnterpriseEffect, EnterpriseError } from "../index";
 import {
@@ -38,17 +38,28 @@ import type {
 } from "@useatlas/types";
 import { PII_CATEGORIES, MASKING_STRATEGIES } from "@useatlas/types";
 import { createHash } from "crypto";
+import {
+  MaskingPolicy,
+  type MaskingPolicyShape,
+} from "@atlas/api/lib/effect/services";
+import {
+  ComplianceError,
+  type ComplianceErrorCode,
+} from "@atlas/api/lib/compliance/errors";
 
 const log = createLogger("ee:compliance");
 
 // ── Typed errors ────────────────────────────────────────────────
 
-export type ComplianceErrorCode = "validation" | "not_found" | "conflict";
-
-export class ComplianceError extends Data.TaggedError("ComplianceError")<{
-  message: string;
-  code: ComplianceErrorCode;
-}> {}
+/**
+ * `ComplianceError` lives in `@atlas/api/lib/compliance/errors`
+ * post-#2566 so the `MaskingPolicy` Tag can type its failure channel
+ * without core importing from `@atlas/ee`. Re-exported here for
+ * back-compat — pre-#2566 EE consumers continue to find this symbol
+ * at the same path with the same `_tag` + payload + `instanceof`
+ * semantics.
+ */
+export { ComplianceError, type ComplianceErrorCode };
 
 // ── Table management ────────────────────────────────────────────
 
@@ -595,3 +606,26 @@ export function _resetComplianceState(): void {
   _classificationCache.clear();
   _tableReady = false;
 }
+
+// ── Tag wiring (#2566 — slice 4/11 of #2017) ─────────────────────────
+//
+// Bridges this module's functions into the `MaskingPolicy` Tag so core
+// call sites (`lib/tools/sql.ts`, `api/routes/admin-compliance.ts`)
+// can `yield* MaskingPolicy` instead of dynamic-importing this module.
+// Aggregated into `ee/src/layers.ts:EELayer`; the no-op default in
+// `lib/effect/services.ts:NoopMaskingPolicyLayer` covers self-hosted
+// installs (passes rows through unchanged — fail open).
+
+export const makeMaskingPolicyLive = (): MaskingPolicyShape => ({
+  available: true,
+  applyMasking,
+  listPIIClassifications,
+  updatePIIClassification,
+  deletePIIClassification,
+  invalidateClassificationCache,
+});
+
+export const MaskingPolicyLive: Layer.Layer<MaskingPolicy> = Layer.sync(
+  MaskingPolicy,
+  makeMaskingPolicyLive,
+);

--- a/ee/src/compliance/reports.ts
+++ b/ee/src/compliance/reports.ts
@@ -11,11 +11,19 @@
  * All exported functions return Effect — callers use `yield*` in Effect.gen.
  */
 
-import { Data, Effect } from "effect";
+import { Effect, Layer } from "effect";
 import { requireEnterpriseEffect, EnterpriseError } from "../index";
 import { requireInternalDBEffect } from "../lib/db-guard";
 import { internalQuery } from "@atlas/api/lib/db/internal";
 import { createLogger } from "@atlas/api/lib/logger";
+import {
+  ComplianceReports,
+  type ComplianceReportsShape,
+} from "@atlas/api/lib/effect/services";
+import {
+  ReportError,
+  type ReportErrorCode,
+} from "@atlas/api/lib/compliance/errors";
 import type {
   ComplianceReportFilters,
   DataAccessReport,
@@ -43,12 +51,14 @@ function validateFilters(filters: ComplianceReportFilters): Effect.Effect<void, 
 
 // ── Error type ──────────────────────────────────────────────────
 
-export type ReportErrorCode = "validation" | "not_available";
-
-export class ReportError extends Data.TaggedError("ReportError")<{
-  message: string;
-  code: ReportErrorCode;
-}> {}
+/**
+ * `ReportError` lives in `@atlas/api/lib/compliance/errors` post-#2566
+ * so the `ComplianceReports` Tag can type its failure channel without
+ * core importing from `@atlas/ee`. Re-exported here for back-compat —
+ * pre-#2566 EE consumers continue to find this symbol at the same path
+ * with the same `_tag` + payload + `instanceof` semantics.
+ */
+export { ReportError, type ReportErrorCode };
 
 // ── Data Access Report ──────────────────────────────────────────
 
@@ -401,3 +411,26 @@ function parseJsonbArray(val: unknown): string[] {
   }
   return [];
 }
+
+// ── Tag wiring (#2566 — slice 4/11 of #2017) ─────────────────────────
+//
+// Bridges this module's functions into the `ComplianceReports` Tag so
+// `api/routes/admin-compliance.ts` can `yield* ComplianceReports`
+// instead of static-importing this module. Aggregated into
+// `ee/src/layers.ts:EELayer`; the no-op default in
+// `lib/effect/services.ts:NoopComplianceReportsLayer` covers self-hosted
+// installs (returns a `ReportError("not_available")` so the admin route
+// maps cleanly to a 404 envelope via `domainError`).
+
+export const makeComplianceReportsLive = (): ComplianceReportsShape => ({
+  available: true,
+  generateDataAccessReport,
+  generateUserActivityReport,
+  dataAccessReportToCSV,
+  userActivityReportToCSV,
+});
+
+export const ComplianceReportsLive: Layer.Layer<ComplianceReports> = Layer.sync(
+  ComplianceReports,
+  makeComplianceReportsLive,
+);

--- a/ee/src/layers.ts
+++ b/ee/src/layers.ts
@@ -9,22 +9,27 @@
  * no-op defaults.
  *
  * Slice 2/11 (#2564) — added `ResidencyResolverLive`.
- * Slice 3/11 (#2565) — added `ModelRouterLive` so core call sites
- *   (`lib/agent.ts`, `lib/scheduler/byot-catalog-refresh.ts`,
- *   `api/routes/admin-model-config.ts`) can `yield* ModelRouter` and
- *   get EE's full BYOT model-routing implementation.
+ * Slice 3/11 (#2565) — added `ModelRouterLive`.
+ * Slice 4/11 (#2566) — added `MaskingPolicyLive` + `ComplianceReportsLive`
+ *   so core call sites (`lib/tools/sql.ts`, `api/routes/admin-compliance.ts`)
+ *   can `yield* MaskingPolicy` / `yield* ComplianceReports` and get EE's
+ *   full PII masking + report generation implementations.
  *
- * Later slices (#2566–#2572) follow the same pattern: one Tag, one
+ * Later slices (#2567–#2572) follow the same pattern: one Tag, one
  * Layer entry. See the parent issue (#2017) for the rationale.
  */
 
 import { Layer } from "effect";
 import type {
+  ComplianceReports,
+  MaskingPolicy,
   ModelRouter,
   ResidencyResolver,
 } from "@atlas/api/lib/effect/services";
 import { ResidencyResolverLive } from "./platform/residency";
 import { ModelRouterLive } from "./platform/model-routing";
+import { MaskingPolicyLive } from "./compliance/masking";
+import { ComplianceReportsLive } from "./compliance/reports";
 
 /**
  * Aggregated EE Layer — typed by the union of every Tag this module
@@ -32,7 +37,11 @@ import { ModelRouterLive } from "./platform/model-routing";
  * import a new slice's Layer) surfaces as a `tsgo` error rather than
  * silently falling through to the no-op default at runtime.
  */
-export const EELayer: Layer.Layer<ResidencyResolver | ModelRouter> = Layer.mergeAll(
+export const EELayer: Layer.Layer<
+  ResidencyResolver | ModelRouter | MaskingPolicy | ComplianceReports
+> = Layer.mergeAll(
   ResidencyResolverLive,
   ModelRouterLive,
+  MaskingPolicyLive,
+  ComplianceReportsLive,
 );

--- a/packages/api/src/api/__tests__/admin-compliance.test.ts
+++ b/packages/api/src/api/__tests__/admin-compliance.test.ts
@@ -149,9 +149,10 @@ mock.module("@atlas/ee/layers", () => ({
     Effect.sync(() => {
       // eslint-disable-next-line @typescript-eslint/no-require-imports
       const services = require("@atlas/api/lib/effect/services") as typeof import("@atlas/api/lib/effect/services");
+      type MaskingContext = import("@atlas/api/lib/effect/services").MaskingContext;
       const maskingLayer = Layer.succeed(services.MaskingPolicy, {
         available: true,
-        applyMasking: (ctx) => Effect.succeed([...ctx.rows]),
+        applyMasking: (ctx: MaskingContext) => Effect.succeed([...ctx.rows]),
         listPIIClassifications: () => Effect.succeed([]),
         updatePIIClassification: () => {
           if (mockUpdateError) return Effect.fail(mockUpdateError);

--- a/packages/api/src/api/__tests__/admin-compliance.test.ts
+++ b/packages/api/src/api/__tests__/admin-compliance.test.ts
@@ -16,9 +16,15 @@
  */
 
 import { describe, it, expect, beforeEach, mock, type Mock } from "bun:test";
-import { Effect } from "effect";
+import { Effect, Layer } from "effect";
 
 import { ADMIN_ACTIONS as REAL_ADMIN_ACTIONS } from "@atlas/api/lib/audit/actions";
+
+// Force enterprise on so `ConditionalEELayer` in
+// `lib/effect/enterprise-layer.ts` lazy-imports the mocked
+// `@atlas/ee/layers` aggregator below (otherwise the no-op default
+// fires and the masking + reports tests would see `available: false`).
+process.env.ATLAS_ENTERPRISE_ENABLED = "true";
 
 // ── Auth + DB stubs ────────────────────────────────────────────────
 
@@ -97,13 +103,11 @@ mock.module("@atlas/api/lib/audit", () => ({
 }));
 
 // ── EE compliance mock — driven per test ──────────────────────────
+// Errors live in core post-#2566; both EE compliance modules re-export
+// for back-compat, so existing references resolve the same class.
 
-const { ComplianceError: RealComplianceError } = await import(
-  "@atlas/ee/compliance/masking"
-);
-const { ReportError: RealReportError } = await import(
-  "@atlas/ee/compliance/reports"
-);
+const { ComplianceError: RealComplianceError, ReportError: RealReportError } =
+  await import("@atlas/api/lib/compliance/errors");
 
 interface PIIClassification {
   id: string;
@@ -126,27 +130,62 @@ let mockUpdateError: Error | null = null;
 let mockDeleteError: Error | null = null;
 const mockInvalidate: Mock<(orgId: string) => void> = mock(() => {});
 
+// Mock the core errors module so route's `instanceof` (via domainError)
+// matches the test's `RealComplianceError` / `RealReportError`. Since
+// both are already real classes from `@atlas/api/lib/compliance/errors`,
+// re-exporting through the mock keeps semantics identical and gives a
+// single place to swap if the test wants to inject a fake class later.
+mock.module("@atlas/api/lib/compliance/errors", () => ({
+  ComplianceError: RealComplianceError,
+  ReportError: RealReportError,
+}));
+
+// Bind both Tags via the EE aggregator mock — post-#2566 the route
+// reaches the masking + report functions through `yield* MaskingPolicy`
+// / `yield* ComplianceReports`. `EnterpriseLayer` lazy-imports this
+// module, so the test's mocked aggregator wins over the no-op default.
+mock.module("@atlas/ee/layers", () => ({
+  EELayer: Layer.unwrapEffect(
+    Effect.sync(() => {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const services = require("@atlas/api/lib/effect/services") as typeof import("@atlas/api/lib/effect/services");
+      const maskingLayer = Layer.succeed(services.MaskingPolicy, {
+        available: true,
+        applyMasking: (ctx) => Effect.succeed([...ctx.rows]),
+        listPIIClassifications: () => Effect.succeed([]),
+        updatePIIClassification: () => {
+          if (mockUpdateError) return Effect.fail(mockUpdateError);
+          return Effect.succeed(mockUpdateResult as never);
+        },
+        deletePIIClassification: () => {
+          if (mockDeleteError) return Effect.fail(mockDeleteError);
+          return Effect.succeed(undefined as never);
+        },
+        invalidateClassificationCache: mockInvalidate,
+      } as never);
+      const reportsLayer = Layer.succeed(services.ComplianceReports, {
+        available: true,
+        generateDataAccessReport: () =>
+          Effect.succeed({ rows: [], summary: { totalQueries: 0, uniqueUsers: 0, uniqueTables: 0, piiTablesAccessed: 0 }, filters: { startDate: "", endDate: "" }, generatedAt: "" } as never),
+        generateUserActivityReport: () =>
+          Effect.succeed({ rows: [], summary: { totalUsers: 0, activeUsers: 0, totalQueries: 0 }, filters: { startDate: "", endDate: "" }, generatedAt: "" } as never),
+        dataAccessReportToCSV: () => "",
+        userActivityReportToCSV: () => "",
+      } as never);
+      return Layer.merge(maskingLayer, reportsLayer);
+    }),
+  ),
+}));
+
+// Keep legacy `@atlas/ee/compliance/*` module mocks as no-op stubs for
+// any transitive EE re-export that still resolves them. Production code
+// no longer hits these paths post-#2566.
 mock.module("@atlas/ee/compliance/masking", () => ({
   ComplianceError: RealComplianceError,
-  listPIIClassifications: () => Effect.succeed([]),
-  getPIIClassification: () => Effect.succeed(mockGetClassification),
-  updatePIIClassification: () => {
-    if (mockUpdateError) return Effect.fail(mockUpdateError);
-    return Effect.succeed(mockUpdateResult);
-  },
-  deletePIIClassification: () => {
-    if (mockDeleteError) return Effect.fail(mockDeleteError);
-    return Effect.succeed(true);
-  },
-  invalidateClassificationCache: mockInvalidate,
 }));
 
 mock.module("@atlas/ee/compliance/reports", () => ({
   ReportError: RealReportError,
-  generateDataAccessReport: () => Effect.succeed({ rows: [], summary: { totalQueries: 0, uniqueUsers: 0, uniqueTables: 0, piiTablesAccessed: 0 }, filters: { startDate: "", endDate: "" }, generatedAt: "" }),
-  generateUserActivityReport: () => Effect.succeed({ rows: [], summary: { totalUsers: 0, activeUsers: 0, totalQueries: 0 }, filters: { startDate: "", endDate: "" }, generatedAt: "" }),
-  dataAccessReportToCSV: () => "",
-  userActivityReportToCSV: () => "",
 }));
 
 // ── Import sub-router AFTER mocks ─────────────────────────────────

--- a/packages/api/src/api/routes/admin-compliance.ts
+++ b/packages/api/src/api/routes/admin-compliance.ts
@@ -17,22 +17,13 @@ import { createRoute, z } from "@hono/zod-openapi";
 import { HTTPException } from "hono/http-exception";
 import type { Context } from "hono";
 import { runEffect, domainError } from "@atlas/api/lib/effect/hono";
-import { AuthContext } from "@atlas/api/lib/effect/services";
+import {
+  AuthContext,
+  ComplianceReports,
+  MaskingPolicy,
+} from "@atlas/api/lib/effect/services";
 import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
-import {
-  listPIIClassifications,
-  updatePIIClassification,
-  deletePIIClassification,
-  invalidateClassificationCache,
-  ComplianceError,
-} from "@atlas/ee/compliance/masking";
-import {
-  generateDataAccessReport,
-  generateUserActivityReport,
-  dataAccessReportToCSV,
-  userActivityReportToCSV,
-  ReportError,
-} from "@atlas/ee/compliance/reports";
+import { ComplianceError, ReportError } from "@atlas/api/lib/compliance/errors";
 import type { PIICategory, MaskingStrategy } from "@useatlas/types";
 import { PIIColumnClassificationSchema as PIIClassificationSchema } from "@useatlas/schemas";
 import { ErrorSchema, AuthErrorSchema, DeletedResponseSchema } from "./shared-schemas";
@@ -135,9 +126,10 @@ adminCompliance.use(requireOrgContext());
 adminCompliance.openapi(listRoute, async (c) => {
   return runEffect(c, Effect.gen(function* () {
     const { orgId } = yield* AuthContext;
+    const masking = yield* MaskingPolicy;
     const { connectionGroupId } = c.req.valid("query");
 
-    const classifications = yield* listPIIClassifications(orgId!, connectionGroupId ?? undefined);
+    const classifications = yield* masking.listPIIClassifications(orgId!, connectionGroupId ?? undefined);
     return c.json({ classifications }, 200);
   }), { label: "list PII classifications", domainErrors: [complianceDomainError, reportDomainError] });
 });
@@ -150,14 +142,15 @@ adminCompliance.openapi(updateRoute, async (c) => {
 
   return runEffect(c, Effect.gen(function* () {
     const { orgId } = yield* AuthContext;
+    const masking = yield* MaskingPolicy;
 
-    const updated = yield* updatePIIClassification(orgId!, id, {
+    const updated = yield* masking.updatePIIClassification(orgId!, id, {
       category: body.category as PIICategory | undefined,
       maskingStrategy: body.maskingStrategy as MaskingStrategy | undefined,
       dismissed: body.dismissed,
       reviewed: body.reviewed,
     });
-    invalidateClassificationCache(orgId!);
+    masking.invalidateClassificationCache(orgId!);
     // Metadata mirrors only the request-body fields that were actually set —
     // spreading the update result would echo post-state defaults and drown
     // the admin's *intent* (shrinking mask from `full` to `redact` is the
@@ -185,9 +178,10 @@ adminCompliance.openapi(deleteRoute, async (c) => {
 
   return runEffect(c, Effect.gen(function* () {
     const { orgId } = yield* AuthContext;
+    const masking = yield* MaskingPolicy;
 
-    yield* deletePIIClassification(orgId!, id);
-    invalidateClassificationCache(orgId!);
+    yield* masking.deletePIIClassification(orgId!, id);
+    masking.invalidateClassificationCache(orgId!);
     logAdminAction({
       actionType: ADMIN_ACTIONS.compliance.piiConfigDelete,
       targetType: "compliance",
@@ -308,9 +302,10 @@ const userActivityReportRoute = createRoute({
 adminCompliance.openapi(dataAccessReportRoute, async (c) => {
   return runEffect(c, Effect.gen(function* () {
     const { orgId } = yield* AuthContext;
+    const reports = yield* ComplianceReports;
     const query = c.req.valid("query");
 
-    const report = yield* generateDataAccessReport(orgId!, {
+    const report = yield* reports.generateDataAccessReport(orgId!, {
       startDate: query.startDate,
       endDate: query.endDate,
       userId: query.userId,
@@ -319,7 +314,7 @@ adminCompliance.openapi(dataAccessReportRoute, async (c) => {
     });
 
     if (query.format === "csv") {
-      const csv = dataAccessReportToCSV(report);
+      const csv = reports.dataAccessReportToCSV(report);
       const safeOrgId = orgId!.replace(/[^a-zA-Z0-9_-]/g, "");
       const filename = `data-access-report-${safeOrgId}-${new Date().toISOString().slice(0, 10)}.csv`;
       // CSV responses bypass OpenAPI typed returns via HTTPException + res
@@ -342,9 +337,10 @@ adminCompliance.openapi(dataAccessReportRoute, async (c) => {
 adminCompliance.openapi(userActivityReportRoute, async (c) => {
   return runEffect(c, Effect.gen(function* () {
     const { orgId } = yield* AuthContext;
+    const reports = yield* ComplianceReports;
     const query = c.req.valid("query");
 
-    const report = yield* generateUserActivityReport(orgId!, {
+    const report = yield* reports.generateUserActivityReport(orgId!, {
       startDate: query.startDate,
       endDate: query.endDate,
       userId: query.userId,
@@ -353,7 +349,7 @@ adminCompliance.openapi(userActivityReportRoute, async (c) => {
     });
 
     if (query.format === "csv") {
-      const csv = userActivityReportToCSV(report);
+      const csv = reports.userActivityReportToCSV(report);
       const safeOrgId = orgId!.replace(/[^a-zA-Z0-9_-]/g, "");
       const filename = `user-activity-report-${safeOrgId}-${new Date().toISOString().slice(0, 10)}.csv`;
       // CSV responses bypass OpenAPI typed returns via HTTPException + res

--- a/packages/api/src/lib/compliance/errors.ts
+++ b/packages/api/src/lib/compliance/errors.ts
@@ -1,0 +1,27 @@
+/**
+ * Compliance errors — promoted to core in #2566 so the `MaskingPolicy`
+ * and `ComplianceReports` Tags in `lib/effect/services.ts` can type
+ * their failure channels without core importing from `@atlas/ee`.
+ *
+ * EE's `ee/src/compliance/{masking,reports}.ts` re-exports both classes
+ * for back-compat. The structural identity (`_tag` + payload shape)
+ * means existing `instanceof` checks and `domainError(...)` mappings
+ * work unchanged whether the class is loaded from core or via the EE
+ * re-export.
+ */
+
+import { Data } from "effect";
+
+export type ComplianceErrorCode = "validation" | "not_found" | "conflict";
+
+export class ComplianceError extends Data.TaggedError("ComplianceError")<{
+  message: string;
+  code: ComplianceErrorCode;
+}> {}
+
+export type ReportErrorCode = "validation" | "not_available";
+
+export class ReportError extends Data.TaggedError("ReportError")<{
+  message: string;
+  code: ReportErrorCode;
+}> {}

--- a/packages/api/src/lib/effect/services.ts
+++ b/packages/api/src/lib/effect/services.ts
@@ -1017,47 +1017,133 @@ export const NoopModelRouterLayer: Layer.Layer<ModelRouter> = Layer.sync(
   },
 );
 
-// ── MaskingPolicy (#2566) ────────────────────────────────────────────
+// ── MaskingPolicy (#2566 — slice 4/11 of #2017) ──────────────────────
 //
-// Replaces `await import("@atlas/ee/compliance/masking")` in
-// `lib/tools/sql.ts`. EE applies PII masking to result rows per org
-// policy; core's no-op passes rows through unchanged.
+// Inverts every `@atlas/ee/compliance/masking` reference in
+// `packages/api/src/`: the two `applyMasking` dynamic imports in
+// `lib/tools/sql.ts` and the PII-classification CRUD imports in
+// `api/routes/admin-compliance.ts`. EE overlays the real implementation;
+// the no-op default fails open (passes rows through unchanged), matching
+// the pre-#2566 behavior when the EE module wasn't installed.
+//
+// `ComplianceError` lives in `lib/compliance/errors.ts` so the Tag's
+// failure channels stay typed without pulling in `@atlas/ee`.
+
+type PIIColumnClassification = import("@useatlas/types").PIIColumnClassification;
+type UpdatePIIClassificationRequest = import("@useatlas/types").UpdatePIIClassificationRequest;
+type ComplianceError = import("@atlas/api/lib/compliance/errors").ComplianceError;
+
+export interface MaskingContext {
+  readonly columns: string[];
+  readonly rows: Record<string, unknown>[];
+  readonly tablesAccessed: string[];
+  readonly orgId: string;
+  readonly userRole: string | undefined;
+  readonly connectionId?: string | null;
+}
 
 export interface MaskingPolicyShape {
-  readonly applyMasking: <T extends Record<string, unknown>>(
-    rows: ReadonlyArray<T>,
-    orgId: string | undefined,
-  ) => Promise<ReadonlyArray<T>>;
+  /** False when EE compliance is not loaded — `applyMasking` becomes identity. */
+  readonly available: boolean;
+  /** Apply PII masking. No-op returns `ctx.rows` unchanged (fail open). */
+  readonly applyMasking: (
+    ctx: MaskingContext,
+  ) => Effect.Effect<Record<string, unknown>[]>;
+  readonly listPIIClassifications: (
+    orgId: string,
+    connectionGroupId?: string,
+  ) => Effect.Effect<PIIColumnClassification[], ComplianceError | Error>;
+  readonly updatePIIClassification: (
+    orgId: string,
+    classificationId: string,
+    updates: UpdatePIIClassificationRequest,
+  ) => Effect.Effect<PIIColumnClassification, ComplianceError | Error>;
+  readonly deletePIIClassification: (
+    orgId: string,
+    classificationId: string,
+  ) => Effect.Effect<void, ComplianceError | Error>;
+  /** Per-org cache buster; safe no-op when EE is missing. */
+  readonly invalidateClassificationCache: (orgId: string) => void;
 }
 export class MaskingPolicy extends Context.Tag("MaskingPolicy")<
   MaskingPolicy,
   MaskingPolicyShape
 >() {}
-export const NoopMaskingPolicyLayer: Layer.Layer<MaskingPolicy> = Layer.succeed(
+export const NoopMaskingPolicyLayer: Layer.Layer<MaskingPolicy> = Layer.sync(
   MaskingPolicy,
-  {
-    applyMasking: async (rows) => rows,
-  } satisfies MaskingPolicyShape,
+  () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { ComplianceError: ComplianceErrorClass } = require("@atlas/api/lib/compliance/errors") as {
+      ComplianceError: new (args: { message: string; code: "not_found" }) => ComplianceError;
+    };
+    const notFound = (id: string) =>
+      new ComplianceErrorClass({
+        message: `PII classification "${id}" not found.`,
+        code: "not_found",
+      });
+    return {
+      available: false,
+      applyMasking: (ctx) => Effect.succeed([...ctx.rows]),
+      listPIIClassifications: () => Effect.succeed([]),
+      updatePIIClassification: (_orgId, id) => Effect.fail(notFound(id)),
+      deletePIIClassification: (_orgId, id) => Effect.fail(notFound(id)),
+      invalidateClassificationCache: () => {},
+    } satisfies MaskingPolicyShape;
+  },
 );
 
-// ── ComplianceReports (#2567) ────────────────────────────────────────
+// ── ComplianceReports (#2566 — slice 4/11 of #2017) ──────────────────
 //
-// Replaces `import { ... } from "@atlas/ee/compliance/reports"` in
-// `api/routes/admin-compliance.ts`. EE generates SOC2/HIPAA reports;
-// core's no-op returns the "feature disabled" sentinel so the admin
-// surface can render the upsell instead of crashing.
+// Inverts the static `import { generateDataAccessReport, ... } from "@atlas/ee/compliance/reports"`
+// in `api/routes/admin-compliance.ts`. EE generates SOC2/HIPAA reports;
+// core's no-op fails with `ReportError("not_available")` so the admin
+// surface routes through `domainError` to a 404 envelope.
+
+type DataAccessReport = import("@useatlas/types").DataAccessReport;
+type UserActivityReport = import("@useatlas/types").UserActivityReport;
+type ComplianceReportFilters = import("@useatlas/types").ComplianceReportFilters;
+type ReportError = import("@atlas/api/lib/compliance/errors").ReportError;
+type EnterpriseErrorForReports = import("@atlas/api/lib/effect/errors").EnterpriseError;
 
 export interface ComplianceReportsShape {
   readonly available: boolean;
+  readonly generateDataAccessReport: (
+    orgId: string,
+    filters: ComplianceReportFilters,
+  ) => Effect.Effect<DataAccessReport, ReportError | EnterpriseErrorForReports | Error>;
+  readonly generateUserActivityReport: (
+    orgId: string,
+    filters: ComplianceReportFilters,
+  ) => Effect.Effect<UserActivityReport, ReportError | EnterpriseErrorForReports | Error>;
+  readonly dataAccessReportToCSV: (report: DataAccessReport) => string;
+  readonly userActivityReportToCSV: (report: UserActivityReport) => string;
 }
 export class ComplianceReports extends Context.Tag("ComplianceReports")<
   ComplianceReports,
   ComplianceReportsShape
 >() {}
 export const NoopComplianceReportsLayer: Layer.Layer<ComplianceReports> =
-  Layer.succeed(ComplianceReports, {
-    available: false,
-  } satisfies ComplianceReportsShape);
+  Layer.sync(ComplianceReports, () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { ReportError: ReportErrorClass } = require("@atlas/api/lib/compliance/errors") as {
+      ReportError: new (args: { message: string; code: "not_available" }) => ReportError;
+    };
+    const notAvailable = () =>
+      new ReportErrorClass({
+        message: "Compliance reports require enterprise features to be enabled.",
+        code: "not_available",
+      });
+    return {
+      available: false,
+      generateDataAccessReport: () => Effect.fail(notAvailable()),
+      generateUserActivityReport: () => Effect.fail(notAvailable()),
+      // CSV converters are pure formatters — return empty CSV headers so a
+      // caller that bypasses the `available` gate doesn't crash on the
+      // pure-function path.
+      dataAccessReportToCSV: () => "",
+      userActivityReportToCSV: () => "",
+    } satisfies ComplianceReportsShape;
+  });
 
 // ── ApprovalGate (#2568) ─────────────────────────────────────────────
 //

--- a/packages/api/src/lib/tools/sql.ts
+++ b/packages/api/src/lib/tools/sql.ts
@@ -39,6 +39,27 @@ import { EXECUTE_SQL_TOOL_DESCRIPTION } from "./descriptions";
 import { resolveRoutingPlan, type RoutingMode, type RoutingReason } from "@atlas/api/lib/env-routing";
 import { loadGroupRoutingContext } from "@atlas/api/lib/env-routing/lookup";
 import { mergeMemberResults } from "@atlas/api/lib/multi-env-merger";
+import { MaskingPolicy, type MaskingContext } from "@atlas/api/lib/effect/services";
+import { EnterpriseLayer } from "@atlas/api/lib/effect/enterprise-layer";
+
+/**
+ * Run `MaskingPolicy.applyMasking` via `EnterpriseLayer`. Promise-shaped
+ * wrapper so the two sql.ts call sites (live + cache path) can keep
+ * their existing async/await structure without restructuring around
+ * `Effect.gen` (#2566 — slice 4/11 of #2017). Fails open: any error in
+ * the program is rethrown to the caller's existing try/catch, which
+ * already logs `"PII masking failed — returning unmasked results"`.
+ */
+function applyMaskingViaTag(
+  ctx: MaskingContext,
+): Promise<Record<string, unknown>[]> {
+  return Effect.runPromise(
+    Effect.gen(function* () {
+      const masking = yield* MaskingPolicy;
+      return yield* masking.applyMasking(ctx);
+    }).pipe(Effect.provide(EnterpriseLayer)),
+  );
+}
 
 const log = createLogger("sql");
 
@@ -965,20 +986,18 @@ function executeAndAuditEffect(opts: {
             sql: querySql, dialect: parserDatabase(dbType, connId), connectionId: connId,
           });
 
-          // PII masking (fails open)
+          // PII masking (fails open) — via `MaskingPolicy` Tag (#2566)
           let maskedRows = result.rows;
           let maskingApplied = false;
           if (classification?.tablesAccessed.length && orgId) {
             try {
-              const { applyMasking } = await import("@atlas/ee/compliance/masking");
               const maskCtx = getRequestContext();
-              const { Effect: E } = await import("effect");
-              maskedRows = await E.runPromise(applyMasking({
+              maskedRows = await applyMaskingViaTag({
                 columns: result.columns, rows: result.rows,
                 tablesAccessed: classification.tablesAccessed,
                 orgId, userRole: maskCtx?.user?.role,
                 connectionId: connId,
-              }));
+              });
               maskingApplied = maskedRows !== result.rows;
             } catch (err) {
               log.warn(
@@ -1569,14 +1588,12 @@ async function executeSqlForConnection({
                 let cachedMaskingApplied = false;
                 if (classification?.tablesAccessed.length && orgId) {
                   try {
-                    const { applyMasking } = await import("@atlas/ee/compliance/masking");
-                    const { Effect: E } = await import("effect");
-                    cachedRows = await E.runPromise(applyMasking({
+                    cachedRows = await applyMaskingViaTag({
                       columns: cached.columns, rows: cached.rows,
                       tablesAccessed: classification.tablesAccessed,
                       orgId, userRole: ctx?.user?.role,
                       connectionId: connId,
-                    }));
+                    });
                     cachedMaskingApplied = cachedRows !== cached.rows;
                   } catch (err) {
                     log.warn(


### PR DESCRIPTION
## Summary

Slice 4/11 of #2017 (1.5.1 — Architecture Deepening). Inverts every `@atlas/ee/compliance/*` import in `packages/api/src/` so core depends on the `MaskingPolicy` + `ComplianceReports` Tags (introduced in #2563) instead of the EE modules directly.

EE overlays the real implementations through `MaskingPolicyLive` + `ComplianceReportsLive` aggregated in `ee/src/layers.ts:EELayer`. Self-hosted falls through to no-op defaults: masking returns rows unchanged (fail open — matches pre-#2566 behavior); reports fail with `ReportError(\"not_available\")` so the admin route surfaces the existing 404 envelope.

## What changed

**Foundation**
- `ComplianceError` + `ReportError` (Data.TaggedError) promoted to `lib/compliance/errors.ts` so the Tags can type their failure channels without core importing `@atlas/ee`. Both EE compliance modules re-export for back-compat — same `_tag` + payload + `instanceof` semantics.
- `MaskingPolicyShape` widened in `services.ts` to cover `applyMasking` + PII classification CRUD (`list/update/delete/invalidateClassificationCache`).
- `ComplianceReportsShape` widened to cover `generateDataAccessReport`, `generateUserActivityReport`, and both CSV converters.
- `MaskingContext` interface exported from core so call sites + the Tag share one source of truth.

**Call sites migrated**
- `lib/tools/sql.ts` — two `await import(\"@atlas/ee/compliance/masking\")` blocks (live query path + cached results path) replaced with a single `applyMaskingViaTag()` helper that runs the Tag program with `EnterpriseLayer` provided. Keeps the existing try/catch fail-open semantics intact at both sites.
- `api/routes/admin-compliance.ts` — all classification + report imports replaced with `yield* MaskingPolicy` / `yield* ComplianceReports` + `router.<method>` calls. `ComplianceError` / `ReportError` import retargeted to core; existing `domainError(...)` mappings still apply.

**Tests**
- `admin-compliance.test.ts` — switched from `mock.module(\"@atlas/ee/compliance/*\")` to `mock.module(\"@atlas/ee/layers\")` injecting both `MaskingPolicy` and `ComplianceReports` test layers via the EE aggregator. Existing fixture state (`mockUpdateResult`, `mockUpdateError`, etc.) threads through to the Tag's methods unchanged.

## Acceptance criteria

- [x] No `@atlas/ee/compliance/*` imports anywhere in `packages/api/src/` (only comments + test mocks remain — closeout grep in #2573 will exclude both)
- [x] Masking applied identically to SaaS-enterprise rows; self-hosted returns rows unchanged through the no-op
- [x] Admin compliance route renders the same data
- [x] `bun run test:api` green (412/412)
- [x] `/ci` gates: lint + type + test:api + test:others + syncpack + template-drift + railway-watch + schema-drift + security-headers + oauth-helper — all pass

## Test plan

- [x] `bun run test:api` — 412/412 pass
- [x] `bun run test:others` — pass
- [x] `bun run lint` — clean (only the pre-existing `warnCalls` warning in `detect.test.ts`)
- [x] `bun x tsgo --noEmit` — clean
- [x] CI gates green
- [ ] Wait for required-checks on the head SHA before merging

Closes #2566