### PR TITLE
fix(api,slack): dogfood — redirect, @mention handler, ephemeral ack, dedupe response blocks

### DIFF
--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -72142,7 +72142,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Installation successful (HTML response)",
+            "description": "Installation successful (HTML response, when no web origin is configured)",
             "content": {
               "text/html": {
                 "schema": {
@@ -72150,6 +72150,9 @@
                 }
               }
             }
+          },
+          "302": {
+            "description": "Installation successful (redirect to /admin/integrations on the web app)"
           },
           "400": {
             "description": "Invalid or expired state, or missing code",
@@ -72374,7 +72377,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Installation successful (HTML response)",
+            "description": "Installation successful (HTML response, when no web origin is configured)",
             "content": {
               "text/html": {
                 "schema": {
@@ -72382,6 +72385,9 @@
                 }
               }
             }
+          },
+          "302": {
+            "description": "Installation successful (redirect to /admin/integrations on the web app)"
           },
           "400": {
             "description": "Invalid or expired state, or consent not granted",
@@ -72606,7 +72612,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Installation successful (HTML response)",
+            "description": "Installation successful (HTML response, when no web origin is configured)",
             "content": {
               "text/html": {
                 "schema": {
@@ -72614,6 +72620,9 @@
                 }
               }
             }
+          },
+          "302": {
+            "description": "Installation successful (redirect to /admin/integrations on the web app)"
           },
           "400": {
             "description": "Invalid or expired state, or authorization denied",

--- a/packages/api/src/api/__tests__/slack.test.ts
+++ b/packages/api/src/api/__tests__/slack.test.ts
@@ -305,7 +305,7 @@ describe("/api/v1/slack", () => {
   });
 
   describe("POST /api/v1/slack/commands", () => {
-    it("acks a slash command with 200 and in_channel response", async () => {
+    it("acks a slash command with 200 and an ephemeral response", async () => {
       const app = await getApp();
       const body = "token=xxx&team_id=T123&channel_id=C456&user_id=U789&text=how+many+users";
       const { signature, timestamp } = makeSignature(body);
@@ -322,7 +322,9 @@ describe("/api/v1/slack", () => {
 
       expect(resp.status).toBe(200);
       const json = (await resp.json()) as Record<string, unknown>;
-      expect(json.response_type).toBe("in_channel");
+      // Ephemeral so the ack doesn't double up with the bot's in-channel
+      // "Thinking..." message — see slack.ts comment for the rationale.
+      expect(json.response_type).toBe("ephemeral");
       expect(json.text).toContain("Processing");
     });
 

--- a/packages/api/src/api/__tests__/slack.test.ts
+++ b/packages/api/src/api/__tests__/slack.test.ts
@@ -501,6 +501,112 @@ describe("/api/v1/slack", () => {
 
       expect(mockRunAgent).toHaveBeenCalled();
     });
+
+    it("processes a top-level app_mention and runs the agent in a new thread", async () => {
+      const app = await getApp();
+      const payload = JSON.stringify({
+        type: "event_callback",
+        team_id: "T123",
+        event: {
+          type: "app_mention",
+          text: "<@U999BOT> how many customers do we have?",
+          channel: "C456",
+          user: "U789",
+          ts: "1234567890.000002",
+        },
+      });
+      const { signature, timestamp } = makeSignature(payload);
+
+      const resp = await app.request("/api/v1/slack/events", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-slack-signature": signature,
+          "x-slack-request-timestamp": timestamp,
+        },
+        body: payload,
+      });
+
+      expect(resp.status).toBe(200);
+      await new Promise((r) => setTimeout(r, 100));
+
+      expect(mockPostMessage).toHaveBeenCalled();
+      expect(mockRunAgent).toHaveBeenCalled();
+      expect(mockUpdateMessage).toHaveBeenCalled();
+      // The thinking message and follow-ups must thread off the mention's ts.
+      const thinkingCall = mockPostMessage.mock.calls[0]?.[1] as
+        | { thread_ts?: string }
+        | undefined;
+      expect(thinkingCall?.thread_ts).toBe("1234567890.000002");
+    });
+
+    it("skips app_mention when posted inside an existing thread (message branch owns it)", async () => {
+      const app = await getApp();
+      // Slack delivers BOTH app_mention and message for an in-thread mention.
+      // The app_mention branch must early-return so the message handler can
+      // own conversation-history loading and reply once.
+      const payload = JSON.stringify({
+        type: "event_callback",
+        team_id: "T123",
+        event: {
+          type: "app_mention",
+          text: "<@U999BOT> follow-up question",
+          channel: "C456",
+          user: "U789",
+          ts: "1234567890.000003",
+          thread_ts: "1234567890.000001",
+        },
+      });
+      const { signature, timestamp } = makeSignature(payload);
+
+      const resp = await app.request("/api/v1/slack/events", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-slack-signature": signature,
+          "x-slack-request-timestamp": timestamp,
+        },
+        body: payload,
+      });
+
+      expect(resp.status).toBe(200);
+      await new Promise((r) => setTimeout(r, 100));
+
+      expect(mockRunAgent).not.toHaveBeenCalled();
+      expect(mockPostMessage).not.toHaveBeenCalled();
+    });
+
+    it("ignores app_mention with only the bot prefix and no question", async () => {
+      const app = await getApp();
+      const payload = JSON.stringify({
+        type: "event_callback",
+        team_id: "T123",
+        event: {
+          type: "app_mention",
+          text: "<@U999BOT>   ",
+          channel: "C456",
+          user: "U789",
+          ts: "1234567890.000004",
+        },
+      });
+      const { signature, timestamp } = makeSignature(payload);
+
+      const resp = await app.request("/api/v1/slack/events", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-slack-signature": signature,
+          "x-slack-request-timestamp": timestamp,
+        },
+        body: payload,
+      });
+
+      expect(resp.status).toBe(200);
+      await new Promise((r) => setTimeout(r, 100));
+
+      expect(mockRunAgent).not.toHaveBeenCalled();
+      expect(mockPostMessage).not.toHaveBeenCalled();
+    });
   });
 
   describe("async processing", () => {
@@ -916,6 +1022,40 @@ describe("/api/v1/slack", () => {
       const html = await resp.text();
       expect(html).toContain("Atlas installed!");
       expect(mockSaveInstallation).toHaveBeenCalledWith("T999", "xoxb-new-token", { orgId: undefined, workspaceName: undefined });
+    });
+
+    it("redirects to /admin/integrations on the web app when ATLAS_CORS_ORIGIN is set", async () => {
+      process.env.SLACK_CLIENT_ID = "test_client_id";
+      process.env.SLACK_CLIENT_SECRET = "test_client_secret";
+      const savedCors = process.env.ATLAS_CORS_ORIGIN;
+      process.env.ATLAS_CORS_ORIGIN = "https://app.example.com";
+      try {
+        mockSlackAPI.mockResolvedValueOnce({
+          ok: true,
+          team: { id: "T999" },
+          access_token: "xoxb-new-token",
+        });
+        const app = await getApp();
+
+        const installResp = await app.request("/api/v1/slack/install", {
+          method: "GET",
+          redirect: "manual",
+        });
+        const location = installResp.headers.get("location") ?? "";
+        const stateParam = new URL(location).searchParams.get("state");
+
+        const resp = await app.request(
+          `/api/v1/slack/callback?code=test_code&state=${stateParam}`,
+          { method: "GET", redirect: "manual" },
+        );
+        expect(resp.status).toBe(302);
+        expect(resp.headers.get("location")).toBe(
+          "https://app.example.com/admin/integrations?installed=slack",
+        );
+      } finally {
+        if (savedCors !== undefined) process.env.ATLAS_CORS_ORIGIN = savedCors;
+        else delete process.env.ATLAS_CORS_ORIGIN;
+      }
     });
 
     it("returns error HTML when OAuth response is missing team data", async () => {

--- a/packages/api/src/api/routes/discord.ts
+++ b/packages/api/src/api/routes/discord.ts
@@ -20,6 +20,7 @@ import { ErrorSchema, AuthErrorSchema } from "./shared-schemas";
 import { validationHook } from "./validation-hook";
 import { adminAuthPreamble } from "./admin-auth";
 import { getConfig } from "@atlas/api/lib/config";
+import { getWebOrigin } from "@atlas/api/lib/web-origin";
 
 const log = createLogger("discord");
 
@@ -84,8 +85,11 @@ const callbackRoute = createRoute({
   },
   responses: {
     200: {
-      description: "Installation successful (HTML response)",
+      description: "Installation successful (HTML response, when no web origin is configured)",
       content: { "text/html": { schema: z.string() } },
+    },
+    302: {
+      description: "Installation successful (redirect to /admin/integrations on the web app)",
     },
     400: {
       description: "Invalid or expired state, or authorization denied",
@@ -296,6 +300,10 @@ discord.openapi(callbackRoute, async (c) => {
     );
   }
 
+  const webOrigin = getWebOrigin();
+  if (webOrigin) {
+    return c.redirect(`${webOrigin}/admin/integrations?installed=discord`);
+  }
   return c.html(
     "<html><body><h1>Atlas installed!</h1><p>You can now use Atlas in your Discord server.</p></body></html>",
   );

--- a/packages/api/src/api/routes/slack.ts
+++ b/packages/api/src/api/routes/slack.ts
@@ -634,17 +634,17 @@ slack.openapi(eventsRoute, async (c) => {
       });
     }
 
-    // @atlas mention in a channel — kicks off a new conversation. Replies
-    // are threaded off the mention's `event.ts` (or, if the mention was
-    // posted inside an existing thread, off that thread's parent).
-    if (eventType === "app_mention" && text.trim()) {
+    // @atlas mention in a top-level channel message — opens a new thread off
+    // the mention's `event.ts`. In-thread mentions are intentionally skipped:
+    // Slack also delivers a `message` event for the same post, and the
+    // `message + threadTs` branch above already loads conversation history
+    // and replies in-thread. Handling both branches would double-fire the
+    // agent for the same user post.
+    if (eventType === "app_mention" && !threadTs && text.trim()) {
       const mentionTs = (event.ts as string) ?? "";
-      // Strip the leading bot mention(s) — e.g. `<@U0AQUSO5HBM> what's …`.
       const question = text.replace(/^(<@[A-Z0-9]+>\s*)+/, "").trim();
       const eventUserId = (event.user as string) ?? "";
-      // If the mention is inside an existing thread, reply there. Otherwise
-      // open a new thread off the mention message itself.
-      const replyThreadTs = threadTs || mentionTs;
+      const replyThreadTs = mentionTs;
 
       if (!question) {
         log.info({ channel, mentionTs }, "Ignoring app_mention with empty question");
@@ -685,8 +685,6 @@ slack.openapi(eventsRoute, async (c) => {
               })
             : undefined;
 
-          // Post a thinking message in-thread, then update it in place with
-          // the final answer. Same pattern as the slash command path.
           const thinkingResult = await postMessage(token, {
             channel,
             text: `:hourglass_flowing_sand: Thinking about: _${question.slice(0, 150)}_...`,

--- a/packages/api/src/api/routes/slack.ts
+++ b/packages/api/src/api/routes/slack.ts
@@ -30,6 +30,7 @@ import { SENSITIVE_PATTERNS } from "@atlas/api/lib/security";
 import { ErrorSchema, AuthErrorSchema } from "./shared-schemas";
 import { adminAuthPreamble } from "./admin-auth";
 import { getConfig } from "@atlas/api/lib/config";
+import { getWebOrigin } from "@atlas/api/lib/web-origin";
 
 const log = createLogger("slack");
 
@@ -199,8 +200,11 @@ const callbackRoute = createRoute({
   },
   responses: {
     200: {
-      description: "Installation successful (HTML response)",
+      description: "Installation successful (HTML response, when no web origin is configured)",
       content: { "text/html": { schema: z.string() } },
+    },
+    302: {
+      description: "Installation successful (redirect to /admin/integrations on the web app)",
     },
     400: {
       description: "Invalid or expired state, or missing code",
@@ -420,9 +424,11 @@ slack.openapi(commandsRoute, async (c) => {
     );
   });
 
-  // Immediate ack to Slack
+  // Immediate ack to Slack. Ephemeral so it only shows to the asker and
+  // doesn't double up with the bot's in-channel "Thinking..." message that
+  // gets updated in place with the final answer.
   return c.json({
-    response_type: "in_channel",
+    response_type: "ephemeral",
     text: `:hourglass_flowing_sand: Processing your question...`,
   }, 200);
 });
@@ -624,6 +630,176 @@ slack.openapi(eventsRoute, async (c) => {
         log.error(
           { err: err instanceof Error ? err : new Error(String(err)) },
           "Unhandled error in thread processing",
+        );
+      });
+    }
+
+    // @atlas mention in a channel — kicks off a new conversation. Replies
+    // are threaded off the mention's `event.ts` (or, if the mention was
+    // posted inside an existing thread, off that thread's parent).
+    if (eventType === "app_mention" && text.trim()) {
+      const mentionTs = (event.ts as string) ?? "";
+      // Strip the leading bot mention(s) — e.g. `<@U0AQUSO5HBM> what's …`.
+      const question = text.replace(/^(<@[A-Z0-9]+>\s*)+/, "").trim();
+      const eventUserId = (event.user as string) ?? "";
+      // If the mention is inside an existing thread, reply there. Otherwise
+      // open a new thread off the mention message itself.
+      const replyThreadTs = threadTs || mentionTs;
+
+      if (!question) {
+        log.info({ channel, mentionTs }, "Ignoring app_mention with empty question");
+        return c.json({ ok: true }, 200);
+      }
+
+      log.info(
+        { channel, mentionTs, threadTs: replyThreadTs, question: question.slice(0, 100) },
+        "App mention received",
+      );
+
+      const processAsync = async () => {
+        try {
+          const token = await getBotToken(teamId);
+          if (!token) {
+            log.error({ teamId }, "No bot token for app mention");
+            return;
+          }
+
+          const rateCheck = checkRateLimit(`slack:${teamId}:${eventUserId || mentionTs}`);
+          if (!rateCheck.allowed) {
+            await postMessage(token, {
+              channel,
+              text: "Rate limit exceeded. Please wait before trying again.",
+              thread_ts: replyThreadTs,
+            });
+            return;
+          }
+
+          const installation = await getInstallation(teamId);
+          const orgId = installation?.org_id ?? null;
+          const actor = orgId
+            ? botActorUser({
+                platform: "slack",
+                externalId: teamId,
+                orgId,
+                ...(eventUserId ? { externalUserId: eventUserId } : {}),
+              })
+            : undefined;
+
+          // Post a thinking message in-thread, then update it in place with
+          // the final answer. Same pattern as the slash command path.
+          const thinkingResult = await postMessage(token, {
+            channel,
+            text: `:hourglass_flowing_sand: Thinking about: _${question.slice(0, 150)}_...`,
+            thread_ts: replyThreadTs,
+          });
+          if (!thinkingResult.ok || !thinkingResult.ts) {
+            log.error({ error: thinkingResult.error }, "Failed to post thinking message for app mention");
+            return;
+          }
+          const messageTs = thinkingResult.ts;
+
+          // Map the thread parent to a conversation so follow-up replies
+          // in the same thread can load history via the existing handler.
+          const existingConversationId = await getConversationId(channel, replyThreadTs);
+          const conversationId = existingConversationId ?? crypto.randomUUID();
+          if (!existingConversationId) {
+            setConversationId(channel, replyThreadTs, conversationId);
+            createConversation({
+              id: conversationId,
+              title: generateTitle(question),
+              surface: "slack",
+            });
+          }
+
+          const queryResult = await executeAgentQuery(question, undefined, {
+            ...(actor ? { actor } : {}),
+            approvalSurface: "slack",
+          });
+
+          addMessage({ conversationId, role: "user", content: question });
+          addMessage({ conversationId, role: "assistant", content: queryResult.answer });
+
+          if (queryResult.pendingApproval) {
+            const approvalText =
+              `:lock: This query requires approval before it can run. ` +
+              `Rule: *${queryResult.pendingApproval.ruleName}*. ` +
+              `Approve via the Atlas admin console.`;
+            log.info(
+              { channel, teamId, mentionTs, approvalRequestId: queryResult.pendingApproval.requestId },
+              "Slack app mention held for approval",
+            );
+            await updateMessage(token, {
+              channel,
+              ts: messageTs,
+              text: approvalText,
+              blocks: formatErrorResponse(approvalText),
+            });
+            return;
+          }
+
+          const blocks = formatQueryResponse(queryResult);
+          const updateResult = await updateMessage(token, {
+            channel,
+            ts: messageTs,
+            text: queryResult.answer,
+            blocks,
+          });
+          if (!updateResult.ok) {
+            log.error(
+              { error: updateResult.error, channel, ts: messageTs },
+              "Failed to update Slack mention message with query result",
+            );
+          }
+
+          if (queryResult.pendingActions?.length && eventUserId) {
+            for (const action of queryResult.pendingActions) {
+              const approvalBlocks = formatActionApproval(action);
+              const ephResult = await postEphemeral(token, {
+                channel,
+                user: eventUserId,
+                text: `Action requires approval: ${action.summary}`,
+                blocks: approvalBlocks,
+                thread_ts: messageTs,
+              });
+              if (!ephResult.ok) {
+                log.error(
+                  { error: ephResult.error, channel, userId: eventUserId, actionId: action.id },
+                  "Failed to post ephemeral action approval prompt for mention",
+                );
+              }
+            }
+          }
+        } catch (err) {
+          log.error(
+            { err: err instanceof Error ? err : new Error(String(err)) },
+            "App mention processing failed",
+          );
+          try {
+            const token = await getBotToken(teamId);
+            if (token) {
+              const errorMessage = scrubError(
+                err instanceof Error ? err.message : "Unknown error",
+              );
+              await postMessage(token, {
+                channel,
+                text: errorMessage,
+                blocks: formatErrorResponse(errorMessage),
+                thread_ts: replyThreadTs,
+              });
+            }
+          } catch (innerErr) {
+            log.error(
+              { err: innerErr instanceof Error ? innerErr.message : String(innerErr) },
+              "Failed to send app mention error message",
+            );
+          }
+        }
+      };
+
+      processAsync().catch((err) => {
+        log.error(
+          { err: err instanceof Error ? err : new Error(String(err)) },
+          "Unhandled error in app mention processing",
         );
       });
     }
@@ -890,6 +1066,10 @@ slack.openapi(callbackRoute, async (c) => {
     return c.html("<html><body><h1>Installation Failed</h1><p>The OAuth response was incomplete. Please try again.</p></body></html>", 500);
   }
 
+  const webOrigin = getWebOrigin();
+  if (webOrigin) {
+    return c.redirect(`${webOrigin}/admin/integrations?installed=slack`);
+  }
   return c.html(
     "<html><body><h1>Atlas installed!</h1><p>You can now use /atlas in your Slack workspace.</p></body></html>",
   );

--- a/packages/api/src/api/routes/teams.ts
+++ b/packages/api/src/api/routes/teams.ts
@@ -19,6 +19,7 @@ import { ErrorSchema, AuthErrorSchema } from "./shared-schemas";
 import { validationHook } from "./validation-hook";
 import { adminAuthPreamble } from "./admin-auth";
 import { getConfig } from "@atlas/api/lib/config";
+import { getWebOrigin } from "@atlas/api/lib/web-origin";
 
 const log = createLogger("teams");
 
@@ -83,8 +84,11 @@ const callbackRoute = createRoute({
   },
   responses: {
     200: {
-      description: "Installation successful (HTML response)",
+      description: "Installation successful (HTML response, when no web origin is configured)",
       content: { "text/html": { schema: z.string() } },
+    },
+    302: {
+      description: "Installation successful (redirect to /admin/integrations on the web app)",
     },
     400: {
       description: "Invalid or expired state, or consent not granted",
@@ -244,6 +248,10 @@ teams.openapi(callbackRoute, async (c) => {
     );
   }
 
+  const webOrigin = getWebOrigin();
+  if (webOrigin) {
+    return c.redirect(`${webOrigin}/admin/integrations?installed=teams`);
+  }
   return c.html(
     "<html><body><h1>Atlas installed!</h1><p>You can now use Atlas in your Teams workspace.</p></body></html>",
   );

--- a/packages/api/src/lib/slack/__tests__/format.test.ts
+++ b/packages/api/src/lib/slack/__tests__/format.test.ts
@@ -120,6 +120,71 @@ describe("formatQueryResponse", () => {
     expect(blockText(blocks[0]).length).toBeLessThanOrEqual(3000);
     expect(blockText(blocks[0])).toEndWith("...");
   });
+
+  it("dedupes identical SQL across cross-env regions", () => {
+    const sql = "SELECT COUNT(*) FROM organization";
+    const blocks = formatQueryResponse(
+      makeResult({ sql: [sql, sql, sql] }),
+    );
+    const sqlBlocks = blocks.filter((b) => blockText(b).startsWith("*SQL*"));
+    expect(sqlBlocks.length).toBe(1);
+    // The fenced SQL body should appear exactly once.
+    const occurrences = blockText(sqlBlocks[0]).match(/SELECT COUNT/g) ?? [];
+    expect(occurrences.length).toBe(1);
+    expect(blockText(sqlBlocks[0])).toContain("ran across 3 regions");
+  });
+
+  it("dedupes identical datasets across regions and annotates the duplicate count", () => {
+    const dataset = {
+      columns: ["total"],
+      rows: [{ total: 1 }],
+    };
+    const blocks = formatQueryResponse(
+      makeResult({ data: [dataset, dataset, dataset] }),
+    );
+    const dataBlocks = blocks.filter((b) => blockText(b).includes("*total:*"));
+    expect(dataBlocks.length).toBe(1);
+    expect(blockText(dataBlocks[0])).toContain("identical across 3 regions");
+  });
+
+  it("renders single-row results as inline key:value text instead of a code block", () => {
+    const blocks = formatQueryResponse(
+      makeResult({
+        data: [{ columns: ["count"], rows: [{ count: 1234 }] }],
+      }),
+    );
+    const dataBlock = blocks.find((b) => blockText(b).includes("*count:*"));
+    expect(dataBlock).toBeDefined();
+    expect(blockText(dataBlock!)).not.toContain("```");
+    expect(blockText(dataBlock!)).toContain("1234");
+  });
+
+  it("skips the dedicated SQL block when the answer already contains a sql fence", () => {
+    const blocks = formatQueryResponse(
+      makeResult({
+        answer: "Here's the query:\n```sql\nSELECT 1\n```",
+      }),
+    );
+    const sqlBlocks = blocks.filter((b) => blockText(b).startsWith("*SQL*"));
+    expect(sqlBlocks.length).toBe(0);
+  });
+
+  it("extracts <suggestions> from the answer and renders them as a context footer", () => {
+    const blocks = formatQueryResponse(
+      makeResult({
+        answer:
+          "There are 1,234 users.\n\n<suggestions>\n- How many were new this month?\n- Top users by activity?\n</suggestions>",
+      }),
+    );
+    expect(blockText(blocks[0])).not.toContain("<suggestions>");
+    expect(blockText(blocks[0])).toContain("1,234 users");
+    const followups = blocks.find((b) =>
+      contextTexts(b).some((t) => t.includes("Follow-ups")),
+    );
+    expect(followups).toBeDefined();
+    expect(contextTexts(followups!)[0]).toContain("How many were new this month?");
+    expect(contextTexts(followups!)[0]).toContain("Top users by activity?");
+  });
 });
 
 describe("formatErrorResponse", () => {

--- a/packages/api/src/lib/slack/format.ts
+++ b/packages/api/src/lib/slack/format.ts
@@ -30,44 +30,71 @@ export type SlackBlock =
 
 /**
  * Format a query result as Slack Block Kit blocks.
+ *
+ * Compared to the web chat surface, Slack needs aggressive deduping and
+ * scalar collapsing — a cross-env query produces identical SQL + result
+ * rows across N regions, and dumping them verbatim turns into a wall of
+ * indistinguishable blocks. We also strip the `<suggestions>` XML tag
+ * the agent emits for the web chat (rendered as buttons there) and
+ * surface its items as a context-line footer instead.
  */
 export function formatQueryResponse(result: SlackQueryResult): SlackBlock[] {
   const blocks: SlackBlock[] = [];
 
-  // Answer section
-  const answer = truncate(result.answer || "No answer generated.", MAX_TEXT_LENGTH);
+  const { answer, suggestions } = extractSuggestions(result.answer || "No answer generated.");
   blocks.push({
     type: "section",
-    text: { type: "mrkdwn", text: answer },
+    text: { type: "mrkdwn", text: truncate(answer, MAX_TEXT_LENGTH) },
   });
 
-  // SQL section
-  if (result.sql.length > 0) {
-    const sqlText = result.sql.join("\n\n");
-    const formatted = truncate(`*SQL*\n\`\`\`${sqlText}\`\`\``, MAX_TEXT_LENGTH);
+  // SQL: dedupe identical strings (cross-env queries hit N regions with the
+  // same SQL). If the answer text already contains a fenced sql block, skip
+  // the dedicated SQL section entirely so we don't double up.
+  const uniqueSql = dedupeStrings(result.sql);
+  const answerHasSql = /```\s*sql/i.test(answer);
+  if (uniqueSql.length > 0 && !answerHasSql) {
+    const ranAcross = result.sql.length > uniqueSql.length
+      ? `  _(ran across ${result.sql.length} regions)_`
+      : "";
+    const header = uniqueSql.length === 1 ? "*SQL*" : `*SQL* _(${uniqueSql.length} queries)_`;
+    const sqlText = uniqueSql.join("\n\n");
+    const formatted = truncate(`${header}${ranAcross}\n\`\`\`${sqlText}\`\`\``, MAX_TEXT_LENGTH);
     blocks.push({
       type: "section",
       text: { type: "mrkdwn", text: formatted },
     });
   }
 
-  // Data section — column-aligned plain text
-  for (const dataset of result.data) {
-    if (!dataset.columns.length || !dataset.rows.length) continue;
+  // Data: dedupe identical datasets, scalarize single-row results.
+  const uniqueDatasets = dedupeDatasets(result.data);
+  for (const { columns, rows, duplicateCount } of uniqueDatasets) {
+    if (!columns.length || !rows.length) continue;
 
-    const table = formatDataTable(dataset.columns, dataset.rows);
-    if (table) {
+    const acrossNote = duplicateCount > 1 ? `  _(identical across ${duplicateCount} regions)_` : "";
+    const body = rows.length === 1
+      ? formatScalarRow(columns, rows[0]!) + acrossNote
+      : (formatDataTable(columns, rows) ?? "") + acrossNote;
+    if (body) {
       blocks.push({
         type: "section",
-        text: { type: "mrkdwn", text: table },
+        text: { type: "mrkdwn", text: body },
       });
     }
-
-    // Stay under the block limit
-    if (blocks.length >= MAX_BLOCKS - 1) break;
+    if (blocks.length >= MAX_BLOCKS - 2) break;
   }
 
-  // Context block with metadata
+  if (suggestions.length) {
+    blocks.push({
+      type: "context",
+      elements: [
+        {
+          type: "mrkdwn",
+          text: `*Follow-ups:* ${suggestions.map((s) => `\`${s}\``).join("  ·  ")}`,
+        },
+      ],
+    });
+  }
+
   blocks.push({
     type: "context",
     elements: [
@@ -79,6 +106,67 @@ export function formatQueryResponse(result: SlackQueryResult): SlackBlock[] {
   });
 
   return blocks.slice(0, MAX_BLOCKS);
+}
+
+/**
+ * Extract the agent's `<suggestions>…</suggestions>` block (used by the web
+ * chat to render follow-up question buttons). Returns the cleaned answer
+ * text and the list of suggestions for separate rendering.
+ */
+function extractSuggestions(text: string): { answer: string; suggestions: string[] } {
+  const match = text.match(/<suggestions>([\s\S]*?)<\/suggestions>/i);
+  if (!match) return { answer: text, suggestions: [] };
+  const inner = match[1] ?? "";
+  const suggestions = inner
+    .split(/\r?\n/)
+    .map((line) => line.replace(/^[-*•\s]+/, "").trim())
+    .filter(Boolean);
+  const answer = text.replace(match[0], "").trim();
+  return { answer, suggestions };
+}
+
+function dedupeStrings(values: string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const v of values) {
+    if (seen.has(v)) continue;
+    seen.add(v);
+    out.push(v);
+  }
+  return out;
+}
+
+interface DedupedDataset {
+  columns: string[];
+  rows: Record<string, unknown>[];
+  duplicateCount: number;
+}
+
+function dedupeDatasets(
+  datasets: { columns: string[]; rows: Record<string, unknown>[] }[],
+): DedupedDataset[] {
+  const buckets = new Map<string, DedupedDataset>();
+  for (const ds of datasets) {
+    const key = JSON.stringify({ columns: ds.columns, rows: ds.rows });
+    const existing = buckets.get(key);
+    if (existing) {
+      existing.duplicateCount += 1;
+    } else {
+      buckets.set(key, { columns: ds.columns, rows: ds.rows, duplicateCount: 1 });
+    }
+  }
+  return Array.from(buckets.values());
+}
+
+/**
+ * Format a single-row result as inline `*col*: value` pairs instead of a
+ * code-block table. Reads better in Slack for scalar answers (counts,
+ * single-record lookups).
+ */
+function formatScalarRow(columns: string[], row: Record<string, unknown>): string {
+  return columns
+    .map((col) => `*${col}:* ${String(row[col] ?? "")}`)
+    .join("    ");
 }
 
 /**

--- a/packages/api/src/lib/slack/format.ts
+++ b/packages/api/src/lib/slack/format.ts
@@ -67,13 +67,17 @@ export function formatQueryResponse(result: SlackQueryResult): SlackBlock[] {
 
   // Data: dedupe identical datasets, scalarize single-row results.
   const uniqueDatasets = dedupeDatasets(result.data);
-  for (const { columns, rows, duplicateCount } of uniqueDatasets) {
+  for (const { columns, rows, occurrences } of uniqueDatasets) {
     if (!columns.length || !rows.length) continue;
 
-    const acrossNote = duplicateCount > 1 ? `  _(identical across ${duplicateCount} regions)_` : "";
-    const body = rows.length === 1
-      ? formatScalarRow(columns, rows[0]!) + acrossNote
-      : (formatDataTable(columns, rows) ?? "") + acrossNote;
+    const acrossNote = occurrences > 1 ? `  _(identical across ${occurrences} regions)_` : "";
+    const rendered = rows.length === 1
+      ? formatScalarRow(columns, rows[0]!)
+      : (formatDataTable(columns, rows) ?? "");
+    // formatDataTable self-truncates; formatScalarRow doesn't — wide single-row
+    // results (many columns × long text) can otherwise exceed Slack's 3000-char
+    // block limit and the API rejects the post with invalid_blocks.
+    const body = truncate(rendered + acrossNote, MAX_TEXT_LENGTH);
     if (body) {
       blocks.push({
         type: "section",
@@ -139,9 +143,13 @@ function dedupeStrings(values: string[]): string[] {
 interface DedupedDataset {
   columns: string[];
   rows: Record<string, unknown>[];
-  duplicateCount: number;
+  /** Number of source datasets that collapsed into this bucket. Always ≥1. */
+  occurrences: number;
 }
 
+// Dedupe key is order-sensitive on both columns and rows — two datasets with
+// the same content in different orders won't collapse. Cross-env queries
+// produce ordered, identical column/row vectors, so this matches the intent.
 function dedupeDatasets(
   datasets: { columns: string[]; rows: Record<string, unknown>[] }[],
 ): DedupedDataset[] {
@@ -150,9 +158,9 @@ function dedupeDatasets(
     const key = JSON.stringify({ columns: ds.columns, rows: ds.rows });
     const existing = buckets.get(key);
     if (existing) {
-      existing.duplicateCount += 1;
+      existing.occurrences += 1;
     } else {
-      buckets.set(key, { columns: ds.columns, rows: ds.rows, duplicateCount: 1 });
+      buckets.set(key, { columns: ds.columns, rows: ds.rows, occurrences: 1 });
     }
   }
   return Array.from(buckets.values());

--- a/packages/api/src/lib/web-origin.ts
+++ b/packages/api/src/lib/web-origin.ts
@@ -1,0 +1,21 @@
+/**
+ * Resolve the web app's origin for cross-host redirects from API routes.
+ *
+ * The API and web app live on separate hostnames in SaaS (api.useatlas.dev →
+ * app.useatlas.dev). OAuth callback success pages need an absolute redirect
+ * so the user lands in the admin UI rather than 404ing on the API host.
+ *
+ * Source of truth: `ATLAS_CORS_ORIGIN` (explicit single-origin var). Falls
+ * back to the first entry in `BETTER_AUTH_TRUSTED_ORIGINS`. Returns `null`
+ * when neither is set — callers should treat that as "render inline HTML
+ * here" rather than emit a malformed redirect.
+ */
+export function getWebOrigin(): string | null {
+  const cors = process.env.ATLAS_CORS_ORIGIN?.trim();
+  if (cors) return cors.replace(/\/+$/, "");
+
+  const trusted = process.env.BETTER_AUTH_TRUSTED_ORIGINS?.split(",")[0]?.trim();
+  if (trusted) return trusted.replace(/\/+$/, "");
+
+  return null;
+}


### PR DESCRIPTION
## Summary

Surface-level fixes from the 2026-05-18 Slack dogfood pass. Both `@atlas` mentions and the `/atlas` slash command output had visible issues; OAuth callbacks dropped users on a bare API-host success page. The deeper gap (proactive listener never instantiated in prod because `@useatlas/chat` isn't loaded) is filed as **#2607** and deferred — it's a real migration, not a one-PR fix.

- **OAuth callback redirects.** Slack / Teams / Discord callbacks now `c.redirect()` to `{webOrigin}/admin/integrations?installed=<provider>` instead of leaving the user staring at `<h1>Atlas installed!</h1>` on api.useatlas.dev. New `lib/web-origin.ts` resolves the web origin from `ATLAS_CORS_ORIGIN` with `BETTER_AUTH_TRUSTED_ORIGINS` as fallback; falls through to the inline HTML when neither is set so single-host self-hosted deploys still work.
- **`app_mention` handler.** `@atlas <q>` was silently 200ing because the only branch in `slack.ts`'s events handler was `message + threadTs` (thread followups). Mentions now strip the leading `<@BOTID>` prefix, kick off the same async pipeline as the slash command, and reply in a thread off `event.ts` (or off the existing `thread_ts` if the mention was inside a thread already).
- **Slash command ack ordering.** Switched from `response_type: "in_channel"` to `"ephemeral"` so the "Processing your question…" ack doesn't render in the channel **after** the bot's actual answer. The bot's "Thinking…" message stays as the user-visible in-channel signal and gets updated in place.
- **`formatQueryResponse` cleanups.** Cross-env queries (1.4.5) immediately exposed this: dedupe identical SQL strings (3 regions × same query → 1 block with "ran across 3 regions" hint), dedupe identical datasets, render single-row results as inline `*col:* value` pairs instead of code-block tables, strip the agent's `<suggestions>` XML and surface its items as a context footer, skip the dedicated SQL section when the answer already contains a sql fence.

## Test plan

- [x] `bun run test` — full suite green
- [x] `bun run scripts/test-isolated.ts --affected` — 18/18 files pass including new format + slack route assertions
- [x] `bun run lint` — no new warnings introduced (10 pre-existing on main)
- [x] `bun run type` — clean
- [x] All 7 drift checks (syncpack / template / security-headers / railway-watch / schema / oauth-helper) — pass
- [ ] After deploy: `@atlas what's our customer count` in `#all-atlas` produces a threaded reply (no app_mention silent drop)
- [ ] After deploy: `/atlas <q>` no longer leaves a trailing "Processing your question…" message after the answer
- [ ] After deploy: cross-env response collapses to one SQL block + one scalar line instead of 3 of each
- [ ] After deploy: Slack OAuth install (via /admin/integrations) lands back on `/admin/integrations?installed=slack` with a fresh integration row

## Out of scope

- Wiring `@useatlas/chat` into `deploy/api/atlas.config.ts` to enable the proactive listener — **#2607** with the (a)/(b) decision call.
- Migrating the rest of the Slack handling onto the Chat SDK bridge (would retire bespoke `slack.ts` paths) — same issue.