### PR TITLE
fix(plugins/chat): pg-adapter appendToList trim binds unused params

### DIFF
--- a/plugins/chat/src/state/pg-adapter.test.ts
+++ b/plugins/chat/src/state/pg-adapter.test.ts
@@ -466,7 +466,10 @@ describe("PgStateAdapter lists", () => {
     expect(result).toEqual([]);
   });
 
-  it("appendToList with both maxLength and ttlMs uses $4 for trim", async () => {
+  it("appendToList with both maxLength and ttlMs trims with a fresh param list", async () => {
+    // Regression: previously the trim query inherited the insert's [key, jsonValue, ttlMs]
+    // params and tacked maxLength on as $4, leaving $2 and $3 bound but never referenced
+    // in the trim SQL. Postgres rejects that with "could not determine data type of parameter $2".
     const mock = createMockDB({
       queryResults: [[], [], [], [], [], [], []],
     });
@@ -476,13 +479,29 @@ describe("PgStateAdapter lists", () => {
 
     await adapter.appendToList("list1", { msg: "hi" }, { maxLength: 200, ttlMs: 604800000 });
 
-    // Insert uses $3 for TTL
+    // Insert uses $3 for TTL.
     expect(mock.calls[0].params).toEqual(["list1", '{"msg":"hi"}', 604800000]);
     expect(mock.calls[0].sql).toContain("make_interval");
 
-    // Trim uses $4 for maxLength
-    expect(mock.calls[1].sql).toContain("$4::int");
-    expect(mock.calls[1].params).toEqual(["list1", '{"msg":"hi"}', 604800000, 200]);
+    // Trim uses its own [key, maxLength] params with $2 for the limit — no orphan binds.
+    expect(mock.calls[1].sql).toContain("$2::int");
+    expect(mock.calls[1].sql).not.toContain("$3");
+    expect(mock.calls[1].sql).not.toContain("$4");
+    expect(mock.calls[1].params).toEqual(["list1", 200]);
+  });
+
+  it("appendToList with only maxLength (no ttlMs) also trims with $2", async () => {
+    const mock = createMockDB({
+      queryResults: [[], [], [], [], [], [], []],
+    });
+    const adapter = new PgStateAdapter(mock.db);
+    await adapter.connect();
+    mock.calls.length = 0;
+
+    await adapter.appendToList("list1", { msg: "hi" }, { maxLength: 50 });
+
+    expect(mock.calls[1].sql).toContain("$2::int");
+    expect(mock.calls[1].params).toEqual(["list1", 50]);
   });
 
   it("getList returns empty array for non-array value", async () => {

--- a/plugins/chat/src/state/pg-adapter.ts
+++ b/plugins/chat/src/state/pg-adapter.ts
@@ -246,11 +246,11 @@ export class PgStateAdapter implements StateAdapter {
       params,
     );
 
-    // Trim to maxLength if needed (keeps newest entries)
+    // Trim to maxLength if needed (keeps newest entries).
+    // Uses its own param list so Postgres can infer types — leaving the
+    // append-query's $2/$3 bound but unreferenced here triggers
+    // "could not determine data type of parameter $2".
     if (options?.maxLength != null) {
-      const trimParam = options.ttlMs != null ? "$4" : "$3";
-      const trimParams = [...params, options.maxLength];
-
       await this.db.query(
         `UPDATE ${this.t("cache")}
          SET value = (
@@ -258,12 +258,12 @@ export class PgStateAdapter implements StateAdapter {
              SELECT elem, ord
              FROM jsonb_array_elements(value) WITH ORDINALITY AS t(elem, ord)
              ORDER BY ord DESC
-             LIMIT ${trimParam}::int
+             LIMIT $2::int
            ) sub
          )
          WHERE key = $1
-           AND jsonb_array_length(value) > ${trimParam}::int`,
-        trimParams,
+           AND jsonb_array_length(value) > $2::int`,
+        [key, options.maxLength],
       );
     }
   }


### PR DESCRIPTION
## Summary

- `appendToList` in `plugins/chat/src/state/pg-adapter.ts` was reusing the insert query's `[key, jsonValue, ttlMs]` params for its trim query, leaving `$2`/`$3` bound but unreferenced — Postgres rejected every trim with `could not determine data type of parameter $2`.
- Trim now uses its own `[key, maxLength]` param list and references the limit as `$2`, matching the `enqueue` pattern.
- Production symptom: every `trackThreadParticipant` call in the proactive Slack flow failed with this SqlError, blocking participant inserts.

## Test plan

- [x] `bun test plugins/chat/src/state/pg-adapter.test.ts` — 31/31 pass (updated regression test asserts trim SQL references only `$1`/`$2` and binds exactly `[key, maxLength]`, both with and without `ttlMs`)
- [x] `bun run lint` — 0 errors (only pre-existing warnings)
- [x] `bun run type` — 0 errors
- [x] `bun run test` — full suite passes
- [x] `bun x syncpack lint` — clean
- [x] all drift checks — clean
- [ ] verify in #sandbox-atlas: ask a question, confirm participant tracking no longer logs `Failed to track thread participant` with the SqlError cause