### PR TITLE
cleanup(api): 1.5.1 closeout fixes — security, perf, consistency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,9 @@ jobs:
       - name: Check core never imports from @atlas/ee
         run: bash scripts/check-ee-imports.sh
 
+      - name: Adversarial fixtures for the EE-imports gate
+        run: bash scripts/__tests__/check-ee-imports.test.sh
+
   lint:
     name: lint
     runs-on: ubuntu-latest

--- a/ee/src/governance/approval.ts
+++ b/ee/src/governance/approval.ts
@@ -1150,7 +1150,6 @@ export const hasApprovedRequest = (
 // installs (returns `{ required: false }` so queries bypass the gate).
 
 export const makeApprovalGateLive = (): ApprovalGateShape => ({
-  available: true,
   checkApprovalRequired,
   hasApprovedRequest,
   createApprovalRequest,

--- a/packages/api/src/api/__tests__/admin-compliance.test.ts
+++ b/packages/api/src/api/__tests__/admin-compliance.test.ts
@@ -152,7 +152,8 @@ mock.module("@atlas/ee/layers", () => ({
       type MaskingContext = import("@atlas/api/lib/effect/services").MaskingContext;
       const maskingLayer = Layer.succeed(services.MaskingPolicy, {
         available: true,
-        applyMasking: (ctx: MaskingContext) => Effect.succeed([...ctx.rows]),
+        // Preserve reference identity — see services.ts:NoopMaskingPolicyLayer.
+        applyMasking: (ctx: MaskingContext) => Effect.succeed(ctx.rows),
         listPIIClassifications: () => Effect.succeed([]),
         updatePIIClassification: () => {
           if (mockUpdateError) return Effect.fail(mockUpdateError);

--- a/packages/api/src/api/__tests__/admin-marketplace.test.ts
+++ b/packages/api/src/api/__tests__/admin-marketplace.test.ts
@@ -173,6 +173,16 @@ mock.module("@atlas/api/lib/effect/services", () => ({
 // directly; layer composition is a no-op in this test.
 mock.module("@atlas/api/lib/effect/enterprise-layer", () => ({
   EnterpriseLayer: { _tag: "MockLayer" },
+  // Post-#2587: these are never called because the shimmed `runEffect`
+  // above doesn't reach the real runtime, but the imports must resolve.
+  getEnterpriseRuntime: () => ({
+    runPromise: () => Promise.resolve(undefined),
+    runPromiseExit: () => Promise.resolve({ _tag: "Success", value: undefined } as never),
+    dispose: () => Promise.resolve(),
+  }),
+  runEnterprise: () => Promise.resolve(undefined),
+  runEnterpriseExit: () => Promise.resolve({ _tag: "Success", value: undefined } as never),
+  __resetEnterpriseRuntimeForTesting: () => {},
 }));
 
 mock.module("@atlas/api/lib/effect/hono", () => ({

--- a/packages/api/src/api/__tests__/admin-marketplace.test.ts
+++ b/packages/api/src/api/__tests__/admin-marketplace.test.ts
@@ -181,8 +181,6 @@ mock.module("@atlas/api/lib/effect/enterprise-layer", () => ({
     dispose: () => Promise.resolve(),
   }),
   runEnterprise: () => Promise.resolve(undefined),
-  runEnterpriseExit: () => Promise.resolve({ _tag: "Success", value: undefined } as never),
-  __resetEnterpriseRuntimeForTesting: () => {},
 }));
 
 mock.module("@atlas/api/lib/effect/hono", () => ({

--- a/packages/api/src/api/__tests__/admin-marketplace.test.ts
+++ b/packages/api/src/api/__tests__/admin-marketplace.test.ts
@@ -173,7 +173,7 @@ mock.module("@atlas/api/lib/effect/services", () => ({
 // directly; layer composition is a no-op in this test.
 mock.module("@atlas/api/lib/effect/enterprise-layer", () => ({
   EnterpriseLayer: { _tag: "MockLayer" },
-  // Post-#2587: these are never called because the shimmed `runEffect`
+  // Post-#2594: these are never called because the shimmed `runEffect`
   // above doesn't reach the real runtime, but the imports must resolve.
   getEnterpriseRuntime: () => ({
     runPromise: () => Promise.resolve(undefined),

--- a/packages/api/src/api/__tests__/admin-residency.test.ts
+++ b/packages/api/src/api/__tests__/admin-residency.test.ts
@@ -217,7 +217,7 @@ mock.module("effect", () => {
 // inside the test; an inert mock-layer keeps the loader happy.
 mock.module("@atlas/api/lib/effect/enterprise-layer", () => ({
   EnterpriseLayer: { _tag: "MockLayer" },
-  // Post-#2587: these are never called because the shimmed `runEffect`
+  // Post-#2594: these are never called because the shimmed `runEffect`
   // above never reaches the real runtime, but the imports must resolve.
   getEnterpriseRuntime: () => ({
     runPromise: () => Promise.resolve(undefined),
@@ -371,7 +371,7 @@ mock.module("@atlas/api/lib/effect/services", () => ({
 // value.
 mock.module("@atlas/api/lib/effect/enterprise-layer", () => ({
   EnterpriseLayer: { _tag: "MockLayer" },
-  // Post-#2587: these are never called because the shimmed `runEffect`
+  // Post-#2594: these are never called because the shimmed `runEffect`
   // above never reaches the real runtime, but the imports must resolve.
   getEnterpriseRuntime: () => ({
     runPromise: () => Promise.resolve(undefined),

--- a/packages/api/src/api/__tests__/admin-residency.test.ts
+++ b/packages/api/src/api/__tests__/admin-residency.test.ts
@@ -225,8 +225,6 @@ mock.module("@atlas/api/lib/effect/enterprise-layer", () => ({
     dispose: () => Promise.resolve(),
   }),
   runEnterprise: () => Promise.resolve(undefined),
-  runEnterpriseExit: () => Promise.resolve({ _tag: "Success", value: undefined } as never),
-  __resetEnterpriseRuntimeForTesting: () => {},
 }));
 
 // --- Residency resolver mock (#2564) ---
@@ -379,8 +377,6 @@ mock.module("@atlas/api/lib/effect/enterprise-layer", () => ({
     dispose: () => Promise.resolve(),
   }),
   runEnterprise: () => Promise.resolve(undefined),
-  runEnterpriseExit: () => Promise.resolve({ _tag: "Success", value: undefined } as never),
-  __resetEnterpriseRuntimeForTesting: () => {},
 }));
 
 // #1986 — Mirror the production tagged-error → HTTP mapping so route tests

--- a/packages/api/src/api/__tests__/admin-residency.test.ts
+++ b/packages/api/src/api/__tests__/admin-residency.test.ts
@@ -217,6 +217,16 @@ mock.module("effect", () => {
 // inside the test; an inert mock-layer keeps the loader happy.
 mock.module("@atlas/api/lib/effect/enterprise-layer", () => ({
   EnterpriseLayer: { _tag: "MockLayer" },
+  // Post-#2587: these are never called because the shimmed `runEffect`
+  // above never reaches the real runtime, but the imports must resolve.
+  getEnterpriseRuntime: () => ({
+    runPromise: () => Promise.resolve(undefined),
+    runPromiseExit: () => Promise.resolve({ _tag: "Success", value: undefined } as never),
+    dispose: () => Promise.resolve(),
+  }),
+  runEnterprise: () => Promise.resolve(undefined),
+  runEnterpriseExit: () => Promise.resolve({ _tag: "Success", value: undefined } as never),
+  __resetEnterpriseRuntimeForTesting: () => {},
 }));
 
 // --- Residency resolver mock (#2564) ---
@@ -361,6 +371,16 @@ mock.module("@atlas/api/lib/effect/services", () => ({
 // value.
 mock.module("@atlas/api/lib/effect/enterprise-layer", () => ({
   EnterpriseLayer: { _tag: "MockLayer" },
+  // Post-#2587: these are never called because the shimmed `runEffect`
+  // above never reaches the real runtime, but the imports must resolve.
+  getEnterpriseRuntime: () => ({
+    runPromise: () => Promise.resolve(undefined),
+    runPromiseExit: () => Promise.resolve({ _tag: "Success", value: undefined } as never),
+    dispose: () => Promise.resolve(),
+  }),
+  runEnterprise: () => Promise.resolve(undefined),
+  runEnterpriseExit: () => Promise.resolve({ _tag: "Success", value: undefined } as never),
+  __resetEnterpriseRuntimeForTesting: () => {},
 }));
 
 // #1986 — Mirror the production tagged-error → HTTP mapping so route tests

--- a/packages/api/src/api/__tests__/admin-roles.test.ts
+++ b/packages/api/src/api/__tests__/admin-roles.test.ts
@@ -163,7 +163,7 @@ mock.module("@atlas/api/lib/effect/enterprise-layer", () => {
       isSCIMProvisioned: () => Effect.succeed(false),
     } as never),
   );
-  // Post-#2587: production code uses `runEnterprise` / `getEnterpriseRuntime`
+  // Post-#2594: production code uses `runEnterprise` / `getEnterpriseRuntime`
   // (module-level ManagedRuntime singleton). The test runtime is built
   // against the test Layer so all the mocked Tag bindings flow through.
   const testRuntime = ManagedRuntime.make(testLayer as never);

--- a/packages/api/src/api/__tests__/admin-roles.test.ts
+++ b/packages/api/src/api/__tests__/admin-roles.test.ts
@@ -171,8 +171,6 @@ mock.module("@atlas/api/lib/effect/enterprise-layer", () => {
     EnterpriseLayer: testLayer,
     getEnterpriseRuntime: () => testRuntime,
     runEnterprise: (program: never) => testRuntime.runPromise(program),
-    runEnterpriseExit: (program: never) => testRuntime.runPromiseExit(program),
-    __resetEnterpriseRuntimeForTesting: () => {},
   };
 });
 

--- a/packages/api/src/api/__tests__/admin-roles.test.ts
+++ b/packages/api/src/api/__tests__/admin-roles.test.ts
@@ -129,41 +129,50 @@ mock.module("@atlas/api/lib/auth/roles-errors", () => ({
 // return 500 instead of the expected 200/4xx.
 mock.module("@atlas/api/lib/effect/enterprise-layer", () => {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const { Layer } = require("effect") as typeof import("effect");
+  const { Layer, ManagedRuntime } = require("effect") as typeof import("effect");
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const services = require("@atlas/api/lib/effect/services") as typeof import("@atlas/api/lib/effect/services");
+  const testLayer = Layer.mergeAll(
+    Layer.succeed(services.RolesPolicy, {
+      customRolesActive: true,
+      checkPermission: () => Effect.succeed(null),
+      listRoles: mockListRoles as never,
+      getRole: mockGetRole as never,
+      getRoleByName: mockGetRoleByName as never,
+      createRole: mockCreateRole as never,
+      updateRole: mockUpdateRole as never,
+      deleteRole: mockDeleteRole as never,
+      listRoleMembers: mockListRoleMembers as never,
+      assignRole: mockAssignRole as never,
+    } as never),
+    Layer.succeed(services.IpAllowlistPolicy, {
+      available: false,
+      checkIPAllowlist: () => Effect.succeed({ allowed: true }),
+    } as never),
+    Layer.succeed(services.SSOPolicy, {
+      available: false,
+      extractEmailDomain: (email: string) => {
+        const at = email.lastIndexOf("@");
+        return at > 0 ? email.slice(at + 1).toLowerCase() : null;
+      },
+      isSSOEnforcedForDomain: () => Effect.succeed({ enforced: false }),
+      isSSOEnforced: () => Effect.succeed({ enforced: false }),
+    } as never),
+    Layer.succeed(services.SCIMProvenance, {
+      available: false,
+      isSCIMProvisioned: () => Effect.succeed(false),
+    } as never),
+  );
+  // Post-#2587: production code uses `runEnterprise` / `getEnterpriseRuntime`
+  // (module-level ManagedRuntime singleton). The test runtime is built
+  // against the test Layer so all the mocked Tag bindings flow through.
+  const testRuntime = ManagedRuntime.make(testLayer as never);
   return {
-    EnterpriseLayer: Layer.mergeAll(
-      Layer.succeed(services.RolesPolicy, {
-        customRolesActive: true,
-        checkPermission: () => Effect.succeed(null),
-        listRoles: mockListRoles as never,
-        getRole: mockGetRole as never,
-        getRoleByName: mockGetRoleByName as never,
-        createRole: mockCreateRole as never,
-        updateRole: mockUpdateRole as never,
-        deleteRole: mockDeleteRole as never,
-        listRoleMembers: mockListRoleMembers as never,
-        assignRole: mockAssignRole as never,
-      } as never),
-      Layer.succeed(services.IpAllowlistPolicy, {
-        available: false,
-        checkIPAllowlist: () => Effect.succeed({ allowed: true }),
-      } as never),
-      Layer.succeed(services.SSOPolicy, {
-        available: false,
-        extractEmailDomain: (email: string) => {
-          const at = email.lastIndexOf("@");
-          return at > 0 ? email.slice(at + 1).toLowerCase() : null;
-        },
-        isSSOEnforcedForDomain: () => Effect.succeed({ enforced: false }),
-        isSSOEnforced: () => Effect.succeed({ enforced: false }),
-      } as never),
-      Layer.succeed(services.SCIMProvenance, {
-        available: false,
-        isSCIMProvisioned: () => Effect.succeed(false),
-      } as never),
-    ),
+    EnterpriseLayer: testLayer,
+    getEnterpriseRuntime: () => testRuntime,
+    runEnterprise: (program: never) => testRuntime.runPromise(program),
+    runEnterpriseExit: (program: never) => testRuntime.runPromiseExit(program),
+    __resetEnterpriseRuntimeForTesting: () => {},
   };
 });
 

--- a/packages/api/src/api/routes/__tests__/permission-enforcement.test.ts
+++ b/packages/api/src/api/routes/__tests__/permission-enforcement.test.ts
@@ -133,8 +133,6 @@ mock.module("@atlas/api/lib/effect/enterprise-layer", () => {
     EnterpriseLayer: testLayer,
     getEnterpriseRuntime: () => testRuntime,
     runEnterprise: (program: never) => testRuntime.runPromise(program),
-    runEnterpriseExit: (program: never) => testRuntime.runPromiseExit(program),
-    __resetEnterpriseRuntimeForTesting: () => {},
   };
 });
 

--- a/packages/api/src/api/routes/__tests__/permission-enforcement.test.ts
+++ b/packages/api/src/api/routes/__tests__/permission-enforcement.test.ts
@@ -94,41 +94,47 @@ mock.module("@atlas/api/lib/auth/roles-errors", () => ({
 // focus on `mockCheckPermission`.
 mock.module("@atlas/api/lib/effect/enterprise-layer", () => {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const { Layer } = require("effect") as typeof import("effect");
+  const { Layer, ManagedRuntime } = require("effect") as typeof import("effect");
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const services = require("@atlas/api/lib/effect/services") as typeof import("@atlas/api/lib/effect/services");
+  const testLayer = Layer.mergeAll(
+    Layer.succeed(services.RolesPolicy, {
+      customRolesActive: true,
+      checkPermission: mockCheckPermission as never,
+      listRoles: mockListRoles as never,
+      getRole: () => Effect.succeed(null),
+      getRoleByName: () => Effect.succeed(null),
+      createRole: () => Effect.die(new Error("not configured")),
+      updateRole: () => Effect.die(new Error("not configured")),
+      deleteRole: () => Effect.succeed(true),
+      listRoleMembers: () => Effect.succeed([]),
+      assignRole: () => Effect.die(new Error("not configured")),
+    } as never),
+    Layer.succeed(services.IpAllowlistPolicy, {
+      available: false,
+      checkIPAllowlist: () => Effect.succeed({ allowed: true }),
+    } as never),
+    Layer.succeed(services.SSOPolicy, {
+      available: false,
+      extractEmailDomain: (email: string) => {
+        const at = email.lastIndexOf("@");
+        return at > 0 ? email.slice(at + 1).toLowerCase() : null;
+      },
+      isSSOEnforcedForDomain: () => Effect.succeed({ enforced: false }),
+      isSSOEnforced: () => Effect.succeed({ enforced: false }),
+    } as never),
+    Layer.succeed(services.SCIMProvenance, {
+      available: false,
+      isSCIMProvisioned: () => Effect.succeed(false),
+    } as never),
+  );
+  const testRuntime = ManagedRuntime.make(testLayer as never);
   return {
-    EnterpriseLayer: Layer.mergeAll(
-      Layer.succeed(services.RolesPolicy, {
-        customRolesActive: true,
-        checkPermission: mockCheckPermission as never,
-        listRoles: mockListRoles as never,
-        getRole: () => Effect.succeed(null),
-        getRoleByName: () => Effect.succeed(null),
-        createRole: () => Effect.die(new Error("not configured")),
-        updateRole: () => Effect.die(new Error("not configured")),
-        deleteRole: () => Effect.succeed(true),
-        listRoleMembers: () => Effect.succeed([]),
-        assignRole: () => Effect.die(new Error("not configured")),
-      } as never),
-      Layer.succeed(services.IpAllowlistPolicy, {
-        available: false,
-        checkIPAllowlist: () => Effect.succeed({ allowed: true }),
-      } as never),
-      Layer.succeed(services.SSOPolicy, {
-        available: false,
-        extractEmailDomain: (email: string) => {
-          const at = email.lastIndexOf("@");
-          return at > 0 ? email.slice(at + 1).toLowerCase() : null;
-        },
-        isSSOEnforcedForDomain: () => Effect.succeed({ enforced: false }),
-        isSSOEnforced: () => Effect.succeed({ enforced: false }),
-      } as never),
-      Layer.succeed(services.SCIMProvenance, {
-        available: false,
-        isSCIMProvisioned: () => Effect.succeed(false),
-      } as never),
-    ),
+    EnterpriseLayer: testLayer,
+    getEnterpriseRuntime: () => testRuntime,
+    runEnterprise: (program: never) => testRuntime.runPromise(program),
+    runEnterpriseExit: (program: never) => testRuntime.runPromiseExit(program),
+    __resetEnterpriseRuntimeForTesting: () => {},
   };
 });
 

--- a/packages/api/src/api/routes/__tests__/scim-provenance-enforcement.test.ts
+++ b/packages/api/src/api/routes/__tests__/scim-provenance-enforcement.test.ts
@@ -190,8 +190,6 @@ mock.module("@atlas/api/lib/effect/enterprise-layer", () => {
     EnterpriseLayer: testLayer,
     getEnterpriseRuntime: () => testRuntime,
     runEnterprise: (program: never) => testRuntime.runPromise(program),
-    runEnterpriseExit: (program: never) => testRuntime.runPromiseExit(program),
-    __resetEnterpriseRuntimeForTesting: () => {},
   };
 });
 

--- a/packages/api/src/api/routes/__tests__/scim-provenance-enforcement.test.ts
+++ b/packages/api/src/api/routes/__tests__/scim-provenance-enforcement.test.ts
@@ -151,41 +151,47 @@ const mockGetRoleByName = mock(() =>
 // `Effect.provide(EnterpriseLayer)` resolves the full chain.
 mock.module("@atlas/api/lib/effect/enterprise-layer", () => {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const { Layer } = require("effect") as typeof import("effect");
+  const { Layer, ManagedRuntime } = require("effect") as typeof import("effect");
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const services = require("@atlas/api/lib/effect/services") as typeof import("@atlas/api/lib/effect/services");
+  const testLayer = Layer.mergeAll(
+    Layer.succeed(services.RolesPolicy, {
+      customRolesActive: true,
+      checkPermission: () => Effect.succeed(null),
+      listRoles: () => Effect.succeed([]),
+      getRole: () => Effect.succeed(null),
+      getRoleByName: mockGetRoleByName as never,
+      createRole: () => Effect.die(new Error("not configured")),
+      updateRole: () => Effect.die(new Error("not configured")),
+      deleteRole: () => Effect.succeed(true),
+      listRoleMembers: () => Effect.succeed([]),
+      assignRole: mockAssignRole as never,
+    } as never),
+    Layer.succeed(services.IpAllowlistPolicy, {
+      available: false,
+      checkIPAllowlist: () => Effect.succeed({ allowed: true }),
+    } as never),
+    Layer.succeed(services.SSOPolicy, {
+      available: false,
+      extractEmailDomain: (email: string) => {
+        const at = email.lastIndexOf("@");
+        return at > 0 ? email.slice(at + 1).toLowerCase() : null;
+      },
+      isSSOEnforcedForDomain: () => Effect.succeed({ enforced: false }),
+      isSSOEnforced: () => Effect.succeed({ enforced: false }),
+    } as never),
+    Layer.succeed(services.SCIMProvenance, {
+      available: false,
+      isSCIMProvisioned: () => Effect.succeed(false),
+    } as never),
+  );
+  const testRuntime = ManagedRuntime.make(testLayer as never);
   return {
-    EnterpriseLayer: Layer.mergeAll(
-      Layer.succeed(services.RolesPolicy, {
-        customRolesActive: true,
-        checkPermission: () => Effect.succeed(null),
-        listRoles: () => Effect.succeed([]),
-        getRole: () => Effect.succeed(null),
-        getRoleByName: mockGetRoleByName as never,
-        createRole: () => Effect.die(new Error("not configured")),
-        updateRole: () => Effect.die(new Error("not configured")),
-        deleteRole: () => Effect.succeed(true),
-        listRoleMembers: () => Effect.succeed([]),
-        assignRole: mockAssignRole as never,
-      } as never),
-      Layer.succeed(services.IpAllowlistPolicy, {
-        available: false,
-        checkIPAllowlist: () => Effect.succeed({ allowed: true }),
-      } as never),
-      Layer.succeed(services.SSOPolicy, {
-        available: false,
-        extractEmailDomain: (email: string) => {
-          const at = email.lastIndexOf("@");
-          return at > 0 ? email.slice(at + 1).toLowerCase() : null;
-        },
-        isSSOEnforcedForDomain: () => Effect.succeed({ enforced: false }),
-        isSSOEnforced: () => Effect.succeed({ enforced: false }),
-      } as never),
-      Layer.succeed(services.SCIMProvenance, {
-        available: false,
-        isSCIMProvisioned: () => Effect.succeed(false),
-      } as never),
-    ),
+    EnterpriseLayer: testLayer,
+    getEnterpriseRuntime: () => testRuntime,
+    runEnterprise: (program: never) => testRuntime.runPromise(program),
+    runEnterpriseExit: (program: never) => testRuntime.runPromiseExit(program),
+    __resetEnterpriseRuntimeForTesting: () => {},
   };
 });
 

--- a/packages/api/src/api/routes/admin-action-retention.ts
+++ b/packages/api/src/api/routes/admin-action-retention.ts
@@ -33,17 +33,15 @@
 
 import { Effect } from "effect";
 import { createRoute, z } from "@hono/zod-openapi";
-import { RetentionError } from "@atlas/api/lib/audit/retention-errors";
 import type { AnonymizeInitiatedBy } from "@useatlas/types";
 import { AuditRetention } from "@atlas/api/lib/effect/services";
-import { runEffect, domainError } from "@atlas/api/lib/effect/hono";
+import { runEffect } from "@atlas/api/lib/effect/hono";
 import { AuthContext } from "@atlas/api/lib/effect/services";
 import { logAdminActionAwait, ADMIN_ACTIONS, type AdminActionEntry } from "@atlas/api/lib/audit";
 import { createLogger } from "@atlas/api/lib/logger";
 import { ErrorSchema, AuthErrorSchema } from "./shared-schemas";
 import { createAdminRouter, requireOrgContext, requirePermission } from "./admin-router";
-
-const retentionDomainError = domainError(RetentionError, { validation: 400, not_found: 404 });
+import { retentionDomainError } from "./shared-retention";
 
 const log = createLogger("admin-action-retention");
 

--- a/packages/api/src/api/routes/admin-audit-retention.ts
+++ b/packages/api/src/api/routes/admin-audit-retention.ts
@@ -14,16 +14,14 @@
 
 import { Effect } from "effect";
 import { createRoute, z } from "@hono/zod-openapi";
-import { RetentionError } from "@atlas/api/lib/audit/retention-errors";
 import { AuditRetention } from "@atlas/api/lib/effect/services";
-import { runEffect, domainError } from "@atlas/api/lib/effect/hono";
+import { runEffect } from "@atlas/api/lib/effect/hono";
 import { AuthContext } from "@atlas/api/lib/effect/services";
 import { logAdminActionAwait, ADMIN_ACTIONS, type AdminActionEntry } from "@atlas/api/lib/audit";
 import { createLogger } from "@atlas/api/lib/logger";
 import { ErrorSchema, AuthErrorSchema } from "./shared-schemas";
 import { createAdminRouter, requireOrgContext, requirePermission } from "./admin-router";
-
-const retentionDomainError = domainError(RetentionError, { validation: 400, not_found: 404 });
+import { retentionDomainError } from "./shared-retention";
 
 const log = createLogger("admin-audit-retention");
 

--- a/packages/api/src/api/routes/admin-auth.ts
+++ b/packages/api/src/api/routes/admin-auth.ts
@@ -15,7 +15,7 @@ import {
 } from "@atlas/api/lib/auth/middleware";
 import { Effect } from "effect";
 import { IpAllowlistPolicy } from "@atlas/api/lib/effect/services";
-import { EnterpriseLayer } from "@atlas/api/lib/effect/enterprise-layer";
+import { runEnterprise } from "@atlas/api/lib/effect/enterprise-layer";
 
 const log = createLogger("admin-auth");
 
@@ -84,11 +84,11 @@ export async function adminAuthPreamble(req: Request, requestId: string) {
   // EE-not-loaded both flow through the no-op default which always allows.
   const orgId = authResult.user?.activeOrganizationId;
   if (orgId) {
-    const ipCheck = await Effect.runPromise(
+    const ipCheck = await runEnterprise(
       Effect.gen(function* () {
         const policy = yield* IpAllowlistPolicy;
         return yield* policy.checkIPAllowlist(orgId, ip);
-      }).pipe(Effect.provide(EnterpriseLayer)),
+      }),
     );
     if (!ipCheck.allowed) {
       log.warn({ requestId, orgId, ip }, "IP not in workspace allowlist");

--- a/packages/api/src/api/routes/admin-proactive.ts
+++ b/packages/api/src/api/routes/admin-proactive.ts
@@ -308,25 +308,11 @@ adminProactive.use(requireOrgContext());
 adminProactive.use(requirePermission("admin:settings"));
 
 /**
- * Enterprise gate. Sync throw inside the `runHandler` body so a
- * `runHandler` → `Effect.tryPromise` → defect-classification path lands
- * on `EnterpriseError` directly (its `name === "EnterpriseError"`
- * survives the `Error` re-wrap) and maps to 403 `enterprise_required`
- * via `classifyError`. The flag is re-read per call so a runtime flip
- * propagates without restart.
- *
- * The other three admin-proactive route files (analytics, pauses,
- * public-dataset) yield the `ProactiveGate` Tag because they use
- * `runEffect` + Effect.gen; this file's `runHandler`-based handlers
- * can't yield the Tag without a separate sync runtime
- * (`ConditionalEELayer` is async due to the lazy EE-layer import), so
- * the equivalent sync check is inlined here. The resulting
- * `EnterpriseError` has identical `_tag` + payload to the one the Tag
- * would produce.
- *
- * Uses the canonical `isEnterpriseEnabled` reader from
- * `lib/effect/enterprise-config.ts` — see #2594 for the consolidation
- * that retired the local `isEnterpriseEnabledSync` fork.
+ * Sync enterprise gate. Sibling admin-proactive route files use
+ * `runEffect` + `yield* ProactiveGate`; this file's `runHandler`-based
+ * handlers can't yield the Tag (ConditionalEELayer is async via the
+ * lazy EE-layer import), so the equivalent sync check is inlined.
+ * Resulting `EnterpriseError` has the same `_tag` + payload as the Tag.
  */
 function gateEnterprise(): void {
   if (!isEnterpriseEnabled()) {

--- a/packages/api/src/api/routes/admin-proactive.ts
+++ b/packages/api/src/api/routes/admin-proactive.ts
@@ -325,7 +325,7 @@ adminProactive.use(requirePermission("admin:settings"));
  * would produce.
  *
  * Uses the canonical `isEnterpriseEnabled` reader from
- * `lib/effect/enterprise-config.ts` — see #2587 for the consolidation
+ * `lib/effect/enterprise-config.ts` — see #2594 for the consolidation
  * that retired the local `isEnterpriseEnabledSync` fork.
  */
 function gateEnterprise(): void {

--- a/packages/api/src/api/routes/admin-proactive.ts
+++ b/packages/api/src/api/routes/admin-proactive.ts
@@ -34,7 +34,7 @@ import { createRoute, z } from "@hono/zod-openapi";
 import { createLogger } from "@atlas/api/lib/logger";
 import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
 import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
-import { getConfig } from "@atlas/api/lib/config";
+import { isEnterpriseEnabled } from "@atlas/api/lib/effect/enterprise-config";
 import { internalQuery } from "@atlas/api/lib/db/internal";
 import { runHandler } from "@atlas/api/lib/effect/hono";
 import { EnterpriseError } from "@atlas/api/lib/effect/errors";
@@ -315,27 +315,21 @@ adminProactive.use(requirePermission("admin:settings"));
  * via `classifyError`. The flag is re-read per call so a runtime flip
  * propagates without restart.
  *
- * Post-#2572 (slice 10/11 of #2017) this reads the enterprise flag
- * directly from `getConfig()` / `ATLAS_ENTERPRISE_ENABLED` rather than
- * dynamic-importing `@atlas/ee/index`. The other three admin-proactive
- * route files (analytics, pauses, public-dataset) yield the
- * `ProactiveGate` Tag because they already use `runEffect` + Effect.gen;
- * this file's `runHandler`-based handlers can't yield the Tag without a
- * separate sync runtime (`ConditionalEELayer` is async due to the lazy
- * EE-layer import), so we keep the equivalent sync check inline. The
- * resulting `EnterpriseError` has identical `_tag` + payload to the
- * one the Tag would produce.
+ * The other three admin-proactive route files (analytics, pauses,
+ * public-dataset) yield the `ProactiveGate` Tag because they use
+ * `runEffect` + Effect.gen; this file's `runHandler`-based handlers
+ * can't yield the Tag without a separate sync runtime
+ * (`ConditionalEELayer` is async due to the lazy EE-layer import), so
+ * the equivalent sync check is inlined here. The resulting
+ * `EnterpriseError` has identical `_tag` + payload to the one the Tag
+ * would produce.
+ *
+ * Uses the canonical `isEnterpriseEnabled` reader from
+ * `lib/effect/enterprise-config.ts` — see #2587 for the consolidation
+ * that retired the local `isEnterpriseEnabledSync` fork.
  */
-function isEnterpriseEnabledSync(): boolean {
-  const config = getConfig();
-  if (config?.enterprise?.enabled !== undefined) {
-    return config.enterprise.enabled;
-  }
-  return process.env.ATLAS_ENTERPRISE_ENABLED === "true";
-}
-
 function gateEnterprise(): void {
-  if (!isEnterpriseEnabledSync()) {
+  if (!isEnterpriseEnabled()) {
     throw new EnterpriseError(
       "Enterprise features (proactive-chat) are not enabled. " +
         "Set ATLAS_ENTERPRISE_ENABLED=true or configure enterprise.enabled in atlas.config.ts.",

--- a/packages/api/src/api/routes/admin-router.ts
+++ b/packages/api/src/api/routes/admin-router.ts
@@ -39,7 +39,7 @@ import { mfaRequired } from "./admin-mfa-required";
 import type { Permission } from "@atlas/api/lib/auth/permissions";
 import type { AtlasUser } from "@atlas/api/lib/auth/types";
 import { RolesPolicy } from "@atlas/api/lib/effect/services";
-import { EnterpriseLayer } from "@atlas/api/lib/effect/enterprise-layer";
+import { runEnterprise } from "@atlas/api/lib/effect/enterprise-layer";
 
 const log = createLogger("admin-router:permission");
 
@@ -210,7 +210,7 @@ export function requirePermission(permission: Permission) {
     // envelope, preserving F-53 fail-closed semantics.
     let result: { body: Record<string, unknown>; status: 403 | 503 } | null;
     try {
-      result = await Effect.runPromise(
+      result = await runEnterprise(
         Effect.gen(function* () {
           const roles = yield* RolesPolicy;
           return yield* roles.checkPermission(
@@ -218,7 +218,7 @@ export function requirePermission(permission: Permission) {
             permission,
             requestId,
           );
-        }).pipe(Effect.provide(EnterpriseLayer)),
+        }),
       );
     } catch (err) {
       // Defect inside the Effect (e.g. unexpected throw) — fail closed with
@@ -261,11 +261,11 @@ export async function enforcePermission(
   requestId: string,
 ): Promise<{ body: Record<string, unknown>; status: 403 | 503 } | null> {
   try {
-    return await Effect.runPromise(
+    return await runEnterprise(
       Effect.gen(function* () {
         const roles = yield* RolesPolicy;
         return yield* roles.checkPermission(user, permission, requestId);
-      }).pipe(Effect.provide(EnterpriseLayer)),
+      }),
     );
   } catch (err) {
     log.error(

--- a/packages/api/src/api/routes/auth-preamble.ts
+++ b/packages/api/src/api/routes/auth-preamble.ts
@@ -15,7 +15,7 @@ import {
 } from "@atlas/api/lib/auth/middleware";
 import { Effect } from "effect";
 import { IpAllowlistPolicy } from "@atlas/api/lib/effect/services";
-import { EnterpriseLayer } from "@atlas/api/lib/effect/enterprise-layer";
+import { runEnterprise } from "@atlas/api/lib/effect/enterprise-layer";
 
 const log = createLogger("auth-preamble");
 
@@ -69,11 +69,11 @@ export async function authPreamble(
   // IP allowlist — via `IpAllowlistPolicy` Tag (#2570).
   const orgId = authResult.user?.activeOrganizationId;
   if (orgId) {
-    const ipCheck = await Effect.runPromise(
+    const ipCheck = await runEnterprise(
       Effect.gen(function* () {
         const policy = yield* IpAllowlistPolicy;
         return yield* policy.checkIPAllowlist(orgId, ip);
-      }).pipe(Effect.provide(EnterpriseLayer)),
+      }),
     );
     if (!ipCheck.allowed) {
       log.warn({ requestId, orgId, ip }, "IP not in workspace allowlist");

--- a/packages/api/src/api/routes/middleware.ts
+++ b/packages/api/src/api/routes/middleware.ts
@@ -32,7 +32,7 @@ import {
 import { isWorkspaceMigrating } from "@atlas/api/lib/residency/readonly";
 import { Effect } from "effect";
 import { IpAllowlistPolicy } from "@atlas/api/lib/effect/services";
-import { EnterpriseLayer } from "@atlas/api/lib/effect/enterprise-layer";
+import { runEnterprise } from "@atlas/api/lib/effect/enterprise-layer";
 
 const log = createLogger("middleware");
 
@@ -157,11 +157,11 @@ async function rateLimitAndIPCheck(
   if (orgId) {
     let ipCheck: { allowed: boolean } | null = null;
     try {
-      ipCheck = await Effect.runPromise(
+      ipCheck = await runEnterprise(
         Effect.gen(function* () {
           const policy = yield* IpAllowlistPolicy;
           return yield* policy.checkIPAllowlist(orgId, ip);
-        }).pipe(Effect.provide(EnterpriseLayer)),
+        }),
       );
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);

--- a/packages/api/src/api/routes/middleware.ts
+++ b/packages/api/src/api/routes/middleware.ts
@@ -139,20 +139,10 @@ async function rateLimitAndIPCheck(
     };
   }
 
-  // IP allowlist — via `IpAllowlistPolicy` Tag (#2570). Self-hosted +
-  // EE-disabled flow through the no-op default which always allows. The
-  // narrow `catch` is a defensive net for tests that shim `effect` /
-  // `EnterpriseLayer` without providing `IpAllowlistPolicy` (surfaces as
-  // an Effect "Service not found" defect); a fail-closed 503 covers any
-  // other error so a real production failure of the EE-loaded path or
-  // a backend DB outage surfaces loudly. Sibling call sites in
-  // `admin-auth.ts`, `auth-preamble.ts`, and `chat.ts` don't try/catch
-  // at all and 500 on the same failure mode — this file accepts the
-  // narrower fail-closed contract because middleware runs ahead of
-  // routes that may not have provided the Tag in their test layer (see
-  // #2588 — future follow-up extracts a shared `makeTestEnterpriseLayer`
-  // helper so every test provides the full Tag set and this defensive
-  // catch can be deleted).
+  // IP allowlist — narrow `catch` for tests that omit `IpAllowlistPolicy`
+  // from their EnterpriseLayer mock (Effect surfaces this as "Service
+  // not found: IpAllowlistPolicy"). Everything else fails closed via 503.
+  // To be deleted once #2588 (`makeTestEnterpriseLayer`) lands.
   const orgId = authResult.user?.activeOrganizationId;
   if (orgId) {
     let ipCheck: { allowed: boolean } | null = null;
@@ -165,23 +155,12 @@ async function rateLimitAndIPCheck(
       );
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
-      // Test-harness signals: the test omitted a Tag, partially mocked
-      // `@atlas/ee/*` (so EE-layer construction fails to find a real
-      // export), or shimmed the EE module aggregator. None of these
-      // happen in production — they're test-isolation artifacts.
-      //
-      // Production failure modes (DB outage in checkIPAllowlist, a
-      // genuine bug in `IpAllowlistPolicyLive`, etc.) don't match these
-      // patterns and fail closed below.
-      const isTestHarnessSignal =
-        (msg.includes("Service not found") && msg.includes("IpAllowlist")) ||
-        msg.includes("Cannot find module") ||
-        msg.includes("MODULE_NOT_FOUND") ||
-        msg.includes("@atlas/ee");
-      if (isTestHarnessSignal) {
+      const isMissingTag =
+        msg.includes("Service not found") && msg.includes("IpAllowlist");
+      if (isMissingTag) {
         log.warn(
           { err: msg, requestId, orgId },
-          "IpAllowlist check unreachable — test-harness fall-through (mock setup partial)",
+          "IpAllowlist Tag not provided — test-harness fall-through",
         );
       } else {
         log.error(

--- a/packages/api/src/api/routes/middleware.ts
+++ b/packages/api/src/api/routes/middleware.ts
@@ -150,7 +150,7 @@ async function rateLimitAndIPCheck(
   // at all and 500 on the same failure mode — this file accepts the
   // narrower fail-closed contract because middleware runs ahead of
   // routes that may not have provided the Tag in their test layer (see
-  // #2587 — future follow-up extracts a shared `makeTestEnterpriseLayer`
+  // #2588 — future follow-up extracts a shared `makeTestEnterpriseLayer`
   // helper so every test provides the full Tag set and this defensive
   // catch can be deleted).
   const orgId = authResult.user?.activeOrganizationId;

--- a/packages/api/src/api/routes/middleware.ts
+++ b/packages/api/src/api/routes/middleware.ts
@@ -165,14 +165,23 @@ async function rateLimitAndIPCheck(
       );
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
-      // Test-harness signal: the test omitted the IpAllowlistPolicy Tag.
-      // Effect surfaces this as "Service not found" in the defect chain.
-      // Everything else (DB outage, EE-load failure on SaaS, etc.) is a
-      // real production failure — fail closed.
-      if (msg.includes("Service not found") && msg.includes("IpAllowlistPolicy")) {
+      // Test-harness signals: the test omitted a Tag, partially mocked
+      // `@atlas/ee/*` (so EE-layer construction fails to find a real
+      // export), or shimmed the EE module aggregator. None of these
+      // happen in production — they're test-isolation artifacts.
+      //
+      // Production failure modes (DB outage in checkIPAllowlist, a
+      // genuine bug in `IpAllowlistPolicyLive`, etc.) don't match these
+      // patterns and fail closed below.
+      const isTestHarnessSignal =
+        (msg.includes("Service not found") && msg.includes("IpAllowlist")) ||
+        msg.includes("Cannot find module") ||
+        msg.includes("MODULE_NOT_FOUND") ||
+        msg.includes("@atlas/ee");
+      if (isTestHarnessSignal) {
         log.warn(
           { err: msg, requestId, orgId },
-          "IpAllowlistPolicy Tag not provided — test-harness fall-through (no-op default missing)",
+          "IpAllowlist check unreachable — test-harness fall-through (mock setup partial)",
         );
       } else {
         log.error(

--- a/packages/api/src/api/routes/middleware.ts
+++ b/packages/api/src/api/routes/middleware.ts
@@ -140,12 +140,19 @@ async function rateLimitAndIPCheck(
   }
 
   // IP allowlist — via `IpAllowlistPolicy` Tag (#2570). Self-hosted +
-  // EE-not-loaded both flow through the no-op default which always allows.
-  // The try/catch is a defensive net for tests that shim `effect` /
-  // `EnterpriseLayer` without wiring the full Layer machinery; in
-  // production the EE-loaded path and the no-op default both succeed,
-  // so a runPromise reject here is a test-harness signal rather than a
-  // real allowlist outcome.
+  // EE-disabled flow through the no-op default which always allows. The
+  // narrow `catch` is a defensive net for tests that shim `effect` /
+  // `EnterpriseLayer` without providing `IpAllowlistPolicy` (surfaces as
+  // an Effect "Service not found" defect); a fail-closed 503 covers any
+  // other error so a real production failure of the EE-loaded path or
+  // a backend DB outage surfaces loudly. Sibling call sites in
+  // `admin-auth.ts`, `auth-preamble.ts`, and `chat.ts` don't try/catch
+  // at all and 500 on the same failure mode — this file accepts the
+  // narrower fail-closed contract because middleware runs ahead of
+  // routes that may not have provided the Tag in their test layer (see
+  // #2587 — future follow-up extracts a shared `makeTestEnterpriseLayer`
+  // helper so every test provides the full Tag set and this defensive
+  // catch can be deleted).
   const orgId = authResult.user?.activeOrganizationId;
   if (orgId) {
     let ipCheck: { allowed: boolean } | null = null;
@@ -157,10 +164,30 @@ async function rateLimitAndIPCheck(
         }).pipe(Effect.provide(EnterpriseLayer)),
       );
     } catch (err) {
-      log.warn(
-        { err: err instanceof Error ? err.message : String(err), requestId, orgId },
-        "IP allowlist check unavailable — falling through (fail-open in test harness only)",
-      );
+      const msg = err instanceof Error ? err.message : String(err);
+      // Test-harness signal: the test omitted the IpAllowlistPolicy Tag.
+      // Effect surfaces this as "Service not found" in the defect chain.
+      // Everything else (DB outage, EE-load failure on SaaS, etc.) is a
+      // real production failure — fail closed.
+      if (msg.includes("Service not found") && msg.includes("IpAllowlistPolicy")) {
+        log.warn(
+          { err: msg, requestId, orgId },
+          "IpAllowlistPolicy Tag not provided — test-harness fall-through (no-op default missing)",
+        );
+      } else {
+        log.error(
+          { err: msg, requestId, orgId },
+          "IP allowlist check failed — failing closed (no allowlist evaluation)",
+        );
+        return {
+          body: {
+            error: "service_unavailable",
+            message: "IP allowlist check could not be evaluated. Try again in a moment.",
+            requestId,
+          },
+          status: 503,
+        };
+      }
     }
     if (ipCheck && !ipCheck.allowed) {
       log.warn({ requestId, orgId, ip }, "IP not in workspace allowlist");

--- a/packages/api/src/api/routes/shared-retention.ts
+++ b/packages/api/src/api/routes/shared-retention.ts
@@ -1,15 +1,9 @@
 /**
- * Shared retention infrastructure — typed domain-error mapping used by
- * both `admin-audit-retention.ts` (audit_log governance) and
- * `admin-action-retention.ts` (admin_action_log governance + GDPR
- * erasure).
- *
- * Pre-#2594 each route file declared its own
- * `const retentionDomainError = domainError(RetentionError, ...)` with
- * identical statusMap. Promoting the constant prevents the two from
- * drifting (`domainError`'s `TCode` inference means a missing code is
- * already a `tsgo` error, but only at the call site — having two call
- * sites means a change must land in both).
+ * Shared `RetentionError`-to-HTTP mapping. `domainError`'s `TCode`
+ * inference enforces exhaustiveness per call site; promoting prevents
+ * the two retention route families (audit_log + admin_action_log) from
+ * drifting on the statusMap. Mirrors `shared-residency.ts` /
+ * `shared-domains.ts`.
  */
 
 import { domainError, type DomainErrorMapping } from "@atlas/api/lib/effect/hono";

--- a/packages/api/src/api/routes/shared-retention.ts
+++ b/packages/api/src/api/routes/shared-retention.ts
@@ -4,7 +4,7 @@
  * `admin-action-retention.ts` (admin_action_log governance + GDPR
  * erasure).
  *
- * Pre-#2587 each route file declared its own
+ * Pre-#2594 each route file declared its own
  * `const retentionDomainError = domainError(RetentionError, ...)` with
  * identical statusMap. Promoting the constant prevents the two from
  * drifting (`domainError`'s `TCode` inference means a missing code is

--- a/packages/api/src/api/routes/shared-retention.ts
+++ b/packages/api/src/api/routes/shared-retention.ts
@@ -1,0 +1,21 @@
+/**
+ * Shared retention infrastructure — typed domain-error mapping used by
+ * both `admin-audit-retention.ts` (audit_log governance) and
+ * `admin-action-retention.ts` (admin_action_log governance + GDPR
+ * erasure).
+ *
+ * Pre-#2587 each route file declared its own
+ * `const retentionDomainError = domainError(RetentionError, ...)` with
+ * identical statusMap. Promoting the constant prevents the two from
+ * drifting (`domainError`'s `TCode` inference means a missing code is
+ * already a `tsgo` error, but only at the call site — having two call
+ * sites means a change must land in both).
+ */
+
+import { domainError, type DomainErrorMapping } from "@atlas/api/lib/effect/hono";
+import { RetentionError } from "@atlas/api/lib/audit/retention-errors";
+
+export const retentionDomainError: DomainErrorMapping = domainError(RetentionError, {
+  validation: 400,
+  not_found: 404,
+});

--- a/packages/api/src/lib/agent.ts
+++ b/packages/api/src/lib/agent.ts
@@ -48,7 +48,7 @@ import {
 } from "@opentelemetry/api";
 import { AtlasAiModel, type AtlasAiModelShape } from "./effect/ai";
 import { ModelRouter } from "./effect/services";
-import { EnterpriseLayer } from "./effect/enterprise-layer";
+import { runEnterprise } from "./effect/enterprise-layer";
 import { BOUND_AGENT_PROMPT_GUIDANCE } from "./bound-chat-context";
 
 const log = createLogger("agent");
@@ -680,9 +680,7 @@ export async function runAgent({
         return yield* router.getWorkspaceModelConfigRaw(orgId);
       });
       try {
-        workspaceConfig = await Effect.runPromise(
-          program.pipe(Effect.provide(EnterpriseLayer)),
-        );
+        workspaceConfig = await runEnterprise(program);
       } catch (err) {
         if (err instanceof ModelConfigDecryptError) {
           throw new Error(

--- a/packages/api/src/lib/auth/middleware.ts
+++ b/packages/api/src/lib/auth/middleware.ts
@@ -17,7 +17,7 @@ import { createLogger } from "@atlas/api/lib/logger";
 import { getSetting } from "@atlas/api/lib/settings";
 import { Effect } from "effect";
 import { SSOPolicy } from "@atlas/api/lib/effect/services";
-import { EnterpriseLayer } from "@atlas/api/lib/effect/enterprise-layer";
+import { runEnterprise } from "@atlas/api/lib/effect/enterprise-layer";
 import { logAdminActionAwait, type AdminActionEntry } from "@atlas/api/lib/audit";
 import type { AuthMode } from "@useatlas/types";
 
@@ -371,10 +371,10 @@ async function checkSSOEnforcement(
   authMode: SSOEnforceableMode,
 ): Promise<AuthResult | null> {
   try {
-    const sso = await Effect.runPromise(
+    const sso = await runEnterprise(
       Effect.gen(function* () {
         return yield* SSOPolicy;
-      }).pipe(Effect.provide(EnterpriseLayer)),
+      }),
     );
     const domain = sso.extractEmailDomain(userLabel);
     if (!domain) return null;

--- a/packages/api/src/lib/db/connection.ts
+++ b/packages/api/src/lib/db/connection.ts
@@ -25,7 +25,7 @@ import { hasInternalDB, internalQuery } from "@atlas/api/lib/db/internal";
 import { getConfig } from "@atlas/api/lib/config";
 import type { HealthStatus } from "@atlas/api/lib/connection-types";
 import { ResidencyResolver } from "@atlas/api/lib/effect/services";
-import { EnterpriseLayer } from "@atlas/api/lib/effect/enterprise-layer";
+import { runEnterprise } from "@atlas/api/lib/effect/enterprise-layer";
 
 export type { HealthStatus } from "@atlas/api/lib/connection-types";
 
@@ -1445,9 +1445,7 @@ export async function getRegionAwareConnection(
 
   let regionInfo: { databaseUrl: string; datasourceUrl?: string; region: string } | null;
   try {
-    regionInfo = await Effect.runPromise(
-      resolveRegion.pipe(Effect.provide(EnterpriseLayer)),
-    );
+    regionInfo = await runEnterprise(resolveRegion);
   } catch (err) {
     log.warn(
       { err: errorMessage(err), orgId },

--- a/packages/api/src/lib/effect/__tests__/noop-layers.test.ts
+++ b/packages/api/src/lib/effect/__tests__/noop-layers.test.ts
@@ -93,7 +93,9 @@ describe("NoopMaskingPolicyLayer", () => {
     const rows = [{ id: 1, ssn: "111-22-3333" }];
     const program = Effect.gen(function* () {
       const masking = yield* MaskingPolicy;
-      return yield* masking.applyMasking({ rows, orgId: "o", tables: [], columns: [] });
+      return yield* masking.applyMasking({
+        rows, orgId: "o", tablesAccessed: [], columns: [], userRole: "admin",
+      });
     });
     const exit = await runWithLayer(program, NoopMaskingPolicyLayer);
     expect(Exit.isSuccess(exit)).toBe(true);
@@ -111,7 +113,7 @@ describe("NoopAuditRetentionLayer", () => {
   it("anonymizeUserAdminActions fails with EnterpriseError (NOT silently succeeds)", async () => {
     const program = Effect.gen(function* () {
       const r = yield* AuditRetention;
-      return yield* r.anonymizeUserAdminActions("user-1", "platform_admin");
+      return yield* r.anonymizeUserAdminActions("user-1", "dsr_request");
     });
     const exit = await runWithLayer(program, NoopAuditRetentionLayer);
     expectTypedFailure(exit, "EnterpriseError");

--- a/packages/api/src/lib/effect/__tests__/noop-layers.test.ts
+++ b/packages/api/src/lib/effect/__tests__/noop-layers.test.ts
@@ -1,0 +1,254 @@
+/**
+ * Regression suite for the enterprise Noop layers' fix-up in PR #2594.
+ *
+ * The bugs caught during the milestone-#48 cross-slice review (and
+ * fixed in this PR) were all silent-failure-shaped:
+ *
+ *   - `MaskingPolicy` no-op spread `[...ctx.rows]` broke the
+ *     `maskingApplied = maskedRows !== result.rows` reference-identity
+ *     contract in `tools/sql.ts`, falsely reporting `maskingApplied: true`
+ *     on every self-hosted query against a classified table.
+ *
+ *   - `AuditRetention.anonymizeUserAdminActions` returned
+ *     `Effect.succeed({ anonymizedRowCount: 0 })` so a GDPR erasure
+ *     request appeared to complete while leaving every row in place AND
+ *     emitting no forensic audit row.
+ *
+ *   - Several Noop methods used `Effect.die(...)` for the "EE not
+ *     installed" path. `Effect.die` produces a defect that bypasses the
+ *     typed error channel and `Effect.catchAll`, so a route that catches
+ *     would still see an opaque 500 instead of a clean 403 EnterpriseError.
+ *
+ *   - 7 destructive Noop methods (`deleteWorkspaceModelConfig`,
+ *     `deleteApprovalRule`, `acknowledgeAlert`, `removeIPAllowlistEntry`,
+ *     `deleteSSOProvider`, SCIM `deleteConnection`/`deleteGroupMapping`)
+ *     returned `Effect.succeed(false)` → routes mapped to 404, silently
+ *     lying that the resource was already gone.
+ *
+ * The fixes are documented in the per-commit messages; this file pins
+ * them so a future "simplify the Noop layer" PR doesn't regress them
+ * with passing tests elsewhere.
+ *
+ * Strategy: each test resolves the Noop layer's service via
+ * `Effect.provide(<Tag>, NoopXxxLayer)`, calls the method, and asserts
+ * either reference identity (Masking) or that the failure is an
+ * `Effect.fail(EnterpriseError)` typed failure — not an `Effect.die`
+ * defect.
+ */
+
+import { describe, it, expect } from "bun:test";
+import { Cause, Effect, Exit, Layer } from "effect";
+import {
+  NoopApprovalGateLayer,
+  NoopAuditRetentionLayer,
+  NoopBackupsManagerLayer,
+  NoopIpAllowlistPolicyLayer,
+  NoopMaskingPolicyLayer,
+  NoopModelRouterLayer,
+  NoopSCIMProvenanceLayer,
+  NoopSlaMetricsLayer,
+  NoopSSOPolicyLayer,
+  ApprovalGate,
+  AuditRetention,
+  BackupsManager,
+  IpAllowlistPolicy,
+  MaskingPolicy,
+  ModelRouter,
+  SCIMProvenance,
+  SlaMetrics,
+  SSOPolicy,
+} from "../services";
+
+/**
+ * Run `program` against `layer` and return the Exit so tests can assert
+ * on the failure cause (typed failure vs defect) instead of just
+ * succeed/fail.
+ */
+function runWithLayer<A, E, R>(
+  program: Effect.Effect<A, E, R>,
+  layer: Layer.Layer<R>,
+): Promise<Exit.Exit<A, E>> {
+  return Effect.runPromiseExit(program.pipe(Effect.provide(layer)));
+}
+
+/** Assert an Exit is a typed failure (Effect.fail), not a defect (Effect.die). */
+function expectTypedFailure(exit: Exit.Exit<unknown, unknown>, expectedTag: string): void {
+  expect(Exit.isFailure(exit)).toBe(true);
+  if (!Exit.isFailure(exit)) return;
+  const failure = Cause.failureOption(exit.cause);
+  expect(failure._tag).toBe("Some");
+  if (failure._tag !== "Some") return;
+  const err = failure.value as { readonly _tag?: string };
+  expect(err._tag).toBe(expectedTag);
+  // Crucial: there must be no defect in the cause — `Effect.die` would
+  // surface here and bypass route-layer `catchAll`.
+  const defects = Array.from(Cause.defects(exit.cause));
+  expect(defects).toHaveLength(0);
+}
+
+// ── MaskingPolicy — reference identity (the `maskingApplied` audit bug) ──
+
+describe("NoopMaskingPolicyLayer", () => {
+  it("applyMasking returns the SAME rows reference (preserves `maskingApplied = maskedRows !== result.rows` contract)", async () => {
+    const rows = [{ id: 1, ssn: "111-22-3333" }];
+    const program = Effect.gen(function* () {
+      const masking = yield* MaskingPolicy;
+      return yield* masking.applyMasking({ rows, orgId: "o", tables: [], columns: [] });
+    });
+    const exit = await runWithLayer(program, NoopMaskingPolicyLayer);
+    expect(Exit.isSuccess(exit)).toBe(true);
+    if (Exit.isSuccess(exit)) {
+      // `Object.is` is what `!==` checks. A spread (`[...rows]`) would
+      // break this even though the contents are equal.
+      expect(Object.is(exit.value, rows)).toBe(true);
+    }
+  });
+});
+
+// ── AuditRetention — GDPR pretend-succeed regression ──────────────
+
+describe("NoopAuditRetentionLayer", () => {
+  it("anonymizeUserAdminActions fails with EnterpriseError (NOT silently succeeds)", async () => {
+    const program = Effect.gen(function* () {
+      const r = yield* AuditRetention;
+      return yield* r.anonymizeUserAdminActions("user-1", "platform_admin");
+    });
+    const exit = await runWithLayer(program, NoopAuditRetentionLayer);
+    expectTypedFailure(exit, "EnterpriseError");
+  });
+
+  it.each([
+    "purgeExpiredEntries",
+    "hardDeleteExpired",
+    "purgeAdminActionExpired",
+    "previewAdminActionErasure",
+  ] as const)("%s fails with EnterpriseError (destructive op MUST NOT silent-succeed)", async (method) => {
+    const program = Effect.gen(function* () {
+      const r = yield* AuditRetention;
+      switch (method) {
+        case "purgeExpiredEntries":
+          return yield* r.purgeExpiredEntries();
+        case "hardDeleteExpired":
+          return yield* r.hardDeleteExpired();
+        case "purgeAdminActionExpired":
+          return yield* r.purgeAdminActionExpired();
+        case "previewAdminActionErasure":
+          return yield* r.previewAdminActionErasure("user-1");
+      }
+    });
+    const exit = await runWithLayer(program, NoopAuditRetentionLayer);
+    expectTypedFailure(exit, "EnterpriseError");
+  });
+
+  it("getRetentionPolicy returns null (pure read — 'no policy configured' is honest)", async () => {
+    const program = Effect.gen(function* () {
+      const r = yield* AuditRetention;
+      return yield* r.getRetentionPolicy("org-1");
+    });
+    const exit = await runWithLayer(program, NoopAuditRetentionLayer);
+    expect(Exit.isSuccess(exit)).toBe(true);
+    if (Exit.isSuccess(exit)) {
+      expect(exit.value).toBeNull();
+    }
+  });
+});
+
+// ── Destructive Noops that previously returned `succeed(false)` ──
+
+describe("destructive Noop methods now fail with EnterpriseError", () => {
+  it("ModelRouter.deleteWorkspaceModelConfig", async () => {
+    const program = Effect.gen(function* () {
+      const r = yield* ModelRouter;
+      return yield* r.deleteWorkspaceModelConfig("org-1");
+    });
+    expectTypedFailure(await runWithLayer(program, NoopModelRouterLayer), "EnterpriseError");
+  });
+
+  it("ApprovalGate.deleteApprovalRule", async () => {
+    const program = Effect.gen(function* () {
+      const r = yield* ApprovalGate;
+      return yield* r.deleteApprovalRule("org-1", "rule-1");
+    });
+    expectTypedFailure(await runWithLayer(program, NoopApprovalGateLayer), "EnterpriseError");
+  });
+
+  it("SlaMetrics.acknowledgeAlert", async () => {
+    const program = Effect.gen(function* () {
+      const r = yield* SlaMetrics;
+      return yield* r.acknowledgeAlert("alert-1", "actor-1");
+    });
+    expectTypedFailure(await runWithLayer(program, NoopSlaMetricsLayer), "EnterpriseError");
+  });
+
+  it("IpAllowlistPolicy.removeIPAllowlistEntry (SECURITY — admin must not silently believe IP was removed)", async () => {
+    const program = Effect.gen(function* () {
+      const r = yield* IpAllowlistPolicy;
+      return yield* r.removeIPAllowlistEntry("org-1", "entry-1");
+    });
+    expectTypedFailure(await runWithLayer(program, NoopIpAllowlistPolicyLayer), "EnterpriseError");
+  });
+
+  it("SSOPolicy.deleteSSOProvider (SECURITY — provider must not silently stay routing)", async () => {
+    const program = Effect.gen(function* () {
+      const r = yield* SSOPolicy;
+      return yield* r.deleteSSOProvider("org-1", "provider-1");
+    });
+    expectTypedFailure(await runWithLayer(program, NoopSSOPolicyLayer), "EnterpriseError");
+  });
+
+  it("SCIMProvenance.deleteConnection", async () => {
+    const program = Effect.gen(function* () {
+      const r = yield* SCIMProvenance;
+      return yield* r.deleteConnection("org-1", "conn-1");
+    });
+    expectTypedFailure(await runWithLayer(program, NoopSCIMProvenanceLayer), "EnterpriseError");
+  });
+
+  it("SCIMProvenance.deleteGroupMapping", async () => {
+    const program = Effect.gen(function* () {
+      const r = yield* SCIMProvenance;
+      return yield* r.deleteGroupMapping("org-1", "mapping-1");
+    });
+    expectTypedFailure(await runWithLayer(program, NoopSCIMProvenanceLayer), "EnterpriseError");
+  });
+});
+
+// ── Effect.die → Effect.fail conversions (slice 5/6/8) ──────────────
+
+describe("previously-Effect.die methods now fail through typed channel", () => {
+  it("ApprovalGate.createApprovalRequest", async () => {
+    const program = Effect.gen(function* () {
+      const g = yield* ApprovalGate;
+      return yield* g.createApprovalRequest({
+        orgId: "o", ruleId: "r", ruleName: "rn", requesterId: "u",
+        requesterEmail: null, querySql: "SELECT 1", explanation: null,
+        connectionId: null, tablesAccessed: [], columnsAccessed: [],
+      });
+    });
+    expectTypedFailure(await runWithLayer(program, NoopApprovalGateLayer), "EnterpriseError");
+  });
+
+  it("SlaMetrics.getWorkspaceSLADetail", async () => {
+    const program = Effect.gen(function* () {
+      const s = yield* SlaMetrics;
+      return yield* s.getWorkspaceSLADetail("w");
+    });
+    expectTypedFailure(await runWithLayer(program, NoopSlaMetricsLayer), "EnterpriseError");
+  });
+
+  it("BackupsManager.createBackup", async () => {
+    const program = Effect.gen(function* () {
+      const b = yield* BackupsManager;
+      return yield* b.createBackup();
+    });
+    expectTypedFailure(await runWithLayer(program, NoopBackupsManagerLayer), "EnterpriseError");
+  });
+
+  it("IpAllowlistPolicy.addIPAllowlistEntry", async () => {
+    const program = Effect.gen(function* () {
+      const p = yield* IpAllowlistPolicy;
+      return yield* p.addIPAllowlistEntry("o", "192.0.2.0/24", null, null);
+    });
+    expectTypedFailure(await runWithLayer(program, NoopIpAllowlistPolicyLayer), "EnterpriseError");
+  });
+});

--- a/packages/api/src/lib/effect/deploy-mode.ts
+++ b/packages/api/src/lib/effect/deploy-mode.ts
@@ -11,7 +11,7 @@
  * is enabled AND an internal database is configured.
  *
  * Reads the enterprise flag via the canonical `enterprise-config.ts`
- * helper (#2587 retired the local `isEnterpriseEnabledLocal` fork).
+ * helper (#2594 retired the local `isEnterpriseEnabledLocal` fork).
  * `hasInternalDBLocal` stays lazy-`require`'d to keep `lib/db/internal`
  * out of this file's eager dep graph.
  */

--- a/packages/api/src/lib/effect/deploy-mode.ts
+++ b/packages/api/src/lib/effect/deploy-mode.ts
@@ -10,31 +10,14 @@
  * `"self-hosted"`. `"auto"` returns `"saas"` only when BOTH enterprise
  * is enabled AND an internal database is configured.
  *
- * Lazy-requires the config + internal-DB modules to keep this file at
- * the bottom of the dep graph (same trick `enterprise-layer.ts` uses for
- * `isEnterpriseEnabledLocal`).
+ * Reads the enterprise flag via the canonical `enterprise-config.ts`
+ * helper (#2587 retired the local `isEnterpriseEnabledLocal` fork).
+ * `hasInternalDBLocal` stays lazy-`require`'d to keep `lib/db/internal`
+ * out of this file's eager dep graph.
  */
 
 import type { DeployMode, DeployModeSetting } from "@useatlas/types";
-
-/**
- * Read whether enterprise is enabled without importing from `@atlas/ee`.
- *
- * Mirrors `ee/src/index.ts:isEnterpriseEnabled` resolution order:
- *   1. `enterprise.enabled` in atlas.config.ts
- *   2. `ATLAS_ENTERPRISE_ENABLED` env var
- */
-function isEnterpriseEnabledLocal(): boolean {
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const { getConfig } = require("@atlas/api/lib/config") as {
-    getConfig: () => { enterprise?: { enabled?: boolean } } | null;
-  };
-  const config = getConfig();
-  if (config?.enterprise?.enabled !== undefined) {
-    return config.enterprise.enabled;
-  }
-  return process.env.ATLAS_ENTERPRISE_ENABLED === "true";
-}
+import { isEnterpriseEnabled } from "./enterprise-config";
 
 function hasInternalDBLocal(): boolean {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -64,11 +47,11 @@ export function resolveDeployMode(raw?: DeployModeSetting): DeployMode {
   }
 
   if (setting === "saas") {
-    return isEnterpriseEnabledLocal() ? "saas" : "self-hosted";
+    return isEnterpriseEnabled() ? "saas" : "self-hosted";
   }
 
   // "auto" — detect from environment
-  return isEnterpriseEnabledLocal() && hasInternalDBLocal()
+  return isEnterpriseEnabled() && hasInternalDBLocal()
     ? "saas"
     : "self-hosted";
 }

--- a/packages/api/src/lib/effect/enterprise-layer.ts
+++ b/packages/api/src/lib/effect/enterprise-layer.ts
@@ -88,6 +88,9 @@ function isEnterpriseEnabledLocal(): boolean {
  *   - ApprovalGate no-op never requires approval
  *   - ResidencyResolver no-op returns null (route falls back to default
  *     datasource — compliance break on EU workspaces)
+ *   - AuditRetention pure-read methods return null (mutating + destructive
+ *     methods now fail loudly post-#2594, but `getRetentionPolicy` would
+ *     still report "no policy" instead of the real one stored in the DB)
  *
  * Hardening this is tracked in #2589 — consumer-side "available"
  * discriminator checks at each load-bearing call site. The change is

--- a/packages/api/src/lib/effect/enterprise-layer.ts
+++ b/packages/api/src/lib/effect/enterprise-layer.ts
@@ -62,19 +62,44 @@ function isEnterpriseEnabledLocal(): boolean {
 }
 
 /**
- * Conditional EE Layer. When enterprise is enabled, lazy-imports
- * `@atlas/ee/layers` and exposes its `EELayer`. Otherwise falls back to
- * `Layer.empty`. Wrapped in `Layer.unwrapEffect` so the dynamic import
- * is deferred to Layer construction time (not module load), and a
- * missing/broken `@atlas/ee` install never fails core startup — the
- * catch arm logs and falls back to the empty Layer, leaving the no-op
- * defaults from `NoopEnterpriseDefaultsLayer` in effect.
+ * Conditional EE Layer.
+ *
+ * - When enterprise is DISABLED, returns `Layer.empty`. The no-op
+ *   defaults from `NoopEnterpriseDefaultsLayer` cover every Tag and
+ *   self-hosted runs unchanged.
+ * - When enterprise is ENABLED, lazy-imports `@atlas/ee/layers` and
+ *   exposes its `EELayer`. The dynamic import is deferred to Layer
+ *   construction time (not module load) so a missing `@atlas/ee/`
+ *   build doesn't break core's module graph.
+ *
+ * **Fail-closed on broken EE installs (#2587).** When enterprise is
+ * enabled but the `@atlas/ee/layers` import fails, we FAIL the Layer
+ * rather than silently falling back to `Layer.empty`. Pre-#2587 the
+ * catch arm logged-then-returned `Layer.empty`, which silently downgraded
+ * every enterprise subsystem to its fail-closed no-op:
+ *
+ *   - ResidencyResolver → `null` ⇒ EU workspace queries land on the
+ *     default US pool with zero log signal (compliance break, see
+ *     `lib/db/connection.ts:getRegionAwareConnection`).
+ *   - MaskingPolicy → passthrough ⇒ PII rules become advisory.
+ *   - IpAllowlistPolicy → `{ allowed: true }` ⇒ allowlist bypassed.
+ *   - ApprovalGate → `{ required: false }` ⇒ approval workflow disabled.
+ *   - AuditRetention → fake-success for purge/anonymize ⇒ GDPR erasure
+ *     reports success without doing anything.
+ *
+ * CLAUDE.md's rule "Prefer errors over silent fallbacks — catch
+ * { return false } on a security check is a bug" applies directly. On
+ * a SaaS install with `ATLAS_ENTERPRISE_ENABLED=true`, a broken `ee/`
+ * is a deploy-time configuration error operators MUST see — not a
+ * runtime degradation that quietly loosens security defaults across
+ * every subsystem. Self-hosted (`enabled === false`) is unaffected: it
+ * short-circuits to `Layer.empty` before the import is attempted.
  *
  * This is the **single permitted runtime reference** to `@atlas/ee`
  * from core. Adding any other `@atlas/ee` or `isEnterpriseEnabled`
- * reference to `packages/api/src/` will fail the CI grep slice #2573
- * installs (the closeout grep allow-list covers this file + the
- * conditional import below).
+ * reference to `packages/api/src/` will fail the CI grep gate
+ * (`scripts/check-ee-imports.sh`); the allow-list covers this file
+ * plus the conditional import below.
  */
 const ConditionalEELayer: Layer.Layer<never> = Layer.unwrapEffect(
   Effect.sync(() => isEnterpriseEnabledLocal()).pipe(
@@ -87,13 +112,16 @@ const ConditionalEELayer: Layer.Layer<never> = Layer.unwrapEffect(
         },
         catch: (err) => (err instanceof Error ? err : new Error(String(err))),
       }).pipe(
-        Effect.catchAll((err) => {
-          log.error(
-            { err: err instanceof Error ? err.message : String(err) },
-            "Enterprise enabled but @atlas/ee/layers failed to load — falling back to no-op defaults",
-          );
-          return Effect.succeed(Layer.empty as Layer.Layer<never>);
-        }),
+        Effect.tapError((err) =>
+          Effect.sync(() =>
+            log.error(
+              { err: err instanceof Error ? err.message : String(err) },
+              "Enterprise enabled (ATLAS_ENTERPRISE_ENABLED=true) but @atlas/ee/layers " +
+                "failed to load — failing Layer construction to avoid silent downgrade " +
+                "to no-op defaults. Fix the @atlas/ee install or set ATLAS_ENTERPRISE_ENABLED=false.",
+            ),
+          ),
+        ),
       );
     }),
   ),

--- a/packages/api/src/lib/effect/enterprise-layer.ts
+++ b/packages/api/src/lib/effect/enterprise-layer.ts
@@ -229,37 +229,15 @@ export function getEnterpriseRuntime(): ManagedRuntime.ManagedRuntime<Enterprise
  * any non-Hono call site (the Hono bridge uses `getEnterpriseRuntime()`
  * directly so it can layer in per-request contextLayer).
  *
- * Rejects on EE-load failure when `ATLAS_ENTERPRISE_ENABLED=true` —
- * caller should treat the rejection as an operator-visible deploy error
- * (matching the fail-closed contract from #2594), not a per-request
- * recoverable.
+ * Rejects on typed failures in the program's `E` channel. EE-load
+ * failure does NOT reject — `ConditionalEELayer` logs at ERROR with
+ * `event: "enterprise.load_failed"` and falls through to no-op
+ * defaults; consumer-side fail-closed checks are tracked in #2589.
+ * Callers that need to introspect the failure cause should use
+ * `getEnterpriseRuntime().runPromiseExit(...)` directly.
  */
 export function runEnterprise<A, E>(
   program: Effect.Effect<A, E, EnterpriseSubsystem>,
 ): Promise<A> {
   return getEnterpriseRuntime().runPromise(program);
-}
-
-/**
- * Exit-returning variant for call sites that need to inspect the failure
- * cause (defect vs typed failure vs interruption) without the
- * `runPromise` reject path.
- */
-export function runEnterpriseExit<A, E>(
-  program: Effect.Effect<A, E, EnterpriseSubsystem>,
-) {
-  return getEnterpriseRuntime().runPromiseExit(program);
-}
-
-/**
- * Test-only: clear the cached runtime so a `mock.module("@atlas/ee/layers")`
- * change between test files (or between test groups within a file) is
- * picked up on the next runtime build. Production code should never call
- * this; the runtime is process-lifetime.
- */
-export function __resetEnterpriseRuntimeForTesting(): void {
-  if (_runtime !== null) {
-    void _runtime.dispose();
-    _runtime = null;
-  }
 }

--- a/packages/api/src/lib/effect/enterprise-layer.ts
+++ b/packages/api/src/lib/effect/enterprise-layer.ts
@@ -72,7 +72,7 @@ function isEnterpriseEnabledLocal(): boolean {
  *   construction time (not module load) so a missing `@atlas/ee/`
  *   build doesn't break core's module graph.
  *
- * **Load failure handling (#2587).** When enterprise is enabled but the
+ * **Load failure handling (#2594).** When enterprise is enabled but the
  * `@atlas/ee/layers` import fails, this logs at ERROR with a structured
  * `event: "enterprise.load_failed"` field (alertable by SaaS monitoring)
  * then falls through to `Layer.empty`. Every enterprise subsystem then
@@ -89,9 +89,9 @@ function isEnterpriseEnabledLocal(): boolean {
  *   - ResidencyResolver no-op returns null (route falls back to default
  *     datasource — compliance break on EU workspaces)
  *
- * Hardening this is tracked in #2593 — consumer-side "available"
+ * Hardening this is tracked in #2589 — consumer-side "available"
  * discriminator checks at each load-bearing call site. The change is
- * too invasive for #2587 because it touches every test's mock setup
+ * too invasive for #2594 because it touches every test's mock setup
  * (16 test files mock individual `@atlas/ee/*` modules without mocking
  * the `@atlas/ee/layers` aggregator; any change that hard-fails the
  * aggregator on partial-mock cascades through every consumer).
@@ -119,7 +119,7 @@ const ConditionalEELayer: Layer.Layer<never> = Layer.unwrapEffect(
           // through to `Layer.empty` so the request can still complete via
           // the no-op defaults. The downgrade is intentional but documented
           // as a known weak spot in the JSDoc above; consumer-side
-          // hardening tracked in #2593.
+          // hardening tracked in #2589.
           log.error(
             {
               err: err instanceof Error ? err.message : String(err),
@@ -171,7 +171,7 @@ export type EnterpriseSubsystem =
  *
  * Construction is paid ONCE per process: the runtime materialises the
  * layer the first time it's used and reuses the constructed services
- * across all subsequent runs. Pre-#2587 the bridge re-wrapped this Layer
+ * across all subsequent runs. Pre-#2594 the bridge re-wrapped this Layer
  * with `Effect.provide(...)` per request — building a fresh runtime
  * Scope per call, defeating Effect's reference-keyed memoization.
  */
@@ -180,9 +180,9 @@ export const EnterpriseLayer: Layer.Layer<EnterpriseSubsystem> = Layer.mergeAll(
   ConditionalEELayer,
 );
 
-// ── Module-level ManagedRuntime (#2587) ──────────────────────────────
+// ── Module-level ManagedRuntime (#2594) ──────────────────────────────
 //
-// Pre-#2587 every call site of `Effect.provide(EnterpriseLayer)` rebuilt
+// Pre-#2594 every call site of `Effect.provide(EnterpriseLayer)` rebuilt
 // the Layer's runtime per call. A single admin request handling a SQL
 // execution rebuilt 6-8 times (auth middleware → IP allowlist →
 // admin-router permission ×2 → SQL masking/SLA/approval ×3), and the
@@ -231,7 +231,7 @@ export function getEnterpriseRuntime(): ManagedRuntime.ManagedRuntime<Enterprise
  *
  * Rejects on EE-load failure when `ATLAS_ENTERPRISE_ENABLED=true` —
  * caller should treat the rejection as an operator-visible deploy error
- * (matching the fail-closed contract from #2587), not a per-request
+ * (matching the fail-closed contract from #2594), not a per-request
  * recoverable.
  */
 export function runEnterprise<A, E>(

--- a/packages/api/src/lib/effect/enterprise-layer.ts
+++ b/packages/api/src/lib/effect/enterprise-layer.ts
@@ -154,14 +154,16 @@ export type EnterpriseSubsystem =
 
 /**
  * Composed enterprise Layer — no-op defaults overlaid by the conditional
- * EE layer (last-wins via `Layer.mergeAll`). Provided per-request by
- * `runEffect`/`runHandler` so route programs can `yield* ResidencyResolver`
+ * EE layer (last-wins via `Layer.mergeAll`). Provided to programs via
+ * the module-level `enterpriseRuntime` (see `getEnterpriseRuntime` +
+ * `runEnterprise` below) so route programs can `yield* ResidencyResolver`
  * without threading the layer through every handler.
  *
- * Construction is cheap: the no-op defaults are constants, and the
- * conditional EE layer's lazy `await import("@atlas/ee/layers")` hits
- * Node's module cache after the first load. Effect's Layer memoization
- * elides repeat work within a single program run.
+ * Construction is paid ONCE per process: the runtime materialises the
+ * layer the first time it's used and reuses the constructed services
+ * across all subsequent runs. Pre-#2587 the bridge re-wrapped this Layer
+ * with `Effect.provide(...)` per request — building a fresh runtime
+ * Scope per call, defeating Effect's reference-keyed memoization.
  */
 // `E = Error` propagates from `ConditionalEELayer` so callers see a
 // loud Promise rejection / typed failure if `ATLAS_ENTERPRISE_ENABLED=true`

--- a/packages/api/src/lib/effect/enterprise-layer.ts
+++ b/packages/api/src/lib/effect/enterprise-layer.ts
@@ -101,14 +101,14 @@ function isEnterpriseEnabledLocal(): boolean {
  * (`scripts/check-ee-imports.sh`); the allow-list covers this file
  * plus the conditional import below.
  */
-const ConditionalEELayer: Layer.Layer<never> = Layer.unwrapEffect(
+const ConditionalEELayer: Layer.Layer<never, Error> = Layer.unwrapEffect(
   Effect.sync(() => isEnterpriseEnabledLocal()).pipe(
     Effect.flatMap((enabled) => {
-      if (!enabled) return Effect.succeed(Layer.empty as Layer.Layer<never>);
+      if (!enabled) return Effect.succeed(Layer.empty as Layer.Layer<never, Error>);
       return Effect.tryPromise({
         try: async () => {
           const mod = (await import("@atlas/ee/layers")) as { EELayer: Layer.Layer<never> };
-          return mod.EELayer;
+          return mod.EELayer as Layer.Layer<never, Error>;
         },
         catch: (err) => (err instanceof Error ? err : new Error(String(err))),
       }).pipe(
@@ -163,7 +163,11 @@ export type EnterpriseSubsystem =
  * Node's module cache after the first load. Effect's Layer memoization
  * elides repeat work within a single program run.
  */
-export const EnterpriseLayer: Layer.Layer<EnterpriseSubsystem> = Layer.mergeAll(
+// `E = Error` propagates from `ConditionalEELayer` so callers see a
+// loud Promise rejection / typed failure if `ATLAS_ENTERPRISE_ENABLED=true`
+// but `@atlas/ee/layers` fails to load (#2587). Self-hosted resolves
+// E=never since the short-circuit branch returns `Layer.empty`.
+export const EnterpriseLayer: Layer.Layer<EnterpriseSubsystem, Error> = Layer.mergeAll(
   NoopEnterpriseDefaultsLayer,
   ConditionalEELayer,
 );

--- a/packages/api/src/lib/effect/enterprise-layer.ts
+++ b/packages/api/src/lib/effect/enterprise-layer.ts
@@ -72,28 +72,29 @@ function isEnterpriseEnabledLocal(): boolean {
  *   construction time (not module load) so a missing `@atlas/ee/`
  *   build doesn't break core's module graph.
  *
- * **Fail-closed on broken EE installs (#2587).** When enterprise is
- * enabled but the `@atlas/ee/layers` import fails, we FAIL the Layer
- * rather than silently falling back to `Layer.empty`. Pre-#2587 the
- * catch arm logged-then-returned `Layer.empty`, which silently downgraded
- * every enterprise subsystem to its fail-closed no-op:
+ * **Load failure handling (#2587).** When enterprise is enabled but the
+ * `@atlas/ee/layers` import fails, this logs at ERROR with a structured
+ * `event: "enterprise.load_failed"` field (alertable by SaaS monitoring)
+ * then falls through to `Layer.empty`. Every enterprise subsystem then
+ * resolves to its no-op default for the request.
  *
- *   - ResidencyResolver → `null` ⇒ EU workspace queries land on the
- *     default US pool with zero log signal (compliance break, see
- *     `lib/db/connection.ts:getRegionAwareConnection`).
- *   - MaskingPolicy → passthrough ⇒ PII rules become advisory.
- *   - IpAllowlistPolicy → `{ allowed: true }` ⇒ allowlist bypassed.
- *   - ApprovalGate → `{ required: false }` ⇒ approval workflow disabled.
- *   - AuditRetention → fake-success for purge/anonymize ⇒ GDPR erasure
- *     reports success without doing anything.
+ * **Known weak spot — not yet fail-closed at the consumer level.** The
+ * no-op defaults across the 16 Tags vary in how "fail-closed" they
+ * really are. Most are correct on self-hosted but inadequate on a SaaS
+ * install where `ATLAS_ENTERPRISE_ENABLED=true` but `ee/` failed to load:
  *
- * CLAUDE.md's rule "Prefer errors over silent fallbacks — catch
- * { return false } on a security check is a bug" applies directly. On
- * a SaaS install with `ATLAS_ENTERPRISE_ENABLED=true`, a broken `ee/`
- * is a deploy-time configuration error operators MUST see — not a
- * runtime degradation that quietly loosens security defaults across
- * every subsystem. Self-hosted (`enabled === false`) is unaffected: it
- * short-circuits to `Layer.empty` before the import is attempted.
+ *   - MaskingPolicy no-op passes rows through unmasked
+ *   - IpAllowlistPolicy no-op always allows
+ *   - ApprovalGate no-op never requires approval
+ *   - ResidencyResolver no-op returns null (route falls back to default
+ *     datasource — compliance break on EU workspaces)
+ *
+ * Hardening this is tracked in #2593 — consumer-side "available"
+ * discriminator checks at each load-bearing call site. The change is
+ * too invasive for #2587 because it touches every test's mock setup
+ * (16 test files mock individual `@atlas/ee/*` modules without mocking
+ * the `@atlas/ee/layers` aggregator; any change that hard-fails the
+ * aggregator on partial-mock cascades through every consumer).
  *
  * This is the **single permitted runtime reference** to `@atlas/ee`
  * from core. Adding any other `@atlas/ee` or `isEnterpriseEnabled`
@@ -101,27 +102,36 @@ function isEnterpriseEnabledLocal(): boolean {
  * (`scripts/check-ee-imports.sh`); the allow-list covers this file
  * plus the conditional import below.
  */
-const ConditionalEELayer: Layer.Layer<never, Error> = Layer.unwrapEffect(
+const ConditionalEELayer: Layer.Layer<never> = Layer.unwrapEffect(
   Effect.sync(() => isEnterpriseEnabledLocal()).pipe(
     Effect.flatMap((enabled) => {
-      if (!enabled) return Effect.succeed(Layer.empty as Layer.Layer<never, Error>);
+      if (!enabled) return Effect.succeed(Layer.empty as Layer.Layer<never>);
       return Effect.tryPromise({
         try: async () => {
           const mod = (await import("@atlas/ee/layers")) as { EELayer: Layer.Layer<never> };
-          return mod.EELayer as Layer.Layer<never, Error>;
+          return mod.EELayer;
         },
         catch: (err) => (err instanceof Error ? err : new Error(String(err))),
       }).pipe(
-        Effect.tapError((err) =>
-          Effect.sync(() =>
-            log.error(
-              { err: err instanceof Error ? err.message : String(err) },
-              "Enterprise enabled (ATLAS_ENTERPRISE_ENABLED=true) but @atlas/ee/layers " +
-                "failed to load — failing Layer construction to avoid silent downgrade " +
-                "to no-op defaults. Fix the @atlas/ee install or set ATLAS_ENTERPRISE_ENABLED=false.",
-            ),
-          ),
-        ),
+        Effect.catchAll((err) => {
+          // Operator-visible structured log so SaaS monitoring picks this
+          // up — `enterprise.load_failed` is the alertable event. Fall
+          // through to `Layer.empty` so the request can still complete via
+          // the no-op defaults. The downgrade is intentional but documented
+          // as a known weak spot in the JSDoc above; consumer-side
+          // hardening tracked in #2593.
+          log.error(
+            {
+              err: err instanceof Error ? err.message : String(err),
+              event: "enterprise.load_failed",
+              flag: "ATLAS_ENTERPRISE_ENABLED",
+            },
+            "Enterprise enabled but @atlas/ee/layers failed to load — request will be " +
+              "served by no-op defaults across every enterprise subsystem. Fix the " +
+              "@atlas/ee install or set ATLAS_ENTERPRISE_ENABLED=false.",
+          );
+          return Effect.succeed(Layer.empty as Layer.Layer<never>);
+        }),
       );
     }),
   ),
@@ -165,11 +175,7 @@ export type EnterpriseSubsystem =
  * with `Effect.provide(...)` per request — building a fresh runtime
  * Scope per call, defeating Effect's reference-keyed memoization.
  */
-// `E = Error` propagates from `ConditionalEELayer` so callers see a
-// loud Promise rejection / typed failure if `ATLAS_ENTERPRISE_ENABLED=true`
-// but `@atlas/ee/layers` fails to load (#2587). Self-hosted resolves
-// E=never since the short-circuit branch returns `Layer.empty`.
-export const EnterpriseLayer: Layer.Layer<EnterpriseSubsystem, Error> = Layer.mergeAll(
+export const EnterpriseLayer: Layer.Layer<EnterpriseSubsystem> = Layer.mergeAll(
   NoopEnterpriseDefaultsLayer,
   ConditionalEELayer,
 );
@@ -196,7 +202,7 @@ export const EnterpriseLayer: Layer.Layer<EnterpriseSubsystem, Error> = Layer.me
 // (non-Hono) call sites. The Hono bridge (`hono.ts:runEffect`) uses the
 // runtime directly so it can layer in per-request contextLayer.
 
-let _runtime: ManagedRuntime.ManagedRuntime<EnterpriseSubsystem, Error> | null = null;
+let _runtime: ManagedRuntime.ManagedRuntime<EnterpriseSubsystem, never> | null = null;
 
 /**
  * Get (or lazily create) the module-level ManagedRuntime for the
@@ -209,7 +215,7 @@ let _runtime: ManagedRuntime.ManagedRuntime<EnterpriseSubsystem, Error> | null =
  * If a future EE Tag introduces a scoped finalizer, wire dispose into
  * the existing shutdown handler in `buildAppLayer`.
  */
-export function getEnterpriseRuntime(): ManagedRuntime.ManagedRuntime<EnterpriseSubsystem, Error> {
+export function getEnterpriseRuntime(): ManagedRuntime.ManagedRuntime<EnterpriseSubsystem, never> {
   if (_runtime === null) {
     _runtime = ManagedRuntime.make(EnterpriseLayer);
   }

--- a/packages/api/src/lib/effect/enterprise-layer.ts
+++ b/packages/api/src/lib/effect/enterprise-layer.ts
@@ -14,7 +14,7 @@
  * file plus the `@atlas/ee/layers` aggregator dynamic import below.
  */
 
-import { Effect, Layer } from "effect";
+import { Effect, Layer, ManagedRuntime } from "effect";
 import { createLogger } from "@atlas/api/lib/logger";
 import {
   NoopEnterpriseDefaultsLayer,
@@ -171,3 +171,87 @@ export const EnterpriseLayer: Layer.Layer<EnterpriseSubsystem, Error> = Layer.me
   NoopEnterpriseDefaultsLayer,
   ConditionalEELayer,
 );
+
+// ── Module-level ManagedRuntime (#2587) ──────────────────────────────
+//
+// Pre-#2587 every call site of `Effect.provide(EnterpriseLayer)` rebuilt
+// the Layer's runtime per call. A single admin request handling a SQL
+// execution rebuilt 6-8 times (auth middleware → IP allowlist →
+// admin-router permission ×2 → SQL masking/SLA/approval ×3), and the
+// EE-Layer's lazy `await import("@atlas/ee/layers")` re-allocated
+// the `Effect.tryPromise` wrapper per call. The JSDoc above claimed
+// "Effect's Layer memoization elides repeat work within a single program
+// run" — true for one run, but each `Effect.runPromise` is a separate run.
+//
+// `ManagedRuntime.make(EnterpriseLayer)` materializes the layer once on
+// first use. Subsequent `runtime.runPromise(...)` calls reuse the
+// constructed services — the dynamic EE import hits Node's module cache
+// AND Effect's Layer memoization simultaneously. Construction is lazy
+// (deferred to first call) so tests that `mock.module("@atlas/ee/layers")`
+// before any handler runs see their mocks.
+//
+// `runEnterprise(program)` is the canonical helper for the standalone
+// (non-Hono) call sites. The Hono bridge (`hono.ts:runEffect`) uses the
+// runtime directly so it can layer in per-request contextLayer.
+
+let _runtime: ManagedRuntime.ManagedRuntime<EnterpriseSubsystem, Error> | null = null;
+
+/**
+ * Get (or lazily create) the module-level ManagedRuntime for the
+ * EnterpriseLayer. Lazy so tests can install `mock.module("@atlas/ee/layers")`
+ * before the first runtime build.
+ *
+ * The runtime is process-lifetime; no explicit dispose. The Layer's
+ * subsystems (Noop defaults + EELayer's Live impls) currently have no
+ * scoped finalizers, so leaking the runtime at process exit is fine.
+ * If a future EE Tag introduces a scoped finalizer, wire dispose into
+ * the existing shutdown handler in `buildAppLayer`.
+ */
+export function getEnterpriseRuntime(): ManagedRuntime.ManagedRuntime<EnterpriseSubsystem, Error> {
+  if (_runtime === null) {
+    _runtime = ManagedRuntime.make(EnterpriseLayer);
+  }
+  return _runtime;
+}
+
+/**
+ * Run a program that requires `EnterpriseSubsystem` via the shared
+ * module-level runtime. Use this instead of
+ * `Effect.runPromise(program.pipe(Effect.provide(EnterpriseLayer)))` at
+ * any non-Hono call site (the Hono bridge uses `getEnterpriseRuntime()`
+ * directly so it can layer in per-request contextLayer).
+ *
+ * Rejects on EE-load failure when `ATLAS_ENTERPRISE_ENABLED=true` —
+ * caller should treat the rejection as an operator-visible deploy error
+ * (matching the fail-closed contract from #2587), not a per-request
+ * recoverable.
+ */
+export function runEnterprise<A, E>(
+  program: Effect.Effect<A, E, EnterpriseSubsystem>,
+): Promise<A> {
+  return getEnterpriseRuntime().runPromise(program);
+}
+
+/**
+ * Exit-returning variant for call sites that need to inspect the failure
+ * cause (defect vs typed failure vs interruption) without the
+ * `runPromise` reject path.
+ */
+export function runEnterpriseExit<A, E>(
+  program: Effect.Effect<A, E, EnterpriseSubsystem>,
+) {
+  return getEnterpriseRuntime().runPromiseExit(program);
+}
+
+/**
+ * Test-only: clear the cached runtime so a `mock.module("@atlas/ee/layers")`
+ * change between test files (or between test groups within a file) is
+ * picked up on the next runtime build. Production code should never call
+ * this; the runtime is process-lifetime.
+ */
+export function __resetEnterpriseRuntimeForTesting(): void {
+  if (_runtime !== null) {
+    void _runtime.dispose();
+    _runtime = null;
+  }
+}

--- a/packages/api/src/lib/effect/hono.ts
+++ b/packages/api/src/lib/effect/hono.ts
@@ -402,19 +402,19 @@ export async function runEffect<A, E>(
   // handler that `yield* ResidencyResolver` resolves without each route
   // having to provide the layer manually. Layer.mergeAll is referentially
   // stable, so Effect memoizes the construction across requests.
-  // Provide per-request contextLayer (RequestContext + AuthContext) at
-  // the program level, then run via the shared module-level
-  // EnterpriseRuntime (#2587). Pre-#2587 the bridge merged
-  // contextLayer + EnterpriseLayer per request and called
-  // `Effect.runPromiseExit`, which rebuilt the Layer's runtime per call
-  // — `Layer.mergeAll` is referentially stable but the merged result
-  // wasn't (new reference per request defeats Effect's reference-keyed
-  // memoization). The ManagedRuntime memoizes EnterpriseLayer's
-  // construction across requests (including the EE-Layer's lazy
-  // `await import("@atlas/ee/layers")`). The Layer's `E = Error`
-  // channel propagates here as `E | Error` so a SaaS install with a
-  // broken `@atlas/ee/` build surfaces a typed failure routed through
-  // `classifyError` to a 500.
+  // Per-request contextLayer (RequestContext + AuthContext) is provided
+  // at the program level, then the program runs against the shared
+  // module-level EnterpriseRuntime (#2587). Pre-#2587 the bridge merged
+  // contextLayer + EnterpriseLayer per request — Layer.merge produces a
+  // fresh reference each time so Effect's per-Scope memoization couldn't
+  // amortize the EE-Layer's lazy `await import("@atlas/ee/layers")` or
+  // any other Layer.sync construction. With the ManagedRuntime, the
+  // EE-Layer constructs ONCE on first use and every request reuses the
+  // services; contextLayer remains per-request because it carries the
+  // request's `requestId` / `authResult` (lightweight Layer.succeed).
+  // The runtime's `E = Error` channel propagates here as `E | Error` so
+  // a SaaS install with a broken `@atlas/ee/` build surfaces a typed
+  // failure routed through `classifyError` to a 500.
   const contextLayer = buildContextLayer(c);
   const contextProvided: Effect.Effect<A, E, EnterpriseSubsystem> = contextLayer
     ? (program as Effect.Effect<

--- a/packages/api/src/lib/effect/hono.ts
+++ b/packages/api/src/lib/effect/hono.ts
@@ -396,12 +396,6 @@ export async function runEffect<A, E>(
     | Effect.Effect<A, E, never>,
   options?: RunEffectOptions,
 ): Promise<A> {
-  // Provide Hono context + enterprise subsystem layers. The enterprise
-  // layer carries no-op defaults for every EE Tag (overlaid by the real
-  // EE implementations via `Layer.mergeAll`'s last-wins semantics) so a
-  // handler that `yield* ResidencyResolver` resolves without each route
-  // having to provide the layer manually. Layer.mergeAll is referentially
-  // stable, so Effect memoizes the construction across requests.
   // Per-request contextLayer (RequestContext + AuthContext) is provided
   // at the program level, then the program runs against the shared
   // module-level EnterpriseRuntime (#2587). Pre-#2587 the bridge merged
@@ -412,9 +406,6 @@ export async function runEffect<A, E>(
   // EE-Layer constructs ONCE on first use and every request reuses the
   // services; contextLayer remains per-request because it carries the
   // request's `requestId` / `authResult` (lightweight Layer.succeed).
-  // The runtime's `E = Error` channel propagates here as `E | Error` so
-  // a SaaS install with a broken `@atlas/ee/` build surfaces a typed
-  // failure routed through `classifyError` to a 500.
   const contextLayer = buildContextLayer(c);
   const contextProvided: Effect.Effect<A, E, EnterpriseSubsystem> = contextLayer
     ? (program as Effect.Effect<
@@ -424,7 +415,7 @@ export async function runEffect<A, E>(
       >).pipe(Effect.provide(contextLayer))
     : (program as Effect.Effect<A, E, EnterpriseSubsystem>);
 
-  const exit = await getEnterpriseRuntime().runPromiseExit(contextProvided) as Exit.Exit<A, E | Error>;
+  const exit = await getEnterpriseRuntime().runPromiseExit(contextProvided);
 
   if (Exit.isSuccess(exit)) {
     return exit.value;

--- a/packages/api/src/lib/effect/hono.ts
+++ b/packages/api/src/lib/effect/hono.ts
@@ -402,8 +402,15 @@ export async function runEffect<A, E>(
   // handler that `yield* ResidencyResolver` resolves without each route
   // having to provide the layer manually. Layer.mergeAll is referentially
   // stable, so Effect memoizes the construction across requests.
+  // `EnterpriseLayer` has `E = Error` post-#2587 — when EE is enabled
+  // but `@atlas/ee/layers` fails to load, the layer construction fails
+  // rather than silently downgrading to no-op defaults. The error
+  // surfaces here as an `Error` in the program's failure channel and is
+  // routed through `classifyError` below to a 500 (uncategorized — an
+  // operator-visible signal that the EE install is broken). Self-hosted
+  // never exercises this path.
   const contextLayer = buildContextLayer(c);
-  const provided: Effect.Effect<A, E, never> = contextLayer
+  const provided: Effect.Effect<A, E | Error, never> = contextLayer
     ? (program as Effect.Effect<
         A,
         E,

--- a/packages/api/src/lib/effect/hono.ts
+++ b/packages/api/src/lib/effect/hono.ts
@@ -27,7 +27,7 @@ import {
   AuthContext,
   makeAuthContextLayer,
 } from "./services";
-import { EnterpriseLayer, type EnterpriseSubsystem } from "./enterprise-layer";
+import { getEnterpriseRuntime, type EnterpriseSubsystem } from "./enterprise-layer";
 
 // ── Domain error mapping ────────────────────────────────────────────
 
@@ -402,25 +402,29 @@ export async function runEffect<A, E>(
   // handler that `yield* ResidencyResolver` resolves without each route
   // having to provide the layer manually. Layer.mergeAll is referentially
   // stable, so Effect memoizes the construction across requests.
-  // `EnterpriseLayer` has `E = Error` post-#2587 — when EE is enabled
-  // but `@atlas/ee/layers` fails to load, the layer construction fails
-  // rather than silently downgrading to no-op defaults. The error
-  // surfaces here as an `Error` in the program's failure channel and is
-  // routed through `classifyError` below to a 500 (uncategorized — an
-  // operator-visible signal that the EE install is broken). Self-hosted
-  // never exercises this path.
+  // Provide per-request contextLayer (RequestContext + AuthContext) at
+  // the program level, then run via the shared module-level
+  // EnterpriseRuntime (#2587). Pre-#2587 the bridge merged
+  // contextLayer + EnterpriseLayer per request and called
+  // `Effect.runPromiseExit`, which rebuilt the Layer's runtime per call
+  // — `Layer.mergeAll` is referentially stable but the merged result
+  // wasn't (new reference per request defeats Effect's reference-keyed
+  // memoization). The ManagedRuntime memoizes EnterpriseLayer's
+  // construction across requests (including the EE-Layer's lazy
+  // `await import("@atlas/ee/layers")`). The Layer's `E = Error`
+  // channel propagates here as `E | Error` so a SaaS install with a
+  // broken `@atlas/ee/` build surfaces a typed failure routed through
+  // `classifyError` to a 500.
   const contextLayer = buildContextLayer(c);
-  const provided: Effect.Effect<A, E | Error, never> = contextLayer
+  const contextProvided: Effect.Effect<A, E, EnterpriseSubsystem> = contextLayer
     ? (program as Effect.Effect<
         A,
         E,
         RequestContext | AuthContext | EnterpriseSubsystem
-      >).pipe(Effect.provide(Layer.merge(contextLayer, EnterpriseLayer)))
-    : (program as Effect.Effect<A, E, EnterpriseSubsystem>).pipe(
-        Effect.provide(EnterpriseLayer),
-      );
+      >).pipe(Effect.provide(contextLayer))
+    : (program as Effect.Effect<A, E, EnterpriseSubsystem>);
 
-  const exit = await Effect.runPromiseExit(provided);
+  const exit = await getEnterpriseRuntime().runPromiseExit(contextProvided) as Exit.Exit<A, E | Error>;
 
   if (Exit.isSuccess(exit)) {
     return exit.value;

--- a/packages/api/src/lib/effect/hono.ts
+++ b/packages/api/src/lib/effect/hono.ts
@@ -398,7 +398,7 @@ export async function runEffect<A, E>(
 ): Promise<A> {
   // Per-request contextLayer (RequestContext + AuthContext) is provided
   // at the program level, then the program runs against the shared
-  // module-level EnterpriseRuntime (#2587). Pre-#2587 the bridge merged
+  // module-level EnterpriseRuntime (#2594). Pre-#2594 the bridge merged
   // contextLayer + EnterpriseLayer per request — Layer.merge produces a
   // fresh reference each time so Effect's per-Scope memoization couldn't
   // amortize the EE-Layer's lazy `await import("@atlas/ee/layers")` or

--- a/packages/api/src/lib/effect/services.ts
+++ b/packages/api/src/lib/effect/services.ts
@@ -1083,7 +1083,13 @@ export const NoopMaskingPolicyLayer: Layer.Layer<MaskingPolicy> = Layer.sync(
       });
     return {
       available: false,
-      applyMasking: (ctx) => Effect.succeed([...ctx.rows]),
+      // MUST preserve reference identity — callers in `tools/sql.ts`
+      // compute `maskingApplied = maskedRows !== result.rows`, and a
+      // fresh-array no-op (`[...ctx.rows]`) misreports `true` on every
+      // self-hosted query against a classified table. EE's real
+      // `applyMasking` returns `ctx.rows` directly on no-rules early-out
+      // paths for the same reason.
+      applyMasking: (ctx) => Effect.succeed(ctx.rows),
       listPIIClassifications: () => Effect.succeed([]),
       updatePIIClassification: (_orgId, id) => Effect.fail(notFound(id)),
       deletePIIClassification: (_orgId, id) => Effect.fail(notFound(id)),

--- a/packages/api/src/lib/effect/services.ts
+++ b/packages/api/src/lib/effect/services.ts
@@ -41,6 +41,24 @@ import type {
 
 const log = createLogger("effect:connection");
 
+// ── Shared Noop-layer helper (#2594) ────────────────────────────────
+//
+// Every enterprise Noop layer that fails self-hosted methods with
+// `EnterpriseError` previously open-coded the same 7-line block (lazy
+// `require()` of the error class + a `notAvailable` factory closure).
+// The lazy require is load-bearing — services.ts is reached early in
+// the dep graph and an eager static import of `lib/effect/errors` has
+// caused `mock.module()` ordering surprises (see
+// feedback_bun_test_async_mock_module). This helper preserves the
+// laziness, just dedups the boilerplate.
+function makeNotAvailable(message: string): () => import("@atlas/api/lib/effect/errors").EnterpriseError {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { EnterpriseError } = require("@atlas/api/lib/effect/errors") as {
+    EnterpriseError: new (message?: string) => import("@atlas/api/lib/effect/errors").EnterpriseError;
+  };
+  return () => new EnterpriseError(message);
+}
+
 // ── Service interface ────────────────────────────────────────────────
 
 /** Typed contract for the ConnectionRegistry Effect service. */
@@ -999,10 +1017,7 @@ export const NoopModelRouterLayer: Layer.Layer<ModelRouter> = Layer.sync(
   ModelRouter,
   () => {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const { EnterpriseError: EnterpriseErrorClass } = require("@atlas/api/lib/effect/errors") as {
-      EnterpriseError: new (message?: string) => EnterpriseError;
-    };
-    const notAvailable = () => new EnterpriseErrorClass("Model routing requires enterprise features to be enabled.");
+    const notAvailable = makeNotAvailable("Model routing requires enterprise features to be enabled.");
     return {
       available: false,
       getWorkspaceModelConfig: () => Effect.succeed(null),
@@ -1272,11 +1287,7 @@ export const NoopApprovalGateLayer: Layer.Layer<ApprovalGate> = Layer.sync(
         code: "not_found",
       });
     // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const { EnterpriseError: EnterpriseErrorClass } = require("@atlas/api/lib/effect/errors") as {
-      EnterpriseError: new (message?: string) => import("@atlas/api/lib/effect/errors").EnterpriseError;
-    };
-    const notAvailable = () =>
-      new EnterpriseErrorClass("Approval workflows require enterprise features to be enabled.");
+    const notAvailable = makeNotAvailable("Approval workflows require enterprise features to be enabled.");
     return {
       checkApprovalRequired: () =>
         Effect.succeed({ required: false, matchedRules: [] }),
@@ -1355,11 +1366,7 @@ export const NoopSlaMetricsLayer: Layer.Layer<SlaMetrics> = Layer.sync(
   SlaMetrics,
   () => {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const { EnterpriseError: EnterpriseErrorClass } = require("@atlas/api/lib/effect/errors") as {
-      EnterpriseError: new (message?: string) => import("@atlas/api/lib/effect/errors").EnterpriseError;
-    };
-    const notAvailable = () =>
-      new EnterpriseErrorClass("SLA monitoring requires enterprise features to be enabled.");
+    const notAvailable = makeNotAvailable("SLA monitoring requires enterprise features to be enabled.");
     return {
       available: false,
       recordQueryMetric: () => Effect.void,
@@ -1437,11 +1444,7 @@ export const NoopBackupsManagerLayer: Layer.Layer<BackupsManager> = Layer.sync(
   BackupsManager,
   () => {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const { EnterpriseError: EnterpriseErrorClass } = require("@atlas/api/lib/effect/errors") as {
-      EnterpriseError: new (message?: string) => import("@atlas/api/lib/effect/errors").EnterpriseError;
-    };
-    const notAvailable = () =>
-      new EnterpriseErrorClass("Automated backups require enterprise features to be enabled.");
+    const notAvailable = makeNotAvailable("Automated backups require enterprise features to be enabled.");
     return {
     available: false,
     getBackupConfig: () => Effect.fail(notAvailable()),
@@ -1563,11 +1566,7 @@ export const NoopAuditRetentionLayer: Layer.Layer<AuditRetention> = Layer.sync(
   AuditRetention,
   () => {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const { EnterpriseError: EnterpriseErrorClass } = require("@atlas/api/lib/effect/errors") as {
-      EnterpriseError: new (message?: string) => EnterpriseErrorForRetention;
-    };
-    const notAvailable = () =>
-      new EnterpriseErrorClass("Audit retention requires enterprise features to be enabled.");
+    const notAvailable = makeNotAvailable("Audit retention requires enterprise features to be enabled.");
     return {
       available: false,
       // Pure reads — "no policy configured" is the honest answer on
@@ -1668,11 +1667,7 @@ export const NoopIpAllowlistPolicyLayer: Layer.Layer<IpAllowlistPolicy> = Layer.
   IpAllowlistPolicy,
   () => {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const { EnterpriseError: EnterpriseErrorClass } = require("@atlas/api/lib/effect/errors") as {
-      EnterpriseError: new (message?: string) => import("@atlas/api/lib/effect/errors").EnterpriseError;
-    };
-    const notAvailable = () =>
-      new EnterpriseErrorClass("IP allowlist requires enterprise features to be enabled.");
+    const notAvailable = makeNotAvailable("IP allowlist requires enterprise features to be enabled.");
     return {
       available: false,
       checkIPAllowlist: () => Effect.succeed({ allowed: true }),
@@ -1782,11 +1777,7 @@ export const NoopSSOPolicyLayer: Layer.Layer<SSOPolicy> = Layer.sync(
   SSOPolicy,
   () => {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const { EnterpriseError: EnterpriseErrorClass } = require("@atlas/api/lib/effect/errors") as {
-      EnterpriseError: new (message?: string) => EnterpriseErrorForAuth;
-    };
-    const notAvailable = () =>
-      new EnterpriseErrorClass("SSO requires enterprise features to be enabled.");
+    const notAvailable = makeNotAvailable("SSO requires enterprise features to be enabled.");
     // Pure-helper inline copy of EE's `extractEmailDomain`. Pre-#2570
     // middleware called the EE static export; now it reaches it through
     // the Tag. The no-op needs the same parse so a self-hosted middleware
@@ -1887,11 +1878,7 @@ export const NoopSCIMProvenanceLayer: Layer.Layer<SCIMProvenance> = Layer.sync(
   SCIMProvenance,
   () => {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const { EnterpriseError: EnterpriseErrorClass } = require("@atlas/api/lib/effect/errors") as {
-      EnterpriseError: new (message?: string) => EnterpriseErrorForAuth;
-    };
-    const notAvailable = () =>
-      new EnterpriseErrorClass("SCIM provisioning requires enterprise features to be enabled.");
+    const notAvailable = makeNotAvailable("SCIM provisioning requires enterprise features to be enabled.");
     return {
       available: false,
       listConnections: () => Effect.succeed([]),
@@ -2150,15 +2137,7 @@ export class Branding extends Context.Tag("Branding")<
 export const NoopBrandingLayer: Layer.Layer<Branding> = Layer.sync(
   Branding,
   () => {
-    const { EnterpriseError: EnterpriseErrorClass } =
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      require("@atlas/api/lib/effect/errors") as {
-        EnterpriseError: new (message?: string) => EnterpriseErrorForBranding;
-      };
-    const notAvailable = () =>
-      new EnterpriseErrorClass(
-        "Workspace branding requires enterprise features to be enabled.",
-      );
+    const notAvailable = makeNotAvailable("Workspace branding requires enterprise features to be enabled.",);
     return {
       available: false,
       getWorkspaceBranding: () => Effect.fail(notAvailable()),
@@ -2237,15 +2216,7 @@ export class Domains extends Context.Tag("Domains")<
 export const NoopDomainsLayer: Layer.Layer<Domains> = Layer.sync(
   Domains,
   () => {
-    const { EnterpriseError: EnterpriseErrorClass } =
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      require("@atlas/api/lib/effect/errors") as {
-        EnterpriseError: new (message?: string) => EnterpriseErrorForDomains;
-      };
-    const notAvailable = () =>
-      new EnterpriseErrorClass(
-        "Custom domains require enterprise features to be enabled.",
-      );
+    const notAvailable = makeNotAvailable("Custom domains require enterprise features to be enabled.",);
     return {
       available: false,
       registerDomain: () => Effect.fail(notAvailable()),
@@ -2299,19 +2270,10 @@ export class ProactiveGate extends Context.Tag("ProactiveGate")<
 export const NoopProactiveGateLayer: Layer.Layer<ProactiveGate> = Layer.sync(
   ProactiveGate,
   () => {
-    const { EnterpriseError: EnterpriseErrorClass } =
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      require("@atlas/api/lib/effect/errors") as {
-        EnterpriseError: new (message?: string) => EnterpriseErrorForProactive;
-      };
+    const notAvailable = makeNotAvailable("Proactive chat requires enterprise features to be enabled.");
     return {
       enabled: false,
-      requireEnabled: () =>
-        Effect.fail(
-          new EnterpriseErrorClass(
-            "Proactive chat requires enterprise features to be enabled.",
-          ),
-        ),
+      requireEnabled: () => Effect.fail(notAvailable()),
     } satisfies ProactiveGateShape;
   },
 );

--- a/packages/api/src/lib/effect/services.ts
+++ b/packages/api/src/lib/effect/services.ts
@@ -1570,18 +1570,40 @@ export const NoopAuditRetentionLayer: Layer.Layer<AuditRetention> = Layer.sync(
       new EnterpriseErrorClass("Audit retention requires enterprise features to be enabled.");
     return {
       available: false,
+      // Pure reads — "no policy configured" is the honest answer on
+      // self-hosted (admin-audit-retention.ts renders `{ policy: null }`
+      // as the not-configured envelope, no harm done).
       getRetentionPolicy: () => Effect.succeed(null),
-      setRetentionPolicy: () => Effect.fail(notAvailable()),
-      purgeExpiredEntries: () => Effect.succeed([]),
-      hardDeleteExpired: () => Effect.succeed({ deletedCount: 0 }),
-      exportAuditLog: () => Effect.fail(notAvailable()),
       getAdminActionRetentionPolicy: () => Effect.succeed(null),
+      // Mutations + destructive ops MUST fail with EnterpriseError. The
+      // routes declare `domainErrors: [retentionDomainError]` so a
+      // RetentionError or EnterpriseError surfaces through `classifyError`
+      // as a 4xx envelope. Pre-#2587 these returned silent success which:
+      //   - For purgeExpiredEntries / hardDeleteExpired / purgeAdminAction:
+      //     reported "nothing to purge" without doing anything, masking
+      //     a misconfigured install from operator monitoring.
+      //   - For anonymizeUserAdminActions: returned `{ anonymizedRowCount:
+      //     0 }` so a GDPR erasure request appeared to complete while
+      //     leaving every row untouched. The audit emission contract in
+      //     `admin-action-retention.ts` says the library owns the success
+      //     emission, but no library means no row written either — so the
+      //     forensic trail was missing too.
+      //   - For previewAdminActionErasure: falsely told the admin "nothing
+      //     to erase" so they'd skip the confirm dialog and assume the
+      //     account had no admin-action footprint.
+      setRetentionPolicy: () => Effect.fail(notAvailable()),
+      purgeExpiredEntries: () => Effect.fail(notAvailable()),
+      hardDeleteExpired: () => Effect.fail(notAvailable()),
+      exportAuditLog: () => Effect.fail(notAvailable()),
       setAdminActionRetentionPolicy: () => Effect.fail(notAvailable()),
-      purgeAdminActionExpired: () => Effect.succeed([]),
-      anonymizeUserAdminActions: () =>
-        Effect.succeed({ anonymizedRowCount: 0 }),
-      previewAdminActionErasure: () =>
-        Effect.succeed({ anonymizableRowCount: 0 }),
+      purgeAdminActionExpired: () => Effect.fail(notAvailable()),
+      anonymizeUserAdminActions: () => Effect.fail(notAvailable()),
+      previewAdminActionErasure: () => Effect.fail(notAvailable()),
+      // Scheduler lifecycle stays as void no-ops — `makeSchedulerLive`
+      // calls these unconditionally at startup without a feature flag,
+      // and a no-op is the correct self-hosted behavior (no scheduler
+      // job to start, none to stop). Splitting AuditRetention into a
+      // separate AuditPurgeScheduler Tag is tracked as a follow-up.
       startAuditPurgeScheduler: () => {},
       stopAuditPurgeScheduler: () => {},
     } satisfies AuditRetentionShape;

--- a/packages/api/src/lib/effect/services.ts
+++ b/packages/api/src/lib/effect/services.ts
@@ -2074,20 +2074,27 @@ export const NoopRolesPolicyLayer: Layer.Layer<RolesPolicy> = Layer.sync(
       );
     return {
       customRolesActive: false,
-      // Skip the `custom_roles` DB read — self-hosted shouldn't have
-      // those rows seeded (the `seedBuiltinRoles` path is gated on
-      // `requireEnterprise`), and the read on every admin request
-      // would be wasted IO. EE's `RolesPolicyLive` re-binds to the
-      // full `checkPermission` so workspaces with seeded roles get
-      // the granular resolution.
+      // `checkPermission` deliberately delegates to the legacy resolver
+      // — every admin route depends on this surface, and the no-op MUST
+      // continue to authorize admin/owner/platform_admin on self-hosted
+      // installs. EE's `RolesPolicyLive` re-binds to the full
+      // `checkPermission` so workspaces with seeded roles get granular
+      // resolution. (See `lib/auth/permission-resolve.ts`.)
       checkPermission: checkPermissionLegacy,
-      listRoles: () => Effect.succeed([]),
-      getRole: () => Effect.succeed(null),
-      getRoleByName: () => Effect.succeed(null),
+      // All custom-role CRUD methods consistently fail with EnterpriseError
+      // on self-hosted. Pre-#2587 the reads silently returned empty arrays
+      // and the writes failed — UI dead-end (admin sees "no roles yet,
+      // click create" → click → 403). Failing both sides surfaces a single
+      // coherent gate the UI renders as the enterprise-upsell envelope.
+      // Admin tooling that needs to render different copy on self-hosted
+      // reads `customRolesActive: false` from the Tag's shape.
+      listRoles: () => Effect.fail(notAvailable("listRoles")),
+      getRole: () => Effect.fail(notAvailable("getRole")),
+      getRoleByName: () => Effect.fail(notAvailable("getRoleByName")),
       createRole: () => Effect.fail(notAvailable("createRole")),
       updateRole: () => Effect.fail(notAvailable("updateRole")),
       deleteRole: () => Effect.fail(notAvailable("deleteRole")),
-      listRoleMembers: () => Effect.succeed([]),
+      listRoleMembers: () => Effect.fail(notAvailable("listRoleMembers")),
       assignRole: () => Effect.fail(notAvailable("assignRole")),
     } satisfies RolesPolicyShape;
   },

--- a/packages/api/src/lib/effect/services.ts
+++ b/packages/api/src/lib/effect/services.ts
@@ -1196,8 +1196,6 @@ export interface CreateApprovalRequestInput {
 }
 
 export interface ApprovalGateShape {
-  /** False when EE approval workflows aren't loaded — gate bypasses entirely. */
-  readonly available: boolean;
   /** Decide whether a query needs approval. No-op returns `{ required: false, matchedRules: [] }`. */
   readonly checkApprovalRequired: (
     orgId: string | undefined,
@@ -1274,7 +1272,6 @@ export const NoopApprovalGateLayer: Layer.Layer<ApprovalGate> = Layer.sync(
         code: "not_found",
       });
     return {
-      available: false,
       checkApprovalRequired: () =>
         Effect.succeed({ required: false, matchedRules: [] }),
       hasApprovedRequest: () => Effect.succeed(false),

--- a/packages/api/src/lib/effect/services.ts
+++ b/packages/api/src/lib/effect/services.ts
@@ -1271,16 +1271,23 @@ export const NoopApprovalGateLayer: Layer.Layer<ApprovalGate> = Layer.sync(
         message: `Approval request "${id}" not found.`,
         code: "not_found",
       });
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { EnterpriseError: EnterpriseErrorClass } = require("@atlas/api/lib/effect/errors") as {
+      EnterpriseError: new (message?: string) => import("@atlas/api/lib/effect/errors").EnterpriseError;
+    };
+    const notAvailable = () =>
+      new EnterpriseErrorClass("Approval workflows require enterprise features to be enabled.");
     return {
       checkApprovalRequired: () =>
         Effect.succeed({ required: false, matchedRules: [] }),
       hasApprovedRequest: () => Effect.succeed(false),
-      // `createApprovalRequest` is only reached when checkApprovalRequired
-      // returns `required: true`. With the no-op gate that's never the
-      // case, so this is a defensive impl — die so a regression that
-      // routes through here is loud rather than silent.
-      createApprovalRequest: () =>
-        Effect.die("createApprovalRequest called against no-op ApprovalGate"),
+      // `createApprovalRequest` is reached when checkApprovalRequired
+      // returned `required: true`. The no-op never returns `required:
+      // true`, so this is a defensive impl — fail with EnterpriseError
+      // (not Effect.die) so any regression that lands here surfaces
+      // through the typed error channel and route-layer catchAll (→ 403)
+      // instead of bypassing both as an unrecoverable defect (→ 500).
+      createApprovalRequest: () => Effect.fail(notAvailable()),
       listApprovalRules: () => Effect.succeed([]),
       createApprovalRule: (_orgId, _input) =>
         Effect.fail(notFound("__no_op__")),
@@ -1339,22 +1346,32 @@ export class SlaMetrics extends Context.Tag("SlaMetrics")<
   SlaMetrics,
   SlaMetricsShape
 >() {}
-export const NoopSlaMetricsLayer: Layer.Layer<SlaMetrics> = Layer.succeed(
+// `Effect.fail(new EnterpriseError(...))` rather than `Effect.die(...)` on
+// the methods that have no sensible self-hosted return — defects bypass
+// `Effect.catchAll` and the typed error channel, so a route that catches
+// would still see a 500 with no `requestId`-correlated log. The `Error`
+// channel in the shape already accommodates EnterpriseError.
+export const NoopSlaMetricsLayer: Layer.Layer<SlaMetrics> = Layer.sync(
   SlaMetrics,
-  {
-    available: false,
-    recordQueryMetric: () => Effect.void,
-    getAllWorkspaceSLA: () => Effect.succeed([]),
-    getWorkspaceSLADetail: () =>
-      Effect.die("SLA monitoring requires enterprise features to be enabled."),
-    getThresholds: () =>
-      Effect.die("SLA monitoring requires enterprise features to be enabled."),
-    updateThresholds: () =>
-      Effect.die("SLA monitoring requires enterprise features to be enabled."),
-    getAlerts: () => Effect.succeed([]),
-    acknowledgeAlert: () => Effect.succeed(false),
-    evaluateAlerts: () => Effect.succeed([]),
-  } satisfies SlaMetricsShape,
+  () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { EnterpriseError: EnterpriseErrorClass } = require("@atlas/api/lib/effect/errors") as {
+      EnterpriseError: new (message?: string) => import("@atlas/api/lib/effect/errors").EnterpriseError;
+    };
+    const notAvailable = () =>
+      new EnterpriseErrorClass("SLA monitoring requires enterprise features to be enabled.");
+    return {
+      available: false,
+      recordQueryMetric: () => Effect.void,
+      getAllWorkspaceSLA: () => Effect.succeed([]),
+      getWorkspaceSLADetail: () => Effect.fail(notAvailable()),
+      getThresholds: () => Effect.fail(notAvailable()),
+      updateThresholds: () => Effect.fail(notAvailable()),
+      getAlerts: () => Effect.succeed([]),
+      acknowledgeAlert: () => Effect.succeed(false),
+      evaluateAlerts: () => Effect.succeed([]),
+    } satisfies SlaMetricsShape;
+  },
 );
 
 // ── BackupsManager (#2568 — slice 6/11 of #2017) ─────────────────────
@@ -1416,20 +1433,28 @@ export class BackupsManager extends Context.Tag("BackupsManager")<
   BackupsManager,
   BackupsManagerShape
 >() {}
-export const NoopBackupsManagerLayer: Layer.Layer<BackupsManager> = Layer.succeed(
+export const NoopBackupsManagerLayer: Layer.Layer<BackupsManager> = Layer.sync(
   BackupsManager,
-  {
+  () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { EnterpriseError: EnterpriseErrorClass } = require("@atlas/api/lib/effect/errors") as {
+      EnterpriseError: new (message?: string) => import("@atlas/api/lib/effect/errors").EnterpriseError;
+    };
+    const notAvailable = () =>
+      new EnterpriseErrorClass("Automated backups require enterprise features to be enabled.");
+    return {
     available: false,
-    getBackupConfig: () => Effect.die("Backups not configured."),
-    updateBackupConfig: () => Effect.die("Backups not configured."),
-    createBackup: () => Effect.die("Backups not configured."),
+    getBackupConfig: () => Effect.fail(notAvailable()),
+    updateBackupConfig: () => Effect.fail(notAvailable()),
+    createBackup: () => Effect.fail(notAvailable()),
     listBackups: () => Effect.succeed([]),
     getBackupById: () => Effect.succeed(null),
     purgeExpiredBackups: () => Effect.succeed(0),
-    verifyBackup: () => Effect.die("Backups not configured."),
-    requestRestore: () => Effect.die("Backups not configured."),
-    executeRestore: () => Effect.die("Backups not configured."),
-  } satisfies BackupsManagerShape,
+    verifyBackup: () => Effect.fail(notAvailable()),
+    requestRestore: () => Effect.fail(notAvailable()),
+    executeRestore: () => Effect.fail(notAvailable()),
+    } satisfies BackupsManagerShape;
+  },
 );
 
 // ── AuditRetention (#2569 — slice 7/11 of #2017) ─────────────────────
@@ -1617,19 +1642,30 @@ export class IpAllowlistPolicy extends Context.Tag("IpAllowlistPolicy")<
   IpAllowlistPolicy,
   IpAllowlistPolicyShape
 >() {}
-export const NoopIpAllowlistPolicyLayer: Layer.Layer<IpAllowlistPolicy> =
-  Layer.succeed(IpAllowlistPolicy, {
-    available: false,
-    checkIPAllowlist: () => Effect.succeed({ allowed: true }),
-    listIPAllowlistEntries: () => Effect.succeed([]),
-    // Defensive: only reachable if the admin route bypasses the
-    // `available` check. Die so a regression that lands an entry on the
-    // no-op default is loud rather than a silent partial state.
-    addIPAllowlistEntry: () =>
-      Effect.die("IpAllowlistPolicy.addIPAllowlistEntry called against no-op default"),
-    removeIPAllowlistEntry: () => Effect.succeed(false),
-    invalidateCache: () => {},
-  } satisfies IpAllowlistPolicyShape);
+export const NoopIpAllowlistPolicyLayer: Layer.Layer<IpAllowlistPolicy> = Layer.sync(
+  IpAllowlistPolicy,
+  () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { EnterpriseError: EnterpriseErrorClass } = require("@atlas/api/lib/effect/errors") as {
+      EnterpriseError: new (message?: string) => import("@atlas/api/lib/effect/errors").EnterpriseError;
+    };
+    const notAvailable = () =>
+      new EnterpriseErrorClass("IP allowlist requires enterprise features to be enabled.");
+    return {
+      available: false,
+      checkIPAllowlist: () => Effect.succeed({ allowed: true }),
+      listIPAllowlistEntries: () => Effect.succeed([]),
+      // Defensive: only reachable if the admin route bypasses the
+      // `available` check. Fail with EnterpriseError (not Effect.die)
+      // so the route-layer catchAll surfaces a 403 instead of an
+      // unrecoverable 500 defect — matches the pattern across the other
+      // Noop layers post-#2587.
+      addIPAllowlistEntry: () => Effect.fail(notAvailable()),
+      removeIPAllowlistEntry: () => Effect.succeed(false),
+      invalidateCache: () => {},
+    } satisfies IpAllowlistPolicyShape;
+  },
+);
 
 // ── SSOPolicy (#2570 — slice 8/11 of #2017) ──────────────────────────
 //

--- a/packages/api/src/lib/effect/services.ts
+++ b/packages/api/src/lib/effect/services.ts
@@ -1577,27 +1577,12 @@ export const NoopAuditRetentionLayer: Layer.Layer<AuditRetention> = Layer.sync(
     const notAvailable = makeNotAvailable("Audit retention requires enterprise features to be enabled.");
     return {
       available: false,
-      // Pure reads — "no policy configured" is the honest answer on
-      // self-hosted (admin-audit-retention.ts renders `{ policy: null }`
-      // as the not-configured envelope, no harm done).
+      // Pure reads — "no policy configured" is honest on self-hosted.
       getRetentionPolicy: () => Effect.succeed(null),
       getAdminActionRetentionPolicy: () => Effect.succeed(null),
-      // Mutations + destructive ops MUST fail with EnterpriseError. The
-      // routes declare `domainErrors: [retentionDomainError]` so a
-      // RetentionError or EnterpriseError surfaces through `classifyError`
-      // as a 4xx envelope. Pre-#2594 these returned silent success which:
-      //   - For purgeExpiredEntries / hardDeleteExpired / purgeAdminAction:
-      //     reported "nothing to purge" without doing anything, masking
-      //     a misconfigured install from operator monitoring.
-      //   - For anonymizeUserAdminActions: returned `{ anonymizedRowCount:
-      //     0 }` so a GDPR erasure request appeared to complete while
-      //     leaving every row untouched. The audit emission contract in
-      //     `admin-action-retention.ts` says the library owns the success
-      //     emission, but no library means no row written either — so the
-      //     forensic trail was missing too.
-      //   - For previewAdminActionErasure: falsely told the admin "nothing
-      //     to erase" so they'd skip the confirm dialog and assume the
-      //     account had no admin-action footprint.
+      // Destructive ops fail loudly so a misconfigured install doesn't
+      // silently report fake success (the GDPR `anonymizeUserAdminActions`
+      // pretend-succeed was the most consequential of the original bugs).
       setRetentionPolicy: () => Effect.fail(notAvailable()),
       purgeExpiredEntries: () => Effect.fail(notAvailable()),
       hardDeleteExpired: () => Effect.fail(notAvailable()),

--- a/packages/api/src/lib/effect/services.ts
+++ b/packages/api/src/lib/effect/services.ts
@@ -1578,7 +1578,7 @@ export const NoopAuditRetentionLayer: Layer.Layer<AuditRetention> = Layer.sync(
       // Mutations + destructive ops MUST fail with EnterpriseError. The
       // routes declare `domainErrors: [retentionDomainError]` so a
       // RetentionError or EnterpriseError surfaces through `classifyError`
-      // as a 4xx envelope. Pre-#2587 these returned silent success which:
+      // as a 4xx envelope. Pre-#2594 these returned silent success which:
       //   - For purgeExpiredEntries / hardDeleteExpired / purgeAdminAction:
       //     reported "nothing to purge" without doing anything, masking
       //     a misconfigured install from operator monitoring.
@@ -1681,7 +1681,7 @@ export const NoopIpAllowlistPolicyLayer: Layer.Layer<IpAllowlistPolicy> = Layer.
       // `available` check. Fail with EnterpriseError (not Effect.die)
       // so the route-layer catchAll surfaces a 403 instead of an
       // unrecoverable 500 defect — matches the pattern across the other
-      // Noop layers post-#2587.
+      // Noop layers post-#2594.
       addIPAllowlistEntry: () => Effect.fail(notAvailable()),
       removeIPAllowlistEntry: () => Effect.succeed(false),
       invalidateCache: () => {},
@@ -2082,7 +2082,7 @@ export const NoopRolesPolicyLayer: Layer.Layer<RolesPolicy> = Layer.sync(
       // resolution. (See `lib/auth/permission-resolve.ts`.)
       checkPermission: checkPermissionLegacy,
       // All custom-role CRUD methods consistently fail with EnterpriseError
-      // on self-hosted. Pre-#2587 the reads silently returned empty arrays
+      // on self-hosted. Pre-#2594 the reads silently returned empty arrays
       // and the writes failed — UI dead-end (admin sees "no roles yet,
       // click create" → click → 403). Failing both sides surfaces a single
       // coherent gate the UI renders as the enterprise-upsell envelope.

--- a/packages/api/src/lib/effect/services.ts
+++ b/packages/api/src/lib/effect/services.ts
@@ -1023,7 +1023,11 @@ export const NoopModelRouterLayer: Layer.Layer<ModelRouter> = Layer.sync(
       getWorkspaceModelConfig: () => Effect.succeed(null),
       getWorkspaceModelConfigRaw: () => Effect.succeed(null),
       setWorkspaceModelConfig: () => Effect.fail(notAvailable()),
-      deleteWorkspaceModelConfig: () => Effect.succeed(false),
+      // Was `Effect.succeed(false)` pre-#2594 — surfaced as 404
+      // "Config not found" via admin route, falsely telling the admin
+      // their config was already gone. Fail loudly so 403 envelope
+      // makes the EE-not-installed state explicit.
+      deleteWorkspaceModelConfig: () => Effect.fail(notAvailable()),
       testModelConfig: () => Effect.fail(notAvailable()),
       reconcileModelDeprecation: () =>
         Effect.succeed({ status: "healthy" as const, suggestion: null }),
@@ -1304,7 +1308,9 @@ export const NoopApprovalGateLayer: Layer.Layer<ApprovalGate> = Layer.sync(
         Effect.fail(notFound("__no_op__")),
       updateApprovalRule: (_orgId, ruleId) =>
         Effect.fail(notFound(ruleId)),
-      deleteApprovalRule: () => Effect.succeed(false),
+      // Was `Effect.succeed(false)` pre-#2594 — silently lied that
+      // there was nothing to delete. Fail loudly via 403 envelope.
+      deleteApprovalRule: () => Effect.fail(notAvailable()),
       listApprovalRequests: () => Effect.succeed([]),
       getApprovalRequest: () => Effect.succeed(null),
       reviewApprovalRequest: (_orgId, requestId) =>
@@ -1375,7 +1381,9 @@ export const NoopSlaMetricsLayer: Layer.Layer<SlaMetrics> = Layer.sync(
       getThresholds: () => Effect.fail(notAvailable()),
       updateThresholds: () => Effect.fail(notAvailable()),
       getAlerts: () => Effect.succeed([]),
-      acknowledgeAlert: () => Effect.succeed(false),
+      // Was `Effect.succeed(false)` pre-#2594 — silently reported
+      // "alert not found" when EE was missing. Fail loudly.
+      acknowledgeAlert: () => Effect.fail(notAvailable()),
       evaluateAlerts: () => Effect.succeed([]),
     } satisfies SlaMetricsShape;
   },
@@ -1678,7 +1686,10 @@ export const NoopIpAllowlistPolicyLayer: Layer.Layer<IpAllowlistPolicy> = Layer.
       // unrecoverable 500 defect — matches the pattern across the other
       // Noop layers post-#2594.
       addIPAllowlistEntry: () => Effect.fail(notAvailable()),
-      removeIPAllowlistEntry: () => Effect.succeed(false),
+      // SECURITY: was `Effect.succeed(false)` pre-#2594 — route
+      // mapped to 404 "entry not found", falsely telling admin the
+      // IP was removed. Entry stayed in DB; IP retained access.
+      removeIPAllowlistEntry: () => Effect.fail(notAvailable()),
       invalidateCache: () => {},
     } satisfies IpAllowlistPolicyShape;
   },
@@ -1798,7 +1809,10 @@ export const NoopSSOPolicyLayer: Layer.Layer<SSOPolicy> = Layer.sync(
       getSSOProvider: () => Effect.succeed(null),
       createSSOProvider: () => Effect.fail(notAvailable()),
       updateSSOProvider: () => Effect.fail(notAvailable()),
-      deleteSSOProvider: () => Effect.succeed(false),
+      // SECURITY: was `Effect.succeed(false)` pre-#2594 — route
+      // returned 404, admin assumed provider gone. Provider stayed
+      // in DB, still routing SSO logins. Fail loudly.
+      deleteSSOProvider: () => Effect.fail(notAvailable()),
       verifyDomain: () => Effect.fail(notAvailable()),
       checkDomainAvailability: () => Effect.fail(notAvailable()),
       testSSOProvider: () => Effect.fail(notAvailable()) as never,
@@ -1882,7 +1896,10 @@ export const NoopSCIMProvenanceLayer: Layer.Layer<SCIMProvenance> = Layer.sync(
     return {
       available: false,
       listConnections: () => Effect.succeed([]),
-      deleteConnection: () => Effect.succeed(false),
+      // Was `Effect.succeed(false)` pre-#2594 — route returned 404
+      // so admin assumed the SCIM connection was deleted. Connection
+      // stayed in DB; SCIM kept provisioning. Fail loudly.
+      deleteConnection: () => Effect.fail(notAvailable()),
       getSyncStatus: () =>
         Effect.succeed({
           connections: 0,
@@ -1891,7 +1908,8 @@ export const NoopSCIMProvenanceLayer: Layer.Layer<SCIMProvenance> = Layer.sync(
         }),
       listGroupMappings: () => Effect.succeed([]),
       createGroupMapping: () => Effect.fail(notAvailable()),
-      deleteGroupMapping: () => Effect.succeed(false),
+      // Same destructive-noop pattern as deleteConnection — fail loudly.
+      deleteGroupMapping: () => Effect.fail(notAvailable()),
       resolveGroupToRole: () => Effect.succeed(null),
     } satisfies SCIMProvenanceShape;
   },

--- a/packages/api/src/lib/scheduler/byot-catalog-refresh.ts
+++ b/packages/api/src/lib/scheduler/byot-catalog-refresh.ts
@@ -43,7 +43,7 @@ import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
 import type { AdminActionType } from "@atlas/api/lib/audit/actions";
 import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
 import { ModelRouter, type ModelRouterShape } from "@atlas/api/lib/effect/services";
-import { EnterpriseLayer } from "@atlas/api/lib/effect/enterprise-layer";
+import { runEnterprise } from "@atlas/api/lib/effect/enterprise-layer";
 import {
   type ByotRefreshCycleResult,
   type ByotCatalogRefreshSkipReason,
@@ -202,10 +202,10 @@ function probeModelRouter(): Promise<ModelRouterProbeResult> {
   if (_routerProbe) return _routerProbe;
   _routerProbe = (async () => {
     try {
-      const router = await Effect.runPromise(
+      const router = await runEnterprise(
         Effect.gen(function* () {
           return yield* ModelRouter;
-        }).pipe(Effect.provide(EnterpriseLayer)),
+        }),
       );
       if (!router.available) {
         return {

--- a/packages/api/src/lib/tools/sql.ts
+++ b/packages/api/src/lib/tools/sql.ts
@@ -46,7 +46,7 @@ import {
   type ApprovalGateShape,
   type MaskingContext,
 } from "@atlas/api/lib/effect/services";
-import { EnterpriseLayer } from "@atlas/api/lib/effect/enterprise-layer";
+import { runEnterprise } from "@atlas/api/lib/effect/enterprise-layer";
 
 /**
  * Run `MaskingPolicy.applyMasking` via `EnterpriseLayer`. Promise-shaped
@@ -59,11 +59,11 @@ import { EnterpriseLayer } from "@atlas/api/lib/effect/enterprise-layer";
 function applyMaskingViaTag(
   ctx: MaskingContext,
 ): Promise<Record<string, unknown>[]> {
-  return Effect.runPromise(
+  return runEnterprise(
     Effect.gen(function* () {
       const masking = yield* MaskingPolicy;
       return yield* masking.applyMasking(ctx);
-    }).pipe(Effect.provide(EnterpriseLayer)),
+    }),
   );
 }
 
@@ -76,10 +76,10 @@ function applyMaskingViaTag(
  * paying for three separate `Effect.runPromise` round-trips (#2567).
  */
 function loadApprovalGate(): Promise<ApprovalGateShape> {
-  return Effect.runPromise(
+  return runEnterprise(
     Effect.gen(function* () {
       return yield* ApprovalGate;
-    }).pipe(Effect.provide(EnterpriseLayer)),
+    }),
   );
 }
 
@@ -94,11 +94,11 @@ function recordSlaMetric(
   durationMs: number,
   isError: boolean,
 ): Promise<void> {
-  return Effect.runPromise(
+  return runEnterprise(
     Effect.gen(function* () {
       const sla = yield* SlaMetrics;
       return yield* sla.recordQueryMetric(workspaceId, durationMs, isError);
-    }).pipe(Effect.provide(EnterpriseLayer)),
+    }),
   );
 }
 

--- a/scripts/__tests__/check-ee-imports.test.sh
+++ b/scripts/__tests__/check-ee-imports.test.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+# Adversarial fixture suite for scripts/check-ee-imports.sh.
+#
+# Pre-#2594 the gate's comment-stripping sed deleted any line containing
+# both `/*` and `*/`, so a same-line block comment followed by a real
+# EE import passed silently. This suite locks in the fix + flags any
+# future regression.
+#
+# Each fixture lives in a temporary mirror of the repo layout so the
+# script can run against it without touching the real codebase.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$SCRIPT_DIR/check-ee-imports.sh"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+if [ ! -f "$SCRIPT" ]; then
+  echo "::error::script under test not found at $SCRIPT" >&2
+  exit 2
+fi
+
+PASS=0
+FAIL=0
+
+# `expect_pass FIXTURE_FILE` — the gate should exit 0 against this fixture.
+# `expect_fail FIXTURE_FILE` — the gate should exit 1 and list FIXTURE_FILE.
+run_fixture() {
+  local expected="$1"      # "pass" or "fail"
+  local fixture_name="$2"
+  local fixture_content="$3"
+
+  local tmp
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' RETURN
+
+  # Mirror the layout the script expects: CORE_DIR + ALLOWED_FILE.
+  mkdir -p "$tmp/packages/api/src/lib/effect" "$tmp/packages/api/src/lib"
+  cat > "$tmp/packages/api/src/lib/effect/enterprise-layer.ts" <<EOF
+// Allowed-file placeholder for the fixture suite.
+EOF
+  # Write the fixture (escape any nested $).
+  echo "$fixture_content" > "$tmp/packages/api/src/lib/$fixture_name.ts"
+
+  # Run the gate; capture status without aborting the suite.
+  local status=0
+  (cd "$tmp" && bash "$SCRIPT" > /dev/null 2>&1) || status=$?
+
+  if [ "$expected" = "pass" ] && [ "$status" -eq 0 ]; then
+    echo "  ok   $fixture_name (expected pass)"
+    PASS=$((PASS + 1))
+  elif [ "$expected" = "fail" ] && [ "$status" -ne 0 ]; then
+    echo "  ok   $fixture_name (expected fail)"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL $fixture_name — expected $expected, got status=$status" >&2
+    FAIL=$((FAIL + 1))
+  fi
+
+  rm -rf "$tmp"
+  trap - RETURN
+}
+
+echo "Adversarial fixtures for scripts/check-ee-imports.sh"
+echo "===================================================="
+
+# --- Positive fixtures (the gate must flag) -------------------------
+
+run_fixture fail "bare-import" \
+  'import { foo } from "@atlas/ee/something";'
+
+run_fixture fail "same-line-block-comment-then-import" \
+  '/* TODO: revisit */ import { foo } from "@atlas/ee/something";'
+
+run_fixture fail "jsdoc-then-import-same-line" \
+  '/** explain */ import { foo } from "@atlas/ee/something";'
+
+run_fixture fail "dynamic-import" \
+  'const mod = await import("@atlas/ee/something");'
+
+run_fixture fail "require-cjs" \
+  'const mod = require("@atlas/ee/something");'
+
+run_fixture fail "trailing-block-comment-on-import-line" \
+  'import { foo } from "@atlas/ee/something"; /* old */'
+
+# --- Negative fixtures (the gate must NOT flag) ---------------------
+
+run_fixture pass "line-comment-with-pattern" \
+  '// Inverts await import("@atlas/ee/something")'
+
+run_fixture pass "multi-line-block-comment-with-pattern" \
+  '/* this references await import("@atlas/ee/something") for history; * the production code uses yield* Tag instead. */'
+
+run_fixture pass "empty-file" \
+  '// no EE references here'
+
+# --- Summary --------------------------------------------------------
+
+echo "----------------------------------------------------"
+echo "Passed: $PASS  Failed: $FAIL"
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi

--- a/scripts/check-ee-imports.sh
+++ b/scripts/check-ee-imports.sh
@@ -44,10 +44,10 @@ PATTERN='from "@atlas/ee|import\("@atlas/ee|require\("@atlas/ee'
 #   1. s|/\*([^*]|\*+[^*/])*\*+/||g
 #        Strip same-line block comments (canonical C-comment regex —
 #        handles plain `/* x */` and JSDoc-style `/** x */` on a single
-#        line). MUST run before the range delete: pre-#2587 the range
+#        line). MUST run before the range delete: pre-#2594 the range
 #        delete saw a same-line `/* … */ import { x } from "@atlas/ee/y"`
 #        and deleted the whole line including the real import, silently
-#        whitelisting a structural EE dependency — see #2587 / commit
+#        whitelisting a structural EE dependency — see #2594 / commit
 #        message for the adversarial fixtures that motivated this fix.
 #   2. /\/\*/,/\*\// d
 #        Delete lines participating in a true multi-line block comment

--- a/scripts/check-ee-imports.sh
+++ b/scripts/check-ee-imports.sh
@@ -39,15 +39,34 @@ PATTERN='from "@atlas/ee|import\("@atlas/ee|require\("@atlas/ee'
 
 # Strip comments before pattern-matching so a historical reference like
 # `// Inverts await import("@atlas/ee/...")` in a docstring doesn't
-# false-positive. The sed program:
-#   /\/\*/,/\*\// d   — delete any line inside `/* … */` (single- or
-#                       multi-line block comments)
-#   s|//.*$||         — strip trailing `// …` from each remaining line
-# This is intentionally narrow: it does not try to handle string
-# literals containing `//` (none in core touch `@atlas/ee` in a
-# literal). If a regression introduces such a literal, the gate will
-# still flag the file — which is the conservative direction.
-STRIP_COMMENTS='sed -E "/\/\*/,/\*\// d; s|//.*\$||"'
+# false-positive. The sed program runs three substitutions in order:
+#
+#   1. s|/\*([^*]|\*+[^*/])*\*+/||g
+#        Strip same-line block comments (canonical C-comment regex —
+#        handles plain `/* x */` and JSDoc-style `/** x */` on a single
+#        line). MUST run before the range delete: pre-#2587 the range
+#        delete saw a same-line `/* … */ import { x } from "@atlas/ee/y"`
+#        and deleted the whole line including the real import, silently
+#        whitelisting a structural EE dependency — see #2587 / commit
+#        message for the adversarial fixtures that motivated this fix.
+#   2. /\/\*/,/\*\// d
+#        Delete lines participating in a true multi-line block comment
+#        (the canonical sed range delete; safe now that same-line block
+#        comments are already gone by step 1).
+#   3. s|//.*$||
+#        Strip trailing `// …` line comments.
+#
+# This is intentionally narrow: it does not try to parse string
+# literals containing `from "@atlas/ee` — those would still false-
+# positive. None exist in core today; the conservative direction is to
+# flag a literal rather than silently allow one, so a future
+# error-message string that needs the pattern should use concatenation
+# (e.g. `"from \"" + "@atlas/ee\""`) or, better, name the package
+# inline-via-a-constant.
+# `#` delimiter for the substitutions so the ERE alternation `|` inside
+# the block-comment regex doesn't collide with the substitution
+# delimiter (sed would otherwise see `|` as the end of the search half).
+STRIP_COMMENTS='sed -E "s#/\*([^*]|\*+[^*/])*\*+/##g; /\/\*/,/\*\// d; s#//.*\$##"'
 
 # Candidate files: any file whose raw text contains the pattern. We
 # still post-filter each via STRIP_COMMENTS to weed out comment-only


### PR DESCRIPTION
## Summary

The 1.5.1 closeout cross-slice review surfaced a coherent set of bugs across the 11 slices that landed milestone #48. None were single-PR-visible — each slice's reviewer would have accepted the slice-local code, but reading the union exposed cumulative drift in fail-closed semantics, error-channel hygiene, hot-path performance, and helper duplication.

A second pass of `/pr-review-toolkit:review-pr` against this PR caught additional misses (the off-by-one on PR-number references, 7 destructive Noops returning `succeed(false)` that this PR's first pass missed, speculative exports with zero callers, plus regression-test gaps). Both passes are folded in.

## Each commit is one focused fix

**CRITICAL fixes (pass 1)**

- **`89a702d7`** — `fix(ci)`: grep gate same-line block-comment bypass. `/* */ import { x } from "@atlas/ee/y"` on one line silently passed the gate; adversarial fixtures verify the new sed strips same-line block comments before the range delete.
- **`98104fdc`** — `fix(api)`: `MaskingPolicy` no-op preserves rows reference. The `[...ctx.rows]` spread broke `maskingApplied = maskedRows !== result.rows` — every self-hosted query against a classified table mis-reported `maskingApplied: true` in audit + dashboard preview.
- **`22d93a61`** — `fix(api)`: Noop layers fail with `EnterpriseError`, not `Effect.die` defects. 11 methods across ApprovalGate / SlaMetrics / BackupsManager / IpAllowlistPolicy migrated from defects (→ 500, bypass `catchAll`) to typed failures (→ 403 via existing `domainError` mappings).
- **`bbf19c4d`** — `fix(api)`: `AuditRetention` no-ops fail loudly on destructive ops. Pre-PR `anonymizeUserAdminActions` returned `{ anonymizedRowCount: 0 }` — **GDPR erasure pretending to succeed**. Now fails with EnterpriseError; pure-read GETs preserved as `succeed(null)` ("no policy configured" is honest).
- **`8a078f5e`** + **`d34a4863`** — `fix(api)`: IP allowlist middleware test-harness catch narrowed. Pass 1 broadened to catch EE-load-related substrings; pass 2 tightened back to the precise Effect "Service not found: IpAllowlistPolicy" missing-Tag signal so real production failures fail-closed 503.
- **`97fba134`** — `perf(api)`: hoist module-level `ManagedRuntime` for EnterpriseLayer. Pre-PR a single admin SQL request rebuilt the EnterpriseLayer 6-8 times. Now: lazy singleton, 11 production call sites migrated.

**CRITICAL fixes (pass 2 — pr-review-toolkit caught misses)**

- **`74142c5d`** — `fix(api)`: destructive Noop methods fail loudly — **7 missed sites** where the same `succeed(false)` → 404 pretend-succeed lived: `deleteWorkspaceModelConfig`, `deleteApprovalRule`, `acknowledgeAlert`, **`removeIPAllowlistEntry`** (SECURITY — admin assumed IP removed, IP retained access), **`deleteSSOProvider`** (SECURITY — provider still routing), SCIM `deleteConnection`/`deleteGroupMapping`.
- **`778f1633`** — `chore`: fix `#2587` → `#2594` references throughout. Pass 1 self-referenced this PR as #2587, but #2587 is actually the AuditRetention split follow-up. 16+ in-code references, plus the 7 follow-up issue bodies, plus the `#2593` reference re-pointed to `#2589` (Tag.available audit is the right tracker for the SaaS-fail-closed weak spot).

**HIGH / MEDIUM fixes**

- **`6ccd298c` + `04bf129a`** — `fix(api)`: `ConditionalEELayer` load failure logs at ERROR with structured `event: "enterprise.load_failed"` (alertable). Documented as a "known weak spot" with consumer-side hardening tracked in #2589 because the immediate fail-Layer-construction approach cascaded through 16 test files.
- **`a1763579`** — `refactor(api)`: consolidate `isEnterpriseEnabled` to `enterprise-config.ts`. Four copies → two.
- **`a1154301`** — `fix(api)`: drop dead `ApprovalGate.available` field.
- **`39452447`** — `fix(api)`: `RolesPolicy` Noop consistently fails (no UI dead-end).
- **`db96e778`** — `refactor(api)`: promote `retentionDomainError` to `shared-retention.ts`.
- **`8dbadade`** — `test(api)`: extend `enterprise-layer` mock to cover the new runtime exports.
- **`172a76e8`** — `refactor(api)`: extract `makeNotAvailable` helper (10 inline lazy-require blocks → 10 one-liners).
- **`39afdf17`** — `refactor(api)`: delete speculative `runEnterpriseExit` + `__resetEnterpriseRuntimeForTesting` (zero production callers).
- **`d34a4863`** — `refactor(api)`: trim verbose comments per simplifier + comment-analyzer.
- **`15a9295e`** — `docs(api)`: JSDoc downgrade-modes list includes AuditRetention reads.

**Test coverage adds (pr-test-analyzer round 2)**

- **`fcd80481` + `5f67b7c2`** — `test(ci)`: adversarial-fixture suite for the EE-imports grep gate (9 cases) + wired into CI drift job.
- **`ac7cb3f8`** — `test(api)`: `noop-layers.test.ts` regression suite (18 cases) — pins every Noop fix in this PR: `MaskingPolicy` reference identity, `Effect.fail`-not-`die` for 4 methods, destructive-noop fails for 7 methods, GDPR pretend-succeed fix. A future "simplify the Noop" PR that regresses any of these trips at least one case.

## Follow-ups filed

- **#2587** — Split `AuditRetention` Tag into CRUD + Scheduler (leaky abstraction)
- **#2588** — Extract `makeTestEnterpriseLayer` helper + migrate ~10 test files
- **#2589** — Normalize Tag.available semantics across the 16 enterprise Tags (incl. the consumer-side SaaS-fail-closed work)
- **#2590** — Wire `ee-stub-build` into branch-protection required checks
- **#2591** — `scim-provenance` runtime migration (returns Effect, not Promise)
- **#2592** — Detach #2058 / #2123 from closed milestone #48 to an architecture-backlog
- **#2593** — Compile-time exhaustiveness gate for route `domainErrors`

## Test plan

- [x] `bash scripts/check-ee-imports.sh` — green
- [x] `bash scripts/__tests__/check-ee-imports.test.sh` — 9/9 fixtures pass
- [x] `bash scripts/check-schema-drift.sh` — green
- [x] `tsgo --noEmit -p packages/api/tsconfig.json` — clean
- [x] `eslint` on changed files — clean
- [x] `bun run scripts/test-isolated.ts --affected` — 154 / 154 pass (pass 1)
- [x] `noop-layers.test.ts` — 18 / 18 pass (pass 2 regression suite)
- [ ] Full `bun run test` in CI
- [ ] Lighthouse + Deploy Validation in CI