### PR TITLE
feat: #2657 — LazyPluginLoader for per-Workspace plugin instances (1.5.2 slice 3)

### DIFF
--- a/packages/api/src/lib/plugins/__tests__/lazy-loader.test.ts
+++ b/packages/api/src/lib/plugins/__tests__/lazy-loader.test.ts
@@ -1,22 +1,17 @@
 /**
- * Unit tests for `LazyPluginLoader` (#2657, milestone 1.5.2 slice 3).
+ * Unit tests for `LazyPluginLoader`.
  *
- * The loader builds and caches per-Workspace plugin instances on first
- * use. `workspace_plugins.config` is the source of truth for per-install
- * config; the loader reads it once per `(workspaceId, catalogId)` and
- * memoizes the instantiated plugin until `evict` clears the entry. The
- * internal-DB module is mocked so we control the row set without
- * spinning up Postgres.
+ * The internal-DB module is mocked so we control the row set without
+ * spinning up Postgres; tests exercise the loader through its public
+ * surface (no peeking at private maps).
  */
 
 import { describe, test, expect, mock, beforeEach } from "bun:test";
 
-// `internalQuery` returns rows keyed by `(workspaceId, catalogId)`. We
-// stash the row set on a mutable map so each test can stage the exact
-// surface it needs. `hasInternalDB` is forced true — the loader is
-// always called from request paths that already require an internal DB.
-type StoredRow = { config: Record<string, unknown> };
-const mockRowsByKey = new Map<string, StoredRow>();
+// `internalQuery` returns rows keyed by `(workspaceId, catalogId)`. The
+// mock value is `unknown` so tests can stage malformed JSONB shapes
+// (null, primitive, array) without fighting the type system.
+const mockRowsByKey = new Map<string, { config: unknown }>();
 const queryCalls: Array<{ sql: string; params: unknown[] }> = [];
 
 mock.module("@atlas/api/lib/db/internal", () => ({
@@ -42,7 +37,7 @@ function buildPlugin(args: { id: string; config: Record<string, unknown> }): Plu
   };
 }
 
-function stageRow(workspaceId: string, catalogId: string, config: Record<string, unknown>): void {
+function stageRow(workspaceId: string, catalogId: string, config: unknown): void {
   mockRowsByKey.set(`${workspaceId}::${catalogId}`, { config });
 }
 
@@ -83,7 +78,6 @@ describe("LazyPluginLoader.getOrInstantiate", () => {
 
     expect(second).toBe(first);
     expect(constructionCount).toBe(1);
-    // Only the first call touches `workspace_plugins` — cache hit short-circuits the read.
     expect(queryCalls).toHaveLength(1);
   });
 
@@ -120,7 +114,7 @@ describe("LazyPluginLoader.getOrInstantiate", () => {
     const before = await loader.getOrInstantiate("ws-1", "salesforce");
     expect(constructionCount).toBe(1);
 
-    const evicted = loader.evict("ws-1", "salesforce");
+    const evicted = await loader.evict("ws-1", "salesforce");
     expect(evicted).toBe(true);
 
     const after = await loader.getOrInstantiate("ws-1", "salesforce");
@@ -165,7 +159,7 @@ describe("LazyPluginLoader.getOrInstantiate", () => {
     );
 
     await expect(loader.getOrInstantiate("ws-1", "salesforce")).rejects.toThrow(
-      /no install row/i,
+      /no enabled install/i,
     );
   });
 
@@ -213,9 +207,9 @@ describe("LazyPluginLoader.getOrInstantiate", () => {
 });
 
 describe("LazyPluginLoader.evict", () => {
-  test("returns false when there's no cached entry for the pair", () => {
+  test("returns false when there's no cached entry for the pair", async () => {
     const loader = new LazyPluginLoader();
-    expect(loader.evict("ws-1", "salesforce")).toBe(false);
+    expect(await loader.evict("ws-1", "salesforce")).toBe(false);
   });
 
   test("only clears the targeted (workspaceId, catalogId) — other entries survive", async () => {
@@ -230,13 +224,129 @@ describe("LazyPluginLoader.evict", () => {
     const acmeBefore = await loader.getOrInstantiate("ws-1", "salesforce");
     const contosoBefore = await loader.getOrInstantiate("ws-2", "salesforce");
 
-    expect(loader.evict("ws-1", "salesforce")).toBe(true);
+    expect(await loader.evict("ws-1", "salesforce")).toBe(true);
 
     const acmeAfter = await loader.getOrInstantiate("ws-1", "salesforce");
     const contosoAfter = await loader.getOrInstantiate("ws-2", "salesforce");
 
     expect(acmeAfter).not.toBe(acmeBefore);
     expect(contosoAfter).toBe(contosoBefore);
+  });
+
+  test("calls instance.teardown() before dropping it from the cache", async () => {
+    const loader = new LazyPluginLoader();
+    stageRow("ws-1", "salesforce", {});
+
+    let teardownCalled = false;
+    loader.registerBuilder("salesforce", ({ catalogId, workspaceId, config }) => ({
+      id: `${catalogId}@${workspaceId}`,
+      types: ["context"],
+      version: "1.0.0",
+      config,
+      teardown: async () => {
+        teardownCalled = true;
+      },
+    }));
+
+    await loader.getOrInstantiate("ws-1", "salesforce");
+    expect(await loader.evict("ws-1", "salesforce")).toBe(true);
+    expect(teardownCalled).toBe(true);
+  });
+
+  test("swallows teardown errors so a failing close cannot block re-instantiation", async () => {
+    const loader = new LazyPluginLoader();
+    stageRow("ws-1", "salesforce", { v: 1 });
+
+    let constructionCount = 0;
+    loader.registerBuilder("salesforce", ({ catalogId, workspaceId, config }) => {
+      constructionCount++;
+      return {
+        id: `${catalogId}@${workspaceId}#${constructionCount}`,
+        types: ["context"],
+        version: "1.0.0",
+        config,
+        teardown: async () => {
+          throw new Error("teardown failed");
+        },
+      };
+    });
+
+    await loader.getOrInstantiate("ws-1", "salesforce");
+    // Should resolve true and not throw.
+    expect(await loader.evict("ws-1", "salesforce")).toBe(true);
+
+    const next = await loader.getOrInstantiate("ws-1", "salesforce");
+    expect(next.id).toBe("salesforce@ws-1#2");
+  });
+
+  test("racing evict during an in-flight build does not repopulate the cache with a stale instance", async () => {
+    const loader = new LazyPluginLoader();
+    stageRow("ws-1", "salesforce", { v: "stale" });
+
+    let constructionCount = 0;
+    let resolveBuild!: (plugin: PluginLike) => void;
+    const buildGate = new Promise<PluginLike>((resolve) => {
+      resolveBuild = resolve;
+    });
+    loader.registerBuilder("salesforce", async ({ catalogId, workspaceId, config }) => {
+      constructionCount++;
+      return buildGate.then(() => buildPlugin({ id: `${catalogId}@${workspaceId}`, config }));
+    });
+
+    const inFlight = loader.getOrInstantiate("ws-1", "salesforce");
+    await loader.evict("ws-1", "salesforce");
+    resolveBuild(buildPlugin({ id: "stale", config: { v: "stale" } }));
+    // The in-flight caller still gets its instance — but it is NOT cached.
+    await inFlight;
+    expect(loader.size()).toBe(0);
+
+    // Stored config has changed since eviction — the next call must
+    // re-read and build from fresh state.
+    stageRow("ws-1", "salesforce", { v: "fresh" });
+    const fresh = await loader.getOrInstantiate("ws-1", "salesforce");
+    expect(fresh.config).toEqual({ v: "fresh" });
+    expect(constructionCount).toBe(2);
+  });
+});
+
+describe("LazyPluginLoader readInstallConfig", () => {
+  test("treats workspace_plugins.enabled = false as not-installed (filter is in the SQL)", () => {
+    const loader = new LazyPluginLoader();
+    loader.registerBuilder("salesforce", ({ workspaceId, catalogId, config }) =>
+      buildPlugin({ id: `${catalogId}@${workspaceId}`, config }),
+    );
+
+    // The mocked `internalQuery` returns rows only when `mockRowsByKey`
+    // has an entry — by not staging a row we model a disabled install
+    // being filtered out. The assertion that matters is the SQL itself.
+    expect(loader.getOrInstantiate("ws-1", "salesforce")).rejects.toThrow(
+      /no enabled install/i,
+    );
+
+    return loader.getOrInstantiate("ws-1", "salesforce").catch(() => {
+      expect(queryCalls[0].sql).toContain("enabled = true");
+    });
+  });
+
+  test.each([
+    ["JSON null", null],
+    ["a string", "an-evil-string"],
+    ["a number", 42],
+    ["a boolean", true],
+    ["an array", [1, 2, 3]],
+  ])("coerces non-object config (%s) to {} and lets the builder run", async (_label, raw) => {
+    const loader = new LazyPluginLoader();
+    stageRow("ws-1", "salesforce", raw);
+
+    let seenConfig: Record<string, unknown> | undefined;
+    loader.registerBuilder("salesforce", ({ workspaceId, catalogId, config }) => {
+      seenConfig = config;
+      return buildPlugin({ id: `${catalogId}@${workspaceId}`, config });
+    });
+
+    const instance = await loader.getOrInstantiate("ws-1", "salesforce");
+    expect(seenConfig).toEqual({});
+    expect(instance.config).toEqual({});
   });
 });
 

--- a/packages/api/src/lib/plugins/__tests__/lazy-loader.test.ts
+++ b/packages/api/src/lib/plugins/__tests__/lazy-loader.test.ts
@@ -1,0 +1,269 @@
+/**
+ * Unit tests for `LazyPluginLoader` (#2657, milestone 1.5.2 slice 3).
+ *
+ * The loader builds and caches per-Workspace plugin instances on first
+ * use. `workspace_plugins.config` is the source of truth for per-install
+ * config; the loader reads it once per `(workspaceId, catalogId)` and
+ * memoizes the instantiated plugin until `evict` clears the entry. The
+ * internal-DB module is mocked so we control the row set without
+ * spinning up Postgres.
+ */
+
+import { describe, test, expect, mock, beforeEach } from "bun:test";
+
+// `internalQuery` returns rows keyed by `(workspaceId, catalogId)`. We
+// stash the row set on a mutable map so each test can stage the exact
+// surface it needs. `hasInternalDB` is forced true — the loader is
+// always called from request paths that already require an internal DB.
+type StoredRow = { config: Record<string, unknown> };
+const mockRowsByKey = new Map<string, StoredRow>();
+const queryCalls: Array<{ sql: string; params: unknown[] }> = [];
+
+mock.module("@atlas/api/lib/db/internal", () => ({
+  hasInternalDB: () => true,
+  internalQuery: async (sql: string, params: unknown[]) => {
+    queryCalls.push({ sql, params });
+    const [workspaceId, catalogId] = params as [string, string];
+    const row = mockRowsByKey.get(`${workspaceId}::${catalogId}`);
+    return row ? [row] : [];
+  },
+}));
+
+const { LazyPluginLoader } = await import("../lazy-loader");
+import type { LazyPluginBuilder } from "../lazy-loader";
+import type { PluginLike } from "../registry";
+
+function buildPlugin(args: { id: string; config: Record<string, unknown> }): PluginLike {
+  return {
+    id: args.id,
+    types: ["context"],
+    version: "1.0.0",
+    config: args.config,
+  };
+}
+
+function stageRow(workspaceId: string, catalogId: string, config: Record<string, unknown>): void {
+  mockRowsByKey.set(`${workspaceId}::${catalogId}`, { config });
+}
+
+beforeEach(() => {
+  mockRowsByKey.clear();
+  queryCalls.length = 0;
+});
+
+describe("LazyPluginLoader.getOrInstantiate", () => {
+  test("first call: constructs from workspace_plugins.config via the registered builder", async () => {
+    const loader = new LazyPluginLoader();
+    stageRow("ws-1", "salesforce", { instanceUrl: "https://acme.my.salesforce.com" });
+
+    const builder: LazyPluginBuilder = ({ workspaceId, catalogId, config }) =>
+      buildPlugin({ id: `${catalogId}@${workspaceId}`, config });
+    loader.registerBuilder("salesforce", builder);
+
+    const instance = await loader.getOrInstantiate("ws-1", "salesforce");
+
+    expect(instance.id).toBe("salesforce@ws-1");
+    expect(instance.config).toEqual({ instanceUrl: "https://acme.my.salesforce.com" });
+    expect(queryCalls).toHaveLength(1);
+    expect(queryCalls[0].params).toEqual(["ws-1", "salesforce"]);
+  });
+
+  test("second call returns the same instance — builder runs once across repeat calls", async () => {
+    const loader = new LazyPluginLoader();
+    stageRow("ws-1", "salesforce", { instanceUrl: "https://acme.my.salesforce.com" });
+
+    let constructionCount = 0;
+    loader.registerBuilder("salesforce", ({ workspaceId, catalogId, config }) => {
+      constructionCount++;
+      return buildPlugin({ id: `${catalogId}@${workspaceId}#${constructionCount}`, config });
+    });
+
+    const first = await loader.getOrInstantiate("ws-1", "salesforce");
+    const second = await loader.getOrInstantiate("ws-1", "salesforce");
+
+    expect(second).toBe(first);
+    expect(constructionCount).toBe(1);
+    // Only the first call touches `workspace_plugins` — cache hit short-circuits the read.
+    expect(queryCalls).toHaveLength(1);
+  });
+
+  test("per-Workspace isolation: same catalogId across two workspaces returns distinct instances", async () => {
+    const loader = new LazyPluginLoader();
+    stageRow("ws-1", "salesforce", { instanceUrl: "https://acme.my.salesforce.com" });
+    stageRow("ws-2", "salesforce", { instanceUrl: "https://contoso.my.salesforce.com" });
+
+    let constructionCount = 0;
+    loader.registerBuilder("salesforce", ({ workspaceId, catalogId, config }) => {
+      constructionCount++;
+      return buildPlugin({ id: `${catalogId}@${workspaceId}`, config });
+    });
+
+    const acme = await loader.getOrInstantiate("ws-1", "salesforce");
+    const contoso = await loader.getOrInstantiate("ws-2", "salesforce");
+
+    expect(acme).not.toBe(contoso);
+    expect(acme.config).toEqual({ instanceUrl: "https://acme.my.salesforce.com" });
+    expect(contoso.config).toEqual({ instanceUrl: "https://contoso.my.salesforce.com" });
+    expect(constructionCount).toBe(2);
+  });
+
+  test("evict removes the cache entry; subsequent getOrInstantiate reconstructs", async () => {
+    const loader = new LazyPluginLoader();
+    stageRow("ws-1", "salesforce", { instanceUrl: "https://acme.my.salesforce.com" });
+
+    let constructionCount = 0;
+    loader.registerBuilder("salesforce", ({ workspaceId, catalogId, config }) => {
+      constructionCount++;
+      return buildPlugin({ id: `${catalogId}@${workspaceId}#${constructionCount}`, config });
+    });
+
+    const before = await loader.getOrInstantiate("ws-1", "salesforce");
+    expect(constructionCount).toBe(1);
+
+    const evicted = loader.evict("ws-1", "salesforce");
+    expect(evicted).toBe(true);
+
+    const after = await loader.getOrInstantiate("ws-1", "salesforce");
+    expect(after).not.toBe(before);
+    expect(after.id).toBe("salesforce@ws-1#2");
+    expect(constructionCount).toBe(2);
+  });
+
+  test("different catalogIds in the same workspace get distinct instances", async () => {
+    const loader = new LazyPluginLoader();
+    stageRow("ws-1", "salesforce", { instanceUrl: "https://acme.my.salesforce.com" });
+    stageRow("ws-1", "jira", { siteUrl: "https://acme.atlassian.net" });
+
+    loader.registerBuilder("salesforce", ({ workspaceId, catalogId, config }) =>
+      buildPlugin({ id: `${catalogId}@${workspaceId}`, config }),
+    );
+    loader.registerBuilder("jira", ({ workspaceId, catalogId, config }) =>
+      buildPlugin({ id: `${catalogId}@${workspaceId}`, config }),
+    );
+
+    const salesforce = await loader.getOrInstantiate("ws-1", "salesforce");
+    const jira = await loader.getOrInstantiate("ws-1", "jira");
+
+    expect(salesforce).not.toBe(jira);
+    expect(salesforce.id).toBe("salesforce@ws-1");
+    expect(jira.id).toBe("jira@ws-1");
+  });
+
+  test("throws when no builder is registered for the catalogId", async () => {
+    const loader = new LazyPluginLoader();
+    stageRow("ws-1", "salesforce", {});
+
+    await expect(loader.getOrInstantiate("ws-1", "salesforce")).rejects.toThrow(
+      /no builder registered/i,
+    );
+  });
+
+  test("throws when `workspace_plugins` has no row for the (workspaceId, catalogId) pair", async () => {
+    const loader = new LazyPluginLoader();
+    loader.registerBuilder("salesforce", ({ workspaceId, catalogId, config }) =>
+      buildPlugin({ id: `${catalogId}@${workspaceId}`, config }),
+    );
+
+    await expect(loader.getOrInstantiate("ws-1", "salesforce")).rejects.toThrow(
+      /no install row/i,
+    );
+  });
+
+  test("concurrent calls coalesce — overlapping getOrInstantiate awaits one in-flight construction", async () => {
+    const loader = new LazyPluginLoader();
+    stageRow("ws-1", "salesforce", { instanceUrl: "https://acme.my.salesforce.com" });
+
+    let constructionCount = 0;
+    let resolveBuild: (plugin: PluginLike) => void;
+    const buildGate = new Promise<PluginLike>((resolve) => {
+      resolveBuild = resolve;
+    });
+    loader.registerBuilder("salesforce", async ({ workspaceId, catalogId, config }) => {
+      constructionCount++;
+      return buildGate.then(() => buildPlugin({ id: `${catalogId}@${workspaceId}`, config }));
+    });
+
+    const a = loader.getOrInstantiate("ws-1", "salesforce");
+    const b = loader.getOrInstantiate("ws-1", "salesforce");
+    resolveBuild!(buildPlugin({ id: "ignored", config: {} }));
+
+    const [first, second] = await Promise.all([a, b]);
+    expect(second).toBe(first);
+    expect(constructionCount).toBe(1);
+  });
+
+  test("failed builder does not cache — next call retries from scratch", async () => {
+    const loader = new LazyPluginLoader();
+    stageRow("ws-1", "salesforce", { instanceUrl: "https://acme.my.salesforce.com" });
+
+    let attempts = 0;
+    loader.registerBuilder("salesforce", ({ workspaceId, catalogId, config }) => {
+      attempts++;
+      if (attempts === 1) throw new Error("transient OAuth refresh failure");
+      return buildPlugin({ id: `${catalogId}@${workspaceId}`, config });
+    });
+
+    await expect(loader.getOrInstantiate("ws-1", "salesforce")).rejects.toThrow(
+      /transient OAuth refresh failure/,
+    );
+    const recovered = await loader.getOrInstantiate("ws-1", "salesforce");
+    expect(recovered.id).toBe("salesforce@ws-1");
+    expect(attempts).toBe(2);
+  });
+});
+
+describe("LazyPluginLoader.evict", () => {
+  test("returns false when there's no cached entry for the pair", () => {
+    const loader = new LazyPluginLoader();
+    expect(loader.evict("ws-1", "salesforce")).toBe(false);
+  });
+
+  test("only clears the targeted (workspaceId, catalogId) — other entries survive", async () => {
+    const loader = new LazyPluginLoader();
+    stageRow("ws-1", "salesforce", { instanceUrl: "https://acme.my.salesforce.com" });
+    stageRow("ws-2", "salesforce", { instanceUrl: "https://contoso.my.salesforce.com" });
+
+    loader.registerBuilder("salesforce", ({ workspaceId, catalogId, config }) =>
+      buildPlugin({ id: `${catalogId}@${workspaceId}`, config }),
+    );
+
+    const acmeBefore = await loader.getOrInstantiate("ws-1", "salesforce");
+    const contosoBefore = await loader.getOrInstantiate("ws-2", "salesforce");
+
+    expect(loader.evict("ws-1", "salesforce")).toBe(true);
+
+    const acmeAfter = await loader.getOrInstantiate("ws-1", "salesforce");
+    const contosoAfter = await loader.getOrInstantiate("ws-2", "salesforce");
+
+    expect(acmeAfter).not.toBe(acmeBefore);
+    expect(contosoAfter).toBe(contosoBefore);
+  });
+});
+
+describe("LazyPluginLoader builder registration", () => {
+  test("hasBuilder reflects current registration state", () => {
+    const loader = new LazyPluginLoader();
+    expect(loader.hasBuilder("salesforce")).toBe(false);
+    loader.registerBuilder("salesforce", ({ workspaceId, catalogId, config }) =>
+      buildPlugin({ id: `${catalogId}@${workspaceId}`, config }),
+    );
+    expect(loader.hasBuilder("salesforce")).toBe(true);
+  });
+
+  test("registerBuilder throws on duplicate catalogId — surface operator wiring mistakes early", () => {
+    const loader = new LazyPluginLoader();
+    const builder: LazyPluginBuilder = ({ workspaceId, catalogId, config }) =>
+      buildPlugin({ id: `${catalogId}@${workspaceId}`, config });
+    loader.registerBuilder("salesforce", builder);
+    expect(() => loader.registerBuilder("salesforce", builder)).toThrow(/already registered/i);
+  });
+
+  test("registerBuilder rejects empty catalogId", () => {
+    const loader = new LazyPluginLoader();
+    expect(() =>
+      loader.registerBuilder("", ({ workspaceId, catalogId, config }) =>
+        buildPlugin({ id: `${catalogId}@${workspaceId}`, config }),
+      ),
+    ).toThrow(/catalogId/i);
+  });
+});

--- a/packages/api/src/lib/plugins/index.ts
+++ b/packages/api/src/lib/plugins/index.ts
@@ -27,3 +27,10 @@ export { loadPluginSettings, savePluginEnabled, savePluginConfig, getPluginConfi
 export type { PluginSettings } from "./settings";
 export { MASKED_PLACEHOLDER, maskSecretFields, restoreMaskedSecrets, parseConfigSchema } from "./secrets";
 export type { ConfigSchema } from "./secrets";
+export {
+  LazyPluginLoader,
+  lazyPluginLoader,
+  LazyPluginBuilderMissingError,
+  LazyPluginInstallNotFoundError,
+} from "./lazy-loader";
+export type { LazyPluginBuilder, LazyPluginBuilderArgs } from "./lazy-loader";

--- a/packages/api/src/lib/plugins/lazy-loader.ts
+++ b/packages/api/src/lib/plugins/lazy-loader.ts
@@ -1,12 +1,10 @@
 /**
- * LazyPluginLoader — milestone 1.5.2 slice 3 (#2657).
+ * LazyPluginLoader.
  *
  * Builds and caches per-Workspace plugin instances on first use. Reads
  * `workspace_plugins.config` once per `(workspaceId, catalogId)`,
  * delegates construction to a builder registered against the catalogId,
- * and returns the same instance on every subsequent call until `evict`
- * clears the entry (e.g. the disconnect path in #2656 tearing down an
- * install).
+ * and memoizes the instance until `evict` clears the entry.
  *
  * Why this lives outside `registry.ts`:
  *   - `PluginRegistry` is the global, boot-time registry of statically
@@ -20,19 +18,20 @@
  *     plugin's credential surface. Sharing one instance across
  *     Workspaces would cross-talk credentials between tenants.
  *
- * Builders vs. registration: a builder is the catalog-side recipe
- * (`{ workspaceId, config } => PluginLike`) registered once per
- * catalogId at boot (Salesforce in #2658, Jira in #2659). The loader
- * looks up the builder by catalogId and invokes it on demand. This
- * matches the per-slug builder shape used by the chat AdapterRegistry
- * (`plugins/chat/src/adapter-registry.ts`), but keyed per-Workspace.
- *
  * Concurrency: overlapping `getOrInstantiate` calls for the same key
  * coalesce — the second caller awaits the first call's in-flight
- * construction Promise rather than firing a parallel build. This
- * matters because tool-call paths in the agent loop can dispatch
- * multiple plugin actions in parallel; without coalescing each one
- * would race to read `workspace_plugins.config` and call the builder.
+ * construction Promise rather than firing a parallel build. The agent
+ * loop's tool-call paths can dispatch multiple plugin actions in
+ * parallel; without coalescing each one would race to read
+ * `workspace_plugins.config` and call the builder.
+ *
+ * Eviction during an in-flight build: `evict` is the source of truth.
+ * Once it clears the pending entry, any build still running will return
+ * its instance to its original caller but will NOT repopulate the
+ * cache — the next `getOrInstantiate` reconstructs against the current
+ * stored config. Combined with `instance.teardown?.()` on evict, this
+ * is how install teardown stays consistent without coordinating with
+ * mid-flight tool calls.
  *
  * Failure semantics: a thrown builder does NOT poison the cache. The
  * pending Promise is cleared so a subsequent call retries from scratch
@@ -94,7 +93,7 @@ export class LazyPluginInstallNotFoundError extends Error {
   readonly catalogId: string;
   constructor(workspaceId: string, catalogId: string) {
     super(
-      `LazyPluginLoader: no install row in workspace_plugins for (workspaceId="${workspaceId}", catalogId="${catalogId}")`,
+      `LazyPluginLoader: no enabled install row in workspace_plugins for (workspaceId="${workspaceId}", catalogId="${catalogId}")`,
     );
     this.name = "LazyPluginInstallNotFoundError";
     this.workspaceId = workspaceId;
@@ -106,6 +105,11 @@ export class LazyPluginInstallNotFoundError extends Error {
 // Loader
 // ---------------------------------------------------------------------------
 
+interface PendingBuild {
+  readonly promise: Promise<PluginLike>;
+  readonly generation: number;
+}
+
 const cacheKey = (workspaceId: string, catalogId: string): string =>
   // `::` is forbidden by the workspace_plugins.workspace_id format
   // (cuid2 / org-prefixed slugs) so no key collision risk.
@@ -114,7 +118,8 @@ const cacheKey = (workspaceId: string, catalogId: string): string =>
 export class LazyPluginLoader {
   private builders = new Map<string, LazyPluginBuilder>();
   private instances = new Map<string, PluginLike>();
-  private pending = new Map<string, Promise<PluginLike>>();
+  private pending = new Map<string, PendingBuild>();
+  private generationCounter = 0;
 
   registerBuilder(catalogId: string, builder: LazyPluginBuilder): void {
     if (!catalogId || !catalogId.trim()) {
@@ -135,8 +140,7 @@ export class LazyPluginLoader {
 
   /**
    * Remove a builder registration. Cached instances stay until they're
-   * explicitly evicted — the disconnect path (#2656) is responsible for
-   * tearing those down.
+   * explicitly evicted.
    */
   unregisterBuilder(catalogId: string): boolean {
     return this.builders.delete(catalogId);
@@ -148,7 +152,9 @@ export class LazyPluginLoader {
    *
    * Concurrent calls for the same key share one in-flight build
    * Promise. A failed build clears the pending entry so the next call
-   * retries from scratch.
+   * retries from scratch. An `evict` that races with an in-flight
+   * build is honored — the build resolves to its original caller, but
+   * the result is not cached.
    */
   async getOrInstantiate(workspaceId: string, catalogId: string): Promise<PluginLike> {
     const key = cacheKey(workspaceId, catalogId);
@@ -157,27 +163,42 @@ export class LazyPluginLoader {
     if (cached) return cached;
 
     const inFlight = this.pending.get(key);
-    if (inFlight) return inFlight;
+    if (inFlight) return inFlight.promise;
 
     const builder = this.builders.get(catalogId);
     if (!builder) {
       throw new LazyPluginBuilderMissingError(catalogId);
     }
 
+    const generation = ++this.generationCounter;
     const buildPromise = (async () => {
       const config = await this.readInstallConfig(workspaceId, catalogId);
-      const instance = await builder({ workspaceId, catalogId, config });
-      return instance;
+      return builder({ workspaceId, catalogId, config });
     })();
 
-    this.pending.set(key, buildPromise);
+    this.pending.set(key, { promise: buildPromise, generation });
 
     try {
       const instance = await buildPromise;
-      this.instances.set(key, instance);
-      log.debug({ workspaceId, catalogId }, "LazyPluginLoader: instance constructed and cached");
+      // If the pending entry was cleared (evict raced with us) or
+      // replaced by a newer generation, drop our result on the floor —
+      // the caller still gets their instance back, but it doesn't go
+      // into the shared cache.
+      const current = this.pending.get(key);
+      if (current?.generation === generation) {
+        this.instances.set(key, instance);
+        this.pending.delete(key);
+        log.debug(
+          { workspaceId, catalogId },
+          "LazyPluginLoader: instance constructed and cached",
+        );
+      }
       return instance;
     } catch (err) {
+      const current = this.pending.get(key);
+      if (current?.generation === generation) {
+        this.pending.delete(key);
+      }
       log.warn(
         {
           workspaceId,
@@ -187,21 +208,42 @@ export class LazyPluginLoader {
         "LazyPluginLoader: builder failed — next call will retry from scratch",
       );
       throw err;
-    } finally {
-      // Clear pending regardless — on success the cached entry covers
-      // subsequent calls; on failure we want the next call to retry.
-      this.pending.delete(key);
     }
   }
 
   /**
-   * Drop the cached instance for `(workspaceId, catalogId)`. Returns
-   * `true` if an entry existed. Called by the install-teardown path
-   * (#2656) so the next `getOrInstantiate` reconstructs against
-   * freshly-stored config rather than a stale memoized instance.
+   * Drop the cached instance for `(workspaceId, catalogId)` and call
+   * its `teardown()` hook so any sockets / timers / refresh handles
+   * are released. Returns `true` if an entry existed.
+   *
+   * Clearing `pending` here is what makes an `evict` racing with an
+   * in-flight `getOrInstantiate` consistent — the build will resolve
+   * but its `set` into `instances` is skipped (see `getOrInstantiate`).
+   *
+   * Teardown errors are caught and logged; they cannot block the next
+   * `getOrInstantiate` from reconstructing.
    */
-  evict(workspaceId: string, catalogId: string): boolean {
-    return this.instances.delete(cacheKey(workspaceId, catalogId));
+  async evict(workspaceId: string, catalogId: string): Promise<boolean> {
+    const key = cacheKey(workspaceId, catalogId);
+    this.pending.delete(key);
+    const instance = this.instances.get(key);
+    if (!instance) return false;
+    this.instances.delete(key);
+    if (typeof instance.teardown === "function") {
+      try {
+        await instance.teardown();
+      } catch (err) {
+        log.warn(
+          {
+            workspaceId,
+            catalogId,
+            err: err instanceof Error ? err.message : String(err),
+          },
+          "LazyPluginLoader: teardown threw during evict — instance is dropped anyway",
+        );
+      }
+    }
+    return true;
   }
 
   size(): number {
@@ -213,24 +255,45 @@ export class LazyPluginLoader {
     this.builders.clear();
     this.instances.clear();
     this.pending.clear();
+    this.generationCounter = 0;
   }
 
   private async readInstallConfig(
     workspaceId: string,
     catalogId: string,
   ): Promise<Record<string, unknown>> {
+    // `enabled = true` gate: a disabled install is treated as
+    // not-installed for execution purposes. Admin surfaces that need
+    // to inspect a disabled install read the table directly — they
+    // don't go through the loader.
     const rows = await internalQuery<StoredRow>(
-      "SELECT config FROM workspace_plugins WHERE workspace_id = $1 AND catalog_id = $2 LIMIT 1",
+      "SELECT config FROM workspace_plugins WHERE workspace_id = $1 AND catalog_id = $2 AND enabled = true LIMIT 1",
       [workspaceId, catalogId],
     );
     if (rows.length === 0) {
       throw new LazyPluginInstallNotFoundError(workspaceId, catalogId);
     }
     const raw = rows[0].config;
-    // JSONB legitimately holds primitives, arrays, or `null`. Anything
-    // that isn't a plain object collapses to `{}` so the builder gets a
-    // stable shape — matching the coercion that `validation.ts` uses.
-    if (raw === null || raw === undefined || typeof raw !== "object" || Array.isArray(raw)) {
+    if (raw === null || raw === undefined) {
+      // `workspace_plugins.config` is `NOT NULL DEFAULT '{}'` so JSON
+      // `null` is data drift, not a default state — warn so ops can
+      // catch a buggy write path. Still collapse to `{}` to keep the
+      // builder shape stable.
+      log.warn(
+        { workspaceId, catalogId },
+        "LazyPluginLoader: workspace_plugins.config is JSON null — coercing to {}",
+      );
+      return {};
+    }
+    if (typeof raw !== "object" || Array.isArray(raw)) {
+      log.warn(
+        {
+          workspaceId,
+          catalogId,
+          actualType: Array.isArray(raw) ? "array" : typeof raw,
+        },
+        "LazyPluginLoader: workspace_plugins.config is not a JSON object — coercing to {}",
+      );
       return {};
     }
     return raw as Record<string, unknown>;
@@ -238,8 +301,8 @@ export class LazyPluginLoader {
 }
 
 /**
- * Global singleton. Mirrors the `plugins` export from `registry.ts` —
- * production callers reach for `lazyPluginLoader` and tests instantiate
- * a fresh `new LazyPluginLoader()` to keep state isolated.
+ * Process-wide singleton. Production callers reach for
+ * `lazyPluginLoader`; tests instantiate a fresh `new LazyPluginLoader()`
+ * to keep state isolated.
  */
 export const lazyPluginLoader = new LazyPluginLoader();

--- a/packages/api/src/lib/plugins/lazy-loader.ts
+++ b/packages/api/src/lib/plugins/lazy-loader.ts
@@ -1,0 +1,245 @@
+/**
+ * LazyPluginLoader — milestone 1.5.2 slice 3 (#2657).
+ *
+ * Builds and caches per-Workspace plugin instances on first use. Reads
+ * `workspace_plugins.config` once per `(workspaceId, catalogId)`,
+ * delegates construction to a builder registered against the catalogId,
+ * and returns the same instance on every subsequent call until `evict`
+ * clears the entry (e.g. the disconnect path in #2656 tearing down an
+ * install).
+ *
+ * Why this lives outside `registry.ts`:
+ *   - `PluginRegistry` is the global, boot-time registry of statically
+ *     loaded plugins (one instance per plugin id, shared across all
+ *     workspaces). It mounts at server start and stays for the process
+ *     lifetime.
+ *   - LazyPluginLoader is per-Workspace, on-demand. Two Workspaces using
+ *     the same `catalogId` (e.g. both connecting Salesforce with their
+ *     own OAuth creds) MUST get distinct plugin instances — the
+ *     per-install `config` blob feeds directly into the constructed
+ *     plugin's credential surface. Sharing one instance across
+ *     Workspaces would cross-talk credentials between tenants.
+ *
+ * Builders vs. registration: a builder is the catalog-side recipe
+ * (`{ workspaceId, config } => PluginLike`) registered once per
+ * catalogId at boot (Salesforce in #2658, Jira in #2659). The loader
+ * looks up the builder by catalogId and invokes it on demand. This
+ * matches the per-slug builder shape used by the chat AdapterRegistry
+ * (`plugins/chat/src/adapter-registry.ts`), but keyed per-Workspace.
+ *
+ * Concurrency: overlapping `getOrInstantiate` calls for the same key
+ * coalesce — the second caller awaits the first call's in-flight
+ * construction Promise rather than firing a parallel build. This
+ * matters because tool-call paths in the agent loop can dispatch
+ * multiple plugin actions in parallel; without coalescing each one
+ * would race to read `workspace_plugins.config` and call the builder.
+ *
+ * Failure semantics: a thrown builder does NOT poison the cache. The
+ * pending Promise is cleared so a subsequent call retries from scratch
+ * (transient OAuth refresh failures recover on the next tool call
+ * rather than wedging the install until process restart).
+ */
+
+import { createLogger } from "@atlas/api/lib/logger";
+import { internalQuery } from "@atlas/api/lib/db/internal";
+import type { PluginLike } from "./registry";
+
+const log = createLogger("plugins:lazy-loader");
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface LazyPluginBuilderArgs {
+  readonly workspaceId: string;
+  readonly catalogId: string;
+  /**
+   * Stored JSONB from `workspace_plugins.config`. Secret-marked fields
+   * may be ciphertext — the builder owns decryption (it knows the
+   * catalog schema; see `plugins/secrets.ts:decryptSecretFields`). The
+   * loader stays generic so it doesn't need to load the catalog row.
+   */
+  readonly config: Record<string, unknown>;
+}
+
+/**
+ * Recipe for constructing a per-Workspace plugin instance. Sync return
+ * matches the common `definePlugin(...)` / `createPlugin()` path; the
+ * Promise overload supports builders that pre-warm network state (e.g.
+ * a token refresh) before returning the instance.
+ */
+export type LazyPluginBuilder = (
+  args: LazyPluginBuilderArgs,
+) => PluginLike | Promise<PluginLike>;
+
+interface StoredRow extends Record<string, unknown> {
+  config: unknown;
+}
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+export class LazyPluginBuilderMissingError extends Error {
+  readonly catalogId: string;
+  constructor(catalogId: string) {
+    super(`LazyPluginLoader: no builder registered for catalogId "${catalogId}"`);
+    this.name = "LazyPluginBuilderMissingError";
+    this.catalogId = catalogId;
+  }
+}
+
+export class LazyPluginInstallNotFoundError extends Error {
+  readonly workspaceId: string;
+  readonly catalogId: string;
+  constructor(workspaceId: string, catalogId: string) {
+    super(
+      `LazyPluginLoader: no install row in workspace_plugins for (workspaceId="${workspaceId}", catalogId="${catalogId}")`,
+    );
+    this.name = "LazyPluginInstallNotFoundError";
+    this.workspaceId = workspaceId;
+    this.catalogId = catalogId;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Loader
+// ---------------------------------------------------------------------------
+
+const cacheKey = (workspaceId: string, catalogId: string): string =>
+  // `::` is forbidden by the workspace_plugins.workspace_id format
+  // (cuid2 / org-prefixed slugs) so no key collision risk.
+  `${workspaceId}::${catalogId}`;
+
+export class LazyPluginLoader {
+  private builders = new Map<string, LazyPluginBuilder>();
+  private instances = new Map<string, PluginLike>();
+  private pending = new Map<string, Promise<PluginLike>>();
+
+  registerBuilder(catalogId: string, builder: LazyPluginBuilder): void {
+    if (!catalogId || !catalogId.trim()) {
+      throw new Error("LazyPluginLoader.registerBuilder: catalogId must not be empty");
+    }
+    if (this.builders.has(catalogId)) {
+      throw new Error(
+        `LazyPluginLoader.registerBuilder: builder for catalogId "${catalogId}" is already registered`,
+      );
+    }
+    this.builders.set(catalogId, builder);
+    log.info({ catalogId }, "LazyPluginLoader: builder registered");
+  }
+
+  hasBuilder(catalogId: string): boolean {
+    return this.builders.has(catalogId);
+  }
+
+  /**
+   * Remove a builder registration. Cached instances stay until they're
+   * explicitly evicted — the disconnect path (#2656) is responsible for
+   * tearing those down.
+   */
+  unregisterBuilder(catalogId: string): boolean {
+    return this.builders.delete(catalogId);
+  }
+
+  /**
+   * Return the cached plugin instance for `(workspaceId, catalogId)`,
+   * constructing it on first call from `workspace_plugins.config`.
+   *
+   * Concurrent calls for the same key share one in-flight build
+   * Promise. A failed build clears the pending entry so the next call
+   * retries from scratch.
+   */
+  async getOrInstantiate(workspaceId: string, catalogId: string): Promise<PluginLike> {
+    const key = cacheKey(workspaceId, catalogId);
+
+    const cached = this.instances.get(key);
+    if (cached) return cached;
+
+    const inFlight = this.pending.get(key);
+    if (inFlight) return inFlight;
+
+    const builder = this.builders.get(catalogId);
+    if (!builder) {
+      throw new LazyPluginBuilderMissingError(catalogId);
+    }
+
+    const buildPromise = (async () => {
+      const config = await this.readInstallConfig(workspaceId, catalogId);
+      const instance = await builder({ workspaceId, catalogId, config });
+      return instance;
+    })();
+
+    this.pending.set(key, buildPromise);
+
+    try {
+      const instance = await buildPromise;
+      this.instances.set(key, instance);
+      log.debug({ workspaceId, catalogId }, "LazyPluginLoader: instance constructed and cached");
+      return instance;
+    } catch (err) {
+      log.warn(
+        {
+          workspaceId,
+          catalogId,
+          err: err instanceof Error ? err.message : String(err),
+        },
+        "LazyPluginLoader: builder failed — next call will retry from scratch",
+      );
+      throw err;
+    } finally {
+      // Clear pending regardless — on success the cached entry covers
+      // subsequent calls; on failure we want the next call to retry.
+      this.pending.delete(key);
+    }
+  }
+
+  /**
+   * Drop the cached instance for `(workspaceId, catalogId)`. Returns
+   * `true` if an entry existed. Called by the install-teardown path
+   * (#2656) so the next `getOrInstantiate` reconstructs against
+   * freshly-stored config rather than a stale memoized instance.
+   */
+  evict(workspaceId: string, catalogId: string): boolean {
+    return this.instances.delete(cacheKey(workspaceId, catalogId));
+  }
+
+  size(): number {
+    return this.instances.size;
+  }
+
+  /** Reset all builder + instance state. Test-only. */
+  _reset(): void {
+    this.builders.clear();
+    this.instances.clear();
+    this.pending.clear();
+  }
+
+  private async readInstallConfig(
+    workspaceId: string,
+    catalogId: string,
+  ): Promise<Record<string, unknown>> {
+    const rows = await internalQuery<StoredRow>(
+      "SELECT config FROM workspace_plugins WHERE workspace_id = $1 AND catalog_id = $2 LIMIT 1",
+      [workspaceId, catalogId],
+    );
+    if (rows.length === 0) {
+      throw new LazyPluginInstallNotFoundError(workspaceId, catalogId);
+    }
+    const raw = rows[0].config;
+    // JSONB legitimately holds primitives, arrays, or `null`. Anything
+    // that isn't a plain object collapses to `{}` so the builder gets a
+    // stable shape — matching the coercion that `validation.ts` uses.
+    if (raw === null || raw === undefined || typeof raw !== "object" || Array.isArray(raw)) {
+      return {};
+    }
+    return raw as Record<string, unknown>;
+  }
+}
+
+/**
+ * Global singleton. Mirrors the `plugins` export from `registry.ts` —
+ * production callers reach for `lazyPluginLoader` and tests instantiate
+ * a fresh `new LazyPluginLoader()` to keep state isolated.
+ */
+export const lazyPluginLoader = new LazyPluginLoader();


### PR DESCRIPTION
## Summary
- Adds `LazyPluginLoader` (`packages/api/src/lib/plugins/lazy-loader.ts`) — a process-cached, first-use-per-Workspace plugin loader. Reads `workspace_plugins.config` once per `(workspaceId, catalogId)`, delegates construction to a builder registered against the catalogId, and memoizes until `evict` clears the entry (e.g. the disconnect path in #2656).
- Two Workspaces using the same `catalogId` get distinct instances — sharing one instance across Workspaces would cross-talk per-install credentials between tenants.
- No consumers in this slice. Salesforce wires up in #2658, Jira in #2659.

## Design notes
- Lives outside `registry.ts` on purpose: `PluginRegistry` is the global boot-time singleton of statically-loaded plugins; `LazyPluginLoader` is per-Workspace, on-demand. Mirrors the per-slug builder shape from the chat `AdapterRegistry` (`plugins/chat/src/adapter-registry.ts`) but keyed per-Workspace.
- Plain class + module-level `lazyPluginLoader` singleton — matches the existing `plugins` export from `registry.ts`. No `Context.Tag` because there's no lifecycle finalizer (in-memory `Map`, evicted by the disconnect path).
- Concurrency: overlapping `getOrInstantiate` calls for the same key share one in-flight Promise — the agent loop can dispatch parallel plugin actions and we don't want each one to race to read `workspace_plugins.config`.
- Failure semantics: a thrown builder clears the pending entry so the next call retries from scratch (transient OAuth refresh failures recover on the next tool call rather than wedging the install until process restart).
- Builders own decryption: the loader passes the raw JSONB `config` to the builder. The builder knows its catalog schema and uses `decryptSecretFields` (`plugins/secrets.ts`) for `secret: true` fields. Keeps the loader generic.

## Acceptance criteria
- [x] `getOrInstantiate` returns a `PluginInstance` on first call; constructs from `workspace_plugins.config`
- [x] Second call within process lifetime returns the same instance — verified via identity check + construction counter
- [x] Per-Workspace isolation: same catalogId, two different workspaceIds → distinct instances
- [x] `evict` removes the cache entry; subsequent `getOrInstantiate` reconstructs
- [x] Unit tests cover all four cases (first call, cache hit, isolation, evict)

## Public surface (`@atlas/api/lib/plugins`)
- `LazyPluginLoader` class + `lazyPluginLoader` global singleton
- `LazyPluginBuilder` / `LazyPluginBuilderArgs` types
- `LazyPluginBuilderMissingError` / `LazyPluginInstallNotFoundError` tagged errors

## Test plan
- [x] `bun test src/lib/plugins/__tests__/lazy-loader.test.ts` — 14/14 pass (37 expect calls), covers the four acceptance cases plus concurrency coalescing, failed-builder retry, missing-builder + missing-install errors, single-key eviction, and duplicate / empty `registerBuilder` rejections
- [x] `bun run scripts/test-isolated.ts --affected` — 1/1 (lazy-loader)
- [x] `bun run lint` — clean (no new warnings; pre-existing warnings unchanged)
- [x] `bun run type` — passes (tsgo --noEmit)
- [x] `bun x syncpack lint` — no issues
- [x] `SKIP_SYNCPACK=1 bash scripts/check-template-drift.sh` — drift-clean
- [x] `bash scripts/check-railway-watch.sh` — all COPY sources covered

## Notes
- Full `bun run test` shows pre-existing flakes in `src/api/__tests__/{slack,discord,teams}.test.ts` and `src/lib/auth/__tests__/rate-limit-integration.test.ts` (timeouts on 5000ms cap). All pass in isolation and don't touch any module I modified — confirmed unrelated.

Closes #2657.