### PR TITLE
fix(api): #2611 — Codex review follow-up (Slack id object normalization + per-user rate limit)

### DIFF
--- a/packages/api/src/lib/chat-plugin/__tests__/execute-query.test.ts
+++ b/packages/api/src/lib/chat-plugin/__tests__/execute-query.test.ts
@@ -209,16 +209,74 @@ describe("chat-plugin executeQuery host helper", () => {
     expect(capturedAgentCalls[0]!.options?.approvalSurface).toBe("slack");
   });
 
-  it("uses rate-limit key 'slack:<teamId>' so legacy buckets keep their state", async () => {
+  it("rate-limit key for thread follow-up is team-wide `slack:<teamId>` — matches slack.ts:491", async () => {
     const { runExecuteQuery } = await import("../executeQuery");
 
     await runExecuteQuery("q", {
       threadId: "slack:C1-1.2",
       adapter: { name: "slack" },
-      rawMessage: { team_id: "T0ABC", user: "U0XYZ", channel: "C1", ts: "1.2" },
+      // No `type: "app_mention"` — this is a thread follow-up.
+      rawMessage: { team_id: "T0ABC", user: "U0XYZ", channel: "C1", ts: "1.2", thread_ts: "1.0" },
     });
 
     expect(observedRateLimitKeys).toEqual(["slack:T0ABC"]);
+  });
+
+  it("rate-limit key for top-level @mention is per-user `slack:<teamId>:<userId>` — matches slack.ts:667", async () => {
+    const { runExecuteQuery } = await import("../executeQuery");
+
+    await runExecuteQuery("q", {
+      threadId: "slack:C1-1.2",
+      adapter: { name: "slack" },
+      rawMessage: {
+        type: "app_mention",
+        team_id: "T0ABC",
+        user: "U0XYZ",
+        channel: "C1",
+        ts: "1.2",
+      },
+    });
+
+    expect(observedRateLimitKeys).toEqual(["slack:T0ABC:U0XYZ"]);
+  });
+
+  it("rate-limit key for top-level @mention without user falls back to ts — matches slack.ts:667 `eventUserId || mentionTs`", async () => {
+    const { runExecuteQuery } = await import("../executeQuery");
+
+    await runExecuteQuery("q", {
+      threadId: "slack:C1-1.2",
+      adapter: { name: "slack" },
+      // app_mention with no `user` (e.g. mentions from automations)
+      rawMessage: { type: "app_mention", team_id: "T0ABC", channel: "C1", ts: "1.2" },
+    });
+
+    expect(observedRateLimitKeys).toEqual(["slack:T0ABC:1.2"]);
+  });
+
+  it("extracts team_id from interactive `block_actions` payload where `team` is `{id, domain}` — not the object literal", async () => {
+    const { runExecuteQuery } = await import("../executeQuery");
+
+    // `atlas_run_again` / `atlas_export_csv` button clicks route through
+    // executeQuery with a Slack `block_actions` payload, where `team` is
+    // an object (not a string) and `team_id` is absent. The helper MUST
+    // pull `team.id` so the rate-limit key + installation lookup get a
+    // real tenant key (not `[object Object]`).
+    await runExecuteQuery("q", {
+      threadId: "slack:C1-1.2",
+      adapter: { name: "slack" },
+      rawMessage: {
+        type: "block_actions",
+        team: { id: "T0ABC", domain: "acme" },
+        user: { id: "U0XYZ" },
+        channel: { id: "C1" },
+      },
+    });
+
+    // Non-`app_mention` event → team-wide key, but with the resolved id.
+    expect(observedRateLimitKeys).toEqual(["slack:T0ABC"]);
+    // user.id + channel.id resolve too (block_actions payloads nest both).
+    expect(capturedAgentCalls).toHaveLength(1);
+    expect(capturedAgentCalls[0]!.options?.actor?.id).toBe("slack-bot:T0ABC:U0XYZ");
   });
 
   it("creates a conversation mapping when none exists for the thread", async () => {

--- a/packages/api/src/lib/chat-plugin/executeQuery.ts
+++ b/packages/api/src/lib/chat-plugin/executeQuery.ts
@@ -59,18 +59,44 @@ const log = createLogger("chat-plugin:executeQuery");
 
 /**
  * Minimum shape we read from the Slack raw event payload. The chat SDK
- * types this as `SlackEvent` (with `team_id`, `user`, `channel`,
- * `thread_ts`, `ts`, etc.) but the contract here is `unknown` — narrow
- * defensively. `team_id` is the primary tenant key; `team` is a legacy
- * alias seen on some webhook shapes. `user` is the asker's Slack user id.
+ * types `SlackEvent` for events_api callbacks but does NOT type
+ * `block_actions` / interactive payloads — those flow through here too
+ * (via `atlas_run_again` / `atlas_export_csv` button clicks). The
+ * contract is `unknown` — narrow defensively.
+ *
+ * Events API: `team_id` / `user` / `channel` are bare strings.
+ * block_actions: `team` / `user` / `channel` are `{ id, ... }` objects.
+ * `type` lets us key the rate-limit bucket per-user for top-level
+ * @mentions and team-wide for thread follow-ups (matches slack.ts).
  */
 interface SlackRawEvent {
+  type?: string;
   team_id?: string;
-  team?: string;
-  user?: string;
-  channel?: string;
+  team?: string | { id?: string };
+  user?: string | { id?: string };
+  channel?: string | { id?: string };
   thread_ts?: string;
   ts?: string;
+}
+
+/**
+ * Normalize a Slack id field that may arrive as a bare string (events_api)
+ * or as a `{ id, ... }` object (interactive `block_actions` payloads).
+ */
+function extractSlackId(
+  value: string | { id?: string } | undefined,
+): string | undefined {
+  if (typeof value === "string") return value;
+  if (value && typeof value === "object" && typeof value.id === "string") {
+    return value.id;
+  }
+  return undefined;
+}
+
+/** Extract `team_id` (events_api) or `team.id` (block_actions). */
+function extractTeamId(raw: SlackRawEvent): string | undefined {
+  if (typeof raw.team_id === "string") return raw.team_id;
+  return extractSlackId(raw.team);
 }
 
 /**
@@ -108,10 +134,11 @@ export async function runExecuteQuery(
     );
   }
 
-  // 2. Resolve tenant from `rawMessage.team_id`. Mirrors
-  //    `lib/proactive/workspace-id-resolver.ts:createSlackWorkspaceIdResolver`.
+  // 2. Resolve tenant from `rawMessage.team_id` (or `team.id` on
+  //    interactive `block_actions` payloads — see `extractTeamId`).
+  //    Mirrors `lib/proactive/workspace-id-resolver.ts:createSlackWorkspaceIdResolver`.
   const raw = (rawMessage ?? {}) as SlackRawEvent;
-  const teamId = raw.team_id ?? raw.team;
+  const teamId = extractTeamId(raw);
   if (!teamId) {
     log.warn(
       { threadId, requestId },
@@ -122,9 +149,19 @@ export async function runExecuteQuery(
     );
   }
 
-  // 3. Per-tenant rate limit. Key shape matches slack.ts so existing
-  //    buckets keep their state across the migration.
-  const rateCheck = checkRateLimit(`slack:${teamId}`);
+  // Normalize Slack id fields (events_api: string; block_actions: object).
+  const externalUserId = extractSlackId(raw.user);
+  const channelId = extractSlackId(raw.channel) ?? "";
+
+  // 3. Rate limit. Top-level @mentions are keyed per-user so one noisy
+  //    user can't throttle the whole workspace (matches slack.ts:667).
+  //    Thread follow-ups stay team-wide so a long-running conversation
+  //    doesn't pile under one user's bucket (matches slack.ts:491).
+  const rateLimitKey =
+    raw.type === "app_mention"
+      ? `slack:${teamId}:${externalUserId ?? raw.ts ?? "unknown"}`
+      : `slack:${teamId}`;
+  const rateCheck = checkRateLimit(rateLimitKey);
   if (!rateCheck.allowed) {
     log.info(
       { teamId, threadId, requestId },
@@ -183,7 +220,6 @@ export async function runExecuteQuery(
     );
   }
 
-  const externalUserId = raw.user;
   const actor = botActorUser({
     platform: "slack",
     externalId: teamId,
@@ -197,7 +233,6 @@ export async function runExecuteQuery(
   //    truth for cross-surface history (admin console + web chat + Slack
   //    thread reads). Mirror what slack.ts does: look up by
   //    (channel, thread_ts) and persist the user/assistant turns.
-  const channelId = raw.channel ?? "";
   const slackThreadTs = raw.thread_ts ?? raw.ts ?? "";
   let conversationId: string | null = null;
   if (channelId && slackThreadTs) {


### PR DESCRIPTION
## Summary

Addresses two issues Codex's automated review surfaced on #2626 (merged 6 minutes before the comments were noticed):

1. **Slack interactive payload `team` is an object, not a string** (P1) — `atlas_run_again` / `atlas_export_csv` button clicks send `block_actions` payloads where `team` is `{id, domain}` and `user`/`channel` are `{id, ...}` objects (not bare strings like in `events_api` callbacks). The previous `raw.team_id ?? raw.team` resolved to the object literal, breaking tenant lookup once the manifest flips (#2612). Adds `extractSlackId()` to normalize all three id fields across both shapes.

2. **Per-user rate-limit key lost for top-level @mentions** (P2 but real) — pre-migration `slack.ts:667` used `slack:${teamId}:${userId|ts}` for top-level mentions so one noisy user couldn't throttle the workspace; thread follow-ups stayed team-wide (`slack.ts:491`). #2626 collapsed both to team-wide. Restored the distinction, gated on `raw.type === "app_mention"`.

## What's NOT in this PR

- Codex's third comment (P1 — fail closed on `getInstallation` throw) was already addressed in #2626's fix-pass commit `16cd5cb` before merge. ✓

## Test plan

- [x] 3 new tests in `execute-query.test.ts` (now 20 total, +3 from #2626's 17):
  - top-level @mention → per-user key `slack:${teamId}:${userId}`
  - top-level @mention without user → falls back to `slack:${teamId}:${ts}`
  - `block_actions` payload with `team: {id, domain}` + `user: {id}` + `channel: {id}` → normalizes to bare ids, actor id correct
- [x] Existing thread-followup rate-limit test relabeled to clearly mark it as the thread-followup path (was the only rate-limit test before; now contrasts with the new per-user tests)
- [x] `bun run lint` — 0 errors
- [x] `bun run type` — clean
- [x] `bun run test` — 421/421 files pass (all packages green)
- [x] Drift checks — template / schema all pass
- [ ] Boot Smoke green on Railway

Closes part of #2611's review feedback (the original PR auto-merged before these were caught).