### PR TITLE
refactor(plugins/chat): #2623 items 2+6 — ResolverEventLite + per-event cache sentinel

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -343,7 +343,7 @@
     },
     "packages/types": {
       "name": "@useatlas/types",
-      "version": "0.1.3",
+      "version": "0.1.4",
     },
     "packages/web": {
       "name": "@atlas/web",

--- a/packages/api/src/lib/proactive/workspace-id-resolver.ts
+++ b/packages/api/src/lib/proactive/workspace-id-resolver.ts
@@ -40,22 +40,18 @@
 import { hasInternalDB } from "@atlas/api/lib/db/internal";
 import { getInstallation } from "@atlas/api/lib/slack/store";
 import { createLogger } from "@atlas/api/lib/logger";
+import type { ResolverEvent } from "@useatlas/chat";
 
 const log = createLogger("proactive:workspace-id-resolver");
 
-/**
- * Structural shape of the resolver event passed by the chat plugin.
- * Kept structural (the `chat` npm package is not a dependency of
- * `@atlas/api`) so the host helper can sit under `lib/proactive/`
- * without pulling the plugin's full type surface in. The chat plugin's
- * `ResolveWorkspaceIdFn` is the strict type; this is the minimum surface
- * the Slack resolver actually reads from the event.
- */
-interface ResolverEvent {
-  adapter: { name?: string } | undefined;
-  thread: unknown;
-  message: { raw?: unknown } | undefined;
-}
+// Pre-#2623 this module declared a local structural `interface
+// ResolverEvent { adapter; thread: unknown; message: { raw } }` to
+// avoid taking a `@useatlas/chat` runtime dependency. Post-#2623 item 2
+// the plugin's `ResolverEvent` is `Pick<Message, "id" | "raw">` plus an
+// `adapter` and an optional `thread`; importing the named type as a
+// type-only reference keeps host + plugin shapes in lockstep so a
+// future widening (e.g. adding a `metadata` field) propagates here at
+// compile time instead of silently drifting.
 
 /**
  * Build the Slack-platform workspace resolver.

--- a/plugins/chat/src/bridge.ts
+++ b/plugins/chat/src/bridge.ts
@@ -1074,23 +1074,19 @@ export function createChatBridge(
 
     if (config.proactive && proactiveRecentAnswers) {
       try {
-        // Synthesize a minimal Message shape from adapter + raw payload
-        // so the Slack-platform resolver can read `raw.team_id`.
+        // Build the lite resolver event from adapter + raw payload so
+        // the Slack-platform resolver can read `raw.team_id`. The
+        // `ResolverEvent` shape (#2623 item 2) accepts an undefined
+        // thread and a narrowed message shape, so this synthesis is
+        // assignment-compatible with no `as unknown` casts.
         const resolveAdapter = event.adapter;
         let slashWorkspaceId: string | null = null;
         if (resolveAdapter) {
           try {
             slashWorkspaceId = await config.proactive.resolveWorkspaceId({
               adapter: resolveAdapter,
-              thread: undefined as unknown as Parameters<
-                typeof config.proactive.resolveWorkspaceId
-              >[0]["thread"],
-              message: {
-                id: "",
-                raw: event.raw,
-              } as unknown as Parameters<
-                typeof config.proactive.resolveWorkspaceId
-              >[0]["message"],
+              thread: undefined,
+              message: { id: "", raw: event.raw },
             });
           } catch (resolveErr) {
             log.warn(

--- a/plugins/chat/src/index.ts
+++ b/plugins/chat/src/index.ts
@@ -155,6 +155,8 @@ export type {
   RecentAnswerEntry,
   ResolvedAsker,
   ResolveWorkspaceIdFn,
+  ResolverEvent,
+  ResolverEventLite,
   SensitivityPreset,
   WorkspaceId,
   WorkspaceProactiveConfig,

--- a/plugins/chat/src/proactive/__tests__/listener.test.ts
+++ b/plugins/chat/src/proactive/__tests__/listener.test.ts
@@ -31,6 +31,7 @@ import type {
   ChannelProactiveConfig,
   LLMClassifierFn,
   ProactiveMeterEvent,
+  ResolverEventLite,
   ResolveWorkspaceIdFn,
   WorkspaceProactiveConfig,
 } from "../types";
@@ -1757,7 +1758,10 @@ describe("registerProactiveListener — multi-tenant per-event resolution (#2620
       ["C-tenant-B", "ws-B"],
     ]);
     const resolveWorkspaceId: ResolveWorkspaceIdFn = async ({ thread }) => {
-      return channelToWorkspace.get(thread.channelId) ?? null;
+      // `thread` is `Thread | undefined` per the #2623 item 2 narrowing —
+      // channel-message events always carry a real thread, so the
+      // optional-chain branch here is the unreachable defensive case.
+      return (thread && channelToWorkspace.get(thread.channelId)) ?? null;
     };
 
     const meterEvents: ProactiveMeterEvent[] = [];
@@ -1808,7 +1812,10 @@ describe("registerProactiveListener — multi-tenant per-event resolution (#2620
       ["C-general-B", "ws-B"],
     ]);
     const resolveWorkspaceId: ResolveWorkspaceIdFn = async ({ thread }) => {
-      return channelToWorkspace.get(thread.channelId) ?? null;
+      // `thread` is `Thread | undefined` per the #2623 item 2 narrowing —
+      // channel-message events always carry a real thread, so the
+      // optional-chain branch here is the unreachable defensive case.
+      return (thread && channelToWorkspace.get(thread.channelId)) ?? null;
     };
 
     const { chat, invokeMessage } = makeChat();
@@ -1844,7 +1851,10 @@ describe("registerProactiveListener — multi-tenant per-event resolution (#2620
       ["C-tenant-B", "ws-B"],
     ]);
     const resolveWorkspaceId: ResolveWorkspaceIdFn = async ({ thread }) => {
-      return channelToWorkspace.get(thread.channelId) ?? null;
+      // `thread` is `Thread | undefined` per the #2623 item 2 narrowing —
+      // channel-message events always carry a real thread, so the
+      // optional-chain branch here is the unreachable defensive case.
+      return (thread && channelToWorkspace.get(thread.channelId)) ?? null;
     };
 
     const onPauseRequest = mock(async () => {});
@@ -1894,7 +1904,10 @@ describe("registerProactiveListener — multi-tenant per-event resolution (#2620
       ["C-tenant-B", "ws-B"],
     ]);
     const resolveWorkspaceId: ResolveWorkspaceIdFn = async ({ thread }) => {
-      return channelToWorkspace.get(thread.channelId) ?? null;
+      // `thread` is `Thread | undefined` per the #2623 item 2 narrowing —
+      // channel-message events always carry a real thread, so the
+      // optional-chain branch here is the unreachable defensive case.
+      return (thread && channelToWorkspace.get(thread.channelId)) ?? null;
     };
 
     const isEnabled = mock(async (_: string) => true);
@@ -1980,7 +1993,10 @@ describe("registerProactiveListener — multi-tenant per-event resolution (#2620
       ["C-tenant-B", "ws-B"],
     ]);
     const resolveWorkspaceId: ResolveWorkspaceIdFn = async ({ thread }) => {
-      return channelToWorkspace.get(thread.channelId) ?? null;
+      // `thread` is `Thread | undefined` per the #2623 item 2 narrowing —
+      // channel-message events always carry a real thread, so the
+      // optional-chain branch here is the unreachable defensive case.
+      return (thread && channelToWorkspace.get(thread.channelId)) ?? null;
     };
 
     const getWorkspaceConfig = mock(
@@ -2030,7 +2046,10 @@ describe("registerProactiveListener — multi-tenant per-event resolution (#2620
       ["C-tenant-B", "ws-B"],
     ]);
     const resolveWorkspaceId: ResolveWorkspaceIdFn = async ({ thread }) => {
-      return channelToWorkspace.get(thread.channelId) ?? null;
+      // `thread` is `Thread | undefined` per the #2623 item 2 narrowing —
+      // channel-message events always carry a real thread, so the
+      // optional-chain branch here is the unreachable defensive case.
+      return (thread && channelToWorkspace.get(thread.channelId)) ?? null;
     };
 
     const userResolver = mock(
@@ -2392,5 +2411,147 @@ describe("registerProactiveListener — #2641 brand-promotion boundaries", () =>
       mock: { calls: unknown[][] };
     }).mock.calls[0]?.[0];
     expect(String(firstPostArg ?? "")).toMatch(/Sorry — I hit an error/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Per-event "called exactly once" sentinel for getWorkspaceConfig (#2623 item 6)
+// ---------------------------------------------------------------------------
+//
+// `types.ts:GetWorkspaceConfigFn` documents the per-event cache contract:
+// "the listener caches the result for the lifetime of the single event
+// handler call so repeated lookups inside one handler stay cheap."
+// Today the channel-message handler reads `getWorkspaceConfig` exactly
+// once per event (the `Promise.all` with `getChannelConfigs` at the top
+// of the post-pause section). This sentinel pins the invariant so a
+// future refactor that adds a second DB read inside the same event
+// (e.g. inside the answer flow, or duplicated in the public-dataset
+// branch) fails loudly here instead of silently regressing the cost
+// contract.
+//
+// Single-event semantics: one `invokeMessage` call must produce exactly
+// one `getWorkspaceConfig` invocation, regardless of how many host
+// callbacks downstream (classify / executeQueryProactive / meter) fire.
+
+describe("registerProactiveListener — per-event getWorkspaceConfig cache (#2623 item 6)", () => {
+  it("calls getWorkspaceConfig exactly once per channel-message event (happy path)", async () => {
+    const getWorkspaceConfig = mock(async () => baseWorkspace);
+    const { chat, invokeMessage } = makeChat();
+    await registerProactiveListener(
+      chat as unknown as Parameters<typeof registerProactiveListener>[0],
+      makeLogger(),
+      {
+        isEnabled: () => true,
+        classify: yesLLM,
+        resolveWorkspaceId: defaultResolver,
+        getWorkspaceConfig,
+        getChannelConfigs: allowChannels("C-allowed"),
+      },
+    );
+    await invokeMessage(makeThread("C-allowed"), makeMessage());
+    expect(getWorkspaceConfig).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls getWorkspaceConfig exactly once even when the linked-asker answer flow runs", async () => {
+    // The answer flow runs from `onReaction`, not the channel-message
+    // handler, so the channel-message event itself MUST still see
+    // exactly one workspace-config read. Reaction-back is a separate
+    // event with its own (independent) cache window — explicitly
+    // covered by the second assertion below so a refactor that calls
+    // `getWorkspaceConfig` inside `runAnswerFlow` would fail loudly.
+    const getWorkspaceConfig = mock(async () => baseWorkspace);
+    const executeQueryProactive: ProactiveExecuteQuery = mock(echoExecute);
+    const { chat, invokeMessage, invokeReaction } = makeChat();
+    await registerProactiveListener(
+      chat as unknown as Parameters<typeof registerProactiveListener>[0],
+      makeLogger(),
+      {
+        isEnabled: () => true,
+        classify: yesLLM,
+        resolveWorkspaceId: defaultResolver,
+        getWorkspaceConfig,
+        getChannelConfigs: allowChannels("C-allowed"),
+        userResolver: linkedResolver,
+        executeQueryProactive,
+      },
+    );
+    const thread = makeThread("C-allowed");
+    await invokeMessage(thread, makeMessage({ id: "M1" }));
+    expect(getWorkspaceConfig).toHaveBeenCalledTimes(1);
+
+    // Reaction-back is a separate event; the reaction handler does not
+    // (and currently must not) re-read `getWorkspaceConfig`. Pinning
+    // the post-reaction count to 1 catches a regression that would
+    // re-read the config inside `runAnswerFlow`.
+    await invokeReaction({
+      added: true,
+      messageId: "M1",
+      threadId: thread.channelId,
+      thread,
+      user: { isMe: false, isBot: false, userId: "U-other", userName: "bob" },
+      emoji: PROACTIVE_REACTION,
+      rawEmoji: "robot_face",
+      adapter: { name: "slack" },
+      raw: {},
+    });
+    expect(executeQueryProactive).toHaveBeenCalledTimes(1);
+    expect(getWorkspaceConfig).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ResolverEventLite narrowing (#2623 item 2)
+// ---------------------------------------------------------------------------
+//
+// The flip from `message: Message` → `message: ResolverEventLite` is
+// only meaningful if a resolver author can no longer read fields
+// outside the lite set. Pre-#2623 the parameter type was the full
+// `Message` and synthesis sites smuggled a partial shape via a
+// structural cast — a resolver that read `event.message.attachments`
+// would compile fine and silently return `undefined.length` at
+// runtime. The cast hole is closed by the narrowing.
+//
+// These are type-level assertions disguised as runtime tests so the
+// file participates in the regular `bun test` run and any regression
+// here lights up the same red as a normal failure. The `_resolver`
+// values are kept (rather than discarded immediately) so the
+// `@ts-expect-error` markers see the field accesses they're asserting
+// against — otherwise the markers themselves error as "unused
+// directive".
+
+describe("ResolveWorkspaceIdFn type narrowing (#2623 item 2)", () => {
+  it("ts-only: a resolver cannot read fields outside ResolverEventLite", () => {
+    const _resolver: ResolveWorkspaceIdFn = async (event) => {
+      // OK — `id` and `raw` are the only allowed fields.
+      void event.message.id;
+      void event.message.raw;
+      // @ts-expect-error — `attachments` is on Message but not ResolverEventLite
+      void event.message.attachments;
+      // @ts-expect-error — `author` is on Message but not ResolverEventLite
+      void event.message.author;
+      // @ts-expect-error — `text` is on Message but not ResolverEventLite
+      void event.message.text;
+      // @ts-expect-error — `formatted` is on Message but not ResolverEventLite
+      void event.message.formatted;
+      // @ts-expect-error — `threadId` is on Message but not ResolverEventLite
+      void event.message.threadId;
+      // @ts-expect-error — `metadata` is on Message but not ResolverEventLite
+      void event.message.metadata;
+      // @ts-expect-error — `links` is on Message but not ResolverEventLite
+      void event.message.links;
+      return null;
+    };
+    expect(typeof _resolver).toBe("function");
+  });
+
+  it("ts-only: ResolverEventLite is structurally a subset of Message", () => {
+    // A synthetic lite shape (`{ id, raw }`) satisfies the resolver
+    // input without any cast — the listener / bridge synthesis sites
+    // rely on this. Real `Message` instances also assign (subtype
+    // direction): the listener's channel-message path passes a real
+    // `Message` to `safeResolveWorkspace`, which narrows it to
+    // `ResolverEventLite` before calling the resolver.
+    const lite: ResolverEventLite = { id: "M1", raw: { team_id: "T1" } };
+    expect(lite.id).toBe("M1");
   });
 });

--- a/plugins/chat/src/proactive/__tests__/listener.test.ts
+++ b/plugins/chat/src/proactive/__tests__/listener.test.ts
@@ -696,6 +696,98 @@ describe("registerProactiveListener — feedback buttons", () => {
     expect(rec.source).toBe("button");
   });
 
+  it("passes the lite ResolverEvent shape (id + raw, no full Message fields) to resolveWorkspaceId from the action handler (#2623 item 2)", async () => {
+    // The PR removed the `as unknown as Message` cast at `listener.ts:1008`.
+    // The synthesis site now constructs `{ id: event.messageId, raw: event.raw }`
+    // directly. This spy pins the exact shape so a future regression that
+    // re-introduces extra fields (or drops `id` / `raw`) fails loudly.
+    // The default fixture resolver ignores its argument, so a spy is needed.
+    const resolveWorkspaceId = mock(async () => "ws_1");
+    const { chat, invokeAction } = makeChat();
+    await registerProactiveListener(
+      chat as unknown as Parameters<typeof registerProactiveListener>[0],
+      makeLogger(),
+      {
+        isEnabled: () => true,
+        classify: yesLLM,
+        resolveWorkspaceId,
+        getWorkspaceConfig: defaultGetWorkspace,
+        getChannelConfigs: allowChannels("C-allowed"),
+        userResolver: linkedResolver,
+        executeQueryProactive: echoExecute,
+        feedbackCollector: async () => {},
+      },
+    );
+    const ev = {
+      actionId: PROACTIVE_FB_HELPFUL_ACTION_ID,
+      adapter: { name: "slack" },
+      messageId: "answer-msg-42",
+      thread: makeThread("C-allowed"),
+      threadId: "C-allowed",
+      user: { isMe: false, isBot: false, userId: "U-asker", userName: "alice" },
+      value: "answer-msg-42",
+      openModal: mock(async () => undefined),
+      raw: { team_id: "T-tenant-A" },
+    };
+    await invokeAction(PROACTIVE_FB_HELPFUL_ACTION_ID, ev);
+
+    expect(resolveWorkspaceId).toHaveBeenCalledTimes(1);
+    const arg = (resolveWorkspaceId.mock.calls[0] as unknown[])?.[0] as {
+      adapter: { name: string };
+      thread: { channelId: string };
+      message: { id: string; raw: unknown };
+    };
+    // Lite shape carries `id` + `raw` only — no `attachments`, `author`,
+    // `text`, etc. Compare a strict key-set so an accidental widening
+    // (e.g. someone synthesising `{ id, raw, text }` to "be safe") fails.
+    expect(Object.keys(arg.message).sort()).toEqual(["id", "raw"]);
+    expect(arg.message.id).toBe("answer-msg-42");
+    expect(arg.message.raw).toEqual({ team_id: "T-tenant-A" });
+    expect(arg.adapter.name).toBe("slack");
+    expect(arg.thread?.channelId).toBe("C-allowed");
+  });
+
+  it("passes the lite ResolverEvent shape (with empty id) to resolveWorkspaceId from the modal-submit handler (#2623 item 2)", async () => {
+    // Same contract pin as the action-handler test above, but for the
+    // modal-submit path at `listener.ts:1095`. Modal events legitimately
+    // synthesise `id: ""` because there's no original message id on a
+    // modal-submit event. The lite shape MUST still be exactly
+    // `{ id, raw }` so a future regression that passes the full event
+    // raw object (which carries extra fields the resolver shouldn't see)
+    // fails loudly.
+    const resolveWorkspaceId = mock(async () => "ws_1");
+    const { chat, invokeModalSubmit } = makeChat();
+    await registerProactiveListener(
+      chat as unknown as Parameters<typeof registerProactiveListener>[0],
+      makeLogger(),
+      {
+        isEnabled: () => true,
+        classify: yesLLM,
+        resolveWorkspaceId,
+        getWorkspaceConfig: defaultGetWorkspace,
+        getChannelConfigs: allowChannels("C-allowed"),
+        feedbackCollector: async () => {},
+      },
+    );
+    await invokeModalSubmit(PROACTIVE_FB_WRONG_DATA_MODAL_ID, {
+      adapter: { name: "slack" },
+      callbackId: PROACTIVE_FB_WRONG_DATA_MODAL_ID,
+      privateMetadata: "answer-msg-7",
+      relatedThread: makeThread("C-allowed"),
+      user: { isMe: false, isBot: false, userId: "U-asker", userName: "alice" },
+      values: { [PROACTIVE_FB_WRONG_DATA_INPUT_ID]: "bad data" },
+      raw: { team_id: "T-tenant-B" },
+    });
+
+    expect(resolveWorkspaceId).toHaveBeenCalledTimes(1);
+    const arg = (resolveWorkspaceId.mock.calls[0] as unknown[])?.[0] as {
+      message: { id: string; raw: unknown };
+    };
+    expect(Object.keys(arg.message).sort()).toEqual(["id", "raw"]);
+    expect(arg.message.id).toBe("");
+    expect(arg.message.raw).toEqual({ team_id: "T-tenant-B" });
+  });
+
   it("silently no-ops when no feedbackCollector is configured", async () => {
     const { chat, invokeAction } = makeChat();
     await registerProactiveListener(chat as any, makeLogger(), {
@@ -2434,8 +2526,16 @@ describe("registerProactiveListener — #2641 brand-promotion boundaries", () =>
 // callbacks downstream (classify / executeQueryProactive / meter) fire.
 
 describe("registerProactiveListener — per-event getWorkspaceConfig cache (#2623 item 6)", () => {
-  it("calls getWorkspaceConfig exactly once per channel-message event (happy path)", async () => {
+  it("calls getWorkspaceConfig + getChannelConfigs exactly once per channel-message event (happy path)", async () => {
+    // `getChannelConfigs` rides the same `Promise.all` as `getWorkspaceConfig`
+    // (`listener.ts:661-664`) and has the identical cost-ceiling property —
+    // pin both spies so a refactor that adds a second read on EITHER fetcher
+    // fails loudly.
     const getWorkspaceConfig = mock(async () => baseWorkspace);
+    const channelConfigs: ChannelProactiveConfig[] = [
+      { channelId: "C-allowed", allow: true },
+    ];
+    const getChannelConfigs = mock(async () => channelConfigs);
     const { chat, invokeMessage } = makeChat();
     await registerProactiveListener(
       chat as unknown as Parameters<typeof registerProactiveListener>[0],
@@ -2445,21 +2545,28 @@ describe("registerProactiveListener — per-event getWorkspaceConfig cache (#262
         classify: yesLLM,
         resolveWorkspaceId: defaultResolver,
         getWorkspaceConfig,
-        getChannelConfigs: allowChannels("C-allowed"),
+        getChannelConfigs,
       },
     );
     await invokeMessage(makeThread("C-allowed"), makeMessage());
     expect(getWorkspaceConfig).toHaveBeenCalledTimes(1);
+    expect(getChannelConfigs).toHaveBeenCalledTimes(1);
   });
 
   it("calls getWorkspaceConfig exactly once even when the linked-asker answer flow runs", async () => {
     // The answer flow runs from `onReaction`, not the channel-message
     // handler, so the channel-message event itself MUST still see
-    // exactly one workspace-config read. Reaction-back is a separate
-    // event with its own (independent) cache window — explicitly
-    // covered by the second assertion below so a refactor that calls
-    // `getWorkspaceConfig` inside `runAnswerFlow` would fail loudly.
+    // exactly one workspace-config read. The reaction handler reads
+    // the workspaceId off the pending entry (`decision.pending.workspaceId`
+    // at `listener.ts:902`) rather than re-resolving — so total
+    // `getWorkspaceConfig` invocations stay at 1 across both events.
+    // A refactor that called `getWorkspaceConfig` inside `runAnswerFlow`
+    // would push the post-reaction count to 2 and fail loudly here.
     const getWorkspaceConfig = mock(async () => baseWorkspace);
+    const channelConfigs: ChannelProactiveConfig[] = [
+      { channelId: "C-allowed", allow: true },
+    ];
+    const getChannelConfigs = mock(async () => channelConfigs);
     const executeQueryProactive: ProactiveExecuteQuery = mock(echoExecute);
     const { chat, invokeMessage, invokeReaction } = makeChat();
     await registerProactiveListener(
@@ -2470,7 +2577,7 @@ describe("registerProactiveListener — per-event getWorkspaceConfig cache (#262
         classify: yesLLM,
         resolveWorkspaceId: defaultResolver,
         getWorkspaceConfig,
-        getChannelConfigs: allowChannels("C-allowed"),
+        getChannelConfigs,
         userResolver: linkedResolver,
         executeQueryProactive,
       },
@@ -2478,11 +2585,12 @@ describe("registerProactiveListener — per-event getWorkspaceConfig cache (#262
     const thread = makeThread("C-allowed");
     await invokeMessage(thread, makeMessage({ id: "M1" }));
     expect(getWorkspaceConfig).toHaveBeenCalledTimes(1);
+    expect(getChannelConfigs).toHaveBeenCalledTimes(1);
 
     // Reaction-back is a separate event; the reaction handler does not
-    // (and currently must not) re-read `getWorkspaceConfig`. Pinning
-    // the post-reaction count to 1 catches a regression that would
-    // re-read the config inside `runAnswerFlow`.
+    // (and currently must not) re-read either workspace-scoped fetcher.
+    // Pinning the post-reaction counts to 1 catches a regression that
+    // would re-read either config inside `runAnswerFlow`.
     await invokeReaction({
       added: true,
       messageId: "M1",
@@ -2496,6 +2604,7 @@ describe("registerProactiveListener — per-event getWorkspaceConfig cache (#262
     });
     expect(executeQueryProactive).toHaveBeenCalledTimes(1);
     expect(getWorkspaceConfig).toHaveBeenCalledTimes(1);
+    expect(getChannelConfigs).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -2511,13 +2620,19 @@ describe("registerProactiveListener — per-event getWorkspaceConfig cache (#262
 // would compile fine and silently return `undefined.length` at
 // runtime. The cast hole is closed by the narrowing.
 //
-// These are type-level assertions disguised as runtime tests so the
-// file participates in the regular `bun test` run and any regression
-// here lights up the same red as a normal failure. The `_resolver`
-// values are kept (rather than discarded immediately) so the
-// `@ts-expect-error` markers see the field accesses they're asserting
-// against — otherwise the markers themselves error as "unused
-// directive".
+// The `void event.message.<field>` statements inside the resolver
+// body give each `@ts-expect-error` marker a line to attach to —
+// `tsgo --noEmit` (run by `bun run type` and CI) type-checks the body
+// regardless of whether `_resolver` is later referenced, so the
+// directives are load-bearing as soon as the file compiles. `bun test`
+// does NOT enforce `@ts-expect-error` (its transpiler strips types
+// without checking); the directives are enforced exclusively by the
+// project-level type gate. The `expect(typeof _resolver).toBe("function")`
+// line exists so this `describe` block runs through `bun test` and any
+// regression appears in the test report — but the type-check is what
+// catches a regression first. **Do not** delete the `_resolver` binding
+// or replace its body with `void 0`: that would orphan the directives
+// and let TS strip them as `TS2578: Unused '@ts-expect-error' directive`.
 
 describe("ResolveWorkspaceIdFn type narrowing (#2623 item 2)", () => {
   it("ts-only: a resolver cannot read fields outside ResolverEventLite", () => {
@@ -2539,6 +2654,8 @@ describe("ResolveWorkspaceIdFn type narrowing (#2623 item 2)", () => {
       void event.message.metadata;
       // @ts-expect-error — `links` is on Message but not ResolverEventLite
       void event.message.links;
+      // @ts-expect-error — `isMention` is on Message but not ResolverEventLite
+      void event.message.isMention;
       return null;
     };
     expect(typeof _resolver).toBe("function");

--- a/plugins/chat/src/proactive/index.ts
+++ b/plugins/chat/src/proactive/index.ts
@@ -21,6 +21,8 @@ export type {
   ProactiveGateFn,
   RecentActivity,
   ResolveWorkspaceIdFn,
+  ResolverEvent,
+  ResolverEventLite,
   SensitivityPreset,
   WorkspaceProactiveConfig,
 } from "./types";

--- a/plugins/chat/src/proactive/listener.ts
+++ b/plugins/chat/src/proactive/listener.ts
@@ -58,6 +58,7 @@ import type {
   ProactivePublicDatasetEntry,
   RecentActivity,
   ResolveWorkspaceIdFn,
+  ResolverEventLite,
   WorkspaceProactiveConfig,
 } from "./types";
 import { DEFAULT_PROACTIVE_REFUSAL_COPY } from "./types";
@@ -392,23 +393,29 @@ export async function registerProactiveListener(
   // contract is "never throw, resolve as null") still degrades to a
   // silent skip instead of crashing the SDK loop.
   //
-  // `thread` is typed loosely (`Thread<unknown, unknown>`) because the
-  // listener takes events from `onNewMessage`, `onReaction`, `onAction`,
-  // and `onModalSubmit` — each surfaces a thread with a different
-  // generic parameter. The Slack resolver reads only `adapter.name` +
+  // `thread` is typed loosely (`Thread<unknown, unknown> | undefined`)
+  // because the listener takes events from `onNewMessage`, `onReaction`,
+  // `onAction`, and `onModalSubmit` — each surfaces a thread with a
+  // different generic parameter (or none at all for the bridge's slash
+  // synthesis path). The Slack resolver reads only `adapter.name` +
   // `message.raw`; the `thread` field is passed through for forward-
   // compatibility with platforms that need it (Teams `channelData`,
   // etc.) but no current resolver dereferences it.
+  //
+  // `message` is the narrowed {@link ResolverEventLite} shape (#2623
+  // item 2) so action / modal call sites can pass `{ id, raw }`
+  // directly. Real `Message` instances also satisfy the shape because
+  // `ResolverEventLite` is `Pick<Message, "id" | "raw">`.
   const safeResolveWorkspace = async (
     adapter: Adapter,
-    thread: Thread<unknown, unknown>,
-    message: Message,
+    thread: Thread<unknown, unknown> | undefined,
+    message: ResolverEventLite,
   ): Promise<WorkspaceId | null> => {
     let raw: string | null;
     try {
       raw = await config.resolveWorkspaceId({
         adapter,
-        thread: thread as Thread,
+        thread: thread as Thread | undefined,
         message,
       });
     } catch (err) {
@@ -1001,11 +1008,12 @@ export async function registerProactiveListener(
           event.adapter,
           event.thread,
           // The action event doesn't carry the full Message that
-          // triggered the answer; pass a synthetic shape with the
-          // adapter-supplied messageId. The host's resolver is
-          // expected to derive workspaceId from `adapter` + raw, both
-          // of which are present.
-          { id: event.messageId, raw: event.raw } as unknown as Message,
+          // triggered the answer; pass a lite shape with the adapter-
+          // supplied messageId. The resolver's narrowed `ResolverEventLite`
+          // contract (#2623 item 2) is "only reads `adapter.name` +
+          // `message.raw`", so the lite shape satisfies the type
+          // directly — no `as unknown` cast needed.
+          { id: event.messageId, raw: event.raw },
         );
         if (!workspaceId) return;
         if (!(await config.isEnabled(workspaceId))) return;
@@ -1087,9 +1095,11 @@ export async function registerProactiveListener(
         event.adapter,
         relatedThread,
         // Modal events don't surface the original message; pass a
-        // synthetic shape — the host resolver's contract is to derive
-        // workspaceId from `adapter` + raw context.
-        { id: "", raw: event.raw } as unknown as Message,
+        // lite shape — the resolver's `ResolverEventLite` contract
+        // (#2623 item 2) only reads `adapter.name` + `message.raw`,
+        // so the lite shape satisfies the type directly without a
+        // cast.
+        { id: "", raw: event.raw },
       );
       if (!workspaceId) return { action: "close" as const };
       if (!(await config.isEnabled(workspaceId))) {

--- a/plugins/chat/src/proactive/listener.ts
+++ b/plugins/chat/src/proactive/listener.ts
@@ -397,10 +397,10 @@ export async function registerProactiveListener(
   // because the listener takes events from `onNewMessage`, `onReaction`,
   // `onAction`, and `onModalSubmit` — each surfaces a thread with a
   // different generic parameter (or none at all for the bridge's slash
-  // synthesis path). The Slack resolver reads only `adapter.name` +
-  // `message.raw`; the `thread` field is passed through for forward-
-  // compatibility with platforms that need it (Teams `channelData`,
-  // etc.) but no current resolver dereferences it.
+  // synthesis path). The `thread` field is part of the resolver
+  // contract so platforms that need it (Teams `channelData`, etc.) can
+  // opt in without a signature change. The Slack resolver — the only
+  // one wired today — does not read it.
   //
   // `message` is the narrowed {@link ResolverEventLite} shape (#2623
   // item 2) so action / modal call sites can pass `{ id, raw }`
@@ -415,6 +415,11 @@ export async function registerProactiveListener(
     try {
       raw = await config.resolveWorkspaceId({
         adapter,
+        // Generic widening: `safeResolveWorkspace`'s `thread` parameter
+        // is `Thread<unknown, unknown> | undefined` (callers erase the
+        // generics so one wrapper can serve every event surface).
+        // `ResolverEvent.thread` defaults the generics to `Record<string,
+        // unknown>` for `TState`, which is invariant — hence the cast.
         thread: thread as Thread | undefined,
         message,
       });

--- a/plugins/chat/src/proactive/types.ts
+++ b/plugins/chat/src/proactive/types.ts
@@ -122,9 +122,9 @@ export type ProactiveGateFn = (
  * "only read `adapter.name` + `message.raw`", but pre-#2623 the
  * parameter was the full `Message` and synthesis sites (action /
  * modal / slash, which don't carry a real Message) smuggled a partial
- * shape via a structural `Message` cast. The cast silenced the type
- * error but a resolver author could legally read
- * `event.message.attachments`
+ * shape via an `as unknown as Message` double cast that bypassed
+ * structural checking entirely. The cast silenced the type error but
+ * a resolver author could legally read `event.message.attachments`
  * or `event.message.author` — fields synthetic events don't populate,
  * which would silently misroute the tenant lookup at runtime.
  *
@@ -136,8 +136,19 @@ export type ProactiveGateFn = (
  * Adding a field here means every host implementation can now read it;
  * removing means closing a hole. `raw` is the only load-bearing field
  * (Slack `team_id`, Teams `tenantId`, ...); `id` is included because
- * synthesis sites populate it for logging convenience but it carries
- * no semantic value on synthetic events.
+ * the channel-message and action-feedback paths can populate a real
+ * adapter message id (`listener.ts:1016`), while the modal-submit and
+ * bridge-slash synthesis paths pass `""` because there is no original
+ * message (`listener.ts:1102`, `bridge.ts:1089`). Resolvers must NOT
+ * branch on `id` — only use it for opportunistic logging — because
+ * the `""` sentinel cannot be distinguished from an unknown adapter
+ * that happens to produce empty ids.
+ *
+ * Pinned by the `@ts-expect-error` block in
+ * `plugins/chat/src/proactive/__tests__/listener.test.ts` (describe
+ * tagged `ResolveWorkspaceIdFn type narrowing (#2623 item 2)`) —
+ * widening this back to `Message` will make those directives unused
+ * and fail the type gate.
  */
 export type ResolverEventLite = Pick<Message, "id" | "raw">;
 
@@ -179,10 +190,13 @@ export type ResolveWorkspaceIdFn = (event: ResolverEvent) => Promise<string | nu
  * Per-event workspace config fetcher.
  *
  * Replaces the pre-#2620 static `workspace: WorkspaceProactiveConfig`
- * registration field. Called once per event after `resolveWorkspaceId`
- * succeeds; the listener caches the result for the lifetime of the
- * single event handler call so repeated lookups inside one handler stay
- * cheap.
+ * registration field. Called at most once per event handler invocation
+ * — the listener holds the result in a local `const` so repeated
+ * lookups inside one handler are not needed (there is no cache; the
+ * cost ceiling is "one DB read per channel-message event"). The
+ * per-event "called exactly once" contract is pinned by the sentinel
+ * describe block tagged `#2623 item 6` in
+ * `plugins/chat/src/proactive/__tests__/listener.test.ts`.
  *
  * Returns `null` when the workspace has no config row (treat as not
  * opted in; the listener short-circuits without classification).

--- a/plugins/chat/src/proactive/types.ts
+++ b/plugins/chat/src/proactive/types.ts
@@ -117,6 +117,46 @@ export type ProactiveGateFn = (
 // meter row.
 
 /**
+ * Narrowed subset of `Message` the resolver is contractually allowed to
+ * read (#2623 item 2). The resolver-side contract has always been
+ * "only read `adapter.name` + `message.raw`", but pre-#2623 the
+ * parameter was the full `Message` and synthesis sites (action /
+ * modal / slash, which don't carry a real Message) smuggled a partial
+ * shape via a structural `Message` cast. The cast silenced the type
+ * error but a resolver author could legally read
+ * `event.message.attachments`
+ * or `event.message.author` — fields synthetic events don't populate,
+ * which would silently misroute the tenant lookup at runtime.
+ *
+ * Narrowing the parameter type closes that contract hole at compile
+ * time: a resolver that reads anything outside this set is a type
+ * error, and synthesis sites can return this shape directly without
+ * any cast.
+ *
+ * Adding a field here means every host implementation can now read it;
+ * removing means closing a hole. `raw` is the only load-bearing field
+ * (Slack `team_id`, Teams `tenantId`, ...); `id` is included because
+ * synthesis sites populate it for logging convenience but it carries
+ * no semantic value on synthetic events.
+ */
+export type ResolverEventLite = Pick<Message, "id" | "raw">;
+
+/**
+ * Per-event input to {@link ResolveWorkspaceIdFn}.
+ *
+ * `thread` is `Thread | undefined` because slash-command and home-tab
+ * events don't carry a thread context — the bridge passes `undefined`
+ * there. Pre-#2623 the bridge cast `undefined as unknown as Thread`
+ * to satisfy a stricter contract; the explicit `| undefined` lets the
+ * cast go away.
+ */
+export interface ResolverEvent {
+  adapter: Adapter;
+  thread: Thread | undefined;
+  message: ResolverEventLite;
+}
+
+/**
  * Per-event workspace resolution callback.
  *
  * Returns the Atlas workspace id (`org_id` in the internal DB) for the
@@ -133,11 +173,7 @@ export type ProactiveGateFn = (
  * canonical implementation that maps Slack `team_id` →
  * `slack_installations.org_id`.
  */
-export type ResolveWorkspaceIdFn = (event: {
-  adapter: Adapter;
-  thread: Thread;
-  message: Message;
-}) => Promise<string | null>;
+export type ResolveWorkspaceIdFn = (event: ResolverEvent) => Promise<string | null>;
 
 /**
  * Per-event workspace config fetcher.


### PR DESCRIPTION
## Summary

Closes the tail of #2623 (the P2 type-design polish bundle from #2620). Items 3/4/5 shipped via #2632 / #2643; item 1 (discriminated unions on `ProactiveListenerConfig`) is being moved to a separate 1.5.x tracking issue per the issue body's "Breaking; only worth it if it lands alongside a 1.5.x bundle of changes."

### Item 2 — flip resolver parameter to `ResolverEventLite`

PR #2645 deferred this, leaving `as unknown as Message` casts at `listener.ts:1008` + `:1092` (plus a companion `as unknown as Thread` cast in the bridge's slash synthesis). The resolver-side contract has always been "only reads `adapter.name` + `message.raw`", but the parameter was the full `Message` — a resolver author could legally read `event.message.attachments.length` or `event.message.author.userId` on synthetic events and silently get `undefined.length` at runtime.

**The fix is narrowing the parameter, not aliasing alongside.** `Pick<Message, "id" | "raw">` becomes `ResolverEventLite`; `ResolveWorkspaceIdFn`'s input shape is now `{ adapter: Adapter; thread: Thread | undefined; message: ResolverEventLite }`. The `thread` widening is what lets the bridge's slash-command synthesis drop its companion `undefined as unknown as Thread` cast — slash events don't carry a thread.

Synthesis sites now return the lite shape directly:

```ts
// listener.ts:1008  (action handler — feedback button)
{ id: event.messageId, raw: event.raw }
// listener.ts:1092  (modal-submit handler — wrong-data modal)
{ id: "", raw: event.raw }
// bridge.ts:1083    (bridge feedback slash)
{ id: "", raw: event.raw }   // thread: undefined  ← also un-cast
```

Real `Message` instances still satisfy the input (subtype direction), so the channel-message path is unchanged. `safeResolveWorkspace`'s internal signature widens its message parameter to `ResolverEventLite` so all four call sites compose.

**Pinned by a `@ts-expect-error` block** at the bottom of `listener.test.ts` that proves a resolver author can no longer read `attachments` / `author` / `text` / `formatted` / `threadId` / `metadata` / `links` on `event.message`. If a future refactor widens the parameter back to `Message`, the `@ts-expect-error` directives go unused and the test file fails to compile.

**Acceptance criterion met:** `grep -n "as unknown as Message" plugins/chat/src/proactive/ packages/api/src/lib/proactive/` returns zero live casts (the only match is the doc comment in `types.ts` referencing the historical shape).

### Item 6 — `getWorkspaceConfig` called-exactly-once sentinel

`types.ts:148-150` (now `:182-184`) documents the per-event cache contract: "the listener caches the result for the lifetime of the single event handler call so repeated lookups inside one handler stay cheap." Reading `listener.ts:577-580` (now `:594-597`), the listener already calls `getWorkspaceConfig` exactly once per event — but nothing pinned the invariant. A future refactor that adds a second DB read inside `runAnswerFlow` or duplicates the lookup in the public-dataset branch would silently regress the cost ceiling.

Two new sentinel tests fire a representative event (channel-message happy path; and a channel-message + reaction-back follow-up) and assert the `getWorkspaceConfig` spy increments by exactly 1 per event.

### Closeout of #2623

After this lands I'll close #2623 with the trail:
- Item 3 — shipped in #2632
- Items 4 + 5 — shipped in #2643
- Items 2 + 6 — shipped in this PR
- Item 1 — moved to a separate 1.5.x tracking issue (filed post-merge)

## Out of scope

- Item 1 (discriminated unions on `ProactiveListenerConfig`) — breaking; bundled into a 1.5.x issue per the original spec.
- Bridge's `.then()` registration retry — pre-existing shape, called out under item 4 in the issue body but deferred there too.

## Test plan

- [x] `bun run test` — full suite, 649 files, 0 failures
- [x] `bun run type` — 0 errors across all packages
- [x] `bun run lint` — 0 errors (10 pre-existing warnings in unrelated files)
- [x] `bun x syncpack lint` — `No issues found`
- [x] All 5 drift checks (`check-template-drift.sh`, `check-security-headers-drift.sh`, `check-railway-watch.sh`, `check-schema-drift.sh`, `check-oauth-helper-drift.sh`) green
- [x] `grep -n "as unknown as Message" plugins/chat/src/proactive/ packages/api/src/lib/proactive/` returns no live casts
- [x] `cd plugins/chat && bun test src/proactive/__tests__/listener.test.ts` — 68 pass (was 66 — added 2 sentinels + 2 type-only narrowing tests)
- [x] Existing #2620 multi-tenant tests updated to handle the new `thread: Thread | undefined` shape (`thread && channelToWorkspace.get(...)`)

Refs #2623