### PR TITLE
fix: #2676 — JSONB-merge state-adapter writes for slack:installation:* keys

### DIFF
--- a/packages/api/src/lib/slack/__tests__/store.test.ts
+++ b/packages/api/src/lib/slack/__tests__/store.test.ts
@@ -53,6 +53,7 @@ const {
   getInstallation,
   getInstallationByOrg,
   saveInstallation,
+  preserveOrgIdOnInstall,
   deleteInstallation,
   deleteInstallationByOrg,
   getBotToken,
@@ -315,6 +316,98 @@ describe("store (chat_cache-backed)", () => {
       mockPoolQuery.mockRejectedValue(new Error("disk full"));
 
       await expect(saveInstallation("T123", "xoxb-token")).rejects.toThrow("disk full");
+    });
+  });
+
+  describe("preserveOrgIdOnInstall (#2676)", () => {
+    it("stamps orgId via jsonb_set when the row is missing the field", async () => {
+      mockHasInternalDB.mockReturnValue(true);
+      mockPoolQuery.mockResolvedValueOnce({ rows: [{ key: "slack:installation:T123" }] });
+
+      await expect(
+        preserveOrgIdOnInstall("T123", "org-1"),
+      ).resolves.toBeUndefined();
+
+      expect(mockPoolQuery).toHaveBeenCalledTimes(1);
+      const [sql, params] = mockPoolQuery.mock.calls[0];
+      expect(sql).toContain("UPDATE chat_cache");
+      expect(sql).toContain("jsonb_set(value, '{orgId}'");
+      expect(sql).toContain("to_jsonb($2::text)");
+      // Hijack-guard WHERE clause mirrors saveInstallation
+      expect(sql).toContain("value->>'orgId' IS NULL");
+      expect(sql).toContain("value->>'orgId' = $2");
+      expect(params).toEqual(["slack:installation:T123", "org-1"]);
+    });
+
+    it("is idempotent when the row's orgId already matches", async () => {
+      // Same SQL semantics as the "missing" case — jsonb_set is a no-op
+      // when path's value equals the new value. RETURNING still emits
+      // the row.
+      mockHasInternalDB.mockReturnValue(true);
+      mockPoolQuery.mockResolvedValueOnce({ rows: [{ key: "slack:installation:T123" }] });
+
+      await expect(
+        preserveOrgIdOnInstall("T123", "org-1"),
+      ).resolves.toBeUndefined();
+      expect(mockPoolQuery).toHaveBeenCalledTimes(1);
+    });
+
+    it("warns and returns (no throw) when the chat_cache row doesn't exist", async () => {
+      // UPDATE returns 0 rows; follow-up probe SELECT returns 0 rows →
+      // distinguishes "row absent" from "hijack" and returns soft.
+      mockHasInternalDB.mockReturnValue(true);
+      mockPoolQuery
+        .mockResolvedValueOnce({ rows: [] }) // UPDATE — no row matched
+        .mockResolvedValueOnce({ rows: [] }); // probe — row absent
+
+      await expect(
+        preserveOrgIdOnInstall("T123", "org-1"),
+      ).resolves.toBeUndefined();
+      expect(mockPoolQuery).toHaveBeenCalledTimes(2);
+    });
+
+    it("throws on cross-tenant hijack", async () => {
+      // UPDATE returns 0 rows; follow-up probe returns the conflicting orgId.
+      mockHasInternalDB.mockReturnValue(true);
+      mockPoolQuery
+        .mockResolvedValueOnce({ rows: [] }) // UPDATE — no row matched
+        .mockResolvedValueOnce({ rows: [{ existing_org_id: "org-other" }] });
+
+      await expect(
+        preserveOrgIdOnInstall("T123", "org-mine"),
+      ).rejects.toThrow("already bound to a different organization (org-other)");
+    });
+
+    it("treats a same-orgId race as idempotent success", async () => {
+      // UPDATE returns 0 rows (another writer beat us between WHERE eval
+      // and RETURNING); probe shows the row now has the matching orgId
+      // we wanted to stamp. Return success.
+      mockHasInternalDB.mockReturnValue(true);
+      mockPoolQuery
+        .mockResolvedValueOnce({ rows: [] })
+        .mockResolvedValueOnce({ rows: [{ existing_org_id: "org-1" }] });
+
+      await expect(
+        preserveOrgIdOnInstall("T123", "org-1"),
+      ).resolves.toBeUndefined();
+    });
+
+    it("rejects empty orgId", async () => {
+      mockHasInternalDB.mockReturnValue(true);
+
+      await expect(preserveOrgIdOnInstall("T123", "")).rejects.toThrow(
+        "orgId must be non-empty",
+      );
+      expect(mockPoolQuery).not.toHaveBeenCalled();
+    });
+
+    it("throws when no internal DB is configured", async () => {
+      mockHasInternalDB.mockReturnValue(false);
+
+      await expect(preserveOrgIdOnInstall("T123", "org-1")).rejects.toThrow(
+        "no internal database configured",
+      );
+      expect(mockPoolQuery).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/api/src/lib/slack/store.ts
+++ b/packages/api/src/lib/slack/store.ts
@@ -338,6 +338,99 @@ export async function saveInstallation(
 }
 
 /**
+ * Stamp `orgId` onto an existing chat_cache row written by the
+ * chat-adapter's own OAuth callback (`@chat-adapter/slack:setInstallation`).
+ *
+ * The chat-adapter is intentionally Atlas-agnostic — its state-adapter
+ * write at `plugins/chat/src/state/pg-adapter.ts:set()` does
+ * `ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value`, fully
+ * overwriting the row and dropping every Atlas-extension field. On a
+ * re-install via the chat-plugin OAuth callback
+ * (`plugins/chat/src/index.ts:/oauth/slack/callback`) this silently
+ * breaks `resolveWorkspaceId` (`lib/proactive/workspace-id-resolver.ts`),
+ * which looks up `installation.org_id` to attribute proactive events to
+ * a tenant — a null `orgId` resolves as "unknown tenant" and the
+ * listener silently skips. See #2676.
+ *
+ * This helper is the post-write reconciliation: idempotent,
+ * single-statement, hijack-guarded `jsonb_set`. The chat-plugin OAuth
+ * callback calls it after `slackAdapterInstance.handleOAuthCallback()`
+ * completes — the chat-adapter owns the row's content (bot-token
+ * encryption envelope, `botUserId`, `teamName`) and we just stitch the
+ * Atlas-extension `orgId` field back in.
+ *
+ * Distinguishes three terminal states:
+ *
+ *   - **Success** — `orgId` was missing or already matched, row stamped.
+ *   - **Row missing** — chat_cache row doesn't exist yet (caller-ordering
+ *     bug: preserve called before chat-adapter write). Logs at warn,
+ *     returns. Failing soft here matches `saveInstallation`'s
+ *     "ON CONFLICT" semantics and avoids 500'ing the OAuth callback on
+ *     a recoverable race.
+ *   - **Cross-tenant hijack** — row exists but bound to a different
+ *     `orgId`. Throws with the same shape as `saveInstallation`'s
+ *     hijack rejection. The chat-adapter has already written its half
+ *     of the row at this point; the throw flags the security-relevant
+ *     state for the caller to handle (typical response: refuse the
+ *     install, delete the chat-adapter's row).
+ *
+ * The UPDATE's WHERE matches both "missing" and "matching" cases.
+ * Returning 0 rows is therefore "row absent" OR "row bound to a
+ * different orgId" — a follow-up probe SELECT on the primary-key path
+ * disambiguates cheaply.
+ */
+export async function preserveOrgIdOnInstall(
+  teamId: string,
+  orgId: string,
+): Promise<void> {
+  if (!hasInternalDB()) {
+    throw new Error(
+      "Cannot preserve Slack installation orgId — no internal database configured",
+    );
+  }
+  if (!orgId) {
+    throw new Error("preserveOrgIdOnInstall: orgId must be non-empty");
+  }
+  const pool = getInternalDB();
+  const result = await pool.query(
+    `UPDATE ${INSTALL_TABLE}
+        SET value = jsonb_set(value, '{${FIELD.orgId}}', to_jsonb($2::text), true)
+      WHERE key = $1
+        AND (value->>'${FIELD.orgId}' IS NULL
+             OR value->>'${FIELD.orgId}' = $2)
+      RETURNING key`,
+    [keyFor(teamId), orgId],
+  );
+  if (result.rows.length > 0) return;
+
+  // Zero rows updated — disambiguate "row absent" from "cross-tenant
+  // hijack" with a follow-up primary-key probe.
+  const probe = await pool.query(
+    `SELECT value->>'${FIELD.orgId}' AS existing_org_id
+       FROM ${INSTALL_TABLE}
+      WHERE key = $1`,
+    [keyFor(teamId)],
+  );
+  if (probe.rows.length === 0) {
+    log.warn(
+      { teamId, orgId },
+      "preserveOrgIdOnInstall: chat_cache row not found — caller ordered preserve before chat-adapter write (no-op)",
+    );
+    return;
+  }
+  const probeRow = probe.rows[0] as { existing_org_id: string | null } | undefined;
+  const existing = probeRow?.existing_org_id ?? null;
+  if (existing && existing !== orgId) {
+    throw new Error(
+      `Slack workspace ${teamId} is already bound to a different organization (${existing}). ` +
+        "Disconnect the existing installation first.",
+    );
+  }
+  // Race: another writer stamped the matching orgId between our UPDATE
+  // and probe. Idempotent success.
+}
+
+/**
  * Remove a Slack installation by team ID. No-op (with warning) when no
  * internal DB is configured.
  */

--- a/plugins/chat/src/state/pg-adapter.test.ts
+++ b/plugins/chat/src/state/pg-adapter.test.ts
@@ -340,6 +340,48 @@ describe("PgStateAdapter cache", () => {
     expect(setCall!.sql).toContain("NULL");
   });
 
+  it("set overwrites value for non-installation keys (#2676)", async () => {
+    const mock = createMockDB({
+      queryResults: [[], [], [], [], [], []],
+    });
+    const adapter = new PgStateAdapter(mock.db);
+    await adapter.connect();
+    mock.calls.length = 0;
+
+    await adapter.set("oauth:slack:abc-123", { orgId: "org-1" }, 600_000);
+
+    const setCall = mock.calls.find((c) => c.sql.includes("INSERT INTO chat_cache"));
+    expect(setCall).toBeDefined();
+    // Non-installation key: standard EXCLUDED.value overwrite, no JSONB merge.
+    expect(setCall!.sql).toContain("SET value = EXCLUDED.value");
+    expect(setCall!.sql).not.toContain("chat_cache.value ||");
+  });
+
+  it("set JSONB-merges value for slack:installation:* keys (#2676)", async () => {
+    // Repro for #2676: chat-adapter's `setInstallation` writes the row
+    // with only its own fields (`botToken`, `botUserId`, `teamName`),
+    // dropping host-extension fields like `orgId` on every re-install.
+    // The fix flips to JSONB-merge for installation keys so prior
+    // host-extension fields are preserved.
+    const mock = createMockDB({
+      queryResults: [[], [], [], [], [], []],
+    });
+    const adapter = new PgStateAdapter(mock.db);
+    await adapter.connect();
+    mock.calls.length = 0;
+
+    await adapter.set("slack:installation:T0AQLT0EBMJ", {
+      botToken: "xoxb-new",
+      botUserId: "U1",
+      teamName: "Atlas",
+    });
+
+    const setCall = mock.calls.find((c) => c.sql.includes("INSERT INTO chat_cache"));
+    expect(setCall).toBeDefined();
+    expect(setCall!.sql).toContain("SET value = chat_cache.value || EXCLUDED.value");
+    expect(setCall!.sql).not.toContain("SET value = EXCLUDED.value,");
+  });
+
   it("delete removes by key", async () => {
     const mock = createMockDB({
       queryResults: [[], [], [], [], [], []],

--- a/plugins/chat/src/state/pg-adapter.ts
+++ b/plugins/chat/src/state/pg-adapter.ts
@@ -168,11 +168,36 @@ export class PgStateAdapter implements StateAdapter {
     const params: unknown[] = [key, JSON.stringify(value)];
     if (ttlMs != null) params.push(ttlMs);
 
+    // Slack installation rows (`slack:installation:<teamId>`) carry
+    // host-extension fields alongside the chat-adapter's own fields.
+    // `@chat-adapter/slack:setInstallation` writes only the fields it
+    // knows about (`botToken`, `botUserId`, `teamName`); the host
+    // (Atlas) stamps additional fields like `orgId`, `workspaceName`,
+    // `installedAt`. The straightforward `SET value = EXCLUDED.value`
+    // semantics drop those extension fields on every re-install, which
+    // silently broke `lib/proactive/workspace-id-resolver.ts` —
+    // `installation.org_id` resolves null and the proactive listener
+    // skips every event as "unknown tenant" (#2676).
+    //
+    // For installation keys we JSONB-merge instead of overwriting: the
+    // chat-adapter's freshly-written fields still win for overlapping
+    // keys (new bot token wins, new teamName wins) but host-extension
+    // fields the prior install added are preserved. Standard `||`
+    // semantics — see #2677 for the structural-prevention audit that
+    // generalises this beyond the slack-installation prefix.
+    //
+    // All other keys keep the overwrite semantics; merging in those
+    // cases would change behaviour for every consumer of the state
+    // adapter (queues, ephemeral state, CSRF tokens, ...).
+    const valueExpr = key.startsWith("slack:installation:")
+      ? `${this.t("cache")}.value || EXCLUDED.value`
+      : "EXCLUDED.value";
+
     await this.db.query(
       `INSERT INTO ${this.t("cache")} (key, value, expires_at)
        VALUES ($1, $2::jsonb, ${expiresExpr})
        ON CONFLICT (key) DO UPDATE
-         SET value = EXCLUDED.value, expires_at = EXCLUDED.expires_at`,
+         SET value = ${valueExpr}, expires_at = EXCLUDED.expires_at`,
       params,
     );
   }


### PR DESCRIPTION
## Summary

- `plugins/chat/src/state/pg-adapter.ts:set()` now JSONB-merges on conflict when the key starts with `slack:installation:`, preserving Atlas-extension fields the chat-adapter doesn't know about (`orgId`, `workspaceName`, ...). All other keys keep the existing `SET value = EXCLUDED.value` overwrite semantics.
- New defensive helper `preserveOrgIdOnInstall(teamId, orgId)` in `packages/api/src/lib/slack/store.ts` — idempotent, hijack-guarded `jsonb_set` for the operator-hotfix path. Distinguishes "row absent" (warn + return) from "cross-tenant hijack" (throw) via a probe SELECT.

## Context

Today's #sandbox-atlas outage: `proactive_meter_events` stopped writing for ~22h despite the listener registering, workspace + channel config set, and Slack bot in channel. Root cause was a two-stage failure:

1. `SLACK_ENCRYPTION_KEY` unset on api/api-eu/api-apac → chat-adapter didn't instantiate, Slack webhooks 404'd. Fixed out of band (env vars set + #2672/#2673 filed for the boot guard + log severity).
2. Even after the adapter came back, `chat_cache.value.orgId` was missing on the `T0AQLT0EBMJ` row. `lib/proactive/workspace-id-resolver.ts:103` reads `installation.org_id` to map team → tenant; null orgId → silent skip. Fixed in prod with an out-of-band `UPDATE chat_cache SET value = jsonb_set(value, '{orgId}', '"<orgId>"', true) WHERE key = 'slack:installation:T0AQLT0EBMJ'`.

This PR is the prevention fix for the second cause.

## Why the orgId got dropped

`@chat-adapter/slack@4.23.0:setInstallation` writes installation rows via the state-adapter's `set(key, installation)`. The pg state-adapter's upsert was a full overwrite (`SET value = EXCLUDED.value`). Every re-install through the legacy chat-plugin OAuth path (`plugins/chat/src/index.ts:298,344` — still mounted alongside the post-#2671/#2674 lifted `SlackOAuthInstallHandler`) replaced the row with only the chat-adapter's known fields, dropping `orgId`.

Both OAuth paths now preserve `orgId`:
- **New lifted path (#2671/#2674)** — `SlackOAuthInstallHandler.complete()` writes via Atlas's `saveInstallation`, which already JSONB-merges. No change needed.
- **Legacy chat-plugin path** — covered by this PR's state-adapter fix.

## Pattern context

This is the third 1.5.2 chat-plugin migration "ported the happy path but dropped an Atlas-extension contract" (sister bugs #2628 `channelAllowed`, #2630 `botToken`). The structural-prevention audit lives in #2677.

## Why state-adapter layer and not callback wiring

I scoped a host-callback approach (`onInstallComplete` hook in `ChatPluginConfig`, host wires preserve logic), but it has a fundamental timing problem: prior `orgId` lives in the chat_cache row, which the chat-adapter overwrites *before* the post-callback hook fires. No callback-layer fix can recover state already destroyed.

The state-adapter layer is the only place we can intercept the write before the data loss. JSONB-merge for installation keys keeps the chat-adapter's intent (write fresh credentials) while preserving the host-extension fields the chat-adapter doesn't know about.

## Test plan

- [x] `bun run type` — clean
- [x] `bun run lint` — 0 errors (only pre-existing warnings in unrelated files)
- [x] `bun test packages/api/src/lib/slack/__tests__/store.test.ts` — 32 pass / 0 fail (includes 7 new cases for `preserveOrgIdOnInstall`)
- [x] `bun test` in `plugins/chat/` — 412 pass / 0 fail (2 new pg-adapter cases for installation-key merge vs overwrite)
- [ ] CI green on the full suite + Deploy Validation
- [x] Verified in prod that the manual `jsonb_set` patch restored proactive: synthetic signed `event_callback` produces a `classify` meter row with confidence 0.98, action `react`

## Follow-ups

- #2672 — SaaS boot guard for chat adapter env vars (different fix path, prevents the *first* stage of today's outage)
- #2673 — AdapterRegistry log severity escalation
- #2677 — Atlas-extension contract audit + structural prevention pattern (this PR is the first slice of that audit's recommended fix)

## Notes for reviewer

- The hijack-guard in `preserveOrgIdOnInstall` mirrors `saveInstallation`'s WHERE clause exactly. The follow-up probe SELECT is the only addition — without it, "row absent" and "row bound to different orgId" are indistinguishable from a zero-row UPDATE return.
- The state-adapter prefix check is intentionally string-based rather than via a configurable list. A configurable list lives in the right scope for the structural fix in #2677; for this PR, hard-coding `slack:installation:` matches today's only known reproduction and keeps the surface area minimal.