### PR TITLE
feat: #2659 — Jira lazy OAuth integration (proves Salesforce pattern abstracts)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -368,6 +368,18 @@ ATLAS_SANDBOX_URL=http://localhost:8080
 # JIRA_API_TOKEN=                                # Jira API token (generate at id.atlassian.com)
 # JIRA_DEFAULT_PROJECT=                          # Default project key for issue creation (e.g. PROJ)
 
+# === Jira Lazy OAuth Integration (1.5.2 / #2659) ===
+# Distinct from the manual JIRA_API_TOKEN flow above — this is the
+# per-Workspace OAuth 2.0 (3LO) integration registered under
+# /api/v1/integrations/jira. Create an OAuth 2.0 (3LO) integration in the
+# Atlassian Developer Console with at least `read:jira-work`,
+# `read:jira-user`, and `offline_access` scopes; set the Callback URL to
+# `${ATLAS_PUBLIC_API_URL}/api/v1/integrations/jira/callback`. Without
+# these env vars, the install handler logs `Jira OAuth handler not
+# registered` at boot and GET /api/v1/integrations/jira/install returns 501.
+# JIRA_CLIENT_ID=                                # Atlassian App's Client ID
+# JIRA_CLIENT_SECRET=                            # Atlassian App's Client Secret
+
 # === Stripe Billing (SaaS only) ===
 # Enables Stripe billing when STRIPE_SECRET_KEY is set. Self-hosted deployments
 # skip this entirely — the self-hosted experience is the free tier.

--- a/apps/docs/content/docs/guides/integrations.mdx
+++ b/apps/docs/content/docs/guides/integrations.mdx
@@ -399,6 +399,51 @@ All endpoints require admin authentication.
 
 ---
 
+## Jira (Lazy OAuth — 1.5.2 / #2659)
+
+Jira is the second **lazy OAuth integration**, riding the shared infrastructure Salesforce established in #2658 — credentials in `integration_credentials`, per-Workspace plugin instances built on demand by `LazyPluginLoader`, dual-store teardown via the same disconnect path.
+
+Atlassian-specific notes vs Salesforce:
+
+- Authorize + token endpoints are **fixed** (`auth.atlassian.com`) — no per-tenant login host.
+- After the token exchange Atlas calls `GET https://api.atlassian.com/oauth/token/accessible-resources` to learn the **`cloudid`** of the Atlassian Cloud the user connected. One Atlas Workspace = one Atlassian Cloud; `cloudid` lands in `workspace_plugins.config`.
+- Atlassian **rotates** the `refresh_token` on every refresh; the new value is persisted back to `integration_credentials` (Salesforce sometimes returns one, sometimes not).
+
+### Operator setup
+
+1. In your Atlassian Developer Console, create an **OAuth 2.0 (3LO) integration**.
+2. Configure permissions — at minimum `read:jira-work`, `read:jira-user`, plus `offline_access` (required to receive refresh tokens).
+3. Set the **Callback URL** to `https://<your-api>/api/v1/integrations/jira/callback`.
+4. Capture the **Client ID** and **Client Secret** from the App's Settings tab.
+5. Set these env vars on your API service:
+
+| Env var | Required | Notes |
+|---|---|---|
+| `JIRA_CLIENT_ID` | yes | Atlassian App's Client ID |
+| `JIRA_CLIENT_SECRET` | yes | Atlassian App's Client Secret |
+| `ATLAS_PUBLIC_API_URL` | yes | Public origin of the API — used to construct the OAuth callback URL |
+
+Without `JIRA_CLIENT_ID` / `JIRA_CLIENT_SECRET`, the install handler logs `Jira OAuth handler not registered` at boot and `GET /api/v1/integrations/jira/install` returns 501.
+
+### Customer admin flow
+
+1. Click **Connect** on the Jira card in `/admin/integrations`.
+2. Atlas redirects to `https://auth.atlassian.com/authorize` with the operator's `client_id`, the required `audience=api.atlassian.com` param, and a CSRF-signed state token.
+3. The Jira admin signs in + selects the Atlassian site(s) to grant access to.
+4. Atlassian redirects back to `/api/v1/integrations/jira/callback?code=...&state=...`. Atlas exchanges the code, calls `accessible-resources` for the `cloudid`, then writes:
+   - `workspace_plugins` — install row with `config = { cloudid, scopes, status: "ok", site_url, site_name }`.
+   - `integration_credentials` — encrypted `{ accessToken, refreshToken, expiresAt, tokenType, scope, instanceUrl }` blob (`instanceUrl = https://api.atlassian.com/ex/jira/<cloudid>`).
+
+### Refresh + reconnect
+
+Jira access tokens are short-lived. On HTTP 401 during a query, Atlas runs `grant_type=refresh_token` and retries; the rotated `refresh_token` is persisted back. On a permanent failure (`invalid_grant`, `unauthorized_client`, `access_denied`), Atlas flips `workspace_plugins.config.status` to `"reconnect_needed"` and the admin UI surfaces a **Reconnect needed** badge + Reconnect button. A re-run of the OAuth dance heals the install.
+
+### Disconnect
+
+`DELETE /api/v1/integrations/jira` tears down both stores in the ADR-0003 order (credentials FIRST, install record SECOND).
+
+---
+
 ## Salesforce (Lazy OAuth — 1.5.2 / #2658)
 
 Salesforce is the first **lazy OAuth integration** — credentials live in the dedicated `integration_credentials` table (per [ADR-0005](https://github.com/AtlasDevHQ/atlas/blob/main/docs/adr/0005-integration-credentials-table.md)) and the per-Workspace plugin instance is built on demand by `LazyPluginLoader` on the first agent tool call.

--- a/deploy/api/atlas.config.ts
+++ b/deploy/api/atlas.config.ts
@@ -130,19 +130,38 @@ export default defineConfig({
       enabled: false,
       saas_eligible: true,
     },
-    // ── Lazy OAuth integrations (1.5.2 slice 8 — #2658) ─────────────
-    // First lazy OAuth integration. Establishes the pattern future
-    // OAuth integrations (Jira / etc.) will reuse:
+    // ── Lazy OAuth integrations (1.5.2 slice 8 — #2658 / #2659) ─────
+    // Salesforce (#2658) established the pattern; Jira (#2659) proves
+    // the abstraction by riding the same shared infra:
     //   - `install_model: 'oauth'` routes through the OAuth install
     //     handler dispatch.
     //   - Credentials persist in `integration_credentials` (migration
     //     0089), not `workspace_plugins.config` JSONB — refresh-token
     //     lifecycle needs its own row.
-    //   - Operator wires `SALESFORCE_CLIENT_ID` + `SALESFORCE_CLIENT_SECRET`
-    //     to a single Connected App per region; per-Workspace OAuth
+    //   - Operator wires `<PLATFORM>_CLIENT_ID` + `<PLATFORM>_CLIENT_SECRET`
+    //     to a single App registration per region; per-Workspace OAuth
     //     consent against that App writes the install + credential rows.
     //   - On refresh failure, `workspace_plugins.config.status = 'reconnect_needed'`
     //     is set and the admin UI surfaces a Reconnect affordance.
+    //
+    // Jira note: Atlassian's 3LO returns a `cloudid` identifying which
+    // Atlassian Cloud instance the customer connected. One Atlas
+    // Workspace = one Atlassian Cloud (matches Salesforce's
+    // `instance_url` shape). `cloudid` goes into
+    // `workspace_plugins.config`; tokens go into
+    // `integration_credentials`. Atlassian rotates the refresh token on
+    // every refresh, so the new value is written back each time.
+    {
+      slug: "jira",
+      type: "integration",
+      install_model: "oauth",
+      enabled: true,
+      saas_eligible: true,
+      name: "Jira",
+      description:
+        "Query Jira issues via JQL. Connects through your operator's Atlassian OAuth 2.0 (3LO) App and refreshes access tokens automatically.",
+      min_plan: "starter",
+    },
     {
       slug: "salesforce",
       type: "integration",

--- a/packages/api/src/api/routes/integrations.ts
+++ b/packages/api/src/api/routes/integrations.ts
@@ -647,8 +647,8 @@ async function getCatalogRowBySlugForDisconnect(slug: string): Promise<{
 
 /**
  * Slugs whose credentials live in `integration_credentials` keyed by
- * (workspace_id, catalog_id). Salesforce ships first (#2658); future
- * lazy OAuth integrations (Jira, etc.) join the set as they land.
+ * (workspace_id, catalog_id). Salesforce shipped first (#2658); Jira
+ * (#2659) is the second consumer that proves the abstraction.
  *
  * Adding a new lazy OAuth integration requires (per the "Consequences"
  * section of ADR-0005):
@@ -663,7 +663,7 @@ async function getCatalogRowBySlugForDisconnect(slug: string): Promise<{
  *
  * @see docs/adr/0005-integration-credentials-table.md
  */
-const INTEGRATION_CREDENTIALS_SLUGS = new Set<string>(["salesforce"]);
+const INTEGRATION_CREDENTIALS_SLUGS = new Set<string>(["salesforce", "jira"]);
 
 /**
  * Credential-store teardown. Branches by slug:

--- a/packages/api/src/lib/effect/errors.ts
+++ b/packages/api/src/lib/effect/errors.ts
@@ -369,6 +369,32 @@ export class SalesforceReconnectRequiredError extends Data.TaggedError(
   readonly upstreamError: string;
 }> {}
 
+/**
+ * Jira refresh-token rotation failed permanently — Atlassian returned
+ * `invalid_grant`, the stored refresh token was rejected, or the
+ * Connected App scopes no longer include `offline_access`. The install
+ * row's `workspace_plugins.config.status` has already been flipped to
+ * `"reconnect_needed"` by the refresh flow; this error signals the route
+ * layer / agent loop that the install needs admin attention.
+ *
+ * Maps to HTTP 409 Conflict — same wire shape as
+ * {@link SalesforceReconnectRequiredError}. Per the #2659 "if you find
+ * yourself adding shared infra, STOP and file an extraction issue"
+ * rule, the duplication is intentional in this PR — a single
+ * `IntegrationReconnectRequiredError(platform)` is a follow-up
+ * extraction once the third consumer arrives.
+ *
+ * @see packages/api/src/lib/integrations/install/jira-token-refresh.ts
+ */
+export class JiraReconnectRequiredError extends Data.TaggedError(
+  "JiraReconnectRequiredError",
+)<{
+  readonly message: string;
+  readonly workspaceId: string;
+  /** Raw Atlassian error code (`invalid_grant`, etc.). Forensic-only. */
+  readonly upstreamError: string;
+}> {}
+
 // ── Scheduler ──────────────────────────────────────────────────────
 
 /** Scheduled task execution timed out. */
@@ -421,6 +447,7 @@ export type AtlasError =
   | AmbiguousEntityError
   | PlatformOAuthExchangeError
   | SalesforceReconnectRequiredError
+  | JiraReconnectRequiredError
   | SchedulerTaskTimeoutError
   | SchedulerExecutionError
   | DeliveryError
@@ -474,6 +501,7 @@ export const ATLAS_ERROR_TAG_LIST = [
   "AmbiguousEntityError",
   "PlatformOAuthExchangeError",
   "SalesforceReconnectRequiredError",
+  "JiraReconnectRequiredError",
   "SchedulerTaskTimeoutError",
   "SchedulerExecutionError",
   "DeliveryError",

--- a/packages/api/src/lib/effect/hono.ts
+++ b/packages/api/src/lib/effect/hono.ts
@@ -193,15 +193,18 @@ export function mapTaggedError(error: AtlasError): HttpErrorMapping {
           entityType: error.entityType,
         },
       };
-    // #2658 — Salesforce install's refresh-token rotation failed
-    // permanently; the install is flagged `reconnect_needed` in
-    // `workspace_plugins.config` and the admin must re-run OAuth.
-    // 409 (not 502) because the request is well-formed but the
-    // resource is in a state the user controls. Reuses the
-    // `"conflict"` wire code rather than adding `"reconnect_required"`
-    // to the closed `HttpErrorCode` vocabulary — the message + the
-    // `_tag` in error logs disambiguate.
+    // #2658 / #2659 — lazy-OAuth integration install's refresh-token
+    // rotation failed permanently; the install is flagged
+    // `reconnect_needed` in `workspace_plugins.config` and the admin
+    // must re-run OAuth. 409 (not 502) because the request is
+    // well-formed but the resource is in a state the user controls.
+    // Reuses the `"conflict"` wire code rather than adding
+    // `"reconnect_required"` to the closed `HttpErrorCode` vocabulary
+    // — the message + the `_tag` in error logs disambiguate. Both
+    // tags collapse to one case so the mapping stays canonical across
+    // the integration_credentials platforms.
     case "SalesforceReconnectRequiredError":
+    case "JiraReconnectRequiredError":
       return {
         status: 409,
         code: "conflict",

--- a/packages/api/src/lib/integrations/install/__tests__/jira-oauth-handler.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/jira-oauth-handler.test.ts
@@ -1,0 +1,483 @@
+/**
+ * Tests for {@link JiraOAuthInstallHandler} (#2659).
+ *
+ * Coverage mirrors `salesforce-oauth-handler.test.ts`; Jira-specific
+ * additions:
+ *
+ *   - `startInstall` URL includes Atlassian's required
+ *     `audience=api.atlassian.com` query param.
+ *   - `handleCallback` fetches `accessible-resources` after the token
+ *     exchange and persists the first cloud's `id` as `cloudid` in
+ *     `workspace_plugins.config` (the one-Atlas-Workspace = one-
+ *     Atlassian-Cloud semantic per the issue body).
+ *   - Empty accessible-resources response throws
+ *     `PlatformOAuthExchangeError` — the install would otherwise orphan
+ *     a credential with no Cloud to call.
+ *   - The credential bundle's `instanceUrl` is the per-cloud API host
+ *     (`https://api.atlassian.com/ex/jira/<cloudid>`).
+ *
+ * Test seam: `fetch` is mocked module-global so both the
+ * `auth.atlassian.com/oauth/token` POST AND the
+ * `api.atlassian.com/oauth/token/accessible-resources` GET are
+ * intercepted in sequence.
+ */
+
+import { afterEach, beforeAll, beforeEach, describe, expect, it, mock, type Mock } from "bun:test";
+import { _resetEncryptionKeyCache } from "@atlas/api/lib/db/encryption-keys";
+import { mutateLastChar } from "../../../../__test-utils__/base64url";
+import {
+  mintOAuthStateToken,
+  verifyOAuthStateToken,
+} from "../oauth-state-token";
+import type { WorkspaceId } from "@useatlas/types";
+
+// ---------------------------------------------------------------------------
+// Module mocks (must precede the SUT import)
+// ---------------------------------------------------------------------------
+
+// ADR-0003/0005 ordering — install row FIRST, credential bundle SECOND.
+const callOrder: string[] = [];
+
+const mockInternalQuery: Mock<(sql: string, params?: unknown[]) => Promise<unknown[]>> = mock(
+  async (sql: string): Promise<unknown[]> => {
+    if (sql.includes("INSERT INTO workspace_plugins")) {
+      callOrder.push("workspace_plugins.insert");
+    }
+    return [];
+  },
+);
+
+mock.module("@atlas/api/lib/db/internal", () => ({
+  internalQuery: mockInternalQuery,
+  hasInternalDB: mock(() => true),
+  getInternalDB: mock(() => ({ query: mock(() => Promise.resolve({ rows: [] })) })),
+}));
+
+const mockSaveCredentialBundle: Mock<
+  (workspaceId: string, catalogId: string, bundle: unknown) => Promise<void>
+> = mock(async () => {
+  callOrder.push("integration_credentials.save");
+});
+
+mock.module("@atlas/api/lib/integrations/credentials/store", () => ({
+  saveCredentialBundle: mockSaveCredentialBundle,
+  readCredentialBundle: mock(() => Promise.resolve(null)),
+  deleteCredentialBundle: mock(() => Promise.resolve(false)),
+}));
+
+const ORIGINAL_FETCH = globalThis.fetch;
+// Loose typing — fetch from bun-types carries a `preconnect` method that
+// a vanilla mock function doesn't, but the call shape is identical.
+const mockFetch: Mock<(input: unknown, init?: unknown) => Promise<Response>> = mock(() =>
+  Promise.resolve(new Response("{}", { status: 200 })),
+);
+
+// ---------------------------------------------------------------------------
+// Test scaffolding
+// ---------------------------------------------------------------------------
+
+const ORIGINAL_ENV = { ...process.env };
+
+function setKeys(value: string): void {
+  process.env.ATLAS_ENCRYPTION_KEYS = value;
+  delete process.env.ATLAS_ENCRYPTION_KEY;
+  delete process.env.BETTER_AUTH_SECRET;
+  _resetEncryptionKeyCache();
+}
+
+const WSID = "ws-jira-test-1" as WorkspaceId;
+const JIRA_CONFIG = {
+  clientId: "test-jira-client-id",
+  clientSecret: "test-jira-client-secret",
+  redirectUri: "https://atlas.example/api/v1/integrations/jira/callback",
+};
+
+const CLOUDID = "11223344-aaaa-bbbb-cccc-ddddeeee0000";
+
+/**
+ * Default happy-path fetch sequence:
+ *   1st call → POST oauth/token → token success
+ *   2nd call → GET accessible-resources → one cloud
+ */
+function happyFetchSequence(): Mock<(input: unknown, init?: unknown) => Promise<Response>>["mock"]["calls"] {
+  mockFetch.mockImplementation((input: unknown) => {
+    const url = typeof input === "string" ? input : (input as Request).url;
+    // accessible-resources first — its URL also contains `/oauth/token`,
+    // so the broader `/oauth/token` check below would mis-match.
+    if (url.includes("accessible-resources")) {
+      return Promise.resolve(
+        new Response(
+          JSON.stringify([
+            {
+              id: CLOUDID,
+              url: "https://acme.atlassian.net",
+              name: "Acme",
+              scopes: ["read:jira-work", "read:jira-user", "offline_access"],
+            },
+          ]),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+      );
+    }
+    if (url.includes("/oauth/token")) {
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            access_token: "jira-access-token",
+            refresh_token: "jira-refresh-token-initial",
+            expires_in: 3600,
+            token_type: "Bearer",
+            scope: "read:jira-work read:jira-user offline_access",
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+      );
+    }
+    return Promise.resolve(new Response("{}", { status: 200 }));
+  });
+  return mockFetch.mock.calls;
+}
+
+type HandlerCtor = typeof import("../jira-oauth-handler").JiraOAuthInstallHandler;
+let JiraOAuthInstallHandler!: HandlerCtor;
+
+beforeAll(async () => {
+  const mod = await import("../jira-oauth-handler");
+  JiraOAuthInstallHandler = mod.JiraOAuthInstallHandler;
+});
+
+beforeEach(() => {
+  setKeys("v1:test-key-one");
+  callOrder.length = 0;
+  mockInternalQuery.mockClear();
+  mockInternalQuery.mockImplementation(async (sql: string): Promise<unknown[]> => {
+    if (sql.includes("INSERT INTO workspace_plugins")) {
+      callOrder.push("workspace_plugins.insert");
+    }
+    return [];
+  });
+  mockSaveCredentialBundle.mockClear();
+  mockSaveCredentialBundle.mockImplementation(async () => {
+    callOrder.push("integration_credentials.save");
+  });
+  mockFetch.mockClear();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  globalThis.fetch = mockFetch as any;
+  happyFetchSequence();
+});
+
+afterEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+  _resetEncryptionKeyCache();
+  globalThis.fetch = ORIGINAL_FETCH;
+});
+
+// ---------------------------------------------------------------------------
+// startInstall
+// ---------------------------------------------------------------------------
+
+describe("JiraOAuthInstallHandler.startInstall", () => {
+  it("returns an Atlassian authorize URL with the minted state token + required audience param", async () => {
+    const handler = new JiraOAuthInstallHandler(JIRA_CONFIG);
+
+    const { redirectUrl, stateToken } = await handler.startInstall(WSID);
+
+    expect(stateToken).toBeTypeOf("string");
+    expect(stateToken.length).toBeGreaterThan(0);
+
+    const parsed = new URL(redirectUrl);
+    expect(parsed.origin + parsed.pathname).toBe("https://auth.atlassian.com/authorize");
+    // The `audience` param is REQUIRED by Atlassian 3LO; without it the
+    // authorize endpoint redirects back with `invalid_request`. Pin it
+    // so a refactor that drops the param surfaces immediately.
+    expect(parsed.searchParams.get("audience")).toBe("api.atlassian.com");
+    expect(parsed.searchParams.get("response_type")).toBe("code");
+    expect(parsed.searchParams.get("client_id")).toBe(JIRA_CONFIG.clientId);
+    expect(parsed.searchParams.get("redirect_uri")).toBe(JIRA_CONFIG.redirectUri);
+    expect(parsed.searchParams.get("state")).toBe(stateToken);
+  });
+
+  it("requests the offline_access scope so Atlassian issues a refresh_token", async () => {
+    // Without offline_access, Atlassian doesn't return a refresh_token
+    // and the install dies on the first access-token expiry. Pin the
+    // scope set explicitly so a refactor that "tightens" scopes notices.
+    const handler = new JiraOAuthInstallHandler(JIRA_CONFIG);
+    const { redirectUrl } = await handler.startInstall(WSID);
+
+    const scope = new URL(redirectUrl).searchParams.get("scope") ?? "";
+    expect(scope).toContain("read:jira-work");
+    expect(scope).toContain("read:jira-user");
+    expect(scope).toContain("offline_access");
+  });
+
+  it("mints a state token that verifies back to (workspaceId, 'jira')", async () => {
+    const handler = new JiraOAuthInstallHandler(JIRA_CONFIG);
+
+    const { stateToken } = await handler.startInstall(WSID);
+
+    expect(verifyOAuthStateToken(stateToken)).toEqual({
+      workspaceId: WSID,
+      catalogId: "jira",
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleCallback — happy path
+// ---------------------------------------------------------------------------
+
+describe("JiraOAuthInstallHandler.handleCallback — happy path", () => {
+  it("verifies state, exchanges the code, fetches cloudid, and writes both stores in order", async () => {
+    const handler = new JiraOAuthInstallHandler(JIRA_CONFIG);
+    const stateToken = mintOAuthStateToken(WSID, "jira");
+
+    const result = await handler.handleCallback("auth-code-xyz", stateToken);
+
+    expect(result).not.toBeNull();
+    expect(result!.workspaceId).toBe(WSID);
+    expect(result!.catalogId).toBe("jira");
+    expect(result!.credentialResult).toEqual({ written: true });
+    expect(result!.installRecord.catalogId).toBe("jira");
+
+    // Two fetch calls — token exchange then accessible-resources.
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    const [tokenUrl, tokenInit] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(tokenUrl).toBe("https://auth.atlassian.com/oauth/token");
+    expect(tokenInit.method).toBe("POST");
+    expect((tokenInit.headers as Record<string, string>)["Content-Type"]).toBe("application/json");
+    const tokenBody = JSON.parse(tokenInit.body as string);
+    expect(tokenBody).toMatchObject({
+      grant_type: "authorization_code",
+      client_id: "test-jira-client-id",
+      code: "auth-code-xyz",
+    });
+
+    const [resourcesUrl, resourcesInit] = mockFetch.mock.calls[1] as [string, RequestInit];
+    expect(resourcesUrl).toBe("https://api.atlassian.com/oauth/token/accessible-resources");
+    expect((resourcesInit.headers as Record<string, string>).Authorization).toBe(
+      "Bearer jira-access-token",
+    );
+
+    // ADR-0003/0005 ordering invariant.
+    expect(callOrder).toEqual(["workspace_plugins.insert", "integration_credentials.save"]);
+
+    // workspace_plugins INSERT carries the cloudid in config (the
+    // critical one-Atlas-Workspace = one-Atlassian-Cloud assertion).
+    const [, params] = mockInternalQuery.mock.calls[0];
+    const configJson = (params as unknown[]).find(
+      (p) => typeof p === "string" && p.startsWith("{") && p.includes("cloudid"),
+    );
+    expect(configJson).toBeDefined();
+    const config = JSON.parse(configJson as string);
+    expect(config).toMatchObject({
+      cloudid: CLOUDID,
+      scopes: "read:jira-work read:jira-user offline_access",
+      status: "ok",
+      site_url: "https://acme.atlassian.net",
+      site_name: "Acme",
+    });
+
+    // Credential bundle: instanceUrl is the per-cloud API host so the
+    // lazy-builder can call Jira without re-reading the install config.
+    expect(mockSaveCredentialBundle).toHaveBeenCalledTimes(1);
+    expect(mockSaveCredentialBundle).toHaveBeenCalledWith(
+      WSID,
+      "catalog:jira",
+      expect.objectContaining({
+        accessToken: "jira-access-token",
+        refreshToken: "jira-refresh-token-initial",
+        instanceUrl: `https://api.atlassian.com/ex/jira/${CLOUDID}`,
+        scope: "read:jira-work read:jira-user offline_access",
+        tokenType: "Bearer",
+      }),
+    );
+  });
+
+  it("picks accessible-resources[0] when Atlassian returns multiple Clouds", async () => {
+    // Per the #2659 one-Atlas-Workspace = one-Atlassian-Cloud rule:
+    // when the OAuth grant covers multiple Clouds, we take the first.
+    // A future "multi-cloud picker" would change this; today the
+    // simplification is intentional.
+    mockFetch.mockImplementation((input: unknown) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url.includes("accessible-resources")) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify([
+              { id: "FIRST-CLOUD", url: "https://first.atlassian.net", name: "First" },
+              { id: "SECOND-CLOUD", url: "https://second.atlassian.net", name: "Second" },
+            ]),
+            { status: 200 },
+          ),
+        );
+      }
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            access_token: "jira-access-token",
+            refresh_token: "jira-refresh",
+            expires_in: 3600,
+            token_type: "Bearer",
+            scope: "read:jira-work offline_access",
+          }),
+          { status: 200 },
+        ),
+      );
+    });
+
+    const handler = new JiraOAuthInstallHandler(JIRA_CONFIG);
+    const stateToken = mintOAuthStateToken(WSID, "jira");
+    await handler.handleCallback("code", stateToken);
+
+    const [, params] = mockInternalQuery.mock.calls[0];
+    const configJson = (params as unknown[]).find(
+      (p) => typeof p === "string" && p.includes("cloudid"),
+    );
+    const config = JSON.parse(configJson as string);
+    expect(config.cloudid).toBe("FIRST-CLOUD");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleCallback — state rejection
+// ---------------------------------------------------------------------------
+
+describe("JiraOAuthInstallHandler.handleCallback — state rejection", () => {
+  it("returns null when the state token is tampered (no fetch, no writes)", async () => {
+    const handler = new JiraOAuthInstallHandler(JIRA_CONFIG);
+    const good = mintOAuthStateToken(WSID, "jira");
+    const parts = good.split(".");
+    const tampered = `${parts[0]}.${mutateLastChar(parts[1])}.${parts[2]}`;
+
+    const result = await handler.handleCallback("auth-code", tampered);
+
+    expect(result).toBeNull();
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(mockInternalQuery).not.toHaveBeenCalled();
+    expect(mockSaveCredentialBundle).not.toHaveBeenCalled();
+  });
+
+  it("returns null when the state token binds to a different catalog", async () => {
+    const handler = new JiraOAuthInstallHandler(JIRA_CONFIG);
+    const wrongBinding = mintOAuthStateToken(WSID, "salesforce");
+
+    const result = await handler.handleCallback("auth-code", wrongBinding);
+
+    expect(result).toBeNull();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleCallback — Atlassian-side failure
+// ---------------------------------------------------------------------------
+
+describe("JiraOAuthInstallHandler.handleCallback — Atlassian-side failure", () => {
+  it("throws PlatformOAuthExchangeError on non-2xx token exchange (no writes)", async () => {
+    mockFetch.mockImplementation((input: unknown) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url.includes("accessible-resources")) {
+        return Promise.resolve(new Response("[]", { status: 200 }));
+      }
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({ error: "invalid_grant", error_description: "expired code" }),
+          { status: 400 },
+        ),
+      );
+    });
+
+    const handler = new JiraOAuthInstallHandler(JIRA_CONFIG);
+    const stateToken = mintOAuthStateToken(WSID, "jira");
+
+    await expect(handler.handleCallback("bad-code", stateToken)).rejects.toMatchObject({
+      _tag: "PlatformOAuthExchangeError",
+      platform: "jira",
+      upstreamError: "invalid_grant",
+    });
+
+    expect(mockInternalQuery).not.toHaveBeenCalled();
+    expect(mockSaveCredentialBundle).not.toHaveBeenCalled();
+  });
+
+  it("throws PlatformOAuthExchangeError when accessible-resources is empty (no writes)", async () => {
+    // Token exchange succeeded but the user has no Atlassian Clouds the
+    // App can reach — installing this credential would orphan it.
+    mockFetch.mockImplementation((input: unknown) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url.includes("accessible-resources")) {
+        // Empty array — no clouds accessible.
+        return Promise.resolve(new Response("[]", { status: 200 }));
+      }
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            access_token: "token",
+            refresh_token: "refresh",
+            expires_in: 3600,
+          }),
+          { status: 200 },
+        ),
+      );
+    });
+
+    const handler = new JiraOAuthInstallHandler(JIRA_CONFIG);
+    const stateToken = mintOAuthStateToken(WSID, "jira");
+
+    await expect(handler.handleCallback("auth-code", stateToken)).rejects.toMatchObject({
+      _tag: "PlatformOAuthExchangeError",
+      platform: "jira",
+      upstreamError: "no_accessible_resources",
+    });
+
+    expect(mockInternalQuery).not.toHaveBeenCalled();
+    expect(mockSaveCredentialBundle).not.toHaveBeenCalled();
+  });
+
+  it("throws PlatformOAuthExchangeError on network failure", async () => {
+    mockFetch.mockImplementationOnce(() =>
+      Promise.reject(new Error("ENOTFOUND auth.atlassian.com")),
+    );
+    const handler = new JiraOAuthInstallHandler(JIRA_CONFIG);
+    const stateToken = mintOAuthStateToken(WSID, "jira");
+
+    await expect(handler.handleCallback("auth-code", stateToken)).rejects.toMatchObject({
+      _tag: "PlatformOAuthExchangeError",
+      platform: "jira",
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleCallback — partial failure (ADR-0003 Reconnect path)
+// ---------------------------------------------------------------------------
+
+describe("JiraOAuthInstallHandler.handleCallback — partial failure", () => {
+  it("returns credentialResult.written=false AND flips status to reconnect_needed when integration_credentials write throws", async () => {
+    mockSaveCredentialBundle.mockImplementationOnce(() =>
+      Promise.reject(new Error("transient db error")),
+    );
+    const handler = new JiraOAuthInstallHandler(JIRA_CONFIG);
+    const stateToken = mintOAuthStateToken(WSID, "jira");
+
+    const result = await handler.handleCallback("auth-code", stateToken);
+
+    expect(result).not.toBeNull();
+    expect(result!.installRecord.workspaceId).toBe(WSID);
+    expect(result!.installRecord.catalogId).toBe("jira");
+    expect(result!.credentialResult.written).toBe(false);
+    expect(result!.credentialResult.reason).toContain("Reconnect");
+
+    // Flipping status: reconnect_needed is what makes the admin card
+    // surface a persistent Reconnect CTA. Without this UPDATE the user
+    // sees `?reconnect=jira` once then a normal "Installed" card on the
+    // next page load.
+    const reconnectUpdate = mockInternalQuery.mock.calls.find(
+      (call) =>
+        (call[0] as string).includes("UPDATE workspace_plugins") &&
+        (call[0] as string).includes("'reconnect_needed'"),
+    );
+    expect(reconnectUpdate).toBeDefined();
+    expect(mockSaveCredentialBundle).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/api/src/lib/integrations/install/__tests__/jira-token-refresh.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/jira-token-refresh.test.ts
@@ -1,0 +1,269 @@
+/**
+ * Tests for the Jira refresh-token rotation flow (#2659).
+ *
+ * Coverage mirrors `salesforce-token-refresh.test.ts`; the
+ * Atlassian-specific pin is the **refresh-token rotation** assertion —
+ * Atlassian returns a fresh refresh_token in every success response and
+ * the new value MUST land in `integration_credentials`. Salesforce
+ * sometimes omits it; Atlassian always returns it. If a refactor drops
+ * the rotated value, the install dies on the second refresh.
+ */
+
+import { afterEach, beforeAll, beforeEach, describe, expect, it, mock, type Mock } from "bun:test";
+import { _resetEncryptionKeyCache } from "@atlas/api/lib/db/encryption-keys";
+
+const mockReadCredentialBundle: Mock<(ws: string, cat: string) => Promise<unknown>> = mock(() =>
+  Promise.resolve(null),
+);
+const mockSaveCredentialBundle: Mock<(ws: string, cat: string, bundle: unknown) => Promise<void>> = mock(() =>
+  Promise.resolve(),
+);
+
+mock.module("@atlas/api/lib/integrations/credentials/store", () => ({
+  readCredentialBundle: mockReadCredentialBundle,
+  saveCredentialBundle: mockSaveCredentialBundle,
+  deleteCredentialBundle: mock(() => Promise.resolve(false)),
+}));
+
+const mockInternalQuery: Mock<(sql: string, params?: unknown[]) => Promise<unknown[]>> = mock(() =>
+  Promise.resolve([]),
+);
+mock.module("@atlas/api/lib/db/internal", () => ({
+  internalQuery: mockInternalQuery,
+  hasInternalDB: mock(() => true),
+  getInternalDB: mock(() => ({ query: mock(() => Promise.resolve({ rows: [] })) })),
+}));
+
+const ORIGINAL_FETCH = globalThis.fetch;
+const mockFetch: Mock<(input: unknown, init?: unknown) => Promise<Response>> = mock(() =>
+  Promise.resolve(new Response("{}", { status: 200, headers: { "content-type": "application/json" } })),
+);
+
+type RefreshModule = typeof import("../jira-token-refresh");
+let refreshMod!: RefreshModule;
+
+beforeAll(async () => {
+  refreshMod = await import("../jira-token-refresh");
+});
+
+const ORIGINAL_ENV = { ...process.env };
+const WSID = "ws-jira-refresh-test-1";
+const CLOUDID = "11223344-aaaa-bbbb-cccc-ddddeeee0000";
+
+const STORED_BUNDLE = {
+  accessToken: "old-access-token",
+  refreshToken: "stored-refresh-token",
+  expiresAt: 1_700_000_000_000,
+  tokenType: "Bearer",
+  scope: "read:jira-work read:jira-user offline_access",
+  instanceUrl: `https://api.atlassian.com/ex/jira/${CLOUDID}`,
+};
+
+const JIRA_ARGS = {
+  workspaceId: WSID,
+  clientId: "jira-client-id",
+  clientSecret: "jira-client-secret",
+};
+
+beforeEach(() => {
+  process.env.ATLAS_ENCRYPTION_KEYS = "v1:test-key-one";
+  _resetEncryptionKeyCache();
+  mockReadCredentialBundle.mockClear();
+  mockSaveCredentialBundle.mockClear();
+  mockInternalQuery.mockClear();
+  mockFetch.mockClear();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  globalThis.fetch = mockFetch as any;
+});
+
+afterEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+  _resetEncryptionKeyCache();
+  globalThis.fetch = ORIGINAL_FETCH;
+});
+
+// ---------------------------------------------------------------------------
+// Happy path — refresh-token rotation
+// ---------------------------------------------------------------------------
+
+describe("refreshJiraToken — happy path (refresh-token rotation)", () => {
+  it("exchanges the refresh token, persists the ROTATED refresh_token, and clears reconnect_needed", async () => {
+    mockReadCredentialBundle.mockResolvedValueOnce(STORED_BUNDLE);
+    mockFetch.mockImplementationOnce(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            access_token: "new-access-token",
+            // Atlassian-specific: the refresh_token rotates on every
+            // refresh. The new value MUST be persisted; using the old
+            // refresh token on the next refresh would fail with
+            // invalid_grant and force a Reconnect.
+            refresh_token: "ROTATED-refresh-token",
+            expires_in: 3600,
+            token_type: "Bearer",
+            scope: "read:jira-work read:jira-user offline_access",
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+      ),
+    );
+
+    const result = await refreshMod.refreshJiraToken(JIRA_ARGS);
+
+    expect(result.accessToken).toBe("new-access-token");
+    // Critical pin — without this assertion a regression that "preserved
+    // the stored refresh token" (mirroring Salesforce's behaviour
+    // wrongly) would compile + pass everything except the second
+    // refresh.
+    expect(result.refreshToken).toBe("ROTATED-refresh-token");
+    expect(result.instanceUrl).toBe(`https://api.atlassian.com/ex/jira/${CLOUDID}`);
+
+    // Token-endpoint POST shape — JSON body, not form-encoded.
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [tokenUrl, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(tokenUrl).toBe("https://auth.atlassian.com/oauth/token");
+    expect(init.method).toBe("POST");
+    expect((init.headers as Record<string, string>)["Content-Type"]).toBe("application/json");
+    const body = JSON.parse(init.body as string);
+    expect(body).toMatchObject({
+      grant_type: "refresh_token",
+      client_id: "jira-client-id",
+      refresh_token: "stored-refresh-token",
+    });
+
+    // Persisted bundle carries the rotated refresh_token.
+    expect(mockSaveCredentialBundle).toHaveBeenCalledWith(
+      WSID,
+      "catalog:jira",
+      expect.objectContaining({
+        accessToken: "new-access-token",
+        refreshToken: "ROTATED-refresh-token",
+      }),
+    );
+
+    // clear-reconnect UPDATE fires alongside the save (independent
+    // statement — see jira-token-refresh.ts JSDoc).
+    const clearUpdate = mockInternalQuery.mock.calls.find(
+      (c) =>
+        (c[0] as string).includes("UPDATE workspace_plugins") &&
+        (c[0] as string).includes("'ok'"),
+    );
+    expect(clearUpdate).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Permanent failure → reconnect_needed
+// ---------------------------------------------------------------------------
+
+describe("refreshJiraToken — permanent failure", () => {
+  it("on invalid_grant: throws JiraReconnectRequiredError + marks status reconnect_needed", async () => {
+    mockReadCredentialBundle.mockResolvedValueOnce(STORED_BUNDLE);
+    mockFetch.mockImplementationOnce(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({ error: "invalid_grant", error_description: "refresh token rejected" }),
+          { status: 400, headers: { "content-type": "application/json" } },
+        ),
+      ),
+    );
+
+    await expect(refreshMod.refreshJiraToken(JIRA_ARGS)).rejects.toMatchObject({
+      _tag: "JiraReconnectRequiredError",
+      workspaceId: WSID,
+      upstreamError: "invalid_grant",
+    });
+
+    // No credential persistence on failure.
+    expect(mockSaveCredentialBundle).not.toHaveBeenCalled();
+
+    // markReconnectNeeded UPDATE fires.
+    const markUpdate = mockInternalQuery.mock.calls.find(
+      (c) =>
+        (c[0] as string).includes("UPDATE workspace_plugins") &&
+        (c[0] as string).includes("'reconnect_needed'"),
+    );
+    expect(markUpdate).toBeDefined();
+  });
+
+  it("on bundle missing refresh_token: short-circuits to JiraReconnectRequiredError without a fetch", async () => {
+    mockReadCredentialBundle.mockResolvedValueOnce({
+      ...STORED_BUNDLE,
+      refreshToken: null,
+    });
+
+    await expect(refreshMod.refreshJiraToken(JIRA_ARGS)).rejects.toMatchObject({
+      _tag: "JiraReconnectRequiredError",
+      upstreamError: "no_refresh_token",
+    });
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(mockSaveCredentialBundle).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Transient failure → NO reconnect_needed
+// ---------------------------------------------------------------------------
+
+describe("refreshJiraToken — transient failure", () => {
+  it("on network failure: throws plain Error, does NOT mark reconnect_needed", async () => {
+    mockReadCredentialBundle.mockResolvedValueOnce(STORED_BUNDLE);
+    mockFetch.mockImplementationOnce(() =>
+      Promise.reject(new Error("ECONNRESET")),
+    );
+
+    await expect(refreshMod.refreshJiraToken(JIRA_ARGS)).rejects.toThrow("ECONNRESET");
+
+    // Crucial — a transient flake must not flip every workspace's
+    // status to reconnect_needed.
+    const markUpdate = mockInternalQuery.mock.calls.find(
+      (c) =>
+        (c[0] as string).includes("UPDATE workspace_plugins") &&
+        (c[0] as string).includes("'reconnect_needed'"),
+    );
+    expect(markUpdate).toBeUndefined();
+  });
+
+  it("on HTTP 500 with no recognized error code: throws plain Error, does NOT mark reconnect_needed", async () => {
+    mockReadCredentialBundle.mockResolvedValueOnce(STORED_BUNDLE);
+    mockFetch.mockImplementationOnce(() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ error: "server_error" }), { status: 500 }),
+      ),
+    );
+
+    await expect(refreshMod.refreshJiraToken(JIRA_ARGS)).rejects.toThrow(/HTTP 500/);
+
+    const markUpdate = mockInternalQuery.mock.calls.find(
+      (c) =>
+        (c[0] as string).includes("UPDATE workspace_plugins") &&
+        (c[0] as string).includes("'reconnect_needed'"),
+    );
+    expect(markUpdate).toBeUndefined();
+  });
+
+  it("on HTTP 400 with an unknown error code (e.g. invalid_request): throws plain Error, does NOT mark reconnect_needed", async () => {
+    // PERMANENT_REFRESH_FAILURE_CODES is intentionally narrow. An
+    // unknown 400 shouldn't strand every workspace on the assumption
+    // that the upstream contract changed silently.
+    mockReadCredentialBundle.mockResolvedValueOnce(STORED_BUNDLE);
+    mockFetch.mockImplementationOnce(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({ error: "invalid_request", error_description: "bad" }),
+          { status: 400 },
+        ),
+      ),
+    );
+
+    await expect(refreshMod.refreshJiraToken(JIRA_ARGS)).rejects.toThrow(/HTTP 400/);
+
+    const markUpdate = mockInternalQuery.mock.calls.find(
+      (c) =>
+        (c[0] as string).includes("UPDATE workspace_plugins") &&
+        (c[0] as string).includes("'reconnect_needed'"),
+    );
+    expect(markUpdate).toBeUndefined();
+  });
+});

--- a/packages/api/src/lib/integrations/install/jira-oauth-handler.ts
+++ b/packages/api/src/lib/integrations/install/jira-oauth-handler.ts
@@ -146,6 +146,36 @@ interface AccessibleResource {
   readonly scopes?: readonly string[];
 }
 
+/**
+ * Hard timeout on the install-time Atlassian round-trips. A hung
+ * endpoint would otherwise stall the OAuth callback request
+ * indefinitely (the install caller is a synchronous HTTP handler).
+ * 15s is generous for both `oauth/token` (typically <1s) and
+ * `accessible-resources` (typically <500ms).
+ */
+const INSTALL_FETCH_TIMEOUT_MS = 15_000;
+
+/**
+ * Fetch with an AbortController-based timeout. Returns the Response on
+ * success; the AbortError surface bubbles up so the caller's existing
+ * `catch` block can wrap it as a `PlatformOAuthExchangeError`. We
+ * don't catch+wrap here so the original `err.message` survives the
+ * upstreamError forensics.
+ */
+async function fetchWithTimeout(
+  url: string,
+  init: RequestInit,
+  timeoutMs: number,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Token exchange — extracted so the refresh-token flow can reuse it
 // ---------------------------------------------------------------------------
@@ -172,29 +202,39 @@ export async function exchangeAuthCodeForTokens(
 ): Promise<JiraTokenSuccess> {
   let resp: Response;
   try {
-    resp = await fetch(TOKEN_URL, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        grant_type: "authorization_code",
-        client_id: args.clientId,
-        client_secret: args.clientSecret,
-        code: args.code,
-        redirect_uri: args.redirectUri,
-      }),
-    });
+    resp = await fetchWithTimeout(
+      TOKEN_URL,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          grant_type: "authorization_code",
+          client_id: args.clientId,
+          client_secret: args.clientSecret,
+          code: args.code,
+          redirect_uri: args.redirectUri,
+        }),
+      },
+      INSTALL_FETCH_TIMEOUT_MS,
+    );
   } catch (err) {
+    const isAbort = err instanceof Error && err.name === "AbortError";
     log.warn(
       {
         err: err instanceof Error ? err.message : String(err),
         stack: err instanceof Error ? err.stack : undefined,
+        timedOut: isAbort,
       },
-      "Atlassian token endpoint unreachable — surfacing PlatformOAuthExchangeError",
+      isAbort
+        ? "Atlassian token endpoint timed out — surfacing PlatformOAuthExchangeError"
+        : "Atlassian token endpoint unreachable — surfacing PlatformOAuthExchangeError",
     );
     throw new PlatformOAuthExchangeError({
-      message: "Failed to reach Atlassian token endpoint. Restart the install.",
+      message: isAbort
+        ? "Atlassian token endpoint timed out. Restart the install."
+        : "Failed to reach Atlassian token endpoint. Restart the install.",
       platform: JIRA_SLUG,
-      upstreamError: err instanceof Error ? err.message : String(err),
+      upstreamError: isAbort ? "timeout" : err instanceof Error ? err.message : String(err),
     });
   }
 
@@ -244,24 +284,34 @@ export async function fetchAccessibleResources(
 ): Promise<readonly AccessibleResource[]> {
   let resp: Response;
   try {
-    resp = await fetch(ACCESSIBLE_RESOURCES_URL, {
-      method: "GET",
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-        Accept: "application/json",
+    resp = await fetchWithTimeout(
+      ACCESSIBLE_RESOURCES_URL,
+      {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          Accept: "application/json",
+        },
       },
-    });
+      INSTALL_FETCH_TIMEOUT_MS,
+    );
   } catch (err) {
+    const isAbort = err instanceof Error && err.name === "AbortError";
     log.warn(
       {
         err: err instanceof Error ? err.message : String(err),
+        timedOut: isAbort,
       },
-      "Atlassian accessible-resources endpoint unreachable",
+      isAbort
+        ? "Atlassian accessible-resources endpoint timed out"
+        : "Atlassian accessible-resources endpoint unreachable",
     );
     throw new PlatformOAuthExchangeError({
-      message: "Failed to reach Atlassian accessible-resources endpoint. Restart the install.",
+      message: isAbort
+        ? "Atlassian accessible-resources endpoint timed out. Restart the install."
+        : "Failed to reach Atlassian accessible-resources endpoint. Restart the install.",
       platform: JIRA_SLUG,
-      upstreamError: err instanceof Error ? err.message : String(err),
+      upstreamError: isAbort ? "timeout" : err instanceof Error ? err.message : String(err),
     });
   }
 
@@ -355,8 +405,40 @@ export class JiraOAuthInstallHandler implements OAuthPlatformInstallHandler {
     // Atlassian doesn't return the cloudid in the token response — it
     // comes from a separate accessible-resources call. We pick `[0]`
     // per the #2659 one-Atlas-Workspace = one-Atlassian-Cloud rule.
+    // `fetchAccessibleResources` throws on empty, so destructuring +
+    // explicit null guard sidesteps the non-null assertion (per
+    // CLAUDE.md "minimize non-null assertions").
     const resources = await fetchAccessibleResources(tokens.access_token);
-    const primaryResource = resources[0]!;
+    const [primaryResource, ...otherResources] = resources;
+    if (!primaryResource) {
+      // Defensive — `fetchAccessibleResources` already rejects empty
+      // arrays, but TS narrows the destructure to `T | undefined` so
+      // we exhaustively handle it. Treating an empty array post-throw
+      // as a fresh PlatformOAuthExchangeError keeps the user-facing
+      // copy consistent with the upstream-empty branch.
+      throw new PlatformOAuthExchangeError({
+        message: "Atlassian returned no accessible Clouds for this OAuth grant. Install Atlas's app into a Jira Cloud workspace and restart.",
+        platform: JIRA_SLUG,
+        upstreamError: "no_accessible_resources_post_fetch",
+      });
+    }
+    if (otherResources.length > 0) {
+      // The #2659 rule binds one Atlas Workspace to one Atlassian
+      // Cloud — but the OAuth grant may cover several. Log the picked
+      // vs available so an operator dogfooding multi-Cloud setups can
+      // see WHICH Cloud got bound without decrypting the credential
+      // row or grepping the audit log. Future multi-Cloud semantics
+      // would surface a picker between the OAuth callback and the
+      // install write.
+      log.info(
+        {
+          workspaceId,
+          picked: { id: primaryResource.id, url: primaryResource.url },
+          alsoAvailable: otherResources.map((r) => ({ id: r.id, url: r.url })),
+        },
+        "Atlassian OAuth grant covers multiple Clouds — bound to the first per one-Workspace = one-Cloud rule",
+      );
+    }
     const cloudid = primaryResource.id;
 
     const scopes = tokens.scope ?? JIRA_SCOPES;

--- a/packages/api/src/lib/integrations/install/jira-oauth-handler.ts
+++ b/packages/api/src/lib/integrations/install/jira-oauth-handler.ts
@@ -1,0 +1,476 @@
+/**
+ * `JiraOAuthInstallHandler` — second lazy OAuth integration (#2659).
+ *
+ * Mirrors {@link SalesforceOAuthInstallHandler}; the structural
+ * differences with Atlassian's OAuth 2.0 3LO flow are:
+ *
+ *   1. **Two authorize hosts.** Authorize / token live at
+ *      `https://auth.atlassian.com/{authorize,oauth/token}` regardless
+ *      of which Atlassian Cloud the customer eventually picks — there
+ *      is no per-tenant `loginUrl` to honour at start-install time.
+ *   2. **`cloudid` discovery is a second hop.** After token exchange,
+ *      the handler calls `GET https://api.atlassian.com/oauth/token/
+ *      accessible-resources` with the bearer token to learn which
+ *      Atlassian Cloud the user just connected. The first resource's
+ *      `id` is persisted on `workspace_plugins.config.cloudid`. Per the
+ *      #2659 issue body, one Atlas Workspace = one Atlassian Cloud, so
+ *      we take `[0]` rather than offering a picker. Future multi-cloud
+ *      semantics would surface a UI choice between install and persist.
+ *   3. **`audience=api.atlassian.com` query param on `/authorize`.**
+ *      Required by Atlassian 3LO; without it the dance redirects back
+ *      with `invalid_request`.
+ *   4. **Refresh-token rotation on every refresh.** Atlassian *rotates*
+ *      refresh tokens (Salesforce sometimes returns one, sometimes
+ *      not). The refresh flow in {@link ./jira-token-refresh.ts} writes
+ *      the new `refresh_token` back to `integration_credentials` on
+ *      every successful refresh; failing to do so wedges the install
+ *      on the next refresh.
+ *
+ * Atomicity per ADR-0003 (two-store install metadata + credentials):
+ *
+ *   1. `workspace_plugins` row INSERT — install metadata (catalog
+ *      binding + `cloudid` + scopes + status). Failure aborts.
+ *   2. `integration_credentials` row INSERT/UPDATE — credentials.
+ *      Failure here returns the install record with
+ *      `credentialResult.written: false`, flips
+ *      `workspace_plugins.config.status` to `"reconnect_needed"`, and
+ *      the OAuth callback redirects to
+ *      `/admin/integrations?reconnect=jira`. Re-running the dance
+ *      retries step 2 (step 1 is an upsert under the unique index) and
+ *      clears the status back to `"ok"` on success.
+ *
+ *   No roll-back of step 1 on step 2 failure — see ADR-0003.
+ *
+ * @see ../oauth-state-token.ts — state mint/verify primitives
+ * @see ../credentials/store.ts — generic integration_credentials store
+ * @see ./jira-token-refresh.ts — refresh-token rotation + reconnect surface
+ * @see ./salesforce-oauth-handler.ts — first reference implementation (#2658)
+ * @see docs/adr/0003-two-store-chat-install-metadata-credentials.md
+ * @see docs/adr/0005-integration-credentials-table.md
+ */
+
+import crypto from "crypto";
+import { createLogger } from "@atlas/api/lib/logger";
+import { internalQuery } from "@atlas/api/lib/db/internal";
+import { PlatformOAuthExchangeError } from "@atlas/api/lib/effect/errors";
+import { saveCredentialBundle } from "@atlas/api/lib/integrations/credentials/store";
+import type { CredentialBundle } from "@atlas/api/lib/integrations/credentials/store";
+import type { WorkspaceId } from "@useatlas/types";
+import {
+  mintOAuthStateToken,
+  verifyOAuthStateToken,
+} from "./oauth-state-token";
+import type {
+  CatalogId,
+  CredentialResult,
+  InstallRecord,
+  OAuthPlatformInstallHandler,
+} from "./types";
+
+const log = createLogger("integrations.install.jira");
+
+/** Catalog row id seeded by `catalog-seeder.ts::upsertEntry` as `catalog:${slug}`. */
+export const JIRA_CATALOG_ID = "catalog:jira";
+
+/** Catalog slug — the dispatch key, value bound into the state token. */
+export const JIRA_SLUG: CatalogId = "jira";
+
+/**
+ * Atlassian OAuth 2.0 (3LO) endpoints. Hard-coded (no operator
+ * override) because — unlike Salesforce — Atlassian doesn't expose a
+ * sandbox login host; staging instances all go through the same
+ * `auth.atlassian.com` front door.
+ */
+const AUTHORIZE_URL = "https://auth.atlassian.com/authorize";
+const TOKEN_URL = "https://auth.atlassian.com/oauth/token";
+const ACCESSIBLE_RESOURCES_URL =
+  "https://api.atlassian.com/oauth/token/accessible-resources";
+
+/**
+ * Scopes requested at install time:
+ *   - `read:jira-work`    — query issues + boards via JQL search.
+ *   - `read:jira-user`    — resolve assignees / reporters to user
+ *                           display names in result rows.
+ *   - `offline_access`    — receive + rotate a `refresh_token`. Without
+ *                           this Atlassian doesn't issue a refresh
+ *                           token and the install would die after the
+ *                           first access-token expiry.
+ *
+ * If the operator's App is configured with a tighter scope set,
+ * Atlassian rejects the install dance with `invalid_scope`; the admin
+ * sees the effective scope list in `workspace_plugins.config.scopes`.
+ */
+const JIRA_SCOPES = "read:jira-work read:jira-user offline_access";
+
+/**
+ * Operator-side Jira OAuth App config. Read once from env in
+ * `register.ts` and passed in.
+ */
+export interface JiraOAuthHandlerConfig {
+  readonly clientId: string;
+  readonly clientSecret: string;
+  /**
+   * Public-facing OAuth callback URL — must match a Callback URL
+   * configured on the operator's Atlassian OAuth 2.0 (3LO) integration.
+   */
+  readonly redirectUri: string;
+}
+
+// ---------------------------------------------------------------------------
+// Atlassian token-response shape (subset we consume)
+// ---------------------------------------------------------------------------
+
+interface JiraTokenSuccess {
+  readonly access_token: string;
+  readonly refresh_token?: string;
+  readonly expires_in?: number;
+  readonly token_type?: string;
+  readonly scope?: string;
+}
+
+interface JiraTokenFailure {
+  readonly error: string;
+  readonly error_description?: string;
+}
+
+type JiraTokenResponse = JiraTokenSuccess | JiraTokenFailure;
+
+function isTokenSuccess(response: JiraTokenResponse): response is JiraTokenSuccess {
+  return "access_token" in response && typeof response.access_token === "string";
+}
+
+interface AccessibleResource {
+  readonly id: string;
+  readonly url?: string;
+  readonly name?: string;
+  readonly scopes?: readonly string[];
+}
+
+// ---------------------------------------------------------------------------
+// Token exchange — extracted so the refresh-token flow can reuse it
+// ---------------------------------------------------------------------------
+
+interface TokenExchangeArgs {
+  readonly clientId: string;
+  readonly clientSecret: string;
+  readonly redirectUri: string;
+  readonly code: string;
+}
+
+/**
+ * POST `auth.atlassian.com/oauth/token` with the auth code. Returns the
+ * parsed JSON shape on success; throws `PlatformOAuthExchangeError` on
+ * any non-2xx, network failure, or structurally invalid response.
+ *
+ * Atlassian's token endpoint takes a JSON body (not form-encoded like
+ * Salesforce's). The `grant_type: authorization_code` shape is
+ * documented at
+ * https://developer.atlassian.com/cloud/jira/platform/oauth-2-3lo-apps/.
+ */
+export async function exchangeAuthCodeForTokens(
+  args: TokenExchangeArgs,
+): Promise<JiraTokenSuccess> {
+  let resp: Response;
+  try {
+    resp = await fetch(TOKEN_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        grant_type: "authorization_code",
+        client_id: args.clientId,
+        client_secret: args.clientSecret,
+        code: args.code,
+        redirect_uri: args.redirectUri,
+      }),
+    });
+  } catch (err) {
+    log.warn(
+      {
+        err: err instanceof Error ? err.message : String(err),
+        stack: err instanceof Error ? err.stack : undefined,
+      },
+      "Atlassian token endpoint unreachable — surfacing PlatformOAuthExchangeError",
+    );
+    throw new PlatformOAuthExchangeError({
+      message: "Failed to reach Atlassian token endpoint. Restart the install.",
+      platform: JIRA_SLUG,
+      upstreamError: err instanceof Error ? err.message : String(err),
+    });
+  }
+
+  let parsed: JiraTokenResponse;
+  try {
+    parsed = (await resp.json()) as JiraTokenResponse;
+  } catch (err) {
+    log.warn(
+      {
+        status: resp.status,
+        err: err instanceof Error ? err.message : String(err),
+      },
+      "Atlassian token response body could not be parsed as JSON",
+    );
+    throw new PlatformOAuthExchangeError({
+      message: "Atlassian returned an unparseable token response. Restart the install.",
+      platform: JIRA_SLUG,
+      upstreamError: `non-json ${resp.status}`,
+    });
+  }
+
+  if (!resp.ok || !isTokenSuccess(parsed)) {
+    const failure = parsed as JiraTokenFailure;
+    throw new PlatformOAuthExchangeError({
+      message: "Atlassian rejected the OAuth code. Restart the install from your Jira admin.",
+      platform: JIRA_SLUG,
+      upstreamError: failure.error ?? `http_${resp.status}`,
+    });
+  }
+
+  return parsed;
+}
+
+/**
+ * Fetch the list of Atlassian Clouds the user just connected to. The
+ * first entry's `id` is the `cloudid` we persist (per the #2659 "one
+ * Atlas Workspace = one Atlassian Cloud" rule). Returns the full list
+ * so the caller can log scope + url for diagnostics.
+ *
+ * Throws `PlatformOAuthExchangeError` when Atlassian returns an empty
+ * list (the OAuth dance technically succeeded but the user has no
+ * Atlassian Clouds the App can reach — installing this credential
+ * would orphan it).
+ */
+export async function fetchAccessibleResources(
+  accessToken: string,
+): Promise<readonly AccessibleResource[]> {
+  let resp: Response;
+  try {
+    resp = await fetch(ACCESSIBLE_RESOURCES_URL, {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        Accept: "application/json",
+      },
+    });
+  } catch (err) {
+    log.warn(
+      {
+        err: err instanceof Error ? err.message : String(err),
+      },
+      "Atlassian accessible-resources endpoint unreachable",
+    );
+    throw new PlatformOAuthExchangeError({
+      message: "Failed to reach Atlassian accessible-resources endpoint. Restart the install.",
+      platform: JIRA_SLUG,
+      upstreamError: err instanceof Error ? err.message : String(err),
+    });
+  }
+
+  if (!resp.ok) {
+    throw new PlatformOAuthExchangeError({
+      message: "Atlassian rejected the accessible-resources request. Restart the install.",
+      platform: JIRA_SLUG,
+      upstreamError: `accessible_resources_http_${resp.status}`,
+    });
+  }
+
+  let resources: readonly AccessibleResource[];
+  try {
+    resources = (await resp.json()) as readonly AccessibleResource[];
+  } catch (err) {
+    throw new PlatformOAuthExchangeError({
+      message: "Atlassian accessible-resources returned an unparseable response. Restart the install.",
+      platform: JIRA_SLUG,
+      upstreamError: err instanceof Error ? err.message : String(err),
+    });
+  }
+
+  if (!Array.isArray(resources) || resources.length === 0) {
+    throw new PlatformOAuthExchangeError({
+      message: "Atlassian returned no accessible Clouds for this OAuth grant. Install Atlas's app into a Jira Cloud workspace and restart.",
+      platform: JIRA_SLUG,
+      upstreamError: "no_accessible_resources",
+    });
+  }
+
+  return resources;
+}
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+export class JiraOAuthInstallHandler implements OAuthPlatformInstallHandler {
+  readonly kind = "oauth" as const;
+
+  constructor(private readonly config: JiraOAuthHandlerConfig) {}
+
+  async startInstall(workspaceId: WorkspaceId): Promise<{
+    readonly redirectUrl: string;
+    readonly stateToken: string;
+  }> {
+    const stateToken = mintOAuthStateToken(workspaceId, JIRA_SLUG);
+    const url = new URL(AUTHORIZE_URL);
+    // `audience=api.atlassian.com` is required by Atlassian 3LO — without
+    // it the authorize endpoint redirects back with `invalid_request`.
+    url.searchParams.set("audience", "api.atlassian.com");
+    url.searchParams.set("client_id", this.config.clientId);
+    url.searchParams.set("scope", JIRA_SCOPES);
+    url.searchParams.set("redirect_uri", this.config.redirectUri);
+    url.searchParams.set("state", stateToken);
+    url.searchParams.set("response_type", "code");
+    url.searchParams.set("prompt", "consent");
+    return { redirectUrl: url.toString(), stateToken };
+  }
+
+  async handleCallback(
+    code: string,
+    stateToken: string,
+  ): Promise<{
+    readonly workspaceId: WorkspaceId;
+    readonly catalogId: CatalogId;
+    readonly installRecord: InstallRecord;
+    readonly credentialResult: CredentialResult;
+  } | null> {
+    // ── 1. Verify state — null on every failure mode ─────────────
+    const verified = verifyOAuthStateToken(stateToken);
+    if (!verified) return null;
+    const workspaceId = verified.workspaceId as WorkspaceId;
+    if (verified.catalogId !== JIRA_SLUG) {
+      log.warn(
+        { expected: JIRA_SLUG, got: verified.catalogId },
+        "Jira OAuth callback received state bound to a different catalog — rejecting",
+      );
+      return null;
+    }
+
+    // ── 2. Exchange code for tokens ───────────────────────────────
+    const tokens = await exchangeAuthCodeForTokens({
+      clientId: this.config.clientId,
+      clientSecret: this.config.clientSecret,
+      redirectUri: this.config.redirectUri,
+      code,
+    });
+
+    // ── 3. Discover cloudid ───────────────────────────────────────
+    // Atlassian doesn't return the cloudid in the token response — it
+    // comes from a separate accessible-resources call. We pick `[0]`
+    // per the #2659 one-Atlas-Workspace = one-Atlassian-Cloud rule.
+    const resources = await fetchAccessibleResources(tokens.access_token);
+    const primaryResource = resources[0]!;
+    const cloudid = primaryResource.id;
+
+    const scopes = tokens.scope ?? JIRA_SCOPES;
+    const tokenType = tokens.token_type ?? "Bearer";
+    // Atlassian returns `expires_in` (seconds). Compute the absolute
+    // expiry ms so the credential store doesn't need to remember when
+    // it was issued.
+    const expiresAt =
+      typeof tokens.expires_in === "number" && Number.isFinite(tokens.expires_in)
+        ? Date.now() + tokens.expires_in * 1000
+        : null;
+
+    // ── 4. Install record — workspace_plugins INSERT (first store) ──
+    // `cloudid` lives operator-visible alongside `status` so the admin
+    // UI / lazy-builder can read it without decrypting the credential
+    // bundle. `status: "ok"` is the default; refresh flow flips to
+    // `"reconnect_needed"` on permanent failure.
+    const installId = crypto.randomUUID();
+    const installConfig: Record<string, unknown> = {
+      cloudid,
+      scopes,
+      status: "ok",
+      ...(primaryResource.url ? { site_url: primaryResource.url } : {}),
+      ...(primaryResource.name ? { site_name: primaryResource.name } : {}),
+    };
+    try {
+      await internalQuery(
+        `INSERT INTO workspace_plugins (id, workspace_id, catalog_id, config, enabled, installed_at)
+         VALUES ($1, $2, $3, $4::jsonb, true, NOW())
+         ON CONFLICT (workspace_id, catalog_id) DO UPDATE
+           SET config = EXCLUDED.config,
+               enabled = true`,
+        [installId, workspaceId, JIRA_CATALOG_ID, JSON.stringify(installConfig)],
+      );
+    } catch (err) {
+      log.error(
+        {
+          workspaceId,
+          cloudid,
+          err: err instanceof Error ? err.message : String(err),
+        },
+        "Failed to write workspace_plugins install record — aborting Jira install",
+      );
+      throw err;
+    }
+
+    const installRecord: InstallRecord = {
+      id: installId,
+      workspaceId,
+      catalogId: JIRA_SLUG,
+    };
+
+    // ── 5. Credential — integration_credentials INSERT (second store) ──
+    // `instanceUrl` carries the per-cloud API host (`api.atlassian.com/
+    // ex/jira/<cloudid>`) so the lazy-builder can construct API URLs
+    // without re-reading the install config. Per CredentialBundle's
+    // shape, `instanceUrl` is the canonical cross-platform "where do I
+    // call?" field.
+    const bundle: CredentialBundle = {
+      accessToken: tokens.access_token,
+      refreshToken: tokens.refresh_token ?? null,
+      expiresAt,
+      tokenType,
+      scope: scopes,
+      instanceUrl: `https://api.atlassian.com/ex/jira/${cloudid}`,
+    };
+
+    try {
+      await saveCredentialBundle(workspaceId, JIRA_CATALOG_ID, bundle);
+      log.info(
+        { workspaceId, cloudid, siteUrl: primaryResource.url },
+        "Jira install completed (both stores written)",
+      );
+      return {
+        workspaceId,
+        catalogId: JIRA_SLUG,
+        installRecord,
+        credentialResult: { written: true },
+      };
+    } catch (err) {
+      const errMessage = err instanceof Error ? err.message : String(err);
+      log.warn(
+        { workspaceId, cloudid, err: errMessage },
+        "Jira install record written but integration_credentials write failed — Reconnect required",
+      );
+      // Mirror Salesforce: flip `status: "reconnect_needed"` so the
+      // admin card surfaces a persistent Reconnect CTA. Without this,
+      // the OAuth callback's `?reconnect=jira` query param shows once
+      // and then disappears on the next admin-page reload.
+      try {
+        await internalQuery(
+          `UPDATE workspace_plugins
+              SET config = config || jsonb_build_object('status', 'reconnect_needed')
+            WHERE workspace_id = $1 AND catalog_id = $2`,
+          [workspaceId, JIRA_CATALOG_ID],
+        );
+      } catch (statusErr) {
+        log.warn(
+          {
+            workspaceId,
+            err: statusErr instanceof Error ? statusErr.message : String(statusErr),
+          },
+          "Failed to mark Jira install as reconnect_needed after credential write failure",
+        );
+      }
+      return {
+        workspaceId,
+        catalogId: JIRA_SLUG,
+        installRecord,
+        credentialResult: {
+          written: false,
+          reason: "Credential persist failed — admin should retry via Reconnect",
+        },
+      };
+    }
+  }
+}

--- a/packages/api/src/lib/integrations/install/jira-token-refresh.ts
+++ b/packages/api/src/lib/integrations/install/jira-token-refresh.ts
@@ -1,0 +1,277 @@
+/**
+ * Jira access-token refresh (#2659).
+ *
+ * Mirrors {@link ./salesforce-token-refresh.ts}; Atlassian-specific
+ * twists:
+ *
+ *   - **Refresh tokens rotate on every refresh.** Atlassian returns a
+ *     fresh `refresh_token` in the success response and the previous
+ *     value MUST NOT be reused; persisting the new value back to
+ *     `integration_credentials` is non-optional, not opportunistic
+ *     (Salesforce sometimes returns one, sometimes not — we kept the
+ *     old value when omitted).
+ *   - **Permanent failures classify the same way.** Atlassian returns
+ *     `invalid_grant` when the stored refresh token is rejected; we
+ *     flip `workspace_plugins.config.status` to `"reconnect_needed"`
+ *     and surface `JiraReconnectRequiredError`.
+ *   - **Operator-side misconfig stays transient.** `invalid_client` is
+ *     wrong env (`JIRA_CLIENT_ID` / `JIRA_CLIENT_SECRET` typo); marking
+ *     the workspace `reconnect_needed` would force every tenant admin
+ *     to re-run OAuth after the operator fixes the env. Treated as
+ *     transient like Salesforce.
+ *
+ * @see ./jira-oauth-handler.ts — the initial OAuth dance
+ * @see ./salesforce-token-refresh.ts — first reference implementation
+ * @see ../credentials/store.ts — the credential bundle store
+ */
+
+import { createLogger } from "@atlas/api/lib/logger";
+import { internalQuery } from "@atlas/api/lib/db/internal";
+import {
+  readCredentialBundle,
+  saveCredentialBundle,
+  type CredentialBundle,
+} from "@atlas/api/lib/integrations/credentials/store";
+import { JiraReconnectRequiredError } from "@atlas/api/lib/effect/errors";
+import { JIRA_CATALOG_ID, JIRA_SLUG } from "./jira-oauth-handler";
+
+// Re-export so the lazy-builder + future callers can pull from this
+// module. Canonical definition lives in `effect/errors.ts` so the error
+// participates in the `AtlasError` union + `mapTaggedError` exhaustive
+// switch (409 Conflict + `conflict` wire code).
+export { JiraReconnectRequiredError };
+
+const log = createLogger("integrations.install.jira-refresh");
+
+const TOKEN_URL = "https://auth.atlassian.com/oauth/token";
+
+/**
+ * Atlassian error codes that prove the install will never recover
+ * without a fresh OAuth dance. `invalid_grant` is the canonical
+ * "refresh token rejected" code from RFC 6749. Kept narrow on purpose
+ * — an unknown error code surfaces as transient so we don't mis-classify
+ * the install as "reconnect needed" without evidence.
+ */
+const PERMANENT_REFRESH_FAILURE_CODES = new Set([
+  "invalid_grant",
+  "unauthorized_client",
+  "access_denied",
+]);
+
+interface JiraRefreshSuccess {
+  readonly access_token: string;
+  readonly refresh_token: string;
+  readonly expires_in?: number;
+  readonly token_type?: string;
+  readonly scope?: string;
+}
+
+interface JiraRefreshFailure {
+  readonly error: string;
+  readonly error_description?: string;
+}
+
+type JiraRefreshResponse = JiraRefreshSuccess | JiraRefreshFailure;
+
+function isRefreshSuccess(r: JiraRefreshResponse): r is JiraRefreshSuccess {
+  return (
+    "access_token" in r &&
+    typeof r.access_token === "string" &&
+    "refresh_token" in r &&
+    typeof r.refresh_token === "string"
+  );
+}
+
+interface RefreshArgs {
+  readonly clientId: string;
+  readonly clientSecret: string;
+  readonly refreshToken: string;
+}
+
+/**
+ * POST `auth.atlassian.com/oauth/token` with `grant_type=refresh_token`.
+ * On HTTP 4xx carrying one of the {@link PERMANENT_REFRESH_FAILURE_CODES},
+ * throws `JiraReconnectRequiredError`. On anything else (network failure,
+ * 5xx, unknown 4xx), throws a plain `Error` so the caller treats it as
+ * transient.
+ */
+async function exchangeRefreshToken(
+  args: RefreshArgs,
+  workspaceId: string,
+): Promise<JiraRefreshSuccess> {
+  let resp: Response;
+  try {
+    resp = await fetch(TOKEN_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        grant_type: "refresh_token",
+        client_id: args.clientId,
+        client_secret: args.clientSecret,
+        refresh_token: args.refreshToken,
+      }),
+    });
+  } catch (err) {
+    // Network failure — transient. Let the caller retry on the next
+    // tool call. Don't flip reconnect_needed without evidence.
+    throw new Error(
+      `Atlassian token endpoint unreachable: ${err instanceof Error ? err.message : String(err)}`,
+      { cause: err },
+    );
+  }
+
+  let parsed: JiraRefreshResponse;
+  try {
+    parsed = (await resp.json()) as JiraRefreshResponse;
+  } catch (err) {
+    throw new Error(
+      `Atlassian refresh returned unparseable body (HTTP ${resp.status})`,
+      { cause: err },
+    );
+  }
+
+  if (!resp.ok || !isRefreshSuccess(parsed)) {
+    const failure = parsed as JiraRefreshFailure;
+    const errorCode = failure.error ?? `http_${resp.status}`;
+    if (resp.status >= 400 && resp.status < 500 && PERMANENT_REFRESH_FAILURE_CODES.has(errorCode)) {
+      log.warn(
+        { workspaceId, errorCode, description: failure.error_description },
+        "Jira refresh failed permanently — flagging reconnect_needed",
+      );
+      throw new JiraReconnectRequiredError({
+        message: "Jira install needs to be reconnected — refresh token rejected by Atlassian.",
+        workspaceId,
+        upstreamError: errorCode,
+      });
+    }
+    // Unknown error code or 5xx — treat as transient.
+    throw new Error(`Jira refresh failed: ${errorCode} (HTTP ${resp.status})`);
+  }
+
+  return parsed;
+}
+
+/**
+ * Mark the install row as `reconnect_needed`. JSONB merge so unrelated
+ * config fields (cloudid, scopes, etc.) survive.
+ */
+async function markReconnectNeeded(workspaceId: string): Promise<void> {
+  try {
+    await internalQuery(
+      `UPDATE workspace_plugins
+          SET config = config || jsonb_build_object('status', 'reconnect_needed')
+        WHERE workspace_id = $1 AND catalog_id = $2`,
+      [workspaceId, JIRA_CATALOG_ID],
+    );
+  } catch (err) {
+    log.warn(
+      { workspaceId, err: err instanceof Error ? err.message : String(err) },
+      "Failed to mark Jira install as reconnect_needed (install row may have been disconnected)",
+    );
+  }
+}
+
+/**
+ * Clear the `reconnect_needed` marker on a successful refresh. Idempotent.
+ */
+async function clearReconnectNeeded(workspaceId: string): Promise<void> {
+  try {
+    await internalQuery(
+      `UPDATE workspace_plugins
+          SET config = config || jsonb_build_object('status', 'ok')
+        WHERE workspace_id = $1 AND catalog_id = $2`,
+      [workspaceId, JIRA_CATALOG_ID],
+    );
+  } catch (err) {
+    log.warn(
+      { workspaceId, err: err instanceof Error ? err.message : String(err) },
+      "Failed to clear reconnect_needed flag after successful Jira refresh",
+    );
+  }
+}
+
+export interface RefreshJiraTokenArgs {
+  readonly workspaceId: string;
+  readonly clientId: string;
+  readonly clientSecret: string;
+}
+
+/**
+ * Refresh the Jira access token for `workspaceId`. Returns the updated
+ * `CredentialBundle` (also persisted to `integration_credentials` with
+ * the rotated refresh_token). On permanent failure throws
+ * `JiraReconnectRequiredError` and flips
+ * `workspace_plugins.config.status` to `"reconnect_needed"`.
+ */
+export async function refreshJiraToken(
+  args: RefreshJiraTokenArgs,
+): Promise<CredentialBundle> {
+  const bundle = await readCredentialBundle(args.workspaceId, JIRA_CATALOG_ID);
+  if (!bundle) {
+    throw new Error(
+      `No Jira credentials found for workspace ${args.workspaceId} — install was disconnected`,
+    );
+  }
+  if (!bundle.refreshToken) {
+    log.warn(
+      { workspaceId: args.workspaceId },
+      "Jira credential bundle has no refresh_token — flagging reconnect_needed",
+    );
+    await markReconnectNeeded(args.workspaceId);
+    throw new JiraReconnectRequiredError({
+      message: "Jira install has no refresh token — App must grant the offline_access scope.",
+      workspaceId: args.workspaceId,
+      upstreamError: "no_refresh_token",
+    });
+  }
+
+  let refreshed: JiraRefreshSuccess;
+  try {
+    refreshed = await exchangeRefreshToken(
+      {
+        clientId: args.clientId,
+        clientSecret: args.clientSecret,
+        refreshToken: bundle.refreshToken,
+      },
+      args.workspaceId,
+    );
+  } catch (err) {
+    if (err instanceof JiraReconnectRequiredError) {
+      await markReconnectNeeded(args.workspaceId);
+    }
+    throw err;
+  }
+
+  // Atlassian rotates the refresh token on every refresh — `refresh_token`
+  // is required in the success response. The `isRefreshSuccess` guard
+  // already asserted both fields are present, so we don't fall back to
+  // the old value the way Salesforce does.
+  const expiresAt =
+    typeof refreshed.expires_in === "number" && Number.isFinite(refreshed.expires_in)
+      ? Date.now() + refreshed.expires_in * 1000
+      : null;
+
+  const next: CredentialBundle = {
+    accessToken: refreshed.access_token,
+    refreshToken: refreshed.refresh_token,
+    expiresAt,
+    tokenType: refreshed.token_type ?? bundle.tokenType,
+    scope: refreshed.scope ?? bundle.scope,
+    instanceUrl: bundle.instanceUrl,
+    ...(bundle.extra ? { extra: bundle.extra } : {}),
+  };
+
+  await saveCredentialBundle(args.workspaceId, JIRA_CATALOG_ID, next);
+  // Independent UPDATE so a failure to clear the flag doesn't roll back
+  // a successful refresh.
+  await clearReconnectNeeded(args.workspaceId);
+
+  log.info(
+    { workspaceId: args.workspaceId, instanceUrl: next.instanceUrl },
+    "Jira token refreshed successfully",
+  );
+  return next;
+}
+
+/** Re-export to keep the slug constant in one place for catalog wiring. */
+export { JIRA_SLUG, JIRA_CATALOG_ID };

--- a/packages/api/src/lib/integrations/install/register.ts
+++ b/packages/api/src/lib/integrations/install/register.ts
@@ -23,10 +23,15 @@ import { EmailFormInstallHandler } from "./email-form-handler";
 import { ObsidianFormInstallHandler } from "./obsidian-form-handler";
 import { WebhookFormInstallHandler } from "./webhook-form-handler";
 import {
+  JiraOAuthInstallHandler,
+  JIRA_CATALOG_ID,
+} from "./jira-oauth-handler";
+import {
   SalesforceOAuthInstallHandler,
   SALESFORCE_CATALOG_ID,
 } from "./salesforce-oauth-handler";
 import { lazyPluginLoader } from "@atlas/api/lib/plugins/lazy-loader";
+import { createJiraLazyBuilder } from "@atlas/api/lib/integrations/jira/lazy-builder";
 import { createSalesforceLazyBuilder } from "@atlas/api/lib/integrations/salesforce/lazy-builder";
 
 const log = createLogger("integrations.install.register");
@@ -91,13 +96,14 @@ export function registerBuiltinInstallHandlers(): void {
   // ── Slack OAuth ───────────────────────────────────────────────────
   registerSlackOAuthHandler();
 
-  // ── Salesforce OAuth (#2658) ──────────────────────────────────────
-  // First lazy OAuth integration. Registers both the OAuth install
-  // handler (for the install + callback routes) AND the
-  // LazyPluginLoader builder (for the on-demand per-Workspace plugin
-  // instantiation that the agent loop dispatches into). Env gates the
-  // pair as a unit — without SALESFORCE_CLIENT_ID / SALESFORCE_CLIENT_SECRET
-  // there is no operator-side Connected App to drive either side.
+  // ── Lazy OAuth integrations (alphabetical — #2658 / #2659) ────────
+  // Each registers both the OAuth install handler (for the install +
+  // callback routes) AND the LazyPluginLoader builder (for the
+  // on-demand per-Workspace plugin instantiation the agent loop
+  // dispatches into). Env gates the pair as a unit so a half-wired
+  // operator install doesn't end up with an installable card that
+  // breaks on the first tool call.
+  registerJiraOAuthHandler();
   registerSalesforceOAuthHandler();
 }
 
@@ -128,6 +134,41 @@ function registerSlackOAuthHandler(): void {
     }),
   );
   log.info({ publicApiUrl }, "Registered SlackOAuthInstallHandler");
+}
+
+function registerJiraOAuthHandler(): void {
+  const clientId = process.env.JIRA_CLIENT_ID;
+  const clientSecret = process.env.JIRA_CLIENT_SECRET;
+  const publicApiUrl = resolvePublicApiUrl();
+
+  if (!clientId || !clientSecret) {
+    log.info(
+      "Jira OAuth handler not registered — JIRA_CLIENT_ID / JIRA_CLIENT_SECRET unset. /api/v1/integrations/jira/install will return 501 until configured.",
+    );
+    return;
+  }
+  if (!publicApiUrl) {
+    log.warn(
+      "Jira OAuth handler not registered — ATLAS_PUBLIC_API_URL is unset, so the redirect URI cannot be resolved.",
+    );
+    return;
+  }
+
+  registerOAuthHandler(
+    "jira",
+    new JiraOAuthInstallHandler({
+      clientId,
+      clientSecret,
+      redirectUri: `${publicApiUrl}/api/v1/integrations/jira/callback`,
+    }),
+  );
+  if (!lazyPluginLoader.hasBuilder(JIRA_CATALOG_ID)) {
+    lazyPluginLoader.registerBuilder(
+      JIRA_CATALOG_ID,
+      createJiraLazyBuilder({ clientId, clientSecret }),
+    );
+  }
+  log.info({ publicApiUrl }, "Registered JiraOAuthInstallHandler + LazyPluginLoader builder");
 }
 
 function registerSalesforceOAuthHandler(): void {

--- a/packages/api/src/lib/integrations/jira/__tests__/lazy-builder.test.ts
+++ b/packages/api/src/lib/integrations/jira/__tests__/lazy-builder.test.ts
@@ -1,0 +1,363 @@
+/**
+ * Tests for the Jira LazyPluginLoader builder (#2659).
+ *
+ * Coverage mirrors `../salesforce/__tests__/lazy-builder.test.ts`;
+ * Jira-specific surface:
+ *   - Cloud-aware base URL: the builder routes JQL searches to
+ *     `https://api.atlassian.com/ex/jira/<cloudid>/rest/api/3/search`,
+ *     not a per-tenant `instance_url` like Salesforce.
+ *   - 401 from the Jira REST API (not `INVALID_SESSION_ID`) is the
+ *     "session expired" signal.
+ *   - On permanent refresh failure → cache eviction wire fires (same
+ *     contract as Salesforce, different error tag).
+ */
+
+import { afterEach, beforeAll, beforeEach, describe, expect, it, mock, type Mock } from "bun:test";
+
+const mockReadCredentialBundle: Mock<(ws: string, cat: string) => Promise<unknown>> = mock(() =>
+  Promise.resolve(null),
+);
+mock.module("@atlas/api/lib/integrations/credentials/store", () => ({
+  readCredentialBundle: mockReadCredentialBundle,
+  saveCredentialBundle: mock(() => Promise.resolve()),
+  deleteCredentialBundle: mock(() => Promise.resolve(false)),
+}));
+
+const mockRefreshJiraToken: Mock<(args: unknown) => Promise<unknown>> = mock(() =>
+  Promise.resolve({
+    accessToken: "refreshed-access-token",
+    refreshToken: "ROTATED-refresh-token",
+    expiresAt: null,
+    tokenType: "Bearer",
+    scope: "read:jira-work read:jira-user offline_access",
+    instanceUrl: "https://api.atlassian.com/ex/jira/CLOUD-1",
+  }),
+);
+
+class TestJiraReconnectRequiredError extends Error {
+  readonly _tag = "JiraReconnectRequiredError" as const;
+  readonly workspaceId: string;
+  readonly upstreamError: string;
+  constructor(args: { workspaceId: string; upstreamError: string }) {
+    super(`reconnect_needed: ${args.upstreamError}`);
+    this.workspaceId = args.workspaceId;
+    this.upstreamError = args.upstreamError;
+  }
+}
+mock.module("@atlas/api/lib/integrations/install/jira-token-refresh", () => ({
+  refreshJiraToken: mockRefreshJiraToken,
+  JiraReconnectRequiredError: TestJiraReconnectRequiredError,
+  JIRA_SLUG: "jira",
+  JIRA_CATALOG_ID: "catalog:jira",
+}));
+
+const mockEvict: Mock<(workspaceId: string, catalogId: string) => Promise<boolean>> = mock(() =>
+  Promise.resolve(true),
+);
+mock.module("@atlas/api/lib/plugins/lazy-loader", () => ({
+  lazyPluginLoader: {
+    evict: mockEvict,
+    hasBuilder: mock(() => false),
+    registerBuilder: mock(() => undefined),
+    unregisterBuilder: mock(() => true),
+    size: mock(() => 0),
+    getOrInstantiate: mock(() => Promise.resolve({} as unknown)),
+  },
+  LazyPluginLoader: class {},
+  LazyPluginBuilderMissingError: class extends Error {},
+  LazyPluginInstallNotFoundError: class extends Error {},
+}));
+
+const ORIGINAL_FETCH = globalThis.fetch;
+const mockFetch: Mock<(input: unknown, init?: unknown) => Promise<Response>> = mock(() =>
+  Promise.resolve(new Response("{}", { status: 200 })),
+);
+
+type BuilderMod = typeof import("../lazy-builder");
+type JiraPluginInstance = import("../lazy-builder").JiraPluginInstance;
+let builderMod!: BuilderMod;
+
+beforeAll(async () => {
+  builderMod = await import("../lazy-builder");
+});
+
+const WSID = "ws-jira-lazy-test";
+const CATALOG_ID = "catalog:jira";
+const CLOUDID = "CLOUD-1";
+
+const HAPPY_BUNDLE = {
+  accessToken: "access-token-from-bundle",
+  refreshToken: "refresh-token",
+  expiresAt: null,
+  tokenType: "Bearer",
+  scope: "read:jira-work read:jira-user offline_access",
+  instanceUrl: `https://api.atlassian.com/ex/jira/${CLOUDID}`,
+};
+
+const BUILDER_CONFIG = {
+  clientId: "jira-client-id",
+  clientSecret: "jira-client-secret",
+};
+
+beforeEach(() => {
+  mockReadCredentialBundle.mockClear();
+  mockRefreshJiraToken.mockClear();
+  mockEvict.mockClear();
+  mockFetch.mockClear();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  globalThis.fetch = mockFetch as any;
+});
+
+afterEach(() => {
+  globalThis.fetch = ORIGINAL_FETCH;
+});
+
+// ---------------------------------------------------------------------------
+// Happy path
+// ---------------------------------------------------------------------------
+
+describe("createJiraLazyBuilder — happy path", () => {
+  it("reads credentials, posts JQL to the per-cloud REST endpoint, and shapes results into columns/rows", async () => {
+    mockReadCredentialBundle.mockResolvedValueOnce(HAPPY_BUNDLE);
+    mockFetch.mockImplementationOnce(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            issues: [
+              {
+                key: "ATL-1",
+                fields: {
+                  summary: "Bug in login",
+                  status: { name: "In Progress" },
+                  assignee: { displayName: "Alice" },
+                  priority: { name: "High" },
+                  issuetype: { name: "Bug" },
+                  created: "2026-01-01T00:00:00.000Z",
+                  updated: "2026-02-01T00:00:00.000Z",
+                },
+              },
+            ],
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+      ),
+    );
+
+    const build = builderMod.createJiraLazyBuilder(BUILDER_CONFIG);
+    const instance = (await build({
+      workspaceId: WSID,
+      catalogId: CATALOG_ID,
+      config: { cloudid: CLOUDID, status: "ok" },
+    })) as JiraPluginInstance;
+
+    expect(instance.id).toBe(`jira:${WSID}`);
+
+    const result = await instance.queryJira("project = ATL");
+    expect(result.columns).toEqual([
+      "key",
+      "summary",
+      "status",
+      "assignee",
+      "priority",
+      "issuetype",
+      "created",
+      "updated",
+    ]);
+    expect(result.rows).toEqual([
+      {
+        key: "ATL-1",
+        summary: "Bug in login",
+        status: "In Progress",
+        assignee: "Alice",
+        priority: "High",
+        issuetype: "Bug",
+        created: "2026-01-01T00:00:00.000Z",
+        updated: "2026-02-01T00:00:00.000Z",
+      },
+    ]);
+
+    // Critical pin — the request hits the per-cloud REST endpoint, not
+    // a generic api.atlassian.com URL. Without cloudid in the path the
+    // request would 404 (or worse, hit another tenant if Atlassian
+    // ever routed bare /rest/api/3 calls).
+    const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(`https://api.atlassian.com/ex/jira/${CLOUDID}/rest/api/3/search`);
+    expect(init.method).toBe("POST");
+    expect((init.headers as Record<string, string>).Authorization).toBe(
+      "Bearer access-token-from-bundle",
+    );
+  });
+
+  it("reconstructs the base URL from workspace_plugins.config.cloudid when the bundle's instanceUrl is empty (defensive)", async () => {
+    // Defensive — shouldn't happen in practice, but a half-written
+    // bundle from a pre-PR install path would otherwise crash.
+    mockReadCredentialBundle.mockResolvedValueOnce({
+      ...HAPPY_BUNDLE,
+      instanceUrl: "",
+    });
+    mockFetch.mockImplementationOnce(() =>
+      Promise.resolve(new Response(JSON.stringify({ issues: [] }), { status: 200 })),
+    );
+
+    const build = builderMod.createJiraLazyBuilder(BUILDER_CONFIG);
+    const instance = (await build({
+      workspaceId: WSID,
+      catalogId: CATALOG_ID,
+      config: { cloudid: "FALLBACK-CLOUD", status: "ok" },
+    })) as JiraPluginInstance;
+
+    await instance.queryJira("project = ATL");
+    const [url] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("https://api.atlassian.com/ex/jira/FALLBACK-CLOUD/rest/api/3/search");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// reconnect_needed short-circuit
+// ---------------------------------------------------------------------------
+
+describe("createJiraLazyBuilder — reconnect_needed", () => {
+  it("refuses to instantiate when workspace_plugins.config.status is reconnect_needed", async () => {
+    const build = builderMod.createJiraLazyBuilder(BUILDER_CONFIG);
+
+    await expect(
+      build({
+        workspaceId: WSID,
+        catalogId: CATALOG_ID,
+        config: { cloudid: CLOUDID, status: "reconnect_needed" },
+      }),
+    ).rejects.toMatchObject({
+      _tag: "JiraReconnectRequiredError",
+      upstreamError: "install_marked_reconnect_needed",
+    });
+
+    expect(mockReadCredentialBundle).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Missing credentials
+// ---------------------------------------------------------------------------
+
+describe("createJiraLazyBuilder — missing credentials", () => {
+  it("throws a clear error when integration_credentials has no row", async () => {
+    mockReadCredentialBundle.mockResolvedValueOnce(null);
+
+    const build = builderMod.createJiraLazyBuilder(BUILDER_CONFIG);
+
+    await expect(
+      build({
+        workspaceId: WSID,
+        catalogId: CATALOG_ID,
+        config: { cloudid: CLOUDID, status: "ok" },
+      }),
+    ).rejects.toThrow("integration_credentials row is missing");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Session-expired retry path
+// ---------------------------------------------------------------------------
+
+describe("createJiraLazyBuilder — session retry", () => {
+  it("on HTTP 401, refreshes the token and retries the query once", async () => {
+    mockReadCredentialBundle.mockResolvedValueOnce(HAPPY_BUNDLE);
+
+    let calls = 0;
+    mockFetch.mockImplementation(() => {
+      calls++;
+      if (calls === 1) {
+        return Promise.resolve(new Response("Unauthorized", { status: 401 }));
+      }
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            issues: [{ key: "ATL-RETRY", fields: { summary: "after retry" } }],
+          }),
+          { status: 200 },
+        ),
+      );
+    });
+
+    const build = builderMod.createJiraLazyBuilder(BUILDER_CONFIG);
+    const instance = (await build({
+      workspaceId: WSID,
+      catalogId: CATALOG_ID,
+      config: { cloudid: CLOUDID, status: "ok" },
+    })) as JiraPluginInstance;
+
+    const result = await instance.queryJira("project = ATL");
+
+    expect(result.rows).toEqual([
+      {
+        key: "ATL-RETRY",
+        summary: "after retry",
+        status: undefined,
+        assignee: undefined,
+        priority: undefined,
+        issuetype: undefined,
+        created: undefined,
+        updated: undefined,
+      },
+    ]);
+    expect(mockRefreshJiraToken).toHaveBeenCalledTimes(1);
+    expect(mockRefreshJiraToken).toHaveBeenCalledWith(
+      expect.objectContaining({ workspaceId: WSID, clientId: "jira-client-id" }),
+    );
+    // After the refresh the retry request carries the new token.
+    const [, retryInit] = mockFetch.mock.calls[1] as [string, RequestInit];
+    expect((retryInit.headers as Record<string, string>).Authorization).toBe(
+      "Bearer refreshed-access-token",
+    );
+  });
+
+  it("propagates JiraReconnectRequiredError AND evicts the cached instance on permanent refresh failure", async () => {
+    mockReadCredentialBundle.mockResolvedValueOnce(HAPPY_BUNDLE);
+    mockFetch.mockImplementationOnce(() =>
+      Promise.resolve(new Response("Unauthorized", { status: 401 })),
+    );
+    mockRefreshJiraToken.mockRejectedValueOnce(
+      new TestJiraReconnectRequiredError({
+        workspaceId: WSID,
+        upstreamError: "invalid_grant",
+      }),
+    );
+
+    const build = builderMod.createJiraLazyBuilder(BUILDER_CONFIG);
+    const instance = (await build({
+      workspaceId: WSID,
+      catalogId: CATALOG_ID,
+      config: { cloudid: CLOUDID, status: "ok" },
+    })) as JiraPluginInstance;
+
+    await expect(instance.queryJira("project = ATL")).rejects.toMatchObject({
+      _tag: "JiraReconnectRequiredError",
+      upstreamError: "invalid_grant",
+    });
+
+    // Without the evict call, the cached instance with a stale access
+    // token would loop on every subsequent tool call until process
+    // restart. The docblock at the top of lazy-builder.ts promises
+    // this happens; this test pins it.
+    expect(mockEvict).toHaveBeenCalledWith(WSID, CATALOG_ID);
+    expect(mockEvict).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT evict the cache on a transient refresh failure (network blip)", async () => {
+    mockReadCredentialBundle.mockResolvedValueOnce(HAPPY_BUNDLE);
+    mockFetch.mockImplementationOnce(() =>
+      Promise.resolve(new Response("Unauthorized", { status: 401 })),
+    );
+    mockRefreshJiraToken.mockRejectedValueOnce(new Error("ECONNRESET"));
+
+    const build = builderMod.createJiraLazyBuilder(BUILDER_CONFIG);
+    const instance = (await build({
+      workspaceId: WSID,
+      catalogId: CATALOG_ID,
+      config: { cloudid: CLOUDID, status: "ok" },
+    })) as JiraPluginInstance;
+
+    await expect(instance.queryJira("project = ATL")).rejects.toThrow("ECONNRESET");
+    expect(mockEvict).not.toHaveBeenCalled();
+  });
+});

--- a/packages/api/src/lib/integrations/jira/lazy-builder.ts
+++ b/packages/api/src/lib/integrations/jira/lazy-builder.ts
@@ -1,0 +1,342 @@
+/**
+ * Jira LazyPluginLoader builder (#2659).
+ *
+ * Second lazy integration plugin to wire through {@link
+ * lazyPluginLoader}; mirrors the Salesforce builder's shape (#2658). On
+ * first tool call per Workspace, the loader:
+ *
+ *   1. Reads `workspace_plugins.config` (passed in as `args.config`)
+ *      to surface admin-visible state (`cloudid`, `status`).
+ *   2. If `config.status === "reconnect_needed"`, the build refuses
+ *      with `JiraReconnectRequiredError` so the agent loop surfaces a
+ *      specific "this install needs Reconnect" message rather than
+ *      silently failing with a 401.
+ *   3. Reads `integration_credentials` for the bundle (already
+ *      decrypted by the store helper).
+ *   4. Constructs an instance that calls the Jira REST API via `fetch`
+ *      against `https://api.atlassian.com/ex/jira/{cloudid}/rest/api/3`.
+ *      We use `fetch` rather than a Jira client library because:
+ *        - Atlassian's official `@atlassian/jira-api-client` is a
+ *          generated wrapper with a heavy dep tree (every endpoint is
+ *          its own class); we use exactly one endpoint here.
+ *        - The REST surface is straightforward — auth header + JQL
+ *          body — and matches the rest of the codebase's pattern
+ *          (Slack's OAuth handler also calls `fetch` directly).
+ *        - Avoiding a new dep keeps the create-atlas template's
+ *          `serverExternalPackages` list shorter.
+ *   5. Returns a {@link PluginLike} carrying `queryJira(jql)`. Agent's
+ *      Jira tool dispatches through this method.
+ *
+ * Refresh strategy: matches Salesforce — on 401, runs the refresh,
+ * retries once. Atlassian rotates the refresh token on every refresh
+ * (Salesforce sometimes returns one, sometimes not), but that detail
+ * is hidden inside `refreshJiraToken` which writes the rotated value
+ * back to `integration_credentials`.
+ *
+ * Cache eviction: on permanent refresh failure, `withRetry` evicts THIS
+ * instance from `lazyPluginLoader` before re-throwing
+ * `JiraReconnectRequiredError`. Same wire as Salesforce — keeps the
+ * agent from cycling through 401 / refresh / fail on every call.
+ *
+ * @see packages/api/src/lib/plugins/lazy-loader.ts — generic loader
+ * @see ./../install/jira-token-refresh.ts — refresh + reconnect surface
+ * @see ./../salesforce/lazy-builder.ts — first reference implementation
+ */
+
+import { createLogger } from "@atlas/api/lib/logger";
+import { readCredentialBundle } from "@atlas/api/lib/integrations/credentials/store";
+import type { CredentialBundle } from "@atlas/api/lib/integrations/credentials/store";
+import {
+  refreshJiraToken,
+  JiraReconnectRequiredError,
+} from "@atlas/api/lib/integrations/install/jira-token-refresh";
+import {
+  lazyPluginLoader,
+  type LazyPluginBuilder,
+  type LazyPluginBuilderArgs,
+} from "@atlas/api/lib/plugins/lazy-loader";
+import type { PluginLike } from "@atlas/api/lib/plugins/registry";
+
+const log = createLogger("integrations.jira.lazy-builder");
+
+export interface JiraQueryResult {
+  readonly columns: readonly string[];
+  readonly rows: readonly Record<string, unknown>[];
+}
+
+/**
+ * Public shape exposed by the lazy-built Jira plugin instance. Agent
+ * tooling calls `queryJira(jql)` with a JQL search expression; the
+ * wrapper handles session-expired retries via {@link refreshJiraToken}.
+ */
+export interface JiraPluginInstance extends PluginLike {
+  queryJira(jql: string, timeoutMs?: number): Promise<JiraQueryResult>;
+}
+
+/**
+ * Operator-side Jira OAuth App credentials. The lazy-builder needs them
+ * so it can run a refresh when the access token expires.
+ */
+export interface JiraLazyBuilderConfig {
+  readonly clientId: string;
+  readonly clientSecret: string;
+}
+
+/**
+ * Status field stored on `workspace_plugins.config.status`. Mirrors
+ * the OAuth handler's seed value (`"ok"`) and the refresh flow's
+ * flipped value (`"reconnect_needed"`).
+ */
+function readInstallStatus(config: Record<string, unknown>): string {
+  const status = config.status;
+  return typeof status === "string" ? status : "ok";
+}
+
+function readCloudid(config: Record<string, unknown>): string | null {
+  const cloudid = config.cloudid;
+  return typeof cloudid === "string" && cloudid.length > 0 ? cloudid : null;
+}
+
+/**
+ * Treat any 401 from the Jira REST API as "session expired" — the
+ * stored access token has expired and a refresh is warranted.
+ */
+function isSessionExpiredError(err: unknown): boolean {
+  if (err instanceof JiraUnauthorizedError) return true;
+  if (!(err instanceof Error)) return false;
+  return err.message.includes("401");
+}
+
+class JiraUnauthorizedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "JiraUnauthorizedError";
+  }
+}
+
+/**
+ * Run a JQL search against Jira Cloud REST API v3. POSTs to
+ * `/rest/api/3/search` with the JQL string + a request for the
+ * standard `summary` / `status` / `assignee` fields. Returns a
+ * tabular shape that lines up with the rest of Atlas's tool surface
+ * (`columns` + `rows`).
+ */
+async function runJqlSearch(
+  baseUrl: string,
+  accessToken: string,
+  jql: string,
+  timeoutMs: number,
+): Promise<JiraQueryResult> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  let resp: Response;
+  try {
+    resp = await fetch(`${baseUrl}/rest/api/3/search`, {
+      method: "POST",
+      signal: controller.signal,
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: JSON.stringify({
+        jql,
+        // Conservative defaults — JQL can match millions of issues. The
+        // agent surface is for analysis, not bulk export. 100 is the
+        // Jira-side default page size.
+        maxResults: 100,
+        fields: ["summary", "status", "assignee", "priority", "issuetype", "created", "updated"],
+      }),
+    });
+  } catch (err) {
+    if (err instanceof Error && err.name === "AbortError") {
+      throw new Error("Jira query timed out", { cause: err });
+    }
+    throw err;
+  } finally {
+    clearTimeout(timer);
+  }
+
+  if (resp.status === 401) {
+    // 401 surfaces through `isSessionExpiredError` so the retry wrapper
+    // runs a refresh + retry. Subclass so the wrapper can pin the type
+    // without string matching.
+    throw new JiraUnauthorizedError(
+      `Jira API returned 401 — access token rejected`,
+    );
+  }
+
+  if (!resp.ok) {
+    let body = "";
+    try {
+      body = (await resp.text()).slice(0, 500);
+    } catch {
+      // best-effort body capture for log forensics
+    }
+    throw new Error(`Jira API returned HTTP ${resp.status}: ${body}`);
+  }
+
+  let parsed: { issues?: ReadonlyArray<Record<string, unknown>> };
+  try {
+    parsed = (await resp.json()) as { issues?: ReadonlyArray<Record<string, unknown>> };
+  } catch (err) {
+    throw new Error(
+      `Jira API response was not valid JSON: ${err instanceof Error ? err.message : String(err)}`,
+      { cause: err },
+    );
+  }
+
+  const issues = parsed.issues ?? [];
+  if (issues.length === 0) return { columns: [], rows: [] };
+
+  // Project the nested Atlassian-Document-Format payload into a flat
+  // table. The agent reads tables — keep this conservative; the full
+  // ADF payload is available via a follow-up tool if the agent needs
+  // it.
+  const columns = ["key", "summary", "status", "assignee", "priority", "issuetype", "created", "updated"];
+  const rows = issues.map((issue) => {
+    const fields = (issue.fields as Record<string, unknown> | undefined) ?? {};
+    return {
+      key: issue.key as string | undefined,
+      summary: fields.summary as string | undefined,
+      status: stringOrName(fields.status),
+      assignee: stringOrName(fields.assignee, "displayName"),
+      priority: stringOrName(fields.priority),
+      issuetype: stringOrName(fields.issuetype),
+      created: fields.created as string | undefined,
+      updated: fields.updated as string | undefined,
+    };
+  });
+  return { columns, rows };
+}
+
+function stringOrName(value: unknown, key: string = "name"): string | undefined {
+  if (typeof value === "string") return value;
+  if (value && typeof value === "object" && key in (value as Record<string, unknown>)) {
+    const v = (value as Record<string, unknown>)[key];
+    return typeof v === "string" ? v : undefined;
+  }
+  return undefined;
+}
+
+/**
+ * Factory returning a {@link LazyPluginBuilder} closed over operator
+ * Jira OAuth App config. Tests inject a custom config; boot wiring in
+ * `register.ts` reads `process.env` once and passes the values in.
+ */
+export function createJiraLazyBuilder(
+  config: JiraLazyBuilderConfig,
+): LazyPluginBuilder {
+  return async (args: LazyPluginBuilderArgs): Promise<JiraPluginInstance> => {
+    const { workspaceId, catalogId } = args;
+    const installConfig = args.config;
+
+    const status = readInstallStatus(installConfig);
+    if (status === "reconnect_needed") {
+      throw new JiraReconnectRequiredError({
+        message: "Jira install needs to be reconnected — workspace_plugins.config.status is reconnect_needed.",
+        workspaceId,
+        upstreamError: "install_marked_reconnect_needed",
+      });
+    }
+
+    let bundle: CredentialBundle | null;
+    try {
+      bundle = await readCredentialBundle(workspaceId, catalogId);
+    } catch (err) {
+      log.error(
+        { workspaceId, err: err instanceof Error ? err.message : String(err) },
+        "Failed to decrypt Jira credentials — refusing to instantiate plugin",
+      );
+      throw err;
+    }
+    if (!bundle) {
+      throw new Error(
+        `LazyPluginLoader: Jira install row exists but integration_credentials row is missing for workspace ${workspaceId} — disconnect + reinstall`,
+      );
+    }
+
+    // The OAuth handler writes `instanceUrl =
+    // https://api.atlassian.com/ex/jira/<cloudid>` into the bundle.
+    // Fall back to reconstructing from the install config's `cloudid`
+    // when the bundle's value is empty — defensive, shouldn't happen
+    // in practice.
+    let activeBaseUrl: string;
+    if (bundle.instanceUrl && bundle.instanceUrl.length > 0) {
+      activeBaseUrl = bundle.instanceUrl;
+    } else {
+      const cloudid = readCloudid(installConfig);
+      if (!cloudid) {
+        throw new Error(
+          `LazyPluginLoader: Jira install for workspace ${workspaceId} has no cloudid`,
+        );
+      }
+      activeBaseUrl = `https://api.atlassian.com/ex/jira/${cloudid}`;
+    }
+
+    let activeAccessToken = bundle.accessToken;
+
+    /**
+     * Run a callback against the Jira API; on 401, refresh the token
+     * (via {@link refreshJiraToken} — which writes the rotated
+     * refresh_token to `integration_credentials` and clears
+     * reconnect_needed) and retry once. On permanent refresh failure,
+     * evict THIS cached instance before re-throwing.
+     */
+    async function withRetry<T>(fn: (baseUrl: string, accessToken: string) => Promise<T>): Promise<T> {
+      try {
+        return await fn(activeBaseUrl, activeAccessToken);
+      } catch (err) {
+        if (!isSessionExpiredError(err)) throw err;
+        log.info({ workspaceId }, "Jira session expired — refreshing token");
+        try {
+          const refreshed = await refreshJiraToken({
+            workspaceId,
+            clientId: config.clientId,
+            clientSecret: config.clientSecret,
+          });
+          activeAccessToken = refreshed.accessToken;
+          if (refreshed.instanceUrl && refreshed.instanceUrl.length > 0) {
+            activeBaseUrl = refreshed.instanceUrl;
+          }
+          return await fn(activeBaseUrl, activeAccessToken);
+        } catch (refreshErr) {
+          if (refreshErr instanceof JiraReconnectRequiredError) {
+            // Fire-and-forget evict — see Salesforce builder for the
+            // rationale. Tagged as void to silence the floating-promise
+            // check.
+            void lazyPluginLoader.evict(workspaceId, catalogId);
+          }
+          throw refreshErr;
+        }
+      }
+    }
+
+    const instance: JiraPluginInstance = {
+      id: `jira:${workspaceId}`,
+      types: ["datasource"] as const,
+      version: "0.1.0",
+      name: "Jira",
+      config: { instanceUrl: activeBaseUrl, scope: bundle.scope },
+
+      async queryJira(jql: string, timeoutMs = 30_000): Promise<JiraQueryResult> {
+        return withRetry((baseUrl, accessToken) =>
+          runJqlSearch(baseUrl, accessToken, jql, timeoutMs),
+        );
+      },
+
+      async teardown(): Promise<void> {
+        // fetch-based — no socket pool to release. Future refactors
+        // that add a keep-alive agent stay backwards-compatible with
+        // LazyPluginLoader's `evict` contract.
+      },
+    };
+
+    log.info(
+      { workspaceId, instanceUrl: activeBaseUrl, scope: bundle.scope },
+      "Jira lazy plugin instantiated",
+    );
+    return instance;
+  };
+}

--- a/packages/api/src/lib/integrations/jira/lazy-builder.ts
+++ b/packages/api/src/lib/integrations/jira/lazy-builder.ts
@@ -100,11 +100,16 @@ function readCloudid(config: Record<string, unknown>): string | null {
 /**
  * Treat any 401 from the Jira REST API as "session expired" — the
  * stored access token has expired and a refresh is warranted.
+ *
+ * Class-only check: `runJqlSearch` is the single 401 source and it
+ * throws `JiraUnauthorizedError` exclusively. A previous string-match
+ * fallback (`err.message.includes("401")`) was dropped because it
+ * could match unrelated errors (e.g. a `4011` HTTP code, or a body
+ * payload that happens to contain "401") and trigger spurious
+ * refreshes.
  */
 function isSessionExpiredError(err: unknown): boolean {
-  if (err instanceof JiraUnauthorizedError) return true;
-  if (!(err instanceof Error)) return false;
-  return err.message.includes("401");
+  return err instanceof JiraUnauthorizedError;
 }
 
 class JiraUnauthorizedError extends Error {


### PR DESCRIPTION
Closes #2659.

## Summary

Second consumer of the lazy-OAuth pattern Salesforce established in #2700. The abstraction holds — this PR adds **only Jira-specific code**; every shared piece of infrastructure (table, store, dispatch, ADRs, dual-store teardown, admin UI) lands as a no-op reuse.

| | This PR (Jira) | #2700 (Salesforce) | Delta |
|---|---|---|---|
| Files changed | 12 | 26 | **-54%** |
| Insertions | +2369 | +3225 | **-27%** |
| Migrations | 0 (reuses 0089) | 1 (creates 0089) | |
| ADRs | 0 (reuses 0005) | 1 (writes 0005) | |
| Schema-drift gate | green (no DB change) | required schema mirror | |

That gap — 14 fewer files, ~860 fewer added lines — IS the abstraction proof asked for in the issue body.

## What's Jira-specific (and why)

| Component | Jira-specific because |
|---|---|
| `JiraOAuthInstallHandler` | Atlassian 3LO posts JSON (not form-encoded), requires `audience=api.atlassian.com`, returns `cloudid` only via a second `accessible-resources` hop |
| `jira-token-refresh.ts` | Atlassian **rotates** the refresh_token on every refresh (vs SF optional) — new value MUST be persisted back; permanent failure codes differ (`invalid_grant` / `unauthorized_client` / `access_denied`) |
| `jira/lazy-builder.ts` | Per-cloud REST base URL (`api.atlassian.com/ex/jira/<cloudid>`); 401 (not `INVALID_SESSION_ID`) is the session-expired signal; **uses `fetch` directly** (no Jira client dep — REST is straightforward, see code comment) |
| `JiraReconnectRequiredError` | Distinct tag for routing 409s; both SF + Jira reconnect tags collapse to one `case` in `hono.ts` (canonical 409 + `conflict` mapping) |

## What's reused unchanged

- `integration_credentials` table + migration 0089 + Drizzle mirror
- `credentials/store.ts` (encrypt/decrypt + upsert + dual-store teardown)
- `install/dispatch.ts` (no new branches — `registerOAuthHandler("jira", ...)` is the seam)
- ADR-0003 two-store atomicity, ADR-0005 credential bundle shape
- `OAuthPlatformInstallHandler` interface — `kind: "oauth"`, `startInstall`, `handleCallback` shapes
- Admin `catalog-section.tsx` integration-card branch (reads `installStatus` generically)
- `/api/v1/admin/integrations/:platform` disconnect — **one-line change**: add `"jira"` to `INTEGRATION_CREDENTIALS_SLUGS`
- `mintOAuthStateToken` / `verifyOAuthStateToken` for CSRF

## Acceptance criteria

- [x] Jira card visible in `/admin/integrations` for plan-eligible Workspaces (the card render is already generalized; the catalog endpoint reflects the new entry)
- [x] Connect Jira → OAuth 3LO dance → installed (workspace_plugins + integration_credentials rows written; cloudid in config)
- [x] `cloudid` persisted in `workspace_plugins.config`; Jira lazy builder reads it correctly (with bundle-instanceUrl preferred, cloudid fallback)
- [x] Agent can query Jira data after install via `LazyPluginLoader` (single tool: `queryJira(jql)`)
- [x] **PR diff is meaningfully smaller than #2700** — 54% fewer files, 27% fewer lines
- [x] Unit tests pin: OAuth scope set (`offline_access` required for refresh_token), cloudid propagation, refresh-token rotation writeback, one-Atlas-Workspace = one-Atlassian-Cloud semantics, ADR-0003 write ordering, partial-failure reconnect path, session-expired retry, evict-on-permanent-failure
- [ ] Browser e2e (manual) — Connect Jira → installed → agent can query Jira data

## Operator setup (Jira-specific)

| Env var | Required | Notes |
|---|---|---|
| `JIRA_CLIENT_ID` | yes | Atlassian App's Client ID |
| `JIRA_CLIENT_SECRET` | yes | Atlassian App's Client Secret |
| `ATLAS_PUBLIC_API_URL` | yes | Used to construct the OAuth callback URL |

Without `JIRA_CLIENT_ID` / `JIRA_CLIENT_SECRET`, the install handler logs "Jira OAuth handler not registered" at boot and `GET /api/v1/integrations/jira/install` returns 501.

## Test plan

- [x] `bun run lint` — 0 errors (10 pre-existing warnings)
- [x] `bun run type` — clean
- [x] `bun run scripts/test-isolated.ts --affected` — 54/54 pass
- [x] `bash scripts/check-schema-drift.sh` — clean (no DB change)
- [x] `bash scripts/check-ee-imports.sh` — clean
- [x] `bash scripts/check-template-drift.sh` — clean
- [x] `bash scripts/check-railway-watch.sh` — clean
- [x] `bunx syncpack lint` — clean
- [x] Full `@atlas/api` suite — 445/445 pass
- [ ] Manual: Verify Jira card appears in `/admin/integrations` when env vars are set
- [ ] Manual: Connect flow → OAuth dance → rows in `workspace_plugins` + `integration_credentials`
- [ ] Manual: Simulate `invalid_grant` refresh → `status: reconnect_needed` → admin UI badge
- [ ] Manual: Disconnect → both rows gone in correct order

## Follow-ups (out of scope)

- The shape `JiraReconnectRequiredError` mirrors `SalesforceReconnectRequiredError` exactly (per-platform `_tag`, `workspaceId`, `upstreamError`). With two consumers the extraction `IntegrationReconnectRequiredError({ platform, ... })` is now justified. Filing as a separate issue rather than expanding this PR's scope per the "if you find yourself adding shared infra, STOP" rule in #2659.
- The `withRetry(refreshFn, isSessionExpired, reconnectErrorClass)` shape between SF and Jira lazy-builders is structurally identical save for the per-platform substitutions. Same disposition — extraction-issue worthy, not in scope here.