### PR TITLE
docs(roadmap): tidy — record post-1.5.0 proactive listener wiring trail

### DIFF
--- a/.claude/research/ROADMAP.md
+++ b/.claude/research/ROADMAP.md
@@ -165,6 +165,7 @@ _None queued. See `/next` for candidates._
 - [x] **Post-1.4.3 bug pass** (PRs #2388, #2390) — semantic-layer whitelist now accepts dialect-quoted reserved-keyword tables (`"user"`, `` `events` ``, `[Order]`); SaaS abuse-detector escalation ladder gated by per-step dwell time (`ATLAS_ABUSE_ESCALATION_COOLDOWN_SECONDS`, default 60s) and short-circuited entirely on self-hosted (operator IS the user).
 - [x] **Post-1.4.4 multi-env tracer + page guard** (#2441, PR #2445) — real-API e2e against three local Postgres on 5433/5434/5435 with divergent seeds (10/100/1000 customers, prod-only `vip_tier`), shared `e2e/browser/lib/{totp,admin-auth}.ts` helpers, MFA-aware seed script, and an `Array.isArray()` defensive guard on `/admin/connections` for the prod render crash tracked at #2444 (root cause still open).
 - [x] **Post-1.5.0 marketing-pass + dogfood** (PRs #2553, #2560, #2561, #2562) — marketing-pass sweep bundled all 9 docs/landing issues into one PR (#2114, #2550–#2559). Dogfood caught two routing bugs: chat env picker defaulted to alphabetical-first instead of group primary (#2560), and admin semantic listed 46 entities (DB + disk dupes) instead of 23 (#2561 — boot reconciliation now GCs orphan YAMLs).
+- [x] **Post-1.5.0 proactive listener wiring** (parent #2607, 11 PRs, closed 2026-05-19) — wired the `@useatlas/chat` proactive listener into SaaS deploy + migrated Slack `@mention`/thread off `slack.ts`; dogfood-verified in `#sandbox-atlas`. Follow-ups: #2622–#2624, #2631, #2633–#2635.
 
 ---
 


### PR DESCRIPTION
## Summary

`/tidy` sweep after the 11-PR proactive listener wiring trail (parent #2607) closed. Adds one bullet to **Closed parallel tracks** so the trail is visible in the public ROADMAP alongside the post-1.5.0 marketing-pass entry.

Also (out of this PR, done in the local checkout):

- Filed #2633 (proactive-Slack e2e webhook coverage), #2634 (dual installation-store consolidation), #2635 (`internal/` ops-scripts promotion) — three deferreds previously living only in PR bodies.
- Labeled open PR #2632 with `bug` / `area: api` / `area: plugins` / `area: deploy`.
- Removed 5 stale worktrees + 8 [gone]/local-only branches.

## Test plan

- [x] Doc-only edit, no code paths touched
- [ ] CI green