### PR TITLE
feat(types): hoist catalog literal unions — 0.1.6 (#2665 prep)

### DIFF
--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@useatlas/types",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Shared types for the Atlas text-to-SQL agent",
   "type": "module",
   "scripts": {
-    "build": "rm -rf dist && bun build src/index.ts src/auth.ts src/conversation.ts src/connection.ts src/action.ts src/scheduled-task.ts src/errors.ts src/semantic.ts src/share.ts src/billing.ts src/dashboard.ts src/mode.ts src/starter-prompt.ts src/integrations.ts src/email-provider.ts src/mcp.ts src/preferences.ts src/execute-sql.ts src/proactive.ts --outdir dist --root src --target node --packages external && bun x tsc -p tsconfig.build.json",
+    "build": "rm -rf dist && bun build src/index.ts src/auth.ts src/conversation.ts src/connection.ts src/action.ts src/scheduled-task.ts src/errors.ts src/semantic.ts src/share.ts src/billing.ts src/dashboard.ts src/mode.ts src/starter-prompt.ts src/integrations.ts src/email-provider.ts src/mcp.ts src/preferences.ts src/execute-sql.ts src/proactive.ts src/catalog.ts --outdir dist --root src --target node --packages external && bun x tsc -p tsconfig.build.json",
     "prepare": "bun run build"
   },
   "exports": {
@@ -102,6 +102,11 @@
       "types": "./dist/proactive.d.ts",
       "import": "./dist/proactive.js",
       "default": "./dist/proactive.js"
+    },
+    "./catalog": {
+      "types": "./dist/catalog.d.ts",
+      "import": "./dist/catalog.js",
+      "default": "./dist/catalog.js"
     }
   },
   "main": "./dist/index.js",

--- a/packages/types/src/catalog.ts
+++ b/packages/types/src/catalog.ts
@@ -1,0 +1,83 @@
+/**
+ * Plugin catalog vocabulary — shared by `@atlas/api` (canonical owner of the
+ * `plugin_catalog` schema + Zod validation) and `@useatlas/chat` (consumes
+ * the catalog at boot to decide which chat adapters to instantiate).
+ *
+ * Pre-#2665 the literal unions were inline-duplicated in `plugins/chat/src/`
+ * because the chat plugin can't import `@atlas/api` (CLAUDE.md
+ * "Frontend is a pure HTTP client" — same package boundary). The same
+ * concern applies to plugin packages, so the shared seam is `@useatlas/types`.
+ *
+ * A rename or addition to either tuple is now a single edit propagating
+ * through both packages via TypeScript's literal-union exhaustiveness checks.
+ */
+
+// ---------------------------------------------------------------------------
+// install_model — install-handler dispatch key
+// ---------------------------------------------------------------------------
+
+/**
+ * Install handlers a catalog entry can dispatch to. Determines which UI
+ * flow the customer admin sees on `/admin/integrations`:
+ *
+ * - `oauth` — Customer admin clicks Connect → operator-owned App Registration
+ *   OAuth dance → bot token persists to per-Workspace encrypted credential
+ *   store. Chat: Slack. Integration: Salesforce, Jira, GitHub Apps (1.5.3),
+ *   Linear OAuth (1.5.3).
+ * - `form` — Customer admin fills a form (API key, SMTP creds, webhook
+ *   URL); validates against the catalog entry's `config_schema`; persists
+ *   to `workspace_plugins.config` + encrypted credential storage.
+ *   Integrations: Email (SMTP), Webhook, Obsidian, GitHub PAT (self-host),
+ *   Linear API-key (1.5.3).
+ * - `static-bot` — Operator-shared bot serves every Workspace; customer
+ *   admin provides only a per-Workspace routing identifier (Discord
+ *   `guild_id`, Telegram `chat_id`, Teams `tenant_id`, WhatsApp phone
+ *   number) via form. No per-Workspace bot token. Chat: Teams, Discord,
+ *   Google Chat, Telegram, WhatsApp.
+ */
+export const CATALOG_INSTALL_MODELS = ["oauth", "form", "static-bot"] as const;
+export type CatalogInstallModel = (typeof CATALOG_INSTALL_MODELS)[number];
+
+// ---------------------------------------------------------------------------
+// type — admin-UI grouping
+// ---------------------------------------------------------------------------
+
+/**
+ * `type` groups catalog entries for admin-UI display. Backend dispatches
+ * by `install_model` (orthogonal), not by `type`. Future milestones may
+ * add `datasource` once datasource plugins migrate to the catalog
+ * (Architecture Backlog).
+ */
+export const CATALOG_ENTRY_TYPES = ["chat", "integration"] as const;
+export type CatalogEntryType = (typeof CATALOG_ENTRY_TYPES)[number];
+
+// ---------------------------------------------------------------------------
+// Chat adapter names
+// ---------------------------------------------------------------------------
+
+/**
+ * Canonical chat platform names supported by `@useatlas/chat`. The chat
+ * SDK's `Adapter` interface types `name` as a bare `string` because
+ * adapters are pluggable, but Atlas only loads the platforms enumerated
+ * here — narrowing to the literal union lets host `executeQuery`
+ * callbacks type-narrow via `if (adapter.name !== "slack")` and forces
+ * every `switch (adapter.name)` to be exhaustive at compile time.
+ *
+ * The runtime tuple `CHAT_ADAPTER_NAMES` is the source of truth — the
+ * `ChatAdapterName` literal union is derived from it via
+ * `(typeof CHAT_ADAPTER_NAMES)[number]`, and `plugins/chat`'s Zod
+ * schema (`z.enum(CHAT_ADAPTER_NAMES)`) validates catalog input against
+ * the same set. Extend the tuple and both the type and runtime
+ * validation update together.
+ */
+export const CHAT_ADAPTER_NAMES = [
+  "slack",
+  "teams",
+  "discord",
+  "gchat",
+  "telegram",
+  "github",
+  "linear",
+  "whatsapp",
+] as const;
+export type ChatAdapterName = (typeof CHAT_ADAPTER_NAMES)[number];

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -37,3 +37,4 @@ export * from "./security";
 export * from "./preferences";
 export * from "./execute-sql";
 export * from "./proactive";
+export * from "./catalog";


### PR DESCRIPTION
## Summary

Publish-first split of #2723 to dodge the documented `@useatlas/types` **scaffold gotcha** (CLAUDE.md). Ships *only* the new `packages/types/src/catalog.ts` module + version bump. Zero consumer changes — `@atlas/api` and `plugins/chat` keep inlining the literals. #2723 then rebases on main and swaps them over once 0.1.6 is published to npm.

## What lands

- `packages/types/src/catalog.ts` — `CATALOG_INSTALL_MODELS` / `CATALOG_ENTRY_TYPES` / `CHAT_ADAPTER_NAMES` runtime tuples plus the derived `CatalogInstallModel` / `CatalogEntryType` / `ChatAdapterName` literal unions. JSDoc on each member captures the install-handler dispatch shape.
- `packages/types/src/index.ts` — re-export from the package barrel.
- `packages/types/package.json` — version 0.1.5 → 0.1.6, add `src/catalog.ts` to the `bun build` entry list, add the `./catalog` subpath export.

## Why a split

The scaffold smoke tests (Scaffold (docker) / Scaffold (vercel)) install `@useatlas/types` from npm and then build the template, whose `src/lib/config.ts` is generated from `packages/api/src/lib/config.ts` by `prepare-templates.sh`. The moment #2723 swaps its config.ts imports to `@useatlas/types`, that template build runs against the *currently-published* version, which doesn't have the new exports → scaffold fails. CLAUDE.md documents this exact pattern; prior precedents are #2325 and #2546 (commit msg explicitly cites "the @useatlas/types scaffold gotcha documented in CLAUDE.md").

## Post-merge

1. Tag and push:
   ```
   git tag types-v0.1.6 && git push origin types-v0.1.6
   ```
2. Wait for the `Publish Atlas npm packages` workflow to finish → 0.1.6 hits npm.
3. Rebase #2723 on main → its scaffold pulls 0.1.6 from npm → passes.
4. Merge #2723.

## Test plan

- [x] `cd packages/types && bun run build` — emits `dist/catalog.js` + `dist/catalog.d.ts` and re-exports the three runtime tuples from the bundle barrel
- [x] `bun run type` — clean (no consumer churn so nothing else to type-check)
- [x] `bun run lint` — clean