### PR TITLE
test(oauth-state-token): fix #2681 — guarantee char-flip in tampering tests

### DIFF
--- a/packages/api/src/__test-utils__/base64url.ts
+++ b/packages/api/src/__test-utils__/base64url.ts
@@ -1,0 +1,19 @@
+/**
+ * Test helpers for mutating base64url-encoded segments (JWT-style tokens).
+ *
+ * Why this exists: tampering tests that "flip a char" by appending a
+ * constant (e.g. `slice(0, -1) + "A"`) are a no-op ~1/64 of the time —
+ * the base64url alphabet is 64 chars, so the original last char already
+ * equals the constant with uniform probability. Surfaced empirically on
+ * PR #2680 CI; tracked as #2681.
+ */
+
+/**
+ * Replace the last char of a base64url segment with one guaranteed to
+ * be different. Returns the input minus its last char, with `"A"`
+ * appended — unless the original last char was already `"A"`, in which
+ * case `"B"`. Both substitutes are valid base64url chars.
+ */
+export function mutateLastChar(s: string): string {
+  return s.slice(0, -1) + (s.slice(-1) === "A" ? "B" : "A");
+}

--- a/packages/api/src/lib/integrations/install/__tests__/oauth-state-token.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/oauth-state-token.test.ts
@@ -16,6 +16,7 @@
 
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { _resetEncryptionKeyCache } from "@atlas/api/lib/db/encryption-keys";
+import { mutateLastChar } from "../../../../__test-utils__/base64url";
 import {
   mintOAuthStateToken,
   verifyOAuthStateToken,
@@ -26,14 +27,6 @@ import {
 // ---------------------------------------------------------------------------
 
 const ORIGINAL_ENV = { ...process.env };
-
-// Flip the last char of a base64url segment to something guaranteed
-// different. Constant-replace (`.slice(0, -1) + "A"`) is a no-op ~1/64 of
-// the time when the original already ends in that char — caught
-// empirically on PR #2680 CI (see #2681).
-function flipLastChar(s: string): string {
-  return s.slice(0, -1) + (s.slice(-1) === "A" ? "B" : "A");
-}
 
 function setKeys(value: string | undefined): void {
   if (value === undefined) {
@@ -85,14 +78,14 @@ describe("OAuthStateToken — tampering", () => {
     const parts = token.split(".");
     expect(parts.length).toBe(3);
     // Flip one character in the payload segment (middle).
-    const tampered = `${parts[0]}.${flipLastChar(parts[1])}.${parts[2]}`;
+    const tampered = `${parts[0]}.${mutateLastChar(parts[1])}.${parts[2]}`;
     expect(verifyOAuthStateToken(tampered)).toBeNull();
   });
 
   it("returns null when the signature segment is tampered", () => {
     const token = mintOAuthStateToken("org-abc", "slack");
     const parts = token.split(".");
-    const tamperedSig = flipLastChar(parts[2]);
+    const tamperedSig = mutateLastChar(parts[2]);
     expect(verifyOAuthStateToken(`${parts[0]}.${parts[1]}.${tamperedSig}`)).toBeNull();
   });
 

--- a/packages/api/src/lib/integrations/install/__tests__/oauth-state-token.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/oauth-state-token.test.ts
@@ -27,6 +27,14 @@ import {
 
 const ORIGINAL_ENV = { ...process.env };
 
+// Flip the last char of a base64url segment to something guaranteed
+// different. Constant-replace (`.slice(0, -1) + "A"`) is a no-op ~1/64 of
+// the time when the original already ends in that char — caught
+// empirically on PR #2680 CI (see #2681).
+function flipLastChar(s: string): string {
+  return s.slice(0, -1) + (s.slice(-1) === "A" ? "B" : "A");
+}
+
 function setKeys(value: string | undefined): void {
   if (value === undefined) {
     delete process.env.ATLAS_ENCRYPTION_KEYS;
@@ -77,14 +85,14 @@ describe("OAuthStateToken — tampering", () => {
     const parts = token.split(".");
     expect(parts.length).toBe(3);
     // Flip one character in the payload segment (middle).
-    const tampered = `${parts[0]}.${parts[1].slice(0, -1)}X.${parts[2]}`;
+    const tampered = `${parts[0]}.${flipLastChar(parts[1])}.${parts[2]}`;
     expect(verifyOAuthStateToken(tampered)).toBeNull();
   });
 
   it("returns null when the signature segment is tampered", () => {
     const token = mintOAuthStateToken("org-abc", "slack");
     const parts = token.split(".");
-    const tamperedSig = `${parts[2].slice(0, -1)}A`;
+    const tamperedSig = flipLastChar(parts[2]);
     expect(verifyOAuthStateToken(`${parts[0]}.${parts[1]}.${tamperedSig}`)).toBeNull();
   });
 

--- a/packages/api/src/lib/integrations/install/__tests__/slack-oauth-handler.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/slack-oauth-handler.test.ts
@@ -20,6 +20,7 @@
 
 import { afterEach, beforeAll, beforeEach, describe, expect, it, mock, type Mock } from "bun:test";
 import { _resetEncryptionKeyCache } from "@atlas/api/lib/db/encryption-keys";
+import { mutateLastChar } from "../../../../__test-utils__/base64url";
 import {
   mintOAuthStateToken,
   verifyOAuthStateToken,
@@ -256,7 +257,7 @@ describe("SlackOAuthInstallHandler.handleCallback — state rejection", () => {
     const handler = new SlackOAuthInstallHandler(SLACK_CONFIG);
     const good = mintOAuthStateToken(WSID, "slack");
     const parts = good.split(".");
-    const tampered = `${parts[0]}.${parts[1].slice(0, -1)}X.${parts[2]}`;
+    const tampered = `${parts[0]}.${mutateLastChar(parts[1])}.${parts[2]}`;
 
     const result = await handler.handleCallback("auth-code-abc", tampered);
 


### PR DESCRIPTION
## Summary

- `payload` and `signature` tampering tests in `oauth-state-token.test.ts` used `slice(0, -1) + "X"` / `+ "A"` — a no-op ~1/64 of the time when the freshly-minted token's last char already matched the constant.
- Added `flipLastChar(s)`: returns `"A"` unless the original ends in `"A"`, in which case `"B"`. Guaranteed bit change regardless of input.
- The kid-swap tampering test builds a fresh fake header — no constant-replace, no flake — left untouched.

Caught empirically on PR #2680 CI ([run 26195551388, api-tests 3/4](https://github.com/AtlasDevHQ/atlas/actions/runs/26195551388/job/77073981292)). Base64url alphabet is 64 chars → 1/64 ≈ 1.5% flake rate per affected case.

## Test plan

- [x] Single-file run: `bun test src/lib/integrations/install/__tests__/oauth-state-token.test.ts` → 17/17 pass
- [x] Tight loop: 200× → 0 failures (versus the prior ~1.5% per-case flake)
- [ ] CI green on this branch

Closes #2681