### PR TITLE
feat(types,plugins/chat,api): #2641 brand proactive identity types

### DIFF
--- a/e2e/surfaces/slack-proactive.test.ts
+++ b/e2e/surfaces/slack-proactive.test.ts
@@ -394,7 +394,7 @@ beforeAll(async () => {
       // branch — reaction-back behaviour is out of scope here (covered
       // by the answerer unit tests + #2624). We only need the react
       // meter row to fire to validate the channel-allowlist path.
-      userResolver: async () => ({ atlasUserId: undefined }),
+      userResolver: async () => ({ kind: "unlinked" }),
     },
   });
 

--- a/packages/api/src/lib/proactive/__tests__/answer-adapter.test.ts
+++ b/packages/api/src/lib/proactive/__tests__/answer-adapter.test.ts
@@ -152,6 +152,13 @@ mock.module("@atlas/api/lib/logger", () => ({
 // Imports (after mocks)
 // ---------------------------------------------------------------------------
 
+import type { ProactiveAsker } from "@useatlas/chat";
+import {
+  assertAtlasUserId,
+  assertExternalUserId,
+  assertWorkspaceId,
+} from "@useatlas/chat";
+
 const { createAiModelTestLayer } = await import(
   "@atlas/api/lib/effect/ai"
 );
@@ -171,9 +178,9 @@ function buildRuntime() {
   );
 }
 
-const slackAsker = {
+const slackAsker: ProactiveAsker = {
   platform: "slack",
-  externalUserId: "U999",
+  externalUserId: assertExternalUserId("U999"),
   userName: "Alice",
 };
 
@@ -213,8 +220,8 @@ describe("createProactiveAnswerAdapter — linked path", () => {
     const result = await adapter("how many customers?", {
       threadId: "T-1",
       asker: slackAsker,
-      atlasUserId: "user-linked",
-      workspaceId: "org-linked",
+      atlasUserId: assertAtlasUserId("user-linked"),
+      workspaceId: assertWorkspaceId("org-linked"),
     });
 
     expect(result.answer).toBe("Linked answer");
@@ -245,8 +252,8 @@ describe("createProactiveAnswerAdapter — linked path", () => {
       adapter("orphan question", {
         threadId: "T-orphan",
         asker: slackAsker,
-        atlasUserId: "user-missing",
-        workspaceId: "org-orphan",
+        atlasUserId: assertAtlasUserId("user-missing"),
+        workspaceId: assertWorkspaceId("org-orphan"),
       }),
     ).rejects.toThrow(/Atlas couldn't answer this/);
 
@@ -276,8 +283,8 @@ describe("createProactiveAnswerAdapter — linked path", () => {
       adapter("how many customers?", {
         threadId: "T-fail",
         asker: slackAsker,
-        atlasUserId: "user-1",
-        workspaceId: "org-1",
+        atlasUserId: assertAtlasUserId("user-1"),
+        workspaceId: assertWorkspaceId("org-1"),
       }),
     ).rejects.toThrow(/Atlas couldn't answer this/);
 
@@ -317,7 +324,7 @@ describe("createProactiveAnswerAdapter — unlinked path", () => {
       threadId: "T-unlinked",
       asker: slackAsker,
       atlasUserId: null,
-      workspaceId: "org-public",
+      workspaceId: assertWorkspaceId("org-public"),
     });
 
     expect(result.answer).toBe("Public-dataset answer");
@@ -345,7 +352,7 @@ describe("createProactiveAnswerAdapter — unlinked path", () => {
         threadId: "T-missing",
         asker: slackAsker,
         atlasUserId: null,
-        workspaceId: "org-missing",
+        workspaceId: assertWorkspaceId("org-missing"),
       }),
     ).rejects.toThrow(/Atlas couldn't answer this/);
 
@@ -374,7 +381,7 @@ describe("createProactiveAnswerAdapter — unlinked path", () => {
         threadId: "T-empty",
         asker: slackAsker,
         atlasUserId: null,
-        workspaceId: "org-empty",
+        workspaceId: assertWorkspaceId("org-empty"),
       }),
     ).rejects.toThrow(/Atlas couldn't answer this/);
     expect(observedRunAgentCalls).toHaveLength(0);
@@ -401,7 +408,7 @@ describe("createProactiveAnswerAdapter — unlinked path", () => {
         threadId: "T-fail",
         asker: slackAsker,
         atlasUserId: null,
-        workspaceId: "org-fail",
+        workspaceId: assertWorkspaceId("org-fail"),
       }),
     ).rejects.toThrow(/Atlas couldn't answer this/);
     expect(observedRunAgentCalls).toHaveLength(0);
@@ -445,13 +452,13 @@ describe("createProactiveAnswerAdapter — unlinked path", () => {
       threadId: "T-scoped",
       asker: slackAsker,
       atlasUserId: null,
-      workspaceId: "tenant-B",
+      workspaceId: assertWorkspaceId("tenant-B"),
     });
 
     expect(observedPublicDatasetCalls).toHaveLength(1);
     expect(observedPublicDatasetCalls[0]).toEqual({
       askerExternalId: slackAsker.externalUserId,
-      workspaceId: "tenant-B",
+      workspaceId: assertWorkspaceId("tenant-B"),
     });
     await runtime.dispose();
   });
@@ -478,8 +485,8 @@ describe("createProactiveAnswerAdapter — error handling", () => {
       adapter("trigger an error", {
         threadId: "T-err",
         asker: slackAsker,
-        atlasUserId: "user-1",
-        workspaceId: "org-1",
+        atlasUserId: assertAtlasUserId("user-1"),
+        workspaceId: assertWorkspaceId("org-1"),
       }),
     ).rejects.toThrow(/Atlas couldn't answer this/);
 
@@ -519,8 +526,8 @@ describe("createProactiveAnswerAdapter — error handling", () => {
       adapter("question with broken model", {
         threadId: "T-model",
         asker: slackAsker,
-        atlasUserId: "user-1",
-        workspaceId: "org-1",
+        atlasUserId: assertAtlasUserId("user-1"),
+        workspaceId: assertWorkspaceId("org-1"),
       }),
     ).rejects.toThrow(/Atlas couldn't answer this/);
 
@@ -641,8 +648,8 @@ describe("collectProactiveResult", () => {
     const result = await adapter("with refs", {
       threadId: "T-refs",
       asker: slackAsker,
-      atlasUserId: "user-x",
-      workspaceId: "org-x",
+      atlasUserId: assertAtlasUserId("user-x"),
+      workspaceId: assertWorkspaceId("org-x"),
     });
 
     expect(result.answer).toBe("Answer with refs");

--- a/packages/api/src/lib/proactive/__tests__/answer-meter-audit.test.ts
+++ b/packages/api/src/lib/proactive/__tests__/answer-meter-audit.test.ts
@@ -34,6 +34,7 @@ mock.module("@atlas/api/lib/db/internal", () => ({
 }));
 
 const { recordMeterEvent } = await import("../answer-meter");
+const { assertWorkspaceId } = await import("@useatlas/chat");
 
 beforeEach(() => {
   observedAuditCalls.length = 0;
@@ -41,7 +42,7 @@ beforeEach(() => {
 
 describe("recordMeterEvent — admin_action_log dual-write (#2631)", () => {
   const baseEvent = {
-    workspaceId: "ws-1",
+    workspaceId: assertWorkspaceId("ws-1"),
     channelId: "C-1",
     messageId: "M-1",
   } as const;

--- a/packages/api/src/lib/proactive/__tests__/user-resolver.test.ts
+++ b/packages/api/src/lib/proactive/__tests__/user-resolver.test.ts
@@ -31,11 +31,17 @@
 
 import { describe, it, expect, mock } from "bun:test";
 
+import {
+  assertExternalUserId,
+  assertWorkspaceId,
+  type ProactiveAsker,
+  type WorkspaceId,
+} from "@useatlas/chat";
 import { createSlackProactiveUserResolver } from "../user-resolver";
 
-const slackAsker = {
+const slackAsker: ProactiveAsker = {
   platform: "slack",
-  externalUserId: "U-asker",
+  externalUserId: assertExternalUserId("U-asker"),
   userName: "alice",
 };
 
@@ -44,12 +50,14 @@ describe("createSlackProactiveUserResolver", () => {
     const verifyWorkspace = mock(async () => true);
     const resolver = createSlackProactiveUserResolver({ verifyWorkspace });
 
-    const out = await resolver(
-      { platform: "teams", externalUserId: "T-1", userName: "bob" },
-      { workspaceId: "ws-1" },
-    );
+    const teamsAsker: ProactiveAsker = {
+      platform: "teams",
+      externalUserId: assertExternalUserId("T-1"),
+      userName: "bob",
+    };
+    const out = await resolver(teamsAsker, { workspaceId: assertWorkspaceId("ws-1") });
 
-    expect(out).toEqual({ atlasUserId: undefined });
+    expect(out).toEqual({ kind: "unlinked" });
     expect(verifyWorkspace).not.toHaveBeenCalled();
   });
 
@@ -57,22 +65,26 @@ describe("createSlackProactiveUserResolver", () => {
     const verifyWorkspace = mock(async () => true);
     const resolver = createSlackProactiveUserResolver({ verifyWorkspace });
 
-    const out = await resolver(slackAsker, { workspaceId: "" });
+    // The listener's `assertWorkspaceId` chokepoint normally prevents
+    // an empty id from reaching the resolver. Cast directly here to
+    // exercise the resolver's defensive short-circuit — a future code
+    // path that bypasses the listener must still refuse-safely instead
+    // of running a global `WHERE org_id = ''` lookup.
+    const out = await resolver(slackAsker, { workspaceId: "" as WorkspaceId });
 
-    expect(out).toEqual({ atlasUserId: undefined });
-    // The empty-workspaceId short-circuit MUST run before the DB
-    // lookup — a global lookup with empty `WHERE org_id = ''` would
-    // match nothing but still hit the DB unnecessarily.
+    expect(out).toEqual({ kind: "unlinked" });
     expect(verifyWorkspace).not.toHaveBeenCalled();
   });
 
   it("returns unlinked when verifyWorkspace returns false (unknown tenant)", async () => {
-    const verifyWorkspace = mock(async (_id: string) => false);
+    const verifyWorkspace = mock(async (_id: WorkspaceId) => false);
     const resolver = createSlackProactiveUserResolver({ verifyWorkspace });
 
-    const out = await resolver(slackAsker, { workspaceId: "ws-unknown" });
+    const out = await resolver(slackAsker, {
+      workspaceId: assertWorkspaceId("ws-unknown"),
+    });
 
-    expect(out).toEqual({ atlasUserId: undefined });
+    expect(out).toEqual({ kind: "unlinked" });
     expect(verifyWorkspace).toHaveBeenCalledWith("ws-unknown");
   });
 
@@ -81,12 +93,14 @@ describe("createSlackProactiveUserResolver", () => {
     // path because no `slack_user_links` table exists in core. The
     // hook point is documented in the resolver — when the link
     // table lands, replace the inner branch with a real lookup.
-    const verifyWorkspace = mock(async (_id: string) => true);
+    const verifyWorkspace = mock(async (_id: WorkspaceId) => true);
     const resolver = createSlackProactiveUserResolver({ verifyWorkspace });
 
-    const out = await resolver(slackAsker, { workspaceId: "ws-known" });
+    const out = await resolver(slackAsker, {
+      workspaceId: assertWorkspaceId("ws-known"),
+    });
 
-    expect(out).toEqual({ atlasUserId: undefined });
+    expect(out).toEqual({ kind: "unlinked" });
     expect(verifyWorkspace).toHaveBeenCalledWith("ws-known");
   });
 
@@ -102,9 +116,11 @@ describe("createSlackProactiveUserResolver", () => {
     });
     const resolver = createSlackProactiveUserResolver({ verifyWorkspace });
 
-    const out = await resolver(slackAsker, { workspaceId: "ws-troubled" });
+    const out = await resolver(slackAsker, {
+      workspaceId: assertWorkspaceId("ws-troubled"),
+    });
 
-    expect(out).toEqual({ atlasUserId: undefined });
+    expect(out).toEqual({ kind: "unlinked" });
     expect(verifyWorkspace).toHaveBeenCalled();
   });
 
@@ -112,13 +128,15 @@ describe("createSlackProactiveUserResolver", () => {
     // Multi-tenant correctness: a future code path that pre-normalizes
     // the workspaceId (case-fold, trim) MUST happen at the listener's
     // resolver, not silently inside this factory. Pin the pass-through.
-    const verifyWorkspace = mock(async (_id: string) => true);
+    const verifyWorkspace = mock(async (_id: WorkspaceId) => true);
     const resolver = createSlackProactiveUserResolver({ verifyWorkspace });
 
-    await resolver(slackAsker, { workspaceId: "WS-MixedCase-42" });
+    await resolver(slackAsker, {
+      workspaceId: assertWorkspaceId("WS-MixedCase-42"),
+    });
 
     expect(verifyWorkspace).toHaveBeenCalledTimes(1);
-    expect(verifyWorkspace.mock.calls[0]![0]).toBe("WS-MixedCase-42");
+    expect(verifyWorkspace.mock.calls[0]![0] as string).toBe("WS-MixedCase-42");
   });
 
   it("isolates two tenants seeing the same Slack externalUserId (#2624 collision case)", async () => {
@@ -129,27 +147,31 @@ describe("createSlackProactiveUserResolver", () => {
     // the collision scenario the issue body called out and pins that
     // both invocations hit the verifier separately.
     const observed: string[] = [];
-    const verifyWorkspace = mock(async (id: string) => {
+    const verifyWorkspace = mock(async (id: WorkspaceId) => {
       observed.push(id);
-      return id === "ws-A"; // pretend only ws-A is installed
+      return (id as string) === "ws-A"; // pretend only ws-A is installed
     });
     const resolver = createSlackProactiveUserResolver({ verifyWorkspace });
 
-    const sharedAsker = {
+    const sharedAsker: ProactiveAsker = {
       platform: "slack",
-      externalUserId: "U-shared",
+      externalUserId: assertExternalUserId("U-shared"),
       userName: "shared",
     };
 
-    const outA = await resolver(sharedAsker, { workspaceId: "ws-A" });
-    const outB = await resolver(sharedAsker, { workspaceId: "ws-B" });
+    const outA = await resolver(sharedAsker, {
+      workspaceId: assertWorkspaceId("ws-A"),
+    });
+    const outB = await resolver(sharedAsker, {
+      workspaceId: assertWorkspaceId("ws-B"),
+    });
 
     // Both tenants are evaluated independently — no collision, no
     // caching by asker identity. Until a link table lands both
     // return unlinked, but the verifier received both ids.
     expect(observed).toEqual(["ws-A", "ws-B"]);
-    expect(outA).toEqual({ atlasUserId: undefined });
-    expect(outB).toEqual({ atlasUserId: undefined });
+    expect(outA).toEqual({ kind: "unlinked" });
+    expect(outB).toEqual({ kind: "unlinked" });
   });
 
   it("default verifier returns false without an internal DB (self-hosted / no DATABASE_URL)", async () => {
@@ -159,7 +181,9 @@ describe("createSlackProactiveUserResolver", () => {
     // an internal DB (no DATABASE_URL set), so the verifier resolves
     // to false → unlinked. This pins the self-hosted/no-DB posture.
     const resolver = createSlackProactiveUserResolver();
-    const out = await resolver(slackAsker, { workspaceId: "ws-any" });
-    expect(out).toEqual({ atlasUserId: undefined });
+    const out = await resolver(slackAsker, {
+      workspaceId: assertWorkspaceId("ws-any"),
+    });
+    expect(out).toEqual({ kind: "unlinked" });
   });
 });

--- a/packages/api/src/lib/proactive/answer-adapter.ts
+++ b/packages/api/src/lib/proactive/answer-adapter.ts
@@ -47,9 +47,11 @@
 import type { ManagedRuntime } from "effect";
 import { Effect } from "effect";
 import type {
+  AtlasUserId,
   ProactiveAsker,
   ProactiveExecuteQuery,
   ProactiveQueryResult,
+  WorkspaceId,
 } from "@useatlas/chat";
 
 import { runAgent } from "@atlas/api/lib/agent";
@@ -110,14 +112,17 @@ export interface ProactiveAnswerAdapterOptions {
    * Resolve an Atlas user's active org. Defaults to a single-row
    * `member` query (first row wins — matches `server.ts`'s
    * activate-first-org heuristic). Override in tests to stub the DB.
+   *
+   * Accepts a branded {@link AtlasUserId} (#2641) — a transposed-arg
+   * call passing `asker.externalUserId` here is a compile error.
    */
-  resolveOrgForUser?: (atlasUserId: string) => Promise<string | null>;
+  resolveOrgForUser?: (atlasUserId: AtlasUserId) => Promise<string | null>;
   /**
    * Resolve the actor identity for a linked user. Defaults to
    * {@link loadActorUser}.
    */
   resolveActor?: (
-    atlasUserId: string,
+    atlasUserId: AtlasUserId,
     orgId: string | null,
   ) => Promise<AtlasUser | null>;
   /**
@@ -131,13 +136,13 @@ export interface ProactiveAnswerAdapterOptions {
    * call is rejected with the user-safe error. Linked calls
    * (`atlasUserId !== null`) never invoke this callback.
    *
-   * Receives the per-event `workspaceId` (#2624) alongside the asker
-   * so multi-tenant hosts scope the allowlist lookup to the right
-   * tenant. Pre-#2624 the callback received only `asker`, which
-   * couldn't distinguish "same Slack user-id seen in tenant A vs
-   * tenant B" and so routed tenant B askers against tenant A's
-   * allowlist on the chat plugin's single-instance multi-tenant SaaS
-   * wiring.
+   * Receives the per-event branded {@link WorkspaceId} (#2624 + #2641
+   * brand) alongside the asker so multi-tenant hosts scope the
+   * allowlist lookup to the right tenant. Pre-#2624 the callback
+   * received only `asker`, which couldn't distinguish "same Slack
+   * user-id seen in tenant A vs tenant B" and so routed tenant B
+   * askers against tenant A's allowlist on the chat plugin's
+   * single-instance multi-tenant SaaS wiring.
    *
    * The default production wiring resolves the allowlist via
    * `getAllowlist(workspaceId)` in
@@ -145,7 +150,7 @@ export interface ProactiveAnswerAdapterOptions {
    */
   getPublicDataset?: (
     asker: ProactiveAsker,
-    ctx: { workspaceId: string },
+    ctx: { workspaceId: WorkspaceId },
   ) => Promise<ReadonlyArray<PublicDatasetEntry>>;
 }
 
@@ -344,9 +349,12 @@ export function createProactiveAnswerAdapter(
 // ---------------------------------------------------------------------------
 
 async function resolveLinkedActor(
-  atlasUserId: string,
-  resolveOrgForUser: (id: string) => Promise<string | null>,
-  resolveActor: (id: string, orgId: string | null) => Promise<AtlasUser | null>,
+  atlasUserId: AtlasUserId,
+  resolveOrgForUser: (id: AtlasUserId) => Promise<string | null>,
+  resolveActor: (
+    id: AtlasUserId,
+    orgId: string | null,
+  ) => Promise<AtlasUser | null>,
 ): Promise<AtlasUser> {
   // Fail-closed F-55: a thrown `resolveOrgForUser` is infra failure,
   // not "user has no org" (that returns null). Letting it propagate
@@ -433,7 +441,7 @@ function normalizeChatPlatform(platform: string): ChatBotPlatform | null {
  * multi-org members the auth hook leaves activation untouched.
  */
 async function defaultResolveOrgForUser(
-  atlasUserId: string,
+  atlasUserId: AtlasUserId,
 ): Promise<string | null> {
   if (!hasInternalDB()) return null;
   const rows = await internalQuery<{ organizationId: string }>(

--- a/packages/api/src/lib/proactive/user-resolver.ts
+++ b/packages/api/src/lib/proactive/user-resolver.ts
@@ -59,6 +59,7 @@ import type {
   ProactiveUserResolver,
   ProactiveUserResolverContext,
   ResolvedAsker,
+  WorkspaceId,
 } from "@useatlas/chat";
 
 import { hasInternalDB, internalQuery } from "@atlas/api/lib/db/internal";
@@ -84,8 +85,11 @@ export interface SlackProactiveUserResolverOptions {
    * resolver still refuses to attribute the asker. Cheap (indexed
    * lookup against `idx_slack_installations_org` on `org_id`) so the
    * extra read isn't material.
+   *
+   * Accepts a branded {@link WorkspaceId} (#2641) so a transposed-arg
+   * call (e.g. passing `asker.externalUserId` here) is a compile error.
    */
-  verifyWorkspace?: (workspaceId: string) => Promise<boolean>;
+  verifyWorkspace?: (workspaceId: WorkspaceId) => Promise<boolean>;
 }
 
 /**
@@ -121,19 +125,20 @@ export function createSlackProactiveUserResolver(
         { platform: asker.platform, workspaceId },
         "Proactive user resolver invoked for non-Slack platform — returning unlinked",
       );
-      return { atlasUserId: undefined };
+      return { kind: "unlinked" };
     }
 
-    if (!workspaceId) {
-      // Defensive: workspaceId should always be non-empty (the
-      // listener short-circuits on a null/empty resolver result),
-      // but an empty string here would skip the workspace check and
-      // collapse all tenants onto the global path. Refuse-safely.
+    // `workspaceId` is the branded {@link WorkspaceId} threaded from
+    // the listener (post-#2641); empty values never reach the resolver
+    // because `assertWorkspaceId` throws at the listener boundary. The
+    // length check below is belt-and-braces against a future caller
+    // that bypasses the listener.
+    if (workspaceId.length === 0) {
       log.warn(
         { externalUserId: asker.externalUserId },
         "Proactive user resolver invoked without workspaceId — returning unlinked",
       );
-      return { atlasUserId: undefined };
+      return { kind: "unlinked" };
     }
 
     try {
@@ -143,7 +148,7 @@ export function createSlackProactiveUserResolver(
           { workspaceId, externalUserId: asker.externalUserId },
           "Proactive user resolver: workspaceId not in slack_installations — returning unlinked",
         );
-        return { atlasUserId: undefined };
+        return { kind: "unlinked" };
       }
     } catch (err) {
       // DB outage → unlinked (NOT errored): the listener treats
@@ -161,17 +166,17 @@ export function createSlackProactiveUserResolver(
         },
         "Proactive user resolver: verifyWorkspace failed — returning unlinked",
       );
-      return { atlasUserId: undefined };
+      return { kind: "unlinked" };
     }
 
     // Hook point — when a Slack-user link table lands, replace the
     // line below with a lookup keyed on (workspaceId, asker.externalUserId)
-    // and return `{ atlasUserId }` for matches. Until then every
-    // asker takes the unlinked path: the listener's public-dataset
-    // gate is the answer-or-refuse branch, and that branch IS
-    // tenant-scoped now (#2624) via the workspaceId threaded through
-    // `getPublicDataset(asker, { workspaceId })`.
-    return { atlasUserId: undefined };
+    // and return `{ kind: "linked", atlasUserId: assertAtlasUserId(row.atlas_user_id) }`
+    // for matches. Until then every asker takes the unlinked path:
+    // the listener's public-dataset gate is the answer-or-refuse
+    // branch, and that branch IS tenant-scoped now (#2624) via the
+    // workspaceId threaded through `getPublicDataset(asker, { workspaceId })`.
+    return { kind: "unlinked" };
   };
 }
 
@@ -183,7 +188,9 @@ export function createSlackProactiveUserResolver(
  * collapses both onto the same unlinked outcome but logs them
  * separately (warn for missing, warn-with-error for outage).
  */
-async function defaultVerifyWorkspace(workspaceId: string): Promise<boolean> {
+async function defaultVerifyWorkspace(
+  workspaceId: WorkspaceId,
+): Promise<boolean> {
   if (!hasInternalDB()) return false;
   const rows = await internalQuery<{ org_id: string | null }>(
     `SELECT org_id

--- a/packages/api/src/lib/proactive/user-resolver.ts
+++ b/packages/api/src/lib/proactive/user-resolver.ts
@@ -1,9 +1,12 @@
 /**
  * Proactive `userResolver` — chat-platform identity → Atlas identity (#2624).
  *
- * The chat plugin's `ProactiveUserResolver` (post-#2624 shape) is:
+ * The chat plugin's `ProactiveUserResolver` (post-#2624 + #2641 shape) is:
  *
- *     (asker, { workspaceId }) => Promise<{ atlasUserId? }>
+ *     (asker, { workspaceId: WorkspaceId }) => Promise<ResolvedAsker>
+ *
+ *     ResolvedAsker = { kind: "linked"; atlasUserId: AtlasUserId }
+ *                   | { kind: "unlinked" }
  *
  * The `workspaceId` is the per-event tenant resolved by
  * `lib/proactive/workspace-id-resolver.ts:createSlackWorkspaceIdResolver`
@@ -17,7 +20,7 @@
  *      case, but if a future code path bypasses the per-event resolver
  *      we still refuse to attribute the asker to a stale tenant).
  *
- *   2. **Returns `{ atlasUserId: undefined }`** for every asker today.
+ *   2. **Returns `{ kind: "unlinked" }`** for every asker today.
  *      The mapping from `(workspaceId, slack_user_id)` to an Atlas
  *      `user.id` requires a link table (e.g. `slack_user_links` with
  *      `(workspace_id, slack_user_id, atlas_user_id)`) that does NOT
@@ -25,31 +28,32 @@
  *      safely link an asker — and we MUST NOT invent a heuristic
  *      match (e.g. "first member of the org") because that would
  *      silently bypass per-user RLS for an unlinked asker by binding
- *      their query to another user's identity.
- *
- *      The listener's unlinked-asker path (public-dataset gate +
- *      refusal copy) is the safe behaviour until the link table
- *      lands.
+ *      their query to another user's identity. The unlinked branch
+ *      is the safe fallback: the listener's public-dataset gate +
+ *      refusal copy gate that asker's access.
  *
  * **Hook point for future linking work.** A follow-up issue is
  * expected to add a Slack-user link mechanism (OAuth user grant, an
  * admin-managed link table, or email matching via the Slack profile
- * API). When that lands the resolver replaces step 2 with a real
- * lookup; the surrounding wiring (#2624 contract change) stays as-is.
+ * API). When that lands the resolver replaces step 2 with
+ * `{ kind: "linked", atlasUserId: assertAtlasUserId(row.atlas_user_id) }`
+ * for matching rows; the surrounding wiring (#2624 contract change +
+ * #2641 brand types) stays as-is.
  *
- * Failures resolve as `{ atlasUserId: undefined }` rather than
- * throwing — the listener's `safeResolveUser` catches throws but
- * treats them as the apology path (refuse, do not downgrade to
- * public-dataset). Returning an explicit unlinked result keeps the
- * three-state ladder ("linked" / "unlinked" / "errored") meaningful
- * for the failure mode that's actually "we don't know yet" (no link
- * table) rather than "the registry is broken" (errored).
+ * Failures resolve as `{ kind: "unlinked" }` rather than throwing —
+ * the listener's `safeResolveUser` catches throws and treats them as
+ * the apology path (refuse, do not downgrade to public-dataset).
+ * Returning an explicit unlinked result keeps the three-state ladder
+ * ("linked" / "unlinked" / "errored") meaningful for the failure
+ * mode that's actually "we don't know yet" (no link table) rather
+ * than "the registry is broken" (errored).
  *
  * Layer hygiene: lives under `lib/proactive/`. Does NOT import from
  * `@atlas/ee` or from `api/routes/`. Only the SaaS deploy wires this
  * up; self-hosted deployments can either reuse this factory (the
  * unlinked-only path is correct everywhere) or omit `userResolver`
- * entirely (the listener defaults to "unlinked" when undefined).
+ * entirely (the listener defaults to `{ kind: "unlinked" }` when
+ * undefined).
  *
  * @module
  */

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useatlas/types",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Shared types for the Atlas text-to-SQL agent",
   "type": "module",
   "scripts": {

--- a/packages/types/src/proactive.ts
+++ b/packages/types/src/proactive.ts
@@ -31,9 +31,50 @@
  *   - `PauseDecision` (boolean-blind `layer?: PauseLayer`)
  *   - `ClassificationResult.isQuestion` (boolean blindness)
  *   - `ProactiveMeterEvent` (eventType-conditional field shape)
- *   - Branded `WorkspaceId` / `ChannelId` / `UserId` / `Confidence` /
- *     `MicroUSD` / `Millis` / `EpochMs` (primitive obsession)
+ *   - Branded `ChannelId` / `MessageId` / `Confidence` / `MicroUSD` /
+ *     `Millis` / `EpochMs` (primitive obsession — see #2641 for the
+ *     identity-bearing brand types that have landed)
+ *
+ * Brand types added in #2641 (type-only — runtime promotion chokepoints
+ * live in `@useatlas/chat` because adding value exports here would
+ * break the scaffold-CI gotcha until the package is republished):
+ *   - `WorkspaceId` — Atlas org id (`organization.id` / `slack_installations.org_id`)
+ *   - `AtlasUserId` — Atlas user id (`user.id`)
+ *   - `ExternalUserId` — Slack/Teams/etc platform user id (Slack `U…`)
  */
+
+// ---------------------------------------------------------------------------
+// Identity brands (#2641) — type-level companion to #2624
+// ---------------------------------------------------------------------------
+
+/**
+ * Atlas workspace id (`organization.id`).
+ *
+ * Distinct nominal type from `AtlasUserId` and `ExternalUserId` even
+ * though all three are strings at runtime, so a transposed-arg call
+ * (`verifyWorkspace(asker.externalUserId)`) is a compile error. The
+ * single runtime chokepoint that promotes a bare string into a
+ * `WorkspaceId` is `assertWorkspaceId` from `@useatlas/chat` — every
+ * boundary (host adapter, SaaS config, default verifier) flows through
+ * it so an empty/malformed id fails fast instead of silently routing
+ * the asker to a "global" tenant.
+ */
+export type WorkspaceId = string & { readonly __brand: "WorkspaceId" };
+
+/**
+ * Atlas user id (`user.id`). Carried by the linked branch of
+ * `ResolvedAsker`. Promoted via `assertAtlasUserId` from `@useatlas/chat`.
+ */
+export type AtlasUserId = string & { readonly __brand: "AtlasUserId" };
+
+/**
+ * Platform-side user id from the chat adapter (Slack `U…`, Teams aad
+ * object id, etc.). Always paired with `platform` to disambiguate
+ * "U999 in Slack tenant A" vs "U999 in Slack tenant B"; tenant scoping
+ * itself is the `WorkspaceId` brand on the per-event resolver context.
+ * Promoted via `assertExternalUserId` from `@useatlas/chat`.
+ */
+export type ExternalUserId = string & { readonly __brand: "ExternalUserId" };
 
 // ---------------------------------------------------------------------------
 // Pause registry (#2295) — three-layer kill switch + per-user opt-out

--- a/packages/types/src/proactive.ts
+++ b/packages/types/src/proactive.ts
@@ -167,9 +167,14 @@ export type ProactiveMeterOutcome =
  * Field shape is deliberately flat — discriminating per `eventType`
  * would force every emitter to switch on the type before constructing
  * the payload. Deferred to a follow-up; see module header.
+ *
+ * `workspaceId` is branded {@link WorkspaceId} (#2641) — the plugin
+ * always emits a branded value (the listener promotes via
+ * `assertWorkspaceId` at the boundary), so consumers on the API side
+ * statically know the id came through the chokepoint.
  */
 export interface ProactiveMeterEvent {
-  workspaceId: string;
+  workspaceId: WorkspaceId;
   channelId: string;
   messageId?: string | null;
   eventType: ProactiveMeterEventType;

--- a/plugins/chat/src/bridge.ts
+++ b/plugins/chat/src/bridge.ts
@@ -56,6 +56,7 @@ import {
   assertExternalUserId,
   assertWorkspaceId,
 } from "./proactive/identity";
+import type { ExternalUserId, WorkspaceId } from "@useatlas/types/proactive";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -1125,68 +1126,82 @@ export function createChatBridge(
 
         if (slashWorkspaceId) {
           // Brand promotion at the boundary (#2641). Empty / malformed
-          // ids fall through to the standard question flow via the
-          // feedback-subcommand refusal path above; the assert helpers
-          // throw on empty, so wrap in a try/catch to keep the slash
-          // handler crash-safe.
-          let brandedWorkspaceId;
-          let brandedExternalUserId;
+          // ids on a *feedback* subcommand → refuse + return (can't
+          // attribute the feedback row). On a *non-feedback* slash the
+          // proactive block doesn't own the response — let it fall
+          // through to the standard question flow at line ~1169 so the
+          // user still gets answered.
+          let brandedWorkspaceId: WorkspaceId | null = null;
+          let brandedExternalUserId: ExternalUserId | null = null;
           try {
             brandedWorkspaceId = assertWorkspaceId(slashWorkspaceId);
             brandedExternalUserId = assertExternalUserId(event.user.userId);
           } catch (err) {
             if (err instanceof InvalidProactiveIdentityError) {
               log.warn(
-                { field: err.field, channelId: event.channel.id },
-                "Proactive feedback slash: identifier promotion failed — refusing",
+                {
+                  field: err.field,
+                  channelId: event.channel.id,
+                  isFeedbackSubcommand,
+                },
+                isFeedbackSubcommand
+                  ? "Proactive feedback slash: identifier promotion failed — refusing"
+                  : "Proactive slash: identifier promotion failed — falling back to standard question flow",
               );
               if (isFeedbackSubcommand) {
                 await refuseFeedbackSubcommand(event);
+                return;
+              }
+              // Non-feedback slash: skip the proactive routing block
+              // and fall through to the standard question flow below.
+              brandedWorkspaceId = null;
+              brandedExternalUserId = null;
+            } else {
+              throw err;
+            }
+          }
+
+          if (brandedWorkspaceId !== null && brandedExternalUserId !== null) {
+            const handled = await handleProactiveFeedbackSlash({
+              text: event.text,
+              channelId: event.channel.id,
+              workspaceId: brandedWorkspaceId,
+              asker: {
+                platform: event.adapter?.name ?? config.proactive.platform ?? "unknown",
+                externalUserId: brandedExternalUserId,
+                userName: event.user.userName,
+              },
+              config: {
+                resolveWorkspaceId: config.proactive.resolveWorkspaceId,
+                isEnabled: config.proactive.isEnabled,
+                classify: config.proactive.classify,
+                getWorkspaceConfig: config.proactive.getWorkspaceConfig,
+                getChannelConfigs: config.proactive.getChannelConfigs,
+                userResolver: config.proactive.userResolver,
+                executeQueryProactive: config.proactive.executeQueryProactive,
+                linkUrl: config.proactive.linkUrl,
+                platform: config.proactive.platform,
+                feedbackCollector: config.proactive.feedbackCollector,
+                slashCommandName: config.slashCommandName,
+              },
+              log,
+              recentAnswers: proactiveRecentAnswers,
+            });
+            if (handled) {
+              try {
+                await event.channel.postEphemeral(
+                  event.user,
+                  { markdown: "Thanks for the feedback." },
+                  { fallbackToDM: false },
+                );
+              } catch (ackErr) {
+                log.debug(
+                  { err: ackErr instanceof Error ? ackErr : new Error(String(ackErr)) },
+                  "Proactive feedback slash ack postEphemeral failed — feedback already recorded",
+                );
               }
               return;
             }
-            throw err;
-          }
-
-          const handled = await handleProactiveFeedbackSlash({
-            text: event.text,
-            channelId: event.channel.id,
-            workspaceId: brandedWorkspaceId,
-            asker: {
-              platform: event.adapter?.name ?? config.proactive.platform ?? "unknown",
-              externalUserId: brandedExternalUserId,
-              userName: event.user.userName,
-            },
-            config: {
-              resolveWorkspaceId: config.proactive.resolveWorkspaceId,
-              isEnabled: config.proactive.isEnabled,
-              classify: config.proactive.classify,
-              getWorkspaceConfig: config.proactive.getWorkspaceConfig,
-              getChannelConfigs: config.proactive.getChannelConfigs,
-              userResolver: config.proactive.userResolver,
-              executeQueryProactive: config.proactive.executeQueryProactive,
-              linkUrl: config.proactive.linkUrl,
-              platform: config.proactive.platform,
-              feedbackCollector: config.proactive.feedbackCollector,
-              slashCommandName: config.slashCommandName,
-            },
-            log,
-            recentAnswers: proactiveRecentAnswers,
-          });
-          if (handled) {
-            try {
-              await event.channel.postEphemeral(
-                event.user,
-                { markdown: "Thanks for the feedback." },
-                { fallbackToDM: false },
-              );
-            } catch (ackErr) {
-              log.debug(
-                { err: ackErr instanceof Error ? ackErr : new Error(String(ackErr)) },
-                "Proactive feedback slash ack postEphemeral failed — feedback already recorded",
-              );
-            }
-            return;
           }
         }
       } catch (err) {

--- a/plugins/chat/src/bridge.ts
+++ b/plugins/chat/src/bridge.ts
@@ -51,6 +51,11 @@ import { handleProactiveFeedbackSlash, registerProactiveListener } from "./proac
 import { detectUnsubscribeDM } from "./proactive/pause";
 import type { RecentAnswers } from "./proactive/feedback";
 import { parseFeedbackSlashArgs } from "./proactive/feedback";
+import {
+  InvalidProactiveIdentityError,
+  assertExternalUserId,
+  assertWorkspaceId,
+} from "./proactive/identity";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -1119,13 +1124,37 @@ export function createChatBridge(
         }
 
         if (slashWorkspaceId) {
+          // Brand promotion at the boundary (#2641). Empty / malformed
+          // ids fall through to the standard question flow via the
+          // feedback-subcommand refusal path above; the assert helpers
+          // throw on empty, so wrap in a try/catch to keep the slash
+          // handler crash-safe.
+          let brandedWorkspaceId;
+          let brandedExternalUserId;
+          try {
+            brandedWorkspaceId = assertWorkspaceId(slashWorkspaceId);
+            brandedExternalUserId = assertExternalUserId(event.user.userId);
+          } catch (err) {
+            if (err instanceof InvalidProactiveIdentityError) {
+              log.warn(
+                { field: err.field, channelId: event.channel.id },
+                "Proactive feedback slash: identifier promotion failed — refusing",
+              );
+              if (isFeedbackSubcommand) {
+                await refuseFeedbackSubcommand(event);
+              }
+              return;
+            }
+            throw err;
+          }
+
           const handled = await handleProactiveFeedbackSlash({
             text: event.text,
             channelId: event.channel.id,
-            workspaceId: slashWorkspaceId,
+            workspaceId: brandedWorkspaceId,
             asker: {
               platform: event.adapter?.name ?? config.proactive.platform ?? "unknown",
-              externalUserId: event.user.userId,
+              externalUserId: brandedExternalUserId,
               userName: event.user.userName,
             },
             config: {

--- a/plugins/chat/src/index.ts
+++ b/plugins/chat/src/index.ts
@@ -124,6 +124,7 @@ export {
   assertExternalUserId,
   assertWorkspaceId,
 } from "./proactive";
+export type { ProactiveIdentityField } from "./proactive";
 export type {
   AtlasUserId,
   ChannelPauseLayer,

--- a/plugins/chat/src/index.ts
+++ b/plugins/chat/src/index.ts
@@ -118,10 +118,18 @@ export type {
 } from "./config";
 
 // Proactive chat layer (slices #2292 reaction-first tracer, #2293 reaction-to-answer, #2295 kill switch, #2298 feedback)
+export {
+  InvalidProactiveIdentityError,
+  assertAtlasUserId,
+  assertExternalUserId,
+  assertWorkspaceId,
+} from "./proactive";
 export type {
+  AtlasUserId,
   ChannelPauseLayer,
   ChannelProactiveConfig,
   ClassificationResult,
+  ExternalUserId,
   FeedbackCollectorFn,
   FeedbackOutcome,
   FeedbackSlashParse,
@@ -147,6 +155,7 @@ export type {
   ResolvedAsker,
   ResolveWorkspaceIdFn,
   SensitivityPreset,
+  WorkspaceId,
   WorkspaceProactiveConfig,
 } from "./proactive";
 export {

--- a/plugins/chat/src/proactive/__tests__/answerer.test.ts
+++ b/plugins/chat/src/proactive/__tests__/answerer.test.ts
@@ -13,12 +13,17 @@ import {
   shouldAnswerOnReaction,
   type ProactiveAsker,
 } from "../answerer";
+import {
+  assertExternalUserId,
+  assertWorkspaceId,
+} from "../identity";
 
 const ASKER: ProactiveAsker = {
   platform: "slack",
-  externalUserId: "U-asker",
+  externalUserId: assertExternalUserId("U-asker"),
   userName: "alice",
 };
+const WS_1 = assertWorkspaceId("ws-1");
 
 // ---------------------------------------------------------------------------
 // PendingAnswers
@@ -27,7 +32,7 @@ const ASKER: ProactiveAsker = {
 describe("PendingAnswers", () => {
   it("records and consumes a single entry", () => {
     const reg = new PendingAnswers();
-    reg.record("T1", "M1", { text: "what was MRR last month?", asker: ASKER, workspaceId: "ws-1" });
+    reg.record("T1", "M1", { text: "what was MRR last month?", asker: ASKER, workspaceId: WS_1 });
     expect(reg.size()).toBe(1);
 
     const peek = reg.peek("T1", "M1");
@@ -42,7 +47,7 @@ describe("PendingAnswers", () => {
   it("expires entries past the TTL", () => {
     let now = 1_000_000;
     const reg = new PendingAnswers(PENDING_ANSWER_TTL_MS, 100, () => now);
-    reg.record("T1", "M1", { text: "q?", asker: ASKER, workspaceId: "ws-1" });
+    reg.record("T1", "M1", { text: "q?", asker: ASKER, workspaceId: WS_1 });
 
     now += PENDING_ANSWER_TTL_MS + 1;
     expect(reg.peek("T1", "M1")).toBeNull();
@@ -51,9 +56,9 @@ describe("PendingAnswers", () => {
 
   it("evicts the oldest entry when over the cap", () => {
     const reg = new PendingAnswers(PENDING_ANSWER_TTL_MS, 2);
-    reg.record("T1", "M1", { text: "first", asker: ASKER, workspaceId: "ws-1" });
-    reg.record("T1", "M2", { text: "second", asker: ASKER, workspaceId: "ws-1" });
-    reg.record("T1", "M3", { text: "third", asker: ASKER, workspaceId: "ws-1" });
+    reg.record("T1", "M1", { text: "first", asker: ASKER, workspaceId: WS_1 });
+    reg.record("T1", "M2", { text: "second", asker: ASKER, workspaceId: WS_1 });
+    reg.record("T1", "M3", { text: "third", asker: ASKER, workspaceId: WS_1 });
 
     expect(reg.peek("T1", "M1")).toBeNull();
     expect(reg.peek("T1", "M2")?.text).toBe("second");
@@ -63,8 +68,8 @@ describe("PendingAnswers", () => {
 
   it("namespaces entries by thread and message id", () => {
     const reg = new PendingAnswers();
-    reg.record("T1", "M1", { text: "a", asker: ASKER, workspaceId: "ws-1" });
-    reg.record("T2", "M1", { text: "b", asker: ASKER, workspaceId: "ws-1" });
+    reg.record("T1", "M1", { text: "a", asker: ASKER, workspaceId: WS_1 });
+    reg.record("T2", "M1", { text: "b", asker: ASKER, workspaceId: WS_1 });
     expect(reg.consume("T1", "M1")?.text).toBe("a");
     expect(reg.consume("T2", "M1")?.text).toBe("b");
   });
@@ -75,7 +80,7 @@ describe("PendingAnswers", () => {
 // ---------------------------------------------------------------------------
 
 describe("shouldAnswerOnReaction", () => {
-  const pending = { text: "q?", asker: ASKER, workspaceId: "ws-1", recordedAt: 0 };
+  const pending = { text: "q?", asker: ASKER, workspaceId: WS_1, recordedAt: 0 };
 
   it("answers when a non-bot user adds the reaction to a known message", () => {
     const decision = shouldAnswerOnReaction({

--- a/plugins/chat/src/proactive/__tests__/identity.test.ts
+++ b/plugins/chat/src/proactive/__tests__/identity.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Tests for the proactive identity-brand chokepoints (#2641).
+ *
+ * Pins:
+ *  - Each `assert*Id` returns the input string when non-empty (the
+ *    brand is purely nominal — runtime value passes through unchanged).
+ *  - Each helper throws `InvalidProactiveIdentityError` on empty input
+ *    AND on non-string input. Empty is the silent-failure mode that
+ *    routed every asker to a "global" tenant pre-#2641; failing fast at
+ *    the boundary is the contract.
+ *  - The thrown error carries the field name so a host's catch can
+ *    distinguish workspace-id misconfig from user-id misconfig in logs.
+ *  - Type-level: the returned brand is NOT assignable across brands —
+ *    a `WorkspaceId` can't be passed where an `AtlasUserId` is expected.
+ *    Asserted via `// @ts-expect-error` lines so a regression on the
+ *    brand `__brand` tag would fail the type-check step in `/ci`.
+ */
+
+import { describe, expect, it } from "bun:test";
+import type {
+  AtlasUserId,
+  ExternalUserId,
+  WorkspaceId,
+} from "@useatlas/types/proactive";
+import {
+  InvalidProactiveIdentityError,
+  assertAtlasUserId,
+  assertExternalUserId,
+  assertWorkspaceId,
+} from "../identity";
+
+describe("assertWorkspaceId", () => {
+  it("promotes a non-empty string into a WorkspaceId at runtime (passthrough)", () => {
+    const id = assertWorkspaceId("org-abc-123");
+    expect(id).toBe("org-abc-123" as WorkspaceId);
+  });
+
+  it("throws InvalidProactiveIdentityError on the empty string", () => {
+    expect(() => assertWorkspaceId("")).toThrow(InvalidProactiveIdentityError);
+  });
+
+  it("throws and tags the field name on empty so host catches can distinguish", () => {
+    try {
+      assertWorkspaceId("");
+      throw new Error("unreachable — assertWorkspaceId(\"\") should throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(InvalidProactiveIdentityError);
+      expect((err as InvalidProactiveIdentityError).field).toBe("WorkspaceId");
+    }
+  });
+
+  it("throws on a non-string runtime value (defensive against JS callers)", () => {
+    // The TS signature rejects this, but plain-JS hosts can still call
+    // with `null` / `undefined` / a number. The helper must reject
+    // before casting — silently branding `undefined as WorkspaceId`
+    // would re-introduce the silent-global-tenant footgun.
+    expect(() =>
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      assertWorkspaceId(undefined as unknown as string),
+    ).toThrow(InvalidProactiveIdentityError);
+  });
+});
+
+describe("assertAtlasUserId", () => {
+  it("promotes a non-empty string into an AtlasUserId at runtime (passthrough)", () => {
+    const id = assertAtlasUserId("user-abc");
+    expect(id).toBe("user-abc" as AtlasUserId);
+  });
+
+  it("throws on empty with the AtlasUserId field tag", () => {
+    try {
+      assertAtlasUserId("");
+      throw new Error("unreachable");
+    } catch (err) {
+      expect(err).toBeInstanceOf(InvalidProactiveIdentityError);
+      expect((err as InvalidProactiveIdentityError).field).toBe("AtlasUserId");
+    }
+  });
+});
+
+describe("assertExternalUserId", () => {
+  it("promotes a non-empty string into an ExternalUserId at runtime (passthrough)", () => {
+    const id = assertExternalUserId("U999");
+    expect(id).toBe("U999" as ExternalUserId);
+  });
+
+  it("throws on empty with the ExternalUserId field tag", () => {
+    try {
+      assertExternalUserId("");
+      throw new Error("unreachable");
+    } catch (err) {
+      expect(err).toBeInstanceOf(InvalidProactiveIdentityError);
+      expect((err as InvalidProactiveIdentityError).field).toBe(
+        "ExternalUserId",
+      );
+    }
+  });
+});
+
+describe("brand types are not assignable across brands (type-level)", () => {
+  it("forbids passing a WorkspaceId where an AtlasUserId is expected", () => {
+    const ws = assertWorkspaceId("org-1");
+    function takesAtlasUserId(_id: AtlasUserId): void {}
+    // @ts-expect-error — WorkspaceId is not assignable to AtlasUserId
+    takesAtlasUserId(ws);
+    // Runtime sanity (the underlying string still passes through).
+    expect(ws).toBe("org-1" as WorkspaceId);
+  });
+
+  it("forbids passing an ExternalUserId where a WorkspaceId is expected", () => {
+    const ext = assertExternalUserId("U999");
+    function takesWorkspaceId(_id: WorkspaceId): void {}
+    // @ts-expect-error — ExternalUserId is not assignable to WorkspaceId
+    takesWorkspaceId(ext);
+    expect(ext).toBe("U999" as ExternalUserId);
+  });
+
+  it("forbids passing a bare string where a brand is expected", () => {
+    function takesWorkspaceId(_id: WorkspaceId): void {}
+    // @ts-expect-error — bare string is not assignable to WorkspaceId
+    takesWorkspaceId("not-branded");
+  });
+});

--- a/plugins/chat/src/proactive/__tests__/listener.test.ts
+++ b/plugins/chat/src/proactive/__tests__/listener.test.ts
@@ -2272,15 +2272,17 @@ describe("registerProactiveListener — #2641 brand-promotion boundaries", () =>
     // No classify event, no react, no pending — full silent skip.
     expect(onMeterEvent).not.toHaveBeenCalled();
     expect(thread._addReaction).not.toHaveBeenCalled();
-    // The warn-log fires so on-call sees the contract violation.
-    const warnCalls = (log.warn as unknown as {
+    // The error-log fires so on-call sees the contract violation —
+    // not warn, because a persistent empty-id host bug would otherwise
+    // hide behind hundreds of identical warns (#2628 history).
+    const errorCalls = (log.error as unknown as {
       mock: { calls: ReadonlyArray<ReadonlyArray<unknown>> };
     }).mock.calls;
-    const matchingWarn = warnCalls.find((c) => {
+    const matchingError = errorCalls.find((c) => {
       const payload = c[0] as { rawWorkspaceId?: string };
       return payload?.rawWorkspaceId === "";
     });
-    expect(matchingWarn).toBeDefined();
+    expect(matchingError).toBeDefined();
   });
 
   it("channel-message handler: missing message.author.userId logs a warn and skips pending registration (orphan reaction)", async () => {

--- a/plugins/chat/src/proactive/__tests__/listener.test.ts
+++ b/plugins/chat/src/proactive/__tests__/listener.test.ts
@@ -38,6 +38,11 @@ import type {
   ProactiveExecuteQuery,
   ProactiveUserResolver,
 } from "../answerer";
+import {
+  assertAtlasUserId,
+  assertExternalUserId,
+  assertWorkspaceId,
+} from "../identity";
 
 // ---------------------------------------------------------------------------
 // Test doubles
@@ -174,8 +179,11 @@ const baseWorkspace: WorkspaceProactiveConfig = {
 const yesLLM: LLMClassifierFn = async () => ({ isQuestion: true, confidence: 0.9 });
 const noLLM: LLMClassifierFn = async () => ({ isQuestion: false, confidence: 0.1 });
 
-const linkedResolver: ProactiveUserResolver = async () => ({ atlasUserId: "atlas-user-1" });
-const unlinkedResolver: ProactiveUserResolver = async () => ({});
+const linkedResolver: ProactiveUserResolver = async () => ({
+  kind: "linked",
+  atlasUserId: assertAtlasUserId("atlas-user-1"),
+});
+const unlinkedResolver: ProactiveUserResolver = async () => ({ kind: "unlinked" });
 
 const echoExecute: ProactiveExecuteQuery = async (question) => ({
   answer: `Echo: ${question}`,
@@ -722,8 +730,8 @@ describe("handleProactiveFeedbackSlash", () => {
     const handled = await handleProactiveFeedbackSlash({
       text: "how many users last month",
       channelId: "C-allowed",
-      workspaceId: "ws_1",
-      asker: { platform: "slack", externalUserId: "U-asker", userName: "alice" },
+      workspaceId: assertWorkspaceId("ws_1"),
+      asker: { platform: "slack", externalUserId: assertExternalUserId("U-asker"), userName: "alice" },
       config: {
         isEnabled: () => true,
         classify: yesLLM,
@@ -753,8 +761,8 @@ describe("handleProactiveFeedbackSlash", () => {
     const handled = await handleProactiveFeedbackSlash({
       text: "feedback figure looks stale",
       channelId: "C-allowed",
-      workspaceId: "ws_1",
-      asker: { platform: "slack", externalUserId: "U-asker", userName: "alice" },
+      workspaceId: assertWorkspaceId("ws_1"),
+      asker: { platform: "slack", externalUserId: assertExternalUserId("U-asker"), userName: "alice" },
       config: {
         isEnabled: () => true,
         classify: yesLLM,
@@ -781,8 +789,8 @@ describe("handleProactiveFeedbackSlash", () => {
     const handled = await handleProactiveFeedbackSlash({
       text: "feedback some text",
       channelId: "C-allowed",
-      workspaceId: "ws_1",
-      asker: { platform: "slack", externalUserId: "U-asker", userName: "alice" },
+      workspaceId: assertWorkspaceId("ws_1"),
+      asker: { platform: "slack", externalUserId: assertExternalUserId("U-asker"), userName: "alice" },
       config: {
         isEnabled: () => true,
         classify: yesLLM,
@@ -896,7 +904,7 @@ describe("registerProactiveListener — kill switch", () => {
     await invoke(thread, makeMessage({ text: "@atlas pause" }));
     expect(onPauseRequest).toHaveBeenCalledTimes(1);
     expect((onPauseRequest.mock.calls[0] as unknown[])?.[0]).toMatchObject({
-      workspaceId: "ws_1",
+      workspaceId: assertWorkspaceId("ws_1"),
       channelId: "C-allowed",
       layer: "channel-24h",
     });
@@ -921,7 +929,7 @@ describe("registerProactiveListener — kill switch", () => {
     await invokeDM(thread, makeMessage({ text: "unsubscribe" }));
     expect(onPauseRequest).toHaveBeenCalledTimes(1);
     expect((onPauseRequest.mock.calls[0] as unknown[])?.[0]).toMatchObject({
-      workspaceId: "ws_1",
+      workspaceId: assertWorkspaceId("ws_1"),
       channelId: null,
       layer: "user-optout",
       durationMs: null,
@@ -1289,7 +1297,7 @@ describe("registerProactiveListener — public dataset (#2297)", () => {
     await invokeMessage(thread, makeMessage({ id: "M1" }));
     await invokeReaction(triggerReaction(thread));
     expect(executeQueryProactive).toHaveBeenCalledTimes(1);
-    expect(executeQueryProactive.mock.calls[0]![1].atlasUserId).toBe(
+    expect(executeQueryProactive.mock.calls[0]![1].atlasUserId as string).toBe(
       "atlas-user-1",
     );
     // The allowlist lookup is for the unlinked path — linked asker
@@ -1345,7 +1353,7 @@ describe("registerProactiveListener — public dataset (#2297)", () => {
       { entityName: "marketing.users", denyMetrics: [] },
     ]);
     const executeQueryProactive = mock(
-      async (q: string, _ctx: { threadId: string; asker: { externalUserId: string }; atlasUserId: string | null; workspaceId: string }) => ({
+      async (q: string, _ctx: Parameters<ProactiveExecuteQuery>[1]) => ({
         answer: `Echo: ${q}`,
         entitiesReferenced: ["marketing.users"],
       }),
@@ -1378,7 +1386,7 @@ describe("registerProactiveListener — public dataset (#2297)", () => {
       { entityName: "marketing.users", denyMetrics: [] },
     ]);
     const executeQueryProactive = mock(
-      async (q: string, _ctx: { threadId: string; asker: { externalUserId: string }; atlasUserId: string | null; workspaceId: string }) => ({
+      async (q: string, _ctx: Parameters<ProactiveExecuteQuery>[1]) => ({
         answer: `Echo: ${q}`,
         entitiesReferenced: ["finance.revenue"],
       }),
@@ -1414,7 +1422,7 @@ describe("registerProactiveListener — public dataset (#2297)", () => {
       { entityName: "finance.revenue", denyMetrics: [] },
     ]);
     const executeQueryProactive = mock(
-      async (q: string, _ctx: { threadId: string; asker: { externalUserId: string }; atlasUserId: string | null; workspaceId: string }) => ({
+      async (q: string, _ctx: Parameters<ProactiveExecuteQuery>[1]) => ({
         answer: `Echo: ${q}`,
         entitiesReferenced: ["finance.revenue", "finance.customers"],
       }),
@@ -1445,7 +1453,7 @@ describe("registerProactiveListener — public dataset (#2297)", () => {
       { entityName: "marketing.users", denyMetrics: ["email"] },
     ]);
     const executeQueryProactive = mock(
-      async (q: string, _ctx: { threadId: string; asker: { externalUserId: string }; atlasUserId: string | null; workspaceId: string }) => ({
+      async (q: string, _ctx: Parameters<ProactiveExecuteQuery>[1]) => ({
         answer: `Echo: ${q}`,
         entitiesReferenced: ["marketing.users"],
         metricsReferenced: ["signup_date", "email"],
@@ -1483,7 +1491,7 @@ describe("registerProactiveListener — public dataset (#2297)", () => {
       { entityName: "marketing.users", denyMetrics: [] },
     ]);
     const executeQueryProactive = mock(
-      async (q: string, _ctx: { threadId: string; asker: { externalUserId: string }; atlasUserId: string | null; workspaceId: string }) => ({
+      async (q: string, _ctx: Parameters<ProactiveExecuteQuery>[1]) => ({
         answer: `Echo: ${q}`,
         // No entitiesReferenced field at all.
       }),
@@ -1518,7 +1526,7 @@ describe("registerProactiveListener — public dataset (#2297)", () => {
       { entityName: "marketing.users", denyMetrics: [] },
     ]);
     const executeQueryProactive = mock(
-      async (q: string, _ctx: { threadId: string; asker: { externalUserId: string }; atlasUserId: string | null; workspaceId: string }) => ({
+      async (q: string, _ctx: Parameters<ProactiveExecuteQuery>[1]) => ({
         answer: `Echo: ${q}`,
         entitiesReferenced: [], // empty array
       }),
@@ -1552,7 +1560,7 @@ describe("registerProactiveListener — public dataset (#2297)", () => {
       { entityName: "marketing.users", denyMetrics: [] },
     ]);
     const executeQueryProactive = mock(
-      async (q: string, _ctx: { threadId: string; asker: { externalUserId: string }; atlasUserId: string | null; workspaceId: string }) => ({
+      async (q: string, _ctx: Parameters<ProactiveExecuteQuery>[1]) => ({
         answer: `Echo: ${q}`,
         // No entitiesReferenced
       }),
@@ -2027,10 +2035,13 @@ describe("registerProactiveListener — multi-tenant per-event resolution (#2620
 
     const userResolver = mock(
       async (
-        _asker: { externalUserId: string },
-        _ctx: { workspaceId: string },
-      ) => ({ atlasUserId: "atlas-user-1" }),
-    );
+        _asker: Parameters<ProactiveUserResolver>[0],
+        _ctx: Parameters<ProactiveUserResolver>[1],
+      ) => ({
+        kind: "linked" as const,
+        atlasUserId: assertAtlasUserId("atlas-user-1"),
+      }),
+    ) satisfies ProactiveUserResolver;
     const executeQueryProactive = mock(echoExecute);
     const { chat, invokeMessage, invokeReaction } = makeChat();
     await registerProactiveListener(
@@ -2080,8 +2091,12 @@ describe("registerProactiveListener — multi-tenant per-event resolution (#2620
     // workspaceId. Pre-#2624 the second arg didn't exist; assert both
     // the shape and the value to pin the contract.
     expect(userResolver).toHaveBeenCalledTimes(2);
-    expect(userResolver.mock.calls[0]![1]).toEqual({ workspaceId: "ws-A" });
-    expect(userResolver.mock.calls[1]![1]).toEqual({ workspaceId: "ws-B" });
+    expect(userResolver.mock.calls[0]![1]).toEqual({
+      workspaceId: assertWorkspaceId("ws-A"),
+    });
+    expect(userResolver.mock.calls[1]![1]).toEqual({
+      workspaceId: assertWorkspaceId("ws-B"),
+    });
 
     // ExecuteQueryProactive context carries the same workspaceId so
     // the host adapter can scope its tool gates.
@@ -2094,20 +2109,24 @@ describe("registerProactiveListener — multi-tenant per-event resolution (#2620
     ).toBe("ws-B");
   });
 
-  it("legacy 1-arg userResolver still runs (TS contravariance) but receives the workspaceId at runtime", async () => {
-    // Pinned behaviour: a pre-#2624 host whose resolver was declared
-    // as `(asker) => Promise<...>` still type-checks against the new
-    // `(asker, ctx) => Promise<...>` shape (TypeScript parameter
-    // contravariance allows fewer params). At runtime the listener
-    // passes the second arg unconditionally; a 1-arg fn silently
-    // ignores it. This is the silent-collision path the contract
-    // change addresses: a self-hosted user who upgrades plugins
-    // without touching their resolver gets the old global-lookup
-    // behaviour with no compile or runtime warning.
+  it("pre-#2641 legacy resolver shape now degrades to unlinked at runtime (clean break, no shim)", async () => {
+    // Clean-break posture (#2641): the resolver contract is now a
+    // discriminated `ResolvedAsker` (`{ kind: "linked"; atlasUserId } |
+    // { kind: "unlinked" }`). A pre-#2641 host whose resolver returned
+    // the structural `{ atlasUserId: "..." }` shape still type-checks
+    // through the `as unknown as ProactiveUserResolver` cast (mirrors
+    // the runtime situation when a host upgrades plugins without
+    // touching their resolver), but `safeResolveUser`'s runtime
+    // discriminator check sees no `kind: "linked"` and routes the
+    // asker through the unlinked branch.
     //
-    // This test documents that posture deliberately. If a future
-    // change adds a runtime guard (e.g. resolver.length === 1 warn),
-    // update this test to assert the warn fires.
+    // This is deliberate per the #2641 issue body (pre-customer
+    // clean break — no deprecation shim — matches the precedent of
+    // #2620 and #2626). The previous incarnation of this test pinned
+    // the OPPOSITE — that the legacy shape silently linked the asker.
+    // After the discriminator that's a structural mismatch, and the
+    // listener fails CLOSED to the unlinked path (no link table is
+    // wired here, so the unlinked-asker stub posts).
     const legacyResolver = mock(async (_asker: { externalUserId: string }) => ({
       atlasUserId: "atlas-user-from-legacy",
     }));
@@ -2121,9 +2140,6 @@ describe("registerProactiveListener — multi-tenant per-event resolution (#2620
         resolveWorkspaceId: makeResolver("ws-1"),
         getWorkspaceConfig: defaultGetWorkspace,
         getChannelConfigs: allowChannels("C-allowed"),
-        // Cast: pre-#2624 hosts had this exact 1-arg shape, and
-        // TypeScript still accepts it via contravariance. The cast
-        // mirrors the runtime situation.
         userResolver: legacyResolver as unknown as ProactiveUserResolver,
         executeQueryProactive: echoExecute,
       },
@@ -2143,21 +2159,25 @@ describe("registerProactiveListener — multi-tenant per-event resolution (#2620
       raw: {},
     });
 
-    // Legacy resolver fired and returned its atlasUserId — listener
-    // accepted the link and routed through the linked path. The
-    // second arg was passed (it would silently be undefined inside
-    // the 1-arg function body) but didn't influence the outcome.
+    // Legacy resolver fired and the listener passed the per-event
+    // workspaceId as the 2nd arg (the runtime invariant survives the
+    // contract change). The discriminator check sees no `kind:
+    // "linked"` and routes the asker through the unlinked branch —
+    // the unlinked-asker stub posts in-thread (`thread.post` called),
+    // the linked-asker echo path is NOT taken.
     expect(legacyResolver).toHaveBeenCalledTimes(1);
     expect(legacyResolver.mock.calls[0]![0]).toMatchObject({
-      externalUserId: "U-asker",
+      externalUserId: assertExternalUserId("U-asker"),
     });
-    // The listener still passes the 2nd arg at the runtime call site;
-    // assert it's there even though TS contravariance lets the body
-    // ignore it. This pins the runtime invariant against an
-    // optimization that might drop the 2nd arg.
     const firstCall = legacyResolver.mock.calls[0] as unknown as unknown[];
     expect(firstCall.length).toBe(2);
-    expect(firstCall[1]).toEqual({ workspaceId: "ws-1" });
+    expect(firstCall[1]).toEqual({ workspaceId: assertWorkspaceId("ws-1") });
+    expect(thread.post).toHaveBeenCalledTimes(1);
+    // Echo path NEVER fires when the resolver is structurally invalid.
+    const firstPostArg = (thread.post as unknown as {
+      mock: { calls: unknown[][] };
+    }).mock.calls[0]?.[0];
+    expect(String(firstPostArg ?? "")).not.toContain("Echo:");
   });
 
   it("userResolver throw is per-tenant — logs workspaceId on the apology path", async () => {
@@ -2203,8 +2223,8 @@ describe("registerProactiveListener — multi-tenant per-event resolution (#2620
     // Resolver received the per-event workspaceId, and the error log
     // carries it (so triage can correlate).
     expect(throwingResolver).toHaveBeenCalledWith(
-      expect.objectContaining({ externalUserId: "U-asker" }),
-      { workspaceId: "ws-troubled" },
+      expect.objectContaining({ externalUserId: assertExternalUserId("U-asker") }),
+      { workspaceId: assertWorkspaceId("ws-troubled") },
     );
     const errorCalls = (log.error as unknown as {
       mock: { calls: ReadonlyArray<ReadonlyArray<unknown>> };

--- a/plugins/chat/src/proactive/__tests__/listener.test.ts
+++ b/plugins/chat/src/proactive/__tests__/listener.test.ts
@@ -2236,3 +2236,159 @@ describe("registerProactiveListener — multi-tenant per-event resolution (#2620
     expect(errorCall).toBeDefined();
   });
 });
+
+// ---------------------------------------------------------------------------
+// #2641 — brand promotion at the listener's boundaries
+// ---------------------------------------------------------------------------
+
+describe("registerProactiveListener — #2641 brand-promotion boundaries", () => {
+  it("treats an empty-string workspaceId from resolveWorkspaceId as unknown tenant (silent skip)", async () => {
+    // Pinned behaviour: `safeResolveWorkspace` runs `assertWorkspaceId`
+    // on the host's `string | null` return; an empty string throws
+    // `InvalidProactiveIdentityError` and falls through to the same
+    // silent-skip path as `null`. Pre-#2641 an empty string was
+    // accepted and propagated, collapsing every event onto a single
+    // global tenant.
+    const onMeterEvent = mock(async () => {});
+    const log = makeLogger();
+    const { chat, invokeMessage } = makeChat();
+    await registerProactiveListener(
+      chat as unknown as Parameters<typeof registerProactiveListener>[0],
+      log,
+      {
+        isEnabled: async () => true,
+        classify: yesLLM,
+        // Host-side bug: returns "" instead of null on unknown tenant.
+        // The listener must NOT treat this as the global path.
+        resolveWorkspaceId: makeResolver(""),
+        getWorkspaceConfig: defaultGetWorkspace,
+        getChannelConfigs: defaultGetChannels,
+        onMeterEvent,
+      },
+    );
+    const thread = makeThread("C-allowed");
+    await invokeMessage(thread, makeMessage());
+
+    // No classify event, no react, no pending — full silent skip.
+    expect(onMeterEvent).not.toHaveBeenCalled();
+    expect(thread._addReaction).not.toHaveBeenCalled();
+    // The warn-log fires so on-call sees the contract violation.
+    const warnCalls = (log.warn as unknown as {
+      mock: { calls: ReadonlyArray<ReadonlyArray<unknown>> };
+    }).mock.calls;
+    const matchingWarn = warnCalls.find((c) => {
+      const payload = c[0] as { rawWorkspaceId?: string };
+      return payload?.rawWorkspaceId === "";
+    });
+    expect(matchingWarn).toBeDefined();
+  });
+
+  it("channel-message handler: missing message.author.userId logs a warn and skips pending registration (orphan reaction)", async () => {
+    // `askerFromAuthor` returns `null` when `author.userId` is empty
+    // (assert helper throws, caller catches). The channel-message
+    // handler must NOT register a pending answer in that state — a
+    // pending entry with an empty `externalUserId` would propagate the
+    // emptiness into audit/meter/feedback on a later reaction-back.
+    // The reaction itself was already posted (cost paid); the asker
+    // can never tap-back.
+    const log = makeLogger();
+    const { chat, invokeMessage, invokeReaction } = makeChat();
+    await registerProactiveListener(
+      chat as unknown as Parameters<typeof registerProactiveListener>[0],
+      log,
+      {
+        isEnabled: async () => true,
+        classify: yesLLM,
+        resolveWorkspaceId: makeResolver("ws-1"),
+        getWorkspaceConfig: defaultGetWorkspace,
+        getChannelConfigs: allowChannels("C-orphan"),
+        userResolver: linkedResolver,
+        executeQueryProactive: echoExecute,
+      },
+    );
+    const thread = makeThread("C-orphan");
+    await invokeMessage(thread, makeMessage({ id: "M-orphan", userId: "" }));
+
+    // Reaction posted (the cost of classification + react had already
+    // been paid by the time `askerFromAuthor` was called).
+    expect(thread._addReaction).toHaveBeenCalledTimes(1);
+    // Warn logged — on-call must see the orphan state.
+    const warnCalls = (log.warn as unknown as {
+      mock: { calls: ReadonlyArray<ReadonlyArray<unknown>> };
+    }).mock.calls;
+    const matchingWarn = warnCalls.find((c) => {
+      const payload = c[0] as { messageId?: string };
+      return payload?.messageId === "M-orphan";
+    });
+    expect(matchingWarn).toBeDefined();
+    // Reaction-back on the same message-id finds nothing pending.
+    await invokeReaction({
+      added: true,
+      messageId: "M-orphan",
+      threadId: thread.channelId,
+      thread,
+      user: { isMe: false, isBot: false, userId: "U-other", userName: "bob" },
+      emoji: PROACTIVE_REACTION,
+      rawEmoji: "robot_face",
+      adapter: { name: "slack" },
+      raw: {},
+    });
+    expect(thread.post).not.toHaveBeenCalled();
+  });
+
+  it("safeResolveUser rejects an empty atlasUserId on the linked branch (plain-JS host RLS-bypass guard)", async () => {
+    // Belt-and-braces: the discriminated union forces a `kind: "linked"`
+    // construction at the type level, but a plain-JS host (or a TS
+    // host that casts `"" as AtlasUserId`) can still propagate an
+    // empty id. The listener's `safeResolveUser` calls
+    // `assertAtlasUserId` on the resolved id; an empty value throws
+    // `InvalidProactiveIdentityError` and routes the asker through the
+    // `errored` apology path — NOT the linked path with an empty id
+    // that would silently bypass per-user RLS in `executeQueryProactive`.
+    const executeQueryProactive = mock(echoExecute);
+    const log = makeLogger();
+    const { chat, invokeMessage, invokeReaction } = makeChat();
+    await registerProactiveListener(
+      chat as unknown as Parameters<typeof registerProactiveListener>[0],
+      log,
+      {
+        isEnabled: async () => true,
+        classify: yesLLM,
+        resolveWorkspaceId: makeResolver("ws-rls"),
+        getWorkspaceConfig: defaultGetWorkspace,
+        getChannelConfigs: allowChannels("C-rls"),
+        // Malformed linked result: kind is correct but atlasUserId is
+        // empty. The `as ...` cast mirrors the plain-JS / TS-cast bypass.
+        userResolver: (async () => ({
+          kind: "linked",
+          atlasUserId: "" as never,
+        })) as unknown as ProactiveUserResolver,
+        executeQueryProactive,
+      },
+    );
+    const thread = makeThread("C-rls");
+    await invokeMessage(thread, makeMessage({ id: "M-rls" }));
+    await invokeReaction({
+      added: true,
+      messageId: "M-rls",
+      threadId: thread.channelId,
+      thread,
+      user: { isMe: false, isBot: false, userId: "U-asker", userName: "asker" },
+      emoji: PROACTIVE_REACTION,
+      rawEmoji: "robot_face",
+      adapter: { name: "slack" },
+      raw: {},
+    });
+
+    // CRITICAL invariant: executeQueryProactive was NOT invoked. The
+    // linked branch with empty atlasUserId would have bypassed per-user
+    // RLS inside the host adapter.
+    expect(executeQueryProactive).not.toHaveBeenCalled();
+    // Apology copy posted (errored ladder, not unlinked path).
+    expect(thread.post).toHaveBeenCalledTimes(1);
+    const firstPostArg = (thread.post as unknown as {
+      mock: { calls: unknown[][] };
+    }).mock.calls[0]?.[0];
+    expect(String(firstPostArg ?? "")).toMatch(/Sorry — I hit an error/);
+  });
+});

--- a/plugins/chat/src/proactive/answerer.ts
+++ b/plugins/chat/src/proactive/answerer.ts
@@ -17,6 +17,11 @@
  */
 
 import type { Author } from "chat";
+import type {
+  AtlasUserId,
+  ExternalUserId,
+  WorkspaceId,
+} from "@useatlas/types/proactive";
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -26,17 +31,33 @@ import type { Author } from "chat";
 export interface ProactiveAsker {
   /** Platform name, e.g. "slack". */
   platform: string;
-  /** Platform-side user ID (Slack U…, etc.). */
-  externalUserId: string;
+  /**
+   * Platform-side user ID (Slack `U…`, etc.). Branded
+   * ({@link ExternalUserId}) — promote via `assertExternalUserId` at
+   * the boundary so a transposed-arg call (e.g. passing an
+   * `externalUserId` where an `AtlasUserId` was expected) is a compile
+   * error. See `plugins/chat/src/proactive/identity.ts`.
+   */
+  externalUserId: ExternalUserId;
   /** Optional display name for logs / fallback prompts. */
   userName?: string;
 }
 
-/** Returned by the host's user-resolver callback. */
-export interface ResolvedAsker {
-  /** Atlas user ID when the chat user is linked via OAuth. */
-  atlasUserId?: string;
-}
+/**
+ * Returned by the host's user-resolver callback. Discriminated union so
+ * the unlinked branch is explicit at the public API (mirrors the
+ * three-state `ResolveOutcome` used inside `listener.ts`).
+ *
+ * Pre-#2641 shape was `{ atlasUserId?: string }` — a host that
+ * returned `{ atlasUserId: undefined }` and a host that returned `{}`
+ * were structurally identical, and the listener had to defensively
+ * check `resolved.atlasUserId` before treating the result as
+ * "unlinked". The discriminator makes the unlinked branch a
+ * deliberate construction, not an accident-of-omission.
+ */
+export type ResolvedAsker =
+  | { kind: "linked"; atlasUserId: AtlasUserId }
+  | { kind: "unlinked" };
 
 /**
  * Per-event context passed to the user resolver (#2624).
@@ -51,11 +72,20 @@ export interface ResolvedAsker {
  * Kept as a separate object (Option 2 from the issue body) rather than
  * inlined into {@link ProactiveAsker} so the asker stays a pure
  * chat-platform identity while the workspace stays per-event context.
+ *
+ * `Readonly` (#2641): a host implementation must not mutate the
+ * workspaceId mid-call — the listener promoted exactly one branded id
+ * before invoking the resolver, and downstream code (meter rows,
+ * audit, public-dataset gate) relies on that identity staying stable.
  */
-export interface ProactiveUserResolverContext {
-  /** Atlas workspace id (`org_id`) the event belongs to. */
-  workspaceId: string;
-}
+export type ProactiveUserResolverContext = Readonly<{
+  /**
+   * Atlas workspace id (`org_id`) the event belongs to. Branded
+   * ({@link WorkspaceId}) — promote via `assertWorkspaceId` at the
+   * boundary.
+   */
+  workspaceId: WorkspaceId;
+}>;
 
 /**
  * Resolver: chat-platform identity → Atlas identity.
@@ -119,24 +149,27 @@ export interface ProactiveQueryResult {
  */
 export type ProactiveExecuteQuery = (
   question: string,
-  context: {
+  context: Readonly<{
     threadId: string;
     asker: ProactiveAsker;
     /**
      * Atlas user id when the asker is OAuth'd into a workspace user.
      * `null` means the asker is unlinked — host MUST constrain the
-     * agent to the workspace's public-dataset allowlist.
+     * agent to the workspace's public-dataset allowlist. Branded
+     * ({@link AtlasUserId}) so a transposed-arg call (e.g. passing
+     * `asker.externalUserId` here) is a compile error.
      */
-    atlasUserId: string | null;
+    atlasUserId: AtlasUserId | null;
     /**
      * Atlas workspace id the event belongs to (#2624). Threaded through
      * from the listener's per-event resolution so the host can scope
      * tool registries, allowlist lookups, and tenant-specific config
      * by the right tenant on multi-tenant SaaS. Static-tenant hosts
-     * can ignore it.
+     * can ignore it. Branded ({@link WorkspaceId}) — promoted via
+     * `assertWorkspaceId` at the listener's boundary.
      */
-    workspaceId: string;
-  },
+    workspaceId: WorkspaceId;
+  }>,
 ) => Promise<ProactiveQueryResult>;
 
 // ---------------------------------------------------------------------------
@@ -152,9 +185,9 @@ export interface PendingAnswerEntry {
    * this message (#2620 multi-tenant). The reaction-back / button-click
    * handlers reuse this id rather than re-resolving from the reaction
    * event so the answer routes to the same tenant that the original
-   * reaction was emitted for.
+   * reaction was emitted for. Branded ({@link WorkspaceId}).
    */
-  workspaceId: string;
+  workspaceId: WorkspaceId;
   /** Epoch ms when this entry was recorded. */
   recordedAt: number;
 }

--- a/plugins/chat/src/proactive/identity.ts
+++ b/plugins/chat/src/proactive/identity.ts
@@ -1,0 +1,85 @@
+/**
+ * Runtime chokepoints for the proactive identity brands (#2641).
+ *
+ * Type-only brands live in `@useatlas/types/proactive`; this module is
+ * the single runtime entry that promotes a bare `string` into a
+ * `WorkspaceId` / `AtlasUserId` / `ExternalUserId`. Every host
+ * adapter — `packages/api/src/lib/proactive/{user-resolver,answer-adapter}.ts`,
+ * the SaaS `deploy/api/atlas.config.ts` boundary, the per-event
+ * resolver in `listener.ts` — constructs branded values via these
+ * helpers so an empty or malformed id fails fast instead of silently
+ * collapsing every asker onto a single global tenant.
+ *
+ * Splitting from `@useatlas/types`: the types package is type-only
+ * (the "@useatlas/types scaffold gotcha" — adding value exports breaks
+ * scaffold CI until the package is republished). Runtime promotion
+ * needs a value export, so the assert helpers live here and the
+ * types live there. The plugin re-exports both from `@useatlas/chat`
+ * so a host can `import { assertWorkspaceId, type WorkspaceId }` from
+ * a single module.
+ */
+
+import type {
+  AtlasUserId,
+  ExternalUserId,
+  WorkspaceId,
+} from "@useatlas/types/proactive";
+
+/**
+ * Thrown by the `assert*Id` helpers when a boundary input is empty.
+ *
+ * Empty is the failure mode that silently routes every asker to the
+ * "global" tenant or the unlinked path (pre-#2624 / pre-#2641). Promoting
+ * an empty string into a brand is a host-wiring bug, not a runtime
+ * condition the listener can recover from — surface as a thrown error
+ * so the host's boundary `try/catch` (see `safeResolveWorkspace` in
+ * `listener.ts`) converts it into a silent skip rather than running
+ * with a misattributed tenant.
+ */
+export class InvalidProactiveIdentityError extends Error {
+  constructor(public readonly field: string) {
+    super(`Proactive identifier ${field} must be a non-empty string`);
+    this.name = "InvalidProactiveIdentityError";
+  }
+}
+
+/**
+ * Promote a bare string into a {@link WorkspaceId}. Throws
+ * {@link InvalidProactiveIdentityError} on empty input. Use at every
+ * boundary that accepts a workspace id from outside the plugin — the
+ * per-event resolver result in the listener, the host adapter
+ * constructors, and the SaaS config wiring.
+ */
+export function assertWorkspaceId(value: string): WorkspaceId {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new InvalidProactiveIdentityError("WorkspaceId");
+  }
+  return value as WorkspaceId;
+}
+
+/**
+ * Promote a bare string into an {@link AtlasUserId}. Throws
+ * {@link InvalidProactiveIdentityError} on empty input. Use when the
+ * host's user-resolver returns a linked Atlas id and before
+ * constructing `{ kind: "linked", atlasUserId }`.
+ */
+export function assertAtlasUserId(value: string): AtlasUserId {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new InvalidProactiveIdentityError("AtlasUserId");
+  }
+  return value as AtlasUserId;
+}
+
+/**
+ * Promote a bare string into an {@link ExternalUserId}. Throws
+ * {@link InvalidProactiveIdentityError} on empty input. Use when
+ * building a {@link import("./answerer").ProactiveAsker} from a chat
+ * SDK `Author`. Self-bot / placeholder events that pass through the
+ * listener never reach `ProactiveAsker` construction.
+ */
+export function assertExternalUserId(value: string): ExternalUserId {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new InvalidProactiveIdentityError("ExternalUserId");
+  }
+  return value as ExternalUserId;
+}

--- a/plugins/chat/src/proactive/identity.ts
+++ b/plugins/chat/src/proactive/identity.ts
@@ -56,14 +56,28 @@ export class InvalidProactiveIdentityError extends Error {
 }
 
 /**
+ * True when `value` is a non-empty string with at least one
+ * non-whitespace character. Whitespace-only strings (`"   "`, `"\n"`,
+ * `"\t"`) are an "innocent-looking empty" upstream-trim-bug that would
+ * otherwise pass the `length === 0` check and propagate a useless id
+ * into the listener — same failure-mode class as the empty string.
+ * Rejection is non-mutating: callers receive the original value if it
+ * passes (DB rows may have been stored with leading/trailing space and
+ * the brand must match those rows verbatim).
+ */
+function isNonEmptyIdentifier(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+/**
  * Promote a bare string into a {@link WorkspaceId}. Throws
- * {@link InvalidProactiveIdentityError} on empty input. Use at every
- * boundary that accepts a workspace id from outside the plugin — the
- * per-event resolver result in the listener, the host adapter
- * constructors, and the SaaS config wiring.
+ * {@link InvalidProactiveIdentityError} on empty / whitespace-only
+ * input. Use at every boundary that accepts a workspace id from
+ * outside the plugin — the per-event resolver result in the listener,
+ * the host adapter constructors, and the SaaS config wiring.
  */
 export function assertWorkspaceId(value: string): WorkspaceId {
-  if (typeof value !== "string" || value.length === 0) {
+  if (!isNonEmptyIdentifier(value)) {
     throw new InvalidProactiveIdentityError("WorkspaceId");
   }
   return value as WorkspaceId;
@@ -71,12 +85,12 @@ export function assertWorkspaceId(value: string): WorkspaceId {
 
 /**
  * Promote a bare string into an {@link AtlasUserId}. Throws
- * {@link InvalidProactiveIdentityError} on empty input. Use when the
- * host's user-resolver returns a linked Atlas id and before
- * constructing `{ kind: "linked", atlasUserId }`.
+ * {@link InvalidProactiveIdentityError} on empty / whitespace-only
+ * input. Use when the host's user-resolver returns a linked Atlas id
+ * and before constructing `{ kind: "linked", atlasUserId }`.
  */
 export function assertAtlasUserId(value: string): AtlasUserId {
-  if (typeof value !== "string" || value.length === 0) {
+  if (!isNonEmptyIdentifier(value)) {
     throw new InvalidProactiveIdentityError("AtlasUserId");
   }
   return value as AtlasUserId;
@@ -84,13 +98,14 @@ export function assertAtlasUserId(value: string): AtlasUserId {
 
 /**
  * Promote a bare string into an {@link ExternalUserId}. Throws
- * {@link InvalidProactiveIdentityError} on empty input. Use when
- * building a {@link import("./answerer").ProactiveAsker} from a chat
- * SDK `Author`. Self-bot / placeholder events that pass through the
+ * {@link InvalidProactiveIdentityError} on empty / whitespace-only
+ * input. Use when building a
+ * {@link import("./answerer").ProactiveAsker} from a chat SDK
+ * `Author`. Self-bot / placeholder events that pass through the
  * listener never reach `ProactiveAsker` construction.
  */
 export function assertExternalUserId(value: string): ExternalUserId {
-  if (typeof value !== "string" || value.length === 0) {
+  if (!isNonEmptyIdentifier(value)) {
     throw new InvalidProactiveIdentityError("ExternalUserId");
   }
   return value as ExternalUserId;

--- a/plugins/chat/src/proactive/identity.ts
+++ b/plugins/chat/src/proactive/identity.ts
@@ -26,6 +26,18 @@ import type {
 } from "@useatlas/types/proactive";
 
 /**
+ * The branded identity field that failed promotion. Literal union (not
+ * `string`) so catch sites — `safeResolveWorkspace` in `listener.ts`,
+ * the slash handler in `bridge.ts` — can exhaustively narrow on
+ * `err.field` and a telemetry consumer grouping by `field` sees a
+ * stable, typo-proof set.
+ */
+export type ProactiveIdentityField =
+  | "WorkspaceId"
+  | "AtlasUserId"
+  | "ExternalUserId";
+
+/**
  * Thrown by the `assert*Id` helpers when a boundary input is empty.
  *
  * Empty is the failure mode that silently routes every asker to the
@@ -37,7 +49,7 @@ import type {
  * with a misattributed tenant.
  */
 export class InvalidProactiveIdentityError extends Error {
-  constructor(public readonly field: string) {
+  constructor(public readonly field: ProactiveIdentityField) {
     super(`Proactive identifier ${field} must be a non-empty string`);
     this.name = "InvalidProactiveIdentityError";
   }

--- a/plugins/chat/src/proactive/index.ts
+++ b/plugins/chat/src/proactive/index.ts
@@ -70,6 +70,22 @@ export {
   type ShouldAnswerOnReactionInput,
 } from "./answerer";
 
+// Identity brands + runtime chokepoints (#2641). Types live in
+// `@useatlas/types/proactive`; the assert helpers + error class live in
+// `./identity` and are re-exported here so hosts can pull both from a
+// single `@useatlas/chat` import.
+export {
+  InvalidProactiveIdentityError,
+  assertAtlasUserId,
+  assertExternalUserId,
+  assertWorkspaceId,
+} from "./identity";
+export type {
+  AtlasUserId,
+  ExternalUserId,
+  WorkspaceId,
+} from "@useatlas/types/proactive";
+
 export {
   PROACTIVE_ANSWER_ACTION_ID,
   PROACTIVE_DISMISS_ACTION_ID,

--- a/plugins/chat/src/proactive/index.ts
+++ b/plugins/chat/src/proactive/index.ts
@@ -79,6 +79,7 @@ export {
   assertAtlasUserId,
   assertExternalUserId,
   assertWorkspaceId,
+  type ProactiveIdentityField,
 } from "./identity";
 export type {
   AtlasUserId,

--- a/plugins/chat/src/proactive/listener.ts
+++ b/plugins/chat/src/proactive/listener.ts
@@ -428,9 +428,15 @@ export async function registerProactiveListener(
       return assertWorkspaceId(raw);
     } catch (err) {
       if (err instanceof InvalidProactiveIdentityError) {
-        log.warn(
-          { rawWorkspaceId: raw },
-          "Proactive resolveWorkspaceId returned an empty/invalid id — treating as unknown tenant (skip)",
+        // Log at error, not warn — the host's `resolveWorkspaceId`
+        // contract is "return null OR a non-empty string". An empty /
+        // whitespace-only string is a host wiring bug that would
+        // persistently fire every event for the misconfigured tenant.
+        // Warn-level would hide the bug behind hundreds of identical
+        // lines (#2628 history); error escalates it to on-call.
+        log.error(
+          { rawWorkspaceId: raw, field: err.field },
+          "Proactive resolveWorkspaceId returned an empty/invalid id — contract violation, treating as unknown tenant (skip)",
         );
         return null;
       }

--- a/plugins/chat/src/proactive/listener.ts
+++ b/plugins/chat/src/proactive/listener.ts
@@ -40,6 +40,7 @@ import {
 } from "./answerer";
 import {
   InvalidProactiveIdentityError,
+  assertAtlasUserId,
   assertExternalUserId,
   assertWorkspaceId,
 } from "./identity";
@@ -807,9 +808,14 @@ export async function registerProactiveListener(
       const platform = adapterPlatform(thread.adapter, config.platform);
       const asker = askerFromAuthor(message.author, platform);
       if (!asker) {
-        log.debug(
+        // Orphan state: reaction already posted (line above), but no
+        // pending entry registered — the asker can never tap-back to
+        // request the answer. Warn so on-call sees the asymmetry; a
+        // missing `message.author.userId` is a chat-adapter contract
+        // violation, not a routine event.
+        log.warn(
           { workspaceId, channelId, messageId: message.id },
-          "Proactive: message.author.userId missing — cannot attribute proactive answer, skipping pending registration",
+          "Proactive: message.author.userId missing — reaction posted but cannot attribute pending answer (orphan reaction)",
         );
         return;
       }
@@ -1001,9 +1007,13 @@ export async function registerProactiveListener(
         const platform = adapterPlatform(event.adapter, config.platform);
         const asker = askerFromAuthor(event.user, platform);
         if (!asker) {
-          log.debug(
+          // User clicked Helpful / Not-helpful / Wrong-data but the
+          // event carries no `event.user.userId` — feedback row is
+          // dropped silently. Warn (not debug) so on-call notices a
+          // chat-adapter contract violation that's eating feedback.
+          log.warn(
             { workspaceId, actionId: event.actionId },
-            "Proactive feedback button: event.user.userId missing — cannot attribute feedback, dropping",
+            "Proactive feedback button: event.user.userId missing — feedback dropped (cannot attribute row)",
           );
           return;
         }
@@ -1695,9 +1705,19 @@ async function safeResolveUser(
     // id. Pre-#2641 the contract was `{ atlasUserId?: string }` and we
     // had to defensively check for an empty/undefined `atlasUserId` to
     // decide which branch to take.
+    //
+    // Belt-and-braces against a plain-JS host (or a TS host that
+    // bypasses the brand via `as AtlasUserId`) returning `kind:
+    // "linked"` with an empty `atlasUserId`: re-run `assertAtlasUserId`
+    // at this boundary. An empty linked id would propagate into
+    // `executeQueryProactive({ atlasUserId: "" })` and silently bypass
+    // per-user RLS — the exact failure mode the brand was meant to
+    // close. The runtime guard catches the case the brand can't (since
+    // brand purity is by code-review, not by the type system).
     const resolved = await resolver(asker, { workspaceId });
     if (resolved.kind === "linked") {
-      return { kind: "linked", atlasUserId: resolved.atlasUserId };
+      const branded = assertAtlasUserId(resolved.atlasUserId);
+      return { kind: "linked", atlasUserId: branded };
     }
     return { kind: "unlinked" };
   } catch (err) {

--- a/plugins/chat/src/proactive/listener.ts
+++ b/plugins/chat/src/proactive/listener.ts
@@ -18,6 +18,11 @@
 import { emoji } from "chat";
 import type { Adapter, Author, Chat, Message, ReactionEvent, Thread } from "chat";
 import type { PluginLogger } from "@useatlas/plugin-sdk";
+import type {
+  AtlasUserId,
+  ExternalUserId,
+  WorkspaceId,
+} from "@useatlas/types/proactive";
 import { classifyMessage } from "./classifier";
 import {
   detectPauseCommand,
@@ -33,6 +38,11 @@ import {
   type ProactiveExecuteQuery,
   type ProactiveUserResolver,
 } from "./answerer";
+import {
+  InvalidProactiveIdentityError,
+  assertExternalUserId,
+  assertWorkspaceId,
+} from "./identity";
 import type {
   ChannelProactiveConfig,
   GetChannelConfigsFn,
@@ -229,13 +239,33 @@ function adapterPlatform(adapter: { name?: string } | undefined, fallback?: stri
   return adapter?.name ?? fallback ?? "unknown";
 }
 
-/** Build a ProactiveAsker from a message author. */
-function askerFromAuthor(author: Author, platform: string): ProactiveAsker {
-  return {
-    platform,
-    externalUserId: author.userId,
-    userName: author.userName,
-  };
+/**
+ * Build a ProactiveAsker from a message author. Brands the
+ * `externalUserId` at this boundary (#2641) — the asker object is the
+ * one runtime shape that flows from the chat SDK into every
+ * proactive entry point (resolver, executeQueryProactive, pause-request,
+ * feedback). Promoting once here means the downstream code can read
+ * `asker.externalUserId` as a typed {@link ExternalUserId} without
+ * each consumer re-validating.
+ *
+ * Returns `null` when the platform-side user id is missing — the
+ * caller treats that as "no asker, skip the proactive flow" because
+ * we can't attribute the reaction / answer to anyone. Pre-#2641 we
+ * would build an asker with an empty `externalUserId` and propagate
+ * it through audit + meter rows.
+ */
+function askerFromAuthor(author: Author, platform: string): ProactiveAsker | null {
+  try {
+    const externalUserId = assertExternalUserId(author.userId);
+    return {
+      platform,
+      externalUserId,
+      userName: author.userName,
+    };
+  } catch (err) {
+    if (err instanceof InvalidProactiveIdentityError) return null;
+    throw err;
+  }
 }
 
 /**
@@ -253,7 +283,7 @@ function askerFromAuthor(author: Author, platform: string): ProactiveAsker {
 async function emitProactiveMeter(
   config: ProactiveListenerConfig,
   log: PluginLogger,
-  workspaceId: string,
+  workspaceId: WorkspaceId,
   partial: Omit<ProactiveMeterEvent, "workspaceId">,
 ): Promise<void> {
   if (!config.onMeterEvent) return;
@@ -352,7 +382,7 @@ export async function registerProactiveListener(
   // pre-applies `config` + `log` so call sites stay terse and the
   // per-event `workspaceId` stays explicit.
   const emitMeter = (
-    workspaceId: string,
+    workspaceId: WorkspaceId,
     partial: Omit<ProactiveMeterEvent, "workspaceId">,
   ): Promise<void> => emitProactiveMeter(config, log, workspaceId, partial);
 
@@ -372,9 +402,10 @@ export async function registerProactiveListener(
     adapter: Adapter,
     thread: Thread<unknown, unknown>,
     message: Message,
-  ): Promise<string | null> => {
+  ): Promise<WorkspaceId | null> => {
+    let raw: string | null;
     try {
-      return await config.resolveWorkspaceId({
+      raw = await config.resolveWorkspaceId({
         adapter,
         thread: thread as Thread,
         message,
@@ -386,13 +417,31 @@ export async function registerProactiveListener(
       );
       return null;
     }
+    if (raw === null) return null;
+    // Brand promotion (#2641). The host's `resolveWorkspaceId`
+    // contract returns `string | null`; promote to `WorkspaceId` at
+    // the boundary so every downstream call site reads a typed brand.
+    // Empty string falls back to "unknown tenant" — would otherwise
+    // silently collapse every asker onto the global path.
+    try {
+      return assertWorkspaceId(raw);
+    } catch (err) {
+      if (err instanceof InvalidProactiveIdentityError) {
+        log.warn(
+          { rawWorkspaceId: raw },
+          "Proactive resolveWorkspaceId returned an empty/invalid id — treating as unknown tenant (skip)",
+        );
+        return null;
+      }
+      throw err;
+    }
   };
 
   // Safe wrappers for the per-event workspace/channel config loaders.
   // Failures resolve to null/empty (the listener falls back to "not
   // opted in" / "no overrides" without crashing the SDK loop).
   const safeGetWorkspaceConfig = async (
-    workspaceId: string,
+    workspaceId: WorkspaceId,
   ): Promise<WorkspaceProactiveConfig | null> => {
     try {
       return await config.getWorkspaceConfig(workspaceId);
@@ -409,7 +458,7 @@ export async function registerProactiveListener(
   };
 
   const safeGetChannelConfigs = async (
-    workspaceId: string,
+    workspaceId: WorkspaceId,
   ): Promise<ReadonlyArray<ChannelProactiveConfig>> => {
     try {
       return await config.getChannelConfigs(workspaceId);
@@ -757,6 +806,13 @@ export async function registerProactiveListener(
 
       const platform = adapterPlatform(thread.adapter, config.platform);
       const asker = askerFromAuthor(message.author, platform);
+      if (!asker) {
+        log.debug(
+          { workspaceId, channelId, messageId: message.id },
+          "Proactive: message.author.userId missing — cannot attribute proactive answer, skipping pending registration",
+        );
+        return;
+      }
       pending.record(thread.channelId, message.id, { text, asker, workspaceId });
 
       // Meter: reaction landed — emit a `react` row so the admin
@@ -944,6 +1000,13 @@ export async function registerProactiveListener(
 
         const platform = adapterPlatform(event.adapter, config.platform);
         const asker = askerFromAuthor(event.user, platform);
+        if (!asker) {
+          log.debug(
+            { workspaceId, actionId: event.actionId },
+            "Proactive feedback button: event.user.userId missing — cannot attribute feedback, dropping",
+          );
+          return;
+        }
         const answerMessageId = event.messageId;
 
         if (outcome === "wrong-data") {
@@ -1019,6 +1082,13 @@ export async function registerProactiveListener(
 
       const platform = adapterPlatform(event.adapter, config.platform);
       const asker = askerFromAuthor(event.user, platform);
+      if (!asker) {
+        log.debug(
+          { workspaceId },
+          "Proactive wrong-data modal: event.user.userId missing — cannot attribute feedback, closing",
+        );
+        return { action: "close" as const };
+      }
       const answerMessageId =
         typeof event.privateMetadata === "string" ? event.privateMetadata : "";
       const rawText = event.values?.[PROACTIVE_FB_WRONG_DATA_INPUT_ID];
@@ -1079,7 +1149,7 @@ export async function registerProactiveListener(
 export async function handleProactiveFeedbackSlash(args: {
   text: string | undefined;
   channelId: string;
-  workspaceId: string;
+  workspaceId: WorkspaceId;
   asker: ProactiveAsker;
   config: ProactiveListenerConfig;
   log: PluginLogger;
@@ -1135,7 +1205,7 @@ async function runAnswerFlow(
   threadId: string,
   text: string,
   asker: ProactiveAsker,
-  workspaceId: string,
+  workspaceId: WorkspaceId,
   config: ProactiveListenerConfig,
   log: PluginLogger,
   recentAnswers: RecentAnswers,
@@ -1170,8 +1240,9 @@ async function runAnswerFlow(
   // Local alias for the module-scope `emitProactiveMeter` helper —
   // pre-applies `config` / `log` / `workspaceId` (the latter is the
   // per-flow tenant resolved at the caller; was `config.workspaceId ?? ""`
-  // pre-#2620). Shared by the public-dataset refusal branch and the
-  // linked-asker happy path below.
+  // pre-#2620, now a typed {@link WorkspaceId} brand per #2641). Shared
+  // by the public-dataset refusal branch and the linked-asker happy
+  // path below.
   const emitMeter = (
     partial: Omit<ProactiveMeterEvent, "workspaceId">,
   ): Promise<void> => emitProactiveMeter(config, log, workspaceId, partial);
@@ -1590,10 +1661,15 @@ async function deliverFeedback(
  * Returned by `safeResolveUser` so the caller can distinguish three
  * states the resolver may produce:
  *
- *   - `kind: "linked"`   — `atlasUserId` is the resolved Atlas id.
- *   - `kind: "unlinked"` — resolver explicitly returned `undefined`
- *                          atlasUserId (this asker is genuinely not
- *                          OAuth'd into a workspace user).
+ *   - `kind: "linked"`   — `atlasUserId` is the resolved branded
+ *                          {@link AtlasUserId}.
+ *   - `kind: "unlinked"` — resolver returned `{ kind: "unlinked" }`
+ *                          (this asker is genuinely not OAuth'd into
+ *                          a workspace user). Discriminated public
+ *                          contract per #2641 — pre-#2641 this branch
+ *                          was an absent `atlasUserId` field on a
+ *                          structural shape, indistinguishable from a
+ *                          host omission.
  *   - `kind: "errored"`  — resolver threw. The caller MUST NOT treat
  *                          this as `unlinked` — that would silently
  *                          downgrade a linked Atlas user (whose
@@ -1603,19 +1679,24 @@ async function deliverFeedback(
  *                          post an apology copy and return.
  */
 type ResolveOutcome =
-  | { kind: "linked"; atlasUserId: string }
+  | { kind: "linked"; atlasUserId: AtlasUserId }
   | { kind: "unlinked" }
   | { kind: "errored" };
 
 async function safeResolveUser(
   resolver: ProactiveUserResolver,
   asker: ProactiveAsker,
-  workspaceId: string,
+  workspaceId: WorkspaceId,
   log: PluginLogger,
 ): Promise<ResolveOutcome> {
   try {
+    // Discriminated `ResolvedAsker` (#2641) — `kind: "linked"` carries
+    // a non-empty branded `AtlasUserId`; `kind: "unlinked"` carries no
+    // id. Pre-#2641 the contract was `{ atlasUserId?: string }` and we
+    // had to defensively check for an empty/undefined `atlasUserId` to
+    // decide which branch to take.
     const resolved = await resolver(asker, { workspaceId });
-    if (resolved.atlasUserId) {
+    if (resolved.kind === "linked") {
       return { kind: "linked", atlasUserId: resolved.atlasUserId };
     }
     return { kind: "unlinked" };


### PR DESCRIPTION
## Summary

Closes #2641. Brand `WorkspaceId` / `AtlasUserId` / `ExternalUserId` on the proactive listener contract — type-level companion to #2624's value-level workspaceId fix.

Pre-#2641 the six identity fields on the proactive contract (`ProactiveUserResolverContext.workspaceId`, `ResolvedAsker.atlasUserId`, `ProactiveAsker.externalUserId`, `ProactiveExecuteQuery.context.{atlasUserId,workspaceId}`, `PendingAnswerEntry.workspaceId`) were all bare `string`, so a transposed-arg call (e.g. `verifyWorkspace(asker.externalUserId)`) type-checked silently. The brands fix it at the type level; runtime `assert*Id` chokepoints fail fast on empty inputs at every boundary.

## What landed

- **Brand types** (type-only) in `@useatlas/types/proactive`:
  - `WorkspaceId`, `AtlasUserId`, `ExternalUserId` — distinct nominal types over `string & { __brand }`
- **Runtime chokepoints** in `plugins/chat/src/proactive/identity.ts`:
  - `assertWorkspaceId` / `assertAtlasUserId` / `assertExternalUserId` — throw `InvalidProactiveIdentityError` on empty input
- Re-exported from `@useatlas/chat` so hosts pull both from one import
- **`ResolvedAsker` is now a discriminated union** — `{ kind: "linked"; atlasUserId } | { kind: "unlinked" }`. The unlinked branch is an explicit construction, not an absent field on a structural shape.
- **`ProactiveUserResolverContext` is `Readonly<{...}>`** so a host can't mutate the workspaceId inside the resolver call.
- **Listener boundary promotions** in `listener.ts`:
  - `safeResolveWorkspace` calls `assertWorkspaceId` on the host's `string | null` return
  - `askerFromAuthor` calls `assertExternalUserId(author.userId)` — returns `null` when the platform-side id is missing, callers short-circuit
- **Host adapters** accept branded inputs:
  - `defaultVerifyWorkspace(workspaceId: WorkspaceId)`
  - `defaultResolveOrgForUser(atlasUserId: AtlasUserId)`
  - `getPublicDataset(asker, ctx: { workspaceId: WorkspaceId })`
- **Bridge** (`plugins/chat/src/bridge.ts`) promotes `slashWorkspaceId` and `event.user.userId` to brands at the boundary

## Clean break (no deprecation shim)

Per the issue body / precedent of #2620 + #2626 (pre-customer). The legacy `{ atlasUserId: "..." }` resolver shape (no `kind` discriminator) now degrades to the unlinked branch at runtime — the listener test that previously documented back-compat is rewritten to document the new posture.

## Versioning

`@useatlas/types` bumped 0.1.3 → 0.1.4 (additive type-only export). Workspace refs use `workspace:*` / `>=0.1.3` so no consumer ref-bump needed.

## Out of scope (deferred)

- Slack-user-link table — required to actually return `{ kind: "linked", atlasUserId }` from the SaaS resolver. Hook point documented in `user-resolver.ts`.
- Synthetic-Message casts in `listener.ts:890,963` — tracked in #2623 item 2.

## Test plan

- [x] New identity-helper tests (11 cases) — runtime passthrough, throws on empty/non-string, `// @ts-expect-error` lines pin cross-brand non-assignability
- [x] Existing proactive tests updated to construct brands at fixtures
- [x] `bun run type` — clean
- [x] All proactive tests pass (chat plugin: 455/0, api proactive: 180/0)
- [x] Full api suite (426/0) + full `test:others`
- [x] Pre-PR /ci gates: lint (0 errors), schema drift, template drift, EE imports, syncpack, railway-watch