### PR TITLE
feat(types): #2740 — hoist IMPLEMENTATION_STATUSES + PILLARS literals (0.1.7)

### DIFF
--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useatlas/types",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Shared types for the Atlas text-to-SQL agent",
   "type": "module",
   "scripts": {

--- a/packages/types/src/catalog.ts
+++ b/packages/types/src/catalog.ts
@@ -52,6 +52,54 @@ export const CATALOG_ENTRY_TYPES = ["chat", "integration"] as const;
 export type CatalogEntryType = (typeof CATALOG_ENTRY_TYPES)[number];
 
 // ---------------------------------------------------------------------------
+// pillar — three-pillar taxonomy (ADR-0006)
+// ---------------------------------------------------------------------------
+
+/**
+ * The three orthogonal ways Atlas reaches the outside world, per ADR-0006:
+ *
+ * - `datasource` — Atlas reads tabular data from it (SQL / SOQL / equivalent).
+ *   Lives on `/admin/connections`. Examples: Postgres, MySQL, Snowflake,
+ *   ClickHouse, BigQuery, DuckDB, Salesforce.
+ * - `chat` — Customer talks to Atlas through it. Lives on
+ *   `/admin/integrations` (Chat section). Examples: Slack, Teams, Discord,
+ *   Google Chat, Telegram, WhatsApp.
+ * - `action` — Atlas writes to / acts on it. Lives on `/admin/integrations`
+ *   (Actions section). Examples: GitHub, Linear, Email, Webhooks.
+ *
+ * Multi-pillar systems (e.g. GitHub-as-Action-Target + future
+ * GitHub-as-Datasource) carry one catalog row per pillar, not one row
+ * with a pillar array — see ADR-0006 for the least-privilege rationale.
+ *
+ * Mirrors the `chk_plugin_catalog_pillar` and `chk_workspace_plugins_pillar`
+ * CHECK constraints on the DB (migration 0092).
+ */
+export const PILLARS = ["datasource", "chat", "action"] as const;
+export type Pillar = (typeof PILLARS)[number];
+
+// ---------------------------------------------------------------------------
+// implementation_status — coming-soon affordance (ADR-0007)
+// ---------------------------------------------------------------------------
+
+/**
+ * Whether Atlas has shipped a working install path for a catalog row.
+ *
+ * - `available` — install handler is wired; the card renders a working
+ *   Connect / Configure CTA (gated by plan + deploy-config).
+ * - `coming_soon` — Atlas hasn't shipped it yet; the card renders an
+ *   inert grey badge with no CTA. Operators can override per deploy via
+ *   `atlas.config.ts:overrideImplementationStatus`.
+ *
+ * `coming_soon` dominates every other gate in the install-status state
+ * machine (`@atlas/api/lib/integrations/install-status-machine`).
+ *
+ * Mirrors the `chk_plugin_catalog_implementation_status` CHECK constraint
+ * on the DB (migration 0092).
+ */
+export const IMPLEMENTATION_STATUSES = ["available", "coming_soon"] as const;
+export type ImplementationStatus = (typeof IMPLEMENTATION_STATUSES)[number];
+
+// ---------------------------------------------------------------------------
 // Chat adapter names
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Publish-first split for the slice-2 review of PR #2758 (issue #2740). Adds two new runtime tuples + derived literal unions to `packages/types/src/catalog.ts`:

- `PILLARS = ["datasource", "chat", "action"] as const`
- `IMPLEMENTATION_STATUSES = ["available", "coming_soon"] as const`

Mirrors the `chk_plugin_catalog_pillar` / `chk_workspace_plugins_pillar` / `chk_plugin_catalog_implementation_status` CHECK constraints from migration 0092 (#2739).

**Zero consumer changes.** PR #2758 (`install-status-machine.ts`) and slice 3's `PillarCatalogQuery` (#2741) will swap their local literals for these imports after this publishes to npm.

## Why publish-first

Matches the precedent set by #2665 / commit 828d46c5 for `CATALOG_INSTALL_MODELS` / `CATALOG_ENTRY_TYPES`. The publish-first split avoids the `Scaffold (docker)` / `Scaffold (vercel)` CI failure mode — `create-atlas/scripts/prepare-templates.sh` copies `packages/api/src/lib/integrations/` into scaffolds, which install `@useatlas/types` from the registry rather than from the workspace. Without a published version, the scaffold build fails with `Export X doesn't exist`.

## Test plan

- [x] `bun run --filter '@useatlas/types' build` — clean
- [x] CI will run `bun run type` repo-wide to verify nothing breaks
- [ ] After merge: tag `types-v0.1.7` to trigger the publish workflow
- [ ] After publish: rebase #2758 and swap local literals for these imports

## Follow-up

- After this merges, tag `types-v0.1.7` and push to trigger `.github/workflows/publish.yml`.
- Rebase PR #2758 on `main`; replace local `ImplementationStatus` union with imports from `@useatlas/types`.
- Slice 3 (#2741, `PillarCatalogQuery`) gets the `PILLARS` tuple ready for its Zod schema.

Refs #2740, #2738, #2665.