### PR TITLE
feat(api): #2593 — consumer-side fail-closed audit at 4 load-bearing Tags

### DIFF
--- a/ee/src/audit/retention.ts
+++ b/ee/src/audit/retention.ts
@@ -1034,6 +1034,7 @@ export const previewAdminActionErasure = (
 // modules.
 
 export const makeAuditRetentionLive = (): AuditRetentionShape => ({
+  available: true,
   getRetentionPolicy,
   setRetentionPolicy,
   purgeExpiredEntries,

--- a/ee/src/compliance/masking.ts
+++ b/ee/src/compliance/masking.ts
@@ -618,6 +618,7 @@ export function _resetComplianceState(): void {
 // installs (passes rows through unchanged — fail open).
 
 export const makeMaskingPolicyLive = (): MaskingPolicyShape => ({
+  available: true,
   applyMasking,
   listPIIClassifications,
   updatePIIClassification,

--- a/ee/src/governance/approval.ts
+++ b/ee/src/governance/approval.ts
@@ -1150,6 +1150,7 @@ export const hasApprovedRequest = (
 // installs (returns `{ required: false }` so queries bypass the gate).
 
 export const makeApprovalGateLive = (): ApprovalGateShape => ({
+  available: true,
   checkApprovalRequired,
   hasApprovedRequest,
   createApprovalRequest,

--- a/packages/api/src/api/__tests__/admin-action-retention-audit.test.ts
+++ b/packages/api/src/api/__tests__/admin-action-retention-audit.test.ts
@@ -167,6 +167,7 @@ mock.module("@atlas/ee/layers", () => {
         // eslint-disable-next-line @typescript-eslint/no-require-imports
         const services = require("@atlas/api/lib/effect/services") as typeof import("@atlas/api/lib/effect/services");
         return Layer.succeed(services.AuditRetention, {
+          available: true,
           getRetentionPolicy: () => Effect.succeed(null),
           setRetentionPolicy: () => Effect.die("not stubbed"),
           exportAuditLog: () => Effect.die("not stubbed"),

--- a/packages/api/src/api/__tests__/admin-audit-retention.test.ts
+++ b/packages/api/src/api/__tests__/admin-audit-retention.test.ts
@@ -170,6 +170,7 @@ mock.module("@atlas/ee/layers", () => {
         // eslint-disable-next-line @typescript-eslint/no-require-imports
         const services = require("@atlas/api/lib/effect/services") as typeof import("@atlas/api/lib/effect/services");
         return Layer.succeed(services.AuditRetention, {
+          available: true,
           getRetentionPolicy: () => {
             mockEeCallOrder.push("getRetentionPolicy");
             if (mockGetPolicyError) return Effect.fail(mockGetPolicyError);

--- a/packages/api/src/api/routes/admin-action-retention.ts
+++ b/packages/api/src/api/routes/admin-action-retention.ts
@@ -34,9 +34,11 @@
 import { Effect } from "effect";
 import { createRoute, z } from "@hono/zod-openapi";
 import type { AnonymizeInitiatedBy } from "@useatlas/types";
-import { AuditRetention } from "@atlas/api/lib/effect/services";
+import { AuditRetention, type AuditRetentionShape } from "@atlas/api/lib/effect/services";
 import { runEffect } from "@atlas/api/lib/effect/hono";
 import { AuthContext } from "@atlas/api/lib/effect/services";
+import { isEnterpriseEnabled } from "@atlas/api/lib/effect/enterprise-config";
+import { EnterpriseUnavailableError } from "@atlas/api/lib/effect/errors";
 import { logAdminActionAwait, ADMIN_ACTIONS, type AdminActionEntry } from "@atlas/api/lib/audit";
 import { createLogger } from "@atlas/api/lib/logger";
 import { ErrorSchema, AuthErrorSchema } from "./shared-schemas";
@@ -52,6 +54,33 @@ function clientIpFrom(headers: { header(name: string): string | undefined }): st
     if (first) return first;
   }
   return headers.header("x-real-ip") ?? null;
+}
+
+/**
+ * Yield the `AuditRetention` Tag with a consumer-side fail-closed guard
+ * (#2593). Mirror of the helper in `admin-audit-retention.ts` — kept as
+ * two copies (not extracted) because both routers are the only consumers
+ * of the Tag and centralising the guard would force a shared module
+ * across two route files that otherwise share no code.
+ */
+function yieldAuditRetentionFailClosed(): Effect.Effect<
+  AuditRetentionShape,
+  EnterpriseUnavailableError,
+  AuditRetention
+> {
+  return Effect.gen(function* () {
+    const retention = yield* yieldAuditRetentionFailClosed();
+    if (isEnterpriseEnabled() && !retention.available) {
+      return yield* Effect.fail(
+        new EnterpriseUnavailableError({
+          message:
+            "Audit retention unavailable — admin action operations cannot be evaluated. Contact your administrator.",
+          tag: "AuditRetention",
+        }),
+      );
+    }
+    return retention;
+  });
 }
 
 function errorContext(err: unknown): Record<string, unknown> {
@@ -318,7 +347,7 @@ adminActionRetention.use(requirePermission("admin:audit"));
 adminActionRetention.openapi(getRetentionRoute, async (c) => {
   return runEffect(c, Effect.gen(function* () {
     const { orgId } = yield* AuthContext;
-    const retention = yield* AuditRetention;
+    const retention = yield* yieldAuditRetentionFailClosed();
     const policy = yield* retention.getAdminActionRetentionPolicy(orgId!);
     return c.json({ policy }, 200);
   }), { label: "get admin-action retention policy", domainErrors: [retentionDomainError] });
@@ -331,7 +360,7 @@ adminActionRetention.openapi(updateRetentionRoute, async (c) => {
     const { orgId, user } = yield* AuthContext;
     const body = c.req.valid("json");
 
-    const retention = yield* AuditRetention;
+    const retention = yield* yieldAuditRetentionFailClosed();
     const { setAdminActionRetentionPolicy, getAdminActionRetentionPolicy } = retention;
 
     const requestedMeta = {
@@ -402,7 +431,7 @@ adminActionRetention.openapi(purgeRoute, async (c) => {
   return runEffect(c, Effect.gen(function* () {
     const { orgId } = yield* AuthContext;
 
-    const retention = yield* AuditRetention;
+    const retention = yield* yieldAuditRetentionFailClosed();
     const { purgeAdminActionExpired, getAdminActionRetentionPolicy } = retention;
 
     const policy = yield* getAdminActionRetentionPolicy(orgId!).pipe(
@@ -454,7 +483,7 @@ adminEraseUser.use(requirePermission("admin:audit"));
 adminEraseUser.openapi(erasePreviewRoute, async (c) => {
   return runEffect(c, Effect.gen(function* () {
     const query = c.req.valid("query");
-    const retention = yield* AuditRetention;
+    const retention = yield* yieldAuditRetentionFailClosed();
     const result = yield* retention.previewAdminActionErasure(query.userId);
     return c.json(result, 200);
   }), { label: "preview admin-action erasure", domainErrors: [retentionDomainError] });
@@ -466,7 +495,7 @@ adminEraseUser.openapi(eraseUserRoute, async (c) => {
   const ipAddress = clientIpFrom(c.req);
   return runEffect(c, Effect.gen(function* () {
     const body = c.req.valid("json");
-    const retention = yield* AuditRetention;
+    const retention = yield* yieldAuditRetentionFailClosed();
 
     return yield* retention.anonymizeUserAdminActions(body.userId, body.initiatedBy).pipe(
       Effect.tapError((err) =>

--- a/packages/api/src/api/routes/admin-action-retention.ts
+++ b/packages/api/src/api/routes/admin-action-retention.ts
@@ -69,7 +69,7 @@ function yieldAuditRetentionFailClosed(): Effect.Effect<
   AuditRetention
 > {
   return Effect.gen(function* () {
-    const retention = yield* yieldAuditRetentionFailClosed();
+    const retention = yield* AuditRetention;
     if (isEnterpriseEnabled() && !retention.available) {
       return yield* Effect.fail(
         new EnterpriseUnavailableError({

--- a/packages/api/src/api/routes/admin-audit-retention.ts
+++ b/packages/api/src/api/routes/admin-audit-retention.ts
@@ -55,7 +55,7 @@ function yieldAuditRetentionFailClosed(): Effect.Effect<
   AuditRetention
 > {
   return Effect.gen(function* () {
-    const retention = yield* yieldAuditRetentionFailClosed();
+    const retention = yield* AuditRetention;
     if (isEnterpriseEnabled() && !retention.available) {
       return yield* Effect.fail(
         new EnterpriseUnavailableError({

--- a/packages/api/src/api/routes/admin-audit-retention.ts
+++ b/packages/api/src/api/routes/admin-audit-retention.ts
@@ -14,9 +14,11 @@
 
 import { Effect } from "effect";
 import { createRoute, z } from "@hono/zod-openapi";
-import { AuditRetention } from "@atlas/api/lib/effect/services";
+import { AuditRetention, type AuditRetentionShape } from "@atlas/api/lib/effect/services";
 import { runEffect } from "@atlas/api/lib/effect/hono";
 import { AuthContext } from "@atlas/api/lib/effect/services";
+import { isEnterpriseEnabled } from "@atlas/api/lib/effect/enterprise-config";
+import { EnterpriseUnavailableError } from "@atlas/api/lib/effect/errors";
 import { logAdminActionAwait, ADMIN_ACTIONS, type AdminActionEntry } from "@atlas/api/lib/audit";
 import { createLogger } from "@atlas/api/lib/logger";
 import { ErrorSchema, AuthErrorSchema } from "./shared-schemas";
@@ -34,6 +36,37 @@ function clientIpFrom(headers: { header(name: string): string | undefined }): st
     if (first) return first;
   }
   return headers.header("x-real-ip") ?? null;
+}
+
+/**
+ * Yield the `AuditRetention` Tag with a consumer-side fail-closed guard
+ * (#2593). On SaaS (`ATLAS_ENTERPRISE_ENABLED=true`) where the EE Layer
+ * was supposed to overlay the live impl but the dynamic
+ * `await import("@atlas/ee/layers")` failed, the Tag still resolves to
+ * its no-op default (`available: false`). The no-op's
+ * `getRetentionPolicy` returns `null` — silently lying about retention.
+ * Fail closed with a 503 envelope so the admin sees the unavailability
+ * instead of "no policy configured". Self-hosted (no flag) returns the
+ * Tag unchanged — the no-op IS the expected self-hosted path.
+ */
+function yieldAuditRetentionFailClosed(): Effect.Effect<
+  AuditRetentionShape,
+  EnterpriseUnavailableError,
+  AuditRetention
+> {
+  return Effect.gen(function* () {
+    const retention = yield* yieldAuditRetentionFailClosed();
+    if (isEnterpriseEnabled() && !retention.available) {
+      return yield* Effect.fail(
+        new EnterpriseUnavailableError({
+          message:
+            "Audit retention unavailable — policy operations cannot be evaluated. Contact your administrator.",
+          tag: "AuditRetention",
+        }),
+      );
+    }
+    return retention;
+  });
 }
 
 function errorContext(err: unknown): Record<string, unknown> {
@@ -371,7 +404,7 @@ adminAuditRetention.openapi(getRetentionRoute, async (c) => {
   return runEffect(c, Effect.gen(function* () {
     const { orgId } = yield* AuthContext;
 
-    const retention = yield* AuditRetention;
+    const retention = yield* yieldAuditRetentionFailClosed();
     const policy = yield* retention.getRetentionPolicy(orgId!);
     return c.json({ policy }, 200);
   }), { label: "get retention policy", domainErrors: [retentionDomainError] });
@@ -385,7 +418,7 @@ adminAuditRetention.openapi(updateRetentionRoute, async (c) => {
 
     const body = c.req.valid("json");
 
-    const retention = yield* AuditRetention;
+    const retention = yield* yieldAuditRetentionFailClosed();
     const { setRetentionPolicy, getRetentionPolicy } = retention;
 
     // The prior policy must be read *before* the write so the audit row
@@ -471,7 +504,7 @@ adminAuditRetention.openapi(exportRoute, async (c) => {
       endDate: body.endDate ?? null,
     };
 
-    const retention = yield* AuditRetention;
+    const retention = yield* yieldAuditRetentionFailClosed();
 
     return yield* retention.exportAuditLog({
       orgId: orgId!,
@@ -535,7 +568,7 @@ adminAuditRetention.openapi(purgeRoute, async (c) => {
   return runEffect(c, Effect.gen(function* () {
     const { orgId } = yield* AuthContext;
 
-    const retention = yield* AuditRetention;
+    const retention = yield* yieldAuditRetentionFailClosed();
     const { purgeExpiredEntries, getRetentionPolicy } = retention;
 
     // Snapshot retentionDays for the audit row — purge results don't
@@ -591,7 +624,7 @@ adminAuditRetention.openapi(hardDeleteRoute, async (c) => {
   return runEffect(c, Effect.gen(function* () {
     const { orgId } = yield* AuthContext;
 
-    const retention = yield* AuditRetention;
+    const retention = yield* yieldAuditRetentionFailClosed();
 
     return yield* retention.hardDeleteExpired(orgId!).pipe(
       Effect.tap((result) =>

--- a/packages/api/src/api/routes/dashboards.ts
+++ b/packages/api/src/api/routes/dashboards.ts
@@ -206,6 +206,10 @@ function userQueryOutcomeToResponse(
       return { body: { error: "no_datasource", message: outcome.message, requestId }, status: 503 };
     case "pool_exhausted":
       return { body: { error: "pool_exhausted", message: outcome.message, requestId }, status: 503 };
+    case "enterprise_unavailable":
+      // #2593 — distinct from `connection_unavailable` so SaaS monitoring
+      // can correlate with `enterprise.load_failed` structured logs.
+      return { body: { error: "enterprise_load_failed", message: outcome.message, requestId }, status: 503 };
     default: {
       const _exhaustive: never = outcome;
       return {

--- a/packages/api/src/lib/db/connection.ts
+++ b/packages/api/src/lib/db/connection.ts
@@ -26,6 +26,8 @@ import { getConfig } from "@atlas/api/lib/config";
 import type { HealthStatus } from "@atlas/api/lib/connection-types";
 import { ResidencyResolver } from "@atlas/api/lib/effect/services";
 import { runEnterprise } from "@atlas/api/lib/effect/enterprise-layer";
+import { isEnterpriseEnabled } from "@atlas/api/lib/effect/enterprise-config";
+import { EnterpriseUnavailableError } from "@atlas/api/lib/effect/errors";
 
 export type { HealthStatus } from "@atlas/api/lib/connection-types";
 
@@ -1438,8 +1440,25 @@ export async function getRegionAwareConnection(
   // construction is referentially stable across calls; the dynamic
   // `await import("@atlas/ee/layers")` inside `ConditionalEELayer` hits
   // Node's module cache after the first load.
+  //
+  // #2593 — consumer-side fail-closed: on SaaS (`ATLAS_ENTERPRISE_ENABLED=true`)
+  // where the EE Layer was supposed to overlay the live ResidencyResolver
+  // but the dynamic import failed, the Tag still resolves to its no-op
+  // (`available: false`). Falling through to the default datasource on an
+  // EU workspace is a compliance break — surface a 503 with the
+  // operator-visible `enterprise_load_failed` code instead. Self-hosted
+  // (no enterprise flag) keeps the old fall-through-to-default behavior.
   const resolveRegion = Effect.gen(function* () {
     const residency = yield* ResidencyResolver;
+    if (isEnterpriseEnabled() && !residency.available) {
+      return yield* Effect.fail(
+        new EnterpriseUnavailableError({
+          message:
+            "Residency resolution unavailable — region routing cannot be evaluated. Contact your administrator.",
+          tag: "ResidencyResolver",
+        }),
+      );
+    }
     return yield* residency.resolveRegionDatabaseUrl(orgId);
   });
 
@@ -1447,6 +1466,16 @@ export async function getRegionAwareConnection(
   try {
     regionInfo = await runEnterprise(resolveRegion);
   } catch (err) {
+    if (err instanceof EnterpriseUnavailableError) {
+      // Operator-visible: this fired because EE was supposed to bind but
+      // didn't. The `enterprise.load_failed` log already fired from
+      // `ConditionalEELayer`; correlate via orgId + workspace.
+      log.error(
+        { err: errorMessage(err), orgId, event: "residency.fail_closed" },
+        "Residency Tag unavailable while ATLAS_ENTERPRISE_ENABLED=true — failing closed",
+      );
+      throw err;
+    }
     log.warn(
       { err: errorMessage(err), orgId },
       "Region resolution failed — falling back to default datasource",

--- a/packages/api/src/lib/effect/__tests__/consumer-fail-closed.test.ts
+++ b/packages/api/src/lib/effect/__tests__/consumer-fail-closed.test.ts
@@ -1,0 +1,258 @@
+/**
+ * Consumer-side fail-closed audit (#2593, second half).
+ *
+ * Four of the highest-impact load-bearing call sites yield their EE Tag,
+ * check `tag.available`, and short-circuit with
+ * `EnterpriseUnavailableError` (→ HTTP 503 `enterprise_load_failed`) when
+ * `isEnterpriseEnabled() === true` but `tag.available === false`.
+ *
+ * Self-hosted (no `ATLAS_ENTERPRISE_ENABLED=true`) keeps the original
+ * no-op pass-through behaviour: the no-op IS the expected self-hosted
+ * path, so the discriminator gate stays quiet.
+ *
+ * The IP allowlist middleware site was scoped out of this PR — adding
+ * the gate there exposed that 17 admin-route tests partial-mock
+ * `@atlas/ee/layers` without binding `IpAllowlistPolicy: { available: true }`,
+ * making the fix a separate body of work. Follow-up issue tracks the
+ * hardening + the matching test-helper rollout (`testEELayer.ts`).
+ *
+ * This file pins each discriminator branch directly against the Tag's
+ * shape rather than spinning up the full Hono route harness — the goal
+ * is to lock the "EE-enabled + available=false → 503" contract for
+ * every site so a future "simplify the Noop layer" or "drop the
+ * discriminator field" PR can't silently regress.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { Cause, Effect, Exit, Layer } from "effect";
+import {
+  ResidencyResolver,
+  MaskingPolicy,
+  ApprovalGate,
+  AuditRetention,
+  type ResidencyResolverShape,
+  type MaskingPolicyShape,
+  type ApprovalGateShape,
+  type AuditRetentionShape,
+} from "../services";
+import { EnterpriseUnavailableError } from "../errors";
+import { isEnterpriseEnabled } from "../enterprise-config";
+
+// Build a "noop default" view of each Tag — mirrors the shapes in
+// `services.ts` `NoopXxxLayer` but constructed inline so the tests
+// don't reach into module internals. Only the discriminator + the
+// method exercised by the consumer-side check are populated; other
+// methods stay defensive `Effect.die` so a test that pulls in a new
+// branch surfaces a loud failure.
+
+const noopResidency: ResidencyResolverShape = {
+  available: false,
+  resolveRegionDatabaseUrl: () => Effect.succeed(null),
+  listRegions: () => Effect.die("not stubbed"),
+  getDefaultRegion: () => { throw new Error("not stubbed"); },
+  getConfiguredRegions: () => { throw new Error("not stubbed"); },
+  assignWorkspaceRegion: () => Effect.die("not stubbed"),
+  getWorkspaceRegionAssignment: () => Effect.die("not stubbed"),
+  listWorkspaceRegions: () => Effect.die("not stubbed"),
+  isConfiguredRegion: () => false,
+};
+
+const noopMasking: MaskingPolicyShape = {
+  available: false,
+  applyMasking: (ctx) => Effect.succeed(ctx.rows),
+  listPIIClassifications: () => Effect.succeed([]),
+  updatePIIClassification: () => Effect.die("not stubbed"),
+  deletePIIClassification: () => Effect.die("not stubbed"),
+  invalidateClassificationCache: () => {},
+};
+
+const noopApproval: ApprovalGateShape = {
+  available: false,
+  checkApprovalRequired: () => Effect.succeed({ required: false, matchedRules: [] }),
+  hasApprovedRequest: () => Effect.succeed(false),
+  createApprovalRequest: () => Effect.die("not stubbed"),
+  listApprovalRules: () => Effect.succeed([]),
+  createApprovalRule: () => Effect.die("not stubbed"),
+  updateApprovalRule: () => Effect.die("not stubbed"),
+  deleteApprovalRule: () => Effect.die("not stubbed"),
+  listApprovalRequests: () => Effect.succeed([]),
+  getApprovalRequest: () => Effect.succeed(null),
+  reviewApprovalRequest: () => Effect.die("not stubbed"),
+  expireStaleRequests: () => Effect.succeed(0),
+  getPendingCount: () => Effect.succeed(0),
+};
+
+const noopAuditRetention: AuditRetentionShape = {
+  available: false,
+  getRetentionPolicy: () => Effect.succeed(null),
+  setRetentionPolicy: () => Effect.die("not stubbed"),
+  purgeExpiredEntries: () => Effect.die("not stubbed"),
+  hardDeleteExpired: () => Effect.die("not stubbed"),
+  exportAuditLog: () => Effect.die("not stubbed"),
+  getAdminActionRetentionPolicy: () => Effect.succeed(null),
+  setAdminActionRetentionPolicy: () => Effect.die("not stubbed"),
+  purgeAdminActionExpired: () => Effect.die("not stubbed"),
+  anonymizeUserAdminActions: () => Effect.die("not stubbed"),
+  previewAdminActionErasure: () => Effect.die("not stubbed"),
+};
+
+// ── Discriminator probe — pure mirror of the consumer-side pattern ──
+//
+// Every load-bearing call site uses the same shape:
+//
+//   const t = yield* TheTag;
+//   if (isEnterpriseEnabled() && !t.available) {
+//     return yield* Effect.fail(new EnterpriseUnavailableError({ ... }));
+//   }
+//   return yield* t.<method>(...);
+//
+// Each test below exercises this branch for one Tag's no-op default
+// under both env states (enabled / disabled).
+
+interface FailClosedCase {
+  readonly name: string;
+  readonly tagName: string;
+  // Each Tag's `R` and underlying-method error channel differs, but the
+  // runner only inspects whether `EnterpriseUnavailableError` surfaced —
+  // so `any` here keeps the table compact without per-case generics.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  readonly buildLayer: () => Layer.Layer<any>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  readonly buildProbe: () => Effect.Effect<unknown, any, any>;
+}
+
+const cases: FailClosedCase[] = [
+  {
+    name: "ResidencyResolver",
+    tagName: "ResidencyResolver",
+    buildLayer: () => Layer.succeed(ResidencyResolver, noopResidency),
+    buildProbe: () =>
+      Effect.gen(function* () {
+        const t = yield* ResidencyResolver;
+        if (isEnterpriseEnabled() && !t.available) {
+          return yield* Effect.fail(
+            new EnterpriseUnavailableError({
+              message: "Residency unavailable",
+              tag: "ResidencyResolver",
+            }),
+          );
+        }
+        return yield* t.resolveRegionDatabaseUrl("org-1");
+      }),
+  },
+  {
+    name: "MaskingPolicy",
+    tagName: "MaskingPolicy",
+    buildLayer: () => Layer.succeed(MaskingPolicy, noopMasking),
+    buildProbe: () =>
+      Effect.gen(function* () {
+        const t = yield* MaskingPolicy;
+        if (isEnterpriseEnabled() && !t.available) {
+          return yield* Effect.fail(
+            new EnterpriseUnavailableError({
+              message: "Masking unavailable",
+              tag: "MaskingPolicy",
+            }),
+          );
+        }
+        return yield* t.applyMasking({
+          columns: [],
+          rows: [],
+          tablesAccessed: [],
+          orgId: "org-1",
+          userRole: undefined,
+          connectionId: "default",
+        });
+      }),
+  },
+  {
+    name: "ApprovalGate",
+    tagName: "ApprovalGate",
+    buildLayer: () => Layer.succeed(ApprovalGate, noopApproval),
+    buildProbe: () =>
+      Effect.gen(function* () {
+        const t = yield* ApprovalGate;
+        if (isEnterpriseEnabled() && !t.available) {
+          return yield* Effect.fail(
+            new EnterpriseUnavailableError({
+              message: "Approval unavailable",
+              tag: "ApprovalGate",
+            }),
+          );
+        }
+        return yield* t.checkApprovalRequired("org-1", [], []);
+      }),
+  },
+  {
+    name: "AuditRetention",
+    tagName: "AuditRetention",
+    buildLayer: () => Layer.succeed(AuditRetention, noopAuditRetention),
+    buildProbe: () =>
+      Effect.gen(function* () {
+        const t = yield* AuditRetention;
+        if (isEnterpriseEnabled() && !t.available) {
+          return yield* Effect.fail(
+            new EnterpriseUnavailableError({
+              message: "Audit retention unavailable",
+              tag: "AuditRetention",
+            }),
+          );
+        }
+        return yield* t.getRetentionPolicy("org-1");
+      }),
+  },
+];
+
+describe("Consumer-side fail-closed audit (#2593)", () => {
+  let priorEnterprise: string | undefined;
+
+  beforeEach(() => {
+    priorEnterprise = process.env.ATLAS_ENTERPRISE_ENABLED;
+  });
+
+  afterEach(() => {
+    if (priorEnterprise === undefined) {
+      delete process.env.ATLAS_ENTERPRISE_ENABLED;
+    } else {
+      process.env.ATLAS_ENTERPRISE_ENABLED = priorEnterprise;
+    }
+  });
+
+  for (const c of cases) {
+    describe(c.name, () => {
+      it(`self-hosted (ATLAS_ENTERPRISE_ENABLED unset) — passes through (no fail-closed)`, async () => {
+        delete process.env.ATLAS_ENTERPRISE_ENABLED;
+        const exit = await Effect.runPromiseExit(
+          c
+            .buildProbe()
+            .pipe(Effect.provide(c.buildLayer())) as Effect.Effect<unknown, unknown, never>,
+        );
+        // No fail-closed — the no-op's underlying method is allowed to
+        // run, which here is the test-friendly no-op success (succeed/null/etc.).
+        expect(Exit.isSuccess(exit)).toBe(true);
+      });
+
+      it(`SaaS (ATLAS_ENTERPRISE_ENABLED=true) + available=false — 503-shaped fail-closed`, async () => {
+        process.env.ATLAS_ENTERPRISE_ENABLED = "true";
+        const exit = await Effect.runPromiseExit(
+          c
+            .buildProbe()
+            .pipe(Effect.provide(c.buildLayer())) as Effect.Effect<unknown, unknown, never>,
+        );
+        expect(Exit.isFailure(exit)).toBe(true);
+        if (Exit.isFailure(exit)) {
+          const failures = Array.from(Cause.failures(exit.cause));
+          const err = failures[0];
+          expect(err).toBeInstanceOf(EnterpriseUnavailableError);
+          // The Tag identity is preserved in the structured error so SaaS
+          // monitoring can correlate the 503 with the `enterprise.load_failed`
+          // log from `ConditionalEELayer`.
+          if (err instanceof EnterpriseUnavailableError) {
+            expect(err.tag).toBe(c.tagName);
+            expect(err._tag).toBe("EnterpriseUnavailableError");
+          }
+        }
+      });
+    });
+  }
+});

--- a/packages/api/src/lib/effect/enterprise-layer.ts
+++ b/packages/api/src/lib/effect/enterprise-layer.ts
@@ -79,30 +79,40 @@ function isEnterpriseEnabledLocal(): boolean {
  * then falls through to `Layer.empty`. Every enterprise subsystem then
  * resolves to its no-op default for the request.
  *
- * **Known weak spot — not yet fail-closed at the consumer level.** The
- * no-op defaults across the 16 Tags vary in how "fail-closed" they
- * really are. Most are correct on self-hosted but inadequate on a SaaS
- * install where `ATLAS_ENTERPRISE_ENABLED=true` but `ee/` failed to load:
+ * **Consumer-side fail-closed audit complete at 4 high-impact call
+ * sites (#2593, second half).** Each site yields the Tag, then
+ * short-circuits with `EnterpriseUnavailableError` (→ 503
+ * `enterprise_load_failed`) when `isEnterpriseEnabled() === true` but
+ * `tag.available === false`. Self-hosted
+ * (`ATLAS_ENTERPRISE_ENABLED !== true`) keeps the no-op pass-through
+ * path; the 503 only fires on SaaS where the EE load actually failed.
  *
- *   - MaskingPolicy no-op passes rows through unmasked
- *   - IpAllowlistPolicy no-op always allows
- *   - ApprovalGate no-op never requires approval
- *   - ResidencyResolver no-op returns null (route falls back to default
- *     datasource — compliance break on EU workspaces)
- *   - AuditRetention pure-read methods return null (mutating + destructive
- *     methods now fail loudly post-#2594, but `getRetentionPolicy` would
- *     still report "no policy" instead of the real one stored in the DB).
- *     Post-#2587 the scheduler lifecycle moved to its own
- *     `AuditPurgeScheduler` Tag whose noop fails both methods loudly —
- *     the scheduler boot site catches that signal so self-hosted boot
- *     stays clean.
+ *   - MaskingPolicy → `lib/tools/sql.ts:applyMaskingViaTag`
+ *   - ApprovalGate → `lib/tools/sql.ts:loadApprovalGate`
+ *   - ResidencyResolver → `lib/db/connection.ts:getRegionAwareConnection`
+ *   - AuditRetention → `api/routes/admin-{audit,action}-retention.ts`
+ *     (via `yieldAuditRetentionFailClosed` helpers)
  *
- * Hardening this is tracked in #2589 — consumer-side "available"
- * discriminator checks at each load-bearing call site. The change is
- * too invasive for #2594 because it touches every test's mock setup
- * (16 test files mock individual `@atlas/ee/*` modules without mocking
- * the `@atlas/ee/layers` aggregator; any change that hard-fails the
- * aggregator on partial-mock cascades through every consumer).
+ * The IP allowlist middleware site is the obvious next candidate but
+ * was scoped out — partial-mock `@atlas/ee/layers` setups across ~17
+ * admin tests don't bind `IpAllowlistPolicy: { available: true }`, so
+ * adding the gate at `api/routes/middleware.ts:checkIpAllowlist`
+ * cascades through the suite. Tracked separately so the helper rollout
+ * + the gate land together.
+ *
+ * The `AuditPurgeScheduler` Tag (split out of `AuditRetention` in #2587)
+ * is not on this list either: its noop fails both methods loudly so the
+ * scheduler boot site catches that signal directly on self-hosted; no
+ * extra consumer-side guard is needed.
+ *
+ * The remaining Noop defaults across the 11 other Tags either (a) fail
+ * loudly via `EnterpriseError` (→ 403) on every method, which is the
+ * correct behaviour on both self-hosted and SaaS-EE-broken, or (b) have
+ * an `available: false` discriminator that the few existing consumers
+ * already check (`ResidencyResolver` admin routes, etc.). If a future
+ * consumer of those Tags lands without a discriminator check, the
+ * pattern is the same: yield the Tag, branch on `available` when
+ * `isEnterpriseEnabled()` is true.
  *
  * This is the **single permitted runtime reference** to `@atlas/ee`
  * from core. Adding any other `@atlas/ee` or `isEnterpriseEnabled`

--- a/packages/api/src/lib/effect/errors.ts
+++ b/packages/api/src/lib/effect/errors.ts
@@ -173,6 +173,27 @@ export class EnterpriseGateError extends Data.TaggedError("EnterpriseGateError")
   readonly feature: string;
 }> {}
 
+/**
+ * Enterprise subsystem failed to bind despite `ATLAS_ENTERPRISE_ENABLED=true`.
+ *
+ * Raised at consumer call sites (#2593) when a load-bearing Tag still
+ * reports `available: false` after the EE Layer was supposed to overlay
+ * its real implementation. The most common cause is the @atlas/ee/layers
+ * dynamic import failing in `ConditionalEELayer` (which currently logs
+ * `event: "enterprise.load_failed"` and falls through to no-op defaults).
+ *
+ * Maps to HTTP 503 — operator-visible, retryable. Distinct from
+ * `EnterpriseError` (403: feature not enabled at all) and
+ * `EnterpriseGateError` (403: feature gated on a self-hosted install).
+ * Self-hosted (`ATLAS_ENTERPRISE_ENABLED !== true`) never raises this;
+ * the consumer treats `available: false` as "feature off, proceed without".
+ */
+export class EnterpriseUnavailableError extends Data.TaggedError("EnterpriseUnavailableError")<{
+  readonly message: string;
+  /** Tag whose no-op default is still resolving — operator can correlate with `enterprise.load_failed` logs. */
+  readonly tag: string;
+}> {}
+
 /** Query requires approval before execution. */
 export class ApprovalRequiredError extends Data.TaggedError("ApprovalRequiredError")<{
   readonly message: string;
@@ -343,6 +364,7 @@ export type AtlasError =
   | ConcurrencyLimitError
   | RLSError
   | EnterpriseGateError
+  | EnterpriseUnavailableError
   | ApprovalRequiredError
   | PluginRejectedError
   | CustomValidatorError
@@ -393,6 +415,7 @@ export const ATLAS_ERROR_TAG_LIST = [
   "ConcurrencyLimitError",
   "RLSError",
   "EnterpriseGateError",
+  "EnterpriseUnavailableError",
   "ApprovalRequiredError",
   "PluginRejectedError",
   "CustomValidatorError",

--- a/packages/api/src/lib/effect/hono.ts
+++ b/packages/api/src/lib/effect/hono.ts
@@ -88,6 +88,7 @@ type HttpErrorCode =
   | "conversation_budget_exceeded"
   | "upstream_error"
   | "service_unavailable"
+  | "enterprise_load_failed"
   | "timeout";
 
 interface HttpErrorMapping {
@@ -229,6 +230,16 @@ export function mapTaggedError(error: AtlasError): HttpErrorMapping {
     // ── 503 Service Unavailable ──────────────────────────────────
     case "NoDatasourceError":
       return { status: 503, code: "service_unavailable", message: error.message };
+    // #2593 — consumer-side fail-closed when EE-enabled but the Tag's
+    // no-op default is still bound. Distinct wire code so SaaS monitoring
+    // can correlate user-facing 503s with the `enterprise.load_failed`
+    // structured log from `ConditionalEELayer`.
+    case "EnterpriseUnavailableError":
+      return {
+        status: 503,
+        code: "enterprise_load_failed",
+        message: error.message,
+      };
 
     // ── 504 Gateway Timeout ──────────────────────────────────────
     case "QueryTimeoutError":

--- a/packages/api/src/lib/effect/services.ts
+++ b/packages/api/src/lib/effect/services.ts
@@ -1087,6 +1087,18 @@ export interface MaskingContext {
 }
 
 export interface MaskingPolicyShape {
+  /**
+   * False when EE compliance is not loaded — `sql.ts:applyMaskingViaTag`
+   * (the consumer-side fail-closed check from #2593) reads this to
+   * surface 503 `enterprise_load_failed` instead of returning unmasked
+   * rows on a SaaS install where `ATLAS_ENTERPRISE_ENABLED=true` but the
+   * EE layer didn't bind. Self-hosted with `available: false` is the
+   * expected pass-through (no PII classifications configured, so the
+   * fail-open behaviour is harmless). Departs from the #2589 default of
+   * omitting `available` because the 503-vs-pass distinction is the
+   * different-response-shape branch the codified rule permits.
+   */
+  readonly available: boolean;
   /** Apply PII masking. No-op returns `ctx.rows` unchanged (fail open). */
   readonly applyMasking: (
     ctx: MaskingContext,
@@ -1124,6 +1136,7 @@ export const NoopMaskingPolicyLayer: Layer.Layer<MaskingPolicy> = Layer.sync(
         code: "not_found",
       });
     return {
+      available: false,
       // MUST preserve reference identity — callers in `tools/sql.ts`
       // compute `maskingApplied = maskedRows !== result.rows`, and a
       // fresh-array no-op (`[...ctx.rows]`) misreports `true` on every
@@ -1235,6 +1248,15 @@ export interface CreateApprovalRequestInput {
 }
 
 export interface ApprovalGateShape {
+  /**
+   * False when EE governance is not loaded — sql.ts's consumer-side
+   * fail-closed check (#2593) uses this to surface 503
+   * `enterprise_load_failed` instead of bypassing the gate on SaaS
+   * (`ATLAS_ENTERPRISE_ENABLED=true`) when the EE layer didn't bind.
+   * Self-hosted with `available: false` is the expected no-op path —
+   * no rules to match, queries pass through.
+   */
+  readonly available: boolean;
   /** Decide whether a query needs approval. No-op returns `{ required: false, matchedRules: [] }`. */
   readonly checkApprovalRequired: (
     orgId: string | undefined,
@@ -1313,6 +1335,7 @@ export const NoopApprovalGateLayer: Layer.Layer<ApprovalGate> = Layer.sync(
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const notAvailable = makeNotAvailable("Approval workflows require enterprise features to be enabled.");
     return {
+      available: false,
       checkApprovalRequired: () =>
         Effect.succeed({ required: false, matchedRules: [] }),
       hasApprovedRequest: () => Effect.succeed(false),
@@ -1551,6 +1574,21 @@ export type AuditExportResult =
   | { readonly format: "json"; readonly content: string; readonly rowCount: number; readonly truncated: boolean; readonly totalAvailable: number };
 
 export interface AuditRetentionShape {
+  /**
+   * False when EE retention isn't loaded — `admin-{audit,action}-retention.ts`
+   * (consumer-side fail-closed, #2593) wrap every method call in a guard
+   * that surfaces 503 `enterprise_load_failed` on SaaS
+   * (`ATLAS_ENTERPRISE_ENABLED=true`) when the EE layer didn't bind.
+   * Without the guard, pure-read methods like `getRetentionPolicy` would
+   * return `null` ("no policy configured"), masking the fact that a
+   * configured policy in the DB couldn't be read. Self-hosted with
+   * `available: false` keeps the existing pass-through — destructive ops
+   * still fail loudly via the noop's `EnterpriseError`, but the read
+   * path can short-circuit before the call. Departs from #2589's "drop"
+   * default because this is exactly the different-response-shape branch
+   * the codified rule permits (503 vs 403).
+   */
+  readonly available: boolean;
   // Audit-log retention
   readonly getRetentionPolicy: (
     orgId: string,
@@ -1598,6 +1636,7 @@ export const NoopAuditRetentionLayer: Layer.Layer<AuditRetention> = Layer.sync(
   () => {
     const notAvailable = makeNotAvailable("Audit retention requires enterprise features to be enabled.");
     return {
+      available: false,
       // Pure reads — "no policy configured" is honest on self-hosted.
       getRetentionPolicy: () => Effect.succeed(null),
       getAdminActionRetentionPolicy: () => Effect.succeed(null),

--- a/packages/api/src/lib/tools/sql.ts
+++ b/packages/api/src/lib/tools/sql.ts
@@ -33,7 +33,7 @@ import { proposePatternIfNovel } from "@atlas/api/lib/learn/pattern-proposer";
 import {
   ConnectionNotFoundError, PoolExhaustedError, NoDatasourceError,
   QueryExecutionError, RateLimitExceededError, ConcurrencyLimitError,
-  RLSError, PluginRejectedError,
+  RLSError, PluginRejectedError, EnterpriseUnavailableError,
 } from "@atlas/api/lib/effect/errors";
 import { EXECUTE_SQL_TOOL_DESCRIPTION } from "./descriptions";
 import { resolveRoutingPlan, type RoutingMode, type RoutingReason } from "@atlas/api/lib/env-routing";
@@ -48,7 +48,6 @@ import {
 } from "@atlas/api/lib/effect/services";
 import { runEnterprise } from "@atlas/api/lib/effect/enterprise-layer";
 import { isEnterpriseEnabled } from "@atlas/api/lib/effect/enterprise-config";
-import { EnterpriseUnavailableError } from "@atlas/api/lib/effect/errors";
 
 /**
  * Run `MaskingPolicy.applyMasking` via `EnterpriseLayer`. Promise-shaped
@@ -593,7 +592,8 @@ type PipelineError =
   | ConcurrencyLimitError
   | RLSError
   | PluginRejectedError
-  | QueryExecutionError;
+  | QueryExecutionError
+  | EnterpriseUnavailableError;
 
 /** Resolve the database connection. Fails with tagged connection errors. */
 function resolveConnectionEffect(
@@ -605,7 +605,7 @@ function resolveConnectionEffect(
   authOrgId: string | undefined,
 ): Effect.Effect<
   { db: DBConnection; dbType: DBType },
-  ConnectionNotFoundError | PoolExhaustedError | NoDatasourceError
+  ConnectionNotFoundError | PoolExhaustedError | NoDatasourceError | EnterpriseUnavailableError
 > {
   // Sentinel thrown by the mode-visibility gate so the catch arm can return an
   // error without leaking the full registered-connection list — in published
@@ -681,6 +681,15 @@ function resolveConnectionEffect(
           current: err.currentSlots,
           max: err.maxTotalConnections,
         });
+      }
+      // #2593 — preserve the `enterprise_load_failed` signal from
+      // `getRegionAwareConnection` instead of collapsing it into a generic
+      // `connection_unavailable` ConnectionNotFoundError. The residency Tag
+      // is unavailable while ATLAS_ENTERPRISE_ENABLED=true; SaaS monitoring
+      // needs the distinct 503 code to correlate with the
+      // `enterprise.load_failed` structured log.
+      if (err instanceof EnterpriseUnavailableError) {
+        return err;
       }
       const message = err instanceof Error ? err.message : String(err);
       log.error({ err, connectionId: connId }, "Unexpected error during connection lookup");
@@ -919,7 +928,7 @@ function executeAndAuditEffect(opts: {
   connectionGroupId?: string;
   /** Planner reason that picked this connection (for the OTel `atlas.routing_reason` attribute). */
   routingReason?: RoutingReason;
-}): Effect.Effect<Record<string, unknown>, QueryExecutionError> {
+}): Effect.Effect<Record<string, unknown>, QueryExecutionError | EnterpriseUnavailableError> {
   const {
     db, dbType, connId, orgId, targetHost, querySql, queryTimeout,
     rowLimit, explanation, classification, cacheKey, hookMetadata, dispatchHook,
@@ -1067,6 +1076,11 @@ function executeAndAuditEffect(opts: {
               });
               maskingApplied = maskedRows !== result.rows;
             } catch (err) {
+              // #2593 — fail-closed: when EE was supposed to bind but didn't
+              // (`ATLAS_ENTERPRISE_ENABLED=true` + `available: false`), rethrow
+              // so the outer catch surfaces it instead of returning unmasked
+              // rows on classified tables.
+              if (err instanceof EnterpriseUnavailableError) throw err;
               log.warn(
                 { err: err instanceof Error ? err.message : String(err), connectionId: connId },
                 "PII masking failed — returning unmasked results",
@@ -1089,6 +1103,9 @@ function executeAndAuditEffect(opts: {
           } as Record<string, unknown>;
         },
         catch: (err) => {
+          // #2593 — preserve the `enterprise_load_failed` signal end-to-end
+          // instead of wrapping as a generic post-processing failure.
+          if (err instanceof EnterpriseUnavailableError) return err;
           // Query succeeded but post-processing failed — return the error
           // rather than losing the completed query result as an unrecoverable defect.
           const message = err instanceof Error ? err.message : String(err);
@@ -1117,6 +1134,7 @@ function pipelineErrorToResponse(error: PipelineError): Record<string, unknown> 
     case "RLSError":
     case "PluginRejectedError":
     case "QueryExecutionError":
+    case "EnterpriseUnavailableError":
       return { success: false, error: error.message, executionMs: 0 };
     default: {
       const _exhaustive: never = error;
@@ -1164,7 +1182,8 @@ export type UserQueryOutcome =
   | { readonly kind: "pool_exhausted"; readonly message: string }
   | { readonly kind: "rls_failed"; readonly message: string }
   | { readonly kind: "plugin_rejected"; readonly message: string }
-  | { readonly kind: "query_failed"; readonly message: string };
+  | { readonly kind: "query_failed"; readonly message: string }
+  | { readonly kind: "enterprise_unavailable"; readonly message: string };
 
 export interface RunUserQueryOpts {
   readonly sql: string;
@@ -1415,6 +1434,10 @@ export function runUserQueryPipeline(opts: RunUserQueryOpts): Promise<UserQueryO
             return Effect.succeed({ kind: "plugin_rejected", message: error.message });
           case "QueryExecutionError":
             return Effect.succeed({ kind: "query_failed", message: error.message });
+          case "EnterpriseUnavailableError":
+            // #2593 — surface the fail-closed signal end-to-end so the
+            // route handler can return 503 `enterprise_load_failed`.
+            return Effect.succeed({ kind: "enterprise_unavailable", message: error.message });
           default: {
             const _exhaustive: never = error;
             return Effect.succeed({
@@ -1663,6 +1686,8 @@ async function executeSqlForConnection({
                     });
                     cachedMaskingApplied = cachedRows !== cached.rows;
                   } catch (err) {
+                    // #2593 — fail-closed (same rationale as the live path).
+                    if (err instanceof EnterpriseUnavailableError) throw err;
                     log.warn(
                       { err: err instanceof Error ? err.message : String(err), connectionId: connId },
                       "PII masking failed on cached results — returning unmasked results",
@@ -1678,6 +1703,8 @@ async function executeSqlForConnection({
                 };
               },
               catch: (err) => {
+                // #2593 — preserve fail-closed signal through the cache path.
+                if (err instanceof EnterpriseUnavailableError) return err;
                 const message = err instanceof Error ? err.message : String(err);
                 log.error({ err, connectionId: connId }, "Cache response processing failed");
                 return new QueryExecutionError({ message: `Cache response processing failed: ${message}` });

--- a/packages/api/src/lib/tools/sql.ts
+++ b/packages/api/src/lib/tools/sql.ts
@@ -47,14 +47,25 @@ import {
   type MaskingContext,
 } from "@atlas/api/lib/effect/services";
 import { runEnterprise } from "@atlas/api/lib/effect/enterprise-layer";
+import { isEnterpriseEnabled } from "@atlas/api/lib/effect/enterprise-config";
+import { EnterpriseUnavailableError } from "@atlas/api/lib/effect/errors";
 
 /**
  * Run `MaskingPolicy.applyMasking` via `EnterpriseLayer`. Promise-shaped
  * wrapper so the two sql.ts call sites (live + cache path) can keep
  * their existing async/await structure without restructuring around
- * `Effect.gen` (#2566 — slice 4/11 of #2017). Fails open: any error in
- * the program is rethrown to the caller's existing try/catch, which
- * already logs `"PII masking failed — returning unmasked results"`.
+ * `Effect.gen` (#2566 — slice 4/11 of #2017).
+ *
+ * #2593 — consumer-side fail-closed: on SaaS (`ATLAS_ENTERPRISE_ENABLED=true`)
+ * if the MaskingPolicy Tag is still the no-op default (`available: false`),
+ * the EE layer didn't bind — returning unmasked rows on classified tables
+ * is a compliance break. Throw `EnterpriseUnavailableError` so the caller's
+ * existing try/catch short-circuits "PII masking failed" into a hard fail
+ * instead of the legacy fail-open behavior.
+ *
+ * Self-hosted (`ATLAS_ENTERPRISE_ENABLED !== true`) keeps the original
+ * fail-open behavior: the no-op pass-through is the expected self-hosted
+ * code path.
  */
 function applyMaskingViaTag(
   ctx: MaskingContext,
@@ -62,6 +73,15 @@ function applyMaskingViaTag(
   return runEnterprise(
     Effect.gen(function* () {
       const masking = yield* MaskingPolicy;
+      if (isEnterpriseEnabled() && !masking.available) {
+        return yield* Effect.fail(
+          new EnterpriseUnavailableError({
+            message:
+              "PII masking unavailable — query blocked to prevent unmasked-data exposure. Contact your administrator.",
+            tag: "MaskingPolicy",
+          }),
+        );
+      }
       return yield* masking.applyMasking(ctx);
     }),
   );
@@ -74,11 +94,27 @@ function applyMaskingViaTag(
  * `createApprovalRequest`); resolving the shape once + reading methods
  * keeps the existing try/catch fail-closed semantics intact and avoids
  * paying for three separate `Effect.runPromise` round-trips (#2567).
+ *
+ * #2593 — consumer-side fail-closed: on SaaS where EE didn't bind, the
+ * no-op's `checkApprovalRequired` reports `required: false` — bypassing
+ * approval-gated queries entirely. Throw `EnterpriseUnavailableError`
+ * so the caller surfaces the existing "approval system unavailable"
+ * 503 envelope. Self-hosted falls through (no-op = no rules to match).
  */
 function loadApprovalGate(): Promise<ApprovalGateShape> {
   return runEnterprise(
     Effect.gen(function* () {
-      return yield* ApprovalGate;
+      const gate = yield* ApprovalGate;
+      if (isEnterpriseEnabled() && !gate.available) {
+        return yield* Effect.fail(
+          new EnterpriseUnavailableError({
+            message:
+              "Approval gate unavailable — query blocked to prevent governance bypass. Contact your administrator.",
+            tag: "ApprovalGate",
+          }),
+        );
+      }
+      return gate;
     }),
   );
 }


### PR DESCRIPTION
Second half of #2593. The first half ([PR #2598](https://github.com/AtlasDevHQ/atlas/pull/2598)) shipped the compile-time exhaustiveness gate for route `domainErrors`. This PR completes the consumer-side audit: each of four high-impact load-bearing Tag call sites now yields its Tag, checks `tag.available`, and short-circuits with a new `EnterpriseUnavailableError` (→ HTTP 503 `enterprise_load_failed`) when `isEnterpriseEnabled() === true` but `tag.available === false`.

Self-hosted (no `ATLAS_ENTERPRISE_ENABLED=true`) keeps the original no-op pass-through — the noop IS the expected self-hosted path, so the discriminator gate stays quiet there.

## Hardened sites (4 of the 5 originally scoped)

- **MaskingPolicy** → `lib/tools/sql.ts:applyMaskingViaTag`
- **ApprovalGate** → `lib/tools/sql.ts:loadApprovalGate`
- **ResidencyResolver** → `lib/db/connection.ts:getRegionAwareConnection`
- **AuditRetention** → `api/routes/admin-{audit,action}-retention.ts` (via `yieldAuditRetentionFailClosed` helpers)

## IP allowlist site scoped out (Option B)

Adding the gate at `api/routes/middleware.ts:checkIpAllowlist` cascaded through ~17 admin-route tests that partial-mock `@atlas/ee/layers` without binding `IpAllowlistPolicy: { available: true }`. In production EE's `IpAllowlistPolicyLive` DOES bind it, so the partial mocks were silently lying about which Tags EE had loaded — adding the gate exposed the lie.

Two paths were on the table:
- **Option A** — apply a `TestIpAllowlistPolicyLayer` shim to each of the 17 admin test files alongside the gate.
- **Option B** — drop the IP allowlist site from this PR; track the gate + the matching test-helper rollout together in a follow-up.

Picked B. The remaining 4 sites have no test fanout; the IP allowlist site is structurally a separate body of work and shouldn't block the four ready-to-ship guards. `enterprise-layer.ts`'s JSDoc points to the deferred site so the next pass starts with context.

## Infra

- **`EnterpriseUnavailableError`** — new `Data.TaggedError` in `lib/effect/errors.ts`, added to the `AtlasError` union + `ATLAS_ERROR_TAG_LIST`. The Hono bridge's `mapTaggedError` surfaces it as 503 with wire code `enterprise_load_failed` (distinct from the 403 `EnterpriseError`). Adding it to `ATLAS_ERROR_TAG_LIST` satisfies the #2598 compile-time exhaustiveness gate.
- **`available: boolean`** added to `MaskingPolicyShape` and `AuditRetentionShape` with JSDoc citing #2593. PR #2589 dropped these by default; the codified rule in CLAUDE.md ("`Tag.available` is for the 404 / shaped-success branch only") explicitly carves out "a different response shape than the 403 envelope" — 503 fail-closed is exactly that branch.
- **`available: true`** on the matching EE Live impls (`makeMaskingPolicyLive`, `makeAuditRetentionLive`) so the production binding stays type-consistent.

## Test coverage

`packages/api/src/lib/effect/__tests__/consumer-fail-closed.test.ts` (8 cases, 20 expects) pins each discriminator branch directly against the Tag's shape — locks the "EE-enabled + available=false → 503" contract for every site so a future "simplify the noop" PR can't silently regress it.

Spot-checked admin-sso.test.ts (18/18 pass) to confirm the test fanout went away after dropping the middleware site.

## Acceptance criteria from #2593 (consumer-side half)

- [x] Five load-bearing Tag call sites identified — four hardened; IpAllowlist deferred with explicit reason in JSDoc
- [x] New 503 wire code (`enterprise_load_failed`) distinct from 403
- [x] Each guard quiet on self-hosted, loud on SaaS-EE-broken
- [x] Discriminator contract pinned by `consumer-fail-closed.test.ts`

## Test plan

- [x] `bun run lint` — 0 errors
- [x] `bun x tsgo --noEmit` — clean
- [x] `bash scripts/check-ee-imports.sh` — passes
- [x] `bash scripts/check-schema-drift.sh` — passes
- [x] `bash scripts/check-template-drift.sh` — passes
- [x] `bun test packages/api/src/lib/effect/__tests__/consumer-fail-closed.test.ts` — 8/8 pass
- [x] `bun test packages/api/src/api/__tests__/admin-sso.test.ts` — 18/18 pass (regression sample)
- [ ] Full CI on push