### PR TITLE
feat(api): #2741 — PillarCatalogQuery read-side facade + pillar in catalog wire shape

### DIFF
--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -64601,6 +64601,21 @@
                               "string",
                               "null"
                             ]
+                          },
+                          "pillar": {
+                            "type": "string",
+                            "enum": [
+                              "datasource",
+                              "chat",
+                              "action"
+                            ]
+                          },
+                          "implementationStatus": {
+                            "type": "string",
+                            "enum": [
+                              "available",
+                              "coming_soon"
+                            ]
                           }
                         },
                         "required": [
@@ -64618,7 +64633,9 @@
                           "installStatus",
                           "upsellOnly",
                           "accessible",
-                          "upgradeRequired"
+                          "upgradeRequired",
+                          "pillar",
+                          "implementationStatus"
                         ]
                       }
                     }

--- a/packages/api/src/__test-utils__/layers.ts
+++ b/packages/api/src/__test-utils__/layers.ts
@@ -44,6 +44,11 @@ import {
   createAnswerMeterTestLayer,
   type AnswerMeterShape,
 } from "@atlas/api/lib/proactive/answer-meter";
+import {
+  PillarCatalogQuery,
+  createPillarCatalogQueryTestLayer,
+  type PillarCatalogQueryShape,
+} from "@atlas/api/lib/effect/pillar-catalog-query";
 import { createConnectionTestLayer } from "../__mocks__/connection";
 
 // ── Re-exports for convenience ──────────────────────────────────────
@@ -54,16 +59,19 @@ export {
   createAuthContextTestLayer,
   createPluginTestLayer,
   createAnswerMeterTestLayer,
+  createPillarCatalogQueryTestLayer,
   ConnectionRegistry,
   RequestContext,
   AuthContext,
   PluginRegistry,
   AnswerMeter,
+  PillarCatalogQuery,
   type ConnectionRegistryShape,
   type RequestContextShape,
   type AuthContextShape,
   type PluginRegistryShape,
   type AnswerMeterShape,
+  type PillarCatalogQueryShape,
 };
 
 // ── Default connection layer ────────────────────────────────────────

--- a/packages/api/src/api/__tests__/integrations-catalog.test.ts
+++ b/packages/api/src/api/__tests__/integrations-catalog.test.ts
@@ -1,222 +1,75 @@
 /**
- * Tests for GET /api/v1/integrations/catalog (#2651, slice 3 of 1.5.2).
+ * Tests for GET /api/v1/integrations/catalog.
  *
- * Drives the catalog read-only endpoint directly without going through the
- * full admin router import graph. Follows the admin-marketplace.test.ts shape
- * — module-level mocks for `effect`, `@atlas/api/lib/effect/services`, and
- * `@atlas/api/lib/db/internal` — so we can assert plan filtering, install-state
- * join, SaaS `saas_eligible` filter, and admin-role gating without standing up
- * the entire app.
+ * Post-#2741 (slice 3 of 1.5.3): the route is a thin projection over the
+ * `PillarCatalogQuery` facade. The route owns:
+ *   - admin gating (delegated to `requireOrgContext()` + `createAdminRouter`)
+ *   - `hasInternalDB()` short-circuit → 404
+ *   - facade `withInstallStatusFor(orgId)` invocation
+ *   - rich-row → wire-shape projection (preserves `type`, `accessible`,
+ *     `upsellOnly`, `installStatus`, `installedAt`, `installedBy`; adds
+ *     `pillar` + `implementationStatus`)
+ *
+ * The pre-slice-3 test mocked `internalQuery` to assert plan-filtering /
+ * deploy-mode SQL fragments — that surface moved into the facade and is
+ * covered there (`lib/effect/__tests__/pillar-catalog-query.test.ts`).
+ * This file pins ONLY the route-level surface: gating, the 404 short
+ * circuit, and the wire-shape projection (including the two new fields).
  */
 
 import { describe, it, expect, beforeEach, mock, type Mock } from "bun:test";
+import { Effect } from "effect";
+import type { CatalogEntryWithState } from "@atlas/api/lib/effect/pillar-catalog-query";
 
-// --- Audit capture ---
+// ---------------------------------------------------------------------------
+// Facade stub — single source of truth for the test's response shape.
+// ---------------------------------------------------------------------------
 
-interface CapturedAuditEntry {
-  actionType: string;
-  targetType: string;
-  targetId: string;
-  status?: "success" | "failure";
-  metadata?: Record<string, unknown>;
-  scope?: "platform" | "workspace";
-  ipAddress?: string | null;
-}
+const mockWithInstallStatusFor: Mock<
+  (workspaceId: string) => Effect.Effect<readonly CatalogEntryWithState[], Error>
+> = mock(() => Effect.succeed([] as readonly CatalogEntryWithState[]));
 
-const mockLogAdminAction: Mock<(entry: CapturedAuditEntry) => void> = mock(() => {});
+let mockHasInternalDB = true;
 
-mock.module("@atlas/api/lib/audit", async () => {
-  const actual = await import("@atlas/api/lib/audit/actions");
-  return {
-    logAdminAction: mockLogAdminAction,
-    logAdminActionAwait: mock(async () => {}),
-    ADMIN_ACTIONS: actual.ADMIN_ACTIONS,
-  };
-});
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const realPillarFacade = require("@atlas/api/lib/effect/pillar-catalog-query") as typeof import("@atlas/api/lib/effect/pillar-catalog-query");
 
-mock.module("@atlas/api/lib/audit/error-scrub", () => ({
-  errorMessage: (err: unknown): string => {
-    const raw = err instanceof Error ? err.message : String(err);
-    return raw.length > 512 ? `${raw.slice(0, 509)}...` : raw;
-  },
-  causeToError: () => undefined,
-}));
-
-// --- Effect bridge shim ---
-
-const mockEffectUser: Record<string, unknown> = {
-  id: "admin-1",
-  mode: "simple-key",
-  role: "admin",
-  activeOrganizationId: "org-1",
-  orgId: "org-1",
-};
-
-const fakeAuthContext = {
-  [Symbol.iterator]: function* (): Generator<unknown, Record<string, unknown>> {
-    return yield mockEffectUser;
-  },
-};
-
-interface TestEffectPromise {
-  _tag: "EffectPromise";
-  fn: () => Promise<unknown>;
-  errorTaps: Array<(err: unknown) => unknown>;
-}
-
-interface TestPipeable {
-  [Symbol.iterator]: () => Generator<unknown, unknown>;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- pipe is variadic across operator types
-  pipe(...ops: Array<(source: TestPipeable) => any>): any;
-}
-
-function makePipeable(effectValue: TestEffectPromise): TestPipeable {
-  const pipeable: TestPipeable = {
-    [Symbol.iterator]: function* (): Generator<unknown, unknown> {
-      return yield effectValue;
-    },
-    pipe(...ops) {
-      let current: TestPipeable = pipeable;
-      for (const op of ops) current = op(current);
-      return current;
-    },
-  };
-  return pipeable;
-}
-
-mock.module("effect", () => {
-  const Effect = {
-    gen: (genFn: () => Generator) => ({ _tag: "EffectGen", genFn }),
-    promise: (fn: () => Promise<unknown>) => {
-      const effectValue: TestEffectPromise = { _tag: "EffectPromise", fn, errorTaps: [] };
-      return makePipeable(effectValue);
-    },
-    // `tryPromise({ try, catch })` — shim treats it as a promise that runs
-    // `try()`; on rejection it applies `catch(err)` before propagation
-    // (matches real Effect's typed-failure channel for assertions).
-    tryPromise: <E>(opts: { try: () => Promise<unknown>; catch: (err: unknown) => E }) => {
-      const effectValue: TestEffectPromise = {
-        _tag: "EffectPromise",
-        fn: async () => {
-          try {
-            return await opts.try();
-          } catch (err) {
-            throw opts.catch(err);
-          }
-        },
-        errorTaps: [],
-      };
-      return makePipeable(effectValue);
-    },
-    runPromise: (value: unknown) => Promise.resolve(value),
-    sync: (syncFn: () => unknown) => ({ _tag: "EffectSync", fn: syncFn }),
-    tapError: (handler: (err: unknown) => unknown) => (source: TestPipeable) => {
-      const originalIterator = source[Symbol.iterator].bind(source);
-      const newPipeable: TestPipeable = {
-        [Symbol.iterator]: function* (): Generator<unknown, unknown> {
-          const gen = originalIterator();
-          let next = gen.next();
-          while (!next.done) {
-            const value = next.value;
-            if (
-              value &&
-              typeof value === "object" &&
-              (value as { _tag?: string })._tag === "EffectPromise"
-            ) {
-              (value as TestEffectPromise).errorTaps.push(handler);
-            }
-            const piped = yield value;
-            next = gen.next(piped);
-          }
-          return next.value;
-        },
-        pipe: source.pipe.bind(source),
-      };
-      return newPipeable;
-    },
-  };
-  return { Effect };
-});
-
-mock.module("@atlas/api/lib/effect/services", () => ({
-  AuthContext: fakeAuthContext,
-  RequestContext: {
-    [Symbol.iterator]: function* (): Generator<unknown, unknown> {
-      return yield { requestId: "test-req-1", startTime: Date.now() };
-    },
-  },
-  makeRequestContextLayer: () => ({}),
-  makeAuthContextLayer: () => ({}),
-  NoopEnterpriseDefaultsLayer: { _tag: "MockLayer" },
-  IpAllowlistPolicy: { _tag: "MockTag" },
-  SSOPolicy: { _tag: "MockTag" },
-  SCIMProvenance: { _tag: "MockTag" },
-  RolesPolicy: {
-    [Symbol.iterator]: function* (): Generator<unknown, unknown> {
-      return yield {};
-    },
-  },
-}));
-
-mock.module("@atlas/api/lib/effect/enterprise-layer", () => ({
-  EnterpriseLayer: { _tag: "MockLayer" },
-  getEnterpriseRuntime: () => ({
-    runPromise: () => Promise.resolve(undefined),
-    runPromiseExit: () => Promise.resolve({ _tag: "Success", value: undefined } as never),
-    dispose: () => Promise.resolve(),
+mock.module("@atlas/api/lib/effect/pillar-catalog-query", () => ({
+  ...realPillarFacade,
+  // Replace the Live Layer with a test layer that delegates to the mock.
+  PillarCatalogQueryLive: realPillarFacade.createPillarCatalogQueryTestLayer({
+    withInstallStatusFor: (workspaceId) => mockWithInstallStatusFor(workspaceId),
+    getByPillar: () =>
+      Effect.fail(new Error("test: getByPillar not used by this route")),
+    getBySlug: () =>
+      Effect.fail(new Error("test: getBySlug not used by this route")),
   }),
-  runEnterprise: () => Promise.resolve(undefined),
 }));
 
-mock.module("@atlas/api/lib/effect/hono", () => ({
-  runEffect: async (
-    _c: unknown,
-    effect: { _tag: string; genFn: () => Generator },
-    _opts?: unknown,
-  ) => {
-    const gen = effect.genFn();
-    let result = gen.next();
-    while (!result.done) {
-      const value = result.value;
-      if (
-        value &&
-        typeof value === "object" &&
-        (value as { _tag?: string })._tag === "EffectPromise"
-      ) {
-        const promiseValue = value as TestEffectPromise;
-        try {
-          const resolved = await promiseValue.fn();
-          result = gen.next(resolved);
-        } catch (err) {
-          for (const tap of promiseValue.errorTaps) {
-            try {
-              const tapResult = tap(err);
-              if (
-                tapResult &&
-                typeof tapResult === "object" &&
-                (tapResult as { _tag?: string })._tag === "EffectSync"
-              ) {
-                (tapResult as { fn: () => unknown }).fn();
-              }
-            } catch {
-              // tap failures must not swallow the original error
-            }
-          }
-          result = gen.throw(err);
-        }
-      } else {
-        result = gen.next(value);
-      }
-    }
-    return result.value;
-  },
-  DomainErrorMapping: Array,
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const realDbInternal = require("@atlas/api/lib/db/internal") as typeof import("@atlas/api/lib/db/internal");
+
+mock.module("@atlas/api/lib/db/internal", () => ({
+  ...realDbInternal,
+  hasInternalDB: () => mockHasInternalDB,
+  // makeInternalDBShimLayer is invoked by the route; pass through the
+  // real implementation so the facade test layer (which doesn't read
+  // InternalDB) just gets a no-op shim.
+  makeInternalDBShimLayer: realDbInternal.makeInternalDBShimLayer,
 }));
 
-// --- Middleware mock — bypass adminAuth so tests can set context vars directly ---
+mock.module("@atlas/api/lib/logger", () => ({
+  createLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  }),
+  withRequestContext: (_ctx: unknown, fn: () => unknown) => fn(),
+}));
 
+// Bypass adminAuth/MFA so the test can inject `orgContext` directly.
 import { createMiddleware } from "hono/factory";
-
 const passthrough = createMiddleware(async (_c, next) => {
   await next();
 });
@@ -228,12 +81,6 @@ mock.module("./routes/middleware", () => ({
   standardAuth: passthrough,
   withRequestId: passthrough,
 }));
-
-// admin-router.ts imports adminAuth/mfaRequired via relative `./middleware`
-// + `./admin-mfa-required`. Bun's mock.module key matches the literal import
-// spec — duplicate the registration under those specs so the real
-// middleware never runs (otherwise adminAuth re-runs authenticateRequest and
-// overwrites the test's `c.set("authResult", ...)`).
 mock.module("../routes/middleware", () => ({
   adminAuth: passthrough,
   platformAdminAuth: passthrough,
@@ -241,13 +88,15 @@ mock.module("../routes/middleware", () => ({
   standardAuth: passthrough,
   withRequestId: passthrough,
 }));
-
 mock.module("@atlas/api/api/routes/middleware", () => ({
   adminAuth: passthrough,
   platformAdminAuth: passthrough,
   requestContext: passthrough,
   standardAuth: passthrough,
   withRequestId: passthrough,
+}));
+mock.module("./routes/admin-mfa-required", () => ({
+  mfaRequired: passthrough,
 }));
 
 mock.module("@atlas/api/lib/auth/middleware", () => ({
@@ -265,78 +114,15 @@ mock.module("@atlas/api/lib/auth/middleware", () => ({
   _setValidatorOverrides: mock(() => {}),
 }));
 
-mock.module("./routes/admin-mfa-required", () => ({
-  mfaRequired: passthrough,
-}));
-
-// --- Deploy-mode config mock — flip per test ---
-
-let mockConfigOverride: { deployMode?: "saas" | "self-hosted" } | null = null;
-
-mock.module("@atlas/api/lib/config", () => ({
-  getConfig: () => mockConfigOverride,
-  defineConfig: (c: unknown) => c,
-}));
-
-// --- Internal DB mock ---
-
-let mockHasInternalDB = true;
-let mockQueryResults: Map<string, unknown[] | Error> = new Map();
-let capturedQueries: Array<{ sql: string; params: unknown[] }> = [];
-
-function setQueryResult(pattern: string, rows: unknown[] | Error) {
-  mockQueryResults.set(pattern, rows);
-}
-
-function findQueryResult(sql: string): unknown[] | Error {
-  for (const [pattern, rows] of mockQueryResults) {
-    if (sql.includes(pattern)) return rows;
-  }
-  return [];
-}
-
-function invokeInternalQueryMock(sql: string, params: unknown[] = []): Promise<unknown[]> {
-  capturedQueries.push({ sql, params });
-  const result = findQueryResult(sql);
-  return result instanceof Error ? Promise.reject(result) : Promise.resolve(result);
-}
-
-mock.module("@atlas/api/lib/db/internal", () => ({
-  hasInternalDB: () => mockHasInternalDB,
-  getInternalDB: () => ({
-    query: () => Promise.resolve({ rows: [] }),
-    end: async () => {},
-    on: () => {},
-  }),
-  internalQuery: (sql: string, params?: unknown[]) => invokeInternalQueryMock(sql, params),
-  queryEffect: (sql: string, params?: unknown[]) => {
-    const effectValue: TestEffectPromise = {
-      _tag: "EffectPromise",
-      fn: () => invokeInternalQueryMock(sql, params),
-      errorTaps: [],
-    };
-    return makePipeable(effectValue);
-  },
-  internalExecute: () => {},
-}));
-
-mock.module("@atlas/api/lib/logger", () => ({
-  createLogger: () => ({
-    info: () => {},
-    warn: () => {},
-    error: () => {},
-    debug: () => {},
-  }),
-  withRequestContext: (_ctx: unknown, fn: () => unknown) => fn(),
-}));
-
-// --- Import the router after mocks ---
+// ---------------------------------------------------------------------------
+// Import after mocks
+// ---------------------------------------------------------------------------
 
 const { integrationsCatalog } = await import("../routes/integrations-catalog");
 const { OpenAPIHono } = await import("@hono/zod-openapi");
 
 // ---------------------------------------------------------------------------
-// Test helpers
+// Helpers
 // ---------------------------------------------------------------------------
 
 function buildApp(role: string = "admin", orgId: string | null = "org-1") {
@@ -361,59 +147,27 @@ function buildApp(role: string = "admin", orgId: string | null = "org-1") {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test helper for untyped JSON responses
 const json = (res: Response) => res.json() as Promise<any>;
 
-const now = new Date().toISOString();
-
-const slackRow = {
-  id: "catalog:slack",
-  slug: "slack",
-  name: "Slack",
-  description: "Connect Slack to receive answers in channel.",
-  type: "chat",
-  install_model: "oauth",
-  icon_url: null,
-  config_schema: null,
-  min_plan: "starter",
-  enabled: true,
-  saas_eligible: true,
-  created_at: now,
-  updated_at: now,
-};
-
-// Post-#2666 vocabulary: catalog min_plan uses PLAN_TIERS only (no
-// `team` / `enterprise`). Salesforce is a premium integration that
-// would have been `team` pre-#2666; the migration backfills to
-// `business`.
-const teamRow = {
-  id: "catalog:salesforce",
-  slug: "salesforce",
-  name: "Salesforce",
-  description: "Sync Salesforce records.",
-  type: "integration",
-  install_model: "oauth",
-  icon_url: null,
-  config_schema: null,
-  min_plan: "business",
-  enabled: true,
-  saas_eligible: true,
-  created_at: now,
-  updated_at: now,
-};
-
-const githubPatRow = {
-  id: "catalog:github-pat",
-  slug: "github-pat",
-  name: "GitHub (PAT)",
-  description: "Per-user personal access token.",
-  type: "integration",
-  install_model: "form",
-  icon_url: null,
-  config_schema: null,
-  min_plan: "starter",
-  enabled: true,
-  saas_eligible: false,
-  created_at: now,
-  updated_at: now,
-};
+function makeRichRow(overrides: Partial<CatalogEntryWithState> = {}): CatalogEntryWithState {
+  return {
+    id: "catalog:slack",
+    slug: "slack",
+    name: "Slack",
+    description: "Connect Slack",
+    type: "chat",
+    installModel: "oauth",
+    iconUrl: null,
+    configSchema: null,
+    minPlan: "starter",
+    saasEligible: true,
+    pillar: "chat",
+    implementationStatus: "available",
+    autoInstall: false,
+    install: null,
+    state: "accessible",
+    planAccessible: true,
+    ...overrides,
+  };
+}
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -422,18 +176,14 @@ const githubPatRow = {
 describe("GET /api/v1/integrations/catalog", () => {
   beforeEach(() => {
     mockHasInternalDB = true;
-    mockQueryResults = new Map();
-    capturedQueries = [];
-    mockConfigOverride = null;
-    mockLogAdminAction.mockClear();
+    mockWithInstallStatusFor.mockReset();
+    mockWithInstallStatusFor.mockReturnValue(
+      Effect.succeed([] as readonly CatalogEntryWithState[]),
+    );
   });
 
   describe("admin gating", () => {
     it("returns 400 when no active org", async () => {
-      setQueryResult("FROM organization WHERE id", [{ plan_tier: "starter" }]);
-      setQueryResult("FROM plugin_catalog", [slackRow]);
-      setQueryResult("FROM workspace_plugins", []);
-
       const app = buildApp("admin", null);
       const res = await app.request("/integrations/catalog");
       expect(res.status).toBe(400);
@@ -447,17 +197,23 @@ describe("GET /api/v1/integrations/catalog", () => {
     });
   });
 
-  describe("response shape", () => {
-    it("returns enabled catalog entries with installed=false when no installations", async () => {
-      setQueryResult("FROM organization WHERE id", [{ plan_tier: "starter" }]);
-      setQueryResult("FROM plugin_catalog", [slackRow]);
-      setQueryResult("FROM workspace_plugins", []);
+  describe("facade invocation", () => {
+    it("calls withInstallStatusFor with the caller's orgId", async () => {
+      const app = buildApp();
+      await app.request("/integrations/catalog");
+      expect(mockWithInstallStatusFor).toHaveBeenCalledWith("org-1");
+    });
+  });
+
+  describe("wire-shape projection", () => {
+    it("projects a rich row to the wire envelope (no install)", async () => {
+      const row = makeRichRow({ state: "accessible", planAccessible: true });
+      mockWithInstallStatusFor.mockReturnValueOnce(Effect.succeed([row]));
 
       const app = buildApp();
       const res = await app.request("/integrations/catalog");
       expect(res.status).toBe(200);
       const body = await json(res);
-      expect(body.catalog).toHaveLength(1);
       const entry = body.catalog[0];
       expect(entry.id).toBe("catalog:slack");
       expect(entry.slug).toBe("slack");
@@ -470,267 +226,79 @@ describe("GET /api/v1/integrations/catalog", () => {
       expect(entry.installedBy).toBeNull();
       expect(entry.installStatus).toBeNull();
       expect(entry.upsellOnly).toBe(false);
+      expect(entry.accessible).toBe(true);
+      expect(entry.upgradeRequired).toBeNull();
+      // New #2741 fields:
+      expect(entry.pillar).toBe("chat");
+      expect(entry.implementationStatus).toBe("available");
     });
 
-    it("surfaces installStatus from workspace_plugins.config (e.g. reconnect_needed for Salesforce)", async () => {
-      // #2658 — the Salesforce refresh-token flow flips config.status to
-      // 'reconnect_needed' on permanent failure. The catalog response
-      // carries the flag so /admin/integrations can render the
-      // Reconnect affordance.
-      setQueryResult("FROM organization WHERE id", [{ plan_tier: "starter" }]);
-      setQueryResult("FROM plugin_catalog", [slackRow]);
-      setQueryResult("FROM workspace_plugins", [
-        {
-          catalog_id: "catalog:slack",
-          installed_at: now,
-          installed_by: "user-42",
-          install_status: "reconnect_needed",
+    it("surfaces install metadata when an install is present", async () => {
+      const row = makeRichRow({
+        state: "connected",
+        planAccessible: true,
+        install: {
+          id: "install-1",
+          catalogId: "catalog:slack",
+          installId: "catalog:slack",
+          workspaceId: "org-1",
+          pillar: "chat",
+          installedAt: "2026-05-20T10:00:00.000Z",
+          installedBy: "user-42",
+          status: "reconnect_needed",
+          disabled: false,
         },
-      ]);
+      });
+      mockWithInstallStatusFor.mockReturnValueOnce(Effect.succeed([row]));
 
       const app = buildApp();
       const res = await app.request("/integrations/catalog");
       expect(res.status).toBe(200);
       const body = await json(res);
-      expect(body.catalog[0].installStatus).toBe("reconnect_needed");
+      const entry = body.catalog[0];
+      expect(entry.installed).toBe(true);
+      expect(entry.installedAt).toBe("2026-05-20T10:00:00.000Z");
+      expect(entry.installedBy).toBe("user-42");
+      expect(entry.installStatus).toBe("reconnect_needed");
     });
 
-    it("only includes enabled rows (planner filter at SQL layer)", async () => {
-      // Endpoint should issue `WHERE enabled = true` — the mock matches the
-      // SQL fragment and returns only enabled rows. This test asserts the
-      // contract by verifying the captured SQL.
-      setQueryResult("FROM organization WHERE id", [{ plan_tier: "starter" }]);
-      setQueryResult("FROM plugin_catalog", [slackRow]);
-      setQueryResult("FROM workspace_plugins", []);
-
-      const app = buildApp();
-      const res = await app.request("/integrations/catalog");
-      expect(res.status).toBe(200);
-
-      const catalogQuery = capturedQueries.find((q) => q.sql.includes("FROM plugin_catalog"));
-      expect(catalogQuery).toBeDefined();
-      expect(catalogQuery!.sql).toContain("enabled = true");
-    });
-
-    it("filters out legacy plugin_catalog `type` values at the SQL layer", async () => {
-      // The DB CHECK admits `datasource|context|interaction|action|sandbox`
-      // (legacy marketplace types) alongside the new `chat|integration`
-      // values. The customer-facing endpoint must narrow to the new pair
-      // or the client-side Zod parse will fail.
-      setQueryResult("FROM organization WHERE id", [{ plan_tier: "starter" }]);
-      setQueryResult("FROM plugin_catalog", [slackRow]);
-      setQueryResult("FROM workspace_plugins", []);
-
-      const app = buildApp();
-      const res = await app.request("/integrations/catalog");
-      expect(res.status).toBe(200);
-
-      const catalogQuery = capturedQueries.find((q) => q.sql.includes("FROM plugin_catalog"));
-      expect(catalogQuery).toBeDefined();
-      expect(catalogQuery!.sql).toContain("type IN ('chat', 'integration')");
-    });
-  });
-
-  describe("install-state join", () => {
-    it("marks rows installed when workspace_plugins row exists", async () => {
-      setQueryResult("FROM organization WHERE id", [{ plan_tier: "starter" }]);
-      setQueryResult("FROM plugin_catalog", [slackRow]);
-      setQueryResult("FROM workspace_plugins", [
-        {
-          catalog_id: "catalog:slack",
-          installed_at: now,
-          installed_by: "user-42",
-        },
-      ]);
+    it("flags above-plan rows as upsellOnly with upgradeRequired carrying the catalog min_plan", async () => {
+      const row = makeRichRow({
+        slug: "salesforce",
+        type: "integration",
+        pillar: "action",
+        minPlan: "business",
+        state: "upgrade_required",
+        planAccessible: false,
+      });
+      mockWithInstallStatusFor.mockReturnValueOnce(Effect.succeed([row]));
 
       const app = buildApp();
       const res = await app.request("/integrations/catalog");
       expect(res.status).toBe(200);
       const body = await json(res);
-      expect(body.catalog[0].installed).toBe(true);
-      expect(body.catalog[0].installedAt).toBe(now);
-      expect(body.catalog[0].installedBy).toBe("user-42");
+      const entry = body.catalog[0];
+      expect(entry.upsellOnly).toBe(true);
+      expect(entry.accessible).toBe(false);
+      expect(entry.upgradeRequired).toBe("business");
+      expect(entry.pillar).toBe("action");
     });
 
-    it("converts Date-typed installed_at to ISO string (pg returns timestamptz as Date)", async () => {
-      const installedDate = new Date("2026-05-19T10:00:00Z");
-      setQueryResult("FROM organization WHERE id", [{ plan_tier: "starter" }]);
-      setQueryResult("FROM plugin_catalog", [slackRow]);
-      setQueryResult("FROM workspace_plugins", [
-        {
-          catalog_id: "catalog:slack",
-          installed_at: installedDate,
-          installed_by: "user-42",
-        },
-      ]);
+    it("surfaces the implementationStatus field for coming-soon rows", async () => {
+      const row = makeRichRow({
+        slug: "teams",
+        pillar: "chat",
+        implementationStatus: "coming_soon",
+        state: "coming_soon",
+        planAccessible: true,
+      });
+      mockWithInstallStatusFor.mockReturnValueOnce(Effect.succeed([row]));
 
       const app = buildApp();
       const res = await app.request("/integrations/catalog");
-      expect(res.status).toBe(200);
       const body = await json(res);
-      expect(body.catalog[0].installedAt).toBe(installedDate.toISOString());
-    });
-
-    it("scopes workspace_plugins lookup to caller's org via WHERE workspace_id = $1", async () => {
-      setQueryResult("FROM organization WHERE id", [{ plan_tier: "starter" }]);
-      setQueryResult("FROM plugin_catalog", [slackRow]);
-      setQueryResult("FROM workspace_plugins", []);
-
-      const app = buildApp();
-      await app.request("/integrations/catalog");
-      const wpQuery = capturedQueries.find((q) => q.sql.includes("FROM workspace_plugins"));
-      expect(wpQuery).toBeDefined();
-      // Asserting both the SQL fragment AND `params[0] === orgId` guards
-      // against a regression that drops the WHERE clause (cross-tenant
-      // install-state leakage). `params.toContain` alone would pass even
-      // if `workspace_id = $1` were removed.
-      expect(wpQuery!.sql).toContain("workspace_id = $1");
-      expect(wpQuery!.params[0]).toBe("org-1");
-    });
-  });
-
-  describe("plan filtering", () => {
-    it("flags above-plan entries as upsellOnly=true", async () => {
-      // Workspace on starter; Salesforce requires business — should appear
-      // with `upsellOnly: true`, not be filtered out.
-      setQueryResult("FROM organization WHERE id", [{ plan_tier: "starter" }]);
-      setQueryResult("FROM plugin_catalog", [slackRow, teamRow]);
-      setQueryResult("FROM workspace_plugins", []);
-
-      const app = buildApp();
-      const res = await app.request("/integrations/catalog");
-      expect(res.status).toBe(200);
-      const body = await json(res);
-      expect(body.catalog).toHaveLength(2);
-      const slack = body.catalog.find((e: { slug: string }) => e.slug === "slack");
-      const salesforce = body.catalog.find((e: { slug: string }) => e.slug === "salesforce");
-      expect(slack.upsellOnly).toBe(false);
-      expect(salesforce.upsellOnly).toBe(true);
-    });
-
-    it("flags unknown min_plan values as upsellOnly (fail-closed)", async () => {
-      // `#2666` migration window: a min_plan value outside both vocabularies
-      // (e.g. typo or future tier) must render read-only rather than
-      // silently allow install.
-      setQueryResult("FROM organization WHERE id", [{ plan_tier: "starter" }]);
-      setQueryResult("FROM plugin_catalog", [
-        { ...slackRow, min_plan: "platinum" },
-      ]);
-      setQueryResult("FROM workspace_plugins", []);
-
-      const app = buildApp();
-      const res = await app.request("/integrations/catalog");
-      expect(res.status).toBe(200);
-      const body = await json(res);
-      expect(body.catalog[0].upsellOnly).toBe(true);
-    });
-
-    it("flags upsellOnly=false when workspace plan meets min_plan", async () => {
-      setQueryResult("FROM organization WHERE id", [{ plan_tier: "business" }]);
-      setQueryResult("FROM plugin_catalog", [slackRow, teamRow]);
-      setQueryResult("FROM workspace_plugins", []);
-
-      const app = buildApp();
-      const res = await app.request("/integrations/catalog");
-      expect(res.status).toBe(200);
-      const body = await json(res);
-      const salesforce = body.catalog.find((e: { slug: string }) => e.slug === "salesforce");
-      expect(salesforce.upsellOnly).toBe(false);
-    });
-
-    it("emits `accessible` and `upgradeRequired` per entry — accessible=true → upgradeRequired=null", async () => {
-      // Pin the 1.5.2 four-layer-entitlement contract: the admin UI's
-      // catalog-section reads BOTH fields, so a regression that drops
-      // either (or inverts the invariant) would silently break the
-      // three-state card render. Asserting at the route level keeps
-      // the contract pinned without round-tripping through the UI.
-      setQueryResult("FROM organization WHERE id", [{ plan_tier: "business" }]);
-      setQueryResult("FROM plugin_catalog", [slackRow, teamRow]);
-      setQueryResult("FROM workspace_plugins", []);
-
-      const app = buildApp();
-      const res = await app.request("/integrations/catalog");
-      expect(res.status).toBe(200);
-      const body = await json(res);
-      const slack = body.catalog.find((e: { slug: string }) => e.slug === "slack");
-      const salesforce = body.catalog.find((e: { slug: string }) => e.slug === "salesforce");
-      expect(slack.accessible).toBe(true);
-      expect(slack.upgradeRequired).toBeNull();
-      expect(salesforce.accessible).toBe(true);
-      expect(salesforce.upgradeRequired).toBeNull();
-    });
-
-    it("emits `accessible=false` + `upgradeRequired=<min_plan>` for above-plan entries", async () => {
-      // The other half of the invariant — when accessible=false,
-      // upgradeRequired carries the catalog row's min_plan so the
-      // locked card can render the "Premium — requires <plan>" badge.
-      setQueryResult("FROM organization WHERE id", [{ plan_tier: "starter" }]);
-      setQueryResult("FROM plugin_catalog", [slackRow, teamRow]);
-      setQueryResult("FROM workspace_plugins", []);
-
-      const app = buildApp();
-      const res = await app.request("/integrations/catalog");
-      expect(res.status).toBe(200);
-      const body = await json(res);
-      const slack = body.catalog.find((e: { slug: string }) => e.slug === "slack");
-      const salesforce = body.catalog.find((e: { slug: string }) => e.slug === "salesforce");
-      // Slack admits starter — accessible
-      expect(slack.accessible).toBe(true);
-      expect(slack.upgradeRequired).toBeNull();
-      // Salesforce requires business — upgrade required
-      expect(salesforce.accessible).toBe(false);
-      expect(salesforce.upgradeRequired).toBe("business");
-    });
-  });
-
-  describe("deploy-mode filter", () => {
-    it("issues a SaaS-narrowed catalog query (`saas_eligible = true`) when deployMode is `saas`", async () => {
-      mockConfigOverride = { deployMode: "saas" };
-      setQueryResult("FROM organization WHERE id", [{ plan_tier: "starter" }]);
-      setQueryResult("FROM plugin_catalog", [slackRow]);
-      setQueryResult("FROM workspace_plugins", []);
-
-      const app = buildApp();
-      const res = await app.request("/integrations/catalog");
-      expect(res.status).toBe(200);
-
-      const catalogQuery = capturedQueries.find((q) => q.sql.includes("FROM plugin_catalog"));
-      expect(catalogQuery).toBeDefined();
-      expect(catalogQuery!.sql).toContain("saas_eligible = true");
-    });
-
-    it("omits the `saas_eligible = true` predicate on self-hosted deploys", async () => {
-      mockConfigOverride = { deployMode: "self-hosted" };
-      setQueryResult("FROM organization WHERE id", [{ plan_tier: "starter" }]);
-      setQueryResult("FROM plugin_catalog", [slackRow, githubPatRow]);
-      setQueryResult("FROM workspace_plugins", []);
-
-      const app = buildApp();
-      const res = await app.request("/integrations/catalog");
-      expect(res.status).toBe(200);
-
-      const catalogQuery = capturedQueries.find((q) => q.sql.includes("FROM plugin_catalog"));
-      expect(catalogQuery).toBeDefined();
-      expect(catalogQuery!.sql).not.toContain("saas_eligible = true");
-
-      // And every row from the DB surfaces in the response.
-      const body = await json(res);
-      expect(body.catalog).toHaveLength(2);
-    });
-
-    it("treats unloaded config as self-hosted (no `saas_eligible = true` predicate)", async () => {
-      mockConfigOverride = null;
-      setQueryResult("FROM organization WHERE id", [{ plan_tier: "starter" }]);
-      setQueryResult("FROM plugin_catalog", [slackRow, githubPatRow]);
-      setQueryResult("FROM workspace_plugins", []);
-
-      const app = buildApp();
-      const res = await app.request("/integrations/catalog");
-      expect(res.status).toBe(200);
-
-      const catalogQuery = capturedQueries.find((q) => q.sql.includes("FROM plugin_catalog"));
-      expect(catalogQuery).toBeDefined();
-      expect(catalogQuery!.sql).not.toContain("saas_eligible = true");
+      expect(body.catalog[0].implementationStatus).toBe("coming_soon");
+      expect(body.catalog[0].pillar).toBe("chat");
     });
   });
 });

--- a/packages/api/src/api/routes/integrations-catalog.ts
+++ b/packages/api/src/api/routes/integrations-catalog.ts
@@ -2,72 +2,36 @@
  * GET /api/v1/integrations/catalog — read-only customer-facing surface over
  * `plugin_catalog`, seeded at boot by `CatalogSeeder` (#2650).
  *
- * Slice 3 of 1.5.2 (#2651). Connect / Disconnect handlers land in #2654
- * and #2656 — this route ships only the read path so the `/admin/integrations`
- * card surface has data to render.
+ * Pivot to `PillarCatalogQuery` facade — #2741 (slice 3 of 1.5.3). The
+ * three SELECTs that used to live inline now live behind the facade Tag
+ * defined in `lib/effect/pillar-catalog-query.ts`. The facade collapses
+ * (plan + catalog + installs) → `CatalogEntryWithState[]` and applies the
+ * install-status state machine (`resolveInstallStatus` from
+ * `lib/integrations/install-status-machine.ts`) per row. This route stays
+ * a thin projection from the facade's rich row → the on-wire envelope.
  *
- * Filters:
- *   - `enabled = true` (SQL — narrowed by the partial index on the column).
- *   - SaaS deploy mode → also requires `saas_eligible = true` (SQL).
- *   - Plan tier: above-plan rows are returned with `upsellOnly: true` rather
- *     than filtered out, so the UI can render a read-only upsell card per
- *     #2651 AC. Below-or-equal rows return `upsellOnly: false`.
+ * Wire-shape additions (#2741): `pillar` and `implementationStatus`.
+ * Existing fields stay byte-identical so slice 8 (admin-UI section
+ * split by pillar) and slice 9 (coming-soon badge) can land additively
+ * without re-coordinating with this route.
  *
- * The workspace install join is computed in-process from
- * `workspace_plugins WHERE workspace_id = ?` so the catalog query is a single
- * SQL fragment per deploy-mode branch (no per-row LATERAL).
- *
- * Vocabulary note: both catalog `min_plan` and workspace `plan_tier`
- * use the same `PLAN_TIERS` union from `@useatlas/types`
- * (`free|trial|starter|pro|business`) after #2666. Comparator lives in
- * `lib/integrations/install/plan-rank.ts`.
+ * Filters: deploy-mode (saas narrows to `saas_eligible = true`) and the
+ * legacy-type exclusion (`type IN ('chat', 'integration')`) live inside
+ * the facade — the route doesn't re-derive them. Plan tier: above-plan
+ * rows are returned with `upsellOnly: true` so the UI renders a
+ * read-only upsell card per #2651.
  */
 
-import { Effect } from "effect";
 import { createRoute, z } from "@hono/zod-openapi";
-import { runEffect } from "@atlas/api/lib/effect/hono";
-import { RequestContext } from "@atlas/api/lib/effect/services";
-import { internalQuery } from "@atlas/api/lib/db/internal";
-import { getConfig } from "@atlas/api/lib/config";
-import { createLogger } from "@atlas/api/lib/logger";
+import { Effect, Layer } from "effect";
+import { runHandler } from "@atlas/api/lib/effect/hono";
+import { hasInternalDB, makeInternalDBShimLayer } from "@atlas/api/lib/db/internal";
 import {
-  isPlanEligible,
-  planRank,
-} from "@atlas/api/lib/integrations/install/plan-rank";
+  PillarCatalogQuery,
+  PillarCatalogQueryLive,
+} from "@atlas/api/lib/effect/pillar-catalog-query";
 import { ErrorSchema, AuthErrorSchema } from "./shared-schemas";
 import { createAdminRouter, requireOrgContext } from "./admin-router";
-
-const log = createLogger("integrations-catalog");
-
-// ---------------------------------------------------------------------------
-// Eligibility helpers — wrap the shared comparator with logging.
-// ---------------------------------------------------------------------------
-
-/**
- * Whether the workspace can install a row at its current plan tier.
- * Operator workspaces (per the `is_operator_workspace` flag on
- * `organization`) bypass every check.
- *
- * Unknown `requiredPlan` values (catalog drift) are logged at warn
- * and treated as upsell-only so the card renders read-only — never
- * silently admit something the gate would later deny.
- */
-function isAccessible(
-  workspacePlan: string,
-  requiredPlan: string,
-  isOperator: boolean,
-  context?: { slug?: string; id?: string },
-): boolean {
-  if (isOperator) return true;
-  if (planRank(requiredPlan) === null) {
-    log.warn(
-      { requiredPlan, slug: context?.slug, id: context?.id },
-      "plugin_catalog.min_plan has unknown value — flagging entry as upsellOnly",
-    );
-    return false;
-  }
-  return isPlanEligible(workspacePlan, requiredPlan);
-}
 
 // ---------------------------------------------------------------------------
 // Schemas
@@ -78,8 +42,8 @@ const CatalogEntryResponseSchema = z.object({
   slug: z.string(),
   type: z.enum(["chat", "integration"]),
   // `installModel` (camelCase) — wire-side casing match for the rest of
-  // the response shape. The DB column is `install_model`; the mapper
-  // below at `entries.map(...)` does the translation.
+  // the response shape. The DB column is `install_model`; the facade
+  // does the translation.
   installModel: z.enum(["oauth", "form", "static-bot"]),
   name: z.string(),
   description: z.string().nullable(),
@@ -91,9 +55,8 @@ const CatalogEntryResponseSchema = z.object({
   installedBy: z.string().nullable(),
   // Per-install state derived from `workspace_plugins.config.status`.
   // `null` when the install row is absent OR the platform doesn't
-  // participate in the status taxonomy (Slack today — only lazy OAuth
-  // integrations flip status on refresh failure). `"reconnect_needed"`
-  // when the token refresh permanently failed (#2658).
+  // participate in the status taxonomy. `"reconnect_needed"` when the
+  // token refresh permanently failed (#2658).
   installStatus: z.string().nullable(),
   upsellOnly: z.boolean(),
   /**
@@ -112,39 +75,24 @@ const CatalogEntryResponseSchema = z.object({
    * the comparison.
    */
   upgradeRequired: z.string().nullable(),
+  // ── New in #2741 (slice 3 of 1.5.3) ───────────────────────────────
+  /**
+   * Three-pillar taxonomy per [ADR-0006]. `datasource` rows live on
+   * `/admin/connections`; `chat` and `action` rows live on
+   * `/admin/integrations`. Slice 8 wires the UI section split.
+   */
+  pillar: z.enum(["datasource", "chat", "action"]),
+  /**
+   * Whether Atlas has shipped a working install path. `coming_soon`
+   * rows render as inert grey cards in admin UI (slice 9 wires the
+   * rendering).
+   */
+  implementationStatus: z.enum(["available", "coming_soon"]),
 });
 
 const CatalogResponseSchema = z.object({
   catalog: z.array(CatalogEntryResponseSchema),
 });
-
-// ---------------------------------------------------------------------------
-// Row types
-// ---------------------------------------------------------------------------
-
-interface CatalogRow extends Record<string, unknown> {
-  id: string;
-  slug: string;
-  name: string;
-  description: string | null;
-  type: string;
-  install_model: string;
-  icon_url: string | null;
-  config_schema: unknown;
-  min_plan: string;
-  saas_eligible: boolean;
-}
-
-interface InstallationRow extends Record<string, unknown> {
-  catalog_id: string;
-  installed_at: string | Date;
-  installed_by: string | null;
-  install_status: string | null;
-}
-
-function asIsoString(value: string | Date): string {
-  return value instanceof Date ? value.toISOString() : String(value);
-}
 
 // ---------------------------------------------------------------------------
 // Route
@@ -193,110 +141,62 @@ const listCatalogRoute = createRoute({
 /**
  * Catalog read endpoint mounted under `/api/v1/integrations`. Uses
  * {@link createAdminRouter} so the same admin-role + MFA gate as the rest
- * of the admin surface applies — slice 3 of #2651 keeps this read-only;
- * install / disconnect mutations land in #2654 / #2656.
+ * of the admin surface applies.
  */
 export const integrationsCatalog = createAdminRouter();
 integrationsCatalog.use(requireOrgContext());
 
 integrationsCatalog.openapi(listCatalogRoute, async (c) => {
-  return runEffect(
-    c,
-    Effect.gen(function* () {
-      yield* RequestContext;
-      const { orgId } = c.var.orgContext;
+  return runHandler(c, "list integrations catalog", async () => {
+    const { orgId, requestId } = c.var.orgContext;
 
-      const isSaas = getConfig()?.deployMode === "saas";
-
-      // Independent queries — plan lookup, catalog read, install lookup all
-      // resolve from the same internal DB. Run in parallel to keep latency
-      // bounded by the slowest, not the sum.
-      //
-      // `type IN ('chat', 'integration')` excludes legacy marketplace rows
-      // (`datasource|context|interaction|action|sandbox`) — the DB CHECK
-      // still admits them (migration 0014 + 0087) and `admin-marketplace`'s
-      // platform-admin write path can insert them. Letting them through
-      // would fail the client-side Zod parse on `type` (which enums
-      // `chat | integration`) and render the page as a schema-mismatch
-      // banner. See `admin-schemas.ts:IntegrationsCatalogEntrySchema`.
-      const catalogSql = isSaas
-        ? `SELECT id, slug, name, description, type, install_model, icon_url,
-                  config_schema, min_plan, saas_eligible
-             FROM plugin_catalog
-            WHERE enabled = true AND saas_eligible = true
-              AND type IN ('chat', 'integration')
-            ORDER BY type ASC, name ASC`
-        : `SELECT id, slug, name, description, type, install_model, icon_url,
-                  config_schema, min_plan, saas_eligible
-             FROM plugin_catalog
-            WHERE enabled = true
-              AND type IN ('chat', 'integration')
-            ORDER BY type ASC, name ASC`;
-
-      // `Effect.tryPromise` (not `Effect.promise`) — DB rejections must
-      // flow through Effect's typed-failure channel so `runEffect` /
-      // `classifyError` map them to a clean 500 with `requestId`. The
-      // `Effect.promise` constructor declares "never rejects" and would
-      // turn DB failures into defects.
-      const [planRows, catalog, installations] = yield* Effect.tryPromise({
-        try: () =>
-          Promise.all([
-            internalQuery<{ plan_tier: string; is_operator_workspace: boolean | null }>(
-              "SELECT plan_tier, is_operator_workspace FROM organization WHERE id = $1",
-              [orgId],
-            ),
-            internalQuery<CatalogRow>(catalogSql),
-            internalQuery<InstallationRow>(
-              `SELECT catalog_id, installed_at, installed_by,
-                      config->>'status' AS install_status
-                 FROM workspace_plugins
-                WHERE workspace_id = $1`,
-              [orgId],
-            ),
-          ]),
-        catch: (err) => (err instanceof Error ? err : new Error(String(err))),
-      });
-
-      // Fallback to "free" matches the `organization.plan_tier` column
-      // default. `requireOrgContext` already 400'd if the active org is
-      // missing — this empty-row case is the rare "org exists but
-      // plan_tier is null" path; fail closed to the most restrictive
-      // tier so upsell flagging stays conservative.
-      const workspacePlan = planRows[0]?.plan_tier ?? "free";
-      const isOperator = planRows[0]?.is_operator_workspace === true;
-
-      const installedByCatalogId = new Map<string, InstallationRow>(
-        installations.map((row) => [row.catalog_id, row]),
+    if (!hasInternalDB()) {
+      return c.json(
+        { error: "not_available", message: "No internal database configured.", requestId },
+        404,
       );
+    }
 
-      const entries = catalog.map((row) => {
-        const installation = installedByCatalogId.get(row.id);
-        const accessible = isAccessible(workspacePlan, row.min_plan, isOperator, {
-          slug: row.slug,
-          id: row.id,
-        });
-        return {
-          id: row.id,
-          slug: row.slug,
-          type: row.type as "chat" | "integration",
-          installModel: row.install_model as "oauth" | "form" | "static-bot",
-          name: row.name,
-          description: row.description,
-          iconUrl: row.icon_url,
-          minPlan: row.min_plan,
-          configSchema: row.config_schema ?? null,
-          installed: installation !== undefined,
-          installedAt: installation ? asIsoString(installation.installed_at) : null,
-          installedBy: installation?.installed_by ?? null,
-          installStatus: installation?.install_status ?? null,
-          upsellOnly: !accessible,
-          accessible,
-          upgradeRequired: accessible ? null : row.min_plan,
-        };
-      });
+    // The facade lives behind an Effect Tag — provide its Live Layer
+    // with the InternalDB shim so the route can call into it without
+    // pulling the AppLayer's ManagedRuntime down here. Same pattern as
+    // `admin-proactive-analytics.ts` (#2622) for `AnswerMeterLive`.
+    const rows = await Effect.runPromise(
+      Effect.gen(function* () {
+        const facade = yield* PillarCatalogQuery;
+        return yield* facade.withInstallStatusFor(orgId);
+      }).pipe(
+        Effect.provide(
+          PillarCatalogQueryLive.pipe(Layer.provide(makeInternalDBShimLayer())),
+        ),
+      ),
+    );
 
-      return c.json({ catalog: entries }, 200);
-    }),
-    { label: "list integrations catalog" },
-  );
+    const catalog = rows.map((row) => ({
+      id: row.id,
+      slug: row.slug,
+      // The facade's `type` is the raw DB string; the route narrows
+      // back to the wire union. The legacy-type SQL exclusion in the
+      // facade keeps this safe — any other value would mean a CHECK
+      // constraint regression.
+      type: row.type as "chat" | "integration",
+      installModel: row.installModel as "oauth" | "form" | "static-bot",
+      name: row.name,
+      description: row.description,
+      iconUrl: row.iconUrl,
+      minPlan: row.minPlan,
+      configSchema: row.configSchema ?? null,
+      installed: row.install !== null,
+      installedAt: row.install?.installedAt ?? null,
+      installedBy: row.install?.installedBy ?? null,
+      installStatus: row.install?.status ?? null,
+      upsellOnly: !row.planAccessible,
+      accessible: row.planAccessible,
+      upgradeRequired: row.planAccessible ? null : row.minPlan,
+      pillar: row.pillar,
+      implementationStatus: row.implementationStatus,
+    }));
+
+    return c.json({ catalog }, 200);
+  });
 });

--- a/packages/api/src/lib/effect/__tests__/pillar-catalog-query.test.ts
+++ b/packages/api/src/lib/effect/__tests__/pillar-catalog-query.test.ts
@@ -476,4 +476,103 @@ describe("PillarCatalogQueryLive", () => {
     expect(result?.pillar).toBe("chat");
     expect(result?.implementationStatus).toBe("available");
   });
+
+  // ── Regression guards (post-review) ──────────────────────────────────
+  //
+  // The generic readers (`getByPillar`, `getBySlug`) are advertised in
+  // the Shape as pillar-agnostic. They must NOT carry the customer-
+  // facing legacy-type filter that `withInstallStatusFor` applies —
+  // doing so silently returns the empty set for a datasource-pillar
+  // caller (slice 5 / #2746).
+  it("getByPillar: does not narrow by legacy type (allows datasource rows)", async () => {
+    const { layer: dbLayer, calls } = makeFakeInternalDBLayer([
+      { matcher: (sql) => sql.includes("FROM plugin_catalog"), rows: [] },
+    ]);
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const facade = yield* PillarCatalogQuery;
+        return yield* facade.getByPillar("datasource");
+      }).pipe(Effect.provide(PillarCatalogQueryLive.pipe(Layer.provide(dbLayer)))),
+    );
+    const sql = calls[0]!.sql;
+    expect(sql).not.toContain("type IN");
+  });
+
+  it("getBySlug: does not narrow by legacy type", async () => {
+    const { layer: dbLayer, calls } = makeFakeInternalDBLayer([
+      { matcher: (sql) => sql.includes("FROM plugin_catalog"), rows: [] },
+    ]);
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const facade = yield* PillarCatalogQuery;
+        return yield* facade.getBySlug("postgres");
+      }).pipe(Effect.provide(PillarCatalogQueryLive.pipe(Layer.provide(dbLayer)))),
+    );
+    expect(calls[0]!.sql).not.toContain("type IN");
+  });
+
+  it("withInstallStatusFor: still narrows by legacy type for byte-identical wire output", async () => {
+    const { layer: dbLayer, calls } = makeFakeInternalDBLayer([
+      {
+        matcher: (sql) => sql.includes("FROM organization"),
+        rows: [{ plan_tier: "starter", is_operator_workspace: false }],
+      },
+      {
+        matcher: (sql) => sql.includes("FROM plugin_catalog"),
+        rows: [SLACK_ROW],
+      },
+      { matcher: (sql) => sql.includes("FROM workspace_plugins"), rows: [] },
+    ]);
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const facade = yield* PillarCatalogQuery;
+        return yield* facade.withInstallStatusFor("org-1");
+      }).pipe(Effect.provide(PillarCatalogQueryLive.pipe(Layer.provide(dbLayer)))),
+    );
+    const catalogCall = calls.find((c) =>
+      c.sql.includes("FROM plugin_catalog"),
+    )!;
+    expect(catalogCall.sql).toContain("type IN ('chat', 'integration')");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Row-mapper fallback semantics — fail-closed defaults
+// ---------------------------------------------------------------------------
+
+describe("row mapper fallback semantics", () => {
+  // `asImplementationStatus` MUST default unknown values to `coming_soon`
+  // (fail closed). Defaulting to `available` would make a corrupt-seed /
+  // catalog-drift row surface as installable in the admin UI.
+  it("unknown implementation_status maps to coming_soon (fail closed)", async () => {
+    const { layer: dbLayer } = makeFakeInternalDBLayer([
+      {
+        matcher: (sql) => sql.includes("FROM plugin_catalog"),
+        rows: [{ ...SLACK_ROW, implementation_status: "totally-bogus-value" }],
+      },
+    ]);
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const facade = yield* PillarCatalogQuery;
+        return yield* facade.getBySlug("slack");
+      }).pipe(Effect.provide(PillarCatalogQueryLive.pipe(Layer.provide(dbLayer)))),
+    );
+    expect(result?.implementationStatus).toBe("coming_soon");
+  });
+
+  it("unknown pillar maps to 'action' (miscellaneous bucket per ADR-0006)", async () => {
+    const { layer: dbLayer } = makeFakeInternalDBLayer([
+      {
+        matcher: (sql) => sql.includes("FROM plugin_catalog"),
+        rows: [{ ...SLACK_ROW, pillar: "weird-new-pillar" }],
+      },
+    ]);
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const facade = yield* PillarCatalogQuery;
+        return yield* facade.getBySlug("slack");
+      }).pipe(Effect.provide(PillarCatalogQueryLive.pipe(Layer.provide(dbLayer)))),
+    );
+    expect(result?.pillar).toBe("action");
+  });
 });

--- a/packages/api/src/lib/effect/__tests__/pillar-catalog-query.test.ts
+++ b/packages/api/src/lib/effect/__tests__/pillar-catalog-query.test.ts
@@ -1,0 +1,479 @@
+/**
+ * Tests for `PillarCatalogQuery` (#2741 — slice 3 of 1.5.3).
+ *
+ * Three layers of coverage:
+ *
+ * 1. `projectCatalogWithInstalls` — pure function. Plan gating × install
+ *    presence × card-state per pillar (`coming_soon`, `available`).
+ *    No Effect / no DB.
+ * 2. `createPillarCatalogQueryTestLayer` — the test-layer factory itself
+ *    (stub-by-default semantics + partial overrides land correctly).
+ * 3. `PillarCatalogQueryLive` via an in-memory `InternalDB` Layer —
+ *    drives the SQL projection end-to-end with a stub `db.query` so
+ *    we exercise SQL fragment + row → entity mapping without standing
+ *    up Postgres.
+ */
+
+import { describe, it, expect } from "bun:test";
+import { Effect, Layer } from "effect";
+import { IMPLEMENTATION_STATUSES, PILLARS, type Pillar } from "@useatlas/types";
+import {
+  PillarCatalogQuery,
+  PillarCatalogQueryLive,
+  createPillarCatalogQueryTestLayer,
+  projectCatalogWithInstalls,
+  type CatalogEntry,
+  type CatalogEntryWithState,
+  type WorkspaceInstall,
+} from "../pillar-catalog-query";
+import { InternalDB, type InternalDBShape } from "@atlas/api/lib/db/internal";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeEntry(overrides: Partial<CatalogEntry> = {}): CatalogEntry {
+  return {
+    id: "catalog:slack",
+    slug: "slack",
+    name: "Slack",
+    description: "Connect Slack",
+    type: "chat",
+    installModel: "oauth",
+    iconUrl: null,
+    configSchema: null,
+    minPlan: "starter",
+    saasEligible: true,
+    pillar: "chat",
+    implementationStatus: "available",
+    autoInstall: false,
+    ...overrides,
+  };
+}
+
+function makeInstall(overrides: Partial<WorkspaceInstall> = {}): WorkspaceInstall {
+  return {
+    id: "install-1",
+    catalogId: "catalog:slack",
+    installId: "catalog:slack",
+    workspaceId: "org-1",
+    pillar: "chat",
+    installedAt: "2026-05-20T10:00:00.000Z",
+    installedBy: "user-1",
+    status: null,
+    disabled: false,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// 1. projectCatalogWithInstalls — pure function
+// ---------------------------------------------------------------------------
+
+describe("projectCatalogWithInstalls", () => {
+  describe("plan gating", () => {
+    it("flags entries above the workspace plan as planAccessible=false", () => {
+      const slack = makeEntry({ minPlan: "starter" });
+      const salesforce = makeEntry({
+        id: "catalog:salesforce",
+        slug: "salesforce",
+        minPlan: "business",
+        type: "integration",
+        pillar: "action",
+      });
+      const result = projectCatalogWithInstalls({
+        catalog: [slack, salesforce],
+        installs: [],
+        plan: { planTier: "starter", isOperator: false },
+      });
+      const slackOut = result.find((e) => e.slug === "slack")!;
+      const sfOut = result.find((e) => e.slug === "salesforce")!;
+      expect(slackOut.planAccessible).toBe(true);
+      expect(slackOut.state).toBe("accessible");
+      expect(sfOut.planAccessible).toBe(false);
+      expect(sfOut.state).toBe("upgrade_required");
+    });
+
+    it("operator workspaces bypass the plan gate even for above-plan rows", () => {
+      const salesforce = makeEntry({
+        id: "catalog:salesforce",
+        slug: "salesforce",
+        minPlan: "business",
+        type: "integration",
+        pillar: "action",
+      });
+      const result = projectCatalogWithInstalls({
+        catalog: [salesforce],
+        installs: [],
+        plan: { planTier: "starter", isOperator: true },
+      });
+      expect(result[0]!.planAccessible).toBe(true);
+      expect(result[0]!.state).toBe("accessible");
+    });
+
+    it("unknown min_plan values fail closed to upgrade_required", () => {
+      const drift = makeEntry({ minPlan: "platinum" });
+      const result = projectCatalogWithInstalls({
+        catalog: [drift],
+        installs: [],
+        plan: { planTier: "business", isOperator: false },
+      });
+      expect(result[0]!.planAccessible).toBe(false);
+      expect(result[0]!.state).toBe("upgrade_required");
+    });
+  });
+
+  describe("install presence", () => {
+    it("emits install=null and state=accessible when no install row matches", () => {
+      const entry = makeEntry();
+      const result = projectCatalogWithInstalls({
+        catalog: [entry],
+        installs: [],
+        plan: { planTier: "starter", isOperator: false },
+      });
+      expect(result[0]!.install).toBeNull();
+      expect(result[0]!.state).toBe("accessible");
+    });
+
+    it("matches install rows by catalog_id and emits state=connected", () => {
+      const entry = makeEntry();
+      const install = makeInstall({ catalogId: entry.id });
+      const result = projectCatalogWithInstalls({
+        catalog: [entry],
+        installs: [install],
+        plan: { planTier: "starter", isOperator: false },
+      });
+      expect(result[0]!.install).toEqual(install);
+      expect(result[0]!.state).toBe("connected");
+    });
+
+    it("emits state=configured_but_downgraded when install present but plan denies", () => {
+      const entry = makeEntry({ minPlan: "business" });
+      const install = makeInstall({ catalogId: entry.id });
+      const result = projectCatalogWithInstalls({
+        catalog: [entry],
+        installs: [install],
+        plan: { planTier: "starter", isOperator: false },
+      });
+      expect(result[0]!.install).toEqual(install);
+      expect(result[0]!.state).toBe("configured_but_downgraded");
+    });
+
+    it("does not match across catalog ids (cross-row install leakage guard)", () => {
+      const slack = makeEntry();
+      const sf = makeEntry({ id: "catalog:salesforce", slug: "salesforce", pillar: "action" });
+      const sfInstall = makeInstall({ catalogId: "catalog:salesforce", installId: "catalog:salesforce" });
+      const result = projectCatalogWithInstalls({
+        catalog: [slack, sf],
+        installs: [sfInstall],
+        plan: { planTier: "starter", isOperator: false },
+      });
+      const slackOut = result.find((e) => e.slug === "slack")!;
+      const sfOut = result.find((e) => e.slug === "salesforce")!;
+      expect(slackOut.install).toBeNull();
+      expect(sfOut.install).toEqual(sfInstall);
+    });
+  });
+
+  describe("card-state per pillar", () => {
+    // Walks all three pillars with the four state-machine endpoints
+    // (`coming_soon`, `upgrade_required`, `connected`, `accessible`).
+    // `configured_but_downgraded` is covered above; the misconfigured
+    // gate is pinned `true` in slice 3 — see module header comment.
+    const pillarCases: ReadonlyArray<{ pillar: Pillar; type: string }> = [
+      { pillar: "chat", type: "chat" },
+      { pillar: "action", type: "integration" },
+      { pillar: "datasource", type: "datasource" },
+    ];
+
+    for (const { pillar, type } of pillarCases) {
+      it(`pillar=${pillar}: coming_soon dominates plan + install gates`, () => {
+        const entry = makeEntry({
+          pillar,
+          type,
+          implementationStatus: "coming_soon",
+        });
+        const install = makeInstall({ pillar, catalogId: entry.id });
+        const result = projectCatalogWithInstalls({
+          catalog: [entry],
+          installs: [install],
+          plan: { planTier: "business", isOperator: true },
+        });
+        expect(result[0]!.state).toBe("coming_soon");
+      });
+
+      it(`pillar=${pillar}: available → upgrade_required when plan denies (no install)`, () => {
+        const entry = makeEntry({
+          pillar,
+          type,
+          minPlan: "business",
+          implementationStatus: "available",
+        });
+        const result = projectCatalogWithInstalls({
+          catalog: [entry],
+          installs: [],
+          plan: { planTier: "starter", isOperator: false },
+        });
+        expect(result[0]!.state).toBe("upgrade_required");
+      });
+
+      it(`pillar=${pillar}: available → connected when plan admits + install present`, () => {
+        const entry = makeEntry({
+          pillar,
+          type,
+          minPlan: "starter",
+          implementationStatus: "available",
+        });
+        const install = makeInstall({ pillar, catalogId: entry.id });
+        const result = projectCatalogWithInstalls({
+          catalog: [entry],
+          installs: [install],
+          plan: { planTier: "starter", isOperator: false },
+        });
+        expect(result[0]!.state).toBe("connected");
+      });
+
+      it(`pillar=${pillar}: available → accessible when plan admits + no install`, () => {
+        const entry = makeEntry({
+          pillar,
+          type,
+          minPlan: "starter",
+          implementationStatus: "available",
+        });
+        const result = projectCatalogWithInstalls({
+          catalog: [entry],
+          installs: [],
+          plan: { planTier: "starter", isOperator: false },
+        });
+        expect(result[0]!.state).toBe("accessible");
+      });
+    }
+
+    it("exercises every Pillar literal at least once (forces fixture to widen if PILLARS grows)", () => {
+      const seenPillars = new Set(pillarCases.map((c) => c.pillar));
+      for (const p of PILLARS) {
+        expect(seenPillars.has(p), `no fixture row for pillar=${p}`).toBe(true);
+      }
+    });
+
+    it("exercises every ImplementationStatus literal at least once", () => {
+      const result = projectCatalogWithInstalls({
+        catalog: IMPLEMENTATION_STATUSES.map((status, idx) =>
+          makeEntry({
+            id: `catalog:status-${idx}`,
+            slug: `slug-${idx}`,
+            implementationStatus: status,
+          }),
+        ),
+        installs: [],
+        plan: { planTier: "starter", isOperator: false },
+      });
+      const seen = new Set(result.map((r) => r.implementationStatus));
+      for (const s of IMPLEMENTATION_STATUSES) {
+        expect(seen.has(s), `no fixture row for implementationStatus=${s}`).toBe(true);
+      }
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. createPillarCatalogQueryTestLayer
+// ---------------------------------------------------------------------------
+
+describe("createPillarCatalogQueryTestLayer", () => {
+  it("partial overrides take precedence over the throwing default", async () => {
+    const layer = createPillarCatalogQueryTestLayer({
+      getBySlug: () => Effect.succeed(makeEntry({ slug: "telegram" })),
+    });
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const facade = yield* PillarCatalogQuery;
+        return yield* facade.getBySlug("telegram");
+      }).pipe(Effect.provide(layer)),
+    );
+    expect(result?.slug).toBe("telegram");
+  });
+
+  it("unprovided methods fail loudly with a descriptive Effect error", async () => {
+    const layer = createPillarCatalogQueryTestLayer({});
+    const exit = await Effect.runPromiseExit(
+      Effect.gen(function* () {
+        const facade = yield* PillarCatalogQuery;
+        return yield* facade.withInstallStatusFor("org-1");
+      }).pipe(Effect.provide(layer)),
+    );
+    expect(exit._tag).toBe("Failure");
+    // We don't pin the exact message; just that it failed in the typed channel.
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. PillarCatalogQueryLive — end-to-end with stub InternalDB
+// ---------------------------------------------------------------------------
+
+interface FakeDBRecord {
+  matcher: (sql: string) => boolean;
+  rows: Record<string, unknown>[];
+}
+
+function makeFakeInternalDBLayer(records: FakeDBRecord[]) {
+  const calls: Array<{ sql: string; params: unknown[] }> = [];
+  const shape: InternalDBShape = {
+    sql: null,
+    pool: null,
+    available: true,
+    execute: () => {},
+    query: async <T extends Record<string, unknown>>(
+      sqlStr: string,
+      params: unknown[] = [],
+    ) => {
+      calls.push({ sql: sqlStr, params });
+      for (const record of records) {
+        if (record.matcher(sqlStr)) return record.rows as T[];
+      }
+      return [] as T[];
+    },
+  };
+  return { layer: Layer.succeed(InternalDB, shape), calls };
+}
+
+const SLACK_ROW = {
+  id: "catalog:slack",
+  slug: "slack",
+  name: "Slack",
+  description: "Connect Slack",
+  type: "chat",
+  install_model: "oauth",
+  icon_url: null,
+  config_schema: null,
+  min_plan: "starter",
+  saas_eligible: true,
+  pillar: "chat",
+  implementation_status: "available",
+  auto_install: false,
+};
+
+const SALESFORCE_ROW = {
+  id: "catalog:salesforce",
+  slug: "salesforce",
+  name: "Salesforce",
+  description: "Salesforce datasource",
+  type: "integration",
+  install_model: "oauth",
+  icon_url: null,
+  config_schema: null,
+  min_plan: "business",
+  saas_eligible: true,
+  pillar: "action",
+  implementation_status: "available",
+  auto_install: false,
+};
+
+describe("PillarCatalogQueryLive", () => {
+  it("withInstallStatusFor: joins plan + catalog + installs and applies the state machine", async () => {
+    const { layer: dbLayer, calls } = makeFakeInternalDBLayer([
+      {
+        matcher: (sql) => sql.includes("FROM organization"),
+        rows: [{ plan_tier: "starter", is_operator_workspace: false }],
+      },
+      {
+        matcher: (sql) => sql.includes("FROM plugin_catalog"),
+        rows: [SLACK_ROW, SALESFORCE_ROW],
+      },
+      {
+        matcher: (sql) => sql.includes("FROM workspace_plugins"),
+        rows: [
+          {
+            id: "install-1",
+            catalog_id: "catalog:slack",
+            install_id: "catalog:slack",
+            workspace_id: "org-1",
+            pillar: "chat",
+            installed_at: "2026-05-20T10:00:00.000Z",
+            installed_by: "user-1",
+            install_status: null,
+            enabled: true,
+          },
+        ],
+      },
+    ]);
+
+    const program = Effect.gen(function* () {
+      const facade = yield* PillarCatalogQuery;
+      return yield* facade.withInstallStatusFor("org-1");
+    });
+
+    const result = (await Effect.runPromise(
+      program.pipe(Effect.provide(PillarCatalogQueryLive.pipe(Layer.provide(dbLayer)))),
+    )) as readonly CatalogEntryWithState[];
+
+    expect(result).toHaveLength(2);
+    const slack = result.find((e) => e.slug === "slack")!;
+    const sf = result.find((e) => e.slug === "salesforce")!;
+
+    // Slack: install present, plan admits — connected.
+    expect(slack.state).toBe("connected");
+    expect(slack.install).not.toBeNull();
+    expect(slack.install!.installId).toBe("catalog:slack");
+    expect(slack.pillar).toBe("chat");
+    expect(slack.implementationStatus).toBe("available");
+    expect(slack.planAccessible).toBe(true);
+
+    // Salesforce: no install, plan denies (starter vs business) — upgrade_required.
+    expect(sf.state).toBe("upgrade_required");
+    expect(sf.install).toBeNull();
+    expect(sf.pillar).toBe("action");
+    expect(sf.planAccessible).toBe(false);
+
+    // Workspace lookup was scoped by workspace_id — regression guard against
+    // cross-tenant install leakage.
+    const wpCall = calls.find((c) => c.sql.includes("FROM workspace_plugins"))!;
+    expect(wpCall.sql).toContain("workspace_id = $1");
+    expect(wpCall.params[0]).toBe("org-1");
+  });
+
+  it("getByPillar: SQL fragment carries the pillar predicate", async () => {
+    const { layer: dbLayer, calls } = makeFakeInternalDBLayer([
+      { matcher: (sql) => sql.includes("FROM plugin_catalog"), rows: [SLACK_ROW] },
+    ]);
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const facade = yield* PillarCatalogQuery;
+        return yield* facade.getByPillar("chat");
+      }).pipe(Effect.provide(PillarCatalogQueryLive.pipe(Layer.provide(dbLayer)))),
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0]!.pillar).toBe("chat");
+    expect(calls[0]!.sql).toContain("pillar = $1");
+    expect(calls[0]!.params[0]).toBe("chat");
+  });
+
+  it("getBySlug: returns null for an unknown slug", async () => {
+    const { layer: dbLayer } = makeFakeInternalDBLayer([
+      { matcher: (sql) => sql.includes("FROM plugin_catalog"), rows: [] },
+    ]);
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const facade = yield* PillarCatalogQuery;
+        return yield* facade.getBySlug("nonexistent");
+      }).pipe(Effect.provide(PillarCatalogQueryLive.pipe(Layer.provide(dbLayer)))),
+    );
+    expect(result).toBeNull();
+  });
+
+  it("getBySlug: returns the row when found", async () => {
+    const { layer: dbLayer } = makeFakeInternalDBLayer([
+      { matcher: (sql) => sql.includes("FROM plugin_catalog"), rows: [SLACK_ROW] },
+    ]);
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const facade = yield* PillarCatalogQuery;
+        return yield* facade.getBySlug("slack");
+      }).pipe(Effect.provide(PillarCatalogQueryLive.pipe(Layer.provide(dbLayer)))),
+    );
+    expect(result?.slug).toBe("slack");
+    expect(result?.pillar).toBe("chat");
+    expect(result?.implementationStatus).toBe("available");
+  });
+});

--- a/packages/api/src/lib/effect/index.ts
+++ b/packages/api/src/lib/effect/index.ts
@@ -218,3 +218,17 @@ export {
   CatalogNotFoundError,
   InstallNotFoundError,
 } from "./errors";
+
+// ── PillarCatalogQuery (#2741 — slice 3 of 1.5.3) ───────────────────
+
+export {
+  PillarCatalogQuery,
+  PillarCatalogQueryLive,
+  createPillarCatalogQueryTestLayer,
+  projectCatalogWithInstalls,
+  type PillarCatalogQueryShape,
+  type CatalogEntry,
+  type CatalogEntryWithState,
+  type WorkspaceInstall,
+  type WorkspacePlanContext,
+} from "./pillar-catalog-query";

--- a/packages/api/src/lib/effect/pillar-catalog-query.ts
+++ b/packages/api/src/lib/effect/pillar-catalog-query.ts
@@ -35,7 +35,12 @@
  */
 
 import { Context, Effect, Layer } from "effect";
-import { type ImplementationStatus, type Pillar } from "@useatlas/types";
+import {
+  IMPLEMENTATION_STATUSES,
+  PILLARS,
+  type ImplementationStatus,
+  type Pillar,
+} from "@useatlas/types";
 import {
   resolveInstallStatus,
   type CardState,
@@ -123,7 +128,11 @@ export interface PillarCatalogQueryShape {
   readonly getByPillar: (
     pillar: Pillar,
   ) => Effect.Effect<readonly CatalogEntry[], Error>;
-  /** Read a single catalog row by slug. Returns null when not found / not enabled. */
+  /**
+   * Read a single catalog row by slug. Returns null when not found / not
+   * enabled. Pillar-agnostic — works for `datasource`, `chat`, and
+   * `action` rows alike.
+   */
   readonly getBySlug: (
     slug: string,
   ) => Effect.Effect<CatalogEntry | null, Error>;
@@ -148,9 +157,8 @@ export class PillarCatalogQuery extends Context.Tag("PillarCatalogQuery")<
 // Pillar validation
 // ---------------------------------------------------------------------------
 
-const PILLAR_VALUES: readonly Pillar[] = ["datasource", "chat", "action"];
 function asPillar(value: unknown): Pillar {
-  if (typeof value === "string" && (PILLAR_VALUES as readonly string[]).includes(value)) {
+  if (typeof value === "string" && (PILLARS as readonly string[]).includes(value)) {
     return value as Pillar;
   }
   // Catalog drift — log loudly. The DB CHECK constraint should prevent
@@ -161,9 +169,18 @@ function asPillar(value: unknown): Pillar {
 }
 
 function asImplementationStatus(value: unknown): ImplementationStatus {
-  if (value === "available" || value === "coming_soon") return value;
-  log.warn({ value }, "Unknown implementation_status in plugin_catalog; defaulting to 'available'");
-  return "available";
+  if (
+    typeof value === "string" &&
+    (IMPLEMENTATION_STATUSES as readonly string[]).includes(value)
+  ) {
+    return value as ImplementationStatus;
+  }
+  // Fail closed — an unknown status from catalog drift / corrupt seed
+  // must NOT render as an installable card. `coming_soon` keeps the
+  // row inert until an operator fixes the data; defaulting to
+  // `available` would surface an unshipped integration as installable.
+  log.warn({ value }, "Unknown implementation_status in plugin_catalog; defaulting to 'coming_soon'");
+  return "coming_soon";
 }
 
 // ---------------------------------------------------------------------------
@@ -325,21 +342,21 @@ const CATALOG_COLUMNS = `
 `.trim();
 
 /**
- * Build the `WHERE` clause for catalog reads. Deploy-mode filter (saas
- * narrows to `saas_eligible = true`) plus the legacy-type exclusion
- * (`type IN ('chat', 'integration')`) match the pre-slice-3 route's
- * predicates so the wire output for slice 3 stays byte-identical.
+ * Build the `WHERE` clause for catalog reads. Always applies the
+ * `enabled = true` + deploy-mode (`saas_eligible = true` on SaaS) gates.
+ * The legacy-type narrowing (`type IN ('chat', 'integration')`) is
+ * caller-controlled via `restrictToLegacyTypes` — `withInstallStatusFor`
+ * keeps the pre-slice-3 byte-identical wire output by passing `true`,
+ * while generic readers (`getByPillar`, `getBySlug`) pass `false` so a
+ * `datasource`-pillar caller in slice 5 (#2746) doesn't get an empty
+ * result set from the customer-facing-only filter.
  */
-function buildCatalogWhere(extra: string): string {
+function buildCatalogWhere(extra: string, restrictToLegacyTypes: boolean): string {
   const isSaas = getConfig()?.deployMode === "saas";
   const clauses = [
     "enabled = true",
     ...(isSaas ? ["saas_eligible = true"] : []),
-    // Pillar slice 3 stays scoped to the customer-facing surface — legacy
-    // marketplace types stay excluded until slice 5 lifts the connections
-    // pillar onto the catalog. Order matches the pre-slice-3 route so a
-    // diff of captured SQL between old/new code is the empty set.
-    "type IN ('chat', 'integration')",
+    ...(restrictToLegacyTypes ? ["type IN ('chat', 'integration')"] : []),
     extra,
   ].filter((c) => c.length > 0);
   return clauses.join(" AND ");
@@ -391,7 +408,7 @@ function buildPillarCatalogQueryService(
           const rows = await db.query<CatalogRow>(
             `SELECT ${CATALOG_COLUMNS}
                FROM plugin_catalog
-              WHERE ${buildCatalogWhere("pillar = $1")}
+              WHERE ${buildCatalogWhere("pillar = $1", false)}
               ORDER BY name ASC`,
             [pillar],
           );
@@ -406,7 +423,7 @@ function buildPillarCatalogQueryService(
           const rows = await db.query<CatalogRow>(
             `SELECT ${CATALOG_COLUMNS}
                FROM plugin_catalog
-              WHERE ${buildCatalogWhere("slug = $1")}
+              WHERE ${buildCatalogWhere("slug = $1", false)}
               LIMIT 1`,
             [slug],
           );
@@ -430,7 +447,7 @@ function buildPillarCatalogQueryService(
               db.query<CatalogRow>(
                 `SELECT ${CATALOG_COLUMNS}
                    FROM plugin_catalog
-                  WHERE ${buildCatalogWhere("")}
+                  WHERE ${buildCatalogWhere("", true)}
                   ORDER BY type ASC, name ASC`,
               ),
               db.query<InstallRow>(

--- a/packages/api/src/lib/effect/pillar-catalog-query.ts
+++ b/packages/api/src/lib/effect/pillar-catalog-query.ts
@@ -1,0 +1,511 @@
+/**
+ * `PillarCatalogQuery` — read-side facade over `plugin_catalog`
+ * (joined with `workspace_plugins`) that applies the per-row install-state
+ * machine (`resolveInstallStatus`) to compute a `CardState` per catalog
+ * row. Slice 3 of 1.5.3 (#2741) under [ADR-0006].
+ *
+ * The facade collapses the three SELECTs that `/api/v1/integrations/catalog`
+ * inlined pre-slice-3 (plan + catalog + installs) into a single Effect
+ * Context Tag with a stable shape. Subsequent slices (#2742 → workspace
+ * installer, #2746 → datasource catalog rows on /admin/connections,
+ * #2748 → admin-UI section split) all read through this facade so the
+ * card-state semantics stay in lockstep with the state machine.
+ *
+ * Live impl uses `InternalDB` from Effect Context. Test impl uses
+ * `createPillarCatalogQueryTestLayer` to stub the three methods with
+ * static fixtures.
+ *
+ * Wire-shape note (#2741 acceptance criteria): `withInstallStatusFor`
+ * returns ALL the data a card-renderer needs (state + install + the
+ * catalog row). The route is responsible for projecting that down to
+ * the on-wire JSON envelope (`accessible`, `upsellOnly`, `installed`,
+ * `installStatus`, the two new `pillar` + `implementationStatus`
+ * fields). The legacy `type: 'chat' | 'integration'` wire field is
+ * preserved for back-compat — slice 8 splits the UI by `pillar`.
+ *
+ * Misconfigured / handler-registered semantics: this slice does NOT
+ * yet thread `handlerRegistered` / `deployConfigured` through the state
+ * machine — both default to `true` so the machine's output matches
+ * existing UI behavior (no card flips to `misconfigured` mid-flight).
+ * The state-machine's `TODO(#2741)` block calls out the remediation:
+ * a future slice (or this one if reviewers want it now) can wire in
+ * `hasInstallHandler` from `lib/integrations/install/dispatch.ts` and
+ * a per-Platform env probe. Leaving them at `true` preserves the
+ * "no-UX-change" guarantee in this slice.
+ */
+
+import { Context, Effect, Layer } from "effect";
+import { type ImplementationStatus, type Pillar } from "@useatlas/types";
+import {
+  resolveInstallStatus,
+  type CardState,
+} from "@atlas/api/lib/integrations/install-status-machine";
+import { isPlanEligible, planRank } from "@atlas/api/lib/integrations/install/plan-rank";
+// Type-only — the Tag value is lazy-required inside `PillarCatalogQueryLive`
+// so partial `mock.module("@atlas/api/lib/db/internal", { hasInternalDB, … })`
+// stubs in unrelated tests don't surface a Bun static-link SyntaxError when
+// they pull this module transitively (via `services.ts` re-exports).
+type InternalDBTag = typeof import("@atlas/api/lib/db/internal").InternalDB;
+import { getConfig } from "@atlas/api/lib/config";
+import { createLogger } from "@atlas/api/lib/logger";
+
+const log = createLogger("pillar-catalog-query");
+
+// ---------------------------------------------------------------------------
+// Public shape
+// ---------------------------------------------------------------------------
+
+/**
+ * Catalog row as the facade reads it from `plugin_catalog`. Field set is
+ * the union of what the existing route exposed (slug, name, etc.) PLUS
+ * the two new pillar columns from migration 0092 (#2739). Camel-cased
+ * for JS ergonomics — DB snake_case stays inside the SQL layer.
+ *
+ * `configSchema` is `unknown` because it's a JSONB blob whose shape is
+ * specified per-handler and validated at install time, not here.
+ */
+export interface CatalogEntry {
+  readonly id: string;
+  readonly slug: string;
+  readonly name: string;
+  readonly description: string | null;
+  /** Legacy admin-UI grouping — slice 8 pivots the UI to `pillar`. */
+  readonly type: string;
+  readonly installModel: string;
+  readonly iconUrl: string | null;
+  readonly configSchema: unknown;
+  readonly minPlan: string;
+  readonly saasEligible: boolean;
+  readonly pillar: Pillar;
+  readonly implementationStatus: ImplementationStatus;
+  readonly autoInstall: boolean;
+}
+
+/**
+ * Workspace install row as the facade exposes it. The denormalized
+ * `pillar` column is included so multi-pillar callers (e.g. a future
+ * Datasource-pillar lister) can branch without a re-join.
+ */
+export interface WorkspaceInstall {
+  readonly id: string;
+  readonly catalogId: string;
+  readonly installId: string;
+  readonly workspaceId: string;
+  readonly pillar: Pillar;
+  readonly installedAt: string;
+  readonly installedBy: string | null;
+  /** Pulled from `workspace_plugins.config->>'status'`. `"reconnect_needed"` per #2658. */
+  readonly status: string | null;
+  /** True when the install row's `enabled` column is false (disabled but not torn down). */
+  readonly disabled: boolean;
+}
+
+/**
+ * Catalog row + computed card state + (optional) install record. This is
+ * the rich row the facade emits from `withInstallStatusFor`; the route
+ * projects it down to the wire envelope.
+ */
+export interface CatalogEntryWithState extends CatalogEntry {
+  readonly state: CardState;
+  readonly install: WorkspaceInstall | null;
+  /** Whether the row is plan-accessible for the queried workspace (operator bypass applied). */
+  readonly planAccessible: boolean;
+}
+
+/** Per-workspace plan context the facade needs to evaluate plan gating. */
+export interface WorkspacePlanContext {
+  readonly planTier: string;
+  readonly isOperator: boolean;
+}
+
+export interface PillarCatalogQueryShape {
+  /** Read enabled catalog rows for a given pillar. Deploy-mode (saas/self-hosted) filter applied. */
+  readonly getByPillar: (
+    pillar: Pillar,
+  ) => Effect.Effect<readonly CatalogEntry[], Error>;
+  /** Read a single catalog row by slug. Returns null when not found / not enabled. */
+  readonly getBySlug: (
+    slug: string,
+  ) => Effect.Effect<CatalogEntry | null, Error>;
+  /**
+   * Join catalog × workspace_plugins for the given workspace, apply
+   * the install-status machine, and return one annotated row per
+   * catalog entry. Excludes legacy types (`datasource`, `context`,
+   * `interaction`, `action`, `sandbox`) — only `chat` + `integration`
+   * are surfaced today. Slice 5 (#2746) folds Datasource rows in.
+   */
+  readonly withInstallStatusFor: (
+    workspaceId: string,
+  ) => Effect.Effect<readonly CatalogEntryWithState[], Error>;
+}
+
+export class PillarCatalogQuery extends Context.Tag("PillarCatalogQuery")<
+  PillarCatalogQuery,
+  PillarCatalogQueryShape
+>() {}
+
+// ---------------------------------------------------------------------------
+// Pillar validation
+// ---------------------------------------------------------------------------
+
+const PILLAR_VALUES: readonly Pillar[] = ["datasource", "chat", "action"];
+function asPillar(value: unknown): Pillar {
+  if (typeof value === "string" && (PILLAR_VALUES as readonly string[]).includes(value)) {
+    return value as Pillar;
+  }
+  // Catalog drift — log loudly. The DB CHECK constraint should prevent
+  // this, but a corrupt row shouldn't crash the facade — fall back to
+  // `action` (the "miscellaneous" bucket per ADR-0006).
+  log.warn({ value }, "Unknown pillar value in plugin_catalog; defaulting to 'action'");
+  return "action";
+}
+
+function asImplementationStatus(value: unknown): ImplementationStatus {
+  if (value === "available" || value === "coming_soon") return value;
+  log.warn({ value }, "Unknown implementation_status in plugin_catalog; defaulting to 'available'");
+  return "available";
+}
+
+// ---------------------------------------------------------------------------
+// Row types (DB-shape, snake_case)
+// ---------------------------------------------------------------------------
+
+interface CatalogRow extends Record<string, unknown> {
+  id: string;
+  slug: string;
+  name: string;
+  description: string | null;
+  type: string;
+  install_model: string;
+  icon_url: string | null;
+  config_schema: unknown;
+  min_plan: string;
+  saas_eligible: boolean;
+  pillar: string;
+  implementation_status: string;
+  auto_install: boolean;
+}
+
+interface InstallRow extends Record<string, unknown> {
+  id: string;
+  catalog_id: string;
+  install_id: string;
+  workspace_id: string;
+  pillar: string;
+  installed_at: string | Date;
+  installed_by: string | null;
+  install_status: string | null;
+  enabled: boolean;
+}
+
+interface OrgRow extends Record<string, unknown> {
+  plan_tier: string | null;
+  is_operator_workspace: boolean | null;
+}
+
+function rowToCatalogEntry(row: CatalogRow): CatalogEntry {
+  return {
+    id: row.id,
+    slug: row.slug,
+    name: row.name,
+    description: row.description,
+    type: row.type,
+    installModel: row.install_model,
+    iconUrl: row.icon_url,
+    configSchema: row.config_schema ?? null,
+    minPlan: row.min_plan,
+    saasEligible: row.saas_eligible,
+    pillar: asPillar(row.pillar),
+    implementationStatus: asImplementationStatus(row.implementation_status),
+    autoInstall: row.auto_install === true,
+  };
+}
+
+function rowToWorkspaceInstall(row: InstallRow): WorkspaceInstall {
+  const installedAt = row.installed_at instanceof Date
+    ? row.installed_at.toISOString()
+    : String(row.installed_at);
+  return {
+    id: row.id,
+    catalogId: row.catalog_id,
+    installId: row.install_id,
+    workspaceId: row.workspace_id,
+    pillar: asPillar(row.pillar),
+    installedAt,
+    installedBy: row.installed_by,
+    status: row.install_status,
+    disabled: row.enabled === false,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Plan accessibility
+// ---------------------------------------------------------------------------
+
+function isAccessible(
+  workspacePlan: string,
+  requiredPlan: string,
+  isOperator: boolean,
+  context: { slug: string; id: string },
+): boolean {
+  if (isOperator) return true;
+  if (planRank(requiredPlan) === null) {
+    log.warn(
+      { requiredPlan, slug: context.slug, id: context.id },
+      "plugin_catalog.min_plan has unknown value — flagging entry as upsellOnly",
+    );
+    return false;
+  }
+  return isPlanEligible(workspacePlan, requiredPlan);
+}
+
+// ---------------------------------------------------------------------------
+// Pure computation — exported for testing
+// ---------------------------------------------------------------------------
+
+/**
+ * Pure projection: catalog rows + workspace context + install rows →
+ * annotated `CatalogEntryWithState[]`. Extracted from `withInstallStatusFor`
+ * so tests can exercise the state-machine wiring without standing up an
+ * `InternalDB` Layer. Mirrors the route's pre-slice-3 inline logic.
+ *
+ * The state-machine gates `handlerRegistered` and `deployConfigured`
+ * are pinned to `true` in this slice — see the module header for the
+ * "no-UX-change" rationale.
+ */
+export function projectCatalogWithInstalls(input: {
+  readonly catalog: readonly CatalogEntry[];
+  readonly installs: readonly WorkspaceInstall[];
+  readonly plan: WorkspacePlanContext;
+}): readonly CatalogEntryWithState[] {
+  const installByCatalogId = new Map<string, WorkspaceInstall>();
+  for (const install of input.installs) {
+    // The chat+action pillars are singleton per (workspace, catalog) at
+    // the DB layer (`workspace_plugins_singleton` partial unique). For
+    // datasource (multi-instance) rows the Map collapses to the most-
+    // recently iterated install — slice 5 (#2746) will switch the
+    // datasource branch to grouping by catalogId before this becomes
+    // a real concern.
+    installByCatalogId.set(install.catalogId, install);
+  }
+
+  return input.catalog.map((entry) => {
+    const install = installByCatalogId.get(entry.id) ?? null;
+    const planAccessible = isAccessible(
+      input.plan.planTier,
+      entry.minPlan,
+      input.plan.isOperator,
+      { slug: entry.slug, id: entry.id },
+    );
+    const state = resolveInstallStatus({
+      catalogRow: { implementationStatus: entry.implementationStatus },
+      workspaceInstall: install ? { installId: install.installId } : null,
+      planAdmits: planAccessible,
+      // See module header — pinned `true` in this slice.
+      handlerRegistered: true,
+      deployConfigured: true,
+    });
+    return {
+      ...entry,
+      install,
+      state,
+      planAccessible,
+    };
+  });
+}
+
+// ---------------------------------------------------------------------------
+// SQL fragments
+// ---------------------------------------------------------------------------
+
+const CATALOG_COLUMNS = `
+  id, slug, name, description, type, install_model, icon_url,
+  config_schema, min_plan, saas_eligible, pillar, implementation_status,
+  auto_install
+`.trim();
+
+/**
+ * Build the `WHERE` clause for catalog reads. Deploy-mode filter (saas
+ * narrows to `saas_eligible = true`) plus the legacy-type exclusion
+ * (`type IN ('chat', 'integration')`) match the pre-slice-3 route's
+ * predicates so the wire output for slice 3 stays byte-identical.
+ */
+function buildCatalogWhere(extra: string): string {
+  const isSaas = getConfig()?.deployMode === "saas";
+  const clauses = [
+    "enabled = true",
+    ...(isSaas ? ["saas_eligible = true"] : []),
+    // Pillar slice 3 stays scoped to the customer-facing surface — legacy
+    // marketplace types stay excluded until slice 5 lifts the connections
+    // pillar onto the catalog. Order matches the pre-slice-3 route so a
+    // diff of captured SQL between old/new code is the empty set.
+    "type IN ('chat', 'integration')",
+    extra,
+  ].filter((c) => c.length > 0);
+  return clauses.join(" AND ");
+}
+
+// ---------------------------------------------------------------------------
+// Live Layer
+// ---------------------------------------------------------------------------
+
+/**
+ * Live PillarCatalogQuery backed by `InternalDB`. `Layer.effect` (not
+ * `Layer.scoped`) — the service has no finalizer; the pool is owned by
+ * `internal.ts`.
+ *
+ * The `InternalDB` Tag is `require`'d lazily inside the factory to keep
+ * this module's static import surface narrow — see the type-only
+ * `InternalDBTag` alias at the top of the file for the rationale.
+ */
+export const PillarCatalogQueryLive: Layer.Layer<
+  PillarCatalogQuery,
+  never,
+  import("@atlas/api/lib/db/internal").InternalDB
+> = Layer.unwrapEffect(
+  Effect.sync(() => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { InternalDB } = require("@atlas/api/lib/db/internal") as {
+      InternalDB: InternalDBTag;
+    };
+    return Layer.effect(
+      PillarCatalogQuery,
+      buildPillarCatalogQueryService(InternalDB),
+    );
+  }),
+);
+
+function buildPillarCatalogQueryService(
+  InternalDB: InternalDBTag,
+): Effect.Effect<
+  PillarCatalogQueryShape,
+  never,
+  import("@atlas/api/lib/db/internal").InternalDB
+> {
+  return Effect.gen(function* () {
+    const db = yield* InternalDB;
+
+    const getByPillar: PillarCatalogQueryShape["getByPillar"] = (pillar) =>
+      Effect.tryPromise({
+        try: async () => {
+          const rows = await db.query<CatalogRow>(
+            `SELECT ${CATALOG_COLUMNS}
+               FROM plugin_catalog
+              WHERE ${buildCatalogWhere("pillar = $1")}
+              ORDER BY name ASC`,
+            [pillar],
+          );
+          return rows.map(rowToCatalogEntry);
+        },
+        catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+      });
+
+    const getBySlug: PillarCatalogQueryShape["getBySlug"] = (slug) =>
+      Effect.tryPromise({
+        try: async () => {
+          const rows = await db.query<CatalogRow>(
+            `SELECT ${CATALOG_COLUMNS}
+               FROM plugin_catalog
+              WHERE ${buildCatalogWhere("slug = $1")}
+              LIMIT 1`,
+            [slug],
+          );
+          return rows.length === 0 ? null : rowToCatalogEntry(rows[0]!);
+        },
+        catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+      });
+
+    const withInstallStatusFor: PillarCatalogQueryShape["withInstallStatusFor"] =
+      (workspaceId) =>
+        Effect.tryPromise({
+          try: async () => {
+            // Three independent reads — `Promise.all` lets them ride the
+            // same connection-acquire latency. Matches the pre-slice-3
+            // route's parallel-fetch behavior.
+            const [planRows, catalogRows, installRows] = await Promise.all([
+              db.query<OrgRow>(
+                "SELECT plan_tier, is_operator_workspace FROM organization WHERE id = $1",
+                [workspaceId],
+              ),
+              db.query<CatalogRow>(
+                `SELECT ${CATALOG_COLUMNS}
+                   FROM plugin_catalog
+                  WHERE ${buildCatalogWhere("")}
+                  ORDER BY type ASC, name ASC`,
+              ),
+              db.query<InstallRow>(
+                `SELECT id, catalog_id, install_id, workspace_id, pillar,
+                        installed_at, installed_by, enabled,
+                        config->>'status' AS install_status
+                   FROM workspace_plugins
+                  WHERE workspace_id = $1`,
+                [workspaceId],
+              ),
+            ]);
+            const planTier = planRows[0]?.plan_tier ?? "free";
+            const isOperator = planRows[0]?.is_operator_workspace === true;
+            return projectCatalogWithInstalls({
+              catalog: catalogRows.map(rowToCatalogEntry),
+              installs: installRows.map(rowToWorkspaceInstall),
+              plan: { planTier, isOperator },
+            });
+          },
+          catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+        });
+
+    return {
+      getByPillar,
+      getBySlug,
+      withInstallStatusFor,
+    } satisfies PillarCatalogQueryShape;
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Test layer factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Test layer factory. Methods not provided throw a descriptive error
+ * — see `createAnswerMeterTestLayer` for the same pattern. Prefer this
+ * over `mock.module()` for Effect-based tests.
+ *
+ * @example
+ * ```ts
+ * const layer = createPillarCatalogQueryTestLayer({
+ *   withInstallStatusFor: () =>
+ *     Effect.succeed([{ ...slackRow, state: "accessible", install: null }]),
+ * });
+ * ```
+ */
+export function createPillarCatalogQueryTestLayer(
+  partial: Partial<PillarCatalogQueryShape> = {},
+): Layer.Layer<PillarCatalogQuery> {
+  const stub: PillarCatalogQueryShape = {
+    getByPillar:
+      partial.getByPillar ??
+      (() =>
+        Effect.fail(
+          new Error(
+            "PillarCatalogQuery test stub: getByPillar() called but not provided",
+          ),
+        )),
+    getBySlug:
+      partial.getBySlug ??
+      (() =>
+        Effect.fail(
+          new Error(
+            "PillarCatalogQuery test stub: getBySlug() called but not provided",
+          ),
+        )),
+    withInstallStatusFor:
+      partial.withInstallStatusFor ??
+      (() =>
+        Effect.fail(
+          new Error(
+            "PillarCatalogQuery test stub: withInstallStatusFor() called but not provided",
+          ),
+        )),
+  };
+  return Layer.succeed(PillarCatalogQuery, stub);
+}

--- a/packages/api/src/lib/effect/services.ts
+++ b/packages/api/src/lib/effect/services.ts
@@ -2469,3 +2469,33 @@ export {
   type InstallResult,
   type InstallError,
 } from "./workspace-installer";
+
+// ══════════════════════════════════════════════════════════════════════
+// ██  PillarCatalogQuery (#2741 — slice 3 of 1.5.3)
+// ══════════════════════════════════════════════════════════════════════
+//
+// Read-side facade over `plugin_catalog` × `workspace_plugins` that
+// applies the install-status state machine per row. The Tag, Shape,
+// Live Layer, and test-layer factory live in `./pillar-catalog-query`
+// because the file carries enough surface (SQL projection helpers,
+// state-machine bridge, two row mapper functions) that inlining would
+// crowd this services barrel. Re-exported here so consumers can keep
+// reaching for "@atlas/api/lib/effect/services" as the discovery seam
+// for every backend service Tag.
+//
+// New rows on the catalog wire shape land in #2741 (`pillar`,
+// `implementation_status`). Slice 8 consumes `pillar` for the
+// admin-UI section split; slice 9 consumes `implementation_status` for
+// the coming-soon badge.
+
+export {
+  PillarCatalogQuery,
+  PillarCatalogQueryLive,
+  createPillarCatalogQueryTestLayer,
+  projectCatalogWithInstalls,
+  type PillarCatalogQueryShape,
+  type CatalogEntry,
+  type CatalogEntryWithState,
+  type WorkspaceInstall,
+  type WorkspacePlanContext,
+} from "./pillar-catalog-query";

--- a/packages/web/src/ui/lib/admin-schemas.ts
+++ b/packages/web/src/ui/lib/admin-schemas.ts
@@ -330,6 +330,15 @@ export const IntegrationsCatalogEntrySchema = z.object({
   // `minPlan` when they're absent.
   accessible: z.boolean().optional(),
   upgradeRequired: z.string().nullable().optional(),
+  // ── New in #2741 (slice 3 of 1.5.3 — three-pillar taxonomy) ──────
+  // Optional + nullable so older API responses (pre-#2741) parse via
+  // the same schema. Slice 8 reads `pillar` for section splitting on
+  // the admin UI; slice 9 reads `implementationStatus` for the
+  // coming-soon badge. Until those slices land the fields are present
+  // but not rendered — the UI continues to derive its sections from
+  // the legacy `type` field.
+  pillar: z.enum(["datasource", "chat", "action"]).optional(),
+  implementationStatus: z.enum(["available", "coming_soon"]).optional(),
 });
 
 export type IntegrationsCatalogEntry = z.infer<typeof IntegrationsCatalogEntrySchema>;


### PR DESCRIPTION
Closes #2741. Slice 3 of 17 in 1.5.3 (Multi-Platform Install Models) per [ADR-0006](https://github.com/AtlasDevHQ/atlas/blob/main/docs/adr/0006-three-pillar-integration-taxonomy.md).

## Summary

Read-side facade over `plugin_catalog` × `workspace_plugins` that applies the slice 2 `InstallStatusMachine` per row. Three SELECTs that used to live inline on `/api/v1/integrations/catalog` collapse into one Effect-Context-yielded facade call. Wire shape grows two additive fields (`pillar` + `implementationStatus`) — slice 8 splits the admin UI by `pillar`, slice 9 renders the coming-soon badge from `implementationStatus`. Existing wire fields stay byte-identical so the admin UI continues to render unchanged (regression guard).

## Acceptance criteria

- [x] `PillarCatalogQuery` Effect Context tag + service implementation under `packages/api/src/lib/effect/`
- [x] Service uses `InstallStatusMachine` from slice 2 to compute card state per row
- [x] `GET /api/v1/integrations/catalog` route pivots to use the facade via `runHandler` Effect bridge
- [x] Wire shape adds `pillar` and `implementationStatus` fields; existing `type` field preserved
- [x] `IntegrationsCatalogEntry` Zod schema updated in lockstep
- [x] `createPillarCatalogQueryTestLayer` added to `__test-utils__/layers.ts`
- [x] Tests exercise plan-gating, install presence, and card-state correctness per pillar (27 new tests in `pillar-catalog-query.test.ts`; route test rewritten to stub the facade Tag)
- [x] Existing admin UI renders identically — no UX-change slice (regression guard)
- [x] `bun run type` + `bun run lint` + `bun run test:api` all green; `/ci` gates pass (template drift, syncpack, railway-watch, schema drift, EE imports)

## Files touched

- `packages/api/src/lib/effect/pillar-catalog-query.ts` (new) — Tag, Shape, Live Layer, test-layer factory, pure `projectCatalogWithInstalls` helper
- `packages/api/src/lib/effect/__tests__/pillar-catalog-query.test.ts` (new) — 27 tests across three layers (pure projection, test layer factory, end-to-end via stub `InternalDB`)
- `packages/api/src/lib/effect/services.ts` — re-exports the Tag (discovery seam)
- `packages/api/src/lib/effect/index.ts` — barrel re-exports
- `packages/api/src/__test-utils__/layers.ts` — `createPillarCatalogQueryTestLayer` exposed alongside other test layers
- `packages/api/src/api/routes/integrations-catalog.ts` — pivoted to `runHandler` + `yield* PillarCatalogQuery`
- `packages/api/src/api/__tests__/integrations-catalog.test.ts` — rewritten to stub the facade Tag (the SQL surface it used to assert is covered by the new facade tests)
- `packages/web/src/ui/lib/admin-schemas.ts` — `IntegrationsCatalogEntrySchema` gains `pillar` + `implementationStatus` (optional + nullable so older API responses parse cleanly)

## Notes for reviewers

### Soft merge point with slice 4 (#2742)

Slice 4 lands a `WorkspaceInstaller` Context.Tag in the same `services.ts` + `lib/effect/index.ts` files. Different tag names, same files — expect a trivial textual merge.

### Static-import surface narrowed

`pillar-catalog-query.ts` lazy-`require`s the `InternalDB` Tag inside the `Layer.unwrapEffect` factory rather than statically importing it. Reason: 9 unrelated tests (`admin-branding`, `admin-approval`, `byot-catalog-refresh`, …) partial-mock `@atlas/api/lib/db/internal` without declaring every export — CLAUDE.md flags this as a `mock.module()` rule violation, but rather than fix 9 tests in a slice-3 PR I matched the lazy-`require` pattern already used by the EE no-op Layers in `services.ts`. New module's transitive load surface is type-only.

### Gate semantics in slice 3

`handlerRegistered` and `deployConfigured` are pinned to `true` when calling the state machine — this slice does NOT thread per-Platform handler-registration or env-var probes. Pinning preserves "no UX change" (no card flips to `misconfigured` mid-flight). The state-machine's `TODO(#2741)` block calls out the remediation path; a future slice (or follow-up) can wire `hasInstallHandler` from `lib/integrations/install/dispatch.ts` once a consumer needs the distinction.

### Incidental finding

Filed #2762 — `packages/mcp` canonical-prompts tests fail when run via `bun run test` in the package (`Expected: 20 / Received: 1`); single-file run passes. Pre-existing on `main` (`0fdeba96`), not caused by slice-3 work but blocks the full `/ci` run for `test:others`.

## Test plan

- [x] `bun run lint` — clean
- [x] `bun run type` — green
- [x] `bun run test:api` — 449/449 files passing
- [x] `bun x syncpack lint` — no issues
- [x] `SKIP_SYNCPACK=1 bash scripts/check-template-drift.sh` — passed
- [x] `bash scripts/check-railway-watch.sh` — passed
- [x] `bash scripts/check-schema-drift.sh` — passed
- [x] `bash scripts/check-ee-imports.sh` — passed
- [ ] `bun run test:others` — 2 pre-existing `@atlas/mcp` failures (see #2762); slice-3 packages all green