### PR TITLE
feat(web,api,docs): #2745 — Salesforce moves to /admin/connections (OAuth render path)

### DIFF
--- a/apps/docs/content/docs/plugins/datasources/salesforce.mdx
+++ b/apps/docs/content/docs/plugins/datasources/salesforce.mdx
@@ -1,19 +1,49 @@
 ---
 title: Salesforce
-description: Connect Atlas to Salesforce CRM for SOQL queries via the jsforce library.
+description: Connect Atlas to Salesforce CRM for SOQL queries via OAuth-managed jsforce sessions.
 ---
 
 import { Callout } from "fumadocs-ui/components/callout";
 
 Connects to Salesforce via the `jsforce` library. Unlike the other datasource plugins, Salesforce uses SOQL (Salesforce Object Query Language) instead of SQL. The plugin registers a dedicated `querySalesforce` agent tool -- the agent uses this tool instead of `executeSQL` when querying Salesforce data.
 
-## Installation
+## Connecting (admin UI)
+
+Salesforce installs through the OAuth flow under **Admin → Connections**. The connection lifecycle (connect, reconnect, disconnect) is unified with the other datasources -- the Salesforce row sits next to PostgreSQL and MySQL on the same page.
+
+1. Sign in as an Atlas admin and open **Admin → Connections**.
+2. Find the Salesforce provider row and click **Connect**.
+3. Approve the OAuth consent screen on the Salesforce side. Atlas requests `api refresh_token offline_access` so it can hold a refresh token after the initial dance.
+4. After the redirect lands back on Atlas, the row flips to "Live" and shows the connected org's instance URL and org ID.
+
+Disconnecting removes the install record from `workspace_plugins` and deletes the stored OAuth refresh token from `integration_credentials` in a single atomic teardown (per [ADR-0007](https://github.com/AtlasDevHQ/atlas/blob/main/docs/adr/0007-unified-install-pipeline.md)). Reconnecting reuses the same OAuth flow -- the callback upserts the install record in place, so a transient refresh-token revocation heals without an admin-side cleanup step.
+
+<Callout type="info">
+The pre-#2745 URL-form configuration (`salesforce://user:password@host?token=...`) is no longer surfaced in the admin UI. Operators on self-hosted who want a static, env-driven install can still wire the legacy plugin through `atlas.config.ts` -- see [Self-hosted (static config)](#self-hosted-static-config) below.
+</Callout>
+
+## Operator setup (Connected App)
+
+Connecting Salesforce requires a Salesforce Connected App with these settings:
+
+| Setting | Value |
+|---------|-------|
+| Callback URL | `https://<atlas-host>/api/v1/integrations/salesforce/callback` |
+| OAuth Scopes | `Access and manage your data (api)`, `Perform requests on your behalf at any time (refresh_token, offline_access)` |
+| Login URL | `https://login.salesforce.com` for production orgs, `https://test.salesforce.com` for sandboxes |
+
+Set these env vars on the Atlas API server:
 
 ```bash
-bun add @useatlas/salesforce jsforce
+SALESFORCE_CLIENT_ID=<consumer key from Connected App>
+SALESFORCE_CLIENT_SECRET=<consumer secret>
+# Optional - defaults to https://login.salesforce.com. Set for sandboxes.
+SALESFORCE_LOGIN_URL=https://test.salesforce.com
 ```
 
-## Configuration
+Without `SALESFORCE_CLIENT_ID` and `SALESFORCE_CLIENT_SECRET` the install handler is not registered and the Connect button on `/admin/connections` returns 501.
+
+## Self-hosted (static config)
 
 ```typescript
 // atlas.config.ts

--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -63328,6 +63328,13 @@
                               "available",
                               "coming_soon"
                             ]
+                          },
+                          "installConfig": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "additionalProperties": {}
                           }
                         },
                         "required": [
@@ -63347,7 +63354,8 @@
                           "accessible",
                           "upgradeRequired",
                           "pillar",
-                          "implementationStatus"
+                          "implementationStatus",
+                          "installConfig"
                         ]
                       }
                     }

--- a/packages/api/src/api/__tests__/integrations-catalog.test.ts
+++ b/packages/api/src/api/__tests__/integrations-catalog.test.ts
@@ -247,6 +247,7 @@ describe("GET /api/v1/integrations/catalog", () => {
           installedBy: "user-42",
           status: "reconnect_needed",
           disabled: false,
+          config: {},
         },
       });
       mockWithInstallStatusFor.mockReturnValueOnce(Effect.succeed([row]));
@@ -260,6 +261,107 @@ describe("GET /api/v1/integrations/catalog", () => {
       expect(entry.installedAt).toBe("2026-05-20T10:00:00.000Z");
       expect(entry.installedBy).toBe("user-42");
       expect(entry.installStatus).toBe("reconnect_needed");
+    });
+
+    // Slice 7 of 1.5.3 (#2745): `installConfig` projects the
+    // non-secret subset of `workspace_plugins.config` to the wire so
+    // /admin/connections can render Salesforce-specific detail rows
+    // (instance URL, org ID) without a second round-trip.
+    it("projects installConfig from the install row's config JSONB", async () => {
+      const row = makeRichRow({
+        slug: "salesforce",
+        type: "integration",
+        pillar: "datasource",
+        state: "connected",
+        planAccessible: true,
+        install: {
+          id: "install-sf",
+          catalogId: "catalog:salesforce",
+          installId: "install-sf",
+          workspaceId: "org-1",
+          pillar: "datasource",
+          installedAt: "2026-05-20T10:00:00.000Z",
+          installedBy: "user-42",
+          status: "ok",
+          disabled: false,
+          config: {
+            instance_url: "https://na139.my.salesforce.com",
+            org_id: "00DAB000000ZmU8",
+            scopes: "api refresh_token offline_access",
+            status: "ok",
+          },
+        },
+      });
+      mockWithInstallStatusFor.mockReturnValueOnce(Effect.succeed([row]));
+
+      const app = buildApp();
+      const res = await app.request("/integrations/catalog");
+      expect(res.status).toBe(200);
+      const body = await json(res);
+      const entry = body.catalog[0];
+      // The catalog row has no `config_schema` (Salesforce OAuth has no
+      // form fields), so `maskSecretFields` passes the whole object
+      // through. The detail-row admin UI relies on `instance_url` and
+      // `org_id` being readable as plain strings.
+      expect(entry.installConfig).toEqual({
+        instance_url: "https://na139.my.salesforce.com",
+        org_id: "00DAB000000ZmU8",
+        scopes: "api refresh_token offline_access",
+        status: "ok",
+      });
+    });
+
+    it("scrubs secret-marked config fields via maskSecretFields", async () => {
+      // Defense-in-depth: when a future integration's catalog row marks
+      // a field `secret: true`, the wire must replace it with the
+      // masked placeholder so plaintext never crosses to the admin UI.
+      const row = makeRichRow({
+        slug: "future-oauth",
+        type: "integration",
+        pillar: "action",
+        state: "connected",
+        planAccessible: true,
+        configSchema: [
+          { key: "api_token", secret: true, type: "string" },
+          { key: "tenant_id", type: "string" },
+        ],
+        install: {
+          id: "install-future",
+          catalogId: "catalog:future-oauth",
+          installId: "install-future",
+          workspaceId: "org-1",
+          pillar: "action",
+          installedAt: "2026-05-20T10:00:00.000Z",
+          installedBy: "user-42",
+          status: "ok",
+          disabled: false,
+          config: {
+            api_token: "supersecret",
+            tenant_id: "tenant-abc",
+          },
+        },
+      });
+      mockWithInstallStatusFor.mockReturnValueOnce(Effect.succeed([row]));
+
+      const app = buildApp();
+      const res = await app.request("/integrations/catalog");
+      const body = await json(res);
+      const entry = body.catalog[0];
+      // The secret-marked field is masked; the operational field
+      // passes through unchanged.
+      expect(entry.installConfig.api_token).not.toBe("supersecret");
+      expect(entry.installConfig.api_token).toMatch(/•/);
+      expect(entry.installConfig.tenant_id).toBe("tenant-abc");
+    });
+
+    it("emits installConfig=null when not installed", async () => {
+      const row = makeRichRow({ state: "accessible", planAccessible: true });
+      mockWithInstallStatusFor.mockReturnValueOnce(Effect.succeed([row]));
+
+      const app = buildApp();
+      const res = await app.request("/integrations/catalog");
+      const body = await json(res);
+      expect(body.catalog[0].installConfig).toBeNull();
     });
 
     it("flags above-plan rows as upsellOnly with upgradeRequired carrying the catalog min_plan", async () => {

--- a/packages/api/src/api/routes/__tests__/integrations.test.ts
+++ b/packages/api/src/api/routes/__tests__/integrations.test.ts
@@ -526,6 +526,102 @@ describe("GET /api/v1/integrations/slack/callback — non-OAuth-exchange failure
 });
 
 // ---------------------------------------------------------------------------
+// Salesforce-specific callback destination — slice 7 of 1.5.3 (#2745).
+// Salesforce moved to `/admin/connections`, so its redirect targets must
+// route there instead of `/admin/integrations`. Locks in the
+// `adminDestinationForPlatform` exception so a future refactor that
+// collapses the helper back to a single path is caught here.
+// ---------------------------------------------------------------------------
+
+describe("GET /api/v1/integrations/salesforce/callback — redirects to /admin/connections", () => {
+  let salesforceCallbackImpl: () => Promise<CallbackResult> = async () => null;
+
+  const salesforceHandler: OAuthPlatformInstallHandler = {
+    kind: "oauth" as const,
+    startInstall: async () => ({
+      redirectUrl: "https://login.salesforce.com/services/oauth2/authorize?client_id=test&state=stub",
+      stateToken: "stub",
+    }),
+    handleCallback: async () => salesforceCallbackImpl(),
+  };
+
+  beforeAll(() => {
+    registerOAuthHandler("salesforce", salesforceHandler);
+  });
+
+  beforeEach(() => {
+    mockInternalQuery.mockImplementation(async (sql: string) => {
+      if (sql.includes("FROM organization")) {
+        return [{ plan_tier: "business", is_operator_workspace: false }];
+      }
+      return [{ slug: "salesforce", install_model: "oauth", enabled: true, min_plan: "starter" }];
+    });
+    salesforceCallbackImpl = async () => null;
+  });
+
+  it("routes installed= to /admin/connections, not /admin/integrations", async () => {
+    salesforceCallbackImpl = async () => ({
+      workspaceId: "ws-1" as never,
+      catalogId: "salesforce",
+      installRecord: {
+        id: "install-sf-1",
+        workspaceId: "ws-1" as never,
+        catalogId: "salesforce",
+      },
+      credentialResult: { written: true },
+    });
+
+    const res = await request(
+      "/api/v1/integrations/salesforce/callback?code=auth-abc&state=stub",
+      { headers: { Accept: "text/html" } },
+    );
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toBe(
+      "https://app.atlas.example/admin/connections?installed=salesforce",
+    );
+  });
+
+  it("routes reconnect= to /admin/connections when the credential write missed", async () => {
+    salesforceCallbackImpl = async () => ({
+      workspaceId: "ws-1" as never,
+      catalogId: "salesforce",
+      installRecord: {
+        id: "install-sf-2",
+        workspaceId: "ws-1" as never,
+        catalogId: "salesforce",
+      },
+      credentialResult: { written: false, reason: "stub" },
+    });
+
+    const res = await request(
+      "/api/v1/integrations/salesforce/callback?code=auth-abc&state=stub",
+      { headers: { Accept: "text/html" } },
+    );
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toBe(
+      "https://app.atlas.example/admin/connections?reconnect=salesforce",
+    );
+  });
+
+  it("routes invalid_state error= to /admin/connections for browser callers", async () => {
+    salesforceCallbackImpl = async () => null;
+
+    const res = await request(
+      "/api/v1/integrations/salesforce/callback?code=auth-abc&state=tampered",
+      { headers: { Accept: "text/html" } },
+    );
+
+    expect(res.status).toBe(302);
+    const location = res.headers.get("location") ?? "";
+    expect(location).toContain("https://app.atlas.example/admin/connections");
+    expect(location).toContain("error=salesforce");
+    expect(location).toContain("reason=invalid_state");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // POST /:platform/install-form — slice 7 (#2660)
 // ---------------------------------------------------------------------------
 

--- a/packages/api/src/api/routes/integrations-catalog.ts
+++ b/packages/api/src/api/routes/integrations-catalog.ts
@@ -30,6 +30,10 @@ import {
   PillarCatalogQuery,
   PillarCatalogQueryLive,
 } from "@atlas/api/lib/effect/pillar-catalog-query";
+import {
+  maskSecretFields,
+  parseConfigSchema,
+} from "@atlas/api/lib/plugins/secrets";
 import { ErrorSchema, AuthErrorSchema } from "./shared-schemas";
 import { createAdminRouter, requireOrgContext } from "./admin-router";
 
@@ -88,6 +92,20 @@ const CatalogEntryResponseSchema = z.object({
    * rendering).
    */
   implementationStatus: z.enum(["available", "coming_soon"]),
+  /**
+   * Non-secret subset of `workspace_plugins.config` for installed rows.
+   * Carries operator-visible install metadata: Salesforce
+   * `instance_url` / `org_id`, Jira `cloud_id`, etc. Secret-marked
+   * fields (driven by the catalog's `config_schema.fields[].secret`
+   * flag) are replaced with a masked placeholder server-side via
+   * {@link maskSecretFields} so the wire never carries plaintext
+   * credentials. `null` when the row is not installed.
+   *
+   * Slice 7 of 1.5.3 (#2745) introduced this field so the
+   * `/admin/connections` Salesforce render path can show "connected
+   * org" + "instance URL" detail rows without a second round-trip.
+   */
+  installConfig: z.record(z.string(), z.unknown()).nullable(),
 });
 
 const CatalogResponseSchema = z.object({
@@ -172,30 +190,42 @@ integrationsCatalog.openapi(listCatalogRoute, async (c) => {
       ),
     );
 
-    const catalog = rows.map((row) => ({
-      id: row.id,
-      slug: row.slug,
-      // The facade's `type` is the raw DB string; the route narrows
-      // back to the wire union. The legacy-type SQL exclusion in the
-      // facade keeps this safe — any other value would mean a CHECK
-      // constraint regression.
-      type: row.type as "chat" | "integration",
-      installModel: row.installModel as "oauth" | "form" | "static-bot",
-      name: row.name,
-      description: row.description,
-      iconUrl: row.iconUrl,
-      minPlan: row.minPlan,
-      configSchema: row.configSchema ?? null,
-      installed: row.install !== null,
-      installedAt: row.install?.installedAt ?? null,
-      installedBy: row.install?.installedBy ?? null,
-      installStatus: row.install?.status ?? null,
-      upsellOnly: !row.planAccessible,
-      accessible: row.planAccessible,
-      upgradeRequired: row.planAccessible ? null : row.minPlan,
-      pillar: row.pillar,
-      implementationStatus: row.implementationStatus,
-    }));
+    const catalog = rows.map((row) => {
+      // Project the non-secret subset of `workspace_plugins.config` to
+      // the wire so admin-UI render paths (e.g. /admin/connections for
+      // Salesforce, #2745) can show "connected org" / instance URL /
+      // tenant id without a second round-trip. `maskSecretFields`
+      // fail-closes on a `corrupt` schema (every non-empty string is
+      // masked) so a drifted catalog row can never leak plaintext.
+      const installConfig = row.install
+        ? maskSecretFields(row.install.config, parseConfigSchema(row.configSchema))
+        : null;
+      return {
+        id: row.id,
+        slug: row.slug,
+        // The facade's `type` is the raw DB string; the route narrows
+        // back to the wire union. The legacy-type SQL exclusion in the
+        // facade keeps this safe — any other value would mean a CHECK
+        // constraint regression.
+        type: row.type as "chat" | "integration",
+        installModel: row.installModel as "oauth" | "form" | "static-bot",
+        name: row.name,
+        description: row.description,
+        iconUrl: row.iconUrl,
+        minPlan: row.minPlan,
+        configSchema: row.configSchema ?? null,
+        installed: row.install !== null,
+        installedAt: row.install?.installedAt ?? null,
+        installedBy: row.install?.installedBy ?? null,
+        installStatus: row.install?.status ?? null,
+        upsellOnly: !row.planAccessible,
+        accessible: row.planAccessible,
+        upgradeRequired: row.planAccessible ? null : row.minPlan,
+        pillar: row.pillar,
+        implementationStatus: row.implementationStatus,
+        installConfig,
+      };
+    });
 
     return c.json({ catalog }, 200);
   });

--- a/packages/api/src/api/routes/integrations.ts
+++ b/packages/api/src/api/routes/integrations.ts
@@ -325,15 +325,28 @@ function prefersHtml(req: Request): boolean {
   return accept.includes("text/html");
 }
 
-function buildAdminIntegrationsUrl(
+/**
+ * Per-platform admin destination for browser-facing redirects after the
+ * OAuth dance (success, reconnect, plan_upgrade_required, invalid_state,
+ * upstream_error). Most platforms render on `/admin/integrations`, but
+ * Salesforce moved to `/admin/connections` in #2745 — sending its
+ * callbacks to the old page would land users on a screen that no longer
+ * lists Salesforce. Add new exceptions here when a future platform
+ * follows the same pattern (Jira, etc.).
+ */
+function adminDestinationForPlatform(platform: string): string {
+  if (platform === "salesforce") return "/admin/connections";
+  return "/admin/integrations";
+}
+
+function buildPlatformAdminUrl(
   param: "installed" | "reconnect" | "error",
   platform: string,
   extra?: Record<string, string>,
 ): string {
   const webOrigin = getWebOrigin();
-  const base = webOrigin
-    ? `${webOrigin}/admin/integrations`
-    : "/admin/integrations";
+  const path = adminDestinationForPlatform(platform);
+  const base = webOrigin ? `${webOrigin}${path}` : path;
   const qs = new URLSearchParams({ [param]: platform, ...extra });
   return `${base}?${qs.toString()}`;
 }
@@ -575,7 +588,7 @@ integrations.openapi(installRoute, async (c) =>
         );
         if (prefersHtml(c.req.raw)) {
           return c.redirect(
-            buildAdminIntegrationsUrl("error", platform, {
+            buildPlatformAdminUrl("error", platform, {
               reason: "plan_upgrade_required",
               required_plan: planCheck.required_plan,
             }),
@@ -880,7 +893,7 @@ integrations.openapi(callbackRoute, async (c) =>
         );
         if (prefersHtml(c.req.raw)) {
           return c.redirect(
-            buildAdminIntegrationsUrl("error", platform, {
+            buildPlatformAdminUrl("error", platform, {
               reason: "plan_upgrade_required",
               required_plan: planCheck.required_plan,
             }),
@@ -916,7 +929,7 @@ integrations.openapi(callbackRoute, async (c) =>
           "Install callback failed: upstream OAuth exchange refused",
         );
         if (prefersHtml(c.req.raw)) {
-          return c.redirect(buildAdminIntegrationsUrl("error", platform, { reason: "upstream_error" }));
+          return c.redirect(buildPlatformAdminUrl("error", platform, { reason: "upstream_error" }));
         }
       }
       throw err;
@@ -928,19 +941,22 @@ integrations.openapi(callbackRoute, async (c) =>
       // redirect; JSON callers keep the 400.
       log.warn({ platform }, "Install callback rejected invalid state token");
       if (prefersHtml(c.req.raw)) {
-        return c.redirect(buildAdminIntegrationsUrl("error", platform, { reason: "invalid_state" }));
+        return c.redirect(buildPlatformAdminUrl("error", platform, { reason: "invalid_state" }));
       }
+      const restartFrom = adminDestinationForPlatform(platform);
       return c.json(
-        { error: "invalid_state", message: "Invalid or expired install state. Restart the install from /admin/integrations.", requestId },
+        { error: "invalid_state", message: `Invalid or expired install state. Restart the install from ${restartFrom}.`, requestId },
         400,
       );
     }
 
     // Success — redirect to admin UI. Partial-failure (credential write
-    // didn't land) flips the query param so /admin/integrations shows
-    // a Reconnect affordance per ADR-0003.
+    // didn't land) flips the query param so the admin page shows a
+    // Reconnect affordance per ADR-0003. Destination is per-platform
+    // (`adminDestinationForPlatform`) — Salesforce lives on
+    // `/admin/connections`, everything else on `/admin/integrations`.
     const queryParam = result.credentialResult.written ? "installed" : "reconnect";
-    return c.redirect(buildAdminIntegrationsUrl(queryParam, platform));
+    return c.redirect(buildPlatformAdminUrl(queryParam, platform));
   }),
 );
 

--- a/packages/api/src/lib/effect/__tests__/pillar-catalog-query.test.ts
+++ b/packages/api/src/lib/effect/__tests__/pillar-catalog-query.test.ts
@@ -62,6 +62,7 @@ function makeInstall(overrides: Partial<WorkspaceInstall> = {}): WorkspaceInstal
     installedBy: "user-1",
     status: null,
     disabled: false,
+    config: {},
     ...overrides,
   };
 }

--- a/packages/api/src/lib/effect/pillar-catalog-query.ts
+++ b/packages/api/src/lib/effect/pillar-catalog-query.ts
@@ -107,6 +107,14 @@ export interface WorkspaceInstall {
   readonly status: string | null;
   /** True when the install row's `enabled` column is false (disabled but not torn down). */
   readonly disabled: boolean;
+  /**
+   * Raw `workspace_plugins.config` JSONB. Carries operator-visible
+   * install metadata (Salesforce `instance_url` / `org_id`, Jira
+   * `cloud_id`, etc.). Secret-marked fields are NOT scrubbed here — the
+   * route layer applies {@link maskSecretFields} against the catalog
+   * row's `configSchema` before projecting to the wire.
+   */
+  readonly config: Record<string, unknown>;
 }
 
 /**
@@ -218,6 +226,7 @@ interface InstallRow extends Record<string, unknown> {
   installed_by: string | null;
   install_status: string | null;
   enabled: boolean;
+  config: unknown;
 }
 
 interface OrgRow extends Record<string, unknown> {
@@ -247,6 +256,14 @@ function rowToWorkspaceInstall(row: InstallRow): WorkspaceInstall {
   const installedAt = row.installed_at instanceof Date
     ? row.installed_at.toISOString()
     : String(row.installed_at);
+  // Defensive narrowing: the column is JSONB so pg returns either a plain
+  // object or `null`. Arrays / scalars would only land here on schema
+  // drift — treat them as empty config so the route's `maskSecretFields`
+  // pass doesn't spread a non-object across the wire envelope.
+  const config =
+    row.config && typeof row.config === "object" && !Array.isArray(row.config)
+      ? (row.config as Record<string, unknown>)
+      : {};
   return {
     id: row.id,
     catalogId: row.catalog_id,
@@ -257,6 +274,7 @@ function rowToWorkspaceInstall(row: InstallRow): WorkspaceInstall {
     installedBy: row.installed_by,
     status: row.install_status,
     disabled: row.enabled === false,
+    config,
   };
 }
 
@@ -461,7 +479,7 @@ function buildPillarCatalogQueryService(
               ),
               db.query<InstallRow>(
                 `SELECT id, catalog_id, install_id, workspace_id, pillar,
-                        installed_at, installed_by, enabled,
+                        installed_at, installed_by, enabled, config,
                         config->>'status' AS install_status
                    FROM workspace_plugins
                   WHERE workspace_id = $1`,

--- a/packages/web/src/app/admin/connections/__tests__/salesforce-block.test.tsx
+++ b/packages/web/src/app/admin/connections/__tests__/salesforce-block.test.tsx
@@ -246,6 +246,59 @@ describe("SalesforceProviderBlock", () => {
     ).not.toBeNull();
   });
 
+  test("upsell branch → renders locked Upgrade CTA, hides OAuth Connect link", async () => {
+    // The wire row carries the pre-#2701 fields the schema transforms
+    // into `access.kind === "upgrade"`. `accessible: false` /
+    // `upgradeRequired: "business"` is the canonical "below-plan"
+    // shape returned by the API for a workspace whose plan tier
+    // doesn't include Salesforce.
+    mockCatalog([
+      salesforceRow({
+        installed: false,
+        upsellOnly: true,
+        accessible: false,
+        upgradeRequired: "business",
+        minPlan: "business",
+      }),
+    ]);
+
+    const { container } = render(
+      <SalesforceProviderBlock demoReadOnly={false} onChange={() => undefined} />,
+    );
+
+    // Locked CTA renders with the same `data-testid` shape the
+    // `CatalogCard` upsell branch uses (`salesforce-locked-cta`) so a
+    // future refactor that conflates the two paths stays consistent.
+    const lockedBtn = await waitFor(() => {
+      const el = container.querySelector<HTMLButtonElement>(
+        'button[data-testid="salesforce-locked-cta"]',
+      );
+      if (!el) throw new Error("locked Upgrade CTA not rendered yet");
+      return el;
+    });
+    expect(lockedBtn.disabled).toBe(true);
+    expect(lockedBtn.textContent).toContain("Upgrade");
+
+    // The OAuth Connect anchor MUST NOT render under upsell — otherwise
+    // a click here would start OAuth only to be rejected server-side
+    // with `plan_upgrade_required`, the exact UX the PR review (P2)
+    // called out as broken.
+    expect(
+      container.querySelector('a[href*="/api/v1/integrations/salesforce/install"]'),
+    ).toBeNull();
+    expect(
+      container.querySelector('a[data-testid="salesforce-connect"]'),
+    ).toBeNull();
+
+    // Plan badge surfaces the required tier so the admin knows why
+    // they're locked out.
+    const badge = container.querySelector(
+      '[data-testid="salesforce-plan-badge"]',
+    );
+    expect(badge).not.toBeNull();
+    expect(badge!.textContent).toContain("business");
+  });
+
   test("coming_soon → inert Coming soon CTA, no Connect link", async () => {
     mockCatalog([
       salesforceRow({ implementationStatus: "coming_soon" }),

--- a/packages/web/src/app/admin/connections/__tests__/salesforce-block.test.tsx
+++ b/packages/web/src/app/admin/connections/__tests__/salesforce-block.test.tsx
@@ -1,0 +1,317 @@
+/**
+ * Render-branch coverage for the Salesforce provider block on
+ * `/admin/connections` — slice 7 of 1.5.3 (#2745).
+ *
+ * Three orthogonal branches the block must keep distinct:
+ *
+ *   1. Disconnected → CompactRow with an OAuth Connect link (NOT a URL
+ *      form CTA — Salesforce ships only the OAuth path).
+ *   2. Connected + status:'ok' → Shell with Instance URL / Org ID /
+ *      "Refresh token: Live" / install date detail rows, plus a
+ *      Disconnect action that hits `DELETE /api/v1/integrations/salesforce`.
+ *   3. Connected + status:'reconnect_needed' → Shell with destructive
+ *      "Reconnect needed" badge + Reconnect (primary) + Disconnect
+ *      (ghost) actions.
+ *
+ * Each branch is asserted via stable `data-testid` hooks so a future
+ * refactor that conflates them breaks loud at the assertion (rather
+ * than silently rendering the wrong CTA against production).
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  cleanup,
+  render as rtlRender,
+  type RenderResult,
+  waitFor,
+} from "@testing-library/react";
+import type { ReactElement } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { AtlasProvider } from "@/ui/context";
+import { SalesforceProviderBlock } from "../salesforce-block";
+
+// Catalog row whose `slug === "salesforce"` is the entire contract
+// between the route and this component. Other rows are filtered out
+// client-side by the `.find(... slug === "salesforce")` lookup.
+const SALESFORCE_ROW_DEFAULTS = {
+  id: "catalog:salesforce",
+  slug: "salesforce",
+  type: "integration" as const,
+  installModel: "oauth" as const,
+  name: "Salesforce",
+  description: "CRM objects via SOQL",
+  iconUrl: null,
+  minPlan: "starter",
+  configSchema: null,
+  installed: false,
+  installedAt: null as string | null,
+  installedBy: null as string | null,
+  installStatus: null as string | null,
+  upsellOnly: false,
+  accessible: true,
+  upgradeRequired: null as string | null,
+  pillar: "datasource" as const,
+  implementationStatus: "available" as const,
+  installConfig: null as Record<string, unknown> | null,
+};
+
+function salesforceRow(
+  overrides: Partial<typeof SALESFORCE_ROW_DEFAULTS> = {},
+): Record<string, unknown> {
+  return { ...SALESFORCE_ROW_DEFAULTS, ...overrides };
+}
+
+const testConfig = {
+  apiUrl: "http://localhost:3001",
+  isCrossOrigin: false,
+  authClient: {
+    getToken: async () => null,
+    getOrgId: () => null,
+    onAuthChange: () => () => undefined,
+  },
+};
+
+function render(ui: ReactElement): RenderResult {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return rtlRender(
+    <QueryClientProvider client={queryClient}>
+      <AtlasProvider config={testConfig}>{ui}</AtlasProvider>
+    </QueryClientProvider>,
+  );
+}
+
+describe("SalesforceProviderBlock", () => {
+  const originalFetch = globalThis.fetch;
+
+  /**
+   * Stub the catalog GET with a single row (or none). Mirrors the
+   * pattern used in catalog-section.test.tsx so the test surface stays
+   * familiar.
+   */
+  function mockCatalog(entries: ReadonlyArray<Record<string, unknown>>) {
+    globalThis.fetch = mock((input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.endsWith("/api/v1/integrations/catalog")) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ catalog: entries }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    }) as unknown as typeof fetch;
+  }
+
+  beforeEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    cleanup();
+  });
+
+  test("disconnected → renders OAuth Connect link, not a URL-form CTA", async () => {
+    mockCatalog([salesforceRow({ installed: false })]);
+    const { container } = render(
+      <SalesforceProviderBlock demoReadOnly={false} onChange={() => undefined} />,
+    );
+
+    // The Connect anchor points at the OAuth install endpoint —
+    // anchor-with-href is the regression guard against a future refactor
+    // that wires Salesforce into the generic URL-form dialog.
+    const link = await waitFor(() => {
+      const el = container.querySelector<HTMLAnchorElement>(
+        'a[data-testid="salesforce-connect"], a[href*="/api/v1/integrations/salesforce/install"]',
+      );
+      if (!el) throw new Error("Connect link not rendered yet");
+      return el;
+    });
+    expect(link.tagName).toBe("A");
+    expect(link.getAttribute("href")).toContain(
+      "/api/v1/integrations/salesforce/install",
+    );
+    expect(link.textContent).toContain("Connect");
+
+    // Defensive: the page-wide URL-form dialog (which lives in
+    // ConnectionFormDialog under page.tsx) is never opened from this
+    // block. Asserting the absence of an open <dialog> rules out a
+    // future regression where the block accidentally renders one.
+    expect(container.querySelector('button[aria-label="Add connection"]')).toBeNull();
+  });
+
+  test("disconnected + demoReadOnly → Connect button is disabled", async () => {
+    mockCatalog([salesforceRow({ installed: false })]);
+    const { container } = render(
+      <SalesforceProviderBlock demoReadOnly={true} onChange={() => undefined} />,
+    );
+
+    const btn = await waitFor(() => {
+      const el = container.querySelector<HTMLButtonElement>(
+        'button[disabled]',
+      );
+      if (!el || !el.textContent?.includes("Connect")) {
+        throw new Error("disabled Connect button not rendered yet");
+      }
+      return el;
+    });
+    expect(btn.disabled).toBe(true);
+  });
+
+  test("connected + status:'ok' → Shell renders Instance URL / Org ID / Live", async () => {
+    mockCatalog([
+      salesforceRow({
+        installed: true,
+        installedAt: "2026-05-20T10:00:00.000Z",
+        installedBy: "admin@example.com",
+        installStatus: "ok",
+        installConfig: {
+          instance_url: "https://na139.my.salesforce.com",
+          org_id: "00DAB000000ZmU8",
+          scopes: "api refresh_token offline_access",
+          status: "ok",
+        },
+      }),
+    ]);
+
+    const { container, findByText } = render(
+      <SalesforceProviderBlock demoReadOnly={false} onChange={() => undefined} />,
+    );
+
+    // Instance URL detail row carries the post-OAuth tenant host.
+    await findByText("https://na139.my.salesforce.com");
+    await findByText("00DAB000000ZmU8");
+
+    // "Refresh token: Live" — the freshness pill maps installStatus='ok'
+    // to a primary-color "Live" label inside the DetailRow.
+    expect(container.textContent).toContain("Refresh token");
+    expect(container.textContent).toContain("Live");
+
+    // The Disconnect button is rendered as a routine "outline" CTA (no
+    // Reconnect competing for primary attention).
+    expect(
+      container.querySelector('button[data-testid="salesforce-disconnect"]'),
+    ).not.toBeNull();
+    // Reconnect badge / primary CTA must NOT appear in the healthy state.
+    expect(
+      container.querySelector('[data-testid="salesforce-reconnect-badge"]'),
+    ).toBeNull();
+  });
+
+  test("connected + status:'reconnect_needed' → Reconnect leads, Disconnect recedes", async () => {
+    mockCatalog([
+      salesforceRow({
+        installed: true,
+        installedAt: "2026-05-20T10:00:00.000Z",
+        installedBy: "admin@example.com",
+        installStatus: "reconnect_needed",
+        installConfig: {
+          instance_url: "https://na139.my.salesforce.com",
+          org_id: "00DAB000000ZmU8",
+          status: "reconnect_needed",
+        },
+      }),
+    ]);
+
+    const { container } = render(
+      <SalesforceProviderBlock demoReadOnly={false} onChange={() => undefined} />,
+    );
+
+    // Reconnect-needed badge surfaces on the Shell title.
+    await waitFor(() => {
+      const badge = container.querySelector(
+        '[data-testid="salesforce-reconnect-badge"]',
+      );
+      if (!badge) throw new Error("reconnect badge not rendered yet");
+      return badge;
+    });
+
+    // Reconnect link is rendered as the primary CTA (same href as
+    // Connect — the OAuth callback upserts the install row in place).
+    const reconnect = container.querySelector<HTMLAnchorElement>(
+      '[data-testid="salesforce-reconnect"]',
+    );
+    expect(reconnect).not.toBeNull();
+    expect(reconnect!.getAttribute("href")).toContain(
+      "/api/v1/integrations/salesforce/install",
+    );
+
+    // Disconnect button is still available; just recedes to a ghost
+    // variant beside Reconnect.
+    expect(
+      container.querySelector('button[data-testid="salesforce-disconnect"]'),
+    ).not.toBeNull();
+  });
+
+  test("coming_soon → inert Coming soon CTA, no Connect link", async () => {
+    mockCatalog([
+      salesforceRow({ implementationStatus: "coming_soon" }),
+    ]);
+    const { container } = render(
+      <SalesforceProviderBlock demoReadOnly={false} onChange={() => undefined} />,
+    );
+
+    await waitFor(() => {
+      const btn = Array.from(
+        container.querySelectorAll<HTMLButtonElement>("button"),
+      ).find((b) => b.textContent?.includes("Coming soon"));
+      if (!btn) throw new Error("Coming soon CTA not rendered yet");
+      return btn;
+    });
+    // OAuth Connect link must not be rendered when the row is gated by
+    // coming_soon — otherwise the admin could initiate an OAuth flow
+    // against an unshipped install handler.
+    expect(
+      container.querySelector('a[href*="/api/v1/integrations/salesforce/install"]'),
+    ).toBeNull();
+  });
+
+  test("salesforce row absent from catalog → renders nothing", async () => {
+    mockCatalog([
+      // Some other catalog row, no salesforce entry. The catalog seeder
+      // ensures `salesforce` exists today, but the deploy posture
+      // (catalog enabled column = false / seeder hasn't run) can hide
+      // it. Render-nothing is safer than rendering a broken Connect.
+      {
+        id: "catalog:slack",
+        slug: "slack",
+        type: "chat",
+        installModel: "oauth",
+        name: "Slack",
+        description: null,
+        iconUrl: null,
+        minPlan: "starter",
+        configSchema: null,
+        installed: false,
+        installedAt: null,
+        installedBy: null,
+        installStatus: null,
+        upsellOnly: false,
+        accessible: true,
+        upgradeRequired: null,
+        pillar: "chat",
+        implementationStatus: "available",
+        installConfig: null,
+      },
+    ]);
+    const { container } = render(
+      <SalesforceProviderBlock demoReadOnly={false} onChange={() => undefined} />,
+    );
+
+    // Catalog fetch resolves and finds no salesforce row → component
+    // returns null. Wait for the fetch to settle by waiting for any
+    // microtask flush.
+    await waitFor(() => {
+      // The loading skeleton renders a "Salesforce" CompactRow with
+      // "Loading…" — after the fetch settles, the absent-row branch
+      // must clean it up entirely.
+      const loading = container.textContent ?? "";
+      if (loading.includes("Loading")) throw new Error("still loading");
+    });
+    expect(container.querySelector('a[href*="salesforce/install"]')).toBeNull();
+    expect(container.querySelector('[data-testid="salesforce-connect"]')).toBeNull();
+  });
+});

--- a/packages/web/src/app/admin/connections/page.tsx
+++ b/packages/web/src/app/admin/connections/page.tsx
@@ -99,6 +99,7 @@ import {
   type PoolMetrics,
 } from "@/ui/lib/types";
 import { ConnectionsResponseSchema } from "@/ui/lib/admin-schemas";
+import { SalesforceProviderBlock } from "./salesforce-block";
 
 // ── Connection Form Dialog ───────────────────────────────────────
 
@@ -1282,6 +1283,23 @@ export default function ConnectionsPage() {
                 <SectionHeading title="Datasources" description="Providers Atlas can read from" />
                 <div className="space-y-2">
                   {providerOrder.map((dbType) => {
+                    // Salesforce is plugin-managed and lives in
+                    // `workspace_plugins WHERE pillar = 'datasource'`
+                    // post-#2744 cutover — `connections.describe()`
+                    // doesn't surface it, so the generic ProviderBlock
+                    // would always render "Add connection" pointing at a
+                    // URL-form dialog that has no input shape for the
+                    // OAuth flow. Render the dedicated block instead
+                    // (slice 7 of 1.5.3, #2745).
+                    if (dbType === "salesforce") {
+                      return (
+                        <SalesforceProviderBlock
+                          key={dbType}
+                          demoReadOnly={demoReadOnly}
+                          onChange={handleMutationSuccess}
+                        />
+                      );
+                    }
                     const conns = byType.get(dbType) ?? [];
                     return (
                       <ProviderBlock

--- a/packages/web/src/app/admin/connections/page.tsx
+++ b/packages/web/src/app/admin/connections/page.tsx
@@ -100,6 +100,7 @@ import {
 } from "@/ui/lib/types";
 import { ConnectionsResponseSchema } from "@/ui/lib/admin-schemas";
 import { SalesforceProviderBlock } from "./salesforce-block";
+import { useRouter, useSearchParams } from "next/navigation";
 
 // ── Connection Form Dialog ───────────────────────────────────────
 
@@ -485,11 +486,21 @@ function ConnectionFormDialog({
                     </SelectTrigger>
                   </FormControl>
                   <SelectContent>
-                    {DB_TYPES.map((t) => (
+                    {DB_TYPES.filter((t) => t.value !== "salesforce").map((t) => (
                       <SelectItem key={t.value} value={t.value}>
                         {t.label}
                       </SelectItem>
                     ))}
+                    {/*
+                      Salesforce intentionally not listed: it's not a URL-form
+                      connection — installs happen via the OAuth dance on the
+                      Salesforce row above (#2745). Picking it here would
+                      create a `connections` row that immediately disappears
+                      from the page (the Salesforce slot renders the OAuth
+                      block instead) and that's never queryable because the
+                      Salesforce adapter reads its install from
+                      `workspace_plugins`, not `connections`.
+                    */}
                   </SelectContent>
                 </Select>
                 <FormMessage />
@@ -1052,6 +1063,54 @@ export default function ConnectionsPage() {
     { schema: ConnectionsResponseSchema },
   );
 
+  // ── OAuth callback toast handling for Salesforce (#2745) ────────────
+  //
+  // The Salesforce OAuth callback at `/api/v1/integrations/salesforce/callback`
+  // redirects browsers here with `?installed=salesforce`, `?reconnect=salesforce`,
+  // or `?error=salesforce&reason=<code>` (see `adminDestinationForPlatform`
+  // in `packages/api/src/api/routes/integrations.ts`). Mirror the toast +
+  // URL-cleanup pattern from `/admin/integrations` so the user sees a
+  // success / reconnect / error toast and a refresh doesn't replay it.
+  // Other platforms still land on `/admin/integrations`, so this handler
+  // is intentionally scoped to the `salesforce` slug only.
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  useEffect(() => {
+    const installed = searchParams.get("installed");
+    const reconnect = searchParams.get("reconnect");
+    const errParam = searchParams.get("error");
+    const reason = searchParams.get("reason");
+    if (!installed && !reconnect && !errParam) return;
+
+    if (installed === "salesforce") {
+      toast.success("Salesforce connected");
+      refetch();
+    }
+    if (reconnect === "salesforce") {
+      toast.warning("Salesforce install completed but credentials didn't persist", {
+        description: "Click Reconnect on the Salesforce row to retry the OAuth dance.",
+      });
+      refetch();
+    }
+    if (errParam === "salesforce") {
+      const description =
+        reason === "plan_upgrade_required"
+          ? "Your workspace plan doesn't include Salesforce. Upgrade and try again."
+          : reason === "invalid_state"
+            ? "The install link expired. Click Connect on the Salesforce row to start again."
+            : reason === "upstream_error"
+              ? "Salesforce refused the OAuth code. Click Connect to retry — if the problem persists, check the connected-app credentials."
+              : "Click Connect on the Salesforce row to retry.";
+      toast.error("Couldn't connect Salesforce", { description });
+    }
+
+    // Strip the four callback keys; preserve any other params for future use.
+    const next = new URLSearchParams(searchParams);
+    for (const key of ["installed", "reconnect", "error", "reason"]) next.delete(key);
+    const url = next.size > 0 ? `/admin/connections?${next.toString()}` : "/admin/connections";
+    router.replace(url, { scroll: false });
+  }, [searchParams, refetch, router]);
+
   // Post-0096 cutover (#2744 / ADR-0007): `/api/v1/admin/connection-groups`
   // is gone (collapsed into JSONB strings on each install). Derive the
   // env dropdown choices inline from the same connections list the page
@@ -1289,15 +1348,34 @@ export default function ConnectionsPage() {
                     // doesn't surface it, so the generic ProviderBlock
                     // would always render "Add connection" pointing at a
                     // URL-form dialog that has no input shape for the
-                    // OAuth flow. Render the dedicated block instead
-                    // (slice 7 of 1.5.3, #2745).
+                    // OAuth flow. Render the dedicated block, AND fall
+                    // through to render any legacy `connections` rows
+                    // with `db_type = salesforce` via `ProviderBlock`
+                    // so admins can still see + delete pre-cutover rows
+                    // (slice 7 of 1.5.3, #2745 — see PR review).
                     if (dbType === "salesforce") {
+                      const legacyConns = byType.get(dbType) ?? [];
                       return (
-                        <SalesforceProviderBlock
-                          key={dbType}
-                          demoReadOnly={demoReadOnly}
-                          onChange={handleMutationSuccess}
-                        />
+                        <div key={dbType} className="space-y-2">
+                          <SalesforceProviderBlock
+                            demoReadOnly={demoReadOnly}
+                            onChange={handleMutationSuccess}
+                          />
+                          {legacyConns.length > 0 ? (
+                            <ProviderBlock
+                              dbType={dbType}
+                              connections={legacyConns}
+                              demoReadOnly={demoReadOnly}
+                              loadingDetail={loadingDetail}
+                              testMutation={testMutation}
+                              testStatus={testStatus}
+                              onTest={testConnection}
+                              onEdit={handleEdit}
+                              onDelete={handleDelete}
+                              onAdd={handleAdd}
+                            />
+                          ) : null}
+                        </div>
                       );
                     }
                     const conns = byType.get(dbType) ?? [];

--- a/packages/web/src/app/admin/connections/salesforce-block.tsx
+++ b/packages/web/src/app/admin/connections/salesforce-block.tsx
@@ -42,7 +42,9 @@ import {
   ExternalLink,
   HardDrive,
   Loader2,
+  Lock,
   Plus,
+  Sparkles,
 } from "lucide-react";
 import {
   AlertDialog,
@@ -212,6 +214,57 @@ export function SalesforceProviderBlock({
 
   // ── Disconnected branch ──────────────────────────────────────────
   if (!installed) {
+    // Plan-gate the Connect CTA: when the catalog row reports
+    // `access.kind === "upgrade"`, the backend `/install` endpoint will
+    // refuse with `plan_upgrade_required` (`integrations.ts` plan-tier
+    // gate). Mirror the upgrade-gated UI from `CatalogCard` so the user
+    // sees the lock and required plan up front instead of bouncing
+    // through OAuth to a 403 redirect. The downgraded-while-installed
+    // case is handled separately by the connected branch — its
+    // Reconnect button keeps working even on a downgraded plan
+    // (matching the DELETE path's "must let downgraded customers
+    // clean up" posture in #2701).
+    if (entry.access.kind === "upgrade") {
+      const requiredPlan = entry.access.requiredPlan ?? entry.minPlan;
+      return (
+        <CompactRow
+          icon={HardDrive}
+          title={entry.name}
+          description={entry.description ?? `Premium — requires ${requiredPlan}`}
+          status="unavailable"
+          statusLabel={`Premium — requires ${requiredPlan}`}
+          action={
+            <div className="flex items-center gap-1.5">
+              <Lock
+                className="size-3.5 text-muted-foreground"
+                aria-label="Premium integration"
+                data-testid="salesforce-lock-icon"
+              />
+              <Badge
+                variant="outline"
+                className="gap-1 text-[10px]"
+                data-testid="salesforce-plan-badge"
+              >
+                <Sparkles className="size-3" />
+                Premium — requires {requiredPlan}
+              </Badge>
+              <Button
+                size="sm"
+                variant="outline"
+                disabled
+                aria-label={`Available on ${requiredPlan} plans and above`}
+                title={`Available on ${requiredPlan} plans and above`}
+                data-testid="salesforce-locked-cta"
+              >
+                <Lock className="mr-1 size-3" />
+                Upgrade
+              </Button>
+            </div>
+          }
+        />
+      );
+    }
+
     const installHref = `${getApiUrl()}/api/v1/integrations/${SALESFORCE_SLUG}/install`;
     return (
       <CompactRow

--- a/packages/web/src/app/admin/connections/salesforce-block.tsx
+++ b/packages/web/src/app/admin/connections/salesforce-block.tsx
@@ -1,0 +1,439 @@
+"use client";
+
+/**
+ * Salesforce render path for `/admin/connections` — slice 7 of 1.5.3 (#2745).
+ *
+ * Salesforce is a `workspace_plugins WHERE pillar = 'datasource'` row post-slice-6
+ * cutover, but it's plugin-managed (not native postgres/mysql) so
+ * `ConnectionRegistry.describe()` doesn't surface it. The /admin/connections
+ * list (`/api/v1/admin/connections`) projects from the registry, so Salesforce
+ * installs are invisible there. This component bridges the gap by reading the
+ * catalog endpoint directly, finding the `salesforce` row, and rendering the
+ * same provider block shape (CompactRow when disconnected, Shell when
+ * connected) the SQL provider blocks use.
+ *
+ * Connect/Disconnect routes:
+ *   - Connect    → `<a href=/api/v1/integrations/salesforce/install>` (OAuth dance,
+ *                  handled by {@link SalesforceOAuthInstallHandler})
+ *   - Disconnect → `DELETE /api/v1/integrations/salesforce` (catalog endpoint,
+ *                  routes through `WorkspaceInstaller.uninstall` per
+ *                  ADR-0007 — both the workspace_plugins row and the
+ *                  integration_credentials entry are removed)
+ *   - Reconnect  → same href as Connect (the OAuth callback upserts the
+ *                  install row, healing an expired refresh token in place)
+ *
+ * Detail rows surfaced when connected:
+ *   - Instance URL (`installConfig.instance_url`) — the per-tenant Salesforce
+ *     host. Differs from the login host (login.salesforce.com vs the
+ *     workspace's na139.my.salesforce.com); always rendered as-is so admins
+ *     can verify they connected the right tenant.
+ *   - Org ID        (`installConfig.org_id`)
+ *   - Refresh token freshness — derived from `installStatus`. `'ok'` →
+ *     "Refresh token live"; `'reconnect_needed'` → red destructive copy.
+ *   - Connected (installedAt · installedBy)
+ *
+ * The catalog endpoint scrubs secret-marked fields server-side via
+ * `maskSecretFields` (`integrations-catalog.ts:projectInstallConfig`), so this
+ * component renders `installConfig` directly without re-scrubbing.
+ */
+
+import { toast } from "sonner";
+import {
+  ExternalLink,
+  HardDrive,
+  Loader2,
+  Plus,
+} from "lucide-react";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  CompactRow,
+  DetailList,
+  DetailRow,
+  InlineError,
+  Shell,
+} from "@/ui/components/admin/compact";
+import { useAdminFetch } from "@/ui/hooks/use-admin-fetch";
+import { useAdminMutation } from "@/ui/hooks/use-admin-mutation";
+import { IntegrationsCatalogResponseSchema } from "@/ui/lib/admin-schemas";
+import { friendlyErrorOrNull } from "@/ui/lib/fetch-error";
+import { getApiUrl } from "@/lib/api-url";
+import { formatDateTime } from "@/lib/format";
+
+const SALESFORCE_SLUG = "salesforce";
+
+/**
+ * Read an `installConfig` field as a non-empty string. The catalog
+ * scrubs secret-marked fields to a masked placeholder, but Salesforce's
+ * `instance_url` / `org_id` are non-secret operational fields by
+ * construction (the access/refresh tokens live in
+ * `integration_credentials`). Returns `null` for absent / non-string /
+ * empty values so the detail row hides cleanly.
+ */
+function readStringField(
+  installConfig: Record<string, unknown> | null | undefined,
+  key: string,
+): string | null {
+  if (!installConfig) return null;
+  const value = installConfig[key];
+  if (typeof value !== "string" || value.length === 0) return null;
+  return value;
+}
+
+interface SalesforceProviderBlockProps {
+  /**
+   * Demo-readonly gate from the parent page. When true, the Connect
+   * affordance is rendered as a disabled button (consistent with the
+   * SQL-provider blocks). Salesforce doesn't ship a demo install today
+   * so this primarily exists for shape parity — flipping it disables
+   * the Connect CTA so the user can't initiate a destructive flow in
+   * published mode without an active workspace.
+   */
+  readonly demoReadOnly: boolean;
+  /** Fires after a disconnect succeeds so the parent refreshes its lists. */
+  readonly onChange: () => void;
+}
+
+/**
+ * Provider block for the Salesforce row on `/admin/connections`. Parallel
+ * to the {@link ProviderBlock} in `page.tsx` — same CompactRow / Shell
+ * shape, but the install lookup goes through the catalog endpoint
+ * (`/api/v1/integrations/catalog`) instead of the connections endpoint.
+ */
+export function SalesforceProviderBlock({
+  demoReadOnly,
+  onChange,
+}: SalesforceProviderBlockProps) {
+  const catalogQuery = useAdminFetch("/api/v1/integrations/catalog", {
+    schema: IntegrationsCatalogResponseSchema,
+  });
+
+  const disconnect = useAdminMutation<{ message: string }>({
+    path: `/api/v1/integrations/${SALESFORCE_SLUG}`,
+    method: "DELETE",
+    invalidates: () => {
+      catalogQuery.refetch();
+      onChange();
+    },
+  });
+
+  // Loading + error states: render a single disabled CompactRow so the
+  // page layout doesn't jump. The provider row is the smallest
+  // self-contained element on the page — surfacing a skeleton there
+  // would be noisier than a one-line "loading" state.
+  if (catalogQuery.loading) {
+    return (
+      <CompactRow
+        icon={HardDrive}
+        title="Salesforce"
+        description="Loading…"
+        status="disconnected"
+        action={
+          <Button size="sm" variant="outline" disabled>
+            <Loader2 className="mr-1.5 size-3.5 animate-spin" />
+            Connect
+          </Button>
+        }
+      />
+    );
+  }
+
+  // Fail-soft on catalog read failure: surface a disconnected block with
+  // an inline error in the action slot so the rest of the page renders.
+  // The catalog endpoint is shared with /admin/integrations — a hard
+  // failure there is already surfaced by `useAdminFetch`'s retry hook;
+  // here we just need to avoid blanking the Salesforce row entirely.
+  if (catalogQuery.error) {
+    const message =
+      friendlyErrorOrNull(catalogQuery.error) ?? "Failed to load catalog.";
+    return (
+      <CompactRow
+        icon={HardDrive}
+        title="Salesforce"
+        description={message}
+        status="unhealthy"
+        action={
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => catalogQuery.refetch()}
+          >
+            Retry
+          </Button>
+        }
+      />
+    );
+  }
+
+  const entry = catalogQuery.data?.catalog.find(
+    (e) => e.slug === SALESFORCE_SLUG,
+  );
+
+  // Salesforce row absent from the catalog → don't render anything. This
+  // happens on deploys where the catalog seeder hasn't run yet or where
+  // the row was explicitly disabled via ops. Rendering a Connect CTA
+  // that would 404 against `/api/v1/integrations/salesforce/install`
+  // would be worse than hiding the row.
+  if (!entry) return null;
+
+  // Coming-soon dominates everything else — render an inert row that
+  // signals "Atlas hasn't shipped this yet" without misleading the admin
+  // into clicking. Mirrors the CatalogCard coming-soon branch.
+  if (entry.implementationStatus === "coming_soon") {
+    return (
+      <CompactRow
+        icon={HardDrive}
+        title={entry.name}
+        description={entry.description ?? "Coming soon"}
+        status="unavailable"
+        statusLabel="Coming soon"
+        action={
+          <Button size="sm" variant="outline" disabled>
+            Coming soon
+          </Button>
+        }
+      />
+    );
+  }
+
+  const installed = entry.installed;
+  const needsReconnect = installed && entry.installStatus === "reconnect_needed";
+
+  // ── Disconnected branch ──────────────────────────────────────────
+  if (!installed) {
+    const installHref = `${getApiUrl()}/api/v1/integrations/${SALESFORCE_SLUG}/install`;
+    return (
+      <CompactRow
+        icon={HardDrive}
+        title={entry.name}
+        description={entry.description ?? "CRM objects via SOQL"}
+        status="disconnected"
+        action={
+          demoReadOnly ? (
+            <Button size="sm" variant="outline" disabled>
+              <Plus className="mr-1.5 size-3.5" />
+              Connect
+            </Button>
+          ) : (
+            <Button
+              size="sm"
+              asChild
+              aria-label={`Connect ${entry.name}`}
+              data-testid="salesforce-connect"
+            >
+              <a href={installHref}>
+                <ExternalLink className="mr-1.5 size-3.5" />
+                Connect
+              </a>
+            </Button>
+          )
+        }
+      />
+    );
+  }
+
+  // ── Connected branch (render in Shell shape, matching SQL provider) ──
+  const installHref = `${getApiUrl()}/api/v1/integrations/${SALESFORCE_SLUG}/install`;
+  const instanceUrl = readStringField(entry.installConfig, "instance_url");
+  const orgId = readStringField(entry.installConfig, "org_id");
+
+  async function handleDisconnect() {
+    const result = await disconnect.mutate({});
+    if (result.ok) {
+      toast.success("Salesforce disconnected");
+    } else {
+      const message =
+        friendlyErrorOrNull(result.error) ?? "Couldn't disconnect Salesforce";
+      toast.error(message);
+    }
+  }
+
+  return (
+    <Shell
+      icon={HardDrive}
+      title="Salesforce"
+      description={entry.description ?? "CRM objects via SOQL"}
+      status={needsReconnect ? "unhealthy" : "connected"}
+      statusLabel={needsReconnect ? "Reconnect needed" : "Live"}
+      titleBadge={
+        needsReconnect ? (
+          <Badge
+            variant="destructive"
+            className="text-[10px]"
+            data-testid="salesforce-reconnect-badge"
+          >
+            Reconnect needed
+          </Badge>
+        ) : (
+          <Badge variant="secondary" className="text-[10px]">
+            Connected
+          </Badge>
+        )
+      }
+      actions={
+        <SalesforceActions
+          name={entry.name}
+          needsReconnect={needsReconnect}
+          installHref={installHref}
+          disconnecting={disconnect.saving}
+          onDisconnect={handleDisconnect}
+        />
+      }
+    >
+      <DetailList>
+        {instanceUrl ? (
+          <DetailRow label="Instance URL" value={instanceUrl} mono truncate />
+        ) : null}
+        {orgId ? <DetailRow label="Org ID" value={orgId} mono truncate /> : null}
+        <DetailRow
+          label="Refresh token"
+          value={
+            <span
+              className={
+                needsReconnect
+                  ? "text-destructive"
+                  : "text-primary"
+              }
+            >
+              {needsReconnect ? "Reconnect required" : "Live"}
+            </span>
+          }
+        />
+        {entry.installedAt ? (
+          <DetailRow
+            label="Connected"
+            value={
+              entry.installedBy
+                ? `${formatDateTime(entry.installedAt)} · by ${entry.installedBy}`
+                : formatDateTime(entry.installedAt)
+            }
+          />
+        ) : null}
+      </DetailList>
+
+      {disconnect.error ? (
+        <InlineError>
+          {friendlyErrorOrNull(disconnect.error) ?? "Disconnect failed."}
+        </InlineError>
+      ) : null}
+    </Shell>
+  );
+}
+
+interface SalesforceActionsProps {
+  readonly name: string;
+  readonly needsReconnect: boolean;
+  readonly installHref: string;
+  readonly disconnecting: boolean;
+  readonly onDisconnect: () => void;
+}
+
+/**
+ * Action footer for the connected Salesforce Shell. Mirrors the
+ * `ShellActions` shape in `catalog-card.tsx`: when `needsReconnect`,
+ * Reconnect is the primary CTA and Disconnect recedes to ghost;
+ * otherwise Disconnect is the only routine action and Reconnect stays
+ * ghost so it doesn't compete for attention.
+ */
+function SalesforceActions({
+  name,
+  needsReconnect,
+  installHref,
+  disconnecting,
+  onDisconnect,
+}: SalesforceActionsProps) {
+  if (needsReconnect) {
+    return (
+      <>
+        <Button size="sm" asChild data-testid="salesforce-reconnect">
+          <a href={installHref}>
+            <ExternalLink className="mr-1.5 size-3.5" />
+            Reconnect
+          </a>
+        </Button>
+        <SalesforceDisconnectDialog
+          name={name}
+          variant="ghost"
+          disconnecting={disconnecting}
+          onConfirm={onDisconnect}
+        />
+      </>
+    );
+  }
+  return (
+    <>
+      <SalesforceDisconnectDialog
+        name={name}
+        disconnecting={disconnecting}
+        onConfirm={onDisconnect}
+      />
+      <Button variant="ghost" size="sm" asChild>
+        <a href={installHref}>
+          <ExternalLink className="mr-1.5 size-3.5" />
+          Reconnect
+        </a>
+      </Button>
+    </>
+  );
+}
+
+function SalesforceDisconnectDialog({
+  name,
+  disconnecting,
+  onConfirm,
+  variant = "outline",
+}: {
+  name: string;
+  disconnecting: boolean;
+  onConfirm: () => void;
+  variant?: "outline" | "ghost";
+}) {
+  return (
+    <AlertDialog>
+      <AlertDialogTrigger asChild>
+        <Button
+          variant={variant}
+          size="sm"
+          disabled={disconnecting}
+          data-testid="salesforce-disconnect"
+        >
+          {disconnecting ? (
+            <Loader2 className="mr-1.5 size-3.5 animate-spin" />
+          ) : null}
+          Disconnect
+        </Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Disconnect {name}?</AlertDialogTitle>
+          <AlertDialogDescription>
+            This removes the Salesforce install for this workspace. Atlas will
+            stop running SOQL queries through the connected org until you
+            reconnect. Both the workspace_plugins row and the stored OAuth
+            refresh token are deleted.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={onConfirm}
+            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+          >
+            Disconnect
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/packages/web/src/ui/lib/admin-schemas.ts
+++ b/packages/web/src/ui/lib/admin-schemas.ts
@@ -353,6 +353,14 @@ const RawCatalogEntrySchema = z.object({
   // the legacy `type` field.
   pillar: z.enum(["datasource", "chat", "action"]).optional(),
   implementationStatus: z.enum(["available", "coming_soon"]).optional(),
+  // ── New in #2745 (slice 7 of 1.5.3) ──────────────────────────────
+  // Non-secret subset of `workspace_plugins.config` for installed rows.
+  // Carries Salesforce `instance_url` / `org_id`, Jira `cloud_id`, etc.
+  // Optional so older API responses (pre-#2745) parse via the same
+  // schema — `/admin/connections` defaults to a generic detail row when
+  // the field is absent. `null` is the explicit "row not installed"
+  // signal; treat it the same as absent at the render layer.
+  installConfig: z.record(z.string(), z.unknown()).nullable().optional(),
 });
 
 /**


### PR DESCRIPTION
## Summary

Slice 7 of 17 in milestone 1.5.3. Salesforce now renders as a real provider row under `/admin/connections` instead of a stub on `/admin/integrations`, per [ADR-0006](docs/adr/0006-three-pillar-integration-taxonomy.md) §"One user-facing surface per pillar".

- **`/admin/connections`** — new `SalesforceProviderBlock` (parallel to the SQL `ProviderBlock`) reads the catalog endpoint:
  - Disconnected → CompactRow with an OAuth Connect link (`<a href=/api/v1/integrations/salesforce/install>`), **not** a URL-form dialog
  - Connected → Shell with detail rows: **Instance URL**, **Org ID**, **Refresh token freshness** (derived from `installStatus`), **Connected (installedAt · installedBy)**
  - `installStatus = 'reconnect_needed'` → destructive "Reconnect needed" badge + primary Reconnect CTA, Disconnect recedes to ghost
  - Disconnect routes through `DELETE /api/v1/integrations/salesforce` (`WorkspaceInstaller.uninstall` — workspace_plugins row + integration_credentials entry both removed per ADR-0005 + ADR-0007)
- **`/api/v1/integrations/catalog`** wire response gains an optional `installConfig` field — the non-secret subset of `workspace_plugins.config`, scrubbed via `maskSecretFields` against the catalog row's `config_schema.fields[].secret` flag. Generic enough that the upcoming chat-install slices (Jira instance, Teams tenant, etc.) read through the same channel.
- **`/admin/integrations`** catalog stub already filters `pillar = 'datasource'` rows (filter landed with #2791); this PR closes the loop by giving Salesforce a real home.
- **Docs** — `apps/docs/content/docs/plugins/datasources/salesforce.mdx` updated with the OAuth flow + Connected App setup; the legacy static-config block is retained for self-hosted operators under a new "Self-hosted (static config)" header.

The `SalesforceOAuthInstallHandler` (#2658) is reused as-is — no backend install-path changes. No new migration; the `salesforce` catalog row already exists from slice 5 (#2743/#2778).

Closes #2745.

## Test plan

- [x] `bun run lint` — clean
- [x] `bun run type` — clean (tsgo)
- [x] `bun run scripts/test-isolated.ts --affected` (api) — 4/4 pass (pillar-catalog-query + integrations-catalog + 2 unrelated)
- [x] `bun run scripts/test-isolated.ts src/app/admin/connections` (web) — 2/2 pass (new `salesforce-block.test.tsx` covers 6 render branches: disconnected OAuth link, demo-readonly disabled, connected `ok`, connected `reconnect_needed`, `coming_soon`, absent-row)
- [x] `bun run scripts/test-isolated.ts src/app/admin/integrations` (web) — 2/2 pass (catalog-section filter test green)
- [x] `bun run scripts/test-isolated.ts integrations` (api) — 29/29 pass (salesforce-oauth-handler, salesforce-token-refresh, register, lazy-builder, etc.)
- [x] `bun run scripts/test-isolated.ts workspace-installer` (api) — 1/1 pass
- [x] Drift checks: schema, template, EE imports, legacy-connections SQL, railway-watch — all green
- [x] `bunx syncpack lint` — no issues
- [ ] **Manual dogfood smoke pending** — needs a Salesforce sandbox account + `SALESFORCE_CLIENT_ID`/`SECRET` env vars. The CLAUDE.md "test the UI in a browser before declaring done" rule applies; flagging this as a follow-up the reviewer (or final pre-merge verification) needs to run before closing #2745's last AC. The render branches are fully covered in component tests via the catalog-endpoint stub.