### PR TITLE
feat(api): #2743 — DatasourcePoolResolver + built-in Datasource catalog rows

### DIFF
--- a/packages/api/src/lib/__tests__/config-override-implementation-status.test.ts
+++ b/packages/api/src/lib/__tests__/config-override-implementation-status.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Tests for the `overrideImplementationStatus` config field (1.5.3 #2743).
+ *
+ * Inert in this slice — only the schema + ResolvedConfig + read helper
+ * are wired. Slice 9 (#2747) adds the UI consumer.
+ *
+ * The hook lets a self-host operator promote a `coming_soon` catalog row
+ * to `available` (e.g. they've shipped their own install handler) per
+ * ADR-0007 §"Catalog seeding for Datasources".
+ */
+import { describe, expect, it } from "bun:test";
+import { resolve } from "path";
+
+const configModPath = resolve(__dirname, "../config.ts");
+const configMod = await import(`${configModPath}?t=${Date.now()}`);
+const { validateAndResolve, getCatalogImplementationStatus, _resetConfig } =
+  configMod as typeof import("../config");
+
+describe("validateAndResolve — overrideImplementationStatus", () => {
+  it("admits a slug → status map", () => {
+    const resolved = validateAndResolve({
+      overrideImplementationStatus: {
+        discord: "available",
+        teams: "coming_soon",
+      },
+    });
+    expect(resolved.overrideImplementationStatus).toEqual({
+      discord: "available",
+      teams: "coming_soon",
+    });
+  });
+
+  it("rejects unknown status values", () => {
+    expect(() =>
+      validateAndResolve({
+        overrideImplementationStatus: { foo: "ga" },
+      }),
+    ).toThrow();
+  });
+
+  it("omits the field on the ResolvedConfig when no override is declared", () => {
+    const resolved = validateAndResolve({});
+    expect("overrideImplementationStatus" in resolved).toBe(false);
+  });
+});
+
+describe("getCatalogImplementationStatus", () => {
+  it("returns the override when set", () => {
+    _resetConfig();
+    const resolved = validateAndResolve({
+      overrideImplementationStatus: { discord: "available" },
+    });
+    expect(getCatalogImplementationStatus("discord", resolved)).toBe(
+      "available",
+    );
+  });
+
+  it("returns undefined when no override is declared for the slug", () => {
+    const resolved = validateAndResolve({
+      overrideImplementationStatus: { discord: "available" },
+    });
+    expect(getCatalogImplementationStatus("teams", resolved)).toBeUndefined();
+  });
+
+  it("returns undefined when overrideImplementationStatus is absent", () => {
+    const resolved = validateAndResolve({});
+    expect(getCatalogImplementationStatus("discord", resolved)).toBeUndefined();
+  });
+
+  it("falls back to the module-level resolved config when no config is passed", () => {
+    _resetConfig();
+    expect(getCatalogImplementationStatus("discord")).toBeUndefined();
+  });
+});

--- a/packages/api/src/lib/auth/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/auth/__tests__/migrate.test.ts
@@ -338,6 +338,7 @@ describe("migrateAuthTables", () => {
             { name: "0090_organization_is_operator_workspace.sql" },
             { name: "0091_unify_catalog_min_plan.sql" },
             { name: "0092_pillar_install_id_columns.sql" },
+            { name: "0093_builtin_datasource_catalog.sql" },
           ],
         };
       }

--- a/packages/api/src/lib/config.ts
+++ b/packages/api/src/lib/config.ts
@@ -32,6 +32,10 @@ import type { ToolRegistry } from "./tools/registry";
 import { ACTION_APPROVAL_MODES, type ActionApprovalMode } from "@atlas/api/lib/action-types";
 import { ATLAS_ROLES } from "@atlas/api/lib/auth/types";
 import {
+  IMPLEMENTATION_STATUSES,
+  type ImplementationStatus,
+} from "@useatlas/types";
+import {
   DEFAULT_AUTO_PROMOTE_CLICKS,
   DEFAULT_COLD_WINDOW_DAYS,
 } from "@atlas/api/lib/suggestions/approval-service";
@@ -607,6 +611,22 @@ const AtlasConfigSchema = z.object({
     },
     "catalog entries must have unique slugs — duplicate found",
   ),
+
+  /**
+   * Per-deploy override for a catalog row's `implementation_status`.
+   * Map from catalog slug → `"available" | "coming_soon"`. Per ADR-0007
+   * (1.5.3 #2743), this hook lets a self-host operator who's shipped
+   * their own install handler for a row Atlas marks `coming_soon`
+   * promote it to `available` without forking the catalog.
+   *
+   * **Inert in slice 5 (#2743)** — the read path is wired through
+   * `getCatalogImplementationStatus()` but no UI consumer renders the
+   * override yet. Slice 9 (#2747) consumes it to flip a card's CTA
+   * from inert to active.
+   */
+  overrideImplementationStatus: z
+    .record(z.string(), z.enum(IMPLEMENTATION_STATUSES))
+    .optional(),
 });
 
 /** The output type after Zod parsing (defaults applied, all fields present). */
@@ -673,6 +693,13 @@ export interface ResolvedConfig {
    * should default to `[]` via `config.catalog ?? []`.
    */
   catalog?: CatalogEntry[];
+  /**
+   * Per-deploy override for a catalog row's `implementation_status`.
+   * Map from catalog slug → `"available" | "coming_soon"`. Read via
+   * {@link getCatalogImplementationStatus} (1.5.3 #2743). Inert until
+   * slice 9 (#2747) wires a UI consumer.
+   */
+  overrideImplementationStatus?: Record<string, ImplementationStatus>;
   /** Whether the config was loaded from a file or synthesized from env vars. */
   source: "file" | "env";
 }
@@ -708,6 +735,24 @@ let _resolved: ResolvedConfig | null = null;
  */
 export function getConfig(): ResolvedConfig | null {
   return _resolved;
+}
+
+/**
+ * Read the per-deploy operator override for a catalog row's
+ * `implementation_status`. Returns the override when set, otherwise
+ * `undefined` — callers fall back to the catalog row's stored value.
+ *
+ * Per ADR-0007 / 1.5.3 slice 5 (#2743): wired but inert. No UI consumer
+ * renders the override yet — slice 9 (#2747) is the first reader.
+ *
+ * @param slug catalog slug (e.g. `"discord"`, `"postgres"`)
+ * @param config optional injected config (defaults to {@link getConfig})
+ */
+export function getCatalogImplementationStatus(
+  slug: string,
+  config: ResolvedConfig | null = getConfig(),
+): ImplementationStatus | undefined {
+  return config?.overrideImplementationStatus?.[slug];
 }
 
 /**
@@ -1233,6 +1278,9 @@ export function validateAndResolve(raw: unknown): ResolvedConfig {
     ...(config.residency ? { residency: config.residency } : {}),
     ...(config.catalog && config.catalog.length > 0
       ? { catalog: config.catalog }
+      : {}),
+    ...(config.overrideImplementationStatus
+      ? { overrideImplementationStatus: config.overrideImplementationStatus }
       : {}),
     source: "file",
   };

--- a/packages/api/src/lib/db/__tests__/datasource-pool-resolver.test.ts
+++ b/packages/api/src/lib/db/__tests__/datasource-pool-resolver.test.ts
@@ -1,0 +1,390 @@
+/**
+ * Tests for `DatasourcePoolResolver` — pure function that translates a
+ * `workspace_plugins` row (with `pillar = 'datasource'`) plus a decrypted
+ * config blob into the typed `DatasourcePoolConfig` shape ConnectionRegistry
+ * will consume in slice 6 (#2744).
+ *
+ * This slice (#2743) ships the resolver inert — no production caller wires
+ * it up; ConnectionRegistry still reads from the `connections` table. The
+ * tests below pin the per-`db_type` translation contract so slice 6 can
+ * pivot ConnectionRegistry without re-deriving the per-`db_type`
+ * conventions (Postgres `search_path` init SQL, MySQL read-only session
+ * var, ClickHouse `readonly: 1`, etc.).
+ *
+ * The decryption round-trip uses real `encryptSecretFields` /
+ * `decryptSecretFields` against the catalog `config_schema` so the test
+ * exercises the same path slice 6 will: row arrives with `url` ciphertext,
+ * caller decrypts, resolver translates.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import {
+  resolveDatasourcePoolConfig,
+  type DatasourceWorkspacePluginRow,
+  type DatasourcePoolConfig,
+  BUILTIN_DATASOURCE_CATALOG_SLUGS,
+  catalogSlugToDbType,
+} from "@atlas/api/lib/db/datasource-pool-resolver";
+import {
+  encryptSecretFields,
+  decryptSecretFields,
+  type ConfigSchema,
+} from "@atlas/api/lib/plugins/secrets";
+import { _resetEncryptionKeyCache } from "@atlas/api/lib/db/internal";
+
+const baseRow = (
+  catalogSlug: string,
+  overrides: Partial<DatasourceWorkspacePluginRow> = {},
+): DatasourceWorkspacePluginRow => ({
+  workspaceId: "ws-1",
+  catalogId: `catalog:${catalogSlug}`,
+  installId: "prod-us",
+  pillar: "datasource",
+  catalogSlug,
+  ...overrides,
+});
+
+const parsedSchema = (fields: { key: string; secret?: boolean }[]): ConfigSchema => ({
+  state: "parsed",
+  fields: fields.map((f) => ({
+    key: f.key,
+    type: "string",
+    secret: f.secret ?? false,
+  })),
+});
+
+describe("resolveDatasourcePoolConfig", () => {
+  describe("catalog slug → db_type mapping", () => {
+    it("maps `demo-postgres` to db_type `postgres`", () => {
+      expect(catalogSlugToDbType("demo-postgres")).toBe("postgres");
+    });
+
+    it("maps each native catalog slug to the matching db_type", () => {
+      const cases = [
+        { slug: "postgres", dbType: "postgres" as const },
+        { slug: "mysql", dbType: "mysql" as const },
+        { slug: "snowflake", dbType: "snowflake" as const },
+        { slug: "clickhouse", dbType: "clickhouse" as const },
+        { slug: "bigquery", dbType: "bigquery" as const },
+        { slug: "duckdb", dbType: "duckdb" as const },
+        { slug: "salesforce", dbType: "salesforce" as const },
+      ];
+      for (const { slug, dbType } of cases) {
+        expect(catalogSlugToDbType(slug)).toBe(dbType);
+      }
+    });
+
+    it("rejects unknown catalog slugs", () => {
+      expect(() => catalogSlugToDbType("oracle")).toThrow(
+        /unknown built-in datasource catalog slug/i,
+      );
+    });
+
+    it("covers every BUILTIN_DATASOURCE_CATALOG_SLUGS entry", () => {
+      expect(BUILTIN_DATASOURCE_CATALOG_SLUGS).toHaveLength(8);
+      for (const slug of BUILTIN_DATASOURCE_CATALOG_SLUGS) {
+        catalogSlugToDbType(slug);
+      }
+    });
+  });
+
+  describe("pillar guard", () => {
+    it("rejects rows where pillar is not `datasource`", () => {
+      const row = baseRow("postgres");
+      expect(() =>
+        resolveDatasourcePoolConfig(
+          { ...row, pillar: "action" as unknown as "datasource" },
+          { url: "postgresql://x:y@localhost/db" },
+        ),
+      ).toThrow(/pillar must be 'datasource'/i);
+    });
+  });
+
+  describe("postgres", () => {
+    it("emits a PostgresPoolConfig with init SQL when `schema` is set", () => {
+      const config = resolveDatasourcePoolConfig(baseRow("postgres"), {
+        url: "postgresql://user:pw@localhost:5432/mydb",
+        schema: "analytics",
+        description: "US prod read replica",
+      });
+      expect(config.dbType).toBe("postgres");
+      if (config.dbType !== "postgres") throw new Error("type narrowing");
+      expect(config.url).toBe("postgresql://user:pw@localhost:5432/mydb");
+      expect(config.schema).toBe("analytics");
+      expect(config.description).toBe("US prod read replica");
+      // search_path init SQL — quoted identifier, includes `public` fallback.
+      expect(config.initSql).toEqual([
+        `SET search_path TO "analytics", public`,
+      ]);
+    });
+
+    it("omits init SQL when no schema (default search_path retained)", () => {
+      const config = resolveDatasourcePoolConfig(baseRow("postgres"), {
+        url: "postgresql://x:y@localhost/db",
+      });
+      if (config.dbType !== "postgres") throw new Error("type narrowing");
+      expect(config.schema).toBeUndefined();
+      expect(config.initSql).toEqual([]);
+    });
+
+    it("rejects schema values that aren't valid SQL identifiers", () => {
+      expect(() =>
+        resolveDatasourcePoolConfig(baseRow("postgres"), {
+          url: "postgresql://x:y@localhost/db",
+          schema: "drop table users; --",
+        }),
+      ).toThrow(/invalid schema/i);
+    });
+
+    it("treats `public` schema as a no-op (no init SQL)", () => {
+      const config = resolveDatasourcePoolConfig(baseRow("postgres"), {
+        url: "postgresql://x:y@localhost/db",
+        schema: "public",
+      });
+      if (config.dbType !== "postgres") throw new Error("type narrowing");
+      expect(config.initSql).toEqual([]);
+    });
+
+    it("emits the same shape for the `demo-postgres` catalog slug", () => {
+      const config = resolveDatasourcePoolConfig(baseRow("demo-postgres"), {
+        url: "postgresql://demo:demo@demo-host/demo",
+        schema: "demo",
+      });
+      expect(config.dbType).toBe("postgres");
+    });
+
+    it("requires `url` in the decrypted config", () => {
+      expect(() =>
+        resolveDatasourcePoolConfig(baseRow("postgres"), {
+          schema: "x",
+        }),
+      ).toThrow(/missing.+url/i);
+    });
+  });
+
+  describe("mysql", () => {
+    it("emits a MySQLPoolConfig with read-only session var init SQL", () => {
+      const config = resolveDatasourcePoolConfig(baseRow("mysql"), {
+        url: "mysql://user:pw@localhost:3306/mydb",
+        description: "EU mysql",
+      });
+      expect(config.dbType).toBe("mysql");
+      if (config.dbType !== "mysql") throw new Error("type narrowing");
+      expect(config.url).toBe("mysql://user:pw@localhost:3306/mydb");
+      expect(config.initSql).toEqual(["SET SESSION TRANSACTION READ ONLY"]);
+      expect(config.description).toBe("EU mysql");
+    });
+  });
+
+  describe("snowflake", () => {
+    it("emits a SnowflakePoolConfig with no init SQL (defense-in-depth lives in plugin)", () => {
+      const config = resolveDatasourcePoolConfig(baseRow("snowflake"), {
+        url: "snowflake://user:pw@account/db/schema?warehouse=WH&role=ROLE",
+        schema: "analytics",
+      });
+      expect(config.dbType).toBe("snowflake");
+      if (config.dbType !== "snowflake") throw new Error("type narrowing");
+      expect(config.url).toBe(
+        "snowflake://user:pw@account/db/schema?warehouse=WH&role=ROLE",
+      );
+      expect(config.schema).toBe("analytics");
+    });
+  });
+
+  describe("clickhouse", () => {
+    it("emits a ClickHousePoolConfig flagging `readonly: 1`", () => {
+      const config = resolveDatasourcePoolConfig(baseRow("clickhouse"), {
+        url: "clickhouse://user:pw@host:8443/db",
+      });
+      expect(config.dbType).toBe("clickhouse");
+      if (config.dbType !== "clickhouse") throw new Error("type narrowing");
+      expect(config.url).toBe("clickhouse://user:pw@host:8443/db");
+      expect(config.readonly).toBe(1);
+    });
+  });
+
+  describe("bigquery", () => {
+    it("emits a BigQueryPoolConfig with serviceAccountJson + projectId", () => {
+      const config = resolveDatasourcePoolConfig(baseRow("bigquery"), {
+        service_account_json: '{"type":"service_account","project_id":"x"}',
+        project_id: "my-gcp-project",
+        description: "GA exports",
+      });
+      expect(config.dbType).toBe("bigquery");
+      if (config.dbType !== "bigquery") throw new Error("type narrowing");
+      expect(config.serviceAccountJson).toBe(
+        '{"type":"service_account","project_id":"x"}',
+      );
+      expect(config.projectId).toBe("my-gcp-project");
+      expect(config.description).toBe("GA exports");
+    });
+
+    it("requires both serviceAccountJson and projectId", () => {
+      expect(() =>
+        resolveDatasourcePoolConfig(baseRow("bigquery"), {
+          service_account_json: "{}",
+        }),
+      ).toThrow(/missing.+project_id/i);
+      expect(() =>
+        resolveDatasourcePoolConfig(baseRow("bigquery"), {
+          project_id: "x",
+        }),
+      ).toThrow(/missing.+service_account_json/i);
+    });
+  });
+
+  describe("duckdb", () => {
+    it("emits a DuckDBPoolConfig with file path", () => {
+      const config = resolveDatasourcePoolConfig(baseRow("duckdb"), {
+        path: "/var/atlas/data/duck.db",
+      });
+      expect(config.dbType).toBe("duckdb");
+      if (config.dbType !== "duckdb") throw new Error("type narrowing");
+      expect(config.path).toBe("/var/atlas/data/duck.db");
+    });
+
+    it("requires `path` (no implicit `:memory:`)", () => {
+      expect(() =>
+        resolveDatasourcePoolConfig(baseRow("duckdb"), {}),
+      ).toThrow(/missing.+path/i);
+    });
+  });
+
+  describe("salesforce", () => {
+    it("emits a SalesforcePoolConfig with description only (handler-managed creds)", () => {
+      const config = resolveDatasourcePoolConfig(baseRow("salesforce"), {
+        description: "CRM read access",
+      });
+      expect(config.dbType).toBe("salesforce");
+      if (config.dbType !== "salesforce") throw new Error("type narrowing");
+      expect(config.description).toBe("CRM read access");
+    });
+
+    it("does not require any config fields (creds live in integration_credentials)", () => {
+      const config = resolveDatasourcePoolConfig(baseRow("salesforce"), {});
+      expect(config.dbType).toBe("salesforce");
+    });
+  });
+
+  describe("optional pool tuning fields", () => {
+    it.each(["postgres", "mysql"] as const)(
+      "passes maxConnections + idleTimeoutMs through for %s",
+      (slug) => {
+        const config = resolveDatasourcePoolConfig(baseRow(slug), {
+          url:
+            slug === "postgres"
+              ? "postgresql://x:y@h/db"
+              : "mysql://x:y@h/db",
+          maxConnections: 25,
+          idleTimeoutMs: 60_000,
+        });
+        if (config.dbType !== "postgres" && config.dbType !== "mysql") {
+          throw new Error("type narrowing");
+        }
+        expect(config.maxConnections).toBe(25);
+        expect(config.idleTimeoutMs).toBe(60_000);
+      },
+    );
+  });
+
+  describe("exhaustive coverage of supported dbTypes", () => {
+    it("produces a PoolConfig for every BUILTIN_DATASOURCE_CATALOG_SLUGS entry", () => {
+      const fixtures: Record<string, Record<string, unknown>> = {
+        postgres: { url: "postgresql://x:y@h/db" },
+        mysql: { url: "mysql://x:y@h/db" },
+        snowflake: { url: "snowflake://x:y@a/d/s" },
+        clickhouse: { url: "clickhouse://x:y@h/db" },
+        bigquery: { service_account_json: "{}", project_id: "p" },
+        duckdb: { path: "/tmp/x.db" },
+        salesforce: {},
+        "demo-postgres": { url: "postgresql://demo:demo@h/demo" },
+      };
+      const seen = new Set<DatasourcePoolConfig["dbType"]>();
+      for (const slug of BUILTIN_DATASOURCE_CATALOG_SLUGS) {
+        const config = resolveDatasourcePoolConfig(
+          baseRow(slug),
+          fixtures[slug] ?? {},
+        );
+        seen.add(config.dbType);
+      }
+      // Every built-in db_type produced at least one PoolConfig.
+      expect(seen.size).toBe(7);
+    });
+  });
+});
+
+describe("DatasourcePoolResolver URL decryption round-trip", () => {
+  const savedKey = process.env.ATLAS_ENCRYPTION_KEY;
+  const savedAuth = process.env.BETTER_AUTH_SECRET;
+
+  beforeEach(() => {
+    process.env.ATLAS_ENCRYPTION_KEY = "atlas-test-pool-resolver-key";
+    delete process.env.BETTER_AUTH_SECRET;
+    _resetEncryptionKeyCache();
+  });
+
+  afterEach(() => {
+    if (savedKey !== undefined) process.env.ATLAS_ENCRYPTION_KEY = savedKey;
+    else delete process.env.ATLAS_ENCRYPTION_KEY;
+    if (savedAuth !== undefined) process.env.BETTER_AUTH_SECRET = savedAuth;
+    else delete process.env.BETTER_AUTH_SECRET;
+    _resetEncryptionKeyCache();
+  });
+
+  it("decrypts an `enc:v1:` workspace_plugins.config blob and feeds the resolver", () => {
+    // Catalog schema for built-in postgres row (matches slice-5 migration).
+    const schema = parsedSchema([
+      { key: "url", secret: true },
+      { key: "schema" },
+      { key: "description" },
+    ]);
+
+    const plaintext = {
+      url: "postgresql://user:pw@prod-host:5432/atlas",
+      schema: "events",
+      description: "US production",
+    };
+
+    // Simulate persisted state: encrypted config in workspace_plugins.config.
+    const encrypted = encryptSecretFields(plaintext, schema);
+    expect(typeof encrypted.url).toBe("string");
+    expect((encrypted.url as string).startsWith("enc:v1:")).toBe(true);
+    // Non-secret fields stay plaintext (DB ops grep-able).
+    expect(encrypted.schema).toBe("events");
+    expect(encrypted.description).toBe("US production");
+
+    // Read path: decrypt, then resolve into a PoolConfig.
+    const decrypted = decryptSecretFields(encrypted, schema);
+    expect(decrypted.url).toBe("postgresql://user:pw@prod-host:5432/atlas");
+
+    const config = resolveDatasourcePoolConfig(baseRow("postgres"), decrypted);
+    if (config.dbType !== "postgres") throw new Error("type narrowing");
+    expect(config.url).toBe("postgresql://user:pw@prod-host:5432/atlas");
+    expect(config.schema).toBe("events");
+    expect(config.initSql).toEqual([
+      `SET search_path TO "events", public`,
+    ]);
+  });
+
+  it("decrypts the bigquery service_account_json blob and preserves projectId plaintext", () => {
+    const schema = parsedSchema([
+      { key: "service_account_json", secret: true },
+      { key: "project_id" },
+      { key: "description" },
+    ]);
+    const plaintext = {
+      service_account_json: '{"type":"service_account","private_key":"-----BEGIN..."}',
+      project_id: "analytics-prod-123",
+      description: "GA4 + Search Console",
+    };
+    const encrypted = encryptSecretFields(plaintext, schema);
+    expect((encrypted.service_account_json as string).startsWith("enc:v1:")).toBe(true);
+    expect(encrypted.project_id).toBe("analytics-prod-123");
+
+    const decrypted = decryptSecretFields(encrypted, schema);
+    const config = resolveDatasourcePoolConfig(baseRow("bigquery"), decrypted);
+    if (config.dbType !== "bigquery") throw new Error("type narrowing");
+    expect(config.serviceAccountJson).toBe(plaintext.service_account_json);
+    expect(config.projectId).toBe("analytics-prod-123");
+  });
+});

--- a/packages/api/src/lib/db/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate.test.ts
@@ -104,8 +104,9 @@ describe("runMigrations", () => {
     // + 0089 (integration_credentials table, #2658)
     // + 0090 (organization.is_operator_workspace flag, #2702)
     // + 0091 (unify catalog min_plan vocabulary, #2666)
-    // + 0092 (pillar + install_id columns, #2739) = 93.
-    expect(count).toBe(93);
+    // + 0092 (pillar + install_id columns, #2739)
+    // + 0093 (built-in datasource catalog rows, #2743) = 94.
+    expect(count).toBe(94);
 
     // Advisory lock acquired before anything else
     expect(queries[0]).toContain("pg_advisory_lock");
@@ -227,6 +228,7 @@ describe("runMigrations", () => {
         "0090_organization_is_operator_workspace.sql",
         "0091_unify_catalog_min_plan.sql",
         "0092_pillar_install_id_columns.sql",
+        "0093_builtin_datasource_catalog.sql",
       ],
     });
 

--- a/packages/api/src/lib/db/__tests__/seed-builtin-datasource-catalog.test.ts
+++ b/packages/api/src/lib/db/__tests__/seed-builtin-datasource-catalog.test.ts
@@ -133,7 +133,11 @@ describe("seedBuiltinDatasourceCatalog (idempotent boot seed)", () => {
     await seedBuiltinDatasourceCatalog(db);
     expect(captured).toHaveLength(1);
     expect(captured[0]!.sql).toContain("INSERT INTO plugin_catalog");
-    expect(captured[0]!.sql).toContain("ON CONFLICT (slug) DO NOTHING");
+    // Unqualified ON CONFLICT DO NOTHING covers both the slug unique
+    // index AND the id PK — see seed module's JSDoc for the edge case
+    // (operator-edited row with a clashing `catalog:<slug>` id).
+    expect(captured[0]!.sql).toContain("ON CONFLICT DO NOTHING");
+    expect(captured[0]!.sql).not.toContain("ON CONFLICT (slug)");
     expect(captured[0]!.sql).toContain("RETURNING slug");
   });
 
@@ -213,8 +217,13 @@ describe("migration 0093 and seed module stay aligned", () => {
     }
   });
 
-  it("uses ON CONFLICT (slug) DO NOTHING — idempotent on re-deploy", () => {
-    expect(migrationSql).toContain("ON CONFLICT (slug) DO NOTHING");
+  it("uses unqualified ON CONFLICT DO NOTHING — covers slug + id PK collisions", () => {
+    // Unqualified (no `(slug)` target) so an operator-hand-edited row
+    // with a clashing `catalog:<slug>` id under a different slug doesn't
+    // crash startup with a PK violation. See migration header for the
+    // edge case.
+    expect(migrationSql).toContain("ON CONFLICT DO NOTHING");
+    expect(migrationSql).not.toContain("ON CONFLICT (slug)");
   });
 
   it("sets auto_install = true only on the demo-postgres row", () => {

--- a/packages/api/src/lib/db/__tests__/seed-builtin-datasource-catalog.test.ts
+++ b/packages/api/src/lib/db/__tests__/seed-builtin-datasource-catalog.test.ts
@@ -1,0 +1,253 @@
+/**
+ * Tests for the built-in Datasource catalog seed pass.
+ *
+ * Two surfaces under test:
+ *
+ *  1. `seedBuiltinDatasourceCatalog(db)` — the runtime seeder. Asserts
+ *     the eight rows are inserted with `ON CONFLICT DO NOTHING` semantics
+ *     and that the result accounting (inserted vs preserved) tracks the
+ *     RETURNING row set.
+ *
+ *  2. `BUILTIN_DATASOURCE_CATALOG_ROWS` — the in-process source of truth.
+ *     Asserts content-level invariants: all eight slugs, only
+ *     `demo-postgres` is auto_install, every catalog slug is recognised
+ *     by the resolver, every secret field is flagged.
+ *
+ * The migration is checked end-to-end by `migrate-pg.test.ts` against
+ * a real Postgres; here we only exercise the boot-time seed against an
+ * in-memory mock pool.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  seedBuiltinDatasourceCatalog,
+  BUILTIN_DATASOURCE_CATALOG_ROWS,
+  type BuiltinDatasourceCatalogSeedDb,
+} from "@atlas/api/lib/db/seed-builtin-datasource-catalog";
+import {
+  BUILTIN_DATASOURCE_CATALOG_SLUGS,
+  catalogSlugToDbType,
+} from "@atlas/api/lib/db/datasource-pool-resolver";
+
+interface CapturedQuery {
+  sql: string;
+  params: unknown[];
+}
+
+const captureDb = (
+  conflictWith: ReadonlyArray<string> = [],
+): { db: BuiltinDatasourceCatalogSeedDb; captured: CapturedQuery[] } => {
+  const captured: CapturedQuery[] = [];
+  const db: BuiltinDatasourceCatalogSeedDb = {
+    async query<T = unknown>(sql: string, params?: unknown[]) {
+      captured.push({ sql, params: params ?? [] });
+      // Simulate ON CONFLICT DO NOTHING ... RETURNING slug:
+      // return slugs that did NOT conflict (i.e. that actually inserted).
+      const allSlugs = BUILTIN_DATASOURCE_CATALOG_ROWS.map((r) => r.slug);
+      const inserted = allSlugs.filter((s) => !conflictWith.includes(s));
+      return { rows: inserted.map((slug) => ({ slug })) as T[] };
+    },
+  };
+  return { db, captured };
+};
+
+describe("BUILTIN_DATASOURCE_CATALOG_ROWS", () => {
+  it("contains exactly the eight built-in slugs", () => {
+    expect(BUILTIN_DATASOURCE_CATALOG_ROWS).toHaveLength(8);
+    const slugs = BUILTIN_DATASOURCE_CATALOG_ROWS.map((r) => r.slug);
+    expect(new Set(slugs)).toEqual(new Set(BUILTIN_DATASOURCE_CATALOG_SLUGS));
+  });
+
+  it("only marks `demo-postgres` as auto_install", () => {
+    const autoInstall = BUILTIN_DATASOURCE_CATALOG_ROWS.filter((r) => r.autoInstall);
+    expect(autoInstall).toHaveLength(1);
+    expect(autoInstall[0]!.slug).toBe("demo-postgres");
+  });
+
+  it("uses install_model 'oauth' only for salesforce (rest are 'form')", () => {
+    for (const row of BUILTIN_DATASOURCE_CATALOG_ROWS) {
+      const expected = row.slug === "salesforce" ? "oauth" : "form";
+      expect(row.installModel).toBe(expected);
+    }
+  });
+
+  it("flags every URL / credential field as `secret: true`", () => {
+    const secretFieldsBySlug: Record<string, string[]> = {
+      postgres: ["url"],
+      mysql: ["url"],
+      snowflake: ["url"],
+      clickhouse: ["url"],
+      bigquery: ["service_account_json"],
+      duckdb: [],
+      salesforce: [],
+      "demo-postgres": [],
+    };
+    for (const row of BUILTIN_DATASOURCE_CATALOG_ROWS) {
+      const expectedSecrets = secretFieldsBySlug[row.slug] ?? [];
+      const actualSecrets = row.configSchema
+        .filter((f) => f.secret === true)
+        .map((f) => f.key);
+      expect(actualSecrets.sort()).toEqual(expectedSecrets.sort());
+    }
+  });
+
+  it("requires the primary credential field on form-based rows", () => {
+    const primary: Record<string, string | null> = {
+      postgres: "url",
+      mysql: "url",
+      snowflake: "url",
+      clickhouse: "url",
+      bigquery: "service_account_json",
+      duckdb: "path",
+      salesforce: null, // handler-managed, empty schema
+      "demo-postgres": null, // operator-managed, empty schema
+    };
+    for (const row of BUILTIN_DATASOURCE_CATALOG_ROWS) {
+      const key = primary[row.slug];
+      if (key === null) continue;
+      const field = row.configSchema.find((f) => f.key === key);
+      expect(field, `expected ${key} field on ${row.slug}`).toBeDefined();
+      expect(field!.required).toBe(true);
+    }
+  });
+
+  it("uses `id = catalog:<slug>` for every row (matches catalog-seeder convention)", () => {
+    for (const row of BUILTIN_DATASOURCE_CATALOG_ROWS) {
+      expect(row.id).toBe(`catalog:${row.slug}`);
+    }
+  });
+
+  it("every seed slug is recognised by the resolver's slug→db_type map", () => {
+    for (const row of BUILTIN_DATASOURCE_CATALOG_ROWS) {
+      // Must not throw — covered separately in datasource-pool-resolver.test.ts.
+      catalogSlugToDbType(row.slug);
+    }
+  });
+});
+
+describe("seedBuiltinDatasourceCatalog (idempotent boot seed)", () => {
+  it("issues a single bulk INSERT covering all eight rows", async () => {
+    const { db, captured } = captureDb();
+    await seedBuiltinDatasourceCatalog(db);
+    expect(captured).toHaveLength(1);
+    expect(captured[0]!.sql).toContain("INSERT INTO plugin_catalog");
+    expect(captured[0]!.sql).toContain("ON CONFLICT (slug) DO NOTHING");
+    expect(captured[0]!.sql).toContain("RETURNING slug");
+  });
+
+  it("emits 7 params per row (id, name, slug, description, install_model, auto_install, config_schema)", async () => {
+    const { db, captured } = captureDb();
+    await seedBuiltinDatasourceCatalog(db);
+    // 8 rows × 7 params per row = 56 bound params total.
+    expect(captured[0]!.params).toHaveLength(8 * 7);
+  });
+
+  it("reports every slug as inserted on a fresh catalog (no conflicts)", async () => {
+    const { db } = captureDb();
+    const result = await seedBuiltinDatasourceCatalog(db);
+    expect([...result.insertedSlugs].sort()).toEqual(
+      [...BUILTIN_DATASOURCE_CATALOG_SLUGS].sort(),
+    );
+    expect(result.preservedSlugs).toHaveLength(0);
+  });
+
+  it("reports preserved slugs when rows already exist (ON CONFLICT DO NOTHING path)", async () => {
+    const { db } = captureDb(["postgres", "demo-postgres"]);
+    const result = await seedBuiltinDatasourceCatalog(db);
+    const preserved: string[] = [...result.preservedSlugs];
+    expect(preserved.sort()).toEqual(["demo-postgres", "postgres"]);
+    expect(result.insertedSlugs).toHaveLength(6);
+    expect(result.insertedSlugs).not.toContain("postgres");
+  });
+
+  it("reports all preserved on a fully-populated catalog (true idempotent re-boot)", async () => {
+    const { db } = captureDb([...BUILTIN_DATASOURCE_CATALOG_SLUGS]);
+    const result = await seedBuiltinDatasourceCatalog(db);
+    expect(result.insertedSlugs).toHaveLength(0);
+    expect([...result.preservedSlugs].sort()).toEqual(
+      [...BUILTIN_DATASOURCE_CATALOG_SLUGS].sort(),
+    );
+  });
+
+  it("serializes config_schema as JSON in the bound params (matches ::jsonb cast in SQL)", async () => {
+    const { db, captured } = captureDb();
+    await seedBuiltinDatasourceCatalog(db);
+    // Each row's 7th param (index 6, 13, 20, …) is the JSON-serialized configSchema.
+    for (let i = 0; i < BUILTIN_DATASOURCE_CATALOG_ROWS.length; i++) {
+      const param = captured[0]!.params[i * 7 + 6];
+      expect(typeof param).toBe("string");
+      const parsed = JSON.parse(param as string);
+      expect(parsed).toEqual(BUILTIN_DATASOURCE_CATALOG_ROWS[i]!.configSchema);
+    }
+  });
+
+  it("propagates DB errors instead of swallowing them", async () => {
+    const failing: BuiltinDatasourceCatalogSeedDb = {
+      async query() {
+        throw new Error("simulated pg error");
+      },
+    };
+    await expect(seedBuiltinDatasourceCatalog(failing)).rejects.toThrow(
+      /simulated pg error/,
+    );
+  });
+});
+
+describe("migration 0093 and seed module stay aligned", () => {
+  // The migration file's VALUES block and the seed module's
+  // BUILTIN_DATASOURCE_CATALOG_ROWS need to express the same eight rows.
+  // A migration-only edit (or a seed-only edit) would let live DBs and
+  // fresh DBs disagree until the next boot. These tests catch the drift.
+
+  const migrationSql = readFileSync(
+    join(import.meta.dir, "..", "migrations", "0093_builtin_datasource_catalog.sql"),
+    "utf8",
+  );
+
+  it("references every seed slug in the migration SQL", () => {
+    for (const row of BUILTIN_DATASOURCE_CATALOG_ROWS) {
+      // Each slug appears in the VALUES block — exact string match.
+      expect(migrationSql).toContain(`'${row.slug}'`);
+    }
+  });
+
+  it("uses ON CONFLICT (slug) DO NOTHING — idempotent on re-deploy", () => {
+    expect(migrationSql).toContain("ON CONFLICT (slug) DO NOTHING");
+  });
+
+  it("sets auto_install = true only on the demo-postgres row", () => {
+    // Coarse but useful: the migration's `true` autoinstall token appears
+    // exactly once — alongside `demo-postgres`. Other rows use `false`.
+    const lines = migrationSql.split("\n");
+    const demoLineIdx = lines.findIndex((l) => l.includes("'demo-postgres'"));
+    expect(demoLineIdx).toBeGreaterThan(-1);
+    // Inspect the row's VALUES block — `true,` appears as the auto_install
+    // position for demo-postgres only.
+    const otherSlugs = BUILTIN_DATASOURCE_CATALOG_ROWS.filter(
+      (r) => r.slug !== "demo-postgres",
+    );
+    for (const row of otherSlugs) {
+      // Each non-demo row's stanza opens with `'catalog:<slug>'`. The
+      // stanza ends before the next row's `(` so we slice to the next
+      // catalog id.
+      const stanzaStart = migrationSql.indexOf(`'catalog:${row.slug}'`);
+      const nextStanza = migrationSql.indexOf(
+        "(\n    'catalog:",
+        stanzaStart + 1,
+      );
+      const stanza = migrationSql.slice(
+        stanzaStart,
+        nextStanza === -1 ? undefined : nextStanza,
+      );
+      // The auto_install position in our VALUES block is the 9th value:
+      // (id, name, slug, description, type, install_model, pillar,
+      //  implementation_status, AUTO_INSTALL, ...). Easier check: this
+      // row's stanza must contain `false,` (its auto_install value) and
+      // must NOT contain `true,\n    'starter'` immediately before the
+      // min_plan position.
+      expect(stanza).toContain("false,\n    'starter'");
+    }
+  });
+});

--- a/packages/api/src/lib/db/__tests__/seed-builtin-datasource-catalog.test.ts
+++ b/packages/api/src/lib/db/__tests__/seed-builtin-datasource-catalog.test.ts
@@ -18,7 +18,7 @@
  * in-memory mock pool.
  */
 
-import { describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it, mock } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import {
@@ -248,6 +248,96 @@ describe("migration 0093 and seed module stay aligned", () => {
       // must NOT contain `true,\n    'starter'` immediately before the
       // min_plan position.
       expect(stanza).toContain("false,\n    'starter'");
+    }
+  });
+});
+
+describe("runBuiltinDatasourceCatalogSeedBoot (discriminated outcomes)", () => {
+  // The boot wrapper sits between the Effect layer and the pure
+  // seed function. Each of its three outcomes (`skipped` / `seeded` /
+  // `error`) must be distinguishable — `BuiltinDatasourceCatalogSeedLive`
+  // maps them onto the user-visible `outcome` field; conflating skip
+  // and error was the bug that the discriminated return shape fixes.
+
+  // Mock pg pool — captures the same shape `getInternalDB()` returns.
+  const mockQuery = mock<
+    (sql: string, params?: unknown[]) => Promise<{ rows: unknown[] }>
+  >(() => Promise.resolve({ rows: [] }));
+
+  // Track which `db/internal` shape we want for the current test.
+  let hasInternalDBReturns = true;
+
+  mock.module("@atlas/api/lib/db/internal", () => ({
+    hasInternalDB: () => hasInternalDBReturns,
+    getInternalDB: () => ({ query: mockQuery }),
+    // Re-export the encryption-key reset so the resolver test file's
+    // `mock.module` companions don't blow up on partial mocks if both
+    // suites end up in the same isolated worker. Defensive.
+    _resetEncryptionKeyCache: () => {},
+  }));
+
+  afterEach(() => {
+    mockQuery.mockClear();
+    hasInternalDBReturns = true;
+  });
+
+  it("returns `{ kind: 'skipped' }` when no internal DB is configured", async () => {
+    hasInternalDBReturns = false;
+    const { runBuiltinDatasourceCatalogSeedBoot } = await import(
+      "@atlas/api/lib/db/seed-builtin-datasource-catalog"
+    );
+    const result = await runBuiltinDatasourceCatalogSeedBoot();
+    expect(result.kind).toBe("skipped");
+    if (result.kind === "skipped") expect(result.reason).toBe("no-internal-db");
+    // Pool must not be queried in the skip path.
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  it("returns `{ kind: 'seeded' }` on a successful seed", async () => {
+    hasInternalDBReturns = true;
+    // Simulate every row inserted (no conflicts) — match the bulk INSERT
+    // RETURNING contract.
+    mockQuery.mockImplementation(() =>
+      Promise.resolve({
+        rows: BUILTIN_DATASOURCE_CATALOG_ROWS.map((r) => ({ slug: r.slug })),
+      }),
+    );
+    const { runBuiltinDatasourceCatalogSeedBoot } = await import(
+      "@atlas/api/lib/db/seed-builtin-datasource-catalog"
+    );
+    const result = await runBuiltinDatasourceCatalogSeedBoot();
+    expect(result.kind).toBe("seeded");
+    if (result.kind === "seeded") {
+      expect(result.insertedSlugs).toHaveLength(8);
+      expect(result.preservedSlugs).toHaveLength(0);
+    }
+  });
+
+  it("returns `{ kind: 'error' }` when the pool query throws", async () => {
+    hasInternalDBReturns = true;
+    mockQuery.mockImplementation(() =>
+      Promise.reject(new Error("simulated pg failure")),
+    );
+    const { runBuiltinDatasourceCatalogSeedBoot } = await import(
+      "@atlas/api/lib/db/seed-builtin-datasource-catalog"
+    );
+    const result = await runBuiltinDatasourceCatalogSeedBoot();
+    expect(result.kind).toBe("error");
+    if (result.kind === "error") {
+      expect(result.message).toContain("simulated pg failure");
+    }
+  });
+
+  it("normalizes a non-Error throw to a string message", async () => {
+    hasInternalDBReturns = true;
+    mockQuery.mockImplementation(() => Promise.reject("just a string"));
+    const { runBuiltinDatasourceCatalogSeedBoot } = await import(
+      "@atlas/api/lib/db/seed-builtin-datasource-catalog"
+    );
+    const result = await runBuiltinDatasourceCatalogSeedBoot();
+    expect(result.kind).toBe("error");
+    if (result.kind === "error") {
+      expect(result.message).toContain("just a string");
     }
   });
 });

--- a/packages/api/src/lib/db/datasource-pool-resolver.ts
+++ b/packages/api/src/lib/db/datasource-pool-resolver.ts
@@ -1,0 +1,389 @@
+/**
+ * `DatasourcePoolResolver` — pure function that translates a
+ * `workspace_plugins` row (with `pillar = 'datasource'`) plus a decrypted
+ * config blob into the typed `DatasourcePoolConfig` ConnectionRegistry
+ * will consume in slice 6 (#2744) of the unified install pipeline.
+ *
+ * Inert in this slice (#2743): no production caller wires it up;
+ * ConnectionRegistry still reads from the `connections` table. The shape
+ * is here so slice 6 can pivot ConnectionRegistry without re-deriving the
+ * per-`db_type` translation conventions.
+ *
+ * Per ADR-0007 §"For ConnectionRegistry":
+ *   > Reads pool definitions from `workspace_plugins WHERE pillar = 'datasource'`.
+ *   > The `default` connection (auto-initialized from `ATLAS_DATASOURCE_URL`)
+ *   > continues to be config-managed and not stored in `workspace_plugins` —
+ *   > that's a runtime artifact, not a per-workspace install.
+ *
+ * Pure function: no IO, no Effect, no logging. Inputs are typed row shapes;
+ * the output is a discriminated union by `dbType`. Schema-level secret
+ * decryption (`decryptSecretFields` from `lib/plugins/secrets`) happens
+ * upstream — this module assumes `decryptedConfig.url` is plaintext.
+ */
+
+/**
+ * Catalog slugs for the eight built-in datasource catalog rows seeded by
+ * migration 0093 + the boot-time `seed-builtin-datasource-catalog` pass.
+ * Two slugs map to the same `db_type` (`postgres` and `demo-postgres`); see
+ * {@link catalogSlugToDbType}.
+ */
+export const BUILTIN_DATASOURCE_CATALOG_SLUGS = [
+  "postgres",
+  "mysql",
+  "snowflake",
+  "clickhouse",
+  "bigquery",
+  "duckdb",
+  "salesforce",
+  "demo-postgres",
+] as const;
+export type BuiltinDatasourceCatalogSlug =
+  (typeof BUILTIN_DATASOURCE_CATALOG_SLUGS)[number];
+
+/**
+ * `db_type` values produced by {@link catalogSlugToDbType}. ConnectionRegistry's
+ * `DBType` union admits arbitrary strings for plugin-managed types — this
+ * type pins the closed set the resolver handles for the built-in catalog.
+ */
+export type BuiltinDatasourceDbType =
+  | "postgres"
+  | "mysql"
+  | "snowflake"
+  | "clickhouse"
+  | "bigquery"
+  | "duckdb"
+  | "salesforce";
+
+/**
+ * Map a built-in datasource catalog slug to its `db_type`. The mapping is
+ * 1:1 for native slugs (`mysql` → `mysql`); `demo-postgres` collapses to
+ * `postgres` because the demo connection is just an operator-managed
+ * Postgres install pointing at the shared demo pool.
+ */
+export function catalogSlugToDbType(
+  slug: string,
+): BuiltinDatasourceDbType {
+  switch (slug) {
+    case "postgres":
+    case "demo-postgres":
+      return "postgres";
+    case "mysql":
+      return "mysql";
+    case "snowflake":
+      return "snowflake";
+    case "clickhouse":
+      return "clickhouse";
+    case "bigquery":
+      return "bigquery";
+    case "duckdb":
+      return "duckdb";
+    case "salesforce":
+      return "salesforce";
+    default:
+      throw new Error(
+        `Unknown built-in datasource catalog slug "${slug}". ` +
+          `Expected one of: ${BUILTIN_DATASOURCE_CATALOG_SLUGS.join(", ")}.`,
+      );
+  }
+}
+
+/**
+ * Narrow shape of the `workspace_plugins` row the resolver consumes. The
+ * full Drizzle row carries many more columns (id, enabled, installed_at,
+ * etc.); the resolver only needs the identifying tuple plus the catalog
+ * slug so it can decide which translation to apply.
+ */
+export interface DatasourceWorkspacePluginRow {
+  readonly workspaceId: string;
+  readonly catalogId: string;
+  readonly installId: string;
+  readonly pillar: "datasource";
+  /**
+   * `plugin_catalog.slug` joined onto the install row. The slug determines
+   * the `db_type` — see {@link catalogSlugToDbType}. Slice 6 (#2744) will
+   * pull this via JOIN in the same SELECT it uses to read the install.
+   */
+  readonly catalogSlug: string;
+}
+
+// ---------------------------------------------------------------------------
+// PoolConfig discriminated union
+// ---------------------------------------------------------------------------
+
+/** Shared pool-tuning fields applicable to native (pg/mysql) pools. */
+interface PoolTuning {
+  readonly maxConnections?: number;
+  readonly idleTimeoutMs?: number;
+}
+
+export interface PostgresPoolConfig extends PoolTuning {
+  readonly dbType: "postgres";
+  readonly url: string;
+  readonly schema?: string;
+  readonly description?: string;
+  /**
+   * SQL statements to run once per physical connection at acquire time.
+   * Empty when no init is needed. Postgres uses this for `SET search_path`
+   * when `schema` is set to a non-`public` identifier.
+   *
+   * The translation lives in the resolver (rather than in ConnectionRegistry's
+   * `createPostgresDB`) so the per-`db_type` convention is testable in
+   * isolation and slice 6 can drive a unified `initSql` runner.
+   */
+  readonly initSql: readonly string[];
+}
+
+export interface MySQLPoolConfig extends PoolTuning {
+  readonly dbType: "mysql";
+  readonly url: string;
+  readonly description?: string;
+  /** Per-session read-only enforcement. */
+  readonly initSql: readonly string[];
+}
+
+export interface SnowflakePoolConfig {
+  readonly dbType: "snowflake";
+  readonly url: string;
+  readonly schema?: string;
+  readonly description?: string;
+}
+
+export interface ClickHousePoolConfig {
+  readonly dbType: "clickhouse";
+  readonly url: string;
+  readonly description?: string;
+  /**
+   * ClickHouse defense-in-depth read-only flag — applied per query in the
+   * `@useatlas/clickhouse` plugin (`clickhouse_settings.readonly`). Pinned
+   * to `1` here so slice 6 / the plugin caller can pass it through without
+   * a magic-number re-derivation.
+   */
+  readonly readonly: 1;
+}
+
+export interface BigQueryPoolConfig {
+  readonly dbType: "bigquery";
+  readonly serviceAccountJson: string;
+  readonly projectId: string;
+  readonly description?: string;
+}
+
+export interface DuckDBPoolConfig {
+  readonly dbType: "duckdb";
+  readonly path: string;
+  readonly description?: string;
+}
+
+export interface SalesforcePoolConfig {
+  readonly dbType: "salesforce";
+  readonly description?: string;
+}
+
+export type DatasourcePoolConfig =
+  | PostgresPoolConfig
+  | MySQLPoolConfig
+  | SnowflakePoolConfig
+  | ClickHousePoolConfig
+  | BigQueryPoolConfig
+  | DuckDBPoolConfig
+  | SalesforcePoolConfig;
+
+// ---------------------------------------------------------------------------
+// Resolver
+// ---------------------------------------------------------------------------
+
+/** Regex for valid SQL identifiers — mirrors `connection.ts:VALID_SQL_IDENTIFIER`. */
+const VALID_SQL_IDENTIFIER = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
+
+/**
+ * Translate a `workspace_plugins` row + decrypted config into a typed
+ * `DatasourcePoolConfig`. Pure: same `(row, decryptedConfig)` always
+ * produces the same output.
+ *
+ * `decryptedConfig` is the `workspace_plugins.config` JSONB after
+ * `decryptSecretFields` has unwrapped every `secret: true` field declared
+ * in the catalog row's `config_schema`. The resolver does not call
+ * `decryptSecretFields` itself — keeping the resolver pure means the
+ * encryption key + keyset are caller concerns.
+ *
+ * Throws when:
+ *   - `row.pillar !== "datasource"`
+ *   - `row.catalogSlug` isn't in {@link BUILTIN_DATASOURCE_CATALOG_SLUGS}
+ *   - the decrypted config is missing a required field for the resolved `db_type`
+ *   - Postgres `schema` is not a valid SQL identifier
+ */
+export function resolveDatasourcePoolConfig(
+  row: DatasourceWorkspacePluginRow,
+  decryptedConfig: Readonly<Record<string, unknown>>,
+): DatasourcePoolConfig {
+  if (row.pillar !== "datasource") {
+    throw new Error(
+      `DatasourcePoolResolver: pillar must be 'datasource', got '${row.pillar}'`,
+    );
+  }
+  const dbType = catalogSlugToDbType(row.catalogSlug);
+
+  switch (dbType) {
+    case "postgres":
+      return resolvePostgres(decryptedConfig);
+    case "mysql":
+      return resolveMySQL(decryptedConfig);
+    case "snowflake":
+      return resolveSnowflake(decryptedConfig);
+    case "clickhouse":
+      return resolveClickHouse(decryptedConfig);
+    case "bigquery":
+      return resolveBigQuery(decryptedConfig);
+    case "duckdb":
+      return resolveDuckDB(decryptedConfig);
+    case "salesforce":
+      return resolveSalesforce(decryptedConfig);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Per-dbType resolvers
+// ---------------------------------------------------------------------------
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function asPositiveInt(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? value
+    : undefined;
+}
+
+function resolvePostgres(c: Readonly<Record<string, unknown>>): PostgresPoolConfig {
+  const url = asString(c.url);
+  if (!url) {
+    throw new Error("DatasourcePoolResolver(postgres): missing required field `url`");
+  }
+  const schema = asString(c.schema);
+  if (schema !== undefined && !VALID_SQL_IDENTIFIER.test(schema)) {
+    throw new Error(
+      `DatasourcePoolResolver(postgres): invalid schema "${schema}" — must be a valid SQL identifier`,
+    );
+  }
+  // `public` is the Postgres default — no init SQL needed and a SET would
+  // be a noisy no-op on every connection acquire.
+  const initSql =
+    schema && schema !== "public" ? [`SET search_path TO "${schema}", public`] : [];
+
+  return {
+    dbType: "postgres",
+    url,
+    ...(schema !== undefined ? { schema } : {}),
+    ...(asString(c.description) !== undefined
+      ? { description: asString(c.description)! }
+      : {}),
+    ...(asPositiveInt(c.maxConnections) !== undefined
+      ? { maxConnections: asPositiveInt(c.maxConnections)! }
+      : {}),
+    ...(asPositiveInt(c.idleTimeoutMs) !== undefined
+      ? { idleTimeoutMs: asPositiveInt(c.idleTimeoutMs)! }
+      : {}),
+    initSql,
+  };
+}
+
+function resolveMySQL(c: Readonly<Record<string, unknown>>): MySQLPoolConfig {
+  const url = asString(c.url);
+  if (!url) {
+    throw new Error("DatasourcePoolResolver(mysql): missing required field `url`");
+  }
+  return {
+    dbType: "mysql",
+    url,
+    ...(asString(c.description) !== undefined
+      ? { description: asString(c.description)! }
+      : {}),
+    ...(asPositiveInt(c.maxConnections) !== undefined
+      ? { maxConnections: asPositiveInt(c.maxConnections)! }
+      : {}),
+    ...(asPositiveInt(c.idleTimeoutMs) !== undefined
+      ? { idleTimeoutMs: asPositiveInt(c.idleTimeoutMs)! }
+      : {}),
+    // Defense-in-depth read-only session — mirrors `createMySQLDB` in
+    // `connection.ts` which executes this per-query today. Hoisting it to
+    // an init-SQL list lets slice 6 run it once per connection acquire.
+    initSql: ["SET SESSION TRANSACTION READ ONLY"],
+  };
+}
+
+function resolveSnowflake(c: Readonly<Record<string, unknown>>): SnowflakePoolConfig {
+  const url = asString(c.url);
+  if (!url) {
+    throw new Error("DatasourcePoolResolver(snowflake): missing required field `url`");
+  }
+  return {
+    dbType: "snowflake",
+    url,
+    ...(asString(c.schema) !== undefined ? { schema: asString(c.schema)! } : {}),
+    ...(asString(c.description) !== undefined
+      ? { description: asString(c.description)! }
+      : {}),
+  };
+}
+
+function resolveClickHouse(c: Readonly<Record<string, unknown>>): ClickHousePoolConfig {
+  const url = asString(c.url);
+  if (!url) {
+    throw new Error("DatasourcePoolResolver(clickhouse): missing required field `url`");
+  }
+  return {
+    dbType: "clickhouse",
+    url,
+    ...(asString(c.description) !== undefined
+      ? { description: asString(c.description)! }
+      : {}),
+    readonly: 1,
+  };
+}
+
+function resolveBigQuery(c: Readonly<Record<string, unknown>>): BigQueryPoolConfig {
+  const serviceAccountJson = asString(c.service_account_json);
+  if (!serviceAccountJson) {
+    throw new Error(
+      "DatasourcePoolResolver(bigquery): missing required field `service_account_json`",
+    );
+  }
+  const projectId = asString(c.project_id);
+  if (!projectId) {
+    throw new Error(
+      "DatasourcePoolResolver(bigquery): missing required field `project_id`",
+    );
+  }
+  return {
+    dbType: "bigquery",
+    serviceAccountJson,
+    projectId,
+    ...(asString(c.description) !== undefined
+      ? { description: asString(c.description)! }
+      : {}),
+  };
+}
+
+function resolveDuckDB(c: Readonly<Record<string, unknown>>): DuckDBPoolConfig {
+  const path = asString(c.path);
+  if (!path) {
+    throw new Error("DatasourcePoolResolver(duckdb): missing required field `path`");
+  }
+  return {
+    dbType: "duckdb",
+    path,
+    ...(asString(c.description) !== undefined
+      ? { description: asString(c.description)! }
+      : {}),
+  };
+}
+
+function resolveSalesforce(c: Readonly<Record<string, unknown>>): SalesforcePoolConfig {
+  return {
+    dbType: "salesforce",
+    ...(asString(c.description) !== undefined
+      ? { description: asString(c.description)! }
+      : {}),
+  };
+}

--- a/packages/api/src/lib/db/migrations/0093_builtin_datasource_catalog.sql
+++ b/packages/api/src/lib/db/migrations/0093_builtin_datasource_catalog.sql
@@ -17,8 +17,13 @@
 -- `demo-postgres` is the only row with `auto_install = true` (auto-seeded
 -- into every workspace at creation in slice 6's cutover migration).
 --
--- Idempotent via `ON CONFLICT (slug) DO NOTHING` — re-runs / re-deploys
--- are no-ops at the DB layer. The companion boot-time seed pass
+-- Idempotent via unqualified ON CONFLICT DO NOTHING — re-runs and
+-- re-deploys are no-ops at the DB layer. The unqualified form covers
+-- both the slug unique index AND the id primary key, so a stray
+-- operator-edited row whose id matches one of our canonical seed ids
+-- under a different slug doesn't crash startup with a PK violation.
+--
+-- The companion boot-time seed pass
 -- (`packages/api/src/lib/db/seed-builtin-datasource-catalog.ts`,
 -- wired via `BuiltinDatasourceCatalogSeedLive` in `effect/layers.ts`)
 -- re-asserts the same rows on every boot so a self-host operator who
@@ -206,4 +211,4 @@ VALUES
     NOW(),
     NOW()
   )
-ON CONFLICT (slug) DO NOTHING;
+ON CONFLICT DO NOTHING;

--- a/packages/api/src/lib/db/migrations/0093_builtin_datasource_catalog.sql
+++ b/packages/api/src/lib/db/migrations/0093_builtin_datasource_catalog.sql
@@ -1,0 +1,209 @@
+-- 0093_builtin_datasource_catalog.sql
+--
+-- 1.5.3 slice 5 (#2743 / PRD #2738 / ADR-0007) — seed the eight built-in
+-- Datasource catalog rows that slice 6 (#2744) needs as install targets.
+--
+-- These rows are NOT declared in `atlas.config.ts` — per ADR-0007 they
+-- ship with Atlas and are seeded as code:
+--
+--   > The current code-hard-wired `DB_TYPES` array promotes to built-in
+--   > `plugin_catalog` rows seeded by a boot-time migration: `postgres`,
+--   > `mysql`, `snowflake`, `clickhouse`, `bigquery`, `duckdb`,
+--   > `salesforce`, `demo-postgres`. Operators do *not* declare these in
+--   > `atlas.config.ts` — they ship with Atlas.
+--
+-- All eight rows carry `pillar = 'datasource'`,
+-- `implementation_status = 'available'`, and the appropriate `install_model`.
+-- `demo-postgres` is the only row with `auto_install = true` (auto-seeded
+-- into every workspace at creation in slice 6's cutover migration).
+--
+-- Idempotent via `ON CONFLICT (slug) DO NOTHING` — re-runs / re-deploys
+-- are no-ops at the DB layer. The companion boot-time seed pass
+-- (`packages/api/src/lib/db/seed-builtin-datasource-catalog.ts`,
+-- wired via `BuiltinDatasourceCatalogSeedLive` in `effect/layers.ts`)
+-- re-asserts the same rows on every boot so a self-host operator who
+-- deleted a row gets it back without a redeploy.
+--
+-- NOT consumed by ConnectionRegistry yet — slice 6 (#2744) pivots
+-- ConnectionRegistry to read from `workspace_plugins WHERE
+-- pillar = 'datasource'`. The `DatasourcePoolResolver` pure function in
+-- `packages/api/src/lib/db/datasource-pool-resolver.ts` translates these
+-- rows into the typed PoolConfig shape.
+--
+-- `config_schema` columns:
+--   * postgres / mysql / snowflake — { url (secret), schema?, description? }
+--   * clickhouse                   — { url (secret), description? }
+--   * bigquery                     — { service_account_json (secret), project_id, description? }
+--   * duckdb                       — { path, description? }
+--   * salesforce                   — handler-managed (empty JSONB array)
+--   * demo-postgres                — operator-managed (empty JSONB array)
+--
+-- The `secret: true` flag on URL / credential fields drives
+-- `plugins/secrets.ts::encryptSecretFields` so per-workspace credentials
+-- land encrypted in `workspace_plugins.config` JSONB once slice 6 wires
+-- the install handler.
+
+INSERT INTO plugin_catalog
+  (id, name, slug, description, type, install_model, pillar,
+   implementation_status, auto_install, min_plan, enabled, saas_eligible,
+   config_schema, created_at, updated_at)
+VALUES
+  (
+    'catalog:postgres',
+    'PostgreSQL',
+    'postgres',
+    'Connect a PostgreSQL database as an analytics datasource.',
+    'datasource',
+    'form',
+    'datasource',
+    'available',
+    false,
+    'starter',
+    true,
+    true,
+    '[
+      {"key": "url", "type": "string", "label": "Connection URL", "required": true, "secret": true, "description": "postgresql://user:pass@host:5432/database"},
+      {"key": "schema", "type": "string", "label": "Schema", "description": "Optional. Sets search_path on connection."},
+      {"key": "description", "type": "string", "label": "Description", "description": "Optional. Shown in the agent system prompt."}
+    ]'::jsonb,
+    NOW(),
+    NOW()
+  ),
+  (
+    'catalog:mysql',
+    'MySQL',
+    'mysql',
+    'Connect a MySQL database as an analytics datasource.',
+    'datasource',
+    'form',
+    'datasource',
+    'available',
+    false,
+    'starter',
+    true,
+    true,
+    '[
+      {"key": "url", "type": "string", "label": "Connection URL", "required": true, "secret": true, "description": "mysql://user:pass@host:3306/database"},
+      {"key": "schema", "type": "string", "label": "Schema", "description": "Optional."},
+      {"key": "description", "type": "string", "label": "Description", "description": "Optional. Shown in the agent system prompt."}
+    ]'::jsonb,
+    NOW(),
+    NOW()
+  ),
+  (
+    'catalog:snowflake',
+    'Snowflake',
+    'snowflake',
+    'Connect a Snowflake account as an analytics datasource.',
+    'datasource',
+    'form',
+    'datasource',
+    'available',
+    false,
+    'starter',
+    true,
+    true,
+    '[
+      {"key": "url", "type": "string", "label": "Connection URL", "required": true, "secret": true, "description": "snowflake://user:pass@account/db/schema?warehouse=WH&role=ROLE"},
+      {"key": "schema", "type": "string", "label": "Schema", "description": "Optional."},
+      {"key": "description", "type": "string", "label": "Description", "description": "Optional. Shown in the agent system prompt."}
+    ]'::jsonb,
+    NOW(),
+    NOW()
+  ),
+  (
+    'catalog:clickhouse',
+    'ClickHouse',
+    'clickhouse',
+    'Connect a ClickHouse instance as an analytics datasource.',
+    'datasource',
+    'form',
+    'datasource',
+    'available',
+    false,
+    'starter',
+    true,
+    true,
+    '[
+      {"key": "url", "type": "string", "label": "Connection URL", "required": true, "secret": true, "description": "clickhouse://user:pass@host:8443/database"},
+      {"key": "description", "type": "string", "label": "Description", "description": "Optional. Shown in the agent system prompt."}
+    ]'::jsonb,
+    NOW(),
+    NOW()
+  ),
+  (
+    'catalog:bigquery',
+    'BigQuery',
+    'bigquery',
+    'Connect a Google BigQuery project as an analytics datasource.',
+    'datasource',
+    'form',
+    'datasource',
+    'available',
+    false,
+    'starter',
+    true,
+    true,
+    '[
+      {"key": "service_account_json", "type": "string", "label": "Service Account JSON", "required": true, "secret": true, "description": "Paste the full service account key JSON."},
+      {"key": "project_id", "type": "string", "label": "GCP Project ID", "required": true},
+      {"key": "description", "type": "string", "label": "Description", "description": "Optional. Shown in the agent system prompt."}
+    ]'::jsonb,
+    NOW(),
+    NOW()
+  ),
+  (
+    'catalog:duckdb',
+    'DuckDB',
+    'duckdb',
+    'Connect a DuckDB file as an analytics datasource.',
+    'datasource',
+    'form',
+    'datasource',
+    'available',
+    false,
+    'starter',
+    true,
+    true,
+    '[
+      {"key": "path", "type": "string", "label": "Database File Path", "required": true, "description": "Absolute path to the .duckdb file."},
+      {"key": "description", "type": "string", "label": "Description", "description": "Optional. Shown in the agent system prompt."}
+    ]'::jsonb,
+    NOW(),
+    NOW()
+  ),
+  (
+    'catalog:salesforce',
+    'Salesforce',
+    'salesforce',
+    'Connect a Salesforce org as an analytics datasource via OAuth.',
+    'datasource',
+    'oauth',
+    'datasource',
+    'available',
+    false,
+    'starter',
+    true,
+    true,
+    '[]'::jsonb,
+    NOW(),
+    NOW()
+  ),
+  (
+    'catalog:demo-postgres',
+    'Demo Dataset',
+    'demo-postgres',
+    'Atlas-managed demo Postgres dataset, shared across all workspaces.',
+    'datasource',
+    'form',
+    'datasource',
+    'available',
+    true,
+    'starter',
+    true,
+    true,
+    '[]'::jsonb,
+    NOW(),
+    NOW()
+  )
+ON CONFLICT (slug) DO NOTHING;

--- a/packages/api/src/lib/db/seed-builtin-datasource-catalog.ts
+++ b/packages/api/src/lib/db/seed-builtin-datasource-catalog.ts
@@ -35,6 +35,7 @@ import {
   BUILTIN_DATASOURCE_CATALOG_SLUGS,
   type BuiltinDatasourceCatalogSlug,
 } from "@atlas/api/lib/db/datasource-pool-resolver";
+import type { ConfigSchemaField } from "@atlas/api/lib/plugins/registry";
 
 const log = createLogger("db.seed-builtin-datasource-catalog");
 
@@ -44,6 +45,12 @@ const log = createLogger("db.seed-builtin-datasource-catalog");
  * `min_plan`, `enabled`, `saas_eligible` are pinned to the row's
  * canonical values; `created_at` / `updated_at` are written as `NOW()`
  * in the SQL — no field here.
+ *
+ * `configSchema` reuses {@link ConfigSchemaField} (the same shape the
+ * rest of the codebase reads back from `plugin_catalog.config_schema`
+ * JSONB) so a future field addition there (e.g. a new option key)
+ * propagates here at compile time instead of silently drifting between
+ * the seed-time write shape and the runtime read shape.
  */
 export interface BuiltinDatasourceCatalogRow {
   readonly id: string;
@@ -52,14 +59,7 @@ export interface BuiltinDatasourceCatalogRow {
   readonly description: string;
   readonly installModel: "form" | "oauth";
   readonly autoInstall: boolean;
-  readonly configSchema: ReadonlyArray<{
-    readonly key: string;
-    readonly type: "string" | "number" | "boolean" | "select";
-    readonly label?: string;
-    readonly description?: string;
-    readonly required?: boolean;
-    readonly secret?: boolean;
-  }>;
+  readonly configSchema: ReadonlyArray<ConfigSchemaField>;
 }
 
 /**
@@ -297,8 +297,15 @@ export async function seedBuiltinDatasourceCatalog(
     }
   }
 
-  // Parameterised bulk INSERT — each row contributes 13 placeholders.
-  // Column order matches migration 0093's VALUES block.
+  // Parameterised bulk INSERT — each row contributes 7 placeholders
+  // (id, name, slug, description, install_model, auto_install,
+  // config_schema). The remaining 8 columns are SQL literals
+  // (`'datasource'` for type and pillar, `'available'` for status,
+  // `'starter'` for min_plan, two `true`s for enabled + saas_eligible,
+  // and two `NOW()` timestamps). Column order matches migration 0093's
+  // VALUES block — drift is checked by
+  // `__tests__/seed-builtin-datasource-catalog.test.ts`'s
+  // `migration-and-seed-stay-aligned` suite.
   const placeholders: string[] = [];
   const params: unknown[] = [];
   let p = 0;
@@ -346,14 +353,33 @@ export async function seedBuiltinDatasourceCatalog(
 }
 
 /**
+ * Discriminated outcome of {@link runBuiltinDatasourceCatalogSeedBoot}.
+ *
+ * `kind: "skipped"` is a legitimate skip (no `InternalDB` — typically a
+ * test runner or a dev process without a DB configured). `kind: "error"`
+ * means the seed actually threw; rows from the prior boot remain
+ * authoritative. The two cases were previously collapsed to `null`,
+ * which forced {@link BuiltinDatasourceCatalogSeedLive} to mislabel a
+ * real failure as `outcome: "skipped-gate"`.
+ */
+export type BuiltinDatasourceCatalogSeedBootResult =
+  | { readonly kind: "skipped"; readonly reason: "no-internal-db" }
+  | {
+      readonly kind: "seeded";
+      readonly insertedSlugs: ReadonlyArray<BuiltinDatasourceCatalogSlug>;
+      readonly preservedSlugs: ReadonlyArray<BuiltinDatasourceCatalogSlug>;
+    }
+  | { readonly kind: "error"; readonly message: string };
+
+/**
  * Boot-pass wrapper. Mirrors `runCatalogSeedBoot` from
  * `integrations/catalog-seeder.ts` — log-and-continue posture so a seed
  * failure leaves pre-existing rows authoritative for the boot rather
- * than crashing the API. Failures still surface in logs.
+ * than crashing the API. Returns a discriminated result so the Effect
+ * Layer can surface skip vs error to health consumers without
+ * conflating them. Failures still surface in logs.
  */
-export async function runBuiltinDatasourceCatalogSeedBoot(): Promise<
-  BuiltinDatasourceCatalogSeedResult | null
-> {
+export async function runBuiltinDatasourceCatalogSeedBoot(): Promise<BuiltinDatasourceCatalogSeedBootResult> {
   const { hasInternalDB, getInternalDB } = await import(
     "@atlas/api/lib/db/internal"
   );
@@ -362,7 +388,7 @@ export async function runBuiltinDatasourceCatalogSeedBoot(): Promise<
     log.info(
       "Built-in Datasource catalog seed: no internal DB configured, skipping",
     );
-    return null;
+    return { kind: "skipped", reason: "no-internal-db" };
   }
 
   const pool = getInternalDB();
@@ -374,12 +400,18 @@ export async function runBuiltinDatasourceCatalogSeedBoot(): Promise<
   };
 
   try {
-    return await seedBuiltinDatasourceCatalog(db);
+    const result = await seedBuiltinDatasourceCatalog(db);
+    return {
+      kind: "seeded",
+      insertedSlugs: result.insertedSlugs,
+      preservedSlugs: result.preservedSlugs,
+    };
   } catch (err) {
+    const normalized = err instanceof Error ? err : new Error(String(err));
     log.error(
-      { err: err instanceof Error ? err : new Error(String(err)) },
+      { err: normalized, rowCount: BUILTIN_DATASOURCE_CATALOG_ROWS.length },
       "Built-in Datasource catalog seed failed — plugin_catalog rows from prior boot remain authoritative",
     );
-    return null;
+    return { kind: "error", message: normalized.message };
   }
 }

--- a/packages/api/src/lib/db/seed-builtin-datasource-catalog.ts
+++ b/packages/api/src/lib/db/seed-builtin-datasource-catalog.ts
@@ -1,0 +1,385 @@
+/**
+ * Boot-time idempotent seed pass for the eight built-in Datasource
+ * catalog rows. Re-asserts the same rows migration 0093 inserts on
+ * fresh DBs — keeps the catalog consistent if an operator deleted a
+ * row out-of-band.
+ *
+ * Per ADR-0007 §"Catalog seeding for Datasources":
+ *
+ *   > The current code-hard-wired `DB_TYPES` array promotes to built-in
+ *   > `plugin_catalog` rows seeded by a boot-time migration: `postgres`,
+ *   > `mysql`, `snowflake`, `clickhouse`, `bigquery`, `duckdb`,
+ *   > `salesforce`, `demo-postgres`. Operators do *not* declare these
+ *   > in `atlas.config.ts` — they ship with Atlas.
+ *
+ * Idempotency:
+ *   - Uses `ON CONFLICT (slug) DO NOTHING` so re-running on a populated
+ *     catalog is a no-op. The atlas.config.ts catalog seeder
+ *     (`integrations/catalog-seeder.ts`) updates mutable fields on
+ *     existing rows; this seed deliberately leaves them alone — once
+ *     a built-in row exists, an operator who edited its `name` or
+ *     `description` via SQL keeps that edit.
+ *   - Slice 5 ships the resolver inert (no ConnectionRegistry consumer);
+ *     a seed-time failure logs at error and the API keeps booting —
+ *     pre-existing rows answer admin-UI reads.
+ *
+ * Inert until slice 6 (#2744): no production caller reads from these
+ * rows. The seeded rows do, however, surface as catalog entries in
+ * admin-UI listings — they appear in the integrations marketplace as
+ * `pillar = 'datasource'` cards (slice 8 / #2746 pivots the UI to
+ * surface them on `/admin/connections`).
+ */
+
+import { createLogger } from "@atlas/api/lib/logger";
+import {
+  BUILTIN_DATASOURCE_CATALOG_SLUGS,
+  type BuiltinDatasourceCatalogSlug,
+} from "@atlas/api/lib/db/datasource-pool-resolver";
+
+const log = createLogger("db.seed-builtin-datasource-catalog");
+
+/**
+ * Declarative description of a single built-in Datasource catalog row.
+ * Mirrors `plugin_catalog`'s column shape for the columns the seed sets.
+ * `min_plan`, `enabled`, `saas_eligible` are pinned to the row's
+ * canonical values; `created_at` / `updated_at` are written as `NOW()`
+ * in the SQL — no field here.
+ */
+export interface BuiltinDatasourceCatalogRow {
+  readonly id: string;
+  readonly slug: BuiltinDatasourceCatalogSlug;
+  readonly name: string;
+  readonly description: string;
+  readonly installModel: "form" | "oauth";
+  readonly autoInstall: boolean;
+  readonly configSchema: ReadonlyArray<{
+    readonly key: string;
+    readonly type: "string" | "number" | "boolean" | "select";
+    readonly label?: string;
+    readonly description?: string;
+    readonly required?: boolean;
+    readonly secret?: boolean;
+  }>;
+}
+
+/**
+ * The eight built-in Datasource catalog rows seeded by this module +
+ * migration 0093. The single source of truth for `name` / `description`
+ * / `config_schema` across both surfaces — keeping the SQL migration
+ * structurally identical to this table is enforced by the
+ * `migration-and-seed-stay-aligned` test in
+ * `__tests__/seed-builtin-datasource-catalog.test.ts`.
+ *
+ * `config_schema` `secret: true` fields drive
+ * `plugins/secrets.ts::encryptSecretFields` so per-workspace credentials
+ * land encrypted in `workspace_plugins.config` JSONB once slice 6 wires
+ * the install handler.
+ */
+export const BUILTIN_DATASOURCE_CATALOG_ROWS: ReadonlyArray<BuiltinDatasourceCatalogRow> = [
+  {
+    id: "catalog:postgres",
+    slug: "postgres",
+    name: "PostgreSQL",
+    description: "Connect a PostgreSQL database as an analytics datasource.",
+    installModel: "form",
+    autoInstall: false,
+    configSchema: [
+      {
+        key: "url",
+        type: "string",
+        label: "Connection URL",
+        required: true,
+        secret: true,
+        description: "postgresql://user:pass@host:5432/database",
+      },
+      {
+        key: "schema",
+        type: "string",
+        label: "Schema",
+        description: "Optional. Sets search_path on connection.",
+      },
+      {
+        key: "description",
+        type: "string",
+        label: "Description",
+        description: "Optional. Shown in the agent system prompt.",
+      },
+    ],
+  },
+  {
+    id: "catalog:mysql",
+    slug: "mysql",
+    name: "MySQL",
+    description: "Connect a MySQL database as an analytics datasource.",
+    installModel: "form",
+    autoInstall: false,
+    configSchema: [
+      {
+        key: "url",
+        type: "string",
+        label: "Connection URL",
+        required: true,
+        secret: true,
+        description: "mysql://user:pass@host:3306/database",
+      },
+      { key: "schema", type: "string", label: "Schema", description: "Optional." },
+      {
+        key: "description",
+        type: "string",
+        label: "Description",
+        description: "Optional. Shown in the agent system prompt.",
+      },
+    ],
+  },
+  {
+    id: "catalog:snowflake",
+    slug: "snowflake",
+    name: "Snowflake",
+    description: "Connect a Snowflake account as an analytics datasource.",
+    installModel: "form",
+    autoInstall: false,
+    configSchema: [
+      {
+        key: "url",
+        type: "string",
+        label: "Connection URL",
+        required: true,
+        secret: true,
+        description:
+          "snowflake://user:pass@account/db/schema?warehouse=WH&role=ROLE",
+      },
+      { key: "schema", type: "string", label: "Schema", description: "Optional." },
+      {
+        key: "description",
+        type: "string",
+        label: "Description",
+        description: "Optional. Shown in the agent system prompt.",
+      },
+    ],
+  },
+  {
+    id: "catalog:clickhouse",
+    slug: "clickhouse",
+    name: "ClickHouse",
+    description: "Connect a ClickHouse instance as an analytics datasource.",
+    installModel: "form",
+    autoInstall: false,
+    configSchema: [
+      {
+        key: "url",
+        type: "string",
+        label: "Connection URL",
+        required: true,
+        secret: true,
+        description: "clickhouse://user:pass@host:8443/database",
+      },
+      {
+        key: "description",
+        type: "string",
+        label: "Description",
+        description: "Optional. Shown in the agent system prompt.",
+      },
+    ],
+  },
+  {
+    id: "catalog:bigquery",
+    slug: "bigquery",
+    name: "BigQuery",
+    description: "Connect a Google BigQuery project as an analytics datasource.",
+    installModel: "form",
+    autoInstall: false,
+    configSchema: [
+      {
+        key: "service_account_json",
+        type: "string",
+        label: "Service Account JSON",
+        required: true,
+        secret: true,
+        description: "Paste the full service account key JSON.",
+      },
+      {
+        key: "project_id",
+        type: "string",
+        label: "GCP Project ID",
+        required: true,
+      },
+      {
+        key: "description",
+        type: "string",
+        label: "Description",
+        description: "Optional. Shown in the agent system prompt.",
+      },
+    ],
+  },
+  {
+    id: "catalog:duckdb",
+    slug: "duckdb",
+    name: "DuckDB",
+    description: "Connect a DuckDB file as an analytics datasource.",
+    installModel: "form",
+    autoInstall: false,
+    configSchema: [
+      {
+        key: "path",
+        type: "string",
+        label: "Database File Path",
+        required: true,
+        description: "Absolute path to the .duckdb file.",
+      },
+      {
+        key: "description",
+        type: "string",
+        label: "Description",
+        description: "Optional. Shown in the agent system prompt.",
+      },
+    ],
+  },
+  {
+    id: "catalog:salesforce",
+    slug: "salesforce",
+    name: "Salesforce",
+    description: "Connect a Salesforce org as an analytics datasource via OAuth.",
+    installModel: "oauth",
+    autoInstall: false,
+    configSchema: [],
+  },
+  {
+    id: "catalog:demo-postgres",
+    slug: "demo-postgres",
+    name: "Demo Dataset",
+    description:
+      "Atlas-managed demo Postgres dataset, shared across all workspaces.",
+    installModel: "form",
+    autoInstall: true,
+    configSchema: [],
+  },
+];
+
+/**
+ * Narrow shape of the DB client the seeder needs. Mirrors
+ * `CatalogSeedDb` from `integrations/catalog-seeder.ts` so a single
+ * mock pool serves both seeders in tests.
+ */
+export interface BuiltinDatasourceCatalogSeedDb {
+  query<T = unknown>(sql: string, params?: unknown[]): Promise<{ rows: T[] }>;
+}
+
+export interface BuiltinDatasourceCatalogSeedResult {
+  /** Slugs whose `ON CONFLICT DO NOTHING` ran an insert (row didn't exist). */
+  readonly insertedSlugs: ReadonlyArray<BuiltinDatasourceCatalogSlug>;
+  /** Slugs whose row already existed (the conflict path). */
+  readonly preservedSlugs: ReadonlyArray<BuiltinDatasourceCatalogSlug>;
+}
+
+/**
+ * Idempotently seed the eight built-in Datasource catalog rows.
+ * `ON CONFLICT (slug) DO NOTHING` makes this safe on every boot.
+ *
+ * Bulk INSERT keeps the seed cheap (single statement vs eight) and lets
+ * the result set (`RETURNING slug`) report which rows actually inserted
+ * vs which were preserved. The bulk shape mirrors migration 0093's
+ * VALUES block exactly — keeping them aligned is checked by the
+ * `migration-and-seed-stay-aligned` test.
+ */
+export async function seedBuiltinDatasourceCatalog(
+  db: BuiltinDatasourceCatalogSeedDb,
+): Promise<BuiltinDatasourceCatalogSeedResult> {
+  // Defense-in-depth: this list is the source of truth for the seed,
+  // and the resolver's slug→db_type map is the source of truth for
+  // accepted slugs. A regression that adds a row here without updating
+  // the resolver would silently land a catalog entry the resolver can't
+  // translate. Fail loud at boot rather than at first install.
+  for (const row of BUILTIN_DATASOURCE_CATALOG_ROWS) {
+    if (!BUILTIN_DATASOURCE_CATALOG_SLUGS.includes(row.slug)) {
+      throw new Error(
+        `Built-in datasource seed: row slug "${row.slug}" is not in BUILTIN_DATASOURCE_CATALOG_SLUGS — update datasource-pool-resolver.ts`,
+      );
+    }
+  }
+
+  // Parameterised bulk INSERT — each row contributes 13 placeholders.
+  // Column order matches migration 0093's VALUES block.
+  const placeholders: string[] = [];
+  const params: unknown[] = [];
+  let p = 0;
+  for (const row of BUILTIN_DATASOURCE_CATALOG_ROWS) {
+    const placeholder = `($${++p}, $${++p}, $${++p}, $${++p}, 'datasource', $${++p}, 'datasource', 'available', $${++p}, 'starter', true, true, $${++p}::jsonb, NOW(), NOW())`;
+    placeholders.push(placeholder);
+    params.push(
+      row.id,
+      row.name,
+      row.slug,
+      row.description,
+      row.installModel,
+      row.autoInstall,
+      JSON.stringify(row.configSchema),
+    );
+  }
+
+  const { rows } = await db.query<{ slug: BuiltinDatasourceCatalogSlug }>(
+    `INSERT INTO plugin_catalog
+       (id, name, slug, description, type, install_model, pillar,
+        implementation_status, auto_install, min_plan, enabled, saas_eligible,
+        config_schema, created_at, updated_at)
+     VALUES ${placeholders.join(", ")}
+     ON CONFLICT (slug) DO NOTHING
+     RETURNING slug`,
+    params,
+  );
+
+  const insertedSlugs = rows.map((r) => r.slug);
+  const insertedSet = new Set<string>(insertedSlugs);
+  const preservedSlugs = BUILTIN_DATASOURCE_CATALOG_ROWS.map((r) => r.slug).filter(
+    (slug) => !insertedSet.has(slug),
+  );
+
+  log.info(
+    {
+      insertedCount: insertedSlugs.length,
+      preservedCount: preservedSlugs.length,
+      insertedSlugs,
+    },
+    "Built-in Datasource catalog seed complete",
+  );
+
+  return { insertedSlugs, preservedSlugs };
+}
+
+/**
+ * Boot-pass wrapper. Mirrors `runCatalogSeedBoot` from
+ * `integrations/catalog-seeder.ts` — log-and-continue posture so a seed
+ * failure leaves pre-existing rows authoritative for the boot rather
+ * than crashing the API. Failures still surface in logs.
+ */
+export async function runBuiltinDatasourceCatalogSeedBoot(): Promise<
+  BuiltinDatasourceCatalogSeedResult | null
+> {
+  const { hasInternalDB, getInternalDB } = await import(
+    "@atlas/api/lib/db/internal"
+  );
+
+  if (!hasInternalDB()) {
+    log.info(
+      "Built-in Datasource catalog seed: no internal DB configured, skipping",
+    );
+    return null;
+  }
+
+  const pool = getInternalDB();
+  const db: BuiltinDatasourceCatalogSeedDb = {
+    async query<T = unknown>(sql: string, params?: unknown[]) {
+      const result = await pool.query(sql, params);
+      return { rows: result.rows as T[] };
+    },
+  };
+
+  try {
+    return await seedBuiltinDatasourceCatalog(db);
+  } catch (err) {
+    log.error(
+      { err: err instanceof Error ? err : new Error(String(err)) },
+      "Built-in Datasource catalog seed failed — plugin_catalog rows from prior boot remain authoritative",
+    );
+    return null;
+  }
+}

--- a/packages/api/src/lib/db/seed-builtin-datasource-catalog.ts
+++ b/packages/api/src/lib/db/seed-builtin-datasource-catalog.ts
@@ -273,12 +273,16 @@ export interface BuiltinDatasourceCatalogSeedResult {
 
 /**
  * Idempotently seed the eight built-in Datasource catalog rows.
- * `ON CONFLICT (slug) DO NOTHING` makes this safe on every boot.
  *
  * Bulk INSERT keeps the seed cheap (single statement vs eight) and lets
  * the result set (`RETURNING slug`) report which rows actually inserted
- * vs which were preserved. The bulk shape mirrors migration 0093's
- * VALUES block exactly — keeping them aligned is checked by the
+ * vs which were preserved. Unqualified `ON CONFLICT DO NOTHING` covers
+ * both the `slug` unique index AND the `id` primary key — so a stray
+ * operator-edited row with one of our canonical `catalog:<slug>` ids
+ * under a different slug doesn't crash the boot pass.
+ *
+ * The bulk shape mirrors migration 0093's VALUES block exactly —
+ * keeping them aligned is checked by the
  * `migration-and-seed-stay-aligned` test.
  */
 export async function seedBuiltinDatasourceCatalog(
@@ -329,7 +333,7 @@ export async function seedBuiltinDatasourceCatalog(
         implementation_status, auto_install, min_plan, enabled, saas_eligible,
         config_schema, created_at, updated_at)
      VALUES ${placeholders.join(", ")}
-     ON CONFLICT (slug) DO NOTHING
+     ON CONFLICT DO NOTHING
      RETURNING slug`,
     params,
   );

--- a/packages/api/src/lib/effect/layers.ts
+++ b/packages/api/src/lib/effect/layers.ts
@@ -423,6 +423,124 @@ export const CatalogSeedLive: Layer.Layer<
 );
 
 // ══════════════════════════════════════════════════════════════════════
+// ██  Built-in Datasource Catalog Seed Layer (#2743 — 1.5.3 slice 5)
+// ══════════════════════════════════════════════════════════════════════
+
+/**
+ * Discriminated outcome of the boot-time built-in Datasource catalog
+ * seed. Distinct from {@link CatalogSeedOutcome} because the built-in
+ * seed is code-driven (eight fixed rows) while the atlas.config.ts
+ * seed is operator-driven. Per ADR-0007, the built-in seed runs in
+ * addition to the atlas.config.ts seed, not instead of it.
+ *
+ * - `skipped-gate`  — InternalDB or Migration upstream not satisfied
+ * - `seeded`        — seed ran (preservedSlugs may include all eight on re-boot)
+ * - `error`         — the boot wrapper or its dynamic import threw;
+ *                     pre-existing rows answer admin-UI reads
+ */
+export type BuiltinDatasourceCatalogSeedOutcome =
+  | "skipped-gate"
+  | "seeded"
+  | "error";
+
+export interface BuiltinDatasourceCatalogSeedShape {
+  /** Slugs whose row was newly inserted this boot. */
+  readonly insertedSlugs: ReadonlyArray<string>;
+  /**
+   * Slugs whose row already existed and was preserved (ON CONFLICT DO
+   * NOTHING). Re-boots on a healthy DB land every built-in slug here.
+   */
+  readonly preservedSlugs: ReadonlyArray<string>;
+  readonly outcome: BuiltinDatasourceCatalogSeedOutcome;
+  /** Scrubbed error message when `outcome === "error"`. */
+  readonly error?: string;
+}
+
+export class BuiltinDatasourceCatalogSeed extends Context.Tag(
+  "BuiltinDatasourceCatalogSeed",
+)<BuiltinDatasourceCatalogSeed, BuiltinDatasourceCatalogSeedShape>() {}
+
+/**
+ * Idempotent boot-time seed of the eight built-in Datasource catalog
+ * rows. Per ADR-0007 these are code-seeded (not declared in
+ * `atlas.config.ts`) and re-asserted on every boot via
+ * `ON CONFLICT (slug) DO NOTHING`.
+ *
+ * Depends on `Migration` so the `pillar` / `implementation_status` /
+ * `auto_install` columns added by migration 0092 exist before the
+ * INSERT; depends on `InternalDB` for the pool.
+ *
+ * **Inert in slice 5 (#2743)** — `ConnectionRegistry` still reads from
+ * the `connections` table; nothing consumes these rows yet. Slice 6
+ * (#2744) pivots `ConnectionRegistry` to read from
+ * `workspace_plugins WHERE pillar = 'datasource'`, at which point the
+ * eight rows seeded here become live install targets.
+ *
+ * Non-fatal: the boot wrapper swallows errors and logs at error so a
+ * failed seed leaves pre-existing rows authoritative.
+ */
+export const BuiltinDatasourceCatalogSeedLive: Layer.Layer<
+  BuiltinDatasourceCatalogSeed,
+  never,
+  InternalDB | Migration
+> = Layer.effect(
+  BuiltinDatasourceCatalogSeed,
+  Effect.gen(function* () {
+    const db = yield* InternalDB;
+    const migration = yield* Migration;
+    const zeroCounts = {
+      insertedSlugs: [] as ReadonlyArray<string>,
+      preservedSlugs: [] as ReadonlyArray<string>,
+    };
+
+    if (!db.available || !migration.migrated) {
+      log.info(
+        { available: db.available, migrated: migration.migrated },
+        "Built-in Datasource catalog seed skipped — upstream gate not satisfied",
+      );
+      return {
+        ...zeroCounts,
+        outcome: "skipped-gate",
+      } satisfies BuiltinDatasourceCatalogSeedShape;
+    }
+
+    return yield* Effect.tryPromise({
+      try: async () => {
+        const { runBuiltinDatasourceCatalogSeedBoot } = await import(
+          "@atlas/api/lib/db/seed-builtin-datasource-catalog"
+        );
+        const result = await runBuiltinDatasourceCatalogSeedBoot();
+        if (result === null) {
+          return {
+            ...zeroCounts,
+            outcome: "skipped-gate",
+          } satisfies BuiltinDatasourceCatalogSeedShape;
+        }
+        return {
+          insertedSlugs: result.insertedSlugs,
+          preservedSlugs: result.preservedSlugs,
+          outcome: "seeded",
+        } satisfies BuiltinDatasourceCatalogSeedShape;
+      },
+      catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+    }).pipe(
+      Effect.catchAll((err) => {
+        // Reachable when the dynamic import itself rejects — the
+        // `runBuiltinDatasourceCatalogSeedBoot` wrapper catches its own
+        // SQL/DB errors. We still surface the failure via
+        // `outcome: "error"` so healthCheck consumers can degrade.
+        log.error({ err }, "Built-in Datasource catalog seed boot wrapper threw");
+        return Effect.succeed({
+          ...zeroCounts,
+          outcome: "error",
+          error: errorMessage(err),
+        } satisfies BuiltinDatasourceCatalogSeedShape);
+      }),
+    );
+  }),
+);
+
+// ══════════════════════════════════════════════════════════════════════
 // ██  Connections Hydrate Layer
 // ══════════════════════════════════════════════════════════════════════
 
@@ -1279,6 +1397,7 @@ export function buildAppLayer(config: ResolvedConfig): Layer.Layer<
   | Migration
   | BackfillSaasTrial
   | CatalogSeed
+  | BuiltinDatasourceCatalogSeed
   | ConnectionsHydrate
   | SemanticSync
   | Settings
@@ -1304,6 +1423,15 @@ export function buildAppLayer(config: ResolvedConfig): Layer.Layer<
   // saas_eligible columns added by 0087 exist) and InternalDB. Same
   // shape as BackfillSaasTrialLive — independent peer otherwise.
   const catalogSeedLayer = CatalogSeedLive.pipe(
+    Layer.provide(Layer.merge(internalDBLayer, migrationLayer)),
+  );
+
+  // BuiltinDatasourceCatalogSeedLive (#2743, slice 5) — depends on
+  // Migration so 0092's pillar / implementation_status / auto_install
+  // columns + 0093's INSERTs are guaranteed before the boot re-assert.
+  // Independent peer of catalogSeedLayer; the two seeds touch disjoint
+  // slug sets so ordering between them doesn't matter.
+  const builtinDatasourceCatalogSeedLayer = BuiltinDatasourceCatalogSeedLive.pipe(
     Layer.provide(Layer.merge(internalDBLayer, migrationLayer)),
   );
 
@@ -1368,6 +1496,7 @@ export function buildAppLayer(config: ResolvedConfig): Layer.Layer<
     migrationLayer,
     backfillSaasTrialLayer,
     catalogSeedLayer,
+    builtinDatasourceCatalogSeedLayer,
     connectionsHydrateLayer,
     semanticSyncLayer,
     settingsLayer,

--- a/packages/api/src/lib/effect/layers.ts
+++ b/packages/api/src/lib/effect/layers.ts
@@ -510,17 +510,28 @@ export const BuiltinDatasourceCatalogSeedLive: Layer.Layer<
           "@atlas/api/lib/db/seed-builtin-datasource-catalog"
         );
         const result = await runBuiltinDatasourceCatalogSeedBoot();
-        if (result === null) {
-          return {
-            ...zeroCounts,
-            outcome: "skipped-gate",
-          } satisfies BuiltinDatasourceCatalogSeedShape;
+        switch (result.kind) {
+          case "skipped":
+            return {
+              ...zeroCounts,
+              outcome: "skipped-gate",
+            } satisfies BuiltinDatasourceCatalogSeedShape;
+          case "seeded":
+            return {
+              insertedSlugs: result.insertedSlugs,
+              preservedSlugs: result.preservedSlugs,
+              outcome: "seeded",
+            } satisfies BuiltinDatasourceCatalogSeedShape;
+          case "error":
+            // `runBuiltinDatasourceCatalogSeedBoot` already logged at
+            // error; surface the message to health consumers via the
+            // documented `outcome: "error"` contract.
+            return {
+              ...zeroCounts,
+              outcome: "error",
+              error: result.message,
+            } satisfies BuiltinDatasourceCatalogSeedShape;
         }
-        return {
-          insertedSlugs: result.insertedSlugs,
-          preservedSlugs: result.preservedSlugs,
-          outcome: "seeded",
-        } satisfies BuiltinDatasourceCatalogSeedShape;
       },
       catch: (err) => (err instanceof Error ? err : new Error(String(err))),
     }).pipe(


### PR DESCRIPTION
## Summary

Slice 5 of 17 in the 1.5.3 unified install pipeline (PRD #2738 / [ADR-0007](https://github.com/AtlasDevHQ/atlas/blob/main/docs/adr/0007-unified-install-pipeline.md)). Ships two coupled modules that prepare the Datasource pillar for slice 6's cutover (#2744). **Both are inert until that slice wires them up** — `ConnectionRegistry` still reads from the `connections` table.

- **`DatasourcePoolResolver`** (`packages/api/src/lib/db/datasource-pool-resolver.ts`) — pure function translating a `workspace_plugins` row (`pillar='datasource'`) + decrypted config into a typed `DatasourcePoolConfig` discriminated union. Per-`db_type` conventions (Postgres `search_path` init SQL, MySQL read-only session var, ClickHouse `readonly: 1`, BigQuery `service_account_json + project_id`, DuckDB `path`, Salesforce handler-managed) live in the resolver so slice 6 can drive a unified init-SQL runner.
- **Built-in catalog rows** — migration `0093_builtin_datasource_catalog.sql` INSERTs the eight rows (postgres, mysql, snowflake, clickhouse, bigquery, duckdb, salesforce, demo-postgres) with `ON CONFLICT (slug) DO NOTHING`. All carry `pillar='datasource'`, `implementation_status='available'`; `demo-postgres` is the only `auto_install=true` row. Companion boot-time seed module (`packages/api/src/lib/db/seed-builtin-datasource-catalog.ts`) + Effect layer (`BuiltinDatasourceCatalogSeedLive`) re-asserts on every boot so a self-host operator who deletes a row gets it back without a redeploy.
- **`atlas.config.ts:overrideImplementationStatus`** — `Record<slug, "available" | "coming_soon">` field on the Zod schema + `ResolvedConfig`; `getCatalogImplementationStatus()` read helper. Wired but inert — UI consumer lands in slice 9 (#2747).

## Acceptance criteria

- [x] Migration adds the eight rows idempotently (`ON CONFLICT (slug) DO NOTHING`)
- [x] Each row carries `pillar='datasource'`, `implementation_status='available'`, correct `install_model`, validated `config_schema` JSON
- [x] `demo-postgres` carries `auto_install=true`; no other row does
- [x] Boot-time seed pass re-asserts row existence on every boot
- [x] `overrideImplementationStatus` field defined; reading wired (inert)
- [x] `DatasourcePoolResolver` exported with full type coverage of supported `db_type`s
- [x] Exhaustive per-`db_type` PoolConfig test
- [x] URL decryption round-trip test via `decryptSecretFields` against a fixture row
- [x] Neither module is consumed by `ConnectionRegistry` yet — slice 6 work
- [x] `bun run lint`, `bun run type`, full `bun run test`, `bun x syncpack lint`, `SKIP_SYNCPACK=1 scripts/check-template-drift.sh`, `scripts/check-railway-watch.sh`, `scripts/check-schema-drift.sh`, `scripts/check-ee-imports.sh` — all green locally
- [x] `migrate-pg.test.ts` (real-Postgres smoke) exercises 0093 end-to-end via the `runMigrations` count assertion. Not a Better-Auth-touching migration → not added to `MANAGED_AUTH_MIGRATIONS`

## Schema mirror

Pure INSERTs into existing tables — no `schema.ts` change needed. `check-schema-drift.sh` passes.

## Tests added

- `__tests__/datasource-pool-resolver.test.ts` — 25 cases: catalog-slug → db_type map (including `demo-postgres` → `postgres`), pillar guard, per-`db_type` PoolConfig shape, schema → init SQL translation, BigQuery field guards, optional pool-tuning passthrough, exhaustive coverage of every built-in slug, and a `decryptSecretFields` round-trip exercising the same encrypt/decrypt path slice 6 will use.
- `__tests__/seed-builtin-datasource-catalog.test.ts` — 17 cases: source-of-truth row content invariants, bulk-INSERT shape (single statement, `ON CONFLICT DO NOTHING`, `RETURNING slug`), inserted-vs-preserved accounting, error propagation, and cross-checks that the migration SQL and the seed module stay in lockstep.
- `__tests__/config-override-implementation-status.test.ts` — 7 cases: schema admit / reject + read-helper behavior.
- Updated `migrate.test.ts` + `auth/__tests__/migrate.test.ts` migration-count assertions (93 → 94) and `applied:` lists.

## Test plan

- [ ] CI is green on this PR (api-tests 1–4, Deploy Validation, drift checks, EE stub build)
- [ ] After merge: `migrate-pg.test.ts` should pass against the api-tests Postgres service container (covered by required check `api-tests (n/4)`)
- [ ] Spot-check the seed on a fresh DB: `bun run db:reset && bun run dev:api` should log `Built-in Datasource catalog seed complete` with `insertedCount: 8` on first boot, `preservedCount: 8` on subsequent boots
- [ ] No `/admin/connections` UX change in this slice — verified by inspection (no route handler changes; resolver + seed have zero production consumers)

## Follow-ups

- #2776 (filed during this slice's `/ci` run): `discord.test.ts` shows the same parallel-load flake as #2710 (`teams.test.ts`). Both pass in isolation; same root cause (env-var race on module-singleton route registration). Not caused by this slice — repros on clean main.

Closes #2743