### PR TITLE
feat(api): #2740 — InstallStatusMachine pure function + exhaustive tests

### DIFF
--- a/packages/api/src/lib/integrations/__tests__/install-status-machine.test.ts
+++ b/packages/api/src/lib/integrations/__tests__/install-status-machine.test.ts
@@ -1,0 +1,220 @@
+/**
+ * Tests for `resolveInstallStatus` — slice 2 of #2738 (issue #2740).
+ *
+ * Pure function under test. Three orthogonal gates from ADR-0006 /
+ * ADR-0007 layer in priority order:
+ *
+ *   1. coming_soon  (Atlas hasn't shipped it)        → trumps everything
+ *   2. misconfigured (operator hasn't wired env vars / handler)
+ *   3. plan-gate    (existing upsell logic)
+ *
+ * When all three gates pass the card resolves to `accessible` (no
+ * install) or `connected` (install row exists). When the plan gate
+ * fails but an install row exists the card resolves to
+ * `configured_but_downgraded` so the user can still disconnect.
+ *
+ * The table below enumerates every combination of the five boolean-ish
+ * input axes (2^5 = 32 rows). The final `assertNever` switch is the
+ * compile-time exhaustiveness guard required by the slice's
+ * acceptance criteria — adding a new CardState variant without
+ * extending the switch breaks the build.
+ */
+
+import { describe, it, expect } from "bun:test";
+import {
+  resolveInstallStatus,
+  type CardState,
+  type ResolveInstallStatusInput,
+  type WorkspaceInstallInput,
+} from "../install-status-machine";
+
+// ---------------------------------------------------------------------------
+// Fixture builders
+// ---------------------------------------------------------------------------
+
+const SOME_INSTALL: WorkspaceInstallInput = { installId: "default" };
+
+function caseInput(opts: {
+  status: "available" | "coming_soon";
+  install: WorkspaceInstallInput | null;
+  planAdmits: boolean;
+  handlerRegistered: boolean;
+  deployConfigured: boolean;
+}): ResolveInstallStatusInput {
+  return {
+    catalogRow: { implementationStatus: opts.status },
+    workspaceInstall: opts.install,
+    planAdmits: opts.planAdmits,
+    handlerRegistered: opts.handlerRegistered,
+    deployConfigured: opts.deployConfigured,
+  };
+}
+
+interface Case {
+  name: string;
+  input: ResolveInstallStatusInput;
+  expected: CardState;
+}
+
+const cases: Case[] = [];
+
+// ---------------------------------------------------------------------------
+// Gate 1 — coming_soon dominates all other gates (16 rows)
+// ---------------------------------------------------------------------------
+
+for (const install of [null, SOME_INSTALL]) {
+  for (const planAdmits of [false, true]) {
+    for (const handlerRegistered of [false, true]) {
+      for (const deployConfigured of [false, true]) {
+        cases.push({
+          name: `coming_soon dominates (install=${install ? "yes" : "no"}, plan=${planAdmits}, handler=${handlerRegistered}, deploy=${deployConfigured})`,
+          input: caseInput({
+            status: "coming_soon",
+            install,
+            planAdmits,
+            handlerRegistered,
+            deployConfigured,
+          }),
+          expected: "coming_soon",
+        });
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Gate 2 — misconfigured: status=available but handler/deploy unwired
+// (12 rows: 3 broken-combos × 2 install × 2 plan)
+// ---------------------------------------------------------------------------
+
+const brokenDeployStates: Array<{ handlerRegistered: boolean; deployConfigured: boolean }> = [
+  { handlerRegistered: false, deployConfigured: false },
+  { handlerRegistered: false, deployConfigured: true },
+  { handlerRegistered: true, deployConfigured: false },
+];
+
+for (const install of [null, SOME_INSTALL]) {
+  for (const planAdmits of [false, true]) {
+    for (const broken of brokenDeployStates) {
+      cases.push({
+        name: `misconfigured (install=${install ? "yes" : "no"}, plan=${planAdmits}, handler=${broken.handlerRegistered}, deploy=${broken.deployConfigured})`,
+        input: caseInput({
+          status: "available",
+          install,
+          planAdmits,
+          handlerRegistered: broken.handlerRegistered,
+          deployConfigured: broken.deployConfigured,
+        }),
+        expected: "misconfigured",
+      });
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Gates 3 + happy paths — status=available, handler+deploy ready (4 rows)
+// ---------------------------------------------------------------------------
+
+cases.push({
+  name: "upgrade_required: plan denies, no install",
+  input: caseInput({
+    status: "available",
+    install: null,
+    planAdmits: false,
+    handlerRegistered: true,
+    deployConfigured: true,
+  }),
+  expected: "upgrade_required",
+});
+
+cases.push({
+  name: "configured_but_downgraded: plan denies, install present",
+  input: caseInput({
+    status: "available",
+    install: SOME_INSTALL,
+    planAdmits: false,
+    handlerRegistered: true,
+    deployConfigured: true,
+  }),
+  expected: "configured_but_downgraded",
+});
+
+cases.push({
+  name: "accessible: plan admits, no install, deploy ready",
+  input: caseInput({
+    status: "available",
+    install: null,
+    planAdmits: true,
+    handlerRegistered: true,
+    deployConfigured: true,
+  }),
+  expected: "accessible",
+});
+
+cases.push({
+  name: "connected: plan admits, install present, deploy ready",
+  input: caseInput({
+    status: "available",
+    install: SOME_INSTALL,
+    planAdmits: true,
+    handlerRegistered: true,
+    deployConfigured: true,
+  }),
+  expected: "connected",
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("resolveInstallStatus", () => {
+  it("covers every combination of the 5 input axes exactly once (32 rows)", () => {
+    expect(cases.length).toBe(32);
+    const seenInputs = new Set<string>();
+    for (const c of cases) {
+      const key = JSON.stringify(c.input);
+      expect(seenInputs.has(key)).toBe(false);
+      seenInputs.add(key);
+    }
+  });
+
+  for (const c of cases) {
+    it(c.name, () => {
+      expect(resolveInstallStatus(c.input)).toBe(c.expected);
+    });
+  }
+
+  it("the fixture reaches every CardState branch (exhaustiveness)", () => {
+    const seen = new Set<CardState>(cases.map((c) => c.expected));
+
+    // Listing every branch through a switch with an `assertNever`
+    // default is the compile-time guard. Adding a new CardState
+    // variant without adding an arm here breaks tsgo.
+    const all: CardState[] = [
+      "connected",
+      "accessible",
+      "coming_soon",
+      "misconfigured",
+      "upgrade_required",
+      "configured_but_downgraded",
+    ];
+    for (const s of all) {
+      switch (s) {
+        case "connected":
+        case "accessible":
+        case "coming_soon":
+        case "misconfigured":
+        case "upgrade_required":
+        case "configured_but_downgraded":
+          break;
+        default:
+          assertNever(s);
+      }
+      expect(seen.has(s)).toBe(true);
+    }
+  });
+});
+
+function assertNever(value: never): never {
+  throw new Error(`Unhandled CardState variant: ${String(value)}`);
+}

--- a/packages/api/src/lib/integrations/__tests__/install-status-machine.test.ts
+++ b/packages/api/src/lib/integrations/__tests__/install-status-machine.test.ts
@@ -1,23 +1,10 @@
 /**
- * Tests for `resolveInstallStatus` — slice 2 of #2738 (issue #2740).
+ * Exhaustive table coverage for `resolveInstallStatus`. The 32 rows
+ * enumerate every combination of the 5 boolean-ish input axes; the
+ * `ALL_CARD_STATES` table at the bottom is the compile-time guard that
+ * forces a new `CardState` variant to extend the fixture.
  *
- * Pure function under test. Three orthogonal gates from ADR-0006 /
- * ADR-0007 layer in priority order:
- *
- *   1. coming_soon  (Atlas hasn't shipped it)        → trumps everything
- *   2. misconfigured (operator hasn't wired env vars / handler)
- *   3. plan-gate    (existing upsell logic)
- *
- * When all three gates pass the card resolves to `accessible` (no
- * install) or `connected` (install row exists). When the plan gate
- * fails but an install row exists the card resolves to
- * `configured_but_downgraded` so the user can still disconnect.
- *
- * The table below enumerates every combination of the five boolean-ish
- * input axes (2^5 = 32 rows). The final `assertNever` switch is the
- * compile-time exhaustiveness guard required by the slice's
- * acceptance criteria — adding a new CardState variant without
- * extending the switch breaks the build.
+ * See `install-status-machine.ts` for the gate contract.
  */
 
 import { describe, it, expect } from "bun:test";
@@ -27,10 +14,6 @@ import {
   type ResolveInstallStatusInput,
   type WorkspaceInstallInput,
 } from "../install-status-machine";
-
-// ---------------------------------------------------------------------------
-// Fixture builders
-// ---------------------------------------------------------------------------
 
 const SOME_INSTALL: WorkspaceInstallInput = { installId: "default" };
 
@@ -50,6 +33,16 @@ function caseInput(opts: {
   };
 }
 
+function inputKey(input: ResolveInstallStatusInput): string {
+  return [
+    input.catalogRow.implementationStatus,
+    input.workspaceInstall ? input.workspaceInstall.installId : "_none",
+    input.planAdmits ? "plan" : "noplan",
+    input.handlerRegistered ? "handler" : "nohandler",
+    input.deployConfigured ? "deploy" : "nodeploy",
+  ].join("|");
+}
+
 interface Case {
   name: string;
   input: ResolveInstallStatusInput;
@@ -58,10 +51,7 @@ interface Case {
 
 const cases: Case[] = [];
 
-// ---------------------------------------------------------------------------
-// Gate 1 — coming_soon dominates all other gates (16 rows)
-// ---------------------------------------------------------------------------
-
+// Gate 1 — coming_soon dominates regardless of any other gate (16 rows).
 for (const install of [null, SOME_INSTALL]) {
   for (const planAdmits of [false, true]) {
     for (const handlerRegistered of [false, true]) {
@@ -82,17 +72,12 @@ for (const install of [null, SOME_INSTALL]) {
   }
 }
 
-// ---------------------------------------------------------------------------
-// Gate 2 — misconfigured: status=available but handler/deploy unwired
-// (12 rows: 3 broken-combos × 2 install × 2 plan)
-// ---------------------------------------------------------------------------
-
+// Gate 2 — status=available but handler/deploy unwired (12 rows).
 const brokenDeployStates: Array<{ handlerRegistered: boolean; deployConfigured: boolean }> = [
   { handlerRegistered: false, deployConfigured: false },
   { handlerRegistered: false, deployConfigured: true },
   { handlerRegistered: true, deployConfigured: false },
 ];
-
 for (const install of [null, SOME_INSTALL]) {
   for (const planAdmits of [false, true]) {
     for (const broken of brokenDeployStates) {
@@ -111,10 +96,7 @@ for (const install of [null, SOME_INSTALL]) {
   }
 }
 
-// ---------------------------------------------------------------------------
-// Gates 3 + happy paths — status=available, handler+deploy ready (4 rows)
-// ---------------------------------------------------------------------------
-
+// Gate 3 + happy paths — status=available, handler+deploy ready (4 rows).
 cases.push({
   name: "upgrade_required: plan denies, no install",
   input: caseInput({
@@ -126,7 +108,6 @@ cases.push({
   }),
   expected: "upgrade_required",
 });
-
 cases.push({
   name: "configured_but_downgraded: plan denies, install present",
   input: caseInput({
@@ -138,7 +119,6 @@ cases.push({
   }),
   expected: "configured_but_downgraded",
 });
-
 cases.push({
   name: "accessible: plan admits, no install, deploy ready",
   input: caseInput({
@@ -150,7 +130,6 @@ cases.push({
   }),
   expected: "accessible",
 });
-
 cases.push({
   name: "connected: plan admits, install present, deploy ready",
   input: caseInput({
@@ -163,17 +142,25 @@ cases.push({
   expected: "connected",
 });
 
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
+// Compile-time exhaustiveness guard: `satisfies Record<CardState, true>`
+// forces a new variant in `CardState` to add a key here, and the for-of
+// loop below asserts the fixture reaches that key at least once.
+const ALL_CARD_STATES = {
+  connected: true,
+  accessible: true,
+  coming_soon: true,
+  misconfigured: true,
+  upgrade_required: true,
+  configured_but_downgraded: true,
+} as const satisfies Record<CardState, true>;
 
 describe("resolveInstallStatus", () => {
   it("covers every combination of the 5 input axes exactly once (32 rows)", () => {
     expect(cases.length).toBe(32);
     const seenInputs = new Set<string>();
     for (const c of cases) {
-      const key = JSON.stringify(c.input);
-      expect(seenInputs.has(key)).toBe(false);
+      const key = inputKey(c.input);
+      expect(seenInputs.has(key), `duplicate fixture row: ${key}`).toBe(false);
       seenInputs.add(key);
     }
   });
@@ -186,35 +173,8 @@ describe("resolveInstallStatus", () => {
 
   it("the fixture reaches every CardState branch (exhaustiveness)", () => {
     const seen = new Set<CardState>(cases.map((c) => c.expected));
-
-    // Listing every branch through a switch with an `assertNever`
-    // default is the compile-time guard. Adding a new CardState
-    // variant without adding an arm here breaks tsgo.
-    const all: CardState[] = [
-      "connected",
-      "accessible",
-      "coming_soon",
-      "misconfigured",
-      "upgrade_required",
-      "configured_but_downgraded",
-    ];
-    for (const s of all) {
-      switch (s) {
-        case "connected":
-        case "accessible":
-        case "coming_soon":
-        case "misconfigured":
-        case "upgrade_required":
-        case "configured_but_downgraded":
-          break;
-        default:
-          assertNever(s);
-      }
-      expect(seen.has(s)).toBe(true);
+    for (const s of Object.keys(ALL_CARD_STATES) as CardState[]) {
+      expect(seen.has(s), `no fixture row produces CardState=${s}`).toBe(true);
     }
   });
 });
-
-function assertNever(value: never): never {
-  throw new Error(`Unhandled CardState variant: ${String(value)}`);
-}

--- a/packages/api/src/lib/integrations/install-status-machine.ts
+++ b/packages/api/src/lib/integrations/install-status-machine.ts
@@ -1,9 +1,8 @@
 /**
- * `resolveInstallStatus` — slice 2 of #2738 (issue #2740).
+ * `resolveInstallStatus` — pure state machine that maps a catalog row ×
+ * workspace install to a `CardState` for admin-UI rendering.
  *
- * Pure function. Encodes the three orthogonal gates from ADR-0006 and
- * ADR-0007 that determine how a catalog row × workspace install renders
- * in admin UIs. No IO, no Effect Context, no service deps.
+ * Encodes the three orthogonal gates from ADR-0006 and ADR-0007:
  *
  *   1. coming_soon  (Atlas hasn't shipped it)        → trumps everything
  *   2. misconfigured (operator hasn't wired env vars / handler)
@@ -13,18 +12,32 @@
  * present). When the plan gate fails but an install row exists the card
  * resolves to `configured_but_downgraded` so the user can still disconnect.
  *
- * Slice 3 (#2741 — `PillarCatalogQuery`) is the first consumer. Until
- * then this module is intentionally unwired.
+ * Pure function. No IO, no Effect Context, no service deps.
+ *
+ * TODO(#2741): If the first consumer (`PillarCatalogQuery`) needs
+ * state-specific payloads — e.g. which env var the operator must set for
+ * `misconfigured`, or the required plan tier for `upgrade_required` —
+ * promote `CardState` from a bare string union to a discriminated object
+ * union (`{ kind: "misconfigured", missing: readonly string[] } | …`)
+ * before more consumers attach parallel detail maps. Doing it later is
+ * a multi-consumer rewrite; doing it now is a ~20-line change.
  */
 
-export type ImplementationStatus = "available" | "coming_soon";
+import { type ImplementationStatus } from "@useatlas/types";
+
+export { type ImplementationStatus };
 
 /**
  * The six mutually exclusive render states for a catalog card.
  *
- * Adding a new variant requires updating the exhaustiveness fixture in
- * `install-status-machine.test.ts` — the `assertNever` switch there will
- * fail to compile until the table is extended.
+ * `configured_but_downgraded` is the orthogonal-to-presence companion to
+ * `upgrade_required` — same plan-gate verdict, but a workspace install row
+ * exists, so the card must keep offering disconnect. That's why this
+ * machine ships six states rather than the five named in PRD #2738.
+ *
+ * Adding a new variant: extend the `ALL_CARD_STATES` table in
+ * `install-status-machine.test.ts`. The `satisfies Record<CardState, …>`
+ * on that table forces the compile to fail until the new variant has a key.
  */
 export type CardState =
   | "connected"
@@ -35,25 +48,33 @@ export type CardState =
   | "configured_but_downgraded";
 
 /**
- * Minimal catalog-row shape the gate machine reads. The full
- * `plugin_catalog` row carries more (slug, type, install_model, plan,
- * etc.), but the state machine only depends on `implementationStatus`.
- * Callers in slice 3 (`PillarCatalogQuery`) own the precomputation of
- * `planAdmits` / `deployConfigured` / `handlerRegistered`.
+ * Minimal catalog-row shape the gate machine reads. The full `plugin_catalog`
+ * row carries many more columns; the state machine only depends on
+ * `implementationStatus`. `PillarCatalogQuery` (slice 3 / #2741) does the
+ * projection at the call site so the gate logic stays decoupled from the
+ * catalog schema.
  */
 export interface CatalogRowInput {
   readonly implementationStatus: ImplementationStatus;
 }
 
 /**
- * Marker shape for a `workspace_plugins` row. The state machine only
- * branches on existence (null vs non-null), but `installId` is required
- * to keep the type stable as slice 3 grows the read-side facade.
+ * `workspace_plugins` row passed by reference (or `null` if no install
+ * exists for this workspace × catalog row). The state machine only branches
+ * on null-vs-non-null; `installId` is included because slice 3's
+ * `PillarCatalogQuery` returns full install records and accepting them
+ * here avoids a mapping step at the call site. Multi-instance datasource
+ * installs (#2743 / #2744) call the machine once per install row.
  */
 export interface WorkspaceInstallInput {
   readonly installId: string;
 }
 
+/**
+ * Evaluated in priority order: `coming_soon` > `misconfigured` >
+ * plan-gate > {`accessible` | `connected`}. Each boolean gate is
+ * precomputed by the caller so the state machine stays pure.
+ */
 export interface ResolveInstallStatusInput {
   readonly catalogRow: CatalogRowInput;
   readonly workspaceInstall: WorkspaceInstallInput | null;
@@ -69,6 +90,10 @@ export function resolveInstallStatus(input: ResolveInstallStatusInput): CardStat
   if (input.catalogRow.implementationStatus === "coming_soon") {
     return "coming_soon";
   }
+  // TODO(#2741): slice 3 may need to distinguish `handler not registered`
+  // (Atlas-side) from `deploy not configured` (operator-side) to drive
+  // different remediation copy. Split this into two `CardState` variants
+  // (or carry a reason payload when CardState becomes discriminated).
   if (!input.handlerRegistered || !input.deployConfigured) {
     return "misconfigured";
   }

--- a/packages/api/src/lib/integrations/install-status-machine.ts
+++ b/packages/api/src/lib/integrations/install-status-machine.ts
@@ -1,0 +1,79 @@
+/**
+ * `resolveInstallStatus` — slice 2 of #2738 (issue #2740).
+ *
+ * Pure function. Encodes the three orthogonal gates from ADR-0006 and
+ * ADR-0007 that determine how a catalog row × workspace install renders
+ * in admin UIs. No IO, no Effect Context, no service deps.
+ *
+ *   1. coming_soon  (Atlas hasn't shipped it)        → trumps everything
+ *   2. misconfigured (operator hasn't wired env vars / handler)
+ *   3. plan-gate    (existing upsell logic)
+ *
+ * When all three pass: `accessible` (no install) or `connected` (install
+ * present). When the plan gate fails but an install row exists the card
+ * resolves to `configured_but_downgraded` so the user can still disconnect.
+ *
+ * Slice 3 (#2741 — `PillarCatalogQuery`) is the first consumer. Until
+ * then this module is intentionally unwired.
+ */
+
+export type ImplementationStatus = "available" | "coming_soon";
+
+/**
+ * The six mutually exclusive render states for a catalog card.
+ *
+ * Adding a new variant requires updating the exhaustiveness fixture in
+ * `install-status-machine.test.ts` — the `assertNever` switch there will
+ * fail to compile until the table is extended.
+ */
+export type CardState =
+  | "connected"
+  | "accessible"
+  | "coming_soon"
+  | "misconfigured"
+  | "upgrade_required"
+  | "configured_but_downgraded";
+
+/**
+ * Minimal catalog-row shape the gate machine reads. The full
+ * `plugin_catalog` row carries more (slug, type, install_model, plan,
+ * etc.), but the state machine only depends on `implementationStatus`.
+ * Callers in slice 3 (`PillarCatalogQuery`) own the precomputation of
+ * `planAdmits` / `deployConfigured` / `handlerRegistered`.
+ */
+export interface CatalogRowInput {
+  readonly implementationStatus: ImplementationStatus;
+}
+
+/**
+ * Marker shape for a `workspace_plugins` row. The state machine only
+ * branches on existence (null vs non-null), but `installId` is required
+ * to keep the type stable as slice 3 grows the read-side facade.
+ */
+export interface WorkspaceInstallInput {
+  readonly installId: string;
+}
+
+export interface ResolveInstallStatusInput {
+  readonly catalogRow: CatalogRowInput;
+  readonly workspaceInstall: WorkspaceInstallInput | null;
+  /** Plan-tier verdict precomputed by the caller (`min_plan` vs workspace plan). */
+  readonly planAdmits: boolean;
+  /** Operator-side readiness — every env var the `install_model` handler reads is present. */
+  readonly deployConfigured: boolean;
+  /** Atlas-side readiness — the `install_model` handler is registered in the install registry. */
+  readonly handlerRegistered: boolean;
+}
+
+export function resolveInstallStatus(input: ResolveInstallStatusInput): CardState {
+  if (input.catalogRow.implementationStatus === "coming_soon") {
+    return "coming_soon";
+  }
+  if (!input.handlerRegistered || !input.deployConfigured) {
+    return "misconfigured";
+  }
+  if (!input.planAdmits) {
+    return input.workspaceInstall !== null ? "configured_but_downgraded" : "upgrade_required";
+  }
+  return input.workspaceInstall !== null ? "connected" : "accessible";
+}


### PR DESCRIPTION
## Summary

Slice 2 of #2738 (three-pillar integration unification). Pure function `resolveInstallStatus` encoding the three orthogonal gates from [ADR-0006](docs/adr/0006-three-pillar-integration-taxonomy.md) / [ADR-0007](docs/adr/0007-unified-install-pipeline.md):

1. **coming_soon** (Atlas hasn't shipped it) — trumps everything
2. **misconfigured** (operator hasn't wired env vars / handler)
3. **plan-gate** (existing upsell logic)

Output is one of six `CardState` branches: `connected`, `accessible`, `coming_soon`, `misconfigured`, `upgrade_required`, `configured_but_downgraded`.

**Foundation-only.** No consumers wired up in this slice — slice 3 (#2741, `PillarCatalogQuery`) is the first reader. No end-user behaviour change.

Closes #2740.

## Files

- `packages/api/src/lib/integrations/install-status-machine.ts` — module exports `resolveInstallStatus`, `CardState`, input shapes.
- `packages/api/src/lib/integrations/__tests__/install-status-machine.test.ts` — 32-row exhaustive fixture (every combination of the 5 boolean-ish input axes) + exhaustiveness guard.

## Acceptance criteria (from #2740)

- [x] Module exports `resolveInstallStatus` pure function + `CardState` discriminated union
- [x] Exhaustive table test covering every combination → expected CardState. Fixture matrix proves all six CardState branches reachable.
- [x] Exhaustiveness guard via `never` switch — adding a new CardState variant fails to compile until the table is updated
- [x] No imports of Effect Context — pure function, no service dependencies
- [x] No reads from DB, env, or filesystem in test setup — fixtures only
- [x] `bun run type` + `bun run test:api` + lint + syncpack + template drift + railway-watch green

## Test plan

- [x] `bun test packages/api/src/lib/integrations/__tests__/install-status-machine.test.ts` — 34/34 pass
- [x] `bun run lint` — clean
- [x] `bun run type` — clean
- [x] `bun run test:api` — 448/448 pass (full isolated suite)
- [x] `bun x syncpack lint` — no issues
- [x] `SKIP_SYNCPACK=1 bash scripts/check-template-drift.sh` — 660 files verified
- [x] `bash scripts/check-railway-watch.sh` — all COPY sources covered

## Out of scope / known noise

- `bun run test:others` surfaces 2 pre-existing failures in `packages/mcp/src/__tests__/prompts/canonical.test.ts` (loadCanonicalPrompts default path returning 1 prompt instead of 20). **Reproduces on a clean `main`** — filed as #2757. Not introduced by this PR.

## Next slices

- #2741 (slice 3 — `PillarCatalogQuery` read-side facade) is the first consumer; it'll join `workspace_plugins` to `plugin_catalog` and feed precomputed `planAdmits` / `deployConfigured` / `handlerRegistered` into `resolveInstallStatus`.
- #2742, #2743 (slices 4–5 — `WorkspaceInstaller` write-side facade and built-in Datasource catalog rows) are independent and can run in parallel.