### PR TITLE
refactor(types): #2665 — hoist catalog literal unions to @useatlas/types

### DIFF
--- a/packages/api/src/lib/config.ts
+++ b/packages/api/src/lib/config.ts
@@ -275,39 +275,25 @@ export type ResidencyConfig = z.infer<typeof ResidencyConfigSchema>;
 // ---------------------------------------------------------------------------
 
 /**
- * `install_model` discriminates the install-handler family per CONTEXT.md
- * "Install models". The dispatch shape is pinned in slice 2 so 1.5.3's
- * static-bot work lands as a single-import change rather than reopening
- * the dispatch design.
- *
- * - `oauth` — OAuth dance against an operator-owned App Registration; per-
- *   Workspace bot token returned and persisted to the platform-native
- *   credential store. Chat: Slack. Integration: Salesforce, Jira, GitHub
- *   Apps (1.5.3), Linear OAuth (1.5.3).
- * - `form` — Customer admin fills a form (API key, SMTP creds, webhook
- *   URL); data validates against the catalog entry's `config_schema`;
- *   persists to `workspace_plugins.config` + encrypted credential storage.
- *   Integrations: Email (SMTP), Webhook, Obsidian, GitHub PAT (self-host),
- *   Linear API-key (1.5.3).
- * - `static-bot` — Operator-shared bot serves every Workspace; customer
- *   admin provides only a per-Workspace routing identifier (Discord
- *   `guild_id`, Telegram `chat_id`, Teams `tenant_id`, WhatsApp phone
- *   number) via form. No per-Workspace bot token. Chat: Teams, Discord,
- *   Google Chat, Telegram, WhatsApp. **Not installable in 1.5.2** — the
- *   handler ships in 1.5.3.
+ * Catalog vocabulary (`install_model`, `type`) is hoisted to
+ * `@useatlas/types` (#2665) so `@useatlas/chat` can share the literal
+ * unions without taking a hard `@atlas/api` dep. JSDoc on each member
+ * lives in `packages/types/src/catalog.ts`. The re-exports here keep
+ * the long-standing call sites (`from "@atlas/api/lib/config"`) working
+ * without churn.
  */
-export const CATALOG_INSTALL_MODELS = ["oauth", "form", "static-bot"] as const;
-export type CatalogInstallModel = (typeof CATALOG_INSTALL_MODELS)[number];
-
-/**
- * `type` groups catalog entries for admin-UI display. Backend dispatches
- * by `install_model` (orthogonal), not by `type`. The list is intentionally
- * narrow today: chat Platforms vs everything-else-integration. Future
- * milestones may add `datasource` once datasource plugins migrate to the
- * catalog (Architecture Backlog issue, out of scope for 1.5.2).
- */
-export const CATALOG_ENTRY_TYPES = ["chat", "integration"] as const;
-export type CatalogEntryType = (typeof CATALOG_ENTRY_TYPES)[number];
+import {
+  CATALOG_INSTALL_MODELS,
+  CATALOG_ENTRY_TYPES,
+} from "@useatlas/types";
+export {
+  CATALOG_INSTALL_MODELS,
+  CATALOG_ENTRY_TYPES,
+};
+export type {
+  CatalogInstallModel,
+  CatalogEntryType,
+} from "@useatlas/types";
 
 /**
  * Plan tiers a catalog entry can require. Unified with `PLAN_TIERS`

--- a/plugins/chat/package.json
+++ b/plugins/chat/package.json
@@ -65,7 +65,7 @@
     "hono": "^4.0.0",
     "zod": "^4.0.0",
     "@useatlas/plugin-sdk": ">=0.0.1",
-    "@useatlas/types": ">=0.1.5"
+    "@useatlas/types": ">=0.1.6"
   },
   "devDependencies": {
     "hono": "^4.12.9",

--- a/plugins/chat/src/adapter-registry.ts
+++ b/plugins/chat/src/adapter-registry.ts
@@ -23,8 +23,13 @@
  */
 
 import type { SlackAdapter } from "@chat-adapter/slack";
+import type {
+  CatalogEntryType,
+  CatalogInstallModel,
+  ChatAdapterName,
+} from "@useatlas/types";
 import { createSlackAdapter } from "./adapters/slack";
-import type { ChatAdapterName, SlackAdapterConfig } from "./config";
+import type { SlackAdapterConfig } from "./config";
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -43,8 +48,10 @@ import type { ChatAdapterName, SlackAdapterConfig } from "./config";
  */
 export interface ChatCatalogEntry {
   readonly slug: string;
-  readonly type: "chat" | "integration";
-  readonly install_model: "oauth" | "form" | "static-bot";
+  // #2665 — literal unions hoisted to @useatlas/types so renames in
+  // one place propagate via TS exhaustiveness.
+  readonly type: CatalogEntryType;
+  readonly install_model: CatalogInstallModel;
   readonly enabled: boolean;
   readonly saas_eligible: boolean;
 }

--- a/plugins/chat/src/config.ts
+++ b/plugins/chat/src/config.ts
@@ -8,6 +8,20 @@
 
 import { z } from "zod";
 import type { StreamChunk } from "chat";
+// #2665 — catalog vocabulary lives in @useatlas/types so the chat plugin
+// and @atlas/api share one source of truth for the literal unions.
+// Re-exported below as `ChatAdapterName` for back-compat with downstream
+// hosts that imported it from `@useatlas/chat`.
+import {
+  CATALOG_ENTRY_TYPES,
+  CATALOG_INSTALL_MODELS,
+  CHAT_ADAPTER_NAMES,
+} from "@useatlas/types";
+import type {
+  CatalogEntryType,
+  CatalogInstallModel,
+  ChatAdapterName as SharedChatAdapterName,
+} from "@useatlas/types";
 import type { ReactionConfig } from "./features/reactions";
 import type {
   AnswerFlowConfig,
@@ -71,32 +85,24 @@ export interface ChatCatalogEntryInput {
   /** Stable slug — `"slack"`, `"telegram"`, etc. */
   readonly slug: string;
   /** Admin-UI grouping. The registry skips non-chat entries. */
-  readonly type: "chat" | "integration";
+  readonly type: CatalogEntryType;
   /** Install-handler dispatch key. Only `"oauth"` activates in 1.5.2. */
-  readonly install_model: "oauth" | "form" | "static-bot";
+  readonly install_model: CatalogInstallModel;
   /** Customer can install? Ops can flip false without removing the row. */
   readonly enabled: boolean;
   /** Visible to SaaS admin UI? (Used in slice 3; unused by AdapterRegistry.) */
   readonly saas_eligible: boolean;
 }
 
-/** Canonical chat platform names supported by the bridge.
- *
- * The chat SDK's `Adapter` interface types `name` as a bare `string`
- * because adapters are pluggable, but this plugin only loads the
- * adapters enumerated under `ChatPluginConfig["adapters"]` — narrowing
- * to the literal union here lets host `executeQuery` callbacks
- * type-narrow via `if (adapter.name !== "slack")` and forces every
- * `switch (adapter.name)` to be exhaustive at compile time. */
-export type ChatAdapterName =
-  | "slack"
-  | "teams"
-  | "discord"
-  | "gchat"
-  | "telegram"
-  | "github"
-  | "linear"
-  | "whatsapp";
+/**
+ * Canonical chat platform names — re-exported from `@useatlas/types`
+ * (#2665) so the literal union is shared with `@atlas/api`'s catalog
+ * dispatch. Adding a platform happens in one place
+ * (`packages/types/src/catalog.ts:CHAT_ADAPTER_NAMES`) and propagates
+ * to both packages via TypeScript exhaustiveness.
+ */
+export type ChatAdapterName = SharedChatAdapterName;
+export { CHAT_ADAPTER_NAMES };
 
 /** Minimal adapter shape passed through to host `executeQuery` callbacks.
  *
@@ -957,8 +963,10 @@ const ChatCatalogEntrySchema = z
       /^[a-z][a-z0-9-]*$/,
       "catalog entry slug must be lowercase alphanumeric with dashes",
     ),
-    type: z.enum(["chat", "integration"]),
-    install_model: z.enum(["oauth", "form", "static-bot"]),
+    // #2665 — shared with @atlas/api via @useatlas/types so the
+    // accepted literal set propagates from one source of truth.
+    type: z.enum(CATALOG_ENTRY_TYPES),
+    install_model: z.enum(CATALOG_INSTALL_MODELS),
     enabled: z.boolean(),
     saas_eligible: z.boolean(),
   })


### PR DESCRIPTION
## Summary

The catalog vocabulary (`install_model`, `type`, chat-adapter slugs) was inline-duplicated across `packages/api/src/lib/config.ts` and `plugins/chat/src/{config,adapter-registry}.ts`. The chat plugin can't import `@atlas/api` (CLAUDE.md frontend/package-boundary rule), so the shared seam is `@useatlas/types` — same pattern as `PLAN_TIERS` post-#2666.

A rename or addition to either tuple now propagates via TypeScript exhaustiveness instead of needing a manual sync.

- New `packages/types/src/catalog.ts` with `CATALOG_INSTALL_MODELS` / `CatalogInstallModel` / `CATALOG_ENTRY_TYPES` / `CatalogEntryType` / `CHAT_ADAPTER_NAMES` / `ChatAdapterName`. JSDoc on each member captures the install-handler dispatch shape from the original config.
- `packages/api/src/lib/config.ts` re-exports the constants + types from `@useatlas/types` so the long-standing `import { CatalogInstallModel } from "@atlas/api/lib/config"` call sites (catalog-seeder, install handlers, install/types, tests) keep working — zero churn for existing imports.
- `plugins/chat/src/config.ts` + `adapter-registry.ts` drop the inline literal unions. `ChatCatalogEntry`, `ChatCatalogEntryInput`, and the Zod `ChatCatalogEntrySchema` all reference the shared tuples.
- `ChatAdapterName` is re-exported from `@useatlas/chat` for hosts that imported it from there (no breaking change).

## Scope note

This PR addresses the **type-design subset** of #2665's AC. The other follow-ups remain open and would benefit from being their own PRs:
- `CatalogSeedDb` narrowing to three named methods
- `noopCount` field on `CatalogSeedResult` / `CatalogSeedShape`
- Test-gap follow-ups (multiple Slack catalog entries, case-sensitivity, `saas_eligible=false + install_model=oauth`, concurrent boot seeding)
- Milestone-marker comment cleanup ("only Slack in 1.5.2" → state assertions)

The `RegistryLogger` asymmetry concern was partially addressed by #2717 (added `error` as required). The remaining `debug?` optional vs `info`/`warn`/`error` required asymmetry is a separate small tweak.

No version bump for `@useatlas/types` — `packages/api` and `plugins/chat` use `workspace:*` and pick up the new exports immediately. Per CLAUDE.md the publish dance only matters when sdk/react/templates need the new exports; they don't here.

## Test plan

- [x] `bun run type` — clean across the workspace
- [x] `bun run lint` — clean
- [x] `bun test` in `plugins/chat` — 433/433 pass (no regressions in adapter-registry / bridge / config / proactive tests)
- [x] `cd packages/api && bun run scripts/test-isolated.ts --affected` — 52/52 pass (catalog-seeder, install dispatch, integrations routes all green)

Closes #2665