### PR TITLE
feat(deploy): #2610 — wire proactive listener callbacks in SaaS deploy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -289,6 +289,12 @@ ATLAS_ADMIN_EMAIL=admin@useatlas.dev
 # Default: http://localhost:3001 (matches `bun run dev` fixed port)
 # ATLAS_API_URL=http://localhost:3001
 
+# === Public Web URL (optional) ===
+# Public-facing web URL used in user-visible link prompts (e.g. the
+# proactive listener's "link your Atlas account" DM CTA). Defaults to
+# the SaaS host; set this on self-hosted deploys with a custom domain.
+# ATLAS_PUBLIC_WEB_URL=https://app.useatlas.dev
+
 # === Frontend API URL (optional) ===
 # When set, the frontend calls the API directly (cross-origin).
 # When unset, the frontend uses same-origin relative URLs

--- a/deploy/api/atlas.config.ts
+++ b/deploy/api/atlas.config.ts
@@ -12,6 +12,7 @@
  *   - ATLAS_REGION_APAC_DB_URL
  */
 
+import { ManagedRuntime } from "effect";
 import { defineConfig } from "./packages/api/src/lib/config";
 // Relative import: atlas.config.ts lives at /app/ in the SaaS container,
 // outside any workspace's node_modules resolution tree. The workspace
@@ -20,6 +21,51 @@ import { defineConfig } from "./packages/api/src/lib/config";
 // The `defineConfig` import above uses the same relative-path pattern
 // for the same reason. Resolved at boot via bun's TS loader.
 import { chatPlugin } from "./plugins/chat/src/index";
+import {
+  AtlasAiModel,
+  AtlasAiModelLive,
+} from "./packages/api/src/lib/effect/ai";
+import { getEnterpriseRuntime } from "./packages/api/src/lib/effect/enterprise-layer";
+import { createSlackWorkspaceIdResolver } from "./packages/api/src/lib/proactive/workspace-id-resolver";
+import { createProactiveEnabledGate } from "./packages/api/src/lib/proactive/enabled-gate";
+import {
+  getChannelProactiveConfigs,
+  getWorkspaceProactiveConfig,
+} from "./packages/api/src/lib/proactive/workspace-config-loader";
+import { createProactiveClassifier } from "./packages/api/src/lib/proactive/classifier-adapter";
+import { createProactiveAnswerAdapter } from "./packages/api/src/lib/proactive/answer-adapter";
+import { recordMeterEvent } from "./packages/api/src/lib/proactive/answer-meter";
+import {
+  handlePluginPauseRequest,
+  isPaused as isPausedHelper,
+} from "./packages/api/src/lib/proactive/pause-registry";
+import { getWorkspaceQuotaStatus } from "./packages/api/src/lib/proactive/quota";
+import { getAllowlist } from "./packages/api/src/lib/proactive/public-dataset";
+
+// ── Lazy ManagedRuntime for AtlasAiModel ────────────────────────────
+//
+// The classifier + answer adapters need a ManagedRuntime that provides
+// AtlasAiModel (the configured Vercel AI SDK LanguageModel). The
+// server's own runtime in `packages/api/src/api/server.ts` is built
+// locally and isn't exported, so we materialise a small dedicated
+// runtime here. Lazy construction defers the `AtlasAiModelLive`
+// resolution (which reads ATLAS_PROVIDER / ATLAS_MODEL via the settings
+// + providers modules) until first call — by then settings are
+// populated and the env is stable. Process-lifetime cached: the layer's
+// 5s TTL inside SaaS mode handles admin-driven model swaps without a
+// restart, so we don't need to rebuild the runtime ourselves.
+let _aiRuntime:
+  | ManagedRuntime.ManagedRuntime<AtlasAiModel, never>
+  | null = null;
+function getProactiveAiRuntime(): ManagedRuntime.ManagedRuntime<
+  AtlasAiModel,
+  never
+> {
+  if (_aiRuntime === null) {
+    _aiRuntime = ManagedRuntime.make(AtlasAiModelLive);
+  }
+  return _aiRuntime;
+}
 
 export default defineConfig({
   // ── Datasource ──────────────────────────────────────────────────
@@ -89,6 +135,87 @@ export default defineConfig({
         throw new Error(
           "This Slack integration is being upgraded. Please try again in a moment, or contact your Atlas admin if this persists.",
         );
+      },
+      // ── Proactive listener wiring (slice 2 of #2607) ──────────────
+      // Wires every callback the proactive listener consumes to the
+      // host helpers under `packages/api/src/lib/proactive/`. After this
+      // block lands, flipping `workspace_proactive_config.enabled = true`
+      // on a workspace + adding a `channel_proactive_config` row makes
+      // Atlas emit 🤖 reactions in real time. The reaction-back / answer
+      // flow runs through `executeQueryProactive`; with the user
+      // resolver stubbed to "unlinked" today (multi-tenant gap — see
+      // follow-up issue), unlinked askers refuse safely until the
+      // resolver is upgraded to carry workspace context.
+      //
+      // All adapters resolve their runtimes lazily so the proactive
+      // block can be declared at module load time without forcing the
+      // AI provider / Effect EE layer to materialise during config
+      // import. `getEnterpriseRuntime()` is module-cached; the
+      // AtlasAiModel runtime is closed over `getProactiveAiRuntime()`
+      // and built on first call.
+      proactive: {
+        platform: "slack",
+        // Per-event resolution: maps Slack `team_id` →
+        // `slack_installations.org_id`. Returns null on unknown tenants
+        // (silent skip — no classify, no meter, no kill-switch read).
+        resolveWorkspaceId: createSlackWorkspaceIdResolver(),
+        // Two-tier gate: enterprise check (cached) + per-workspace
+        // `workspace_proactive_config.enabled` (re-read every call).
+        // `getEnterpriseRuntime()` provides ProactiveGate (and the rest
+        // of EnterpriseSubsystem); the wider runtime is structurally
+        // compatible with the narrower `ManagedRuntime<ProactiveGate>`
+        // the factory requires.
+        isEnabled: createProactiveEnabledGate(getEnterpriseRuntime()),
+        // Per-event config fetchers (post-#2620 multi-tenant).
+        getWorkspaceConfig: getWorkspaceProactiveConfig,
+        getChannelConfigs: getChannelProactiveConfigs,
+        // Classifier wraps Atlas's primary configured LLM via the
+        // module-level lazy AI runtime. `createProactiveClassifier`'s
+        // `RIn` type parameter widens to allow this `ManagedRuntime<
+        // AtlasAiModel, never>`.
+        classify: createProactiveClassifier(getProactiveAiRuntime()),
+        // Reaction-back answer flow. Unlinked askers (every asker today
+        // because `userResolver` stubs `atlasUserId: undefined`) get
+        // refused with the user-safe error since we omit the adapter's
+        // `getPublicDataset` option — refusing is the safe default
+        // until the multi-tenant user-resolver gap is closed.
+        executeQueryProactive: createProactiveAnswerAdapter(
+          getProactiveAiRuntime(),
+        ),
+        // TODO(#2624): The plugin's `ProactiveUserResolver` shape —
+        // `(asker) => Promise<ResolvedAsker>` — doesn't carry team_id /
+        // workspaceId. On SaaS the same Slack userId can exist across
+        // multiple tenants and would resolve to different Atlas users.
+        // Stub to always-unlinked for now (constrains the agent to
+        // refuse on the unlinked path, which is the safe fallback).
+        userResolver: async () => ({ atlasUserId: undefined }),
+        linkUrl:
+          process.env.ATLAS_PUBLIC_WEB_URL ?? "https://app.useatlas.dev",
+        // Three-layer kill switch + per-user opt-out. The plugin's
+        // `IsPausedFn` input shape (`{ workspaceId, channelId, userId? }`)
+        // is a structural subset of the host helper's input — pass the
+        // helper directly so admin-inspection options (`failOpenOnError`,
+        // `now`) stay on the helper while the listener uses the
+        // fail-CLOSED default.
+        isPaused: isPausedHelper,
+        onPauseRequest: handlePluginPauseRequest,
+        // Per-event meter callback. `recordMeterEvent` swallows DB
+        // failures internally (logs at error) so the Chat SDK event
+        // loop never sees a rejection.
+        onMeterEvent: recordMeterEvent,
+        // Monthly cap reader. Plugin's `GetQuotaStatusFn` takes
+        // `{ workspaceId }`; the host helper takes a bare `workspaceId`
+        // (plus an optional `now` for tests), so adapt the shape here.
+        getQuotaStatus: (input) => getWorkspaceQuotaStatus(input.workspaceId),
+        // Public-dataset allowlist reader for the unlinked-asker
+        // post-filter. Plugin's `GetPublicDatasetFn` takes
+        // `{ workspaceId }`; the host helper takes a bare workspaceId
+        // and returns the same `PublicDatasetEntry[]` shape.
+        getPublicDataset: (input) => getAllowlist(input.workspaceId),
+        // feedbackCollector intentionally omitted — adding it would
+        // require a non-trivial host helper (write to meter +
+        // optionally to evals dataset). Per slice 2 scope: defer
+        // feedback wiring to a follow-up.
       },
     }),
   ],

--- a/deploy/api/atlas.config.ts
+++ b/deploy/api/atlas.config.ts
@@ -12,7 +12,6 @@
  *   - ATLAS_REGION_APAC_DB_URL
  */
 
-import { ManagedRuntime } from "effect";
 import { defineConfig } from "./packages/api/src/lib/config";
 // Relative import: atlas.config.ts lives at /app/ in the SaaS container,
 // outside any workspace's node_modules resolution tree. The workspace
@@ -21,7 +20,7 @@ import { defineConfig } from "./packages/api/src/lib/config";
 // The `defineConfig` import above uses the same relative-path pattern
 // for the same reason. Resolved at boot via bun's TS loader.
 import { chatPlugin } from "./plugins/chat/src/index";
-import { AtlasAiModelLive } from "./packages/api/src/lib/effect/ai";
+import { getProactiveAiRuntime } from "./packages/api/src/lib/effect/ai";
 import { getEnterpriseRuntime } from "./packages/api/src/lib/effect/enterprise-layer";
 import { createSlackWorkspaceIdResolver } from "./packages/api/src/lib/proactive/workspace-id-resolver";
 import { createProactiveEnabledGate } from "./packages/api/src/lib/proactive/enabled-gate";
@@ -40,12 +39,12 @@ import { getWorkspaceQuotaStatus } from "./packages/api/src/lib/proactive/quota"
 import { getAllowlist } from "./packages/api/src/lib/proactive/public-dataset";
 
 // Dedicated runtime for the proactive classifier + answer adapters.
-// The server's own runtime in `packages/api/src/api/server.ts` isn't
-// exported, so we build a small one here. `ManagedRuntime.make` is
-// cheap — it defers `AtlasAiModelLive` resolution until the first
-// `runPromise()`, by which point settings are populated. The layer's
-// 5s settings TTL absorbs admin-driven model swaps without a restart.
-const proactiveAiRuntime = ManagedRuntime.make(AtlasAiModelLive);
+// Built inside the workspace by `getProactiveAiRuntime()` so this file
+// stays free of bare-package `effect` imports (which can't be resolved
+// from /app/ in the SaaS container — the workspace's `effect` lives
+// under packages/api/node_modules and isn't on the upward walk from
+// /app/atlas.config.ts). Process-lifetime cached on the helper side.
+const proactiveAiRuntime = getProactiveAiRuntime();
 
 export default defineConfig({
   // ── Datasource ──────────────────────────────────────────────────

--- a/deploy/api/atlas.config.ts
+++ b/deploy/api/atlas.config.ts
@@ -21,10 +21,7 @@ import { defineConfig } from "./packages/api/src/lib/config";
 // The `defineConfig` import above uses the same relative-path pattern
 // for the same reason. Resolved at boot via bun's TS loader.
 import { chatPlugin } from "./plugins/chat/src/index";
-import {
-  AtlasAiModel,
-  AtlasAiModelLive,
-} from "./packages/api/src/lib/effect/ai";
+import { AtlasAiModelLive } from "./packages/api/src/lib/effect/ai";
 import { getEnterpriseRuntime } from "./packages/api/src/lib/effect/enterprise-layer";
 import { createSlackWorkspaceIdResolver } from "./packages/api/src/lib/proactive/workspace-id-resolver";
 import { createProactiveEnabledGate } from "./packages/api/src/lib/proactive/enabled-gate";
@@ -37,35 +34,18 @@ import { createProactiveAnswerAdapter } from "./packages/api/src/lib/proactive/a
 import { recordMeterEvent } from "./packages/api/src/lib/proactive/answer-meter";
 import {
   handlePluginPauseRequest,
-  isPaused as isPausedHelper,
+  isPaused,
 } from "./packages/api/src/lib/proactive/pause-registry";
 import { getWorkspaceQuotaStatus } from "./packages/api/src/lib/proactive/quota";
 import { getAllowlist } from "./packages/api/src/lib/proactive/public-dataset";
 
-// ── Lazy ManagedRuntime for AtlasAiModel ────────────────────────────
-//
-// The classifier + answer adapters need a ManagedRuntime that provides
-// AtlasAiModel (the configured Vercel AI SDK LanguageModel). The
-// server's own runtime in `packages/api/src/api/server.ts` is built
-// locally and isn't exported, so we materialise a small dedicated
-// runtime here. Lazy construction defers the `AtlasAiModelLive`
-// resolution (which reads ATLAS_PROVIDER / ATLAS_MODEL via the settings
-// + providers modules) until first call — by then settings are
-// populated and the env is stable. Process-lifetime cached: the layer's
-// 5s TTL inside SaaS mode handles admin-driven model swaps without a
-// restart, so we don't need to rebuild the runtime ourselves.
-let _aiRuntime:
-  | ManagedRuntime.ManagedRuntime<AtlasAiModel, never>
-  | null = null;
-function getProactiveAiRuntime(): ManagedRuntime.ManagedRuntime<
-  AtlasAiModel,
-  never
-> {
-  if (_aiRuntime === null) {
-    _aiRuntime = ManagedRuntime.make(AtlasAiModelLive);
-  }
-  return _aiRuntime;
-}
+// Dedicated runtime for the proactive classifier + answer adapters.
+// The server's own runtime in `packages/api/src/api/server.ts` isn't
+// exported, so we build a small one here. `ManagedRuntime.make` is
+// cheap — it defers `AtlasAiModelLive` resolution until the first
+// `runPromise()`, by which point settings are populated. The layer's
+// 5s settings TTL absorbs admin-driven model swaps without a restart.
+const proactiveAiRuntime = ManagedRuntime.make(AtlasAiModelLive);
 
 export default defineConfig({
   // ── Datasource ──────────────────────────────────────────────────
@@ -136,23 +116,15 @@ export default defineConfig({
           "This Slack integration is being upgraded. Please try again in a moment, or contact your Atlas admin if this persists.",
         );
       },
-      // ── Proactive listener wiring (slice 2 of #2607) ──────────────
-      // Wires every callback the proactive listener consumes to the
-      // host helpers under `packages/api/src/lib/proactive/`. After this
+      // ── Proactive listener wiring (#2607) ─────────────────────────
+      // Wires every callback the proactive listener consumes to host
+      // helpers under `packages/api/src/lib/proactive/`. After this
       // block lands, flipping `workspace_proactive_config.enabled = true`
       // on a workspace + adding a `channel_proactive_config` row makes
       // Atlas emit 🤖 reactions in real time. The reaction-back / answer
-      // flow runs through `executeQueryProactive`; with the user
-      // resolver stubbed to "unlinked" today (multi-tenant gap — see
-      // follow-up issue), unlinked askers refuse safely until the
-      // resolver is upgraded to carry workspace context.
-      //
-      // All adapters resolve their runtimes lazily so the proactive
-      // block can be declared at module load time without forcing the
-      // AI provider / Effect EE layer to materialise during config
-      // import. `getEnterpriseRuntime()` is module-cached; the
-      // AtlasAiModel runtime is closed over `getProactiveAiRuntime()`
-      // and built on first call.
+      // flow runs through `executeQueryProactive`; the user-resolver
+      // stub (multi-tenant gap — #2624) keeps every asker on the
+      // unlinked path, where the adapter refuses safely.
       proactive: {
         platform: "slack",
         // Per-event resolution: maps Slack `team_id` →
@@ -169,35 +141,33 @@ export default defineConfig({
         // Per-event config fetchers (post-#2620 multi-tenant).
         getWorkspaceConfig: getWorkspaceProactiveConfig,
         getChannelConfigs: getChannelProactiveConfigs,
-        // Classifier wraps Atlas's primary configured LLM via the
-        // module-level lazy AI runtime. `createProactiveClassifier`'s
-        // `RIn` type parameter widens to allow this `ManagedRuntime<
-        // AtlasAiModel, never>`.
-        classify: createProactiveClassifier(getProactiveAiRuntime()),
-        // Reaction-back answer flow. Unlinked askers (every asker today
-        // because `userResolver` stubs `atlasUserId: undefined`) get
-        // refused with the user-safe error since we omit the adapter's
-        // `getPublicDataset` option — refusing is the safe default
-        // until the multi-tenant user-resolver gap is closed.
-        executeQueryProactive: createProactiveAnswerAdapter(
-          getProactiveAiRuntime(),
-        ),
-        // TODO(#2624): The plugin's `ProactiveUserResolver` shape —
-        // `(asker) => Promise<ResolvedAsker>` — doesn't carry team_id /
-        // workspaceId. On SaaS the same Slack userId can exist across
-        // multiple tenants and would resolve to different Atlas users.
-        // Stub to always-unlinked for now (constrains the agent to
-        // refuse on the unlinked path, which is the safe fallback).
+        // Classifier wraps Atlas's primary configured LLM via
+        // `proactiveAiRuntime`. The factory's `RIn` type parameter
+        // widens to accept the runtime's full service set.
+        classify: createProactiveClassifier(proactiveAiRuntime),
+        // Reaction-back answer flow. The adapter's optional
+        // `getPublicDataset(asker)` callback — distinct from the
+        // plugin-level `getPublicDataset` wired below — is intentionally
+        // omitted: with the user resolver stubbed to unlinked, every
+        // asker hits the adapter's "refuse unlinked" path before
+        // touching the agent. The plugin-level `getPublicDataset` post-
+        // filter on the listener side is wired (line ~199) and becomes
+        // load-bearing once #2624 closes the user-resolver gap.
+        executeQueryProactive: createProactiveAnswerAdapter(proactiveAiRuntime),
+        // TODO(#2624): `ProactiveAsker` carries `{ platform, externalUserId, userName? }`
+        // — no `team_id` / `workspaceId`. On SaaS the same Slack userId
+        // can exist across multiple tenants and would resolve to
+        // different Atlas users without workspace context. Stubbed to
+        // always-unlinked; the unlinked path is the refuse-safe branch
+        // (adapter refuses; plugin-level public-dataset post-filter
+        // remains a defense-in-depth net for when #2624 lands).
         userResolver: async () => ({ atlasUserId: undefined }),
         linkUrl:
           process.env.ATLAS_PUBLIC_WEB_URL ?? "https://app.useatlas.dev",
-        // Three-layer kill switch + per-user opt-out. The plugin's
-        // `IsPausedFn` input shape (`{ workspaceId, channelId, userId? }`)
-        // is a structural subset of the host helper's input — pass the
-        // helper directly so admin-inspection options (`failOpenOnError`,
-        // `now`) stay on the helper while the listener uses the
-        // fail-CLOSED default.
-        isPaused: isPausedHelper,
+        // Three-layer kill switch + per-user opt-out. Plugin's
+        // `IsPausedFn` input shape is a structural subset of the host
+        // helper's — pass the helper directly.
+        isPaused,
         onPauseRequest: handlePluginPauseRequest,
         // Per-event meter callback. `recordMeterEvent` swallows DB
         // failures internally (logs at error) so the Chat SDK event
@@ -207,15 +177,15 @@ export default defineConfig({
         // `{ workspaceId }`; the host helper takes a bare `workspaceId`
         // (plus an optional `now` for tests), so adapt the shape here.
         getQuotaStatus: (input) => getWorkspaceQuotaStatus(input.workspaceId),
-        // Public-dataset allowlist reader for the unlinked-asker
-        // post-filter. Plugin's `GetPublicDatasetFn` takes
-        // `{ workspaceId }`; the host helper takes a bare workspaceId
-        // and returns the same `PublicDatasetEntry[]` shape.
+        // Plugin-level public-dataset allowlist (post-filter on the
+        // listener side, distinct from the adapter option omitted at
+        // `executeQueryProactive` above). Defense-in-depth: once #2624
+        // closes the user-resolver gap and linked askers reach the
+        // agent, this post-filter still gates unlinked-asker results.
         getPublicDataset: (input) => getAllowlist(input.workspaceId),
         // feedbackCollector intentionally omitted — adding it would
         // require a non-trivial host helper (write to meter +
-        // optionally to evals dataset). Per slice 2 scope: defer
-        // feedback wiring to a follow-up.
+        // optionally to evals dataset). Deferred to a follow-up.
       },
     }),
   ],

--- a/packages/api/src/lib/effect/ai.ts
+++ b/packages/api/src/lib/effect/ai.ts
@@ -23,7 +23,7 @@
  * ```
  */
 
-import { Context, Effect, Layer } from "effect";
+import { Context, Effect, Layer, ManagedRuntime } from "effect";
 import type { LanguageModel } from "ai";
 import { createLogger } from "@atlas/api/lib/logger";
 
@@ -154,6 +154,41 @@ export const AtlasAiModelLive: Layer.Layer<AtlasAiModel, Error> = Layer.effect(
     return bootModel satisfies AtlasAiModelShape;
   }),
 );
+
+/**
+ * Lazily-built ManagedRuntime over {@link AtlasAiModelLive}.
+ *
+ * The proactive classifier + answer adapters (`lib/proactive/*-adapter.ts`)
+ * need a `ManagedRuntime` providing `AtlasAiModel`. The server's app
+ * runtime in `api/server.ts` isn't exported and the deploy config
+ * (`deploy/api/atlas.config.ts` at `/app/`) sits outside the workspace
+ * `node_modules` tree — so `effect` itself can't be imported directly
+ * from atlas.config.ts. Exposing a built runtime through this module
+ * (which atlas.config.ts already reaches via relative path) keeps the
+ * deploy config free of bare-package imports.
+ *
+ * Process-lifetime cached. The layer's 5s settings TTL handles admin-
+ * driven model swaps without rebuilding the runtime.
+ */
+let _proactiveAiRuntime:
+  | ManagedRuntime.ManagedRuntime<AtlasAiModel, never>
+  | null = null;
+export function getProactiveAiRuntime(): ManagedRuntime.ManagedRuntime<
+  AtlasAiModel,
+  never
+> {
+  if (_proactiveAiRuntime === null) {
+    // AtlasAiModelLive has `Error` in its error channel (boot-time AI
+    // provider misconfig surfaces as a Layer failure). `Layer.orDie`
+    // converts that to an unrecoverable defect so the runtime's `E` is
+    // `never` — matching what the proactive factories require. A boot-
+    // time AI failure now surfaces as a rejected promise on the first
+    // `runPromise()`, which the classifier/answer adapters already
+    // catch + fail-closed.
+    _proactiveAiRuntime = ManagedRuntime.make(Layer.orDie(AtlasAiModelLive));
+  }
+  return _proactiveAiRuntime;
+}
 
 /**
  * Create a Live layer for a workspace-level model configuration.


### PR DESCRIPTION
## Summary

- Adds the `proactive:` block to the existing `chatPlugin({...})` call in `deploy/api/atlas.config.ts`. Slice 2 of #2607 — pure wiring, no new business logic.
- All required callbacks wired to host helpers under `packages/api/src/lib/proactive/`:
  - `resolveWorkspaceId` → Slack `team_id` → `slack_installations.org_id` lookup (post-#2620)
  - `isEnabled` → `createProactiveEnabledGate(getEnterpriseRuntime())` (two-tier: EE cached, workspace re-read)
  - `getWorkspaceConfig` / `getChannelConfigs` → fetchers from `workspace-config-loader.ts`
  - `classify` → `createProactiveClassifier(getProactiveAiRuntime())` (#2617)
  - `executeQueryProactive` → `createProactiveAnswerAdapter(getProactiveAiRuntime())` (#2618)
  - `isPaused` / `onPauseRequest` → `pause-registry.ts`
  - `onMeterEvent` → `recordMeterEvent` from `answer-meter.ts`
  - `getQuotaStatus` → `getWorkspaceQuotaStatus` (shape-adapted from `{ workspaceId }` → bare arg)
  - `getPublicDataset` → `getAllowlist` (shape-adapted similarly)
- Lazy `getProactiveAiRuntime()` (process-lifetime cached) defers `AtlasAiModelLive` materialisation until first call — keeps boot fast and lets the layer's 5s TTL handle admin model swaps.
- All imports are relative paths (`./packages/api/src/lib/...`) per the slice-1 container constraint (`atlas.config.ts` lives at `/app/` in SaaS, outside the workspace tree).

## Known gap (deferred — #2624)

- `userResolver` stubbed to always-unlinked (`{ atlasUserId: undefined }`)
- `getPublicDataset` adapter option intentionally omitted

Reason: the plugin's `ProactiveUserResolver` and `executeQueryProactive` shapes don't carry workspace context. On SaaS the same Slack `externalUserId` can exist across tenants. With the safe stubs in place, the 🤖 reaction + classify + meter / kill switch / quota all light up, but the reaction-back answer flow refuses safely until #2624 closes the plugin-side contract gap. Slice 4 dogfood will need #2624 landed (or worked around) to fully demonstrate the answer flow.

`feedbackCollector` intentionally deferred — non-trivial host helper.

## Test plan

- [x] CI gates green: lint / type / test / syncpack / template-drift / security-headers / railway-watch / schema-drift / oauth-helper-drift
- [ ] Boot Smoke green on Railway (proves the new config block parses + the lazy runtime construction doesn't trip boot)
- [ ] No regression on `executeQuery` stub (slice 1's friendly-upgrade throw still wired — slice 3 retires it)
- [ ] /pr-review-toolkit:review-pr addresses any P0/P1

## Follow-ups

- #2624 — `ProactiveUserResolver` + `executeQueryProactive` need workspace context (unblocks slice 4 dogfood)
- #2623 — Type-design polish (P2 items from #2620 review)

Closes #2610