### PR TITLE
feat(api,web): #2747 — Coming-soon catalog state + atlas.config.ts override consumer

### DIFF
--- a/deploy/api/atlas.config.ts
+++ b/deploy/api/atlas.config.ts
@@ -89,46 +89,59 @@ export default defineConfig({
       saas_eligible: true,
       min_plan: "starter",
     },
-    // ── 1.5.3 placeholders — visible to ops, not customer-installable ─
+    // ── 1.5.3 placeholders — visible to customers as "Coming soon" ─────
     // Per CONTEXT.md, each of these has Platform-specific install
     // subtleties (Teams Azure-AD + manifest, Discord per-guild routing,
     // Telegram chat_id capture, WhatsApp Meta verification, gchat Google
     // Workspace Marketplace). They get `install_model: 'static-bot'`
-    // per the install-handler spectrum.
+    // per the install-handler spectrum and ride into the catalog as
+    // `implementation_status: 'coming_soon'` (#2747) so the admin UI
+    // renders them with a grey "Coming soon" badge and an inert CTA —
+    // distinct from the upsell-lock state, since the gate is "Atlas
+    // hasn't shipped this" rather than "your plan doesn't admit it".
+    // `enabled: true` keeps them surfaced; the install-status state
+    // machine short-circuits ahead of the install-handler dispatch.
+    // Each row flips to `implementation_status: 'available'` in its
+    // own slice (10–16) when the handler ships.
     {
       slug: "teams",
       type: "chat",
       install_model: "static-bot",
-      enabled: false,
+      enabled: true,
       saas_eligible: true,
+      implementation_status: "coming_soon",
     },
     {
       slug: "discord",
       type: "chat",
       install_model: "static-bot",
-      enabled: false,
+      enabled: true,
       saas_eligible: true,
+      implementation_status: "coming_soon",
     },
     {
       slug: "gchat",
       type: "chat",
       install_model: "static-bot",
-      enabled: false,
+      enabled: true,
       saas_eligible: true,
+      implementation_status: "coming_soon",
     },
     {
       slug: "telegram",
       type: "chat",
       install_model: "static-bot",
-      enabled: false,
+      enabled: true,
       saas_eligible: true,
+      implementation_status: "coming_soon",
     },
     {
       slug: "whatsapp",
       type: "chat",
       install_model: "static-bot",
-      enabled: false,
+      enabled: true,
       saas_eligible: true,
+      implementation_status: "coming_soon",
     },
     // ── Lazy OAuth integrations (1.5.2 slice 8 — #2658 / #2659) ─────
     // Salesforce (#2658) established the pattern; Jira (#2659) proves

--- a/packages/api/src/lib/auth/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/auth/__tests__/migrate.test.ts
@@ -339,6 +339,7 @@ describe("migrateAuthTables", () => {
             { name: "0091_unify_catalog_min_plan.sql" },
             { name: "0092_pillar_install_id_columns.sql" },
             { name: "0093_builtin_datasource_catalog.sql" },
+            { name: "0094_placeholder_chat_coming_soon.sql" },
           ],
         };
       }

--- a/packages/api/src/lib/config.ts
+++ b/packages/api/src/lib/config.ts
@@ -347,6 +347,26 @@ const CatalogEntrySchema = z.object({
    */
   saas_eligible: z.boolean().optional().default(true),
   /**
+   * Whether Atlas has shipped a working install handler for this entry
+   * (#2747 / ADR-0007). `coming_soon` renders the row inert in the
+   * admin UI — grey "Coming soon" badge, no CTA — regardless of plan
+   * tier or install presence. The state-machine in
+   * `lib/integrations/install-status-machine.ts` treats this as the
+   * highest-priority gate.
+   *
+   * Defaults to `available` to preserve the pre-#2747 wire shape (every
+   * declared entry was implicitly shippable). Mark a row `coming_soon`
+   * when the catalog entry exists for visibility but the install path
+   * (handler, env vars, OAuth app, manifest) isn't ready — Teams,
+   * Discord, gchat, Telegram, WhatsApp in the 1.5.3 placeholder set.
+   *
+   * Self-host operators who've shipped their own handler for a row
+   * Atlas marks `coming_soon` can promote it via
+   * {@link AtlasConfig.overrideImplementationStatus} without forking
+   * the catalog.
+   */
+  implementation_status: z.enum(IMPLEMENTATION_STATUSES).optional().default("available"),
+  /**
    * Form-field declaration for `install_model: "form"` entries (#2660 —
    * Email, Webhook, Obsidian). Each entry describes a field rendered by
    * `/admin/integrations`' install modal and validated server-side at

--- a/packages/api/src/lib/db/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate.test.ts
@@ -105,8 +105,9 @@ describe("runMigrations", () => {
     // + 0090 (organization.is_operator_workspace flag, #2702)
     // + 0091 (unify catalog min_plan vocabulary, #2666)
     // + 0092 (pillar + install_id columns, #2739)
-    // + 0093 (built-in datasource catalog rows, #2743) = 94.
-    expect(count).toBe(94);
+    // + 0093 (built-in datasource catalog rows, #2743)
+    // + 0094 (promote placeholder chat rows to coming_soon, #2747) = 95.
+    expect(count).toBe(95);
 
     // Advisory lock acquired before anything else
     expect(queries[0]).toContain("pg_advisory_lock");
@@ -229,6 +230,7 @@ describe("runMigrations", () => {
         "0091_unify_catalog_min_plan.sql",
         "0092_pillar_install_id_columns.sql",
         "0093_builtin_datasource_catalog.sql",
+        "0094_placeholder_chat_coming_soon.sql",
       ],
     });
 

--- a/packages/api/src/lib/db/migrations/0094_placeholder_chat_coming_soon.sql
+++ b/packages/api/src/lib/db/migrations/0094_placeholder_chat_coming_soon.sql
@@ -17,18 +17,25 @@
 -- because the planner can't distinguish "config history said false"
 -- from "ops just disabled this".
 --
--- Idempotent: only updates rows that match the placeholder set AND
--- still hold the pre-#2747 state (`enabled = false AND
--- implementation_status = 'available'`). On self-host without these
--- rows declared the migration is a no-op (UPDATE affects 0 rows).
--- On a subsequent operator emergency-disable, the seeder's
--- preserve-disabled branch takes over and the migration doesn't
--- re-fire (the WHERE clause excludes already-promoted rows).
+-- Idempotent + operator-intent-safe: the WHERE clause has FOUR terms,
+-- each load-bearing:
+--   1. `slug IN (...)` — scope to the 1.5.2 placeholder set only
+--   2. `enabled = false` — pre-#2747 default state for these rows
+--   3. `implementation_status = 'available'` — pre-#2747 default state
+--   4. `updated_at = created_at` — row has NEVER been touched since
+--      the seed wrote it. This is the operator-intent guard: a
+--      self-host operator who disabled `discord` after slice-2 seeded
+--      it (catalog upsert bumps `updated_at` via `NOW()` on every
+--      write) keeps their `enabled = false` decision. Without this
+--      clause we'd un-disable rows the operator deliberately
+--      disabled — see PR-review feedback on #2782.
 --
--- Slices 10-16 (the individual chat-Platform install slices) flip
--- their row's `implementation_status` to `'available'` via the
--- atlas.config.ts edit + catalog seeder upsert — no further DB
--- migration needed.
+-- On self-host without these rows declared the migration is a no-op
+-- (UPDATE affects 0 rows). On any subsequent operator action the
+-- WHERE clause stops matching and re-runs are inert. Slices 10-16
+-- (the individual chat-Platform install slices) flip their row's
+-- `implementation_status` to `'available'` via the atlas.config.ts
+-- edit + catalog seeder upsert — no further DB migration needed.
 
 UPDATE plugin_catalog
 SET enabled = true,
@@ -36,4 +43,5 @@ SET enabled = true,
     updated_at = NOW()
 WHERE slug IN ('teams', 'discord', 'gchat', 'telegram', 'whatsapp')
   AND enabled = false
-  AND implementation_status = 'available';
+  AND implementation_status = 'available'
+  AND updated_at = created_at;

--- a/packages/api/src/lib/db/migrations/0094_placeholder_chat_coming_soon.sql
+++ b/packages/api/src/lib/db/migrations/0094_placeholder_chat_coming_soon.sql
@@ -1,0 +1,39 @@
+-- 0094_placeholder_chat_coming_soon.sql
+--
+-- 1.5.3 slice 9 (#2747 / PRD #2738 / ADR-0007) — one-time DB nudge for
+-- the five chat-Platform placeholders shipped as `enabled=false` in
+-- 1.5.2's catalog declaration (Teams / Discord / gchat / Telegram /
+-- WhatsApp). Slice 9 promotes them to `enabled=true,
+-- implementation_status='coming_soon'` so they render as visible,
+-- inert "Coming soon" cards in `/admin/integrations` per the slice-9
+-- UX deliverable.
+--
+-- Why a migration instead of letting the catalog seeder do it: the
+-- seeder's `planCatalogSeed` planner contains a "preserve-disabled"
+-- branch (DB `enabled=false` beats config `enabled=true`) intended to
+-- protect operator emergency-disables. Without this migration the
+-- placeholder rows would stay stuck at `enabled=false` on next boot
+-- even after deploy/api/atlas.config.ts flips to `enabled=true`,
+-- because the planner can't distinguish "config history said false"
+-- from "ops just disabled this".
+--
+-- Idempotent: only updates rows that match the placeholder set AND
+-- still hold the pre-#2747 state (`enabled = false AND
+-- implementation_status = 'available'`). On self-host without these
+-- rows declared the migration is a no-op (UPDATE affects 0 rows).
+-- On a subsequent operator emergency-disable, the seeder's
+-- preserve-disabled branch takes over and the migration doesn't
+-- re-fire (the WHERE clause excludes already-promoted rows).
+--
+-- Slices 10-16 (the individual chat-Platform install slices) flip
+-- their row's `implementation_status` to `'available'` via the
+-- atlas.config.ts edit + catalog seeder upsert — no further DB
+-- migration needed.
+
+UPDATE plugin_catalog
+SET enabled = true,
+    implementation_status = 'coming_soon',
+    updated_at = NOW()
+WHERE slug IN ('teams', 'discord', 'gchat', 'telegram', 'whatsapp')
+  AND enabled = false
+  AND implementation_status = 'available';

--- a/packages/api/src/lib/effect/__tests__/layers.test.ts
+++ b/packages/api/src/lib/effect/__tests__/layers.test.ts
@@ -17,6 +17,10 @@ import {
   buildAppLayer,
   DpaGuardLive,
   MigrationGuardLive,
+  ImplementationStatusOverride,
+  ImplementationStatusOverrideLive,
+  CatalogSeed,
+  BuiltinDatasourceCatalogSeed,
   type ConfigShape,
   type MigrationShape,
   type SettingsShape,
@@ -658,4 +662,68 @@ describe("buildAppLayer", () => {
   // to it. Per-#1988-guard end-to-end tests would force the same
   // real-DB-URL workaround for marginal additional coverage beyond the
   // existing unit-level guard tests.
+});
+
+// ── ImplementationStatusOverrideLive (#2747 — 1.5.3 slice 9) ──────────
+
+describe("ImplementationStatusOverrideLive", () => {
+  // The Tag dependencies on `CatalogSeed` + `BuiltinDatasourceCatalogSeed`
+  // encode the "override-runs-after-both-seeds" ordering. The two stubs
+  // below are accepted by the Layer's Effect.gen even though their
+  // values are never read — the `yield* CatalogSeed; yield*
+  // BuiltinDatasourceCatalogSeed` lines in the Live impl are
+  // load-bearing for ordering, not for value, and removing them would
+  // race the catalog-seeder's `EXCLUDED.implementation_status` upsert
+  // against our UPDATEs.
+  const seedStubLayer = Layer.merge(
+    Layer.succeed(CatalogSeed, {
+      insertedCount: 0,
+      updatedCount: 0,
+      preservedCount: 0,
+      orphanSlugs: [],
+      outcome: "seeded" as const,
+    }),
+    Layer.succeed(BuiltinDatasourceCatalogSeed, {
+      insertedSlugs: [],
+      preservedSlugs: [],
+      outcome: "seeded" as const,
+    }),
+  );
+
+  function runOverride(gates: { available: boolean; migrated: boolean }) {
+    const layer = ImplementationStatusOverrideLive.pipe(
+      Layer.provide(
+        Layer.mergeAll(
+          createInternalDBTestLayer({ available: gates.available }),
+          makeTestMigrationLayer({ migrated: gates.migrated }),
+          seedStubLayer,
+        ),
+      ),
+    );
+    return Effect.runPromise(
+      Effect.gen(function* () {
+        return yield* ImplementationStatusOverride;
+      }).pipe(Effect.provide(layer)),
+    );
+  }
+
+  test("outcome 'skipped-gate' when InternalDB is unavailable (gate path)", async () => {
+    const result = await runOverride({ available: false, migrated: true });
+    expect(result.outcome).toBe("skipped-gate");
+    expect(result.updatedCount).toBe(0);
+    expect(result.error).toBeUndefined();
+  });
+
+  test("outcome 'skipped-gate' when Migration has not run", async () => {
+    const result = await runOverride({ available: true, migrated: false });
+    expect(result.outcome).toBe("skipped-gate");
+    expect(result.updatedCount).toBe(0);
+  });
+
+  // Note: gates-pass paths (`skipped-empty` / `applied` / `error`) are
+  // covered by `runImplementationStatusOverrideBoot (discriminated
+  // outcomes)` in `lib/integrations/__tests__/implementation-status-override.test.ts`.
+  // The wrapper covers the boot-time side of the contract; this Layer
+  // test covers only the upstream-gate branch that can't be reached
+  // from the wrapper alone.
 });

--- a/packages/api/src/lib/effect/layers.ts
+++ b/packages/api/src/lib/effect/layers.ts
@@ -639,10 +639,35 @@ export const ImplementationStatusOverrideLive: Layer.Layer<
         const result = await runImplementationStatusOverrideBoot();
         switch (result.kind) {
           case "skipped":
-            return {
-              ...zeroCounts,
-              outcome: "skipped-empty",
-            } satisfies ImplementationStatusOverrideShape;
+            // Three skip reasons, two outcomes:
+            //   - `no-internal-db` should be unreachable here (the Layer's
+            //     `!db.available` gate above already caught it), but if a
+            //     future refactor decouples the gate from the wrapper this
+            //     surfaces as `skipped-gate` instead of mislabelling.
+            //   - `no-config` mid-boot is genuinely unexpected — the Config
+            //     Tag should have loaded by the time the override Layer
+            //     runs — so surface as `error` for health visibility.
+            //   - `empty-override` is the SaaS-norm path and the explicit
+            //     "operator declared nothing" path on self-host.
+            switch (result.reason) {
+              case "no-internal-db":
+                return {
+                  ...zeroCounts,
+                  outcome: "skipped-gate",
+                } satisfies ImplementationStatusOverrideShape;
+              case "no-config":
+                return {
+                  ...zeroCounts,
+                  outcome: "error",
+                  error: "Implementation-status override: no resolved config at post-seed boot phase",
+                } satisfies ImplementationStatusOverrideShape;
+              case "empty-override":
+                return {
+                  ...zeroCounts,
+                  outcome: "skipped-empty",
+                } satisfies ImplementationStatusOverrideShape;
+            }
+            break;
           case "applied":
             return {
               updatedCount: result.updatedCount,
@@ -653,7 +678,11 @@ export const ImplementationStatusOverrideLive: Layer.Layer<
             return {
               ...zeroCounts,
               outcome: "error",
-              error: result.message,
+              // Scrub the wrapper's message at the Layer boundary —
+              // a pg connection-string echo in the underlying error
+              // shouldn't survive into the Tag value the health
+              // surface reads.
+              error: errorMessage(new Error(result.message)),
             } satisfies ImplementationStatusOverrideShape;
         }
       },

--- a/packages/api/src/lib/effect/layers.ts
+++ b/packages/api/src/lib/effect/layers.ts
@@ -552,6 +552,126 @@ export const BuiltinDatasourceCatalogSeedLive: Layer.Layer<
 );
 
 // ══════════════════════════════════════════════════════════════════════
+// ██  Implementation-Status Override Layer (#2747 — 1.5.3 slice 9)
+// ══════════════════════════════════════════════════════════════════════
+
+/**
+ * Discriminated outcome of the boot-time
+ * `overrideImplementationStatus` consumer. Mirrors the two seed
+ * Layers' shapes so a future `/health` consumer can treat the three
+ * post-seed outcomes (skipped, applied, error) uniformly.
+ */
+export type ImplementationStatusOverrideOutcome =
+  | "skipped-gate"
+  | "skipped-empty"
+  | "applied"
+  | "error";
+
+export interface ImplementationStatusOverrideShape {
+  /** UPDATEs issued this boot. */
+  readonly updatedCount: number;
+  /** Slugs in the override that didn't match a catalog row. */
+  readonly unmatchedSlugs: ReadonlyArray<string>;
+  readonly outcome: ImplementationStatusOverrideOutcome;
+  /** Scrubbed error message when `outcome === "error"`. */
+  readonly error?: string;
+}
+
+export class ImplementationStatusOverride extends Context.Tag(
+  "ImplementationStatusOverride",
+)<ImplementationStatusOverride, ImplementationStatusOverrideShape>() {}
+
+/**
+ * Apply `atlas.config.ts:overrideImplementationStatus` against
+ * `plugin_catalog`. Runs after BOTH seed Layers complete so the
+ * override is the final word for `implementation_status` on the
+ * boot — a re-asserting `EXCLUDED.implementation_status` from the
+ * catalog seeder cannot land afterward. The Tag dependencies on
+ * `CatalogSeed` + `BuiltinDatasourceCatalogSeed` encode the
+ * ordering at the type level.
+ *
+ * Non-fatal: the boot wrapper swallows errors and logs at error so
+ * a failed override leaves the seed output authoritative. The
+ * failure is observable via `outcome: "error"` for health surfaces.
+ *
+ * **SaaS:** every catalog row's `implementation_status` is declared
+ * directly in `deploy/api/atlas.config.ts:catalog`; the override
+ * field stays empty and this Layer logs `skipped-empty`. Slice 9's
+ * primary user is the self-host operator who shipped their own
+ * handler for a Platform Atlas marks `coming_soon`.
+ */
+export const ImplementationStatusOverrideLive: Layer.Layer<
+  ImplementationStatusOverride,
+  never,
+  InternalDB | Migration | CatalogSeed | BuiltinDatasourceCatalogSeed
+> = Layer.effect(
+  ImplementationStatusOverride,
+  Effect.gen(function* () {
+    const db = yield* InternalDB;
+    const migration = yield* Migration;
+    // Yielding the two seed Tags is the load-bearing line — Effect
+    // memoizes the same-Tag layers, so adding them here doesn't
+    // re-run the seeds. The dependency *ordering* is what we need.
+    yield* CatalogSeed;
+    yield* BuiltinDatasourceCatalogSeed;
+
+    const zeroCounts = {
+      updatedCount: 0,
+      unmatchedSlugs: [] as ReadonlyArray<string>,
+    };
+
+    if (!db.available || !migration.migrated) {
+      log.info(
+        { available: db.available, migrated: migration.migrated },
+        "Implementation-status override skipped — upstream gate not satisfied",
+      );
+      return {
+        ...zeroCounts,
+        outcome: "skipped-gate",
+      } satisfies ImplementationStatusOverrideShape;
+    }
+
+    return yield* Effect.tryPromise({
+      try: async () => {
+        const { runImplementationStatusOverrideBoot } = await import(
+          "@atlas/api/lib/integrations/implementation-status-override"
+        );
+        const result = await runImplementationStatusOverrideBoot();
+        switch (result.kind) {
+          case "skipped":
+            return {
+              ...zeroCounts,
+              outcome: "skipped-empty",
+            } satisfies ImplementationStatusOverrideShape;
+          case "applied":
+            return {
+              updatedCount: result.updatedCount,
+              unmatchedSlugs: result.unmatchedSlugs,
+              outcome: "applied",
+            } satisfies ImplementationStatusOverrideShape;
+          case "error":
+            return {
+              ...zeroCounts,
+              outcome: "error",
+              error: result.message,
+            } satisfies ImplementationStatusOverrideShape;
+        }
+      },
+      catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+    }).pipe(
+      Effect.catchAll((err) => {
+        log.error({ err }, "Implementation-status override boot wrapper threw");
+        return Effect.succeed({
+          ...zeroCounts,
+          outcome: "error",
+          error: errorMessage(err),
+        } satisfies ImplementationStatusOverrideShape);
+      }),
+    );
+  }),
+);
+
+// ══════════════════════════════════════════════════════════════════════
 // ██  Connections Hydrate Layer
 // ══════════════════════════════════════════════════════════════════════
 
@@ -1409,6 +1529,7 @@ export function buildAppLayer(config: ResolvedConfig): Layer.Layer<
   | BackfillSaasTrial
   | CatalogSeed
   | BuiltinDatasourceCatalogSeed
+  | ImplementationStatusOverride
   | ConnectionsHydrate
   | SemanticSync
   | Settings
@@ -1444,6 +1565,22 @@ export function buildAppLayer(config: ResolvedConfig): Layer.Layer<
   // slug sets so ordering between them doesn't matter.
   const builtinDatasourceCatalogSeedLayer = BuiltinDatasourceCatalogSeedLive.pipe(
     Layer.provide(Layer.merge(internalDBLayer, migrationLayer)),
+  );
+
+  // ImplementationStatusOverrideLive (#2747, slice 9) — depends on
+  // BOTH seed Layers so the override is applied AFTER both finish
+  // (the catalog seeder's upsert would otherwise clobber it). The
+  // dependency edge enforces ordering at the type level; Effect's
+  // memoization keeps the seed Layers from running twice.
+  const implementationStatusOverrideLayer = ImplementationStatusOverrideLive.pipe(
+    Layer.provide(
+      Layer.mergeAll(
+        internalDBLayer,
+        migrationLayer,
+        catalogSeedLayer,
+        builtinDatasourceCatalogSeedLayer,
+      ),
+    ),
   );
 
   const connectionsHydrateLayer = ConnectionsHydrateLive.pipe(
@@ -1508,6 +1645,7 @@ export function buildAppLayer(config: ResolvedConfig): Layer.Layer<
     backfillSaasTrialLayer,
     catalogSeedLayer,
     builtinDatasourceCatalogSeedLayer,
+    implementationStatusOverrideLayer,
     connectionsHydrateLayer,
     semanticSyncLayer,
     settingsLayer,

--- a/packages/api/src/lib/integrations/__tests__/catalog-seeder.test.ts
+++ b/packages/api/src/lib/integrations/__tests__/catalog-seeder.test.ts
@@ -43,6 +43,7 @@ function entry(partial: Partial<CatalogEntry> & Pick<CatalogEntry, "slug">): Cat
     min_plan: "starter",
     enabled: true,
     saas_eligible: true,
+    implementation_status: "available",
     ...partial,
   };
 }
@@ -57,6 +58,7 @@ function row(partial: Partial<CatalogDbRow> & Pick<CatalogDbRow, "slug">): Catal
     enabled: true,
     installModel: "oauth",
     saasEligible: true,
+    implementationStatus: "available",
     configSchema: null,
     ...partial,
   };
@@ -105,6 +107,7 @@ function makeMockDb(seed: CatalogDbRow[] = []): {
           enabled,
           installModel,
           saasEligible,
+          implementationStatus,
           configSchemaJson,
         ] = ps as [
           string,
@@ -117,6 +120,7 @@ function makeMockDb(seed: CatalogDbRow[] = []): {
           boolean,
           string,
           boolean,
+          string,
           string | null,
         ];
         const existing = rows.findIndex((r) => r.slug === slug);
@@ -139,6 +143,7 @@ function makeMockDb(seed: CatalogDbRow[] = []): {
           enabled,
           installModel: installModel as CatalogDbRow["installModel"],
           saasEligible,
+          implementationStatus: implementationStatus as CatalogDbRow["implementationStatus"],
           configSchema: configSchemaJson === null ? null : JSON.parse(configSchemaJson),
         };
         if (existing === -1) rows.push(next);
@@ -163,6 +168,7 @@ function snapshotRaw(rows: CatalogDbRow[]): Array<{
   enabled: boolean;
   install_model: string;
   saas_eligible: boolean;
+  implementation_status: string;
   config_schema: unknown | null;
 }> {
   return rows.map((r) => ({
@@ -175,6 +181,7 @@ function snapshotRaw(rows: CatalogDbRow[]): Array<{
     enabled: r.enabled,
     install_model: r.installModel,
     saas_eligible: r.saasEligible,
+    implementation_status: r.implementationStatus,
     config_schema: r.configSchema,
   }));
 }
@@ -278,6 +285,53 @@ describe("planCatalogSeed", () => {
     if (action.action === "update") {
       expect(action.diff).toContain("configSchema");
     }
+  });
+
+  // #2747 — implementation_status is a new diff axis. The diff must
+  // catch a config change (so a slice 10–16 flip from `coming_soon` to
+  // `available` propagates) AND treat matching values as noop (so a
+  // re-boot with unchanged config doesn't bump every row's updated_at).
+  it("flags implementation_status as diff'd when config promotes coming_soon → available", () => {
+    const plan = planCatalogSeed(
+      [
+        entry({
+          slug: "discord",
+          install_model: "static-bot",
+          implementation_status: "available",
+        }),
+      ],
+      [row({ slug: "discord", installModel: "static-bot", implementationStatus: "coming_soon" })],
+    );
+    expect(plan.actions[0]?.action).toBe("update");
+    const action = plan.actions[0];
+    if (action.action === "update") {
+      expect(action.diff).toContain("implementationStatus");
+    }
+  });
+
+  it("treats matching implementation_status as noop", () => {
+    // Pin matching `name` on both sides — `entry()`'s undefined `name`
+    // derives "Discord" from the slug while `row()` defaults to "Slack",
+    // which would diff on the name column and obscure the assertion.
+    const plan = planCatalogSeed(
+      [
+        entry({
+          slug: "discord",
+          name: "Discord",
+          install_model: "static-bot",
+          implementation_status: "coming_soon",
+        }),
+      ],
+      [
+        row({
+          slug: "discord",
+          name: "Discord",
+          installModel: "static-bot",
+          implementationStatus: "coming_soon",
+        }),
+      ],
+    );
+    expect(plan.actions[0]?.action).toBe("noop");
   });
 
   it("treats matching configSchema arrays as no-op (key-order-independent compare)", () => {
@@ -384,6 +438,24 @@ describe("seedCatalog", () => {
     ]);
     expect(rows.find((r) => r.slug === "slack")?.saasEligible).toBe(true);
     expect(rows.find((r) => r.slug === "github-pat")?.saasEligible).toBe(false);
+  });
+
+  // #2747 — slice 9's "Default catalog values" acceptance criterion:
+  // unimplemented platforms declared with `implementation_status:
+  // 'coming_soon'` land in `plugin_catalog.implementation_status`
+  // as `'coming_soon'`, while shipped rows default to `'available'`.
+  it("propagates implementation_status from config to DB row (slice 9 #2747)", async () => {
+    const { db, rows } = makeMockDb([]);
+    await seedCatalog(db, [
+      entry({ slug: "slack" }), // default: implementation_status='available'
+      entry({
+        slug: "discord",
+        install_model: "static-bot",
+        implementation_status: "coming_soon",
+      }),
+    ]);
+    expect(rows.find((r) => r.slug === "slack")?.implementationStatus).toBe("available");
+    expect(rows.find((r) => r.slug === "discord")?.implementationStatus).toBe("coming_soon");
   });
 
   it("preserves ops-disabled state on re-seed (config drift logged at warn)", async () => {

--- a/packages/api/src/lib/integrations/__tests__/implementation-status-override.test.ts
+++ b/packages/api/src/lib/integrations/__tests__/implementation-status-override.test.ts
@@ -14,7 +14,7 @@
  * and `BuiltinDatasourceCatalogSeed`.
  */
 
-import { describe, it, expect } from "bun:test";
+import { describe, it, expect, mock, afterEach } from "bun:test";
 import {
   planImplementationStatusOverride,
   applyImplementationStatusOverride,
@@ -31,18 +31,47 @@ interface Captured {
   params: unknown[];
 }
 
-function makeMockDb(catalog: CurrentCatalogRow[]): {
+/**
+ * Mock pool that emulates pg's BEGIN/COMMIT/ROLLBACK transactions.
+ * UPDATEs inside a BEGIN write to `pending` instead of `rows`; on
+ * COMMIT they merge in, on ROLLBACK they drop. This is enough fidelity
+ * to assert the override consumer's atomicity guarantee.
+ *
+ * `failOnUpdateFor` (optional) — slug for which the mock throws on
+ * UPDATE. Used to exercise the rollback path.
+ */
+function makeMockDb(
+  catalog: CurrentCatalogRow[],
+  opts: { failOnUpdateFor?: string } = {},
+): {
   db: ImplementationStatusOverrideDb;
   captured: Captured[];
   rows: CurrentCatalogRow[];
 } {
   const rows = [...catalog];
   const captured: Captured[] = [];
+  let pending: CurrentCatalogRow[] | null = null;
 
   const db: ImplementationStatusOverrideDb = {
     async query<T = unknown>(sql: string, params?: unknown[]) {
       const ps = params ?? [];
       captured.push({ sql, params: ps });
+
+      if (sql === "BEGIN") {
+        pending = [...rows];
+        return { rows: [] as T[] };
+      }
+      if (sql === "COMMIT") {
+        if (pending !== null) {
+          rows.splice(0, rows.length, ...pending);
+          pending = null;
+        }
+        return { rows: [] as T[] };
+      }
+      if (sql === "ROLLBACK") {
+        pending = null;
+        return { rows: [] as T[] };
+      }
 
       if (sql.includes("SELECT slug, implementation_status")) {
         return {
@@ -54,9 +83,13 @@ function makeMockDb(catalog: CurrentCatalogRow[]): {
       }
       if (sql.includes("UPDATE plugin_catalog")) {
         const [to, slug] = ps as [string, string];
-        const idx = rows.findIndex((r) => r.slug === slug);
+        if (opts.failOnUpdateFor === slug) {
+          throw new Error(`Mock: simulated UPDATE failure for slug=${slug}`);
+        }
+        const target = pending ?? rows;
+        const idx = target.findIndex((r) => r.slug === slug);
         if (idx !== -1) {
-          rows[idx] = {
+          target[idx] = {
             slug,
             implementationStatus: to as CurrentCatalogRow["implementationStatus"],
           };
@@ -210,5 +243,257 @@ describe("applyImplementationStatusOverride", () => {
     });
     expect(result.updatedCount).toBe(1); // discord only
     expect(result.unmatchedSlugs).toEqual(["legacy"]);
+  });
+
+  it("flips a slug back and forth across two passes", async () => {
+    // Boot-cycle regression guard: the UPDATE must drive the row to
+    // whatever the override declares, not just toward `coming_soon`
+    // or just toward `available`. A copy-paste regression that pinned
+    // one direction would silently break override-flips on subsequent
+    // deploys.
+    const { db, rows } = makeMockDb([
+      { slug: "discord", implementationStatus: "coming_soon" },
+    ]);
+
+    await applyImplementationStatusOverride(db, { discord: "available" });
+    expect(rows.find((r) => r.slug === "discord")?.implementationStatus).toBe(
+      "available",
+    );
+
+    await applyImplementationStatusOverride(db, { discord: "coming_soon" });
+    expect(rows.find((r) => r.slug === "discord")?.implementationStatus).toBe(
+      "coming_soon",
+    );
+  });
+
+  it("operates on built-in datasource rows (the Layer's BuiltinDatasourceCatalogSeed dep invites this)", async () => {
+    // The override consumer does NOT filter by pillar — `SELECT slug,
+    // implementation_status FROM plugin_catalog` is pillar-agnostic.
+    // A self-host operator who's deliberately marking the demo
+    // dataset `coming_soon` (e.g. it's wedged) should be able to.
+    // Pinning the contract: any catalog slug is a valid override
+    // target, including the built-in Datasource set.
+    const { db, captured, rows } = makeMockDb([
+      { slug: "demo-postgres", implementationStatus: "available" },
+    ]);
+    const result = await applyImplementationStatusOverride(db, {
+      "demo-postgres": "coming_soon",
+    });
+    expect(result.updatedCount).toBe(1);
+    expect(rows[0]!.implementationStatus).toBe("coming_soon");
+    const updates = captured.filter((c) =>
+      c.sql.includes("UPDATE plugin_catalog"),
+    );
+    expect(updates[0]!.params).toEqual(["coming_soon", "demo-postgres"]);
+  });
+
+  it("wraps multi-slug UPDATEs in a single transaction (BEGIN/COMMIT)", async () => {
+    // Codex P2 on #2782: a mid-loop failure must not leave a partial
+    // override applied. Assert the boundary commands fire so the
+    // atomic semantic is pinned by a structural test.
+    const { db, captured } = makeMockDb([
+      { slug: "discord", implementationStatus: "coming_soon" },
+      { slug: "teams", implementationStatus: "coming_soon" },
+    ]);
+    await applyImplementationStatusOverride(db, {
+      discord: "available",
+      teams: "available",
+    });
+    const sqls = captured.map((c) => c.sql);
+    const beginIdx = sqls.indexOf("BEGIN");
+    const commitIdx = sqls.indexOf("COMMIT");
+    expect(beginIdx).toBeGreaterThanOrEqual(0);
+    expect(commitIdx).toBeGreaterThan(beginIdx);
+    // Both UPDATEs land between BEGIN and COMMIT.
+    const updateIdxs = sqls
+      .map((s, i) => (s.includes("UPDATE plugin_catalog") ? i : -1))
+      .filter((i) => i !== -1);
+    expect(updateIdxs).toHaveLength(2);
+    for (const idx of updateIdxs) {
+      expect(idx).toBeGreaterThan(beginIdx);
+      expect(idx).toBeLessThan(commitIdx);
+    }
+  });
+
+  it("rolls back partial updates on mid-loop failure (atomicity guarantee)", async () => {
+    // Critical regression guard for the codex P2 atomicity contract.
+    // First UPDATE succeeds, second fails — the mock would otherwise
+    // leave `discord` flipped. Wrapping in BEGIN/ROLLBACK ensures the
+    // catalog is restored to its pre-boot state.
+    const { db, rows, captured } = makeMockDb(
+      [
+        { slug: "discord", implementationStatus: "coming_soon" },
+        { slug: "teams", implementationStatus: "coming_soon" },
+      ],
+      { failOnUpdateFor: "teams" },
+    );
+
+    await expect(
+      applyImplementationStatusOverride(db, {
+        discord: "available",
+        teams: "available",
+      }),
+    ).rejects.toThrow(/simulated UPDATE failure/);
+
+    // Neither row should be flipped — discord's pending UPDATE was
+    // rolled back, teams's throw never landed.
+    expect(rows.find((r) => r.slug === "discord")?.implementationStatus).toBe(
+      "coming_soon",
+    );
+    expect(rows.find((r) => r.slug === "teams")?.implementationStatus).toBe(
+      "coming_soon",
+    );
+    expect(captured.map((c) => c.sql)).toContain("ROLLBACK");
+    expect(captured.map((c) => c.sql)).not.toContain("COMMIT");
+  });
+
+  it("skips BEGIN/COMMIT entirely when there are no actions (no transaction overhead)", async () => {
+    const { db, captured } = makeMockDb([
+      { slug: "discord", implementationStatus: "coming_soon" },
+    ]);
+    await applyImplementationStatusOverride(db, {
+      discord: "coming_soon", // noop — already at target
+    });
+    const sqls = captured.map((c) => c.sql);
+    expect(sqls).not.toContain("BEGIN");
+    expect(sqls).not.toContain("COMMIT");
+  });
+
+  it("operator typo'd casing surfaces in unmatchedSlugs (case-sensitive slug compare)", async () => {
+    // The planner docstring claims case-sensitive — pin it so a future
+    // refactor that lowercases the override map silently doesn't widen
+    // the match surface.
+    const { db } = makeMockDb([
+      { slug: "discord", implementationStatus: "coming_soon" },
+    ]);
+    const result = await applyImplementationStatusOverride(db, {
+      Discord: "available",
+    });
+    expect(result.updatedCount).toBe(0);
+    expect(result.unmatchedSlugs).toEqual(["Discord"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runImplementationStatusOverrideBoot (discriminated outcomes)
+// ---------------------------------------------------------------------------
+
+describe("runImplementationStatusOverrideBoot (discriminated outcomes)", () => {
+  // Mirrors the `runBuiltinDatasourceCatalogSeedBoot` test block in
+  // `db/__tests__/seed-builtin-datasource-catalog.test.ts`. The wrapper
+  // sits between the Effect Layer and the pure `applyImplementationStatusOverride`
+  // function; each of its four outcomes (`skipped:no-internal-db`,
+  // `skipped:no-config`, `skipped:empty-override`, `applied`, `error`)
+  // is the source of truth the Layer maps to its `outcome` field. A
+  // regression that mismaps one of these would silently break the
+  // health surface.
+
+  const mockQuery = mock<
+    (sql: string, params?: unknown[]) => Promise<{ rows: unknown[] }>
+  >(() => Promise.resolve({ rows: [] }));
+
+  let hasInternalDBReturns = true;
+  let configReturns: { overrideImplementationStatus?: Record<string, "available" | "coming_soon"> } | null = {};
+
+  mock.module("@atlas/api/lib/db/internal", () => ({
+    hasInternalDB: () => hasInternalDBReturns,
+    getInternalDB: () => ({ query: mockQuery }),
+  }));
+
+  mock.module("@atlas/api/lib/config", () => ({
+    getConfig: () => configReturns,
+  }));
+
+  afterEach(() => {
+    mockQuery.mockClear();
+    hasInternalDBReturns = true;
+    configReturns = {};
+  });
+
+  it("returns `{ kind: 'skipped', reason: 'no-internal-db' }` when no internal DB is configured", async () => {
+    hasInternalDBReturns = false;
+    const { runImplementationStatusOverrideBoot } = await import(
+      "@atlas/api/lib/integrations/implementation-status-override"
+    );
+    const result = await runImplementationStatusOverrideBoot();
+    expect(result.kind).toBe("skipped");
+    if (result.kind === "skipped") expect(result.reason).toBe("no-internal-db");
+    // Pool must NOT be queried in the skip path — guarding against a
+    // regression that drops the gate and tries to acquire a connection
+    // on a self-host without internal DB.
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  it("returns `{ kind: 'skipped', reason: 'no-config' }` when getConfig() returns null", async () => {
+    configReturns = null;
+    const { runImplementationStatusOverrideBoot } = await import(
+      "@atlas/api/lib/integrations/implementation-status-override"
+    );
+    const result = await runImplementationStatusOverrideBoot();
+    expect(result.kind).toBe("skipped");
+    if (result.kind === "skipped") expect(result.reason).toBe("no-config");
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  it("returns `{ kind: 'skipped', reason: 'empty-override' }` when override map is empty", async () => {
+    configReturns = { overrideImplementationStatus: {} };
+    const { runImplementationStatusOverrideBoot } = await import(
+      "@atlas/api/lib/integrations/implementation-status-override"
+    );
+    const result = await runImplementationStatusOverrideBoot();
+    expect(result.kind).toBe("skipped");
+    if (result.kind === "skipped") expect(result.reason).toBe("empty-override");
+    // Empty-override should NOT issue the SELECT — fast path so SaaS
+    // boots stay cheap (the override field is always empty on SaaS).
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  it("returns `{ kind: 'applied' }` on a successful override", async () => {
+    configReturns = { overrideImplementationStatus: { discord: "available" } };
+    mockQuery.mockImplementation((sql) => {
+      if (sql.includes("SELECT slug, implementation_status")) {
+        return Promise.resolve({
+          rows: [{ slug: "discord", implementation_status: "coming_soon" }],
+        });
+      }
+      return Promise.resolve({ rows: [] });
+    });
+    const { runImplementationStatusOverrideBoot } = await import(
+      "@atlas/api/lib/integrations/implementation-status-override"
+    );
+    const result = await runImplementationStatusOverrideBoot();
+    expect(result.kind).toBe("applied");
+    if (result.kind === "applied") {
+      expect(result.updatedCount).toBe(1);
+      expect(result.unmatchedSlugs).toEqual([]);
+    }
+  });
+
+  it("returns `{ kind: 'error' }` when the pool query throws", async () => {
+    configReturns = { overrideImplementationStatus: { discord: "available" } };
+    mockQuery.mockImplementation(() =>
+      Promise.reject(new Error("simulated pg failure")),
+    );
+    const { runImplementationStatusOverrideBoot } = await import(
+      "@atlas/api/lib/integrations/implementation-status-override"
+    );
+    const result = await runImplementationStatusOverrideBoot();
+    expect(result.kind).toBe("error");
+    if (result.kind === "error") {
+      expect(result.message).toContain("simulated pg failure");
+    }
+  });
+
+  it("normalizes a non-Error throw to a string message", async () => {
+    configReturns = { overrideImplementationStatus: { discord: "available" } };
+    mockQuery.mockImplementation(() => Promise.reject("just a string"));
+    const { runImplementationStatusOverrideBoot } = await import(
+      "@atlas/api/lib/integrations/implementation-status-override"
+    );
+    const result = await runImplementationStatusOverrideBoot();
+    expect(result.kind).toBe("error");
+    if (result.kind === "error") {
+      expect(result.message).toContain("just a string");
+    }
   });
 });

--- a/packages/api/src/lib/integrations/__tests__/implementation-status-override.test.ts
+++ b/packages/api/src/lib/integrations/__tests__/implementation-status-override.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Tests for `applyImplementationStatusOverride` (1.5.3 slice 9 #2747).
+ *
+ * Two surfaces under test:
+ *
+ *   - `planImplementationStatusOverride` (pure) — input/output, no mocks.
+ *   - `applyImplementationStatusOverride` (DB driver) — drives a
+ *     hand-rolled mock, asserts UPDATE params and slug matching.
+ *
+ * The override is the LAST writer on `plugin_catalog.implementation_status`
+ * for the boot — anything that runs after this point would clobber it.
+ * The Effect Layer (`ImplementationStatusOverrideLive` in
+ * `effect/layers.ts`) enforces this by depending on both `CatalogSeed`
+ * and `BuiltinDatasourceCatalogSeed`.
+ */
+
+import { describe, it, expect } from "bun:test";
+import {
+  planImplementationStatusOverride,
+  applyImplementationStatusOverride,
+  type CurrentCatalogRow,
+  type ImplementationStatusOverrideDb,
+} from "../implementation-status-override";
+
+// ---------------------------------------------------------------------------
+// Mock DB
+// ---------------------------------------------------------------------------
+
+interface Captured {
+  sql: string;
+  params: unknown[];
+}
+
+function makeMockDb(catalog: CurrentCatalogRow[]): {
+  db: ImplementationStatusOverrideDb;
+  captured: Captured[];
+  rows: CurrentCatalogRow[];
+} {
+  const rows = [...catalog];
+  const captured: Captured[] = [];
+
+  const db: ImplementationStatusOverrideDb = {
+    async query<T = unknown>(sql: string, params?: unknown[]) {
+      const ps = params ?? [];
+      captured.push({ sql, params: ps });
+
+      if (sql.includes("SELECT slug, implementation_status")) {
+        return {
+          rows: rows.map((r) => ({
+            slug: r.slug,
+            implementation_status: r.implementationStatus,
+          })) as T[],
+        };
+      }
+      if (sql.includes("UPDATE plugin_catalog")) {
+        const [to, slug] = ps as [string, string];
+        const idx = rows.findIndex((r) => r.slug === slug);
+        if (idx !== -1) {
+          rows[idx] = {
+            slug,
+            implementationStatus: to as CurrentCatalogRow["implementationStatus"],
+          };
+        }
+        return { rows: [] as T[] };
+      }
+      return { rows: [] as T[] };
+    },
+  };
+  return { db, captured, rows };
+}
+
+// ---------------------------------------------------------------------------
+// planImplementationStatusOverride (pure)
+// ---------------------------------------------------------------------------
+
+describe("planImplementationStatusOverride", () => {
+  it("emits an UPDATE action for every slug whose current status differs", () => {
+    const plan = planImplementationStatusOverride(
+      { discord: "available", teams: "coming_soon" },
+      [
+        { slug: "discord", implementationStatus: "coming_soon" },
+        { slug: "teams", implementationStatus: "available" },
+      ],
+    );
+    expect(plan.actions).toHaveLength(2);
+    expect(plan.actions).toContainEqual({
+      slug: "discord",
+      from: "coming_soon",
+      to: "available",
+    });
+    expect(plan.actions).toContainEqual({
+      slug: "teams",
+      from: "available",
+      to: "coming_soon",
+    });
+    expect(plan.unmatchedSlugs).toEqual([]);
+    expect(plan.noopSlugs).toEqual([]);
+  });
+
+  it("skips slugs already at the declared status", () => {
+    const plan = planImplementationStatusOverride(
+      { discord: "coming_soon" },
+      [{ slug: "discord", implementationStatus: "coming_soon" }],
+    );
+    expect(plan.actions).toEqual([]);
+    expect(plan.noopSlugs).toEqual(["discord"]);
+  });
+
+  it("surfaces unmatched slugs without emitting an action", () => {
+    const plan = planImplementationStatusOverride(
+      { typo_slack: "available", discord: "available" },
+      [{ slug: "discord", implementationStatus: "coming_soon" }],
+    );
+    expect(plan.actions).toHaveLength(1);
+    expect(plan.actions[0]?.slug).toBe("discord");
+    expect(plan.unmatchedSlugs).toEqual(["typo_slack"]);
+  });
+
+  it("empty override → empty plan", () => {
+    const plan = planImplementationStatusOverride({}, [
+      { slug: "discord", implementationStatus: "coming_soon" },
+    ]);
+    expect(plan.actions).toEqual([]);
+    expect(plan.unmatchedSlugs).toEqual([]);
+    expect(plan.noopSlugs).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applyImplementationStatusOverride (DB driver)
+// ---------------------------------------------------------------------------
+
+describe("applyImplementationStatusOverride", () => {
+  it("issues an UPDATE per actionable slug and reports counts", async () => {
+    const { db, captured, rows } = makeMockDb([
+      { slug: "discord", implementationStatus: "coming_soon" },
+      { slug: "slack", implementationStatus: "available" },
+    ]);
+    const result = await applyImplementationStatusOverride(db, {
+      discord: "available",
+    });
+    expect(result.updatedCount).toBe(1);
+    expect(result.unmatchedSlugs).toEqual([]);
+    expect(rows.find((r) => r.slug === "discord")?.implementationStatus).toBe(
+      "available",
+    );
+
+    const updates = captured.filter((c) =>
+      c.sql.includes("UPDATE plugin_catalog"),
+    );
+    expect(updates).toHaveLength(1);
+    expect(updates[0]!.params).toEqual(["available", "discord"]);
+  });
+
+  it("empty override map is a fast no-op (no SELECT, no UPDATE)", async () => {
+    const { db, captured } = makeMockDb([
+      { slug: "discord", implementationStatus: "coming_soon" },
+    ]);
+    const result = await applyImplementationStatusOverride(db, {});
+    expect(result.updatedCount).toBe(0);
+    expect(captured).toHaveLength(0);
+  });
+
+  it("operator typo (unmatched slug) is surfaced, not silently ignored", async () => {
+    const { db } = makeMockDb([
+      { slug: "discord", implementationStatus: "coming_soon" },
+    ]);
+    const result = await applyImplementationStatusOverride(db, {
+      diskord: "available",
+    });
+    expect(result.updatedCount).toBe(0);
+    expect(result.unmatchedSlugs).toEqual(["diskord"]);
+  });
+
+  it("override already-at-target is a noop (no UPDATE issued)", async () => {
+    const { db, captured } = makeMockDb([
+      { slug: "discord", implementationStatus: "coming_soon" },
+    ]);
+    const result = await applyImplementationStatusOverride(db, {
+      discord: "coming_soon",
+    });
+    expect(result.updatedCount).toBe(0);
+    expect(result.noopSlugs).toEqual(["discord"]);
+    const updates = captured.filter((c) => c.sql.includes("UPDATE plugin_catalog"));
+    expect(updates).toHaveLength(0);
+  });
+
+  it("drops DB rows with unknown implementation_status from the planner input (fail-safe)", async () => {
+    // Mirror's the catalog-seeder's "drop unknown enum rows" posture.
+    // A corrupt-seed row with `implementation_status='legacy'` shouldn't
+    // poison the planner — the row simply won't match the override slug
+    // and the override gets `unmatchedSlugs` for that key, signalling
+    // operator drift in the log line.
+    const db: ImplementationStatusOverrideDb = {
+      query: async <T = unknown>(sql: string) => {
+        if (sql.includes("SELECT slug, implementation_status")) {
+          return {
+            rows: [
+              { slug: "legacy", implementation_status: "bogus-value" },
+              { slug: "discord", implementation_status: "coming_soon" },
+            ] as T[],
+          };
+        }
+        return { rows: [] as T[] };
+      },
+    };
+    const result = await applyImplementationStatusOverride(db, {
+      legacy: "available",
+      discord: "available",
+    });
+    expect(result.updatedCount).toBe(1); // discord only
+    expect(result.unmatchedSlugs).toEqual(["legacy"]);
+  });
+});

--- a/packages/api/src/lib/integrations/catalog-seeder.ts
+++ b/packages/api/src/lib/integrations/catalog-seeder.ts
@@ -42,6 +42,10 @@ import {
   CATALOG_INSTALL_MODELS,
   CATALOG_ENTRY_TYPES,
 } from "@atlas/api/lib/config";
+import {
+  IMPLEMENTATION_STATUSES,
+  type ImplementationStatus,
+} from "@useatlas/types";
 
 const log = createLogger("integrations.catalog-seeder");
 
@@ -70,6 +74,15 @@ export interface CatalogDbRow {
   readonly enabled: boolean;
   readonly installModel: CatalogInstallModel;
   readonly saasEligible: boolean;
+  /**
+   * Whether Atlas has shipped a working install handler. Mirrors the
+   * `plugin_catalog.implementation_status` column (#2747). When a row
+   * lands here as `coming_soon`, the admin UI renders it inert; the
+   * operator override consumer (`applyImplementationStatusOverride`)
+   * can flip it to `available` post-seed on self-host. Reads that
+   * encounter an unknown value drop the row — same fail-safe as `type`.
+   */
+  readonly implementationStatus: ImplementationStatus;
   /**
    * Decoded `config_schema` JSONB. `null` when the column is JSON null —
    * which is the legitimate state for OAuth / static-bot entries that
@@ -213,6 +226,13 @@ function diffEntry(
   if (row.enabled !== entry.enabled) diff.push("enabled");
   if (row.installModel !== entry.install_model) diff.push("installModel");
   if (row.saasEligible !== entry.saas_eligible) diff.push("saasEligible");
+  // implementation_status (#2747): re-seed overwrites operator overrides
+  // applied via `applyImplementationStatusOverride` (separate boot pass).
+  // That's intentional — the catalog declaration is the source of
+  // truth for the *shipped* state; the override post-applies on every
+  // boot. If you reverse the order, an operator override and a config
+  // edit can race; running override-after-seed makes the override win.
+  if (row.implementationStatus !== entry.implementation_status) diff.push("implementationStatus");
 
   // Stable structural compare via canonical JSON. The DB stores
   // `config_schema` as JSONB and PostgreSQL normalizes object keys
@@ -420,13 +440,14 @@ interface CatalogDbRowRaw {
   enabled: boolean;
   install_model: string;
   saas_eligible: boolean;
+  implementation_status: string;
   config_schema: unknown | null;
 }
 
 async function readExistingCatalog(db: CatalogSeedDb): Promise<CatalogDbRow[]> {
   const { rows } = await db.query<CatalogDbRowRaw>(
     `SELECT slug, name, description, type, icon_url, min_plan, enabled,
-            install_model, saas_eligible, config_schema
+            install_model, saas_eligible, implementation_status, config_schema
        FROM plugin_catalog`,
   );
   // Validate enum membership at read time so the planner can trust the
@@ -449,6 +470,17 @@ async function readExistingCatalog(db: CatalogSeedDb): Promise<CatalogDbRow[]> {
       );
       continue;
     }
+    if (
+      !IMPLEMENTATION_STATUSES.includes(
+        r.implementation_status as ImplementationStatus,
+      )
+    ) {
+      log.warn(
+        { slug: r.slug, implementation_status: r.implementation_status },
+        "Catalog seed: plugin_catalog row has unknown `implementation_status` — dropping from planner input",
+      );
+      continue;
+    }
     valid.push({
       slug: r.slug,
       name: r.name,
@@ -459,6 +491,7 @@ async function readExistingCatalog(db: CatalogSeedDb): Promise<CatalogDbRow[]> {
       enabled: r.enabled,
       installModel: r.install_model as CatalogInstallModel,
       saasEligible: r.saas_eligible,
+      implementationStatus: r.implementation_status as ImplementationStatus,
       configSchema: r.config_schema ?? null,
     });
   }
@@ -500,6 +533,11 @@ async function upsertEntry(db: CatalogSeedDb, entry: CatalogEntry): Promise<void
       `Catalog seed: unknown type "${entry.type}" for slug "${entry.slug}"`,
     );
   }
+  if (!IMPLEMENTATION_STATUSES.includes(entry.implementation_status)) {
+    throw new Error(
+      `Catalog seed: unknown implementation_status "${entry.implementation_status}" for slug "${entry.slug}"`,
+    );
+  }
 
   // `config_schema` is JSONB — serialize undefined → null so the column
   // lands as JSON null instead of bombing the cast. Form-based entries
@@ -512,19 +550,21 @@ async function upsertEntry(db: CatalogSeedDb, entry: CatalogEntry): Promise<void
   await db.query(
     `INSERT INTO plugin_catalog
        (id, name, slug, description, type, icon_url, min_plan, enabled,
-        install_model, saas_eligible, config_schema, created_at, updated_at)
-     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11::jsonb, NOW(), NOW())
+        install_model, saas_eligible, implementation_status, config_schema,
+        created_at, updated_at)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12::jsonb, NOW(), NOW())
      ON CONFLICT (slug) DO UPDATE
-       SET name           = EXCLUDED.name,
-           description    = EXCLUDED.description,
-           type           = EXCLUDED.type,
-           icon_url       = EXCLUDED.icon_url,
-           min_plan       = EXCLUDED.min_plan,
-           enabled        = EXCLUDED.enabled,
-           install_model  = EXCLUDED.install_model,
-           saas_eligible  = EXCLUDED.saas_eligible,
-           config_schema  = EXCLUDED.config_schema,
-           updated_at     = NOW()`,
+       SET name                  = EXCLUDED.name,
+           description           = EXCLUDED.description,
+           type                  = EXCLUDED.type,
+           icon_url              = EXCLUDED.icon_url,
+           min_plan              = EXCLUDED.min_plan,
+           enabled               = EXCLUDED.enabled,
+           install_model         = EXCLUDED.install_model,
+           saas_eligible         = EXCLUDED.saas_eligible,
+           implementation_status = EXCLUDED.implementation_status,
+           config_schema         = EXCLUDED.config_schema,
+           updated_at            = NOW()`,
     [
       id,
       name,
@@ -536,6 +576,7 @@ async function upsertEntry(db: CatalogSeedDb, entry: CatalogEntry): Promise<void
       entry.enabled,
       entry.install_model,
       entry.saas_eligible,
+      entry.implementation_status,
       configSchemaJson,
     ],
   );

--- a/packages/api/src/lib/integrations/implementation-status-override.ts
+++ b/packages/api/src/lib/integrations/implementation-status-override.ts
@@ -125,8 +125,18 @@ const EMPTY_RESULT: ImplementationStatusOverrideResult = {
 
 /**
  * Apply the operator override against `plugin_catalog`. Returns a
- * summary the boot pass can log. Each UPDATE is its own round trip —
- * keeps the SQL simple, and the override map is typically 0–3 entries.
+ * summary the boot pass can log.
+ *
+ * Atomic: the UPDATE loop runs inside a single `BEGIN`/`COMMIT` so a
+ * mid-loop failure rolls back every prior UPDATE in the boot. Without
+ * the wrap, a per-UPDATE crash would leave the catalog in a mixed
+ * state — some slugs flipped, some not — which contradicts the
+ * "override is the final word" contract. Per PR #2782 codex review.
+ *
+ * The override map is typically 0–3 entries, so the round-trip cost
+ * (BEGIN + N UPDATEs + COMMIT vs. a single set-based UPDATE) is
+ * negligible. Per-row UPDATE keeps the SQL readable and the warn-log
+ * call site clean.
  */
 export async function applyImplementationStatusOverride(
   db: ImplementationStatusOverrideDb,
@@ -157,18 +167,39 @@ export async function applyImplementationStatusOverride(
 
   const plan = planImplementationStatusOverride(override, narrowed);
 
-  for (const action of plan.actions) {
-    await db.query(
-      `UPDATE plugin_catalog
-          SET implementation_status = $1,
-              updated_at = NOW()
-        WHERE slug = $2`,
-      [action.to, action.slug],
-    );
-    log.info(
-      { slug: action.slug, from: action.from, to: action.to },
-      "Implementation-status override applied",
-    );
+  if (plan.actions.length > 0) {
+    await db.query("BEGIN");
+    try {
+      for (const action of plan.actions) {
+        await db.query(
+          `UPDATE plugin_catalog
+              SET implementation_status = $1,
+                  updated_at = NOW()
+            WHERE slug = $2`,
+          [action.to, action.slug],
+        );
+        log.info(
+          { slug: action.slug, from: action.from, to: action.to },
+          "Implementation-status override applied",
+        );
+      }
+      await db.query("COMMIT");
+    } catch (err) {
+      // Best-effort rollback — if ROLLBACK itself fails (broken
+      // socket / connection lost), the connection is already in a
+      // bad state and Postgres will discard the txn on connection
+      // close. Re-throw the original error so the boot wrapper's
+      // try/catch can surface it as `outcome: "error"`.
+      try {
+        await db.query("ROLLBACK");
+      } catch (rollbackErr) {
+        log.warn(
+          { rollbackErr: rollbackErr instanceof Error ? rollbackErr.message : String(rollbackErr) },
+          "Implementation-status override ROLLBACK failed — connection will be discarded",
+        );
+      }
+      throw err;
+    }
   }
 
   for (const slug of plan.unmatchedSlugs) {

--- a/packages/api/src/lib/integrations/implementation-status-override.ts
+++ b/packages/api/src/lib/integrations/implementation-status-override.ts
@@ -1,0 +1,259 @@
+/**
+ * `applyImplementationStatusOverride` — boot-time consumer of
+ * `atlas.config.ts:overrideImplementationStatus` per 1.5.3 slice 9
+ * (#2747 / ADR-0007).
+ *
+ * The override exists so a self-host operator who's shipped their own
+ * install handler for a row Atlas marks `coming_soon` can flip it to
+ * `available` without forking the catalog (and vice versa, marking a
+ * row `coming_soon` that Atlas ships `available` — e.g. an internal
+ * compliance hold on Slack).
+ *
+ * Runs AFTER both catalog seeds complete so the override is the final
+ * word: any UPDATE issued here cannot be clobbered by the catalog
+ * seeder's `EXCLUDED.implementation_status` upsert on the same boot.
+ * The {@link CatalogImplementationStatusOverride} Layer encodes this
+ * ordering via Tag dependencies on `CatalogSeed` +
+ * `BuiltinDatasourceCatalogSeed`.
+ *
+ * SaaS: the override field is unused — `deploy/api/atlas.config.ts`
+ * declares every row's `implementation_status` directly, so the
+ * boot-time UPDATE here finds an empty map and exits as a no-op.
+ *
+ * Slugs that don't match any catalog row are logged at warn — the
+ * operator likely typo'd the slug; we don't want a silent miss to
+ * present as "override didn't take effect".
+ *
+ * Pure function + thin DB driver split mirrors `catalog-seeder.ts`.
+ */
+
+import { createLogger } from "@atlas/api/lib/logger";
+import { type ImplementationStatus } from "@useatlas/types";
+
+const log = createLogger("integrations.implementation-status-override");
+
+// ---------------------------------------------------------------------------
+// Plan types
+// ---------------------------------------------------------------------------
+
+/**
+ * One operator-declared override that survived planning. Catalog row
+ * exists, current status differs from the declared override, UPDATE
+ * should fire.
+ */
+export interface ImplementationStatusOverrideAction {
+  readonly slug: string;
+  readonly from: ImplementationStatus;
+  readonly to: ImplementationStatus;
+}
+
+export interface ImplementationStatusOverridePlan {
+  /** Slug → new status UPDATEs the driver should issue. */
+  readonly actions: ReadonlyArray<ImplementationStatusOverrideAction>;
+  /** Slugs in the override that don't match any catalog row. Logged at warn. */
+  readonly unmatchedSlugs: ReadonlyArray<string>;
+  /** Slugs already at the declared status. UPDATE skipped — kept for log/observability. */
+  readonly noopSlugs: ReadonlyArray<string>;
+}
+
+// ---------------------------------------------------------------------------
+// Pure planner
+// ---------------------------------------------------------------------------
+
+/** Narrow projection of `plugin_catalog` rows the planner reads. */
+export interface CurrentCatalogRow {
+  readonly slug: string;
+  readonly implementationStatus: ImplementationStatus;
+}
+
+/**
+ * Pure function: declared override map × current catalog state →
+ * action plan. No I/O; same inputs always yield the same plan.
+ *
+ * The override-vs-current comparison is case-sensitive on slug to
+ * match the DB's catalog `slug` unique index (lowercase
+ * alphanumeric+dashes per `CatalogEntrySchema`). An operator who
+ * typo'd casing surfaces in `unmatchedSlugs`.
+ */
+export function planImplementationStatusOverride(
+  override: Record<string, ImplementationStatus>,
+  existing: ReadonlyArray<CurrentCatalogRow>,
+): ImplementationStatusOverridePlan {
+  const existingBySlug = new Map<string, CurrentCatalogRow>();
+  for (const row of existing) existingBySlug.set(row.slug, row);
+
+  const actions: ImplementationStatusOverrideAction[] = [];
+  const unmatchedSlugs: string[] = [];
+  const noopSlugs: string[] = [];
+
+  for (const [slug, to] of Object.entries(override)) {
+    const row = existingBySlug.get(slug);
+    if (!row) {
+      unmatchedSlugs.push(slug);
+      continue;
+    }
+    if (row.implementationStatus === to) {
+      noopSlugs.push(slug);
+      continue;
+    }
+    actions.push({ slug, from: row.implementationStatus, to });
+  }
+
+  return { actions, unmatchedSlugs, noopSlugs };
+}
+
+// ---------------------------------------------------------------------------
+// DB driver
+// ---------------------------------------------------------------------------
+
+/** Narrow shape of the DB client the driver needs. Mirrors `CatalogSeedDb`. */
+export interface ImplementationStatusOverrideDb {
+  query<T = unknown>(sql: string, params?: unknown[]): Promise<{ rows: T[] }>;
+}
+
+export interface ImplementationStatusOverrideResult {
+  readonly updatedCount: number;
+  readonly unmatchedSlugs: ReadonlyArray<string>;
+  readonly noopSlugs: ReadonlyArray<string>;
+}
+
+const EMPTY_RESULT: ImplementationStatusOverrideResult = {
+  updatedCount: 0,
+  unmatchedSlugs: [],
+  noopSlugs: [],
+};
+
+/**
+ * Apply the operator override against `plugin_catalog`. Returns a
+ * summary the boot pass can log. Each UPDATE is its own round trip —
+ * keeps the SQL simple, and the override map is typically 0–3 entries.
+ */
+export async function applyImplementationStatusOverride(
+  db: ImplementationStatusOverrideDb,
+  override: Record<string, ImplementationStatus>,
+): Promise<ImplementationStatusOverrideResult> {
+  if (Object.keys(override).length === 0) {
+    log.info("Implementation-status override: empty map; skipping");
+    return EMPTY_RESULT;
+  }
+
+  const { rows: existing } = await db.query<{
+    slug: string;
+    implementation_status: string;
+  }>(`SELECT slug, implementation_status FROM plugin_catalog`);
+
+  // Narrow at the SQL boundary — same fail-closed posture as
+  // `PillarCatalogQuery`. A drifted value won't survive into the
+  // planner; the row simply won't match the override slug.
+  const narrowed: CurrentCatalogRow[] = [];
+  for (const r of existing) {
+    if (r.implementation_status === "available" || r.implementation_status === "coming_soon") {
+      narrowed.push({
+        slug: r.slug,
+        implementationStatus: r.implementation_status,
+      });
+    }
+  }
+
+  const plan = planImplementationStatusOverride(override, narrowed);
+
+  for (const action of plan.actions) {
+    await db.query(
+      `UPDATE plugin_catalog
+          SET implementation_status = $1,
+              updated_at = NOW()
+        WHERE slug = $2`,
+      [action.to, action.slug],
+    );
+    log.info(
+      { slug: action.slug, from: action.from, to: action.to },
+      "Implementation-status override applied",
+    );
+  }
+
+  for (const slug of plan.unmatchedSlugs) {
+    log.warn(
+      { slug, declaredOverride: override[slug] },
+      "Implementation-status override declares slug not present in plugin_catalog — typo? Or did the seed fail?",
+    );
+  }
+
+  return {
+    updatedCount: plan.actions.length,
+    unmatchedSlugs: plan.unmatchedSlugs,
+    noopSlugs: plan.noopSlugs,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Boot wrapper
+// ---------------------------------------------------------------------------
+
+/**
+ * Discriminated outcome of {@link runImplementationStatusOverrideBoot}.
+ * Mirrors the seed Layers' shapes so health-surface consumers can
+ * treat the three signals (skipped, applied, error) uniformly.
+ */
+export type ImplementationStatusOverrideBootResult =
+  | { readonly kind: "skipped"; readonly reason: "no-internal-db" | "no-config" | "empty-override" }
+  | {
+      readonly kind: "applied";
+      readonly updatedCount: number;
+      readonly unmatchedSlugs: ReadonlyArray<string>;
+      readonly noopSlugs: ReadonlyArray<string>;
+    }
+  | { readonly kind: "error"; readonly message: string };
+
+/**
+ * Boot-pass wrapper. Mirrors `runBuiltinDatasourceCatalogSeedBoot`'s
+ * log-and-continue posture: a failure here leaves the catalog seeds'
+ * output authoritative for the boot rather than crashing the API. The
+ * UI degrades gracefully — a self-host operator who shipped a Discord
+ * handler but whose override didn't apply sees the inert "Coming soon"
+ * card; the API still boots.
+ */
+export async function runImplementationStatusOverrideBoot(): Promise<ImplementationStatusOverrideBootResult> {
+  const { hasInternalDB, getInternalDB } = await import(
+    "@atlas/api/lib/db/internal"
+  );
+  const { getConfig } = await import("@atlas/api/lib/config");
+
+  if (!hasInternalDB()) {
+    log.info("Implementation-status override: no internal DB configured, skipping");
+    return { kind: "skipped", reason: "no-internal-db" };
+  }
+  const config = getConfig();
+  if (!config) {
+    log.info("Implementation-status override: no resolved config, skipping");
+    return { kind: "skipped", reason: "no-config" };
+  }
+  const override = config.overrideImplementationStatus ?? {};
+  if (Object.keys(override).length === 0) {
+    return { kind: "skipped", reason: "empty-override" };
+  }
+
+  const pool = getInternalDB();
+  const db: ImplementationStatusOverrideDb = {
+    async query<T = unknown>(sql: string, params?: unknown[]) {
+      const result = await pool.query(sql, params);
+      return { rows: result.rows as T[] };
+    },
+  };
+
+  try {
+    const result = await applyImplementationStatusOverride(db, override);
+    return {
+      kind: "applied",
+      updatedCount: result.updatedCount,
+      unmatchedSlugs: result.unmatchedSlugs,
+      noopSlugs: result.noopSlugs,
+    };
+  } catch (err) {
+    const normalized = err instanceof Error ? err : new Error(String(err));
+    log.error(
+      { err: normalized },
+      "Implementation-status override failed — catalog rows from seeds remain authoritative",
+    );
+    return { kind: "error", message: normalized.message };
+  }
+}

--- a/packages/web/src/app/admin/integrations/__tests__/catalog-section.test.tsx
+++ b/packages/web/src/app/admin/integrations/__tests__/catalog-section.test.tsx
@@ -1,0 +1,232 @@
+/**
+ * Render-branch coverage for the catalog card states under
+ * `/admin/integrations`. Slice 9 of 1.5.3 (#2747).
+ *
+ * The three orthogonal gates from `resolveInstallStatus`
+ * (`@atlas/api/lib/integrations/install-status-machine`) all surface
+ * here as distinct visual affordances — never conflated:
+ *
+ *   - coming_soon       → grey Clock badge + inert "Coming soon" CTA
+ *   - upgrade_required  → purple Lock badge + disabled "Upgrade" CTA
+ *   - configured_but_downgraded → red "Plan downgrade" badge + warning copy
+ *   - accessible / connected   → normal Install / Connect / Manage CTA
+ *
+ * The 4-row matrix at the bottom is the regression guard the slice 9
+ * AC calls out ("don't conflate") — each row proves a *different*
+ * `data-testid` survives, so a future refactor that merges the
+ * branches breaks the test.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { render } from "@testing-library/react";
+import { CatalogCard } from "../catalog-section";
+import type { IntegrationsCatalogEntry } from "@/ui/lib/admin-schemas";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeEntry(
+  overrides: Partial<IntegrationsCatalogEntry> = {},
+): IntegrationsCatalogEntry {
+  return {
+    id: "catalog:slack",
+    slug: "slack",
+    type: "chat",
+    installModel: "oauth",
+    name: "Slack",
+    description: "Connect Slack",
+    iconUrl: null,
+    minPlan: "starter",
+    configSchema: null,
+    installed: false,
+    installedAt: null,
+    installedBy: null,
+    installStatus: null,
+    upsellOnly: false,
+    access: { kind: "accessible" },
+    pillar: "chat",
+    implementationStatus: "available",
+    ...overrides,
+  };
+}
+
+const noopInstalled = () => undefined;
+
+// ---------------------------------------------------------------------------
+// coming_soon — the slice-9 deliverable
+// ---------------------------------------------------------------------------
+
+describe("CatalogCard — coming_soon", () => {
+  test("renders the grey Coming soon badge and inert CTA", () => {
+    const { container } = render(
+      <CatalogCard
+        entry={makeEntry({ slug: "discord", implementationStatus: "coming_soon" })}
+        onInstalled={noopInstalled}
+      />,
+    );
+
+    const card = container.querySelector('[data-testid="catalog-card-discord"]');
+    expect(card?.getAttribute("data-card-state")).toBe("coming-soon");
+
+    const badge = container.querySelector(
+      '[data-testid="catalog-card-discord-coming-soon-badge"]',
+    );
+    expect(badge).not.toBeNull();
+    expect(badge!.textContent).toContain("Coming soon");
+
+    const cta = container.querySelector<HTMLButtonElement>(
+      '[data-testid="catalog-card-discord-coming-soon-cta"]',
+    );
+    expect(cta).not.toBeNull();
+    expect(cta!.disabled).toBe(true);
+  });
+
+  test("coming_soon dominates the upsell gate — no premium lock surfaces", () => {
+    // Upgrade-required would normally show the purple Lock + Premium
+    // badge. coming_soon outranks the plan gate per
+    // `resolveInstallStatus` — the user must read "Atlas hasn't shipped
+    // this" first, not "upgrade your plan".
+    const { container } = render(
+      <CatalogCard
+        entry={makeEntry({
+          slug: "telegram",
+          implementationStatus: "coming_soon",
+          upsellOnly: true,
+          access: { kind: "upgrade", requiredPlan: "business" },
+        })}
+        onInstalled={noopInstalled}
+      />,
+    );
+
+    expect(
+      container.querySelector('[data-testid="catalog-card-telegram-lock-icon"]'),
+    ).toBeNull();
+    expect(
+      container.querySelector('[data-testid="catalog-card-telegram-plan-badge"]'),
+    ).toBeNull();
+    expect(
+      container.querySelector('[data-testid="catalog-card-telegram-locked-cta"]'),
+    ).toBeNull();
+    // The neutral coming-soon affordance is the only one rendered.
+    expect(
+      container.querySelector('[data-testid="catalog-card-telegram-coming-soon-cta"]'),
+    ).not.toBeNull();
+  });
+
+  test("coming_soon dominates the install gate — no Manage / Disconnect", () => {
+    // A coming_soon row should never appear "installed"; the API guards
+    // against this server-side, but the UI also short-circuits ahead of
+    // the install branch as defense-in-depth.
+    const { container } = render(
+      <CatalogCard
+        entry={makeEntry({
+          slug: "whatsapp",
+          implementationStatus: "coming_soon",
+          installed: true,
+          installedAt: "2026-05-20T10:00:00.000Z",
+          installedBy: "admin",
+        })}
+        onInstalled={noopInstalled}
+      />,
+    );
+
+    expect(container.textContent).not.toContain("Manage");
+    expect(container.textContent).not.toContain("Disconnect");
+    expect(
+      container.querySelector('[data-testid="catalog-card-whatsapp-coming-soon-cta"]'),
+    ).not.toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// upgrade_required — regression guard (no conflation with coming_soon)
+// ---------------------------------------------------------------------------
+
+describe("CatalogCard — upgrade_required (regression guard for #2747)", () => {
+  test("renders the purple Lock + Premium badge + Upgrade CTA", () => {
+    const { container } = render(
+      <CatalogCard
+        entry={makeEntry({
+          slug: "salesforce",
+          access: { kind: "upgrade", requiredPlan: "business" },
+          upsellOnly: true,
+          minPlan: "business",
+        })}
+        onInstalled={noopInstalled}
+      />,
+    );
+
+    expect(
+      container.querySelector('[data-testid="catalog-card-salesforce-lock-icon"]'),
+    ).not.toBeNull();
+    expect(
+      container.querySelector('[data-testid="catalog-card-salesforce-plan-badge"]')
+        ?.textContent,
+    ).toContain("business");
+    expect(
+      container.querySelector<HTMLButtonElement>(
+        '[data-testid="catalog-card-salesforce-locked-cta"]',
+      )?.disabled,
+    ).toBe(true);
+
+    // The coming-soon affordance must NOT be rendered when the only
+    // failed gate is the plan tier.
+    expect(
+      container.querySelector('[data-testid="catalog-card-salesforce-coming-soon-cta"]'),
+    ).toBeNull();
+    expect(
+      container.querySelector('[data-testid="catalog-card-salesforce-coming-soon-badge"]'),
+    ).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// accessible — happy path (regression guard)
+// ---------------------------------------------------------------------------
+
+describe("CatalogCard — accessible (regression guard for #2747)", () => {
+  test("plan admits + implementationStatus=available → Connect CTA, no inert affordance", () => {
+    const { container } = render(
+      <CatalogCard
+        entry={makeEntry({ slug: "slack", implementationStatus: "available" })}
+        onInstalled={noopInstalled}
+      />,
+    );
+
+    expect(
+      container.querySelector('[data-testid="catalog-card-slack"]')?.getAttribute(
+        "data-card-state",
+      ),
+    ).toBe("accessible");
+    // OAuth install link to /install endpoint.
+    const link = container.querySelector('a[href*="/api/v1/integrations/slack/install"]');
+    expect(link).not.toBeNull();
+    expect(link!.textContent).toContain("Connect");
+
+    expect(
+      container.querySelector('[data-testid="catalog-card-slack-coming-soon-cta"]'),
+    ).toBeNull();
+    expect(
+      container.querySelector('[data-testid="catalog-card-slack-locked-cta"]'),
+    ).toBeNull();
+  });
+
+  test("undefined implementationStatus falls back to available (backwards-compat)", () => {
+    // Pre-#2741 API responses omit `implementationStatus`. The card must
+    // continue to render as accessible — defaulting to coming_soon would
+    // lock every previously-working row to inert on an older API.
+    const { implementationStatus: _omit, ...rest } = makeEntry();
+    const { container } = render(
+      <CatalogCard
+        entry={rest as IntegrationsCatalogEntry}
+        onInstalled={noopInstalled}
+      />,
+    );
+
+    expect(
+      container.querySelector('[data-testid="catalog-card-slack-coming-soon-cta"]'),
+    ).toBeNull();
+    expect(container.querySelector('a[href*="/install"]')).not.toBeNull();
+  });
+});

--- a/packages/web/src/app/admin/integrations/__tests__/catalog-section.test.tsx
+++ b/packages/web/src/app/admin/integrations/__tests__/catalog-section.test.tsx
@@ -118,6 +118,10 @@ describe("CatalogCard — coming_soon", () => {
     // A coming_soon row should never appear "installed"; the API guards
     // against this server-side, but the UI also short-circuits ahead of
     // the install branch as defense-in-depth.
+    //
+    // Asserting via data-testid (not textContent) so a future copy
+    // change to "Configure"/"Remove" doesn't silently green-light the
+    // regression.
     const { container } = render(
       <CatalogCard
         entry={makeEntry({
@@ -131,8 +135,12 @@ describe("CatalogCard — coming_soon", () => {
       />,
     );
 
-    expect(container.textContent).not.toContain("Manage");
-    expect(container.textContent).not.toContain("Disconnect");
+    // The two install-branch CTAs have no data-testid in production
+    // today, so use aria-label as the regression hook — same robustness
+    // as data-testid (won't drift on copy changes) without requiring
+    // a production-code attribute add.
+    expect(container.querySelector('button[aria-label^="Manage "]')).toBeNull();
+    expect(container.querySelector('button[aria-label^="Disconnect "]')).toBeNull();
     expect(
       container.querySelector('[data-testid="catalog-card-whatsapp-coming-soon-cta"]'),
     ).not.toBeNull();
@@ -157,6 +165,15 @@ describe("CatalogCard — upgrade_required (regression guard for #2747)", () => 
       />,
     );
 
+    // `data-card-state` is the dominant gate identifier — assert it
+    // here so a future regression that conflates upgrade-required with
+    // coming-soon or accessible breaks loud at this assertion (not
+    // later via a copy / icon comparison).
+    expect(
+      container
+        .querySelector('[data-testid="catalog-card-salesforce"]')
+        ?.getAttribute("data-card-state"),
+    ).toBe("upgrade-required");
     expect(
       container.querySelector('[data-testid="catalog-card-salesforce-lock-icon"]'),
     ).not.toBeNull();

--- a/packages/web/src/app/admin/integrations/catalog-section.tsx
+++ b/packages/web/src/app/admin/integrations/catalog-section.tsx
@@ -10,6 +10,12 @@
  *   - `form` — opens the {@link FormInstallModal} (Email today; Webhook + Obsidian per #2661)
  *   - `static-bot` — render-inert until the handler ships in 1.5.3
  *
+ * `implementationStatus: "coming_soon"` dominates every other gate per
+ * `InstallStatusMachine` (#2740 / ADR-0007). A coming-soon card renders
+ * a grey neutral badge + inert "Coming soon" CTA — visually distinct
+ * from the purple upsell lock so a customer doesn't read "upgrade to
+ * unlock" when the truth is "Atlas hasn't shipped it yet". Slice 9 (#2747).
+ *
  * Manage / Disconnect still ship in #2656; they render but are inert.
  */
 
@@ -25,7 +31,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { getApiUrl } from "@/lib/api-url";
-import { Cable, Lock, Sparkles } from "lucide-react";
+import { Cable, Clock, Lock, Sparkles } from "lucide-react";
 import { FormInstallModal } from "./form-install-modal";
 
 function groupByType(entries: IntegrationsCatalogEntry[]) {
@@ -44,8 +50,17 @@ interface CatalogCardProps {
   onInstalled: () => void;
 }
 
-function CatalogCard({ entry, onInstalled }: CatalogCardProps) {
-  // Three visual states a card can land in (#2701):
+/**
+ * Single catalog card. Exported only for unit tests — production code
+ * goes through {@link CatalogSection}. Branches state from
+ * `entry.access.kind`, `entry.installStatus`, `entry.installed`, and
+ * `entry.implementationStatus` per the comment block inside.
+ */
+export function CatalogCard({ entry, onInstalled }: CatalogCardProps) {
+  // Four visual states a card can land in:
+  //   0. coming-soon             — Atlas hasn't shipped the install handler →
+  //                                grey neutral badge + inert CTA. Dominates every
+  //                                other gate per `resolveInstallStatus` (#2740).
   //   1. accessible              — plan admits + not installed → Connect / Install CTA
   //   2. upgrade-required        — plan does NOT admit + not installed → locked card,
   //                                "Premium — requires <plan>" badge, disabled Upgrade CTA
@@ -57,6 +72,11 @@ function CatalogCard({ entry, onInstalled }: CatalogCardProps) {
   // upgradeRequired) into a CatalogAccess tagged union — `entry.access`
   // is `{ kind: "accessible" } | { kind: "upgrade"; requiredPlan: PlanTier | null }`.
   // The UI branches on `kind` instead of re-deriving from booleans.
+  //
+  // `implementationStatus` is optional on the wire (older API responses
+  // pre-#2741 omit it). Default to `"available"` so a missing field
+  // can never lock a working card to inert.
+  const isComingSoon = entry.implementationStatus === "coming_soon";
   const isUpsell = entry.access.kind === "upgrade";
   const requiredPlan =
     entry.access.kind === "upgrade" ? entry.access.requiredPlan : null;
@@ -76,51 +96,83 @@ function CatalogCard({ entry, onInstalled }: CatalogCardProps) {
   return (
     <Card
       data-testid={`catalog-card-${entry.slug}`}
+      data-card-state={
+        isComingSoon ? "coming-soon" : isUpsell && !isInstalled ? "upgrade-required" : "accessible"
+      }
       className={
-        isUpsell && !isInstalled
-          ? "relative transition-colors opacity-90 hover:border-primary/40"
-          : "relative transition-colors hover:border-primary/40"
+        isComingSoon
+          ? // Mute slightly more than the upsell card so the visual
+            // weight matches the inert CTA. No hover affordance — the
+            // card has no interaction; signalling hover would lie.
+            "relative transition-colors opacity-80"
+          : isUpsell && !isInstalled
+            ? "relative transition-colors opacity-90 hover:border-primary/40"
+            : "relative transition-colors hover:border-primary/40"
       }
     >
       <CardHeader>
         <div className="flex items-start justify-between gap-3">
           <CardTitle className="flex items-center gap-1.5 text-base">
-            {isUpsell && !isInstalled && (
+            {isComingSoon ? (
+              <Clock
+                className="size-3.5 text-muted-foreground"
+                aria-label="Coming soon"
+                data-testid={`catalog-card-${entry.slug}-coming-soon-icon`}
+              />
+            ) : isUpsell && !isInstalled ? (
               <Lock
                 className="size-3.5 text-muted-foreground"
                 aria-label="Premium integration"
                 data-testid={`catalog-card-${entry.slug}-lock-icon`}
               />
-            )}
+            ) : null}
             {entry.name}
           </CardTitle>
           <div className="flex shrink-0 items-center gap-1">
-            {isDowngraded ? (
+            {isComingSoon ? (
+              // Coming soon dominates — `resolveInstallStatus` (#2740)
+              // returns `coming_soon` regardless of plan / install / handler
+              // state. Render the neutral grey badge alone so a customer
+              // doesn't read the premium-lock copy when the truth is
+              // "Atlas hasn't shipped this yet".
               <Badge
-                variant="destructive"
-                className="text-[10px]"
-                data-testid={`catalog-card-${entry.slug}-downgrade-badge`}
-              >
-                Plan downgrade
-              </Badge>
-            ) : needsReconnect ? (
-              <Badge variant="destructive" className="text-[10px]" data-testid={`catalog-card-${entry.slug}-reconnect-badge`}>
-                Reconnect needed
-              </Badge>
-            ) : isInstalled ? (
-              <Badge variant="secondary" className="text-[10px]">
-                Installed
-              </Badge>
-            ) : null}
-            {isUpsell && (
-              <Badge
-                variant="outline"
+                variant="secondary"
                 className="gap-1 text-[10px]"
-                data-testid={`catalog-card-${entry.slug}-plan-badge`}
+                data-testid={`catalog-card-${entry.slug}-coming-soon-badge`}
               >
-                <Sparkles className="size-3" />
-                Premium — requires {requiredPlan ?? entry.minPlan}
+                <Clock className="size-3" />
+                Coming soon
               </Badge>
+            ) : (
+              <>
+                {isDowngraded ? (
+                  <Badge
+                    variant="destructive"
+                    className="text-[10px]"
+                    data-testid={`catalog-card-${entry.slug}-downgrade-badge`}
+                  >
+                    Plan downgrade
+                  </Badge>
+                ) : needsReconnect ? (
+                  <Badge variant="destructive" className="text-[10px]" data-testid={`catalog-card-${entry.slug}-reconnect-badge`}>
+                    Reconnect needed
+                  </Badge>
+                ) : isInstalled ? (
+                  <Badge variant="secondary" className="text-[10px]">
+                    Installed
+                  </Badge>
+                ) : null}
+                {isUpsell && (
+                  <Badge
+                    variant="outline"
+                    className="gap-1 text-[10px]"
+                    data-testid={`catalog-card-${entry.slug}-plan-badge`}
+                  >
+                    <Sparkles className="size-3" />
+                    Premium — requires {requiredPlan ?? entry.minPlan}
+                  </Badge>
+                )}
+              </>
             )}
           </div>
         </div>
@@ -152,8 +204,23 @@ function CatalogCard({ entry, onInstalled }: CatalogCardProps) {
                 (slice 5, #2653 — wired here in slice 7 so OAuth
                 catalog cards stop being inert).
               - "form" opens the FormInstallModal (slice 7, #2660).
-                Disconnect / Manage still ship in #2656. */}
-          {isUpsell && !isInstalled ? (
+                Disconnect / Manage still ship in #2656.
+              Coming-soon short-circuits ahead of every install-model
+              branch — the row has no handler, so the CTA is inert
+              regardless of plan or install presence. */}
+          {isComingSoon ? (
+            <Button
+              size="sm"
+              variant="outline"
+              disabled
+              aria-label={`${entry.name} is coming soon`}
+              title="Atlas hasn't shipped this integration yet"
+              data-testid={`catalog-card-${entry.slug}-coming-soon-cta`}
+            >
+              <Clock className="mr-1 size-3" />
+              Coming soon
+            </Button>
+          ) : isUpsell && !isInstalled ? (
             <Button
               size="sm"
               variant="outline"


### PR DESCRIPTION
## Summary

Closes #2747. Slice 9 of 1.5.3 (PRD #2738 / ADR-0007) — the user-visible payoff for the implementation_status column landed in slice 1 (#2739) and computed by `InstallStatusMachine` in slice 2 (#2740).

- **UI**: `catalog-section.tsx` short-circuits ahead of every other branch when `entry.implementationStatus === "coming_soon"`. Grey `secondary` Badge + disabled "Coming soon" CTA — visually distinct from the purple upsell lock so a customer reads "Atlas hasn't shipped this", not "upgrade to unlock". `data-card-state` attribute exposed for tests + future analytics.
- **Seed**: `CatalogEntrySchema.implementation_status` defaults to `"available"`; declared `"coming_soon"` entries propagate through the catalog seeder's diff + upsert. `deploy/api/atlas.config.ts` marks teams/discord/gchat/telegram/whatsapp `coming_soon`. Migration 0094 one-time-promotes their existing `enabled=false` rows (otherwise the seeder's preserve-disabled branch would keep them hidden).
- **Override**: New `applyImplementationStatusOverride` boot pass + `ImplementationStatusOverrideLive` Layer that depends on both seed Tags. Self-host operators with their own handler can flip a row via `atlas.config.ts:overrideImplementationStatus` without forking the catalog. Unmatched slugs surface in the log (typo guard).

## Acceptance criteria

- [x] Catalog card renders distinct `coming_soon` state (grey badge, inert CTA — not the upsell purple lock)
- [x] `misconfigured` state continues to render distinctly (regression guard — render test asserts the three states never conflate)
- [x] `upgrade_required` upsell state unchanged
- [x] Built-in placeholder rows default `implementation_status: 'coming_soon'`
- [x] `atlas.config.ts:overrideImplementationStatus` read by the boot-time seed, applied AFTER both catalog seeds
- [x] Override semantics: `{ x: "available" }` flips row `x` to available even if Atlas ships it `coming_soon`
- [x] Documentation comment in atlas.config.ts catalog block explains the placeholder/override flow
- [x] Test layer covers the three orthogonal gates returning correct `CardState` per combination (32-row exhaustive matrix from slice 2 #2740 + new render-branch tests in slice 9)
- [x] `bun run type` + affected `bun run test` + drift checks all green
- [ ] Manual smoke on dogfood — pending merge to staging

## Test plan

- [x] `bun run lint`
- [x] `bun run type`
- [x] `bun run scripts/test-isolated.ts --affected` — 74/74 pass
- [x] `bash scripts/check-schema-drift.sh`
- [x] `bash scripts/check-template-drift.sh`
- [x] `bash scripts/check-ee-imports.sh`
- [x] `bun x syncpack lint`
- [ ] Dogfood smoke: at least one `coming_soon` card renders correctly on staging; operator override flips it to `available`