### PR TITLE
feat: #2654 — wire /admin/integrations Connect → Slack OAuth end-to-end (1.5.2 slice 6)

### DIFF
--- a/apps/docs/content/docs/guides/slack.mdx
+++ b/apps/docs/content/docs/guides/slack.mdx
@@ -110,7 +110,9 @@ DATABASE_URL=postgresql://...         # Required — stores per-workspace bot to
 
 ### 3. Install Flow
 
-Direct users to `https://your-api-host/api/v1/integrations/slack/install`. This redirects to Slack's OAuth authorize page. After approval, the callback persists the bot token under `chat_cache:slack:installation:<teamId>` — the single store shared with the `@chat-adapter/slack` multi-workspace lookup path.
+The supported path is the admin UI: a Workspace admin opens **`/admin/integrations`** and clicks **Connect** on the Slack card. The button redirects to Slack's OAuth authorize page; after approval, the callback persists the bot token under `chat_cache:slack:installation:<teamId>` — the single store shared with the `@chat-adapter/slack` multi-workspace lookup path. The admin lands back on `/admin/integrations` with a success toast and the Slack card now showing the connected workspace name, install timestamp, and the user who completed the install.
+
+For headless installs (CI provisioning, SDK consumers), the install endpoint is still callable directly at `https://your-api-host/api/v1/integrations/slack/install`. A browser-based callback failure (invalid state, upstream Slack error) redirects to `/admin/integrations?error=slack&reason=...` with an actionable toast; JSON-Accept callers receive the original 400/502 for machine-readable debugging.
 
 ### 4. Workspace Disclosure
 

--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -42644,6 +42644,9 @@
                             "null"
                           ]
                         },
+                        "hasOAuthInstall": {
+                          "type": "boolean"
+                        },
                         "oauthConfigured": {
                           "type": "boolean"
                         },
@@ -42660,6 +42663,7 @@
                         "workspaceName",
                         "installedAt",
                         "installedBy",
+                        "hasOAuthInstall",
                         "oauthConfigured",
                         "envConfigured",
                         "configurable"

--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -42638,6 +42638,12 @@
                           ],
                           "format": "date-time"
                         },
+                        "installedBy": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
                         "oauthConfigured": {
                           "type": "boolean"
                         },
@@ -42653,6 +42659,7 @@
                         "teamId",
                         "workspaceName",
                         "installedAt",
+                        "installedBy",
                         "oauthConfigured",
                         "envConfigured",
                         "configurable"
@@ -72195,10 +72202,10 @@
         ],
         "responses": {
           "302": {
-            "description": "Install complete — redirected to /admin/integrations"
+            "description": "Install complete or failed in a recoverable way — redirected to /admin/integrations. Success: `?installed=<platform>`. Credential write missed: `?reconnect=<platform>`. Hard failure (browser caller): `?error=<platform>&reason=<code>`. JSON callers receive 400/502 instead."
           },
           "400": {
-            "description": "Invalid or expired state, or unknown platform",
+            "description": "Invalid or expired state, or unknown platform (JSON-Accept caller)",
             "content": {
               "application/json": {
                 "schema": {
@@ -72273,7 +72280,7 @@
             }
           },
           "502": {
-            "description": "Upstream Platform rejected the OAuth exchange",
+            "description": "Upstream Platform rejected the OAuth exchange (JSON-Accept caller)",
             "content": {
               "application/json": {
                 "schema": {

--- a/e2e/browser/admin-integrations-slack-connect.spec.ts
+++ b/e2e/browser/admin-integrations-slack-connect.spec.ts
@@ -1,0 +1,215 @@
+/**
+ * Browser e2e for the Slack Connect happy path (#2654, slice 6 of 1.5.2).
+ *
+ * Validates the UI wiring across the OAuth callback redirect, not the
+ * full Slack roundtrip — slice 5's route tests already cover the install
+ * handler. Here we:
+ *
+ *   1. Mock `/api/v1/admin/integrations/status` so the page renders
+ *      Slack as configurable-but-not-connected before the click. After
+ *      the simulated callback the mock flips to "connected" so the
+ *      Connected-state metadata renders.
+ *   2. Click the Slack Connect button to confirm the navigation target
+ *      is the `/api/v1/integrations/slack/install` endpoint (intercept
+ *      the request — don't follow it offsite to slack.com).
+ *   3. Navigate the page directly to `/admin/integrations?installed=slack`
+ *      to simulate the API callback's 302. Assert the green success
+ *      toast fires with the team name and the Slack card switches to
+ *      Connected with the install metadata visible.
+ *
+ * No `@llm` tag — pure DOM assertions, no model calls.
+ *
+ * Mock scope deliberately narrow: only `/api/v1/admin/integrations/status`
+ * is mocked. Other admin reads pass through (the page also hits
+ * `/api/v1/mode` etc. via shared admin chrome) — falling back to the real
+ * dev server keeps the test honest about page composition.
+ */
+
+import { test, expect, type Page, type Route } from "@playwright/test";
+
+// The `window` reference is evaluated inside the browser via
+// `page.waitForFunction` — declare it here so the file type-checks under
+// the Node-targeted e2e tsconfig.
+declare const window: { location: { search: string } };
+
+interface SlackStatusFixture {
+  connected: boolean;
+  workspaceName: string | null;
+  installedBy: string | null;
+}
+
+/** Default IntegrationStatus shape with one connected/disconnected fixture for Slack. */
+function buildStatus(slack: SlackStatusFixture) {
+  return {
+    slack: {
+      connected: slack.connected,
+      teamId: slack.connected ? "T01TESTTEAM" : null,
+      workspaceName: slack.workspaceName,
+      installedAt: slack.connected ? "2026-05-20T12:00:00.000Z" : null,
+      installedBy: slack.installedBy,
+      oauthConfigured: true,
+      envConfigured: false,
+      configurable: true,
+    },
+    teams: {
+      connected: false,
+      tenantId: null,
+      tenantName: null,
+      installedAt: null,
+      configurable: false,
+    },
+    discord: {
+      connected: false,
+      guildId: null,
+      guildName: null,
+      installedAt: null,
+      configurable: false,
+    },
+    telegram: {
+      connected: false,
+      botId: null,
+      botUsername: null,
+      installedAt: null,
+      configurable: false,
+    },
+    gchat: {
+      connected: false,
+      projectId: null,
+      serviceAccountEmail: null,
+      installedAt: null,
+      configurable: false,
+    },
+    github: {
+      connected: false,
+      username: null,
+      installedAt: null,
+      configurable: false,
+    },
+    linear: {
+      connected: false,
+      userName: null,
+      userEmail: null,
+      installedAt: null,
+      configurable: false,
+    },
+    whatsapp: {
+      connected: false,
+      phoneNumberId: null,
+      displayPhone: null,
+      installedAt: null,
+      configurable: false,
+    },
+    email: {
+      connected: false,
+      provider: null,
+      senderAddress: null,
+      installedAt: null,
+      configurable: false,
+    },
+    webhooks: { activeCount: 0, configurable: false },
+    deliveryChannels: ["email", "webhook"],
+    deployMode: "self-hosted",
+    hasInternalDB: true,
+  };
+}
+
+/**
+ * Wire up the /admin/integrations status mock. Returns a setter so the
+ * test can flip Slack from disconnected to connected mid-flow — the
+ * useAdminFetch invalidation on the toast effect refetches and sees the
+ * new state.
+ */
+async function installStatusMock(page: Page): Promise<(slack: SlackStatusFixture) => void> {
+  let current: SlackStatusFixture = {
+    connected: false,
+    workspaceName: null,
+    installedBy: null,
+  };
+
+  await page.route(/\/api\/v1\/admin\/integrations\/status(?:\?|$)/, async (route: Route) => {
+    if (route.request().method() !== "GET") {
+      await route.abort("failed");
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(buildStatus(current)),
+    });
+  });
+
+  return (next) => {
+    current = next;
+  };
+}
+
+test.describe("Admin Console — Slack Connect happy path", () => {
+  test("clicking Connect points at the install endpoint, then the callback redirect lands on a connected card + success toast", async ({ page }) => {
+    const setSlack = await installStatusMock(page);
+
+    // ── 1. Land on /admin/integrations with Slack disconnected. ────────
+    await page.goto("/admin/integrations");
+    await expect(page.locator("h1", { hasText: "Integrations" })).toBeVisible({ timeout: 15_000 });
+
+    // The Slack Connect button is rendered inside the legacy admin
+    // chrome (slice 6 wires the click through the existing anchor — we
+    // don't introduce a new test id, instead we anchor on the row that
+    // contains "Slack" and the visible Connect text).
+    const slackConnect = page
+      .locator("div", { hasText: "Slack" })
+      .getByRole("link", { name: /Connect/ })
+      .first();
+    await expect(slackConnect).toBeVisible({ timeout: 10_000 });
+
+    // The href must point at the install endpoint. We never follow it
+    // offsite — Playwright intercepts the request and aborts so the
+    // Slack OAuth dance doesn't actually run.
+    const href = await slackConnect.getAttribute("href");
+    expect(href ?? "").toContain("/api/v1/integrations/slack/install");
+
+    // Block the install endpoint so a stray click can't actually
+    // round-trip to Slack during the test. (We don't click the link —
+    // we navigate manually to the callback below — but the route guard
+    // keeps the test deterministic if a future change wires a fetch.)
+    await page.route(/\/api\/v1\/integrations\/slack\/install$/, (route) => route.abort("blockedbyclient"));
+
+    // ── 2. Flip the status mock to "connected" and navigate to the
+    //       admin page with the callback's `?installed=slack` query
+    //       param. This simulates the 302 from the API callback handler.
+    setSlack({
+      connected: true,
+      workspaceName: "TestTeam",
+      installedBy: "admin@useatlas.dev",
+    });
+    await page.goto("/admin/integrations?installed=slack");
+
+    // ── 3. Green success toast names the workspace. sonner renders a
+    //       <li> with the title inside; matching on the visible text is
+    //       robust to icon/role changes.
+    await expect(page.getByText("Slack connected to TestTeam")).toBeVisible({ timeout: 10_000 });
+
+    // ── 4. The Connected state replaces the Connect button with a
+    //       Reconnect link + a disabled Disconnect button (slice 6
+    //       placeholder for #2655). Both must be visible.
+    await expect(
+      page.locator("a", { hasText: "Reconnect" }),
+    ).toBeVisible({ timeout: 5_000 });
+
+    const disconnectButton = page.getByRole("button", { name: "Disconnect" });
+    await expect(disconnectButton).toBeVisible();
+    await expect(disconnectButton).toBeDisabled();
+
+    // ── 5. The "Connected by … on …" metadata renders inside the
+    //       Slack card. The label "Connected" is paired with a value
+    //       that includes the formatted timestamp and the installer.
+    await expect(page.getByText(/admin@useatlas\.dev/)).toBeVisible();
+
+    // ── 6. The query param has been stripped via router.replace so a
+    //       refresh wouldn't re-fire the toast.
+    await page.waitForFunction(
+      () => !window.location.search.includes("installed="),
+      undefined,
+      { timeout: 5_000 },
+    );
+  });
+});

--- a/e2e/browser/admin-integrations-slack-connect.spec.ts
+++ b/e2e/browser/admin-integrations-slack-connect.spec.ts
@@ -47,6 +47,7 @@ function buildStatus(slack: SlackStatusFixture) {
       workspaceName: slack.workspaceName,
       installedAt: slack.connected ? "2026-05-20T12:00:00.000Z" : null,
       installedBy: slack.installedBy,
+      hasOAuthInstall: slack.connected,
       oauthConfigured: true,
       envConfigured: false,
       configurable: true,

--- a/packages/api/src/api/routes/__tests__/integrations.test.ts
+++ b/packages/api/src/api/routes/__tests__/integrations.test.ts
@@ -1,0 +1,318 @@
+/**
+ * Tests for the platform-install routes (#2654, slice 6).
+ *
+ * Focus: the OAuth callback's response shape. Slice 5 already covered the
+ * happy-path 302 + the credential-partial 302; slice 6 promotes hard
+ * failures (`null` state, upstream `oauth.v2.access` non-OK) from JSON
+ * 400/502 to 302 redirects when the caller is a browser (`Accept:
+ * text/html`). JSON-Accept callers still get the original 400/502 so
+ * curl-based debugging stays machine-readable.
+ *
+ * The test app mounts the integrations router at /api/v1/integrations
+ * and stubs out the install handler's dispatch via a fake handler so the
+ * tests don't depend on the real Slack `oauth.v2.access` round-trip or
+ * the workspace_plugins INSERT.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it, mock } from "bun:test";
+import { Context, Effect, Layer } from "effect";
+import { PlatformOAuthExchangeError } from "@atlas/api/lib/effect/errors";
+import {
+  MockInternalDB,
+  makeMockInternalDBShimLayer,
+} from "@atlas/api/testing/api-test-mocks";
+import {
+  _resetInstallHandlerRegistries,
+  registerOAuthHandler,
+  type OAuthPlatformInstallHandler,
+} from "@atlas/api/lib/integrations/install";
+
+// ---------------------------------------------------------------------------
+// Auth — admin user with an org binding for the install route. The
+// callback handler doesn't gate on auth (the state token is the gate),
+// so the admin shape is only load-bearing for the install endpoint;
+// callback tests pass anonymous requests through fine.
+// ---------------------------------------------------------------------------
+
+mock.module("@atlas/api/lib/auth/middleware", () => ({
+  authenticateRequest: mock(() =>
+    Promise.resolve({
+      authenticated: true,
+      mode: "managed",
+      user: {
+        id: "admin-1",
+        role: "admin",
+        activeOrganizationId: "ws-1",
+      },
+    }),
+  ),
+  checkRateLimit: () => ({ allowed: true }),
+  getClientIP: () => null,
+  resetRateLimits: () => {},
+  rateLimitCleanupTick: () => {},
+}));
+
+mock.module("@atlas/api/lib/logger", () => {
+  const noop = () => {};
+  const logger = { info: noop, warn: noop, error: noop, debug: noop, child: () => logger };
+  return {
+    createLogger: () => logger,
+    getLogger: () => logger,
+    withRequestContext: (_ctx: unknown, fn: () => unknown) => fn(),
+    getRequestContext: () => undefined,
+    redactPaths: [],
+  };
+});
+
+mock.module("@atlas/ee/auth/ip-allowlist", () => ({
+  checkIPAllowlist: () => Effect.succeed({ allowed: true }),
+}));
+
+// ---------------------------------------------------------------------------
+// Internal DB — the catalog row lookup hits `internalQuery`. Default
+// response is the Slack OAuth row; individual tests override via
+// `mockInternalQuery.mockImplementationOnce` for the "platform not
+// found" path.
+// ---------------------------------------------------------------------------
+
+const mockInternalQuery = mock(async (_sql: string, _params?: unknown[]): Promise<unknown[]> => [
+  { slug: "slack", install_model: "oauth", enabled: true },
+]);
+
+mock.module("@atlas/api/lib/db/internal", () => ({
+  InternalDB: MockInternalDB,
+  hasInternalDB: () => true,
+  internalQuery: mockInternalQuery,
+  internalExecute: mock(() => Promise.resolve()),
+  makeInternalDBShimLayer: () => makeMockInternalDBShimLayer(mockInternalQuery, { available: true }),
+  makeInternalDBLive: () => Layer.succeedContext(Context.empty()),
+  createInternalDBTestLayer: () => makeMockInternalDBShimLayer(mockInternalQuery, { available: true }),
+  getInternalDB: () => ({
+    query: mockInternalQuery,
+    connect: () => ({ query: mockInternalQuery, release: () => {} }),
+    end: async () => {},
+    on: () => {},
+  }),
+  closeInternalDB: async () => {},
+  queryEffect: (sql: string, params?: unknown[]) =>
+    Effect.tryPromise({
+      try: () => mockInternalQuery(sql, params),
+      catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+    }),
+  migrateInternalDB: async () => {},
+  loadSavedConnections: async () => 0,
+  findPatternBySQL: async () => null,
+  insertLearnedPattern: () => {},
+  insertSemanticAmendment: async () => {},
+  getPendingAmendmentCount: async () => 0,
+  getAutoApproveThreshold: () => 0.95,
+  getAutoApproveTypes: () => new Set<string>(),
+  getEncryptionKey: () => null,
+  encryptSecret: (v: string) => v,
+  decryptSecret: (v: string) => v,
+  isPlaintextUrl: () => true,
+  _resetEncryptionKeyCache: () => {},
+  _resetPool: () => {},
+  _resetCircuitBreaker: () => {},
+}));
+
+// ---------------------------------------------------------------------------
+// Web origin — fixes the absolute redirect target so tests can assert
+// the full URL without depending on the host's env.
+// ---------------------------------------------------------------------------
+
+const ORIGINAL_ENV = { ...process.env };
+process.env.ATLAS_CORS_ORIGIN = "https://app.atlas.example";
+
+// ---------------------------------------------------------------------------
+// Fake OAuth handler — swapped in per test via the install registry's
+// idempotent registerOAuthHandler. Drives the callback's three branches:
+//
+//   - happy:    returns { credentialResult: { written: true } }
+//   - reconnect: returns { credentialResult: { written: false } }
+//   - invalid:  returns null
+//   - upstream: throws PlatformOAuthExchangeError
+//
+// Slice 5 already covers the handler's internal contract; here we only
+// need the route's view of the four outcomes.
+// ---------------------------------------------------------------------------
+
+type CallbackResult = Awaited<ReturnType<OAuthPlatformInstallHandler["handleCallback"]>>;
+
+let callbackImpl: () => Promise<CallbackResult> = async () => null;
+
+const fakeHandler: OAuthPlatformInstallHandler = {
+  kind: "oauth" as const,
+  startInstall: async () => ({
+    redirectUrl: "https://slack.com/oauth/v2/authorize?client_id=test&state=stub",
+    stateToken: "stub",
+  }),
+  handleCallback: async () => callbackImpl(),
+};
+
+// ---------------------------------------------------------------------------
+// Late imports (after mocks)
+// ---------------------------------------------------------------------------
+
+const { integrations } = await import("../integrations");
+const { Hono } = await import("hono");
+
+const app = new Hono();
+app.route("/api/v1/integrations", integrations);
+
+function request(path: string, init?: RequestInit) {
+  return app.request(`http://localhost${path}`, init);
+}
+
+// ---------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------
+
+beforeAll(() => {
+  registerOAuthHandler("slack", fakeHandler);
+});
+
+afterAll(() => {
+  _resetInstallHandlerRegistries();
+  process.env = { ...ORIGINAL_ENV };
+});
+
+beforeEach(() => {
+  callbackImpl = async () => null;
+  mockInternalQuery.mockImplementation(async () => [
+    { slug: "slack", install_model: "oauth", enabled: true },
+  ]);
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function happyResult(): CallbackResult {
+  return {
+    workspaceId: "ws-1" as never,
+    catalogId: "slack",
+    installRecord: {
+      id: "install-1",
+      workspaceId: "ws-1" as never,
+      catalogId: "slack",
+    },
+    credentialResult: { written: true },
+  };
+}
+
+function partialResult(): CallbackResult {
+  return {
+    workspaceId: "ws-1" as never,
+    catalogId: "slack",
+    installRecord: {
+      id: "install-1",
+      workspaceId: "ws-1" as never,
+      catalogId: "slack",
+    },
+    credentialResult: { written: false, reason: "Credential persist failed — admin should retry via Reconnect" },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("GET /api/v1/integrations/slack/callback — happy path", () => {
+  it("redirects to /admin/integrations?installed=slack on success", async () => {
+    callbackImpl = async () => happyResult();
+
+    const res = await request(
+      "/api/v1/integrations/slack/callback?code=auth-abc&state=stub",
+      { headers: { Accept: "text/html" } },
+    );
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toBe(
+      "https://app.atlas.example/admin/integrations?installed=slack",
+    );
+  });
+
+  it("redirects with ?reconnect=slack when the credential write missed (ADR-0003 partial)", async () => {
+    callbackImpl = async () => partialResult();
+
+    const res = await request(
+      "/api/v1/integrations/slack/callback?code=auth-abc&state=stub",
+      { headers: { Accept: "text/html" } },
+    );
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toBe(
+      "https://app.atlas.example/admin/integrations?reconnect=slack",
+    );
+  });
+});
+
+describe("GET /api/v1/integrations/slack/callback — invalid state", () => {
+  it("redirects to /admin/integrations?error=slack&reason=invalid_state for browser callers", async () => {
+    callbackImpl = async () => null;
+
+    const res = await request(
+      "/api/v1/integrations/slack/callback?code=auth-abc&state=tampered",
+      { headers: { Accept: "text/html" } },
+    );
+
+    expect(res.status).toBe(302);
+    const location = res.headers.get("location") ?? "";
+    expect(location).toContain("https://app.atlas.example/admin/integrations");
+    expect(location).toContain("error=slack");
+    expect(location).toContain("reason=invalid_state");
+  });
+
+  it("still returns 400 JSON for application/json callers (back-compat for curl)", async () => {
+    callbackImpl = async () => null;
+
+    const res = await request(
+      "/api/v1/integrations/slack/callback?code=auth-abc&state=tampered",
+      { headers: { Accept: "application/json" } },
+    );
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("invalid_state");
+  });
+});
+
+describe("GET /api/v1/integrations/slack/callback — upstream Slack failure", () => {
+  it("redirects to /admin/integrations?error=slack&reason=upstream_error for browser callers", async () => {
+    callbackImpl = async () => {
+      throw new PlatformOAuthExchangeError({
+        message: "Slack rejected the OAuth code.",
+        platform: "slack",
+        upstreamError: "invalid_code",
+      });
+    };
+
+    const res = await request(
+      "/api/v1/integrations/slack/callback?code=bad-code&state=stub",
+      { headers: { Accept: "text/html" } },
+    );
+
+    expect(res.status).toBe(302);
+    const location = res.headers.get("location") ?? "";
+    expect(location).toContain("error=slack");
+    expect(location).toContain("reason=upstream_error");
+  });
+
+  it("still returns 502 JSON for application/json callers", async () => {
+    callbackImpl = async () => {
+      throw new PlatformOAuthExchangeError({
+        message: "Slack rejected the OAuth code.",
+        platform: "slack",
+        upstreamError: "invalid_code",
+      });
+    };
+
+    const res = await request(
+      "/api/v1/integrations/slack/callback?code=bad-code&state=stub",
+      { headers: { Accept: "application/json" } },
+    );
+
+    expect(res.status).toBe(502);
+  });
+});

--- a/packages/api/src/api/routes/__tests__/integrations.test.ts
+++ b/packages/api/src/api/routes/__tests__/integrations.test.ts
@@ -316,3 +316,43 @@ describe("GET /api/v1/integrations/slack/callback — upstream Slack failure", (
     expect(res.status).toBe(502);
   });
 });
+
+describe("GET /api/v1/integrations/slack/callback — non-OAuth-exchange failure", () => {
+  // Slice 5's SlackOAuthInstallHandler re-throws raw errors when the
+  // workspace_plugins INSERT fails — those must NOT be downgraded to a
+  // "click Reconnect" toast. The browser caller still sees a 500 with a
+  // request id so the admin reports an actual bug instead of cycling
+  // through an unhelpful retry loop.
+  it("rethrows non-PlatformOAuthExchangeError for browser callers — runHandler maps to 500", async () => {
+    callbackImpl = async () => {
+      throw new Error("workspace_plugins INSERT failed: connection refused");
+    };
+
+    const res = await request(
+      "/api/v1/integrations/slack/callback?code=auth-abc&state=stub",
+      { headers: { Accept: "text/html" } },
+    );
+
+    // Definitely not a redirect masking the fault.
+    expect(res.status).not.toBe(302);
+    // runHandler's default mapper surfaces unknown errors as 500.
+    expect(res.status).toBe(500);
+  });
+
+  it("rethrows non-PlatformOAuthExchangeError for JSON callers too", async () => {
+    callbackImpl = async () => {
+      throw new Error("workspace_plugins INSERT failed: connection refused");
+    };
+
+    const res = await request(
+      "/api/v1/integrations/slack/callback?code=auth-abc&state=stub",
+      { headers: { Accept: "application/json" } },
+    );
+
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { requestId?: string };
+    // 500 responses always include a requestId for log correlation
+    // (runHandler bridge invariant).
+    expect(body.requestId).toBeDefined();
+  });
+});

--- a/packages/api/src/api/routes/admin-integrations.ts
+++ b/packages/api/src/api/routes/admin-integrations.ts
@@ -200,12 +200,36 @@ adminIntegrations.openapi(getStatusRoute, async (c) => {
 
       const deployMode = getConfig()?.deployMode ?? "self-hosted";
 
-      // Run all integration lookups in parallel — they are independent
-      const [slackInstall, teamsInstall, discordInstall, telegramInstall, gchatInstall, githubInstall, linearInstall, whatsappInstall, emailInstall, webhookActiveCount] =
+      // Run all integration lookups in parallel — they are independent.
+      // The `slackInstallMeta` lookup reads the slice 5 install record
+      // (`workspace_plugins`) for `installed_by` / `installed_at`, which
+      // `chat_cache` does not carry. Null on legacy installs that
+      // predate slice 5 — the UI then degrades to "Connected on <chat_cache
+      // installed_at>" without the "by X" part. Cheap (one PK lookup
+      // on the unique workspace_id + catalog_id index).
+      const [slackInstall, slackInstallMeta, teamsInstall, discordInstall, telegramInstall, gchatInstall, githubInstall, linearInstall, whatsappInstall, emailInstall, webhookActiveCount] =
         yield* Effect.all(
           [
             Effect.tryPromise({
               try: () => getInstallationByOrg(orgId),
+              catch: (err) => err instanceof Error ? err : new Error(String(err)),
+            }),
+            Effect.tryPromise({
+              try: async () => {
+                if (!hasInternalDB()) return null;
+                const rows = await internalQuery<{
+                  installed_at: string | null;
+                  installed_by: string | null;
+                }>(
+                  `SELECT to_char(installed_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') AS installed_at,
+                          installed_by
+                     FROM workspace_plugins
+                    WHERE workspace_id = $1 AND catalog_id = 'catalog:slack'
+                    LIMIT 1`,
+                  [orgId],
+                );
+                return rows[0] ?? null;
+              },
               catch: (err) => err instanceof Error ? err : new Error(String(err)),
             }),
             Effect.tryPromise({
@@ -264,11 +288,15 @@ adminIntegrations.openapi(getStatusRoute, async (c) => {
       const envConfigured = !!process.env.SLACK_BOT_TOKEN;
       const slackConfigurable = oauthConfigured;
 
+      // Prefer `workspace_plugins.installed_at` when present — it's the
+      // canonical first-store timestamp (slice 5 always writes it). Fall
+      // back to the chat_cache value for legacy installs.
       const slack = {
         connected: slackInstall !== null,
         teamId: slackInstall?.team_id ?? null,
         workspaceName: slackInstall?.workspace_name ?? null,
-        installedAt: slackInstall?.installed_at ?? null,
+        installedAt: slackInstallMeta?.installed_at ?? slackInstall?.installed_at ?? null,
+        installedBy: slackInstallMeta?.installed_by ?? null,
         oauthConfigured,
         envConfigured,
         configurable: slackConfigurable,

--- a/packages/api/src/api/routes/admin-integrations.ts
+++ b/packages/api/src/api/routes/admin-integrations.ts
@@ -291,12 +291,21 @@ adminIntegrations.openapi(getStatusRoute, async (c) => {
       // Prefer `workspace_plugins.installed_at` when present — it's the
       // canonical first-store timestamp (slice 5 always writes it). Fall
       // back to the chat_cache value for legacy installs.
+      //
+      // `hasOAuthInstall` discriminates OAuth installs (slice-5 wrote a
+      // workspace_plugins row) from BYOT / env-token installs (only
+      // chat_cache or env). The admin UI gates the slice-6 "Disconnect
+      // pending in #2655" placeholder on this — BYOT installs still get
+      // the working DisconnectDialog because their teardown path
+      // (`DELETE /admin/integrations/slack` → `deleteInstallationByOrg`)
+      // is unchanged.
       const slack = {
         connected: slackInstall !== null,
         teamId: slackInstall?.team_id ?? null,
         workspaceName: slackInstall?.workspace_name ?? null,
         installedAt: slackInstallMeta?.installed_at ?? slackInstall?.installed_at ?? null,
         installedBy: slackInstallMeta?.installed_by ?? null,
+        hasOAuthInstall: slackInstallMeta !== null,
         oauthConfigured,
         envConfigured,
         configurable: slackConfigurable,

--- a/packages/api/src/api/routes/integrations.ts
+++ b/packages/api/src/api/routes/integrations.ts
@@ -101,11 +101,16 @@ const callbackRoute = createRoute({
     }),
   },
   responses: {
-    302: { description: "Install complete — redirected to /admin/integrations" },
-    400: { description: "Invalid or expired state, or unknown platform", content: { "application/json": { schema: ErrorSchema } } },
+    302: {
+      description:
+        "Install complete or failed in a recoverable way — redirected to /admin/integrations. " +
+        "Success: `?installed=<platform>`. Credential write missed: `?reconnect=<platform>`. " +
+        "Hard failure (browser caller): `?error=<platform>&reason=<code>`. JSON callers receive 400/502 instead.",
+    },
+    400: { description: "Invalid or expired state, or unknown platform (JSON-Accept caller)", content: { "application/json": { schema: ErrorSchema } } },
     404: { description: "Platform not found in catalog", content: { "application/json": { schema: ErrorSchema } } },
     501: { description: "OAuth handler not registered", content: { "application/json": { schema: ErrorSchema } } },
-    502: { description: "Upstream Platform rejected the OAuth exchange", content: { "application/json": { schema: ErrorSchema } } },
+    502: { description: "Upstream Platform rejected the OAuth exchange (JSON-Accept caller)", content: { "application/json": { schema: ErrorSchema } } },
   },
 });
 
@@ -117,6 +122,36 @@ interface CatalogRowFromDb extends Record<string, unknown> {
   readonly slug: string;
   readonly install_model: string;
   readonly enabled: boolean;
+}
+
+/**
+ * The OAuth callback's realistic caller is a browser — the platform
+ * authorize page redirects with a `<meta>`-driven 302. We want hard
+ * failures (invalid state, upstream-non-OK) to land on the admin UI with
+ * an actionable toast, not on a raw JSON page.
+ *
+ * Heuristic: if the `Accept` header includes `text/html` (the browser
+ * default), redirect to `/admin/integrations?error=:platform&reason=:code`.
+ * Otherwise keep the JSON response so curl-based debugging still sees the
+ * machine-readable error. Browsers don't send `application/json` on a
+ * top-level navigation, so this split is stable.
+ */
+function prefersHtml(req: Request): boolean {
+  const accept = req.headers.get("accept") ?? "";
+  return accept.includes("text/html");
+}
+
+function buildAdminIntegrationsUrl(
+  param: "installed" | "reconnect" | "error",
+  platform: string,
+  extra?: Record<string, string>,
+): string {
+  const webOrigin = getWebOrigin();
+  const base = webOrigin
+    ? `${webOrigin}/admin/integrations`
+    : "/admin/integrations";
+  const qs = new URLSearchParams({ [param]: platform, ...extra });
+  return `${base}?${qs.toString()}`;
 }
 
 /**
@@ -269,8 +304,34 @@ integrations.openapi(callbackRoute, async (c) =>
       return c.json({ error: "handler_unavailable", message: "Install handler misconfigured.", requestId }, 501);
     }
 
-    const result = await handler.handleCallback(code, state);
+    let result: Awaited<ReturnType<typeof handler.handleCallback>>;
+    try {
+      result = await handler.handleCallback(code, state);
+    } catch (err) {
+      // The handler throws `PlatformOAuthExchangeError` for upstream
+      // failures (e.g. Slack `oauth.v2.access` non-OK). For browser
+      // callers, redirect to the admin UI with an actionable reason so
+      // the toast can translate the upstream error. JSON callers fall
+      // through to runHandler's default tagged-error → HTTP mapping
+      // (which surfaces 502 for `PlatformOAuthExchangeError`).
+      log.warn(
+        { platform, err: err instanceof Error ? err.message : String(err) },
+        "Install callback failed with upstream error",
+      );
+      if (prefersHtml(c.req.raw)) {
+        return c.redirect(buildAdminIntegrationsUrl("error", platform, { reason: "upstream_error" }));
+      }
+      throw err;
+    }
     if (result === null) {
+      // Forged / expired / tampered state. Log once at the handler
+      // boundary so the operator sees the rate (a flood of these means
+      // an attacker probing). Browser callers get a toast-friendly
+      // redirect; JSON callers keep the 400.
+      log.warn({ platform }, "Install callback rejected invalid state token");
+      if (prefersHtml(c.req.raw)) {
+        return c.redirect(buildAdminIntegrationsUrl("error", platform, { reason: "invalid_state" }));
+      }
       return c.json(
         { error: "invalid_state", message: "Invalid or expired install state. Restart the install from /admin/integrations.", requestId },
         400,
@@ -280,12 +341,8 @@ integrations.openapi(callbackRoute, async (c) =>
     // Success — redirect to admin UI. Partial-failure (credential write
     // didn't land) flips the query param so /admin/integrations shows
     // a Reconnect affordance per ADR-0003.
-    const webOrigin = getWebOrigin();
     const queryParam = result.credentialResult.written ? "installed" : "reconnect";
-    const target = webOrigin
-      ? `${webOrigin}/admin/integrations?${queryParam}=${encodeURIComponent(platform)}`
-      : `/admin/integrations?${queryParam}=${encodeURIComponent(platform)}`;
-    return c.redirect(target);
+    return c.redirect(buildAdminIntegrationsUrl(queryParam, platform));
   }),
 );
 

--- a/packages/api/src/api/routes/integrations.ts
+++ b/packages/api/src/api/routes/integrations.ts
@@ -42,6 +42,7 @@ import { createLogger } from "@atlas/api/lib/logger";
 import { getWebOrigin } from "@atlas/api/lib/web-origin";
 import { runHandler } from "@atlas/api/lib/effect/hono";
 import { getConfig } from "@atlas/api/lib/config";
+import { PlatformOAuthExchangeError } from "@atlas/api/lib/effect/errors";
 import { getInstallHandler } from "@atlas/api/lib/integrations/install";
 import { adminAuthPreamble } from "./admin-auth";
 import { validationHook } from "./validation-hook";
@@ -308,18 +309,24 @@ integrations.openapi(callbackRoute, async (c) =>
     try {
       result = await handler.handleCallback(code, state);
     } catch (err) {
-      // The handler throws `PlatformOAuthExchangeError` for upstream
-      // failures (e.g. Slack `oauth.v2.access` non-OK). For browser
-      // callers, redirect to the admin UI with an actionable reason so
-      // the toast can translate the upstream error. JSON callers fall
-      // through to runHandler's default tagged-error → HTTP mapping
-      // (which surfaces 502 for `PlatformOAuthExchangeError`).
-      log.warn(
-        { platform, err: err instanceof Error ? err.message : String(err) },
-        "Install callback failed with upstream error",
-      );
-      if (prefersHtml(c.req.raw)) {
-        return c.redirect(buildAdminIntegrationsUrl("error", platform, { reason: "upstream_error" }));
+      // ONLY `PlatformOAuthExchangeError` is a user-actionable
+      // "the upstream Platform refused the code exchange" — those get
+      // the browser redirect to a translated toast. Every other throw
+      // (e.g. the workspace_plugins INSERT in slice 5's handler
+      // failing, an unhandled DB error, a logic bug) must propagate
+      // to `runHandler`'s tagged-error → HTTP mapping so the user
+      // sees a real 5xx with a `requestId` for log correlation —
+      // not a misleading "click Reconnect" toast on top of a server
+      // fault. JSON callers always fall through to the standard
+      // mapper.
+      if (err instanceof PlatformOAuthExchangeError) {
+        log.warn(
+          { platform, err: err.message, upstreamError: err.upstreamError },
+          "Install callback failed: upstream OAuth exchange refused",
+        );
+        if (prefersHtml(c.req.raw)) {
+          return c.redirect(buildAdminIntegrationsUrl("error", platform, { reason: "upstream_error" }));
+        }
       }
       throw err;
     }

--- a/packages/schemas/src/__tests__/integrations.test.ts
+++ b/packages/schemas/src/__tests__/integrations.test.ts
@@ -19,6 +19,7 @@ const slack = {
   teamId: "T01ABCD2EF",
   workspaceName: "Acme HQ",
   installedAt: "2026-04-19T12:00:00.000Z",
+  installedBy: "user_01ABCDEF",
   oauthConfigured: true,
   envConfigured: false,
   configurable: true,

--- a/packages/schemas/src/__tests__/integrations.test.ts
+++ b/packages/schemas/src/__tests__/integrations.test.ts
@@ -20,6 +20,7 @@ const slack = {
   workspaceName: "Acme HQ",
   installedAt: "2026-04-19T12:00:00.000Z",
   installedBy: "user_01ABCDEF",
+  hasOAuthInstall: true,
   oauthConfigured: true,
   envConfigured: false,
   configurable: true,

--- a/packages/schemas/src/integrations.ts
+++ b/packages/schemas/src/integrations.ts
@@ -45,6 +45,7 @@ export const SlackStatusSchema = z.object({
   teamId: z.string().nullable(),
   workspaceName: z.string().nullable(),
   installedAt: z.string().datetime().nullable(),
+  installedBy: z.string().nullable(),
   oauthConfigured: z.boolean(),
   envConfigured: z.boolean(),
   configurable: z.boolean(),

--- a/packages/schemas/src/integrations.ts
+++ b/packages/schemas/src/integrations.ts
@@ -46,6 +46,7 @@ export const SlackStatusSchema = z.object({
   workspaceName: z.string().nullable(),
   installedAt: z.string().datetime().nullable(),
   installedBy: z.string().nullable(),
+  hasOAuthInstall: z.boolean(),
   oauthConfigured: z.boolean(),
   envConfigured: z.boolean(),
   configurable: z.boolean(),

--- a/packages/types/src/integrations.ts
+++ b/packages/types/src/integrations.ts
@@ -54,6 +54,13 @@ interface ConnectedPlatformBase {
 export interface SlackStatus extends ConnectedPlatformBase {
   teamId: string | null;
   workspaceName: string | null;
+  /**
+   * User id of the admin who completed the OAuth install (from
+   * `workspace_plugins.installed_by`). Null on legacy installs that
+   * predate the slice-5 install handler — the UI degrades to
+   * "Connected on {installedAt}" when null.
+   */
+  installedBy: string | null;
   /** Whether Slack OAuth env vars are configured (SLACK_CLIENT_ID etc.). */
   oauthConfigured: boolean;
   /** Whether env-based token is set (single-workspace mode). */

--- a/packages/types/src/integrations.ts
+++ b/packages/types/src/integrations.ts
@@ -61,6 +61,18 @@ export interface SlackStatus extends ConnectedPlatformBase {
    * "Connected on {installedAt}" when null.
    */
   installedBy: string | null;
+  /**
+   * True when the active install was completed via OAuth — i.e. a
+   * `workspace_plugins` row exists for this workspace's Slack catalog
+   * entry. BYOT and env-token installs leave this `false` because they
+   * write only to `chat_cache`, not `workspace_plugins`.
+   *
+   * The admin UI uses this to decide whether to render the OAuth-only
+   * Disconnect affordance (slice-6 placeholder pointing at #2655) vs.
+   * the existing BYOT Disconnect dialog (which already works against
+   * the chat_cache row).
+   */
+  hasOAuthInstall: boolean;
   /** Whether Slack OAuth env vars are configured (SLACK_CLIENT_ID etc.). */
   oauthConfigured: boolean;
   /** Whether env-based token is set (single-workspace mode). */

--- a/packages/web/src/app/admin/integrations/page.tsx
+++ b/packages/web/src/app/admin/integrations/page.tsx
@@ -1,6 +1,8 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { toast } from "sonner";
 import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
 import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
 import { friendlyErrorOrNull } from "@/ui/lib/fetch-error";
@@ -48,6 +50,12 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import Link from "next/link";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
@@ -70,9 +78,46 @@ import {
 
 // -- Component --
 
+// Human-readable labels for OAuth callback query-param toasts. New
+// platforms must be appended as their slice-6 equivalent wires the
+// Connect button — TS narrowing on `data.<platform>` won't flag a
+// missing entry here, so audit when adding a row.
+const PLATFORM_LABEL: Record<string, string> = {
+  slack: "Slack",
+  teams: "Microsoft Teams",
+  discord: "Discord",
+};
+
+/**
+ * Translate the `reason=` code from the API callback's error redirect
+ * into actionable copy. Reasons are stable wire codes (`invalid_state`,
+ * `upstream_error`) emitted by `packages/api/src/api/routes/integrations.ts`
+ * — keep the cases in lockstep with that file. Unknown reasons fall back
+ * to a non-vague but generic message; "Something went wrong" is forbidden
+ * per CLAUDE.md.
+ */
+function translateInstallError(platform: string, reason: string | null): string {
+  const platformLabel = PLATFORM_LABEL[platform] ?? platform;
+  switch (reason) {
+    case "invalid_state":
+      return `The ${platformLabel} install session expired or was tampered with. Click Connect to start a fresh install.`;
+    case "upstream_error":
+      return `${platformLabel} rejected the OAuth handshake. Check the app's redirect URL matches this deploy, then retry.`;
+    default:
+      return `The ${platformLabel} OAuth callback failed. Click Connect to retry — if the problem persists, check the app credentials.`;
+  }
+}
+
 export default function IntegrationsPage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
   const { data, loading, error, refetch } =
     useAdminFetch("/api/v1/admin/integrations/status", { schema: IntegrationStatusSchema });
+
+  // Holds the platform slug whose success toast is waiting for fresh
+  // data — fired in a follow-up effect once the GET reflects the new
+  // Connected state (so the toast can surface the team name).
+  const [pendingSuccessPlatform, setPendingSuccessPlatform] = useState<string | null>(null);
 
   const disconnectMutation = useAdminMutation<{ message: string }>({
     path: "/api/v1/admin/integrations/slack",
@@ -260,6 +305,61 @@ export default function IntegrationsPage() {
   async function handleWhatsAppDisconnect() {
     await whatsappDisconnectMutation.mutate({});
   }
+
+  // ── OAuth callback query-param toasts ──────────────────────────────
+  //
+  // The API callback (`/api/v1/integrations/:platform/callback`) lands
+  // here with one of `?installed=`, `?reconnect=`, or `?error=&reason=`.
+  // Strip the param after firing the toast so a refresh doesn't replay
+  // it. Success toasts pause until the fresh GET reflects the new
+  // Connected state — that's how we get the team name in the toast.
+  useEffect(() => {
+    const installed = searchParams.get("installed");
+    const reconnect = searchParams.get("reconnect");
+    const errParam = searchParams.get("error");
+    const reason = searchParams.get("reason");
+    if (!installed && !reconnect && !errParam) return;
+
+    if (installed) {
+      setPendingSuccessPlatform(installed);
+      refetch();
+    }
+    if (reconnect) {
+      const label = PLATFORM_LABEL[reconnect] ?? reconnect;
+      toast.warning(`${label} install completed but credentials didn't persist`, {
+        description: "Click Reconnect on the card to retry the OAuth dance.",
+      });
+      refetch();
+    }
+    if (errParam) {
+      const label = PLATFORM_LABEL[errParam] ?? errParam;
+      toast.error(`Couldn't connect ${label}`, {
+        description: translateInstallError(errParam, reason),
+      });
+    }
+    // Strip query params so a manual refresh doesn't re-fire the toast.
+    router.replace("/admin/integrations", { scroll: false });
+    // Deps narrow on the serialized search string so a transient render
+    // with an unchanged URL doesn't re-trigger. router + refetch are
+    // stable references from Next + useAdminFetch and don't need to be
+    // listed here.
+  }, [searchParams, refetch, router]);
+
+  // Fire the deferred success toast once the GET reports the platform
+  // as connected. Reading the team name from the response keeps the
+  // toast specific ("Slack connected to TestTeam") rather than generic.
+  useEffect(() => {
+    if (!pendingSuccessPlatform || !data) return;
+    if (pendingSuccessPlatform === "slack" && data.slack?.connected) {
+      const workspace = data.slack.workspaceName?.trim();
+      toast.success(
+        workspace
+          ? `Slack connected to ${workspace}`
+          : "Slack connected successfully",
+      );
+      setPendingSuccessPlatform(null);
+    }
+  }, [pendingSuccessPlatform, data]);
 
   const isSaas = data?.deployMode === "saas";
   const hasDB = data?.hasInternalDB ?? false;
@@ -555,7 +655,14 @@ function SlackCard({
       onCollapse={!slack.connected ? collapse : undefined}
       actions={
         <>
-          {slack.connected && (canConnect || canByot) && (
+          {/* OAuth installs get the slice-6 disabled-Disconnect tooltip
+              while #2655 lands the real Disconnect flow. BYOT installs
+              keep the existing DisconnectDialog wired to /admin/integrations/slack
+              DELETE — that endpoint already supports BYOT teardown. */}
+          {slack.connected && canConnect && (
+            <DisconnectPendingButton issue="#2655" />
+          )}
+          {slack.connected && !canConnect && canByot && (
             <DisconnectDialog
               name="Slack"
               description="This will remove the Slack connection for this workspace. The /atlas command and thread follow-ups will stop working until you reconnect."
@@ -583,7 +690,14 @@ function SlackCard({
             <DetailRow label="Team ID" value={slack.teamId} mono truncate />
           )}
           {slack.installedAt && (
-            <DetailRow label="Connected" value={formatDateTime(slack.installedAt)} />
+            <DetailRow
+              label="Connected"
+              value={
+                slack.installedBy
+                  ? `${formatDateTime(slack.installedAt)} · by ${slack.installedBy}`
+                  : formatDateTime(slack.installedAt)
+              }
+            />
           )}
           {!isSaas && slack.envConfigured && !slack.oauthConfigured && (
             <div className="pt-1.5 text-[11px] leading-relaxed text-muted-foreground">
@@ -1997,6 +2111,34 @@ function EmailCard({ email }: { email: EmailStatus }) {
         </Button>
       }
     />
+  );
+}
+
+// -- Disconnect Pending (slice 6 placeholder) --
+
+/**
+ * Slice-6 placeholder for OAuth-installed platforms — the real
+ * Disconnect handler ships in #2655. Renders a disabled button with a
+ * tooltip that points to the follow-up issue so an admin clicking it
+ * knows where the work is tracked.
+ */
+function DisconnectPendingButton({ issue }: { issue: string }) {
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          {/* span wrapper so the disabled button still receives pointer events for the tooltip */}
+          <span tabIndex={0} aria-disabled="true" className="inline-flex">
+            <Button variant="outline" size="sm" disabled aria-disabled="true">
+              Disconnect
+            </Button>
+          </span>
+        </TooltipTrigger>
+        <TooltipContent side="top" align="end">
+          Disconnect ships in {issue}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   );
 }
 

--- a/packages/web/src/app/admin/integrations/page.tsx
+++ b/packages/web/src/app/admin/integrations/page.tsx
@@ -655,14 +655,17 @@ function SlackCard({
       onCollapse={!slack.connected ? collapse : undefined}
       actions={
         <>
-          {/* OAuth installs get the slice-6 disabled-Disconnect tooltip
-              while #2655 lands the real Disconnect flow. BYOT installs
-              keep the existing DisconnectDialog wired to /admin/integrations/slack
-              DELETE — that endpoint already supports BYOT teardown. */}
-          {slack.connected && canConnect && (
+          {/* Gate on the *install source*, not on whether OAuth env
+              vars are configured. `canConnect` (= slack.configurable)
+              only reports that SLACK_CLIENT_ID/SECRET are set on this
+              deploy — a workspace can have OAuth env vars available
+              and still be connected via BYOT. In that case the working
+              chat_cache-backed DisconnectDialog must stay, otherwise
+              the admin loses the ability to remove their token. */}
+          {slack.connected && slack.hasOAuthInstall && (
             <DisconnectPendingButton issue="#2655" />
           )}
-          {slack.connected && !canConnect && canByot && (
+          {slack.connected && !slack.hasOAuthInstall && (canConnect || canByot) && (
             <DisconnectDialog
               name="Slack"
               description="This will remove the Slack connection for this workspace. The /atlas command and thread follow-ups will stop working until you reconnect."


### PR DESCRIPTION
## Summary

End-to-end wiring of the Slack Connect button on `/admin/integrations`. A workspace admin can now click Connect, complete the Slack OAuth dance, and land back on the admin UI with a success toast naming the workspace and the Slack card flipped to Connected with install metadata (team name, when, by whom).

This is slice 6 of the 1.5.2 Multi-Adapter SaaS Readiness milestone (#50, PRD #2649). Slice 5 (#2671) shipped the install handler + route plumbing; slice 6 wires the UI.

## What changed

**Frontend (`packages/web/src/app/admin/integrations/page.tsx`)**
- Toast handlers on `?installed=:platform` / `?reconnect=:platform` / `?error=:platform&reason=:code`. Success toast waits for the refetched `IntegrationStatus` so the team name appears in the toast body.
- Query params stripped via `router.replace` after handling — manual refresh doesn't re-fire the toast.
- Connected-state card body for Slack now renders workspace name, team ID, and `Connected on <ts> · by <user>`.
- Disabled Disconnect placeholder via Radix Tooltip pointing at #2655. Reconnect link kept on Connected OAuth cards.

**Backend**
- `packages/api/src/api/routes/integrations.ts` — promoted callback's `null`-state (was 400 JSON) and `PlatformOAuthExchangeError` (was 502 JSON) to 302 redirects to `/admin/integrations?error=slack&reason=:code` for browser callers (`Accept: text/html`). JSON-Accept callers still get the original 400/502.
- `packages/api/src/api/routes/admin-integrations.ts` — widened the `GET /status` Slack response with a `workspace_plugins` lookup for `installed_by` + canonical `installed_at`.

**Types / schemas**
- `SlackStatus.installedBy` added in `@useatlas/types`.
- `SlackStatusSchema.installedBy` added in `@useatlas/schemas`.
- Schema fixture in `packages/schemas/src/__tests__/integrations.test.ts` updated.

**Tests**
- `packages/api/src/api/routes/__tests__/integrations.test.ts` — 6 tests: happy 302, reconnect 302, invalid_state browser-302 + JSON-400, upstream_error browser-302 + JSON-502.
- `e2e/browser/admin-integrations-slack-connect.spec.ts` — Playwright happy-path: Connect button href asserted, callback simulated via direct navigation with `?installed=slack`, toast + Connected card + disabled Disconnect verified.

**Docs**
- `apps/docs/content/docs/guides/slack.mdx` — Install Flow section leads with the admin UI Connect flow; raw install URL framed as the headless-install fallback.
- `apps/docs/openapi.json` + `apps/docs/content/docs/api-reference/` regenerated from the widened 302 response descriptions.

## Test plan

- [x] `bun run lint` — clean (10 pre-existing warnings unchanged)
- [x] `bun run type` — clean
- [x] `bun run test` — full suite green
- [x] `bun x syncpack lint`
- [x] `SKIP_SYNCPACK=1 bash scripts/check-template-drift.sh`
- [x] `bash scripts/check-railway-watch.sh`
- [x] `bash scripts/check-schema-drift.sh`
- [x] `bash scripts/check-ee-imports.sh`
- [x] Affected unit tests: `cd packages/api && bun run scripts/test-isolated.ts --affected` (4 files, 4 pass)
- [ ] Browser e2e in CI (requires dev server) — covered by `bun run test:browser:fast` per `.claude/commands/test-browser.md`

## Out of scope

- Disconnect handler implementation — #2655
- Form-based install — #2660
- Lazy plugin loading — #2657

Closes #2654.
References slice 5 (#2671).