### PR TITLE
test(ee,api,e2e): #2744 — close the 1.5.3 keystone (post-cutover test sweep)

### DIFF
--- a/e2e/browser/lib/multi-env-helpers.ts
+++ b/e2e/browser/lib/multi-env-helpers.ts
@@ -197,13 +197,11 @@ interface ConnectionRow {
 interface ConnectionsResp { connections?: ConnectionRow[] }
 
 /**
- * Resolve a group by name. Post-#2744 cutover the `connection_groups`
- * table is gone — groups are derived from distinct non-null
- * `groupId` values on the connections list. Since the wire returns
- * `groupName === groupId` (the string IS the name), the synthesized
- * `GroupRow.id` is that same string. The seed provisions `dev`,
- * `staging`, `prod`; any other name is treated as a spec-created
- * throwaway and `null` is a legitimate result.
+ * Resolve a seeded group by name. `groupName === groupId` on the wire
+ * (the string IS the name), so the synthesized `GroupRow.id` is that
+ * string. `primaryConnectionId` is the first matching install — not an
+ * elected primary, since the post-cutover schema has no separate group
+ * row to carry one. Empty / archived-only groups resolve to `null`.
  */
 export async function findGroupByName(
   request: APIRequestContext,

--- a/e2e/browser/lib/multi-env-helpers.ts
+++ b/e2e/browser/lib/multi-env-helpers.ts
@@ -188,20 +188,32 @@ export interface GroupRow {
   primaryConnectionId?: string | null;
   resolvedConnectionId?: string | null;
 }
-interface GroupsResp { groups: GroupRow[] }
+
+interface ConnectionRow {
+  id: string;
+  groupId: string | null;
+  groupName: string | null;
+}
+interface ConnectionsResp { connections?: ConnectionRow[] }
 
 /**
- * Resolve a group id by name. The seed provisions `dev`, `staging`, `prod`;
- * any other name is treated as a spec-created throwaway and `null` is a
- * legitimate result (so the caller can decide between create-or-skip).
+ * Resolve a group by name. Post-#2744 cutover the `connection_groups`
+ * table is gone — groups are derived from distinct non-null
+ * `groupId` values on the connections list. Since the wire returns
+ * `groupName === groupId` (the string IS the name), the synthesized
+ * `GroupRow.id` is that same string. The seed provisions `dev`,
+ * `staging`, `prod`; any other name is treated as a spec-created
+ * throwaway and `null` is a legitimate result.
  */
 export async function findGroupByName(
   request: APIRequestContext,
   name: string,
 ): Promise<GroupRow | null> {
-  const r = await adminGet<GroupsResp>(request, "/api/v1/admin/connection-groups", { query: "includeArchived=true" });
+  const r = await adminGet<ConnectionsResp>(request, "/api/v1/admin/connections");
   if (r.status !== 200 || !r.body) return null;
-  return r.body.groups.find((g) => g.name === name) ?? null;
+  const member = (r.body.connections ?? []).find((c) => c.groupId === name);
+  if (!member) return null;
+  return { id: name, name, status: "active", primaryConnectionId: member.id, resolvedConnectionId: member.id };
 }
 
 /**

--- a/e2e/browser/multi-env-approvals.spec.ts
+++ b/e2e/browser/multi-env-approvals.spec.ts
@@ -67,9 +67,7 @@ test.describe("multi-env approvals — group pointer round-trips through queue r
     const ruleNameDev = `${SYNTH_PREFIX}rule_${stamp}_dev`;
     const ruleNameStaging = `${SYNTH_PREFIX}rule_${stamp}_staging`;
 
-    // Post-#2744 cutover: `connection_groups` is gone. The org owning a
-    // named group is any workspace_plugins row whose `config.group_id`
-    // matches; pick one and pull `workspace_id` off it.
+    // Any install in the group works — they all share workspace_id.
     const orgRow = await withInternalDb(async (c) => {
       const { rows } = await c.query<{ org_id: string }>(
         `SELECT workspace_id AS org_id

--- a/e2e/browser/multi-env-approvals.spec.ts
+++ b/e2e/browser/multi-env-approvals.spec.ts
@@ -67,9 +67,16 @@ test.describe("multi-env approvals — group pointer round-trips through queue r
     const ruleNameDev = `${SYNTH_PREFIX}rule_${stamp}_dev`;
     const ruleNameStaging = `${SYNTH_PREFIX}rule_${stamp}_staging`;
 
+    // Post-#2744 cutover: `connection_groups` is gone. The org owning a
+    // named group is any workspace_plugins row whose `config.group_id`
+    // matches; pick one and pull `workspace_id` off it.
     const orgRow = await withInternalDb(async (c) => {
       const { rows } = await c.query<{ org_id: string }>(
-        `SELECT org_id FROM connection_groups WHERE id = $1 LIMIT 1`,
+        `SELECT workspace_id AS org_id
+           FROM workspace_plugins
+          WHERE config->>'group_id' = $1
+            AND pillar = 'datasource'
+          LIMIT 1`,
         [dev.id],
       );
       return rows[0];

--- a/e2e/browser/multi-env-pii-bleed.spec.ts
+++ b/e2e/browser/multi-env-pii-bleed.spec.ts
@@ -76,11 +76,16 @@ test.describe("multi-env PII — per-group filter does not bleed across groups",
     const tableDev = `${SYNTH_PREFIX}t_${stamp}_dev`;
     const tableStaging = `${SYNTH_PREFIX}t_${stamp}_staging`;
 
-    // Grab the org id off the group row — `connection_groups` carries it,
-    // and we've already resolved both target groups in this org.
+    // Post-#2744 cutover: `connection_groups` is gone. The org owning a
+    // named group is any workspace_plugins row whose `config.group_id`
+    // matches; pull `workspace_id` off one such install.
     const orgRow = await withInternalDb(async (c) => {
       const { rows } = await c.query<{ org_id: string }>(
-        `SELECT org_id FROM connection_groups WHERE id = $1 LIMIT 1`,
+        `SELECT workspace_id AS org_id
+           FROM workspace_plugins
+          WHERE config->>'group_id' = $1
+            AND pillar = 'datasource'
+          LIMIT 1`,
         [dev.id],
       );
       return rows[0];

--- a/e2e/browser/multi-env-pii-bleed.spec.ts
+++ b/e2e/browser/multi-env-pii-bleed.spec.ts
@@ -76,9 +76,7 @@ test.describe("multi-env PII — per-group filter does not bleed across groups",
     const tableDev = `${SYNTH_PREFIX}t_${stamp}_dev`;
     const tableStaging = `${SYNTH_PREFIX}t_${stamp}_staging`;
 
-    // Post-#2744 cutover: `connection_groups` is gone. The org owning a
-    // named group is any workspace_plugins row whose `config.group_id`
-    // matches; pull `workspace_id` off one such install.
+    // Any install in the group works — they all share workspace_id.
     const orgRow = await withInternalDb(async (c) => {
       const { rows } = await c.query<{ org_id: string }>(
         `SELECT workspace_id AS org_id

--- a/e2e/browser/multi-env-semantic-ambiguity.spec.ts
+++ b/e2e/browser/multi-env-semantic-ambiguity.spec.ts
@@ -73,9 +73,16 @@ test.describe("multi-env semantic — 409 ambiguity surface", () => {
     // to assert the 409 surface specifically, planting two rows directly
     // is the most reliable way to set up the ambiguity precondition.
     // The route's read-path 409 contract is then exercised by the GET.
+    // Post-#2744 cutover: `connection_groups` is gone. The org owning a
+    // named group is any workspace_plugins row whose `config.group_id`
+    // matches; pull `workspace_id` off one such install.
     const orgRow = await withInternalDb(async (c) => {
       const { rows } = await c.query<{ org_id: string }>(
-        `SELECT org_id FROM connection_groups WHERE id = $1 LIMIT 1`,
+        `SELECT workspace_id AS org_id
+           FROM workspace_plugins
+          WHERE config->>'group_id' = $1
+            AND pillar = 'datasource'
+          LIMIT 1`,
         [dev.id],
       );
       return rows[0];

--- a/e2e/browser/multi-env-semantic-ambiguity.spec.ts
+++ b/e2e/browser/multi-env-semantic-ambiguity.spec.ts
@@ -73,9 +73,7 @@ test.describe("multi-env semantic — 409 ambiguity surface", () => {
     // to assert the 409 surface specifically, planting two rows directly
     // is the most reliable way to set up the ambiguity precondition.
     // The route's read-path 409 contract is then exercised by the GET.
-    // Post-#2744 cutover: `connection_groups` is gone. The org owning a
-    // named group is any workspace_plugins row whose `config.group_id`
-    // matches; pull `workspace_id` off one such install.
+    // Any install in the group works — they all share workspace_id.
     const orgRow = await withInternalDb(async (c) => {
       const { rows } = await c.query<{ org_id: string }>(
         `SELECT workspace_id AS org_id

--- a/ee/src/governance/approval.test.ts
+++ b/ee/src/governance/approval.test.ts
@@ -602,6 +602,34 @@ describe("createApprovalRequest", () => {
     expect(result.surface).toBeNull();
   });
 
+  it("writes literal NULL when both connectionGroupId and connectionId are absent", async () => {
+    // Third branch in approval.ts: neither explicit group nor inline
+    // resolution available — groupExpression collapses to the SQL
+    // literal `NULL`. Without this test the legacy sentinel-call-site
+    // path could regress to a $8 placeholder mismatch that crashes at
+    // runtime against a real Postgres.
+    ee.queueMockRows([makeQueueRow({ connection_group_id: null, connection_id: null })]);
+    const result = await run(createApprovalRequest({
+      orgId: "org-1",
+      ruleId: "rule-1",
+      ruleName: "Sentinel rule",
+      requesterId: "user-1",
+      requesterEmail: null,
+      querySql: "SELECT * FROM users",
+      explanation: null,
+      connectionId: null,
+      tablesAccessed: ["users"],
+      columnsAccessed: ["id"],
+    }));
+    expect(result.connectionGroupId).toBeNull();
+    const insert = ee.capturedQueries.find((q) => q.sql.includes("INSERT INTO approval_queue"));
+    expect(insert).toBeDefined();
+    expect(insert!.sql).not.toContain("FROM workspace_plugins");
+    // Param at position 7 (groupParam) is null — verifies the slot isn't
+    // accidentally bound to a string when groupExpression is the literal.
+    expect(insert!.params[7]).toBeNull();
+  });
+
   it("#2072: rejects a surface value that isn't in the request enum (typo)", async () => {
     try {
       await run(createApprovalRequest({
@@ -996,6 +1024,11 @@ describe("createApprovalRequest — group-scoped (#2344)", () => {
     expect(insert!.sql).toContain("FROM workspace_plugins");
     expect(insert!.sql).toContain("pillar = 'datasource'");
     expect(insert!.params).toContain("conn-us");
+    // Overlay branches are both load-bearing: the workspace's own row
+    // wins over `__global__`, and the LIMIT 1 collapses any tie.
+    // Dropping either turns demo-install resolution flaky.
+    expect(insert!.sql).toContain("'__global__'");
+    expect(insert!.sql).toContain("LIMIT 1");
   });
 });
 

--- a/ee/src/governance/approval.test.ts
+++ b/ee/src/governance/approval.test.ts
@@ -534,16 +534,16 @@ describe("checkApprovalRequired", () => {
 
 // ── Queue Management Tests ──────────────────────────────────────────
 
-// TODO(#2744 step 5 — test sweep): mock queue assumes the pre-cutover
-// mirror-global-connection-group SQL sequence + the `FROM connections`
-// inline group resolution. Both shapes were rewritten in step 5 to
-// pivot to `workspace_plugins (pillar='datasource')`. Rewrite the
-// mock fixtures to match the new query shape — tracked in #2786.
-describe.skip("createApprovalRequest", () => {
+// Post-#2744 (0096 cutover): `createApprovalRequest` is a single
+// INSERT with the group_id resolved inline via a scalar subquery
+// against `workspace_plugins (pillar='datasource')`. No SELECT-then-
+// INSERT race, no tenant-mirror step — fixtures queue one batch (the
+// RETURNING row).
+describe("createApprovalRequest", () => {
   beforeEach(resetMocks);
 
   it("creates an approval request", async () => {
-    ee.queueMockRows([], [makeQueueRow()]);
+    ee.queueMockRows([makeQueueRow()]);
     const result = await run(createApprovalRequest({
       orgId: "org-1",
       ruleId: "rule-1",
@@ -563,7 +563,7 @@ describe.skip("createApprovalRequest", () => {
   });
 
   it("#2072: stamps surface on the queued row when caller provides it", async () => {
-    ee.queueMockRows([], [makeQueueRow({ surface: "mcp" })]);
+    ee.queueMockRows([makeQueueRow({ surface: "mcp" })]);
     const result = await run(createApprovalRequest({
       orgId: "org-1",
       ruleId: "rule-1",
@@ -586,7 +586,7 @@ describe.skip("createApprovalRequest", () => {
   });
 
   it("#2072: stores surface as null when the caller does not provide it (legacy shape)", async () => {
-    ee.queueMockRows([], [makeQueueRow({ surface: null })]);
+    ee.queueMockRows([makeQueueRow({ surface: null })]);
     const result = await run(createApprovalRequest({
       orgId: "org-1",
       ruleId: "rule-1",
@@ -942,19 +942,15 @@ describe("hasApprovedRequest — group-scoped (#2344)", () => {
 // #2344 — group-scoped createApprovalRequest. The approval row carries
 // `connection_group_id` so the lookup above can filter on it. The
 // caller may pass it explicitly (preferred — sql.ts has the connection
-// in hand), and the service resolves it inline via the connections
-// 1:1 group map when omitted, mirroring `inlineConnectionGroupSql` in
-// `semantic/entities.ts`.
-//
-// TODO(#2744 step 5 — test sweep): post-cutover the inline group
-// resolution reads from `workspace_plugins.config->>'group_id'`, not
-// the dropped `connections.group_id`. Mock fixtures need the new
-// query shape — tracked in #2786.
-describe.skip("createApprovalRequest — group-scoped (#2344)", () => {
+// in hand), and the service resolves it inline via a scalar subquery
+// against `workspace_plugins.config->>'group_id'` when omitted (post-
+// #2744 cutover; mirrors `inlineConnectionGroupSql` in
+// `semantic/entities.ts`).
+describe("createApprovalRequest — group-scoped (#2344)", () => {
   beforeEach(resetMocks);
 
   it("stamps connection_group_id on the queued row when caller passes one", async () => {
-    ee.queueMockRows([], [], [makeQueueRow({ connection_group_id: "g-prod" })]);
+    ee.queueMockRows([makeQueueRow({ connection_group_id: "g-prod" })]);
     const result = await run(createApprovalRequest({
       orgId: "org-1",
       ruleId: "rule-1",
@@ -979,7 +975,7 @@ describe.skip("createApprovalRequest — group-scoped (#2344)", () => {
     // Mirrors the inline scalar-subquery shape used by
     // `inlineConnectionGroupSql`. The returned queue row carries the
     // group resolved by the subquery rather than the caller passing it.
-    ee.queueMockRows([], [makeQueueRow({ connection_group_id: "g-prod", connection_id: "conn-us" })]);
+    ee.queueMockRows([makeQueueRow({ connection_group_id: "g-prod", connection_id: "conn-us" })]);
     const result = await run(createApprovalRequest({
       orgId: "org-1",
       ruleId: "rule-1",
@@ -995,9 +991,11 @@ describe.skip("createApprovalRequest — group-scoped (#2344)", () => {
     expect(result.connectionGroupId).toBe("g-prod");
     const insert = ee.capturedQueries.find((q) => q.sql.includes("INSERT INTO approval_queue"));
     expect(insert).toBeDefined();
-    // Inline subquery against connections — the SQL contains both the
-    // connection_id parameter and the inline group lookup.
-    expect(insert!.sql).toContain("FROM connections");
+    // Post-#2744 cutover: inline scalar subquery against workspace_plugins
+    // (pillar='datasource'), keyed on install_id = $8 (= connection_id).
+    expect(insert!.sql).toContain("FROM workspace_plugins");
+    expect(insert!.sql).toContain("pillar = 'datasource'");
+    expect(insert!.params).toContain("conn-us");
   });
 });
 

--- a/packages/api/src/api/__tests__/admin.test.ts
+++ b/packages/api/src/api/__tests__/admin.test.ts
@@ -848,11 +848,8 @@ describe("GET /api/v1/admin/overview", () => {
     // count them, not just per-org rows. Dropping the UNION branch would
     // silently report `connections: 0` for every onboarded workspace.
     setOrgScopedAdmin("org-test-1");
-    // #2744 — admin overview / billing counter both pivot to
-    // workspace_plugins; either name pattern matches for back-compat
-    // until step 5 rewrites this mock setup fully.
     mockInternalQuery.mockImplementation(async (sql: string) => {
-      if (sql.includes("FROM workspace_plugins") || sql.includes("FROM connections")) {
+      if (sql.includes("FROM workspace_plugins")) {
         return [{ id: "__demo__", install_id: "__demo__" }];
       }
       return [];

--- a/packages/api/src/api/__tests__/onboarding.test.ts
+++ b/packages/api/src/api/__tests__/onboarding.test.ts
@@ -1022,7 +1022,7 @@ describe("POST /api/v1/onboarding/use-demo", () => {
     // Reproduces the dharma symptom — connection had been committed BEFORE
     // the import attempt, so a failed import left a half-state. Phase order
     // is now: import first, connection last. A throwing import must mean
-    // zero `INSERT INTO connections` calls.
+    // zero `INSERT INTO workspace_plugins` calls (post-#2744 cutover).
     mockImportFromDisk.mockImplementation(async () => {
       throw new Error("simulated disk failure");
     });

--- a/packages/api/src/api/__tests__/onboarding.test.ts
+++ b/packages/api/src/api/__tests__/onboarding.test.ts
@@ -1022,7 +1022,7 @@ describe("POST /api/v1/onboarding/use-demo", () => {
     // Reproduces the dharma symptom — connection had been committed BEFORE
     // the import attempt, so a failed import left a half-state. Phase order
     // is now: import first, connection last. A throwing import must mean
-    // zero `INSERT INTO workspace_plugins` calls (post-#2744 cutover).
+    // zero `INSERT INTO workspace_plugins` calls.
     mockImportFromDisk.mockImplementation(async () => {
       throw new Error("simulated disk failure");
     });


### PR DESCRIPTION
## Summary

Closes the 1.5.3 keystone (#2744 / [ADR-0007](docs/adr/0007-unified-install-pipeline.md)). The schema drop (0096 + 0097 hotfix), `ConnectionRegistry` + admin-route pivot, lib sweep, and CI grep gate (`scripts/check-no-legacy-connections-sql.sh`) all landed via #2784/#2788/#2792/#2803. This PR clears the last test-side residue.

- **`ee/src/governance/approval.test.ts`** — un-skip both `createApprovalRequest` describes (basic + #2344 group-scoped). Mock fixtures now match the single-INSERT shape with inline scalar-subquery against `workspace_plugins (pillar='datasource')`; the `FROM connections` assertion flips to `FROM workspace_plugins` + checks `pillar = 'datasource'` and the install_id param wiring.
- **`e2e/browser/multi-env-{approvals,pii-bleed,semantic-ambiguity}.spec.ts`** — resolve `org_id` off `workspace_plugins.config->>'group_id'` instead of the dropped `connection_groups` table.
- **`e2e/browser/lib/multi-env-helpers.ts`** — `findGroupByName` derives groups from `/api/v1/admin/connections` (since `/api/v1/admin/connection-groups` is gone), mirroring the inline derivation the admin page already does.
- **`packages/api/src/api/__tests__/admin.test.ts`** — drop the legacy `FROM connections` half of the mock callback fork.
- **`packages/api/src/api/__tests__/onboarding.test.ts`** — comment-only refresh.

The 1.5.3 milestone stays open per the locked decision — slice 17 closeout (#2755) and the remaining Phase D chat platforms (#2751/#2752/#2753/#2754) are out of scope here.

## Test plan

- [x] `bun run lint` clean
- [x] `bun run type` clean
- [x] `bun run test` — 459/464 files pass; the 5 failures (`admin-action-retention-audit`, `admin-approval-audit`, `admin-scim`, `discord`, `teams`) all pass in isolation and are pre-existing parallel-load flakies in scope of 1.5.4 (#2776, #2710, plus 3 admin siblings) — none touch the changeset
- [x] `scripts/check-no-legacy-connections-sql.sh` — green
- [x] Syncpack, template-drift, schema-drift, oauth-helper-drift, security-headers-drift, railway-watch — green
- [x] EE approval tests: 74/74 pass in isolation (was 67/74 with 7 skipped pre-PR)
- [ ] Dogfood verification per the original AC step 9 (manual)