### PR TITLE
fix(api): slack OAuth callback — use form-encoded body for oauth.v2.access

### DIFF
--- a/packages/api/src/lib/slack/__tests__/api.test.ts
+++ b/packages/api/src/lib/slack/__tests__/api.test.ts
@@ -96,6 +96,34 @@ describe("api", () => {
       }
     });
 
+    it("oauth.v2.access sends form-encoded body and no Bearer header", async () => {
+      mockFetch.mockResolvedValue(
+        new Response(
+          JSON.stringify({ ok: true, access_token: "xoxb-x", team: { id: "T1", name: "Acme" } }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      );
+
+      const result = await slackAPI("oauth.v2.access", "", {
+        client_id: "cid",
+        client_secret: "csec",
+        code: "the-code",
+      });
+      expect(result.ok).toBe(true);
+
+      const [url, init] = mockFetch.mock.calls[0];
+      expect(url).toBe("https://slack.com/api/oauth.v2.access");
+      const headers = (init as RequestInit).headers as Record<string, string>;
+      expect(headers["Content-Type"]).toContain("application/x-www-form-urlencoded");
+      expect(headers.Authorization).toBeUndefined();
+
+      const body = (init as RequestInit).body as string;
+      const parsed = new URLSearchParams(body);
+      expect(parsed.get("client_id")).toBe("cid");
+      expect(parsed.get("client_secret")).toBe("csec");
+      expect(parsed.get("code")).toBe("the-code");
+    });
+
     it("Slack-level error (HTTP 200, ok: false) returns the error", async () => {
       mockFetch.mockResolvedValue(
         new Response(JSON.stringify({ ok: false, error: "channel_not_found" }), {

--- a/packages/api/src/lib/slack/api.ts
+++ b/packages/api/src/lib/slack/api.ts
@@ -2,8 +2,10 @@
  * Thin Slack Web API client using native fetch.
  *
  * No heavy dependencies — POST to slack.com/api endpoints with JSON body
- * and Bearer token auth. For oauth.v2.access, pass an empty token — Slack
- * uses client_id/client_secret from the body instead.
+ * and Bearer token auth. The `oauth.*` namespace is the exception: Slack
+ * rejects JSON bodies there and requires application/x-www-form-urlencoded
+ * with client_id/client_secret in the body (no Bearer token). Sending
+ * JSON makes Slack fail to parse `code` and return `invalid_code`.
  */
 
 import { createLogger } from "@atlas/api/lib/logger";
@@ -25,14 +27,27 @@ export async function slackAPI(
   token: string,
   body: Record<string, unknown>,
 ): Promise<SlackAPIResponse> {
+  const isOauth = method.startsWith("oauth.");
+  const headers: Record<string, string> = isOauth
+    ? { "Content-Type": "application/x-www-form-urlencoded; charset=utf-8" }
+    : {
+        "Content-Type": "application/json; charset=utf-8",
+        Authorization: `Bearer ${token}`,
+      };
+  const requestBody = isOauth
+    ? new URLSearchParams(
+        Object.entries(body).reduce<Record<string, string>>((acc, [k, v]) => {
+          if (v !== undefined && v !== null) acc[k] = String(v);
+          return acc;
+        }, {}),
+      ).toString()
+    : JSON.stringify(body);
+
   try {
     const resp = await fetch(`${SLACK_API_BASE}/${method}`, {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json; charset=utf-8",
-        Authorization: `Bearer ${token}`,
-      },
-      body: JSON.stringify(body),
+      headers,
+      body: requestBody,
     });
 
     if (!resp.ok) {


### PR DESCRIPTION
## Summary
- Live bug: `https://api.useatlas.dev/api/v1/slack/callback?code=...` returned `{"error":"oauth_failed","message":"OAuth failed"}` for every install attempt.
- Root cause (confirmed via Railway logs — `Slack API returned error … method=oauth.v2.access error=invalid_code`): `slackAPI()` sends `Content-Type: application/json` for every endpoint, but Slack's `oauth.*` namespace rejects JSON and requires `application/x-www-form-urlencoded` with `client_id`/`client_secret` in the body (no Bearer token). The mismatch causes Slack to fail to parse `code` and respond `invalid_code`, which the callback handler surfaces as the generic `oauth_failed`.
- Fix: branch `slackAPI()` on `method.startsWith("oauth.")` — form-encode the body and drop the `Authorization` header for `oauth.*` calls only. All other methods (chat.postMessage, etc.) keep JSON + Bearer behavior unchanged.

## Test plan
- [x] `bun test packages/api/src/lib/slack/__tests__/api.test.ts` — 8/8 pass (7 existing + 1 new OAuth shape assertion)
- [ ] After deploy: visit `https://api.useatlas.dev/api/v1/slack/install`, complete Slack consent, confirm the callback now renders the "Atlas installed!" success page and a row is written to the Slack installations table.