### PR TITLE
feat(api): #2742 — WorkspaceInstaller write-side facade (integration install + disconnect + update-config)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -343,7 +343,7 @@
     },
     "packages/types": {
       "name": "@useatlas/types",
-      "version": "0.1.6",
+      "version": "0.1.7",
     },
     "packages/web": {
       "name": "@atlas/web",

--- a/packages/api/src/api/routes/__tests__/disconnect-listener-gate.test.ts
+++ b/packages/api/src/api/routes/__tests__/disconnect-listener-gate.test.ts
@@ -100,13 +100,17 @@ const mockInternalQuery = mock(async (sql: string, _params?: unknown[]): Promise
   // both by checking for the SELECT column list rather than the WHERE
   // suffix. Return a row that satisfies both shapes.
   if (sql.includes("FROM plugin_catalog") && sql.includes("WHERE slug = $1")) {
-    return [{ id: "catalog:slack", slug: "slack", install_model: "oauth", enabled: true }];
+    // #2742 — WorkspaceInstaller.uninstall SELECTs `pillar` +
+    // `config_schema` from plugin_catalog; supply them so the row
+    // passes `isValidPillar` and reaches the credential teardown.
+    return [{ id: "catalog:slack", slug: "slack", install_model: "oauth", enabled: true, pillar: "chat", config_schema: null }];
   }
   // Install-row config lookup for teamId resolution (DELETE handler).
   // The substring is specific enough to avoid colliding with the gate
-  // JOIN query below.
-  if (sql.includes("SELECT config->>'team_id'")) {
-    return state.installPresent ? [{ team_id: "T-listener-gate-1" }] : [];
+  // JOIN query below. WorkspaceInstaller's row lookup SELECTs `id,
+  // install_id, config->>'team_id'` so supply all three.
+  if (sql.includes("SELECT id, install_id, config->>'team_id'")) {
+    return state.installPresent ? [{ id: "install-1", install_id: "install-1", team_id: "T-listener-gate-1" }] : [];
   }
   // Install-row DELETE (DELETE handler step 2). Flips the in-memory
   // flag so the next gate read sees the missing row.

--- a/packages/api/src/api/routes/__tests__/integrations.test.ts
+++ b/packages/api/src/api/routes/__tests__/integrations.test.ts
@@ -973,10 +973,10 @@ describe("plan-tier gating", () => {
           return [];
         }
         if (sql.includes("FROM plugin_catalog")) {
-          return [{ id: "catalog:slack", slug: "slack", install_model: "oauth", enabled: true, min_plan: "business" }];
+          return [{ id: "catalog:slack", slug: "slack", install_model: "oauth", enabled: true, min_plan: "business", pillar: "chat", config_schema: null }];
         }
         if (sql.includes("FROM workspace_plugins")) {
-          return [{ team_id: "T-downgraded" }];
+          return [{ id: "install-1", install_id: "install-1", team_id: "T-downgraded" }];
         }
         if (sql.includes("FROM organization")) {
           return [{ plan_tier: "free", is_operator_workspace: false }];
@@ -1020,11 +1020,13 @@ function stageSlackInstallLookup(teamId: string | null) {
       // (`getCatalogRowBySlugForDisconnect` — no gate) hit this branch.
       // Return a row with both shapes' fields populated so a single mock
       // serves both.
-      return [{ id: "catalog:slack", slug: "slack", install_model: "oauth", enabled: true }];
+      return [{ id: "catalog:slack", slug: "slack", install_model: "oauth", enabled: true, pillar: "chat", config_schema: null }];
     }
     if (sql.includes("FROM workspace_plugins")) {
       callOrder.push("workspace_plugins.select");
-      return teamId === null ? [] : [{ team_id: teamId }];
+      // #2742 — WorkspaceInstaller.uninstall SELECTs `id, install_id, team_id`
+      // for the row lookup; older route SELECTed `team_id` only.
+      return teamId === null ? [] : [{ id: "install-1", install_id: "install-1", team_id: teamId }];
     }
     return [];
   });
@@ -1133,11 +1135,12 @@ describe("DELETE /api/v1/integrations/slack — dual-store teardown", () => {
 
   it("returns 501 for a real catalog platform whose disconnect path isn't wired", async () => {
     // Future-Platform safety net: catalog returns a `teams` row (a real
-    // Platform), but `deleteCredentialStore` only dispatches `slack`
-    // today. The 501 must short-circuit before either store is touched.
+    // Platform), but the WorkspaceInstaller credential dispatch only
+    // covers `slack` + INTEGRATION_CREDENTIALS_SLUGS today. The 501
+    // must short-circuit before either store is touched.
     mockInternalQuery.mockImplementation(async (sql: string): Promise<unknown[]> => {
       if (sql.includes("FROM plugin_catalog")) {
-        return [{ id: "catalog:teams", slug: "teams", install_model: "oauth", enabled: true }];
+        return [{ id: "catalog:teams", slug: "teams", install_model: "oauth", enabled: true, pillar: "chat", config_schema: null }];
       }
       return [];
     });
@@ -1264,12 +1267,16 @@ describe("DELETE /api/v1/integrations/slack — dual-store teardown", () => {
         return [];
       }
       if (sql.includes("FROM plugin_catalog")) {
-        // enabled: false — the kill-switched state.
-        return [{ id: "catalog:slack", slug: "slack" }];
+        // enabled: false — the kill-switched state. WorkspaceInstaller's
+        // disconnect-side loader SELECTs `install_model, pillar,
+        // config_schema` as well as `id, slug, enabled` so the row needs
+        // every column (or the loader returns null → 404). Min-plan stays
+        // off because disconnect doesn't plan-gate.
+        return [{ id: "catalog:slack", slug: "slack", install_model: "oauth", enabled: false, pillar: "chat", config_schema: null }];
       }
       if (sql.includes("FROM workspace_plugins")) {
         callOrder.push("workspace_plugins.select");
-        return [{ team_id: "T-kill-switched" }];
+        return [{ id: "install-1", install_id: "install-1", team_id: "T-kill-switched" }];
       }
       return [];
     });
@@ -1293,11 +1300,11 @@ describe("DELETE /api/v1/integrations/slack — dual-store teardown", () => {
         return [];
       }
       if (sql.includes("FROM plugin_catalog")) {
-        return [{ id: "catalog:slack", slug: "slack", install_model: "oauth", enabled: true }];
+        return [{ id: "catalog:slack", slug: "slack", install_model: "oauth", enabled: true, pillar: "chat", config_schema: null }];
       }
       if (sql.includes("FROM workspace_plugins")) {
         callOrder.push("workspace_plugins.select");
-        return [{ team_id: "T-self-hosted" }];
+        return [{ id: "install-1", install_id: "install-1", team_id: "T-self-hosted" }];
       }
       return [];
     });
@@ -1337,14 +1344,17 @@ function stageSalesforceInstallLookup(present: boolean) {
       return [];
     }
     if (sql.includes("FROM plugin_catalog")) {
-      return [{ id: "catalog:salesforce", slug: "salesforce", install_model: "oauth", enabled: true }];
+      // #2742 — WorkspaceInstaller's catalog loader SELECTs `pillar` +
+      // `config_schema` too; supply them so the row passes the
+      // `isValidPillar` gate.
+      return [{ id: "catalog:salesforce", slug: "salesforce", install_model: "oauth", enabled: true, pillar: "action", config_schema: null }];
     }
     if (sql.includes("FROM workspace_plugins")) {
       callOrder.push("workspace_plugins.select");
       // Salesforce installs don't carry team_id — `team_id` resolves to NULL
       // through the JSONB extraction. The disconnect path tolerates a null
       // teamId for non-Slack platforms.
-      return present ? [{ team_id: null }] : [];
+      return present ? [{ id: "install-sf", install_id: "install-sf", team_id: null }] : [];
     }
     return [];
   });

--- a/packages/api/src/api/routes/admin-integrations.ts
+++ b/packages/api/src/api/routes/admin-integrations.ts
@@ -12,6 +12,11 @@ import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
 import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
 import { runEffect } from "@atlas/api/lib/effect/hono";
 import { AuthContext } from "@atlas/api/lib/effect/services";
+import {
+  WorkspaceInstaller,
+  WorkspaceInstallerLive,
+} from "@atlas/api/lib/effect/workspace-installer";
+import type { WorkspaceId } from "@useatlas/types";
 import { internalQuery, hasInternalDB } from "@atlas/api/lib/db/internal";
 import { getInstallationByOrg, saveInstallation, deleteInstallationByOrg } from "@atlas/api/lib/slack/store";
 import {
@@ -424,7 +429,17 @@ adminIntegrations.openapi(getStatusRoute, async (c) => {
   );
 });
 
-// DELETE /slack — disconnect Slack for current org
+// DELETE /slack — disconnect Slack for current org.
+//
+// #2742 — consolidated through `WorkspaceInstaller.uninstall` so the
+// ADR-0003 two-store teardown sequencing (chat_cache before
+// workspace_plugins) lives in one place. For OAuth installs this
+// clears both stores; for BYOT installs (which write to chat_cache
+// only via `connectSlackByotRoute` and never produce a
+// workspace_plugins row) the facade returns `InstallNotFoundError`
+// and we fall back to the legacy `deleteInstallationByOrg` — keeping
+// the BYOT disconnect path working without forcing every BYOT user
+// to first migrate to OAuth.
 adminIntegrations.openapi(disconnectSlackRoute, async (c) => {
   return runEffect(
     c,
@@ -438,16 +453,38 @@ adminIntegrations.openapi(disconnectSlackRoute, async (c) => {
         );
       }
 
-      const deleted = yield* Effect.tryPromise({
-        try: () => deleteInstallationByOrg(orgId),
-        catch: (err) => err instanceof Error ? err : new Error(String(err)),
-      });
+      // Try the facade first — drains both stores when the install was
+      // created via OAuth (slice 5+ flow). Catch `InstallNotFoundError`
+      // so we can fall back to the BYOT-only path.
+      const facadeOutcome = yield* Effect.gen(function* () {
+        const installer = yield* WorkspaceInstaller;
+        yield* installer.uninstall(orgId as WorkspaceId, "slack");
+        return "ok" as const;
+      }).pipe(
+        Effect.provide(WorkspaceInstallerLive),
+        Effect.catchTag("InstallNotFoundError", () =>
+          Effect.succeed("not_found" as const),
+        ),
+        Effect.catchTag("CatalogNotFoundError", () =>
+          // No catalog row → no OAuth install possible; treat as BYOT
+          // fallback so an environment without the `slack` catalog row
+          // can still clean up legacy BYOT credentials.
+          Effect.succeed("not_found" as const),
+        ),
+      );
 
-      if (!deleted) {
-        return c.json(
-          { error: "not_found", message: "No Slack installation found for this workspace." },
-          404,
-        );
+      if (facadeOutcome === "not_found") {
+        // BYOT fallback — legacy single-store delete keyed by orgId.
+        const deleted = yield* Effect.tryPromise({
+          try: () => deleteInstallationByOrg(orgId),
+          catch: (err) => err instanceof Error ? err : new Error(String(err)),
+        });
+        if (!deleted) {
+          return c.json(
+            { error: "not_found", message: "No Slack installation found for this workspace." },
+            404,
+          );
+        }
       }
 
       log.info({ orgId }, "Slack installation disconnected by admin");

--- a/packages/api/src/api/routes/integrations.ts
+++ b/packages/api/src/api/routes/integrations.ts
@@ -35,20 +35,24 @@
  * org binding (would write under a shared sentinel workspace id).
  */
 
+import { Effect } from "effect";
 import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
 import { z } from "zod";
 import { internalQuery } from "@atlas/api/lib/db/internal";
 import { createLogger } from "@atlas/api/lib/logger";
 import { getWebOrigin } from "@atlas/api/lib/web-origin";
-import { runHandler } from "@atlas/api/lib/effect/hono";
+import { runHandler, runEffect } from "@atlas/api/lib/effect/hono";
 import { getConfig } from "@atlas/api/lib/config";
 import { PlatformOAuthExchangeError } from "@atlas/api/lib/effect/errors";
+import {
+  WorkspaceInstaller,
+  WorkspaceInstallerLive,
+  INTEGRATION_CREDENTIALS_SLUGS,
+} from "@atlas/api/lib/effect/workspace-installer";
 import { getInstallHandler } from "@atlas/api/lib/integrations/install";
 import { FormInstallValidationError } from "@atlas/api/lib/integrations/install/email-form-handler";
 import { isPlanEligible } from "@atlas/api/lib/integrations/install/plan-rank";
 import { verifyOAuthStateToken } from "@atlas/api/lib/integrations/install/oauth-state-token";
-import { deleteInstallation as deleteSlackInstallation } from "@atlas/api/lib/slack/store";
-import { deleteCredentialBundle } from "@atlas/api/lib/integrations/credentials/store";
 import {
   detectMisrouting,
   isStrictRoutingEnabled,
@@ -861,10 +865,6 @@ integrations.openapi(callbackRoute, async (c) =>
 // real error if they try.
 // ---------------------------------------------------------------------------
 
-interface InstallRowFromDb extends Record<string, unknown> {
-  readonly team_id: string | null;
-}
-
 /**
  * Disconnect-side variant of {@link getInstallableCatalogRowBySlug} — same
  * shape minus the `enabled = true` predicate. Disconnect must succeed even
@@ -892,59 +892,11 @@ async function getCatalogRowBySlugForDisconnect(slug: string): Promise<{
   return { id: rows[0]!.id, slug: rows[0]!.slug };
 }
 
-/**
- * Slugs whose credentials live in `integration_credentials` keyed by
- * (workspace_id, catalog_id). Salesforce shipped first (#2658); Jira
- * (#2659) is the second consumer that proves the abstraction.
- *
- * Adding a new lazy OAuth integration requires (per the "Consequences"
- * section of ADR-0005):
- *   1. One line here.
- *   2. A `<slug>-oauth-handler.ts` + `<slug>-token-refresh.ts` pair.
- *   3. Registration in `lib/integrations/install/register.ts`
- *      (handler + LazyPluginLoader builder, env-gated together).
- *   4. A catalog entry in `deploy/api/atlas.config.ts`.
- *
- * Kept as a Set rather than a single `=== "salesforce"` check so the
- * one-line addition for the next integration is obvious.
- *
- * @see docs/adr/0005-integration-credentials-table.md
- */
-const INTEGRATION_CREDENTIALS_SLUGS = new Set<string>(["salesforce", "jira"]);
-
-/**
- * Credential-store teardown. Branches by slug:
- *   - `slack` → chat_cache row (legacy single-store path).
- *   - Any slug in {@link INTEGRATION_CREDENTIALS_SLUGS} → row in
- *     `integration_credentials` keyed by (workspace_id, catalog_id).
- *
- * Returns nothing — failure throws and the route layer surfaces 500.
- * Callers must invoke this BEFORE deleting `workspace_plugins` per
- * ADR-0003 (credentials must not outlive the install record).
- */
-async function deleteCredentialStore(
-  platform: string,
-  workspaceId: string,
-  catalogId: string,
-  teamId: string | null,
-): Promise<void> {
-  if (platform === "slack") {
-    if (!teamId) {
-      throw new Error("Slack disconnect requires a team_id from workspace_plugins.config");
-    }
-    await deleteSlackInstallation(teamId);
-    return;
-  }
-  if (INTEGRATION_CREDENTIALS_SLUGS.has(platform)) {
-    await deleteCredentialBundle(workspaceId, catalogId);
-    return;
-  }
-  // Any other slug that reached here passed the catalog enabled-check
-  // — so it's a real Platform, just one whose disconnect path isn't
-  // wired yet. The route surfaces 501 before reaching this branch, but
-  // the throw is a defensive backstop.
-  throw new Error(`Disconnect not implemented for platform "${platform}"`);
-}
+// Per-Platform credential-store dispatch lives in
+// `lib/effect/workspace-installer.ts` (`INTEGRATION_CREDENTIALS_SLUGS`
+// + `deleteCredentialStoreForSlug`). The route layer only consults the
+// imported set to decide whether disconnect is even wired (501 path
+// below).
 
 integrations.openapi(disconnectRoute, async (c) =>
   // No plan-tier gate here (#2701). A downgraded customer whose plan
@@ -1030,85 +982,47 @@ integrations.openapi(disconnectRoute, async (c) =>
       }
     }
 
-    // ── Catalog lookup — accepts disabled platforms ───────────────
-    // Unlike install, disconnect must succeed even when ops has
-    // kill-switched a Platform via `plugin_catalog.enabled = false` —
-    // otherwise the kill switch strands existing installs with no
-    // admin-visible UI to clear their credentials.
-    const catalog = await getCatalogRowBySlugForDisconnect(platform);
-    if (!catalog) {
-      return c.json({ error: "not_found", message: `Unknown platform "${platform}"`, requestId }, 404);
-    }
-
     // ── Per-Platform disconnect-handler check ─────────────────────
+    // The facade's `uninstall` is general but the route layer keeps
+    // the "is this platform supported by this deploy" gate so the
+    // pre-cutover 501 envelope (for non-wired chat/action platforms)
+    // stays stable. Slack and the lazy-OAuth set are the universe of
+    // chat/action installs the disconnect path can handle today.
     const isSlack = platform === "slack";
     const isIntegrationCredentials = INTEGRATION_CREDENTIALS_SLUGS.has(platform);
     if (!isSlack && !isIntegrationCredentials) {
+      // Cheap pre-check: catalog lookup so the 404 still fires before
+      // the 501. Otherwise an attacker probing unknown slugs would
+      // learn whether the slug exists (501 vs 404).
+      const catalog = await getCatalogRowBySlugForDisconnect(platform);
+      if (!catalog) {
+        return c.json({ error: "not_found", message: `Unknown platform "${platform}"`, requestId }, 404);
+      }
       return c.json(
         { error: "disconnect_unavailable", message: `Disconnect for "${platform}" is not yet implemented on this deploy.`, requestId },
         501,
       );
     }
 
-    // ── Resolve install row ───────────────────────────────────────
-    // Slack needs `config.team_id` to look up the chat_cache row.
-    // Salesforce / future integration_credentials Platforms only need
-    // the existence check — credential deletion is keyed by
-    // (workspace_id, catalog_id) directly. Reading `team_id`
-    // unconditionally is harmless (returns NULL for non-Slack rows).
-    //
-    // The install row's `catalog_id` matches `plugin_catalog.id` (read
-    // from the catalog lookup above) — synthesizing `catalog:${slug}`
-    // would be brittle if the seeder's id-derivation ever changes.
-    const catalogId = catalog.id;
-    const installRows = await internalQuery<InstallRowFromDb>(
-      `SELECT config->>'team_id' AS team_id
-         FROM workspace_plugins
-        WHERE workspace_id = $1 AND catalog_id = $2
-        LIMIT 1`,
-      [workspaceId, catalogId],
-    );
-    if (installRows.length === 0) {
-      return c.json(
-        { error: "not_found", message: `No ${platform} install found for this workspace.`, requestId },
-        404,
-      );
-    }
-    const teamId = installRows[0]?.team_id ?? null;
-    if (isSlack && !teamId) {
-      // Defensive — a Slack install row should always carry team_id.
-      // If it doesn't, the row is corrupted and the credential cleanup
-      // can't run; surface as 404 rather than throwing so the admin
-      // can disconnect via the legacy path.
-      return c.json(
-        { error: "not_found", message: `No ${platform} install found for this workspace.`, requestId },
-        404,
-      );
-    }
-
-    // ── Two-store teardown (ADR-0003 order is load-bearing) ───────
-    // 1) Credential row FIRST — credentials must not outlive the install
-    //    record. A failure here aborts the workspace_plugins delete; the
-    //    admin sees a 500 with a requestId and the install row is
-    //    preserved so they can retry.
-    // 2) workspace_plugins SECOND. A failure here leaves the install
-    //    row dangling but credentials are already gone. For Slack the
-    //    listener's per-event credential lookup misses on the cleared
-    //    chat_cache row and the event is silently skipped. For lazy
-    //    OAuth integrations the LazyPluginLoader's next build will fail
-    //    with "integration_credentials row is missing" and the agent
-    //    surfaces a clear "disconnect + reinstall" error. Acceptable
-    //    failed states per ADR-0003 "Consequences > For uninstall."
-    await deleteCredentialStore(platform, workspaceId, catalogId, teamId);
-
-    await internalQuery(
-      `DELETE FROM workspace_plugins
-        WHERE workspace_id = $1 AND catalog_id = $2`,
-      [workspaceId, catalogId],
+    // ── Pivot to WorkspaceInstaller.uninstall (#2742) ─────────────
+    // Two-store teardown (ADR-0003 order: credentials FIRST, install
+    // row SECOND) is owned by the facade. Tagged errors flow through
+    // `runEffect`'s `classifyError`: `CatalogNotFoundError` /
+    // `InstallNotFoundError` → 404; defects (unexpected DB failure)
+    // → 500 with requestId. `runEffect` throws `HTTPException`s
+    // directly — they bubble up to Hono's error handler as the
+    // structured error envelope.
+    await runEffect(
+      c,
+      Effect.gen(function* () {
+        const installer = yield* WorkspaceInstaller;
+        yield* installer.uninstall(workspaceId, platform);
+      }).pipe(Effect.provide(WorkspaceInstallerLive)),
+      { label: "platform disconnect" },
     );
 
     log.info(
-      { workspaceId, platform, teamId },
+      { workspaceId, platform },
       "Platform install disconnected (both stores cleared)",
     );
     return c.json({ message: `${platform} disconnected successfully.` }, 200);

--- a/packages/api/src/lib/effect/__tests__/workspace-installer.test.ts
+++ b/packages/api/src/lib/effect/__tests__/workspace-installer.test.ts
@@ -1,0 +1,754 @@
+/**
+ * Tests for `WorkspaceInstaller` (#2742 — slice 4 of 1.5.3).
+ *
+ * Three layers of coverage:
+ *
+ *   1. Schema validation — `validateAgainstConfigSchema` (pure helper).
+ *   2. Pillar singleton + dispatch — the facade's `install` method against
+ *      a stubbed install handler and `mock.module()`-shadowed
+ *      `internalQuery` / credential store.
+ *   3. Two-store teardown — `uninstall` calls credential store FIRST,
+ *      then `workspace_plugins` DELETE, in the order ADR-0003 mandates.
+ *
+ * The facade is a thin orchestration layer over the existing per-Platform
+ * install handlers (slice 5 — Slack OAuth; #2660 — form-based; ADR-0005
+ * — action OAuth). The handler unit tests already cover per-Platform
+ * write semantics; these tests verify the facade-level invariants
+ * (singleton, schema validation, error mapping, teardown order).
+ *
+ * `mock.module()` shadows the DB and credential store modules so the
+ * facade can be exercised without standing up Postgres or chat_cache.
+ * Effect test layers (`createWorkspaceInstallerTestLayer`) cover the
+ * stub-by-default semantics route-handler tests will eventually rely on.
+ */
+
+import { afterEach, beforeAll, beforeEach, describe, expect, it, mock, type Mock } from "bun:test";
+import { Effect } from "effect";
+import type { WorkspaceId } from "@useatlas/types";
+
+// ---------------------------------------------------------------------------
+// Module mocks — shadow DB + credential stores BEFORE importing the facade
+// ---------------------------------------------------------------------------
+
+// `internalQuery` is the DB seam every catalog / install lookup goes
+// through. We thread a queue of canned responses keyed by the SQL
+// fragment so each test stays declarative about the rows it cares about.
+const internalQueryResponses: Array<{
+  match: (sql: string, params?: unknown[]) => boolean;
+  rows: unknown[];
+}> = [];
+
+const internalQueryCalls: Array<{ sql: string; params?: unknown[] }> = [];
+
+const mockInternalQuery: Mock<(sql: string, params?: unknown[]) => Promise<unknown[]>> = mock(
+  async (sql: string, params?: unknown[]) => {
+    internalQueryCalls.push({ sql, params });
+    for (let i = 0; i < internalQueryResponses.length; i++) {
+      const entry = internalQueryResponses[i];
+      if (entry.match(sql, params)) {
+        // Pop matched response so tests can queue multiple in order.
+        internalQueryResponses.splice(i, 1);
+        return entry.rows;
+      }
+    }
+    return [];
+  },
+);
+
+mock.module("@atlas/api/lib/db/internal", () => ({
+  internalQuery: mockInternalQuery,
+  hasInternalDB: mock(() => true),
+  getInternalDB: mock(() => ({ query: mock(() => Promise.resolve({ rows: [] })) })),
+  // Re-stub the Effect-facing surface; the facade doesn't yield InternalDB
+  // but other modules in the dep graph might.
+  InternalDB: { _tag: "InternalDB" },
+  makeInternalDBLive: mock(() => ({})),
+  createInternalDBTestLayer: mock(() => ({})),
+  queryEffect: mock(() => Effect.succeed([])),
+}));
+
+// Slack credential store — chat_cache write path. Capture calls so the
+// teardown-order test can assert ordering.
+const slackDeleteCalls: string[] = [];
+const mockDeleteSlackInstallation: Mock<(teamId: string) => Promise<void>> = mock(
+  async (teamId: string) => {
+    slackDeleteCalls.push(teamId);
+  },
+);
+
+mock.module("@atlas/api/lib/slack/store", () => ({
+  deleteInstallation: mockDeleteSlackInstallation,
+  saveInstallation: mock(() => Promise.resolve()),
+}));
+
+// integration_credentials store — action OAuth teardown.
+const credentialDeleteCalls: Array<{ workspaceId: string; catalogId: string }> = [];
+const mockDeleteCredentialBundle: Mock<(workspaceId: string, catalogId: string) => Promise<boolean>> = mock(
+  async (workspaceId: string, catalogId: string) => {
+    credentialDeleteCalls.push({ workspaceId, catalogId });
+    return true;
+  },
+);
+
+mock.module("@atlas/api/lib/integrations/credentials/store", () => ({
+  deleteCredentialBundle: mockDeleteCredentialBundle,
+  saveCredentialBundle: mock(() => Promise.resolve()),
+  readCredentialBundle: mock(() => Promise.resolve(null)),
+}));
+
+// Install handler dispatch — let tests inject per-slug handlers.
+type DispatchHandler =
+  | {
+      kind: "form";
+      validateConfig: (workspaceId: WorkspaceId, formData: unknown) => Promise<unknown>;
+    }
+  | {
+      kind: "oauth";
+      startInstall: (workspaceId: WorkspaceId) => Promise<unknown>;
+      handleCallback: (code: string, stateToken: string) => Promise<unknown>;
+    }
+  | {
+      kind: "static-bot";
+      confirmInstall: (
+        workspaceId: WorkspaceId,
+        routingIdentifier: string,
+        verificationProof?: string,
+      ) => Promise<unknown>;
+    };
+
+const dispatchHandlers = new Map<string, DispatchHandler>();
+const mockGetInstallHandler = mock((catalogRow: { slug: string; install_model: string }) => {
+  const handler = dispatchHandlers.get(catalogRow.slug);
+  if (!handler) {
+    throw new Error(`Test stub: no install handler registered for "${catalogRow.slug}"`);
+  }
+  return handler;
+});
+
+// Mock the dispatch sub-module — the facade lazy-`require`s
+// `lib/integrations/install/dispatch` (not the barrel) so we shadow
+// the same path. Mock ALL named exports of that file per CLAUDE.md's
+// "mock all exports" rule.
+mock.module("@atlas/api/lib/integrations/install/dispatch", () => ({
+  getInstallHandler: mockGetInstallHandler,
+  registerOAuthHandler: mock(() => {}),
+  registerFormHandler: mock(() => {}),
+  _resetInstallHandlerRegistries: mock(() => {}),
+}));
+
+// ---------------------------------------------------------------------------
+// Lazy import of the facade after mocks are in place
+// ---------------------------------------------------------------------------
+
+type WorkspaceInstallerModule = typeof import("../workspace-installer");
+let mod!: WorkspaceInstallerModule;
+
+beforeAll(async () => {
+  mod = await import("../workspace-installer");
+});
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+const WSID = "ws-test-1" as WorkspaceId;
+
+function resetState() {
+  internalQueryResponses.length = 0;
+  internalQueryCalls.length = 0;
+  slackDeleteCalls.length = 0;
+  credentialDeleteCalls.length = 0;
+  dispatchHandlers.clear();
+  mockInternalQuery.mockClear();
+  mockDeleteSlackInstallation.mockClear();
+  mockDeleteCredentialBundle.mockClear();
+  mockGetInstallHandler.mockClear();
+}
+
+beforeEach(() => {
+  resetState();
+});
+
+afterEach(() => {
+  resetState();
+});
+
+function queueCatalogLookup(
+  slug: string,
+  overrides: Partial<{
+    id: string;
+    install_model: string;
+    pillar: string;
+    config_schema: unknown;
+    enabled: boolean;
+  }> = {},
+): void {
+  internalQueryResponses.push({
+    match: (sql: string, params?: unknown[]) =>
+      sql.includes("FROM plugin_catalog") && (params?.[0] === slug),
+    rows: [
+      {
+        id: overrides.id ?? `catalog:${slug}`,
+        slug,
+        install_model: overrides.install_model ?? "oauth",
+        pillar: overrides.pillar ?? "chat",
+        config_schema: overrides.config_schema ?? null,
+        enabled: overrides.enabled ?? true,
+      },
+    ],
+  });
+}
+
+function queueInstallLookup(
+  workspaceId: string,
+  catalogId: string,
+  existing: { id: string; install_id: string; team_id?: string | null } | null,
+): void {
+  internalQueryResponses.push({
+    match: (sql: string, params?: unknown[]) =>
+      sql.includes("FROM workspace_plugins") &&
+      sql.includes("install_id") &&
+      params?.[0] === workspaceId &&
+      params?.[1] === catalogId &&
+      !sql.includes("DELETE"),
+    rows: existing
+      ? [
+          {
+            id: existing.id,
+            install_id: existing.install_id,
+            team_id: existing.team_id ?? null,
+          },
+        ]
+      : [],
+  });
+}
+
+function runEffect<A, E>(eff: Effect.Effect<A, E>): Promise<A> {
+  return Effect.runPromise(eff as Effect.Effect<A, E, never>);
+}
+
+// ---------------------------------------------------------------------------
+// 1. Schema validation
+// ---------------------------------------------------------------------------
+
+describe("validateAgainstConfigSchema", () => {
+  it("returns null when schema is absent (null / undefined)", () => {
+    const err = mod._testing.validateAgainstConfigSchema("foo", null, { host: "x" });
+    expect(err).toBeNull();
+  });
+
+  it("returns null when schema is corrupt — facade defers to per-handler validation", () => {
+    const err = mod._testing.validateAgainstConfigSchema(
+      "foo",
+      { not: "an array" },
+      { host: "x" },
+    );
+    expect(err).toBeNull();
+  });
+
+  it("returns null when all required fields are present and well-typed", () => {
+    const schema = [
+      { key: "host", type: "string", required: true },
+      { key: "port", type: "number", required: true },
+    ];
+    const err = mod._testing.validateAgainstConfigSchema("foo", schema, {
+      host: "smtp.example.com",
+      port: 587,
+    });
+    expect(err).toBeNull();
+  });
+
+  it("flags missing required field with per-field error", () => {
+    const schema = [
+      { key: "host", type: "string", required: true },
+      { key: "port", type: "number", required: true },
+    ];
+    const err = mod._testing.validateAgainstConfigSchema("foo", schema, { host: "x" });
+    expect(err).not.toBeNull();
+    expect(err?._tag).toBe("ConfigSchemaError");
+    expect(err?.fieldErrors.port).toBeDefined();
+    expect(err?.fieldErrors.port?.[0]).toContain("required");
+  });
+
+  it("flags wrong-type field — string vs number", () => {
+    const schema = [{ key: "port", type: "number", required: true }];
+    const err = mod._testing.validateAgainstConfigSchema("foo", schema, {
+      port: "not-a-number",
+    });
+    expect(err).not.toBeNull();
+    expect(err?.fieldErrors.port).toBeDefined();
+    expect(err?.fieldErrors.port?.[0]).toContain("number");
+  });
+
+  it("allows optional fields to be absent", () => {
+    const schema = [
+      { key: "host", type: "string", required: true },
+      { key: "secure", type: "boolean", required: false },
+    ];
+    const err = mod._testing.validateAgainstConfigSchema("foo", schema, {
+      host: "smtp.example.com",
+    });
+    expect(err).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. install() — dispatch + singleton + schema validation
+// ---------------------------------------------------------------------------
+
+describe("WorkspaceInstaller.install", () => {
+  it("rejects unknown catalog slug with CatalogNotFoundError → 404", async () => {
+    // No catalog row — empty response.
+    internalQueryResponses.push({
+      match: (sql, params) => sql.includes("FROM plugin_catalog") && params?.[0] === "missing",
+      rows: [],
+    });
+    const installer = await getLiveService();
+    const exit = await Effect.runPromiseExit(
+      installer.install(WSID, "missing", { kind: "oauth-start" }),
+    );
+    expect(exit._tag).toBe("Failure");
+    if (exit._tag === "Failure") {
+      const failure = exit.cause;
+      // Extract the failure value
+      const json = JSON.stringify(failure);
+      expect(json).toContain("CatalogNotFoundError");
+    }
+  });
+
+  it("rejects datasource pillar — slice 6 owns those installs", async () => {
+    queueCatalogLookup("postgres", { pillar: "datasource", install_model: "form" });
+    const installer = await getLiveService();
+    const exit = await Effect.runPromiseExit(
+      installer.install(WSID, "postgres", {
+        kind: "form",
+        formData: {},
+      }),
+    );
+    expect(exit._tag).toBe("Failure");
+    if (exit._tag === "Failure") {
+      expect(JSON.stringify(exit.cause)).toContain("CatalogNotFoundError");
+    }
+  });
+
+  it("rejects second chat install with AlreadyInstalledError → 409", async () => {
+    queueCatalogLookup("slack", { pillar: "chat", install_model: "oauth" });
+    queueInstallLookup(WSID, "catalog:slack", { id: "install-1", install_id: "install-1", team_id: "T123" });
+    const installer = await getLiveService();
+    const exit = await Effect.runPromiseExit(
+      installer.install(WSID, "slack", { kind: "oauth-start" }),
+    );
+    expect(exit._tag).toBe("Failure");
+    if (exit._tag === "Failure") {
+      const json = JSON.stringify(exit.cause);
+      expect(json).toContain("AlreadyInstalledError");
+      expect(json).toContain("slack");
+    }
+  });
+
+  it("allows oauth-callback to re-install (Reconnect path per ADR-0003)", async () => {
+    queueCatalogLookup("slack", { pillar: "chat", install_model: "oauth" });
+    queueInstallLookup(WSID, "catalog:slack", { id: "install-1", install_id: "install-1", team_id: "T123" });
+    // Even with an existing install, OAuth callback must be allowed
+    // through (UPSERT is the documented re-connect path).
+    dispatchHandlers.set("slack", {
+      kind: "oauth",
+      startInstall: async () => ({ redirectUrl: "x", stateToken: "y" }),
+      handleCallback: async () => ({
+        workspaceId: WSID,
+        catalogId: "slack",
+        installRecord: { id: "install-1", workspaceId: WSID, catalogId: "slack" },
+        credentialResult: { written: true },
+      }),
+    });
+    const installer = await getLiveService();
+    const result = await runEffect(
+      installer.install(WSID, "slack", {
+        kind: "oauth-callback",
+        code: "abc",
+        stateToken: "tok",
+      }),
+    );
+    expect(result.kind).toBe("oauth-callback");
+  });
+
+  it("rejects form install with ConfigSchemaError when required field missing", async () => {
+    queueCatalogLookup("email", {
+      pillar: "action",
+      install_model: "form",
+      config_schema: [
+        { key: "host", type: "string", required: true },
+        { key: "port", type: "number", required: true },
+      ],
+    });
+    queueInstallLookup(WSID, "catalog:email", null);
+    dispatchHandlers.set("email", {
+      kind: "form",
+      validateConfig: async () => ({
+        installRecord: { id: "id-1", workspaceId: WSID, catalogId: "email" },
+        credentialWritten: true,
+      }),
+    });
+    const installer = await getLiveService();
+    const exit = await Effect.runPromiseExit(
+      installer.install(WSID, "email", {
+        kind: "form",
+        formData: { host: "smtp.example.com" }, // missing port
+      }),
+    );
+    expect(exit._tag).toBe("Failure");
+    if (exit._tag === "Failure") {
+      const json = JSON.stringify(exit.cause);
+      expect(json).toContain("ConfigSchemaError");
+      expect(json).toContain("port");
+    }
+  });
+
+  it("dispatches to OAuth handler.startInstall when kind=oauth-start", async () => {
+    queueCatalogLookup("slack", { pillar: "chat", install_model: "oauth" });
+    queueInstallLookup(WSID, "catalog:slack", null);
+    let started = false;
+    dispatchHandlers.set("slack", {
+      kind: "oauth",
+      startInstall: async () => {
+        started = true;
+        return { redirectUrl: "https://slack.example/authorize", stateToken: "tok-1" };
+      },
+      handleCallback: async () => null,
+    });
+    const installer = await getLiveService();
+    const result = await runEffect(
+      installer.install(WSID, "slack", { kind: "oauth-start" }),
+    );
+    expect(started).toBe(true);
+    expect(result.kind).toBe("oauth-start");
+    if (result.kind === "oauth-start") {
+      expect(result.redirectUrl).toBe("https://slack.example/authorize");
+      expect(result.stateToken).toBe("tok-1");
+    }
+  });
+
+  it("dispatches to form handler.validateConfig for valid form install", async () => {
+    queueCatalogLookup("email", {
+      pillar: "action",
+      install_model: "form",
+      config_schema: [{ key: "host", type: "string", required: true }],
+    });
+    queueInstallLookup(WSID, "catalog:email", null);
+    let validated: unknown = null;
+    dispatchHandlers.set("email", {
+      kind: "form",
+      validateConfig: async (_workspaceId, formData) => {
+        validated = formData;
+        return {
+          installRecord: { id: "id-email-1", workspaceId: WSID, catalogId: "email" },
+          credentialWritten: true,
+        };
+      },
+    });
+    const installer = await getLiveService();
+    const result = await runEffect(
+      installer.install(WSID, "email", {
+        kind: "form",
+        formData: { host: "smtp.example.com" },
+      }),
+    );
+    expect(validated).toEqual({ host: "smtp.example.com" });
+    expect(result.kind).toBe("form");
+    if (result.kind === "form") {
+      expect(result.row.id).toBe("id-email-1");
+      expect(result.row.pillar).toBe("action");
+      expect(result.credentialWritten).toBe(true);
+    }
+  });
+
+  it("dispatches to OAuth handler.handleCallback when kind=oauth-callback", async () => {
+    queueCatalogLookup("slack", { pillar: "chat", install_model: "oauth" });
+    queueInstallLookup(WSID, "catalog:slack", null);
+    let calledWith: { code?: string; state?: string } = {};
+    dispatchHandlers.set("slack", {
+      kind: "oauth",
+      startInstall: async () => ({ redirectUrl: "x", stateToken: "y" }),
+      handleCallback: async (code, state) => {
+        calledWith = { code, state };
+        return {
+          workspaceId: WSID,
+          catalogId: "slack",
+          installRecord: { id: "install-x", workspaceId: WSID, catalogId: "slack" },
+          credentialResult: { written: true },
+        };
+      },
+    });
+    const installer = await getLiveService();
+    const result = await runEffect(
+      installer.install(WSID, "slack", {
+        kind: "oauth-callback",
+        code: "the-code",
+        stateToken: "the-state",
+      }),
+    );
+    expect(calledWith.code).toBe("the-code");
+    expect(calledWith.state).toBe("the-state");
+    expect(result.kind).toBe("oauth-callback");
+    if (result.kind === "oauth-callback") {
+      expect(result.row).not.toBeNull();
+      expect(result.row?.id).toBe("install-x");
+    }
+  });
+
+  it("propagates null row when OAuth handler.handleCallback returns null (invalid state)", async () => {
+    queueCatalogLookup("slack", { pillar: "chat", install_model: "oauth" });
+    queueInstallLookup(WSID, "catalog:slack", null);
+    dispatchHandlers.set("slack", {
+      kind: "oauth",
+      startInstall: async () => ({ redirectUrl: "x", stateToken: "y" }),
+      handleCallback: async () => null,
+    });
+    const installer = await getLiveService();
+    const result = await runEffect(
+      installer.install(WSID, "slack", {
+        kind: "oauth-callback",
+        code: "the-code",
+        stateToken: "bad-state",
+      }),
+    );
+    expect(result.kind).toBe("oauth-callback");
+    if (result.kind === "oauth-callback") {
+      expect(result.row).toBeNull();
+      expect(result.credentialResult).toBeNull();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. uninstall() — two-store teardown order
+// ---------------------------------------------------------------------------
+
+describe("WorkspaceInstaller.uninstall", () => {
+  it("returns CatalogNotFoundError for unknown slug", async () => {
+    internalQueryResponses.push({
+      match: (sql, params) => sql.includes("FROM plugin_catalog") && params?.[0] === "missing",
+      rows: [],
+    });
+    const installer = await getLiveService();
+    const exit = await Effect.runPromiseExit(installer.uninstall(WSID, "missing"));
+    expect(exit._tag).toBe("Failure");
+    if (exit._tag === "Failure") {
+      expect(JSON.stringify(exit.cause)).toContain("CatalogNotFoundError");
+    }
+  });
+
+  it("returns InstallNotFoundError when no install row exists", async () => {
+    queueCatalogLookup("slack", { pillar: "chat", install_model: "oauth" });
+    queueInstallLookup(WSID, "catalog:slack", null);
+    const installer = await getLiveService();
+    const exit = await Effect.runPromiseExit(installer.uninstall(WSID, "slack"));
+    expect(exit._tag).toBe("Failure");
+    if (exit._tag === "Failure") {
+      expect(JSON.stringify(exit.cause)).toContain("InstallNotFoundError");
+    }
+  });
+
+  it("calls chat_cache (Slack) DELETE BEFORE workspace_plugins DELETE", async () => {
+    queueCatalogLookup("slack", { pillar: "chat", install_model: "oauth" });
+    queueInstallLookup(WSID, "catalog:slack", {
+      id: "install-1",
+      install_id: "install-1",
+      team_id: "T-team-123",
+    });
+    // Queue the DELETE FROM workspace_plugins response (no rows returned).
+    internalQueryResponses.push({
+      match: (sql) => sql.includes("DELETE FROM workspace_plugins"),
+      rows: [],
+    });
+
+    const installer = await getLiveService();
+    await runEffect(installer.uninstall(WSID, "slack"));
+
+    // Order assertion: chat_cache delete must precede the workspace_plugins DELETE.
+    expect(slackDeleteCalls).toEqual(["T-team-123"]);
+    const deleteSqlIdx = internalQueryCalls.findIndex((c) =>
+      c.sql.includes("DELETE FROM workspace_plugins"),
+    );
+    expect(deleteSqlIdx).toBeGreaterThanOrEqual(0);
+    // Slack delete was invoked synchronously before the DELETE call,
+    // and the queue captures the workspace_plugins DELETE here.
+    expect(mockDeleteSlackInstallation).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls integration_credentials DELETE BEFORE workspace_plugins for action OAuth (salesforce)", async () => {
+    queueCatalogLookup("salesforce", { pillar: "action", install_model: "oauth" });
+    queueInstallLookup(WSID, "catalog:salesforce", {
+      id: "install-sf",
+      install_id: "install-sf",
+      team_id: null,
+    });
+    internalQueryResponses.push({
+      match: (sql) => sql.includes("DELETE FROM workspace_plugins"),
+      rows: [],
+    });
+
+    const installer = await getLiveService();
+    await runEffect(installer.uninstall(WSID, "salesforce"));
+
+    expect(credentialDeleteCalls).toEqual([
+      { workspaceId: WSID, catalogId: "catalog:salesforce" },
+    ]);
+    expect(mockDeleteCredentialBundle).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips per-platform credential teardown for form-based installs (no separate store)", async () => {
+    queueCatalogLookup("email", { pillar: "action", install_model: "form" });
+    queueInstallLookup(WSID, "catalog:email", {
+      id: "install-email",
+      install_id: "install-email",
+      team_id: null,
+    });
+    internalQueryResponses.push({
+      match: (sql) => sql.includes("DELETE FROM workspace_plugins"),
+      rows: [],
+    });
+
+    const installer = await getLiveService();
+    await runEffect(installer.uninstall(WSID, "email"));
+
+    // Neither Slack nor integration_credentials store should be touched.
+    expect(mockDeleteSlackInstallation).not.toHaveBeenCalled();
+    expect(mockDeleteCredentialBundle).not.toHaveBeenCalled();
+    // workspace_plugins DELETE still ran.
+    const deleteSqlIdx = internalQueryCalls.findIndex((c) =>
+      c.sql.includes("DELETE FROM workspace_plugins"),
+    );
+    expect(deleteSqlIdx).toBeGreaterThanOrEqual(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. updateConfig() — schema validation + secret encryption
+// ---------------------------------------------------------------------------
+
+describe("WorkspaceInstaller.updateConfig", () => {
+  it("returns InstallNotFoundError when row doesn't exist", async () => {
+    queueCatalogLookup("email", { pillar: "action", install_model: "form" });
+    // queue empty install row lookup
+    internalQueryResponses.push({
+      match: (sql) =>
+        sql.includes("FROM workspace_plugins") && sql.includes("install_id") && !sql.includes("DELETE"),
+      rows: [],
+    });
+    const installer = await getLiveService();
+    const exit = await Effect.runPromiseExit(
+      installer.updateConfig(WSID, "email", "missing-id", { host: "x" }),
+    );
+    expect(exit._tag).toBe("Failure");
+    if (exit._tag === "Failure") {
+      expect(JSON.stringify(exit.cause)).toContain("InstallNotFoundError");
+    }
+  });
+
+  it("returns ConfigSchemaError when merged config violates schema", async () => {
+    queueCatalogLookup("email", {
+      pillar: "action",
+      install_model: "form",
+      config_schema: [
+        { key: "host", type: "string", required: true },
+        { key: "port", type: "number", required: true },
+      ],
+    });
+    internalQueryResponses.push({
+      match: (sql) =>
+        sql.includes("FROM workspace_plugins") && sql.includes("install_id") && !sql.includes("DELETE"),
+      // existing row WITHOUT port — partial update doesn't supply port either
+      rows: [{ id: "id-1", install_id: "id-1", config: { host: "smtp.x" } }],
+    });
+    const installer = await getLiveService();
+    const exit = await Effect.runPromiseExit(
+      installer.updateConfig(WSID, "email", "id-1", { host: "smtp.new" }),
+    );
+    expect(exit._tag).toBe("Failure");
+    if (exit._tag === "Failure") {
+      expect(JSON.stringify(exit.cause)).toContain("ConfigSchemaError");
+    }
+  });
+
+  it("writes through merged config when validation passes", async () => {
+    queueCatalogLookup("email", {
+      pillar: "action",
+      install_model: "form",
+      config_schema: [
+        { key: "host", type: "string", required: true },
+        { key: "port", type: "number", required: true },
+      ],
+    });
+    internalQueryResponses.push({
+      match: (sql) =>
+        sql.includes("FROM workspace_plugins") && sql.includes("install_id") && !sql.includes("DELETE"),
+      rows: [{ id: "id-1", install_id: "id-1", config: { host: "smtp.x", port: 25 } }],
+    });
+    // queue the UPDATE response
+    internalQueryResponses.push({
+      match: (sql) => sql.includes("UPDATE workspace_plugins"),
+      rows: [],
+    });
+    const installer = await getLiveService();
+    const row = await runEffect(
+      installer.updateConfig(WSID, "email", "id-1", { host: "smtp.new" }),
+    );
+    expect(row.id).toBe("id-1");
+    expect(row.pillar).toBe("action");
+    // assert the UPDATE was issued with the merged config
+    const updateCall = internalQueryCalls.find((c) => c.sql.includes("UPDATE workspace_plugins"));
+    expect(updateCall).toBeDefined();
+    // first param is the JSON-stringified config
+    const persistedConfig = JSON.parse((updateCall?.params?.[0] as string) ?? "{}");
+    expect(persistedConfig.host).toBe("smtp.new");
+    expect(persistedConfig.port).toBe(25);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. Test-layer factory
+// ---------------------------------------------------------------------------
+
+describe("createWorkspaceInstallerTestLayer", () => {
+  it("provides the partial methods and throws for unspecified ones", async () => {
+    const layer = mod.createWorkspaceInstallerTestLayer({
+      uninstall: () => Effect.succeed(undefined),
+    });
+    // uninstall is provided
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const svc = yield* mod.WorkspaceInstaller;
+        yield* svc.uninstall(WSID, "slack");
+        return "ok";
+      }).pipe(Effect.provide(layer)),
+    );
+    expect(result).toBe("ok");
+
+    // install is NOT provided — should throw with descriptive error
+    try {
+      await Effect.runPromise(
+        Effect.gen(function* () {
+          const svc = yield* mod.WorkspaceInstaller;
+          return svc.install(WSID, "slack", { kind: "oauth-start" });
+        }).pipe(Effect.provide(layer)),
+      );
+      throw new Error("expected throw");
+    } catch (err) {
+      expect((err as Error).message).toContain("install");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Helper: build the live service for the tests above.
+// ---------------------------------------------------------------------------
+
+async function getLiveService(): Promise<import("../workspace-installer").WorkspaceInstallerShape> {
+  return await Effect.runPromise(
+    Effect.gen(function* () {
+      const svc = yield* mod.WorkspaceInstaller;
+      return svc;
+    }).pipe(Effect.provide(mod.WorkspaceInstallerLive)),
+  );
+}

--- a/packages/api/src/lib/effect/errors.ts
+++ b/packages/api/src/lib/effect/errors.ts
@@ -395,6 +395,68 @@ export class JiraReconnectRequiredError extends Data.TaggedError(
   readonly upstreamError: string;
 }> {}
 
+// ── Workspace Installer (#2742) ────────────────────────────────────
+
+/**
+ * Pillar-singleton violation — a `chat` / `action` install already
+ * exists for `(workspaceId, catalogSlug)`. Maps to HTTP 409.
+ *
+ * Backed by `workspace_plugins_singleton` partial unique index (slice 1,
+ * #2739); the facade pre-checks for a friendlier error and the index
+ * remains the defensive backstop against races. Defined here rather
+ * than in `lib/effect/workspace-installer.ts` so it participates in
+ * the `AtlasError` union and the `mapTaggedError` exhaustive switch.
+ *
+ * @see packages/api/src/lib/effect/workspace-installer.ts
+ */
+export class AlreadyInstalledError extends Data.TaggedError("AlreadyInstalledError")<{
+  readonly message: string;
+  readonly workspaceId: string;
+  readonly catalogSlug: string;
+  readonly pillar: "chat" | "action";
+}> {}
+
+/**
+ * `config` failed validation against `plugin_catalog.config_schema`.
+ * Maps to HTTP 400 with `fieldErrors` / `formErrors` in the response
+ * body so the admin UI form can render per-field messages.
+ *
+ * Per-handler Zod validation layers richer checks on top — this error
+ * is the catalog-level contract violation (missing required field,
+ * wrong type) the facade enforces before the handler runs.
+ *
+ * @see packages/api/src/lib/effect/workspace-installer.ts
+ */
+export class ConfigSchemaError extends Data.TaggedError("ConfigSchemaError")<{
+  readonly message: string;
+  readonly catalogSlug: string;
+  readonly fieldErrors: Readonly<Record<string, readonly string[]>>;
+  readonly formErrors: readonly string[];
+}> {}
+
+/**
+ * Catalog row not found or kill-switched. Maps to HTTP 404.
+ *
+ * @see packages/api/src/lib/effect/workspace-installer.ts
+ */
+export class CatalogNotFoundError extends Data.TaggedError("CatalogNotFoundError")<{
+  readonly message: string;
+  readonly catalogSlug: string;
+}> {}
+
+/**
+ * Install row not found for `(workspaceId, catalogSlug)`. Surfaces from
+ * `uninstall` and `updateConfig` when the target row is gone. Maps to
+ * HTTP 404.
+ *
+ * @see packages/api/src/lib/effect/workspace-installer.ts
+ */
+export class InstallNotFoundError extends Data.TaggedError("InstallNotFoundError")<{
+  readonly message: string;
+  readonly workspaceId: string;
+  readonly catalogSlug: string;
+}> {}
+
 // ── Scheduler ──────────────────────────────────────────────────────
 
 /** Scheduled task execution timed out. */
@@ -448,6 +510,10 @@ export type AtlasError =
   | PlatformOAuthExchangeError
   | SalesforceReconnectRequiredError
   | JiraReconnectRequiredError
+  | AlreadyInstalledError
+  | ConfigSchemaError
+  | CatalogNotFoundError
+  | InstallNotFoundError
   | SchedulerTaskTimeoutError
   | SchedulerExecutionError
   | DeliveryError
@@ -502,6 +568,10 @@ export const ATLAS_ERROR_TAG_LIST = [
   "PlatformOAuthExchangeError",
   "SalesforceReconnectRequiredError",
   "JiraReconnectRequiredError",
+  "AlreadyInstalledError",
+  "ConfigSchemaError",
+  "CatalogNotFoundError",
+  "InstallNotFoundError",
   "SchedulerTaskTimeoutError",
   "SchedulerExecutionError",
   "DeliveryError",

--- a/packages/api/src/lib/effect/hono.ts
+++ b/packages/api/src/lib/effect/hono.ts
@@ -166,6 +166,26 @@ export function mapTaggedError(error: AtlasError): HttpErrorMapping {
     case "EmptyQueryError":
     case "ParseError":
       return { status: 400, code: "bad_request", message: error.message };
+    // #2742 — catalog `config_schema` violation. Surface per-field
+    // detail in the response body so the admin UI's form can highlight
+    // the wrong inputs without a follow-up roundtrip. Field names are
+    // catalog-declared keys; `formErrors` covers top-level issues that
+    // don't bind to one field.
+    case "ConfigSchemaError":
+      return {
+        status: 400,
+        code: "bad_request",
+        message: error.message,
+        body: {
+          catalogSlug: error.catalogSlug,
+          // Cast back to plain arrays at the response boundary so
+          // OpenAPI schema clients see regular `string[]`.
+          fieldErrors: Object.fromEntries(
+            Object.entries(error.fieldErrors).map(([k, v]) => [k, [...v]]),
+          ),
+          formErrors: [...error.formErrors],
+        },
+      };
 
     // ── 403 Forbidden — policy/permission violations ─────────────
     case "ForbiddenPatternError":
@@ -209,6 +229,37 @@ export function mapTaggedError(error: AtlasError): HttpErrorMapping {
         status: 409,
         code: "conflict",
         message: error.message,
+      };
+    // #2742 — pillar-singleton violation. Maps to 409 so the admin UI
+    // surfaces "already installed; disconnect first to reinstall"
+    // rather than the generic upstream-error toast.
+    case "AlreadyInstalledError":
+      return {
+        status: 409,
+        code: "conflict",
+        message: error.message,
+        body: {
+          catalogSlug: error.catalogSlug,
+          pillar: error.pillar,
+        },
+      };
+    // #2742 — install row missing for `(workspace, catalog)`. Distinct
+    // from `CatalogNotFoundError` (catalog itself is missing) — both
+    // map to 404 but the body fields differ so the admin UI can render
+    // the right toast.
+    case "InstallNotFoundError":
+      return {
+        status: 404,
+        code: "not_found",
+        message: error.message,
+        body: { catalogSlug: error.catalogSlug },
+      };
+    case "CatalogNotFoundError":
+      return {
+        status: 404,
+        code: "not_found",
+        message: error.message,
+        body: { catalogSlug: error.catalogSlug },
       };
 
     // ── 422 Unprocessable Entity — plugin rejected ───────────────

--- a/packages/api/src/lib/effect/index.ts
+++ b/packages/api/src/lib/effect/index.ts
@@ -197,3 +197,24 @@ export {
   queryEffect,
   type InternalDBShape,
 } from "@atlas/api/lib/db/internal";
+
+// ── WorkspaceInstaller (#2742 — slice 4 of 1.5.3) ───────────────────
+
+export {
+  WorkspaceInstaller,
+  WorkspaceInstallerLive,
+  createWorkspaceInstallerTestLayer,
+  INTEGRATION_CREDENTIALS_SLUGS,
+  type WorkspaceInstallerShape,
+  type WorkspaceInstallRow,
+  type InstallInput,
+  type InstallResult,
+  type InstallError,
+} from "./workspace-installer";
+
+export {
+  AlreadyInstalledError,
+  ConfigSchemaError,
+  CatalogNotFoundError,
+  InstallNotFoundError,
+} from "./errors";

--- a/packages/api/src/lib/effect/services.ts
+++ b/packages/api/src/lib/effect/services.ts
@@ -2439,3 +2439,33 @@ export const NoopEnterpriseDefaultsLayer: Layer.Layer<
   NoopProactiveGateLayer,
   NoopDeployModeResolverLayer,
 );
+
+// ══════════════════════════════════════════════════════════════════════
+// ██  WorkspaceInstaller (#2742 — slice 4 of 1.5.3)
+// ══════════════════════════════════════════════════════════════════════
+//
+// Write-side facade for integration install / uninstall / updateConfig
+// across the chat + action pillars. Per ADR-0007 the facade orchestrates
+// the existing per-Platform install handlers from
+// `lib/integrations/install/`; it does NOT unify credential stores
+// (deferred). Datasource installs (`pillar = 'datasource'`) pivot in
+// slice 6 (#2744) once the `connections` table cutover lands.
+//
+// The Tag, Shape, Live Layer, tagged errors, and test-layer factory live
+// in `./workspace-installer` because the file carries enough surface
+// (per-input-kind dispatch, catalog-schema validation, two-store teardown
+// sequencing) that inlining would crowd this services barrel. Re-exported
+// here so consumers can keep reaching for `@atlas/api/lib/effect/services`
+// as the discovery seam for every backend service Tag.
+
+export {
+  WorkspaceInstaller,
+  WorkspaceInstallerLive,
+  createWorkspaceInstallerTestLayer,
+  INTEGRATION_CREDENTIALS_SLUGS,
+  type WorkspaceInstallerShape,
+  type WorkspaceInstallRow,
+  type InstallInput,
+  type InstallResult,
+  type InstallError,
+} from "./workspace-installer";

--- a/packages/api/src/lib/effect/workspace-installer.ts
+++ b/packages/api/src/lib/effect/workspace-installer.ts
@@ -1,0 +1,1009 @@
+/**
+ * `WorkspaceInstaller` — slice 4 of #2742 (PRD #2738).
+ *
+ * Write-side facade owning the universal install / uninstall / update-config
+ * surface for integration `pillar IN ('chat', 'action')`. Per ADR-0007 the
+ * facade orchestrates the existing per-Platform handlers; it does NOT unify
+ * credential stores (that's deferred). The handlers themselves continue to
+ * own the per-Platform write semantics:
+ *
+ *   - Chat OAuth (Slack) → `workspace_plugins` + `chat_cache` (ADR-0003).
+ *   - Action OAuth (Salesforce, Jira) → `workspace_plugins` +
+ *     `integration_credentials` (ADR-0005).
+ *   - Form-based (Email, Webhook, Obsidian) → `workspace_plugins` with
+ *     `secret: true` fields inside `config` JSONB encrypted via
+ *     `encryptSecretFields` (per `db/secret-encryption.ts`).
+ *   - Static-bot (Teams, Discord, …) — handler stub in 1.5.2; the facade
+ *     dispatch wiring is in place so 1.5.3 can swap in the real handler
+ *     without route churn.
+ *
+ * `/admin/connections` (`pillar = 'datasource'`) is intentionally NOT pivoted
+ * through this facade — the `connections` table is still source-of-truth
+ * pre-cutover. Slice 6 (#2744) handles that pivot.
+ *
+ * The facade enforces three invariants the per-handler dispatch can't see:
+ *
+ *   1. **Pillar singleton.** For `chat` and `action` pillars, only one install
+ *      row per (workspace, catalog) is allowed. Backed by
+ *      `workspace_plugins_singleton` partial unique index (slice 1, #2739).
+ *      The facade pre-checks; the unique violation is the defensive backstop.
+ *   2. **Catalog `config_schema` validation.** Every `config` payload is
+ *      validated against `plugin_catalog.config_schema` before it reaches
+ *      persist. Per-handler Zod schemas (Email's SMTP shape, etc.) remain
+ *      authoritative for shape — this layer enforces the
+ *      catalog-declared `secret: true` / required / type contract that
+ *      drives admin UI form rendering AND the at-rest encryption walker.
+ *   3. **Tagged errors.** `AlreadyInstalledError` (singleton violation) →
+ *      HTTP 409; `ConfigSchemaError` (field-level validation failures) →
+ *      HTTP 400. Both flow through `mapTaggedError` in `errors.ts`.
+ *
+ * The OAuth callback path stays handler-owned: `OAuthPlatformInstallHandler`
+ * already does its own state-token verification, code-for-token exchange,
+ * and dual-store write. The facade's `install()` accepts either a "form" or
+ * "callback" mode via `options.kind` and delegates accordingly — for OAuth
+ * the singleton check is the only pre-write gate the facade adds, because
+ * the catalog config_schema doesn't bind to OAuth callback payloads.
+ *
+ * @see docs/adr/0007-unified-install-pipeline.md
+ * @see docs/adr/0003-two-store-chat-install-metadata-credentials.md
+ * @see docs/adr/0005-integration-credentials-table.md
+ */
+
+import { Context, Data, Effect, Layer } from "effect";
+import { createLogger } from "@atlas/api/lib/logger";
+import { encryptSecretFields, parseConfigSchema } from "@atlas/api/lib/plugins/secrets";
+import type {
+  CatalogRowForDispatch,
+  CredentialResult,
+  PlatformInstallHandler,
+} from "@atlas/api/lib/integrations/install/types";
+import type { CatalogInstallModel } from "@atlas/api/lib/config";
+import type { WorkspaceId } from "@useatlas/types";
+
+// Type-only import for `InternalDB` so admin-approval-style tests that
+// partial-mock `db/internal` don't trip bun's loader on services.ts ->
+// hono.ts re-export chain. The value-level `internalQuery` is lazy-
+// `require`'d inside the helpers below — same pattern PillarCatalogQuery
+// uses for the same reason (#2741).
+type InternalQueryFn = <T = unknown>(sql: string, params?: unknown[]) => Promise<T[]>;
+function lazyInternalQuery(): InternalQueryFn {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const mod = require("@atlas/api/lib/db/internal") as {
+    internalQuery: InternalQueryFn;
+  };
+  return mod.internalQuery;
+}
+
+function lazyGetInstallHandler(): (row: CatalogRowForDispatch) => PlatformInstallHandler {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const mod = require("@atlas/api/lib/integrations/install/dispatch") as {
+    getInstallHandler: (row: CatalogRowForDispatch) => PlatformInstallHandler;
+  };
+  return mod.getInstallHandler;
+}
+
+const log = createLogger("workspace-installer");
+
+// ---------------------------------------------------------------------------
+// Tagged errors
+// ---------------------------------------------------------------------------
+
+/**
+ * Pillar-singleton violation — a `chat` / `action` install already exists
+ * for `(workspaceId, catalogSlug)`. Maps to HTTP 409 in `mapTaggedError`.
+ *
+ * Friendlier than relying on the DB partial-unique-index violation: the
+ * pre-check produces an actionable error message and avoids a wasted
+ * round-trip through the per-handler write path before the constraint
+ * fires. The index remains the defensive backstop against races.
+ */
+export class AlreadyInstalledError extends Data.TaggedError("AlreadyInstalledError")<{
+  readonly message: string;
+  readonly workspaceId: string;
+  readonly catalogSlug: string;
+  readonly pillar: "chat" | "action";
+}> {}
+
+/**
+ * `config` failed validation against `plugin_catalog.config_schema`. Maps
+ * to HTTP 400 in `mapTaggedError`. `fieldErrors` carries per-field issues
+ * shaped for the admin UI's per-field message rendering; `formErrors`
+ * collects top-level issues (unknown fields, schema-level rejections).
+ *
+ * Per-handler Zod validation (e.g. Email's strict shape) layers richer
+ * checks on top — this error is the catalog-level contract violation
+ * (missing required field, wrong type) that fires before the handler
+ * runs.
+ */
+export class ConfigSchemaError extends Data.TaggedError("ConfigSchemaError")<{
+  readonly message: string;
+  readonly catalogSlug: string;
+  readonly fieldErrors: Readonly<Record<string, readonly string[]>>;
+  readonly formErrors: readonly string[];
+}> {}
+
+/**
+ * Catalog row not found, kill-switched, or carries an unknown
+ * `install_model`. Maps to HTTP 404 in `mapTaggedError` (the catalog
+ * lookup is the closest analogue to "resource doesn't exist").
+ */
+export class CatalogNotFoundError extends Data.TaggedError("CatalogNotFoundError")<{
+  readonly message: string;
+  readonly catalogSlug: string;
+}> {}
+
+/**
+ * Install row not found for `(workspaceId, catalogSlug)`. Surfaces from
+ * `uninstall` and `updateConfig` when the target row is gone. Maps to
+ * HTTP 404 in `mapTaggedError`.
+ */
+export class InstallNotFoundError extends Data.TaggedError("InstallNotFoundError")<{
+  readonly message: string;
+  readonly workspaceId: string;
+  readonly catalogSlug: string;
+}> {}
+
+/** Discriminated union of every error the facade emits in its E channel. */
+export type InstallError =
+  | AlreadyInstalledError
+  | ConfigSchemaError
+  | CatalogNotFoundError
+  | InstallNotFoundError;
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/**
+ * Row returned by `install` / `updateConfig`. Mirrors the subset of
+ * `workspace_plugins` columns admin UI cards need; secrets stay
+ * encrypted in DB (admin GET masks them per `maskSecretFields`).
+ */
+export interface WorkspaceInstallRow {
+  readonly id: string;
+  readonly workspaceId: WorkspaceId;
+  readonly catalogSlug: string;
+  readonly catalogId: string;
+  readonly pillar: "chat" | "action";
+  readonly installId: string;
+}
+
+/**
+ * Discriminated input to `install`. Three install models, three input
+ * shapes — the handler dispatch already encodes this taxonomy so the
+ * facade mirrors it rather than inventing a wider envelope.
+ */
+export type InstallInput =
+  | {
+      readonly kind: "form";
+      /** Raw form body — per-handler Zod schema does the real validation. */
+      readonly formData: Record<string, unknown>;
+    }
+  | {
+      readonly kind: "oauth-start";
+    }
+  | {
+      readonly kind: "oauth-callback";
+      readonly code: string;
+      readonly stateToken: string;
+    }
+  | {
+      readonly kind: "static-bot";
+      readonly routingIdentifier: string;
+      readonly verificationProof?: string;
+    };
+
+export type InstallResult =
+  | {
+      readonly kind: "form";
+      readonly row: WorkspaceInstallRow;
+      readonly credentialWritten: boolean;
+    }
+  | {
+      readonly kind: "oauth-start";
+      readonly redirectUrl: string;
+      readonly stateToken: string;
+    }
+  | {
+      readonly kind: "oauth-callback";
+      readonly row: WorkspaceInstallRow | null;
+      readonly credentialResult: CredentialResult | null;
+    }
+  | {
+      readonly kind: "static-bot";
+      readonly row: WorkspaceInstallRow;
+    };
+
+// ---------------------------------------------------------------------------
+// Catalog helpers (DB I/O — kept as plain async functions; the Effect
+// wrappers in the Live layer normalize errors)
+// ---------------------------------------------------------------------------
+
+/**
+ * Slugs whose credentials live in `integration_credentials` keyed by
+ * (workspace_id, catalog_id). Salesforce shipped first (#2658); Jira
+ * (#2659) is the second consumer that proves the abstraction.
+ *
+ * Moved from `api/routes/integrations.ts` so the facade owns the
+ * dispatch table for action-OAuth teardown. Per ADR-0005, adding a new
+ * lazy OAuth integration is one line here + a `*-oauth-handler.ts`
+ * pair + registration in `lib/integrations/install/register.ts`.
+ *
+ * @see docs/adr/0005-integration-credentials-table.md
+ */
+export const INTEGRATION_CREDENTIALS_SLUGS: ReadonlySet<string> = new Set<string>([
+  "salesforce",
+  "jira",
+]);
+
+interface CatalogRow {
+  readonly id: string;
+  readonly slug: string;
+  readonly install_model: CatalogInstallModel;
+  readonly pillar: "chat" | "action" | "datasource";
+  readonly config_schema: unknown;
+  readonly enabled: boolean;
+}
+
+interface CatalogRowFromDb extends Record<string, unknown> {
+  readonly id: string;
+  readonly slug: string;
+  readonly install_model: string;
+  readonly pillar: string;
+  readonly config_schema: unknown;
+  readonly enabled: boolean;
+}
+
+function isValidInstallModel(value: string): value is CatalogInstallModel {
+  return value === "oauth" || value === "form" || value === "static-bot";
+}
+
+function isValidPillar(value: string): value is "chat" | "action" | "datasource" {
+  return value === "chat" || value === "action" || value === "datasource";
+}
+
+/**
+ * Catalog lookup for the install path — requires `enabled = true`. The
+ * caller may opt to read disabled rows (for disconnect of a kill-switched
+ * row) via {@link loadCatalogRowForDisconnect}.
+ */
+async function loadCatalogRowForInstall(slug: string): Promise<CatalogRow | null> {
+  const rows = await lazyInternalQuery()<CatalogRowFromDb>(
+    `SELECT id, slug, install_model, pillar, config_schema, enabled
+       FROM plugin_catalog
+      WHERE slug = $1 AND enabled = true
+      LIMIT 1`,
+    [slug],
+  );
+  if (rows.length === 0) return null;
+  const row = rows[0];
+  if (!isValidInstallModel(row.install_model)) {
+    log.warn(
+      { slug, install_model: row.install_model },
+      "Catalog row has unknown install_model — refusing install",
+    );
+    return null;
+  }
+  if (!isValidPillar(row.pillar)) {
+    log.warn({ slug, pillar: row.pillar }, "Catalog row has unknown pillar — refusing install");
+    return null;
+  }
+  return {
+    id: row.id,
+    slug: row.slug,
+    install_model: row.install_model,
+    pillar: row.pillar,
+    config_schema: row.config_schema,
+    enabled: row.enabled,
+  };
+}
+
+/**
+ * Catalog lookup for uninstall — accepts disabled rows. Disconnect must
+ * succeed even when ops has kill-switched a Platform; otherwise the kill
+ * switch strands existing installs with no admin-visible UI.
+ */
+async function loadCatalogRowForDisconnect(slug: string): Promise<CatalogRow | null> {
+  const rows = await lazyInternalQuery()<CatalogRowFromDb>(
+    `SELECT id, slug, install_model, pillar, config_schema, enabled
+       FROM plugin_catalog
+      WHERE slug = $1
+      LIMIT 1`,
+    [slug],
+  );
+  if (rows.length === 0) return null;
+  const row = rows[0];
+  if (!isValidInstallModel(row.install_model)) return null;
+  if (!isValidPillar(row.pillar)) return null;
+  return {
+    id: row.id,
+    slug: row.slug,
+    install_model: row.install_model,
+    pillar: row.pillar,
+    config_schema: row.config_schema,
+    enabled: row.enabled,
+  };
+}
+
+/**
+ * Find an install row by (workspace, catalog). Returns null when none
+ * exists. For chat/action pillars at most one row is expected (singleton
+ * partial unique index from slice 1, #2739); datasource installs are
+ * out of scope for the facade.
+ */
+async function findInstallRow(
+  workspaceId: string,
+  catalogId: string,
+): Promise<{ id: string; installId: string; teamId: string | null } | null> {
+  const rows = await lazyInternalQuery()<{
+    id: string;
+    install_id: string;
+    team_id: string | null;
+  }>(
+    `SELECT id, install_id, config->>'team_id' AS team_id
+       FROM workspace_plugins
+      WHERE workspace_id = $1 AND catalog_id = $2
+      LIMIT 1`,
+    [workspaceId, catalogId],
+  );
+  if (rows.length === 0) return null;
+  return {
+    id: rows[0].id,
+    installId: rows[0].install_id,
+    teamId: rows[0].team_id ?? null,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Config-schema validation
+// ---------------------------------------------------------------------------
+
+/**
+ * Validate `config` against the catalog's `config_schema`. Returns a
+ * tagged error on missing-required / wrong-type. Per-handler Zod
+ * validation is the source of truth for richer shape rules; this layer
+ * catches catalog-contract violations the handler would otherwise see
+ * as opaque "unrecognized field" / "missing field" errors.
+ *
+ * Three-state schema handling matches `parseConfigSchema`:
+ *   - `absent` / empty fields → pass through (catalog hasn't declared
+ *     a schema; per-handler validation is the only gate).
+ *   - `corrupt` → log + pass through. The encryption walker already
+ *     fail-closes by encrypting every string; surfacing 400 here would
+ *     break installs on a transient catalog drift, which is the wrong
+ *     posture for a misconfigured operator.
+ *   - `parsed` → enforce required + basic type checks.
+ */
+function validateAgainstConfigSchema(
+  catalogSlug: string,
+  rawConfigSchema: unknown,
+  config: Record<string, unknown>,
+): ConfigSchemaError | null {
+  const schema = parseConfigSchema(rawConfigSchema);
+  if (schema.state === "absent") return null;
+  if (schema.state === "corrupt") {
+    log.warn(
+      { catalogSlug, reason: schema.reason },
+      "Catalog config_schema is corrupt — skipping facade-level validation (per-handler validation still runs)",
+    );
+    return null;
+  }
+  if (schema.fields.length === 0) return null;
+
+  const fieldErrors: Record<string, string[]> = {};
+  const formErrors: string[] = [];
+
+  for (const field of schema.fields) {
+    const value = config[field.key];
+    const present = value !== undefined && value !== null && value !== "";
+    if (field.required === true && !present) {
+      (fieldErrors[field.key] ??= []).push(`${field.key} is required`);
+      continue;
+    }
+    if (!present) continue;
+    switch (field.type) {
+      case "string":
+      case "select":
+        if (typeof value !== "string") {
+          (fieldErrors[field.key] ??= []).push(`${field.key} must be a string`);
+        }
+        break;
+      case "number":
+        if (typeof value !== "number" || Number.isNaN(value)) {
+          (fieldErrors[field.key] ??= []).push(`${field.key} must be a number`);
+        }
+        break;
+      case "boolean":
+        if (typeof value !== "boolean") {
+          (fieldErrors[field.key] ??= []).push(`${field.key} must be a boolean`);
+        }
+        break;
+      default: {
+        // Unknown type in catalog — log and skip; treat as pass.
+        log.warn(
+          { catalogSlug, field: field.key, type: field.type },
+          "Catalog config_schema field has unknown type — skipping facade-level type check",
+        );
+      }
+    }
+  }
+
+  if (Object.keys(fieldErrors).length === 0 && formErrors.length === 0) return null;
+
+  const readonlyFieldErrors: Record<string, readonly string[]> = {};
+  for (const [k, v] of Object.entries(fieldErrors)) readonlyFieldErrors[k] = v;
+
+  return new ConfigSchemaError({
+    message: `Config for "${catalogSlug}" failed validation against plugin_catalog.config_schema.`,
+    catalogSlug,
+    fieldErrors: readonlyFieldErrors,
+    formErrors,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Service contract
+// ---------------------------------------------------------------------------
+
+export interface WorkspaceInstallerShape {
+  /**
+   * Install a Platform for the given workspace. Dispatches by
+   * `catalog.install_model` and the discriminant on `input.kind`. The
+   * pillar-singleton check fires first; the catalog-schema validation
+   * fires for `kind: "form"` only (OAuth callback payloads aren't
+   * config-shaped, and `oauth-start` is a redirect-mint, not a write).
+   *
+   * Note: `oauth-callback` may return `row: null` when the state token
+   * is forged / expired — the handler returns `null` and the route
+   * layer surfaces the standard `invalid_state` toast.
+   */
+  readonly install: (
+    workspaceId: WorkspaceId,
+    catalogSlug: string,
+    input: InstallInput,
+  ) => Effect.Effect<InstallResult, InstallError>;
+
+  /**
+   * Disconnect a Platform install. Tears down both stores in the order
+   * mandated by ADR-0003 / ADR-0005: credentials FIRST, install row
+   * SECOND. The credential store is selected by slug:
+   *   - `slack` → `chat_cache` (ADR-0003)
+   *   - {@link INTEGRATION_CREDENTIALS_SLUGS} → `integration_credentials`
+   *     (ADR-0005)
+   *   - form-based slugs → no separate credential store; the secrets
+   *     are inside `workspace_plugins.config` JSONB and disappear with
+   *     the row.
+   *
+   * `installId` is optional — chat/action pillars are singleton per
+   * (workspace, catalog), so the row is unambiguous without it. Reserved
+   * for slice 6 (#2744) when datasource installs land with N rows per
+   * (workspace, catalog).
+   */
+  readonly uninstall: (
+    workspaceId: WorkspaceId,
+    catalogSlug: string,
+    installId?: string,
+  ) => Effect.Effect<void, InstallError>;
+
+  /**
+   * Update `config` on an existing install row. Validates the merged
+   * (existing + partial) config against the catalog's `config_schema`,
+   * encrypts `secret: true` fields, and writes through. Per ADR-0005,
+   * OAuth-managed credential fields stay in their store-of-record —
+   * `updateConfig` only mutates `workspace_plugins.config`.
+   */
+  readonly updateConfig: (
+    workspaceId: WorkspaceId,
+    catalogSlug: string,
+    installId: string,
+    partialConfig: Record<string, unknown>,
+  ) => Effect.Effect<WorkspaceInstallRow, InstallError>;
+}
+
+export class WorkspaceInstaller extends Context.Tag("WorkspaceInstaller")<
+  WorkspaceInstaller,
+  WorkspaceInstallerShape
+>() {}
+
+// ---------------------------------------------------------------------------
+// Live implementation
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the Live `WorkspaceInstaller` service. `Layer.effect` (not
+ * `Layer.scoped`) — there's no per-service finalizer; every DB call is
+ * via the shared `internalQuery` pool which lives on its own scope.
+ */
+export const WorkspaceInstallerLive: Layer.Layer<WorkspaceInstaller> = Layer.effect(
+  WorkspaceInstaller,
+  Effect.sync(() => makeWorkspaceInstallerService()),
+);
+
+function makeWorkspaceInstallerService(): WorkspaceInstallerShape {
+  const installImpl: WorkspaceInstallerShape["install"] = (workspaceId, catalogSlug, input) =>
+    Effect.gen(function* () {
+      const catalog = yield* Effect.tryPromise({
+        try: () => loadCatalogRowForInstall(catalogSlug),
+        catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+      }).pipe(
+        Effect.catchAll((err) => Effect.die(err)),
+      );
+      if (catalog === null) {
+        return yield* Effect.fail(
+          new CatalogNotFoundError({
+            message: `Unknown or disabled catalog slug "${catalogSlug}".`,
+            catalogSlug,
+          }),
+        );
+      }
+
+      // Pillar guard — facade only handles chat / action (slice 6 owns
+      // datasource).
+      if (catalog.pillar === "datasource") {
+        return yield* Effect.fail(
+          new CatalogNotFoundError({
+            message: `Datasource installs are not handled by WorkspaceInstaller (see slice 6 / issue #2744). Slug: "${catalogSlug}".`,
+            catalogSlug,
+          }),
+        );
+      }
+      const pillar: "chat" | "action" = catalog.pillar;
+
+      // ── Pillar singleton check ───────────────────────────────────
+      // OAuth-start is a redirect-mint with no DB write, so the check
+      // is mostly defensive there — but doing it up-front spares the
+      // user a doomed redirect → callback round-trip. Form / OAuth-
+      // callback / static-bot all write, so the check is load-bearing.
+      const existing = yield* Effect.tryPromise({
+        try: () => findInstallRow(workspaceId, catalog.id),
+        catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+      }).pipe(
+        Effect.catchAll((err) => Effect.die(err)),
+      );
+      // For OAuth callback we DO allow re-install (the handler's UPSERT
+      // on `(workspace_id, catalog_id)` is the documented Reconnect
+      // path). The singleton invariant is "at most one row", not "first
+      // install wins" — re-issuing the OAuth dance for the same Platform
+      // is the canonical recovery path per ADR-0003.
+      if (existing && input.kind !== "oauth-callback") {
+        return yield* Effect.fail(
+          new AlreadyInstalledError({
+            message: `${pillar === "chat" ? "Chat" : "Action"} platform "${catalogSlug}" is already installed for this workspace. Disconnect first to reinstall.`,
+            workspaceId,
+            catalogSlug,
+            pillar,
+          }),
+        );
+      }
+
+      // Dispatch to handler.
+      const handler = yield* Effect.try({
+        try: () =>
+          lazyGetInstallHandler()({
+            slug: catalog.slug,
+            install_model: catalog.install_model,
+          } satisfies CatalogRowForDispatch),
+        catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+      }).pipe(
+        // No-handler-registered is a route-level concern (501) — surface
+        // as a defect so `classifyError` falls through to the generic
+        // 500. Route handlers can pre-check via `try { getInstallHandler }`
+        // when they want a 501 instead.
+        Effect.catchAll((err) => Effect.die(err)),
+      );
+
+      switch (input.kind) {
+        case "form": {
+          if (handler.kind !== "form") {
+            // Catalog and dispatch agree on `install_model: "form"`, so
+            // this is a config drift the route layer should have caught.
+            return yield* Effect.die(
+              new Error(
+                `Catalog "${catalogSlug}" install_model is "${catalog.install_model}" — refusing form install via WorkspaceInstaller.`,
+              ),
+            );
+          }
+          // Catalog-schema validation (chat/action) — fires before the
+          // per-handler Zod schema so the admin UI gets a consistent
+          // 400-with-fieldErrors envelope regardless of handler.
+          const schemaErr = validateAgainstConfigSchema(
+            catalogSlug,
+            catalog.config_schema,
+            input.formData,
+          );
+          if (schemaErr) return yield* Effect.fail(schemaErr);
+
+          // Delegate to the form handler — it owns Zod validation +
+          // selective-field encryption + the `workspace_plugins` upsert.
+          // Schema-driven `encryptSecretFields` is invoked inside the
+          // handler today (see Email's handler for the canonical
+          // shape); the facade does NOT re-encrypt to avoid the
+          // `enc:v1:enc:v1:` double-encryption hazard. Idempotence
+          // guards in `encryptSecretFields` would catch a double-call
+          // anyway, but the right answer is to not call twice.
+          const result = yield* Effect.tryPromise({
+            try: () => handler.validateConfig(workspaceId, input.formData),
+            catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+          }).pipe(
+            // Handler-tagged validation errors (e.g.
+            // `FormInstallValidationError`) bubble up as defects so the
+            // route's existing `instanceof` catch still runs. Promoting
+            // those into the facade's E channel would require teaching
+            // `mapTaggedError` about the legacy class — out of scope for
+            // slice 4 per the issue's "behavior-preserving refactor" bar.
+            Effect.catchAll((err) => Effect.die(err)),
+          );
+          return {
+            kind: "form" as const,
+            row: {
+              id: result.installRecord.id,
+              workspaceId,
+              catalogSlug: result.installRecord.catalogId,
+              catalogId: catalog.id,
+              pillar,
+              installId: result.installRecord.id,
+            },
+            credentialWritten: result.credentialWritten,
+          } satisfies InstallResult;
+        }
+        case "oauth-start": {
+          if (handler.kind !== "oauth") {
+            return yield* Effect.die(
+              new Error(
+                `Catalog "${catalogSlug}" install_model is "${catalog.install_model}" — refusing OAuth start via WorkspaceInstaller.`,
+              ),
+            );
+          }
+          const { redirectUrl, stateToken } = yield* Effect.tryPromise({
+            try: () => handler.startInstall(workspaceId),
+            catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+          }).pipe(Effect.catchAll((err) => Effect.die(err)));
+          return { kind: "oauth-start" as const, redirectUrl, stateToken } satisfies InstallResult;
+        }
+        case "oauth-callback": {
+          if (handler.kind !== "oauth") {
+            return yield* Effect.die(
+              new Error(
+                `Catalog "${catalogSlug}" install_model is "${catalog.install_model}" — refusing OAuth callback via WorkspaceInstaller.`,
+              ),
+            );
+          }
+          const callbackResult = yield* Effect.tryPromise({
+            try: () => handler.handleCallback(input.code, input.stateToken),
+            catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+          }).pipe(
+            // `PlatformOAuthExchangeError` and other tagged errors
+            // bubble through as defects → `classifyError` maps them. The
+            // route's `prefersHtml` redirect path runs in the route
+            // wrapper, not here.
+            Effect.catchAll((err) => Effect.die(err)),
+          );
+          if (callbackResult === null) {
+            return {
+              kind: "oauth-callback" as const,
+              row: null,
+              credentialResult: null,
+            } satisfies InstallResult;
+          }
+          return {
+            kind: "oauth-callback" as const,
+            row: {
+              id: callbackResult.installRecord.id,
+              workspaceId: callbackResult.workspaceId,
+              catalogSlug: callbackResult.catalogId,
+              catalogId: catalog.id,
+              pillar,
+              installId: callbackResult.installRecord.id,
+            },
+            credentialResult: callbackResult.credentialResult,
+          } satisfies InstallResult;
+        }
+        case "static-bot": {
+          if (handler.kind !== "static-bot") {
+            return yield* Effect.die(
+              new Error(
+                `Catalog "${catalogSlug}" install_model is "${catalog.install_model}" — refusing static-bot install via WorkspaceInstaller.`,
+              ),
+            );
+          }
+          const result = yield* Effect.tryPromise({
+            try: () =>
+              handler.confirmInstall(
+                workspaceId,
+                input.routingIdentifier,
+                input.verificationProof,
+              ),
+            catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+          }).pipe(Effect.catchAll((err) => Effect.die(err)));
+          return {
+            kind: "static-bot" as const,
+            row: {
+              id: result.installRecord.id,
+              workspaceId,
+              catalogSlug: result.installRecord.catalogId,
+              catalogId: catalog.id,
+              pillar,
+              installId: result.installRecord.id,
+            },
+          } satisfies InstallResult;
+        }
+        default: {
+          const _exhaustive: never = input;
+          return yield* Effect.die(
+            new Error(`Unknown InstallInput kind: ${String(_exhaustive)}`),
+          );
+        }
+      }
+    });
+
+  const uninstallImpl: WorkspaceInstallerShape["uninstall"] = (
+    workspaceId,
+    catalogSlug,
+    // installId reserved for slice 6 datasource multi-instance disconnect;
+    // chat/action pillars are singleton so the slug alone identifies the row.
+    _installId,
+  ) =>
+    Effect.gen(function* () {
+      const catalog = yield* Effect.tryPromise({
+        try: () => loadCatalogRowForDisconnect(catalogSlug),
+        catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+      }).pipe(Effect.catchAll((err) => Effect.die(err)));
+      if (catalog === null) {
+        return yield* Effect.fail(
+          new CatalogNotFoundError({
+            message: `Unknown catalog slug "${catalogSlug}".`,
+            catalogSlug,
+          }),
+        );
+      }
+      if (catalog.pillar === "datasource") {
+        return yield* Effect.fail(
+          new CatalogNotFoundError({
+            message: `Datasource uninstalls are not handled by WorkspaceInstaller (see slice 6 / issue #2744). Slug: "${catalogSlug}".`,
+            catalogSlug,
+          }),
+        );
+      }
+
+      const row = yield* Effect.tryPromise({
+        try: () => findInstallRow(workspaceId, catalog.id),
+        catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+      }).pipe(Effect.catchAll((err) => Effect.die(err)));
+      if (row === null) {
+        return yield* Effect.fail(
+          new InstallNotFoundError({
+            message: `No ${catalogSlug} install found for this workspace.`,
+            workspaceId,
+            catalogSlug,
+          }),
+        );
+      }
+
+      // ── Two-store teardown (ADR-0003 order is load-bearing) ──────
+      // 1) Credential row FIRST — credentials must not outlive the
+      //    install record. A failure here propagates and the
+      //    workspace_plugins row is preserved so the admin can retry.
+      // 2) workspace_plugins SECOND. A failure here leaves the install
+      //    row dangling but credentials are already gone (recoverable).
+      yield* Effect.tryPromise({
+        try: () => deleteCredentialStoreForSlug(catalogSlug, workspaceId, catalog.id, row.teamId),
+        catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+      }).pipe(Effect.catchAll((err) => Effect.die(err)));
+
+      yield* Effect.tryPromise({
+        try: () =>
+          lazyInternalQuery()(
+            `DELETE FROM workspace_plugins
+              WHERE workspace_id = $1 AND catalog_id = $2`,
+            [workspaceId, catalog.id],
+          ),
+        catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+      }).pipe(Effect.catchAll((err) => Effect.die(err)));
+
+      log.info(
+        { workspaceId, catalogSlug, pillar: catalog.pillar, teamId: row.teamId },
+        "WorkspaceInstaller.uninstall completed (both stores cleared)",
+      );
+    });
+
+  const updateConfigImpl: WorkspaceInstallerShape["updateConfig"] = (
+    workspaceId,
+    catalogSlug,
+    installId,
+    partialConfig,
+  ) =>
+    Effect.gen(function* () {
+      const catalog = yield* Effect.tryPromise({
+        try: () => loadCatalogRowForInstall(catalogSlug),
+        catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+      }).pipe(Effect.catchAll((err) => Effect.die(err)));
+      if (catalog === null) {
+        return yield* Effect.fail(
+          new CatalogNotFoundError({
+            message: `Unknown or disabled catalog slug "${catalogSlug}".`,
+            catalogSlug,
+          }),
+        );
+      }
+      if (catalog.pillar === "datasource") {
+        return yield* Effect.fail(
+          new CatalogNotFoundError({
+            message: `Datasource updateConfig is not handled by WorkspaceInstaller (see slice 6 / issue #2744). Slug: "${catalogSlug}".`,
+            catalogSlug,
+          }),
+        );
+      }
+      const pillar: "chat" | "action" = catalog.pillar;
+
+      // Read existing config so the partial overlay can be schema-
+      // validated against the merged shape (catalog `required` rules
+      // apply to the post-merge config, not just the patch payload).
+      const rows = yield* Effect.tryPromise({
+        try: () =>
+          lazyInternalQuery()<{
+            id: string;
+            install_id: string;
+            config: Record<string, unknown> | null;
+          }>(
+            `SELECT id, install_id, config
+               FROM workspace_plugins
+              WHERE workspace_id = $1 AND catalog_id = $2 AND install_id = $3
+              LIMIT 1`,
+            [workspaceId, catalog.id, installId],
+          ),
+        catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+      }).pipe(Effect.catchAll((err) => Effect.die(err)));
+      if (rows.length === 0) {
+        return yield* Effect.fail(
+          new InstallNotFoundError({
+            message: `No ${catalogSlug} install found for installId "${installId}".`,
+            workspaceId,
+            catalogSlug,
+          }),
+        );
+      }
+      const existingConfig = rows[0].config ?? {};
+      const mergedConfig: Record<string, unknown> = {
+        ...existingConfig,
+        ...partialConfig,
+      };
+
+      // Catalog-schema validation against the merged config.
+      const schemaErr = validateAgainstConfigSchema(
+        catalogSlug,
+        catalog.config_schema,
+        mergedConfig,
+      );
+      if (schemaErr) return yield* Effect.fail(schemaErr);
+
+      // Encrypt secrets. `encryptSecretFields` is idempotent against
+      // already-`enc:v1:` ciphertext, so re-encrypting the existing
+      // (already-encrypted) values on a partial update is a no-op.
+      const schema = parseConfigSchema(catalog.config_schema);
+      const encryptedConfig = encryptSecretFields(mergedConfig, schema);
+
+      yield* Effect.tryPromise({
+        try: () =>
+          lazyInternalQuery()(
+            `UPDATE workspace_plugins
+                SET config = $1::jsonb
+              WHERE workspace_id = $2 AND catalog_id = $3 AND install_id = $4`,
+            [JSON.stringify(encryptedConfig), workspaceId, catalog.id, installId],
+          ),
+        catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+      }).pipe(Effect.catchAll((err) => Effect.die(err)));
+
+      log.info(
+        { workspaceId, catalogSlug, installId, pillar },
+        "WorkspaceInstaller.updateConfig completed",
+      );
+
+      return {
+        id: rows[0].id,
+        workspaceId,
+        catalogSlug,
+        catalogId: catalog.id,
+        pillar,
+        installId: rows[0].install_id,
+      } satisfies WorkspaceInstallRow;
+    });
+
+  return {
+    install: installImpl,
+    uninstall: uninstallImpl,
+    updateConfig: updateConfigImpl,
+  } satisfies WorkspaceInstallerShape;
+}
+
+/**
+ * Slug-keyed credential teardown. Dispatched off the per-Platform
+ * convention rather than the catalog's `install_model`:
+ *   - chat OAuth (Slack) writes to `chat_cache` keyed by `team_id`.
+ *   - action OAuth (Salesforce, Jira, …) writes to `integration_credentials`
+ *     keyed by (workspace, catalog).
+ *   - form-based installs have no separate credential row — secrets are
+ *     inside `workspace_plugins.config` and disappear with the row.
+ *
+ * Throws on unknown slugs whose pillar would imply a credential store
+ * but no dispatch is wired — defensive backstop; the route layer should
+ * surface 501 before this fires.
+ */
+async function deleteCredentialStoreForSlug(
+  slug: string,
+  workspaceId: string,
+  catalogId: string,
+  teamId: string | null,
+): Promise<void> {
+  if (slug === "slack") {
+    if (!teamId) {
+      // Defensive — a Slack install row should always carry team_id.
+      // If it doesn't, the row is corrupted; surface as a hard error
+      // so the admin disconnect attempt isn't silently a no-op.
+      throw new Error(
+        `Slack disconnect requires team_id from workspace_plugins.config for workspace=${workspaceId}`,
+      );
+    }
+    // Lazy import — keeps `slack/store` and
+    // `integrations/credentials/store` out of the static import graph
+    // so partial `mock.module()` setups elsewhere (which intentionally
+    // omit `deleteInstallation` / `deleteCredentialBundle` because
+    // those tests don't exercise the disconnect path) don't trip
+    // bun's "Export named 'X' not found" loader error. Production
+    // perf cost is one resolver hit per disconnect call.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { deleteInstallation } = require("@atlas/api/lib/slack/store") as {
+      deleteInstallation: (teamId: string) => Promise<void>;
+    };
+    await deleteInstallation(teamId);
+    return;
+  }
+  if (INTEGRATION_CREDENTIALS_SLUGS.has(slug)) {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { deleteCredentialBundle } = require("@atlas/api/lib/integrations/credentials/store") as {
+      deleteCredentialBundle: (workspaceId: string, catalogId: string) => Promise<boolean>;
+    };
+    await deleteCredentialBundle(workspaceId, catalogId);
+    return;
+  }
+  // Form-based: no separate credential store; the DELETE on
+  // workspace_plugins (step 2) is the credential teardown. No-op here.
+}
+
+// ---------------------------------------------------------------------------
+// Test helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a test Layer for `WorkspaceInstaller` backed by a partial impl.
+ * Mirrors the Proxy-stub pattern used by `createConnectionTestLayer` etc.
+ * — unspecified methods throw with a descriptive error rather than
+ * silently returning undefined.
+ */
+export function createWorkspaceInstallerTestLayer(
+  partial: Partial<WorkspaceInstallerShape>,
+): Layer.Layer<WorkspaceInstaller> {
+  const handler: ProxyHandler<WorkspaceInstallerShape> = {
+    get(_target, prop: string | symbol) {
+      if (typeof prop === "symbol") return undefined;
+      if (prop === "then" || prop === "toJSON") return undefined;
+      if (prop in partial) {
+        return (partial as Record<string, unknown>)[prop];
+      }
+      return (..._args: unknown[]) => {
+        throw new Error(
+          `WorkspaceInstaller test stub: "${String(prop)}" was called but not provided in createWorkspaceInstallerTestLayer()`,
+        );
+      };
+    },
+  };
+  const stubService = new Proxy({} as WorkspaceInstallerShape, handler);
+  return Layer.succeed(WorkspaceInstaller, stubService);
+}
+
+// ---------------------------------------------------------------------------
+// Schema validation export (test surface)
+// ---------------------------------------------------------------------------
+
+export const _testing = {
+  validateAgainstConfigSchema,
+} as const;


### PR DESCRIPTION
Closes #2742. Slice 4 of 17 in the 1.5.3 multi-platform install models milestone.

## Summary

Adds `WorkspaceInstaller` — an Effect service that owns the universal install / uninstall / updateConfig surface for `pillar IN ('chat', 'action')`. Per [ADR-0007](https://github.com/AtlasDevHQ/atlas/blob/main/docs/adr/0007-unified-install-pipeline.md) the facade orchestrates the existing per-Platform install handlers; it does NOT unify credential stores (deferred). Datasource installs are out of scope — slice 6 (#2744) handles that pivot post-cutover.

The facade enforces three invariants the per-handler dispatch can't see:
1. **Pillar singleton** — chat/action installs reject second install with `AlreadyInstalledError` (HTTP 409). Backed by `workspace_plugins_singleton` partial unique index from slice 1 (#2739).
2. **Catalog `config_schema` validation** — `ConfigSchemaError` (HTTP 400 with field-level detail) before the handler runs.
3. **Two-store teardown order** — credential store FIRST (`chat_cache` for Slack per ADR-0003, `integration_credentials` for action-OAuth per ADR-0005), then `workspace_plugins`. Sequencing is owned by the facade so all disconnect callers inherit it.

## Acceptance criteria

- [x] `WorkspaceInstaller` Effect Context tag + service implementation under `packages/api/src/lib/effect/`
- [x] Pillar-aware singleton enforcement: chat/action installs reject second install with a tagged `AlreadyInstalledError`
- [x] `config` validated against `plugin_catalog.config_schema` before persist; validation failures return tagged `ConfigSchemaError` with actionable field-level messages
- [x] Selective-field encryption (`encryptSecretFields`) applied to `config` fields marked `secret: true` in `updateConfig` (form-install path keeps using the per-handler encryption to avoid double-encryption)
- [x] OAuth handler delegate path preserved: `OAuthPlatformInstallHandler` writes to `chat_cache` (chat) or `integration_credentials` (action OAuth) as today
- [x] `/api/v1/integrations/:slug` DELETE pivoted through the facade
- [x] `/api/v1/admin/integrations/slack` DELETE consolidated through the facade with BYOT fallback (no `workspace_plugins` row → legacy `deleteInstallationByOrg`)
- [x] ADR-0003 two-store teardown sequencing preserved inside the facade — Slack `chat_cache` delete strictly before `workspace_plugins` delete
- [x] Test layer + Effect-based tests cover dispatch (per `installModel`), pillar-uniqueness gate, schema validation, error mapping, OAuth-callback Reconnect allowance, two-store teardown order
- [x] All existing integration install/disconnect tests still pass (test mocks updated to supply the catalog row's new `pillar` + `config_schema` columns the facade SELECTs)
- [x] `bun run lint` + `bun run type` + affected test suite all green

## Routes NOT pivoted in this slice

The install / install-form / OAuth callback routes intentionally stay on the existing handler dispatch in this slice. The per-handler dispatch already encapsulates everything the facade adds for those paths (singleton check is meaningful only for repeated installs, and the route-level OAuth state token verification + plan-tier gating is route logic, not a facade concern). The facade's `install` method is wired and tested so future pivots are a one-line change.

`PATCH /api/v1/integrations/:slug` doesn't exist today — `updateConfig` is reachable via the facade so the next admin-UI consumer can pick it up without further plumbing.

## Soft merge point with slice 3

Slice 3 (#2741, PillarCatalogQuery) also adds a `Context.Tag` re-export to `packages/api/src/lib/effect/services.ts`. Different tag names; trivial merge.

## Test plan

- [x] `bun test packages/api/src/lib/effect/__tests__/workspace-installer.test.ts` — 24 facade tests pass
- [x] `bun test packages/api/src/api/routes/__tests__/integrations.test.ts` — 42 existing route tests pass (test mocks updated for the new column SELECT shape)
- [x] `bun test packages/api/src/api/routes/__tests__/disconnect-listener-gate.test.ts` — listener-gate end-to-end still passes after route pivot
- [x] `bun test packages/api/src/lib/integrations/install/__tests__/` — all 156 install handler tests still pass
- [x] `cd packages/api && bun run scripts/test-isolated.ts --affected` — 63 affected files green
- [x] `bun run lint` clean
- [x] `bun run type` clean
- [x] `bun x syncpack lint` — no issues
- [x] `SKIP_SYNCPACK=1 bash scripts/check-template-drift.sh` — clean
- [x] `bash scripts/check-railway-watch.sh` — clean
- [ ] `bun run test` full suite — 2 pre-existing failures in `@atlas/mcp` (unrelated to this PR, present on main): `loadCanonicalPrompts > loads all 20 prompts from the real eval/canonical-questions/questions.yml` and one unnamed test