### PR TITLE
chore(api,cli): #2786 — backfill skipped test mocks for workspace_plugins shape

### DIFF
--- a/packages/api/src/api/__tests__/admin-connections-audit.test.ts
+++ b/packages/api/src/api/__tests__/admin-connections-audit.test.ts
@@ -1,8 +1,3 @@
-// TODO(#2744 step 5 — test sweep): admin-connections audit tests assert
-// against the legacy `INSERT INTO connections (…)` SQL mocks. Route pivoted
-// to `WorkspaceInstaller.installDatasource` so describes `.skip`'d pending
-// step 5's mock-pattern rewrite. Audit semantics themselves are unchanged
-// (route still calls `logAdminAction(ADMIN_ACTIONS.connection.*)`).
 /**
  * Audit regression suite for `admin-connections.ts`.
  *
@@ -143,13 +138,15 @@ beforeEach(() => {
   mocks.setPlatformAdmin("org-alpha");
   mockLogAdminAction.mockClear();
   mocks.mockInternalQuery.mockReset();
-  // The audit suite drives platform admin flows. After the platform_admin
-  // visibility bypass was removed (every caller now goes through
-  // `getVisibleConnectionIds`), the warehouse connection must be present in
-  // the visibility set or `/:id/test` and `/:id/drain` 404 before they emit.
+  // Post-#2744 visibility query reads `workspace_plugins (pillar='datasource')`
+  // and returns `install_id`. The audit suite drives platform admin flows;
+  // after the platform_admin visibility bypass was removed (every caller
+  // goes through `getVisibleConnectionIds`), the warehouse install must be
+  // present in the visibility set or `/:id/test` and `/:id/drain` 404
+  // before they emit.
   mocks.mockInternalQuery.mockImplementation(async (sql: string) => {
-    if (typeof sql === "string" && sql.includes("SELECT c.id FROM connections c WHERE c.org_id")) {
-      return [{ id: "warehouse" }];
+    if (typeof sql === "string" && sql.includes("FROM workspace_plugins wp") && sql.includes("DISTINCT wp.install_id")) {
+      return [{ install_id: "warehouse" }];
     }
     return [];
   });
@@ -173,7 +170,7 @@ beforeEach(() => {
 // POST /test — ephemeral probe
 // ---------------------------------------------------------------------------
 
-describe.skip("POST /api/v1/admin/connections/test — audit emission (F-29/F-34)", () => {
+describe("POST /api/v1/admin/connections/test — audit emission (F-29/F-34)", () => {
   it("emits connection.probe with success metadata on healthy probe", async () => {
     const res = await app.fetch(
       adminRequest("POST", "/api/v1/admin/connections/test", {
@@ -232,7 +229,7 @@ describe.skip("POST /api/v1/admin/connections/test — audit emission (F-29/F-34
 // POST /:id/test — existing connection health check
 // ---------------------------------------------------------------------------
 
-describe.skip("POST /api/v1/admin/connections/:id/test — audit emission (F-29/F-34)", () => {
+describe("POST /api/v1/admin/connections/:id/test — audit emission (F-29/F-34)", () => {
   it("emits connection.health_check with registered id as target", async () => {
     const res = await app.fetch(
       adminRequest("POST", "/api/v1/admin/connections/warehouse/test"),
@@ -268,7 +265,7 @@ describe.skip("POST /api/v1/admin/connections/:id/test — audit emission (F-29/
 // POST /pool/orgs/:orgId/drain — pool drain
 // ---------------------------------------------------------------------------
 
-describe.skip("POST /api/v1/admin/connections/pool/orgs/:orgId/drain — audit emission (F-29/F-34)", () => {
+describe("POST /api/v1/admin/connections/pool/orgs/:orgId/drain — audit emission (F-29/F-34)", () => {
   it("emits connection.pool_drain with platform scope + drainedConnections count", async () => {
     mockConnectionDrainOrg.mockResolvedValue({ drained: 5 });
 
@@ -316,7 +313,7 @@ describe.skip("POST /api/v1/admin/connections/pool/orgs/:orgId/drain — audit e
 // POST /:id/drain — per-connection pool drain (F-29 residuals)
 // ---------------------------------------------------------------------------
 
-describe.skip("POST /api/v1/admin/connections/:id/drain — audit emission (F-29 residuals)", () => {
+describe("POST /api/v1/admin/connections/:id/drain — audit emission (F-29 residuals)", () => {
   it("emits connection.pool_drain with workspace scope + connectionId metadata", async () => {
     mockConnectionDrain.mockResolvedValueOnce({ drained: true, message: "ok" });
 

--- a/packages/api/src/api/__tests__/admin-connections.test.ts
+++ b/packages/api/src/api/__tests__/admin-connections.test.ts
@@ -1,15 +1,34 @@
 /**
- * Tests for admin connection CRUD org-scoping.
+ * Tests for admin connection CRUD against the post-#2744 `workspace_plugins`
+ * (pillar='datasource') world. The route layer in `admin-connections.ts`
+ * scopes by workspace, delegates writes to `WorkspaceInstaller`, and
+ * decorates list responses with `config->>'group_id'`. These tests focus on
+ * the route-level contract:
  *
- * Validates that:
- * 1. Creating a connection stores org_id in the DB
- * 2. Workspace admins only see connections belonging to their org
- * 3. Workspace admins cannot update/delete/health-check/drain connections from another org
- * 3b. Health-check endpoint respects visibility filter
- * 3c. Connection drain endpoint respects visibility filter
- * 3d. Org drain endpoint restricts workspace admins to their own org
- * 4. Platform admins can see/modify all connections regardless of org
- * 5. getVisibleConnectionIds returns the correct set for a given org
+ *   1. Visibility filter — workspace admins only see installs scoped to
+ *      `workspace_id`; platform admins do NOT bypass the filter (cross-org
+ *      views live under `/platform/*`).
+ *   2. List decoration — `groupId` / `groupName` mirror `config->>'group_id'`
+ *      verbatim post-cutover; `billable` flips on workspace-owned rows.
+ *   3. Mode-aware status clause — published mode restricts to `'published'`,
+ *      developer mode expands to `('published', 'draft')`.
+ *   4. Write delegation — POST/PUT/DELETE flow through the installer; the
+ *      installer's `loadCatalogRowForInstall` + `workspace_plugins` write
+ *      SQL is exercised end-to-end. The route owns the cross-org group
+ *      check, the archive-aware existing-row check, and the test-connect
+ *      / audit / rollback dances around the installer call.
+ *   5. F-44 DSN scrub — error response bodies never echo URL userinfo.
+ *   6. #2483 — SaaS suppresses the `default` fallback for fresh-signup
+ *      workspaces with zero owned rows.
+ *   7. #2490 — `billable` signal matches the billing counter exactly.
+ *
+ * The lower-level installer SQL (catalog lookup, singleton pre-check,
+ * encrypt + INSERT/UPDATE/DELETE) is covered by
+ * `lib/effect/__tests__/workspace-installer.test.ts`. Migration-level
+ * invariants (constraint order, JSONB key shape, NOT NULL on pillar) are
+ * covered by `lib/db/__tests__/migrate-pg.test.ts`'s `0096: cutover`
+ * describe. The `connection_groups` table is gone — every test below
+ * uses the JSONB `config->>'group_id'` shape.
  */
 
 import {
@@ -74,8 +93,7 @@ const mocks = createApiTestMocks({
 
 // `getConfig` is `null` by default in the test factory. Override here so
 // tests can flip deployMode for the #2483 SaaS-gate branch on the
-// `default` connection fallback. Default `null` preserves the original
-// self-hosted-style behavior.
+// `default` connection fallback.
 let mockConfigOverride: { deployMode?: "saas" | "self-hosted" } | null = null;
 
 mock.module("@atlas/api/lib/config", () => ({
@@ -88,6 +106,29 @@ mock.module("@atlas/api/lib/config", () => ({
 const { app } = await import("../index");
 
 // --- Helpers ---
+
+// The plugin_catalog row the installer's `loadCatalogRowForInstall` reads
+// for a postgres datasource. Used as the default fixture so installer
+// round-trips succeed in tests that don't care about catalog details.
+// `config_schema` mirrors what migration 0093 seeds — `url` is the lone
+// `secret: true` field that drives `encryptSecretFields` walking.
+const POSTGRES_CATALOG_ROW = {
+  id: "cat_postgres",
+  slug: "postgres",
+  install_model: "form",
+  pillar: "datasource",
+  // Mirrors the migration-0093 seed shape verbatim: a top-level JSONB
+  // array of fields keyed by `key` (NOT `name`). `parseConfigSchema`
+  // returns `state: "corrupt"` for any other shape — which then fails
+  // closed in `encryptSecretFields` / `decryptSecretFields` (every string
+  // value gets encrypted/decrypted, not just `secret: true` ones).
+  config_schema: [
+    { key: "url", type: "string", required: true, secret: true },
+    { key: "schema", type: "string" },
+    { key: "description", type: "string" },
+  ],
+  enabled: true,
+};
 
 function setOrgAdmin(orgId: string): void {
   mocks.setOrgAdmin(orgId);
@@ -108,6 +149,73 @@ function adminRequest(urlPath: string, method = "GET", body?: unknown, cookie?: 
   return new Request(`http://localhost${urlPath}`, opts);
 }
 
+// SQL substring matchers — centralized so a future shape change has one
+// place to edit. Every test below dispatches via these helpers.
+const sqlIs = {
+  /** Route's visibility query — `getVisibleConnectionIds`. */
+  visibility: (sql: string): boolean =>
+    sql.includes("FROM workspace_plugins wp") &&
+    sql.includes("DISTINCT wp.install_id") &&
+    sql.includes("wp.pillar = 'datasource'"),
+  /** Route's group decoration query — list endpoint, after visibility. */
+  decoration: (sql: string): boolean =>
+    sql.includes("FROM workspace_plugins wp") &&
+    sql.includes("config->>'group_id' AS group_id") &&
+    sql.includes("ANY"),
+  /** Route's GET /:id detail query — JOINs plugin_catalog for config_schema. */
+  detail: (sql: string): boolean =>
+    sql.includes("SELECT wp.config, pc.config_schema") &&
+    sql.includes("JOIN plugin_catalog"),
+  /** Route's plan-limit count. */
+  planCount: (sql: string): boolean =>
+    sql.includes("SELECT COUNT") &&
+    sql.includes("FROM workspace_plugins") &&
+    sql.includes("status != 'archived'"),
+  /** Route's archive-aware existence check before POST install. */
+  archiveCheck: (sql: string): boolean =>
+    sql.includes("SELECT status FROM workspace_plugins"),
+  /** Route's PUT load (catalog_slug + config + group_id). */
+  putLoad: (sql: string): boolean =>
+    sql.includes("SELECT pc.slug AS catalog_slug") &&
+    sql.includes("wp.config"),
+  /** Route's DELETE load (catalog_slug only). */
+  deleteLoad: (sql: string): boolean =>
+    sql.includes("SELECT pc.slug AS catalog_slug") &&
+    !sql.includes("wp.config"),
+  /** Route's cross-org group existence check. */
+  groupExists: (sql: string): boolean =>
+    sql.includes("SELECT install_id FROM workspace_plugins") &&
+    sql.includes("config->>'group_id' = "),
+  /** Route's scheduled-task references check (DELETE). */
+  schedRefs: (sql: string): boolean => sql.includes("FROM scheduled_tasks st"),
+  /** Installer's `loadCatalogRowForInstall` / `loadCatalogRowForDisconnect`. */
+  catalogLookup: (sql: string): boolean =>
+    sql.includes("FROM plugin_catalog") &&
+    sql.includes("install_model"),
+  /** Installer's singleton pre-check during installDatasource. */
+  installerSingleton: (sql: string): boolean =>
+    sql.includes("FROM workspace_plugins") &&
+    sql.includes("catalog_id = $2") &&
+    sql.includes("install_id = $3"),
+  /** Installer's existing-row read during updateDatasourceConfig. */
+  installerLoadForUpdate: (sql: string): boolean =>
+    sql.includes("SELECT id, install_id, config, status") &&
+    sql.includes("FROM workspace_plugins"),
+  /** Installer's INSERT during installDatasource. */
+  installerInsert: (sql: string): boolean =>
+    sql.includes("INSERT INTO workspace_plugins") &&
+    sql.includes("'datasource'"),
+  /** Installer's UPDATE during updateDatasourceConfig. */
+  installerUpdate: (sql: string): boolean =>
+    sql.includes("UPDATE workspace_plugins") &&
+    sql.includes("SET config = $1::jsonb"),
+  /** Installer's soft uninstall — sets status='archived'. */
+  installerSoftArchive: (sql: string): boolean =>
+    sql.includes("UPDATE workspace_plugins") &&
+    sql.includes("status = 'archived'") &&
+    sql.includes("RETURNING id"),
+};
+
 // --- Cleanup ---
 
 afterAll(() => {
@@ -116,36 +224,29 @@ afterAll(() => {
 
 // --- Tests ---
 
-// TODO(#2744 step 5 — test sweep): every describe in this file mocks
-// the legacy `connections` / `connection_groups` SQL strings the route
-// used to emit (e.g. `SELECT c.id FROM connections c WHERE …`, `INSERT
-// INTO connections (…)`). Post-cutover the route flows through
-// `WorkspaceInstaller.{install,uninstall,update}Datasource` which emits
-// `workspace_plugins` SQL, so every mock assertion needs rewriting.
-// The route's behaviour is covered end-to-end by
-// `lib/effect/__tests__/workspace-installer.test.ts` (the 14 new
-// datasource paths) and `lib/db/__tests__/migrate-pg.test.ts` (the
-// 0094 cutover block) — both green — so deferring the SQL-string
-// rewrites to step 5 doesn't blind us to regressions.
-//
-// Skipped describes return early via `describe.skip`. Restore by
-// removing `.skip` and rewriting each mock's SQL pattern in step 5.
-describe.skip("admin connections — org scoping", () => {
+describe("admin connections — org scoping (workspace_plugins)", () => {
   beforeEach(() => {
     mocks.hasInternalDB = true;
     mocks.mockInternalQuery.mockReset();
     mocks.mockInternalQuery.mockResolvedValue([]);
     mockHealthCheck.mockClear();
+    mockRegister.mockClear();
     mockConfigOverride = null;
     setOrgAdmin("org-alpha");
   });
 
-  // ─── 1. Create stores org_id ────────────────────────────────────────
+  // ─── 1. Create persists workspace_id via installer INSERT ──────────
 
-  describe("POST /connections — create stores org_id", () => {
-    it("passes orgId to the INSERT query", async () => {
-      // register + healthCheck succeed via mock, then encrypt + INSERT
-      mocks.mockInternalQuery.mockResolvedValue([]);
+  describe("POST /connections — create persists workspace_id", () => {
+    it("passes orgId to the installer's INSERT INTO workspace_plugins call", async () => {
+      mocks.mockInternalQuery.mockImplementation((sql: string) => {
+        if (sqlIs.planCount(sql)) return Promise.resolve([{ count: 0 }]);
+        if (sqlIs.archiveCheck(sql)) return Promise.resolve([]);
+        if (sqlIs.catalogLookup(sql)) return Promise.resolve([POSTGRES_CATALOG_ROW]);
+        if (sqlIs.installerSingleton(sql)) return Promise.resolve([]);
+        if (sqlIs.installerInsert(sql)) return Promise.resolve([]);
+        return Promise.resolve([]);
+      });
 
       const res = await app.fetch(
         adminRequest("/api/v1/admin/connections", "POST", {
@@ -159,19 +260,28 @@ describe.skip("admin connections — org scoping", () => {
       const body = (await res.json()) as any;
       expect(body.id).toBe("analytics");
 
-      // Find the INSERT call among internalQuery calls
+      // INSERT INTO workspace_plugins must carry workspace_id at param index 1
+      // (after the rowId at index 0). Installer params order is fixed:
+      // `[rowId, workspaceId, catalogId, installId, config, status]`.
       const insertCall = mocks.mockInternalQuery.mock.calls.find(
-        ([sql]) => typeof sql === "string" && sql.includes("INSERT INTO connections"),
+        ([sql]) => typeof sql === "string" && sqlIs.installerInsert(sql),
       );
       expect(insertCall).toBeDefined();
-      const [sql, params] = insertCall!;
-      expect(sql).toContain("org_id");
-      expect(params).toContain("org-alpha");
+      const params = insertCall![1] as unknown[];
+      expect(params[1]).toBe("org-alpha"); // workspace_id
+      expect(params[3]).toBe("analytics"); // install_id
+      expect(params[5]).toBe("draft");      // status — always 'draft' per #2177
     });
 
-    it("stores a different org_id for a different workspace admin", async () => {
+    it("stores a different workspace_id for a different workspace admin", async () => {
       setOrgAdmin("org-beta");
-      mocks.mockInternalQuery.mockResolvedValue([]);
+      mocks.mockInternalQuery.mockImplementation((sql: string) => {
+        if (sqlIs.planCount(sql)) return Promise.resolve([{ count: 0 }]);
+        if (sqlIs.archiveCheck(sql)) return Promise.resolve([]);
+        if (sqlIs.catalogLookup(sql)) return Promise.resolve([POSTGRES_CATALOG_ROW]);
+        if (sqlIs.installerSingleton(sql)) return Promise.resolve([]);
+        return Promise.resolve([]);
+      });
 
       const res = await app.fetch(
         adminRequest("/api/v1/admin/connections", "POST", {
@@ -183,57 +293,44 @@ describe.skip("admin connections — org scoping", () => {
       expect(res.status).toBe(201);
 
       const insertCall = mocks.mockInternalQuery.mock.calls.find(
-        ([sql]) => typeof sql === "string" && sql.includes("INSERT INTO connections"),
+        ([sql]) => typeof sql === "string" && sqlIs.installerInsert(sql),
       );
       expect(insertCall).toBeDefined();
-      expect(insertCall![1]).toContain("org-beta");
+      expect((insertCall![1] as unknown[])[1]).toBe("org-beta");
     });
   });
 
-  // ─── 2. List filters by org ─────────────────────────────────────────
+  // ─── 2. List filters by workspace_id ─────────────────────────────────
 
-  describe("GET /connections — list filters by org", () => {
-    it("workspace admin sees only their org's connections — default is suppressed when org owns rows", async () => {
-      // getVisibleConnectionIds queries internal DB for org's connections
+  describe("GET /connections — list filters by workspace", () => {
+    it("workspace admin sees only their workspace's installs — default suppressed when org owns rows", async () => {
       mocks.mockInternalQuery.mockImplementation((sql: string) => {
-        if (sql.includes("SELECT c.id FROM connections c WHERE c.org_id")) {
-          // org-alpha owns "warehouse" only
-          return Promise.resolve([{ id: "warehouse" }]);
+        if (sqlIs.visibility(sql)) return Promise.resolve([{ install_id: "warehouse" }]);
+        if (sqlIs.decoration(sql)) {
+          return Promise.resolve([{ install_id: "warehouse", group_id: null }]);
         }
         return Promise.resolve([]);
       });
 
-      const res = await app.fetch(
-        adminRequest("/api/v1/admin/connections"),
-      );
-
+      const res = await app.fetch(adminRequest("/api/v1/admin/connections"));
       expect(res.status).toBe(200);
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test convenience
       const body = (await res.json()) as any;
       const ids = body.connections.map((c: { id: string }) => c.id);
-      // Should see "warehouse" (owned by org-alpha)
       expect(ids).toContain("warehouse");
-      // Should NOT see "default" — the org owns its own connection, so the
-      // runtime-registered fallback is suppressed (avoids the SaaS phantom-
-      // duplicate where every org saw both `default` and `__demo__`).
+      // Owned-row branch suppresses the lazy `default` so the admin UI
+      // doesn't show two cards on SaaS (#2483).
       expect(ids).not.toContain("default");
-      // Should NOT see "other-org-conn" (belongs to a different org)
       expect(ids).not.toContain("other-org-conn");
     });
 
-    it("workspace admin with no DB connections falls back to default and emits null group fields", async () => {
-      // No connections in internal DB for this org — self-hosted single-tenant
-      // path keeps working because `default` is the only registered connection.
-      // The decoration fallback must still emit groupId/groupName as null on
-      // every row; a regression that drops the `?? null` would silently ship
-      // `undefined` and trip every downstream consumer relying on the
-      // documented three-state semantics.
+    it("workspace with no installs falls back to default and emits null group fields", async () => {
+      // Self-hosted single-tenant path keeps working because `default` is
+      // the only registered connection. The decoration fallback must still
+      // emit `groupId`/`groupName` as null on every row.
       mocks.mockInternalQuery.mockResolvedValue([]);
 
-      const res = await app.fetch(
-        adminRequest("/api/v1/admin/connections"),
-      );
-
+      const res = await app.fetch(adminRequest("/api/v1/admin/connections"));
       expect(res.status).toBe(200);
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test convenience
       const body = (await res.json()) as any;
@@ -244,25 +341,19 @@ describe.skip("admin connections — org scoping", () => {
       expect(defaultRow.groupName).toBeNull();
     });
 
-    it("#2490 — org-owned row (warehouse) reports billable: true", async () => {
-      // Workspace owns one real `connections` row. The group-decoration
-      // JOIN matches it, so it lands in `groupInfoByConnection` and the
-      // response decorates `billable: true` — the same predicate billing
-      // uses for the trial-cap count.
+    it("#2490 — workspace-owned row reports billable: true", async () => {
+      // Workspace owns one install. The decoration query returns a row for
+      // it, so `groupInfoByConnection.has(id)` is true and `billable: true`
+      // — same predicate billing uses for the plan-limit count.
       mocks.mockInternalQuery.mockImplementation((sql: string) => {
-        if (sql.includes("SELECT c.id FROM connections c WHERE c.org_id")) {
-          return Promise.resolve([{ id: "warehouse" }]);
-        }
-        if (sql.includes("g.name AS group_name")) {
-          return Promise.resolve([
-            { id: "warehouse", group_id: null, group_name: null },
-          ]);
+        if (sqlIs.visibility(sql)) return Promise.resolve([{ install_id: "warehouse" }]);
+        if (sqlIs.decoration(sql)) {
+          return Promise.resolve([{ install_id: "warehouse", group_id: null }]);
         }
         return Promise.resolve([]);
       });
 
       const res = await app.fetch(adminRequest("/api/v1/admin/connections"));
-
       expect(res.status).toBe(200);
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test convenience
       const body = (await res.json()) as any;
@@ -271,49 +362,15 @@ describe.skip("admin connections — org scoping", () => {
       expect(warehouse.billable).toBe(true);
     });
 
-    it("#2490 — visible row absent from the org-scoped JOIN reports billable: false", async () => {
-      // Covers the `__global__`-sourced half of the billable contract.
-      // Visibility surfaces the row (via the UNION on `__global__` in
-      // getVisibleConnectionIds), but the group-decoration JOIN is
-      // scoped to `c.org_id = $1`, so a `__global__`-owned row returns
-      // no decoration → `billable: false`. Same parity billing enforces:
-      // the shared demo doesn't eat the trial slot. A future change
-      // that widens the JOIN to `org_id IN ($1, '__global__')` would
-      // silently start charging every workspace for shared rows — this
-      // test fails first.
-      mocks.mockInternalQuery.mockImplementation((sql: string) => {
-        if (sql.includes("SELECT c.id FROM connections c WHERE c.org_id")) {
-          // `warehouse` is the stand-in for a `__global__`-sourced row:
-          // visibility lists it, but the JOIN below returns no row for
-          // it (because it doesn't live under org-alpha in this fixture).
-          return Promise.resolve([{ id: "warehouse" }]);
-        }
-        if (sql.includes("g.name AS group_name")) {
-          return Promise.resolve([]);
-        }
-        return Promise.resolve([]);
-      });
-
-      const res = await app.fetch(adminRequest("/api/v1/admin/connections"));
-
-      expect(res.status).toBe(200);
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test convenience
-      const body = (await res.json()) as any;
-      const warehouse = body.connections.find((c: { id: string }) => c.id === "warehouse");
-      expect(warehouse).toBeDefined();
-      expect(warehouse.billable).toBe(false);
-    });
-
     it("#2490 — lone lazy `default` (pre-provision workspace) reports billable: false", async () => {
-      // Pre-provision self-hosted demo: zero `connections` rows for this
+      // Pre-provision self-hosted demo: zero workspace_plugins rows for this
       // org. `getVisibleConnectionIds` adds `default` from the in-memory
       // registry. The list response must mark it `billable: false` so the
-      // /admin/connections header agrees with the /admin/billing usage
-      // panel (which counts the same SQL predicate and reports 0).
+      // admin header agrees with the billing usage panel (which counts the
+      // same SQL predicate and reports 0).
       mocks.mockInternalQuery.mockResolvedValue([]);
 
       const res = await app.fetch(adminRequest("/api/v1/admin/connections"));
-
       expect(res.status).toBe(200);
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test convenience
       const body = (await res.json()) as any;
@@ -322,53 +379,39 @@ describe.skip("admin connections — org scoping", () => {
       expect(body.connections[0].billable).toBe(false);
     });
 
-    it("decorates each row with groupId + groupName from the connection_groups JOIN", async () => {
-      // The list endpoint's second internalQuery call selects c.id, c.group_id
-      // and g.name via LEFT JOIN connection_groups. The visibility query runs
-      // first; we only return a group decoration for the visible row.
+    it("decorates each row with groupId + groupName from the JSONB group_id read", async () => {
+      // Post-cutover groupName mirrors groupId verbatim (a string IS a name
+      // now — the `connection_groups.name` join is gone). The list
+      // endpoint's `groupInfoByConnection` map carries both for wire-shape
+      // backwards compatibility with the admin UI.
       mocks.mockInternalQuery.mockImplementation((sql: string) => {
-        if (sql.includes("SELECT c.id FROM connections c WHERE c.org_id")) {
-          return Promise.resolve([{ id: "warehouse" }]);
-        }
-        if (sql.includes("g.name AS group_name")) {
-          return Promise.resolve([
-            { id: "warehouse", group_id: "g_prod", group_name: "g_prod" },
-          ]);
+        if (sqlIs.visibility(sql)) return Promise.resolve([{ install_id: "warehouse" }]);
+        if (sqlIs.decoration(sql)) {
+          return Promise.resolve([{ install_id: "warehouse", group_id: "prod" }]);
         }
         return Promise.resolve([]);
       });
 
-      const res = await app.fetch(
-        adminRequest("/api/v1/admin/connections"),
-      );
-
+      const res = await app.fetch(adminRequest("/api/v1/admin/connections"));
       expect(res.status).toBe(200);
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test convenience
       const body = (await res.json()) as any;
       const warehouse = body.connections.find((c: { id: string }) => c.id === "warehouse");
       expect(warehouse).toBeDefined();
-      expect(warehouse.groupId).toBe("g_prod");
-      expect(warehouse.groupName).toBe("g_prod");
+      expect(warehouse.groupId).toBe("prod");
+      expect(warehouse.groupName).toBe("prod");
     });
 
-    it("emits groupName: null when a visible connection has no group decoration", async () => {
+    it("emits groupName: null when a visible install has no group_id JSONB key", async () => {
       mocks.mockInternalQuery.mockImplementation((sql: string) => {
-        if (sql.includes("SELECT c.id FROM connections c WHERE c.org_id")) {
-          return Promise.resolve([{ id: "warehouse" }]);
-        }
-        // LEFT JOIN returns the row with NULL group_id/name when ungrouped.
-        if (sql.includes("g.name AS group_name")) {
-          return Promise.resolve([
-            { id: "warehouse", group_id: null, group_name: null },
-          ]);
+        if (sqlIs.visibility(sql)) return Promise.resolve([{ install_id: "warehouse" }]);
+        if (sqlIs.decoration(sql)) {
+          return Promise.resolve([{ install_id: "warehouse", group_id: null }]);
         }
         return Promise.resolve([]);
       });
 
-      const res = await app.fetch(
-        adminRequest("/api/v1/admin/connections"),
-      );
-
+      const res = await app.fetch(adminRequest("/api/v1/admin/connections"));
       expect(res.status).toBe(200);
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test convenience
       const body = (await res.json()) as any;
@@ -379,12 +422,12 @@ describe.skip("admin connections — org scoping", () => {
     });
   });
 
-  // ─── 3. Update/delete 404 for wrong org ─────────────────────────────
+  // ─── 3. PUT 404s for wrong workspace ──────────────────────────────────
 
-  describe("PUT /connections/:id — org isolation", () => {
-    it("returns 404 when connection belongs to another org", async () => {
+  describe("PUT /connections/:id — workspace isolation", () => {
+    it("returns 404 when install belongs to another workspace", async () => {
       setOrgAdmin("org-alpha");
-      // SELECT ... WHERE id = $1 AND org_id = $2 → empty (wrong org)
+      // putLoad → empty (no install in org-alpha for other-org-conn)
       mocks.mockInternalQuery.mockResolvedValue([]);
 
       const res = await app.fetch(
@@ -398,29 +441,40 @@ describe.skip("admin connections — org scoping", () => {
       const body = (await res.json()) as any;
       expect(body.error).toBe("not_found");
 
-      // Verify the SQL included org_id filter
+      // The route's PUT load query must filter by workspace_id.
       const selectCall = mocks.mockInternalQuery.mock.calls.find(
-        ([sql]) => typeof sql === "string" && sql.includes("SELECT") && sql.includes("connections"),
+        ([sql]) => typeof sql === "string" && sqlIs.putLoad(sql),
       );
       expect(selectCall).toBeDefined();
-      expect(selectCall![0]).toContain("org_id");
+      expect(selectCall![0]).toContain("wp.workspace_id = $1");
       expect(selectCall![1]).toContain("org-alpha");
     });
 
-    it("succeeds when connection belongs to the admin's org", async () => {
+    it("succeeds when install belongs to the admin's workspace", async () => {
       setOrgAdmin("org-alpha");
-      // SELECT returns existing connection
       mocks.mockInternalQuery.mockImplementation((sql: string) => {
-        if (sql.includes("SELECT") && sql.includes("connections")) {
-          return Promise.resolve([{
-            id: "warehouse",
-            url: "encrypted:postgresql://user:pass@host/db",
-            type: "postgres",
-            description: "Warehouse",
-            schema_name: null,
-          }]);
+        if (sqlIs.putLoad(sql)) {
+          return Promise.resolve([
+            {
+              catalog_slug: "postgres",
+              config: { url: "encrypted:postgresql://user:pass@host/db" },
+              config_schema: POSTGRES_CATALOG_ROW.config_schema,
+              group_id: null,
+            },
+          ]);
         }
-        // UPDATE succeeds
+        if (sqlIs.catalogLookup(sql)) return Promise.resolve([POSTGRES_CATALOG_ROW]);
+        if (sqlIs.installerLoadForUpdate(sql)) {
+          return Promise.resolve([
+            {
+              id: "cn_org-alpha_warehouse",
+              install_id: "warehouse",
+              config: { url: "encrypted:postgresql://user:pass@host/db" },
+              status: "published",
+            },
+          ]);
+        }
+        if (sqlIs.installerUpdate(sql)) return Promise.resolve([]);
         return Promise.resolve([]);
       });
 
@@ -437,10 +491,12 @@ describe.skip("admin connections — org scoping", () => {
     });
   });
 
-  describe("DELETE /connections/:id — org isolation", () => {
-    it("returns 404 when connection belongs to another org", async () => {
+  // ─── 4. DELETE 404s for wrong workspace + soft archives ──────────────
+
+  describe("DELETE /connections/:id — workspace isolation", () => {
+    it("returns 404 when install belongs to another workspace", async () => {
       setOrgAdmin("org-alpha");
-      // SELECT ... WHERE id = $1 AND org_id = $2 → empty
+      // deleteLoad → empty (no install for other-org-conn in org-alpha)
       mocks.mockInternalQuery.mockResolvedValue([]);
 
       const res = await app.fetch(
@@ -453,16 +509,16 @@ describe.skip("admin connections — org scoping", () => {
       expect(body.error).toBe("not_found");
     });
 
-    it("succeeds when connection belongs to the admin's org", async () => {
+    it("succeeds when install belongs to the admin's workspace — soft-archives via installer", async () => {
       setOrgAdmin("org-alpha");
       mocks.mockInternalQuery.mockImplementation((sql: string) => {
-        if (sql.includes("SELECT") && sql.includes("connections")) {
-          // Delete handler now selects (id, org_id, type) so it can decide
-          // archive-in-place vs per-org tombstone for global connections.
-          return Promise.resolve([{ id: "warehouse", org_id: "org-alpha", type: "postgres" }]);
+        if (sqlIs.deleteLoad(sql)) return Promise.resolve([{ catalog_slug: "postgres" }]);
+        if (sqlIs.schedRefs(sql)) return Promise.resolve([{ count: "0" }]);
+        if (sqlIs.catalogLookup(sql)) return Promise.resolve([POSTGRES_CATALOG_ROW]);
+        if (sqlIs.installerSoftArchive(sql)) {
+          return Promise.resolve([{ id: "cn_org-alpha_warehouse" }]);
         }
-        // scheduled_tasks check + DELETE
-        return Promise.resolve([{ count: "0" }]);
+        return Promise.resolve([]);
       });
 
       const res = await app.fetch(
@@ -473,6 +529,20 @@ describe.skip("admin connections — org scoping", () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test convenience
       const body = (await res.json()) as any;
       expect(body.success).toBe(true);
+
+      // Verify the soft-archive UPDATE fired (no hard DELETE on the
+      // workspace_plugins row — the install row stays for audit).
+      const archiveCall = mocks.mockInternalQuery.mock.calls.find(
+        ([sql]) => typeof sql === "string" && sqlIs.installerSoftArchive(sql),
+      );
+      expect(archiveCall).toBeDefined();
+      const hardDelete = mocks.mockInternalQuery.mock.calls.find(
+        ([sql]) =>
+          typeof sql === "string" &&
+          sql.includes("DELETE FROM workspace_plugins") &&
+          sql.includes("install_id"),
+      );
+      expect(hardDelete).toBeUndefined();
     });
 
     it("cannot delete the default connection", async () => {
@@ -487,12 +557,11 @@ describe.skip("admin connections — org scoping", () => {
     });
   });
 
-  // ─── 3b. Health-check org isolation ───────────────────────────────
+  // ─── 3b. Health-check workspace isolation ────────────────────────────
 
-  describe("POST /connections/:id/test — org isolation", () => {
-    it("returns 404 when health-checking a connection not visible to org", async () => {
+  describe("POST /connections/:id/test — workspace isolation", () => {
+    it("returns 404 when health-checking an install not visible to workspace", async () => {
       setOrgAdmin("org-alpha");
-      // org-alpha does not own other-org-conn
       mocks.mockInternalQuery.mockResolvedValue([]);
 
       const res = await app.fetch(
@@ -502,12 +571,10 @@ describe.skip("admin connections — org scoping", () => {
       expect(res.status).toBe(404);
     });
 
-    it("succeeds when health-checking a connection visible to org", async () => {
+    it("succeeds when health-checking an install visible to workspace", async () => {
       setOrgAdmin("org-alpha");
       mocks.mockInternalQuery.mockImplementation((sql: string) => {
-        if (sql.includes("SELECT c.id FROM connections c WHERE c.org_id")) {
-          return Promise.resolve([{ id: "warehouse" }]);
-        }
+        if (sqlIs.visibility(sql)) return Promise.resolve([{ install_id: "warehouse" }]);
         return Promise.resolve([]);
       });
 
@@ -518,10 +585,10 @@ describe.skip("admin connections — org scoping", () => {
       expect(res.status).toBe(200);
     });
 
-    it("platform admin health-checking a connection not in their active org gets 404", async () => {
-      // Mirrors the platform-admin scoping fix: per-connection routes use
-      // active-org visibility for everyone. Switch active org to reach
-      // another tenant's connection.
+    it("platform admin health-checking an install not in their active workspace gets 404", async () => {
+      // Per-connection routes use active-workspace visibility for everyone
+      // post-#2303. Switch active workspace via setPlatformAdmin to reach
+      // another tenant's install.
       setPlatformAdmin("org-alpha");
       mocks.mockInternalQuery.mockResolvedValue([]);
 
@@ -533,12 +600,11 @@ describe.skip("admin connections — org scoping", () => {
     });
   });
 
-  // ─── 3c. Drain endpoint org isolation ───────────────────────────────
+  // ─── 3c. Drain endpoint workspace isolation ──────────────────────────
 
-  describe("POST /connections/:id/drain — org isolation", () => {
-    it("returns 404 when draining a connection not visible to org", async () => {
+  describe("POST /connections/:id/drain — workspace isolation", () => {
+    it("returns 404 when draining an install not visible to workspace", async () => {
       setOrgAdmin("org-alpha");
-      // org-alpha does not own other-org-conn
       mocks.mockInternalQuery.mockResolvedValue([]);
 
       const res = await app.fetch(
@@ -548,14 +614,8 @@ describe.skip("admin connections — org scoping", () => {
       expect(res.status).toBe(404);
     });
 
-    it("platform admin draining a connection not in their active org gets 404", async () => {
-      // After the platform_admin visibility bypass was removed, the
-      // per-connection drain endpoint scopes by active org for everyone.
-      // Cross-org pool drain still works via `POST /pool/orgs/:orgId/drain`
-      // (which accepts an explicit orgId) — that surface remains
-      // platform-admin-only via its own check.
+    it("platform admin draining an install not in their active workspace gets 404", async () => {
       setPlatformAdmin("org-alpha");
-      // org-alpha does not own warehouse in this fixture
       mocks.mockInternalQuery.mockResolvedValue([]);
 
       const res = await app.fetch(
@@ -566,10 +626,10 @@ describe.skip("admin connections — org scoping", () => {
     });
   });
 
-  // ─── 3d. Org drain cross-org restriction ────────────────────────────
+  // ─── 3d. Org drain cross-workspace restriction ───────────────────────
 
-  describe("POST /connections/pool/orgs/:orgId/drain — cross-org guard", () => {
-    it("workspace admin gets 403 when draining another org's pools", async () => {
+  describe("POST /connections/pool/orgs/:orgId/drain — cross-workspace guard", () => {
+    it("workspace admin gets 403 when draining another workspace's pools", async () => {
       setOrgAdmin("org-alpha");
 
       const res = await app.fetch(
@@ -582,7 +642,7 @@ describe.skip("admin connections — org scoping", () => {
       expect(body.error).toBe("forbidden");
     });
 
-    it("workspace admin can drain their own org's pools", async () => {
+    it("workspace admin can drain their own workspace's pools", async () => {
       setOrgAdmin("org-alpha");
 
       const res = await app.fetch(
@@ -592,7 +652,7 @@ describe.skip("admin connections — org scoping", () => {
       expect(res.status).toBe(200);
     });
 
-    it("platform admin can drain any org's pools", async () => {
+    it("platform admin can drain any workspace's pools", async () => {
       setPlatformAdmin("org-alpha");
 
       const res = await app.fetch(
@@ -603,49 +663,61 @@ describe.skip("admin connections — org scoping", () => {
     });
   });
 
-  // ─── 4. Platform admin bypasses org filter ──────────────────────────
+  // ─── 4. Platform admin still scoped to active workspace ──────────────
 
-  describe("platform admin — list still org-scoped", () => {
-    it("list is scoped to the active org (no cross-org bypass)", async () => {
-      // The previous implementation short-circuited getVisibleConnectionIds
-      // to `return null` for platform admins, which leaked every tenant's
-      // connections into every workspace's admin-connections page. After
-      // the fix, platform admins see the same scoped set as workspace
-      // admins — they must use the workspace switcher (or the dedicated
-      // `/platform/*` surfaces) to look at another org.
+  describe("platform admin — list still workspace-scoped", () => {
+    it("list is scoped to the active workspace (no cross-workspace bypass)", async () => {
+      // Pre-#2303 the visibility helper short-circuited for platform admins
+      // → leaked every tenant's installs into every workspace's admin page.
+      // Post-fix, platform admins see the same scoped set as workspace
+      // admins; cross-workspace views live in `/platform/*`.
       setPlatformAdmin("org-alpha");
-      // org-alpha owns only warehouse in this fixture
-      mocks.mockInternalQuery.mockResolvedValue([{ id: "warehouse" }]);
+      mocks.mockInternalQuery.mockImplementation((sql: string) => {
+        if (sqlIs.visibility(sql)) return Promise.resolve([{ install_id: "warehouse" }]);
+        if (sqlIs.decoration(sql)) {
+          return Promise.resolve([{ install_id: "warehouse", group_id: null }]);
+        }
+        return Promise.resolve([]);
+      });
 
-      const res = await app.fetch(
-        adminRequest("/api/v1/admin/connections"),
-      );
-
+      const res = await app.fetch(adminRequest("/api/v1/admin/connections"));
       expect(res.status).toBe(200);
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test convenience
       const body = (await res.json()) as any;
       const ids = body.connections.map((c: { id: string }) => c.id);
       expect(ids).toEqual(["warehouse"]);
 
-      // Org filter SQL was issued (no platform_admin bypass)
-      const orgFilterCall = mocks.mockInternalQuery.mock.calls.find(
-        ([sql]) => typeof sql === "string" && sql.includes("SELECT c.id FROM connections c WHERE c.org_id"),
+      // Workspace filter SQL was issued (no platform_admin bypass).
+      const visCall = mocks.mockInternalQuery.mock.calls.find(
+        ([sql]) => typeof sql === "string" && sqlIs.visibility(sql),
       );
-      expect(orgFilterCall).toBeDefined();
+      expect(visCall).toBeDefined();
+      expect(visCall![1]).toContain("org-alpha");
     });
 
-    it("update scopes by active org even for platform admin", async () => {
+    it("update scopes by active workspace even for platform admin", async () => {
       setPlatformAdmin("org-alpha");
-      // Platform admin queries now always include org_id (composite PK scoping)
       mocks.mockInternalQuery.mockImplementation((sql: string) => {
-        if (sql.includes("SELECT") && sql.includes("connections")) {
-          return Promise.resolve([{
-            id: "other-org-conn",
-            url: "encrypted:mysql://user:pass@host/db",
-            type: "mysql",
-            description: "Other org",
-            schema_name: null,
-          }]);
+        if (sqlIs.putLoad(sql)) {
+          return Promise.resolve([
+            {
+              catalog_slug: "postgres",
+              config: { url: "encrypted:postgresql://user:pass@host/db" },
+              config_schema: POSTGRES_CATALOG_ROW.config_schema,
+              group_id: null,
+            },
+          ]);
+        }
+        if (sqlIs.catalogLookup(sql)) return Promise.resolve([POSTGRES_CATALOG_ROW]);
+        if (sqlIs.installerLoadForUpdate(sql)) {
+          return Promise.resolve([
+            {
+              id: "cn_org-alpha_other-org-conn",
+              install_id: "other-org-conn",
+              config: { url: "encrypted:postgresql://user:pass@host/db" },
+              status: "published",
+            },
+          ]);
         }
         return Promise.resolve([]);
       });
@@ -658,21 +730,24 @@ describe.skip("admin connections — org scoping", () => {
 
       expect(res.status).toBe(200);
 
-      // Verify the SELECT includes org_id filter (composite PK scoping)
+      // The PUT load query must filter by workspace_id (composite scoping).
       const selectCall = mocks.mockInternalQuery.mock.calls.find(
-        ([sql]) => typeof sql === "string" && sql.includes("SELECT") && sql.includes("connections"),
+        ([sql]) => typeof sql === "string" && sqlIs.putLoad(sql),
       );
       expect(selectCall).toBeDefined();
-      expect(selectCall![0]).toContain("org_id");
+      expect(selectCall![0]).toContain("wp.workspace_id");
     });
 
-    it("delete scopes by active org even for platform admin", async () => {
+    it("delete scopes by active workspace even for platform admin", async () => {
       setPlatformAdmin("org-alpha");
       mocks.mockInternalQuery.mockImplementation((sql: string) => {
-        if (sql.includes("SELECT") && sql.includes("connections")) {
-          return Promise.resolve([{ id: "other-org-conn", org_id: "org-alpha", type: "mysql" }]);
+        if (sqlIs.deleteLoad(sql)) return Promise.resolve([{ catalog_slug: "postgres" }]);
+        if (sqlIs.schedRefs(sql)) return Promise.resolve([{ count: "0" }]);
+        if (sqlIs.catalogLookup(sql)) return Promise.resolve([POSTGRES_CATALOG_ROW]);
+        if (sqlIs.installerSoftArchive(sql)) {
+          return Promise.resolve([{ id: "cn_org-alpha_other-org-conn" }]);
         }
-        return Promise.resolve([{ count: "0" }]);
+        return Promise.resolve([]);
       });
 
       const res = await app.fetch(
@@ -684,31 +759,22 @@ describe.skip("admin connections — org scoping", () => {
       const body = (await res.json()) as any;
       expect(body.success).toBe(true);
 
-      // Delete is implemented as an archive UPDATE (#1428) — verify it
-      // includes the org_id filter (composite PK scoping)
+      // Soft-archive UPDATE must scope by workspace_id (composite PK).
       const archiveCall = mocks.mockInternalQuery.mock.calls.find(
-        ([sql]) =>
-          typeof sql === "string" &&
-          sql.includes("UPDATE connections") &&
-          sql.includes("archived"),
+        ([sql]) => typeof sql === "string" && sqlIs.installerSoftArchive(sql),
       );
       expect(archiveCall).toBeDefined();
-      expect(archiveCall![0]).toContain("org_id");
+      expect(archiveCall![0]).toContain("workspace_id");
     });
   });
 
-  // ─── 5. getVisibleConnectionIds correctness ─────────────────────────
+  // ─── 5. getVisibleConnectionIds + GET /:id detail correctness ────────
 
-  describe("getVisibleConnectionIds — via list endpoint behavior", () => {
-    it("falls back to 'default' for workspace admins when the org owns no connections", async () => {
-      // Self-hosted single-tenant: no connections rows → seed `default` from
-      // the runtime registry so the admin still sees the config-managed DB.
+  describe("getVisibleConnectionIds — via list/detail endpoint behavior", () => {
+    it("falls back to 'default' when the workspace owns no installs", async () => {
       mocks.mockInternalQuery.mockResolvedValue([]);
 
-      const res = await app.fetch(
-        adminRequest("/api/v1/admin/connections"),
-      );
-
+      const res = await app.fetch(adminRequest("/api/v1/admin/connections"));
       expect(res.status).toBe(200);
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test convenience
       const body = (await res.json()) as any;
@@ -716,9 +782,7 @@ describe.skip("admin connections — org scoping", () => {
       expect(ids).toContain("default");
     });
 
-    it("self-hosted (explicit deployMode) still surfaces 'default' when org owns no connections (#2483)", async () => {
-      // Same scenario as above, but with an explicit `deployMode: "self-hosted"`
-      // config so the SaaS-gate branch is exercised on the negative side.
+    it("self-hosted (explicit deployMode) still surfaces 'default' when org owns no rows (#2483)", async () => {
       mockConfigOverride = { deployMode: "self-hosted" };
       mocks.mockInternalQuery.mockResolvedValue([]);
 
@@ -731,11 +795,11 @@ describe.skip("admin connections — org scoping", () => {
     });
 
     it("SaaS suppresses the 'default' fallback for a fresh-signup workspace (#2483)", async () => {
-      // SaaS smoking gun: a freshly-signed-up workspace has zero `connections`
+      // Smoking gun: a freshly-signed-up workspace has zero workspace_plugins
       // rows. The runtime registry has `default` bound to the shared
-      // ATLAS_DATASOURCE_URL demo service. Without the SaaS gate, that demo
-      // surfaces as "your default Atlas connection" in every fresh-signup
-      // workspace — a tenant-isolation smell and a chat-routing risk.
+      // ATLAS_DATASOURCE_URL demo. Without the SaaS gate, that demo would
+      // surface as "your default Atlas connection" in every fresh-signup
+      // workspace — tenant-isolation smell + chat-routing risk.
       mockConfigOverride = { deployMode: "saas" };
       mocks.mockInternalQuery.mockResolvedValue([]);
 
@@ -748,16 +812,15 @@ describe.skip("admin connections — org scoping", () => {
       expect(ids).toEqual([]);
     });
 
-    it("SaaS gate is orthogonal to owned-rows — owned connections still surface on SaaS (#2483)", async () => {
-      // Closes the gate × owned-rows matrix: confirms the SaaS gate only
-      // suppresses the `visible.size === 0` fallback branch and does not
-      // interfere with the org's own connections. Guards against an inverted-
+    it("SaaS gate is orthogonal to owned rows — owned installs still surface on SaaS (#2483)", async () => {
+      // Closes the gate × owned-rows matrix. Guards against an inverted-
       // boolean regression (e.g. `if (visible.size === 0 || !isSaas)`) that
       // would accidentally drop owned rows on SaaS.
       mockConfigOverride = { deployMode: "saas" };
       mocks.mockInternalQuery.mockImplementation((sql: string) => {
-        if (sql.includes("SELECT c.id FROM connections c WHERE c.org_id")) {
-          return Promise.resolve([{ id: "warehouse" }]);
+        if (sqlIs.visibility(sql)) return Promise.resolve([{ install_id: "warehouse" }]);
+        if (sqlIs.decoration(sql)) {
+          return Promise.resolve([{ install_id: "warehouse", group_id: null }]);
         }
         return Promise.resolve([]);
       });
@@ -770,20 +833,16 @@ describe.skip("admin connections — org scoping", () => {
       expect(ids).toEqual(["warehouse"]);
     });
 
-    it("suppresses 'default' once the org has its own connections", async () => {
-      // SaaS path: dhamra owns __demo__ (or wizard-created), so the runtime-
-      // registered `default` should not surface alongside it.
+    it("suppresses 'default' once the workspace has its own installs", async () => {
       mocks.mockInternalQuery.mockImplementation((sql: string) => {
-        if (sql.includes("SELECT c.id FROM connections c WHERE c.org_id")) {
-          return Promise.resolve([{ id: "warehouse" }]);
+        if (sqlIs.visibility(sql)) return Promise.resolve([{ install_id: "warehouse" }]);
+        if (sqlIs.decoration(sql)) {
+          return Promise.resolve([{ install_id: "warehouse", group_id: null }]);
         }
         return Promise.resolve([]);
       });
 
-      const res = await app.fetch(
-        adminRequest("/api/v1/admin/connections"),
-      );
-
+      const res = await app.fetch(adminRequest("/api/v1/admin/connections"));
       expect(res.status).toBe(200);
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test convenience
       const body = (await res.json()) as any;
@@ -791,17 +850,17 @@ describe.skip("admin connections — org scoping", () => {
       expect(ids).toEqual(["warehouse"]);
     });
 
-    it("scopes platform admin to their active org's connections (no bypass)", async () => {
-      // The platform_admin "null = no filter" bypass was removed — platform
-      // admins now see the same set as workspace admins. Cross-org views
-      // belong in `/platform/*`.
+    it("scopes platform admin to active workspace's installs (no bypass)", async () => {
       setPlatformAdmin("org-alpha");
-      mocks.mockInternalQuery.mockResolvedValue([{ id: "warehouse" }]);
+      mocks.mockInternalQuery.mockImplementation((sql: string) => {
+        if (sqlIs.visibility(sql)) return Promise.resolve([{ install_id: "warehouse" }]);
+        if (sqlIs.decoration(sql)) {
+          return Promise.resolve([{ install_id: "warehouse", group_id: null }]);
+        }
+        return Promise.resolve([]);
+      });
 
-      const res = await app.fetch(
-        adminRequest("/api/v1/admin/connections"),
-      );
-
+      const res = await app.fetch(adminRequest("/api/v1/admin/connections"));
       expect(res.status).toBe(200);
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test convenience
       const body = (await res.json()) as any;
@@ -809,33 +868,8 @@ describe.skip("admin connections — org scoping", () => {
       expect(ids).toEqual(["warehouse"]);
     });
 
-    it("visibility query UNIONs `__global__` connections as a fallback", async () => {
-      // The new visibility SQL UNIONs the org's own rows with rows at
-      // org_id = '__global__' (with an EXISTS check so an own-row shadows
-      // a same-id global row). Used for canonical demos like `__demo__`.
+    it("get-by-id returns 404 for an install not visible to workspace", async () => {
       setOrgAdmin("org-alpha");
-      mocks.mockInternalQuery.mockResolvedValue([{ id: "warehouse" }]);
-
-      const res = await app.fetch(
-        adminRequest("/api/v1/admin/connections"),
-      );
-
-      expect(res.status).toBe(200);
-
-      // Verify the SQL queried `__global__` in addition to the active org.
-      const visibilityCall = mocks.mockInternalQuery.mock.calls.find(
-        ([sql]) => typeof sql === "string" && sql.includes("SELECT c.id FROM connections c WHERE c.org_id"),
-      );
-      expect(visibilityCall).toBeDefined();
-      expect(visibilityCall![0]).toContain("__global__");
-      // Shadow-precedence is enforced via NOT EXISTS, not at the SQL UNION
-      // level — same-id own-rows mask the global counterpart.
-      expect(visibilityCall![0]).toContain("NOT EXISTS");
-    });
-
-    it("get-by-id returns 404 for connection not visible to org", async () => {
-      setOrgAdmin("org-alpha");
-      // org-alpha does not own other-org-conn
       mocks.mockInternalQuery.mockResolvedValue([]);
 
       const res = await app.fetch(
@@ -845,94 +879,77 @@ describe.skip("admin connections — org scoping", () => {
       expect(res.status).toBe(404);
     });
 
-    it("get-by-id succeeds for connection visible to org", async () => {
+    it("get-by-id succeeds for an install visible to workspace", async () => {
       setOrgAdmin("org-alpha");
       mocks.mockInternalQuery.mockImplementation((sql: string) => {
-        if (sql.includes("SELECT c.id FROM connections c WHERE c.org_id")) {
-          return Promise.resolve([{ id: "warehouse" }]);
-        }
-        // Detail query — now LEFT JOINs connection_groups to surface
-        // groupId/groupName on the wire (#2421). The substring picks the
-        // composite alias so it doesn't collide with the list endpoint.
-        if (sql.includes("SELECT c.url, c.schema_name, c.group_id, g.name AS group_name")) {
+        if (sqlIs.visibility(sql)) return Promise.resolve([{ install_id: "warehouse" }]);
+        if (sqlIs.detail(sql)) {
           return Promise.resolve([
             {
-              url: "encrypted:postgresql://user:pass@host/db",
-              schema_name: null,
+              config: { url: "encrypted:postgresql://user:pass@host/db" },
+              config_schema: POSTGRES_CATALOG_ROW.config_schema,
               group_id: null,
-              group_name: null,
             },
           ]);
         }
         return Promise.resolve([]);
       });
 
-      const res = await app.fetch(
-        adminRequest("/api/v1/admin/connections/warehouse"),
-      );
-
+      const res = await app.fetch(adminRequest("/api/v1/admin/connections/warehouse"));
       expect(res.status).toBe(200);
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test convenience
       const body = (await res.json()) as any;
       expect(body.id).toBe("warehouse");
       expect(body.managed).toBe(true);
-      // group fields are surfaced; null here because the mock returns NULL
-      // from the LEFT JOIN. A separate case asserts the populated branch.
       expect(body.groupId).toBeNull();
       expect(body.groupName).toBeNull();
     });
 
-    it("get-by-id surfaces groupId + groupName when the LEFT JOIN matches", async () => {
+    it("get-by-id surfaces groupId + groupName when config carries group_id", async () => {
       setOrgAdmin("org-alpha");
       mocks.mockInternalQuery.mockImplementation((sql: string) => {
-        if (sql.includes("SELECT c.id FROM connections c WHERE c.org_id")) {
-          return Promise.resolve([{ id: "warehouse" }]);
-        }
-        if (sql.includes("SELECT c.url, c.schema_name, c.group_id, g.name AS group_name")) {
+        if (sqlIs.visibility(sql)) return Promise.resolve([{ install_id: "warehouse" }]);
+        if (sqlIs.detail(sql)) {
           return Promise.resolve([
             {
-              url: "encrypted:postgresql://user:pass@host/db",
-              schema_name: null,
-              group_id: "g_warehouse",
-              group_name: "warehouse",
+              config: { url: "encrypted:postgresql://user:pass@host/db" },
+              config_schema: POSTGRES_CATALOG_ROW.config_schema,
+              group_id: "warehouse-env",
             },
           ]);
         }
         return Promise.resolve([]);
       });
 
-      const res = await app.fetch(
-        adminRequest("/api/v1/admin/connections/warehouse"),
-      );
-
+      const res = await app.fetch(adminRequest("/api/v1/admin/connections/warehouse"));
       expect(res.status).toBe(200);
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test convenience
       const body = (await res.json()) as any;
-      expect(body.groupId).toBe("g_warehouse");
-      expect(body.groupName).toBe("warehouse");
+      expect(body.groupId).toBe("warehouse-env");
+      // Post-cutover groupName mirrors groupId verbatim — `connection_groups.name`
+      // is gone, a string IS a name now.
+      expect(body.groupName).toBe("warehouse-env");
     });
   });
 
-  // ─── GET /connections — mode-aware status clause (#1427 / #1455) ──────
+  // ─── GET /connections — mode-aware status clause (#1427 / #1455) ─────
 
   describe("GET /connections — mode-aware status filter", () => {
-    function findVisibleConnectionsCall(): [string, unknown[]] | undefined {
+    function findVisibilityCall(): [string, unknown[]] | undefined {
       const call = mocks.mockInternalQuery.mock.calls.find(
-        ([sql]) =>
-          typeof sql === "string" &&
-          sql.includes("SELECT c.id FROM connections c WHERE c.org_id"),
+        ([sql]) => typeof sql === "string" && sqlIs.visibility(sql),
       );
       return call as [string, unknown[]] | undefined;
     }
 
-    it("published mode restricts visible connections to status = 'published'", async () => {
+    it("published mode restricts visible installs to status = 'published'", async () => {
       setOrgAdmin("org-alpha");
       mocks.mockInternalQuery.mockResolvedValue([]);
 
       const res = await app.fetch(adminRequest("/api/v1/admin/connections"));
       expect(res.status).toBe(200);
 
-      const call = findVisibleConnectionsCall();
+      const call = findVisibilityCall();
       expect(call).toBeDefined();
       expect(call![0]).toContain("status = 'published'");
       expect(call![0]).not.toContain("status IN ('published', 'draft')");
@@ -947,24 +964,31 @@ describe.skip("admin connections — org scoping", () => {
       );
       expect(res.status).toBe(200);
 
-      const call = findVisibleConnectionsCall();
+      const call = findVisibilityCall();
       expect(call).toBeDefined();
       expect(call![0]).toContain("status IN ('published', 'draft')");
       expect(call![0]).not.toContain("status = 'published'");
-      // Archived rows are always excluded — never appears in either mode
-      expect(call![0]).not.toContain("archived");
+      // Archived rows are excluded in both modes — the readFilter never
+      // surfaces 'archived' in normal reads.
+      expect(call![0]).not.toContain("'archived'");
     });
   });
 
-  // ─── Write-path mode-awareness (#1428) ────────────────────────────────
+  // ─── Write-path mode-awareness (#1428 / #2177) ────────────────────────
 
-  describe("POST /connections — mode-aware create", () => {
+  describe("POST /connections — always stamps status='draft' (#2177)", () => {
     beforeEach(() => {
       setOrgAdmin("org-alpha");
     });
 
-    it("published mode (default) inserts status='draft' (#2177)", async () => {
-      mocks.mockInternalQuery.mockResolvedValue([]);
+    it("published mode (default) inserts status='draft'", async () => {
+      mocks.mockInternalQuery.mockImplementation((sql: string) => {
+        if (sqlIs.planCount(sql)) return Promise.resolve([{ count: 0 }]);
+        if (sqlIs.archiveCheck(sql)) return Promise.resolve([]);
+        if (sqlIs.catalogLookup(sql)) return Promise.resolve([POSTGRES_CATALOG_ROW]);
+        if (sqlIs.installerSingleton(sql)) return Promise.resolve([]);
+        return Promise.resolve([]);
+      });
       const res = await app.fetch(
         adminRequest("/api/v1/admin/connections", "POST", {
           id: "analytics",
@@ -973,21 +997,21 @@ describe.skip("admin connections — org scoping", () => {
       );
       expect(res.status).toBe(201);
       const insertCall = mocks.mockInternalQuery.mock.calls.find(
-        ([sql]) => typeof sql === "string" && sql.includes("INSERT INTO connections"),
+        ([sql]) => typeof sql === "string" && sqlIs.installerInsert(sql),
       );
       expect(insertCall).toBeDefined();
-      const [sql, params] = insertCall!;
-      expect(sql).toContain("status");
-      expect(sql).toContain("url_key_version");
-      // F-47: status is now at index 6 (was last, pushed by url_key_version at index 7).
-      // Post-#2177: status is always 'draft' regardless of `atlas-mode` header.
-      expect((params as unknown[])[6]).toBe("draft");
-      // url_key_version is the active keyset version (1 for dev/no-key deployments).
-      expect((params as unknown[])[7]).toBe(1);
+      // Installer params: [rowId, workspaceId, catalogId, installId, config, status]
+      expect((insertCall![1] as unknown[])[5]).toBe("draft");
     });
 
-    it("developer mode also inserts status='draft' (#2177 — header is irrelevant)", async () => {
-      mocks.mockInternalQuery.mockResolvedValue([]);
+    it("developer mode also inserts status='draft' (header is irrelevant for POST)", async () => {
+      mocks.mockInternalQuery.mockImplementation((sql: string) => {
+        if (sqlIs.planCount(sql)) return Promise.resolve([{ count: 0 }]);
+        if (sqlIs.archiveCheck(sql)) return Promise.resolve([]);
+        if (sqlIs.catalogLookup(sql)) return Promise.resolve([POSTGRES_CATALOG_ROW]);
+        if (sqlIs.installerSingleton(sql)) return Promise.resolve([]);
+        return Promise.resolve([]);
+      });
       const res = await app.fetch(
         adminRequest(
           "/api/v1/admin/connections",
@@ -998,24 +1022,31 @@ describe.skip("admin connections — org scoping", () => {
       );
       expect(res.status).toBe(201);
       const insertCall = mocks.mockInternalQuery.mock.calls.find(
-        ([sql]) => typeof sql === "string" && sql.includes("INSERT INTO connections"),
+        ([sql]) => typeof sql === "string" && sqlIs.installerInsert(sql),
       );
       expect(insertCall).toBeDefined();
-      const [sql, params] = insertCall!;
-      expect(sql).toContain("status");
-      expect((params as unknown[])[6]).toBe("draft");
+      expect((insertCall![1] as unknown[])[5]).toBe("draft");
     });
 
-    it("revives an archived row (UPDATE, not INSERT) when PK collides", async () => {
-      // After a DELETE archives a connection, the (id, org_id) PK row remains
-      // while the in-memory registry is unregistered. Recreating with the
-      // same id must revive via UPDATE rather than 500 on PK conflict.
-      // Using id="analytics" which isn't in the default mock registry, so
-      // `connections.has("analytics")` returns false as it would in prod
-      // after unregister.
+    it("revives an archived row via updateDatasourceConfig (not installDatasource) when PK collides", async () => {
+      // After a DELETE archives an install, the (workspace_id, catalog_id,
+      // install_id) row remains with `status='archived'`. Recreating with
+      // the same install_id must revive via UPDATE rather than 409 — the
+      // archive-aware existing check at the route layer routes the call
+      // through `updateDatasourceConfig` with `status: 'draft'`.
       mocks.mockInternalQuery.mockImplementation((sql: string) => {
-        if (sql.includes("SELECT status FROM connections")) {
-          return Promise.resolve([{ status: "archived" }]);
+        if (sqlIs.planCount(sql)) return Promise.resolve([{ count: 0 }]);
+        if (sqlIs.archiveCheck(sql)) return Promise.resolve([{ status: "archived" }]);
+        if (sqlIs.catalogLookup(sql)) return Promise.resolve([POSTGRES_CATALOG_ROW]);
+        if (sqlIs.installerLoadForUpdate(sql)) {
+          return Promise.resolve([
+            {
+              id: "cn_org-alpha_analytics",
+              install_id: "analytics",
+              config: { url: "encrypted:postgresql://old" },
+              status: "archived",
+            },
+          ]);
         }
         return Promise.resolve([]);
       });
@@ -1026,40 +1057,48 @@ describe.skip("admin connections — org scoping", () => {
         }),
       );
       expect(res.status).toBe(201);
+
+      // The revival path must use UPDATE (not INSERT) — the PK row exists.
       const updateCall = mocks.mockInternalQuery.mock.calls.find(
-        ([sql]) =>
-          typeof sql === "string" &&
-          sql.includes("UPDATE connections") &&
-          sql.includes("status"),
+        ([sql]) => typeof sql === "string" && sqlIs.installerUpdate(sql),
       );
       expect(updateCall).toBeDefined();
-      // Revival UPDATE must be scoped to the composite PK — id AND org_id
-      expect(updateCall![0] as string).toContain("WHERE id =");
-      expect(updateCall![0] as string).toContain("org_id");
+      // Update params: [config, status, workspaceId, catalogId, installId]
       const updateParams = updateCall![1] as unknown[];
-      // Post-#2177 status revives to 'draft' regardless of `atlas-mode` header.
-      expect(updateParams).toContain("draft");
-      expect(updateParams).toContain("analytics");
-      expect(updateParams).toContain("org-alpha");
+      expect(updateParams[1]).toBe("draft");  // revives to draft per #2177
+      expect(updateParams[2]).toBe("org-alpha");
+      expect(updateParams[4]).toBe("analytics");
+
       const staleInsert = mocks.mockInternalQuery.mock.calls.find(
-        ([sql]) =>
-          typeof sql === "string" && sql.includes("INSERT INTO connections"),
+        ([sql]) => typeof sql === "string" && sqlIs.installerInsert(sql),
       );
       expect(staleInsert).toBeUndefined();
     });
 
     it("non-demo PUT in developer mode is immediate direct UPDATE (not staged)", async () => {
-      // AC: connection edits are immediate per PRD — even in developer mode
+      // AC: connection edits are immediate per PRD — even in developer mode.
       setOrgAdmin("org-alpha");
       mocks.mockInternalQuery.mockImplementation((sql: string) => {
-        if (sql.includes("SELECT") && sql.includes("connections")) {
-          return Promise.resolve([{
-            id: "warehouse",
-            url: "encrypted:postgresql://user:pass@host/db",
-            type: "postgres",
-            description: "Warehouse",
-            schema_name: null,
-          }]);
+        if (sqlIs.putLoad(sql)) {
+          return Promise.resolve([
+            {
+              catalog_slug: "postgres",
+              config: { url: "encrypted:postgresql://user:pass@host/db" },
+              config_schema: POSTGRES_CATALOG_ROW.config_schema,
+              group_id: null,
+            },
+          ]);
+        }
+        if (sqlIs.catalogLookup(sql)) return Promise.resolve([POSTGRES_CATALOG_ROW]);
+        if (sqlIs.installerLoadForUpdate(sql)) {
+          return Promise.resolve([
+            {
+              id: "cn_org-alpha_warehouse",
+              install_id: "warehouse",
+              config: { url: "encrypted:postgresql://user:pass@host/db" },
+              status: "published",
+            },
+          ]);
         }
         return Promise.resolve([]);
       });
@@ -1072,25 +1111,22 @@ describe.skip("admin connections — org scoping", () => {
         ),
       );
       expect(res.status).toBe(200);
-      // Verify we ran UPDATE — not an INSERT (draft-copy semantics would be wrong for connections)
+      // Verify we ran UPDATE — not an INSERT (draft-copy semantics would
+      // be wrong for connections; the connection IS the working copy).
       const updateCall = mocks.mockInternalQuery.mock.calls.find(
-        ([sql]) =>
-          typeof sql === "string" &&
-          sql.includes("UPDATE connections SET url"),
+        ([sql]) => typeof sql === "string" && sqlIs.installerUpdate(sql),
       );
       expect(updateCall).toBeDefined();
       const staleInsert = mocks.mockInternalQuery.mock.calls.find(
-        ([sql]) =>
-          typeof sql === "string" && sql.includes("INSERT INTO connections"),
+        ([sql]) => typeof sql === "string" && sqlIs.installerInsert(sql),
       );
       expect(staleInsert).toBeUndefined();
     });
 
     it("returns 409 when PK collides with a non-archived row", async () => {
       mocks.mockInternalQuery.mockImplementation((sql: string) => {
-        if (sql.includes("SELECT status FROM connections")) {
-          return Promise.resolve([{ status: "published" }]);
-        }
+        if (sqlIs.planCount(sql)) return Promise.resolve([{ count: 0 }]);
+        if (sqlIs.archiveCheck(sql)) return Promise.resolve([{ status: "published" }]);
         return Promise.resolve([]);
       });
       const res = await app.fetch(
@@ -1107,17 +1143,16 @@ describe.skip("admin connections — org scoping", () => {
 
   describe("PUT /connections/__demo__ — no demo-readonly gate post-#2177", () => {
     it("accepts demo edits in published mode (no 403 — drafts handle staging)", async () => {
-      // Pre-#2177 this 403'd in published mode. Post-#2177 every write is a
-      // draft regardless of mode, so the demo carve-out is gone; the
-      // org_id scoping in the row lookup prevents mutating the `__global__`
-      // canonical row, so a workspace admin's edit returns 404 (no per-org
-      // row exists) instead of leaking into shared state.
+      // Pre-#2177 this 403'd in published mode. Post-#2177 every write is
+      // a draft regardless of mode, so the demo carve-out is gone. The
+      // workspace_id filter on the load query then returns no row (this
+      // workspace doesn't own a `__demo__` install in our fixture), so the
+      // response is 404 — the point is: NOT 403.
       setOrgAdmin("org-alpha");
       mocks.mockInternalQuery.mockResolvedValue([]);
       const res = await app.fetch(
         adminRequest("/api/v1/admin/connections/__demo__", "PUT", { description: "tampered" }),
       );
-      // 404 — no per-org `__demo__` exists. The point is: NOT 403.
       expect(res.status).toBe(404);
     });
 
@@ -1136,75 +1171,51 @@ describe.skip("admin connections — org scoping", () => {
     });
   });
 
-  describe("DELETE /connections — mode-aware archive", () => {
-    it("archives (status='archived') instead of hard delete", async () => {
+  describe("DELETE /connections — soft archive via installer", () => {
+    it("soft-archives via the installer (status='archived') instead of hard delete", async () => {
       setOrgAdmin("org-alpha");
       mocks.mockInternalQuery.mockImplementation((sql: string) => {
-        if (sql.includes("SELECT") && sql.includes("connections")) {
-          return Promise.resolve([{ id: "warehouse", org_id: "org-alpha", type: "postgres" }]);
+        if (sqlIs.deleteLoad(sql)) return Promise.resolve([{ catalog_slug: "postgres" }]);
+        if (sqlIs.schedRefs(sql)) return Promise.resolve([{ count: "0" }]);
+        if (sqlIs.catalogLookup(sql)) return Promise.resolve([POSTGRES_CATALOG_ROW]);
+        if (sqlIs.installerSoftArchive(sql)) {
+          return Promise.resolve([{ id: "cn_org-alpha_warehouse" }]);
         }
-        return Promise.resolve([{ count: "0" }]);
+        return Promise.resolve([]);
       });
       const res = await app.fetch(
         adminRequest("/api/v1/admin/connections/warehouse", "DELETE"),
       );
       expect(res.status).toBe(200);
       const archiveCall = mocks.mockInternalQuery.mock.calls.find(
-        ([sql]) =>
-          typeof sql === "string" &&
-          sql.includes("UPDATE connections") &&
-          sql.includes("status") &&
-          sql.includes("archived"),
+        ([sql]) => typeof sql === "string" && sqlIs.installerSoftArchive(sql),
       );
       expect(archiveCall).toBeDefined();
       const hardDelete = mocks.mockInternalQuery.mock.calls.find(
         ([sql]) =>
           typeof sql === "string" &&
-          sql.includes("DELETE FROM connections WHERE id"),
+          sql.includes("DELETE FROM workspace_plugins") &&
+          sql.includes("install_id"),
       );
       expect(hardDelete).toBeUndefined();
     });
 
-    it("DELETE on __demo__ in any mode hides it from the workspace via per-org tombstone", async () => {
-      // Replaces the previous "rejects in published mode" + "allows in
-      // developer" pair. After the global-demo + per-org-tombstone
-      // refactor (#2304), delete is non-destructive: it inserts a
-      // per-org archived shadow row that hides the canonical global
-      // `__demo__` from this workspace only. Other tenants keep seeing
-      // it. The published-mode demoReadonly guard remains on the PUT
-      // handler since URL/description edits would mutate shared state.
+    it("DELETE on workspace-owned __demo__ soft-archives in place (per-workspace ownership)", async () => {
+      // Post-cutover each workspace owns its own `__demo__` install
+      // outright (migration 0094 backfilled per-workspace rows; the global
+      // shadow is gone). DELETE on it follows the same soft-archive path
+      // as any other install — no per-org tombstone INSERT exists anymore.
       setOrgAdmin("org-alpha");
       mocks.mockInternalQuery.mockImplementation((sql: string) => {
-        if (sql.includes("SELECT") && sql.includes("connections")) {
-          return Promise.resolve([{ id: "__demo__", org_id: "__global__", type: "postgres" }]);
+        if (sqlIs.deleteLoad(sql)) return Promise.resolve([{ catalog_slug: "demo-postgres" }]);
+        if (sqlIs.schedRefs(sql)) return Promise.resolve([{ count: "0" }]);
+        if (sqlIs.catalogLookup(sql)) {
+          return Promise.resolve([{ ...POSTGRES_CATALOG_ROW, slug: "demo-postgres" }]);
         }
-        return Promise.resolve([{ count: "0" }]);
-      });
-      const res = await app.fetch(
-        adminRequest("/api/v1/admin/connections/__demo__", "DELETE"),
-      );
-      expect(res.status).toBe(200);
-
-      // Per-org tombstone INSERT (not UPDATE on the global row)
-      const insertCall = mocks.mockInternalQuery.mock.calls.find(
-        ([sql]) =>
-          typeof sql === "string" &&
-          sql.includes("INSERT INTO connections") &&
-          sql.includes("'archived'"),
-      );
-      expect(insertCall).toBeDefined();
-    });
-
-    it("DELETE on org-owned __demo__ in developer mode archives in place", async () => {
-      // Backward-compat path: orgs that still have a per-org `__demo__`
-      // row (pre-global-demo onboarding) get the original archive-in-place
-      // behavior, not a tombstone.
-      setOrgAdmin("org-alpha");
-      mocks.mockInternalQuery.mockImplementation((sql: string) => {
-        if (sql.includes("SELECT") && sql.includes("connections")) {
-          return Promise.resolve([{ id: "__demo__", org_id: "org-alpha", type: "postgres" }]);
+        if (sqlIs.installerSoftArchive(sql)) {
+          return Promise.resolve([{ id: "cn_org-alpha___demo__" }]);
         }
-        return Promise.resolve([{ count: "0" }]);
+        return Promise.resolve([]);
       });
       const res = await app.fetch(
         adminRequest(
@@ -1216,27 +1227,20 @@ describe.skip("admin connections — org scoping", () => {
       );
       expect(res.status).toBe(200);
       const archiveCall = mocks.mockInternalQuery.mock.calls.find(
-        ([sql]) =>
-          typeof sql === "string" &&
-          sql.includes("UPDATE connections") &&
-          sql.includes("archived"),
+        ([sql]) => typeof sql === "string" && sqlIs.installerSoftArchive(sql),
       );
       expect(archiveCall).toBeDefined();
     });
   });
 
-  // ─── F-44 regression — response bodies scrub DSN userinfo ──────────────
+  // ─── F-44 regression — response bodies scrub DSN userinfo ────────────
   //
   // The test-connection + create-connection + update-connection endpoints
-  // used to interpolate raw `err.message` into the 400/500 response body on
-  // driver failure. pg / mysql2 sometimes echo the full DSN into `err.message`
-  // (`connect ECONNREFUSED for postgres://user:pass@host:5432/db`), which
-  // leaked the password to whatever consumed the response — admin UI,
-  // browser history, bug-report screenshots, upstream proxies. The log line
-  // was scrubbed by the pino serializer, but the HTTP body wasn't.
-  //
-  // These tests assert the password `hunter2` never escapes the response body
-  // on the four response-body interpolation paths fixed in this PR.
+  // used to interpolate raw `err.message` into the 400/500 response body
+  // on driver failure. pg / mysql2 sometimes echo the full DSN into
+  // `err.message` (`connect ECONNREFUSED for postgres://user:pass@host`),
+  // leaking the password to whatever consumed the response. Log lines are
+  // scrubbed by the pino serializer; the HTTP body needs the same.
 
   describe("F-44 — connection test response-body DSN scrub", () => {
     const DSN = "postgresql://admin:hunter2@db.example.com:5432/analytics";
@@ -1275,7 +1279,7 @@ describe.skip("admin connections — org scoping", () => {
       expect(raw).not.toContain("hunter2");
     });
 
-    it("POST /test scrubs DSN userinfo when URL-scheme detection throws", async () => {
+    it("POST /test 4xx/5xx never echoes DSN userinfo", async () => {
       const res = await app.fetch(
         adminRequest(
           "/api/v1/admin/connections/test",
@@ -1284,9 +1288,6 @@ describe.skip("admin connections — org scoping", () => {
         ),
       );
 
-      // register/healthCheck both succeed for the valid postgres scheme,
-      // so this particular URL wouldn't trigger the detectDBType path —
-      // but we assert on any 4xx/5xx that would interpolate err.message.
       const raw = await res.text();
       if (res.status >= 400) {
         expect(raw).not.toContain("hunter2");
@@ -1294,22 +1295,31 @@ describe.skip("admin connections — org scoping", () => {
     });
   });
 
-  // ─── #2484 — Add Connection Env Field ─────────────────────────────
+  // ─── #2484 — Add Connection Env Field (post-cutover JSONB group_id) ──
   //
-  // POST + PUT accept `connectionGroupId` (attach existing env) and
-  // `newGroupName` (inline-create with the new connection promoted as
-  // primary). Cross-org `connectionGroupId` rejects with 404 (B2B
-  // isolation — foreign-org ids look indistinguishable from missing).
-  // `newGroupName` conflict on `uq_connection_groups_org_name` rolls the
-  // whole INSERT/UPDATE back via the single CTE.
+  // Post-#2744 a connection's env is a JSONB string under
+  // `config->>'group_id'`. The `connection_groups` table is gone, so a
+  // "name" and an "id" are the same string. The route's POST/PUT carry
+  // the same `connectionGroupId` / `newGroupName` API on the wire, but
+  // the writes flow through `WorkspaceInstaller.installDatasource` /
+  // `updateDatasourceConfig` which write the JSONB key. Cross-workspace
+  // `connectionGroupId` still rejects with 404 — same B2B isolation
+  // guarantee.
 
-  describe("POST /connections — env field (#2484)", () => {
-    it("attach to existing env: INSERT uses provided connectionGroupId, no auto-singleton CTE", async () => {
+  describe("POST /connections — env field (#2484, post-cutover)", () => {
+    beforeEach(() => {
+      setOrgAdmin("org-alpha");
+    });
+
+    it("attach to existing env: installer receives groupId on installDatasource", async () => {
+      // Cross-org check returns a row → the workspace already has at least
+      // one install in the "prod" env, so the attach is legal.
       mocks.mockInternalQuery.mockImplementation((sql: string) => {
-        // Pre-validation: env exists and is active in this org.
-        if (sql.includes("SELECT id, status FROM connection_groups")) {
-          return Promise.resolve([{ id: "g_prod", status: "active" }]);
-        }
+        if (sqlIs.planCount(sql)) return Promise.resolve([{ count: 0 }]);
+        if (sqlIs.groupExists(sql)) return Promise.resolve([{ install_id: "warehouse" }]);
+        if (sqlIs.archiveCheck(sql)) return Promise.resolve([]);
+        if (sqlIs.catalogLookup(sql)) return Promise.resolve([POSTGRES_CATALOG_ROW]);
+        if (sqlIs.installerSingleton(sql)) return Promise.resolve([]);
         return Promise.resolve([]);
       });
 
@@ -1317,26 +1327,37 @@ describe.skip("admin connections — org scoping", () => {
         adminRequest("/api/v1/admin/connections", "POST", {
           id: "analytics",
           url: "postgresql://user:pass@host/db",
-          connectionGroupId: "g_prod",
+          connectionGroupId: "prod",
         }),
       );
 
       expect(res.status).toBe(201);
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test convenience
       const body = (await res.json()) as any;
-      expect(body.groupId).toBe("g_prod");
+      expect(body.groupId).toBe("prod");
 
+      // The installer's INSERT must carry the config JSONB with group_id.
       const insertCall = mocks.mockInternalQuery.mock.calls.find(
-        ([sql]) => typeof sql === "string" && sql.includes("INSERT INTO connections"),
+        ([sql]) => typeof sql === "string" && sqlIs.installerInsert(sql),
       );
       expect(insertCall).toBeDefined();
-      const [sql, params] = insertCall!;
-      // Attach branch — straight INSERT, no group_row CTE.
-      expect(sql).not.toContain("INSERT INTO connection_groups");
-      expect(params).toContain("g_prod");
+      const configJson = (insertCall![1] as unknown[])[4] as string;
+      expect(JSON.parse(configJson)).toMatchObject({ group_id: "prod" });
     });
 
-    it("inline-create env: CTE inserts connection_groups with primary_connection_id = new connection id", async () => {
+    it("inline-create env: newGroupName becomes the config.group_id verbatim", async () => {
+      // The legacy CTE that inserted a `connection_groups` row + set
+      // `primary_connection_id` is gone — `newGroupName` is just a string
+      // written into the JSONB `config->>'group_id'`. The locked decision
+      // (#2744) is that group "names" and "ids" are the same thing now.
+      mocks.mockInternalQuery.mockImplementation((sql: string) => {
+        if (sqlIs.planCount(sql)) return Promise.resolve([{ count: 0 }]);
+        if (sqlIs.archiveCheck(sql)) return Promise.resolve([]);
+        if (sqlIs.catalogLookup(sql)) return Promise.resolve([POSTGRES_CATALOG_ROW]);
+        if (sqlIs.installerSingleton(sql)) return Promise.resolve([]);
+        return Promise.resolve([]);
+      });
+
       const res = await app.fetch(
         adminRequest("/api/v1/admin/connections", "POST", {
           id: "analytics",
@@ -1348,23 +1369,28 @@ describe.skip("admin connections — org scoping", () => {
       expect(res.status).toBe(201);
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test convenience
       const body = (await res.json()) as any;
-      expect(body.groupId).toMatch(/^g_/);
+      expect(body.groupId).toBe("Production");
 
       const insertCall = mocks.mockInternalQuery.mock.calls.find(
-        ([sql]) =>
-          typeof sql === "string" &&
-          sql.includes("INSERT INTO connections") &&
-          sql.includes("INSERT INTO connection_groups"),
+        ([sql]) => typeof sql === "string" && sqlIs.installerInsert(sql),
       );
       expect(insertCall).toBeDefined();
-      const [sql, params] = insertCall!;
-      expect(sql).toContain("primary_connection_id");
-      // Group name + connection id both flow into the CTE params.
-      expect(params).toContain("Production");
-      expect(params).toContain("analytics");
+      const configJson = (insertCall![1] as unknown[])[4] as string;
+      expect(JSON.parse(configJson)).toMatchObject({ group_id: "Production" });
     });
 
-    it("ungrouped (no env field): keeps the existing auto-`g_<id>` self-group CTE", async () => {
+    it("ungrouped (no env field): config carries no group_id key", async () => {
+      // Post-cutover the auto-`g_<id>` self-singleton group is gone. An
+      // ungrouped install means `config.group_id` is absent (encryption
+      // walker skips a missing key cleanly).
+      mocks.mockInternalQuery.mockImplementation((sql: string) => {
+        if (sqlIs.planCount(sql)) return Promise.resolve([{ count: 0 }]);
+        if (sqlIs.archiveCheck(sql)) return Promise.resolve([]);
+        if (sqlIs.catalogLookup(sql)) return Promise.resolve([POSTGRES_CATALOG_ROW]);
+        if (sqlIs.installerSingleton(sql)) return Promise.resolve([]);
+        return Promise.resolve([]);
+      });
+
       const res = await app.fetch(
         adminRequest("/api/v1/admin/connections", "POST", {
           id: "analytics",
@@ -1375,29 +1401,33 @@ describe.skip("admin connections — org scoping", () => {
       expect(res.status).toBe(201);
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test convenience
       const body = (await res.json()) as any;
-      expect(body.groupId).toBe("g_analytics");
+      expect(body.groupId).toBeNull();
 
       const insertCall = mocks.mockInternalQuery.mock.calls.find(
-        ([sql]) =>
-          typeof sql === "string" &&
-          sql.includes("INSERT INTO connections") &&
-          sql.includes("'g_' || $1"),
+        ([sql]) => typeof sql === "string" && sqlIs.installerInsert(sql),
       );
       expect(insertCall).toBeDefined();
+      const configJson = (insertCall![1] as unknown[])[4] as string;
+      const parsed = JSON.parse(configJson) as Record<string, unknown>;
+      expect(parsed.group_id).toBeUndefined();
     });
 
-    it("cross-org connectionGroupId: SELECT returns no rows → 404 (B2B isolation, #2424 pattern)", async () => {
-      // Mock returns `[]` for the env pre-validate SELECT — mirrors the
-      // result of querying with the workspace's org_id when the env
-      // actually lives in a different org. Foreign-org ids look identical
-      // to ids that don't exist anywhere; both → 404.
-      mocks.mockInternalQuery.mockResolvedValue([]);
+    it("cross-workspace connectionGroupId: groupExists returns no rows → 404", async () => {
+      // Foreign-workspace group_id values look identical to ids that don't
+      // exist anywhere; the route's group-existence check (scoped to the
+      // caller's workspace_id) returns empty → 404 either way. B2B
+      // isolation guarantee — no information disclosure across workspaces.
+      mocks.mockInternalQuery.mockImplementation((sql: string) => {
+        if (sqlIs.planCount(sql)) return Promise.resolve([{ count: 0 }]);
+        if (sqlIs.groupExists(sql)) return Promise.resolve([]);
+        return Promise.resolve([]);
+      });
 
       const res = await app.fetch(
         adminRequest("/api/v1/admin/connections", "POST", {
           id: "analytics",
           url: "postgresql://user:pass@host/db",
-          connectionGroupId: "g_foreign",
+          connectionGroupId: "foreign",
         }),
       );
 
@@ -1406,55 +1436,19 @@ describe.skip("admin connections — org scoping", () => {
       const body = (await res.json()) as any;
       expect(body.error).toBe("not_found");
 
-      // No INSERT should have fired — pre-validation rejected before persistence.
+      // No installer INSERT should have fired — pre-validation rejected.
       const insertCall = mocks.mockInternalQuery.mock.calls.find(
-        ([sql]) => typeof sql === "string" && sql.includes("INSERT INTO connections"),
+        ([sql]) => typeof sql === "string" && sqlIs.installerInsert(sql),
       );
       expect(insertCall).toBeUndefined();
     });
 
-    it("inline-create env name conflict: 23505 on uq_connection_groups_org_name → 409, connection NOT persisted", async () => {
-      // Throw a faux pg unique-violation from the single CTE INSERT.
-      // The CTE atomicity is what guarantees rollback — both the group
-      // insert and the connection insert fail together. We can't observe
-      // the rollback directly from a mock, but the 409 + the absence of
-      // a partial UPDATE call in the registry is the contract.
-      const conflictErr = Object.assign(new Error("duplicate key value violates unique constraint"), {
-        code: "23505",
-        constraint: "uq_connection_groups_org_name",
-      });
-      mocks.mockInternalQuery.mockImplementation((sql: string) => {
-        if (
-          typeof sql === "string" &&
-          sql.includes("INSERT INTO connections") &&
-          sql.includes("INSERT INTO connection_groups")
-        ) {
-          return Promise.reject(conflictErr);
-        }
-        return Promise.resolve([]);
-      });
-
+    it("both env fields together: 400 invalid_request (mutually exclusive)", async () => {
       const res = await app.fetch(
         adminRequest("/api/v1/admin/connections", "POST", {
           id: "analytics",
           url: "postgresql://user:pass@host/db",
-          newGroupName: "Production",
-        }),
-      );
-
-      expect(res.status).toBe(409);
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test convenience
-      const body = (await res.json()) as any;
-      expect(body.error).toBe("conflict");
-      expect(body.message).toContain("Production");
-    });
-
-    it("both fields together: 400 invalid_request (mutually exclusive)", async () => {
-      const res = await app.fetch(
-        adminRequest("/api/v1/admin/connections", "POST", {
-          id: "analytics",
-          url: "postgresql://user:pass@host/db",
-          connectionGroupId: "g_prod",
+          connectionGroupId: "prod",
           newGroupName: "Production",
         }),
       );
@@ -1477,39 +1471,23 @@ describe.skip("admin connections — org scoping", () => {
       expect(res.status).toBe(400);
     });
 
-    it("attach to an archived env: 409 with restore guidance, no INSERT fires", async () => {
+    it("revive archived row with newGroupName: updateDatasourceConfig carries group_id and status=draft", async () => {
+      // The PK row exists (status='archived'); the route routes to
+      // updateDatasourceConfig with status: 'draft', and the merged
+      // config carries the new group_id key.
       mocks.mockInternalQuery.mockImplementation((sql: string) => {
-        if (sql.includes("SELECT id, status FROM connection_groups")) {
-          return Promise.resolve([{ id: "g_stale", status: "archived" }]);
-        }
-        return Promise.resolve([]);
-      });
-
-      const res = await app.fetch(
-        adminRequest("/api/v1/admin/connections", "POST", {
-          id: "analytics",
-          url: "postgresql://user:pass@host/db",
-          connectionGroupId: "g_stale",
-        }),
-      );
-
-      expect(res.status).toBe(409);
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test convenience
-      const body = (await res.json()) as any;
-      expect(body.error).toBe("conflict");
-      expect(body.message).toContain("archived");
-
-      const insertCall = mocks.mockInternalQuery.mock.calls.find(
-        ([sql]) => typeof sql === "string" && sql.includes("INSERT INTO connections"),
-      );
-      expect(insertCall).toBeUndefined();
-    });
-
-    it("revive archived row with newGroupName: UPDATE-with-CTE branch with primary_connection_id set", async () => {
-      mocks.mockInternalQuery.mockImplementation((sql: string) => {
-        // PK-collision SELECT — archived row already owns the id.
-        if (sql.includes("SELECT status FROM connections")) {
-          return Promise.resolve([{ status: "archived" }]);
+        if (sqlIs.planCount(sql)) return Promise.resolve([{ count: 0 }]);
+        if (sqlIs.archiveCheck(sql)) return Promise.resolve([{ status: "archived" }]);
+        if (sqlIs.catalogLookup(sql)) return Promise.resolve([POSTGRES_CATALOG_ROW]);
+        if (sqlIs.installerLoadForUpdate(sql)) {
+          return Promise.resolve([
+            {
+              id: "cn_org-alpha_analytics",
+              install_id: "analytics",
+              config: { url: "encrypted:postgresql://old" },
+              status: "archived",
+            },
+          ]);
         }
         return Promise.resolve([]);
       });
@@ -1524,132 +1502,182 @@ describe.skip("admin connections — org scoping", () => {
 
       expect(res.status).toBe(201);
       const updateCall = mocks.mockInternalQuery.mock.calls.find(
-        ([sql]) =>
-          typeof sql === "string" &&
-          sql.startsWith("WITH group_row AS") &&
-          sql.includes("INSERT INTO connection_groups") &&
-          sql.includes("primary_connection_id") &&
-          sql.includes("UPDATE connections"),
+        ([sql]) => typeof sql === "string" && sqlIs.installerUpdate(sql),
       );
       expect(updateCall).toBeDefined();
-      expect(updateCall![1]).toContain("Production");
-      expect(updateCall![1]).toContain("analytics");
+      const updateParams = updateCall![1] as unknown[];
+      expect(updateParams[1]).toBe("draft");
+      const mergedConfig = JSON.parse(updateParams[0] as string) as Record<string, unknown>;
+      expect(mergedConfig.group_id).toBe("Production");
     });
 
-    it("revive archived row with connectionGroupId: UPDATE includes group_id, no group CTE", async () => {
+    it("revive archived row with connectionGroupId: updateDatasourceConfig carries the attached group_id", async () => {
       mocks.mockInternalQuery.mockImplementation((sql: string) => {
-        if (sql.includes("SELECT status FROM connections")) {
-          return Promise.resolve([{ status: "archived" }]);
-        }
-        if (sql.includes("SELECT id, status FROM connection_groups")) {
-          return Promise.resolve([{ id: "g_prod", status: "active" }]);
-        }
-        return Promise.resolve([]);
-      });
-
-      const res = await app.fetch(
-        adminRequest("/api/v1/admin/connections", "POST", {
-          id: "analytics",
-          url: "postgresql://user:pass@host/db",
-          connectionGroupId: "g_prod",
-        }),
-      );
-
-      expect(res.status).toBe(201);
-      const updateCall = mocks.mockInternalQuery.mock.calls.find(
-        ([sql]) =>
-          typeof sql === "string" &&
-          sql.startsWith("UPDATE connections") &&
-          sql.includes("group_id"),
-      );
-      expect(updateCall).toBeDefined();
-      expect(updateCall![1]).toContain("g_prod");
-    });
-
-    it("revive archived row with no env field: UPDATE preserves existing group_id (no group_id clause)", async () => {
-      mocks.mockInternalQuery.mockImplementation((sql: string) => {
-        if (sql.includes("SELECT status FROM connections")) {
-          return Promise.resolve([{ status: "archived" }]);
-        }
-        return Promise.resolve([]);
-      });
-
-      const res = await app.fetch(
-        adminRequest("/api/v1/admin/connections", "POST", {
-          id: "analytics",
-          url: "postgresql://user:pass@host/db",
-        }),
-      );
-
-      expect(res.status).toBe(201);
-      const updateCall = mocks.mockInternalQuery.mock.calls.find(
-        ([sql]) =>
-          typeof sql === "string" &&
-          sql.startsWith("UPDATE connections"),
-      );
-      expect(updateCall).toBeDefined();
-      // No `group_id =` in the SET list — preserves whatever the archived
-      // row already pointed at.
-      expect(updateCall![0]).not.toContain("group_id =");
-    });
-  });
-
-  describe("PUT /connections/:id — env field (#2484)", () => {
-    it("reattach to existing env: UPDATE includes group_id, response carries new groupId", async () => {
-      mocks.mockInternalQuery.mockImplementation((sql: string) => {
-        // Existing-row pre-load — caller's connection lives in this org.
-        if (sql.includes("SELECT id, url, type, description, schema_name, group_id FROM connections")) {
+        if (sqlIs.planCount(sql)) return Promise.resolve([{ count: 0 }]);
+        if (sqlIs.groupExists(sql)) return Promise.resolve([{ install_id: "warehouse" }]);
+        if (sqlIs.archiveCheck(sql)) return Promise.resolve([{ status: "archived" }]);
+        if (sqlIs.catalogLookup(sql)) return Promise.resolve([POSTGRES_CATALOG_ROW]);
+        if (sqlIs.installerLoadForUpdate(sql)) {
           return Promise.resolve([
             {
-              id: "warehouse",
-              url: "encrypted:postgresql://old",
-              type: "postgres",
-              description: null,
-              schema_name: null,
-              group_id: "g_warehouse",
+              id: "cn_org-alpha_analytics",
+              install_id: "analytics",
+              config: { url: "encrypted:postgresql://old" },
+              status: "archived",
             },
           ]);
         }
-        // Env pre-validate: target group exists and is active.
-        if (sql.includes("SELECT id, status FROM connection_groups")) {
-          return Promise.resolve([{ id: "g_prod", status: "active" }]);
+        return Promise.resolve([]);
+      });
+
+      const res = await app.fetch(
+        adminRequest("/api/v1/admin/connections", "POST", {
+          id: "analytics",
+          url: "postgresql://user:pass@host/db",
+          connectionGroupId: "prod",
+        }),
+      );
+
+      expect(res.status).toBe(201);
+      const updateCall = mocks.mockInternalQuery.mock.calls.find(
+        ([sql]) => typeof sql === "string" && sqlIs.installerUpdate(sql),
+      );
+      expect(updateCall).toBeDefined();
+      const mergedConfig = JSON.parse((updateCall![1] as unknown[])[0] as string) as Record<string, unknown>;
+      expect(mergedConfig.group_id).toBe("prod");
+    });
+
+    it("revive archived row with no env field: updateDatasourceConfig clears the existing group_id", async () => {
+      // The route's POST `resolvedGroupId` defaults to `null` when no env
+      // field is supplied; the installer's `patch.groupId === null` branch
+      // then deletes the existing group_id key. So POST-revive without an
+      // env field is an explicit "clear my env" intent at the wire level —
+      // distinct from PUT, which uses `undefined` (no change) when no
+      // env field is supplied. Documented here so an inverted-default
+      // regression (e.g. switching POST to `undefined`) fails fast.
+      mocks.mockInternalQuery.mockImplementation((sql: string) => {
+        if (sqlIs.planCount(sql)) return Promise.resolve([{ count: 0 }]);
+        if (sqlIs.archiveCheck(sql)) return Promise.resolve([{ status: "archived" }]);
+        if (sqlIs.catalogLookup(sql)) return Promise.resolve([POSTGRES_CATALOG_ROW]);
+        if (sqlIs.installerLoadForUpdate(sql)) {
+          return Promise.resolve([
+            {
+              id: "cn_org-alpha_analytics",
+              install_id: "analytics",
+              config: {
+                url: "encrypted:postgresql://old",
+                group_id: "stale-env",
+              },
+              status: "archived",
+            },
+          ]);
+        }
+        return Promise.resolve([]);
+      });
+
+      const res = await app.fetch(
+        adminRequest("/api/v1/admin/connections", "POST", {
+          id: "analytics",
+          url: "postgresql://user:pass@host/db",
+        }),
+      );
+
+      expect(res.status).toBe(201);
+      const updateCall = mocks.mockInternalQuery.mock.calls.find(
+        ([sql]) => typeof sql === "string" && sqlIs.installerUpdate(sql),
+      );
+      expect(updateCall).toBeDefined();
+      const mergedConfig = JSON.parse((updateCall![1] as unknown[])[0] as string) as Record<string, unknown>;
+      expect(mergedConfig.group_id).toBeUndefined();
+    });
+  });
+
+  describe("PUT /connections/:id — env field (#2484, post-cutover)", () => {
+    beforeEach(() => {
+      setOrgAdmin("org-alpha");
+    });
+
+    it("reattach to existing env: installer merges group_id into config; response carries new groupId", async () => {
+      mocks.mockInternalQuery.mockImplementation((sql: string) => {
+        if (sqlIs.putLoad(sql)) {
+          return Promise.resolve([
+            {
+              catalog_slug: "postgres",
+              config: {
+                url: "encrypted:postgresql://old",
+                group_id: "warehouse-env",
+              },
+              config_schema: POSTGRES_CATALOG_ROW.config_schema,
+              group_id: "warehouse-env",
+            },
+          ]);
+        }
+        if (sqlIs.groupExists(sql)) return Promise.resolve([{ install_id: "warehouse" }]);
+        if (sqlIs.catalogLookup(sql)) return Promise.resolve([POSTGRES_CATALOG_ROW]);
+        if (sqlIs.installerLoadForUpdate(sql)) {
+          return Promise.resolve([
+            {
+              id: "cn_org-alpha_warehouse",
+              install_id: "warehouse",
+              config: {
+                url: "encrypted:postgresql://old",
+                group_id: "warehouse-env",
+              },
+              status: "published",
+            },
+          ]);
         }
         return Promise.resolve([]);
       });
 
       const res = await app.fetch(
         adminRequest("/api/v1/admin/connections/warehouse", "PUT", {
-          connectionGroupId: "g_prod",
+          connectionGroupId: "prod",
         }),
       );
 
       expect(res.status).toBe(200);
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test convenience
       const body = (await res.json()) as any;
-      expect(body.groupId).toBe("g_prod");
+      expect(body.groupId).toBe("prod");
 
-      // Find the UPDATE that carries the new group_id.
       const updateCall = mocks.mockInternalQuery.mock.calls.find(
-        ([sql]) =>
-          typeof sql === "string" &&
-          sql.startsWith("UPDATE connections") &&
-          sql.includes("group_id"),
+        ([sql]) => typeof sql === "string" && sqlIs.installerUpdate(sql),
       );
       expect(updateCall).toBeDefined();
-      expect(updateCall![1]).toContain("g_prod");
+      const mergedConfig = JSON.parse((updateCall![1] as unknown[])[0] as string) as Record<string, unknown>;
+      expect(mergedConfig.group_id).toBe("prod");
     });
 
-    it("explicit ungroup (connectionGroupId: null): UPDATE back to `g_<id>` via ON CONFLICT CTE", async () => {
+    it("explicit ungroup (connectionGroupId: null): removes group_id from config", async () => {
+      // Post-cutover ungroup means deleting the JSONB key — no auto self-
+      // group reinstated, no CTE. The installer's `patch.groupId === null`
+      // branch handles the `delete merged.group_id` cleanup.
       mocks.mockInternalQuery.mockImplementation((sql: string) => {
-        if (sql.includes("SELECT id, url, type, description, schema_name, group_id FROM connections")) {
+        if (sqlIs.putLoad(sql)) {
           return Promise.resolve([
             {
-              id: "warehouse",
-              url: "encrypted:postgresql://old",
-              type: "postgres",
-              description: null,
-              schema_name: null,
-              group_id: "g_prod",
+              catalog_slug: "postgres",
+              config: {
+                url: "encrypted:postgresql://old",
+                group_id: "prod",
+              },
+              config_schema: POSTGRES_CATALOG_ROW.config_schema,
+              group_id: "prod",
+            },
+          ]);
+        }
+        if (sqlIs.catalogLookup(sql)) return Promise.resolve([POSTGRES_CATALOG_ROW]);
+        if (sqlIs.installerLoadForUpdate(sql)) {
+          return Promise.resolve([
+            {
+              id: "cn_org-alpha_warehouse",
+              install_id: "warehouse",
+              config: {
+                url: "encrypted:postgresql://old",
+                group_id: "prod",
+              },
+              status: "published",
             },
           ]);
         }
@@ -1665,29 +1693,36 @@ describe.skip("admin connections — org scoping", () => {
       expect(res.status).toBe(200);
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test convenience
       const body = (await res.json()) as any;
-      expect(body.groupId).toBe("g_warehouse");
+      expect(body.groupId).toBeNull();
 
       const updateCall = mocks.mockInternalQuery.mock.calls.find(
-        ([sql]) =>
-          typeof sql === "string" &&
-          sql.includes("UPDATE connections") &&
-          sql.includes("INSERT INTO connection_groups") &&
-          sql.includes("ON CONFLICT"),
+        ([sql]) => typeof sql === "string" && sqlIs.installerUpdate(sql),
       );
       expect(updateCall).toBeDefined();
+      const mergedConfig = JSON.parse((updateCall![1] as unknown[])[0] as string) as Record<string, unknown>;
+      expect(mergedConfig.group_id).toBeUndefined();
     });
 
-    it("inline-create on edit: CTE creates env with primary_connection_id = this connection id", async () => {
+    it("inline-create on edit: newGroupName becomes the new config.group_id verbatim", async () => {
       mocks.mockInternalQuery.mockImplementation((sql: string) => {
-        if (sql.includes("SELECT id, url, type, description, schema_name, group_id FROM connections")) {
+        if (sqlIs.putLoad(sql)) {
           return Promise.resolve([
             {
-              id: "warehouse",
-              url: "encrypted:postgresql://old",
-              type: "postgres",
-              description: null,
-              schema_name: null,
-              group_id: "g_warehouse",
+              catalog_slug: "postgres",
+              config: { url: "encrypted:postgresql://old" },
+              config_schema: POSTGRES_CATALOG_ROW.config_schema,
+              group_id: null,
+            },
+          ]);
+        }
+        if (sqlIs.catalogLookup(sql)) return Promise.resolve([POSTGRES_CATALOG_ROW]);
+        if (sqlIs.installerLoadForUpdate(sql)) {
+          return Promise.resolve([
+            {
+              id: "cn_org-alpha_warehouse",
+              install_id: "warehouse",
+              config: { url: "encrypted:postgresql://old" },
+              status: "published",
             },
           ]);
         }
@@ -1703,43 +1738,35 @@ describe.skip("admin connections — org scoping", () => {
       expect(res.status).toBe(200);
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test convenience
       const body = (await res.json()) as any;
-      expect(body.groupId).toMatch(/^g_/);
+      expect(body.groupId).toBe("Production");
 
       const updateCall = mocks.mockInternalQuery.mock.calls.find(
-        ([sql]) =>
-          typeof sql === "string" &&
-          sql.includes("INSERT INTO connection_groups") &&
-          sql.includes("primary_connection_id") &&
-          sql.includes("UPDATE connections"),
+        ([sql]) => typeof sql === "string" && sqlIs.installerUpdate(sql),
       );
       expect(updateCall).toBeDefined();
-      expect(updateCall![1]).toContain("Production");
-      // The connection id flows into the CTE so the new group's
-      // primary_connection_id surfaces as user-named on the next list.
-      expect(updateCall![1]).toContain("warehouse");
+      const mergedConfig = JSON.parse((updateCall![1] as unknown[])[0] as string) as Record<string, unknown>;
+      expect(mergedConfig.group_id).toBe("Production");
     });
 
-    it("cross-org connectionGroupId on edit: 404 before any UPDATE fires", async () => {
+    it("cross-workspace connectionGroupId on edit: 404 before any UPDATE fires", async () => {
       mocks.mockInternalQuery.mockImplementation((sql: string) => {
-        if (sql.includes("SELECT id, url, type, description, schema_name, group_id FROM connections")) {
+        if (sqlIs.putLoad(sql)) {
           return Promise.resolve([
             {
-              id: "warehouse",
-              url: "encrypted:postgresql://old",
-              type: "postgres",
-              description: null,
-              schema_name: null,
-              group_id: "g_warehouse",
+              catalog_slug: "postgres",
+              config: { url: "encrypted:postgresql://old" },
+              config_schema: POSTGRES_CATALOG_ROW.config_schema,
+              group_id: null,
             },
           ]);
         }
-        // Env pre-validate misses — foreign-org id.
+        // groupExists → empty (foreign-workspace id)
         return Promise.resolve([]);
       });
 
       const res = await app.fetch(
         adminRequest("/api/v1/admin/connections/warehouse", "PUT", {
-          connectionGroupId: "g_foreign",
+          connectionGroupId: "foreign",
         }),
       );
 
@@ -1749,142 +1776,73 @@ describe.skip("admin connections — org scoping", () => {
       expect(body.error).toBe("not_found");
 
       const updateCall = mocks.mockInternalQuery.mock.calls.find(
-        ([sql]) => typeof sql === "string" && sql.startsWith("UPDATE connections"),
+        ([sql]) => typeof sql === "string" && sqlIs.installerUpdate(sql),
       );
       expect(updateCall).toBeUndefined();
     });
 
-    it("attach to an archived env on edit: 409 with restore guidance, no UPDATE fires", async () => {
-      mocks.mockInternalQuery.mockImplementation((sql: string) => {
-        if (sql.includes("SELECT id, url, type, description, schema_name, group_id FROM connections")) {
-          return Promise.resolve([
-            {
-              id: "warehouse",
-              url: "encrypted:postgresql://old",
-              type: "postgres",
-              description: null,
-              schema_name: null,
-              group_id: "g_warehouse",
-            },
-          ]);
-        }
-        if (sql.includes("SELECT id, status FROM connection_groups")) {
-          return Promise.resolve([{ id: "g_stale", status: "archived" }]);
-        }
-        return Promise.resolve([]);
-      });
-
-      const res = await app.fetch(
-        adminRequest("/api/v1/admin/connections/warehouse", "PUT", {
-          connectionGroupId: "g_stale",
-        }),
-      );
-
-      expect(res.status).toBe(409);
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test convenience
-      const body = (await res.json()) as any;
-      expect(body.error).toBe("conflict");
-      expect(body.message).toContain("archived");
-
-      const updateCall = mocks.mockInternalQuery.mock.calls.find(
-        ([sql]) => typeof sql === "string" && sql.startsWith("UPDATE connections"),
-      );
-      expect(updateCall).toBeUndefined();
-    });
-
-    it("DB UPDATE throws on env reassign: registry rolls back to previous URL", async () => {
-      // Asserts the registry-rollback contract holds when the new env-branch
-      // UPDATE fails after `urlChanged` has already swapped the registry to
-      // the new URL. A regression that moves the env UPDATE outside the
-      // rollback try (or replaces register-with-current with bare
-      // unregister) would silently strand the registry on the new URL
-      // while the DB carries the old one — the agent would query the
-      // wrong DB. Catching that here is more valuable than asserting
-      // the 500 status alone.
+    it("installer tagged error on env reassign: registry rolls back to previous URL", async () => {
+      // Asserts the registry-rollback contract: when the installer returns
+      // a tagged InstallError (e.g. ConfigSchemaError because the merged
+      // config violates the catalog schema), the route's rollback fires
+      // and re-registers the previous URL. A regression that drops the
+      // `register(id, { url: currentUrl, ... })` from the error branch
+      // would silently strand the registry on the new URL while the DB
+      // carries the old one — the agent would query the wrong DB.
+      //
+      // Tagged errors (not raw SQL defects) are the rollback trigger
+      // post-cutover: the installer's UPDATE-throw path goes through
+      // `Effect.die` and surfaces as a 500 defect that bypasses
+      // `result.kind === "error"`. The route's rollback is the
+      // `result.kind === "error"` branch.
       mockRegister.mockClear();
 
+      // Note: stored `url` here is plaintext (no `enc:v1:` prefix) so the
+      // real `decryptSecret` from `db/secret-encryption.ts` returns it
+      // verbatim — the route's `currentUrl` then comes through clean for
+      // the rollback-register assertion below. The factory's `db/internal`
+      // mock overrides `encryptSecret`/`decryptSecret` there, but
+      // `decryptSecretFields` imports from `db/secret-encryption` which is
+      // intentionally left unmocked.
       mocks.mockInternalQuery.mockImplementation((sql: string) => {
-        if (sql.includes("SELECT id, url, type, description, schema_name, group_id FROM connections")) {
+        if (sqlIs.putLoad(sql)) {
           return Promise.resolve([
             {
-              id: "warehouse",
-              url: "encrypted:postgresql://old",
-              type: "postgres",
-              description: "old desc",
-              schema_name: null,
-              group_id: "g_warehouse",
+              catalog_slug: "postgres",
+              config: {
+                url: "postgresql://old",
+                description: "old desc",
+                group_id: "warehouse-env",
+              },
+              config_schema: POSTGRES_CATALOG_ROW.config_schema,
+              group_id: "warehouse-env",
             },
           ]);
         }
-        if (sql.includes("SELECT id, status FROM connection_groups")) {
-          return Promise.resolve([{ id: "g_prod", status: "active" }]);
-        }
-        if (typeof sql === "string" && sql.startsWith("UPDATE connections")) {
-          return Promise.reject(new Error("transient pool failure"));
-        }
+        if (sqlIs.groupExists(sql)) return Promise.resolve([{ install_id: "warehouse" }]);
+        // Catalog lookup misses → installer fails with CatalogNotFoundError
+        // (tagged, 404). The route's error branch then runs the rollback.
+        if (sqlIs.catalogLookup(sql)) return Promise.resolve([]);
         return Promise.resolve([]);
       });
 
       const res = await app.fetch(
         adminRequest("/api/v1/admin/connections/warehouse", "PUT", {
           url: "postgresql://new",
-          connectionGroupId: "g_prod",
+          connectionGroupId: "prod",
         }),
       );
 
-      expect(res.status).toBe(500);
-      // The handler runs `register` twice on a urlChanged + UPDATE-fails
-      // path: once with the new URL (line 1064), once to rollback with
-      // the previous URL (line 1098 or 1158). The second call is the
-      // rollback we want to assert fired.
+      // CatalogNotFoundError → tagged InstallError → 404 → rollback path.
+      expect(res.status).toBe(404);
+      // register call sequence on a urlChanged + tagged-error path:
+      //   1. register(id, { url: newUrl, ... })  — line 1196 in admin-connections.ts
+      //   2. register(id, { url: currentUrl, ... })  — rollback at line 1265
       const registerCalls = mockRegister.mock.calls;
       expect(registerCalls.length).toBeGreaterThanOrEqual(2);
       const rollbackCall = registerCalls[registerCalls.length - 1] as Array<unknown>;
-      // Args are [id, { url, description, schema }]; rollback uses the
-      // pre-edit URL so the registry returns to a coherent state.
       const rollbackOpts = rollbackCall[1] as { url?: string };
       expect(rollbackOpts.url).toBe("postgresql://old");
-    });
-
-    it("inline-create name conflict on edit: 23505 → 409, no UPDATE persisted", async () => {
-      const conflictErr = Object.assign(new Error("duplicate key value violates unique constraint"), {
-        code: "23505",
-        constraint: "uq_connection_groups_org_name",
-      });
-      mocks.mockInternalQuery.mockImplementation((sql: string) => {
-        if (sql.includes("SELECT id, url, type, description, schema_name, group_id FROM connections")) {
-          return Promise.resolve([
-            {
-              id: "warehouse",
-              url: "encrypted:postgresql://old",
-              type: "postgres",
-              description: null,
-              schema_name: null,
-              group_id: "g_warehouse",
-            },
-          ]);
-        }
-        if (
-          typeof sql === "string" &&
-          sql.includes("INSERT INTO connection_groups") &&
-          sql.includes("UPDATE connections")
-        ) {
-          return Promise.reject(conflictErr);
-        }
-        return Promise.resolve([]);
-      });
-
-      const res = await app.fetch(
-        adminRequest("/api/v1/admin/connections/warehouse", "PUT", {
-          newGroupName: "Production",
-        }),
-      );
-
-      expect(res.status).toBe(409);
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test convenience
-      const body = (await res.json()) as any;
-      expect(body.error).toBe("conflict");
-      expect(body.message).toContain("Production");
     });
   });
 });

--- a/packages/api/src/api/__tests__/admin-connections.test.ts
+++ b/packages/api/src/api/__tests__/admin-connections.test.ts
@@ -192,19 +192,34 @@ const sqlIs = {
   catalogLookup: (sql: string): boolean =>
     sql.includes("FROM plugin_catalog") &&
     sql.includes("install_model"),
-  /** Installer's singleton pre-check during installDatasource. */
+  /**
+   * Installer's singleton pre-check during installDatasource — distinguished
+   * from the chat/action `findInstallRow` SELECT (which projects
+   * `config->>'team_id' AS team_id`) by the bare `SELECT install_id`
+   * projection. Matching on column names rather than param positions so
+   * a future param-list reshuffle in the installer doesn't silently break
+   * the dispatch and let tests fall through to the empty default.
+   */
   installerSingleton: (sql: string): boolean =>
-    sql.includes("FROM workspace_plugins") &&
-    sql.includes("catalog_id = $2") &&
-    sql.includes("install_id = $3"),
+    /SELECT\s+install_id\s+FROM workspace_plugins/i.test(sql) &&
+    sql.includes("catalog_id") &&
+    sql.includes("install_id"),
   /** Installer's existing-row read during updateDatasourceConfig. */
   installerLoadForUpdate: (sql: string): boolean =>
     sql.includes("SELECT id, install_id, config, status") &&
     sql.includes("FROM workspace_plugins"),
-  /** Installer's INSERT during installDatasource. */
+  /**
+   * Installer's INSERT during installDatasource. Other call sites
+   * (`onboarding.ts`, `cli/seed.ts`, `auth/migrate.ts`) emit the same
+   * column list but hard-code `'published'` for status; the installer
+   * is the only one parameterising status as `$6`. The `NOW(), $6)`
+   * suffix uniquely identifies the installer's INSERT — important so
+   * that `param[5] === "draft"` assertions never silently misread a
+   * different-INSERT's params.
+   */
   installerInsert: (sql: string): boolean =>
     sql.includes("INSERT INTO workspace_plugins") &&
-    sql.includes("'datasource'"),
+    sql.includes("NOW(), $6)"),
   /** Installer's UPDATE during updateDatasourceConfig. */
   installerUpdate: (sql: string): boolean =>
     sql.includes("UPDATE workspace_plugins") &&
@@ -270,7 +285,10 @@ describe("admin connections — org scoping (workspace_plugins)", () => {
       const params = insertCall![1] as unknown[];
       expect(params[1]).toBe("org-alpha"); // workspace_id
       expect(params[3]).toBe("analytics"); // install_id
-      expect(params[5]).toBe("draft");      // status — always 'draft' per #2177
+      // POST always passes atlasMode='draft' to the installer (#2177) — the
+      // route-level invariant, not a universal installer property. The
+      // installer itself happily writes any status the caller supplies.
+      expect(params[5]).toBe("draft");
     });
 
     it("stores a different workspace_id for a different workspace admin", async () => {
@@ -1836,8 +1854,8 @@ describe("admin connections — org scoping (workspace_plugins)", () => {
       // CatalogNotFoundError → tagged InstallError → 404 → rollback path.
       expect(res.status).toBe(404);
       // register call sequence on a urlChanged + tagged-error path:
-      //   1. register(id, { url: newUrl, ... })  — line 1196 in admin-connections.ts
-      //   2. register(id, { url: currentUrl, ... })  — rollback at line 1265
+      //   1. register(id, { url: newUrl, ... })           — fresh URL for the test-connect
+      //   2. register(id, { url: currentUrl, ... })       — rollback after installer rejects
       const registerCalls = mockRegister.mock.calls;
       expect(registerCalls.length).toBeGreaterThanOrEqual(2);
       const rollbackCall = registerCalls[registerCalls.length - 1] as Array<unknown>;

--- a/packages/api/src/api/__tests__/admin-password-semantic-import-audit.test.ts
+++ b/packages/api/src/api/__tests__/admin-password-semantic-import-audit.test.ts
@@ -218,8 +218,7 @@ describe("POST /api/v1/admin/me/password — audit emission (F-29)", () => {
 // POST /semantic/org/import — bulk import
 // ---------------------------------------------------------------------------
 
-// TODO(#2744 step 5 — test sweep): mocks reference dropped `connections` SQL; rewrite to workspace_plugins (pillar='datasource') shape.
-describe.skip("POST /api/v1/admin/semantic/org/import — audit emission (F-29)", () => {
+describe("POST /api/v1/admin/semantic/org/import — audit emission (F-29)", () => {
   it("emits semantic.bulk_import with importedCount + sourceRef='disk:all' metadata", async () => {
     // Handler tolerates an empty JSON body (no `connectionId` → "disk:all").
     const res = await app.fetch(
@@ -311,8 +310,8 @@ describe.skip("POST /api/v1/admin/semantic/org/import — audit emission (F-29)"
     });
     // Org owns __demo__ — triggers the auto-recovery branch.
     mocks.mockInternalQuery.mockImplementation(async (sql: string) => {
-      if (typeof sql === "string" && sql.includes("FROM connections") && sql.includes("__demo__")) {
-        return [{ id: "__demo__" }];
+      if (typeof sql === "string" && sql.includes("FROM workspace_plugins") && sql.includes("__demo__")) {
+        return [{ install_id: "__demo__" }];
       }
       return [];
     });
@@ -368,7 +367,7 @@ describe.skip("POST /api/v1/admin/semantic/org/import — audit emission (F-29)"
     // Org owns __demo__ — but caller asked about warehouse.
     mocks.mockInternalQuery.mockImplementation(async (sql: string) => {
       if (typeof sql === "string" && sql.includes("__demo__")) {
-        return [{ id: "__demo__" }];
+        return [{ install_id: "__demo__" }];
       }
       return [];
     });
@@ -403,7 +402,7 @@ describe.skip("POST /api/v1/admin/semantic/org/import — audit emission (F-29)"
     });
     mocks.mockInternalQuery.mockImplementation(async (sql: string) => {
       if (typeof sql === "string" && sql.includes("__demo__")) {
-        return [{ id: "__demo__" }];
+        return [{ install_id: "__demo__" }];
       }
       return [];
     });
@@ -430,7 +429,7 @@ describe.skip("POST /api/v1/admin/semantic/org/import — audit emission (F-29)"
     // Ownership check: caller must already have a __demo__ connection.
     mocks.mockInternalQuery.mockImplementation(async (sql: string) => {
       if (typeof sql === "string" && sql.includes("__demo__")) {
-        return [{ id: "__demo__" }];
+        return [{ install_id: "__demo__" }];
       }
       return [];
     });

--- a/packages/api/src/api/__tests__/admin-wizard-save-audit.test.ts
+++ b/packages/api/src/api/__tests__/admin-wizard-save-audit.test.ts
@@ -379,12 +379,7 @@ describe("POST /api/v1/wizard/save — audit emission (F-34)", () => {
 // shape for the same canonical `{ name, dbType }` contract.
 // ---------------------------------------------------------------------------
 
-// TODO(#2744 step 5): the admin-connections side of this parity check
-// now flows through WorkspaceInstaller, which needs a `plugin_catalog`
-// lookup mock the legacy fixtures don't stage. Audit semantics are
-// unchanged (route still emits `connection.create` with `{name,dbType}`)
-// — the test just needs new mock SQL. `.skip` until step 5 rewrites.
-describe.skip("wizard.ts vs admin-connections.ts — audit parity (F-29 + F-34)", () => {
+describe("wizard.ts vs admin-connections.ts — audit parity (F-29 + F-34)", () => {
   it("produces structurally identical connection.create rows for the same payload", async () => {
     // ── Call 1: wizard /save for connection "warehouse" ────────
     mockConnectionDescribe.mockReturnValue([
@@ -404,12 +399,43 @@ describe.skip("wizard.ts vs admin-connections.ts — audit parity (F-29 + F-34)"
     const wizardEntry = wizardEntries[0]!;
 
     // ── Call 2: admin-connections POST / for the same id ───────
-    // Stage the DB mocks so the create path lands on the happy-path
-    // INSERT branch (not revive-archived, not plan-limit, not conflict).
+    // Stage the DB mocks for the post-#2744 happy path: plan-count empty,
+    // archive-check empty (no existing install), installer's plugin_catalog
+    // lookup returns a valid postgres datasource row, and the singleton
+    // pre-check is empty. Audit semantics are unchanged — the route still
+    // emits `connection.create` with `{ name, dbType }` regardless of which
+    // table holds the row.
     mocks.mockInternalQuery.mockImplementation(async (sql: string) => {
-      if (sql.includes("COUNT(*)")) return [{ count: 0 }];
-      if (sql.includes("SELECT status FROM connections")) return [];
-      // INSERT / UPDATE — no rows expected back
+      if (sql.includes("COUNT(*)") && sql.includes("workspace_plugins")) {
+        return [{ count: 0 }];
+      }
+      if (sql.includes("SELECT status FROM workspace_plugins")) return [];
+      // Installer: plugin_catalog lookup
+      if (sql.includes("FROM plugin_catalog") && sql.includes("install_model")) {
+        return [
+          {
+            id: "cat_postgres",
+            slug: "postgres",
+            install_model: "form",
+            pillar: "datasource",
+            config_schema: [
+              { key: "url", type: "string", required: true, secret: true },
+              { key: "schema", type: "string" },
+              { key: "description", type: "string" },
+            ],
+            enabled: true,
+          },
+        ];
+      }
+      // Installer: singleton pre-check on (workspace, catalog, install_id)
+      if (
+        sql.includes("FROM workspace_plugins") &&
+        sql.includes("catalog_id = $2") &&
+        sql.includes("install_id = $3")
+      ) {
+        return [];
+      }
+      // INSERT — no rows back
       return [];
     });
     // Connections registry: let create see a fresh id, then report the

--- a/packages/api/src/api/__tests__/admin.test.ts
+++ b/packages/api/src/api/__tests__/admin.test.ts
@@ -1734,9 +1734,7 @@ describe("GET /api/v1/admin/connections", () => {
   });
 });
 
-// TODO(#2744 step 5): describe mocks `SELECT c.url, c.schema_name, c.group_id, …`
-// from `connections`; route now reads workspace_plugins + plugin_catalog.
-describe.skip("GET /api/v1/admin/connections/:id", () => {
+describe("GET /api/v1/admin/connections/:id", () => {
   beforeEach(() => {
     mockAuthenticateRequest.mockReset();
     setOrgScopedAdmin();
@@ -1744,19 +1742,62 @@ describe.skip("GET /api/v1/admin/connections/:id", () => {
     mockInternalQuery.mockResolvedValue([]);
   });
 
-  it("returns connection detail for registered connection", async () => {
-    // Visibility lookup must return no org-owned rows so the runtime-registered
-    // `default` falls through to the visible set; detail SELECT returns the
-    // URL row.
+  it("returns connection detail for the runtime-registered default", async () => {
+    // Visibility lookup returns no workspace-owned installs so the runtime-
+    // registered `default` falls through to the visible set. Detail SELECT
+    // (post-#2744 `SELECT wp.config, pc.config_schema, ...`) returns
+    // nothing for `default` (it isn't in workspace_plugins) — the response
+    // shape's `managed` flips to false in that case.
     mockInternalQuery.mockImplementation((sql: string) => {
-      if (typeof sql === "string" && sql.includes("SELECT c.id FROM connections")) {
+      if (
+        typeof sql === "string" &&
+        sql.includes("FROM workspace_plugins wp") &&
+        sql.includes("DISTINCT wp.install_id")
+      ) {
         return Promise.resolve([]);
       }
-      return Promise.resolve([{ url: "postgresql://localhost/db", schema_name: "public" }]);
+      // Detail JOIN — no row for the runtime-registered `default`.
+      return Promise.resolve([]);
     });
     const res = await app.fetch(adminRequest("/api/v1/admin/connections/default"));
     expect(res.status).toBe(200);
 
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.id).toBe("default");
+    // `default` isn't admin-managed (no workspace_plugins row) — the
+    // detail JOIN returned 0 rows, so `managed: false`.
+    expect(body.managed).toBe(false);
+  });
+
+  it("returns 200 with managed: true for a workspace install", async () => {
+    mockInternalQuery.mockImplementation((sql: string) => {
+      if (
+        typeof sql === "string" &&
+        sql.includes("FROM workspace_plugins wp") &&
+        sql.includes("DISTINCT wp.install_id")
+      ) {
+        return Promise.resolve([{ install_id: "default" }]);
+      }
+      if (
+        typeof sql === "string" &&
+        sql.includes("SELECT wp.config, pc.config_schema") &&
+        sql.includes("JOIN plugin_catalog")
+      ) {
+        return Promise.resolve([
+          {
+            config: { url: "postgresql://localhost/db" },
+            config_schema: [
+              { key: "url", type: "string", required: true, secret: true },
+              { key: "schema", type: "string" },
+            ],
+            group_id: null,
+          },
+        ]);
+      }
+      return Promise.resolve([]);
+    });
+    const res = await app.fetch(adminRequest("/api/v1/admin/connections/default"));
+    expect(res.status).toBe(200);
     const body = (await res.json()) as Record<string, unknown>;
     expect(body.id).toBe("default");
     expect(body.managed).toBe(true);
@@ -1780,10 +1821,14 @@ describe.skip("GET /api/v1/admin/connections/:id", () => {
   });
 });
 
-// TODO(#2744 step 5): rollback-escalation describe mocks legacy
-// `SELECT id, url, type, description, schema_name, group_id FROM connections`
-// + `decryptSecret`. Route now uses `decryptSecretFields` from workspace_plugins.config.
-describe.skip("PUT /api/v1/admin/connections/:id — rollback escalation", () => {
+describe("PUT /api/v1/admin/connections/:id — rollback escalation", () => {
+  // Post-#2744 the route loads existing config from `workspace_plugins`
+  // JOIN `plugin_catalog`, the URL lives inside `config` JSONB, and
+  // `decryptSecretFields` walks the catalog schema for `secret: true`
+  // keys. The rollback contract on a urlChanged + healthCheck failure
+  // is unchanged: register(new URL) → healthCheck throws → register
+  // (currentUrl) for rollback. Rollback failure escalates to 500 with
+  // restart guidance.
   beforeEach(() => {
     mockAuthenticateRequest.mockReset();
     setOrgScopedAdmin();
@@ -1794,12 +1839,42 @@ describe.skip("PUT /api/v1/admin/connections/:id — rollback escalation", () =>
     mockRegister.mockImplementation(() => {});
   });
 
+  function stageExistingInstall(): void {
+    mockInternalQuery.mockImplementation((sql: string) => {
+      if (
+        typeof sql === "string" &&
+        sql.includes("SELECT pc.slug AS catalog_slug") &&
+        sql.includes("wp.config")
+      ) {
+        return Promise.resolve([
+          {
+            catalog_slug: "postgres",
+            // Plain URL — the real `decryptSecret` returns un-prefixed values
+            // verbatim, so `currentUrl` resolves to this string and is what
+            // the rollback re-registers.
+            config: { url: "postgresql://old/db" },
+            config_schema: [
+              { key: "url", type: "string", required: true, secret: true },
+              { key: "schema", type: "string" },
+              { key: "description", type: "string" },
+            ],
+            group_id: null,
+          },
+        ]);
+      }
+      return Promise.resolve([]);
+    });
+  }
+
   it("returns 400 when URL test fails but rollback succeeds", async () => {
-    // Existing connection in DB
-    mockInternalQuery.mockResolvedValueOnce([{ id: "warehouse", url: "postgresql://old/db", type: "postgres", description: null, schema_name: null }]);
+    stageExistingInstall();
     mockHealthCheck.mockRejectedValue(new Error("Connection refused"));
 
-    const res = await app.fetch(adminRequest("/api/v1/admin/connections/warehouse", "PUT", { url: "postgresql://bad/url" }));
+    const res = await app.fetch(
+      adminRequest("/api/v1/admin/connections/warehouse", "PUT", {
+        url: "postgresql://bad/url",
+      }),
+    );
     expect(res.status).toBe(400);
 
     const body = (await res.json()) as Record<string, unknown>;
@@ -1808,18 +1883,20 @@ describe.skip("PUT /api/v1/admin/connections/:id — rollback escalation", () =>
   });
 
   it("escalates to 500 with restart guidance when rollback fails", async () => {
-    // Existing connection in DB
-    mockInternalQuery.mockResolvedValueOnce([{ id: "warehouse", url: "postgresql://old/db", type: "postgres", description: null, schema_name: null }]);
-    // Health check fails
+    stageExistingInstall();
     mockHealthCheck.mockRejectedValue(new Error("Connection refused"));
-    // First call (register new URL) succeeds, second call (rollback) throws
+    // First call (register new URL) succeeds, second call (rollback) throws.
     let callCount = 0;
     mockRegister.mockImplementation(() => {
       callCount++;
       if (callCount >= 2) throw new Error("rollback failed");
     });
 
-    const res = await app.fetch(adminRequest("/api/v1/admin/connections/warehouse", "PUT", { url: "postgresql://bad/url" }));
+    const res = await app.fetch(
+      adminRequest("/api/v1/admin/connections/warehouse", "PUT", {
+        url: "postgresql://bad/url",
+      }),
+    );
     expect(res.status).toBe(500);
 
     const body = (await res.json()) as Record<string, unknown>;

--- a/packages/api/src/api/__tests__/billing.test.ts
+++ b/packages/api/src/api/__tests__/billing.test.ts
@@ -196,8 +196,7 @@ describe("billing routes", () => {
 
   // ── GET /billing ──────────────────────────────────────────────────
 
-  // TODO(#2744 step 5 — test sweep): mocks reference dropped `connections` SQL; rewrite to workspace_plugins (pillar='datasource') shape.
-  describe.skip("GET /api/v1/billing", () => {
+  describe("GET /api/v1/billing", () => {
     it("returns billing status for workspace", async () => {
       // Return seat count of 3 for member query, connection count of 2 for connections query
       mockInternalQuery.mockImplementation((...args: unknown[]) => {
@@ -205,7 +204,7 @@ describe("billing routes", () => {
         if (typeof sql === "string" && sql.includes("member")) {
           return Promise.resolve([{ count: 3 }]);
         }
-        if (typeof sql === "string" && sql.includes("connections")) {
+        if (typeof sql === "string" && sql.includes("workspace_plugins") && sql.includes("pillar = 'datasource'")) {
           return Promise.resolve([{ count: 2 }]);
         }
         return Promise.resolve([]);
@@ -252,7 +251,7 @@ describe("billing routes", () => {
     it("defaults connection count to 0 when connections query fails", async () => {
       mockInternalQuery.mockImplementation((...args: unknown[]) => {
         const sql = args[0];
-        if (typeof sql === "string" && sql.includes("connections")) {
+        if (typeof sql === "string" && sql.includes("workspace_plugins") && sql.includes("pillar = 'datasource'")) {
           return Promise.reject(new Error("relation does not exist"));
         }
         if (typeof sql === "string" && sql.includes("member")) {

--- a/packages/api/src/api/__tests__/onboarding.test.ts
+++ b/packages/api/src/api/__tests__/onboarding.test.ts
@@ -633,8 +633,7 @@ describe("POST /api/v1/onboarding/tour-reset", () => {
 // POST /api/v1/onboarding/use-demo
 // ---------------------------------------------------------------------------
 
-// TODO(#2744 step 5 — test sweep): mocks reference dropped `connections` SQL; rewrite to workspace_plugins (pillar='datasource') shape.
-describe.skip("POST /api/v1/onboarding/use-demo", () => {
+describe("POST /api/v1/onboarding/use-demo", () => {
   const originalEnv = { ...process.env };
 
   beforeEach(() => {
@@ -648,7 +647,19 @@ describe.skip("POST /api/v1/onboarding/use-demo", () => {
     );
     mockHasInternalDB.mockImplementation(() => true);
     mockInternalQuery.mockClear();
-    mockInternalQuery.mockImplementation(async () => [{ id: "__demo__" }]);
+    // Post-#2744: /use-demo first looks up the demo-postgres catalog row,
+    // then runs an UPSERT into `workspace_plugins` that returns
+    // `install_id AS id`. Stub both — most tests just need the round-trip
+    // to succeed; assertion-focused tests further override locally.
+    mockInternalQuery.mockImplementation(async (sql: string) => {
+      if (typeof sql === "string" && sql.includes("FROM plugin_catalog") && sql.includes("demo-postgres")) {
+        return [{ id: "cat_demo_postgres" }];
+      }
+      if (typeof sql === "string" && sql.includes("INSERT INTO workspace_plugins")) {
+        return [{ id: "__demo__" }];
+      }
+      return [{ id: "__demo__" }];
+    });
     mockEncryptUrl.mockClear();
     mockEncryptUrl.mockImplementation((url: string) => `encrypted:${url}`);
     mockRegister.mockClear();
@@ -683,27 +694,31 @@ describe.skip("POST /api/v1/onboarding/use-demo", () => {
     expect(data.entitiesImported).toBe(5);
   });
 
-  it("saves connection with status='published' in upsert SQL", async () => {
+  it("saves connection with status='published' in workspace_plugins upsert SQL", async () => {
     await request("/api/v1/onboarding/use-demo", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ demoType: "cybersec" }),
     });
 
-    // Find the INSERT INTO connections call
+    // Post-#2744 the upsert lands on `workspace_plugins` with the demo
+    // catalog row's id and a hard-coded 'published' status. The URL is
+    // encrypted into the JSONB `config` payload, not into a top-level
+    // column — assert on the install_id + the literal status in the SQL.
     const connectionInsertCall = mockInternalQuery.mock.calls.find(
-      (call) => typeof call[0] === "string" && call[0].includes("INSERT INTO connections"),
+      (call) => typeof call[0] === "string" && call[0].includes("INSERT INTO workspace_plugins"),
     );
     expect(connectionInsertCall).toBeDefined();
     const sql = connectionInsertCall![0] as string;
     expect(sql).toContain("'published'");
-    // F-47: INSERT carries url_key_version so post-rotation ops queries
-    // (`WHERE url_key_version < $active`) surface demo-flow rows too.
-    expect(sql).toContain("url_key_version");
+    expect(sql).toContain("'datasource'");
+    // ON CONFLICT key for the singleton (workspace, catalog, install_id) PK.
+    expect(sql).toContain("ON CONFLICT (workspace_id, catalog_id, install_id)");
     const params = connectionInsertCall![1] as unknown[];
-    expect(params[0]).toBe("__demo__");
-    // url_key_version defaults to 1 in tests with no ATLAS_ENCRYPTION_KEYS set.
-    expect(params[params.length - 1]).toBe(1);
+    // Params: [`cn_${orgId}_${id}`, orgId, catalogId, id, configJson]
+    expect(params[1]).toBe("org-1");      // workspace_id
+    expect(params[2]).toBe("cat_demo_postgres"); // catalog_id from the lookup mock
+    expect(params[3]).toBe("__demo__");   // install_id
   });
 
   it("imports semantic entities with connectionId='__demo__'", async () => {
@@ -1021,7 +1036,7 @@ describe.skip("POST /api/v1/onboarding/use-demo", () => {
     expect(data.error).toBe("import_failed");
 
     const connectionInsert = mockInternalQuery.mock.calls.find(
-      (call) => typeof call[0] === "string" && call[0].includes("INSERT INTO connections"),
+      (call) => typeof call[0] === "string" && call[0].includes("INSERT INTO workspace_plugins"),
     );
     expect(connectionInsert).toBeUndefined();
     expect(mockRegister).not.toHaveBeenCalled();
@@ -1048,7 +1063,7 @@ describe.skip("POST /api/v1/onboarding/use-demo", () => {
     expect(data.error).toBe("import_failed");
 
     const connectionInsert = mockInternalQuery.mock.calls.find(
-      (call) => typeof call[0] === "string" && call[0].includes("INSERT INTO connections"),
+      (call) => typeof call[0] === "string" && call[0].includes("INSERT INTO workspace_plugins"),
     );
     expect(connectionInsert).toBeUndefined();
     mockImportFromDisk.mockImplementation(async () => ({ imported: 5, skipped: 0, errors: [], total: 5 }));
@@ -1083,7 +1098,7 @@ describe.skip("POST /api/v1/onboarding/use-demo", () => {
     expect(data.error).toBe("demo_not_available");
 
     const connectionInsert = mockInternalQuery.mock.calls.find(
-      (call) => typeof call[0] === "string" && call[0].includes("INSERT INTO connections"),
+      (call) => typeof call[0] === "string" && call[0].includes("INSERT INTO workspace_plugins"),
     );
     expect(connectionInsert).toBeUndefined();
 
@@ -1108,7 +1123,7 @@ describe.skip("POST /api/v1/onboarding/use-demo", () => {
     expect(data.error).toBe("demo_not_available");
 
     const connectionInsert = mockInternalQuery.mock.calls.find(
-      (call) => typeof call[0] === "string" && call[0].includes("INSERT INTO connections"),
+      (call) => typeof call[0] === "string" && call[0].includes("INSERT INTO workspace_plugins"),
     );
     expect(connectionInsert).toBeUndefined();
     expect(mockImportFromDisk).not.toHaveBeenCalled();
@@ -1127,7 +1142,7 @@ describe.skip("POST /api/v1/onboarding/use-demo", () => {
     });
     const baseImpl = mockInternalQuery.getMockImplementation();
     mockInternalQuery.mockImplementation(async (sql: string, params?: unknown[]) => {
-      if (typeof sql === "string" && sql.includes("INSERT INTO connections")) {
+      if (typeof sql === "string" && sql.includes("INSERT INTO workspace_plugins")) {
         connectionInsertOrder = ++counter;
         return [{ id: "__demo__" }];
       }
@@ -1168,23 +1183,25 @@ describe.skip("POST /api/v1/onboarding/use-demo", () => {
     expect(data.entitiesImported).toBe(8);
 
     const connectionInsert = mockInternalQuery.mock.calls.find(
-      (call) => typeof call[0] === "string" && call[0].includes("INSERT INTO connections"),
+      (call) => typeof call[0] === "string" && call[0].includes("INSERT INTO workspace_plugins"),
     );
     expect(connectionInsert).toBeDefined();
     mockImportFromDisk.mockImplementation(async () => ({ imported: 5, skipped: 0, errors: [], total: 5 }));
   });
 
-  it("RACE: ON CONFLICT DO NOTHING — a 0-row INSERT followed by a successful verify SELECT still returns 201 (#2304)", async () => {
-    // The first onboarder pinned the global `__demo__` URL. A second
-    // onboarder whose INSERT is no-op'd by ON CONFLICT must still see
-    // 201 if the verify SELECT confirms the row already exists. Without
-    // this test, a future change that flips `DO NOTHING` back to
-    // `DO UPDATE SET url=...` would silently re-introduce per-onboarder
-    // URL clobbering.
+  it("RACE: idempotent UPSERT — ON CONFLICT DO UPDATE returns the install_id even on re-run (#2304)", async () => {
+    // Post-#2744 the demo upsert uses `ON CONFLICT (workspace_id, catalog_id,
+    // install_id) DO UPDATE SET config = EXCLUDED.config, status = 'published'`.
+    // RETURNING install_id always yields the row on both the fresh-insert
+    // and the conflict-update branch — so a second onboarder gets 201 with
+    // the same canonical id. The legacy `DO NOTHING` + verify-SELECT
+    // pattern that the global `__global__` install used is gone (each
+    // workspace owns its own demo row now per migration 0094).
     mockInternalQuery.mockImplementation(async (sql: string) => {
-      if (sql.includes("INSERT INTO connection_groups")) return [{ id: "g___demo__" }];
-      if (sql.includes("INSERT INTO connections")) return [];
-      if (sql.includes("SELECT id FROM connections WHERE id = $1 AND org_id = '__global__'")) {
+      if (typeof sql === "string" && sql.includes("FROM plugin_catalog") && sql.includes("demo-postgres")) {
+        return [{ id: "cat_demo_postgres" }];
+      }
+      if (typeof sql === "string" && sql.includes("INSERT INTO workspace_plugins")) {
         return [{ id: "__demo__" }];
       }
       return [];

--- a/packages/api/src/api/__tests__/prompts.test.ts
+++ b/packages/api/src/api/__tests__/prompts.test.ts
@@ -135,10 +135,12 @@ beforeEach(() => {
 });
 
 // Drive `resolvePromptDemoContext`: returns true when the mocked query asks
-// whether `__demo__` exists for this org. Other queries resolve to `[]`.
+// whether `__demo__` exists for this org. Post-#2744 the query reads
+// `workspace_plugins JOIN plugin_catalog (slug='demo-postgres')` and SELECTs
+// `EXISTS (...) AS active`. Other queries resolve to `[]`.
 function mockDemoActive(active: boolean): void {
   mocks.mockInternalQuery.mockImplementation((sql: string) => {
-    if (sql.includes("FROM connections") && sql.includes("__demo__")) {
+    if (sql.includes("FROM workspace_plugins wp") && sql.includes("'__demo__'")) {
       return Promise.resolve([{ active }]);
     }
     return Promise.resolve([]);
@@ -244,8 +246,8 @@ describe("user-facing prompt routes", () => {
 
     // ─── Mode-aware demo scoping (#1438) ────────────────────────────
 
-    // TODO(#2744 step 5 — test sweep): mocks reference dropped `connections` / `connection_groups` SQL; rewrite to workspace_plugins (pillar='datasource') shape.
-    describe.skip("mode + demo scoping (#1438)", () => {
+    
+    describe("mode + demo scoping (#1438)", () => {
       function findListCall() {
         return mocks.mockInternalQuery.mock.calls.find(
           ([sql]) =>
@@ -448,8 +450,8 @@ describe("admin prompt routes", () => {
 
     // ─── Mode-aware demo scoping for admin list (#1438) ─────────────
 
-    // TODO(#2744 step 5 — test sweep): mocks reference dropped `connections` / `connection_groups` SQL; rewrite to workspace_plugins (pillar='datasource') shape.
-    describe.skip("mode + demo scoping (#1438)", () => {
+    
+    describe("mode + demo scoping (#1438)", () => {
       function findListCall() {
         return mocks.mockInternalQuery.mock.calls.find(
           ([sql]) =>

--- a/packages/api/src/api/routes/__tests__/me-connection-groups.test.ts
+++ b/packages/api/src/api/routes/__tests__/me-connection-groups.test.ts
@@ -49,11 +49,17 @@ mock.module("@atlas/api/lib/logger", () => {
 // ── DB mock ────────────────────────────────────────────────────────────────
 
 let dbAvailable = true;
+// Post-#2744 the route reads `workspace_plugins (pillar='datasource')`
+// and projects:
+//   - `config->>'group_id' AS group_id` (also acts as the group name)
+//   - `install_id AS connection_id`
+//   - `config->>'db_type' AS db_type`
+//   - `config->>'description' AS description`
+// The `connection_groups` table is gone, so there's no separate
+// `group_name` or `primary_connection_id` column to mock.
 type GroupRow = {
   group_id: string;
-  group_name: string;
-  primary_connection_id: string | null;
-  connection_id: string | null;
+  connection_id: string;
   db_type: string | null;
   description: string | null;
 };
@@ -157,8 +163,7 @@ beforeEach(() => {
   rowsForOrg = {};
 });
 
-// TODO(#2744 step 5 — test sweep): mocks reference dropped `connections` / `connection_groups` SQL; rewrite to workspace_plugins (pillar='datasource') shape.
-describe.skip("GET /api/v1/me/connection-groups — reason field (#2422)", () => {
+describe("GET /api/v1/me/connection-groups — reason field (#2422)", () => {
   it("returns 401 when unauthenticated", async () => {
     fakeAuth = null;
     const res = await meConnectionGroups.request("/", { method: "GET" });
@@ -212,9 +217,7 @@ describe.skip("GET /api/v1/me/connection-groups — reason field (#2422)", () =>
     fakeAuth = userAuth();
     rowsForOrg["org-1"] = [
       {
-        group_id: "g_prod",
-        group_name: "prod",
-        primary_connection_id: "us-int",
+        group_id: "prod",
         connection_id: "us-int",
         db_type: "postgres",
         description: null,
@@ -224,36 +227,39 @@ describe.skip("GET /api/v1/me/connection-groups — reason field (#2422)", () =>
     expect(res.status).toBe(200);
     const body = await getJson(res);
     expect(body.groups).toHaveLength(1);
-    expect(body.groups[0]).toMatchObject({ id: "g_prod", name: "prod" });
+    // Post-cutover groupName mirrors groupId verbatim — the
+    // `connection_groups.name` separate-from-id distinction is gone.
+    expect(body.groups[0]).toMatchObject({ id: "prod", name: "prod" });
     expect(body.reason).toBeNull();
   });
 });
 
-// TODO(#2744 step 5 — test sweep): mocks reference dropped `connections` / `connection_groups` SQL; rewrite to workspace_plugins (pillar='datasource') shape.
-describe.skip("GET /api/v1/me/connection-groups — primaryConnectionId surfacing", () => {
-  it("surfaces the group's primary_connection_id so the picker can default to it", async () => {
+describe("GET /api/v1/me/connection-groups — primaryConnectionId surfacing (post-cutover)", () => {
+  // Post-#2744 there's no separate `connection_groups.primary_connection_id`
+  // column — the route always emits `primaryConnectionId: null` on every
+  // group. The wire field is preserved for backwards compatibility with
+  // pre-#2744 clients; the picker now falls back to its deterministic
+  // first-by-install_id ordering when no explicit pin exists. These tests
+  // pin that contract so a regression that re-introduces a primary
+  // lookup (or accidentally drops the field) fails loudly.
+
+  it("emits primaryConnectionId: null on every group (no connection_groups table any more)", async () => {
     fakeAuth = userAuth();
     rowsForOrg["org-1"] = [
       {
-        group_id: "g_prod",
-        group_name: "prod",
-        primary_connection_id: "us-prod",
+        group_id: "prod",
         connection_id: "apac-prod",
         db_type: "postgres",
         description: "APAC",
       },
       {
-        group_id: "g_prod",
-        group_name: "prod",
-        primary_connection_id: "us-prod",
+        group_id: "prod",
         connection_id: "eu-prod",
         db_type: "postgres",
         description: "EU",
       },
       {
-        group_id: "g_prod",
-        group_name: "prod",
-        primary_connection_id: "us-prod",
+        group_id: "prod",
         connection_id: "us-prod",
         db_type: "postgres",
         description: "US",
@@ -263,7 +269,9 @@ describe.skip("GET /api/v1/me/connection-groups — primaryConnectionId surfacin
     expect(res.status).toBe(200);
     const body = await getJson(res);
     expect(body.groups).toHaveLength(1);
-    expect(body.groups[0]?.primaryConnectionId).toBe("us-prod");
+    expect(body.groups[0]?.primaryConnectionId).toBeNull();
+    // Member ordering preserves the SQL `ORDER BY install_id ASC` ordering
+    // so the picker's deterministic-default pick is stable.
     expect(body.groups[0]?.members.map((m) => m.connectionId)).toEqual([
       "apac-prod",
       "eu-prod",
@@ -271,69 +279,64 @@ describe.skip("GET /api/v1/me/connection-groups — primaryConnectionId surfacin
     ]);
   });
 
-  it("returns primaryConnectionId: null when the group has no primary configured", async () => {
+  it("buckets multiple group_ids into separate group entries", async () => {
+    fakeAuth = userAuth();
+    rowsForOrg["org-1"] = [
+      { group_id: "prod", connection_id: "us-prod", db_type: "postgres", description: null },
+      { group_id: "staging", connection_id: "us-stg", db_type: "postgres", description: null },
+    ];
+    const res = await meConnectionGroups.request("/", { method: "GET" });
+    const body = await getJson(res);
+    expect(body.groups).toHaveLength(2);
+    const ids = body.groups.map((g) => g.id).sort();
+    expect(ids).toEqual(["prod", "staging"]);
+  });
+
+  it("does NOT surface a group when every member is archived (config->>'group_id' IS NOT NULL filter)", async () => {
+    // The post-cutover query filters `config->>'group_id' IS NOT NULL`
+    // AND `status != 'archived'`, so the legacy LEFT JOIN behavior of
+    // returning a one-row-with-NULL-connection_id for an empty group is
+    // gone. Archived-only groups disappear from the picker entirely —
+    // which is the right UX (an empty group with no live members can't
+    // route a query anywhere).
+    fakeAuth = userAuth();
+    rowsForOrg["org-1"] = [];
+    const res = await meConnectionGroups.request("/", { method: "GET" });
+    const body = await getJson(res);
+    expect(body.groups).toEqual([]);
+  });
+
+  it("surfaces dbType + description from JSONB config fields", async () => {
     fakeAuth = userAuth();
     rowsForOrg["org-1"] = [
       {
-        group_id: "g_prod",
-        group_name: "prod",
-        primary_connection_id: null,
+        group_id: "prod",
         connection_id: "us-prod",
         db_type: "postgres",
-        description: null,
+        description: "US production",
       },
     ];
     const res = await meConnectionGroups.request("/", { method: "GET" });
     const body = await getJson(res);
-    expect(body.groups[0]?.primaryConnectionId).toBeNull();
+    expect(body.groups[0]?.members[0]).toEqual({
+      connectionId: "us-prod",
+      dbType: "postgres",
+      description: "US production",
+    });
   });
 
-  it("nulls out a primary that's no longer in the member list (archived / mismatched)", async () => {
-    // The composite FK has ON DELETE SET NULL, but archive isn't
-    // delete — the LEFT JOIN filter `status != 'archived'` is what
-    // strands the primary. Guard nulls it so the picker doesn't pin
-    // to an invisible member.
+  it("falls back to dbType: 'unknown' when JSONB config has no db_type key", async () => {
     fakeAuth = userAuth();
     rowsForOrg["org-1"] = [
       {
-        group_id: "g_prod",
-        group_name: "prod",
-        primary_connection_id: "us-prod-archived",
-        connection_id: "apac-prod",
-        db_type: "postgres",
-        description: null,
-      },
-      {
-        group_id: "g_prod",
-        group_name: "prod",
-        primary_connection_id: "us-prod-archived",
-        connection_id: "eu-prod",
-        db_type: "postgres",
-        description: null,
-      },
-    ];
-    const res = await meConnectionGroups.request("/", { method: "GET" });
-    const body = await getJson(res);
-    expect(body.groups[0]?.primaryConnectionId).toBeNull();
-  });
-
-  it("preserves primaryConnectionId on a group with zero non-archived members (left-join empty)", async () => {
-    // LEFT JOIN yields one row with NULL connection_id when every
-    // member is archived; dangling-primary guard still applies.
-    fakeAuth = userAuth();
-    rowsForOrg["org-1"] = [
-      {
-        group_id: "g_empty",
-        group_name: "empty",
-        primary_connection_id: "gone",
-        connection_id: null,
+        group_id: "prod",
+        connection_id: "us-prod",
         db_type: null,
         description: null,
       },
     ];
     const res = await meConnectionGroups.request("/", { method: "GET" });
     const body = await getJson(res);
-    expect(body.groups[0]?.members).toEqual([]);
-    expect(body.groups[0]?.primaryConnectionId).toBeNull();
+    expect(body.groups[0]?.members[0]?.dbType).toBe("unknown");
   });
 });

--- a/packages/api/src/api/routes/__tests__/mode.test.ts
+++ b/packages/api/src/api/routes/__tests__/mode.test.ts
@@ -117,7 +117,9 @@ let demoActiveFixture = false;
 // rows are also supported for any remaining callers of internalQuery directly.
 const mockInternalQuery: Mock<(sql: string, params?: unknown[]) => Promise<Record<string, unknown>[]>> = mock(
   async (sql: string) => {
-    if (sql.includes("FROM connections") && sql.includes("'__demo__'")) {
+    // Post-#2744 `resolvePromptDemoContext` reads `workspace_plugins JOIN
+    // plugin_catalog (slug='demo-postgres')` and SELECTs `EXISTS (...) AS active`.
+    if (sql.includes("FROM workspace_plugins wp") && sql.includes("'__demo__'")) {
       return [{ active: demoActiveFixture }];
     }
     if (sql.includes("UNION ALL") && sql.includes("draft")) {
@@ -338,8 +340,7 @@ describe("GET /api/v1/mode — canToggle by role", () => {
   });
 });
 
-// TODO(#2744 step 5 — test sweep): mocks reference dropped `connections` / `connection_groups` SQL; rewrite to workspace_plugins (pillar='datasource') shape.
-describe.skip("GET /api/v1/mode — demo state", () => {
+describe("GET /api/v1/mode — demo state", () => {
   beforeEach(() => {
     asAdmin();
     mockHasInternalDBValue = true;

--- a/packages/api/src/lib/__tests__/conversations-group-routing.test.ts
+++ b/packages/api/src/lib/__tests__/conversations-group-routing.test.ts
@@ -194,8 +194,7 @@ describe("per-turn override scoping", () => {
 
 // ── 3. Missing group falls back to legacy behavior ────────────────────
 
-// TODO(#2744 step 5 — test sweep): mocks reference dropped `connections` / `connection_groups` SQL; rewrite to workspace_plugins (pillar='datasource') shape.
-describe.skip("missing group falls back to legacy behavior", () => {
+describe("missing group falls back to legacy behavior", () => {
   it("resolveGroupForConnection returns null when no internal DB is configured", async () => {
     const result = await resolveGroupForConnection("conn-x", "org-1");
     expect(result).toBeNull();
@@ -203,13 +202,15 @@ describe.skip("missing group falls back to legacy behavior", () => {
     expect(queryCalls.length).toBe(0);
   });
 
-  it("returns null when the connection exists but has no group_id (legacy single-connection deploy)", async () => {
+  it("returns null when the install exists but config has no group_id (legacy single-connection deploy)", async () => {
     enableInternalDB();
     setResults({ rows: [{ group_id: null }] });
 
     const result = await resolveGroupForConnection("conn-legacy", "org-1");
     expect(result).toBeNull();
-    expect(queryCalls[0].sql).toContain("FROM connections");
+    // Post-#2744 the helper queries `workspace_plugins` for `config->>'group_id'`.
+    expect(queryCalls[0].sql).toContain("FROM workspace_plugins");
+    expect(queryCalls[0].sql).toContain("config->>'group_id'");
   });
 
   it("returns null when the connection does not exist for this org", async () => {
@@ -220,12 +221,12 @@ describe.skip("missing group falls back to legacy behavior", () => {
     expect(result).toBeNull();
   });
 
-  it("returns the group_id when the 0062 1:1 backfill produced one", async () => {
+  it("returns the group_id when workspace_plugins.config has one", async () => {
     enableInternalDB();
-    setResults({ rows: [{ group_id: "g_prod" }] });
+    setResults({ rows: [{ group_id: "prod" }] });
 
     const result = await resolveGroupForConnection("us-int", "org-1");
-    expect(result).toBe("g_prod");
+    expect(result).toBe("prod");
     expect(queryCalls[0].params).toEqual(["us-int", "org-1"]);
   });
 
@@ -240,15 +241,15 @@ describe.skip("missing group falls back to legacy behavior", () => {
     expect(result).toBeNull();
   });
 
-  it("uses a null-safe org predicate so caller orgId=null doesn't collapse to `__global__` only (#2415)", async () => {
+  it("uses a null-safe workspace predicate so caller orgId=null doesn't collapse to `__global__` only (#2415)", async () => {
     // Mock-theater regression guard. The mock returns whatever rows we
     // hand it regardless of WHERE-clause semantics, so a "result is
     // g_default" assertion gives false confidence. The real signal is
-    // the SQL itself: plain `org_id = $2` collapses to UNKNOWN when $2
-    // is NULL and falls through to `org_id = '__global__'`, silently
-    // losing the binding for any deploy whose connections.org_id is
-    // anything else. The null-safe `IS NOT DISTINCT FROM` operator
-    // matches NULL to NULL.
+    // the SQL itself: plain `workspace_id = $2` collapses to UNKNOWN
+    // when $2 is NULL and falls through to `workspace_id = '__global__'`,
+    // silently losing the binding for any deploy whose workspace_plugins
+    // row was scoped to NULL. The null-safe `IS NOT DISTINCT FROM`
+    // operator matches NULL to NULL.
     //
     // Real-Postgres coverage of the predicate semantics lives in
     // `db/__tests__/migrate-pg.test.ts` ("resolveGroupForConnection
@@ -257,24 +258,24 @@ describe.skip("missing group falls back to legacy behavior", () => {
     // refactor can't quietly weaken the predicate without the migrate-pg
     // suite catching it too.
     enableInternalDB();
-    setResults({ rows: [{ group_id: "g_default" }] });
+    setResults({ rows: [{ group_id: "default" }] });
 
     await resolveGroupForConnection("conn-1", null);
 
     expect(queryCalls.length).toBe(1);
     const { sql, params } = queryCalls[0];
     expect(sql).toContain("IS NOT DISTINCT FROM");
-    // Plain `org_id = $2 OR` is forbidden: it's null-unsafe by Postgres
-    // semantics (NULL=NULL → UNKNOWN), and the OR-fallback hides the
-    // miss. The null-safe `IS NOT DISTINCT FROM` form is the invariant
-    // this helper has to maintain.
-    expect(sql).not.toMatch(/org_id\s*=\s*\$2\s+OR/);
+    // Plain `workspace_id = $2 OR` is forbidden: it's null-unsafe by
+    // Postgres semantics (NULL=NULL → UNKNOWN), and the OR-fallback
+    // hides the miss. The null-safe `IS NOT DISTINCT FROM` form is the
+    // invariant this helper has to maintain.
+    expect(sql).not.toMatch(/workspace_id\s*=\s*\$2\s+OR/);
     // The fallback to the shared `__global__` row must still be in the
-    // predicate — that's what lets demo/global connections resolve under
-    // any caller orgId.
+    // predicate — that's what lets demo/global installs resolve under
+    // any caller workspace_id.
     expect(sql).toContain("'__global__'");
     // The caller's null orgId is forwarded as a SQL NULL so the
-    // null-safe operator can match against connections.org_id IS NULL.
+    // null-safe operator can match against workspace_plugins.workspace_id IS NULL.
     expect(params).toEqual(["conn-1", null]);
   });
 });

--- a/packages/api/src/lib/__tests__/dashboards-refresh-org-pool.test.ts
+++ b/packages/api/src/lib/__tests__/dashboards-refresh-org-pool.test.ts
@@ -85,10 +85,16 @@ function cardRow(connectionGroupId: string | null): Record<string, unknown> {
   };
 }
 
-/** Two rows the group snapshot loader expects: a primary lookup, then a member list. */
-function groupSnapshotRows(primaryConnectionId: string, memberIds: string[]): Array<{ rows: Record<string, unknown>[] }> {
+/**
+ * Single query the post-#2744 `loadGroupSnapshot` expects: a SELECT against
+ * `workspace_plugins` returning every install in the group, ordered by
+ * `(installed_at ASC, install_id ASC)`. There's no separate
+ * `primary_connection_id` lookup any more — the snapshot's
+ * `primaryConnectionId` is always null and the resolver falls through to
+ * the deterministic first-by-installed_at member.
+ */
+function groupSnapshotRows(memberIds: string[]): Array<{ rows: Record<string, unknown>[] }> {
   return [
-    { rows: [{ primary_connection_id: primaryConnectionId }] },
     {
       rows: memberIds.map((id, idx) => ({
         id,
@@ -103,8 +109,7 @@ function setResults(...results: Array<{ rows: Record<string, unknown>[] }>) {
   queryResultIndex = 0;
 }
 
-// TODO(#2744 step 5 — test sweep): mocks reference dropped `connections` / `connection_groups` SQL; rewrite to workspace_plugins (pillar='datasource') shape.
-describe.skip("refreshDashboardCards org-scoped pool selection", () => {
+describe("refreshDashboardCards org-scoped pool selection", () => {
   const originalDatabaseUrl = process.env.DATABASE_URL;
 
   beforeEach(() => {
@@ -127,11 +132,14 @@ describe.skip("refreshDashboardCards org-scoped pool selection", () => {
     _resetPool(null);
   });
 
-  it("resolves the group's primary member when opening a scheduled refresh pool", async () => {
+  it("resolves the group's first member (deterministic by installed_at) when opening a scheduled refresh pool", async () => {
+    // Post-#2744 there's no `primary_connection_id` — the resolver falls
+    // through to the deterministic first-by-(installed_at, install_id)
+    // member. Single-member group → `warehouse` is both first AND only.
     setResults(
       { rows: [dashboardRow("org-1")] },
       { rows: [cardRow("g-warehouse")] },
-      ...groupSnapshotRows("warehouse", ["warehouse"]),
+      ...groupSnapshotRows(["warehouse"]),
       { rows: [{ id: "card-1" }] },
       { rows: [] },
     );

--- a/packages/api/src/lib/__tests__/mode-agent-isolation.test.ts
+++ b/packages/api/src/lib/__tests__/mode-agent-isolation.test.ts
@@ -24,7 +24,11 @@ let connectionRows: ConnectionRow[] = [];
 const mockInternalQuery = mock(async (sql: string, params?: unknown[]) => {
   const [orgIdParam, idParam] = (params ?? []) as string[];
 
-  if (sql.includes("FROM connections")) {
+  // Post-#2744 `isConnectionVisibleInMode` queries `workspace_plugins`
+  // (pillar='datasource') and projects `install_id AS id`. The status
+  // clause is the same — published mode restricts to `status = 'published'`,
+  // developer mode expands to `status IN ('published', 'draft')`.
+  if (sql.includes("FROM workspace_plugins")) {
     const published = sql.includes("status = 'published'");
     const overlay = sql.includes("status IN ('published', 'draft')");
     const allowedStatuses = new Set<"published" | "draft">(
@@ -63,8 +67,7 @@ const { getSemanticRoot } = syncMod;
 // Connection visibility
 // ---------------------------------------------------------------------------
 
-// TODO(#2744 step 5 — test sweep): mocks reference dropped `connections` / `connection_groups` SQL; rewrite to workspace_plugins (pillar='datasource') shape.
-describe.skip("isConnectionVisibleInMode", () => {
+describe("isConnectionVisibleInMode", () => {
   beforeEach(() => {
     connectionRows = [];
     mockInternalQuery.mockClear();

--- a/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
@@ -1170,10 +1170,11 @@ describeIfPg("migrate-pg (real Postgres)", () => {
   // CHECK so a regression that drops either column or admits a stray value
   // (`oauth2`, `oAuth`, etc.) fails the migrate smoke instead of landing
   // an un-dispatchable catalog row in production.
-  // TODO(#2744 step 5 — test sweep): tests assert trigger-derived `pillar`
-  // defaulting that 0096 step 7 drops. Re-write to assert post-cutover
-  // explicit-pillar-required behavior in a follow-up.
-  it.skip("0087: plugin_catalog.install_model + saas_eligible columns exist and CHECK is enforced", async () => {
+  // Post-#2744 the 0092 BEFORE INSERT trigger that filled pillar is gone
+  // (dropped by 0096 step 7), so every plugin_catalog INSERT must now
+  // name `pillar` explicitly. The 0087 column-existence + CHECK
+  // assertions stay relevant; we just thread pillar through.
+  it("0087: plugin_catalog.install_model + saas_eligible columns exist and CHECK is enforced", async () => {
     const slug = `pg-smoke-${Date.now()}`;
     const id = `cat-${slug}`;
 
@@ -1181,8 +1182,8 @@ describeIfPg("migrate-pg (real Postgres)", () => {
     // saas_eligible. Defaults are tested by the seeder unit tests; here
     // we just confirm the columns accept the documented enum values.
     await pool.query(
-      `INSERT INTO plugin_catalog (id, name, slug, type, install_model, saas_eligible)
-       VALUES ($1, 'PG Smoke Catalog Entry', $2, 'chat', 'oauth', true)`,
+      `INSERT INTO plugin_catalog (id, name, slug, type, pillar, install_model, saas_eligible)
+       VALUES ($1, 'PG Smoke Catalog Entry', $2, 'chat', 'chat', 'oauth', true)`,
       [id, slug],
     );
 
@@ -1197,8 +1198,8 @@ describeIfPg("migrate-pg (real Postgres)", () => {
     // CHECK rejects an unknown install_model with 23514 (check_violation).
     await expect(
       pool.query(
-        `INSERT INTO plugin_catalog (id, name, slug, type, install_model)
-         VALUES ($1, 'Should Fail', $2, 'chat', 'not-a-model')`,
+        `INSERT INTO plugin_catalog (id, name, slug, type, pillar, install_model)
+         VALUES ($1, 'Should Fail', $2, 'chat', 'chat', 'not-a-model')`,
         [`${id}-bad`, `${slug}-bad`],
       ),
     ).rejects.toMatchObject({ code: "23514" });
@@ -1206,19 +1207,23 @@ describeIfPg("migrate-pg (real Postgres)", () => {
     // CHECK also accepts the other two documented values.
     for (const value of ["form", "static-bot"] as const) {
       await pool.query(
-        `INSERT INTO plugin_catalog (id, name, slug, type, install_model)
-         VALUES ($1, 'PG Smoke', $2, 'integration', $3)`,
+        `INSERT INTO plugin_catalog (id, name, slug, type, pillar, install_model)
+         VALUES ($1, 'PG Smoke', $2, 'integration', 'action', $3)`,
         [`${id}-${value}`, `${slug}-${value}`, value],
       );
     }
 
     // The widened `type` CHECK admits 'chat' and 'integration' alongside
-    // the legacy values. Lock both new values down.
-    for (const t of ["chat", "integration"] as const) {
+    // the legacy values. Lock both new values down — pillar mirrors type
+    // here so the test fixture is faithful to the production catalog seed.
+    for (const [t, pillar] of [
+      ["chat", "chat"],
+      ["integration", "action"],
+    ] as const) {
       await pool.query(
-        `INSERT INTO plugin_catalog (id, name, slug, type, install_model)
-         VALUES ($1, 'PG Smoke Type', $2, $3, 'oauth')`,
-        [`${id}-type-${t}`, `${slug}-type-${t}`, t],
+        `INSERT INTO plugin_catalog (id, name, slug, type, pillar, install_model)
+         VALUES ($1, 'PG Smoke Type', $2, $3, $4, 'oauth')`,
+        [`${id}-type-${t}`, `${slug}-type-${t}`, t, pillar],
       );
     }
   }, PG_TEST_TIMEOUT_MS);
@@ -1228,14 +1233,16 @@ describeIfPg("migrate-pg (real Postgres)", () => {
   // "tidying" revision that drops them. Without defaults, a row that
   // omits the columns lands NULL, which fails the CHECK (install_model)
   // or breaks downstream consumers (saas_eligible).
-  // TODO(#2744 step 5 — test sweep): same trigger dependency as above.
-  it.skip("0087: install_model + saas_eligible defaults apply on omission", async () => {
+  it("0087: install_model + saas_eligible defaults apply on omission", async () => {
     const slug = `pg-default-${Date.now()}`;
     const id = `cat-${slug}`;
 
+    // Post-#2744 the pillar trigger is gone — must name pillar explicitly.
+    // The 0087 defaults under test (install_model + saas_eligible) are
+    // orthogonal: they still default cleanly when the caller omits them.
     await pool.query(
-      `INSERT INTO plugin_catalog (id, name, slug, type)
-       VALUES ($1, 'PG Default Smoke', $2, 'chat')`,
+      `INSERT INTO plugin_catalog (id, name, slug, type, pillar)
+       VALUES ($1, 'PG Default Smoke', $2, 'chat', 'chat')`,
       [id, slug],
     );
 
@@ -1289,700 +1296,21 @@ describeIfPg("migrate-pg (real Postgres)", () => {
   // it verbatim — drift in the file (column rename, ON CONFLICT typo,
   // wrong substring offset) fails the smoke instead of silently passing
   // a hand-rolled copy. Pinned by pr-test-analyzer review on #2692.
-  // TODO(#2744 step 5 — test sweep): 0088 replays migration SQL that
-  // relies on the 0092 BEFORE-INSERT trigger to fill in `pillar` /
-  // `install_id` — both dropped by 0096 step 7. Rewrite to insert
-  // pillar+install_id explicitly in a follow-up.
-  describe.skip("0088: backfill workspace_plugins from chat_cache (#2655)", () => {
-    const migration0088Sql = readFileSync(
-      join(
-        import.meta.dir,
-        "..",
-        "migrations",
-        "0088_backfill_workspace_plugins.sql",
-      ),
-      "utf-8",
-    );
+  // 0088 backfill describe removed in #2786 (post-#2744 cleanup).
+  //
+  // The block re-executed migration 0088's actual SQL via `readFileSync`
+  // to assert idempotency + slug-JOIN robustness. The replay path stops
+  // working post-0096: 0088 INSERTs `workspace_plugins` without naming
+  // `pillar` / `install_id` and relied on 0092's BEFORE INSERT trigger
+  // to fill them. 0096 step 7 drops the trigger, so re-running 0088
+  // against the post-0096 schema fails with 23502 on `pillar`. The
+  // production migration chain still runs 0088 once at the right point
+  // (between 0092 trigger creation and 0096 trigger drop), and the
+  // migration smoke at `beforeAll` covers that end-to-end. Post-cutover
+  // invariants (workspace_plugins shape, status column, demo per-workspace
+  // backfill) live in the `0096: cutover` describe at the bottom of
+  // this file.
 
-    it("inserts workspace_plugins rows for chat_cache:slack:installation rows with non-empty orgId", async () => {
-      const ws = "org-backfill-smoke";
-      const team = `T-backfill-${Date.now()}`;
-      // Write a chat_cache row in the post-#2634 consolidated shape.
-      await pool.query(
-        `INSERT INTO chat_cache (key, value)
-         VALUES ($1, $2::jsonb)
-         ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value`,
-        [
-          `slack:installation:${team}`,
-          JSON.stringify({
-            botToken: "xoxb-backfill-smoke",
-            orgId: ws,
-            workspaceName: "Backfill Smoke",
-            installedAt: "2026-01-01T00:00:00.000Z",
-          }),
-        ],
-      );
-      // Re-execute the migration's actual SQL verbatim. The migration
-      // runner already replayed it at beforeAll (so `catalog:slack` row
-      // exists); this run picks up the new chat_cache row via the
-      // INSERT…SELECT sweep.
-      await pool.query(migration0088Sql);
-      const { rows: after } = await pool.query<{
-        catalog_id: string;
-        config: { team_id: string; backfilled_from: string };
-      }>(
-        `SELECT wp.catalog_id, wp.config
-           FROM workspace_plugins wp
-           JOIN plugin_catalog pc ON pc.id = wp.catalog_id
-          WHERE pc.slug = 'slack' AND wp.workspace_id = $1
-          LIMIT 1`,
-        [ws],
-      );
-      expect(after).toHaveLength(1);
-      expect(after[0]?.config.team_id).toBe(team);
-      expect(after[0]?.config.backfilled_from).toBe("chat_cache (migration 0088)");
-    }, PG_TEST_TIMEOUT_MS);
-
-    it("resolves catalog_id via slug JOIN, not the literal 'catalog:slack' string (Codex P1)", async () => {
-      // Codex flagged on #2692: if `plugin_catalog` already carried a
-      // `slug='slack'` row with a non-`catalog:slack` id (admin-marketplace
-      // mints UUIDs via `crypto.randomUUID()`), the migration's
-      // `ON CONFLICT (slug) DO NOTHING` keeps the legacy id, and a
-      // hard-coded `'catalog:slack'` FK target would abort with a
-      // foreign-key violation. Pinning the slug-JOIN posture here.
-      const customCatalogId = `cat-custom-${Date.now()}`;
-      const customSlug = `custom-slack-${Date.now()}`;
-      const ws = `org-custom-${Date.now()}`;
-      const team = `T-custom-${Date.now()}`;
-
-      // Pre-seed plugin_catalog with a non-canonical id but slug=custom-slack.
-      // (Using a non-'slack' slug so we don't disturb the dogfood catalog row.)
-      await pool.query(
-        `INSERT INTO plugin_catalog (id, name, slug, type, install_model, enabled)
-         VALUES ($1, 'Custom Slack', $2, 'chat', 'oauth', true)`,
-        [customCatalogId, customSlug],
-      );
-      await pool.query(
-        `INSERT INTO chat_cache (key, value)
-         VALUES ($1, $2::jsonb)
-         ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value`,
-        [
-          `slack:installation:${team}`,
-          JSON.stringify({ botToken: "xoxb-custom", orgId: ws }),
-        ],
-      );
-      // Run the equivalent slug-JOIN INSERT against the custom slug.
-      // Demonstrates the JOIN pattern is robust to non-canonical
-      // catalog ids — exactly what the Codex P1 fix protects against.
-      await pool.query(
-        `INSERT INTO workspace_plugins
-          (id, workspace_id, catalog_id, config, enabled, installed_at)
-         SELECT
-           gen_random_uuid()::text,
-           cc.value ->> 'orgId',
-           pc.id,
-           jsonb_build_object('team_id', substring(cc.key FROM length('slack:installation:') + 1)),
-           true,
-           NOW()
-         FROM chat_cache cc
-         JOIN plugin_catalog pc ON pc.slug = $2
-         WHERE cc.key LIKE 'slack:installation:%'
-           AND cc.value ->> 'orgId' = $1
-         ON CONFLICT (workspace_id, catalog_id) DO NOTHING`,
-        [ws, customSlug],
-      );
-      const { rows } = await pool.query<{ catalog_id: string }>(
-        `SELECT catalog_id FROM workspace_plugins WHERE workspace_id = $1`,
-        [ws],
-      );
-      // FK resolved against the pre-seeded id, not 'catalog:custom-slack'.
-      expect(rows[0]?.catalog_id).toBe(customCatalogId);
-    }, PG_TEST_TIMEOUT_MS);
-
-    it("is idempotent — re-running the migration SQL does not duplicate", async () => {
-      const ws = "org-backfill-idempotent";
-      const team = `T-idem-${Date.now()}`;
-      await pool.query(
-        `INSERT INTO chat_cache (key, value)
-         VALUES ($1, $2::jsonb)
-         ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value`,
-        [
-          `slack:installation:${team}`,
-          JSON.stringify({ botToken: "xoxb-idem", orgId: ws }),
-        ],
-      );
-      await pool.query(migration0088Sql);
-      await pool.query(migration0088Sql);
-      await pool.query(migration0088Sql);
-      const { rows } = await pool.query<{ n: string }>(
-        `SELECT COUNT(*)::text AS n FROM workspace_plugins wp
-           JOIN plugin_catalog pc ON pc.id = wp.catalog_id
-          WHERE pc.slug = 'slack' AND wp.workspace_id = $1`,
-        [ws],
-      );
-      // Three runs, one row — the composite unique index does the job.
-      expect(rows[0]?.n).toBe("1");
-    }, PG_TEST_TIMEOUT_MS);
-
-    it("skips chat_cache rows with NULL or empty orgId (no FK-less workspace_plugins rows)", async () => {
-      const team = `T-noorg-${Date.now()}`;
-      await pool.query(
-        `INSERT INTO chat_cache (key, value)
-         VALUES ($1, $2::jsonb)
-         ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value`,
-        [
-          `slack:installation:${team}`,
-          // No orgId at all.
-          JSON.stringify({ botToken: "xoxb-noorg" }),
-        ],
-      );
-      // Run the migration's actual SQL — it sweeps every chat_cache
-      // installation row, so this exercises the WHERE-filter against
-      // a real orgId-less row sitting in the table.
-      await pool.query(migration0088Sql);
-      const after = await pool.query<{ n: string }>(
-        `SELECT COUNT(*)::text AS n FROM workspace_plugins wp
-           JOIN plugin_catalog pc ON pc.id = wp.catalog_id
-          WHERE pc.slug = 'slack' AND wp.config ->> 'team_id' = $1`,
-        [team],
-      );
-      // Orphan row was orgId-less → migration's WHERE clause filtered
-      // it out, so no workspace_plugins row carries our team_id.
-      expect(after.rows[0]?.n).toBe("0");
-    }, PG_TEST_TIMEOUT_MS);
-  });
-
-  // 0092 / #2739 — three-pillar taxonomy + install_id foundation.
-  // Schema-only slice: callers under integrations/install/*-handler.ts
-  // continue to omit `pillar` and `install_id`; two BEFORE INSERT
-  // triggers fill them in. These tests pin trigger fill (both tables),
-  // trigger non-clobber, CHECK enforcement (both pillar columns +
-  // implementation_status), defaults-on-omission, the composite PK,
-  // the partial unique singleton, the preserved `id` uniqueness, the
-  // diagnostic 23503 the workspace trigger raises on orphan catalog_id,
-  // and the prod-critical backfill regression — the prior-art "fresh
-  // self-host upgrade" path subsequent slices depend on.
-  // TODO(#2744 step 5 — test sweep): 0092 describe tests the BEFORE
-  // INSERT/UPDATE triggers, the partial unique 'workspace_plugins_singleton',
-  // and the global unique on (workspace_id, catalog_id). All three are
-  // dropped by 0096 step 6 + step 7. The post-cutover invariants live
-  // in the new 0096 cutover describe at the bottom of this file.
-  describe.skip("0092: pillar + install_id columns (#2739, 1.5.3 slice 1)", () => {
-    it("plugin_catalog: new columns + CHECK constraints are enforced (pillar, implementation_status)", async () => {
-      const slug = `pg-0092-${Date.now()}`;
-      const id = `cat-${slug}`;
-
-      // Insert with all three new columns explicit — exercises that the
-      // columns exist with the documented types and that explicit values
-      // round-trip (no SELECT pillar/implementation_status/auto_install
-      // semantics happen in production code yet — slice 3+ wire reads).
-      await pool.query(
-        `INSERT INTO plugin_catalog (id, name, slug, type, pillar, implementation_status, auto_install)
-         VALUES ($1, '0092 Smoke', $2, 'integration', 'action', 'available', false)`,
-        [id, slug],
-      );
-
-      const { rows } = await pool.query<{
-        pillar: string;
-        implementation_status: string;
-        auto_install: boolean;
-      }>(
-        `SELECT pillar, implementation_status, auto_install FROM plugin_catalog WHERE id = $1`,
-        [id],
-      );
-      expect(rows[0]?.pillar).toBe("action");
-      expect(rows[0]?.implementation_status).toBe("available");
-      expect(rows[0]?.auto_install).toBe(false);
-
-      // CHECK rejects unknown pillar with 23514.
-      await expect(
-        pool.query(
-          `INSERT INTO plugin_catalog (id, name, slug, type, pillar)
-           VALUES ($1, 'Bad Pillar', $2, 'chat', 'something-else')`,
-          [`${id}-bad-pillar`, `${slug}-bad-pillar`],
-        ),
-      ).rejects.toMatchObject({ code: "23514" });
-
-      // CHECK rejects unknown implementation_status with 23514.
-      await expect(
-        pool.query(
-          `INSERT INTO plugin_catalog (id, name, slug, type, pillar, implementation_status)
-           VALUES ($1, 'Bad Status', $2, 'chat', 'chat', 'totally-shipped')`,
-          [`${id}-bad-status`, `${slug}-bad-status`],
-        ),
-      ).rejects.toMatchObject({ code: "23514" });
-    }, PG_TEST_TIMEOUT_MS);
-
-    it("plugin_catalog: trigger derives pillar from type (chat/datasource/integration) when caller omits pillar", async () => {
-      // Three call sites today (admin-marketplace.ts, catalog-seeder.ts,
-      // migration 0088) INSERT plugin_catalog rows without naming
-      // pillar. Trigger must map type → pillar correctly for each.
-      const slug = `pg-0092-cat-trig-${Date.now()}`;
-
-      type Row = { pillar: string };
-      const cases: Array<{ type: string; expected: string }> = [
-        { type: "chat", expected: "chat" },
-        { type: "datasource", expected: "datasource" },
-        { type: "integration", expected: "action" },
-        { type: "action", expected: "action" },
-      ];
-
-      for (const { type, expected } of cases) {
-        const id = `cat-${slug}-${type}`;
-        await pool.query(
-          `INSERT INTO plugin_catalog (id, name, slug, type) VALUES ($1, '0092 Trigger', $2, $3)`,
-          [id, `${slug}-${type}`, type],
-        );
-        const { rows } = await pool.query<Row>(
-          `SELECT pillar FROM plugin_catalog WHERE id = $1`,
-          [id],
-        );
-        expect(rows[0]?.pillar).toBe(expected);
-      }
-    }, PG_TEST_TIMEOUT_MS);
-
-    it("plugin_catalog: trigger does NOT clobber caller-provided pillar", async () => {
-      // Load-bearing for slice 5 (#2743): once built-in Datasource
-      // catalog rows are seeded with explicit pillar, a future
-      // "simplification" that drops the `IF NEW.pillar IS NULL` guard
-      // would silently rewrite their pillar from the CASE expression
-      // (e.g. a `type='datasource', pillar='datasource'` row stays at
-      // datasource — but a future `type='custom', pillar='chat'` row
-      // would silently get rewritten to 'action').
-      const slug = `pg-0092-cat-noclobber-${Date.now()}`;
-      const id = `cat-${slug}`;
-      // type='datasource' would auto-derive pillar='datasource'; we
-      // pass pillar='chat' explicitly to prove the guard holds even
-      // when the CASE would produce a different value.
-      await pool.query(
-        `INSERT INTO plugin_catalog (id, name, slug, type, pillar)
-         VALUES ($1, '0092 No-Clobber', $2, 'datasource', 'chat')`,
-        [id, slug],
-      );
-      const { rows } = await pool.query<{ pillar: string }>(
-        `SELECT pillar FROM plugin_catalog WHERE id = $1`,
-        [id],
-      );
-      expect(rows[0]?.pillar).toBe("chat");
-    }, PG_TEST_TIMEOUT_MS);
-
-    it("plugin_catalog: BEFORE UPDATE trigger re-derives pillar when type changes (UPDATE without naming pillar)", async () => {
-      // Codex P1 on PR #2756: catalog-seeder upsert (`SET type =
-      // EXCLUDED.type`) and admin marketplace PATCH both UPDATE type
-      // on existing rows. Without the UPDATE trigger, pillar drifts
-      // and the workspace_plugins INSERT trigger propagates the stale
-      // value.
-      const slug = `pg-0092-cat-update-${Date.now()}`;
-      const id = `cat-${slug}`;
-
-      await pool.query(
-        `INSERT INTO plugin_catalog (id, name, slug, type) VALUES ($1, '0092 Update Trigger', $2, 'chat')`,
-        [id, slug],
-      );
-      // INSERT trigger derives pillar='chat' from type='chat'.
-      let { rows } = await pool.query<{ pillar: string }>(
-        `SELECT pillar FROM plugin_catalog WHERE id = $1`,
-        [id],
-      );
-      expect(rows[0]?.pillar).toBe("chat");
-
-      // Update type only — UPDATE trigger re-derives pillar.
-      await pool.query(
-        `UPDATE plugin_catalog SET type = 'datasource' WHERE id = $1`,
-        [id],
-      );
-      ({ rows } = await pool.query<{ pillar: string }>(
-        `SELECT pillar FROM plugin_catalog WHERE id = $1`,
-        [id],
-      ));
-      expect(rows[0]?.pillar).toBe("datasource");
-
-      // Update type from datasource → integration — pillar follows
-      // to 'action'.
-      await pool.query(
-        `UPDATE plugin_catalog SET type = 'integration' WHERE id = $1`,
-        [id],
-      );
-      ({ rows } = await pool.query<{ pillar: string }>(
-        `SELECT pillar FROM plugin_catalog WHERE id = $1`,
-        [id],
-      ));
-      expect(rows[0]?.pillar).toBe("action");
-    }, PG_TEST_TIMEOUT_MS);
-
-    it("plugin_catalog: BEFORE UPDATE trigger does NOT clobber when caller updates both type AND pillar", async () => {
-      // Same UPDATE statement names both columns to different values:
-      // the explicit pillar wins. Locks the `IS NOT DISTINCT FROM`
-      // guard against a future revision that drops it.
-      const slug = `pg-0092-cat-update-noclobber-${Date.now()}`;
-      const id = `cat-${slug}`;
-
-      await pool.query(
-        `INSERT INTO plugin_catalog (id, name, slug, type, pillar) VALUES ($1, '0092 Update No-Clobber', $2, 'chat', 'chat')`,
-        [id, slug],
-      );
-
-      // Update type='datasource' would normally derive pillar='datasource';
-      // caller explicitly says pillar='action' — explicit wins.
-      await pool.query(
-        `UPDATE plugin_catalog SET type = 'datasource', pillar = 'action' WHERE id = $1`,
-        [id],
-      );
-      const { rows } = await pool.query<{ type: string; pillar: string }>(
-        `SELECT type, pillar FROM plugin_catalog WHERE id = $1`,
-        [id],
-      );
-      expect(rows[0]?.type).toBe("datasource");
-      expect(rows[0]?.pillar).toBe("action");
-    }, PG_TEST_TIMEOUT_MS);
-
-    it("plugin_catalog: BEFORE UPDATE trigger leaves pillar alone when only unrelated columns change", async () => {
-      // Updating description/enabled/etc. must not touch pillar — the
-      // trigger guard `NEW.type IS DISTINCT FROM OLD.type` short-
-      // circuits when type didn't change.
-      const slug = `pg-0092-cat-update-unrelated-${Date.now()}`;
-      const id = `cat-${slug}`;
-
-      // Insert with explicit non-trigger-mapped pillar (chat for a
-      // datasource-typed row) so a stray "re-derive on every update"
-      // would visibly rewrite to 'datasource'.
-      await pool.query(
-        `INSERT INTO plugin_catalog (id, name, slug, type, pillar) VALUES ($1, '0092 Update Untouched', $2, 'datasource', 'chat')`,
-        [id, slug],
-      );
-
-      await pool.query(
-        `UPDATE plugin_catalog SET description = 'updated description' WHERE id = $1`,
-        [id],
-      );
-      const { rows } = await pool.query<{ pillar: string }>(
-        `SELECT pillar FROM plugin_catalog WHERE id = $1`,
-        [id],
-      );
-      expect(rows[0]?.pillar).toBe("chat");
-    }, PG_TEST_TIMEOUT_MS);
-
-    it("plugin_catalog: implementation_status + auto_install defaults apply on omission", async () => {
-      // Pinned by silent-failure review on #2756 — guards the
-      // `DEFAULT 'available'` / `DEFAULT false` clauses against a
-      // future revision that drops them. Without defaults, a row that
-      // omits the columns lands NULL, which fails the
-      // implementation_status CHECK (23514).
-      const slug = `pg-0092-cat-defaults-${Date.now()}`;
-      const id = `cat-${slug}`;
-      await pool.query(
-        `INSERT INTO plugin_catalog (id, name, slug, type) VALUES ($1, '0092 Defaults', $2, 'integration')`,
-        [id, slug],
-      );
-      const { rows } = await pool.query<{
-        implementation_status: string;
-        auto_install: boolean;
-      }>(
-        `SELECT implementation_status, auto_install FROM plugin_catalog WHERE id = $1`,
-        [id],
-      );
-      expect(rows[0]?.implementation_status).toBe("available");
-      expect(rows[0]?.auto_install).toBe(false);
-    }, PG_TEST_TIMEOUT_MS);
-
-    it("workspace_plugins: BEFORE INSERT trigger fills install_id + pillar when caller omits them", async () => {
-      // Seed a catalog row whose pillar will flow through the trigger.
-      const slug = `pg-0092-trig-${Date.now()}`;
-      const catalogId = `cat-${slug}`;
-      await pool.query(
-        `INSERT INTO plugin_catalog (id, name, slug, type, pillar)
-         VALUES ($1, '0092 Trigger Smoke', $2, 'chat', 'chat')`,
-        [catalogId, slug],
-      );
-
-      // Mimic the existing handler INSERT shape (no install_id, no
-      // pillar). Trigger fills both.
-      const installId = `wp-${slug}`;
-      const workspaceId = `ws-${slug}`;
-      await pool.query(
-        `INSERT INTO workspace_plugins (id, workspace_id, catalog_id, config, enabled, installed_at)
-         VALUES ($1, $2, $3, '{}'::jsonb, true, NOW())`,
-        [installId, workspaceId, catalogId],
-      );
-
-      const { rows } = await pool.query<{
-        install_id: string;
-        pillar: string;
-      }>(
-        `SELECT install_id, pillar FROM workspace_plugins WHERE workspace_id = $1 AND catalog_id = $2`,
-        [workspaceId, catalogId],
-      );
-      expect(rows[0]?.install_id).toBe(catalogId);
-      expect(rows[0]?.pillar).toBe("chat");
-    }, PG_TEST_TIMEOUT_MS);
-
-    it("workspace_plugins: partial unique 'workspace_plugins_singleton' blocks a second chat install for the same (workspace, catalog)", async () => {
-      const slug = `pg-0092-uniq-${Date.now()}`;
-      const catalogId = `cat-${slug}`;
-      await pool.query(
-        `INSERT INTO plugin_catalog (id, name, slug, type, pillar)
-         VALUES ($1, '0092 Unique Smoke', $2, 'chat', 'chat')`,
-        [catalogId, slug],
-      );
-
-      const workspaceId = `ws-${slug}`;
-      await pool.query(
-        `INSERT INTO workspace_plugins (id, workspace_id, catalog_id, config, enabled, installed_at)
-         VALUES ($1, $2, $3, '{}'::jsonb, true, NOW())`,
-        [`first-${slug}`, workspaceId, catalogId],
-      );
-
-      // Second insert for the same (workspace, catalog) — different `id`
-      // and `install_id` — should still be blocked. The pre-existing
-      // `idx_workspace_plugins_unique` would catch it too in this slice,
-      // but the partial unique is the post-1.5.3 invariant that survives
-      // slice 5/6's global-unique drop. Either way: 23505.
-      await expect(
-        pool.query(
-          `INSERT INTO workspace_plugins (id, workspace_id, catalog_id, install_id, pillar, config, enabled, installed_at)
-           VALUES ($1, $2, $3, $4, 'chat', '{}'::jsonb, true, NOW())`,
-          [`second-${slug}`, workspaceId, catalogId, `second-install-${slug}`],
-        ),
-      ).rejects.toMatchObject({ code: "23505" });
-    }, PG_TEST_TIMEOUT_MS);
-
-    it("workspace_plugins: composite PK rejects an exact (workspace, catalog, install) duplicate even across pillars", async () => {
-      const slug = `pg-0092-pk-${Date.now()}`;
-      const catalogId = `cat-${slug}`;
-      await pool.query(
-        `INSERT INTO plugin_catalog (id, name, slug, type, pillar)
-         VALUES ($1, '0092 PK Smoke', $2, 'integration', 'action')`,
-        [catalogId, slug],
-      );
-
-      const workspaceId = `ws-${slug}`;
-      const installId = `inst-${slug}`;
-
-      await pool.query(
-        `INSERT INTO workspace_plugins (id, workspace_id, catalog_id, install_id, pillar, config, enabled, installed_at)
-         VALUES ($1, $2, $3, $4, 'action', '{}'::jsonb, true, NOW())`,
-        [`first-${slug}`, workspaceId, catalogId, installId],
-      );
-
-      await expect(
-        pool.query(
-          `INSERT INTO workspace_plugins (id, workspace_id, catalog_id, install_id, pillar, config, enabled, installed_at)
-           VALUES ($1, $2, $3, $4, 'action', '{}'::jsonb, true, NOW())`,
-          [`second-${slug}`, workspaceId, catalogId, installId],
-        ),
-      ).rejects.toMatchObject({ code: "23505" });
-    }, PG_TEST_TIMEOUT_MS);
-
-    it("workspace_plugins: `id` uniqueness preserved after PK swap", async () => {
-      // The dropped single-column PK used to enforce id uniqueness;
-      // `workspace_plugins_id_unique` takes over. Reuse the same id
-      // across two distinct (workspace, catalog) pairs and confirm
-      // the second insert rejects with 23505.
-      const slug = `pg-0092-id-${Date.now()}`;
-      const catalogIdA = `cat-a-${slug}`;
-      const catalogIdB = `cat-b-${slug}`;
-      const sharedId = `shared-${slug}`;
-
-      await pool.query(
-        `INSERT INTO plugin_catalog (id, name, slug, type, pillar)
-         VALUES ($1, '0092 ID Smoke A', $2, 'chat', 'chat'),
-                ($3, '0092 ID Smoke B', $4, 'chat', 'chat')`,
-        [catalogIdA, `${slug}-a`, catalogIdB, `${slug}-b`],
-      );
-
-      await pool.query(
-        `INSERT INTO workspace_plugins (id, workspace_id, catalog_id, config, enabled, installed_at)
-         VALUES ($1, $2, $3, '{}'::jsonb, true, NOW())`,
-        [sharedId, `ws-${slug}`, catalogIdA],
-      );
-
-      await expect(
-        pool.query(
-          `INSERT INTO workspace_plugins (id, workspace_id, catalog_id, config, enabled, installed_at)
-           VALUES ($1, $2, $3, '{}'::jsonb, true, NOW())`,
-          [sharedId, `ws-${slug}`, catalogIdB],
-        ),
-      ).rejects.toMatchObject({ code: "23505" });
-    }, PG_TEST_TIMEOUT_MS);
-
-    it("workspace_plugins: trigger does NOT clobber caller-provided install_id + pillar", async () => {
-      // Slice 4 (WorkspaceInstaller, #2742) will explicitly name both
-      // columns. The `IF NEW.x IS NULL` guards are load-bearing then —
-      // a "simplification" that drops them would silently rewrite the
-      // explicit values from the catalog lookup / sentinel.
-      const slug = `pg-0092-wp-noclobber-${Date.now()}`;
-      const catalogId = `cat-${slug}`;
-      await pool.query(
-        `INSERT INTO plugin_catalog (id, name, slug, type, pillar)
-         VALUES ($1, '0092 No-Clobber', $2, 'integration', 'action')`,
-        [catalogId, slug],
-      );
-
-      const explicitInstallId = `prod-us-${slug}`;
-      const workspaceId = `ws-${slug}`;
-      // Caller passes pillar='datasource' even though catalog says
-      // 'action' — proves the trigger doesn't second-guess explicit
-      // values via its catalog SELECT.
-      await pool.query(
-        `INSERT INTO workspace_plugins (id, workspace_id, catalog_id, install_id, pillar, config, enabled, installed_at)
-         VALUES ($1, $2, $3, $4, 'datasource', '{}'::jsonb, true, NOW())`,
-        [`wp-${slug}`, workspaceId, catalogId, explicitInstallId],
-      );
-
-      const { rows } = await pool.query<{ install_id: string; pillar: string }>(
-        `SELECT install_id, pillar FROM workspace_plugins WHERE workspace_id = $1 AND catalog_id = $2`,
-        [workspaceId, catalogId],
-      );
-      expect(rows[0]?.install_id).toBe(explicitInstallId);
-      expect(rows[0]?.pillar).toBe("datasource");
-    }, PG_TEST_TIMEOUT_MS);
-
-    it("workspace_plugins: chk_workspace_plugins_pillar rejects unknown pillar with 23514", async () => {
-      // Separate constraint from `chk_plugin_catalog_pillar` — a
-      // missing `ADD CONSTRAINT chk_workspace_plugins_pillar` in the
-      // migration would only surface on the catalog side without this
-      // test.
-      const slug = `pg-0092-wp-check-${Date.now()}`;
-      const catalogId = `cat-${slug}`;
-      await pool.query(
-        `INSERT INTO plugin_catalog (id, name, slug, type, pillar)
-         VALUES ($1, '0092 Pillar Check', $2, 'integration', 'action')`,
-        [catalogId, slug],
-      );
-      await expect(
-        pool.query(
-          `INSERT INTO workspace_plugins (id, workspace_id, catalog_id, install_id, pillar, config, enabled, installed_at)
-           VALUES ($1, $2, $3, $4, 'something-else', '{}'::jsonb, true, NOW())`,
-          [`wp-${slug}`, `ws-${slug}`, catalogId, `inst-${slug}`],
-        ),
-      ).rejects.toMatchObject({ code: "23514" });
-    }, PG_TEST_TIMEOUT_MS);
-
-    it("workspace_plugins: backfill UPDATEs assign sentinel install_id + joined pillar for pre-existing NULL rows", async () => {
-      // Prod-critical regression: a self-host upgrade with live rows
-      // walks through ADD COLUMN (NULL on existing rows) → UPDATE
-      // backfill → SET NOT NULL. The full migration has already run
-      // in beforeAll, so we simulate the pre-backfill state inside a
-      // transaction: drop the NOT NULLs, disable the trigger so we
-      // can insert NULLs, replay the migration's UPDATE statements,
-      // assert. Postgres DDL is transactional — ROLLBACK reverts every
-      // change so subsequent tests see the unchanged shape.
-      const slug = `pg-0092-backfill-${Date.now()}`;
-      const catalogId = `cat-${slug}`;
-      const workspaceId = `ws-${slug}`;
-      const installRowId = `wp-${slug}`;
-
-      const client = await pool.connect();
-      try {
-        await client.query("BEGIN");
-        // Mimic the post-ADD-COLUMN, pre-UPDATE state of the live
-        // migration:
-        //   1. Drop the composite PK so install_id can lose its
-        //      implicit NOT NULL (PK columns can't be nullable).
-        //   2. Drop the explicit NOT NULLs on pillar + install_id.
-        //   3. Disable the BEFORE INSERT triggers so we can stage
-        //      NULL rows.
-        // Postgres DDL is transactional — ROLLBACK reverts every
-        // change so subsequent tests see the unchanged shape.
-        await client.query(
-          `ALTER TABLE workspace_plugins DROP CONSTRAINT workspace_plugins_pkey`,
-        );
-        await client.query(
-          `ALTER TABLE plugin_catalog ALTER COLUMN pillar DROP NOT NULL`,
-        );
-        await client.query(
-          `ALTER TABLE workspace_plugins ALTER COLUMN pillar DROP NOT NULL`,
-        );
-        await client.query(
-          `ALTER TABLE workspace_plugins ALTER COLUMN install_id DROP NOT NULL`,
-        );
-        await client.query(
-          `ALTER TABLE plugin_catalog DISABLE TRIGGER trg_plugin_catalog_default_pillar`,
-        );
-        await client.query(
-          `ALTER TABLE workspace_plugins DISABLE TRIGGER trg_workspace_plugins_default_pillar_install_id`,
-        );
-
-        await client.query(
-          `INSERT INTO plugin_catalog (id, name, slug, type, pillar)
-           VALUES ($1, '0092 Backfill', $2, 'chat', NULL)`,
-          [catalogId, slug],
-        );
-        await client.query(
-          `INSERT INTO workspace_plugins (id, workspace_id, catalog_id, install_id, pillar, config, enabled, installed_at)
-           VALUES ($1, $2, $3, NULL, NULL, '{}'::jsonb, true, NOW())`,
-          [installRowId, workspaceId, catalogId],
-        );
-
-        // Replay the migration's backfill — three plugin_catalog
-        // UPDATEs, then the workspace_plugins UPDATE that sets
-        // install_id = catalog_id sentinel, then the join that sets
-        // workspace_plugins.pillar from the now-populated catalog.
-        await client.query(
-          `UPDATE plugin_catalog SET pillar = 'chat'       WHERE pillar IS NULL AND type = 'chat'`,
-        );
-        await client.query(
-          `UPDATE plugin_catalog SET pillar = 'datasource' WHERE pillar IS NULL AND type = 'datasource'`,
-        );
-        await client.query(
-          `UPDATE plugin_catalog SET pillar = 'action'     WHERE pillar IS NULL`,
-        );
-        await client.query(
-          `UPDATE workspace_plugins SET install_id = catalog_id WHERE install_id IS NULL`,
-        );
-        await client.query(
-          `UPDATE workspace_plugins wp SET pillar = pc.pillar FROM plugin_catalog pc WHERE pc.id = wp.catalog_id AND wp.pillar IS NULL`,
-        );
-
-        const { rows } = await client.query<{
-          install_id: string;
-          pillar: string;
-        }>(
-          `SELECT install_id, pillar FROM workspace_plugins WHERE id = $1`,
-          [installRowId],
-        );
-        expect(rows[0]?.install_id).toBe(catalogId);
-        expect(rows[0]?.pillar).toBe("chat");
-
-        const { rows: catRows } = await client.query<{ pillar: string }>(
-          `SELECT pillar FROM plugin_catalog WHERE id = $1`,
-          [catalogId],
-        );
-        expect(catRows[0]?.pillar).toBe("chat");
-      } finally {
-        await client.query("ROLLBACK");
-        client.release();
-      }
-    }, PG_TEST_TIMEOUT_MS);
-
-    it("workspace_plugins: orphan catalog_id surfaces 23503 from the trigger, not 23502 from NOT NULL", async () => {
-      // The trigger raises a FK-style 23503 with a diagnostic message
-      // naming the missing catalog_id, instead of letting the row fall
-      // through to a confusing `NULL value in column "pillar"` NOT NULL
-      // violation. The real FK normally prevents this path; the trigger
-      // is a belt-and-braces diagnostic. To exercise it we drop the FK
-      // inside a transaction and roll back — works without superuser
-      // (unlike SET session_replication_role).
-      const slug = `pg-0092-orphan-${Date.now()}`;
-      const client = await pool.connect();
-      try {
-        await client.query("BEGIN");
-        await client.query(
-          `ALTER TABLE workspace_plugins DROP CONSTRAINT workspace_plugins_catalog_id_fkey`,
-        );
-        await expect(
-          client.query(
-            `INSERT INTO workspace_plugins (id, workspace_id, catalog_id, config, enabled, installed_at)
-             VALUES ($1, $2, $3, '{}'::jsonb, true, NOW())`,
-            [`wp-${slug}`, `ws-${slug}`, `does-not-exist-${slug}`],
-          ),
-        ).rejects.toMatchObject({ code: "23503" });
-      } finally {
-        await client.query("ROLLBACK");
-        client.release();
-      }
-    }, PG_TEST_TIMEOUT_MS);
-  });
 
   // ─────────────────────────────────────────────────────────────────────
   // 0096: connections / connection_groups cutover (#2744, 1.5.3 slice 6)

--- a/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
@@ -1310,6 +1310,25 @@ describeIfPg("migrate-pg (real Postgres)", () => {
   // invariants (workspace_plugins shape, status column, demo per-workspace
   // backfill) live in the `0096: cutover` describe at the bottom of
   // this file.
+  //
+  // 0092 pillar+install_id describe also removed in #2786. It asserted:
+  //   (a) trigger-derived `pillar` defaulting on plugin_catalog INSERT,
+  //   (b) trigger non-clobber on caller-supplied pillar (INSERT + UPDATE),
+  //   (c) `workspace_plugins` BEFORE INSERT trigger filling `pillar` +
+  //       `install_id` when callers omit them,
+  //   (d) the partial unique `workspace_plugins_singleton` index + the
+  //       global `(workspace_id, catalog_id)` unique,
+  //   (e) the prod-critical fresh-self-host backfill UPDATE chain.
+  // 0096 step 7 drops all three triggers; 0096 step 6 collapses the
+  // unique indexes into the composite PK `(workspace_id, catalog_id,
+  // install_id)`. None of (a)–(d) describe behavior that survives 0096,
+  // so replay would either trip 23514 (CHECK on now-required pillar)
+  // or 23505 against the new PK. (e) was a one-shot upgrade-path
+  // assertion that doesn't apply once the schema is stable. The
+  // post-cutover schema shape (CHECK constraints on pillar, NOT NULL
+  // on pillar+install_id, composite PK, demo per-workspace backfill,
+  // `status` column) is covered structurally by the `0096: cutover`
+  // describe + the full migration replay at `beforeAll`.
 
 
   // ─────────────────────────────────────────────────────────────────────

--- a/packages/api/src/lib/env-routing/__tests__/lookup.test.ts
+++ b/packages/api/src/lib/env-routing/__tests__/lookup.test.ts
@@ -14,7 +14,6 @@ import { describe, it, expect, beforeEach, mock } from "bun:test";
 let mockHasInternalDB = true;
 let mockConnRows: { group_id: string | null }[] = [];
 let mockMemberRows: { id: string }[] = [];
-let mockGroupRows: { primary_connection_id: string | null }[] = [];
 let mockShouldThrow: Error | null = null;
 let mockQueryCalls: { sql: string; params: unknown[] | undefined }[] = [];
 
@@ -23,17 +22,16 @@ mock.module("@atlas/api/lib/db/internal", () => ({
   internalQuery: async (sql: string, params?: unknown[]) => {
     mockQueryCalls.push({ sql, params });
     if (mockShouldThrow) throw mockShouldThrow;
-    // Step 1 fetches `group_id` from `connections`.
-    if (sql.includes("FROM connections") && sql.includes("group_id") && !sql.includes("WHERE group_id")) {
+    // Post-#2744 the helper hits `workspace_plugins` in two steps:
+    //   1. Look up the install's `config->>'group_id'` (matched by install_id).
+    //   2. Aggregate sibling installs sharing the same group_id.
+    // The legacy `connection_groups` table (and its `primary_connection_id`
+    // column) is gone — `members[0]` is the deterministic primary now.
+    if (sql.includes("FROM workspace_plugins") && sql.includes("WHERE install_id = $1")) {
       return mockConnRows;
     }
-    // Step 2a fetches member ids.
-    if (sql.includes("FROM connections") && sql.includes("WHERE group_id")) {
+    if (sql.includes("FROM workspace_plugins") && sql.includes("config->>'group_id' = $1")) {
       return mockMemberRows;
-    }
-    // Step 2b fetches the group's primary.
-    if (sql.includes("FROM connection_groups")) {
-      return mockGroupRows;
     }
     return [];
   },
@@ -46,7 +44,6 @@ describe("loadGroupRoutingContext — 1×1 fallback paths", () => {
     mockHasInternalDB = true;
     mockConnRows = [];
     mockMemberRows = [];
-    mockGroupRows = [];
     mockShouldThrow = null;
     mockQueryCalls = [];
   });
@@ -103,51 +100,43 @@ describe("loadGroupRoutingContext — 1×1 fallback paths", () => {
   });
 });
 
-// TODO(#2744 step 5 — test sweep): mocks reference dropped `connections` / `connection_groups` SQL; rewrite to workspace_plugins (pillar='datasource') shape.
-describe.skip("loadGroupRoutingContext — multi-member resolution", () => {
+describe("loadGroupRoutingContext — multi-member resolution (post-cutover)", () => {
+  // Post-#2744 there's no explicit `primary_connection_id` — the primary
+  // is always the first member returned by `ORDER BY install_id`. The
+  // production SQL sorts alphabetically, so a deterministic mock fixture
+  // matches that contract verbatim.
   beforeEach(() => {
     mockHasInternalDB = true;
     mockConnRows = [];
     mockMemberRows = [];
-    mockGroupRows = [];
     mockShouldThrow = null;
     mockQueryCalls = [];
   });
 
-  it("3-member group with explicit primary → returns all 3 + named primary", async () => {
-    mockConnRows = [{ group_id: "g-prod" }];
+  it("3-member group → returns all 3 with first-alphabetical as primary", async () => {
+    mockConnRows = [{ group_id: "prod" }];
+    // Mock returns rows in the SQL's ORDER BY install_id ordering.
     mockMemberRows = [{ id: "apac" }, { id: "eu" }, { id: "us-int" }];
-    mockGroupRows = [{ primary_connection_id: "us-int" }];
     const ctx = await loadGroupRoutingContext("org-1", "eu");
-    expect(ctx.groupId).toBe("g-prod");
+    expect(ctx.groupId).toBe("prod");
     expect(ctx.members).toEqual(["apac", "eu", "us-int"]);
-    expect(ctx.primaryMember).toBe("us-int");
+    expect(ctx.primaryMember).toBe("apac"); // first by install_id
     expect(ctx.currentMember).toBe("eu");
   });
 
-  it("primary_connection_id NOT in members (stale FK) → first member becomes primary", async () => {
-    mockConnRows = [{ group_id: "g-prod" }];
-    mockMemberRows = [{ id: "apac" }, { id: "eu" }];
-    mockGroupRows = [{ primary_connection_id: "us-int" }]; // not in members
-    const ctx = await loadGroupRoutingContext("org-1", "eu");
-    expect(ctx.primaryMember).toBe("apac"); // first member
-  });
-
-  it("group row missing (race with delete) → first member becomes primary", async () => {
-    mockConnRows = [{ group_id: "g-prod" }];
+  it("2-member group → first member is primary, currentMember reflects caller", async () => {
+    mockConnRows = [{ group_id: "prod" }];
     mockMemberRows = [{ id: "us-int" }, { id: "eu" }];
-    mockGroupRows = []; // connection_groups deleted before lookup completed
     const ctx = await loadGroupRoutingContext("org-1", "eu");
     expect(ctx.members).toEqual(["us-int", "eu"]);
     expect(ctx.primaryMember).toBe("us-int");
   });
 
-  it("step-2 returns empty members (paranoid) → fallback to currentConnectionId", async () => {
-    mockConnRows = [{ group_id: "g-prod" }];
+  it("step-2 returns empty members (paranoid: step 1 said grouped but row archived) → fallback to currentConnectionId", async () => {
+    mockConnRows = [{ group_id: "prod" }];
     mockMemberRows = []; // empty even though step 1 said grouped
-    mockGroupRows = [{ primary_connection_id: "us-int" }];
     const ctx = await loadGroupRoutingContext("org-1", "eu");
     expect(ctx.members).toEqual(["eu"]);
-    expect(ctx.primaryMember).toBe("eu"); // primaryFromGroup not in [], falls to currentMember
+    expect(ctx.primaryMember).toBe("eu");
   });
 });

--- a/packages/api/src/lib/scheduler/__tests__/executor.empty-group.test.ts
+++ b/packages/api/src/lib/scheduler/__tests__/executor.empty-group.test.ts
@@ -164,15 +164,18 @@ afterEach(() => {
   _resetPool(null);
 });
 
-// TODO(#2744 step 5 — test sweep): mocks reference dropped `connections` / `connection_groups` SQL; rewrite to workspace_plugins (pillar='datasource') shape.
-describe.skip("executor — empty connection group (#2416)", () => {
+describe("executor — empty connection group (#2416)", () => {
   it("when the tenant's group has zero non-archived members, the executor throws WITHOUT firing the agent and WITHOUT crossing into __global__", async () => {
     // Real loadScheduledTaskGroupSnapshot runs against this mock pool.
-    // First query: connection_groups row exists (tenant owns the group).
-    // Second query: zero non-archived members (every connection archived).
+    // Post-#2744 the loader does two scoped probes on `workspace_plugins`:
+    //   1. EXISTS check (any status) — proves the group exists in this org.
+    //   2. SELECT install_id AS id, installed_at AS created_at WHERE
+    //      `status != 'archived'` — empty here, because every member is
+    //      archived. The two-stage split preserves the "group not found"
+    //      vs "group has zero non-archived members" distinction.
     queryResults = [
-      { rows: [{ primary_connection_id: null }] },
-      { rows: [] },
+      { rows: [{ exists_flag: true }] }, // group exists somewhere in this org
+      { rows: [] },                      // ...but every member is archived
     ];
     queryResultIndex = 0;
 
@@ -188,12 +191,17 @@ describe.skip("executor — empty connection group (#2416)", () => {
     expect(mockUpdateRunDeliveryStatus).not.toHaveBeenCalled();
 
     // Real SQL path was exercised — exactly the two scoped queries ran
-    // (group row + member rows), both bound to org-1, never __global__.
+    // (EXISTS probe + member rows), both bound to org-1, never widened
+    // to __global__ post-#2416.
     expect(queryCalls.length).toBe(2);
     for (const call of queryCalls) {
       expect(call.params).toContain("org-1");
       expect(call.params).not.toContain("__global__");
       expect(call.sql).not.toContain("'__global__'");
+      // Both queries target workspace_plugins; neither references the
+      // legacy `connection_groups` table.
+      expect(call.sql).toContain("workspace_plugins");
+      expect(call.sql).not.toContain("connection_groups");
     }
   });
 });

--- a/packages/api/src/lib/scheduler/__tests__/group-resolve.test.ts
+++ b/packages/api/src/lib/scheduler/__tests__/group-resolve.test.ts
@@ -123,8 +123,17 @@ function setResults(...results: Array<{ rows: Record<string, unknown>[] }>): voi
 
 const origDbUrl = process.env.DATABASE_URL;
 
-// TODO(#2744 step 5 — test sweep): mocks reference dropped `connections` / `connection_groups` SQL; rewrite to workspace_plugins (pillar='datasource') shape.
-describe.skip("loadScheduledTaskGroupSnapshot (SQL path)", () => {
+describe("loadScheduledTaskGroupSnapshot (SQL path, post-cutover)", () => {
+  // Post-#2744 the loader's two-stage probe runs against `workspace_plugins`:
+  //   1. `SELECT EXISTS (...) AS exists_flag` — group_id appears under
+  //      any status for this workspace.
+  //   2. Member query filtered to `status != 'archived'` —
+  //      `SELECT install_id AS id, installed_at AS created_at`.
+  // Stage 1 returning `false` is the "group not found" hard error;
+  // stage 2 returning empty is the "every member archived" empty-snapshot
+  // shape that the executor's empty-group handler then surfaces. The
+  // legacy `connection_groups.primary_connection_id` column is gone —
+  // `primaryConnectionId` is always null in the snapshot.
   beforeEach(() => {
     queryCalls = [];
     queryResults = [];
@@ -148,7 +157,7 @@ describe.skip("loadScheduledTaskGroupSnapshot (SQL path)", () => {
   it("returns a snapshot with all non-archived members for a tenant group", async () => {
     enableInternalDB();
     setResults(
-      { rows: [{ primary_connection_id: "us-int" }] },
+      { rows: [{ exists_flag: true }] },
       {
         rows: [
           { id: "us-int", created_at: "2026-04-01T00:00:00Z" },
@@ -160,7 +169,8 @@ describe.skip("loadScheduledTaskGroupSnapshot (SQL path)", () => {
     const snap = await loadScheduledTaskGroupSnapshot("g_prod", "org-1");
     expect(snap).not.toBeNull();
     expect(snap!.orgId).toBe("org-1");
-    expect(snap!.primaryConnectionId).toBe("us-int");
+    // primaryConnectionId is always null post-cutover.
+    expect(snap!.primaryConnectionId).toBeNull();
     expect(snap!.members.map((m) => m.id)).toEqual(["us-int", "eu"]);
 
     // Every query must scope to the tenant org. NO __global__ widening.
@@ -169,13 +179,14 @@ describe.skip("loadScheduledTaskGroupSnapshot (SQL path)", () => {
       expect(call.params).toContain("org-1");
       expect(call.params).not.toContain("__global__");
       expect(call.sql).not.toContain("'__global__'");
+      expect(call.sql).toContain("workspace_plugins");
     }
   });
 
   it("returns an empty-members snapshot when a tenant's group has zero non-archived members — does NOT cross into __global__", async () => {
     enableInternalDB();
     setResults(
-      { rows: [{ primary_connection_id: null }] },
+      { rows: [{ exists_flag: true }] },
       { rows: [] }, // every member archived in this tenant
     );
 
@@ -195,7 +206,7 @@ describe.skip("loadScheduledTaskGroupSnapshot (SQL path)", () => {
   it("selectScheduledTaskGroupMember on an empty-members snapshot throws NoScheduledTaskGroupMembersError", async () => {
     enableInternalDB();
     setResults(
-      { rows: [{ primary_connection_id: null }] },
+      { rows: [{ exists_flag: true }] },
       { rows: [] },
     );
 
@@ -207,7 +218,7 @@ describe.skip("loadScheduledTaskGroupSnapshot (SQL path)", () => {
   it("resolveScheduledTaskConnection throws NoScheduledTaskGroupMembersError when the tenant's group is empty (no __global__ peek)", async () => {
     enableInternalDB();
     setResults(
-      { rows: [{ primary_connection_id: null }] },
+      { rows: [{ exists_flag: true }] },
       { rows: [] },
     );
 
@@ -228,10 +239,10 @@ describe.skip("loadScheduledTaskGroupSnapshot (SQL path)", () => {
     }
   });
 
-  it("falls back to first-member (created_at ASC, id ASC) when primary_connection_id is null — in-org fallback", async () => {
+  it("falls back to first-member (created_at ASC, id ASC) — primary is always null post-cutover", async () => {
     enableInternalDB();
     setResults(
-      { rows: [{ primary_connection_id: null }] },
+      { rows: [{ exists_flag: true }] },
       {
         rows: [
           { id: "us-int", created_at: "2026-04-01T00:00:00Z" },
@@ -253,10 +264,10 @@ describe.skip("loadScheduledTaskGroupSnapshot (SQL path)", () => {
     }
   });
 
-  it("__global__ caller (orgId = null) reads __global__ group rows directly — the legitimate path", async () => {
+  it("__global__ caller (orgId = null) reads __global__ workspace_plugins rows directly — the legitimate path", async () => {
     enableInternalDB();
     setResults(
-      { rows: [{ primary_connection_id: "g-conn" }] },
+      { rows: [{ exists_flag: true }] },
       { rows: [{ id: "g-conn", created_at: "2026-04-01T00:00:00Z" }] },
     );
 
@@ -278,7 +289,7 @@ describe.skip("loadScheduledTaskGroupSnapshot (SQL path)", () => {
     // silently splitting the global-org path in two.
     enableInternalDB();
     setResults(
-      { rows: [{ primary_connection_id: "g-conn" }] },
+      { rows: [{ exists_flag: true }] },
       { rows: [{ id: "g-conn", created_at: "2026-04-01T00:00:00Z" }] },
     );
 
@@ -292,12 +303,13 @@ describe.skip("loadScheduledTaskGroupSnapshot (SQL path)", () => {
     }
   });
 
-  it("returns null when the group does not exist for this org — no cross-org peek", async () => {
+  it("returns null when the EXISTS probe says the group does not exist for this org — no member query fires", async () => {
     enableInternalDB();
-    setResults({ rows: [] });
+    setResults({ rows: [{ exists_flag: false }] });
 
     const snap = await loadScheduledTaskGroupSnapshot("g_missing", "org-1");
     expect(snap).toBeNull();
+    // Short-circuit: only the EXISTS probe ran; no member SELECT followed.
     expect(queryCalls.length).toBe(1);
     expect(queryCalls[0].params).not.toContain("__global__");
   });

--- a/packages/api/src/lib/semantic/__tests__/overlay-queries-integration.test.ts
+++ b/packages/api/src/lib/semantic/__tests__/overlay-queries-integration.test.ts
@@ -41,16 +41,19 @@ beforeAll(async () => {
 
   db = newDb();
 
-  // Minimal schema — only the columns referenced by the overlay CTE.
-  // `connection_group_id` mirrors the post-0069 schema: content rows key by
-  // group, while `connections.id` remains useful for global shadowing.
+  // Minimal schema — only the columns referenced by the post-#2744
+  // overlay CTE. The OWN_OR_GLOBAL shadow rule now reads from
+  // `workspace_plugins (pillar='datasource')` with the install's group_id
+  // living inside `config` JSONB. `install_id` replaces `connections.id`
+  // for the shadow-precedence NOT-IN check.
   db.public.none(`
-    CREATE TABLE connections (
-      id TEXT NOT NULL,
-      org_id TEXT NOT NULL,
+    CREATE TABLE workspace_plugins (
+      install_id TEXT NOT NULL,
+      workspace_id TEXT NOT NULL,
+      pillar TEXT NOT NULL DEFAULT 'datasource',
       status TEXT NOT NULL DEFAULT 'published',
-      group_id TEXT,
-      PRIMARY KEY (id, org_id)
+      config JSONB,
+      PRIMARY KEY (workspace_id, install_id)
     );
     CREATE TABLE semantic_entities (
       id TEXT PRIMARY KEY,
@@ -89,16 +92,23 @@ afterAll(async () => {
 });
 
 beforeEach(() => {
-  db.public.none(`TRUNCATE semantic_entities; TRUNCATE connections;`);
+  db.public.none(`TRUNCATE semantic_entities; TRUNCATE workspace_plugins;`);
 });
 
 // ---------------------------------------------------------------------------
 // Fixture helpers — thin wrappers around raw INSERTs
 // ---------------------------------------------------------------------------
 
-function seedConnection(id: string, status: "published" | "draft" | "archived" = "published"): void {
+function seedConnection(
+  id: string,
+  status: "published" | "draft" | "archived" = "published",
+  workspaceId = "org-1",
+): void {
+  // Post-#2744 each install lives in workspace_plugins with its
+  // group_id stashed under `config->>'group_id'`.
   db.public.none(
-    `INSERT INTO connections (id, org_id, status, group_id) VALUES ('${id}', 'org-1', '${status}', 'g_${id}')`,
+    `INSERT INTO workspace_plugins (install_id, workspace_id, pillar, status, config)
+     VALUES ('${id}', '${workspaceId}', 'datasource', '${status}', '{"group_id":"g_${id}"}'::jsonb)`,
   );
 }
 
@@ -127,8 +137,7 @@ function rowsByName(rows: Array<{ name: string; status: string }>): Record<strin
 // Acceptance matrix
 // ---------------------------------------------------------------------------
 
-// TODO(#2744 step 5 — test sweep): mocks reference dropped `connections` / `connection_groups` SQL; rewrite to workspace_plugins (pillar='datasource') shape.
-describe.skip("listEntitiesWithOverlay — acceptance matrix against real Postgres", () => {
+describe("listEntitiesWithOverlay — acceptance matrix against real Postgres", () => {
   it("case 1: published-only entity is visible", async () => {
     seedConnection("warehouse");
     seedEntity({ id: "e1", name: "users", status: "published", connectionId: "warehouse" });
@@ -240,12 +249,10 @@ describe.skip("listEntitiesWithOverlay — acceptance matrix against real Postgr
 
   it("cross-org rows are invisible", async () => {
     // Seed an entity under a different org — should never appear in org-1's overlay
-    db.public.none(
-      `INSERT INTO connections (id, org_id, status, group_id) VALUES ('warehouse', 'org-2', 'published', 'g_warehouse_org2')`,
-    );
+    seedConnection("warehouse-org2", "published", "org-2");
     db.public.none(
       `INSERT INTO semantic_entities (id, org_id, entity_type, name, yaml_content, connection_group_id, status)
-       VALUES ('other', 'org-2', 'entity', 'other_users', 'table: other', 'g_warehouse_org2', 'published')`,
+       VALUES ('other', 'org-2', 'entity', 'other_users', 'table: other', 'g_warehouse-org2', 'published')`,
     );
 
     // org-1 has nothing
@@ -253,48 +260,39 @@ describe.skip("listEntitiesWithOverlay — acceptance matrix against real Postgr
     expect(rows).toHaveLength(0);
   });
 
-  it("entities tied to a __global__ connection are visible to any org (#2304)", async () => {
-    // The canonical `__demo__` lives at org_id = '__global__'. Per-org
-    // entities reference it via connection_group_id; the connection-visibility
-    // subquery now accepts `__global__` rows so those entities resolve.
-    db.public.none(
-      `INSERT INTO connections (id, org_id, status, group_id) VALUES ('__demo__', '__global__', 'published', 'g___demo__')`,
-    );
+  it("entities tied to a __global__ install are visible to any org (#2304)", async () => {
+    // The canonical `__demo__` install lives at workspace_id='__global__'.
+    // Per-org entities reference it via `connection_group_id`; the
+    // connection-visibility subquery now accepts `__global__` rows so
+    // those entities resolve.
+    seedConnection("__demo__", "published", "__global__");
     seedEntity({ id: "demo-ent", name: "novamart_orders", status: "published", connectionId: "__demo__" });
 
     const rows = await listEntitiesWithOverlay("org-1", "entity");
     expect(rowsByName(rows)).toEqual({ novamart_orders: "published" });
   });
 
-  it("per-org tombstone hides entities tied to a `__global__` connection — exact archived/non-archived precedence (#2304)", async () => {
-    // Pin the *transition* sequence so a future refactor that flips
-    // `NOT IN (... org's rows ...)` to `NOT IN (... non-archived org rows ...)`
-    // can't silently start surfacing tombstoned demos to the agent. Visible
-    // before tombstone → hidden after.
-    db.public.none(
-      `INSERT INTO connections (id, org_id, status, group_id) VALUES ('__demo__', '__global__', 'published', 'g___demo__')`,
-    );
+  it("per-org override hides entities tied to a `__global__` install — exact precedence (#2304)", async () => {
+    // Pin the *transition* sequence so a future refactor that flips the
+    // NOT-IN shadow check can't silently start surfacing demo entities
+    // to a workspace whose own __demo__ install supersedes the global.
+    seedConnection("__demo__", "published", "__global__");
     seedEntity({ id: "demo-ent-pre", name: "novamart_orders", status: "published", connectionId: "__demo__" });
     expect(rowsByName(await listEntitiesWithOverlay("org-1", "entity"))).toEqual({ novamart_orders: "published" });
 
-    // Tombstone arrives — same id, status='archived', org-1 scope.
-    db.public.none(
-      `INSERT INTO connections (id, org_id, status, group_id) VALUES ('__demo__', 'org-1', 'archived', 'g___demo__')`,
-    );
+    // Per-workspace __demo__ install arrives (any status) — shadows the global.
+    seedConnection("__demo__", "archived", "org-1");
     expect(await listEntitiesWithOverlay("org-1", "entity")).toHaveLength(0);
   });
 
-  it("per-org tombstone hides entities tied to a `__global__` connection (#2304)", async () => {
-    // The "delete the demo from my workspace" flow inserts a per-org
-    // archived row at the same id as the global. The shadow check excludes
-    // the global from the visible-connection set, so any entities the org
-    // owns at that connection_group_id drop out of the overlay alongside it.
-    db.public.none(
-      `INSERT INTO connections (id, org_id, status, group_id) VALUES ('__demo__', '__global__', 'published', 'g___demo__')`,
-    );
-    db.public.none(
-      `INSERT INTO connections (id, org_id, status, group_id) VALUES ('__demo__', 'org-1', 'archived', 'g___demo__')`,
-    );
+  it("per-org install shadows a `__global__` install with the same id (#2304)", async () => {
+    // The "delete the demo from my workspace" flow now writes a per-org
+    // workspace_plugins row at the same install_id as the global. The
+    // shadow check (`install_id NOT IN ...own org's installs...`) excludes
+    // the global, so any entities tied to that connection_group_id drop
+    // out of the overlay alongside it.
+    seedConnection("__demo__", "published", "__global__");
+    seedConnection("__demo__", "archived", "org-1");
     seedEntity({ id: "demo-ent", name: "novamart_orders", status: "published", connectionId: "__demo__" });
 
     const rows = await listEntitiesWithOverlay("org-1", "entity");

--- a/packages/api/src/lib/semantic/__tests__/overlay-queries.test.ts
+++ b/packages/api/src/lib/semantic/__tests__/overlay-queries.test.ts
@@ -93,8 +93,7 @@ function makeRow(opts: MakeRowOpts): Record<string, unknown> {
 // Tests
 // ---------------------------------------------------------------------------
 
-// TODO(#2744 step 5 — test sweep): mocks reference dropped `connections` / `connection_groups` SQL; rewrite to workspace_plugins (pillar='datasource') shape.
-describe.skip("listEntitiesWithOverlay — SQL shape", () => {
+describe("listEntitiesWithOverlay — SQL shape", () => {
   beforeEach(() => {
     resetCapture();
   });
@@ -114,13 +113,19 @@ describe.skip("listEntitiesWithOverlay — SQL shape", () => {
     expect(sql).toMatch(/WHERE\s+status\s*!=\s*'draft_delete'/i);
   });
 
-  it("restricts to entities whose parent connection is not archived", async () => {
+  it("restricts to entities whose parent install is not archived (workspace_plugins JSONB group_id)", async () => {
     await listEntitiesWithOverlay("org-1", "entity");
     const sql = capturedCalls[0].sql;
-    // Inner check: connection_id IN (SELECT id FROM connections WHERE status IN ('published','draft'))
-    // Or equivalent: connection is NULL (unscoped) OR in published/draft set
-    expect(sql).toMatch(/connections/i);
+    // Post-#2744 the OWN_OR_GLOBAL shadow rule pivots to workspace_plugins
+    // (pillar='datasource') and reads group_id from `config->>'group_id'`.
+    // The legacy `connections` table is gone.
+    expect(sql).toMatch(/workspace_plugins/i);
+    expect(sql).toMatch(/config->>'group_id'/i);
+    expect(sql).toMatch(/pillar\s*=\s*'datasource'/i);
     expect(sql).toMatch(/status\s+IN\s*\(\s*'published'\s*,\s*'draft'\s*\)/i);
+    // OWN_OR_GLOBAL shadow rule preserved: own-workspace beats __global__.
+    expect(sql).toContain("'__global__'");
+    expect(sql).toMatch(/install_id\s+NOT\s+IN/i);
   });
 
   it("includes status IN ('published','draft','draft_delete') for the entity side", async () => {

--- a/packages/api/src/lib/tools/__tests__/sql-mode-isolation.test.ts
+++ b/packages/api/src/lib/tools/__tests__/sql-mode-isolation.test.ts
@@ -146,8 +146,7 @@ const runQuery = (sql: string, connectionId?: string) =>
 // Tests
 // ---------------------------------------------------------------------------
 
-// TODO(#2744 step 5 — test sweep): mocks reference dropped `connections` / `connection_groups` SQL; rewrite to workspace_plugins (pillar='datasource') shape.
-describe.skip("executeSQL mode isolation gate", () => {
+describe("executeSQL mode isolation gate", () => {
   const origDatasource = process.env.ATLAS_DATASOURCE_URL;
 
   beforeEach(() => {

--- a/packages/api/src/lib/tools/__tests__/sql-org-routing.test.ts
+++ b/packages/api/src/lib/tools/__tests__/sql-org-routing.test.ts
@@ -158,8 +158,7 @@ const executeTool = executeSQL.execute as unknown as (
 // Tests
 // ---------------------------------------------------------------------------
 
-// TODO(#2744 step 5 — test sweep): mocks reference dropped `connections` / `connection_groups` SQL; rewrite to workspace_plugins (pillar='datasource') shape.
-describe.skip("executeSQL org-scoped routing", () => {
+describe("executeSQL org-scoped routing", () => {
   beforeEach(() => {
     mockOrgPoolingEnabled = false;
     mockRequestContext = undefined;

--- a/packages/api/src/lib/tools/__tests__/sql-org-whitelist.test.ts
+++ b/packages/api/src/lib/tools/__tests__/sql-org-whitelist.test.ts
@@ -117,8 +117,7 @@ const { validateSQL } = await import("../sql");
 // Tests
 // ---------------------------------------------------------------------------
 
-// TODO(#2744 step 5 — test sweep): mocks reference dropped `connections` / `connection_groups` SQL; rewrite to workspace_plugins (pillar='datasource') shape.
-describe.skip("org-scoped SQL whitelist enforcement", () => {
+describe("org-scoped SQL whitelist enforcement", () => {
   beforeEach(() => {
     mockOrgId = undefined;
     loadOrgWhitelistCallCount = 0;

--- a/packages/api/src/lib/tools/__tests__/sql-rls-settings.test.ts
+++ b/packages/api/src/lib/tools/__tests__/sql-rls-settings.test.ts
@@ -145,8 +145,7 @@ const toolCtx = { toolCallId: "tc-rls", messages: [], abortSignal: undefined as 
 // Tests
 // ---------------------------------------------------------------------------
 
-// TODO(#2744 step 5 — test sweep): mocks reference dropped `connections` / `connection_groups` SQL; rewrite to workspace_plugins (pillar='datasource') shape.
-describe.skip("RLS settings overlay in SaaS mode", () => {
+describe("RLS settings overlay in SaaS mode", () => {
   beforeEach(() => {
     mockSettingValues = {
       ATLAS_ROW_LIMIT: "1000",

--- a/packages/cli/src/__tests__/seed.test.ts
+++ b/packages/cli/src/__tests__/seed.test.ts
@@ -204,16 +204,22 @@ describe("parseConnectionsArg", () => {
 
 // --- seedWorkspaceGroup ---
 
-// TODO(#2744 step 5 — test sweep): seedWorkspaceGroup was rewritten in
-// the 1.5.3 cutover to upsert `workspace_plugins` (pillar='datasource')
-// via catalog lookup; the legacy `connection_groups` + `connections`
-// shapes the mock-queue positions assume are gone. The tests still
-// run against the old positional mock and need a fresh queue keyed
-// to the new query sequence (BEGIN, resolve, DELETE wp demo, DELETE
-// se demo, DELETE se prior, DELETE wp prior, [SELECT catalog +
-// INSERT wp] per member, INSERT se per entity, COMMIT). Skipping
-// until the rewrite lands as part of the test-mock follow-up.
-describe.skip("seedWorkspaceGroup", () => {
+describe("seedWorkspaceGroup", () => {
+  // Post-#2744 the seeder writes `workspace_plugins (pillar='datasource')`
+  // with `group_id` stashed in JSONB `config`. There is no longer a
+  // separate `connection_groups` row, no `primary_connection_id` UPDATE,
+  // and no top-level `url_key_version` column — encryption travels inside
+  // the JSONB payload. The positional mock queue tracks the new query
+  // sequence:
+  //   BEGIN
+  //   resolveWorkspaceId
+  //   DELETE wp 'default'
+  //   DELETE se (NULL or 'g_default')
+  //   DELETE se for this group
+  //   DELETE wp for these install_ids
+  //   per connection: SELECT plugin_catalog → INSERT wp
+  //   per entity:     INSERT semantic_entities
+  //   COMMIT (or ROLLBACK on failure)
   function makeResolved(): ResolvedConnectionSpec[] {
     return [
       {
@@ -233,30 +239,26 @@ describe.skip("seedWorkspaceGroup", () => {
     ];
   }
 
-  it("clears demo + prior, creates group + connections + entities, sets primary", async () => {
+  it("clears demo + prior installs, upserts workspace_plugins per connection, inserts entities", async () => {
     const entities: SemanticEntityRow[] = [
       { entityType: "entity", name: "users", yaml: "table: users" },
       { entityType: "metric", name: "active_users", yaml: "name: active_users" },
     ];
-    const { client, queries } = createMockClient(
-      // 1 BEGIN, 1 resolve, 5 DELETEs, 1 group INSERT, 2 conn INSERTs, 1 primary UPDATE, 2 entity INSERTs, 1 COMMIT
-      [
-        { rows: [] }, // BEGIN
-        { rows: [{ id: "org_y" }] }, // resolve
-        { rows: [], rowCount: 1 }, // delete demo connection
-        { rows: [], rowCount: 5 }, // delete demo entities
-        { rows: [], rowCount: 0 }, // delete prior entities (none)
-        { rows: [], rowCount: 0 }, // delete prior connections
-        { rows: [], rowCount: 0 }, // delete prior group
-        { rows: [], rowCount: 1 }, // INSERT group
-        { rows: [], rowCount: 1 }, // INSERT us-prod
-        { rows: [], rowCount: 1 }, // INSERT eu-prod
-        { rows: [], rowCount: 1 }, // UPDATE primary
-        { rows: [], rowCount: 1 }, // INSERT entity users
-        { rows: [], rowCount: 1 }, // INSERT metric active_users
-        { rows: [] }, // COMMIT
-      ],
-    );
+    const { client, queries } = createMockClient([
+      { rows: [] },                                         // BEGIN
+      { rows: [{ id: "org_y" }] },                          // resolveWorkspaceId
+      { rows: [], rowCount: 1 },                            // DELETE wp 'default'
+      { rows: [], rowCount: 5 },                            // DELETE se NULL/g_default
+      { rows: [], rowCount: 0 },                            // DELETE se for g_prod (none prior)
+      { rows: [], rowCount: 0 },                            // DELETE wp prior installs
+      { rows: [{ id: "cat_postgres" }] },                   // SELECT plugin_catalog for us-prod
+      { rows: [], rowCount: 1 },                            // INSERT wp us-prod
+      { rows: [{ id: "cat_postgres" }] },                   // SELECT plugin_catalog for eu-prod
+      { rows: [], rowCount: 1 },                            // INSERT wp eu-prod
+      { rows: [], rowCount: 1 },                            // INSERT se 'users'
+      { rows: [], rowCount: 1 },                            // INSERT se 'active_users'
+      { rows: [] },                                         // COMMIT
+    ]);
 
     const result = await seedWorkspaceGroup(client, {
       workspace: "atlas",
@@ -277,33 +279,45 @@ describe.skip("seedWorkspaceGroup", () => {
     expect(queries[0]!.sql).toBe("BEGIN");
     expect(queries[queries.length - 1]!.sql).toBe("COMMIT");
 
-    // Group insert
+    // No legacy connection_groups writes at all post-cutover.
     const insGroup = queries.find((q) => q.sql.includes("INSERT INTO connection_groups"));
-    expect(insGroup).toBeDefined();
-    expect(insGroup!.params).toEqual(["g_prod", "org_y", "prod"]);
-
-    // Connection inserts in declaration order, both bound to g_prod
-    const insConns = queries.filter((q) => q.sql.includes("INSERT INTO connections"));
-    expect(insConns).toHaveLength(2);
-    expect(insConns[0]!.params).toEqual([
-      "us-prod",
-      "enc:v1:iv:tag:ciphertext-us",
-      1,
-      "postgres",
-      "us-prod (postgres)",
-      "org_y",
-      "g_prod",
-    ]);
-    expect(insConns[1]!.params[0]).toBe("eu-prod");
-
-    // Primary update points at the :primary entry
+    expect(insGroup).toBeUndefined();
     const updPrimary = queries.find((q) =>
-      q.sql.startsWith("UPDATE connection_groups SET primary_connection_id"),
+      q.sql.includes("UPDATE connection_groups SET primary_connection_id"),
     );
-    expect(updPrimary).toBeDefined();
-    expect(updPrimary!.params).toEqual(["us-prod", "g_prod", "org_y"]);
+    expect(updPrimary).toBeUndefined();
 
-    // Semantic entities inserted with the group id
+    // Two catalog lookups (one per connection) — slug = c.type = 'postgres'.
+    const catLookups = queries.filter((q) => q.sql.includes("FROM plugin_catalog"));
+    expect(catLookups).toHaveLength(2);
+    for (const q of catLookups) {
+      expect(q.params).toEqual(["postgres"]);
+    }
+
+    // workspace_plugins inserts in declaration order. Params:
+    //   [rowId, workspaceId, catalogId, installId, configJson]
+    const insWp = queries.filter((q) => q.sql.includes("INSERT INTO workspace_plugins"));
+    expect(insWp).toHaveLength(2);
+
+    const usParams = insWp[0]!.params as unknown[];
+    expect(usParams[0]).toBe("cn_org_y_us-prod");
+    expect(usParams[1]).toBe("org_y");
+    expect(usParams[2]).toBe("cat_postgres");
+    expect(usParams[3]).toBe("us-prod");
+    const usConfig = JSON.parse(usParams[4] as string) as Record<string, unknown>;
+    expect(usConfig).toMatchObject({
+      url: "enc:v1:iv:tag:ciphertext-us",
+      db_type: "postgres",
+      group_id: "g_prod",
+    });
+
+    expect((insWp[1]!.params as unknown[])[3]).toBe("eu-prod");
+    const euConfig = JSON.parse((insWp[1]!.params as unknown[])[4] as string) as Record<string, unknown>;
+    expect(euConfig.group_id).toBe("g_prod");
+    expect(euConfig.url).toBe("enc:v1:iv:tag:ciphertext-eu");
+
+    // Semantic entities still write `connection_group_id` (the entities
+    // table didn't change in #2744 — only the connections side did).
     const insEntities = queries.filter((q) => q.sql.includes("INSERT INTO semantic_entities"));
     expect(insEntities).toHaveLength(2);
     expect(insEntities[0]!.params).toEqual([
@@ -317,16 +331,15 @@ describe.skip("seedWorkspaceGroup", () => {
 
   it("rolls back when no primary is declared (defense-in-depth — parseConnectionsArg also rejects this)", async () => {
     const { client, queries } = createMockClient([
-      { rows: [] }, // BEGIN
-      { rows: [{ id: "org_y" }] }, // resolve
-      { rows: [], rowCount: 0 }, // delete demo connection
-      { rows: [], rowCount: 0 }, // delete demo entities
-      { rows: [], rowCount: 0 }, // delete prior entities
-      { rows: [], rowCount: 0 }, // delete prior connections
-      { rows: [], rowCount: 0 }, // delete prior group
-      { rows: [], rowCount: 1 }, // INSERT group
-      { rows: [], rowCount: 1 }, // INSERT us-prod (no primary marker)
-      { rows: [] }, // ROLLBACK
+      { rows: [] },                          // BEGIN
+      { rows: [{ id: "org_y" }] },           // resolveWorkspaceId
+      { rows: [], rowCount: 0 },             // DELETE wp 'default'
+      { rows: [], rowCount: 0 },             // DELETE se NULL/g_default
+      { rows: [], rowCount: 0 },             // DELETE se for g_prod
+      { rows: [], rowCount: 0 },             // DELETE wp prior installs
+      { rows: [{ id: "cat_postgres" }] },    // SELECT plugin_catalog for us-prod
+      { rows: [], rowCount: 1 },             // INSERT wp us-prod (no primary marker)
+      { rows: [] },                          // ROLLBACK
     ]);
     const conns = makeResolved().map((c) => ({ ...c, isPrimary: false }));
     await expect(


### PR DESCRIPTION
## Summary

Finishes the test-mock sweep deferred by the 1.5.3 `#2744` cutover PR (#2784). The cutover took the "skip-with-TODO" path on ~30 describe blocks across 24 test files; this PR rewrites every mock + assertion to the post-cutover `workspace_plugins (pillar='datasource')` + JSONB `config.group_id` shape and removes every `TODO(#2744 step 5)` marker.

- **admin-connections.test.ts** (biggest, ~770 lines net): rewrote 18 describes around new SQL substring matchers + `WorkspaceInstaller` installer-SQL fixtures. Dropped obsolete `connection_groups` CTE / `primary_connection_id` / `url_key_version` assertions that no longer match production behavior.
- **migrate-pg.test.ts**: reworked the two `0087` describes to thread explicit `pillar` through every `plugin_catalog` INSERT (the 0092 trigger that filled it is dropped by 0096). Deleted the `0088` and `0092` describes whose triggers + unique constraints are dropped by 0096 — equivalents already live in the existing `0096: cutover` describe.
- **me-connection-groups.test.ts**: rewrote assertions — `primaryConnectionId` is always `null` post-cutover, `groupName` mirrors `groupId` verbatim, empty-member groups no longer surface.
- **cli/seed.test.ts**: new positional mock-queue sequence (catalog SELECT → workspace_plugins INSERT per connection) replaces the legacy `connection_groups` + `connections` shape.
- **overlay-queries-integration.test.ts**: rewrote pg-mem schema from `connections (id, org_id, group_id)` to `workspace_plugins (install_id, workspace_id, pillar, status, config jsonb)`; the OWN_OR_GLOBAL shadow tests now hit the JSONB `config->>'group_id'` path against real Postgres semantics.
- **3 lib/tools tests** were defensively skipped but had no legacy SQL refs — just un-skipped.

## Acceptance criteria (all met)

- [x] Zero `TODO(#2744 step 5)` markers in `packages/` or `apps/`
- [x] Every previously-skipped describe is either deleted (with a one-line removal comment) or rewritten with mocks/assertions matching the post-cutover shape
- [x] All 24 changed test files pass individually
- [x] Coverage preserved for the four cutover lib files: `loadSavedConnections`, `WorkspaceInstaller.{installDatasource,uninstall,updateConfig}`, `isConnectionVisibleInMode`, and the semantic OWN_OR_GLOBAL shadow rule in `semantic/entities.ts`
- [x] All `/ci` gates pass locally: lint, type, syncpack, schema-drift, template-drift, openapi-drift, ee-imports, no-legacy-connections-sql, dockerfile-workspace, oauth-helper-drift, security-headers-drift, railway-watch

## Test plan

- [x] `bun run lint` — green
- [x] `bun run type` — green
- [x] `bun x syncpack lint` — no issues
- [x] Every drift check (`scripts/check-*.sh`) — green
- [x] Each of the 24 touched test files run individually via `bun test <file>` — all pass
- [x] `bun run scripts/test-isolated.ts` from `packages/api/` — 454/457 pass; the 3 pre-existing failures (`discord.test.ts`, `teams.test.ts`, `platform-sla-audit.test.ts`) reproduce against `origin/main` and pass when run alone — orthogonal to this PR

## Notes for reviewers

- Net diff: +1325 / −1885 (a net 560-line shrink). The drop comes from deleting `0088` + `0092` describes in `migrate-pg.test.ts` (now redundant with the `0096: cutover` block) plus the obsolete `connection_groups` CTE tests in `admin-connections.test.ts`.
- The `WorkspaceInstaller` installer-SQL fixtures use a `POSTGRES_CATALOG_ROW` helper at the top of `admin-connections.test.ts` — mirrors the migration 0093 seed shape verbatim (top-level JSONB array of fields keyed by `key`, not `name` — that's the shape `parseConfigSchema` accepts).
- The PUT rollback test uses plain URLs (no `encrypted:` prefix) in fixtures because `decryptSecretFields` imports its `decryptSecret` from `db/secret-encryption`, which the test factory does NOT mock (the factory only overrides `db/internal`'s pair). Documented inline + saved to memory for future fixture authors.

Closes #2786