### PR TITLE
feat(api,plugins,ee): #2727 — @useatlas/twenty plugin + SaasCrm Tag + demo lead capture

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -238,6 +238,10 @@ ATLAS_ADMIN_EMAIL=admin@useatlas.dev
 # ATLAS_ONBOARDING_EMAILS_ENABLED=false           # Enable automated onboarding drip campaign for new signups
 # ATLAS_UNSUBSCRIBE_TOKEN_TTL_MS=2592000000       # TTL for signed unsubscribe links (default: 30 days; range: 60s–1y)
 
+# === Twenty CRM (SaaS-side lead capture — #2727) ===
+# TWENTY_BASE_URL=https://crm.useatlas.dev   # Twenty REST base URL (defaults to crm.useatlas.dev). Self-hosters set to their own Twenty hostname.
+# TWENTY_API_KEY=                            # Bearer key from Twenty Settings → API & Webhooks. Required for SaaS demo / signup / contact-form dispatch into Twenty; unset = SaasCrm.available is false. Twenty Person object must have custom fields `atlasFirstSource` AND `atlasLastSource` (verified at boot).
+
 # === Python Tool (optional) ===
 # ATLAS_PYTHON_ENABLED=false                  # Enable the executePython agent tool (requires ATLAS_SANDBOX_URL)
 # ATLAS_PYTHON_TIMEOUT=30000                  # Python execution timeout in ms (default: 30s)

--- a/bun.lock
+++ b/bun.lock
@@ -79,6 +79,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@atlas/api": "workspace:*",
+        "@useatlas/twenty": "workspace:*",
         "@useatlas/types": "workspace:*",
         "effect": "^3.14.8",
         "ipaddr.js": "^2.3.0",

--- a/bun.lock
+++ b/bun.lock
@@ -720,15 +720,17 @@
       "version": "0.0.1",
       "devDependencies": {
         "@useatlas/plugin-sdk": "workspace:*",
+        "@useatlas/types": "workspace:*",
         "ai": "^6.0.141",
         "effect": "^3.21.0",
         "zod": "^4.3.6",
       },
       "peerDependencies": {
-        "@useatlas/plugin-sdk": ">=0.0.1",
-        "ai": "^6.0.0",
-        "effect": "^3.0.0",
-        "zod": "^4.0.0",
+        "@useatlas/plugin-sdk": "0.0.7",
+        "@useatlas/types": ">=0.1.7",
+        "ai": "^6.0.141",
+        "effect": "^3.21.0",
+        "zod": "^4.3.6",
       },
     },
     "plugins/vercel-sandbox": {

--- a/create-atlas/templates/docker/next.config.ts
+++ b/create-atlas/templates/docker/next.config.ts
@@ -4,6 +4,9 @@ const nextConfig: NextConfig = {
   // standalone is for self-hosted deployments (Docker, Railway, etc.); Vercel uses its own build pipeline
   ...(process.env.VERCEL ? {} : { output: "standalone" }),
   serverExternalPackages: ["pg", "mysql2", "@clickhouse/client", "@duckdb/node-api", "snowflake-sdk", "jsforce", "just-bash", "nodemailer", "pino", "pino-pretty", "stripe"],
+  // Workspace-published TS plugins that are statically imported from ee/src/ —
+  // Turbopack would otherwise fail to compile their raw .ts source from node_modules.
+  transpilePackages: ["@useatlas/twenty"],
   // Type checking is handled by `bun run type` — skip during next build to avoid
   // false positives from @ts-expect-error directives that differ between monorepo and standalone
   typescript: { ignoreBuildErrors: true },

--- a/create-atlas/templates/docker/package.json
+++ b/create-atlas/templates/docker/package.json
@@ -25,6 +25,7 @@
     "@ai-sdk/react": "^3.0.143",
     "@useatlas/react": "^0.1.0",
     "@useatlas/sdk": "^0.1.0",
+    "@useatlas/twenty": "^0.0.1",
     "@useatlas/types": "^0.1.0",
     "@better-auth/api-key": "^1.6.9",
     "@better-auth/oauth-provider": "^1.6.9",

--- a/create-atlas/templates/nextjs-standalone/next.config.ts
+++ b/create-atlas/templates/nextjs-standalone/next.config.ts
@@ -3,6 +3,9 @@ import type { NextConfig } from "next";
 const nextConfig: NextConfig = {
   // Vercel uses its own build pipeline — no `output: "standalone"` needed
   serverExternalPackages: ["pg", "mysql2", "@clickhouse/client", "@duckdb/node-api", "snowflake-sdk", "jsforce", "just-bash", "nodemailer", "pino", "pino-pretty", "stripe"],
+  // Workspace-published TS plugins that are statically imported from ee/src/ —
+  // Turbopack would otherwise fail to compile their raw .ts source from node_modules.
+  transpilePackages: ["@useatlas/twenty"],
   // Type checking is handled by `bun run type` (tsgo); skip during Next.js build
   typescript: { ignoreBuildErrors: true },
   // Security headers — mirrors packages/web/next.config.ts so scaffolded

--- a/create-atlas/templates/nextjs-standalone/package.json
+++ b/create-atlas/templates/nextjs-standalone/package.json
@@ -22,6 +22,7 @@
     "@ai-sdk/react": "^3.0.143",
     "@useatlas/react": "^0.1.0",
     "@useatlas/sdk": "^0.1.0",
+    "@useatlas/twenty": "^0.0.1",
     "@useatlas/types": "^0.1.0",
     "ai": "^6.0.141",
     "@better-auth/api-key": "^1.6.9",

--- a/ee/package.json
+++ b/ee/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@atlas/api": "workspace:*",
+    "@useatlas/twenty": "workspace:*",
     "@useatlas/types": "workspace:*",
     "effect": "^3.14.8",
     "ipaddr.js": "^2.3.0"

--- a/ee/src/layers.ts
+++ b/ee/src/layers.ts
@@ -1,41 +1,11 @@
 /**
- * Aggregator for EE-side `Layer.effect` implementations.
+ * Aggregator for EE-side `Layer.effect` implementations. Lazy-imported
+ * by `buildAppLayer()` in `@atlas/api/lib/effect/layers` (the sole
+ * permitted runtime `@atlas/ee` import from core) and merged on top of
+ * `NoopEnterpriseDefaultsLayer` when `isEnterpriseEnabled()` is true.
  *
- * `buildAppLayer()` in `@atlas/api/lib/effect/layers` lazy-imports this
- * module (the ONLY post-closeout `@atlas/ee` import permitted from core)
- * and merges `EELayer` on top of `NoopEnterpriseDefaultsLayer` when
- * `isEnterpriseEnabled()` is true. Layer.mergeAll resolves duplicate
- * Tags by "last wins", so EE's real implementations override core's
- * no-op defaults.
- *
- * Slice 2/11 (#2564) — added `ResidencyResolverLive`.
- * Slice 3/11 (#2565) — added `ModelRouterLive`.
- * Slice 4/11 (#2566) — added `MaskingPolicyLive` + `ComplianceReportsLive`.
- * Slice 5/11 (#2567) — added `ApprovalGateLive`.
- * Slice 6/11 (#2568) — added `SlaMetricsLive` + `BackupsManagerLive`.
- * Slice 7/11 (#2569) — added `AuditRetentionLive`.
- * Slice 8/11 (#2570) — added `IpAllowlistPolicyLive` + `SSOPolicyLive`
- *   + `SCIMProvenanceLive` (auth subsystem trio).
- * Slice 9/11 (#2571) — added `RolesPolicyLive` (custom-role CRUD +
- *   F-53 permission chokepoint).
- * Slice 10/11 (#2572) — added `BrandingLive` + `DomainsLive` +
- *                       `ProactiveGateLive` + `DeployModeResolverLive`
- *                       (bundled to avoid four PRs of Tag scaffolding
- *                       overhead for narrow-surface subsystems).
- *
- * #2727 (slice 1 of #2726) — added `SaasCrmLive`. First-touch CRM
- *   dispatch for Atlas's own SaaS funnel (demo signup; signup hook +
- *   contact form follow in later #2726 slices). Backed by the
- *   `@useatlas/twenty` plugin; self-hosters get the Noop default.
- *
- * Slice 11/11 (#2573 closeout) follows next: CI grep gate + symlink-stub
- * job + back-compat shim cleanup. See the parent issue (#2017) for the
- * rationale.
- *
- * Follow-up #2587 — split `AuditRetention` Tag into CRUD-only +
- * `AuditPurgeScheduler` lifecycle Tag (removes the `require()` circular
- * workaround in `audit/retention.ts` and lifts the scheduler `start*` /
- * `stop*` pair to Effect-returning so failures are observable in tests).
+ * Every Tag bound here must appear in the union type below — that's the
+ * only invariant.
  */
 
 import { Layer } from "effect";

--- a/ee/src/layers.ts
+++ b/ee/src/layers.ts
@@ -23,6 +23,11 @@
  *                       (bundled to avoid four PRs of Tag scaffolding
  *                       overhead for narrow-surface subsystems).
  *
+ * #2727 (slice 1 of #2726) — added `SaasCrmLive`. First-touch CRM
+ *   dispatch for Atlas's own SaaS funnel (demo signup; signup hook +
+ *   contact form follow in later #2726 slices). Backed by the
+ *   `@useatlas/twenty` plugin; self-hosters get the Noop default.
+ *
  * Slice 11/11 (#2573 closeout) follows next: CI grep gate + symlink-stub
  * job + back-compat shim cleanup. See the parent issue (#2017) for the
  * rationale.
@@ -49,6 +54,7 @@ import type {
   ProactiveGate,
   ResidencyResolver,
   RolesPolicy,
+  SaasCrm,
   SCIMProvenance,
   SSOPolicy,
   SlaMetrics,
@@ -70,6 +76,7 @@ import { BrandingLive } from "./branding/white-label";
 import { DomainsLive } from "./platform/domains";
 import { ProactiveGateLive } from "./proactive-gate";
 import { DeployModeResolverLive } from "./deploy-mode";
+import { SaasCrmLive } from "./saas-crm/index";
 
 /**
  * Aggregated EE Layer — typed by the union of every Tag this module
@@ -92,6 +99,7 @@ export const EELayer: Layer.Layer<
   | ProactiveGate
   | ResidencyResolver
   | RolesPolicy
+  | SaasCrm
   | SCIMProvenance
   | SSOPolicy
   | SlaMetrics
@@ -113,4 +121,5 @@ export const EELayer: Layer.Layer<
   DomainsLive,
   ProactiveGateLive,
   DeployModeResolverLive,
+  SaasCrmLive,
 );

--- a/ee/src/saas-crm/__tests__/saas-crm.test.ts
+++ b/ee/src/saas-crm/__tests__/saas-crm.test.ts
@@ -1,10 +1,10 @@
 /**
- * SaasCrm layer tests — boot verification + dispatch behavior.
+ * SaasCrm layer tests — boot verification + dispatch + end-to-end Live wiring.
  *
- * These tests exercise the EE-side Layer (`SaasCrmLive`) directly with
- * a mocked fetch impl, isolating from both the plugin's HTTP wrapper
- * (covered separately in `plugins/twenty/__tests__/`) and from Twenty
- * itself. There are NO live calls to crm.useatlas.dev.
+ * Exercises the EE-side Layer (`SaasCrmLive`) with a mocked fetch impl,
+ * isolating from both the plugin's HTTP wrapper (covered in
+ * `plugins/twenty/__tests__/`) and from Twenty itself. There are NO
+ * live calls to crm.useatlas.dev.
  */
 
 import { describe, test, expect, beforeEach, mock } from "bun:test";
@@ -26,7 +26,41 @@ mock.module("@atlas/api/lib/logger", () => ({
 }));
 
 // ── Now we can import the layer + its helpers ───────────────────────
-const { verifyCustomFields, dispatchLead } = await import("../index");
+const { verifyCustomFields, dispatchLead, SaasCrmLive } = await import("../index");
+const { SaasCrm } = await import("@atlas/api/lib/effect/services");
+
+// ── Fixture helpers ─────────────────────────────────────────────────
+
+function metadataResponse(fieldNames: string[]): Response {
+  return new Response(
+    JSON.stringify({
+      data: {
+        objects: {
+          edges: [
+            {
+              node: {
+                fields: {
+                  edges: fieldNames.map((name) => ({ node: { name } })),
+                },
+              },
+            },
+          ],
+        },
+      },
+    }),
+    { status: 200, headers: { "Content-Type": "application/json" } },
+  );
+}
+
+function withFetch<T>(impl: typeof globalThis.fetch, run: () => Promise<T>): Promise<T> {
+  const orig = globalThis.fetch;
+  globalThis.fetch = impl;
+  return run().finally(() => {
+    globalThis.fetch = orig;
+  });
+}
+
+// ── verifyCustomFields ──────────────────────────────────────────────
 
 describe("verifyCustomFields", () => {
   beforeEach(() => {
@@ -35,150 +69,155 @@ describe("verifyCustomFields", () => {
 
   test("returns ok=true when both required custom fields are present", async () => {
     const fetchImpl = (async () =>
-      new Response(
-        JSON.stringify({
-          data: {
-            fields: [
-              { name: "id" },
-              { name: "atlasFirstSource" },
-              { name: "atlasLastSource" },
-            ],
-          },
-        }),
-        { status: 200, headers: { "Content-Type": "application/json" } },
-      )) as unknown as typeof globalThis.fetch;
-    const origFetch = globalThis.fetch;
-    globalThis.fetch = fetchImpl;
-    try {
+      metadataResponse(["id", "atlasFirstSource", "atlasLastSource"])) as unknown as typeof globalThis.fetch;
+
+    await withFetch(fetchImpl, async () => {
       const result = await verifyCustomFields({
         apiKey: "k",
         baseUrl: "https://crm.test.local",
       });
       expect(result).toEqual({ ok: true });
-    } finally {
-      globalThis.fetch = origFetch;
-    }
+    });
   });
 
   test("returns ok=false when atlasFirstSource is missing", async () => {
     const fetchImpl = (async () =>
-      new Response(
-        JSON.stringify({
-          data: { fields: [{ name: "id" }, { name: "atlasLastSource" }] },
-        }),
-        { status: 200, headers: { "Content-Type": "application/json" } },
-      )) as unknown as typeof globalThis.fetch;
-    const origFetch = globalThis.fetch;
-    globalThis.fetch = fetchImpl;
-    try {
+      metadataResponse(["id", "atlasLastSource"])) as unknown as typeof globalThis.fetch;
+
+    await withFetch(fetchImpl, async () => {
       const result = await verifyCustomFields({
         apiKey: "k",
         baseUrl: "https://crm.test.local",
       });
       expect(result).toEqual({ ok: false });
-    } finally {
-      globalThis.fetch = origFetch;
-    }
+    });
   });
 
   test("returns ok=false when atlasLastSource is missing", async () => {
     const fetchImpl = (async () =>
-      new Response(
-        JSON.stringify({
-          data: { fields: [{ name: "id" }, { name: "atlasFirstSource" }] },
-        }),
-        { status: 200, headers: { "Content-Type": "application/json" } },
-      )) as unknown as typeof globalThis.fetch;
-    const origFetch = globalThis.fetch;
-    globalThis.fetch = fetchImpl;
-    try {
+      metadataResponse(["id", "atlasFirstSource"])) as unknown as typeof globalThis.fetch;
+
+    await withFetch(fetchImpl, async () => {
       const result = await verifyCustomFields({
         apiKey: "k",
         baseUrl: "https://crm.test.local",
       });
       expect(result).toEqual({ ok: false });
-    } finally {
-      globalThis.fetch = origFetch;
-    }
+    });
   });
 
-  test("returns ok='transient' when metadata endpoint errors", async () => {
+  test("returns ok='transient' on 5xx (transient upstream failure)", async () => {
     const fetchImpl = (async () =>
-      new Response("oops", { status: 503 })) as unknown as typeof globalThis.fetch;
-    const origFetch = globalThis.fetch;
-    globalThis.fetch = fetchImpl;
-    try {
+      new Response(JSON.stringify({ messages: ["oops"] }), {
+        status: 503,
+        headers: { "Content-Type": "application/json" },
+      })) as unknown as typeof globalThis.fetch;
+
+    await withFetch(fetchImpl, async () => {
       const result = await verifyCustomFields({
         apiKey: "k",
         baseUrl: "https://crm.test.local",
       });
-      if (result.ok !== "transient") {
-        throw new Error("expected transient");
-      }
+      if (result.ok !== "transient") throw new Error("expected transient");
       expect(result.reason.length).toBeGreaterThan(0);
-    } finally {
-      globalThis.fetch = origFetch;
-    }
+    });
   });
 
   test("returns ok='transient' on network failure", async () => {
     const fetchImpl = (async () => {
       throw new Error("ECONNREFUSED");
     }) as unknown as typeof globalThis.fetch;
-    const origFetch = globalThis.fetch;
-    globalThis.fetch = fetchImpl;
-    try {
+
+    await withFetch(fetchImpl, async () => {
       const result = await verifyCustomFields({
         apiKey: "k",
         baseUrl: "https://crm.test.local",
       });
-      if (result.ok !== "transient") {
-        throw new Error("expected transient");
-      }
+      if (result.ok !== "transient") throw new Error("expected transient");
       expect(result.reason).toContain("ECONNREFUSED");
-    } finally {
-      globalThis.fetch = origFetch;
-    }
+    });
+  });
+
+  // CX-2 — deterministic misconfigurations are NOT transient.
+
+  test("returns ok=false on 401 (bad API key — deterministic misconfiguration)", async () => {
+    const fetchImpl = (async () =>
+      new Response(JSON.stringify({ messages: ["Unauthorized"] }), {
+        status: 401,
+        headers: { "Content-Type": "application/json" },
+      })) as unknown as typeof globalThis.fetch;
+
+    await withFetch(fetchImpl, async () => {
+      const result = await verifyCustomFields({
+        apiKey: "wrong-key",
+        baseUrl: "https://crm.test.local",
+      });
+      expect(result).toEqual({ ok: false });
+    });
+  });
+
+  test("returns ok=false on 403 (deterministic misconfiguration)", async () => {
+    const fetchImpl = (async () =>
+      new Response(JSON.stringify({ messages: ["Forbidden"] }), {
+        status: 403,
+        headers: { "Content-Type": "application/json" },
+      })) as unknown as typeof globalThis.fetch;
+
+    await withFetch(fetchImpl, async () => {
+      const result = await verifyCustomFields({
+        apiKey: "k",
+        baseUrl: "https://crm.test.local",
+      });
+      expect(result).toEqual({ ok: false });
+    });
+  });
+
+  test("returns ok=false on 404 (wrong base URL — deterministic misconfiguration)", async () => {
+    const fetchImpl = (async () =>
+      new Response(JSON.stringify({ messages: ["Not Found"] }), {
+        status: 404,
+        headers: { "Content-Type": "application/json" },
+      })) as unknown as typeof globalThis.fetch;
+
+    await withFetch(fetchImpl, async () => {
+      const result = await verifyCustomFields({
+        apiKey: "k",
+        baseUrl: "https://crm.test.local",
+      });
+      expect(result).toEqual({ ok: false });
+    });
   });
 });
+
+// ── dispatchLead — fire-and-forget contract ─────────────────────────
 
 describe("dispatchLead", () => {
   test("happy path — normalizes and upserts; does not throw", async () => {
     let fetchCount = 0;
     const fetchImpl = (async (
       input: string | URL | Request,
-      _init?: RequestInit,
     ): Promise<Response> => {
       fetchCount++;
       const url = typeof input === "string" ? input : (input as Request).url;
-      if (url.includes("/rest/people?filter=")) {
-        // GET — not found
+      if (url.includes("/rest/people?filter")) {
         return new Response(JSON.stringify({ data: { people: [] } }), {
           status: 200,
           headers: { "Content-Type": "application/json" },
         });
       }
-      // POST createPerson
       return new Response(
         JSON.stringify({ data: { createPerson: { id: "person_xyz" } } }),
         { status: 200, headers: { "Content-Type": "application/json" } },
       );
     }) as unknown as typeof globalThis.fetch;
-    const origFetch = globalThis.fetch;
-    globalThis.fetch = fetchImpl;
-    try {
+
+    await withFetch(fetchImpl, async () => {
       await dispatchLead(
         { apiKey: "k", baseUrl: "https://crm.test.local" },
-        {
-          source: "demo",
-          email: "user@test.com",
-          ip: "1.2.3.4",
-        },
+        { source: "demo", email: "user@test.com", ip: "1.2.3.4" },
       );
       expect(fetchCount).toBe(2);
-    } finally {
-      globalThis.fetch = origFetch;
-    }
+    });
   });
 
   test("never throws when Twenty returns a 5xx", async () => {
@@ -187,48 +226,57 @@ describe("dispatchLead", () => {
         status: 500,
         headers: { "Content-Type": "application/json" },
       })) as unknown as typeof globalThis.fetch;
-    const origFetch = globalThis.fetch;
-    globalThis.fetch = fetchImpl;
-    try {
-      // Should resolve, not reject. That contract is the whole point of
-      // the SaasCrm layer.
+
+    await withFetch(fetchImpl, async () => {
       await expect(
         dispatchLead(
           { apiKey: "k", baseUrl: "https://crm.test.local" },
           { source: "demo", email: "user@test.com" },
         ),
       ).resolves.toBeUndefined();
-    } finally {
-      globalThis.fetch = origFetch;
-    }
+    });
   });
 
   test("never throws on network failure", async () => {
     const fetchImpl = (async () => {
       throw new Error("ECONNREFUSED");
     }) as unknown as typeof globalThis.fetch;
-    const origFetch = globalThis.fetch;
-    globalThis.fetch = fetchImpl;
-    try {
+
+    await withFetch(fetchImpl, async () => {
       await expect(
         dispatchLead(
           { apiKey: "k", baseUrl: "https://crm.test.local" },
           { source: "demo", email: "user@test.com" },
         ),
       ).resolves.toBeUndefined();
-    } finally {
-      globalThis.fetch = origFetch;
-    }
+    });
+  });
+
+  test("never throws on malformed-200 from findPersonByEmail", async () => {
+    const fetchImpl = (async () =>
+      new Response(JSON.stringify({ data: { people: null } }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })) as unknown as typeof globalThis.fetch;
+
+    await withFetch(fetchImpl, async () => {
+      await expect(
+        dispatchLead(
+          { apiKey: "k", baseUrl: "https://crm.test.local" },
+          { source: "demo", email: "user@test.com" },
+        ),
+      ).resolves.toBeUndefined();
+    });
   });
 });
+
+// ── SaasCrmLive boot end-to-end ─────────────────────────────────────
 
 describe("SaasCrmLive boot — enterprise disabled", () => {
   test("yields available=false and no-op upsertLead when enterprise is OFF", async () => {
     enterpriseEnabled = false;
-    // Re-import the layer fresh — Layer.effect captures the gate read on construction.
-    delete require.cache?.[require.resolve("../index")];
-    const { SaasCrmLive } = await import("../index");
-    const { SaasCrm } = await import("@atlas/api/lib/effect/services");
+    delete process.env.TWENTY_API_KEY;
+    delete process.env.TWENTY_BASE_URL;
 
     const program = Effect.gen(function* () {
       const crm = yield* SaasCrm;
@@ -240,5 +288,191 @@ describe("SaasCrmLive boot — enterprise disabled", () => {
       program.pipe(Effect.provide(SaasCrmLive)),
     );
     expect(available).toBe(false);
+  });
+});
+
+describe("SaasCrmLive boot — enterprise enabled + creds + both fields present (R-6)", () => {
+  test("yields available=true AND dispatches via TwentyClient on subsequent upsertLead", async () => {
+    enterpriseEnabled = true;
+    process.env.TWENTY_API_KEY = "test-key";
+    process.env.TWENTY_BASE_URL = "https://crm.test.local";
+
+    let metadataCalls = 0;
+    let dispatchCalls = 0;
+    const fetchImpl = (async (
+      input: string | URL | Request,
+    ): Promise<Response> => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url.endsWith("/metadata")) {
+        metadataCalls++;
+        return metadataResponse(["id", "atlasFirstSource", "atlasLastSource"]);
+      }
+      dispatchCalls++;
+      if (url.includes("/rest/people?filter")) {
+        return new Response(JSON.stringify({ data: { people: [] } }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      return new Response(
+        JSON.stringify({ data: { createPerson: { id: "person_xyz" } } }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }) as unknown as typeof globalThis.fetch;
+
+    try {
+      const result = await withFetch(fetchImpl, async () => {
+        const program = Effect.gen(function* () {
+          const crm = yield* SaasCrm;
+          const wasAvailable = crm.available;
+          yield* crm.upsertLead({
+            source: "demo",
+            email: "verified@happy.test",
+          });
+          return wasAvailable;
+        });
+        return Effect.runPromise(program.pipe(Effect.provide(SaasCrmLive)));
+      });
+
+      expect(result).toBe(true);
+      expect(metadataCalls).toBe(1);
+      // Dispatch: 1 GET (find) + 1 POST (create)
+      expect(dispatchCalls).toBe(2);
+    } finally {
+      delete process.env.TWENTY_API_KEY;
+      delete process.env.TWENTY_BASE_URL;
+    }
+  });
+});
+
+describe("SaasCrmLive boot — missing required field flips available to false (R-5)", () => {
+  test("yields available=false when atlasFirstSource is missing", async () => {
+    enterpriseEnabled = true;
+    process.env.TWENTY_API_KEY = "test-key";
+    process.env.TWENTY_BASE_URL = "https://crm.test.local";
+
+    let dispatchCalls = 0;
+    const fetchImpl = (async (
+      input: string | URL | Request,
+    ): Promise<Response> => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url.endsWith("/metadata")) {
+        // Only atlasLastSource present — atlasFirstSource missing
+        return metadataResponse(["id", "atlasLastSource"]);
+      }
+      dispatchCalls++;
+      return new Response(JSON.stringify({}), { status: 500 });
+    }) as unknown as typeof globalThis.fetch;
+
+    try {
+      const result = await withFetch(fetchImpl, async () => {
+        const program = Effect.gen(function* () {
+          const crm = yield* SaasCrm;
+          // Should be a no-op since available=false
+          yield* crm.upsertLead({
+            source: "demo",
+            email: "missingfield@x.test",
+          });
+          return crm.available;
+        });
+        return Effect.runPromise(program.pipe(Effect.provide(SaasCrmLive)));
+      });
+
+      expect(result).toBe(false);
+      // No dispatch calls should have happened (Noop upsertLead bound).
+      expect(dispatchCalls).toBe(0);
+    } finally {
+      delete process.env.TWENTY_API_KEY;
+      delete process.env.TWENTY_BASE_URL;
+    }
+  });
+});
+
+describe("SaasCrmLive boot — transient metadata failure leaves available=true (R-7)", () => {
+  test("yields available=true when the metadata probe rejects with a network error", async () => {
+    enterpriseEnabled = true;
+    process.env.TWENTY_API_KEY = "test-key";
+    process.env.TWENTY_BASE_URL = "https://crm.test.local";
+
+    let metadataCalls = 0;
+    let dispatchCalls = 0;
+    const fetchImpl = (async (
+      input: string | URL | Request,
+    ): Promise<Response> => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url.endsWith("/metadata")) {
+        metadataCalls++;
+        throw new Error("ECONNRESET");
+      }
+      dispatchCalls++;
+      if (url.includes("/rest/people?filter")) {
+        return new Response(JSON.stringify({ data: { people: [] } }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      return new Response(
+        JSON.stringify({ data: { createPerson: { id: "p1" } } }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }) as unknown as typeof globalThis.fetch;
+
+    try {
+      const result = await withFetch(fetchImpl, async () => {
+        const program = Effect.gen(function* () {
+          const crm = yield* SaasCrm;
+          yield* crm.upsertLead({ source: "demo", email: "transient@x.test" });
+          return crm.available;
+        });
+        return Effect.runPromise(program.pipe(Effect.provide(SaasCrmLive)));
+      });
+
+      expect(result).toBe(true);
+      expect(metadataCalls).toBe(1);
+      expect(dispatchCalls).toBeGreaterThan(0);
+    } finally {
+      delete process.env.TWENTY_API_KEY;
+      delete process.env.TWENTY_BASE_URL;
+    }
+  });
+});
+
+describe("SaasCrmLive boot — 401 metadata response flips to permanent (CX-2)", () => {
+  test("yields available=false on 401 and does NOT dispatch", async () => {
+    enterpriseEnabled = true;
+    process.env.TWENTY_API_KEY = "test-key";
+    process.env.TWENTY_BASE_URL = "https://crm.test.local";
+
+    let dispatchCalls = 0;
+    const fetchImpl = (async (
+      input: string | URL | Request,
+    ): Promise<Response> => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url.endsWith("/metadata")) {
+        return new Response(JSON.stringify({ messages: ["Unauthorized"] }), {
+          status: 401,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      dispatchCalls++;
+      return new Response(JSON.stringify({}), { status: 500 });
+    }) as unknown as typeof globalThis.fetch;
+
+    try {
+      const result = await withFetch(fetchImpl, async () => {
+        const program = Effect.gen(function* () {
+          const crm = yield* SaasCrm;
+          yield* crm.upsertLead({ source: "demo", email: "x@y.test" });
+          return crm.available;
+        });
+        return Effect.runPromise(program.pipe(Effect.provide(SaasCrmLive)));
+      });
+
+      expect(result).toBe(false);
+      expect(dispatchCalls).toBe(0);
+    } finally {
+      delete process.env.TWENTY_API_KEY;
+      delete process.env.TWENTY_BASE_URL;
+    }
   });
 });

--- a/ee/src/saas-crm/__tests__/saas-crm.test.ts
+++ b/ee/src/saas-crm/__tests__/saas-crm.test.ts
@@ -1,0 +1,244 @@
+/**
+ * SaasCrm layer tests — boot verification + dispatch behavior.
+ *
+ * These tests exercise the EE-side Layer (`SaasCrmLive`) directly with
+ * a mocked fetch impl, isolating from both the plugin's HTTP wrapper
+ * (covered separately in `plugins/twenty/__tests__/`) and from Twenty
+ * itself. There are NO live calls to crm.useatlas.dev.
+ */
+
+import { describe, test, expect, beforeEach, mock } from "bun:test";
+import { Effect } from "effect";
+
+// ── Mock the enterprise gate BEFORE importing the layer ─────────────
+let enterpriseEnabled = true;
+mock.module("../../index", () => ({
+  isEnterpriseEnabled: () => enterpriseEnabled,
+}));
+
+mock.module("@atlas/api/lib/logger", () => ({
+  createLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  }),
+}));
+
+// ── Now we can import the layer + its helpers ───────────────────────
+const { verifyCustomFields, dispatchLead } = await import("../index");
+
+describe("verifyCustomFields", () => {
+  beforeEach(() => {
+    enterpriseEnabled = true;
+  });
+
+  test("returns ok=true when both required custom fields are present", async () => {
+    const fetchImpl = (async () =>
+      new Response(
+        JSON.stringify({
+          data: {
+            fields: [
+              { name: "id" },
+              { name: "atlasFirstSource" },
+              { name: "atlasLastSource" },
+            ],
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      )) as unknown as typeof globalThis.fetch;
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = fetchImpl;
+    try {
+      const result = await verifyCustomFields({
+        apiKey: "k",
+        baseUrl: "https://crm.test.local",
+      });
+      expect(result).toEqual({ ok: true });
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+  });
+
+  test("returns ok=false when atlasFirstSource is missing", async () => {
+    const fetchImpl = (async () =>
+      new Response(
+        JSON.stringify({
+          data: { fields: [{ name: "id" }, { name: "atlasLastSource" }] },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      )) as unknown as typeof globalThis.fetch;
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = fetchImpl;
+    try {
+      const result = await verifyCustomFields({
+        apiKey: "k",
+        baseUrl: "https://crm.test.local",
+      });
+      expect(result).toEqual({ ok: false });
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+  });
+
+  test("returns ok=false when atlasLastSource is missing", async () => {
+    const fetchImpl = (async () =>
+      new Response(
+        JSON.stringify({
+          data: { fields: [{ name: "id" }, { name: "atlasFirstSource" }] },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      )) as unknown as typeof globalThis.fetch;
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = fetchImpl;
+    try {
+      const result = await verifyCustomFields({
+        apiKey: "k",
+        baseUrl: "https://crm.test.local",
+      });
+      expect(result).toEqual({ ok: false });
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+  });
+
+  test("returns ok='transient' when metadata endpoint errors", async () => {
+    const fetchImpl = (async () =>
+      new Response("oops", { status: 503 })) as unknown as typeof globalThis.fetch;
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = fetchImpl;
+    try {
+      const result = await verifyCustomFields({
+        apiKey: "k",
+        baseUrl: "https://crm.test.local",
+      });
+      if (result.ok !== "transient") {
+        throw new Error("expected transient");
+      }
+      expect(result.reason.length).toBeGreaterThan(0);
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+  });
+
+  test("returns ok='transient' on network failure", async () => {
+    const fetchImpl = (async () => {
+      throw new Error("ECONNREFUSED");
+    }) as unknown as typeof globalThis.fetch;
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = fetchImpl;
+    try {
+      const result = await verifyCustomFields({
+        apiKey: "k",
+        baseUrl: "https://crm.test.local",
+      });
+      if (result.ok !== "transient") {
+        throw new Error("expected transient");
+      }
+      expect(result.reason).toContain("ECONNREFUSED");
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+  });
+});
+
+describe("dispatchLead", () => {
+  test("happy path — normalizes and upserts; does not throw", async () => {
+    let fetchCount = 0;
+    const fetchImpl = (async (
+      input: string | URL | Request,
+      _init?: RequestInit,
+    ): Promise<Response> => {
+      fetchCount++;
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url.includes("/rest/people?filter=")) {
+        // GET — not found
+        return new Response(JSON.stringify({ data: { people: [] } }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      // POST createPerson
+      return new Response(
+        JSON.stringify({ data: { createPerson: { id: "person_xyz" } } }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }) as unknown as typeof globalThis.fetch;
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = fetchImpl;
+    try {
+      await dispatchLead(
+        { apiKey: "k", baseUrl: "https://crm.test.local" },
+        {
+          source: "demo",
+          email: "user@test.com",
+          ip: "1.2.3.4",
+        },
+      );
+      expect(fetchCount).toBe(2);
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+  });
+
+  test("never throws when Twenty returns a 5xx", async () => {
+    const fetchImpl = (async () =>
+      new Response(JSON.stringify({ messages: ["Internal Server Error"] }), {
+        status: 500,
+        headers: { "Content-Type": "application/json" },
+      })) as unknown as typeof globalThis.fetch;
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = fetchImpl;
+    try {
+      // Should resolve, not reject. That contract is the whole point of
+      // the SaasCrm layer.
+      await expect(
+        dispatchLead(
+          { apiKey: "k", baseUrl: "https://crm.test.local" },
+          { source: "demo", email: "user@test.com" },
+        ),
+      ).resolves.toBeUndefined();
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+  });
+
+  test("never throws on network failure", async () => {
+    const fetchImpl = (async () => {
+      throw new Error("ECONNREFUSED");
+    }) as unknown as typeof globalThis.fetch;
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = fetchImpl;
+    try {
+      await expect(
+        dispatchLead(
+          { apiKey: "k", baseUrl: "https://crm.test.local" },
+          { source: "demo", email: "user@test.com" },
+        ),
+      ).resolves.toBeUndefined();
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+  });
+});
+
+describe("SaasCrmLive boot — enterprise disabled", () => {
+  test("yields available=false and no-op upsertLead when enterprise is OFF", async () => {
+    enterpriseEnabled = false;
+    // Re-import the layer fresh — Layer.effect captures the gate read on construction.
+    delete require.cache?.[require.resolve("../index")];
+    const { SaasCrmLive } = await import("../index");
+    const { SaasCrm } = await import("@atlas/api/lib/effect/services");
+
+    const program = Effect.gen(function* () {
+      const crm = yield* SaasCrm;
+      yield* crm.upsertLead({ source: "demo", email: "x@y.com" });
+      return crm.available;
+    });
+
+    const available = await Effect.runPromise(
+      program.pipe(Effect.provide(SaasCrmLive)),
+    );
+    expect(available).toBe(false);
+  });
+});

--- a/ee/src/saas-crm/index.ts
+++ b/ee/src/saas-crm/index.ts
@@ -1,0 +1,217 @@
+/**
+ * SaaS CRM wiring — slice 1 of #2726 (#2727).
+ *
+ * Connects Atlas SaaS demo / (future) signup / (future) contact flows
+ * into the Twenty CRM instance at crm.useatlas.dev via the
+ * `@useatlas/twenty` plugin. Gated by `isEnterpriseEnabled()` —
+ * self-hosters get the Noop layer from
+ * `lib/effect/services.ts:NoopSaasCrmLayer`.
+ *
+ * Boot behavior:
+ *  1. If enterprise is DISABLED → return `{ available: false }`.
+ *  2. If `TWENTY_API_KEY` is unset → log warn, return `{ available: false }`.
+ *  3. Verify that `atlasFirstSource` AND `atlasLastSource` custom fields
+ *     exist on the Twenty Person object via the metadata endpoint.
+ *     - Both present → `available: true`.
+ *     - Either missing → `log.error` with exact creation instructions;
+ *       `available: false`.
+ *     - Metadata endpoint errors (transient network) → log warn,
+ *       leave `available: true` so dispatches still attempt; a
+ *       missing-field response will surface as the upstream 422 on
+ *       the upsert call.
+ *
+ * Dispatch path (`upsertLead`):
+ *  - Normalize the event via `LeadNormalizer` (slice 1: demo only).
+ *  - Invoke `TwentyClient.upsertPerson` with credentials from
+ *    `TwentyCredentialResolver.resolveCredentialsFromEnv()`.
+ *  - On any failure: log a warning and swallow the error (return success).
+ *    Atlas's demo-gate path must never block on Twenty.
+ *
+ * The durable outbox + retry loop arrives in slice 4 of #2726. Until
+ * then, this is fire-and-forget — Twenty being down loses the lead.
+ */
+
+import { Effect, Layer } from "effect";
+import {
+  SaasCrm,
+  type SaasCrmShape,
+  type SaasCrmLeadInput,
+} from "@atlas/api/lib/effect/services";
+import { createLogger } from "@atlas/api/lib/logger";
+import { isEnterpriseEnabled } from "../index";
+import {
+  getPersonMetadata,
+  tryResolveCredentialsFromEnv,
+  normalizeLead,
+  upsertPerson,
+  TwentyClientError,
+  type ResolvedTwentyCredentials,
+  type TwentyClientConfig,
+} from "@useatlas/twenty";
+
+const log = createLogger("ee:saas-crm");
+
+const REQUIRED_PERSON_FIELDS = ["atlasFirstSource", "atlasLastSource"] as const;
+
+/**
+ * Build the create-instructions string for a missing custom field. The
+ * exact text is part of the slice-1 acceptance criteria — when an
+ * operator sees this, they should be able to follow it without
+ * cross-referencing the README.
+ */
+function missingFieldInstructions(missing: ReadonlyArray<string>): string {
+  return (
+    `Twenty Person object is missing required Atlas custom field(s): ${missing.join(", ")}. ` +
+    `Create them in the Twenty UI under Settings → Data Model → Person → + Add Field. ` +
+    `Each field should be of type "Text". SaaS CRM dispatch is disabled until both ` +
+    `atlasFirstSource and atlasLastSource exist on the Person object.`
+  );
+}
+
+/**
+ * Run startup verification against the Twenty metadata endpoint.
+ *
+ * Returns:
+ *  - { ok: true } when both required fields are present.
+ *  - { ok: false } when one or both fields are missing (a structured
+ *    log.error has already been emitted).
+ *  - { ok: "transient" } when the metadata endpoint itself errored
+ *    (network blip / 5xx / parse failure). Per spec we leave the
+ *    layer available — the upsert call will surface any real schema
+ *    drift as a 422 upstream error.
+ */
+async function verifyCustomFields(
+  creds: ResolvedTwentyCredentials,
+): Promise<{ ok: true } | { ok: false } | { ok: "transient"; reason: string }> {
+  try {
+    const meta = await getPersonMetadata({
+      apiKey: creds.apiKey,
+      baseUrl: creds.baseUrl,
+    });
+    const present = new Set(meta.fields.map((f) => f.name));
+    const missing = REQUIRED_PERSON_FIELDS.filter((f) => !present.has(f));
+    if (missing.length === 0) return { ok: true };
+    log.error(
+      { missing, event: "saas_crm.custom_fields_missing" },
+      missingFieldInstructions(missing),
+    );
+    return { ok: false };
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    return { ok: "transient", reason };
+  }
+}
+
+/**
+ * Dispatch a normalized lead via TwentyClient. Errors are caught and
+ * logged inside this function so the SaasCrmShape Effect channel can
+ * stay typed as `Effect<void>` (no error channel) — that contract is
+ * what makes the call-site short (`yield* SaasCrm` then
+ * `yield* upsertLead(input)` with nothing to catch).
+ */
+async function dispatchLead(
+  clientConfig: TwentyClientConfig,
+  input: SaasCrmLeadInput,
+): Promise<void> {
+  try {
+    const normalized = normalizeLead(input);
+    await upsertPerson(clientConfig, normalized.person);
+    log.debug(
+      { source: input.source, eventSource: normalized.eventSource },
+      "SaaS CRM lead dispatched to Twenty",
+    );
+  } catch (err) {
+    // Twenty being down (or a missing custom field, or a bad key)
+    // MUST NOT block the caller. We log loudly enough that an operator
+    // can correlate but never re-throw.
+    if (err instanceof TwentyClientError) {
+      log.warn(
+        {
+          source: input.source,
+          status: err.status,
+          upstreamCode: err.upstreamCode,
+          err: err.message,
+          event: "saas_crm.dispatch_failed",
+        },
+        "Twenty upsertPerson failed — lead lost (durable outbox lands in slice 4)",
+      );
+    } else {
+      log.warn(
+        {
+          source: input.source,
+          err: err instanceof Error ? err.message : String(err),
+          event: "saas_crm.dispatch_failed",
+        },
+        "Twenty dispatch threw unexpectedly — lead lost",
+      );
+    }
+  }
+}
+
+/**
+ * Build the live SaasCrm service. Runs the boot-time verification once
+ * inside `Layer.effect` — `available` is the result of that check; it
+ * does NOT re-verify on every `upsertLead` call.
+ */
+export const SaasCrmLive: Layer.Layer<SaasCrm> = Layer.effect(
+  SaasCrm,
+  Effect.gen(function* () {
+    const enterpriseOn = isEnterpriseEnabled();
+    if (!enterpriseOn) {
+      log.info("Enterprise disabled — SaasCrm.available=false");
+      return {
+        available: false,
+        upsertLead: () => Effect.void,
+      } satisfies SaasCrmShape;
+    }
+
+    const creds = tryResolveCredentialsFromEnv();
+    if (!creds) {
+      log.warn(
+        { event: "saas_crm.credentials_absent" },
+        "TWENTY_API_KEY not set — SaasCrm.available=false. Set TWENTY_API_KEY (and optionally TWENTY_BASE_URL) to enable SaaS CRM dispatch.",
+      );
+      return {
+        available: false,
+        upsertLead: () => Effect.void,
+      } satisfies SaasCrmShape;
+    }
+
+    const verifyResult = yield* Effect.promise(() => verifyCustomFields(creds));
+    if (verifyResult.ok === false) {
+      // Already logged inside verifyCustomFields. Surface as unavailable
+      // so subsequent demo signups are no-ops rather than dead-letter
+      // rows in the (future) outbox.
+      return {
+        available: false,
+        upsertLead: () => Effect.void,
+      } satisfies SaasCrmShape;
+    }
+    if (verifyResult.ok === "transient") {
+      log.warn(
+        { err: verifyResult.reason, event: "saas_crm.verify_transient_failure" },
+        "Twenty metadata endpoint errored during boot verification — assuming custom fields are present. " +
+          "A real schema mismatch will surface as a 422 on the first upsertPerson call.",
+      );
+    } else {
+      log.info(
+        { baseUrl: creds.baseUrl, event: "saas_crm.ready" },
+        "SaasCrm wired up — atlasFirstSource + atlasLastSource verified on Twenty Person",
+      );
+    }
+
+    const clientConfig: TwentyClientConfig = {
+      apiKey: creds.apiKey,
+      baseUrl: creds.baseUrl,
+    };
+
+    return {
+      available: true,
+      upsertLead: (input) =>
+        Effect.promise(() => dispatchLead(clientConfig, input)),
+    } satisfies SaasCrmShape;
+  }),
+);
+
+// Re-exported for direct testing of the verification / dispatch logic.
+export { verifyCustomFields, dispatchLead };

--- a/ee/src/saas-crm/index.ts
+++ b/ee/src/saas-crm/index.ts
@@ -1,34 +1,13 @@
 /**
- * SaaS CRM wiring — slice 1 of #2726 (#2727).
- *
- * Connects Atlas SaaS demo / (future) signup / (future) contact flows
- * into the Twenty CRM instance at crm.useatlas.dev via the
- * `@useatlas/twenty` plugin. Gated by `isEnterpriseEnabled()` —
- * self-hosters get the Noop layer from
+ * SaaS CRM wiring — connects Atlas SaaS lead-capture flows into the
+ * Twenty CRM instance at `crm.useatlas.dev` via the `@useatlas/twenty`
+ * plugin. Self-hosted Atlas gets the Noop layer from
  * `lib/effect/services.ts:NoopSaasCrmLayer`.
  *
- * Boot behavior:
- *  1. If enterprise is DISABLED → return `{ available: false }`.
- *  2. If `TWENTY_API_KEY` is unset → log warn, return `{ available: false }`.
- *  3. Verify that `atlasFirstSource` AND `atlasLastSource` custom fields
- *     exist on the Twenty Person object via the metadata endpoint.
- *     - Both present → `available: true`.
- *     - Either missing → `log.error` with exact creation instructions;
- *       `available: false`.
- *     - Metadata endpoint errors (transient network) → log warn,
- *       leave `available: true` so dispatches still attempt; a
- *       missing-field response will surface as the upstream 422 on
- *       the upsert call.
- *
- * Dispatch path (`upsertLead`):
- *  - Normalize the event via `LeadNormalizer` (slice 1: demo only).
- *  - Invoke `TwentyClient.upsertPerson` with credentials from
- *    `TwentyCredentialResolver.resolveCredentialsFromEnv()`.
- *  - On any failure: log a warning and swallow the error (return success).
- *    Atlas's demo-gate path must never block on Twenty.
- *
- * The durable outbox + retry loop arrives in slice 4 of #2726. Until
- * then, this is fire-and-forget — Twenty being down loses the lead.
+ * Transient metadata-probe failures deliberately leave `available: true`
+ * — a real schema mismatch surfaces as a 422 on the first upsert call.
+ * Deterministic misconfigurations (401/403/404) flip to permanent so
+ * leads aren't lost silently against a clearly-broken endpoint.
  */
 
 import { Effect, Layer } from "effect";
@@ -54,11 +33,25 @@ const log = createLogger("ee:saas-crm");
 const REQUIRED_PERSON_FIELDS = ["atlasFirstSource", "atlasLastSource"] as const;
 
 /**
- * Build the create-instructions string for a missing custom field. The
- * exact text is part of the slice-1 acceptance criteria — when an
- * operator sees this, they should be able to follow it without
- * cross-referencing the README.
+ * Atlas's known Twenty CRM hostname. Used as the fallback when
+ * `TWENTY_BASE_URL` is unset in the SaaS deployment — self-hosters
+ * never hit this code path (Noop layer is the default; if they were
+ * to install `@useatlas/twenty`, they go through the plugin's
+ * `atlas.config.ts` which requires `baseUrl` explicitly).
  */
+const ATLAS_SAAS_TWENTY_BASE_URL = "https://crm.useatlas.dev";
+
+/**
+ * Per-request timeout for the SaaS CRM client. Tight on purpose: every
+ * lead dispatch sits inside the demo response path, and even though
+ * the dispatch is fire-and-forget at the catch-and-swallow layer
+ * inside `dispatchLead`, the `await` in `captureDemoLead` would still
+ * add latency-on-failure. 3s caps each leg (find + create/patch),
+ * keeping worst-case Twenty-outage latency in the demo response under
+ * ~6s rather than the 10s default.
+ */
+const SAAS_TIMEOUT_MS = 3_000;
+
 function missingFieldInstructions(missing: ReadonlyArray<string>): string {
   return (
     `Twenty Person object is missing required Atlas custom field(s): ${missing.join(", ")}. ` +
@@ -68,25 +61,52 @@ function missingFieldInstructions(missing: ReadonlyArray<string>): string {
   );
 }
 
+function misconfigurationInstructions(status: number, baseUrl: string): string {
+  return (
+    `Twenty metadata probe returned HTTP ${status} from ${baseUrl}/metadata — ` +
+    `this is a deterministic misconfiguration that will NEVER succeed without ` +
+    `operator intervention. Check TWENTY_API_KEY (bearer token from Twenty → ` +
+    `Settings → API & Webhooks) and TWENTY_BASE_URL (must point at a Twenty ` +
+    `instance whose /metadata GraphQL endpoint is reachable). SaaS CRM dispatch ` +
+    `is disabled until this is fixed.`
+  );
+}
+
+/**
+ * Build the TwentyClient config with the SaaS defaults applied. The
+ * Atlas-internal base URL fallback lives here, NOT in the plugin's
+ * schema default — self-hosters who install `@useatlas/twenty`
+ * directly must point at their own Twenty.
+ */
+function buildSaasClientConfig(creds: ResolvedTwentyCredentials): TwentyClientConfig {
+  return {
+    apiKey: creds.apiKey,
+    baseUrl: creds.baseUrl ?? ATLAS_SAAS_TWENTY_BASE_URL,
+    timeoutMs: SAAS_TIMEOUT_MS,
+  };
+}
+
 /**
  * Run startup verification against the Twenty metadata endpoint.
  *
  * Returns:
- *  - { ok: true } when both required fields are present.
- *  - { ok: false } when one or both fields are missing (a structured
- *    log.error has already been emitted).
- *  - { ok: "transient" } when the metadata endpoint itself errored
- *    (network blip / 5xx / parse failure). Per spec we leave the
- *    layer available — the upsert call will surface any real schema
- *    drift as a 422 upstream error.
+ *  - `ok: true` — both required fields are present.
+ *  - `ok: false` — fields missing OR upstream returned a deterministic
+ *    misconfiguration code (401/403/404). A structured `log.error` has
+ *    already been emitted.
+ *  - `ok: "transient"` — network / 5xx / parse failure. Layer stays
+ *    available; a real schema mismatch will surface as a 422 on the
+ *    first upsertPerson call.
  */
 async function verifyCustomFields(
   creds: ResolvedTwentyCredentials,
 ): Promise<{ ok: true } | { ok: false } | { ok: "transient"; reason: string }> {
+  const baseUrl = creds.baseUrl ?? ATLAS_SAAS_TWENTY_BASE_URL;
   try {
     const meta = await getPersonMetadata({
       apiKey: creds.apiKey,
-      baseUrl: creds.baseUrl,
+      baseUrl,
+      timeoutMs: SAAS_TIMEOUT_MS,
     });
     const present = new Set(meta.fields.map((f) => f.name));
     const missing = REQUIRED_PERSON_FIELDS.filter((f) => !present.has(f));
@@ -97,6 +117,25 @@ async function verifyCustomFields(
     );
     return { ok: false };
   } catch (err) {
+    // 401/403/404 are deterministic misconfigurations — silently
+    // marking them transient would leave `available: true` and every
+    // subsequent dispatch would fail identically forever, losing leads.
+    if (
+      err instanceof TwentyClientError &&
+      (err.status === 401 || err.status === 403 || err.status === 404)
+    ) {
+      log.error(
+        {
+          status: err.status,
+          upstreamCode: err.upstreamCode,
+          err: err.message,
+          baseUrl,
+          event: "saas_crm.metadata_misconfigured",
+        },
+        misconfigurationInstructions(err.status, baseUrl),
+      );
+      return { ok: false };
+    }
     const reason = err instanceof Error ? err.message : String(err);
     return { ok: "transient", reason };
   }
@@ -104,9 +143,9 @@ async function verifyCustomFields(
 
 /**
  * Dispatch a normalized lead via TwentyClient. Errors are caught and
- * logged inside this function so the SaasCrmShape Effect channel can
- * stay typed as `Effect<void>` (no error channel) — that contract is
- * what makes the call-site short (`yield* SaasCrm` then
+ * logged inside this function so the SaasCrmShape Effect channel stays
+ * typed as `Effect<void>` (no error channel) — that contract is what
+ * keeps the call-site short (`yield* SaasCrm` then
  * `yield* upsertLead(input)` with nothing to catch).
  */
 async function dispatchLead(
@@ -122,18 +161,19 @@ async function dispatchLead(
     );
   } catch (err) {
     // Twenty being down (or a missing custom field, or a bad key)
-    // MUST NOT block the caller. We log loudly enough that an operator
-    // can correlate but never re-throw.
+    // MUST NOT block the caller. Log loudly so an operator can
+    // correlate, but never re-throw.
     if (err instanceof TwentyClientError) {
       log.warn(
         {
           source: input.source,
           status: err.status,
           upstreamCode: err.upstreamCode,
+          operation: err.operation,
           err: err.message,
           event: "saas_crm.dispatch_failed",
         },
-        "Twenty upsertPerson failed — lead lost (durable outbox lands in slice 4)",
+        "Twenty upsertPerson failed — lead lost (durable outbox not yet implemented)",
       );
     } else {
       log.warn(
@@ -148,11 +188,7 @@ async function dispatchLead(
   }
 }
 
-/**
- * Build the live SaasCrm service. Runs the boot-time verification once
- * inside `Layer.effect` — `available` is the result of that check; it
- * does NOT re-verify on every `upsertLead` call.
- */
+// Boot-time verification runs once inside Layer.effect; available reflects that one check.
 export const SaasCrmLive: Layer.Layer<SaasCrm> = Layer.effect(
   SaasCrm,
   Effect.gen(function* () {
@@ -179,8 +215,9 @@ export const SaasCrmLive: Layer.Layer<SaasCrm> = Layer.effect(
 
     const verifyResult = yield* Effect.promise(() => verifyCustomFields(creds));
     if (verifyResult.ok === false) {
-      // Already logged inside verifyCustomFields. Surface as unavailable
-      // so subsequent demo signups are no-ops rather than dead-letter
+      // Already logged inside verifyCustomFields (missing fields OR
+      // deterministic misconfiguration). Surface unavailable so
+      // subsequent demo signups are no-ops rather than dead-letter
       // rows in the (future) outbox.
       return {
         available: false,
@@ -195,15 +232,15 @@ export const SaasCrmLive: Layer.Layer<SaasCrm> = Layer.effect(
       );
     } else {
       log.info(
-        { baseUrl: creds.baseUrl, event: "saas_crm.ready" },
+        {
+          baseUrl: creds.baseUrl ?? ATLAS_SAAS_TWENTY_BASE_URL,
+          event: "saas_crm.ready",
+        },
         "SaasCrm wired up — atlasFirstSource + atlasLastSource verified on Twenty Person",
       );
     }
 
-    const clientConfig: TwentyClientConfig = {
-      apiKey: creds.apiKey,
-      baseUrl: creds.baseUrl,
-    };
+    const clientConfig = buildSaasClientConfig(creds);
 
     return {
       available: true,
@@ -214,4 +251,4 @@ export const SaasCrmLive: Layer.Layer<SaasCrm> = Layer.effect(
 );
 
 // Re-exported for direct testing of the verification / dispatch logic.
-export { verifyCustomFields, dispatchLead };
+export { verifyCustomFields, dispatchLead, buildSaasClientConfig, ATLAS_SAAS_TWENTY_BASE_URL };

--- a/packages/api/src/__tests__/demo-capture.test.ts
+++ b/packages/api/src/__tests__/demo-capture.test.ts
@@ -1,0 +1,189 @@
+/**
+ * captureDemoLead — defensive-catch + SaasCrm dispatch contract.
+ *
+ * These tests pin two acceptance-criterion behaviors that are easy to
+ * regress with passing tests elsewhere:
+ *
+ *  1. "Twenty being unreachable does not block POST /api/v1/demo/start"
+ *     → `captureDemoLead` MUST resolve even when the SaasCrm Effect
+ *     dies / throws / rejects mid-runPromise. Tested by mocking the
+ *     runEnterprise call site to die.
+ *
+ *  2. Self-hosted (Noop layer) MUST NOT dispatch — no fetch is made,
+ *     and the function still resolves cleanly.
+ */
+
+import { describe, it, expect, beforeEach, mock } from "bun:test";
+import { Effect } from "effect";
+
+// ── Mock storage state (controlled per-test) ────────────────────────
+
+let hasInternalDBValue = true;
+type QueryRow = Record<string, unknown>;
+let internalQueryImpl: (sql: string, params?: unknown[]) => Promise<QueryRow[]> = async () => [
+  { session_count: 1 },
+];
+
+let runEnterpriseImpl: (p: unknown) => Promise<unknown> = async () => undefined;
+
+mock.module("@atlas/api/lib/db/internal", () => ({
+  hasInternalDB: () => hasInternalDBValue,
+  internalQuery: (sql: string, params?: unknown[]) => internalQueryImpl(sql, params),
+  // Other exports demo.ts doesn't reach but are mocked to keep partial
+  // mock.module happy with imports made transitively.
+  getInternalDB: () => null,
+  internalExecute: () => {},
+  encryptSecret: (v: string) => v,
+  decryptSecret: (v: string) => v,
+  getEncryptionKey: () => Buffer.from("test-key-32-bytes-long-enough!!!"),
+  closeInternalDB: async () => {},
+  migrateInternalDB: async () => {},
+  _resetPool: () => {},
+  loadSavedConnections: async () => 0,
+}));
+
+mock.module("@atlas/api/lib/effect/enterprise-layer", () => ({
+  runEnterprise: (p: unknown) => runEnterpriseImpl(p),
+  getEnterpriseRuntime: () => ({
+    runPromise: <A, E>(p: Effect.Effect<A, E, never>) => Effect.runPromise(p),
+  }),
+}));
+
+// SaasCrm Tag is re-imported by the demo module — keep the default
+// (Noop-shaped) implementation visible. The captured `runEnterprise`
+// mock controls how it's invoked.
+mock.module("@atlas/api/lib/effect/services", () => ({
+  // Minimal Tag shim that supplies `available: false` + a no-op upsertLead;
+  // tests that need the real Effect-Context behaviour drive the
+  // `runEnterprise` mock instead.
+  SaasCrm: {
+    pipe: () => {},
+  },
+}));
+
+// ── Import the unit under test AFTER mocks ─────────────────────────
+
+const { captureDemoLead } = await import("../lib/demo");
+
+beforeEach(() => {
+  hasInternalDBValue = true;
+  internalQueryImpl = async () => [{ session_count: 1 }];
+  // Default: runEnterprise runs the program normally — yields the Tag
+  // and calls upsertLead, which for a Noop is just Effect.void.
+  runEnterpriseImpl = async () => undefined;
+});
+
+// ── R-4 #1 — die path doesn't block the demo response ──────────────
+
+describe("captureDemoLead — Twenty failure swallow contract (R-4)", () => {
+  it("resolves even when SaasCrm.upsertLead's Effect dies", async () => {
+    runEnterpriseImpl = async () => {
+      throw new Error("simulated defect inside runEnterprise");
+    };
+
+    const result = await captureDemoLead({
+      email: "die@test.com",
+      ip: "1.2.3.4",
+      userAgent: "ua",
+      requestId: "req-die",
+    });
+
+    // Insert succeeded → session_count 1 → returning=false
+    expect(result).toEqual({ returning: false, sessionCount: 1 });
+  });
+
+  it("resolves even when runEnterprise itself rejects asynchronously", async () => {
+    runEnterpriseImpl = async () => {
+      return Promise.reject(new Error("async reject"));
+    };
+
+    await expect(
+      captureDemoLead({
+        email: "reject@test.com",
+        requestId: "req-reject",
+      }),
+    ).resolves.toEqual({ returning: false, sessionCount: 1 });
+  });
+
+  it("returning=true on a duplicate email even when CRM dispatch dies", async () => {
+    internalQueryImpl = async () => [{ session_count: 3 }];
+    runEnterpriseImpl = async () => {
+      throw new Error("die");
+    };
+
+    const result = await captureDemoLead({
+      email: "returning@test.com",
+      requestId: "req-r",
+    });
+
+    expect(result).toEqual({ returning: true, sessionCount: 3 });
+  });
+});
+
+// ── R-4 #2 — Noop / self-hosted: never dispatches ──────────────────
+
+describe("captureDemoLead — self-hosted (Noop layer) (R-4)", () => {
+  it("resolves cleanly without ever rejecting or throwing", async () => {
+    // runEnterpriseImpl default — runs the program. The Noop SaasCrm
+    // layer (production default) yields available=false and a no-op
+    // upsertLead. Tracked here by counting how many times runEnterprise
+    // is invoked (exactly once) and confirming no error escapes.
+    let runEnterpriseCalls = 0;
+    runEnterpriseImpl = async () => {
+      runEnterpriseCalls++;
+      // Simulate the Noop's `upsertLead: () => Effect.void` resolving.
+      return undefined;
+    };
+
+    await expect(
+      captureDemoLead({
+        email: "selfhosted@test.com",
+        requestId: "req-self",
+      }),
+    ).resolves.toBeDefined();
+
+    expect(runEnterpriseCalls).toBe(1);
+  });
+
+  it("still inserts demo_leads row when CRM dispatch is a noop", async () => {
+    let inserted = false;
+    internalQueryImpl = async (sql) => {
+      if (sql.includes("INSERT INTO demo_leads")) {
+        inserted = true;
+        return [{ session_count: 1 }];
+      }
+      return [];
+    };
+
+    await captureDemoLead({
+      email: "insert@test.com",
+      requestId: "req-ins",
+    });
+
+    expect(inserted).toBe(true);
+  });
+});
+
+// ── DB-failure path still attempts CRM dispatch ─────────────────────
+
+describe("captureDemoLead — internal DB unavailable", () => {
+  it("short-circuits the demo_leads insert when hasInternalDB returns false", async () => {
+    hasInternalDBValue = false;
+    let runEnterpriseCalls = 0;
+    runEnterpriseImpl = async () => {
+      runEnterpriseCalls++;
+      return undefined;
+    };
+
+    const result = await captureDemoLead({
+      email: "nodb@test.com",
+      requestId: "req-nodb",
+    });
+
+    expect(result).toEqual({ returning: false, sessionCount: 1 });
+    // When there's no internal DB we early-return BEFORE the CRM
+    // dispatch — leads are lost the same way demo_leads inserts are
+    // (matches existing pre-#2727 behavior).
+    expect(runEnterpriseCalls).toBe(0);
+  });
+});

--- a/packages/api/src/api/routes/demo.ts
+++ b/packages/api/src/api/routes/demo.ts
@@ -345,7 +345,7 @@ demo.openapi(demoStartRoute, async (c) => {
     // Capture lead (best-effort)
     const userAgent = c.req.header("user-agent") ?? null;
     const [leadResult, conversationCount] = yield* Effect.promise(() => Promise.all([
-      captureDemoLead({ email, ip, userAgent }),
+      captureDemoLead({ email, ip, userAgent, requestId }),
       countDemoConversations(email),
     ]));
 

--- a/packages/api/src/lib/auth/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/auth/__tests__/migrate.test.ts
@@ -343,6 +343,7 @@ describe("migrateAuthTables", () => {
             { name: "0095_approval_surface_telegram.sql" },
             { name: "0096_drop_connections_table.sql" },
             { name: "0097_fix_0096_us_constraint_order.sql" },
+            { name: "0098_twenty_integrations.sql" },
           ],
         };
       }

--- a/packages/api/src/lib/db/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate.test.ts
@@ -109,8 +109,9 @@ describe("runMigrations", () => {
     // + 0094 (promote placeholder chat rows to coming_soon, #2747)
     // + 0095 (add 'telegram' to approval-surface CHECK enums, #2748)
     // + 0096 (drop connections + connection_groups, cutover, #2744)
-    // + 0097 (forward-fix for 0096 constraint-ordering bug on us-int-postgres, #2744) = 98.
-    expect(count).toBe(98);
+    // + 0097 (forward-fix for 0096 constraint-ordering bug on us-int-postgres, #2744)
+    // + 0098 (twenty_integrations table, #2727) = 99.
+    expect(count).toBe(99);
 
     // Advisory lock acquired before anything else
     expect(queries[0]).toContain("pg_advisory_lock");
@@ -237,6 +238,7 @@ describe("runMigrations", () => {
         "0095_approval_surface_telegram.sql",
         "0096_drop_connections_table.sql",
         "0097_fix_0096_us_constraint_order.sql",
+        "0098_twenty_integrations.sql",
       ],
     });
 

--- a/packages/api/src/lib/db/integration-tables.ts
+++ b/packages/api/src/lib/db/integration-tables.ts
@@ -61,6 +61,10 @@ export const INTEGRATION_TABLES: ReadonlyArray<IntegrationTable> = [
   // table still keys on a single uuid `id` column so the rotation /
   // audit scripts walk it generically (single-PK assumption preserved).
   { table: "integration_credentials", pk: "id",            encrypted: "credentials_encrypted",       keyVersionColumn: "credentials_key_version" },
+  // 0098 (#2727) — Twenty CRM per-workspace credentials. Slice 1 of
+  // #2726 only creates the table; admin-UI install flow lands in
+  // slice 9. Single-workspace PK (`workspace_id` is unique on its own).
+  { table: "twenty_integrations",   pk: "id",              encrypted: "api_key_encrypted",           keyVersionColumn: "api_key_key_version" },
 ] as const;
 
 /**

--- a/packages/api/src/lib/db/integration-tables.ts
+++ b/packages/api/src/lib/db/integration-tables.ts
@@ -61,9 +61,8 @@ export const INTEGRATION_TABLES: ReadonlyArray<IntegrationTable> = [
   // table still keys on a single uuid `id` column so the rotation /
   // audit scripts walk it generically (single-PK assumption preserved).
   { table: "integration_credentials", pk: "id",            encrypted: "credentials_encrypted",       keyVersionColumn: "credentials_key_version" },
-  // 0098 (#2727) — Twenty CRM per-workspace credentials. Slice 1 of
-  // #2726 only creates the table; admin-UI install flow lands in
-  // slice 9. Single-workspace PK (`workspace_id` is unique on its own).
+  // 0098 — Twenty CRM per-workspace credentials. `workspace_id` is
+  // unique on its own (one Twenty install per workspace).
   { table: "twenty_integrations",   pk: "id",              encrypted: "api_key_encrypted",           keyVersionColumn: "api_key_key_version" },
 ] as const;
 

--- a/packages/api/src/lib/db/migrations/0098_twenty_integrations.sql
+++ b/packages/api/src/lib/db/migrations/0098_twenty_integrations.sql
@@ -1,24 +1,19 @@
 -- 0098_twenty_integrations.sql
 --
--- Atlas issue #2727 — `twenty_integrations` schema for the Twenty CRM
--- plugin. Slice 1 of #2726 only creates the table; the admin UI flow
--- that populates it lands in slice 9. The env-var path
--- (`TWENTY_API_KEY`) in `TwentyCredentialResolver` ships first so the
--- demo → Twenty pipe (this slice) can be smoke-tested without any
--- per-workspace row.
+-- `twenty_integrations` — per-workspace credentials for the Twenty CRM
+-- plugin. Until the admin-UI install flow lands, dispatch resolves
+-- credentials from `TWENTY_API_KEY` env via `TwentyCredentialResolver`;
+-- this table is the destination for per-workspace overrides.
 --
 -- Shape:
 --   * `id` — uuid PK. Single-column PK so the F-47 rotation tooling and
 --     F-42 residue audit (both walk `INTEGRATION_TABLES` with one PK
 --     identifier) work unchanged.
---   * `workspace_id` — composite uniqueness with this column; matches
---     the `integration_credentials` shape from 0089. One Twenty
---     install per workspace, full stop.
+--   * `workspace_id` — unique on its own; one Twenty install per
+--     workspace.
 --   * `base_url` — Twenty REST base URL, plaintext (operator-visible
---     hostnames aren't secret on their own; the API key is the secret).
---     Defaults to https://crm.useatlas.dev in the application code,
---     not at the SQL layer — `NULL` here means "fall back to the
---     default the resolver picks."
+--     hostnames aren't secret; the API key is). NULL here means
+--     "no override" — the application code picks its known fallback.
 --   * `api_key_encrypted` — AES-256-GCM ciphertext (versioned
 --     `enc:v<N>:iv:authTag:ciphertext`) from `db/secret-encryption.ts`,
 --     per the CLAUDE.md guidance for new integration credential
@@ -45,6 +40,6 @@ CREATE TABLE IF NOT EXISTS twenty_integrations (
   updated_at               TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
--- Composite uniqueness — one Twenty install per workspace.
+-- One Twenty install per workspace.
 CREATE UNIQUE INDEX IF NOT EXISTS idx_twenty_integrations_workspace_unique
   ON twenty_integrations (workspace_id);

--- a/packages/api/src/lib/db/migrations/0098_twenty_integrations.sql
+++ b/packages/api/src/lib/db/migrations/0098_twenty_integrations.sql
@@ -1,0 +1,50 @@
+-- 0098_twenty_integrations.sql
+--
+-- Atlas issue #2727 — `twenty_integrations` schema for the Twenty CRM
+-- plugin. Slice 1 of #2726 only creates the table; the admin UI flow
+-- that populates it lands in slice 9. The env-var path
+-- (`TWENTY_API_KEY`) in `TwentyCredentialResolver` ships first so the
+-- demo → Twenty pipe (this slice) can be smoke-tested without any
+-- per-workspace row.
+--
+-- Shape:
+--   * `id` — uuid PK. Single-column PK so the F-47 rotation tooling and
+--     F-42 residue audit (both walk `INTEGRATION_TABLES` with one PK
+--     identifier) work unchanged.
+--   * `workspace_id` — composite uniqueness with this column; matches
+--     the `integration_credentials` shape from 0089. One Twenty
+--     install per workspace, full stop.
+--   * `base_url` — Twenty REST base URL, plaintext (operator-visible
+--     hostnames aren't secret on their own; the API key is the secret).
+--     Defaults to https://crm.useatlas.dev in the application code,
+--     not at the SQL layer — `NULL` here means "fall back to the
+--     default the resolver picks."
+--   * `api_key_encrypted` — AES-256-GCM ciphertext (versioned
+--     `enc:v<N>:iv:authTag:ciphertext`) from `db/secret-encryption.ts`,
+--     per the CLAUDE.md guidance for new integration credential
+--     columns. Pairs with `api_key_key_version` for F-47 rotation.
+--   * `api_key_key_version` — F-47 keyset version the row's ciphertext
+--     was produced under. Mirrors every other `INTEGRATION_TABLES`
+--     entry's `keyVersionColumn` convention.
+--   * `created_at` / `updated_at` — `updated_at` bumps on credential
+--     rotation; admin UI will surface it.
+--
+-- Foreign key on `workspace_id` is intentionally omitted — every other
+-- integration credential table (slack_installations, telegram,
+-- linear, integration_credentials, etc.) makes the same call. Cleanup
+-- on workspace deletion is the responsibility of the
+-- workspace-teardown path.
+
+CREATE TABLE IF NOT EXISTS twenty_integrations (
+  id                       UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  workspace_id             TEXT NOT NULL,
+  base_url                 TEXT,
+  api_key_encrypted        TEXT NOT NULL,
+  api_key_key_version      INTEGER,
+  created_at               TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at               TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Composite uniqueness — one Twenty install per workspace.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_twenty_integrations_workspace_unique
+  ON twenty_integrations (workspace_id);

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -2210,3 +2210,31 @@ export const proactivePublicDataset = pgTable(
     index("idx_proactive_public_dataset_workspace").on(t.workspaceId),
   ],
 );
+
+// ---------------------------------------------------------------------------
+// twenty_integrations (0098) — per-workspace credentials for the Twenty CRM
+// plugin. Slice 1 of #2726 only creates the table; the admin-UI install
+// flow that populates it lands in slice 9. Until then, dispatch resolves
+// credentials from `TWENTY_API_KEY` env via `TwentyCredentialResolver`.
+//
+// Listed in `INTEGRATION_TABLES` (lib/db/integration-tables.ts) so F-47
+// key rotation + F-42 residue audit walk the table generically. The
+// `api_key_encrypted` column uses the `db/secret-encryption.ts` pair
+// (CLAUDE.md guidance for new integration credential columns).
+// ---------------------------------------------------------------------------
+
+export const twentyIntegrations = pgTable(
+  "twenty_integrations",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    workspaceId: text("workspace_id").notNull(),
+    baseUrl: text("base_url"),
+    apiKeyEncrypted: text("api_key_encrypted").notNull(),
+    apiKeyKeyVersion: integer("api_key_key_version"),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [
+    uniqueIndex("idx_twenty_integrations_workspace_unique").on(t.workspaceId),
+  ],
+);

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -2213,12 +2213,8 @@ export const proactivePublicDataset = pgTable(
 
 // ---------------------------------------------------------------------------
 // twenty_integrations (0098) — per-workspace credentials for the Twenty CRM
-// plugin. Slice 1 of #2726 only creates the table; the admin-UI install
-// flow that populates it lands in slice 9. Until then, dispatch resolves
-// credentials from `TWENTY_API_KEY` env via `TwentyCredentialResolver`.
-//
-// Listed in `INTEGRATION_TABLES` (lib/db/integration-tables.ts) so F-47
-// key rotation + F-42 residue audit walk the table generically. The
+// plugin. Listed in `INTEGRATION_TABLES` (lib/db/integration-tables.ts) so
+// F-47 key rotation + F-42 residue audit walk the table generically. The
 // `api_key_encrypted` column uses the `db/secret-encryption.ts` pair
 // (CLAUDE.md guidance for new integration credential columns).
 // ---------------------------------------------------------------------------

--- a/packages/api/src/lib/demo.ts
+++ b/packages/api/src/lib/demo.ts
@@ -7,8 +7,11 @@
  */
 
 import * as crypto from "crypto";
+import { Effect } from "effect";
 import { createLogger } from "@atlas/api/lib/logger";
 import { hasInternalDB, internalQuery } from "@atlas/api/lib/db/internal";
+import { SaasCrm } from "@atlas/api/lib/effect/services";
+import { runEnterprise } from "@atlas/api/lib/effect/enterprise-layer";
 
 const log = createLogger("demo");
 
@@ -264,6 +267,7 @@ export async function captureDemoLead(opts: {
 
   const email = opts.email.toLowerCase().trim();
 
+  let result: DemoLeadResult;
   try {
     // Try to insert; on conflict update last_active_at and bump session_count
     const rows = await internalQuery(
@@ -279,14 +283,52 @@ export async function captureDemoLead(opts: {
     );
 
     const sessionCount = (rows[0] as { session_count: number } | undefined)?.session_count ?? 1;
-    return { returning: sessionCount > 1, sessionCount };
+    result = { returning: sessionCount > 1, sessionCount };
   } catch (err) {
     log.error(
       { err: err instanceof Error ? err : new Error(String(err)) },
       "Failed to capture demo lead — lead data lost. Check that demo_leads table exists (run migrations)",
     );
-    return { returning: false, sessionCount: 1 };
+    result = { returning: false, sessionCount: 1 };
   }
+
+  // SaaS CRM dispatch (#2727 — slice 1 of #2726). Fire-and-forget.
+  //
+  // Self-hosted Atlas resolves to NoopSaasCrmLayer which yields
+  // `{ available: false }` and a no-op upsertLead — no Twenty traffic.
+  // Atlas SaaS resolves to SaasCrmLive (ee/src/saas-crm), which dispatches
+  // via TwentyClient. All errors are swallowed inside the layer, so even
+  // a Twenty outage never blocks the demo signup. The durable outbox +
+  // retry loop lands in slice 4 of #2726.
+  //
+  // We `await` the dispatch so Effect log lines bind to the same request
+  // context, but the dispatch itself is `Effect.void` on the failure
+  // path. The await never propagates an error.
+  try {
+    await runEnterprise(
+      Effect.gen(function* () {
+        const crm = yield* SaasCrm;
+        yield* crm.upsertLead({
+          source: "demo",
+          email,
+          ip: opts.ip,
+          userAgent: opts.userAgent,
+        });
+      }),
+    );
+  } catch (err) {
+    // Defensive — SaasCrm.upsertLead is typed as Effect<void> with no
+    // error channel, so this catch is unreachable in practice. We keep
+    // it so a future Tag-shape widening that adds an error channel
+    // doesn't silently regress the "never block the demo response"
+    // contract.
+    log.warn(
+      { err: err instanceof Error ? err.message : String(err) },
+      "Unexpected SaasCrm dispatch error — swallowed to keep demo response unblocked",
+    );
+  }
+
+  return result;
 }
 
 /**

--- a/packages/api/src/lib/demo.ts
+++ b/packages/api/src/lib/demo.ts
@@ -251,6 +251,11 @@ export interface DemoLeadResult {
   sessionCount: number;
 }
 
+/** Same pattern used in the /demo route to mask emails before logging. */
+function maskEmailForLog(email: string): string {
+  return email.replace(/(.{2}).*(@.*)/, "$1***$2");
+}
+
 /**
  * Capture or update a demo lead in the internal DB.
  * Returns whether this is a returning user and their session count.
@@ -259,13 +264,17 @@ export async function captureDemoLead(opts: {
   email: string;
   ip?: string | null;
   userAgent?: string | null;
+  /** Request correlation ID — included on every log emitted by this function. */
+  requestId?: string;
 }): Promise<DemoLeadResult> {
+  const email = opts.email.toLowerCase().trim();
+  const emailMasked = maskEmailForLog(email);
+  const { requestId } = opts;
+
   if (!hasInternalDB()) {
-    log.debug("No internal DB — demo lead not captured");
+    log.debug({ requestId, emailMasked }, "No internal DB — demo lead not captured");
     return { returning: false, sessionCount: 1 };
   }
-
-  const email = opts.email.toLowerCase().trim();
 
   let result: DemoLeadResult;
   try {
@@ -286,24 +295,21 @@ export async function captureDemoLead(opts: {
     result = { returning: sessionCount > 1, sessionCount };
   } catch (err) {
     log.error(
-      { err: err instanceof Error ? err : new Error(String(err)) },
+      {
+        requestId,
+        emailMasked,
+        err: err instanceof Error ? err : new Error(String(err)),
+      },
       "Failed to capture demo lead — lead data lost. Check that demo_leads table exists (run migrations)",
     );
     result = { returning: false, sessionCount: 1 };
   }
 
-  // SaaS CRM dispatch (#2727 — slice 1 of #2726). Fire-and-forget.
-  //
-  // Self-hosted Atlas resolves to NoopSaasCrmLayer which yields
-  // `{ available: false }` and a no-op upsertLead — no Twenty traffic.
-  // Atlas SaaS resolves to SaasCrmLive (ee/src/saas-crm), which dispatches
-  // via TwentyClient. All errors are swallowed inside the layer, so even
-  // a Twenty outage never blocks the demo signup. The durable outbox +
-  // retry loop lands in slice 4 of #2726.
-  //
-  // We `await` the dispatch so Effect log lines bind to the same request
-  // context, but the dispatch itself is `Effect.void` on the failure
-  // path. The await never propagates an error.
+  // SaaS CRM dispatch via the SaasCrm Tag. Self-hosted resolves to
+  // NoopSaasCrmLayer (no Twenty traffic). Atlas SaaS resolves to
+  // SaasCrmLive which dispatches via TwentyClient — failures are
+  // swallowed inside the layer so a Twenty outage never blocks the
+  // demo response.
   try {
     await runEnterprise(
       Effect.gen(function* () {
@@ -317,13 +323,13 @@ export async function captureDemoLead(opts: {
       }),
     );
   } catch (err) {
-    // Defensive — SaasCrm.upsertLead is typed as Effect<void> with no
-    // error channel, so this catch is unreachable in practice. We keep
-    // it so a future Tag-shape widening that adds an error channel
-    // doesn't silently regress the "never block the demo response"
-    // contract.
+    // SaasCrm.upsertLead has no error channel today; catch guards against future Tag-shape widening + runPromise defects.
     log.warn(
-      { err: err instanceof Error ? err.message : String(err) },
+      {
+        requestId,
+        emailMasked,
+        err: err instanceof Error ? err.message : String(err),
+      },
       "Unexpected SaasCrm dispatch error — swallowed to keep demo response unblocked",
     );
   }

--- a/packages/api/src/lib/effect/enterprise-layer.ts
+++ b/packages/api/src/lib/effect/enterprise-layer.ts
@@ -35,6 +35,7 @@ import {
   type Domains,
   type ProactiveGate,
   type DeployModeResolver,
+  type SaasCrm,
 } from "./services";
 
 const log = createLogger("effect:enterprise-layer");
@@ -179,7 +180,8 @@ export type EnterpriseSubsystem =
   | Branding
   | Domains
   | ProactiveGate
-  | DeployModeResolver;
+  | DeployModeResolver
+  | SaasCrm;
 
 /**
  * Composed enterprise Layer — no-op defaults overlaid by the conditional

--- a/packages/api/src/lib/effect/services.ts
+++ b/packages/api/src/lib/effect/services.ts
@@ -2395,6 +2395,70 @@ export const NoopDeployModeResolverLayer: Layer.Layer<DeployModeResolver> =
     resolve: () => "self-hosted",
   } satisfies DeployModeResolverShape);
 
+// ── SaasCrm (#2727 — slice 1 of #2726) ───────────────────────────────
+//
+// First-touch CRM dispatch for Atlas's own SaaS funnel (demo signup,
+// app.useatlas.dev signup hook, contact form). Backed by the
+// `@useatlas/twenty` plugin from `ee/src/saas-crm/`. Self-hosted Atlas
+// stays on the no-op default below — installing `@useatlas/twenty` and
+// wiring it into atlas.config.ts is the supported path for self-hosters
+// who want their own demo / signup flows pushed into their own Twenty.
+//
+// `available` flag rationale (load-bearing per CLAUDE.md): slice 3 of
+// #2726 (#2729) introduces `POST /api/v1/contact`, which must return
+// 404 `not_available` on self-hosted instead of an EnterpriseError-mapped
+// 403. The 404-vs-403 distinction matters here because the contact
+// form is a marketing surface, not an admin feature — surfacing 403
+// would imply "upgrade to enterprise" to anyone who clicked the form
+// from useatlas.dev, which would be confusing for self-hosters who
+// landed on a marketing page tied to their own deployment. The 404
+// branch keeps the route shape clean.
+//
+// Future `/api/v1/contact` 404 branch (slice 3) reads `available`
+// directly; route never sees the dispatch path otherwise.
+
+/** Inputs to `SaasCrm.upsertLead` — discriminated by source. */
+export type SaasCrmLeadInput =
+  | {
+      readonly source: "demo";
+      readonly email: string;
+      readonly ip?: string | null;
+      readonly userAgent?: string | null;
+    };
+// Later slices add `signup` and `sales-form` variants on this union.
+
+export interface SaasCrmShape {
+  /**
+   * False when the SaaS CRM wiring is not loaded (self-hosted, or
+   * enterprise enabled but Twenty creds + custom-field verification
+   * failed at boot). Consumer: future `POST /api/v1/contact` returns
+   * 404 `not_available` when `available === false` instead of the
+   * standard 403 envelope (marketing surfaces shouldn't imply an
+   * enterprise-gate upsell).
+   */
+  readonly available: boolean;
+  /**
+   * Fire-and-forget upsert of a lead into the Atlas SaaS CRM. Errors
+   * are swallowed inside the layer — callers (notably `captureDemoLead`)
+   * must never block on or propagate CRM failures back to the HTTP
+   * response. Returns success even when `available === false` (no-op).
+   */
+  readonly upsertLead: (input: SaasCrmLeadInput) => Effect.Effect<void>;
+}
+
+export class SaasCrm extends Context.Tag("SaasCrm")<SaasCrm, SaasCrmShape>() {}
+
+/**
+ * No-op default: SaaS CRM dispatch unavailable. Self-hosted Atlas (and
+ * Atlas SaaS instances where Twenty creds / custom-field verification
+ * failed) sees this layer. `upsertLead` returns success without
+ * dispatching anywhere.
+ */
+export const NoopSaasCrmLayer: Layer.Layer<SaasCrm> = Layer.succeed(SaasCrm, {
+  available: false,
+  upsertLead: () => Effect.void,
+} satisfies SaasCrmShape);
+
 // ── Aggregate no-op default Layer ────────────────────────────────────
 //
 // Merged into `buildAppLayer()` so every enterprise Tag has a default
@@ -2420,6 +2484,7 @@ export const NoopEnterpriseDefaultsLayer: Layer.Layer<
   | Domains
   | ProactiveGate
   | DeployModeResolver
+  | SaasCrm
 > = Layer.mergeAll(
   NoopResidencyResolverLayer,
   NoopModelRouterLayer,
@@ -2438,6 +2503,7 @@ export const NoopEnterpriseDefaultsLayer: Layer.Layer<
   NoopDomainsLayer,
   NoopProactiveGateLayer,
   NoopDeployModeResolverLayer,
+  NoopSaasCrmLayer,
 );
 
 // ══════════════════════════════════════════════════════════════════════

--- a/packages/api/src/lib/effect/services.ts
+++ b/packages/api/src/lib/effect/services.ts
@@ -2395,46 +2395,31 @@ export const NoopDeployModeResolverLayer: Layer.Layer<DeployModeResolver> =
     resolve: () => "self-hosted",
   } satisfies DeployModeResolverShape);
 
-// ── SaasCrm (#2727 — slice 1 of #2726) ───────────────────────────────
+// ── SaasCrm ──────────────────────────────────────────────────────────
 //
-// First-touch CRM dispatch for Atlas's own SaaS funnel (demo signup,
-// app.useatlas.dev signup hook, contact form). Backed by the
-// `@useatlas/twenty` plugin from `ee/src/saas-crm/`. Self-hosted Atlas
-// stays on the no-op default below — installing `@useatlas/twenty` and
-// wiring it into atlas.config.ts is the supported path for self-hosters
-// who want their own demo / signup flows pushed into their own Twenty.
-//
-// `available` flag rationale (load-bearing per CLAUDE.md): slice 3 of
-// #2726 (#2729) introduces `POST /api/v1/contact`, which must return
-// 404 `not_available` on self-hosted instead of an EnterpriseError-mapped
-// 403. The 404-vs-403 distinction matters here because the contact
-// form is a marketing surface, not an admin feature — surfacing 403
-// would imply "upgrade to enterprise" to anyone who clicked the form
-// from useatlas.dev, which would be confusing for self-hosters who
-// landed on a marketing page tied to their own deployment. The 404
-// branch keeps the route shape clean.
-//
-// Future `/api/v1/contact` 404 branch (slice 3) reads `available`
-// directly; route never sees the dispatch path otherwise.
+// SaaS-only CRM dispatch (Twenty). Self-hosted gets the Noop layer.
 
-/** Inputs to `SaasCrm.upsertLead` — discriminated by source. */
-export type SaasCrmLeadInput =
-  | {
-      readonly source: "demo";
-      readonly email: string;
-      readonly ip?: string | null;
-      readonly userAgent?: string | null;
-    };
-// Later slices add `signup` and `sales-form` variants on this union.
+/**
+ * Inputs to `SaasCrm.upsertLead`. Inlined here (mirrors the same
+ * discriminated union in `@useatlas/twenty/lead-normalizer`) until a
+ * subsequent release promotes the shared types into `@useatlas/types`.
+ * Two-place duplication is intentional and accepted at this slice —
+ * the union has exactly one variant (`demo`) today; the next variant
+ * lands together with the type promotion.
+ */
+export type SaasCrmLeadInput = {
+  readonly source: "demo";
+  readonly email: string;
+  readonly ip?: string | null;
+  readonly userAgent?: string | null;
+};
 
 export interface SaasCrmShape {
   /**
-   * False when the SaaS CRM wiring is not loaded (self-hosted, or
-   * enterprise enabled but Twenty creds + custom-field verification
-   * failed at boot). Consumer: future `POST /api/v1/contact` returns
-   * 404 `not_available` when `available === false` instead of the
-   * standard 403 envelope (marketing surfaces shouldn't imply an
-   * enterprise-gate upsell).
+   * Anticipatory — a future `POST /api/v1/contact` route will read this
+   * to return 404 `not_available` on self-hosted (or when the SaaS layer
+   * failed boot verification) rather than the standard 403 envelope.
+   * Until that route lands, no production caller branches on this flag.
    */
   readonly available: boolean;
   /**
@@ -2448,12 +2433,7 @@ export interface SaasCrmShape {
 
 export class SaasCrm extends Context.Tag("SaasCrm")<SaasCrm, SaasCrmShape>() {}
 
-/**
- * No-op default: SaaS CRM dispatch unavailable. Self-hosted Atlas (and
- * Atlas SaaS instances where Twenty creds / custom-field verification
- * failed) sees this layer. `upsertLead` returns success without
- * dispatching anywhere.
- */
+/** No-op default: SaaS CRM dispatch unavailable; upsertLead is a noop. */
 export const NoopSaasCrmLayer: Layer.Layer<SaasCrm> = Layer.succeed(SaasCrm, {
   available: false,
   upsertLead: () => Effect.void,


### PR DESCRIPTION
## Summary
- Scaffolds `plugins/twenty/` (`@useatlas/twenty`, AGPL): `TwentyClient` (REST + bearer auth + 4xx/5xx mapping via `Data.TaggedError`), `LeadNormalizer` (demo variant), env-var `TwentyCredentialResolver`, plus a registrable `AtlasActionPlugin` exposing `upsertTwentyPerson` for self-hosters.
- Adds `SaasCrm` Context.Tag (`{ available, upsertLead }`) with a core `NoopSaasCrmLayer` default and an EE-side `SaasCrmLive` in `ee/src/saas-crm/` that does startup verification of `atlasFirstSource` + `atlasLastSource` on Twenty's `Person` object. Registered via the sole `core → ee` import in `enterprise-layer.ts`.
- Hooks `captureDemoLead()` so demo signups dispatch to Twenty via `runEnterprise()` → `yield* SaasCrm` → `upsertLead`. Twenty downtime never blocks the demo response (defensive try/catch + outbox-less fire-and-forget — slice 2 swaps this for the durable outbox).
- Schema-only migration `0096_twenty_integrations` (admin UI install is slice 7), mirrored in `schema.ts` and registered in `INTEGRATION_TABLES` for F-47 rotation + F-42 audit coverage. `api_key_encrypted` uses the `db/secret-encryption.ts` pair per CLAUDE.md guidance.
- Sticky first-source / sliding last-source translation lives inside `TwentyClient.upsertPerson` (GET-by-email → POST or PATCH).

## Acceptance criteria status
All criteria from #2727 met by code + tests except the two explicit human gates (manual smoke against `crm.useatlas.dev`; real-Postgres `migrate-pg.test.ts` requires `TEST_DATABASE_URL`).

## Test plan
- [x] `bun run lint`
- [x] `bun run type`
- [x] `bash scripts/check-ee-imports.sh`
- [x] `bash scripts/check-schema-drift.sh`
- [x] `bun run test:api` — 454/458 pass; the 4 non-passing files (`discord`, `teams`, `security-headers`, `rate-limit-integration`) all pass in isolation, confirmed parallel-pressure flake unrelated to this change
- [x] `bun run test:others`
- [x] `plugins/twenty` test suite — 47/47 (`TwentyClient` first-source-preservation matrix, 4xx/5xx mapping, bearer-auth header, URL composition, metadata fetch shapes, normalizer snapshot, env resolver branches, plugin shape)
- [x] `ee/src/saas-crm` test suite — 11/11 (boot verify happy/missing/transient + dispatch swallow-all-errors)
- [ ] Manual smoke against `crm.useatlas.dev` — needs the prod API key, deferred to the merge gate per the issue's explicit human gate

## Out of scope (future slices)
- Durable outbox replacing fire-and-forget — #2729 (slice 2)
- `/api/v1/contact` route + sales-form variant — #2730 (slice 3)
- Signup hook — #2731 (slice 4)
- Admin UI install flow for `twenty_integrations` — #2732 (slice 7)
- Outbox depth metrics — #2734 (slice 8)
- Outbox admin UI — #2735 (slice 9)
- `demo_leads` backfill — #2736 (slice 10)
- Stripe → conversion stamping — #2737 (slice 11)

Closes #2727