### PR TITLE
fix(plugins/chat,deploy): make slack botToken optional + drop SaaS placeholder (slice 4 dogfood blocker)

### DIFF
--- a/deploy/api/atlas.config.ts
+++ b/deploy/api/atlas.config.ts
@@ -82,15 +82,20 @@ export default defineConfig({
   // handle slash commands, block actions, modals, and OAuth.
   //
   // SaaS is multi-tenant: real Slack bot tokens live in the internal
-  // DB (slack_installations) keyed by team_id. The static `botToken`
-  // below is required by Zod (min(1)) but is never used for outbound
-  // calls in SaaS — `createChatPluginExecuteQuery()` resolves the
-  // per-tenant token via `getBotToken(teamId)` inside the agent loop.
+  // DB (slack_installations) keyed by team_id and are backfilled into
+  // the chat plugin's installation store (chat_cache:slack:installation:<teamId>).
+  // We intentionally OMIT `botToken` so `@chat-adapter/slack` operates in
+  // multi-workspace mode and resolves the per-event token via
+  // `resolveTokenForTeam()`. Passing a placeholder string would put the
+  // adapter in single-workspace mode and the placeholder would be sent as
+  // the Slack API bearer token (rejected with `invalid_auth`).
   plugins: [
     chatPlugin({
       adapters: {
         slack: {
-          botToken: process.env.SLACK_BOT_TOKEN ?? "saas-multi-tenant-unused",
+          ...(process.env.SLACK_BOT_TOKEN
+            ? { botToken: process.env.SLACK_BOT_TOKEN }
+            : {}),
           signingSecret:
             process.env.SLACK_SIGNING_SECRET ?? "saas-multi-tenant-unused",
           ...(process.env.SLACK_CLIENT_ID

--- a/plugins/chat/src/config.ts
+++ b/plugins/chat/src/config.ts
@@ -112,7 +112,12 @@ export interface ChatQueryResult {
 
 /** Adapter-specific credential configuration. */
 export interface SlackAdapterConfig {
-  botToken: string;
+  /**
+   * Single-workspace bot token. Omit in multi-workspace deploys so
+   * `@chat-adapter/slack` resolves per-event tokens from its installation
+   * store. Required when `clientId`+`clientSecret` are not set.
+   */
+  botToken?: string;
   signingSecret: string;
   /** Client ID for multi-workspace OAuth. */
   clientId?: string;
@@ -628,7 +633,13 @@ export interface ProactiveConfig {
 // ---------------------------------------------------------------------------
 
 const SlackAdapterSchema = z.object({
-  botToken: z.string().min(1, "slack botToken must not be empty"),
+  // Optional: required for single-workspace mode (the adapter uses this
+  // bare token for every outbound call). MULTI-WORKSPACE deploys OMIT
+  // this field so `@chat-adapter/slack` resolves per-event tokens from
+  // its installation store (state-adapter `slack:installation:<teamId>`).
+  // A non-empty placeholder here puts the adapter in single-workspace
+  // mode and the placeholder ends up as the bearer token → Slack rejects.
+  botToken: z.string().min(1, "slack botToken must not be empty").optional(),
   signingSecret: z.string().min(1, "slack signingSecret must not be empty"),
   clientId: z.string().min(1).optional(),
   clientSecret: z.string().min(1).optional(),


### PR DESCRIPTION
## The bug

`@chat-adapter/slack` line 1124:
\`\`\`js
if (!this.defaultBotToken && payload.type === \"event_callback\") {
  // multi-workspace: resolve token per-team from state adapter
} else {
  // single-workspace: use defaultBotToken as bearer
}
\`\`\`

SaaS set \`botToken: process.env.SLACK_BOT_TOKEN ?? \"saas-multi-tenant-unused\"\` — the placeholder made \`defaultBotToken\` truthy, so the adapter used it as the bearer instead of looking up the real per-tenant token from \`chat_cache\`. Slack rejected the bogus bearer; the proactive listener's \`addReaction\` silently failed.

Confirmed in dogfood: classifier ran fine (meter rows with \`action: \"react\"\`), reaction never landed, no \`react\` meter row emitted.

## Fix

1. **Plugin** — \`SlackAdapterConfig.botToken\` is now optional in both the TS interface and Zod schema. Multi-workspace deploys omit it; single-workspace deploys still need it.
2. **SaaS** — drop the placeholder; only spread \`SLACK_BOT_TOKEN\` into the config when actually set. Adapter operates in multi-workspace mode and resolves per-event tokens via \`chat_cache:slack:installation:<teamId>\`.

## Test plan

- [x] \`bun run lint\` — 0 errors
- [x] \`bun run type\` — clean
- [x] Chat plugin: 438/438 tests pass
- [ ] Boot Smoke green on Railway
- [ ] Slice 4 dogfood retry produces the 🤖