### PR TITLE
feat(api,docs): #2750 — Linear install (OAuth + API-key)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -384,6 +384,20 @@ ATLAS_SANDBOX_URL=http://localhost:8080
 # JIRA_CLIENT_ID=                                # Atlassian App's Client ID
 # JIRA_CLIENT_SECRET=                            # Atlassian App's Client Secret
 
+# === Linear Lazy OAuth Integration (1.5.3 / #2750) ===
+# Per-Workspace OAuth 2.0 integration registered under
+# /api/v1/integrations/linear. Create an OAuth Application in Linear at
+# https://linear.app/settings/api → "OAuth Applications" with at least
+# `read`, `write`, and `issues:create` scopes; set the Callback URL to
+# `${ATLAS_PUBLIC_API_URL}/api/v1/integrations/linear/callback`. Without
+# these env vars, the install handler logs `Linear OAuth handler not
+# registered` at boot and GET /api/v1/integrations/linear/install returns
+# 501. The `linear-apikey` form-install path is independent and does NOT
+# require these env vars — workspace admins paste a personal API key
+# directly.
+# LINEAR_CLIENT_ID=                              # Linear OAuth Application's Client ID
+# LINEAR_CLIENT_SECRET=                          # Linear OAuth Application's Client Secret
+
 # === Stripe Billing (SaaS only) ===
 # Enables Stripe billing when STRIPE_SECRET_KEY is set. Self-hosted deployments
 # skip this entirely — the self-hosted experience is the free tier.

--- a/apps/docs/content/docs/integrations/linear.mdx
+++ b/apps/docs/content/docs/integrations/linear.mdx
@@ -1,0 +1,218 @@
+---
+title: Linear
+description: Create Linear issues from Atlas agent findings. Two install modes — OAuth (recommended, refreshes automatically) and Personal API Key (simplest, no OAuth App registration required).
+---
+
+import { Callout } from "fumadocs-ui/components/callout";
+
+Atlas's Linear integration is an **Action Target**: Atlas creates Linear
+issues from agent findings (e.g. "file a Linear ticket for every failing
+test in the dashboard"). It is NOT a chat platform — users don't talk to
+Atlas through Linear.
+
+Linear ships with **two install modes**, surfaced as two distinct cards
+in **Admin → Integrations → Actions**. Workspace admins pick whichever
+fits their access model:
+
+- **Linear (OAuth)** — the operator registers a Linear OAuth Application
+  once; each workspace admin authorizes Atlas through Linear's OAuth
+  consent screen. Access tokens refresh automatically.
+- **Linear (API Key)** — no operator setup. The workspace admin
+  generates a Personal API Key in their own Linear settings and pastes
+  it into Atlas. Simplest install; the key is tied to one Linear user.
+
+<Callout type="info" title="Which mode should I use?">
+  **OAuth** is the recommended path for production workspaces and any
+  workspace that wants installs to survive a Linear user being
+  deactivated. **API Key** is the right choice for self-hosted operators
+  who don't want to register an OAuth Application and for entry-tier
+  SaaS workspaces where the OAuth dance feels like overkill.
+</Callout>
+
+## Mode 1 — OAuth (`linear` catalog row)
+
+### Operator setup (one-time, per deploy)
+
+Self-hosted operators run these steps once during initial deployment;
+Atlas Cloud customers don't — the Atlas Cloud team has already done
+this on the hosted regions.
+
+#### 1. Create a Linear OAuth Application
+
+In [Linear settings → API → OAuth Applications](https://linear.app/settings/api/applications/new),
+create a new application:
+
+- **Application name**: "Atlas" (or whatever brand makes sense for
+  your deploy)
+- **Developer URL / Callback URLs**: `${ATLAS_PUBLIC_API_URL}/api/v1/integrations/linear/callback`
+- **Scopes**: enable `read`, `write`, and `issues:create`
+- **Public**: leave off — Atlas's OAuth App is private to your deploy
+
+Linear shows the Client ID and Client Secret on the application page
+after creation. Treat the Client Secret as a credential — anyone with
+it can act as your OAuth App.
+
+#### 2. Set the env vars
+
+Set both on every Atlas API service in your deploy:
+
+```bash
+LINEAR_CLIENT_ID=<Client ID from step 1>
+LINEAR_CLIENT_SECRET=<Client Secret from step 1>
+```
+
+`ATLAS_PUBLIC_API_URL` must already be set on the same services — it's
+required by every OAuth-based integration to build the callback URL.
+
+#### 3. Verify boot wiring
+
+After restart, the API service logs should include:
+
+```
+Registered LinearOAuthInstallHandler + LazyPluginLoader builder
+```
+
+If you see `Linear OAuth handler not registered — LINEAR_CLIENT_ID /
+LINEAR_CLIENT_SECRET unset` instead, double check the env vars aren't
+empty / whitespace-only.
+
+### Customer install (per workspace)
+
+Once the operator has wired the OAuth Application, workspace admins
+can install the OAuth mode from **Admin → Integrations → Linear (OAuth)**.
+
+1. Click **Install** on the Linear (OAuth) card. Atlas redirects to
+   Linear's OAuth consent screen.
+2. Pick the Linear workspace you want Atlas to act in, review the
+   requested scopes (`read`, `write`, `issues:create`), and click
+   **Authorize Atlas**.
+3. Linear redirects back. Atlas confirms the install by calling
+   Linear's GraphQL `viewer` query and persists the workspace's
+   organization id + display name. The card flips to **Installed**.
+
+After install, agent findings can trigger `createLinearIssue` calls.
+Issues attribute to the workspace admin who installed (Atlas uses
+`actor=user` — see [Attribution](#attribution) below).
+
+### Disconnecting (OAuth mode)
+
+Open **Admin → Integrations → Linear (OAuth)** and click **Disconnect**.
+Atlas deletes the `integration_credentials` row FIRST, then the
+`workspace_plugins` row — per ADR-0003's two-store teardown order. The
+Linear-side OAuth grant is NOT revoked automatically; workspace admins
+who want to fully revoke can do so in
+[Linear settings → API → OAuth Applications](https://linear.app/settings/api/applications)
+under **Authorized apps**.
+
+## Mode 2 — Personal API Key (`linear-apikey` catalog row)
+
+### Customer install (per workspace, no operator setup)
+
+The API-key install has no operator-side prerequisites — every Atlas
+deploy supports it. Workspace admins install it from **Admin →
+Integrations → Linear (API Key)**.
+
+1. In Linear, open [Linear settings → API → Personal API keys](https://linear.app/settings/api).
+   Click **Create key**, name it (e.g. "Atlas integration"), and copy
+   the value — it's shown once.
+2. Back in Atlas, click **Install** on the Linear (API Key) card and
+   paste the key into the **Linear Personal API Key** field. Optionally
+   add a **Workspace name** label to help disambiguate when multiple
+   Linear workspaces are involved.
+3. Click **Save**. Atlas encrypts the key at rest (selective-field
+   encryption per ADR-0007) and the card flips to **Installed**.
+
+<Callout type="warn" title="API keys are tied to a single Linear user">
+  A Personal API Key carries the same access as the Linear user who
+  generated it — if that user is deactivated or removed from a Linear
+  workspace, Atlas's access dies and `createLinearIssue` calls fail
+  with `apikey_rejected`. Rotate by generating a new key in Linear
+  settings and re-submitting the install form.
+</Callout>
+
+### Disconnecting (API Key mode)
+
+Open **Admin → Integrations → Linear (API Key)** and click
+**Disconnect**. Atlas deletes the `workspace_plugins` row containing
+the encrypted key — there's no separate credential store to clean up
+in this mode.
+
+You can also revoke the key from Linear's side: open
+[Linear settings → API → Personal API keys](https://linear.app/settings/api)
+and delete the entry. Atlas's next `createLinearIssue` call will return
+`reconnect_required` and surface the "rotate your key" copy to the
+agent and admin.
+
+## Both modes — using the integration
+
+Once either install mode is enabled, the agent can call
+`createLinearIssue`. The tool accepts:
+
+- **title** (required) — issue title, up to 255 characters
+- **description** (optional) — issue body; markdown supported
+- **teamKey** (optional) — team identifier like `"ENG"`; resolved to a
+  Linear team UUID at call time
+- **teamId** (optional) — team UUID directly; takes precedence over
+  `teamKey`
+- **priority** (optional) — Linear priority code (0=no priority,
+  1=urgent, 2=high, 3=medium, 4=low)
+- **labelIds** (optional) — array of Linear label UUIDs
+
+If neither `teamKey` nor `teamId` is supplied, Linear picks the
+bearer's default team. Agent prompts that target a specific team
+should pass `teamKey` for predictability.
+
+The tool tries the OAuth install first and falls back to the API-key
+install. If both are installed (uncommon but allowed), OAuth wins.
+
+## Attribution
+
+Atlas uses Linear's `actor=user` OAuth scope, so issues created via
+OAuth mode attribute to the workspace admin who completed the install
+— not to a separate "Atlas Bot" user that customers would have to
+discover and manage permissions for. Trade-off: if that admin is
+deactivated in Linear, the OAuth install dies and the workspace needs
+to re-install with a new admin.
+
+API-key mode follows the same shape: issues attribute to whoever
+generated the Personal API Key.
+
+## Troubleshooting
+
+### "Install the Linear integration at /admin/integrations" from the agent
+
+Neither catalog row is installed for the workspace. Open
+**Admin → Integrations** and pick the install mode that fits.
+
+### "Linear install needs to be reconnected" (OAuth mode)
+
+The stored refresh token was rejected by Linear — typically because
+the granting user revoked Atlas's access in
+[Linear settings → API → OAuth Applications](https://linear.app/settings/api/applications)
+or was deactivated from the Linear workspace. Click **Reconnect** on
+the Linear (OAuth) card in **Admin → Integrations**.
+
+### "Linear rejected the stored API key" (API Key mode)
+
+The Personal API Key was revoked or its owning user was deactivated.
+Generate a fresh key in
+[Linear settings → API → Personal API keys](https://linear.app/settings/api)
+and re-submit the install form via **Admin → Integrations → Linear
+(API Key)**.
+
+### "No OAuth install handler registered for catalog slug 'linear'"
+
+The operator hasn't set `LINEAR_CLIENT_ID` and `LINEAR_CLIENT_SECRET`,
+or one is empty on the API process handling the install. Ops sets both
+per-service and restarts the API. The boot log should then include
+`Registered LinearOAuthInstallHandler + LazyPluginLoader builder`. If
+the operator never plans to register a Linear OAuth Application, point
+admins at the API-key card instead — that path needs no operator env.
+
+### Linear GraphQL errors with `team … not found`
+
+The `teamKey` or `teamId` passed to `createLinearIssue` doesn't match a
+team the install's bearer can see. Retry with a `teamKey` you can
+confirm exists in the Linear workspace (the agent can usually call
+`createLinearIssue` again with an adjusted `teamKey` based on the
+error message).

--- a/apps/docs/content/docs/integrations/meta.json
+++ b/apps/docs/content/docs/integrations/meta.json
@@ -7,6 +7,7 @@
     "llm-providers",
     "telegram",
     "discord",
+    "linear",
     "sub-processor-feed"
   ]
 }

--- a/deploy/api/atlas.config.ts
+++ b/deploy/api/atlas.config.ts
@@ -214,6 +214,70 @@ export default defineConfig({
       saas_eligible: true,
       implementation_status: "coming_soon",
     },
+    // ── Linear (1.5.3 #2750 — Phase D, Action Target) ──────────────
+    // Two catalog rows, one per install mode (per CONTEXT.md
+    // "Multi-mode integrations" — each install model is its own row so
+    // the admin sees the real trade-off in /admin/integrations cards).
+    // Both rows are pillar='action' (Atlas creates Linear issues; this
+    // is NOT a chat platform — users don't talk to Atlas through Linear).
+    // A future `linear-data` row for Linear-as-Datasource is documented
+    // in ADR-0006 but out of scope for this milestone.
+    //
+    //   - `linear` (OAuth): Atlas OAuth App (per-deploy LINEAR_CLIENT_ID
+    //     + LINEAR_CLIENT_SECRET); workspace admins grant Atlas access
+    //     to one Linear workspace; refresh tokens persist in
+    //     `integration_credentials`. Mirrors the Jira/Salesforce shape.
+    //   - `linear-apikey` (form): workspace admin pastes a Personal API
+    //     Key from Linear settings; the key encrypts inline into
+    //     `workspace_plugins.config.api_key` via selective-field
+    //     encryption (keyed on `secret: true` below).
+    //
+    // SaaS-eligible note: API-key mode is acceptable on SaaS for entry-
+    // tier workspaces (low blast radius — a per-workspace personal key
+    // can be rotated unilaterally). OAuth is the recommended path for
+    // every other workspace. Self-host operators who'd rather not
+    // register an OAuth App can use API-key mode exclusively.
+    {
+      slug: "linear",
+      type: "integration",
+      install_model: "oauth",
+      enabled: true,
+      saas_eligible: true,
+      name: "Linear (OAuth)",
+      description:
+        "Create Linear issues from agent findings. Connects through your operator's Linear OAuth App and refreshes access tokens automatically.",
+      min_plan: "starter",
+    },
+    {
+      slug: "linear-apikey",
+      type: "integration",
+      install_model: "form",
+      enabled: true,
+      saas_eligible: true,
+      name: "Linear (API Key)",
+      description:
+        "Create Linear issues from agent findings using a personal API key from Linear settings. The simplest install — no OAuth App registration required — but the key is tied to one Linear user.",
+      min_plan: "starter",
+      configSchema: [
+        {
+          key: "api_key",
+          type: "string",
+          label: "Linear Personal API Key",
+          description:
+            "Generate one at https://linear.app/settings/api → \"Personal API keys\". Stored encrypted at rest.",
+          required: true,
+          secret: true,
+        },
+        {
+          key: "workspace_name",
+          type: "string",
+          label: "Workspace name",
+          description:
+            "Optional admin-friendly label for which Linear workspace this key belongs to. Defaults to the workspace name returned by Linear's API at first use.",
+          required: false,
+        },
+      ],
+    },
     // ── Lazy OAuth integrations (1.5.2 slice 8 — #2658 / #2659) ─────
     // Salesforce (#2658) established the pattern; Jira (#2659) proves
     // the abstraction by riding the same shared infra:

--- a/packages/api/src/lib/effect/errors.ts
+++ b/packages/api/src/lib/effect/errors.ts
@@ -395,6 +395,31 @@ export class JiraReconnectRequiredError extends Data.TaggedError(
   readonly upstreamError: string;
 }> {}
 
+/**
+ * Linear OAuth refresh-token rotation failed permanently — Linear returned
+ * `invalid_grant` / `invalid_client`, the stored refresh token was rejected,
+ * or the OAuth App's `actor=app` scope was revoked. The install row's
+ * `workspace_plugins.config.status` has already been flipped to
+ * `"reconnect_needed"` by the refresh flow.
+ *
+ * Maps to HTTP 409 Conflict — same wire shape as
+ * {@link JiraReconnectRequiredError}. Third consumer of the pattern.
+ * The {@link IntegrationReconnectRequiredError} extraction (filed as a
+ * follow-up at #2659 review time) becomes justified at three; this
+ * Linear addition makes the rule of three concrete, so the extraction
+ * issue can land in a follow-up PR.
+ *
+ * @see packages/api/src/lib/integrations/install/linear-token-refresh.ts
+ */
+export class LinearReconnectRequiredError extends Data.TaggedError(
+  "LinearReconnectRequiredError",
+)<{
+  readonly message: string;
+  readonly workspaceId: string;
+  /** Raw Linear error code (`invalid_grant`, etc.). Forensic-only. */
+  readonly upstreamError: string;
+}> {}
+
 // ── Telegram static-bot install (#2748 — 1.5.3 Phase D keystone) ────
 
 /**
@@ -642,6 +667,7 @@ export type AtlasError =
   | PlatformOAuthExchangeError
   | SalesforceReconnectRequiredError
   | JiraReconnectRequiredError
+  | LinearReconnectRequiredError
   | TelegramChatIdInvalidError
   | TelegramReachabilityError
   | TelegramApiUnavailableError
@@ -707,6 +733,7 @@ export const ATLAS_ERROR_TAG_LIST = [
   "PlatformOAuthExchangeError",
   "SalesforceReconnectRequiredError",
   "JiraReconnectRequiredError",
+  "LinearReconnectRequiredError",
   "TelegramChatIdInvalidError",
   "TelegramReachabilityError",
   "TelegramApiUnavailableError",

--- a/packages/api/src/lib/effect/hono.ts
+++ b/packages/api/src/lib/effect/hono.ts
@@ -252,6 +252,7 @@ export function mapTaggedError(error: AtlasError): HttpErrorMapping {
     // the integration_credentials platforms.
     case "SalesforceReconnectRequiredError":
     case "JiraReconnectRequiredError":
+    case "LinearReconnectRequiredError":
       return {
         status: 409,
         code: "conflict",

--- a/packages/api/src/lib/effect/workspace-installer.ts
+++ b/packages/api/src/lib/effect/workspace-installer.ts
@@ -387,6 +387,13 @@ export type InstallResult =
 export const INTEGRATION_CREDENTIALS_SLUGS: ReadonlySet<string> = new Set<string>([
   "salesforce",
   "jira",
+  // #2750 — Linear OAuth mode. The API-key mode (`linear-apikey`)
+  // intentionally is NOT in this set: its credentials live inline in
+  // `workspace_plugins.config` via selective-field encryption, so the
+  // standard `workspace_plugins` DELETE teardown is sufficient. Only
+  // OAuth installs that hydrate `integration_credentials` need
+  // dual-store teardown.
+  "linear",
 ]);
 
 interface CatalogRow {

--- a/packages/api/src/lib/integrations/__tests__/linear-tool.test.ts
+++ b/packages/api/src/lib/integrations/__tests__/linear-tool.test.ts
@@ -1,0 +1,285 @@
+/**
+ * Tests for the `createLinearIssue` agent tool (#2750).
+ *
+ * Coverage mirrors `email-tool.test.ts`; Linear-specific surface is the
+ * dual-catalog dispatch:
+ *
+ *   - OAuth install found at `catalog:linear` → uses that instance.
+ *   - OAuth absent, API-key install found at `catalog:linear-apikey` →
+ *     falls back to that instance.
+ *   - Neither installed → `no_install` with the /admin/integrations copy.
+ *
+ * The unit test injects fakes via the `CreateLinearIssueToolDeps`
+ * constructor — no `mock.module()` — so the loader interactions can be
+ * driven precisely without booting the real lazy loader.
+ */
+
+import { describe, expect, it, mock, type Mock } from "bun:test";
+
+import {
+  createCreateLinearIssueTool,
+  type CreateLinearIssueToolDeps,
+} from "../linear-tool";
+import {
+  LazyPluginBuilderMissingError,
+  LazyPluginInstallNotFoundError,
+  type LazyPluginLoader,
+} from "@atlas/api/lib/plugins/lazy-loader";
+import type { PluginLike } from "@atlas/api/lib/plugins/registry";
+import {
+  LinearApiKeyDecryptFailureError,
+  LinearApiKeyRejectedError,
+  LinearGraphQLError,
+  LINEAR_CATALOG_ID,
+} from "../linear/lazy-builder";
+import { LinearReconnectRequiredError } from "../install/linear-token-refresh";
+
+const WSID = "ws-linear-tool-test";
+
+interface FakeInstance {
+  createLinearIssue: Mock<(...args: unknown[]) => Promise<unknown>>;
+}
+
+function makeFakeInstance(impl?: (args: unknown) => Promise<unknown>): FakeInstance {
+  return {
+    createLinearIssue: mock(impl ?? (() =>
+      Promise.resolve({
+        id: "issue-uuid",
+        identifier: "ENG-1",
+        url: "https://linear.app/x",
+        title: "T",
+      })) as (args: unknown) => Promise<unknown>),
+  };
+}
+
+interface FakeLoaderState {
+  oauth?: FakeInstance | "no_install" | Error;
+  apikey?: FakeInstance | "no_install" | Error;
+}
+
+function makeLoader(state: FakeLoaderState): Pick<LazyPluginLoader, "getOrInstantiate"> {
+  const getOrInstantiate = (async (
+    _workspaceId: string,
+    catalogId: string,
+  ): Promise<PluginLike> => {
+    const target = catalogId === LINEAR_CATALOG_ID ? state.oauth : state.apikey;
+    if (target === "no_install" || target === undefined) {
+      throw new LazyPluginInstallNotFoundError(_workspaceId, catalogId);
+    }
+    if (target instanceof Error) {
+      throw target;
+    }
+    return target as unknown as PluginLike;
+  }) as LazyPluginLoader["getOrInstantiate"];
+  return { getOrInstantiate };
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function runTool<T = unknown>(tool: any, args: unknown): Promise<T> {
+  if (!tool?.execute) throw new Error("tool has no execute");
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return (await tool.execute(args, undefined as any)) as T;
+}
+
+function makeDeps(state: FakeLoaderState, opts: Partial<CreateLinearIssueToolDeps> = {}): CreateLinearIssueToolDeps {
+  return {
+    loader: makeLoader(state),
+    resolveWorkspaceId: () => WSID,
+    resolveRequestId: () => "req-test-1",
+    ...opts,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// no_workspace
+// ---------------------------------------------------------------------------
+
+describe("createLinearIssue — no_workspace", () => {
+  it("returns no_workspace when activeOrganizationId is unset", async () => {
+    const tool = createCreateLinearIssueTool({
+      ...makeDeps({}),
+      resolveWorkspaceId: () => undefined,
+    });
+    const result = await runTool<{ status: string; message: string }>(tool, {
+      title: "ping",
+    });
+    expect(result.status).toBe("no_workspace");
+    expect(result.message).toMatch(/workspace/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// no_install
+// ---------------------------------------------------------------------------
+
+describe("createLinearIssue — no_install", () => {
+  it("returns no_install when neither catalog row has an install", async () => {
+    const tool = createCreateLinearIssueTool(makeDeps({ oauth: "no_install", apikey: "no_install" }));
+    const result = await runTool<{ status: string; message: string }>(tool, {
+      title: "ping",
+    });
+    expect(result.status).toBe("no_install");
+    expect(result.message).toMatch(/\/admin\/integrations/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Dispatch — OAuth wins, API-key fallback
+// ---------------------------------------------------------------------------
+
+describe("createLinearIssue — dispatch", () => {
+  it("uses the OAuth install when present", async () => {
+    const oauth = makeFakeInstance();
+    const apikey = makeFakeInstance();
+    const tool = createCreateLinearIssueTool(makeDeps({ oauth, apikey }));
+
+    const result = await runTool<{ status: string; mode: string }>(tool, { title: "x" });
+
+    expect(result.status).toBe("created");
+    expect(result.mode).toBe("oauth");
+    expect(oauth.createLinearIssue).toHaveBeenCalled();
+    expect(apikey.createLinearIssue).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the API-key install when OAuth has no install row", async () => {
+    const apikey = makeFakeInstance();
+    const tool = createCreateLinearIssueTool(makeDeps({ oauth: "no_install", apikey }));
+
+    const result = await runTool<{ status: string; mode: string }>(tool, { title: "x" });
+
+    expect(result.status).toBe("created");
+    expect(result.mode).toBe("apikey");
+    expect(apikey.createLinearIssue).toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Reconnect surfaces — distinct mode tag for each install path
+// ---------------------------------------------------------------------------
+
+describe("createLinearIssue — reconnect surfaces", () => {
+  it("returns reconnect_required (mode=oauth) when OAuth instantiation throws LinearReconnectRequiredError", async () => {
+    const tool = createCreateLinearIssueTool(
+      makeDeps({
+        oauth: new LinearReconnectRequiredError({
+          message: "reconnect",
+          workspaceId: WSID,
+          upstreamError: "invalid_grant",
+        }),
+      }),
+    );
+    const result = await runTool<{ status: string; mode: string; message: string }>(tool, {
+      title: "x",
+    });
+    expect(result.status).toBe("reconnect_required");
+    expect(result.mode).toBe("oauth");
+    expect(result.message).toMatch(/Linear \(OAuth\)/);
+  });
+
+  it("returns reconnect_required (mode=apikey) when API-key issueCreate throws LinearApiKeyRejectedError", async () => {
+    const apikey = makeFakeInstance(() =>
+      Promise.reject(new LinearApiKeyRejectedError(WSID)),
+    );
+    const tool = createCreateLinearIssueTool(makeDeps({ oauth: "no_install", apikey }));
+    const result = await runTool<{ status: string; mode: string; message: string }>(tool, {
+      title: "x",
+    });
+    expect(result.status).toBe("reconnect_required");
+    expect(result.mode).toBe("apikey");
+    expect(result.message).toMatch(/Linear \(API Key\)|personal API key/i);
+  });
+
+  it("returns reconnect_required (mode=oauth) when OAuth issueCreate mid-call throws LinearReconnectRequiredError", async () => {
+    // Hits the post-instantiate branch — the instance was created, but
+    // the actual call failed because the builder's `withRetry` couldn't
+    // refresh successfully and rethrew.
+    const oauth = makeFakeInstance(() =>
+      Promise.reject(
+        new LinearReconnectRequiredError({
+          message: "mid-call",
+          workspaceId: WSID,
+          upstreamError: "invalid_grant",
+        }),
+      ),
+    );
+    const tool = createCreateLinearIssueTool(makeDeps({ oauth }));
+    const result = await runTool<{ status: string; mode: string }>(tool, { title: "x" });
+    expect(result.status).toBe("reconnect_required");
+    expect(result.mode).toBe("oauth");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Failure surfaces — decrypt_failure / misconfigured / create_failure
+// ---------------------------------------------------------------------------
+
+describe("createLinearIssue — failure surfaces", () => {
+  it("returns decrypt_failure when the API-key builder throws LinearApiKeyDecryptFailureError", async () => {
+    const tool = createCreateLinearIssueTool(
+      makeDeps({
+        oauth: "no_install",
+        apikey: new LinearApiKeyDecryptFailureError(WSID, new Error("bad keyset")),
+      }),
+    );
+    const result = await runTool<{ status: string; requestId: string }>(tool, { title: "x" });
+    expect(result.status).toBe("decrypt_failure");
+    expect(result.requestId).toBe("req-test-1");
+  });
+
+  it("returns misconfigured when the loader throws LazyPluginBuilderMissingError", async () => {
+    const tool = createCreateLinearIssueTool(
+      makeDeps({ oauth: new LazyPluginBuilderMissingError(LINEAR_CATALOG_ID) }),
+    );
+    const result = await runTool<{ status: string; requestId: string }>(tool, { title: "x" });
+    expect(result.status).toBe("misconfigured");
+    expect(result.requestId).toBe("req-test-1");
+  });
+
+  it("returns create_failure with a scrubbed upstream message when Linear GraphQL rejects the mutation", async () => {
+    const oauth = makeFakeInstance(() =>
+      Promise.reject(new LinearGraphQLError("team not found")),
+    );
+    const tool = createCreateLinearIssueTool(makeDeps({ oauth }));
+    const result = await runTool<{ status: string; message: string }>(tool, { title: "x" });
+    expect(result.status).toBe("create_failure");
+    expect(result.message).toMatch(/team not found/);
+  });
+
+  it("returns create_failure with errorMessage-scrubbed text when issueCreate throws a plain error", async () => {
+    const oauth = makeFakeInstance(() =>
+      Promise.reject(new Error("ECONNRESET against api.linear.app")),
+    );
+    const tool = createCreateLinearIssueTool(makeDeps({ oauth }));
+    const result = await runTool<{ status: string; message: string }>(tool, { title: "x" });
+    expect(result.status).toBe("create_failure");
+    expect(result.message).toMatch(/ECONNRESET/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Input validation
+// ---------------------------------------------------------------------------
+
+describe("createLinearIssue — input validation", () => {
+  it("rejects an empty title at the Zod boundary", async () => {
+    const oauth = makeFakeInstance();
+    const tool = createCreateLinearIssueTool(makeDeps({ oauth }));
+    // The AI SDK's `tool({...}).execute(args, ctx)` runs WITHOUT the
+    // schema parse (the parse happens upstream of the tool execution
+    // when called via streamText). Test the schema directly to pin
+    // the contract.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const inputSchema = (tool as any).inputSchema as { safeParse: (v: unknown) => { success: boolean } };
+    expect(inputSchema.safeParse({ title: "" }).success).toBe(false);
+    expect(inputSchema.safeParse({ title: "ok" }).success).toBe(true);
+  });
+
+  it("rejects teamKey that isn't uppercase alphanumeric", async () => {
+    const oauth = makeFakeInstance();
+    const tool = createCreateLinearIssueTool(makeDeps({ oauth }));
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const inputSchema = (tool as any).inputSchema as { safeParse: (v: unknown) => { success: boolean } };
+    expect(inputSchema.safeParse({ title: "x", teamKey: "lowercase" }).success).toBe(false);
+    expect(inputSchema.safeParse({ title: "x", teamKey: "ENG" }).success).toBe(true);
+  });
+});

--- a/packages/api/src/lib/integrations/install/__tests__/linear-apikey-form-handler.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/linear-apikey-form-handler.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Tests for {@link LinearApiKeyFormInstallHandler} (#2750).
+ *
+ * Mirrors {@link ./email-form-handler.test.ts}; Linear-API-key-specific
+ * pins:
+ *
+ *   - Only the `api_key` field is `secret: true` and round-trips through
+ *     `encryptSecretFields`; `workspace_name` stays plaintext.
+ *   - INSERT uses the post-0092 explicit `pillar='action'` + `install_id`
+ *     shape with the partial unique index conflict target. Pin so a
+ *     refactor that drops back to the pre-0092 trigger-derived shape
+ *     surfaces immediately.
+ *   - SaaS keyset gate refuses to persist plaintext when
+ *     `ATLAS_DEPLOY_MODE=saas` and no encryption keyset is set.
+ */
+
+import { afterEach, beforeAll, beforeEach, describe, expect, it, mock, type Mock } from "bun:test";
+import { _resetEncryptionKeyCache } from "@atlas/api/lib/db/encryption-keys";
+import { decryptSecret } from "@atlas/api/lib/db/secret-encryption";
+import type { WorkspaceId } from "@useatlas/types";
+
+const mockInternalQuery: Mock<(sql: string, params?: unknown[]) => Promise<unknown[]>> = mock(
+  async (sql: string, params?: unknown[]) => {
+    if (sql.includes("RETURNING id")) {
+      const id = (params?.[0] as string | undefined) ?? "unknown";
+      return [{ id }];
+    }
+    return [];
+  },
+);
+
+mock.module("@atlas/api/lib/db/internal", () => ({
+  internalQuery: mockInternalQuery,
+  hasInternalDB: mock(() => true),
+  getInternalDB: mock(() => ({ query: mock(() => Promise.resolve({ rows: [] })) })),
+}));
+
+const WSID = "ws-linear-apikey-1" as WorkspaceId;
+
+type HandlerCtor = typeof import("../linear-apikey-form-handler").LinearApiKeyFormInstallHandler;
+type ValidationErrCtor = typeof import("../linear-apikey-form-handler").FormInstallValidationError;
+let LinearApiKeyFormInstallHandler!: HandlerCtor;
+let FormInstallValidationError!: ValidationErrCtor;
+
+beforeAll(async () => {
+  const mod = await import("../linear-apikey-form-handler");
+  LinearApiKeyFormInstallHandler = mod.LinearApiKeyFormInstallHandler;
+  FormInstallValidationError = mod.FormInstallValidationError;
+});
+
+const ORIGINAL_ENV = { ...process.env };
+
+function setKeys(value: string): void {
+  process.env.ATLAS_ENCRYPTION_KEYS = value;
+  delete process.env.ATLAS_ENCRYPTION_KEY;
+  delete process.env.BETTER_AUTH_SECRET;
+  _resetEncryptionKeyCache();
+}
+
+function validForm(overrides: Partial<Record<string, unknown>> = {}): Record<string, unknown> {
+  return {
+    api_key: "lin_api_test_secret_abc123",
+    workspace_name: "Acme Linear",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  setKeys("v1:test-key-for-linear-apikey-handler-unit-tests-must-be-long-enough");
+  mockInternalQuery.mockClear();
+  mockInternalQuery.mockImplementation(async (sql: string, params?: unknown[]) => {
+    if (sql.includes("RETURNING id")) {
+      const id = (params?.[0] as string | undefined) ?? "unknown";
+      return [{ id }];
+    }
+    return [];
+  });
+});
+
+afterEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+  _resetEncryptionKeyCache();
+});
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+describe("LinearApiKeyFormInstallHandler.validateConfig — input validation", () => {
+  it("rejects missing api_key with FormInstallValidationError", async () => {
+    const handler = new LinearApiKeyFormInstallHandler();
+    let caught: unknown;
+    try {
+      await handler.validateConfig(WSID, { workspace_name: "Acme" });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(FormInstallValidationError);
+    const errs = (caught as InstanceType<typeof FormInstallValidationError>).fieldErrors;
+    expect(errs.api_key).toBeDefined();
+    expect(mockInternalQuery).not.toHaveBeenCalled();
+  });
+
+  it("rejects api_key with characters Linear never uses", async () => {
+    const handler = new LinearApiKeyFormInstallHandler();
+    await expect(
+      handler.validateConfig(WSID, validForm({ api_key: "has spaces and special chars!" })),
+    ).rejects.toBeInstanceOf(FormInstallValidationError);
+    expect(mockInternalQuery).not.toHaveBeenCalled();
+  });
+
+  it("accepts a missing workspace_name (optional)", async () => {
+    const handler = new LinearApiKeyFormInstallHandler();
+    const result = await handler.validateConfig(WSID, { api_key: "lin_api_only_key" });
+    expect(result.credentialWritten).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Happy path — encryption round-trip + INSERT shape
+// ---------------------------------------------------------------------------
+
+describe("LinearApiKeyFormInstallHandler.validateConfig — happy path", () => {
+  it("encrypts only the api_key field and persists workspace_name plaintext", async () => {
+    const handler = new LinearApiKeyFormInstallHandler();
+
+    await handler.validateConfig(WSID, validForm());
+
+    expect(mockInternalQuery).toHaveBeenCalledTimes(1);
+    const [, params] = mockInternalQuery.mock.calls[0];
+    const configJson = (params as unknown[]).find(
+      (p) => typeof p === "string" && p.startsWith("{"),
+    ) as string | undefined;
+    expect(configJson).toBeDefined();
+    const persisted = JSON.parse(configJson!) as Record<string, unknown>;
+
+    // api_key is encrypted at rest — should NOT round-trip as plaintext.
+    expect(persisted.api_key).toBeTypeOf("string");
+    expect(persisted.api_key).not.toBe("lin_api_test_secret_abc123");
+    expect(persisted.api_key as string).toMatch(/^enc:/);
+    // Decrypt to verify the round-trip.
+    expect(decryptSecret(persisted.api_key as string)).toBe("lin_api_test_secret_abc123");
+
+    // workspace_name stays plaintext — admin UI reads need no decrypt.
+    expect(persisted.workspace_name).toBe("Acme Linear");
+  });
+
+  it("INSERT names pillar='action' and install_id explicitly (post-0092 shape)", async () => {
+    const handler = new LinearApiKeyFormInstallHandler();
+    await handler.validateConfig(WSID, validForm());
+
+    const [sql] = mockInternalQuery.mock.calls[0] as [string, unknown[]];
+    expect(sql).toMatch(/install_id/);
+    expect(sql).toMatch(/pillar/);
+    expect(sql).toMatch(/'action'/);
+    expect(sql).toMatch(/ON CONFLICT.*workspace_id.*catalog_id.*WHERE.*pillar.*DO UPDATE/s);
+    // Catalog id must be `catalog:linear-apikey` — the dispatch key.
+    const params = mockInternalQuery.mock.calls[0][1] as unknown[];
+    expect(params).toContain("catalog:linear-apikey");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SaaS keyset gate — fail-closed on missing encryption keyset
+// ---------------------------------------------------------------------------
+
+describe("LinearApiKeyFormInstallHandler.validateConfig — SaaS keyset gate", () => {
+  it("refuses to persist when SaaS + no keyset (would leak plaintext)", async () => {
+    // Mirror the EmailFormInstallHandler posture — a misconfigured SaaS
+    // deploy must fail closed at the credential boundary rather than
+    // silently passing the api_key through as plaintext.
+    delete process.env.ATLAS_ENCRYPTION_KEYS;
+    delete process.env.ATLAS_ENCRYPTION_KEY;
+    delete process.env.BETTER_AUTH_SECRET;
+    process.env.ATLAS_DEPLOY_MODE = "saas";
+    _resetEncryptionKeyCache();
+
+    const handler = new LinearApiKeyFormInstallHandler();
+    await expect(handler.validateConfig(WSID, validForm())).rejects.toThrow(
+      /Encryption keyset unavailable/,
+    );
+    expect(mockInternalQuery).not.toHaveBeenCalled();
+  });
+});

--- a/packages/api/src/lib/integrations/install/__tests__/linear-oauth-handler.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/linear-oauth-handler.test.ts
@@ -1,0 +1,417 @@
+/**
+ * Tests for {@link LinearOAuthInstallHandler} (#2750).
+ *
+ * Coverage mirrors `jira-oauth-handler.test.ts`; Linear-specific
+ * additions:
+ *
+ *   - Token endpoint is `application/x-www-form-urlencoded` (Salesforce-
+ *     shaped, not JSON-shaped like Atlassian).
+ *   - `actor=user` param on the authorize URL — pinned so a refactor
+ *     that drops the attribution semantic surfaces immediately.
+ *   - Viewer GraphQL second-hop populates `organization_id` /
+ *     `organization_name` / `organization_url_key` in `workspace_plugins.config`.
+ *   - GraphQL `errors[]` array on the viewer call surfaces as
+ *     `PlatformOAuthExchangeError` (not silently passed through).
+ *   - INSERT uses the post-0092 explicit `pillar` + `install_id` shape
+ *     with the partial unique index conflict target.
+ */
+
+import { afterEach, beforeAll, beforeEach, describe, expect, it, mock, type Mock } from "bun:test";
+import { _resetEncryptionKeyCache } from "@atlas/api/lib/db/encryption-keys";
+import { mutateLastChar } from "../../../../__test-utils__/base64url";
+import {
+  mintOAuthStateToken,
+  verifyOAuthStateToken,
+} from "../oauth-state-token";
+import type { WorkspaceId } from "@useatlas/types";
+
+// ---------------------------------------------------------------------------
+// Module mocks (must precede the SUT import)
+// ---------------------------------------------------------------------------
+
+const callOrder: string[] = [];
+
+const mockInternalQuery: Mock<(sql: string, params?: unknown[]) => Promise<unknown[]>> = mock(
+  async (sql: string): Promise<unknown[]> => {
+    if (sql.includes("INSERT INTO workspace_plugins")) {
+      callOrder.push("workspace_plugins.insert");
+    }
+    return [];
+  },
+);
+
+mock.module("@atlas/api/lib/db/internal", () => ({
+  internalQuery: mockInternalQuery,
+  hasInternalDB: mock(() => true),
+  getInternalDB: mock(() => ({ query: mock(() => Promise.resolve({ rows: [] })) })),
+}));
+
+const mockSaveCredentialBundle: Mock<
+  (workspaceId: string, catalogId: string, bundle: unknown) => Promise<void>
+> = mock(async () => {
+  callOrder.push("integration_credentials.save");
+});
+
+mock.module("@atlas/api/lib/integrations/credentials/store", () => ({
+  saveCredentialBundle: mockSaveCredentialBundle,
+  readCredentialBundle: mock(() => Promise.resolve(null)),
+  deleteCredentialBundle: mock(() => Promise.resolve(false)),
+}));
+
+const ORIGINAL_FETCH = globalThis.fetch;
+const mockFetch: Mock<(input: unknown, init?: unknown) => Promise<Response>> = mock(() =>
+  Promise.resolve(new Response("{}", { status: 200 })),
+);
+
+const ORIGINAL_ENV = { ...process.env };
+
+function setKeys(value: string): void {
+  process.env.ATLAS_ENCRYPTION_KEYS = value;
+  delete process.env.ATLAS_ENCRYPTION_KEY;
+  delete process.env.BETTER_AUTH_SECRET;
+  _resetEncryptionKeyCache();
+}
+
+const WSID = "ws-linear-test-1" as WorkspaceId;
+const LINEAR_CONFIG = {
+  clientId: "test-linear-client-id",
+  clientSecret: "test-linear-client-secret",
+  redirectUri: "https://atlas.example/api/v1/integrations/linear/callback",
+};
+
+const ORGANIZATION_ID = "11223344-aaaa-bbbb-cccc-ddddeeee0000";
+
+function happyFetchSequence(): void {
+  mockFetch.mockImplementation((input: unknown) => {
+    const url = typeof input === "string" ? input : (input as Request).url;
+    if (url.includes("/graphql")) {
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            data: {
+              viewer: {
+                id: "user-id-abc",
+                name: "Alice",
+                email: "alice@example.com",
+                organization: {
+                  id: ORGANIZATION_ID,
+                  urlKey: "acme",
+                  name: "Acme",
+                },
+              },
+            },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+      );
+    }
+    if (url.includes("/oauth/token")) {
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            access_token: "linear-access-token",
+            refresh_token: "linear-refresh-token-initial",
+            expires_in: 3600,
+            token_type: "Bearer",
+            scope: "read write issues:create",
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+      );
+    }
+    return Promise.resolve(new Response("{}", { status: 200 }));
+  });
+}
+
+type HandlerCtor = typeof import("../linear-oauth-handler").LinearOAuthInstallHandler;
+let LinearOAuthInstallHandler!: HandlerCtor;
+let PlatformOAuthExchangeError!: typeof import("@atlas/api/lib/effect/errors").PlatformOAuthExchangeError;
+
+beforeAll(async () => {
+  const mod = await import("../linear-oauth-handler");
+  LinearOAuthInstallHandler = mod.LinearOAuthInstallHandler;
+  const errs = await import("@atlas/api/lib/effect/errors");
+  PlatformOAuthExchangeError = errs.PlatformOAuthExchangeError;
+});
+
+beforeEach(() => {
+  setKeys("v1:test-key-one");
+  callOrder.length = 0;
+  mockInternalQuery.mockClear();
+  mockInternalQuery.mockImplementation(async (sql: string): Promise<unknown[]> => {
+    if (sql.includes("INSERT INTO workspace_plugins")) {
+      callOrder.push("workspace_plugins.insert");
+    }
+    return [];
+  });
+  mockSaveCredentialBundle.mockClear();
+  mockSaveCredentialBundle.mockImplementation(async () => {
+    callOrder.push("integration_credentials.save");
+  });
+  mockFetch.mockClear();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  globalThis.fetch = mockFetch as any;
+  happyFetchSequence();
+});
+
+afterEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+  _resetEncryptionKeyCache();
+  globalThis.fetch = ORIGINAL_FETCH;
+});
+
+// ---------------------------------------------------------------------------
+// startInstall
+// ---------------------------------------------------------------------------
+
+describe("LinearOAuthInstallHandler.startInstall", () => {
+  it("returns a Linear authorize URL with the minted state token + actor=user", async () => {
+    const handler = new LinearOAuthInstallHandler(LINEAR_CONFIG);
+
+    const { redirectUrl, stateToken } = await handler.startInstall(WSID);
+
+    expect(stateToken).toBeTypeOf("string");
+    expect(stateToken.length).toBeGreaterThan(0);
+
+    const parsed = new URL(redirectUrl);
+    expect(parsed.origin + parsed.pathname).toBe("https://linear.app/oauth/authorize");
+    expect(parsed.searchParams.get("response_type")).toBe("code");
+    expect(parsed.searchParams.get("client_id")).toBe(LINEAR_CONFIG.clientId);
+    expect(parsed.searchParams.get("redirect_uri")).toBe(LINEAR_CONFIG.redirectUri);
+    expect(parsed.searchParams.get("state")).toBe(stateToken);
+    // `actor=user` ensures issues attribute to the granting user, not
+    // a separate "Atlas Bot" identity. Pin so a refactor that drops the
+    // attribution semantic surfaces immediately.
+    expect(parsed.searchParams.get("actor")).toBe("user");
+    expect(parsed.searchParams.get("prompt")).toBe("consent");
+  });
+
+  it("requests the read + write + issues:create scopes", async () => {
+    const handler = new LinearOAuthInstallHandler(LINEAR_CONFIG);
+    const { redirectUrl } = await handler.startInstall(WSID);
+
+    const scope = new URL(redirectUrl).searchParams.get("scope") ?? "";
+    expect(scope).toContain("read");
+    expect(scope).toContain("write");
+    expect(scope).toContain("issues:create");
+  });
+
+  it("mints a state token that verifies back to (workspaceId, 'linear')", async () => {
+    const handler = new LinearOAuthInstallHandler(LINEAR_CONFIG);
+    const { stateToken } = await handler.startInstall(WSID);
+    expect(verifyOAuthStateToken(stateToken)).toEqual({
+      workspaceId: WSID,
+      catalogId: "linear",
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleCallback — happy path
+// ---------------------------------------------------------------------------
+
+describe("LinearOAuthInstallHandler.handleCallback — happy path", () => {
+  it("verifies state, exchanges the code form-encoded, fetches viewer, and writes both stores in order", async () => {
+    const handler = new LinearOAuthInstallHandler(LINEAR_CONFIG);
+    const stateToken = mintOAuthStateToken(WSID, "linear");
+
+    const result = await handler.handleCallback("auth-code-xyz", stateToken);
+
+    expect(result).not.toBeNull();
+    expect(result!.workspaceId).toBe(WSID);
+    expect(result!.catalogId).toBe("linear");
+    expect(result!.credentialResult).toEqual({ written: true });
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    const [tokenUrl, tokenInit] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(tokenUrl).toBe("https://api.linear.app/oauth/token");
+    expect(tokenInit.method).toBe("POST");
+    // Linear's token endpoint is form-encoded (matching Salesforce, not
+    // Atlassian's JSON-shaped one). Pin both the content type and the
+    // body shape.
+    expect((tokenInit.headers as Record<string, string>)["Content-Type"]).toBe(
+      "application/x-www-form-urlencoded",
+    );
+    const formBody = new URLSearchParams(tokenInit.body as string);
+    expect(formBody.get("grant_type")).toBe("authorization_code");
+    expect(formBody.get("client_id")).toBe("test-linear-client-id");
+    expect(formBody.get("code")).toBe("auth-code-xyz");
+
+    const [graphqlUrl, graphqlInit] = mockFetch.mock.calls[1] as [string, RequestInit];
+    expect(graphqlUrl).toBe("https://api.linear.app/graphql");
+    expect((graphqlInit.headers as Record<string, string>).Authorization).toBe(
+      "Bearer linear-access-token",
+    );
+
+    // ADR-0003/0005 ordering invariant.
+    expect(callOrder).toEqual(["workspace_plugins.insert", "integration_credentials.save"]);
+
+    // The INSERT uses the post-0092 explicit `pillar` + `install_id`
+    // shape with the partial unique index conflict target. Pin both so
+    // a refactor that drops back to the pre-0092 trigger-derived shape
+    // surfaces immediately.
+    const [sql] = mockInternalQuery.mock.calls[0] as [string, unknown[]];
+    expect(sql).toMatch(/install_id/);
+    expect(sql).toMatch(/pillar/);
+    expect(sql).toMatch(/'action'/);
+    expect(sql).toMatch(/ON CONFLICT.*workspace_id.*catalog_id.*WHERE.*pillar.*DO UPDATE/s);
+
+    // workspace_plugins INSERT carries the organization fields in config.
+    const [, params] = mockInternalQuery.mock.calls[0];
+    const configJson = (params as unknown[]).find(
+      (p) => typeof p === "string" && p.startsWith("{") && p.includes("organization_id"),
+    );
+    expect(configJson).toBeDefined();
+    const config = JSON.parse(configJson as string);
+    expect(config).toMatchObject({
+      organization_id: ORGANIZATION_ID,
+      organization_name: "Acme",
+      organization_url_key: "acme",
+      user_id: "user-id-abc",
+      user_email: "alice@example.com",
+      scopes: "read write issues:create",
+      status: "ok",
+    });
+
+    expect(mockSaveCredentialBundle).toHaveBeenCalledTimes(1);
+    expect(mockSaveCredentialBundle).toHaveBeenCalledWith(
+      WSID,
+      "catalog:linear",
+      expect.objectContaining({
+        accessToken: "linear-access-token",
+        refreshToken: "linear-refresh-token-initial",
+        instanceUrl: "https://api.linear.app/graphql",
+        scope: "read write issues:create",
+        tokenType: "Bearer",
+      }),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleCallback — state token failures
+// ---------------------------------------------------------------------------
+
+describe("LinearOAuthInstallHandler.handleCallback — state failures", () => {
+  it("returns null when the state token is tampered with", async () => {
+    const handler = new LinearOAuthInstallHandler(LINEAR_CONFIG);
+    const stateToken = mintOAuthStateToken(WSID, "linear");
+    const tampered = mutateLastChar(stateToken);
+
+    const result = await handler.handleCallback("auth-code", tampered);
+    expect(result).toBeNull();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("returns null when the state token was minted for a different catalog", async () => {
+    // A state token bound to (workspace, 'jira') should never authorize
+    // a Linear callback — cross-catalog reuse would break the dispatch
+    // invariant.
+    const handler = new LinearOAuthInstallHandler(LINEAR_CONFIG);
+    const wrongCatalogState = mintOAuthStateToken(WSID, "jira");
+
+    const result = await handler.handleCallback("auth-code", wrongCatalogState);
+    expect(result).toBeNull();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleCallback — upstream failures
+// ---------------------------------------------------------------------------
+
+describe("LinearOAuthInstallHandler.handleCallback — upstream failures", () => {
+  it("throws PlatformOAuthExchangeError when Linear rejects the code", async () => {
+    mockFetch.mockImplementation(() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ error: "invalid_grant" }), { status: 400 }),
+      ),
+    );
+
+    const handler = new LinearOAuthInstallHandler(LINEAR_CONFIG);
+    const stateToken = mintOAuthStateToken(WSID, "linear");
+
+    await expect(handler.handleCallback("bad-code", stateToken)).rejects.toThrow(
+      PlatformOAuthExchangeError,
+    );
+    expect(mockInternalQuery).not.toHaveBeenCalled();
+    expect(mockSaveCredentialBundle).not.toHaveBeenCalled();
+  });
+
+  it("throws PlatformOAuthExchangeError when the viewer GraphQL returns errors[]", async () => {
+    // A GraphQL response with `errors[]` populated should NEVER pass
+    // silently — the install would persist a credential bundle but the
+    // workspace's `viewer` view of the install is broken.
+    mockFetch.mockImplementation((input: unknown) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url.includes("/graphql")) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              data: null,
+              errors: [{ message: "Field 'viewer' is restricted" }],
+            }),
+            { status: 200 },
+          ),
+        );
+      }
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            access_token: "linear-access-token",
+            refresh_token: "linear-refresh-token",
+            expires_in: 3600,
+          }),
+          { status: 200 },
+          ),
+      );
+    });
+
+    const handler = new LinearOAuthInstallHandler(LINEAR_CONFIG);
+    const stateToken = mintOAuthStateToken(WSID, "linear");
+
+    await expect(handler.handleCallback("auth-code", stateToken)).rejects.toThrow(
+      PlatformOAuthExchangeError,
+    );
+    // No install row written — we throw before the workspace_plugins INSERT.
+    expect(mockInternalQuery).not.toHaveBeenCalled();
+    expect(mockSaveCredentialBundle).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleCallback — partial failure (install row written, credential failed)
+// ---------------------------------------------------------------------------
+
+describe("LinearOAuthInstallHandler.handleCallback — partial failure", () => {
+  it("flips status to reconnect_needed when credential persist fails after install row write", async () => {
+    // Force the integration_credentials write to fail; the install row
+    // should still land, status flips to reconnect_needed, and the
+    // returned credentialResult.written is false.
+    mockSaveCredentialBundle.mockImplementation(async () => {
+      throw new Error("credentials_encrypted column write rejected");
+    });
+
+    const handler = new LinearOAuthInstallHandler(LINEAR_CONFIG);
+    const stateToken = mintOAuthStateToken(WSID, "linear");
+
+    const result = await handler.handleCallback("auth-code", stateToken);
+
+    expect(result).not.toBeNull();
+    expect(result!.credentialResult.written).toBe(false);
+    expect(result!.credentialResult.reason).toMatch(/Reconnect/);
+
+    // Two writes: the install row insert, then the status UPDATE.
+    const insertCall = mockInternalQuery.mock.calls.find(
+      (c) => typeof c[0] === "string" && (c[0] as string).includes("INSERT INTO workspace_plugins"),
+    );
+    expect(insertCall).toBeDefined();
+    const statusUpdateCall = mockInternalQuery.mock.calls.find(
+      (c) =>
+        typeof c[0] === "string" &&
+        (c[0] as string).includes("UPDATE workspace_plugins") &&
+        (c[0] as string).includes("reconnect_needed"),
+    );
+    expect(statusUpdateCall).toBeDefined();
+  });
+});

--- a/packages/api/src/lib/integrations/install/__tests__/linear-oauth-handler.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/linear-oauth-handler.test.ts
@@ -186,14 +186,16 @@ describe("LinearOAuthInstallHandler.startInstall", () => {
     expect(parsed.searchParams.get("prompt")).toBe("consent");
   });
 
-  it("requests the read + write + issues:create scopes", async () => {
+  it("requests the read + write + issues:create scopes as a comma-separated list", async () => {
+    // Linear's authorize endpoint is Linear-specific: scopes are
+    // **comma-separated**, not space-separated like Slack/Atlassian. A
+    // space-delimited value here returns `invalid_scope` and blocks
+    // every install. Pin the exact format so a refactor can't regress it.
     const handler = new LinearOAuthInstallHandler(LINEAR_CONFIG);
     const { redirectUrl } = await handler.startInstall(WSID);
 
     const scope = new URL(redirectUrl).searchParams.get("scope") ?? "";
-    expect(scope).toContain("read");
-    expect(scope).toContain("write");
-    expect(scope).toContain("issues:create");
+    expect(scope).toBe("read,write,issues:create");
   });
 
   it("mints a state token that verifies back to (workspaceId, 'linear')", async () => {

--- a/packages/api/src/lib/integrations/install/__tests__/linear-token-refresh.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/linear-token-refresh.test.ts
@@ -1,0 +1,280 @@
+/**
+ * Tests for the Linear refresh-token rotation flow (#2750).
+ *
+ * Coverage mirrors `jira-token-refresh.test.ts`; the Linear-specific
+ * pins are:
+ *
+ *   - Token endpoint is form-encoded (matches Salesforce, not Atlassian).
+ *   - Refresh tokens rotate on every refresh — the new value MUST land
+ *     in `integration_credentials`. If a refactor drops the rotated
+ *     value, the install dies on the second refresh.
+ *   - `invalid_grant` / `unauthorized_client` / `access_denied` flip
+ *     `reconnect_needed`; `invalid_client` (operator env misconfig)
+ *     stays transient.
+ */
+
+import { afterEach, beforeAll, beforeEach, describe, expect, it, mock, type Mock } from "bun:test";
+import { _resetEncryptionKeyCache } from "@atlas/api/lib/db/encryption-keys";
+
+const mockReadCredentialBundle: Mock<(ws: string, cat: string) => Promise<unknown>> = mock(() =>
+  Promise.resolve(null),
+);
+const mockSaveCredentialBundle: Mock<(ws: string, cat: string, bundle: unknown) => Promise<void>> = mock(() =>
+  Promise.resolve(),
+);
+
+mock.module("@atlas/api/lib/integrations/credentials/store", () => ({
+  readCredentialBundle: mockReadCredentialBundle,
+  saveCredentialBundle: mockSaveCredentialBundle,
+  deleteCredentialBundle: mock(() => Promise.resolve(false)),
+}));
+
+const mockInternalQuery: Mock<(sql: string, params?: unknown[]) => Promise<unknown[]>> = mock(() =>
+  Promise.resolve([]),
+);
+mock.module("@atlas/api/lib/db/internal", () => ({
+  internalQuery: mockInternalQuery,
+  hasInternalDB: mock(() => true),
+  getInternalDB: mock(() => ({ query: mock(() => Promise.resolve({ rows: [] })) })),
+}));
+
+const ORIGINAL_FETCH = globalThis.fetch;
+const mockFetch: Mock<(input: unknown, init?: unknown) => Promise<Response>> = mock(() =>
+  Promise.resolve(new Response("{}", { status: 200, headers: { "content-type": "application/json" } })),
+);
+
+type RefreshModule = typeof import("../linear-token-refresh");
+let refreshMod!: RefreshModule;
+
+beforeAll(async () => {
+  refreshMod = await import("../linear-token-refresh");
+});
+
+const ORIGINAL_ENV = { ...process.env };
+const WSID = "ws-linear-refresh-test-1";
+
+const STORED_BUNDLE = {
+  accessToken: "old-access-token",
+  refreshToken: "stored-refresh-token",
+  expiresAt: 1_700_000_000_000,
+  tokenType: "Bearer",
+  scope: "read write issues:create",
+  instanceUrl: "https://api.linear.app/graphql",
+};
+
+const LINEAR_ARGS = {
+  workspaceId: WSID,
+  clientId: "linear-client-id",
+  clientSecret: "linear-client-secret",
+};
+
+beforeEach(() => {
+  process.env.ATLAS_ENCRYPTION_KEYS = "v1:test-key-one";
+  _resetEncryptionKeyCache();
+  mockReadCredentialBundle.mockClear();
+  mockSaveCredentialBundle.mockClear();
+  mockInternalQuery.mockClear();
+  mockFetch.mockClear();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  globalThis.fetch = mockFetch as any;
+});
+
+afterEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+  _resetEncryptionKeyCache();
+  globalThis.fetch = ORIGINAL_FETCH;
+});
+
+// ---------------------------------------------------------------------------
+// Happy path — token rotation
+// ---------------------------------------------------------------------------
+
+describe("refreshLinearToken — happy path", () => {
+  it("rotates the refresh_token and writes the new bundle back", async () => {
+    mockReadCredentialBundle.mockImplementation(() => Promise.resolve(STORED_BUNDLE));
+    mockFetch.mockImplementation(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            access_token: "new-access-token",
+            // CRITICAL: the new refresh token MUST land in storage. Linear
+            // rotates refresh tokens on every refresh — keeping the old
+            // one would brick the install on the second refresh.
+            refresh_token: "rotated-refresh-token",
+            expires_in: 3600,
+            token_type: "Bearer",
+            scope: "read write issues:create",
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+      ),
+    );
+
+    const result = await refreshMod.refreshLinearToken(LINEAR_ARGS);
+
+    expect(result.accessToken).toBe("new-access-token");
+    expect(result.refreshToken).toBe("rotated-refresh-token");
+    expect(result.instanceUrl).toBe("https://api.linear.app/graphql");
+    expect(mockSaveCredentialBundle).toHaveBeenCalledWith(
+      WSID,
+      "catalog:linear",
+      expect.objectContaining({
+        accessToken: "new-access-token",
+        refreshToken: "rotated-refresh-token",
+      }),
+    );
+
+    // Token endpoint is form-encoded.
+    const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect((init.headers as Record<string, string>)["Content-Type"]).toBe(
+      "application/x-www-form-urlencoded",
+    );
+    const form = new URLSearchParams(init.body as string);
+    expect(form.get("grant_type")).toBe("refresh_token");
+    expect(form.get("refresh_token")).toBe("stored-refresh-token");
+  });
+
+  it("clears reconnect_needed on success", async () => {
+    mockReadCredentialBundle.mockImplementation(() => Promise.resolve(STORED_BUNDLE));
+    mockFetch.mockImplementation(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            access_token: "new-access-token",
+            refresh_token: "rotated-refresh-token",
+            expires_in: 3600,
+          }),
+          { status: 200 },
+        ),
+      ),
+    );
+
+    await refreshMod.refreshLinearToken(LINEAR_ARGS);
+
+    const clearCall = mockInternalQuery.mock.calls.find(
+      (c) =>
+        typeof c[0] === "string" &&
+        (c[0] as string).includes("UPDATE workspace_plugins") &&
+        (c[0] as string).includes("'ok'"),
+    );
+    expect(clearCall).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Permanent failures — reconnect_needed
+// ---------------------------------------------------------------------------
+
+describe("refreshLinearToken — permanent failures", () => {
+  it("flips reconnect_needed and throws LinearReconnectRequiredError on invalid_grant", async () => {
+    mockReadCredentialBundle.mockImplementation(() => Promise.resolve(STORED_BUNDLE));
+    mockFetch.mockImplementation(() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ error: "invalid_grant" }), { status: 400 }),
+      ),
+    );
+
+    await expect(refreshMod.refreshLinearToken(LINEAR_ARGS)).rejects.toBeInstanceOf(
+      refreshMod.LinearReconnectRequiredError,
+    );
+
+    const flipCall = mockInternalQuery.mock.calls.find(
+      (c) =>
+        typeof c[0] === "string" &&
+        (c[0] as string).includes("UPDATE workspace_plugins") &&
+        (c[0] as string).includes("reconnect_needed"),
+    );
+    expect(flipCall).toBeDefined();
+    expect(mockSaveCredentialBundle).not.toHaveBeenCalled();
+  });
+
+  it.each(["unauthorized_client", "access_denied"])(
+    "flips reconnect_needed for permanent code %s",
+    async (code) => {
+      mockReadCredentialBundle.mockImplementation(() => Promise.resolve(STORED_BUNDLE));
+      mockFetch.mockImplementation(() =>
+        Promise.resolve(
+          new Response(JSON.stringify({ error: code }), { status: 400 }),
+        ),
+      );
+      await expect(refreshMod.refreshLinearToken(LINEAR_ARGS)).rejects.toBeInstanceOf(
+        refreshMod.LinearReconnectRequiredError,
+      );
+    },
+  );
+
+  it("flips reconnect_needed when the stored bundle has no refresh_token", async () => {
+    mockReadCredentialBundle.mockImplementation(() =>
+      Promise.resolve({ ...STORED_BUNDLE, refreshToken: null }),
+    );
+
+    await expect(refreshMod.refreshLinearToken(LINEAR_ARGS)).rejects.toBeInstanceOf(
+      refreshMod.LinearReconnectRequiredError,
+    );
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Transient failures — do NOT flip reconnect_needed
+// ---------------------------------------------------------------------------
+
+describe("refreshLinearToken — transient failures", () => {
+  it("does NOT flip reconnect_needed on invalid_client (operator env typo)", async () => {
+    mockReadCredentialBundle.mockImplementation(() => Promise.resolve(STORED_BUNDLE));
+    mockFetch.mockImplementation(() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ error: "invalid_client" }), { status: 401 }),
+      ),
+    );
+
+    let caught: unknown;
+    try {
+      await refreshMod.refreshLinearToken(LINEAR_ARGS);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(Error);
+    // Critically NOT a reconnect error — operator-side env typo should
+    // not force every tenant admin to re-OAuth.
+    expect(caught).not.toBeInstanceOf(refreshMod.LinearReconnectRequiredError);
+
+    const flipCall = mockInternalQuery.mock.calls.find(
+      (c) =>
+        typeof c[0] === "string" &&
+        (c[0] as string).includes("UPDATE workspace_plugins") &&
+        (c[0] as string).includes("reconnect_needed"),
+    );
+    expect(flipCall).toBeUndefined();
+  });
+
+  it("does NOT flip reconnect_needed on 5xx", async () => {
+    mockReadCredentialBundle.mockImplementation(() => Promise.resolve(STORED_BUNDLE));
+    mockFetch.mockImplementation(() =>
+      Promise.resolve(new Response("oops", { status: 500 })),
+    );
+
+    await expect(refreshMod.refreshLinearToken(LINEAR_ARGS)).rejects.toThrow();
+    const flipCall = mockInternalQuery.mock.calls.find(
+      (c) =>
+        typeof c[0] === "string" &&
+        (c[0] as string).includes("UPDATE workspace_plugins") &&
+        (c[0] as string).includes("reconnect_needed"),
+    );
+    expect(flipCall).toBeUndefined();
+  });
+
+  it("does NOT flip reconnect_needed on network failure", async () => {
+    mockReadCredentialBundle.mockImplementation(() => Promise.resolve(STORED_BUNDLE));
+    mockFetch.mockImplementation(() => Promise.reject(new Error("ECONNRESET")));
+
+    await expect(refreshMod.refreshLinearToken(LINEAR_ARGS)).rejects.toThrow();
+    const flipCall = mockInternalQuery.mock.calls.find(
+      (c) =>
+        typeof c[0] === "string" &&
+        (c[0] as string).includes("UPDATE workspace_plugins") &&
+        (c[0] as string).includes("reconnect_needed"),
+    );
+    expect(flipCall).toBeUndefined();
+  });
+});

--- a/packages/api/src/lib/integrations/install/linear-apikey-form-handler.ts
+++ b/packages/api/src/lib/integrations/install/linear-apikey-form-handler.ts
@@ -1,0 +1,185 @@
+/**
+ * `LinearApiKeyFormInstallHandler` — Linear API-key install (#2750).
+ *
+ * Second {@link FormBasedInstallHandler} implementation after Email
+ * (#2697). The admin pastes a Linear Personal API Key from their
+ * Linear settings page; the key encrypts inline via
+ * {@link encryptSecretFields} into `workspace_plugins.config.api_key`.
+ *
+ * Trade-off vs the OAuth mode (`linear` slug — see
+ * {@link LinearOAuthInstallHandler}):
+ *
+ *   - **API-key mode** is the simplest install: no OAuth App
+ *     registration, no callback URL plumbing, no refresh-token
+ *     lifecycle. Drawback: the key is tied to one Linear user — if
+ *     that user is deactivated, Atlas's access dies and the workspace
+ *     admin has to issue a new key. Also, API keys don't carry per-
+ *     workspace scoping, so a deactivated user's key is useless for
+ *     any of their workspaces.
+ *   - **OAuth mode** rotates access tokens automatically and survives
+ *     the granting user being deactivated (the refresh-token flow re-
+ *     issues an access token tied to the OAuth grant, not the user
+ *     session).
+ *
+ * SaaS-eligible at the entry plan tier per the catalog declaration —
+ * API-key mode is mostly a self-host convenience but acceptable on SaaS
+ * for entry-tier workspaces where the OAuth dance feels like overkill.
+ *
+ * Connection liveness: NOT probed at install time. A failed Linear API
+ * round-trip at install would surface as a misleading "couldn't reach
+ * Linear" error even when the user's key is correct; the first
+ * agent-issued `createLinearIssue` call surfaces real auth errors with
+ * the full path intact (HTTP 401 vs API rate-limit vs network).
+ *
+ * @see ./types.ts — {@link FormBasedInstallHandler}
+ * @see ./linear-apikey-secret-schema.ts — shared form + secret schema
+ * @see ./email-form-handler.ts — first form-based handler reference
+ * @see ../../plugins/secrets.ts — {@link encryptSecretFields}
+ */
+
+import crypto from "crypto";
+import { createLogger } from "@atlas/api/lib/logger";
+import { internalQuery } from "@atlas/api/lib/db/internal";
+import { encryptSecretFields } from "@atlas/api/lib/plugins/secrets";
+import { lazyPluginLoader } from "@atlas/api/lib/plugins/lazy-loader";
+import { getEncryptionKeyset } from "@atlas/api/lib/db/encryption-keys";
+import type { WorkspaceId } from "@useatlas/types";
+import {
+  LINEAR_APIKEY_CATALOG_ID,
+  LINEAR_APIKEY_SECRET_FIELDS_SCHEMA,
+  LinearApiKeyFormDataSchema,
+} from "./linear-apikey-secret-schema";
+import { FormInstallValidationError } from "./email-form-handler";
+import type {
+  CatalogId,
+  FormBasedInstallHandler,
+  InstallRecord,
+} from "./types";
+
+// Re-export the validation error class for callers that catch with
+// `instanceof`. {@link FormInstallValidationError} is the canonical
+// throw type for every form-based install handler — declared in the
+// Email module first per #2697.
+export { FormInstallValidationError };
+
+const log = createLogger("integrations.install.linear-apikey");
+
+/** Catalog slug — the dispatch key in {@link registerFormHandler}. */
+const LINEAR_APIKEY_SLUG: CatalogId = "linear-apikey";
+
+/** Test-only injection of the install id generator. */
+export interface LinearApiKeyFormInstallHandlerOptions {
+  readonly idGenerator?: () => string;
+}
+
+export class LinearApiKeyFormInstallHandler implements FormBasedInstallHandler {
+  readonly kind = "form" as const;
+
+  private readonly newId: () => string;
+
+  constructor(options: LinearApiKeyFormInstallHandlerOptions = {}) {
+    this.newId = options.idGenerator ?? (() => crypto.randomUUID());
+  }
+
+  async validateConfig(
+    workspaceId: WorkspaceId,
+    formData: unknown,
+  ): Promise<{
+    readonly installRecord: InstallRecord;
+    readonly credentialWritten: boolean;
+  }> {
+    // ── 1. Validate the form against the API-key schema ─────────────
+    const parsed = LinearApiKeyFormDataSchema.safeParse(formData);
+    if (!parsed.success) {
+      throw FormInstallValidationError.fromZodFlatten(parsed.error.flatten());
+    }
+    const config = parsed.data;
+
+    // ── 2. SaaS keyset gate ─────────────────────────────────────────
+    // `encryptSecret` falls back to plaintext when no key is configured
+    // (dev convenience). Boot logs a one-shot warning, but a missed log
+    // in SaaS would leak the API key plaintext. Refuse the install per-
+    // call so a misconfigured deploy fails closed at the credential
+    // boundary. Mirrors EmailFormInstallHandler's posture.
+    if (
+      process.env.ATLAS_DEPLOY_MODE === "saas" &&
+      !getEncryptionKeyset()
+    ) {
+      log.error(
+        { workspaceId },
+        "Refusing form install: SaaS mode + no encryption keyset (would persist plaintext api_key)",
+      );
+      throw new Error(
+        "Encryption keyset unavailable in SaaS mode — refusing to persist plaintext credentials. Set ATLAS_ENCRYPTION_KEYS and retry.",
+      );
+    }
+
+    // ── 3. Encrypt secret fields (api_key) at rest ──────────────────
+    const encryptedConfig = encryptSecretFields(config, LINEAR_APIKEY_SECRET_FIELDS_SCHEMA);
+
+    // ── 4. Upsert workspace_plugins ─────────────────────────────────
+    // Pillar='action' + install_id named explicitly per migration 0092
+    // (#2739). The partial unique index keys re-installs to the same
+    // row; `RETURNING id` lets us pick up the existing id rather than a
+    // phantom freshly-generated one on conflict (per EmailFormInstallHandler
+    // commentary).
+    const candidateId = this.newId();
+    let persistedId: string;
+    try {
+      const rows = await internalQuery<{ id: string }>(
+        `INSERT INTO workspace_plugins
+           (id, workspace_id, catalog_id, install_id, pillar, config, enabled, installed_at)
+         VALUES ($1, $2, $3, $1, 'action', $4::jsonb, true, NOW())
+         ON CONFLICT (workspace_id, catalog_id) WHERE pillar IN ('chat', 'action')
+         DO UPDATE
+           SET config = EXCLUDED.config,
+               enabled = true
+         RETURNING id`,
+        [candidateId, workspaceId, LINEAR_APIKEY_CATALOG_ID, JSON.stringify(encryptedConfig)],
+      );
+      const returned = rows[0]?.id;
+      if (typeof returned !== "string" || returned.length === 0) {
+        log.warn(
+          { workspaceId, candidateId },
+          "workspace_plugins upsert returned no id — falling back to candidate",
+        );
+        persistedId = candidateId;
+      } else {
+        persistedId = returned;
+      }
+    } catch (err) {
+      log.error(
+        { workspaceId, err: err instanceof Error ? err.message : String(err) },
+        "Failed to persist Linear API-key install record — aborting install",
+      );
+      throw err;
+    }
+
+    // Evict any cached PluginLike for this (workspace, catalog) so the
+    // next tool dispatch rebuilds against the freshly-persisted config.
+    // Without this, a re-install that rotates the API key keeps the
+    // stale in-memory instance from before the upsert. Fire-and-forget
+    // — `evict` swallows teardown errors internally.
+    try {
+      await lazyPluginLoader.evict(workspaceId, LINEAR_APIKEY_CATALOG_ID);
+    } catch (err) {
+      log.warn(
+        { workspaceId, err: err instanceof Error ? err.message : String(err) },
+        "LazyPluginLoader.evict threw after Linear API-key install upsert — DB row is persisted anyway",
+      );
+    }
+
+    log.info(
+      {
+        workspaceId,
+        installId: persistedId,
+        workspaceName: config.workspace_name ?? null,
+      },
+      "Linear API-key install completed",
+    );
+    return {
+      installRecord: { id: persistedId, workspaceId, catalogId: LINEAR_APIKEY_SLUG },
+      credentialWritten: true,
+    };
+  }
+}

--- a/packages/api/src/lib/integrations/install/linear-apikey-secret-schema.ts
+++ b/packages/api/src/lib/integrations/install/linear-apikey-secret-schema.ts
@@ -1,0 +1,80 @@
+/**
+ * Shared form schema + secret-field map for the Linear API-key install
+ * mode (#2750).
+ *
+ * Mirrors {@link ./email-secret-schema.ts} — both the form install
+ * handler ({@link LinearApiKeyFormInstallHandler}) and the lazy builder
+ * ({@link createLinearApiKeyLazyBuilder}) need to know:
+ *
+ *   1. The Zod shape of the install form (api_key, workspace_name) so
+ *      stored configs can be re-validated on read without re-deriving
+ *      the schema in two places.
+ *   2. Which fields in `workspace_plugins.config` are `secret: true` so
+ *      the write path encrypts and the read path decrypts the same set.
+ *
+ * Duplicating the `secret: true` flag set in two modules is the F-42
+ * audit's exact failure mode — a write that encrypts more than the read
+ * decrypts corrupts the stored value silently. Centralizing keeps both
+ * sides in lockstep.
+ */
+
+import { z } from "zod";
+import type { ConfigSchema } from "@atlas/api/lib/plugins/secrets";
+import type { ConfigSchemaField } from "@atlas/api/lib/plugins/registry";
+
+/** Stable `plugin_catalog.id` for the Linear API-key install mode. */
+export const LINEAR_APIKEY_CATALOG_ID = "catalog:linear-apikey";
+
+/** Defensive upper bound on the API-key field — JSONB rows shouldn't carry 50MB strings. */
+const API_KEY_MAX = 4096;
+
+/**
+ * Linear Personal API keys are prefixed `lin_api_` followed by an
+ * opaque alphanumeric secret (Linear documents the format at
+ * https://developers.linear.app/docs/graphql/working-with-the-graphql-api#personal-api-keys).
+ * The regex is permissive — we accept any length within the JSONB
+ * defensive cap and don't enforce the prefix here, because a key
+ * mis-typed without the prefix is better surfaced as a clean "Linear
+ * rejected the key" error from the first GraphQL call than as a vague
+ * form-validation error that doesn't explain WHY the input shape
+ * matters.
+ */
+const LINEAR_API_KEY_RE = /^[A-Za-z0-9_-]+$/;
+
+export const LinearApiKeyFormDataSchema = z.object({
+  api_key: z
+    .string()
+    .min(1, "api_key is required")
+    .max(API_KEY_MAX, `api_key must be ${API_KEY_MAX} characters or fewer`)
+    .regex(
+      LINEAR_API_KEY_RE,
+      "api_key contains characters Linear keys never use — copy the value directly from Linear's settings page",
+    ),
+  /**
+   * Optional admin-friendly label. The field exists so admins managing
+   * multiple Linear workspaces can disambiguate at a glance; if missing
+   * the lazy builder backfills the workspace name from the `viewer`
+   * GraphQL query on first use.
+   */
+  workspace_name: z.string().min(1).max(255).optional(),
+}).strict();
+
+export type LinearApiKeyFormData = z.infer<typeof LinearApiKeyFormDataSchema>;
+
+/**
+ * `encryptSecretFields` / `decryptSecretFields` schema for the Linear
+ * API-key handler. The `fields[].key` element is constrained to
+ * `keyof LinearApiKeyFormData` so a Zod rename without a matching
+ * update here surfaces as a TS error rather than a silent encryption
+ * regression at runtime.
+ */
+export const LINEAR_APIKEY_SECRET_FIELDS_SCHEMA: ConfigSchema & {
+  state: "parsed";
+  fields: ReadonlyArray<ConfigSchemaField & { key: keyof LinearApiKeyFormData }>;
+} = {
+  state: "parsed",
+  fields: [
+    { key: "api_key", type: "string", secret: true },
+    { key: "workspace_name", type: "string" },
+  ],
+};

--- a/packages/api/src/lib/integrations/install/linear-oauth-handler.ts
+++ b/packages/api/src/lib/integrations/install/linear-oauth-handler.ts
@@ -1,0 +1,566 @@
+/**
+ * `LinearOAuthInstallHandler` — third lazy OAuth integration (#2750).
+ *
+ * Mirrors {@link JiraOAuthInstallHandler}; Linear-specific structural
+ * differences:
+ *
+ *   1. **Single authorize host.** Authorize at `linear.app/oauth/authorize`
+ *      and exchange at `api.linear.app/oauth/token`. No per-tenant
+ *      `loginUrl` (unlike Salesforce) and no `cloudid` second hop (unlike
+ *      Atlassian) — the workspace is implicit in the OAuth grant.
+ *   2. **Token endpoint is `application/x-www-form-urlencoded`.** Salesforce
+ *      uses form-encoded too; Atlassian uses JSON. Linear matches Salesforce.
+ *   3. **Refresh tokens rotate on every refresh.** Like Atlassian, the
+ *      refresh flow MUST persist the new `refresh_token` back to
+ *      `integration_credentials` — see {@link ./linear-token-refresh.ts}.
+ *   4. **`actor=user` vs `actor=app` scope choice.** Linear's OAuth supports
+ *      acting AS the granting user (`actor=user`, default) or AS the OAuth
+ *      App itself (`actor=app`). We default to `actor=user` so issues
+ *      created by Atlas attribute to the workspace admin who installed —
+ *      not a generic "Atlas Bot" user that customers would have to
+ *      separately discover and manage permissions for. The trade-off:
+ *      access dies if the granting user is deactivated. Workspace admins
+ *      can rotate by reinstalling.
+ *   5. **`/viewer` discovery is a second hop.** After token exchange, the
+ *      handler calls `POST api.linear.app/graphql` with `query { viewer
+ *      { organization { id urlKey name } } }` to learn which Linear
+ *      workspace was granted. The id + name persist on
+ *      `workspace_plugins.config` for admin-UI display; no cloud-id-style
+ *      routing identifier is needed for subsequent API calls.
+ *
+ * Atomicity per ADR-0003 (two-store install metadata + credentials) is
+ * identical to Jira's: install row INSERT first, credential bundle
+ * INSERT second, partial-failure flips
+ * `workspace_plugins.config.status` to `"reconnect_needed"`.
+ *
+ * @see ../oauth-state-token.ts — state mint/verify primitives
+ * @see ../credentials/store.ts — generic integration_credentials store
+ * @see ./linear-token-refresh.ts — refresh-token rotation + reconnect surface
+ * @see ./jira-oauth-handler.ts — sibling reference implementation (#2659)
+ * @see docs/adr/0003-two-store-chat-install-metadata-credentials.md
+ * @see docs/adr/0005-integration-credentials-table.md
+ */
+
+import crypto from "crypto";
+import { createLogger } from "@atlas/api/lib/logger";
+import { internalQuery } from "@atlas/api/lib/db/internal";
+import { PlatformOAuthExchangeError } from "@atlas/api/lib/effect/errors";
+import { saveCredentialBundle } from "@atlas/api/lib/integrations/credentials/store";
+import type { CredentialBundle } from "@atlas/api/lib/integrations/credentials/store";
+import type { WorkspaceId } from "@useatlas/types";
+import {
+  mintOAuthStateToken,
+  verifyOAuthStateToken,
+} from "./oauth-state-token";
+import type {
+  CatalogId,
+  CredentialResult,
+  InstallRecord,
+  OAuthPlatformInstallHandler,
+} from "./types";
+
+const log = createLogger("integrations.install.linear");
+
+/** Catalog row id seeded by `catalog-seeder.ts::upsertEntry` as `catalog:${slug}`. */
+export const LINEAR_CATALOG_ID = "catalog:linear";
+
+/** Catalog slug — the dispatch key, value bound into the state token. */
+export const LINEAR_SLUG: CatalogId = "linear";
+
+/**
+ * Linear OAuth 2.0 endpoints. Hard-coded (no operator override) —
+ * Linear doesn't expose region-specific hosts.
+ */
+const AUTHORIZE_URL = "https://linear.app/oauth/authorize";
+const TOKEN_URL = "https://api.linear.app/oauth/token";
+const GRAPHQL_URL = "https://api.linear.app/graphql";
+
+/**
+ * Scopes requested at install time:
+ *   - `read`        — read issues, projects, users via GraphQL. Required
+ *                     for the `viewer` discovery hop and for any future
+ *                     "look up the issue you just created" agent flows.
+ *   - `write`       — create issues. The base "write" scope covers
+ *                     `issueCreate` mutations.
+ *   - `issues:create` — Linear's narrow per-action scope. Granted
+ *                     redundantly with `write` so a future Linear
+ *                     scope-tightening doesn't break Atlas without
+ *                     re-issuing the OAuth dance.
+ *
+ * If the operator's App is configured with a tighter scope set, Linear
+ * rejects the install with `invalid_scope`; the admin sees the effective
+ * scope list in `workspace_plugins.config.scopes`.
+ */
+const LINEAR_SCOPES = "read write issues:create";
+
+/**
+ * Operator-side Linear OAuth App config. Read once from env in
+ * `register.ts` and passed in.
+ */
+export interface LinearOAuthHandlerConfig {
+  readonly clientId: string;
+  readonly clientSecret: string;
+  /**
+   * Public-facing OAuth callback URL — must match a Callback URL
+   * configured on the operator's Linear OAuth Application.
+   */
+  readonly redirectUri: string;
+}
+
+// ---------------------------------------------------------------------------
+// Linear token-response shape (subset we consume)
+// ---------------------------------------------------------------------------
+
+interface LinearTokenSuccess {
+  readonly access_token: string;
+  readonly refresh_token?: string;
+  readonly expires_in?: number;
+  readonly token_type?: string;
+  readonly scope?: string;
+}
+
+interface LinearTokenFailure {
+  readonly error: string;
+  readonly error_description?: string;
+}
+
+type LinearTokenResponse = LinearTokenSuccess | LinearTokenFailure;
+
+function isTokenSuccess(response: LinearTokenResponse): response is LinearTokenSuccess {
+  return "access_token" in response && typeof response.access_token === "string";
+}
+
+interface LinearViewerResponse {
+  readonly data?: {
+    readonly viewer?: {
+      readonly id?: string;
+      readonly name?: string;
+      readonly email?: string;
+      readonly organization?: {
+        readonly id?: string;
+        readonly urlKey?: string;
+        readonly name?: string;
+      };
+    };
+  };
+  readonly errors?: ReadonlyArray<{ readonly message?: string }>;
+}
+
+/**
+ * Hard timeout on the install-time Linear round-trips. A hung endpoint
+ * would otherwise stall the OAuth callback request indefinitely. 15s is
+ * generous for both `/oauth/token` (typically <1s) and `/graphql`
+ * viewer query (typically <500ms).
+ */
+const INSTALL_FETCH_TIMEOUT_MS = 15_000;
+
+async function fetchWithTimeout(
+  url: string,
+  init: RequestInit,
+  timeoutMs: number,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Token exchange — exposed so the refresh flow can call it too
+// ---------------------------------------------------------------------------
+
+interface TokenExchangeArgs {
+  readonly clientId: string;
+  readonly clientSecret: string;
+  readonly redirectUri: string;
+  readonly code: string;
+}
+
+/**
+ * POST `api.linear.app/oauth/token` with the auth code. Returns the
+ * parsed JSON shape on success; throws `PlatformOAuthExchangeError`
+ * on any non-2xx, network failure, or structurally invalid response.
+ *
+ * Linear's token endpoint takes form-encoded body (Salesforce-shaped,
+ * not JSON-shaped like Atlassian). Documented at
+ * https://developers.linear.app/docs/oauth/authentication.
+ */
+export async function exchangeAuthCodeForTokens(
+  args: TokenExchangeArgs,
+): Promise<LinearTokenSuccess> {
+  const body = new URLSearchParams({
+    grant_type: "authorization_code",
+    client_id: args.clientId,
+    client_secret: args.clientSecret,
+    code: args.code,
+    redirect_uri: args.redirectUri,
+  });
+
+  let resp: Response;
+  try {
+    resp = await fetchWithTimeout(
+      TOKEN_URL,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: body.toString(),
+      },
+      INSTALL_FETCH_TIMEOUT_MS,
+    );
+  } catch (err) {
+    const isAbort = err instanceof Error && err.name === "AbortError";
+    log.warn(
+      {
+        err: err instanceof Error ? err.message : String(err),
+        stack: err instanceof Error ? err.stack : undefined,
+        timedOut: isAbort,
+      },
+      isAbort
+        ? "Linear token endpoint timed out — surfacing PlatformOAuthExchangeError"
+        : "Linear token endpoint unreachable — surfacing PlatformOAuthExchangeError",
+    );
+    throw new PlatformOAuthExchangeError({
+      message: isAbort
+        ? "Linear token endpoint timed out. Restart the install."
+        : "Failed to reach Linear token endpoint. Restart the install.",
+      platform: LINEAR_SLUG,
+      upstreamError: isAbort ? "timeout" : err instanceof Error ? err.message : String(err),
+    });
+  }
+
+  let parsed: LinearTokenResponse;
+  try {
+    parsed = (await resp.json()) as LinearTokenResponse;
+  } catch (err) {
+    log.warn(
+      {
+        status: resp.status,
+        err: err instanceof Error ? err.message : String(err),
+      },
+      "Linear token response body could not be parsed as JSON",
+    );
+    throw new PlatformOAuthExchangeError({
+      message: "Linear returned an unparseable token response. Restart the install.",
+      platform: LINEAR_SLUG,
+      upstreamError: `non-json ${resp.status}`,
+    });
+  }
+
+  if (!resp.ok || !isTokenSuccess(parsed)) {
+    const failure = parsed as LinearTokenFailure;
+    throw new PlatformOAuthExchangeError({
+      message: "Linear rejected the OAuth code. Restart the install from your Linear admin.",
+      platform: LINEAR_SLUG,
+      upstreamError: failure.error ?? `http_${resp.status}`,
+    });
+  }
+
+  return parsed;
+}
+
+interface ViewerInfo {
+  readonly userId: string | null;
+  readonly userName: string | null;
+  readonly userEmail: string | null;
+  readonly organizationId: string | null;
+  readonly organizationName: string | null;
+  readonly organizationUrlKey: string | null;
+}
+
+/**
+ * Fetch the granting user + their Linear workspace via the GraphQL
+ * `viewer` query. Returns a structurally validated subset for persistence
+ * on `workspace_plugins.config`. Tolerates missing inner fields (Linear
+ * may evolve the schema); only an outright transport / parse failure
+ * throws.
+ *
+ * The handler does NOT depend on a non-null `organizationId` — Linear
+ * always returns one in practice but the lazy builder doesn't require it
+ * to call the API (the bearer token implicitly scopes to the granting
+ * workspace). The id is persisted for admin-UI display, not for routing.
+ */
+export async function fetchLinearViewer(
+  accessToken: string,
+): Promise<ViewerInfo> {
+  const query = `query { viewer { id name email organization { id urlKey name } } }`;
+  let resp: Response;
+  try {
+    resp = await fetchWithTimeout(
+      GRAPHQL_URL,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          "Content-Type": "application/json",
+          Accept: "application/json",
+        },
+        body: JSON.stringify({ query }),
+      },
+      INSTALL_FETCH_TIMEOUT_MS,
+    );
+  } catch (err) {
+    const isAbort = err instanceof Error && err.name === "AbortError";
+    log.warn(
+      { err: err instanceof Error ? err.message : String(err), timedOut: isAbort },
+      isAbort
+        ? "Linear /graphql viewer query timed out"
+        : "Linear /graphql viewer query unreachable",
+    );
+    throw new PlatformOAuthExchangeError({
+      message: isAbort
+        ? "Linear API timed out while confirming the install. Restart the install."
+        : "Failed to reach Linear API while confirming the install. Restart the install.",
+      platform: LINEAR_SLUG,
+      upstreamError: isAbort ? "timeout" : err instanceof Error ? err.message : String(err),
+    });
+  }
+
+  if (!resp.ok) {
+    throw new PlatformOAuthExchangeError({
+      message: "Linear rejected the viewer-confirmation request. Restart the install.",
+      platform: LINEAR_SLUG,
+      upstreamError: `viewer_http_${resp.status}`,
+    });
+  }
+
+  let parsed: LinearViewerResponse;
+  try {
+    parsed = (await resp.json()) as LinearViewerResponse;
+  } catch (err) {
+    throw new PlatformOAuthExchangeError({
+      message: "Linear viewer query returned an unparseable response. Restart the install.",
+      platform: LINEAR_SLUG,
+      upstreamError: err instanceof Error ? err.message : String(err),
+    });
+  }
+
+  if (parsed.errors && parsed.errors.length > 0) {
+    const first = parsed.errors[0]?.message ?? "unknown_graphql_error";
+    throw new PlatformOAuthExchangeError({
+      message: "Linear API rejected the viewer confirmation. Restart the install.",
+      platform: LINEAR_SLUG,
+      upstreamError: `graphql:${first}`,
+    });
+  }
+
+  const viewer = parsed.data?.viewer;
+  if (!viewer) {
+    throw new PlatformOAuthExchangeError({
+      message: "Linear API returned no viewer for this OAuth grant. Restart the install.",
+      platform: LINEAR_SLUG,
+      upstreamError: "no_viewer",
+    });
+  }
+
+  return {
+    userId: typeof viewer.id === "string" ? viewer.id : null,
+    userName: typeof viewer.name === "string" ? viewer.name : null,
+    userEmail: typeof viewer.email === "string" ? viewer.email : null,
+    organizationId:
+      typeof viewer.organization?.id === "string" ? viewer.organization.id : null,
+    organizationName:
+      typeof viewer.organization?.name === "string" ? viewer.organization.name : null,
+    organizationUrlKey:
+      typeof viewer.organization?.urlKey === "string" ? viewer.organization.urlKey : null,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+export class LinearOAuthInstallHandler implements OAuthPlatformInstallHandler {
+  readonly kind = "oauth" as const;
+
+  constructor(private readonly config: LinearOAuthHandlerConfig) {}
+
+  async startInstall(workspaceId: WorkspaceId): Promise<{
+    readonly redirectUrl: string;
+    readonly stateToken: string;
+  }> {
+    const stateToken = mintOAuthStateToken(workspaceId, LINEAR_SLUG);
+    const url = new URL(AUTHORIZE_URL);
+    url.searchParams.set("client_id", this.config.clientId);
+    url.searchParams.set("redirect_uri", this.config.redirectUri);
+    url.searchParams.set("response_type", "code");
+    url.searchParams.set("scope", LINEAR_SCOPES);
+    url.searchParams.set("state", stateToken);
+    // `prompt=consent` forces Linear's consent screen on every install —
+    // even for an admin who has previously granted Atlas access. Without
+    // it, Linear silently re-uses the prior grant and the customer admin
+    // never sees what Atlas is asking for on a re-install.
+    url.searchParams.set("prompt", "consent");
+    // `actor=user` is the default but we set it explicitly so the
+    // attribution semantic is on the URL (audit-grep-able). Atlas
+    // creates issues that attribute to the granting user, not to a
+    // separate "Atlas Bot" user. See the file header for the trade-off.
+    url.searchParams.set("actor", "user");
+    return { redirectUrl: url.toString(), stateToken };
+  }
+
+  async handleCallback(
+    code: string,
+    stateToken: string,
+  ): Promise<{
+    readonly workspaceId: WorkspaceId;
+    readonly catalogId: CatalogId;
+    readonly installRecord: InstallRecord;
+    readonly credentialResult: CredentialResult;
+  } | null> {
+    // ── 1. Verify state — null on every failure mode ─────────────
+    const verified = verifyOAuthStateToken(stateToken);
+    if (!verified) return null;
+    const workspaceId = verified.workspaceId as WorkspaceId;
+    if (verified.catalogId !== LINEAR_SLUG) {
+      log.warn(
+        { expected: LINEAR_SLUG, got: verified.catalogId },
+        "Linear OAuth callback received state bound to a different catalog — rejecting",
+      );
+      return null;
+    }
+
+    // ── 2. Exchange code for tokens ───────────────────────────────
+    const tokens = await exchangeAuthCodeForTokens({
+      clientId: this.config.clientId,
+      clientSecret: this.config.clientSecret,
+      redirectUri: this.config.redirectUri,
+      code,
+    });
+
+    // ── 3. Discover viewer + organization ────────────────────────
+    // Used purely for admin-UI display ("Connected to <Linear workspace name>")
+    // and forensics. The bearer token implicitly scopes API calls to the
+    // granting workspace, so no routing identifier is needed.
+    const viewer = await fetchLinearViewer(tokens.access_token);
+
+    const scopes = tokens.scope ?? LINEAR_SCOPES;
+    const tokenType = tokens.token_type ?? "Bearer";
+    const expiresAt =
+      typeof tokens.expires_in === "number" && Number.isFinite(tokens.expires_in)
+        ? Date.now() + tokens.expires_in * 1000
+        : null;
+
+    // ── 4. Install record — workspace_plugins INSERT (first store) ──
+    // Operator-visible fields land in `config`; the credential bundle
+    // (access + refresh token) lands in `integration_credentials` in
+    // step 5. Status seeds as `"ok"`; the refresh flow flips it to
+    // `"reconnect_needed"` on permanent failure.
+    //
+    // Per migration 0092 (#2739) the INSERT names `pillar` and
+    // `install_id` explicitly — pillar='action' for Linear (Atlas writes
+    // to Linear, not chat) and `install_id` is the same UUID as `id`
+    // because action-pillar installs are singletons per (workspace,
+    // catalog) under the partial unique index
+    // `workspace_plugins_singleton`. Newer pattern than Jira's
+    // pre-0092 trigger-derived shape (see discord-static-bot-handler.ts
+    // for the same explicit-pillar idiom in newer code).
+    const installId = crypto.randomUUID();
+    const installConfig: Record<string, unknown> = {
+      scopes,
+      status: "ok",
+      ...(viewer.organizationId ? { organization_id: viewer.organizationId } : {}),
+      ...(viewer.organizationName ? { organization_name: viewer.organizationName } : {}),
+      ...(viewer.organizationUrlKey ? { organization_url_key: viewer.organizationUrlKey } : {}),
+      ...(viewer.userId ? { user_id: viewer.userId } : {}),
+      ...(viewer.userName ? { user_name: viewer.userName } : {}),
+      ...(viewer.userEmail ? { user_email: viewer.userEmail } : {}),
+    };
+    try {
+      await internalQuery(
+        `INSERT INTO workspace_plugins
+           (id, workspace_id, catalog_id, install_id, pillar, config, enabled, installed_at)
+         VALUES ($1, $2, $3, $1, 'action', $4::jsonb, true, NOW())
+         ON CONFLICT (workspace_id, catalog_id) WHERE pillar IN ('chat', 'action')
+         DO UPDATE
+           SET config = EXCLUDED.config,
+               enabled = true`,
+        [installId, workspaceId, LINEAR_CATALOG_ID, JSON.stringify(installConfig)],
+      );
+    } catch (err) {
+      log.error(
+        {
+          workspaceId,
+          err: err instanceof Error ? err.message : String(err),
+        },
+        "Failed to write workspace_plugins install record — aborting Linear install",
+      );
+      throw err;
+    }
+
+    const installRecord: InstallRecord = {
+      id: installId,
+      workspaceId,
+      catalogId: LINEAR_SLUG,
+    };
+
+    // ── 5. Credential — integration_credentials INSERT (second store) ──
+    // `instanceUrl` is the Linear GraphQL endpoint. There's no per-
+    // tenant variation today; the field is populated so the bundle
+    // shape stays uniform across platforms (Jira / Salesforce both
+    // carry a per-tenant URL here).
+    const bundle: CredentialBundle = {
+      accessToken: tokens.access_token,
+      refreshToken: tokens.refresh_token ?? null,
+      expiresAt,
+      tokenType,
+      scope: scopes,
+      instanceUrl: GRAPHQL_URL,
+    };
+
+    try {
+      await saveCredentialBundle(workspaceId, LINEAR_CATALOG_ID, bundle);
+      log.info(
+        {
+          workspaceId,
+          organizationId: viewer.organizationId,
+          organizationName: viewer.organizationName,
+        },
+        "Linear install completed (both stores written)",
+      );
+      return {
+        workspaceId,
+        catalogId: LINEAR_SLUG,
+        installRecord,
+        credentialResult: { written: true },
+      };
+    } catch (err) {
+      const errMessage = err instanceof Error ? err.message : String(err);
+      log.warn(
+        { workspaceId, err: errMessage },
+        "Linear install record written but integration_credentials write failed — Reconnect required",
+      );
+      // Flip `status: "reconnect_needed"` so the admin card surfaces a
+      // persistent Reconnect CTA. Mirror Jira / Salesforce behaviour —
+      // without this the `?reconnect=linear` callback query param shows
+      // once and then disappears on the next admin-page reload.
+      try {
+        await internalQuery(
+          `UPDATE workspace_plugins
+              SET config = config || jsonb_build_object('status', 'reconnect_needed')
+            WHERE workspace_id = $1 AND catalog_id = $2`,
+          [workspaceId, LINEAR_CATALOG_ID],
+        );
+      } catch (statusErr) {
+        log.warn(
+          {
+            workspaceId,
+            err: statusErr instanceof Error ? statusErr.message : String(statusErr),
+          },
+          "Failed to mark Linear install as reconnect_needed after credential write failure",
+        );
+      }
+      return {
+        workspaceId,
+        catalogId: LINEAR_SLUG,
+        installRecord,
+        credentialResult: {
+          written: false,
+          reason: "Credential persist failed — admin should retry via Reconnect",
+        },
+      };
+    }
+  }
+}

--- a/packages/api/src/lib/integrations/install/linear-oauth-handler.ts
+++ b/packages/api/src/lib/integrations/install/linear-oauth-handler.ts
@@ -90,8 +90,17 @@ const GRAPHQL_URL = "https://api.linear.app/graphql";
  * If the operator's App is configured with a tighter scope set, Linear
  * rejects the install with `invalid_scope`; the admin sees the effective
  * scope list in `workspace_plugins.config.scopes`.
+ *
+ * Format note: Linear's `/oauth/authorize` expects the `scope` param as a
+ * **comma-separated** list (Linear-specific — distinct from the OAuth 2.0
+ * spec's space-separated convention used by Slack/Atlassian). Linear's
+ * `/oauth/token` response, conversely, echoes scopes as a **space-separated**
+ * string (per their docs, for apps created after Dec 1 2023). We keep one
+ * source of truth and serialize per-side.
  */
-const LINEAR_SCOPES = "read write issues:create";
+const LINEAR_SCOPES = ["read", "write", "issues:create"] as const;
+const LINEAR_AUTHORIZE_SCOPE = LINEAR_SCOPES.join(",");
+const LINEAR_DEFAULT_TOKEN_SCOPE = LINEAR_SCOPES.join(" ");
 
 /**
  * Operator-side Linear OAuth App config. Read once from env in
@@ -386,7 +395,7 @@ export class LinearOAuthInstallHandler implements OAuthPlatformInstallHandler {
     url.searchParams.set("client_id", this.config.clientId);
     url.searchParams.set("redirect_uri", this.config.redirectUri);
     url.searchParams.set("response_type", "code");
-    url.searchParams.set("scope", LINEAR_SCOPES);
+    url.searchParams.set("scope", LINEAR_AUTHORIZE_SCOPE);
     url.searchParams.set("state", stateToken);
     // `prompt=consent` forces Linear's consent screen on every install —
     // even for an admin who has previously granted Atlas access. Without
@@ -436,7 +445,7 @@ export class LinearOAuthInstallHandler implements OAuthPlatformInstallHandler {
     // granting workspace, so no routing identifier is needed.
     const viewer = await fetchLinearViewer(tokens.access_token);
 
-    const scopes = tokens.scope ?? LINEAR_SCOPES;
+    const scopes = tokens.scope ?? LINEAR_DEFAULT_TOKEN_SCOPE;
     const tokenType = tokens.token_type ?? "Bearer";
     const expiresAt =
       typeof tokens.expires_in === "number" && Number.isFinite(tokens.expires_in)

--- a/packages/api/src/lib/integrations/install/linear-token-refresh.ts
+++ b/packages/api/src/lib/integrations/install/linear-token-refresh.ts
@@ -1,0 +1,283 @@
+/**
+ * Linear access-token refresh (#2750).
+ *
+ * Mirrors {@link ./jira-token-refresh.ts}; Linear-specific twists:
+ *
+ *   - **Refresh tokens rotate on every refresh.** Like Atlassian, Linear
+ *     returns a fresh `refresh_token` in the success response and the
+ *     previous value MUST NOT be reused. Persisting the new value back
+ *     to `integration_credentials` is non-optional.
+ *   - **Token endpoint is form-encoded.** Linear's `/oauth/token`
+ *     accepts `application/x-www-form-urlencoded`, matching Salesforce
+ *     (Atlassian is the odd one out with JSON).
+ *   - **Permanent failures classify the same way.** Linear returns
+ *     `invalid_grant` when the stored refresh token is rejected and
+ *     `invalid_client` when the OAuth App credentials are wrong. Only
+ *     `invalid_grant` and Linear-side scope revocation flip
+ *     `reconnect_needed`; `invalid_client` stays transient (operator-
+ *     side env misconfig should not force every tenant admin to re-
+ *     OAuth after the operator fixes the env).
+ *
+ * @see ./linear-oauth-handler.ts — the initial OAuth dance
+ * @see ./jira-token-refresh.ts — sibling reference implementation
+ * @see ../credentials/store.ts — the credential bundle store
+ */
+
+import { createLogger } from "@atlas/api/lib/logger";
+import { internalQuery } from "@atlas/api/lib/db/internal";
+import {
+  readCredentialBundle,
+  saveCredentialBundle,
+  type CredentialBundle,
+} from "@atlas/api/lib/integrations/credentials/store";
+import { LinearReconnectRequiredError } from "@atlas/api/lib/effect/errors";
+import { LINEAR_CATALOG_ID, LINEAR_SLUG } from "./linear-oauth-handler";
+
+// Re-export so the lazy-builder + future callers can pull from this
+// module. Canonical definition lives in `effect/errors.ts` so the error
+// participates in the `AtlasError` union + `mapTaggedError` exhaustive
+// switch (409 Conflict + `conflict` wire code, alongside Salesforce + Jira).
+export { LinearReconnectRequiredError };
+
+const log = createLogger("integrations.install.linear-refresh");
+
+const TOKEN_URL = "https://api.linear.app/oauth/token";
+
+/**
+ * Linear error codes that prove the install will never recover without
+ * a fresh OAuth dance. `invalid_grant` is RFC 6749's "refresh token
+ * rejected"; `unauthorized_client` and `access_denied` cover scope
+ * revocation. Kept narrow on purpose — an unknown error code surfaces
+ * as transient so we don't mis-classify the install as "reconnect
+ * needed" without evidence.
+ *
+ * `invalid_client` is intentionally NOT in this set — that signals
+ * wrong env wiring (`LINEAR_CLIENT_ID` / `LINEAR_CLIENT_SECRET` typo),
+ * not a per-Workspace problem.
+ */
+const PERMANENT_REFRESH_FAILURE_CODES = new Set([
+  "invalid_grant",
+  "unauthorized_client",
+  "access_denied",
+]);
+
+interface LinearRefreshSuccess {
+  readonly access_token: string;
+  readonly refresh_token: string;
+  readonly expires_in?: number;
+  readonly token_type?: string;
+  readonly scope?: string;
+}
+
+interface LinearRefreshFailure {
+  readonly error: string;
+  readonly error_description?: string;
+}
+
+type LinearRefreshResponse = LinearRefreshSuccess | LinearRefreshFailure;
+
+function isRefreshSuccess(r: LinearRefreshResponse): r is LinearRefreshSuccess {
+  return (
+    "access_token" in r &&
+    typeof r.access_token === "string" &&
+    "refresh_token" in r &&
+    typeof r.refresh_token === "string"
+  );
+}
+
+interface RefreshArgs {
+  readonly clientId: string;
+  readonly clientSecret: string;
+  readonly refreshToken: string;
+}
+
+/**
+ * POST `api.linear.app/oauth/token` with `grant_type=refresh_token`.
+ * On HTTP 4xx carrying one of the {@link PERMANENT_REFRESH_FAILURE_CODES},
+ * throws `LinearReconnectRequiredError`. On anything else (network failure,
+ * 5xx, unknown 4xx, `invalid_client`), throws a plain `Error` so the
+ * caller treats it as transient.
+ */
+async function exchangeRefreshToken(
+  args: RefreshArgs,
+  workspaceId: string,
+): Promise<LinearRefreshSuccess> {
+  const body = new URLSearchParams({
+    grant_type: "refresh_token",
+    client_id: args.clientId,
+    client_secret: args.clientSecret,
+    refresh_token: args.refreshToken,
+  });
+
+  let resp: Response;
+  try {
+    resp = await fetch(TOKEN_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: body.toString(),
+    });
+  } catch (err) {
+    // Network failure — transient. Let the caller retry on the next
+    // tool call. Don't flip reconnect_needed without evidence.
+    throw new Error(
+      `Linear token endpoint unreachable: ${err instanceof Error ? err.message : String(err)}`,
+      { cause: err },
+    );
+  }
+
+  let parsed: LinearRefreshResponse;
+  try {
+    parsed = (await resp.json()) as LinearRefreshResponse;
+  } catch (err) {
+    throw new Error(
+      `Linear refresh returned unparseable body (HTTP ${resp.status})`,
+      { cause: err },
+    );
+  }
+
+  if (!resp.ok || !isRefreshSuccess(parsed)) {
+    const failure = parsed as LinearRefreshFailure;
+    const errorCode = failure.error ?? `http_${resp.status}`;
+    if (resp.status >= 400 && resp.status < 500 && PERMANENT_REFRESH_FAILURE_CODES.has(errorCode)) {
+      log.warn(
+        { workspaceId, errorCode, description: failure.error_description },
+        "Linear refresh failed permanently — flagging reconnect_needed",
+      );
+      throw new LinearReconnectRequiredError({
+        message: "Linear install needs to be reconnected — refresh token rejected by Linear.",
+        workspaceId,
+        upstreamError: errorCode,
+      });
+    }
+    // Unknown error code, 5xx, or `invalid_client` (operator env
+    // misconfig) — treat as transient.
+    throw new Error(`Linear refresh failed: ${errorCode} (HTTP ${resp.status})`);
+  }
+
+  return parsed;
+}
+
+/**
+ * Mark the install row as `reconnect_needed`. JSONB merge so unrelated
+ * config fields (organization_id, scopes, etc.) survive.
+ */
+async function markReconnectNeeded(workspaceId: string): Promise<void> {
+  try {
+    await internalQuery(
+      `UPDATE workspace_plugins
+          SET config = config || jsonb_build_object('status', 'reconnect_needed')
+        WHERE workspace_id = $1 AND catalog_id = $2`,
+      [workspaceId, LINEAR_CATALOG_ID],
+    );
+  } catch (err) {
+    log.warn(
+      { workspaceId, err: err instanceof Error ? err.message : String(err) },
+      "Failed to mark Linear install as reconnect_needed (install row may have been disconnected)",
+    );
+  }
+}
+
+/**
+ * Clear the `reconnect_needed` marker on a successful refresh. Idempotent.
+ */
+async function clearReconnectNeeded(workspaceId: string): Promise<void> {
+  try {
+    await internalQuery(
+      `UPDATE workspace_plugins
+          SET config = config || jsonb_build_object('status', 'ok')
+        WHERE workspace_id = $1 AND catalog_id = $2`,
+      [workspaceId, LINEAR_CATALOG_ID],
+    );
+  } catch (err) {
+    log.warn(
+      { workspaceId, err: err instanceof Error ? err.message : String(err) },
+      "Failed to clear reconnect_needed flag after successful Linear refresh",
+    );
+  }
+}
+
+export interface RefreshLinearTokenArgs {
+  readonly workspaceId: string;
+  readonly clientId: string;
+  readonly clientSecret: string;
+}
+
+/**
+ * Refresh the Linear access token for `workspaceId`. Returns the updated
+ * `CredentialBundle` (also persisted to `integration_credentials` with
+ * the rotated refresh_token). On permanent failure throws
+ * `LinearReconnectRequiredError` and flips
+ * `workspace_plugins.config.status` to `"reconnect_needed"`.
+ */
+export async function refreshLinearToken(
+  args: RefreshLinearTokenArgs,
+): Promise<CredentialBundle> {
+  const bundle = await readCredentialBundle(args.workspaceId, LINEAR_CATALOG_ID);
+  if (!bundle) {
+    throw new Error(
+      `No Linear credentials found for workspace ${args.workspaceId} — install was disconnected`,
+    );
+  }
+  if (!bundle.refreshToken) {
+    log.warn(
+      { workspaceId: args.workspaceId },
+      "Linear credential bundle has no refresh_token — flagging reconnect_needed",
+    );
+    await markReconnectNeeded(args.workspaceId);
+    throw new LinearReconnectRequiredError({
+      message: "Linear install has no refresh token — App must request the offline scope.",
+      workspaceId: args.workspaceId,
+      upstreamError: "no_refresh_token",
+    });
+  }
+
+  let refreshed: LinearRefreshSuccess;
+  try {
+    refreshed = await exchangeRefreshToken(
+      {
+        clientId: args.clientId,
+        clientSecret: args.clientSecret,
+        refreshToken: bundle.refreshToken,
+      },
+      args.workspaceId,
+    );
+  } catch (err) {
+    if (err instanceof LinearReconnectRequiredError) {
+      await markReconnectNeeded(args.workspaceId);
+    }
+    throw err;
+  }
+
+  // Linear rotates the refresh token on every refresh — `refresh_token`
+  // is required in the success response. The `isRefreshSuccess` guard
+  // already asserted both fields are present, so we don't fall back to
+  // the stored value the way Salesforce sometimes does.
+  const expiresAt =
+    typeof refreshed.expires_in === "number" && Number.isFinite(refreshed.expires_in)
+      ? Date.now() + refreshed.expires_in * 1000
+      : null;
+
+  const next: CredentialBundle = {
+    accessToken: refreshed.access_token,
+    refreshToken: refreshed.refresh_token,
+    expiresAt,
+    tokenType: refreshed.token_type ?? bundle.tokenType,
+    scope: refreshed.scope ?? bundle.scope,
+    instanceUrl: bundle.instanceUrl,
+    ...(bundle.extra ? { extra: bundle.extra } : {}),
+  };
+
+  await saveCredentialBundle(args.workspaceId, LINEAR_CATALOG_ID, next);
+  // Independent UPDATE so a failure to clear the flag doesn't roll back
+  // a successful refresh.
+  await clearReconnectNeeded(args.workspaceId);
+
+  log.info(
+    { workspaceId: args.workspaceId },
+    "Linear token refreshed successfully",
+  );
+  return next;
+}
+
+/** Re-export to keep the slug constant in one place for catalog wiring. */
+export { LINEAR_SLUG, LINEAR_CATALOG_ID };

--- a/packages/api/src/lib/integrations/install/register.ts
+++ b/packages/api/src/lib/integrations/install/register.ts
@@ -47,6 +47,16 @@ import { createJiraLazyBuilder } from "@atlas/api/lib/integrations/jira/lazy-bui
 import { createSalesforceLazyBuilder } from "@atlas/api/lib/integrations/salesforce/lazy-builder";
 import { createEmailLazyBuilder } from "@atlas/api/lib/integrations/email-tool";
 import { EMAIL_CATALOG_ID } from "./email-secret-schema";
+import {
+  LinearOAuthInstallHandler,
+  LINEAR_CATALOG_ID,
+} from "./linear-oauth-handler";
+import { LinearApiKeyFormInstallHandler } from "./linear-apikey-form-handler";
+import { LINEAR_APIKEY_CATALOG_ID } from "./linear-apikey-secret-schema";
+import {
+  createLinearOAuthLazyBuilder,
+  createLinearApiKeyLazyBuilder,
+} from "@atlas/api/lib/integrations/linear/lazy-builder";
 
 const log = createLogger("integrations.install.register");
 
@@ -113,6 +123,19 @@ export function registerBuiltinInstallHandlers(): void {
   log.info("Registered ObsidianFormInstallHandler");
   registerFormHandler("webhook", new WebhookFormInstallHandler());
   log.info("Registered WebhookFormInstallHandler");
+  // Linear API-key form-install (#2750). Pairs with the lazy builder
+  // for `catalog:linear-apikey` registered below — same "register both
+  // halves together so a half-wired deploy can't end up with an
+  // installable card whose first tool call fails with builder_missing"
+  // rule as Email's pairing above.
+  registerFormHandler("linear-apikey", new LinearApiKeyFormInstallHandler());
+  if (!lazyPluginLoader.hasBuilder(LINEAR_APIKEY_CATALOG_ID)) {
+    lazyPluginLoader.registerBuilder(
+      LINEAR_APIKEY_CATALOG_ID,
+      createLinearApiKeyLazyBuilder(),
+    );
+  }
+  log.info("Registered LinearApiKeyFormInstallHandler + LazyPluginLoader builder");
 
   // ── Slack OAuth ───────────────────────────────────────────────────
   registerSlackOAuthHandler();
@@ -125,6 +148,7 @@ export function registerBuiltinInstallHandlers(): void {
   // operator install doesn't end up with an installable card that
   // breaks on the first tool call.
   registerJiraOAuthHandler();
+  registerLinearOAuthHandler();
   registerSalesforceOAuthHandler();
 
   // ── Static-bot platforms (1.5.3 — Phase D, #2748+) ────────────────
@@ -200,6 +224,41 @@ function registerJiraOAuthHandler(): void {
     );
   }
   log.info({ publicApiUrl }, "Registered JiraOAuthInstallHandler + LazyPluginLoader builder");
+}
+
+function registerLinearOAuthHandler(): void {
+  const clientId = process.env.LINEAR_CLIENT_ID;
+  const clientSecret = process.env.LINEAR_CLIENT_SECRET;
+  const publicApiUrl = resolvePublicApiUrl();
+
+  if (!clientId || !clientSecret) {
+    log.info(
+      "Linear OAuth handler not registered — LINEAR_CLIENT_ID / LINEAR_CLIENT_SECRET unset. /api/v1/integrations/linear/install will return 501 until configured. (linear-apikey form-install path remains available — no env gate.)",
+    );
+    return;
+  }
+  if (!publicApiUrl) {
+    log.warn(
+      "Linear OAuth handler not registered — ATLAS_PUBLIC_API_URL is unset, so the redirect URI cannot be resolved.",
+    );
+    return;
+  }
+
+  registerOAuthHandler(
+    "linear",
+    new LinearOAuthInstallHandler({
+      clientId,
+      clientSecret,
+      redirectUri: `${publicApiUrl}/api/v1/integrations/linear/callback`,
+    }),
+  );
+  if (!lazyPluginLoader.hasBuilder(LINEAR_CATALOG_ID)) {
+    lazyPluginLoader.registerBuilder(
+      LINEAR_CATALOG_ID,
+      createLinearOAuthLazyBuilder({ clientId, clientSecret }),
+    );
+  }
+  log.info({ publicApiUrl }, "Registered LinearOAuthInstallHandler + LazyPluginLoader builder");
 }
 
 function registerSalesforceOAuthHandler(): void {

--- a/packages/api/src/lib/integrations/linear-tool.ts
+++ b/packages/api/src/lib/integrations/linear-tool.ts
@@ -1,0 +1,387 @@
+/**
+ * `createLinearIssue` agent tool (#2750).
+ *
+ * Per-Workspace lazy-plugin tool that dispatches through whichever
+ * Linear install is enabled for the active workspace:
+ *
+ *   1. Look up `catalog:linear` (OAuth mode) first — preferred path
+ *      because access tokens rotate automatically.
+ *   2. Fall back to `catalog:linear-apikey` (API-key mode) when no
+ *      OAuth install is present.
+ *   3. If neither is installed, return `no_install` with the
+ *      `/admin/integrations` install copy.
+ *
+ * Two-mode dispatch lives in this tool — not in the lazy-loader —
+ * because the loader's contract is "one builder per catalog id." The
+ * tool is the natural seam where "Linear is one *capability* with two
+ * install paths" is expressed; the loader stays unaware that the two
+ * catalog rows are related.
+ *
+ * Surfaces seven distinct status discriminants to the agent so the
+ * model can self-correct or stop looping (sendEmail #2698 set the
+ * pattern):
+ *
+ *   - **`created`** — happy path; carries the issue id + URL.
+ *   - **`no_workspace`** — request had no `activeOrganizationId`.
+ *   - **`no_install`** — actionable "install at /admin/integrations"
+ *     message. Triggered when NEITHER `catalog:linear` nor
+ *     `catalog:linear-apikey` has an enabled `workspace_plugins` row.
+ *   - **`decrypt_failure`** — selective-field decrypt threw. Surfaces
+ *     `requestId` for ops correlation. Terminal — retry won't help.
+ *   - **`misconfigured`** — `LazyPluginBuilderMissingError` from the
+ *     loader. The catalog row is installed but the boot DAG never
+ *     registered the matching builder — an operator-side bug.
+ *   - **`reconnect_required`** — the OAuth install's refresh-token
+ *     rotation failed permanently OR the API-key was rejected. Distinct
+ *     remediation per mode: OAuth → Reconnect button at
+ *     /admin/integrations; API-key → rotate the personal key and
+ *     re-submit the install form.
+ *   - **`create_failure`** — Linear's GraphQL returned errors. Wraps
+ *     the upstream message (scrubbed via `errorMessage()` so credentials
+ *     embedded in upstream error text don't leak to the agent).
+ *
+ * Workspace context resolution: read from {@link getRequestContext}'s
+ * `user.activeOrganizationId`. Tool registration happens at boot;
+ * workspace presence is NOT checked at registration time — the tool is
+ * always discoverable, and the per-Workspace install gate runs at
+ * execute time. Matches the sendEmail #2698 pattern.
+ *
+ * @see ./linear/lazy-builder.ts — per-mode builders + shared GraphQL helper
+ * @see ./install/linear-oauth-handler.ts — OAuth install path
+ * @see ./install/linear-apikey-form-handler.ts — API-key install path
+ * @see ./email-tool.ts — first per-Workspace lazy-plugin tool reference
+ * @see ../tools/registry.ts — `defaultRegistry` registration site
+ */
+
+import { tool } from "ai";
+import { z } from "zod";
+
+import { createLogger, getRequestContext } from "@atlas/api/lib/logger";
+import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
+import {
+  lazyPluginLoader,
+  LazyPluginBuilderMissingError,
+  LazyPluginInstallNotFoundError,
+  type LazyPluginLoader,
+} from "@atlas/api/lib/plugins/lazy-loader";
+import {
+  LINEAR_CATALOG_ID,
+  LINEAR_APIKEY_CATALOG_ID,
+  LinearApiKeyDecryptFailureError,
+  LinearApiKeyMissingError,
+  LinearApiKeyRejectedError,
+  LinearGraphQLError,
+  type LinearPluginInstance,
+  type LinearIssueCreateResult,
+} from "./linear/lazy-builder";
+import { LinearReconnectRequiredError } from "./install/linear-token-refresh";
+
+const log = createLogger("integrations.linear.tool");
+
+export const CREATE_LINEAR_ISSUE_DESCRIPTION = `### Create Linear Issue
+Use createLinearIssue to create a new Linear issue based on the agent's findings:
+- Provide a concise title (the issue's name in Linear)
+- Include relevant context in the description (markdown supported)
+- Optionally specify a teamKey (e.g. "ENG") or teamId (UUID) to target a specific team — without one, Linear picks the bearer's default team
+- Optionally include labelIds to tag the issue
+- The Linear integration must be installed for the workspace at /admin/integrations
+- Either OAuth mode (catalog:linear) or API-key mode (catalog:linear-apikey) works; the tool tries OAuth first and falls back to API-key`;
+
+/**
+ * Test seam — production calls go through the singleton
+ * `lazyPluginLoader`. Tests inject a fake loader (and a fake context
+ * source) so the tool's execute path can be exercised without booting
+ * the loader.
+ */
+export interface CreateLinearIssueToolDeps {
+  readonly loader?: Pick<LazyPluginLoader, "getOrInstantiate">;
+  readonly resolveWorkspaceId?: () => string | undefined;
+  readonly resolveRequestId?: () => string | undefined;
+}
+
+const CreateLinearIssueInput = z.object({
+  title: z
+    .string()
+    .min(1, "title must not be empty")
+    .max(255, "title must be 255 characters or fewer"),
+  description: z.string().optional(),
+  teamKey: z
+    .string()
+    .regex(
+      /^[A-Z][A-Z0-9_]*$/,
+      "teamKey must be uppercase alphanumeric (e.g. 'ENG')",
+    )
+    .optional(),
+  teamId: z.string().uuid().optional(),
+  priority: z
+    .number()
+    .int()
+    .min(0)
+    .max(4)
+    .optional()
+    .describe("0=no priority, 1=urgent, 2=high, 3=medium, 4=low"),
+  labelIds: z.array(z.string().uuid()).optional(),
+});
+
+type CreateLinearIssueExecuteResult =
+  | {
+      status: "created";
+      mode: "oauth" | "apikey";
+      issue: LinearIssueCreateResult;
+    }
+  | {
+      status: "no_workspace";
+      message: string;
+    }
+  | {
+      status: "no_install";
+      message: string;
+    }
+  | {
+      status: "decrypt_failure";
+      message: string;
+      requestId: string | undefined;
+    }
+  | {
+      status: "misconfigured";
+      message: string;
+      requestId: string | undefined;
+    }
+  | {
+      // OAuth refresh permanently failed OR API-key was rejected.
+      // Mode tells the agent which remediation to point the user at.
+      status: "reconnect_required";
+      mode: "oauth" | "apikey";
+      message: string;
+    }
+  | {
+      status: "create_failure";
+      message: string;
+      requestId: string | undefined;
+    };
+
+function defaultResolveWorkspaceId(): string | undefined {
+  return getRequestContext()?.user?.activeOrganizationId;
+}
+
+function defaultResolveRequestId(): string | undefined {
+  return getRequestContext()?.requestId;
+}
+
+/**
+ * Try to instantiate a Linear plugin for `(workspaceId, catalogId)`.
+ * Returns:
+ *   - `instance` on success
+ *   - `null` on `LazyPluginInstallNotFoundError` (no enabled install row)
+ *   - throws on every other class so the caller can branch into
+ *     decrypt_failure / misconfigured / reconnect_required / create_failure
+ */
+async function tryInstantiate(
+  loader: Pick<LazyPluginLoader, "getOrInstantiate">,
+  workspaceId: string,
+  catalogId: string,
+): Promise<LinearPluginInstance | null> {
+  try {
+    const raw = await loader.getOrInstantiate(workspaceId, catalogId);
+    return raw as LinearPluginInstance;
+  } catch (err) {
+    if (err instanceof LazyPluginInstallNotFoundError) {
+      return null;
+    }
+    throw err;
+  }
+}
+
+export function createCreateLinearIssueTool(deps: CreateLinearIssueToolDeps = {}) {
+  const loader = deps.loader ?? lazyPluginLoader;
+  const resolveWorkspaceId = deps.resolveWorkspaceId ?? defaultResolveWorkspaceId;
+  const resolveRequestId = deps.resolveRequestId ?? defaultResolveRequestId;
+
+  return tool({
+    description:
+      "Create a Linear issue from the agent's findings. Uses the workspace's installed Linear integration (OAuth-preferred, API-key fallback).",
+    inputSchema: CreateLinearIssueInput,
+    execute: async ({
+      title,
+      description,
+      teamKey,
+      teamId,
+      priority,
+      labelIds,
+    }): Promise<CreateLinearIssueExecuteResult> => {
+      const workspaceId = resolveWorkspaceId();
+      if (!workspaceId) {
+        log.warn(
+          { requestId: resolveRequestId() },
+          "createLinearIssue invoked with no active workspaceId",
+        );
+        return {
+          status: "no_workspace",
+          message:
+            "No workspace is selected for this request. Open a workspace-scoped session before creating Linear issues.",
+        };
+      }
+
+      // ── Dispatch: OAuth first, then API-key ─────────────────────────
+      // Both modes can coexist (different catalog_id under the partial
+      // unique index) but OAuth is preferred because it refreshes
+      // automatically. If both are installed we pick OAuth and ignore
+      // the API-key row entirely.
+      let mode: "oauth" | "apikey" = "oauth";
+      let instance: LinearPluginInstance | null;
+
+      try {
+        instance = await tryInstantiate(loader, workspaceId, LINEAR_CATALOG_ID);
+        if (!instance) {
+          instance = await tryInstantiate(loader, workspaceId, LINEAR_APIKEY_CATALOG_ID);
+          if (instance) mode = "apikey";
+        }
+      } catch (err) {
+        if (err instanceof LinearReconnectRequiredError) {
+          log.warn(
+            { workspaceId, err: err.message },
+            "createLinearIssue aborted — Linear OAuth install needs Reconnect",
+          );
+          return {
+            status: "reconnect_required",
+            mode: "oauth",
+            message:
+              "Linear install needs to be reconnected. Open /admin/integrations and click Reconnect on the Linear (OAuth) card.",
+          };
+        }
+        if (err instanceof LinearApiKeyDecryptFailureError) {
+          const requestId = resolveRequestId();
+          log.error(
+            { workspaceId, requestId, err: err.message },
+            "createLinearIssue aborted — Linear API-key install decrypt failure",
+          );
+          return {
+            status: "decrypt_failure",
+            message: `Linear API-key credentials could not be decrypted for this workspace. Verify the encryption keyset and retry; request id ${requestId ?? "<unset>"}.`,
+            requestId,
+          };
+        }
+        if (err instanceof LinearApiKeyMissingError) {
+          const requestId = resolveRequestId();
+          log.error(
+            { workspaceId, requestId, err: err.message },
+            "createLinearIssue aborted — Linear API-key install row missing api_key field",
+          );
+          return {
+            status: "create_failure",
+            message: `Linear API-key install row is missing the api_key field. Disconnect + reinstall at /admin/integrations. Request id ${requestId ?? "<unset>"}.`,
+            requestId,
+          };
+        }
+        if (err instanceof LazyPluginBuilderMissingError) {
+          const requestId = resolveRequestId();
+          log.error(
+            { workspaceId, requestId, err: err.message },
+            "createLinearIssue aborted — Linear lazy builder not registered (boot DAG issue)",
+          );
+          return {
+            status: "misconfigured",
+            message: `Linear integration is installed but no builder is registered. This is a deploy-side configuration issue; contact your operator. Request id ${requestId ?? "<unset>"}.`,
+            requestId,
+          };
+        }
+        const requestId = resolveRequestId();
+        log.error(
+          { workspaceId, requestId, err: err instanceof Error ? err.message : String(err) },
+          "createLinearIssue aborted — failed to instantiate Linear plugin",
+        );
+        return {
+          status: "create_failure",
+          message: `Could not initialise the Linear integration: ${errorMessage(err)}`,
+          requestId,
+        };
+      }
+
+      if (!instance) {
+        log.info(
+          { workspaceId },
+          "createLinearIssue rejected — workspace has no Linear install (OAuth or API-key)",
+        );
+        return {
+          status: "no_install",
+          message:
+            "Install the Linear integration at /admin/integrations before creating issues. Neither catalog:linear (OAuth) nor catalog:linear-apikey (API key) is enabled for this workspace.",
+        };
+      }
+
+      // ── Execute the create ─────────────────────────────────────────
+      try {
+        const issue = await instance.createLinearIssue({
+          title,
+          ...(description ? { description } : {}),
+          ...(teamKey ? { teamKey } : {}),
+          ...(teamId ? { teamId } : {}),
+          ...(typeof priority === "number" ? { priority } : {}),
+          ...(labelIds && labelIds.length > 0 ? { labelIds } : {}),
+        });
+        log.info(
+          {
+            workspaceId,
+            mode,
+            issueId: issue.id,
+            issueIdentifier: issue.identifier,
+          },
+          "createLinearIssue created Linear issue",
+        );
+        return { status: "created", mode, issue };
+      } catch (err) {
+        if (err instanceof LinearReconnectRequiredError) {
+          log.warn(
+            { workspaceId, err: err.message },
+            "createLinearIssue: Linear OAuth refresh failed permanently mid-call",
+          );
+          return {
+            status: "reconnect_required",
+            mode: "oauth",
+            message:
+              "Linear OAuth refresh failed permanently. Open /admin/integrations and click Reconnect on the Linear (OAuth) card.",
+          };
+        }
+        if (err instanceof LinearApiKeyRejectedError) {
+          log.warn(
+            { workspaceId, err: err.message },
+            "createLinearIssue: Linear rejected the stored API key",
+          );
+          return {
+            status: "reconnect_required",
+            mode: "apikey",
+            message:
+              "Linear rejected the stored API key. Generate a new personal API key in Linear settings and re-submit the install form at /admin/integrations.",
+          };
+        }
+        if (err instanceof LinearGraphQLError) {
+          const requestId = resolveRequestId();
+          log.warn(
+            { workspaceId, requestId, err: err.upstreamMessage },
+            "createLinearIssue: Linear GraphQL rejected the mutation",
+          );
+          return {
+            status: "create_failure",
+            message: `Linear rejected the issue creation: ${err.upstreamMessage}`,
+            requestId,
+          };
+        }
+        const requestId = resolveRequestId();
+        log.error(
+          { workspaceId, requestId, err: err instanceof Error ? err.message : String(err) },
+          "createLinearIssue: Linear issueCreate threw",
+        );
+        return {
+          status: "create_failure",
+          // `errorMessage()` scrubs connection-string-shaped substrings
+          // from the underlying error text and truncates to 512 chars.
+          message: `Linear issue creation failed: ${errorMessage(err)}`,
+          requestId,
+        };
+      }
+    },
+  });
+}
+
+/** Production tool instance, registered with `defaultRegistry` in `tools/registry.ts`. */
+export const createLinearIssueTool = createCreateLinearIssueTool();

--- a/packages/api/src/lib/integrations/linear/__tests__/lazy-builder.test.ts
+++ b/packages/api/src/lib/integrations/linear/__tests__/lazy-builder.test.ts
@@ -1,0 +1,355 @@
+/**
+ * Tests for the Linear LazyPluginLoader builders (#2750).
+ *
+ * Two builders share this file because they share `runIssueCreate`:
+ *
+ *   - {@link createLinearOAuthLazyBuilder} — OAuth-bundle source, refresh
+ *     on 401, evict on permanent refresh failure (mirrors Jira pattern).
+ *   - {@link createLinearApiKeyLazyBuilder} — decrypts the api_key from
+ *     `workspace_plugins.config`, treats 401 as "rotate your key"
+ *     surface (no refresh path).
+ *
+ * Both builders return the same `LinearPluginInstance` shape so the
+ * tool layer's dispatch can pick either.
+ */
+
+import { afterEach, beforeAll, beforeEach, describe, expect, it, mock, type Mock } from "bun:test";
+import { _resetEncryptionKeyCache } from "@atlas/api/lib/db/encryption-keys";
+
+const mockReadCredentialBundle: Mock<(ws: string, cat: string) => Promise<unknown>> = mock(() =>
+  Promise.resolve(null),
+);
+mock.module("@atlas/api/lib/integrations/credentials/store", () => ({
+  readCredentialBundle: mockReadCredentialBundle,
+  saveCredentialBundle: mock(() => Promise.resolve()),
+  deleteCredentialBundle: mock(() => Promise.resolve(false)),
+}));
+
+const mockRefreshLinearToken: Mock<(args: unknown) => Promise<unknown>> = mock(() =>
+  Promise.resolve({
+    accessToken: "refreshed-access-token",
+    refreshToken: "ROTATED-refresh-token",
+    expiresAt: null,
+    tokenType: "Bearer",
+    scope: "read write issues:create",
+    instanceUrl: "https://api.linear.app/graphql",
+  }),
+);
+
+class TestLinearReconnectRequiredError extends Error {
+  readonly _tag = "LinearReconnectRequiredError" as const;
+  readonly workspaceId: string;
+  readonly upstreamError: string;
+  constructor(args: { workspaceId: string; upstreamError: string }) {
+    super(`reconnect_needed: ${args.upstreamError}`);
+    this.workspaceId = args.workspaceId;
+    this.upstreamError = args.upstreamError;
+  }
+}
+mock.module("@atlas/api/lib/integrations/install/linear-token-refresh", () => ({
+  refreshLinearToken: mockRefreshLinearToken,
+  LinearReconnectRequiredError: TestLinearReconnectRequiredError,
+  LINEAR_SLUG: "linear",
+  LINEAR_CATALOG_ID: "catalog:linear",
+}));
+
+const mockEvict: Mock<(workspaceId: string, catalogId: string) => Promise<boolean>> = mock(() =>
+  Promise.resolve(true),
+);
+mock.module("@atlas/api/lib/plugins/lazy-loader", () => ({
+  lazyPluginLoader: {
+    evict: mockEvict,
+    hasBuilder: mock(() => false),
+    registerBuilder: mock(() => undefined),
+    unregisterBuilder: mock(() => true),
+    size: mock(() => 0),
+    getOrInstantiate: mock(() => Promise.resolve({} as unknown)),
+  },
+  LazyPluginLoader: class {},
+  LazyPluginBuilderMissingError: class extends Error {},
+  LazyPluginInstallNotFoundError: class extends Error {},
+}));
+
+const ORIGINAL_FETCH = globalThis.fetch;
+const mockFetch: Mock<(input: unknown, init?: unknown) => Promise<Response>> = mock(() =>
+  Promise.resolve(new Response("{}", { status: 200 })),
+);
+
+type BuilderMod = typeof import("../lazy-builder");
+type LinearPluginInstance = import("../lazy-builder").LinearPluginInstance;
+let builderMod!: BuilderMod;
+
+beforeAll(async () => {
+  builderMod = await import("../lazy-builder");
+});
+
+const ORIGINAL_ENV = { ...process.env };
+
+beforeEach(() => {
+  process.env.ATLAS_ENCRYPTION_KEYS = "v1:test-key-for-linear-lazy-builder-unit-tests-long-enough";
+  _resetEncryptionKeyCache();
+  mockReadCredentialBundle.mockClear();
+  mockRefreshLinearToken.mockClear();
+  mockEvict.mockClear();
+  mockFetch.mockClear();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  globalThis.fetch = mockFetch as any;
+});
+
+afterEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+  _resetEncryptionKeyCache();
+  globalThis.fetch = ORIGINAL_FETCH;
+});
+
+const WSID = "ws-linear-builder-1";
+
+const STORED_OAUTH_BUNDLE = {
+  accessToken: "oauth-access-token",
+  refreshToken: "oauth-refresh-token",
+  expiresAt: null,
+  tokenType: "Bearer",
+  scope: "read write issues:create",
+  instanceUrl: "https://api.linear.app/graphql",
+};
+
+// ---------------------------------------------------------------------------
+// OAuth builder
+// ---------------------------------------------------------------------------
+
+describe("createLinearOAuthLazyBuilder", () => {
+  it("instantiates and calls issueCreate via Bearer token", async () => {
+    mockReadCredentialBundle.mockImplementation(() => Promise.resolve(STORED_OAUTH_BUNDLE));
+    mockFetch.mockImplementation(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            data: {
+              issueCreate: {
+                success: true,
+                issue: {
+                  id: "issue-uuid",
+                  identifier: "ENG-42",
+                  url: "https://linear.app/acme/issue/ENG-42",
+                  title: "Stale data",
+                },
+              },
+            },
+          }),
+          { status: 200 },
+        ),
+      ),
+    );
+
+    const builder = builderMod.createLinearOAuthLazyBuilder({
+      clientId: "ci",
+      clientSecret: "cs",
+    });
+    const instance = (await builder({
+      workspaceId: WSID,
+      catalogId: "catalog:linear",
+      config: {},
+    })) as LinearPluginInstance;
+
+    const result = await instance.createLinearIssue({ title: "Stale data" });
+    expect(result).toEqual({
+      id: "issue-uuid",
+      identifier: "ENG-42",
+      url: "https://linear.app/acme/issue/ENG-42",
+      title: "Stale data",
+    });
+
+    const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("https://api.linear.app/graphql");
+    expect((init.headers as Record<string, string>).Authorization).toBe(
+      "Bearer oauth-access-token",
+    );
+  });
+
+  it("refuses to instantiate when install status is reconnect_needed", async () => {
+    mockReadCredentialBundle.mockImplementation(() => Promise.resolve(STORED_OAUTH_BUNDLE));
+    const builder = builderMod.createLinearOAuthLazyBuilder({
+      clientId: "ci",
+      clientSecret: "cs",
+    });
+    await expect(
+      builder({
+        workspaceId: WSID,
+        catalogId: "catalog:linear",
+        config: { status: "reconnect_needed" },
+      }),
+    ).rejects.toBeInstanceOf(TestLinearReconnectRequiredError);
+
+    // No GraphQL traffic should fire — we threw before constructing the
+    // instance.
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("refreshes on 401 and retries the mutation once", async () => {
+    mockReadCredentialBundle.mockImplementation(() => Promise.resolve(STORED_OAUTH_BUNDLE));
+
+    let call = 0;
+    mockFetch.mockImplementation(() => {
+      call += 1;
+      if (call === 1) {
+        return Promise.resolve(new Response("unauthorized", { status: 401 }));
+      }
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            data: {
+              issueCreate: {
+                success: true,
+                issue: { id: "u", identifier: "ENG-9", url: "https://linear.app/x", title: "OK" },
+              },
+            },
+          }),
+          { status: 200 },
+        ),
+      );
+    });
+
+    const builder = builderMod.createLinearOAuthLazyBuilder({
+      clientId: "ci",
+      clientSecret: "cs",
+    });
+    const instance = (await builder({
+      workspaceId: WSID,
+      catalogId: "catalog:linear",
+      config: {},
+    })) as LinearPluginInstance;
+
+    const result = await instance.createLinearIssue({ title: "OK" });
+    expect(result.identifier).toBe("ENG-9");
+    expect(mockRefreshLinearToken).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+
+    // Second call used the refreshed access token.
+    const [, secondInit] = mockFetch.mock.calls[1] as [string, RequestInit];
+    expect((secondInit.headers as Record<string, string>).Authorization).toBe(
+      "Bearer refreshed-access-token",
+    );
+  });
+
+  it("evicts cached instance + rethrows when refresh fails permanently", async () => {
+    mockReadCredentialBundle.mockImplementation(() => Promise.resolve(STORED_OAUTH_BUNDLE));
+    mockFetch.mockImplementation(() => Promise.resolve(new Response("nope", { status: 401 })));
+    mockRefreshLinearToken.mockImplementation(() =>
+      Promise.reject(
+        new TestLinearReconnectRequiredError({
+          workspaceId: WSID,
+          upstreamError: "invalid_grant",
+        }),
+      ),
+    );
+
+    const builder = builderMod.createLinearOAuthLazyBuilder({
+      clientId: "ci",
+      clientSecret: "cs",
+    });
+    const instance = (await builder({
+      workspaceId: WSID,
+      catalogId: "catalog:linear",
+      config: {},
+    })) as LinearPluginInstance;
+
+    await expect(instance.createLinearIssue({ title: "x" })).rejects.toBeInstanceOf(
+      TestLinearReconnectRequiredError,
+    );
+
+    // Eviction fires so the agent doesn't keep re-trying through a
+    // dead cached instance.
+    expect(mockEvict).toHaveBeenCalledWith(WSID, "catalog:linear");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// API-key builder
+// ---------------------------------------------------------------------------
+
+describe("createLinearApiKeyLazyBuilder", () => {
+  it("decrypts api_key from config and uses it as the Bearer", async () => {
+    const { encryptSecretFields } = await import("@atlas/api/lib/plugins/secrets");
+    const { LINEAR_APIKEY_SECRET_FIELDS_SCHEMA } = await import(
+      "@atlas/api/lib/integrations/install/linear-apikey-secret-schema"
+    );
+    const encrypted = encryptSecretFields(
+      { api_key: "lin_api_secret_xyz", workspace_name: "Acme" },
+      LINEAR_APIKEY_SECRET_FIELDS_SCHEMA,
+    );
+
+    mockFetch.mockImplementation(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            data: {
+              issueCreate: {
+                success: true,
+                issue: { id: "id", identifier: "ENG-7", url: "u", title: "T" },
+              },
+            },
+          }),
+          { status: 200 },
+        ),
+      ),
+    );
+
+    const builder = builderMod.createLinearApiKeyLazyBuilder();
+    const instance = (await builder({
+      workspaceId: WSID,
+      catalogId: "catalog:linear-apikey",
+      config: encrypted,
+    })) as LinearPluginInstance;
+
+    await instance.createLinearIssue({ title: "Hello" });
+
+    const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect((init.headers as Record<string, string>).Authorization).toBe(
+      "Bearer lin_api_secret_xyz",
+    );
+
+    // Refresh path is not exercised — API-key mode has no refresh.
+    expect(mockRefreshLinearToken).not.toHaveBeenCalled();
+  });
+
+  it("translates 401 into LinearApiKeyRejectedError (rotate-your-key surface)", async () => {
+    const { encryptSecretFields } = await import("@atlas/api/lib/plugins/secrets");
+    const { LINEAR_APIKEY_SECRET_FIELDS_SCHEMA } = await import(
+      "@atlas/api/lib/integrations/install/linear-apikey-secret-schema"
+    );
+    const encrypted = encryptSecretFields(
+      { api_key: "lin_api_revoked_key" },
+      LINEAR_APIKEY_SECRET_FIELDS_SCHEMA,
+    );
+
+    mockFetch.mockImplementation(() =>
+      Promise.resolve(new Response("revoked", { status: 401 })),
+    );
+
+    const builder = builderMod.createLinearApiKeyLazyBuilder();
+    const instance = (await builder({
+      workspaceId: WSID,
+      catalogId: "catalog:linear-apikey",
+      config: encrypted,
+    })) as LinearPluginInstance;
+
+    await expect(instance.createLinearIssue({ title: "x" })).rejects.toBeInstanceOf(
+      builderMod.LinearApiKeyRejectedError,
+    );
+    // Critically: no refresh, no evict — API-key mode just bubbles the
+    // rotation surface to the tool layer.
+    expect(mockRefreshLinearToken).not.toHaveBeenCalled();
+    expect(mockEvict).not.toHaveBeenCalled();
+  });
+
+  it("throws LinearApiKeyMissingError when decrypt yields no api_key", async () => {
+    const builder = builderMod.createLinearApiKeyLazyBuilder();
+    await expect(
+      builder({
+        workspaceId: WSID,
+        catalogId: "catalog:linear-apikey",
+        config: { workspace_name: "Acme but no key" },
+      }),
+    ).rejects.toBeInstanceOf(builderMod.LinearApiKeyMissingError);
+  });
+});

--- a/packages/api/src/lib/integrations/linear/lazy-builder.ts
+++ b/packages/api/src/lib/integrations/linear/lazy-builder.ts
@@ -1,0 +1,544 @@
+/**
+ * Linear LazyPluginLoader builders (#2750).
+ *
+ * Two builders that each produce a {@link LinearPluginInstance}; the
+ * `createLinearIssue` agent tool dispatches through whichever install
+ * is enabled for the active workspace:
+ *
+ *   1. {@link createLinearOAuthLazyBuilder} — reads the access token
+ *      from `integration_credentials` and runs Jira-style refresh +
+ *      retry on 401. Bound to `catalog:linear`.
+ *   2. {@link createLinearApiKeyLazyBuilder} — decrypts the personal
+ *      API key from `workspace_plugins.config` and uses it as the
+ *      bearer directly. No refresh path — a rotated key requires the
+ *      admin to re-submit the install form. Bound to
+ *      `catalog:linear-apikey`.
+ *
+ * Both builders share the {@link runIssueCreate} helper so the GraphQL
+ * mutation lives in one place; refresh / retry semantics differ only
+ * by builder.
+ *
+ * Cache eviction (OAuth path): on permanent refresh failure, `withRetry`
+ * evicts THIS instance from `lazyPluginLoader` before re-throwing
+ * `LinearReconnectRequiredError`. Same wire as Salesforce / Jira —
+ * keeps the agent from cycling through 401 / refresh / fail on every
+ * call.
+ *
+ * @see packages/api/src/lib/plugins/lazy-loader.ts — generic loader
+ * @see ./../install/linear-token-refresh.ts — refresh + reconnect surface
+ * @see ./../jira/lazy-builder.ts — sibling reference implementation
+ */
+
+import { createLogger } from "@atlas/api/lib/logger";
+import { readCredentialBundle } from "@atlas/api/lib/integrations/credentials/store";
+import type { CredentialBundle } from "@atlas/api/lib/integrations/credentials/store";
+import { decryptSecretFields } from "@atlas/api/lib/plugins/secrets";
+import {
+  refreshLinearToken,
+  LinearReconnectRequiredError,
+} from "@atlas/api/lib/integrations/install/linear-token-refresh";
+import {
+  LINEAR_APIKEY_CATALOG_ID,
+  LINEAR_APIKEY_SECRET_FIELDS_SCHEMA,
+} from "@atlas/api/lib/integrations/install/linear-apikey-secret-schema";
+import {
+  lazyPluginLoader,
+  type LazyPluginBuilder,
+  type LazyPluginBuilderArgs,
+} from "@atlas/api/lib/plugins/lazy-loader";
+import type { PluginLike } from "@atlas/api/lib/plugins/registry";
+
+const log = createLogger("integrations.linear.lazy-builder");
+
+const LINEAR_GRAPHQL_URL = "https://api.linear.app/graphql";
+
+// ---------------------------------------------------------------------------
+// Shape returned by `createLinearIssue` — also the tool's result shape.
+// ---------------------------------------------------------------------------
+
+export interface LinearIssueCreateInput {
+  readonly title: string;
+  readonly description?: string;
+  readonly teamId?: string;
+  readonly teamKey?: string;
+  readonly priority?: number;
+  readonly labelIds?: readonly string[];
+}
+
+export interface LinearIssueCreateResult {
+  readonly id: string;
+  readonly identifier: string;
+  readonly url: string;
+  readonly title: string;
+}
+
+/** Public shape exposed by both lazy-built Linear plugin instances. */
+export interface LinearPluginInstance extends PluginLike {
+  createLinearIssue(
+    args: LinearIssueCreateInput,
+    timeoutMs?: number,
+  ): Promise<LinearIssueCreateResult>;
+}
+
+// ---------------------------------------------------------------------------
+// Errors — narrow enough for tool-side branching without string matching.
+// ---------------------------------------------------------------------------
+
+/**
+ * Linear's GraphQL endpoint returned 401, signalling the bearer token
+ * was rejected. The OAuth builder catches this to trigger a refresh +
+ * retry; the API-key builder treats it as a hard "rotate your key"
+ * surface to the agent.
+ */
+class LinearUnauthorizedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "LinearUnauthorizedError";
+  }
+}
+
+function isUnauthorizedError(err: unknown): boolean {
+  return err instanceof LinearUnauthorizedError;
+}
+
+/**
+ * Linear's GraphQL endpoint returned errors that aren't auth-related —
+ * scope mismatch, mutation rejected, validation. Surface the message
+ * to the tool so the agent can decide whether to retry with different
+ * arguments.
+ */
+export class LinearGraphQLError extends Error {
+  readonly _tag = "LinearGraphQLError" as const;
+  readonly upstreamMessage: string;
+  constructor(upstreamMessage: string) {
+    super(`Linear GraphQL rejected the request: ${upstreamMessage}`);
+    this.name = "LinearGraphQLError";
+    this.upstreamMessage = upstreamMessage;
+  }
+}
+
+/**
+ * Linear API-key install row contains a config that doesn't decrypt to
+ * an `api_key` field. Surfaces as a tool error so the admin re-submits
+ * the install form with a fresh key.
+ */
+export class LinearApiKeyMissingError extends Error {
+  readonly _tag = "LinearApiKeyMissingError" as const;
+  readonly workspaceId: string;
+  constructor(workspaceId: string) {
+    super(
+      `Linear API-key install for workspace ${workspaceId} is missing the decrypted api_key field — disconnect + reinstall`,
+    );
+    this.name = "LinearApiKeyMissingError";
+    this.workspaceId = workspaceId;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Shared GraphQL helper — both builders call this.
+// ---------------------------------------------------------------------------
+
+/**
+ * Linear's `issueCreate` mutation. Resolves the team via either
+ * `teamId` (UUID) or `teamKey` (e.g. "ENG"); when neither is provided
+ * the mutation looks up the bearer's default team via the `viewer`'s
+ * first team membership — agent tools should prefer explicit `teamKey`
+ * for predictability.
+ */
+async function runIssueCreate(
+  bearerToken: string,
+  args: LinearIssueCreateInput,
+  timeoutMs: number,
+): Promise<LinearIssueCreateResult> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  // ── Resolve the team if only `teamKey` was supplied ─────────────
+  // Linear's `issueCreate` mutation takes `teamId` (UUID), not key.
+  // For tools that pass `teamKey` (the user-facing identifier — `"ENG"`)
+  // we issue a small lookup first. Skipped when `teamId` is provided.
+  let teamId = args.teamId;
+  if (!teamId && args.teamKey) {
+    teamId = await resolveTeamIdByKey(bearerToken, args.teamKey, controller, timeoutMs);
+  }
+
+  const mutation = `
+    mutation IssueCreate($input: IssueCreateInput!) {
+      issueCreate(input: $input) {
+        success
+        issue { id identifier url title }
+      }
+    }
+  `;
+  const input: Record<string, unknown> = {
+    title: args.title,
+    ...(args.description ? { description: args.description } : {}),
+    ...(teamId ? { teamId } : {}),
+    ...(typeof args.priority === "number" ? { priority: args.priority } : {}),
+    ...(args.labelIds && args.labelIds.length > 0
+      ? { labelIds: Array.from(args.labelIds) }
+      : {}),
+  };
+
+  let resp: Response;
+  try {
+    resp = await fetch(LINEAR_GRAPHQL_URL, {
+      method: "POST",
+      signal: controller.signal,
+      headers: {
+        Authorization: `Bearer ${bearerToken}`,
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: JSON.stringify({ query: mutation, variables: { input } }),
+    });
+  } catch (err) {
+    if (err instanceof Error && err.name === "AbortError") {
+      throw new Error("Linear issueCreate timed out", { cause: err });
+    }
+    throw err;
+  } finally {
+    clearTimeout(timer);
+  }
+
+  if (resp.status === 401) {
+    throw new LinearUnauthorizedError(
+      `Linear API returned 401 — bearer token rejected`,
+    );
+  }
+
+  if (!resp.ok) {
+    let body = "";
+    try {
+      body = (await resp.text()).slice(0, 500);
+    } catch {
+      // best-effort body capture for log forensics
+    }
+    throw new Error(`Linear API returned HTTP ${resp.status}: ${body}`);
+  }
+
+  let parsed: {
+    data?: {
+      issueCreate?: {
+        success?: boolean;
+        issue?: {
+          id?: string;
+          identifier?: string;
+          url?: string;
+          title?: string;
+        };
+      };
+    };
+    errors?: ReadonlyArray<{ message?: string }>;
+  };
+  try {
+    parsed = (await resp.json()) as typeof parsed;
+  } catch (err) {
+    throw new Error(
+      `Linear API response was not valid JSON: ${err instanceof Error ? err.message : String(err)}`,
+      { cause: err },
+    );
+  }
+
+  if (parsed.errors && parsed.errors.length > 0) {
+    const first = parsed.errors[0]?.message ?? "unknown_graphql_error";
+    throw new LinearGraphQLError(first);
+  }
+
+  const issue = parsed.data?.issueCreate?.issue;
+  if (parsed.data?.issueCreate?.success !== true || !issue?.id) {
+    throw new LinearGraphQLError(
+      "issueCreate returned success=false without an issue payload",
+    );
+  }
+
+  return {
+    id: issue.id,
+    identifier: issue.identifier ?? "",
+    url: issue.url ?? "",
+    title: issue.title ?? args.title,
+  };
+}
+
+async function resolveTeamIdByKey(
+  bearerToken: string,
+  teamKey: string,
+  controller: AbortController,
+  timeoutMs: number,
+): Promise<string | undefined> {
+  // Tight inner timeout sized to a fraction of the outer one. If the
+  // lookup hangs we still want enough room for the mutation itself.
+  const innerTimeoutMs = Math.max(2000, Math.floor(timeoutMs / 3));
+  const innerController = new AbortController();
+  const innerTimer = setTimeout(() => innerController.abort(), innerTimeoutMs);
+  try {
+    const resp = await fetch(LINEAR_GRAPHQL_URL, {
+      method: "POST",
+      signal: innerController.signal,
+      headers: {
+        Authorization: `Bearer ${bearerToken}`,
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: JSON.stringify({
+        query: `query TeamByKey($key: String!) { teams(filter: { key: { eq: $key } }) { nodes { id key } } }`,
+        variables: { key: teamKey },
+      }),
+    });
+    if (resp.status === 401) {
+      // Bubble through the same 401-handling path as the mutation.
+      throw new LinearUnauthorizedError(
+        `Linear API returned 401 during teamKey lookup`,
+      );
+    }
+    if (!resp.ok) {
+      // Non-fatal: continue without teamId so issueCreate falls back to
+      // the bearer's default team. Logged so an operator can correlate.
+      log.warn(
+        { teamKey, status: resp.status },
+        "Linear teamKey lookup non-2xx — falling back to default team",
+      );
+      return undefined;
+    }
+    const parsed = (await resp.json()) as {
+      data?: { teams?: { nodes?: Array<{ id?: string; key?: string }> } };
+    };
+    const node = parsed.data?.teams?.nodes?.[0];
+    return typeof node?.id === "string" ? node.id : undefined;
+  } catch (err) {
+    if (err instanceof LinearUnauthorizedError) throw err;
+    log.warn(
+      {
+        teamKey,
+        err: err instanceof Error ? err.message : String(err),
+      },
+      "Linear teamKey lookup threw — falling back to default team",
+    );
+    return undefined;
+  } finally {
+    clearTimeout(innerTimer);
+    // The outer controller is still ticking; clear the inner aborter
+    // without aborting the outer.
+    if (!controller.signal.aborted) {
+      // no-op — kept for symmetry / explicit lifetime tracking
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// OAuth builder — bound to `catalog:linear`
+// ---------------------------------------------------------------------------
+
+export interface LinearOAuthLazyBuilderConfig {
+  readonly clientId: string;
+  readonly clientSecret: string;
+}
+
+function readInstallStatus(config: Record<string, unknown>): string {
+  const status = config.status;
+  return typeof status === "string" ? status : "ok";
+}
+
+export function createLinearOAuthLazyBuilder(
+  config: LinearOAuthLazyBuilderConfig,
+): LazyPluginBuilder {
+  return async (args: LazyPluginBuilderArgs): Promise<LinearPluginInstance> => {
+    const { workspaceId, catalogId } = args;
+    const installConfig = args.config;
+
+    const status = readInstallStatus(installConfig);
+    if (status === "reconnect_needed") {
+      throw new LinearReconnectRequiredError({
+        message: "Linear install needs to be reconnected — workspace_plugins.config.status is reconnect_needed.",
+        workspaceId,
+        upstreamError: "install_marked_reconnect_needed",
+      });
+    }
+
+    let bundle: CredentialBundle | null;
+    try {
+      bundle = await readCredentialBundle(workspaceId, catalogId);
+    } catch (err) {
+      log.error(
+        { workspaceId, err: err instanceof Error ? err.message : String(err) },
+        "Failed to decrypt Linear credentials — refusing to instantiate plugin",
+      );
+      throw err;
+    }
+    if (!bundle) {
+      throw new Error(
+        `LazyPluginLoader: Linear OAuth install row exists but integration_credentials row is missing for workspace ${workspaceId} — disconnect + reinstall`,
+      );
+    }
+
+    let activeAccessToken = bundle.accessToken;
+
+    async function withRetry<T>(fn: (accessToken: string) => Promise<T>): Promise<T> {
+      try {
+        return await fn(activeAccessToken);
+      } catch (err) {
+        if (!isUnauthorizedError(err)) throw err;
+        log.info({ workspaceId }, "Linear session expired — refreshing token");
+        try {
+          const refreshed = await refreshLinearToken({
+            workspaceId,
+            clientId: config.clientId,
+            clientSecret: config.clientSecret,
+          });
+          activeAccessToken = refreshed.accessToken;
+          return await fn(activeAccessToken);
+        } catch (refreshErr) {
+          if (refreshErr instanceof LinearReconnectRequiredError) {
+            // Fire-and-forget evict — see Jira/Salesforce builder for
+            // the rationale. Tagged as void to silence the floating-
+            // promise check.
+            void lazyPluginLoader.evict(workspaceId, catalogId);
+          }
+          throw refreshErr;
+        }
+      }
+    }
+
+    const instance: LinearPluginInstance = {
+      id: `linear:${workspaceId}`,
+      types: ["action"] as const,
+      version: "0.1.0",
+      name: "Linear",
+      config: { scope: bundle.scope, mode: "oauth" },
+
+      async createLinearIssue(
+        input: LinearIssueCreateInput,
+        timeoutMs = 30_000,
+      ): Promise<LinearIssueCreateResult> {
+        return withRetry((accessToken) => runIssueCreate(accessToken, input, timeoutMs));
+      },
+
+      async teardown(): Promise<void> {
+        // fetch-based — no socket pool to release. Mirrors Jira's
+        // builder shape.
+      },
+    };
+
+    log.info(
+      { workspaceId, mode: "oauth", scope: bundle.scope },
+      "Linear OAuth lazy plugin instantiated",
+    );
+    return instance;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// API-key builder — bound to `catalog:linear-apikey`
+// ---------------------------------------------------------------------------
+
+/**
+ * Error class equivalent to {@link LinearReconnectRequiredError} but for
+ * the API-key install mode. Not part of the Effect-tagged-error union
+ * because the API-key install has no refresh flow — the surface is
+ * "rotate your key", not "re-run OAuth". The tool layer catches
+ * `instanceof` and maps to its `apikey_rejected` status.
+ */
+export class LinearApiKeyRejectedError extends Error {
+  readonly _tag = "LinearApiKeyRejectedError" as const;
+  readonly workspaceId: string;
+  constructor(workspaceId: string) {
+    super(
+      `Linear rejected the stored API key for workspace ${workspaceId}. Rotate the key in Linear settings and re-submit the install form.`,
+    );
+    this.name = "LinearApiKeyRejectedError";
+    this.workspaceId = workspaceId;
+  }
+}
+
+/**
+ * Decrypt-failure error — mirror {@link EmailDecryptFailureError} shape
+ * so the tool layer's catch surface is uniform. Tool-internal; lives
+ * here rather than `effect/errors.ts` because the API-key path doesn't
+ * touch the Effect error hierarchy.
+ */
+export class LinearApiKeyDecryptFailureError extends Error {
+  readonly _tag = "LinearApiKeyDecryptFailureError" as const;
+  readonly workspaceId: string;
+  constructor(workspaceId: string, cause: unknown) {
+    const causeMessage = cause instanceof Error ? cause.message : String(cause);
+    super(`Linear API-key install decrypt failed for workspace ${workspaceId}: ${causeMessage}`);
+    this.name = "LinearApiKeyDecryptFailureError";
+    this.workspaceId = workspaceId;
+    if (cause instanceof Error) this.cause = cause;
+  }
+}
+
+function readApiKey(decrypted: Record<string, unknown>): string | null {
+  const v = decrypted.api_key;
+  return typeof v === "string" && v.length > 0 ? v : null;
+}
+
+export function createLinearApiKeyLazyBuilder(): LazyPluginBuilder {
+  return async (args: LazyPluginBuilderArgs): Promise<LinearPluginInstance> => {
+    const { workspaceId } = args;
+    const installConfig = args.config;
+
+    let decrypted: Record<string, unknown>;
+    try {
+      decrypted = decryptSecretFields(installConfig, LINEAR_APIKEY_SECRET_FIELDS_SCHEMA);
+    } catch (err) {
+      log.error(
+        { workspaceId, err: err instanceof Error ? err.message : String(err) },
+        "Failed to decrypt Linear API-key install config — refusing to instantiate plugin",
+      );
+      throw new LinearApiKeyDecryptFailureError(workspaceId, err);
+    }
+
+    const apiKey = readApiKey(decrypted);
+    if (!apiKey) {
+      throw new LinearApiKeyMissingError(workspaceId);
+    }
+
+    const instance: LinearPluginInstance = {
+      id: `linear-apikey:${workspaceId}`,
+      types: ["action"] as const,
+      version: "0.1.0",
+      name: "Linear (API Key)",
+      config: {
+        mode: "apikey",
+        // Surface the workspace_name for log forensics — never the key.
+        workspaceName:
+          typeof decrypted.workspace_name === "string" ? decrypted.workspace_name : null,
+      },
+
+      async createLinearIssue(
+        input: LinearIssueCreateInput,
+        timeoutMs = 30_000,
+      ): Promise<LinearIssueCreateResult> {
+        try {
+          return await runIssueCreate(apiKey, input, timeoutMs);
+        } catch (err) {
+          if (isUnauthorizedError(err)) {
+            // API keys don't refresh — re-throw as a key-rotation surface.
+            throw new LinearApiKeyRejectedError(workspaceId);
+          }
+          throw err;
+        }
+      },
+
+      async teardown(): Promise<void> {
+        // fetch-based — no socket pool to release.
+      },
+    };
+
+    log.info(
+      {
+        workspaceId,
+        mode: "apikey",
+        workspaceName:
+          typeof decrypted.workspace_name === "string" ? decrypted.workspace_name : null,
+      },
+      "Linear API-key lazy plugin instantiated",
+    );
+    return instance;
+  };
+}
+
+/** Catalog ids both builders register against — exported for the tool dispatch. */
+export { LINEAR_APIKEY_CATALOG_ID };
+export { LINEAR_CATALOG_ID } from "@atlas/api/lib/integrations/install/linear-oauth-handler";

--- a/packages/api/src/lib/tools/__tests__/registry.test.ts
+++ b/packages/api/src/lib/tools/__tests__/registry.test.ts
@@ -153,6 +153,7 @@ describe("defaultRegistry", () => {
     const all = defaultRegistry.getAll();
     expect(Object.keys(all).sort()).toEqual([
       "createDashboard",
+      "createLinearIssue",
       "executeSQL",
       "explore",
       "sendEmail",
@@ -203,6 +204,7 @@ describe("buildRegistry", () => {
       const names = Object.keys(registry.getAll()).sort();
       expect(names).toEqual([
         "createDashboard",
+        "createLinearIssue",
         "executePython",
         "executeSQL",
         "explore",
@@ -220,7 +222,13 @@ describe("buildRegistry", () => {
   it("returns core tools by default", async () => {
     const { registry } = await buildRegistry();
     const names = Object.keys(registry.getAll()).sort();
-    expect(names).toEqual(["createDashboard", "executeSQL", "explore", "sendEmail"]);
+    expect(names).toEqual([
+      "createDashboard",
+      "createLinearIssue",
+      "executeSQL",
+      "explore",
+      "sendEmail",
+    ]);
   });
 
   it("with includeActions includes createJiraTicket and sendEmailReport alongside core tools", async () => {
@@ -229,6 +237,7 @@ describe("buildRegistry", () => {
     expect(names).toEqual([
       "createDashboard",
       "createJiraTicket",
+      "createLinearIssue",
       "executeSQL",
       "explore",
       "sendEmail",

--- a/packages/api/src/lib/tools/registry.ts
+++ b/packages/api/src/lib/tools/registry.ts
@@ -4,6 +4,10 @@ import { explore } from "./explore";
 import { executeSQL } from "./sql";
 import { createDashboard } from "./create-dashboard";
 import { sendEmailTool, SEND_EMAIL_DESCRIPTION } from "@atlas/api/lib/integrations/email-tool";
+import {
+  createLinearIssueTool,
+  CREATE_LINEAR_ISSUE_DESCRIPTION,
+} from "@atlas/api/lib/integrations/linear-tool";
 
 export type { AtlasAction };
 export { isAction };
@@ -186,6 +190,17 @@ defaultRegistry.register({
   tool: sendEmailTool,
 });
 
+// #2750 — Linear action target. Registered globally for the same reason
+// as `sendEmail` above: workspace + install check happens at execute
+// time, tool stays discoverable across all Workspaces, and the dual-
+// catalog (`catalog:linear` OAuth + `catalog:linear-apikey` form) dispatch
+// lives inside the tool's execute path.
+defaultRegistry.register({
+  name: "createLinearIssue",
+  description: CREATE_LINEAR_ISSUE_DESCRIPTION,
+  tool: createLinearIssueTool,
+});
+
 defaultRegistry.freeze();
 
 interface BuildRegistryResult {
@@ -230,6 +245,12 @@ export async function buildRegistry(options?: {
     name: "sendEmail",
     description: SEND_EMAIL_DESCRIPTION,
     tool: sendEmailTool,
+  });
+
+  registry.register({
+    name: "createLinearIssue",
+    description: CREATE_LINEAR_ISSUE_DESCRIPTION,
+    tool: createLinearIssueTool,
   });
 
   if (process.env.ATLAS_PYTHON_ENABLED === "true") {


### PR DESCRIPTION
Closes #2750.

## Summary

Third consumer of the lazy-OAuth pattern Salesforce (#2700) and Jira (#2707) established — and first multi-mode integration to ship two catalog rows side by side. Both `linear` (OAuth) and `linear-apikey` (form) land in `/admin/integrations` → Actions section as distinct cards, with `pillar='action'`.

| | This PR (Linear) | #2707 (Jira) | #2700 (Salesforce) |
|---|---|---|---|
| Catalog rows shipped | **2** (linear + linear-apikey) | 1 | 1 |
| Install handlers | 1 OAuth + 1 form | 1 OAuth | 1 OAuth |
| Lazy builders | 2 (one per catalog row) | 1 | 1 |
| Agent tool | `createLinearIssue` (OAuth-first w/ API-key fallback) | `queryJira` | (read-only — no action tool) |
| Migrations | **0** (catalog seeded via atlas.config.ts) | 0 | 1 |
| Files changed | 21 | 13 | 26 |

## What's in the slice

| Component | Linear-specific notes |
|---|---|
| **`linear` catalog row + `linear-apikey` catalog row** | Added to `deploy/api/atlas.config.ts`. CatalogSeeder idempotently upserts at boot per ADR-0002. `type: "integration"` → pillar auto-derives to `"action"` via the 0092 trigger. |
| **`LinearOAuthInstallHandler`** | Token endpoint is `application/x-www-form-urlencoded` (matches Salesforce, not Atlassian's JSON). `actor=user` attribution — issues created by Atlas attribute to the granting workspace admin, not a separate "Atlas Bot" user. Viewer GraphQL second hop persists organization id + name for admin-UI display. INSERT uses the post-0092 explicit `pillar` + `install_id` shape (matches Discord/Telegram). |
| **`linear-token-refresh.ts`** | Refresh tokens rotate on every refresh (like Atlassian). `invalid_grant` / `unauthorized_client` / `access_denied` flip `reconnect_needed`; `invalid_client` stays transient (operator-side env typo should not force every tenant admin to re-OAuth). |
| **`LinearApiKeyFormInstallHandler`** | API-key encrypts inline via `encryptSecretFields` keyed on the catalog's `secret: true` flag — same selective-field pattern as Email/Obsidian/Webhook. SaaS keyset gate refuses to persist plaintext when no encryption keyset is configured. |
| **`linear/lazy-builder.ts`** (two builders) | OAuth builder: 401 → refresh → retry once → evict on permanent failure. API-key builder: 401 → `LinearApiKeyRejectedError` ("rotate your key" surface, no refresh path). Both share `runIssueCreate` so the GraphQL mutation lives in one place. |
| **`createLinearIssue` agent tool** | Tries `catalog:linear` (OAuth) first, falls back to `catalog:linear-apikey` (API-key). Surfaces seven distinct status discriminants (`created` / `no_workspace` / `no_install` / `decrypt_failure` / `misconfigured` / `reconnect_required` / `create_failure`) so the model can self-correct. Mode tag on reconnect_required distinguishes "Reconnect OAuth" vs "Rotate API key" remediations. |
| **`INTEGRATION_CREDENTIALS_SLUGS`** | `"linear"` added (OAuth mode); `"linear-apikey"` intentionally NOT added (form-mode credentials live inline in `workspace_plugins.config`). |
| **`LinearReconnectRequiredError`** | Third consumer of the Salesforce/Jira pattern. Wires into `mapTaggedError` alongside the sibling tags (same 409 + `conflict` envelope). |
| **Docs** | `apps/docs/content/docs/integrations/linear.mdx` (operator + customer-admin walkthroughs for both modes) + meta.json. |

## Acceptance criteria

- [x] `linear` catalog row seeded (OAuth, saas_eligible: true)
- [x] `linear-apikey` catalog row seeded (form, saas_eligible: true at low plan tier)
- [x] Both install models route through `WorkspaceInstaller` — OAuth via `OAuthPlatformInstallHandler`, API-key via `FormBasedInstallHandler` (no new install handler needed)
- [x] UI renders both as distinct cards on `/admin/integrations` Actions section (no toggle) — catalog-card.tsx from #2791 handles this generically
- [x] API key from the form mode encrypts via selective-field (`encryptSecretFields` keyed on `config_schema.api_key.secret: true`)
- [x] OAuth callback writes `integration_credentials` row per ADR-0005; API-key mode writes encrypted `config.api_key` inline
- [x] Disconnect for both modes routes through `WorkspaceInstaller.uninstall` (only OAuth slug in `INTEGRATION_CREDENTIALS_SLUGS` — API-key needs no second store)
- [x] Per-platform docs page at `apps/docs/content/docs/integrations/linear.mdx`
- [x] `bun run type` + isolated test suite + `/ci` gates all green

## Operator setup (OAuth mode only)

API-key mode has no operator-side prerequisites. OAuth mode needs:

| Env var | Required | Notes |
|---|---|---|
| `LINEAR_CLIENT_ID` | yes | Linear OAuth Application's Client ID |
| `LINEAR_CLIENT_SECRET` | yes | Linear OAuth Application's Client Secret |
| `ATLAS_PUBLIC_API_URL` | yes | Used to build the callback URL |

Without `LINEAR_CLIENT_ID` / `LINEAR_CLIENT_SECRET`, the install handler logs `Linear OAuth handler not registered` at boot and `GET /api/v1/integrations/linear/install` returns 501. The `linear-apikey` form-install path remains available either way.

## Test plan

- [x] `bun run lint` — clean
- [x] `bun run type` (full `tsgo --noEmit` + web tsgo) — clean
- [x] `cd packages/api && bun run scripts/test-isolated.ts --affected` — 88/88 pass
- [x] Linear tests in isolation: linear-oauth-handler / linear-token-refresh / linear-apikey-form-handler / linear/lazy-builder / linear-tool / registry — 6/6 pass
- [x] `bun x syncpack lint` — clean
- [x] `bash scripts/check-template-drift.sh` — clean (675 files)
- [x] `bash scripts/check-railway-watch.sh` — clean
- [x] `bash scripts/check-schema-drift.sh` — clean (no migration; mirror unchanged)
- [x] `bash scripts/check-ee-imports.sh` — clean
- [ ] Manual: Linear (OAuth) card connect flow → both stores written (admin → integrations → Linear (OAuth))
- [ ] Manual: Linear (API Key) card paste-key flow → workspace_plugins row with encrypted api_key
- [ ] Manual: agent createLinearIssue with OAuth installed → issue lands in Linear
- [ ] Manual: agent createLinearIssue with only API-key installed → falls back to apikey mode
- [ ] Manual: Disconnect (OAuth) → both rows gone in correct order; Disconnect (API-key) → workspace_plugins row gone

## Follow-ups (out of scope)

- **`IntegrationReconnectRequiredError` extraction.** Three consumers (Salesforce, Jira, Linear) now justify the extraction filed at #2659 review time. Landing as its own thin refactor PR.
- **Legacy `linear_installations` table cleanup.** The pre-unified-pipeline Linear admin route (`/api/v1/admin/integrations/linear`) and the `linear_installations` table from migration 0009 are left in place — they're parallel surfaces that don't conflict with the new pipeline. A follow-up can retire them once the new install model has soak time.
- **Linear-as-Datasource (`linear-data`).** Documented in ADR-0006 but explicitly out of scope here. Future multi-pillar slice.