### PR TITLE
fix(web): #2637 — admin proactive-chat crash from analytics schema cache collision

### DIFF
--- a/packages/web/src/app/admin/proactive-chat/__tests__/analytics-schema.test.ts
+++ b/packages/web/src/app/admin/proactive-chat/__tests__/analytics-schema.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from "bun:test";
+import { AnalyticsResponseSchema } from "../page";
+
+/**
+ * Round-trip test for the production parse path in `/admin/proactive-chat`.
+ *
+ * Two consumers (`QuotaUsageIndicator`, `DecisionDrillDownPanel`) hit
+ * `/api/v1/admin/proactive/analytics` through `useAdminFetch`, which dedupes
+ * by `[ADMIN_FETCH_QUERY_KEY, path, ...deps]` and only runs the first
+ * mount's `queryFn`. Zod's `z.object` strips unrecognized keys, so the
+ * cached parsed value is only safe for the second consumer when both
+ * consumers agree on a schema that validates *every* slice they read.
+ *
+ * #2637 regression: previously, two partial schemas (one for `quota`, one
+ * for `summary`) split the validation, and whichever ran first stripped the
+ * other's slice from the cached value. The drill-down then crashed on
+ * `aggregate.data.summary.classifyCount` because `summary` was undefined.
+ *
+ * These tests pin the consolidated schema's invariants so a future PR that
+ * tries to split it back into partials has to delete an assertion.
+ */
+describe("AnalyticsResponseSchema round-trip", () => {
+  const FIXTURE = {
+    summary: {
+      classifyCount: 6,
+      reactCount: 2,
+    },
+    quota: {
+      classifyCountThisMonth: 6,
+      monthlyClassifierCap: null,
+      capReached: false,
+    },
+  };
+
+  test("parses a realistic API response and keeps both slices", () => {
+    const parsed = AnalyticsResponseSchema.parse(FIXTURE);
+    expect(parsed.summary.classifyCount).toBe(6);
+    expect(parsed.summary.reactCount).toBe(2);
+    expect(parsed.quota.classifyCountThisMonth).toBe(6);
+    expect(parsed.quota.monthlyClassifierCap).toBeNull();
+    expect(parsed.quota.capReached).toBe(false);
+  });
+
+  test("monthlyClassifierCap accepts a positive integer", () => {
+    const parsed = AnalyticsResponseSchema.parse({
+      ...FIXTURE,
+      quota: { ...FIXTURE.quota, monthlyClassifierCap: 10_000, capReached: true },
+    });
+    expect(parsed.quota.monthlyClassifierCap).toBe(10_000);
+    expect(parsed.quota.capReached).toBe(true);
+  });
+
+  test("rejects when `summary` slice is missing (drill-down crash repro)", () => {
+    const { summary: _omit, ...rest } = FIXTURE;
+    const result = AnalyticsResponseSchema.safeParse(rest);
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects when `quota` slice is missing (usage-bar would render undefined)", () => {
+    const { quota: _omit, ...rest } = FIXTURE;
+    const result = AnalyticsResponseSchema.safeParse(rest);
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects negative or non-integer counts in `summary`", () => {
+    expect(
+      AnalyticsResponseSchema.safeParse({
+        ...FIXTURE,
+        summary: { ...FIXTURE.summary, classifyCount: -1 },
+      }).success,
+    ).toBe(false);
+    expect(
+      AnalyticsResponseSchema.safeParse({
+        ...FIXTURE,
+        summary: { ...FIXTURE.summary, classifyCount: 1.5 },
+      }).success,
+    ).toBe(false);
+  });
+
+  test("ignores unknown server-additive keys without dropping required slices", () => {
+    // Forward-compat: the API route also returns `workspaceId` and
+    // `sinceMs`. Those keys must parse cleanly (Zod strip-unknown) while
+    // both required slices stay intact for the consumers.
+    const parsed = AnalyticsResponseSchema.parse({
+      workspaceId: "ws_123",
+      sinceMs: 2_592_000_000,
+      ...FIXTURE,
+    });
+    expect(parsed.summary.classifyCount).toBe(6);
+    expect(parsed.quota.capReached).toBe(false);
+  });
+});

--- a/packages/web/src/app/admin/proactive-chat/page.tsx
+++ b/packages/web/src/app/admin/proactive-chat/page.tsx
@@ -512,14 +512,21 @@ function MonthlyCapField({
 // ---------------------------------------------------------------------------
 
 // Both `QuotaUsageIndicator` and `DecisionDrillDownPanel` read this same
-// endpoint. TanStack Query dedupes by path and Zod's `z.object` strips
-// unrecognized keys, so two parallel `useAdminFetch` calls with partial
-// schemas would have one consumer's slice silently dropped from the cached
-// parsed value (#2637 regression — the drill-down's `summary.classifyCount`
-// access crashed when the quota indicator's schema parsed first). Validate
-// both slices in a single schema so the cached value is shaped for either
-// reader.
-const AnalyticsResponseSchema = z.object({
+// endpoint. `useAdminFetch` keys the TanStack Query cache by
+// `[ADMIN_FETCH_QUERY_KEY, path, ...deps]` and only the first mount's
+// `queryFn` runs — every later mount with the same key reads back the
+// already-parsed value. Zod's `z.object` strips unrecognized keys, so two
+// callers with disjoint partial schemas would have the *second* consumer
+// read a value that's already missing its slice (#2637 regression — the
+// drill-down crashed on `aggregate.data.summary.classifyCount` when the
+// quota indicator's partial schema parsed first). Keep both slices in one
+// shared schema so the cached value satisfies either reader. The same rule
+// applies to any future consumer added on this path or any `deps` it
+// passes; an endpoint-level `defineAdminEndpoint(path, schema)` helper is a
+// follow-up if this bug class recurs a third time.
+//
+// Exported for `__tests__/analytics-schema.test.ts` regression coverage.
+export const AnalyticsResponseSchema = z.object({
   summary: z.object({
     classifyCount: z.number().int().nonnegative(),
     reactCount: z.number().int().nonnegative(),
@@ -539,7 +546,16 @@ function QuotaUsageIndicator() {
     { schema: AnalyticsResponseSchema },
   );
 
-  if (loading || error || !data) return null;
+  if (loading) return null;
+  if (error) {
+    // Inline indicator under the cap input — surfacing a full ErrorBanner
+    // here would dwarf the input. Log so a 403 / 500 / `schema_mismatch`
+    // shows up in admin debug breadcrumbs instead of vanishing as a
+    // missing usage bar.
+    console.warn("QuotaUsageIndicator: analytics fetch failed", error);
+    return null;
+  }
+  if (!data) return null;
   const { classifyCountThisMonth, monthlyClassifierCap, capReached } = data.quota;
   if (monthlyClassifierCap === null) return null;
 
@@ -1107,8 +1123,6 @@ const EventsResponseSchema = z.object({
 });
 
 function DecisionDrillDownPanel() {
-  // Share the same schema as `QuotaUsageIndicator` so TanStack Query's
-  // path-keyed dedupe returns a value that's shaped for both consumers.
   const aggregate = useAdminFetch<AnalyticsResponse>(
     "/api/v1/admin/proactive/analytics",
     { schema: AnalyticsResponseSchema },
@@ -1118,12 +1132,21 @@ function DecisionDrillDownPanel() {
     { schema: EventsResponseSchema },
   );
 
+  // Surface either fetch's failure through the wrapper. Without this, an
+  // analytics-endpoint outage rendered the drill-down tiles with "—" /
+  // `0 / 0 reacted` — identical to the legitimate "no calls in window"
+  // state, hiding a real backend failure as fake-zero data.
+  const refetchAll = () => {
+    events.refetch();
+    aggregate.refetch();
+  };
+
   return (
     <AdminContentWrapper
-      loading={events.loading}
-      error={events.error}
+      loading={events.loading || aggregate.loading}
+      error={events.error ?? aggregate.error}
       feature="Proactive Chat"
-      onRetry={events.refetch}
+      onRetry={refetchAll}
       loadingMessage="Loading classifier decisions..."
     >
       {events.data ? (
@@ -1133,13 +1156,7 @@ function DecisionDrillDownPanel() {
             aggregateReact={aggregate.data?.summary.reactCount ?? null}
             reviewSummary={events.data.reviewSummary}
           />
-          <EventsTable
-            initial={events.data}
-            refetchAll={() => {
-              events.refetch();
-              aggregate.refetch();
-            }}
-          />
+          <EventsTable initial={events.data} refetchAll={refetchAll} />
         </div>
       ) : null}
     </AdminContentWrapper>

--- a/packages/web/src/app/admin/proactive-chat/page.tsx
+++ b/packages/web/src/app/admin/proactive-chat/page.tsx
@@ -511,7 +511,19 @@ function MonthlyCapField({
 // usage-bar against.
 // ---------------------------------------------------------------------------
 
+// Both `QuotaUsageIndicator` and `DecisionDrillDownPanel` read this same
+// endpoint. TanStack Query dedupes by path and Zod's `z.object` strips
+// unrecognized keys, so two parallel `useAdminFetch` calls with partial
+// schemas would have one consumer's slice silently dropped from the cached
+// parsed value (#2637 regression — the drill-down's `summary.classifyCount`
+// access crashed when the quota indicator's schema parsed first). Validate
+// both slices in a single schema so the cached value is shaped for either
+// reader.
 const AnalyticsResponseSchema = z.object({
+  summary: z.object({
+    classifyCount: z.number().int().nonnegative(),
+    reactCount: z.number().int().nonnegative(),
+  }),
   quota: z.object({
     classifyCountThisMonth: z.number().int().nonnegative(),
     monthlyClassifierCap: z.number().int().nonnegative().nullable(),
@@ -1094,17 +1106,12 @@ const EventsResponseSchema = z.object({
   }),
 });
 
-const AggregateForDrillSchema = z.object({
-  summary: z.object({
-    classifyCount: z.number().int().nonnegative(),
-    reactCount: z.number().int().nonnegative(),
-  }),
-});
-
 function DecisionDrillDownPanel() {
-  const aggregate = useAdminFetch<z.infer<typeof AggregateForDrillSchema>>(
+  // Share the same schema as `QuotaUsageIndicator` so TanStack Query's
+  // path-keyed dedupe returns a value that's shaped for both consumers.
+  const aggregate = useAdminFetch<AnalyticsResponse>(
     "/api/v1/admin/proactive/analytics",
-    { schema: AggregateForDrillSchema },
+    { schema: AnalyticsResponseSchema },
   );
   const events = useAdminFetch<z.infer<typeof EventsResponseSchema>>(
     "/api/v1/admin/proactive/events?since=30d&eventType=classify&limit=50",


### PR DESCRIPTION
## Summary
- **Primary fix:** `/admin/proactive-chat` crashed in prod with "This section failed to render. Try again or reload the page." after #2637 added the classifier drill-down. Both `QuotaUsageIndicator` and `DecisionDrillDownPanel` called `useAdminFetch` against `/api/v1/admin/proactive/analytics` but with *different* partial Zod schemas. `useAdminFetch` keys the TanStack Query cache by `[ADMIN_FETCH_QUERY_KEY, path, ...deps]` — only the first mount's `queryFn` runs; later mounts read back the already-parsed value. Zod's `z.object` strips unrecognized keys, so the second consumer always saw a value missing its slice and crashed on `aggregate.data?.summary.classifyCount`. Folded both slices into one shared `AnalyticsResponseSchema`.
- **Same bug class as #2444** (object-envelope vs array-transform on `/admin/connections`). The hook-level invariant ("same path → same schema") is comment-enforced. If this recurs a third time across the ~22 admin pages, the right fix is a `defineAdminEndpoint(path, schema)` helper that makes mismatched schemas unrepresentable. Filing follow-up only if it happens again.

## Additional changes from review
- **Silent-failure-hunter Finding 2 (HIGH):** `DecisionDrillDownPanel` only passed `events.error` into `AdminContentWrapper`, so an analytics-endpoint outage rendered the tiles with `—` / `0 / 0 reacted` — identical to the "no calls in window" state and hiding a real backend failure as fake-zero data. Now ORs both fetches' errors into the wrapper and shares one `refetchAll` so retry refreshes both halves. Stricter, since the consolidated schema is now more likely to throw `schema_mismatch`.
- **Silent-failure-hunter Finding 1:** `QuotaUsageIndicator` collapsed every failure (403 / 500 / `schema_mismatch`) into `return null`. Keep the silent render (full ErrorBanner would dwarf the cap input) but `console.warn` so Sentry/admin breadcrumbs catch the failure.
- **Comment-analyzer:** Dropped the redundant inner 2-line echo and tightened the schema preamble to mention the `deps`-aware queryKey shape and that the second consumer's `queryFn` never runs (it reads back the first's stripped result, not a fresh parse).
- **pr-test-analyzer:** Added page-local schema round-trip test at `packages/web/src/app/admin/proactive-chat/__tests__/analytics-schema.test.ts`, mirroring the `oauth-clients` / `sessions` precedent. Pins both-slices-required, count integrity, and forward-compat with extra server keys.

## Not addressed (out of scope)
- **`.strict()` on the schema:** would break forward-compat with backend additions; type-design-analyzer concurred.
- **`useAdminFetch` dev-mode warning for schema drift on same path:** code-reviewer flagged as a reasonable follow-up; cross-cutting hook change doesn't belong in a one-file hotfix PR.

## Repro before fix
1. Visit `https://app.useatlas.dev/admin/proactive-chat` while signed in as an admin.
2. Observe the red "This section failed to render" banner under the hero.
3. Console:
   ```
   TypeError: Cannot read properties of undefined (reading 'classifyCount')
   ```

## Test plan
- [x] `bun run type` passes (root tsgo + per-package builds).
- [x] `bun x eslint packages/web/src/app/admin/proactive-chat/` clean.
- [x] `bun test src/app/admin/proactive-chat/__tests__/analytics-schema.test.ts` — 6/6 pass.
- [x] `bun test src/ui/__tests__/use-admin-fetch.test.ts` — 41/41 pass (sibling #2444 collision tests unaffected).
- [ ] After deploy: reload `/admin/proactive-chat` in prod, confirm the page renders fully (Activation / Behavior / Channel overrides / Public dataset / Refused topics / Decision drill-down) with no console error.
- [ ] Confirm the quota usage bar and drill-down tiles both populate (they read different slices of the same cached response).
- [ ] Confirm a forced analytics-endpoint 500 now surfaces the `AdminContentWrapper` error state on the drill-down rather than fake-zero tiles.