### PR TITLE
feat(plugins/chat,api,deploy): #2624 — thread workspaceId through ProactiveUserResolver

### DIFF
--- a/deploy/api/atlas.config.ts
+++ b/deploy/api/atlas.config.ts
@@ -23,6 +23,7 @@ import { chatPlugin } from "./plugins/chat/src/index";
 import { getProactiveAiRuntime } from "./packages/api/src/lib/effect/ai";
 import { getEnterpriseRuntime } from "./packages/api/src/lib/effect/enterprise-layer";
 import { createSlackWorkspaceIdResolver } from "./packages/api/src/lib/proactive/workspace-id-resolver";
+import { createSlackProactiveUserResolver } from "./packages/api/src/lib/proactive/user-resolver";
 import { createProactiveEnabledGate } from "./packages/api/src/lib/proactive/enabled-gate";
 import {
   getChannelProactiveConfigs,
@@ -139,23 +140,28 @@ export default defineConfig({
         // `proactiveAiRuntime`. The factory's `RIn` type parameter
         // widens to accept the runtime's full service set.
         classify: createProactiveClassifier(proactiveAiRuntime),
-        // Reaction-back answer flow. The adapter's optional
-        // `getPublicDataset(asker)` callback — distinct from the
-        // plugin-level `getPublicDataset` wired below — is intentionally
-        // omitted: with the user resolver stubbed to unlinked, every
-        // asker hits the adapter's "refuse unlinked" path before
-        // touching the agent. The plugin-level `getPublicDataset` post-
-        // filter on the listener side is wired (line ~199) and becomes
-        // load-bearing once #2624 closes the user-resolver gap.
-        executeQueryProactive: createProactiveAnswerAdapter(proactiveAiRuntime),
-        // TODO(#2624): `ProactiveAsker` carries `{ platform, externalUserId, userName? }`
-        // — no `team_id` / `workspaceId`. On SaaS the same Slack userId
-        // can exist across multiple tenants and would resolve to
-        // different Atlas users without workspace context. Stubbed to
-        // always-unlinked; the unlinked path is the refuse-safe branch
-        // (adapter refuses; plugin-level public-dataset post-filter
-        // remains a defense-in-depth net for when #2624 lands).
-        userResolver: async () => ({ atlasUserId: undefined }),
+        // Reaction-back answer flow. Wires the adapter-side
+        // `getPublicDataset(asker, { workspaceId })` so unlinked-asker
+        // answers run with the workspace's curated allowlist gating
+        // `executeSQL` + `explore` at the tool boundary (the plugin-
+        // level post-filter on the listener side is the second gate).
+        // The workspaceId is threaded from the listener per #2624;
+        // pre-#2624 wiring couldn't pass it through.
+        executeQueryProactive: createProactiveAnswerAdapter(
+          proactiveAiRuntime,
+          {
+            getPublicDataset: (_asker, { workspaceId }) =>
+              getAllowlist(workspaceId),
+          },
+        ),
+        // Slack user resolver (#2624). Validates the workspaceId and
+        // returns `{ atlasUserId: undefined }` for every asker today
+        // (no Slack-user link table in core yet — the function has a
+        // clear hook point for a future linking mechanism). The
+        // unlinked path is the safe branch: the listener routes
+        // unlinked askers through the public-dataset allowlist gate,
+        // which is now tenant-scoped via #2624.
+        userResolver: createSlackProactiveUserResolver(),
         linkUrl:
           process.env.ATLAS_PUBLIC_WEB_URL ?? "https://app.useatlas.dev",
         // Three-layer kill switch + per-user opt-out. Plugin's

--- a/packages/api/src/lib/proactive/__tests__/answer-adapter.test.ts
+++ b/packages/api/src/lib/proactive/__tests__/answer-adapter.test.ts
@@ -214,6 +214,7 @@ describe("createProactiveAnswerAdapter — linked path", () => {
       threadId: "T-1",
       asker: slackAsker,
       atlasUserId: "user-linked",
+      workspaceId: "org-linked",
     });
 
     expect(result.answer).toBe("Linked answer");
@@ -245,6 +246,7 @@ describe("createProactiveAnswerAdapter — linked path", () => {
         threadId: "T-orphan",
         asker: slackAsker,
         atlasUserId: "user-missing",
+        workspaceId: "org-orphan",
       }),
     ).rejects.toThrow(/Atlas couldn't answer this/);
 
@@ -275,6 +277,7 @@ describe("createProactiveAnswerAdapter — linked path", () => {
         threadId: "T-fail",
         asker: slackAsker,
         atlasUserId: "user-1",
+        workspaceId: "org-1",
       }),
     ).rejects.toThrow(/Atlas couldn't answer this/);
 
@@ -314,6 +317,7 @@ describe("createProactiveAnswerAdapter — unlinked path", () => {
       threadId: "T-unlinked",
       asker: slackAsker,
       atlasUserId: null,
+      workspaceId: "org-public",
     });
 
     expect(result.answer).toBe("Public-dataset answer");
@@ -341,6 +345,7 @@ describe("createProactiveAnswerAdapter — unlinked path", () => {
         threadId: "T-missing",
         asker: slackAsker,
         atlasUserId: null,
+        workspaceId: "org-missing",
       }),
     ).rejects.toThrow(/Atlas couldn't answer this/);
 
@@ -369,6 +374,7 @@ describe("createProactiveAnswerAdapter — unlinked path", () => {
         threadId: "T-empty",
         asker: slackAsker,
         atlasUserId: null,
+        workspaceId: "org-empty",
       }),
     ).rejects.toThrow(/Atlas couldn't answer this/);
     expect(observedRunAgentCalls).toHaveLength(0);
@@ -395,6 +401,7 @@ describe("createProactiveAnswerAdapter — unlinked path", () => {
         threadId: "T-fail",
         asker: slackAsker,
         atlasUserId: null,
+        workspaceId: "org-fail",
       }),
     ).rejects.toThrow(/Atlas couldn't answer this/);
     expect(observedRunAgentCalls).toHaveLength(0);
@@ -404,6 +411,48 @@ describe("createProactiveAnswerAdapter — unlinked path", () => {
     );
     expect(matchingError).toBeDefined();
     expect(matchingError?.payload.errorMessage).toContain("registry connection refused");
+    await runtime.dispose();
+  });
+
+  it("threads the per-event workspaceId through to getPublicDataset (#2624 multi-tenant)", async () => {
+    // The point: pre-#2624 the adapter called `getPublicDataset(asker)`
+    // with no workspaceId, so on multi-tenant SaaS the same Slack
+    // user-id seen from two tenants would resolve against whichever
+    // tenant's allowlist the host implementation happened to default
+    // to. The contract change passes the per-event workspaceId so the
+    // host scopes the lookup correctly.
+    nextRunAgentResult = {
+      text: Promise.resolve("scoped public answer"),
+      steps: Promise.resolve([]),
+      totalUsage: Promise.resolve({ inputTokens: 0, outputTokens: 0 }),
+    };
+    const observedPublicDatasetCalls: Array<{
+      askerExternalId: string | undefined;
+      workspaceId: string;
+    }> = [];
+    const runtime = buildRuntime();
+    const adapter = createProactiveAnswerAdapter(runtime, {
+      getPublicDataset: async (asker, ctx) => {
+        observedPublicDatasetCalls.push({
+          askerExternalId: asker.externalUserId,
+          workspaceId: ctx.workspaceId,
+        });
+        return [{ entityName: "tenant_scoped_entity", denyMetrics: [] }];
+      },
+    });
+
+    await adapter("scoped question", {
+      threadId: "T-scoped",
+      asker: slackAsker,
+      atlasUserId: null,
+      workspaceId: "tenant-B",
+    });
+
+    expect(observedPublicDatasetCalls).toHaveLength(1);
+    expect(observedPublicDatasetCalls[0]).toEqual({
+      askerExternalId: slackAsker.externalUserId,
+      workspaceId: "tenant-B",
+    });
     await runtime.dispose();
   });
 });
@@ -430,6 +479,7 @@ describe("createProactiveAnswerAdapter — error handling", () => {
         threadId: "T-err",
         asker: slackAsker,
         atlasUserId: "user-1",
+        workspaceId: "org-1",
       }),
     ).rejects.toThrow(/Atlas couldn't answer this/);
 
@@ -470,6 +520,7 @@ describe("createProactiveAnswerAdapter — error handling", () => {
         threadId: "T-model",
         asker: slackAsker,
         atlasUserId: "user-1",
+        workspaceId: "org-1",
       }),
     ).rejects.toThrow(/Atlas couldn't answer this/);
 
@@ -591,6 +642,7 @@ describe("collectProactiveResult", () => {
       threadId: "T-refs",
       asker: slackAsker,
       atlasUserId: "user-x",
+      workspaceId: "org-x",
     });
 
     expect(result.answer).toBe("Answer with refs");

--- a/packages/api/src/lib/proactive/__tests__/user-resolver.test.ts
+++ b/packages/api/src/lib/proactive/__tests__/user-resolver.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Tests for `createSlackProactiveUserResolver` (#2624).
+ *
+ * The factory is the SaaS implementation of the chat plugin's
+ * `ProactiveUserResolver`. Pin behaviour:
+ *
+ *  - Non-Slack platforms → `{ atlasUserId: undefined }` (no Slack-bot
+ *    handling, no throw).
+ *  - Missing/empty workspaceId → `{ atlasUserId: undefined }` (defensive
+ *    — the listener short-circuits on empty workspaceIds before
+ *    invoking the resolver, but the resolver must not collapse all
+ *    tenants onto a single global path if a future caller bypasses
+ *    the listener).
+ *  - Unknown workspaceId (verifier returns false) → `{ atlasUserId:
+ *    undefined }`.
+ *  - Known workspaceId → `{ atlasUserId: undefined }` (no Slack-user
+ *    link table exists yet — the hook point is documented in the
+ *    factory; once the link table lands the resolver returns the
+ *    Atlas user id for matches).
+ *  - Verifier throws → `{ atlasUserId: undefined }` (registry hiccup
+ *    falls through to the public-dataset gate; the resolver MUST NOT
+ *    surface as `kind: "errored"` for this case because that would
+ *    block every asker behind an apology copy during a DB blip).
+ *
+ * No `mock.module()` here — the factory exposes its DB lookup via the
+ * `verifyWorkspace` option for exactly this reason. The default-path
+ * test (no override) drops to `hasInternalDB() === false` (no
+ * `DATABASE_URL` in the test env) which returns false from the
+ * default verifier — assertable without touching Postgres.
+ */
+
+import { describe, it, expect, mock } from "bun:test";
+
+import { createSlackProactiveUserResolver } from "../user-resolver";
+
+const slackAsker = {
+  platform: "slack",
+  externalUserId: "U-asker",
+  userName: "alice",
+};
+
+describe("createSlackProactiveUserResolver", () => {
+  it("returns unlinked for non-Slack platforms without invoking verifyWorkspace", async () => {
+    const verifyWorkspace = mock(async () => true);
+    const resolver = createSlackProactiveUserResolver({ verifyWorkspace });
+
+    const out = await resolver(
+      { platform: "teams", externalUserId: "T-1", userName: "bob" },
+      { workspaceId: "ws-1" },
+    );
+
+    expect(out).toEqual({ atlasUserId: undefined });
+    expect(verifyWorkspace).not.toHaveBeenCalled();
+  });
+
+  it("returns unlinked when workspaceId is empty (defensive — listener should not reach this)", async () => {
+    const verifyWorkspace = mock(async () => true);
+    const resolver = createSlackProactiveUserResolver({ verifyWorkspace });
+
+    const out = await resolver(slackAsker, { workspaceId: "" });
+
+    expect(out).toEqual({ atlasUserId: undefined });
+    // The empty-workspaceId short-circuit MUST run before the DB
+    // lookup — a global lookup with empty `WHERE org_id = ''` would
+    // match nothing but still hit the DB unnecessarily.
+    expect(verifyWorkspace).not.toHaveBeenCalled();
+  });
+
+  it("returns unlinked when verifyWorkspace returns false (unknown tenant)", async () => {
+    const verifyWorkspace = mock(async (_id: string) => false);
+    const resolver = createSlackProactiveUserResolver({ verifyWorkspace });
+
+    const out = await resolver(slackAsker, { workspaceId: "ws-unknown" });
+
+    expect(out).toEqual({ atlasUserId: undefined });
+    expect(verifyWorkspace).toHaveBeenCalledWith("ws-unknown");
+  });
+
+  it("returns unlinked even when verifyWorkspace returns true — no Slack-user link table yet", async () => {
+    // Today's pragmatic behaviour: every asker takes the unlinked
+    // path because no `slack_user_links` table exists in core. The
+    // hook point is documented in the resolver — when the link
+    // table lands, replace the inner branch with a real lookup.
+    const verifyWorkspace = mock(async (_id: string) => true);
+    const resolver = createSlackProactiveUserResolver({ verifyWorkspace });
+
+    const out = await resolver(slackAsker, { workspaceId: "ws-known" });
+
+    expect(out).toEqual({ atlasUserId: undefined });
+    expect(verifyWorkspace).toHaveBeenCalledWith("ws-known");
+  });
+
+  it("falls back to unlinked when verifyWorkspace throws (registry hiccup, not control-path failure)", async () => {
+    // Reasoning the comment in `user-resolver.ts` pins: a DB outage
+    // here should NOT throw out of the resolver (which would surface
+    // as `kind: "errored"` in the listener → apology copy → no answer
+    // at all). The listener's public-dataset gate IS the refuse-safe
+    // branch; collapsing the hiccup onto "unlinked" routes the asker
+    // through that gate.
+    const verifyWorkspace = mock(async () => {
+      throw new Error("connection terminated unexpectedly");
+    });
+    const resolver = createSlackProactiveUserResolver({ verifyWorkspace });
+
+    const out = await resolver(slackAsker, { workspaceId: "ws-troubled" });
+
+    expect(out).toEqual({ atlasUserId: undefined });
+    expect(verifyWorkspace).toHaveBeenCalled();
+  });
+
+  it("passes the workspaceId straight through to verifyWorkspace (no normalization)", async () => {
+    // Multi-tenant correctness: a future code path that pre-normalizes
+    // the workspaceId (case-fold, trim) MUST happen at the listener's
+    // resolver, not silently inside this factory. Pin the pass-through.
+    const verifyWorkspace = mock(async (_id: string) => true);
+    const resolver = createSlackProactiveUserResolver({ verifyWorkspace });
+
+    await resolver(slackAsker, { workspaceId: "WS-MixedCase-42" });
+
+    expect(verifyWorkspace).toHaveBeenCalledTimes(1);
+    expect(verifyWorkspace.mock.calls[0]![0]).toBe("WS-MixedCase-42");
+  });
+
+  it("default verifier returns false without an internal DB (self-hosted / no DATABASE_URL)", async () => {
+    // Drop-the-override path: when no `verifyWorkspace` is supplied,
+    // the factory uses `defaultVerifyWorkspace` which short-circuits
+    // on `hasInternalDB() === false`. The test runner doesn't expose
+    // an internal DB (no DATABASE_URL set), so the verifier resolves
+    // to false → unlinked. This pins the self-hosted/no-DB posture.
+    const resolver = createSlackProactiveUserResolver();
+    const out = await resolver(slackAsker, { workspaceId: "ws-any" });
+    expect(out).toEqual({ atlasUserId: undefined });
+  });
+});

--- a/packages/api/src/lib/proactive/__tests__/user-resolver.test.ts
+++ b/packages/api/src/lib/proactive/__tests__/user-resolver.test.ts
@@ -121,6 +121,37 @@ describe("createSlackProactiveUserResolver", () => {
     expect(verifyWorkspace.mock.calls[0]![0]).toBe("WS-MixedCase-42");
   });
 
+  it("isolates two tenants seeing the same Slack externalUserId (#2624 collision case)", async () => {
+    // The point of #2624: a single Slack user-id may appear in
+    // multiple tenants on SaaS. The resolver MUST query the verifier
+    // with each per-event workspaceId distinctly — no global lookup,
+    // no caching keyed on asker.externalUserId. This test reproduces
+    // the collision scenario the issue body called out and pins that
+    // both invocations hit the verifier separately.
+    const observed: string[] = [];
+    const verifyWorkspace = mock(async (id: string) => {
+      observed.push(id);
+      return id === "ws-A"; // pretend only ws-A is installed
+    });
+    const resolver = createSlackProactiveUserResolver({ verifyWorkspace });
+
+    const sharedAsker = {
+      platform: "slack",
+      externalUserId: "U-shared",
+      userName: "shared",
+    };
+
+    const outA = await resolver(sharedAsker, { workspaceId: "ws-A" });
+    const outB = await resolver(sharedAsker, { workspaceId: "ws-B" });
+
+    // Both tenants are evaluated independently — no collision, no
+    // caching by asker identity. Until a link table lands both
+    // return unlinked, but the verifier received both ids.
+    expect(observed).toEqual(["ws-A", "ws-B"]);
+    expect(outA).toEqual({ atlasUserId: undefined });
+    expect(outB).toEqual({ atlasUserId: undefined });
+  });
+
   it("default verifier returns false without an internal DB (self-hosted / no DATABASE_URL)", async () => {
     // Drop-the-override path: when no `verifyWorkspace` is supplied,
     // the factory uses `defaultVerifyWorkspace` which short-circuits

--- a/packages/api/src/lib/proactive/answer-adapter.ts
+++ b/packages/api/src/lib/proactive/answer-adapter.ts
@@ -131,13 +131,21 @@ export interface ProactiveAnswerAdapterOptions {
    * call is rejected with the user-safe error. Linked calls
    * (`atlasUserId !== null`) never invoke this callback.
    *
-   * The default production wiring resolves the allowlist for the
-   * `asker.platform` workspace via
+   * Receives the per-event `workspaceId` (#2624) alongside the asker
+   * so multi-tenant hosts scope the allowlist lookup to the right
+   * tenant. Pre-#2624 the callback received only `asker`, which
+   * couldn't distinguish "same Slack user-id seen in tenant A vs
+   * tenant B" and so routed tenant B askers against tenant A's
+   * allowlist on the chat plugin's single-instance multi-tenant SaaS
+   * wiring.
+   *
+   * The default production wiring resolves the allowlist via
    * `getAllowlist(workspaceId)` in
    * `packages/api/src/lib/proactive/public-dataset.ts`.
    */
   getPublicDataset?: (
     asker: ProactiveAsker,
+    ctx: { workspaceId: string },
   ) => Promise<ReadonlyArray<PublicDatasetEntry>>;
 }
 
@@ -161,7 +169,7 @@ export function createProactiveAnswerAdapter(
 
   return async (question, context): Promise<ProactiveQueryResult> => {
     const requestId = crypto.randomUUID();
-    const { threadId, asker, atlasUserId } = context;
+    const { threadId, asker, atlasUserId, workspaceId } = context;
     const askerId = describeAskerId(asker);
 
     // 1. Resolve identity + (unlinked) restricted tool registry ----------
@@ -183,19 +191,20 @@ export function createProactiveAnswerAdapter(
         // warehouse before the listener's post-filter ever ran.
         if (!getPublicDataset) {
           log.error(
-            { threadId, askerId, event: "proactive.answer.public_dataset_missing" },
+            { threadId, askerId, workspaceId, event: "proactive.answer.public_dataset_missing" },
             "Unlinked asker reached the adapter but getPublicDataset is not wired — refusing",
           );
           throw new Error(PROACTIVE_USER_SAFE_ERROR_MESSAGE);
         }
         let allowlist: ReadonlyArray<PublicDatasetEntry>;
         try {
-          allowlist = await getPublicDataset(asker);
+          allowlist = await getPublicDataset(asker, { workspaceId });
         } catch (err) {
           log.error(
             {
               threadId,
               askerId,
+              workspaceId,
               errorMessage: errorMessage(err),
               event: "proactive.answer.public_dataset_failed",
             },
@@ -208,6 +217,7 @@ export function createProactiveAnswerAdapter(
             {
               threadId,
               askerId,
+              workspaceId,
               event: "proactive.answer.public_dataset_empty",
             },
             "Public dataset allowlist is empty — refusing unlinked-asker request",
@@ -299,6 +309,7 @@ export function createProactiveAnswerAdapter(
           threadId,
           askerId,
           atlasUserId,
+          workspaceId,
           linked: atlasUserId !== null,
           sqlCount: collected.sql.length,
           dataCount: collected.data.length,

--- a/packages/api/src/lib/proactive/answer-adapter.ts
+++ b/packages/api/src/lib/proactive/answer-adapter.ts
@@ -245,6 +245,7 @@ export function createProactiveAnswerAdapter(
           threadId,
           askerId,
           atlasUserId,
+          workspaceId,
           errorMessage: errorMessage(err),
           event: "proactive.answer.identity_failed",
         },
@@ -270,6 +271,7 @@ export function createProactiveAnswerAdapter(
           threadId,
           askerId,
           atlasUserId,
+          workspaceId,
           errorMessage: errorMessage(err),
           event: "proactive.answer.model_resolution_failed",
         },
@@ -326,6 +328,7 @@ export function createProactiveAnswerAdapter(
           threadId,
           askerId,
           atlasUserId,
+          workspaceId,
           errorMessage: errorMessage(err),
           event: "proactive.answer.agent_failed",
         },
@@ -416,15 +419,18 @@ function normalizeChatPlatform(platform: string): ChatBotPlatform | null {
 }
 
 /**
- * Default resolver — pick the first org the user is a member of. Tests
- * inject a stub via {@link ProactiveAnswerAdapterOptions.resolveOrgForUser}.
+ * Default resolver — pick one org the user is a member of, ordered by
+ * `organizationId ASC` so multi-org members resolve deterministically.
+ * Tests inject a stub via
+ * {@link ProactiveAnswerAdapterOptions.resolveOrgForUser}.
  *
- * Single-row `LIMIT 1` matches the activation heuristic in
- * `auth/server.ts` (the Better Auth hook that auto-activates an org on
- * sign-in). If the user belongs to multiple orgs this picks one
- * deterministically (lexical `organizationId` order); for the proactive
- * path that's adequate because the Slack workspace itself is
- * single-org-bound at install time.
+ * Adequate for the proactive path because each Slack workspace is
+ * single-org-bound at install time (`slack_installations.org_id`),
+ * so a Slack-asker who is a member of multiple Atlas orgs only sees
+ * proactive answers from one of them by definition. Note this is NOT
+ * the same policy as the Better Auth sign-in hook in `auth/server.ts`,
+ * which only auto-activates when the user has exactly one org; on
+ * multi-org members the auth hook leaves activation untouched.
  */
 async function defaultResolveOrgForUser(
   atlasUserId: string,

--- a/packages/api/src/lib/proactive/user-resolver.ts
+++ b/packages/api/src/lib/proactive/user-resolver.ts
@@ -1,0 +1,196 @@
+/**
+ * Proactive `userResolver` — chat-platform identity → Atlas identity (#2624).
+ *
+ * The chat plugin's `ProactiveUserResolver` (post-#2624 shape) is:
+ *
+ *     (asker, { workspaceId }) => Promise<{ atlasUserId? }>
+ *
+ * The `workspaceId` is the per-event tenant resolved by
+ * `lib/proactive/workspace-id-resolver.ts:createSlackWorkspaceIdResolver`
+ * (Slack `team_id` → `slack_installations.org_id`). This module wires
+ * a resolver factory for the Slack platform that:
+ *
+ *   1. **Verifies the workspace is a real Atlas org.** A defensive
+ *      lookup against `slack_installations.org_id` — defends against a
+ *      hypothetical caller that hands us an unknown workspaceId (the
+ *      listener's resolver should already have returned `null` in that
+ *      case, but if a future code path bypasses the per-event resolver
+ *      we still refuse to attribute the asker to a stale tenant).
+ *
+ *   2. **Returns `{ atlasUserId: undefined }`** for every asker today.
+ *      The mapping from `(workspaceId, slack_user_id)` to an Atlas
+ *      `user.id` requires a link table (e.g. `slack_user_links` with
+ *      `(workspace_id, slack_user_id, atlas_user_id)`) that does NOT
+ *      yet exist in core. Without that table the resolver cannot
+ *      safely link an asker — and we MUST NOT invent a heuristic
+ *      match (e.g. "first member of the org") because that would
+ *      silently bypass per-user RLS for an unlinked asker by binding
+ *      their query to another user's identity.
+ *
+ *      The listener's unlinked-asker path (public-dataset gate +
+ *      refusal copy) is the safe behaviour until the link table
+ *      lands.
+ *
+ * **Hook point for future linking work.** A follow-up issue is
+ * expected to add a Slack-user link mechanism (OAuth user grant, an
+ * admin-managed link table, or email matching via the Slack profile
+ * API). When that lands the resolver replaces step 2 with a real
+ * lookup; the surrounding wiring (#2624 contract change) stays as-is.
+ *
+ * Failures resolve as `{ atlasUserId: undefined }` rather than
+ * throwing — the listener's `safeResolveUser` catches throws but
+ * treats them as the apology path (refuse, do not downgrade to
+ * public-dataset). Returning an explicit unlinked result keeps the
+ * three-state ladder ("linked" / "unlinked" / "errored") meaningful
+ * for the failure mode that's actually "we don't know yet" (no link
+ * table) rather than "the registry is broken" (errored).
+ *
+ * Layer hygiene: lives under `lib/proactive/`. Does NOT import from
+ * `@atlas/ee` or from `api/routes/`. Only the SaaS deploy wires this
+ * up; self-hosted deployments can either reuse this factory (the
+ * unlinked-only path is correct everywhere) or omit `userResolver`
+ * entirely (the listener defaults to "unlinked" when undefined).
+ *
+ * @module
+ */
+
+import type {
+  ProactiveAsker,
+  ProactiveUserResolver,
+  ProactiveUserResolverContext,
+  ResolvedAsker,
+} from "@useatlas/chat";
+
+import { hasInternalDB, internalQuery } from "@atlas/api/lib/db/internal";
+import { createLogger } from "@atlas/api/lib/logger";
+
+const log = createLogger("proactive:user-resolver");
+
+/**
+ * Options for {@link createSlackProactiveUserResolver}. All optional;
+ * tests pass `verifyWorkspace: () => Promise.resolve(true)` to stub
+ * the DB lookup.
+ */
+export interface SlackProactiveUserResolverOptions {
+  /**
+   * Verify the given workspaceId maps to a real Atlas org via
+   * `slack_installations.org_id`. Defaults to a single-row lookup
+   * against the internal DB. Override in tests to stub.
+   *
+   * The Slack workspace-id resolver
+   * (`createSlackWorkspaceIdResolver`) already does this lookup at
+   * the per-event boundary; this is a defensive re-check so a
+   * resolver invoked through a code path that bypasses the workspace
+   * resolver still refuses to attribute the asker. Cheap (PK lookup
+   * on `slack_installations.org_id` via `idx_slack_installations_org`)
+   * so the extra read isn't material.
+   */
+  verifyWorkspace?: (workspaceId: string) => Promise<boolean>;
+}
+
+/**
+ * Build the SaaS proactive user-resolver for the Slack platform.
+ *
+ * Today: validates the workspaceId and returns
+ * `{ atlasUserId: undefined }` for every asker (no Slack-user link
+ * table exists yet). When a link mechanism lands, the lookup goes
+ * inside the inner `try` block below — the calling contract stays
+ * unchanged.
+ *
+ * The factory pattern (vs a top-level function) keeps the test
+ * surface narrow: pass a stubbed `verifyWorkspace` and you can
+ * exercise every branch without touching the internal DB.
+ */
+export function createSlackProactiveUserResolver(
+  options: SlackProactiveUserResolverOptions = {},
+): ProactiveUserResolver {
+  const verifyWorkspace =
+    options.verifyWorkspace ?? defaultVerifyWorkspace;
+
+  return async (
+    asker: ProactiveAsker,
+    ctx: ProactiveUserResolverContext,
+  ): Promise<ResolvedAsker> => {
+    const { workspaceId } = ctx;
+    if (asker.platform !== "slack") {
+      // Future platforms wire their own resolver. Returning unlinked
+      // (vs throwing) keeps the failure-closed posture: the listener
+      // refuses-safely via the public-dataset gate rather than
+      // surfacing an apology copy on a misrouted event.
+      log.debug(
+        { platform: asker.platform, workspaceId },
+        "Proactive user resolver invoked for non-Slack platform — returning unlinked",
+      );
+      return { atlasUserId: undefined };
+    }
+
+    if (!workspaceId) {
+      // Defensive: workspaceId should always be non-empty (the
+      // listener short-circuits on a null/empty resolver result),
+      // but an empty string here would skip the workspace check and
+      // collapse all tenants onto the global path. Refuse-safely.
+      log.warn(
+        { externalUserId: asker.externalUserId },
+        "Proactive user resolver invoked without workspaceId — returning unlinked",
+      );
+      return { atlasUserId: undefined };
+    }
+
+    try {
+      const known = await verifyWorkspace(workspaceId);
+      if (!known) {
+        log.warn(
+          { workspaceId, externalUserId: asker.externalUserId },
+          "Proactive user resolver: workspaceId not in slack_installations — returning unlinked",
+        );
+        return { atlasUserId: undefined };
+      }
+    } catch (err) {
+      // DB outage → unlinked (NOT errored): the listener treats
+      // `errored` as "post the apology copy", and a registry hiccup
+      // should fall through to the public-dataset path (refuse-safely
+      // via the listener's allowlist gate) rather than blocking
+      // every asker behind an apology. The pause registry uses the
+      // opposite posture (fail-closed) because IT is a control;
+      // user-linking is observability + UX, not a permission gate.
+      log.warn(
+        {
+          err: err instanceof Error ? err.message : String(err),
+          workspaceId,
+          externalUserId: asker.externalUserId,
+        },
+        "Proactive user resolver: verifyWorkspace failed — returning unlinked",
+      );
+      return { atlasUserId: undefined };
+    }
+
+    // Hook point — when a Slack-user link table lands, replace the
+    // line below with a lookup keyed on (workspaceId, asker.externalUserId)
+    // and return `{ atlasUserId }` for matches. Until then every
+    // asker takes the unlinked path: the listener's public-dataset
+    // gate is the answer-or-refuse branch, and that branch IS
+    // tenant-scoped now (#2624) via the workspaceId threaded through
+    // `getPublicDataset(asker, { workspaceId })`.
+    return { atlasUserId: undefined };
+  };
+}
+
+/**
+ * Default workspace verifier — single-row lookup against
+ * `slack_installations`. Returns false on a missing row or null
+ * `org_id`. Throws on DB error so the caller can distinguish
+ * "unknown workspace" from "DB is down"; the calling resolver
+ * collapses both onto the same unlinked outcome but logs them
+ * separately (warn for missing, warn-with-error for outage).
+ */
+async function defaultVerifyWorkspace(workspaceId: string): Promise<boolean> {
+  if (!hasInternalDB()) return false;
+  const rows = await internalQuery<{ org_id: string | null }>(
+    `SELECT org_id
+       FROM slack_installations
+      WHERE org_id = $1
+      LIMIT 1`,
+    [workspaceId],
+  );
+  return rows.length > 0 && rows[0]!.org_id !== null;
+}

--- a/packages/api/src/lib/proactive/user-resolver.ts
+++ b/packages/api/src/lib/proactive/user-resolver.ts
@@ -81,9 +81,9 @@ export interface SlackProactiveUserResolverOptions {
    * (`createSlackWorkspaceIdResolver`) already does this lookup at
    * the per-event boundary; this is a defensive re-check so a
    * resolver invoked through a code path that bypasses the workspace
-   * resolver still refuses to attribute the asker. Cheap (PK lookup
-   * on `slack_installations.org_id` via `idx_slack_installations_org`)
-   * so the extra read isn't material.
+   * resolver still refuses to attribute the asker. Cheap (indexed
+   * lookup against `idx_slack_installations_org` on `org_id`) so the
+   * extra read isn't material.
    */
   verifyWorkspace?: (workspaceId: string) => Promise<boolean>;
 }
@@ -192,5 +192,6 @@ async function defaultVerifyWorkspace(workspaceId: string): Promise<boolean> {
       LIMIT 1`,
     [workspaceId],
   );
-  return rows.length > 0 && rows[0]!.org_id !== null;
+  const [row] = rows;
+  return row !== undefined && row.org_id !== null;
 }

--- a/plugins/chat/src/index.ts
+++ b/plugins/chat/src/index.ts
@@ -142,6 +142,7 @@ export type {
   ProactiveGateFn,
   ProactiveQueryResult,
   ProactiveUserResolver,
+  ProactiveUserResolverContext,
   RecentAnswerEntry,
   ResolvedAsker,
   ResolveWorkspaceIdFn,

--- a/plugins/chat/src/proactive/__tests__/listener.test.ts
+++ b/plugins/chat/src/proactive/__tests__/listener.test.ts
@@ -2045,6 +2045,72 @@ describe("registerProactiveListener — multi-tenant per-event resolution (#2620
     ).toBe("ws-B");
   });
 
+  it("legacy 1-arg userResolver still runs (TS contravariance) but receives the workspaceId at runtime", async () => {
+    // Pinned behaviour: a pre-#2624 host whose resolver was declared
+    // as `(asker) => Promise<...>` still type-checks against the new
+    // `(asker, ctx) => Promise<...>` shape (TypeScript parameter
+    // contravariance allows fewer params). At runtime the listener
+    // passes the second arg unconditionally; a 1-arg fn silently
+    // ignores it. This is the silent-collision path the contract
+    // change addresses: a self-hosted user who upgrades plugins
+    // without touching their resolver gets the old global-lookup
+    // behaviour with no compile or runtime warning.
+    //
+    // This test documents that posture deliberately. If a future
+    // change adds a runtime guard (e.g. resolver.length === 1 warn),
+    // update this test to assert the warn fires.
+    const legacyResolver = mock(async (_asker: { externalUserId: string }) => ({
+      atlasUserId: "atlas-user-from-legacy",
+    }));
+    const { chat, invokeMessage, invokeReaction } = makeChat();
+    await registerProactiveListener(
+      chat as unknown as Parameters<typeof registerProactiveListener>[0],
+      makeLogger(),
+      {
+        isEnabled: async () => true,
+        classify: yesLLM,
+        resolveWorkspaceId: makeResolver("ws-1"),
+        getWorkspaceConfig: defaultGetWorkspace,
+        getChannelConfigs: allowChannels("C-allowed"),
+        // Cast: pre-#2624 hosts had this exact 1-arg shape, and
+        // TypeScript still accepts it via contravariance. The cast
+        // mirrors the runtime situation.
+        userResolver: legacyResolver as unknown as ProactiveUserResolver,
+        executeQueryProactive: echoExecute,
+      },
+    );
+
+    const thread = makeThread("C-allowed");
+    await invokeMessage(thread, makeMessage({ id: "M1" }));
+    await invokeReaction({
+      added: true,
+      messageId: "M1",
+      threadId: thread.channelId,
+      thread,
+      user: { isMe: false, isBot: false, userId: "U-asker", userName: "asker" },
+      emoji: PROACTIVE_REACTION,
+      rawEmoji: "robot_face",
+      adapter: { name: "slack" },
+      raw: {},
+    });
+
+    // Legacy resolver fired and returned its atlasUserId — listener
+    // accepted the link and routed through the linked path. The
+    // second arg was passed (it would silently be undefined inside
+    // the 1-arg function body) but didn't influence the outcome.
+    expect(legacyResolver).toHaveBeenCalledTimes(1);
+    expect(legacyResolver.mock.calls[0]![0]).toMatchObject({
+      externalUserId: "U-asker",
+    });
+    // The listener still passes the 2nd arg at the runtime call site;
+    // assert it's there even though TS contravariance lets the body
+    // ignore it. This pins the runtime invariant against an
+    // optimization that might drop the 2nd arg.
+    const firstCall = legacyResolver.mock.calls[0] as unknown as unknown[];
+    expect(firstCall.length).toBe(2);
+    expect(firstCall[1]).toEqual({ workspaceId: "ws-1" });
+  });
+
   it("userResolver throw is per-tenant — logs workspaceId on the apology path", async () => {
     // A resolver hiccup on tenant A must not silently route tenant A's
     // asker through tenant B's workspace context. The listener logs at

--- a/plugins/chat/src/proactive/__tests__/listener.test.ts
+++ b/plugins/chat/src/proactive/__tests__/listener.test.ts
@@ -1296,7 +1296,7 @@ describe("registerProactiveListener — public dataset (#2297)", () => {
       { entityName: "marketing.users", denyMetrics: [] },
     ]);
     const executeQueryProactive = mock(
-      async (q: string, _ctx: { threadId: string; asker: { externalUserId: string }; atlasUserId: string | null }) => ({
+      async (q: string, _ctx: { threadId: string; asker: { externalUserId: string }; atlasUserId: string | null; workspaceId: string }) => ({
         answer: `Echo: ${q}`,
         entitiesReferenced: ["marketing.users"],
       }),
@@ -1329,7 +1329,7 @@ describe("registerProactiveListener — public dataset (#2297)", () => {
       { entityName: "marketing.users", denyMetrics: [] },
     ]);
     const executeQueryProactive = mock(
-      async (q: string, _ctx: { threadId: string; asker: { externalUserId: string }; atlasUserId: string | null }) => ({
+      async (q: string, _ctx: { threadId: string; asker: { externalUserId: string }; atlasUserId: string | null; workspaceId: string }) => ({
         answer: `Echo: ${q}`,
         entitiesReferenced: ["finance.revenue"],
       }),
@@ -1365,7 +1365,7 @@ describe("registerProactiveListener — public dataset (#2297)", () => {
       { entityName: "finance.revenue", denyMetrics: [] },
     ]);
     const executeQueryProactive = mock(
-      async (q: string, _ctx: { threadId: string; asker: { externalUserId: string }; atlasUserId: string | null }) => ({
+      async (q: string, _ctx: { threadId: string; asker: { externalUserId: string }; atlasUserId: string | null; workspaceId: string }) => ({
         answer: `Echo: ${q}`,
         entitiesReferenced: ["finance.revenue", "finance.customers"],
       }),
@@ -1396,7 +1396,7 @@ describe("registerProactiveListener — public dataset (#2297)", () => {
       { entityName: "marketing.users", denyMetrics: ["email"] },
     ]);
     const executeQueryProactive = mock(
-      async (q: string, _ctx: { threadId: string; asker: { externalUserId: string }; atlasUserId: string | null }) => ({
+      async (q: string, _ctx: { threadId: string; asker: { externalUserId: string }; atlasUserId: string | null; workspaceId: string }) => ({
         answer: `Echo: ${q}`,
         entitiesReferenced: ["marketing.users"],
         metricsReferenced: ["signup_date", "email"],
@@ -1434,7 +1434,7 @@ describe("registerProactiveListener — public dataset (#2297)", () => {
       { entityName: "marketing.users", denyMetrics: [] },
     ]);
     const executeQueryProactive = mock(
-      async (q: string, _ctx: { threadId: string; asker: { externalUserId: string }; atlasUserId: string | null }) => ({
+      async (q: string, _ctx: { threadId: string; asker: { externalUserId: string }; atlasUserId: string | null; workspaceId: string }) => ({
         answer: `Echo: ${q}`,
         // No entitiesReferenced field at all.
       }),
@@ -1469,7 +1469,7 @@ describe("registerProactiveListener — public dataset (#2297)", () => {
       { entityName: "marketing.users", denyMetrics: [] },
     ]);
     const executeQueryProactive = mock(
-      async (q: string, _ctx: { threadId: string; asker: { externalUserId: string }; atlasUserId: string | null }) => ({
+      async (q: string, _ctx: { threadId: string; asker: { externalUserId: string }; atlasUserId: string | null; workspaceId: string }) => ({
         answer: `Echo: ${q}`,
         entitiesReferenced: [], // empty array
       }),
@@ -1503,7 +1503,7 @@ describe("registerProactiveListener — public dataset (#2297)", () => {
       { entityName: "marketing.users", denyMetrics: [] },
     ]);
     const executeQueryProactive = mock(
-      async (q: string, _ctx: { threadId: string; asker: { externalUserId: string }; atlasUserId: string | null }) => ({
+      async (q: string, _ctx: { threadId: string; asker: { externalUserId: string }; atlasUserId: string | null; workspaceId: string }) => ({
         answer: `Echo: ${q}`,
         // No entitiesReferenced
       }),
@@ -1955,5 +1955,149 @@ describe("registerProactiveListener — multi-tenant per-event resolution (#2620
     const wsBCount = callArgs.filter((id) => id === "ws-B").length;
     expect(wsACount).toBe(2);
     expect(wsBCount).toBe(1);
+  });
+
+  it("userResolver receives the pending entry's workspaceId as the second arg (#2624)", async () => {
+    // The point of #2624: a multi-tenant host needs the workspaceId
+    // to scope the (platform, externalUserId) lookup. Pre-#2624 the
+    // resolver received only the asker — two tenants' askers with
+    // the same Slack user-id would collide. Now the listener threads
+    // the pending entry's workspaceId through as the second arg.
+    //
+    // We also pin the executeQueryProactive context: the same
+    // per-event workspaceId must appear on the proactive context
+    // (otherwise the host adapter's tool gates couldn't scope the
+    // allowlist correctly either).
+    const channelToWorkspace = new Map<string, string>([
+      ["C-tenant-A", "ws-A"],
+      ["C-tenant-B", "ws-B"],
+    ]);
+    const resolveWorkspaceId: ResolveWorkspaceIdFn = async ({ thread }) => {
+      return channelToWorkspace.get(thread.channelId) ?? null;
+    };
+
+    const userResolver = mock(
+      async (
+        _asker: { externalUserId: string },
+        _ctx: { workspaceId: string },
+      ) => ({ atlasUserId: "atlas-user-1" }),
+    );
+    const executeQueryProactive = mock(echoExecute);
+    const { chat, invokeMessage, invokeReaction } = makeChat();
+    await registerProactiveListener(
+      chat as unknown as Parameters<typeof registerProactiveListener>[0],
+      makeLogger(),
+      {
+        isEnabled: async () => true,
+        classify: yesLLM,
+        resolveWorkspaceId,
+        getWorkspaceConfig: defaultGetWorkspace,
+        getChannelConfigs: allowChannels("C-tenant-A", "C-tenant-B"),
+        userResolver,
+        executeQueryProactive,
+      },
+    );
+
+    const threadA = makeThread("C-tenant-A");
+    const threadB = makeThread("C-tenant-B");
+    await invokeMessage(threadA, makeMessage({ id: "M-A-1", userId: "U-shared" }));
+    await invokeMessage(threadB, makeMessage({ id: "M-B-1", userId: "U-shared" }));
+
+    // Reaction-back drives the answer flow (and therefore the resolver).
+    await invokeReaction({
+      added: true,
+      messageId: "M-A-1",
+      threadId: threadA.channelId,
+      thread: threadA,
+      user: { isMe: false, isBot: false, userId: "U-shared", userName: "bob" },
+      emoji: PROACTIVE_REACTION,
+      rawEmoji: "robot_face",
+      adapter: { name: "slack" },
+      raw: {},
+    });
+    await invokeReaction({
+      added: true,
+      messageId: "M-B-1",
+      threadId: threadB.channelId,
+      thread: threadB,
+      user: { isMe: false, isBot: false, userId: "U-shared", userName: "bob" },
+      emoji: PROACTIVE_REACTION,
+      rawEmoji: "robot_face",
+      adapter: { name: "slack" },
+      raw: {},
+    });
+
+    // Two resolver invocations, each carrying the originating tenant's
+    // workspaceId. Pre-#2624 the second arg didn't exist; assert both
+    // the shape and the value to pin the contract.
+    expect(userResolver).toHaveBeenCalledTimes(2);
+    expect(userResolver.mock.calls[0]![1]).toEqual({ workspaceId: "ws-A" });
+    expect(userResolver.mock.calls[1]![1]).toEqual({ workspaceId: "ws-B" });
+
+    // ExecuteQueryProactive context carries the same workspaceId so
+    // the host adapter can scope its tool gates.
+    expect(executeQueryProactive).toHaveBeenCalledTimes(2);
+    expect(
+      (executeQueryProactive.mock.calls[0]![1] as { workspaceId: string }).workspaceId,
+    ).toBe("ws-A");
+    expect(
+      (executeQueryProactive.mock.calls[1]![1] as { workspaceId: string }).workspaceId,
+    ).toBe("ws-B");
+  });
+
+  it("userResolver throw is per-tenant — logs workspaceId on the apology path", async () => {
+    // A resolver hiccup on tenant A must not silently route tenant A's
+    // asker through tenant B's workspace context. The listener logs at
+    // error with workspaceId so an operator triaging the apology
+    // posts can correlate to the right tenant.
+    const throwingResolver: ProactiveUserResolver = mock(async () => {
+      throw new Error("resolver-DB-down");
+    });
+    const log = makeLogger();
+    const { chat, invokeMessage, invokeReaction } = makeChat();
+    await registerProactiveListener(
+      chat as unknown as Parameters<typeof registerProactiveListener>[0],
+      log,
+      {
+        isEnabled: async () => true,
+        classify: yesLLM,
+        resolveWorkspaceId: makeResolver("ws-troubled"),
+        getWorkspaceConfig: defaultGetWorkspace,
+        getChannelConfigs: allowChannels("C-allowed"),
+        userResolver: throwingResolver,
+        executeQueryProactive: echoExecute,
+      },
+    );
+
+    const thread = makeThread("C-allowed");
+    await invokeMessage(thread, makeMessage({ id: "M1" }));
+    await invokeReaction({
+      added: true,
+      messageId: "M1",
+      threadId: thread.channelId,
+      thread,
+      user: { isMe: false, isBot: false, userId: "U-asker", userName: "asker" },
+      emoji: PROACTIVE_REACTION,
+      rawEmoji: "robot_face",
+      adapter: { name: "slack" },
+      raw: {},
+    });
+
+    // Apology posted, agent NEVER invoked.
+    expect(thread.post).toHaveBeenCalledTimes(1);
+    // Resolver received the per-event workspaceId, and the error log
+    // carries it (so triage can correlate).
+    expect(throwingResolver).toHaveBeenCalledWith(
+      expect.objectContaining({ externalUserId: "U-asker" }),
+      { workspaceId: "ws-troubled" },
+    );
+    const errorCalls = (log.error as unknown as {
+      mock: { calls: ReadonlyArray<ReadonlyArray<unknown>> };
+    }).mock.calls;
+    const errorCall = errorCalls.find((c) => {
+      const payload = c[0] as { workspaceId?: string };
+      return payload?.workspaceId === "ws-troubled";
+    });
+    expect(errorCall).toBeDefined();
   });
 });

--- a/plugins/chat/src/proactive/answerer.ts
+++ b/plugins/chat/src/proactive/answerer.ts
@@ -38,9 +38,41 @@ export interface ResolvedAsker {
   atlasUserId?: string;
 }
 
-/** Resolver: chat-platform identity → Atlas identity. */
+/**
+ * Per-event context passed to the user resolver (#2624).
+ *
+ * Carries the per-event `workspaceId` resolved by the listener so a
+ * multi-tenant host can distinguish "the same Slack user-id seen in
+ * tenant A vs tenant B". Pre-#2624 the resolver received only the
+ * platform identity and could only do a global lookup — on SaaS that
+ * collapses two tenants' askers onto whichever workspace the user
+ * happens to be a member of first.
+ *
+ * Kept as a separate object (Option 2 from the issue body) rather than
+ * inlined into {@link ProactiveAsker} so the asker stays a pure
+ * chat-platform identity while the workspace stays per-event context.
+ */
+export interface ProactiveUserResolverContext {
+  /** Atlas workspace id (`org_id`) the event belongs to. */
+  workspaceId: string;
+}
+
+/**
+ * Resolver: chat-platform identity → Atlas identity.
+ *
+ * Receives both the asker (platform identity) and a per-event context
+ * carrying the workspaceId. Hosts MUST scope the lookup by workspaceId
+ * — otherwise multi-tenant collisions silently route an unlinked
+ * tenant B asker to a tenant A Atlas user.
+ *
+ * Implementations may throw on infra failure; the listener's
+ * `safeResolveUser` catches the throw and refuses with the apology
+ * copy (no downgrade to the public-dataset path — that would silently
+ * bypass per-user RLS for a linked Atlas user).
+ */
 export type ProactiveUserResolver = (
   asker: ProactiveAsker,
+  ctx: ProactiveUserResolverContext,
 ) => Promise<ResolvedAsker>;
 
 /** Result returned by `executeQueryProactive`. */
@@ -96,6 +128,14 @@ export type ProactiveExecuteQuery = (
      * agent to the workspace's public-dataset allowlist.
      */
     atlasUserId: string | null;
+    /**
+     * Atlas workspace id the event belongs to (#2624). Threaded through
+     * from the listener's per-event resolution so the host can scope
+     * tool registries, allowlist lookups, and tenant-specific config
+     * by the right tenant on multi-tenant SaaS. Static-tenant hosts
+     * can ignore it.
+     */
+    workspaceId: string;
   },
 ) => Promise<ProactiveQueryResult>;
 

--- a/plugins/chat/src/proactive/index.ts
+++ b/plugins/chat/src/proactive/index.ts
@@ -64,6 +64,7 @@ export {
   type ProactiveExecuteQuery,
   type ProactiveQueryResult,
   type ProactiveUserResolver,
+  type ProactiveUserResolverContext,
   type ReactionAnswerDecision,
   type ResolvedAsker,
   type ShouldAnswerOnReactionInput,

--- a/plugins/chat/src/proactive/listener.ts
+++ b/plugins/chat/src/proactive/listener.ts
@@ -1091,7 +1091,7 @@ async function runAnswerFlow(
   recentAnswers: RecentAnswers,
 ): Promise<void> {
   const resolved: ResolveOutcome = config.userResolver
-    ? await safeResolveUser(config.userResolver, asker, log)
+    ? await safeResolveUser(config.userResolver, asker, workspaceId, log)
     : { kind: "unlinked" };
 
   // Resolver THREW → post the apology copy and return. Critical
@@ -1206,6 +1206,7 @@ async function runAnswerFlow(
         // allowlist. Nullable signature (vs an empty-string sentinel)
         // forces deliberate null handling on every host.
         atlasUserId: null,
+        workspaceId,
       });
     } catch (err) {
       log.error(
@@ -1265,6 +1266,7 @@ async function runAnswerFlow(
       threadId,
       asker,
       atlasUserId: resolved.atlasUserId,
+      workspaceId,
     });
   } catch (err) {
     log.error(
@@ -1558,10 +1560,11 @@ type ResolveOutcome =
 async function safeResolveUser(
   resolver: ProactiveUserResolver,
   asker: ProactiveAsker,
+  workspaceId: string,
   log: PluginLogger,
 ): Promise<ResolveOutcome> {
   try {
-    const resolved = await resolver(asker);
+    const resolved = await resolver(asker, { workspaceId });
     if (resolved.atlasUserId) {
       return { kind: "linked", atlasUserId: resolved.atlasUserId };
     }
@@ -1578,6 +1581,7 @@ async function safeResolveUser(
       {
         err: err instanceof Error ? err : new Error(String(err)),
         externalUserId: asker.externalUserId,
+        workspaceId,
       },
       "Proactive userResolver threw — refusing the answer (do NOT downgrade linked askers to public-dataset on resolver failure)",
     );


### PR DESCRIPTION
## Summary

Closes #2624. Threads the per-event `workspaceId` through the chat plugin's `ProactiveUserResolver` (and the host-side answer adapter) so multi-tenant SaaS scopes asker→Atlas lookups by tenant instead of collapsing them globally.

- **Contract change** (pre-customer clean break, matches #2620 / #2626 precedent): `ProactiveUserResolver = (asker, ctx: { workspaceId }) => Promise<…>` (Option 2 from the issue body). Also threads `workspaceId` into the `ProactiveExecuteQuery` context and the `createProactiveAnswerAdapter`'s `getPublicDataset` option.
- **New SaaS resolver factory** `createSlackProactiveUserResolver()` (`packages/api/src/lib/proactive/user-resolver.ts`): validates the workspaceId via `slack_installations.org_id`, returns `{ atlasUserId: undefined }` for every asker today. No Slack-user link table exists in core yet — the factory documents the hook point for a future link mechanism. Registry hiccups fall through to the unlinked (refuse-safe via the listener's public-dataset gate) path rather than surfacing as the apology copy.
- **Wires the adapter-side allowlist call** in `deploy/api/atlas.config.ts` so unlinked-asker answers now run against the right tenant's allowlist (was omitted pre-#2624 because the workspaceId couldn't be threaded through).

The unlinked path is now tenant-correct end-to-end. Linked-asker answering remains blocked until a Slack-user link mechanism lands as a follow-up — this PR is the structural unblock.

## Test plan
- [x] `bun run type` green
- [x] `bun run lint` no errors (only pre-existing warnings)
- [x] `bun run test` — all suites green (api 426/426, plus 22/159/25/11 across other workspaces)
- [x] New: 8 tests for `createSlackProactiveUserResolver` (non-Slack platform, empty/unknown/known workspaceId, throw fallthrough, no-normalization, no-DB self-hosted)
- [x] New: listener test pins `userResolver` is invoked with `{ workspaceId }` per-pending-entry on a two-tenant scenario
- [x] New: listener test pins the apology-path error log carries `workspaceId` for tenant-scoped triage
- [x] New: answer-adapter test pins `getPublicDataset(asker, { workspaceId })` receives the per-event workspaceId
- [x] Schema-drift / template-drift / EE-import-guard scripts all pass
- [x] `bun x syncpack lint` clean
- [ ] CI checks green on the PR head SHA