### PR TITLE
feat(api): #2739 — workspace_plugins + plugin_catalog three-pillar schema

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -343,7 +343,7 @@
     },
     "packages/types": {
       "name": "@useatlas/types",
-      "version": "0.1.5",
+      "version": "0.1.6",
     },
     "packages/web": {
       "name": "@atlas/web",
@@ -456,7 +456,7 @@
       },
       "peerDependencies": {
         "@useatlas/plugin-sdk": ">=0.0.1",
-        "@useatlas/types": ">=0.1.5",
+        "@useatlas/types": ">=0.1.6",
         "hono": "^4.0.0",
         "zod": "^4.0.0",
       },

--- a/packages/api/src/lib/auth/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/auth/__tests__/migrate.test.ts
@@ -337,6 +337,7 @@ describe("migrateAuthTables", () => {
             { name: "0089_integration_credentials.sql" },
             { name: "0090_organization_is_operator_workspace.sql" },
             { name: "0091_unify_catalog_min_plan.sql" },
+            { name: "0092_pillar_install_id_columns.sql" },
           ],
         };
       }

--- a/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
@@ -4582,20 +4582,26 @@ describeIfPg("migrate-pg (real Postgres)", () => {
 
   // 0092 / #2739 — three-pillar taxonomy + install_id foundation.
   // Schema-only slice: callers under integrations/install/*-handler.ts
-  // continue to omit `pillar` and `install_id`; the BEFORE INSERT
-  // trigger fills them in. These tests pin the trigger behavior + the
-  // new constraints so a future "tidying" revision that drops them
-  // surfaces here rather than at the next handler INSERT.
+  // continue to omit `pillar` and `install_id`; two BEFORE INSERT
+  // triggers fill them in. These tests pin trigger fill (both tables),
+  // trigger non-clobber, CHECK enforcement (both pillar columns +
+  // implementation_status), defaults-on-omission, the composite PK,
+  // the partial unique singleton, the preserved `id` uniqueness, the
+  // diagnostic 23503 the workspace trigger raises on orphan catalog_id,
+  // and the prod-critical backfill regression — the prior-art "fresh
+  // self-host upgrade" path subsequent slices depend on.
   describe("0092: pillar + install_id columns (#2739, 1.5.3 slice 1)", () => {
-    it("plugin_catalog: pillar + implementation_status + auto_install columns exist and CHECK is enforced", async () => {
+    it("plugin_catalog: new columns + CHECK constraints are enforced (pillar, implementation_status)", async () => {
       const slug = `pg-0092-${Date.now()}`;
       const id = `cat-${slug}`;
 
-      // Happy path: insert an integration row, get backfilled `action` pillar
-      // and the documented defaults for the other two columns.
+      // Insert with all three new columns explicit — exercises that the
+      // columns exist with the documented types and that explicit values
+      // round-trip (no SELECT pillar/implementation_status/auto_install
+      // semantics happen in production code yet — slice 3+ wire reads).
       await pool.query(
-        `INSERT INTO plugin_catalog (id, name, slug, type, pillar)
-         VALUES ($1, '0092 Smoke', $2, 'integration', 'action')`,
+        `INSERT INTO plugin_catalog (id, name, slug, type, pillar, implementation_status, auto_install)
+         VALUES ($1, '0092 Smoke', $2, 'integration', 'action', 'available', false)`,
         [id, slug],
       );
 
@@ -4628,6 +4634,82 @@ describeIfPg("migrate-pg (real Postgres)", () => {
           [`${id}-bad-status`, `${slug}-bad-status`],
         ),
       ).rejects.toMatchObject({ code: "23514" });
+    }, PG_TEST_TIMEOUT_MS);
+
+    it("plugin_catalog: trigger derives pillar from type (chat/datasource/integration) when caller omits pillar", async () => {
+      // Three call sites today (admin-marketplace.ts, catalog-seeder.ts,
+      // migration 0088) INSERT plugin_catalog rows without naming
+      // pillar. Trigger must map type → pillar correctly for each.
+      const slug = `pg-0092-cat-trig-${Date.now()}`;
+
+      type Row = { pillar: string };
+      const cases: Array<{ type: string; expected: string }> = [
+        { type: "chat", expected: "chat" },
+        { type: "datasource", expected: "datasource" },
+        { type: "integration", expected: "action" },
+        { type: "action", expected: "action" },
+      ];
+
+      for (const { type, expected } of cases) {
+        const id = `cat-${slug}-${type}`;
+        await pool.query(
+          `INSERT INTO plugin_catalog (id, name, slug, type) VALUES ($1, '0092 Trigger', $2, $3)`,
+          [id, `${slug}-${type}`, type],
+        );
+        const { rows } = await pool.query<Row>(
+          `SELECT pillar FROM plugin_catalog WHERE id = $1`,
+          [id],
+        );
+        expect(rows[0]?.pillar).toBe(expected);
+      }
+    }, PG_TEST_TIMEOUT_MS);
+
+    it("plugin_catalog: trigger does NOT clobber caller-provided pillar", async () => {
+      // Load-bearing for slice 5 (#2743): once built-in Datasource
+      // catalog rows are seeded with explicit pillar, a future
+      // "simplification" that drops the `IF NEW.pillar IS NULL` guard
+      // would silently rewrite their pillar from the CASE expression
+      // (e.g. a `type='datasource', pillar='datasource'` row stays at
+      // datasource — but a future `type='custom', pillar='chat'` row
+      // would silently get rewritten to 'action').
+      const slug = `pg-0092-cat-noclobber-${Date.now()}`;
+      const id = `cat-${slug}`;
+      // type='datasource' would auto-derive pillar='datasource'; we
+      // pass pillar='chat' explicitly to prove the guard holds even
+      // when the CASE would produce a different value.
+      await pool.query(
+        `INSERT INTO plugin_catalog (id, name, slug, type, pillar)
+         VALUES ($1, '0092 No-Clobber', $2, 'datasource', 'chat')`,
+        [id, slug],
+      );
+      const { rows } = await pool.query<{ pillar: string }>(
+        `SELECT pillar FROM plugin_catalog WHERE id = $1`,
+        [id],
+      );
+      expect(rows[0]?.pillar).toBe("chat");
+    }, PG_TEST_TIMEOUT_MS);
+
+    it("plugin_catalog: implementation_status + auto_install defaults apply on omission", async () => {
+      // Pinned by silent-failure review on #2756 — guards the
+      // `DEFAULT 'available'` / `DEFAULT false` clauses against a
+      // future revision that drops them. Without defaults, a row that
+      // omits the columns lands NULL, which fails the
+      // implementation_status CHECK (23514).
+      const slug = `pg-0092-cat-defaults-${Date.now()}`;
+      const id = `cat-${slug}`;
+      await pool.query(
+        `INSERT INTO plugin_catalog (id, name, slug, type) VALUES ($1, '0092 Defaults', $2, 'integration')`,
+        [id, slug],
+      );
+      const { rows } = await pool.query<{
+        implementation_status: string;
+        auto_install: boolean;
+      }>(
+        `SELECT implementation_status, auto_install FROM plugin_catalog WHERE id = $1`,
+        [id],
+      );
+      expect(rows[0]?.implementation_status).toBe("available");
+      expect(rows[0]?.auto_install).toBe(false);
     }, PG_TEST_TIMEOUT_MS);
 
     it("workspace_plugins: BEFORE INSERT trigger fills install_id + pillar when caller omits them", async () => {
@@ -4748,6 +4830,184 @@ describeIfPg("migrate-pg (real Postgres)", () => {
           [sharedId, `ws-${slug}`, catalogIdB],
         ),
       ).rejects.toMatchObject({ code: "23505" });
+    }, PG_TEST_TIMEOUT_MS);
+
+    it("workspace_plugins: trigger does NOT clobber caller-provided install_id + pillar", async () => {
+      // Slice 4 (WorkspaceInstaller, #2742) will explicitly name both
+      // columns. The `IF NEW.x IS NULL` guards are load-bearing then —
+      // a "simplification" that drops them would silently rewrite the
+      // explicit values from the catalog lookup / sentinel.
+      const slug = `pg-0092-wp-noclobber-${Date.now()}`;
+      const catalogId = `cat-${slug}`;
+      await pool.query(
+        `INSERT INTO plugin_catalog (id, name, slug, type, pillar)
+         VALUES ($1, '0092 No-Clobber', $2, 'integration', 'action')`,
+        [catalogId, slug],
+      );
+
+      const explicitInstallId = `prod-us-${slug}`;
+      const workspaceId = `ws-${slug}`;
+      // Caller passes pillar='datasource' even though catalog says
+      // 'action' — proves the trigger doesn't second-guess explicit
+      // values via its catalog SELECT.
+      await pool.query(
+        `INSERT INTO workspace_plugins (id, workspace_id, catalog_id, install_id, pillar, config, enabled, installed_at)
+         VALUES ($1, $2, $3, $4, 'datasource', '{}'::jsonb, true, NOW())`,
+        [`wp-${slug}`, workspaceId, catalogId, explicitInstallId],
+      );
+
+      const { rows } = await pool.query<{ install_id: string; pillar: string }>(
+        `SELECT install_id, pillar FROM workspace_plugins WHERE workspace_id = $1 AND catalog_id = $2`,
+        [workspaceId, catalogId],
+      );
+      expect(rows[0]?.install_id).toBe(explicitInstallId);
+      expect(rows[0]?.pillar).toBe("datasource");
+    }, PG_TEST_TIMEOUT_MS);
+
+    it("workspace_plugins: chk_workspace_plugins_pillar rejects unknown pillar with 23514", async () => {
+      // Separate constraint from `chk_plugin_catalog_pillar` — a
+      // missing `ADD CONSTRAINT chk_workspace_plugins_pillar` in the
+      // migration would only surface on the catalog side without this
+      // test.
+      const slug = `pg-0092-wp-check-${Date.now()}`;
+      const catalogId = `cat-${slug}`;
+      await pool.query(
+        `INSERT INTO plugin_catalog (id, name, slug, type, pillar)
+         VALUES ($1, '0092 Pillar Check', $2, 'integration', 'action')`,
+        [catalogId, slug],
+      );
+      await expect(
+        pool.query(
+          `INSERT INTO workspace_plugins (id, workspace_id, catalog_id, install_id, pillar, config, enabled, installed_at)
+           VALUES ($1, $2, $3, $4, 'something-else', '{}'::jsonb, true, NOW())`,
+          [`wp-${slug}`, `ws-${slug}`, catalogId, `inst-${slug}`],
+        ),
+      ).rejects.toMatchObject({ code: "23514" });
+    }, PG_TEST_TIMEOUT_MS);
+
+    it("workspace_plugins: backfill UPDATEs assign sentinel install_id + joined pillar for pre-existing NULL rows", async () => {
+      // Prod-critical regression: a self-host upgrade with live rows
+      // walks through ADD COLUMN (NULL on existing rows) → UPDATE
+      // backfill → SET NOT NULL. The full migration has already run
+      // in beforeAll, so we simulate the pre-backfill state inside a
+      // transaction: drop the NOT NULLs, disable the trigger so we
+      // can insert NULLs, replay the migration's UPDATE statements,
+      // assert. Postgres DDL is transactional — ROLLBACK reverts every
+      // change so subsequent tests see the unchanged shape.
+      const slug = `pg-0092-backfill-${Date.now()}`;
+      const catalogId = `cat-${slug}`;
+      const workspaceId = `ws-${slug}`;
+      const installRowId = `wp-${slug}`;
+
+      const client = await pool.connect();
+      try {
+        await client.query("BEGIN");
+        // Mimic the post-ADD-COLUMN, pre-UPDATE state of the live
+        // migration:
+        //   1. Drop the composite PK so install_id can lose its
+        //      implicit NOT NULL (PK columns can't be nullable).
+        //   2. Drop the explicit NOT NULLs on pillar + install_id.
+        //   3. Disable the BEFORE INSERT triggers so we can stage
+        //      NULL rows.
+        // Postgres DDL is transactional — ROLLBACK reverts every
+        // change so subsequent tests see the unchanged shape.
+        await client.query(
+          `ALTER TABLE workspace_plugins DROP CONSTRAINT workspace_plugins_pkey`,
+        );
+        await client.query(
+          `ALTER TABLE plugin_catalog ALTER COLUMN pillar DROP NOT NULL`,
+        );
+        await client.query(
+          `ALTER TABLE workspace_plugins ALTER COLUMN pillar DROP NOT NULL`,
+        );
+        await client.query(
+          `ALTER TABLE workspace_plugins ALTER COLUMN install_id DROP NOT NULL`,
+        );
+        await client.query(
+          `ALTER TABLE plugin_catalog DISABLE TRIGGER trg_plugin_catalog_default_pillar`,
+        );
+        await client.query(
+          `ALTER TABLE workspace_plugins DISABLE TRIGGER trg_workspace_plugins_default_pillar_install_id`,
+        );
+
+        await client.query(
+          `INSERT INTO plugin_catalog (id, name, slug, type, pillar)
+           VALUES ($1, '0092 Backfill', $2, 'chat', NULL)`,
+          [catalogId, slug],
+        );
+        await client.query(
+          `INSERT INTO workspace_plugins (id, workspace_id, catalog_id, install_id, pillar, config, enabled, installed_at)
+           VALUES ($1, $2, $3, NULL, NULL, '{}'::jsonb, true, NOW())`,
+          [installRowId, workspaceId, catalogId],
+        );
+
+        // Replay the migration's backfill — three plugin_catalog
+        // UPDATEs, then the workspace_plugins UPDATE that sets
+        // install_id = catalog_id sentinel, then the join that sets
+        // workspace_plugins.pillar from the now-populated catalog.
+        await client.query(
+          `UPDATE plugin_catalog SET pillar = 'chat'       WHERE pillar IS NULL AND type = 'chat'`,
+        );
+        await client.query(
+          `UPDATE plugin_catalog SET pillar = 'datasource' WHERE pillar IS NULL AND type = 'datasource'`,
+        );
+        await client.query(
+          `UPDATE plugin_catalog SET pillar = 'action'     WHERE pillar IS NULL`,
+        );
+        await client.query(
+          `UPDATE workspace_plugins SET install_id = catalog_id WHERE install_id IS NULL`,
+        );
+        await client.query(
+          `UPDATE workspace_plugins wp SET pillar = pc.pillar FROM plugin_catalog pc WHERE pc.id = wp.catalog_id AND wp.pillar IS NULL`,
+        );
+
+        const { rows } = await client.query<{
+          install_id: string;
+          pillar: string;
+        }>(
+          `SELECT install_id, pillar FROM workspace_plugins WHERE id = $1`,
+          [installRowId],
+        );
+        expect(rows[0]?.install_id).toBe(catalogId);
+        expect(rows[0]?.pillar).toBe("chat");
+
+        const { rows: catRows } = await client.query<{ pillar: string }>(
+          `SELECT pillar FROM plugin_catalog WHERE id = $1`,
+          [catalogId],
+        );
+        expect(catRows[0]?.pillar).toBe("chat");
+      } finally {
+        await client.query("ROLLBACK");
+        client.release();
+      }
+    }, PG_TEST_TIMEOUT_MS);
+
+    it("workspace_plugins: orphan catalog_id surfaces 23503 from the trigger, not 23502 from NOT NULL", async () => {
+      // The trigger raises a FK-style 23503 with a diagnostic message
+      // naming the missing catalog_id, instead of letting the row fall
+      // through to a confusing `NULL value in column "pillar"` NOT NULL
+      // violation. The real FK normally prevents this path; the trigger
+      // is a belt-and-braces diagnostic. To exercise it we drop the FK
+      // inside a transaction and roll back — works without superuser
+      // (unlike SET session_replication_role).
+      const slug = `pg-0092-orphan-${Date.now()}`;
+      const client = await pool.connect();
+      try {
+        await client.query("BEGIN");
+        await client.query(
+          `ALTER TABLE workspace_plugins DROP CONSTRAINT workspace_plugins_catalog_id_fkey`,
+        );
+        await expect(
+          client.query(
+            `INSERT INTO workspace_plugins (id, workspace_id, catalog_id, config, enabled, installed_at)
+             VALUES ($1, $2, $3, '{}'::jsonb, true, NOW())`,
+            [`wp-${slug}`, `ws-${slug}`, `does-not-exist-${slug}`],
+          ),
+        ).rejects.toMatchObject({ code: "23503" });
+      } finally {
+        await client.query("ROLLBACK");
+        client.release();
+      }
     }, PG_TEST_TIMEOUT_MS);
   });
 });

--- a/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
@@ -4579,6 +4579,177 @@ describeIfPg("migrate-pg (real Postgres)", () => {
       expect(after.rows[0]?.n).toBe("0");
     }, PG_TEST_TIMEOUT_MS);
   });
+
+  // 0092 / #2739 — three-pillar taxonomy + install_id foundation.
+  // Schema-only slice: callers under integrations/install/*-handler.ts
+  // continue to omit `pillar` and `install_id`; the BEFORE INSERT
+  // trigger fills them in. These tests pin the trigger behavior + the
+  // new constraints so a future "tidying" revision that drops them
+  // surfaces here rather than at the next handler INSERT.
+  describe("0092: pillar + install_id columns (#2739, 1.5.3 slice 1)", () => {
+    it("plugin_catalog: pillar + implementation_status + auto_install columns exist and CHECK is enforced", async () => {
+      const slug = `pg-0092-${Date.now()}`;
+      const id = `cat-${slug}`;
+
+      // Happy path: insert an integration row, get backfilled `action` pillar
+      // and the documented defaults for the other two columns.
+      await pool.query(
+        `INSERT INTO plugin_catalog (id, name, slug, type, pillar)
+         VALUES ($1, '0092 Smoke', $2, 'integration', 'action')`,
+        [id, slug],
+      );
+
+      const { rows } = await pool.query<{
+        pillar: string;
+        implementation_status: string;
+        auto_install: boolean;
+      }>(
+        `SELECT pillar, implementation_status, auto_install FROM plugin_catalog WHERE id = $1`,
+        [id],
+      );
+      expect(rows[0]?.pillar).toBe("action");
+      expect(rows[0]?.implementation_status).toBe("available");
+      expect(rows[0]?.auto_install).toBe(false);
+
+      // CHECK rejects unknown pillar with 23514.
+      await expect(
+        pool.query(
+          `INSERT INTO plugin_catalog (id, name, slug, type, pillar)
+           VALUES ($1, 'Bad Pillar', $2, 'chat', 'something-else')`,
+          [`${id}-bad-pillar`, `${slug}-bad-pillar`],
+        ),
+      ).rejects.toMatchObject({ code: "23514" });
+
+      // CHECK rejects unknown implementation_status with 23514.
+      await expect(
+        pool.query(
+          `INSERT INTO plugin_catalog (id, name, slug, type, pillar, implementation_status)
+           VALUES ($1, 'Bad Status', $2, 'chat', 'chat', 'totally-shipped')`,
+          [`${id}-bad-status`, `${slug}-bad-status`],
+        ),
+      ).rejects.toMatchObject({ code: "23514" });
+    }, PG_TEST_TIMEOUT_MS);
+
+    it("workspace_plugins: BEFORE INSERT trigger fills install_id + pillar when caller omits them", async () => {
+      // Seed a catalog row whose pillar will flow through the trigger.
+      const slug = `pg-0092-trig-${Date.now()}`;
+      const catalogId = `cat-${slug}`;
+      await pool.query(
+        `INSERT INTO plugin_catalog (id, name, slug, type, pillar)
+         VALUES ($1, '0092 Trigger Smoke', $2, 'chat', 'chat')`,
+        [catalogId, slug],
+      );
+
+      // Mimic the existing handler INSERT shape (no install_id, no
+      // pillar). Trigger fills both.
+      const installId = `wp-${slug}`;
+      const workspaceId = `ws-${slug}`;
+      await pool.query(
+        `INSERT INTO workspace_plugins (id, workspace_id, catalog_id, config, enabled, installed_at)
+         VALUES ($1, $2, $3, '{}'::jsonb, true, NOW())`,
+        [installId, workspaceId, catalogId],
+      );
+
+      const { rows } = await pool.query<{
+        install_id: string;
+        pillar: string;
+      }>(
+        `SELECT install_id, pillar FROM workspace_plugins WHERE workspace_id = $1 AND catalog_id = $2`,
+        [workspaceId, catalogId],
+      );
+      expect(rows[0]?.install_id).toBe(catalogId);
+      expect(rows[0]?.pillar).toBe("chat");
+    }, PG_TEST_TIMEOUT_MS);
+
+    it("workspace_plugins: partial unique 'workspace_plugins_singleton' blocks a second chat install for the same (workspace, catalog)", async () => {
+      const slug = `pg-0092-uniq-${Date.now()}`;
+      const catalogId = `cat-${slug}`;
+      await pool.query(
+        `INSERT INTO plugin_catalog (id, name, slug, type, pillar)
+         VALUES ($1, '0092 Unique Smoke', $2, 'chat', 'chat')`,
+        [catalogId, slug],
+      );
+
+      const workspaceId = `ws-${slug}`;
+      await pool.query(
+        `INSERT INTO workspace_plugins (id, workspace_id, catalog_id, config, enabled, installed_at)
+         VALUES ($1, $2, $3, '{}'::jsonb, true, NOW())`,
+        [`first-${slug}`, workspaceId, catalogId],
+      );
+
+      // Second insert for the same (workspace, catalog) — different `id`
+      // and `install_id` — should still be blocked. The pre-existing
+      // `idx_workspace_plugins_unique` would catch it too in this slice,
+      // but the partial unique is the post-1.5.3 invariant that survives
+      // slice 5/6's global-unique drop. Either way: 23505.
+      await expect(
+        pool.query(
+          `INSERT INTO workspace_plugins (id, workspace_id, catalog_id, install_id, pillar, config, enabled, installed_at)
+           VALUES ($1, $2, $3, $4, 'chat', '{}'::jsonb, true, NOW())`,
+          [`second-${slug}`, workspaceId, catalogId, `second-install-${slug}`],
+        ),
+      ).rejects.toMatchObject({ code: "23505" });
+    }, PG_TEST_TIMEOUT_MS);
+
+    it("workspace_plugins: composite PK rejects an exact (workspace, catalog, install) duplicate even across pillars", async () => {
+      const slug = `pg-0092-pk-${Date.now()}`;
+      const catalogId = `cat-${slug}`;
+      await pool.query(
+        `INSERT INTO plugin_catalog (id, name, slug, type, pillar)
+         VALUES ($1, '0092 PK Smoke', $2, 'integration', 'action')`,
+        [catalogId, slug],
+      );
+
+      const workspaceId = `ws-${slug}`;
+      const installId = `inst-${slug}`;
+
+      await pool.query(
+        `INSERT INTO workspace_plugins (id, workspace_id, catalog_id, install_id, pillar, config, enabled, installed_at)
+         VALUES ($1, $2, $3, $4, 'action', '{}'::jsonb, true, NOW())`,
+        [`first-${slug}`, workspaceId, catalogId, installId],
+      );
+
+      await expect(
+        pool.query(
+          `INSERT INTO workspace_plugins (id, workspace_id, catalog_id, install_id, pillar, config, enabled, installed_at)
+           VALUES ($1, $2, $3, $4, 'action', '{}'::jsonb, true, NOW())`,
+          [`second-${slug}`, workspaceId, catalogId, installId],
+        ),
+      ).rejects.toMatchObject({ code: "23505" });
+    }, PG_TEST_TIMEOUT_MS);
+
+    it("workspace_plugins: `id` uniqueness preserved after PK swap", async () => {
+      // The dropped single-column PK used to enforce id uniqueness;
+      // `workspace_plugins_id_unique` takes over. Reuse the same id
+      // across two distinct (workspace, catalog) pairs and confirm
+      // the second insert rejects with 23505.
+      const slug = `pg-0092-id-${Date.now()}`;
+      const catalogIdA = `cat-a-${slug}`;
+      const catalogIdB = `cat-b-${slug}`;
+      const sharedId = `shared-${slug}`;
+
+      await pool.query(
+        `INSERT INTO plugin_catalog (id, name, slug, type, pillar)
+         VALUES ($1, '0092 ID Smoke A', $2, 'chat', 'chat'),
+                ($3, '0092 ID Smoke B', $4, 'chat', 'chat')`,
+        [catalogIdA, `${slug}-a`, catalogIdB, `${slug}-b`],
+      );
+
+      await pool.query(
+        `INSERT INTO workspace_plugins (id, workspace_id, catalog_id, config, enabled, installed_at)
+         VALUES ($1, $2, $3, '{}'::jsonb, true, NOW())`,
+        [sharedId, `ws-${slug}`, catalogIdA],
+      );
+
+      await expect(
+        pool.query(
+          `INSERT INTO workspace_plugins (id, workspace_id, catalog_id, config, enabled, installed_at)
+           VALUES ($1, $2, $3, '{}'::jsonb, true, NOW())`,
+          [sharedId, `ws-${slug}`, catalogIdB],
+        ),
+      ).rejects.toMatchObject({ code: "23505" });
+    }, PG_TEST_TIMEOUT_MS);
+  });
 });
 
 // #2606 — source-level revert guard for the integration-store SQL formatter.

--- a/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
@@ -4689,6 +4689,102 @@ describeIfPg("migrate-pg (real Postgres)", () => {
       expect(rows[0]?.pillar).toBe("chat");
     }, PG_TEST_TIMEOUT_MS);
 
+    it("plugin_catalog: BEFORE UPDATE trigger re-derives pillar when type changes (UPDATE without naming pillar)", async () => {
+      // Codex P1 on PR #2756: catalog-seeder upsert (`SET type =
+      // EXCLUDED.type`) and admin marketplace PATCH both UPDATE type
+      // on existing rows. Without the UPDATE trigger, pillar drifts
+      // and the workspace_plugins INSERT trigger propagates the stale
+      // value.
+      const slug = `pg-0092-cat-update-${Date.now()}`;
+      const id = `cat-${slug}`;
+
+      await pool.query(
+        `INSERT INTO plugin_catalog (id, name, slug, type) VALUES ($1, '0092 Update Trigger', $2, 'chat')`,
+        [id, slug],
+      );
+      // INSERT trigger derives pillar='chat' from type='chat'.
+      let { rows } = await pool.query<{ pillar: string }>(
+        `SELECT pillar FROM plugin_catalog WHERE id = $1`,
+        [id],
+      );
+      expect(rows[0]?.pillar).toBe("chat");
+
+      // Update type only — UPDATE trigger re-derives pillar.
+      await pool.query(
+        `UPDATE plugin_catalog SET type = 'datasource' WHERE id = $1`,
+        [id],
+      );
+      ({ rows } = await pool.query<{ pillar: string }>(
+        `SELECT pillar FROM plugin_catalog WHERE id = $1`,
+        [id],
+      ));
+      expect(rows[0]?.pillar).toBe("datasource");
+
+      // Update type from datasource → integration — pillar follows
+      // to 'action'.
+      await pool.query(
+        `UPDATE plugin_catalog SET type = 'integration' WHERE id = $1`,
+        [id],
+      );
+      ({ rows } = await pool.query<{ pillar: string }>(
+        `SELECT pillar FROM plugin_catalog WHERE id = $1`,
+        [id],
+      ));
+      expect(rows[0]?.pillar).toBe("action");
+    }, PG_TEST_TIMEOUT_MS);
+
+    it("plugin_catalog: BEFORE UPDATE trigger does NOT clobber when caller updates both type AND pillar", async () => {
+      // Same UPDATE statement names both columns to different values:
+      // the explicit pillar wins. Locks the `IS NOT DISTINCT FROM`
+      // guard against a future revision that drops it.
+      const slug = `pg-0092-cat-update-noclobber-${Date.now()}`;
+      const id = `cat-${slug}`;
+
+      await pool.query(
+        `INSERT INTO plugin_catalog (id, name, slug, type, pillar) VALUES ($1, '0092 Update No-Clobber', $2, 'chat', 'chat')`,
+        [id, slug],
+      );
+
+      // Update type='datasource' would normally derive pillar='datasource';
+      // caller explicitly says pillar='action' — explicit wins.
+      await pool.query(
+        `UPDATE plugin_catalog SET type = 'datasource', pillar = 'action' WHERE id = $1`,
+        [id],
+      );
+      const { rows } = await pool.query<{ type: string; pillar: string }>(
+        `SELECT type, pillar FROM plugin_catalog WHERE id = $1`,
+        [id],
+      );
+      expect(rows[0]?.type).toBe("datasource");
+      expect(rows[0]?.pillar).toBe("action");
+    }, PG_TEST_TIMEOUT_MS);
+
+    it("plugin_catalog: BEFORE UPDATE trigger leaves pillar alone when only unrelated columns change", async () => {
+      // Updating description/enabled/etc. must not touch pillar — the
+      // trigger guard `NEW.type IS DISTINCT FROM OLD.type` short-
+      // circuits when type didn't change.
+      const slug = `pg-0092-cat-update-unrelated-${Date.now()}`;
+      const id = `cat-${slug}`;
+
+      // Insert with explicit non-trigger-mapped pillar (chat for a
+      // datasource-typed row) so a stray "re-derive on every update"
+      // would visibly rewrite to 'datasource'.
+      await pool.query(
+        `INSERT INTO plugin_catalog (id, name, slug, type, pillar) VALUES ($1, '0092 Update Untouched', $2, 'datasource', 'chat')`,
+        [id, slug],
+      );
+
+      await pool.query(
+        `UPDATE plugin_catalog SET description = 'updated description' WHERE id = $1`,
+        [id],
+      );
+      const { rows } = await pool.query<{ pillar: string }>(
+        `SELECT pillar FROM plugin_catalog WHERE id = $1`,
+        [id],
+      );
+      expect(rows[0]?.pillar).toBe("chat");
+    }, PG_TEST_TIMEOUT_MS);
+
     it("plugin_catalog: implementation_status + auto_install defaults apply on omission", async () => {
       // Pinned by silent-failure review on #2756 — guards the
       // `DEFAULT 'available'` / `DEFAULT false` clauses against a

--- a/packages/api/src/lib/db/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate.test.ts
@@ -103,8 +103,9 @@ describe("runMigrations", () => {
     // + 0088 (backfill workspace_plugins from chat_cache, #2655)
     // + 0089 (integration_credentials table, #2658)
     // + 0090 (organization.is_operator_workspace flag, #2702)
-    // + 0091 (unify catalog min_plan vocabulary, #2666) = 92.
-    expect(count).toBe(92);
+    // + 0091 (unify catalog min_plan vocabulary, #2666)
+    // + 0092 (pillar + install_id columns, #2739) = 93.
+    expect(count).toBe(93);
 
     // Advisory lock acquired before anything else
     expect(queries[0]).toContain("pg_advisory_lock");
@@ -225,6 +226,7 @@ describe("runMigrations", () => {
         "0089_integration_credentials.sql",
         "0090_organization_is_operator_workspace.sql",
         "0091_unify_catalog_min_plan.sql",
+        "0092_pillar_install_id_columns.sql",
       ],
     });
 

--- a/packages/api/src/lib/db/migrations/0092_pillar_install_id_columns.sql
+++ b/packages/api/src/lib/db/migrations/0092_pillar_install_id_columns.sql
@@ -1,0 +1,196 @@
+-- 0092_pillar_install_id_columns.sql
+--
+-- 1.5.3 slice 1 (#2739 / PRD #2738 / ADR-0006 + ADR-0007) — schema
+-- foundation for the three-pillar taxonomy (Datasource / Chat / Action)
+-- and the unified install pipeline.
+--
+-- Adds the columns + constraints + indexes that subsequent 1.5.3 slices
+-- (PillarCatalogQuery #2741, WorkspaceInstaller #2742,
+-- DatasourcePoolResolver #2743, the connections-table cutover #2744)
+-- will consume. NO production code reads or writes the new columns
+-- yet — existing INSERT call sites under
+-- packages/api/src/lib/integrations/install/*-handler.ts continue to
+-- INSERT (id, workspace_id, catalog_id, config, enabled, installed_at)
+-- without naming the new columns. A BEFORE INSERT trigger + the
+-- temporarily-retained `idx_workspace_plugins_unique` index keep
+-- those callers green; slice 4 (WorkspaceInstaller) pivots them onto
+-- the composite PK and slice 5/6 drops the old unique + trigger.
+--
+-- Why the old (workspace_id, catalog_id) unique index lingers:
+--   * Existing handler INSERTs ON CONFLICT (workspace_id, catalog_id)
+--     target it explicitly. The new partial unique
+--     `workspace_plugins_singleton` only covers chat + action pillars;
+--     a bare ON CONFLICT (workspace_id, catalog_id) wouldn't bind to
+--     a partial index without a matching WHERE clause. Keeping the
+--     global unique avoids touching consumer SQL in this slice.
+--   * Pre-cutover the new partial is a strict subset of the global
+--     (every existing row is chat/action), so the two coexist
+--     without conflict. Datasource multi-instance lands in slice 5/6
+--     which drops the global at the same time it pivots handlers.
+
+-- ---------------------------------------------------------------------------
+-- plugin_catalog: pillar, implementation_status, auto_install
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE plugin_catalog
+  ADD COLUMN IF NOT EXISTS pillar TEXT;
+
+ALTER TABLE plugin_catalog
+  ADD COLUMN IF NOT EXISTS implementation_status TEXT NOT NULL DEFAULT 'available';
+
+ALTER TABLE plugin_catalog
+  ADD COLUMN IF NOT EXISTS auto_install BOOLEAN NOT NULL DEFAULT false;
+
+-- Backfill pillar from existing `type` per ADR-0006:
+--   chat        → chat
+--   integration → action  (current admin-UI grouping for everything
+--                 customer-installable that isn't chat)
+--   datasource  → datasource  (no rows today, future-proof)
+--   action      → action  (pre-#2650 type with semantically-matching
+--                 pillar)
+--   context | interaction | sandbox → action  (degenerate fallback;
+--                 production catalogs don't hold these today but
+--                 0087's CHECK admits them; defaulting to `action`
+--                 keeps the upcoming NOT NULL gate green if a stale
+--                 self-host seed has one)
+UPDATE plugin_catalog SET pillar = 'chat'       WHERE pillar IS NULL AND type = 'chat';
+UPDATE plugin_catalog SET pillar = 'datasource' WHERE pillar IS NULL AND type = 'datasource';
+UPDATE plugin_catalog SET pillar = 'action'     WHERE pillar IS NULL;
+
+ALTER TABLE plugin_catalog ALTER COLUMN pillar SET NOT NULL;
+
+ALTER TABLE plugin_catalog
+  DROP CONSTRAINT IF EXISTS chk_plugin_catalog_pillar;
+ALTER TABLE plugin_catalog
+  ADD CONSTRAINT chk_plugin_catalog_pillar
+  CHECK (pillar IN ('datasource', 'chat', 'action'));
+
+ALTER TABLE plugin_catalog
+  DROP CONSTRAINT IF EXISTS chk_plugin_catalog_implementation_status;
+ALTER TABLE plugin_catalog
+  ADD CONSTRAINT chk_plugin_catalog_implementation_status
+  CHECK (implementation_status IN ('available', 'coming_soon'));
+
+-- BEFORE INSERT trigger fills pillar when callers omit it. Slice 1's
+-- acceptance criterion is "no production code reads or writes the new
+-- columns yet" — admin-marketplace.ts:325 (admin catalog CRUD),
+-- catalog-seeder.ts:513 (boot-time catalog upsert from atlas.config.ts),
+-- and migration 0088 all INSERT plugin_catalog rows without naming
+-- pillar. The trigger derives pillar from `type` using the same
+-- mapping as the backfill above so a stale call site stays valid.
+-- Slice 3 (PillarCatalogQuery) and slice 5 (built-in Datasource
+-- catalog rows) start naming pillar explicitly; this trigger can be
+-- dropped when the seeder + admin route stop relying on it.
+CREATE OR REPLACE FUNCTION plugin_catalog_default_pillar()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF NEW.pillar IS NULL THEN
+    NEW.pillar := CASE NEW.type
+      WHEN 'chat'       THEN 'chat'
+      WHEN 'datasource' THEN 'datasource'
+      ELSE                   'action'
+    END;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_plugin_catalog_default_pillar ON plugin_catalog;
+CREATE TRIGGER trg_plugin_catalog_default_pillar
+BEFORE INSERT ON plugin_catalog
+FOR EACH ROW EXECUTE FUNCTION plugin_catalog_default_pillar();
+
+-- ---------------------------------------------------------------------------
+-- workspace_plugins: install_id, pillar, composite PK
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE workspace_plugins
+  ADD COLUMN IF NOT EXISTS install_id TEXT;
+
+ALTER TABLE workspace_plugins
+  ADD COLUMN IF NOT EXISTS pillar TEXT;
+
+-- Backfill install_id = catalog_id (singleton sentinel — pre-1.5.3
+-- every (workspace, catalog) is unique under the old global unique,
+-- so catalog_id can't collide with itself within a workspace).
+UPDATE workspace_plugins
+SET install_id = catalog_id
+WHERE install_id IS NULL;
+
+-- Backfill pillar from the joined catalog row (populated above).
+UPDATE workspace_plugins wp
+SET pillar = pc.pillar
+FROM plugin_catalog pc
+WHERE pc.id = wp.catalog_id AND wp.pillar IS NULL;
+
+-- Fail loud if any row still NULL — would indicate an orphan
+-- workspace_plugins row whose catalog_id doesn't resolve. The FK
+-- normally prevents this, but a self-host that bypassed Drizzle
+-- could have one.
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM workspace_plugins WHERE install_id IS NULL OR pillar IS NULL) THEN
+    RAISE EXCEPTION 'workspace_plugins backfill incomplete — orphan rows without resolvable catalog?';
+  END IF;
+END $$;
+
+ALTER TABLE workspace_plugins ALTER COLUMN install_id SET NOT NULL;
+ALTER TABLE workspace_plugins ALTER COLUMN pillar SET NOT NULL;
+
+ALTER TABLE workspace_plugins
+  DROP CONSTRAINT IF EXISTS chk_workspace_plugins_pillar;
+ALTER TABLE workspace_plugins
+  ADD CONSTRAINT chk_workspace_plugins_pillar
+  CHECK (pillar IN ('datasource', 'chat', 'action'));
+
+-- BEFORE INSERT trigger fills install_id + pillar when callers omit
+-- them. Slice 1's acceptance criterion is "no production code reads
+-- or writes the new columns yet" — the existing handler INSERTs
+-- under packages/api/src/lib/integrations/install/*-handler.ts
+-- continue to INSERT (id, workspace_id, catalog_id, config, enabled,
+-- installed_at) without naming the new columns. The trigger looks up
+-- pillar from the joined catalog row (FK guarantees the row exists)
+-- and defaults install_id to catalog_id (singleton sentinel). Slice 4
+-- (WorkspaceInstaller) pivots callers to name the columns explicitly;
+-- slice 5/6 can then drop this trigger along with the global unique
+-- index it pairs with.
+CREATE OR REPLACE FUNCTION workspace_plugins_default_pillar_install_id()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF NEW.install_id IS NULL THEN
+    NEW.install_id := NEW.catalog_id;
+  END IF;
+  IF NEW.pillar IS NULL THEN
+    SELECT pc.pillar INTO NEW.pillar FROM plugin_catalog pc WHERE pc.id = NEW.catalog_id;
+    -- If catalog lookup fails (shouldn't happen — FK enforces
+    -- existence at constraint-check time), NEW.pillar stays NULL
+    -- and the NOT NULL constraint rejects the row with a clear
+    -- error rather than silently defaulting to an arbitrary pillar.
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_workspace_plugins_default_pillar_install_id ON workspace_plugins;
+CREATE TRIGGER trg_workspace_plugins_default_pillar_install_id
+BEFORE INSERT ON workspace_plugins
+FOR EACH ROW EXECUTE FUNCTION workspace_plugins_default_pillar_install_id();
+
+-- Swap PK: single `id` → composite (workspace_id, catalog_id, install_id).
+-- Retain `id` as a unique-indexed column so existing handler INSERTs
+-- that RETURNING id (email/obsidian/webhook/salesforce/jira/slack)
+-- keep working until slice 4 pivots them onto the composite PK.
+ALTER TABLE workspace_plugins DROP CONSTRAINT IF EXISTS workspace_plugins_pkey;
+ALTER TABLE workspace_plugins ADD PRIMARY KEY (workspace_id, catalog_id, install_id);
+
+CREATE UNIQUE INDEX IF NOT EXISTS workspace_plugins_id_unique
+  ON workspace_plugins (id);
+
+-- New partial unique index — singleton enforcement for chat + action
+-- pillars. Datasource pillar admits multiple installs per (workspace,
+-- catalog) once slice 5/6 lands. Until then this index is a strict
+-- subset of `idx_workspace_plugins_unique` (every existing row is
+-- chat or action), so the two coexist without conflict.
+CREATE UNIQUE INDEX IF NOT EXISTS workspace_plugins_singleton
+  ON workspace_plugins (workspace_id, catalog_id)
+  WHERE pillar IN ('chat', 'action');

--- a/packages/api/src/lib/db/migrations/0092_pillar_install_id_columns.sql
+++ b/packages/api/src/lib/db/migrations/0092_pillar_install_id_columns.sql
@@ -134,6 +134,43 @@ CREATE TRIGGER trg_plugin_catalog_default_pillar
 BEFORE INSERT ON plugin_catalog
 FOR EACH ROW EXECUTE FUNCTION plugin_catalog_default_pillar();
 
+-- Companion BEFORE UPDATE trigger keeps pillar in sync when `type`
+-- changes (the catalog-seeder upsert `SET type = EXCLUDED.type` and
+-- the admin marketplace PATCH both UPDATE type on existing rows;
+-- without this, pillar drifts and the workspace_plugins trigger
+-- propagates the stale value into new install rows). The
+-- `IS NOT DISTINCT FROM` guard preserves the no-clobber pattern:
+-- a caller that updates both type AND pillar in the same statement
+-- gets their explicit pillar; a caller that updates only type gets
+-- a re-derivation. RAISE WARNING again surfaces unexpected type
+-- values without aborting the update.
+-- TODO(#2743): drop alongside the INSERT trigger once writers name
+-- pillar explicitly.
+CREATE OR REPLACE FUNCTION plugin_catalog_sync_pillar_on_type_change()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF NEW.type IS DISTINCT FROM OLD.type
+     AND NEW.pillar IS NOT DISTINCT FROM OLD.pillar THEN
+    NEW.pillar := CASE NEW.type
+      WHEN 'chat'        THEN 'chat'
+      WHEN 'datasource'  THEN 'datasource'
+      WHEN 'integration' THEN 'action'
+      WHEN 'action'      THEN 'action'
+      ELSE                    'action'
+    END;
+    IF NEW.type NOT IN ('chat', 'datasource', 'integration', 'action') THEN
+      RAISE WARNING 'plugin_catalog: pillar re-derived to ''action'' for unexpected type % on row id=%', NEW.type, NEW.id;
+    END IF;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_plugin_catalog_sync_pillar_on_type_change ON plugin_catalog;
+CREATE TRIGGER trg_plugin_catalog_sync_pillar_on_type_change
+BEFORE UPDATE ON plugin_catalog
+FOR EACH ROW EXECUTE FUNCTION plugin_catalog_sync_pillar_on_type_change();
+
 -- ---------------------------------------------------------------------------
 -- workspace_plugins: install_id, pillar, composite PK
 -- ---------------------------------------------------------------------------

--- a/packages/api/src/lib/db/migrations/0092_pillar_install_id_columns.sql
+++ b/packages/api/src/lib/db/migrations/0092_pillar_install_id_columns.sql
@@ -11,12 +11,13 @@
 -- yet — existing INSERT call sites under
 -- packages/api/src/lib/integrations/install/*-handler.ts continue to
 -- INSERT (id, workspace_id, catalog_id, config, enabled, installed_at)
--- without naming the new columns. A BEFORE INSERT trigger + the
--- temporarily-retained `idx_workspace_plugins_unique` index keep
--- those callers green; slice 4 (WorkspaceInstaller) pivots them onto
--- the composite PK and slice 5/6 drops the old unique + trigger.
+-- without naming the new columns. Two BEFORE INSERT triggers + the
+-- temporarily-retained (workspace_id, catalog_id) unique constraint
+-- keep those callers green; slice 4 (WorkspaceInstaller, #2742) pivots
+-- them onto the composite PK and slice 5/6 (#2743 / #2744) drops the
+-- old unique + triggers.
 --
--- Why the old (workspace_id, catalog_id) unique index lingers:
+-- Why the old (workspace_id, catalog_id) unique constraint lingers:
 --   * Existing handler INSERTs ON CONFLICT (workspace_id, catalog_id)
 --     target it explicitly. The new partial unique
 --     `workspace_plugins_singleton` only covers chat + action pillars;
@@ -25,8 +26,26 @@
 --     global unique avoids touching consumer SQL in this slice.
 --   * Pre-cutover the new partial is a strict subset of the global
 --     (every existing row is chat/action), so the two coexist
---     without conflict. Datasource multi-instance lands in slice 5/6
---     which drops the global at the same time it pivots handlers.
+--     without conflict. Datasource multi-instance lands in #2743 /
+--     #2744 which drops the global at the same time it pivots handlers.
+--
+-- A naming-drift note for slice 5/6: the 0014 baseline declared the
+-- constraint as inline `UNIQUE(workspace_id, catalog_id)`, which
+-- Postgres auto-names `workspace_plugins_workspace_id_catalog_id_key`.
+-- The Drizzle mirror's logical name `idx_workspace_plugins_unique` does
+-- NOT exist on disk in production PG — it's a pre-existing drift from
+-- 0014. The slice 5/6 cleanup should `ALTER TABLE workspace_plugins
+-- DROP CONSTRAINT workspace_plugins_workspace_id_catalog_id_key` (or
+-- the migration-managed equivalent), NOT `DROP INDEX
+-- idx_workspace_plugins_unique`. Aligning the Drizzle name with the
+-- on-disk name is out of scope for this slice.
+--
+-- Migration-runner transaction guarantee: `runMigrations` wraps every
+-- `.sql` file in a single `BEGIN` / `COMMIT` (see migrate.ts) under an
+-- advisory lock, and the `ALTER TABLE` statements below take
+-- `ACCESS EXCLUSIVE` — so the PK-swap window where neither the old `id`
+-- PK nor the new composite PK is in force is invisible to concurrent
+-- writers.
 
 -- ---------------------------------------------------------------------------
 -- plugin_catalog: pillar, implementation_status, auto_install
@@ -73,23 +92,38 @@ ALTER TABLE plugin_catalog
 
 -- BEFORE INSERT trigger fills pillar when callers omit it. Slice 1's
 -- acceptance criterion is "no production code reads or writes the new
--- columns yet" — admin-marketplace.ts:325 (admin catalog CRUD),
--- catalog-seeder.ts:513 (boot-time catalog upsert from atlas.config.ts),
+-- columns yet" — admin-marketplace.ts (admin catalog CRUD),
+-- catalog-seeder.ts (boot-time catalog upsert from atlas.config.ts),
 -- and migration 0088 all INSERT plugin_catalog rows without naming
 -- pillar. The trigger derives pillar from `type` using the same
 -- mapping as the backfill above so a stale call site stays valid.
--- Slice 3 (PillarCatalogQuery) and slice 5 (built-in Datasource
--- catalog rows) start naming pillar explicitly; this trigger can be
--- dropped when the seeder + admin route stop relying on it.
+-- Slice 3 (PillarCatalogQuery, #2741) and slice 5 (built-in Datasource
+-- catalog rows, #2743) start naming pillar explicitly; this trigger
+-- can be dropped when the seeder + admin route stop relying on it.
+-- TODO(#2743): drop this trigger once all writers name pillar.
+--
+-- The `ELSE 'action'` branch is intentional but conservative: every
+-- type value admitted by `chk_plugin_catalog_type` other than `chat`
+-- and `datasource` (i.e. `context`, `interaction`, `sandbox`, the
+-- pre-#2650 admin-UI grouping `integration`, and `action`) maps to
+-- the `action` pillar. The first four shouldn't appear in any
+-- production seed today; a `RAISE WARNING` surfaces the case in
+-- Postgres logs so a stale self-host seed or a future typo is
+-- visible without breaking the insert.
 CREATE OR REPLACE FUNCTION plugin_catalog_default_pillar()
 RETURNS TRIGGER AS $$
 BEGIN
   IF NEW.pillar IS NULL THEN
     NEW.pillar := CASE NEW.type
-      WHEN 'chat'       THEN 'chat'
-      WHEN 'datasource' THEN 'datasource'
-      ELSE                   'action'
+      WHEN 'chat'        THEN 'chat'
+      WHEN 'datasource'  THEN 'datasource'
+      WHEN 'integration' THEN 'action'
+      WHEN 'action'      THEN 'action'
+      ELSE                    'action'
     END;
+    IF NEW.type NOT IN ('chat', 'datasource', 'integration', 'action') THEN
+      RAISE WARNING 'plugin_catalog: pillar defaulted to ''action'' for unexpected type % on row id=%', NEW.type, NEW.id;
+    END IF;
   END IF;
   RETURN NEW;
 END;
@@ -149,11 +183,15 @@ ALTER TABLE workspace_plugins
 -- under packages/api/src/lib/integrations/install/*-handler.ts
 -- continue to INSERT (id, workspace_id, catalog_id, config, enabled,
 -- installed_at) without naming the new columns. The trigger looks up
--- pillar from the joined catalog row (FK guarantees the row exists)
+-- pillar from the joined catalog row (FK guarantees the row exists
+-- at end-of-statement; the BEFORE trigger fires earlier than the FK
+-- check, so we must surface a clear error here if the lookup misses)
 -- and defaults install_id to catalog_id (singleton sentinel). Slice 4
--- (WorkspaceInstaller) pivots callers to name the columns explicitly;
--- slice 5/6 can then drop this trigger along with the global unique
--- index it pairs with.
+-- (WorkspaceInstaller, #2742) pivots callers to name the columns
+-- explicitly; slice 5/6 (#2743 / #2744) can then drop this trigger
+-- along with the global unique index it pairs with.
+-- TODO(#2743): drop this trigger once all writers name install_id +
+-- pillar.
 CREATE OR REPLACE FUNCTION workspace_plugins_default_pillar_install_id()
 RETURNS TRIGGER AS $$
 BEGIN
@@ -162,10 +200,16 @@ BEGIN
   END IF;
   IF NEW.pillar IS NULL THEN
     SELECT pc.pillar INTO NEW.pillar FROM plugin_catalog pc WHERE pc.id = NEW.catalog_id;
-    -- If catalog lookup fails (shouldn't happen — FK enforces
-    -- existence at constraint-check time), NEW.pillar stays NULL
-    -- and the NOT NULL constraint rejects the row with a clear
-    -- error rather than silently defaulting to an arbitrary pillar.
+    -- Postgres BEFORE INSERT triggers fire before FK enforcement, so
+    -- an orphan catalog_id surfaces here as an empty SELECT, not as
+    -- the more familiar FK-violation error. Raise an explicit 23503
+    -- (foreign_key_violation) so the message names the actual root
+    -- cause rather than the downstream "NULL value in column 'pillar'"
+    -- the NOT NULL constraint would otherwise produce.
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'workspace_plugins: catalog_id % not present in plugin_catalog', NEW.catalog_id
+        USING ERRCODE = 'foreign_key_violation';
+    END IF;
   END IF;
   RETURN NEW;
 END;

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -1591,6 +1591,17 @@ export const pluginCatalog = pgTable(
     // #2650 — gate on per-deploy-mode visibility. SaaS hides `false`
     // rows from admin-UI listings; self-host always shows them.
     saasEligible: boolean("saas_eligible").notNull().default(true),
+    // 0092 / #2739 — three-pillar taxonomy. Backfilled from `type` on
+    // migration; required for every catalog row. ADR-0006 mapping:
+    // chat→chat, datasource→datasource, everything else→action.
+    pillar: text("pillar").notNull(),
+    // 0092 / #2739 — coming-soon affordance. `coming_soon` rows render
+    // as grey/inert cards in admin UI (slice 9 wires the rendering).
+    implementationStatus: text("implementation_status").notNull().default("available"),
+    // 0092 / #2739 — built-in Datasource catalog rows (slice 5) set
+    // this true so the cutover migrator backfills a workspace_plugins
+    // row per workspace (demo connection as auto_install).
+    autoInstall: boolean("auto_install").notNull().default(false),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
@@ -1605,24 +1616,57 @@ export const pluginCatalog = pgTable(
       .where(sql`enabled = true`),
     check("chk_plugin_catalog_type", sql`type IN ('datasource', 'context', 'interaction', 'action', 'sandbox', 'chat', 'integration')`),
     check("chk_plugin_catalog_install_model", sql`install_model IN ('oauth', 'form', 'static-bot')`),
+    check("chk_plugin_catalog_pillar", sql`pillar IN ('datasource', 'chat', 'action')`),
+    check("chk_plugin_catalog_implementation_status", sql`implementation_status IN ('available', 'coming_soon')`),
   ],
 );
 
 export const workspacePlugins = pgTable(
   "workspace_plugins",
   {
-    id: text("id").primaryKey(),
+    // 0092 / #2739 — `id` lost its PK status when the composite PK
+    // landed; it stays as a NOT NULL, uniquely-indexed column so
+    // existing handler INSERTs that RETURNING id keep working until
+    // slice 4 (WorkspaceInstaller) pivots them onto the composite.
+    id: text("id").notNull(),
     workspaceId: text("workspace_id").notNull(),
     catalogId: text("catalog_id").notNull().references(() => pluginCatalog.id, { onDelete: "cascade" }),
+    // 0092 / #2739 — per-instance install identifier.
+    //  - chat/action installs: catalog_id sentinel (singleton enforced
+    //    by `workspace_plugins_singleton` partial unique).
+    //  - datasource installs (slice 5+): user-facing id like `prod-us`,
+    //    multi-instance per (workspace, catalog).
+    installId: text("install_id").notNull(),
+    // 0092 / #2739 — three-pillar taxonomy. Denormalized from
+    // plugin_catalog.pillar so the partial unique index can gate on
+    // it without a join.
+    pillar: text("pillar").notNull(),
     config: jsonb("config").notNull().default(sql`'{}'`),
     enabled: boolean("enabled").notNull().default(true),
     installedAt: timestamp("installed_at", { withTimezone: true }).notNull().defaultNow(),
     installedBy: text("installed_by"),
   },
   (t) => [
+    // 0092 / #2739 — composite PK per ADR-0007. Replaces single-column
+    // `id` PK from 0014.
+    primaryKey({ columns: [t.workspaceId, t.catalogId, t.installId] }),
+    // 0092 / #2739 — preserves the `id` uniqueness invariant that the
+    // dropped single-column PK used to enforce.
+    uniqueIndex("workspace_plugins_id_unique").on(t.id),
+    // Pre-existing global unique (0014). Kept until slice 5/6
+    // introduces multi-instance datasource installs and pivots
+    // handler ON CONFLICT clauses off this index — see migration
+    // 0092's header comment for the rationale.
     uniqueIndex("idx_workspace_plugins_unique").on(t.workspaceId, t.catalogId),
+    // 0092 / #2739 — post-1.5.3 invariant: singleton install per
+    // (workspace, catalog) for chat + action pillars only. Datasource
+    // pillar is admitted multiple times.
+    uniqueIndex("workspace_plugins_singleton")
+      .on(t.workspaceId, t.catalogId)
+      .where(sql`pillar IN ('chat', 'action')`),
     index("idx_workspace_plugins_workspace").on(t.workspaceId),
     index("idx_workspace_plugins_catalog").on(t.catalogId),
+    check("chk_workspace_plugins_pillar", sql`pillar IN ('datasource', 'chat', 'action')`),
   ],
 );
 

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -1627,15 +1627,17 @@ export const workspacePlugins = pgTable(
     // 0092 / #2739 — `id` lost its PK status when the composite PK
     // landed; it stays as a NOT NULL, uniquely-indexed column so
     // existing handler INSERTs that RETURNING id keep working until
-    // slice 4 (WorkspaceInstaller) pivots them onto the composite.
+    // WorkspaceInstaller (#2742) pivots them onto the composite.
+    // TODO(#2742): decide whether `id` is still needed once
+    // WorkspaceInstaller owns the writes.
     id: text("id").notNull(),
     workspaceId: text("workspace_id").notNull(),
     catalogId: text("catalog_id").notNull().references(() => pluginCatalog.id, { onDelete: "cascade" }),
     // 0092 / #2739 — per-instance install identifier.
     //  - chat/action installs: catalog_id sentinel (singleton enforced
     //    by `workspace_plugins_singleton` partial unique).
-    //  - datasource installs (slice 5+): user-facing id like `prod-us`,
-    //    multi-instance per (workspace, catalog).
+    //  - datasource installs (#2743 / #2744): user-facing id like
+    //    `prod-us`, multi-instance per (workspace, catalog).
     installId: text("install_id").notNull(),
     // 0092 / #2739 — three-pillar taxonomy. Denormalized from
     // plugin_catalog.pillar so the partial unique index can gate on
@@ -1653,10 +1655,14 @@ export const workspacePlugins = pgTable(
     // 0092 / #2739 — preserves the `id` uniqueness invariant that the
     // dropped single-column PK used to enforce.
     uniqueIndex("workspace_plugins_id_unique").on(t.id),
-    // Pre-existing global unique (0014). Kept until slice 5/6
+    // Pre-existing global unique (0014). Kept until #2743 / #2744
     // introduces multi-instance datasource installs and pivots
-    // handler ON CONFLICT clauses off this index — see migration
-    // 0092's header comment for the rationale.
+    // handler ON CONFLICT clauses off this constraint — see migration
+    // 0092's header comment for the rationale, including the
+    // Drizzle-vs-production naming drift (on disk this lives as
+    // `workspace_plugins_workspace_id_catalog_id_key`).
+    // TODO(#2743): drop and align the Drizzle name with the on-disk
+    // constraint when the cutover lands.
     uniqueIndex("idx_workspace_plugins_unique").on(t.workspaceId, t.catalogId),
     // 0092 / #2739 — post-1.5.3 invariant: singleton install per
     // (workspace, catalog) for chat + action pillars only. Datasource


### PR DESCRIPTION
## Summary

1.5.3 slice 1 of 17 (#2739). Foundation for [ADR-0006](docs/adr/0006-three-pillar-integration-taxonomy.md) (three-pillar taxonomy) + [ADR-0007](docs/adr/0007-unified-install-pipeline.md) (unified install pipeline). Schema-only — no production code reads or writes the new columns yet (subsequent slices add the consumers).

### Migration 0092

**`plugin_catalog`** gets three new columns:
- `pillar` (`datasource | chat | action`, CHECK + NOT NULL, backfilled from `type`: `chat→chat`, `datasource→datasource`, everything else→`action`)
- `implementation_status` (`available | coming_soon`, CHECK + NOT NULL, default `available`)
- `auto_install` (boolean, NOT NULL, default `false`)

**`workspace_plugins`** gets:
- `install_id` (text NOT NULL) — per-instance identifier; `catalog_id` sentinel for chat/action, user-facing id like `prod-us` for datasource (slice 5+)
- `pillar` (text NOT NULL, CHECK same set) — denormalized so the partial unique can gate without a join
- **Composite PK** on `(workspace_id, catalog_id, install_id)` replaces the single-column `id` PK
- `id` retained as a `NOT NULL` + uniquely-indexed column so handler INSERTs that `RETURNING id` keep working until slice 4 (WorkspaceInstaller) pivots them
- New partial unique `workspace_plugins_singleton` on `(workspace_id, catalog_id) WHERE pillar IN ('chat', 'action')` — the post-1.5.3 invariant
- Old global unique `idx_workspace_plugins_unique` kept temporarily so existing handler `ON CONFLICT (workspace_id, catalog_id)` clauses bind to a matching index; slice 5/6 drops it when handlers pivot off and datasource multi-instance lands

### Why two triggers

Two `BEFORE INSERT` triggers bridge old call sites to the new shape without touching any consumer SQL — the slice's acceptance criterion is "no production code reads from or writes to the new columns yet":

- `plugin_catalog_default_pillar` — derives `pillar` from `type` for the seeder (`catalog-seeder.ts:513`), admin marketplace route (`admin-marketplace.ts:325`), and the 0088 backfill migration that replays in tests
- `workspace_plugins_default_pillar_install_id` — defaults `install_id` to `catalog_id` and looks up `pillar` from the joined catalog row, covering every handler under `lib/integrations/install/*-handler.ts`

Both can be dropped in slice 4/5 when `WorkspaceInstaller` takes over.

### Drizzle mirror + tests

- `schema.ts` updated per CLAUDE.md's drift check — `bash scripts/check-schema-drift.sh` green
- `migrate-pg.test.ts` gets 5 new real-Postgres asserts: trigger fill, partial unique gate, composite PK rejection, id uniqueness preservation, and the `pillar` / `implementation_status` CHECK enforcement
- `migrate.test.ts` + `auth/__tests__/migrate.test.ts` bump pinned migration counts (92 → 93) + applied-list

## Test plan

- [x] `bash scripts/check-schema-drift.sh` — green
- [x] `bun run lint` — clean
- [x] `bun run type` — green
- [x] `bun x syncpack lint` — no issues
- [x] `bash scripts/check-template-drift.sh` — green
- [x] `bash scripts/check-security-headers-drift.sh` — green
- [x] `bash scripts/check-railway-watch.sh` — green
- [x] `bash scripts/check-oauth-helper-drift.sh` — green
- [x] `migrate-pg.test.ts` passes in isolation (131/131)
- [x] `migrate.test.ts` passes (58/58)
- [x] `auth/__tests__/migrate.test.ts` passes (14/14)
- [x] All integration handler + catalog-seeder tests pass (177/177)
- [ ] Full `test:api` — `migrate-pg.test.ts` flakes locally on this machine (WSL2 → Ubuntu shift); same flake reproduces on clean main with no other changes. Letting CI verify in its canonical env.

## Follows / unblocks

- Closes part of #2739 (slice 1 only).
- Unblocks #2740 (InstallStatusMachine — parallel), #2741 (PillarCatalogQuery — needs schema), #2742 (WorkspaceInstaller — needs schema)