### PR TITLE
feat(api): #2593 — compile-time exhaustiveness gate for route domainErrors

### DIFF
--- a/packages/api/src/lib/effect/__tests__/hono.test.ts
+++ b/packages/api/src/lib/effect/__tests__/hono.test.ts
@@ -45,6 +45,17 @@ const {
   SchedulerExecutionError,
   DeliveryError,
   UnsafeRegionMigrationResetError,
+  // ── EE-domain errors (safety net — see #2593) ─────────────────────
+  RetentionError,
+  RoleError,
+  ApprovalError,
+  ResidencyError,
+  BrandingError,
+  DomainError,
+  ComplianceError,
+  ReportError,
+  ModelConfigError,
+  ModelConfigDecryptError,
 } = await import("../errors");
 
 // ---------------------------------------------------------------------------
@@ -243,6 +254,107 @@ describe("mapTaggedError", () => {
     expect(result.status).toBe(409);
     expect(result.code).toBe("conflict");
     expect(result.message).toBe("Cannot reset");
+  });
+
+  // ── EE-domain errors (safety-net mappings — see #2593) ──────────
+  //
+  // These tags ALSO flow through per-route `domainErrors: [...]`
+  // (which wins on `classifyError` precedence). The cases tested below
+  // are the safety net: an unwired route that yields one of these
+  // tagged errors gets a proper 4xx envelope instead of a generic 500.
+
+  it("maps RetentionError(validation) to 400", () => {
+    const result = mapTaggedError(new RetentionError({ message: "bad", code: "validation" }));
+    expect(result.status).toBe(400);
+    expect(result.code).toBe("bad_request");
+  });
+
+  it("maps RetentionError(not_found) to 404", () => {
+    const result = mapTaggedError(new RetentionError({ message: "missing", code: "not_found" }));
+    expect(result.status).toBe(404);
+    expect(result.code).toBe("not_found");
+  });
+
+  it("maps RoleError(builtin_protected) to 403", () => {
+    const result = mapTaggedError(new RoleError({ message: "builtin", code: "builtin_protected" }));
+    expect(result.status).toBe(403);
+    expect(result.code).toBe("forbidden");
+  });
+
+  it("maps RoleError(conflict) to 409", () => {
+    const result = mapTaggedError(new RoleError({ message: "dup", code: "conflict" }));
+    expect(result.status).toBe(409);
+    expect(result.code).toBe("conflict");
+  });
+
+  it("maps ApprovalError(expired) to 410", () => {
+    const result = mapTaggedError(new ApprovalError({ message: "expired", code: "expired" }));
+    expect(result.status).toBe(410);
+  });
+
+  it("maps ResidencyError(workspace_not_found) to 404", () => {
+    const result = mapTaggedError(
+      new ResidencyError({ message: "no workspace", code: "workspace_not_found" }),
+    );
+    expect(result.status).toBe(404);
+    expect(result.code).toBe("not_found");
+  });
+
+  it("maps ResidencyError(no_internal_db) to 503", () => {
+    const result = mapTaggedError(
+      new ResidencyError({ message: "no db", code: "no_internal_db" }),
+    );
+    expect(result.status).toBe(503);
+    expect(result.code).toBe("service_unavailable");
+  });
+
+  it("maps BrandingError(not_found) to 404", () => {
+    const result = mapTaggedError(new BrandingError({ message: "missing", code: "not_found" }));
+    expect(result.status).toBe(404);
+    expect(result.code).toBe("not_found");
+  });
+
+  it("maps DomainError(railway_error) to 502", () => {
+    const result = mapTaggedError(new DomainError({ message: "railway", code: "railway_error" }));
+    expect(result.status).toBe(502);
+    expect(result.code).toBe("upstream_error");
+  });
+
+  it("maps DomainError(no_internal_db) to 503", () => {
+    const result = mapTaggedError(new DomainError({ message: "no db", code: "no_internal_db" }));
+    expect(result.status).toBe(503);
+    expect(result.code).toBe("service_unavailable");
+  });
+
+  it("maps ComplianceError(conflict) to 409", () => {
+    const result = mapTaggedError(new ComplianceError({ message: "conflict", code: "conflict" }));
+    expect(result.status).toBe(409);
+    expect(result.code).toBe("conflict");
+  });
+
+  it("maps ReportError(not_available) to 404", () => {
+    const result = mapTaggedError(new ReportError({ message: "no report", code: "not_available" }));
+    expect(result.status).toBe(404);
+    expect(result.code).toBe("not_found");
+  });
+
+  it("maps ModelConfigError(test_failed) to 422", () => {
+    const result = mapTaggedError(
+      new ModelConfigError({ message: "test failed", code: "test_failed" }),
+    );
+    expect(result.status).toBe(422);
+    expect(result.code).toBe("unprocessable_entity");
+  });
+
+  it("maps ModelConfigDecryptError to 422 with sanitized message", () => {
+    const result = mapTaggedError(
+      new ModelConfigDecryptError({ configId: "cfg-1", cause: "key rotated" }),
+    );
+    expect(result.status).toBe(422);
+    expect(result.code).toBe("unprocessable_entity");
+    // Message stays generic — `configId` and `cause` are forensic-only.
+    expect(result.message).not.toContain("cfg-1");
+    expect(result.message).not.toContain("key rotated");
   });
 });
 

--- a/packages/api/src/lib/effect/errors.ts
+++ b/packages/api/src/lib/effect/errors.ts
@@ -34,6 +34,40 @@ export {
   UnknownTableError,
 } from "@atlas/api/lib/content-mode/port";
 
+// EE-domain errors (promoted to core in slices 4–11 of #2017) — folded
+// into `AtlasError` below so `classifyError` / `mapTaggedError` provide
+// a safety-net mapping when a route forgets to wire its per-route
+// `domainErrors: [...]` opt-in. Without this fallback (#2593), a new
+// admin route that yields a Tag whose error isn't listed surfaces as a
+// generic 500 in production instead of the expected 4xx envelope.
+// Per-route `domainErrors:` still wins on `classifyError` precedence
+// (instanceof check runs before the tagged-error fallback), so existing
+// routes keep their bespoke per-code status maps.
+import { RetentionError } from "@atlas/api/lib/audit/retention-errors";
+import { RoleError } from "@atlas/api/lib/auth/roles-errors";
+import { ApprovalError } from "@atlas/api/lib/governance/errors";
+import { ResidencyError } from "@atlas/api/lib/residency/errors";
+import { BrandingError } from "@atlas/api/lib/branding/branding-errors";
+import { DomainError } from "@atlas/api/lib/platform/domains-errors";
+import { ComplianceError, ReportError } from "@atlas/api/lib/compliance/errors";
+import {
+  ModelConfigError,
+  ModelConfigDecryptError,
+} from "@atlas/api/lib/model-routing/errors";
+
+export {
+  RetentionError,
+  RoleError,
+  ApprovalError,
+  ResidencyError,
+  BrandingError,
+  DomainError,
+  ComplianceError,
+  ReportError,
+  ModelConfigError,
+  ModelConfigDecryptError,
+};
+
 // ── Utilities ──────────────────────────────────────────────────────
 
 /** Normalize unknown caught values to Error. Used in Effect.tryPromise catch clauses. */
@@ -321,7 +355,18 @@ export type AtlasError =
   | DeliveryError
   | PublishPhaseError
   | UnknownTableError
-  | ExoticReadFilterUnavailableError;
+  | ExoticReadFilterUnavailableError
+  // ── EE-domain errors (safety net — see #2593) ───────────────────
+  | RetentionError
+  | RoleError
+  | ApprovalError
+  | ResidencyError
+  | BrandingError
+  | DomainError
+  | ComplianceError
+  | ReportError
+  | ModelConfigError
+  | ModelConfigDecryptError;
 
 /** Discriminant union of all known `_tag` values — derived from `AtlasError`. */
 export type AtlasErrorTag = AtlasError["_tag"];
@@ -361,6 +406,17 @@ export const ATLAS_ERROR_TAG_LIST = [
   "PublishPhaseError",
   "UnknownTableError",
   "ExoticReadFilterUnavailableError",
+  // ── EE-domain errors (safety net — see #2593) ───────────────────
+  "RetentionError",
+  "RoleError",
+  "ApprovalError",
+  "ResidencyError",
+  "BrandingError",
+  "DomainError",
+  "ComplianceError",
+  "ReportError",
+  "ModelConfigError",
+  "ModelConfigDecryptError",
 ] as const satisfies readonly AtlasErrorTag[];
 
 /** Compile-time check: every `AtlasErrorTag` must appear in the list. */

--- a/packages/api/src/lib/effect/hono.ts
+++ b/packages/api/src/lib/effect/hono.ts
@@ -136,6 +136,21 @@ function isAtlasError(error: { readonly _tag: string }): error is AtlasError {
 }
 
 /**
+ * Compile-time exhaustiveness guard for inner switches.
+ *
+ * After every variant of an error's `code` union is handled, TS narrows
+ * `error` to `never` at the post-switch position; reading `.code` directly
+ * on `error` would surface as "property does not exist on type 'never'".
+ * Passing `error` through this helper keeps the assertion local while
+ * preserving the original failure mode — a new `*ErrorCode` variant added
+ * to a `Data.TaggedError` payload without a switch case fails this line
+ * at compile time.
+ */
+function assertNever(error: never): never {
+  throw new Error(`Unreachable: unhandled error variant ${JSON.stringify(error)}`);
+}
+
+/**
  * Map a known Atlas error to an HTTP status code, error code, and optional headers.
  *
  * Exhaustive over `AtlasError` — the compiler will error if a new variant
@@ -257,6 +272,138 @@ export function mapTaggedError(error: AtlasError): HttpErrorMapping {
         status: 500,
         code: "upstream_error",
         message: `No read filter registered for exotic table "${error.table}"`,
+      };
+
+    // ── EE-domain errors (safety net — see #2593) ──────────────────
+    // These tags also flow through per-route `domainErrors: [...]`
+    // (which wins on `classifyError` precedence via the `instanceof`
+    // check). The cases below catch the *unwired* path: a route that
+    // yields `RolesPolicy` / `ApprovalGate` / etc. without listing the
+    // corresponding `domainError` mapping would otherwise surface as a
+    // generic 500. With these cases in place, the failure channel
+    // already in the typed Effect surfaces as a proper 4xx envelope
+    // even when the per-route opt-in is missing.
+    //
+    // **Wire-code drift.** This safety-net path uses the `HttpErrorCode`
+    // vocabulary (e.g. `"conflict"` for `ApprovalError(expired)` →
+    // 410), whereas the per-route `domainError(...)` path uses the
+    // literal `error.code` (e.g. `"expired"`). Status codes match; wire
+    // codes differ. Acceptable because the safety net only runs for
+    // unwired routes — every current route is wired correctly, so the
+    // drift is a hypothetical that surfaces only on a future regression.
+    // A `4xx-with-different-wire-code` is strictly better than a 500.
+    //
+    // Status assignments mirror the canonical per-route maps in
+    // `shared-{retention,residency,domains}.ts` and the inline maps in
+    // `admin-{roles,approval,branding,compliance,model-config}.ts`.
+    case "RetentionError":
+      return {
+        status: error.code === "not_found" ? 404 : 400,
+        code: error.code === "not_found" ? "not_found" : "bad_request",
+        message: error.message,
+      };
+    case "RoleError":
+      switch (error.code) {
+        case "not_found":
+          return { status: 404, code: "not_found", message: error.message };
+        case "conflict":
+          return { status: 409, code: "conflict", message: error.message };
+        case "builtin_protected":
+          return { status: 403, code: "forbidden", message: error.message };
+        case "validation":
+          return { status: 400, code: "bad_request", message: error.message };
+      }
+      // Exhaustiveness guard — TS narrows error.code to `never` here
+      // once every variant above is handled. A new code added to
+      // `RoleErrorCode` will fail this line at compile time.
+      return assertNever(error);
+    case "ApprovalError":
+      switch (error.code) {
+        case "not_found":
+          return { status: 404, code: "not_found", message: error.message };
+        case "conflict":
+          return { status: 409, code: "conflict", message: error.message };
+        case "expired":
+          // 410 Gone is non-`HttpErrorCode`-vocabulary; reuse `conflict`
+          // for wire consistency with `shared-residency.ts:already_assigned`.
+          return { status: 410, code: "conflict", message: error.message };
+        case "validation":
+          return { status: 400, code: "bad_request", message: error.message };
+      }
+      return assertNever(error);
+    case "ResidencyError":
+      switch (error.code) {
+        case "not_configured":
+        case "workspace_not_found":
+          return { status: 404, code: "not_found", message: error.message };
+        case "invalid_region":
+          return { status: 400, code: "bad_request", message: error.message };
+        case "already_assigned":
+          return { status: 409, code: "conflict", message: error.message };
+        case "no_internal_db":
+          return { status: 503, code: "service_unavailable", message: error.message };
+      }
+      return assertNever(error);
+    case "BrandingError":
+      return {
+        status: error.code === "not_found" ? 404 : 400,
+        code: error.code === "not_found" ? "not_found" : "bad_request",
+        message: error.message,
+      };
+    case "DomainError":
+      switch (error.code) {
+        case "domain_not_found":
+          return { status: 404, code: "not_found", message: error.message };
+        case "invalid_domain":
+          return { status: 400, code: "bad_request", message: error.message };
+        case "duplicate_domain":
+          return { status: 409, code: "conflict", message: error.message };
+        case "railway_error":
+          return { status: 502, code: "upstream_error", message: error.message };
+        case "no_internal_db":
+        case "railway_not_configured":
+          return { status: 503, code: "service_unavailable", message: error.message };
+        case "data_integrity":
+          // 5xx — sanitize like `classifyError`'s domain-error path does
+          // for 5xx codes. The detail goes to the log via `requestId`.
+          return { status: 500, code: "upstream_error", message: error.message };
+      }
+      return assertNever(error);
+    case "ComplianceError":
+      switch (error.code) {
+        case "not_found":
+          return { status: 404, code: "not_found", message: error.message };
+        case "conflict":
+          return { status: 409, code: "conflict", message: error.message };
+        case "validation":
+          return { status: 400, code: "bad_request", message: error.message };
+      }
+      return assertNever(error);
+    case "ReportError":
+      return {
+        status: error.code === "not_available" ? 404 : 400,
+        code: error.code === "not_available" ? "not_found" : "bad_request",
+        message: error.message,
+      };
+    case "ModelConfigError":
+      switch (error.code) {
+        case "not_found":
+          return { status: 404, code: "not_found", message: error.message };
+        case "test_failed":
+          return { status: 422, code: "unprocessable_entity", message: error.message };
+        case "validation":
+          return { status: 400, code: "bad_request", message: error.message };
+      }
+      return assertNever(error);
+    case "ModelConfigDecryptError":
+      // No `code` field — single mapping. 422 mirrors the inline
+      // `Effect.catchTag("ModelConfigDecryptError", …)` handling in
+      // `admin-model-config.ts` (the "re-enter the key" envelope).
+      // Message stays generic — `configId` and `cause` are forensic-only.
+      return {
+        status: 422,
+        code: "unprocessable_entity",
+        message: "The stored API key could not be decrypted. Re-enter the key on the AI Provider page.",
       };
   }
 }


### PR DESCRIPTION
Closes #2593.

## Summary

Approach **C** from the issue body — extend the `AtlasError` union and `ATLAS_ERROR_TAG_LIST` in `packages/api/src/lib/effect/errors.ts` with the 10 EE-domain error classes promoted to core during the #2017 slice trail:

- `RetentionError`, `RoleError`, `ApprovalError`, `ResidencyError`, `BrandingError`, `DomainError`, `ComplianceError`, `ReportError`, `ModelConfigError`, `ModelConfigDecryptError`

The exhaustive `mapTaggedError()` switch in `hono.ts` gains a matching case for each tag. Status assignments mirror the canonical per-route maps in `shared-{retention,residency,domains}.ts` and the inline maps in `admin-{roles,approval,branding,compliance,model-config}.ts` (e.g. `RoleError(builtin_protected) -> 403`, `ResidencyError(no_internal_db) -> 503`, `DomainError(railway_error) -> 502`, `ModelConfigDecryptError -> 422`).

## Why

Before this PR, a route that yields `RolesPolicy` / `ApprovalGate` / etc. without listing the corresponding `domainError(...)` in its `domainErrors: [...]` opt-in would surface the typed failure as a generic 500 in production — the issue body called this out as "10 promoted error classes, ~20 route files using them, easy to forget."

After this PR: per-route `domainErrors:` mappings still win on `classifyError` precedence (the `instanceof` check at step 3 runs before the tagged-error fallback at step 4), so existing routes keep their bespoke per-code status maps unchanged. **But** if a route forgets to wire `domainErrors:`, the typed failure now falls through to the tagged-error path and surfaces as a proper 4xx envelope instead of a 500.

## Audit findings

Manually walked every route under `packages/api/src/api/routes/` that yields one of the affected Tags. All currently wire `domainErrors:` correctly:

- `admin-router.ts` yields `RolesPolicy` via `runEnterprise` (different runner) with explicit try/catch fail-closed 503 — safe.
- `public-branding.ts` yields `Branding` but only calls `getWorkspaceBrandingPublic`, whose Effect channel is `never` — safe.
- `onboarding.ts` first handler yields `ResidencyResolver` for configuration reads (no error channel); the second handler (which calls `assignWorkspaceRegion`) already wires `residencyDomainError`.

The union-level mapping is the safety net for future drift, not a fix for an existing leak.

## Exhaustiveness mechanism

- **Outer switch**: TS's existing exhaustiveness over `error._tag` (the `mapTaggedError` switch) — adding a new tag to `AtlasError` without a case fails `tsgo`. Same pattern as before, now covering 10 more tags.
- **Inner switches**: each domain error's `switch (error.code)` ends with `return assertNever(error);`. Adding a new code variant to e.g. `RoleErrorCode` without a case fails `tsgo` until the case is added.
- **Tag list**: `ATLAS_ERROR_TAG_LIST` already uses `as const satisfies readonly AtlasErrorTag[]` plus `_AssertComplete` — both extended.

## Test plan

- [x] `bun x tsgo --noEmit -p packages/api/tsconfig.json` — clean.
- [x] `cd packages/api && bun run scripts/test-isolated.ts --affected` — 42 files, 0 failures.
- [x] `cd packages/api && bun run scripts/test-isolated.ts` — full api suite, 413 files, 0 failures.
- [x] 13 new `mapTaggedError` unit tests in `hono.test.ts` (75 tests total in the file, all pass).
- [x] `bun run lint` — only pre-existing warnings, no errors introduced.
- [x] `bash scripts/check-ee-imports.sh` — passes. The new imports are all from core (`@atlas/api/lib/...`), never `@atlas/ee`.
- [x] `bash scripts/check-schema-drift.sh` — passes (no schema changes).
- [x] `bash scripts/check-template-drift.sh` — passes (no template changes).

## Acceptance criteria (from #2593)

- [x] Pick a design, prototype it.
- [x] Audit current routes for any missing `domainErrors:` wiring (manually first).
- [x] Lock in via the chosen mechanism so future routes can't regress.