### PR TITLE
docs(plugins/chat): #2712 — point Slack OAuth refs at canonical /api/v1/integrations/slack

### DIFF
--- a/apps/docs/content/docs/plugins/interactions/chat.mdx
+++ b/apps/docs/content/docs/plugins/interactions/chat.mdx
@@ -475,10 +475,10 @@ The `chunkIntervalMs` setting controls how frequently messages are edited on pla
 | `POST` | `/webhooks/linear` | Linear webhook (issue comment events) |
 | `GET` | `/webhooks/whatsapp` | WhatsApp webhook verification (Meta challenge-response) |
 | `POST` | `/webhooks/whatsapp` | WhatsApp webhook (incoming messages) |
-| `GET` | `/oauth/slack/install` | Slack OAuth install redirect (only when `clientId` configured) |
-| `GET` | `/oauth/slack/callback` | Slack OAuth callback (only when `clientId` configured) |
 
 Routes are mounted under the plugin's base path (e.g., `/api/plugins/chat-interaction/webhooks/slack`).
+
+Slack OAuth install + callback are NOT mounted under the chat-plugin prefix — they live at the canonical integration surface `/api/v1/integrations/slack/{install,callback}` (owned by `SlackOAuthInstallHandler`). See [Integrations guide](/docs/guides/integrations) for the operator/customer seam and install-model design.
 
 ## Install consent language
 
@@ -620,8 +620,8 @@ Update your Slack app webhook URLs:
 | Slash commands | `/commands` | `/webhooks/slack` |
 | Events | `/events` | `/webhooks/slack` |
 | Interactions | `/interactions` | `/webhooks/slack` |
-| OAuth install | `/install` | `/oauth/slack/install` |
-| OAuth callback | `/callback` | `/oauth/slack/callback` |
+| OAuth install | `/install` | `/api/v1/integrations/slack/install` |
+| OAuth callback | `/callback` | `/api/v1/integrations/slack/callback` |
 
 ## Migrating from @useatlas/teams
 

--- a/apps/docs/content/docs/plugins/interactions/slack.mdx
+++ b/apps/docs/content/docs/plugins/interactions/slack.mdx
@@ -158,7 +158,7 @@ export default defineConfig({
 | Feature | @useatlas/slack | @useatlas/chat |
 |---------|----------------|----------------|
 | Webhook | `/commands`, `/events`, `/interactions` | `/webhooks/slack` |
-| OAuth | `/install`, `/callback` | `/oauth/slack/install`, `/oauth/slack/callback` |
+| OAuth | `/install`, `/callback` | `/api/v1/integrations/slack/install`, `/api/v1/integrations/slack/callback` |
 | Block Kit | Hand-rolled builders | Automatic via Chat SDK |
 | State | Custom DB tables | State adapter (memory/PG/Redis) |
 | Multi-platform | Slack only | Slack, Teams, Discord, etc. |


### PR DESCRIPTION
## Summary

#2689 retired `/api/plugins/chat-interaction/oauth/slack/{install,callback}` in favor of `/api/v1/integrations/slack/{install,callback}` owned by `SlackOAuthInstallHandler` (slices #2671 + #2674). Three doc lines still pointed at the retired paths (which return 404 today).

- `apps/docs/content/docs/plugins/interactions/slack.mdx:161` — comparison-table row updated to the canonical paths.
- `apps/docs/content/docs/plugins/interactions/chat.mdx` — removed the two `/oauth/slack/*` rows from the chat-plugin routes table entirely (they no longer mount under the plugin prefix) and added a note pointing at the canonical integration surface + the integrations guide.
- `apps/docs/content/docs/plugins/interactions/chat.mdx` — updated the Slack-app-config migration table so consumers configure the canonical URLs in their Slack app.

## Test plan

- [x] `grep -rn "oauth/slack/install\|oauth/slack/callback" apps/docs/` returns zero hits (excluding `node_modules` / `.next`)
- [x] `cd apps/docs && bun run build` passes
- [x] No code changes — purely docs

Closes #2712