### PR TITLE
test(mcp): #2760/#2762 — adopt isolated test runner

### DIFF
--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "dev": "bun run --hot bin/serve.ts",
-    "test": "bun test"
+    "test": "bun run scripts/test-isolated.ts"
   },
   "dependencies": {
     "@atlas/api": "workspace:*",

--- a/packages/mcp/scripts/test-isolated.ts
+++ b/packages/mcp/scripts/test-isolated.ts
@@ -1,0 +1,117 @@
+/**
+ * Isolated test runner — spawns each test file in its own subprocess to
+ * avoid bun's process-global `mock.module()` contamination across files.
+ *
+ * Mirrors the @atlas/api runner at packages/api/scripts/test-isolated.ts;
+ * trimmed of --shard and --affected modes because the MCP suite is small
+ * (~17 files / ~3s wallclock). Sync forward when the suite grows.
+ *
+ * Usage: bun run scripts/test-isolated.ts [--concurrency N] [filter]
+ */
+
+import { Glob } from "bun";
+import { cpus } from "node:os";
+import { resolve, relative } from "node:path";
+
+const ROOT = resolve(import.meta.dir, "..");
+const SRC = resolve(ROOT, "src");
+
+const args = process.argv.slice(2);
+let concurrency = cpus().length;
+let filter: string | undefined;
+for (let i = 0; i < args.length; i++) {
+  if (args[i] === "--concurrency" && args[i + 1]) {
+    concurrency = parseInt(args[i + 1], 10);
+    i++;
+  } else if (!args[i].startsWith("-")) {
+    filter = args[i];
+  }
+}
+
+const glob = new Glob("**/*.test.ts");
+let files: string[] = [];
+for await (const path of glob.scan({ cwd: SRC, absolute: true })) {
+  files.push(path);
+}
+files.sort();
+if (filter) files = files.filter((f) => f.includes(filter));
+
+if (files.length === 0) {
+  console.log("No test files found.");
+  process.exit(0);
+}
+
+console.log(`Running ${files.length} test files (concurrency: ${concurrency})\n`);
+
+interface Result {
+  file: string;
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+  durationMs: number;
+}
+
+async function runFile(file: string): Promise<Result> {
+  const start = performance.now();
+  const proc = Bun.spawn(["bun", "test", file], {
+    cwd: ROOT,
+    stdout: "pipe",
+    stderr: "pipe",
+    env: { ...process.env, FORCE_COLOR: "1" },
+  });
+  const [stdout, stderr] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
+  const exitCode = await proc.exited;
+  return { file, exitCode, stdout, stderr, durationMs: performance.now() - start };
+}
+
+const results: Result[] = [];
+const queue = [...files];
+const active = new Set<Promise<void>>();
+
+async function scheduleNext(): Promise<void> {
+  if (queue.length === 0) return;
+  const file = queue.shift()!;
+  const p = runFile(file).then((result) => {
+    results.push(result);
+    const rel = relative(ROOT, result.file);
+    const status = result.exitCode === 0 ? "\x1b[32mPASS\x1b[0m" : "\x1b[31mFAIL\x1b[0m";
+    console.log(`  ${status}  ${rel}  (${result.durationMs.toFixed(0)}ms)`);
+    if (result.exitCode !== 0) {
+      const output = (result.stdout + result.stderr).trim();
+      if (output) {
+        for (const line of output.split("\n")) console.log(`    ${line}`);
+        console.log();
+      }
+    }
+    active.delete(p);
+    return scheduleNext();
+  });
+  active.add(p);
+}
+
+for (let i = 0; i < concurrency && queue.length > 0; i++) await scheduleNext();
+while (active.size > 0) await Promise.race(active);
+
+const passed = results.filter((r) => r.exitCode === 0).length;
+const failed = results.filter((r) => r.exitCode !== 0).length;
+const totalMs = results.reduce((s, r) => s + r.durationMs, 0).toFixed(0);
+
+console.log("\n" + "─".repeat(60));
+console.log(
+  `  Files: ${results.length}  |  ` +
+    `\x1b[32mPassed: ${passed}\x1b[0m  |  ` +
+    (failed > 0 ? `\x1b[31mFailed: ${failed}\x1b[0m` : `Failed: 0`) +
+    `  |  Time: ${totalMs}ms`,
+);
+console.log("─".repeat(60));
+
+if (failed > 0) {
+  console.log("\nFailed files:");
+  for (const r of results.filter((r) => r.exitCode !== 0)) {
+    console.log(`  \x1b[31m✗\x1b[0m ${relative(ROOT, r.file)}`);
+  }
+  process.exit(1);
+}

--- a/packages/mcp/src/__tests__/hosted-token-refresh.test.ts
+++ b/packages/mcp/src/__tests__/hosted-token-refresh.test.ts
@@ -150,6 +150,7 @@ mock.module("@atlas/api/lib/db/internal", () => {
     assignWorkspaceRegion: notUsed("assignWorkspaceRegion"),
     isWorkspaceMigrating: async () => false,
     closeInternalDB: async () => undefined,
+    isInternalCircuitOpen: () => false,
   };
 });
 

--- a/packages/mcp/src/__tests__/hosted.test.ts
+++ b/packages/mcp/src/__tests__/hosted.test.ts
@@ -153,6 +153,7 @@ mock.module("@atlas/api/lib/db/internal", () => {
     assignWorkspaceRegion: notUsed("assignWorkspaceRegion"),
     isWorkspaceMigrating: async () => false,
     closeInternalDB: async () => undefined,
+    isInternalCircuitOpen: () => false,
   };
 });
 

--- a/packages/mcp/src/__tests__/telemetry.test.ts
+++ b/packages/mcp/src/__tests__/telemetry.test.ts
@@ -68,6 +68,10 @@ mock.module("@atlas/api/lib/metrics", () => ({
       counterCalls.push({ metric: "atlas.mcp.activations", value, attributes });
     },
   },
+  rateLimitAuditDropped: { add: () => {} },
+  rateLimitLoaderFailures: { add: () => {} },
+  oauthTokenRefresh: { add: () => {} },
+  mcpPromptCalls: { add: () => {} },
 }));
 
 // --- Mocks for AI SDK tool execute functions ------------------------------


### PR DESCRIPTION
## Summary

- Switch `@atlas/mcp` from in-process `bun test` to a per-file isolated runner (`packages/mcp/scripts/test-isolated.ts`), mirroring `@atlas/api`. Each file gets its own subprocess so `mock.module()` state cannot leak between files.
- Backfill 3 partial-mock blocks that were masked by test ordering:
  - `telemetry.test.ts` → add `rateLimitAuditDropped` + `rateLimitLoaderFailures` + `oauthTokenRefresh` + `mcpPromptCalls` to `@atlas/api/lib/metrics` mock (the first was added in #2713).
  - `hosted.test.ts` + `hosted-token-refresh.test.ts` → add `isInternalCircuitOpen: () => false` to `@atlas/api/lib/db/internal` mock (called transitively via `rate-limit/middleware.ts`).

Closes #2760, closes #2762.

## Why

Both issues had the same root cause: `bun test` runs every file in a single process. `mock.module()` is process-global, so a file that stubs a dependency as throw-on-call (#2760) or shifts cwd / replaces filesystem reads (#2762) silently corrupts every later file in load order. CI hid it because `test:others` runs after `test:api` — failures buried in scrollback.

The runner is the trimmed twin of `packages/api/scripts/test-isolated.ts` — kept the parallel-by-cpu-count + bounded-queue + per-file pass/fail reporting; dropped `--shard` and `--affected` for now since the MCP suite is 17 files / ~8s wallclock. Header note flags the sync point if either gets needed.

## Test plan

- [x] `bun run --filter '@atlas/mcp' test` — 17/17 pass on a clean checkout (was 1 fail / 248 tests before)
- [x] `bun test src/__tests__/canonical-mcp-auth.test.ts` (single-file) still 5/5
- [x] `bun test src/__tests__/prompts/canonical.test.ts` (single-file) still 17/17
- [x] `bun run type` clean
- [x] `bun run lint` clean on MCP
- [ ] `bun run test:others` end-to-end in CI (covers the full path)