### PR TITLE
fix: #2672 — SaaS boot guard for chat adapter requiredEnv

### DIFF
--- a/packages/api/src/lib/effect/__tests__/saas-env.test.ts
+++ b/packages/api/src/lib/effect/__tests__/saas-env.test.ts
@@ -55,6 +55,9 @@ describe("SAAS_ENV_KEYS", () => {
       BETTER_AUTH_URL: undefined,
       BETTER_AUTH_TRUSTED_ORIGINS: undefined,
       SLACK_SIGNING_SECRET: undefined,
+      SLACK_CLIENT_ID: undefined,
+      SLACK_CLIENT_SECRET: undefined,
+      SLACK_ENCRYPTION_KEY: undefined,
     };
     const expectedKeys: readonly string[] = Object.keys(exhaustive).sort();
     const actualKeys: readonly string[] = [...SAAS_ENV_KEYS].sort();

--- a/packages/api/src/lib/effect/__tests__/saas-guards.test.ts
+++ b/packages/api/src/lib/effect/__tests__/saas-guards.test.ts
@@ -738,14 +738,19 @@ describe("RegionGuardLive", () => {
 // requiredEnv automatically flows through). The fixture envs below
 // populate everything except the key we want to fail on.
 
-const SLACK_ENV_KEYS_FULL = {
+type SlackEnvOverrides = Partial<Record<
+  "SLACK_CLIENT_ID" | "SLACK_CLIENT_SECRET" | "SLACK_SIGNING_SECRET" | "SLACK_ENCRYPTION_KEY",
+  string | undefined
+>>;
+
+const SLACK_ENV_KEYS_FULL: Required<SlackEnvOverrides> = {
   SLACK_CLIENT_ID: "ci-client-id",
   SLACK_CLIENT_SECRET: "ci-client-secret",
   SLACK_SIGNING_SECRET: "0123456789abcdef0123456789abcdef",
   SLACK_ENCRYPTION_KEY: "0123456789abcdef0123456789abcdef",
-} as const;
+};
 
-function setSlackEnv(overrides: Partial<typeof SLACK_ENV_KEYS_FULL> = SLACK_ENV_KEYS_FULL): void {
+function setSlackEnv(overrides: SlackEnvOverrides = SLACK_ENV_KEYS_FULL): void {
   for (const [key, value] of Object.entries({ ...SLACK_ENV_KEYS_FULL, ...overrides })) {
     if (value === undefined) {
       delete process.env[key];

--- a/packages/api/src/lib/effect/__tests__/saas-guards.test.ts
+++ b/packages/api/src/lib/effect/__tests__/saas-guards.test.ts
@@ -763,8 +763,6 @@ function setSlackEnv(overrides: SlackEnvOverrides = SLACK_ENV_KEYS_FULL): void {
 describe("ChatAdapterEnvGuardLive", () => {
   test("fails boot in SaaS when catalog enables Slack but SLACK_ENCRYPTION_KEY is unset (the #2672 incident)", async () => {
     await withCleanEnv(async () => {
-      // Set every required Slack env EXCEPT the encryption key — exactly
-      // the prod misconfig that caused the silent outage.
       setSlackEnv({ SLACK_ENCRYPTION_KEY: undefined });
       const exit = await Effect.runPromiseExit(
         Effect.void.pipe(
@@ -799,8 +797,6 @@ describe("ChatAdapterEnvGuardLive", () => {
 
   test("fails boot in SaaS reporting every missing key (not just the first)", async () => {
     await withCleanEnv(async () => {
-      // Two missing keys — the error's `missingEnv` array must list
-      // both so the operator can fix them in one pass.
       setSlackEnv({
         SLACK_CLIENT_SECRET: undefined,
         SLACK_ENCRYPTION_KEY: undefined,
@@ -988,11 +984,6 @@ describe("ChatAdapterEnvGuardLive", () => {
 
   test("succeeds in SaaS for an unknown slug — operator typo falls through to AdapterRegistry's runtime warn", async () => {
     await withCleanEnv(async () => {
-      // The guard's contract is "if Atlas ships a builder, every key
-      // the builder needs must be present". An unknown slug has no
-      // builder so there's nothing for this guard to assert; the
-      // AdapterRegistry's `unrecognizedSlugs` diagnostic surfaces the
-      // typo at runtime instead.
       const exit = await Effect.runPromiseExit(
         Effect.void.pipe(
           Effect.provide(
@@ -1019,8 +1010,6 @@ describe("ChatAdapterEnvGuardLive", () => {
 
   test("succeeds on self-hosted with the same misconfig (the dev box can fix env when ready)", async () => {
     await withCleanEnv(async () => {
-      // Exactly the prod incident — but on self-hosted, the api just
-      // doesn't activate the adapter and boots fine.
       setSlackEnv({ SLACK_ENCRYPTION_KEY: undefined });
       const exit = await Effect.runPromiseExit(
         Effect.void.pipe(
@@ -1031,6 +1020,52 @@ describe("ChatAdapterEnvGuardLive", () => {
                 catalog: [
                   {
                     slug: "slack",
+                    type: "chat",
+                    install_model: "oauth",
+                    enabled: true,
+                    saas_eligible: true,
+                  },
+                ],
+              })),
+            ),
+          ),
+        ),
+      );
+      expect(Exit.isSuccess(exit)).toBe(true);
+    });
+  });
+
+  // Iteration-continuation regression guard. If the for...of ever
+  // accidentally bailed after the first healthy entry (e.g. a
+  // `return` in the success path instead of `continue`), a second
+  // oauth+enabled chat entry with missing envs would silently pass.
+  // Today only `slack` ships; this test future-proofs the iteration
+  // against the static-bot platforms gaining OAuth flows in 1.5.3.
+  test("walks past healthy chat entries to inspect later entries", async () => {
+    await withCleanEnv(async () => {
+      setSlackEnv();
+      const exit = await Effect.runPromiseExit(
+        Effect.void.pipe(
+          Effect.provide(
+            ChatAdapterEnvGuardLive.pipe(
+              Layer.provide(makeTestConfigLayer({
+                deployMode: "saas",
+                catalog: [
+                  // Healthy entry first (every Slack env set above).
+                  {
+                    slug: "slack",
+                    type: "chat",
+                    install_model: "oauth",
+                    enabled: true,
+                    saas_eligible: true,
+                  },
+                  // Second chat+oauth+enabled entry the guard MUST
+                  // also inspect. Unknown-slug fall-through means
+                  // the loop exits cleanly without crashing — the
+                  // load-bearing assertion is that the iteration
+                  // doesn't bail after the first healthy entry.
+                  {
+                    slug: "slcak",
                     type: "chat",
                     install_model: "oauth",
                     enabled: true,

--- a/packages/api/src/lib/effect/__tests__/saas-guards.test.ts
+++ b/packages/api/src/lib/effect/__tests__/saas-guards.test.ts
@@ -46,6 +46,7 @@ import type {
   InternalDatabaseRequiredError as TInternalDatabaseRequiredError,
   RateLimitRequiredError as TRateLimitRequiredError,
   RegionMisconfiguredError as TRegionMisconfiguredError,
+  ChatAdapterEnvMissingError as TChatAdapterEnvMissingError,
 } from "../saas-guards";
 
 const {
@@ -60,6 +61,8 @@ const {
   RateLimitRequiredError,
   RegionGuardLive,
   RegionMisconfiguredError,
+  ChatAdapterEnvGuardLive,
+  ChatAdapterEnvMissingError,
 } = await import("../saas-guards");
 const { Config } = await import("../layers");
 const { _resetEncryptionKeyCache } = await import("@atlas/api/lib/db/encryption-keys");
@@ -716,3 +719,325 @@ describe("RegionGuardLive", () => {
 // (`plugin-config-guard.test.ts`) — the validator is mocked via
 // `mock.module()` and bun's mock scope is per-file, so isolating
 // avoids leaking the mocks into the other guards' tests in this file.
+
+// ══════════════════════════════════════════════════════════════════════
+// ██  ChatAdapterEnvGuardLive (#2672)
+// ══════════════════════════════════════════════════════════════════════
+
+// The 2026-05-19 → 2026-05-20 incident: every Railway api region booted
+// fine with `SLACK_ENCRYPTION_KEY` unset; the adapter was silently
+// dropped, the proactive listener registered, and ~22h of "green health
+// signals + zero events" followed. These tests pin the contract that
+// the same misconfig must now fail boot in SaaS, stay tolerant on
+// self-hosted, and only fire when the catalog opts in.
+//
+// The Slack builder's actual requiredEnv list lives in
+// `plugins/chat/src/adapter-registry.ts :: SLACK_BUILDER.requiredEnv`
+// — the guard imports it via `getChatAdapterRequiredEnv` so these tests
+// exercise the real list (any future addition to the builder's
+// requiredEnv automatically flows through). The fixture envs below
+// populate everything except the key we want to fail on.
+
+const SLACK_ENV_KEYS_FULL = {
+  SLACK_CLIENT_ID: "ci-client-id",
+  SLACK_CLIENT_SECRET: "ci-client-secret",
+  SLACK_SIGNING_SECRET: "0123456789abcdef0123456789abcdef",
+  SLACK_ENCRYPTION_KEY: "0123456789abcdef0123456789abcdef",
+} as const;
+
+function setSlackEnv(overrides: Partial<typeof SLACK_ENV_KEYS_FULL> = SLACK_ENV_KEYS_FULL): void {
+  for (const [key, value] of Object.entries({ ...SLACK_ENV_KEYS_FULL, ...overrides })) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+}
+
+describe("ChatAdapterEnvGuardLive", () => {
+  test("fails boot in SaaS when catalog enables Slack but SLACK_ENCRYPTION_KEY is unset (the #2672 incident)", async () => {
+    await withCleanEnv(async () => {
+      // Set every required Slack env EXCEPT the encryption key — exactly
+      // the prod misconfig that caused the silent outage.
+      setSlackEnv({ SLACK_ENCRYPTION_KEY: undefined });
+      const exit = await Effect.runPromiseExit(
+        Effect.void.pipe(
+          Effect.provide(
+            ChatAdapterEnvGuardLive.pipe(
+              Layer.provide(makeTestConfigLayer({
+                deployMode: "saas",
+                catalog: [
+                  {
+                    slug: "slack",
+                    type: "chat",
+                    install_model: "oauth",
+                    enabled: true,
+                    saas_eligible: true,
+                  },
+                ],
+              })),
+            ),
+          ),
+        ),
+      );
+      expect(Exit.isFailure(exit)).toBe(true);
+      const failure = Exit.isFailure(exit) && exit.cause._tag === "Fail" ? exit.cause.error : null;
+      expect(failure).toBeInstanceOf(ChatAdapterEnvMissingError);
+      expect((failure as TChatAdapterEnvMissingError)._tag).toBe("ChatAdapterEnvMissingError");
+      expect((failure as TChatAdapterEnvMissingError).slug).toBe("slack");
+      expect((failure as TChatAdapterEnvMissingError).missingEnv).toEqual(["SLACK_ENCRYPTION_KEY"]);
+      expect((failure as TChatAdapterEnvMissingError).message).toContain("#2672");
+      expect((failure as TChatAdapterEnvMissingError).message).toContain("SLACK_ENCRYPTION_KEY");
+    });
+  });
+
+  test("fails boot in SaaS reporting every missing key (not just the first)", async () => {
+    await withCleanEnv(async () => {
+      // Two missing keys — the error's `missingEnv` array must list
+      // both so the operator can fix them in one pass.
+      setSlackEnv({
+        SLACK_CLIENT_SECRET: undefined,
+        SLACK_ENCRYPTION_KEY: undefined,
+      });
+      const exit = await Effect.runPromiseExit(
+        Effect.void.pipe(
+          Effect.provide(
+            ChatAdapterEnvGuardLive.pipe(
+              Layer.provide(makeTestConfigLayer({
+                deployMode: "saas",
+                catalog: [
+                  {
+                    slug: "slack",
+                    type: "chat",
+                    install_model: "oauth",
+                    enabled: true,
+                    saas_eligible: true,
+                  },
+                ],
+              })),
+            ),
+          ),
+        ),
+      );
+      expect(Exit.isFailure(exit)).toBe(true);
+      const failure = Exit.isFailure(exit) && exit.cause._tag === "Fail" ? exit.cause.error : null;
+      expect(failure).toBeInstanceOf(ChatAdapterEnvMissingError);
+      const missing = (failure as TChatAdapterEnvMissingError).missingEnv;
+      expect([...missing].sort()).toEqual(["SLACK_CLIENT_SECRET", "SLACK_ENCRYPTION_KEY"]);
+    });
+  });
+
+  test("treats empty-string env values as missing (matches AdapterRegistry's truthy check)", async () => {
+    await withCleanEnv(async () => {
+      // The builder's `if (!encryptionKey)` rejects empty strings as
+      // surely as it rejects undefined — the guard must match.
+      setSlackEnv({ SLACK_ENCRYPTION_KEY: "" });
+      const exit = await Effect.runPromiseExit(
+        Effect.void.pipe(
+          Effect.provide(
+            ChatAdapterEnvGuardLive.pipe(
+              Layer.provide(makeTestConfigLayer({
+                deployMode: "saas",
+                catalog: [
+                  {
+                    slug: "slack",
+                    type: "chat",
+                    install_model: "oauth",
+                    enabled: true,
+                    saas_eligible: true,
+                  },
+                ],
+              })),
+            ),
+          ),
+        ),
+      );
+      expect(Exit.isFailure(exit)).toBe(true);
+      const failure = Exit.isFailure(exit) && exit.cause._tag === "Fail" ? exit.cause.error : null;
+      expect(failure).toBeInstanceOf(ChatAdapterEnvMissingError);
+      expect((failure as TChatAdapterEnvMissingError).missingEnv).toEqual(["SLACK_ENCRYPTION_KEY"]);
+    });
+  });
+
+  test("succeeds in SaaS when every Slack env var is set", async () => {
+    await withCleanEnv(async () => {
+      setSlackEnv();
+      const exit = await Effect.runPromiseExit(
+        Effect.void.pipe(
+          Effect.provide(
+            ChatAdapterEnvGuardLive.pipe(
+              Layer.provide(makeTestConfigLayer({
+                deployMode: "saas",
+                catalog: [
+                  {
+                    slug: "slack",
+                    type: "chat",
+                    install_model: "oauth",
+                    enabled: true,
+                    saas_eligible: true,
+                  },
+                ],
+              })),
+            ),
+          ),
+        ),
+      );
+      expect(Exit.isSuccess(exit)).toBe(true);
+    });
+  });
+
+  test("succeeds in SaaS when catalog entry is disabled — operator-disabled rows don't activate the adapter", async () => {
+    await withCleanEnv(async () => {
+      // No Slack env at all. With `enabled: false` the guard must skip.
+      const exit = await Effect.runPromiseExit(
+        Effect.void.pipe(
+          Effect.provide(
+            ChatAdapterEnvGuardLive.pipe(
+              Layer.provide(makeTestConfigLayer({
+                deployMode: "saas",
+                catalog: [
+                  {
+                    slug: "slack",
+                    type: "chat",
+                    install_model: "oauth",
+                    enabled: false,
+                    saas_eligible: true,
+                  },
+                ],
+              })),
+            ),
+          ),
+        ),
+      );
+      expect(Exit.isSuccess(exit)).toBe(true);
+    });
+  });
+
+  test("succeeds in SaaS when catalog entry is non-OAuth — static-bot has no event-loop adapter to instantiate", async () => {
+    await withCleanEnv(async () => {
+      const exit = await Effect.runPromiseExit(
+        Effect.void.pipe(
+          Effect.provide(
+            ChatAdapterEnvGuardLive.pipe(
+              Layer.provide(makeTestConfigLayer({
+                deployMode: "saas",
+                catalog: [
+                  {
+                    slug: "teams",
+                    type: "chat",
+                    install_model: "static-bot",
+                    enabled: true,
+                    saas_eligible: true,
+                  },
+                ],
+              })),
+            ),
+          ),
+        ),
+      );
+      expect(Exit.isSuccess(exit)).toBe(true);
+    });
+  });
+
+  test("succeeds in SaaS when catalog has no chat entries", async () => {
+    await withCleanEnv(async () => {
+      const exit = await Effect.runPromiseExit(
+        Effect.void.pipe(
+          Effect.provide(
+            ChatAdapterEnvGuardLive.pipe(
+              Layer.provide(makeTestConfigLayer({
+                deployMode: "saas",
+                catalog: [
+                  {
+                    slug: "salesforce",
+                    type: "integration",
+                    install_model: "oauth",
+                    enabled: true,
+                    saas_eligible: true,
+                  },
+                ],
+              })),
+            ),
+          ),
+        ),
+      );
+      expect(Exit.isSuccess(exit)).toBe(true);
+    });
+  });
+
+  test("succeeds in SaaS when catalog is empty / unset", async () => {
+    await withCleanEnv(async () => {
+      const exit = await Effect.runPromiseExit(
+        Effect.void.pipe(
+          Effect.provide(
+            ChatAdapterEnvGuardLive.pipe(
+              Layer.provide(makeTestConfigLayer({ deployMode: "saas" })),
+            ),
+          ),
+        ),
+      );
+      expect(Exit.isSuccess(exit)).toBe(true);
+    });
+  });
+
+  test("succeeds in SaaS for an unknown slug — operator typo falls through to AdapterRegistry's runtime warn", async () => {
+    await withCleanEnv(async () => {
+      // The guard's contract is "if Atlas ships a builder, every key
+      // the builder needs must be present". An unknown slug has no
+      // builder so there's nothing for this guard to assert; the
+      // AdapterRegistry's `unrecognizedSlugs` diagnostic surfaces the
+      // typo at runtime instead.
+      const exit = await Effect.runPromiseExit(
+        Effect.void.pipe(
+          Effect.provide(
+            ChatAdapterEnvGuardLive.pipe(
+              Layer.provide(makeTestConfigLayer({
+                deployMode: "saas",
+                catalog: [
+                  {
+                    slug: "slakc",
+                    type: "chat",
+                    install_model: "oauth",
+                    enabled: true,
+                    saas_eligible: true,
+                  },
+                ],
+              })),
+            ),
+          ),
+        ),
+      );
+      expect(Exit.isSuccess(exit)).toBe(true);
+    });
+  });
+
+  test("succeeds on self-hosted with the same misconfig (the dev box can fix env when ready)", async () => {
+    await withCleanEnv(async () => {
+      // Exactly the prod incident — but on self-hosted, the api just
+      // doesn't activate the adapter and boots fine.
+      setSlackEnv({ SLACK_ENCRYPTION_KEY: undefined });
+      const exit = await Effect.runPromiseExit(
+        Effect.void.pipe(
+          Effect.provide(
+            ChatAdapterEnvGuardLive.pipe(
+              Layer.provide(makeTestConfigLayer({
+                deployMode: "self-hosted",
+                catalog: [
+                  {
+                    slug: "slack",
+                    type: "chat",
+                    install_model: "oauth",
+                    enabled: true,
+                    saas_eligible: true,
+                  },
+                ],
+              })),
+            ),
+          ),
+        ),
+      );
+      expect(Exit.isSuccess(exit)).toBe(true);
+    });
+  });
+});

--- a/packages/api/src/lib/effect/layers.ts
+++ b/packages/api/src/lib/effect/layers.ts
@@ -45,6 +45,7 @@ import {
   RateLimitGuardLive,
   RegionGuardLive,
   PluginConfigGuardLive,
+  ChatAdapterEnvGuardLive,
   MigrationsRequiredError,
 } from "./saas-guards";
 import { readSaasEnv } from "./saas-env";
@@ -1336,6 +1337,11 @@ export function buildAppLayer(config: ResolvedConfig): Layer.Layer<
   const encryptionKeyGuardLayer = EncryptionKeyGuardLive.pipe(Layer.provide(configLayer));
   const internalDbGuardLayer = InternalDbGuardLive.pipe(Layer.provide(configLayer));
   const rateLimitGuardLayer = RateLimitGuardLive.pipe(Layer.provide(configLayer));
+  // #2672 — walks the chat catalog and fails boot when an oauth+enabled
+  // entry's adapter-builder requiredEnv keys are missing in SaaS. Depends
+  // only on `Config` and reads env directly, so it runs in parallel with
+  // the migration + sync layers alongside the other env-checking guards.
+  const chatAdapterEnvGuardLayer = ChatAdapterEnvGuardLive.pipe(Layer.provide(configLayer));
   // #1988 C7 + C8 — region routing claim and stale plugin config checks.
   // Both depend only on `Config`. PluginConfigGuardLive lazy-imports the
   // plugin registry + InternalDB inside its Effect body so it can run as
@@ -1373,6 +1379,7 @@ export function buildAppLayer(config: ResolvedConfig): Layer.Layer<
     rateLimitGuardLayer,
     regionGuardLayer,
     pluginConfigGuardLayer,
+    chatAdapterEnvGuardLayer,
     migrationGuardLayer,
     EnterpriseLayer,
   );

--- a/packages/api/src/lib/effect/saas-env.ts
+++ b/packages/api/src/lib/effect/saas-env.ts
@@ -78,6 +78,20 @@ export interface SaasEnv {
   // boot-smoke fixture emits a syntactically-valid placeholder so the
   // schema parses without crashing the boot guards.
   readonly SLACK_SIGNING_SECRET: string | undefined;
+
+  // Slack OAuth + at-rest credentials (#2672 — ChatAdapterEnvGuardLive).
+  // When the chat catalog enables `slug: "slack"` with `install_model:
+  // "oauth"`, the AdapterRegistry's `SLACK_BUILDER.build()` requires all
+  // four envs (the signing secret above plus these three). Missing any
+  // of them in SaaS silently drops the adapter — proactive chat keeps
+  // booting, admin analytics keep returning 200s, and no Slack event
+  // ever lands. The 2026-05-19 → 2026-05-20 incident hit exactly this
+  // path (`SLACK_ENCRYPTION_KEY` unset across all three Railway api
+  // services). Listed here so the boot-smoke fixture populates them and
+  // `ChatAdapterEnvGuardLive` asserts on them via `readSaasEnv()`.
+  readonly SLACK_CLIENT_ID: string | undefined;
+  readonly SLACK_CLIENT_SECRET: string | undefined;
+  readonly SLACK_ENCRYPTION_KEY: string | undefined;
 }
 
 /**
@@ -106,6 +120,9 @@ export const SAAS_ENV_KEYS = [
   "BETTER_AUTH_URL",
   "BETTER_AUTH_TRUSTED_ORIGINS",
   "SLACK_SIGNING_SECRET",
+  "SLACK_CLIENT_ID",
+  "SLACK_CLIENT_SECRET",
+  "SLACK_ENCRYPTION_KEY",
 ] as const satisfies readonly (keyof SaasEnv)[];
 
 // Compile-time exhaustiveness: every key in SaasEnv must appear in
@@ -140,6 +157,9 @@ export function readSaasEnv(env: NodeJS.ProcessEnv = process.env): SaasEnv {
     BETTER_AUTH_URL: env.BETTER_AUTH_URL,
     BETTER_AUTH_TRUSTED_ORIGINS: env.BETTER_AUTH_TRUSTED_ORIGINS,
     SLACK_SIGNING_SECRET: env.SLACK_SIGNING_SECRET,
+    SLACK_CLIENT_ID: env.SLACK_CLIENT_ID,
+    SLACK_CLIENT_SECRET: env.SLACK_CLIENT_SECRET,
+    SLACK_ENCRYPTION_KEY: env.SLACK_ENCRYPTION_KEY,
   };
 }
 
@@ -211,6 +231,17 @@ export function makeBootSmokeFixture(
     // SaaS deploy config parses cleanly under Boot Smoke without
     // requiring a real Slack app credential.
     SLACK_SIGNING_SECRET: "0123456789abcdef0123456789abcdef",
+    // #2672 — placeholders for the SLACK adapter's other three
+    // requiredEnv keys. ChatAdapterEnvGuardLive only asserts presence
+    // (non-empty), so any non-empty string suffices for the boot-smoke
+    // gate. The encryption key placeholder mirrors the
+    // `SLACK_SIGNING_SECRET` shape (32-char lowercase hex) since
+    // `@chat-adapter/slack` derives an AES-256-GCM key from it via
+    // SHA-256 and a syntactically valid placeholder keeps adapter
+    // construction clean under Boot Smoke.
+    SLACK_CLIENT_ID: "ci-fixture-slack-client-id-not-a-secret",
+    SLACK_CLIENT_SECRET: "ci-fixture-slack-client-secret-not-a-secret",
+    SLACK_ENCRYPTION_KEY: "0123456789abcdef0123456789abcdef",
   };
   return { ...fixture, ...opts.overrides };
 }

--- a/packages/api/src/lib/effect/saas-env.ts
+++ b/packages/api/src/lib/effect/saas-env.ts
@@ -234,11 +234,11 @@ export function makeBootSmokeFixture(
     // #2672 — placeholders for the SLACK adapter's other three
     // requiredEnv keys. ChatAdapterEnvGuardLive only asserts presence
     // (non-empty), so any non-empty string suffices for the boot-smoke
-    // gate. The encryption key placeholder mirrors the
-    // `SLACK_SIGNING_SECRET` shape (32-char lowercase hex) since
-    // `@chat-adapter/slack` derives an AES-256-GCM key from it via
-    // SHA-256 and a syntactically valid placeholder keeps adapter
-    // construction clean under Boot Smoke.
+    // gate. The encryption key reuses the 32-char hex shape for
+    // consistency with `SLACK_SIGNING_SECRET`; the real key (used by
+    // `lib/slack/installation-encryption.ts` to decode bot tokens) is
+    // hex (64 chars) or base64 (44 chars), so this placeholder would
+    // fail real decode — boot-smoke never reaches that path.
     SLACK_CLIENT_ID: "ci-fixture-slack-client-id-not-a-secret",
     SLACK_CLIENT_SECRET: "ci-fixture-slack-client-secret-not-a-secret",
     SLACK_ENCRYPTION_KEY: "0123456789abcdef0123456789abcdef",

--- a/packages/api/src/lib/effect/saas-guards.ts
+++ b/packages/api/src/lib/effect/saas-guards.ts
@@ -237,7 +237,7 @@ export class PluginConfigCheckFailedError extends Data.TaggedError("PluginConfig
  *
  * `slug` is the catalog entry slug (e.g. `"slack"`) the guard tripped
  * on; `missingEnv` is the subset of the builder's `requiredEnv` that
- * `readSaasEnv()` resolved as undefined/empty. Both exposed on the
+ * `process.env` resolved as undefined/empty. Both exposed on the
  * error so the operator log line names the missing keys without
  * re-parsing `message`.
  */
@@ -798,9 +798,6 @@ export const ChatAdapterEnvGuardLive: Layer.Layer<never, ChatAdapterEnvMissingEr
     const catalog = config.catalog ?? [];
     if (catalog.length === 0) return;
 
-    const env = readSaasEnv();
-    const envRecord = env as unknown as Record<string, string | undefined>;
-
     // Lazy-import the per-slug requiredEnv accessor from the chat
     // plugin. `Effect.tryPromise` routes a rejected import into the E
     // channel; `Effect.orDie` then converts that into a defect, which
@@ -827,8 +824,17 @@ export const ChatAdapterEnvGuardLive: Layer.Layer<never, ChatAdapterEnvMissingEr
       // builder, every key the builder needs must be present."
       if (!requiredEnv) continue;
 
+      // Read each key directly from `process.env` so the contract
+      // honors the builder map's single source of truth. Going through
+      // `readSaasEnv()` would silently treat any key not statically
+      // enumerated in `SaasEnv` as undefined — a future adapter adding
+      // a new `requiredEnv` entry would then fail boot for a properly-
+      // configured operator until they also touched `saas-env.ts`,
+      // which would break the "builder is the source of truth" claim.
+      // The runtime AdapterRegistry reads `process.env` for the same
+      // reason; matching it keeps the parity check load-bearing.
       const missingEnv = requiredEnv.filter((key) => {
-        const value = envRecord[key];
+        const value = process.env[key];
         return value === undefined || value === "";
       });
 

--- a/packages/api/src/lib/effect/saas-guards.ts
+++ b/packages/api/src/lib/effect/saas-guards.ts
@@ -780,9 +780,15 @@ export const PluginConfigGuardLive: Layer.Layer<never, PluginConfigStaleError | 
  * `PluginConfigGuardLive` — keeps the chat plugin's static graph out
  * of `saas-guards.ts` (the wall-off rationale is documented at the
  * bottom of this file). A rejected import is rare-but-possible (build
- * artefact missing); we surface it as a `defect` rather than a typed
- * failure so the boot Layer's `E` channel stays narrowed to the one
- * tagged error this guard produces.
+ * artefact missing); we promote it to a defect via `Effect.orDie` so
+ * the boot Layer dies rather than silently skipping the check. The
+ * silent-skip path was the exact #2672 outage pattern — log+continue
+ * here would reintroduce the same class of bug this guard exists to
+ * prevent. `@useatlas/chat` is a workspace dep used throughout core
+ * (proactive listeners, install handlers, executeQuery wiring), so
+ * in practice an import rejection means the api can't run anyway —
+ * dying here surfaces the root cause at boot instead of letting a
+ * downstream route 500 minutes later.
  */
 export const ChatAdapterEnvGuardLive: Layer.Layer<never, ChatAdapterEnvMissingError, Config> = Layer.effectDiscard(
   Effect.gen(function* () {
@@ -795,28 +801,20 @@ export const ChatAdapterEnvGuardLive: Layer.Layer<never, ChatAdapterEnvMissingEr
     const env = readSaasEnv();
     const envRecord = env as unknown as Record<string, string | undefined>;
 
-    // Lazy-import the per-slug requiredEnv accessor from the chat plugin.
-    // Wrapped in a try/catch so a missing build artefact doesn't widen
-    // this Effect's E channel — same defect-channel pattern as
-    // EncryptionKeyGuardLive.
-    const accessor = yield* Effect.promise(
-      async (): Promise<((slug: string) => ReadonlyArray<string> | null) | null> => {
-        try {
-          const mod = await import("@useatlas/chat");
-          return mod.getChatAdapterRequiredEnv;
-        } catch (err) {
-          log.warn(
-            { err: err instanceof Error ? err.message : String(err) },
-            `ChatAdapterEnvGuardLive: failed to load @useatlas/chat — skipping check ` +
-              `(catalog declares chat entries but adapter accessor is unreachable). ` +
-              `See ${CHAT_ADAPTER_ISSUE_REF}.`,
-          );
-          return null;
-        }
+    // Lazy-import the per-slug requiredEnv accessor from the chat
+    // plugin. `Effect.tryPromise` routes a rejected import into the E
+    // channel; `Effect.orDie` then converts that into a defect, which
+    // crashes the boot Layer. This keeps the E channel narrow (still
+    // just `ChatAdapterEnvMissingError`) while ensuring an
+    // accessor-unreachable failure doesn't silently bypass the check.
+    const accessor = yield* Effect.tryPromise({
+      try: async (): Promise<(slug: string) => ReadonlyArray<string> | null> => {
+        const mod = await import("@useatlas/chat");
+        return mod.getChatAdapterRequiredEnv;
       },
-    );
-
-    if (!accessor) return;
+      catch: (err) =>
+        err instanceof Error ? err : new Error(String(err)),
+    }).pipe(Effect.orDie);
 
     for (const entry of catalog) {
       if (entry.type !== "chat") continue;

--- a/packages/api/src/lib/effect/saas-guards.ts
+++ b/packages/api/src/lib/effect/saas-guards.ts
@@ -87,6 +87,7 @@ const log = createLogger("effect:saas-guards");
 const ISSUE_REF = "#1978";
 const RATE_LIMIT_ISSUE_REF = "#1983";
 const ISSUE_REF_1988 = "#1988";
+const CHAT_ADAPTER_ISSUE_REF = "#2672";
 
 // ══════════════════════════════════════════════════════════════════════
 // ██  Tagged errors
@@ -220,6 +221,30 @@ export class PluginConfigStaleError extends Data.TaggedError("PluginConfigStaleE
 export class PluginConfigCheckFailedError extends Data.TaggedError("PluginConfigCheckFailedError")<{
   readonly message: string;
   readonly cause: Error;
+}> {}
+
+/**
+ * SaaS region declared a chat catalog entry with `install_model:
+ * "oauth"` and `enabled: true` but the env vars the adapter builder
+ * needs to instantiate are missing. Without this guard the
+ * `AdapterRegistry` builder returns `null`, the adapter is silently
+ * dropped, and the api still boots — the proactive listener registers,
+ * admin analytics keep returning 200s, and no Slack event ever lands.
+ * The 2026-05-19 → 2026-05-20 incident in `#sandbox-atlas` (~22h of
+ * silent outage) hit exactly this path: `SLACK_ENCRYPTION_KEY` was
+ * unset across all three Railway api services and every health signal
+ * stayed green while no events were processed.
+ *
+ * `slug` is the catalog entry slug (e.g. `"slack"`) the guard tripped
+ * on; `missingEnv` is the subset of the builder's `requiredEnv` that
+ * `readSaasEnv()` resolved as undefined/empty. Both exposed on the
+ * error so the operator log line names the missing keys without
+ * re-parsing `message`.
+ */
+export class ChatAdapterEnvMissingError extends Data.TaggedError("ChatAdapterEnvMissingError")<{
+  readonly message: string;
+  readonly slug: string;
+  readonly missingEnv: readonly string[];
 }> {}
 
 /**
@@ -712,6 +737,120 @@ export const PluginConfigGuardLive: Layer.Layer<never, PluginConfigStaleError | 
     // because the docstring at the top of this guard claims "stale
     // configs are always logged as warnings", and that promise lives
     // in the validator, not here. See #2252.
+  }),
+);
+
+// ══════════════════════════════════════════════════════════════════════
+// ██  ChatAdapterEnvGuardLive (#2672)
+// ══════════════════════════════════════════════════════════════════════
+
+/**
+ * Fail boot in SaaS when a chat catalog entry declares
+ * `install_model: "oauth"` and `enabled: true` but the platform
+ * adapter's `requiredEnv` keys aren't all present.
+ *
+ * Background: between 2026-05-19 17:59 UTC and 2026-05-20 16:39 UTC,
+ * proactive chat silently stopped in prod because `SLACK_ENCRYPTION_KEY`
+ * was unset across all three Railway api services. The chat plugin's
+ * `AdapterRegistry.SLACK_BUILDER.build()` returns `null` when any of
+ * its four envs (`SLACK_CLIENT_ID`, `_SECRET`, `_SIGNING_SECRET`,
+ * `_ENCRYPTION_KEY`) is missing, so the adapter was dropped, the api
+ * still booted, the proactive listener still registered, and the
+ * admin analytics endpoints kept returning 200s — every signal looked
+ * green except actual events.
+ *
+ * Self-hosted is intentionally unaffected: a self-hosted dev box can
+ * legitimately have an OAuth catalog entry without populated creds
+ * (the adapter quietly doesn't activate, the api boots, the operator
+ * fixes the env when they're ready). The SaaS contract is stricter
+ * because there's no operator at the keyboard to notice the silent
+ * downgrade.
+ *
+ * Walks `config.catalog`, filters by `type === "chat"` AND
+ * `install_model === "oauth"` AND `enabled === true`, then for each
+ * entry looks up `getChatAdapterRequiredEnv(slug)` from
+ * `@useatlas/chat`. The per-slug `requiredEnv` lives there as the
+ * single source of truth — duplicating in core would let the lists
+ * drift between packages. Unknown slugs are ignored (the
+ * AdapterRegistry's `unrecognizedSlugs` diagnostic already covers
+ * operator typos at runtime).
+ *
+ * The `@useatlas/chat` accessor is loaded via dynamic `import()` to
+ * match the lazy-import pattern of `EncryptionKeyGuardLive` and
+ * `PluginConfigGuardLive` — keeps the chat plugin's static graph out
+ * of `saas-guards.ts` (the wall-off rationale is documented at the
+ * bottom of this file). A rejected import is rare-but-possible (build
+ * artefact missing); we surface it as a `defect` rather than a typed
+ * failure so the boot Layer's `E` channel stays narrowed to the one
+ * tagged error this guard produces.
+ */
+export const ChatAdapterEnvGuardLive: Layer.Layer<never, ChatAdapterEnvMissingError, Config> = Layer.effectDiscard(
+  Effect.gen(function* () {
+    const { config } = yield* Config;
+    if (config.deployMode !== "saas") return;
+
+    const catalog = config.catalog ?? [];
+    if (catalog.length === 0) return;
+
+    const env = readSaasEnv();
+    const envRecord = env as unknown as Record<string, string | undefined>;
+
+    // Lazy-import the per-slug requiredEnv accessor from the chat plugin.
+    // Wrapped in a try/catch so a missing build artefact doesn't widen
+    // this Effect's E channel — same defect-channel pattern as
+    // EncryptionKeyGuardLive.
+    const accessor = yield* Effect.promise(
+      async (): Promise<((slug: string) => ReadonlyArray<string> | null) | null> => {
+        try {
+          const mod = await import("@useatlas/chat");
+          return mod.getChatAdapterRequiredEnv;
+        } catch (err) {
+          log.warn(
+            { err: err instanceof Error ? err.message : String(err) },
+            `ChatAdapterEnvGuardLive: failed to load @useatlas/chat — skipping check ` +
+              `(catalog declares chat entries but adapter accessor is unreachable). ` +
+              `See ${CHAT_ADAPTER_ISSUE_REF}.`,
+          );
+          return null;
+        }
+      },
+    );
+
+    if (!accessor) return;
+
+    for (const entry of catalog) {
+      if (entry.type !== "chat") continue;
+      if (entry.install_model !== "oauth") continue;
+      if (!entry.enabled) continue;
+
+      const requiredEnv = accessor(entry.slug);
+      // Unknown slug — let the runtime AdapterRegistry warn about the
+      // operator typo; this guard's contract is "if Atlas ships a
+      // builder, every key the builder needs must be present."
+      if (!requiredEnv) continue;
+
+      const missingEnv = requiredEnv.filter((key) => {
+        const value = envRecord[key];
+        return value === undefined || value === "";
+      });
+
+      if (missingEnv.length > 0) {
+        return yield* Effect.fail(
+          new ChatAdapterEnvMissingError({
+            slug: entry.slug,
+            missingEnv,
+            message:
+              `SaaS region booted with catalog entry slug="${entry.slug}" (type=chat, ` +
+              `install_model=oauth, enabled=true) but the adapter builder's required env ` +
+              `vars are missing: [${missingEnv.join(", ")}]. Without them the AdapterRegistry ` +
+              `silently drops the adapter — the api would boot, proactive chat would register, ` +
+              `and every health signal would stay green while no chat event ever lands. Set ` +
+              `the missing env var(s) on every region's api service before booting. ` +
+              `See ${CHAT_ADAPTER_ISSUE_REF}.`,
+          }),
+        );
+      }
+    }
   }),
 );
 

--- a/plugins/chat/src/adapter-registry.ts
+++ b/plugins/chat/src/adapter-registry.ts
@@ -152,6 +152,23 @@ const BUILDERS_BY_SLUG: Readonly<Record<string, ChatAdapterBuilder<unknown>>> = 
   slack: SLACK_BUILDER,
 };
 
+/**
+ * Look up the per-slug `requiredEnv` list. Core (`@atlas/api`) calls
+ * this from `ChatAdapterEnvGuardLive` (#2672) so the SaaS boot guard
+ * can assert that every env var the builder needs is present without
+ * redeclaring the list (single source of truth — the builder map above
+ * is the only place `requiredEnv` is authored).
+ *
+ * Returns `null` for unknown slugs. The guard treats that the same as
+ * the registry's `unrecognizedSlugs` diagnostic: a catalog row for a
+ * Platform Atlas doesn't ship code for is an operator typo, not a
+ * missing-env failure.
+ */
+export function getChatAdapterRequiredEnv(slug: string): ReadonlyArray<string> | null {
+  const builder = BUILDERS_BY_SLUG[slug];
+  return builder ? builder.requiredEnv : null;
+}
+
 // ---------------------------------------------------------------------------
 // Logger contract
 // ---------------------------------------------------------------------------

--- a/plugins/chat/src/index.ts
+++ b/plugins/chat/src/index.ts
@@ -166,6 +166,14 @@ export type { StreamChunk, TaskUpdateChunk, PlanUpdateChunk, MarkdownTextChunk }
 export { createStateAdapter } from "./state";
 export type { PluginDB } from "./state";
 
+// Per-slug adapter env-var lookup (#2672). Core's `ChatAdapterEnvGuardLive`
+// imports this to assert that a SaaS deploy whose chat catalog enables an
+// OAuth Platform has every env var the AdapterRegistry would otherwise
+// silently drop the adapter for. Single source of truth for the
+// per-Platform requiredEnv list — duplicating in core would let the lists
+// drift across packages.
+export { getChatAdapterRequiredEnv } from "./adapter-registry";
+
 // File upload / CSV export utilities
 export {
   generateCSV,


### PR DESCRIPTION
## Summary

Closes #2672.

- New `ChatAdapterEnvGuardLive` walks `config.catalog` and fails boot in SaaS when a `type=chat, install_model=oauth, enabled=true` entry's per-Platform `requiredEnv` keys aren't all present. Tagged `ChatAdapterEnvMissingError` lists the missing keys + the offending slug.
- Self-hosted is unaffected — the adapter quietly doesn't activate, current behaviour.
- `SLACK_CLIENT_ID`, `SLACK_CLIENT_SECRET`, `SLACK_ENCRYPTION_KEY` added to `SaasEnv` + `makeBootSmokeFixture`, so the boot-smoke gate auto-picks them up via `scripts/saas-env-fixture.ts`.
- `getChatAdapterRequiredEnv(slug)` exported from `@useatlas/chat` so core reads the per-slug `requiredEnv` from the builder map — single source of truth.

## Background

Between 2026-05-19 17:59 UTC and 2026-05-20 16:39 UTC, proactive chat in `#sandbox-atlas` silently stopped because `SLACK_ENCRYPTION_KEY` was unset across all three Railway api services. `AdapterRegistry.SLACK_BUILDER.build()` returned `null`, the adapter was dropped, the api still booted, the proactive listener still registered, and every admin analytics endpoint kept returning 200s — every signal looked green except actual events. ~22h of silent outage.

This guard fails the boot Layer before any HTTP listener starts, so the same misconfig class is impossible going forward — not just for Slack but for any chat-platform builder in `BUILDERS_BY_SLUG` (1.5.3 adapter additions inherit the contract automatically).

## Test plan

- [x] `bun run lint` — clean
- [x] `bun run type` — clean
- [x] `bun x syncpack lint` — no issues
- [x] `bash scripts/check-template-drift.sh` — 643 files verified
- [x] `bash scripts/check-railway-watch.sh` — all 44 COPY sources covered
- [x] `bun test src/lib/effect/__tests__/saas-guards.test.ts` — 40 pass (10 new for ChatAdapterEnvGuardLive)
- [x] `bun test src/lib/effect/__tests__/saas-env.test.ts` — 8 pass
- [x] `bun run scripts/test-isolated.ts --affected` — 27/27 pass
- [ ] GitHub Actions `api-tests` (full suite under canonical environment)
- [ ] GitHub Actions `boot-smoke` (validates the extended fixture)

### Unit-test cases (saas-guards.test.ts)

- fails boot in SaaS when catalog enables Slack but `SLACK_ENCRYPTION_KEY` is unset (the #2672 incident)
- fails boot reporting every missing key, not just the first
- treats empty-string env values as missing (matches `AdapterRegistry`'s truthy check)
- succeeds in SaaS when every Slack env var is set
- succeeds in SaaS when catalog entry is disabled (operator-disabled rows don't activate)
- succeeds in SaaS when catalog entry is non-OAuth (static-bot has no event-loop adapter)
- succeeds in SaaS when catalog has no chat entries
- succeeds in SaaS when catalog is empty / unset
- succeeds in SaaS for an unknown slug (operator typo falls through to AdapterRegistry's runtime warn)
- succeeds on self-hosted with the same misconfig (dev box can fix env when ready)

## Notes

The boot-smoke fixture's placeholders for the three new keys are syntactically valid (`SLACK_CLIENT_ID` and `_SECRET` are opaque non-empty strings; `SLACK_ENCRYPTION_KEY` mirrors the 32-char lowercase hex shape `@chat-adapter/slack` SHA-256s into an AES key). No real Slack app credential required.