### PR TITLE
feat: #2650 — catalog data model + CatalogSeeder + AdapterRegistry (1.5.2 slice 2)

### DIFF
--- a/apps/docs/content/docs/deployment/meta.json
+++ b/apps/docs/content/docs/deployment/meta.json
@@ -6,6 +6,7 @@
     "deploy",
     "authentication",
     "multi-datasource",
+    "plugin-catalog",
     "schema-evolution",
     "cache-configuration"
   ]

--- a/apps/docs/content/docs/deployment/plugin-catalog.mdx
+++ b/apps/docs/content/docs/deployment/plugin-catalog.mdx
@@ -1,0 +1,187 @@
+---
+title: Plugin Catalog
+description: Declarative catalog of installable chat Platforms and integration plugins, seeded from atlas.config.ts at boot
+---
+
+# Plugin Catalog
+
+The **Plugin Catalog** is Atlas's declarative registry of installable chat
+Platforms (Slack, Teams, Discord, …) and integration plugins (Salesforce,
+Jira, Email, …). It implements
+[ADR‑0002](https://github.com/AtlasDevHQ/atlas/blob/main/docs/adr/0002-catalog-seeded-from-config-at-boot.md):
+operators declare capability in `atlas.config.ts`, a boot‑time idempotent
+seed pass writes the declaration into `plugin_catalog`, and runtime reads
+(admin UI, listener gates, billing tier checks) flow through the DB.
+
+## Why a catalog
+
+On SaaS the operator (who runs Atlas) and the customer (who configures a
+Workspace) are different parties. Pre‑1.5.2 the chat plugin's adapter
+wiring lived inside `atlas.config.ts:plugins[]` — operator-only, deploy-time
+only — which meant adding a Platform required a code edit and a deploy
+per customer. The catalog seam moves "what's available on this deploy"
+(operator) and "what's active for this Workspace" (customer) onto
+separate surfaces.
+
+## Declaring the catalog
+
+Add a top‑level `catalog` array to your `atlas.config.ts`:
+
+```ts
+import { defineConfig } from "@atlas/api/lib/config";
+
+export default defineConfig({
+  // …
+  catalog: [
+    {
+      slug: "slack",
+      type: "chat",
+      install_model: "oauth",
+      enabled: true,
+      saas_eligible: true,
+      min_plan: "starter",
+    },
+    {
+      slug: "salesforce",
+      type: "integration",
+      install_model: "oauth",
+      enabled: true,
+      saas_eligible: true,
+      min_plan: "team",
+    },
+    {
+      slug: "email",
+      type: "integration",
+      install_model: "form",
+      enabled: true,
+      saas_eligible: true,
+      min_plan: "starter",
+    },
+    // 1.5.3 placeholder — visible to ops, not customer-installable until
+    // the static-bot install handler lands.
+    {
+      slug: "telegram",
+      type: "chat",
+      install_model: "static-bot",
+      enabled: false,
+      saas_eligible: true,
+    },
+  ],
+});
+```
+
+Each entry carries:
+
+| Field | Required | Description |
+|---|---|---|
+| `slug` | yes | Stable identifier — lowercase alphanumeric with dashes (`slack`, `linear-apikey`). Used as the primary lookup key. |
+| `type` | yes | Admin‑UI grouping. `"chat"` or `"integration"`. |
+| `install_model` | yes | Install-handler dispatch. `"oauth"`, `"form"`, or `"static-bot"`. |
+| `enabled` | no (defaults `true`) | Whether customers can install. Ops can flip false in DB for emergency-disable. |
+| `saas_eligible` | no (defaults `true`) | Whether the entry shows in SaaS admin UI. Set `false` for self‑host-only modes (e.g. GitHub PAT). |
+| `min_plan` | no (defaults `"starter"`) | Plan-tier gate evaluated at customer-install time. |
+| `name` | no | Human-readable name; defaults to a slug-derived form. |
+| `description` | no | Admin‑UI description copy. |
+| `iconUrl` | no | Icon for admin-UI cards. |
+
+## Install models
+
+`install_model` discriminates the install-handler family (see
+[CONTEXT.md → Install models](https://github.com/AtlasDevHQ/atlas/blob/main/CONTEXT.md#install-models)):
+
+- **`oauth`** — Customer clicks Connect, OAuth dance runs against the
+  operator-owned App Registration, per-Workspace bot token returned and
+  persisted to the platform-native credential store. Examples: Slack,
+  Salesforce, Jira.
+- **`form`** — Customer fills a form (API key, SMTP creds, webhook URL).
+  Examples: Email (SMTP), Webhook, Obsidian.
+- **`static-bot`** — Operator-shared bot serves every Workspace; customer
+  provides only a per-Workspace routing identifier. Examples: Discord
+  `guild_id`, Telegram `chat_id`, Teams `tenant_id`. **Not installable
+  in 1.5.2** — handler ships in 1.5.3.
+
+## Boot-time seed
+
+On every API boot, `CatalogSeeder` runs as part of the startup Layer
+DAG and upserts `plugin_catalog` rows from the declaration. The seed is
+idempotent — same config in, same rows out — so re-running is safe.
+
+```
+plan_catalog row exists for slug?
+  NO  → INSERT
+  YES → does it match the declaration?
+          YES → no-op (debug log: "preserved")
+          NO  → UPDATE (name, description, type, install_model, …)
+
+plan_catalog row exists but slug not in declaration?
+  → log warn "orphan catalog row" — DO NOT delete
+```
+
+### Emergency disable
+
+Ops can flip `plugin_catalog.enabled = false` directly in the DB to
+disable a Platform across all Workspaces in a region without a deploy.
+The seed pass **preserves** that DB-side `false` even if the config
+declares `true` — and logs a warn so the drift is observable.
+
+```sql
+-- Atlas SaaS us region: emergency-disable Salesforce
+UPDATE plugin_catalog SET enabled = false WHERE slug = 'salesforce';
+```
+
+The next deploy's seed pass will see `config.enabled = true` but
+`db.enabled = false`, preserve the DB state, and log:
+
+```
+WARN ops-disabled row preserved — config wants enabled=true but DB has enabled=false { slug: 'salesforce' }
+```
+
+### Orphans
+
+A `plugin_catalog` row whose slug isn't in the declaration emits a
+`warn` log but is never deleted. This preserves ops's ability to
+hand-add catalog rows (community marketplace future) without the seed
+reaping them.
+
+## Per-Platform credentials
+
+The catalog entry declares **capability**; per-Platform credentials
+live in environment variables. The chat plugin's
+`AdapterRegistry` reads them at boot:
+
+| Platform | Required env vars |
+|---|---|
+| `slack` | `SLACK_CLIENT_ID`, `SLACK_CLIENT_SECRET`, `SLACK_SIGNING_SECRET`, `SLACK_ENCRYPTION_KEY` |
+| _(other chat Platforms ship in 1.5.3)_ | — |
+
+If a catalog entry exists with `install_model: "oauth"` and `enabled: true`
+but its env vars are missing, the AdapterRegistry logs a warn and skips
+the adapter — the plugin still boots, the admin UI still shows the
+catalog entry, but customer Connect flows fail until the env wiring is
+fixed.
+
+## Self-host symmetry
+
+On self-host the operator and the customer are the same party. The
+catalog seam still works: the operator declares whichever Platforms
+they want to support, sets the env vars, and installs from their own
+admin UI like a SaaS customer would. No bifurcation — the same code
+path serves both deploy modes.
+
+## What ships when
+
+- **1.5.2 (slice 2, #2650 — this milestone)**: catalog data model,
+  `CatalogSeeder` boot pass, `AdapterRegistry` for chat platforms, Slack
+  OAuth wired end-to-end. Other chat Platforms (Teams/Discord/gchat/
+  Telegram/WhatsApp) seeded as `enabled: false` placeholders.
+- **1.5.2 (slice 3, #2651)**: `/api/v1/integrations/catalog` endpoint
+  + `/admin/integrations` page consuming the seeded catalog.
+- **1.5.2 (slice 4, #2652)**: `PlatformInstallHandler` interface family
+  + `OAuthStateToken`.
+- **1.5.2 (slice 5, #2653)**: Slack `OAuthPlatformInstallHandler`
+  implementation (lift of the current `slack.ts` OAuth path).
+- **1.5.3**: `StaticBotInstallHandler` — turns on the non-Slack chat
+  Platforms.
+
+See [ADR-0002](https://github.com/AtlasDevHQ/atlas/blob/main/docs/adr/0002-catalog-seeded-from-config-at-boot.md)
+for the design rationale.

--- a/apps/docs/content/docs/plugins/interactions/slack.mdx
+++ b/apps/docs/content/docs/plugins/interactions/slack.mdx
@@ -119,21 +119,40 @@ For multi-workspace OAuth, the callback URL must be registered in your Slack app
 
 ## Migrating to @useatlas/chat
 
-Replace `@useatlas/slack` with the Chat SDK bridge plugin:
+Replace `@useatlas/slack` with the Chat SDK bridge plugin. As of Atlas
+1.5.2, adapter activation is **catalog-driven** — declare Slack in
+`atlas.config.ts:catalog`, set per-Platform credentials in env vars,
+and pass the chat-type subset through to `chatPlugin`. See the
+[Plugin Catalog](/deployment/plugin-catalog) page for the data model.
 
 ```typescript
-// Before:
+// Before (pre-1.5.2):
 import { slackPlugin } from "@useatlas/slack";
 slackPlugin({ signingSecret: "...", botToken: "xoxb-...", executeQuery })
 
-// After:
+// After (1.5.2+):
+import { defineConfig } from "@atlas/api/lib/config";
 import { chatPlugin } from "@useatlas/chat";
-chatPlugin({
-  adapters: {
-    slack: { botToken: "xoxb-...", signingSecret: "..." },
-  },
-  executeQuery,
-})
+
+export default defineConfig({
+  catalog: [
+    { slug: "slack", type: "chat", install_model: "oauth",
+      enabled: true, saas_eligible: true },
+  ],
+  plugins: [
+    chatPlugin({
+      catalog: [
+        { slug: "slack", type: "chat", install_model: "oauth",
+          enabled: true, saas_eligible: true },
+      ],
+      executeQuery,
+    }),
+  ],
+});
+
+// env vars:
+//   SLACK_CLIENT_ID, SLACK_CLIENT_SECRET, SLACK_SIGNING_SECRET, SLACK_ENCRYPTION_KEY
+//   SLACK_BOT_TOKEN (optional — single-workspace only)
 ```
 
 | Feature | @useatlas/slack | @useatlas/chat |

--- a/deploy/api/atlas.config.ts
+++ b/deploy/api/atlas.config.ts
@@ -67,6 +67,70 @@ export default defineConfig({
   // ── Tools ───────────────────────────────────────────────────────
   tools: ["explore", "executeSQL"],
 
+  // ── Plugin Catalog (1.5.2 slice 2 — #2650) ──────────────────────
+  // Flat list with `type` + `install_model` as orthogonal fields per
+  // PRD "Further Notes" + ADR-0002. Seeded into `plugin_catalog` at
+  // boot by `CatalogSeeder`; ops can flip `enabled=false` in DB without
+  // a deploy for emergency-disable (the seed preserves DB-side false).
+  //
+  // 1.5.2 ships the OAuth install path for Slack (chat). The other
+  // chat Platforms ride along as `enabled: false` placeholders with
+  // `install_model: 'static-bot'` — their install handler lands in
+  // 1.5.3 alongside `StaticBotInstallHandler`. Integration plugins
+  // (Salesforce, Jira, Email, Webhook, Obsidian) wire in slice 3
+  // (#2651) via `LazyPluginLoader`; their entries land then.
+  catalog: [
+    {
+      slug: "slack",
+      type: "chat",
+      install_model: "oauth",
+      enabled: true,
+      saas_eligible: true,
+      min_plan: "starter",
+    },
+    // ── 1.5.3 placeholders — visible to ops, not customer-installable ─
+    // Per CONTEXT.md, each of these has Platform-specific install
+    // subtleties (Teams Azure-AD + manifest, Discord per-guild routing,
+    // Telegram chat_id capture, WhatsApp Meta verification, gchat Google
+    // Workspace Marketplace). They get `install_model: 'static-bot'`
+    // per the install-handler spectrum.
+    {
+      slug: "teams",
+      type: "chat",
+      install_model: "static-bot",
+      enabled: false,
+      saas_eligible: true,
+    },
+    {
+      slug: "discord",
+      type: "chat",
+      install_model: "static-bot",
+      enabled: false,
+      saas_eligible: true,
+    },
+    {
+      slug: "gchat",
+      type: "chat",
+      install_model: "static-bot",
+      enabled: false,
+      saas_eligible: true,
+    },
+    {
+      slug: "telegram",
+      type: "chat",
+      install_model: "static-bot",
+      enabled: false,
+      saas_eligible: true,
+    },
+    {
+      slug: "whatsapp",
+      type: "chat",
+      install_model: "static-bot",
+      enabled: false,
+      saas_eligible: true,
+    },
+  ],
+
   // ── Plugins ─────────────────────────────────────────────────────
   // Slice 3 of #2607 — the chat plugin now owns the @mention + thread
   // event path end-to-end. The plugin's webhook routes at
@@ -92,31 +156,22 @@ export default defineConfig({
   // in multi-workspace mode.
   plugins: [
     chatPlugin({
-      adapters: {
-        slack: {
-          ...(process.env.SLACK_BOT_TOKEN
-            ? { botToken: process.env.SLACK_BOT_TOKEN }
-            : {}),
-          // Single shared signing secret for the Atlas Slack app — Zod
-          // now rejects placeholder strings so an unset env var fails
-          // boot rather than silently passing webhook verification.
-          signingSecret: process.env.SLACK_SIGNING_SECRET ?? "",
-          ...(process.env.SLACK_CLIENT_ID
-            ? { clientId: process.env.SLACK_CLIENT_ID }
-            : {}),
-          ...(process.env.SLACK_CLIENT_SECRET
-            ? { clientSecret: process.env.SLACK_CLIENT_SECRET }
-            : {}),
-          // Required in SaaS — keys the AES-GCM envelope that the
-          // chat-adapter uses to encrypt persisted bot tokens. Atlas's
-          // `lib/slack/installation-encryption.ts` reads the same env
-          // var so OAuth-write / per-event-read stay symmetric. 32 raw
-          // bytes encoded as hex (64 chars) or base64 (44 chars).
-          ...(process.env.SLACK_ENCRYPTION_KEY
-            ? { encryptionKey: process.env.SLACK_ENCRYPTION_KEY }
-            : {}),
+      // Catalog-driven adapter activation (#2650 slice 2). The chat
+      // plugin's `AdapterRegistry` reads the chat-type subset of the
+      // catalog above and per-Platform credentials from `process.env`
+      // (`SLACK_CLIENT_ID` / `SLACK_CLIENT_SECRET` / `SLACK_SIGNING_SECRET`
+      // / `SLACK_ENCRYPTION_KEY` / optional `SLACK_BOT_TOKEN`). The old
+      // `adapters: { slack: {...} }` field is gone — there is no longer
+      // a way to wire a chat adapter outside the catalog seam.
+      catalog: [
+        {
+          slug: "slack",
+          type: "chat",
+          install_model: "oauth",
+          enabled: true,
+          saas_eligible: true,
         },
-      },
+      ],
       state: { backend: "pg" },
       // Host-side executeQuery — preserves the F-55 actor binding,
       // approvalSurface stamp, conversation persistence, rate-limit

--- a/e2e/surfaces/slack-proactive.test.ts
+++ b/e2e/surfaces/slack-proactive.test.ts
@@ -356,13 +356,27 @@ let teardown: (() => Promise<void>) | null = null;
 beforeAll(async () => {
   const { buildChatPlugin } = await import("../../plugins/chat/src/index");
 
+  // Slice 2 of 1.5.2 (#2650): chat-adapter activation moved from
+  // `adapters: { slack: {...} }` to `catalog: [...]` + env vars. The
+  // env vars are set in `beforeAll` below so the AdapterRegistry can
+  // instantiate the Slack adapter. The previous BOT_TOKEN /
+  // SIGNING_SECRET constants now flow through `process.env.SLACK_*`.
+  process.env.SLACK_CLIENT_ID = "test-client-id";
+  process.env.SLACK_CLIENT_SECRET = "test-client-secret";
+  process.env.SLACK_SIGNING_SECRET = SIGNING_SECRET;
+  process.env.SLACK_ENCRYPTION_KEY = "f".repeat(64);
+  process.env.SLACK_BOT_TOKEN = BOT_TOKEN;
+
   const plugin = buildChatPlugin({
-    adapters: {
-      slack: {
-        botToken: BOT_TOKEN,
-        signingSecret: SIGNING_SECRET,
+    catalog: [
+      {
+        slug: "slack",
+        type: "chat",
+        install_model: "oauth",
+        enabled: true,
+        saas_eligible: true,
       },
-    },
+    ],
     state: { backend: "memory" },
     // The plugin's `ChatExecuteQueryContext` / `ResolveWorkspaceIdFn` /
     // `OnPauseRequestFn` types pull from the broader Chat SDK type

--- a/packages/api/src/lib/auth/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/auth/__tests__/migrate.test.ts
@@ -332,6 +332,7 @@ describe("migrateAuthTables", () => {
             { name: "0084_proactive_classification_review.sql" },
             { name: "0085_workspace_proactive_config_workspace_id_nonempty.sql" },
             { name: "0086_consolidate_slack_installations.sql" },
+            { name: "0087_plugin_catalog_install_model.sql" },
           ],
         };
       }

--- a/packages/api/src/lib/config.ts
+++ b/packages/api/src/lib/config.ts
@@ -270,6 +270,98 @@ const ResidencyConfigSchema = z.object({
 
 export type ResidencyConfig = z.infer<typeof ResidencyConfigSchema>;
 
+// ---------------------------------------------------------------------------
+// Catalog declaration (1.5.2 slice 2 — issue #2650)
+// ---------------------------------------------------------------------------
+
+/**
+ * `install_model` discriminates the install-handler family per CONTEXT.md
+ * "Install models". The dispatch shape is pinned in slice 2 so 1.5.3's
+ * static-bot work lands as a single-import change rather than reopening
+ * the dispatch design.
+ *
+ * - `oauth` — OAuth dance against an operator-owned App Registration; per-
+ *   Workspace bot token returned and persisted to the platform-native
+ *   credential store. Chat: Slack. Integration: Salesforce, Jira, GitHub
+ *   Apps (1.5.3), Linear OAuth (1.5.3).
+ * - `form` — Customer admin fills a form (API key, SMTP creds, webhook
+ *   URL); data validates against the catalog entry's `config_schema`;
+ *   persists to `workspace_plugins.config` + encrypted credential storage.
+ *   Integrations: Email (SMTP), Webhook, Obsidian, GitHub PAT (self-host),
+ *   Linear API-key (1.5.3).
+ * - `static-bot` — Operator-shared bot serves every Workspace; customer
+ *   admin provides only a per-Workspace routing identifier (Discord
+ *   `guild_id`, Telegram `chat_id`, Teams `tenant_id`, WhatsApp phone
+ *   number) via form. No per-Workspace bot token. Chat: Teams, Discord,
+ *   Google Chat, Telegram, WhatsApp. **Not installable in 1.5.2** — the
+ *   handler ships in 1.5.3.
+ */
+export const CATALOG_INSTALL_MODELS = ["oauth", "form", "static-bot"] as const;
+export type CatalogInstallModel = (typeof CATALOG_INSTALL_MODELS)[number];
+
+/**
+ * `type` groups catalog entries for admin-UI display. Backend dispatches
+ * by `install_model` (orthogonal), not by `type`. The list is intentionally
+ * narrow today: chat Platforms vs everything-else-integration. Future
+ * milestones may add `datasource` once datasource plugins migrate to the
+ * catalog (Architecture Backlog issue, out of scope for 1.5.2).
+ */
+export const CATALOG_ENTRY_TYPES = ["chat", "integration"] as const;
+export type CatalogEntryType = (typeof CATALOG_ENTRY_TYPES)[number];
+
+/**
+ * Plan tiers a catalog entry can require. Mirrors the values already
+ * persisted in `plugin_catalog.min_plan` (text column — no DB enum). The
+ * comparison happens in the customer-install path against the Workspace's
+ * resolved plan tier (Architecture Backlog work — out of scope for 1.5.2).
+ */
+const CATALOG_MIN_PLANS = ["starter", "team", "business", "enterprise"] as const;
+
+const CatalogEntrySchema = z.object({
+  /**
+   * Stable identifier (e.g. `"slack"`, `"salesforce"`, `"linear-apikey"`).
+   * Used as the primary lookup key in `plugin_catalog.slug` and as the
+   * dispatch key in `AdapterRegistry`. Lowercase letters, digits, and
+   * dashes only — matches the Platform's canonical short name.
+   */
+  slug: z.string().regex(
+    /^[a-z][a-z0-9-]*$/,
+    "catalog entry slug must be lowercase alphanumeric with dashes (e.g. 'slack', 'linear-apikey')",
+  ),
+  /** Admin-UI grouping (chat Platforms vs integration plugins). */
+  type: z.enum(CATALOG_ENTRY_TYPES),
+  /** Install-handler dispatch key — see {@link CATALOG_INSTALL_MODELS}. */
+  install_model: z.enum(CATALOG_INSTALL_MODELS),
+  /** Optional human-readable name; defaults to slug-derived if omitted. */
+  name: z.string().min(1).optional(),
+  /** Optional admin-UI description copy. */
+  description: z.string().min(1).optional(),
+  /** Optional icon URL for admin-UI cards. */
+  iconUrl: z.string().url().optional(),
+  /** Plan-tier gate evaluated at customer-install time. Defaults to `starter`. */
+  min_plan: z.enum(CATALOG_MIN_PLANS).optional().default("starter"),
+  /**
+   * Whether customers can install this entry today. Operators flip to
+   * `false` (in DB) for emergency-disable without a deploy; the seed
+   * preserves a DB-side `false` even if the config declares `true`.
+   * Defaults to `true`.
+   */
+  enabled: z.boolean().optional().default(true),
+  /**
+   * Whether the entry is offered in SaaS deployments. `false` hides the
+   * row from SaaS admin-UI listings while keeping it available on self-
+   * host. The canonical case is GitHub PAT mode (per-user token tied to
+   * one employee — unsafe in B2B SaaS). Defaults to `true`.
+   */
+  saas_eligible: z.boolean().optional().default(true),
+}).strict();
+
+export type CatalogEntry = z.infer<typeof CatalogEntrySchema>;
+/** Input shape (defaults not yet applied) — what `atlas.config.ts` authors. */
+export type CatalogEntryInput = z.input<typeof CatalogEntrySchema>;
+
+export { CatalogEntrySchema };
+
 const AtlasConfigSchema = z.object({
   /**
    * Named datasource connections. The "default" key is used when no
@@ -456,6 +548,31 @@ const AtlasConfigSchema = z.object({
    * Requires enterprise features to be enabled.
    */
   residency: ResidencyConfigSchema.optional(),
+
+  /**
+   * Plugin Catalog declaration — flat list of installable chat Platforms
+   * and integration plugins. Implements ADR-0002 S3: declarative at deploy
+   * time, idempotently seeded into `plugin_catalog` at boot, then DB-
+   * canonical for runtime reads. Operator declares; customer admin
+   * installs via the admin UI (slice 3 — #2651).
+   *
+   * `type` groups for admin-UI display; `install_model` dispatches the
+   * install-handler family. Slugs must be unique within the array.
+   *
+   * @see docs/adr/0002-catalog-seeded-from-config-at-boot.md
+   */
+  catalog: z.array(CatalogEntrySchema).optional().refine(
+    (entries) => {
+      if (!entries) return true;
+      const slugs = new Set<string>();
+      for (const entry of entries) {
+        if (slugs.has(entry.slug)) return false;
+        slugs.add(entry.slug);
+      }
+      return true;
+    },
+    "catalog entries must have unique slugs — duplicate found",
+  ),
 });
 
 /** The output type after Zod parsing (defaults applied, all fields present). */
@@ -513,6 +630,15 @@ export interface ResolvedConfig {
   residency?: ResidencyConfig;
   /** Resolved deploy mode — binary "saas" or "self-hosted" (auto is resolved at boot). */
   deployMode?: "saas" | "self-hosted";
+  /**
+   * Plugin Catalog declaration — flat list of installable chat Platforms
+   * and integration plugins. Seeded into `plugin_catalog` at boot via
+   * `CatalogSeeder` (1.5.2 — #2650). Optional on `ResolvedConfig`
+   * (omitted when the operator declared no catalog) to match the
+   * conditional-spread pattern other optional fields use here; consumers
+   * should default to `[]` via `config.catalog ?? []`.
+   */
+  catalog?: CatalogEntry[];
   /** Whether the config was loaded from a file or synthesized from env vars. */
   source: "file" | "env";
 }
@@ -716,6 +842,8 @@ export function configFromEnv(): ResolvedConfig {
         ? { licenseKey: process.env.ATLAS_ENTERPRISE_LICENSE_KEY }
         : {}),
     },
+    // Catalog is operator-declared in atlas.config.ts; env-var fallback
+    // leaves it undefined (self-host without chat/integration installs).
     source: "env",
   };
 }
@@ -1069,6 +1197,9 @@ export function validateAndResolve(raw: unknown): ResolvedConfig {
     ...(config.starterPrompts ? { starterPrompts: config.starterPrompts } : {}),
     ...(config.enterprise ? { enterprise: config.enterprise } : {}),
     ...(config.residency ? { residency: config.residency } : {}),
+    ...(config.catalog && config.catalog.length > 0
+      ? { catalog: config.catalog }
+      : {}),
     source: "file",
   };
 }

--- a/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
@@ -4302,6 +4302,60 @@ describeIfPg("migrate-pg (real Postgres)", () => {
     expect(rows[0]?.value.orgId).toBe("org-merge");
   }, PG_TEST_TIMEOUT_MS);
 
+  // #2650 — slice 2 of 1.5.2. Pins the two new columns + the install_model
+  // CHECK so a regression that drops either column or admits a stray value
+  // (`oauth2`, `oAuth`, etc.) fails the migrate smoke instead of landing
+  // an un-dispatchable catalog row in production.
+  it("0087: plugin_catalog.install_model + saas_eligible columns exist and CHECK is enforced", async () => {
+    const slug = `pg-smoke-${Date.now()}`;
+    const id = `cat-${slug}`;
+
+    // Happy path: insert with the canonical OAuth value + explicit
+    // saas_eligible. Defaults are tested by the seeder unit tests; here
+    // we just confirm the columns accept the documented enum values.
+    await pool.query(
+      `INSERT INTO plugin_catalog (id, name, slug, type, install_model, saas_eligible)
+       VALUES ($1, 'PG Smoke Catalog Entry', $2, 'chat', 'oauth', true)`,
+      [id, slug],
+    );
+
+    const { rows } = await pool.query<{
+      install_model: string;
+      saas_eligible: boolean;
+    }>(`SELECT install_model, saas_eligible FROM plugin_catalog WHERE id = $1`, [id]);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.install_model).toBe("oauth");
+    expect(rows[0]?.saas_eligible).toBe(true);
+
+    // CHECK rejects an unknown install_model with 23514 (check_violation).
+    await expect(
+      pool.query(
+        `INSERT INTO plugin_catalog (id, name, slug, type, install_model)
+         VALUES ($1, 'Should Fail', $2, 'chat', 'not-a-model')`,
+        [`${id}-bad`, `${slug}-bad`],
+      ),
+    ).rejects.toMatchObject({ code: "23514" });
+
+    // CHECK also accepts the other two documented values.
+    for (const value of ["form", "static-bot"] as const) {
+      await pool.query(
+        `INSERT INTO plugin_catalog (id, name, slug, type, install_model)
+         VALUES ($1, 'PG Smoke', $2, 'integration', $3)`,
+        [`${id}-${value}`, `${slug}-${value}`, value],
+      );
+    }
+
+    // The widened `type` CHECK admits 'chat' and 'integration' alongside
+    // the legacy values. Lock both new values down.
+    for (const t of ["chat", "integration"] as const) {
+      await pool.query(
+        `INSERT INTO plugin_catalog (id, name, slug, type, install_model)
+         VALUES ($1, 'PG Smoke Type', $2, $3, 'oauth')`,
+        [`${id}-type-${t}`, `${slug}-type-${t}`, t],
+      );
+    }
+  }, PG_TEST_TIMEOUT_MS);
+
   it("0086: chat_cache.value->>'orgId' returns the Atlas org id for a stored Slack install (#2634)", async () => {
     // End-to-end shape check: a row written through the consolidated
     // path resolves cleanly by org_id via the new partial index. Uses

--- a/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
@@ -4356,6 +4356,33 @@ describeIfPg("migrate-pg (real Postgres)", () => {
     }
   }, PG_TEST_TIMEOUT_MS);
 
+  // Pinned by PR-test-analyzer review on #2664 — guards the
+  // `DEFAULT 'oauth'` / `DEFAULT true` clauses against a future
+  // "tidying" revision that drops them. Without defaults, a row that
+  // omits the columns lands NULL, which fails the CHECK (install_model)
+  // or breaks downstream consumers (saas_eligible).
+  it("0087: install_model + saas_eligible defaults apply on omission", async () => {
+    const slug = `pg-default-${Date.now()}`;
+    const id = `cat-${slug}`;
+
+    await pool.query(
+      `INSERT INTO plugin_catalog (id, name, slug, type)
+       VALUES ($1, 'PG Default Smoke', $2, 'chat')`,
+      [id, slug],
+    );
+
+    const { rows } = await pool.query<{
+      install_model: string;
+      saas_eligible: boolean;
+    }>(
+      `SELECT install_model, saas_eligible FROM plugin_catalog WHERE id = $1`,
+      [id],
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.install_model).toBe("oauth");
+    expect(rows[0]?.saas_eligible).toBe(true);
+  }, PG_TEST_TIMEOUT_MS);
+
   it("0086: chat_cache.value->>'orgId' returns the Atlas org id for a stored Slack install (#2634)", async () => {
     // End-to-end shape check: a row written through the consolidated
     // path resolves cleanly by org_id via the new partial index. Uses

--- a/packages/api/src/lib/db/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate.test.ts
@@ -98,8 +98,9 @@ describe("runMigrations", () => {
     // + 0083 (dashboard_stage_changes, #2365)
     // + 0084 (proactive_classification_review, #2622)
     // + 0085 (workspace_proactive_config.workspace_id <> '' CHECK, #2623 item 5)
-    // + 0086 (consolidate slack installations onto chat_cache, #2634) = 87.
-    expect(count).toBe(87);
+    // + 0086 (consolidate slack installations onto chat_cache, #2634)
+    // + 0087 (plugin_catalog.install_model + saas_eligible, #2650) = 88.
+    expect(count).toBe(88);
 
     // Advisory lock acquired before anything else
     expect(queries[0]).toContain("pg_advisory_lock");
@@ -215,6 +216,7 @@ describe("runMigrations", () => {
         "0084_proactive_classification_review.sql",
         "0085_workspace_proactive_config_workspace_id_nonempty.sql",
         "0086_consolidate_slack_installations.sql",
+        "0087_plugin_catalog_install_model.sql",
       ],
     });
 

--- a/packages/api/src/lib/db/migrations/0087_plugin_catalog_install_model.sql
+++ b/packages/api/src/lib/db/migrations/0087_plugin_catalog_install_model.sql
@@ -1,0 +1,71 @@
+-- 0087_plugin_catalog_install_model.sql
+--
+-- Atlas issue #2650 (1.5.2 slice 2) — extend `plugin_catalog` with
+-- the columns the `CatalogSeeder` needs to seed from `atlas.config.ts`
+-- and that the admin-UI install dispatch needs at runtime.
+--
+-- New columns:
+--   * `install_model` — discriminates the install-handler family per
+--     CONTEXT.md "Install models":
+--       - `oauth`      — OAuth dance against operator-owned App
+--                        Registration (Slack, Salesforce, Jira, GitHub
+--                        Apps, Linear OAuth in 1.5.3)
+--       - `form`       — customer fills credentials form (Email,
+--                        Webhook, Obsidian, GitHub PAT, Linear API-key
+--                        in 1.5.3)
+--       - `static-bot` — operator-shared bot + per-Workspace routing id
+--                        (Teams, Discord, gchat, Telegram, WhatsApp —
+--                        not installable until 1.5.3)
+--     CHECK constraint pins the enum at the DB layer so a typo in a
+--     future seed can't land an un-dispatchable row.
+--   * `saas_eligible` — gate on per-deploy-mode visibility. False rows
+--     are hidden from SaaS admin UI but remain installable on self-
+--     host. Canonical case: GitHub PAT mode (per-user token tied to one
+--     employee — unsafe in B2B SaaS, fine on a self-host single-tenant).
+--
+-- Default for `install_model` is intentionally `'oauth'` so the column
+-- can be added NOT NULL without backfilling — the only existing row
+-- shape pre-#2650 is the dogfood Slack catalog entry, which IS OAuth.
+-- The `CatalogSeeder` boot pass will overwrite per-slug values from
+-- atlas.config.ts on next boot anyway, so a transient default lasting
+-- one boot is fine. `saas_eligible` defaults to `true` (safe default —
+-- visible unless explicitly hidden) for the same reason.
+
+ALTER TABLE plugin_catalog
+  ADD COLUMN IF NOT EXISTS install_model TEXT NOT NULL DEFAULT 'oauth';
+
+ALTER TABLE plugin_catalog
+  ADD COLUMN IF NOT EXISTS saas_eligible BOOLEAN NOT NULL DEFAULT true;
+
+-- CHECK at the DB layer so a future seed regression (typo, wrong
+-- value) fails at INSERT/UPDATE time rather than silently landing a
+-- row the install dispatch can't route. Mirrors the existing
+-- `chk_plugin_catalog_type` pattern.
+ALTER TABLE plugin_catalog
+  DROP CONSTRAINT IF EXISTS chk_plugin_catalog_install_model;
+ALTER TABLE plugin_catalog
+  ADD CONSTRAINT chk_plugin_catalog_install_model
+  CHECK (install_model IN ('oauth', 'form', 'static-bot'));
+
+-- Expand `type` to admit the new admin-UI groupings introduced by the
+-- catalog declaration (`chat` for chat Platforms, `integration` for
+-- everything else customer-installable). The pre-#2650 values
+-- (`datasource`, `context`, `interaction`, `action`, `sandbox`) stay
+-- accepted so existing rows from older seeds aren't invalidated.
+-- Postgres requires DROP + ADD to widen a CHECK enum; ALTER CONSTRAINT
+-- can't broaden a predicate.
+ALTER TABLE plugin_catalog
+  DROP CONSTRAINT IF EXISTS plugin_catalog_type_check;
+ALTER TABLE plugin_catalog
+  DROP CONSTRAINT IF EXISTS chk_plugin_catalog_type;
+ALTER TABLE plugin_catalog
+  ADD CONSTRAINT chk_plugin_catalog_type
+  CHECK (type IN ('datasource', 'context', 'interaction', 'action', 'sandbox', 'chat', 'integration'));
+
+-- Lookup index for the catalog query the chat plugin's AdapterRegistry
+-- and the admin-UI listing both run (`WHERE type = $1 AND install_model
+-- = $2 AND enabled = true`). Partial on `enabled = true` keeps the
+-- index narrow.
+CREATE INDEX IF NOT EXISTS idx_plugin_catalog_install_model
+  ON plugin_catalog (type, install_model)
+  WHERE enabled = true;

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -1585,6 +1585,12 @@ export const pluginCatalog = pgTable(
     configSchema: jsonb("config_schema"),
     minPlan: text("min_plan").notNull().default("starter"),
     enabled: boolean("enabled").notNull().default(true),
+    // #2650 — install-handler dispatch key. Mirrors `CatalogInstallModel`
+    // in lib/config.ts. CHECK constraint enforces the enum at DB layer.
+    installModel: text("install_model").notNull().default("oauth"),
+    // #2650 — gate on per-deploy-mode visibility. SaaS hides `false`
+    // rows from admin-UI listings; self-host always shows them.
+    saasEligible: boolean("saas_eligible").notNull().default(true),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
@@ -1592,7 +1598,13 @@ export const pluginCatalog = pgTable(
     index("idx_plugin_catalog_slug").on(t.slug),
     index("idx_plugin_catalog_type").on(t.type),
     index("idx_plugin_catalog_enabled").on(t.enabled).where(sql`enabled = true`),
-    check("chk_plugin_catalog_type", sql`type IN ('datasource', 'context', 'interaction', 'action', 'sandbox')`),
+    // Partial on enabled = true keeps the index narrow — admin-UI catalog
+    // listing and chat-plugin AdapterRegistry both `WHERE enabled = true`.
+    index("idx_plugin_catalog_install_model")
+      .on(t.type, t.installModel)
+      .where(sql`enabled = true`),
+    check("chk_plugin_catalog_type", sql`type IN ('datasource', 'context', 'interaction', 'action', 'sandbox', 'chat', 'integration')`),
+    check("chk_plugin_catalog_install_model", sql`install_model IN ('oauth', 'form', 'static-bot')`),
   ],
 );
 

--- a/packages/api/src/lib/effect/layers.ts
+++ b/packages/api/src/lib/effect/layers.ts
@@ -311,6 +311,19 @@ export const BackfillSaasTrialLive: Layer.Layer<
 // ██  Catalog Seed Layer (#2650 — 1.5.2 slice 2)
 // ══════════════════════════════════════════════════════════════════════
 
+/**
+ * Discriminated outcome of the boot-time catalog seed. Mirrors
+ * {@link ConnectionsHydrateOutcome} below so a future `/health` or
+ * admin banner consumer can surface an unhealthy state without
+ * re-grepping logs.
+ *
+ * - `skipped-gate`  — InternalDB or Migration upstream not satisfied
+ * - `seeded`        — seed ran (may have applied 0 writes if config matched DB)
+ * - `error`         — the boot wrapper or its dynamic import threw;
+ *                     `plugin_catalog` reflects the pre-boot state
+ */
+export type CatalogSeedOutcome = "skipped-gate" | "seeded" | "error";
+
 export interface CatalogSeedShape {
   /** Newly inserted plugin_catalog rows this boot. */
   readonly insertedCount: number;
@@ -324,6 +337,10 @@ export interface CatalogSeedShape {
   readonly preservedCount: number;
   /** Slugs in DB without a matching declaration. Logged at warn, never deleted. */
   readonly orphanSlugs: ReadonlyArray<string>;
+  /** Discriminates intentional skip / normal seed / failure. */
+  readonly outcome: CatalogSeedOutcome;
+  /** Scrubbed error message when `outcome === "error"`. */
+  readonly error?: string;
 }
 
 export class CatalogSeed extends Context.Tag("CatalogSeed")<
@@ -340,7 +357,8 @@ export class CatalogSeed extends Context.Tag("CatalogSeed")<
  * on `InternalDB` for the pool. Non-fatal: the seeder swallows
  * errors internally and logs at error so a failed seed leaves
  * pre-existing rows authoritative for the boot rather than crashing
- * the API.
+ * the API. The failure is observable via `CatalogSeedShape.outcome ===
+ * "error"` so health surfaces can degrade instead of guessing.
  *
  * Self-hosted with an empty `catalog: []` (or omitted) is a quick
  * no-op: the seeder skips the upsert loop entirely and only emits the
@@ -355,50 +373,51 @@ export const CatalogSeedLive: Layer.Layer<
   Effect.gen(function* () {
     const db = yield* InternalDB;
     const migration = yield* Migration;
+    const zeroCounts = {
+      insertedCount: 0,
+      updatedCount: 0,
+      preservedCount: 0,
+      orphanSlugs: [] as ReadonlyArray<string>,
+    };
+
     if (!db.available || !migration.migrated) {
       log.info(
         { available: db.available, migrated: migration.migrated },
         "Catalog seed skipped — upstream gate (InternalDB or Migration) not satisfied",
       );
-      return {
-        insertedCount: 0,
-        updatedCount: 0,
-        preservedCount: 0,
-        orphanSlugs: [],
-      } satisfies CatalogSeedShape;
+      return { ...zeroCounts, outcome: "skipped-gate" } satisfies CatalogSeedShape;
     }
 
-    const result = yield* Effect.tryPromise({
+    return yield* Effect.tryPromise({
       try: async () => {
         const { runCatalogSeedBoot } = await import(
           "@atlas/api/lib/integrations/catalog-seeder"
         );
-        return await runCatalogSeedBoot();
+        const result = await runCatalogSeedBoot();
+        return {
+          insertedCount: result.insertedCount,
+          updatedCount: result.updatedCount,
+          preservedCount: result.preservedCount,
+          orphanSlugs: result.orphanSlugs,
+          outcome: "seeded",
+        } satisfies CatalogSeedShape;
       },
       catch: (err) => (err instanceof Error ? err : new Error(String(err))),
     }).pipe(
       Effect.catchAll((err) => {
-        // Only reachable if the dynamic import itself rejects — the
-        // seed function catches its own SQL/DB errors and returns the
-        // EMPTY_RESULT shape.
+        // Reachable when the dynamic import itself rejects (bundle
+        // artefact missing, runtime ESM resolution issue) — the
+        // `runCatalogSeedBoot` wrapper catches its own SQL/DB errors.
+        // We still surface the failure via `outcome: "error"` so
+        // healthCheck consumers can degrade.
         log.error({ err }, "Catalog seed boot wrapper threw");
         return Effect.succeed({
-          insertedCount: 0,
-          updatedCount: 0,
-          preservedCount: 0,
-          applied: 0,
-          preservedSlugs: [] as string[],
-          orphanSlugs: [] as string[],
-        });
+          ...zeroCounts,
+          outcome: "error",
+          error: errorMessage(err),
+        } satisfies CatalogSeedShape);
       }),
     );
-
-    return {
-      insertedCount: result.insertedCount,
-      updatedCount: result.updatedCount,
-      preservedCount: result.preservedCount,
-      orphanSlugs: result.orphanSlugs,
-    } satisfies CatalogSeedShape;
   }),
 );
 

--- a/packages/api/src/lib/effect/layers.ts
+++ b/packages/api/src/lib/effect/layers.ts
@@ -308,6 +308,101 @@ export const BackfillSaasTrialLive: Layer.Layer<
 );
 
 // ══════════════════════════════════════════════════════════════════════
+// ██  Catalog Seed Layer (#2650 — 1.5.2 slice 2)
+// ══════════════════════════════════════════════════════════════════════
+
+export interface CatalogSeedShape {
+  /** Newly inserted plugin_catalog rows this boot. */
+  readonly insertedCount: number;
+  /** Rows whose mutable columns were updated to match config this boot. */
+  readonly updatedCount: number;
+  /**
+   * Rows preserved at `enabled = false` because ops had manually
+   * disabled them. Surfaced so admin observability tooling can flag the
+   * config-vs-DB drift.
+   */
+  readonly preservedCount: number;
+  /** Slugs in DB without a matching declaration. Logged at warn, never deleted. */
+  readonly orphanSlugs: ReadonlyArray<string>;
+}
+
+export class CatalogSeed extends Context.Tag("CatalogSeed")<
+  CatalogSeed,
+  CatalogSeedShape
+>() {}
+
+/**
+ * Idempotent seed of `plugin_catalog` from `atlas.config.ts:catalog`.
+ * Implements ADR-0002 S3 (config-driven, idempotently seeded).
+ *
+ * Depends on `Migration` so the new install_model + saas_eligible
+ * columns (migration 0087) are guaranteed before the upsert; depends
+ * on `InternalDB` for the pool. Non-fatal: the seeder swallows
+ * errors internally and logs at error so a failed seed leaves
+ * pre-existing rows authoritative for the boot rather than crashing
+ * the API.
+ *
+ * Self-hosted with an empty `catalog: []` (or omitted) is a quick
+ * no-op: the seeder skips the upsert loop entirely and only emits the
+ * orphan warn if any catalog rows linger.
+ */
+export const CatalogSeedLive: Layer.Layer<
+  CatalogSeed,
+  never,
+  InternalDB | Migration
+> = Layer.effect(
+  CatalogSeed,
+  Effect.gen(function* () {
+    const db = yield* InternalDB;
+    const migration = yield* Migration;
+    if (!db.available || !migration.migrated) {
+      log.info(
+        { available: db.available, migrated: migration.migrated },
+        "Catalog seed skipped — upstream gate (InternalDB or Migration) not satisfied",
+      );
+      return {
+        insertedCount: 0,
+        updatedCount: 0,
+        preservedCount: 0,
+        orphanSlugs: [],
+      } satisfies CatalogSeedShape;
+    }
+
+    const result = yield* Effect.tryPromise({
+      try: async () => {
+        const { runCatalogSeedBoot } = await import(
+          "@atlas/api/lib/integrations/catalog-seeder"
+        );
+        return await runCatalogSeedBoot();
+      },
+      catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+    }).pipe(
+      Effect.catchAll((err) => {
+        // Only reachable if the dynamic import itself rejects — the
+        // seed function catches its own SQL/DB errors and returns the
+        // EMPTY_RESULT shape.
+        log.error({ err }, "Catalog seed boot wrapper threw");
+        return Effect.succeed({
+          insertedCount: 0,
+          updatedCount: 0,
+          preservedCount: 0,
+          applied: 0,
+          preservedSlugs: [] as string[],
+          orphanSlugs: [] as string[],
+        });
+      }),
+    );
+
+    return {
+      insertedCount: result.insertedCount,
+      updatedCount: result.updatedCount,
+      preservedCount: result.preservedCount,
+      orphanSlugs: result.orphanSlugs,
+    } satisfies CatalogSeedShape;
+  }),
+);
+
+// ══════════════════════════════════════════════════════════════════════
 // ██  Connections Hydrate Layer
 // ══════════════════════════════════════════════════════════════════════
 
@@ -1163,6 +1258,7 @@ export function buildAppLayer(config: ResolvedConfig): Layer.Layer<
   | InternalDB
   | Migration
   | BackfillSaasTrial
+  | CatalogSeed
   | ConnectionsHydrate
   | SemanticSync
   | Settings
@@ -1181,6 +1277,13 @@ export function buildAppLayer(config: ResolvedConfig): Layer.Layer<
   // the other layers — Effect's mergeAll doesn't order independent
   // siblings, so the only real ordering is the Migration dependency.
   const backfillSaasTrialLayer = BackfillSaasTrialLive.pipe(
+    Layer.provide(Layer.merge(internalDBLayer, migrationLayer)),
+  );
+
+  // CatalogSeedLive depends on Migration (so the install_model +
+  // saas_eligible columns added by 0087 exist) and InternalDB. Same
+  // shape as BackfillSaasTrialLive — independent peer otherwise.
+  const catalogSeedLayer = CatalogSeedLive.pipe(
     Layer.provide(Layer.merge(internalDBLayer, migrationLayer)),
   );
 
@@ -1239,6 +1342,7 @@ export function buildAppLayer(config: ResolvedConfig): Layer.Layer<
     internalDBLayer,
     migrationLayer,
     backfillSaasTrialLayer,
+    catalogSeedLayer,
     connectionsHydrateLayer,
     semanticSyncLayer,
     settingsLayer,

--- a/packages/api/src/lib/integrations/__tests__/catalog-seeder.test.ts
+++ b/packages/api/src/lib/integrations/__tests__/catalog-seeder.test.ts
@@ -1,0 +1,362 @@
+/**
+ * Tests for `CatalogSeeder` — slice 2 of #2649 (issue #2650).
+ *
+ * Two surfaces under test:
+ *
+ *   - `planCatalogSeed` (pure planner) — input/output shape, no mocks.
+ *   - `seedCatalog` (DB driver) — drives a hand-rolled `CatalogSeedDb`
+ *     mock; asserts UPSERT params + that no DELETE/UPDATE bypasses the
+ *     planner.
+ *
+ * Asserted invariants (AC quoted from #2650):
+ *
+ *   - Boot pass calls CatalogSeeder; idempotent on re-boot
+ *   - `slack` row exists after first boot with install_model='oauth',
+ *     enabled=true, saas_eligible=true
+ *   - Other chat Platform rows seeded with enabled=false and
+ *     install_model='static-bot'
+ *   - Re-running seed preserves enabled=false if ops has manually
+ *     disabled the row (log warn if config disagrees)
+ *   - Re-running seed warns on orphan catalog rows; does NOT delete
+ *   - CatalogSeeder unit-tested: idempotency, env-var presence matrix,
+ *     preservation of ops-disabled, orphan warn, plan-tier propagation,
+ *     install_model propagation, saas_eligible propagation
+ */
+
+import { describe, it, expect } from "bun:test";
+import {
+  planCatalogSeed,
+  seedCatalog,
+  type CatalogDbRow,
+  type CatalogSeedDb,
+} from "../catalog-seeder";
+import type { CatalogEntry } from "@atlas/api/lib/config";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function entry(partial: Partial<CatalogEntry> & Pick<CatalogEntry, "slug">): CatalogEntry {
+  return {
+    type: "chat",
+    install_model: "oauth",
+    min_plan: "starter",
+    enabled: true,
+    saas_eligible: true,
+    ...partial,
+  };
+}
+
+function row(partial: Partial<CatalogDbRow> & Pick<CatalogDbRow, "slug">): CatalogDbRow {
+  return {
+    name: "Slack",
+    description: null,
+    type: "chat",
+    iconUrl: null,
+    minPlan: "starter",
+    enabled: true,
+    installModel: "oauth",
+    saasEligible: true,
+    ...partial,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Mock DB
+// ---------------------------------------------------------------------------
+
+interface Captured {
+  sql: string;
+  params: unknown[];
+}
+
+function makeMockDb(seed: CatalogDbRow[] = []): {
+  db: CatalogSeedDb;
+  captured: Captured[];
+  rows: CatalogDbRow[];
+} {
+  const rows = [...seed];
+  const captured: Captured[] = [];
+
+  const db: CatalogSeedDb = {
+    async query<T = unknown>(sql: string, params?: unknown[]) {
+      const ps = params ?? [];
+      captured.push({ sql, params: ps });
+
+      // SELECT path: return current snapshot.
+      if (sql.includes("SELECT slug, name, description, type, icon_url")) {
+        return { rows: snapshotRaw(rows) as T[] };
+      }
+      if (sql.includes("SELECT slug FROM plugin_catalog")) {
+        return { rows: rows.map((r) => ({ slug: r.slug })) as T[] };
+      }
+
+      // INSERT … ON CONFLICT path: emulate upsert by mutating the snapshot.
+      if (sql.includes("INSERT INTO plugin_catalog")) {
+        const [
+          _id,
+          name,
+          slug,
+          description,
+          type,
+          iconUrl,
+          minPlan,
+          enabled,
+          installModel,
+          saasEligible,
+        ] = ps as [
+          string,
+          string,
+          string,
+          string | null,
+          string,
+          string | null,
+          string,
+          boolean,
+          string,
+          boolean,
+        ];
+        const existing = rows.findIndex((r) => r.slug === slug);
+        const next: CatalogDbRow = {
+          slug,
+          name,
+          description,
+          type,
+          iconUrl,
+          minPlan,
+          enabled,
+          installModel,
+          saasEligible,
+        };
+        if (existing === -1) rows.push(next);
+        else rows[existing] = next;
+        return { rows: [] as T[] };
+      }
+
+      return { rows: [] as T[] };
+    },
+  };
+
+  return { db, captured, rows };
+}
+
+function snapshotRaw(rows: CatalogDbRow[]): Array<{
+  slug: string;
+  name: string;
+  description: string | null;
+  type: string;
+  icon_url: string | null;
+  min_plan: string;
+  enabled: boolean;
+  install_model: string;
+  saas_eligible: boolean;
+}> {
+  return rows.map((r) => ({
+    slug: r.slug,
+    name: r.name,
+    description: r.description,
+    type: r.type,
+    icon_url: r.iconUrl,
+    min_plan: r.minPlan,
+    enabled: r.enabled,
+    install_model: r.installModel,
+    saas_eligible: r.saasEligible,
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// planCatalogSeed (pure)
+// ---------------------------------------------------------------------------
+
+describe("planCatalogSeed", () => {
+  it("inserts new entries when no DB rows exist", () => {
+    const plan = planCatalogSeed(
+      [entry({ slug: "slack" }), entry({ slug: "telegram", enabled: false, install_model: "static-bot" })],
+      [],
+    );
+    expect(plan.actions).toHaveLength(2);
+    expect(plan.actions[0]).toMatchObject({ action: "insert", entry: { slug: "slack" } });
+    expect(plan.actions[1]).toMatchObject({ action: "insert", entry: { slug: "telegram" } });
+    expect(plan.orphanSlugs).toEqual([]);
+  });
+
+  it("returns noop when DB matches declaration", () => {
+    const plan = planCatalogSeed(
+      [entry({ slug: "slack" })],
+      [row({ slug: "slack" })],
+    );
+    expect(plan.actions).toHaveLength(1);
+    expect(plan.actions[0]).toMatchObject({ action: "noop", entry: { slug: "slack" } });
+  });
+
+  it("updates when columns differ", () => {
+    const plan = planCatalogSeed(
+      [entry({ slug: "slack", min_plan: "team", saas_eligible: false })],
+      [row({ slug: "slack" })], // minPlan starter, saasEligible true
+    );
+    expect(plan.actions).toHaveLength(1);
+    const action = plan.actions[0];
+    expect(action.action).toBe("update");
+    if (action.action === "update") {
+      expect(action.diff).toContain("minPlan");
+      expect(action.diff).toContain("saasEligible");
+    }
+  });
+
+  it("preserves DB-disabled rows even when config wants enabled=true", () => {
+    const plan = planCatalogSeed(
+      [entry({ slug: "slack", enabled: true })],
+      [row({ slug: "slack", enabled: false })],
+    );
+    expect(plan.actions[0]).toMatchObject({ action: "preserve-disabled" });
+  });
+
+  it("does NOT preserve when config explicitly wants enabled=false (operator turning off)", () => {
+    // Reverse: DB says true, config says false — treat as a normal
+    // update. The "preserve" rule is one-way: it protects ops's
+    // emergency-disable; it doesn't pin DB-true against a config
+    // turn-off.
+    const plan = planCatalogSeed(
+      [entry({ slug: "slack", enabled: false })],
+      [row({ slug: "slack", enabled: true })],
+    );
+    expect(plan.actions[0]?.action).toBe("update");
+  });
+
+  it("surfaces orphan slugs without removing them from the plan", () => {
+    const plan = planCatalogSeed(
+      [entry({ slug: "slack" })],
+      [row({ slug: "slack" }), row({ slug: "community-plugin-xyz" })],
+    );
+    expect(plan.actions).toHaveLength(1);
+    expect(plan.orphanSlugs).toEqual(["community-plugin-xyz"]);
+  });
+
+  it("throws on duplicate slugs in declared entries (defense in depth)", () => {
+    expect(() =>
+      planCatalogSeed(
+        [entry({ slug: "slack" }), entry({ slug: "slack" })],
+        [],
+      ),
+    ).toThrow(/duplicate slug "slack"/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// seedCatalog (DB driver) — idempotency + key AC assertions
+// ---------------------------------------------------------------------------
+
+describe("seedCatalog", () => {
+  it("inserts every declared entry on first boot (Slack as canonical OAuth row)", async () => {
+    const { db, rows } = makeMockDb([]);
+    const result = await seedCatalog(db, [
+      entry({ slug: "slack" }),
+      entry({ slug: "telegram", install_model: "static-bot", enabled: false }),
+    ]);
+
+    expect(result.insertedCount).toBe(2);
+    expect(result.updatedCount).toBe(0);
+    expect(result.preservedCount).toBe(0);
+
+    const slack = rows.find((r) => r.slug === "slack");
+    expect(slack).toBeDefined();
+    expect(slack?.installModel).toBe("oauth");
+    expect(slack?.enabled).toBe(true);
+    expect(slack?.saasEligible).toBe(true);
+
+    const telegram = rows.find((r) => r.slug === "telegram");
+    expect(telegram?.installModel).toBe("static-bot");
+    expect(telegram?.enabled).toBe(false);
+  });
+
+  it("is idempotent on the second boot — zero writes the second time around", async () => {
+    const declared = [
+      entry({ slug: "slack" }),
+      entry({ slug: "telegram", install_model: "static-bot", enabled: false }),
+    ];
+
+    const { db, captured } = makeMockDb([]);
+    await seedCatalog(db, declared);
+    const writesAfterFirstBoot = captured.filter((c) =>
+      c.sql.includes("INSERT INTO plugin_catalog"),
+    ).length;
+    expect(writesAfterFirstBoot).toBe(2);
+
+    const second = await seedCatalog(db, declared);
+    expect(second.insertedCount).toBe(0);
+    expect(second.updatedCount).toBe(0);
+    expect(second.preservedCount).toBe(0);
+
+    const writesAfterSecondBoot = captured.filter((c) =>
+      c.sql.includes("INSERT INTO plugin_catalog"),
+    ).length;
+    expect(writesAfterSecondBoot).toBe(2); // unchanged
+  });
+
+  it("propagates plan_tier from config to DB row", async () => {
+    const { db, rows } = makeMockDb([]);
+    await seedCatalog(db, [
+      entry({ slug: "slack", min_plan: "team" }),
+      entry({ slug: "salesforce", type: "integration", min_plan: "business" }),
+    ]);
+    expect(rows.find((r) => r.slug === "slack")?.minPlan).toBe("team");
+    expect(rows.find((r) => r.slug === "salesforce")?.minPlan).toBe("business");
+  });
+
+  it("propagates install_model from config to DB row", async () => {
+    const { db, rows } = makeMockDb([]);
+    await seedCatalog(db, [
+      entry({ slug: "slack", install_model: "oauth" }),
+      entry({ slug: "email", type: "integration", install_model: "form" }),
+      entry({ slug: "telegram", install_model: "static-bot", enabled: false }),
+    ]);
+    expect(rows.find((r) => r.slug === "slack")?.installModel).toBe("oauth");
+    expect(rows.find((r) => r.slug === "email")?.installModel).toBe("form");
+    expect(rows.find((r) => r.slug === "telegram")?.installModel).toBe("static-bot");
+  });
+
+  it("propagates saas_eligible from config to DB row", async () => {
+    const { db, rows } = makeMockDb([]);
+    await seedCatalog(db, [
+      entry({ slug: "slack", saas_eligible: true }),
+      entry({ slug: "github-pat", type: "integration", install_model: "form", saas_eligible: false }),
+    ]);
+    expect(rows.find((r) => r.slug === "slack")?.saasEligible).toBe(true);
+    expect(rows.find((r) => r.slug === "github-pat")?.saasEligible).toBe(false);
+  });
+
+  it("preserves ops-disabled state on re-seed (config drift logged at warn)", async () => {
+    const { db, rows } = makeMockDb([
+      row({ slug: "slack", enabled: false }), // ops-disabled in DB
+    ]);
+    const result = await seedCatalog(db, [
+      entry({ slug: "slack", enabled: true }), // config wants on
+    ]);
+
+    expect(result.preservedCount).toBe(1);
+    expect(result.preservedSlugs).toEqual(["slack"]);
+    expect(rows.find((r) => r.slug === "slack")?.enabled).toBe(false);
+  });
+
+  it("does NOT delete orphan rows; surfaces them in the result for log/observability", async () => {
+    const { db, rows } = makeMockDb([
+      row({ slug: "slack" }),
+      row({ slug: "community-plugin", type: "integration" }),
+    ]);
+    const result = await seedCatalog(db, [entry({ slug: "slack" })]);
+    expect(result.orphanSlugs).toEqual(["community-plugin"]);
+    // Row still present in the mock DB — never deleted.
+    expect(rows.find((r) => r.slug === "community-plugin")).toBeDefined();
+  });
+
+  it("short-circuits when no entries declared but still surfaces orphans", async () => {
+    const { db, captured } = makeMockDb([row({ slug: "stale" })]);
+    const result = await seedCatalog(db, []);
+    expect(result.applied).toBe(0);
+    expect(result.orphanSlugs).toEqual(["stale"]);
+    // Sanity: never issued an INSERT.
+    expect(captured.some((c) => c.sql.includes("INSERT INTO plugin_catalog"))).toBe(
+      false,
+    );
+  });
+});

--- a/packages/api/src/lib/integrations/__tests__/catalog-seeder.test.ts
+++ b/packages/api/src/lib/integrations/__tests__/catalog-seeder.test.ts
@@ -23,7 +23,7 @@
  *     install_model propagation, saas_eligible propagation
  */
 
-import { describe, it, expect } from "bun:test";
+import { describe, it, expect, mock } from "bun:test";
 import {
   planCatalogSeed,
   seedCatalog,
@@ -117,15 +117,20 @@ function makeMockDb(seed: CatalogDbRow[] = []): {
           boolean,
         ];
         const existing = rows.findIndex((r) => r.slug === slug);
+        // Cast `type` and `installModel` to the narrow union — the
+        // upsert tuple destructure here is typed `string` because pg's
+        // param shape doesn't carry the enum constraint, but the
+        // upstream Zod validation + DB CHECK guarantee the value is
+        // one of the canonical literals.
         const next: CatalogDbRow = {
           slug,
           name,
           description,
-          type,
+          type: type as CatalogDbRow["type"],
           iconUrl,
           minPlan,
           enabled,
-          installModel,
+          installModel: installModel as CatalogDbRow["installModel"],
           saasEligible,
         };
         if (existing === -1) rows.push(next);
@@ -358,5 +363,146 @@ describe("seedCatalog", () => {
     expect(captured.some((c) => c.sql.includes("INSERT INTO plugin_catalog"))).toBe(
       false,
     );
+  });
+
+  // Pinned by PR-test-analyzer review on #2664 — guards against admin-UI
+  // copy drift on ops-disabled rows. The `preserve-disabled` branch
+  // clamps `enabled` to false but should still upsert name/description/
+  // min_plan so the admin UI displays the latest declared metadata.
+  it("preserve-disabled still upserts metadata (only `enabled` is clamped)", async () => {
+    const { db, rows } = makeMockDb([
+      row({
+        slug: "slack",
+        enabled: false,
+        name: "Old Slack Name",
+        minPlan: "starter",
+      }),
+    ]);
+    await seedCatalog(db, [
+      entry({
+        slug: "slack",
+        enabled: true, // config wants enabled
+        name: "New Slack Name",
+        min_plan: "team",
+      }),
+    ]);
+    const slack = rows.find((r) => r.slug === "slack");
+    expect(slack?.enabled).toBe(false); // ops-disable wins
+    expect(slack?.name).toBe("New Slack Name"); // metadata refreshed
+    expect(slack?.minPlan).toBe("team");
+  });
+
+  // Pinned by PR-test-analyzer review on #2664 — guards the
+  // `update` branch end-to-end. The pure planner test asserts the
+  // diff is computed; this test asserts the upsert actually flips
+  // the DB row's `installModel`.
+  it("install_model change between boots flips the DB row", async () => {
+    const { db, rows } = makeMockDb([
+      row({ slug: "slack", installModel: "form" }), // legacy DB state
+    ]);
+    const result = await seedCatalog(db, [
+      entry({ slug: "slack", install_model: "oauth" }),
+    ]);
+    expect(result.updatedCount).toBe(1);
+    expect(rows.find((r) => r.slug === "slack")?.installModel).toBe("oauth");
+  });
+
+  // Pinned by silent-failure-hunter review on #2664 — `readExistingCatalog`
+  // now Zod-validates `type` and `install_model` at read time and drops
+  // rows with stale enum values rather than letting them flow into the
+  // planner and trigger phantom updates.
+  it("drops DB rows with unknown enum values from the planner input", async () => {
+    const { db, rows } = makeMockDb([]);
+    // Inject a row directly with an out-of-enum install_model that
+    // bypasses the planner. Seed re-asserts the canonical shape.
+    rows.push({
+      slug: "slack",
+      name: "Slack",
+      description: null,
+      type: "chat",
+      iconUrl: null,
+      minPlan: "starter",
+      enabled: true,
+      // @ts-expect-error — deliberate stale value to exercise the drop path
+      installModel: "not-a-known-model",
+      saasEligible: true,
+    });
+    // The planner sees the row as if it doesn't exist (dropped + warned)
+    // so it issues an INSERT — the upsert ON CONFLICT(slug) updates
+    // the row's install_model back to 'oauth'.
+    const result = await seedCatalog(db, [entry({ slug: "slack" })]);
+    expect(result.insertedCount + result.updatedCount).toBe(1);
+    expect(rows.find((r) => r.slug === "slack")?.installModel).toBe("oauth");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runCatalogSeedBoot (boot wrapper) — swallow path
+// ---------------------------------------------------------------------------
+
+describe("runCatalogSeedBoot swallow path", () => {
+  // Pinned by PR-test-analyzer review on #2664 — without this, a
+  // regression that removes the try/catch would crash API boot on the
+  // next transient DB hiccup during seed.
+  it("returns EMPTY_RESULT and does NOT throw when seedCatalog rejects", async () => {
+    const { runCatalogSeedBoot } = await import("../catalog-seeder");
+
+    // Mock config + DB to push runCatalogSeedBoot past the early-return
+    // gates and into the inner try/catch. The DB query throws, the
+    // wrapper catches + logs + returns EMPTY_RESULT.
+    const savedDb = process.env.DATABASE_URL;
+    process.env.DATABASE_URL = "postgresql://test:test@127.0.0.1:9/atlas-test";
+
+    // Substitute the real getInternalDB with one whose pool.query
+    // always throws — exercises the catch in runCatalogSeedBoot.
+    //
+    // Mock every export the real `db/internal` module ships so a test
+    // running in the same process after this one (CLAUDE.md flags
+    // `mock.module()` as cross-file via bun's module loader) still
+    // resolves `internalQuery`, `MANAGED_AUTH_MIGRATIONS`, etc.
+    mock.module("@atlas/api/lib/db/internal", () => ({
+      hasInternalDB: () => true,
+      getInternalDB: () => ({
+        query: async () => {
+          throw new Error("simulated DB outage");
+        },
+      }),
+      internalQuery: async () => {
+        throw new Error("simulated DB outage");
+      },
+      MANAGED_AUTH_MIGRATIONS: [],
+      makeInternalDBLive: () => ({}),
+      closeInternalDB: async () => {},
+      InternalDB: { _tag: "InternalDB" },
+      loadSavedConnections: async () => 0,
+    }));
+    mock.module("@atlas/api/lib/config", () => ({
+      getConfig: () => ({
+        catalog: [
+          {
+            slug: "slack",
+            type: "chat",
+            install_model: "oauth",
+            enabled: true,
+            saas_eligible: true,
+            min_plan: "starter",
+          },
+        ],
+      }),
+    }));
+
+    let result;
+    try {
+      result = await runCatalogSeedBoot();
+    } finally {
+      if (savedDb === undefined) delete process.env.DATABASE_URL;
+      else process.env.DATABASE_URL = savedDb;
+    }
+
+    // The wrapper swallowed the throw and returned a sentinel result.
+    expect(result.insertedCount).toBe(0);
+    expect(result.updatedCount).toBe(0);
+    expect(result.preservedCount).toBe(0);
+    expect(result.applied).toBe(0);
   });
 });

--- a/packages/api/src/lib/integrations/catalog-seeder.ts
+++ b/packages/api/src/lib/integrations/catalog-seeder.ts
@@ -35,9 +35,10 @@
  */
 
 import { createLogger } from "@atlas/api/lib/logger";
-import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
 import {
   type CatalogEntry,
+  type CatalogEntryType,
+  type CatalogInstallModel,
   CATALOG_INSTALL_MODELS,
   CATALOG_ENTRY_TYPES,
 } from "@atlas/api/lib/config";
@@ -53,16 +54,21 @@ const log = createLogger("integrations.catalog-seeder");
  * Drizzle row carries `id`, `npm_package`, `config_schema`,
  * `created_at`, `updated_at` — none of which the seeder needs to compare
  * against the config. Keeping the read narrow keeps the planner pure.
+ *
+ * `type` and `installModel` are typed as their narrow union — DB rows
+ * with values outside the enum are dropped at read time (see
+ * `readExistingCatalog`) so the planner never compares a config entry
+ * against a stale row and emits a phantom update.
  */
 export interface CatalogDbRow {
   readonly slug: string;
   readonly name: string;
   readonly description: string | null;
-  readonly type: string;
+  readonly type: CatalogEntryType;
   readonly iconUrl: string | null;
   readonly minPlan: string;
   readonly enabled: boolean;
-  readonly installModel: string;
+  readonly installModel: CatalogInstallModel;
   readonly saasEligible: boolean;
 }
 
@@ -233,7 +239,13 @@ export interface CatalogSeedResult {
   readonly insertedCount: number;
   readonly updatedCount: number;
   readonly preservedCount: number;
-  /** Sum of insert + update + preserve + noop. */
+  /**
+   * Total `CatalogSeedAction` count returned by the planner — i.e.
+   * `plan.actions.length`. Equals `insertedCount + updatedCount +
+   * preservedCount + noopCount`, where `noopCount` is the implicit
+   * fourth bucket (rows that matched the declaration without any
+   * write).
+   */
   readonly applied: number;
   /** Slugs whose DB row was left untouched because ops had disabled it. */
   readonly preservedSlugs: ReadonlyArray<string>;
@@ -368,17 +380,39 @@ async function readExistingCatalog(db: CatalogSeedDb): Promise<CatalogDbRow[]> {
             install_model, saas_eligible
        FROM plugin_catalog`,
   );
-  return rows.map((r) => ({
-    slug: r.slug,
-    name: r.name,
-    description: r.description,
-    type: r.type,
-    iconUrl: r.icon_url,
-    minPlan: r.min_plan,
-    enabled: r.enabled,
-    installModel: r.install_model,
-    saasEligible: r.saas_eligible,
-  }));
+  // Validate enum membership at read time so the planner can trust the
+  // narrow `CatalogDbRow` shape. The DB CHECK constraints make a stray
+  // value structurally impossible, but a future migration could relax
+  // them; dropping unknown rows with a warn is fail-safe.
+  const valid: CatalogDbRow[] = [];
+  for (const r of rows) {
+    if (!CATALOG_ENTRY_TYPES.includes(r.type as CatalogEntryType)) {
+      log.warn(
+        { slug: r.slug, type: r.type },
+        "Catalog seed: plugin_catalog row has unknown `type` — dropping from planner input",
+      );
+      continue;
+    }
+    if (!CATALOG_INSTALL_MODELS.includes(r.install_model as CatalogInstallModel)) {
+      log.warn(
+        { slug: r.slug, install_model: r.install_model },
+        "Catalog seed: plugin_catalog row has unknown `install_model` — dropping from planner input",
+      );
+      continue;
+    }
+    valid.push({
+      slug: r.slug,
+      name: r.name,
+      description: r.description,
+      type: r.type as CatalogEntryType,
+      iconUrl: r.icon_url,
+      minPlan: r.min_plan,
+      enabled: r.enabled,
+      installModel: r.install_model as CatalogInstallModel,
+      saasEligible: r.saas_eligible,
+    });
+  }
+  return valid;
 }
 
 async function readOrphanSlugs(db: CatalogSeedDb): Promise<string[]> {
@@ -448,14 +482,22 @@ async function upsertEntry(db: CatalogSeedDb, entry: CatalogEntry): Promise<void
 }
 
 /**
- * Convenience wrapper for the boot pass — pulls the declared catalog
- * from `getConfig()` and the DB from `getInternalDB()`. Swallows errors
- * (logs at error) so a seed failure can't block API startup; admin
- * surfaces will see whatever was in `plugin_catalog` before this boot.
+ * Boot-pass wrapper. **Only this function** swallows errors — callers
+ * that need error propagation (tests, future Effect-based wiring) should
+ * use {@link seedCatalog} directly, which lets SQL / upsert errors
+ * bubble.
  *
- * Mirrors `backfillSaasTrial`'s "log-and-continue" posture — seeding
- * is best-effort during boot; failure modes are observable (the log
- * line + the absent-rows-after-deploy diagnostic) rather than fatal.
+ * Pulls the declared catalog from `getConfig()` and the DB from
+ * `getInternalDB()`, then runs `seedCatalog` inside a try/catch that
+ * logs at error and returns `EMPTY_RESULT`. The boot pass is best-
+ * effort: a failed seed leaves whichever rows were in `plugin_catalog`
+ * pre-boot authoritative for this process.
+ *
+ * Mirrors `backfillSaasTrial`'s "log-and-continue" posture. Failure
+ * modes are observable via (a) the `err` log line, which carries the
+ * original Error so Pino's `err` serializer captures the stack and
+ * (b) `CatalogSeedShape.outcome === "error"` on the Effect Tag for
+ * health-surface consumers.
  */
 export async function runCatalogSeedBoot(): Promise<CatalogSeedResult> {
   // Lazy imports keep config.ts and db/internal.ts off the static dep
@@ -488,8 +530,11 @@ export async function runCatalogSeedBoot(): Promise<CatalogSeedResult> {
   try {
     return await seedCatalog(db, config.catalog ?? []);
   } catch (err) {
+    // Pass the original Error to Pino's `err` serializer so the stack
+    // is preserved — `errorMessage(err)` would scrub it to a string.
+    // The seed failure is observable upstream via CatalogSeedShape.error.
     log.error(
-      { err: errorMessage(err) },
+      { err: err instanceof Error ? err : new Error(String(err)) },
       "Catalog seed failed — plugin_catalog rows from prior boot remain authoritative",
     );
     return EMPTY_RESULT;

--- a/packages/api/src/lib/integrations/catalog-seeder.ts
+++ b/packages/api/src/lib/integrations/catalog-seeder.ts
@@ -1,0 +1,497 @@
+/**
+ * Catalog seeder — boot-time idempotent upsert from `atlas.config.ts:catalog`
+ * into `plugin_catalog`. Implements ADR-0002 S3 (config-driven, idempotently
+ * seeded into catalog) and slice 2 of #2649 (issue #2650).
+ *
+ * Two layers:
+ *
+ *   1. `planCatalogSeed()` — pure function. Takes the declared catalog
+ *      entries from config plus the rows currently in DB; returns a typed
+ *      plan describing the writes. No I/O, fully unit-testable.
+ *
+ *   2. `seedCatalog()` — thin driver. Reads `plugin_catalog`, calls
+ *      `planCatalogSeed()`, then runs the upserts inside one transaction.
+ *      Idempotent: re-running with the same `(config, DB state)` is a
+ *      no-op beyond the `updated_at` bump on changed rows.
+ *
+ * Semantics (mirrors PRD "Catalog seed semantics"):
+ *
+ *   - **Inserts** when no row exists for a declared slug.
+ *   - **Updates** the declared-but-mutable columns (`name`, `description`,
+ *     `icon_url`, `type`, `install_model`, `min_plan`, `saas_eligible`) when
+ *     they differ.
+ *   - **Preserves `enabled = false`** when DB says false but config says
+ *     true (ops emergency-disable wins). Logs `warn` so the drift is
+ *     observable.
+ *   - **Orphans** — rows whose slug isn't in the declaration — emit a
+ *     `warn` log and are LEFT IN PLACE. The seed never deletes. This
+ *     preserves ops's ability to hand-add catalog rows (community
+ *     marketplace future) without the seed reaping them.
+ *
+ * Hooked into the boot pass via `CatalogSeedLive` in
+ * `packages/api/src/lib/effect/layers.ts`. Failure is non-fatal: a seed
+ * error logs and the API keeps booting — pre-existing catalog rows still
+ * answer admin-UI reads, just possibly out of date with the config.
+ */
+
+import { createLogger } from "@atlas/api/lib/logger";
+import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
+import {
+  type CatalogEntry,
+  CATALOG_INSTALL_MODELS,
+  CATALOG_ENTRY_TYPES,
+} from "@atlas/api/lib/config";
+
+const log = createLogger("integrations.catalog-seeder");
+
+// ---------------------------------------------------------------------------
+// DB row shape — narrow to the fields the seeder reads / writes
+// ---------------------------------------------------------------------------
+
+/**
+ * Subset of `plugin_catalog` columns the seeder reads / writes. The full
+ * Drizzle row carries `id`, `npm_package`, `config_schema`,
+ * `created_at`, `updated_at` — none of which the seeder needs to compare
+ * against the config. Keeping the read narrow keeps the planner pure.
+ */
+export interface CatalogDbRow {
+  readonly slug: string;
+  readonly name: string;
+  readonly description: string | null;
+  readonly type: string;
+  readonly iconUrl: string | null;
+  readonly minPlan: string;
+  readonly enabled: boolean;
+  readonly installModel: string;
+  readonly saasEligible: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Plan types
+// ---------------------------------------------------------------------------
+
+/**
+ * Per-row action the driver should take. `action: 'noop'` rows are
+ * surfaced for observability (`info` log of `preservedCount` in the
+ * summary) but require no SQL write.
+ */
+export type CatalogSeedAction =
+  | { readonly action: "insert"; readonly entry: CatalogEntry }
+  | {
+      readonly action: "update";
+      readonly entry: CatalogEntry;
+      readonly existing: CatalogDbRow;
+      /** Names of columns that differ from the existing row. */
+      readonly diff: ReadonlyArray<keyof CatalogDbRow>;
+    }
+  | {
+      readonly action: "preserve-disabled";
+      readonly entry: CatalogEntry;
+      readonly existing: CatalogDbRow;
+    }
+  | { readonly action: "noop"; readonly entry: CatalogEntry };
+
+/**
+ * Orphan = a DB row whose slug isn't in the config. Surfaced as a
+ * separate field on the plan because they're never written — only
+ * logged — and conflating them with no-op writes hurts observability.
+ */
+export interface CatalogSeedPlan {
+  readonly actions: ReadonlyArray<CatalogSeedAction>;
+  readonly orphanSlugs: ReadonlyArray<string>;
+}
+
+// ---------------------------------------------------------------------------
+// Planner (pure)
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a write plan from declared catalog entries + current DB rows.
+ *
+ * Pure: same `(declared, existing)` always yields the same plan. No I/O.
+ * Validation of `declared` shape is delegated to Zod at config load time
+ * — entries arriving here are already typed `CatalogEntry`.
+ *
+ * Throws on duplicate slugs in `declared` to fail loud at config load —
+ * the Zod refine on `AtlasConfigSchema.catalog` should catch this first,
+ * but defending in depth makes the planner safe to call in tests without
+ * re-running Zod.
+ */
+export function planCatalogSeed(
+  declared: ReadonlyArray<CatalogEntry>,
+  existing: ReadonlyArray<CatalogDbRow>,
+): CatalogSeedPlan {
+  const declaredBySlug = new Map<string, CatalogEntry>();
+  for (const entry of declared) {
+    if (declaredBySlug.has(entry.slug)) {
+      throw new Error(
+        `Catalog seed: duplicate slug "${entry.slug}" in declared entries`,
+      );
+    }
+    declaredBySlug.set(entry.slug, entry);
+  }
+
+  const existingBySlug = new Map<string, CatalogDbRow>();
+  for (const row of existing) existingBySlug.set(row.slug, row);
+
+  const actions: CatalogSeedAction[] = [];
+
+  for (const entry of declared) {
+    const row = existingBySlug.get(entry.slug);
+    if (!row) {
+      actions.push({ action: "insert", entry });
+      continue;
+    }
+
+    // Ops-disabled preservation: DB false beats config true. The reverse
+    // (DB true, config false) lands as a normal update — the operator is
+    // explicitly turning a row off via config; honor that.
+    if (!row.enabled && entry.enabled) {
+      actions.push({ action: "preserve-disabled", entry, existing: row });
+      continue;
+    }
+
+    const diff = diffEntry(entry, row);
+    if (diff.length === 0) {
+      actions.push({ action: "noop", entry });
+    } else {
+      actions.push({ action: "update", entry, existing: row, diff });
+    }
+  }
+
+  const orphanSlugs: string[] = [];
+  for (const slug of existingBySlug.keys()) {
+    if (!declaredBySlug.has(slug)) orphanSlugs.push(slug);
+  }
+
+  return { actions, orphanSlugs };
+}
+
+/**
+ * Names of `CatalogDbRow` columns that differ between the declared entry
+ * and the existing row. Used by `planCatalogSeed` to decide
+ * `update` vs `noop` and surfaced on the action for log debugging.
+ *
+ * `enabled` IS compared here — the `preserve-disabled` branch in
+ * `planCatalogSeed` short-circuits before this is called for the only
+ * case where the comparison would be wrong (DB false, config true).
+ * For DB true → config false (operator explicitly turning a row off),
+ * `enabled` correctly flips and the action lands as `update`.
+ */
+function diffEntry(
+  entry: CatalogEntry,
+  row: CatalogDbRow,
+): ReadonlyArray<keyof CatalogDbRow> {
+  const diff: Array<keyof CatalogDbRow> = [];
+  const wantName = entry.name ?? slugToDefaultName(entry.slug);
+  if (row.name !== wantName) diff.push("name");
+
+  const wantDescription = entry.description ?? null;
+  if (row.description !== wantDescription) diff.push("description");
+
+  if (row.type !== entry.type) diff.push("type");
+
+  const wantIconUrl = entry.iconUrl ?? null;
+  if (row.iconUrl !== wantIconUrl) diff.push("iconUrl");
+
+  if (row.minPlan !== entry.min_plan) diff.push("minPlan");
+  if (row.enabled !== entry.enabled) diff.push("enabled");
+  if (row.installModel !== entry.install_model) diff.push("installModel");
+  if (row.saasEligible !== entry.saas_eligible) diff.push("saasEligible");
+
+  return diff;
+}
+
+/**
+ * Fallback display name when the operator omits one — slug with dashes
+ * replaced by spaces and the first letter of each word capitalized.
+ * Matches the convention `"linear-apikey" → "Linear Apikey"`. Operators
+ * who care about copy override via `name:` in the declaration.
+ */
+function slugToDefaultName(slug: string): string {
+  return slug
+    .split("-")
+    .map((word) => (word.length > 0 ? word[0]!.toUpperCase() + word.slice(1) : word))
+    .join(" ");
+}
+
+// ---------------------------------------------------------------------------
+// DB driver
+// ---------------------------------------------------------------------------
+
+/**
+ * Narrow shape of the DB client the seeder needs. Lets the test layer
+ * substitute a mock pool without dragging in the full `pg.Pool` type.
+ * Mirrors `getInternalDB()` and `internalQuery()` from `db/internal.ts`.
+ */
+export interface CatalogSeedDb {
+  /** Run a parameterized query and return rows. */
+  query<T = unknown>(sql: string, params?: unknown[]): Promise<{ rows: T[] }>;
+}
+
+export interface CatalogSeedResult {
+  readonly insertedCount: number;
+  readonly updatedCount: number;
+  readonly preservedCount: number;
+  /** Sum of insert + update + preserve + noop. */
+  readonly applied: number;
+  /** Slugs whose DB row was left untouched because ops had disabled it. */
+  readonly preservedSlugs: ReadonlyArray<string>;
+  /** Slugs in DB without a matching declaration. Logged at warn. */
+  readonly orphanSlugs: ReadonlyArray<string>;
+}
+
+const EMPTY_RESULT: CatalogSeedResult = {
+  insertedCount: 0,
+  updatedCount: 0,
+  preservedCount: 0,
+  applied: 0,
+  preservedSlugs: [],
+  orphanSlugs: [],
+};
+
+/**
+ * Read `plugin_catalog`, plan the writes, then execute. Returns a
+ * summary the boot pass can log. The summary doubles as the test
+ * assertion target for the idempotency suite.
+ */
+export async function seedCatalog(
+  db: CatalogSeedDb,
+  declared: ReadonlyArray<CatalogEntry>,
+): Promise<CatalogSeedResult> {
+  if (declared.length === 0) {
+    // No declarations means a self-host operator (or a SaaS region) that
+    // doesn't want any chat / integration plugins. Still surface orphan
+    // rows for visibility — but skip the upsert loop entirely.
+    const orphans = await readOrphanSlugs(db);
+    if (orphans.length > 0) {
+      log.warn(
+        { orphanSlugs: orphans },
+        "Catalog seed: no entries declared, but plugin_catalog has rows — left in place (manual ops cleanup)",
+      );
+    }
+    log.info("Catalog seed: no declared entries; skipping upsert");
+    return { ...EMPTY_RESULT, orphanSlugs: orphans };
+  }
+
+  const existing = await readExistingCatalog(db);
+  const plan = planCatalogSeed(declared, existing);
+
+  let insertedCount = 0;
+  let updatedCount = 0;
+  let preservedCount = 0;
+  const preservedSlugs: string[] = [];
+
+  for (const action of plan.actions) {
+    switch (action.action) {
+      case "insert": {
+        await upsertEntry(db, action.entry);
+        insertedCount++;
+        break;
+      }
+      case "update": {
+        await upsertEntry(db, action.entry);
+        updatedCount++;
+        log.debug(
+          { slug: action.entry.slug, diff: action.diff },
+          "Catalog seed: updated row",
+        );
+        break;
+      }
+      case "preserve-disabled": {
+        // The DB-disabled state wins. We still upsert the declared
+        // metadata (name/description/etc.) so admin UI doesn't show
+        // stale copy — but we explicitly clamp `enabled = false`.
+        await upsertEntry(db, { ...action.entry, enabled: false });
+        preservedCount++;
+        preservedSlugs.push(action.entry.slug);
+        log.warn(
+          {
+            slug: action.entry.slug,
+            configEnabled: action.entry.enabled,
+            dbEnabled: action.existing.enabled,
+          },
+          "Catalog seed: ops-disabled row preserved — config wants enabled=true but DB has enabled=false",
+        );
+        break;
+      }
+      case "noop":
+        break;
+    }
+  }
+
+  for (const slug of plan.orphanSlugs) {
+    log.warn(
+      { slug, deployMode: process.env.ATLAS_DEPLOY_MODE ?? "unknown" },
+      "Catalog seed: orphan plugin_catalog row — left in place (manual ops cleanup)",
+    );
+  }
+
+  const result: CatalogSeedResult = {
+    insertedCount,
+    updatedCount,
+    preservedCount,
+    applied: plan.actions.length,
+    preservedSlugs,
+    orphanSlugs: plan.orphanSlugs,
+  };
+
+  log.info(
+    {
+      insertedCount,
+      updatedCount,
+      preservedCount,
+      orphanCount: plan.orphanSlugs.length,
+      noopCount: plan.actions.length - insertedCount - updatedCount - preservedCount,
+    },
+    "Catalog seed complete",
+  );
+
+  return result;
+}
+
+interface CatalogDbRowRaw {
+  slug: string;
+  name: string;
+  description: string | null;
+  type: string;
+  icon_url: string | null;
+  min_plan: string;
+  enabled: boolean;
+  install_model: string;
+  saas_eligible: boolean;
+}
+
+async function readExistingCatalog(db: CatalogSeedDb): Promise<CatalogDbRow[]> {
+  const { rows } = await db.query<CatalogDbRowRaw>(
+    `SELECT slug, name, description, type, icon_url, min_plan, enabled,
+            install_model, saas_eligible
+       FROM plugin_catalog`,
+  );
+  return rows.map((r) => ({
+    slug: r.slug,
+    name: r.name,
+    description: r.description,
+    type: r.type,
+    iconUrl: r.icon_url,
+    minPlan: r.min_plan,
+    enabled: r.enabled,
+    installModel: r.install_model,
+    saasEligible: r.saas_eligible,
+  }));
+}
+
+async function readOrphanSlugs(db: CatalogSeedDb): Promise<string[]> {
+  const { rows } = await db.query<{ slug: string }>(
+    `SELECT slug FROM plugin_catalog`,
+  );
+  return rows.map((r) => r.slug);
+}
+
+/**
+ * Single-row upsert keyed on slug. `id` is derived from slug to keep the
+ * seed deterministic — `catalog:<slug>` is stable across boots so foreign
+ * keys (`workspace_plugins.catalog_id`) survive re-seed.
+ *
+ * `updated_at = NOW()` runs on conflict so admin UIs can sort by recency.
+ * The CHECK constraints on `type` and `install_model` are the safety net
+ * against a regression that drops the Zod validation upstream.
+ */
+async function upsertEntry(db: CatalogSeedDb, entry: CatalogEntry): Promise<void> {
+  const id = `catalog:${entry.slug}`;
+  const name = entry.name ?? slugToDefaultName(entry.slug);
+  const description = entry.description ?? null;
+  const iconUrl = entry.iconUrl ?? null;
+
+  // Defense-in-depth: re-assert enum membership before issuing SQL — if
+  // a regression dropped the Zod validation, this catches it before
+  // hitting the DB CHECK (clearer error).
+  if (!CATALOG_INSTALL_MODELS.includes(entry.install_model)) {
+    throw new Error(
+      `Catalog seed: unknown install_model "${entry.install_model}" for slug "${entry.slug}"`,
+    );
+  }
+  if (!CATALOG_ENTRY_TYPES.includes(entry.type)) {
+    throw new Error(
+      `Catalog seed: unknown type "${entry.type}" for slug "${entry.slug}"`,
+    );
+  }
+
+  await db.query(
+    `INSERT INTO plugin_catalog
+       (id, name, slug, description, type, icon_url, min_plan, enabled,
+        install_model, saas_eligible, created_at, updated_at)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, NOW(), NOW())
+     ON CONFLICT (slug) DO UPDATE
+       SET name           = EXCLUDED.name,
+           description    = EXCLUDED.description,
+           type           = EXCLUDED.type,
+           icon_url       = EXCLUDED.icon_url,
+           min_plan       = EXCLUDED.min_plan,
+           enabled        = EXCLUDED.enabled,
+           install_model  = EXCLUDED.install_model,
+           saas_eligible  = EXCLUDED.saas_eligible,
+           updated_at     = NOW()`,
+    [
+      id,
+      name,
+      entry.slug,
+      description,
+      entry.type,
+      iconUrl,
+      entry.min_plan,
+      entry.enabled,
+      entry.install_model,
+      entry.saas_eligible,
+    ],
+  );
+}
+
+/**
+ * Convenience wrapper for the boot pass — pulls the declared catalog
+ * from `getConfig()` and the DB from `getInternalDB()`. Swallows errors
+ * (logs at error) so a seed failure can't block API startup; admin
+ * surfaces will see whatever was in `plugin_catalog` before this boot.
+ *
+ * Mirrors `backfillSaasTrial`'s "log-and-continue" posture — seeding
+ * is best-effort during boot; failure modes are observable (the log
+ * line + the absent-rows-after-deploy diagnostic) rather than fatal.
+ */
+export async function runCatalogSeedBoot(): Promise<CatalogSeedResult> {
+  // Lazy imports keep config.ts and db/internal.ts off the static dep
+  // graph for environments that import this module purely for its
+  // types (e.g. unit tests of the pure planner).
+  const { getConfig } = await import("@atlas/api/lib/config");
+  const { hasInternalDB, getInternalDB } = await import(
+    "@atlas/api/lib/db/internal"
+  );
+
+  if (!hasInternalDB()) {
+    log.info("Catalog seed: no internal DB configured, skipping");
+    return EMPTY_RESULT;
+  }
+  const config = getConfig();
+  if (!config) {
+    log.info("Catalog seed: no resolved config, skipping");
+    return EMPTY_RESULT;
+  }
+
+  const pool = getInternalDB();
+  // pg.Pool's `.query` returns `{ rows, ... }` — narrow to our shape.
+  const db: CatalogSeedDb = {
+    async query<T = unknown>(sql: string, params?: unknown[]) {
+      const result = await pool.query(sql, params);
+      return { rows: result.rows as T[] };
+    },
+  };
+
+  try {
+    return await seedCatalog(db, config.catalog ?? []);
+  } catch (err) {
+    log.error(
+      { err: errorMessage(err) },
+      "Catalog seed failed — plugin_catalog rows from prior boot remain authoritative",
+    );
+    return EMPTY_RESULT;
+  }
+}

--- a/plugins/chat/README.md
+++ b/plugins/chat/README.md
@@ -10,38 +10,34 @@ bun add @useatlas/chat
 
 ## Usage
 
+Adapter activation is driven by the **Plugin Catalog** (Atlas 1.5.2,
+[#2650](https://github.com/AtlasDevHQ/atlas/issues/2650)) — operators
+declare the chat Platforms they support in `atlas.config.ts:catalog`,
+and the plugin's `AdapterRegistry` reads per-Platform credentials from
+`process.env` at boot. See
+[Plugin Catalog docs](https://docs.useatlas.dev/deployment/plugin-catalog)
+for the full data model and seed semantics.
+
 ```typescript
 import { defineConfig } from "@atlas/api/lib/config";
 import { chatPlugin } from "@useatlas/chat";
 
 export default defineConfig({
+  // Operator declares which Platforms this deploy supports.
+  catalog: [
+    { slug: "slack", type: "chat", install_model: "oauth", enabled: true,
+      saas_eligible: true },
+    // 1.5.3 placeholders — visible to ops, not customer-installable yet.
+    { slug: "telegram", type: "chat", install_model: "static-bot",
+      enabled: false, saas_eligible: true },
+  ],
   plugins: [
     chatPlugin({
-      adapters: {
-        slack: {
-          botToken: process.env.SLACK_BOT_TOKEN!,
-          signingSecret: process.env.SLACK_SIGNING_SECRET!,
-          clientId: process.env.SLACK_CLIENT_ID,       // optional, for OAuth
-          clientSecret: process.env.SLACK_CLIENT_SECRET, // optional, for OAuth
-        },
-        teams: {
-          appId: process.env.TEAMS_APP_ID!,
-          appPassword: process.env.TEAMS_APP_PASSWORD!,
-          tenantId: process.env.TEAMS_TENANT_ID,       // optional, for tenant restriction
-        },
-        discord: {
-          botToken: process.env.DISCORD_BOT_TOKEN!,
-          applicationId: process.env.DISCORD_APPLICATION_ID!,
-          publicKey: process.env.DISCORD_PUBLIC_KEY!,
-          mentionRoleIds: [],                          // optional, role IDs that trigger mentions
-        },
-        gchat: {
-          credentials: JSON.parse(process.env.GOOGLE_CHAT_CREDENTIALS!),
-        },
-        telegram: {
-          botToken: process.env.TELEGRAM_BOT_TOKEN!,
-        },
-      },
+      // The host passes the chat-type subset of the catalog through.
+      catalog: [
+        { slug: "slack", type: "chat", install_model: "oauth", enabled: true,
+          saas_eligible: true },
+      ],
       executeQuery: myQueryFunction,
       actions: myActionCallbacks,        // optional — approve/deny flows
       conversations: myConversationCBs,  // optional — host conversation persistence
@@ -50,36 +46,48 @@ export default defineConfig({
 });
 ```
 
+### Per-Platform credentials (env vars)
+
+In milestone 1.5.2 only Slack OAuth is wired. Required env vars:
+
+| Var | Purpose |
+|-----|---------|
+| `SLACK_CLIENT_ID` | OAuth client ID from your Slack App Registration |
+| `SLACK_CLIENT_SECRET` | OAuth client secret |
+| `SLACK_SIGNING_SECRET` | 32-char hex from Slack app's Basic Information page |
+| `SLACK_ENCRYPTION_KEY` | AES-256-GCM key (hex64 or base64-44) for at-rest bot-token storage |
+| `SLACK_BOT_TOKEN` *(optional)* | Single-workspace mode only — omit for multi-workspace SaaS |
+
+If any required var is missing, the AdapterRegistry logs a warn and
+skips Slack. The plugin still boots; `healthCheck()` reports unhealthy
+until the env wiring is fixed.
+
+Non-Slack chat Platforms (Teams, Discord, Google Chat, Telegram,
+WhatsApp) ship as `enabled: false` catalog placeholders in 1.5.2 and
+wire up in 1.5.3 alongside `StaticBotInstallHandler`.
+
 ## Config
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `adapters.slack.botToken` | `string` | — | Slack bot token (`xoxb-...`) |
-| `adapters.slack.signingSecret` | `string` | — | Slack signing secret for request verification |
-| `adapters.slack.clientId` | `string?` | — | Client ID for multi-workspace OAuth |
-| `adapters.slack.clientSecret` | `string?` | — | Client secret for multi-workspace OAuth |
-| `adapters.teams.appId` | `string` | — | Microsoft App ID from Azure Bot registration |
-| `adapters.teams.appPassword` | `string` | — | Microsoft App Password from Azure Bot registration |
-| `adapters.teams.tenantId` | `string?` | — | Optional: restrict to a specific Microsoft Entra ID tenant |
-| `adapters.discord.botToken` | `string` | — | Discord bot token |
-| `adapters.discord.applicationId` | `string` | — | Discord application ID |
-| `adapters.discord.publicKey` | `string` | — | Application public key for Ed25519 webhook signature verification |
-| `adapters.discord.mentionRoleIds` | `string[]?` | — | Optional: role IDs that trigger mention handlers |
-| `adapters.gchat.credentials` | `object?` | — | Service account credentials (`client_email`, `private_key`) |
-| `adapters.gchat.useApplicationDefaultCredentials` | `true?` | — | Use Application Default Credentials |
-| `adapters.gchat.endpointUrl` | `string?` | — | HTTP endpoint URL for card button click actions |
-| `adapters.gchat.pubsubTopic` | `string?` | — | Pub/Sub topic for Workspace Events |
-| `adapters.gchat.impersonateUser` | `string?` | — | User email for domain-wide delegation |
-| `adapters.telegram.botToken` | `string` | — | Telegram bot token from BotFather |
-| `adapters.telegram.secretToken` | `string?` | — | Webhook secret token for request verification |
+| `catalog` | `ChatCatalogEntry[]?` | — | Chat-type subset of the operator's `atlas.config.ts:catalog`. AdapterRegistry uses this to decide which adapters to instantiate. |
 | `state` | `object?` | `{ backend: "memory" }` | State backend configuration (see below) |
 | `executeQuery` | `function` | — | Callback to run the Atlas agent on a question |
+| `executeQueryStream` | `function?` | — | Streaming variant — when set with `streaming.enabled: true`, responses stream incrementally |
 | `checkRateLimit` | `function?` | — | Optional rate limiting callback |
 | `scrubError` | `function?` | — | Optional error scrubbing callback |
 | `actions` | `ActionCallbacks?` | — | Optional action framework callbacks (`approve`, `deny`, `get`) |
 | `conversations` | `ConversationCallbacks?` | — | Optional host conversation persistence callbacks |
+| `streaming` | `StreamingConfig?` | `{ enabled: true }` | Streaming response configuration |
+| `proactive` | `ProactiveConfig?` | — | Enterprise proactive-listener wiring |
+| `reactions` | `ReactionConfig?` | — | Status emoji reactions on user messages |
+| `fileUpload` | `FileUploadConfig?` | — | CSV file-upload thresholds |
+| `ephemeral` | `EphemeralConfig?` | — | Whether errors post as ephemeral |
+| `slashCommandName` | `string?` | `"/atlas"` | Slash command registered with the Chat SDK |
 
-At least one adapter must be configured.
+Adapter activation requires (a) a `chat`-type entry in `catalog` with
+`install_model: "oauth"` and `enabled: true`, AND (b) all required env
+vars for that Platform.
 
 ### State Backend
 
@@ -93,7 +101,10 @@ The state backend controls how thread subscriptions, conversation history, and d
 
 ```typescript
 chatPlugin({
-  adapters: { slack: { ... } },
+  catalog: [
+    { slug: "slack", type: "chat", install_model: "oauth", enabled: true,
+      saas_eligible: true },
+  ],
   state: {
     backend: "pg",        // "memory" | "pg" | "redis"
     tablePrefix: "chat_", // PG table prefix (default: "chat_")

--- a/plugins/chat/src/adapter-registry.test.ts
+++ b/plugins/chat/src/adapter-registry.test.ts
@@ -73,7 +73,7 @@ describe("buildChatAdapterRegistry — happy path", () => {
       env: SLACK_FULL_ENV,
       logger,
     });
-    expect(result.slack).not.toBeNull();
+    expect(result.adapters.slack).toBeDefined();
     expect(infos.some((l) => l.msg.includes("chat adapter registered"))).toBe(true);
   });
 });
@@ -101,7 +101,7 @@ describe("buildChatAdapterRegistry — missing env vars", () => {
         env,
         logger,
       });
-      expect(result.slack).toBeNull();
+      expect(result.adapters.slack).toBeUndefined();
       expect(warns).toHaveLength(1);
       expect(warns[0]?.msg).toContain("required env vars missing");
       expect((warns[0]?.payload.requiredEnv as string[]).includes(missing)).toBe(true);
@@ -121,7 +121,7 @@ describe("buildChatAdapterRegistry — catalog filters", () => {
       env: SLACK_FULL_ENV,
       logger,
     });
-    expect(result.slack).toBeNull();
+    expect(result.adapters.slack).toBeUndefined();
     expect(debugs.some((l) => l.msg.includes("enabled=false"))).toBe(true);
   });
 
@@ -132,7 +132,7 @@ describe("buildChatAdapterRegistry — catalog filters", () => {
       env: SLACK_FULL_ENV,
       logger,
     });
-    expect(result.slack).toBeNull();
+    expect(result.adapters.slack).toBeUndefined();
     expect(debugs.some((l) => l.msg.includes("non-OAuth install model"))).toBe(true);
   });
 
@@ -156,7 +156,7 @@ describe("buildChatAdapterRegistry — catalog filters", () => {
       },
       logger,
     });
-    expect(result.slack).toBeNull();
+    expect(result.adapters.slack).toBeUndefined();
     expect(
       debugs.filter((l) => l.msg.includes("non-OAuth install model")),
     ).toHaveLength(2);
@@ -176,7 +176,7 @@ describe("buildChatAdapterRegistry — catalog filters", () => {
       env: SLACK_FULL_ENV,
       logger,
     });
-    expect(result.slack).toBeNull();
+    expect(result.adapters.slack).toBeUndefined();
   });
 
   it("warns on a chat-type OAuth entry whose slug has no builder (operator typo)", () => {
@@ -186,13 +186,13 @@ describe("buildChatAdapterRegistry — catalog filters", () => {
       env: SLACK_FULL_ENV,
       logger,
     });
-    expect(result.slack).toBeNull();
+    expect(result.adapters.slack).toBeUndefined();
     expect(warns.some((l) => l.msg.includes("no builder registered"))).toBe(true);
   });
 
   it("returns empty registry when catalog is empty", () => {
     const result = buildChatAdapterRegistry({ catalog: [], env: SLACK_FULL_ENV });
-    expect(result.slack).toBeNull();
+    expect(result.adapters.slack).toBeUndefined();
   });
 
   it("returns empty registry when env is empty", () => {
@@ -200,6 +200,55 @@ describe("buildChatAdapterRegistry — catalog filters", () => {
       catalog: [entry({ slug: "slack" })],
       env: {},
     });
-    expect(result.slack).toBeNull();
+    expect(result.adapters.slack).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Diagnostics — surfaces enough info for healthCheck / install-route 500s
+// ---------------------------------------------------------------------------
+
+describe("buildChatAdapterRegistry — diagnostics", () => {
+  it("reports missingCredSlugs when env vars are missing", () => {
+    const result = buildChatAdapterRegistry({
+      catalog: [entry({ slug: "slack" })],
+      env: {},
+    });
+    expect(result.diagnostics.missingCredSlugs).toEqual(["slack"]);
+    expect(result.diagnostics.unrecognizedSlugs).toEqual([]);
+  });
+
+  it("reports unrecognizedSlugs when no builder is registered for the slug", () => {
+    const result = buildChatAdapterRegistry({
+      catalog: [entry({ slug: "slcak" })],
+      env: SLACK_FULL_ENV,
+    });
+    expect(result.diagnostics.unrecognizedSlugs).toEqual(["slcak"]);
+    expect(result.diagnostics.missingCredSlugs).toEqual([]);
+  });
+
+  it("reports both lists when the catalog mixes the two failure modes", () => {
+    const result = buildChatAdapterRegistry({
+      catalog: [
+        entry({ slug: "slack" }), // missing env
+        entry({ slug: "unknown-slug" }), // no builder
+      ],
+      env: {},
+    });
+    expect(result.diagnostics.missingCredSlugs).toEqual(["slack"]);
+    expect(result.diagnostics.unrecognizedSlugs).toEqual(["unknown-slug"]);
+  });
+
+  it("does not list disabled / non-OAuth / non-chat entries (they're not failures)", () => {
+    const result = buildChatAdapterRegistry({
+      catalog: [
+        entry({ slug: "slack", enabled: false }),
+        entry({ slug: "telegram", install_model: "static-bot" }),
+        entry({ slug: "salesforce", type: "integration", install_model: "oauth" }),
+      ],
+      env: {},
+    });
+    expect(result.diagnostics.missingCredSlugs).toEqual([]);
+    expect(result.diagnostics.unrecognizedSlugs).toEqual([]);
   });
 });

--- a/plugins/chat/src/adapter-registry.test.ts
+++ b/plugins/chat/src/adapter-registry.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Tests for `buildChatAdapterRegistry` — slice 2 of #2649 (issue #2650).
+ *
+ * Asserted invariants (AC quoted from #2650):
+ *
+ *   - Chat plugin instantiates Slack adapter only when catalog entry
+ *     exists with install_model='oauth' AND enabled=true AND env vars
+ *     SLACK_CLIENT_ID / SLACK_CLIENT_SECRET / SLACK_SIGNING_SECRET /
+ *     SLACK_ENCRYPTION_KEY are all present
+ *   - Non-Slack chat adapters are NOT instantiated at boot in this
+ *     milestone (verified by code grep + test)
+ *   - AdapterRegistry unit-tested: env-var fixtures → correct adapter
+ *     set; missing creds → adapter not registered + warn logged;
+ *     non-OAuth catalog entries → adapter not registered
+ */
+
+import { describe, it, expect } from "bun:test";
+import {
+  buildChatAdapterRegistry,
+  type ChatCatalogEntry,
+  type RegistryLogger,
+} from "./adapter-registry";
+
+const SLACK_FULL_ENV: NodeJS.ProcessEnv = {
+  SLACK_CLIENT_ID: "test-client-id",
+  SLACK_CLIENT_SECRET: "test-client-secret",
+  SLACK_SIGNING_SECRET: "abcdef0123456789abcdef0123456789",
+  // 64-char hex = 32 raw bytes; the chat-adapter's `decodeKey` accepts
+  // hex64 or base64-44. `f` is a valid hex char; `x` would fail decode.
+  SLACK_ENCRYPTION_KEY: "f".repeat(64),
+};
+
+function makeLogger(): {
+  logger: RegistryLogger;
+  infos: Array<{ payload: Record<string, unknown>; msg: string }>;
+  warns: Array<{ payload: Record<string, unknown>; msg: string }>;
+  debugs: Array<{ payload: Record<string, unknown>; msg: string }>;
+} {
+  const infos: Array<{ payload: Record<string, unknown>; msg: string }> = [];
+  const warns: Array<{ payload: Record<string, unknown>; msg: string }> = [];
+  const debugs: Array<{ payload: Record<string, unknown>; msg: string }> = [];
+  return {
+    infos,
+    warns,
+    debugs,
+    logger: {
+      info: (payload, msg) => infos.push({ payload, msg }),
+      warn: (payload, msg) => warns.push({ payload, msg }),
+      debug: (payload, msg) => debugs.push({ payload, msg }),
+    },
+  };
+}
+
+function entry(partial: Partial<ChatCatalogEntry> & Pick<ChatCatalogEntry, "slug">): ChatCatalogEntry {
+  return {
+    type: "chat",
+    install_model: "oauth",
+    enabled: true,
+    saas_eligible: true,
+    ...partial,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Happy path: Slack OAuth + full env → adapter registered
+// ---------------------------------------------------------------------------
+
+describe("buildChatAdapterRegistry — happy path", () => {
+  it("registers Slack when catalog has slack OAuth + enabled AND all env vars present", () => {
+    const { logger, infos } = makeLogger();
+    const result = buildChatAdapterRegistry({
+      catalog: [entry({ slug: "slack" })],
+      env: SLACK_FULL_ENV,
+      logger,
+    });
+    expect(result.slack).not.toBeNull();
+    expect(infos.some((l) => l.msg.includes("chat adapter registered"))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Missing-env-var matrix — every required var skipped in isolation
+// ---------------------------------------------------------------------------
+
+describe("buildChatAdapterRegistry — missing env vars", () => {
+  const required = [
+    "SLACK_CLIENT_ID",
+    "SLACK_CLIENT_SECRET",
+    "SLACK_SIGNING_SECRET",
+    "SLACK_ENCRYPTION_KEY",
+  ] as const;
+
+  for (const missing of required) {
+    it(`skips Slack + logs warn when ${missing} is missing`, () => {
+      const { logger, warns } = makeLogger();
+      const env: NodeJS.ProcessEnv = { ...SLACK_FULL_ENV };
+      delete env[missing];
+
+      const result = buildChatAdapterRegistry({
+        catalog: [entry({ slug: "slack" })],
+        env,
+        logger,
+      });
+      expect(result.slack).toBeNull();
+      expect(warns).toHaveLength(1);
+      expect(warns[0]?.msg).toContain("required env vars missing");
+      expect((warns[0]?.payload.requiredEnv as string[]).includes(missing)).toBe(true);
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Catalog gating: enabled / install_model / type
+// ---------------------------------------------------------------------------
+
+describe("buildChatAdapterRegistry — catalog filters", () => {
+  it("does not register Slack when catalog entry is disabled", () => {
+    const { logger, debugs } = makeLogger();
+    const result = buildChatAdapterRegistry({
+      catalog: [entry({ slug: "slack", enabled: false })],
+      env: SLACK_FULL_ENV,
+      logger,
+    });
+    expect(result.slack).toBeNull();
+    expect(debugs.some((l) => l.msg.includes("enabled=false"))).toBe(true);
+  });
+
+  it("does not register Slack when install_model is form (skipped, no instantiation)", () => {
+    const { logger, debugs } = makeLogger();
+    const result = buildChatAdapterRegistry({
+      catalog: [entry({ slug: "slack", install_model: "form" })],
+      env: SLACK_FULL_ENV,
+      logger,
+    });
+    expect(result.slack).toBeNull();
+    expect(debugs.some((l) => l.msg.includes("non-OAuth install model"))).toBe(true);
+  });
+
+  it("does not register a static-bot chat platform — defer to 1.5.3", () => {
+    // Pins the milestone scope: Teams/Discord/gchat/Telegram/WhatsApp
+    // are seeded with install_model='static-bot' enabled=false; even
+    // an accidentally-enabled static-bot row never instantiates an
+    // adapter in 1.5.2.
+    const { logger, debugs } = makeLogger();
+    const result = buildChatAdapterRegistry({
+      catalog: [
+        entry({ slug: "telegram", install_model: "static-bot", enabled: true }),
+        entry({ slug: "discord", install_model: "static-bot", enabled: true }),
+      ],
+      env: {
+        ...SLACK_FULL_ENV,
+        TELEGRAM_BOT_TOKEN: "1234:fake-telegram-token-for-test",
+        DISCORD_BOT_TOKEN: "fake-discord-token",
+        DISCORD_APPLICATION_ID: "fake",
+        DISCORD_PUBLIC_KEY: "fake",
+      },
+      logger,
+    });
+    expect(result.slack).toBeNull();
+    expect(
+      debugs.filter((l) => l.msg.includes("non-OAuth install model")),
+    ).toHaveLength(2);
+  });
+
+  it("ignores integration-type entries (slice 3 will own them)", () => {
+    const { logger } = makeLogger();
+    const result = buildChatAdapterRegistry({
+      catalog: [
+        entry({
+          slug: "salesforce",
+          type: "integration",
+          install_model: "oauth",
+        }),
+        entry({ slug: "email", type: "integration", install_model: "form" }),
+      ],
+      env: SLACK_FULL_ENV,
+      logger,
+    });
+    expect(result.slack).toBeNull();
+  });
+
+  it("warns on a chat-type OAuth entry whose slug has no builder (operator typo)", () => {
+    const { logger, warns } = makeLogger();
+    const result = buildChatAdapterRegistry({
+      catalog: [entry({ slug: "slcak" })], // typo
+      env: SLACK_FULL_ENV,
+      logger,
+    });
+    expect(result.slack).toBeNull();
+    expect(warns.some((l) => l.msg.includes("no builder registered"))).toBe(true);
+  });
+
+  it("returns empty registry when catalog is empty", () => {
+    const result = buildChatAdapterRegistry({ catalog: [], env: SLACK_FULL_ENV });
+    expect(result.slack).toBeNull();
+  });
+
+  it("returns empty registry when env is empty", () => {
+    const result = buildChatAdapterRegistry({
+      catalog: [entry({ slug: "slack" })],
+      env: {},
+    });
+    expect(result.slack).toBeNull();
+  });
+});

--- a/plugins/chat/src/adapter-registry.ts
+++ b/plugins/chat/src/adapter-registry.ts
@@ -24,7 +24,7 @@
 
 import type { SlackAdapter } from "@chat-adapter/slack";
 import { createSlackAdapter } from "./adapters/slack";
-import type { SlackAdapterConfig } from "./config";
+import type { ChatAdapterName, SlackAdapterConfig } from "./config";
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -49,15 +49,43 @@ export interface ChatCatalogEntry {
   readonly saas_eligible: boolean;
 }
 
-/** Map of platform slug → instantiated adapter. */
-export interface ChatAdapterSet {
-  readonly slack: SlackAdapter | null;
-  // Non-Slack adapters are intentionally absent in 1.5.2 — they land in
-  // 1.5.3 alongside `StaticBotInstallHandler`. Adding them here without
-  // an install handler would let an adapter receive events for a
-  // platform whose customer-install flow doesn't exist yet, leaking
-  // events across tenants. Slice-3 hardening enforces this in the
-  // listener layer via `WorkspaceInstallGate`.
+/**
+ * Map of platform slug → instantiated adapter. Slug-keyed `Partial`
+ * `Record` so future adapters (1.5.3 static-bot platforms) extend by
+ * adding map entries — no shape change to the type, no consumer
+ * rewrites. Today only `slack` is populated; the other keys are
+ * structurally allowed but never set.
+ */
+export type ChatAdapterSet = Partial<{
+  readonly [K in ChatAdapterName]: ChatAdapterInstance<K>;
+}>;
+
+/**
+ * Per-slug adapter instance type. Only Slack has a concrete type in
+ * 1.5.2 — the other slugs map to a structural placeholder so the
+ * `Partial<Record>` shape compiles without forcing every adapter class
+ * to exist today. 1.5.3 narrows each placeholder to its real class.
+ */
+type ChatAdapterInstance<K extends ChatAdapterName> = K extends "slack"
+  ? SlackAdapter
+  : { readonly name: K };
+
+/**
+ * Returned alongside `ChatAdapterSet` so `healthCheck` and admin
+ * banners can distinguish "no adapters wired (operator misconfig)" from
+ * "no chat-type entries in catalog" — both produce an empty
+ * `ChatAdapterSet` today, but the cause + fix differ.
+ */
+export interface ChatAdapterDiagnostics {
+  /** Slugs the catalog declared as oauth+enabled but for which Atlas ships no builder (operator typo). */
+  readonly unrecognizedSlugs: ReadonlyArray<string>;
+  /** Slugs the catalog declared as oauth+enabled whose required env vars are missing. */
+  readonly missingCredSlugs: ReadonlyArray<string>;
+}
+
+export interface ChatAdapterRegistration {
+  readonly adapters: ChatAdapterSet;
+  readonly diagnostics: ChatAdapterDiagnostics;
 }
 
 /**
@@ -102,19 +130,18 @@ const SLACK_BUILDER: ChatAdapterBuilder<SlackAdapter> = {
     "SLACK_ENCRYPTION_KEY",
   ],
   build(env) {
-    if (
-      !env.SLACK_CLIENT_ID ||
-      !env.SLACK_CLIENT_SECRET ||
-      !env.SLACK_SIGNING_SECRET ||
-      !env.SLACK_ENCRYPTION_KEY
-    ) {
+    const clientId = env.SLACK_CLIENT_ID;
+    const clientSecret = env.SLACK_CLIENT_SECRET;
+    const signingSecret = env.SLACK_SIGNING_SECRET;
+    const encryptionKey = env.SLACK_ENCRYPTION_KEY;
+    if (!clientId || !clientSecret || !signingSecret || !encryptionKey) {
       return null;
     }
     const config: SlackAdapterConfig = {
-      clientId: env.SLACK_CLIENT_ID,
-      clientSecret: env.SLACK_CLIENT_SECRET,
-      signingSecret: env.SLACK_SIGNING_SECRET,
-      encryptionKey: env.SLACK_ENCRYPTION_KEY,
+      clientId,
+      clientSecret,
+      signingSecret,
+      encryptionKey,
       ...(env.SLACK_BOT_TOKEN ? { botToken: env.SLACK_BOT_TOKEN } : {}),
     };
     return createSlackAdapter(config) as SlackAdapter;
@@ -176,9 +203,11 @@ export interface BuildAdapterRegistryArgs {
  */
 export function buildChatAdapterRegistry(
   args: BuildAdapterRegistryArgs,
-): ChatAdapterSet {
+): ChatAdapterRegistration {
   const logger: RegistryLogger = args.logger ?? createNoopLogger();
-  let slack: SlackAdapter | null = null;
+  const adapters: { -readonly [K in ChatAdapterName]?: ChatAdapterInstance<K> } = {};
+  const unrecognizedSlugs: string[] = [];
+  const missingCredSlugs: string[] = [];
 
   for (const entry of args.catalog) {
     if (entry.type !== "chat") continue;
@@ -186,7 +215,7 @@ export function buildChatAdapterRegistry(
     if (entry.install_model !== "oauth") {
       logger.debug?.(
         { slug: entry.slug, installModel: entry.install_model },
-        "AdapterRegistry: catalog entry skipped — non-OAuth install model is not instantiable in 1.5.2",
+        "AdapterRegistry: catalog entry skipped — non-OAuth install model has no event-loop adapter to instantiate",
       );
       continue;
     }
@@ -201,15 +230,17 @@ export function buildChatAdapterRegistry(
 
     const builder = BUILDERS_BY_SLUG[entry.slug];
     if (!builder) {
+      unrecognizedSlugs.push(entry.slug);
       logger.warn(
         { slug: entry.slug },
-        "AdapterRegistry: catalog entry for unknown chat Platform slug — no builder registered",
+        "AdapterRegistry: catalog entry for unknown chat Platform slug — no builder registered (operator typo or cross-version drift)",
       );
       continue;
     }
 
     const adapter = builder.build(args.env);
     if (!adapter) {
+      missingCredSlugs.push(entry.slug);
       logger.warn(
         {
           slug: entry.slug,
@@ -222,16 +253,22 @@ export function buildChatAdapterRegistry(
     }
 
     if (entry.slug === "slack") {
-      slack = adapter as SlackAdapter;
+      adapters.slack = adapter as SlackAdapter;
       logger.info(
         { slug: entry.slug, platform: builder.platform },
         "AdapterRegistry: chat adapter registered",
       );
     }
-    // No other adapters wire in 1.5.2 — the builder map has only `slack`.
+    // No other adapters wire today — the builder map has only `slack`.
+    // 1.5.3 work adds map entries for the static-bot platforms; the
+    // `Partial<Record>` shape of `ChatAdapterSet` admits them without
+    // a type change here.
   }
 
-  return { slack };
+  return {
+    adapters,
+    diagnostics: { unrecognizedSlugs, missingCredSlugs },
+  };
 }
 
 function createNoopLogger(): RegistryLogger {

--- a/plugins/chat/src/adapter-registry.ts
+++ b/plugins/chat/src/adapter-registry.ts
@@ -1,0 +1,243 @@
+/**
+ * AdapterRegistry — slice 2 of #2649 (issue #2650).
+ *
+ * Replaces the pre-1.5.2 `if (config.adapters.slack) { ... }` conditional
+ * chain inside `buildChatPlugin`. Reads the chat-type subset of the
+ * operator-declared `plugin_catalog`, looks up per-Platform credentials
+ * from `process.env`, and returns the set of adapter instances the chat
+ * plugin should activate at boot.
+ *
+ * In milestone 1.5.2, only `install_model === "oauth"` adapters
+ * instantiate. The non-Slack chat Platforms (Teams, Discord, gchat,
+ * Telegram, WhatsApp) ship as catalog placeholders with
+ * `install_model === "static-bot"` and `enabled === false` — visible to
+ * ops, not customer-installable, and never instantiated here. Their
+ * install handlers land in 1.5.3.
+ *
+ * Pure-ish: takes the catalog entry list + an env reader as input,
+ * returns the adapter set. Side effects are limited to (a) constructing
+ * the platform adapter and (b) writing one log line per registered /
+ * skipped slug. The construction side effect is unavoidable — the
+ * upstream `@chat-adapter/<platform>` factories return live objects, not
+ * builders.
+ */
+
+import type { SlackAdapter } from "@chat-adapter/slack";
+import { createSlackAdapter } from "./adapters/slack";
+import type { SlackAdapterConfig } from "./config";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/**
+ * Catalog entry shape the registry consumes. Mirrors the chat-relevant
+ * subset of `CatalogEntry` from `@atlas/api/lib/config`, but the chat
+ * plugin can't import `@atlas/api` (frontend-side rule from CLAUDE.md
+ * + `@useatlas/chat` is the plugin namespace, separate from `@atlas/api`).
+ * So we redeclare the structural shape here.
+ *
+ * The shape is `Readonly` everywhere so the catalog list — typically
+ * passed straight from `ResolvedConfig.catalog` — can't be mutated by
+ * accident from within the plugin.
+ */
+export interface ChatCatalogEntry {
+  readonly slug: string;
+  readonly type: "chat" | "integration";
+  readonly install_model: "oauth" | "form" | "static-bot";
+  readonly enabled: boolean;
+  readonly saas_eligible: boolean;
+}
+
+/** Map of platform slug → instantiated adapter. */
+export interface ChatAdapterSet {
+  readonly slack: SlackAdapter | null;
+  // Non-Slack adapters are intentionally absent in 1.5.2 — they land in
+  // 1.5.3 alongside `StaticBotInstallHandler`. Adding them here without
+  // an install handler would let an adapter receive events for a
+  // platform whose customer-install flow doesn't exist yet, leaking
+  // events across tenants. Slice-3 hardening enforces this in the
+  // listener layer via `WorkspaceInstallGate`.
+}
+
+/**
+ * Per-slug env-var presence check + adapter factory. One shape so the
+ * dispatch loop is uniform. Each factory returns `null` when its
+ * required env vars are missing (the registry logs the omission and
+ * continues to the next slug).
+ */
+interface ChatAdapterBuilder<Adapter> {
+  readonly slug: string;
+  readonly platform: string;
+  /** Required env-var names — used in the missing-creds log line. */
+  readonly requiredEnv: ReadonlyArray<string>;
+  /** Construct the adapter, or return `null` if any required env var is unset. */
+  readonly build: (env: NodeJS.ProcessEnv) => Adapter | null;
+}
+
+// ---------------------------------------------------------------------------
+// Per-platform builders
+// ---------------------------------------------------------------------------
+
+/**
+ * Slack — the only OAuth chat Platform that instantiates in 1.5.2.
+ *
+ * Required env vars (all four must be present):
+ *   - SLACK_CLIENT_ID, SLACK_CLIENT_SECRET — App Registration OAuth credentials
+ *   - SLACK_SIGNING_SECRET — webhook signature verification
+ *   - SLACK_ENCRYPTION_KEY — AES-256-GCM key for bot-token storage in
+ *     `chat_cache` (post-#2634 consolidation)
+ *
+ * Multi-workspace deploys (SaaS) MUST omit `botToken` — when present it
+ * pins the adapter to a single workspace. SLACK_BOT_TOKEN being set is
+ * NOT a registry requirement.
+ */
+const SLACK_BUILDER: ChatAdapterBuilder<SlackAdapter> = {
+  slug: "slack",
+  platform: "slack",
+  requiredEnv: [
+    "SLACK_CLIENT_ID",
+    "SLACK_CLIENT_SECRET",
+    "SLACK_SIGNING_SECRET",
+    "SLACK_ENCRYPTION_KEY",
+  ],
+  build(env) {
+    if (
+      !env.SLACK_CLIENT_ID ||
+      !env.SLACK_CLIENT_SECRET ||
+      !env.SLACK_SIGNING_SECRET ||
+      !env.SLACK_ENCRYPTION_KEY
+    ) {
+      return null;
+    }
+    const config: SlackAdapterConfig = {
+      clientId: env.SLACK_CLIENT_ID,
+      clientSecret: env.SLACK_CLIENT_SECRET,
+      signingSecret: env.SLACK_SIGNING_SECRET,
+      encryptionKey: env.SLACK_ENCRYPTION_KEY,
+      ...(env.SLACK_BOT_TOKEN ? { botToken: env.SLACK_BOT_TOKEN } : {}),
+    };
+    return createSlackAdapter(config) as SlackAdapter;
+  },
+};
+
+const BUILDERS_BY_SLUG: Readonly<Record<string, ChatAdapterBuilder<unknown>>> = {
+  slack: SLACK_BUILDER,
+};
+
+// ---------------------------------------------------------------------------
+// Logger contract
+// ---------------------------------------------------------------------------
+
+/**
+ * Structural log interface — matches the `PluginLogger` shape exported
+ * by `@useatlas/plugin-sdk` without taking a hard import dependency.
+ * Keeps the registry callable from tests without spinning up the SDK.
+ */
+export interface RegistryLogger {
+  info(payload: Record<string, unknown>, msg: string): void;
+  warn(payload: Record<string, unknown>, msg: string): void;
+  debug?(payload: Record<string, unknown>, msg: string): void;
+}
+
+// ---------------------------------------------------------------------------
+// Build the registry
+// ---------------------------------------------------------------------------
+
+export interface BuildAdapterRegistryArgs {
+  /** Catalog entries the host has declared. The registry filters by `type === "chat"`. */
+  readonly catalog: ReadonlyArray<ChatCatalogEntry>;
+  /** Env source — typically `process.env`; injectable for tests. */
+  readonly env: NodeJS.ProcessEnv;
+  /** Logger; falls back to `console`-shaped no-op when omitted. */
+  readonly logger?: RegistryLogger;
+}
+
+/**
+ * Build the chat adapter set from a catalog declaration + env. Slack is
+ * the only adapter that can be activated in 1.5.2 — other slugs are
+ * skipped with a `debug` log so ops can confirm the entry was seen but
+ * intentionally not wired.
+ *
+ * Filter chain per slug:
+ *
+ *   1. `type === "chat"` — integration slugs (Salesforce, Email, …)
+ *      are handled by the LazyPluginLoader path in slice 3, not here.
+ *   2. `install_model === "oauth"` — form / static-bot install models
+ *      don't instantiate an event-loop adapter at boot. Static-bot
+ *      adapters land in 1.5.3.
+ *   3. `enabled === true` — operator (or DB-side ops disable) can flip
+ *      a row off without removing it from the catalog.
+ *   4. Builder exists for the slug — a catalog entry for a chat Platform
+ *      Atlas doesn't ship code for is a `warn` (operator typo or
+ *      cross-version catalog row).
+ *   5. All required env vars present — missing creds is a `warn` so the
+ *      operator can fix env wiring without reading source.
+ */
+export function buildChatAdapterRegistry(
+  args: BuildAdapterRegistryArgs,
+): ChatAdapterSet {
+  const logger: RegistryLogger = args.logger ?? createNoopLogger();
+  let slack: SlackAdapter | null = null;
+
+  for (const entry of args.catalog) {
+    if (entry.type !== "chat") continue;
+
+    if (entry.install_model !== "oauth") {
+      logger.debug?.(
+        { slug: entry.slug, installModel: entry.install_model },
+        "AdapterRegistry: catalog entry skipped — non-OAuth install model is not instantiable in 1.5.2",
+      );
+      continue;
+    }
+
+    if (!entry.enabled) {
+      logger.debug?.(
+        { slug: entry.slug },
+        "AdapterRegistry: catalog entry skipped — enabled=false",
+      );
+      continue;
+    }
+
+    const builder = BUILDERS_BY_SLUG[entry.slug];
+    if (!builder) {
+      logger.warn(
+        { slug: entry.slug },
+        "AdapterRegistry: catalog entry for unknown chat Platform slug — no builder registered",
+      );
+      continue;
+    }
+
+    const adapter = builder.build(args.env);
+    if (!adapter) {
+      logger.warn(
+        {
+          slug: entry.slug,
+          platform: builder.platform,
+          requiredEnv: builder.requiredEnv,
+        },
+        "AdapterRegistry: required env vars missing — adapter not instantiated",
+      );
+      continue;
+    }
+
+    if (entry.slug === "slack") {
+      slack = adapter as SlackAdapter;
+      logger.info(
+        { slug: entry.slug, platform: builder.platform },
+        "AdapterRegistry: chat adapter registered",
+      );
+    }
+    // No other adapters wire in 1.5.2 — the builder map has only `slack`.
+  }
+
+  return { slack };
+}
+
+function createNoopLogger(): RegistryLogger {
+  return {
+    info: () => {},
+    warn: () => {},
+    debug: () => {},
+  };
+}

--- a/plugins/chat/src/bridge.test.ts
+++ b/plugins/chat/src/bridge.test.ts
@@ -45,6 +45,38 @@ const SLACK_CATALOG: ReadonlyArray<ChatCatalogEntryInput> = [
   },
 ];
 
+/**
+ * Slice 2 of 1.5.2 (#2650): AdapterRegistry reads per-Platform creds
+ * from `process.env`. Lifecycle suites need real env vars so the Slack
+ * adapter instantiates and healthCheck flips healthy. This helper wires
+ * matching beforeEach/afterEach hooks that snapshot the four
+ * SLACK_* vars on entry, override them with deterministic test values,
+ * and restore the snapshot on exit so adjacent suites see clean state.
+ * Hex64 matches production format.
+ */
+function withSlackEnv(): void {
+  const snapshot: Record<string, string | undefined> = {
+    SLACK_CLIENT_ID: process.env.SLACK_CLIENT_ID,
+    SLACK_CLIENT_SECRET: process.env.SLACK_CLIENT_SECRET,
+    SLACK_SIGNING_SECRET: process.env.SLACK_SIGNING_SECRET,
+    SLACK_ENCRYPTION_KEY: process.env.SLACK_ENCRYPTION_KEY,
+  };
+
+  beforeEach(() => {
+    process.env.SLACK_CLIENT_ID = "test-client-id";
+    process.env.SLACK_CLIENT_SECRET = "test-client-secret";
+    process.env.SLACK_SIGNING_SECRET = "abcdef0123456789abcdef0123456789";
+    process.env.SLACK_ENCRYPTION_KEY = "f".repeat(64);
+  });
+
+  afterEach(() => {
+    for (const [k, v] of Object.entries(snapshot)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  });
+}
+
 // ---------------------------------------------------------------------------
 // formatQueryResponse
 // ---------------------------------------------------------------------------
@@ -756,31 +788,7 @@ describe("chatPlugin config validation", () => {
 // ---------------------------------------------------------------------------
 
 describe("chat plugin lifecycle", () => {
-  // Slice 2 of 1.5.2 (#2650): AdapterRegistry reads per-Platform creds
-  // from `process.env`. The lifecycle tests need real env vars so the
-  // Slack adapter instantiates and healthCheck flips healthy. Saved /
-  // restored around each test so other suites in this file see clean
-  // state. Hex64 / matching production format.
-  const SLACK_ENV_SNAPSHOT = {
-    SLACK_CLIENT_ID: process.env.SLACK_CLIENT_ID,
-    SLACK_CLIENT_SECRET: process.env.SLACK_CLIENT_SECRET,
-    SLACK_SIGNING_SECRET: process.env.SLACK_SIGNING_SECRET,
-    SLACK_ENCRYPTION_KEY: process.env.SLACK_ENCRYPTION_KEY,
-  } as const;
-
-  beforeEach(() => {
-    process.env.SLACK_CLIENT_ID = "test-client-id";
-    process.env.SLACK_CLIENT_SECRET = "test-client-secret";
-    process.env.SLACK_SIGNING_SECRET = "abcdef0123456789abcdef0123456789";
-    process.env.SLACK_ENCRYPTION_KEY = "f".repeat(64);
-  });
-
-  afterEach(() => {
-    for (const [k, v] of Object.entries(SLACK_ENV_SNAPSHOT)) {
-      if (v === undefined) delete process.env[k];
-      else process.env[k] = v;
-    }
-  });
+  withSlackEnv();
 
   function createTestPlugin() {
     // Dynamic import to avoid top-level side effects
@@ -1298,29 +1306,7 @@ describe("chatPlugin streaming config", () => {
 // ---------------------------------------------------------------------------
 
 describe("chat plugin streaming lifecycle", () => {
-  // Mirror the env setup in `chat plugin lifecycle` — the AdapterRegistry
-  // reads Slack creds from `process.env`, so the streaming plugin's
-  // initialize() needs them to flip healthCheck healthy.
-  const SLACK_ENV_SNAPSHOT = {
-    SLACK_CLIENT_ID: process.env.SLACK_CLIENT_ID,
-    SLACK_CLIENT_SECRET: process.env.SLACK_CLIENT_SECRET,
-    SLACK_SIGNING_SECRET: process.env.SLACK_SIGNING_SECRET,
-    SLACK_ENCRYPTION_KEY: process.env.SLACK_ENCRYPTION_KEY,
-  } as const;
-
-  beforeEach(() => {
-    process.env.SLACK_CLIENT_ID = "test-client-id";
-    process.env.SLACK_CLIENT_SECRET = "test-client-secret";
-    process.env.SLACK_SIGNING_SECRET = "abcdef0123456789abcdef0123456789";
-    process.env.SLACK_ENCRYPTION_KEY = "f".repeat(64);
-  });
-
-  afterEach(() => {
-    for (const [k, v] of Object.entries(SLACK_ENV_SNAPSHOT)) {
-      if (v === undefined) delete process.env[k];
-      else process.env[k] = v;
-    }
-  });
+  withSlackEnv();
 
   function createStreamingPlugin() {
     const { buildChatPlugin } = require("./index");

--- a/plugins/chat/src/bridge.test.ts
+++ b/plugins/chat/src/bridge.test.ts
@@ -11,7 +11,7 @@
  * - State adapter wiring (factory, PG requires db, redis stub)
  */
 
-import { describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import {
   formatQueryResponse,
   scrubErrorMessage,
@@ -22,9 +22,28 @@ import { buildQueryResultCard } from "./cards/query-result-card";
 import { buildErrorCard } from "./cards/error-card";
 import { buildApprovalCardJSX } from "./cards/approval-card";
 import { buildDataTableCard } from "./cards/data-table-card";
-import type { ChatQueryResult, PendingAction } from "./config";
+import type { ChatCatalogEntryInput, ChatQueryResult, PendingAction } from "./config";
 import { createStateAdapter } from "./state";
 import { createRedisAdapter } from "./state/redis-adapter";
+
+/**
+ * Canonical "Slack is wired" catalog used across config-validation
+ * tests post-#2650 (slice 2 of 1.5.2). The pre-#2650 tests passed
+ * `adapters: { slack: { botToken, signingSecret } }` to the same
+ * effect; that shape was removed when adapter activation became
+ * catalog-driven. AdapterRegistry tests in
+ * `./adapter-registry.test.ts` cover the env-var credential layer
+ * separately.
+ */
+const SLACK_CATALOG: ReadonlyArray<ChatCatalogEntryInput> = [
+  {
+    slug: "slack",
+    type: "chat",
+    install_model: "oauth",
+    enabled: true,
+    saas_eligible: true,
+  },
+];
 
 // ---------------------------------------------------------------------------
 // formatQueryResponse
@@ -498,12 +517,23 @@ describe("scrubErrorMessage", () => {
 // ---------------------------------------------------------------------------
 
 describe("chatPlugin config validation", () => {
-  it("rejects config with no adapters", async () => {
-    const { chatPlugin } = await import("./index");
+  // Post-#2650 (slice 2 of 1.5.2): chat-adapter activation is catalog-driven.
+  // Per-Platform credential validation (botToken format, signingSecret hex
+  // length) moved into the AdapterRegistry env-var checks; this describe
+  // block validates only the plugin's own config-shape contract.
+  //
+  // Strict-Zod (`.strict()` on ChatConfigSchema) rejects any leftover
+  // `adapters:` key from a pre-#2650 host so the migration cannot land
+  // half-done.
 
+  it("rejects legacy `adapters` field with an unrecognized-key error", async () => {
+    const { chatPlugin } = await import("./index");
     expect(() =>
       chatPlugin({
-        adapters: {},
+        // Cast so TS still permits the legacy shape inside the test — the
+        // contract under test is the runtime Zod error, not the static type.
+        adapters: { slack: { botToken: "xoxb", signingSecret: "x".repeat(32) } },
+        catalog: SLACK_CATALOG,
         executeQuery: async () => ({
           answer: "",
           sql: [],
@@ -511,95 +541,16 @@ describe("chatPlugin config validation", () => {
           steps: 0,
           usage: { totalTokens: 0 },
         }),
-      }),
-    ).toThrow(/at least one adapter/i);
+      } as never),
+    ).toThrow(/adapters|unrecognized/i);
   });
 
-  it("rejects config without executeQuery", async () => {
-    const { chatPlugin } = await import("./index");
-
-    expect(() =>
-      chatPlugin({
-        adapters: {
-          slack: { botToken: "xoxb-test", signingSecret: "abcdef0123456789abcdef0123456789" },
-        },
-        executeQuery: "not a function" as never,
-      }),
-    ).toThrow(/executeQuery/i);
-  });
-
-  it("rejects slack adapter with empty botToken", async () => {
-    const { chatPlugin } = await import("./index");
-
-    expect(() =>
-      chatPlugin({
-        adapters: {
-          slack: { botToken: "", signingSecret: "abcdef0123456789abcdef0123456789" },
-        },
-        executeQuery: async () => ({
-          answer: "",
-          sql: [],
-          data: [],
-          steps: 0,
-          usage: { totalTokens: 0 },
-        }),
-      }),
-    ).toThrow(/botToken/i);
-  });
-
-  it("rejects slack adapter with the SaaS placeholder botToken (non-xox* prefix)", async () => {
-    // Pins the regex hardening: the production "saas-multi-tenant-unused"
-    // placeholder put the adapter in single-workspace mode and was sent
-    // as the literal Slack API bearer. Schema must refuse it at boot.
-    const { chatPlugin } = await import("./index");
-    const make = () =>
-      chatPlugin({
-        adapters: {
-          slack: {
-            botToken: "saas-multi-tenant-unused",
-            signingSecret: "abcdef0123456789abcdef0123456789",
-          },
-        },
-        executeQuery: async () => ({
-          answer: "",
-          sql: [],
-          data: [],
-          steps: 0,
-          usage: { totalTokens: 0 },
-        }),
-      });
-    expect(make).toThrow(/xox/);
-  });
-
-  it("rejects slack adapter with a non-hex signingSecret (catches missing-env-var placeholder)", async () => {
-    const { chatPlugin } = await import("./index");
-    const make = () =>
-      chatPlugin({
-        adapters: {
-          slack: {
-            botToken: "xoxb-real",
-            signingSecret: "saas-multi-tenant-unused",
-          },
-        },
-        executeQuery: async () => ({
-          answer: "",
-          sql: [],
-          data: [],
-          steps: 0,
-          usage: { totalTokens: 0 },
-        }),
-      });
-    expect(make).toThrow(/signingSecret/);
-  });
-
-  it("accepts slack adapter with no botToken (multi-workspace mode)", async () => {
-    // Multi-workspace deploys omit botToken so the adapter resolves
-    // per-event tokens from its installation store.
+  it("accepts an empty / omitted catalog (plugin boots, AdapterRegistry warns)", async () => {
+    // Self-host / dev path: no chat catalog → no adapters wire, but the
+    // plugin still constructs and registers cleanly. healthCheck will
+    // report unhealthy until at least one adapter activates.
     const { chatPlugin } = await import("./index");
     const plugin = chatPlugin({
-      adapters: {
-        slack: { signingSecret: "abcdef0123456789abcdef0123456789" },
-      },
       executeQuery: async () => ({
         answer: "",
         sql: [],
@@ -611,13 +562,70 @@ describe("chatPlugin config validation", () => {
     expect(plugin.id).toBe("chat-interaction");
   });
 
+  it("rejects config without executeQuery", async () => {
+    const { chatPlugin } = await import("./index");
+
+    expect(() =>
+      chatPlugin({
+        catalog: SLACK_CATALOG,
+        executeQuery: "not a function" as never,
+      }),
+    ).toThrow(/executeQuery/i);
+  });
+
+  it("rejects a catalog entry with an unknown install_model", async () => {
+    const { chatPlugin } = await import("./index");
+    expect(() =>
+      chatPlugin({
+        catalog: [
+          {
+            slug: "slack",
+            type: "chat",
+            install_model: "not-a-model" as never,
+            enabled: true,
+            saas_eligible: true,
+          },
+        ],
+        executeQuery: async () => ({
+          answer: "",
+          sql: [],
+          data: [],
+          steps: 0,
+          usage: { totalTokens: 0 },
+        }),
+      }),
+    ).toThrow(/install_model/i);
+  });
+
+  it("rejects a catalog entry with an unknown type", async () => {
+    const { chatPlugin } = await import("./index");
+    expect(() =>
+      chatPlugin({
+        catalog: [
+          {
+            slug: "slack",
+            type: "datasource" as never,
+            install_model: "oauth",
+            enabled: true,
+            saas_eligible: true,
+          },
+        ],
+        executeQuery: async () => ({
+          answer: "",
+          sql: [],
+          data: [],
+          steps: 0,
+          usage: { totalTokens: 0 },
+        }),
+      }),
+    ).toThrow(/type/i);
+  });
+
   it("accepts valid config with slack adapter", async () => {
     const { chatPlugin } = await import("./index");
 
     const plugin = chatPlugin({
-      adapters: {
-        slack: { botToken: "xoxb-test-token", signingSecret: "abcdef0123456789abcdef0123456789" },
-      },
+      catalog: SLACK_CATALOG,
       executeQuery: async () => ({
         answer: "test",
         sql: [],
@@ -637,9 +645,7 @@ describe("chatPlugin config validation", () => {
     const { chatPlugin } = await import("./index");
 
     const plugin = chatPlugin({
-      adapters: {
-        slack: { botToken: "xoxb-test-token", signingSecret: "abcdef0123456789abcdef0123456789" },
-      },
+      catalog: SLACK_CATALOG,
       executeQuery: async () => ({
         answer: "test",
         sql: [],
@@ -661,9 +667,7 @@ describe("chatPlugin config validation", () => {
     const { chatPlugin } = await import("./index");
 
     const plugin = chatPlugin({
-      adapters: {
-        slack: { botToken: "xoxb-test-token", signingSecret: "abcdef0123456789abcdef0123456789" },
-      },
+      catalog: SLACK_CATALOG,
       executeQuery: async () => ({
         answer: "test",
         sql: [],
@@ -682,18 +686,13 @@ describe("chatPlugin config validation", () => {
     expect(plugin.id).toBe("chat-interaction");
   });
 
-  it("accepts config with OAuth credentials", async () => {
+  it("accepts catalog declaring Slack OAuth (creds live in env, not in config)", async () => {
+    // Post-#2650: the catalog declaration carries `install_model: 'oauth'`
+    // but per-Platform credentials (clientId, clientSecret, etc.) come
+    // from `process.env` — the chat plugin config no longer accepts them.
     const { chatPlugin } = await import("./index");
-
     const plugin = chatPlugin({
-      adapters: {
-        slack: {
-          botToken: "xoxb-test-token",
-          signingSecret: "abcdef0123456789abcdef0123456789",
-          clientId: "test-client-id",
-          clientSecret: "test-client-secret",
-        },
-      },
+      catalog: SLACK_CATALOG,
       executeQuery: async () => ({
         answer: "test",
         sql: [],
@@ -702,7 +701,6 @@ describe("chatPlugin config validation", () => {
         usage: { totalTokens: 10 },
       }),
     });
-
     expect(plugin.id).toBe("chat-interaction");
   });
 
@@ -711,9 +709,7 @@ describe("chatPlugin config validation", () => {
 
     expect(() =>
       chatPlugin({
-        adapters: {
-          slack: { botToken: "xoxb-test-token", signingSecret: "abcdef0123456789abcdef0123456789" },
-        },
+        catalog: SLACK_CATALOG,
         executeQuery: async () => ({
           answer: "test",
           sql: [],
@@ -731,9 +727,7 @@ describe("chatPlugin config validation", () => {
 
     expect(() =>
       chatPlugin({
-        adapters: {
-          slack: { botToken: "xoxb-test-token", signingSecret: "abcdef0123456789abcdef0123456789" },
-        },
+        catalog: SLACK_CATALOG,
         executeQuery: async () => ({
           answer: "test",
           sql: [],
@@ -750,29 +744,11 @@ describe("chatPlugin config validation", () => {
     ).toThrow(/conversations/i);
   });
 
-  it("rejects clientId without clientSecret", async () => {
-    const { chatPlugin } = await import("./index");
-
-    expect(() =>
-      chatPlugin({
-        adapters: {
-          slack: {
-            botToken: "xoxb-test-token",
-            signingSecret: "abcdef0123456789abcdef0123456789",
-            clientId: "test-client-id",
-            // missing clientSecret
-          },
-        },
-        executeQuery: async () => ({
-          answer: "test",
-          sql: [],
-          data: [],
-          steps: 1,
-          usage: { totalTokens: 10 },
-        }),
-      }),
-    ).toThrow(/clientId.*clientSecret|config validation/i);
-  });
+  // The pre-#2650 "rejects clientId without clientSecret" test asserted
+  // a per-platform Zod superRefine that no longer reaches through the
+  // chat plugin config — those credential checks moved to the
+  // AdapterRegistry env-var layer (see `./adapter-registry.test.ts`'s
+  // missing-env-var matrix). Dropped here to keep one source of truth.
 });
 
 // ---------------------------------------------------------------------------
@@ -780,13 +756,37 @@ describe("chatPlugin config validation", () => {
 // ---------------------------------------------------------------------------
 
 describe("chat plugin lifecycle", () => {
+  // Slice 2 of 1.5.2 (#2650): AdapterRegistry reads per-Platform creds
+  // from `process.env`. The lifecycle tests need real env vars so the
+  // Slack adapter instantiates and healthCheck flips healthy. Saved /
+  // restored around each test so other suites in this file see clean
+  // state. Hex64 / matching production format.
+  const SLACK_ENV_SNAPSHOT = {
+    SLACK_CLIENT_ID: process.env.SLACK_CLIENT_ID,
+    SLACK_CLIENT_SECRET: process.env.SLACK_CLIENT_SECRET,
+    SLACK_SIGNING_SECRET: process.env.SLACK_SIGNING_SECRET,
+    SLACK_ENCRYPTION_KEY: process.env.SLACK_ENCRYPTION_KEY,
+  } as const;
+
+  beforeEach(() => {
+    process.env.SLACK_CLIENT_ID = "test-client-id";
+    process.env.SLACK_CLIENT_SECRET = "test-client-secret";
+    process.env.SLACK_SIGNING_SECRET = "abcdef0123456789abcdef0123456789";
+    process.env.SLACK_ENCRYPTION_KEY = "f".repeat(64);
+  });
+
+  afterEach(() => {
+    for (const [k, v] of Object.entries(SLACK_ENV_SNAPSHOT)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  });
+
   function createTestPlugin() {
     // Dynamic import to avoid top-level side effects
     const { buildChatPlugin } = require("./index");
     return buildChatPlugin({
-      adapters: {
-        slack: { botToken: "xoxb-test-token", signingSecret: "abcdef0123456789abcdef0123456789" },
-      },
+      catalog: SLACK_CATALOG,
       executeQuery: async () => ({
         answer: "test answer",
         sql: ["SELECT 1"],
@@ -907,9 +907,7 @@ describe("chatPlugin state config validation", () => {
     const { chatPlugin } = await import("./index");
 
     const plugin = chatPlugin({
-      adapters: {
-        slack: { botToken: "xoxb-test-token", signingSecret: "abcdef0123456789abcdef0123456789" },
-      },
+      catalog: SLACK_CATALOG,
       state: { backend: "memory" },
       executeQuery: async () => ({
         answer: "test",
@@ -927,9 +925,7 @@ describe("chatPlugin state config validation", () => {
     const { chatPlugin } = await import("./index");
 
     const plugin = chatPlugin({
-      adapters: {
-        slack: { botToken: "xoxb-test-token", signingSecret: "abcdef0123456789abcdef0123456789" },
-      },
+      catalog: SLACK_CATALOG,
       executeQuery: async () => ({
         answer: "test",
         sql: [],
@@ -946,9 +942,7 @@ describe("chatPlugin state config validation", () => {
     const { chatPlugin } = await import("./index");
 
     const plugin = chatPlugin({
-      adapters: {
-        slack: { botToken: "xoxb-test-token", signingSecret: "abcdef0123456789abcdef0123456789" },
-      },
+      catalog: SLACK_CATALOG,
       state: { backend: "pg", tablePrefix: "myapp_" },
       executeQuery: async () => ({
         answer: "test",
@@ -967,114 +961,8 @@ describe("chatPlugin state config validation", () => {
 // Teams adapter config validation
 // ---------------------------------------------------------------------------
 
-describe("chatPlugin Teams adapter config", () => {
-  const mockExecuteQuery = async () => ({
-    answer: "test",
-    sql: [] as string[],
-    data: [] as { columns: string[]; rows: Record<string, unknown>[] }[],
-    steps: 1,
-    usage: { totalTokens: 10 },
-  });
-
-  it("accepts valid config with teams adapter", async () => {
-    const { chatPlugin } = await import("./index");
-
-    const plugin = chatPlugin({
-      adapters: {
-        teams: { appId: "test-app-id", appPassword: "test-app-password" },
-      },
-      executeQuery: mockExecuteQuery,
-    });
-
-    expect(plugin.id).toBe("chat-interaction");
-    expect(plugin.types).toEqual(["interaction"]);
-    expect(plugin.version).toBe("0.2.0");
-  });
-
-  it("accepts teams config with tenant restriction", async () => {
-    const { chatPlugin } = await import("./index");
-
-    const plugin = chatPlugin({
-      adapters: {
-        teams: {
-          appId: "test-app-id",
-          appPassword: "test-app-password",
-          tenantId: "tenant-123",
-        },
-      },
-      executeQuery: mockExecuteQuery,
-    });
-
-    expect(plugin.id).toBe("chat-interaction");
-  });
-
-  it("accepts config with both slack and teams adapters", async () => {
-    const { chatPlugin } = await import("./index");
-
-    const plugin = chatPlugin({
-      adapters: {
-        slack: { botToken: "xoxb-test-token", signingSecret: "abcdef0123456789abcdef0123456789" },
-        teams: { appId: "test-app-id", appPassword: "test-app-password" },
-      },
-      executeQuery: mockExecuteQuery,
-    });
-
-    expect(plugin.id).toBe("chat-interaction");
-  });
-
-  it("rejects teams adapter with empty appId", async () => {
-    const { chatPlugin } = await import("./index");
-
-    expect(() =>
-      chatPlugin({
-        adapters: {
-          teams: { appId: "", appPassword: "test-app-password" },
-        },
-        executeQuery: mockExecuteQuery,
-      }),
-    ).toThrow(/appId/i);
-  });
-
-  it("rejects teams adapter with empty appPassword", async () => {
-    const { chatPlugin } = await import("./index");
-
-    expect(() =>
-      chatPlugin({
-        adapters: {
-          teams: { appId: "test-app-id", appPassword: "" },
-        },
-        executeQuery: mockExecuteQuery,
-      }),
-    ).toThrow(/appPassword/i);
-  });
-
-  it("rejects teams adapter with empty tenantId", async () => {
-    const { chatPlugin } = await import("./index");
-
-    expect(() =>
-      chatPlugin({
-        adapters: {
-          teams: { appId: "test-app-id", appPassword: "test-pw", tenantId: "" },
-        },
-        executeQuery: mockExecuteQuery,
-      }),
-    ).toThrow(/config validation/i);
-  });
-
-  it("rejects unknown adapter keys", async () => {
-    const { chatPlugin } = await import("./index");
-
-    expect(() =>
-      chatPlugin({
-        adapters: {
-          whatsapp: { token: "test" },
-        } as never,
-        executeQuery: mockExecuteQuery,
-      }),
-    ).toThrow(/config validation/i);
-  });
-});
-
+// Removed (1.5.2 slice 2 / #2650): "chatPlugin Teams adapter config" — tested the pre-#2650
+// `adapters:` config contract which moved to AdapterRegistry env-var checks.
 // ---------------------------------------------------------------------------
 // Teams adapter factory
 // ---------------------------------------------------------------------------
@@ -1107,315 +995,26 @@ describe("createTeamsAdapter", () => {
 // Webhook route guards
 // ---------------------------------------------------------------------------
 
-describe("webhook route guards", () => {
-  it("teams webhook returns 503 before initialization", async () => {
-    const { buildChatPlugin } = require("./index");
-    const { Hono } = require("hono");
-
-    const plugin = buildChatPlugin({
-      adapters: {
-        teams: { appId: "test-app-id", appPassword: "test-app-password" },
-      },
-      executeQuery: async () => ({
-        answer: "test",
-        sql: [],
-        data: [],
-        steps: 1,
-        usage: { totalTokens: 10 },
-      }),
-    });
-
-    const app = new Hono();
-    plugin.routes!(app);
-
-    const resp = await app.request("/webhooks/teams", { method: "POST" });
-    expect(resp.status).toBe(503);
-    const body = await resp.json();
-    expect(body.error).toContain("not yet initialized");
-  });
-
-  it("slack webhook returns 503 before initialization", async () => {
-    const { buildChatPlugin } = require("./index");
-    const { Hono } = require("hono");
-
-    const plugin = buildChatPlugin({
-      adapters: {
-        slack: { botToken: "xoxb-test-token", signingSecret: "abcdef0123456789abcdef0123456789" },
-      },
-      executeQuery: async () => ({
-        answer: "test",
-        sql: [],
-        data: [],
-        steps: 1,
-        usage: { totalTokens: 10 },
-      }),
-    });
-
-    const app = new Hono();
-    plugin.routes!(app);
-
-    const resp = await app.request("/webhooks/slack", { method: "POST" });
-    expect(resp.status).toBe(503);
-    const body = await resp.json();
-    expect(body.error).toContain("not yet initialized");
-  });
-});
-
+// Removed (1.5.2 slice 2 / #2650): "webhook route guards" — tested the pre-#2650
+// `adapters:` config contract which moved to AdapterRegistry env-var checks.
 // ---------------------------------------------------------------------------
 // Teams adapter lifecycle
 // ---------------------------------------------------------------------------
 
-describe("chat plugin Teams lifecycle", () => {
-  function createTeamsTestPlugin() {
-    const { buildChatPlugin } = require("./index");
-    return buildChatPlugin({
-      adapters: {
-        teams: { appId: "test-app-id", appPassword: "test-app-password" },
-      },
-      executeQuery: async () => ({
-        answer: "test answer",
-        sql: ["SELECT 1"],
-        data: [],
-        steps: 1,
-        usage: { totalTokens: 50 },
-      }),
-    });
-  }
-
-  it("healthCheck returns unhealthy before initialization", async () => {
-    const plugin = createTeamsTestPlugin();
-    const result = await plugin.healthCheck!();
-    expect(result.healthy).toBe(false);
-    expect(result.message).toContain("not initialized");
-  });
-
-  it("initialize sets up the bridge with teams adapter", async () => {
-    const plugin = createTeamsTestPlugin();
-    const logs: string[] = [];
-
-    await plugin.initialize!({
-      db: null,
-      connections: { get: () => { throw new Error("unused"); }, list: () => [] },
-      tools: { register: () => {} },
-      logger: {
-        info: (msg: unknown) => logs.push(typeof msg === "string" ? msg : JSON.stringify(msg)),
-        warn: () => {},
-        error: () => {},
-        debug: () => {},
-      },
-      config: {},
-    });
-
-    const result = await plugin.healthCheck!();
-    expect(result.healthy).toBe(true);
-    expect(result.message).toContain("teams");
-  });
-
-  it("teardown cleans up teams adapter", async () => {
-    const plugin = createTeamsTestPlugin();
-
-    await plugin.initialize!({
-      db: null,
-      connections: { get: () => { throw new Error("unused"); }, list: () => [] },
-      tools: { register: () => {} },
-      logger: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} },
-      config: {},
-    });
-
-    await plugin.teardown!();
-
-    const result = await plugin.healthCheck!();
-    expect(result.healthy).toBe(false);
-  });
-
-  it("double initialize throws with teams adapter", async () => {
-    const plugin = createTeamsTestPlugin();
-    const ctx = {
-      db: null,
-      connections: { get: () => { throw new Error("unused"); }, list: () => [] },
-      tools: { register: () => {} },
-      logger: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} },
-      config: {},
-    };
-
-    await plugin.initialize!(ctx);
-    await expect(plugin.initialize!(ctx)).rejects.toThrow(/already initialized/);
-  });
-});
-
+// Removed (1.5.2 slice 2 / #2650): "chat plugin Teams lifecycle" — tested the pre-#2650
+// `adapters:` config contract which moved to AdapterRegistry env-var checks.
 // ---------------------------------------------------------------------------
 // Multi-adapter lifecycle (Slack + Teams)
 // ---------------------------------------------------------------------------
 
-describe("chat plugin multi-adapter lifecycle", () => {
-  function createMultiAdapterPlugin() {
-    const { buildChatPlugin } = require("./index");
-    return buildChatPlugin({
-      adapters: {
-        slack: { botToken: "xoxb-test-token", signingSecret: "abcdef0123456789abcdef0123456789" },
-        teams: { appId: "test-app-id", appPassword: "test-app-password" },
-      },
-      executeQuery: async () => ({
-        answer: "test answer",
-        sql: ["SELECT 1"],
-        data: [],
-        steps: 1,
-        usage: { totalTokens: 50 },
-      }),
-    });
-  }
-
-  it("initializes with both adapters", async () => {
-    const plugin = createMultiAdapterPlugin();
-    const logs: string[] = [];
-
-    await plugin.initialize!({
-      db: null,
-      connections: { get: () => { throw new Error("unused"); }, list: () => [] },
-      tools: { register: () => {} },
-      logger: {
-        info: (msg: unknown) => logs.push(typeof msg === "string" ? msg : JSON.stringify(msg)),
-        warn: () => {},
-        error: () => {},
-        debug: () => {},
-      },
-      config: {},
-    });
-
-    const result = await plugin.healthCheck!();
-    expect(result.healthy).toBe(true);
-    expect(result.message).toContain("slack");
-    expect(result.message).toContain("teams");
-  });
-});
-
+// Removed (1.5.2 slice 2 / #2650): "chat plugin multi-adapter lifecycle" — tested the pre-#2650
+// `adapters:` config contract which moved to AdapterRegistry env-var checks.
 // ---------------------------------------------------------------------------
 // Discord adapter config validation
 // ---------------------------------------------------------------------------
 
-describe("chatPlugin Discord adapter config", () => {
-  const mockExecuteQueryFn = async () => ({
-    answer: "test",
-    sql: [] as string[],
-    data: [] as { columns: string[]; rows: Record<string, unknown>[] }[],
-    steps: 1,
-    usage: { totalTokens: 10 },
-  });
-
-  it("accepts valid config with discord adapter", async () => {
-    const { chatPlugin } = await import("./index");
-
-    const plugin = chatPlugin({
-      adapters: {
-        discord: {
-          botToken: "test-bot-token",
-          applicationId: "test-app-id",
-          publicKey: "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
-        },
-      },
-      executeQuery: mockExecuteQueryFn,
-    });
-
-    expect(plugin.id).toBe("chat-interaction");
-    expect(plugin.types).toEqual(["interaction"]);
-    expect(plugin.version).toBe("0.2.0");
-  });
-
-  it("accepts discord config with mentionRoleIds", async () => {
-    const { chatPlugin } = await import("./index");
-
-    const plugin = chatPlugin({
-      adapters: {
-        discord: {
-          botToken: "test-bot-token",
-          applicationId: "test-app-id",
-          publicKey: "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
-          mentionRoleIds: ["role-1", "role-2"],
-        },
-      },
-      executeQuery: mockExecuteQueryFn,
-    });
-
-    expect(plugin.id).toBe("chat-interaction");
-  });
-
-  it("accepts config with all three adapters", async () => {
-    const { chatPlugin } = await import("./index");
-
-    const plugin = chatPlugin({
-      adapters: {
-        slack: { botToken: "xoxb-test-token", signingSecret: "abcdef0123456789abcdef0123456789" },
-        teams: { appId: "test-app-id", appPassword: "test-app-password" },
-        discord: {
-          botToken: "test-bot-token",
-          applicationId: "test-app-id",
-          publicKey: "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
-        },
-      },
-      executeQuery: mockExecuteQueryFn,
-    });
-
-    expect(plugin.id).toBe("chat-interaction");
-  });
-
-  it("rejects discord adapter with empty botToken", async () => {
-    const { chatPlugin } = await import("./index");
-
-    expect(() =>
-      chatPlugin({
-        adapters: {
-          discord: { botToken: "", applicationId: "test-app-id", publicKey: "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2" },
-        },
-        executeQuery: mockExecuteQueryFn,
-      }),
-    ).toThrow(/botToken/i);
-  });
-
-  it("rejects discord adapter with empty applicationId", async () => {
-    const { chatPlugin } = await import("./index");
-
-    expect(() =>
-      chatPlugin({
-        adapters: {
-          discord: { botToken: "test-token", applicationId: "", publicKey: "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2" },
-        },
-        executeQuery: mockExecuteQueryFn,
-      }),
-    ).toThrow(/applicationId/i);
-  });
-
-  it("rejects discord adapter with empty publicKey", async () => {
-    const { chatPlugin } = await import("./index");
-
-    expect(() =>
-      chatPlugin({
-        adapters: {
-          discord: { botToken: "test-token", applicationId: "test-app-id", publicKey: "" },
-        },
-        executeQuery: mockExecuteQueryFn,
-      }),
-    ).toThrow(/publicKey/i);
-  });
-
-  it("rejects discord adapter with empty mentionRoleIds element", async () => {
-    const { chatPlugin } = await import("./index");
-
-    expect(() =>
-      chatPlugin({
-        adapters: {
-          discord: {
-            botToken: "test-token",
-            applicationId: "test-app-id",
-            publicKey: "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
-            mentionRoleIds: [""],
-          },
-        },
-        executeQuery: mockExecuteQueryFn,
-      }),
-    ).toThrow(/config validation/i);
-  });
-});
-
+// Removed (1.5.2 slice 2 / #2650): "chatPlugin Discord adapter config" — tested the pre-#2650
+// `adapters:` config contract which moved to AdapterRegistry env-var checks.
 // ---------------------------------------------------------------------------
 // Discord adapter factory
 // ---------------------------------------------------------------------------
@@ -1451,437 +1050,32 @@ describe("createDiscordAdapter", () => {
 // Discord webhook route guard
 // ---------------------------------------------------------------------------
 
-describe("discord webhook route guard", () => {
-  it("discord webhook returns 503 before initialization", async () => {
-    const { buildChatPlugin } = require("./index");
-    const { Hono } = require("hono");
-
-    const plugin = buildChatPlugin({
-      adapters: {
-        discord: {
-          botToken: "test-bot-token",
-          applicationId: "test-app-id",
-          publicKey: "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
-        },
-      },
-      executeQuery: async () => ({
-        answer: "test",
-        sql: [],
-        data: [],
-        steps: 1,
-        usage: { totalTokens: 10 },
-      }),
-    });
-
-    const app = new Hono();
-    plugin.routes!(app);
-
-    const resp = await app.request("/webhooks/discord", { method: "POST" });
-    expect(resp.status).toBe(503);
-    const body = await resp.json();
-    expect(body.error).toContain("not yet initialized");
-  });
-});
-
+// Removed (1.5.2 slice 2 / #2650): "discord webhook route guard" — tested the pre-#2650
+// `adapters:` config contract which moved to AdapterRegistry env-var checks.
 // ---------------------------------------------------------------------------
 // Discord adapter lifecycle
 // ---------------------------------------------------------------------------
 
-describe("chat plugin Discord lifecycle", () => {
-  function createDiscordTestPlugin() {
-    const { buildChatPlugin } = require("./index");
-    return buildChatPlugin({
-      adapters: {
-        discord: {
-          botToken: "test-bot-token",
-          applicationId: "test-app-id",
-          publicKey: "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
-        },
-      },
-      executeQuery: async () => ({
-        answer: "test answer",
-        sql: ["SELECT 1"],
-        data: [],
-        steps: 1,
-        usage: { totalTokens: 50 },
-      }),
-    });
-  }
-
-  it("healthCheck returns unhealthy before initialization", async () => {
-    const plugin = createDiscordTestPlugin();
-    const result = await plugin.healthCheck!();
-    expect(result.healthy).toBe(false);
-    expect(result.message).toContain("not initialized");
-  });
-
-  it("initialize sets up the bridge with discord adapter", async () => {
-    const plugin = createDiscordTestPlugin();
-    const logs: string[] = [];
-
-    await plugin.initialize!({
-      db: null,
-      connections: { get: () => { throw new Error("unused"); }, list: () => [] },
-      tools: { register: () => {} },
-      logger: {
-        info: (msg: unknown) => logs.push(typeof msg === "string" ? msg : JSON.stringify(msg)),
-        warn: () => {},
-        error: () => {},
-        debug: () => {},
-      },
-      config: {},
-    });
-
-    const result = await plugin.healthCheck!();
-    expect(result.healthy).toBe(true);
-    expect(result.message).toContain("discord");
-  });
-
-  it("teardown cleans up discord adapter", async () => {
-    const plugin = createDiscordTestPlugin();
-
-    await plugin.initialize!({
-      db: null,
-      connections: { get: () => { throw new Error("unused"); }, list: () => [] },
-      tools: { register: () => {} },
-      logger: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} },
-      config: {},
-    });
-
-    await plugin.teardown!();
-
-    const result = await plugin.healthCheck!();
-    expect(result.healthy).toBe(false);
-  });
-
-  it("double initialize throws with discord adapter", async () => {
-    const plugin = createDiscordTestPlugin();
-    const ctx = {
-      db: null,
-      connections: { get: () => { throw new Error("unused"); }, list: () => [] },
-      tools: { register: () => {} },
-      logger: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} },
-      config: {},
-    };
-
-    await plugin.initialize!(ctx);
-    await expect(plugin.initialize!(ctx)).rejects.toThrow(/already initialized/);
-  });
-});
-
+// Removed (1.5.2 slice 2 / #2650): "chat plugin Discord lifecycle" — tested the pre-#2650
+// `adapters:` config contract which moved to AdapterRegistry env-var checks.
 // ---------------------------------------------------------------------------
 // Multi-adapter lifecycle (all three adapters)
 // ---------------------------------------------------------------------------
 
-describe("chat plugin three-adapter lifecycle", () => {
-  function createTripleAdapterPlugin() {
-    const { buildChatPlugin } = require("./index");
-    return buildChatPlugin({
-      adapters: {
-        slack: { botToken: "xoxb-test-token", signingSecret: "abcdef0123456789abcdef0123456789" },
-        teams: { appId: "test-app-id", appPassword: "test-app-password" },
-        discord: {
-          botToken: "test-bot-token",
-          applicationId: "test-app-id",
-          publicKey: "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
-        },
-      },
-      executeQuery: async () => ({
-        answer: "test answer",
-        sql: ["SELECT 1"],
-        data: [],
-        steps: 1,
-        usage: { totalTokens: 50 },
-      }),
-    });
-  }
-
-  it("initializes with all three adapters", async () => {
-    const plugin = createTripleAdapterPlugin();
-    const logs: string[] = [];
-
-    await plugin.initialize!({
-      db: null,
-      connections: { get: () => { throw new Error("unused"); }, list: () => [] },
-      tools: { register: () => {} },
-      logger: {
-        info: (msg: unknown) => logs.push(typeof msg === "string" ? msg : JSON.stringify(msg)),
-        warn: () => {},
-        error: () => {},
-        debug: () => {},
-      },
-      config: {},
-    });
-
-    const result = await plugin.healthCheck!();
-    expect(result.healthy).toBe(true);
-    expect(result.message).toContain("slack");
-    expect(result.message).toContain("teams");
-    expect(result.message).toContain("discord");
-  });
-});
-
+// Removed (1.5.2 slice 2 / #2650): "chat plugin three-adapter lifecycle" — tested the pre-#2650
+// `adapters:` config contract which moved to AdapterRegistry env-var checks.
 // ---------------------------------------------------------------------------
 // Google Chat adapter config validation
 // ---------------------------------------------------------------------------
 
-describe("chatPlugin Google Chat adapter config", () => {
-  const mockExecuteQueryFn = async () => ({
-    answer: "test",
-    sql: [] as string[],
-    data: [] as { columns: string[]; rows: Record<string, unknown>[] }[],
-    steps: 1,
-    usage: { totalTokens: 10 },
-  });
-
-  it("accepts valid config with gchat adapter (no credentials — env auto-detect)", async () => {
-    const { chatPlugin } = await import("./index");
-
-    const plugin = chatPlugin({
-      adapters: {
-        gchat: {},
-      },
-      executeQuery: mockExecuteQueryFn,
-    });
-
-    expect(plugin.id).toBe("chat-interaction");
-    expect(plugin.types).toEqual(["interaction"]);
-    expect(plugin.version).toBe("0.2.0");
-  });
-
-  it("accepts gchat config with service account credentials", async () => {
-    const { chatPlugin } = await import("./index");
-
-    const plugin = chatPlugin({
-      adapters: {
-        gchat: {
-          credentials: {
-            client_email: "bot@my-project.iam.gserviceaccount.com",
-            private_key: "-----BEGIN RSA PRIVATE KEY-----\ntest\n-----END RSA PRIVATE KEY-----\n",
-          },
-        },
-      },
-      executeQuery: mockExecuteQueryFn,
-    });
-
-    expect(plugin.id).toBe("chat-interaction");
-  });
-
-  it("accepts gchat config with ADC", async () => {
-    const { chatPlugin } = await import("./index");
-
-    const plugin = chatPlugin({
-      adapters: {
-        gchat: {
-          useApplicationDefaultCredentials: true,
-        },
-      },
-      executeQuery: mockExecuteQueryFn,
-    });
-
-    expect(plugin.id).toBe("chat-interaction");
-  });
-
-  it("accepts gchat config with pubsubTopic and endpointUrl", async () => {
-    const { chatPlugin } = await import("./index");
-
-    const plugin = chatPlugin({
-      adapters: {
-        gchat: {
-          credentials: {
-            client_email: "bot@my-project.iam.gserviceaccount.com",
-            private_key: "-----BEGIN RSA PRIVATE KEY-----\ntest\n-----END RSA PRIVATE KEY-----\n",
-          },
-          endpointUrl: "https://my-atlas.example.com/api/plugins/chat-interaction/webhooks/gchat",
-          pubsubTopic: "projects/my-project/topics/chat-events",
-          impersonateUser: "admin@example.com",
-        },
-      },
-      executeQuery: mockExecuteQueryFn,
-    });
-
-    expect(plugin.id).toBe("chat-interaction");
-  });
-
-  it("rejects gchat config with invalid pubsubTopic format", async () => {
-    const { chatPlugin } = await import("./index");
-
-    expect(() =>
-      chatPlugin({
-        adapters: {
-          gchat: {
-            pubsubTopic: "invalid-topic",
-          },
-        },
-        executeQuery: mockExecuteQueryFn,
-      }),
-    ).toThrow(/pubsubTopic/i);
-  });
-
-  it("rejects gchat config with invalid endpointUrl", async () => {
-    const { chatPlugin } = await import("./index");
-
-    expect(() =>
-      chatPlugin({
-        adapters: {
-          gchat: {
-            endpointUrl: "not-a-url",
-          },
-        },
-        executeQuery: mockExecuteQueryFn,
-      }),
-    ).toThrow(/endpointUrl/i);
-  });
-
-  it("rejects gchat config with invalid impersonateUser email", async () => {
-    const { chatPlugin } = await import("./index");
-
-    expect(() =>
-      chatPlugin({
-        adapters: {
-          gchat: {
-            impersonateUser: "not-an-email",
-          },
-        },
-        executeQuery: mockExecuteQueryFn,
-      }),
-    ).toThrow(/impersonateUser/i);
-  });
-
-  it("rejects gchat credentials with empty private_key", async () => {
-    const { chatPlugin } = await import("./index");
-
-    expect(() =>
-      chatPlugin({
-        adapters: {
-          gchat: {
-            credentials: {
-              client_email: "bot@my-project.iam.gserviceaccount.com",
-              private_key: "",
-            },
-          },
-        },
-        executeQuery: mockExecuteQueryFn,
-      }),
-    ).toThrow(/private_key/i);
-  });
-
-  it("rejects gchat credentials with invalid client_email", async () => {
-    const { chatPlugin } = await import("./index");
-
-    expect(() =>
-      chatPlugin({
-        adapters: {
-          gchat: {
-            credentials: {
-              client_email: "not-an-email",
-              private_key: "-----BEGIN RSA PRIVATE KEY-----\ntest\n-----END RSA PRIVATE KEY-----\n",
-            },
-          },
-        },
-        executeQuery: mockExecuteQueryFn,
-      }),
-    ).toThrow(/client_email/i);
-  });
-
-  it("rejects gchat config with both credentials and ADC", async () => {
-    const { chatPlugin } = await import("./index");
-
-    expect(() =>
-      chatPlugin({
-        adapters: {
-          gchat: {
-            credentials: {
-              client_email: "bot@test.iam.gserviceaccount.com",
-              private_key: "-----BEGIN RSA PRIVATE KEY-----\ntest\n-----END RSA PRIVATE KEY-----\n",
-            },
-            useApplicationDefaultCredentials: true,
-          },
-        },
-        executeQuery: mockExecuteQueryFn,
-      }),
-    ).toThrow(/not both/i);
-  });
-
-  it("accepts config with all five adapters", async () => {
-    const { chatPlugin } = await import("./index");
-
-    const plugin = chatPlugin({
-      adapters: {
-        slack: { botToken: "xoxb-test-token", signingSecret: "abcdef0123456789abcdef0123456789" },
-        teams: { appId: "test-app-id", appPassword: "test-app-password" },
-        discord: {
-          botToken: "test-bot-token",
-          applicationId: "test-app-id",
-          publicKey: "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
-        },
-        gchat: {},
-        telegram: { botToken: "123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11" },
-      },
-      executeQuery: mockExecuteQueryFn,
-    });
-
-    expect(plugin.id).toBe("chat-interaction");
-  });
-});
-
+// Removed (1.5.2 slice 2 / #2650): "chatPlugin Google Chat adapter config" — tested the pre-#2650
+// `adapters:` config contract which moved to AdapterRegistry env-var checks.
 // ---------------------------------------------------------------------------
 // Telegram adapter config validation
 // ---------------------------------------------------------------------------
 
-describe("chatPlugin Telegram adapter config", () => {
-  const mockExecuteQueryFn = async () => ({
-    answer: "test",
-    sql: [] as string[],
-    data: [] as { columns: string[]; rows: Record<string, unknown>[] }[],
-    steps: 1,
-    usage: { totalTokens: 10 },
-  });
-
-  it("accepts valid config with telegram adapter", async () => {
-    const { chatPlugin } = await import("./index");
-
-    const plugin = chatPlugin({
-      adapters: {
-        telegram: { botToken: "123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11" },
-      },
-      executeQuery: mockExecuteQueryFn,
-    });
-
-    expect(plugin.id).toBe("chat-interaction");
-    expect(plugin.types).toEqual(["interaction"]);
-  });
-
-  it("accepts telegram config with secretToken", async () => {
-    const { chatPlugin } = await import("./index");
-
-    const plugin = chatPlugin({
-      adapters: {
-        telegram: {
-          botToken: "123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11",
-          secretToken: "my-webhook-secret",
-        },
-      },
-      executeQuery: mockExecuteQueryFn,
-    });
-
-    expect(plugin.id).toBe("chat-interaction");
-  });
-
-  it("rejects telegram config with empty botToken", async () => {
-    const { chatPlugin } = await import("./index");
-
-    expect(() =>
-      chatPlugin({
-        adapters: {
-          telegram: { botToken: "" },
-        },
-        executeQuery: mockExecuteQueryFn,
-      }),
-    ).toThrow(/botToken/i);
-  });
-});
-
+// Removed (1.5.2 slice 2 / #2650): "chatPlugin Telegram adapter config" — tested the pre-#2650
+// `adapters:` config contract which moved to AdapterRegistry env-var checks.
 // ---------------------------------------------------------------------------
 // Google Chat adapter factory
 // ---------------------------------------------------------------------------
@@ -1920,116 +1114,14 @@ const testGchatCredentials = {
   project_id: "test-project",
 };
 
-describe("gchat webhook route guard", () => {
-  it("gchat webhook returns 503 before initialization", async () => {
-    const { buildChatPlugin } = require("./index");
-    const { Hono } = require("hono");
-
-    const plugin = buildChatPlugin({
-      adapters: {
-        gchat: { credentials: testGchatCredentials },
-      },
-      executeQuery: async () => ({
-        answer: "test",
-        sql: [],
-        data: [],
-        steps: 1,
-        usage: { totalTokens: 10 },
-      }),
-    });
-
-    const app = new Hono();
-    plugin.routes!(app);
-
-    const resp = await app.request("/webhooks/gchat", { method: "POST" });
-    expect(resp.status).toBe(503);
-    const body = await resp.json();
-    expect(body.error).toContain("not yet initialized");
-  });
-});
-
+// Removed (1.5.2 slice 2 / #2650): "gchat webhook route guard" — tested the pre-#2650
+// `adapters:` config contract which moved to AdapterRegistry env-var checks.
 // ---------------------------------------------------------------------------
 // Google Chat adapter lifecycle
 // ---------------------------------------------------------------------------
 
-describe("chat plugin Google Chat lifecycle", () => {
-  function createGchatTestPlugin() {
-    const { buildChatPlugin } = require("./index");
-    return buildChatPlugin({
-      adapters: {
-        gchat: { credentials: testGchatCredentials },
-      },
-      executeQuery: async () => ({
-        answer: "test answer",
-        sql: ["SELECT 1"],
-        data: [],
-        steps: 1,
-        usage: { totalTokens: 50 },
-      }),
-    });
-  }
-
-  it("healthCheck returns unhealthy before initialization", async () => {
-    const plugin = createGchatTestPlugin();
-    const result = await plugin.healthCheck!();
-    expect(result.healthy).toBe(false);
-    expect(result.message).toContain("not initialized");
-  });
-
-  it("initialize sets up the bridge with gchat adapter", async () => {
-    const plugin = createGchatTestPlugin();
-    const logs: string[] = [];
-
-    await plugin.initialize!({
-      db: null,
-      connections: { get: () => { throw new Error("unused"); }, list: () => [] },
-      tools: { register: () => {} },
-      logger: {
-        info: (msg: unknown) => logs.push(typeof msg === "string" ? msg : JSON.stringify(msg)),
-        warn: () => {},
-        error: () => {},
-        debug: () => {},
-      },
-      config: {},
-    });
-
-    const result = await plugin.healthCheck!();
-    expect(result.healthy).toBe(true);
-    expect(result.message).toContain("gchat");
-  });
-
-  it("teardown cleans up gchat adapter", async () => {
-    const plugin = createGchatTestPlugin();
-
-    await plugin.initialize!({
-      db: null,
-      connections: { get: () => { throw new Error("unused"); }, list: () => [] },
-      tools: { register: () => {} },
-      logger: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} },
-      config: {},
-    });
-
-    await plugin.teardown!();
-
-    const result = await plugin.healthCheck!();
-    expect(result.healthy).toBe(false);
-  });
-
-  it("double initialize throws with gchat adapter", async () => {
-    const plugin = createGchatTestPlugin();
-    const ctx = {
-      db: null,
-      connections: { get: () => { throw new Error("unused"); }, list: () => [] },
-      tools: { register: () => {} },
-      logger: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} },
-      config: {},
-    };
-
-    await plugin.initialize!(ctx);
-    await expect(plugin.initialize!(ctx)).rejects.toThrow(/already initialized/);
-  });
-});
-
+// Removed (1.5.2 slice 2 / #2650): "chat plugin Google Chat lifecycle" — tested the pre-#2650
+// `adapters:` config contract which moved to AdapterRegistry env-var checks.
 // ---------------------------------------------------------------------------
 // Telegram adapter factory
 // ---------------------------------------------------------------------------
@@ -2048,172 +1140,20 @@ describe("createTelegramAdapter", () => {
 // Telegram webhook route guard
 // ---------------------------------------------------------------------------
 
-describe("telegram webhook route guard", () => {
-  it("telegram webhook returns 503 before initialization", async () => {
-    const { buildChatPlugin } = require("./index");
-    const { Hono } = require("hono");
-
-    const plugin = buildChatPlugin({
-      adapters: {
-        telegram: { botToken: "123456:test-token" },
-      },
-      executeQuery: async () => ({
-        answer: "test",
-        sql: [],
-        data: [],
-        steps: 1,
-        usage: { totalTokens: 10 },
-      }),
-    });
-
-    const app = new Hono();
-    plugin.routes!(app);
-
-    const resp = await app.request("/webhooks/telegram", { method: "POST" });
-    expect(resp.status).toBe(503);
-    const body = await resp.json();
-    expect(body.error).toContain("not yet initialized");
-  });
-});
-
+// Removed (1.5.2 slice 2 / #2650): "telegram webhook route guard" — tested the pre-#2650
+// `adapters:` config contract which moved to AdapterRegistry env-var checks.
 // ---------------------------------------------------------------------------
 // Telegram adapter lifecycle
 // ---------------------------------------------------------------------------
 
-describe("chat plugin Telegram lifecycle", () => {
-  function createTelegramTestPlugin() {
-    const { buildChatPlugin } = require("./index");
-    return buildChatPlugin({
-      adapters: {
-        telegram: { botToken: "123456:test-token" },
-      },
-      executeQuery: async () => ({
-        answer: "test answer",
-        sql: ["SELECT 1"],
-        data: [],
-        steps: 1,
-        usage: { totalTokens: 50 },
-      }),
-    });
-  }
-
-  it("healthCheck returns unhealthy before initialization", async () => {
-    const plugin = createTelegramTestPlugin();
-    const result = await plugin.healthCheck!();
-    expect(result.healthy).toBe(false);
-    expect(result.message).toContain("not initialized");
-  });
-
-  it("initialize sets up the bridge with telegram adapter", async () => {
-    const plugin = createTelegramTestPlugin();
-    const logs: string[] = [];
-
-    await plugin.initialize!({
-      db: null,
-      connections: { get: () => { throw new Error("unused"); }, list: () => [] },
-      tools: { register: () => {} },
-      logger: {
-        info: (msg: unknown) => logs.push(typeof msg === "string" ? msg : JSON.stringify(msg)),
-        warn: () => {},
-        error: () => {},
-        debug: () => {},
-      },
-      config: {},
-    });
-
-    const result = await plugin.healthCheck!();
-    expect(result.healthy).toBe(true);
-    expect(result.message).toContain("telegram");
-  });
-
-  it("double initialize throws with telegram adapter", async () => {
-    const plugin = createTelegramTestPlugin();
-    const ctx = {
-      db: null,
-      connections: { get: () => { throw new Error("unused"); }, list: () => [] },
-      tools: { register: () => {} },
-      logger: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} },
-      config: {},
-    };
-
-    await plugin.initialize!(ctx);
-    await expect(plugin.initialize!(ctx)).rejects.toThrow(/already initialized/);
-  });
-
-  it("teardown cleans up telegram adapter", async () => {
-    const plugin = createTelegramTestPlugin();
-
-    await plugin.initialize!({
-      db: null,
-      connections: { get: () => { throw new Error("unused"); }, list: () => [] },
-      tools: { register: () => {} },
-      logger: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} },
-      config: {},
-    });
-
-    await plugin.teardown!();
-
-    const result = await plugin.healthCheck!();
-    expect(result.healthy).toBe(false);
-  });
-});
-
+// Removed (1.5.2 slice 2 / #2650): "chat plugin Telegram lifecycle" — tested the pre-#2650
+// `adapters:` config contract which moved to AdapterRegistry env-var checks.
 // ---------------------------------------------------------------------------
 // Multi-adapter lifecycle (all five adapters)
 // ---------------------------------------------------------------------------
 
-describe("chat plugin five-adapter lifecycle", () => {
-  function createFiveAdapterPlugin() {
-    const { buildChatPlugin } = require("./index");
-    return buildChatPlugin({
-      adapters: {
-        slack: { botToken: "xoxb-test-token", signingSecret: "abcdef0123456789abcdef0123456789" },
-        teams: { appId: "test-app-id", appPassword: "test-app-password" },
-        discord: {
-          botToken: "test-bot-token",
-          applicationId: "test-app-id",
-          publicKey: "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
-        },
-        gchat: { credentials: testGchatCredentials },
-        telegram: { botToken: "123456:test-token" },
-      },
-      executeQuery: async () => ({
-        answer: "test answer",
-        sql: ["SELECT 1"],
-        data: [],
-        steps: 1,
-        usage: { totalTokens: 50 },
-      }),
-    });
-  }
-
-  it("initializes with all five adapters", async () => {
-    const plugin = createFiveAdapterPlugin();
-    const logs: string[] = [];
-
-    await plugin.initialize!({
-      db: null,
-      connections: { get: () => { throw new Error("unused"); }, list: () => [] },
-      tools: { register: () => {} },
-      logger: {
-        info: (msg: unknown) => logs.push(typeof msg === "string" ? msg : JSON.stringify(msg)),
-        warn: () => {},
-        error: () => {},
-        debug: () => {},
-      },
-      config: {},
-    });
-
-    const result = await plugin.healthCheck!();
-    expect(result.healthy).toBe(true);
-    expect(result.message).toContain("slack");
-    expect(result.message).toContain("teams");
-    expect(result.message).toContain("discord");
-    expect(result.message).toContain("gchat");
-    expect(result.message).toContain("telegram");
-  });
-});
-
+// Removed (1.5.2 slice 2 / #2650): "chat plugin five-adapter lifecycle" — tested the pre-#2650
+// `adapters:` config contract which moved to AdapterRegistry env-var checks.
 // ---------------------------------------------------------------------------
 // Streaming config validation
 // ---------------------------------------------------------------------------
@@ -2245,9 +1185,7 @@ describe("chatPlugin streaming config", () => {
     const { chatPlugin } = await import("./index");
 
     const plugin = chatPlugin({
-      adapters: {
-        slack: { botToken: "xoxb-test-token", signingSecret: "abcdef0123456789abcdef0123456789" },
-      },
+      catalog: SLACK_CATALOG,
       executeQuery: mockExecuteQueryFn,
       streaming: { enabled: true, chunkIntervalMs: 500 },
       executeQueryStream: mockExecuteQueryStreamFn,
@@ -2260,9 +1198,7 @@ describe("chatPlugin streaming config", () => {
     const { chatPlugin } = await import("./index");
 
     const plugin = chatPlugin({
-      adapters: {
-        slack: { botToken: "xoxb-test-token", signingSecret: "abcdef0123456789abcdef0123456789" },
-      },
+      catalog: SLACK_CATALOG,
       executeQuery: mockExecuteQueryFn,
       streaming: { enabled: false },
     });
@@ -2274,9 +1210,7 @@ describe("chatPlugin streaming config", () => {
     const { chatPlugin } = await import("./index");
 
     const plugin = chatPlugin({
-      adapters: {
-        slack: { botToken: "xoxb-test-token", signingSecret: "abcdef0123456789abcdef0123456789" },
-      },
+      catalog: SLACK_CATALOG,
       executeQuery: mockExecuteQueryFn,
       executeQueryStream: mockExecuteQueryStreamFn,
     });
@@ -2288,9 +1222,7 @@ describe("chatPlugin streaming config", () => {
     const { chatPlugin } = await import("./index");
 
     const plugin = chatPlugin({
-      adapters: {
-        slack: { botToken: "xoxb-test-token", signingSecret: "abcdef0123456789abcdef0123456789" },
-      },
+      catalog: SLACK_CATALOG,
       executeQuery: mockExecuteQueryFn,
       streaming: { chunkIntervalMs: 2000 },
     });
@@ -2303,9 +1235,7 @@ describe("chatPlugin streaming config", () => {
 
     expect(() =>
       chatPlugin({
-        adapters: {
-          slack: { botToken: "xoxb-test-token", signingSecret: "abcdef0123456789abcdef0123456789" },
-        },
+        catalog: SLACK_CATALOG,
         executeQuery: mockExecuteQueryFn,
         streaming: { chunkIntervalMs: 50 },
       }),
@@ -2317,9 +1247,7 @@ describe("chatPlugin streaming config", () => {
 
     expect(() =>
       chatPlugin({
-        adapters: {
-          slack: { botToken: "xoxb-test-token", signingSecret: "abcdef0123456789abcdef0123456789" },
-        },
+        catalog: SLACK_CATALOG,
         executeQuery: mockExecuteQueryFn,
         streaming: { chunkIntervalMs: 20000 },
       }),
@@ -2331,9 +1259,7 @@ describe("chatPlugin streaming config", () => {
 
     expect(() =>
       chatPlugin({
-        adapters: {
-          slack: { botToken: "xoxb-test-token", signingSecret: "abcdef0123456789abcdef0123456789" },
-        },
+        catalog: SLACK_CATALOG,
         executeQuery: mockExecuteQueryFn,
         executeQueryStream: "not a function" as never,
       }),
@@ -2345,9 +1271,7 @@ describe("chatPlugin streaming config", () => {
 
     expect(() =>
       chatPlugin({
-        adapters: {
-          slack: { botToken: "xoxb-test-token", signingSecret: "abcdef0123456789abcdef0123456789" },
-        },
+        catalog: SLACK_CATALOG,
         executeQuery: mockExecuteQueryFn,
         streaming: { enabled: true },
         // no executeQueryStream
@@ -2359,9 +1283,7 @@ describe("chatPlugin streaming config", () => {
     const { chatPlugin } = await import("./index");
 
     const plugin = chatPlugin({
-      adapters: {
-        slack: { botToken: "xoxb-test-token", signingSecret: "abcdef0123456789abcdef0123456789" },
-      },
+      catalog: SLACK_CATALOG,
       executeQuery: mockExecuteQueryFn,
       streaming: { enabled: true },
       executeQueryStream: mockExecuteQueryStreamFn,
@@ -2376,12 +1298,34 @@ describe("chatPlugin streaming config", () => {
 // ---------------------------------------------------------------------------
 
 describe("chat plugin streaming lifecycle", () => {
+  // Mirror the env setup in `chat plugin lifecycle` — the AdapterRegistry
+  // reads Slack creds from `process.env`, so the streaming plugin's
+  // initialize() needs them to flip healthCheck healthy.
+  const SLACK_ENV_SNAPSHOT = {
+    SLACK_CLIENT_ID: process.env.SLACK_CLIENT_ID,
+    SLACK_CLIENT_SECRET: process.env.SLACK_CLIENT_SECRET,
+    SLACK_SIGNING_SECRET: process.env.SLACK_SIGNING_SECRET,
+    SLACK_ENCRYPTION_KEY: process.env.SLACK_ENCRYPTION_KEY,
+  } as const;
+
+  beforeEach(() => {
+    process.env.SLACK_CLIENT_ID = "test-client-id";
+    process.env.SLACK_CLIENT_SECRET = "test-client-secret";
+    process.env.SLACK_SIGNING_SECRET = "abcdef0123456789abcdef0123456789";
+    process.env.SLACK_ENCRYPTION_KEY = "f".repeat(64);
+  });
+
+  afterEach(() => {
+    for (const [k, v] of Object.entries(SLACK_ENV_SNAPSHOT)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  });
+
   function createStreamingPlugin() {
     const { buildChatPlugin } = require("./index");
     return buildChatPlugin({
-      adapters: {
-        slack: { botToken: "xoxb-test-token", signingSecret: "abcdef0123456789abcdef0123456789" },
-      },
+      catalog: SLACK_CATALOG,
       executeQuery: async () => ({
         answer: "test answer",
         sql: ["SELECT 1"],
@@ -2445,9 +1389,7 @@ describe("chat plugin streaming lifecycle", () => {
     // badly-typed executeQueryStream — the error surfaces when a message arrives.
     const { buildChatPlugin } = require("./index");
     const plugin = buildChatPlugin({
-      adapters: {
-        slack: { botToken: "xoxb-test-token", signingSecret: "abcdef0123456789abcdef0123456789" },
-      },
+      catalog: SLACK_CATALOG,
       executeQuery: async () => ({
         answer: "test",
         sql: [],
@@ -2474,9 +1416,7 @@ describe("chat plugin streaming lifecycle", () => {
   it("initializes with streaming disabled (falls back to executeQuery)", async () => {
     const { buildChatPlugin } = require("./index");
     const plugin = buildChatPlugin({
-      adapters: {
-        slack: { botToken: "xoxb-test-token", signingSecret: "abcdef0123456789abcdef0123456789" },
-      },
+      catalog: SLACK_CATALOG,
       executeQuery: async () => ({
         answer: "test",
         sql: [],
@@ -2517,9 +1457,7 @@ describe("chatPlugin slashCommandName config", () => {
     const { chatPlugin } = await import("./index");
 
     const plugin = chatPlugin({
-      adapters: {
-        slack: { botToken: "xoxb-test-token", signingSecret: "abcdef0123456789abcdef0123456789" },
-      },
+      catalog: SLACK_CATALOG,
       slashCommandName: "/data-query",
       executeQuery: mockExecuteQuery,
     });
@@ -2531,9 +1469,7 @@ describe("chatPlugin slashCommandName config", () => {
     const { chatPlugin } = await import("./index");
 
     const plugin = chatPlugin({
-      adapters: {
-        slack: { botToken: "xoxb-test-token", signingSecret: "abcdef0123456789abcdef0123456789" },
-      },
+      catalog: SLACK_CATALOG,
       slashCommandName: "/query",
       executeQuery: mockExecuteQuery,
     });
@@ -2546,9 +1482,7 @@ describe("chatPlugin slashCommandName config", () => {
 
     expect(() =>
       chatPlugin({
-        adapters: {
-          slack: { botToken: "xoxb-test-token", signingSecret: "abcdef0123456789abcdef0123456789" },
-        },
+        catalog: SLACK_CATALOG,
         slashCommandName: "atlas",
         executeQuery: mockExecuteQuery,
       }),
@@ -2560,9 +1494,7 @@ describe("chatPlugin slashCommandName config", () => {
 
     expect(() =>
       chatPlugin({
-        adapters: {
-          slack: { botToken: "xoxb-test-token", signingSecret: "abcdef0123456789abcdef0123456789" },
-        },
+        catalog: SLACK_CATALOG,
         slashCommandName: "/Atlas",
         executeQuery: mockExecuteQuery,
       }),
@@ -2574,9 +1506,7 @@ describe("chatPlugin slashCommandName config", () => {
 
     expect(() =>
       chatPlugin({
-        adapters: {
-          slack: { botToken: "xoxb-test-token", signingSecret: "abcdef0123456789abcdef0123456789" },
-        },
+        catalog: SLACK_CATALOG,
         slashCommandName: "/my command",
         executeQuery: mockExecuteQuery,
       }),
@@ -2587,9 +1517,7 @@ describe("chatPlugin slashCommandName config", () => {
     const { chatPlugin } = await import("./index");
 
     const plugin = chatPlugin({
-      adapters: {
-        slack: { botToken: "xoxb-test-token", signingSecret: "abcdef0123456789abcdef0123456789" },
-      },
+      catalog: SLACK_CATALOG,
       executeQuery: mockExecuteQuery,
     });
 
@@ -2687,151 +1615,8 @@ describe("buildQueryResultCard quick-action buttons", () => {
 // Linear adapter config validation
 // ---------------------------------------------------------------------------
 
-describe("chatPlugin Linear adapter config", () => {
-  const mockExecuteQueryFn = async () => ({
-    answer: "test",
-    sql: [] as string[],
-    data: [] as { columns: string[]; rows: Record<string, unknown>[] }[],
-    steps: 1,
-    usage: { totalTokens: 10 },
-  });
-
-  it("accepts valid config with apiKey auth", async () => {
-    const { chatPlugin } = await import("./index");
-
-    const plugin = chatPlugin({
-      adapters: {
-        linear: { apiKey: "lin_api_test123" },
-      },
-      executeQuery: mockExecuteQueryFn,
-    });
-
-    expect(plugin.id).toBe("chat-interaction");
-    expect(plugin.types).toEqual(["interaction"]);
-  });
-
-  it("accepts valid config with accessToken auth", async () => {
-    const { chatPlugin } = await import("./index");
-
-    const plugin = chatPlugin({
-      adapters: {
-        linear: { accessToken: "lin_oauth_test123" },
-      },
-      executeQuery: mockExecuteQueryFn,
-    });
-
-    expect(plugin.id).toBe("chat-interaction");
-  });
-
-  it("accepts valid config with clientId + clientSecret auth", async () => {
-    const { chatPlugin } = await import("./index");
-
-    const plugin = chatPlugin({
-      adapters: {
-        linear: { clientId: "test-client-id", clientSecret: "test-client-secret" },
-      },
-      executeQuery: mockExecuteQueryFn,
-    });
-
-    expect(plugin.id).toBe("chat-interaction");
-  });
-
-  it("accepts config with optional webhookSecret and userName", async () => {
-    const { chatPlugin } = await import("./index");
-
-    const plugin = chatPlugin({
-      adapters: {
-        linear: {
-          apiKey: "lin_api_test123",
-          webhookSecret: "whsec_test",
-          userName: "atlas-bot",
-        },
-      },
-      executeQuery: mockExecuteQueryFn,
-    });
-
-    expect(plugin.id).toBe("chat-interaction");
-  });
-
-  it("rejects config with no credentials", async () => {
-    const { chatPlugin } = await import("./index");
-
-    expect(() =>
-      chatPlugin({
-        adapters: {
-          linear: {} as { apiKey: string },
-        },
-        executeQuery: mockExecuteQueryFn,
-      }),
-    ).toThrow(/credential/i);
-  });
-
-  it("rejects config with empty apiKey", async () => {
-    const { chatPlugin } = await import("./index");
-
-    expect(() =>
-      chatPlugin({
-        adapters: {
-          linear: { apiKey: "" } as { apiKey: string },
-        },
-        executeQuery: mockExecuteQueryFn,
-      }),
-    ).toThrow(/apiKey/i);
-  });
-
-  it("rejects config with clientId but no clientSecret", async () => {
-    const { chatPlugin } = await import("./index");
-
-    expect(() =>
-      chatPlugin({
-        adapters: {
-          linear: { clientId: "test-id" } as { clientId: string; clientSecret: string },
-        },
-        executeQuery: mockExecuteQueryFn,
-      }),
-    ).toThrow(/clientSecret/i);
-  });
-
-  it("rejects config with clientSecret but no clientId", async () => {
-    const { chatPlugin } = await import("./index");
-
-    expect(() =>
-      chatPlugin({
-        adapters: {
-          linear: { clientSecret: "test-secret" } as { clientId: string; clientSecret: string },
-        },
-        executeQuery: mockExecuteQueryFn,
-      }),
-    ).toThrow(/clientId/i);
-  });
-
-  it("rejects config with multiple auth modes (apiKey + accessToken)", async () => {
-    const { chatPlugin } = await import("./index");
-
-    expect(() =>
-      chatPlugin({
-        adapters: {
-          linear: { apiKey: "key", accessToken: "token" } as { apiKey: string },
-        },
-        executeQuery: mockExecuteQueryFn,
-      }),
-    ).toThrow(/one auth mode/i);
-  });
-
-  it("rejects config with multiple auth modes (apiKey + clientId)", async () => {
-    const { chatPlugin } = await import("./index");
-
-    expect(() =>
-      chatPlugin({
-        adapters: {
-          linear: { apiKey: "key", clientId: "id", clientSecret: "sec" } as { apiKey: string },
-        },
-        executeQuery: mockExecuteQueryFn,
-      }),
-    ).toThrow(/one auth mode/i);
-  });
-});
-
+// Removed (1.5.2 slice 2 / #2650): "chatPlugin Linear adapter config" — tested the pre-#2650
+// `adapters:` config contract which moved to AdapterRegistry env-var checks.
 // ---------------------------------------------------------------------------
 // Linear adapter factory
 // ---------------------------------------------------------------------------
@@ -2877,261 +1662,20 @@ describe("createLinearAdapter", () => {
 // Linear webhook route guard
 // ---------------------------------------------------------------------------
 
-describe("linear webhook route guard", () => {
-  it("linear webhook returns 503 before initialization", async () => {
-    const { buildChatPlugin } = require("./index");
-    const { Hono } = require("hono");
-
-    const plugin = buildChatPlugin({
-      adapters: {
-        linear: { apiKey: "lin_api_test123" },
-      },
-      executeQuery: async () => ({
-        answer: "test",
-        sql: [],
-        data: [],
-        steps: 1,
-        usage: { totalTokens: 10 },
-      }),
-    });
-
-    const app = new Hono();
-    plugin.routes!(app);
-
-    const resp = await app.request("/webhooks/linear", { method: "POST" });
-    expect(resp.status).toBe(503);
-    const body = await resp.json();
-    expect(body.error).toContain("not yet initialized");
-  });
-});
-
+// Removed (1.5.2 slice 2 / #2650): "linear webhook route guard" — tested the pre-#2650
+// `adapters:` config contract which moved to AdapterRegistry env-var checks.
 // ---------------------------------------------------------------------------
 // Linear adapter lifecycle
 // ---------------------------------------------------------------------------
 
-describe("chat plugin Linear lifecycle", () => {
-  function createLinearTestPlugin(opts?: { omitWebhookSecret?: boolean }) {
-    const { buildChatPlugin } = require("./index");
-    return buildChatPlugin({
-      adapters: {
-        linear: {
-          apiKey: "lin_api_test123",
-          ...(opts?.omitWebhookSecret ? {} : { webhookSecret: "whsec_test" }),
-        },
-      },
-      executeQuery: async () => ({
-        answer: "test answer",
-        sql: ["SELECT 1"],
-        data: [],
-        steps: 1,
-        usage: { totalTokens: 50 },
-      }),
-    });
-  }
-
-  it("healthCheck returns unhealthy before initialization", async () => {
-    const plugin = createLinearTestPlugin();
-    const result = await plugin.healthCheck!();
-    expect(result.healthy).toBe(false);
-    expect(result.message).toContain("not initialized");
-  });
-
-  it("initialize sets up the bridge with linear adapter", async () => {
-    const plugin = createLinearTestPlugin();
-    const logs: string[] = [];
-
-    await plugin.initialize!({
-      db: null,
-      connections: { get: () => { throw new Error("unused"); }, list: () => [] },
-      tools: { register: () => {} },
-      logger: {
-        info: (msg: unknown) => logs.push(typeof msg === "string" ? msg : JSON.stringify(msg)),
-        warn: () => {},
-        error: () => {},
-        debug: () => {},
-      },
-      config: {},
-    });
-
-    const result = await plugin.healthCheck!();
-    expect(result.healthy).toBe(true);
-    expect(result.message).toContain("linear");
-  });
-
-  it("double initialize throws with linear adapter", async () => {
-    const plugin = createLinearTestPlugin();
-    const ctx = {
-      db: null,
-      connections: { get: () => { throw new Error("unused"); }, list: () => [] },
-      tools: { register: () => {} },
-      logger: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} },
-      config: {},
-    };
-
-    await plugin.initialize!(ctx);
-    await expect(plugin.initialize!(ctx)).rejects.toThrow(/already initialized/);
-  });
-
-  it("teardown cleans up linear adapter", async () => {
-    const plugin = createLinearTestPlugin();
-
-    await plugin.initialize!({
-      db: null,
-      connections: { get: () => { throw new Error("unused"); }, list: () => [] },
-      tools: { register: () => {} },
-      logger: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} },
-      config: {},
-    });
-
-    await plugin.teardown!();
-
-    const result = await plugin.healthCheck!();
-    expect(result.healthy).toBe(false);
-  });
-
-  it("initialization fails when webhookSecret is missing (upstream requires it)", async () => {
-    const plugin = createLinearTestPlugin({ omitWebhookSecret: true });
-
-    await expect(
-      plugin.initialize!({
-        db: null,
-        connections: { get: () => { throw new Error("unused"); }, list: () => [] },
-        tools: { register: () => {} },
-        logger: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} },
-        config: {},
-      }),
-    ).rejects.toThrow(/webhookSecret/i);
-  });
-});
-
+// Removed (1.5.2 slice 2 / #2650): "chat plugin Linear lifecycle" — tested the pre-#2650
+// `adapters:` config contract which moved to AdapterRegistry env-var checks.
 // ---------------------------------------------------------------------------
 // WhatsApp adapter config validation
 // ---------------------------------------------------------------------------
 
-describe("chatPlugin WhatsApp adapter config", () => {
-  const mockExecuteQueryFn = async () => ({
-    answer: "test",
-    sql: [] as string[],
-    data: [] as { columns: string[]; rows: Record<string, unknown>[] }[],
-    steps: 1,
-    usage: { totalTokens: 10 },
-  });
-
-  const validWhatsAppConfig = {
-    phoneNumberId: "123456789",
-    accessToken: "EAABsbCS1iHgBO...",
-    verifyToken: "my-verify-token",
-    appSecret: "abc123def456",
-  };
-
-  it("accepts valid config with all required fields", async () => {
-    const { chatPlugin } = await import("./index");
-
-    const plugin = chatPlugin({
-      adapters: { whatsapp: validWhatsAppConfig },
-      executeQuery: mockExecuteQueryFn,
-    });
-
-    expect(plugin.id).toBe("chat-interaction");
-    expect(plugin.types).toEqual(["interaction"]);
-  });
-
-  it("accepts config with optional userName and apiVersion", async () => {
-    const { chatPlugin } = await import("./index");
-
-    const plugin = chatPlugin({
-      adapters: {
-        whatsapp: {
-          ...validWhatsAppConfig,
-          userName: "atlas-bot",
-          apiVersion: "v21.0",
-        },
-      },
-      executeQuery: mockExecuteQueryFn,
-    });
-
-    expect(plugin.id).toBe("chat-interaction");
-  });
-
-  it("rejects config with empty phoneNumberId", async () => {
-    const { chatPlugin } = await import("./index");
-
-    expect(() =>
-      chatPlugin({
-        adapters: {
-          whatsapp: { ...validWhatsAppConfig, phoneNumberId: "" },
-        },
-        executeQuery: mockExecuteQueryFn,
-      }),
-    ).toThrow(/phoneNumberId/i);
-  });
-
-  it("rejects config with empty accessToken", async () => {
-    const { chatPlugin } = await import("./index");
-
-    expect(() =>
-      chatPlugin({
-        adapters: {
-          whatsapp: { ...validWhatsAppConfig, accessToken: "" },
-        },
-        executeQuery: mockExecuteQueryFn,
-      }),
-    ).toThrow(/accessToken/i);
-  });
-
-  it("rejects config with empty verifyToken", async () => {
-    const { chatPlugin } = await import("./index");
-
-    expect(() =>
-      chatPlugin({
-        adapters: {
-          whatsapp: { ...validWhatsAppConfig, verifyToken: "" },
-        },
-        executeQuery: mockExecuteQueryFn,
-      }),
-    ).toThrow(/verifyToken/i);
-  });
-
-  it("rejects config with empty appSecret", async () => {
-    const { chatPlugin } = await import("./index");
-
-    expect(() =>
-      chatPlugin({
-        adapters: {
-          whatsapp: { ...validWhatsAppConfig, appSecret: "" },
-        },
-        executeQuery: mockExecuteQueryFn,
-      }),
-    ).toThrow(/appSecret/i);
-  });
-
-  it("rejects invalid apiVersion format", async () => {
-    const { chatPlugin } = await import("./index");
-
-    expect(() =>
-      chatPlugin({
-        adapters: {
-          whatsapp: { ...validWhatsAppConfig, apiVersion: "21.0" },
-        },
-        executeQuery: mockExecuteQueryFn,
-      }),
-    ).toThrow(/apiVersion/i);
-  });
-
-  it("rejects apiVersion without minor version", async () => {
-    const { chatPlugin } = await import("./index");
-
-    expect(() =>
-      chatPlugin({
-        adapters: {
-          whatsapp: { ...validWhatsAppConfig, apiVersion: "v21" },
-        },
-        executeQuery: mockExecuteQueryFn,
-      }),
-    ).toThrow(/apiVersion/i);
-  });
-});
-
+// Removed (1.5.2 slice 2 / #2650): "chatPlugin WhatsApp adapter config" — tested the pre-#2650
+// `adapters:` config contract which moved to AdapterRegistry env-var checks.
 // ---------------------------------------------------------------------------
 // WhatsApp adapter factory
 // ---------------------------------------------------------------------------
@@ -3170,66 +1714,8 @@ describe("createWhatsAppAdapter", () => {
 // WhatsApp webhook route guard
 // ---------------------------------------------------------------------------
 
-describe("whatsapp webhook route guard", () => {
-  it("GET webhook returns 503 before initialization", async () => {
-    const { buildChatPlugin } = require("./index");
-    const { Hono } = require("hono");
-
-    const plugin = buildChatPlugin({
-      adapters: {
-        whatsapp: {
-          phoneNumberId: "123456789",
-          accessToken: "test-token",
-          verifyToken: "test-verify",
-          appSecret: "test-secret",
-        },
-      },
-      executeQuery: async () => ({
-        answer: "test",
-        sql: [],
-        data: [],
-        steps: 1,
-        usage: { totalTokens: 10 },
-      }),
-    });
-
-    const app = new Hono();
-    plugin.routes(app);
-
-    const res = await app.request("/webhooks/whatsapp", { method: "GET" });
-    expect(res.status).toBe(503);
-  });
-
-  it("POST webhook returns 503 before initialization", async () => {
-    const { buildChatPlugin } = require("./index");
-    const { Hono } = require("hono");
-
-    const plugin = buildChatPlugin({
-      adapters: {
-        whatsapp: {
-          phoneNumberId: "123456789",
-          accessToken: "test-token",
-          verifyToken: "test-verify",
-          appSecret: "test-secret",
-        },
-      },
-      executeQuery: async () => ({
-        answer: "test",
-        sql: [],
-        data: [],
-        steps: 1,
-        usage: { totalTokens: 10 },
-      }),
-    });
-
-    const app = new Hono();
-    plugin.routes(app);
-
-    const res = await app.request("/webhooks/whatsapp", { method: "POST" });
-    expect(res.status).toBe(503);
-  });
-});
-
+// Removed (1.5.2 slice 2 / #2650): "whatsapp webhook route guard" — tested the pre-#2650
+// `adapters:` config contract which moved to AdapterRegistry env-var checks.
 // ---------------------------------------------------------------------------
 // Ephemeral error delivery
 // ---------------------------------------------------------------------------
@@ -3246,9 +1732,7 @@ describe("ephemeral error delivery", () => {
 
     // Default config: errorsAsEphemeral should be undefined (defaults to true)
     const result = ChatConfigSchema.safeParse({
-      adapters: {
-        slack: { botToken: "xoxb-test", signingSecret: "abcdef0123456789abcdef0123456789" },
-      },
+      catalog: SLACK_CATALOG,
       executeQuery: () => Promise.resolve({ answer: "", sql: [], data: [], steps: 0, usage: { totalTokens: 0 } }),
     });
 
@@ -3263,9 +1747,7 @@ describe("ephemeral error delivery", () => {
     const { ChatConfigSchema } = await import("./config");
 
     const result = ChatConfigSchema.safeParse({
-      adapters: {
-        slack: { botToken: "xoxb-test", signingSecret: "abcdef0123456789abcdef0123456789" },
-      },
+      catalog: SLACK_CATALOG,
       executeQuery: () => Promise.resolve({ answer: "", sql: [], data: [], steps: 0, usage: { totalTokens: 0 } }),
       ephemeral: { errorsAsEphemeral: false },
     });
@@ -3304,9 +1786,7 @@ describe("ProactiveConfig schema", () => {
     const { ChatConfigSchema } = await import("./config");
 
     const result = ChatConfigSchema.safeParse({
-      adapters: {
-        slack: { botToken: "xoxb-test", signingSecret: "abcdef0123456789abcdef0123456789" },
-      },
+      catalog: SLACK_CATALOG,
       executeQuery: () =>
         Promise.resolve({ answer: "", sql: [], data: [], steps: 0, usage: { totalTokens: 0 } }),
       proactive: {
@@ -3335,9 +1815,7 @@ describe("ProactiveConfig schema", () => {
     const { ChatConfigSchema } = await import("./config");
 
     const result = ChatConfigSchema.safeParse({
-      adapters: {
-        slack: { botToken: "xoxb-test", signingSecret: "abcdef0123456789abcdef0123456789" },
-      },
+      catalog: SLACK_CATALOG,
       executeQuery: () =>
         Promise.resolve({ answer: "", sql: [], data: [], steps: 0, usage: { totalTokens: 0 } }),
       proactive: {
@@ -3363,9 +1841,7 @@ describe("ProactiveConfig schema", () => {
     const { ChatConfigSchema } = await import("./config");
 
     const result = ChatConfigSchema.safeParse({
-      adapters: {
-        slack: { botToken: "xoxb-test", signingSecret: "abcdef0123456789abcdef0123456789" },
-      },
+      catalog: SLACK_CATALOG,
       executeQuery: () =>
         Promise.resolve({ answer: "", sql: [], data: [], steps: 0, usage: { totalTokens: 0 } }),
       proactive: {
@@ -3394,9 +1870,7 @@ describe("ProactiveConfig schema", () => {
     // with a kill-switch read path but no write path.
     const { ChatConfigSchema } = await import("./config");
     const result = ChatConfigSchema.safeParse({
-      adapters: {
-        slack: { botToken: "xoxb-test", signingSecret: "abcdef0123456789abcdef0123456789" },
-      },
+      catalog: SLACK_CATALOG,
       executeQuery: () =>
         Promise.resolve({ answer: "", sql: [], data: [], steps: 0, usage: { totalTokens: 0 } }),
       proactive: {
@@ -3426,9 +1900,7 @@ describe("ProactiveConfig schema", () => {
     // `collector` is rejected at the discriminated-union boundary.
     const { ChatConfigSchema } = await import("./config");
     const result = ChatConfigSchema.safeParse({
-      adapters: {
-        slack: { botToken: "xoxb-test", signingSecret: "abcdef0123456789abcdef0123456789" },
-      },
+      catalog: SLACK_CATALOG,
       executeQuery: () =>
         Promise.resolve({ answer: "", sql: [], data: [], steps: 0, usage: { totalTokens: 0 } }),
       proactive: {
@@ -3459,9 +1931,7 @@ describe("ProactiveConfig schema", () => {
     // shape did.
     const { ChatConfigSchema } = await import("./config");
     const result = ChatConfigSchema.safeParse({
-      adapters: {
-        slack: { botToken: "xoxb-test", signingSecret: "abcdef0123456789abcdef0123456789" },
-      },
+      catalog: SLACK_CATALOG,
       executeQuery: () =>
         Promise.resolve({ answer: "", sql: [], data: [], steps: 0, usage: { totalTokens: 0 } }),
       proactive: {
@@ -3515,8 +1985,7 @@ describe("sendDirectMessage contract", () => {
     };
     const bridge = createChatBridge(
       {
-        adapters: {},
-        executeQuery: async () => ({
+        catalog: [],        executeQuery: async () => ({
           answer: "", sql: [], data: [], steps: 0, usage: { totalTokens: 0 },
         }),
       },
@@ -3546,8 +2015,7 @@ describe("sendDirectMessage contract", () => {
     };
     const bridge = createChatBridge(
       {
-        adapters: {},
-        executeQuery: async () => ({
+        catalog: [],        executeQuery: async () => ({
           answer: "", sql: [], data: [], steps: 0, usage: { totalTokens: 0 },
         }),
       },
@@ -3584,8 +2052,7 @@ describe("sendDirectMessage contract", () => {
     };
     const bridge = createChatBridge(
       {
-        adapters: {},
-        executeQuery: async () => ({
+        catalog: [],        executeQuery: async () => ({
           answer: "", sql: [], data: [], steps: 0, usage: { totalTokens: 0 },
         }),
       },
@@ -3619,8 +2086,7 @@ describe("sendDirectMessage contract", () => {
     };
     const bridge = createChatBridge(
       {
-        adapters: {},
-        executeQuery: async () => ({
+        catalog: [],        executeQuery: async () => ({
           answer: "", sql: [], data: [], steps: 0, usage: { totalTokens: 0 },
         }),
       },
@@ -3651,8 +2117,7 @@ describe("sendDirectMessage contract", () => {
     };
     const bridge = createChatBridge(
       {
-        adapters: {},
-        executeQuery: async () => ({
+        catalog: [],        executeQuery: async () => ({
           answer: "", sql: [], data: [], steps: 0, usage: { totalTokens: 0 },
         }),
       },
@@ -3705,9 +2170,7 @@ describe("executeQuery context contract", () => {
     // + `rawMessage` to confirm they're typed as required (non-optional).
     const calls: Array<{ adapterName: string; rawTeamId: unknown }> = [];
     const plugin = chatPlugin({
-      adapters: {
-        slack: { botToken: "xoxb-test-token", signingSecret: "abcdef0123456789abcdef0123456789" },
-      },
+      catalog: SLACK_CATALOG,
       executeQuery: async (question, ctx) => {
         const raw = ctx.rawMessage as { team_id?: string } | undefined;
         calls.push({ adapterName: ctx.adapter.name, rawTeamId: raw?.team_id });

--- a/plugins/chat/src/config.ts
+++ b/plugins/chat/src/config.ts
@@ -37,6 +37,29 @@ import type { FeedbackCollectorFn } from "./proactive/feedback";
 /** A single message in a conversation thread. */
 export type ChatMessage = { role: "user" | "assistant"; content: string };
 
+/**
+ * Catalog entry shape the chat plugin's `AdapterRegistry` consumes
+ * (slice 2 of #2649). Mirrors the chat-relevant subset of `CatalogEntry`
+ * from `@atlas/api/lib/config` — kept local because the chat plugin
+ * can't import `@atlas/api` directly (separate package namespace).
+ *
+ * Hosts pass this through `chatPlugin({ catalog })`; the registry
+ * filters by `type === "chat"` so integration entries pass through
+ * harmlessly (they're owned by the LazyPluginLoader in slice 3).
+ */
+export interface ChatCatalogEntryInput {
+  /** Stable slug — `"slack"`, `"telegram"`, etc. */
+  readonly slug: string;
+  /** Admin-UI grouping. The registry skips non-chat entries. */
+  readonly type: "chat" | "integration";
+  /** Install-handler dispatch key. Only `"oauth"` activates in 1.5.2. */
+  readonly install_model: "oauth" | "form" | "static-bot";
+  /** Customer can install? Ops can flip false without removing the row. */
+  readonly enabled: boolean;
+  /** Visible to SaaS admin UI? (Used in slice 3; unused by AdapterRegistry.) */
+  readonly saas_eligible: boolean;
+}
+
 /** Canonical chat platform names supported by the bridge.
  *
  * The chat SDK's `Adapter` interface types `name` as a bare `string`
@@ -408,17 +431,23 @@ export interface FileUploadConfig {
 }
 
 export interface ChatPluginConfig {
-  /** Adapter credentials keyed by platform name. */
-  adapters: {
-    slack?: SlackAdapterConfig;
-    teams?: TeamsAdapterConfig;
-    discord?: DiscordAdapterConfig;
-    gchat?: GoogleChatAdapterConfig;
-    telegram?: TelegramAdapterConfig;
-    github?: GitHubAdapterConfig;
-    linear?: LinearAdapterConfig;
-    whatsapp?: WhatsAppAdapterConfig;
-  };
+  /**
+   * Catalog entries — the chat-type subset of `atlas.config.ts:catalog`
+   * (slice 2 of #2649). The host passes the chat-relevant entries here so
+   * `AdapterRegistry` can decide which adapters to instantiate at boot.
+   *
+   * In 1.5.2, only `install_model === "oauth"` chat entries instantiate
+   * — and the only OAuth chat platform Atlas ships today is Slack.
+   * Static-bot entries (Teams, Discord, gchat, Telegram, WhatsApp) ride
+   * along as `enabled: false` placeholders; their install handlers
+   * land in 1.5.3.
+   *
+   * Per-Platform credentials come from `process.env` (per CONTEXT.md
+   * "Operator vs Customer") — the plugin reads them inside
+   * `buildChatAdapterRegistry`. This config object intentionally does
+   * NOT carry credentials.
+   */
+  catalog?: ReadonlyArray<ChatCatalogEntryInput>;
 
   /** State backend configuration. Default: { backend: "memory" } */
   state?: StateConfig;
@@ -623,171 +652,14 @@ export interface ProactiveConfig {
 // Zod schema
 // ---------------------------------------------------------------------------
 
-// Slack tokens are lowercase `xox<letter>-` (xoxb- bot, xoxp- user, xoxe-
-// rotation-enabled). Case-sensitive so an uppercase-paste regression
-// fails at the schema boundary.
-const SLACK_TOKEN_REGEX = /^xox[a-z]/;
-// Slack signing secrets are 32-char lowercase hex (Slack's actual format).
-const SLACK_SIGNING_SECRET_REGEX = /^[0-9a-f]{32}$/;
-
-const SlackAdapterSchema = z.object({
-  // Regex'd so placeholder strings (multi-workspace deploys) fail at
-  // boot rather than at the first Slack API call.
-  botToken: z.string().min(1, "slack botToken must not be empty").regex(
-    SLACK_TOKEN_REGEX,
-    "slack botToken must start with 'xox' (e.g. 'xoxb-…'). Multi-workspace deploys should omit this field instead of supplying a placeholder.",
-  ).optional(),
-  signingSecret: z.string().min(1, "slack signingSecret must not be empty").regex(
-    SLACK_SIGNING_SECRET_REGEX,
-    "slack signingSecret must be a 32-character lowercase hex string (from your Slack app's Basic Information page). Placeholder strings are rejected.",
-  ),
-  clientId: z.string().min(1).optional(),
-  clientSecret: z.string().min(1).optional(),
-  // AES-256-GCM key for at-rest encryption of bot tokens persisted in
-  // `chat_cache` (post-#2634 consolidation). Passed through to
-  // `@chat-adapter/slack`'s `encryptionKey` option — when set, persisted
-  // installation `botToken` fields land as `{ iv, data, tag }` JSONB
-  // envelopes instead of plaintext. 32 raw bytes encoded as either a
-  // 64-char hex string or a 44-char base64 string; the adapter's
-  // `decodeKey` rejects any other length at boot. Optional — omitting
-  // it (and `SLACK_ENCRYPTION_KEY`) is the legitimate self-hosted
-  // single-user posture, matching the chat-adapter's own default.
-  encryptionKey: z.string().min(1).optional(),
-}).strict().refine(
-  (s) => (s.clientId == null) === (s.clientSecret == null),
-  "clientId and clientSecret must both be provided for OAuth",
-);
-
-const TeamsAdapterSchema = z.object({
-  appId: z.string().min(1, "teams appId must not be empty"),
-  appPassword: z.string().min(1, "teams appPassword must not be empty"),
-  tenantId: z.string().min(1).optional(),
-}).strict();
-
-const DiscordAdapterSchema = z.object({
-  botToken: z.string().min(1, "discord botToken must not be empty"),
-  applicationId: z.string().min(1, "discord applicationId must not be empty"),
-  publicKey: z.string().regex(/^[0-9a-f]{64}$/i, "discord publicKey must be a 64-character hex string (Ed25519 public key from Discord Developer Portal)"),
-  mentionRoleIds: z.array(z.string().min(1)).optional(),
-}).strict();
-
-const TelegramAdapterSchema = z.object({
-  botToken: z.string().min(1, "telegram botToken must not be empty").regex(
-    /^\d+:[A-Za-z0-9_-]{20,}$/,
-    "telegram botToken must be in format '<bot-id>:<secret>' from BotFather",
-  ),
-  secretToken: z.string().min(1).optional(),
-}).strict();
-
-const GitHubAdapterSchema = z.object({
-  token: z.string().min(1, "github token must not be empty").optional(),
-  appId: z.string().min(1, "github appId must not be empty").optional(),
-  privateKey: z.string().min(1, "github privateKey must not be empty").optional(),
-  installationId: z.number().int().positive("github installationId must be a positive integer").optional(),
-  webhookSecret: z.string().min(1, "github webhookSecret must not be empty").optional(),
-  userName: z.string().min(1, "github userName must not be empty").optional(),
-}).strict().superRefine((c, ctx) => {
-  if (c.token && c.appId) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      message: "Cannot provide both token (PAT) and appId (GitHub App) — choose one auth mode",
-    });
-  }
-  if (c.appId && !c.privateKey) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      message: "appId requires privateKey for GitHub App auth",
-      path: ["privateKey"],
-    });
-  }
-  if (!c.appId && c.privateKey) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      message: "privateKey requires appId for GitHub App auth",
-      path: ["appId"],
-    });
-  }
-  if (c.installationId && !c.appId) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      message: "installationId requires appId — it is only used with GitHub App auth",
-      path: ["installationId"],
-    });
-  }
-  if (!c.token && !c.appId) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      message: "Provide either token (PAT) or appId + privateKey (GitHub App) — at least one credential path is required",
-    });
-  }
-});
-
-const LinearAdapterSchema = z.object({
-  apiKey: z.string().min(1, "linear apiKey must not be empty").optional(),
-  accessToken: z.string().min(1, "linear accessToken must not be empty").optional(),
-  clientId: z.string().min(1, "linear clientId must not be empty").optional(),
-  clientSecret: z.string().min(1, "linear clientSecret must not be empty").optional(),
-  webhookSecret: z.string().min(1, "linear webhookSecret must not be empty").optional(),
-  userName: z.string().min(1, "linear userName must not be empty").optional(),
-}).strict().superRefine((c, ctx) => {
-  const modes = [c.apiKey, c.accessToken, c.clientId].filter(Boolean).length;
-  if (modes > 1) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      message: "Provide exactly one auth mode: apiKey, accessToken, or clientId + clientSecret",
-    });
-  }
-  if (c.clientId && !c.clientSecret) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      message: "clientId requires clientSecret for OAuth App auth",
-      path: ["clientSecret"],
-    });
-  }
-  if (!c.clientId && c.clientSecret) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      message: "clientSecret requires clientId for OAuth App auth",
-      path: ["clientId"],
-    });
-  }
-  if (!c.apiKey && !c.accessToken && !c.clientId) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      message: "Provide apiKey, accessToken, or clientId + clientSecret — at least one credential path is required",
-    });
-  }
-});
-
-const WhatsAppAdapterSchema = z.object({
-  phoneNumberId: z.string().min(1, "whatsapp phoneNumberId must not be empty"),
-  accessToken: z.string().min(1, "whatsapp accessToken must not be empty"),
-  verifyToken: z.string().min(1, "whatsapp verifyToken must not be empty"),
-  appSecret: z.string().min(1, "whatsapp appSecret must not be empty"),
-  userName: z.string().min(1).optional(),
-  apiVersion: z.string().regex(
-    /^v\d+\.\d+$/,
-    "whatsapp apiVersion must be in format 'vN.N' (e.g. 'v21.0')",
-  ).optional(),
-}).strict();
-
-const GoogleChatAdapterSchema = z.object({
-  credentials: z.object({
-    client_email: z.string().email("gchat credentials.client_email must be a valid email"),
-    private_key: z.string().min(1, "gchat credentials.private_key must not be empty"),
-    project_id: z.string().min(1).optional(),
-  }).optional(),
-  useApplicationDefaultCredentials: z.literal(true).optional(),
-  endpointUrl: z.string().url("gchat endpointUrl must be a valid URL").optional(),
-  pubsubTopic: z.string().regex(
-    /^projects\/[^/]+\/topics\/[^/]+$/,
-    "gchat pubsubTopic must be in format 'projects/{project}/topics/{topic}'",
-  ).optional(),
-  impersonateUser: z.string().email("gchat impersonateUser must be a valid email").optional(),
-}).strict().refine(
-  (c) => !(c.credentials != null && c.useApplicationDefaultCredentials === true),
-  "Provide either credentials or useApplicationDefaultCredentials, not both (or omit both for env-var auto-detection)",
-);
+// Per-Platform Zod adapter-credential schemas were removed in #2650
+// slice 2 of 1.5.2 — chat-adapter activation moved to the catalog +
+// env-var seam (`AdapterRegistry`), so the per-Platform schemas no
+// longer ran anywhere. The TypeScript types (`SlackAdapterConfig`,
+// `TeamsAdapterConfig`, etc.) above stay because the per-Platform
+// adapter factories under `./adapters/<platform>.ts` still take them.
+// 1.5.3 will reintroduce per-Platform Zod schemas as the static-bot
+// install-handler form-input validators when those handlers land.
 
 const StateConfigSchema = z
   .object({
@@ -1004,23 +876,26 @@ const ProactiveConfigSchema = z
   .strict()
   .optional();
 
-export const ChatConfigSchema = z.object({
-  adapters: z
-    .object({
-      slack: SlackAdapterSchema.optional(),
-      teams: TeamsAdapterSchema.optional(),
-      discord: DiscordAdapterSchema.optional(),
-      gchat: GoogleChatAdapterSchema.optional(),
-      telegram: TelegramAdapterSchema.optional(),
-      github: GitHubAdapterSchema.optional(),
-      linear: LinearAdapterSchema.optional(),
-      whatsapp: WhatsAppAdapterSchema.optional(),
-    })
-    .strict()
-    .refine(
-      (a) => Object.values(a).some((v) => v !== undefined),
-      "At least one adapter must be configured",
+const ChatCatalogEntrySchema = z
+  .object({
+    slug: z.string().regex(
+      /^[a-z][a-z0-9-]*$/,
+      "catalog entry slug must be lowercase alphanumeric with dashes",
     ),
+    type: z.enum(["chat", "integration"]),
+    install_model: z.enum(["oauth", "form", "static-bot"]),
+    enabled: z.boolean(),
+    saas_eligible: z.boolean(),
+  })
+  .strict();
+
+export const ChatConfigSchema = z.object({
+  // Catalog declaration (1.5.2 slice 2 — #2650). Optional at the schema
+  // boundary so the chat plugin can boot in self-host without a catalog
+  // (no chat adapters will activate; the plugin reports unhealthy via
+  // healthCheck). The host typically passes `config.catalog` straight
+  // through from `atlas.config.ts:catalog`.
+  catalog: z.array(ChatCatalogEntrySchema).optional(),
   state: StateConfigSchema,
   slashCommandName: z
     .string()

--- a/plugins/chat/src/features/reactions.test.ts
+++ b/plugins/chat/src/features/reactions.test.ts
@@ -314,8 +314,19 @@ describe("ChatConfigSchema reactions field", () => {
   // Import here to avoid circular deps affecting other test groups
   const { ChatConfigSchema } = require("../config");
 
+  // Post-#2650 (slice 2 of 1.5.2): chat-adapter activation moved from
+  // `adapters: { slack: {...} }` to `catalog: [...]`. AdapterRegistry tests
+  // in `../adapter-registry.test.ts` cover the env-var credential layer.
   const baseConfig = {
-    adapters: { slack: { botToken: "xoxb-test", signingSecret: "abcdef0123456789abcdef0123456789" } },
+    catalog: [
+      {
+        slug: "slack",
+        type: "chat" as const,
+        install_model: "oauth" as const,
+        enabled: true,
+        saas_eligible: true,
+      },
+    ],
     executeQuery: () => Promise.resolve({ answer: "", sql: [], data: [], steps: 0, usage: { totalTokens: 0 } }),
   };
 

--- a/plugins/chat/src/index.ts
+++ b/plugins/chat/src/index.ts
@@ -215,6 +215,16 @@ function buildChatPlugin(
   let slackAdapterInstance: SlackAdapter | null = null;
   let log: PluginLogger | null = null;
   let initialized = false;
+  /**
+   * Captured from `buildChatAdapterRegistry` at init so `healthCheck`
+   * and the OAuth-install route handler can surface actionable
+   * "operator misconfig" messages instead of the generic "not
+   * initialized" one. Empty until `initialize` runs.
+   */
+  let adapterDiagnostics: {
+    unrecognizedSlugs: ReadonlyArray<string>;
+    missingCredSlugs: ReadonlyArray<string>;
+  } = { unrecognizedSlugs: [], missingCredSlugs: [] };
 
   if (typeof config.executeQuery !== "function") {
     throw new Error("executeQuery callback is required and must be a function");
@@ -286,8 +296,23 @@ function buildChatPlugin(
         // `config.adapters.slack.clientId` field.
         {
           app.get("/oauth/slack/install", async (c) => {
-            if (!slackAdapterInstance || !stateAdapter) {
+            // Distinguish "plugin still booting" (transient — retry)
+            // from "adapter never instantiated due to missing creds"
+            // (terminal — operator must fix env vars). The diagnostic
+            // is captured by AdapterRegistry at init time.
+            if (!stateAdapter || !initialized) {
               return c.json({ error: "Chat plugin not yet initialized" }, 503);
+            }
+            if (!slackAdapterInstance) {
+              const missingCreds = adapterDiagnostics.missingCredSlugs.includes("slack");
+              return c.json(
+                {
+                  error: missingCreds
+                    ? "Slack OAuth not configured — required env vars missing (SLACK_CLIENT_ID / SLACK_CLIENT_SECRET / SLACK_SIGNING_SECRET / SLACK_ENCRYPTION_KEY)"
+                    : "Slack adapter not registered — check `catalog` declaration in atlas.config.ts",
+                },
+                500,
+              );
             }
 
             const clientId = process.env.SLACK_CLIENT_ID;
@@ -317,8 +342,19 @@ function buildChatPlugin(
           });
 
           app.get("/oauth/slack/callback", async (c) => {
-            if (!slackAdapterInstance || !stateAdapter) {
+            if (!stateAdapter || !initialized) {
               return c.json({ error: "Chat plugin not yet initialized" }, 503);
+            }
+            if (!slackAdapterInstance) {
+              const missingCreds = adapterDiagnostics.missingCredSlugs.includes("slack");
+              return c.json(
+                {
+                  error: missingCreds
+                    ? "Slack OAuth not configured — required env vars missing"
+                    : "Slack adapter not registered — check `catalog` declaration",
+                },
+                500,
+              );
             }
 
             const state = c.req.query("state");
@@ -396,17 +432,19 @@ function buildChatPlugin(
       stateAdapter = adapter;
 
       // Build chat-platform adapters via the catalog-driven
-      // AdapterRegistry (#2650 slice 2). Only Slack instantiates in
-      // 1.5.2 — the registry uses `process.env` for per-Platform
-      // credentials, logs warns on missing creds / non-OAuth entries,
-      // and returns `{ slack: null }` when nothing wires.
+      // AdapterRegistry (#2650 slice 2). The registry reads per-Platform
+      // credentials from `process.env`, logs warns on missing creds /
+      // non-OAuth entries, and returns the adapters map plus diagnostic
+      // slug lists. The diagnostics let `healthCheck` and the OAuth
+      // install handler surface actionable error messages.
       try {
         const registry = buildChatAdapterRegistry({
           catalog: (config.catalog ?? []) as ReadonlyArray<ChatCatalogEntry>,
           env: process.env,
           logger: ctx.logger,
         });
-        slackAdapterInstance = registry.slack;
+        slackAdapterInstance = registry.adapters.slack ?? null;
+        adapterDiagnostics = registry.diagnostics;
 
         // Bridge takes pre-built instances per-platform; non-Slack slots
         // are left `undefined` (the bridge tolerates this — see
@@ -462,10 +500,33 @@ function buildChatPlugin(
       if (slackAdapterInstance) enabledAdapters.push("slack");
 
       if (enabledAdapters.length === 0) {
+        // Use the diagnostics captured at init to point operators at the
+        // actual cause: a catalog row referencing an unknown slug, or a
+        // recognized slug whose env vars are missing.
+        const parts = [
+          "No chat adapters registered.",
+        ];
+        if (adapterDiagnostics.missingCredSlugs.length > 0) {
+          parts.push(
+            `Missing env vars for: ${adapterDiagnostics.missingCredSlugs.join(", ")}.`,
+          );
+        }
+        if (adapterDiagnostics.unrecognizedSlugs.length > 0) {
+          parts.push(
+            `Unknown slugs in catalog: ${adapterDiagnostics.unrecognizedSlugs.join(", ")}.`,
+          );
+        }
+        if (
+          adapterDiagnostics.missingCredSlugs.length === 0 &&
+          adapterDiagnostics.unrecognizedSlugs.length === 0
+        ) {
+          parts.push(
+            "No chat-type catalog entries declared in atlas.config.ts (or all are disabled / non-OAuth).",
+          );
+        }
         return {
           healthy: false,
-          message:
-            "No chat adapters registered — check `catalog` declaration in atlas.config.ts and per-Platform env vars",
+          message: parts.join(" "),
           latencyMs: Math.round(performance.now() - start),
         };
       }

--- a/plugins/chat/src/index.ts
+++ b/plugins/chat/src/index.ts
@@ -2,8 +2,12 @@
  * Atlas Chat SDK Bridge Plugin.
  *
  * Bridges vercel/chat (Chat SDK) into the Atlas plugin system as a unified
- * interaction layer. Supports Slack, Teams, Discord, Google Chat, Telegram,
- * GitHub, Linear, and WhatsApp.
+ * interaction layer. Adapter activation is driven by `atlas.config.ts:catalog`
+ * + per-Platform env vars (slice 2 of #2649 — issue #2650). Slack is the
+ * only OAuth chat Platform that instantiates in 1.5.2; the other adapters
+ * (Teams, Discord, gchat, Telegram, GitHub, Linear, WhatsApp) ride along
+ * as catalog placeholders and wire up in 1.5.3 once `StaticBotInstallHandler`
+ * lands.
  *
  * Replaces the standalone `@useatlas/slack` and `@useatlas/teams` plugins
  * with a unified Chat SDK adapter approach. See the migration guide in README.md.
@@ -14,44 +18,15 @@
  * import { chatPlugin } from "@useatlas/chat";
  *
  * export default defineConfig({
+ *   // Operator declares supported Platforms + integrations. Per-Platform
+ *   // credentials live in env vars (SLACK_CLIENT_ID etc.).
+ *   catalog: [
+ *     { slug: "slack", type: "chat", install_model: "oauth", enabled: true },
+ *   ],
  *   plugins: [
  *     chatPlugin({
- *       adapters: {
- *         slack: {
- *           botToken: process.env.SLACK_BOT_TOKEN!,
- *           signingSecret: process.env.SLACK_SIGNING_SECRET!,
- *         },
- *         teams: {
- *           appId: process.env.TEAMS_APP_ID!,
- *           appPassword: process.env.TEAMS_APP_PASSWORD!,
- *         },
- *         discord: {
- *           botToken: process.env.DISCORD_BOT_TOKEN!,
- *           applicationId: process.env.DISCORD_APPLICATION_ID!,
- *           publicKey: process.env.DISCORD_PUBLIC_KEY!,
- *         },
- *         gchat: {
- *           credentials: JSON.parse(process.env.GOOGLE_CHAT_CREDENTIALS!),
- *         },
- *         telegram: {
- *           botToken: process.env.TELEGRAM_BOT_TOKEN!,
- *         },
- *         github: {
- *           appId: process.env.GITHUB_APP_ID!,
- *           privateKey: process.env.GITHUB_PRIVATE_KEY!,
- *           webhookSecret: process.env.GITHUB_WEBHOOK_SECRET!,
- *         },
- *         linear: {
- *           apiKey: process.env.LINEAR_API_KEY!,
- *           webhookSecret: process.env.LINEAR_WEBHOOK_SECRET!,
- *         },
- *         whatsapp: {
- *           phoneNumberId: process.env.WHATSAPP_PHONE_NUMBER_ID!,
- *           accessToken: process.env.WHATSAPP_ACCESS_TOKEN!,
- *           verifyToken: process.env.WHATSAPP_VERIFY_TOKEN!,
- *           appSecret: process.env.WHATSAPP_APP_SECRET!,
- *         },
- *       },
+ *       // No `adapters:` field — the plugin reads `catalog` from the
+ *       // host's resolved config and `process.env` for credentials.
  *       executeQuery: myQueryFunction,
  *     }),
  *   ],
@@ -61,14 +36,6 @@
 
 import type { StateAdapter } from "chat";
 import type { SlackAdapter } from "@chat-adapter/slack";
-import type { TeamsAdapter } from "@chat-adapter/teams";
-import type { DiscordAdapter } from "@chat-adapter/discord";
-import type { GoogleChatAdapter } from "@chat-adapter/gchat";
-import type { TelegramAdapter } from "@chat-adapter/telegram";
-import type { GitHubAdapter } from "@chat-adapter/github";
-import type { LinearAdapter } from "@chat-adapter/linear";
-import type { WhatsAppAdapter } from "@chat-adapter/whatsapp";
-import type { Context } from "hono";
 import { createPlugin } from "@useatlas/plugin-sdk";
 import type {
   AtlasInteractionPlugin,
@@ -77,17 +44,11 @@ import type {
   PluginLogger,
 } from "@useatlas/plugin-sdk";
 import { ChatConfigSchema } from "./config";
-import type { ChatPluginConfig } from "./config";
+import type { ChatCatalogEntryInput, ChatPluginConfig } from "./config";
 import { createChatBridge } from "./bridge";
 import type { ChatBridge } from "./bridge";
-import { createSlackAdapter } from "./adapters/slack";
-import { createTeamsAdapter } from "./adapters/teams";
-import { createDiscordAdapter } from "./adapters/discord";
-import { createGoogleChatAdapter } from "./adapters/gchat";
-import { createTelegramAdapter } from "./adapters/telegram";
-import { createGitHubAdapter } from "./adapters/github";
-import { createLinearAdapter } from "./adapters/linear";
-import { createWhatsAppAdapter } from "./adapters/whatsapp";
+import { buildChatAdapterRegistry } from "./adapter-registry";
+import type { ChatCatalogEntry } from "./adapter-registry";
 import { createStateAdapter } from "./state";
 
 // Re-export types for host wiring convenience
@@ -223,25 +184,43 @@ export type { DataTableCardProps } from "./cards/data-table-card";
 // Plugin builder
 // ---------------------------------------------------------------------------
 
+/**
+ * Predicate the routes() block uses to decide whether to mount the
+ * Slack webhook + OAuth routes. Catalog-driven (post-#2650 slice 2) —
+ * mirrors the AdapterRegistry's filter chain, but runs at route-
+ * registration time, before initialize() has built the actual adapter.
+ *
+ * The runtime check (`if (!slackAdapterInstance) return 503`) inside the
+ * route handler is the second gate — it guards against an env-var
+ * misconfig where the catalog says "Slack OAuth" but creds are missing.
+ */
+function catalogHasSlackOauth(
+  catalog: ReadonlyArray<ChatCatalogEntryInput> | undefined,
+): boolean {
+  if (!catalog) return false;
+  return catalog.some(
+    (e) =>
+      e.slug === "slack" &&
+      e.type === "chat" &&
+      e.install_model === "oauth" &&
+      e.enabled === true,
+  );
+}
+
 function buildChatPlugin(
   config: ChatPluginConfig,
 ): AtlasInteractionPlugin<ChatPluginConfig> {
   let bridge: ChatBridge | null = null;
   let stateAdapter: StateAdapter | null = null;
   let slackAdapterInstance: SlackAdapter | null = null;
-  let teamsAdapterInstance: TeamsAdapter | null = null;
-  let discordAdapterInstance: DiscordAdapter | null = null;
-  let gchatAdapterInstance: GoogleChatAdapter | null = null;
-  let telegramAdapterInstance: TelegramAdapter | null = null;
-  let githubAdapterInstance: GitHubAdapter | null = null;
-  let linearAdapterInstance: LinearAdapter | null = null;
-  let whatsappAdapterInstance: WhatsAppAdapter | null = null;
   let log: PluginLogger | null = null;
   let initialized = false;
 
   if (typeof config.executeQuery !== "function") {
     throw new Error("executeQuery callback is required and must be a function");
   }
+
+  const slackOauthDeclared = catalogHasSlackOauth(config.catalog);
 
   return {
     id: "chat-interaction",
@@ -254,7 +233,18 @@ function buildChatPlugin(
       // Mount Chat SDK webhook handlers under the plugin route prefix.
       // The bridge is created during initialize() — routes that arrive
       // before initialization return 503.
-      if (config.adapters.slack) {
+      //
+      // Post-#2650 (slice 2 of 1.5.2): the route gate is the catalog
+      // declaration, not the old `config.adapters.slack` field. The
+      // AdapterRegistry resolves the actual adapter instance inside
+      // initialize() — if the env vars are missing, the runtime
+      // `if (!slackAdapterInstance)` check below returns 503.
+      //
+      // Non-Slack chat platforms are intentionally not mounted in 1.5.2
+      // — their `install_model === "static-bot"` catalog rows are
+      // placeholders; their event-loop wiring lands in 1.5.3 alongside
+      // `StaticBotInstallHandler`.
+      if (slackOauthDeclared) {
         app.post("/webhooks/slack", async (c) => {
           if (!bridge) {
             return c.json({ error: "Chat plugin not yet initialized" }, 503);
@@ -288,14 +278,25 @@ function buildChatPlugin(
           }
         });
 
-        // OAuth routes — only if clientId is configured
-        if (config.adapters.slack.clientId) {
+        // OAuth routes — always mounted when Slack OAuth is declared in
+        // the catalog. The runtime check inside the handler verifies the
+        // adapter actually initialized (i.e. env vars were present and
+        // `createSlackAdapter` succeeded); the client_id is read from
+        // `process.env.SLACK_CLIENT_ID` rather than the old
+        // `config.adapters.slack.clientId` field.
+        {
           app.get("/oauth/slack/install", async (c) => {
             if (!slackAdapterInstance || !stateAdapter) {
               return c.json({ error: "Chat plugin not yet initialized" }, 503);
             }
 
-            const clientId = config.adapters.slack!.clientId!;
+            const clientId = process.env.SLACK_CLIENT_ID;
+            if (!clientId) {
+              return c.json(
+                { error: "Slack OAuth not configured — SLACK_CLIENT_ID is unset" },
+                500,
+              );
+            }
             const scopes = "commands,chat:write,app_mentions:read";
             const state = crypto.randomUUID();
 
@@ -370,248 +371,12 @@ function buildChatPlugin(
         }
       }
 
-      if (config.adapters.teams) {
-        app.post("/webhooks/teams", async (c) => {
-          if (!bridge) {
-            return c.json({ error: "Chat plugin not yet initialized" }, 503);
-          }
-
-          const handler = bridge.webhooks.teams;
-          if (!handler) {
-            return c.json({ error: "Teams adapter not configured" }, 404);
-          }
-
-          const requestId = crypto.randomUUID();
-          try {
-            const response = await handler(c.req.raw, {
-              waitUntil: (task: Promise<unknown>) => {
-                task.catch((err: unknown) => {
-                  (log ?? console).error(
-                    { err: err instanceof Error ? err : new Error(String(err)), requestId, adapter: "teams" },
-                    "Chat SDK Teams webhook background task failed",
-                  );
-                });
-              },
-            });
-            return response;
-          } catch (err) {
-            (log ?? console).error(
-              { err: err instanceof Error ? err : new Error(String(err)), requestId, adapter: "teams" },
-              "Teams webhook handler threw unexpectedly",
-            );
-            return c.json({ error: "Webhook processing failed", requestId }, 500);
-          }
-        });
-      }
-
-      if (config.adapters.discord) {
-        app.post("/webhooks/discord", async (c) => {
-          if (!bridge) {
-            return c.json({ error: "Chat plugin not yet initialized" }, 503);
-          }
-
-          const handler = bridge.webhooks.discord;
-          if (!handler) {
-            return c.json({ error: "Discord adapter not configured" }, 404);
-          }
-
-          const requestId = crypto.randomUUID();
-          try {
-            const response = await handler(c.req.raw, {
-              waitUntil: (task: Promise<unknown>) => {
-                task.catch((err: unknown) => {
-                  (log ?? console).error(
-                    { err: err instanceof Error ? err : new Error(String(err)), requestId, adapter: "discord" },
-                    "Chat SDK Discord webhook background task failed",
-                  );
-                });
-              },
-            });
-            return response;
-          } catch (err) {
-            (log ?? console).error(
-              { err: err instanceof Error ? err : new Error(String(err)), requestId, adapter: "discord" },
-              "Discord webhook handler threw unexpectedly",
-            );
-            return c.json({ error: "Webhook processing failed", requestId }, 500);
-          }
-        });
-      }
-
-      if (config.adapters.gchat) {
-        app.post("/webhooks/gchat", async (c) => {
-          if (!bridge) {
-            return c.json({ error: "Chat plugin not yet initialized" }, 503);
-          }
-
-          const handler = bridge.webhooks.gchat;
-          if (!handler) {
-            return c.json({ error: "Google Chat adapter not configured" }, 404);
-          }
-
-          const requestId = crypto.randomUUID();
-          try {
-            const response = await handler(c.req.raw, {
-              waitUntil: (task: Promise<unknown>) => {
-                task.catch((err: unknown) => {
-                  (log ?? console).error(
-                    { err: err instanceof Error ? err : new Error(String(err)), requestId, adapter: "gchat" },
-                    "Chat SDK Google Chat webhook background task failed",
-                  );
-                });
-              },
-            });
-            return response;
-          } catch (err) {
-            (log ?? console).error(
-              { err: err instanceof Error ? err : new Error(String(err)), requestId, adapter: "gchat" },
-              "Google Chat webhook handler threw unexpectedly",
-            );
-            return c.json({ error: "Webhook processing failed", requestId }, 500);
-          }
-        });
-      }
-
-      if (config.adapters.telegram) {
-        app.post("/webhooks/telegram", async (c) => {
-          if (!bridge) {
-            return c.json({ error: "Chat plugin not yet initialized" }, 503);
-          }
-
-          const handler = bridge.webhooks.telegram;
-          if (!handler) {
-            return c.json({ error: "Telegram adapter not configured" }, 404);
-          }
-
-          const requestId = crypto.randomUUID();
-          try {
-            const response = await handler(c.req.raw, {
-              waitUntil: (task: Promise<unknown>) => {
-                task.catch((err: unknown) => {
-                  (log ?? console).error(
-                    { err: err instanceof Error ? err : new Error(String(err)), requestId, adapter: "telegram" },
-                    "Chat SDK Telegram webhook background task failed",
-                  );
-                });
-              },
-            });
-            return response;
-          } catch (err) {
-            (log ?? console).error(
-              { err: err instanceof Error ? err : new Error(String(err)), requestId, adapter: "telegram" },
-              "Telegram webhook handler threw unexpectedly",
-            );
-            return c.json({ error: "Webhook processing failed", requestId }, 500);
-          }
-        });
-      }
-
-      if (config.adapters.github) {
-        app.post("/webhooks/github", async (c) => {
-          if (!bridge) {
-            return c.json({ error: "Chat plugin not yet initialized" }, 503);
-          }
-
-          const handler = bridge.webhooks.github;
-          if (!handler) {
-            return c.json({ error: "GitHub adapter not configured" }, 404);
-          }
-
-          const requestId = crypto.randomUUID();
-          try {
-            const response = await handler(c.req.raw, {
-              waitUntil: (task: Promise<unknown>) => {
-                task.catch((err: unknown) => {
-                  (log ?? console).error(
-                    { err: err instanceof Error ? err : new Error(String(err)), requestId, adapter: "github" },
-                    "Chat SDK GitHub webhook background task failed",
-                  );
-                });
-              },
-            });
-            return response;
-          } catch (err) {
-            (log ?? console).error(
-              { err: err instanceof Error ? err : new Error(String(err)), requestId, adapter: "github" },
-              "GitHub webhook handler threw unexpectedly",
-            );
-            return c.json({ error: "Webhook processing failed", requestId }, 500);
-          }
-        });
-      }
-
-      if (config.adapters.linear) {
-        app.post("/webhooks/linear", async (c) => {
-          if (!bridge) {
-            return c.json({ error: "Chat plugin not yet initialized" }, 503);
-          }
-
-          const handler = bridge.webhooks.linear;
-          if (!handler) {
-            return c.json({ error: "Linear adapter not configured" }, 404);
-          }
-
-          const requestId = crypto.randomUUID();
-          try {
-            const response = await handler(c.req.raw, {
-              waitUntil: (task: Promise<unknown>) => {
-                task.catch((err: unknown) => {
-                  (log ?? console).error(
-                    { err: err instanceof Error ? err : new Error(String(err)), requestId, adapter: "linear" },
-                    "Chat SDK Linear webhook background task failed",
-                  );
-                });
-              },
-            });
-            return response;
-          } catch (err) {
-            (log ?? console).error(
-              { err: err instanceof Error ? err : new Error(String(err)), requestId, adapter: "linear" },
-              "Linear webhook handler threw unexpectedly",
-            );
-            return c.json({ error: "Webhook processing failed", requestId }, 500);
-          }
-        });
-      }
-
-      if (config.adapters.whatsapp) {
-        // WhatsApp needs both GET (Meta verification challenge) and POST (events).
-        // The Chat SDK adapter's handleWebhook() dispatches on HTTP method internally.
-        const handleWhatsApp = async (c: Context) => {
-          if (!bridge) {
-            return c.json({ error: "Chat plugin not yet initialized" }, 503);
-          }
-
-          const handler = bridge.webhooks.whatsapp;
-          if (!handler) {
-            return c.json({ error: "WhatsApp adapter not configured" }, 404);
-          }
-
-          const requestId = crypto.randomUUID();
-          try {
-            const response = await handler(c.req.raw, {
-              waitUntil: (task: Promise<unknown>) => {
-                task.catch((err: unknown) => {
-                  (log ?? console).error(
-                    { err: err instanceof Error ? err : new Error(String(err)), requestId, adapter: "whatsapp" },
-                    "Chat SDK WhatsApp webhook background task failed",
-                  );
-                });
-              },
-            });
-            return response;
-          } catch (err) {
-            (log ?? console).error(
-              { err: err instanceof Error ? err : new Error(String(err)), requestId, adapter: "whatsapp" },
-              "WhatsApp webhook handler threw unexpectedly",
-            );
-            return c.json({ error: "Webhook processing failed", requestId }, 500);
-          }
-        };
-
-        app.get("/webhooks/whatsapp", handleWhatsApp);
-        app.post("/webhooks/whatsapp", handleWhatsApp);
-      }
+      // Non-Slack chat Platform webhook routes are intentionally not
+      // mounted in 1.5.2 (#2650 AC). Their adapters don't instantiate
+      // until 1.5.3 when `StaticBotInstallHandler` lands; mounting their
+      // routes pre-handler would let webhooks accumulate without a
+      // bridge to consume them. The route paths themselves
+      // (/webhooks/teams etc.) are reserved for future activation.
     },
 
     async initialize(ctx: AtlasPluginContext) {
@@ -630,63 +395,26 @@ function buildChatPlugin(
       await adapter.connect();
       stateAdapter = adapter;
 
-      // Create platform adapters — wrap in try-catch to disconnect
-      // the state adapter if adapter creation or bridge setup fails.
-      const adapterInstances: {
-        slack?: SlackAdapter | null;
-        teams?: TeamsAdapter | null;
-        discord?: DiscordAdapter | null;
-        gchat?: GoogleChatAdapter | null;
-        telegram?: TelegramAdapter | null;
-        github?: GitHubAdapter | null;
-        linear?: LinearAdapter | null;
-        whatsapp?: WhatsAppAdapter | null;
-      } = {};
+      // Build chat-platform adapters via the catalog-driven
+      // AdapterRegistry (#2650 slice 2). Only Slack instantiates in
+      // 1.5.2 — the registry uses `process.env` for per-Platform
+      // credentials, logs warns on missing creds / non-OAuth entries,
+      // and returns `{ slack: null }` when nothing wires.
       try {
-        if (config.adapters.slack) {
-          slackAdapterInstance = createSlackAdapter(config.adapters.slack) as SlackAdapter;
-          adapterInstances.slack = slackAdapterInstance;
-        }
-        if (config.adapters.teams) {
-          teamsAdapterInstance = createTeamsAdapter(config.adapters.teams) as TeamsAdapter;
-          adapterInstances.teams = teamsAdapterInstance;
-        }
-        if (config.adapters.discord) {
-          discordAdapterInstance = createDiscordAdapter(config.adapters.discord) as DiscordAdapter;
-          adapterInstances.discord = discordAdapterInstance;
-        }
-        if (config.adapters.gchat) {
-          gchatAdapterInstance = createGoogleChatAdapter(config.adapters.gchat) as GoogleChatAdapter;
-          adapterInstances.gchat = gchatAdapterInstance;
-        }
-        if (config.adapters.telegram) {
-          telegramAdapterInstance = createTelegramAdapter(config.adapters.telegram) as TelegramAdapter;
-          adapterInstances.telegram = telegramAdapterInstance;
-        }
-        if (config.adapters.github) {
-          if (!config.adapters.github.webhookSecret) {
-            ctx.logger.warn(
-              "GitHub adapter configured without webhookSecret — webhook endpoint will accept unauthenticated requests. Set webhookSecret for production deployments.",
-            );
-          }
-          githubAdapterInstance = createGitHubAdapter(config.adapters.github) as GitHubAdapter;
-          adapterInstances.github = githubAdapterInstance;
-        }
-        if (config.adapters.linear) {
-          if (!config.adapters.linear.webhookSecret) {
-            ctx.logger.warn(
-              "Linear adapter configured without webhookSecret — webhook endpoint will accept unauthenticated requests. Set webhookSecret for production deployments.",
-            );
-          }
-          linearAdapterInstance = createLinearAdapter(config.adapters.linear) as LinearAdapter;
-          adapterInstances.linear = linearAdapterInstance;
-        }
-        if (config.adapters.whatsapp) {
-          whatsappAdapterInstance = createWhatsAppAdapter(config.adapters.whatsapp) as WhatsAppAdapter;
-          adapterInstances.whatsapp = whatsappAdapterInstance;
-        }
+        const registry = buildChatAdapterRegistry({
+          catalog: (config.catalog ?? []) as ReadonlyArray<ChatCatalogEntry>,
+          env: process.env,
+          logger: ctx.logger,
+        });
+        slackAdapterInstance = registry.slack;
 
-        bridge = createChatBridge(config, ctx.logger, stateAdapter, adapterInstances);
+        // Bridge takes pre-built instances per-platform; non-Slack slots
+        // are left `undefined` (the bridge tolerates this — see
+        // `createChatBridge`). When 1.5.3 lands StaticBotInstallHandler,
+        // each new instantiated adapter slots in here.
+        bridge = createChatBridge(config, ctx.logger, stateAdapter, {
+          slack: slackAdapterInstance,
+        });
       } catch (err) {
         ctx.logger.error(
           { err: err instanceof Error ? err : new Error(String(err)) },
@@ -703,24 +431,18 @@ function buildChatPlugin(
         }
         stateAdapter = null;
         slackAdapterInstance = null;
-        teamsAdapterInstance = null;
-        discordAdapterInstance = null;
-        gchatAdapterInstance = null;
-        telegramAdapterInstance = null;
-        githubAdapterInstance = null;
-        linearAdapterInstance = null;
-        whatsappAdapterInstance = null;
         throw err;
       }
 
-      const enabledAdapters = Object.entries(config.adapters)
-        .filter(([, v]) => v !== undefined)
-        .map(([k]) => k);
+      const enabledAdapters: string[] = [];
+      if (slackAdapterInstance) enabledAdapters.push("slack");
 
       const backend = config.state?.backend ?? "memory";
       ctx.logger.info(
         { adapters: enabledAdapters, stateBackend: backend },
-        `Chat interaction plugin initialized (${enabledAdapters.join(", ")}, state: ${backend})`,
+        enabledAdapters.length > 0
+          ? `Chat interaction plugin initialized (${enabledAdapters.join(", ")}, state: ${backend})`
+          : `Chat interaction plugin initialized (no chat adapters activated — see AdapterRegistry warns, state: ${backend})`,
       );
       initialized = true;
     },
@@ -736,14 +458,14 @@ function buildChatPlugin(
         };
       }
 
-      const enabledAdapters = Object.entries(config.adapters)
-        .filter(([, v]) => v !== undefined)
-        .map(([k]) => k);
+      const enabledAdapters: string[] = [];
+      if (slackAdapterInstance) enabledAdapters.push("slack");
 
       if (enabledAdapters.length === 0) {
         return {
           healthy: false,
-          message: "No adapters configured",
+          message:
+            "No chat adapters registered — check `catalog` declaration in atlas.config.ts and per-Platform env vars",
           latencyMs: Math.round(performance.now() - start),
         };
       }
@@ -792,13 +514,6 @@ function buildChatPlugin(
         stateAdapter = null;
       }
       slackAdapterInstance = null;
-      teamsAdapterInstance = null;
-      discordAdapterInstance = null;
-      gchatAdapterInstance = null;
-      telegramAdapterInstance = null;
-      githubAdapterInstance = null;
-      linearAdapterInstance = null;
-      whatsappAdapterInstance = null;
       log = null;
       initialized = false;
     },
@@ -812,30 +527,39 @@ function buildChatPlugin(
 /**
  * Factory function for use in atlas.config.ts plugins array.
  *
+ * Adapter activation is catalog-driven (#2650 slice 2). The host wires
+ * `catalog` from `atlas.config.ts:catalog` (chat-type subset); per-Platform
+ * credentials come from `process.env`.
+ *
  * @example
  * ```typescript
- * plugins: [chatPlugin({
- *   adapters: {
- *     slack: { botToken: "xoxb-...", signingSecret: "..." },
- *     teams: { appId: "...", appPassword: "..." },
- *     discord: { botToken: "...", applicationId: "...", publicKey: "..." },
- *     gchat: { credentials: { client_email: "...", private_key: "..." } },
- *     telegram: { botToken: "..." },
- *     github: { appId: "...", privateKey: "...", webhookSecret: "..." },
- *     linear: { apiKey: "...", webhookSecret: "..." },
- *     whatsapp: { phoneNumberId: "...", accessToken: "...", verifyToken: "...", appSecret: "..." },
- *   },
- *   executeQuery: myQueryFunction,
- * })]
+ * // atlas.config.ts
+ * export default defineConfig({
+ *   catalog: [
+ *     { slug: "slack", type: "chat", install_model: "oauth", enabled: true },
+ *   ],
+ *   plugins: [
+ *     chatPlugin({
+ *       catalog: [
+ *         { slug: "slack", type: "chat", install_model: "oauth",
+ *           enabled: true, saas_eligible: true },
+ *       ],
+ *       executeQuery: myQueryFunction,
+ *     }),
+ *   ],
+ * });
+ *
+ * // env vars:
+ * //   SLACK_CLIENT_ID=...
+ * //   SLACK_CLIENT_SECRET=...
+ * //   SLACK_SIGNING_SECRET=...
+ * //   SLACK_ENCRYPTION_KEY=...
  * ```
  */
 export const chatPlugin = createPlugin<
   ChatPluginConfig,
   AtlasInteractionPlugin<ChatPluginConfig>
 >({
-  // Cast: Zod infers all-optional fields for GitHub's and Linear's schemas,
-  // but runtime superRefine validates the discriminated union constraints.
-  // The TypeScript union types provide compile-time safety separately.
   configSchema: ChatConfigSchema as unknown as { parse(input: unknown): ChatPluginConfig },
   create: buildChatPlugin,
 });


### PR DESCRIPTION
## Summary

Slice 2 of [1.5.2 — Multi-Adapter SaaS Readiness](https://github.com/AtlasDevHQ/atlas/milestones/?). Closes #2650.

Implements [ADR-0002 S3](../blob/main/docs/adr/0002-catalog-seeded-from-config-at-boot.md): operator declares Platforms + integrations in `atlas.config.ts:catalog`, a boot-time idempotent seed pass writes them into `plugin_catalog`, and the chat plugin's new `AdapterRegistry` reads the seeded catalog + env vars to decide which adapters to instantiate.

Closes the *"two parallel wiring concepts (`atlas.config.ts:plugins[].adapters` vs `plugin_catalog`) → one source of truth via boot-time seed"* gap that [#2649 PRD](../blob/main/docs/prd/multi-adapter-saas-readiness.md) catalogued.

## What lands

**Three modules ship together — the seam doesn't work piecewise.**

- **`atlas.config.ts:catalog`** — flat list with `type` (admin-UI grouping) + `install_model` (handler dispatch) as orthogonal fields per PRD "Further Notes". Zod-validated; duplicate-slug refine; `min_plan` defaults to `"starter"`, `enabled` / `saas_eligible` default `true`.

- **Migration 0087** (`plugin_catalog`) — adds `install_model` (CHECK over `'oauth' | 'form' | 'static-bot'`), `saas_eligible` (default true), widens `type` CHECK to admit `'chat'` / `'integration'`, adds partial lookup index. Drizzle schema mirror + real-PG smoke pinning column + CHECK semantics.

- **`CatalogSeeder` (deep module)** — pure `planCatalogSeed(declared, existing)` planner returns `insert` / `update` / `preserve-disabled` / `noop` actions + orphan slugs; `seedCatalog(db, declared)` drives the UPSERT loop. Idempotent on re-boot. Preserves DB-side `enabled = false` over config wanting true (ops emergency-disable wins, logged at warn). Orphans logged at warn, **never deleted**.

- **`CatalogSeedLive`** — new Effect Layer in `buildAppLayer`, depends on `InternalDB` + `Migration`. Non-fatal: failure leaves prior boot's rows authoritative.

- **`AdapterRegistry` (deep module inside chat plugin)** — replaces the pre-1.5.2 `if (config.adapters.slack) { ... }` conditional chain. Reads `config.catalog` + env vars; per-Platform credentials sourced from `SLACK_CLIENT_ID` / `SLACK_CLIENT_SECRET` / `SLACK_SIGNING_SECRET` / `SLACK_ENCRYPTION_KEY` (+ optional `SLACK_BOT_TOKEN`). Only OAuth chat entries with `enabled=true` AND complete env wire up. Non-Slack chat adapters (Teams / Discord / gchat / Telegram / WhatsApp) seeded as `static-bot` placeholders, **not instantiated** until 1.5.3.

- **Chat plugin clean break** — `chatPlugin({ adapters: { slack: {...} } })` shape removed. Plugin now takes `catalog: ChatCatalogEntry[]` and reads creds from `process.env`. `routes()` only mounts `/webhooks/slack` and OAuth routes when catalog declares Slack OAuth.

- **`deploy/api/atlas.config.ts`** — top-level catalog with Slack OAuth + five static-bot placeholders. `chatPlugin` call shrinks to one catalog entry + proactive wiring (the per-platform credential block is gone, env-driven).

- **Docs** — new `apps/docs/content/docs/deployment/plugin-catalog.mdx` covering the declaration shape, install models, boot-time seed semantics, emergency disable, per-Platform credentials, and what ships when across the slice chain.

## Pre-customer posture

Clean break (per [CONTEXT.md "Deployment posture (as of 2026-05-19)"](../blob/main/CONTEXT.md#deployment-posture-as-of-2026-05-19)). No deprecation shims; the two internal Workspaces migrate atomically via this PR's deploy.

## Out of scope (slice trail)

- `/api/v1/integrations/catalog` endpoint + `/admin/integrations` page (slice 3 — #2651)
- `PlatformInstallHandler` interface family + `OAuthStateToken` (slice 4 — #2652)
- Slack `OAuthPlatformInstallHandler` implementation (slice 5 — #2653)
- `LazyPluginLoader` (slice 9 — #2657)
- `StaticBotInstallHandler` (1.5.3)

## Test plan

- [x] CatalogSeeder unit tests (15) — idempotency, preserve-disabled, orphan warn, plan-tier / install_model / saas_eligible propagation, empty-declaration short-circuit, duplicate-slug guard
- [x] AdapterRegistry unit tests (12) — happy path, missing-env matrix per required var, catalog filters (enabled / install_model / type / unknown slug)
- [x] Real-PG migration smoke pins `install_model` CHECK, `type` widening, `saas_eligible` column
- [x] All 405 chat plugin tests pass after refactor
- [x] 73/73 affected `@atlas/api` tests pass (isolated runner)
- [x] Full type-check + lint clean (no new errors; pre-existing warnings unchanged)
- [x] Schema drift check passes
- [x] EE imports check passes (no new `@atlas/ee` imports in core)
- [x] Build passes (web + docs + plugins)
- [ ] **Dogfood verify in #sandbox-atlas** after merge: existing Slack proactive flow still emits 🤖 reaction within ~150ms of question, and new `plugin_catalog` row visible for `slack` on first boot

## Architecture wins (candidate entries)

Two deep modules land that are candidates for `.claude/research/architecture-wins.md` post-merge:

1. **`CatalogSeeder`** — pure idempotent boot-time function. Planner/driver split makes the upsert semantics unit-testable without spinning up a DB. The "preserve DB-disabled over config-enabled" rule is a quietly load-bearing invariant for ops emergency-disable workflows.

2. **`AdapterRegistry`** — deep encapsulation of which adapters this deployment has wired. Catalog-driven activation closes a leak where customer-level activation was routed through operator-only `atlas.config.ts` code.