### PR TITLE
docs: 1.5.3 quick-wins sweep — operator CLI, catalog-driven chat, obsidian-reader + webhook-action, useMcpConnect

### DIFF
--- a/apps/docs/content/docs/plugins/actions/index.mdx
+++ b/apps/docs/content/docs/plugins/actions/index.mdx
@@ -12,6 +12,7 @@ Action plugins give the agent the ability to perform write operations. All actio
 <Cards>
   <Card title="Email" href="/plugins/actions/email" description="Send email reports to stakeholders via Resend" />
   <Card title="JIRA" href="/plugins/actions/jira" description="Create JIRA tickets from analysis findings" />
+  <Card title="Webhook" href="/plugins/actions/webhook-action" description="POST signed JSON payloads to an outbound HTTPS endpoint" />
 </Cards>
 
 ## Approval Modes

--- a/apps/docs/content/docs/plugins/actions/meta.json
+++ b/apps/docs/content/docs/plugins/actions/meta.json
@@ -3,6 +3,7 @@
   "pages": [
     "index",
     "email",
-    "jira"
+    "jira",
+    "webhook-action"
   ]
 }

--- a/apps/docs/content/docs/plugins/actions/webhook-action.mdx
+++ b/apps/docs/content/docs/plugins/actions/webhook-action.mdx
@@ -1,0 +1,146 @@
+---
+title: Webhook
+description: Let the Atlas agent POST signed JSON payloads to an outbound webhook with HMAC-SHA256 verification and configurable retry.
+---
+
+import { Callout } from "fumadocs-ui/components/callout";
+
+The webhook action plugin (`@useatlas/webhook-action`) lets the Atlas agent POST a JSON payload to a configured HTTPS endpoint. Bodies are signed with HMAC-SHA256 (sent in the `X-Atlas-Signature` header) so the receiver can verify the request really came from Atlas using a shared signing secret. The signing shape mirrors Stripe / GitHub / Shopify webhook conventions.
+
+Use this to fire alerts into PagerDuty / Opsgenie / Slack-compatible inbound webhooks, push findings into an internal queue, or trigger downstream automations from agent analyses.
+
+## Installation
+
+```bash
+bun add @useatlas/webhook-action
+```
+
+### Prerequisites
+
+- An outbound HTTPS endpoint that accepts JSON POSTs (HTTP is rejected — see [Security](#security) below)
+- A shared signing secret for HMAC verification (any high-entropy string)
+
+## Configuration
+
+```typescript
+// atlas.config.ts
+import { defineConfig } from "@atlas/api/lib/config";
+import { webhookActionPlugin } from "@useatlas/webhook-action";
+
+export default defineConfig({
+  plugins: [
+    webhookActionPlugin({
+      url: "https://hooks.example.com/atlas",
+      signing_secret: process.env.WEBHOOK_SIGNING_SECRET!,
+      retry_policy: "exponential",
+    }),
+  ],
+});
+```
+
+### Options
+
+| Option | Type | Required | Default | Description |
+|--------|------|----------|---------|-------------|
+| `url` | `string` | Yes | — | Destination URL. Must be a well-formed `https://` URL (the config schema rejects `http://` and malformed URLs at factory call time) |
+| `signing_secret` | `string` | Yes | — | HMAC-SHA256 signing secret shared with the receiver |
+| `retry_policy` | `"none" \| "exponential"` | No | `"exponential"` | Retry on 5xx / network errors. `"exponential"` uses `[250ms, 1s, 4s]` between 4 attempts (total budget ~5.25s) |
+| `approvalMode` | `"auto" \| "manual" \| "admin-only"` | No | `"admin-only"` | Who can approve a webhook send |
+
+<Callout type="warn">
+Never commit the signing secret. Pass it via `process.env.WEBHOOK_SIGNING_SECRET` and add `.env` to `.gitignore`.
+</Callout>
+
+## Action Details
+
+| Property | Value |
+|----------|-------|
+| **Action name** | `postWebhook` |
+| **Action type** | `webhook:post` |
+| **Reversible** | No |
+| **Default approval** | `admin-only` (configurable via `approvalMode`) |
+
+The agent tool accepts a single parameter:
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `payload` | `unknown` | JSON-serializable payload. Stringified to a stable form, signed, and sent as the POST body |
+
+On success the tool returns `{ status, signature }` — the destination's HTTP status and the hex-encoded HMAC of the body (surfaced for audit / debugging).
+
+## Example
+
+```
+User: Open a Pager when revenue drops more than 10% week-over-week.
+
+Agent calls postWebhook({
+  payload: {
+    severity: "warning",
+    summary: "Revenue ↓ 12.4% WoW",
+    details: { week: "2026-04-13", delta_pct: -12.4 }
+  }
+})
+  → 202 from PagerDuty Events API
+  → X-Atlas-Signature = 7f3c...
+```
+
+## Security
+
+### `https://` only
+
+The Zod schema rejects any `url` that isn't a well-formed `https://` URL. This is deliberate — exfiltrating an HMAC signature over cleartext HTTP would defeat the integrity guarantee. Run the receiver behind TLS; for local development against a non-TLS service, use a tunnel like ngrok that gives you an HTTPS URL.
+
+### HMAC-SHA256 signature verification
+
+The plugin computes `HMAC_SHA256(signing_secret, raw_body)` and sends the hex digest in the `X-Atlas-Signature` header. Receivers verify by computing the same MAC over the raw request body and **constant-time** comparing against the header. Constant-time compare is required — naive `==` makes the receiver vulnerable to timing attacks that recover the secret one byte at a time.
+
+#### Node.js receiver template
+
+```typescript
+import crypto from "node:crypto";
+
+function verifyAtlasWebhook(rawBody: string, headerSig: string, secret: string) {
+  const expected = crypto
+    .createHmac("sha256", secret)
+    .update(rawBody)
+    .digest("hex");
+  const a = Buffer.from(expected, "hex");
+  const b = Buffer.from(headerSig, "hex");
+  return a.length === b.length && crypto.timingSafeEqual(a, b);
+}
+```
+
+Read the raw request body **before** any JSON parsing — if the body is reserialized via `JSON.stringify(JSON.parse(...))`, byte-for-byte equality breaks and signatures stop matching.
+
+### Approval mode defaults to `admin-only`
+
+Outbound writes are irreversible — once Atlas has POSTed the payload, you can't unsend it. The default `admin-only` mode means only workspace admins approve agent-proposed webhook calls. Set `approvalMode: "manual"` to let any conversation participant approve; `"auto"` to skip approval entirely (only safe when the destination is idempotent and you trust the agent loop end-to-end).
+
+## How It Works
+
+1. The agent calls `postWebhook({ payload })` with a JSON-serializable object
+2. The plugin `JSON.stringify`s the payload, computes `HMAC_SHA256(signing_secret, body)`, and POSTs it to `url` with `X-Atlas-Signature: <hex>` and `Content-Type: application/json`
+3. On a network error or 5xx response under `retry_policy: "exponential"`, the plugin retries with `[250ms, 1s, 4s]` backoff (4 attempts total, ~5.25s budget). 4xx responses surface immediately — they're destination-side rejections, not transient
+4. On success, the tool returns `{ status, signature }`. On any 4xx (or after the exponential ramp), the tool throws and the agent surfaces the error
+
+<Callout type="info">
+The health check unconditionally returns healthy because webhook destinations don't have a standard liveness endpoint — a `HEAD` probe could 405 on receivers that only accept POST, and Atlas won't send a real signed payload at boot. Real failures surface on first send, same approach the email plugin uses.
+</Callout>
+
+## Troubleshooting
+
+### `url must be a well-formed https:// URL`
+
+The config schema rejects HTTP and malformed URLs at startup. Switch the receiver to HTTPS (or front it with a TLS-terminating proxy / ngrok tunnel) and pass that URL instead.
+
+### Receiver rejects signature
+
+Make sure the receiver verifies HMAC over the **raw** request body, not a reparsed-and-restringified copy. Frameworks that auto-parse JSON (Express's `express.json()`, Hono's `c.req.json()`) reformat whitespace, which breaks byte-equality. Read the raw body first, verify, then parse.
+
+### Retries blasting the destination
+
+If you don't want exponential retry behavior — e.g. the destination is non-idempotent and a duplicate POST is worse than a missed one — set `retry_policy: "none"`. The plugin will give up after the first failure and surface the error to the agent.
+
+### `Webhook POST failed: HTTP 4xx`
+
+The destination accepted the TCP connection but rejected the payload. The error message includes up to 200 characters of the response body — check that excerpt for the receiver's specific complaint (auth header missing, schema mismatch, signature header missing, etc.).

--- a/apps/docs/content/docs/plugins/datasources/index.mdx
+++ b/apps/docs/content/docs/plugins/datasources/index.mdx
@@ -27,6 +27,7 @@ Never commit credentials to version control. Use environment variables (`process
   <Card title="MySQL" href="/plugins/datasources/mysql" description="MySQL / MariaDB via connection pool" />
   <Card title="Snowflake" href="/plugins/datasources/snowflake" description="Snowflake Data Cloud with pool management" />
   <Card title="Salesforce" href="/plugins/datasources/salesforce" description="Salesforce CRM via SOQL (not SQL)" />
+  <Card title="Obsidian Reader" href="/plugins/datasources/obsidian-reader" description="Read-only access to an Obsidian vault via the Local REST API" />
 </Cards>
 
 ## Comparison

--- a/apps/docs/content/docs/plugins/datasources/meta.json
+++ b/apps/docs/content/docs/plugins/datasources/meta.json
@@ -7,6 +7,7 @@
     "duckdb",
     "mysql",
     "snowflake",
-    "salesforce"
+    "salesforce",
+    "obsidian-reader"
   ]
 }

--- a/apps/docs/content/docs/plugins/datasources/obsidian-reader.mdx
+++ b/apps/docs/content/docs/plugins/datasources/obsidian-reader.mdx
@@ -1,0 +1,110 @@
+---
+title: Obsidian Reader
+description: Read-only access to an Obsidian vault via the Obsidian Local REST API — give the agent a tool to look up notes, definitions, and prior analysis.
+---
+
+import { Callout } from "fumadocs-ui/components/callout";
+
+The Obsidian Reader plugin (`@useatlas/obsidian-reader`) gives the Atlas agent a read-only `readObsidianVault` tool backed by the [Obsidian Local REST API](https://github.com/coddingtonbear/obsidian-local-rest-api) community plugin. The agent uses it to search the user's vault for reference material — definitions, decisions, prior analysis — without ever writing to the vault.
+
+Read-only by construction: the plugin only calls `/search/simple/`, so there is no write endpoint exposed to the agent even by mistake.
+
+<Callout type="info">
+This plugin is registered under **Datasources** because it surfaces a knowledge store the agent reads to ground answers — same role as a database connection. Mechanically, the plugin ships an action-shaped `readObsidianVault` tool (read-only, `defaultApproval: "auto"`), mirroring the existing read-only patterns used by the SQL `executeSQL` and JIRA `readJiraTicket` paths.
+</Callout>
+
+## Installation
+
+```bash
+bun add @useatlas/obsidian-reader
+```
+
+### Prerequisites
+
+- An Obsidian vault with the [Local REST API plugin](https://github.com/coddingtonbear/obsidian-local-rest-api) installed and enabled
+- The Bearer API key issued by the REST API plugin's settings tab
+- Atlas reachable from the machine running Obsidian (default: `http://127.0.0.1:27123`)
+
+## Configuration
+
+```typescript
+// atlas.config.ts
+import { defineConfig } from "@atlas/api/lib/config";
+import { obsidianReaderPlugin } from "@useatlas/obsidian-reader";
+
+export default defineConfig({
+  plugins: [
+    obsidianReaderPlugin({
+      api_url: "http://127.0.0.1:27123",
+      api_key: process.env.OBSIDIAN_API_KEY!,
+    }),
+  ],
+});
+```
+
+### Options
+
+| Option | Type | Required | Default | Description |
+|--------|------|----------|---------|-------------|
+| `api_key` | `string` | Yes | — | Bearer API key issued by the Obsidian Local REST API plugin's settings tab |
+| `api_url` | `string` | No | `http://127.0.0.1:27123` | Base URL of the REST API. Override when Obsidian runs on a different host or port |
+
+<Callout type="warn">
+Never commit the Obsidian API key. Pass it via `process.env.OBSIDIAN_API_KEY` and add `.env` to `.gitignore`.
+</Callout>
+
+## Tool Details
+
+| Property | Value |
+|----------|-------|
+| **Tool name** | `readObsidianVault` |
+| **Action type** | `obsidian:read` |
+| **Reversible** | Yes (read-only) |
+| **Default approval** | `auto` (mirrors `executeSQL`) |
+
+The agent tool accepts a single parameter:
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `query` | `string` | Free-text search query matched against note bodies and titles |
+
+The tool returns `{ hits: [{ filename, excerpt, score }] }` — one entry per matching note, with the REST API's match-window excerpts joined by `\n---\n`. Higher `score` means more relevant. Excerpts are taken from the REST API's `contextLength=100` window so whole files don't flow into the agent context.
+
+## Example
+
+```
+User: What did we decide about the canonical question set?
+
+Agent calls readObsidianVault({ query: "canonical question set" })
+  → hits[0].filename = "decisions/2025-12-10-canonical-questions.md"
+  → hits[0].excerpt   = "…we chose to ship NovaMart as the single seed because…"
+
+Agent: According to your note from 2025-12-10, you chose to ship NovaMart as
+the single seed because…
+```
+
+## How It Works
+
+1. The agent calls `readObsidianVault({ query })` when it needs vault content to ground an answer
+2. The plugin POSTs to `GET ${api_url}/search/simple/?query=...&contextLength=100` with a `Bearer ${api_key}` header
+3. The REST API returns an array of `{ filename, matches[], score }` rows
+4. The plugin flattens `matches[].context` into a single excerpt string per hit so the agent doesn't have to parse the per-match window structure
+5. The agent receives `{ hits: [{ filename, excerpt, score }] }` and quotes / synthesizes from it
+
+<Callout type="info">
+The health check probes `GET /` on the configured `api_url`. A `200` is healthy; a `401` is also reported as reachable-but-misconfigured (the REST API plugin is running, just the API key is wrong) so transient install retries aren't blocked by a single typo. Other non-2xx responses report as unhealthy.
+</Callout>
+
+## Troubleshooting
+
+### `Obsidian REST API rejected the API key (401)`
+
+The Local REST API plugin is reachable, but the Bearer key in `api_key` doesn't match the one shown in the plugin's settings tab. Regenerate the key in Obsidian → Settings → Community Plugins → Local REST API and update the env var.
+
+### Plugin unreachable / timeout
+
+The default `http://127.0.0.1:27123` assumes Atlas runs on the same machine as Obsidian. If Atlas runs in Docker or on a remote host, set `api_url` to the host-accessible address (e.g. `http://host.docker.internal:27123` on Docker Desktop) and make sure the REST API plugin is configured to listen on a routable interface.
+
+### Empty `hits` array
+
+The query simply didn't match. Try broader terms — `/search/simple/` does case-insensitive substring matching, not full-text relevance, so very specific multi-word queries can miss.

--- a/apps/docs/content/docs/plugins/interactions/chat.mdx
+++ b/apps/docs/content/docs/plugins/interactions/chat.mdx
@@ -71,24 +71,25 @@ Stable adapters are bundled as dependencies of `@useatlas/chat` — no separate 
 ## Configuration
 
 <Callout type="info" title="Catalog-driven activation (1.5.2+)">
-The `adapters:` config field was removed in [#2650](https://github.com/AtlasDevHQ/atlas/pull/2650) (1.5.2). Adapter activation is now driven by the `catalog` rows declared in `atlas.config.ts` plus per-Platform env vars; `chatPlugin()` itself takes no credentials. The chat plugin reads the chat-type subset of the catalog inside `buildChatAdapterRegistry` and reads credentials from `process.env`.
+The `adapters:` config field was removed in [#2650](https://github.com/AtlasDevHQ/atlas/pull/2650) (1.5.2). Adapter activation is now driven by `catalog` rows + per-Platform env vars; `chatPlugin()` itself takes no credentials. **You must pass the chat-relevant catalog entries through to `chatPlugin({ catalog })`** — the plugin's route gate, webhook mounts, and `AdapterRegistry` all read from `config.catalog` of the `chatPlugin(...)` call itself (not from the top-level `atlas.config.ts`). Credentials are read from `process.env`.
 </Callout>
 
 ```typescript
 import { defineConfig } from "@atlas/api/lib/config";
 import { chatPlugin } from "@useatlas/chat";
 
+// Declared once and passed through to chatPlugin — see the Callout above.
+const catalog = [
+  { slug: "slack", type: "chat", install_model: "oauth",
+    enabled: true, saas_eligible: true },
+] as const;
+
 export default defineConfig({
-  // Operator declares which Platforms are wired + their install model.
-  // The chat plugin filters this to `type === "chat"` entries.
-  catalog: [
-    { slug: "slack", type: "chat", install_model: "oauth",
-      enabled: true, saas_eligible: true },
-  ],
+  catalog,
   plugins: [
     chatPlugin({
-      // No `adapters:` — credentials live in env vars (SLACK_CLIENT_ID etc.).
-      executeQuery: myQueryFunction,
+      catalog,                       // REQUIRED — the plugin reads it from here.
+      executeQuery: myQueryFunction, // credentials live in env vars (SLACK_CLIENT_ID etc.).
     }),
   ],
 });
@@ -97,15 +98,18 @@ export default defineConfig({
 ### Multi-Platform with State Persistence
 
 ```typescript
+const catalog = [
+  { slug: "slack",    type: "chat", install_model: "oauth",
+    enabled: true, saas_eligible: true },
+  { slug: "telegram", type: "chat", install_model: "static-bot",
+    enabled: true, saas_eligible: true },
+] as const;
+
 export default defineConfig({
-  catalog: [
-    { slug: "slack",    type: "chat", install_model: "oauth",
-      enabled: true, saas_eligible: true },
-    { slug: "telegram", type: "chat", install_model: "static-bot",
-      enabled: true, saas_eligible: true },
-  ],
+  catalog,
   plugins: [
     chatPlugin({
+      catalog,
       state: { backend: "pg" },
       executeQuery: myQueryFunction,
       actions: myActionCallbacks,
@@ -133,7 +137,7 @@ Per-Platform credentials come from environment variables — see [Environment Va
 
 | Option | Type | Required | Description |
 |--------|------|----------|-------------|
-| `catalog` | `ChatCatalogEntryInput[]` | No | Chat-type subset of `atlas.config.ts:catalog`. Pass through when the host wants to scope which catalog rows the plugin sees (e.g. in tests). Omit to let the plugin read from the host's resolved config. |
+| `catalog` | `ChatCatalogEntryInput[]` | Yes | Chat-relevant subset of `atlas.config.ts:catalog`. Pass the same `catalog` entries you declared at the host (non-chat entries pass through harmlessly — the registry filters by `type === "chat"`). **Required:** the route gate, webhook mounts, and `AdapterRegistry` all read from `config.catalog` of this `chatPlugin(...)` call itself — omitting it leaves no chat adapter activated and the plugin's health check reports unhealthy. |
 | `state` | `object` | No | State backend config (default: `{ backend: "memory" }`). |
 | `state.backend` | `"memory" \| "pg" \| "redis"` | No | State backend to use. Default: `"memory"`. |
 | `state.tablePrefix` | `string` | No | Table name prefix for PG backend. Must be a valid SQL identifier. Default: `"chat_"`. |
@@ -156,7 +160,7 @@ Per-Platform credentials come from environment variables — see [Environment Va
 | `reactions.customEmoji` | `object` | No | Override default emoji for each lifecycle stage (`received`, `processing`, `complete`, `error`). |
 
 <Callout type="info">
-At least one `catalog` row with `type: "chat"`, `enabled: true`, and a supported `install_model` must be present — otherwise no adapter activates and the plugin's health check reports unhealthy. Per-Platform credentials come from env vars (see [Environment Variables](#environment-variables)); Slack additionally requires both `SLACK_CLIENT_ID` and `SLACK_CLIENT_SECRET` together for the OAuth install path.
+At least one `catalog` row with `type: "chat"`, `enabled: true`, and a supported `install_model` must be present (and threaded through to `chatPlugin({ catalog })`) — otherwise no adapter activates and the plugin's health check reports unhealthy. Per-Platform credentials come from env vars (see [Environment Variables](#environment-variables)). For Slack OAuth specifically you need **all four**: `SLACK_CLIENT_ID`, `SLACK_CLIENT_SECRET`, `SLACK_SIGNING_SECRET`, and `SLACK_ENCRYPTION_KEY` — the install will be skipped (and the chat plugin reported unhealthy) if any one is missing.
 </Callout>
 
 ## State Adapters
@@ -580,13 +584,15 @@ slackPlugin({ signingSecret: "...", botToken: "xoxb-...", executeQuery })
 import { defineConfig } from "@atlas/api/lib/config";
 import { chatPlugin } from "@useatlas/chat";
 
+const catalog = [
+  { slug: "slack", type: "chat", install_model: "oauth",
+    enabled: true, saas_eligible: true },
+] as const;
+
 export default defineConfig({
-  catalog: [
-    { slug: "slack", type: "chat", install_model: "oauth",
-      enabled: true, saas_eligible: true },
-  ],
+  catalog,
   plugins: [
-    chatPlugin({ executeQuery }),
+    chatPlugin({ catalog, executeQuery }),
   ],
 });
 
@@ -616,13 +622,15 @@ teamsPlugin({ appId: "...", appPassword: "...", executeQuery })
 import { defineConfig } from "@atlas/api/lib/config";
 import { chatPlugin } from "@useatlas/chat";
 
+const catalog = [
+  { slug: "teams", type: "chat", install_model: "static-bot",
+    enabled: true, saas_eligible: true },
+] as const;
+
 export default defineConfig({
-  catalog: [
-    { slug: "teams", type: "chat", install_model: "static-bot",
-      enabled: true, saas_eligible: true },
-  ],
+  catalog,
   plugins: [
-    chatPlugin({ executeQuery }),
+    chatPlugin({ catalog, executeQuery }),
   ],
 });
 

--- a/apps/docs/content/docs/plugins/interactions/chat.mdx
+++ b/apps/docs/content/docs/plugins/interactions/chat.mdx
@@ -70,19 +70,24 @@ Stable adapters are bundled as dependencies of `@useatlas/chat` — no separate 
 
 ## Configuration
 
+<Callout type="info" title="Catalog-driven activation (1.5.2+)">
+The `adapters:` config field was removed in [#2650](https://github.com/AtlasDevHQ/atlas/pull/2650) (1.5.2). Adapter activation is now driven by the `catalog` rows declared in `atlas.config.ts` plus per-Platform env vars; `chatPlugin()` itself takes no credentials. The chat plugin reads the chat-type subset of the catalog inside `buildChatAdapterRegistry` and reads credentials from `process.env`.
+</Callout>
+
 ```typescript
 import { defineConfig } from "@atlas/api/lib/config";
 import { chatPlugin } from "@useatlas/chat";
 
 export default defineConfig({
+  // Operator declares which Platforms are wired + their install model.
+  // The chat plugin filters this to `type === "chat"` entries.
+  catalog: [
+    { slug: "slack", type: "chat", install_model: "oauth",
+      enabled: true, saas_eligible: true },
+  ],
   plugins: [
     chatPlugin({
-      adapters: {
-        slack: {
-          botToken: process.env.SLACK_BOT_TOKEN!,
-          signingSecret: process.env.SLACK_SIGNING_SECRET!,
-        },
-      },
+      // No `adapters:` — credentials live in env vars (SLACK_CLIENT_ID etc.).
       executeQuery: myQueryFunction,
     }),
   ],
@@ -93,21 +98,14 @@ export default defineConfig({
 
 ```typescript
 export default defineConfig({
+  catalog: [
+    { slug: "slack",    type: "chat", install_model: "oauth",
+      enabled: true, saas_eligible: true },
+    { slug: "telegram", type: "chat", install_model: "static-bot",
+      enabled: true, saas_eligible: true },
+  ],
   plugins: [
     chatPlugin({
-      adapters: {
-        slack: {
-          botToken: process.env.SLACK_BOT_TOKEN!,
-          signingSecret: process.env.SLACK_SIGNING_SECRET!,
-          clientId: process.env.SLACK_CLIENT_ID,
-          clientSecret: process.env.SLACK_CLIENT_SECRET,
-        },
-        teams: {
-          appId: process.env.TEAMS_APP_ID!,
-          appPassword: process.env.TEAMS_APP_PASSWORD!,
-          tenantId: process.env.TEAMS_TENANT_ID,
-        },
-      },
       state: { backend: "pg" },
       executeQuery: myQueryFunction,
       actions: myActionCallbacks,
@@ -117,47 +115,25 @@ export default defineConfig({
 });
 ```
 
-### Options
+### Catalog entry fields
+
+Each chat-row in `catalog` is the shape `AdapterRegistry` consumes — the chat-relevant subset of `CatalogEntry` from `@atlas/api/lib/config`. Non-chat entries (e.g. datasource rows) pass through harmlessly because the registry filters by `type === "chat"`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `slug` | `string` | Stable platform key — `"slack"`, `"telegram"`, etc. |
+| `type` | `"chat"` | Required for chat dispatch — the registry skips non-chat entries. |
+| `install_model` | `"oauth" \| "static-bot"` | `"oauth"` activates today (Slack); `"static-bot"` activates the static-bot install handler (Telegram from 1.5.3, the rest of Phase D following). |
+| `enabled` | `boolean` | Customer can install this row? Ops can flip false without removing the row. |
+| `saas_eligible` | `boolean` | Visible to the SaaS admin UI. |
+
+Per-Platform credentials come from environment variables — see [Environment Variables](#environment-variables) below for the full list.
+
+### chatPlugin options
 
 | Option | Type | Required | Description |
 |--------|------|----------|-------------|
-| `adapters` | `object` | Yes | Platform adapter credentials (at least one required). |
-| `adapters.slack.botToken` | `string` | Yes* | Slack bot token (`xoxb-...`). |
-| `adapters.slack.signingSecret` | `string` | Yes* | Slack signing secret for request verification. |
-| `adapters.slack.clientId` | `string` | No | Client ID for multi-workspace OAuth. |
-| `adapters.slack.clientSecret` | `string` | No | Client secret for multi-workspace OAuth. |
-| `adapters.teams.appId` | `string` | Yes* | Microsoft App ID from Azure Bot registration. |
-| `adapters.teams.appPassword` | `string` | Yes* | Microsoft App Password from Azure Bot registration. |
-| `adapters.teams.tenantId` | `string` | No | Restrict to a specific Microsoft Entra ID tenant. |
-| `adapters.discord.botToken` | `string` | Yes* | Discord bot token. |
-| `adapters.discord.applicationId` | `string` | Yes* | Discord application ID. |
-| `adapters.discord.publicKey` | `string` | Yes* | 64-character hex string (Ed25519 public key from Discord Developer Portal). |
-| `adapters.discord.mentionRoleIds` | `string[]` | No | Role IDs that trigger mention handlers (in addition to direct @mentions). |
-| `adapters.gchat.credentials` | `object` | No* | Service account credentials (`client_email`, `private_key`, optional `project_id`). |
-| `adapters.gchat.useApplicationDefaultCredentials` | `true` | No* | Use Application Default Credentials. |
-| `adapters.gchat.endpointUrl` | `string` | No | HTTP endpoint URL for card button click actions. |
-| `adapters.gchat.pubsubTopic` | `string` | No | Pub/Sub topic for Workspace Events (`projects/{project}/topics/{topic}`). |
-| `adapters.gchat.impersonateUser` | `string` | No | User email for domain-wide delegation. |
-| `adapters.telegram.botToken` | `string` | Yes* | Telegram bot token from BotFather. |
-| `adapters.telegram.secretToken` | `string` | No | Webhook secret token for request verification. |
-| `adapters.github.appId` | `string` | Yes* | GitHub App ID. Required for App-based auth. |
-| `adapters.github.privateKey` | `string` | Yes* | GitHub App private key (PEM format). |
-| `adapters.github.installationId` | `number` | No | Installation ID for single-tenant mode. |
-| `adapters.github.token` | `string` | Yes* | Personal Access Token (alternative to App auth). |
-| `adapters.github.webhookSecret` | `string` | No | Webhook secret for HMAC-SHA256 verification. |
-| `adapters.github.userName` | `string` | No | Bot username for @-mention detection. |
-| `adapters.linear.apiKey` | `string` | Yes* | Personal API key from Linear Settings. |
-| `adapters.linear.accessToken` | `string` | Yes* | Pre-obtained OAuth access token. |
-| `adapters.linear.clientId` | `string` | Yes* | OAuth application client ID. |
-| `adapters.linear.clientSecret` | `string` | Yes* | OAuth application client secret. Required with `clientId`. |
-| `adapters.linear.webhookSecret` | `string` | No | Webhook signing secret for HMAC-SHA256 verification. |
-| `adapters.linear.userName` | `string` | No | Bot display name for @-mention detection. |
-| `adapters.whatsapp.phoneNumberId` | `string` | Yes* | WhatsApp Business phone number ID. |
-| `adapters.whatsapp.accessToken` | `string` | Yes* | System User access token for Cloud API. |
-| `adapters.whatsapp.verifyToken` | `string` | Yes* | Verify token for webhook challenge-response. |
-| `adapters.whatsapp.appSecret` | `string` | Yes* | Meta App Secret for HMAC-SHA256 signature verification. |
-| `adapters.whatsapp.userName` | `string` | No | Bot display name. |
-| `adapters.whatsapp.apiVersion` | `string` | No | Meta Graph API version (default: `"v21.0"`). |
+| `catalog` | `ChatCatalogEntryInput[]` | No | Chat-type subset of `atlas.config.ts:catalog`. Pass through when the host wants to scope which catalog rows the plugin sees (e.g. in tests). Omit to let the plugin read from the host's resolved config. |
 | `state` | `object` | No | State backend config (default: `{ backend: "memory" }`). |
 | `state.backend` | `"memory" \| "pg" \| "redis"` | No | State backend to use. Default: `"memory"`. |
 | `state.tablePrefix` | `string` | No | Table name prefix for PG backend. Must be a valid SQL identifier. Default: `"chat_"`. |
@@ -180,9 +156,7 @@ export default defineConfig({
 | `reactions.customEmoji` | `object` | No | Override default emoji for each lifecycle stage (`received`, `processing`, `complete`, `error`). |
 
 <Callout type="info">
-\* Required when that adapter is configured. At least one adapter must be present.
-
-For Slack OAuth, `clientId` and `clientSecret` must both be provided together.
+At least one `catalog` row with `type: "chat"`, `enabled: true`, and a supported `install_model` must be present — otherwise no adapter activates and the plugin's health check reports unhealthy. Per-Platform credentials come from env vars (see [Environment Variables](#environment-variables)); Slack additionally requires both `SLACK_CLIENT_ID` and `SLACK_CLIENT_SECRET` together for the OAuth install path.
 </Callout>
 
 ## State Adapters
@@ -197,7 +171,7 @@ The state backend controls how thread subscriptions, conversation history, and d
 
 ```typescript
 chatPlugin({
-  adapters: { slack: { /* ... */ } },
+  // catalog rows + env-var credentials declared at the host (see Configuration above).
   state: {
     backend: "pg",
     tablePrefix: "chat_", // default — customize to avoid conflicts
@@ -240,7 +214,7 @@ By default, the bridge registers `/atlas` as the slash command. To use a custom 
 
 ```typescript
 chatPlugin({
-  adapters: { slack: { /* ... */ } },
+  // catalog rows + env-var credentials declared at the host (see Configuration above).
   slashCommandName: "/data-query",
   executeQuery: myQueryFunction,
 })
@@ -284,7 +258,7 @@ On platforms without file upload support, a "View full results" link to the Atla
 
 ```typescript
 chatPlugin({
-  adapters: { /* ... */ },
+  // catalog rows + env-var credentials declared at the host (see Configuration above).
   executeQuery: myQueryFunction,
   fileUpload: {
     autoAttachThreshold: 50,        // attach CSV when > 50 rows (default: 20)
@@ -358,7 +332,7 @@ Reactions are enabled by default. To disable or customize:
 import { emoji } from "chat";
 
 chatPlugin({
-  adapters: { slack: { /* ... */ } },
+  // catalog rows + env-var credentials declared at the host (see Configuration above).
   executeQuery: myQueryFunction,
   reactions: {
     enabled: true, // default — set to false to disable
@@ -387,7 +361,7 @@ Set `reactions.enabled` to `false` to skip all reaction lifecycle calls:
 
 ```typescript
 chatPlugin({
-  adapters: { /* ... */ },
+  // catalog rows + env-var credentials declared at the host (see Configuration above).
   executeQuery: myQueryFunction,
   reactions: { enabled: false },
 })
@@ -415,10 +389,7 @@ import { chatPlugin } from "@useatlas/chat";
 import type { StreamChunk } from "@useatlas/chat";
 
 chatPlugin({
-  adapters: {
-    slack: { botToken: "xoxb-...", signingSecret: "..." },
-    teams: { appId: "...", appPassword: "..." },
-  },
+  // catalog rows + env-var credentials declared at the host (see Configuration above).
   executeQuery: myQueryFunction, // always required — used when streaming is disabled
   streaming: {
     enabled: true,        // default: true
@@ -562,7 +533,7 @@ Configure via the `ephemeral` option:
 
 ```typescript
 chatPlugin({
-  adapters: { slack: { /* ... */ } },
+  // catalog rows + env-var credentials declared at the host (see Configuration above).
   executeQuery,
   ephemeral: {
     // Default: true — errors shown only to requesting user
@@ -605,14 +576,23 @@ if (result) {
 import { slackPlugin } from "@useatlas/slack";
 slackPlugin({ signingSecret: "...", botToken: "xoxb-...", executeQuery })
 
-// After:
+// After (1.5.2+):
+import { defineConfig } from "@atlas/api/lib/config";
 import { chatPlugin } from "@useatlas/chat";
-chatPlugin({
-  adapters: {
-    slack: { botToken: "xoxb-...", signingSecret: "..." },
-  },
-  executeQuery,
-})
+
+export default defineConfig({
+  catalog: [
+    { slug: "slack", type: "chat", install_model: "oauth",
+      enabled: true, saas_eligible: true },
+  ],
+  plugins: [
+    chatPlugin({ executeQuery }),
+  ],
+});
+
+// env vars:
+//   SLACK_CLIENT_ID, SLACK_CLIENT_SECRET, SLACK_SIGNING_SECRET, SLACK_ENCRYPTION_KEY
+//   SLACK_BOT_TOKEN (optional — single-workspace only)
 ```
 
 Update your Slack app webhook URLs:
@@ -632,14 +612,22 @@ Update your Slack app webhook URLs:
 import { teamsPlugin } from "@useatlas/teams";
 teamsPlugin({ appId: "...", appPassword: "...", executeQuery })
 
-// After:
+// After (1.5.2+):
+import { defineConfig } from "@atlas/api/lib/config";
 import { chatPlugin } from "@useatlas/chat";
-chatPlugin({
-  adapters: {
-    teams: { appId: "...", appPassword: "..." },
-  },
-  executeQuery,
-})
+
+export default defineConfig({
+  catalog: [
+    { slug: "teams", type: "chat", install_model: "static-bot",
+      enabled: true, saas_eligible: true },
+  ],
+  plugins: [
+    chatPlugin({ executeQuery }),
+  ],
+});
+
+// env vars:
+//   TEAMS_APP_ID, TEAMS_APP_PASSWORD, TEAMS_TENANT_ID (optional)
 ```
 
 Update the **messaging endpoint** in your Azure Bot Configuration:

--- a/apps/docs/content/docs/plugins/interactions/slack.mdx
+++ b/apps/docs/content/docs/plugins/interactions/slack.mdx
@@ -6,7 +6,14 @@ description: Slack is now wired through the @useatlas/chat plugin. This page red
 import { Callout } from "fumadocs-ui/components/callout";
 
 <Callout type="warn" title="Moved — @useatlas/slack is no longer published">
-The standalone `@useatlas/slack` package was removed in Atlas 1.5.2 ([#2650](https://github.com/AtlasDevHQ/atlas/pull/2650)). Slack is now a first-class adapter inside the unified **[Chat SDK bridge plugin (`@useatlas/chat`)](/plugins/interactions/chat)** — same routes, same env vars, plus multi-platform support (Teams, Discord, gchat, Telegram, GitHub, Linear, WhatsApp) and built-in state management.
+The standalone `@useatlas/slack` package was removed in Atlas 1.5.2 ([#2650](https://github.com/AtlasDevHQ/atlas/pull/2650)). Slack is now a first-class adapter inside the unified **[Chat SDK bridge plugin (`@useatlas/chat`)](/plugins/interactions/chat)**, which adds multi-platform support (Teams, Discord, gchat, Telegram, GitHub, Linear, WhatsApp) and built-in state management.
+
+**Routes and OAuth endpoints changed** — update your Slack app configuration:
+
+- Slash commands, events, and interactions → consolidated under `/api/plugins/chat-interaction/webhooks/slack` (was `/commands`, `/events`, `/interactions`)
+- OAuth install / callback → `/api/v1/integrations/slack/{install,callback}` (was `/install`, `/callback`)
+
+The Slack-side env vars (`SLACK_CLIENT_ID`, `SLACK_CLIENT_SECRET`, `SLACK_SIGNING_SECRET`, `SLACK_BOT_TOKEN`) carry over; `SLACK_ENCRYPTION_KEY` is now required to encrypt per-workspace bot tokens at rest in `chat_cache`.
 </Callout>
 
 ## Where things live now

--- a/apps/docs/content/docs/plugins/interactions/slack.mdx
+++ b/apps/docs/content/docs/plugins/interactions/slack.mdx
@@ -1,132 +1,25 @@
 ---
-title: Slack Bot
-description: Integrate Slack as a full interaction surface for Atlas with slash commands, threads, and OAuth.
+title: Slack Bot (moved)
+description: Slack is now wired through the @useatlas/chat plugin. This page redirects to the canonical chat-plugin docs.
 ---
 
 import { Callout } from "fumadocs-ui/components/callout";
 
-<Callout type="warn">
-**`@useatlas/slack` is deprecated.** Use [`@useatlas/chat`](/plugins/interactions/chat) with the Slack adapter instead.
-The Chat SDK bridge plugin provides the same Slack functionality plus multi-platform support (Teams, Discord, etc.) and built-in state management. See the [migration guide](#migrating-to-useatlas-chat) below.
+<Callout type="warn" title="Moved — @useatlas/slack is no longer published">
+The standalone `@useatlas/slack` package was removed in Atlas 1.5.2 ([#2650](https://github.com/AtlasDevHQ/atlas/pull/2650)). Slack is now a first-class adapter inside the unified **[Chat SDK bridge plugin (`@useatlas/chat`)](/plugins/interactions/chat)** — same routes, same env vars, plus multi-platform support (Teams, Discord, gchat, Telegram, GitHub, Linear, WhatsApp) and built-in state management.
 </Callout>
 
-The Slack interaction plugin integrates Slack as a full interaction surface for Atlas. Users can ask questions via slash commands (`/atlas`), continue conversations in threads, approve or deny actions via Block Kit buttons, and install the bot across multiple workspaces via OAuth.
+## Where things live now
 
-This plugin uses the `routes()` interface to mount Hono routes directly into the Atlas API server, and receives runtime dependencies (agent execution, conversation persistence, action approval) via config callbacks rather than importing from `@atlas/api`.
+| Topic | Page |
+|-------|------|
+| Wiring Slack via the chat plugin | [`@useatlas/chat` — Configuration](/plugins/interactions/chat#configuration) |
+| Catalog entry shape | [`@useatlas/chat` — Catalog entry fields](/plugins/interactions/chat#catalog-entry-fields) |
+| Slack-specific env vars | [`@useatlas/chat` — Environment Variables](/plugins/interactions/chat#environment-variables) |
+| Mounted webhook + OAuth routes | [`@useatlas/chat` — Mounted Routes](/plugins/interactions/chat#mounted-routes) |
+| Migration from pre-1.5.2 | [`@useatlas/chat` — Migrating from @useatlas/slack](/plugins/interactions/chat#migrating-from-useatlas-slack) |
 
-## Installation
-
-> **Removed.** The standalone `@useatlas/slack` package no longer ships — Slack support is built into `@useatlas/chat` (see the migration section below). The historical config below is preserved for migrators still on pre-1.5.2.
-
-```bash
-# Historical (pre-1.5.2) — package no longer published:
-# bun add @useatlas/slack
-```
-
-### Prerequisites
-
-- A Slack app configured with slash commands and Events API subscriptions
-- Either a bot token (single-workspace) or OAuth credentials (multi-workspace)
-
-## Configuration
-
-```typescript
-import { defineConfig } from "@atlas/api/lib/config";
-import { executeAgentQuery } from "@atlas/api/lib/agent-query";
-import { slackPlugin } from "@useatlas/slack";
-
-export default defineConfig({
-  plugins: [
-    slackPlugin({
-      signingSecret: process.env.SLACK_SIGNING_SECRET!,
-      botToken: process.env.SLACK_BOT_TOKEN,
-      executeQuery: executeAgentQuery,
-    }),
-  ],
-});
-```
-
-For multi-workspace OAuth with conversation persistence and action approval:
-
-```typescript
-export default defineConfig({
-  plugins: [
-    slackPlugin({
-      signingSecret: process.env.SLACK_SIGNING_SECRET!,
-      clientId: process.env.SLACK_CLIENT_ID!,
-      clientSecret: process.env.SLACK_CLIENT_SECRET!,
-      executeQuery: executeAgentQuery,
-      conversations: myConversationCallbacks,
-      actions: myActionCallbacks,
-    }),
-  ],
-});
-```
-
-### Options
-
-| Option | Type | Required | Description |
-|--------|------|----------|-------------|
-| `signingSecret` | `string` | Yes | Slack signing secret for request verification. Found in your Slack app's Basic Information page. |
-| `botToken` | `string` | Conditional | Bot token for single-workspace mode (`xoxb-...`). Required if `clientId`/`clientSecret` are not set. |
-| `clientId` | `string` | Conditional | Client ID for multi-workspace OAuth. Required (with `clientSecret`) if `botToken` is not set. |
-| `clientSecret` | `string` | Conditional | Client secret for multi-workspace OAuth. Required (with `clientId`) if `botToken` is not set. |
-| `executeQuery` | `function` | Yes | Callback that runs the Atlas agent on a question and returns structured results. |
-| `checkRateLimit` | `function` | No | Optional rate limiting callback. |
-| `conversations` | `ConversationCallbacks` | No | Optional conversation persistence callbacks (`create`, `addMessage`, `get`, `generateTitle`). |
-| `actions` | `ActionCallbacks` | No | Optional action framework callbacks (`approve`, `deny`, `get`). |
-| `scrubError` | `function` | No | Optional error scrubbing callback to strip sensitive information from error messages. |
-
-<Callout type="warn">
-Either `botToken` (single-workspace) or both `clientId` and `clientSecret` (multi-workspace OAuth) must be provided. The config schema validates this constraint at factory call time.
-</Callout>
-
-## Mounted Routes
-
-The plugin mounts the following Hono routes under the plugin's base path:
-
-| Method | Path | Description |
-|--------|------|-------------|
-| `POST` | `/commands` | Slash command handler (`/atlas`) |
-| `POST` | `/events` | Slack Events API (thread follow-ups, `url_verification`) |
-| `POST` | `/interactions` | Block Kit action buttons (approve/deny actions) |
-| `GET` | `/install` | OAuth install redirect (multi-workspace mode) |
-| `GET` | `/callback` | OAuth callback (multi-workspace mode) |
-
-## Database Schema
-
-The Slack plugin uses two Atlas internal-database tables:
-
-- **`chat_cache`** -- Created by Atlas migration `0085_consolidate_slack_installations.sql`. Rows keyed `slack:installation:<teamId>` hold per-workspace OAuth installs (`botToken`, `botUserId`, `teamName`, `orgId`). The same store backs the chat-plugin's multi-workspace adapter — there is no separate `slack_installations` table post-#2634. Bot tokens are encrypted at rest via AES-256-GCM when `SLACK_ENCRYPTION_KEY` is set.
-- **`slack_threads`** -- Created by Atlas migration `0000_baseline.sql`. Maps Slack threads to Atlas conversations (`channel_id`, `thread_ts`, `conversation_id`).
-
-<Callout type="info">
-The `executeQuery` callback is the bridge between the Slack plugin and the Atlas agent. It receives the user's question and optional prior messages (for threaded conversations), runs the agent, and returns structured results that the plugin formats into Block Kit messages.
-</Callout>
-
-See the [Slack guide](/guides/slack) for full Slack app setup instructions.
-
-## Troubleshooting
-
-### Signature verification failures
-
-Ensure `SLACK_SIGNING_SECRET` matches the signing secret from your Slack app's Basic Information page. Clock skew between your server and Slack can also cause verification failures.
-
-### Bot not responding to slash commands
-
-Verify the slash command URL in your Slack app configuration points to your Atlas API's `/commands` endpoint. For local development, use a tunnel service like ngrok.
-
-### OAuth callback errors
-
-For multi-workspace OAuth, the callback URL must be registered in your Slack app's OAuth & Permissions page. Ensure it matches the route where the plugin is mounted.
-
-## Migrating to @useatlas/chat
-
-Replace `@useatlas/slack` with the Chat SDK bridge plugin. As of Atlas
-1.5.2, adapter activation is **catalog-driven** — declare Slack in
-`atlas.config.ts:catalog`, set per-Platform credentials in env vars,
-and pass the chat-type subset through to `chatPlugin`. See the
-[Plugin Catalog](/deployment/plugin-catalog) page for the data model.
+## TL;DR migration
 
 ```typescript
 // Before (pre-1.5.2):
@@ -143,25 +36,12 @@ export default defineConfig({
       enabled: true, saas_eligible: true },
   ],
   plugins: [
-    chatPlugin({
-      catalog: [
-        { slug: "slack", type: "chat", install_model: "oauth",
-          enabled: true, saas_eligible: true },
-      ],
-      executeQuery,
-    }),
+    chatPlugin({ executeQuery }),
   ],
 });
 
-// env vars:
-//   SLACK_CLIENT_ID, SLACK_CLIENT_SECRET, SLACK_SIGNING_SECRET, SLACK_ENCRYPTION_KEY
-//   SLACK_BOT_TOKEN (optional — single-workspace only)
+// env vars: SLACK_CLIENT_ID, SLACK_CLIENT_SECRET, SLACK_SIGNING_SECRET,
+//           SLACK_ENCRYPTION_KEY, SLACK_BOT_TOKEN (optional)
 ```
 
-| Feature | @useatlas/slack | @useatlas/chat |
-|---------|----------------|----------------|
-| Webhook | `/commands`, `/events`, `/interactions` | `/webhooks/slack` |
-| OAuth | `/install`, `/callback` | `/api/v1/integrations/slack/install`, `/api/v1/integrations/slack/callback` |
-| Block Kit | Hand-rolled builders | Automatic via Chat SDK |
-| State | Custom DB tables | State adapter (memory/PG/Redis) |
-| Multi-platform | Slack only | Slack, Teams, Discord, etc. |
+See the [chat-plugin × Atlas contract](https://github.com/AtlasDevHQ/atlas/blob/main/docs/architecture/chat-plugin-atlas-contract.md) for the canonical boundary between `@useatlas/chat`, `@chat-adapter/*`, and the Atlas host.

--- a/apps/docs/content/docs/reference/cli.mdx
+++ b/apps/docs/content/docs/reference/cli.mdx
@@ -1,6 +1,6 @@
 ---
 title: CLI Reference
-description: Complete reference for the Atlas CLI — init, diff, migrate, import, export, migrate-import, index, learn, improve, query, doctor, validate, mcp, eval, canonical-eval, smoke, completions, and more.
+description: Complete reference for the Atlas CLI — init, diff, migrate, import, export, migrate-import, index, learn, improve, query, doctor, validate, mcp, eval, canonical-eval, smoke, completions, and operator subcommands (proactive / seed / ops).
 ---
 
 import { Callout } from "fumadocs-ui/components/callout";
@@ -751,6 +751,90 @@ echo 'eval "$(atlas completions zsh)"' >> ~/.zshrc
 # Install fish completions (saved to file, auto-loaded by fish)
 bun run atlas -- completions fish > ~/.config/fish/completions/atlas.fish
 ```
+
+---
+
+## Operator subcommands
+
+Operator-only tools for tenant-data ops, promoted from the gitignored `internal/` directory in [#2635](https://github.com/AtlasDevHQ/atlas/pull/2635) so they're type-checked, unit-tested, and discoverable. All subcommands target the tenant Postgres at `ATLAS_TEAM_PG_URL`, falling back to `DATABASE_URL` when unset. `--workspace` accepts either a literal `org_*` id or an `organization.slug`.
+
+The CLAUDE.md "Operator subcommands (destructive)" block is the source of truth for these — keep this page and CLAUDE.md aligned when adding subcommands.
+
+### proactive enable
+
+Turn proactive chat on for a workspace and opt one or more channels into the allowlist. Idempotent — re-running upserts `workspace_proactive_config` plus every channel row.
+
+```bash
+bun run atlas -- proactive enable --workspace <id|slug> --channels <c1,c2,...>
+```
+
+| Flag | Description |
+|------|-------------|
+| `--workspace <id\|slug>` | Required. Org id (`org_*`) or `organization.slug`. |
+| `--channels <c1,c2,...>` | Required. Comma-separated channel ids (Slack `C…` etc.) to allow. |
+
+### proactive disable
+
+Flip the workspace toggle off. Channel rows are preserved so a later `enable` doesn't lose channel configs.
+
+```bash
+bun run atlas -- proactive disable --workspace <id|slug>
+```
+
+| Flag | Description |
+|------|-------------|
+| `--workspace <id\|slug>` | Required. Same shape as `proactive enable`. |
+
+### seed prompts
+
+Seed a prompt-library collection + items from a YAML file. Replaces any prior collection with the same `(org_id, name)` and pins the org's demo industry so the starter-prompt resolver matches.
+
+```bash
+bun run atlas -- seed prompts --workspace <id|slug> --library ./prompts/library.yml
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--workspace <id\|slug>` | — | Required. |
+| `--library <path>` | `./prompts/library.yml` | YAML file with `collection: { name, industry, description }` and `categories: [{ name, prompts: [...] }]`. |
+
+### seed workspace
+
+Provision a connection group, member connections, and the accompanying semantic entities for that group. The `--connections` argument is a comma-separated list of `id=urlEnv:type[:primary]` entries — exactly one entry must carry `:primary`. Connection URLs are read from `process.env[urlEnv]` and encrypted at rest with the active `ATLAS_ENCRYPTION_KEYS` version.
+
+```bash
+bun run atlas -- seed workspace \
+  --workspace <id|slug> \
+  --group prod \
+  --connections us-prod=US_DB_URL:postgres:primary,eu-prod=EU_DB_URL:postgres
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--workspace <id\|slug>` | — | Required. |
+| `--group <name>` | — | Required. Human-readable group name. |
+| `--group-id <id>` | `g_<group>` | Override the stable group id. |
+| `--connections <list>` | — | Required. `id=urlEnv:type[:primary],...`. Exactly one `:primary` per group. |
+| `--semantic <path>` | — | Optional root with `entities/`, `metrics/`, `glossary/` subdirs to seed alongside the group. |
+
+### ops wipe
+
+<Callout type="warn" title="Destructive — double-confirm gate">
+`ops wipe` `TRUNCATE`s every public table in the tenant DB (excluding migration bookkeeping) with `RESTART IDENTITY CASCADE`. It requires **both** `ATLAS_WIPE_OK=1` in the env **and** `--confirm` on the command line. No backup is taken — wrap the call with `pg_dump` yourself if you might want the data back. Operates on one DB per invocation by design: wiping multiple regional clusters means running it once per cluster.
+</Callout>
+
+```bash
+ATLAS_WIPE_OK=1 bun run atlas -- ops wipe --confirm [--database-url <url>]
+```
+
+| Flag | Description |
+|------|-------------|
+| `--confirm` | Required. Acknowledges the second half of the double-confirm gate. |
+| `--database-url <url>` | Optional. Explicit URL wins over `ATLAS_TEAM_PG_URL` / `DATABASE_URL`. |
+
+**Exit codes:** `0` = tables truncated; `1` = gate failed or wipe errored; `2` = zero tables matched the exclusion query (almost always a wrong-DB typo — nothing was truncated).
+
+The exclusion list (`__atlas_migrations`, `region_migrations`) lives next to the SQL in `packages/cli/src/commands/ops.ts:WIPE_EXCLUDED_TABLES`.
 
 ---
 

--- a/apps/docs/content/docs/reference/react.mdx
+++ b/apps/docs/content/docs/reference/react.mdx
@@ -471,6 +471,85 @@ const AUTH_MODES: readonly ["none", "simple-key", "managed", "byot"];
 
 ---
 
+## useMcpConnect
+
+Wraps the SDK's `beginConnect` + `completeConnect` with a popup-or-redirect lifecycle so React embedders can drop a "Connect your AI agent" button into their app without owning OAuth bookkeeping. Exported from the root entry point (`@useatlas/react`), not the `/hooks` subpath.
+
+```tsx
+"use client";
+
+import { useMcpConnect } from "@useatlas/react";
+import { buildConfig } from "@useatlas/sdk";
+
+export function ConnectAgentButton() {
+  const { connect, status, error, accessToken, workspaceId } = useMcpConnect({
+    apiUrl: "https://mcp.useatlas.dev",
+    clientName: "My SaaS — Atlas",
+    redirectUri: `${window.location.origin}/oauth/callback`,
+    mode: "popup",
+  });
+
+  if (accessToken && workspaceId) {
+    const config = buildConfig({
+      client: "claude-desktop",
+      apiUrl: "https://mcp.useatlas.dev",
+      accessToken,
+      workspaceId,
+    });
+    return <pre>{JSON.stringify(config, null, 2)}</pre>;
+  }
+
+  return (
+    <>
+      <button onClick={() => void connect()} disabled={status !== "idle"}>
+        Connect your AI agent
+      </button>
+      {error && <p style={{ color: "crimson" }}>{error.message}</p>}
+    </>
+  );
+}
+```
+
+### useMcpConnect options
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `apiUrl` | `string` | Yes | — | Atlas API base (e.g. `https://mcp.useatlas.dev`) |
+| `clientName` | `string` | Yes | — | Human-readable name registered via DCR |
+| `redirectUri` | `string` | Yes | — | Where the OAuth server should redirect the user |
+| `scopes` | `ReadonlyArray<string>` | No | `["mcp:read", "offline_access"]` | OAuth scopes to request |
+| `mode` | `"popup" \| "redirect"` | No | `"popup"` | Flow mode (see below) |
+| `storageId` | `string` | No | `redirectUri` | Override the `sessionStorage` key suffix when running multiple flows on the same origin |
+
+### Flow modes
+
+- **`mode: "popup"`** — `connect()` opens a centered popup at the authorize URL. The `redirectUri` must be a page hosted by the embedder that calls `window.opener.postMessage({ type: "atlas-mcp-callback", code, state }, "<your-origin>")`. The hook listens for that message, runs the token exchange, and exposes the resulting `accessToken` + `workspaceId`. The popup closes itself on receipt.
+- **`mode: "redirect"`** — `connect()` redirects the current window to the authorize URL. On the callback page, mount the same hook with the same options — when it sees `?code` + `?state` in the URL it reads the persisted state from `sessionStorage` and completes the exchange automatically.
+
+### useMcpConnect return value
+
+The return type is **discriminated by `status`** so consumers don't need to write `if (accessToken)` guards — the type already proves the token fields are non-null when `status === "success"`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `status` | `UseMcpConnectStatus` | `"idle"`, `"starting"`, `"awaiting_callback"`, `"exchanging"`, `"success"`, or `"error"` |
+| `connect` | `() => Promise<void>` | Kick off the OAuth flow (opens popup or redirects) |
+| `reset` | `() => void` | Clear all state — returns to `"idle"` and wipes the persisted sessionStorage entry |
+| `accessToken` | `string \| null` | Bearer token. Non-null only when `status === "success"` |
+| `refreshToken` | `string \| null` | Refresh token. Non-null only when `status === "success"` and the issuer returned one |
+| `workspaceId` | `string \| null` | Singular workspace claim from the token. Non-null on `"success"` |
+| `workspaces` | `ReadonlyArray<string> \| null` | Plural `workspace_ids` claim. Use `workspaces.length > 1` to gate a post-onboarding workspace picker |
+| `expiresAt` | `number \| null` | Unix-seconds expiry. Non-null on `"success"` |
+| `error` | `AtlasMcpError \| Error \| null` | Set when `status === "error"` |
+
+### What survives across the round-trip
+
+In both modes the hook persists `state`, `codeVerifier`, `clientId`, `tokenEndpoint`, and `issuer` under a single `sessionStorage` key (`atlas-mcp-connect:<storageId>`). `storageId` defaults to the `redirectUri`; pass an explicit `storageId` if you run multiple onboarding flows on the same origin so they don't trample each other.
+
+See the full embedded-onboarding walkthrough at [MCP onboarding (SDK)](/sdk/mcp), including a worked Next.js example with the popup callback page that posts back to the opener.
+
+---
+
 ## useAtlasTheme
 
 Manages light/dark/system theme mode with localStorage persistence.
@@ -1136,6 +1215,7 @@ The `AtlasChat` component uses the same hooks internally — you can start with 
 
 - [Embedding Widget](/guides/embedding-widget) — Script-tag widget embedding (no React required)
 - [SDK Reference](/reference/sdk) — Typed TypeScript client for server-side and headless usage
+- [MCP onboarding (SDK)](/sdk/mcp) — Full embedded-onboarding walkthrough that the [`useMcpConnect`](#usemcpconnect) hook wraps
 - [Error Codes](/reference/error-codes) — Full catalog of `ChatErrorCode` and `ClientErrorCode` values
 - [Authentication](/deployment/authentication) — Auth mode setup (affects `useAtlasAuth` behavior)
 - [Choosing an Integration](/guides/choosing-an-integration) — Compare widget, hooks, SDK, and REST API

--- a/apps/docs/content/docs/reference/react.mdx
+++ b/apps/docs/content/docs/reference/react.mdx
@@ -3,6 +3,8 @@ title: React Hooks Reference
 description: Headless React hooks for building custom Atlas chat UIs.
 ---
 
+import { Callout } from "fumadocs-ui/components/callout";
+
 The `@useatlas/react` package provides headless React hooks and a pre-built chat component for embedding Atlas into React applications. Use the hooks to build a fully custom UI, or drop in the `AtlasChat` component for a ready-made experience.
 
 ## Installation
@@ -478,14 +480,26 @@ Wraps the SDK's `beginConnect` + `completeConnect` with a popup-or-redirect life
 ```tsx
 "use client";
 
+import { useEffect, useState } from "react";
 import { useMcpConnect } from "@useatlas/react";
 import { buildConfig } from "@useatlas/sdk";
 
 export function ConnectAgentButton() {
+  // `useMcpConnect` runs in the browser, but the surrounding component
+  // can be rendered server-side under Next.js / RSC. Resolve the
+  // `redirectUri` from `window.location.origin` inside an effect so the
+  // first render doesn't crash with `window is not defined`.
+  const [redirectUri, setRedirectUri] = useState<string | null>(null);
+  useEffect(() => {
+    setRedirectUri(`${window.location.origin}/oauth/callback`);
+  }, []);
+
   const { connect, status, error, accessToken, workspaceId } = useMcpConnect({
     apiUrl: "https://mcp.useatlas.dev",
     clientName: "My SaaS — Atlas",
-    redirectUri: `${window.location.origin}/oauth/callback`,
+    // Pass a stable placeholder until the effect resolves the real origin.
+    // The button below is disabled while `redirectUri` is null.
+    redirectUri: redirectUri ?? "https://placeholder.invalid/oauth/callback",
     mode: "popup",
   });
 
@@ -501,7 +515,10 @@ export function ConnectAgentButton() {
 
   return (
     <>
-      <button onClick={() => void connect()} disabled={status !== "idle"}>
+      <button
+        onClick={() => void connect()}
+        disabled={status !== "idle" || redirectUri === null}
+      >
         Connect your AI agent
       </button>
       {error && <p style={{ color: "crimson" }}>{error.message}</p>}
@@ -509,6 +526,10 @@ export function ConnectAgentButton() {
   );
 }
 ```
+
+<Callout type="info">
+The example resolves `redirectUri` inside `useEffect` because `window` is undefined during server-side render (Next.js RSC, Remix loaders, etc.). If your component tree is browser-only — e.g. the page is statically exported and the button only mounts on the client — you can drop the effect and pass a template literal off `window.location.origin` directly.
+</Callout>
 
 ### useMcpConnect options
 


### PR DESCRIPTION
Bundle of five small 1.5.3 docs gaps closed together. Docs-only sweep — no source changes.

Closes #2766, closes #2769, closes #2771, closes #2773, closes #2775.

## Summary

- **#2766 — CLI operator subcommands.** New `## Operator subcommands` section in `apps/docs/content/docs/reference/cli.mdx` covering `proactive enable/disable`, `seed prompts`, `seed workspace`, and `ops wipe`. `ops wipe` leads with the `ATLAS_WIPE_OK=1 + --confirm` double-gate as a `Callout`. Frontmatter description updated. Sourced from `packages/cli/src/commands/{proactive,seed,ops}.ts` + the CLAUDE.md "Operator subcommands (destructive)" block — the two stay aligned.
- **#2769 — Chat plugin: removed-field cleanup.** `apps/docs/content/docs/plugins/interactions/chat.mdx` no longer documents the removed `adapters:` config field. Replaced with the catalog-driven shape per [#2650](https://github.com/AtlasDevHQ/atlas/pull/2650): `catalog: [{ slug, type: "chat", install_model, enabled, saas_eligible }]` + per-Platform env-var credentials, with `chatPlugin()` itself taking no credentials. Configuration examples, options table, migration snippets, and inline option examples (state / streaming / fileUpload / reactions / ephemeral) all updated.
- **#2771 — Slack page redirect.** `apps/docs/content/docs/plugins/interactions/slack.mdx` rewritten as a short "moved to" stub pointing at the canonical chat-plugin docs — the `@useatlas/slack` package was removed in 1.5.2 and the page now reflects that, with a TL;DR migration snippet.
- **#2773 — Two new pages for undocumented published plugins.**
  - `apps/docs/content/docs/plugins/datasources/obsidian-reader.mdx`
  - `apps/docs/content/docs/plugins/actions/webhook-action.mdx`

  Both registered in the respective `meta.json` nav and the index `Cards` grid. Sourced from `plugins/{obsidian-reader,webhook-action}/src/`.
- **#2775 — `useMcpConnect` docs.** Added a dedicated section to `apps/docs/content/docs/reference/react.mdx` — options table, popup vs redirect flow, status-discriminated return shape, sessionStorage round-trip, and a cross-link to the SDK MCP guide. The hook was exported but never documented on the React reference page.

## Incidental finding

Filed as #2815 — the per-platform interaction pages (discord / gchat / github / linear / teams / telegram / whatsapp) still pass the removed `adapters: { … }` shape to `chatPlugin()`. Mechanical replacement using the now-canonical `chat.mdx` as the template. Kept out of this PR per the prompt's incidental-finding rule.

No chat-plugin × Atlas contract changes — `docs/architecture/chat-plugin-atlas-contract.md` does not need an update here.

## Test plan

- [x] Docs site builds: `cd apps/docs && bun run build` → 1802 static pages, exit 0
- [x] `bun run lint` (ESLint) — 0 issues
- [x] `bun run type` (tsgo + workspace) — 0 issues
- [x] `bun run -- syncpack lint` — no issues found
- [x] `bash scripts/check-template-drift.sh` — 678 files verified
- [x] `bash scripts/check-schema-drift.sh` — 77 tables verified
- [x] `bash scripts/check-ee-imports.sh` — only the one allowed boot-time import
- [x] `bun run test` — full suite (one pre-existing flake in `plugins/mcp/__tests__/init/hosted.test.ts:1219` reproduces on `origin/main` head; unrelated to this docs-only change)
- [ ] After merge: skim the rendered pages on the live docs and confirm the operator-subcommands section + the two new plugin pages render with their tables intact

https://claude.ai/code/session_01DbAfkP1eMXkLk9QyLWLXA7

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbAfkP1eMXkLk9QyLWLXA7)_