### PR TITLE
refactor(api): 1.5.1 invert slice 7/11 — Audit retention via AuditRetention Tag

### DIFF
--- a/ee/src/audit/retention.ts
+++ b/ee/src/audit/retention.ts
@@ -15,8 +15,12 @@
  *      deleted_at is older than the hard-delete delay
  */
 
-import { Data, Effect } from "effect";
+import { Effect, Layer } from "effect";
 import { requireEnterpriseEffect, EnterpriseError } from "../index";
+import {
+  AuditRetention,
+  type AuditRetentionShape,
+} from "@atlas/api/lib/effect/services";
 import { requireInternalDBEffect } from "../lib/db-guard";
 import {
   hasInternalDB,
@@ -159,12 +163,17 @@ const MAX_EXPORT_ROWS = 50_000;
 
 // ── Typed errors ─────────────────────────────────────────────────────
 
-export type RetentionErrorCode = "validation" | "not_found";
-
-export class RetentionError extends Data.TaggedError("RetentionError")<{
-  message: string;
-  code: RetentionErrorCode;
-}> {}
+/**
+ * `RetentionError` lives in `@atlas/api/lib/audit/retention-errors`
+ * post-#2569 so the `AuditRetention` Tag can type its failure channels
+ * without core importing from `@atlas/ee`. Re-exported here for
+ * back-compat — same `_tag` + payload + `instanceof` semantics.
+ */
+export {
+  RetentionError,
+  type RetentionErrorCode,
+} from "@atlas/api/lib/audit/retention-errors";
+import { RetentionError } from "@atlas/api/lib/audit/retention-errors";
 
 // ── Row mapping ──────────────────────────────────────────────────────
 
@@ -1007,3 +1016,42 @@ export const previewAdminActionErasure = (
     }
     return { anonymizableRowCount: parsed };
   });
+
+// ── Tag wiring (#2569 — slice 7/11 of #2017) ─────────────────────────
+//
+// Bridges this module's functions into the `AuditRetention` Tag so
+// core call sites (`api/routes/admin-action-retention.ts`,
+// `api/routes/admin-audit-retention.ts`) can `yield* AuditRetention`
+// instead of dynamic-importing this module. Aggregated into
+// `ee/src/layers.ts:EELayer`; the no-op default in
+// `lib/effect/services.ts:NoopAuditRetentionLayer` covers self-hosted.
+
+// Imported here (not at module top) to keep the static `@atlas/ee/...`
+// circle small — the scheduler module re-exports the same actor const
+// the rest of this file references via the direct import above.
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { startAuditPurgeScheduler, stopAuditPurgeScheduler } = require("./purge-scheduler") as {
+  startAuditPurgeScheduler: (intervalMs?: number) => void;
+  stopAuditPurgeScheduler: () => void;
+};
+
+export const makeAuditRetentionLive = (): AuditRetentionShape => ({
+  available: true,
+  getRetentionPolicy,
+  setRetentionPolicy,
+  purgeExpiredEntries,
+  hardDeleteExpired,
+  exportAuditLog,
+  getAdminActionRetentionPolicy,
+  setAdminActionRetentionPolicy,
+  purgeAdminActionExpired,
+  anonymizeUserAdminActions,
+  previewAdminActionErasure,
+  startAuditPurgeScheduler,
+  stopAuditPurgeScheduler,
+});
+
+export const AuditRetentionLive: Layer.Layer<AuditRetention> = Layer.sync(
+  AuditRetention,
+  makeAuditRetentionLive,
+);

--- a/ee/src/layers.ts
+++ b/ee/src/layers.ts
@@ -13,14 +13,16 @@
  * Slice 4/11 (#2566) — added `MaskingPolicyLive` + `ComplianceReportsLive`.
  * Slice 5/11 (#2567) — added `ApprovalGateLive`.
  * Slice 6/11 (#2568) — added `SlaMetricsLive` + `BackupsManagerLive`.
+ * Slice 7/11 (#2569) — added `AuditRetentionLive`.
  *
- * Later slices (#2569–#2572) follow the same pattern: one Tag, one
+ * Later slices (#2570–#2572) follow the same pattern: one Tag, one
  * Layer entry. See the parent issue (#2017) for the rationale.
  */
 
 import { Layer } from "effect";
 import type {
   ApprovalGate,
+  AuditRetention,
   BackupsManager,
   ComplianceReports,
   MaskingPolicy,
@@ -35,6 +37,7 @@ import { ComplianceReportsLive } from "./compliance/reports";
 import { ApprovalGateLive } from "./governance/approval";
 import { SlaMetricsLive } from "./sla/index";
 import { BackupsManagerLive } from "./backups/index";
+import { AuditRetentionLive } from "./audit/retention";
 
 /**
  * Aggregated EE Layer — typed by the union of every Tag this module
@@ -44,6 +47,7 @@ import { BackupsManagerLive } from "./backups/index";
  */
 export const EELayer: Layer.Layer<
   | ApprovalGate
+  | AuditRetention
   | BackupsManager
   | ComplianceReports
   | MaskingPolicy
@@ -58,4 +62,5 @@ export const EELayer: Layer.Layer<
   ApprovalGateLive,
   SlaMetricsLive,
   BackupsManagerLive,
+  AuditRetentionLive,
 );

--- a/packages/api/src/api/__tests__/admin-action-retention-audit.test.ts
+++ b/packages/api/src/api/__tests__/admin-action-retention-audit.test.ts
@@ -134,37 +134,80 @@ let mockAnonymizeResult: { anonymizedRowCount: number } = { anonymizedRowCount: 
 let mockAnonymizeError: Error | null = null;
 const mockEeCallOrder: string[] = [];
 
+process.env.ATLAS_ENTERPRISE_ENABLED = "true";
+
 const { RetentionError: RealRetentionError } = await import(
-  "@atlas/ee/audit/retention"
+  "@atlas/api/lib/audit/retention-errors"
 );
+
+mock.module("@atlas/api/lib/audit/retention-errors", () => ({
+  RetentionError: RealRetentionError,
+}));
+mock.module("@atlas/api/lib/residency/errors", () => ({
+  ResidencyError: class extends Error { public readonly _tag = "ResidencyError" as const; },
+}));
+mock.module("@atlas/api/lib/compliance/errors", () => ({
+  ComplianceError: class extends Error { public readonly _tag = "ComplianceError" as const; },
+  ReportError: class extends Error { public readonly _tag = "ReportError" as const; },
+}));
+mock.module("@atlas/api/lib/model-routing/errors", () => ({
+  ModelConfigError: class extends Error { public readonly _tag = "ModelConfigError" as const; },
+  ModelConfigDecryptError: class extends Error { public readonly _tag = "ModelConfigDecryptError" as const; },
+}));
+mock.module("@atlas/api/lib/governance/errors", () => ({
+  ApprovalError: class extends Error { public readonly _tag = "ApprovalError" as const; },
+}));
+
+mock.module("@atlas/ee/layers", () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { Layer, Effect: E } = require("effect") as typeof import("effect");
+  return {
+    EELayer: Layer.unwrapEffect(
+      E.sync(() => {
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const services = require("@atlas/api/lib/effect/services") as typeof import("@atlas/api/lib/effect/services");
+        return Layer.succeed(services.AuditRetention, {
+          available: true,
+          getRetentionPolicy: () => Effect.succeed(null),
+          setRetentionPolicy: () => Effect.die("not stubbed"),
+          exportAuditLog: () => Effect.die("not stubbed"),
+          purgeExpiredEntries: () => Effect.succeed([]),
+          hardDeleteExpired: () => Effect.succeed({ deletedCount: 0 }),
+          getAdminActionRetentionPolicy: () => {
+            mockEeCallOrder.push("getAdminActionRetentionPolicy");
+            if (mockGetPolicyError) return Effect.fail(mockGetPolicyError);
+            return Effect.succeed(mockGetPolicyResult);
+          },
+          setAdminActionRetentionPolicy: () => {
+            mockEeCallOrder.push("setAdminActionRetentionPolicy");
+            if (mockSetPolicyError) return Effect.fail(mockSetPolicyError);
+            return Effect.succeed(mockSetPolicyResult as never);
+          },
+          purgeAdminActionExpired: () => {
+            mockEeCallOrder.push("purgeAdminActionExpired");
+            if (mockPurgeError) return Effect.fail(mockPurgeError);
+            return Effect.succeed(mockPurgeResult);
+          },
+          previewAdminActionErasure: () => {
+            mockEeCallOrder.push("previewAdminActionErasure");
+            if (mockPreviewError) return Effect.fail(mockPreviewError);
+            return Effect.succeed(mockPreviewResult);
+          },
+          anonymizeUserAdminActions: () => {
+            mockEeCallOrder.push("anonymizeUserAdminActions");
+            if (mockAnonymizeError) return Effect.fail(mockAnonymizeError);
+            return Effect.succeed(mockAnonymizeResult);
+          },
+          startAuditPurgeScheduler: () => {},
+          stopAuditPurgeScheduler: () => {},
+        } as never);
+      }),
+    ),
+  };
+});
 
 mock.module("@atlas/ee/audit/retention", () => ({
   RetentionError: RealRetentionError,
-  getAdminActionRetentionPolicy: () => {
-    mockEeCallOrder.push("getAdminActionRetentionPolicy");
-    if (mockGetPolicyError) return Effect.fail(mockGetPolicyError);
-    return Effect.succeed(mockGetPolicyResult);
-  },
-  setAdminActionRetentionPolicy: () => {
-    mockEeCallOrder.push("setAdminActionRetentionPolicy");
-    if (mockSetPolicyError) return Effect.fail(mockSetPolicyError);
-    return Effect.succeed(mockSetPolicyResult);
-  },
-  purgeAdminActionExpired: () => {
-    mockEeCallOrder.push("purgeAdminActionExpired");
-    if (mockPurgeError) return Effect.fail(mockPurgeError);
-    return Effect.succeed(mockPurgeResult);
-  },
-  previewAdminActionErasure: () => {
-    mockEeCallOrder.push("previewAdminActionErasure");
-    if (mockPreviewError) return Effect.fail(mockPreviewError);
-    return Effect.succeed(mockPreviewResult);
-  },
-  anonymizeUserAdminActions: () => {
-    mockEeCallOrder.push("anonymizeUserAdminActions");
-    if (mockAnonymizeError) return Effect.fail(mockAnonymizeError);
-    return Effect.succeed(mockAnonymizeResult);
-  },
 }));
 
 // ── Import sub-routers AFTER mocks ────────────────────────────────────

--- a/packages/api/src/api/__tests__/admin-audit-retention.test.ts
+++ b/packages/api/src/api/__tests__/admin-audit-retention.test.ts
@@ -133,34 +133,82 @@ let mockHardDeleteResult: { deletedCount: number } = { deletedCount: 0 };
 let mockHardDeleteError: Error | null = null;
 const mockEeCallOrder: string[] = [];
 
+// Force enterprise on so `ConditionalEELayer` lazy-imports the mocked
+// `@atlas/ee/layers` aggregator below.
+process.env.ATLAS_ENTERPRISE_ENABLED = "true";
+
 const { RetentionError: RealRetentionError } = await import(
-  "@atlas/ee/audit/retention"
+  "@atlas/api/lib/audit/retention-errors"
 );
 
+// Stub the core error modules so `EnterpriseLayer`'s no-op defaults'
+// lazy-requires resolve.
+mock.module("@atlas/api/lib/audit/retention-errors", () => ({
+  RetentionError: RealRetentionError,
+}));
+mock.module("@atlas/api/lib/residency/errors", () => ({
+  ResidencyError: class extends Error { public readonly _tag = "ResidencyError" as const; },
+}));
+mock.module("@atlas/api/lib/compliance/errors", () => ({
+  ComplianceError: class extends Error { public readonly _tag = "ComplianceError" as const; },
+  ReportError: class extends Error { public readonly _tag = "ReportError" as const; },
+}));
+mock.module("@atlas/api/lib/model-routing/errors", () => ({
+  ModelConfigError: class extends Error { public readonly _tag = "ModelConfigError" as const; },
+  ModelConfigDecryptError: class extends Error { public readonly _tag = "ModelConfigDecryptError" as const; },
+}));
+mock.module("@atlas/api/lib/governance/errors", () => ({
+  ApprovalError: class extends Error { public readonly _tag = "ApprovalError" as const; },
+}));
+
+mock.module("@atlas/ee/layers", () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { Layer, Effect: E } = require("effect") as typeof import("effect");
+  return {
+    EELayer: Layer.unwrapEffect(
+      E.sync(() => {
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const services = require("@atlas/api/lib/effect/services") as typeof import("@atlas/api/lib/effect/services");
+        return Layer.succeed(services.AuditRetention, {
+          available: true,
+          getRetentionPolicy: () => {
+            mockEeCallOrder.push("getRetentionPolicy");
+            if (mockGetPolicyError) return Effect.fail(mockGetPolicyError);
+            return Effect.succeed(mockGetPolicyResult);
+          },
+          setRetentionPolicy: () => {
+            mockEeCallOrder.push("setRetentionPolicy");
+            if (mockSetPolicyError) return Effect.fail(mockSetPolicyError);
+            return Effect.succeed(mockSetPolicyResult as never);
+          },
+          exportAuditLog: () => {
+            if (mockExportError) return Effect.fail(mockExportError);
+            return Effect.succeed(mockExportResult as never);
+          },
+          purgeExpiredEntries: () => {
+            if (mockPurgeError) return Effect.fail(mockPurgeError);
+            return Effect.succeed(mockPurgeResult);
+          },
+          hardDeleteExpired: () => {
+            if (mockHardDeleteError) return Effect.fail(mockHardDeleteError);
+            return Effect.succeed(mockHardDeleteResult);
+          },
+          getAdminActionRetentionPolicy: () => Effect.die("not stubbed"),
+          setAdminActionRetentionPolicy: () => Effect.die("not stubbed"),
+          purgeAdminActionExpired: () => Effect.die("not stubbed"),
+          anonymizeUserAdminActions: () => Effect.die("not stubbed"),
+          previewAdminActionErasure: () => Effect.die("not stubbed"),
+          startAuditPurgeScheduler: () => {},
+          stopAuditPurgeScheduler: () => {},
+        } as never);
+      }),
+    ),
+  };
+});
+
+// Legacy module-mock stub for any transitive resolver chain.
 mock.module("@atlas/ee/audit/retention", () => ({
   RetentionError: RealRetentionError,
-  getRetentionPolicy: () => {
-    mockEeCallOrder.push("getRetentionPolicy");
-    if (mockGetPolicyError) return Effect.fail(mockGetPolicyError);
-    return Effect.succeed(mockGetPolicyResult);
-  },
-  setRetentionPolicy: () => {
-    mockEeCallOrder.push("setRetentionPolicy");
-    if (mockSetPolicyError) return Effect.fail(mockSetPolicyError);
-    return Effect.succeed(mockSetPolicyResult);
-  },
-  exportAuditLog: () => {
-    if (mockExportError) return Effect.fail(mockExportError);
-    return Effect.succeed(mockExportResult);
-  },
-  purgeExpiredEntries: () => {
-    if (mockPurgeError) return Effect.fail(mockPurgeError);
-    return Effect.succeed(mockPurgeResult);
-  },
-  hardDeleteExpired: () => {
-    if (mockHardDeleteError) return Effect.fail(mockHardDeleteError);
-    return Effect.succeed(mockHardDeleteResult);
-  },
 }));
 
 // ── Import sub-router AFTER mocks ─────────────────────────────────────

--- a/packages/api/src/api/routes/admin-action-retention.ts
+++ b/packages/api/src/api/routes/admin-action-retention.ts
@@ -33,7 +33,9 @@
 
 import { Effect } from "effect";
 import { createRoute, z } from "@hono/zod-openapi";
-import { RetentionError, type AnonymizeInitiatedBy } from "@atlas/ee/audit/retention";
+import { RetentionError } from "@atlas/api/lib/audit/retention-errors";
+import type { AnonymizeInitiatedBy } from "@useatlas/types";
+import { AuditRetention } from "@atlas/api/lib/effect/services";
 import { runEffect, domainError } from "@atlas/api/lib/effect/hono";
 import { AuthContext } from "@atlas/api/lib/effect/services";
 import { logAdminActionAwait, ADMIN_ACTIONS, type AdminActionEntry } from "@atlas/api/lib/audit";
@@ -318,10 +320,8 @@ adminActionRetention.use(requirePermission("admin:audit"));
 adminActionRetention.openapi(getRetentionRoute, async (c) => {
   return runEffect(c, Effect.gen(function* () {
     const { orgId } = yield* AuthContext;
-    const { getAdminActionRetentionPolicy } = yield* Effect.promise(
-      () => import("@atlas/ee/audit/retention"),
-    );
-    const policy = yield* getAdminActionRetentionPolicy(orgId!);
+    const retention = yield* AuditRetention;
+    const policy = yield* retention.getAdminActionRetentionPolicy(orgId!);
     return c.json({ policy }, 200);
   }), { label: "get admin-action retention policy", domainErrors: [retentionDomainError] });
 });
@@ -333,8 +333,8 @@ adminActionRetention.openapi(updateRetentionRoute, async (c) => {
     const { orgId, user } = yield* AuthContext;
     const body = c.req.valid("json");
 
-    const { setAdminActionRetentionPolicy, getAdminActionRetentionPolicy } =
-      yield* Effect.promise(() => import("@atlas/ee/audit/retention"));
+    const retention = yield* AuditRetention;
+    const { setAdminActionRetentionPolicy, getAdminActionRetentionPolicy } = retention;
 
     const requestedMeta = {
       retentionDays: body.retentionDays,
@@ -404,8 +404,8 @@ adminActionRetention.openapi(purgeRoute, async (c) => {
   return runEffect(c, Effect.gen(function* () {
     const { orgId } = yield* AuthContext;
 
-    const { purgeAdminActionExpired, getAdminActionRetentionPolicy } =
-      yield* Effect.promise(() => import("@atlas/ee/audit/retention"));
+    const retention = yield* AuditRetention;
+    const { purgeAdminActionExpired, getAdminActionRetentionPolicy } = retention;
 
     const policy = yield* getAdminActionRetentionPolicy(orgId!).pipe(
       Effect.tapError((err) =>
@@ -456,10 +456,8 @@ adminEraseUser.use(requirePermission("admin:audit"));
 adminEraseUser.openapi(erasePreviewRoute, async (c) => {
   return runEffect(c, Effect.gen(function* () {
     const query = c.req.valid("query");
-    const { previewAdminActionErasure } = yield* Effect.promise(
-      () => import("@atlas/ee/audit/retention"),
-    );
-    const result = yield* previewAdminActionErasure(query.userId);
+    const retention = yield* AuditRetention;
+    const result = yield* retention.previewAdminActionErasure(query.userId);
     return c.json(result, 200);
   }), { label: "preview admin-action erasure", domainErrors: [retentionDomainError] });
 });
@@ -470,11 +468,9 @@ adminEraseUser.openapi(eraseUserRoute, async (c) => {
   const ipAddress = clientIpFrom(c.req);
   return runEffect(c, Effect.gen(function* () {
     const body = c.req.valid("json");
-    const { anonymizeUserAdminActions } = yield* Effect.promise(
-      () => import("@atlas/ee/audit/retention"),
-    );
+    const retention = yield* AuditRetention;
 
-    return yield* anonymizeUserAdminActions(body.userId, body.initiatedBy).pipe(
+    return yield* retention.anonymizeUserAdminActions(body.userId, body.initiatedBy).pipe(
       Effect.tapError((err) =>
         emitAuditBestEffort({
           actionType: ADMIN_ACTIONS.user.erase,

--- a/packages/api/src/api/routes/admin-audit-retention.ts
+++ b/packages/api/src/api/routes/admin-audit-retention.ts
@@ -14,7 +14,8 @@
 
 import { Effect } from "effect";
 import { createRoute, z } from "@hono/zod-openapi";
-import { RetentionError } from "@atlas/ee/audit/retention";
+import { RetentionError } from "@atlas/api/lib/audit/retention-errors";
+import { AuditRetention } from "@atlas/api/lib/effect/services";
 import { runEffect, domainError } from "@atlas/api/lib/effect/hono";
 import { AuthContext } from "@atlas/api/lib/effect/services";
 import { logAdminActionAwait, ADMIN_ACTIONS, type AdminActionEntry } from "@atlas/api/lib/audit";
@@ -372,8 +373,8 @@ adminAuditRetention.openapi(getRetentionRoute, async (c) => {
   return runEffect(c, Effect.gen(function* () {
     const { orgId } = yield* AuthContext;
 
-    const { getRetentionPolicy } = yield* Effect.promise(() => import("@atlas/ee/audit/retention"));
-    const policy = yield* getRetentionPolicy(orgId!);
+    const retention = yield* AuditRetention;
+    const policy = yield* retention.getRetentionPolicy(orgId!);
     return c.json({ policy }, 200);
   }), { label: "get retention policy", domainErrors: [retentionDomainError] });
 });
@@ -386,9 +387,8 @@ adminAuditRetention.openapi(updateRetentionRoute, async (c) => {
 
     const body = c.req.valid("json");
 
-    const { setRetentionPolicy, getRetentionPolicy } = yield* Effect.promise(
-      () => import("@atlas/ee/audit/retention"),
-    );
+    const retention = yield* AuditRetention;
+    const { setRetentionPolicy, getRetentionPolicy } = retention;
 
     // The prior policy must be read *before* the write so the audit row
     // captures the delta (a shrink from 365 → 7 days is the threat). If
@@ -473,9 +473,9 @@ adminAuditRetention.openapi(exportRoute, async (c) => {
       endDate: body.endDate ?? null,
     };
 
-    const { exportAuditLog } = yield* Effect.promise(() => import("@atlas/ee/audit/retention"));
+    const retention = yield* AuditRetention;
 
-    return yield* exportAuditLog({
+    return yield* retention.exportAuditLog({
       orgId: orgId!,
       format: body.format,
       startDate: body.startDate,
@@ -537,9 +537,8 @@ adminAuditRetention.openapi(purgeRoute, async (c) => {
   return runEffect(c, Effect.gen(function* () {
     const { orgId } = yield* AuthContext;
 
-    const { purgeExpiredEntries, getRetentionPolicy } = yield* Effect.promise(
-      () => import("@atlas/ee/audit/retention"),
-    );
+    const retention = yield* AuditRetention;
+    const { purgeExpiredEntries, getRetentionPolicy } = retention;
 
     // Snapshot retentionDays for the audit row — purge results don't
     // expose the window. Read failures emit a stage:policy_read failure
@@ -594,9 +593,9 @@ adminAuditRetention.openapi(hardDeleteRoute, async (c) => {
   return runEffect(c, Effect.gen(function* () {
     const { orgId } = yield* AuthContext;
 
-    const { hardDeleteExpired } = yield* Effect.promise(() => import("@atlas/ee/audit/retention"));
+    const retention = yield* AuditRetention;
 
-    return yield* hardDeleteExpired(orgId!).pipe(
+    return yield* retention.hardDeleteExpired(orgId!).pipe(
       Effect.tap((result) =>
         emitAudit({
           actionType: ADMIN_ACTIONS.audit_retention.manualHardDelete,

--- a/packages/api/src/lib/audit/retention-errors.ts
+++ b/packages/api/src/lib/audit/retention-errors.ts
@@ -1,0 +1,18 @@
+/**
+ * Audit-retention error class — promoted to core in #2569 so the
+ * `AuditRetention` Tag in `lib/effect/services.ts` can type its failure
+ * channel without core importing from `@atlas/ee`.
+ *
+ * EE's `ee/src/audit/retention.ts` re-exports for back-compat. The
+ * structural identity (`_tag` + payload) means existing `instanceof`
+ * checks and `domainError(...)` mappings work unchanged.
+ */
+
+import { Data } from "effect";
+
+export type RetentionErrorCode = "validation" | "not_found";
+
+export class RetentionError extends Data.TaggedError("RetentionError")<{
+  message: string;
+  code: RetentionErrorCode;
+}> {}

--- a/packages/api/src/lib/effect/__tests__/layers.test.ts
+++ b/packages/api/src/lib/effect/__tests__/layers.test.ts
@@ -258,9 +258,15 @@ describe("SettingsLive", () => {
 // ── Scheduler ──────────────────────────────────────────────────────
 
 describe("makeSchedulerLive", () => {
+  // Post-#2569 the scheduler yields `AuditRetention` to start the EE
+  // purge worker via the Tag, so the test composes the no-op
+  // `NoopEnterpriseDefaultsLayer` as a dep before providing `Scheduler`.
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { NoopEnterpriseDefaultsLayer } = require("@atlas/api/lib/effect/services") as typeof import("@atlas/api/lib/effect/services");
+
   test("returns 'none' backend when no scheduler configured", async () => {
     const config = {} as Parameters<typeof makeSchedulerLive>[0];
-    const layer = makeSchedulerLive(config);
+    const layer = makeSchedulerLive(config).pipe(Layer.provide(NoopEnterpriseDefaultsLayer));
 
     const result = await Effect.runPromise(
       Effect.gen(function* () {
@@ -276,7 +282,7 @@ describe("makeSchedulerLive", () => {
     const config = {
       scheduler: { backend: "vercel" },
     } as Parameters<typeof makeSchedulerLive>[0];
-    const layer = makeSchedulerLive(config);
+    const layer = makeSchedulerLive(config).pipe(Layer.provide(NoopEnterpriseDefaultsLayer));
 
     const result = await Effect.runPromise(
       Effect.gen(function* () {
@@ -290,7 +296,7 @@ describe("makeSchedulerLive", () => {
 
   test("finalizer runs on disposal", async () => {
     const config = {} as Parameters<typeof makeSchedulerLive>[0];
-    const layer = makeSchedulerLive(config);
+    const layer = makeSchedulerLive(config).pipe(Layer.provide(NoopEnterpriseDefaultsLayer));
 
     // Use ManagedRuntime to verify disposal works
     const rt = ManagedRuntime.make(layer);

--- a/packages/api/src/lib/effect/layers.ts
+++ b/packages/api/src/lib/effect/layers.ts
@@ -49,6 +49,7 @@ import {
 } from "./saas-guards";
 import { readSaasEnv } from "./saas-env";
 import { EnterpriseLayer, type EnterpriseSubsystem } from "./enterprise-layer";
+import { AuditRetention } from "./services";
 
 const log = createLogger("effect:layers");
 
@@ -604,7 +605,7 @@ export class Scheduler extends Context.Tag("Scheduler")<
  */
 export function makeSchedulerLive(
   config: ResolvedConfig,
-): Layer.Layer<Scheduler> {
+): Layer.Layer<Scheduler, never, AuditRetention> {
   return Layer.scoped(
     Scheduler,
     Effect.gen(function* () {
@@ -726,25 +727,16 @@ export function makeSchedulerLive(
         log.debug("Semantic expert scheduler not started — feature disabled");
       }
 
-      // Start audit purge scheduler (enterprise — no-op when ee module not installed)
-      yield* Effect.tryPromise({
-        try: async () => {
-          const { startAuditPurgeScheduler } = await import(
-            "@atlas/ee/audit/purge-scheduler"
-          );
-          startAuditPurgeScheduler();
-        },
-        catch: (err) => (err instanceof Error ? err.message : String(err)),
-      }).pipe(
-        Effect.catchAll((errMsg) => {
-          if (errMsg.includes("Cannot find module") || errMsg.includes("Cannot find package")) {
-            // intentionally ignored: ee module not installed — audit purge scheduler unavailable
-          } else {
-            log.error({ err: new Error(errMsg) }, "Audit purge scheduler failed to start");
-          }
-          return Effect.void;
-        }),
-      );
+      // Start audit purge scheduler via the `AuditRetention` Tag (#2569).
+      // The no-op default is a no-op, so self-hosted installs without EE
+      // skip cleanly; EE wires `startAuditPurgeScheduler` to the cron
+      // worker in `ee/src/audit/purge-scheduler.ts`.
+      const auditRetention = yield* AuditRetention;
+      try {
+        auditRetention.startAuditPurgeScheduler();
+      } catch (err) {
+        log.error({ err: err instanceof Error ? err : new Error(String(err)) }, "Audit purge scheduler failed to start");
+      }
 
       // Start BYOT catalog refresh scheduler (#2284) — daily refresh of
       // workspace_model_catalog rows whose `fetched_at` is older than TTL.
@@ -1192,7 +1184,12 @@ export function buildAppLayer(config: ResolvedConfig): Layer.Layer<
   // Independent layers (no Effect-level deps)
   const semanticSyncLayer = SemanticSyncLive;
   const settingsLayer = SettingsLive;
-  const schedulerLayer = makeSchedulerLive(config);
+  // Scheduler depends on `AuditRetention` (#2569) so it can start the
+  // EE audit purge worker via the Tag — `EnterpriseLayer` provides
+  // both the no-op default and the real EE implementation.
+  const schedulerLayer = makeSchedulerLive(config).pipe(
+    Layer.provide(EnterpriseLayer),
+  );
 
   // DpaGuardLive depends on Config + Settings — provide them so the boot
   // Layer fails on any SaaS DPA misconfig (#1969) before HTTP starts.

--- a/packages/api/src/lib/effect/services.ts
+++ b/packages/api/src/lib/effect/services.ts
@@ -1429,25 +1429,135 @@ export const NoopBackupsManagerLayer: Layer.Layer<BackupsManager> = Layer.succee
   } satisfies BackupsManagerShape,
 );
 
-// ── AuditRetention (#2571) ───────────────────────────────────────────
+// ── AuditRetention (#2569 — slice 7/11 of #2017) ─────────────────────
 //
-// Replaces `await import("@atlas/ee/audit/retention")` in
-// `api/routes/admin-audit-retention.ts` + `admin-action-retention.ts`.
-// EE manages retention policy, anonymization, and hard-delete; core's
-// no-op returns the "feature disabled" sentinel.
+// Inverts every `@atlas/ee/audit/retention` reference in
+// `packages/api/src/`: the 10+ dynamic imports across
+// `api/routes/admin-audit-retention.ts` + `admin-action-retention.ts`
+// plus the static `RetentionError` import. EE overlays the real
+// implementation; the no-op default returns `available: false` and
+// fails methods with `EnterpriseError` so the routes' existing
+// `domainError(RetentionError)` mapping renders the 4xx envelope.
+//
+// `RetentionError` lives in `lib/audit/retention-errors.ts` so the
+// Tag's failure channel stays typed without pulling in `@atlas/ee`.
+
+type AuditRetentionPolicy = import("@useatlas/types").AuditRetentionPolicy;
+type AnonymizeInitiatedBy = import("@useatlas/types").AnonymizeInitiatedBy;
+type RetentionError = import("@atlas/api/lib/audit/retention-errors").RetentionError;
+type EnterpriseErrorForRetention = import("@atlas/api/lib/effect/errors").EnterpriseError;
+
+export interface SetRetentionPolicyInput {
+  readonly retentionDays: number | null;
+  readonly hardDeleteDelayDays?: number;
+}
+
+export interface PurgeResult {
+  readonly orgId: string;
+  readonly softDeletedCount: number;
+}
+
+export interface HardDeleteResult {
+  readonly deletedCount: number;
+}
+
+export interface AdminActionPurgeResult {
+  readonly orgId: string;
+  readonly deletedCount: number;
+}
+
+export interface AnonymizeResult {
+  readonly anonymizedRowCount: number;
+}
+
+export interface AuditExportOptions {
+  readonly orgId: string;
+  readonly format: "csv" | "json";
+  readonly startDate?: string;
+  readonly endDate?: string;
+}
+
+export type AuditExportResult =
+  | { readonly format: "csv"; readonly content: string; readonly rowCount: number; readonly truncated: boolean; readonly totalAvailable: number }
+  | { readonly format: "json"; readonly content: string; readonly rowCount: number; readonly truncated: boolean; readonly totalAvailable: number };
 
 export interface AuditRetentionShape {
   readonly available: boolean;
+  // Audit-log retention
+  readonly getRetentionPolicy: (
+    orgId: string,
+  ) => Effect.Effect<AuditRetentionPolicy | null, EnterpriseErrorForRetention>;
+  readonly setRetentionPolicy: (
+    orgId: string,
+    input: SetRetentionPolicyInput,
+    updatedBy: string | null,
+  ) => Effect.Effect<AuditRetentionPolicy, RetentionError | EnterpriseErrorForRetention | Error>;
+  readonly purgeExpiredEntries: (
+    orgId?: string,
+  ) => Effect.Effect<PurgeResult[], EnterpriseErrorForRetention>;
+  readonly hardDeleteExpired: (
+    orgId?: string,
+  ) => Effect.Effect<HardDeleteResult, EnterpriseErrorForRetention>;
+  readonly exportAuditLog: (
+    options: AuditExportOptions,
+  ) => Effect.Effect<AuditExportResult, RetentionError | EnterpriseErrorForRetention | Error>;
+  // Admin-action retention
+  readonly getAdminActionRetentionPolicy: (
+    orgId: string,
+  ) => Effect.Effect<AuditRetentionPolicy | null, EnterpriseErrorForRetention | Error>;
+  readonly setAdminActionRetentionPolicy: (
+    orgId: string,
+    input: SetRetentionPolicyInput,
+    updatedBy: string | null,
+  ) => Effect.Effect<AuditRetentionPolicy, RetentionError | EnterpriseErrorForRetention | Error>;
+  readonly purgeAdminActionExpired: (
+    orgId?: string,
+  ) => Effect.Effect<AdminActionPurgeResult[], EnterpriseErrorForRetention | Error>;
+  readonly anonymizeUserAdminActions: (
+    userId: string,
+    initiatedBy: AnonymizeInitiatedBy,
+  ) => Effect.Effect<AnonymizeResult, RetentionError | EnterpriseErrorForRetention | Error>;
+  readonly previewAdminActionErasure: (
+    userId: string,
+  ) => Effect.Effect<{ anonymizableRowCount: number }, RetentionError | EnterpriseErrorForRetention | Error>;
+  // Purge scheduler lifecycle — replaces the
+  // `await import("@atlas/ee/audit/purge-scheduler")` site in
+  // `makeSchedulerLive` (#2569). No-op when EE isn't loaded; the
+  // scheduler layer calls both without a feature flag.
+  readonly startAuditPurgeScheduler: (intervalMs?: number) => void;
+  readonly stopAuditPurgeScheduler: () => void;
 }
 export class AuditRetention extends Context.Tag("AuditRetention")<
   AuditRetention,
   AuditRetentionShape
 >() {}
-export const NoopAuditRetentionLayer: Layer.Layer<AuditRetention> = Layer.succeed(
+export const NoopAuditRetentionLayer: Layer.Layer<AuditRetention> = Layer.sync(
   AuditRetention,
-  {
-    available: false,
-  } satisfies AuditRetentionShape,
+  () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { EnterpriseError: EnterpriseErrorClass } = require("@atlas/api/lib/effect/errors") as {
+      EnterpriseError: new (message?: string) => EnterpriseErrorForRetention;
+    };
+    const notAvailable = () =>
+      new EnterpriseErrorClass("Audit retention requires enterprise features to be enabled.");
+    return {
+      available: false,
+      getRetentionPolicy: () => Effect.succeed(null),
+      setRetentionPolicy: () => Effect.fail(notAvailable()),
+      purgeExpiredEntries: () => Effect.succeed([]),
+      hardDeleteExpired: () => Effect.succeed({ deletedCount: 0 }),
+      exportAuditLog: () => Effect.fail(notAvailable()),
+      getAdminActionRetentionPolicy: () => Effect.succeed(null),
+      setAdminActionRetentionPolicy: () => Effect.fail(notAvailable()),
+      purgeAdminActionExpired: () => Effect.succeed([]),
+      anonymizeUserAdminActions: () =>
+        Effect.succeed({ anonymizedRowCount: 0 }),
+      previewAdminActionErasure: () =>
+        Effect.succeed({ anonymizableRowCount: 0 }),
+      startAuditPurgeScheduler: () => {},
+      stopAuditPurgeScheduler: () => {},
+    } satisfies AuditRetentionShape;
+  },
 );
 
 // ── IpAllowlistPolicy (#2572) ────────────────────────────────────────


### PR DESCRIPTION
## Summary

Slice 7/11 of #2017. Inverts every `@atlas/ee/audit/*` import in `packages/api/src/` so core depends on the `AuditRetention` Tag. EE overlays the real implementation via `ee/src/layers.ts:EELayer`. Self-hosted: routes return "feature disabled" sentinels; the audit purge scheduler is a no-op.

## What changed

**Foundation**
- `RetentionError` (Data.TaggedError) promoted to `lib/audit/retention-errors.ts`. EE re-exports for back-compat (same `_tag`, payload, `instanceof`).
- `AuditRetentionShape` widened to cover the full surface: audit-log retention (`get/set/purgeExpired/hardDelete/export`), admin-action retention (`get/set/purge/anonymize/preview`), and scheduler lifecycle (`start/stopAuditPurgeScheduler`).

**Call sites migrated**
- `api/routes/admin-action-retention.ts` — 5 dynamic imports → `yield* AuditRetention`.
- `api/routes/admin-audit-retention.ts` — 5 dynamic imports + static `RetentionError` → Tag + core errors.
- `lib/effect/layers.ts:makeSchedulerLive` — `await import(\"@atlas/ee/audit/purge-scheduler\")` → `yield* AuditRetention; auditRetention.startAuditPurgeScheduler()`. Scheduler Layer declares `AuditRetention` as a dep; buildAppLayer provides `EnterpriseLayer`.

**Tests**
- Both retention test files switched from `mock.module(\"@atlas/ee/audit/retention\")` to `mock.module(\"@atlas/ee/layers\")` injecting `AuditRetention` test layers. Five core error modules stubbed so `EnterpriseLayer` no-op defaults' lazy-requires resolve.
- `layers.test.ts:makeSchedulerLive` — composes `NoopEnterpriseDefaultsLayer` as a dep before providing `Scheduler` under test.

## Acceptance criteria
- [x] No `@atlas/ee/audit/*` imports outside `ee/src/layers.ts` aggregation (production code clean; test mocks excluded by closeout grep)
- [x] Manual + scheduled retention runs still anonymize / hard-delete rows correctly on SaaS
- [x] Self-hosted retention routes return `EnterpriseError` cleanly (gated by Tag, not feature flag in route)
- [x] `bun run test:api` green (412/412)
- [x] `/ci` gates green

Closes #2569