### PR TITLE
refactor(api): 1.5.1 invert slice 10/11 — Platform admin gates (Branding + Domains + Proactive + Deploy mode)

### DIFF
--- a/ee/src/__tests__/deploy-mode.test.ts
+++ b/ee/src/__tests__/deploy-mode.test.ts
@@ -1,28 +1,28 @@
+/**
+ * Deploy-mode resolution test.
+ *
+ * Post-#2572 (slice 10/11 of #2017) the `resolveDeployMode` function lives
+ * in core (`@atlas/api/lib/effect/deploy-mode`) and reads:
+ *
+ *   - `getConfig().enterprise?.enabled` (or `ATLAS_ENTERPRISE_ENABLED` env)
+ *   - `hasInternalDB()` from the internal-DB module
+ *
+ * The EE re-export from `../deploy-mode` is exercised so a future
+ * regression that strips the re-export surfaces here.
+ */
+
 import { describe, it, expect, beforeEach, mock } from "bun:test";
 
 // ── Mutable state for mocks ─────────────────────────────────────────
-let enterpriseEnabled = true;
+let enterpriseEnabledConfig: boolean | undefined = true;
 let _hasInternalDB = true;
 
 // ── Register ALL mocks before any dynamic imports ───────────────────
 mock.module("@atlas/api/lib/config", () => ({
-  getConfig: () => null,
-}));
-
-mock.module("../index", () => ({
-  isEnterpriseEnabled: () => enterpriseEnabled,
-  getEnterpriseLicenseKey: () => "test-key",
-  EnterpriseError: class EnterpriseError extends Error {
-    readonly code = "enterprise_required" as const;
-    constructor(message = "Enterprise features are not enabled") {
-      super(message);
-      this.name = "EnterpriseError";
-    }
-  },
-  requireEnterprise: () => {
-    if (!enterpriseEnabled) throw new Error("Enterprise features are not enabled");
-  },
-  resolveDeployMode: () => { throw new Error("Use the direct import"); },
+  getConfig: () =>
+    enterpriseEnabledConfig === undefined
+      ? null
+      : { enterprise: { enabled: enterpriseEnabledConfig } },
 }));
 
 mock.module("@atlas/api/lib/db/internal", () => ({
@@ -35,7 +35,8 @@ mock.module("@atlas/api/lib/db/internal", () => ({
   internalQuery: async () => [],
   internalExecute: () => {},
   encryptSecret: (v: string) => `encrypted:${v}`,
-  decryptSecret: (v: string) => (v.startsWith("encrypted:") ? v.slice(10) : v),
+  decryptSecret: (v: string) =>
+    v.startsWith("encrypted:") ? v.slice(10) : v,
   getEncryptionKey: () => Buffer.from("test-key-32-bytes-long-enough!!!"),
   closeInternalDB: async () => {},
   migrateInternalDB: async () => {},
@@ -52,38 +53,39 @@ mock.module("@atlas/api/lib/logger", () => ({
   }),
 }));
 
-// ── Import module under test AFTER all mocks are registered ─────────
+// ── Import the EE re-export AFTER all mocks are registered ──────────
 const { resolveDeployMode } = await import("../deploy-mode");
 
-describe("resolveDeployMode", () => {
+describe("resolveDeployMode (EE re-export)", () => {
   beforeEach(() => {
-    enterpriseEnabled = true;
+    enterpriseEnabledConfig = true;
     _hasInternalDB = true;
     delete process.env.ATLAS_DEPLOY_MODE;
+    delete process.env.ATLAS_ENTERPRISE_ENABLED;
   });
 
   // -- auto mode ------------------------------------------------------------
 
   it('auto + enterprise enabled + hasInternalDB → "saas"', () => {
-    enterpriseEnabled = true;
+    enterpriseEnabledConfig = true;
     _hasInternalDB = true;
     expect(resolveDeployMode("auto")).toBe("saas");
   });
 
   it('auto + enterprise disabled → "self-hosted"', () => {
-    enterpriseEnabled = false;
+    enterpriseEnabledConfig = false;
     _hasInternalDB = true;
     expect(resolveDeployMode("auto")).toBe("self-hosted");
   });
 
   it('auto + no internal DB → "self-hosted"', () => {
-    enterpriseEnabled = true;
+    enterpriseEnabledConfig = true;
     _hasInternalDB = false;
     expect(resolveDeployMode("auto")).toBe("self-hosted");
   });
 
   it('auto + enterprise disabled + no internal DB → "self-hosted"', () => {
-    enterpriseEnabled = false;
+    enterpriseEnabledConfig = false;
     _hasInternalDB = false;
     expect(resolveDeployMode("auto")).toBe("self-hosted");
   });
@@ -91,46 +93,61 @@ describe("resolveDeployMode", () => {
   // -- explicit saas --------------------------------------------------------
 
   it('explicit saas + enterprise enabled → "saas"', () => {
-    enterpriseEnabled = true;
+    enterpriseEnabledConfig = true;
     expect(resolveDeployMode("saas")).toBe("saas");
   });
 
   it('explicit saas + enterprise disabled → "self-hosted" (no-op without license)', () => {
-    enterpriseEnabled = false;
+    enterpriseEnabledConfig = false;
     expect(resolveDeployMode("saas")).toBe("self-hosted");
   });
 
   // -- explicit self-hosted -------------------------------------------------
 
   it('explicit self-hosted → "self-hosted" always (enterprise enabled)', () => {
-    enterpriseEnabled = true;
+    enterpriseEnabledConfig = true;
     _hasInternalDB = true;
     expect(resolveDeployMode("self-hosted")).toBe("self-hosted");
   });
 
   it('explicit self-hosted → "self-hosted" always (enterprise disabled)', () => {
-    enterpriseEnabled = false;
+    enterpriseEnabledConfig = false;
     expect(resolveDeployMode("self-hosted")).toBe("self-hosted");
   });
 
   // -- env var fallback -----------------------------------------------------
 
   it("reads ATLAS_DEPLOY_MODE env var when no argument provided", () => {
-    enterpriseEnabled = true;
+    enterpriseEnabledConfig = true;
     _hasInternalDB = true;
     process.env.ATLAS_DEPLOY_MODE = "saas";
     expect(resolveDeployMode()).toBe("saas");
   });
 
   it('defaults to "auto" when no argument and no env var', () => {
-    enterpriseEnabled = true;
+    enterpriseEnabledConfig = true;
     _hasInternalDB = true;
     // No env var, no argument → auto → saas (because enterprise + internalDB)
     expect(resolveDeployMode()).toBe("saas");
   });
 
   it('defaults to "self-hosted" with auto when enterprise disabled and no env var', () => {
-    enterpriseEnabled = false;
+    enterpriseEnabledConfig = false;
     expect(resolveDeployMode()).toBe("self-hosted");
+  });
+
+  // -- env-var path for enterprise (config absent) --------------------------
+
+  it("respects ATLAS_ENTERPRISE_ENABLED env var when config has no enterprise key", () => {
+    enterpriseEnabledConfig = undefined; // getConfig() → null
+    _hasInternalDB = true;
+    process.env.ATLAS_ENTERPRISE_ENABLED = "true";
+    expect(resolveDeployMode("auto")).toBe("saas");
+  });
+
+  it("treats missing ATLAS_ENTERPRISE_ENABLED as disabled (auto → self-hosted)", () => {
+    enterpriseEnabledConfig = undefined;
+    _hasInternalDB = true;
+    expect(resolveDeployMode("auto")).toBe("self-hosted");
   });
 });

--- a/ee/src/branding/white-label.ts
+++ b/ee/src/branding/white-label.ts
@@ -13,7 +13,7 @@
  * All exported functions return Effect — callers use `yield*` in Effect.gen.
  */
 
-import { Data, Effect } from "effect";
+import { Effect, Layer } from "effect";
 import { requireEnterpriseEffect, EnterpriseError } from "../index";
 import { requireInternalDBEffect } from "../lib/db-guard";
 import {
@@ -22,6 +22,14 @@ import {
   getInternalDB,
 } from "@atlas/api/lib/db/internal";
 import { createLogger } from "@atlas/api/lib/logger";
+import {
+  Branding,
+  type BrandingShape,
+} from "@atlas/api/lib/effect/services";
+import {
+  BrandingError,
+  type BrandingErrorCode,
+} from "@atlas/api/lib/branding/branding-errors";
 import type { WorkspaceBranding, SetWorkspaceBrandingInput } from "@useatlas/types";
 
 export type { WorkspaceBranding, SetWorkspaceBrandingInput } from "@useatlas/types";
@@ -30,12 +38,13 @@ const log = createLogger("ee:branding");
 
 // ── Typed errors ────────────────────────────────────────────────────
 
-export type BrandingErrorCode = "validation" | "not_found";
-
-export class BrandingError extends Data.TaggedError("BrandingError")<{
-  message: string;
-  code: BrandingErrorCode;
-}> {}
+/**
+ * `BrandingError` lives in `@atlas/api/lib/branding/branding-errors` post-#2572
+ * so the `Branding` Tag can type its failure channel without core
+ * importing from `@atlas/ee`. Re-exported here for back-compat — same
+ * `_tag` + payload + `instanceof` semantics.
+ */
+export { BrandingError, type BrandingErrorCode };
 
 // ── Internal row shape ──────────────────────────────────────────────
 
@@ -211,3 +220,24 @@ export const deleteWorkspaceBranding = (orgId: string): Effect.Effect<boolean, E
     }
     return deleted;
   });
+
+// ── Tag wiring (#2572 — slice 10/11 of #2017) ────────────────────────
+//
+// Bridges this module's functions into the `Branding` Tag so core call
+// sites (`api/routes/admin-branding.ts`, `public-branding.ts`) can
+// `yield* Branding` instead of static-importing this module.
+// Aggregated into `ee/src/layers.ts:EELayer`; the no-op default in
+// `lib/effect/services.ts:NoopBrandingLayer` covers self-hosted.
+
+export const makeBrandingLive = (): BrandingShape => ({
+  available: true,
+  getWorkspaceBranding,
+  getWorkspaceBrandingPublic,
+  setWorkspaceBranding,
+  deleteWorkspaceBranding,
+});
+
+export const BrandingLive: Layer.Layer<Branding> = Layer.sync(
+  Branding,
+  makeBrandingLive,
+);

--- a/ee/src/deploy-mode.ts
+++ b/ee/src/deploy-mode.ts
@@ -5,33 +5,34 @@
  * `"saas" | "self-hosted"` value. The `"saas"` mode requires enterprise
  * to be enabled — without it, deploy mode always resolves to `"self-hosted"`.
  *
- * Computed once at import time and cached for the lifetime of the process.
+ * Slice 10/11 of #2017 (#2572) moved the resolver to core
+ * (`@atlas/api/lib/effect/deploy-mode`) so `lib/config.ts:applyDeployMode`
+ * could stop dynamic-importing from `@atlas/ee`. This file is now a thin
+ * re-export plus the EE-side `DeployModeResolver` Layer wiring — same
+ * behavior, no behavior change for either SaaS or self-hosted.
  */
 
-import { isEnterpriseEnabled } from "./index";
-import { hasInternalDB } from "@atlas/api/lib/db/internal";
-import type { DeployMode, DeployModeSetting } from "@useatlas/types";
+import { Layer } from "effect";
+import { resolveDeployMode } from "@atlas/api/lib/effect/deploy-mode";
+import {
+  DeployModeResolver,
+  type DeployModeResolverShape,
+} from "@atlas/api/lib/effect/services";
 
-/**
- * Resolve the effective deploy mode from the raw setting value.
- *
- * Logic:
- * - `"saas"`: requires enterprise enabled, otherwise falls back to `"self-hosted"`
- * - `"self-hosted"`: always returns `"self-hosted"`
- * - `"auto"` (default): returns `"saas"` when both enterprise is enabled AND
- *   an internal database is configured, otherwise `"self-hosted"`
- */
-export function resolveDeployMode(raw?: DeployModeSetting): DeployMode {
-  const setting: DeployModeSetting = raw ?? (process.env.ATLAS_DEPLOY_MODE as DeployModeSetting) ?? "auto";
+export { resolveDeployMode };
 
-  if (setting === "self-hosted") {
-    return "self-hosted";
-  }
+// ── Tag wiring (#2572 — slice 10/11 of #2017) ────────────────────────
+//
+// Bridges `resolveDeployMode` into the `DeployModeResolver` Tag so core
+// can `yield* DeployModeResolver` instead of `await import("@atlas/ee/deploy-mode")`.
+// Aggregated into `ee/src/layers.ts:EELayer`; the no-op default in
+// `lib/effect/services.ts:NoopDeployModeResolverLayer` returns
+// `"self-hosted"` (the correct answer when EE is not loaded — `"saas"`
+// mode requires enterprise).
 
-  if (setting === "saas") {
-    return isEnterpriseEnabled() ? "saas" : "self-hosted";
-  }
+export const makeDeployModeResolverLive = (): DeployModeResolverShape => ({
+  resolve: () => resolveDeployMode(),
+});
 
-  // "auto" — detect from environment
-  return isEnterpriseEnabled() && hasInternalDB() ? "saas" : "self-hosted";
-}
+export const DeployModeResolverLive: Layer.Layer<DeployModeResolver> =
+  Layer.sync(DeployModeResolver, makeDeployModeResolverLive);

--- a/ee/src/layers.ts
+++ b/ee/src/layers.ts
@@ -16,9 +16,13 @@
  * Slice 7/11 (#2569) — added `AuditRetentionLive`.
  * Slice 8/11 (#2570) — added `IpAllowlistPolicyLive` + `SSOPolicyLive`
  *   + `SCIMProvenanceLive` (auth subsystem trio).
+ * Slice 10/11 (#2572) — added `BrandingLive` + `DomainsLive` +
+ *                       `ProactiveGateLive` + `DeployModeResolverLive`
+ *                       (bundled to avoid four PRs of Tag scaffolding
+ *                       overhead for narrow-surface subsystems).
  *
- * Later slices (#2571–#2572) follow the same pattern: one Tag, one
- * Layer entry. See the parent issue (#2017) for the rationale.
+ * Slice 9/11 (#2571) follows the same pattern: one Tag, one Layer
+ * entry. See the parent issue (#2017) for the rationale.
  */
 
 import { Layer } from "effect";
@@ -26,10 +30,14 @@ import type {
   ApprovalGate,
   AuditRetention,
   BackupsManager,
+  Branding,
   ComplianceReports,
+  DeployModeResolver,
+  Domains,
   IpAllowlistPolicy,
   MaskingPolicy,
   ModelRouter,
+  ProactiveGate,
   ResidencyResolver,
   SCIMProvenance,
   SSOPolicy,
@@ -46,6 +54,10 @@ import { AuditRetentionLive } from "./audit/retention";
 import { IpAllowlistPolicyLive } from "./auth/ip-allowlist";
 import { SSOPolicyLive } from "./auth/sso";
 import { SCIMProvenanceLive } from "./auth/scim";
+import { BrandingLive } from "./branding/white-label";
+import { DomainsLive } from "./platform/domains";
+import { ProactiveGateLive } from "./proactive-gate";
+import { DeployModeResolverLive } from "./deploy-mode";
 
 /**
  * Aggregated EE Layer — typed by the union of every Tag this module
@@ -57,10 +69,14 @@ export const EELayer: Layer.Layer<
   | ApprovalGate
   | AuditRetention
   | BackupsManager
+  | Branding
   | ComplianceReports
+  | DeployModeResolver
+  | Domains
   | IpAllowlistPolicy
   | MaskingPolicy
   | ModelRouter
+  | ProactiveGate
   | ResidencyResolver
   | SCIMProvenance
   | SSOPolicy
@@ -77,4 +93,8 @@ export const EELayer: Layer.Layer<
   IpAllowlistPolicyLive,
   SSOPolicyLive,
   SCIMProvenanceLive,
+  BrandingLive,
+  DomainsLive,
+  ProactiveGateLive,
+  DeployModeResolverLive,
 );

--- a/ee/src/platform/domains.ts
+++ b/ee/src/platform/domains.ts
@@ -18,7 +18,7 @@
  * - RAILWAY_WEB_SERVICE_ID — Railway service ID for the web service
  */
 
-import { Data, Effect } from "effect";
+import { Effect, Layer } from "effect";
 import { generateVerificationToken, verifyDnsTxt } from "../lib/domain-verification";
 import { requireInternalDBEffect } from "../lib/db-guard";
 import {
@@ -26,6 +26,14 @@ import {
   internalQuery,
 } from "@atlas/api/lib/db/internal";
 import { createLogger } from "@atlas/api/lib/logger";
+import {
+  Domains,
+  type DomainsShape,
+} from "@atlas/api/lib/effect/services";
+import {
+  DomainError,
+  type DomainErrorCode,
+} from "@atlas/api/lib/platform/domains-errors";
 import type { CustomDomain, CertificateStatus, DomainVerificationStatus } from "@useatlas/types";
 import { DOMAIN_STATUSES, CERTIFICATE_STATUSES, DOMAIN_VERIFICATION_STATUSES } from "@useatlas/types";
 
@@ -33,19 +41,13 @@ const log = createLogger("ee:domains");
 
 // ── Typed errors ────────────────────────────────────────────────────
 
-export type DomainErrorCode =
-  | "no_internal_db"
-  | "invalid_domain"
-  | "duplicate_domain"
-  | "domain_not_found"
-  | "railway_error"
-  | "railway_not_configured"
-  | "data_integrity";
-
-export class DomainError extends Data.TaggedError("DomainError")<{
-  message: string;
-  code: DomainErrorCode;
-}> {}
+/**
+ * `DomainError` lives in `@atlas/api/lib/platform/domains-errors`
+ * post-#2572 so the `Domains` Tag can type its failure channel without
+ * core importing from `@atlas/ee`. Re-exported here for back-compat —
+ * same `_tag` + payload + `instanceof` semantics.
+ */
+export { DomainError, type DomainErrorCode };
 
 // ── Helpers ─────────────────────────────────────────────────────────
 
@@ -726,3 +728,31 @@ export const resolveWorkspaceByHost = (hostname: string): Effect.Effect<string |
 export function _resetHostCache(): void {
   hostCache.clear();
 }
+
+// ── Tag wiring (#2572 — slice 10/11 of #2017) ────────────────────────
+//
+// Bridges this module's functions into the `Domains` Tag so core call
+// sites (`api/routes/admin-domains.ts` via `shared-domains.ts`) can
+// `yield* Domains` instead of dynamic-importing this module.
+// Aggregated into `ee/src/layers.ts:EELayer`; the no-op default in
+// `lib/effect/services.ts:NoopDomainsLayer` covers self-hosted (reads
+// return empty / fail-closed, writes fail with EnterpriseError).
+
+export const makeDomainsLive = (): DomainsShape => ({
+  available: true,
+  registerDomain,
+  verifyDomain,
+  verifyDomainDnsTxt,
+  listDomains,
+  listAllDomains,
+  deleteDomain,
+  checkDomainAvailability,
+  hasVerifiedCustomDomain,
+  resolveWorkspaceByHost,
+  redactDomain,
+});
+
+export const DomainsLive: Layer.Layer<Domains> = Layer.sync(
+  Domains,
+  makeDomainsLive,
+);

--- a/ee/src/proactive-gate.ts
+++ b/ee/src/proactive-gate.ts
@@ -1,0 +1,42 @@
+/**
+ * Proactive-chat enterprise gate — slice 10/11 of #2017 (#2572).
+ *
+ * Replaces the four `requireEnterpriseEffect("proactive-chat")` calls in
+ * `packages/api/src/api/routes/admin-proactive*.ts`. EE always reports
+ * `enabled: true` from the perspective of the gate (the route's caller
+ * still has to be authorized to reach the admin router); the no-op
+ * default in `lib/effect/services.ts:NoopProactiveGateLayer` fails with
+ * `EnterpriseError` so non-enterprise tenants see 403
+ * `enterprise_required` and route through `EnterpriseUpsell` /
+ * `<FeatureGate feature="Proactive Chat">`.
+ *
+ * `requireEnabled` re-reads `isEnterpriseEnabled()` on every call so a
+ * runtime flip of `ATLAS_ENTERPRISE_ENABLED` propagates without
+ * restart — same semantics as the original
+ * `requireEnterpriseEffect("proactive-chat")` it replaces.
+ */
+
+import { Effect, Layer } from "effect";
+import { isEnterpriseEnabled, EnterpriseError } from "./index";
+import {
+  ProactiveGate,
+  type ProactiveGateShape,
+} from "@atlas/api/lib/effect/services";
+
+export const makeProactiveGateLive = (): ProactiveGateShape => ({
+  enabled: true,
+  requireEnabled: () =>
+    isEnterpriseEnabled()
+      ? Effect.void
+      : Effect.fail(
+          new EnterpriseError(
+            "Enterprise features (proactive-chat) are not enabled. " +
+              "Set ATLAS_ENTERPRISE_ENABLED=true or configure enterprise.enabled in atlas.config.ts.",
+          ),
+        ),
+});
+
+export const ProactiveGateLive: Layer.Layer<ProactiveGate> = Layer.sync(
+  ProactiveGate,
+  makeProactiveGateLive,
+);

--- a/packages/api/src/api/__tests__/admin-branding.test.ts
+++ b/packages/api/src/api/__tests__/admin-branding.test.ts
@@ -51,30 +51,57 @@ mock.module("@atlas/api/lib/db/internal", () => ({
 }));
 
 // --- EE branding mock ---
+//
+// Post-#2572 (slice 10/11) `admin-branding.ts` yields the `Branding` Tag.
+// The EE-side `Branding` Live binding lives in `ee/src/branding/white-label.ts`
+// and is composed into `EELayer` via `ee/src/layers.ts`. Tests stub
+// `@atlas/ee/layers` directly with a Tag-bound test layer (same pattern
+// slice 7 introduced for `AuditRetention`).
 
 let mockBranding: Record<string, unknown> | null = null;
 let mockSetResult: Record<string, unknown> | null = null;
 let mockDeleteResult = false;
 let mockEeError: Error | null = null;
 
-const { BrandingError: RealBrandingError } = await import("@atlas/ee/branding/white-label");
-const { EnterpriseError } = await import("@atlas/ee/index");
+process.env.ATLAS_ENTERPRISE_ENABLED = "true";
 
-mock.module("@atlas/ee/branding/white-label", () => ({
-  getWorkspaceBranding: () => {
-    if (mockEeError) return Effect.fail(mockEeError);
-    return Effect.succeed(mockBranding);
-  },
-  setWorkspaceBranding: () => {
-    if (mockEeError) return Effect.fail(mockEeError);
-    return Effect.succeed(mockSetResult);
-  },
-  deleteWorkspaceBranding: () => {
-    if (mockEeError) return Effect.fail(mockEeError);
-    return Effect.succeed(mockDeleteResult);
-  },
+const { BrandingError: RealBrandingError } = await import(
+  "@atlas/api/lib/branding/branding-errors"
+);
+const { EnterpriseError } = await import("@atlas/api/lib/effect/errors");
+
+mock.module("@atlas/api/lib/branding/branding-errors", () => ({
   BrandingError: RealBrandingError,
 }));
+
+mock.module("@atlas/ee/layers", () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { Layer, Effect: E } = require("effect") as typeof import("effect");
+  return {
+    EELayer: Layer.unwrapEffect(
+      E.sync(() => {
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const services = require("@atlas/api/lib/effect/services") as typeof import("@atlas/api/lib/effect/services");
+        return Layer.succeed(services.Branding, {
+          available: true,
+          getWorkspaceBranding: () => {
+            if (mockEeError) return Effect.fail(mockEeError);
+            return Effect.succeed(mockBranding);
+          },
+          getWorkspaceBrandingPublic: () => Effect.succeed(null),
+          setWorkspaceBranding: () => {
+            if (mockEeError) return Effect.fail(mockEeError);
+            return Effect.succeed(mockSetResult);
+          },
+          deleteWorkspaceBranding: () => {
+            if (mockEeError) return Effect.fail(mockEeError);
+            return Effect.succeed(mockDeleteResult);
+          },
+        } as never);
+      }),
+    ),
+  };
+});
 
 mock.module("@atlas/api/lib/logger", () => ({
   createLogger: () => ({ info: () => {}, warn: () => {}, error: () => {}, debug: () => {} }),

--- a/packages/api/src/api/__tests__/admin-domains.test.ts
+++ b/packages/api/src/api/__tests__/admin-domains.test.ts
@@ -79,26 +79,60 @@ mock.module("@atlas/api/lib/audit", () => ({
   causeToError: () => undefined,
 }));
 
-// --- EE domains mock: loadDomains returns null to simulate EE-off build ---
+// --- EE domains mock: `Domains` Tag returns `available: false` to simulate
+// EE-off build ---
 //
-// The admin-domains.ts router calls `loadDomains()` from shared-domains.ts,
-// which dynamic-imports "@atlas/ee/platform/domains" and catches
-// MODULE_NOT_FOUND to return null. Mocking shared-domains lets us control
-// that null branch directly without having to forge a MODULE_NOT_FOUND
-// from the EE import.
+// Post-#2572 (slice 10/11) `admin-domains.ts` yields the `Domains` Tag
+// instead of calling `loadDomains()`. Tests flip `available: false` to
+// reproduce the EE-disabled path; `available: true` with stubbed methods
+// drives the audit-emission tests. Same pattern slice 7 introduced for
+// `AuditRetention`.
 
-const mockLoadDomains: Mock<() => Promise<unknown>> = mock(() => Promise.resolve(null));
+process.env.ATLAS_ENTERPRISE_ENABLED = "true";
 
-// Preserve the real helper exports — customDomainError is consumed by
-// runEffect's error mapping. Re-export with the mocked loadDomains.
-const realShared = await import("../routes/shared-domains");
+type DomainsStub = {
+  available: boolean;
+  listDomains: (orgId: string) => unknown;
+  registerDomain: (orgId: string, domain: string) => unknown;
+  verifyDomain: (id: string) => unknown;
+  verifyDomainDnsTxt: (id: string) => unknown;
+  deleteDomain: (id: string) => unknown;
+  checkDomainAvailability: (domain: string, workspaceId: string) => unknown;
+  listAllDomains: () => unknown;
+  hasVerifiedCustomDomain: () => unknown;
+  resolveWorkspaceByHost: () => unknown;
+  redactDomain: (d: Record<string, unknown>) => Record<string, unknown>;
+};
 
-mock.module("../routes/shared-domains", () => ({
-  CustomDomainSchema: realShared.CustomDomainSchema,
-  DomainCheckResponseSchema: realShared.DomainCheckResponseSchema,
-  customDomainError: realShared.customDomainError,
-  loadDomains: mockLoadDomains,
-}));
+let domainsStub: DomainsStub = {
+  available: false,
+  listDomains: () => Effect.succeed([]),
+  registerDomain: () => Effect.die("not stubbed"),
+  verifyDomain: () => Effect.die("not stubbed"),
+  verifyDomainDnsTxt: () => Effect.die("not stubbed"),
+  deleteDomain: () => Effect.die("not stubbed"),
+  checkDomainAvailability: () => Effect.die("not stubbed"),
+  listAllDomains: () => Effect.die("not stubbed"),
+  hasVerifiedCustomDomain: () => Effect.die("not stubbed"),
+  resolveWorkspaceByHost: () => Effect.die("not stubbed"),
+  redactDomain: (d) => d,
+};
+
+mock.module("@atlas/ee/layers", () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { Layer, Effect: E } = require("effect") as typeof import("effect");
+  return {
+    EELayer: Layer.unwrapEffect(
+      E.sync(() => {
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const services = require("@atlas/api/lib/effect/services") as typeof import("@atlas/api/lib/effect/services");
+        return Layer.succeed(services.Domains, new Proxy(domainsStub, {
+          get: (_t, prop) => (domainsStub as unknown as Record<string, unknown>)[prop as string],
+        }) as never);
+      }),
+    ),
+  };
+});
 
 // --- Import sub-router AFTER mocks ---
 
@@ -107,7 +141,19 @@ const { adminDomains } = await import("../routes/admin-domains");
 // --- Helpers ---
 
 function resetMocks() {
-  mockLoadDomains.mockImplementation(() => Promise.resolve(null));
+  domainsStub = {
+    available: false,
+    listDomains: () => Effect.succeed([]),
+    registerDomain: () => Effect.die("not stubbed"),
+    verifyDomain: () => Effect.die("not stubbed"),
+    verifyDomainDnsTxt: () => Effect.die("not stubbed"),
+    deleteDomain: () => Effect.die("not stubbed"),
+    checkDomainAvailability: () => Effect.die("not stubbed"),
+    listAllDomains: () => Effect.die("not stubbed"),
+    hasVerifiedCustomDomain: () => Effect.die("not stubbed"),
+    resolveWorkspaceByHost: () => Effect.die("not stubbed"),
+    redactDomain: (d) => d,
+  };
   mockLogAdminAction.mockClear();
   mockAuthenticateRequest.mockImplementation(() =>
     Promise.resolve({
@@ -118,9 +164,10 @@ function resetMocks() {
   );
 }
 
-// --- EE domains stub: load a fake module so POST / DELETE / verify routes
-// reach the audit emission path. The stub returns Effect.succeed(...) for
-// every method so the Effect.gen handlers run to completion.
+// --- EE domains stub: flip `Domains.available = true` and stub the
+// methods exercised by the audit-emission tests. The Tag-backed stub
+// returns Effect.succeed(...) for every method so the Effect.gen
+// handlers run to completion.
 
 function makeDomainRecord(overrides: Record<string, unknown> = {}): Record<string, unknown> {
   return {
@@ -143,28 +190,30 @@ function enableEe(
     checkDomainAvailability?: Record<string, unknown>;
   } = {},
 ): void {
-  mockLoadDomains.mockImplementation(() =>
-    Promise.resolve({
-      listDomains: (_orgId: string) => Effect.succeed(opts.listDomains ?? []),
-      registerDomain: (_orgId: string, _domain: string) =>
-        opts.registerDomain instanceof Error
-          ? Effect.fail(opts.registerDomain)
-          : Effect.succeed(opts.registerDomain ?? makeDomainRecord()),
-      verifyDomain: (_id: string) =>
-        opts.verifyDomain instanceof Error
-          ? Effect.fail(opts.verifyDomain)
-          : Effect.succeed(opts.verifyDomain ?? makeDomainRecord({ status: "verified" })),
-      verifyDomainDnsTxt: (_id: string) =>
-        opts.verifyDomainDnsTxt instanceof Error
-          ? Effect.fail(opts.verifyDomainDnsTxt)
-          : Effect.succeed(opts.verifyDomainDnsTxt ?? makeDomainRecord({ status: "dns_verified" })),
-      deleteDomain: (_id: string) =>
-        opts.deleteDomain instanceof Error ? Effect.fail(opts.deleteDomain) : Effect.succeed(true),
-      checkDomainAvailability: (_domain: string, _orgId: string) =>
-        Effect.succeed(opts.checkDomainAvailability ?? { available: true }),
-      redactDomain: (d: Record<string, unknown>) => d,
-    }),
-  );
+  domainsStub = {
+    available: true,
+    listDomains: (_orgId: string) => Effect.succeed(opts.listDomains ?? []),
+    registerDomain: (_orgId: string, _domain: string) =>
+      opts.registerDomain instanceof Error
+        ? Effect.fail(opts.registerDomain)
+        : Effect.succeed(opts.registerDomain ?? makeDomainRecord()),
+    verifyDomain: (_id: string) =>
+      opts.verifyDomain instanceof Error
+        ? Effect.fail(opts.verifyDomain)
+        : Effect.succeed(opts.verifyDomain ?? makeDomainRecord({ status: "verified" })),
+    verifyDomainDnsTxt: (_id: string) =>
+      opts.verifyDomainDnsTxt instanceof Error
+        ? Effect.fail(opts.verifyDomainDnsTxt)
+        : Effect.succeed(opts.verifyDomainDnsTxt ?? makeDomainRecord({ status: "dns_verified" })),
+    deleteDomain: (_id: string) =>
+      opts.deleteDomain instanceof Error ? Effect.fail(opts.deleteDomain) : Effect.succeed(true),
+    checkDomainAvailability: (_domain: string, _orgId: string) =>
+      Effect.succeed(opts.checkDomainAvailability ?? { available: true }),
+    listAllDomains: () => Effect.succeed([]),
+    hasVerifiedCustomDomain: () => Effect.succeed(false),
+    resolveWorkspaceByHost: () => Effect.succeed(null),
+    redactDomain: (d: Record<string, unknown>) => d,
+  };
 }
 
 async function request(urlPath: string, method: string, body?: unknown) {

--- a/packages/api/src/api/__tests__/admin-proactive-analytics.test.ts
+++ b/packages/api/src/api/__tests__/admin-proactive-analytics.test.ts
@@ -137,26 +137,42 @@ mock.module("@atlas/api/lib/proactive/quota", () => ({
 }));
 
 // ---------------------------------------------------------------------------
-// Enterprise gate — default on so the route reaches the meter
+// Enterprise gate — post-#2572 (slice 10/11) the route yields the
+// `ProactiveGate` Tag from EELayer. Default-on so the route reaches the
+// meter; flip `enterpriseEnabled` to drive the 403 path.
 // ---------------------------------------------------------------------------
 
 let enterpriseEnabled = true;
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-const realEE = require("@atlas/ee/index") as typeof import("@atlas/ee/index");
+process.env.ATLAS_ENTERPRISE_ENABLED = "true";
+
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const effectMod = require("effect") as typeof import("effect");
 
-mock.module("@atlas/ee/index", () => ({
-  ...realEE,
-  isEnterpriseEnabled: () => enterpriseEnabled,
-  requireEnterpriseEffect: (feature?: string) => {
-    if (enterpriseEnabled) return effectMod.Effect.void;
-    return effectMod.Effect.fail(
-      new realEE.EnterpriseError(`feature ${feature ?? ""} not enabled`),
-    );
-  },
-}));
+mock.module("@atlas/ee/layers", () => {
+  const { Layer, Effect: E } = effectMod;
+  return {
+    EELayer: Layer.unwrapEffect(
+      E.sync(() => {
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const services = require("@atlas/api/lib/effect/services") as typeof import("@atlas/api/lib/effect/services");
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const { EnterpriseError } = require("@atlas/api/lib/effect/errors") as typeof import("@atlas/api/lib/effect/errors");
+        return Layer.succeed(services.ProactiveGate, {
+          enabled: true,
+          requireEnabled: () =>
+            enterpriseEnabled
+              ? effectMod.Effect.void
+              : effectMod.Effect.fail(
+                  new EnterpriseError(
+                    "Enterprise features (proactive-chat) are not enabled.",
+                  ),
+                ),
+        });
+      }),
+    ),
+  };
+});
 
 // ---------------------------------------------------------------------------
 // Standard API mocks

--- a/packages/api/src/api/__tests__/admin-proactive-public-dataset.test.ts
+++ b/packages/api/src/api/__tests__/admin-proactive-public-dataset.test.ts
@@ -52,26 +52,41 @@ mock.module("@atlas/api/lib/proactive/public-dataset", () => ({
 }));
 
 // ---------------------------------------------------------------------------
-// Enterprise gate — default ON
+// Enterprise gate — post-#2572 (slice 10/11) the route yields the
+// `ProactiveGate` Tag from EELayer. Default-on; flip to drive the 403 path.
 // ---------------------------------------------------------------------------
 
 let enterpriseEnabled = true;
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-const realEE = require("@atlas/ee/index") as typeof import("@atlas/ee/index");
+process.env.ATLAS_ENTERPRISE_ENABLED = "true";
+
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const effectMod = require("effect") as typeof import("effect");
 
-mock.module("@atlas/ee/index", () => ({
-  ...realEE,
-  isEnterpriseEnabled: () => enterpriseEnabled,
-  requireEnterpriseEffect: (feature?: string) => {
-    if (enterpriseEnabled) return effectMod.Effect.void;
-    return effectMod.Effect.fail(
-      new realEE.EnterpriseError(`feature ${feature ?? ""} not enabled`),
-    );
-  },
-}));
+mock.module("@atlas/ee/layers", () => {
+  const { Layer, Effect: E } = effectMod;
+  return {
+    EELayer: Layer.unwrapEffect(
+      E.sync(() => {
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const services = require("@atlas/api/lib/effect/services") as typeof import("@atlas/api/lib/effect/services");
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const { EnterpriseError } = require("@atlas/api/lib/effect/errors") as typeof import("@atlas/api/lib/effect/errors");
+        return Layer.succeed(services.ProactiveGate, {
+          enabled: true,
+          requireEnabled: () =>
+            enterpriseEnabled
+              ? effectMod.Effect.void
+              : effectMod.Effect.fail(
+                  new EnterpriseError(
+                    "Enterprise features (proactive-chat) are not enabled.",
+                  ),
+                ),
+        });
+      }),
+    ),
+  };
+});
 
 // ---------------------------------------------------------------------------
 // Standard API mocks

--- a/packages/api/src/api/__tests__/public-branding.test.ts
+++ b/packages/api/src/api/__tests__/public-branding.test.ts
@@ -29,12 +29,33 @@ mock.module("@atlas/api/lib/auth/middleware", () => ({
 }));
 
 // --- EE branding mock ---
+//
+// Post-#2572 (slice 10/11) `public-branding.ts` yields the `Branding`
+// Tag. Stub `@atlas/ee/layers` directly with a Tag-bound test layer.
 
 let mockPublicBranding: Record<string, unknown> | null = null;
 
-mock.module("@atlas/ee/branding/white-label", () => ({
-  getWorkspaceBrandingPublic: () => Effect.succeed(mockPublicBranding),
-}));
+process.env.ATLAS_ENTERPRISE_ENABLED = "true";
+
+mock.module("@atlas/ee/layers", () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { Layer, Effect: E } = require("effect") as typeof import("effect");
+  return {
+    EELayer: Layer.unwrapEffect(
+      E.sync(() => {
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const services = require("@atlas/api/lib/effect/services") as typeof import("@atlas/api/lib/effect/services");
+        return Layer.succeed(services.Branding, {
+          available: true,
+          getWorkspaceBranding: () => Effect.succeed(null),
+          getWorkspaceBrandingPublic: () => Effect.succeed(mockPublicBranding),
+          setWorkspaceBranding: () => Effect.die("not stubbed"),
+          deleteWorkspaceBranding: () => Effect.die("not stubbed"),
+        } as never);
+      }),
+    ),
+  };
+});
 
 mock.module("@atlas/api/lib/logger", () => ({
   createLogger: () => ({ info: () => {}, warn: () => {}, error: () => {}, debug: () => {} }),

--- a/packages/api/src/api/routes/admin-branding.ts
+++ b/packages/api/src/api/routes/admin-branding.ts
@@ -9,14 +9,9 @@ import { Effect } from "effect";
 import { createRoute, z } from "@hono/zod-openapi";
 import type { Context } from "hono";
 import { runEffect, domainError } from "@atlas/api/lib/effect/hono";
-import { AuthContext } from "@atlas/api/lib/effect/services";
+import { AuthContext, Branding } from "@atlas/api/lib/effect/services";
 import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
-import {
-  getWorkspaceBranding,
-  setWorkspaceBranding,
-  deleteWorkspaceBranding,
-  BrandingError,
-} from "@atlas/ee/branding/white-label";
+import { BrandingError } from "@atlas/api/lib/branding/branding-errors";
 import { WorkspaceBrandingSchema as BrandingSchema } from "@useatlas/schemas";
 import { ErrorSchema, AuthErrorSchema } from "./shared-schemas";
 import { createAdminRouter, requireOrgContext, requirePermission } from "./admin-router";
@@ -219,9 +214,10 @@ adminBranding.use(requirePermission("admin:settings"));
 adminBranding.openapi(getBrandingRoute, async (c) => {
   return runEffect(c, Effect.gen(function* () {
     const { orgId } = yield* AuthContext;
+    const branding = yield* Branding;
 
-    const branding = yield* getWorkspaceBranding(orgId!);
-    return c.json({ branding }, 200);
+    const result = yield* branding.getWorkspaceBranding(orgId!);
+    return c.json({ branding: result }, 200);
   }), { label: "get workspace branding", domainErrors: [brandingDomainError] });
 });
 
@@ -232,8 +228,9 @@ adminBranding.openapi(setBrandingRoute, async (c) => {
 
   return runEffect(c, Effect.gen(function* () {
     const { orgId } = yield* AuthContext;
+    const brandingSvc = yield* Branding;
 
-    const branding = yield* setWorkspaceBranding(orgId!, {
+    const branding = yield* brandingSvc.setWorkspaceBranding(orgId!, {
       logoUrl: body.logoUrl,
       logoText: body.logoText,
       primaryColor: body.primaryColor,
@@ -268,8 +265,9 @@ adminBranding.openapi(deleteBrandingRoute, async (c) => {
 
   return runEffect(c, Effect.gen(function* () {
     const { orgId } = yield* AuthContext;
+    const brandingSvc = yield* Branding;
 
-    const deleted = yield* deleteWorkspaceBranding(orgId!);
+    const deleted = yield* brandingSvc.deleteWorkspaceBranding(orgId!);
     if (!deleted) {
       // No-op deletes don't audit — nothing was reset, so emitting a row
       // would pollute forensic queries that count actual branding changes.

--- a/packages/api/src/api/routes/admin-domains.ts
+++ b/packages/api/src/api/routes/admin-domains.ts
@@ -21,16 +21,15 @@ import type { Context } from "hono";
 import { createLogger } from "@atlas/api/lib/logger";
 import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
 import { runEffect } from "@atlas/api/lib/effect/hono";
-import { AuthContext, RequestContext } from "@atlas/api/lib/effect/services";
+import { AuthContext, Domains, RequestContext } from "@atlas/api/lib/effect/services";
+import { EnterpriseError } from "@atlas/api/lib/effect/errors";
 import { hasInternalDB, getWorkspaceDetails } from "@atlas/api/lib/db/internal";
-import { EnterpriseError } from "@atlas/ee/index";
 import { ErrorSchema, AuthErrorSchema } from "./shared-schemas";
 import { createAdminRouter, requireOrgContext, requirePermission } from "./admin-router";
 import {
   CustomDomainSchema,
   DomainCheckResponseSchema,
   customDomainError,
-  loadDomains,
 } from "./shared-domains";
 
 function clientIP(c: Context): string | null {
@@ -274,13 +273,13 @@ adminDomains.openapi(getDomainRoute, async (c) => {
   return runEffect(c, Effect.gen(function* () {
     const { orgId } = yield* AuthContext;
     const { requestId } = yield* RequestContext;
+    const mod = yield* Domains;
 
     if (!orgId) {
       return c.json({ error: "bad_request", message: "No active organization.", requestId }, 400);
     }
 
-    const mod = yield* Effect.promise(() => loadDomains());
-    if (!mod) {
+    if (!mod.available) {
       return c.json({ error: "not_available", message: "Custom domains require enterprise features to be enabled.", requestId }, 404);
     }
 
@@ -294,13 +293,13 @@ adminDomains.openapi(addDomainRoute, async (c) => {
   return runEffect(c, Effect.gen(function* () {
     const { orgId } = yield* AuthContext;
     const { requestId } = yield* RequestContext;
+    const mod = yield* Domains;
 
     if (!orgId) {
       return c.json({ error: "bad_request", message: "No active organization.", requestId }, 400);
     }
 
-    const mod = yield* Effect.promise(() => loadDomains());
-    if (!mod) {
+    if (!mod.available) {
       return yield* Effect.fail(new EnterpriseError(EE_REQUIRED_MESSAGE));
     }
 
@@ -344,13 +343,13 @@ adminDomains.openapi(verifyDomainRoute, async (c) => {
   return runEffect(c, Effect.gen(function* () {
     const { orgId } = yield* AuthContext;
     const { requestId } = yield* RequestContext;
+    const mod = yield* Domains;
 
     if (!orgId) {
       return c.json({ error: "bad_request", message: "No active organization.", requestId }, 400);
     }
 
-    const mod = yield* Effect.promise(() => loadDomains());
-    if (!mod) {
+    if (!mod.available) {
       return yield* Effect.fail(new EnterpriseError(EE_REQUIRED_MESSAGE));
     }
 
@@ -377,13 +376,13 @@ adminDomains.openapi(verifyDnsTxtRoute, async (c) => {
   return runEffect(c, Effect.gen(function* () {
     const { orgId } = yield* AuthContext;
     const { requestId } = yield* RequestContext;
+    const mod = yield* Domains;
 
     if (!orgId) {
       return c.json({ error: "bad_request", message: "No active organization.", requestId }, 400);
     }
 
-    const mod = yield* Effect.promise(() => loadDomains());
-    if (!mod) {
+    if (!mod.available) {
       return yield* Effect.fail(new EnterpriseError(EE_REQUIRED_MESSAGE));
     }
 
@@ -409,13 +408,13 @@ adminDomains.openapi(domainCheckRoute, async (c) => {
   return runEffect(c, Effect.gen(function* () {
     const { orgId } = yield* AuthContext;
     const { requestId } = yield* RequestContext;
+    const mod = yield* Domains;
 
     if (!orgId) {
       return c.json({ error: "bad_request", message: "No active organization.", requestId }, 400);
     }
 
-    const mod = yield* Effect.promise(() => loadDomains());
-    if (!mod) {
+    if (!mod.available) {
       return c.json({ error: "not_available", message: "Custom domains require enterprise features to be enabled.", requestId }, 404);
     }
 
@@ -434,13 +433,13 @@ adminDomains.openapi(removeDomainRoute, async (c) => {
   return runEffect(c, Effect.gen(function* () {
     const { orgId } = yield* AuthContext;
     const { requestId } = yield* RequestContext;
+    const mod = yield* Domains;
 
     if (!orgId) {
       return c.json({ error: "bad_request", message: "No active organization.", requestId }, 400);
     }
 
-    const mod = yield* Effect.promise(() => loadDomains());
-    if (!mod) {
+    if (!mod.available) {
       return yield* Effect.fail(new EnterpriseError(EE_REQUIRED_MESSAGE));
     }
 

--- a/packages/api/src/api/routes/admin-proactive-analytics.ts
+++ b/packages/api/src/api/routes/admin-proactive-analytics.ts
@@ -16,8 +16,11 @@
 import { Effect } from "effect";
 import { createLogger } from "@atlas/api/lib/logger";
 import { runEffect } from "@atlas/api/lib/effect/hono";
-import { AuthContext, RequestContext } from "@atlas/api/lib/effect/services";
-import { requireEnterpriseEffect } from "@atlas/ee/index";
+import {
+  AuthContext,
+  ProactiveGate,
+  RequestContext,
+} from "@atlas/api/lib/effect/services";
 import { AnswerMeter, AnswerMeterLive } from "@atlas/api/lib/proactive/answer-meter";
 import { getWorkspaceQuotaStatus } from "@atlas/api/lib/proactive/quota";
 import { createAdminRouter, requireOrgContext, requirePermission } from "./admin-router";
@@ -85,7 +88,8 @@ adminProactiveAnalytics.get("/", async (c) => {
   return runEffect(
     c,
     Effect.gen(function* () {
-      yield* requireEnterpriseEffect("proactive-chat");
+      const proactive = yield* ProactiveGate;
+      yield* proactive.requireEnabled();
 
       const { orgId } = yield* AuthContext;
       const { requestId } = yield* RequestContext;

--- a/packages/api/src/api/routes/admin-proactive-pauses.ts
+++ b/packages/api/src/api/routes/admin-proactive-pauses.ts
@@ -11,9 +11,11 @@
  *     the literal `unsubscribe`.
  *   - `admin-channel`: persisted by the channel-config surface (#2294).
  *
- * Enterprise-gated: every mutation requires
- * `requireEnterpriseEffect("proactive-chat")`. Self-hosted callers
- * without enterprise see 403 with a typed `EnterpriseError`.
+ * Enterprise-gated: every mutation yields `ProactiveGate` from
+ * `@atlas/api/lib/effect/services` and calls `.requireEnabled()`.
+ * Self-hosted callers without enterprise see 403 with a typed
+ * `EnterpriseError` (the no-op `ProactiveGate` default fails closed —
+ * EE overlays `Effect.void` when `ATLAS_ENTERPRISE_ENABLED=true`).
  */
 
 import { createRoute, z } from "@hono/zod-openapi";
@@ -21,9 +23,13 @@ import { Effect } from "effect";
 import { createLogger } from "@atlas/api/lib/logger";
 import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
 import { runEffect } from "@atlas/api/lib/effect/hono";
-import { AuthContext, RequestContext } from "@atlas/api/lib/effect/services";
+import {
+  AuthContext,
+  ProactiveGate,
+  RequestContext,
+} from "@atlas/api/lib/effect/services";
+import { EnterpriseError } from "@atlas/api/lib/effect/errors";
 import { hasInternalDB } from "@atlas/api/lib/db/internal";
-import { EnterpriseError, requireEnterpriseEffect } from "@atlas/ee/index";
 import {
   expirePauses,
   isPaused,
@@ -156,7 +162,8 @@ adminProactivePauses.openapi(getPauseStatusRoute, async (c) =>
       const { requestId } = yield* RequestContext;
       const { orgId } = yield* AuthContext;
 
-      yield* requireEnterpriseEffect("proactive-chat");
+      const proactive = yield* ProactiveGate;
+      yield* proactive.requireEnabled();
 
       if (!orgId) {
         return c.json(
@@ -206,7 +213,8 @@ adminProactivePauses.openapi(enableKillSwitchRoute, async (c) =>
       const { requestId } = yield* RequestContext;
       const { orgId, user } = yield* AuthContext;
 
-      yield* requireEnterpriseEffect("proactive-chat");
+      const proactive = yield* ProactiveGate;
+      yield* proactive.requireEnabled();
 
       if (!orgId) {
         return c.json(
@@ -275,7 +283,8 @@ adminProactivePauses.openapi(liftKillSwitchRoute, async (c) =>
       const { requestId } = yield* RequestContext;
       const { orgId, user } = yield* AuthContext;
 
-      yield* requireEnterpriseEffect("proactive-chat");
+      const proactive = yield* ProactiveGate;
+      yield* proactive.requireEnabled();
 
       if (!orgId) {
         return c.json(

--- a/packages/api/src/api/routes/admin-proactive-public-dataset.ts
+++ b/packages/api/src/api/routes/admin-proactive-public-dataset.ts
@@ -13,10 +13,9 @@
  *   - Discoverability: piggybacks on the answer meter via a new
  *     public_refused event type (see migration 0079).
  *
- * Every route gates via requireEnterpriseEffect("proactive-chat") so
+ * Every route yields `ProactiveGate.requireEnabled()` so
  * non-enterprise tenants see 403 enterprise_required rather than a
- * surface to twiddle. The route layer is the only place in this slice
- * that imports @atlas/ee; the lib/proactive/public-dataset.ts helpers
+ * surface to twiddle. The lib/proactive/public-dataset.ts helpers
  * stay enterprise-agnostic so tests can exercise the DB shape without
  * booting the gate.
  *
@@ -36,9 +35,12 @@ import { Effect } from "effect";
 import { createLogger } from "@atlas/api/lib/logger";
 import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
 import { runEffect } from "@atlas/api/lib/effect/hono";
-import { AuthContext, RequestContext } from "@atlas/api/lib/effect/services";
+import {
+  AuthContext,
+  ProactiveGate,
+  RequestContext,
+} from "@atlas/api/lib/effect/services";
 import { hasInternalDB } from "@atlas/api/lib/db/internal";
-import { requireEnterpriseEffect } from "@atlas/ee/index";
 import {
   addEntry,
   getAllowlist,
@@ -244,7 +246,8 @@ adminProactivePublicDataset.openapi(listEntriesRoute, async (c) =>
       const { requestId } = yield* RequestContext;
       const { orgId } = yield* AuthContext;
 
-      yield* requireEnterpriseEffect("proactive-chat");
+      const proactive = yield* ProactiveGate;
+      yield* proactive.requireEnabled();
 
       if (!orgId) {
         return c.json(
@@ -273,7 +276,8 @@ adminProactivePublicDataset.openapi(upsertEntryRoute, async (c) =>
       const { requestId } = yield* RequestContext;
       const { orgId, user } = yield* AuthContext;
 
-      yield* requireEnterpriseEffect("proactive-chat");
+      const proactive = yield* ProactiveGate;
+      yield* proactive.requireEnabled();
 
       if (!orgId) {
         return c.json(
@@ -335,7 +339,8 @@ adminProactivePublicDataset.openapi(deleteEntryRoute, async (c) =>
       const { requestId } = yield* RequestContext;
       const { orgId, user } = yield* AuthContext;
 
-      yield* requireEnterpriseEffect("proactive-chat");
+      const proactive = yield* ProactiveGate;
+      yield* proactive.requireEnabled();
 
       if (!orgId) {
         return c.json(
@@ -391,7 +396,8 @@ adminProactivePublicDataset.openapi(refusedRollupRoute, async (c) =>
       const { requestId } = yield* RequestContext;
       const { orgId } = yield* AuthContext;
 
-      yield* requireEnterpriseEffect("proactive-chat");
+      const proactive = yield* ProactiveGate;
+      yield* proactive.requireEnabled();
 
       if (!orgId) {
         return c.json(

--- a/packages/api/src/api/routes/admin-proactive.ts
+++ b/packages/api/src/api/routes/admin-proactive.ts
@@ -34,11 +34,12 @@ import { createRoute, z } from "@hono/zod-openapi";
 import { createLogger } from "@atlas/api/lib/logger";
 import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
 import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
+import { getConfig } from "@atlas/api/lib/config";
 import { internalQuery } from "@atlas/api/lib/db/internal";
 import { runHandler } from "@atlas/api/lib/effect/hono";
+import { EnterpriseError } from "@atlas/api/lib/effect/errors";
 import { announceActivation } from "@atlas/api/lib/proactive/announcement-coordinator";
 import { getChatAnnouncer } from "@atlas/api/lib/proactive/announcer-registry";
-import { isEnterpriseEnabled, EnterpriseError } from "@atlas/ee/index";
 import { ErrorSchema, AuthErrorSchema } from "./shared-schemas";
 import { createAdminRouter, requireOrgContext, requirePermission } from "./admin-router";
 
@@ -309,20 +310,35 @@ adminProactive.use(requirePermission("admin:settings"));
 /**
  * Enterprise gate. Sync throw inside the `runHandler` body so a
  * `runHandler` → `Effect.tryPromise` → defect-classification path lands
- * on `EnterpriseError` directly (its `name === "EnterpriseError"` survives
- * the `Error` re-wrap) and maps to 403 `enterprise_required` via
- * `classifyError`. The flag is re-read per call so a runtime flip
+ * on `EnterpriseError` directly (its `name === "EnterpriseError"`
+ * survives the `Error` re-wrap) and maps to 403 `enterprise_required`
+ * via `classifyError`. The flag is re-read per call so a runtime flip
  * propagates without restart.
  *
- * Inline `Effect.runPromise(requireEnterpriseEffect(...))` would reject
- * with a FiberFailure that loses the `name` identity, so `classifyError`
- * would treat it as an opaque 500 instead of the 403 the gate wants.
- * Pinning to the synchronous primitive avoids that lossy wrap.
+ * Post-#2572 (slice 10/11 of #2017) this reads the enterprise flag
+ * directly from `getConfig()` / `ATLAS_ENTERPRISE_ENABLED` rather than
+ * dynamic-importing `@atlas/ee/index`. The other three admin-proactive
+ * route files (analytics, pauses, public-dataset) yield the
+ * `ProactiveGate` Tag because they already use `runEffect` + Effect.gen;
+ * this file's `runHandler`-based handlers can't yield the Tag without a
+ * separate sync runtime (`ConditionalEELayer` is async due to the lazy
+ * EE-layer import), so we keep the equivalent sync check inline. The
+ * resulting `EnterpriseError` has identical `_tag` + payload to the
+ * one the Tag would produce.
  */
+function isEnterpriseEnabledSync(): boolean {
+  const config = getConfig();
+  if (config?.enterprise?.enabled !== undefined) {
+    return config.enterprise.enabled;
+  }
+  return process.env.ATLAS_ENTERPRISE_ENABLED === "true";
+}
+
 function gateEnterprise(): void {
-  if (!isEnterpriseEnabled()) {
+  if (!isEnterpriseEnabledSync()) {
     throw new EnterpriseError(
-      "Proactive chat requires enterprise features to be enabled.",
+      "Enterprise features (proactive-chat) are not enabled. " +
+        "Set ATLAS_ENTERPRISE_ENABLED=true or configure enterprise.enabled in atlas.config.ts.",
     );
   }
 }

--- a/packages/api/src/api/routes/platform-domains.ts
+++ b/packages/api/src/api/routes/platform-domains.ts
@@ -15,13 +15,12 @@ import { Effect } from "effect";
 import { createLogger } from "@atlas/api/lib/logger";
 import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
 import { runEffect } from "@atlas/api/lib/effect/hono";
-import { RequestContext } from "@atlas/api/lib/effect/services";
+import { Domains, RequestContext } from "@atlas/api/lib/effect/services";
 import { ErrorSchema, AuthErrorSchema } from "./shared-schemas";
 import { createPlatformRouter } from "./admin-router";
 import {
   CustomDomainSchema,
   customDomainError,
-  loadDomains,
 } from "./shared-domains";
 
 const log = createLogger("platform-domains");
@@ -144,9 +143,9 @@ const platformDomains = createPlatformRouter();
 platformDomains.openapi(listDomainsRoute, async (c) => {
   return runEffect(c, Effect.gen(function* () {
     const { requestId } = yield* RequestContext;
+    const mod = yield* Domains;
 
-    const mod = yield* Effect.promise(() => loadDomains());
-    if (!mod) {
+    if (!mod.available) {
       return c.json({ error: "not_available", message: "Custom domains require enterprise features to be enabled.", requestId }, 404);
     }
 
@@ -161,9 +160,9 @@ platformDomains.openapi(registerDomainRoute, async (c) => {
   return runEffect(c, Effect.gen(function* () {
     const { requestId } = yield* RequestContext;
     const body = c.req.valid("json");
+    const mod = yield* Domains;
 
-    const mod = yield* Effect.promise(() => loadDomains());
-    if (!mod) {
+    if (!mod.available) {
       return c.json({ error: "not_available", message: "Custom domains require enterprise features to be enabled.", requestId }, 404);
     }
 
@@ -189,9 +188,9 @@ platformDomains.openapi(verifyDomainRoute, async (c) => {
   return runEffect(c, Effect.gen(function* () {
     const { requestId } = yield* RequestContext;
     const domainId = c.req.param("id");
+    const mod = yield* Domains;
 
-    const mod = yield* Effect.promise(() => loadDomains());
-    if (!mod) {
+    if (!mod.available) {
       return c.json({ error: "not_available", message: "Custom domains require enterprise features to be enabled.", requestId }, 404);
     }
 
@@ -215,9 +214,9 @@ platformDomains.openapi(deleteDomainRoute, async (c) => {
   return runEffect(c, Effect.gen(function* () {
     const { requestId } = yield* RequestContext;
     const domainId = c.req.param("id");
+    const mod = yield* Domains;
 
-    const mod = yield* Effect.promise(() => loadDomains());
-    if (!mod) {
+    if (!mod.available) {
       return c.json({ error: "not_available", message: "Custom domains require enterprise features to be enabled.", requestId }, 404);
     }
 

--- a/packages/api/src/api/routes/public-branding.ts
+++ b/packages/api/src/api/routes/public-branding.ts
@@ -12,7 +12,7 @@ import { validationHook } from "./validation-hook";
 import { createLogger } from "@atlas/api/lib/logger";
 import { authenticateRequest } from "@atlas/api/lib/auth/middleware";
 import { Effect } from "effect";
-import { getWorkspaceBrandingPublic } from "@atlas/ee/branding/white-label";
+import { Branding } from "@atlas/api/lib/effect/services";
 import { runEffect } from "@atlas/api/lib/effect/hono";
 import { withRequestId, type AuthEnv } from "./middleware";
 import { ErrorSchema } from "./shared-schemas";
@@ -94,7 +94,8 @@ publicBranding.openapi(getBrandingRoute, async (c) => {
       return c.json({ branding: null }, 200);
     }
 
-    const branding = yield* getWorkspaceBrandingPublic(orgId);
+    const brandingSvc = yield* Branding;
+    const branding = yield* brandingSvc.getWorkspaceBrandingPublic(orgId);
     if (!branding) {
       return c.json({ branding: null }, 200);
     }

--- a/packages/api/src/api/routes/shared-domains.ts
+++ b/packages/api/src/api/routes/shared-domains.ts
@@ -1,21 +1,27 @@
 /**
- * Shared domain infrastructure — schemas, error mapping, and module loading
- * used by both admin-domains.ts (workspace) and platform-domains.ts (platform admin).
+ * Shared domain infrastructure — schemas + error mapping used by both
+ * admin-domains.ts (workspace) and platform-domains.ts (platform admin).
  * Infrastructure error sanitization happens in classifyError (hono.ts).
+ *
+ * Slice 10/11 of #2017 (#2572) inverted both routers to yield the
+ * `Domains` Tag (`@atlas/api/lib/effect/services`) instead of
+ * dynamic-importing `@atlas/ee/platform/domains`. The error class lives
+ * in core (`@atlas/api/lib/platform/domains-errors`) post-#2572 so the
+ * Tag can type its failure channel without core importing from
+ * `@atlas/ee`. `loadDomains` was removed in the same slice — callers
+ * now use `yield* Domains` and check `.available` to decide between the
+ * EE-enabled path and the 404 fallback.
  */
 
 import { z } from "@hono/zod-openapi";
-import { createLogger } from "@atlas/api/lib/logger";
 import { domainError } from "@atlas/api/lib/effect/hono";
-import { DomainError } from "@atlas/ee/platform/domains";
+import { DomainError } from "@atlas/api/lib/platform/domains-errors";
 
 // Re-export the shared wire shape so existing callers (admin-domains,
 // platform-domains) keep their `./shared-domains` import path. The single
 // source of truth lives in @useatlas/schemas — this module now owns only
-// the domain-error mapping and the EE module loader.
+// the domain-error mapping.
 export { CustomDomainSchema } from "@useatlas/schemas";
-
-const log = createLogger("domains-shared");
 
 // ---------------------------------------------------------------------------
 // Error mapping
@@ -35,29 +41,4 @@ export const customDomainError = domainError(DomainError, {
   railway_not_configured: 503,
   data_integrity: 500,
 });
-
-// ---------------------------------------------------------------------------
-// Module loader (lazy import — fail gracefully when ee is unavailable)
-// ---------------------------------------------------------------------------
-
-export type DomainsModule = typeof import("@atlas/ee/platform/domains");
-
-export async function loadDomains(): Promise<DomainsModule | null> {
-  try {
-    return await import("@atlas/ee/platform/domains");
-  } catch (err) {
-    if (
-      err instanceof Error &&
-      "code" in err &&
-      (err as NodeJS.ErrnoException).code === "MODULE_NOT_FOUND"
-    ) {
-      return null;
-    }
-    log.error(
-      { err: err instanceof Error ? err : new Error(String(err)) },
-      "Failed to load domains module — unexpected error",
-    );
-    throw err;
-  }
-}
 

--- a/packages/api/src/lib/branding/branding-errors.ts
+++ b/packages/api/src/lib/branding/branding-errors.ts
@@ -1,0 +1,18 @@
+/**
+ * Workspace-branding error class — promoted to core in #2572 so the
+ * `Branding` Tag in `lib/effect/services.ts` can type its failure
+ * channel without core importing from `@atlas/ee`.
+ *
+ * EE's `ee/src/branding/white-label.ts` re-exports for back-compat. The
+ * structural identity (`_tag` + payload) means existing `instanceof`
+ * checks and `domainError(...)` mappings work unchanged.
+ */
+
+import { Data } from "effect";
+
+export type BrandingErrorCode = "validation" | "not_found";
+
+export class BrandingError extends Data.TaggedError("BrandingError")<{
+  message: string;
+  code: BrandingErrorCode;
+}> {}

--- a/packages/api/src/lib/config.ts
+++ b/packages/api/src/lib/config.ts
@@ -1092,9 +1092,12 @@ export function validateAndResolve(raw: unknown): ResolvedConfig {
 /**
  * Resolve the deploy mode for a ResolvedConfig.
  *
- * Tries to load `resolveDeployMode` from the enterprise (`ee/`) package.
- * When the enterprise module is not available, falls back to `"self-hosted"`.
- * Mutates `resolved.deployMode` in place and logs the result.
+ * Calls `resolveDeployMode` from `@atlas/api/lib/effect/deploy-mode`
+ * (pure core helper — promoted from `@atlas/ee/deploy-mode` in #2572 to
+ * end the dynamic-import dance during config bootstrap). Mutates
+ * `resolved.deployMode` in place and logs the result. EE still
+ * re-exports `resolveDeployMode` for any external caller pinned to the
+ * old path.
  */
 async function applyDeployMode(
   resolved: ResolvedConfig,
@@ -1112,34 +1115,14 @@ async function applyDeployMode(
     );
   }
 
-  try {
-    const { resolveDeployMode } = await import("@atlas/ee/deploy-mode");
-    resolved.deployMode = resolveDeployMode(rawSetting);
-  } catch (err) {
-    // The expected case is "AGPL-only build, ee/ legitimately absent" —
-    // log at debug, default to self-hosted. Anything else (syntax error
-    // in a transitive ee/ import, version skew between @atlas/api and
-    // @atlas/ee, bundler/runtime resolution failure) is a real bug that
-    // would otherwise hide as a silent self-hosted downgrade. Surface
-    // the unexpected case at error level so production telemetry catches
-    // it. #1978 finding 3.
-    const code = (err as NodeJS.ErrnoException | undefined)?.code;
-    const isModuleNotFound =
-      code === "ERR_MODULE_NOT_FOUND" ||
-      code === "MODULE_NOT_FOUND" ||
-      // bun's dynamic-import error before it sets a code
-      (err instanceof Error && /Cannot find (module|package)/i.test(err.message));
-    const detail = err instanceof Error ? err.message : String(err);
-    if (isModuleNotFound) {
-      log.debug({ err: detail }, "ee/ module not installed — defaulting to self-hosted");
-    } else {
-      log.error(
-        { err: detail, code },
-        "ee/ module load FAILED unexpectedly (not a missing-module error) — defaulting to self-hosted. Check the @atlas/ee install / version skew",
-      );
-    }
-    resolved.deployMode = "self-hosted";
-  }
+  // Lazy require keeps `config.ts` at the bottom of the dep graph. The
+  // resolver itself is a sync pure function that lazy-requires `getConfig`
+  // and `hasInternalDB` — neither pulls in anything heavy.
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { resolveDeployMode } = require("@atlas/api/lib/effect/deploy-mode") as {
+    resolveDeployMode: (raw?: typeof rawSetting) => "saas" | "self-hosted";
+  };
+  resolved.deployMode = resolveDeployMode(rawSetting);
   log.info({ deployMode: resolved.deployMode }, "Deploy mode resolved");
 
   // #1978 — when deployMode "saas" was requested but resolveDeployMode

--- a/packages/api/src/lib/effect/deploy-mode.ts
+++ b/packages/api/src/lib/effect/deploy-mode.ts
@@ -1,0 +1,74 @@
+/**
+ * Deploy mode resolution — promoted to core in #2572 so the
+ * `DeployModeResolver` Tag (and `lib/config.ts:applyDeployMode`) can
+ * resolve `"saas" | "self-hosted"` without core importing from
+ * `@atlas/ee`.
+ *
+ * EE's `ee/src/deploy-mode.ts` is now a thin re-export for back-compat —
+ * the resolution logic lives here. Behavior is identical: `"saas"` mode
+ * requires enterprise to be enabled, otherwise falls back to
+ * `"self-hosted"`. `"auto"` returns `"saas"` only when BOTH enterprise
+ * is enabled AND an internal database is configured.
+ *
+ * Lazy-requires the config + internal-DB modules to keep this file at
+ * the bottom of the dep graph (same trick `enterprise-layer.ts` uses for
+ * `isEnterpriseEnabledLocal`).
+ */
+
+import type { DeployMode, DeployModeSetting } from "@useatlas/types";
+
+/**
+ * Read whether enterprise is enabled without importing from `@atlas/ee`.
+ *
+ * Mirrors `ee/src/index.ts:isEnterpriseEnabled` resolution order:
+ *   1. `enterprise.enabled` in atlas.config.ts
+ *   2. `ATLAS_ENTERPRISE_ENABLED` env var
+ */
+function isEnterpriseEnabledLocal(): boolean {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { getConfig } = require("@atlas/api/lib/config") as {
+    getConfig: () => { enterprise?: { enabled?: boolean } } | null;
+  };
+  const config = getConfig();
+  if (config?.enterprise?.enabled !== undefined) {
+    return config.enterprise.enabled;
+  }
+  return process.env.ATLAS_ENTERPRISE_ENABLED === "true";
+}
+
+function hasInternalDBLocal(): boolean {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { hasInternalDB } = require("@atlas/api/lib/db/internal") as {
+    hasInternalDB: () => boolean;
+  };
+  return hasInternalDB();
+}
+
+/**
+ * Resolve the effective deploy mode from the raw setting value.
+ *
+ * Logic:
+ * - `"self-hosted"`: always returns `"self-hosted"`
+ * - `"saas"`: requires enterprise enabled, otherwise falls back to
+ *   `"self-hosted"`
+ * - `"auto"` (default): returns `"saas"` when both enterprise is
+ *   enabled AND an internal database is configured, otherwise
+ *   `"self-hosted"`
+ */
+export function resolveDeployMode(raw?: DeployModeSetting): DeployMode {
+  const setting: DeployModeSetting =
+    raw ?? (process.env.ATLAS_DEPLOY_MODE as DeployModeSetting) ?? "auto";
+
+  if (setting === "self-hosted") {
+    return "self-hosted";
+  }
+
+  if (setting === "saas") {
+    return isEnterpriseEnabledLocal() ? "saas" : "self-hosted";
+  }
+
+  // "auto" — detect from environment
+  return isEnterpriseEnabledLocal() && hasInternalDBLocal()
+    ? "saas"
+    : "self-hosted";
+}

--- a/packages/api/src/lib/effect/index.ts
+++ b/packages/api/src/lib/effect/index.ts
@@ -49,6 +49,11 @@ export {
 
 export { runEffect, runHandler, mapTaggedError, domainError, type DomainErrorMapping, type RunEffectOptions } from "./hono";
 
+// Deploy-mode resolver (#2572 — slice 10/11 of #2017). Pure function;
+// lives in core so `lib/config.ts:applyDeployMode` can call it without
+// dynamic-importing `@atlas/ee/deploy-mode`. EE re-exports for back-compat.
+export { resolveDeployMode } from "./deploy-mode";
+
 // ── Effect Services (P4+) ───────────────────────────────────────────
 
 export {

--- a/packages/api/src/lib/effect/services.ts
+++ b/packages/api/src/lib/effect/services.ts
@@ -1873,69 +1873,231 @@ export const NoopRolesPolicyLayer: Layer.Layer<RolesPolicy> = Layer.succeed(
   } satisfies RolesPolicyShape,
 );
 
-// ── Branding (slice TBD) ─────────────────────────────────────────────
+// ── Branding (#2572 — slice 10/11 of #2017) ──────────────────────────
 //
-// Replaces `import { ... } from "@atlas/ee/branding/white-label"` in
-// `api/routes/admin-branding.ts` + `public-branding.ts`. EE serves
-// per-workspace white-label config; core's no-op returns `null` so
-// the public surface falls back to Atlas branding.
+// Inverts every `@atlas/ee/branding/white-label` reference in
+// `packages/api/src/`: the static imports in `api/routes/admin-branding.ts`
+// + `public-branding.ts`. EE serves per-workspace white-label config;
+// the no-op default returns `null` (read fallthrough — frontend renders
+// Atlas defaults) and fails writes with `EnterpriseError` so the routes'
+// existing `domainError(BrandingError)` + `EnterpriseError → 403`
+// mapping renders the upsell envelope.
+//
+// `BrandingError` lives in `lib/branding/branding-errors.ts` so the
+// Tag's failure channel stays typed without pulling in `@atlas/ee`.
+
+type WorkspaceBranding = import("@useatlas/types").WorkspaceBranding;
+type SetWorkspaceBrandingInput =
+  import("@useatlas/types").SetWorkspaceBrandingInput;
+type BrandingError =
+  import("@atlas/api/lib/branding/branding-errors").BrandingError;
+type EnterpriseErrorForBranding =
+  import("@atlas/api/lib/effect/errors").EnterpriseError;
 
 export interface BrandingShape {
+  readonly available: boolean;
+  /** Admin endpoint — enterprise-gated. */
+  readonly getWorkspaceBranding: (
+    orgId: string,
+  ) => Effect.Effect<WorkspaceBranding | null, EnterpriseErrorForBranding>;
+  /** Public endpoint — skips the enterprise gate so existing branding
+   * keeps rendering when a license lapses. */
   readonly getWorkspaceBrandingPublic: (
     orgId: string,
-  ) => Promise<unknown | null>;
+  ) => Effect.Effect<WorkspaceBranding | null>;
+  readonly setWorkspaceBranding: (
+    orgId: string,
+    input: SetWorkspaceBrandingInput,
+  ) => Effect.Effect<
+    WorkspaceBranding,
+    BrandingError | EnterpriseErrorForBranding | Error
+  >;
+  readonly deleteWorkspaceBranding: (
+    orgId: string,
+  ) => Effect.Effect<boolean, EnterpriseErrorForBranding | Error>;
 }
 export class Branding extends Context.Tag("Branding")<
   Branding,
   BrandingShape
 >() {}
-export const NoopBrandingLayer: Layer.Layer<Branding> = Layer.succeed(Branding, {
-  getWorkspaceBrandingPublic: async () => null,
-} satisfies BrandingShape);
+export const NoopBrandingLayer: Layer.Layer<Branding> = Layer.sync(
+  Branding,
+  () => {
+    const { EnterpriseError: EnterpriseErrorClass } =
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      require("@atlas/api/lib/effect/errors") as {
+        EnterpriseError: new (message?: string) => EnterpriseErrorForBranding;
+      };
+    const notAvailable = () =>
+      new EnterpriseErrorClass(
+        "Workspace branding requires enterprise features to be enabled.",
+      );
+    return {
+      available: false,
+      getWorkspaceBranding: () => Effect.fail(notAvailable()),
+      getWorkspaceBrandingPublic: () => Effect.succeed(null),
+      setWorkspaceBranding: () => Effect.fail(notAvailable()),
+      deleteWorkspaceBranding: () => Effect.fail(notAvailable()),
+    } satisfies BrandingShape;
+  },
+);
 
-// ── Domains (slice TBD) ──────────────────────────────────────────────
+// ── Domains (#2572 — slice 10/11 of #2017) ───────────────────────────
 //
-// Replaces `await import("@atlas/ee/platform/domains")` in
-// `api/routes/shared-domains.ts` + `admin-domains.ts`. EE manages
-// custom-domain mappings; core's no-op reports none configured.
+// Inverts every `@atlas/ee/platform/domains` reference in
+// `packages/api/src/`: the `loadDomains()` dynamic-import in
+// `api/routes/shared-domains.ts` (consumed by `admin-domains.ts`). EE
+// manages custom-domain mappings; the no-op default reports `available:
+// false` and fails writes with `EnterpriseError` so the admin page
+// continues to render its enterprise-upsell envelope.
+//
+// `DomainError` lives in `lib/platform/domains-errors.ts` so the Tag's
+// failure channel stays typed without pulling in `@atlas/ee`.
+
+type CustomDomain = import("@useatlas/types").CustomDomain;
+type DomainError =
+  import("@atlas/api/lib/platform/domains-errors").DomainError;
+type EnterpriseErrorForDomains =
+  import("@atlas/api/lib/effect/errors").EnterpriseError;
 
 export interface DomainsShape {
   readonly available: boolean;
+  readonly registerDomain: (
+    workspaceId: string,
+    domain: string,
+  ) => Effect.Effect<CustomDomain, DomainError | EnterpriseErrorForDomains | Error>;
+  readonly verifyDomain: (
+    domainId: string,
+  ) => Effect.Effect<CustomDomain, DomainError | EnterpriseErrorForDomains | Error>;
+  readonly verifyDomainDnsTxt: (
+    domainId: string,
+  ) => Effect.Effect<CustomDomain, DomainError | EnterpriseErrorForDomains | Error>;
+  readonly listDomains: (
+    workspaceId: string,
+  ) => Effect.Effect<CustomDomain[], DomainError | EnterpriseErrorForDomains | Error>;
+  readonly listAllDomains: () => Effect.Effect<
+    CustomDomain[],
+    DomainError | EnterpriseErrorForDomains | Error
+  >;
+  readonly deleteDomain: (
+    domainId: string,
+  ) => Effect.Effect<void, DomainError | EnterpriseErrorForDomains | Error>;
+  readonly checkDomainAvailability: (
+    domain: string,
+    workspaceId: string,
+  ) => Effect.Effect<
+    { available: boolean; reason?: string },
+    DomainError | EnterpriseErrorForDomains | Error
+  >;
+  readonly hasVerifiedCustomDomain: (
+    workspaceId: string,
+    domain: string,
+  ) => Effect.Effect<boolean, Error>;
+  readonly resolveWorkspaceByHost: (
+    hostname: string,
+  ) => Effect.Effect<string | null>;
+  /** Redact the verification token from a CustomDomain before returning
+   * to API consumers. Synchronous — no Effect wrapping. */
+  readonly redactDomain: (
+    domain: CustomDomain,
+    includeToken?: boolean,
+  ) => CustomDomain;
 }
 export class Domains extends Context.Tag("Domains")<
   Domains,
   DomainsShape
 >() {}
-export const NoopDomainsLayer: Layer.Layer<Domains> = Layer.succeed(Domains, {
-  available: false,
-} satisfies DomainsShape);
+export const NoopDomainsLayer: Layer.Layer<Domains> = Layer.sync(
+  Domains,
+  () => {
+    const { EnterpriseError: EnterpriseErrorClass } =
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      require("@atlas/api/lib/effect/errors") as {
+        EnterpriseError: new (message?: string) => EnterpriseErrorForDomains;
+      };
+    const notAvailable = () =>
+      new EnterpriseErrorClass(
+        "Custom domains require enterprise features to be enabled.",
+      );
+    return {
+      available: false,
+      registerDomain: () => Effect.fail(notAvailable()),
+      verifyDomain: () => Effect.fail(notAvailable()),
+      verifyDomainDnsTxt: () => Effect.fail(notAvailable()),
+      listDomains: () => Effect.succeed([]),
+      listAllDomains: () => Effect.succeed([]),
+      deleteDomain: () => Effect.fail(notAvailable()),
+      checkDomainAvailability: () =>
+        Effect.succeed({
+          available: false,
+          reason: "Custom domains are not available.",
+        }),
+      hasVerifiedCustomDomain: () => Effect.succeed(false),
+      resolveWorkspaceByHost: () => Effect.succeed(null),
+      redactDomain: (d) => d,
+    } satisfies DomainsShape;
+  },
+);
 
-// ── ProactiveGate (slice TBD) ────────────────────────────────────────
+// ── ProactiveGate (#2572 — slice 10/11 of #2017) ─────────────────────
 //
-// Replaces `requireEnterpriseEffect("proactive")` + the
-// `admin-proactive-*` route guards. EE gates the proactive chat
-// surface; core's no-op reports unavailable so the feature is hidden.
+// Replaces `requireEnterpriseEffect("proactive-chat")` in the four
+// `admin-proactive-*` routes. EE gates the proactive chat surface
+// (PRD #2291 — 1.5.0 paid tier); the no-op default fails with
+// `EnterpriseError` so non-enterprise tenants see 403
+// `enterprise_required` and the admin page routes through
+// `EnterpriseUpsell` / `<FeatureGate feature="Proactive Chat">`.
+
+type EnterpriseErrorForProactive =
+  import("@atlas/api/lib/effect/errors").EnterpriseError;
 
 export interface ProactiveGateShape {
   readonly enabled: boolean;
+  /** Effect-style guard. `Effect.void` when enterprise is enabled,
+   * `Effect.fail(EnterpriseError)` otherwise. The route layer's
+   * `classifyError` maps that to a 403 `enterprise_required` envelope.
+   *
+   * Re-reads the enterprise flag on every call (Effect wrapper closes
+   * over the EE-side `isEnterpriseEnabled()`) so a runtime flip
+   * propagates without restart. */
+  readonly requireEnabled: () => Effect.Effect<
+    void,
+    EnterpriseErrorForProactive
+  >;
 }
 export class ProactiveGate extends Context.Tag("ProactiveGate")<
   ProactiveGate,
   ProactiveGateShape
 >() {}
-export const NoopProactiveGateLayer: Layer.Layer<ProactiveGate> = Layer.succeed(
+export const NoopProactiveGateLayer: Layer.Layer<ProactiveGate> = Layer.sync(
   ProactiveGate,
-  {
-    enabled: false,
-  } satisfies ProactiveGateShape,
+  () => {
+    const { EnterpriseError: EnterpriseErrorClass } =
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      require("@atlas/api/lib/effect/errors") as {
+        EnterpriseError: new (message?: string) => EnterpriseErrorForProactive;
+      };
+    return {
+      enabled: false,
+      requireEnabled: () =>
+        Effect.fail(
+          new EnterpriseErrorClass(
+            "Proactive chat requires enterprise features to be enabled.",
+          ),
+        ),
+    } satisfies ProactiveGateShape;
+  },
 );
 
-// ── DeployModeResolver (slice TBD) ───────────────────────────────────
+// ── DeployModeResolver (#2572 — slice 10/11 of #2017) ────────────────
 //
 // Replaces `await import("@atlas/ee/deploy-mode")` in `lib/config.ts`.
-// EE resolves `"saas" | "self-hosted"` from env + internal-DB presence;
-// core's no-op always reports `"self-hosted"` (the correct answer when
-// EE is not loaded — `"saas"` mode requires enterprise).
+// Resolution logic moved to `lib/effect/deploy-mode.ts` in core
+// (`resolveDeployMode`); EE re-exports for back-compat. The Tag still
+// exists because some non-config callers (e.g. agent-loop telemetry,
+// SaaS guards) may eventually want to yield it. The no-op default
+// always reports `"self-hosted"` (the correct answer when EE is not
+// loaded — `"saas"` mode requires enterprise).
 
 export interface DeployModeResolverShape {
   readonly resolve: () => "saas" | "self-hosted";

--- a/packages/api/src/lib/platform/domains-errors.ts
+++ b/packages/api/src/lib/platform/domains-errors.ts
@@ -1,0 +1,25 @@
+/**
+ * Custom-domain error class — promoted to core in #2572 so the
+ * `Domains` Tag in `lib/effect/services.ts` can type its failure
+ * channel without core importing from `@atlas/ee`.
+ *
+ * EE's `ee/src/platform/domains.ts` re-exports for back-compat. The
+ * structural identity (`_tag` + payload) means existing `instanceof`
+ * checks and `domainError(...)` mappings work unchanged.
+ */
+
+import { Data } from "effect";
+
+export type DomainErrorCode =
+  | "no_internal_db"
+  | "invalid_domain"
+  | "duplicate_domain"
+  | "domain_not_found"
+  | "railway_error"
+  | "railway_not_configured"
+  | "data_integrity";
+
+export class DomainError extends Data.TaggedError("DomainError")<{
+  message: string;
+  code: DomainErrorCode;
+}> {}


### PR DESCRIPTION
## Summary

Slice 10/11 of #2017. Bundles four narrow-surface subsystem Tag inverts into a single PR to avoid four PRs of Tag scaffolding overhead:

- **Branding** Tag — widens `BrandingShape` to the full surface used by `admin-branding.ts` + `public-branding.ts`. Promotes `BrandingError` to `@atlas/api/lib/branding/branding-errors`.
- **Domains** Tag — widens `DomainsShape` to the full custom-domain surface used by `admin-domains.ts`, `platform-domains.ts`, `shared-domains.ts`. Promotes `DomainError` to `@atlas/api/lib/platform/domains-errors`. `loadDomains()` is gone.
- **ProactiveGate** Tag — adds `requireEnabled(): Effect<void, EnterpriseError>`. Three of the four `admin-proactive-*` routes yield the Tag; `admin-proactive.ts` keeps its sync `gateEnterprise()` but reads the enterprise flag from `getConfig()` / `ATLAS_ENTERPRISE_ENABLED` directly (the runHandler async-Hono handler can't unwrap the lazy-async `ConditionalEELayer` synchronously).
- **DeployModeResolver** Tag — `resolveDeployMode` moves to `@atlas/api/lib/effect/deploy-mode`. EE re-exports for back-compat; `lib/config.ts` lazy-requires the core helper instead of dynamic-importing `@atlas/ee/deploy-mode`.

EE Live layers wire into `ee/src/layers.ts:EELayer`. No-op defaults fail closed (reads → `null` / empty, writes → `EnterpriseError`).

After this slice, `packages/api/src/` has no static or dynamic imports of `@atlas/ee/{branding,platform/domains,deploy-mode}` and no `requireEnterpriseEffect` calls in `admin-proactive*` routes.

Closes #2572

## Test plan

- [x] `bun run lint` — 0 errors, 3 pre-existing warnings unrelated to this slice
- [x] `bun run type` — 0 errors
- [x] `bun run test` — 412 (api) + 22 (others) + 159 (api2) passing, 0 failures
- [x] `bun x syncpack lint` — clean
- [x] Template / Railway / schema / OAuth-helper / security-headers drift — all green
- [x] Behavior parity: branding + custom-domains admin pages still render and gate the same way; proactive routes still 403 with `enterprise_required` when EE is off; deploy mode resolution returns the same value on SaaS + self-hosted