### PR TITLE
feat(api): #2616 — proactive enabled-gate (Tag→callback bridge)

### DIFF
--- a/packages/api/src/lib/proactive/__tests__/enabled-gate.test.ts
+++ b/packages/api/src/lib/proactive/__tests__/enabled-gate.test.ts
@@ -1,0 +1,293 @@
+/**
+ * Unit tests for `createProactiveEnabledGate` (#2616, slice 2c of #2607).
+ *
+ * Covers:
+ *   - Enterprise enabled + workspace enabled → true
+ *   - Enterprise enabled + workspace disabled (enabled = false) → false
+ *   - Enterprise enabled + workspace row missing → false
+ *   - Enterprise DISABLED (Tag yields EnterpriseError) → false; no DB query
+ *   - Enterprise enabled + DB query throws → false + log.warn called
+ *   - Caching: enterprise check runs once across many calls; workspace
+ *     flag re-queried every call.
+ *
+ * Mock notes:
+ *   - `mock.module()` factories are sync — async + inner await hangs the
+ *     bun loader (CLAUDE.md `feedback_bun_test_async_mock_module`).
+ *   - The logger mock returns a fully-stubbed shape (no
+ *     `...realLogger`) — re-requiring `@atlas/api/lib/logger` from
+ *     inside its own mock factory body deadlocks the loader.
+ *   - Modules under test are loaded via `require()` AFTER mocks are
+ *     installed; `await import(...)` between mock + load is also a
+ *     known deadlock path.
+ */
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  mock,
+  type Mock,
+} from "bun:test";
+
+// ── Logger mock ─────────────────────────────────────────────────────
+//
+// Installed FIRST so the `lib/effect/services` chain (transitively
+// imports `createLogger`) sees the stub. The mock returns a fully-
+// stubbed pino-shaped object — `realLogger.createLogger(...)` recursion
+// inside the mock factory hangs the bun loader.
+
+const mockLogWarn: Mock<(...args: unknown[]) => void> = mock(() => {});
+
+mock.module("@atlas/api/lib/logger", () => ({
+  createLogger: () => ({
+    warn: mockLogWarn,
+    info: () => {},
+    debug: () => {},
+    error: () => {},
+    trace: () => {},
+    fatal: () => {},
+    silent: () => {},
+    child: () => ({
+      warn: mockLogWarn,
+      info: () => {},
+      debug: () => {},
+      error: () => {},
+      trace: () => {},
+      fatal: () => {},
+      silent: () => {},
+    }),
+  }),
+}));
+
+// ── DB internal mock ────────────────────────────────────────────────
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const realInternal = require("@atlas/api/lib/db/internal") as typeof import("@atlas/api/lib/db/internal");
+
+const mockInternalQuery: Mock<
+  (sql: string, params: unknown[]) => Promise<unknown[]>
+> = mock(async () => []);
+
+mock.module("@atlas/api/lib/db/internal", () => ({
+  ...realInternal,
+  internalQuery: (sql: string, params: unknown[]) =>
+    mockInternalQuery(sql, params),
+}));
+
+// ── Real modules (loaded AFTER mocks via sync require) ───────────────
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { Effect, Layer, ManagedRuntime } = require("effect") as typeof import("effect");
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { ProactiveGate } = require("@atlas/api/lib/effect/services") as typeof import("@atlas/api/lib/effect/services");
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { EnterpriseError } = require("@atlas/api/lib/effect/errors") as typeof import("@atlas/api/lib/effect/errors");
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { createProactiveEnabledGate } = require("../enabled-gate") as typeof import("../enabled-gate");
+
+// ── Test layer helpers ──────────────────────────────────────────────
+
+type RequireEnabledFn = () => ReturnType<
+  InstanceType<typeof ProactiveGate>["requireEnabled"]
+>;
+
+function buildGateLayer(opts: {
+  enabled: boolean;
+  spy?: Mock<RequireEnabledFn>;
+}) {
+  const fallback: RequireEnabledFn = () =>
+    opts.enabled
+      ? (Effect.void as ReturnType<RequireEnabledFn>)
+      : (Effect.fail(
+          new EnterpriseError(
+            "Enterprise features (proactive-chat) are not enabled.",
+          ),
+        ) as ReturnType<RequireEnabledFn>);
+  const requireEnabled = opts.spy ?? mock(fallback);
+  if (!opts.spy) {
+    requireEnabled.mockImplementation(fallback);
+  }
+  return Layer.succeed(ProactiveGate, {
+    requireEnabled: () => requireEnabled(),
+  });
+}
+
+function buildRuntime(layer: ReturnType<typeof buildGateLayer>) {
+  return ManagedRuntime.make(layer);
+}
+
+// ── Per-test reset ──────────────────────────────────────────────────
+
+beforeEach(() => {
+  mockInternalQuery.mockClear();
+  mockInternalQuery.mockImplementation(async () => []);
+  mockLogWarn.mockClear();
+});
+
+afterEach(() => {
+  mockInternalQuery.mockClear();
+  mockLogWarn.mockClear();
+});
+
+// ── Tests ───────────────────────────────────────────────────────────
+
+describe("createProactiveEnabledGate", () => {
+  it("returns true when enterprise is enabled AND workspace flag is true", async () => {
+    const runtime = buildRuntime(buildGateLayer({ enabled: true }));
+    mockInternalQuery.mockImplementation(async () => [{ enabled: true }]);
+
+    const gate = createProactiveEnabledGate(runtime, "ws-1");
+    expect(await gate()).toBe(true);
+
+    expect(mockInternalQuery).toHaveBeenCalledTimes(1);
+    const [sql, params] = mockInternalQuery.mock.calls[0]!;
+    expect(sql).toContain("workspace_proactive_config");
+    expect(sql).toContain("SELECT enabled");
+    expect(params).toEqual(["ws-1"]);
+  });
+
+  it("returns false when enterprise is enabled but workspace flag is false", async () => {
+    const runtime = buildRuntime(buildGateLayer({ enabled: true }));
+    mockInternalQuery.mockImplementation(async () => [{ enabled: false }]);
+
+    const gate = createProactiveEnabledGate(runtime, "ws-1");
+    expect(await gate()).toBe(false);
+    expect(mockInternalQuery).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns false when enterprise is enabled but the workspace row is missing", async () => {
+    const runtime = buildRuntime(buildGateLayer({ enabled: true }));
+    mockInternalQuery.mockImplementation(async () => []);
+
+    const gate = createProactiveEnabledGate(runtime, "ws-1");
+    expect(await gate()).toBe(false);
+    expect(mockInternalQuery).toHaveBeenCalledTimes(1);
+    // Row-missing is the expected "not opted in" path — no warning.
+    expect(mockLogWarn).not.toHaveBeenCalled();
+  });
+
+  it("returns false when enterprise is disabled (Tag fails with EnterpriseError) — and skips DB query entirely", async () => {
+    const runtime = buildRuntime(buildGateLayer({ enabled: false }));
+    // If the gate accidentally queries the DB, the test would still
+    // pass on the boolean — but the call-count assertion proves the
+    // workspace SELECT short-circuited.
+    mockInternalQuery.mockImplementation(async () => [{ enabled: true }]);
+
+    const gate = createProactiveEnabledGate(runtime, "ws-1");
+    expect(await gate()).toBe(false);
+    expect(mockInternalQuery).not.toHaveBeenCalled();
+    // EnterpriseError is the expected self-hosted path — no warn.
+    expect(mockLogWarn).not.toHaveBeenCalled();
+  });
+
+  it("returns false + logs warn when the workspace DB query throws", async () => {
+    const runtime = buildRuntime(buildGateLayer({ enabled: true }));
+    mockInternalQuery.mockImplementation(async () => {
+      throw new Error("connection refused");
+    });
+
+    const gate = createProactiveEnabledGate(runtime, "ws-1");
+    expect(await gate()).toBe(false);
+
+    expect(mockLogWarn).toHaveBeenCalledTimes(1);
+    const [payload, message] = mockLogWarn.mock.calls[0] as [
+      Record<string, unknown>,
+      string,
+    ];
+    expect(payload.workspaceId).toBe("ws-1");
+    expect(payload.err).toBe("connection refused");
+    expect(message).toContain("workspace_proactive_config");
+  });
+
+  it("type-narrows non-Error throws in the DB path", async () => {
+    const runtime = buildRuntime(buildGateLayer({ enabled: true }));
+    mockInternalQuery.mockImplementation(async () => {
+      // Defensive: covers the `String(err)` branch (CLAUDE.md
+      // "type-narrow caught errors").
+      throw "string-thrown";
+    });
+
+    const gate = createProactiveEnabledGate(runtime, "ws-1");
+    expect(await gate()).toBe(false);
+
+    const [payload] = mockLogWarn.mock.calls[0] as [Record<string, unknown>];
+    expect(payload.err).toBe("string-thrown");
+  });
+
+  it("caches the enterprise check — ProactiveGate.requireEnabled yielded exactly once across many calls", async () => {
+    const spy: Mock<RequireEnabledFn> = mock(
+      () => Effect.void as ReturnType<RequireEnabledFn>,
+    );
+    const runtime = buildRuntime(buildGateLayer({ enabled: true, spy }));
+    mockInternalQuery.mockImplementation(async () => [{ enabled: true }]);
+
+    const gate = createProactiveEnabledGate(runtime, "ws-1");
+    await gate();
+    await gate();
+    await gate();
+    await gate();
+
+    // The Tag's `requireEnabled` is invoked ONCE — subsequent calls
+    // hit the per-closure cache. The workspace SELECT runs every time.
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(mockInternalQuery).toHaveBeenCalledTimes(4);
+  });
+
+  it("caches a false enterprise result — subsequent calls return false without yielding the Tag or hitting the DB", async () => {
+    const spy: Mock<RequireEnabledFn> = mock(
+      () =>
+        Effect.fail(
+          new EnterpriseError(
+            "Enterprise features (proactive-chat) are not enabled.",
+          ),
+        ) as ReturnType<RequireEnabledFn>,
+    );
+    const runtime = buildRuntime(buildGateLayer({ enabled: false, spy }));
+
+    const gate = createProactiveEnabledGate(runtime, "ws-1");
+    expect(await gate()).toBe(false);
+    expect(await gate()).toBe(false);
+    expect(await gate()).toBe(false);
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(mockInternalQuery).not.toHaveBeenCalled();
+  });
+
+  it("workspace flag flips between calls — uncached, picks up the new value immediately", async () => {
+    const runtime = buildRuntime(buildGateLayer({ enabled: true }));
+
+    let workspaceEnabled = true;
+    mockInternalQuery.mockImplementation(async () => [
+      { enabled: workspaceEnabled },
+    ]);
+
+    const gate = createProactiveEnabledGate(runtime, "ws-1");
+    expect(await gate()).toBe(true);
+
+    workspaceEnabled = false;
+    expect(await gate()).toBe(false);
+
+    workspaceEnabled = true;
+    expect(await gate()).toBe(true);
+  });
+
+  it("each createProactiveEnabledGate call returns an independent closure with its own enterprise cache", async () => {
+    const runtime = buildRuntime(buildGateLayer({ enabled: true }));
+    mockInternalQuery.mockImplementation(async () => [{ enabled: true }]);
+
+    const gateA = createProactiveEnabledGate(runtime, "ws-A");
+    const gateB = createProactiveEnabledGate(runtime, "ws-B");
+
+    expect(await gateA()).toBe(true);
+    expect(await gateB()).toBe(true);
+
+    expect(mockInternalQuery).toHaveBeenCalledTimes(2);
+    const params = mockInternalQuery.mock.calls.map((c) => c[1]);
+    expect(params).toEqual([["ws-A"], ["ws-B"]]);
+  });
+});

--- a/packages/api/src/lib/proactive/__tests__/enabled-gate.test.ts
+++ b/packages/api/src/lib/proactive/__tests__/enabled-gate.test.ts
@@ -290,4 +290,92 @@ describe("createProactiveEnabledGate", () => {
     const params = mockInternalQuery.mock.calls.map((c) => c[1]);
     expect(params).toEqual([["ws-A"], ["ws-B"]]);
   });
+
+  it("transient runtime defect (non-EnterpriseError throw) does NOT cache — next call retries the Tag", async () => {
+    // Simulate a `ManagedRuntime` that throws a non-`EnterpriseError`
+    // out of `runPromise` (Layer construction failure, init race,
+    // etc.). The gate must fail the current call closed but leave the
+    // cache as `undefined` so the next call retries — otherwise a
+    // single boot-time blip closes the gate for the whole process
+    // lifetime.
+    let throwOnce = true;
+    const spy: Mock<RequireEnabledFn> = mock(() => {
+      if (throwOnce) {
+        throwOnce = false;
+        // Throw a non-`EnterpriseError` *defect* by wrapping in
+        // `Effect.sync` — this becomes an unhandled defect that
+        // surfaces as a thrown error out of `runtime.runPromise`,
+        // bypassing the inner `Effect.catchAll` (which handles the
+        // `E` channel only).
+        return Effect.sync(() => {
+          throw new Error("layer construction failed");
+        }) as ReturnType<RequireEnabledFn>;
+      }
+      // Second call: succeed.
+      return Effect.void as ReturnType<RequireEnabledFn>;
+    });
+    const runtime = buildRuntime(buildGateLayer({ enabled: true, spy }));
+    mockInternalQuery.mockImplementation(async () => [{ enabled: true }]);
+
+    const gate = createProactiveEnabledGate(runtime, "ws-1");
+
+    // First call: defect → fails closed, does NOT cache.
+    expect(await gate()).toBe(false);
+    expect(mockLogWarn).toHaveBeenCalledTimes(1);
+    const [payload, message] = mockLogWarn.mock.calls[0] as [
+      Record<string, unknown>,
+      string,
+    ];
+    expect(payload.workspaceId).toBe("ws-1");
+    expect(payload.retry).toBe(true);
+    expect(message).toContain("transient");
+    // No DB query — the workspace check is gated on a positive
+    // enterprise resolution.
+    expect(mockInternalQuery).not.toHaveBeenCalled();
+
+    // Second call: retries the Tag, succeeds, hits the DB.
+    expect(await gate()).toBe(true);
+    expect(spy).toHaveBeenCalledTimes(2);
+    expect(mockInternalQuery).toHaveBeenCalledTimes(1);
+  });
+
+  it("__reset() clears the per-closure enterprise cache so the next call re-yields the Tag", async () => {
+    const spy: Mock<RequireEnabledFn> = mock(
+      () => Effect.void as ReturnType<RequireEnabledFn>,
+    );
+    const runtime = buildRuntime(buildGateLayer({ enabled: true, spy }));
+    mockInternalQuery.mockImplementation(async () => [{ enabled: true }]);
+
+    const gate = createProactiveEnabledGate(runtime, "ws-1");
+
+    // Prime the cache.
+    expect(await gate()).toBe(true);
+    expect(await gate()).toBe(true);
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    // Reset, then call again — Tag should be re-yielded.
+    gate.__reset();
+    expect(await gate()).toBe(true);
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
+
+  it("includes the pg error `code` on the workspace DB warn payload", async () => {
+    const runtime = buildRuntime(buildGateLayer({ enabled: true }));
+    // Construct a pg-shaped error: `Error` instance with a `.code`.
+    const err = Object.assign(new Error("admin shutdown"), {
+      code: "57P01",
+    });
+    mockInternalQuery.mockImplementation(async () => {
+      throw err;
+    });
+
+    const gate = createProactiveEnabledGate(runtime, "ws-1");
+    expect(await gate()).toBe(false);
+
+    expect(mockLogWarn).toHaveBeenCalledTimes(1);
+    const [payload] = mockLogWarn.mock.calls[0] as [Record<string, unknown>];
+    expect(payload.workspaceId).toBe("ws-1");
+    expect(payload.err).toBe("admin shutdown");
+    expect(payload.code).toBe("57P01");
+  });
 });

--- a/packages/api/src/lib/proactive/enabled-gate.ts
+++ b/packages/api/src/lib/proactive/enabled-gate.ts
@@ -34,9 +34,17 @@
  *   - EE not loaded     → `requireEnabled` fails with `EnterpriseError`;
  *                          caches `enterpriseEnabled = false`. No DB query
  *                          made on this call or any future call.
- *   - DB query throws   → catches, logs at `warn` with `{ workspaceId, err }`,
- *                          returns `false`. Enterprise cache untouched so a
- *                          transient DB blip doesn't permanently degrade.
+ *   - Runtime defect    → `runtime.runPromise` rejects with a non-
+ *                          `EnterpriseError` throw (Layer construction
+ *                          failure, transient init race, etc.). Logs +
+ *                          fails the current call closed, but leaves
+ *                          `enterpriseEnabled` as `undefined` so the next
+ *                          call retries. Without this distinction a single
+ *                          boot-time blip would gate the process for life.
+ *   - DB query throws   → catches, logs at `warn` with `{ workspaceId, err, code }`
+ *                          (the `pg` error code helps operators tell a DB
+ *                          blip from a missing migration), returns `false`.
+ *                          Enterprise cache untouched.
  *   - Workspace row missing → SELECT returns 0 rows → treats as `enabled=false`.
  *
  * The factory captures a `ManagedRuntime` at boot (the host wiring slice
@@ -57,16 +65,31 @@ import { ProactiveGate } from "@atlas/api/lib/effect/services";
 const log = createLogger("proactive:enabled-gate");
 
 /**
- * Minimum runtime contract the factory needs. The host's
- * `getEnterpriseRuntime()` (from `lib/effect/enterprise-layer.ts`)
- * returns a `ManagedRuntime<EnterpriseSubsystem, never>` which satisfies
- * this — but we only require `ProactiveGate` in the requirements channel
- * so callers can pass a narrower test runtime that binds just the gate.
+ * Minimum runtime contract the factory needs. The production caller is
+ * `getEnterpriseRuntime()` from `lib/effect/enterprise-layer.ts`, which
+ * returns a `ManagedRuntime<EnterpriseSubsystem, never>` that satisfies
+ * this shape — but we only require `ProactiveGate` in the requirements
+ * channel so callers can pass a narrower test runtime that binds just
+ * the gate (see `__tests__/enabled-gate.test.ts:buildRuntime`).
  */
 export type ProactiveGateRuntime = ManagedRuntime.ManagedRuntime<
   ProactiveGate,
   never
 >;
+
+/**
+ * Per-workspace `isEnabled` callback returned by
+ * `createProactiveEnabledGate`. Satisfies the plugin-side
+ * `ProactiveGateFn` (`() => Promise<boolean>`); also carries a
+ * test-only `__reset()` hook that clears the per-closure enterprise
+ * cache. Per-process today — if the EE roadmap adds runtime license
+ * activation, hook `__reset` into the config-reload path so the gate
+ * doesn't stay closed against the new license state.
+ */
+export type ProactiveEnabledGate = (() => Promise<boolean>) & {
+  /** @internal Test-only: clears the per-closure enterprise cache. */
+  __reset: () => void;
+};
 
 /**
  * Build a per-workspace `isEnabled` callback for the proactive listener.
@@ -86,14 +109,14 @@ export type ProactiveGateRuntime = ManagedRuntime.ManagedRuntime<
 export function createProactiveEnabledGate(
   runtime: ProactiveGateRuntime,
   workspaceId: string,
-): () => Promise<boolean> {
+): ProactiveEnabledGate {
   // Cached enterprise result. `undefined` ⇒ not yet checked; `true` /
   // `false` ⇒ resolved (and never re-resolved for the lifetime of this
   // closure). Self-hosted's `NoopProactiveGateLayer` makes this a one-
   // shot `false`; SaaS-EE makes it a one-shot `true`.
   let enterpriseEnabled: boolean | undefined = undefined;
 
-  return async function isProactiveEnabled(): Promise<boolean> {
+  const isProactiveEnabled = async function (): Promise<boolean> {
     // ── 1. Enterprise check (cached) ─────────────────────────────
     if (enterpriseEnabled === undefined) {
       const program = Effect.gen(function* () {
@@ -124,17 +147,33 @@ export function createProactiveEnabledGate(
       try {
         enterpriseEnabled = await runtime.runPromise(program);
       } catch (err) {
-        // ManagedRuntime defect path (Layer construction failure, etc.)
-        // — log + cache `false`. The next call returns false without
-        // a runtime hop.
+        // ManagedRuntime defect path (Layer construction failure,
+        // transient init race, etc.). Distinguish:
+        //   - `EnterpriseError` thrown out the runtime (shouldn't
+        //     happen — `Effect.catchAll` above swallows it — but
+        //     belt-and-suspenders): legitimately permanent, cache `false`.
+        //   - Any other throw: transient by assumption. Leave
+        //     `enterpriseEnabled` as `undefined` so the next call retries.
+        //     Without this, a single boot-time blip would close the gate
+        //     for the whole process lifetime.
+        const isEnterpriseShape =
+          err instanceof Error && err.name === "EnterpriseError";
         log.warn(
           {
             workspaceId,
             err: err instanceof Error ? err.message : String(err),
+            retry: !isEnterpriseShape,
           },
-          "Proactive enabled-gate: enterprise runtime threw — treating as disabled",
+          isEnterpriseShape
+            ? "Proactive enabled-gate: enterprise runtime threw EnterpriseError — caching disabled"
+            : "Proactive enabled-gate: enterprise runtime threw (transient) — will retry on next call",
         );
-        enterpriseEnabled = false;
+        if (isEnterpriseShape) {
+          enterpriseEnabled = false;
+        }
+        // Transient: enterpriseEnabled stays `undefined`; fall through
+        // to the early-return below so this call still fails closed.
+        if (enterpriseEnabled === undefined) return false;
       }
     }
 
@@ -151,14 +190,33 @@ export function createProactiveEnabledGate(
       if (rows.length === 0) return false;
       return rows[0]!.enabled === true;
     } catch (err) {
+      // `pg` errors carry a `.code` (e.g. `57P01` admin shutdown,
+      // `53300` too-many-connections, `42P01` undefined-table) — the
+      // operator needs this to distinguish a DB blip from a missing
+      // migration. Spread it onto the warn payload when present.
+      const code =
+        err instanceof Error && "code" in err
+          ? { code: (err as { code: unknown }).code }
+          : {};
       log.warn(
         {
           workspaceId,
           err: err instanceof Error ? err.message : String(err),
+          ...code,
         },
         "Proactive enabled-gate: workspace_proactive_config read failed — treating as disabled",
       );
       return false;
     }
+  } as ProactiveEnabledGate;
+
+  // Per-process cache; if EE roadmap adds runtime license activation,
+  // hook this `__reset` into the config-reload path so a license that
+  // flips from disabled-at-boot to enabled-at-runtime doesn't stay
+  // gated off for the whole process lifetime.
+  isProactiveEnabled.__reset = () => {
+    enterpriseEnabled = undefined;
   };
+
+  return isProactiveEnabled;
 }

--- a/packages/api/src/lib/proactive/enabled-gate.ts
+++ b/packages/api/src/lib/proactive/enabled-gate.ts
@@ -1,0 +1,164 @@
+/**
+ * Proactive listener enabled-gate (#2616, slice 2c of #2607).
+ *
+ * Bridges the Effect-only `ProactiveGate` Tag (lives in
+ * `lib/effect/services.ts`, fails closed with `EnterpriseError` when EE
+ * isn't loaded) into the sync/promise callback shape the
+ * `@useatlas/chat` proactive listener consumes from outside the Effect
+ * runtime.
+ *
+ * The listener calls `config.isEnabled()` once at registration
+ * (`listener.ts:267`) and then again on every channel message
+ * (`listener.ts:329`, `:612`, ...), so the gate is on the hot path —
+ * potentially several calls per second on busy workspaces.
+ *
+ * Two-tier resolution:
+ *   1. **Enterprise check, cached per-closure.** `ProactiveGate.requireEnabled`
+ *      reads `process.env.ATLAS_ENTERPRISE_ENABLED` plus the optional
+ *      `enterprise.enabled` config flag (see
+ *      `lib/effect/enterprise-layer.ts:isEnterpriseEnabledLocal`); both are
+ *      resolved at boot and never flip without a restart. We yield the Tag
+ *      ONCE per closure and cache the boolean — re-yielding on every
+ *      message would pay an Effect runtime hop just to read a process-
+ *      lifetime constant.
+ *   2. **Workspace check, re-read every call.** Admins toggle
+ *      `workspace_proactive_config.enabled` at runtime via
+ *      `/admin/proactive-chat`; the kill-switch contract is that the next
+ *      classified message must respect the new value. Cache would defeat
+ *      that, so the SELECT runs on every call. The query hits the
+ *      `workspace_id` primary key and is index-only — costs a small ms
+ *      regardless.
+ *
+ * Failure modes — every failure path returns `false` (fail-closed) and
+ * never throws into the SDK event loop:
+ *   - EE not loaded     → `requireEnabled` fails with `EnterpriseError`;
+ *                          caches `enterpriseEnabled = false`. No DB query
+ *                          made on this call or any future call.
+ *   - DB query throws   → catches, logs at `warn` with `{ workspaceId, err }`,
+ *                          returns `false`. Enterprise cache untouched so a
+ *                          transient DB blip doesn't permanently degrade.
+ *   - Workspace row missing → SELECT returns 0 rows → treats as `enabled=false`.
+ *
+ * The factory captures a `ManagedRuntime` at boot (the host wiring slice
+ * passes `getEnterpriseRuntime()` from `lib/effect/enterprise-layer.ts`),
+ * so this module doesn't import `@atlas/ee` directly — the EE check flows
+ * entirely through the `ProactiveGate` Tag, satisfying the
+ * `core → ee` inversion rule from CLAUDE.md.
+ *
+ * @module
+ */
+
+import type { ManagedRuntime } from "effect";
+import { Effect } from "effect";
+import { internalQuery } from "@atlas/api/lib/db/internal";
+import { createLogger } from "@atlas/api/lib/logger";
+import { ProactiveGate } from "@atlas/api/lib/effect/services";
+
+const log = createLogger("proactive:enabled-gate");
+
+/**
+ * Minimum runtime contract the factory needs. The host's
+ * `getEnterpriseRuntime()` (from `lib/effect/enterprise-layer.ts`)
+ * returns a `ManagedRuntime<EnterpriseSubsystem, never>` which satisfies
+ * this — but we only require `ProactiveGate` in the requirements channel
+ * so callers can pass a narrower test runtime that binds just the gate.
+ */
+export type ProactiveGateRuntime = ManagedRuntime.ManagedRuntime<
+  ProactiveGate,
+  never
+>;
+
+/**
+ * Build a per-workspace `isEnabled` callback for the proactive listener.
+ *
+ * The returned closure satisfies the plugin-side `ProactiveGateFn`
+ * (`() => Promise<boolean>` — see
+ * `plugins/chat/src/proactive/types.ts`). Bind one per workspace at
+ * plugin boot; the closure carries its own enterprise-result cache.
+ *
+ * Returns `true` iff BOTH:
+ *   - Enterprise is loaded (Tag's `requireEnabled` doesn't fail with
+ *     `EnterpriseError`); AND
+ *   - The workspace has `workspace_proactive_config.enabled = true`.
+ *
+ * Never throws. Every failure → `false` + structured `log.warn`.
+ */
+export function createProactiveEnabledGate(
+  runtime: ProactiveGateRuntime,
+  workspaceId: string,
+): () => Promise<boolean> {
+  // Cached enterprise result. `undefined` ⇒ not yet checked; `true` /
+  // `false` ⇒ resolved (and never re-resolved for the lifetime of this
+  // closure). Self-hosted's `NoopProactiveGateLayer` makes this a one-
+  // shot `false`; SaaS-EE makes it a one-shot `true`.
+  let enterpriseEnabled: boolean | undefined = undefined;
+
+  return async function isProactiveEnabled(): Promise<boolean> {
+    // ── 1. Enterprise check (cached) ─────────────────────────────
+    if (enterpriseEnabled === undefined) {
+      const program = Effect.gen(function* () {
+        const gate = yield* ProactiveGate;
+        yield* gate.requireEnabled();
+        return true;
+      }).pipe(
+        // Any failure in the E channel (EnterpriseError or otherwise)
+        // → enterprise is unavailable. Log unexpected errors so a
+        // misconfigured Tag is operator-visible; `EnterpriseError` is
+        // the expected self-hosted path and stays silent.
+        Effect.catchAll((err) => {
+          const name =
+            err instanceof Error ? err.name : String(err);
+          if (name !== "EnterpriseError") {
+            log.warn(
+              {
+                workspaceId,
+                err: err instanceof Error ? err.message : String(err),
+              },
+              "Proactive enabled-gate: unexpected enterprise check failure — treating as disabled",
+            );
+          }
+          return Effect.succeed(false);
+        }),
+      );
+
+      try {
+        enterpriseEnabled = await runtime.runPromise(program);
+      } catch (err) {
+        // ManagedRuntime defect path (Layer construction failure, etc.)
+        // — log + cache `false`. The next call returns false without
+        // a runtime hop.
+        log.warn(
+          {
+            workspaceId,
+            err: err instanceof Error ? err.message : String(err),
+          },
+          "Proactive enabled-gate: enterprise runtime threw — treating as disabled",
+        );
+        enterpriseEnabled = false;
+      }
+    }
+
+    if (!enterpriseEnabled) return false;
+
+    // ── 2. Workspace check (re-read every call) ──────────────────
+    try {
+      const rows = await internalQuery<{ enabled: boolean }>(
+        `SELECT enabled
+           FROM workspace_proactive_config
+          WHERE workspace_id = $1`,
+        [workspaceId],
+      );
+      if (rows.length === 0) return false;
+      return rows[0]!.enabled === true;
+    } catch (err) {
+      log.warn(
+        {
+          workspaceId,
+          err: err instanceof Error ? err.message : String(err),
+        },
+        "Proactive enabled-gate: workspace_proactive_config read failed — treating as disabled",
+      );
+      return false;
+    }
+  };
+}


### PR DESCRIPTION
## Summary

Slice 2c of #2607. A foundational adapter that bridges the Effect-only `ProactiveGate` Tag into the sync/promise callback the chat plugin's proactive listener calls from outside the Effect runtime.

`createProactiveEnabledGate(runtime, workspaceId)` returns a `() => Promise<boolean>` that returns `true` iff:

1. Enterprise is loaded (Tag's `requireEnabled` doesn't fail with `EnterpriseError`); **AND**
2. `workspace_proactive_config.enabled = true` for the workspace.

## Caching strategy

- **Enterprise result cached per-closure.** The flag resolves at boot from `ATLAS_ENTERPRISE_ENABLED` + atlas.config and never flips without a restart. The proactive listener calls `isEnabled` at ~3 per-message call sites (`listener.ts:267, 329, 612, ...`) so re-yielding the Tag on every message would pay an Effect runtime hop on a process-lifetime constant. Yielded **once** per closure; cached forever after.
- **Workspace flag re-read every call.** Admins toggle `workspace_proactive_config.enabled` at runtime via `/admin/proactive-chat`; the kill-switch contract requires the next classified message to respect the new value. SELECT runs on every call (hits the `workspace_id` PK, index-only, costs sub-ms).

## Fail-closed semantics

Every failure path returns `false` and never throws into the SDK event loop:

| Path | Result | Logged? |
|------|--------|---------|
| EE not loaded (`EnterpriseError`) | `false` (cached); no DB query ever | No — expected self-hosted path |
| Workspace row missing | `false` | No — expected "not opted in" path |
| DB query throws | `false` (enterprise cache untouched) | `log.warn { workspaceId, err }` |
| Non-Error thrown value | `false` | `log.warn` with `String(err)` narrowing |

## No EE coupling

This module imports only the `ProactiveGate` Tag from `lib/effect/services.ts` — never `@atlas/ee`. The host wiring slice will pass `getEnterpriseRuntime()` from `lib/effect/enterprise-layer.ts` (the single allow-listed core→ee bridge). `scripts/check-ee-imports.sh` green.

## Acceptance criteria (all from #2616)

- [x] `createProactiveEnabledGate(runtime, workspaceId)` exported from `packages/api/src/lib/proactive/enabled-gate.ts`
- [x] Returned callback satisfies `ProactiveGateFn` from `@useatlas/chat` (`() => Promise<boolean>`)
- [x] Enterprise check yields `ProactiveGate.requireEnabled` and returns `false` if it fails with `EnterpriseError`
- [x] Workspace check: SELECT `enabled` FROM `workspace_proactive_config` WHERE `workspace_id = $1` (returns `false` if no row)
- [x] Enterprise result cached per-process (per-closure); workspace flag re-read every call
- [x] DB errors → fail-closed (`return false`) + `log.warn` with `{ workspaceId, err }`
- [x] Unit tests cover all matrix branches
- [x] No `@atlas/ee` imports; no `@atlas/api/api/routes/` imports

## Test plan

10 unit tests covering:

- [x] Enterprise enabled + workspace enabled → `true`
- [x] Enterprise enabled + workspace disabled → `false`
- [x] Enterprise enabled + workspace row missing → `false` (no warn)
- [x] Enterprise disabled (`EnterpriseError`) → `false` + DB query skipped
- [x] DB throw → `false` + `log.warn { workspaceId, err: "..." }`
- [x] Non-Error throw → `false` + `String(err)` narrowed payload
- [x] Caching: Tag `requireEnabled` called exactly once across 4 invocations; workspace SELECT runs 4×
- [x] False-enterprise cache: Tag called once, never called again, DB never queried
- [x] Workspace flag flip between calls is picked up immediately (uncached)
- [x] Independent closures per `createProactiveEnabledGate` call (separate caches per workspace)

## Local CI

- `bun run lint` → 0 errors (10 warnings, none in new files)
- `bun run type` → clean
- `bun test src/lib/proactive/__tests__/enabled-gate.test.ts` → 10 pass / 0 fail
- `bun run scripts/test-isolated.ts --affected` → 1 pass / 0 fail
- `bash scripts/check-ee-imports.sh` → green
- `bash scripts/check-schema-drift.sh` → green

Closes #2616
Refs #2607