### PR TITLE
feat(api,docs): #2751 — GitHub install (PAT mode); App modes seeded as coming_soon

### DIFF
--- a/apps/docs/content/docs/integrations/github.mdx
+++ b/apps/docs/content/docs/integrations/github.mdx
@@ -1,0 +1,203 @@
+---
+title: GitHub
+description: Create GitHub issues and open pull requests from Atlas agent findings. Three install modes — GitHub App multi-tenant (SaaS recommended), App single-tenant (self-host), and Personal Access Token (self-host).
+---
+
+import { Callout } from "fumadocs-ui/components/callout";
+
+Atlas's GitHub integration is an **Action Target**: Atlas creates GitHub
+issues and opens pull requests from agent findings (e.g. "file a GitHub
+issue for every failing test in the dashboard"). It is NOT a chat
+platform — users don't talk to Atlas through GitHub.
+
+GitHub ships with **three install modes**, surfaced as distinct cards in
+**Admin → Integrations → Actions**. Workspace admins pick the mode that
+fits their deploy posture and access model:
+
+- **GitHub (App)** — multi-tenant GitHub App, OAuth-flavored install.
+  The operator registers a GitHub App once; each workspace admin
+  installs that App against their own GitHub organization. Installation
+  tokens mint on demand by signing a JWT with the App's private key.
+  **The primary SaaS-eligible mode.**
+- **GitHub (App, single-tenant)** — same wire shape, but the App is
+  pinned to one GitHub organization (the operator's). Use when you
+  don't want to publish a multi-tenant App registration. **Self-host
+  only.**
+- **GitHub (Personal Access Token)** — workspace admin pastes a PAT
+  from their own GitHub settings. The simplest install — no App
+  registration required — but the token is tied to one GitHub user
+  and dies if that user leaves the org or rotates the token.
+  **Self-host only.**
+
+<Callout type="info" title="Which mode should I use?">
+  **GitHub App (multi-tenant)** is the recommended path for any deploy
+  expecting more than a handful of workspaces and the only mode SaaS
+  customers see. **App (single-tenant)** is the right choice for
+  self-host operators serving one GitHub org who don't want to maintain
+  a public App registration. **PAT** is the quickest install for
+  self-host evaluation and one-off integrations where the failure mode
+  (token tied to one user) is acceptable.
+</Callout>
+
+<Callout type="warn" title="GitHub App modes are not yet implemented">
+  Both **GitHub (App)** and **GitHub (App, single-tenant)** ship with
+  `implementation_status: "coming_soon"` in the catalog. The cards
+  render in **Admin → Integrations** as inert "Coming soon" badges
+  until the App install handler lands in a follow-up PR (JWT minting
+  for installation tokens is its own slice). Until then, **GitHub
+  (Personal Access Token)** is the only working install mode — and it's
+  self-host only.
+</Callout>
+
+## Mode 1 — GitHub App, multi-tenant (`github` catalog row) <span data-coming-soon>Coming soon</span>
+
+The multi-tenant GitHub App ships in a follow-up PR. This section
+documents the planned shape for operator setup so self-host deploys can
+prepare environment values now.
+
+### Operator setup (one-time, per deploy)
+
+Self-hosted operators run these steps once during initial deployment;
+Atlas Cloud customers don't — the Atlas Cloud team will have already
+done this on the hosted regions.
+
+#### 1. Register a GitHub App
+
+In [GitHub Developer Settings → GitHub Apps → New GitHub App](https://github.com/settings/apps/new),
+create a new App:
+
+- **GitHub App name**: "Atlas" (or whatever brand makes sense for your
+  deploy)
+- **Homepage URL**: your Atlas marketing URL or `https://useatlas.dev`
+- **Callback URL**: `${ATLAS_PUBLIC_API_URL}/api/v1/integrations/github/callback`
+- **Request user authorization (OAuth) during installation**: enable
+- **Webhook → Active**: disable (Atlas does not need webhook events for
+  Action-target use cases)
+- **Repository permissions**: `Issues: Read & write`, `Pull requests:
+  Read & write`, `Contents: Read & write`
+- **Where can this GitHub App be installed?**: **Any account** (this is
+  the multi-tenant setting)
+
+After creation:
+- Note the **App ID** shown on the App settings page
+- Generate a **Private key** (`.pem` file). Treat as a credential —
+  anyone with it can act as your App
+- Note the **App slug** from the App's public URL
+  (`https://github.com/apps/<your-app-slug>`)
+
+#### 2. Set the env vars
+
+Set all three on every Atlas API service in your deploy:
+
+```bash
+GITHUB_APP_ID=<App ID from step 1>
+GITHUB_APP_SLUG=<App slug from step 1>
+GITHUB_APP_PRIVATE_KEY=<contents of the downloaded .pem file>
+```
+
+`ATLAS_PUBLIC_API_URL` must already be set on the same services — it's
+required by every OAuth-based integration to build the callback URL.
+
+## Mode 2 — GitHub App, single-tenant (`github-single-tenant` catalog row) <span data-coming-soon>Coming soon</span>
+
+Wire shape is identical to Mode 1; the only difference is the GitHub App
+registration's **Where can this GitHub App be installed?** setting is
+**Only on this account**. Use when you don't want to publish a
+multi-tenant registration. **`saas_eligible: false`** — one org's App
+installation cannot serve multiple Atlas workspaces, so this row is
+hidden from the SaaS catalog.
+
+## Mode 3 — Personal Access Token (`github-pat` catalog row)
+
+**Self-host only.** The catalog row carries `saas_eligible: false`
+because a PAT is tied to one GitHub user — when that user leaves the
+org or rotates the token, Atlas's access dies with no automatic
+recovery. The failure mode is too sharp for hosted SaaS.
+
+### Customer install (per workspace, no operator setup)
+
+The PAT install has no operator-side prerequisites — any self-hosted
+Atlas deploy supports it. Workspace admins install it from **Admin →
+Integrations → GitHub (Personal Access Token)**.
+
+1. In GitHub, open [Settings → Developer settings → Personal access tokens](https://github.com/settings/tokens).
+   Either format works:
+   - **Fine-grained tokens** (recommended) — choose **Generate new token**,
+     set an expiration, restrict to specific repositories if desired,
+     and grant **Issues: Read and write** + **Pull requests: Read and
+     write** + **Contents: Read and write**.
+   - **Classic tokens** — choose **Generate new token (classic)** and
+     select the `repo` scope.
+
+   Copy the value — it's shown once.
+
+2. Back in Atlas, click **Install** on the GitHub (Personal Access Token)
+   card and paste the token into the **GitHub Personal Access Token**
+   field. Optionally add a **Default owner** (your GitHub username or
+   organization name) so the agent doesn't have to specify one on every
+   call.
+
+3. Click **Save**. Atlas encrypts the token at rest (selective-field
+   encryption per ADR-0007) and the card flips to **Installed**.
+
+<Callout type="warn" title="PATs are tied to a single GitHub user">
+  A Personal Access Token carries the same access as the GitHub user
+  who generated it — if that user is removed from the organization or
+  the token is revoked, Atlas's access dies and agent calls fail with
+  `pat_rejected`. Rotate by generating a new token in GitHub settings
+  and re-submitting the install form.
+</Callout>
+
+### Disconnecting (PAT mode)
+
+Open **Admin → Integrations → GitHub (Personal Access Token)** and
+click **Disconnect**. Atlas deletes the `workspace_plugins` row
+containing the encrypted token — there's no separate credential store
+to clean up in this mode.
+
+You can also revoke the token from GitHub's side: open
+[Settings → Developer settings → Personal access tokens](https://github.com/settings/tokens)
+and delete the entry. Atlas's next GitHub call will return
+`reconnect_required` and surface "rotate your token" copy to the agent
+and admin.
+
+## SaaS vs self-host visibility
+
+Atlas Cloud (`saas_eligible` deploys) only surfaces the GitHub App
+(multi-tenant) card. The two `saas_eligible: false` rows are hidden:
+
+| Catalog row | `saas_eligible` | Visible on SaaS | Visible on self-host |
+| :---------- | :-------------- | :-------------- | :------------------- |
+| `github` | true | yes | yes |
+| `github-single-tenant` | false | **no** | yes |
+| `github-pat` | false | **no** | yes |
+
+The filter lives in [`PillarCatalogQuery`](https://github.com/AtlasDevHQ/atlas/blob/main/packages/api/src/lib/effect/pillar-catalog-query.ts) —
+generic across every catalog row, not GitHub-specific. Operators who
+need to override the gate (e.g. an enterprise self-host deploy that
+wants to expose all three modes) can flip `ATLAS_DEPLOY_MODE` away from
+`saas` at the deploy level.
+
+## Troubleshooting
+
+### "GitHub install needs to be set up first" (any mode)
+
+No GitHub catalog row is installed for the workspace. Open **Admin →
+Integrations** and pick the install mode that fits your deploy.
+
+### "GitHub rejected the stored PAT" (PAT mode)
+
+The Personal Access Token was revoked, its owning user was removed from
+the organization, or the token expired. Generate a fresh token in
+[GitHub settings → Personal access tokens](https://github.com/settings/tokens)
+and re-submit the install form via **Admin → Integrations → GitHub
+(Personal Access Token)**.
+
+### "GitHub App install handler not registered"
+
+The operator hasn't set `GITHUB_APP_ID`, `GITHUB_APP_SLUG`, and
+`GITHUB_APP_PRIVATE_KEY`, or one is empty on the API process handling
+the install. The App-based install handler ships in a follow-up PR;
+until then, the install routes for `github` and `github-single-tenant`
+return 501. The PAT mode (`github-pat`) does not depend on these env
+vars and is always available on self-host deploys.

--- a/apps/docs/content/docs/integrations/meta.json
+++ b/apps/docs/content/docs/integrations/meta.json
@@ -8,6 +8,7 @@
     "telegram",
     "discord",
     "linear",
+    "github",
     "sub-processor-feed"
   ]
 }

--- a/deploy/api/atlas.config.ts
+++ b/deploy/api/atlas.config.ts
@@ -278,6 +278,88 @@ export default defineConfig({
         },
       ],
     },
+    // ── GitHub (1.5.3 #2751 — Phase D, Action Target) ──────────────
+    // Three catalog rows, one per install mode (per CONTEXT.md
+    // "Multi-mode integrations"). All rows are pillar='action' — Atlas
+    // creates issues / opens PRs through GitHub; this is NOT a chat
+    // platform. A future `github-data` row for GitHub-as-Datasource is
+    // documented in ADR-0006 but out of scope for this milestone.
+    //
+    //   - `github` (App, multi-tenant OAuth): workspace admins grant a
+    //     GitHub App per Atlas Workspace. Installation tokens are minted
+    //     on demand by signing a JWT with the App's private key. The
+    //     primary SaaS-eligible mode. Currently `coming_soon` — handler
+    //     ships in a follow-up PR (JWT minting + installation-token
+    //     lifecycle is its own slice).
+    //   - `github-single-tenant` (App, single-tenant): identical wire
+    //     shape to multi-tenant, but the App's install is pinned to one
+    //     GitHub org (the operator's). `saas_eligible: false` because
+    //     one org's install cannot serve multiple Atlas workspaces.
+    //     Also `coming_soon` — same follow-up PR.
+    //   - `github-pat` (form): workspace admin pastes a Personal Access
+    //     Token from https://github.com/settings/tokens. The token
+    //     encrypts inline into `workspace_plugins.config.pat` via
+    //     selective-field encryption. `saas_eligible: false` — a PAT is
+    //     tied to one GitHub user and dies when they leave; acceptable
+    //     for self-host but the failure mode is too sharp for SaaS.
+    //
+    // SaaS visibility: the catalog route filters out
+    // `saas_eligible: false` rows on SaaS deploys, so only `github`
+    // surfaces in the SaaS catalog. Self-host shows all three.
+    {
+      slug: "github",
+      type: "integration",
+      install_model: "oauth",
+      enabled: true,
+      saas_eligible: true,
+      implementation_status: "coming_soon",
+      name: "GitHub (App)",
+      description:
+        "Create GitHub issues and open pull requests from agent findings. Connects through your operator's GitHub App and mints short-lived installation tokens automatically.",
+      min_plan: "starter",
+    },
+    {
+      slug: "github-single-tenant",
+      type: "integration",
+      install_model: "oauth",
+      enabled: true,
+      saas_eligible: false,
+      implementation_status: "coming_soon",
+      name: "GitHub (App, single-tenant)",
+      description:
+        "Self-host only. Operator-baked GitHub App pinned to one GitHub organization. Use when you don't want to publish a multi-tenant App registration.",
+      min_plan: "starter",
+    },
+    {
+      slug: "github-pat",
+      type: "integration",
+      install_model: "form",
+      enabled: true,
+      saas_eligible: false,
+      name: "GitHub (Personal Access Token)",
+      description:
+        "Self-host only. The simplest install — no GitHub App registration required — but the token is tied to one GitHub user. Atlas access dies if that user leaves the org or the token is revoked.",
+      min_plan: "starter",
+      configSchema: [
+        {
+          key: "pat",
+          type: "string",
+          label: "GitHub Personal Access Token",
+          description:
+            "Generate one at https://github.com/settings/tokens. Fine-grained tokens are recommended; classic tokens also work. Scope: `repo` (issues + pull requests). Stored encrypted at rest.",
+          required: true,
+          secret: true,
+        },
+        {
+          key: "default_owner",
+          type: "string",
+          label: "Default owner (optional)",
+          description:
+            "GitHub user or organization Atlas defaults to when creating issues. Can be overridden per call. Leave blank to require the agent to specify each time.",
+          required: false,
+        },
+      ],
+    },
     // ── Lazy OAuth integrations (1.5.2 slice 8 — #2658 / #2659) ─────
     // Salesforce (#2658) established the pattern; Jira (#2659) proves
     // the abstraction by riding the same shared infra:

--- a/packages/api/src/lib/integrations/install/__tests__/github-pat-form-handler.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/github-pat-form-handler.test.ts
@@ -181,6 +181,62 @@ describe("GitHubPatFormInstallHandler.validateConfig — happy path", () => {
 });
 
 // ---------------------------------------------------------------------------
+// RETURNING-id invariant — fail loud when Postgres returns no row
+// ---------------------------------------------------------------------------
+
+describe("GitHubPatFormInstallHandler.validateConfig — RETURNING invariant", () => {
+  it("throws when the upsert returns no row (driver/RLS/rewrite anomaly)", async () => {
+    // INSERT ... ON CONFLICT ... DO UPDATE RETURNING is guaranteed by
+    // Postgres to emit one row. If the mock returns []  (simulating a
+    // structural anomaly), the handler must surface a 500 rather than
+    // silently fall back to candidateId — falling back would return a
+    // WRONG id on the DO UPDATE path and corrupt downstream lookups.
+    mockInternalQuery.mockImplementation(async () => []);
+    const handler = new GitHubPatFormInstallHandler();
+    await expect(handler.validateConfig(WSID, validForm())).rejects.toThrow(
+      /upsert returned no id/,
+    );
+  });
+
+  it("throws when the returned id is an empty string", async () => {
+    mockInternalQuery.mockImplementation(async () => [{ id: "" }]);
+    const handler = new GitHubPatFormInstallHandler();
+    await expect(handler.validateConfig(WSID, validForm())).rejects.toThrow(
+      /upsert returned no id/,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Lazy-loader evict — fire-and-forget posture survives evict failures
+// ---------------------------------------------------------------------------
+
+describe("GitHubPatFormInstallHandler.validateConfig — evict resilience", () => {
+  it("returns credentialWritten: true even when lazy-loader evict throws", async () => {
+    // The DB row is the authoritative install record; an evict failure
+    // on a likely-empty cache must NOT roll back a successful credential
+    // write. A future refactor that moves the evict before the INSERT
+    // or removes the catch wrapper would break this contract.
+    const { lazyPluginLoader } = await import("@atlas/api/lib/plugins/lazy-loader");
+    const originalEvict = lazyPluginLoader.evict.bind(lazyPluginLoader);
+    const evictSpy = mock(async () => {
+      throw new Error("simulated cache layer failure");
+    });
+    (lazyPluginLoader as unknown as { evict: typeof evictSpy }).evict = evictSpy;
+    try {
+      const handler = new GitHubPatFormInstallHandler();
+      const result = await handler.validateConfig(WSID, validForm());
+      expect(result.credentialWritten).toBe(true);
+      expect(evictSpy).toHaveBeenCalledTimes(1);
+      // The INSERT still ran — the credential is persisted regardless.
+      expect(mockInternalQuery).toHaveBeenCalledTimes(1);
+    } finally {
+      (lazyPluginLoader as unknown as { evict: typeof originalEvict }).evict = originalEvict;
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
 // SaaS keyset gate — defense in depth even though catalog hides this row
 // ---------------------------------------------------------------------------
 

--- a/packages/api/src/lib/integrations/install/__tests__/github-pat-form-handler.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/github-pat-form-handler.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Tests for {@link GitHubPatFormInstallHandler} (#2751, Phase D PAT mode).
+ *
+ * Mirrors {@link ./linear-apikey-form-handler.test.ts}; GitHub-PAT-specific
+ * pins:
+ *
+ *   - Only the `pat` field is `secret: true` and round-trips through
+ *     `encryptSecretFields`; `default_owner` stays plaintext.
+ *   - INSERT uses the post-0092 explicit `pillar='action'` + `install_id`
+ *     shape with the partial unique index conflict target.
+ *   - SaaS keyset gate fails closed even though the catalog row carries
+ *     `saas_eligible: false` (defense in depth — if the integrations-
+ *     catalog filter is ever bypassed, the handler still refuses to
+ *     persist plaintext).
+ *   - Validation pins the owner-name regex (alphanumeric + hyphens,
+ *     leading alphanumeric) so a typo like a leading hyphen surfaces
+ *     before the upstream GitHub call.
+ */
+
+import { afterEach, beforeAll, beforeEach, describe, expect, it, mock, type Mock } from "bun:test";
+import { _resetEncryptionKeyCache } from "@atlas/api/lib/db/encryption-keys";
+import { decryptSecret } from "@atlas/api/lib/db/secret-encryption";
+import type { WorkspaceId } from "@useatlas/types";
+
+const mockInternalQuery: Mock<(sql: string, params?: unknown[]) => Promise<unknown[]>> = mock(
+  async (sql: string, params?: unknown[]) => {
+    if (sql.includes("RETURNING id")) {
+      const id = (params?.[0] as string | undefined) ?? "unknown";
+      return [{ id }];
+    }
+    return [];
+  },
+);
+
+mock.module("@atlas/api/lib/db/internal", () => ({
+  internalQuery: mockInternalQuery,
+  hasInternalDB: mock(() => true),
+  getInternalDB: mock(() => ({ query: mock(() => Promise.resolve({ rows: [] })) })),
+}));
+
+const WSID = "ws-github-pat-1" as WorkspaceId;
+
+type HandlerCtor = typeof import("../github-pat-form-handler").GitHubPatFormInstallHandler;
+type ValidationErrCtor = typeof import("../github-pat-form-handler").FormInstallValidationError;
+let GitHubPatFormInstallHandler!: HandlerCtor;
+let FormInstallValidationError!: ValidationErrCtor;
+
+beforeAll(async () => {
+  const mod = await import("../github-pat-form-handler");
+  GitHubPatFormInstallHandler = mod.GitHubPatFormInstallHandler;
+  FormInstallValidationError = mod.FormInstallValidationError;
+});
+
+const ORIGINAL_ENV = { ...process.env };
+
+function setKeys(value: string): void {
+  process.env.ATLAS_ENCRYPTION_KEYS = value;
+  delete process.env.ATLAS_ENCRYPTION_KEY;
+  delete process.env.BETTER_AUTH_SECRET;
+  _resetEncryptionKeyCache();
+}
+
+function validForm(overrides: Partial<Record<string, unknown>> = {}): Record<string, unknown> {
+  return {
+    pat: "ghp_testtokenabcdefghijklmnopqrstuvwxyz1234",
+    default_owner: "acme-corp",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  setKeys("v1:test-key-for-github-pat-handler-unit-tests-must-be-long-enough");
+  mockInternalQuery.mockClear();
+  mockInternalQuery.mockImplementation(async (sql: string, params?: unknown[]) => {
+    if (sql.includes("RETURNING id")) {
+      const id = (params?.[0] as string | undefined) ?? "unknown";
+      return [{ id }];
+    }
+    return [];
+  });
+});
+
+afterEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+  _resetEncryptionKeyCache();
+});
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+describe("GitHubPatFormInstallHandler.validateConfig — input validation", () => {
+  it("rejects missing pat with FormInstallValidationError", async () => {
+    const handler = new GitHubPatFormInstallHandler();
+    let caught: unknown;
+    try {
+      await handler.validateConfig(WSID, { default_owner: "acme-corp" });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(FormInstallValidationError);
+    const errs = (caught as InstanceType<typeof FormInstallValidationError>).fieldErrors;
+    expect(errs.pat).toBeDefined();
+    expect(mockInternalQuery).not.toHaveBeenCalled();
+  });
+
+  it("rejects pat with characters GitHub never uses (whitespace / punctuation)", async () => {
+    const handler = new GitHubPatFormInstallHandler();
+    await expect(
+      handler.validateConfig(WSID, validForm({ pat: "has spaces and !" })),
+    ).rejects.toBeInstanceOf(FormInstallValidationError);
+    expect(mockInternalQuery).not.toHaveBeenCalled();
+  });
+
+  it("accepts both classic (ghp_) and fine-grained (github_pat_) token shapes", async () => {
+    const handler = new GitHubPatFormInstallHandler();
+    // Classic
+    await handler.validateConfig(WSID, validForm({ pat: "ghp_classic40charsABCDEFGHIJKLMNOPQRSTUV" }));
+    // Fine-grained — long string of underscore + alphanum after the prefix
+    await handler.validateConfig(WSID, validForm({ pat: "github_pat_abc_DEF_123_xyz_789_long_enough" }));
+    expect(mockInternalQuery).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects default_owner with a leading hyphen (GitHub owner-name rule)", async () => {
+    const handler = new GitHubPatFormInstallHandler();
+    await expect(
+      handler.validateConfig(WSID, validForm({ default_owner: "-bad-leading" })),
+    ).rejects.toBeInstanceOf(FormInstallValidationError);
+    expect(mockInternalQuery).not.toHaveBeenCalled();
+  });
+
+  it("accepts a missing default_owner (optional)", async () => {
+    const handler = new GitHubPatFormInstallHandler();
+    const result = await handler.validateConfig(WSID, { pat: "ghp_only_token_no_owner" });
+    expect(result.credentialWritten).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Happy path — encryption round-trip + INSERT shape
+// ---------------------------------------------------------------------------
+
+describe("GitHubPatFormInstallHandler.validateConfig — happy path", () => {
+  it("encrypts only the pat field and persists default_owner plaintext", async () => {
+    const handler = new GitHubPatFormInstallHandler();
+
+    await handler.validateConfig(WSID, validForm());
+
+    expect(mockInternalQuery).toHaveBeenCalledTimes(1);
+    const [, params] = mockInternalQuery.mock.calls[0];
+    const configJson = (params as unknown[]).find(
+      (p) => typeof p === "string" && p.startsWith("{"),
+    ) as string | undefined;
+    expect(configJson).toBeDefined();
+    const persisted = JSON.parse(configJson!) as Record<string, unknown>;
+
+    // pat is encrypted at rest — should NOT round-trip as plaintext.
+    expect(persisted.pat).toBeTypeOf("string");
+    expect(persisted.pat).not.toBe("ghp_testtokenabcdefghijklmnopqrstuvwxyz1234");
+    expect(persisted.pat as string).toMatch(/^enc:/);
+    // Decrypt to verify the round-trip.
+    expect(decryptSecret(persisted.pat as string)).toBe("ghp_testtokenabcdefghijklmnopqrstuvwxyz1234");
+
+    // default_owner stays plaintext — admin UI reads need no decrypt.
+    expect(persisted.default_owner).toBe("acme-corp");
+  });
+
+  it("INSERT names pillar='action' and install_id explicitly (post-0092 shape)", async () => {
+    const handler = new GitHubPatFormInstallHandler();
+    await handler.validateConfig(WSID, validForm());
+
+    const [sql] = mockInternalQuery.mock.calls[0] as [string, unknown[]];
+    expect(sql).toMatch(/install_id/);
+    expect(sql).toMatch(/pillar/);
+    expect(sql).toMatch(/'action'/);
+    expect(sql).toMatch(/ON CONFLICT.*workspace_id.*catalog_id.*WHERE.*pillar.*DO UPDATE/s);
+    // Catalog id must be `catalog:github-pat` — the dispatch key.
+    const params = mockInternalQuery.mock.calls[0][1] as unknown[];
+    expect(params).toContain("catalog:github-pat");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SaaS keyset gate — defense in depth even though catalog hides this row
+// ---------------------------------------------------------------------------
+
+describe("GitHubPatFormInstallHandler.validateConfig — SaaS keyset gate", () => {
+  it("refuses to persist when SaaS + no keyset (would leak plaintext)", async () => {
+    // The catalog row carries `saas_eligible: false`, so the
+    // integrations-catalog filter already hides github-pat on SaaS.
+    // The keyset gate stays as defense in depth: if a SaaS deploy
+    // somehow surfaces this install path (filter bypass, dev-mode
+    // operator, future regression), refuse to persist plaintext.
+    delete process.env.ATLAS_ENCRYPTION_KEYS;
+    delete process.env.ATLAS_ENCRYPTION_KEY;
+    delete process.env.BETTER_AUTH_SECRET;
+    process.env.ATLAS_DEPLOY_MODE = "saas";
+    _resetEncryptionKeyCache();
+
+    const handler = new GitHubPatFormInstallHandler();
+    await expect(handler.validateConfig(WSID, validForm())).rejects.toThrow(
+      /Encryption keyset unavailable/,
+    );
+    expect(mockInternalQuery).not.toHaveBeenCalled();
+  });
+});

--- a/packages/api/src/lib/integrations/install/__tests__/github-pat-form-handler.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/github-pat-form-handler.test.ts
@@ -134,6 +134,41 @@ describe("GitHubPatFormInstallHandler.validateConfig — input validation", () =
     const result = await handler.validateConfig(WSID, { pat: "ghp_only_token_no_owner" });
     expect(result.credentialWritten).toBe(true);
   });
+
+  it("accepts blank-string default_owner (preprocess normalizes to undefined)", async () => {
+    // The admin form-install-modal's `buildDefaultValues` initializes
+    // optional string fields to `""`. Without the preprocess hop, the
+    // `.min(1)` constraint would reject the empty default and the
+    // admin would have to manually clear the field to install. Codex
+    // P2 #1: keep this path passing.
+    const handler = new GitHubPatFormInstallHandler();
+    const result = await handler.validateConfig(WSID, validForm({ default_owner: "" }));
+    expect(result.credentialWritten).toBe(true);
+    // The stored config should NOT carry a blank-string owner.
+    const [, params] = mockInternalQuery.mock.calls[0];
+    const configJson = (params as unknown[]).find(
+      (p) => typeof p === "string" && p.startsWith("{"),
+    ) as string;
+    const persisted = JSON.parse(configJson) as Record<string, unknown>;
+    expect(persisted.default_owner).toBeUndefined();
+  });
+
+  it("rejects default_owner exceeding GitHub's 39-char ceiling", async () => {
+    // GitHub user/org names cap at 39 chars. Enforce locally so a
+    // typo'd 40-char value surfaces as a deterministic form error
+    // instead of a confusing 404 from the upstream create-issue call.
+    const handler = new GitHubPatFormInstallHandler();
+    await expect(
+      handler.validateConfig(WSID, validForm({ default_owner: "a".repeat(40) })),
+    ).rejects.toBeInstanceOf(FormInstallValidationError);
+    expect(mockInternalQuery).not.toHaveBeenCalled();
+  });
+
+  it("accepts default_owner at the 39-char boundary", async () => {
+    const handler = new GitHubPatFormInstallHandler();
+    const result = await handler.validateConfig(WSID, validForm({ default_owner: "a".repeat(39) }));
+    expect(result.credentialWritten).toBe(true);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/api/src/lib/integrations/install/github-pat-form-handler.ts
+++ b/packages/api/src/lib/integrations/install/github-pat-form-handler.ts
@@ -11,14 +11,7 @@
  * false`. Failure mode is too sharp for SaaS — a PAT is tied to one
  * GitHub user and dies if that user leaves the org or rotates the
  * token. The integrations-catalog route filters this row out on SaaS
- * deploys; admins on SaaS only see the GitHub App mode (currently
- * `coming_soon`).
- *
- * The GitHub App OAuth flow (multi-tenant `github` + single-tenant
- * `github-single-tenant` catalog rows) ships in a follow-up PR — JWT
- * minting for installation tokens is its own slice. Until then, those
- * rows carry `implementation_status: 'coming_soon'` and the catalog
- * route renders them inert.
+ * deploys.
  *
  * Connection liveness: NOT probed at install time. A failed GitHub API
  * round-trip at install would surface as a misleading "couldn't reach
@@ -59,10 +52,8 @@ export { FormInstallValidationError };
 
 const log = createLogger("integrations.install.github-pat");
 
-/** Catalog slug — the dispatch key in {@link registerFormHandler}. */
 const GITHUB_PAT_SLUG: CatalogId = "github-pat";
 
-/** Test-only injection of the install id generator. */
 export interface GitHubPatFormInstallHandlerOptions {
   readonly idGenerator?: () => string;
 }
@@ -134,14 +125,23 @@ export class GitHubPatFormInstallHandler implements FormBasedInstallHandler {
       );
       const returned = rows[0]?.id;
       if (typeof returned !== "string" || returned.length === 0) {
-        log.warn(
+        // INSERT ... ON CONFLICT ... DO UPDATE RETURNING is guaranteed
+        // by Postgres to emit exactly one row on both paths. Reaching
+        // here means a structural anomaly (driver rewrite, RLS hiding
+        // the result, partial-index miss). Falling back to candidateId
+        // would silently return a WRONG id on the DO UPDATE path
+        // (persisted row keeps its existing id, not the candidate),
+        // and downstream lookups would create phantom updates. Fail
+        // loud so the operator sees the invariant break with a 500.
+        log.error(
           { workspaceId, candidateId },
-          "workspace_plugins upsert returned no id — falling back to candidate",
+          "workspace_plugins upsert returned no id — Postgres invariant violation",
         );
-        persistedId = candidateId;
-      } else {
-        persistedId = returned;
+        throw new Error(
+          "workspace_plugins upsert returned no id from RETURNING — likely a driver/RLS/query-rewrite anomaly",
+        );
       }
+      persistedId = returned;
     } catch (err) {
       log.error(
         { workspaceId, err: err instanceof Error ? err.message : String(err) },

--- a/packages/api/src/lib/integrations/install/github-pat-form-handler.ts
+++ b/packages/api/src/lib/integrations/install/github-pat-form-handler.ts
@@ -1,0 +1,180 @@
+/**
+ * `GitHubPatFormInstallHandler` — GitHub Personal Access Token install
+ * (#2751, Phase D PAT mode).
+ *
+ * Form-based install mirroring {@link LinearApiKeyFormInstallHandler}.
+ * The admin pastes a PAT from https://github.com/settings/tokens; the
+ * token encrypts inline via {@link encryptSecretFields} into
+ * `workspace_plugins.config.pat`.
+ *
+ * Self-host only: the matching catalog row carries `saas_eligible:
+ * false`. Failure mode is too sharp for SaaS — a PAT is tied to one
+ * GitHub user and dies if that user leaves the org or rotates the
+ * token. The integrations-catalog route filters this row out on SaaS
+ * deploys; admins on SaaS only see the GitHub App mode (currently
+ * `coming_soon`).
+ *
+ * The GitHub App OAuth flow (multi-tenant `github` + single-tenant
+ * `github-single-tenant` catalog rows) ships in a follow-up PR — JWT
+ * minting for installation tokens is its own slice. Until then, those
+ * rows carry `implementation_status: 'coming_soon'` and the catalog
+ * route renders them inert.
+ *
+ * Connection liveness: NOT probed at install time. A failed GitHub API
+ * round-trip at install would surface as a misleading "couldn't reach
+ * GitHub" error even when the user's token is correct; the first
+ * agent-issued GitHub call surfaces real auth errors with the full
+ * path intact (HTTP 401 vs API rate-limit vs network).
+ *
+ * @see ./types.ts — {@link FormBasedInstallHandler}
+ * @see ./github-pat-secret-schema.ts — shared form + secret schema
+ * @see ./linear-apikey-form-handler.ts — sibling form-handler reference
+ * @see ../../plugins/secrets.ts — {@link encryptSecretFields}
+ */
+
+import crypto from "crypto";
+import { createLogger } from "@atlas/api/lib/logger";
+import { internalQuery } from "@atlas/api/lib/db/internal";
+import { encryptSecretFields } from "@atlas/api/lib/plugins/secrets";
+import { lazyPluginLoader } from "@atlas/api/lib/plugins/lazy-loader";
+import { getEncryptionKeyset } from "@atlas/api/lib/db/encryption-keys";
+import type { WorkspaceId } from "@useatlas/types";
+import {
+  GITHUB_PAT_CATALOG_ID,
+  GITHUB_PAT_SECRET_FIELDS_SCHEMA,
+  GitHubPatFormDataSchema,
+} from "./github-pat-secret-schema";
+import { FormInstallValidationError } from "./email-form-handler";
+import type {
+  CatalogId,
+  FormBasedInstallHandler,
+  InstallRecord,
+} from "./types";
+
+// Re-export the validation error class for callers that catch with
+// `instanceof`. {@link FormInstallValidationError} is the canonical
+// throw type for every form-based install handler — declared in the
+// Email module first per #2697.
+export { FormInstallValidationError };
+
+const log = createLogger("integrations.install.github-pat");
+
+/** Catalog slug — the dispatch key in {@link registerFormHandler}. */
+const GITHUB_PAT_SLUG: CatalogId = "github-pat";
+
+/** Test-only injection of the install id generator. */
+export interface GitHubPatFormInstallHandlerOptions {
+  readonly idGenerator?: () => string;
+}
+
+export class GitHubPatFormInstallHandler implements FormBasedInstallHandler {
+  readonly kind = "form" as const;
+
+  private readonly newId: () => string;
+
+  constructor(options: GitHubPatFormInstallHandlerOptions = {}) {
+    this.newId = options.idGenerator ?? (() => crypto.randomUUID());
+  }
+
+  async validateConfig(
+    workspaceId: WorkspaceId,
+    formData: unknown,
+  ): Promise<{
+    readonly installRecord: InstallRecord;
+    readonly credentialWritten: boolean;
+  }> {
+    // ── 1. Validate the form against the PAT schema ────────────────
+    const parsed = GitHubPatFormDataSchema.safeParse(formData);
+    if (!parsed.success) {
+      throw FormInstallValidationError.fromZodFlatten(parsed.error.flatten());
+    }
+    const config = parsed.data;
+
+    // ── 2. SaaS keyset gate ─────────────────────────────────────────
+    // The matching catalog row is `saas_eligible: false`, so the
+    // integrations-catalog route already hides this install path on
+    // SaaS — a caller would have to bypass that filter to reach here.
+    // The keyset gate stays as defense-in-depth: if a SaaS deploy
+    // somehow surfaces the install path, refuse to persist plaintext.
+    // Mirrors LinearApiKeyFormInstallHandler's posture.
+    if (
+      process.env.ATLAS_DEPLOY_MODE === "saas" &&
+      !getEncryptionKeyset()
+    ) {
+      log.error(
+        { workspaceId },
+        "Refusing form install: SaaS mode + no encryption keyset (would persist plaintext pat)",
+      );
+      throw new Error(
+        "Encryption keyset unavailable in SaaS mode — refusing to persist plaintext credentials. Set ATLAS_ENCRYPTION_KEYS and retry.",
+      );
+    }
+
+    // ── 3. Encrypt secret fields (pat) at rest ──────────────────────
+    const encryptedConfig = encryptSecretFields(config, GITHUB_PAT_SECRET_FIELDS_SCHEMA);
+
+    // ── 4. Upsert workspace_plugins ─────────────────────────────────
+    // Pillar='action' + install_id named explicitly per migration 0092
+    // (#2739). The partial unique index keys re-installs to the same
+    // row; `RETURNING id` lets us pick up the existing id rather than a
+    // phantom freshly-generated one on conflict.
+    const candidateId = this.newId();
+    let persistedId: string;
+    try {
+      const rows = await internalQuery<{ id: string }>(
+        `INSERT INTO workspace_plugins
+           (id, workspace_id, catalog_id, install_id, pillar, config, enabled, installed_at)
+         VALUES ($1, $2, $3, $1, 'action', $4::jsonb, true, NOW())
+         ON CONFLICT (workspace_id, catalog_id) WHERE pillar IN ('chat', 'action')
+         DO UPDATE
+           SET config = EXCLUDED.config,
+               enabled = true
+         RETURNING id`,
+        [candidateId, workspaceId, GITHUB_PAT_CATALOG_ID, JSON.stringify(encryptedConfig)],
+      );
+      const returned = rows[0]?.id;
+      if (typeof returned !== "string" || returned.length === 0) {
+        log.warn(
+          { workspaceId, candidateId },
+          "workspace_plugins upsert returned no id — falling back to candidate",
+        );
+        persistedId = candidateId;
+      } else {
+        persistedId = returned;
+      }
+    } catch (err) {
+      log.error(
+        { workspaceId, err: err instanceof Error ? err.message : String(err) },
+        "Failed to persist GitHub PAT install record — aborting install",
+      );
+      throw err;
+    }
+
+    // Evict any cached PluginLike for this (workspace, catalog) so a
+    // future agent-tool dispatch rebuilds against the freshly-persisted
+    // config. The GitHub action tool ships in a follow-up PR; the evict
+    // call stays here so re-installs that rotate the PAT don't leave a
+    // stale in-memory instance behind once the tool lands.
+    try {
+      await lazyPluginLoader.evict(workspaceId, GITHUB_PAT_CATALOG_ID);
+    } catch (err) {
+      log.warn(
+        { workspaceId, err: err instanceof Error ? err.message : String(err) },
+        "LazyPluginLoader.evict threw after GitHub PAT install upsert — DB row is persisted anyway",
+      );
+    }
+
+    log.info(
+      {
+        workspaceId,
+        installId: persistedId,
+        defaultOwner: config.default_owner ?? null,
+      },
+      "GitHub PAT install completed",
+    );
+    return {
+      installRecord: { id: persistedId, workspaceId, catalogId: GITHUB_PAT_SLUG },
+      credentialWritten: true,
+    };
+  }
+}

--- a/packages/api/src/lib/integrations/install/github-pat-secret-schema.ts
+++ b/packages/api/src/lib/integrations/install/github-pat-secret-schema.ts
@@ -1,0 +1,105 @@
+/**
+ * Shared form schema + secret-field map for the GitHub Personal Access
+ * Token install mode (#2751).
+ *
+ * Mirrors {@link ./linear-apikey-secret-schema.ts} — both the form
+ * install handler ({@link GitHubPatFormInstallHandler}) and any future
+ * lazy builder for GitHub need to know:
+ *
+ *   1. The Zod shape of the install form (pat, default_owner) so stored
+ *      configs can be re-validated on read without re-deriving the
+ *      schema in two places.
+ *   2. Which fields in `workspace_plugins.config` are `secret: true` so
+ *      the write path encrypts and the read path decrypts the same set.
+ *
+ * Duplicating the `secret: true` flag set in two modules is the F-42
+ * audit's exact failure mode — a write that encrypts more than the read
+ * decrypts corrupts the stored value silently. Centralizing keeps both
+ * sides in lockstep.
+ */
+
+import { z } from "zod";
+import type { ConfigSchema } from "@atlas/api/lib/plugins/secrets";
+import type { ConfigSchemaField } from "@atlas/api/lib/plugins/registry";
+
+/** Stable `plugin_catalog.id` for the GitHub PAT install mode. */
+export const GITHUB_PAT_CATALOG_ID = "catalog:github-pat";
+
+/**
+ * Defensive upper bound on the PAT field. Real GitHub tokens are
+ * well under 200 chars (classic: 40 hex chars; fine-grained:
+ * `github_pat_` + ~80 chars). 4096 is the same belt-and-braces cap
+ * Linear API-key uses — JSONB rows shouldn't carry 50MB strings.
+ */
+const PAT_MAX = 4096;
+
+/**
+ * GitHub PATs come in two shapes that we accept:
+ *   - Classic: `ghp_` followed by 36 base62 chars (older format).
+ *   - Fine-grained: `github_pat_` followed by ~82 chars (`A-Za-z0-9_`).
+ *
+ * The regex is permissive — we accept the union of "alphanumeric +
+ * underscore" but DON'T enforce the prefix. A token mis-typed without
+ * the prefix is better surfaced as a clean GitHub-side 401 from the
+ * first API call than as a vague form-validation error that doesn't
+ * explain WHY the input shape matters. Same rationale as the Linear
+ * API-key handler.
+ */
+const GITHUB_PAT_RE = /^[A-Za-z0-9_]+$/;
+
+/**
+ * GitHub owner names (users + organizations) are constrained to
+ * 1–39 chars of alphanumerics and single hyphens. We don't enforce the
+ * hyphen rules here (no leading/trailing/double hyphens) — that's a
+ * GitHub-side 404 the agent surfaces clearly. We DO bound the length so
+ * a copy-paste accident doesn't store a 50KB blob.
+ */
+const GITHUB_OWNER_MAX = 64;
+const GITHUB_OWNER_RE = /^[A-Za-z0-9][A-Za-z0-9-]*$/;
+
+export const GitHubPatFormDataSchema = z.object({
+  pat: z
+    .string()
+    .min(1, "pat is required")
+    .max(PAT_MAX, `pat must be ${PAT_MAX} characters or fewer`)
+    .regex(
+      GITHUB_PAT_RE,
+      "pat contains characters GitHub tokens never use — copy the value directly from https://github.com/settings/tokens",
+    ),
+  /**
+   * Optional default owner (user or organization) the agent falls back
+   * to when an `issueCreate`-style call doesn't specify one. Empty
+   * string is rejected — admins who don't want a default should omit
+   * the field entirely rather than submit an empty value (which would
+   * later surface as a confusing GitHub-side error).
+   */
+  default_owner: z
+    .string()
+    .min(1)
+    .max(GITHUB_OWNER_MAX)
+    .regex(
+      GITHUB_OWNER_RE,
+      "default_owner must start with an alphanumeric and contain only alphanumerics and hyphens (GitHub user/org name rules)",
+    )
+    .optional(),
+}).strict();
+
+export type GitHubPatFormData = z.infer<typeof GitHubPatFormDataSchema>;
+
+/**
+ * `encryptSecretFields` / `decryptSecretFields` schema for the GitHub
+ * PAT handler. The `fields[].key` element is constrained to
+ * `keyof GitHubPatFormData` so a Zod rename without a matching update
+ * here surfaces as a TS error rather than a silent encryption regression
+ * at runtime.
+ */
+export const GITHUB_PAT_SECRET_FIELDS_SCHEMA: ConfigSchema & {
+  state: "parsed";
+  fields: ReadonlyArray<ConfigSchemaField & { key: keyof GitHubPatFormData }>;
+} = {
+  state: "parsed",
+  fields: [
+    { key: "pat", type: "string", secret: true },
+    { key: "default_owner", type: "string" },
+  ],
+};

--- a/packages/api/src/lib/integrations/install/github-pat-secret-schema.ts
+++ b/packages/api/src/lib/integrations/install/github-pat-secret-schema.ts
@@ -22,7 +22,6 @@ import { z } from "zod";
 import type { ConfigSchema } from "@atlas/api/lib/plugins/secrets";
 import type { ConfigSchemaField } from "@atlas/api/lib/plugins/registry";
 
-/** Stable `plugin_catalog.id` for the GitHub PAT install mode. */
 export const GITHUB_PAT_CATALOG_ID = "catalog:github-pat";
 
 /**

--- a/packages/api/src/lib/integrations/install/github-pat-secret-schema.ts
+++ b/packages/api/src/lib/integrations/install/github-pat-secret-schema.ts
@@ -48,12 +48,14 @@ const GITHUB_PAT_RE = /^[A-Za-z0-9_]+$/;
 
 /**
  * GitHub owner names (users + organizations) are constrained to
- * 1–39 chars of alphanumerics and single hyphens. We don't enforce the
+ * 1–39 chars of alphanumerics and single hyphens. We enforce the
+ * length ceiling locally so a typo'd 40+ char value surfaces as a
+ * deterministic form error instead of a confusing GitHub-side 404
+ * later when the agent tries to create an issue. We don't enforce the
  * hyphen rules here (no leading/trailing/double hyphens) — that's a
- * GitHub-side 404 the agent surfaces clearly. We DO bound the length so
- * a copy-paste accident doesn't store a 50KB blob.
+ * GitHub-side 404 the agent surfaces clearly.
  */
-const GITHUB_OWNER_MAX = 64;
+const GITHUB_OWNER_MAX = 39;
 const GITHUB_OWNER_RE = /^[A-Za-z0-9][A-Za-z0-9-]*$/;
 
 export const GitHubPatFormDataSchema = z.object({
@@ -67,20 +69,25 @@ export const GitHubPatFormDataSchema = z.object({
     ),
   /**
    * Optional default owner (user or organization) the agent falls back
-   * to when an `issueCreate`-style call doesn't specify one. Empty
-   * string is rejected — admins who don't want a default should omit
-   * the field entirely rather than submit an empty value (which would
-   * later surface as a confusing GitHub-side error).
+   * to when an `issueCreate`-style call doesn't specify one. The
+   * preprocess step normalizes the admin form's empty-string default
+   * (`buildDefaultValues` in form-install-modal initializes optional
+   * string fields to `""`) to `undefined` so leaving the field blank
+   * round-trips as "no default" instead of failing validation.
    */
   default_owner: z
-    .string()
-    .min(1)
-    .max(GITHUB_OWNER_MAX)
-    .regex(
-      GITHUB_OWNER_RE,
-      "default_owner must start with an alphanumeric and contain only alphanumerics and hyphens (GitHub user/org name rules)",
-    )
-    .optional(),
+    .preprocess(
+      (v) => (v === "" ? undefined : v),
+      z
+        .string()
+        .min(1)
+        .max(GITHUB_OWNER_MAX, `default_owner must be ${GITHUB_OWNER_MAX} characters or fewer (GitHub's user/org name limit)`)
+        .regex(
+          GITHUB_OWNER_RE,
+          "default_owner must start with an alphanumeric and contain only alphanumerics and hyphens (GitHub user/org name rules)",
+        )
+        .optional(),
+    ),
 }).strict();
 
 export type GitHubPatFormData = z.infer<typeof GitHubPatFormDataSchema>;

--- a/packages/api/src/lib/integrations/install/register.ts
+++ b/packages/api/src/lib/integrations/install/register.ts
@@ -57,6 +57,7 @@ import {
   createLinearOAuthLazyBuilder,
   createLinearApiKeyLazyBuilder,
 } from "@atlas/api/lib/integrations/linear/lazy-builder";
+import { GitHubPatFormInstallHandler } from "./github-pat-form-handler";
 
 const log = createLogger("integrations.install.register");
 
@@ -136,6 +137,15 @@ export function registerBuiltinInstallHandlers(): void {
     );
   }
   log.info("Registered LinearApiKeyFormInstallHandler + LazyPluginLoader builder");
+  // GitHub PAT form-install (#2751, Phase D PAT mode). No paired lazy
+  // builder yet — the GitHub action tool ships in a follow-up PR
+  // (alongside the GitHub App OAuth handler). The form handler still
+  // registers so the install path works end-to-end: the credential
+  // persists, and the tool dispatch will find it once the builder
+  // lands. Self-host only — the catalog row carries `saas_eligible:
+  // false`, so the integrations-catalog route hides this on SaaS.
+  registerFormHandler("github-pat", new GitHubPatFormInstallHandler());
+  log.info("Registered GitHubPatFormInstallHandler (no lazy builder yet — agent tool ships in follow-up)");
 
   // ── Slack OAuth ───────────────────────────────────────────────────
   registerSlackOAuthHandler();


### PR DESCRIPTION
## Summary

1.5.3 slice 13 Phase D, **scoped to the PAT install mode**. The two GitHub App modes (multi-tenant + single-tenant) ship as `coming_soon` catalog rows. The App OAuth handler (JWT-signed installation token minting) is deferred to a follow-up PR — it's its own slice's worth of work.

**Why split:** GitHub App OAuth diverges structurally from the Linear/Jira/Salesforce pattern. The callback gives `installation_id`, not an authorization `code`; installation tokens are minted on demand by signing a JWT with the App's RSA private key (no refresh token). That's a new OAuth helper surface — better as its own focused PR than bundled with the PAT happy path.

**What lands here:**
- 3 catalog rows in `deploy/api/atlas.config.ts`. `github-pat` is `available`; the two App rows are `coming_soon` (admin UI renders them inert).
- `GitHubPatFormInstallHandler` mirroring `LinearApiKeyFormInstallHandler`. Selective-field encryption on the `pat` field; `default_owner` stays plaintext.
- `GitHubPatFormDataSchema` validation: rejects characters GitHub tokens never use, caps length at 4096, pins GitHub's user/org name rules on `default_owner`.
- Register wiring (no paired lazy builder yet — the GitHub action tool ships with the App OAuth slice).
- 8 tests: validation rejection paths, encryption round-trip, post-0092 INSERT shape, SaaS keyset gate.
- Docs page at `apps/docs/content/docs/integrations/github.mdx` covering all three modes; App sections marked "Coming soon" with operator setup laid out so self-host deploys can prepare env values now.

**`saas_eligible` gating is a generic primitive that already exists** (column on `plugin_catalog`, filter in `PillarCatalogQuery` facade). This PR just consumes it — no new gating mechanism needed. The catalog filter hides `github-single-tenant` and `github-pat` on SaaS deploys; only the multi-tenant `github` row surfaces in the SaaS catalog (currently coming_soon, so functionally nothing shows on SaaS for GitHub until the App handler lands).

## Test plan

- [x] `bun run lint` clean
- [x] `bun run type` clean
- [x] `bun run test` — 464/465 files pass; the 1 failure (`discord.test.ts`) is the known parallel-load flake (#2776), green in isolation, untouched by this changeset
- [x] 8/8 new tests pass in isolation
- [x] Syncpack, template-drift, schema-drift, oauth-helper-drift, security-headers-drift, railway-watch, legacy-connections-SQL gate — all green
- [ ] Dogfood: install a PAT through `Admin → Integrations → GitHub (Personal Access Token)` and confirm the catalog card flips to Installed (manual, self-host only)
- [ ] Follow-up PR: GitHub App OAuth handler (multi-tenant + single-tenant), JWT minting, GitHub action tool, flip the two `coming_soon` rows to `available`