### PR TITLE
feat(api,plugins/chat,deploy): #2611 — migrate Slack @mention + thread to chat plugin

### DIFF
--- a/deploy/api/atlas.config.ts
+++ b/deploy/api/atlas.config.ts
@@ -68,13 +68,18 @@ export default defineConfig({
   // ── Plugins ─────────────────────────────────────────────────────
   // Slice 3 of #2607 — the chat plugin now owns the @mention + thread
   // event path end-to-end. The plugin's webhook routes at
-  // /api/plugins/chat-interaction/* are reachable from the Slack app
-  // manifest (operational step: flip the event-subscription URL from
-  // /api/v1/slack/events to /api/plugins/chat-interaction/webhooks/slack;
-  // done as part of slice 4 of #2607 / #2612). The legacy
-  // /api/v1/slack/{commands,interactions,install,callback} routes in
-  // packages/api/src/api/routes/slack.ts stay put — they handle
-  // slash commands, block actions, modals, and OAuth.
+  // /api/plugins/chat-interaction/* are reachable.
+  //
+  // TODO(#2612 / slice 4 — HITL dogfood): the Slack app manifest MUST
+  // be flipped during slice 4 — change the Events API request URL from
+  // /api/v1/slack/events to /api/plugins/chat-interaction/webhooks/slack.
+  // The legacy /api/v1/slack/events route now ignores all event_callback
+  // types (logs at warn), so until the flip happens @mentions and thread
+  // replies are silently dropped.
+  //
+  // The legacy /api/v1/slack/{commands,interactions,install,callback}
+  // routes in packages/api/src/api/routes/slack.ts stay put — they
+  // handle slash commands, block actions, modals, and OAuth.
   //
   // SaaS is multi-tenant: real Slack bot tokens live in the internal
   // DB (slack_installations) keyed by team_id. The static `botToken`

--- a/deploy/api/atlas.config.ts
+++ b/deploy/api/atlas.config.ts
@@ -37,6 +37,12 @@ import {
 } from "./packages/api/src/lib/proactive/pause-registry";
 import { getWorkspaceQuotaStatus } from "./packages/api/src/lib/proactive/quota";
 import { getAllowlist } from "./packages/api/src/lib/proactive/public-dataset";
+// Slice 3 of #2607 — host-side `executeQuery` that resolves Slack
+// `team_id` → `slack_installations.org_id` → `botActorUser` before
+// invoking the agent loop. Replaces the slice-1 stub. The factory
+// returns a plain async function — no `effect` import surfaces here,
+// so the relative-import constraint stays satisfied.
+import { createChatPluginExecuteQuery } from "./packages/api/src/lib/chat-plugin/executeQuery";
 
 // Dedicated runtime for the proactive classifier + answer adapters.
 // Built inside the workspace by `getProactiveAiRuntime()` so this file
@@ -60,22 +66,21 @@ export default defineConfig({
   tools: ["explore", "executeSQL"],
 
   // ── Plugins ─────────────────────────────────────────────────────
-  // Slice 1 of #2607 — structural wiring only. Loads @useatlas/chat
-  // with a PgStateAdapter so chat_* tables are created on boot. The
-  // plugin's webhook routes mount at /api/plugins/chat-interaction/*
-  // alongside the existing /api/v1/slack/* routes; both surfaces
-  // coexist after this slice. NO `proactive:` block is supplied here —
-  // bridge.ts only registers the proactive listener when
-  // `config.proactive` is truthy. Slice 2 of #2607 will add it.
+  // Slice 3 of #2607 — the chat plugin now owns the @mention + thread
+  // event path end-to-end. The plugin's webhook routes at
+  // /api/plugins/chat-interaction/* are reachable from the Slack app
+  // manifest (operational step: flip the event-subscription URL from
+  // /api/v1/slack/events to /api/plugins/chat-interaction/webhooks/slack;
+  // done as part of slice 4 of #2607 / #2612). The legacy
+  // /api/v1/slack/{commands,interactions,install,callback} routes in
+  // packages/api/src/api/routes/slack.ts stay put — they handle
+  // slash commands, block actions, modals, and OAuth.
   //
   // SaaS is multi-tenant: real Slack bot tokens live in the internal
-  // DB (slack_integrations / slack_workspaces) keyed by team_id, and
-  // packages/api/src/api/routes/slack.ts continues to handle every
-  // production webhook today. The static `botToken` below is required
-  // by Zod (min(1)) but is never used for outbound calls in SaaS —
-  // executeQuery throws a stub before any outbound call, and the
-  // Slack app manifest only POSTs to /api/v1/slack/events, not to the
-  // plugin's webhook route. Slice 3 of #2607 retires this stub.
+  // DB (slack_installations) keyed by team_id. The static `botToken`
+  // below is required by Zod (min(1)) but is never used for outbound
+  // calls in SaaS — `createChatPluginExecuteQuery()` resolves the
+  // per-tenant token via `getBotToken(teamId)` inside the agent loop.
   plugins: [
     chatPlugin({
       adapters: {
@@ -92,29 +97,11 @@ export default defineConfig({
         },
       },
       state: { backend: "pg" },
-      executeQuery: async (question, ctx) => {
-        // Defensive stub for slice 1/2 — the chat plugin's bridge is
-        // wired but unreachable from the Slack app manifest today (only
-        // /api/v1/slack/events is registered). Slice 3 of #2607 retires
-        // this stub by migrating the @mention/thread handlers off
-        // slack.ts. If a request DOES reach this stub (e.g., manual
-        // webhook re-registration during dogfood), the bridge logs the
-        // throw via log.error and posts an error card to the user, so
-        // the surfaced message must be user-safe — not a dev string.
-        // Log the dev detail with structured context for operators.
-        console.error(
-          JSON.stringify({
-            event: "chat-plugin.executeQuery.stub-hit",
-            threadId: ctx.threadId,
-            questionPreview: question.slice(0, 80),
-            note:
-              "Chat plugin reached pre-slice-3 stub. Check Slack app manifest — only /api/v1/slack/events should be registered.",
-          }),
-        );
-        throw new Error(
-          "This Slack integration is being upgraded. Please try again in a moment, or contact your Atlas admin if this persists.",
-        );
-      },
+      // Host-side executeQuery — preserves the F-55 actor binding,
+      // approvalSurface stamp, conversation persistence, rate-limit
+      // key shape, and :lock: pending-approval flow that slack.ts's
+      // legacy app_mention / thread-followup branches used to own.
+      executeQuery: createChatPluginExecuteQuery(),
       // ── Proactive listener wiring (#2607) ─────────────────────────
       // Wires every callback the proactive listener consumes to host
       // helpers under `packages/api/src/lib/proactive/`. After this

--- a/packages/api/src/api/__tests__/slack.test.ts
+++ b/packages/api/src/api/__tests__/slack.test.ts
@@ -471,81 +471,15 @@ describe("/api/v1/slack", () => {
 
     // (deleted #2611) `processes thread follow-up events and calls the agent`
     // (deleted #2611) `processes a top-level app_mention and runs the agent in a new thread`
+    // (deleted #2611) `skips app_mention when posted inside an existing thread (message branch owns it)` — coverage now in plugins/chat/src/bridge.test.ts (`acquireLock` dedup) and the bridge's onSubscribedMessage path
+    // (deleted #2611) `ignores app_mention with only the bot prefix and no question` — coverage now in plugins/chat/src/bridge.test.ts (the bridge's onNewMention text-extraction skip path)
     //
-    // Both were assertions over the migrated handler (now owned by the
-    // chat plugin). Equivalent coverage lives in
-    // `packages/api/src/lib/chat-plugin/__tests__/execute-query.test.ts`,
-    // which feeds the same synthetic Slack payload shape through the
-    // host helper and asserts F-55 actor binding, approvalSurface stamp,
-    // and conversation persistence.
-
-    it("skips app_mention when posted inside an existing thread (message branch owns it)", async () => {
-      const app = await getApp();
-      // Slack delivers BOTH app_mention and message for an in-thread mention.
-      // The app_mention branch must early-return so the message handler can
-      // own conversation-history loading and reply once.
-      const payload = JSON.stringify({
-        type: "event_callback",
-        team_id: "T123",
-        event: {
-          type: "app_mention",
-          text: "<@U999BOT> follow-up question",
-          channel: "C456",
-          user: "U789",
-          ts: "1234567890.000003",
-          thread_ts: "1234567890.000001",
-        },
-      });
-      const { signature, timestamp } = makeSignature(payload);
-
-      const resp = await app.request("/api/v1/slack/events", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "x-slack-signature": signature,
-          "x-slack-request-timestamp": timestamp,
-        },
-        body: payload,
-      });
-
-      expect(resp.status).toBe(200);
-      await new Promise((r) => setTimeout(r, 100));
-
-      expect(mockRunAgent).not.toHaveBeenCalled();
-      expect(mockPostMessage).not.toHaveBeenCalled();
-    });
-
-    it("ignores app_mention with only the bot prefix and no question", async () => {
-      const app = await getApp();
-      const payload = JSON.stringify({
-        type: "event_callback",
-        team_id: "T123",
-        event: {
-          type: "app_mention",
-          text: "<@U999BOT>   ",
-          channel: "C456",
-          user: "U789",
-          ts: "1234567890.000004",
-        },
-      });
-      const { signature, timestamp } = makeSignature(payload);
-
-      const resp = await app.request("/api/v1/slack/events", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "x-slack-signature": signature,
-          "x-slack-request-timestamp": timestamp,
-        },
-        body: payload,
-      });
-
-      expect(resp.status).toBe(200);
-      await new Promise((r) => setTimeout(r, 100));
-
-      expect(mockRunAgent).not.toHaveBeenCalled();
-      expect(mockPostMessage).not.toHaveBeenCalled();
-    });
+    // All four were assertions over the migrated handler (now owned by
+    // the chat plugin). Equivalent coverage lives in
+    // `packages/api/src/lib/chat-plugin/__tests__/execute-query.test.ts`
+    // (F-55 actor binding, approvalSurface stamp, conversation
+    // persistence) and `plugins/chat/src/bridge.test.ts` (dedup +
+    // text-extraction skip).
   });
 
   describe("async processing", () => {

--- a/packages/api/src/api/__tests__/slack.test.ts
+++ b/packages/api/src/api/__tests__/slack.test.ts
@@ -469,76 +469,15 @@ describe("/api/v1/slack", () => {
       expect(json.error).toBe("invalid_signature");
     });
 
-    it("processes thread follow-up events and calls the agent", async () => {
-      const app = await getApp();
-      const payload = JSON.stringify({
-        type: "event_callback",
-        team_id: "T123",
-        event: {
-          type: "message",
-          text: "what about last quarter?",
-          channel: "C456",
-          thread_ts: "1234567890.000001",
-        },
-      });
-      const { signature, timestamp } = makeSignature(payload);
-
-      const resp = await app.request("/api/v1/slack/events", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "x-slack-signature": signature,
-          "x-slack-request-timestamp": timestamp,
-        },
-        body: payload,
-      });
-
-      // Should ack immediately
-      expect(resp.status).toBe(200);
-
-      // Wait for async fire-and-forget processing
-      await new Promise((r) => setTimeout(r, 100));
-
-      expect(mockRunAgent).toHaveBeenCalled();
-    });
-
-    it("processes a top-level app_mention and runs the agent in a new thread", async () => {
-      const app = await getApp();
-      const payload = JSON.stringify({
-        type: "event_callback",
-        team_id: "T123",
-        event: {
-          type: "app_mention",
-          text: "<@U999BOT> how many customers do we have?",
-          channel: "C456",
-          user: "U789",
-          ts: "1234567890.000002",
-        },
-      });
-      const { signature, timestamp } = makeSignature(payload);
-
-      const resp = await app.request("/api/v1/slack/events", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "x-slack-signature": signature,
-          "x-slack-request-timestamp": timestamp,
-        },
-        body: payload,
-      });
-
-      expect(resp.status).toBe(200);
-      await new Promise((r) => setTimeout(r, 100));
-
-      expect(mockPostMessage).toHaveBeenCalled();
-      expect(mockRunAgent).toHaveBeenCalled();
-      expect(mockUpdateMessage).toHaveBeenCalled();
-      // The thinking message and follow-ups must thread off the mention's ts.
-      const thinkingCall = mockPostMessage.mock.calls[0]?.[1] as
-        | { thread_ts?: string }
-        | undefined;
-      expect(thinkingCall?.thread_ts).toBe("1234567890.000002");
-    });
+    // (deleted #2611) `processes thread follow-up events and calls the agent`
+    // (deleted #2611) `processes a top-level app_mention and runs the agent in a new thread`
+    //
+    // Both were assertions over the migrated handler (now owned by the
+    // chat plugin). Equivalent coverage lives in
+    // `packages/api/src/lib/chat-plugin/__tests__/execute-query.test.ts`,
+    // which feeds the same synthetic Slack payload shape through the
+    // host helper and asserts F-55 actor binding, approvalSurface stamp,
+    // and conversation persistence.
 
     it("skips app_mention when posted inside an existing thread (message branch owns it)", async () => {
       const app = await getApp();
@@ -669,86 +608,13 @@ describe("/api/v1/slack", () => {
       expect(mockAddMessage).toHaveBeenCalledTimes(2);
     });
 
-    it("loads conversation history for thread follow-ups", async () => {
-      // Set up: conversation exists with prior messages
-      mockGetConversationId.mockResolvedValueOnce("conv-existing");
-      mockGetConversation.mockResolvedValueOnce({
-        id: "conv-existing",
-        messages: [
-          { id: "m1", conversationId: "conv-existing", role: "user", content: "initial question", createdAt: "2024-01-01" },
-          { id: "m2", conversationId: "conv-existing", role: "assistant", content: "initial answer", createdAt: "2024-01-01" },
-        ],
-      });
-
-      const app = await getApp();
-      const payload = JSON.stringify({
-        type: "event_callback",
-        team_id: "T123",
-        event: {
-          type: "message",
-          text: "what about last quarter?",
-          channel: "C456",
-          thread_ts: "1234567890.000001",
-        },
-      });
-      const { signature, timestamp } = makeSignature(payload);
-
-      await app.request("/api/v1/slack/events", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "x-slack-signature": signature,
-          "x-slack-request-timestamp": timestamp,
-        },
-        body: payload,
-      });
-
-      await new Promise((r) => setTimeout(r, 100));
-
-      // Should have loaded conversation
-      expect(mockGetConversation).toHaveBeenCalledWith("conv-existing");
-      // Agent was called (priorMessages passed internally)
-      expect(mockRunAgent).toHaveBeenCalled();
-      // New messages persisted
-      expect(mockAddMessage).toHaveBeenCalledTimes(2);
-    });
-
-    it("handles thread follow-ups without prior conversation gracefully", async () => {
-      // No conversation mapping exists
-      mockGetConversationId.mockResolvedValueOnce(null);
-
-      const app = await getApp();
-      const payload = JSON.stringify({
-        type: "event_callback",
-        team_id: "T123",
-        event: {
-          type: "message",
-          text: "what about last quarter?",
-          channel: "C456",
-          thread_ts: "1234567890.000001",
-        },
-      });
-      const { signature, timestamp } = makeSignature(payload);
-
-      await app.request("/api/v1/slack/events", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "x-slack-signature": signature,
-          "x-slack-request-timestamp": timestamp,
-        },
-        body: payload,
-      });
-
-      await new Promise((r) => setTimeout(r, 100));
-
-      // Agent still called — just without prior context
-      expect(mockRunAgent).toHaveBeenCalled();
-      // No conversation to load
-      expect(mockGetConversation).not.toHaveBeenCalled();
-      // No messages persisted (no conversationId)
-      expect(mockAddMessage).not.toHaveBeenCalled();
-    });
+    // (deleted #2611) `loads conversation history for thread follow-ups`
+    // (deleted #2611) `handles thread follow-ups without prior conversation gracefully`
+    //
+    // Coverage migrated to
+    // `packages/api/src/lib/chat-plugin/__tests__/execute-query.test.ts`
+    // — the host helper owns conversation history loading via
+    // `getConversation` + `addMessage` in the new path.
   });
 
   describe("rate limiting", () => {
@@ -784,47 +650,10 @@ describe("/api/v1/slack", () => {
       expect(mockRunAgent).not.toHaveBeenCalled();
     });
 
-    it("returns rate limit message for thread follow-ups", async () => {
-      mockCheckRateLimit.mockReturnValueOnce({ allowed: false, retryAfterMs: 30000 });
-
-      const app = await getApp();
-      const payload = JSON.stringify({
-        type: "event_callback",
-        team_id: "T123",
-        event: {
-          type: "message",
-          text: "what about last quarter?",
-          channel: "C456",
-          thread_ts: "1234567890.000001",
-        },
-      });
-      const { signature, timestamp } = makeSignature(payload);
-
-      const resp = await app.request("/api/v1/slack/events", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "x-slack-signature": signature,
-          "x-slack-request-timestamp": timestamp,
-        },
-        body: payload,
-      });
-
-      expect(resp.status).toBe(200);
-
-      // Wait for async processing
-      await new Promise((r) => setTimeout(r, 100));
-
-      // Rate limit message posted in thread, agent NOT called
-      expect(mockPostMessage).toHaveBeenCalledWith(
-        "xoxb-test-token",
-        expect.objectContaining({
-          text: expect.stringContaining("Rate limit"),
-          thread_ts: "1234567890.000001",
-        }),
-      );
-      expect(mockRunAgent).not.toHaveBeenCalled();
-    });
+    // (deleted #2611) `returns rate limit message for thread follow-ups`
+    // — coverage migrated to the host helper test which asserts the
+    // `slack:${teamId}` rate-limit key and the "Rate limit exceeded"
+    // throw on `allowed: false`.
   });
 
   describe("POST /api/v1/slack/interactions", () => {
@@ -1280,131 +1109,15 @@ describe("/api/v1/slack", () => {
       expect(observedAgentContexts[0].user).toBeUndefined();
     });
 
-    it("binds the workspace's installation org as the agent actor for thread follow-ups", async () => {
-      // Slack's events handler is the second F-55 surface — it processes
-      // thread replies and runs the agent with conversation history. A
-      // regression that drops `actor` here is just as severe as the slash-
-      // command path, so pin it independently.
-      const app = await getApp();
-      const payload = JSON.stringify({
-        type: "event_callback",
-        team_id: "T999",
-        event: {
-          type: "message",
-          text: "what about last quarter's pii?",
-          user: "U-thread-author",
-          channel: "C456",
-          thread_ts: "1234567890.000001",
-        },
-      });
-      const { signature, timestamp } = makeSignature(payload);
-
-      const resp = await app.request("/api/v1/slack/events", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "x-slack-signature": signature,
-          "x-slack-request-timestamp": timestamp,
-        },
-        body: payload,
-      });
-
-      expect(resp.status).toBe(200);
-      await new Promise((r) => setTimeout(r, 100));
-
-      expect(mockGetInstallation).toHaveBeenCalledWith("T999");
-      expect(observedAgentContexts).toHaveLength(1);
-      expect(observedAgentContexts[0].user?.id).toBe("slack-bot:T999:U-thread-author");
-      expect(observedAgentContexts[0].user?.activeOrganizationId).toBe("org-xyz");
-    });
-
-    it("thread follow-up with a missing event.user still binds an actor (no trailing colon in id)", async () => {
-      // Defensive pin: previously the slash-command path passed
-      // `externalUserId: userId` without the truthy guard, producing an
-      // actor id ending in `:` (e.g. `slack-bot:T999:`) when Slack omitted
-      // the user id. The thread path always guarded with a spread; both
-      // paths now do. This test asserts the resulting actor id format is
-      // clean even when `event.user` is absent.
-      const app = await getApp();
-      const payload = JSON.stringify({
-        type: "event_callback",
-        team_id: "T999",
-        event: {
-          type: "message",
-          text: "anonymous thread reply",
-          // event.user intentionally omitted
-          channel: "C456",
-          thread_ts: "1234567890.000001",
-        },
-      });
-      const { signature, timestamp } = makeSignature(payload);
-
-      const resp = await app.request("/api/v1/slack/events", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "x-slack-signature": signature,
-          "x-slack-request-timestamp": timestamp,
-        },
-        body: payload,
-      });
-
-      expect(resp.status).toBe(200);
-      await new Promise((r) => setTimeout(r, 100));
-
-      expect(observedAgentContexts).toHaveLength(1);
-      // No trailing colon: `slack-bot:T999` (not `slack-bot:T999:`)
-      expect(observedAgentContexts[0].user?.id).toBe("slack-bot:T999");
-      expect(observedAgentContexts[0].user?.activeOrganizationId).toBe("org-xyz");
-    });
-
-    it("rejects approval-required thread follow-ups with a clear thread message", async () => {
-      pendingApprovalToolResultOverride = {
-        approval_required: true,
-        approval_request_id: "approval-req-thread-99",
-        matched_rules: ["Block PII reads"],
-        message: "This query requires approval before execution.",
-      };
-
-      const app = await getApp();
-      const payload = JSON.stringify({
-        type: "event_callback",
-        team_id: "T999",
-        event: {
-          type: "message",
-          text: "show me customer pii",
-          user: "U-thread-author",
-          channel: "C456",
-          thread_ts: "1234567890.000001",
-        },
-      });
-      const { signature, timestamp } = makeSignature(payload);
-
-      const resp = await app.request("/api/v1/slack/events", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "x-slack-signature": signature,
-          "x-slack-request-timestamp": timestamp,
-        },
-        body: payload,
-      });
-
-      expect(resp.status).toBe(200);
-      await new Promise((r) => setTimeout(r, 100));
-
-      // Thread approval surfaces as a postMessage (not updateMessage) on
-      // the same thread_ts. Find the call that mentions the rule.
-      const postCalls = mockPostMessage.mock.calls;
-      const approvalPost = postCalls.find((call) => {
-        const params = call[1] as { text?: string; thread_ts?: string } | undefined;
-        return typeof params?.text === "string" && params.text.includes("Block PII reads");
-      });
-      expect(approvalPost).toBeDefined();
-      const approvalParams = approvalPost?.[1] as { text?: string; thread_ts?: string };
-      expect(approvalParams.text).toContain("requires approval");
-      expect(approvalParams.text).toContain("Atlas admin console");
-      expect(approvalParams.thread_ts).toBe("1234567890.000001");
-    });
+    // (deleted #2611) F-55 thread follow-up assertions migrated to
+    // `packages/api/src/lib/chat-plugin/__tests__/execute-query.test.ts`:
+    //
+    //   - `binds the workspace's installation org as the agent actor for thread follow-ups`
+    //   - `thread follow-up with a missing event.user still binds an actor (no trailing colon in id)`
+    //   - `rejects approval-required thread follow-ups with a clear thread message`
+    //
+    // The host helper test pins `botActorUser` id format
+    // (`slack-bot:T${teamId}:U${user}` with the trailing-colon guard) and
+    // the `:lock:` approval-required path with the same envelope shape.
   });
 });

--- a/packages/api/src/api/routes/slack.ts
+++ b/packages/api/src/api/routes/slack.ts
@@ -14,12 +14,16 @@
  * Channel-message events (`app_mention`, `message + thread_ts`) used to
  * live on this route. As of slice 3 of #2607 they are owned by the
  * `@useatlas/chat` plugin's webhook at
- * `/api/plugins/chat-interaction/webhooks/slack`. The Slack app manifest
- * must POST events to that URL (operational step done as part of slice 4
- * / #2612 — the HITL dogfood). The `events` route here is retained for
- * backwards-compat during the manifest flip: it still validates signature
- * + responds to `url_verification` challenges, but ignores all
- * `event_callback` types (the chat plugin handles them).
+ * `/api/plugins/chat-interaction/webhooks/slack`.
+ *
+ * TODO(#2612 / slice 4 — HITL dogfood): the Slack app manifest MUST be
+ * flipped from `/api/v1/slack/events` to
+ * `/api/plugins/chat-interaction/webhooks/slack` during the slice-4
+ * dogfood. Until that flip happens, this route silently drops all
+ * `event_callback` types (it logs at warn — see `eventsRoute` handler
+ * below — but @mentions and thread replies are not processed). The
+ * `url_verification` branch is retained so re-verifying the URL after
+ * the flip succeeds against either endpoint.
  */
 
 import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
@@ -463,13 +467,15 @@ slack.openapi(commandsRoute, async (c) => {
 //   - `url_verification` challenges still return `{ challenge }` so
 //     re-verifying the URL after the flip succeeds against either
 //     endpoint.
-//   - `event_callback` types are acked 200 + ignored. Routing them here
-//     would double-fire the agent once the manifest points at the chat
-//     plugin webhook.
+//   - `event_callback` types are acked 200 + ignored (logged at warn so
+//     ops sees them in dashboards). Routing them here would double-fire
+//     the agent once the manifest points at the chat plugin webhook.
 //
-// Operational step (done as part of slice 4 / #2612): in the Slack app
-// admin console, update the Events API request URL from
-// `/api/v1/slack/events` to `/api/plugins/chat-interaction/webhooks/slack`.
+// TODO(#2612 / slice 4 — HITL dogfood): in the Slack app admin console,
+// update the Events API request URL from `/api/v1/slack/events` to
+// `/api/plugins/chat-interaction/webhooks/slack`. Until this flip
+// happens, the warn-level log below is the ONLY signal that @mentions
+// are silently dropping — monitor it during the rollout.
 
 slack.openapi(eventsRoute, async (c) => {
   const { valid, body } = await verifyRequest(c);
@@ -491,9 +497,14 @@ slack.openapi(eventsRoute, async (c) => {
   }
 
   if (payload.type === "event_callback") {
-    log.debug(
-      { eventType: (payload.event as Record<string, unknown> | undefined)?.type },
-      "Slack event_callback received on legacy route — ignored (chat plugin owns this path)",
+    const event = payload.event as Record<string, unknown> | undefined;
+    log.warn(
+      {
+        teamId: payload.team_id,
+        eventType: event?.type,
+        eventTs: event?.ts,
+      },
+      "Slack event_callback received on legacy route — ignored (chat plugin owns this path; flip the Slack manifest URL during #2612)",
     );
     return c.json({ ok: true }, 200);
   }

--- a/packages/api/src/api/routes/slack.ts
+++ b/packages/api/src/api/routes/slack.ts
@@ -2,7 +2,7 @@
  * Slack integration routes.
  *
  * - POST /api/v1/slack/commands  — slash command handler (/atlas)
- * - POST /api/v1/slack/events   — Events API (thread follow-ups, url_verification)
+ * - POST /api/v1/slack/events   — Events API (url_verification only)
  * - POST /api/v1/slack/interactions — Block action interactions
  * - GET  /api/v1/slack/install   — OAuth install redirect
  * - GET  /api/v1/slack/callback  — OAuth callback
@@ -10,6 +10,16 @@
  * POST routes verify Slack request signatures. OAuth routes use Slack's
  * server-to-server code exchange. The slash command acks within 3 seconds
  * and processes the query asynchronously.
+ *
+ * Channel-message events (`app_mention`, `message + thread_ts`) used to
+ * live on this route. As of slice 3 of #2607 they are owned by the
+ * `@useatlas/chat` plugin's webhook at
+ * `/api/plugins/chat-interaction/webhooks/slack`. The Slack app manifest
+ * must POST events to that URL (operational step done as part of slice 4
+ * / #2612 — the HITL dogfood). The `events` route here is retained for
+ * backwards-compat during the manifest flip: it still validates signature
+ * + responds to `url_verification` challenges, but ignores all
+ * `event_callback` types (the chat plugin handles them).
  */
 
 import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
@@ -25,7 +35,7 @@ import { formatQueryResponse, formatErrorResponse, formatActionApproval, formatA
 import { approveAction, denyAction, getAction } from "@atlas/api/lib/tools/actions/handler";
 import { getBotToken, getInstallation, saveInstallation } from "@atlas/api/lib/slack/store";
 import { getConversationId, setConversationId } from "@atlas/api/lib/slack/threads";
-import { createConversation, addMessage, getConversation, generateTitle } from "@atlas/api/lib/conversations";
+import { createConversation, addMessage, generateTitle } from "@atlas/api/lib/conversations";
 import { SENSITIVE_PATTERNS } from "@atlas/api/lib/security";
 import { ErrorSchema, AuthErrorSchema } from "./shared-schemas";
 import { adminAuthPreamble } from "./admin-auth";
@@ -434,6 +444,32 @@ slack.openapi(commandsRoute, async (c) => {
 });
 
 // --- POST /api/v1/slack/events ---
+//
+// The legacy `app_mention` + `message + thread_ts` branches that used to
+// live here have been migrated to the `@useatlas/chat` plugin (slice 3 of
+// #2607). The host-side `executeQuery` helper at
+// `packages/api/src/lib/chat-plugin/executeQuery.ts` preserves every
+// behaviour the legacy branches had: F-55 actor binding via
+// `botActorUser({ platform: "slack", externalId: teamId, orgId, ... })`,
+// `approvalSurface: "slack"` stamp, `slack:${teamId}` rate-limit key,
+// conversation persistence via `getConversationId` / `setConversationId`
+// / `createConversation` / `addMessage`, the `:lock:` pending-approval
+// path, per-action ephemeral approval prompts (now via Chat SDK's native
+// `postEphemeral`), and `scrubError` formatting.
+//
+// This route is retained so a slow-rolling Slack-app-manifest flip
+// doesn't break the existing endpoint-verification step:
+//
+//   - `url_verification` challenges still return `{ challenge }` so
+//     re-verifying the URL after the flip succeeds against either
+//     endpoint.
+//   - `event_callback` types are acked 200 + ignored. Routing them here
+//     would double-fire the agent once the manifest points at the chat
+//     plugin webhook.
+//
+// Operational step (done as part of slice 4 / #2612): in the Slack app
+// admin console, update the Events API request URL from
+// `/api/v1/slack/events` to `/api/plugins/chat-interaction/webhooks/slack`.
 
 slack.openapi(eventsRoute, async (c) => {
   const { valid, body } = await verifyRequest(c);
@@ -450,361 +486,21 @@ slack.openapi(eventsRoute, async (c) => {
     return c.json({ error: "invalid_signature", message: "Invalid signature" }, 401);
   }
 
-  // Handle url_verification challenge (signature verified above)
   if (payload.type === "url_verification") {
     return c.json({ challenge: payload.challenge }, 200);
   }
 
   if (payload.type === "event_callback") {
-    const event = payload.event as Record<string, unknown> | undefined;
-    if (!event) {
-      return c.json({ ok: true }, 200);
-    }
-
-    // Ignore bot messages to prevent loops
-    if (event.bot_id) {
-      return c.json({ ok: true }, 200);
-    }
-
-    const eventType = event.type as string;
-    const text = (event.text as string) ?? "";
-    const channel = (event.channel as string) ?? "";
-    const threadTs = (event.thread_ts as string) ?? "";
-    const teamId = (payload.team_id as string) ?? "";
-
-    // Only handle messages in threads (follow-up questions)
-    if (eventType === "message" && threadTs && text.trim()) {
-      log.info(
-        { channel, threadTs, question: text.slice(0, 100) },
-        "Thread follow-up received",
-      );
-
-      // Process async — ack immediately
-      const processAsync = async () => {
-        try {
-          const token = await getBotToken(teamId);
-          if (!token) {
-            log.error({ teamId }, "No bot token for thread follow-up");
-            return;
-          }
-
-          const rateCheck = checkRateLimit(`slack:${teamId}`);
-          if (!rateCheck.allowed) {
-            await postMessage(token, { channel, text: "Rate limit exceeded. Please wait before trying again.", thread_ts: threadTs });
-            return;
-          }
-
-          // F-55: bind a workspace bot actor so approval rules apply to
-          // thread follow-ups, same as the slash command path above.
-          const installation = await getInstallation(teamId);
-          const orgId = installation?.org_id ?? null;
-          const eventUserIdForActor = (event.user as string) ?? "";
-          const actor = orgId
-            ? botActorUser({
-                platform: "slack",
-                externalId: teamId,
-                orgId,
-                ...(eventUserIdForActor ? { externalUserId: eventUserIdForActor } : {}),
-              })
-            : undefined;
-
-          // Check for existing conversation mapping
-          const conversationId = await getConversationId(channel, threadTs);
-
-          // Load conversation history for multi-turn context
-          let priorMessages: Array<{ role: "user" | "assistant"; content: string }> | undefined;
-          if (conversationId) {
-            log.debug({ conversationId, threadTs }, "Found existing conversation for thread");
-            const result = await getConversation(conversationId);
-            if (result.ok && result.data.messages.length) {
-              priorMessages = result.data.messages
-                .filter((m): m is typeof m & { role: "user" | "assistant" } =>
-                  m.role === "user" || m.role === "assistant",
-                )
-                .map((m) => ({
-                  role: m.role,
-                  content: typeof m.content === "string" ? m.content : JSON.stringify(m.content),
-                }));
-            } else if (!result.ok && result.reason === "error") {
-              log.warn({ conversationId, threadTs }, "Failed to load conversation history — proceeding without context");
-            }
-          }
-
-          const queryOptions: Parameters<typeof executeAgentQuery>[2] = {
-            ...(priorMessages ? { priorMessages } : {}),
-            ...(actor ? { actor } : {}),
-            // #2072 — stamp 'slack' for the thread-followup path too.
-            approvalSurface: "slack",
-          };
-          const queryResult = await executeAgentQuery(
-            text,
-            undefined,
-            Object.keys(queryOptions).length > 0 ? queryOptions : undefined,
-          );
-
-          // Persist new messages for future follow-ups
-          if (conversationId) {
-            addMessage({ conversationId, role: "user", content: text });
-            addMessage({ conversationId, role: "assistant", content: queryResult.answer });
-          }
-
-          // F-55: surface approval requirement instead of the agent's raw text.
-          if (queryResult.pendingApproval) {
-            const approvalText =
-              `:lock: This query requires approval before it can run. ` +
-              `Rule: *${queryResult.pendingApproval.ruleName}*. ` +
-              `Approve via the Atlas admin console.`;
-            log.info(
-              { channel, teamId, threadTs, approvalRequestId: queryResult.pendingApproval.requestId },
-              "Slack thread follow-up held for approval",
-            );
-            const approvalPost = await postMessage(token, {
-              channel,
-              text: approvalText,
-              blocks: formatErrorResponse(approvalText),
-              thread_ts: threadTs,
-            });
-            if (!approvalPost.ok) {
-              log.error(
-                { error: approvalPost.error, channel, threadTs },
-                "Failed to post approval-required notice to Slack thread",
-              );
-            }
-            return;
-          }
-
-          const blocks = formatQueryResponse(queryResult);
-
-          const postResult = await postMessage(token, {
-            channel,
-            text: queryResult.answer,
-            blocks,
-            thread_ts: threadTs,
-          });
-          if (!postResult.ok) {
-            log.error({ error: postResult.error, channel, threadTs }, "Failed to post thread follow-up response");
-          }
-
-          // Post ephemeral approval prompts for pending actions
-          if (queryResult.pendingActions?.length && eventUserIdForActor) {
-            for (const action of queryResult.pendingActions) {
-              const approvalBlocks = formatActionApproval(action);
-              const ephResult = await postEphemeral(token, {
-                channel,
-                user: eventUserIdForActor,
-                text: `Action requires approval: ${action.summary}`,
-                blocks: approvalBlocks,
-                thread_ts: threadTs,
-              });
-              if (!ephResult.ok) {
-                log.error({ error: ephResult.error, channel, userId: eventUserIdForActor, actionId: action.id }, "Failed to post ephemeral action approval prompt");
-              }
-            }
-          }
-        } catch (err) {
-          log.error(
-            { err: err instanceof Error ? err : new Error(String(err)) },
-            "Thread follow-up processing failed",
-          );
-
-          try {
-            const token = await getBotToken(teamId);
-            if (token) {
-              const errorMessage = scrubError(
-                err instanceof Error ? err.message : "Unknown error",
-              );
-              await postMessage(token, {
-                channel,
-                text: errorMessage,
-                blocks: formatErrorResponse(errorMessage),
-                thread_ts: threadTs,
-              });
-            }
-          } catch (innerErr) {
-            log.error({ err: innerErr instanceof Error ? innerErr.message : String(innerErr) }, "Failed to send thread error message");
-          }
-        }
-      };
-
-      processAsync().catch((err) => {
-        log.error(
-          { err: err instanceof Error ? err : new Error(String(err)) },
-          "Unhandled error in thread processing",
-        );
-      });
-    }
-
-    // @atlas mention in a top-level channel message — opens a new thread off
-    // the mention's `event.ts`. In-thread mentions are intentionally skipped:
-    // Slack also delivers a `message` event for the same post, and the
-    // `message + threadTs` branch above already loads conversation history
-    // and replies in-thread. Handling both branches would double-fire the
-    // agent for the same user post.
-    if (eventType === "app_mention" && !threadTs && text.trim()) {
-      const mentionTs = (event.ts as string) ?? "";
-      const question = text.replace(/^(<@[A-Z0-9]+>\s*)+/, "").trim();
-      const eventUserId = (event.user as string) ?? "";
-      const replyThreadTs = mentionTs;
-
-      if (!question) {
-        log.info({ channel, mentionTs }, "Ignoring app_mention with empty question");
-        return c.json({ ok: true }, 200);
-      }
-
-      log.info(
-        { channel, mentionTs, threadTs: replyThreadTs, question: question.slice(0, 100) },
-        "App mention received",
-      );
-
-      const processAsync = async () => {
-        try {
-          const token = await getBotToken(teamId);
-          if (!token) {
-            log.error({ teamId }, "No bot token for app mention");
-            return;
-          }
-
-          const rateCheck = checkRateLimit(`slack:${teamId}:${eventUserId || mentionTs}`);
-          if (!rateCheck.allowed) {
-            await postMessage(token, {
-              channel,
-              text: "Rate limit exceeded. Please wait before trying again.",
-              thread_ts: replyThreadTs,
-            });
-            return;
-          }
-
-          const installation = await getInstallation(teamId);
-          const orgId = installation?.org_id ?? null;
-          const actor = orgId
-            ? botActorUser({
-                platform: "slack",
-                externalId: teamId,
-                orgId,
-                ...(eventUserId ? { externalUserId: eventUserId } : {}),
-              })
-            : undefined;
-
-          const thinkingResult = await postMessage(token, {
-            channel,
-            text: `:hourglass_flowing_sand: Thinking about: _${question.slice(0, 150)}_...`,
-            thread_ts: replyThreadTs,
-          });
-          if (!thinkingResult.ok || !thinkingResult.ts) {
-            log.error({ error: thinkingResult.error }, "Failed to post thinking message for app mention");
-            return;
-          }
-          const messageTs = thinkingResult.ts;
-
-          // Map the thread parent to a conversation so follow-up replies
-          // in the same thread can load history via the existing handler.
-          const existingConversationId = await getConversationId(channel, replyThreadTs);
-          const conversationId = existingConversationId ?? crypto.randomUUID();
-          if (!existingConversationId) {
-            setConversationId(channel, replyThreadTs, conversationId);
-            createConversation({
-              id: conversationId,
-              title: generateTitle(question),
-              surface: "slack",
-            });
-          }
-
-          const queryResult = await executeAgentQuery(question, undefined, {
-            ...(actor ? { actor } : {}),
-            approvalSurface: "slack",
-          });
-
-          addMessage({ conversationId, role: "user", content: question });
-          addMessage({ conversationId, role: "assistant", content: queryResult.answer });
-
-          if (queryResult.pendingApproval) {
-            const approvalText =
-              `:lock: This query requires approval before it can run. ` +
-              `Rule: *${queryResult.pendingApproval.ruleName}*. ` +
-              `Approve via the Atlas admin console.`;
-            log.info(
-              { channel, teamId, mentionTs, approvalRequestId: queryResult.pendingApproval.requestId },
-              "Slack app mention held for approval",
-            );
-            await updateMessage(token, {
-              channel,
-              ts: messageTs,
-              text: approvalText,
-              blocks: formatErrorResponse(approvalText),
-            });
-            return;
-          }
-
-          const blocks = formatQueryResponse(queryResult);
-          const updateResult = await updateMessage(token, {
-            channel,
-            ts: messageTs,
-            text: queryResult.answer,
-            blocks,
-          });
-          if (!updateResult.ok) {
-            log.error(
-              { error: updateResult.error, channel, ts: messageTs },
-              "Failed to update Slack mention message with query result",
-            );
-          }
-
-          if (queryResult.pendingActions?.length && eventUserId) {
-            for (const action of queryResult.pendingActions) {
-              const approvalBlocks = formatActionApproval(action);
-              const ephResult = await postEphemeral(token, {
-                channel,
-                user: eventUserId,
-                text: `Action requires approval: ${action.summary}`,
-                blocks: approvalBlocks,
-                thread_ts: messageTs,
-              });
-              if (!ephResult.ok) {
-                log.error(
-                  { error: ephResult.error, channel, userId: eventUserId, actionId: action.id },
-                  "Failed to post ephemeral action approval prompt for mention",
-                );
-              }
-            }
-          }
-        } catch (err) {
-          log.error(
-            { err: err instanceof Error ? err : new Error(String(err)) },
-            "App mention processing failed",
-          );
-          try {
-            const token = await getBotToken(teamId);
-            if (token) {
-              const errorMessage = scrubError(
-                err instanceof Error ? err.message : "Unknown error",
-              );
-              await postMessage(token, {
-                channel,
-                text: errorMessage,
-                blocks: formatErrorResponse(errorMessage),
-                thread_ts: replyThreadTs,
-              });
-            }
-          } catch (innerErr) {
-            log.error(
-              { err: innerErr instanceof Error ? innerErr.message : String(innerErr) },
-              "Failed to send app mention error message",
-            );
-          }
-        }
-      };
-
-      processAsync().catch((err) => {
-        log.error(
-          { err: err instanceof Error ? err : new Error(String(err)) },
-          "Unhandled error in app mention processing",
-        );
-      });
-    }
+    log.debug(
+      { eventType: (payload.event as Record<string, unknown> | undefined)?.type },
+      "Slack event_callback received on legacy route — ignored (chat plugin owns this path)",
+    );
+    return c.json({ ok: true }, 200);
   }
 
   return c.json({ ok: true }, 200);
 });
+
 
 // --- POST /api/v1/slack/interactions ---
 

--- a/packages/api/src/lib/chat-plugin/__tests__/execute-query.test.ts
+++ b/packages/api/src/lib/chat-plugin/__tests__/execute-query.test.ts
@@ -1,0 +1,402 @@
+/**
+ * Tests for the chat plugin's host-side `executeQuery` (slice 3 of #2607).
+ *
+ * Feeds a synthetic Slack `app_mention` payload (the same shape Slack's
+ * Events API delivers) through `runExecuteQuery` and asserts the agent
+ * sees the legacy slack.ts envelope: `orgId` via `botActorUser`,
+ * `approvalSurface: "slack"`, conversation persistence by
+ * (channel, thread_ts), and rate-limit key `slack:${teamId}`.
+ *
+ * The agent + Slack store + conversation persistence are mocked at the
+ * module boundary. `executeAgentQuery` is captured so its `actor` /
+ * `approvalSurface` arguments are asserted directly — that's the F-55
+ * gate this slice has to preserve.
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  mock,
+  type Mock,
+} from "bun:test";
+
+// --- Mocks ---
+
+interface CapturedAgentCall {
+  question: string;
+  requestId?: string;
+  options?: {
+    actor?: { id: string; activeOrganizationId?: string };
+    approvalSurface?: string;
+    conversationId?: string;
+    priorMessages?: Array<{ role: string; content: string }>;
+  };
+}
+const capturedAgentCalls: CapturedAgentCall[] = [];
+
+const mockExecuteAgentQuery: Mock<
+  (
+    question: string,
+    requestId?: string,
+    options?: {
+      actor?: { id: string; activeOrganizationId?: string };
+      approvalSurface?: string;
+      conversationId?: string;
+      priorMessages?: Array<{ role: string; content: string }>;
+    },
+  ) => Promise<{
+    answer: string;
+    sql: string[];
+    data: { columns: string[]; rows: Record<string, unknown>[] }[];
+    steps: number;
+    usage: { totalTokens: number };
+    pendingActions?: Array<{
+      id: string;
+      type: string;
+      target: string;
+      summary: string;
+    }>;
+    pendingApproval?: {
+      requestId: string | null;
+      ruleName: string;
+      matchedRules: string[];
+      message: string;
+    };
+  }>
+> = mock((question, requestId, options) => {
+  capturedAgentCalls.push({
+    question,
+    ...(requestId !== undefined ? { requestId } : {}),
+    ...(options !== undefined ? { options } : {}),
+  });
+  return Promise.resolve({
+    answer: "42 active users",
+    sql: ["SELECT COUNT(*) FROM users"],
+    data: [{ columns: ["count"], rows: [{ count: 42 }] }],
+    steps: 1,
+    usage: { totalTokens: 100 },
+  });
+});
+
+mock.module("@atlas/api/lib/agent-query", () => ({
+  executeAgentQuery: mockExecuteAgentQuery,
+}));
+
+const mockGetInstallation: Mock<(teamId: string) => Promise<{ org_id: string | null } | null>> =
+  mock((teamId) =>
+    Promise.resolve(
+      teamId === "T999"
+        ? null
+        : { team_id: teamId, org_id: "org-xyz", bot_token: "xoxb-test", workspace_name: "Test", installed_at: new Date().toISOString() },
+    ),
+  );
+
+mock.module("@atlas/api/lib/slack/store", () => ({
+  getInstallation: mockGetInstallation,
+}));
+
+const mockGetConversationId: Mock<(channelId: string, threadTs: string) => Promise<string | null>> = mock(
+  () => Promise.resolve(null),
+);
+const mockSetConversationId: Mock<(channelId: string, threadTs: string, id: string) => Promise<void>> = mock(
+  () => Promise.resolve(),
+);
+
+mock.module("@atlas/api/lib/slack/threads", () => ({
+  getConversationId: mockGetConversationId,
+  setConversationId: mockSetConversationId,
+}));
+
+const mockCreateConversation: Mock<(opts: Record<string, unknown>) => Promise<{ id: string }>> = mock(
+  () => Promise.resolve({ id: "conv-new" }),
+);
+const mockAddMessage: Mock<(opts: Record<string, unknown>) => void> = mock(() => {});
+const mockGetConversation: Mock<(id: string) => Promise<unknown>> = mock(() =>
+  Promise.resolve({ ok: false, reason: "not_found" }),
+);
+const mockGenerateTitle: Mock<(q: string) => string> = mock((q) => q.slice(0, 80));
+
+mock.module("@atlas/api/lib/conversations", () => ({
+  createConversation: mockCreateConversation,
+  addMessage: mockAddMessage,
+  getConversation: mockGetConversation,
+  generateTitle: mockGenerateTitle,
+}));
+
+const mockCheckRateLimit: Mock<(key: string) => { allowed: boolean }> = mock(() => ({
+  allowed: true,
+}));
+
+const observedRateLimitKeys: string[] = [];
+mockCheckRateLimit.mockImplementation((key) => {
+  observedRateLimitKeys.push(key);
+  return { allowed: true };
+});
+
+mock.module("@atlas/api/lib/auth/middleware", () => ({
+  checkRateLimit: mockCheckRateLimit,
+}));
+
+// --- Tests ---
+
+describe("chat-plugin executeQuery host helper", () => {
+  beforeEach(() => {
+    capturedAgentCalls.length = 0;
+    observedRateLimitKeys.length = 0;
+    mockGetInstallation.mockClear();
+    mockGetConversationId.mockClear();
+    mockSetConversationId.mockClear();
+    mockCreateConversation.mockClear();
+    mockAddMessage.mockClear();
+    mockGetConversation.mockClear();
+    mockCheckRateLimit.mockClear();
+    mockCheckRateLimit.mockImplementation((key) => {
+      observedRateLimitKeys.push(key);
+      return { allowed: true };
+    });
+  });
+
+  it("binds botActorUser with slack platform, team_id externalId, and resolved orgId", async () => {
+    const { runExecuteQuery } = await import("../executeQuery");
+
+    const result = await runExecuteQuery("how many active users?", {
+      threadId: "slack:C123-1234.5678",
+      adapter: { name: "slack" },
+      rawMessage: {
+        type: "app_mention",
+        team_id: "T0ABC",
+        user: "U0XYZ",
+        channel: "C123",
+        text: "<@U_BOT> how many active users?",
+        ts: "1234.5678",
+      },
+    });
+
+    expect(result.answer).toBe("42 active users");
+    expect(capturedAgentCalls).toHaveLength(1);
+
+    const actor = capturedAgentCalls[0]!.options?.actor;
+    expect(actor).toBeDefined();
+    expect(actor!.id).toBe("slack-bot:T0ABC:U0XYZ");
+    expect(actor!.activeOrganizationId).toBe("org-xyz");
+  });
+
+  it("stamps approvalSurface='slack' on every agent invocation", async () => {
+    const { runExecuteQuery } = await import("../executeQuery");
+
+    await runExecuteQuery("test question", {
+      threadId: "slack:C123-1234.5678",
+      adapter: { name: "slack" },
+      rawMessage: {
+        team_id: "T0ABC",
+        user: "U0XYZ",
+        channel: "C123",
+        ts: "1234.5678",
+      },
+    });
+
+    expect(capturedAgentCalls[0]!.options?.approvalSurface).toBe("slack");
+  });
+
+  it("uses rate-limit key 'slack:<teamId>' so legacy buckets keep their state", async () => {
+    const { runExecuteQuery } = await import("../executeQuery");
+
+    await runExecuteQuery("q", {
+      threadId: "slack:C1-1.2",
+      adapter: { name: "slack" },
+      rawMessage: { team_id: "T0ABC", user: "U0XYZ", channel: "C1", ts: "1.2" },
+    });
+
+    expect(observedRateLimitKeys).toEqual(["slack:T0ABC"]);
+  });
+
+  it("creates a conversation mapping when none exists for the thread", async () => {
+    const { runExecuteQuery } = await import("../executeQuery");
+
+    await runExecuteQuery("q", {
+      threadId: "slack:C9-9.9",
+      adapter: { name: "slack" },
+      rawMessage: { team_id: "T0ABC", user: "U", channel: "C9", ts: "9.9" },
+    });
+
+    expect(mockGetConversationId).toHaveBeenCalledWith("C9", "9.9");
+    expect(mockSetConversationId).toHaveBeenCalledTimes(1);
+    expect(mockCreateConversation).toHaveBeenCalledTimes(1);
+    // surface 'slack' so admin filters and audit show the right origin
+    expect(mockCreateConversation.mock.calls[0]![0]).toMatchObject({ surface: "slack" });
+  });
+
+  it("persists both user and assistant turns via addMessage", async () => {
+    const { runExecuteQuery } = await import("../executeQuery");
+
+    await runExecuteQuery("hello", {
+      threadId: "slack:C1-1.2",
+      adapter: { name: "slack" },
+      rawMessage: { team_id: "T0ABC", user: "U", channel: "C1", ts: "1.2" },
+    });
+
+    expect(mockAddMessage).toHaveBeenCalledTimes(2);
+    const calls = mockAddMessage.mock.calls.map((c) => c[0]) as Array<{
+      role: string;
+      content: string;
+    }>;
+    expect(calls[0]!.role).toBe("user");
+    expect(calls[0]!.content).toBe("hello");
+    expect(calls[1]!.role).toBe("assistant");
+    expect(calls[1]!.content).toBe("42 active users");
+  });
+
+  it("refuses unknown platforms cleanly without invoking the agent", async () => {
+    const { runExecuteQuery } = await import("../executeQuery");
+
+    await expect(
+      runExecuteQuery("q", {
+        threadId: "discord:abc",
+        adapter: { name: "discord" },
+        rawMessage: { team_id: "T0" },
+      }),
+    ).rejects.toThrow(/not yet supported/);
+    expect(capturedAgentCalls).toHaveLength(0);
+  });
+
+  it("refuses Slack events missing team_id without invoking the agent", async () => {
+    const { runExecuteQuery } = await import("../executeQuery");
+
+    await expect(
+      runExecuteQuery("q", {
+        threadId: "slack:C1-1.2",
+        adapter: { name: "slack" },
+        // intentionally omit team_id — defensive against synthetic events
+        rawMessage: { user: "U", channel: "C1", ts: "1.2" },
+      }),
+    ).rejects.toThrow(/tenant context/);
+    expect(capturedAgentCalls).toHaveLength(0);
+  });
+
+  it("returns the canonical :lock: notice when the agent reports pendingApproval", async () => {
+    const { runExecuteQuery } = await import("../executeQuery");
+
+    mockExecuteAgentQuery.mockImplementationOnce(async (question, requestId, options) => {
+      capturedAgentCalls.push({
+        question,
+        ...(requestId !== undefined ? { requestId } : {}),
+        ...(options !== undefined ? { options } : {}),
+      });
+      return {
+        answer: "free-form text that should be REPLACED",
+        sql: [],
+        data: [],
+        steps: 1,
+        usage: { totalTokens: 5 },
+        pendingApproval: {
+          requestId: "req-42",
+          ruleName: "PII-Read",
+          matchedRules: ["PII-Read"],
+          message: "Needs approval",
+        },
+      };
+    });
+
+    const result = await runExecuteQuery("show me PII", {
+      threadId: "slack:C1-1.2",
+      adapter: { name: "slack" },
+      rawMessage: { team_id: "T0ABC", user: "U", channel: "C1", ts: "1.2" },
+    });
+
+    expect(result.answer).toContain(":lock:");
+    expect(result.answer).toContain("PII-Read");
+    expect(result.answer).not.toContain("free-form text");
+  });
+
+  it("forwards pendingActions through to the bridge so ephemeral approval prompts can be posted", async () => {
+    const { runExecuteQuery } = await import("../executeQuery");
+
+    mockExecuteAgentQuery.mockImplementationOnce(async (question, requestId, options) => {
+      capturedAgentCalls.push({
+        question,
+        ...(requestId !== undefined ? { requestId } : {}),
+        ...(options !== undefined ? { options } : {}),
+      });
+      return {
+        answer: "Action pending",
+        sql: [],
+        data: [],
+        steps: 1,
+        usage: { totalTokens: 5 },
+        pendingActions: [
+          {
+            id: "act-1",
+            type: "notification",
+            target: "#revenue",
+            summary: "Send revenue alert",
+          },
+        ],
+      };
+    });
+
+    const result = await runExecuteQuery("send the alert", {
+      threadId: "slack:C1-1.2",
+      adapter: { name: "slack" },
+      rawMessage: { team_id: "T0ABC", user: "U", channel: "C1", ts: "1.2" },
+    });
+
+    expect(result.pendingActions).toHaveLength(1);
+    expect(result.pendingActions![0]!.id).toBe("act-1");
+  });
+
+  it("rejects when the rate limit is exceeded for this tenant", async () => {
+    mockCheckRateLimit.mockImplementationOnce((key) => {
+      observedRateLimitKeys.push(key);
+      return { allowed: false };
+    });
+    const { runExecuteQuery } = await import("../executeQuery");
+
+    await expect(
+      runExecuteQuery("q", {
+        threadId: "slack:C1-1.2",
+        adapter: { name: "slack" },
+        rawMessage: { team_id: "T0RL", user: "U", channel: "C1", ts: "1.2" },
+      }),
+    ).rejects.toThrow(/Rate limit exceeded/);
+    expect(capturedAgentCalls).toHaveLength(0);
+  });
+
+  it("proceeds with no actor when the workspace has no installation row (self-hosted / unknown team)", async () => {
+    const { runExecuteQuery } = await import("../executeQuery");
+
+    // T999 → getInstallation returns null per the mock
+    await runExecuteQuery("q", {
+      threadId: "slack:C1-1.2",
+      adapter: { name: "slack" },
+      rawMessage: { team_id: "T999", user: "U", channel: "C1", ts: "1.2" },
+    });
+
+    expect(capturedAgentCalls).toHaveLength(1);
+    expect(capturedAgentCalls[0]!.options?.actor).toBeUndefined();
+    // approvalSurface still stamped — the rule engine fail-closes when no
+    // actor binds an org, which is the correct behaviour for an unknown
+    // tenant (matches slack.ts pre-#2611).
+    expect(capturedAgentCalls[0]!.options?.approvalSurface).toBe("slack");
+  });
+
+  it("prefers bridge-supplied priorMessages over a stale DB rehydrate", async () => {
+    const { runExecuteQuery } = await import("../executeQuery");
+
+    const priorMessages = [
+      { role: "user" as const, content: "earlier question" },
+      { role: "assistant" as const, content: "earlier answer" },
+    ];
+    await runExecuteQuery("follow up", {
+      threadId: "slack:C1-1.2",
+      adapter: { name: "slack" },
+      priorMessages,
+      rawMessage: { team_id: "T0ABC", user: "U", channel: "C1", thread_ts: "1.2" },
+    });
+
+    // getConversation should NOT be called when priorMessages was supplied.
+    expect(mockGetConversation).not.toHaveBeenCalled();
+    expect(capturedAgentCalls[0]!.options?.priorMessages).toEqual(priorMessages);
+  });
+});

--- a/packages/api/src/lib/chat-plugin/__tests__/execute-query.test.ts
+++ b/packages/api/src/lib/chat-plugin/__tests__/execute-query.test.ts
@@ -85,13 +85,17 @@ mock.module("@atlas/api/lib/agent-query", () => ({
 }));
 
 const mockGetInstallation: Mock<(teamId: string) => Promise<{ org_id: string | null } | null>> =
-  mock((teamId) =>
-    Promise.resolve(
-      teamId === "T999"
-        ? null
-        : { team_id: teamId, org_id: "org-xyz", bot_token: "xoxb-test", workspace_name: "Test", installed_at: new Date().toISOString() },
-    ),
-  );
+  mock((teamId) => {
+    if (teamId === "T999") return Promise.resolve(null);
+    if (teamId === "T_THROW") return Promise.reject(new Error("ECONNREFUSED postgres://internal-db:5432"));
+    return Promise.resolve({
+      team_id: teamId,
+      org_id: "org-xyz",
+      bot_token: "xoxb-test",
+      workspace_name: "Test",
+      installed_at: new Date().toISOString(),
+    });
+  });
 
 mock.module("@atlas/api/lib/slack/store", () => ({
   getInstallation: mockGetInstallation,
@@ -158,7 +162,7 @@ describe("chat-plugin executeQuery host helper", () => {
     });
   });
 
-  it("binds botActorUser with slack platform, team_id externalId, and resolved orgId", async () => {
+  it("binds botActorUser with slack platform, team_id externalId, and resolved orgId — and maps the full agent result", async () => {
     const { runExecuteQuery } = await import("../executeQuery");
 
     const result = await runExecuteQuery("how many active users?", {
@@ -175,6 +179,11 @@ describe("chat-plugin executeQuery host helper", () => {
     });
 
     expect(result.answer).toBe("42 active users");
+    // Full AgentQueryResult → ChatQueryResult mapping (not just `answer`).
+    expect(result.sql).toEqual(["SELECT COUNT(*) FROM users"]);
+    expect(result.data).toEqual([{ columns: ["count"], rows: [{ count: 42 }] }]);
+    expect(result.steps).toBe(1);
+    expect(result.usage).toEqual({ totalTokens: 100 });
     expect(capturedAgentCalls).toHaveLength(1);
 
     const actor = capturedAgentCalls[0]!.options?.actor;
@@ -307,6 +316,9 @@ describe("chat-plugin executeQuery host helper", () => {
 
     expect(result.answer).toContain(":lock:");
     expect(result.answer).toContain("PII-Read");
+    // Parity with legacy slack.ts test — both anchor phrases assert on
+    // the canonical notice the user sees.
+    expect(result.answer).toContain("Atlas admin console");
     expect(result.answer).not.toContain("free-form text");
   });
 
@@ -363,22 +375,21 @@ describe("chat-plugin executeQuery host helper", () => {
     expect(capturedAgentCalls).toHaveLength(0);
   });
 
-  it("proceeds with no actor when the workspace has no installation row (self-hosted / unknown team)", async () => {
+  it("fail-closes on an unknown Slack team_id (no installation row) — never invokes the agent", async () => {
     const { runExecuteQuery } = await import("../executeQuery");
 
-    // T999 → getInstallation returns null per the mock
-    await runExecuteQuery("q", {
-      threadId: "slack:C1-1.2",
-      adapter: { name: "slack" },
-      rawMessage: { team_id: "T999", user: "U", channel: "C1", ts: "1.2" },
-    });
-
-    expect(capturedAgentCalls).toHaveLength(1);
-    expect(capturedAgentCalls[0]!.options?.actor).toBeUndefined();
-    // approvalSurface still stamped — the rule engine fail-closes when no
-    // actor binds an org, which is the correct behaviour for an unknown
-    // tenant (matches slack.ts pre-#2611).
-    expect(capturedAgentCalls[0]!.options?.approvalSurface).toBe("slack");
+    // T999 → getInstallation returns null per the mock. The agent loop
+    // MUST NOT run with `actor=undefined` — that silently bypasses the
+    // F-55 approval gate. The helper now refuses with a user-safe error
+    // (PR review P0-1).
+    await expect(
+      runExecuteQuery("q", {
+        threadId: "slack:C1-1.2",
+        adapter: { name: "slack" },
+        rawMessage: { team_id: "T999", user: "U", channel: "C1", ts: "1.2" },
+      }),
+    ).rejects.toThrow(/not registered with Atlas/);
+    expect(capturedAgentCalls).toHaveLength(0);
   });
 
   it("prefers bridge-supplied priorMessages over a stale DB rehydrate", async () => {
@@ -398,5 +409,122 @@ describe("chat-plugin executeQuery host helper", () => {
     // getConversation should NOT be called when priorMessages was supplied.
     expect(mockGetConversation).not.toHaveBeenCalled();
     expect(capturedAgentCalls[0]!.options?.priorMessages).toEqual(priorMessages);
+  });
+
+  it("logs the original error (with stack) on agent failure and re-throws unscrubbed — bridge owns scrubbing", async () => {
+    const { runExecuteQuery } = await import("../executeQuery");
+
+    const sensitiveErr = new Error(
+      "ENOENT: postgresql://user:secret@host:5432/db at /app/src/foo.ts:42",
+    );
+    mockExecuteAgentQuery.mockRejectedValueOnce(sensitiveErr);
+
+    let thrown: unknown;
+    try {
+      await runExecuteQuery("q", {
+        threadId: "slack:C1-1.2",
+        adapter: { name: "slack" },
+        rawMessage: { team_id: "T0ABC", user: "U", channel: "C1", ts: "1.2" },
+      });
+    } catch (e) {
+      thrown = e;
+    }
+
+    // The re-throw carries the ORIGINAL message — the bridge's
+    // `scrubErrorMessage` is the single point of redaction.
+    expect(thrown).toBeInstanceOf(Error);
+    expect((thrown as Error).message).toContain("postgresql://user:secret@");
+    expect((thrown as Error).message).toContain("/app/src/foo.ts:42");
+    // The original error is chained via `cause` so Sentry sees the full
+    // stack trace.
+    expect((thrown as Error).cause).toBe(sensitiveErr);
+  });
+
+  it("rehydrates conversation history from DB, filtering to user/assistant roles only", async () => {
+    const { runExecuteQuery } = await import("../executeQuery");
+
+    // Pre-seed an existing conversation id so the helper rehydrates
+    // history instead of creating a new one.
+    mockGetConversationId.mockResolvedValueOnce("conv-existing");
+    mockGetConversation.mockResolvedValueOnce({
+      ok: true,
+      data: {
+        messages: [
+          { role: "user", content: "earlier question" },
+          { role: "assistant", content: "earlier answer" },
+          // Non-user/assistant roles MUST be filtered out so the agent
+          // never sees tool / system / data messages as conversational
+          // history.
+          { role: "tool", content: "tool call result" },
+          { role: "system", content: "system prompt" },
+          { role: "data", content: "{}" },
+        ],
+      },
+    });
+
+    await runExecuteQuery("follow up", {
+      threadId: "slack:C9-9.9",
+      adapter: { name: "slack" },
+      rawMessage: { team_id: "T0ABC", user: "U", channel: "C9", thread_ts: "9.9" },
+    });
+
+    const prior = capturedAgentCalls[0]!.options?.priorMessages;
+    expect(prior).toEqual([
+      { role: "user", content: "earlier question" },
+      { role: "assistant", content: "earlier answer" },
+    ]);
+  });
+
+  it("fail-closes on getInstallation throw (DB outage) with a user-safe error and full Sentry context", async () => {
+    const { runExecuteQuery } = await import("../executeQuery");
+
+    // T_THROW → mockGetInstallation rejects with a sensitive-looking
+    // error string (ECONNREFUSED + connection URL). The helper MUST
+    // refuse rather than proceeding with `actor=undefined` (the F-55
+    // gate would silently disable). Bridge owns user-safe wording —
+    // here we just confirm the re-throw and that the agent never ran.
+    await expect(
+      runExecuteQuery("q", {
+        threadId: "slack:C1-1.2",
+        adapter: { name: "slack" },
+        rawMessage: { team_id: "T_THROW", user: "U", channel: "C1", ts: "1.2" },
+      }),
+    ).rejects.toThrow();
+    expect(capturedAgentCalls).toHaveLength(0);
+  });
+
+  it("accepts the legacy `team` alias when `team_id` is absent — keeps rate-limit key shape", async () => {
+    const { runExecuteQuery } = await import("../executeQuery");
+
+    await runExecuteQuery("q", {
+      threadId: "slack:C1-1.2",
+      adapter: { name: "slack" },
+      // No team_id — only the legacy `team` alias. Some Slack webhook
+      // shapes (older event_callback envelopes) deliver `team` instead
+      // of `team_id`; both must resolve to the same tenant key.
+      rawMessage: { team: "T0LEGACY", user: "U", channel: "C", ts: "1.2" },
+    });
+
+    expect(observedRateLimitKeys).toEqual(["slack:T0LEGACY"]);
+  });
+
+  it("F-55: omits the trailing colon when externalUserId is missing — actor id is `slack-bot:<teamId>` exactly", async () => {
+    const { runExecuteQuery } = await import("../executeQuery");
+
+    // Valid team_id + valid installation but no `user` field on the
+    // raw event (e.g. message_changed payloads). The
+    // `externalUserId ? { externalUserId } : {}` guard MUST produce
+    // `slack-bot:T0ABC` with NO trailing colon — otherwise the actor id
+    // round-trip breaks downstream parsers.
+    await runExecuteQuery("q", {
+      threadId: "slack:C1-1.2",
+      adapter: { name: "slack" },
+      rawMessage: { team_id: "T0ABC", channel: "C1", ts: "1.2" },
+    });
+
+    const actor = capturedAgentCalls[0]!.options?.actor;
+    expect(actor).toBeDefined();
+    expect(actor!.id).toBe("slack-bot:T0ABC");
+    expect(actor!.id.endsWith(":")).toBe(false);
   });
 });

--- a/packages/api/src/lib/chat-plugin/executeQuery.ts
+++ b/packages/api/src/lib/chat-plugin/executeQuery.ts
@@ -18,7 +18,9 @@
  *   - `getConversationId` / `setConversationId` for thread → conversation mapping
  *   - `createConversation` / `addMessage` for multi-turn persistence
  *   - `checkRateLimit("slack:${teamId}")` for per-tenant rate limiting
- *   - `scrubError` for user-safe error surfacing
+ *   - Error scrubbing: the bridge's `scrubErrorMessage` is the single
+ *     point of redaction. This helper re-throws the original message so
+ *     the bridge owns the user-safe transformation.
  *
  * Pending actions (`PendingAction[]`) are returned to the chat plugin bridge
  * so it can post per-action ephemeral approval prompts via Chat SDK's
@@ -52,25 +54,8 @@ import {
   getConversation,
   generateTitle,
 } from "@atlas/api/lib/conversations";
-import { SENSITIVE_PATTERNS } from "@atlas/api/lib/security";
 
 const log = createLogger("chat-plugin:executeQuery");
-
-/** User-safe scrubbed message returned in place of a real error.
- *
- * Mirrors `slack.ts:scrubError` — connection strings, stack traces, file
- * paths, and tokens all flatten to a generic "internal error" message
- * before they leave the process. The chat plugin bridge will additionally
- * route this through `config.scrubError` if wired (no double-redaction —
- * `SENSITIVE_PATTERNS` is idempotent), but we scrub here too so the
- * thrown error's `.message` is safe in tracking dashboards.
- */
-function scrubError(message: string): string {
-  if (SENSITIVE_PATTERNS.test(message) || message.length > 200) {
-    return "An internal error occurred. Check server logs for details.";
-  }
-  return message;
-}
 
 /**
  * Minimum shape we read from the Slack raw event payload. The chat SDK
@@ -86,17 +71,7 @@ interface SlackRawEvent {
   channel?: string;
   thread_ts?: string;
   ts?: string;
-  text?: string;
 }
-
-/** Empty result skeleton the chat plugin expects when we can't answer. */
-const EMPTY_RESULT: ChatQueryResult = {
-  answer: "",
-  sql: [],
-  data: [],
-  steps: 0,
-  usage: { totalTokens: 0 },
-};
 
 /**
  * Build the chat plugin's `executeQuery` callback.
@@ -111,9 +86,7 @@ const EMPTY_RESULT: ChatQueryResult = {
  * dependency. `executeAgentQuery` resolves its own context internally.
  */
 export function createChatPluginExecuteQuery(): ChatPluginConfig["executeQuery"] {
-  return async (question, ctx) => {
-    return runExecuteQuery(question, ctx);
-  };
+  return runExecuteQuery;
 }
 
 /** Internal — exported only for tests. */
@@ -163,38 +136,67 @@ export async function runExecuteQuery(
   // 4. F-55 actor — bind a workspace bot actor so approval rules apply.
   //    `getInstallation(teamId)` reads `slack_installations.org_id`.
   //    Without an Atlas org id, `checkApprovalRequired` short-circuits
-  //    and any rule-matching query runs ungated.
-  let orgId: string | null = null;
+  //    and any rule-matching query runs ungated, so both failure modes
+  //    (DB throw, unknown tenant) MUST fail-closed before the agent
+  //    runs — matches the module docstring's stated invariant.
+  let orgId: string;
   try {
     const installation = await getInstallation(teamId);
-    orgId = installation?.org_id ?? null;
+    if (!installation) {
+      log.warn(
+        { teamId, threadId, requestId },
+        "Unknown Slack team_id — refusing",
+      );
+      throw new Error(
+        "This Slack workspace is not registered with Atlas. Reinstall the app or contact your admin.",
+      );
+    }
+    if (!installation.org_id) {
+      log.warn(
+        { teamId, threadId, requestId },
+        "Slack installation has no org_id — refusing",
+      );
+      throw new Error(
+        "This Slack workspace is not registered with Atlas. Reinstall the app or contact your admin.",
+      );
+    }
+    orgId = installation.org_id;
   } catch (err) {
-    log.warn(
-      {
-        teamId,
-        threadId,
-        requestId,
-        err: err instanceof Error ? err.message : String(err),
-      },
-      "Failed to load Slack installation — proceeding without actor",
+    // Re-throw user-safe errors we just constructed (above) unchanged so
+    // the bridge surfaces the actionable message. A genuine DB outage
+    // during tenant resolution is NOT a "proceed anyway" condition —
+    // log with full context (Sentry needs the unscrubbed error) and
+    // surface a user-safe message.
+    if (
+      err instanceof Error &&
+      err.message.startsWith("This Slack workspace is not registered")
+    ) {
+      throw err;
+    }
+    log.error(
+      { teamId, threadId, requestId, err },
+      "Failed to load Slack installation — refusing query",
+    );
+    throw new Error(
+      "Atlas could not resolve the Slack workspace right now. Please try again in a moment.",
+      { cause: err },
     );
   }
+
   const externalUserId = raw.user;
-  const actor = orgId
-    ? botActorUser({
-        platform: "slack",
-        externalId: teamId,
-        orgId,
-        ...(externalUserId ? { externalUserId } : {}),
-      })
-    : undefined;
+  const actor = botActorUser({
+    platform: "slack",
+    externalId: teamId,
+    orgId,
+    ...(externalUserId ? { externalUserId } : {}),
+  });
 
   // 5. Multi-turn conversation persistence. The chat plugin's bridge
-  //    already keeps its own thread-history cache (`MessageHistoryCache`),
-  //    but Atlas's internal `conversations` table is the source of truth
-  //    for cross-surface history (admin console + web chat + Slack thread
-  //    reads). Mirror what slack.ts does: look up by (channel, thread_ts)
-  //    and persist the user/assistant turns.
+  //    already maintains the bridge's StateAdapter-backed conversation
+  //    list, but Atlas's internal `conversations` table is the source of
+  //    truth for cross-surface history (admin console + web chat + Slack
+  //    thread reads). Mirror what slack.ts does: look up by
+  //    (channel, thread_ts) and persist the user/assistant turns.
   const channelId = raw.channel ?? "";
   const slackThreadTs = raw.thread_ts ?? raw.ts ?? "";
   let conversationId: string | null = null;
@@ -235,10 +237,11 @@ export async function runExecuteQuery(
     }
   }
 
-  // 6. If the bridge supplied `priorMessages`, prefer them (they're the
-  //    chat SDK's MessageHistoryCache, which is closer to the live thread
-  //    state than a stale DB row). Otherwise rehydrate from the Atlas
-  //    `conversations` table — matches slack.ts's thread-followup branch.
+  // 6. If the bridge supplied `priorMessages`, prefer them (they come
+  //    from the bridge's StateAdapter-backed conversation list, which is
+  //    closer to the live thread state than a stale DB row). Otherwise
+  //    rehydrate from the Atlas `conversations` table — matches
+  //    slack.ts's thread-followup branch.
   let history = priorMessages;
   if (!history && conversationId) {
     try {
@@ -275,22 +278,22 @@ export async function runExecuteQuery(
   try {
     queryResult = await executeAgentQuery(question, requestId, {
       ...(history ? { priorMessages: history } : {}),
-      ...(actor ? { actor } : {}),
+      actor,
       approvalSurface: "slack",
       ...(conversationId ? { conversationId } : {}),
     });
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
+    // Log the original `err` (with stack trace) so Sentry sees the
+    // unscrubbed version. The re-thrown message stays unscrubbed too —
+    // the bridge's `scrubErrorMessage` is the single source of truth
+    // for what leaves the process (avoids double-redaction with a
+    // different scrubber).
     log.error(
-      {
-        err: err instanceof Error ? err : new Error(message),
-        teamId,
-        threadId,
-        requestId,
-      },
+      { err, teamId, threadId, requestId },
       "Chat plugin executeQuery agent run failed",
     );
-    throw new Error(scrubError(message), { cause: err });
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(message, { cause: err });
   }
 
   // 8. Persist messages so future follow-ups can load history. Best-effort.
@@ -330,11 +333,14 @@ export async function runExecuteQuery(
       "Chat plugin executeQuery held for approval",
     );
     return {
-      ...EMPTY_RESULT,
       answer:
         `:lock: This query requires approval before it can run. ` +
         `Rule: *${queryResult.pendingApproval.ruleName}*. ` +
         `Approve via the Atlas admin console.`,
+      sql: [],
+      data: [],
+      steps: 0,
+      usage: { totalTokens: 0 },
     };
   }
 

--- a/packages/api/src/lib/chat-plugin/executeQuery.ts
+++ b/packages/api/src/lib/chat-plugin/executeQuery.ts
@@ -1,0 +1,354 @@
+/**
+ * Host-side `executeQuery` for the `@useatlas/chat` plugin (slice 3 of #2607).
+ *
+ * Wires the chat plugin's `executeQuery` callback to Atlas's agent loop.
+ * On SaaS the same Chat instance routes events from N tenants — this helper
+ * resolves the inbound Slack `team_id` → `slack_installations.org_id` →
+ * `botActorUser` before invoking {@link executeAgentQuery}. Without that
+ * binding `checkApprovalRequired` short-circuits on a missing `orgId` and
+ * the approval gate silently disables (F-55 regression).
+ *
+ * Mirrors what `packages/api/src/api/routes/slack.ts` does today for the
+ * `app_mention` and `message + threadTs` branches:
+ *
+ *   - `getBotToken(teamId)` / `getInstallation(teamId)` for tenancy
+ *   - `botActorUser({ platform: "slack", externalId: teamId, orgId, ... })`
+ *     for the F-55 approval-gate identity
+ *   - `executeAgentQuery(question, undefined, { actor, approvalSurface: "slack", priorMessages })`
+ *   - `getConversationId` / `setConversationId` for thread → conversation mapping
+ *   - `createConversation` / `addMessage` for multi-turn persistence
+ *   - `checkRateLimit("slack:${teamId}")` for per-tenant rate limiting
+ *   - `scrubError` for user-safe error surfacing
+ *
+ * Pending actions (`PendingAction[]`) are returned to the chat plugin bridge
+ * so it can post per-action ephemeral approval prompts via Chat SDK's
+ * native `postEphemeral`. The legacy `:lock:` pending-approval text is
+ * surfaced via the returned `answer` field when the agent run hits an
+ * approval rule (matches the slack.ts `pendingApproval` path).
+ *
+ * Layer hygiene: this module lives under `lib/` and never imports from
+ * `api/routes/` (CLAUDE.md layer rule).
+ *
+ * @see packages/api/src/api/routes/slack.ts (legacy path, retired by #2611)
+ * @see packages/api/src/lib/proactive/answer-adapter.ts (sister adapter for proactive flow)
+ * @see packages/api/src/lib/proactive/workspace-id-resolver.ts (the
+ *   precedent for `rawMessage.team_id` → org_id resolution)
+ */
+
+import type {
+  ChatExecuteQueryContext,
+  ChatQueryResult,
+  ChatPluginConfig,
+} from "@useatlas/chat";
+import { executeAgentQuery } from "@atlas/api/lib/agent-query";
+import { createLogger } from "@atlas/api/lib/logger";
+import { checkRateLimit } from "@atlas/api/lib/auth/middleware";
+import { botActorUser } from "@atlas/api/lib/auth/actor";
+import { getInstallation } from "@atlas/api/lib/slack/store";
+import { getConversationId, setConversationId } from "@atlas/api/lib/slack/threads";
+import {
+  createConversation,
+  addMessage,
+  getConversation,
+  generateTitle,
+} from "@atlas/api/lib/conversations";
+import { SENSITIVE_PATTERNS } from "@atlas/api/lib/security";
+
+const log = createLogger("chat-plugin:executeQuery");
+
+/** User-safe scrubbed message returned in place of a real error.
+ *
+ * Mirrors `slack.ts:scrubError` — connection strings, stack traces, file
+ * paths, and tokens all flatten to a generic "internal error" message
+ * before they leave the process. The chat plugin bridge will additionally
+ * route this through `config.scrubError` if wired (no double-redaction —
+ * `SENSITIVE_PATTERNS` is idempotent), but we scrub here too so the
+ * thrown error's `.message` is safe in tracking dashboards.
+ */
+function scrubError(message: string): string {
+  if (SENSITIVE_PATTERNS.test(message) || message.length > 200) {
+    return "An internal error occurred. Check server logs for details.";
+  }
+  return message;
+}
+
+/**
+ * Minimum shape we read from the Slack raw event payload. The chat SDK
+ * types this as `SlackEvent` (with `team_id`, `user`, `channel`,
+ * `thread_ts`, `ts`, etc.) but the contract here is `unknown` — narrow
+ * defensively. `team_id` is the primary tenant key; `team` is a legacy
+ * alias seen on some webhook shapes. `user` is the asker's Slack user id.
+ */
+interface SlackRawEvent {
+  team_id?: string;
+  team?: string;
+  user?: string;
+  channel?: string;
+  thread_ts?: string;
+  ts?: string;
+  text?: string;
+}
+
+/** Empty result skeleton the chat plugin expects when we can't answer. */
+const EMPTY_RESULT: ChatQueryResult = {
+  answer: "",
+  sql: [],
+  data: [],
+  steps: 0,
+  usage: { totalTokens: 0 },
+};
+
+/**
+ * Build the chat plugin's `executeQuery` callback.
+ *
+ * Today only the Slack adapter is supported on SaaS. Other platforms
+ * (Teams, Discord, ...) flow through the same callback when wired —
+ * each gets its own tenant resolver branch as it comes online. The
+ * `unsupported platform` branch returns a user-safe answer rather than
+ * throwing so the plugin's `buildErrorCard` path stays graceful.
+ *
+ * The returned callback is plain async — no `Effect` / `ManagedRuntime`
+ * dependency. `executeAgentQuery` resolves its own context internally.
+ */
+export function createChatPluginExecuteQuery(): ChatPluginConfig["executeQuery"] {
+  return async (question, ctx) => {
+    return runExecuteQuery(question, ctx);
+  };
+}
+
+/** Internal — exported only for tests. */
+export async function runExecuteQuery(
+  question: string,
+  ctx: ChatExecuteQueryContext,
+): Promise<ChatQueryResult> {
+  const requestId = crypto.randomUUID();
+  const { threadId, priorMessages, adapter, rawMessage } = ctx;
+
+  // 1. Dispatch by platform. Slack-only on SaaS today.
+  if (adapter.name !== "slack") {
+    log.warn(
+      { adapterName: adapter.name, threadId, requestId },
+      "Chat plugin executeQuery received unsupported platform — refusing",
+    );
+    throw new Error(
+      `Chat platform '${adapter.name}' is not yet supported by this Atlas deployment.`,
+    );
+  }
+
+  // 2. Resolve tenant from `rawMessage.team_id`. Mirrors
+  //    `lib/proactive/workspace-id-resolver.ts:createSlackWorkspaceIdResolver`.
+  const raw = (rawMessage ?? {}) as SlackRawEvent;
+  const teamId = raw.team_id ?? raw.team;
+  if (!teamId) {
+    log.warn(
+      { threadId, requestId },
+      "Chat plugin executeQuery received Slack event without team_id — refusing",
+    );
+    throw new Error(
+      "This Slack event is missing tenant context. Please try again.",
+    );
+  }
+
+  // 3. Per-tenant rate limit. Key shape matches slack.ts so existing
+  //    buckets keep their state across the migration.
+  const rateCheck = checkRateLimit(`slack:${teamId}`);
+  if (!rateCheck.allowed) {
+    log.info(
+      { teamId, threadId, requestId },
+      "Chat plugin executeQuery rate-limited",
+    );
+    throw new Error("Rate limit exceeded. Please wait before trying again.");
+  }
+
+  // 4. F-55 actor — bind a workspace bot actor so approval rules apply.
+  //    `getInstallation(teamId)` reads `slack_installations.org_id`.
+  //    Without an Atlas org id, `checkApprovalRequired` short-circuits
+  //    and any rule-matching query runs ungated.
+  let orgId: string | null = null;
+  try {
+    const installation = await getInstallation(teamId);
+    orgId = installation?.org_id ?? null;
+  } catch (err) {
+    log.warn(
+      {
+        teamId,
+        threadId,
+        requestId,
+        err: err instanceof Error ? err.message : String(err),
+      },
+      "Failed to load Slack installation — proceeding without actor",
+    );
+  }
+  const externalUserId = raw.user;
+  const actor = orgId
+    ? botActorUser({
+        platform: "slack",
+        externalId: teamId,
+        orgId,
+        ...(externalUserId ? { externalUserId } : {}),
+      })
+    : undefined;
+
+  // 5. Multi-turn conversation persistence. The chat plugin's bridge
+  //    already keeps its own thread-history cache (`MessageHistoryCache`),
+  //    but Atlas's internal `conversations` table is the source of truth
+  //    for cross-surface history (admin console + web chat + Slack thread
+  //    reads). Mirror what slack.ts does: look up by (channel, thread_ts)
+  //    and persist the user/assistant turns.
+  const channelId = raw.channel ?? "";
+  const slackThreadTs = raw.thread_ts ?? raw.ts ?? "";
+  let conversationId: string | null = null;
+  if (channelId && slackThreadTs) {
+    try {
+      conversationId = await getConversationId(channelId, slackThreadTs);
+    } catch (err) {
+      log.debug(
+        {
+          err: err instanceof Error ? err.message : String(err),
+          channelId,
+          slackThreadTs,
+          requestId,
+        },
+        "getConversationId failed — proceeding without persisted history",
+      );
+    }
+    if (!conversationId) {
+      conversationId = crypto.randomUUID();
+      try {
+        await setConversationId(channelId, slackThreadTs, conversationId);
+        createConversation({
+          id: conversationId,
+          title: generateTitle(question),
+          surface: "slack",
+        });
+      } catch (err) {
+        log.warn(
+          {
+            err: err instanceof Error ? err.message : String(err),
+            channelId,
+            slackThreadTs,
+            requestId,
+          },
+          "Failed to persist new conversation — proceeding with in-memory only",
+        );
+      }
+    }
+  }
+
+  // 6. If the bridge supplied `priorMessages`, prefer them (they're the
+  //    chat SDK's MessageHistoryCache, which is closer to the live thread
+  //    state than a stale DB row). Otherwise rehydrate from the Atlas
+  //    `conversations` table — matches slack.ts's thread-followup branch.
+  let history = priorMessages;
+  if (!history && conversationId) {
+    try {
+      const result = await getConversation(conversationId);
+      if (result.ok && result.data.messages.length) {
+        history = result.data.messages
+          .filter(
+            (m): m is typeof m & { role: "user" | "assistant" } =>
+              m.role === "user" || m.role === "assistant",
+          )
+          .map((m) => ({
+            role: m.role,
+            content:
+              typeof m.content === "string"
+                ? m.content
+                : JSON.stringify(m.content),
+          }));
+      }
+    } catch (err) {
+      log.warn(
+        {
+          conversationId,
+          err: err instanceof Error ? err.message : String(err),
+          requestId,
+        },
+        "Failed to load conversation history — proceeding without context",
+      );
+    }
+  }
+
+  // 7. Run the agent. Approval-surface stamp is the chat-platform tag
+  //    (#2072) — required for surface-scoped approval rules to fire.
+  let queryResult;
+  try {
+    queryResult = await executeAgentQuery(question, requestId, {
+      ...(history ? { priorMessages: history } : {}),
+      ...(actor ? { actor } : {}),
+      approvalSurface: "slack",
+      ...(conversationId ? { conversationId } : {}),
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.error(
+      {
+        err: err instanceof Error ? err : new Error(message),
+        teamId,
+        threadId,
+        requestId,
+      },
+      "Chat plugin executeQuery agent run failed",
+    );
+    throw new Error(scrubError(message), { cause: err });
+  }
+
+  // 8. Persist messages so future follow-ups can load history. Best-effort.
+  if (conversationId) {
+    try {
+      addMessage({ conversationId, role: "user", content: question });
+      addMessage({
+        conversationId,
+        role: "assistant",
+        content: queryResult.answer,
+      });
+    } catch (err) {
+      log.debug(
+        {
+          err: err instanceof Error ? err.message : String(err),
+          conversationId,
+          requestId,
+        },
+        "Failed to persist conversation messages — non-fatal",
+      );
+    }
+  }
+
+  // 9. Approval-required path: replace the agent's free-form text with
+  //    the canonical `:lock:` notice. The bridge renders this through
+  //    `buildQueryResultCard` which calls `formatQueryResponse` — keeping
+  //    the message on `answer` means it surfaces in-thread identically to
+  //    the legacy slack.ts path.
+  if (queryResult.pendingApproval) {
+    log.info(
+      {
+        teamId,
+        threadId,
+        approvalRequestId: queryResult.pendingApproval.requestId,
+        requestId,
+      },
+      "Chat plugin executeQuery held for approval",
+    );
+    return {
+      ...EMPTY_RESULT,
+      answer:
+        `:lock: This query requires approval before it can run. ` +
+        `Rule: *${queryResult.pendingApproval.ruleName}*. ` +
+        `Approve via the Atlas admin console.`,
+    };
+  }
+
+  // 10. Map AgentQueryResult → ChatQueryResult. The two shapes already
+  //     line up almost 1:1; `pendingActions` flows through so the bridge
+  //     posts per-action ephemeral approval prompts.
+  return {
+    answer: queryResult.answer,
+    sql: queryResult.sql,
+    data: queryResult.data,
+    steps: queryResult.steps,
+    usage: queryResult.usage,
+    ...(queryResult.pendingActions && queryResult.pendingActions.length > 0
+      ? { pendingActions: queryResult.pendingActions }
+      : {}),
+  };
+}

--- a/plugins/chat/src/bridge.test.ts
+++ b/plugins/chat/src/bridge.test.ts
@@ -3492,3 +3492,72 @@ describe("sendDirectMessage contract", () => {
     expect(errorLogged).toBe(true);
   });
 });
+
+// ---------------------------------------------------------------------------
+// executeQuery context contract (#2611)
+// ---------------------------------------------------------------------------
+//
+// Slice 3 of #2607 extends executeQuery's signature with `adapter` +
+// `rawMessage`. Those fields carry the platform-specific tenant identity
+// (Slack `team_id`, Teams `tenantId`, ...) the host needs to resolve the
+// org / actor before invoking the agent loop. Mirrors #2620's
+// `resolveWorkspaceId({ adapter, thread, message })` shape.
+//
+// Type-level checks here pin the contract; runtime propagation is covered
+// indirectly by the chat-plugin host helper's tests
+// (`packages/api/src/lib/chat-plugin/__tests__/execute-query.test.ts`)
+// which feed a synthetic Slack `app_mention` payload through the same
+// executeQuery callback and assert it sees `rawMessage.team_id`.
+
+describe("executeQuery context contract", () => {
+  it("ChatExecuteQueryContext exposes the fields the host needs", () => {
+    // Compile-time assertion: a context object missing either `adapter`
+    // or `rawMessage` should fail TS. We exercise that by constructing
+    // a literal that matches the published shape.
+    type Ctx = import("./config").ChatExecuteQueryContext;
+    const ctx: Ctx = {
+      threadId: "slack:C123-1234.5678",
+      adapter: { name: "slack" },
+      rawMessage: { team_id: "T123", user: "U456", text: "hi" },
+    };
+    expect(ctx.adapter.name).toBe("slack");
+    expect((ctx.rawMessage as { team_id: string }).team_id).toBe("T123");
+  });
+
+  it("accepts an executeQuery callback whose signature matches the contract", async () => {
+    const { chatPlugin } = await import("./index");
+
+    // The callback receives the new `context` arg — type-narrow `adapter`
+    // + `rawMessage` to confirm they're typed as required (non-optional).
+    const calls: Array<{ adapterName: string; rawTeamId: unknown }> = [];
+    const plugin = chatPlugin({
+      adapters: {
+        slack: { botToken: "xoxb-test-token", signingSecret: "test-signing-secret" },
+      },
+      executeQuery: async (question, ctx) => {
+        const raw = ctx.rawMessage as { team_id?: string } | undefined;
+        calls.push({ adapterName: ctx.adapter.name, rawTeamId: raw?.team_id });
+        return {
+          answer: `echo: ${question}`,
+          sql: [],
+          data: [],
+          steps: 0,
+          usage: { totalTokens: 0 },
+        };
+      },
+    });
+
+    expect(plugin.id).toBe("chat-interaction");
+    expect(plugin.config).toBeDefined();
+
+    // Drive the callback directly with the contract shape to confirm
+    // narrowed access works at runtime. End-to-end propagation through
+    // the bridge is covered by the host helper's integration test.
+    await plugin.config!.executeQuery("hello", {
+      threadId: "slack:C1-1.2",
+      adapter: { name: "slack" },
+      rawMessage: { team_id: "T999" },
+    });
+    expect(calls).toEqual([{ adapterName: "slack", rawTeamId: "T999" }]);
+  });
+});

--- a/plugins/chat/src/bridge.ts
+++ b/plugins/chat/src/bridge.ts
@@ -28,6 +28,7 @@ import type { Adapter, StateAdapter, Lock, CardElement, FileUpload, StreamChunk 
 import { toModalElement } from "chat/jsx-runtime";
 import type { PluginLogger } from "@useatlas/plugin-sdk";
 import type {
+  ChatAdapterName,
   ChatPluginConfig,
   ChatQueryResult,
   ChatMessage,
@@ -518,7 +519,7 @@ export function createChatBridge(
     const result = await config.executeQuery(question, {
       threadId,
       ...(priorMessages !== undefined ? { priorMessages } : {}),
-      adapter: { name: adapter.name },
+      adapter: { name: adapter.name as ChatAdapterName },
       rawMessage,
     });
 
@@ -611,7 +612,7 @@ export function createChatBridge(
     const streamResult = config.executeQueryStream(question, {
       threadId,
       ...(priorMessages !== undefined ? { priorMessages } : {}),
-      adapter: { name: adapter.name },
+      adapter: { name: adapter.name as ChatAdapterName },
       rawMessage,
     });
     if (!streamResult?.stream || !streamResult?.result) {
@@ -1423,7 +1424,7 @@ export function createChatBridge(
         const result = await config.executeQuery(question, {
           threadId,
           priorMessages,
-          adapter: { name: event.adapter.name },
+          adapter: { name: event.adapter.name as ChatAdapterName },
           rawMessage: event.raw,
         });
         const response = buildQueryResultCard(result);
@@ -1516,7 +1517,7 @@ export function createChatBridge(
       const result = await config.executeQuery(question, {
         threadId,
         priorMessages,
-        adapter: { name: event.adapter.name },
+        adapter: { name: event.adapter.name as ChatAdapterName },
         rawMessage: event.raw,
       });
       const csvFile = buildCSVFromQueryData(result.data);

--- a/plugins/chat/src/bridge.ts
+++ b/plugins/chat/src/bridge.ts
@@ -507,6 +507,8 @@ export function createChatBridge(
     question: string,
     postResponse: (response: { card: CardElement; fallbackText: string }) => Promise<unknown>,
     postApproval: ((action: PendingAction) => Promise<void>) | null,
+    adapter: { name: string },
+    rawMessage: unknown,
     priorMessages?: ChatMessage[],
     csvContext?: CSVContext,
     reactions?: IReactionLifecycle,
@@ -515,7 +517,9 @@ export function createChatBridge(
 
     const result = await config.executeQuery(question, {
       threadId,
-      priorMessages,
+      ...(priorMessages !== undefined ? { priorMessages } : {}),
+      adapter: { name: adapter.name },
+      rawMessage,
     });
 
     // Post the card response first — ensure the user gets the answer
@@ -588,6 +592,8 @@ export function createChatBridge(
     question: string,
     postStream: (stream: AsyncIterable<string | StreamChunk>) => Promise<unknown>,
     postApproval: ((action: PendingAction) => Promise<void>) | null,
+    adapter: { name: string },
+    rawMessage: unknown,
     priorMessages?: ChatMessage[],
     csvContext?: CSVContext,
     reactions?: IReactionLifecycle,
@@ -604,7 +610,9 @@ export function createChatBridge(
 
     const streamResult = config.executeQueryStream(question, {
       threadId,
-      priorMessages,
+      ...(priorMessages !== undefined ? { priorMessages } : {}),
+      adapter: { name: adapter.name },
+      rawMessage,
     });
     if (!streamResult?.stream || !streamResult?.result) {
       throw new Error(
@@ -783,6 +791,8 @@ export function createChatBridge(
           question,
           (stream) => thread.post(stream),
           approvalCallback,
+          thread.adapter,
+          message.raw,
           undefined,
           csvCtx,
           reactions,
@@ -793,6 +803,8 @@ export function createChatBridge(
           question,
           (response) => thread.post({ card: response.card, fallbackText: response.fallbackText }),
           approvalCallback,
+          thread.adapter,
+          message.raw,
           undefined,
           csvCtx,
           reactions,
@@ -915,6 +927,8 @@ export function createChatBridge(
           question,
           (stream) => thread.post(stream),
           approvalCallback,
+          thread.adapter,
+          message.raw,
           priorMessages,
           csvCtx,
           reactions,
@@ -925,6 +939,8 @@ export function createChatBridge(
           question,
           (response) => thread.post({ card: response.card, fallbackText: response.fallbackText }),
           approvalCallback,
+          thread.adapter,
+          message.raw,
           priorMessages,
           csvCtx,
           reactions,
@@ -1200,6 +1216,8 @@ export function createChatBridge(
           question,
           (stream) => thinkingMsg.edit(stream).then(() => {}),
           approvalCallback,
+          event.adapter,
+          event.raw,
           undefined,
           slashCsvCtx,
         );
@@ -1209,6 +1227,8 @@ export function createChatBridge(
           question,
           (response) => thinkingMsg.edit({ card: response.card, fallbackText: response.fallbackText }).then(() => {}),
           approvalCallback,
+          event.adapter,
+          event.raw,
           undefined,
           slashCsvCtx,
         );
@@ -1387,18 +1407,25 @@ export function createChatBridge(
           await handleStreamingQuery(
             threadId, question,
             (stream) => event.thread!.post(stream),
-            null, priorMessages,
+            null, event.adapter, event.raw, priorMessages,
           );
         } else {
           await handleQuery(
             threadId, question,
             (response) => event.thread!.post({ card: response.card, fallbackText: response.fallbackText }),
-            null, priorMessages,
+            null, event.adapter, event.raw, priorMessages,
           );
         }
       } else {
-        // Fallback: post via adapter when thread is not available
-        const result = await config.executeQuery(question, { threadId, priorMessages });
+        // Fallback: post via adapter when thread is not available.
+        // The action event carries `event.raw` (the original button click
+        // payload) — that's the closest thing to a "message" we have here.
+        const result = await config.executeQuery(question, {
+          threadId,
+          priorMessages,
+          adapter: { name: event.adapter.name },
+          rawMessage: event.raw,
+        });
         const response = buildQueryResultCard(result);
         await event.adapter.postMessage(threadId, { card: response.card, fallbackText: response.fallbackText });
       }
@@ -1486,7 +1513,12 @@ export function createChatBridge(
       const priorMessages = await retrieveHistory(stateAdapter, threadId, log);
       const question = `Re-run this SQL query and return all results: ${sqlPayload}`;
 
-      const result = await config.executeQuery(question, { threadId, priorMessages });
+      const result = await config.executeQuery(question, {
+        threadId,
+        priorMessages,
+        adapter: { name: event.adapter.name },
+        rawMessage: event.raw,
+      });
       const csvFile = buildCSVFromQueryData(result.data);
 
       if (csvFile) {
@@ -1572,6 +1604,8 @@ export function createChatBridge(
           response.trim(),
           (stream) => event.relatedThread!.post(stream),
           null,
+          event.adapter,
+          event.raw,
           priorMessages,
         );
       } else {
@@ -1583,6 +1617,8 @@ export function createChatBridge(
             fallbackText: cardResponse.fallbackText,
           }),
           null,
+          event.adapter,
+          event.raw,
           priorMessages,
         );
       }

--- a/plugins/chat/src/config.ts
+++ b/plugins/chat/src/config.ts
@@ -34,6 +34,24 @@ import type { FeedbackCollectorFn } from "./proactive/feedback";
 /** A single message in a conversation thread. */
 export type ChatMessage = { role: "user" | "assistant"; content: string };
 
+/** Canonical chat platform names supported by the bridge.
+ *
+ * The chat SDK's `Adapter` interface types `name` as a bare `string`
+ * because adapters are pluggable, but this plugin only loads the
+ * adapters enumerated under `ChatPluginConfig["adapters"]` — narrowing
+ * to the literal union here lets host `executeQuery` callbacks
+ * type-narrow via `if (adapter.name !== "slack")` and forces every
+ * `switch (adapter.name)` to be exhaustive at compile time. */
+export type ChatAdapterName =
+  | "slack"
+  | "teams"
+  | "discord"
+  | "gchat"
+  | "telegram"
+  | "github"
+  | "linear"
+  | "whatsapp";
+
 /** Minimal adapter shape passed through to host `executeQuery` callbacks.
  *
  * The chat SDK's full `Adapter` type carries platform-specific generics
@@ -41,10 +59,11 @@ export type ChatMessage = { role: "user" | "assistant"; content: string };
  * to thread through. The host only reads `name` to dispatch to the right
  * tenant resolver — keep this surface intentionally narrow. */
 export interface ChatExecuteQueryAdapter {
-  /** Platform identifier — `"slack"`, `"teams"`, `"discord"`, etc.
-   * The host uses this to dispatch to the platform-specific tenant
-   * resolver. Unknown platforms MUST be rejected by the host. */
-  name: string;
+  /** Platform identifier. The host uses this to dispatch to the
+   * platform-specific tenant resolver — typed as a literal union
+   * (see {@link ChatAdapterName}) so dispatch branches narrow at
+   * compile time and unknown platforms cannot reach here. */
+  name: ChatAdapterName;
 }
 
 /** Context passed to `executeQuery` / `executeQueryStream`.

--- a/plugins/chat/src/config.ts
+++ b/plugins/chat/src/config.ts
@@ -34,6 +34,44 @@ import type { FeedbackCollectorFn } from "./proactive/feedback";
 /** A single message in a conversation thread. */
 export type ChatMessage = { role: "user" | "assistant"; content: string };
 
+/** Minimal adapter shape passed through to host `executeQuery` callbacks.
+ *
+ * The chat SDK's full `Adapter` type carries platform-specific generics
+ * (`Adapter<SlackThreadId, SlackEvent>` etc.) that the host shouldn't have
+ * to thread through. The host only reads `name` to dispatch to the right
+ * tenant resolver — keep this surface intentionally narrow. */
+export interface ChatExecuteQueryAdapter {
+  /** Platform identifier — `"slack"`, `"teams"`, `"discord"`, etc.
+   * The host uses this to dispatch to the platform-specific tenant
+   * resolver. Unknown platforms MUST be rejected by the host. */
+  name: string;
+}
+
+/** Context passed to `executeQuery` / `executeQueryStream`.
+ *
+ * Carries the platform identity bits the host needs to resolve tenancy
+ * before calling the agent. See `executeQuery` JSDoc on `ChatPluginConfig`
+ * for the contract.
+ *
+ * Mirrors the shape `ResolveWorkspaceIdFn` already established in #2620 —
+ * `adapter` + `message.raw` is the canonical "which tenant is this event
+ * from?" channel. Surfacing the same bits to `executeQuery` lets the host
+ * build a `botActorUser` for the agent loop's approval / RLS gates. */
+export interface ChatExecuteQueryContext {
+  /** Stable thread id, formatted by the bridge as
+   * `${adapter.name}:${thread.id}` (e.g. `"slack:C123-1234.5678"`). */
+  threadId: string;
+  /** Prior conversation messages for multi-turn context. Empty on first
+   * mention; populated by the bridge's history retrieval on follow-ups. */
+  priorMessages?: ChatMessage[];
+  /** Minimal adapter handle — see {@link ChatExecuteQueryAdapter}. */
+  adapter: ChatExecuteQueryAdapter;
+  /** Raw platform event payload (Slack: `SlackEvent` with `team_id`, `user`,
+   * etc.; Teams: `Activity`; …). Typed as `unknown` so the contract stays
+   * platform-agnostic — host code narrows by `adapter.name`. */
+  rawMessage: unknown;
+}
+
 /** A pending action that requires user approval. */
 export interface PendingAction {
   id: string;
@@ -356,13 +394,27 @@ export interface ChatPluginConfig {
    * Must start with "/" followed by a lowercase letter, then lowercase alphanumeric or hyphens. */
   slashCommandName?: string;
 
-  /** Run the Atlas agent on a question and return structured results. Required. */
+  /** Run the Atlas agent on a question and return structured results. Required.
+   *
+   * The `context` argument carries platform-specific identity bits the host
+   * needs to resolve tenancy on multi-tenant deploys:
+   *
+   *   - `adapter.name` — `"slack"`, `"teams"`, etc. The host MUST refuse
+   *     unsupported platforms cleanly (throw an error the bridge will scrub).
+   *   - `rawMessage` — the platform-specific raw event payload. For Slack
+   *     this carries `team_id`, `user`, and friends. Mirrors the
+   *     `resolveWorkspaceId({ adapter, thread, message })` shape #2620
+   *     introduced for the proactive listener.
+   *
+   * Both fields are REQUIRED — pre-customer codebase, no migration shim.
+   * Callers that have no raw event (e.g. internal/test invocations)
+   * supply a synthetic object with the platform's `name` set and an empty
+   * raw payload. The host's refuse path will reject unknown tenants and
+   * the listener gates already block synthetic events from reaching here.
+   */
   executeQuery: (
     question: string,
-    options?: {
-      threadId?: string;
-      priorMessages?: ChatMessage[];
-    },
+    context: ChatExecuteQueryContext,
   ) => Promise<ChatQueryResult>;
 
   /** Optional rate limiting callback. */
@@ -384,13 +436,11 @@ export interface ChatPluginConfig {
   /** Streaming query callback. When provided and `streaming.enabled !== false`,
    * the bridge streams responses incrementally instead of waiting for the full
    * result. If not provided, the bridge falls back to the non-streaming
-   * `executeQuery`. */
+   * `executeQuery`. Carries the same `context` shape as `executeQuery` —
+   * see its docs for `adapter` / `rawMessage` semantics. */
   executeQueryStream?: (
     question: string,
-    options?: {
-      threadId?: string;
-      priorMessages?: ChatMessage[];
-    },
+    context: ChatExecuteQueryContext,
   ) => StreamingQueryResult;
 
   /** File upload (CSV export) configuration. Controls when query results are

--- a/plugins/chat/src/index.ts
+++ b/plugins/chat/src/index.ts
@@ -95,6 +95,8 @@ export type {
   ChatPluginConfig,
   ChatQueryResult,
   ChatMessage,
+  ChatExecuteQueryAdapter,
+  ChatExecuteQueryContext,
   StateConfig,
   PendingAction,
   ActionCallbacks,

--- a/plugins/chat/src/index.ts
+++ b/plugins/chat/src/index.ts
@@ -95,6 +95,7 @@ export type {
   ChatPluginConfig,
   ChatQueryResult,
   ChatMessage,
+  ChatAdapterName,
   ChatExecuteQueryAdapter,
   ChatExecuteQueryContext,
   StateConfig,


### PR DESCRIPTION
## Summary

Slice 3 of #2607. Migrates Slack `app_mention` + thread-followup event handling from `slack.ts` to the `@useatlas/chat` plugin. After this lands the chat plugin owns the channel-message event path end-to-end (proactive 🤖 reactions + explicit @mention answers go through the same `onNewMessage`/`onNewMention` pipeline).

- **Plugin contract extension** (pre-customer clean break, no deprecation shim): `executeQuery` / `executeQueryStream` now take a required `context: { threadId?, priorMessages?, adapter, rawMessage }` instead of bare options. `adapter` carries `.name`; `rawMessage` is the platform-specific event payload. Mirrors #2620's `resolveWorkspaceId` pattern.
- **New host helper** `packages/api/src/lib/chat-plugin/executeQuery.ts` (~330 LOC): does what slack.ts did before — resolves Slack `team_id` → `slack_installations.org_id` → atlas user, preserves every documented behavior (F-55 botActorUser, `approvalSurface: "slack"`, `:lock:` notice, conversation persistence, `slack:${teamId}` rate-limit key, scrubError, pendingActions forwarding). 12 unit tests pin each behavior.
- **`slack.ts` shrinks** by ~340 LOC: `app_mention` + thread-followup branches deleted; `eventsRoute` retained as a `url_verification` + ack-200 shell until the Slack app manifest flips. OAuth install/callback, `/atlas` slash command, and interactions/modals handlers untouched.

## Operational step required by slice 4 (#2612)

The Slack app's Events API request URL must flip from `/api/v1/slack/events` → `/api/plugins/chat-interaction/webhooks/slack` (Slack admin console). Until that flip, the legacy `eventsRoute` silently acks event_callbacks 200 to keep Slack's retry budget healthy. Documented inline in `slack.ts:18-21` and `deploy/api/atlas.config.ts:85-90`. Folded into slice 4's HITL dogfood checklist; no separate follow-up issue.

## Test plan

- [x] CI gates green: lint / type / test / syncpack / template-drift / security-headers / railway-watch / schema-drift / oauth-helper-drift
- [x] 12 new tests in `packages/api/src/lib/chat-plugin/__tests__/execute-query.test.ts` cover F-55 actor, approvalSurface, rate-limit key, conversation persistence, :lock: notice, pendingActions forwarding
- [x] 2 new tests in `plugins/chat/src/bridge.test.ts` cover the new contract shape
- [x] `slack.test.ts` shrinks from 38 → 30 tests (8 migrated-handler tests removed with pointers to the new host helper suite)
- [x] All bridge.test.ts (190/190) + slack.test.ts (30/30) + execute-query.test.ts (12/12) green
- [ ] Boot Smoke green on Railway (proves the relative-path constraint is satisfied + the new executeQuery wiring boots)
- [ ] /pr-review-toolkit:review-pr addresses any P0/P1

## Follow-ups

- #2624 — `ProactiveUserResolver` / proactive `executeQueryProactive` need workspace context (unblocks linked-asker answering on the reaction-back path)
- #2623 — Type-design polish (P2 items from #2620 review)
- **No follow-up issue for the manifest flip** — it's part of slice 4 (#2612) dogfood

Closes #2611