### PR TITLE
fix(plugins/chat): channelAllowed reads from channel_proactive_config (slice 4 dogfood blocker)

### DIFF
--- a/plugins/chat/src/proactive/__tests__/listener.test.ts
+++ b/plugins/chat/src/proactive/__tests__/listener.test.ts
@@ -306,6 +306,41 @@ describe("registerProactiveListener — channel-message handler", () => {
     expect(thread.postEphemeral).not.toHaveBeenCalled();
   });
 
+  it("reacts when a channel_proactive_config row has allow=true (DB opt-in)", async () => {
+    // Post-#2620 multi-tenant path: the per-event `getChannelConfigs`
+    // fetcher is the source of truth. A DB row with `allow: true` opts
+    // the channel in even when the legacy env-var allowlist is empty.
+    const { chat, invokeMessage } = makeChat();
+    await registerProactiveListener(chat as any, makeLogger(), {
+      isEnabled: () => true,
+      classify: yesLLM,
+      resolveWorkspaceId: defaultResolver,
+      getWorkspaceConfig: defaultGetWorkspace,
+      getChannelConfigs: makeWorkspaceFetchers(baseWorkspace, [{ channelId: "C-db-opted-in", allow: true }]).getChannelConfigs,
+      // No channelAllowlist — DB row is the sole opt-in signal.
+    });
+    const thread = makeThread("C-db-opted-in");
+    await invokeMessage(thread, makeMessage());
+    expect(thread._addReaction).toHaveBeenCalledWith(PROACTIVE_REACTION);
+  });
+
+  it("skips when a channel_proactive_config row has allow=false (DB opt-out wins over env allowlist)", async () => {
+    const { chat, invokeMessage } = makeChat();
+    await registerProactiveListener(chat as any, makeLogger(), {
+      isEnabled: () => true,
+      classify: yesLLM,
+      resolveWorkspaceId: defaultResolver,
+      getWorkspaceConfig: defaultGetWorkspace,
+      getChannelConfigs: makeWorkspaceFetchers(baseWorkspace, [{ channelId: "C-opted-out", allow: false }]).getChannelConfigs,
+      // Channel IS on the env allowlist — but the DB row explicitly opts out.
+      // DB wins over env so an admin's deny in the UI is honored.
+      channelAllowlist: ["C-opted-out"],
+    });
+    const thread = makeThread("C-opted-out");
+    await invokeMessage(thread, makeMessage());
+    expect(thread._addReaction).not.toHaveBeenCalled();
+  });
+
   it("rate-limits a chatty channel — only the first message reacts", async () => {
     const { chat, invokeMessage } = makeChat();
     await registerProactiveListener(chat as any, makeLogger(), {

--- a/plugins/chat/src/proactive/listener.ts
+++ b/plugins/chat/src/proactive/listener.ts
@@ -592,10 +592,19 @@ export async function registerProactiveListener(
         return;
       }
 
-      const channelAllowed = allowlist.has(channelId);
+      // Post-#2620: the per-event `getChannelConfigs` fetcher is the
+      // source of truth for which channels are opted in. The legacy
+      // env-var allowlist (`ATLAS_PROACTIVE_CHANNELS`, resolved at
+      // registration time) is kept as a fallback for self-hosted dev
+      // setups, but only kicks in when no DB row exists for the channel.
+      // A row with `allow: false` is an explicit opt-out and wins over
+      // the env-var allowlist.
       const channelConfig = channelConfigs.find(
         (cfg) => cfg.channelId === channelId,
       );
+      const channelAllowed = channelConfig
+        ? channelConfig.allow === true
+        : allowlist.has(channelId);
 
       // ---------------------------------------------------------------
       // Monthly quota cap (#2301) — short-circuit BEFORE the classifier


### PR DESCRIPTION
## Summary

Hotfix found during slice 4 dogfood of #2607. The proactive listener's `channelAllowed` check at `listener.ts:595` read from the legacy env-var allowlist (`ATLAS_PROACTIVE_CHANNELS`) — but #2620's multi-tenant refactor was supposed to make `channel_proactive_config` rows the source of truth. The env-var path was never updated; admins setting a DB row got silent skips with `metadata.reason: "channel-not-allowed"`.

## Repro

Slice 4 dogfood (manifest flipped, slices 2/3 deployed): post a question in a channel with a `channel_proactive_config` row (`allow=true`). Classifier fires (meter row with `isQuestion: true, confidence: 0.98`) but no 🤖 reaction.

## Fix

`channelAllowed = channelConfig.allow === true` when a row exists; fall back to env allowlist when no row (self-hosted dev convenience kept intact). DB-derived deny (`allow: false`) wins over an env-var entry. Two regression tests pin both branches.

## Test plan

- [x] 61/61 listener tests pass (was 59 + 2 new)
- [x] `bun run lint` — 0 errors
- [x] `bun run type` — clean
- [ ] Boot Smoke green on Railway
- [ ] Slice 4 dogfood retry shows 🤖 reaction