### PR TITLE
refactor(api,plugins/chat): #2623 — items 4 + 5, enabled-gate doc + workspace_id CHECK

### DIFF
--- a/packages/api/src/lib/auth/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/auth/__tests__/migrate.test.ts
@@ -330,6 +330,7 @@ describe("migrateAuthTables", () => {
             { name: "0082_audit_log_parent_audit_id_deferrable.sql" },
             { name: "0083_dashboard_stage_changes.sql" },
             { name: "0084_proactive_classification_review.sql" },
+            { name: "0085_workspace_proactive_config_workspace_id_nonempty.sql" },
           ],
         };
       }

--- a/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
@@ -3798,6 +3798,21 @@ describeIfPg("migrate-pg (real Postgres)", () => {
     expect(rows[0].monthly_classifier_cap).toBeNull();
   }, PG_TEST_TIMEOUT_MS);
 
+  it("workspace_proactive_config: CHECK rejects empty workspace_id (#2623 item 5, migration 0085)", async () => {
+    let err: Error | null = null;
+    try {
+      await pool.query(
+        `INSERT INTO workspace_proactive_config (workspace_id) VALUES ('')`,
+      );
+    } catch (e) {
+      err = e instanceof Error ? e : new Error(String(e));
+    }
+    expect(err).not.toBeNull();
+    expect(err?.message).toMatch(
+      /chk_workspace_proactive_workspace_id_nonempty|23514|check constraint/i,
+    );
+  }, PG_TEST_TIMEOUT_MS);
+
   // ---------------------------------------------------------------------------
   // AnswerMeter end-to-end round-trip (#2296). recordMeterEvent ↔
   // summarizeMeterEvents has only been tested via the pure aggregator

--- a/packages/api/src/lib/db/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate.test.ts
@@ -96,8 +96,9 @@ describe("runMigrations", () => {
     // + 0081 (workspace_proactive_config.announcement_posted_at, #2300)
     // + 0082 (audit_log.parent_audit_id FK → DEFERRABLE)
     // + 0083 (dashboard_stage_changes, #2365)
-    // + 0084 (proactive_classification_review, #2622) = 85.
-    expect(count).toBe(85);
+    // + 0084 (proactive_classification_review, #2622)
+    // + 0085 (workspace_proactive_config.workspace_id <> '' CHECK, #2623 item 5) = 86.
+    expect(count).toBe(86);
 
     // Advisory lock acquired before anything else
     expect(queries[0]).toContain("pg_advisory_lock");
@@ -211,6 +212,7 @@ describe("runMigrations", () => {
         "0082_audit_log_parent_audit_id_deferrable.sql",
         "0083_dashboard_stage_changes.sql",
         "0084_proactive_classification_review.sql",
+        "0085_workspace_proactive_config_workspace_id_nonempty.sql",
       ],
     });
 

--- a/packages/api/src/lib/db/migrations/0085_workspace_proactive_config_workspace_id_nonempty.sql
+++ b/packages/api/src/lib/db/migrations/0085_workspace_proactive_config_workspace_id_nonempty.sql
@@ -1,0 +1,44 @@
+-- 0085 — workspace_proactive_config: CHECK (workspace_id <> '') (#2623 item 5).
+--
+-- Defense-in-depth on multi-tenant attribution. The proactive listener's
+-- enabled-gate already short-circuits empty workspaceId at the application
+-- layer (the #2620 follow-up — `packages/api/src/lib/proactive/enabled-gate.ts`
+-- treats `""` as the registration probe and skips the SELECT entirely). A
+-- CHECK on the column locks the same invariant at the schema layer so a
+-- buggy upsert that drifts past the gate can never create a row that would
+-- mis-attribute proactive behaviour to "no tenant".
+--
+-- Pre-existing empty rows: dropped before adding the constraint. An empty
+-- workspace_id row is structurally orphaned — no consumer of this table
+-- (admin/proactive routes, enabled-gate, AnswerMeter, AnnouncementCoordinator)
+-- ever queries with `workspace_id = ''`, so dropping the row reclaims nothing
+-- that was being read. The `RAISE NOTICE` makes the drop visible in
+-- migration logs so an operator who sees a non-zero count can investigate
+-- whatever wrote the row (the gate flips to `""` only during the
+-- registration probe, never during a real upsert path).
+--
+-- Scope: just `workspace_proactive_config`. Other proactive tables
+-- (`channel_proactive_config`, `proactive_pauses`, `proactive_meter_events`,
+-- `proactive_public_dataset`, `proactive_classification_review`) carry
+-- `workspace_id` columns too and would benefit from the same guard, but
+-- defense-in-depth on the *master toggle* row is the leverage point — every
+-- other proactive write path checks the master row's `enabled=true` first,
+-- so a constraint here closes the only persistence surface where a
+-- tenant-less write could begin a proactive session.
+
+DO $$
+DECLARE
+  empty_count INTEGER;
+BEGIN
+  SELECT COUNT(*) INTO empty_count
+    FROM workspace_proactive_config
+   WHERE workspace_id = '';
+  IF empty_count > 0 THEN
+    RAISE NOTICE 'Dropping % workspace_proactive_config row(s) with empty workspace_id before adding CHECK', empty_count;
+    DELETE FROM workspace_proactive_config WHERE workspace_id = '';
+  END IF;
+END $$;
+
+ALTER TABLE workspace_proactive_config
+  ADD CONSTRAINT chk_workspace_proactive_workspace_id_nonempty
+  CHECK (workspace_id <> '');

--- a/packages/api/src/lib/db/migrations/0085_workspace_proactive_config_workspace_id_nonempty.sql
+++ b/packages/api/src/lib/db/migrations/0085_workspace_proactive_config_workspace_id_nonempty.sql
@@ -12,10 +12,14 @@
 -- workspace_id row is structurally orphaned — no consumer of this table
 -- (admin/proactive routes, enabled-gate, AnswerMeter, AnnouncementCoordinator)
 -- ever queries with `workspace_id = ''`, so dropping the row reclaims nothing
--- that was being read. The `RAISE NOTICE` makes the drop visible in
--- migration logs so an operator who sees a non-zero count can investigate
--- whatever wrote the row (the gate flips to `""` only during the
--- registration probe, never during a real upsert path).
+-- that was being read. (The non-empty invariant on call-site `workspaceId`
+-- is enforced upstream: admin routes derive it from `AuthContext.orgId`
+-- which Better Auth never sets to `""`, and the listener path resolves it
+-- via the host's `resolveWorkspaceId` and short-circuits on null. Only
+-- `enabled-gate.ts` has an explicit `''` short-circuit because it's the
+-- one path that *intentionally* probes with the empty sentinel.) The
+-- `RAISE NOTICE` makes the drop visible in migration logs so an operator
+-- who sees a non-zero count can investigate whatever wrote the row.
 --
 -- Scope: just `workspace_proactive_config`. Other proactive tables
 -- (`channel_proactive_config`, `proactive_pauses`, `proactive_meter_events`,

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -2051,6 +2051,10 @@ export const workspaceProactiveConfig = pgTable(
       "chk_workspace_proactive_monthly_cap_nonneg",
       sql`${t.monthlyClassifierCap} IS NULL OR ${t.monthlyClassifierCap} >= 0`,
     ),
+    check(
+      "chk_workspace_proactive_workspace_id_nonempty",
+      sql`${t.workspaceId} <> ''`,
+    ),
   ],
 );
 

--- a/packages/api/src/lib/proactive/enabled-gate.ts
+++ b/packages/api/src/lib/proactive/enabled-gate.ts
@@ -58,6 +58,23 @@
  *                          Enterprise cache untouched.
  *   - Workspace row missing → SELECT returns 0 rows → treats as `enabled=false`.
  *
+ * **Transient-retry caveat — registration-only callers can wedge.** The
+ * "leave `enterpriseEnabled` as `undefined` so the next call retries"
+ * contract only helps callers that invoke the gate again. The proactive
+ * listener (`plugins/chat/src/proactive/listener.ts:306`) calls
+ * `isEnabled("")` once at registration and short-circuits to a no-op
+ * handle (`recentAnswers: null`) if it returns falsy — no per-event
+ * call ever fires, so a transient runtime defect at boot becomes
+ * permanent for the process lifetime. The mitigation is at the call
+ * site, not here: if the registration is load-bearing, wrap it in
+ * exponential-backoff retry (e.g. 3 attempts at 1s / 5s / 30s) or call
+ * `__reset()` on a periodic timer. The gate intentionally stays
+ * single-attempt — adding retry here would couple the boot path to a
+ * scheduler the gate doesn't own. Today the proactive listener is
+ * best-effort (process keeps running, other bridge features unaffected)
+ * so we accept the wedge; revisit if SaaS dogfood surfaces a
+ * registration regression.
+ *
  * The factory captures a `ManagedRuntime` at boot (the host wiring slice
  * passes `getEnterpriseRuntime()` from `lib/effect/enterprise-layer.ts`),
  * so this module doesn't import `@atlas/ee` directly — the EE check flows

--- a/packages/api/src/lib/proactive/enabled-gate.ts
+++ b/packages/api/src/lib/proactive/enabled-gate.ts
@@ -61,19 +61,20 @@
  * **Transient-retry caveat — registration-only callers can wedge.** The
  * "leave `enterpriseEnabled` as `undefined` so the next call retries"
  * contract only helps callers that invoke the gate again. The proactive
- * listener (`plugins/chat/src/proactive/listener.ts:306`) calls
- * `isEnabled("")` once at registration and short-circuits to a no-op
- * handle (`recentAnswers: null`) if it returns falsy — no per-event
- * call ever fires, so a transient runtime defect at boot becomes
- * permanent for the process lifetime. The mitigation is at the call
- * site, not here: if the registration is load-bearing, wrap it in
- * exponential-backoff retry (e.g. 3 attempts at 1s / 5s / 30s) or call
- * `__reset()` on a periodic timer. The gate intentionally stays
- * single-attempt — adding retry here would couple the boot path to a
- * scheduler the gate doesn't own. Today the proactive listener is
- * best-effort (process keeps running, other bridge features unaffected)
- * so we accept the wedge; revisit if SaaS dogfood surfaces a
- * registration regression.
+ * listener's `registerProactiveListener` calls `isEnabled("")` once at
+ * boot and, if it returns falsy, short-circuits to a no-op handle
+ * (`recentAnswers: null`) without registering any per-event handlers.
+ * Per-message hooks are wired up only on the truthy branch — so a
+ * transient runtime defect at the boot probe becomes permanent for the
+ * process lifetime, because no later call exists to exercise the retry.
+ * The mitigation is at the call site, not here: if the registration is
+ * load-bearing, wrap it in exponential-backoff retry (e.g. 3 attempts
+ * at 1s / 5s / 30s) or call `__reset()` on a periodic timer. The gate
+ * intentionally stays single-attempt — adding retry here would couple
+ * the boot path to a scheduler the gate doesn't own. Today the
+ * proactive listener is best-effort (process keeps running, other
+ * bridge features unaffected) so we accept the wedge; revisit if SaaS
+ * dogfood surfaces a registration regression.
  *
  * The factory captures a `ManagedRuntime` at boot (the host wiring slice
  * passes `getEnterpriseRuntime()` from `lib/effect/enterprise-layer.ts`),

--- a/plugins/chat/src/proactive/listener.ts
+++ b/plugins/chat/src/proactive/listener.ts
@@ -303,6 +303,15 @@ export async function registerProactiveListener(
   // `false` on a row-missing lookup with `$1 = ''`). If EE isn't loaded,
   // registration short-circuits at line 295-297. Real per-event calls
   // pass actual workspaceIds.
+  //
+  // Single-attempt by design. The host gate's transient-retry contract
+  // (`enabled-gate.ts` — "leave `enterpriseEnabled` undefined so the next
+  // call retries") only fires when a per-event call follows. We never
+  // make one — a falsy result here returns a no-op handle and that's
+  // the end of it, so a boot-time runtime defect wedges proactive for
+  // the process lifetime. Accepted because proactive is best-effort
+  // (the rest of the bridge stays up). If SaaS dogfood surfaces a
+  // registration regression, wrap this in exponential-backoff retry.
   const enabledAtRegistration = await config.isEnabled("");
   if (!enabledAtRegistration) {
     log.debug("Proactive listener not registered — gate is closed");

--- a/plugins/chat/src/proactive/listener.ts
+++ b/plugins/chat/src/proactive/listener.ts
@@ -301,17 +301,18 @@ export async function registerProactiveListener(
   // `isEnabled` short-circuits on `""` and answers only the enterprise
   // check (skipping the workspace SELECT, which would otherwise resolve
   // `false` on a row-missing lookup with `$1 = ''`). If EE isn't loaded,
-  // registration short-circuits at line 295-297. Real per-event calls
-  // pass actual workspaceIds.
+  // registration short-circuits to the no-op handle below. Real
+  // per-event calls pass actual workspaceIds.
   //
   // Single-attempt by design. The host gate's transient-retry contract
   // (`enabled-gate.ts` — "leave `enterpriseEnabled` undefined so the next
-  // call retries") only fires when a per-event call follows. We never
-  // make one — a falsy result here returns a no-op handle and that's
-  // the end of it, so a boot-time runtime defect wedges proactive for
-  // the process lifetime. Accepted because proactive is best-effort
-  // (the rest of the bridge stays up). If SaaS dogfood surfaces a
-  // registration regression, wrap this in exponential-backoff retry.
+  // call retries") only fires when a per-event call follows. On the
+  // falsy branch we return a no-op handle without registering any
+  // event hooks, so no later call exists to exercise the retry — a
+  // boot-time runtime defect wedges proactive for the process lifetime.
+  // Accepted because proactive is best-effort (the rest of the bridge
+  // stays up). If SaaS dogfood surfaces a registration regression, wrap
+  // this in exponential-backoff retry.
   const enabledAtRegistration = await config.isEnabled("");
   if (!enabledAtRegistration) {
     log.debug("Proactive listener not registered — gate is closed");


### PR DESCRIPTION
## Summary

- **Item 4 (doc only).** `enabled-gate.ts` already retries transient runtime defects on the *next call* — but the proactive listener only ever calls `isEnabled("")` once at registration and drops the closure on falsy. A boot-time blip wedges proactive for the process. Documented at both ends (the gate's failure-modes block + the listener call site) so the wedge is visible to future readers. No behaviour change.
- **Item 5 (migration + smoke).** `CHECK (workspace_id <> '')` on `workspace_proactive_config`. Defense-in-depth on top of the application-layer gate that already short-circuits empty workspaceId. Migration 0085 also defensively `DELETE`s any pre-existing empty rows (with `RAISE NOTICE`) before adding the constraint — empty rows are structurally orphaned, no consumer queries them.

Drizzle schema.ts mirrors the new CHECK. `migrate.test.ts` count bumped (85 → 86) + migration list appended. New real-PG smoke pins INSERT-with-empty-workspace_id → SQLSTATE 23514.

## Out of scope (closes #2623 partially)

- **Item 3 — already landed in #2632** (refuseFeedbackSubcommand helper). Verified at bridge.ts:989-1014, 1029-1036, 1071-1074.
- **Item 1 — discriminated unions on ProactiveListenerConfig.** Breaking; only worth a bundled 1.5.x.
- **Item 2 — ResolverEventLite.** Conflicts with #2641 (active) on types.ts / answerer.ts. Pair with that PR.
- **Item 6 — sentinel "called exactly once" cache test.** Conflicts with #2638 (active) on listener.ts. Pair with that PR.

After this lands, #2623 still has items 1/2/6 open. Will leave a comment on the issue with the trail and close when 2/6 land (item 1 stays as 1.5.x backlog candidate).

## Test plan

- [x] `bash scripts/check-schema-drift.sh` — 77 mirrored tables, drift clean.
- [x] `bun run lint` — 0 errors (pre-existing warnings unchanged).
- [x] `bun run type` — green.
- [x] `cd packages/api && bun test src/lib/db/__tests__/migrate.test.ts` — 58/58 green (count assert + appliedMigrations list updated).
- [x] `cd plugins/chat && bun test src/proactive/__tests__/listener.test.ts src/bridge.test.ts` — 253/253 green (doc-comment-only changes confirmed no runtime impact).
- [x] `cd packages/api && bun run scripts/test-isolated.ts --since HEAD~3` — 5/5 green (enabled-gate, admin-plugins, registry-health, user-resolver, answer-adapter).
- [ ] Real-PG smoke (`migrate-pg.test.ts`) — runs in CI's `api-tests` job with the Postgres service container (no local `TEST_DATABASE_URL` available in this worktree).