### PR TITLE
chore: #2592 — detach milestone-1.5.1 leftover issues to Architecture Backlog

### DIFF
--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -119,3 +119,27 @@ gh issue list -R AtlasDevHQ/atlas --state open --search "<keywords>" --json numb
 ```
 
 If a matching issue exists, comment on it instead of duplicating.
+
+## Detaching unfinished issues at milestone closeout
+
+**Closed milestones reflect only what shipped.** An issue that was scoped into a milestone but didn't make the cut must be detached *before* the milestone is closed — otherwise `gh issue list -m <N>` (and the milestone page on github.com) misrepresent what the milestone delivered.
+
+The convention is to move detached work to the open **`Architecture Backlog`** milestone (#49) — long-running architecture work that doesn't fit a specific milestone. Pick from it when a slice naturally fits an active milestone.
+
+```bash
+# During /closeout, for any issue scoped to the milestone but still open:
+gh issue edit <number> -R AtlasDevHQ/atlas --milestone "Architecture Backlog"
+```
+
+**Don't** strip the milestone outright (`--remove-milestone`). Milestone-less issues become invisible to `/next` and lose the discoverability that the backlog milestone gives them. The `architecture` label complements but does not replace the backlog milestone.
+
+**Audit gate.** As part of closeout, run:
+
+```bash
+gh api repos/AtlasDevHQ/atlas/milestones --paginate \
+  --jq '.[] | select(.state=="closed" and .open_issues>0) | {number, title, open_issues}'
+```
+
+Output must be empty before the milestone closeout is complete. If it isn't, migrate the open issues to `Architecture Backlog` (or another active milestone if the work is being picked up immediately).
+
+**Carry-over watch.** An issue that gets detached during one closeout, then re-attached to a later milestone without being completed, then detached again, is a signal — the scope is genuinely long-running architecture rather than a single milestone slice. Examples from project history: #2123 (explore tool refactor) was detached from 1.4.1 closeout, pulled into 1.5.1 at kickoff as a candidate refactor, never picked up, and detached again at 1.5.1 closeout. These belong in `Architecture Backlog` semi-permanently — pull them into an active milestone only when there's a concrete plan and an owner.


### PR DESCRIPTION
Closes #2592.

## Summary

The 1.5.1 closeout left #2058 and #2123 attached to closed milestone #48, so `gh issue list -m 48` misrepresented what 1.5.1 shipped. The 1.4.1 closeout had already left #2109 / #2200 milestone-less, which made them invisible to `/next`. This PR formalises the convention via a new **Architecture Backlog** milestone (#49) and documents the pattern so future closeouts don't repeat it.

## Issue migrations (applied via gh CLI, no code change)

| Issue | Before | After |
|-------|--------|-------|
| #2058 — agent-auth provider | 1.5.1 (#48, closed) | Architecture Backlog (#49) |
| #2123 — explore tool refactor | 1.5.1 (#48, closed) | Architecture Backlog (#49) |
| #2109 — durable MCP session store | (no milestone) | Architecture Backlog (#49) |
| #2200 — Claude Desktop catalog submission | (no milestone) | Architecture Backlog (#49) |

Audit gate is clean — `gh api repos/AtlasDevHQ/atlas/milestones --paginate --jq '.[] | select(.state=="closed" and .open_issues>0)'` returns empty.

## Investigation: #2123 carry-over

MEMORY.md flagged #2123 as appearing in both the 1.4.1 and 1.5.1 leftover lists. Timeline confirms this is a real carry-over, not a duplicate:

- **2026-05-08** — attached to 1.4.1
- **2026-05-09** — detached from 1.4.1 at closeout (clean, alongside #2109 / #2200)
- **2026-05-17** — re-attached to 1.5.1 (likely 1.5.1 kickoff pulled it back in as a candidate refactor)
- **2026-05-18** — 1.5.1 closed with #2123 still attached, never picked up

The work is genuinely long-running architecture (file-ops → semantic ops for the `explore` tool) that fits no single milestone slice cleanly. The new docs section calls this out as a "carry-over watch" signal — pull these into an active milestone only when there's a concrete plan and an owner.

## Documented pattern

`docs/agents/issue-tracker.md` now has a "Detaching unfinished issues at milestone closeout" section covering:

- The convention (move detached work to Architecture Backlog, **not** `--remove-milestone`)
- The audit gate that closeouts must run before declaring done
- The carry-over watch signal, with #2123 as the worked example

## Test plan

- [x] Architecture Backlog milestone (#49) created and contains the 4 expected issues
- [x] Audit query returns empty — no closed milestones have open issues
- [x] `bun run lint` passes (docs-only change; 0 errors)
- [x] Diff is one file, docs-only