### PR TITLE
fix(api): emit installed_at as ISO 8601 from integration stores

### DIFF
--- a/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
@@ -2,6 +2,7 @@ import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { Pool } from "pg";
+import { z } from "zod";
 import { runMigrations } from "@atlas/api/lib/db/migrate";
 import { MANAGED_AUTH_MIGRATIONS } from "@atlas/api/lib/db/internal";
 import {
@@ -4057,6 +4058,23 @@ describeIfPg("migrate-pg (real Postgres)", () => {
     expect(statusErr?.code).toBe("23514");
   }, PG_TEST_TIMEOUT_MS);
 
+  // #2606 — every integration store renders `installed_at` via the same
+  // `to_char(... AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')`
+  // formatter so the admin /admin/integrations response satisfies
+  // IntegrationStatusSchema's strict `z.string().datetime()`. The bug class
+  // (Postgres `::text` default render uses ' ' + '+00', which Zod rejects)
+  // was dormant until the first real install row landed in prod. Exercises
+  // the formatter against real Postgres; the source-level revert guard
+  // lives in the always-on describe block at the bottom of this file.
+  it("integration stores: to_char formatter emits strict ISO 8601 that passes z.string().datetime()", async () => {
+    const { rows } = await pool.query<{ installed_at: string }>(
+      `SELECT to_char(now() AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') AS installed_at`,
+    );
+    const value = rows[0]?.installed_at;
+    expect(typeof value).toBe("string");
+    expect(() => z.string().datetime().parse(value)).not.toThrow();
+  }, PG_TEST_TIMEOUT_MS);
+
   it("0080: ON DELETE CASCADE — dropping the parent dashboard drops every stage (#2365)", async () => {
     const stamp = Date.now();
     const orgId = `org-2365-cascade-${stamp}`;
@@ -4083,4 +4101,18 @@ describeIfPg("migrate-pg (real Postgres)", () => {
     );
     expect(afterCount.rows[0]?.c).toBe(0);
   }, PG_TEST_TIMEOUT_MS);
+});
+
+// #2606 — source-level revert guard for the integration-store SQL formatter.
+// Lives outside `describeIfPg` so it runs in every shard, including dev
+// without TEST_DATABASE_URL — fails in milliseconds if any store reverts
+// to `installed_at::text` (the format Zod's strict .datetime() rejects).
+describe("integration stores: ISO timestamp SQL", () => {
+  it("no store reintroduces installed_at::text", () => {
+    const platforms = ["discord", "email", "gchat", "github", "linear", "slack", "teams", "telegram", "whatsapp"] as const;
+    for (const platform of platforms) {
+      const source = readFileSync(join(import.meta.dir, "..", "..", platform, "store.ts"), "utf8");
+      expect(source).not.toContain("installed_at::text");
+    }
+  });
 });

--- a/packages/api/src/lib/discord/store.ts
+++ b/packages/api/src/lib/discord/store.ts
@@ -18,7 +18,7 @@ export type { DiscordInstallation, DiscordInstallationWithSecret } from "@atlas/
 
 const log = createLogger("discord-store");
 
-const SELECT_COLS = "guild_id, org_id, guild_name, bot_token_encrypted, application_id, public_key, installed_at::text";
+const SELECT_COLS = "guild_id, org_id, guild_name, bot_token_encrypted, application_id, public_key, to_char(installed_at AT TIME ZONE 'UTC', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"') AS installed_at";
 
 // ---------------------------------------------------------------------------
 // Shared row parser

--- a/packages/api/src/lib/email/store.ts
+++ b/packages/api/src/lib/email/store.ts
@@ -179,7 +179,7 @@ export async function getEmailInstallationByOrg(
 
   try {
     const rows = await internalQuery<Record<string, unknown>>(
-      "SELECT config_id, provider, sender_address, config_encrypted, org_id, installed_at::text FROM email_installations WHERE org_id = $1",
+      "SELECT config_id, provider, sender_address, config_encrypted, org_id, to_char(installed_at AT TIME ZONE 'UTC', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"') AS installed_at FROM email_installations WHERE org_id = $1",
       [orgId],
     );
     if (rows.length > 0) {

--- a/packages/api/src/lib/gchat/store.ts
+++ b/packages/api/src/lib/gchat/store.ts
@@ -16,7 +16,7 @@ export type { GChatInstallation, GChatInstallationWithSecret } from "@atlas/api/
 
 const log = createLogger("gchat-store");
 
-const SELECT_COLS = "project_id, service_account_email, credentials_json_encrypted, org_id, installed_at::text";
+const SELECT_COLS = "project_id, service_account_email, credentials_json_encrypted, org_id, to_char(installed_at AT TIME ZONE 'UTC', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"') AS installed_at";
 
 // ---------------------------------------------------------------------------
 // Shared row parser

--- a/packages/api/src/lib/github/store.ts
+++ b/packages/api/src/lib/github/store.ts
@@ -15,7 +15,7 @@ export type { GitHubInstallation, GitHubInstallationWithSecret } from "@atlas/ap
 
 const log = createLogger("github-store");
 
-const SELECT_COLS = "user_id, access_token_encrypted, username, org_id, installed_at::text";
+const SELECT_COLS = "user_id, access_token_encrypted, username, org_id, to_char(installed_at AT TIME ZONE 'UTC', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"') AS installed_at";
 
 // ---------------------------------------------------------------------------
 // Shared row parser

--- a/packages/api/src/lib/linear/store.ts
+++ b/packages/api/src/lib/linear/store.ts
@@ -15,7 +15,7 @@ export type { LinearInstallation, LinearInstallationWithSecret } from "@atlas/ap
 
 const log = createLogger("linear-store");
 
-const SELECT_COLS = "user_id, api_key_encrypted, user_name, user_email, org_id, installed_at::text";
+const SELECT_COLS = "user_id, api_key_encrypted, user_name, user_email, org_id, to_char(installed_at AT TIME ZONE 'UTC', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"') AS installed_at";
 
 // ---------------------------------------------------------------------------
 // Shared row parser

--- a/packages/api/src/lib/slack/store.ts
+++ b/packages/api/src/lib/slack/store.ts
@@ -60,7 +60,7 @@ function parseInstallationRow(
   };
 }
 
-const SELECT_COLS = "team_id, bot_token_encrypted, org_id, workspace_name, installed_at::text";
+const SELECT_COLS = "team_id, bot_token_encrypted, org_id, workspace_name, to_char(installed_at AT TIME ZONE 'UTC', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"') AS installed_at";
 
 // ---------------------------------------------------------------------------
 // Read operations

--- a/packages/api/src/lib/teams/store.ts
+++ b/packages/api/src/lib/teams/store.ts
@@ -17,7 +17,7 @@ export type { TeamsInstallation, TeamsInstallationWithSecret } from "@atlas/api/
 
 const log = createLogger("teams-store");
 
-const SELECT_COLS = "tenant_id, org_id, tenant_name, app_password_encrypted, installed_at::text";
+const SELECT_COLS = "tenant_id, org_id, tenant_name, app_password_encrypted, to_char(installed_at AT TIME ZONE 'UTC', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"') AS installed_at";
 
 // ---------------------------------------------------------------------------
 // Shared row parser

--- a/packages/api/src/lib/telegram/store.ts
+++ b/packages/api/src/lib/telegram/store.ts
@@ -16,7 +16,7 @@ export type { TelegramInstallation, TelegramInstallationWithSecret } from "@atla
 
 const log = createLogger("telegram-store");
 
-const SELECT_COLS = "bot_id, bot_token_encrypted, bot_username, org_id, installed_at::text";
+const SELECT_COLS = "bot_id, bot_token_encrypted, bot_username, org_id, to_char(installed_at AT TIME ZONE 'UTC', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"') AS installed_at";
 
 // ---------------------------------------------------------------------------
 // Shared row parser

--- a/packages/api/src/lib/whatsapp/store.ts
+++ b/packages/api/src/lib/whatsapp/store.ts
@@ -16,7 +16,7 @@ export type { WhatsAppInstallation, WhatsAppInstallationWithSecret } from "@atla
 
 const log = createLogger("whatsapp-store");
 
-const SELECT_COLS = "phone_number_id, access_token_encrypted, display_phone, org_id, installed_at::text";
+const SELECT_COLS = "phone_number_id, access_token_encrypted, display_phone, org_id, to_char(installed_at AT TIME ZONE 'UTC', 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"') AS installed_at";
 
 // ---------------------------------------------------------------------------
 // Shared row parser


### PR DESCRIPTION
## Summary
- Follow-up to #2605. After Slack OAuth started working again, the first real install row landed in `slack_installations` — and the admin **/admin/integrations** page immediately broke with *"The server returned data this version of the app can't read. This usually means the server and app are out of sync — contact your administrator or try again later."*
- Root cause: every integration store selects `installed_at::text`, which Postgres renders as `2026-05-18 22:22:53.318+00` (space separator, offset suffix). That fails `z.string().datetime()` in `IntegrationStatusSchema` — Zod's default strict ISO 8601 requires `T` separator and `Z` suffix. The page works when all tables are empty (null passes the schema), so the bug was dormant until the first real install row appeared.
- Fix: replace `installed_at::text` with `to_char(installed_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') AS installed_at` in all 9 stores (slack, teams, discord, telegram, gchat, github, linear, whatsapp, email). Output becomes `2026-05-18T22:22:53.318Z` — passes the strict schema unchanged. Parsers already accept any string for `installed_at`, so no other code changes needed.

## Test plan
- [x] `bun run scripts/test-isolated.ts --affected` — 20/20 affected tests pass (all 9 store suites + `admin-integrations`, `admin-integrations-byot`, `admin-integrations-audit`, `slack`, `teams`, `discord`, `admin-email-provider-route`)
- [ ] After deploy: revisit `/admin/integrations`, confirm the page renders the Slack install row with the proper "Connected" status instead of the schema-mismatch error.