### PR TITLE
test(plugins/chat): #2693 — backfill bridge.onAction handler dispatch tests

### DIFF
--- a/plugins/chat/src/bridge-actions.test.ts
+++ b/plugins/chat/src/bridge-actions.test.ts
@@ -1,0 +1,341 @@
+/**
+ * Tests for `dispatchApproveDenyAction` — the approve/deny button
+ * handler dispatch path extracted from the `chat.onAction(...)` lambda
+ * inside `createChatBridge` (#2693).
+ *
+ * Asserted invariants (issue #2693 AC, narrowed to the approve/deny
+ * subset — Gap 2 OAuth tests are owned by `slack-oauth-handler.test.ts`
+ * post-#2689):
+ *
+ *   - On approve: `actions.get(actionId)` then `actions.approve(actionId, "chat-sdk:<userId>")`,
+ *     then `adapter.editMessage` with the formatted result.
+ *   - On deny: same shape with `actions.deny`.
+ *   - On missing action (`get` returns null): fallback markdown edit.
+ *   - On already-resolved (approve|deny returns null): "already resolved" edit.
+ *   - On thrown error: error log + fallback edit + survive editMessage failure.
+ *   - Empty `event.value`: warn + return (no `actions.get` call).
+ *
+ * The chat-sdk's `ActionEvent` is structurally compatible with the
+ * helper's `ApproveDenyActionEvent` subset, so the test passes plain
+ * objects without constructing real chat-sdk types.
+ */
+
+import { describe, it, expect, mock } from "bun:test";
+import {
+  dispatchApproveDenyAction,
+  type ApproveDenyActionEvent,
+} from "./bridge";
+import type { ActionCallbacks } from "./config";
+import type { PluginLogger } from "@useatlas/plugin-sdk";
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+function makeLogger(): {
+  log: PluginLogger;
+  infos: Array<unknown[]>;
+  warns: Array<unknown[]>;
+  errors: Array<unknown[]>;
+} {
+  const infos: Array<unknown[]> = [];
+  const warns: Array<unknown[]> = [];
+  const errors: Array<unknown[]> = [];
+  return {
+    infos,
+    warns,
+    errors,
+    log: {
+      info: (...args: unknown[]) => infos.push(args),
+      warn: (...args: unknown[]) => warns.push(args),
+      error: (...args: unknown[]) => errors.push(args),
+      debug: () => {},
+    } as unknown as PluginLogger,
+  };
+}
+
+function makeEvent(
+  overrides: Partial<ApproveDenyActionEvent> = {},
+): {
+  event: ApproveDenyActionEvent;
+  editMessage: ReturnType<typeof mock>;
+} {
+  const editMessage = mock(() => Promise.resolve());
+  const event: ApproveDenyActionEvent = {
+    actionId: "atlas_action_approve",
+    value: "act-123",
+    user: { userId: "U-ALICE" },
+    threadId: "thread-1",
+    messageId: "msg-1",
+    adapter: { editMessage },
+    ...overrides,
+  };
+  return { event, editMessage };
+}
+
+function makeActions(
+  overrides: Partial<ActionCallbacks> = {},
+): {
+  actions: ActionCallbacks;
+  get: ReturnType<typeof mock>;
+  approve: ReturnType<typeof mock>;
+  deny: ReturnType<typeof mock>;
+} {
+  const defaultGet = mock(() =>
+    Promise.resolve({
+      id: "act-123",
+      action_type: "send_email",
+      target: "users@example.com",
+      summary: "Send email to users",
+    }),
+  );
+  const defaultApprove = mock(() =>
+    Promise.resolve({ status: "approved", error: null }),
+  );
+  const defaultDeny = mock(() => Promise.resolve({ denied: true }));
+  // Use the override mock when supplied so the returned mock matches
+  // the one the helper actually calls — destructuring `get` etc. from a
+  // builder pattern is otherwise a footgun (you assert against the
+  // default mock instead of the override).
+  const get = (overrides.get ?? defaultGet) as ReturnType<typeof mock>;
+  const approve = (overrides.approve ?? defaultApprove) as ReturnType<typeof mock>;
+  const deny = (overrides.deny ?? defaultDeny) as ReturnType<typeof mock>;
+  const actions: ActionCallbacks = { get, approve, deny };
+  return { actions, get, approve, deny };
+}
+
+// ---------------------------------------------------------------------------
+// Happy paths — approve + deny → actor format + editMessage
+// ---------------------------------------------------------------------------
+
+describe("dispatchApproveDenyAction — approve happy path", () => {
+  it("calls actions.get then actions.approve with chat-sdk:<userId> actor", async () => {
+    const { event, editMessage } = makeEvent({
+      actionId: "atlas_action_approve",
+      value: "act-123",
+      user: { userId: "U-ALICE" },
+    });
+    const { actions, get, approve, deny } = makeActions();
+    const { log } = makeLogger();
+
+    await dispatchApproveDenyAction(event, actions, log);
+
+    expect(get).toHaveBeenCalledTimes(1);
+    expect(get.mock.calls[0]).toEqual(["act-123"]);
+    expect(approve).toHaveBeenCalledTimes(1);
+    expect(approve.mock.calls[0]).toEqual(["act-123", "chat-sdk:U-ALICE"]);
+    expect(deny).not.toHaveBeenCalled();
+    expect(editMessage).toHaveBeenCalledTimes(1);
+    const [threadId, messageId, content] = editMessage.mock.calls[0] as [
+      string,
+      string,
+      { markdown: string },
+    ];
+    expect(threadId).toBe("thread-1");
+    expect(messageId).toBe("msg-1");
+    expect(content.markdown).toContain("Send email to users");
+  });
+});
+
+describe("dispatchApproveDenyAction — deny happy path", () => {
+  it("calls actions.deny with chat-sdk:<userId> actor and edits the message", async () => {
+    const { event, editMessage } = makeEvent({
+      actionId: "atlas_action_deny",
+      value: "act-deny-1",
+      user: { userId: "U-BOB" },
+    });
+    const { actions, get, approve, deny } = makeActions();
+    const { log } = makeLogger();
+
+    await dispatchApproveDenyAction(event, actions, log);
+
+    expect(get).toHaveBeenCalledTimes(1);
+    expect(get.mock.calls[0]).toEqual(["act-deny-1"]);
+    expect(deny).toHaveBeenCalledTimes(1);
+    expect(deny.mock.calls[0]).toEqual(["act-deny-1", "chat-sdk:U-BOB"]);
+    expect(approve).not.toHaveBeenCalled();
+    expect(editMessage).toHaveBeenCalledTimes(1);
+    const [, , content] = editMessage.mock.calls[0] as [
+      string,
+      string,
+      { markdown: string },
+    ];
+    // `formatActionResult(..., "denied")` includes the "denied" status word
+    expect(content.markdown.toLowerCase()).toContain("denied");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Missing-value path — empty `value` is warn + return
+// ---------------------------------------------------------------------------
+
+describe("dispatchApproveDenyAction — missing event.value", () => {
+  it("warns and returns without calling actions when value is undefined", async () => {
+    const { event, editMessage } = makeEvent({ value: undefined });
+    const { actions, get, approve, deny } = makeActions();
+    const { log, warns } = makeLogger();
+
+    await dispatchApproveDenyAction(event, actions, log);
+
+    expect(get).not.toHaveBeenCalled();
+    expect(approve).not.toHaveBeenCalled();
+    expect(deny).not.toHaveBeenCalled();
+    expect(editMessage).not.toHaveBeenCalled();
+    expect(warns.length).toBeGreaterThan(0);
+    expect(JSON.stringify(warns[0])).toContain("missing value");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Missing-action path — actions.get returns null
+// ---------------------------------------------------------------------------
+
+describe("dispatchApproveDenyAction — actions.get returns null", () => {
+  it("edits the message with the 'no longer available' fallback", async () => {
+    const { event, editMessage } = makeEvent();
+    const { actions, get, approve } = makeActions({
+      get: mock(() => Promise.resolve(null)),
+    });
+    const { log } = makeLogger();
+
+    await dispatchApproveDenyAction(event, actions, log);
+
+    expect(get).toHaveBeenCalledTimes(1);
+    expect(approve).not.toHaveBeenCalled();
+    expect(editMessage).toHaveBeenCalledTimes(1);
+    const [, , content] = editMessage.mock.calls[0] as [
+      string,
+      string,
+      { markdown: string },
+    ];
+    expect(content.markdown).toContain("no longer available");
+  });
+
+  it("survives an editMessage failure during the missing-action fallback (logged as warn)", async () => {
+    // The handler tries to edit with the fallback markdown; if the edit
+    // itself throws, we should log a warn and return cleanly — not
+    // propagate the editMessage error. This is the recovery path the
+    // outer try/catch can't reach (already inside the actionEntry===null branch).
+    const editMessage = mock(() => Promise.reject(new Error("network blip")));
+    const { event } = makeEvent({ adapter: { editMessage } });
+    const { actions, approve } = makeActions({
+      get: mock(() => Promise.resolve(null)),
+    });
+    const { log, warns } = makeLogger();
+
+    await expect(
+      dispatchApproveDenyAction(event, actions, log),
+    ).resolves.toBeUndefined();
+    expect(approve).not.toHaveBeenCalled();
+    // Two warns: "Action not found" + "Failed to edit message for missing action"
+    expect(warns.length).toBe(2);
+    expect(JSON.stringify(warns[1])).toContain("Failed to edit message");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Already-resolved path — approve|deny returns null
+// ---------------------------------------------------------------------------
+
+describe("dispatchApproveDenyAction — approve returns null (already resolved)", () => {
+  it("edits the message with the 'already been resolved' fallback", async () => {
+    const { event, editMessage } = makeEvent({
+      actionId: "atlas_action_approve",
+    });
+    const { actions } = makeActions({
+      approve: mock(() => Promise.resolve(null)),
+    });
+    const { log, warns } = makeLogger();
+
+    await dispatchApproveDenyAction(event, actions, log);
+
+    expect(editMessage).toHaveBeenCalledTimes(1);
+    const [, , content] = editMessage.mock.calls[0] as [
+      string,
+      string,
+      { markdown: string },
+    ];
+    expect(content.markdown).toContain("already been resolved");
+    expect(JSON.stringify(warns)).toContain("Action already resolved");
+  });
+});
+
+describe("dispatchApproveDenyAction — deny returns null (already resolved)", () => {
+  it("edits the message with the 'already been resolved' fallback", async () => {
+    const { event, editMessage } = makeEvent({
+      actionId: "atlas_action_deny",
+    });
+    const { actions } = makeActions({
+      deny: mock(() => Promise.resolve(null)),
+    });
+    const { log, warns } = makeLogger();
+
+    await dispatchApproveDenyAction(event, actions, log);
+
+    expect(editMessage).toHaveBeenCalledTimes(1);
+    const [, , content] = editMessage.mock.calls[0] as [
+      string,
+      string,
+      { markdown: string },
+    ];
+    expect(content.markdown).toContain("already been resolved");
+    expect(JSON.stringify(warns)).toContain(
+      "Action already resolved when deny attempted",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Thrown-error path — actions.get/approve/deny throws
+// ---------------------------------------------------------------------------
+
+describe("dispatchApproveDenyAction — actions.approve throws", () => {
+  it("logs error and edits the message with the failure fallback", async () => {
+    const { event, editMessage } = makeEvent({
+      actionId: "atlas_action_approve",
+    });
+    const { actions } = makeActions({
+      approve: mock(() => Promise.reject(new Error("DB exploded"))),
+    });
+    const { log, errors } = makeLogger();
+
+    await dispatchApproveDenyAction(event, actions, log);
+
+    expect(editMessage).toHaveBeenCalledTimes(1);
+    const [, , content] = editMessage.mock.calls[0] as [
+      string,
+      string,
+      { markdown: string },
+    ];
+    expect(content.markdown).toContain("Failed to process action");
+    expect(errors.length).toBe(1);
+    expect(JSON.stringify(errors[0])).toContain("Failed to process action");
+  });
+});
+
+describe("dispatchApproveDenyAction — survives editMessage failure during error recovery", () => {
+  it("logs both the dispatch error and the editMessage failure", async () => {
+    // actions.approve throws → outer catch tries editMessage with the
+    // "Failed to process" markdown → editMessage ALSO throws. The
+    // handler should not propagate either; just log and return.
+    const editMessage = mock(() => Promise.reject(new Error("network blip")));
+    const { event } = makeEvent({
+      actionId: "atlas_action_approve",
+      adapter: { editMessage },
+    });
+    const { actions } = makeActions({
+      approve: mock(() => Promise.reject(new Error("DB exploded"))),
+    });
+    const { log, errors, warns } = makeLogger();
+
+    await expect(
+      dispatchApproveDenyAction(event, actions, log),
+    ).resolves.toBeUndefined();
+    expect(errors.length).toBe(1);
+    expect(JSON.stringify(errors[0])).toContain("Failed to process action");
+    expect(warns.length).toBe(1);
+    expect(JSON.stringify(warns[0])).toContain(
+      "Failed to edit message with action error",
+    );
+  });
+});

--- a/plugins/chat/src/bridge.ts
+++ b/plugins/chat/src/bridge.ts
@@ -28,6 +28,7 @@ import type { Adapter, StateAdapter, Lock, CardElement, FileUpload, Message, Str
 import { toModalElement } from "chat/jsx-runtime";
 import type { PluginLogger } from "@useatlas/plugin-sdk";
 import type {
+  ActionCallbacks,
   ChatAdapterName,
   ChatPluginConfig,
   ChatQueryResult,
@@ -437,6 +438,152 @@ export interface ChatBridge {
 /**
  * Create a Chat SDK bridge wired to Atlas callbacks.
  *
+/**
+ * Structural subset of the chat-sdk `ActionEvent` that the approve/deny
+ * dispatch path actually reads. Defined as a subset so tests can pass
+ * plain objects without constructing real chat-sdk event types.
+ */
+export interface ApproveDenyActionEvent {
+  readonly actionId: string;
+  readonly value?: string;
+  readonly user: { readonly userId: string };
+  readonly threadId: string;
+  readonly messageId: string;
+  readonly adapter: {
+    editMessage(
+      threadId: string,
+      messageId: string,
+      content: { markdown: string },
+    ): Promise<unknown>;
+  };
+}
+
+/**
+ * Dispatch an approve/deny button click. Extracted from the
+ * `chat.onAction([approve, deny], ...)` registration in
+ * `createChatBridge` so the dispatch behaviour can be unit-tested
+ * without standing up a real `Chat` instance (#2693).
+ *
+ * Actor identity is `chat-sdk:<userId>` — the chat-sdk's `event.user.userId`
+ * is platform-prefixed (`slack:U123`, `teams:abc`, …) so adding the
+ * `chat-sdk:` prefix here records the action came through the chat
+ * surface (vs the web UI's `web:<userId>` actor format used by
+ * action-routes elsewhere).
+ *
+ * Terminal states:
+ *   - Missing `event.value` (button rendered without an action ID): warn + return.
+ *   - `actions.get(actionId)` returns null: edit message with "no longer available" fallback.
+ *   - `actions.approve|deny(...)` returns null (already resolved): edit message with "already resolved" fallback.
+ *   - Success: edit message with `formatActionResult(...)` body.
+ *   - Thrown error in the try block: log + edit with a "failed to process" fallback. Both
+ *     the dispatch error AND a failure to edit the fallback are logged.
+ */
+export async function dispatchApproveDenyAction(
+  event: ApproveDenyActionEvent,
+  actions: ActionCallbacks,
+  log: PluginLogger,
+): Promise<void> {
+  const actionId = event.value;
+  const isApprove = event.actionId === "atlas_action_approve";
+  const userId = event.user.userId;
+
+  if (!actionId) {
+    log.warn({ actionId: event.actionId }, "Action event missing value");
+    return;
+  }
+
+  log.info(
+    { actionId, userId, action: isApprove ? "approve" : "deny" },
+    "Action button clicked",
+  );
+
+  try {
+    const actionEntry = await actions.get(actionId);
+    if (!actionEntry) {
+      log.warn({ actionId, userId }, "Action not found — may have expired");
+      try {
+        await event.adapter.editMessage(event.threadId, event.messageId, {
+          markdown: "This action is no longer available — it may have expired or already been resolved.",
+        });
+      } catch (editErr) {
+        log.warn(
+          { err: editErr instanceof Error ? editErr : new Error(String(editErr)), actionId },
+          "Failed to edit message for missing action",
+        );
+      }
+      return;
+    }
+
+    const pendingAction: PendingAction = {
+      id: actionEntry.id,
+      type: actionEntry.action_type,
+      target: actionEntry.target,
+      summary: actionEntry.summary,
+    };
+
+    if (isApprove) {
+      const result = await actions.approve(actionId, `chat-sdk:${userId}`);
+
+      if (!result) {
+        // Already resolved
+        log.warn({ actionId, userId }, "Action already resolved");
+        await event.adapter.editMessage(event.threadId, event.messageId, {
+          markdown: `${pendingAction.summary || pendingAction.type} — this action has already been resolved.`,
+        });
+        return;
+      }
+
+      const status =
+        result.status === "executed"
+          ? ("executed" as const)
+          : result.status === "failed"
+            ? ("failed" as const)
+            : ("approved" as const);
+      const resultText = formatActionResult(
+        pendingAction,
+        status,
+        result.error ?? undefined,
+      );
+      await event.adapter.editMessage(event.threadId, event.messageId, {
+        markdown: resultText,
+      });
+    } else {
+      const result = await actions.deny(actionId, `chat-sdk:${userId}`);
+
+      if (!result) {
+        log.warn({ actionId }, "Action already resolved when deny attempted");
+        await event.adapter.editMessage(event.threadId, event.messageId, {
+          markdown: `${pendingAction.summary || pendingAction.type} — this action has already been resolved.`,
+        });
+        return;
+      }
+
+      const resultText = formatActionResult(pendingAction, "denied");
+      await event.adapter.editMessage(event.threadId, event.messageId, {
+        markdown: resultText,
+      });
+    }
+  } catch (err) {
+    log.error(
+      { err: err instanceof Error ? err : new Error(String(err)), actionId },
+      "Failed to process action",
+    );
+
+    // Try to update the original message with an error
+    try {
+      await event.adapter.editMessage(event.threadId, event.messageId, {
+        markdown: `${chatEmoji.warning} Failed to process action. Please try again or use the web UI.`,
+      });
+    } catch (editErr) {
+      log.warn(
+        { err: editErr instanceof Error ? editErr : new Error(String(editErr)), actionId },
+        "Failed to edit message with action error",
+      );
+    }
+  }
+}
+
+/**
  * The bridge:
  * 1. Creates the Chat SDK instance from pre-built adapters
  * 2. Sets up onNewMention → lock + subscribe + executeQuery → thread.post
@@ -1412,115 +1559,13 @@ export function createChatBridge(
   });
 
   // --- onAction: approve/deny buttons ---
+  // Body extracted to `dispatchApproveDenyAction` (#2693) for unit
+  // testability — the chat-sdk's `event` is structurally compatible
+  // with `ApproveDenyActionEvent`, so the lambda is a thin pass-through.
   if (config.actions) {
     chat.onAction(
       ["atlas_action_approve", "atlas_action_deny"],
-      async (event) => {
-        const actionId = event.value;
-        const isApprove = event.actionId === "atlas_action_approve";
-        const userId = event.user.userId;
-
-        if (!actionId) {
-          log.warn({ actionId: event.actionId }, "Action event missing value");
-          return;
-        }
-
-        log.info(
-          { actionId, userId, action: isApprove ? "approve" : "deny" },
-          "Action button clicked",
-        );
-
-        try {
-          const actionEntry = await config.actions!.get(actionId);
-          if (!actionEntry) {
-            log.warn({ actionId, userId }, "Action not found — may have expired");
-            try {
-              await event.adapter.editMessage(event.threadId, event.messageId, {
-                markdown: "This action is no longer available — it may have expired or already been resolved.",
-              });
-            } catch (editErr) {
-              log.warn(
-                { err: editErr instanceof Error ? editErr : new Error(String(editErr)), actionId },
-                "Failed to edit message for missing action",
-              );
-            }
-            return;
-          }
-
-          const pendingAction: PendingAction = {
-            id: actionEntry.id,
-            type: actionEntry.action_type,
-            target: actionEntry.target,
-            summary: actionEntry.summary,
-          };
-
-          if (isApprove) {
-            const result = await config.actions!.approve(
-              actionId,
-              `chat-sdk:${userId}`,
-            );
-
-            if (!result) {
-              // Already resolved
-              log.warn({ actionId, userId }, "Action already resolved");
-              await event.adapter.editMessage(event.threadId, event.messageId, {
-                markdown: `${pendingAction.summary || pendingAction.type} — this action has already been resolved.`,
-              });
-              return;
-            }
-
-            const status =
-              result.status === "executed"
-                ? "executed" as const
-                : result.status === "failed"
-                  ? "failed" as const
-                  : "approved" as const;
-            const resultText = formatActionResult(
-              pendingAction,
-              status,
-              result.error ?? undefined,
-            );
-            await event.adapter.editMessage(event.threadId, event.messageId, {
-              markdown: resultText,
-            });
-          } else {
-            const result = await config.actions!.deny(
-              actionId,
-              `chat-sdk:${userId}`,
-            );
-
-            if (!result) {
-              log.warn({ actionId }, "Action already resolved when deny attempted");
-              await event.adapter.editMessage(event.threadId, event.messageId, {
-                markdown: `${pendingAction.summary || pendingAction.type} — this action has already been resolved.`,
-              });
-              return;
-            }
-
-            const resultText = formatActionResult(pendingAction, "denied");
-            await event.adapter.editMessage(event.threadId, event.messageId, {
-              markdown: resultText,
-            });
-          }
-        } catch (err) {
-          log.error(
-            { err: err instanceof Error ? err : new Error(String(err)), actionId },
-            "Failed to process action",
-          );
-
-          // Try to update the original message with an error
-          try {
-            await event.adapter.editMessage(event.threadId, event.messageId, {
-              markdown: `${chatEmoji.warning} Failed to process action. Please try again or use the web UI.`,
-            });
-          } catch (editErr) {
-            log.warn(
-              { err: editErr instanceof Error ? editErr : new Error(String(editErr)), actionId },
-              "Failed to edit message with action error",
-            );
-          }
-        }
-      },
+      async (event) => dispatchApproveDenyAction(event, config.actions!, log),
     );
   }
 

--- a/plugins/chat/src/bridge.ts
+++ b/plugins/chat/src/bridge.ts
@@ -436,9 +436,6 @@ export interface ChatBridge {
 }
 
 /**
- * Create a Chat SDK bridge wired to Atlas callbacks.
- *
-/**
  * Structural subset of the chat-sdk `ActionEvent` that the approve/deny
  * dispatch path actually reads. Defined as a subset so tests can pass
  * plain objects without constructing real chat-sdk event types.


### PR DESCRIPTION
## Summary

The chat-sdk's `Chat` class isn't trivially mockable without reproducing its full type surface. Extract the approve/deny handler body from the `chat.onAction(...)` lambda into a pure helper `dispatchApproveDenyAction` so tests can pass plain structurally-compatible event objects and assert dispatch behaviour directly.

- New exported helper `dispatchApproveDenyAction(event, actions, log)` accepts a structural `ApproveDenyActionEvent` subset (`actionId`, `value?`, `user.userId`, `threadId`, `messageId`, `adapter.editMessage`) — chat-sdk's `ActionEvent` is compatible at the call site, so runtime behaviour is identical.
- Inline `chat.onAction(["atlas_action_approve", "atlas_action_deny"], …)` lambda becomes a 1-line pass-through.
- New test file `bridge-actions.test.ts` with 9 cases covering: approve/deny happy paths (asserting the `chat-sdk:<userId>` actor format), missing `event.value`, `actions.get` null fallback, already-resolved fallback for both approve and deny, thrown-error fallback, and survives-editMessage-failure recovery.

## Note on issue AC scope

- **Gap 2 (OAuth route tests)** is moot — #2689 retired the chat-plugin's `/oauth/slack/{install,callback}` routes in favor of the canonical `/api/v1/integrations/slack/{install,callback}` surface, which already has coverage at `slack-oauth-handler.test.ts`.
- **Actor format**: the issue body referenced `slack:<userId>` but production uses `chat-sdk:<userId>` (settled during slice 5/6). Tests pin the production value.
- **Run Again / Export CSV handlers**: out of scope for this PR. The same extract-helper pattern applies; can be filed as a follow-up if there's demand.

## Test plan

- [x] `bun test src/bridge-actions.test.ts` (plugins/chat) — 9/9 pass, 45 expect() calls
- [x] Full `bun test` (plugins/chat) — 442/442 pass (no regressions in existing bridge.test.ts lifecycle tests)
- [x] `bun run type` — clean across the workspace
- [x] `bun run lint` — clean

Closes #2693