### PR TITLE
feat: #2652 — install-handler foundation (OAuthStateToken + dispatch) (1.5.2 slice 4)

### DIFF
--- a/docs/prd/multi-adapter-saas-readiness.md
+++ b/docs/prd/multi-adapter-saas-readiness.md
@@ -241,6 +241,15 @@ Each install handler interface documents rotation semantics in its docstring:
 
 Slice 4 (`PlatformInstallHandler` interface family) registers a dispatch keyed on `install_model`. Even though `StaticBotInstallHandler` ships in 1.5.3, the 1.5.2 dispatch must already cover all three branches — with `StaticBotInstallHandler` registered as a stub that throws `EnterpriseError("install_model 'static-bot' not implemented until 1.5.3")` (or similar). This pins the registration shape so 1.5.3 lands as a single import + stub-removal change, not a dispatch-mechanism design call.
 
+Landed (slice 4 / PR #2652) calls worth pinning so 1.5.3 doesn't re-litigate them:
+
+- **Stub error type** — plain `Error` (not `EnterpriseError`). The static-bot stub is a "not implemented yet" deferral, not an EE feature gate; mapping it to a 403 "Requires Enterprise" response would mislead the admin UI. Slice 5 / #2660 callers can assert on the message substring `"not implemented until 1.5.3"`.
+- **`OAuthStateToken` shape** — compact JWT-ish three-part wire format `base64url(header).base64url(payload).base64url(hmacSha256)`. Header `{ alg: "HS256", kid: <int>, typ: "AtlasOAuthState" }`; payload `{ workspaceId, catalogId, exp }` (unix seconds). Format is local — `@atlas/oauth-helper` doesn't currently expose an HMAC signer and editing the helper is out of scope for the foundation slice.
+- **`kid` = active key version** — the `kid` integer is the `version` field of the entry in `ATLAS_ENCRYPTION_KEYS` that signed the token. Always the *highest* version at mint time; on verify, any version still present in the keyset is accepted. This lets an operator rotate keys (promote v2 to active, keep v1 readable for a window) without bulk-invalidating in-flight install dances.
+- **Default TTL** — 10 minutes. Env override `ATLAS_OAUTH_STATE_TTL_SECONDS` clamped to [60, 3600]; per-call override on `mint()` is for tests only.
+- **Verify policy** — `verify()` returns `null` on every failure path (malformed, tampered, expired, unknown kid, no key configured). Never throws — callers must not introspect which check tripped.
+- **Mint when no key is configured** — throws, does not fall back. Unlike opaque-secret encryption (which has a dev-friendly plaintext passthrough), CSRF state cannot degrade silently. Self-host operators must set at least `BETTER_AUTH_SECRET`; SaaS deploys must set `ATLAS_ENCRYPTION_KEYS`.
+
 ### Per-Workspace platform identifiers
 
 Some Platforms with OAuth install still need per-Workspace platform-specific identifiers persisted alongside the credential:

--- a/packages/api/src/lib/integrations/install/__tests__/dispatch.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/dispatch.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Tests for `getInstallHandler` dispatch — slice 4 of #2649 (issue #2652).
+ *
+ * Asserted invariants (per #2652 ACs):
+ *
+ *   - Each `install_model` value returns the correct handler shape
+ *   - `static-bot` returns the stub
+ *   - The stub's `confirmInstall` throws an actionable "not implemented
+ *     until 1.5.3 — see milestone #51" error
+ *   - An unknown `install_model` value is a compile error at the
+ *     dispatch switch (demonstrated via a `@ts-expect-error`)
+ *
+ * The dispatch shape is the load-bearing part of this slice: slice 5
+ * (Slack) and #2660 (form-based) drop their handlers in by calling
+ * `registerOAuthHandler` / `registerFormHandler` at module load.
+ */
+
+import { afterEach, describe, expect, it } from "bun:test";
+import {
+  _resetInstallHandlerRegistries,
+  getInstallHandler,
+  registerFormHandler,
+  registerOAuthHandler,
+} from "../dispatch";
+import type {
+  CatalogRowForDispatch,
+  FormBasedInstallHandler,
+  InstallRecord,
+  OAuthPlatformInstallHandler,
+} from "../types";
+import { staticBotInstallHandlerStub } from "../static-bot-stub";
+import type { WorkspaceId } from "@useatlas/types";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const wsid = "org-test" as WorkspaceId;
+
+function makeOAuthHandler(slug: string): OAuthPlatformInstallHandler {
+  const record: InstallRecord = { id: `install-${slug}`, workspaceId: wsid, catalogId: slug };
+  return {
+    kind: "oauth",
+    async startInstall() {
+      return { redirectUrl: `https://example.test/${slug}/authorize`, stateToken: "tok" };
+    },
+    async handleCallback() {
+      return {
+        workspaceId: wsid,
+        catalogId: slug,
+        installRecord: record,
+        credentialResult: { written: true },
+      };
+    },
+  };
+}
+
+function makeFormHandler(slug: string): FormBasedInstallHandler {
+  const record: InstallRecord = { id: `install-${slug}`, workspaceId: wsid, catalogId: slug };
+  return {
+    kind: "form",
+    async validateConfig() {
+      return { installRecord: record, credentialWritten: true };
+    },
+  };
+}
+
+afterEach(() => {
+  _resetInstallHandlerRegistries();
+});
+
+// ---------------------------------------------------------------------------
+// Per-`install_model` dispatch
+// ---------------------------------------------------------------------------
+
+describe("getInstallHandler — install_model: 'oauth'", () => {
+  it("returns the registered OAuth handler for a known slug", () => {
+    const handler = makeOAuthHandler("slack");
+    registerOAuthHandler("slack", handler);
+
+    const row: CatalogRowForDispatch = { slug: "slack", install_model: "oauth" };
+    const resolved = getInstallHandler(row);
+    expect(resolved.kind).toBe("oauth");
+    expect(resolved).toBe(handler);
+  });
+
+  it("throws when no OAuth handler is registered for the slug", () => {
+    const row: CatalogRowForDispatch = { slug: "slack", install_model: "oauth" };
+    expect(() => getInstallHandler(row)).toThrow(
+      /No OAuth install handler registered for catalog slug "slack"/,
+    );
+  });
+
+  it("treats re-registration as overwrite (test ergonomics)", () => {
+    registerOAuthHandler("slack", makeOAuthHandler("slack-v1"));
+    const replacement = makeOAuthHandler("slack-v2");
+    registerOAuthHandler("slack", replacement);
+
+    const row: CatalogRowForDispatch = { slug: "slack", install_model: "oauth" };
+    expect(getInstallHandler(row)).toBe(replacement);
+  });
+});
+
+describe("getInstallHandler — install_model: 'form'", () => {
+  it("returns the registered form handler for a known slug", () => {
+    const handler = makeFormHandler("email");
+    registerFormHandler("email", handler);
+
+    const row: CatalogRowForDispatch = { slug: "email", install_model: "form" };
+    const resolved = getInstallHandler(row);
+    expect(resolved.kind).toBe("form");
+    expect(resolved).toBe(handler);
+  });
+
+  it("throws when no form handler is registered for the slug", () => {
+    const row: CatalogRowForDispatch = { slug: "email", install_model: "form" };
+    expect(() => getInstallHandler(row)).toThrow(
+      /No form-based install handler registered for catalog slug "email"/,
+    );
+  });
+});
+
+describe("getInstallHandler — install_model: 'static-bot'", () => {
+  it("always returns the operator-shared stub", () => {
+    const row: CatalogRowForDispatch = { slug: "telegram", install_model: "static-bot" };
+    expect(getInstallHandler(row)).toBe(staticBotInstallHandlerStub);
+  });
+
+  it("returns the same stub regardless of slug — bot is operator-shared", () => {
+    const tg: CatalogRowForDispatch = { slug: "telegram", install_model: "static-bot" };
+    const discord: CatalogRowForDispatch = { slug: "discord", install_model: "static-bot" };
+    expect(getInstallHandler(tg)).toBe(getInstallHandler(discord));
+  });
+});
+
+describe("StaticBotInstallHandler stub", () => {
+  it("throws the actionable 1.5.3 deferral when confirmInstall is called", async () => {
+    await expect(
+      staticBotInstallHandlerStub.confirmInstall(wsid, "guild-123"),
+    ).rejects.toThrow(/not implemented until 1\.5\.3.*milestone #51/);
+  });
+
+  it("identifies itself with kind: 'static-bot' for narrowing", () => {
+    expect(staticBotInstallHandlerStub.kind).toBe("static-bot");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Compile-time exhaustiveness
+// ---------------------------------------------------------------------------
+
+describe("getInstallHandler — compile-time exhaustiveness", () => {
+  it("rejects unknown install_model values at the type level", () => {
+    // @ts-expect-error — "manifest" isn't in CatalogInstallModel; this
+    // line MUST be flagged by tsc/tsgo. If a future migration extends
+    // the enum without updating the dispatch switch, that error fires
+    // at the `_exhaustive: never` branch in `getInstallHandler` instead.
+    const row: CatalogRowForDispatch = { slug: "future", install_model: "manifest" };
+    // The runtime check is a defense-in-depth — if a regression bypasses
+    // the type system, the default branch throws so we don't silently
+    // dispatch nothing.
+    expect(() => getInstallHandler(row)).toThrow(/Unknown install_model "manifest"/);
+  });
+});

--- a/packages/api/src/lib/integrations/install/__tests__/oauth-state-token.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/oauth-state-token.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Tests for `OAuthStateToken` — slice 4 of #2649 (issue #2652).
+ *
+ * The token is the CSRF gate between Platform install start and OAuth
+ * callback. A working token says: "the same Workspace that started this
+ * install is the one whose code is now coming back." `verify` returns
+ * `null` on every failure path so callers cannot accidentally leak which
+ * check tripped (header tamper vs. signature mismatch vs. expiry).
+ *
+ * Key rotation:
+ *   - `mint` always signs with the active (highest-version) key
+ *   - `verify` honours the token's `kid` claim and looks up the key in
+ *     the keyset — so a token minted under v1 still verifies after v2
+ *     was promoted to active, until v1 is dropped from the env.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { _resetEncryptionKeyCache } from "@atlas/api/lib/db/encryption-keys";
+import {
+  mintOAuthStateToken,
+  verifyOAuthStateToken,
+} from "../oauth-state-token";
+
+// ---------------------------------------------------------------------------
+// Test scaffolding — env-driven keyset
+// ---------------------------------------------------------------------------
+
+const ORIGINAL_ENV = { ...process.env };
+
+function setKeys(value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env.ATLAS_ENCRYPTION_KEYS;
+  } else {
+    process.env.ATLAS_ENCRYPTION_KEYS = value;
+  }
+  delete process.env.ATLAS_ENCRYPTION_KEY;
+  delete process.env.BETTER_AUTH_SECRET;
+  _resetEncryptionKeyCache();
+}
+
+beforeEach(() => {
+  setKeys("v1:test-key-one");
+});
+
+afterEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+  _resetEncryptionKeyCache();
+});
+
+// ---------------------------------------------------------------------------
+// Happy path
+// ---------------------------------------------------------------------------
+
+describe("OAuthStateToken — roundtrip", () => {
+  it("mints a token and verifies the same workspaceId + catalogId back", () => {
+    const token = mintOAuthStateToken("org-abc", "slack");
+    const verified = verifyOAuthStateToken(token);
+    expect(verified).toEqual({ workspaceId: "org-abc", catalogId: "slack" });
+  });
+
+  it("produces a different token each call (random not required, but distinct payload+sig is fine)", () => {
+    const a = mintOAuthStateToken("org-abc", "slack");
+    // Force a different `exp` by passing an explicit nowSeconds — this
+    // also documents the test injection seam.
+    const b = mintOAuthStateToken("org-abc", "slack", { nowSeconds: 1_700_000_000 });
+    expect(a).not.toEqual(b);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Failure modes — all must return null, never throw
+// ---------------------------------------------------------------------------
+
+describe("OAuthStateToken — tampering", () => {
+  it("returns null when the payload segment is tampered", () => {
+    const token = mintOAuthStateToken("org-abc", "slack");
+    const parts = token.split(".");
+    expect(parts.length).toBe(3);
+    // Flip one character in the payload segment (middle).
+    const tampered = `${parts[0]}.${parts[1].slice(0, -1)}X.${parts[2]}`;
+    expect(verifyOAuthStateToken(tampered)).toBeNull();
+  });
+
+  it("returns null when the signature segment is tampered", () => {
+    const token = mintOAuthStateToken("org-abc", "slack");
+    const parts = token.split(".");
+    const tamperedSig = `${parts[2].slice(0, -1)}A`;
+    expect(verifyOAuthStateToken(`${parts[0]}.${parts[1]}.${tamperedSig}`)).toBeNull();
+  });
+
+  it("returns null when the header segment is tampered (kid swap)", () => {
+    const token = mintOAuthStateToken("org-abc", "slack");
+    const parts = token.split(".");
+    // Re-encode a header with a kid that isn't in the keyset.
+    const fakeHeader = Buffer.from(
+      JSON.stringify({ alg: "HS256", kid: 999, typ: "AtlasOAuthState" }),
+      "utf8",
+    )
+      .toString("base64")
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "");
+    expect(verifyOAuthStateToken(`${fakeHeader}.${parts[1]}.${parts[2]}`)).toBeNull();
+  });
+
+  it("returns null when alg is anything but HS256", () => {
+    const token = mintOAuthStateToken("org-abc", "slack");
+    const parts = token.split(".");
+    const noneHeader = Buffer.from(
+      JSON.stringify({ alg: "none", kid: 1, typ: "AtlasOAuthState" }),
+      "utf8",
+    )
+      .toString("base64")
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "");
+    expect(verifyOAuthStateToken(`${noneHeader}.${parts[1]}.${parts[2]}`)).toBeNull();
+  });
+});
+
+describe("OAuthStateToken — expiry", () => {
+  it("returns null when the token's exp is in the past", () => {
+    const past = Math.floor(Date.now() / 1000) - 60 * 60; // 1h ago
+    const token = mintOAuthStateToken("org-abc", "slack", {
+      nowSeconds: past,
+      ttlSeconds: 60, // 1 min lifetime, already long expired
+    });
+    expect(verifyOAuthStateToken(token)).toBeNull();
+  });
+
+  it("accepts a token within its TTL window", () => {
+    // exp = now + 10 min
+    const token = mintOAuthStateToken("org-abc", "slack", { ttlSeconds: 600 });
+    expect(verifyOAuthStateToken(token)).toEqual({
+      workspaceId: "org-abc",
+      catalogId: "slack",
+    });
+  });
+});
+
+describe("OAuthStateToken — key rotation", () => {
+  it("verifies a v1-minted token after v2 has been promoted to active", () => {
+    // Mint with only v1 in the keyset.
+    setKeys("v1:legacy-key");
+    const token = mintOAuthStateToken("org-abc", "slack");
+
+    // Now rotate: v2 is active, v1 is still readable.
+    setKeys("v2:current-key,v1:legacy-key");
+    expect(verifyOAuthStateToken(token)).toEqual({
+      workspaceId: "org-abc",
+      catalogId: "slack",
+    });
+  });
+
+  it("rejects a v1-minted token once v1 has been dropped from the keyset", () => {
+    setKeys("v1:legacy-key");
+    const token = mintOAuthStateToken("org-abc", "slack");
+
+    setKeys("v2:current-key");
+    expect(verifyOAuthStateToken(token)).toBeNull();
+  });
+});
+
+describe("OAuthStateToken — malformed input", () => {
+  it("returns null for the empty string", () => {
+    expect(verifyOAuthStateToken("")).toBeNull();
+  });
+
+  it("returns null when the token has the wrong segment count", () => {
+    expect(verifyOAuthStateToken("only.two")).toBeNull();
+    expect(verifyOAuthStateToken("a.b.c.d")).toBeNull();
+  });
+
+  it("returns null when a segment is not valid base64url JSON", () => {
+    expect(verifyOAuthStateToken("@@@.@@@.@@@")).toBeNull();
+  });
+
+  it("returns null when claims are missing required fields", () => {
+    // Hand-craft a token with a v1-signed body that omits `catalogId`.
+    // We do this by minting then surgically replacing the payload — the
+    // signature will no longer match, which is the *whole point* (any
+    // edit invalidates the token).
+    const token = mintOAuthStateToken("org-abc", "slack");
+    const parts = token.split(".");
+    const badPayload = Buffer.from(
+      JSON.stringify({ workspaceId: "org-abc", exp: 9_999_999_999 }),
+      "utf8",
+    )
+      .toString("base64")
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "");
+    expect(verifyOAuthStateToken(`${parts[0]}.${badPayload}.${parts[2]}`)).toBeNull();
+  });
+});
+
+describe("OAuthStateToken — misconfig", () => {
+  it("throws when no encryption key is configured at mint time (CSRF cannot passthrough)", () => {
+    setKeys(undefined);
+    expect(() => mintOAuthStateToken("org-abc", "slack")).toThrow(
+      /encryption key/i,
+    );
+  });
+
+  it("returns null on verify when no encryption key is configured", () => {
+    // First mint with a key, then yank the env.
+    setKeys("v1:test-key");
+    const token = mintOAuthStateToken("org-abc", "slack");
+    setKeys(undefined);
+    expect(verifyOAuthStateToken(token)).toBeNull();
+  });
+});

--- a/packages/api/src/lib/integrations/install/__tests__/oauth-state-token.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/oauth-state-token.test.ts
@@ -209,4 +209,17 @@ describe("OAuthStateToken — misconfig", () => {
     setKeys(undefined);
     expect(verifyOAuthStateToken(token)).toBeNull();
   });
+
+  it("returns null (does not throw) when ATLAS_ENCRYPTION_KEYS is malformed", () => {
+    // Mint a token under a valid keyset first.
+    setKeys("v1:test-key");
+    const token = mintOAuthStateToken("org-abc", "slack");
+
+    // Now drift the env to a malformed value that makes
+    // `getEncryptionKeyset()` throw (duplicate version labels). The
+    // contract is that `verify` returns null on every failure mode —
+    // a keyset misconfig must not bubble a 500 from a verify call.
+    setKeys("v1:one,v1:two");
+    expect(verifyOAuthStateToken(token)).toBeNull();
+  });
 });

--- a/packages/api/src/lib/integrations/install/dispatch.ts
+++ b/packages/api/src/lib/integrations/install/dispatch.ts
@@ -1,0 +1,131 @@
+/**
+ * Install-handler dispatch — slice 4 of #2649 (issue #2652).
+ *
+ * `getInstallHandler(catalogRow)` switches on `catalog.install_model`
+ * and returns the matching handler. Three branches today (`oauth` /
+ * `form` / `static-bot`); the exhaustive `never` check at the default
+ * branch turns a future fourth `install_model` value (e.g. `"manifest"`)
+ * into a compile error here, before any runtime drift.
+ *
+ * Handler registration (per-Platform):
+ *
+ *   `oauth` and `form` handlers are looked up by the catalog row's
+ *   slug in two small in-module registries. Each Platform's handler
+ *   file calls {@link registerOAuthHandler} / {@link registerFormHandler}
+ *   at module-load time (slice 5 registers Slack; #2660 registers
+ *   form-based Email/Webhook/Obsidian; etc.). The registries are
+ *   intentionally **empty** in 1.5.2 — calling `getInstallHandler` on
+ *   a `slack` catalog row today throws "no handler registered" because
+ *   slice 5 hasn't landed yet. That's the correct failure mode: the
+ *   dispatch shape is pinned, the implementations slot in cleanly.
+ *
+ *   For `static-bot`, the dispatch always returns the stub from
+ *   {@link staticBotInstallHandlerStub} — there is no per-slug registry
+ *   because the bot is operator-shared (one handler per Platform suffices,
+ *   not per Workspace install). Slice 5/6 may replace the single stub
+ *   with the real handler; until then, calling its methods throws.
+ */
+
+import type {
+  CatalogRowForDispatch,
+  FormBasedInstallHandler,
+  OAuthPlatformInstallHandler,
+  PlatformInstallHandler,
+  StaticBotInstallHandler,
+} from "./types";
+import { staticBotInstallHandlerStub } from "./static-bot-stub";
+
+// ---------------------------------------------------------------------------
+// Per-slug registries
+// ---------------------------------------------------------------------------
+
+const oauthHandlers = new Map<string, OAuthPlatformInstallHandler>();
+const formHandlers = new Map<string, FormBasedInstallHandler>();
+
+/**
+ * Register an OAuth install handler for a given catalog slug. Idempotent
+ * — re-registering the same slug overwrites the previous entry (helpful
+ * in tests that swap a real handler for a mock). Production code calls
+ * this once at module load.
+ */
+export function registerOAuthHandler(
+  slug: string,
+  handler: OAuthPlatformInstallHandler,
+): void {
+  oauthHandlers.set(slug, handler);
+}
+
+/**
+ * Register a form-based install handler for a given catalog slug.
+ * See {@link registerOAuthHandler} for the idempotency contract.
+ */
+export function registerFormHandler(
+  slug: string,
+  handler: FormBasedInstallHandler,
+): void {
+  formHandlers.set(slug, handler);
+}
+
+/** @internal Test-only — clears both registries between tests. */
+export function _resetInstallHandlerRegistries(): void {
+  oauthHandlers.clear();
+  formHandlers.clear();
+}
+
+// ---------------------------------------------------------------------------
+// Dispatch
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the install handler for a catalog row. Throws when no handler
+ * is registered for an `oauth` / `form` slug — that's a config drift:
+ * the catalog declares an install model that no implementation supports
+ * yet, and silently returning a no-op handler would let install start
+ * pages render without a working backend.
+ *
+ * The default branch is a compile-time exhaustiveness gate via the
+ * unused `_exhaustive: never` binding — adding a new `install_model`
+ * value to {@link CatalogInstallModel} surfaces here as a TS error
+ * before any runtime drift.
+ */
+export function getInstallHandler(
+  catalogRow: CatalogRowForDispatch,
+): PlatformInstallHandler {
+  switch (catalogRow.install_model) {
+    case "oauth": {
+      const handler = oauthHandlers.get(catalogRow.slug);
+      if (!handler) {
+        throw new Error(
+          `No OAuth install handler registered for catalog slug "${catalogRow.slug}". Register via registerOAuthHandler() at module load.`,
+        );
+      }
+      return handler;
+    }
+    case "form": {
+      const handler = formHandlers.get(catalogRow.slug);
+      if (!handler) {
+        throw new Error(
+          `No form-based install handler registered for catalog slug "${catalogRow.slug}". Register via registerFormHandler() at module load.`,
+        );
+      }
+      return handler;
+    }
+    case "static-bot":
+      return staticBotInstallHandlerStub;
+    default: {
+      const _exhaustive: never = catalogRow.install_model;
+      throw new Error(
+        `Unknown install_model "${String(_exhaustive)}" — add a case to getInstallHandler when introducing a new install model`,
+      );
+    }
+  }
+}
+
+// Re-export the handler shape for callers that want to narrow the
+// dispatch result without going through `./types` directly.
+export type {
+  OAuthPlatformInstallHandler,
+  FormBasedInstallHandler,
+  StaticBotInstallHandler,
+  PlatformInstallHandler,
+};

--- a/packages/api/src/lib/integrations/install/index.ts
+++ b/packages/api/src/lib/integrations/install/index.ts
@@ -1,0 +1,34 @@
+/**
+ * Barrel for the Platform install module — slice 4 of #2649 (issue #2652).
+ *
+ * Consumers should import from this module, not from individual files,
+ * so the surface stays observable in code review and the internal layout
+ * (registries, stub placement) can evolve without churn at call sites.
+ */
+
+export {
+  mintOAuthStateToken,
+  verifyOAuthStateToken,
+  type MintOptions,
+  type VerifiedState,
+} from "./oauth-state-token";
+
+export type {
+  CatalogId,
+  CatalogRowForDispatch,
+  CredentialResult,
+  FormBasedInstallHandler,
+  InstallRecord,
+  OAuthPlatformInstallHandler,
+  PlatformInstallHandler,
+  StaticBotInstallHandler,
+} from "./types";
+
+export {
+  getInstallHandler,
+  registerFormHandler,
+  registerOAuthHandler,
+  _resetInstallHandlerRegistries,
+} from "./dispatch";
+
+export { staticBotInstallHandlerStub } from "./static-bot-stub";

--- a/packages/api/src/lib/integrations/install/oauth-state-token.ts
+++ b/packages/api/src/lib/integrations/install/oauth-state-token.ts
@@ -1,0 +1,272 @@
+/**
+ * OAuthStateToken — CSRF gate for Platform OAuth install flows.
+ *
+ * Per ADR-0004, Platform integration OAuth is a separate subsystem from
+ * Better Auth's user OAuth. The `state` parameter that binds an install
+ * start to its callback must be:
+ *
+ *   - signed (no client tampering)
+ *   - keyed to `(workspaceId, catalogId)` so an attacker can't redirect
+ *     a code earned for Workspace A into Workspace B's install record
+ *   - short-lived (5–10 min default — the OAuth dance is interactive,
+ *     so a long lifetime widens the attack window without buying us
+ *     anything)
+ *   - rotation-aware so an encryption-key rotation doesn't bulk-
+ *     invalidate every in-flight install
+ *
+ * Token shape — a compact JWT-ish three-part format:
+ *
+ *   `base64url(header).base64url(payload).base64url(hmacSha256)`
+ *
+ * - header = `{ alg: "HS256", kid: <int>, typ: "AtlasOAuthState" }`
+ *   - `kid` points into `ATLAS_ENCRYPTION_KEYS` (versioned keyset).
+ *     Always written as the active version at mint time.
+ * - payload = `{ workspaceId, catalogId, exp }` (exp in unix seconds)
+ *
+ * Why this shape (not full JWT via a library):
+ *
+ * - `@atlas/oauth-helper` exposes `decodeJwtPayload` for *consuming*
+ *   tokens from external IDPs but doesn't ship an HMAC signer — adding
+ *   one would require a package edit, which is out of scope for this
+ *   slice (see issue #2652 footnote).
+ * - The signing key derivation reuses the same versioned
+ *   `ATLAS_ENCRYPTION_KEYS` keyset as `db/secret-encryption.ts`, so
+ *   rotation is operator-aligned with the rest of the encryption story.
+ * - `crypto.timingSafeEqual` guards against signature-comparison side
+ *   channels.
+ *
+ * Verification policy:
+ *
+ *   `verify()` returns `null` on every failure path — malformed,
+ *   tampered, expired, unknown kid, no key configured. Callers must NOT
+ *   try to introspect which check tripped: leaking that lets attackers
+ *   probe the validation pipeline. Token-validity is a boolean.
+ */
+
+import * as crypto from "crypto";
+import { createLogger } from "@atlas/api/lib/logger";
+import { getEncryptionKeyset } from "@atlas/api/lib/db/encryption-keys";
+
+const log = createLogger("integrations.install.oauth-state-token");
+
+const SIG_ALGORITHM = "sha256";
+const TYP = "AtlasOAuthState";
+const ALG = "HS256";
+
+/**
+ * Default token lifetime. The OAuth dance is interactive — admin clicks
+ * "Install Slack", lands on the consent screen, clicks "Allow". Ten
+ * minutes covers reasonable network/think latency while keeping the
+ * CSRF replay window narrow.
+ *
+ * Override via `ATLAS_OAUTH_STATE_TTL_SECONDS` at the env layer (per-
+ * deploy tuning) or via the `ttlSeconds` option on `mint` (per-call,
+ * primarily for tests). The env override is clamped to 60–3600s — values
+ * outside the band are ignored with a `warn` log.
+ */
+const DEFAULT_TTL_SECONDS = 10 * 60;
+const MIN_TTL_SECONDS = 60;
+const MAX_TTL_SECONDS = 60 * 60;
+
+export interface MintOptions {
+  /** Override the token TTL in seconds. */
+  readonly ttlSeconds?: number;
+  /**
+   * Override "now" in unix seconds — used by tests to mint expired or
+   * far-future tokens deterministically. Defaults to `Date.now() / 1000`.
+   */
+  readonly nowSeconds?: number;
+}
+
+interface TokenHeader {
+  readonly alg: typeof ALG;
+  readonly kid: number;
+  readonly typ: typeof TYP;
+}
+
+interface TokenPayload {
+  readonly workspaceId: string;
+  readonly catalogId: string;
+  /** Expiration in unix seconds. */
+  readonly exp: number;
+}
+
+export interface VerifiedState {
+  readonly workspaceId: string;
+  readonly catalogId: string;
+}
+
+// ---------------------------------------------------------------------------
+// Mint
+// ---------------------------------------------------------------------------
+
+/**
+ * Mints a signed state token binding the OAuth install start to its
+ * callback. Always signs with the active (highest-version) key in the
+ * configured keyset.
+ *
+ * Throws when no encryption key is configured — unlike opaque-secret
+ * encryption (which has a dev-friendly plaintext passthrough), CSRF
+ * protection cannot degrade silently. Fail loud at boot or first install
+ * attempt so the operator gates this on real key material.
+ */
+export function mintOAuthStateToken(
+  workspaceId: string,
+  catalogId: string,
+  options: MintOptions = {},
+): string {
+  const keyset = getEncryptionKeyset();
+  if (!keyset) {
+    throw new Error(
+      "OAuthStateToken.mint: no encryption key configured — set ATLAS_ENCRYPTION_KEYS / ATLAS_ENCRYPTION_KEY / BETTER_AUTH_SECRET. CSRF state cannot fall through to plaintext.",
+    );
+  }
+
+  const ttl = resolveTtlSeconds(options.ttlSeconds);
+  const now = options.nowSeconds ?? Math.floor(Date.now() / 1000);
+  const exp = now + ttl;
+
+  const header: TokenHeader = {
+    alg: ALG,
+    kid: keyset.active.version,
+    typ: TYP,
+  };
+  const payload: TokenPayload = { workspaceId, catalogId, exp };
+
+  const headerB64 = encodeBase64UrlJson(header);
+  const payloadB64 = encodeBase64UrlJson(payload);
+  const signingInput = `${headerB64}.${payloadB64}`;
+  const sig = crypto
+    .createHmac(SIG_ALGORITHM, keyset.active.key)
+    .update(signingInput)
+    .digest();
+
+  return `${signingInput}.${encodeBase64Url(sig)}`;
+}
+
+// ---------------------------------------------------------------------------
+// Verify
+// ---------------------------------------------------------------------------
+
+/**
+ * Verifies a state token. Returns the bound `(workspaceId, catalogId)`
+ * on success, `null` on every failure mode (malformed, bad signature,
+ * expired, unknown kid, no key configured). Never throws.
+ *
+ * Verification is constant-time on the signature comparison via
+ * `crypto.timingSafeEqual`. Other checks (segment count, JSON parsing)
+ * are not constant-time but reveal only "wrong shape" — the same answer
+ * any random garbage string produces — so timing leaks have no useful
+ * signal.
+ */
+export function verifyOAuthStateToken(token: string): VerifiedState | null {
+  if (typeof token !== "string" || token.length === 0) return null;
+
+  const keyset = getEncryptionKeyset();
+  if (!keyset) {
+    log.debug("verifyOAuthStateToken: no encryption key configured — rejecting");
+    return null;
+  }
+
+  const parts = token.split(".");
+  if (parts.length !== 3) return null;
+  const [headerB64, payloadB64, sigB64] = parts;
+
+  const header = decodeBase64UrlJson<TokenHeader>(headerB64);
+  if (!header || header.alg !== ALG || header.typ !== TYP) return null;
+  if (typeof header.kid !== "number" || !Number.isFinite(header.kid)) return null;
+
+  const key = keyset.byVersion.get(header.kid);
+  if (!key) {
+    log.debug(
+      { kid: header.kid, activeKid: keyset.active.version },
+      "verifyOAuthStateToken: unknown kid — rejecting (key may have been rotated out)",
+    );
+    return null;
+  }
+
+  const expectedSig = crypto
+    .createHmac(SIG_ALGORITHM, key)
+    .update(`${headerB64}.${payloadB64}`)
+    .digest();
+
+  let providedSig: Buffer;
+  try {
+    providedSig = base64UrlToBuffer(sigB64);
+  } catch {
+    return null;
+  }
+  if (providedSig.length !== expectedSig.length) return null;
+  if (!crypto.timingSafeEqual(providedSig, expectedSig)) return null;
+
+  const payload = decodeBase64UrlJson<TokenPayload>(payloadB64);
+  if (!payload) return null;
+  if (typeof payload.workspaceId !== "string" || payload.workspaceId.length === 0) return null;
+  if (typeof payload.catalogId !== "string" || payload.catalogId.length === 0) return null;
+  if (typeof payload.exp !== "number" || !Number.isFinite(payload.exp)) return null;
+
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  if (payload.exp <= nowSeconds) return null;
+
+  return { workspaceId: payload.workspaceId, catalogId: payload.catalogId };
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function resolveTtlSeconds(override: number | undefined): number {
+  if (override !== undefined) {
+    // Per-call override is for tests — allow anything ≥1 second.
+    if (override >= 1 && Number.isFinite(override)) return Math.floor(override);
+    return DEFAULT_TTL_SECONDS;
+  }
+  const envRaw = process.env.ATLAS_OAUTH_STATE_TTL_SECONDS;
+  if (!envRaw) return DEFAULT_TTL_SECONDS;
+  const parsed = Number.parseInt(envRaw, 10);
+  if (!Number.isFinite(parsed) || parsed < MIN_TTL_SECONDS || parsed > MAX_TTL_SECONDS) {
+    log.warn(
+      { ATLAS_OAUTH_STATE_TTL_SECONDS: envRaw, min: MIN_TTL_SECONDS, max: MAX_TTL_SECONDS },
+      "Ignoring out-of-range ATLAS_OAUTH_STATE_TTL_SECONDS — using default",
+    );
+    return DEFAULT_TTL_SECONDS;
+  }
+  return parsed;
+}
+
+function encodeBase64Url(buf: Buffer): string {
+  return buf
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+function encodeBase64UrlJson(value: unknown): string {
+  return encodeBase64Url(Buffer.from(JSON.stringify(value), "utf8"));
+}
+
+function base64UrlToBuffer(input: string): Buffer {
+  // Restore standard base64 padding before letting Buffer parse it.
+  const padded = input.replace(/-/g, "+").replace(/_/g, "/");
+  const pad = padded.length % 4 === 0 ? "" : "=".repeat(4 - (padded.length % 4));
+  const buf = Buffer.from(padded + pad, "base64");
+  // `Buffer.from` is tolerant — round-trip to confirm the input was
+  // valid base64url, so garbage like "@@@" doesn't sneak through.
+  const reencoded = encodeBase64Url(buf);
+  if (reencoded !== input) {
+    throw new Error("invalid base64url");
+  }
+  return buf;
+}
+
+function decodeBase64UrlJson<T>(input: string): T | null {
+  try {
+    const buf = base64UrlToBuffer(input);
+    const parsed = JSON.parse(buf.toString("utf8")) as T;
+    if (typeof parsed !== "object" || parsed === null) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}

--- a/packages/api/src/lib/integrations/install/oauth-state-token.ts
+++ b/packages/api/src/lib/integrations/install/oauth-state-token.ts
@@ -162,7 +162,24 @@ export function mintOAuthStateToken(
 export function verifyOAuthStateToken(token: string): VerifiedState | null {
   if (typeof token !== "string" || token.length === 0) return null;
 
-  const keyset = getEncryptionKeyset();
+  // `getEncryptionKeyset()` throws on malformed `ATLAS_ENCRYPTION_KEYS`
+  // (duplicate version labels, mixed prefixed/bare, out-of-range version
+  // ints). Those are operator misconfig that should normally fail at
+  // boot — but the keyset resolver is lazy, so a regression that bypasses
+  // the boot-time validation could surface the throw here. `verify` is
+  // contractually `null`-only; warn loud once so the operator sees the
+  // misconfig in logs, then return null. We don't surface the message to
+  // callers because the verify return value is a boolean-shaped signal.
+  let keyset: ReturnType<typeof getEncryptionKeyset>;
+  try {
+    keyset = getEncryptionKeyset();
+  } catch (err) {
+    log.warn(
+      { err: err instanceof Error ? err.message : String(err) },
+      "verifyOAuthStateToken: keyset resolution threw — operator misconfig in ATLAS_ENCRYPTION_KEYS; rejecting all tokens",
+    );
+    return null;
+  }
   if (!keyset) {
     log.debug("verifyOAuthStateToken: no encryption key configured — rejecting");
     return null;
@@ -194,6 +211,11 @@ export function verifyOAuthStateToken(token: string): VerifiedState | null {
   try {
     providedSig = base64UrlToBuffer(sigB64);
   } catch {
+    // intentionally ignored: `verify` returns null on every failure
+    // mode. A non-base64url signature segment is the same signal as
+    // any other tampering — surfacing the specific cause (log or
+    // distinct return value) would help an attacker probe the
+    // pipeline. The contract is boolean-shaped.
     return null;
   }
   if (providedSig.length !== expectedSig.length) return null;
@@ -267,6 +289,11 @@ function decodeBase64UrlJson<T>(input: string): T | null {
     if (typeof parsed !== "object" || parsed === null) return null;
     return parsed;
   } catch {
+    // intentionally ignored: helper's return type pairs success with
+    // `null` for both base64url and JSON parse failures. Callers in
+    // `verifyOAuthStateToken` already gate on the null and return
+    // null to the outer caller — the boolean-shaped contract is
+    // documented at the function level.
     return null;
   }
 }

--- a/packages/api/src/lib/integrations/install/static-bot-stub.ts
+++ b/packages/api/src/lib/integrations/install/static-bot-stub.ts
@@ -1,0 +1,27 @@
+/**
+ * `StaticBotInstallHandler` stub — pinned in 1.5.2 so the dispatch
+ * table covers all three `install_model` branches today, but the real
+ * handler doesn't land until 1.5.3 (milestone #51).
+ *
+ * Calling `confirmInstall` throws an actionable error rather than
+ * silently failing or returning a fake record — a half-installed
+ * static-bot row would mislead the admin UI and the AdapterRegistry
+ * into a broken routing state. The throw is the documentation: don't
+ * register this catalog row's `enabled = true` until the 1.5.3 handler
+ * lands.
+ */
+
+import type { StaticBotInstallHandler } from "./types";
+
+class StaticBotInstallHandlerStub implements StaticBotInstallHandler {
+  readonly kind = "static-bot" as const;
+
+  async confirmInstall(): Promise<never> {
+    throw new Error(
+      "StaticBotInstallHandler not implemented until 1.5.3 — see milestone #51",
+    );
+  }
+}
+
+export const staticBotInstallHandlerStub: StaticBotInstallHandler =
+  new StaticBotInstallHandlerStub();

--- a/packages/api/src/lib/integrations/install/types.ts
+++ b/packages/api/src/lib/integrations/install/types.ts
@@ -1,0 +1,220 @@
+/**
+ * `PlatformInstallHandler` interface family — slice 4 of #2649 (issue #2652).
+ *
+ * Three concrete handler shapes, one per `install_model` value in the
+ * plugin catalog (`oauth` / `form` / `static-bot`). The {@link
+ * getInstallHandler} dispatch in `./dispatch.ts` switches on the catalog
+ * row's `install_model` and returns the matching handler.
+ *
+ * Per ADR-0004, Platform OAuth is a separate subsystem from Better
+ * Auth's user OAuth. These interfaces never touch the `account` table —
+ * they write to `workspace_plugins` (install record, per ADR-0003) and
+ * to the per-Platform credential store (`chat_cache` for chat Platforms,
+ * per-plugin store for lazy integrations).
+ *
+ * Per-handler return-shape note: each handler intentionally returns its
+ * *own* result shape rather than a shared envelope, because the three
+ * install models have genuinely different success semantics (a static-
+ * bot install carries no credential, an OAuth callback carries both an
+ * install record and a credential write outcome, etc.). The dispatch
+ * union ({@link PlatformInstallHandler}) is tagged via the `kind` field
+ * so consumers can narrow safely.
+ */
+
+import type { WorkspaceId } from "@useatlas/types";
+import type { CatalogInstallModel } from "@atlas/api/lib/config";
+
+// ---------------------------------------------------------------------------
+// Shared result shapes
+// ---------------------------------------------------------------------------
+
+/**
+ * Catalog id — the slug column of `plugin_catalog` (e.g. `"slack"`,
+ * `"jira"`). Kept as a plain string for now; if catalog ids grow more
+ * structure (e.g. namespaced community plugins) we'd promote this to a
+ * branded type alongside the existing brands in `@useatlas/types`.
+ */
+export type CatalogId = string;
+
+/**
+ * Outcome of writing a Platform install record — the row in
+ * `workspace_plugins`. Returned by every handler so callers can render
+ * "installed" UI without a follow-up read.
+ *
+ * Persisted-row id and the catalog binding land here; per-Platform
+ * metadata (Slack `team_id`, Jira `cloud_id`, etc.) lives in the
+ * adapter's own state store and is not part of this envelope.
+ */
+export interface InstallRecord {
+  readonly id: string;
+  readonly workspaceId: WorkspaceId;
+  readonly catalogId: CatalogId;
+}
+
+/**
+ * Outcome of writing the per-Platform credential blob. Tracked as a
+ * distinct field from {@link InstallRecord} because a partial failure
+ * — install row written, credential write failed — needs to surface as
+ * "Reconnect needed" rather than "Installed" (admin must re-run the
+ * OAuth dance). The dual-store semantics are documented in ADR-0003.
+ */
+export interface CredentialResult {
+  readonly written: boolean;
+  /**
+   * Operator-facing reason when `written: false`. Surfaced in the
+   * `/admin/integrations` card. Never include secret material.
+   */
+  readonly reason?: string;
+}
+
+// ---------------------------------------------------------------------------
+// OAuth install handler
+// ---------------------------------------------------------------------------
+
+/**
+ * Handler for `install_model: "oauth"` catalog entries — Slack, Jira,
+ * Salesforce, etc. Atlas's per-deploy app registration drives the
+ * OAuth dance; the Workspace gets its own bot token / per-tenant
+ * credential at callback time.
+ *
+ * Credential rotation semantics: each implementation documents how it
+ * refreshes — Slack's bot token does not expire, Salesforce / Jira use
+ * refresh tokens. See the per-Platform JSDoc in 1.5.3+ handler files.
+ */
+export interface OAuthPlatformInstallHandler {
+  readonly kind: "oauth";
+
+  /**
+   * Begin the OAuth dance. Mints a CSRF state token via
+   * {@link OAuthStateToken} bound to `(workspaceId, catalogId)` and
+   * returns the Platform's authorize URL with that state baked in.
+   *
+   * `redirectUrl` is what the admin's browser is redirected to;
+   * `stateToken` is the same token, surfaced separately so the API
+   * route can persist it client-side (cookie / hidden form input) when
+   * the Platform's authorize URL doesn't echo the state back through
+   * the query string verbatim.
+   */
+  startInstall(workspaceId: WorkspaceId): Promise<{
+    readonly redirectUrl: string;
+    readonly stateToken: string;
+  }>;
+
+  /**
+   * Handle the OAuth callback. Verifies the state token, exchanges the
+   * authorization code with the Platform, then writes both stores:
+   * the install record (`workspace_plugins`) and the per-Platform
+   * credential.
+   *
+   * Returns `null` on state-token failure (forged, expired, replayed).
+   * Bubbles a tagged error on Platform-side failures (`oauth.v2.access`
+   * non-OK responses for Slack, etc.) so the route can surface an
+   * actionable user error.
+   */
+  handleCallback(
+    code: string,
+    stateToken: string,
+  ): Promise<{
+    readonly workspaceId: WorkspaceId;
+    readonly catalogId: CatalogId;
+    readonly installRecord: InstallRecord;
+    readonly credentialResult: CredentialResult;
+  } | null>;
+}
+
+// ---------------------------------------------------------------------------
+// Form-based install handler
+// ---------------------------------------------------------------------------
+
+/**
+ * Handler for `install_model: "form"` catalog entries — Email, Webhook,
+ * Obsidian, etc. Admin submits a form (SMTP host + creds, webhook URL +
+ * shared secret, etc.); handler validates the config and writes both
+ * stores in one shot.
+ *
+ * `formData` is `unknown` at this level — each implementation is
+ * responsible for validating with its own Zod schema before touching
+ * persistence. The catalog row's `config_schema` JSONB column is the
+ * source of truth for what fields a Platform expects.
+ *
+ * Credential rotation semantics: form-based credentials don't refresh
+ * automatically — when an SMTP password expires, the admin re-submits
+ * the form. Some implementations may surface "test connection" actions
+ * that re-validate without rewriting.
+ */
+export interface FormBasedInstallHandler {
+  readonly kind: "form";
+
+  validateConfig(
+    workspaceId: WorkspaceId,
+    formData: unknown,
+  ): Promise<{
+    readonly installRecord: InstallRecord;
+    readonly credentialWritten: boolean;
+  }>;
+}
+
+// ---------------------------------------------------------------------------
+// Static-bot install handler
+// ---------------------------------------------------------------------------
+
+/**
+ * Handler for `install_model: "static-bot"` catalog entries — Telegram,
+ * Discord, Teams, gchat, WhatsApp. The bot itself is operator-shared
+ * (single app registration per Platform); the customer admin supplies a
+ * routing identifier (Discord `guild_id`, Telegram `chat_id`, Teams
+ * `tenant_id`, etc.) that the shared bot uses to scope messages.
+ *
+ * `verificationProof` is optional — a Platform-specific proof (e.g.
+ * Telegram's `/start@AtlasBot` echo, Discord's bot-member presence
+ * check) that the routing identifier really belongs to the requesting
+ * Workspace. Required for Platforms where impersonation would let
+ * Workspace B claim Workspace A's chat id.
+ *
+ * Credential rotation semantics: there is no per-Workspace credential —
+ * the bot's auth lives with the operator. Rotation is operator-side.
+ *
+ * **No implementation lands in 1.5.2.** The shape is pinned here so the
+ * dispatch table in `./dispatch.ts` covers all three branches today;
+ * 1.5.3 lands the real handler as an import-and-register change.
+ */
+export interface StaticBotInstallHandler {
+  readonly kind: "static-bot";
+
+  confirmInstall(
+    workspaceId: WorkspaceId,
+    routingIdentifier: string,
+    verificationProof?: string,
+  ): Promise<{
+    readonly installRecord: InstallRecord;
+  }>;
+}
+
+// ---------------------------------------------------------------------------
+// Dispatch union
+// ---------------------------------------------------------------------------
+
+/**
+ * Discriminated union returned by {@link getInstallHandler}. The `kind`
+ * tag mirrors the catalog row's {@link CatalogInstallModel} value so
+ * callers can narrow with a single switch.
+ *
+ * Adding a new `install_model` value (e.g. `"manifest"`) in a future
+ * milestone is a compile error at the dispatch switch — the exhaustive
+ * `never` branch surfaces the missing case before any runtime drift.
+ */
+export type PlatformInstallHandler =
+  | OAuthPlatformInstallHandler
+  | FormBasedInstallHandler
+  | StaticBotInstallHandler;
+
+/**
+ * Subset of the catalog row that the dispatch needs — kept narrow so
+ * the install module doesn't depend on Drizzle row shapes. The seeder
+ * already validates `install_model` against {@link CatalogInstallModel}
+ * at read time (see `catalog-seeder.ts::readExistingCatalog`).
+ */
+export interface CatalogRowForDispatch {
+  readonly slug: CatalogId;
+  readonly install_model: CatalogInstallModel;
+}


### PR DESCRIPTION
Closes #2652
Milestone: [1.5.2 — Multi-Adapter SaaS Readiness](https://github.com/AtlasDevHQ/atlas/milestone/50)
ADR: [docs/adr/0004-platform-oauth-is-not-better-auth.md](https://github.com/AtlasDevHQ/atlas/blob/main/docs/adr/0004-platform-oauth-is-not-better-auth.md)
PRD: #2649

## Summary

Foundation modules + dispatch shape that all Platform install flows depend on. No Platform implementations land in this slice — just the seam so slices 5–8 are drop-in.

- **`OAuthStateToken` (deep)** — HMAC-SHA256 signed CSRF token bound to `(workspaceId, catalogId, exp)`. Reuses the versioned `ATLAS_ENCRYPTION_KEYS` keyset; the token carries `kid` so a v1-minted token verifies after v2 promotion as long as v1 stays in the keyset. `verify()` returns null on every failure mode — never throws, never leaks which check tripped.
- **`PlatformInstallHandler` interface family** — three concrete shapes (`OAuthPlatformInstallHandler`, `FormBasedInstallHandler`, `StaticBotInstallHandler`) discriminated by `kind`, under `packages/api/src/lib/integrations/install/`.
- **`StaticBotInstallHandler` stub** — throws `"not implemented until 1.5.3 — see milestone #51"` so the dispatch is exhaustive today.
- **`getInstallHandler(catalogRow)` dispatch** — switch on `install_model` with `_exhaustive: never` default branch (adding a fourth install model becomes a TS error here, not runtime drift). Empty per-slug `oauth`/`form` registries; slice 5 (#2653) registers Slack, #2660 registers Email/Webhook/Obsidian.
- **PRD implementation notes** — short subsection under "Dispatch shape pinned in 1.5.2" pinning the token claim shape, kid format, default TTL, verify policy, and mint-throws-on-misconfig decisions so 1.5.3 doesn't re-litigate them.

Per ADR-0004 this is **not** Better Auth machinery — Platform OAuth is a separate subsystem from user OAuth and does not touch the `account` table.

## Test plan

- [x] 16 unit tests for `OAuthStateToken` (`oauth-state-token.test.ts`): mint/verify roundtrip; tampered payload / signature / header rejected; `alg: "none"` downgrade rejected; expired token rejected; key rotation safe (v1-after-v2-promotion verifies, v1-after-eviction rejected); 4 malformed-input cases; 2 misconfig modes (mint throws / verify returns null when no key configured).
- [x] 10 dispatch tests (`dispatch.test.ts`): each `install_model` returns the expected handler kind; static-bot returns the operator-shared stub (same instance across slugs); stub `confirmInstall` throws the actionable `"1.5.3 — milestone #51"` error; registry overwrite semantics; `@ts-expect-error` on a fake `"manifest"` install model demonstrates the compile-time exhaustiveness gate; runtime throw as defense-in-depth.
- [x] `bun run lint` — pre-existing warnings only, no new findings.
- [x] `bun run type` — green (tsgo across all packages).
- [x] `bun run scripts/test-isolated.ts --affected` (in `packages/api/`) — 54 affected files, all pass (67s).
- [x] `bun x syncpack lint` — no issues.
- [x] `SKIP_SYNCPACK=1 bash scripts/check-template-drift.sh` — 640 files verified, no drift.
- [x] `bash scripts/check-railway-watch.sh` — all COPY sources covered.
- [x] `bash scripts/check-ee-imports.sh` — only `enterprise-layer.ts` imports from `@atlas/ee` (unchanged).
- [x] `bash scripts/check-schema-drift.sh` — 77 migrations present in schema.ts (unchanged).

## Out of scope

- No new routes — slice 5 lifts Slack to `/api/v1/integrations/slack/{install,callback}`.
- No persistence layer changes.
- No `@atlas/oauth-helper` package edits (no HMAC signer exported there today; consuming, not extending).
- No Slack / Teams / form-based handlers — slice 5 (#2653) and #2660 land those as `registerOAuthHandler` / `registerFormHandler` calls.

## Unblocks

- #2653 — Slack `OAuthPlatformInstallHandler` (slice 5)
- #2660 — Form-based `FormBasedInstallHandler` for Email / Webhook / Obsidian

These two can run in parallel post-merge.