### PR TITLE
feat(api): #2615 — proactive classifier adapter (LLM question detection)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -145,6 +145,7 @@
         "@opentelemetry/resources": "^2.6.1",
         "@opentelemetry/sdk-node": "^0.217.0",
         "@opentelemetry/semantic-conventions": "^1.40.0",
+        "@useatlas/chat": "workspace:*",
         "@useatlas/schemas": "workspace:*",
         "@useatlas/types": "workspace:*",
         "ai": "^6.0.141",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -52,6 +52,7 @@
     "@opentelemetry/resources": "^2.6.1",
     "@opentelemetry/sdk-node": "^0.217.0",
     "@opentelemetry/semantic-conventions": "^1.40.0",
+    "@useatlas/chat": "workspace:*",
     "@useatlas/schemas": "workspace:*",
     "@useatlas/types": "workspace:*",
     "ai": "^6.0.141",

--- a/packages/api/src/lib/proactive/__tests__/classifier-adapter.test.ts
+++ b/packages/api/src/lib/proactive/__tests__/classifier-adapter.test.ts
@@ -1,0 +1,259 @@
+/**
+ * Tests for the proactive classifier adapter (slice 2b of #2607).
+ *
+ * The adapter is a thin wrapper that:
+ *   - Yields `AtlasAiModel` from a `ManagedRuntime` to get the
+ *     configured LLM.
+ *   - Calls `generateText` with a tight question-detection prompt.
+ *   - Parses + Zod-validates the JSON response.
+ *   - Fails closed on any error.
+ *
+ * We inject a fake `generateText` via the adapter's `options.generateText`
+ * hook so we control the model's response without needing to instantiate
+ * a real provider. The `AtlasAiModel` Tag is satisfied by
+ * `createAiModelTestLayer()` from `@atlas/api/lib/effect/ai`. Effect's
+ * `ManagedRuntime.make(layer)` materialises the layer once per test.
+ */
+
+import { describe, it, expect, beforeEach, mock, type Mock } from "bun:test";
+import { ManagedRuntime } from "effect";
+import type { generateText } from "ai";
+
+import {
+  AtlasAiModel,
+  createAiModelTestLayer,
+} from "@atlas/api/lib/effect/ai";
+
+// --- Logger mock — silences the warn-on-failure path so test output stays clean,
+//     while letting us assert the warn call site fired.
+const warnSpy: Mock<(...args: unknown[]) => void> = mock(() => {});
+mock.module("@atlas/api/lib/logger", () => ({
+  createLogger: () => ({
+    info: () => {},
+    warn: warnSpy,
+    error: () => {},
+    debug: () => {},
+  }),
+}));
+
+const { createProactiveClassifier, __testing } = await import(
+  "../classifier-adapter"
+);
+
+// --- Test helpers ---------------------------------------------------------
+
+type GenerateTextResult = { text: string };
+type GenerateTextFn = typeof generateText;
+
+/**
+ * Build a fake `generateText` function that returns a fixed text body
+ * (or throws). The real `generateText` returns dozens of fields the
+ * adapter never reads — we cast through `unknown` so the parameter
+ * type-checks without re-declaring the SDK's response surface.
+ */
+function fakeGenerate(
+  outcome: { text: string } | { throws: Error },
+): GenerateTextFn {
+  const fn = async (): Promise<GenerateTextResult> => {
+    if ("throws" in outcome) throw outcome.throws;
+    return { text: outcome.text };
+  };
+  return fn as unknown as GenerateTextFn;
+}
+
+/**
+ * Build a fake `generateText` that records the call options (so tests
+ * can assert prompt + temperature invariants) and returns a stub body.
+ */
+function recordingGenerate(
+  body: string,
+  sink: Array<Record<string, unknown>>,
+): GenerateTextFn {
+  const fn = async (opts: Record<string, unknown>): Promise<GenerateTextResult> => {
+    sink.push(opts);
+    return { text: body };
+  };
+  return fn as unknown as GenerateTextFn;
+}
+
+function makeRuntime(): ManagedRuntime.ManagedRuntime<AtlasAiModel, never> {
+  return ManagedRuntime.make(createAiModelTestLayer());
+}
+
+beforeEach(() => {
+  warnSpy.mockClear();
+});
+
+// --- Happy paths ----------------------------------------------------------
+
+describe("createProactiveClassifier — positive cases", () => {
+  it("returns isQuestion=true for a confident-question response", async () => {
+    const runtime = makeRuntime();
+    const classify = createProactiveClassifier(runtime, {
+      generateText: fakeGenerate({
+        text: JSON.stringify({ isQuestion: true, confidence: 0.9 }),
+      }),
+    });
+
+    const result = await classify("what was MRR last month?");
+    expect(result).toEqual({ isQuestion: true, confidence: 0.9 });
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns isQuestion=false for a confident-non-question response", async () => {
+    const runtime = makeRuntime();
+    const classify = createProactiveClassifier(runtime, {
+      generateText: fakeGenerate({
+        text: JSON.stringify({ isQuestion: false, confidence: 0.95 }),
+      }),
+    });
+
+    const result = await classify("good morning team!");
+    expect(result).toEqual({ isQuestion: false, confidence: 0.95 });
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("passes ambiguous low-confidence results through unfiltered (gating lives in the policy layer)", async () => {
+    // The adapter must NOT enforce a sensitivity threshold here — that
+    // is the listener's `policy.ts` job, gated by workspace
+    // `SensitivityPreset`. Filtering at the adapter layer would deny the
+    // listener the ability to distinguish "model unsure" from "model
+    // certainly no" (both would collapse to isQuestion=false).
+    const runtime = makeRuntime();
+    const classify = createProactiveClassifier(runtime, {
+      generateText: fakeGenerate({
+        text: JSON.stringify({ isQuestion: true, confidence: 0.3 }),
+      }),
+    });
+
+    const result = await classify("anyone seen the dashboard?");
+    expect(result).toEqual({ isQuestion: true, confidence: 0.3 });
+  });
+
+  it("strips a ```json fence the model may add despite the strict-JSON instruction", async () => {
+    const runtime = makeRuntime();
+    const classify = createProactiveClassifier(runtime, {
+      generateText: fakeGenerate({
+        text: "```json\n" + JSON.stringify({ isQuestion: true, confidence: 0.8 }) + "\n```",
+      }),
+    });
+
+    const result = await classify("what was signups yesterday?");
+    expect(result).toEqual({ isQuestion: true, confidence: 0.8 });
+  });
+});
+
+// --- Fail-closed paths ----------------------------------------------------
+
+describe("createProactiveClassifier — fail-closed cases", () => {
+  it("returns FAIL_CLOSED + log.warn when the model invocation throws", async () => {
+    const runtime = makeRuntime();
+    const classify = createProactiveClassifier(runtime, {
+      generateText: fakeGenerate({ throws: new Error("provider 503") }),
+    });
+
+    const result = await classify("how many users signed up?");
+    expect(result).toEqual(__testing.FAIL_CLOSED);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+
+    // textPreview is the canonical forensic field — assert the
+    // call site captured it (and clipped at 80 chars per the spec).
+    const [payload] = warnSpy.mock.calls[0] as [{ textPreview: string; err: string }];
+    expect(payload.textPreview).toBe("how many users signed up?");
+    expect(payload.err).toContain("provider 503");
+  });
+
+  it("returns FAIL_CLOSED + log.warn when the model returns malformed JSON", async () => {
+    const runtime = makeRuntime();
+    const classify = createProactiveClassifier(runtime, {
+      generateText: fakeGenerate({ text: "not json {" }),
+    });
+
+    const result = await classify("hey what's up?");
+    expect(result).toEqual(__testing.FAIL_CLOSED);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns FAIL_CLOSED + log.warn when the JSON violates the schema (wrong type)", async () => {
+    const runtime = makeRuntime();
+    const classify = createProactiveClassifier(runtime, {
+      generateText: fakeGenerate({
+        text: JSON.stringify({ isQuestion: "yes", confidence: 0.7 }),
+      }),
+    });
+
+    const result = await classify("is the dashboard broken?");
+    expect(result).toEqual(__testing.FAIL_CLOSED);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const [payload] = warnSpy.mock.calls[0] as [{ err: string }];
+    // The error message should reference the schema validation failure
+    // so an operator scanning logs sees the rejection class.
+    expect(payload.err).toContain("schema validation");
+  });
+
+  it("returns FAIL_CLOSED + log.warn when the JSON violates the schema (confidence out of range)", async () => {
+    // Confidence must be in [0, 1]. The Zod schema rejects out-of-range
+    // values so a misbehaving model can't propagate a 2.0 into the
+    // listener's `policy.decideInterjection` (which would then accept
+    // a noise message because the threshold trivially passes).
+    const runtime = makeRuntime();
+    const classify = createProactiveClassifier(runtime, {
+      generateText: fakeGenerate({
+        text: JSON.stringify({ isQuestion: true, confidence: 1.5 }),
+      }),
+    });
+
+    const result = await classify("what is churn?");
+    expect(result).toEqual(__testing.FAIL_CLOSED);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("clips the textPreview to 80 chars on long messages so logs stay bounded", async () => {
+    const runtime = makeRuntime();
+    const classify = createProactiveClassifier(runtime, {
+      generateText: fakeGenerate({ throws: new Error("boom") }),
+    });
+
+    const longText = "a".repeat(500);
+    await classify(longText);
+    const [payload] = warnSpy.mock.calls[0] as [{ textPreview: string }];
+    expect(payload.textPreview.length).toBeLessThanOrEqual(80);
+  });
+});
+
+// --- Prompt + config invariants ------------------------------------------
+
+describe("createProactiveClassifier — prompt + config invariants", () => {
+  it("uses temperature=0 and a bounded maxOutputTokens for determinism + cost control", async () => {
+    const runtime = makeRuntime();
+    const callsSeen: Array<Record<string, unknown>> = [];
+    const classify = createProactiveClassifier(runtime, {
+      generateText: recordingGenerate(
+        JSON.stringify({ isQuestion: false, confidence: 0.5 }),
+        callsSeen,
+      ),
+    });
+
+    await classify("what's MRR?");
+    expect(callsSeen).toHaveLength(1);
+    expect(callsSeen[0].temperature).toBe(0);
+    expect(callsSeen[0].maxOutputTokens).toBe(__testing.MAX_OUTPUT_TOKENS);
+    expect(callsSeen[0].system).toBe(__testing.CLASSIFIER_SYSTEM_PROMPT);
+  });
+
+  it("clamps overlong input before sending it to the model", async () => {
+    const runtime = makeRuntime();
+    const callsSeen: Array<Record<string, unknown>> = [];
+    const classify = createProactiveClassifier(runtime, {
+      generateText: recordingGenerate(
+        JSON.stringify({ isQuestion: false, confidence: 0.5 }),
+        callsSeen,
+      ),
+    });
+
+    const huge = "x".repeat(__testing.MAX_INPUT_CHARS + 5000);
+    await classify(huge);
+    const messages = callsSeen[0].messages as Array<{ content: string }> | undefined;
+    expect(messages?.[0]?.content.length).toBe(__testing.MAX_INPUT_CHARS);
+  });
+});

--- a/packages/api/src/lib/proactive/classifier-adapter.ts
+++ b/packages/api/src/lib/proactive/classifier-adapter.ts
@@ -1,0 +1,208 @@
+/**
+ * Proactive classifier adapter — slice 2b of #2607.
+ *
+ * Bridges the @useatlas/chat plugin's `LLMClassifierFn` callback shape
+ * to Atlas's configured primary LLM (`AtlasAiModel`). The plugin's
+ * proactive listener calls `config.classify(text)` for every Slack
+ * message that passes the regex prefilter — this adapter is the host
+ * implementation that wraps the configured model with a tight question-
+ * detection prompt and returns a structured `{ isQuestion, confidence }`.
+ *
+ * Design decisions (locked in the slice-2 scope-confirm):
+ *
+ *   - **Reuse the primary model.** No second model knob, no
+ *     `ATLAS_PROACTIVE_CLASSIFIER_MODEL` env var. Latency/cost is
+ *     bounded by the listener's default `regex-prefilter` mode, which
+ *     only invokes the LLM for ambiguous candidates.
+ *   - **Deterministic + JSON-shaped output.** `temperature: 0`, system
+ *     prompt asks for strict JSON, Zod validates the parsed payload so
+ *     a model that hallucinates an extra field or wrong type falls into
+ *     the fail-closed branch rather than poisoning the meter.
+ *   - **Fail closed.** Any error — model invocation throws, response
+ *     isn't JSON, JSON doesn't match the schema — resolves as
+ *     `{ isQuestion: false, confidence: 0 }` and logs at warn. The
+ *     listener treats this as "not a question" and never reacts, so a
+ *     provider outage degrades silently instead of producing rogue
+ *     interjections. The plugin's `classifyMessage` further surfaces
+ *     `classifierErrored: true` on the meter row when this callback
+ *     resolves to the fail-closed shape after invocation.
+ */
+
+import { generateText, type LanguageModel } from "ai";
+import { Effect, ManagedRuntime } from "effect";
+import { z } from "zod";
+
+import { AtlasAiModel } from "@atlas/api/lib/effect/ai";
+import { createLogger } from "@atlas/api/lib/logger";
+import type {
+  ClassificationResult,
+  LLMClassifierFn,
+} from "@useatlas/chat";
+
+/**
+ * Type-only alias for `generateText`. The adapter calls into the real
+ * `ai` SDK by default but exposes the call site as a parameter on
+ * `invokeClassifier` so tests can inject a fake without resorting to
+ * `mock.module("ai", ...)` (which would require re-exporting the
+ * SDK's ~120-name surface area to satisfy bun:test's
+ * "mock all exports" rule).
+ */
+type GenerateTextFn = typeof generateText;
+
+const log = createLogger("proactive-classifier-adapter");
+
+// ── Prompt ───────────────────────────────────────────────────────────
+
+/**
+ * System prompt — kept tight so a small/cheap primary model can answer
+ * reliably and so the cost-per-classify stays low. Asks for strict JSON
+ * with two fields; downstream Zod validation rejects anything else.
+ */
+const CLASSIFIER_SYSTEM_PROMPT = [
+  "You classify Slack messages as data questions or not.",
+  "A data question is one that could plausibly be answered by querying a connected analytics warehouse (e.g. MRR, signups, conversion, churn, user counts, revenue).",
+  "Respond ONLY with strict JSON matching this shape: {\"isQuestion\": boolean, \"confidence\": number}.",
+  "confidence is a value in [0, 1] — 1.0 = certain it is a data question, 0.0 = certainly not.",
+  "Do not include markdown fences, prose, or any text outside the JSON object.",
+].join("\n");
+
+// ── Zod schema for the model's structured output ─────────────────────
+
+const ClassifierResponseSchema = z.object({
+  isQuestion: z.boolean(),
+  confidence: z.number().min(0).max(1),
+});
+
+// ── Fail-closed sentinel ─────────────────────────────────────────────
+
+const FAIL_CLOSED: ClassificationResult = {
+  isQuestion: false,
+  confidence: 0,
+};
+
+// ── Constants ────────────────────────────────────────────────────────
+
+/** Bound on `text` to keep prompt size predictable. The listener's
+ *  prefilter already rejects messages > 2000 chars, but defence in
+ *  depth: this adapter clamps regardless of caller. */
+const MAX_INPUT_CHARS = 2000;
+
+/** Bound on the model's response length — JSON shape is ~50 chars, so
+ *  100 leaves room for whitespace + numeric precision without inviting
+ *  a model to wander into prose. */
+const MAX_OUTPUT_TOKENS = 100;
+
+// ── Public API ───────────────────────────────────────────────────────
+
+/**
+ * Build the `LLMClassifierFn` callback wired to the workspace's primary
+ * configured Atlas model.
+ *
+ * The returned callback never throws — failures fold into the
+ * fail-closed `{ isQuestion: false, confidence: 0 }` sentinel and log
+ * at warn with the first 80 chars of the offending text for forensic
+ * correlation (full text is intentionally NOT logged — Slack content
+ * is sensitive).
+ *
+ * `runtime` must be a `ManagedRuntime` whose `R` channel provides
+ * `AtlasAiModel` (typically the module-level `getProactiveRuntime()`
+ * the chat-plugin wiring constructs at boot).
+ *
+ * @param runtime ManagedRuntime providing `AtlasAiModel` (and any
+ *                additional services the caller wants in scope).
+ * @returns The `LLMClassifierFn` to hand to `config.proactive.classify`.
+ */
+export function createProactiveClassifier<RIn>(
+  runtime: ManagedRuntime.ManagedRuntime<RIn | AtlasAiModel, never>,
+  options: { generateText?: GenerateTextFn } = {},
+): LLMClassifierFn {
+  const gen = options.generateText ?? generateText;
+  return async (text: string): Promise<ClassificationResult> => {
+    // Bound the input so we don't ship a 100KB Slack message to the LLM
+    // even if some upstream path bypasses the listener's prefilter.
+    const bounded = text.length > MAX_INPUT_CHARS ? text.slice(0, MAX_INPUT_CHARS) : text;
+
+    const program = Effect.gen(function* () {
+      const { model } = yield* AtlasAiModel;
+      return yield* Effect.tryPromise({
+        try: () => invokeClassifier(model, bounded, gen),
+        catch: (err) =>
+          err instanceof Error ? err : new Error(String(err)),
+      });
+    });
+
+    try {
+      return await runtime.runPromise(program);
+    } catch (err) {
+      log.warn(
+        {
+          textPreview: text.slice(0, 80),
+          err: err instanceof Error ? err.message : String(err),
+        },
+        "Proactive classifier failed — falling back to not-a-question (fail-closed)",
+      );
+      return FAIL_CLOSED;
+    }
+  };
+}
+
+// ── Internal: single classification round-trip ───────────────────────
+
+/**
+ * Run the model once with the classifier system prompt and return the
+ * parsed-and-validated `ClassificationResult`. Throws on any failure
+ * (model error, JSON parse error, schema validation error) so the
+ * caller's outer try/catch can map all failure modes to a single
+ * fail-closed log + return path.
+ */
+async function invokeClassifier(
+  model: LanguageModel,
+  text: string,
+  gen: GenerateTextFn,
+): Promise<ClassificationResult> {
+  const result = await gen({
+    model,
+    system: CLASSIFIER_SYSTEM_PROMPT,
+    messages: [{ role: "user", content: text }],
+    temperature: 0,
+    maxOutputTokens: MAX_OUTPUT_TOKENS,
+  });
+
+  const raw = result.text.trim();
+  // Defensive: a model may still wrap output in a ```json fence
+  // despite the system instruction. Strip before parsing.
+  const stripped = raw
+    .replace(/^```(?:json)?\s*\n?/i, "")
+    .replace(/\n?```\s*$/i, "");
+
+  const json: unknown = JSON.parse(stripped);
+  const parsed = ClassifierResponseSchema.safeParse(json);
+  if (!parsed.success) {
+    throw new Error(
+      `Classifier response failed schema validation: ${parsed.error.issues
+        .map((i) => `${i.path.join(".")}: ${i.message}`)
+        .join("; ")}`,
+    );
+  }
+
+  return {
+    isQuestion: parsed.data.isQuestion,
+    confidence: parsed.data.confidence,
+  };
+}
+
+// ── Test surface (for tests in `__tests__/`) ─────────────────────────
+
+/**
+ * Internal exports used by unit tests to assert prompt shape without
+ * re-declaring magic strings. Not part of the public API.
+ *
+ * @internal
+ */
+export const __testing = {
+  CLASSIFIER_SYSTEM_PROMPT,
+  MAX_INPUT_CHARS,
+  MAX_OUTPUT_TOKENS,
+  ClassifierResponseSchema,
+  FAIL_CLOSED,
+};


### PR DESCRIPTION
## Summary

Slice 2b of #2607 — foundational host helper that bridges the chat plugin's `LLMClassifierFn` callback shape to Atlas's configured primary LLM (`AtlasAiModel`).

- New module `packages/api/src/lib/proactive/classifier-adapter.ts` exporting `createProactiveClassifier(runtime, options?): LLMClassifierFn`.
- Reuses the workspace's primary model — no second model knob, no `ATLAS_PROACTIVE_CLASSIFIER_MODEL` env var (per the slice-2 scope-confirm). Cost/latency is bounded by the listener's default `regex-prefilter` mode.
- Tight, deterministic prompt: 5-line system message, `temperature: 0`, 100-token cap, strict JSON output, Zod-validated.
- Fail-closed on every error path (model invocation, JSON parse, schema mismatch) → `{ isQuestion: false, confidence: 0 }` + `log.warn` with an 80-char `textPreview` (full text is intentionally not logged — Slack content is sensitive).

## Prompt

```
You classify Slack messages as data questions or not.
A data question is one that could plausibly be answered by querying a connected analytics warehouse (e.g. MRR, signups, conversion, churn, user counts, revenue).
Respond ONLY with strict JSON matching this shape: {"isQuestion": boolean, "confidence": number}.
confidence is a value in [0, 1] — 1.0 = certain it is a data question, 0.0 = certainly not.
Do not include markdown fences, prose, or any text outside the JSON object.
```

## Test plan

- [x] `bun test packages/api/src/lib/proactive/__tests__/classifier-adapter.test.ts` — 11 pass / 0 fail
- [x] `cd packages/api && bun run scripts/test-isolated.ts --affected` — 1 file passed
- [x] `bun run lint` — 0 errors
- [x] `bun run type` — passes
- [x] `bash scripts/check-ee-imports.sh` — passes (no `@atlas/ee` imports)
- [x] `bash scripts/check-schema-drift.sh` — passes (no migrations)
- [x] `bun x syncpack lint` — no issues
- [ ] Wired into `deploy/api/atlas.config.ts:plugins[0].proactive.classify` — out of scope; handled in parent slice 2 of #2607

## Acceptance criteria (from #2615)

- [x] `createProactiveClassifier(runtime)` exported from `packages/api/src/lib/proactive/classifier-adapter.ts`
- [x] Returned callback satisfies `LLMClassifierFn` from `@useatlas/chat`
- [x] Prompt is tight (~10 lines), deterministic (`temperature: 0`), constrained to JSON for reliable parsing
- [x] Successful classification returns `{ isQuestion, confidence }` with `confidence ∈ [0, 1]`
- [x] LLM errors caught → returns `{ isQuestion: false, confidence: 0 }` + `log.warn` (fail-closed)
- [x] Parser errors (malformed JSON) caught → same fail-closed behavior
- [x] Unit tests cover: question (positive), non-question (negative), ambiguous (low confidence), LLM error, malformed JSON, schema-violating JSON
- [x] No `@atlas/ee` imports; no `@atlas/api/api/routes/` imports
- [x] Uses primary configured model only (no new env var, no second model knob)

## Notes

- Added `@useatlas/chat: workspace:*` as a runtime dep of `packages/api` so the adapter can import `LLMClassifierFn` from the canonical export. The plugin code itself is not loaded unless `deploy/api/atlas.config.ts` registers it (slice 1 of #2607).
- The adapter accepts an `options.generateText` hook for tests to inject a fake. Real callers omit it and get the SDK's `generateText` from `ai`. This is preferred over `mock.module("ai", ...)` which would need to re-export the SDK's ~120-name surface to satisfy bun:test's "mock all exports" rule.
- The `runtime` parameter is typed `ManagedRuntime<RIn | AtlasAiModel, never>` so callers can pass a runtime that bundles other services alongside the model — typically the module-level runtime the chat-plugin wiring will construct at boot.

Closes #2615
Refs #2607