### PR TITLE
fix(plugins/chat): #2673 — escalate AdapterRegistry log severity for SaaS misconfigs

### DIFF
--- a/plugins/chat/src/adapter-registry.test.ts
+++ b/plugins/chat/src/adapter-registry.test.ts
@@ -17,6 +17,7 @@
 import { describe, it, expect } from "bun:test";
 import {
   buildChatAdapterRegistry,
+  hasInstantiationFailure,
   type ChatCatalogEntry,
   type RegistryLogger,
 } from "./adapter-registry";
@@ -34,18 +35,22 @@ function makeLogger(): {
   logger: RegistryLogger;
   infos: Array<{ payload: Record<string, unknown>; msg: string }>;
   warns: Array<{ payload: Record<string, unknown>; msg: string }>;
+  errors: Array<{ payload: Record<string, unknown>; msg: string }>;
   debugs: Array<{ payload: Record<string, unknown>; msg: string }>;
 } {
   const infos: Array<{ payload: Record<string, unknown>; msg: string }> = [];
   const warns: Array<{ payload: Record<string, unknown>; msg: string }> = [];
+  const errors: Array<{ payload: Record<string, unknown>; msg: string }> = [];
   const debugs: Array<{ payload: Record<string, unknown>; msg: string }> = [];
   return {
     infos,
     warns,
+    errors,
     debugs,
     logger: {
       info: (payload, msg) => infos.push({ payload, msg }),
       warn: (payload, msg) => warns.push({ payload, msg }),
+      error: (payload, msg) => errors.push({ payload, msg }),
       debug: (payload, msg) => debugs.push({ payload, msg }),
     },
   };
@@ -91,8 +96,13 @@ describe("buildChatAdapterRegistry — missing env vars", () => {
   ] as const;
 
   for (const missing of required) {
-    it(`skips Slack + logs warn when ${missing} is missing`, () => {
-      const { logger, warns } = makeLogger();
+    it(`skips Slack + logs error when ${missing} is missing (entry enabled)`, () => {
+      // #2673 — `enabled: true` + missing creds is a silent-degradation
+      // bug on SaaS; the registry's control flow guarantees we only
+      // reach the missing-creds branch when the entry was opted in, so
+      // bump the log level from `warn` (lost in routine boot noise) to
+      // `error` (catches operator log-stream alerts).
+      const { logger, errors, warns } = makeLogger();
       const env: NodeJS.ProcessEnv = { ...SLACK_FULL_ENV };
       delete env[missing];
 
@@ -102,9 +112,12 @@ describe("buildChatAdapterRegistry — missing env vars", () => {
         logger,
       });
       expect(result.adapters.slack).toBeUndefined();
-      expect(warns).toHaveLength(1);
-      expect(warns[0]?.msg).toContain("required env vars missing");
-      expect((warns[0]?.payload.requiredEnv as string[]).includes(missing)).toBe(true);
+      expect(errors).toHaveLength(1);
+      expect(errors[0]?.msg).toContain("required env vars missing");
+      expect((errors[0]?.payload.requiredEnv as string[]).includes(missing)).toBe(true);
+      // No warn for this case — the missing-creds line is the only
+      // log emitted, and it MUST be at error level.
+      expect(warns.some((l) => l.msg.includes("required env vars missing"))).toBe(false);
     });
   }
 });
@@ -114,15 +127,23 @@ describe("buildChatAdapterRegistry — missing env vars", () => {
 // ---------------------------------------------------------------------------
 
 describe("buildChatAdapterRegistry — catalog filters", () => {
-  it("does not register Slack when catalog entry is disabled", () => {
-    const { logger, debugs } = makeLogger();
+  it("does not register Slack when catalog entry is disabled — debug log only, never error", () => {
+    // #2673 — operator explicitly disabling an entry must not trigger
+    // the missing-env-vars error path even when env vars are also
+    // unset; the operator intent is clear and we should stay quiet.
+    const { logger, debugs, errors, warns } = makeLogger();
     const result = buildChatAdapterRegistry({
       catalog: [entry({ slug: "slack", enabled: false })],
-      env: SLACK_FULL_ENV,
+      env: {}, // env unset too — must NOT escalate
       logger,
     });
     expect(result.adapters.slack).toBeUndefined();
     expect(debugs.some((l) => l.msg.includes("enabled=false"))).toBe(true);
+    expect(errors).toEqual([]);
+    expect(warns).toEqual([]);
+    // Diagnostics also stay clean — disabled is not a failure mode.
+    expect(result.diagnostics.missingCredSlugs).toEqual([]);
+    expect(result.diagnostics.unrecognizedSlugs).toEqual([]);
   });
 
   it("does not register Slack when install_model is form (skipped, no instantiation)", () => {
@@ -250,5 +271,40 @@ describe("buildChatAdapterRegistry — diagnostics", () => {
     });
     expect(result.diagnostics.missingCredSlugs).toEqual([]);
     expect(result.diagnostics.unrecognizedSlugs).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// hasInstantiationFailure — gates the post-init log severity in index.ts
+// (see #2673). Pinned as a unit test so a future refactor can't silently
+// flip the predicate.
+// ---------------------------------------------------------------------------
+
+describe("hasInstantiationFailure", () => {
+  it("returns false for empty diagnostics (intentionally-empty catalog)", () => {
+    expect(
+      hasInstantiationFailure({ missingCredSlugs: [], unrecognizedSlugs: [] }),
+    ).toBe(false);
+  });
+
+  it("returns true when at least one slug has missing creds", () => {
+    expect(
+      hasInstantiationFailure({ missingCredSlugs: ["slack"], unrecognizedSlugs: [] }),
+    ).toBe(true);
+  });
+
+  it("returns true when at least one slug is unrecognized", () => {
+    expect(
+      hasInstantiationFailure({ missingCredSlugs: [], unrecognizedSlugs: ["slcak"] }),
+    ).toBe(true);
+  });
+
+  it("returns true when both lists are populated", () => {
+    expect(
+      hasInstantiationFailure({
+        missingCredSlugs: ["slack"],
+        unrecognizedSlugs: ["unknown"],
+      }),
+    ).toBe(true);
   });
 });

--- a/plugins/chat/src/adapter-registry.ts
+++ b/plugins/chat/src/adapter-registry.ts
@@ -181,6 +181,7 @@ export function getChatAdapterRequiredEnv(slug: string): ReadonlyArray<string> |
 export interface RegistryLogger {
   info(payload: Record<string, unknown>, msg: string): void;
   warn(payload: Record<string, unknown>, msg: string): void;
+  error(payload: Record<string, unknown>, msg: string): void;
   debug?(payload: Record<string, unknown>, msg: string): void;
 }
 
@@ -258,7 +259,13 @@ export function buildChatAdapterRegistry(
     const adapter = builder.build(args.env);
     if (!adapter) {
       missingCredSlugs.push(entry.slug);
-      logger.warn(
+      // `error`, not `warn` — the entry-disabled branch above already
+      // short-circuits, so reaching here means the operator opted the
+      // Platform in and the env vars are missing. On a SaaS deploy this
+      // is always a critical misconfig; on self-hosted it surfaces the
+      // same way (operator declared enabled=true and meant it). See
+      // #2673 for the 2026-05-20 silent-degradation incident.
+      logger.error(
         {
           slug: entry.slug,
           platform: builder.platform,
@@ -292,6 +299,25 @@ function createNoopLogger(): RegistryLogger {
   return {
     info: () => {},
     warn: () => {},
+    error: () => {},
     debug: () => {},
   };
+}
+
+/**
+ * True when the catalog declared an instantiable adapter we couldn't
+ * wire — missing env vars or unknown slug. Both are SaaS-deploy bugs:
+ * the operator opted the Platform in, but the adapter isn't there.
+ *
+ * Empty adapters with empty diagnostics is fine (intentionally-empty
+ * catalog, or only non-OAuth / disabled entries declared); that path
+ * stays at `info`. This predicate gates the post-init log severity so
+ * a silently-degraded SaaS deploy surfaces as an error in operator
+ * log streams instead of blending into routine boot info noise.
+ *
+ * See #2673 — 2026-05-20 incident where a dropped `SLACK_ENCRYPTION_KEY`
+ * left `adapters=[]` for ~22h and the warn/info lines were missed.
+ */
+export function hasInstantiationFailure(d: ChatAdapterDiagnostics): boolean {
+  return d.missingCredSlugs.length > 0 || d.unrecognizedSlugs.length > 0;
 }

--- a/plugins/chat/src/index.ts
+++ b/plugins/chat/src/index.ts
@@ -47,7 +47,7 @@ import { ChatConfigSchema } from "./config";
 import type { ChatCatalogEntryInput, ChatPluginConfig } from "./config";
 import { createChatBridge } from "./bridge";
 import type { ChatBridge } from "./bridge";
-import { buildChatAdapterRegistry } from "./adapter-registry";
+import { buildChatAdapterRegistry, hasInstantiationFailure } from "./adapter-registry";
 import type { ChatCatalogEntry } from "./adapter-registry";
 import { createStateAdapter } from "./state";
 
@@ -390,12 +390,33 @@ function buildChatPlugin(
       if (slackAdapterInstance) enabledAdapters.push("slack");
 
       const backend = config.state?.backend ?? "memory";
-      ctx.logger.info(
-        { adapters: enabledAdapters, stateBackend: backend },
+      const initFailedSilently =
+        enabledAdapters.length === 0 &&
+        hasInstantiationFailure(adapterDiagnostics);
+
+      const msg =
         enabledAdapters.length > 0
           ? `Chat interaction plugin initialized (${enabledAdapters.join(", ")}, state: ${backend})`
-          : `Chat interaction plugin initialized (no chat adapters activated — see AdapterRegistry warns, state: ${backend})`,
-      );
+          : `Chat interaction plugin initialized (no chat adapters activated — see AdapterRegistry warns, state: ${backend})`;
+
+      if (initFailedSilently) {
+        // SaaS-eligible catalog entry failed to instantiate (missing
+        // env vars or unknown slug) — see #2673. Surface at `error` so
+        // operator log streams catch the silent-degradation case.
+        ctx.logger.error(
+          {
+            adapters: enabledAdapters,
+            stateBackend: backend,
+            diagnostics: adapterDiagnostics,
+          },
+          msg,
+        );
+      } else {
+        ctx.logger.info(
+          { adapters: enabledAdapters, stateBackend: backend },
+          msg,
+        );
+      }
       initialized = true;
     },
 

--- a/plugins/chat/src/index.ts
+++ b/plugins/chat/src/index.ts
@@ -347,8 +347,8 @@ function buildChatPlugin(
 
       // Build chat-platform adapters via the catalog-driven
       // AdapterRegistry (#2650 slice 2). The registry reads per-Platform
-      // credentials from `process.env`, logs warns on missing creds /
-      // non-OAuth entries, and returns the adapters map plus diagnostic
+      // credentials from `process.env`, logs errors on missing creds /
+      // warns on non-OAuth entries, and returns the adapters map plus diagnostic
       // slug lists. The diagnostics let `healthCheck` surface actionable
       // error messages.
       try {
@@ -397,7 +397,7 @@ function buildChatPlugin(
       const msg =
         enabledAdapters.length > 0
           ? `Chat interaction plugin initialized (${enabledAdapters.join(", ")}, state: ${backend})`
-          : `Chat interaction plugin initialized (no chat adapters activated — see AdapterRegistry warns, state: ${backend})`;
+          : `Chat interaction plugin initialized (no chat adapters activated — see AdapterRegistry errors, state: ${backend})`;
 
       if (initFailedSilently) {
         // SaaS-eligible catalog entry failed to instantiate (missing


### PR DESCRIPTION
## Summary

- `AdapterRegistry: required env vars missing — adapter not instantiated` now logs at `error` (was `warn`). The entry-disabled branch above already short-circuits, so this branch is only reachable when the operator opted the Platform in — that's always a real misconfig.
- Post-init `Chat interaction plugin initialized (no chat adapters activated …)` log escalates to `error` when `adapters=[]` AND the registry's diagnostics flag a real instantiation failure (missing creds or unknown slug). Stays at `info` for intentionally-empty / all-disabled / non-OAuth catalogs.
- New exported predicate `hasInstantiationFailure(diagnostics)` gates the post-init severity — pinned by unit tests so a future refactor can't silently flip the gate.
- `RegistryLogger` interface gains `error` to match `PluginLogger`.

Motivation: 2026-05-20 outage where a dropped `SLACK_ENCRYPTION_KEY` left the chat plugin running with `adapters=[]` for ~22 hours. The warn/info lines blended into routine Railway boot noise. #2672 shipped the load-bearing SaaS boot guard; this is the observability defense-in-depth.

## Note on AC interpretation

The issue body's AC #2 says "no chat adapters activated AND the catalog has at least one `enabled: true` chat entry" → error. I narrowed this to "instantiation failure" (`missingCredSlugs` or `unrecognizedSlugs` non-empty). The broader literal would over-fire when a catalog contains only `static-bot enabled: true` entries (intentionally not wired in 1.5.2 — Telegram/Discord/gchat/WhatsApp are catalog placeholders pending 1.5.3). The diagnostics-based predicate exactly matches the production incident motivation.

## Test plan

- [x] `bun test src/adapter-registry.test.ts` (plugins/chat) — 20/20 pass including the four new `hasInstantiationFailure` cases and the disabled-entry no-error pin
- [x] Full `bun test` in `plugins/chat` — 437/437 pass
- [x] `bun run type` — clean across the workspace
- [x] `bun run lint` — clean
- [x] `/ci` gates all green except one pre-existing flake in `@atlas/cli` (DuckDB profiler, unrelated to this change) — filed as #2716

Closes #2673