### PR TITLE
fix(docs): generate fumadocs .source/ via postinstall

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -7,7 +7,8 @@
     "dev": "next dev --turbopack -p 3003",
     "build": "next build",
     "start": "next start -p 3003",
-    "generate:api": "bun ./scripts/generate-openapi.ts"
+    "generate:api": "bun ./scripts/generate-openapi.ts",
+    "postinstall": "fumadocs-mdx"
   },
   "dependencies": {
     "fumadocs-core": "^16.7.7",


### PR DESCRIPTION
## Summary

- Add `"postinstall": "fumadocs-mdx"` to `apps/docs/package.json` so the generated `.source/` entry exists at install time, not as a side effect of `next build`.
- Fixes the docs Railway build that started failing at `ae56731f` with `Module not found: Can't resolve '@/../.source/server'`.

## Root cause

`apps/docs/src/lib/source.ts:1` imports `@/../.source/server` — that file is generated by `fumadocs-mdx`. Until now it was generated as a side effect of `createMDX()` during `next build`. With Next 16.2.1 + Turbopack the integration is racy — the failing build log shows:

```
22:20:48  [MDX] generated files in 32ms
22:20:54  Build error occurred
          Module not found: Can't resolve '@/../.source/server'
```

The race was masked until #2787 (publish `@useatlas/twenty`) churned the workspace `bun.lock`. The docs Dockerfile copies the workspace lockfile alongside only `apps/docs/`, so `bun install` regenerates the lockfile inside the container (`Saved lockfile` + `Removed: 55` in the log), which tipped the race from "usually works" → "fails".

## Fix

Per [fumadocs typegen docs](https://fumadocs.dev/docs/mdx/typegen), the canonical pattern is a `postinstall` that runs the `fumadocs-mdx` CLI to generate `.source/` ahead of `next build`. No Turbopack race; types are also available to the IDE immediately after install.

## Test plan

- [x] `rm -rf apps/docs/.source && cd apps/docs && bun install` → `.source/{server,browser,dynamic}.ts` regenerated
- [x] `rm -rf apps/docs/.source && bun install` (workspace root) → same, postinstall fires through workspace install
- [ ] Railway docs deploy on this branch goes green