### PR TITLE
fix(api,plugins/chat,deploy): #2607 aggregate review fixes — F-55 proactive, await, schema hardening, audit dual-write

### DIFF
--- a/deploy/api/atlas.config.ts
+++ b/deploy/api/atlas.config.ts
@@ -81,15 +81,10 @@ export default defineConfig({
   // routes in packages/api/src/api/routes/slack.ts stay put — they
   // handle slash commands, block actions, modals, and OAuth.
   //
-  // SaaS is multi-tenant: real Slack bot tokens live in the internal
-  // DB (slack_installations) keyed by team_id and are backfilled into
-  // the chat plugin's installation store (chat_cache:slack:installation:<teamId>).
-  // We intentionally OMIT `botToken` here so `@chat-adapter/slack`
-  // operates in multi-workspace mode and resolves the per-event token
-  // via `resolveTokenForTeam()`. Passing a placeholder string puts the
-  // adapter in single-workspace mode and that string ends up as the
-  // Slack API bearer (rejected with `invalid_auth`). The schema now
-  // refuses any non-`xox*` botToken so misconfiguration fails fast in CI.
+  // Multi-tenant SaaS: real bot tokens live in `slack_installations`
+  // and are resolved per-event by `@chat-adapter/slack` from its
+  // installation store (`chat_cache:slack:installation:<teamId>`).
+  // OMIT `botToken` so the adapter operates in multi-workspace mode.
   plugins: [
     chatPlugin({
       adapters: {

--- a/deploy/api/atlas.config.ts
+++ b/deploy/api/atlas.config.ts
@@ -84,11 +84,12 @@ export default defineConfig({
   // SaaS is multi-tenant: real Slack bot tokens live in the internal
   // DB (slack_installations) keyed by team_id and are backfilled into
   // the chat plugin's installation store (chat_cache:slack:installation:<teamId>).
-  // We intentionally OMIT `botToken` so `@chat-adapter/slack` operates in
-  // multi-workspace mode and resolves the per-event token via
-  // `resolveTokenForTeam()`. Passing a placeholder string would put the
-  // adapter in single-workspace mode and the placeholder would be sent as
-  // the Slack API bearer token (rejected with `invalid_auth`).
+  // We intentionally OMIT `botToken` here so `@chat-adapter/slack`
+  // operates in multi-workspace mode and resolves the per-event token
+  // via `resolveTokenForTeam()`. Passing a placeholder string puts the
+  // adapter in single-workspace mode and that string ends up as the
+  // Slack API bearer (rejected with `invalid_auth`). The schema now
+  // refuses any non-`xox*` botToken so misconfiguration fails fast in CI.
   plugins: [
     chatPlugin({
       adapters: {
@@ -96,8 +97,10 @@ export default defineConfig({
           ...(process.env.SLACK_BOT_TOKEN
             ? { botToken: process.env.SLACK_BOT_TOKEN }
             : {}),
-          signingSecret:
-            process.env.SLACK_SIGNING_SECRET ?? "saas-multi-tenant-unused",
+          // Single shared signing secret for the Atlas Slack app — Zod
+          // now rejects placeholder strings so an unset env var fails
+          // boot rather than silently passing webhook verification.
+          signingSecret: process.env.SLACK_SIGNING_SECRET ?? "",
           ...(process.env.SLACK_CLIENT_ID
             ? { clientId: process.env.SLACK_CLIENT_ID }
             : {}),

--- a/packages/api/src/api/__tests__/slack.test.ts
+++ b/packages/api/src/api/__tests__/slack.test.ts
@@ -469,6 +469,27 @@ describe("/api/v1/slack", () => {
       expect(json.error).toBe("invalid_signature");
     });
 
+    it("rejects invalid signature with 401 even when body is malformed JSON (verify before parse)", async () => {
+      // Pins the verify-before-parse ordering: an attacker sending
+      // garbage with a forged signature must hit `invalid_signature` /
+      // 401, not `invalid_json` / 400. A regression that swaps the
+      // order would leak "your signature was fine, your JSON wasn't".
+      const app = await getApp();
+      const resp = await app.request("/api/v1/slack/events", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-slack-signature": "v0=bad_signature",
+          "x-slack-request-timestamp": String(Math.floor(Date.now() / 1000)),
+        },
+        body: "not-json{",
+      });
+
+      expect(resp.status).toBe(401);
+      const json = (await resp.json()) as Record<string, unknown>;
+      expect(json.error).toBe("invalid_signature");
+    });
+
     // (deleted #2611) `processes thread follow-up events and calls the agent`
     // (deleted #2611) `processes a top-level app_mention and runs the agent in a new thread`
     // (deleted #2611) `skips app_mention when posted inside an existing thread (message branch owns it)` — coverage now in plugins/chat/src/bridge.test.ts (`acquireLock` dedup) and the bridge's onSubscribedMessage path

--- a/packages/api/src/api/routes/slack.ts
+++ b/packages/api/src/api/routes/slack.ts
@@ -479,6 +479,9 @@ slack.openapi(commandsRoute, async (c) => {
 
 slack.openapi(eventsRoute, async (c) => {
   const { valid, body } = await verifyRequest(c);
+  if (!valid) {
+    return c.json({ error: "invalid_signature", message: "Invalid signature" }, 401);
+  }
 
   let payload: Record<string, unknown>;
   try {
@@ -486,10 +489,6 @@ slack.openapi(eventsRoute, async (c) => {
   } catch (err) {
     log.warn({ err: err instanceof Error ? err.message : String(err) }, "Slack events received non-JSON body");
     return c.json({ error: "invalid_json", message: "Invalid JSON" }, 400);
-  }
-
-  if (!valid) {
-    return c.json({ error: "invalid_signature", message: "Invalid signature" }, 401);
   }
 
   if (payload.type === "url_verification") {

--- a/packages/api/src/lib/chat-plugin/__tests__/execute-query.test.ts
+++ b/packages/api/src/lib/chat-plugin/__tests__/execute-query.test.ts
@@ -293,6 +293,27 @@ describe("chat-plugin executeQuery host helper", () => {
     expect(mockCreateConversation).toHaveBeenCalledTimes(1);
     // surface 'slack' so admin filters and audit show the right origin
     expect(mockCreateConversation.mock.calls[0]![0]).toMatchObject({ surface: "slack" });
+    // Orphan-row guard: createConversation must complete before
+    // setConversationId stamps the thread mapping, otherwise a failed
+    // create leaves the mapping pointing at a non-existent row.
+    const createOrder = mockCreateConversation.mock.invocationCallOrder[0]!;
+    const setOrder = mockSetConversationId.mock.invocationCallOrder[0]!;
+    expect(createOrder).toBeLessThan(setOrder);
+  });
+
+  it("does not stamp the thread mapping when createConversation rejects (no orphan row)", async () => {
+    mockCreateConversation.mockRejectedValueOnce(new Error("db down"));
+    const { runExecuteQuery } = await import("../executeQuery");
+
+    // The catch logs at error and proceeds with in-memory only — the
+    // call should still complete, but no setConversationId stamp.
+    await runExecuteQuery("q", {
+      threadId: "slack:Corph-1.0",
+      adapter: { name: "slack" },
+      rawMessage: { team_id: "T0ABC", user: "U", channel: "Corph", ts: "1.0" },
+    });
+    expect(mockCreateConversation).toHaveBeenCalledTimes(1);
+    expect(mockSetConversationId).not.toHaveBeenCalled();
   });
 
   it("persists both user and assistant turns via addMessage", async () => {

--- a/packages/api/src/lib/chat-plugin/executeQuery.ts
+++ b/packages/api/src/lib/chat-plugin/executeQuery.ts
@@ -253,7 +253,7 @@ export async function runExecuteQuery(
       conversationId = crypto.randomUUID();
       try {
         await setConversationId(channelId, slackThreadTs, conversationId);
-        createConversation({
+        await createConversation({
           id: conversationId,
           title: generateTitle(question),
           surface: "slack",

--- a/packages/api/src/lib/chat-plugin/executeQuery.ts
+++ b/packages/api/src/lib/chat-plugin/executeQuery.ts
@@ -252,14 +252,23 @@ export async function runExecuteQuery(
     if (!conversationId) {
       conversationId = crypto.randomUUID();
       try {
-        await setConversationId(channelId, slackThreadTs, conversationId);
+        // Create the conversation row BEFORE stamping the thread →
+        // conversationId mapping so a failure can't leave the mapping
+        // pointing at a non-existent row. If `setConversationId` then
+        // fails, the next event in the same thread allocates a fresh
+        // conversation — worse for context continuity, harmless for
+        // correctness.
         await createConversation({
           id: conversationId,
           title: generateTitle(question),
           surface: "slack",
         });
+        await setConversationId(channelId, slackThreadTs, conversationId);
       } catch (err) {
-        log.warn(
+        // A DB write failure on the critical-path agent run is on-call
+        // signal — log at error so Sentry / alerts fire alongside the
+        // sibling tenant-resolution and agent-run failure paths.
+        log.error(
           {
             err: err instanceof Error ? err.message : String(err),
             channelId,

--- a/packages/api/src/lib/effect/__tests__/saas-env.test.ts
+++ b/packages/api/src/lib/effect/__tests__/saas-env.test.ts
@@ -54,6 +54,7 @@ describe("SAAS_ENV_KEYS", () => {
       RESEND_API_KEY: undefined,
       BETTER_AUTH_URL: undefined,
       BETTER_AUTH_TRUSTED_ORIGINS: undefined,
+      SLACK_SIGNING_SECRET: undefined,
     };
     const expectedKeys: readonly string[] = Object.keys(exhaustive).sort();
     const actualKeys: readonly string[] = [...SAAS_ENV_KEYS].sort();

--- a/packages/api/src/lib/effect/saas-env.ts
+++ b/packages/api/src/lib/effect/saas-env.ts
@@ -71,6 +71,13 @@ export interface SaasEnv {
   // would silently land users on the API host instead of the web app.
   readonly BETTER_AUTH_URL: string | undefined;
   readonly BETTER_AUTH_TRUSTED_ORIGINS: string | undefined;
+
+  // Slack plugin signing secret — required by `chatPlugin`'s Slack
+  // adapter schema, which now enforces a 32-char lowercase hex format
+  // at boot. Production deploys provide a real Slack app secret; the
+  // boot-smoke fixture emits a syntactically-valid placeholder so the
+  // schema parses without crashing the boot guards.
+  readonly SLACK_SIGNING_SECRET: string | undefined;
 }
 
 /**
@@ -98,6 +105,7 @@ export const SAAS_ENV_KEYS = [
   "RESEND_API_KEY",
   "BETTER_AUTH_URL",
   "BETTER_AUTH_TRUSTED_ORIGINS",
+  "SLACK_SIGNING_SECRET",
 ] as const satisfies readonly (keyof SaasEnv)[];
 
 // Compile-time exhaustiveness: every key in SaasEnv must appear in
@@ -131,6 +139,7 @@ export function readSaasEnv(env: NodeJS.ProcessEnv = process.env): SaasEnv {
     RESEND_API_KEY: env.RESEND_API_KEY,
     BETTER_AUTH_URL: env.BETTER_AUTH_URL,
     BETTER_AUTH_TRUSTED_ORIGINS: env.BETTER_AUTH_TRUSTED_ORIGINS,
+    SLACK_SIGNING_SECRET: env.SLACK_SIGNING_SECRET,
   };
 }
 
@@ -197,6 +206,11 @@ export function makeBootSmokeFixture(
     RESEND_API_KEY: "ci-fixture-resend-key-not-a-secret",
     BETTER_AUTH_URL: "http://127.0.0.1:3001",
     BETTER_AUTH_TRUSTED_ORIGINS: "http://127.0.0.1:3000",
+    // 32-char lowercase hex placeholder. Satisfies the new strict
+    // `SLACK_SIGNING_SECRET_REGEX` in plugins/chat/src/config.ts so the
+    // SaaS deploy config parses cleanly under Boot Smoke without
+    // requiring a real Slack app credential.
+    SLACK_SIGNING_SECRET: "0123456789abcdef0123456789abcdef",
   };
   return { ...fixture, ...opts.overrides };
 }

--- a/packages/api/src/lib/proactive/__tests__/answer-adapter.test.ts
+++ b/packages/api/src/lib/proactive/__tests__/answer-adapter.test.ts
@@ -231,12 +231,9 @@ describe("createProactiveAnswerAdapter — linked path", () => {
 
   it("refuses (does not invoke the agent) when the linked user no longer resolves to an actor", async () => {
     // Deleted-account scenario: resolveOrgForUser succeeds but
-    // resolveActor returns null. The interactive path
-    // (executeQuery.ts:188) treats this as a hard refusal; the
-    // proactive path must match for cross-layer consistency. Running
-    // the agent with `actor: null` would attach no `user` to
-    // RequestContext and any rule-matching gate downstream would
-    // short-circuit.
+    // resolveActor returns null. Running the agent with actor=null
+    // would attach no `user` to RequestContext and short-circuit any
+    // downstream rule-matching gate — refuse instead.
     const runtime = buildRuntime();
     const adapter = createProactiveAnswerAdapter(runtime, {
       resolveOrgForUser: async () => null,
@@ -257,11 +254,10 @@ describe("createProactiveAnswerAdapter — linked path", () => {
   });
 
   it("refuses (F-55 fail-closed) when resolveOrgForUser throws — never runs the agent with reduced scope", async () => {
-    // F-55 regression: a thrown `resolveOrgForUser` is a DB/infra
-    // failure, not "user has no org" (which returns null). Running
-    // with `orgId = null` would short-circuit `checkApprovalRequired`
-    // and bypass rule-matching gates. Match the interactive path
-    // (executeQuery.ts:201–221) by refusing.
+    // F-55 regression: a thrown `resolveOrgForUser` is infra failure,
+    // not "user has no org" (which returns null). Running with
+    // orgId=null would short-circuit checkApprovalRequired and bypass
+    // rule-matching gates — refuse instead.
     const runtime = buildRuntime();
     const dbError = new Error("connection terminated unexpectedly");
     const adapter = createProactiveAnswerAdapter(runtime, {

--- a/packages/api/src/lib/proactive/__tests__/answer-adapter.test.ts
+++ b/packages/api/src/lib/proactive/__tests__/answer-adapter.test.ts
@@ -229,28 +229,60 @@ describe("createProactiveAnswerAdapter — linked path", () => {
     await runtime.dispose();
   });
 
-  it("degrades to anonymous identity when the linked user cannot be resolved", async () => {
-    nextRunAgentResult = {
-      text: Promise.resolve("Fallback answer"),
-      steps: Promise.resolve([]),
-      totalUsage: Promise.resolve({ inputTokens: 0, outputTokens: 0 }),
-    };
-
+  it("refuses (does not invoke the agent) when the linked user no longer resolves to an actor", async () => {
+    // Deleted-account scenario: resolveOrgForUser succeeds but
+    // resolveActor returns null. The interactive path
+    // (executeQuery.ts:188) treats this as a hard refusal; the
+    // proactive path must match for cross-layer consistency. Running
+    // the agent with `actor: null` would attach no `user` to
+    // RequestContext and any rule-matching gate downstream would
+    // short-circuit.
     const runtime = buildRuntime();
     const adapter = createProactiveAnswerAdapter(runtime, {
       resolveOrgForUser: async () => null,
-      // `resolveActor` returns null — user row deleted / not found.
       resolveActor: async () => null,
     });
 
-    const result = await adapter("orphan question", {
-      threadId: "T-orphan",
-      asker: slackAsker,
-      atlasUserId: "user-missing",
+    await expect(
+      adapter("orphan question", {
+        threadId: "T-orphan",
+        asker: slackAsker,
+        atlasUserId: "user-missing",
+      }),
+    ).rejects.toThrow(/Atlas couldn't answer this/);
+
+    // Critical: the agent must NOT have been invoked.
+    expect(observedRunAgentCalls).toHaveLength(0);
+    await runtime.dispose();
+  });
+
+  it("refuses (F-55 fail-closed) when resolveOrgForUser throws — never runs the agent with reduced scope", async () => {
+    // F-55 regression: a thrown `resolveOrgForUser` is a DB/infra
+    // failure, not "user has no org" (which returns null). Running
+    // with `orgId = null` would short-circuit `checkApprovalRequired`
+    // and bypass rule-matching gates. Match the interactive path
+    // (executeQuery.ts:201–221) by refusing.
+    const runtime = buildRuntime();
+    const dbError = new Error("connection terminated unexpectedly");
+    const adapter = createProactiveAnswerAdapter(runtime, {
+      resolveOrgForUser: async () => {
+        throw dbError;
+      },
+      // Should never be invoked once resolveOrgForUser throws.
+      resolveActor: async () => {
+        throw new Error("resolveActor must not be called after resolveOrgForUser throws");
+      },
     });
 
-    expect(result.answer).toBe("Fallback answer");
-    expect(observedRunAgentCalls[0].userId).toBeUndefined();
+    await expect(
+      adapter("how many customers?", {
+        threadId: "T-fail",
+        asker: slackAsker,
+        atlasUserId: "user-1",
+      }),
+    ).rejects.toThrow(/Atlas couldn't answer this/);
+
+    expect(observedRunAgentCalls).toHaveLength(0);
     await runtime.dispose();
   });
 });

--- a/packages/api/src/lib/proactive/__tests__/answer-meter-audit.test.ts
+++ b/packages/api/src/lib/proactive/__tests__/answer-meter-audit.test.ts
@@ -1,21 +1,4 @@
-/**
- * Tests for the proactive meter → admin_action_log dual-write (#2631).
- *
- * The AC for #2610 required that every meter row also emit an
- * `ADMIN_ACTIONS.proactive.{classify,react,answer,feedback}` audit row
- * so `/admin/proactive-chat` analytics that join on `admin_action_log`
- * stay in lockstep with `proactive_meter_events`. Originally only the
- * meter row was being written.
- *
- * These tests pin the dual-write: `logAdminAction` is mock-modded and
- * asserts the audit row goes out for every supported event type, with
- * the meter event's `workspaceId`/`channelId`/`outcome` etc. flowing
- * through to the audit `metadata` blob. The `offer` and
- * `public_refused` event types do not have a sibling admin action and
- * MUST NOT emit (they are meter-only by design).
- *
- * Uses sync `mock.module()` factories per CLAUDE.md.
- */
+// Pins the meter → admin_action_log dual-write per event type.
 
 import { describe, it, expect, beforeEach, mock } from "bun:test";
 
@@ -29,16 +12,23 @@ interface ObservedAuditCall {
 }
 const observedAuditCalls: ObservedAuditCall[] = [];
 
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const realAuditAdmin = require("@atlas/api/lib/audit/admin");
 mock.module("@atlas/api/lib/audit/admin", () => ({
+  ...realAuditAdmin,
   logAdminAction: (entry: ObservedAuditCall) => {
     observedAuditCalls.push(entry);
   },
 }));
 
-// `hasInternalDB` returns false so we exercise the dual-write logic
-// without needing a real Postgres pool; the audit emit fires BEFORE
-// the DB-skip return so the test still observes the call.
+// `hasInternalDB` returns false so the dual-write logic runs without
+// a real Postgres pool; the audit emit fires BEFORE the DB-skip return.
+// Spread the real module so sibling tests that mock-module the same
+// path aren't corrupted by a partial-export factory.
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const realDbInternal = require("@atlas/api/lib/db/internal");
 mock.module("@atlas/api/lib/db/internal", () => ({
+  ...realDbInternal,
   hasInternalDB: () => false,
   internalQuery: async () => [],
 }));

--- a/packages/api/src/lib/proactive/__tests__/answer-meter-audit.test.ts
+++ b/packages/api/src/lib/proactive/__tests__/answer-meter-audit.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Tests for the proactive meter → admin_action_log dual-write (#2631).
+ *
+ * The AC for #2610 required that every meter row also emit an
+ * `ADMIN_ACTIONS.proactive.{classify,react,answer,feedback}` audit row
+ * so `/admin/proactive-chat` analytics that join on `admin_action_log`
+ * stay in lockstep with `proactive_meter_events`. Originally only the
+ * meter row was being written.
+ *
+ * These tests pin the dual-write: `logAdminAction` is mock-modded and
+ * asserts the audit row goes out for every supported event type, with
+ * the meter event's `workspaceId`/`channelId`/`outcome` etc. flowing
+ * through to the audit `metadata` blob. The `offer` and
+ * `public_refused` event types do not have a sibling admin action and
+ * MUST NOT emit (they are meter-only by design).
+ *
+ * Uses sync `mock.module()` factories per CLAUDE.md.
+ */
+
+import { describe, it, expect, beforeEach, mock } from "bun:test";
+
+interface ObservedAuditCall {
+  actionType: string;
+  targetType: string;
+  targetId: string;
+  scope?: "platform" | "workspace";
+  systemActor?: string;
+  metadata?: Record<string, unknown>;
+}
+const observedAuditCalls: ObservedAuditCall[] = [];
+
+mock.module("@atlas/api/lib/audit/admin", () => ({
+  logAdminAction: (entry: ObservedAuditCall) => {
+    observedAuditCalls.push(entry);
+  },
+}));
+
+// `hasInternalDB` returns false so we exercise the dual-write logic
+// without needing a real Postgres pool; the audit emit fires BEFORE
+// the DB-skip return so the test still observes the call.
+mock.module("@atlas/api/lib/db/internal", () => ({
+  hasInternalDB: () => false,
+  internalQuery: async () => [],
+}));
+
+const { recordMeterEvent } = await import("../answer-meter");
+
+beforeEach(() => {
+  observedAuditCalls.length = 0;
+});
+
+describe("recordMeterEvent — admin_action_log dual-write (#2631)", () => {
+  const baseEvent = {
+    workspaceId: "ws-1",
+    channelId: "C-1",
+    messageId: "M-1",
+  } as const;
+
+  it("emits proactive.classify for a classify meter event", async () => {
+    await recordMeterEvent({
+      ...baseEvent,
+      eventType: "classify",
+      confidence: 0.84,
+    });
+
+    expect(observedAuditCalls).toHaveLength(1);
+    expect(observedAuditCalls[0].actionType).toBe("proactive.classify");
+    expect(observedAuditCalls[0].targetType).toBe("proactive");
+    expect(observedAuditCalls[0].targetId).toBe("C-1");
+    expect(observedAuditCalls[0].scope).toBe("workspace");
+    expect(observedAuditCalls[0].systemActor).toBe("system:proactive-meter");
+    expect(observedAuditCalls[0].metadata).toMatchObject({
+      workspaceId: "ws-1",
+      channelId: "C-1",
+      messageId: "M-1",
+      confidence: 0.84,
+    });
+  });
+
+  it("emits proactive.react for a react meter event", async () => {
+    await recordMeterEvent({ ...baseEvent, eventType: "react" });
+    expect(observedAuditCalls).toHaveLength(1);
+    expect(observedAuditCalls[0].actionType).toBe("proactive.react");
+  });
+
+  it("emits proactive.answer for an accept meter event (user accepted the offer)", async () => {
+    // The meter's `accept` lifecycle stage IS the moment an answer was
+    // delivered — map to ADMIN_ACTIONS.proactive.answer.
+    await recordMeterEvent({ ...baseEvent, eventType: "accept" });
+    expect(observedAuditCalls).toHaveLength(1);
+    expect(observedAuditCalls[0].actionType).toBe("proactive.answer");
+  });
+
+  it("emits proactive.feedback with the outcome in metadata", async () => {
+    await recordMeterEvent({
+      ...baseEvent,
+      eventType: "feedback",
+      outcome: "not-helpful",
+    });
+    expect(observedAuditCalls).toHaveLength(1);
+    expect(observedAuditCalls[0].actionType).toBe("proactive.feedback");
+    expect(observedAuditCalls[0].metadata).toMatchObject({
+      outcome: "not-helpful",
+    });
+  });
+
+  it("does NOT emit an audit row for offer events (meter-only by design)", async () => {
+    // `offer` is a tracer reaction stage with no forensic sibling —
+    // adding an audit row would double-count engagement.
+    await recordMeterEvent({ ...baseEvent, eventType: "offer" });
+    expect(observedAuditCalls).toHaveLength(0);
+  });
+
+  it("does NOT emit an audit row for public_refused events", async () => {
+    await recordMeterEvent({
+      ...baseEvent,
+      eventType: "public_refused",
+    });
+    expect(observedAuditCalls).toHaveLength(0);
+  });
+
+  it("threads custom metadata through to the audit row alongside fixed fields", async () => {
+    await recordMeterEvent({
+      ...baseEvent,
+      eventType: "classify",
+      actorUserId: "U-bot",
+      metadata: { reason: "channel-not-allowed", classifierMode: "balanced" },
+    });
+    expect(observedAuditCalls).toHaveLength(1);
+    expect(observedAuditCalls[0].metadata).toMatchObject({
+      workspaceId: "ws-1",
+      actorUserId: "U-bot",
+      reason: "channel-not-allowed",
+      classifierMode: "balanced",
+    });
+  });
+});

--- a/packages/api/src/lib/proactive/answer-adapter.ts
+++ b/packages/api/src/lib/proactive/answer-adapter.ts
@@ -269,11 +269,6 @@ export function createProactiveAnswerAdapter(
     }
 
     // 3. Run the agent inside a synthesized RequestContext --------------
-    // `withRequestContext` binds `requestId` into AsyncLocalStorage so
-    // every `log.X()` call inside `runAgent` (tool dispatch, SQL execution,
-    // token usage) automatically carries the same correlation id as the
-    // adapter's own logs. No need to thread `requestId` through `runAgent`
-    // explicitly.
     try {
       const stream = await withRequestContext(
         {
@@ -339,25 +334,16 @@ async function resolveLinkedActor(
   resolveOrgForUser: (id: string) => Promise<string | null>,
   resolveActor: (id: string, orgId: string | null) => Promise<AtlasUser | null>,
 ): Promise<AtlasUser> {
-  // F-55 fail-closed: a thrown `resolveOrgForUser` is a DB/infra
-  // failure, not a business condition. "User has no org" returns null
-  // without throwing — that's a valid state we tolerate. A throw,
-  // however, means we don't actually know whether the user has an org;
-  // running the agent with `orgId = null` would short-circuit
-  // `checkApprovalRequired` and bypass rule-matching gates. Let the
-  // throw propagate to the adapter's outer catch (which logs
-  // `identity_failed` and surfaces the user-safe error). Matches the
-  // interactive path at executeQuery.ts:201–221.
+  // Fail-closed F-55: a thrown `resolveOrgForUser` is infra failure,
+  // not "user has no org" (that returns null). Letting it propagate
+  // keeps the agent from running with orgId=null and short-circuiting
+  // the approval gate.
   const orgId = await resolveOrgForUser(atlasUserId);
 
   const actor = await resolveActor(atlasUserId, orgId);
   if (actor) return actor;
 
-  // Deleted account — refuse rather than silently running the agent
-  // with `actor: null`. The interactive path treats this as a hard
-  // refusal (executeQuery.ts:188); the proactive path matches for
-  // cross-layer consistency. The outer catch converts this into the
-  // user-safe message posted in-thread.
+  // Deleted account — refuse rather than run with no actor.
   throw new Error(
     `Linked atlasUserId ${atlasUserId} did not resolve to an actor (deleted account?)`,
   );

--- a/packages/api/src/lib/proactive/answer-adapter.ts
+++ b/packages/api/src/lib/proactive/answer-adapter.ts
@@ -165,7 +165,7 @@ export function createProactiveAnswerAdapter(
     const askerId = describeAskerId(asker);
 
     // 1. Resolve identity + (unlinked) restricted tool registry ----------
-    let actor: AtlasUser | null;
+    let actor: AtlasUser;
     let toolRegistry: ToolRegistry | undefined;
     try {
       if (atlasUserId) {
@@ -269,11 +269,16 @@ export function createProactiveAnswerAdapter(
     }
 
     // 3. Run the agent inside a synthesized RequestContext --------------
+    // `withRequestContext` binds `requestId` into AsyncLocalStorage so
+    // every `log.X()` call inside `runAgent` (tool dispatch, SQL execution,
+    // token usage) automatically carries the same correlation id as the
+    // adapter's own logs. No need to thread `requestId` through `runAgent`
+    // explicitly.
     try {
       const stream = await withRequestContext(
         {
           requestId,
-          ...(actor ? { user: actor } : {}),
+          user: actor,
           approvalSurface: "slack",
         },
         () =>
@@ -333,35 +338,29 @@ async function resolveLinkedActor(
   atlasUserId: string,
   resolveOrgForUser: (id: string) => Promise<string | null>,
   resolveActor: (id: string, orgId: string | null) => Promise<AtlasUser | null>,
-): Promise<AtlasUser | null> {
-  let orgId: string | null = null;
-  try {
-    orgId = await resolveOrgForUser(atlasUserId);
-  } catch (err) {
-    // Treat as "no org" — `loadActorUser` will still return a usable
-    // actor (without orgId); the agent runs with reduced scope and the
-    // approval gate short-circuits per `botActorUser` semantics.
-    log.warn(
-      { atlasUserId, err: errorMessage(err) },
-      "resolveOrgForUser failed — proceeding with linked actor minus org context",
-    );
-  }
+): Promise<AtlasUser> {
+  // F-55 fail-closed: a thrown `resolveOrgForUser` is a DB/infra
+  // failure, not a business condition. "User has no org" returns null
+  // without throwing — that's a valid state we tolerate. A throw,
+  // however, means we don't actually know whether the user has an org;
+  // running the agent with `orgId = null` would short-circuit
+  // `checkApprovalRequired` and bypass rule-matching gates. Let the
+  // throw propagate to the adapter's outer catch (which logs
+  // `identity_failed` and surfaces the user-safe error). Matches the
+  // interactive path at executeQuery.ts:201–221.
+  const orgId = await resolveOrgForUser(atlasUserId);
 
   const actor = await resolveActor(atlasUserId, orgId);
   if (actor) return actor;
 
-  // User row missing (deleted account) — fall back to a null actor so
-  // the agent run gets no `user` on RequestContext and downstream
-  // RLS / org-scoped overlays neutralize. The unlinked-asker branch
-  // in the caller installs the public-dataset tool gate; this branch
-  // (a deleted LINKED account) is rare and the safer behavior is to
-  // refuse rather than silently degrade — but degrading-without-org
-  // is the legacy shape and tests pin it, so keep it for now.
-  log.warn(
-    { atlasUserId, orgId },
-    "Linked atlasUserId did not resolve to an actor — degrading to anonymous identity",
+  // Deleted account — refuse rather than silently running the agent
+  // with `actor: null`. The interactive path treats this as a hard
+  // refusal (executeQuery.ts:188); the proactive path matches for
+  // cross-layer consistency. The outer catch converts this into the
+  // user-safe message posted in-thread.
+  throw new Error(
+    `Linked atlasUserId ${atlasUserId} did not resolve to an actor (deleted account?)`,
   );
-  return null;
 }
 
 /**

--- a/packages/api/src/lib/proactive/answer-meter.ts
+++ b/packages/api/src/lib/proactive/answer-meter.ts
@@ -28,6 +28,9 @@ import {
   internalQuery,
 } from "@atlas/api/lib/db/internal";
 import { createLogger } from "@atlas/api/lib/logger";
+import { logAdminAction } from "@atlas/api/lib/audit/admin";
+import { ADMIN_ACTIONS } from "@atlas/api/lib/audit/actions";
+import type { AdminActionType } from "@atlas/api/lib/audit/actions";
 import type {
   ProactiveMeterEventType as ProactiveEventType,
   ProactiveMeterOutcome as ProactiveOutcome,
@@ -225,11 +228,75 @@ ORDER BY created_at DESC`;
 // ---------------------------------------------------------------------------
 
 /**
+ * Map a meter event type to its sibling `ADMIN_ACTIONS.proactive.*`
+ * audit action. Only the lifecycle stages with a forensic counterpart
+ * (`classify` / `react` / `answer` / `feedback`) emit an audit row;
+ * `offer` and `public_refused` aggregate into the meter only because
+ * they don't have a corresponding admin action constant.
+ *
+ * The `accept` event maps to `proactive.answer` — the user accepting
+ * the offer is the moment an answer was actually delivered, which is
+ * what the audit story describes (vs `offer` which is "we presented a
+ * tracer 🤖"). Matches the AC in #2610 / #2631.
+ */
+function adminActionForEvent(
+  eventType: ProactiveEventType,
+): AdminActionType | null {
+  switch (eventType) {
+    case "classify":
+      return ADMIN_ACTIONS.proactive.classify;
+    case "react":
+      return ADMIN_ACTIONS.proactive.react;
+    case "accept":
+      return ADMIN_ACTIONS.proactive.answer;
+    case "feedback":
+      return ADMIN_ACTIONS.proactive.feedback;
+    case "offer":
+    case "public_refused":
+      return null;
+  }
+}
+
+/**
  * Real implementation backing the AnswerMeter service. Exported so the
  * plugin host (which lives outside Effect) can wire the meter callback
  * to the database without booting a full Effect runtime.
+ *
+ * Dual-write: every meter row that has a sibling `proactive.*` admin
+ * action also emits a `logAdminAction` row so the forensic trail and
+ * the analytics rollup stay in lockstep. Closes #2631 (AC drift —
+ * meter rows were landing but `admin_action_log proactive.*` was
+ * empty, so `/admin/proactive-chat` analytics that join on the audit
+ * table came up empty).
  */
 export async function recordMeterEvent(event: ProactiveMeterEvent): Promise<void> {
+  // Audit emit is fire-and-forget (logAdminAction never throws) and
+  // intentionally fires BEFORE the meter insert. If the meter retry
+  // path drops the row we still want a forensic trace that the event
+  // happened — admin_action_log is the source of truth for "did this
+  // happen?" while proactive_meter_events is "what did it cost?".
+  const adminAction = adminActionForEvent(event.eventType);
+  if (adminAction) {
+    logAdminAction({
+      actionType: adminAction,
+      targetType: "proactive",
+      // Use channelId so admins filtering by channel see the row land
+      // on the channel they care about; message_id is too noisy.
+      targetId: event.channelId,
+      scope: "workspace",
+      systemActor: "system:proactive-meter",
+      metadata: {
+        workspaceId: event.workspaceId,
+        channelId: event.channelId,
+        ...(event.messageId ? { messageId: event.messageId } : {}),
+        ...(event.outcome ? { outcome: event.outcome } : {}),
+        ...(event.confidence != null ? { confidence: event.confidence } : {}),
+        ...(event.actorUserId ? { actorUserId: event.actorUserId } : {}),
+        ...(event.metadata ?? {}),
+      },
+    });
+  }
+
   if (!hasInternalDB()) {
     log.debug(
       { eventType: event.eventType, workspaceId: event.workspaceId },

--- a/packages/api/src/lib/proactive/answer-meter.ts
+++ b/packages/api/src/lib/proactive/answer-meter.ts
@@ -229,15 +229,9 @@ ORDER BY created_at DESC`;
 
 /**
  * Map a meter event type to its sibling `ADMIN_ACTIONS.proactive.*`
- * audit action. Only the lifecycle stages with a forensic counterpart
- * (`classify` / `react` / `answer` / `feedback`) emit an audit row;
- * `offer` and `public_refused` aggregate into the meter only because
- * they don't have a corresponding admin action constant.
- *
- * The `accept` event maps to `proactive.answer` — the user accepting
- * the offer is the moment an answer was actually delivered, which is
- * what the audit story describes (vs `offer` which is "we presented a
- * tracer 🤖"). Matches the AC in #2610 / #2631.
+ * audit action. `accept` maps to `proactive.answer` (the moment the
+ * answer was delivered). `offer` / `public_refused` aggregate into
+ * the meter only — no audit emit.
  */
 function adminActionForEvent(
   eventType: ProactiveEventType,
@@ -254,7 +248,46 @@ function adminActionForEvent(
     case "offer":
     case "public_refused":
       return null;
+    default: {
+      // Compile-time exhaustiveness — a future event type added to
+      // ProactiveEventType breaks the build here instead of silently
+      // returning `undefined` from this function.
+      const _exhaustive: never = eventType;
+      return _exhaustive;
+    }
   }
+}
+
+/**
+ * Emit the forensic audit row for a meter event. Fire-and-forget
+ * (`logAdminAction` is documented as never-throws). Skips events that
+ * have no sibling admin action.
+ *
+ * Ordering invariant: emit BEFORE the meter insert. If the meter retry
+ * path drops the row, pino still captures the audit line — the table
+ * itself is best-effort but the log floor survives.
+ */
+function emitMeterAudit(event: ProactiveMeterEvent): void {
+  const adminAction = adminActionForEvent(event.eventType);
+  if (!adminAction) return;
+  logAdminAction({
+    actionType: adminAction,
+    targetType: "proactive",
+    // channelId so admins filtering by channel see the row on the
+    // channel they care about; message_id is too noisy.
+    targetId: event.channelId,
+    scope: "workspace",
+    systemActor: "system:proactive-meter",
+    metadata: {
+      workspaceId: event.workspaceId,
+      channelId: event.channelId,
+      ...(event.messageId ? { messageId: event.messageId } : {}),
+      ...(event.outcome ? { outcome: event.outcome } : {}),
+      ...(event.confidence != null ? { confidence: event.confidence } : {}),
+      ...(event.actorUserId ? { actorUserId: event.actorUserId } : {}),
+      ...(event.metadata ?? {}),
+    },
+  });
 }
 
 /**
@@ -262,40 +295,12 @@ function adminActionForEvent(
  * plugin host (which lives outside Effect) can wire the meter callback
  * to the database without booting a full Effect runtime.
  *
- * Dual-write: every meter row that has a sibling `proactive.*` admin
- * action also emits a `logAdminAction` row so the forensic trail and
- * the analytics rollup stay in lockstep. Closes #2631 (AC drift —
- * meter rows were landing but `admin_action_log proactive.*` was
- * empty, so `/admin/proactive-chat` analytics that join on the audit
- * table came up empty).
+ * Dual-write: every meter row whose event type has a sibling
+ * `proactive.*` admin action also emits a `logAdminAction` row so the
+ * forensic trail and the analytics rollup stay in lockstep.
  */
 export async function recordMeterEvent(event: ProactiveMeterEvent): Promise<void> {
-  // Audit emit is fire-and-forget (logAdminAction never throws) and
-  // intentionally fires BEFORE the meter insert. If the meter retry
-  // path drops the row we still want a forensic trace that the event
-  // happened — admin_action_log is the source of truth for "did this
-  // happen?" while proactive_meter_events is "what did it cost?".
-  const adminAction = adminActionForEvent(event.eventType);
-  if (adminAction) {
-    logAdminAction({
-      actionType: adminAction,
-      targetType: "proactive",
-      // Use channelId so admins filtering by channel see the row land
-      // on the channel they care about; message_id is too noisy.
-      targetId: event.channelId,
-      scope: "workspace",
-      systemActor: "system:proactive-meter",
-      metadata: {
-        workspaceId: event.workspaceId,
-        channelId: event.channelId,
-        ...(event.messageId ? { messageId: event.messageId } : {}),
-        ...(event.outcome ? { outcome: event.outcome } : {}),
-        ...(event.confidence != null ? { confidence: event.confidence } : {}),
-        ...(event.actorUserId ? { actorUserId: event.actorUserId } : {}),
-        ...(event.metadata ?? {}),
-      },
-    });
-  }
+  emitMeterAudit(event);
 
   if (!hasInternalDB()) {
     log.debug(

--- a/plugins/chat/src/bridge.test.ts
+++ b/plugins/chat/src/bridge.test.ts
@@ -547,6 +547,70 @@ describe("chatPlugin config validation", () => {
     ).toThrow(/botToken/i);
   });
 
+  it("rejects slack adapter with the SaaS placeholder botToken (non-xox* prefix)", async () => {
+    // Pins the regex hardening: the production "saas-multi-tenant-unused"
+    // placeholder put the adapter in single-workspace mode and was sent
+    // as the literal Slack API bearer. Schema must refuse it at boot.
+    const { chatPlugin } = await import("./index");
+    const make = () =>
+      chatPlugin({
+        adapters: {
+          slack: {
+            botToken: "saas-multi-tenant-unused",
+            signingSecret: "abcdef0123456789abcdef0123456789",
+          },
+        },
+        executeQuery: async () => ({
+          answer: "",
+          sql: [],
+          data: [],
+          steps: 0,
+          usage: { totalTokens: 0 },
+        }),
+      });
+    expect(make).toThrow(/xox/);
+  });
+
+  it("rejects slack adapter with a non-hex signingSecret (catches missing-env-var placeholder)", async () => {
+    const { chatPlugin } = await import("./index");
+    const make = () =>
+      chatPlugin({
+        adapters: {
+          slack: {
+            botToken: "xoxb-real",
+            signingSecret: "saas-multi-tenant-unused",
+          },
+        },
+        executeQuery: async () => ({
+          answer: "",
+          sql: [],
+          data: [],
+          steps: 0,
+          usage: { totalTokens: 0 },
+        }),
+      });
+    expect(make).toThrow(/signingSecret/);
+  });
+
+  it("accepts slack adapter with no botToken (multi-workspace mode)", async () => {
+    // Multi-workspace deploys omit botToken so the adapter resolves
+    // per-event tokens from its installation store.
+    const { chatPlugin } = await import("./index");
+    const plugin = chatPlugin({
+      adapters: {
+        slack: { signingSecret: "abcdef0123456789abcdef0123456789" },
+      },
+      executeQuery: async () => ({
+        answer: "",
+        sql: [],
+        data: [],
+        steps: 0,
+        usage: { totalTokens: 0 },
+      }),
+    });
+    expect(plugin.id).toBe("chat-interaction");
+  });
+
   it("accepts valid config with slack adapter", async () => {
     const { chatPlugin } = await import("./index");
 

--- a/plugins/chat/src/bridge.test.ts
+++ b/plugins/chat/src/bridge.test.ts
@@ -521,7 +521,7 @@ describe("chatPlugin config validation", () => {
     expect(() =>
       chatPlugin({
         adapters: {
-          slack: { botToken: "xoxb-test", signingSecret: "test-secret" },
+          slack: { botToken: "xoxb-test", signingSecret: "abcdef0123456789abcdef0123456789" },
         },
         executeQuery: "not a function" as never,
       }),
@@ -534,7 +534,7 @@ describe("chatPlugin config validation", () => {
     expect(() =>
       chatPlugin({
         adapters: {
-          slack: { botToken: "", signingSecret: "test-secret" },
+          slack: { botToken: "", signingSecret: "abcdef0123456789abcdef0123456789" },
         },
         executeQuery: async () => ({
           answer: "",
@@ -552,7 +552,7 @@ describe("chatPlugin config validation", () => {
 
     const plugin = chatPlugin({
       adapters: {
-        slack: { botToken: "xoxb-test-token", signingSecret: "test-signing-secret" },
+        slack: { botToken: "xoxb-test-token", signingSecret: "abcdef0123456789abcdef0123456789" },
       },
       executeQuery: async () => ({
         answer: "test",
@@ -574,7 +574,7 @@ describe("chatPlugin config validation", () => {
 
     const plugin = chatPlugin({
       adapters: {
-        slack: { botToken: "xoxb-test-token", signingSecret: "test-signing-secret" },
+        slack: { botToken: "xoxb-test-token", signingSecret: "abcdef0123456789abcdef0123456789" },
       },
       executeQuery: async () => ({
         answer: "test",
@@ -598,7 +598,7 @@ describe("chatPlugin config validation", () => {
 
     const plugin = chatPlugin({
       adapters: {
-        slack: { botToken: "xoxb-test-token", signingSecret: "test-signing-secret" },
+        slack: { botToken: "xoxb-test-token", signingSecret: "abcdef0123456789abcdef0123456789" },
       },
       executeQuery: async () => ({
         answer: "test",
@@ -625,7 +625,7 @@ describe("chatPlugin config validation", () => {
       adapters: {
         slack: {
           botToken: "xoxb-test-token",
-          signingSecret: "test-signing-secret",
+          signingSecret: "abcdef0123456789abcdef0123456789",
           clientId: "test-client-id",
           clientSecret: "test-client-secret",
         },
@@ -648,7 +648,7 @@ describe("chatPlugin config validation", () => {
     expect(() =>
       chatPlugin({
         adapters: {
-          slack: { botToken: "xoxb-test-token", signingSecret: "test-signing-secret" },
+          slack: { botToken: "xoxb-test-token", signingSecret: "abcdef0123456789abcdef0123456789" },
         },
         executeQuery: async () => ({
           answer: "test",
@@ -668,7 +668,7 @@ describe("chatPlugin config validation", () => {
     expect(() =>
       chatPlugin({
         adapters: {
-          slack: { botToken: "xoxb-test-token", signingSecret: "test-signing-secret" },
+          slack: { botToken: "xoxb-test-token", signingSecret: "abcdef0123456789abcdef0123456789" },
         },
         executeQuery: async () => ({
           answer: "test",
@@ -694,7 +694,7 @@ describe("chatPlugin config validation", () => {
         adapters: {
           slack: {
             botToken: "xoxb-test-token",
-            signingSecret: "test-signing-secret",
+            signingSecret: "abcdef0123456789abcdef0123456789",
             clientId: "test-client-id",
             // missing clientSecret
           },
@@ -721,7 +721,7 @@ describe("chat plugin lifecycle", () => {
     const { buildChatPlugin } = require("./index");
     return buildChatPlugin({
       adapters: {
-        slack: { botToken: "xoxb-test-token", signingSecret: "test-signing-secret" },
+        slack: { botToken: "xoxb-test-token", signingSecret: "abcdef0123456789abcdef0123456789" },
       },
       executeQuery: async () => ({
         answer: "test answer",
@@ -844,7 +844,7 @@ describe("chatPlugin state config validation", () => {
 
     const plugin = chatPlugin({
       adapters: {
-        slack: { botToken: "xoxb-test-token", signingSecret: "test-signing-secret" },
+        slack: { botToken: "xoxb-test-token", signingSecret: "abcdef0123456789abcdef0123456789" },
       },
       state: { backend: "memory" },
       executeQuery: async () => ({
@@ -864,7 +864,7 @@ describe("chatPlugin state config validation", () => {
 
     const plugin = chatPlugin({
       adapters: {
-        slack: { botToken: "xoxb-test-token", signingSecret: "test-signing-secret" },
+        slack: { botToken: "xoxb-test-token", signingSecret: "abcdef0123456789abcdef0123456789" },
       },
       executeQuery: async () => ({
         answer: "test",
@@ -883,7 +883,7 @@ describe("chatPlugin state config validation", () => {
 
     const plugin = chatPlugin({
       adapters: {
-        slack: { botToken: "xoxb-test-token", signingSecret: "test-signing-secret" },
+        slack: { botToken: "xoxb-test-token", signingSecret: "abcdef0123456789abcdef0123456789" },
       },
       state: { backend: "pg", tablePrefix: "myapp_" },
       executeQuery: async () => ({
@@ -949,7 +949,7 @@ describe("chatPlugin Teams adapter config", () => {
 
     const plugin = chatPlugin({
       adapters: {
-        slack: { botToken: "xoxb-test-token", signingSecret: "test-signing-secret" },
+        slack: { botToken: "xoxb-test-token", signingSecret: "abcdef0123456789abcdef0123456789" },
         teams: { appId: "test-app-id", appPassword: "test-app-password" },
       },
       executeQuery: mockExecuteQuery,
@@ -1076,7 +1076,7 @@ describe("webhook route guards", () => {
 
     const plugin = buildChatPlugin({
       adapters: {
-        slack: { botToken: "xoxb-test-token", signingSecret: "test-signing-secret" },
+        slack: { botToken: "xoxb-test-token", signingSecret: "abcdef0123456789abcdef0123456789" },
       },
       executeQuery: async () => ({
         answer: "test",
@@ -1188,7 +1188,7 @@ describe("chat plugin multi-adapter lifecycle", () => {
     const { buildChatPlugin } = require("./index");
     return buildChatPlugin({
       adapters: {
-        slack: { botToken: "xoxb-test-token", signingSecret: "test-signing-secret" },
+        slack: { botToken: "xoxb-test-token", signingSecret: "abcdef0123456789abcdef0123456789" },
         teams: { appId: "test-app-id", appPassword: "test-app-password" },
       },
       executeQuery: async () => ({
@@ -1280,7 +1280,7 @@ describe("chatPlugin Discord adapter config", () => {
 
     const plugin = chatPlugin({
       adapters: {
-        slack: { botToken: "xoxb-test-token", signingSecret: "test-signing-secret" },
+        slack: { botToken: "xoxb-test-token", signingSecret: "abcdef0123456789abcdef0123456789" },
         teams: { appId: "test-app-id", appPassword: "test-app-password" },
         discord: {
           botToken: "test-bot-token",
@@ -1514,7 +1514,7 @@ describe("chat plugin three-adapter lifecycle", () => {
     const { buildChatPlugin } = require("./index");
     return buildChatPlugin({
       adapters: {
-        slack: { botToken: "xoxb-test-token", signingSecret: "test-signing-secret" },
+        slack: { botToken: "xoxb-test-token", signingSecret: "abcdef0123456789abcdef0123456789" },
         teams: { appId: "test-app-id", appPassword: "test-app-password" },
         discord: {
           botToken: "test-bot-token",
@@ -1744,7 +1744,7 @@ describe("chatPlugin Google Chat adapter config", () => {
 
     const plugin = chatPlugin({
       adapters: {
-        slack: { botToken: "xoxb-test-token", signingSecret: "test-signing-secret" },
+        slack: { botToken: "xoxb-test-token", signingSecret: "abcdef0123456789abcdef0123456789" },
         teams: { appId: "test-app-id", appPassword: "test-app-password" },
         discord: {
           botToken: "test-bot-token",
@@ -2103,7 +2103,7 @@ describe("chat plugin five-adapter lifecycle", () => {
     const { buildChatPlugin } = require("./index");
     return buildChatPlugin({
       adapters: {
-        slack: { botToken: "xoxb-test-token", signingSecret: "test-signing-secret" },
+        slack: { botToken: "xoxb-test-token", signingSecret: "abcdef0123456789abcdef0123456789" },
         teams: { appId: "test-app-id", appPassword: "test-app-password" },
         discord: {
           botToken: "test-bot-token",
@@ -2182,7 +2182,7 @@ describe("chatPlugin streaming config", () => {
 
     const plugin = chatPlugin({
       adapters: {
-        slack: { botToken: "xoxb-test-token", signingSecret: "test-signing-secret" },
+        slack: { botToken: "xoxb-test-token", signingSecret: "abcdef0123456789abcdef0123456789" },
       },
       executeQuery: mockExecuteQueryFn,
       streaming: { enabled: true, chunkIntervalMs: 500 },
@@ -2197,7 +2197,7 @@ describe("chatPlugin streaming config", () => {
 
     const plugin = chatPlugin({
       adapters: {
-        slack: { botToken: "xoxb-test-token", signingSecret: "test-signing-secret" },
+        slack: { botToken: "xoxb-test-token", signingSecret: "abcdef0123456789abcdef0123456789" },
       },
       executeQuery: mockExecuteQueryFn,
       streaming: { enabled: false },
@@ -2211,7 +2211,7 @@ describe("chatPlugin streaming config", () => {
 
     const plugin = chatPlugin({
       adapters: {
-        slack: { botToken: "xoxb-test-token", signingSecret: "test-signing-secret" },
+        slack: { botToken: "xoxb-test-token", signingSecret: "abcdef0123456789abcdef0123456789" },
       },
       executeQuery: mockExecuteQueryFn,
       executeQueryStream: mockExecuteQueryStreamFn,
@@ -2225,7 +2225,7 @@ describe("chatPlugin streaming config", () => {
 
     const plugin = chatPlugin({
       adapters: {
-        slack: { botToken: "xoxb-test-token", signingSecret: "test-signing-secret" },
+        slack: { botToken: "xoxb-test-token", signingSecret: "abcdef0123456789abcdef0123456789" },
       },
       executeQuery: mockExecuteQueryFn,
       streaming: { chunkIntervalMs: 2000 },
@@ -2240,7 +2240,7 @@ describe("chatPlugin streaming config", () => {
     expect(() =>
       chatPlugin({
         adapters: {
-          slack: { botToken: "xoxb-test-token", signingSecret: "test-signing-secret" },
+          slack: { botToken: "xoxb-test-token", signingSecret: "abcdef0123456789abcdef0123456789" },
         },
         executeQuery: mockExecuteQueryFn,
         streaming: { chunkIntervalMs: 50 },
@@ -2254,7 +2254,7 @@ describe("chatPlugin streaming config", () => {
     expect(() =>
       chatPlugin({
         adapters: {
-          slack: { botToken: "xoxb-test-token", signingSecret: "test-signing-secret" },
+          slack: { botToken: "xoxb-test-token", signingSecret: "abcdef0123456789abcdef0123456789" },
         },
         executeQuery: mockExecuteQueryFn,
         streaming: { chunkIntervalMs: 20000 },
@@ -2268,7 +2268,7 @@ describe("chatPlugin streaming config", () => {
     expect(() =>
       chatPlugin({
         adapters: {
-          slack: { botToken: "xoxb-test-token", signingSecret: "test-signing-secret" },
+          slack: { botToken: "xoxb-test-token", signingSecret: "abcdef0123456789abcdef0123456789" },
         },
         executeQuery: mockExecuteQueryFn,
         executeQueryStream: "not a function" as never,
@@ -2282,7 +2282,7 @@ describe("chatPlugin streaming config", () => {
     expect(() =>
       chatPlugin({
         adapters: {
-          slack: { botToken: "xoxb-test-token", signingSecret: "test-signing-secret" },
+          slack: { botToken: "xoxb-test-token", signingSecret: "abcdef0123456789abcdef0123456789" },
         },
         executeQuery: mockExecuteQueryFn,
         streaming: { enabled: true },
@@ -2296,7 +2296,7 @@ describe("chatPlugin streaming config", () => {
 
     const plugin = chatPlugin({
       adapters: {
-        slack: { botToken: "xoxb-test-token", signingSecret: "test-signing-secret" },
+        slack: { botToken: "xoxb-test-token", signingSecret: "abcdef0123456789abcdef0123456789" },
       },
       executeQuery: mockExecuteQueryFn,
       streaming: { enabled: true },
@@ -2316,7 +2316,7 @@ describe("chat plugin streaming lifecycle", () => {
     const { buildChatPlugin } = require("./index");
     return buildChatPlugin({
       adapters: {
-        slack: { botToken: "xoxb-test-token", signingSecret: "test-signing-secret" },
+        slack: { botToken: "xoxb-test-token", signingSecret: "abcdef0123456789abcdef0123456789" },
       },
       executeQuery: async () => ({
         answer: "test answer",
@@ -2382,7 +2382,7 @@ describe("chat plugin streaming lifecycle", () => {
     const { buildChatPlugin } = require("./index");
     const plugin = buildChatPlugin({
       adapters: {
-        slack: { botToken: "xoxb-test-token", signingSecret: "test-signing-secret" },
+        slack: { botToken: "xoxb-test-token", signingSecret: "abcdef0123456789abcdef0123456789" },
       },
       executeQuery: async () => ({
         answer: "test",
@@ -2411,7 +2411,7 @@ describe("chat plugin streaming lifecycle", () => {
     const { buildChatPlugin } = require("./index");
     const plugin = buildChatPlugin({
       adapters: {
-        slack: { botToken: "xoxb-test-token", signingSecret: "test-signing-secret" },
+        slack: { botToken: "xoxb-test-token", signingSecret: "abcdef0123456789abcdef0123456789" },
       },
       executeQuery: async () => ({
         answer: "test",
@@ -2454,7 +2454,7 @@ describe("chatPlugin slashCommandName config", () => {
 
     const plugin = chatPlugin({
       adapters: {
-        slack: { botToken: "xoxb-test-token", signingSecret: "test-signing-secret" },
+        slack: { botToken: "xoxb-test-token", signingSecret: "abcdef0123456789abcdef0123456789" },
       },
       slashCommandName: "/data-query",
       executeQuery: mockExecuteQuery,
@@ -2468,7 +2468,7 @@ describe("chatPlugin slashCommandName config", () => {
 
     const plugin = chatPlugin({
       adapters: {
-        slack: { botToken: "xoxb-test-token", signingSecret: "test-signing-secret" },
+        slack: { botToken: "xoxb-test-token", signingSecret: "abcdef0123456789abcdef0123456789" },
       },
       slashCommandName: "/query",
       executeQuery: mockExecuteQuery,
@@ -2483,7 +2483,7 @@ describe("chatPlugin slashCommandName config", () => {
     expect(() =>
       chatPlugin({
         adapters: {
-          slack: { botToken: "xoxb-test-token", signingSecret: "test-signing-secret" },
+          slack: { botToken: "xoxb-test-token", signingSecret: "abcdef0123456789abcdef0123456789" },
         },
         slashCommandName: "atlas",
         executeQuery: mockExecuteQuery,
@@ -2497,7 +2497,7 @@ describe("chatPlugin slashCommandName config", () => {
     expect(() =>
       chatPlugin({
         adapters: {
-          slack: { botToken: "xoxb-test-token", signingSecret: "test-signing-secret" },
+          slack: { botToken: "xoxb-test-token", signingSecret: "abcdef0123456789abcdef0123456789" },
         },
         slashCommandName: "/Atlas",
         executeQuery: mockExecuteQuery,
@@ -2511,7 +2511,7 @@ describe("chatPlugin slashCommandName config", () => {
     expect(() =>
       chatPlugin({
         adapters: {
-          slack: { botToken: "xoxb-test-token", signingSecret: "test-signing-secret" },
+          slack: { botToken: "xoxb-test-token", signingSecret: "abcdef0123456789abcdef0123456789" },
         },
         slashCommandName: "/my command",
         executeQuery: mockExecuteQuery,
@@ -2524,7 +2524,7 @@ describe("chatPlugin slashCommandName config", () => {
 
     const plugin = chatPlugin({
       adapters: {
-        slack: { botToken: "xoxb-test-token", signingSecret: "test-signing-secret" },
+        slack: { botToken: "xoxb-test-token", signingSecret: "abcdef0123456789abcdef0123456789" },
       },
       executeQuery: mockExecuteQuery,
     });
@@ -3183,7 +3183,7 @@ describe("ephemeral error delivery", () => {
     // Default config: errorsAsEphemeral should be undefined (defaults to true)
     const result = ChatConfigSchema.safeParse({
       adapters: {
-        slack: { botToken: "xoxb-test", signingSecret: "test-secret" },
+        slack: { botToken: "xoxb-test", signingSecret: "abcdef0123456789abcdef0123456789" },
       },
       executeQuery: () => Promise.resolve({ answer: "", sql: [], data: [], steps: 0, usage: { totalTokens: 0 } }),
     });
@@ -3200,7 +3200,7 @@ describe("ephemeral error delivery", () => {
 
     const result = ChatConfigSchema.safeParse({
       adapters: {
-        slack: { botToken: "xoxb-test", signingSecret: "test-secret" },
+        slack: { botToken: "xoxb-test", signingSecret: "abcdef0123456789abcdef0123456789" },
       },
       executeQuery: () => Promise.resolve({ answer: "", sql: [], data: [], steps: 0, usage: { totalTokens: 0 } }),
       ephemeral: { errorsAsEphemeral: false },
@@ -3241,7 +3241,7 @@ describe("ProactiveConfig schema", () => {
 
     const result = ChatConfigSchema.safeParse({
       adapters: {
-        slack: { botToken: "xoxb-test", signingSecret: "test-secret" },
+        slack: { botToken: "xoxb-test", signingSecret: "abcdef0123456789abcdef0123456789" },
       },
       executeQuery: () =>
         Promise.resolve({ answer: "", sql: [], data: [], steps: 0, usage: { totalTokens: 0 } }),
@@ -3266,7 +3266,7 @@ describe("ProactiveConfig schema", () => {
 
     const result = ChatConfigSchema.safeParse({
       adapters: {
-        slack: { botToken: "xoxb-test", signingSecret: "test-secret" },
+        slack: { botToken: "xoxb-test", signingSecret: "abcdef0123456789abcdef0123456789" },
       },
       executeQuery: () =>
         Promise.resolve({ answer: "", sql: [], data: [], steps: 0, usage: { totalTokens: 0 } }),
@@ -3291,7 +3291,7 @@ describe("ProactiveConfig schema", () => {
 
     const result = ChatConfigSchema.safeParse({
       adapters: {
-        slack: { botToken: "xoxb-test", signingSecret: "test-secret" },
+        slack: { botToken: "xoxb-test", signingSecret: "abcdef0123456789abcdef0123456789" },
       },
       executeQuery: () =>
         Promise.resolve({ answer: "", sql: [], data: [], steps: 0, usage: { totalTokens: 0 } }),
@@ -3531,7 +3531,7 @@ describe("executeQuery context contract", () => {
     const calls: Array<{ adapterName: string; rawTeamId: unknown }> = [];
     const plugin = chatPlugin({
       adapters: {
-        slack: { botToken: "xoxb-test-token", signingSecret: "test-signing-secret" },
+        slack: { botToken: "xoxb-test-token", signingSecret: "abcdef0123456789abcdef0123456789" },
       },
       executeQuery: async (question, ctx) => {
         const raw = ctx.rawMessage as { team_id?: string } | undefined;

--- a/plugins/chat/src/bridge.ts
+++ b/plugins/chat/src/bridge.ts
@@ -979,36 +979,72 @@ export function createChatBridge(
 
   // --- onSlashCommand: /<configurable> <question> ---
   const commandName = config.slashCommandName ?? "/atlas";
+
+  /**
+   * Refuse a feedback subcommand with an ephemeral hint. Shared by every
+   * branch that can't deliver feedback — buffer unset, tenant unresolved,
+   * resolver throw — so the explicit `feedback` prefix can never silently
+   * fall through to the SQL question flow.
+   */
+  async function refuseFeedbackSubcommand(
+    event: Parameters<Parameters<typeof chat.onSlashCommand>[1]>[0],
+  ): Promise<void> {
+    try {
+      await event.channel.postEphemeral(
+        event.user,
+        {
+          markdown:
+            "Sorry — Atlas couldn't route your feedback right now. Please try again in a moment.",
+        },
+        { fallbackToDM: true },
+      );
+    } catch (ephErr) {
+      // This is the only path where the refuse-and-tell-user contract
+      // can silently fail. Log at error so on-call sees a feedback
+      // subcommand that never received any response.
+      log.error(
+        {
+          err: ephErr instanceof Error ? ephErr : new Error(String(ephErr)),
+          channelId: event.channel.id,
+          userId: event.user.userId,
+        },
+        "Proactive feedback slash refusal-ephemeral failed — user received no feedback",
+      );
+    }
+  }
+
   chat.onSlashCommand(commandName, async (event) => {
-    // Slice #2298: `/atlas feedback <text>` routes to the proactive
-    // feedback collector before falling through to the question flow.
-    //
-    // Fail-closed on feedback subcommand: if the user explicitly typed
-    // `/atlas feedback <text>` we must NEVER fall through to the
-    // question flow when tenant resolution fails — that would treat
-    // "the chart was wrong" as a SQL question (#2623 item 3). The
-    // ambiguous-question path (no `feedback` prefix) still falls
-    // through because there is nothing else to do with the text.
+    // The explicit `feedback` subcommand must NEVER fall through to the
+    // SQL question flow. Treating "the chart was wrong" as a query is
+    // strictly worse than refusing. Detect the prefix up front so every
+    // failure mode below (buffer unset, tenant unresolved, resolver
+    // throw) shares the same refuse-with-ephemeral exit.
     const isFeedbackSubcommand =
       config.proactive !== undefined &&
       parseFeedbackSlashArgs(event.text).kind === "feedback";
+
+    // Top-level guard: feedback subcommand without the recent-answers
+    // buffer can't be routed (handleProactiveFeedbackSlash requires it).
+    // Refuse rather than fall through.
+    if (isFeedbackSubcommand && !proactiveRecentAnswers) {
+      log.warn(
+        { channelId: event.channel.id },
+        "Proactive feedback slash: recent-answers buffer not initialized — refusing",
+      );
+      await refuseFeedbackSubcommand(event);
+      return;
+    }
+
     if (config.proactive && proactiveRecentAnswers) {
       try {
-        // Post-#2620 multi-tenant: resolve the workspace for this slash
-        // event before delegating. The slash event doesn't carry the
-        // same Message shape onNewMessage does — we synthesize a
-        // minimal shape from the adapter + raw payload, which is what
-        // the Slack-platform resolver uses anyway (`raw.team_id`).
+        // Synthesize a minimal Message shape from adapter + raw payload
+        // so the Slack-platform resolver can read `raw.team_id`.
         const resolveAdapter = event.adapter;
         let slashWorkspaceId: string | null = null;
         if (resolveAdapter) {
           try {
             slashWorkspaceId = await config.proactive.resolveWorkspaceId({
               adapter: resolveAdapter,
-              // Slash events have no thread; the resolver only reads
-              // `adapter.name` + `message.raw`, so a null-ish thread is
-              // fine. Cast for the same reason the action/modal handlers
-              // do — the resolver contract is platform-determined.
               thread: undefined as unknown as Parameters<
                 typeof config.proactive.resolveWorkspaceId
               >[0]["thread"],
@@ -1029,36 +1065,26 @@ export function createChatBridge(
                 isFeedbackSubcommand,
               },
               isFeedbackSubcommand
-                ? "Proactive feedback slash: resolveWorkspaceId threw — refusing (will NOT fall through to question flow)"
+                ? "Proactive feedback slash: resolveWorkspaceId threw — refusing"
                 : "Proactive feedback slash: resolveWorkspaceId threw — falling back to standard question flow",
             );
-            // #2623 item 3 — refuse rather than run feedback text as
-            // a SQL question. The user gets an ephemeral hint; the
-            // question-flow path below is never reached.
             if (isFeedbackSubcommand) {
-              try {
-                await event.channel.postEphemeral(
-                  event.user,
-                  {
-                    markdown:
-                      "Sorry — Atlas couldn't route your feedback right now. Please try again in a moment.",
-                  },
-                  { fallbackToDM: true },
-                );
-              } catch (ephErr) {
-                log.debug(
-                  {
-                    err:
-                      ephErr instanceof Error
-                        ? ephErr
-                        : new Error(String(ephErr)),
-                  },
-                  "Proactive feedback slash refusal-ephemeral failed",
-                );
-              }
+              await refuseFeedbackSubcommand(event);
               return;
             }
           }
+        }
+
+        // Tenant resolution returned null on a feedback subcommand —
+        // can't route the feedback to a workspace. Refuse instead of
+        // letting it leak into the question flow.
+        if (isFeedbackSubcommand && !slashWorkspaceId) {
+          log.warn(
+            { channelId: event.channel.id },
+            "Proactive feedback slash: workspace unresolved — refusing",
+          );
+          await refuseFeedbackSubcommand(event);
+          return;
         }
 
         if (slashWorkspaceId) {

--- a/plugins/chat/src/bridge.ts
+++ b/plugins/chat/src/bridge.ts
@@ -49,6 +49,7 @@ import { createReactionLifecycle } from "./features/reactions";
 import type { IReactionLifecycle } from "./features/reactions";
 import { handleProactiveFeedbackSlash, registerProactiveListener } from "./proactive/listener";
 import type { RecentAnswers } from "./proactive/feedback";
+import { parseFeedbackSlashArgs } from "./proactive/feedback";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -981,6 +982,16 @@ export function createChatBridge(
   chat.onSlashCommand(commandName, async (event) => {
     // Slice #2298: `/atlas feedback <text>` routes to the proactive
     // feedback collector before falling through to the question flow.
+    //
+    // Fail-closed on feedback subcommand: if the user explicitly typed
+    // `/atlas feedback <text>` we must NEVER fall through to the
+    // question flow when tenant resolution fails — that would treat
+    // "the chart was wrong" as a SQL question (#2623 item 3). The
+    // ambiguous-question path (no `feedback` prefix) still falls
+    // through because there is nothing else to do with the text.
+    const isFeedbackSubcommand =
+      config.proactive !== undefined &&
+      parseFeedbackSlashArgs(event.text).kind === "feedback";
     if (config.proactive && proactiveRecentAnswers) {
       try {
         // Post-#2620 multi-tenant: resolve the workspace for this slash
@@ -1015,9 +1026,38 @@ export function createChatBridge(
                   resolveErr instanceof Error
                     ? resolveErr
                     : new Error(String(resolveErr)),
+                isFeedbackSubcommand,
               },
-              "Proactive feedback slash: resolveWorkspaceId threw — falling back to standard question flow",
+              isFeedbackSubcommand
+                ? "Proactive feedback slash: resolveWorkspaceId threw — refusing (will NOT fall through to question flow)"
+                : "Proactive feedback slash: resolveWorkspaceId threw — falling back to standard question flow",
             );
+            // #2623 item 3 — refuse rather than run feedback text as
+            // a SQL question. The user gets an ephemeral hint; the
+            // question-flow path below is never reached.
+            if (isFeedbackSubcommand) {
+              try {
+                await event.channel.postEphemeral(
+                  event.user,
+                  {
+                    markdown:
+                      "Sorry — Atlas couldn't route your feedback right now. Please try again in a moment.",
+                  },
+                  { fallbackToDM: true },
+                );
+              } catch (ephErr) {
+                log.debug(
+                  {
+                    err:
+                      ephErr instanceof Error
+                        ? ephErr
+                        : new Error(String(ephErr)),
+                  },
+                  "Proactive feedback slash refusal-ephemeral failed",
+                );
+              }
+              return;
+            }
           }
         }
 

--- a/plugins/chat/src/config.ts
+++ b/plugins/chat/src/config.ts
@@ -112,13 +112,7 @@ export interface ChatQueryResult {
 
 /** Adapter-specific credential configuration. */
 export interface SlackAdapterConfig {
-  /**
-   * Single-workspace bot token (`xoxb-…` / `xoxe.xoxb-…`). Omit in
-   * multi-workspace deploys so `@chat-adapter/slack` resolves per-event
-   * tokens from its installation store; passing a placeholder string
-   * puts the adapter in single-workspace mode and that string ends up
-   * as the Slack API bearer (rejected with `invalid_auth`).
-   */
+  /** Single-workspace bot token (`xoxb-…`). Omit in multi-workspace deploys. */
   botToken?: string;
   signingSecret: string;
   /** Client ID for multi-workspace OAuth. */
@@ -634,24 +628,16 @@ export interface ProactiveConfig {
 // Zod schema
 // ---------------------------------------------------------------------------
 
-// Slack bot tokens always start with `xox<letter>-` (xoxb- bot, xoxp- user,
-// xoxe.xoxb- rotation-enabled). Reject placeholder strings at the schema
-// boundary so misconfiguration ("saas-multi-tenant-unused") fails fast in
-// CI instead of being sent as a Slack API bearer at runtime.
-const SLACK_TOKEN_REGEX = /^xox[a-z]/i;
-// Slack signing secrets are 32-char lowercase hex. The deploy placeholder
-// "saas-multi-tenant-unused" violates both the length and charset checks;
-// rejecting it here catches missing-env-var misconfig before boot.
-const SLACK_SIGNING_SECRET_REGEX = /^[0-9a-f]{32}$/i;
+// Slack tokens are lowercase `xox<letter>-` (xoxb- bot, xoxp- user, xoxe-
+// rotation-enabled). Case-sensitive so an uppercase-paste regression
+// fails at the schema boundary.
+const SLACK_TOKEN_REGEX = /^xox[a-z]/;
+// Slack signing secrets are 32-char lowercase hex (Slack's actual format).
+const SLACK_SIGNING_SECRET_REGEX = /^[0-9a-f]{32}$/;
 
 const SlackAdapterSchema = z.object({
-  // Optional + regex'd: single-workspace mode uses this bare token for
-  // every outbound call. Multi-workspace deploys MUST omit this field so
-  // `@chat-adapter/slack` resolves per-event tokens from its installation
-  // store (state-adapter `slack:installation:<teamId>`). Any non-`xox*`
-  // string here puts the adapter in single-workspace mode AND ends up as
-  // the bearer token → Slack rejects with `invalid_auth`. Catches the
-  // pre-#2630 SaaS placeholder pattern at boot.
+  // Regex'd so placeholder strings (multi-workspace deploys) fail at
+  // boot rather than at the first Slack API call.
   botToken: z.string().min(1, "slack botToken must not be empty").regex(
     SLACK_TOKEN_REGEX,
     "slack botToken must start with 'xox' (e.g. 'xoxb-…'). Multi-workspace deploys should omit this field instead of supplying a placeholder.",

--- a/plugins/chat/src/config.ts
+++ b/plugins/chat/src/config.ts
@@ -113,9 +113,11 @@ export interface ChatQueryResult {
 /** Adapter-specific credential configuration. */
 export interface SlackAdapterConfig {
   /**
-   * Single-workspace bot token. Omit in multi-workspace deploys so
-   * `@chat-adapter/slack` resolves per-event tokens from its installation
-   * store. Required when `clientId`+`clientSecret` are not set.
+   * Single-workspace bot token (`xoxb-…` / `xoxe.xoxb-…`). Omit in
+   * multi-workspace deploys so `@chat-adapter/slack` resolves per-event
+   * tokens from its installation store; passing a placeholder string
+   * puts the adapter in single-workspace mode and that string ends up
+   * as the Slack API bearer (rejected with `invalid_auth`).
    */
   botToken?: string;
   signingSecret: string;
@@ -632,18 +634,35 @@ export interface ProactiveConfig {
 // Zod schema
 // ---------------------------------------------------------------------------
 
+// Slack bot tokens always start with `xox<letter>-` (xoxb- bot, xoxp- user,
+// xoxe.xoxb- rotation-enabled). Reject placeholder strings at the schema
+// boundary so misconfiguration ("saas-multi-tenant-unused") fails fast in
+// CI instead of being sent as a Slack API bearer at runtime.
+const SLACK_TOKEN_REGEX = /^xox[a-z]/i;
+// Slack signing secrets are 32-char lowercase hex. The deploy placeholder
+// "saas-multi-tenant-unused" violates both the length and charset checks;
+// rejecting it here catches missing-env-var misconfig before boot.
+const SLACK_SIGNING_SECRET_REGEX = /^[0-9a-f]{32}$/i;
+
 const SlackAdapterSchema = z.object({
-  // Optional: required for single-workspace mode (the adapter uses this
-  // bare token for every outbound call). MULTI-WORKSPACE deploys OMIT
-  // this field so `@chat-adapter/slack` resolves per-event tokens from
-  // its installation store (state-adapter `slack:installation:<teamId>`).
-  // A non-empty placeholder here puts the adapter in single-workspace
-  // mode and the placeholder ends up as the bearer token → Slack rejects.
-  botToken: z.string().min(1, "slack botToken must not be empty").optional(),
-  signingSecret: z.string().min(1, "slack signingSecret must not be empty"),
+  // Optional + regex'd: single-workspace mode uses this bare token for
+  // every outbound call. Multi-workspace deploys MUST omit this field so
+  // `@chat-adapter/slack` resolves per-event tokens from its installation
+  // store (state-adapter `slack:installation:<teamId>`). Any non-`xox*`
+  // string here puts the adapter in single-workspace mode AND ends up as
+  // the bearer token → Slack rejects with `invalid_auth`. Catches the
+  // pre-#2630 SaaS placeholder pattern at boot.
+  botToken: z.string().min(1, "slack botToken must not be empty").regex(
+    SLACK_TOKEN_REGEX,
+    "slack botToken must start with 'xox' (e.g. 'xoxb-…'). Multi-workspace deploys should omit this field instead of supplying a placeholder.",
+  ).optional(),
+  signingSecret: z.string().min(1, "slack signingSecret must not be empty").regex(
+    SLACK_SIGNING_SECRET_REGEX,
+    "slack signingSecret must be a 32-character lowercase hex string (from your Slack app's Basic Information page). Placeholder strings are rejected.",
+  ),
   clientId: z.string().min(1).optional(),
   clientSecret: z.string().min(1).optional(),
-}).refine(
+}).strict().refine(
   (s) => (s.clientId == null) === (s.clientSecret == null),
   "clientId and clientSecret must both be provided for OAuth",
 );
@@ -652,14 +671,14 @@ const TeamsAdapterSchema = z.object({
   appId: z.string().min(1, "teams appId must not be empty"),
   appPassword: z.string().min(1, "teams appPassword must not be empty"),
   tenantId: z.string().min(1).optional(),
-});
+}).strict();
 
 const DiscordAdapterSchema = z.object({
   botToken: z.string().min(1, "discord botToken must not be empty"),
   applicationId: z.string().min(1, "discord applicationId must not be empty"),
   publicKey: z.string().regex(/^[0-9a-f]{64}$/i, "discord publicKey must be a 64-character hex string (Ed25519 public key from Discord Developer Portal)"),
   mentionRoleIds: z.array(z.string().min(1)).optional(),
-});
+}).strict();
 
 const TelegramAdapterSchema = z.object({
   botToken: z.string().min(1, "telegram botToken must not be empty").regex(
@@ -667,7 +686,7 @@ const TelegramAdapterSchema = z.object({
     "telegram botToken must be in format '<bot-id>:<secret>' from BotFather",
   ),
   secretToken: z.string().min(1).optional(),
-});
+}).strict();
 
 const GitHubAdapterSchema = z.object({
   token: z.string().min(1, "github token must not be empty").optional(),
@@ -676,7 +695,7 @@ const GitHubAdapterSchema = z.object({
   installationId: z.number().int().positive("github installationId must be a positive integer").optional(),
   webhookSecret: z.string().min(1, "github webhookSecret must not be empty").optional(),
   userName: z.string().min(1, "github userName must not be empty").optional(),
-}).superRefine((c, ctx) => {
+}).strict().superRefine((c, ctx) => {
   if (c.token && c.appId) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
@@ -719,7 +738,7 @@ const LinearAdapterSchema = z.object({
   clientSecret: z.string().min(1, "linear clientSecret must not be empty").optional(),
   webhookSecret: z.string().min(1, "linear webhookSecret must not be empty").optional(),
   userName: z.string().min(1, "linear userName must not be empty").optional(),
-}).superRefine((c, ctx) => {
+}).strict().superRefine((c, ctx) => {
   const modes = [c.apiKey, c.accessToken, c.clientId].filter(Boolean).length;
   if (modes > 1) {
     ctx.addIssue({
@@ -759,7 +778,7 @@ const WhatsAppAdapterSchema = z.object({
     /^v\d+\.\d+$/,
     "whatsapp apiVersion must be in format 'vN.N' (e.g. 'v21.0')",
   ).optional(),
-});
+}).strict();
 
 const GoogleChatAdapterSchema = z.object({
   credentials: z.object({
@@ -774,7 +793,7 @@ const GoogleChatAdapterSchema = z.object({
     "gchat pubsubTopic must be in format 'projects/{project}/topics/{topic}'",
   ).optional(),
   impersonateUser: z.string().email("gchat impersonateUser must be a valid email").optional(),
-}).refine(
+}).strict().refine(
   (c) => !(c.credentials != null && c.useApplicationDefaultCredentials === true),
   "Provide either credentials or useApplicationDefaultCredentials, not both (or omit both for env-var auto-detection)",
 );
@@ -998,7 +1017,7 @@ export const ChatConfigSchema = z.object({
   executeQueryStream: zCallback<NonNullable<ChatPluginConfig["executeQueryStream"]>>(
     "executeQueryStream must be a function",
   ).optional(),
-}).refine(
+}).strict().refine(
   (c) => {
     // Warn if streaming.enabled is explicitly true but executeQueryStream is missing
     if (c.streaming?.enabled === true && typeof c.executeQueryStream !== "function") {

--- a/plugins/chat/src/features/reactions.test.ts
+++ b/plugins/chat/src/features/reactions.test.ts
@@ -315,7 +315,7 @@ describe("ChatConfigSchema reactions field", () => {
   const { ChatConfigSchema } = require("../config");
 
   const baseConfig = {
-    adapters: { slack: { botToken: "xoxb-test", signingSecret: "test-secret" } },
+    adapters: { slack: { botToken: "xoxb-test", signingSecret: "abcdef0123456789abcdef0123456789" } },
     executeQuery: () => Promise.resolve({ answer: "", sql: [], data: [], steps: 0, usage: { totalTokens: 0 } }),
   };
 

--- a/plugins/chat/src/proactive/listener.ts
+++ b/plugins/chat/src/proactive/listener.ts
@@ -608,7 +608,11 @@ export async function registerProactiveListener(
           // bypass without double-counting the underlying `classify`
           // event.
           log.error(
-            { err: err instanceof Error ? err : new Error(String(err)) },
+            {
+              workspaceId,
+              channelId,
+              err: err instanceof Error ? err : new Error(String(err)),
+            },
             "Proactive: quota callback threw — treating as under cap (monthly cap NOT enforced this request)",
           );
           quotaReadFailed = true;


### PR DESCRIPTION
## Summary

Aggregate fixes from the multi-agent review of the proactive listener wiring trail (parent #2607). Subsumes #2630 (botToken optional + drop placeholder) and closes #2631 (admin_action_log dual-write AC drift). Adds #2623 item 3 (slash-command resolver-throw refuse).

**P0 bug fixes**
- `executeQuery.ts:256` — `await createConversation` so DB errors propagate to the surrounding try/catch and successive thread events can't race the conversation row insert.
- `answer-adapter.ts:338-365` — F-55 fail-closed. `resolveOrgForUser` throwing was logged-and-continued with `orgId=null`, short-circuiting `checkApprovalRequired` on the proactive path. Match the interactive path by letting the throw propagate to the adapter's outer catch. Same module: refuse rather than silently run the agent with `actor=null` when `resolveActor` returns null.
- `slack.ts:480-492` — verify Slack signature BEFORE parsing JSON on the legacy events route. Matches the rest of the file's defense-in-depth ordering.

**P1 / Hardening**
- `plugins/chat/src/config.ts` — `.strict()` on `ChatConfigSchema` top-level and every per-adapter schema. `SlackAdapterSchema`: `botToken` optional + regex `^xox[a-z]`; `signingSecret` regex `^[0-9a-f]{32}$`. Both reject the SaaS `"saas-multi-tenant-unused"` placeholder that put `@chat-adapter/slack` into single-workspace mode and broke #2630 in production.
- `deploy/api/atlas.config.ts` — drop the `botToken` placeholder (subsumes #2630) and the `signingSecret` placeholder. `signingSecret` resolves from `SLACK_SIGNING_SECRET` only; empty string → schema rejects → boot fails.
- `plugins/chat/src/proactive/listener.ts:611` — `workspaceId` on the quota error log so multi-tenant outages are correlatable.

**#2631 — admin_action_log dual-write**
- `answer-meter.ts:recordMeterEvent` — every meter event whose type maps to an `ADMIN_ACTIONS.proactive.*` constant (`classify`, `react`, `accept→answer`, `feedback`) now emits a `logAdminAction` sibling row alongside the `proactive_meter_events` insert. Audit emit fires BEFORE the DB-skip return so `/admin/proactive-chat` analytics that join on `admin_action_log` stay in lockstep with the meter. Closes the #2610 AC drift surfaced during dogfood at 16:57:50Z 2026-05-19. `offer` / `public_refused` have no sibling constant and stay meter-only.

**#2623 item 3 — slash command resolver-throw refuse**
- `plugins/chat/src/bridge.ts:onSlashCommand` — when the user explicitly typed `/atlas feedback <text>` and `resolveWorkspaceId` throws, refuse with an ephemeral instead of falling through to the standard question flow. Previously \`/atlas feedback the chart was wrong\` would run the text as a SQL query on resolver failure.

**Tests**
- New: `answer-meter-audit.test.ts` (7 cases) pinning the dual-write, including the offer/public_refused meter-only branch.
- Updated: `answer-adapter.test.ts` — replaced "degrades to anonymous identity" pin with two refusal cases (deleted account + F-55 regression for `resolveOrgForUser` throw). Both assert `observedRunAgentCalls` is empty.
- Updated: `bridge.test.ts` / `reactions.test.ts` fixtures — `signingSecret` now uses a 32-char hex string instead of `"test-secret"` so the new Zod regex accepts them.

All checks green locally: type 0, lint 0, api tests 67/67, plugin tests 438/438.

## Closes / Supersedes

- Closes #2631 (admin_action_log dual-write)
- Supersedes #2630 (botToken optional + drop placeholder) — its diff is absorbed verbatim plus the regex hardening
- Picks up #2623 item 3 of 6 (slash-command resolver-throw refuse)

## Deferred to follow-up PRs

- **#2624** — ProactiveUserResolver needs workspace context (plugin contract change, breaking; design follows #2620's resolveWorkspaceId pattern). Needs its own RFC + plugin bump.
- **#2623 items 1, 2, 4, 5, 6** — discriminated unions, ResolverEventLite, enabled-gate retry, schema CHECK on empty workspace_id, sentinel cache test. Polish-PR worthy.
- **#2622** — classifier-decisions drill-down + misfire labelling (new endpoint + new table + UI). Forward-looking feature, scoped post-#2607.
- **Integration test category** — \`packages/api/src/__tests__/integration/proactive-slack-e2e.test.ts\` (~250 LOC, 5 cases, uses TEST_DATABASE_URL). Both #2628 + #2630 passed all unit tests + Boot Smoke and were caught only at dogfood; this is the systemic gap.
- **chat-adapter/slack installation store vs Atlas slack_installations** — two separate stores bridged today via \`internal/backfill-chat-installations.ts\`. Long-term consolidation.
- **internal/ operational scripts** — gitignored, production-touching. Worth promoting setup-dogfood.ts to a CLI subcommand; rest can live with a tracked README.

## Test plan

- [ ] CI green (lint, type, api-tests 1-4, drift, deploy validation, symlink stub build)
- [ ] No regressions on existing answer-meter consumers (audit rows now appear for proactive.classify/react/answer/feedback; consumers that grep for these strings will start seeing them)
- [ ] Verify on dogfood after merge: a proactive.classify row in admin_action_log lands alongside the proactive_meter_events row
- [ ] Verify on dogfood after merge: \`/atlas feedback ...\` no longer runs as a SQL question when tenant resolution fails