### PR TITLE
fix(mcp): #2757 — loadCanonicalPrompts default-path resolution

### DIFF
--- a/packages/mcp/src/__tests__/prompts/canonical.test.ts
+++ b/packages/mcp/src/__tests__/prompts/canonical.test.ts
@@ -14,6 +14,7 @@ import * as os from "os";
 import * as path from "path";
 import {
   loadCanonicalPrompts,
+  getCanonicalQuestionsPath,
   CANONICAL_PROMPT_PREFIX,
   type CanonicalPrompt,
 } from "../../prompts/canonical.js";
@@ -30,6 +31,15 @@ function writeQuestions(yamlBody: string): string {
 beforeEach(() => {
   tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "canonical-prompts-"));
   originalEnv = process.env.ATLAS_CANONICAL_QUESTIONS_PATH;
+  // Defensive: explicitly clear the env var so the "default path"
+  // test in this file genuinely exercises the walk-up resolution
+  // from `prompts/canonical.ts`. Sibling test files
+  // (`listing.test.ts`, `registry.test.ts`) set this env at module
+  // top-level + inside individual tests without always restoring it.
+  // When bun runs the whole suite in one process and they execute
+  // first, the leaked value pointed at a stale 1-question fixture
+  // and `loadCanonicalPrompts()` returned 1 instead of 20 (#2757).
+  delete process.env.ATLAS_CANONICAL_QUESTIONS_PATH;
 });
 
 afterEach(() => {
@@ -206,6 +216,29 @@ questions:
     for (const p of result) {
       expect(p.name.startsWith(CANONICAL_PROMPT_PREFIX)).toBe(true);
     }
+  });
+
+  // #2757 regression — the default path must resolve to the real
+  // repo-root `eval/canonical-questions/questions.yml`, not a leaked
+  // override from a sibling test file. Pre-fix, `listing.test.ts` and
+  // `registry.test.ts` set `ATLAS_CANONICAL_QUESTIONS_PATH` at module
+  // top-level and inside individual tests without restoring, leaking
+  // a 1-question fixture into this file's process state and silently
+  // dropping the "20 prompts" assertion to "1 prompt". The
+  // `beforeEach` `delete` above prevents env leakage; this test pins
+  // the actual resolved path so a future change to the loader's
+  // walk-up strategy fails loudly here (not silently three test files
+  // later).
+  it("default path resolves to the real repo-root fixture (#2757 regression)", () => {
+    expect(process.env.ATLAS_CANONICAL_QUESTIONS_PATH).toBeUndefined();
+    const resolved = getCanonicalQuestionsPath();
+    expect(resolved.endsWith("/eval/canonical-questions/questions.yml")).toBe(
+      true,
+    );
+    expect(fs.existsSync(resolved)).toBe(true);
+    // And the file it resolves to has the 20-question shape.
+    const result = loadCanonicalPrompts({ path: resolved });
+    expect(result.length).toBe(20);
   });
 
   // #2185 — runtime invariant check that mirrors the type-level

--- a/packages/mcp/src/__tests__/prompts/listing.test.ts
+++ b/packages/mcp/src/__tests__/prompts/listing.test.ts
@@ -9,7 +9,7 @@
  * registry.test.ts continues to exercise the SDK-bound flow end-to-end.
  */
 
-import { describe, expect, it, mock, beforeEach } from "bun:test";
+import { describe, expect, it, mock, beforeEach, afterEach } from "bun:test";
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
@@ -53,14 +53,9 @@ mock.module("@atlas/api/lib/settings", () => ({
 const emptyCanonicalDir = fs.mkdtempSync(
   path.join(os.tmpdir(), "listing-canonical-empty-"),
 );
-fs.writeFileSync(
-  path.join(emptyCanonicalDir, "questions.yml"),
-  "questions: []\n",
-);
-process.env.ATLAS_CANONICAL_QUESTIONS_PATH = path.join(
-  emptyCanonicalDir,
-  "questions.yml",
-);
+const emptyCanonicalFixture = path.join(emptyCanonicalDir, "questions.yml");
+fs.writeFileSync(emptyCanonicalFixture, "questions: []\n");
+process.env.ATLAS_CANONICAL_QUESTIONS_PATH = emptyCanonicalFixture;
 
 const { listMcpPrompts } = await import("../../prompts/listing.js");
 
@@ -70,6 +65,20 @@ beforeEach(() => {
   mockInternalQueryError = null;
   mockScannedEntities = [];
   mockSettings = {};
+  // Re-pin every test to the empty fixture so a prior test that
+  // overrode the env var (the "ordering" / "producer ↔ schema
+  // contract" tests below set 1-question fixtures inline) can't
+  // bleed its fixture into the next test in this file.
+  process.env.ATLAS_CANONICAL_QUESTIONS_PATH = emptyCanonicalFixture;
+});
+
+afterEach(() => {
+  // Bound the worst-case leak across the file boundary to a known
+  // 0-question fixture rather than whatever the last test set
+  // (#2757 — `canonical.test.ts`'s default-path test failed because
+  // a 1-question fixture leaked from here). The next test file's
+  // own setup is responsible for snapshotting + clearing.
+  process.env.ATLAS_CANONICAL_QUESTIONS_PATH = emptyCanonicalFixture;
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/mcp/src/__tests__/prompts/registry.test.ts
+++ b/packages/mcp/src/__tests__/prompts/registry.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, mock, beforeEach } from "bun:test";
+import { describe, expect, it, mock, beforeEach, afterEach } from "bun:test";
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
@@ -67,17 +67,31 @@ mock.module("@atlas/api/lib/logger", () => ({
 const emptyCanonicalDir = fs.mkdtempSync(
   path.join(os.tmpdir(), "registry-canonical-empty-"),
 );
-fs.writeFileSync(
-  path.join(emptyCanonicalDir, "questions.yml"),
-  "questions: []\n",
-);
-process.env.ATLAS_CANONICAL_QUESTIONS_PATH = path.join(
-  emptyCanonicalDir,
-  "questions.yml",
-);
+const emptyCanonicalFixture = path.join(emptyCanonicalDir, "questions.yml");
+fs.writeFileSync(emptyCanonicalFixture, "questions: []\n");
+process.env.ATLAS_CANONICAL_QUESTIONS_PATH = emptyCanonicalFixture;
 
 // Import after mocks
 const { registerPrompts } = await import("../../prompts/registry.js");
+
+// Defense in depth — re-pin the canonical env between every test so a
+// test that overrides it (e.g. the "canonical end-to-end" group below
+// that `delete`s it to exercise the real fixture) can't leak the
+// override into subsequent tests. This file pre-#2757 used to leave
+// `ATLAS_CANONICAL_QUESTIONS_PATH` pointing at whatever the last test
+// set it to, including into other test files via the shared process.
+beforeEach(() => {
+  process.env.ATLAS_CANONICAL_QUESTIONS_PATH = emptyCanonicalFixture;
+});
+
+afterEach(() => {
+  // Re-pin again so the LAST test in this file (whose override would
+  // otherwise persist past the file boundary) can't leak into the
+  // next test file's process state. The next file's own `beforeEach`
+  // is responsible for snapshotting + clearing; this just bounds the
+  // worst-case leaked value to a known-empty fixture.
+  process.env.ATLAS_CANONICAL_QUESTIONS_PATH = emptyCanonicalFixture;
+});
 
 // ---------------------------------------------------------------------------
 // Helpers


### PR DESCRIPTION
## Summary

Closes #2757.

`bun run --filter '@atlas/mcp' test` failed two tests in `packages/mcp/src/__tests__/prompts/canonical.test.ts` on a clean checkout of `main`:

- `loads all 20 prompts from the real eval/canonical-questions/questions.yml` (Expected 20, Received 1)
- `every loaded prompt satisfies the sourceMode↔evalMode invariant` (failed precondition: zero prompts loaded)

## Root cause

Default path resolution in `loadCanonicalPrompts()` is correct — confirmed by running `canonical.test.ts` in isolation (16/16). The actual bug was **env-var leakage from sibling test files**.

Both `listing.test.ts` and `registry.test.ts` set `ATLAS_CANONICAL_QUESTIONS_PATH` to fixture paths inside individual tests without restoring after:

- `listing.test.ts:296` (ordering test) — points at a 1-question fixture
- `listing.test.ts:372` (producer ↔ schema contract test) — also 1-question
- `registry.test.ts:622` and `:781` — 2-question fixtures

Because `bun test` runs every test file in one process, whichever of those tests ran last left `ATLAS_CANONICAL_QUESTIONS_PATH` pointing at a stale temp fixture. `canonical.test.ts`'s "default path" test then snapshotted that leaked value in its `beforeEach` `originalEnv =` line and reused it — hence "Received: 1".

The default path resolution itself (`__dirname` + `../../../../eval/canonical-questions/questions.yml`) works correctly. The issue's "Likely cause" hypotheses (changed walk-up, sibling YAML) were both wrong; the real cause is process-state pollution.

## Fix

- **`canonical.test.ts` `beforeEach`** explicitly `delete process.env.ATLAS_CANONICAL_QUESTIONS_PATH` so the "default path" test exercises the real walk-up resolution regardless of sibling state.
- **`listing.test.ts` + `registry.test.ts`** re-pin to a known-empty fixture in `beforeEach` (and in `afterEach` for `registry.test.ts`) so per-test overrides can't leak across the file boundary into other test files.
- **New regression test in `canonical.test.ts`** — `default path resolves to the real repo-root fixture (#2757 regression)` — pins both the resolved absolute path (`.../eval/canonical-questions/questions.yml`) and the 20-question count, so a future loader-resolution change fails loudly here rather than as a silent count drop.

## Silent-fallback note

Per CLAUDE.md error-handling rules, the issue asked whether `loadCanonicalPrompts` had a silent fallback masking the file miss. It does not — every catch in `canonical.ts` already logs to `process.stderr.write`. The "Failed to load prompt library" and "connection refused" lines in the failing test output came from `gating.ts` / `listing.ts` (DB-backed prompt library), not the canonical loader.

## Follow-up

While running the suite locally I hit a separate pre-existing failure in `canonical-mcp-auth.test.ts` caused by `hosted.test.ts`'s `mock.module()` stubs leaking process-globally (bun has no per-file mock scoping). It's intermittent — CI on `main` is green because bun 1.3.11 (CI) and 1.3.14 (local) order files differently — but it's a real bug. Filed as #2760.

## Test plan

- [x] `cd packages/mcp && bun test src/__tests__/prompts/canonical.test.ts` — 17/17 (including new regression test)
- [x] `cd packages/mcp && bun test src/__tests__/prompts/` — 76/76
- [x] `cd packages/mcp && bun test src/__tests__/prompts/listing.test.ts src/__tests__/prompts/canonical.test.ts` — 30/30 (verifies leak is fixed)
- [x] `bun run lint` — clean
- [x] `bun run type` — clean
- [x] `bun x syncpack lint` — clean
- [x] `SKIP_SYNCPACK=1 bash scripts/check-template-drift.sh` — clean
- [x] `bash scripts/check-railway-watch.sh` — clean
- [x] `bun run test:api` — 448/448