### PR TITLE
fix(plugins/chat): #2638 — proactive DM unsubscribe via chat.onDirectMessage

### DIFF
--- a/e2e/surfaces/slack-proactive.test.ts
+++ b/e2e/surfaces/slack-proactive.test.ts
@@ -42,11 +42,14 @@
  *      registered or threw inside its outer `try` block (see #2638 for
  *      the DM-routing variant where this would otherwise mask a bug).
  *
- *   4. DM `unsubscribe` is *unreachable* via `onNewMessage` (chat SDK
- *      routes DMs to mention handlers). Documented as such — the test
- *      asserts `mockResolveWorkspaceId` was *not* called for the DM
- *      event, pinning the production gap until #2638 lands an
- *      `onDirectMessage` registration.
+ *   4. DM `unsubscribe` lands as `user-optout` via `onDirectMessage`
+ *      (#2638). Pre-#2638 the proactive listener only registered
+ *      `chat.onNewMessage(/.+/)` — but the chat SDK routes DM events
+ *      to `directMessageHandlers` (then `mentionHandlers`), so the
+ *      `unsubscribe` branch was unreachable in production. #2638 added
+ *      an `onDirectMessage` registration; this test exercises the full
+ *      DM webhook → SDK dispatch → DM handler → `onPauseRequest` chain
+ *      end to end.
  *
  * Plugin webhook only — the legacy `/api/v1/slack/*` slash +
  * interaction paths stay covered by `slack.test.ts`.
@@ -749,22 +752,20 @@ describe("E2E: chat-interaction webhook — kill switch (#2607 slice trail)", ()
   });
 
   // ---------------------------------------------------------------------
-  // DM `unsubscribe` is a documented production gap (#2638), not a
-  // working kill-switch layer. The proactive listener's
-  // `chat.onNewMessage(/.+/)` handler (see the `detectUnsubscribeDM`
-  // branch in `plugins/chat/src/proactive/listener.ts`) checks for DM
-  // unsubscribe — but the chat SDK routes DMs to mention handlers, not
-  // `onNewMessage`, when no `chat.onDirectMessage` handler is
-  // registered. So the listener's onNewMessage handler *never fires*
-  // for DMs in production.
+  // #2638 — DM unsubscribe lands as `user-optout` via the listener's
+  // `onDirectMessage` registration.
   //
-  // This test pins that gap explicitly: `mockResolveWorkspaceId` must
-  // NOT have been called for the DM event (proof the listener didn't
-  // run). A naive "no meter rows landed" assertion would silently pass
-  // whether the listener fired-and-gated or never fired at all — the
-  // earlier draft of this test had exactly that hole (#2633 review).
+  // Pre-#2638 this was a documented production gap: the listener only
+  // registered `chat.onNewMessage(/.+/)`, but the chat SDK routes DM
+  // events to `directMessageHandlers` (then `mentionHandlers`), never
+  // to `onNewMessage` patterns. The unsubscribe branch sat inside the
+  // pattern handler and was unreachable for DMs in production. #2638
+  // added the second registration; this test drives the full chain
+  // end to end so a future regression that drops the `onDirectMessage`
+  // registration (or breaks DM webhook dispatch) fails here, not in
+  // a customer's #atlas-questions Slack workspace.
   // ---------------------------------------------------------------------
-  it("DM unsubscribe — proactive listener does NOT fire for DMs (documents production gap #2638)", async () => {
+  it("DM unsubscribe — fires user-optout onPauseRequest via onDirectMessage (#2638)", async () => {
     const payload = makeEventPayload({
       type: "message",
       text: "unsubscribe",
@@ -776,42 +777,22 @@ describe("E2E: chat-interaction webhook — kill switch (#2607 slice trail)", ()
     const res = await app.fetch(makeSignedEventRequest(payload));
     expect(res.status).toBe(200);
 
-    // Long enough that, if the listener WERE wired for DMs, its first
-    // await (`resolveWorkspaceId`) would have landed. The negative
-    // assertion below catches the day #2638 ships an `onDirectMessage`
-    // registration without updating this test — it will start failing
-    // (the gap is closed) and the `.todo` below can be promoted to a
-    // real assertion in the same PR.
-    await new Promise((r) => setTimeout(r, 200));
-    expect(mockResolveWorkspaceId).not.toHaveBeenCalled();
-    expectNoProactiveActivity();
-    expect(mockPauseRequest).not.toHaveBeenCalled();
-  });
-
-  // ---------------------------------------------------------------------
-  // TODO(#2638): DM `unsubscribe` should also fire `onPauseRequest`
-  // with a `user-optout` row so the asker is removed from proactive
-  // workspace-wide. When the listener adds a
-  // `chat.onDirectMessage(...)` registration that re-dispatches to its
-  // unsubscribe branch, drop the `.todo`, update the test above to
-  // assert `mockResolveWorkspaceId` *was* called, and remove this
-  // block (its assertion will move into a real test).
-  // ---------------------------------------------------------------------
-  it.todo("DM unsubscribe — fires user-optout onPauseRequest (blocked by #2638: listener missing onDirectMessage registration)", async () => {
-    const payload = makeEventPayload({
-      type: "message",
-      text: "unsubscribe",
-      ts: "1700000023.000700",
-      channel: DM_CHANNEL_ID,
-      channelType: "im",
-    });
-    const res = await app.fetch(makeSignedEventRequest(payload));
-    expect(res.status).toBe(200);
+    // Wait for the pause-registry write to land. The DM handler awaits
+    // `resolveWorkspaceId` → `isEnabled` → `onPauseRequest`; a green
+    // assertion proves all three ran. A naive "200 OK + sleep" check
+    // would silently pass if the handler never fired (the production
+    // gap pre-#2638), so we assert on the write side-effect directly.
     await waitFor(() => pauseRequests.length > 0);
+    expect(pauseRequests).toHaveLength(1);
     const req = pauseRequests[0]!;
     expect(req.layer).toBe("user-optout");
     expect(req.workspaceId).toBe(WORKSPACE_ID);
     expect(req.userId).toBe(USER_ID);
     expect(req.channelId).toBeNull();
+
+    // Belt + braces: the unsubscribe branch must short-circuit BEFORE
+    // classification — paying an LLM call for a mute message would
+    // defeat the cost-of-silence contract the kill switch promises.
+    expectNoProactiveActivity();
   });
 });

--- a/e2e/surfaces/slack-proactive.test.ts
+++ b/e2e/surfaces/slack-proactive.test.ts
@@ -827,5 +827,13 @@ describe("E2E: chat-interaction webhook — kill switch (#2607 slice trail)", ()
     // classification — paying an LLM call for a mute message would
     // defeat the cost-of-silence contract the kill switch promises.
     expectNoProactiveActivity();
+    // The bridge ALSO registers `onDirectMessage` (to preserve the
+    // chat-with-bot DM path), so the SDK calls both handlers for the
+    // same DM. Without the bridge's `detectUnsubscribeDM` short-circuit
+    // the agent would silently run `executeQuery("unsubscribe")` and
+    // post a confused reply alongside the user-optout write. Pin
+    // both halves of the "silent unsubscribe" contract.
+    expect(executeQueryCalls).toHaveLength(0);
+    expect(stubWebClientPostCalls.filter((c) => c.method === "chat.postMessage")).toHaveLength(0);
   });
 });

--- a/e2e/surfaces/slack-proactive.test.ts
+++ b/e2e/surfaces/slack-proactive.test.ts
@@ -42,14 +42,15 @@
  *      registered or threw inside its outer `try` block (see #2638 for
  *      the DM-routing variant where this would otherwise mask a bug).
  *
- *   4. DM `unsubscribe` lands as `user-optout` via `onDirectMessage`
- *      (#2638). Pre-#2638 the proactive listener only registered
- *      `chat.onNewMessage(/.+/)` — but the chat SDK routes DM events
- *      to `directMessageHandlers` (then `mentionHandlers`), so the
- *      `unsubscribe` branch was unreachable in production. #2638 added
- *      an `onDirectMessage` registration; this test exercises the full
- *      DM webhook → SDK dispatch → DM handler → `onPauseRequest` chain
- *      end to end.
+ *   4. DM behaviour (#2638) — dual coverage. The SDK runs DM
+ *      handlers and returns; mention/`onNewMessage` paths only fire
+ *      for DMs when no DM handler is registered. Pre-#2638 the
+ *      proactive listener's `unsubscribe` branch sat inside
+ *      `onNewMessage` and was unreachable. Two tests pin both halves
+ *      of the dual `onDirectMessage` registration: the proactive
+ *      listener writes `user-optout` on `unsubscribe`, and the
+ *      bridge's chat-with-bot path keeps reaching `executeQuery` for
+ *      every other DM.
  *
  * Plugin webhook only — the legacy `/api/v1/slack/*` slash +
  * interaction paths stay covered by `slack.test.ts`.
@@ -752,18 +753,50 @@ describe("E2E: chat-interaction webhook — kill switch (#2607 slice trail)", ()
   });
 
   // ---------------------------------------------------------------------
-  // #2638 — DM unsubscribe lands as `user-optout` via the listener's
-  // `onDirectMessage` registration.
+  // #2638 — Non-unsubscribe DMs still reach `executeQuery` through the
+  // bridge's `onDirectMessage` handler.
   //
-  // Pre-#2638 this was a documented production gap: the listener only
-  // registered `chat.onNewMessage(/.+/)`, but the chat SDK routes DM
-  // events to `directMessageHandlers` (then `mentionHandlers`), never
-  // to `onNewMessage` patterns. The unsubscribe branch sat inside the
-  // pattern handler and was unreachable for DMs in production. #2638
-  // added the second registration; this test drives the full chain
-  // end to end so a future regression that drops the `onDirectMessage`
-  // registration (or breaks DM webhook dispatch) fails here, not in
-  // a customer's #atlas-questions Slack workspace.
+  // The proactive listener registers `onDirectMessage` for unsubscribe
+  // detection (test below), which makes the SDK route DM events to
+  // direct-message handlers and stop after the loop — mention handlers
+  // never fire for DMs. Without the bridge ALSO registering
+  // `onDirectMessage`, the chat-with-bot DM path would silently
+  // disappear ("what is MRR?" in a DM would land at the proactive
+  // listener's `if (isDM) return;` short-circuit and nothing else).
+  // This test pins both halves of the dual-registration contract.
+  // ---------------------------------------------------------------------
+  it("DM `what is MRR?` reaches executeQuery via bridge.onDirectMessage (#2638)", async () => {
+    const payload = makeEventPayload({
+      type: "message",
+      text: "what was MRR last month?",
+      ts: "1700000030.000800",
+      channel: DM_CHANNEL_ID,
+      channelType: "im",
+    });
+    const res = await app.fetch(makeSignedEventRequest(payload));
+    expect(res.status).toBe(200);
+
+    await waitFor(() => executeQueryCalls.length > 0);
+    expect(executeQueryCalls).toHaveLength(1);
+    expect(executeQueryCalls[0]!.adapterName).toBe("slack");
+    expect(executeQueryCalls[0]!.question).toContain("MRR");
+
+    // The proactive listener's DM short-circuit kicks in before
+    // classify — no classify / react meter rows should land. If they
+    // do, the listener has started running its channel-only flow on
+    // DMs, burning LLM tokens on every chat-with-bot message.
+    expectNoProactiveActivity();
+    // No unsubscribe match → no pause-registry write.
+    expect(pauseRequests).toHaveLength(0);
+  });
+
+  // ---------------------------------------------------------------------
+  // #2638 — DM unsubscribe lands as `user-optout` via the listener's
+  // `onDirectMessage` registration. Pre-#2638 this was a production
+  // gap: the SDK runs DM handlers and returns, never reaching mention
+  // handlers or `onNewMessage` patterns where the unsubscribe branch
+  // lived. End-to-end signal so a future regression fails here, not
+  // in a customer's #atlas-questions Slack workspace.
   // ---------------------------------------------------------------------
   it("DM unsubscribe — fires user-optout onPauseRequest via onDirectMessage (#2638)", async () => {
     const payload = makeEventPayload({

--- a/plugins/chat/src/bridge.ts
+++ b/plugins/chat/src/bridge.ts
@@ -24,7 +24,7 @@
  */
 
 import { Chat, Modal, TextInput, emoji as chatEmoji } from "chat";
-import type { Adapter, StateAdapter, Lock, CardElement, FileUpload, StreamChunk } from "chat";
+import type { Adapter, StateAdapter, Lock, CardElement, FileUpload, Message, StreamChunk, Thread } from "chat";
 import { toModalElement } from "chat/jsx-runtime";
 import type { PluginLogger } from "@useatlas/plugin-sdk";
 import type {
@@ -708,21 +708,19 @@ export function createChatBridge(
   // --- onNewMention + onDirectMessage: first interaction in a thread ---
   //
   // Both handlers share the same body. Pre-#2638 the chat SDK
-  // (`chat@4.23.0`, `dispatchToHandlers`) marked any DM as a mention
-  // when no `onDirectMessage` handler was registered, so a single
-  // `onNewMention` registration caught both @-mentions in channels and
-  // 1:1 DMs to the bot. #2638 added `onDirectMessage` on the proactive
-  // listener (for DM `unsubscribe` detection), which makes the SDK
-  // route DMs to direct-message handlers and skip mention handlers.
-  // Without the explicit DM registration below, the chat-with-bot DM
-  // path would silently stop working — DM "what is MRR?" would no
-  // longer reach `executeQuery`. Both registrations run independently
-  // (the SDK loops every DM handler before returning); the proactive
-  // listener handles `unsubscribe` short-circuits, this handler
-  // handles every other DM the same way it always has.
+  // (`dispatchToHandlers`) marked any DM as a mention when no
+  // `onDirectMessage` was registered, so a single `onNewMention`
+  // registration caught both @-mentions and 1:1 DMs. #2638 added
+  // `onDirectMessage` on the proactive listener; once any DM handler
+  // is registered the SDK runs DM handlers and returns without
+  // touching mention handlers. Without the explicit DM registration
+  // below, the chat-with-bot DM path ("what is MRR?" in a DM) would
+  // silently stop reaching `executeQuery`. The SDK iterates every
+  // registered DM handler before returning, so the proactive
+  // listener's unsubscribe handler and this one fire independently.
   const handleMentionOrDM = async (
-    thread: Parameters<Parameters<typeof chat.onNewMention>[0]>[0],
-    message: Parameters<Parameters<typeof chat.onNewMention>[0]>[1],
+    thread: Thread,
+    message: Message,
   ): Promise<void> => {
     const threadId = `${thread.adapter.name}:${thread.id}`;
     const question = message.text?.trim();
@@ -859,11 +857,6 @@ export function createChatBridge(
   };
 
   chat.onNewMention(handleMentionOrDM);
-  // Preserve the chat-with-bot DM path now that the proactive listener
-  // also registers `onDirectMessage` (#2638). The SDK routes DM events
-  // to all registered DM handlers before returning, so this fires
-  // alongside the proactive unsubscribe handler instead of being
-  // bypassed by mention-handler routing as it was pre-#2638.
   chat.onDirectMessage(handleMentionOrDM);
 
   // --- onSubscribedMessage: follow-up in a subscribed thread ---

--- a/plugins/chat/src/bridge.ts
+++ b/plugins/chat/src/bridge.ts
@@ -48,6 +48,7 @@ import {
 import { createReactionLifecycle } from "./features/reactions";
 import type { IReactionLifecycle } from "./features/reactions";
 import { handleProactiveFeedbackSlash, registerProactiveListener } from "./proactive/listener";
+import { detectUnsubscribeDM } from "./proactive/pause";
 import type { RecentAnswers } from "./proactive/feedback";
 import { parseFeedbackSlashArgs } from "./proactive/feedback";
 
@@ -727,6 +728,18 @@ export function createChatBridge(
 
     if (!question) {
       log.debug({ threadId }, "Empty mention received, ignoring");
+      return;
+    }
+
+    // DM `unsubscribe` is owned by the proactive listener's
+    // `onDirectMessage` handler (writes `user-optout`). The SDK
+    // invokes every registered DM handler for the same event, so
+    // without this short-circuit `executeQuery` would also run on
+    // "unsubscribe" — producing a confused agent reply alongside the
+    // silent opt-out write. Skip silently; the proactive handler is
+    // the sole responder for this text.
+    if (thread.isDM === true && detectUnsubscribeDM(question)) {
+      log.debug({ threadId }, "DM unsubscribe — bridge defers to proactive listener");
       return;
     }
 

--- a/plugins/chat/src/bridge.ts
+++ b/plugins/chat/src/bridge.ts
@@ -705,8 +705,25 @@ export function createChatBridge(
     );
   }
 
-  // --- onNewMention: first interaction in a thread ---
-  chat.onNewMention(async (thread, message) => {
+  // --- onNewMention + onDirectMessage: first interaction in a thread ---
+  //
+  // Both handlers share the same body. Pre-#2638 the chat SDK
+  // (`chat@4.23.0`, `dispatchToHandlers`) marked any DM as a mention
+  // when no `onDirectMessage` handler was registered, so a single
+  // `onNewMention` registration caught both @-mentions in channels and
+  // 1:1 DMs to the bot. #2638 added `onDirectMessage` on the proactive
+  // listener (for DM `unsubscribe` detection), which makes the SDK
+  // route DMs to direct-message handlers and skip mention handlers.
+  // Without the explicit DM registration below, the chat-with-bot DM
+  // path would silently stop working — DM "what is MRR?" would no
+  // longer reach `executeQuery`. Both registrations run independently
+  // (the SDK loops every DM handler before returning); the proactive
+  // listener handles `unsubscribe` short-circuits, this handler
+  // handles every other DM the same way it always has.
+  const handleMentionOrDM = async (
+    thread: Parameters<Parameters<typeof chat.onNewMention>[0]>[0],
+    message: Parameters<Parameters<typeof chat.onNewMention>[0]>[1],
+  ): Promise<void> => {
     const threadId = `${thread.adapter.name}:${thread.id}`;
     const question = message.text?.trim();
 
@@ -839,7 +856,15 @@ export function createChatBridge(
         );
       });
     }
-  });
+  };
+
+  chat.onNewMention(handleMentionOrDM);
+  // Preserve the chat-with-bot DM path now that the proactive listener
+  // also registers `onDirectMessage` (#2638). The SDK routes DM events
+  // to all registered DM handlers before returning, so this fires
+  // alongside the proactive unsubscribe handler instead of being
+  // bypassed by mention-handler routing as it was pre-#2638.
+  chat.onDirectMessage(handleMentionOrDM);
 
   // --- onSubscribedMessage: follow-up in a subscribed thread ---
   chat.onSubscribedMessage(async (thread, message) => {

--- a/plugins/chat/src/proactive/__tests__/listener.test.ts
+++ b/plugins/chat/src/proactive/__tests__/listener.test.ts
@@ -1,11 +1,19 @@
 /**
  * Tests for the proactive listener wiring.
  *
- * We capture the functions passed to `chat.onNewMessage`, `chat.onReaction`,
- * and `chat.onAction` and invoke them directly with stand-in thread,
- * message, reaction-event, and action-event objects. That keeps the
- * test free of any real Chat SDK plumbing while still proving the
- * wiring is correct.
+ * We capture the functions passed to `chat.onNewMessage`,
+ * `chat.onDirectMessage`, `chat.onReaction`, and `chat.onAction` and
+ * invoke them directly with stand-in thread, message, reaction-event,
+ * and action-event objects. That keeps the test free of any real Chat
+ * SDK plumbing while still proving the wiring is correct.
+ *
+ * The DM path is exercised via `invokeDM` (the `onDirectMessage`
+ * capture) so the unit-test contract matches what the SDK actually
+ * does in production. Pre-#2638 the DM tests called `invokeMessage`
+ * (the `onNewMessage` capture) — that worked at the unit level but
+ * the chat SDK routes real DM events to `directMessageHandlers`
+ * first, so a test that only exercised the channel-pattern path
+ * silently masked the production gap (#2638).
  */
 
 import { describe, expect, it, mock } from "bun:test";
@@ -56,6 +64,7 @@ function makeLogger() {
 
 function makeChat() {
   let messageHandler: AnyHandler | null = null;
+  let directMessageHandler: AnyHandler | null = null;
   let reactionHandler: AnyHandler | null = null;
   const actionHandlers = new Map<string, AnyHandler>();
   const modalSubmitHandlers = new Map<string, AnyHandler>();
@@ -63,6 +72,14 @@ function makeChat() {
   const chat = {
     onNewMessage: mock((_pattern: RegExp, handler: AnyHandler) => {
       messageHandler = handler;
+    }),
+    // Matches the chat SDK signature: `onDirectMessage(handler)` with
+    // a single handler arg (no pattern). Production SDK dispatches DMs
+    // here first; if no handler is registered, DMs fall through to the
+    // mention handlers (NOT the `onNewMessage` patterns) — the routing
+    // gap #2638 fixed.
+    onDirectMessage: mock((handler: AnyHandler) => {
+      directMessageHandler = handler;
     }),
     onReaction: mock((_filter: unknown[], handler: AnyHandler) => {
       reactionHandler = handler;
@@ -82,6 +99,17 @@ function makeChat() {
       if (!messageHandler) throw new Error("listener never registered a message handler");
       await messageHandler(thread, message);
     },
+    // Exercises the `chat.onDirectMessage` registration (#2638). The
+    // SDK calls the handler with `(thread, message, channel, context)`;
+    // the listener's wrapper only forwards `thread` + `message` so we
+    // match that surface here. Tests that want to assert "DM path was
+    // taken" should call this, not `invokeMessage`.
+    invokeDM: async (thread: unknown, message: unknown) => {
+      if (!directMessageHandler) {
+        throw new Error("listener never registered a direct-message handler");
+      }
+      await directMessageHandler(thread, message);
+    },
     invokeReaction: async (event: unknown) => {
       if (!reactionHandler) throw new Error("listener never registered a reaction handler");
       await reactionHandler(event);
@@ -97,6 +125,7 @@ function makeChat() {
       return handler(event);
     },
     isRegistered: () => messageHandler !== null,
+    isDMRegistered: () => directMessageHandler !== null,
     handlerCount: () => actionHandlers.size,
     modalCount: () => modalSubmitHandlers.size,
   };
@@ -219,7 +248,7 @@ const allowChannels = (...ids: string[]) =>
 
 describe("registerProactiveListener — gating", () => {
   it("does not register when isEnabled() is false at boot", async () => {
-    const { chat, isRegistered } = makeChat();
+    const { chat, isRegistered, isDMRegistered } = makeChat();
     await registerProactiveListener(chat as any, makeLogger(), {
       isEnabled: () => false,
       classify: yesLLM,
@@ -228,11 +257,13 @@ describe("registerProactiveListener — gating", () => {
       getChannelConfigs: allowChannels("C-allowed"),
     });
     expect(isRegistered()).toBe(false);
+    expect(isDMRegistered()).toBe(false);
     expect(chat.onNewMessage).not.toHaveBeenCalled();
+    expect(chat.onDirectMessage).not.toHaveBeenCalled();
   });
 
   it("registers all expected handler types when enabled", async () => {
-    const { chat, isRegistered, handlerCount, modalCount } = makeChat();
+    const { chat, isRegistered, isDMRegistered, handlerCount, modalCount } = makeChat();
     await registerProactiveListener(chat as any, makeLogger(), {
       isEnabled: () => true,
       classify: yesLLM,
@@ -241,7 +272,13 @@ describe("registerProactiveListener — gating", () => {
       getChannelConfigs: allowChannels("C-allowed"),
     });
     expect(isRegistered()).toBe(true);
+    // #2638: a separate DM handler is required because the chat SDK
+    // routes DMs to `directMessageHandlers` first; without this the
+    // `onNewMessage` pattern handler never sees DM events in
+    // production (the unsubscribe branch was unreachable).
+    expect(isDMRegistered()).toBe(true);
     expect(chat.onNewMessage).toHaveBeenCalledTimes(1);
+    expect(chat.onDirectMessage).toHaveBeenCalledTimes(1);
     expect(chat.onReaction).toHaveBeenCalledTimes(1);
     // Offer card: Yes,answer + Not now. Feedback row: Helpful, Not helpful, Wrong data.
     expect(handlerCount()).toBe(5);
@@ -889,10 +926,16 @@ describe("registerProactiveListener — kill switch", () => {
     expect(thread._addReaction).not.toHaveBeenCalled();
   });
 
-  it("DM `unsubscribe` writes a user-optout row and skips classification", async () => {
+  it("DM `unsubscribe` (via onDirectMessage path) writes a user-optout row and skips classification", async () => {
+    // Exercises the `onDirectMessage` registration added in #2638 —
+    // the chat SDK routes real DM events to `directMessageHandlers`
+    // (then `mentionHandlers`), NEVER to `onNewMessage` patterns. The
+    // earlier version of this test invoked the `onNewMessage` capture
+    // directly, which bypassed the SDK routing and let the unit test
+    // pass even though production unsubscribe was unreachable.
     const onPauseRequest = mock(async () => {});
     const classify = mock(yesLLM);
-    const { chat, invokeMessage: invoke } = makeChat();
+    const { chat, invokeDM } = makeChat();
     await registerProactiveListener(chat as unknown as Parameters<typeof registerProactiveListener>[0], makeLogger(), {
       isEnabled: () => true,
       classify,
@@ -903,7 +946,7 @@ describe("registerProactiveListener — kill switch", () => {
       onPauseRequest,
     });
     const thread = makeThread("D-direct", { isDM: true });
-    await invoke(thread, makeMessage({ text: "unsubscribe" }));
+    await invokeDM(thread, makeMessage({ text: "unsubscribe" }));
     expect(onPauseRequest).toHaveBeenCalledTimes(1);
     expect((onPauseRequest.mock.calls[0] as unknown[])?.[0]).toMatchObject({
       workspaceId: "ws_1",

--- a/plugins/chat/src/proactive/__tests__/listener.test.ts
+++ b/plugins/chat/src/proactive/__tests__/listener.test.ts
@@ -929,27 +929,36 @@ describe("registerProactiveListener — kill switch", () => {
     expect(classify).not.toHaveBeenCalled();
   });
 
-  it("non-unsubscribe DM short-circuits before classify (cost-control contract)", async () => {
-    // The DM handler must not invoke the LLM classifier — DMs are
-    // 1:1 with the bot and the bridge owns the answer path. Pre-#2638
-    // DMs never reached the proactive handler at all; the new
-    // registration plus the `if (isDM) return;` short-circuit preserve
-    // the zero-LLM-cost contract. A regression that moves the isDM
-    // return below classify would silently burn tokens on every DM.
+  it("non-unsubscribe DM short-circuits before resolveWorkspaceId (cost-control contract)", async () => {
+    // The DM handler skips chat-with-bot DMs cheaply — no
+    // `resolveWorkspaceId` call, no `isEnabled` read, no classifier.
+    // Pre-#2638 DMs never reached the proactive handler at all; the
+    // new registration plus the early `isDM && !detectUnsubscribeDM`
+    // short-circuit preserve the zero-DB / zero-LLM-cost contract for
+    // every chat-with-bot DM. A regression that moves the skip below
+    // workspace resolution would silently add two host calls per DM.
     const classify = mock(yesLLM);
     const onPauseRequest = mock(async () => {});
+    const resolveWorkspaceId = mock(async () => "ws_1");
+    const isEnabled = mock(async () => true);
     const { chat, invokeDM } = makeChat();
     await registerProactiveListener(chat as unknown as Parameters<typeof registerProactiveListener>[0], makeLogger(), {
-      isEnabled: () => true,
+      isEnabled,
       classify,
-      resolveWorkspaceId: defaultResolver,
+      resolveWorkspaceId,
       getWorkspaceConfig: defaultGetWorkspace,
       getChannelConfigs: allowChannels("C-allowed"),
       isPaused: mock(async () => ({ paused: false })),
       onPauseRequest,
     });
     const thread = makeThread("D-direct", { isDM: true });
+    // Reset after registration — the listener probes `isEnabled("")`
+    // at boot to gate registration, which would otherwise count
+    // against the "not called per event" assertion below.
+    isEnabled.mockClear();
     await invokeDM(thread, makeMessage({ text: "what was MRR last month?" }));
+    expect(resolveWorkspaceId).not.toHaveBeenCalled();
+    expect(isEnabled).not.toHaveBeenCalled();
     expect(classify).not.toHaveBeenCalled();
     expect(onPauseRequest).not.toHaveBeenCalled();
   });

--- a/plugins/chat/src/proactive/__tests__/listener.test.ts
+++ b/plugins/chat/src/proactive/__tests__/listener.test.ts
@@ -4,16 +4,8 @@
  * We capture the functions passed to `chat.onNewMessage`,
  * `chat.onDirectMessage`, `chat.onReaction`, and `chat.onAction` and
  * invoke them directly with stand-in thread, message, reaction-event,
- * and action-event objects. That keeps the test free of any real Chat
- * SDK plumbing while still proving the wiring is correct.
- *
- * The DM path is exercised via `invokeDM` (the `onDirectMessage`
- * capture) so the unit-test contract matches what the SDK actually
- * does in production. Pre-#2638 the DM tests called `invokeMessage`
- * (the `onNewMessage` capture) — that worked at the unit level but
- * the chat SDK routes real DM events to `directMessageHandlers`
- * first, so a test that only exercised the channel-pattern path
- * silently masked the production gap (#2638).
+ * and action-event objects. DM scenarios use `invokeDM` so the unit
+ * contract matches the SDK's `directMessageHandlers` dispatch path.
  */
 
 import { describe, expect, it, mock } from "bun:test";
@@ -73,11 +65,6 @@ function makeChat() {
     onNewMessage: mock((_pattern: RegExp, handler: AnyHandler) => {
       messageHandler = handler;
     }),
-    // Matches the chat SDK signature: `onDirectMessage(handler)` with
-    // a single handler arg (no pattern). Production SDK dispatches DMs
-    // here first; if no handler is registered, DMs fall through to the
-    // mention handlers (NOT the `onNewMessage` patterns) — the routing
-    // gap #2638 fixed.
     onDirectMessage: mock((handler: AnyHandler) => {
       directMessageHandler = handler;
     }),
@@ -99,11 +86,6 @@ function makeChat() {
       if (!messageHandler) throw new Error("listener never registered a message handler");
       await messageHandler(thread, message);
     },
-    // Exercises the `chat.onDirectMessage` registration (#2638). The
-    // SDK calls the handler with `(thread, message, channel, context)`;
-    // the listener's wrapper only forwards `thread` + `message` so we
-    // match that surface here. Tests that want to assert "DM path was
-    // taken" should call this, not `invokeMessage`.
     invokeDM: async (thread: unknown, message: unknown) => {
       if (!directMessageHandler) {
         throw new Error("listener never registered a direct-message handler");
@@ -272,10 +254,6 @@ describe("registerProactiveListener — gating", () => {
       getChannelConfigs: allowChannels("C-allowed"),
     });
     expect(isRegistered()).toBe(true);
-    // #2638: a separate DM handler is required because the chat SDK
-    // routes DMs to `directMessageHandlers` first; without this the
-    // `onNewMessage` pattern handler never sees DM events in
-    // production (the unsubscribe branch was unreachable).
     expect(isDMRegistered()).toBe(true);
     expect(chat.onNewMessage).toHaveBeenCalledTimes(1);
     expect(chat.onDirectMessage).toHaveBeenCalledTimes(1);
@@ -927,12 +905,6 @@ describe("registerProactiveListener — kill switch", () => {
   });
 
   it("DM `unsubscribe` (via onDirectMessage path) writes a user-optout row and skips classification", async () => {
-    // Exercises the `onDirectMessage` registration added in #2638 —
-    // the chat SDK routes real DM events to `directMessageHandlers`
-    // (then `mentionHandlers`), NEVER to `onNewMessage` patterns. The
-    // earlier version of this test invoked the `onNewMessage` capture
-    // directly, which bypassed the SDK routing and let the unit test
-    // pass even though production unsubscribe was unreachable.
     const onPauseRequest = mock(async () => {});
     const classify = mock(yesLLM);
     const { chat, invokeDM } = makeChat();
@@ -955,6 +927,31 @@ describe("registerProactiveListener — kill switch", () => {
       durationMs: null,
     });
     expect(classify).not.toHaveBeenCalled();
+  });
+
+  it("non-unsubscribe DM short-circuits before classify (cost-control contract)", async () => {
+    // The DM handler must not invoke the LLM classifier — DMs are
+    // 1:1 with the bot and the bridge owns the answer path. Pre-#2638
+    // DMs never reached the proactive handler at all; the new
+    // registration plus the `if (isDM) return;` short-circuit preserve
+    // the zero-LLM-cost contract. A regression that moves the isDM
+    // return below classify would silently burn tokens on every DM.
+    const classify = mock(yesLLM);
+    const onPauseRequest = mock(async () => {});
+    const { chat, invokeDM } = makeChat();
+    await registerProactiveListener(chat as unknown as Parameters<typeof registerProactiveListener>[0], makeLogger(), {
+      isEnabled: () => true,
+      classify,
+      resolveWorkspaceId: defaultResolver,
+      getWorkspaceConfig: defaultGetWorkspace,
+      getChannelConfigs: allowChannels("C-allowed"),
+      isPaused: mock(async () => ({ paused: false })),
+      onPauseRequest,
+    });
+    const thread = makeThread("D-direct", { isDM: true });
+    await invokeDM(thread, makeMessage({ text: "what was MRR last month?" }));
+    expect(classify).not.toHaveBeenCalled();
+    expect(onPauseRequest).not.toHaveBeenCalled();
   });
 
   it("does not treat literal `unsubscribe` in a non-DM channel as a pause command", async () => {

--- a/plugins/chat/src/proactive/listener.ts
+++ b/plugins/chat/src/proactive/listener.ts
@@ -420,20 +420,17 @@ export async function registerProactiveListener(
   // answer.
   //
   // Registered against BOTH `chat.onNewMessage(/.+/, ...)` AND
-  // `chat.onDirectMessage(...)`. Without the second registration the chat
-  // SDK (`chat@4.23.0`, `dispatchToHandlers`) routes DM events to mention
-  // handlers — `onNewMessage` patterns only run for non-mention, non-DM,
-  // non-subscribed messages — so the DM `unsubscribe` branch below was
-  // unreachable in production (#2638).
+  // `chat.onDirectMessage(...)`. The chat SDK's `dispatchToHandlers`
+  // sends DMs to `directMessageHandlers` and returns; mention handlers
+  // and `onNewMessage` patterns only run for non-DM events (or for
+  // DMs when no DM handler is registered, the pre-#2638 fallback that
+  // marked DMs as mentions). Without the DM registration the
+  // `unsubscribe` branch below was unreachable in production (#2638).
   //
-  // DM events short-circuit AFTER the unsubscribe check (returning
-  // before classify / react / offer card): the proactive interjection
-  // model is for channel chatter, not 1:1 bot chats — classifying every
-  // DM would cost an LLM call per message just to land at "skip:
-  // channel-not-allowed" inside `decideInterjection`. The bridge's
-  // `onDirectMessage` registration (see `bridge.ts`) handles the
-  // chat-with-bot path on a parallel rail; both handlers fire because
-  // the SDK loops every registered DM handler before returning.
+  // DMs short-circuit after the unsubscribe check. The bridge owns
+  // the chat-with-bot DM path on a parallel `onDirectMessage`
+  // registration; the SDK iterates every DM handler before returning,
+  // so the two handlers run independently.
   const handleProactiveMessage = async (
     thread: Thread,
     message: Message,
@@ -498,18 +495,20 @@ export async function registerProactiveListener(
       }
 
       // DMs short-circuit here. The unsubscribe branch above is the
-      // only proactive-listener action that applies to DMs; classify /
-      // react / offer-card are channel-only flows. The bridge's
-      // `onDirectMessage` handler (registered separately, runs in the
-      // same SDK loop) owns the chat-with-bot path. Without this
-      // return a DM that isn't `unsubscribe` would pay one LLM
-      // classify call per message just to land at "skip:
-      // channel-not-allowed" inside `decideInterjection`.
-      if (isDM) return;
+      // only proactive-listener action that applies to DMs; the rest
+      // of this handler is channel-only (classify / react / offer
+      // card). Debug-logged so a future bug that misclassifies channel
+      // events as DMs is visible in the rollup instead of silent.
+      if (isDM) {
+        log.debug(
+          { workspaceId, channelId, messageId: message.id },
+          "Proactive: DM short-circuit (bridge owns chat-with-bot path)",
+        );
+        return;
+      }
 
       // In-channel `@atlas pause` → 24h channel-scoped pause.
       if (
-        !isDM &&
         config.onPauseRequest &&
         detectPauseCommand(text)
       ) {
@@ -776,12 +775,9 @@ export async function registerProactiveListener(
   };
 
   chat.onNewMessage(/.+/, handleProactiveMessage);
-  // SDK routes DMs to `directMessageHandlers` first when registered
-  // (`chat/dist/index.js:dispatchToHandlers`); without this registration
-  // DMs fall through to `mentionHandlers` and the listener never sees
-  // them. The `channel` / `context` parameters from the DM-handler
-  // signature aren't needed — `handleProactiveMessage` reads everything
-  // it needs from `thread` + `message`.
+  // The DM-handler signature accepts a `channel` + `context` the
+  // listener doesn't read — wrapping rather than passing
+  // `handleProactiveMessage` directly keeps the contract narrow.
   chat.onDirectMessage(async (thread: Thread, message: Message) => {
     await handleProactiveMessage(thread, message);
   });

--- a/plugins/chat/src/proactive/listener.ts
+++ b/plugins/chat/src/proactive/listener.ts
@@ -440,11 +440,23 @@ export async function registerProactiveListener(
       const text = message.text?.trim() ?? "";
       if (text.length === 0) return;
 
+      const isDM = thread.isDM === true;
+
+      // DM short-circuit. The proactive listener only cares about DMs
+      // that match the `unsubscribe` command; chat-with-bot DMs flow
+      // through the bridge's `onDirectMessage` registration. Skip
+      // every other DM cheaply (no `resolveWorkspaceId`, no
+      // `isEnabled`, no DB reads) — a chat-with-bot DM otherwise pays
+      // two host calls per message just to land at the `if (isDM)
+      // return;` below.
+      if (isDM && !detectUnsubscribeDM(text)) return;
+
       // ---------------------------------------------------------------
       // Per-event workspace resolution (#2620) — first DB / host call
       // we make. Runs before classify, meter, or kill-switch reads.
-      // (Bot/`isMe`/empty-text skips above run cheaper and earlier.)
-      // Unknown tenant → silent skip, no meter event, no DB reads.
+      // (Bot/`isMe`/empty-text and DM-not-unsubscribe skips above run
+      // cheaper and earlier.) Unknown tenant → silent skip, no meter
+      // event, no DB reads.
       // ---------------------------------------------------------------
       const workspaceId = await safeResolveWorkspace(
         thread.adapter,
@@ -457,7 +469,6 @@ export async function registerProactiveListener(
 
       const channelId = thread.channelId;
       const userId = message.author.userId;
-      const isDM = thread.isDM === true;
       // Workspace-scoped cooldown key — two tenants that share a channel
       // id (e.g. both have a "C-general") must not share cooldown state.
       const cooldownKey = `${workspaceId}:${channelId}`;
@@ -467,43 +478,36 @@ export async function registerProactiveListener(
       // a mute message never costs an LLM call.
       // ---------------------------------------------------------------
 
-      // DM `unsubscribe` → workspace-wide user-optout row.
-      if (
-        isDM &&
-        config.onPauseRequest &&
-        detectUnsubscribeDM(text)
-      ) {
-        try {
-          await config.onPauseRequest(
-            resolvePauseRequest("dm-unsubscribe", {
-              workspaceId,
-              channelId,
-              userId,
-            }),
-          );
-          log.info(
+      // DM `unsubscribe` → workspace-wide user-optout row. The early
+      // skip above guarantees we only reach this with an unsubscribe
+      // DM, so it's an unconditional handler for the DM path. The rest
+      // of the function is channel-only.
+      if (isDM) {
+        if (config.onPauseRequest) {
+          try {
+            await config.onPauseRequest(
+              resolvePauseRequest("dm-unsubscribe", {
+                workspaceId,
+                channelId,
+                userId,
+              }),
+            );
+            log.info(
+              { workspaceId, userId },
+              "Proactive: user opted out via DM unsubscribe",
+            );
+          } catch (err) {
+            log.warn(
+              { err: err instanceof Error ? err : new Error(String(err)) },
+              "Proactive: DM unsubscribe write failed — user still listed in proactive",
+            );
+          }
+        } else {
+          log.debug(
             { workspaceId, userId },
-            "Proactive: user opted out via DM unsubscribe",
-          );
-        } catch (err) {
-          log.warn(
-            { err: err instanceof Error ? err : new Error(String(err)) },
-            "Proactive: DM unsubscribe write failed — user still listed in proactive",
+            "Proactive: DM unsubscribe received but no onPauseRequest configured — discarding",
           );
         }
-        return;
-      }
-
-      // DMs short-circuit here. The unsubscribe branch above is the
-      // only proactive-listener action that applies to DMs; the rest
-      // of this handler is channel-only (classify / react / offer
-      // card). Debug-logged so a future bug that misclassifies channel
-      // events as DMs is visible in the rollup instead of silent.
-      if (isDM) {
-        log.debug(
-          { workspaceId, channelId, messageId: message.id },
-          "Proactive: DM short-circuit (bridge owns chat-with-bot path)",
-        );
         return;
       }
 

--- a/plugins/chat/src/proactive/listener.ts
+++ b/plugins/chat/src/proactive/listener.ts
@@ -416,9 +416,28 @@ export async function registerProactiveListener(
   };
 
   // -------------------------------------------------------------------------
-  // Channel-message hook: classify + react + record asker for later answer
-  // -------------------------------------------------------------------------
-  chat.onNewMessage(/.+/, async (thread: Thread, message: Message) => {
+  // Channel-message + DM hook: classify + react + record asker for later
+  // answer.
+  //
+  // Registered against BOTH `chat.onNewMessage(/.+/, ...)` AND
+  // `chat.onDirectMessage(...)`. Without the second registration the chat
+  // SDK (`chat@4.23.0`, `dispatchToHandlers`) routes DM events to mention
+  // handlers — `onNewMessage` patterns only run for non-mention, non-DM,
+  // non-subscribed messages — so the DM `unsubscribe` branch below was
+  // unreachable in production (#2638).
+  //
+  // DM events short-circuit AFTER the unsubscribe check (returning
+  // before classify / react / offer card): the proactive interjection
+  // model is for channel chatter, not 1:1 bot chats — classifying every
+  // DM would cost an LLM call per message just to land at "skip:
+  // channel-not-allowed" inside `decideInterjection`. The bridge's
+  // `onDirectMessage` registration (see `bridge.ts`) handles the
+  // chat-with-bot path on a parallel rail; both handlers fire because
+  // the SDK loops every registered DM handler before returning.
+  const handleProactiveMessage = async (
+    thread: Thread,
+    message: Message,
+  ): Promise<void> => {
     try {
       if (message.author.isBot === true || message.author.isMe) return;
       const text = message.text?.trim() ?? "";
@@ -477,6 +496,16 @@ export async function registerProactiveListener(
         }
         return;
       }
+
+      // DMs short-circuit here. The unsubscribe branch above is the
+      // only proactive-listener action that applies to DMs; classify /
+      // react / offer-card are channel-only flows. The bridge's
+      // `onDirectMessage` handler (registered separately, runs in the
+      // same SDK loop) owns the chat-with-bot path. Without this
+      // return a DM that isn't `unsubscribe` would pay one LLM
+      // classify call per message just to land at "skip:
+      // channel-not-allowed" inside `decideInterjection`.
+      if (isDM) return;
 
       // In-channel `@atlas pause` → 24h channel-scoped pause.
       if (
@@ -744,6 +773,17 @@ export async function registerProactiveListener(
         "Proactive listener handler threw — suppressed",
       );
     }
+  };
+
+  chat.onNewMessage(/.+/, handleProactiveMessage);
+  // SDK routes DMs to `directMessageHandlers` first when registered
+  // (`chat/dist/index.js:dispatchToHandlers`); without this registration
+  // DMs fall through to `mentionHandlers` and the listener never sees
+  // them. The `channel` / `context` parameters from the DM-handler
+  // signature aren't needed — `handleProactiveMessage` reads everything
+  // it needs from `thread` + `message`.
+  chat.onDirectMessage(async (thread: Thread, message: Message) => {
+    await handleProactiveMessage(thread, message);
   });
 
   // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #2638. The proactive listener's DM `unsubscribe` branch was unreachable in production because the chat SDK (`chat@4.23.0`, `dispatchToHandlers`) routes DM events to `directMessageHandlers` (then `mentionHandlers`), never to `onNewMessage` patterns. A real Slack DM `unsubscribe` was reaching `bridge.onNewMention` and being answered as a SQL question.

- **Proactive listener** registers `chat.onDirectMessage(handler)` alongside `onNewMessage`. The shared handler short-circuits for DMs after the `unsubscribe` / pause check — `classify` / `react` / offer-card are channel-only flows.
- **Bridge** also registers `chat.onDirectMessage` so the chat-with-bot DM path (`DM "what is MRR?"` → `executeQuery`) keeps working. Without this, the proactive DM registration would make the SDK skip mention-handler routing and silently drop every DM that wasn't `unsubscribe`. SDK loops every registered DM handler before returning, so both fire independently.
- **Unit tests** now capture `onDirectMessage` and exercise DM scenarios via `invokeDM` so the unit-test contract matches what the SDK does in production (the earlier `invokeMessage` path bypassed SDK routing and silently passed even though production was broken — exactly the #2633 unit-vs-e2e divergence the issue was filed against).
- **E2E** `.todo` promoted to a real assertion: a signed Slack DM `unsubscribe` webhook produces a `pauseRequests` row with `layer: "user-optout"`, `channelId: null`. Short-circuit also asserted (`expectNoProactiveActivity`).

## Test plan

- [x] `cd plugins/chat && bun test src/` — 444 pass
- [x] `bun test e2e/surfaces/slack-proactive.test.ts` — 7 pass (DM unsubscribe e2e green, was `.todo`)
- [x] `bun run lint` — 0 errors
- [x] `bun run type` — 0 errors
- [x] `bun run test` — full suite green
- [x] `bun x syncpack lint`, template-drift, security-headers, railway-watch, schema-drift, oauth-helper-drift — all green
- [ ] Dogfood in #sandbox-atlas: DM `unsubscribe` to the Atlas bot creates a `proactive_pauses` row with `layer: 'user-optout'`