### PR TITLE
feat(plugins/chat,api): #2620 — multi-tenant proactive listener (per-event workspaceId)

### DIFF
--- a/packages/api/src/lib/proactive/__tests__/enabled-gate.test.ts
+++ b/packages/api/src/lib/proactive/__tests__/enabled-gate.test.ts
@@ -306,6 +306,62 @@ describe("createProactiveEnabledGate", () => {
     expect(params).toEqual([["ws-A"], ["ws-B"]]);
   });
 
+  it("returns true for empty workspaceId when enterprise is enabled — registration probe, no DB call", async () => {
+    // The chat plugin's `registerProactiveListener` calls
+    // `config.isEnabled("")` once at boot to answer "is the listener
+    // even possible in this process?" — there's no tenant yet. The
+    // gate must answer the enterprise question and skip the workspace
+    // SELECT; otherwise `$1 = ''` returns 0 rows and silently mis-gates
+    // the listener on SaaS where EE is enabled.
+    const runtime = buildRuntime(buildGateLayer({ enabled: true }));
+    mockInternalQuery.mockImplementation(async () => [{ enabled: true }]);
+
+    const gate = createProactiveEnabledGate(runtime);
+    expect(await gate("")).toBe(true);
+    expect(mockInternalQuery).not.toHaveBeenCalled();
+  });
+
+  it("returns false for empty workspaceId when enterprise is disabled — registration probe, no DB call", async () => {
+    // EE-disabled path: the enterprise cache short-circuits first, so
+    // the registration probe correctly answers "no listener" without
+    // touching the DB.
+    const runtime = buildRuntime(buildGateLayer({ enabled: false }));
+    mockInternalQuery.mockImplementation(async () => [{ enabled: true }]);
+
+    const gate = createProactiveEnabledGate(runtime);
+    expect(await gate("")).toBe(false);
+    expect(mockInternalQuery).not.toHaveBeenCalled();
+  });
+
+  it("caches a false enterprise result across many tenants — never yields Tag twice, never queries DB", async () => {
+    // Mirror of "one closure serves multiple tenants" for the
+    // EE-disabled scenario. A self-hosted deploy that never enables EE
+    // must not pay an Effect runtime hop AND must not hit the DB on
+    // every event — both would defeat the per-closure cache the
+    // enabled-gate exists to provide.
+    const spy: Mock<RequireEnabledFn> = mock(
+      () =>
+        Effect.fail(
+          new EnterpriseError(
+            "Enterprise features (proactive-chat) are not enabled.",
+          ),
+        ) as ReturnType<RequireEnabledFn>,
+    );
+    const runtime = buildRuntime(buildGateLayer({ enabled: false, spy }));
+
+    const gate = createProactiveEnabledGate(runtime);
+
+    expect(await gate("ws-A")).toBe(false);
+    expect(await gate("ws-B")).toBe(false);
+    expect(await gate("ws-C")).toBe(false);
+
+    // (a) Enterprise check yielded exactly ONCE across all three tenants.
+    expect(spy).toHaveBeenCalledTimes(1);
+    // (b) No DB calls at all — the workspace SELECT is gated behind
+    //     a positive enterprise resolution.
+    expect(mockInternalQuery).not.toHaveBeenCalled();
+  });
+
   it("one closure serves multiple tenants — single enterprise cache, per-call workspace SELECT", async () => {
     // The core #2620 multi-tenant correctness assertion: a single
     // closure built ONCE per process must serve N tenants. The

--- a/packages/api/src/lib/proactive/__tests__/enabled-gate.test.ts
+++ b/packages/api/src/lib/proactive/__tests__/enabled-gate.test.ts
@@ -141,8 +141,8 @@ describe("createProactiveEnabledGate", () => {
     const runtime = buildRuntime(buildGateLayer({ enabled: true }));
     mockInternalQuery.mockImplementation(async () => [{ enabled: true }]);
 
-    const gate = createProactiveEnabledGate(runtime, "ws-1");
-    expect(await gate()).toBe(true);
+    const gate = createProactiveEnabledGate(runtime);
+    expect(await gate("ws-1")).toBe(true);
 
     expect(mockInternalQuery).toHaveBeenCalledTimes(1);
     const [sql, params] = mockInternalQuery.mock.calls[0]!;
@@ -155,8 +155,8 @@ describe("createProactiveEnabledGate", () => {
     const runtime = buildRuntime(buildGateLayer({ enabled: true }));
     mockInternalQuery.mockImplementation(async () => [{ enabled: false }]);
 
-    const gate = createProactiveEnabledGate(runtime, "ws-1");
-    expect(await gate()).toBe(false);
+    const gate = createProactiveEnabledGate(runtime);
+    expect(await gate("ws-1")).toBe(false);
     expect(mockInternalQuery).toHaveBeenCalledTimes(1);
   });
 
@@ -164,8 +164,8 @@ describe("createProactiveEnabledGate", () => {
     const runtime = buildRuntime(buildGateLayer({ enabled: true }));
     mockInternalQuery.mockImplementation(async () => []);
 
-    const gate = createProactiveEnabledGate(runtime, "ws-1");
-    expect(await gate()).toBe(false);
+    const gate = createProactiveEnabledGate(runtime);
+    expect(await gate("ws-1")).toBe(false);
     expect(mockInternalQuery).toHaveBeenCalledTimes(1);
     // Row-missing is the expected "not opted in" path — no warning.
     expect(mockLogWarn).not.toHaveBeenCalled();
@@ -178,8 +178,8 @@ describe("createProactiveEnabledGate", () => {
     // workspace SELECT short-circuited.
     mockInternalQuery.mockImplementation(async () => [{ enabled: true }]);
 
-    const gate = createProactiveEnabledGate(runtime, "ws-1");
-    expect(await gate()).toBe(false);
+    const gate = createProactiveEnabledGate(runtime);
+    expect(await gate("ws-1")).toBe(false);
     expect(mockInternalQuery).not.toHaveBeenCalled();
     // EnterpriseError is the expected self-hosted path — no warn.
     expect(mockLogWarn).not.toHaveBeenCalled();
@@ -191,8 +191,8 @@ describe("createProactiveEnabledGate", () => {
       throw new Error("connection refused");
     });
 
-    const gate = createProactiveEnabledGate(runtime, "ws-1");
-    expect(await gate()).toBe(false);
+    const gate = createProactiveEnabledGate(runtime);
+    expect(await gate("ws-1")).toBe(false);
 
     expect(mockLogWarn).toHaveBeenCalledTimes(1);
     const [payload, message] = mockLogWarn.mock.calls[0] as [
@@ -212,8 +212,8 @@ describe("createProactiveEnabledGate", () => {
       throw "string-thrown";
     });
 
-    const gate = createProactiveEnabledGate(runtime, "ws-1");
-    expect(await gate()).toBe(false);
+    const gate = createProactiveEnabledGate(runtime);
+    expect(await gate("ws-1")).toBe(false);
 
     const [payload] = mockLogWarn.mock.calls[0] as [Record<string, unknown>];
     expect(payload.err).toBe("string-thrown");
@@ -226,11 +226,11 @@ describe("createProactiveEnabledGate", () => {
     const runtime = buildRuntime(buildGateLayer({ enabled: true, spy }));
     mockInternalQuery.mockImplementation(async () => [{ enabled: true }]);
 
-    const gate = createProactiveEnabledGate(runtime, "ws-1");
-    await gate();
-    await gate();
-    await gate();
-    await gate();
+    const gate = createProactiveEnabledGate(runtime);
+    await gate("ws-1");
+    await gate("ws-1");
+    await gate("ws-1");
+    await gate("ws-1");
 
     // The Tag's `requireEnabled` is invoked ONCE — subsequent calls
     // hit the per-closure cache. The workspace SELECT runs every time.
@@ -249,10 +249,10 @@ describe("createProactiveEnabledGate", () => {
     );
     const runtime = buildRuntime(buildGateLayer({ enabled: false, spy }));
 
-    const gate = createProactiveEnabledGate(runtime, "ws-1");
-    expect(await gate()).toBe(false);
-    expect(await gate()).toBe(false);
-    expect(await gate()).toBe(false);
+    const gate = createProactiveEnabledGate(runtime);
+    expect(await gate("ws-1")).toBe(false);
+    expect(await gate("ws-1")).toBe(false);
+    expect(await gate("ws-1")).toBe(false);
 
     expect(spy).toHaveBeenCalledTimes(1);
     expect(mockInternalQuery).not.toHaveBeenCalled();
@@ -266,29 +266,70 @@ describe("createProactiveEnabledGate", () => {
       { enabled: workspaceEnabled },
     ]);
 
-    const gate = createProactiveEnabledGate(runtime, "ws-1");
-    expect(await gate()).toBe(true);
+    const gate = createProactiveEnabledGate(runtime);
+    expect(await gate("ws-1")).toBe(true);
 
     workspaceEnabled = false;
-    expect(await gate()).toBe(false);
+    expect(await gate("ws-1")).toBe(false);
 
     workspaceEnabled = true;
-    expect(await gate()).toBe(true);
+    expect(await gate("ws-1")).toBe(true);
   });
 
   it("each createProactiveEnabledGate call returns an independent closure with its own enterprise cache", async () => {
-    const runtime = buildRuntime(buildGateLayer({ enabled: true }));
+    // Post-#2620 the factory is workspaceId-less; closures are bound
+    // once per process and serve N tenants. This test proves that two
+    // independent closures (e.g. built in two different bridges) keep
+    // their own enterprise caches without sharing state.
+    const spyA: Mock<RequireEnabledFn> = mock(
+      () => Effect.void as ReturnType<RequireEnabledFn>,
+    );
+    const spyB: Mock<RequireEnabledFn> = mock(
+      () => Effect.void as ReturnType<RequireEnabledFn>,
+    );
+    const runtimeA = buildRuntime(buildGateLayer({ enabled: true, spy: spyA }));
+    const runtimeB = buildRuntime(buildGateLayer({ enabled: true, spy: spyB }));
     mockInternalQuery.mockImplementation(async () => [{ enabled: true }]);
 
-    const gateA = createProactiveEnabledGate(runtime, "ws-A");
-    const gateB = createProactiveEnabledGate(runtime, "ws-B");
+    const gateA = createProactiveEnabledGate(runtimeA);
+    const gateB = createProactiveEnabledGate(runtimeB);
 
-    expect(await gateA()).toBe(true);
-    expect(await gateB()).toBe(true);
+    expect(await gateA("ws-A")).toBe(true);
+    expect(await gateB("ws-B")).toBe(true);
 
+    // Each closure yields its own Tag once (independent caches).
+    expect(spyA).toHaveBeenCalledTimes(1);
+    expect(spyB).toHaveBeenCalledTimes(1);
+    // Each closure ran the workspace SELECT once with its arg.
     expect(mockInternalQuery).toHaveBeenCalledTimes(2);
     const params = mockInternalQuery.mock.calls.map((c) => c[1]);
     expect(params).toEqual([["ws-A"], ["ws-B"]]);
+  });
+
+  it("one closure serves multiple tenants — single enterprise cache, per-call workspace SELECT", async () => {
+    // The core #2620 multi-tenant correctness assertion: a single
+    // closure built ONCE per process must serve N tenants. The
+    // enterprise check is cached (per-closure / process-lifetime
+    // constant) and the workspace SELECT re-runs every call with the
+    // caller-supplied workspaceId.
+    const spy: Mock<RequireEnabledFn> = mock(
+      () => Effect.void as ReturnType<RequireEnabledFn>,
+    );
+    const runtime = buildRuntime(buildGateLayer({ enabled: true, spy }));
+    mockInternalQuery.mockImplementation(async () => [{ enabled: true }]);
+
+    const gate = createProactiveEnabledGate(runtime);
+
+    expect(await gate("ws-A")).toBe(true);
+    expect(await gate("ws-B")).toBe(true);
+    expect(await gate("ws-C")).toBe(true);
+
+    // Tag yielded once — caches across all three calls.
+    expect(spy).toHaveBeenCalledTimes(1);
+    // Workspace SELECT ran per call with each workspaceId.
+    expect(mockInternalQuery).toHaveBeenCalledTimes(3);
+    const params = mockInternalQuery.mock.calls.map((c) => c[1]);
+    expect(params).toEqual([["ws-A"], ["ws-B"], ["ws-C"]]);
   });
 
   it("transient runtime defect (non-EnterpriseError throw) does NOT cache — next call retries the Tag", async () => {
@@ -317,10 +358,10 @@ describe("createProactiveEnabledGate", () => {
     const runtime = buildRuntime(buildGateLayer({ enabled: true, spy }));
     mockInternalQuery.mockImplementation(async () => [{ enabled: true }]);
 
-    const gate = createProactiveEnabledGate(runtime, "ws-1");
+    const gate = createProactiveEnabledGate(runtime);
 
     // First call: defect → fails closed, does NOT cache.
-    expect(await gate()).toBe(false);
+    expect(await gate("ws-1")).toBe(false);
     expect(mockLogWarn).toHaveBeenCalledTimes(1);
     const [payload, message] = mockLogWarn.mock.calls[0] as [
       Record<string, unknown>,
@@ -334,7 +375,7 @@ describe("createProactiveEnabledGate", () => {
     expect(mockInternalQuery).not.toHaveBeenCalled();
 
     // Second call: retries the Tag, succeeds, hits the DB.
-    expect(await gate()).toBe(true);
+    expect(await gate("ws-1")).toBe(true);
     expect(spy).toHaveBeenCalledTimes(2);
     expect(mockInternalQuery).toHaveBeenCalledTimes(1);
   });
@@ -346,16 +387,16 @@ describe("createProactiveEnabledGate", () => {
     const runtime = buildRuntime(buildGateLayer({ enabled: true, spy }));
     mockInternalQuery.mockImplementation(async () => [{ enabled: true }]);
 
-    const gate = createProactiveEnabledGate(runtime, "ws-1");
+    const gate = createProactiveEnabledGate(runtime);
 
     // Prime the cache.
-    expect(await gate()).toBe(true);
-    expect(await gate()).toBe(true);
+    expect(await gate("ws-1")).toBe(true);
+    expect(await gate("ws-1")).toBe(true);
     expect(spy).toHaveBeenCalledTimes(1);
 
     // Reset, then call again — Tag should be re-yielded.
     gate.__reset();
-    expect(await gate()).toBe(true);
+    expect(await gate("ws-1")).toBe(true);
     expect(spy).toHaveBeenCalledTimes(2);
   });
 
@@ -369,8 +410,8 @@ describe("createProactiveEnabledGate", () => {
       throw err;
     });
 
-    const gate = createProactiveEnabledGate(runtime, "ws-1");
-    expect(await gate()).toBe(false);
+    const gate = createProactiveEnabledGate(runtime);
+    expect(await gate("ws-1")).toBe(false);
 
     expect(mockLogWarn).toHaveBeenCalledTimes(1);
     const [payload] = mockLogWarn.mock.calls[0] as [Record<string, unknown>];

--- a/packages/api/src/lib/proactive/__tests__/workspace-config-loader.test.ts
+++ b/packages/api/src/lib/proactive/__tests__/workspace-config-loader.test.ts
@@ -1,0 +1,264 @@
+/**
+ * Unit tests for the workspace + channel config loaders (#2620).
+ *
+ * Covers `getWorkspaceProactiveConfig` + `getChannelProactiveConfigs`:
+ *   - Workspace row missing → null
+ *   - Workspace row present → { enabled, sensitivity, classifierMode }
+ *   - Sensitivity / classifier_mode out-of-enum drift → safe defaults
+ *   - DB throws → null / [] + log.warn
+ *   - Channels: zero rows → []
+ *   - Channels: multiple rows → ordered + nullable sensitivity dropped
+ *
+ * Mock notes — same constraints as `workspace-id-resolver.test.ts`.
+ */
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  mock,
+  type Mock,
+} from "bun:test";
+
+// ── Logger mock ─────────────────────────────────────────────────────
+
+const mockLogWarn: Mock<(...args: unknown[]) => void> = mock(() => {});
+
+mock.module("@atlas/api/lib/logger", () => ({
+  createLogger: () => ({
+    warn: mockLogWarn,
+    info: () => {},
+    debug: () => {},
+    error: () => {},
+    trace: () => {},
+    fatal: () => {},
+    silent: () => {},
+    child: () => ({
+      warn: mockLogWarn,
+      info: () => {},
+      debug: () => {},
+      error: () => {},
+      trace: () => {},
+      fatal: () => {},
+      silent: () => {},
+    }),
+  }),
+}));
+
+// ── DB internal mock ────────────────────────────────────────────────
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const realInternal = require("@atlas/api/lib/db/internal") as typeof import("@atlas/api/lib/db/internal");
+
+const mockInternalQuery: Mock<
+  (sql: string, params: unknown[]) => Promise<unknown[]>
+> = mock(async () => []);
+const mockHasInternalDB: Mock<() => boolean> = mock(() => true);
+
+mock.module("@atlas/api/lib/db/internal", () => ({
+  ...realInternal,
+  internalQuery: (sql: string, params: unknown[]) =>
+    mockInternalQuery(sql, params),
+  hasInternalDB: () => mockHasInternalDB(),
+}));
+
+// ── Module under test (loaded AFTER mocks via sync require) ──────────
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const loader = require("../workspace-config-loader") as typeof import("../workspace-config-loader");
+const { getWorkspaceProactiveConfig, getChannelProactiveConfigs } = loader;
+
+// ── Per-test reset ──────────────────────────────────────────────────
+
+beforeEach(() => {
+  mockInternalQuery.mockClear();
+  mockInternalQuery.mockImplementation(async () => []);
+  mockHasInternalDB.mockClear();
+  mockHasInternalDB.mockImplementation(() => true);
+  mockLogWarn.mockClear();
+});
+
+afterEach(() => {
+  mockInternalQuery.mockClear();
+  mockLogWarn.mockClear();
+});
+
+// ── getWorkspaceProactiveConfig ──────────────────────────────────────
+
+describe("getWorkspaceProactiveConfig", () => {
+  it("returns null when no workspace row exists", async () => {
+    mockInternalQuery.mockImplementation(async () => []);
+    const out = await getWorkspaceProactiveConfig("ws-1");
+    expect(out).toBeNull();
+    // Row missing is the expected "not opted in" path — no warn.
+    expect(mockLogWarn).not.toHaveBeenCalled();
+  });
+
+  it("returns the parsed config when the workspace row exists", async () => {
+    mockInternalQuery.mockImplementation(async () => [
+      {
+        enabled: true,
+        sensitivity: "eager",
+        classifier_mode: "classify-all",
+      },
+    ]);
+    const out = await getWorkspaceProactiveConfig("ws-1");
+    expect(out).toEqual({
+      enabled: true,
+      sensitivity: "eager",
+      classifierMode: "classify-all",
+    });
+
+    expect(mockInternalQuery).toHaveBeenCalledTimes(1);
+    const [sql, params] = mockInternalQuery.mock.calls[0]!;
+    expect(sql).toContain("workspace_proactive_config");
+    expect(sql).toContain("classifier_mode");
+    expect(params).toEqual(["ws-1"]);
+  });
+
+  it("falls back to balanced sensitivity on schema drift (non-enum value)", async () => {
+    mockInternalQuery.mockImplementation(async () => [
+      {
+        enabled: true,
+        sensitivity: "extreme", // not in the enum
+        classifier_mode: "regex-prefilter",
+      },
+    ]);
+    const out = await getWorkspaceProactiveConfig("ws-1");
+    expect(out?.sensitivity).toBe("balanced");
+  });
+
+  it("falls back to regex-prefilter classifier mode on schema drift", async () => {
+    mockInternalQuery.mockImplementation(async () => [
+      {
+        enabled: true,
+        sensitivity: "balanced",
+        classifier_mode: "future-mode-not-yet-defined",
+      },
+    ]);
+    const out = await getWorkspaceProactiveConfig("ws-1");
+    expect(out?.classifierMode).toBe("regex-prefilter");
+  });
+
+  it("returns null + logs warn when the workspace DB query throws", async () => {
+    mockInternalQuery.mockImplementation(async () => {
+      throw new Error("connection refused");
+    });
+    const out = await getWorkspaceProactiveConfig("ws-1");
+    expect(out).toBeNull();
+
+    expect(mockLogWarn).toHaveBeenCalledTimes(1);
+    const [payload, message] = mockLogWarn.mock.calls[0] as [
+      Record<string, unknown>,
+      string,
+    ];
+    expect(payload.workspaceId).toBe("ws-1");
+    expect(payload.err).toBe("connection refused");
+    expect(message).toContain("workspace_proactive_config");
+  });
+
+  it("propagates the pg error `code` onto the warn payload", async () => {
+    const err = Object.assign(new Error("undefined table"), { code: "42P01" });
+    mockInternalQuery.mockImplementation(async () => {
+      throw err;
+    });
+    await getWorkspaceProactiveConfig("ws-1");
+    const [payload] = mockLogWarn.mock.calls[0] as [Record<string, unknown>];
+    expect(payload.code).toBe("42P01");
+  });
+
+  it("returns null when the internal DB is unavailable", async () => {
+    mockHasInternalDB.mockImplementation(() => false);
+    const out = await getWorkspaceProactiveConfig("ws-1");
+    expect(out).toBeNull();
+    expect(mockInternalQuery).not.toHaveBeenCalled();
+  });
+
+  it("treats enabled as boolean — falsy values resolve to false", async () => {
+    mockInternalQuery.mockImplementation(async () => [
+      {
+        enabled: 0,
+        sensitivity: "balanced",
+        classifier_mode: "regex-prefilter",
+      },
+    ]);
+    const out = await getWorkspaceProactiveConfig("ws-1");
+    expect(out?.enabled).toBe(false);
+  });
+});
+
+// ── getChannelProactiveConfigs ───────────────────────────────────────
+
+describe("getChannelProactiveConfigs", () => {
+  it("returns an empty array when no overrides exist", async () => {
+    mockInternalQuery.mockImplementation(async () => []);
+    const out = await getChannelProactiveConfigs("ws-1");
+    expect(out).toEqual([]);
+    expect(mockLogWarn).not.toHaveBeenCalled();
+  });
+
+  it("returns mapped overrides with sensitivity carried through", async () => {
+    mockInternalQuery.mockImplementation(async () => [
+      { channel_id: "C-1", allow: true, sensitivity: "cautious" },
+      { channel_id: "C-2", allow: false, sensitivity: null },
+    ]);
+    const out = await getChannelProactiveConfigs("ws-1");
+    expect(out).toEqual([
+      { channelId: "C-1", allow: true, sensitivity: "cautious" },
+      { channelId: "C-2", allow: false },
+    ]);
+
+    expect(mockInternalQuery).toHaveBeenCalledTimes(1);
+    const [sql, params] = mockInternalQuery.mock.calls[0]!;
+    expect(sql).toContain("channel_proactive_config");
+    expect(sql).toContain("ORDER BY channel_id");
+    expect(params).toEqual(["ws-1"]);
+  });
+
+  it("drops out-of-enum sensitivity to the safe default rather than carrying drift", async () => {
+    mockInternalQuery.mockImplementation(async () => [
+      { channel_id: "C-1", allow: true, sensitivity: "weird" },
+    ]);
+    const out = await getChannelProactiveConfigs("ws-1");
+    expect(out[0]!.sensitivity).toBe("balanced");
+  });
+
+  it("returns [] + logs warn when the channel DB query throws", async () => {
+    mockInternalQuery.mockImplementation(async () => {
+      throw new Error("table is locked");
+    });
+    const out = await getChannelProactiveConfigs("ws-1");
+    expect(out).toEqual([]);
+
+    expect(mockLogWarn).toHaveBeenCalledTimes(1);
+    const [payload, message] = mockLogWarn.mock.calls[0] as [
+      Record<string, unknown>,
+      string,
+    ];
+    expect(payload.workspaceId).toBe("ws-1");
+    expect(payload.err).toBe("table is locked");
+    expect(message).toContain("channel_proactive_config");
+  });
+
+  it("returns [] when the internal DB is unavailable", async () => {
+    mockHasInternalDB.mockImplementation(() => false);
+    const out = await getChannelProactiveConfigs("ws-1");
+    expect(out).toEqual([]);
+    expect(mockInternalQuery).not.toHaveBeenCalled();
+  });
+
+  it("normalises `allow` to boolean", async () => {
+    mockInternalQuery.mockImplementation(async () => [
+      { channel_id: "C-1", allow: 1, sensitivity: null },
+      { channel_id: "C-2", allow: 0, sensitivity: null },
+    ]);
+    const out = await getChannelProactiveConfigs("ws-1");
+    expect(out[0]!.allow).toBe(false);
+    expect(out[1]!.allow).toBe(false);
+    // Truthy non-`true` values are coerced — only literal `true` passes
+    // through. The DB column is `BOOLEAN NOT NULL`, so this is purely
+    // defensive against driver type-shape drift.
+  });
+});

--- a/packages/api/src/lib/proactive/__tests__/workspace-id-resolver.test.ts
+++ b/packages/api/src/lib/proactive/__tests__/workspace-id-resolver.test.ts
@@ -1,0 +1,249 @@
+/**
+ * Unit tests for `createSlackWorkspaceIdResolver` (#2620).
+ *
+ * Covers:
+ *   - Non-Slack adapter → null (cross-platform isolation)
+ *   - Missing team_id / missing raw → null
+ *   - Known team_id → org_id from slack_installations
+ *   - Unknown team_id → null
+ *   - DB throws → null + log.warn
+ *   - `team` field accepted as alias for `team_id`
+ *   - `org_id` null in the DB row → null
+ *
+ * Mock notes — same constraints as `enabled-gate.test.ts`:
+ *   - `mock.module()` factories are sync; async + inner await deadlocks
+ *     the bun loader (CLAUDE.md `feedback_bun_test_async_mock_module`).
+ *   - Logger mock returns a fully-stubbed shape — recursing into
+ *     `createLogger` inside its own factory hangs the loader.
+ *   - Module-under-test is loaded via `require()` AFTER mocks; `await
+ *     import(...)` between mock + load is also a known deadlock path.
+ */
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  mock,
+  type Mock,
+} from "bun:test";
+
+// ── Logger mock ─────────────────────────────────────────────────────
+
+const mockLogWarn: Mock<(...args: unknown[]) => void> = mock(() => {});
+
+mock.module("@atlas/api/lib/logger", () => ({
+  createLogger: () => ({
+    warn: mockLogWarn,
+    info: () => {},
+    debug: () => {},
+    error: () => {},
+    trace: () => {},
+    fatal: () => {},
+    silent: () => {},
+    child: () => ({
+      warn: mockLogWarn,
+      info: () => {},
+      debug: () => {},
+      error: () => {},
+      trace: () => {},
+      fatal: () => {},
+      silent: () => {},
+    }),
+  }),
+}));
+
+// ── DB internal mock ────────────────────────────────────────────────
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const realInternal = require("@atlas/api/lib/db/internal") as typeof import("@atlas/api/lib/db/internal");
+
+const mockInternalQuery: Mock<
+  (sql: string, params: unknown[]) => Promise<unknown[]>
+> = mock(async () => []);
+const mockHasInternalDB: Mock<() => boolean> = mock(() => true);
+
+mock.module("@atlas/api/lib/db/internal", () => ({
+  ...realInternal,
+  internalQuery: (sql: string, params: unknown[]) =>
+    mockInternalQuery(sql, params),
+  hasInternalDB: () => mockHasInternalDB(),
+}));
+
+// ── Module under test (loaded AFTER mocks via sync require) ──────────
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { createSlackWorkspaceIdResolver } = require(
+  "../workspace-id-resolver",
+) as typeof import("../workspace-id-resolver");
+
+// ── Test helpers ────────────────────────────────────────────────────
+
+/**
+ * Build a resolver event with the minimum surface the resolver reads
+ * (`adapter.name`, `message.raw`). Tests pass `null` for `thread`
+ * because the Slack resolver never inspects it.
+ */
+function makeEvent(opts: {
+  adapterName?: string;
+  raw?: Record<string, unknown> | null | undefined;
+}): Parameters<ReturnType<typeof createSlackWorkspaceIdResolver>>[0] {
+  return {
+    adapter: { name: opts.adapterName ?? "slack" },
+    thread: {},
+    message: { raw: opts.raw },
+  } as unknown as Parameters<
+    ReturnType<typeof createSlackWorkspaceIdResolver>
+  >[0];
+}
+
+// ── Per-test reset ──────────────────────────────────────────────────
+
+beforeEach(() => {
+  mockInternalQuery.mockClear();
+  mockInternalQuery.mockImplementation(async () => []);
+  mockHasInternalDB.mockClear();
+  mockHasInternalDB.mockImplementation(() => true);
+  mockLogWarn.mockClear();
+});
+
+afterEach(() => {
+  mockInternalQuery.mockClear();
+  mockLogWarn.mockClear();
+});
+
+// ── Tests ───────────────────────────────────────────────────────────
+
+describe("createSlackWorkspaceIdResolver", () => {
+  it("returns null for a non-Slack adapter without touching the DB", async () => {
+    const resolver = createSlackWorkspaceIdResolver();
+    const out = await resolver(
+      makeEvent({ adapterName: "teams", raw: { team_id: "T1" } }),
+    );
+    expect(out).toBeNull();
+    expect(mockInternalQuery).not.toHaveBeenCalled();
+  });
+
+  it("returns null when message.raw is missing entirely", async () => {
+    const resolver = createSlackWorkspaceIdResolver();
+    const out = await resolver(makeEvent({ raw: undefined }));
+    expect(out).toBeNull();
+    expect(mockInternalQuery).not.toHaveBeenCalled();
+  });
+
+  it("returns null when neither team_id nor team is set on the raw payload", async () => {
+    const resolver = createSlackWorkspaceIdResolver();
+    const out = await resolver(makeEvent({ raw: { channel: "C1" } }));
+    expect(out).toBeNull();
+    expect(mockInternalQuery).not.toHaveBeenCalled();
+  });
+
+  it("returns the org_id from slack_installations for a known team_id", async () => {
+    mockInternalQuery.mockImplementation(async () => [{ org_id: "org-1" }]);
+    const resolver = createSlackWorkspaceIdResolver();
+    const out = await resolver(makeEvent({ raw: { team_id: "T-known" } }));
+    expect(out).toBe("org-1");
+
+    expect(mockInternalQuery).toHaveBeenCalledTimes(1);
+    const [sql, params] = mockInternalQuery.mock.calls[0]!;
+    expect(sql).toContain("slack_installations");
+    expect(sql).toContain("SELECT org_id");
+    expect(params).toEqual(["T-known"]);
+  });
+
+  it("accepts `team` as an alias for `team_id` (older webhook shapes)", async () => {
+    mockInternalQuery.mockImplementation(async () => [{ org_id: "org-1" }]);
+    const resolver = createSlackWorkspaceIdResolver();
+    const out = await resolver(makeEvent({ raw: { team: "T-alias" } }));
+    expect(out).toBe("org-1");
+
+    const [, params] = mockInternalQuery.mock.calls[0]!;
+    expect(params).toEqual(["T-alias"]);
+  });
+
+  it("prefers `team_id` over `team` when both are present", async () => {
+    mockInternalQuery.mockImplementation(async () => [{ org_id: "org-1" }]);
+    const resolver = createSlackWorkspaceIdResolver();
+    await resolver(
+      makeEvent({ raw: { team_id: "T-primary", team: "T-fallback" } }),
+    );
+    const [, params] = mockInternalQuery.mock.calls[0]!;
+    expect(params).toEqual(["T-primary"]);
+  });
+
+  it("returns null when slack_installations has no row for the team_id", async () => {
+    mockInternalQuery.mockImplementation(async () => []);
+    const resolver = createSlackWorkspaceIdResolver();
+    const out = await resolver(makeEvent({ raw: { team_id: "T-unknown" } }));
+    expect(out).toBeNull();
+    // Unknown tenant is the expected silent-skip path — no warn.
+    expect(mockLogWarn).not.toHaveBeenCalled();
+  });
+
+  it("returns null when the row exists but org_id is null", async () => {
+    // Slack installations can exist without an org binding (e.g. an
+    // install that hasn't completed onboarding). Treat as unknown.
+    mockInternalQuery.mockImplementation(async () => [{ org_id: null }]);
+    const resolver = createSlackWorkspaceIdResolver();
+    const out = await resolver(makeEvent({ raw: { team_id: "T-unbound" } }));
+    expect(out).toBeNull();
+  });
+
+  it("returns null + logs warn when the DB query throws", async () => {
+    mockInternalQuery.mockImplementation(async () => {
+      throw new Error("connection refused");
+    });
+    const resolver = createSlackWorkspaceIdResolver();
+    const out = await resolver(makeEvent({ raw: { team_id: "T-down" } }));
+    expect(out).toBeNull();
+
+    expect(mockLogWarn).toHaveBeenCalledTimes(1);
+    const [payload, message] = mockLogWarn.mock.calls[0] as [
+      Record<string, unknown>,
+      string,
+    ];
+    expect(payload.teamId).toBe("T-down");
+    expect(payload.err).toBe("connection refused");
+    expect(message).toContain("slack_installations");
+  });
+
+  it("includes the pg error `code` on the warn payload", async () => {
+    const err = Object.assign(new Error("undefined table"), {
+      code: "42P01",
+    });
+    mockInternalQuery.mockImplementation(async () => {
+      throw err;
+    });
+    const resolver = createSlackWorkspaceIdResolver();
+    await resolver(makeEvent({ raw: { team_id: "T-x" } }));
+
+    const [payload] = mockLogWarn.mock.calls[0] as [
+      Record<string, unknown>,
+    ];
+    expect(payload.code).toBe("42P01");
+  });
+
+  it("returns null when the internal DB is unavailable", async () => {
+    mockHasInternalDB.mockImplementation(() => false);
+    const resolver = createSlackWorkspaceIdResolver();
+    const out = await resolver(makeEvent({ raw: { team_id: "T-x" } }));
+    expect(out).toBeNull();
+    expect(mockInternalQuery).not.toHaveBeenCalled();
+  });
+
+  it("never throws — defensive contract", async () => {
+    // Even with the DB layer wired to throw, the resolver must
+    // resolve (returning null), never reject. The chat plugin's
+    // safe-wrapper provides defence in depth, but a clean resolver
+    // returns null on every error path so warn rows line up with
+    // rejected events.
+    mockInternalQuery.mockImplementation(async () => {
+      throw new Error("boom");
+    });
+    const resolver = createSlackWorkspaceIdResolver();
+    await expect(
+      resolver(makeEvent({ raw: { team_id: "T-x" } })),
+    ).resolves.toBeNull();
+  });
+});

--- a/packages/api/src/lib/proactive/enabled-gate.ts
+++ b/packages/api/src/lib/proactive/enabled-gate.ts
@@ -78,26 +78,35 @@ export type ProactiveGateRuntime = ManagedRuntime.ManagedRuntime<
 >;
 
 /**
- * Per-workspace `isEnabled` callback returned by
+ * Per-call `isEnabled` callback returned by
  * `createProactiveEnabledGate`. Satisfies the plugin-side
- * `ProactiveGateFn` (`() => Promise<boolean>`); also carries a
- * test-only `__reset()` hook that clears the per-closure enterprise
- * cache. Per-process today — if the EE roadmap adds runtime license
- * activation, hook `__reset` into the config-reload path so the gate
- * doesn't stay closed against the new license state.
+ * `ProactiveGateFn` (`(workspaceId: string) => Promise<boolean>`); also
+ * carries a test-only `__reset()` hook that clears the per-closure
+ * enterprise cache.
+ *
+ * Post-#2620 multi-tenant refactor: the closure is bound ONCE per
+ * process (was once per workspace pre-refactor) — the EE check is
+ * still per-process-cacheable because the license doesn't flip without
+ * a restart, but the workspace SELECT now reads the per-call
+ * `workspaceId` argument and re-runs every call.
+ *
+ * If the EE roadmap adds runtime license activation, hook `__reset`
+ * into the config-reload path so the gate doesn't stay closed against
+ * the new license state.
  */
-export type ProactiveEnabledGate = (() => Promise<boolean>) & {
+export type ProactiveEnabledGate = ((workspaceId: string) => Promise<boolean>) & {
   /** @internal Test-only: clears the per-closure enterprise cache. */
   __reset: () => void;
 };
 
 /**
- * Build a per-workspace `isEnabled` callback for the proactive listener.
+ * Build the proactive listener's `isEnabled` callback.
  *
  * The returned closure satisfies the plugin-side `ProactiveGateFn`
- * (`() => Promise<boolean>` — see
- * `plugins/chat/src/proactive/types.ts`). Bind one per workspace at
- * plugin boot; the closure carries its own enterprise-result cache.
+ * (`(workspaceId: string) => Promise<boolean>` — see
+ * `plugins/chat/src/proactive/types.ts`). Post-#2620 the factory takes
+ * no `workspaceId` argument — `workspaceId` is per-call, so one closure
+ * serves N tenants in the same process.
  *
  * Returns `true` iff BOTH:
  *   - Enterprise is loaded (Tag's `requireEnabled` doesn't fail with
@@ -105,10 +114,15 @@ export type ProactiveEnabledGate = (() => Promise<boolean>) & {
  *   - The workspace has `workspace_proactive_config.enabled = true`.
  *
  * Never throws. Every failure → `false` + structured `log.warn`.
+ *
+ * Pre-#2620 the factory took `workspaceId` so the SELECT closed over
+ * a constant; that's what made the listener single-tenant. The
+ * enterprise-result cache stays per-closure (still a process-lifetime
+ * constant — license flips require a restart); the workspace SELECT
+ * re-runs per call reading the arg, same semantics as before.
  */
 export function createProactiveEnabledGate(
   runtime: ProactiveGateRuntime,
-  workspaceId: string,
 ): ProactiveEnabledGate {
   // Cached enterprise result. `undefined` ⇒ not yet checked; `true` /
   // `false` ⇒ resolved (and never re-resolved for the lifetime of this
@@ -116,7 +130,9 @@ export function createProactiveEnabledGate(
   // shot `false`; SaaS-EE makes it a one-shot `true`.
   let enterpriseEnabled: boolean | undefined = undefined;
 
-  const isProactiveEnabled = async function (): Promise<boolean> {
+  const isProactiveEnabled = async function (
+    workspaceId: string,
+  ): Promise<boolean> {
     // ── 1. Enterprise check (cached) ─────────────────────────────
     if (enterpriseEnabled === undefined) {
       const program = Effect.gen(function* () {

--- a/packages/api/src/lib/proactive/enabled-gate.ts
+++ b/packages/api/src/lib/proactive/enabled-gate.ts
@@ -12,6 +12,16 @@
  * (`listener.ts:329`, `:612`, ...), so the gate is on the hot path —
  * potentially several calls per second on busy workspaces.
  *
+ * **Registration-probe contract (post-#2620).** The chat plugin's
+ * `registerProactiveListener` calls `config.isEnabled("")` once at boot
+ * to answer "is the listener even possible in this process?" — there's
+ * no tenant yet. An empty `workspaceId` argument is the agreed sentinel
+ * for that probe: this gate returns the enterprise-cached value and
+ * skips the workspace SELECT (which would otherwise resolve `false` on
+ * a row-missing lookup with `$1 = ''` and silently mis-gate the
+ * listener on SaaS where EE is enabled). Real per-event calls always
+ * pass an actual workspaceId, so they run the SELECT as usual.
+ *
  * Two-tier resolution:
  *   1. **Enterprise check, cached per-closure.** `ProactiveGate.requireEnabled`
  *      reads `process.env.ATLAS_ENTERPRISE_ENABLED` plus the optional
@@ -21,13 +31,14 @@
  *      ONCE per closure and cache the boolean — re-yielding on every
  *      message would pay an Effect runtime hop just to read a process-
  *      lifetime constant.
- *   2. **Workspace check, re-read every call.** Admins toggle
- *      `workspace_proactive_config.enabled` at runtime via
+ *   2. **Workspace check, re-read every call (real workspaceIds only).**
+ *      Admins toggle `workspace_proactive_config.enabled` at runtime via
  *      `/admin/proactive-chat`; the kill-switch contract is that the next
  *      classified message must respect the new value. Cache would defeat
  *      that, so the SELECT runs on every call. The query hits the
  *      `workspace_id` primary key and is index-only — costs a small ms
- *      regardless.
+ *      regardless. The registration probe (empty `workspaceId`) skips
+ *      this step.
  *
  * Failure modes — every failure path returns `false` (fail-closed) and
  * never throws into the SDK event loop:
@@ -194,6 +205,18 @@ export function createProactiveEnabledGate(
     }
 
     if (!enterpriseEnabled) return false;
+
+    // ── 1.5. Registration-probe short-circuit ────────────────────
+    // The chat plugin's `registerProactiveListener` calls this gate
+    // once at boot with `workspaceId = ""` to answer "is the listener
+    // even possible in this process?" — there's no tenant yet. Skip
+    // the workspace SELECT: with `$1 = ''` it returns 0 rows and
+    // resolves to `false`, which would silently mis-gate the listener
+    // on SaaS where EE is enabled. Real per-event calls always pass
+    // an actual id and fall through to the SELECT.
+    if (workspaceId === "") {
+      return true;
+    }
 
     // ── 2. Workspace check (re-read every call) ──────────────────
     try {

--- a/packages/api/src/lib/proactive/workspace-config-loader.ts
+++ b/packages/api/src/lib/proactive/workspace-config-loader.ts
@@ -1,0 +1,219 @@
+/**
+ * Per-event workspace + channel config loaders for the proactive
+ * listener (#2620).
+ *
+ * The chat plugin's `registerProactiveListener` calls these once per
+ * event (after `resolveWorkspaceId` succeeds) so the master toggle /
+ * sensitivity / classifier mode / per-channel allow-list reflect the
+ * current admin state without a process restart.
+ *
+ * Pre-#2620 the plugin baked a static `workspace` + `channelConfigs`
+ * object at registration time; SaaS routes Slack events from N tenants
+ * through one Chat instance, so a baked-in config silently served the
+ * wrong tenant. The fix lifts both into per-event fetchers; this module
+ * is the host-side implementation backed by `workspace_proactive_config`
+ * + `channel_proactive_config` (migration `0075_proactive_chat_config.sql`).
+ *
+ * Contract (from `plugins/chat/src/proactive/types.ts`):
+ *
+ *   - `getWorkspaceProactiveConfig(workspaceId)` returns the workspace's
+ *     row as `{ enabled, sensitivity, classifierMode }` or `null` when
+ *     no row exists (treat as "not opted in" — the listener short-
+ *     circuits silently).
+ *   - `getChannelProactiveConfigs(workspaceId)` returns the workspace's
+ *     per-channel overrides as a flat array. Empty array means "no
+ *     overrides"; the listener falls back to workspace defaults.
+ *
+ * Both functions never throw — failures resolve as `null` / `[]` so a
+ * registry hiccup degrades to "not opted in" / "no overrides" instead
+ * of crashing the Chat SDK event loop. The plugin's safe-wrapper
+ * (`listener.ts:safeGetWorkspaceConfig` / `safeGetChannelConfigs`)
+ * provides defence in depth, but we still fail closed here so the
+ * structured `log.warn` rows line up cleanly with rejected events.
+ *
+ * @module
+ */
+
+import { hasInternalDB, internalQuery } from "@atlas/api/lib/db/internal";
+import { createLogger } from "@atlas/api/lib/logger";
+import type { SensitivityPreset } from "@useatlas/types";
+
+const log = createLogger("proactive:workspace-config-loader");
+
+/**
+ * Workspace-level proactive settings.
+ *
+ * Mirrors the plugin-side `WorkspaceProactiveConfig` from
+ * `plugins/chat/src/proactive/types.ts`. Kept structural (rather than
+ * importing from `@useatlas/chat`) so consumers that wire this loader
+ * into the listener don't pull the plugin's full dependency tree into
+ * `lib/`. The shape stays in lockstep with the plugin via the schema
+ * smoke test in `workspace-config-loader.test.ts`.
+ */
+export interface WorkspaceProactiveConfig {
+  /** Master toggle — when false, the listener never reacts. */
+  enabled: boolean;
+  /** Confidence-threshold preset. */
+  sensitivity: SensitivityPreset;
+  /** Classifier mode. */
+  classifierMode: "regex-prefilter" | "classify-all";
+}
+
+/**
+ * Per-channel override row.
+ *
+ * Mirrors the plugin-side `ChannelProactiveConfig`. `sensitivity` is
+ * optional — when absent, the listener uses the workspace default.
+ */
+export interface ChannelProactiveConfig {
+  channelId: string;
+  /** When false, the channel is denied (Atlas never interjects). */
+  allow: boolean;
+  /** Optional sensitivity override. */
+  sensitivity?: SensitivityPreset;
+}
+
+/**
+ * Raw shape returned by the workspace SELECT.
+ *
+ * The index signature satisfies `internalQuery`'s
+ * `T extends Record<string, unknown>` constraint without widening the
+ * declared columns.
+ */
+interface RawWorkspaceRow {
+  enabled: boolean;
+  sensitivity: string;
+  classifier_mode: string;
+  [key: string]: unknown;
+}
+
+/** Raw shape returned by the channels SELECT. */
+interface RawChannelRow {
+  channel_id: string;
+  allow: boolean;
+  sensitivity: string | null;
+  [key: string]: unknown;
+}
+
+/**
+ * Narrow the raw `sensitivity` column to the plugin's `SensitivityPreset`
+ * union. The DB check constraint (`chk_workspace_proactive_sensitivity`
+ * / `chk_channel_proactive_sensitivity`) enforces the same values, so
+ * a non-matching value here would be a schema-drift bug worth surfacing.
+ * Falls back to `"balanced"` defensively so a drift doesn't crash the
+ * listener.
+ */
+function toSensitivity(raw: string | null): SensitivityPreset {
+  if (raw === "cautious" || raw === "balanced" || raw === "eager") {
+    return raw;
+  }
+  return "balanced";
+}
+
+/**
+ * Narrow `classifier_mode` to the plugin's enum. DB check constraint
+ * enforces the same values; falls back to `"regex-prefilter"`
+ * defensively so a drift doesn't crash the listener.
+ */
+function toClassifierMode(
+  raw: string,
+): "regex-prefilter" | "classify-all" {
+  return raw === "classify-all" ? "classify-all" : "regex-prefilter";
+}
+
+/**
+ * Fetch the per-workspace proactive config row.
+ *
+ * Returns `null` when no row exists for the workspace (the workspace
+ * hasn't opted in to proactive mode — listener short-circuits). Returns
+ * `null` (with `log.warn`) on DB failure — fail-closed by default so a
+ * blip silently disables the listener rather than crashing the SDK
+ * event loop with an unhandled rejection.
+ */
+export async function getWorkspaceProactiveConfig(
+  workspaceId: string,
+): Promise<WorkspaceProactiveConfig | null> {
+  if (!hasInternalDB()) return null;
+  try {
+    const rows = await internalQuery<RawWorkspaceRow>(
+      `SELECT enabled, sensitivity, classifier_mode
+         FROM workspace_proactive_config
+        WHERE workspace_id = $1
+        LIMIT 1`,
+      [workspaceId],
+    );
+    if (rows.length === 0) return null;
+    const row = rows[0]!;
+    return {
+      enabled: row.enabled === true,
+      sensitivity: toSensitivity(row.sensitivity),
+      classifierMode: toClassifierMode(row.classifier_mode),
+    };
+  } catch (err) {
+    const code =
+      err instanceof Error && "code" in err
+        ? { code: (err as { code: unknown }).code }
+        : {};
+    log.warn(
+      {
+        workspaceId,
+        err: err instanceof Error ? err.message : String(err),
+        ...code,
+      },
+      "Proactive workspace-config loader: workspace_proactive_config read failed — treating as not opted in",
+    );
+    return null;
+  }
+}
+
+/**
+ * Fetch the per-channel proactive override rows for the workspace.
+ *
+ * Returns an empty array when no overrides are configured (the listener
+ * falls back to workspace defaults). Returns `[]` (with `log.warn`) on
+ * DB failure — fail-closed so the listener treats a hiccup as "no
+ * overrides" rather than crashing.
+ *
+ * The rows are returned in `channel_id ASC` order so the listener's
+ * `Array.prototype.find` walk is stable for testing/log analysis (the
+ * actual lookup is O(N) but channel-config arrays are short in
+ * practice — a handful of overrides per workspace).
+ */
+export async function getChannelProactiveConfigs(
+  workspaceId: string,
+): Promise<ChannelProactiveConfig[]> {
+  if (!hasInternalDB()) return [];
+  try {
+    const rows = await internalQuery<RawChannelRow>(
+      `SELECT channel_id, allow, sensitivity
+         FROM channel_proactive_config
+        WHERE workspace_id = $1
+        ORDER BY channel_id ASC`,
+      [workspaceId],
+    );
+    return rows.map((row) => {
+      const out: ChannelProactiveConfig = {
+        channelId: row.channel_id,
+        allow: row.allow === true,
+      };
+      if (row.sensitivity !== null && row.sensitivity !== undefined) {
+        out.sensitivity = toSensitivity(row.sensitivity);
+      }
+      return out;
+    });
+  } catch (err) {
+    const code =
+      err instanceof Error && "code" in err
+        ? { code: (err as { code: unknown }).code }
+        : {};
+    log.warn(
+      {
+        workspaceId,
+        err: err instanceof Error ? err.message : String(err),
+        ...code,
+      },
+      "Proactive workspace-config loader: channel_proactive_config read failed — treating as no overrides",
+    );
+    return [];
+  }
+}

--- a/packages/api/src/lib/proactive/workspace-id-resolver.ts
+++ b/packages/api/src/lib/proactive/workspace-id-resolver.ts
@@ -1,0 +1,133 @@
+/**
+ * Per-event workspace resolution for the proactive listener (#2620).
+ *
+ * The chat plugin's `registerProactiveListener` calls
+ * `config.resolveWorkspaceId({ adapter, thread, message })` at the top
+ * of every event handler so it can attribute meter rows / pause checks /
+ * quota lookups to the right tenant. SaaS routes Slack events from N
+ * tenants through one Chat instance; pre-#2620 a baked-in workspaceId
+ * would have stamped every event with the same tenant.
+ *
+ * This module ships the Slack-platform resolver — the only platform on
+ * the SaaS roadmap today (per the #2620 spec). Other platforms (Teams,
+ * Discord, ...) plug in their own resolver when the time comes; each
+ * just needs to extract the tenant identifier from `message.raw` and
+ * look it up against the internal DB.
+ *
+ * Contract (from `plugins/chat/src/proactive/types.ts:ResolveWorkspaceIdFn`):
+ *
+ *   - Returns the Atlas workspace id (`org_id` in the internal DB) for
+ *     the tenant that sent this event, or `null` when the event doesn't
+ *     belong to any known tenant (unrecognized `team_id`, missing raw
+ *     payload, non-matching adapter, ...). On `null` the listener
+ *     silently skips: no classification, no meter row, no kill-switch
+ *     read.
+ *   - Never throws. Implementation failures should resolve as `null` so
+ *     the listener fails closed (skip) without crashing the SDK loop —
+ *     the wrapper inside `listener.ts:safeResolveWorkspace` provides a
+ *     defensive try/catch, but a clean resolver still returns `null` on
+ *     every error path.
+ *
+ * The lookup table is `slack_installations` (defined in
+ * `0000_baseline.sql:74` — `team_id PRIMARY KEY, org_id TEXT`). The
+ * issue body refers to "`slack_integrations`" but the actual table in
+ * the migrations is `slack_installations`; we use the canonical table
+ * name here.
+ *
+ * @module
+ */
+
+import { hasInternalDB, internalQuery } from "@atlas/api/lib/db/internal";
+import { createLogger } from "@atlas/api/lib/logger";
+
+const log = createLogger("proactive:workspace-id-resolver");
+
+/**
+ * Structural shape of the resolver event passed by the chat plugin.
+ * Kept structural (the `chat` npm package is not a dependency of
+ * `@atlas/api`) so the host helper can sit under `lib/proactive/`
+ * without pulling the plugin's full type surface in. The chat plugin's
+ * `ResolveWorkspaceIdFn` is the strict type; this is the minimum surface
+ * the Slack resolver actually reads from the event.
+ */
+interface ResolverEvent {
+  adapter: { name?: string } | undefined;
+  thread: unknown;
+  message: { raw?: unknown } | undefined;
+}
+
+/**
+ * Build the Slack-platform workspace resolver.
+ *
+ * Maps the inbound Slack `team_id` (from the raw event payload) to the
+ * Atlas workspace id by reading `slack_installations.org_id`. Behaves
+ * defensively at every step:
+ *
+ *   - Non-Slack adapter → `null` (the caller may pass events from
+ *     multiple platforms through the same listener).
+ *   - Missing `team_id` / `team` in the raw payload → `null`. Slack
+ *     events always carry `team_id` for `message`-type events; defence
+ *     against synthetic events from tests / unusual webhooks.
+ *   - DB read failure → `null` + structured `log.warn` so an operator
+ *     triaging missing meter rows can spot the resolver outage in logs.
+ *   - Row missing (`team_id` not installed) → `null`. Treated as
+ *     "unknown tenant"; matches the behaviour the listener relies on.
+ *
+ * Never throws. The chat plugin's safe-wrapper catches throws as a
+ * defence in depth, but a clean resolver returns `null` on every error
+ * path so the listener's behaviour stays observable in logs (warn rows
+ * line up with rejected events).
+ */
+export function createSlackWorkspaceIdResolver(): (
+  event: ResolverEvent,
+) => Promise<string | null> {
+  return async (event) => {
+    if (event.adapter?.name !== "slack") return null;
+
+    // Slack `team_id` lives at the top level of the raw event for
+    // channel messages, app mentions, and reactions; `team` is the
+    // older alias still used on some webhook shapes. Accept either.
+    const raw = event.message?.raw as
+      | { team_id?: string; team?: string }
+      | undefined;
+    const teamId = raw?.team_id ?? raw?.team;
+    if (!teamId) return null;
+
+    if (!hasInternalDB()) {
+      // Self-hosted / no internal DB → the listener can't resolve any
+      // tenant, so silently skip. The chat plugin's gate (`isEnabled`)
+      // already returns false in this configuration, so we won't be
+      // reached in practice — defensive return for completeness.
+      return null;
+    }
+
+    try {
+      const rows = await internalQuery<{ org_id: string | null }>(
+        `SELECT org_id
+           FROM slack_installations
+          WHERE team_id = $1
+          LIMIT 1`,
+        [teamId],
+      );
+      if (rows.length === 0) return null;
+      return rows[0]!.org_id ?? null;
+    } catch (err) {
+      // `pg`-shaped errors carry a `.code` (e.g. `57P01` admin shutdown,
+      // `42P01` undefined-table); spread onto the warn payload so an
+      // operator can distinguish a missing migration from a DB blip.
+      const code =
+        err instanceof Error && "code" in err
+          ? { code: (err as { code: unknown }).code }
+          : {};
+      log.warn(
+        {
+          teamId,
+          err: err instanceof Error ? err.message : String(err),
+          ...code,
+        },
+        "Proactive workspace resolver: slack_installations lookup failed — treating as unknown tenant",
+      );
+      return null;
+    }
+  };
+}

--- a/plugins/chat/src/bridge.test.ts
+++ b/plugins/chat/src/bridge.test.ts
@@ -3246,17 +3246,16 @@ describe("ProactiveConfig schema", () => {
       executeQuery: () =>
         Promise.resolve({ answer: "", sql: [], data: [], steps: 0, usage: { totalTokens: 0 } }),
       proactive: {
+        resolveWorkspaceId: async () => "ws-1",
         isEnabled: () => true,
         classify: async () => ({ isQuestion: true, confidence: 0.9 }),
-        workspace: {
+        getWorkspaceConfig: async () => ({
           enabled: true,
           sensitivity: "balanced",
           classifierMode: "regex-prefilter",
-        },
+        }),
+        getChannelConfigs: async () => [],
         channelAllowlist: ["C-allowed"],
-        channelConfigs: {
-          "C-allowed": { channelId: "C-allowed", allow: true },
-        },
       },
     });
 
@@ -3273,20 +3272,22 @@ describe("ProactiveConfig schema", () => {
       executeQuery: () =>
         Promise.resolve({ answer: "", sql: [], data: [], steps: 0, usage: { totalTokens: 0 } }),
       proactive: {
+        resolveWorkspaceId: async () => "ws-1",
         isEnabled: "not-a-function",
         classify: async () => ({ isQuestion: false, confidence: 0 }),
-        workspace: {
+        getWorkspaceConfig: async () => ({
           enabled: true,
           sensitivity: "balanced",
           classifierMode: "regex-prefilter",
-        },
+        }),
+        getChannelConfigs: async () => [],
       },
     });
 
     expect(result.success).toBe(false);
   });
 
-  it("rejects invalid sensitivity preset", async () => {
+  it("rejects when proactive.resolveWorkspaceId is missing", async () => {
     const { ChatConfigSchema } = await import("./config");
 
     const result = ChatConfigSchema.safeParse({
@@ -3296,13 +3297,15 @@ describe("ProactiveConfig schema", () => {
       executeQuery: () =>
         Promise.resolve({ answer: "", sql: [], data: [], steps: 0, usage: { totalTokens: 0 } }),
       proactive: {
+        // resolveWorkspaceId deliberately omitted
         isEnabled: () => true,
         classify: async () => ({ isQuestion: false, confidence: 0 }),
-        workspace: {
+        getWorkspaceConfig: async () => ({
           enabled: true,
-          sensitivity: "extreme",
+          sensitivity: "balanced",
           classifierMode: "regex-prefilter",
-        },
+        }),
+        getChannelConfigs: async () => [],
       },
     });
 

--- a/plugins/chat/src/bridge.ts
+++ b/plugins/chat/src/bridge.ts
@@ -966,41 +966,83 @@ export function createChatBridge(
     // feedback collector before falling through to the question flow.
     if (config.proactive && proactiveRecentAnswers) {
       try {
-        const handled = await handleProactiveFeedbackSlash({
-          text: event.text,
-          channelId: event.channel.id,
-          asker: {
-            platform: event.adapter?.name ?? config.proactive.platform ?? "unknown",
-            externalUserId: event.user.userId,
-            userName: event.user.userName,
-          },
-          config: {
-            isEnabled: config.proactive.isEnabled,
-            classify: config.proactive.classify,
-            workspace: config.proactive.workspace,
-            channelAllowlist: config.proactive.channelAllowlist,
-            channelConfigs: config.proactive.channelConfigs,
-            userResolver: config.proactive.userResolver,
-            executeQueryProactive: config.proactive.executeQueryProactive,
-            linkUrl: config.proactive.linkUrl,
-            platform: config.proactive.platform,
-            feedbackCollector: config.proactive.feedbackCollector,
-            slashCommandName: config.slashCommandName,
-          },
-          log,
-          recentAnswers: proactiveRecentAnswers,
-        });
-        if (handled) {
+        // Post-#2620 multi-tenant: resolve the workspace for this slash
+        // event before delegating. The slash event doesn't carry the
+        // same Message shape onNewMessage does — we synthesize a
+        // minimal shape from the adapter + raw payload, which is what
+        // the Slack-platform resolver uses anyway (`raw.team_id`).
+        const resolveAdapter = event.adapter;
+        let slashWorkspaceId: string | null = null;
+        if (resolveAdapter) {
           try {
-            await event.channel.postEphemeral(
-              event.user,
-              { markdown: "Thanks for the feedback." },
-              { fallbackToDM: false },
+            slashWorkspaceId = await config.proactive.resolveWorkspaceId({
+              adapter: resolveAdapter,
+              // Slash events have no thread; the resolver only reads
+              // `adapter.name` + `message.raw`, so a null-ish thread is
+              // fine. Cast for the same reason the action/modal handlers
+              // do — the resolver contract is platform-determined.
+              thread: undefined as unknown as Parameters<
+                typeof config.proactive.resolveWorkspaceId
+              >[0]["thread"],
+              message: {
+                id: "",
+                raw: event.raw,
+              } as unknown as Parameters<
+                typeof config.proactive.resolveWorkspaceId
+              >[0]["message"],
+            });
+          } catch (resolveErr) {
+            log.warn(
+              {
+                err:
+                  resolveErr instanceof Error
+                    ? resolveErr
+                    : new Error(String(resolveErr)),
+              },
+              "Proactive feedback slash: resolveWorkspaceId threw — falling back to standard question flow",
             );
-          } catch {
-            // Ack is best-effort.
           }
-          return;
+        }
+
+        if (slashWorkspaceId) {
+          const handled = await handleProactiveFeedbackSlash({
+            text: event.text,
+            channelId: event.channel.id,
+            workspaceId: slashWorkspaceId,
+            asker: {
+              platform: event.adapter?.name ?? config.proactive.platform ?? "unknown",
+              externalUserId: event.user.userId,
+              userName: event.user.userName,
+            },
+            config: {
+              resolveWorkspaceId: config.proactive.resolveWorkspaceId,
+              isEnabled: config.proactive.isEnabled,
+              classify: config.proactive.classify,
+              getWorkspaceConfig: config.proactive.getWorkspaceConfig,
+              channelAllowlist: config.proactive.channelAllowlist,
+              getChannelConfigs: config.proactive.getChannelConfigs,
+              userResolver: config.proactive.userResolver,
+              executeQueryProactive: config.proactive.executeQueryProactive,
+              linkUrl: config.proactive.linkUrl,
+              platform: config.proactive.platform,
+              feedbackCollector: config.proactive.feedbackCollector,
+              slashCommandName: config.slashCommandName,
+            },
+            log,
+            recentAnswers: proactiveRecentAnswers,
+          });
+          if (handled) {
+            try {
+              await event.channel.postEphemeral(
+                event.user,
+                { markdown: "Thanks for the feedback." },
+                { fallbackToDM: false },
+              );
+            } catch {
+              // Ack is best-effort.
+            }
+            return;
+          }
         }
       } catch (err) {
         log.warn(
@@ -1571,29 +1613,35 @@ export function createChatBridge(
     );
   });
 
-  // --- Proactive listener (slices #2292, #2293, #2298) ---
+  // --- Proactive listener (slices #2292, #2293, #2298; multi-tenant #2620) ---
   // Only registers when proactive config is present AND the host-supplied
-  // gate (`isEnterpriseEnabled() && workspaceFlag`) returns true. Failures
-  // never block the rest of the bridge from coming up.
+  // gate (`isEnterpriseEnabled()`) returns true at boot. Failures never
+  // block the rest of the bridge from coming up.
+  //
+  // Post-#2620: `workspaceId` / `workspace` / `channelConfigs` are
+  // resolved per event via `resolveWorkspaceId` / `getWorkspaceConfig` /
+  // `getChannelConfigs` rather than baked statically — the same Chat
+  // instance can now serve N tenants without cross-pollination.
   let proactiveRecentAnswers: RecentAnswers | null = null;
   if (config.proactive) {
     const proactiveConfig = config.proactive;
     Promise.resolve()
       .then(async () => {
         const handle = await registerProactiveListener(chat, log, {
+          // Per-event tenant + config resolution (#2620).
+          resolveWorkspaceId: proactiveConfig.resolveWorkspaceId,
+          getWorkspaceConfig: proactiveConfig.getWorkspaceConfig,
+          getChannelConfigs: proactiveConfig.getChannelConfigs,
           isEnabled: proactiveConfig.isEnabled,
           classify: proactiveConfig.classify,
-          workspace: proactiveConfig.workspace,
           channelAllowlist: proactiveConfig.channelAllowlist,
-          channelConfigs: proactiveConfig.channelConfigs,
           userResolver: proactiveConfig.userResolver,
           executeQueryProactive: proactiveConfig.executeQueryProactive,
           linkUrl: proactiveConfig.linkUrl,
           platform: proactiveConfig.platform,
           feedbackCollector: proactiveConfig.feedbackCollector,
           slashCommandName: config.slashCommandName,
-          // Kill switch (#2295).
-          workspaceId: proactiveConfig.workspaceId,
+          // Kill switch (#2295). `workspaceId` is now per-event (#2620).
           isPaused: proactiveConfig.isPaused,
           onPauseRequest: proactiveConfig.onPauseRequest,
           // AnswerMeter (#2296) — shared callback also covers

--- a/plugins/chat/src/bridge.ts
+++ b/plugins/chat/src/bridge.ts
@@ -1038,8 +1038,11 @@ export function createChatBridge(
                 { markdown: "Thanks for the feedback." },
                 { fallbackToDM: false },
               );
-            } catch {
-              // Ack is best-effort.
+            } catch (ackErr) {
+              log.debug(
+                { err: ackErr instanceof Error ? ackErr : new Error(String(ackErr)) },
+                "Proactive feedback slash ack postEphemeral failed — feedback already recorded",
+              );
             }
             return;
           }

--- a/plugins/chat/src/config.ts
+++ b/plugins/chat/src/config.ts
@@ -10,14 +10,15 @@ import { z } from "zod";
 import type { StreamChunk } from "chat";
 import type { ReactionConfig } from "./features/reactions";
 import type {
-  ChannelProactiveConfig,
+  GetChannelConfigsFn,
   GetPublicDatasetFn,
   GetQuotaStatusFn,
+  GetWorkspaceConfigFn,
   LLMClassifierFn,
   OnPauseRequestFn,
   ProactiveGateFn,
   ProactiveMeterEventFn,
-  WorkspaceProactiveConfig,
+  ResolveWorkspaceIdFn,
 } from "./proactive/types";
 import type { IsPausedFn } from "./proactive/pause";
 import type {
@@ -423,19 +424,41 @@ export interface ChatPluginConfig {
 
 /** Proactive chat configuration. */
 export interface ProactiveConfig {
-  /** Gate: returns true when proactive mode is allowed. */
+  /**
+   * Per-event workspace resolution (#2620). The bridge passes this to
+   * the listener so every event handler resolves which tenant the
+   * event belongs to before any classification / meter / quota work
+   * happens. Returning `null` is a silent skip.
+   *
+   * Host wiring (Slack-first): see
+   * `packages/api/src/lib/proactive/workspace-id-resolver.ts:createSlackWorkspaceIdResolver`.
+   */
+  resolveWorkspaceId: ResolveWorkspaceIdFn;
+  /**
+   * Gate: returns true when proactive mode is allowed for the given
+   * workspace. Per-call workspaceId (post-#2620 multi-tenant refactor).
+   */
   isEnabled: ProactiveGateFn;
   /** LLM classifier injected from the host. */
   classify: LLMClassifierFn;
-  /** Workspace-level settings (master toggle, sensitivity, classifier mode). */
-  workspace: WorkspaceProactiveConfig;
+  /**
+   * Per-event fetcher for workspace-level proactive settings (master
+   * toggle, sensitivity, classifier mode). Replaces the pre-#2620
+   * static `workspace` field — the listener calls this once per event
+   * after `resolveWorkspaceId` succeeds.
+   */
+  getWorkspaceConfig: GetWorkspaceConfigFn;
   /**
    * Optional explicit channel allowlist. If omitted, the listener reads
    * `ATLAS_PROACTIVE_CHANNELS` (comma-separated channel IDs).
    */
   channelAllowlist?: string[];
-  /** Per-channel overrides keyed by channel ID. */
-  channelConfigs?: Record<string, ChannelProactiveConfig>;
+  /**
+   * Per-event fetcher for per-channel overrides. Replaces the pre-#2620
+   * static `channelConfigs` map — the listener calls this once per
+   * event and scans the returned array linearly.
+   */
+  getChannelConfigs: GetChannelConfigsFn;
 
   // ---- Slice #2293 additions: reaction-to-answer flow ----
 
@@ -495,12 +518,11 @@ export interface ProactiveConfig {
   //  shared callback covers the public_refused events from #2297.)
 
   // ---- Slice #2295 additions: kill switch + per-user opt-out ----
+  //
+  // Post-#2620 multi-tenant: workspaceId is resolved per event via
+  // `resolveWorkspaceId` (above) and threaded into these callbacks at
+  // the call site. The static `workspaceId?` field was removed.
 
-  /**
-   * Workspace id threaded into the kill-switch callbacks. Required
-   * when `isPaused` or `onPauseRequest` is set.
-   */
-  workspaceId?: string;
   /**
    * Pause-registry read API. Host backs this with the API package's
    * `PauseRegistry` so the listener consults it BEFORE classification.
@@ -768,31 +790,34 @@ const ReactionConfigSchema = z
   })
   .optional();
 
-const SensitivityPresetSchema = z.enum(["cautious", "balanced", "eager"]);
-
-const ProactiveWorkspaceConfigSchema = z.object({
-  enabled: z.boolean(),
-  sensitivity: SensitivityPresetSchema,
-  classifierMode: z.enum(["regex-prefilter", "classify-all"]),
-});
-
-const ProactiveChannelConfigSchema = z.object({
-  channelId: z.string().min(1),
-  allow: z.boolean(),
-  sensitivity: SensitivityPresetSchema.optional(),
-});
+// Pre-#2620 these wrapped the static `workspace` / `channelConfigs`
+// fields on `ProactiveConfig`. They were dropped when those fields
+// migrated to per-event fetchers — the wire shapes still live in
+// `proactive/types.ts` (`WorkspaceProactiveConfig`,
+// `ChannelProactiveConfig`) and the host now validates them at the
+// /admin/proactive-chat route + DB-constraint layer rather than here.
+//   const SensitivityPresetSchema = z.enum(["cautious", "balanced", "eager"]);
 
 const ProactiveConfigSchema = z
   .object({
+    // Per-event workspace resolution (#2620). Required.
+    resolveWorkspaceId: zCallback<ResolveWorkspaceIdFn>(
+      "proactive.resolveWorkspaceId must be a function returning Promise<string | null>",
+    ),
     isEnabled: zCallback<ProactiveGateFn>(
-      "proactive.isEnabled must be a function returning boolean | Promise<boolean>",
+      "proactive.isEnabled must be a function (workspaceId) => boolean | Promise<boolean>",
     ),
     classify: zCallback<LLMClassifierFn>(
       "proactive.classify must be a function returning Promise<ClassificationResult>",
     ),
-    workspace: ProactiveWorkspaceConfigSchema,
+    // Per-event workspace + channel config fetchers (#2620). Required.
+    getWorkspaceConfig: zCallback<GetWorkspaceConfigFn>(
+      "proactive.getWorkspaceConfig must be a function returning Promise<WorkspaceProactiveConfig | null>",
+    ),
     channelAllowlist: z.array(z.string().min(1)).optional(),
-    channelConfigs: z.record(z.string(), ProactiveChannelConfigSchema).optional(),
+    getChannelConfigs: zCallback<GetChannelConfigsFn>(
+      "proactive.getChannelConfigs must be a function returning Promise<ChannelProactiveConfig[]>",
+    ),
     userResolver: zCallback<ProactiveUserResolver>(
       "proactive.userResolver must be a function",
     ).optional(),
@@ -812,9 +837,8 @@ const ProactiveConfigSchema = z
     ).optional(),
     refusalCopy: z.string().min(1).max(1024).optional(),
     allowAnswerWhenEntitiesUnknown: z.boolean().optional(),
-    // Kill-switch wiring (#2295). All three optional so the legacy
-    // env-var allowlist mode (used by tests + dev) keeps working.
-    workspaceId: z.string().min(1).optional(),
+    // Kill-switch wiring (#2295). Both optional so the legacy env-var
+    // allowlist mode (used by tests + dev) keeps working.
     isPaused: zCallback<IsPausedFn>(
       "proactive.isPaused must be a function returning Promise<PauseDecision>",
     ).optional(),

--- a/plugins/chat/src/index.ts
+++ b/plugins/chat/src/index.ts
@@ -123,6 +123,8 @@ export type {
   FeedbackOutcome,
   FeedbackSlashParse,
   FeedbackSource,
+  GetChannelConfigsFn,
+  GetWorkspaceConfigFn,
   InterjectionAction,
   InterjectionDecision,
   IsPausedFn,
@@ -139,6 +141,7 @@ export type {
   ProactiveUserResolver,
   RecentAnswerEntry,
   ResolvedAsker,
+  ResolveWorkspaceIdFn,
   SensitivityPreset,
   WorkspaceProactiveConfig,
 } from "./proactive";

--- a/plugins/chat/src/proactive/__tests__/answerer.test.ts
+++ b/plugins/chat/src/proactive/__tests__/answerer.test.ts
@@ -27,7 +27,7 @@ const ASKER: ProactiveAsker = {
 describe("PendingAnswers", () => {
   it("records and consumes a single entry", () => {
     const reg = new PendingAnswers();
-    reg.record("T1", "M1", { text: "what was MRR last month?", asker: ASKER });
+    reg.record("T1", "M1", { text: "what was MRR last month?", asker: ASKER, workspaceId: "ws-1" });
     expect(reg.size()).toBe(1);
 
     const peek = reg.peek("T1", "M1");
@@ -42,7 +42,7 @@ describe("PendingAnswers", () => {
   it("expires entries past the TTL", () => {
     let now = 1_000_000;
     const reg = new PendingAnswers(PENDING_ANSWER_TTL_MS, 100, () => now);
-    reg.record("T1", "M1", { text: "q?", asker: ASKER });
+    reg.record("T1", "M1", { text: "q?", asker: ASKER, workspaceId: "ws-1" });
 
     now += PENDING_ANSWER_TTL_MS + 1;
     expect(reg.peek("T1", "M1")).toBeNull();
@@ -51,9 +51,9 @@ describe("PendingAnswers", () => {
 
   it("evicts the oldest entry when over the cap", () => {
     const reg = new PendingAnswers(PENDING_ANSWER_TTL_MS, 2);
-    reg.record("T1", "M1", { text: "first", asker: ASKER });
-    reg.record("T1", "M2", { text: "second", asker: ASKER });
-    reg.record("T1", "M3", { text: "third", asker: ASKER });
+    reg.record("T1", "M1", { text: "first", asker: ASKER, workspaceId: "ws-1" });
+    reg.record("T1", "M2", { text: "second", asker: ASKER, workspaceId: "ws-1" });
+    reg.record("T1", "M3", { text: "third", asker: ASKER, workspaceId: "ws-1" });
 
     expect(reg.peek("T1", "M1")).toBeNull();
     expect(reg.peek("T1", "M2")?.text).toBe("second");
@@ -63,8 +63,8 @@ describe("PendingAnswers", () => {
 
   it("namespaces entries by thread and message id", () => {
     const reg = new PendingAnswers();
-    reg.record("T1", "M1", { text: "a", asker: ASKER });
-    reg.record("T2", "M1", { text: "b", asker: ASKER });
+    reg.record("T1", "M1", { text: "a", asker: ASKER, workspaceId: "ws-1" });
+    reg.record("T2", "M1", { text: "b", asker: ASKER, workspaceId: "ws-1" });
     expect(reg.consume("T1", "M1")?.text).toBe("a");
     expect(reg.consume("T2", "M1")?.text).toBe("b");
   });
@@ -75,7 +75,7 @@ describe("PendingAnswers", () => {
 // ---------------------------------------------------------------------------
 
 describe("shouldAnswerOnReaction", () => {
-  const pending = { text: "q?", asker: ASKER, recordedAt: 0 };
+  const pending = { text: "q?", asker: ASKER, workspaceId: "ws-1", recordedAt: 0 };
 
   it("answers when a non-bot user adds the reaction to a known message", () => {
     const decision = shouldAnswerOnReaction({

--- a/plugins/chat/src/proactive/__tests__/listener.test.ts
+++ b/plugins/chat/src/proactive/__tests__/listener.test.ts
@@ -29,8 +29,10 @@ import {
   type FeedbackCollectorFn,
 } from "../feedback";
 import type {
+  ChannelProactiveConfig,
   LLMClassifierFn,
   ProactiveMeterEvent,
+  ResolveWorkspaceIdFn,
   WorkspaceProactiveConfig,
 } from "../types";
 import type {
@@ -104,6 +106,7 @@ function makeChat() {
 interface ThreadDouble {
   channelId: string;
   isDM: boolean;
+  adapter: { name: string };
   createSentMessageFromMessage: ReturnType<typeof mock>;
   postEphemeral: ReturnType<typeof mock>;
   post: ReturnType<typeof mock>;
@@ -111,11 +114,19 @@ interface ThreadDouble {
   _addReaction: ReturnType<typeof mock>;
 }
 
-function makeThread(channelId = "C-allowed", opts: { isDM?: boolean } = {}): ThreadDouble {
+function makeThread(
+  channelId = "C-allowed",
+  opts: { isDM?: boolean; adapterName?: string } = {},
+): ThreadDouble {
   const addReaction = mock(async () => {});
   return {
     channelId,
     isDM: opts.isDM ?? false,
+    // Post-#2620: the listener reads `thread.adapter` to pass to the
+    // host-supplied `resolveWorkspaceId`. Test threads supply a minimal
+    // adapter stub (name only — the default fixture resolver returns a
+    // constant workspaceId, so it doesn't actually inspect the adapter).
+    adapter: { name: opts.adapterName ?? "slack" },
     createSentMessageFromMessage: mock(() => ({ addReaction })),
     postEphemeral: mock(async () => ({ id: "E1", threadId: channelId, raw: {} })),
     post: mock(async () => ({ id: "P1" })),
@@ -161,6 +172,39 @@ const echoExecute: ProactiveExecuteQuery = async (question) => ({
 });
 
 // ---------------------------------------------------------------------------
+// #2620 — multi-tenant per-event resolution fixtures
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a per-event workspace resolver that returns `workspaceId` for
+ * every event. Tests that exercise the unknown-tenant skip pass
+ * `() => null` directly.
+ */
+function makeResolver(workspaceId: string | null): ResolveWorkspaceIdFn {
+  return async () => workspaceId;
+}
+
+/**
+ * Build the standard pair of `getWorkspaceConfig` / `getChannelConfigs`
+ * fetchers from a workspace config + optional per-channel overrides.
+ * Replaces the pre-#2620 static `workspace` + `channelConfigs` registration
+ * fields the tests used to stub directly.
+ */
+function makeWorkspaceFetchers(
+  workspace: WorkspaceProactiveConfig | null = baseWorkspace,
+  channelConfigs: ChannelProactiveConfig[] = [],
+) {
+  return {
+    getWorkspaceConfig: async () => workspace,
+    getChannelConfigs: async () => channelConfigs,
+  };
+}
+
+const defaultResolver = makeResolver("ws_1");
+const { getWorkspaceConfig: defaultGetWorkspace, getChannelConfigs: defaultGetChannels } =
+  makeWorkspaceFetchers();
+
+// ---------------------------------------------------------------------------
 // resolveChannelAllowlist
 // ---------------------------------------------------------------------------
 
@@ -195,7 +239,9 @@ describe("registerProactiveListener — gating", () => {
     await registerProactiveListener(chat as any, makeLogger(), {
       isEnabled: () => false,
       classify: yesLLM,
-      workspace: baseWorkspace,
+      resolveWorkspaceId: defaultResolver,
+      getWorkspaceConfig: defaultGetWorkspace,
+      getChannelConfigs: defaultGetChannels,
       channelAllowlist: ["C-allowed"],
     });
     expect(isRegistered()).toBe(false);
@@ -207,7 +253,9 @@ describe("registerProactiveListener — gating", () => {
     await registerProactiveListener(chat as any, makeLogger(), {
       isEnabled: () => true,
       classify: yesLLM,
-      workspace: baseWorkspace,
+      resolveWorkspaceId: defaultResolver,
+      getWorkspaceConfig: defaultGetWorkspace,
+      getChannelConfigs: defaultGetChannels,
       channelAllowlist: ["C-allowed"],
     });
     expect(isRegistered()).toBe(true);
@@ -230,7 +278,9 @@ describe("registerProactiveListener — channel-message handler", () => {
     await registerProactiveListener(chat as any, makeLogger(), {
       isEnabled: () => true,
       classify: yesLLM,
-      workspace: baseWorkspace,
+      resolveWorkspaceId: defaultResolver,
+      getWorkspaceConfig: defaultGetWorkspace,
+      getChannelConfigs: defaultGetChannels,
       channelAllowlist: ["C-allowed"],
     });
     const thread = makeThread("C-allowed");
@@ -245,7 +295,9 @@ describe("registerProactiveListener — channel-message handler", () => {
     await registerProactiveListener(chat as any, makeLogger(), {
       isEnabled: () => true,
       classify: yesLLM,
-      workspace: baseWorkspace,
+      resolveWorkspaceId: defaultResolver,
+      getWorkspaceConfig: defaultGetWorkspace,
+      getChannelConfigs: defaultGetChannels,
       channelAllowlist: ["C-allowed"],
     });
     const thread = makeThread("C-other");
@@ -259,7 +311,9 @@ describe("registerProactiveListener — channel-message handler", () => {
     await registerProactiveListener(chat as any, makeLogger(), {
       isEnabled: () => true,
       classify: yesLLM,
-      workspace: baseWorkspace,
+      resolveWorkspaceId: defaultResolver,
+      getWorkspaceConfig: defaultGetWorkspace,
+      getChannelConfigs: defaultGetChannels,
       channelAllowlist: ["C-allowed"],
     });
     const thread = makeThread("C-allowed");
@@ -273,7 +327,9 @@ describe("registerProactiveListener — channel-message handler", () => {
     await registerProactiveListener(chat as any, makeLogger(), {
       isEnabled: () => true,
       classify: yesLLM,
-      workspace: baseWorkspace,
+      resolveWorkspaceId: defaultResolver,
+      getWorkspaceConfig: defaultGetWorkspace,
+      getChannelConfigs: defaultGetChannels,
       channelAllowlist: ["C-allowed"],
     });
     const thread = makeThread("C-allowed");
@@ -286,7 +342,9 @@ describe("registerProactiveListener — channel-message handler", () => {
     await registerProactiveListener(chat as any, makeLogger(), {
       isEnabled: () => true,
       classify: noLLM,
-      workspace: baseWorkspace,
+      resolveWorkspaceId: defaultResolver,
+      getWorkspaceConfig: defaultGetWorkspace,
+      getChannelConfigs: defaultGetChannels,
       channelAllowlist: ["C-allowed"],
     });
     const thread = makeThread("C-allowed");
@@ -310,7 +368,9 @@ describe("registerProactiveListener — reaction-back handler", () => {
     await registerProactiveListener(chat as any, log, {
       isEnabled: () => true,
       classify: yesLLM,
-      workspace: baseWorkspace,
+      resolveWorkspaceId: defaultResolver,
+      getWorkspaceConfig: defaultGetWorkspace,
+      getChannelConfigs: defaultGetChannels,
       channelAllowlist: ["C-allowed"],
       userResolver: opts.userResolver,
       executeQueryProactive: opts.executeQueryProactive,
@@ -454,7 +514,9 @@ describe("registerProactiveListener — button handlers", () => {
     await registerProactiveListener(chat as any, makeLogger(), {
       isEnabled: () => true,
       classify: yesLLM,
-      workspace: baseWorkspace,
+      resolveWorkspaceId: defaultResolver,
+      getWorkspaceConfig: defaultGetWorkspace,
+      getChannelConfigs: defaultGetChannels,
       channelAllowlist: ["C-allowed"],
       userResolver: linkedResolver,
       executeQueryProactive,
@@ -481,7 +543,9 @@ describe("registerProactiveListener — button handlers", () => {
     await registerProactiveListener(chat as any, makeLogger(), {
       isEnabled: () => true,
       classify: yesLLM,
-      workspace: baseWorkspace,
+      resolveWorkspaceId: defaultResolver,
+      getWorkspaceConfig: defaultGetWorkspace,
+      getChannelConfigs: defaultGetChannels,
       channelAllowlist: ["C-allowed"],
       userResolver: linkedResolver,
       executeQueryProactive,
@@ -533,7 +597,9 @@ describe("registerProactiveListener — feedback buttons", () => {
     const handle = await registerProactiveListener(chat as any, log, {
       isEnabled: () => true,
       classify: yesLLM,
-      workspace: baseWorkspace,
+      resolveWorkspaceId: defaultResolver,
+      getWorkspaceConfig: defaultGetWorkspace,
+      getChannelConfigs: defaultGetChannels,
       channelAllowlist: ["C-allowed"],
       userResolver: linkedResolver,
       executeQueryProactive: echoExecute,
@@ -585,6 +651,11 @@ describe("registerProactiveListener — feedback buttons", () => {
       adapter: { name: "slack" },
       callbackId: PROACTIVE_FB_WRONG_DATA_MODAL_ID,
       privateMetadata: "answer-msg-1",
+      // Post-#2620 the modal-submit handler needs `relatedThread` to
+      // resolve the tenant (the modal is opened from the in-thread
+      // feedback button, so `relatedThread` is always present in
+      // production). Tests synthesise a minimal thread stub.
+      relatedThread: makeThread("C-allowed"),
       user: { isMe: false, isBot: false, userId: "U-asker", userName: "alice" },
       values: { [PROACTIVE_FB_WRONG_DATA_INPUT_ID]: "MRR figure is stale" },
       raw: {},
@@ -616,7 +687,9 @@ describe("registerProactiveListener — feedback buttons", () => {
     await registerProactiveListener(chat as any, makeLogger(), {
       isEnabled: () => true,
       classify: yesLLM,
-      workspace: baseWorkspace,
+      resolveWorkspaceId: defaultResolver,
+      getWorkspaceConfig: defaultGetWorkspace,
+      getChannelConfigs: defaultGetChannels,
       channelAllowlist: ["C-allowed"],
       // feedbackCollector deliberately omitted
     });
@@ -645,11 +718,14 @@ describe("handleProactiveFeedbackSlash", () => {
     const handled = await handleProactiveFeedbackSlash({
       text: "how many users last month",
       channelId: "C-allowed",
+      workspaceId: "ws_1",
       asker: { platform: "slack", externalUserId: "U-asker", userName: "alice" },
       config: {
         isEnabled: () => true,
         classify: yesLLM,
-        workspace: baseWorkspace,
+        resolveWorkspaceId: defaultResolver,
+        getWorkspaceConfig: defaultGetWorkspace,
+        getChannelConfigs: defaultGetChannels,
         feedbackCollector: async (ev) => {
           calls.push(ev);
         },
@@ -673,11 +749,14 @@ describe("handleProactiveFeedbackSlash", () => {
     const handled = await handleProactiveFeedbackSlash({
       text: "feedback figure looks stale",
       channelId: "C-allowed",
+      workspaceId: "ws_1",
       asker: { platform: "slack", externalUserId: "U-asker", userName: "alice" },
       config: {
         isEnabled: () => true,
         classify: yesLLM,
-        workspace: baseWorkspace,
+        resolveWorkspaceId: defaultResolver,
+        getWorkspaceConfig: defaultGetWorkspace,
+        getChannelConfigs: defaultGetChannels,
         feedbackCollector: async (ev) => {
           calls.push(ev);
         },
@@ -698,11 +777,14 @@ describe("handleProactiveFeedbackSlash", () => {
     const handled = await handleProactiveFeedbackSlash({
       text: "feedback some text",
       channelId: "C-allowed",
+      workspaceId: "ws_1",
       asker: { platform: "slack", externalUserId: "U-asker", userName: "alice" },
       config: {
         isEnabled: () => true,
         classify: yesLLM,
-        workspace: baseWorkspace,
+        resolveWorkspaceId: defaultResolver,
+        getWorkspaceConfig: defaultGetWorkspace,
+        getChannelConfigs: defaultGetChannels,
         // feedbackCollector deliberately omitted
       },
       log: makeLogger(),
@@ -724,9 +806,10 @@ describe("registerProactiveListener — kill switch", () => {
     await registerProactiveListener(chat as unknown as Parameters<typeof registerProactiveListener>[0], makeLogger(), {
       isEnabled: () => true,
       classify,
-      workspace: baseWorkspace,
+      resolveWorkspaceId: defaultResolver,
+      getWorkspaceConfig: defaultGetWorkspace,
+      getChannelConfigs: defaultGetChannels,
       channelAllowlist: ["C-allowed"],
-      workspaceId: "ws_1",
       isPaused,
       onPauseRequest: mock(async () => {}),
     });
@@ -743,9 +826,10 @@ describe("registerProactiveListener — kill switch", () => {
     await registerProactiveListener(chat as unknown as Parameters<typeof registerProactiveListener>[0], makeLogger(), {
       isEnabled: () => true,
       classify: yesLLM,
-      workspace: baseWorkspace,
+      resolveWorkspaceId: defaultResolver,
+      getWorkspaceConfig: defaultGetWorkspace,
+      getChannelConfigs: defaultGetChannels,
       channelAllowlist: ["C-allowed"],
-      workspaceId: "ws_1",
       isPaused,
       onPauseRequest: mock(async () => {}),
     });
@@ -772,9 +856,10 @@ describe("registerProactiveListener — kill switch", () => {
     await registerProactiveListener(chat as unknown as Parameters<typeof registerProactiveListener>[0], log, {
       isEnabled: () => true,
       classify,
-      workspace: baseWorkspace,
+      resolveWorkspaceId: defaultResolver,
+      getWorkspaceConfig: defaultGetWorkspace,
+      getChannelConfigs: defaultGetChannels,
       channelAllowlist: ["C-allowed"],
-      workspaceId: "ws_1",
       isPaused,
       onPauseRequest: mock(async () => {}),
       onMeterEvent,
@@ -800,9 +885,10 @@ describe("registerProactiveListener — kill switch", () => {
     await registerProactiveListener(chat as unknown as Parameters<typeof registerProactiveListener>[0], makeLogger(), {
       isEnabled: () => true,
       classify,
-      workspace: baseWorkspace,
+      resolveWorkspaceId: defaultResolver,
+      getWorkspaceConfig: defaultGetWorkspace,
+      getChannelConfigs: defaultGetChannels,
       channelAllowlist: ["C-allowed"],
-      workspaceId: "ws_1",
       isPaused: mock(async () => ({ paused: false })),
       onPauseRequest,
     });
@@ -810,7 +896,6 @@ describe("registerProactiveListener — kill switch", () => {
     await invoke(thread, makeMessage({ text: "@atlas pause" }));
     expect(onPauseRequest).toHaveBeenCalledTimes(1);
     expect((onPauseRequest.mock.calls[0] as unknown[])?.[0]).toMatchObject({
-      workspaceId: "ws_1",
       channelId: "C-allowed",
       layer: "channel-24h",
     });
@@ -825,9 +910,10 @@ describe("registerProactiveListener — kill switch", () => {
     await registerProactiveListener(chat as unknown as Parameters<typeof registerProactiveListener>[0], makeLogger(), {
       isEnabled: () => true,
       classify,
-      workspace: baseWorkspace,
+      resolveWorkspaceId: defaultResolver,
+      getWorkspaceConfig: defaultGetWorkspace,
+      getChannelConfigs: defaultGetChannels,
       channelAllowlist: ["C-allowed"],
-      workspaceId: "ws_1",
       isPaused: mock(async () => ({ paused: false })),
       onPauseRequest,
     });
@@ -835,7 +921,6 @@ describe("registerProactiveListener — kill switch", () => {
     await invoke(thread, makeMessage({ text: "unsubscribe" }));
     expect(onPauseRequest).toHaveBeenCalledTimes(1);
     expect((onPauseRequest.mock.calls[0] as unknown[])?.[0]).toMatchObject({
-      workspaceId: "ws_1",
       channelId: null,
       layer: "user-optout",
       durationMs: null,
@@ -849,9 +934,10 @@ describe("registerProactiveListener — kill switch", () => {
     await registerProactiveListener(chat as unknown as Parameters<typeof registerProactiveListener>[0], makeLogger(), {
       isEnabled: () => true,
       classify: yesLLM,
-      workspace: baseWorkspace,
+      resolveWorkspaceId: defaultResolver,
+      getWorkspaceConfig: defaultGetWorkspace,
+      getChannelConfigs: defaultGetChannels,
       channelAllowlist: ["C-allowed"],
-      workspaceId: "ws_1",
       isPaused: mock(async () => ({ paused: false })),
       onPauseRequest,
     });
@@ -869,9 +955,10 @@ describe("registerProactiveListener — kill switch", () => {
     await registerProactiveListener(chat as unknown as Parameters<typeof registerProactiveListener>[0], log, {
       isEnabled: () => true,
       classify: yesLLM,
-      workspace: baseWorkspace,
+      resolveWorkspaceId: defaultResolver,
+      getWorkspaceConfig: defaultGetWorkspace,
+      getChannelConfigs: defaultGetChannels,
       channelAllowlist: ["C-allowed"],
-      workspaceId: "ws_1",
       isPaused: mock(async () => ({ paused: false })),
       onPauseRequest,
     });
@@ -881,21 +968,28 @@ describe("registerProactiveListener — kill switch", () => {
     expect(log.warn).toHaveBeenCalled();
   });
 
-  it("is a no-op for kill-switch checks when workspaceId is omitted", async () => {
+  it("skips kill-switch check entirely when resolveWorkspaceId returns null (#2620 multi-tenant)", async () => {
+    // Pre-#2620 the listener had a static `workspaceId?` field — when
+    // omitted, the kill-switch check was bypassed. Post-#2620 the
+    // workspaceId is always resolved per event; null = unknown tenant
+    // = silent skip BEFORE any kill-switch / classify call.
     const isPaused = mock(async () => ({ paused: true, layer: "workspace-kill" as const }));
+    const classify = mock(yesLLM);
     const { chat, invokeMessage: invoke } = makeChat();
     await registerProactiveListener(chat as unknown as Parameters<typeof registerProactiveListener>[0], makeLogger(), {
       isEnabled: () => true,
-      classify: yesLLM,
-      workspace: baseWorkspace,
+      classify,
+      resolveWorkspaceId: makeResolver(null), // unknown tenant
+      getWorkspaceConfig: defaultGetWorkspace,
+      getChannelConfigs: defaultGetChannels,
       channelAllowlist: ["C-allowed"],
-      // No workspaceId — listener should NOT call isPaused.
       isPaused,
     });
     const thread = makeThread("C-allowed");
     await invoke(thread, makeMessage());
     expect(isPaused).not.toHaveBeenCalled();
-    expect(thread._addReaction).toHaveBeenCalledTimes(1);
+    expect(classify).not.toHaveBeenCalled();
+    expect(thread._addReaction).not.toHaveBeenCalled();
   });
 });
 
@@ -927,10 +1021,11 @@ describe("registerProactiveListener — monthly quota cap (#2301)", () => {
       {
         isEnabled: () => true,
         classify,
-        workspace: baseWorkspace,
+        resolveWorkspaceId: defaultResolver,
+      getWorkspaceConfig: defaultGetWorkspace,
+      getChannelConfigs: defaultGetChannels,
         channelAllowlist: ["C-allowed"],
-        workspaceId: "ws_1",
-        getQuotaStatus,
+          getQuotaStatus,
         onMeterEvent,
       },
     );
@@ -978,10 +1073,11 @@ describe("registerProactiveListener — monthly quota cap (#2301)", () => {
       {
         isEnabled: () => true,
         classify,
-        workspace: baseWorkspace,
+        resolveWorkspaceId: defaultResolver,
+      getWorkspaceConfig: defaultGetWorkspace,
+      getChannelConfigs: defaultGetChannels,
         channelAllowlist: ["C-allowed"],
-        workspaceId: "ws_1",
-        getQuotaStatus,
+          getQuotaStatus,
         onMeterEvent,
       },
     );
@@ -1018,10 +1114,11 @@ describe("registerProactiveListener — monthly quota cap (#2301)", () => {
       {
         isEnabled: () => true,
         classify,
-        workspace: baseWorkspace,
+        resolveWorkspaceId: defaultResolver,
+      getWorkspaceConfig: defaultGetWorkspace,
+      getChannelConfigs: defaultGetChannels,
         channelAllowlist: ["C-allowed"],
-        workspaceId: "ws_1",
-        getQuotaStatus,
+          getQuotaStatus,
         onMeterEvent,
       },
     );
@@ -1060,10 +1157,11 @@ describe("registerProactiveListener — monthly quota cap (#2301)", () => {
       {
         isEnabled: () => true,
         classify,
-        workspace: baseWorkspace,
+        resolveWorkspaceId: defaultResolver,
+      getWorkspaceConfig: defaultGetWorkspace,
+      getChannelConfigs: defaultGetChannels,
         channelAllowlist: ["C-allowed"],
-        workspaceId: "ws_1",
-        getQuotaStatus,
+          getQuotaStatus,
       },
     );
     const thread = makeThread("C-allowed");
@@ -1073,29 +1171,35 @@ describe("registerProactiveListener — monthly quota cap (#2301)", () => {
     expect(thread._addReaction).toHaveBeenCalledTimes(1);
   });
 
-  it("is a no-op for quota checks when workspaceId is omitted", async () => {
+  it("skips quota check entirely when resolveWorkspaceId returns null (#2620 multi-tenant)", async () => {
+    // Pre-#2620 the listener had a static `workspaceId?` field — when
+    // omitted, the quota check was bypassed. Post-#2620 the unknown-
+    // tenant skip happens BEFORE classification (and quota).
     const getQuotaStatus = mock(async () => ({
       monthlyClassifierCap: 50,
       classifyCountThisMonth: 50,
       capReached: true,
     }));
+    const classify = mock(yesLLM);
     const { chat, invokeMessage: invoke } = makeChat();
     await registerProactiveListener(
       chat as unknown as Parameters<typeof registerProactiveListener>[0],
       makeLogger(),
       {
         isEnabled: () => true,
-        classify: yesLLM,
-        workspace: baseWorkspace,
+        classify,
+        resolveWorkspaceId: makeResolver(null),
+        getWorkspaceConfig: defaultGetWorkspace,
+        getChannelConfigs: defaultGetChannels,
         channelAllowlist: ["C-allowed"],
-        // No workspaceId — listener should NOT call getQuotaStatus.
         getQuotaStatus,
       },
     );
     const thread = makeThread("C-allowed");
     await invoke(thread, makeMessage());
     expect(getQuotaStatus).not.toHaveBeenCalled();
-    expect(thread._addReaction).toHaveBeenCalledTimes(1);
+    expect(classify).not.toHaveBeenCalled();
+    expect(thread._addReaction).not.toHaveBeenCalled();
   });
 });
 
@@ -1119,9 +1223,10 @@ describe("registerProactiveListener — public dataset (#2297)", () => {
     await registerProactiveListener(chat as unknown as Parameters<typeof registerProactiveListener>[0], log, {
       isEnabled: () => true,
       classify: yesLLM,
-      workspace: baseWorkspace,
+      resolveWorkspaceId: defaultResolver,
+      getWorkspaceConfig: defaultGetWorkspace,
+      getChannelConfigs: defaultGetChannels,
       channelAllowlist: ["C-allowed"],
-      workspaceId: "ws_1",
       userResolver: opts.userResolver,
       executeQueryProactive: opts.executeQueryProactive,
       getPublicDataset: opts.getPublicDataset,
@@ -1521,5 +1626,182 @@ describe("registerProactiveListener — public dataset (#2297)", () => {
       (c) => (c as unknown[])[0] as { eventType: string },
     );
     expect(meterCalls.some((c) => c.eventType === "public_refused")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #2620 — multi-tenant per-event resolution
+// ---------------------------------------------------------------------------
+
+describe("registerProactiveListener — multi-tenant per-event resolution (#2620)", () => {
+  it("silently skips the event when resolveWorkspaceId returns null", async () => {
+    const classify = mock(yesLLM);
+    const onMeterEvent = mock(async () => {});
+    const { chat, invokeMessage } = makeChat();
+    await registerProactiveListener(
+      chat as unknown as Parameters<typeof registerProactiveListener>[0],
+      makeLogger(),
+      {
+        isEnabled: () => true,
+        classify,
+        resolveWorkspaceId: makeResolver(null),
+        getWorkspaceConfig: defaultGetWorkspace,
+        getChannelConfigs: defaultGetChannels,
+        channelAllowlist: ["C-allowed"],
+        onMeterEvent,
+      },
+    );
+    const thread = makeThread("C-allowed");
+    await invokeMessage(thread, makeMessage());
+    // Unknown tenant = nothing runs: no classify, no reaction, no meter row.
+    expect(classify).not.toHaveBeenCalled();
+    expect(thread._addReaction).not.toHaveBeenCalled();
+    expect(onMeterEvent).not.toHaveBeenCalled();
+  });
+
+  it("silently skips when resolveWorkspaceId throws (fails as null)", async () => {
+    // Resolver contract is "never throw"; the safe-wrapper catches and
+    // degrades to null so a registry hiccup can't crash the SDK loop.
+    const classify = mock(yesLLM);
+    const onMeterEvent = mock(async () => {});
+    const { chat, invokeMessage } = makeChat();
+    const log = makeLogger();
+    await registerProactiveListener(
+      chat as unknown as Parameters<typeof registerProactiveListener>[0],
+      log,
+      {
+        isEnabled: () => true,
+        classify,
+        resolveWorkspaceId: async () => {
+          throw new Error("slack_installations table missing");
+        },
+        getWorkspaceConfig: defaultGetWorkspace,
+        getChannelConfigs: defaultGetChannels,
+        channelAllowlist: ["C-allowed"],
+        onMeterEvent,
+      },
+    );
+    const thread = makeThread("C-allowed");
+    await invokeMessage(thread, makeMessage());
+    expect(classify).not.toHaveBeenCalled();
+    expect(thread._addReaction).not.toHaveBeenCalled();
+    expect(onMeterEvent).not.toHaveBeenCalled();
+    expect(log.warn).toHaveBeenCalled();
+  });
+
+  it("skips when getWorkspaceConfig returns null (workspace not opted in)", async () => {
+    const classify = mock(yesLLM);
+    const onMeterEvent = mock(async () => {});
+    const { chat, invokeMessage } = makeChat();
+    await registerProactiveListener(
+      chat as unknown as Parameters<typeof registerProactiveListener>[0],
+      makeLogger(),
+      {
+        isEnabled: () => true,
+        classify,
+        resolveWorkspaceId: defaultResolver,
+        getWorkspaceConfig: async () => null, // no config row
+        getChannelConfigs: defaultGetChannels,
+        channelAllowlist: ["C-allowed"],
+        onMeterEvent,
+      },
+    );
+    const thread = makeThread("C-allowed");
+    await invokeMessage(thread, makeMessage());
+    expect(classify).not.toHaveBeenCalled();
+    expect(thread._addReaction).not.toHaveBeenCalled();
+    expect(onMeterEvent).not.toHaveBeenCalled();
+  });
+
+  it("attributes meter rows to the correct workspace across two simulated tenants in the same process", async () => {
+    // The core multi-tenant correctness test: pre-#2620 every meter row
+    // would have stamped the same baked-in workspaceId regardless of
+    // which tenant the message came from. Post-#2620 the listener must
+    // read the workspace per event and stamp it onto the meter row.
+
+    // Map (channel id) → workspace id so the resolver can route two
+    // distinct tenants through the same Chat instance.
+    const channelToWorkspace = new Map<string, string>([
+      ["C-tenant-A", "ws-A"],
+      ["C-tenant-B", "ws-B"],
+    ]);
+    const resolveWorkspaceId: ResolveWorkspaceIdFn = async ({ thread }) => {
+      return channelToWorkspace.get(thread.channelId) ?? null;
+    };
+
+    const meterEvents: ProactiveMeterEvent[] = [];
+    const onMeterEvent = mock(async (event: ProactiveMeterEvent) => {
+      meterEvents.push(event);
+    });
+
+    const { chat, invokeMessage } = makeChat();
+    await registerProactiveListener(
+      chat as unknown as Parameters<typeof registerProactiveListener>[0],
+      makeLogger(),
+      {
+        isEnabled: () => true,
+        classify: yesLLM,
+        resolveWorkspaceId,
+        getWorkspaceConfig: defaultGetWorkspace,
+        getChannelConfigs: defaultGetChannels,
+        channelAllowlist: ["C-tenant-A", "C-tenant-B"],
+        onMeterEvent,
+      },
+    );
+
+    const threadA = makeThread("C-tenant-A");
+    const threadB = makeThread("C-tenant-B");
+    await invokeMessage(threadA, makeMessage({ id: "M-A-1" }));
+    await invokeMessage(threadB, makeMessage({ id: "M-B-1" }));
+
+    // Both events should land classify + react meter rows.
+    const wsA = meterEvents.filter((e) => e.workspaceId === "ws-A");
+    const wsB = meterEvents.filter((e) => e.workspaceId === "ws-B");
+    expect(wsA.length).toBeGreaterThan(0);
+    expect(wsB.length).toBeGreaterThan(0);
+    // Pre-#2620 every row would have stamped the same workspaceId
+    // (the baked-in one). Post-#2620 they MUST attribute correctly.
+    expect(wsA.every((e) => e.workspaceId === "ws-A")).toBe(true);
+    expect(wsB.every((e) => e.workspaceId === "ws-B")).toBe(true);
+    // And the message ids must not bleed across tenants.
+    expect(wsA.some((e) => e.messageId === "M-B-1")).toBe(false);
+    expect(wsB.some((e) => e.messageId === "M-A-1")).toBe(false);
+  });
+
+  it("does not share rate-limit cooldown across tenants sharing the same channel id", async () => {
+    // Two tenants that both have a "C-general" channel must NOT share
+    // the in-memory cooldown row — otherwise tenant A reacting in
+    // C-general would silence tenant B's C-general for the cooldown
+    // window. Cooldown is keyed by `${workspaceId}:${channelId}`.
+    const channelToWorkspace = new Map<string, string>([
+      ["C-general-A", "ws-A"],
+      ["C-general-B", "ws-B"],
+    ]);
+    const resolveWorkspaceId: ResolveWorkspaceIdFn = async ({ thread }) => {
+      return channelToWorkspace.get(thread.channelId) ?? null;
+    };
+
+    const { chat, invokeMessage } = makeChat();
+    await registerProactiveListener(
+      chat as unknown as Parameters<typeof registerProactiveListener>[0],
+      makeLogger(),
+      {
+        isEnabled: () => true,
+        classify: yesLLM,
+        resolveWorkspaceId,
+        getWorkspaceConfig: defaultGetWorkspace,
+        getChannelConfigs: defaultGetChannels,
+        channelAllowlist: ["C-general-A", "C-general-B"],
+      },
+    );
+
+    const threadA = makeThread("C-general-A");
+    const threadB = makeThread("C-general-B");
+    await invokeMessage(threadA, makeMessage({ id: "M-A-1" }));
+    await invokeMessage(threadB, makeMessage({ id: "M-B-1" }));
+
+    // Both tenants should react — the cooldown is per-tenant.
+    expect(threadA._addReaction).toHaveBeenCalledTimes(1);
+    expect(threadB._addReaction).toHaveBeenCalledTimes(1);
   });
 });

--- a/plugins/chat/src/proactive/__tests__/listener.test.ts
+++ b/plugins/chat/src/proactive/__tests__/listener.test.ts
@@ -896,6 +896,7 @@ describe("registerProactiveListener — kill switch", () => {
     await invoke(thread, makeMessage({ text: "@atlas pause" }));
     expect(onPauseRequest).toHaveBeenCalledTimes(1);
     expect((onPauseRequest.mock.calls[0] as unknown[])?.[0]).toMatchObject({
+      workspaceId: "ws_1",
       channelId: "C-allowed",
       layer: "channel-24h",
     });
@@ -921,6 +922,7 @@ describe("registerProactiveListener — kill switch", () => {
     await invoke(thread, makeMessage({ text: "unsubscribe" }));
     expect(onPauseRequest).toHaveBeenCalledTimes(1);
     expect((onPauseRequest.mock.calls[0] as unknown[])?.[0]).toMatchObject({
+      workspaceId: "ws_1",
       channelId: null,
       layer: "user-optout",
       durationMs: null,
@@ -1803,5 +1805,188 @@ describe("registerProactiveListener — multi-tenant per-event resolution (#2620
     // Both tenants should react — the cooldown is per-tenant.
     expect(threadA._addReaction).toHaveBeenCalledTimes(1);
     expect(threadB._addReaction).toHaveBeenCalledTimes(1);
+  });
+
+  it("pause writes carry the per-event workspaceId (two tenants, two channels)", async () => {
+    // Stamping the wrong workspaceId on a pause row routes the
+    // kill-switch / opt-out to the wrong tenant — the most dangerous
+    // multi-tenant regression possible. This test pins onPauseRequest's
+    // workspaceId arg to whichever tenant the event resolved to.
+    const channelToWorkspace = new Map<string, string>([
+      ["C-tenant-A", "ws-A"],
+      ["C-tenant-B", "ws-B"],
+    ]);
+    const resolveWorkspaceId: ResolveWorkspaceIdFn = async ({ thread }) => {
+      return channelToWorkspace.get(thread.channelId) ?? null;
+    };
+
+    const onPauseRequest = mock(async () => {});
+    const { chat, invokeMessage } = makeChat();
+    await registerProactiveListener(
+      chat as unknown as Parameters<typeof registerProactiveListener>[0],
+      makeLogger(),
+      {
+        isEnabled: () => true,
+        classify: yesLLM,
+        resolveWorkspaceId,
+        getWorkspaceConfig: defaultGetWorkspace,
+        getChannelConfigs: defaultGetChannels,
+        channelAllowlist: ["C-tenant-A", "C-tenant-B"],
+        isPaused: mock(async () => ({ paused: false })),
+        onPauseRequest,
+      },
+    );
+
+    const threadA = makeThread("C-tenant-A");
+    const threadB = makeThread("C-tenant-B");
+    await invokeMessage(threadA, makeMessage({ text: "@atlas pause" }));
+    await invokeMessage(threadB, makeMessage({ text: "@atlas pause" }));
+
+    expect(onPauseRequest).toHaveBeenCalledTimes(2);
+    expect((onPauseRequest.mock.calls[0] as unknown[])?.[0]).toMatchObject({
+      workspaceId: "ws-A",
+      channelId: "C-tenant-A",
+      layer: "channel-24h",
+    });
+    expect((onPauseRequest.mock.calls[1] as unknown[])?.[0]).toMatchObject({
+      workspaceId: "ws-B",
+      channelId: "C-tenant-B",
+      layer: "channel-24h",
+    });
+  });
+
+  it("reaction-back replays the pending entry's workspaceId — not the reaction event's", async () => {
+    // The point: a future refactor that swaps `pending.workspaceId` →
+    // `safeResolveWorkspace(event)` would silently break multi-tenant
+    // correctness because the reaction event's adapter / raw payload
+    // may resolve to a DIFFERENT workspace (Slack OAuth shares a single
+    // user across workspaces; a wandering reactor could "answer-leak"
+    // an answer card across tenants). We pin `isEnabled` to the
+    // pending entry's workspaceId.
+    const channelToWorkspace = new Map<string, string>([
+      ["C-tenant-A", "ws-A"],
+      ["C-tenant-B", "ws-B"],
+    ]);
+    const resolveWorkspaceId: ResolveWorkspaceIdFn = async ({ thread }) => {
+      return channelToWorkspace.get(thread.channelId) ?? null;
+    };
+
+    const isEnabled = mock(async (_: string) => true);
+    const executeQueryProactive: ProactiveExecuteQuery = mock(echoExecute);
+    const { chat, invokeMessage, invokeReaction } = makeChat();
+    await registerProactiveListener(
+      chat as unknown as Parameters<typeof registerProactiveListener>[0],
+      makeLogger(),
+      {
+        isEnabled,
+        classify: yesLLM,
+        resolveWorkspaceId,
+        getWorkspaceConfig: defaultGetWorkspace,
+        getChannelConfigs: defaultGetChannels,
+        channelAllowlist: ["C-tenant-A", "C-tenant-B"],
+        userResolver: linkedResolver,
+        executeQueryProactive,
+      },
+    );
+
+    const threadA = makeThread("C-tenant-A");
+    const threadB = makeThread("C-tenant-B");
+    await invokeMessage(threadA, makeMessage({ id: "M-A-1" }));
+    await invokeMessage(threadB, makeMessage({ id: "M-B-1" }));
+
+    // Snapshot the workspaceIds isEnabled saw during registration +
+    // channel-message handling so we can isolate the reaction-back calls.
+    const isEnabledCallsAfterMessages = isEnabled.mock.calls.length;
+    const executeCallsBeforeReactions = (
+      executeQueryProactive as unknown as { mock: { calls: unknown[] } }
+    ).mock.calls.length;
+
+    // Reaction-back on ws-A's message.
+    await invokeReaction({
+      added: true,
+      messageId: "M-A-1",
+      threadId: threadA.channelId,
+      thread: threadA,
+      user: { isMe: false, isBot: false, userId: "U-other", userName: "bob" },
+      emoji: PROACTIVE_REACTION,
+      rawEmoji: "robot_face",
+      adapter: { name: "slack" },
+      raw: {},
+    });
+    // Reaction-back on ws-B's message.
+    await invokeReaction({
+      added: true,
+      messageId: "M-B-1",
+      threadId: threadB.channelId,
+      thread: threadB,
+      user: { isMe: false, isBot: false, userId: "U-other", userName: "bob" },
+      emoji: PROACTIVE_REACTION,
+      rawEmoji: "robot_face",
+      adapter: { name: "slack" },
+      raw: {},
+    });
+
+    // The two reaction-back calls must hit isEnabled with the pending
+    // entry's workspaceId (NOT something re-resolved from the reaction
+    // event — though here both happen to match, the assertion is
+    // structural: the call comes from the pending entry).
+    const reactionIsEnabledCalls = isEnabled.mock.calls.slice(
+      isEnabledCallsAfterMessages,
+    );
+    expect(reactionIsEnabledCalls).toEqual([["ws-A"], ["ws-B"]]);
+
+    // And executeQueryProactive (downstream of the gate) should have
+    // received the same per-pending-entry workspaceId on the proactive
+    // context (slice options.workspaceId is host-controlled, so we
+    // assert via call count alone — both tenants ran).
+    const executeCallsAfterReactions = (
+      executeQueryProactive as unknown as { mock: { calls: unknown[] } }
+    ).mock.calls.length;
+    expect(executeCallsAfterReactions - executeCallsBeforeReactions).toBe(2);
+  });
+
+  it("getWorkspaceConfig is invoked per-event with the resolver's tenant id (no closure-baked workspaceId)", async () => {
+    // Pre-#2620 the workspace config was a static registration field;
+    // post-#2620 it's a per-event fetch. This test pins the spy's call
+    // args so a regression that re-introduces a closure-baked id (e.g.
+    // memoising the first event's workspaceId) fails immediately.
+    const channelToWorkspace = new Map<string, string>([
+      ["C-tenant-A", "ws-A"],
+      ["C-tenant-B", "ws-B"],
+    ]);
+    const resolveWorkspaceId: ResolveWorkspaceIdFn = async ({ thread }) => {
+      return channelToWorkspace.get(thread.channelId) ?? null;
+    };
+
+    const getWorkspaceConfig = mock(
+      async (_workspaceId: string): Promise<WorkspaceProactiveConfig | null> =>
+        baseWorkspace,
+    );
+
+    const { chat, invokeMessage } = makeChat();
+    await registerProactiveListener(
+      chat as unknown as Parameters<typeof registerProactiveListener>[0],
+      makeLogger(),
+      {
+        isEnabled: () => true,
+        classify: yesLLM,
+        resolveWorkspaceId,
+        getWorkspaceConfig,
+        getChannelConfigs: defaultGetChannels,
+        channelAllowlist: ["C-tenant-A", "C-tenant-B"],
+      },
+    );
+
+    const threadA = makeThread("C-tenant-A");
+    const threadB = makeThread("C-tenant-B");
+    await invokeMessage(threadA, makeMessage({ id: "M-A-1" }));
+    await invokeMessage(threadB, makeMessage({ id: "M-B-1" }));
+    await invokeMessage(threadA, makeMessage({ id: "M-A-2" }));
+
+    const callArgs = getWorkspaceConfig.mock.calls.map((c) => c[0]);
+    const wsACount = callArgs.filter((id) => id === "ws-A").length;
+    const wsBCount = callArgs.filter((id) => id === "ws-B").length;
+    expect(wsACount).toBe(2);
+    expect(wsBCount).toBe(1);
   });
 });

--- a/plugins/chat/src/proactive/answerer.ts
+++ b/plugins/chat/src/proactive/answerer.ts
@@ -107,6 +107,14 @@ export type ProactiveExecuteQuery = (
 export interface PendingAnswerEntry {
   text: string;
   asker: ProactiveAsker;
+  /**
+   * Workspace id resolved when the channel-message handler reacted to
+   * this message (#2620 multi-tenant). The reaction-back / button-click
+   * handlers reuse this id rather than re-resolving from the reaction
+   * event so the answer routes to the same tenant that the original
+   * reaction was emitted for.
+   */
+  workspaceId: string;
   /** Epoch ms when this entry was recorded. */
   recordedAt: number;
 }

--- a/plugins/chat/src/proactive/index.ts
+++ b/plugins/chat/src/proactive/index.ts
@@ -11,6 +11,8 @@ export type {
   ChannelPauseLayer,
   ChannelProactiveConfig,
   ClassificationResult,
+  GetChannelConfigsFn,
+  GetWorkspaceConfigFn,
   InterjectionAction,
   InterjectionDecision,
   LLMClassifierFn,
@@ -18,6 +20,7 @@ export type {
   PauseLayer,
   ProactiveGateFn,
   RecentActivity,
+  ResolveWorkspaceIdFn,
   SensitivityPreset,
   WorkspaceProactiveConfig,
 } from "./types";

--- a/plugins/chat/src/proactive/listener.ts
+++ b/plugins/chat/src/proactive/listener.ts
@@ -16,7 +16,7 @@
  */
 
 import { emoji } from "chat";
-import type { Author, Chat, Message, ReactionEvent, Thread } from "chat";
+import type { Adapter, Author, Chat, Message, ReactionEvent, Thread } from "chat";
 import type { PluginLogger } from "@useatlas/plugin-sdk";
 import { classifyMessage } from "./classifier";
 import {
@@ -35,8 +35,10 @@ import {
 } from "./answerer";
 import type {
   ChannelProactiveConfig,
+  GetChannelConfigsFn,
   GetPublicDatasetFn,
   GetQuotaStatusFn,
+  GetWorkspaceConfigFn,
   LLMClassifierFn,
   OnPauseRequestFn,
   ProactiveGateFn,
@@ -44,6 +46,7 @@ import type {
   ProactiveMeterEventFn,
   ProactivePublicDatasetEntry,
   RecentActivity,
+  ResolveWorkspaceIdFn,
   WorkspaceProactiveConfig,
 } from "./types";
 import { DEFAULT_PROACTIVE_REFUSAL_COPY } from "./types";
@@ -73,16 +76,36 @@ import {
 // ---------------------------------------------------------------------------
 
 export interface ProactiveListenerConfig {
-  /** Gate: true when proactive mode is allowed (enterprise + workspace flag). */
+  /**
+   * Per-event workspace resolution (#2620). The listener calls this
+   * at the top of every event handler to figure out which tenant the
+   * event belongs to. Returning `null` is a silent skip — no classify,
+   * no meter row, no kill-switch read. Implementations should never
+   * throw; failures should resolve as `null`.
+   */
+  resolveWorkspaceId: ResolveWorkspaceIdFn;
+  /**
+   * Gate: true when proactive mode is allowed for the given workspace
+   * (enterprise + workspace flag). Per-call workspaceId (post-#2620
+   * multi-tenant refactor).
+   */
   isEnabled: ProactiveGateFn;
   /** LLM classifier callback. */
   classify: LLMClassifierFn;
-  /** Workspace-level config. */
-  workspace: WorkspaceProactiveConfig;
+  /**
+   * Per-event workspace config fetcher (#2620). Called once per event
+   * after `resolveWorkspaceId` returns non-null. Returning `null`
+   * short-circuits the event (treat as not opted in).
+   */
+  getWorkspaceConfig: GetWorkspaceConfigFn;
   /** Explicit channel allowlist, else `ATLAS_PROACTIVE_CHANNELS`. */
   channelAllowlist?: string[];
-  /** Per-channel overrides keyed by channel ID. */
-  channelConfigs?: Record<string, ChannelProactiveConfig>;
+  /**
+   * Per-event channel-config fetcher (#2620). Returns the workspace's
+   * per-channel overrides as a flat array; the listener scans linearly
+   * (arrays are short in practice). Empty array = no overrides.
+   */
+  getChannelConfigs: GetChannelConfigsFn;
 
   // ---- Slice #2293 additions ----
 
@@ -171,14 +194,12 @@ export interface ProactiveListenerConfig {
   allowAnswerWhenEntitiesUnknown?: boolean;
 
   // ---- Slice #2295 additions (kill switch + per-user opt-out) ----
+  //
+  // workspaceId is resolved per event via `resolveWorkspaceId` (#2620)
+  // and threaded into these callbacks at the call site. Pre-#2620 this
+  // interface carried a static `workspaceId?: string`; multi-tenant
+  // SaaS (one Chat instance, N tenants) made that incorrect.
 
-  /**
-   * Workspace id threaded into the kill-switch callbacks. Required
-   * when `isPaused` or `onPauseRequest` is set. In single-tenant
-   * deployments this can be a constant; multi-tenant hosts pass the
-   * org id.
-   */
-  workspaceId?: string;
   /**
    * Pause-registry read API. Consulted BEFORE classification so the
    * kill switch pays only a DB read, never an LLM call. When omitted
@@ -264,7 +285,13 @@ export async function registerProactiveListener(
   log: PluginLogger,
   config: ProactiveListenerConfig,
 ): Promise<ProactiveListenerHandle> {
-  const enabledAtRegistration = await config.isEnabled();
+  // Registration-time gate. Pre-#2620 the gate was zero-arg with
+  // `workspaceId` baked in; post-#2620 the gate takes workspaceId per
+  // call. At registration we don't know any tenant yet, so probe with
+  // an empty string — the host's implementation is expected to short-
+  // circuit on falsy / unknown ids (no enterprise license at boot means
+  // no listener registers anywhere, regardless of which workspace).
+  const enabledAtRegistration = await config.isEnabled("");
   if (!enabledAtRegistration) {
     log.debug("Proactive listener not registered — gate is closed");
     return { recentAnswers: null };
@@ -281,7 +308,7 @@ export async function registerProactiveListener(
   );
   if (config.allowAnswerWhenEntitiesUnknown) {
     log.warn(
-      { workspaceId: config.workspaceId },
+      {},
       "Proactive: allowAnswerWhenEntitiesUnknown=true — unlinked-asker results without entitiesReferenced will be allowed through. Public-dataset allowlist is NOT enforced for these results; the host must provide a compensating control.",
     );
   }
@@ -290,6 +317,10 @@ export async function registerProactiveListener(
   // is fine for slices #2292–#2293 — #2296 layered in a durable meter
   // row but kept the cooldown gate cheap and local; cross-host cooldown
   // could ride the same `proactive_meter_events` table in a later slice.
+  //
+  // Post-#2620: keyed by `${workspaceId}:${channelId}` so two tenants
+  // that share a channel id (different Slack workspaces both have a
+  // "C-general") don't share a cooldown row.
   const recent = new Map<string, RecentActivity>();
   // Pending answers awaiting a reaction-back or button-click.
   const pending = new PendingAnswers();
@@ -299,15 +330,17 @@ export async function registerProactiveListener(
 
   // Local helper: route an event through the host meter callback,
   // swallowing failures so a meter outage never propagates into the
-  // SDK event loop. Stamps `workspaceId` from the registration config
-  // so callers don't have to repeat it at every call site.
+  // SDK event loop. Post-#2620 `workspaceId` is per event — caller
+  // supplies it as the first arg, the helper threads it onto the
+  // wire-format `ProactiveMeterEvent`.
   const emitMeter = async (
+    workspaceId: string,
     partial: Omit<ProactiveMeterEvent, "workspaceId">,
   ): Promise<void> => {
     if (!config.onMeterEvent) return;
     try {
       await config.onMeterEvent({
-        workspaceId: config.workspaceId ?? "",
+        workspaceId,
         ...partial,
       });
     } catch (err) {
@@ -321,19 +354,101 @@ export async function registerProactiveListener(
     }
   };
 
+  // Per-event workspace resolution helper. Wraps `config.resolveWorkspaceId`
+  // with a defensive try/catch so a host implementation that throws (the
+  // contract is "never throw, resolve as null") still degrades to a
+  // silent skip instead of crashing the SDK loop.
+  //
+  // `thread` is typed loosely (`Thread<unknown, unknown>`) because the
+  // listener takes events from `onNewMessage`, `onReaction`, `onAction`,
+  // and `onModalSubmit` — each surfaces a thread with a different
+  // generic parameter. The resolver only reads `thread.channelId` /
+  // `adapter` / `message.raw`, so a loose generic is correct here.
+  const safeResolveWorkspace = async (
+    adapter: Adapter,
+    thread: Thread<unknown, unknown>,
+    message: Message,
+  ): Promise<string | null> => {
+    try {
+      return await config.resolveWorkspaceId({
+        adapter,
+        thread: thread as Thread,
+        message,
+      });
+    } catch (err) {
+      log.warn(
+        { err: err instanceof Error ? err : new Error(String(err)) },
+        "Proactive resolveWorkspaceId threw — treating as unknown tenant (skip)",
+      );
+      return null;
+    }
+  };
+
+  // Safe wrappers for the per-event workspace/channel config loaders.
+  // Failures resolve to null/empty (the listener falls back to "not
+  // opted in" / "no overrides" without crashing the SDK loop).
+  const safeGetWorkspaceConfig = async (
+    workspaceId: string,
+  ): Promise<WorkspaceProactiveConfig | null> => {
+    try {
+      return await config.getWorkspaceConfig(workspaceId);
+    } catch (err) {
+      log.warn(
+        {
+          err: err instanceof Error ? err : new Error(String(err)),
+          workspaceId,
+        },
+        "Proactive getWorkspaceConfig threw — treating as not opted in",
+      );
+      return null;
+    }
+  };
+
+  const safeGetChannelConfigs = async (
+    workspaceId: string,
+  ): Promise<ReadonlyArray<ChannelProactiveConfig>> => {
+    try {
+      return await config.getChannelConfigs(workspaceId);
+    } catch (err) {
+      log.warn(
+        {
+          err: err instanceof Error ? err : new Error(String(err)),
+          workspaceId,
+        },
+        "Proactive getChannelConfigs threw — treating as no overrides",
+      );
+      return [];
+    }
+  };
+
   // -------------------------------------------------------------------------
   // Channel-message hook: classify + react + record asker for later answer
   // -------------------------------------------------------------------------
   chat.onNewMessage(/.+/, async (thread: Thread, message: Message) => {
     try {
-      if (!(await config.isEnabled())) return;
       if (message.author.isBot === true || message.author.isMe) return;
       const text = message.text?.trim() ?? "";
       if (text.length === 0) return;
 
+      // ---------------------------------------------------------------
+      // Per-event workspace resolution (#2620) — FIRST thing we do.
+      // Unknown tenant → silent skip, no meter event, no DB reads.
+      // ---------------------------------------------------------------
+      const workspaceId = await safeResolveWorkspace(
+        thread.adapter,
+        thread,
+        message,
+      );
+      if (!workspaceId) return;
+
+      if (!(await config.isEnabled(workspaceId))) return;
+
       const channelId = thread.channelId;
       const userId = message.author.userId;
       const isDM = thread.isDM === true;
+      // Workspace-scoped cooldown key — two tenants that share a channel
+      // id (e.g. both have a "C-general") must not share cooldown state.
+      const cooldownKey = `${workspaceId}:${channelId}`;
 
       // ---------------------------------------------------------------
       // Pause-command intake (#2295) — runs BEFORE classification so
@@ -343,20 +458,19 @@ export async function registerProactiveListener(
       // DM `unsubscribe` → workspace-wide user-optout row.
       if (
         isDM &&
-        config.workspaceId &&
         config.onPauseRequest &&
         detectUnsubscribeDM(text)
       ) {
         try {
           await config.onPauseRequest(
             resolvePauseRequest("dm-unsubscribe", {
-              workspaceId: config.workspaceId,
+              workspaceId,
               channelId,
               userId,
             }),
           );
           log.info(
-            { workspaceId: config.workspaceId, userId },
+            { workspaceId, userId },
             "Proactive: user opted out via DM unsubscribe",
           );
         } catch (err) {
@@ -371,20 +485,19 @@ export async function registerProactiveListener(
       // In-channel `@atlas pause` → 24h channel-scoped pause.
       if (
         !isDM &&
-        config.workspaceId &&
         config.onPauseRequest &&
         detectPauseCommand(text)
       ) {
         try {
           await config.onPauseRequest(
             resolvePauseRequest("channel-pause-command", {
-              workspaceId: config.workspaceId,
+              workspaceId,
               channelId,
               userId,
             }),
           );
           log.info(
-            { workspaceId: config.workspaceId, channelId, userId },
+            { workspaceId, channelId, userId },
             "Proactive: channel paused for 24h via @atlas pause",
           );
         } catch (err) {
@@ -409,11 +522,11 @@ export async function registerProactiveListener(
       // failure, so the listener's posture matches the registry's
       // regardless of host wiring.
       // ---------------------------------------------------------------
-      if (config.isPaused && config.workspaceId) {
+      if (config.isPaused) {
         let pause: Awaited<ReturnType<IsPausedFn>>;
         try {
           pause = await config.isPaused({
-            workspaceId: config.workspaceId,
+            workspaceId,
             channelId,
             userId,
           });
@@ -427,7 +540,7 @@ export async function registerProactiveListener(
         if (pause.paused) {
           log.debug(
             {
-              workspaceId: config.workspaceId,
+              workspaceId,
               channelId,
               userId,
               layer: pause.layer,
@@ -439,8 +552,32 @@ export async function registerProactiveListener(
         }
       }
 
+      // ---------------------------------------------------------------
+      // Per-event workspace/channel config (#2620). Loaded after the
+      // pause check passes so a paused workspace pays zero config-read
+      // cost. Both calls are independent; run them in parallel.
+      // ---------------------------------------------------------------
+      const [workspaceConfig, channelConfigs] = await Promise.all([
+        safeGetWorkspaceConfig(workspaceId),
+        safeGetChannelConfigs(workspaceId),
+      ]);
+      if (!workspaceConfig) {
+        // No config row → workspace hasn't opted in. Silent skip; the
+        // `isEnabled` gate already returned true (e.g. enterprise on),
+        // but the per-workspace toggle isn't set. Pre-#2620 this state
+        // never happened because the config was baked at registration;
+        // multi-tenant resolution means we discover it per event.
+        log.debug(
+          { workspaceId },
+          "Proactive: workspace has no config — skipping",
+        );
+        return;
+      }
+
       const channelAllowed = allowlist.has(channelId);
-      const channelConfig = config.channelConfigs?.[channelId];
+      const channelConfig = channelConfigs.find(
+        (cfg) => cfg.channelId === channelId,
+      );
 
       // ---------------------------------------------------------------
       // Monthly quota cap (#2301) — short-circuit BEFORE the classifier
@@ -457,11 +594,11 @@ export async function registerProactiveListener(
       // without distinguishing skip-tagged ones), defeating the very
       // cost-ceiling contract the bypass tag was meant to surface.
       let quotaReadFailed = false;
-      if (config.getQuotaStatus && config.workspaceId) {
+      if (config.getQuotaStatus) {
         let quota: Awaited<ReturnType<GetQuotaStatusFn>> | null = null;
         try {
           quota = await config.getQuotaStatus({
-            workspaceId: config.workspaceId,
+            workspaceId,
           });
         } catch (err) {
           // Fail open on quota — cost ceiling, not a security control.
@@ -483,14 +620,14 @@ export async function registerProactiveListener(
         } else if (quota?.capReached) {
           log.debug(
             {
-              workspaceId: config.workspaceId,
+              workspaceId,
               channelId,
               classifyCountThisMonth: quota.classifyCountThisMonth,
               monthlyClassifierCap: quota.monthlyClassifierCap,
             },
             "Proactive: skipped — monthly classifier cap reached",
           );
-          await emitMeter({
+          await emitMeter(workspaceId, {
             channelId,
             messageId: message.id,
             eventType: "classify",
@@ -509,21 +646,22 @@ export async function registerProactiveListener(
 
       const classification = await classifyMessage({
         text,
-        mode: config.workspace.classifierMode,
+        mode: workspaceConfig.classifierMode,
         llm: config.classify,
         log,
       });
 
       const decision = decideInterjection({
         classification,
-        workspace: config.workspace,
+        workspace: workspaceConfig,
         channel: channelConfig,
         channelAllowed,
-        recentActivity: recent.get(channelId),
+        recentActivity: recent.get(cooldownKey),
       });
 
       log.debug(
         {
+          workspaceId,
           channelId,
           messageId: message.id,
           isQuestion: classification.isQuestion,
@@ -540,7 +678,7 @@ export async function registerProactiveListener(
       // LLM-invoked calls without re-scanning metadata. `quotaReadFailed`
       // surfaces the per-message bypass without double-counting the
       // classify event.
-      await emitMeter({
+      await emitMeter(workspaceId, {
         channelId,
         messageId: message.id,
         eventType: "classify",
@@ -569,17 +707,17 @@ export async function registerProactiveListener(
 
       const sent = thread.createSentMessageFromMessage(message);
       await sent.addReaction(PROACTIVE_REACTION);
-      recent.set(channelId, { lastInterjectionAt: Date.now() });
+      recent.set(cooldownKey, { lastInterjectionAt: Date.now() });
 
-      const platform = adapterPlatform(undefined, config.platform);
+      const platform = adapterPlatform(thread.adapter, config.platform);
       const asker = askerFromAuthor(message.author, platform);
-      pending.record(thread.channelId, message.id, { text, asker });
+      pending.record(thread.channelId, message.id, { text, asker, workspaceId });
 
       // Meter: reaction landed — emit a `react` row so the admin
       // analytics panel and the eventual billing aggregator have a
       // clean "how often did the policy actually fire?" count without
       // scanning every classify row.
-      await emitMeter({
+      await emitMeter(workspaceId, {
         channelId,
         messageId: message.id,
         eventType: "react",
@@ -609,7 +747,12 @@ export async function registerProactiveListener(
   // -------------------------------------------------------------------------
   chat.onReaction([PROACTIVE_REACTION], async (event: ReactionEvent) => {
     try {
-      if (!(await config.isEnabled())) return;
+      // The pending entry carries `workspaceId` from the original
+      // channel-message handler. If there's no pending entry the
+      // reaction is on an unknown message — short-circuit before any
+      // gate or DB read. If there IS a pending entry, the workspace was
+      // already known-good at react-time; we just re-check the gate
+      // (license / kill-switch flip while the asker paused).
       const lookup = pending.peek(event.threadId, event.messageId);
       const decision = shouldAnswerOnReaction({
         added: event.added,
@@ -627,9 +770,20 @@ export async function registerProactiveListener(
         );
         return;
       }
+      const workspaceId = decision.pending.workspaceId;
+      if (!(await config.isEnabled(workspaceId))) return;
       // Consume now so a second reactor doesn't double-fire.
       pending.consume(event.threadId, event.messageId);
-      await runAnswerFlow(event.thread, event.threadId, decision.pending.text, decision.pending.asker, config, log, recentAnswers);
+      await runAnswerFlow(
+        event.thread,
+        event.threadId,
+        decision.pending.text,
+        decision.pending.asker,
+        workspaceId,
+        config,
+        log,
+        recentAnswers,
+      );
     } catch (err) {
       log.warn(
         {
@@ -646,7 +800,6 @@ export async function registerProactiveListener(
   // -------------------------------------------------------------------------
   chat.onAction(PROACTIVE_ANSWER_ACTION_ID, async (event) => {
     try {
-      if (!(await config.isEnabled())) return;
       // Thread is null for view-based actions (e.g. home-tab buttons),
       // which the proactive offer card never reaches.
       if (!event.thread) return;
@@ -664,7 +817,18 @@ export async function registerProactiveListener(
         );
         return;
       }
-      await runAnswerFlow(event.thread, event.threadId, lookup.text, lookup.asker, config, log, recentAnswers);
+      const workspaceId = lookup.workspaceId;
+      if (!(await config.isEnabled(workspaceId))) return;
+      await runAnswerFlow(
+        event.thread,
+        event.threadId,
+        lookup.text,
+        lookup.asker,
+        workspaceId,
+        config,
+        log,
+        recentAnswers,
+      );
     } catch (err) {
       log.warn(
         {
@@ -703,9 +867,26 @@ export async function registerProactiveListener(
     ],
     async (event) => {
       try {
-        if (!(await config.isEnabled())) return;
         const outcome = outcomeForActionId(event.actionId);
         if (!outcome) return;
+
+        // Resolve the tenant from the event's thread (the feedback
+        // button is clicked on the answer card, which lives in the
+        // same thread as the original question). Unknown tenant →
+        // silent skip.
+        if (!event.thread) return;
+        const workspaceId = await safeResolveWorkspace(
+          event.adapter,
+          event.thread,
+          // The action event doesn't carry the full Message that
+          // triggered the answer; pass a synthetic shape with the
+          // adapter-supplied messageId. The host's resolver is
+          // expected to derive workspaceId from `adapter` + raw, both
+          // of which are present.
+          { id: event.messageId, raw: event.raw } as unknown as Message,
+        );
+        if (!workspaceId) return;
+        if (!(await config.isEnabled(workspaceId))) return;
 
         const platform = adapterPlatform(event.adapter, config.platform);
         const asker = askerFromAuthor(event.user, platform);
@@ -756,7 +937,31 @@ export async function registerProactiveListener(
   // -------------------------------------------------------------------------
   chat.onModalSubmit(PROACTIVE_FB_WRONG_DATA_MODAL_ID, async (event) => {
     try {
-      if (!(await config.isEnabled())) return { action: "close" as const };
+      // Multi-tenant (#2620): resolve workspace from `relatedThread`
+      // when present (the modal was opened from the answer-card action
+      // button, which carries the thread context). When not present we
+      // can't safely attribute the feedback row — close the modal
+      // silently rather than write to the wrong tenant.
+      const relatedThread = event.relatedThread;
+      if (!relatedThread) {
+        log.debug(
+          {},
+          "Proactive wrong-data modal submit: no related thread — cannot resolve tenant, dropping",
+        );
+        return { action: "close" as const };
+      }
+      const workspaceId = await safeResolveWorkspace(
+        event.adapter,
+        relatedThread,
+        // Modal events don't surface the original message; pass a
+        // synthetic shape — the host resolver's contract is to derive
+        // workspaceId from `adapter` + raw context.
+        { id: "", raw: event.raw } as unknown as Message,
+      );
+      if (!workspaceId) return { action: "close" as const };
+      if (!(await config.isEnabled(workspaceId))) {
+        return { action: "close" as const };
+      }
 
       const platform = adapterPlatform(event.adapter, config.platform);
       const asker = askerFromAuthor(event.user, platform);
@@ -809,21 +1014,29 @@ export async function registerProactiveListener(
  * keep it as a free function (rather than a closure captured during
  * `registerProactiveListener`) so the bridge can call it directly
  * with the shared `RecentAnswers` registry.
+ *
+ * Post-#2620 multi-tenant: the bridge resolves `workspaceId` from the
+ * slash-command event (slack `team_id`) and threads it in. The slash
+ * subcommand intentionally bypasses `config.resolveWorkspaceId` — the
+ * resolver is keyed on the Message shape, and slash commands fire
+ * without a Message in the same sense (no thread). The bridge has the
+ * raw event and can resolve it directly.
  */
 export async function handleProactiveFeedbackSlash(args: {
   text: string | undefined;
   channelId: string;
+  workspaceId: string;
   asker: ProactiveAsker;
   config: ProactiveListenerConfig;
   log: PluginLogger;
   recentAnswers: RecentAnswers;
 }): Promise<boolean> {
-  const { text, channelId, asker, config, log, recentAnswers } = args;
+  const { text, channelId, workspaceId, asker, config, log, recentAnswers } = args;
   if (!config.feedbackCollector) return false;
   const parsed = parseFeedbackSlashArgs(text);
   if (parsed.kind !== "feedback") return false;
 
-  if (!(await config.isEnabled())) return false;
+  if (!(await config.isEnabled(workspaceId))) return false;
 
   const recent = recentAnswers.lookup(channelId, asker.externalUserId);
 
@@ -868,6 +1081,7 @@ async function runAnswerFlow(
   threadId: string,
   text: string,
   asker: ProactiveAsker,
+  workspaceId: string,
   config: ProactiveListenerConfig,
   log: PluginLogger,
   recentAnswers: RecentAnswers,
@@ -902,14 +1116,16 @@ async function runAnswerFlow(
   // Helper: route a meter event through the host (slice #2297 / #2296).
   // Shared with the public-dataset refusal branch below and the linked-
   // asker happy path. Failures are swallowed because the meter is
-  // observability, not control flow.
+  // observability, not control flow. Closes over `workspaceId` from
+  // the caller (#2620 multi-tenant — was `config.workspaceId ?? ""`
+  // pre-refactor).
   const emitMeter = async (
     partial: Omit<ProactiveMeterEvent, "workspaceId">,
   ): Promise<void> => {
     if (!config.onMeterEvent) return;
     try {
       await config.onMeterEvent({
-        workspaceId: config.workspaceId ?? "",
+        workspaceId,
         ...partial,
       });
     } catch (err) {
@@ -963,7 +1179,7 @@ async function runAnswerFlow(
     let allowlist: ReadonlyArray<ProactivePublicDatasetEntry> = [];
     try {
       allowlist = await config.getPublicDataset({
-        workspaceId: config.workspaceId ?? "",
+        workspaceId,
       });
     } catch (err) {
       // Fail closed — a registry hiccup must NOT widen the refusal
@@ -972,7 +1188,7 @@ async function runAnswerFlow(
       log.warn(
         {
           err: err instanceof Error ? err : new Error(String(err)),
-          workspaceId: config.workspaceId,
+          workspaceId,
         },
         "Proactive public-dataset lookup threw — treating as empty allowlist",
       );

--- a/plugins/chat/src/proactive/listener.ts
+++ b/plugins/chat/src/proactive/listener.ts
@@ -258,6 +258,38 @@ function askerFromAuthor(author: Author, platform: string): ProactiveAsker {
   };
 }
 
+/**
+ * Route a meter event through the host meter callback (slice #2296 /
+ * #2297). Failures are swallowed because the meter is observability,
+ * not control flow — a meter outage must never propagate into the SDK
+ * event loop.
+ *
+ * Single source of truth for proactive meter emission. Both the
+ * registration closure (`registerProactiveListener`) and the per-flow
+ * helper (`runAnswerFlow`) used to define identical inline closures
+ * over `config` / `log` / `workspaceId`; consolidating into one
+ * free function eliminates the drift risk.
+ */
+async function emitProactiveMeter(
+  config: ProactiveListenerConfig,
+  log: PluginLogger,
+  workspaceId: string,
+  partial: Omit<ProactiveMeterEvent, "workspaceId">,
+): Promise<void> {
+  if (!config.onMeterEvent) return;
+  try {
+    await config.onMeterEvent({ workspaceId, ...partial });
+  } catch (err) {
+    log.warn(
+      {
+        err: err instanceof Error ? err : new Error(String(err)),
+        eventType: partial.eventType,
+      },
+      "Proactive meter callback threw — suppressed",
+    );
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Listener registration
 // ---------------------------------------------------------------------------
@@ -285,12 +317,12 @@ export async function registerProactiveListener(
   log: PluginLogger,
   config: ProactiveListenerConfig,
 ): Promise<ProactiveListenerHandle> {
-  // Registration-time gate. Pre-#2620 the gate was zero-arg with
-  // `workspaceId` baked in; post-#2620 the gate takes workspaceId per
-  // call. At registration we don't know any tenant yet, so probe with
-  // an empty string — the host's implementation is expected to short-
-  // circuit on falsy / unknown ids (no enterprise license at boot means
-  // no listener registers anywhere, regardless of which workspace).
+  // Registration-time gate. Probe with empty string — the host's
+  // `isEnabled` short-circuits on `""` and answers only the enterprise
+  // check (skipping the workspace SELECT, which would otherwise resolve
+  // `false` on a row-missing lookup with `$1 = ''`). If EE isn't loaded,
+  // registration short-circuits at line 295-297. Real per-event calls
+  // pass actual workspaceIds.
   const enabledAtRegistration = await config.isEnabled("");
   if (!enabledAtRegistration) {
     log.debug("Proactive listener not registered — gate is closed");
@@ -328,31 +360,13 @@ export async function registerProactiveListener(
   // slice #2298 `/atlas feedback <text>` fallback path.
   const recentAnswers = new RecentAnswers();
 
-  // Local helper: route an event through the host meter callback,
-  // swallowing failures so a meter outage never propagates into the
-  // SDK event loop. Post-#2620 `workspaceId` is per event — caller
-  // supplies it as the first arg, the helper threads it onto the
-  // wire-format `ProactiveMeterEvent`.
-  const emitMeter = async (
+  // Local alias for the module-scope `emitProactiveMeter` helper —
+  // pre-applies `config` + `log` so call sites stay terse and the
+  // per-event `workspaceId` stays explicit.
+  const emitMeter = (
     workspaceId: string,
     partial: Omit<ProactiveMeterEvent, "workspaceId">,
-  ): Promise<void> => {
-    if (!config.onMeterEvent) return;
-    try {
-      await config.onMeterEvent({
-        workspaceId,
-        ...partial,
-      });
-    } catch (err) {
-      log.warn(
-        {
-          err: err instanceof Error ? err : new Error(String(err)),
-          eventType: partial.eventType,
-        },
-        "Proactive meter callback threw — suppressed",
-      );
-    }
-  };
+  ): Promise<void> => emitProactiveMeter(config, log, workspaceId, partial);
 
   // Per-event workspace resolution helper. Wraps `config.resolveWorkspaceId`
   // with a defensive try/catch so a host implementation that throws (the
@@ -362,8 +376,10 @@ export async function registerProactiveListener(
   // `thread` is typed loosely (`Thread<unknown, unknown>`) because the
   // listener takes events from `onNewMessage`, `onReaction`, `onAction`,
   // and `onModalSubmit` — each surfaces a thread with a different
-  // generic parameter. The resolver only reads `thread.channelId` /
-  // `adapter` / `message.raw`, so a loose generic is correct here.
+  // generic parameter. The Slack resolver reads only `adapter.name` +
+  // `message.raw`; the `thread` field is passed through for forward-
+  // compatibility with platforms that need it (Teams `channelData`,
+  // etc.) but no current resolver dereferences it.
   const safeResolveWorkspace = async (
     adapter: Adapter,
     thread: Thread<unknown, unknown>,
@@ -431,7 +447,9 @@ export async function registerProactiveListener(
       if (text.length === 0) return;
 
       // ---------------------------------------------------------------
-      // Per-event workspace resolution (#2620) — FIRST thing we do.
+      // Per-event workspace resolution (#2620) — first DB / host call
+      // we make. Runs before classify, meter, or kill-switch reads.
+      // (Bot/`isMe`/empty-text skips above run cheaper and earlier.)
       // Unknown tenant → silent skip, no meter event, no DB reads.
       // ---------------------------------------------------------------
       const workspaceId = await safeResolveWorkspace(
@@ -1015,12 +1033,12 @@ export async function registerProactiveListener(
  * `registerProactiveListener`) so the bridge can call it directly
  * with the shared `RecentAnswers` registry.
  *
- * Post-#2620 multi-tenant: the bridge resolves `workspaceId` from the
- * slash-command event (slack `team_id`) and threads it in. The slash
- * subcommand intentionally bypasses `config.resolveWorkspaceId` — the
- * resolver is keyed on the Message shape, and slash commands fire
- * without a Message in the same sense (no thread). The bridge has the
- * raw event and can resolve it directly.
+ * Post-#2620 multi-tenant: the bridge calls `config.resolveWorkspaceId`
+ * with a synthetic Message (id `""`, `raw` from the slash event) before
+ * invoking this helper, because slash events don't surface a Thread or
+ * Message the way `onNewMessage` does. The Slack resolver only reads
+ * `adapter.name` + `message.raw.team_id`, so the synthetic shape
+ * resolves correctly.
  */
 export async function handleProactiveFeedbackSlash(args: {
   text: string | undefined;
@@ -1113,31 +1131,14 @@ async function runAnswerFlow(
     return;
   }
 
-  // Helper: route a meter event through the host (slice #2297 / #2296).
-  // Shared with the public-dataset refusal branch below and the linked-
-  // asker happy path. Failures are swallowed because the meter is
-  // observability, not control flow. Closes over `workspaceId` from
-  // the caller (#2620 multi-tenant — was `config.workspaceId ?? ""`
-  // pre-refactor).
-  const emitMeter = async (
+  // Local alias for the module-scope `emitProactiveMeter` helper —
+  // pre-applies `config` / `log` / `workspaceId` (the latter is the
+  // per-flow tenant resolved at the caller; was `config.workspaceId ?? ""`
+  // pre-#2620). Shared by the public-dataset refusal branch and the
+  // linked-asker happy path below.
+  const emitMeter = (
     partial: Omit<ProactiveMeterEvent, "workspaceId">,
-  ): Promise<void> => {
-    if (!config.onMeterEvent) return;
-    try {
-      await config.onMeterEvent({
-        workspaceId,
-        ...partial,
-      });
-    } catch (err) {
-      log.warn(
-        {
-          err: err instanceof Error ? err : new Error(String(err)),
-          eventType: partial.eventType,
-        },
-        "Proactive meter callback threw — suppressed",
-      );
-    }
-  };
+  ): Promise<void> => emitProactiveMeter(config, log, workspaceId, partial);
 
   // -----------------------------------------------------------------
   // Slice #2297 — unlinked-asker public dataset gate

--- a/plugins/chat/src/proactive/types.ts
+++ b/plugins/chat/src/proactive/types.ts
@@ -29,6 +29,7 @@ export type {
   AnnouncementOutcome,
 } from "@useatlas/types";
 
+import type { Adapter, Message, Thread } from "chat";
 import type {
   ClassificationResult,
   ProactiveMeterEvent,
@@ -88,11 +89,88 @@ export type LLMClassifierFn = (text: string) => Promise<ClassificationResult>;
 /**
  * Gate callback injected from the host.
  *
- * Returns true when proactive mode is allowed for this workspace. The
- * host wires this to `isEnterpriseEnabled() && workspaceFlag` so the
+ * Returns true when proactive mode is allowed for the given workspace.
+ * Takes `workspaceId` as a per-call argument (multi-tenant) — pre-#2620
+ * this was zero-arg with `workspaceId` baked at registration; after #2620
+ * the listener resolves workspace per event and threads the id through.
+ *
+ * The host wires this to `isEnterpriseEnabled() && workspaceFlag` so the
  * plugin itself does not import `@atlas/ee`.
  */
-export type ProactiveGateFn = () => boolean | Promise<boolean>;
+export type ProactiveGateFn = (
+  workspaceId: string,
+) => boolean | Promise<boolean>;
+
+// ---------------------------------------------------------------------------
+// Per-event workspace resolution (#2620)
+// ---------------------------------------------------------------------------
+//
+// Pre-#2620 the listener carried a single `workspaceId` baked at
+// registration. SaaS routes Slack events from N tenants through one Chat
+// instance, so a static workspaceId stamps the wrong tenant on every meter
+// row / pause check / quota lookup. The fix is per-event resolution.
+//
+// The host implements `ResolveWorkspaceIdFn` by reading the platform-
+// specific tenant identifier (Slack `team_id`, Teams `tenantId`, ...) out
+// of the raw message and looking up the corresponding Atlas workspace.
+// Returning `null` is a silent skip: unrecognized tenant, no classify, no
+// meter row.
+
+/**
+ * Per-event workspace resolution callback.
+ *
+ * Returns the Atlas workspace id (`org_id` in the internal DB) for the
+ * tenant that sent this event, or `null` when the event doesn't belong
+ * to any known tenant (unrecognized `team_id`, missing raw payload,
+ * etc.). On `null` the listener silently skips — no classification, no
+ * meter event, no kill-switch read.
+ *
+ * Implementations should never throw. Failures should resolve as `null`
+ * so the listener fails closed (skip) without crashing the SDK loop.
+ *
+ * Host wiring (Slack-first): see
+ * `packages/api/src/lib/proactive/workspace-id-resolver.ts` for the
+ * canonical implementation that maps Slack `team_id` →
+ * `slack_installations.org_id`.
+ */
+export type ResolveWorkspaceIdFn = (event: {
+  adapter: Adapter;
+  thread: Thread;
+  message: Message;
+}) => Promise<string | null>;
+
+/**
+ * Per-event workspace config fetcher.
+ *
+ * Replaces the pre-#2620 static `workspace: WorkspaceProactiveConfig`
+ * registration field. Called once per event after `resolveWorkspaceId`
+ * succeeds; the listener caches the result for the lifetime of the
+ * single event handler call so repeated lookups inside one handler stay
+ * cheap.
+ *
+ * Returns `null` when the workspace has no config row (treat as not
+ * opted in; the listener short-circuits without classification).
+ * Implementations should never throw — failures resolve as `null`.
+ */
+export type GetWorkspaceConfigFn = (
+  workspaceId: string,
+) => Promise<WorkspaceProactiveConfig | null>;
+
+/**
+ * Per-event channel-config fetcher.
+ *
+ * Replaces the pre-#2620 static `channelConfigs:
+ * Record<string, ChannelProactiveConfig>` registration field. Returns
+ * the workspace's per-channel overrides as a flat array; the listener
+ * scans it linearly per event (channel-config arrays are short in
+ * practice — a handful of allow/deny overrides per workspace).
+ *
+ * Implementations should never throw — failures should resolve as an
+ * empty array so the listener falls back to workspace-default behaviour.
+ */
+export type GetChannelConfigsFn = (
+  workspaceId: string,
+) => Promise<ReadonlyArray<ChannelProactiveConfig>>;
 
 // ---------------------------------------------------------------------------
 // Kill switch (#2295) — three-layer pause + per-user opt-out


### PR DESCRIPTION
## Summary

- Lifts `workspaceId` from a static field at registration to a per-event resolution callback on the chat plugin's proactive listener. SaaS routes N tenants through one Chat instance — once slice 3 (#2611) migrates `@mention` off `slack.ts`, every tenant's events arrive at the plugin. Without this, the listener would stamp them all with one baked `workspaceId` (cross-tenant meter pollution, wrong-workspace quota, wrong pause-registry rows).
- Plugin contract: `ProactiveListenerConfig` drops `workspaceId`/`workspace`/`channelConfigs` and gains `resolveWorkspaceId` + `getWorkspaceConfig` + `getChannelConfigs`. `ProactiveGateFn` now takes `workspaceId`. `emitMeter` plumbs workspaceId per call. `PendingAnswerEntry` carries `workspaceId` so reaction-back / button-click flows route to the right tenant.
- Host side: `createProactiveEnabledGate(runtime)` returns a per-call `(workspaceId) => Promise<bool>` (enterprise cache stays per-closure; workspace SELECT still re-runs per call). New helpers `createSlackWorkspaceIdResolver()` (Slack `team_id` → `slack_installations.org_id`) and `getWorkspaceProactiveConfig` / `getChannelProactiveConfigs`.
- 31 new tests added (26 host-helper, 4 multi-tenant listener cases, 1 multi-tenant gate). Listener test fixtures migrated to stub the new fetcher shape.

## Deviation from issue spec

- Issue body referenced `slack_integrations`; canonical table from `0000_baseline.sql:74` is `slack_installations`. Used the canonical name (documented inline).
- Resolver uses a structural interface for `Adapter` / `Message` rather than importing `chat` types — keeps the host helper out of the plugin's full type tree. Strict types still enforced at the plugin call site.

## Test plan

- [ ] CI green (lint / type / test / syncpack / drift / railway-watch / schema-drift — all pass locally)
- [ ] No production callers wire the new shape yet — slice 2 (#2610) is the wiring follow-up; this PR is a prereq refactor with no behavior change at the registration site
- [ ] Boot Smoke green on Railway after merge
- [ ] /pr-review-toolkit:review-pr addresses any P0/P1

Closes #2620