### PR TITLE
feat(api,plugins,docs): #2753 — WhatsApp install (Meta Business API, phone_number_id routing)

### DIFF
--- a/apps/docs/content/docs/integrations/whatsapp.mdx
+++ b/apps/docs/content/docs/integrations/whatsapp.mdx
@@ -1,0 +1,318 @@
+---
+title: WhatsApp
+description: Connect Atlas to WhatsApp. The operator wires a single shared Meta Business / WhatsApp Business Cloud API account; each workspace points Atlas at one WhatsApp Business phone number via its Meta phone_number_id.
+---
+
+import { Callout } from "fumadocs-ui/components/callout";
+
+Atlas's WhatsApp integration follows the **static-bot** install model:
+one operator-owned Meta Business / WhatsApp Business Cloud API account
+serves every workspace in your deploy, and each workspace admin points
+Atlas at one WhatsApp Business phone number by pasting Meta's
+`phone_number_id` (a numeric routing id, **not** the human-readable
+phone number) into the install modal. The Meta access token itself
+authenticates once at deploy time using the operator's System User
+credentials; per-workspace routing is the only thing a customer admin
+configures.
+
+This is in contrast to Slack, where each workspace runs its own OAuth
+dance and gets its own bot token. WhatsApp's model is operator-shared
+because Meta's Cloud API issues a single System User access token per
+WhatsApp Business Account that can act on every phone number shared
+into it — the operator-owned token is sufficient to send and receive
+on every customer's number, so adding a new tenant is just a
+configuration change in the operator's Meta Business Suite, not a
+fresh OAuth dance.
+
+<Callout type="warn" title="Plan tier">
+  WhatsApp installs are gated to the **Business** plan tier. Meta
+  charges the operator per-conversation for both user-initiated (24h
+  customer-service window) and template-initiated conversations — the
+  economics only work for workspaces on the highest tier. Lower-tier
+  workspaces see the upsell state on the WhatsApp catalog card instead
+  of the connect CTA.
+</Callout>
+
+## Operator setup (one-time, per deploy)
+
+These steps wire your deploy to a Meta Business / WhatsApp Business
+Cloud API account. Self-hosted operators run them once during initial
+deployment; Atlas Cloud customers don't — the Atlas Cloud team has
+already done this on the hosted regions.
+
+### 1. Create a Meta App with WhatsApp product
+
+In the [Meta for Developers console](https://developers.facebook.com),
+create a new **Business**-type app. During creation:
+
+- Set **App Type** to **Business**.
+- Choose your **Meta Business Account** as the owning Business
+  Account. This is the account whose System User token will act on
+  every customer's phone number — pick the operator-owned one, not a
+  customer's.
+- From the app dashboard, add the **WhatsApp** product. Meta walks you
+  through configuring a sandbox phone number; the production
+  WhatsApp Business phone numbers come in step 3.
+- From the app dashboard, copy the **App ID** → `META_BUSINESS_APP_ID`.
+- From **App Settings → Basic**, copy the **App Secret** →
+  `WHATSAPP_APP_SECRET`. Keep this secret — anyone with it can verify
+  webhook deliveries pretending to be Meta.
+
+### 2. Mint a System User access token
+
+In the [Meta Business Suite](https://business.facebook.com), open
+**Business Settings → Users → System Users** and create a new System
+User with **Admin** access. Then:
+
+- **Assign assets**: grant the System User access to the WhatsApp
+  Business Account that owns (or will own) the customer phone numbers.
+  Set the role to **Manage**.
+- **Generate token**: click **Generate New Token** and pick the app
+  you created in step 1. In the permissions panel select both
+  `whatsapp_business_management` (for the phone-number reachability
+  check Atlas runs at install time) and `whatsapp_business_messaging`
+  (for the chat adapter's outbound sends).
+- **Expiration**: choose **Never** — this is an operator-shared,
+  long-lived token. Rotating it requires updating
+  `META_BUSINESS_ACCESS_TOKEN` on every API service in your deploy.
+- Copy the generated token → `META_BUSINESS_ACCESS_TOKEN`. This is
+  the token Atlas uses to verify customer-supplied phone_number_ids
+  at install time and to send messages on behalf of every customer.
+
+### 3. Set the env vars
+
+Set the following on every Atlas API service in your deploy:
+
+```bash
+META_BUSINESS_ACCESS_TOKEN=<System User access token from step 2>
+META_BUSINESS_APP_ID=<Meta App ID from step 1>
+WHATSAPP_APP_SECRET=<App Secret from step 1>
+WHATSAPP_VERIFY_TOKEN=<a random string — invent one, keep it secret>
+```
+
+`META_BUSINESS_ACCESS_TOKEN` + `META_BUSINESS_APP_ID` are required by
+the install handler (Atlas refuses to register the install path
+without them); `WHATSAPP_APP_SECRET` + `WHATSAPP_VERIFY_TOKEN` are
+required by the chat adapter (Atlas refuses to wire the inbound
+webhook without them). The two pairs are gated independently so a
+half-wired deploy fails in an actionable way — the install path may
+work without the adapter half, but inbound messages won't route.
+
+For single-tenant deploys (where one operator and one customer are the
+same party, and there's only one WhatsApp number to send from), you
+can additionally set:
+
+```bash
+WHATSAPP_DEFAULT_PHONE_NUMBER_ID=<the single tenant's phone_number_id>
+```
+
+The chat adapter uses this as the default sender when no per-workspace
+routing applies. MultiTenant deploys leave it empty — the adapter
+pulls the phone_number_id from the inbound webhook envelope's
+`metadata.phone_number_id` field, and Atlas's host `executeQuery`
+resolves the right workspace by matching it against the
+`workspace_plugins.config` rows.
+
+### 4. Configure the Meta webhook
+
+In the Meta for Developers console, on your app's **WhatsApp →
+Configuration** blade:
+
+- Set the **Callback URL** to your Atlas deploy's webhook URL:
+
+  ```
+  https://api.your-atlas-deploy.example.com/api/plugins/chat-interaction/webhooks/whatsapp
+  ```
+
+- Set the **Verify token** to the same value you put in
+  `WHATSAPP_VERIFY_TOKEN`.
+- Click **Verify and Save**. Meta makes a GET request to your callback
+  URL with the verify token; Atlas's adapter mirrors it back to
+  confirm.
+- After saving, click **Manage** next to the webhook field and
+  subscribe to the `messages` field at minimum. Reactions and message
+  status updates can be subscribed too, but `messages` is the
+  user-initiated event Atlas responds to.
+
+### 5. Enable the catalog row
+
+Atlas ships the WhatsApp catalog entry pre-declared in
+`deploy/api/atlas.config.ts`. If you've started from the deploy
+template, the row is already `enabled: true` — no change needed. For
+custom configs, mirror the shape:
+
+```ts
+{
+  slug: "whatsapp",
+  type: "chat",
+  install_model: "static-bot",
+  enabled: true,
+  saas_eligible: true,
+  min_plan: "business",
+  // (configSchema omitted here — see atlas.config.ts for the full row)
+}
+```
+
+Once the env vars are set and the catalog row is enabled, the boot
+log should include:
+
+```
+Registered WhatsAppStaticBotInstallHandler
+AdapterRegistry: chat adapter registered  { slug: 'whatsapp', platform: 'whatsapp' }
+```
+
+If either line is missing, see [troubleshooting](#troubleshooting) below.
+
+## Customer install (per workspace)
+
+Once the operator has wired the Meta App, workspace admins can install
+WhatsApp from **Admin → Integrations**.
+
+<Callout type="warn" title="Operator must add the number first">
+  Before a customer admin can install, the operator has to share the
+  customer's WhatsApp Business phone number into the operator's Meta
+  Business Account. This is a one-time step per customer phone number,
+  done by the operator in the Meta Business Suite — Atlas can't do it
+  on the customer's behalf because the share requires the operator's
+  Meta admin credentials.
+</Callout>
+
+### 1. Operator adds the customer's number to the Meta Business Account
+
+In the Meta Business Suite, open **WhatsApp Manager → Phone numbers →
+Add phone number**. Walk through Meta's verification flow (SMS or
+voice OTP to the customer's number). Once verified, the number
+appears in the **Phone numbers** list with a Meta-assigned
+`Phone number ID` next to it. Copy that ID — that's the value the
+customer admin will paste into Atlas's install modal.
+
+### 2. Customer admin pastes the phone_number_id
+
+In **Admin → Integrations → WhatsApp**, click **Install** and paste
+the `Phone number ID` from step 1 (a numeric routing id, e.g.
+`1098765432109876` — NOT the human-readable phone number) into the
+input.
+
+Click **Confirm**.
+
+### 3. Atlas verifies the number
+
+Atlas immediately calls Meta Graph API
+(`GET /v21.0/{phone_number_id}`) with the operator's access token to
+confirm:
+
+- The phone_number_id is visible to the operator's Meta Business
+  Account (i.e. the operator did step 1).
+- The access token has the `whatsapp_business_management` scope.
+
+If both pass, the install row is persisted and the card flips to
+"Installed". The display phone number (e.g. `+1 415 555 0100`) Meta
+returns is captured as the optional `display_phone` label on the
+install card. If verification fails, Meta's error message bubbles up
+verbatim — see the next section.
+
+## Troubleshooting
+
+### "Meta rejected phone_number_id … — this phone_number_id isn't visible to the operator's Meta Business Account"
+
+Atlas couldn't find the phone_number_id you submitted under the
+operator's Meta Business Account. Common causes:
+
+- The phone_number_id has a typo — re-copy it from the Meta Business
+  Suite under **WhatsApp Manager → Phone numbers → API Setup → Phone
+  number ID**.
+- The operator hasn't yet shared the customer's WhatsApp number into
+  the operator's Meta Business Account. The operator must add the
+  number first (see customer-install step 1 above).
+- You pasted the WhatsApp Business Account ID (`waba_id`) by mistake;
+  it's a different identifier on the same screen.
+
+### "WhatsApp phone_number_id … is not a valid Meta routing id"
+
+You submitted a value that doesn't match the canonical 10–30 decimal
+digit format. Human-readable phone numbers (`+1 415 555 0100`) and
+WhatsApp Business Account IDs are common paste mistakes. Find the
+numeric Phone Number ID in the Meta Business Suite under
+**WhatsApp Manager → Phone numbers → API Setup** and re-submit.
+
+### "Meta rejected phone_number_id … — the operator-side META_BUSINESS_ACCESS_TOKEN may be expired or revoked"
+
+Meta returned error code 190 (or similar). The operator's System User
+access token has expired, been revoked, or had its scopes downgraded.
+Ops must mint a fresh System User token with `whatsapp_business_management`
++ `whatsapp_business_messaging` and update `META_BUSINESS_ACCESS_TOKEN`
+on every API service in the deploy.
+
+### "Meta Graph API unreachable"
+
+A network failure between Atlas and `graph.facebook.com`. Check
+operator-side egress (firewall, region routing, DNS) and retry. Atlas
+does not retry automatically — install attempts are user-initiated and
+a transient failure surfaces back to the admin.
+
+### "No static-bot install handler registered for catalog slug 'whatsapp'"
+
+The operator hasn't set `META_BUSINESS_ACCESS_TOKEN` and
+`META_BUSINESS_APP_ID`, or one is empty on the API process handling
+the install. Both are required (the install flow can't proceed without
+either). Ops sets both per-service and restarts the API. On the next
+boot, log streams should include `Registered
+WhatsAppStaticBotInstallHandler` — if not, double check the env values
+aren't empty / whitespace-only.
+
+### Bot doesn't respond inside WhatsApp
+
+Atlas listens over Meta's WhatsApp Cloud API webhook. That means:
+
+- The Meta webhook callback URL must match your Atlas deploy's webhook
+  URL (see operator-setup step 4).
+- The webhook must be subscribed to the `messages` field — Meta
+  delivers user-initiated events on that channel.
+- `WHATSAPP_APP_SECRET` and `WHATSAPP_VERIFY_TOKEN` on the API service
+  must match the Meta app's App Secret and the verify token you
+  pasted into the webhook configuration.
+- The customer's phone number must be shared into the operator's Meta
+  Business Account AND a `workspace_plugins` row must exist for that
+  phone_number_id (i.e. the customer admin has actually clicked
+  Install in `/admin/integrations`).
+
+If all four are correct and messages still don't arrive, check the
+Meta for Developers app's **Webhooks → Recent deliveries** panel for
+delivery attempts and their response codes.
+
+### Webhook deliveries land but routing's wrong
+
+Inbound WhatsApp messages carry the phone_number_id in
+`value.metadata.phone_number_id`. Atlas matches this against
+`workspace_plugins.config.phone_number_id` to route to the right
+workspace. If a workspace is receiving another tenant's messages (or
+vice versa), the most common cause is two `workspace_plugins` rows
+pointing at the same `phone_number_id` — Atlas's UPSERT path makes
+this impossible at install time, but a database-level edit can
+introduce it. Check the DB:
+
+```sql
+SELECT workspace_id, config->>'phone_number_id' AS phone_number_id
+FROM workspace_plugins
+WHERE catalog_id = 'catalog:whatsapp';
+```
+
+Phone number IDs must be unique across the column. Resolve the
+duplicate manually before re-installing. (Atlas's executeQuery
+resolver fails-closed when it sees >1 match — inbound messages will
+be rejected with a user-safe error until the duplicate is fixed.)
+
+## Disconnecting
+
+To disconnect a workspace from WhatsApp, open **Admin → Integrations
+→ WhatsApp** and click **Disconnect**. Atlas clears the
+`workspace_plugins` row via `WorkspaceInstaller.uninstall` — the
+phone number stays connected to the operator's Meta Business Account
+(Atlas doesn't have permission to unshare it), but incoming messages
+are no longer routed to the workspace.
+
+To remove the phone number from the operator's Meta Business Account
+entirely, the operator opens the **Meta Business Suite → WhatsApp
+Manager → Phone numbers**, picks the number, and clicks **Delete**.
+This is operator-scoped — a workspace admin can't trigger it from
+Atlas.

--- a/apps/docs/content/docs/integrations/whatsapp.mdx
+++ b/apps/docs/content/docs/integrations/whatsapp.mdx
@@ -287,9 +287,17 @@ Inbound WhatsApp messages carry the phone_number_id in
 `workspace_plugins.config.phone_number_id` to route to the right
 workspace. If a workspace is receiving another tenant's messages (or
 vice versa), the most common cause is two `workspace_plugins` rows
-pointing at the same `phone_number_id` — Atlas's UPSERT path makes
-this impossible at install time, but a database-level edit can
-introduce it. Check the DB:
+pointing at the same `phone_number_id`. Atlas does **not** enforce
+cross-workspace uniqueness at install time — the singleton constraint
+is `(workspace_id, catalog_id)`, not `(catalog_id, phone_number_id)`,
+so two admins pasting the same id will both succeed at install. The
+duplicate then surfaces only on the receive side, where the
+executeQuery resolver fails closed when it sees >1 match: inbound
+messages are rejected with a user-safe error and an
+`error`-severity operator log naming the matched workspace ids until
+the duplicate is removed.
+
+Check the DB:
 
 ```sql
 SELECT workspace_id, config->>'phone_number_id' AS phone_number_id
@@ -297,10 +305,10 @@ FROM workspace_plugins
 WHERE catalog_id = 'catalog:whatsapp';
 ```
 
-Phone number IDs must be unique across the column. Resolve the
-duplicate manually before re-installing. (Atlas's executeQuery
-resolver fails-closed when it sees >1 match — inbound messages will
-be rejected with a user-safe error until the duplicate is fixed.)
+Disconnect the duplicate from `/admin/integrations → WhatsApp →
+Disconnect` on the wrong workspace (or `DELETE` the row directly if
+the admin UI is unreachable), then re-install on the correct
+workspace.
 
 ## Disconnecting
 

--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -35206,6 +35206,7 @@
                                   "teams",
                                   "telegram",
                                   "discord",
+                                  "whatsapp",
                                   "webhook"
                                 ]
                               },
@@ -35270,6 +35271,7 @@
                                   "teams",
                                   "telegram",
                                   "discord",
+                                  "whatsapp",
                                   "webhook"
                                 ]
                               },
@@ -35331,6 +35333,7 @@
                                   "teams",
                                   "telegram",
                                   "discord",
+                                  "whatsapp",
                                   "webhook"
                                 ]
                               },
@@ -35535,6 +35538,7 @@
                           "teams",
                           "telegram",
                           "discord",
+                          "whatsapp",
                           "webhook"
                         ],
                         "description": "Origin surface this rule applies to. 'any' (default) fires for every request; the others pin to a single transport. See #2072.",
@@ -35592,6 +35596,7 @@
                           "teams",
                           "telegram",
                           "discord",
+                          "whatsapp",
                           "webhook"
                         ],
                         "description": "Origin surface this rule applies to. 'any' (default) fires for every request; the others pin to a single transport. See #2072.",
@@ -35645,6 +35650,7 @@
                                 "teams",
                                 "telegram",
                                 "discord",
+                                "whatsapp",
                                 "webhook"
                               ]
                             },
@@ -35709,6 +35715,7 @@
                                 "teams",
                                 "telegram",
                                 "discord",
+                                "whatsapp",
                                 "webhook"
                               ]
                             },
@@ -35770,6 +35777,7 @@
                                 "teams",
                                 "telegram",
                                 "discord",
+                                "whatsapp",
                                 "webhook"
                               ]
                             },
@@ -35957,6 +35965,7 @@
                       "teams",
                       "telegram",
                       "discord",
+                      "whatsapp",
                       "webhook"
                     ],
                     "description": "Origin surface this rule applies to. 'any' (default) fires for every request; the others pin to a single transport. See #2072.",
@@ -36003,6 +36012,7 @@
                                 "teams",
                                 "telegram",
                                 "discord",
+                                "whatsapp",
                                 "webhook"
                               ]
                             },
@@ -36067,6 +36077,7 @@
                                 "teams",
                                 "telegram",
                                 "discord",
+                                "whatsapp",
                                 "webhook"
                               ]
                             },
@@ -36128,6 +36139,7 @@
                                 "teams",
                                 "telegram",
                                 "discord",
+                                "whatsapp",
                                 "webhook"
                               ]
                             },
@@ -36501,6 +36513,7 @@
                                   "teams",
                                   "telegram",
                                   "discord",
+                                  "whatsapp",
                                   "webhook",
                                   null
                                 ]
@@ -36616,6 +36629,7 @@
                                   "teams",
                                   "telegram",
                                   "discord",
+                                  "whatsapp",
                                   "webhook",
                                   null
                                 ]
@@ -36737,6 +36751,7 @@
                                   "teams",
                                   "telegram",
                                   "discord",
+                                  "whatsapp",
                                   "webhook",
                                   null
                                 ]
@@ -36858,6 +36873,7 @@
                                   "teams",
                                   "telegram",
                                   "discord",
+                                  "whatsapp",
                                   "webhook",
                                   null
                                 ]
@@ -37127,6 +37143,7 @@
                                 "teams",
                                 "telegram",
                                 "discord",
+                                "whatsapp",
                                 "webhook",
                                 null
                               ]
@@ -37242,6 +37259,7 @@
                                 "teams",
                                 "telegram",
                                 "discord",
+                                "whatsapp",
                                 "webhook",
                                 null
                               ]
@@ -37363,6 +37381,7 @@
                                 "teams",
                                 "telegram",
                                 "discord",
+                                "whatsapp",
                                 "webhook",
                                 null
                               ]
@@ -37484,6 +37503,7 @@
                                 "teams",
                                 "telegram",
                                 "discord",
+                                "whatsapp",
                                 "webhook",
                                 null
                               ]
@@ -37754,6 +37774,7 @@
                                 "teams",
                                 "telegram",
                                 "discord",
+                                "whatsapp",
                                 "webhook",
                                 null
                               ]
@@ -37869,6 +37890,7 @@
                                 "teams",
                                 "telegram",
                                 "discord",
+                                "whatsapp",
                                 "webhook",
                                 null
                               ]
@@ -37990,6 +38012,7 @@
                                 "teams",
                                 "telegram",
                                 "discord",
+                                "whatsapp",
                                 "webhook",
                                 null
                               ]
@@ -38111,6 +38134,7 @@
                                 "teams",
                                 "telegram",
                                 "discord",
+                                "whatsapp",
                                 "webhook",
                                 null
                               ]

--- a/deploy/api/atlas.config.ts
+++ b/deploy/api/atlas.config.ts
@@ -242,13 +242,58 @@ export default defineConfig({
         },
       ],
     },
+    // WhatsApp — 1.5.3 #2753 (Phase D). The operator wires a Meta
+    // Business / WhatsApp Business Cloud API account
+    // (META_BUSINESS_ACCESS_TOKEN + META_BUSINESS_APP_ID, plus
+    // WHATSAPP_APP_SECRET + WHATSAPP_VERIFY_TOKEN for the webhook
+    // envelope verification). Each customer admin pastes their
+    // WhatsApp Business phone number id (Meta's numeric routing id,
+    // distinct from the human phone number) into the install modal.
+    // `WhatsAppStaticBotInstallHandler` verifies the id is reachable
+    // through the operator's Meta credentials via Graph API before
+    // persisting.
+    //
+    // `phone_number_id` is NOT marked `secret: true` — Meta-issued
+    // phone number ids are routing identifiers that leak in every
+    // webhook envelope's `value.metadata.phone_number_id`. Same
+    // posture as Discord's `guild_id` / Telegram's `chat_id` / Teams's
+    // `tenant_id`.
+    //
+    // Plan gating: `min_plan: "business"` — Meta charges the operator
+    // per-conversation for user-initiated (24h customer-service window)
+    // and template-initiated conversations. The economics only work for
+    // workspaces on the highest tier; lower-tier installs would unbound
+    // operator spend in a way the rest of the static-bot family
+    // (Telegram / Discord / Teams — free per-message) doesn't.
     {
       slug: "whatsapp",
       type: "chat",
       install_model: "static-bot",
       enabled: true,
       saas_eligible: true,
-      implementation_status: "coming_soon",
+      implementation_status: "available",
+      name: "WhatsApp",
+      description:
+        "Chat with Atlas inside WhatsApp. The operator wires a shared Meta Business / WhatsApp Business Cloud API account (META_BUSINESS_ACCESS_TOKEN + META_BUSINESS_APP_ID); each workspace admin points Atlas at one WhatsApp Business phone number by its Meta phone_number_id. Higher plan tier — Meta charges the operator per-conversation.",
+      min_plan: "business",
+      configSchema: [
+        {
+          key: "phone_number_id",
+          type: "string",
+          label: "Phone Number ID",
+          description:
+            "Meta's numeric phone number id (NOT the human-readable phone number, e.g. \"+1 415 555 0100\"). Find it in the Meta Business Suite under WhatsApp Manager → Phone numbers → API Setup → copy the \"Phone number ID\" field.",
+          required: true,
+        },
+        {
+          key: "display_phone",
+          type: "string",
+          label: "Display phone",
+          description:
+            "Optional admin-friendly label for this number. Defaults to the display_phone_number Meta returns at install time.",
+          required: false,
+        },
+      ],
     },
     // ── Linear (1.5.3 #2750 — Phase D, Action Target) ──────────────
     // Two catalog rows, one per install mode (per CONTEXT.md

--- a/docs/architecture/chat-plugin-atlas-contract.md
+++ b/docs/architecture/chat-plugin-atlas-contract.md
@@ -84,7 +84,7 @@ These don't ride on `chat_cache` — Atlas owns the schema and the writers. They
 | Telegram | yes | #2748 | ✓ verified — static-bot install via `TelegramStaticBotInstallHandler`; per-Workspace `chat_id` in `workspace_plugins.config`; no per-Workspace credential store; reachability verified via Bot API `getChat` at install time |
 | GitHub | yes | #2662 | ○ pending — 1.5.3 |
 | Linear | yes | #2662 | ○ pending — 1.5.3 |
-| WhatsApp | yes | #2753 | ○ pending — 1.5.3 (rides Telegram's interface) |
+| WhatsApp | yes | #2753 | ✓ verified — static-bot install via `WhatsAppStaticBotInstallHandler`; per-Workspace `phone_number_id` in `workspace_plugins.config`; no per-Workspace credential store (operator-shared `META_BUSINESS_ACCESS_TOKEN` does all sends + reads); reachability verified via Meta Graph API `GET /v21.0/{phone_number_id}` at install time |
 
 ## Structural prevention
 

--- a/packages/api/src/lib/auth/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/auth/__tests__/migrate.test.ts
@@ -345,6 +345,7 @@ describe("migrateAuthTables", () => {
             { name: "0097_fix_0096_us_constraint_order.sql" },
             { name: "0098_twenty_integrations.sql" },
             { name: "0099_approval_surface_discord.sql" },
+            { name: "0100_approval_surface_whatsapp.sql" },
           ],
         };
       }

--- a/packages/api/src/lib/auth/actor.ts
+++ b/packages/api/src/lib/auth/actor.ts
@@ -132,9 +132,13 @@ async function resolveEffectiveRole(
  * iterable list of valid platforms.
  */
 // Telegram (#2748) is the first non-Slack chat platform with a real
-// botActor binding — see lib/chat-plugin/executeQuery.ts's Telegram branch.
-// Discord (#2749) and WhatsApp (#2753) shipped real bindings; teams
-// remains a forward placeholder (no executeQuery branch yet).
+// botActor binding — see lib/chat-plugin/executeQuery.ts's Telegram
+// branch. Discord (#2749) and WhatsApp (#2753) shipped real bindings.
+// Teams (#2752) ships install + chat adapter but has no executeQuery
+// branch yet — the dispatch falls through to the `unsupported
+// platform` refusal, so Teams customers who install today get a
+// user-safe "not yet supported" error on first message rather than a
+// silent agent run.
 export const CHAT_BOT_PLATFORMS = ["slack", "teams", "telegram", "discord", "whatsapp"] as const;
 export type ChatBotPlatform = (typeof CHAT_BOT_PLATFORMS)[number];
 

--- a/packages/api/src/lib/auth/actor.ts
+++ b/packages/api/src/lib/auth/actor.ts
@@ -133,9 +133,9 @@ async function resolveEffectiveRole(
  */
 // Telegram (#2748) is the first non-Slack chat platform with a real
 // botActor binding — see lib/chat-plugin/executeQuery.ts's Telegram branch.
-// Discord (#2749) lands a real binding here when its slice ships; teams
+// Discord (#2749) and WhatsApp (#2753) shipped real bindings; teams
 // remains a forward placeholder (no executeQuery branch yet).
-export const CHAT_BOT_PLATFORMS = ["slack", "teams", "telegram", "discord"] as const;
+export const CHAT_BOT_PLATFORMS = ["slack", "teams", "telegram", "discord", "whatsapp"] as const;
 export type ChatBotPlatform = (typeof CHAT_BOT_PLATFORMS)[number];
 
 /**

--- a/packages/api/src/lib/chat-plugin/__tests__/execute-query.test.ts
+++ b/packages/api/src/lib/chat-plugin/__tests__/execute-query.test.ts
@@ -772,4 +772,151 @@ describe("chat-plugin executeQuery host helper", () => {
     expect(mockInternalQuery).not.toHaveBeenCalled();
     expect(capturedAgentCalls).toHaveLength(0);
   });
+
+  // ---------------------------------------------------------------------------
+  // WhatsApp branch — 1.5.3 #2753 (Phase D)
+  //
+  // Per-tenant phone routing verified end-to-end with a mocked Meta
+  // webhook envelope. The chat adapter normalizes Meta's nested webhook
+  // shape (entry[].changes[].value.metadata.phone_number_id) onto a flat
+  // `rawMessage.phoneNumberId` before reaching executeQuery, so the
+  // routing test feeds the flat shape — the same data the bridge would
+  // hand the host callback in production.
+  // ---------------------------------------------------------------------------
+
+  it("WhatsApp happy path: resolves phone_number_id → workspace + binds whatsapp actor + stamps approvalSurface='whatsapp'", async () => {
+    mockInternalQuery.mockImplementation((sql: string) => {
+      if (sql.includes("workspace_plugins")) {
+        return Promise.resolve([{ workspace_id: "org-whatsapp-tenant" }]);
+      }
+      return Promise.resolve([]);
+    });
+    const { runExecuteQuery } = await import("../executeQuery");
+
+    const result = await runExecuteQuery("how many active users?", {
+      threadId: "whatsapp:1098765432109876:16315551234",
+      adapter: { name: "whatsapp" },
+      rawMessage: {
+        phoneNumberId: "1098765432109876",
+        contact: { profile: { name: "Test User" }, wa_id: "16315551234" },
+        message: {
+          id: "wamid.HBgLMTYzMTU1NTEyMzQVAgARGBI",
+          from: "16315551234",
+          type: "text",
+          text: { body: "how many active users?" },
+        },
+      },
+    });
+
+    expect(result.answer).toBe("42 active users");
+    const call = capturedAgentCalls[0];
+    expect(call.options?.actor?.id).toBe("whatsapp-bot:1098765432109876:16315551234");
+    expect(call.options?.actor?.activeOrganizationId).toBe("org-whatsapp-tenant");
+    expect(call.options?.approvalSurface).toBe("whatsapp");
+    // Rate-limit key shape is `whatsapp:${phoneNumberId}` (per-number bucket).
+    expect(observedRateLimitKeys).toContain("whatsapp:1098765432109876");
+    // DB lookup against the catalog row's stable id with config->>'phone_number_id'.
+    const installQueryCalls = mockInternalQuery.mock.calls.filter(([sql]) =>
+      String(sql).includes("workspace_plugins"),
+    );
+    expect(installQueryCalls).toHaveLength(1);
+    const [sql, params] = installQueryCalls[0];
+    expect(String(sql)).toMatch(/config->>'phone_number_id'/);
+    expect(params).toEqual(["catalog:whatsapp", "1098765432109876"]);
+  });
+
+  it("WhatsApp fail-closes on unknown phone_number_id (no install row) — never invokes the agent", async () => {
+    // No rows match → resolveWhatsAppWorkspaceId throws the inline
+    // WhatsAppUnknownTenantError; runWhatsAppExecuteQuery rethrows as
+    // a user-safe error. The agent must never run.
+    mockInternalQuery.mockImplementation(() => Promise.resolve([]));
+    const { runExecuteQuery } = await import("../executeQuery");
+
+    await expect(
+      runExecuteQuery("q", {
+        threadId: "whatsapp:9999999999999999:16315551234",
+        adapter: { name: "whatsapp" },
+        rawMessage: {
+          phoneNumberId: "9999999999999999",
+          contact: { profile: { name: "Test" }, wa_id: "16315551234" },
+          message: { from: "16315551234", type: "text", text: { body: "q" } },
+        },
+      }),
+    ).rejects.toThrow(/not connected to Atlas/i);
+    expect(capturedAgentCalls).toHaveLength(0);
+  });
+
+  it("WhatsApp fail-closes on DB outage during workspace resolution — user-safe error, never invokes the agent", async () => {
+    mockInternalQuery.mockImplementation(() =>
+      Promise.reject(new Error("ECONNREFUSED postgres://internal-db:5432")),
+    );
+    const { runExecuteQuery } = await import("../executeQuery");
+
+    await expect(
+      runExecuteQuery("q", {
+        threadId: "whatsapp:1098765432109876",
+        adapter: { name: "whatsapp" },
+        rawMessage: {
+          phoneNumberId: "1098765432109876",
+          message: { from: "16315551234", type: "text", text: { body: "q" } },
+        },
+      }),
+    ).rejects.toThrow(/could not resolve the WhatsApp workspace/i);
+    expect(capturedAgentCalls).toHaveLength(0);
+  });
+
+  it("WhatsApp fail-closes when the same phone_number_id maps to multiple workspaces — cross-tenant misroute defense", async () => {
+    // Meta issues each phone_number_id exactly once across the entire
+    // platform, so a duplicate here is operator misconfig (manual DB
+    // edit). The fail-closed branch surfaces as the same user-safe
+    // error as "unknown number," and an operator log line points at
+    // the duplicate.
+    mockInternalQuery.mockImplementation((sql: string) => {
+      if (sql.includes("workspace_plugins")) {
+        return Promise.resolve([
+          { workspace_id: "org-a" },
+          { workspace_id: "org-b" },
+        ]);
+      }
+      return Promise.resolve([]);
+    });
+    const { runExecuteQuery } = await import("../executeQuery");
+
+    await expect(
+      runExecuteQuery("q", {
+        threadId: "whatsapp:dup",
+        adapter: { name: "whatsapp" },
+        rawMessage: {
+          phoneNumberId: "1098765432109876",
+          message: { from: "16315551234", type: "text", text: { body: "q" } },
+        },
+      }),
+    ).rejects.toThrow(/not connected to Atlas/i);
+    expect(capturedAgentCalls).toHaveLength(0);
+  });
+
+  it("WhatsApp rejects events whose phoneNumberId isn't a valid Meta routing id — defends rate-limit cache key shape", async () => {
+    // Even though the HMAC-SHA256 webhook signature gate catches forgery
+    // at the adapter layer, the dispatcher belt-and-suspenders by
+    // re-validating the routing-id shape (WHATSAPP_PHONE_NUMBER_ID_RE).
+    // Garbage phoneNumberId surfaces as the "missing tenant context"
+    // error — no DB read, no agent.
+    mockInternalQuery.mockImplementation(() => {
+      throw new Error("internalQuery should never be reached on shape failure");
+    });
+    const { runExecuteQuery } = await import("../executeQuery");
+
+    await expect(
+      runExecuteQuery("q", {
+        threadId: "whatsapp:bad",
+        adapter: { name: "whatsapp" },
+        rawMessage: {
+          phoneNumberId: "not-a-number'; DROP TABLE--",
+          message: { from: "16315551234", type: "text", text: { body: "q" } },
+        },
+      }),
+    ).rejects.toThrow(/missing tenant context/i);
+    expect(mockInternalQuery).not.toHaveBeenCalled();
+    expect(capturedAgentCalls).toHaveLength(0);
+  });
 });

--- a/packages/api/src/lib/chat-plugin/__tests__/execute-query.test.ts
+++ b/packages/api/src/lib/chat-plugin/__tests__/execute-query.test.ts
@@ -870,7 +870,8 @@ describe("chat-plugin executeQuery host helper", () => {
     // platform, so a duplicate here is operator misconfig (manual DB
     // edit). The fail-closed branch surfaces as the same user-safe
     // error as "unknown number," and an operator log line points at
-    // the duplicate.
+    // the duplicate (including the matched workspace_ids — see the
+    // handler resolver, the fingerprint-only log was insufficient).
     mockInternalQuery.mockImplementation((sql: string) => {
       if (sql.includes("workspace_plugins")) {
         return Promise.resolve([
@@ -893,6 +894,19 @@ describe("chat-plugin executeQuery host helper", () => {
       }),
     ).rejects.toThrow(/not connected to Atlas/i);
     expect(capturedAgentCalls).toHaveLength(0);
+    // SQL filter shape: the duplicate-match defense MUST scope its
+    // lookup to (catalog_id = catalog:whatsapp, enabled = true,
+    // config->>'phone_number_id'). A refactor that genericized the
+    // resolver and dropped any of these filters would silently widen
+    // the cross-tenant boundary.
+    const installQueryCalls = mockInternalQuery.mock.calls.filter(([sql]) =>
+      String(sql).includes("workspace_plugins"),
+    );
+    const [sql, params] = installQueryCalls[0];
+    expect(String(sql)).toMatch(/catalog_id\s*=\s*\$1/);
+    expect(String(sql)).toMatch(/enabled\s*=\s*true/);
+    expect(String(sql)).toMatch(/config->>'phone_number_id'/);
+    expect(params).toEqual(["catalog:whatsapp", "1098765432109876"]);
   });
 
   it("WhatsApp rejects events whose phoneNumberId isn't a valid Meta routing id — defends rate-limit cache key shape", async () => {

--- a/packages/api/src/lib/chat-plugin/executeQuery.ts
+++ b/packages/api/src/lib/chat-plugin/executeQuery.ts
@@ -12,9 +12,14 @@
  *     → `workspace_id` via the static-bot install record.
  *   - **Discord** (1.5.3 slice 11 / #2749) — resolves `guild_id` →
  *     `workspace_plugins.config->>'guild_id'` → `workspace_id`. Same
- *     fail-closed contract as Telegram. Remaining static-bot platforms
- *     (gchat #2754, WhatsApp #2753) extend this dispatch as their
- *     slices land.
+ *     fail-closed contract as Telegram.
+ *   - **WhatsApp** (1.5.3 slice 15 / #2753) — resolves the inbound
+ *     webhook's normalized `phoneNumberId` →
+ *     `workspace_plugins.config->>'phone_number_id'` → `workspace_id`.
+ *     The user-side `wa_id` anchors per-user conversation persistence
+ *     (WhatsApp has no thread / channel concept; every conversation is
+ *     1:1). Remaining static-bot platform (gchat #2754) extends this
+ *     dispatch when its slice lands.
  *
  * Without a per-platform tenant binding, `checkApprovalRequired`
  * short-circuits on a missing `orgId` and the approval gate silently
@@ -1095,6 +1100,24 @@ async function runWhatsAppExecuteQuery(
       : typeof raw.message?.from === "string" && raw.message.from.length > 0
         ? raw.message.from
         : undefined;
+  if (!externalUserId) {
+    // Meta sometimes routes status events (delivered / read receipts)
+    // through the same webhook with no `contact` payload — the chat
+    // adapter forwards them here without a wa_id. The actor binding
+    // narrows from per-user (`whatsapp-bot:<phone>:<wa>`) to per-tenant
+    // (`whatsapp-bot:<phone>`), F-55 approval rules keyed on the
+    // per-user actor silently widen to the per-tenant actor, AND
+    // conversation persistence below disables (no wa_id thread anchor).
+    // Warn so the silent degradation is observable in operator logs.
+    log.warn(
+      {
+        phoneNumberIdFingerprint: fingerprintPhoneNumberId(phoneNumberId),
+        threadId,
+        requestId,
+      },
+      "WhatsApp event missing wa_id — actor narrows to per-tenant granularity and conversation persistence disables for this event",
+    );
+  }
   const actor = botActorUser({
     platform: "whatsapp",
     externalId: phoneNumberId,
@@ -1108,7 +1131,8 @@ async function runWhatsAppExecuteQuery(
   //    wa_id is the only thread anchor available. The chat plugin
   //    bridge encodes this in `WhatsAppThreadId` as
   //    `whatsapp:{phoneNumberId}:{userWaId}`; here we just persist
-  //    by the (phoneNumberId, wa_id) pair.
+  //    by the (phoneNumberId, wa_id) pair. Empty wa_id disables
+  //    persistence — see the warn above.
   const userWaId = externalUserId ?? "";
   const conversationId = await loadOrCreateConversation(
     phoneNumberId,
@@ -1184,10 +1208,17 @@ async function resolveWhatsAppWorkspaceId(phoneNumberId: string): Promise<string
     throw new WhatsAppUnknownTenantError(fingerprintPhoneNumberId(phoneNumberId));
   }
   if (rows.length > 1) {
+    // Surface the matched workspace_ids so the operator can disconnect
+    // the duplicate without dumping the table. Meta phone_number_ids
+    // are sequentially assigned in batches, so last-4-char
+    // fingerprints have a meaningfully higher collision rate than
+    // Discord snowflakes — the explicit list is what makes the cross-
+    // tenant misroute warning actually triagable.
     log.error(
       {
         phoneNumberIdFingerprint: fingerprintPhoneNumberId(phoneNumberId),
         matchCount: rows.length,
+        matchedWorkspaceIds: rows.map((r) => r.workspace_id),
       },
       "WhatsApp phone_number_id maps to multiple workspaces — refusing query (cross-tenant misroute risk). Operator must disconnect the duplicate install.",
     );

--- a/packages/api/src/lib/chat-plugin/executeQuery.ts
+++ b/packages/api/src/lib/chat-plugin/executeQuery.ts
@@ -63,6 +63,7 @@ import { botActorUser, type ChatBotPlatform } from "@atlas/api/lib/auth/actor";
 import { getInstallation } from "@atlas/api/lib/slack/store";
 import { internalQuery } from "@atlas/api/lib/db/internal";
 import { DISCORD_GUILD_ID_RE } from "@atlas/api/lib/integrations/install/discord-static-bot-handler";
+import { WHATSAPP_PHONE_NUMBER_ID_RE } from "@atlas/api/lib/integrations/install/whatsapp-static-bot-handler";
 import { getConversationId, setConversationId } from "@atlas/api/lib/slack/threads";
 import {
   createConversation,
@@ -142,6 +143,35 @@ interface DiscordRawEvent {
 }
 
 /**
+ * Minimum shape we read from a WhatsApp raw message envelope. The chat
+ * adapter passes `WhatsAppRawMessage` (from `@chat-adapter/whatsapp`)
+ * through the `rawMessage` slot — the per-message normalized shape, NOT
+ * the unwrapped Meta webhook envelope. Documented at
+ * https://developers.facebook.com/docs/whatsapp/cloud-api/webhooks/payload-examples.
+ *
+ * `phoneNumberId` is the per-Workspace routing identifier persisted by
+ * {@link WhatsAppStaticBotInstallHandler} into
+ * `workspace_plugins.config->>'phone_number_id'`. The user-side wa_id
+ * (`contact.wa_id` or `message.from`) anchors per-user conversation
+ * persistence — WhatsApp has no thread or channel concept; every
+ * conversation is a 1:1 between the operator's business phone and a
+ * single user, so wa_id is the only thread anchor available.
+ */
+interface WhatsAppRawEvent {
+  /** Phone number id that received the message (per-Workspace routing). */
+  phoneNumberId?: string;
+  /** Contact info from the webhook. */
+  contact?: { profile?: { name?: string }; wa_id?: string };
+  /** The raw inbound message. */
+  message?: {
+    id?: string;
+    from?: string;
+    type?: string;
+    text?: { body?: string };
+  };
+}
+
+/**
  * Normalize a Slack id field that may arrive as a bare string (events_api)
  * or as a `{ id, ... }` object (interactive `block_actions` payloads).
  */
@@ -195,6 +225,27 @@ function extractDiscordGuildId(raw: DiscordRawEvent): string | undefined {
 }
 
 /**
+ * Extract the WhatsApp phone_number_id from an inbound message envelope.
+ * Returns undefined when the field is missing OR when the value isn't a
+ * valid Meta phone-number id (per {@link WHATSAPP_PHONE_NUMBER_ID_RE}).
+ * Even though the HMAC-SHA256 webhook signature gate upstream catches
+ * forgery, defending the shape here prevents an attacker-controllable
+ * string from polluting the rate-limit cache key
+ * (`whatsapp:${phoneNumberId}`) or the workspace-resolution log
+ * fingerprint.
+ *
+ * Reuses {@link WHATSAPP_PHONE_NUMBER_ID_RE} from the install handler —
+ * single source of truth for the routing-id invariant across install +
+ * receive paths.
+ */
+function extractWhatsAppPhoneNumberId(raw: WhatsAppRawEvent): string | undefined {
+  const id = raw.phoneNumberId;
+  if (typeof id !== "string" || id.length === 0) return undefined;
+  if (!WHATSAPP_PHONE_NUMBER_ID_RE.test(id)) return undefined;
+  return id;
+}
+
+/**
  * Build the chat plugin's `executeQuery` callback.
  *
  * Multi-platform dispatch lives inside `runExecuteQuery`. Each chat
@@ -225,6 +276,9 @@ export async function runExecuteQuery(
   }
   if (adapter.name === "discord") {
     return runDiscordExecuteQuery(question, ctx, requestId);
+  }
+  if (adapter.name === "whatsapp") {
+    return runWhatsAppExecuteQuery(question, ctx, requestId);
   }
 
   log.warn(
@@ -743,7 +797,7 @@ async function loadOrCreateConversation(
   channel: string,
   threadAnchor: string,
   question: string,
-  surface: "slack" | "telegram" | "discord",
+  surface: "slack" | "telegram" | "discord" | "whatsapp",
   requestId: string,
 ): Promise<string | null> {
   if (!channel || !threadAnchor) return null;
@@ -952,8 +1006,198 @@ async function runAgentAndMap(args: RunAgentArgs): Promise<ChatQueryResult> {
   };
 }
 
+// ---------------------------------------------------------------------------
+// WhatsApp branch — 1.5.3 #2753 (Phase D)
+// ---------------------------------------------------------------------------
+
+async function runWhatsAppExecuteQuery(
+  question: string,
+  ctx: ChatExecuteQueryContext,
+  requestId: string,
+): Promise<ChatQueryResult> {
+  const { threadId, priorMessages, rawMessage } = ctx;
+  const raw = (rawMessage ?? {}) as WhatsAppRawEvent;
+
+  // 1. Resolve tenant — phone_number_id is the routing identifier
+  //    persisted by `WhatsAppStaticBotInstallHandler` into
+  //    `workspace_plugins.config`. Meta tags every inbound message
+  //    envelope with the phone_number_id that received it; the chat
+  //    adapter normalizes that field onto `rawMessage.phoneNumberId`.
+  const phoneNumberId = extractWhatsAppPhoneNumberId(raw);
+  if (!phoneNumberId) {
+    log.warn(
+      { threadId, requestId },
+      "Chat plugin executeQuery received WhatsApp event without phoneNumberId — refusing",
+    );
+    throw new Error(
+      "This WhatsApp event is missing tenant context. Please try again.",
+    );
+  }
+
+  // 2. Rate limit — keyed per-phone_number_id (one install row == one
+  //    rate-limit bucket). Same posture as Discord's per-guild key.
+  //    Per-user keying isn't right here because WhatsApp doesn't have
+  //    a multi-user channel concept — every conversation is 1:1, so
+  //    "one user owns the bucket" already.
+  const rateCheck = checkRateLimit(`whatsapp:${phoneNumberId}`);
+  if (!rateCheck.allowed) {
+    log.info(
+      {
+        phoneNumberIdFingerprint: fingerprintPhoneNumberId(phoneNumberId),
+        threadId,
+        requestId,
+      },
+      "Chat plugin executeQuery rate-limited",
+    );
+    throw new Error("Rate limit exceeded. Please wait before trying again.");
+  }
+
+  // 3. F-55 actor — resolve phone_number_id → workspace_id via the
+  //    install row. Same fail-closed contract as Slack / Telegram /
+  //    Discord: unknown tenant or DB outage MUST throw before the agent
+  //    runs.
+  let orgId: string;
+  try {
+    orgId = await resolveWhatsAppWorkspaceId(phoneNumberId);
+  } catch (err) {
+    if (err instanceof WhatsAppUnknownTenantError) {
+      log.warn(
+        {
+          phoneNumberIdFingerprint: fingerprintPhoneNumberId(phoneNumberId),
+          threadId,
+          requestId,
+        },
+        "Unknown WhatsApp phone_number_id — refusing",
+      );
+      throw new Error(
+        "This WhatsApp number is not connected to Atlas. Ask your admin to install WhatsApp in the Atlas integrations console.",
+        { cause: err },
+      );
+    }
+    log.error(
+      {
+        phoneNumberIdFingerprint: fingerprintPhoneNumberId(phoneNumberId),
+        threadId,
+        requestId,
+        err,
+      },
+      "Failed to resolve WhatsApp phone_number_id → workspace — refusing query",
+    );
+    throw new Error(
+      "Atlas could not resolve the WhatsApp workspace right now. Please try again in a moment.",
+      { cause: err },
+    );
+  }
+
+  const externalUserId =
+    typeof raw.contact?.wa_id === "string" && raw.contact.wa_id.length > 0
+      ? raw.contact.wa_id
+      : typeof raw.message?.from === "string" && raw.message.from.length > 0
+        ? raw.message.from
+        : undefined;
+  const actor = botActorUser({
+    platform: "whatsapp",
+    externalId: phoneNumberId,
+    orgId,
+    ...(externalUserId ? { externalUserId } : {}),
+  });
+
+  // 4. Conversation persistence keyed on (phone_number_id, user wa_id).
+  //    WhatsApp has no thread or channel concept — conversations are
+  //    1:1 between the operator's business phone and a single user, so
+  //    wa_id is the only thread anchor available. The chat plugin
+  //    bridge encodes this in `WhatsAppThreadId` as
+  //    `whatsapp:{phoneNumberId}:{userWaId}`; here we just persist
+  //    by the (phoneNumberId, wa_id) pair.
+  const userWaId = externalUserId ?? "";
+  const conversationId = await loadOrCreateConversation(
+    phoneNumberId,
+    userWaId,
+    question,
+    "whatsapp",
+    requestId,
+  );
+
+  return runAgentAndMap({
+    question,
+    requestId,
+    actor,
+    approvalSurface: "whatsapp",
+    conversationId,
+    priorMessages: priorMessages ?? null,
+    presentationMode: ctx.presentationMode,
+    tenantLabel: {
+      phoneNumberIdFingerprint: fingerprintPhoneNumberId(phoneNumberId),
+      threadId,
+    },
+  });
+}
+
+/**
+ * Log-safe phone_number_id fingerprint — last 4 chars only. Mirrors the
+ * helper in `whatsapp-static-bot-handler.ts`; kept inline here to avoid
+ * a cross-module import for one 2-line helper.
+ */
+function fingerprintPhoneNumberId(phoneNumberId: string): string {
+  return phoneNumberId.length <= 4 ? phoneNumberId : `…${phoneNumberId.slice(-4)}`;
+}
+
+/**
+ * Unknown-tenant marker for the WhatsApp branch's fail-closed path.
+ * Same posture as {@link DiscordUnknownTenantError} — an `instanceof`
+ * sentinel caught inline and rethrown user-safe, NOT a Data.TaggedError.
+ */
+class WhatsAppUnknownTenantError extends Error {
+  constructor(phoneNumberIdFingerprint: string) {
+    super(`No Atlas workspace bound to WhatsApp number …${phoneNumberIdFingerprint}`);
+    this.name = "WhatsAppUnknownTenantError";
+  }
+}
+
+/**
+ * Resolve a WhatsApp phone_number_id → Atlas workspace_id via the
+ * static-bot install record. Reads
+ * `workspace_plugins.config->>'phone_number_id'` for the catalog row
+ * `catalog:whatsapp`. Throws {@link WhatsAppUnknownTenantError} on
+ * no-row, propagates DB errors verbatim for caller-side logging.
+ *
+ * Same rationale as the Telegram / Discord resolvers — the install row
+ * IS the tenant lookup (no parallel store to keep in sync). See
+ * ADR-0007.
+ */
+async function resolveWhatsAppWorkspaceId(phoneNumberId: string): Promise<string> {
+  // No LIMIT — fail-closed when the same phone_number_id maps to >1
+  // workspace. Meta's Cloud API issues each phone_number_id exactly
+  // once across the entire WhatsApp Business platform, so a duplicate
+  // here is operator misconfig (manual DB edit) rather than a
+  // legitimate routing case — silently picking one match is a
+  // cross-tenant data exposure risk.
+  const rows = await internalQuery<{ workspace_id: string }>(
+    `SELECT workspace_id
+       FROM workspace_plugins
+      WHERE catalog_id = $1
+        AND enabled = true
+        AND config->>'phone_number_id' = $2`,
+    ["catalog:whatsapp", phoneNumberId],
+  );
+  if (rows.length === 0) {
+    throw new WhatsAppUnknownTenantError(fingerprintPhoneNumberId(phoneNumberId));
+  }
+  if (rows.length > 1) {
+    log.error(
+      {
+        phoneNumberIdFingerprint: fingerprintPhoneNumberId(phoneNumberId),
+        matchCount: rows.length,
+      },
+      "WhatsApp phone_number_id maps to multiple workspaces — refusing query (cross-tenant misroute risk). Operator must disconnect the duplicate install.",
+    );
+    throw new WhatsAppUnknownTenantError(fingerprintPhoneNumberId(phoneNumberId));
+  }
+  return rows[0].workspace_id;
+}
+
 // Compile-time guard that the platforms wired here all exist in
 // `CHAT_BOT_PLATFORMS`. Adding a new branch above without extending the
 // actor enum surfaces here as a TS error.
-const _platformGuards: ReadonlyArray<ChatBotPlatform> = ["telegram", "discord"];
+const _platformGuards: ReadonlyArray<ChatBotPlatform> = ["telegram", "discord", "whatsapp"];
 void _platformGuards;

--- a/packages/api/src/lib/db/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate.test.ts
@@ -112,8 +112,10 @@ describe("runMigrations", () => {
     // + 0097 (forward-fix for 0096 constraint-ordering bug on us-int-postgres, #2744)
     // + 0098 (twenty_integrations table, #2727)
     // + 0099 (add 'discord' to approval-surface CHECK enums + promote
-    //   discord catalog row to 'available', #2749) = 100.
-    expect(count).toBe(100);
+    //   discord catalog row to 'available', #2749)
+    // + 0100 (add 'whatsapp' to approval-surface CHECK enums + promote
+    //   whatsapp catalog row to 'available', #2753) = 101.
+    expect(count).toBe(101);
 
     // Advisory lock acquired before anything else
     expect(queries[0]).toContain("pg_advisory_lock");
@@ -242,6 +244,7 @@ describe("runMigrations", () => {
         "0097_fix_0096_us_constraint_order.sql",
         "0098_twenty_integrations.sql",
         "0099_approval_surface_discord.sql",
+        "0100_approval_surface_whatsapp.sql",
       ],
     });
 

--- a/packages/api/src/lib/db/migrations/0100_approval_surface_whatsapp.sql
+++ b/packages/api/src/lib/db/migrations/0100_approval_surface_whatsapp.sql
@@ -16,7 +16,7 @@
 -- gchat (the remaining Phase D static-bot platform — #2754) will land
 -- analogous nudges in its own slice.
 --
--- All four statements are idempotent — same shape as 0095 / 0099.
+-- All statements are idempotent — same shape as 0095 / 0099.
 
 -- ── Approval-surface enum extension ──────────────────────────────────
 

--- a/packages/api/src/lib/db/migrations/0100_approval_surface_whatsapp.sql
+++ b/packages/api/src/lib/db/migrations/0100_approval_surface_whatsapp.sql
@@ -1,0 +1,44 @@
+-- Migration 0100: WhatsApp-related DB nudges for slice #2753.
+--
+-- Mirrors 0099 (Discord, #2749) for the WhatsApp platform — two
+-- distinct one-time changes the catalog seeder + handler can't make on
+-- their own, bundled because both fire on the same code release:
+--
+--   1. Add `whatsapp` to the two approval-surface CHECK enums (extends
+--      0099's Discord-added set).
+--   2. Promote the `whatsapp` catalog row's `implementation_status`
+--      from `coming_soon` (set by 0094 / #2747) to `available`. The
+--      catalog seeder's upsert intentionally does NOT write the
+--      `implementation_status` column (operator-only surface state per
+--      ADR-0007), so without a one-time UPDATE the whatsapp row stays
+--      inert in the admin UI even though slice #2753 shipped the handler.
+--
+-- gchat (the remaining Phase D static-bot platform — #2754) will land
+-- analogous nudges in its own slice.
+--
+-- All four statements are idempotent — same shape as 0095 / 0099.
+
+-- ── Approval-surface enum extension ──────────────────────────────────
+
+ALTER TABLE approval_rules DROP CONSTRAINT IF EXISTS chk_approval_rule_surface;
+ALTER TABLE approval_rules
+  ADD CONSTRAINT chk_approval_rule_surface
+  CHECK (surface IN ('any', 'chat', 'mcp', 'scheduler', 'slack', 'teams', 'telegram', 'discord', 'whatsapp', 'webhook'));
+
+ALTER TABLE approval_queue DROP CONSTRAINT IF EXISTS chk_approval_request_surface;
+ALTER TABLE approval_queue
+  ADD CONSTRAINT chk_approval_request_surface
+  CHECK (surface IS NULL OR surface IN ('chat', 'mcp', 'scheduler', 'slack', 'teams', 'telegram', 'discord', 'whatsapp', 'webhook'));
+
+COMMENT ON COLUMN approval_rules.surface IS
+  'Origin surface this rule applies to. ''any'' fires for every request (pre-2072 default); ''chat'' / ''mcp'' / ''scheduler'' / ''slack'' / ''teams'' / ''telegram'' / ''discord'' / ''whatsapp'' / ''webhook'' scope to the named transport. See packages/api/src/lib/approvals/evaluate.ts (#2072; telegram added in #2748; discord added in #2749; whatsapp added in #2753).';
+
+-- ── Implementation-status promotion ──────────────────────────────────
+-- Pre-condition: 0094 (#2747) flipped whatsapp to `coming_soon`. The
+-- WHERE clause makes either case a no-op if a deploy bypassed 0094.
+
+UPDATE plugin_catalog
+SET implementation_status = 'available',
+    updated_at = NOW()
+WHERE slug = 'whatsapp'
+  AND implementation_status = 'coming_soon';

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -986,7 +986,7 @@ export const approvalRules = pgTable(
     check("chk_approval_rule_type", sql`rule_type IN ('table', 'column', 'cost')`),
     check(
       "chk_approval_rule_surface",
-      sql`surface IN ('any', 'chat', 'mcp', 'scheduler', 'slack', 'teams', 'telegram', 'discord', 'webhook')`,
+      sql`surface IN ('any', 'chat', 'mcp', 'scheduler', 'slack', 'teams', 'telegram', 'discord', 'whatsapp', 'webhook')`,
     ),
     index("idx_approval_rules_org").on(t.orgId),
     index("idx_approval_rules_org_enabled").on(t.orgId).where(sql`enabled = true`),
@@ -1030,7 +1030,7 @@ export const approvalQueue = pgTable(
     check("chk_approval_status", sql`status IN ('pending', 'approved', 'denied', 'expired')`),
     check(
       "chk_approval_request_surface",
-      sql`surface IS NULL OR surface IN ('chat', 'mcp', 'scheduler', 'slack', 'teams', 'telegram', 'discord', 'webhook')`,
+      sql`surface IS NULL OR surface IN ('chat', 'mcp', 'scheduler', 'slack', 'teams', 'telegram', 'discord', 'whatsapp', 'webhook')`,
     ),
     // 0094 / #2744 — composite FK to `connection_groups (id, org_id)`
     // dropped with the table. `connection_group_id` stays as a

--- a/packages/api/src/lib/effect/errors.ts
+++ b/packages/api/src/lib/effect/errors.ts
@@ -580,6 +580,63 @@ export class TeamsApiUnavailableError extends Data.TaggedError(
   readonly message: string;
 }> {}
 
+// ── WhatsApp static-bot install (#2753 — 1.5.3 Phase D) ─────────────
+
+/**
+ * WhatsApp install rejected the supplied `phone_number_id` at the input-
+ * shape layer — not a numeric Meta phone-number identifier, empty, or
+ * pasted as the human-readable phone number (`+1 415 555 0100`). Maps to
+ * HTTP 400. The constructor message is admin-actionable verbatim; the
+ * route does not translate.
+ *
+ * Fourth subclass of the static-bot input-validation family alongside
+ * {@link TelegramChatIdInvalidError}, {@link DiscordGuildIdInvalidError},
+ * and {@link TeamsTenantIdInvalidError}.
+ *
+ * @see packages/api/src/lib/integrations/install/whatsapp-static-bot-handler.ts
+ */
+export class WhatsAppPhoneNumberIdInvalidError extends Data.TaggedError(
+  "WhatsAppPhoneNumberIdInvalidError",
+)<{
+  readonly message: string;
+}> {}
+
+/**
+ * Meta Graph API returned a non-OK envelope when verifying the supplied
+ * `phone_number_id` via `GET /v21.0/{phone_number_id}`. Maps to HTTP 400
+ * because the common failure modes (unknown number, number not owned by
+ * the operator's Meta Business Account, access token lacks
+ * whatsapp_business_management scope) are admin-correctable: re-copy the
+ * id from the Meta Business Suite, or ask the operator to extend the
+ * shared Meta Business account to include the customer's number.
+ *
+ * Distinct from {@link WhatsAppApiUnavailableError} (502 — operator/
+ * upstream) because user-correctable errors must not auto-retry.
+ */
+export class WhatsAppReachabilityError extends Data.TaggedError(
+  "WhatsAppReachabilityError",
+)<{
+  /** Admin-facing message — includes Meta's verbatim `error.message`. */
+  readonly message: string;
+  /** Meta-side numeric error code (100 "Invalid parameter", 190 "Access token expired", etc.). Forensic-only. */
+  readonly errorCode: number;
+}> {}
+
+/**
+ * Meta Graph API was unreachable at the network layer — DNS, TLS,
+ * timeout, or a malformed response. Maps to HTTP 502. The thrown message
+ * is admin-safe (the operator-shared `META_BUSINESS_ACCESS_TOKEN` rides
+ * in the `Authorization: Bearer` header, not in the URL path — so it
+ * doesn't surface in fetch error messages the way Telegram's URL-
+ * embedded bot token can); the underlying error is logged with the
+ * structured `requestId` for operator forensics.
+ */
+export class WhatsAppApiUnavailableError extends Data.TaggedError(
+  "WhatsAppApiUnavailableError",
+)<{
+  readonly message: string;
+}> {}
+
 // ── Workspace Installer (#2742) ────────────────────────────────────
 
 /**
@@ -730,6 +787,9 @@ export type AtlasError =
   | TeamsTenantIdInvalidError
   | TeamsReachabilityError
   | TeamsApiUnavailableError
+  | WhatsAppPhoneNumberIdInvalidError
+  | WhatsAppReachabilityError
+  | WhatsAppApiUnavailableError
   | AlreadyInstalledError
   | ConfigSchemaError
   | CatalogNotFoundError
@@ -799,6 +859,9 @@ export const ATLAS_ERROR_TAG_LIST = [
   "TeamsTenantIdInvalidError",
   "TeamsReachabilityError",
   "TeamsApiUnavailableError",
+  "WhatsAppPhoneNumberIdInvalidError",
+  "WhatsAppReachabilityError",
+  "WhatsAppApiUnavailableError",
   "AlreadyInstalledError",
   "ConfigSchemaError",
   "CatalogNotFoundError",

--- a/packages/api/src/lib/effect/hono.ts
+++ b/packages/api/src/lib/effect/hono.ts
@@ -190,6 +190,15 @@ export function mapTaggedError(error: AtlasError): HttpErrorMapping {
     case "TeamsTenantIdInvalidError":
     case "TeamsReachabilityError":
       return { status: 400, code: "bad_request", message: error.message };
+    // #2753 — WhatsApp install rejected at the input or upstream-
+    // verification layer. Both are admin-correctable (re-paste the id,
+    // confirm the number is in the operator's Meta Business Account,
+    // refresh the access token) so 400 is the right surface. The
+    // message carries Meta's verbatim `error.message` for
+    // `WhatsAppReachabilityError`; the route does not translate.
+    case "WhatsAppPhoneNumberIdInvalidError":
+    case "WhatsAppReachabilityError":
+      return { status: 400, code: "bad_request", message: error.message };
     // #2742 — catalog `config_schema` violation. Surface per-field
     // detail in the response body so the admin UI's form can highlight
     // the wrong inputs without a follow-up roundtrip. Field names are
@@ -353,6 +362,13 @@ export function mapTaggedError(error: AtlasError): HttpErrorMapping {
     // TEAMS_APP_PASSWORD never reach the discovery endpoint, so they
     // can't leak in fetch error messages).
     case "TeamsApiUnavailableError":
+      return { status: 502, code: "upstream_error", message: error.message };
+    // #2753 — Meta Graph API unreachable at the network layer (DNS, TLS,
+    // timeout). Same upstream posture as Telegram / Discord / Teams; the
+    // message is admin-safe (the operator-shared META_BUSINESS_ACCESS_TOKEN
+    // rides in `Authorization: Bearer`, not in the URL path, so it
+    // can't surface in fetch error messages).
+    case "WhatsAppApiUnavailableError":
       return { status: 502, code: "upstream_error", message: error.message };
 
     // ── 503 Service Unavailable ──────────────────────────────────

--- a/packages/api/src/lib/integrations/install/__tests__/register.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/register.test.ts
@@ -63,12 +63,18 @@ function clearTeamsEnv(): void {
   delete process.env.TEAMS_APP_PASSWORD;
 }
 
+function clearWhatsAppEnv(): void {
+  delete process.env.META_BUSINESS_ACCESS_TOKEN;
+  delete process.env.META_BUSINESS_APP_ID;
+}
+
 beforeEach(() => {
   // Reset the env to a known-clean state; each test sets only what it needs.
   process.env = { ...ORIGINAL_ENV };
   clearTelegramEnv();
   clearDiscordEnv();
   clearTeamsEnv();
+  clearWhatsAppEnv();
   delete process.env.SLACK_CLIENT_ID;
   delete process.env.SLACK_CLIENT_SECRET;
   delete process.env.JIRA_CLIENT_ID;
@@ -255,6 +261,63 @@ describe("registerBuiltinInstallHandlers — Teams env gate (#2752)", () => {
   });
 
   it("does not throw when the catalog has no teams row at all (operator hasn't opted in)", () => {
+    mockedConfig = { catalog: [{ slug: "slack", enabled: true }] };
+    expect(() => registerBuiltinInstallHandlers()).not.toThrow();
+  });
+});
+
+describe("registerBuiltinInstallHandlers — WhatsApp env gate (#2753)", () => {
+  it("does not register the WhatsApp handler when META_BUSINESS_ACCESS_TOKEN is unset", () => {
+    process.env.META_BUSINESS_APP_ID = "fake-meta-app-id";
+    registerBuiltinInstallHandlers();
+    expect(() =>
+      getInstallHandler({ slug: "whatsapp", install_model: "static-bot" }),
+    ).toThrow(/No static-bot install handler registered/);
+  });
+
+  it("does not register the WhatsApp handler when META_BUSINESS_APP_ID is unset", () => {
+    process.env.META_BUSINESS_ACCESS_TOKEN = "fake-meta-token";
+    registerBuiltinInstallHandlers();
+    expect(() =>
+      getInstallHandler({ slug: "whatsapp", install_model: "static-bot" }),
+    ).toThrow(/No static-bot install handler registered/);
+  });
+
+  it("does not register when either WhatsApp env var is an empty string", () => {
+    process.env.META_BUSINESS_ACCESS_TOKEN = "";
+    process.env.META_BUSINESS_APP_ID = "";
+    registerBuiltinInstallHandlers();
+    expect(() =>
+      getInstallHandler({ slug: "whatsapp", install_model: "static-bot" }),
+    ).toThrow(/No static-bot install handler registered/);
+  });
+
+  it("registers the WhatsApp handler when both META_BUSINESS_ACCESS_TOKEN and META_BUSINESS_APP_ID are set", () => {
+    process.env.META_BUSINESS_ACCESS_TOKEN = "fake-meta-access-token";
+    process.env.META_BUSINESS_APP_ID = "fake-meta-app-id";
+    registerBuiltinInstallHandlers();
+    const handler = getInstallHandler({
+      slug: "whatsapp",
+      install_model: "static-bot",
+    });
+    expect(handler.kind).toBe("static-bot");
+  });
+
+  it("logs (but does not throw) when the catalog says whatsapp is enabled but the env is half-wired — #2673 escalation", () => {
+    // Only META_BUSINESS_ACCESS_TOKEN set (META_BUSINESS_APP_ID missing)
+    // — same severity-escalation contract as the Telegram / Discord /
+    // Teams catalog-enabled + env-missing paths.
+    process.env.META_BUSINESS_ACCESS_TOKEN = "fake-token-only";
+    mockedConfig = {
+      catalog: [{ slug: "whatsapp", enabled: true }],
+    };
+    expect(() => registerBuiltinInstallHandlers()).not.toThrow();
+    expect(() =>
+      getInstallHandler({ slug: "whatsapp", install_model: "static-bot" }),
+    ).toThrow(/No static-bot install handler registered/);
+  });
+
+  it("does not throw when the catalog has no whatsapp row at all (operator hasn't opted in)", () => {
     mockedConfig = { catalog: [{ slug: "slack", enabled: true }] };
     expect(() => registerBuiltinInstallHandlers()).not.toThrow();
   });

--- a/packages/api/src/lib/integrations/install/__tests__/whatsapp-static-bot-handler.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/whatsapp-static-bot-handler.test.ts
@@ -1,0 +1,465 @@
+/**
+ * Tests for {@link WhatsAppStaticBotInstallHandler} — slice 15 of 1.5.3
+ * (issue #2753). WhatsApp is the fourth concrete implementation of the
+ * `StaticBotInstallHandler` interface keystoned by Telegram (#2748)
+ * after Discord (#2749) and Teams (#2752).
+ *
+ * The shared contract pinned by the sibling handler tests carries over
+ * (validate identifier → reachability round-trip → UPSERT → tagged
+ * errors → no half-installed rows). The WhatsApp-specific divergences
+ * this suite exercises:
+ *
+ *   - Routing identifier is a **Meta phone_number_id** — a numeric
+ *     routing id distinct from the human-readable phone number. Pasted
+ *     phone numbers (`+1 415 555 0100`) and WhatsApp Business Account
+ *     IDs are rejected before the API call.
+ *   - Reachability is verified via Meta Graph API
+ *     `GET /v21.0/{phone_number_id}` with the operator access token in
+ *     `Authorization: Bearer`. Meta's failure envelope is nested under
+ *     `{ error: { message, code, ... } }` — distinct from Discord's
+ *     top-level `{ message, code }`.
+ *   - Optional `display_phone` rides through `extras` analogous to
+ *     Discord's `guild_name`, and falls back to Meta's
+ *     `display_phone_number` when extras don't supply one (mirrors the
+ *     Discord guild-name fallback).
+ *   - Token redaction is NOT required for the URL — the access token
+ *     rides in `Authorization: Bearer`, not in the path — but we still
+ *     assert errors don't attach `cause: err` (preserves symmetry with
+ *     the Discord / Telegram / Teams safe-by-default posture).
+ *
+ * `mock.module()` stubs the two module dependencies the handler reaches
+ * into: `lib/db/internal` (`internalQuery`) and the global `fetch` used
+ * for the Meta Graph API call. Each mock exports every named export it
+ * shadows (CLAUDE.md "mock all exports" rule).
+ */
+
+import { afterEach, beforeEach, describe, expect, it, mock, type Mock } from "bun:test";
+import type { WorkspaceId } from "@useatlas/types";
+
+// ---------------------------------------------------------------------------
+// Module mocks — hoist above the handler import
+// ---------------------------------------------------------------------------
+
+const mockInternalQuery: Mock<(sql: string, params?: unknown[]) => Promise<unknown[]>> = mock(() =>
+  Promise.resolve([{ id: "install-whatsapp-row-1" }]),
+);
+
+mock.module("@atlas/api/lib/db/internal", () => ({
+  internalQuery: mockInternalQuery,
+  hasInternalDB: mock(() => true),
+  getInternalDB: mock(() => ({ query: mock(() => Promise.resolve({ rows: [] })) })),
+}));
+
+// ---------------------------------------------------------------------------
+// Test scaffolding
+// ---------------------------------------------------------------------------
+
+const wsid = "org-test" as WorkspaceId;
+
+// Sample phone_number_id — Meta's docs use 15-digit numeric ids; this
+// is shape-correct without being any real production number.
+const SAMPLE_PHONE_NUMBER_ID = "1098765432109876";
+
+interface FetchCall {
+  readonly url: string;
+  readonly init?: RequestInit;
+}
+const fetchCalls: FetchCall[] = [];
+const ORIGINAL_FETCH = globalThis.fetch;
+
+type FetchInput = string | URL | Request;
+
+function setFetchOk(
+  body: { id?: string; display_phone_number?: string; verified_name?: string } = {},
+): void {
+  globalThis.fetch = (async (input: FetchInput, init?: RequestInit) => {
+    fetchCalls.push({ url: String(input), ...(init ? { init } : {}) });
+    return new Response(
+      JSON.stringify({
+        id: body.id ?? SAMPLE_PHONE_NUMBER_ID,
+        ...(body.display_phone_number !== undefined
+          ? { display_phone_number: body.display_phone_number }
+          : { display_phone_number: "+1 415 555 0100" }),
+        ...(body.verified_name !== undefined
+          ? { verified_name: body.verified_name }
+          : { verified_name: "Atlas Test Co" }),
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+  }) as unknown as typeof fetch;
+}
+
+function setFetchMetaError(message: string, code: number, status: number): void {
+  globalThis.fetch = (async (input: FetchInput, init?: RequestInit) => {
+    fetchCalls.push({ url: String(input), ...(init ? { init } : {}) });
+    return new Response(
+      JSON.stringify({ error: { message, type: "OAuthException", code } }),
+      { status, headers: { "content-type": "application/json" } },
+    );
+  }) as unknown as typeof fetch;
+}
+
+function setFetchNonJson(status: number): void {
+  globalThis.fetch = (async (input: FetchInput, init?: RequestInit) => {
+    fetchCalls.push({ url: String(input), ...(init ? { init } : {}) });
+    return new Response("<html>error</html>", {
+      status,
+      headers: { "content-type": "text/html" },
+    });
+  }) as unknown as typeof fetch;
+}
+
+function setFetchNetworkError(): void {
+  globalThis.fetch = (async () => {
+    throw new TypeError("simulated network failure");
+  }) as unknown as typeof fetch;
+}
+
+beforeEach(() => {
+  mockInternalQuery.mockClear();
+  mockInternalQuery.mockImplementation(() =>
+    Promise.resolve([{ id: "install-whatsapp-row-1" }]),
+  );
+  fetchCalls.length = 0;
+  setFetchOk();
+});
+
+afterEach(() => {
+  globalThis.fetch = ORIGINAL_FETCH;
+});
+
+// ---------------------------------------------------------------------------
+// Handler import (after mocks)
+// ---------------------------------------------------------------------------
+
+import {
+  WhatsAppStaticBotInstallHandler,
+  WHATSAPP_CATALOG_ID,
+  WHATSAPP_SLUG,
+  WHATSAPP_PHONE_NUMBER_ID_RE,
+} from "../whatsapp-static-bot-handler";
+
+// ---------------------------------------------------------------------------
+// Constructor + kind
+// ---------------------------------------------------------------------------
+
+describe("WhatsAppStaticBotInstallHandler — shape", () => {
+  it("identifies itself with kind: 'static-bot' for dispatch narrowing", () => {
+    const handler = new WhatsAppStaticBotInstallHandler({
+      accessToken: "EAAxxx",
+      appId: "111222333",
+    });
+    expect(handler.kind).toBe("static-bot");
+  });
+
+  it("refuses to construct when accessToken is empty — actionable env name in the error", () => {
+    expect(
+      () => new WhatsAppStaticBotInstallHandler({ accessToken: "", appId: "id" }),
+    ).toThrow(/META_BUSINESS_ACCESS_TOKEN/);
+  });
+
+  it("refuses to construct when appId is empty — actionable env name in the error", () => {
+    expect(
+      () => new WhatsAppStaticBotInstallHandler({ accessToken: "t", appId: "" }),
+    ).toThrow(/META_BUSINESS_APP_ID/);
+  });
+
+  it("exposes applicationId for the setup link / manifest deep-link routes", () => {
+    const handler = new WhatsAppStaticBotInstallHandler({
+      accessToken: "EAAxxx",
+      appId: "the-meta-app-id",
+    });
+    expect(handler.applicationId).toBe("the-meta-app-id");
+  });
+
+  it("exports WHATSAPP_SLUG and WHATSAPP_CATALOG_ID — wired into register.ts + workspace-installer dispatch", () => {
+    expect(WHATSAPP_SLUG).toBe("whatsapp");
+    expect(WHATSAPP_CATALOG_ID).toBe("catalog:whatsapp");
+  });
+
+  it("WHATSAPP_PHONE_NUMBER_ID_RE accepts numeric ids and rejects obvious paste-mistakes", () => {
+    // Canonical 16-digit id
+    expect(WHATSAPP_PHONE_NUMBER_ID_RE.test(SAMPLE_PHONE_NUMBER_ID)).toBe(true);
+    // 10-digit edge of the valid range
+    expect(WHATSAPP_PHONE_NUMBER_ID_RE.test("1234567890")).toBe(true);
+    // Human-readable phone number — rejected
+    expect(WHATSAPP_PHONE_NUMBER_ID_RE.test("+1 415 555 0100")).toBe(false);
+    expect(WHATSAPP_PHONE_NUMBER_ID_RE.test("+14155550100")).toBe(false);
+    // Too short
+    expect(WHATSAPP_PHONE_NUMBER_ID_RE.test("123456")).toBe(false);
+    // Non-numeric characters
+    expect(WHATSAPP_PHONE_NUMBER_ID_RE.test("12345abc6789")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// phone_number_id validation
+// ---------------------------------------------------------------------------
+
+describe("WhatsAppStaticBotInstallHandler.confirmInstall — phone_number_id validation", () => {
+  it("rejects empty phone_number_id", async () => {
+    const handler = new WhatsAppStaticBotInstallHandler({ accessToken: "t", appId: "id" });
+    await expect(handler.confirmInstall(wsid, "")).rejects.toThrow(/phone_number_id/);
+    expect(mockInternalQuery).not.toHaveBeenCalled();
+    // No upstream call either — format validation happens first.
+    expect(fetchCalls).toHaveLength(0);
+  });
+
+  it("rejects human-readable phone numbers — admins routinely paste these by mistake", async () => {
+    const handler = new WhatsAppStaticBotInstallHandler({ accessToken: "t", appId: "id" });
+    await expect(handler.confirmInstall(wsid, "+1 415 555 0100")).rejects.toThrow(
+      /phone_number_id/,
+    );
+    await expect(handler.confirmInstall(wsid, "+14155550100")).rejects.toThrow(
+      /phone_number_id/,
+    );
+    expect(mockInternalQuery).not.toHaveBeenCalled();
+    expect(fetchCalls).toHaveLength(0);
+  });
+
+  it("rejects non-numeric strings (display names, etc.)", async () => {
+    const handler = new WhatsAppStaticBotInstallHandler({ accessToken: "t", appId: "id" });
+    await expect(handler.confirmInstall(wsid, "Acme Inc")).rejects.toThrow(
+      /phone_number_id/,
+    );
+    await expect(handler.confirmInstall(wsid, "12345abc")).rejects.toThrow(
+      /phone_number_id/,
+    );
+    expect(mockInternalQuery).not.toHaveBeenCalled();
+  });
+
+  it("accepts a canonical numeric id", async () => {
+    const handler = new WhatsAppStaticBotInstallHandler({ accessToken: "t", appId: "id" });
+    const result = await handler.confirmInstall(wsid, SAMPLE_PHONE_NUMBER_ID);
+    expect(result.installRecord.catalogId).toBe(WHATSAPP_SLUG);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Reachability verification (Meta Graph API)
+// ---------------------------------------------------------------------------
+
+describe("WhatsAppStaticBotInstallHandler.confirmInstall — reachability verification", () => {
+  it("calls Meta Graph API with the phone_number_id in the path and bearer auth", async () => {
+    const handler = new WhatsAppStaticBotInstallHandler({
+      accessToken: "EAA-test-token",
+      appId: "id",
+    });
+    await handler.confirmInstall(wsid, SAMPLE_PHONE_NUMBER_ID);
+    expect(fetchCalls).toHaveLength(1);
+    expect(fetchCalls[0].url).toBe(
+      `https://graph.facebook.com/v21.0/${SAMPLE_PHONE_NUMBER_ID}?fields=verified_name,display_phone_number`,
+    );
+    const headers = (fetchCalls[0].init?.headers ?? {}) as Record<string, string>;
+    expect(headers.Authorization).toBe("Bearer EAA-test-token");
+  });
+
+  it("never embeds the access token in the URL — token rides in Authorization header", async () => {
+    const handler = new WhatsAppStaticBotInstallHandler({
+      accessToken: "EAA-secret-do-not-leak",
+      appId: "id",
+    });
+    await handler.confirmInstall(wsid, SAMPLE_PHONE_NUMBER_ID);
+    expect(fetchCalls[0].url).not.toContain("EAA-secret-do-not-leak");
+  });
+
+  it("throws WhatsAppReachabilityError when Meta returns code 100 (phone not in operator's Business Account)", async () => {
+    setFetchMetaError(
+      "Unsupported get request. Object with ID '0' does not exist, cannot be loaded due to missing permissions, or does not support this operation.",
+      100,
+      400,
+    );
+    const handler = new WhatsAppStaticBotInstallHandler({ accessToken: "t", appId: "id" });
+    await expect(handler.confirmInstall(wsid, SAMPLE_PHONE_NUMBER_ID)).rejects.toThrow(
+      /Unsupported get request/,
+    );
+    expect(mockInternalQuery).not.toHaveBeenCalled();
+  });
+
+  it("appends the operator-side hint for code 100 (phone not shared into Business Account)", async () => {
+    setFetchMetaError("Tried accessing nonexisting field", 100, 400);
+    const handler = new WhatsAppStaticBotInstallHandler({ accessToken: "t", appId: "id" });
+    let caught: Error | undefined;
+    try {
+      await handler.confirmInstall(wsid, SAMPLE_PHONE_NUMBER_ID);
+    } catch (err) {
+      caught = err instanceof Error ? err : new Error(String(err));
+    }
+    expect(caught?.message).toContain("isn't visible to the operator's Meta Business Account");
+  });
+
+  it("throws with token-rotation hint when Meta returns code 190 (token expired)", async () => {
+    setFetchMetaError("Error validating access token: Session has expired.", 190, 401);
+    const handler = new WhatsAppStaticBotInstallHandler({ accessToken: "t", appId: "id" });
+    let caught: Error | undefined;
+    try {
+      await handler.confirmInstall(wsid, SAMPLE_PHONE_NUMBER_ID);
+    } catch (err) {
+      caught = err instanceof Error ? err : new Error(String(err));
+    }
+    expect(caught?.message).toMatch(/META_BUSINESS_ACCESS_TOKEN/);
+    expect(mockInternalQuery).not.toHaveBeenCalled();
+  });
+
+  it("throws WhatsAppApiUnavailableError when the Graph API call fails at the network layer (no install row)", async () => {
+    setFetchNetworkError();
+    const handler = new WhatsAppStaticBotInstallHandler({ accessToken: "t", appId: "id" });
+    await expect(handler.confirmInstall(wsid, SAMPLE_PHONE_NUMBER_ID)).rejects.toThrow(
+      /Meta Graph API unreachable/,
+    );
+    expect(mockInternalQuery).not.toHaveBeenCalled();
+  });
+
+  it("throws when Meta returns a non-JSON body — upstream contract violation", async () => {
+    setFetchNonJson(503);
+    const handler = new WhatsAppStaticBotInstallHandler({ accessToken: "t", appId: "id" });
+    await expect(handler.confirmInstall(wsid, SAMPLE_PHONE_NUMBER_ID)).rejects.toThrow(
+      /Meta Graph API/,
+    );
+    expect(mockInternalQuery).not.toHaveBeenCalled();
+  });
+
+  it("throws when Meta returns 2xx but no id field — upstream contract violation, not silent success", async () => {
+    globalThis.fetch = (async (input: FetchInput, init?: RequestInit) => {
+      fetchCalls.push({ url: String(input), ...(init ? { init } : {}) });
+      return new Response(JSON.stringify({ foo: "bar" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }) as unknown as typeof fetch;
+    const handler = new WhatsAppStaticBotInstallHandler({ accessToken: "t", appId: "id" });
+    await expect(handler.confirmInstall(wsid, SAMPLE_PHONE_NUMBER_ID)).rejects.toThrow(
+      /unexpected response shape/,
+    );
+    expect(mockInternalQuery).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Persistence
+// ---------------------------------------------------------------------------
+
+describe("WhatsAppStaticBotInstallHandler.confirmInstall — persistence", () => {
+  it("UPSERTs workspace_plugins with the catalog id + phone_number_id config payload", async () => {
+    const handler = new WhatsAppStaticBotInstallHandler({ accessToken: "t", appId: "id" });
+    await handler.confirmInstall(wsid, SAMPLE_PHONE_NUMBER_ID, undefined, {
+      display_phone: "Acme Sales Line",
+    });
+
+    expect(mockInternalQuery).toHaveBeenCalledTimes(1);
+    const [sql, params] = mockInternalQuery.mock.calls[0];
+    const sqlText = String(sql);
+    expect(sqlText).toMatch(/INSERT INTO workspace_plugins/);
+    // Required NOT NULL columns post-0092 / 0096 — the INSERT must
+    // name pillar + install_id explicitly, and chat-pillar installs
+    // target the partial singleton index via the WHERE clause on the
+    // conflict target so re-install is idempotent.
+    expect(sqlText).toMatch(/install_id/);
+    expect(sqlText).toMatch(/pillar/);
+    expect(sqlText).toMatch(/'chat'/);
+    expect(sqlText).toMatch(/ON CONFLICT.*workspace_id.*catalog_id.*WHERE.*pillar.*DO UPDATE/s);
+
+    const paramsArr = params as unknown[];
+    expect(paramsArr).toContain(wsid);
+    expect(paramsArr).toContain(WHATSAPP_CATALOG_ID);
+    const configJson = paramsArr.find(
+      (p): p is string => typeof p === "string" && p.includes("phone_number_id"),
+    );
+    expect(configJson).toBeDefined();
+    const parsed = JSON.parse(configJson as string) as Record<string, unknown>;
+    expect(parsed.phone_number_id).toBe(SAMPLE_PHONE_NUMBER_ID);
+    // extras override beats the API fallback
+    expect(parsed.display_phone).toBe("Acme Sales Line");
+  });
+
+  it("falls back to Meta's display_phone_number when extras don't supply display_phone (Discord-style fallback)", async () => {
+    setFetchOk({ display_phone_number: "+44 20 7946 0958" });
+    const handler = new WhatsAppStaticBotInstallHandler({ accessToken: "t", appId: "id" });
+    await handler.confirmInstall(wsid, SAMPLE_PHONE_NUMBER_ID);
+    const [, params] = mockInternalQuery.mock.calls[0];
+    const configJson = (params as unknown[]).find(
+      (p): p is string => typeof p === "string" && p.includes("phone_number_id"),
+    );
+    const parsed = JSON.parse(configJson as string) as Record<string, unknown>;
+    expect(parsed.display_phone).toBe("+44 20 7946 0958");
+  });
+
+  it("omits display_phone when neither extras nor API supplied one", async () => {
+    // Override the fetch to return only `id`, no display_phone_number.
+    globalThis.fetch = (async (input: FetchInput, init?: RequestInit) => {
+      fetchCalls.push({ url: String(input), ...(init ? { init } : {}) });
+      return new Response(JSON.stringify({ id: SAMPLE_PHONE_NUMBER_ID }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }) as unknown as typeof fetch;
+    const handler = new WhatsAppStaticBotInstallHandler({ accessToken: "t", appId: "id" });
+    await handler.confirmInstall(wsid, SAMPLE_PHONE_NUMBER_ID);
+    const [, params] = mockInternalQuery.mock.calls[0];
+    const configJson = (params as unknown[]).find(
+      (p): p is string => typeof p === "string" && p.includes("phone_number_id"),
+    );
+    const parsed = JSON.parse(configJson as string) as Record<string, unknown>;
+    expect("display_phone" in parsed).toBe(false);
+  });
+
+  it("drops display_phone when extras supplies the wrong type (number / null) — logs but doesn't throw", async () => {
+    const handler = new WhatsAppStaticBotInstallHandler({ accessToken: "t", appId: "id" });
+    await handler.confirmInstall(wsid, SAMPLE_PHONE_NUMBER_ID, undefined, {
+      display_phone: 12345 as unknown as string,
+    });
+    const [, params] = mockInternalQuery.mock.calls[0];
+    const configJson = (params as unknown[]).find(
+      (p): p is string => typeof p === "string" && p.includes("phone_number_id"),
+    );
+    const parsed = JSON.parse(configJson as string) as Record<string, unknown>;
+    // Falls back to the API-provided value, not the malformed extras.
+    expect(parsed.display_phone).toBe("+1 415 555 0100");
+  });
+
+  it("returns the persisted install id from RETURNING (re-install idempotency)", async () => {
+    mockInternalQuery.mockImplementation(() =>
+      Promise.resolve([{ id: "existing-install-row" }]),
+    );
+    const handler = new WhatsAppStaticBotInstallHandler({ accessToken: "t", appId: "id" });
+    const result = await handler.confirmInstall(wsid, SAMPLE_PHONE_NUMBER_ID);
+    expect(result.installRecord.id).toBe("existing-install-row");
+    expect(result.installRecord.workspaceId).toBe(wsid);
+    expect(result.installRecord.catalogId).toBe(WHATSAPP_SLUG);
+  });
+
+  it("throws when RETURNING comes back empty — never ships a candidate id that doesn't match the persisted row", async () => {
+    mockInternalQuery.mockImplementation(() => Promise.resolve([]));
+    const handler = new WhatsAppStaticBotInstallHandler({
+      accessToken: "t",
+      appId: "id",
+      idGenerator: () => "candidate-id-xyz",
+    });
+    await expect(handler.confirmInstall(wsid, SAMPLE_PHONE_NUMBER_ID)).rejects.toThrow(
+      /RETURNING must always populate/,
+    );
+  });
+
+  it("surfaces DB failure rather than half-installing — no return after a throw", async () => {
+    mockInternalQuery.mockImplementation(() => Promise.reject(new Error("DB down")));
+    const handler = new WhatsAppStaticBotInstallHandler({ accessToken: "t", appId: "id" });
+    await expect(handler.confirmInstall(wsid, SAMPLE_PHONE_NUMBER_ID)).rejects.toThrow(/DB down/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// verificationProof — interface-defined but unused for WhatsApp today
+// ---------------------------------------------------------------------------
+
+describe("WhatsAppStaticBotInstallHandler.confirmInstall — verificationProof", () => {
+  it("ignores verificationProof when supplied — reachability is verified server-side via Graph API", async () => {
+    const handler = new WhatsAppStaticBotInstallHandler({ accessToken: "t", appId: "id" });
+    const result = await handler.confirmInstall(
+      wsid,
+      SAMPLE_PHONE_NUMBER_ID,
+      "ignored-proof",
+    );
+    expect(result.installRecord.catalogId).toBe(WHATSAPP_SLUG);
+    expect(fetchCalls).toHaveLength(1);
+  });
+});

--- a/packages/api/src/lib/integrations/install/__tests__/whatsapp-static-bot-handler.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/whatsapp-static-bot-handler.test.ts
@@ -333,6 +333,92 @@ describe("WhatsAppStaticBotInstallHandler.confirmInstall — reachability verifi
     );
     expect(mockInternalQuery).not.toHaveBeenCalled();
   });
+
+  it("refuses 2xx responses that ALSO carry an error envelope — silent-success defense (P0 from review)", async () => {
+    // Meta has been observed to ship 200/204 responses with a populated
+    // `error` object on partial-batch traversals / debug-payload opt-ins
+    // / proxy-injected envelopes. Treating those as success would write
+    // a workspace_plugins row for a phone number Meta is actively
+    // rejecting. Parser refuses; caller surfaces upstream-contract
+    // violation. The previous version of this parser would silently
+    // succeed here.
+    globalThis.fetch = (async (input: FetchInput, init?: RequestInit) => {
+      fetchCalls.push({ url: String(input), ...(init ? { init } : {}) });
+      return new Response(
+        JSON.stringify({
+          id: SAMPLE_PHONE_NUMBER_ID,
+          error: { message: "Partial batch failure", type: "Exception", code: 200 },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }) as unknown as typeof fetch;
+    const handler = new WhatsAppStaticBotInstallHandler({ accessToken: "t", appId: "id" });
+    await expect(handler.confirmInstall(wsid, SAMPLE_PHONE_NUMBER_ID)).rejects.toThrow(
+      /unexpected response shape/,
+    );
+    expect(mockInternalQuery).not.toHaveBeenCalled();
+  });
+
+  it("refuses non-2xx responses with an empty error envelope — upstream contract violation", async () => {
+    // The `{ message: "", code: 0 }` empty-body branch in the parser
+    // forces this path through `WhatsAppApiUnavailableError` rather
+    // than fabricating a WhatsAppReachabilityError with an empty
+    // message (which would surface as "Meta rejected …:  — " with no
+    // hint for the admin).
+    globalThis.fetch = (async (input: FetchInput, init?: RequestInit) => {
+      fetchCalls.push({ url: String(input), ...(init ? { init } : {}) });
+      return new Response(JSON.stringify({ error: {} }), {
+        status: 400,
+        headers: { "content-type": "application/json" },
+      });
+    }) as unknown as typeof fetch;
+    const handler = new WhatsAppStaticBotInstallHandler({ accessToken: "t", appId: "id" });
+    await expect(handler.confirmInstall(wsid, SAMPLE_PHONE_NUMBER_ID)).rejects.toThrow(
+      /unexpected response shape/,
+    );
+    expect(mockInternalQuery).not.toHaveBeenCalled();
+  });
+
+  it("does NOT attach the underlying fetch error as `cause` — preserves the no-leak posture on Authorization headers", async () => {
+    // A future pino serializer walking through `cause` could otherwise
+    // dump the request headers (which include `Authorization: Bearer
+    // <token>`). The keystone family preserves `cause: undefined`
+    // explicitly; this test locks the invariant on the WhatsApp
+    // handler so a well-intentioned refactor can't silently
+    // re-introduce the leak.
+    setFetchNetworkError();
+    const handler = new WhatsAppStaticBotInstallHandler({
+      accessToken: "EAA-secret-do-not-leak",
+      appId: "id",
+    });
+    let caught: Error | undefined;
+    try {
+      await handler.confirmInstall(wsid, SAMPLE_PHONE_NUMBER_ID);
+    } catch (err) {
+      caught = err instanceof Error ? err : new Error(String(err));
+    }
+    expect(caught).toBeDefined();
+    expect(caught?.cause).toBeUndefined();
+    // Belt-and-suspenders: the surface message must not contain the
+    // raw token either.
+    expect(caught?.message).not.toContain("EAA-secret-do-not-leak");
+  });
+
+  it("does NOT attach `cause` on the reachability-error path (Meta returned 4xx)", async () => {
+    setFetchMetaError("Tried accessing nonexisting field", 100, 400);
+    const handler = new WhatsAppStaticBotInstallHandler({
+      accessToken: "EAA-secret-do-not-leak",
+      appId: "id",
+    });
+    let caught: Error | undefined;
+    try {
+      await handler.confirmInstall(wsid, SAMPLE_PHONE_NUMBER_ID);
+    } catch (err) {
+      caught = err instanceof Error ? err : new Error(String(err));
+    }
+    expect(caught?.cause).toBeUndefined();
+    expect(caught?.message).not.toContain("EAA-secret-do-not-leak");
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -404,6 +490,15 @@ describe("WhatsAppStaticBotInstallHandler.confirmInstall — persistence", () =>
   });
 
   it("drops display_phone when extras supplies the wrong type (number / null) — logs but doesn't throw", async () => {
+    // Isolate the "wrong-type drop" behavior from the fallback chain
+    // by giving Meta nothing to fall back through.
+    globalThis.fetch = (async (input: FetchInput, init?: RequestInit) => {
+      fetchCalls.push({ url: String(input), ...(init ? { init } : {}) });
+      return new Response(JSON.stringify({ id: SAMPLE_PHONE_NUMBER_ID }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }) as unknown as typeof fetch;
     const handler = new WhatsAppStaticBotInstallHandler({ accessToken: "t", appId: "id" });
     await handler.confirmInstall(wsid, SAMPLE_PHONE_NUMBER_ID, undefined, {
       display_phone: 12345 as unknown as string,
@@ -413,7 +508,47 @@ describe("WhatsAppStaticBotInstallHandler.confirmInstall — persistence", () =>
       (p): p is string => typeof p === "string" && p.includes("phone_number_id"),
     );
     const parsed = JSON.parse(configJson as string) as Record<string, unknown>;
-    // Falls back to the API-provided value, not the malformed extras.
+    // With no API fallback either, the field is omitted entirely.
+    expect("display_phone" in parsed).toBe(false);
+  });
+
+  it("falls back to Meta's verified_name when display_phone_number is absent (third-tier fallback)", async () => {
+    globalThis.fetch = (async (input: FetchInput, init?: RequestInit) => {
+      fetchCalls.push({ url: String(input), ...(init ? { init } : {}) });
+      return new Response(
+        JSON.stringify({ id: SAMPLE_PHONE_NUMBER_ID, verified_name: "Acme Test Co" }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }) as unknown as typeof fetch;
+    const handler = new WhatsAppStaticBotInstallHandler({ accessToken: "t", appId: "id" });
+    await handler.confirmInstall(wsid, SAMPLE_PHONE_NUMBER_ID);
+    const [, params] = mockInternalQuery.mock.calls[0];
+    const configJson = (params as unknown[]).find(
+      (p): p is string => typeof p === "string" && p.includes("phone_number_id"),
+    );
+    const parsed = JSON.parse(configJson as string) as Record<string, unknown>;
+    expect(parsed.display_phone).toBe("Acme Test Co");
+  });
+
+  it("prefers display_phone_number over verified_name when both are present", async () => {
+    globalThis.fetch = (async (input: FetchInput, init?: RequestInit) => {
+      fetchCalls.push({ url: String(input), ...(init ? { init } : {}) });
+      return new Response(
+        JSON.stringify({
+          id: SAMPLE_PHONE_NUMBER_ID,
+          display_phone_number: "+1 415 555 0100",
+          verified_name: "Acme Test Co",
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }) as unknown as typeof fetch;
+    const handler = new WhatsAppStaticBotInstallHandler({ accessToken: "t", appId: "id" });
+    await handler.confirmInstall(wsid, SAMPLE_PHONE_NUMBER_ID);
+    const [, params] = mockInternalQuery.mock.calls[0];
+    const configJson = (params as unknown[]).find(
+      (p): p is string => typeof p === "string" && p.includes("phone_number_id"),
+    );
+    const parsed = JSON.parse(configJson as string) as Record<string, unknown>;
     expect(parsed.display_phone).toBe("+1 415 555 0100");
   });
 

--- a/packages/api/src/lib/integrations/install/dispatch.ts
+++ b/packages/api/src/lib/integrations/install/dispatch.ts
@@ -133,7 +133,7 @@ export function getInstallHandler(
       const handler = staticBotHandlers.get(catalogRow.slug);
       if (!handler) {
         throw new Error(
-          `No static-bot install handler registered for catalog slug "${catalogRow.slug}". Register via registerStaticBotHandler() at module load (set the operator env vars the handler needs — TELEGRAM_BOT_TOKEN for telegram; DISCORD_BOT_TOKEN + DISCORD_CLIENT_ID for discord).`,
+          `No static-bot install handler registered for catalog slug "${catalogRow.slug}". Register via registerStaticBotHandler() at module load (set the operator env vars the handler needs — TELEGRAM_BOT_TOKEN for telegram; DISCORD_BOT_TOKEN + DISCORD_CLIENT_ID for discord; TEAMS_APP_ID + TEAMS_APP_PASSWORD for teams; META_BUSINESS_ACCESS_TOKEN + META_BUSINESS_APP_ID for whatsapp).`,
         );
       }
       return handler;

--- a/packages/api/src/lib/integrations/install/index.ts
+++ b/packages/api/src/lib/integrations/install/index.ts
@@ -64,6 +64,26 @@ export type {
   DiscordInstallConfig,
 } from "./discord-static-bot-handler";
 export {
+  TeamsStaticBotInstallHandler,
+  TEAMS_CATALOG_ID,
+  TEAMS_SLUG,
+  TEAMS_TENANT_ID_RE,
+} from "./teams-static-bot-handler";
+export type {
+  TeamsStaticBotHandlerConfig,
+  TeamsInstallConfig,
+} from "./teams-static-bot-handler";
+export {
+  WhatsAppStaticBotInstallHandler,
+  WHATSAPP_CATALOG_ID,
+  WHATSAPP_SLUG,
+  WHATSAPP_PHONE_NUMBER_ID_RE,
+} from "./whatsapp-static-bot-handler";
+export type {
+  WhatsAppStaticBotHandlerConfig,
+  WhatsAppInstallConfig,
+} from "./whatsapp-static-bot-handler";
+export {
   EmailFormInstallHandler,
   EmailFormDataSchema,
   EmailFormValidationError,

--- a/packages/api/src/lib/integrations/install/register.ts
+++ b/packages/api/src/lib/integrations/install/register.ts
@@ -46,6 +46,10 @@ import {
   TeamsStaticBotInstallHandler,
   TEAMS_SLUG,
 } from "./teams-static-bot-handler";
+import {
+  WhatsAppStaticBotInstallHandler,
+  WHATSAPP_SLUG,
+} from "./whatsapp-static-bot-handler";
 import { lazyPluginLoader } from "@atlas/api/lib/plugins/lazy-loader";
 import { createJiraLazyBuilder } from "@atlas/api/lib/integrations/jira/lazy-builder";
 import { createSalesforceLazyBuilder } from "@atlas/api/lib/integrations/salesforce/lazy-builder";
@@ -185,6 +189,7 @@ export function registerBuiltinInstallHandlers(): void {
   registerTelegramStaticBotHandler();
   registerDiscordStaticBotHandler();
   registerTeamsStaticBotHandler();
+  registerWhatsAppStaticBotHandler();
 }
 
 function registerSlackOAuthHandler(): void {
@@ -486,6 +491,69 @@ function registerTeamsStaticBotHandler(): void {
       appPasswordFingerprint: fingerprintToken(appPassword),
     },
     "Registered TeamsStaticBotInstallHandler",
+  );
+}
+
+/**
+ * Register the WhatsApp static-bot install handler when the operator env
+ * is wired (#2753). Mirrors {@link registerTeamsStaticBotHandler} exactly
+ * — same severity-escalation contract when the catalog row says
+ * `enabled: true` but a required env var is missing.
+ *
+ * Two env vars gate registration: `META_BUSINESS_ACCESS_TOKEN` (the
+ * operator's WhatsApp Business Cloud API System User token) and
+ * `META_BUSINESS_APP_ID` (the operator's Meta App ID, used by the
+ * install routes / manifest deep-link to be the single source of truth
+ * for "WhatsApp is wired"). Both are required because the install flow
+ * can't proceed without either — the route would otherwise 501 in a
+ * confusing half-wired way.
+ *
+ * `WHATSAPP_APP_SECRET` (HMAC-SHA256 webhook signature) and
+ * `WHATSAPP_VERIFY_TOKEN` (webhook challenge handshake) are required by
+ * the chat adapter (the inbound webhook path needs both) but are NOT
+ * required here — the install handler itself doesn't process webhooks.
+ * An operator who wires install creds but forgets the webhook envelope
+ * would get a working install + a non-functional receive path; the
+ * AdapterRegistry's missing-env log is the signal for that gap.
+ */
+function registerWhatsAppStaticBotHandler(): void {
+  const accessToken = process.env.META_BUSINESS_ACCESS_TOKEN;
+  const appId = process.env.META_BUSINESS_APP_ID;
+  if (
+    !accessToken ||
+    accessToken.length === 0 ||
+    !appId ||
+    appId.length === 0
+  ) {
+    if (isCatalogSlugEnabled("whatsapp")) {
+      log.error(
+        {
+          slug: "whatsapp",
+          requiredEnv: ["META_BUSINESS_ACCESS_TOKEN", "META_BUSINESS_APP_ID"],
+          missing: [
+            ...(!accessToken ? ["META_BUSINESS_ACCESS_TOKEN"] : []),
+            ...(!appId ? ["META_BUSINESS_APP_ID"] : []),
+          ],
+        },
+        "WhatsApp catalog row is enabled but META_BUSINESS_ACCESS_TOKEN and/or META_BUSINESS_APP_ID is unset — install route will return 501 and AdapterRegistry will skip the adapter. Set both per-service. See #2673 for the same-class silent-degradation precedent.",
+      );
+    } else {
+      log.info(
+        "WhatsApp static-bot handler not registered — META_BUSINESS_ACCESS_TOKEN and/or META_BUSINESS_APP_ID unset and the 'whatsapp' catalog row is not enabled (operator hasn't opted in).",
+      );
+    }
+    return;
+  }
+  registerStaticBotHandler(
+    WHATSAPP_SLUG,
+    new WhatsAppStaticBotInstallHandler({ accessToken, appId }),
+  );
+  log.info(
+    {
+      appIdFingerprint: fingerprintToken(appId),
+      accessTokenFingerprint: fingerprintToken(accessToken),
+    },
+    "Registered WhatsAppStaticBotInstallHandler",
   );
 }
 

--- a/packages/api/src/lib/integrations/install/whatsapp-static-bot-handler.ts
+++ b/packages/api/src/lib/integrations/install/whatsapp-static-bot-handler.ts
@@ -26,9 +26,11 @@
  * A 200 confirms the phone number is owned by the operator's Meta
  * Business Account and the token has the requisite
  * `whatsapp_business_management` scope; the response also returns
- * `display_phone_number` and `verified_name`, which the install row uses
- * as the optional `display_phone` fallback when `extras` doesn't supply
- * one (mirrors Discord's `GET /guilds/{id}` → `guild_name` fallback).
+ * `display_phone_number` and `verified_name`, which the install row
+ * uses as the optional `display_phone` fallback chain when `extras`
+ * doesn't supply one (`extras.display_phone` → Meta's
+ * `display_phone_number` → Meta's `verified_name` → omit). Mirrors
+ * Discord's `GET /guilds/{id}` → `guild_name` fallback.
  *
  * Why this scoping matters: Meta's Cloud API lets one System User token
  * access every phone number under the Business Account it was minted
@@ -90,13 +92,13 @@ const META_GRAPH_API_VERSION = "v21.0";
 
 /**
  * WhatsApp Business phone number ids are decimal strings — Meta assigns
- * them when a phone is added to a WhatsApp Business Account. Documented
- * shape is "a numeric id"; current production values are 15–17 digits but
- * Meta's docs don't bound this. The 10–30 range here is defensive — wide
- * enough that a future Meta-side change doesn't reject valid input, tight
- * enough to reject the obvious paste mistakes (human-readable phone
- * numbers like `+1 415 555 0100`, the human display string, or a Meta
- * WhatsApp Business Account ID which is a different identifier).
+ * them when a phone is added to a WhatsApp Business Account. Meta's
+ * docs describe them as "a numeric id" without an explicit length bound.
+ * The 10–30 range here is defensive — wide enough that a future
+ * Meta-side change doesn't reject valid input, tight enough to reject
+ * the obvious paste mistakes (human-readable phone numbers like
+ * `+1 415 555 0100`, the human display string, or a WhatsApp Business
+ * Account ID which is a different identifier).
  *
  * Exported so the executeQuery dispatcher can reuse the same regex on
  * inbound webhook envelopes — keeps the phone_number_id invariant on a
@@ -131,17 +133,15 @@ export interface WhatsAppStaticBotHandlerConfig {
   readonly accessToken: string;
   /**
    * Operator's Meta App ID (`META_BUSINESS_APP_ID`). Captured at
-   * construction even though `confirmInstall` doesn't use it directly —
-   * the chat adapter and the manifest / setup-link routes need it, and
-   * the handler is the single source of truth for "WhatsApp is wired"
-   * so the env-gate at construction time fails loud if either var is
-   * missing. Mirrors Teams's `appId` capture posture.
+   * construction even though `confirmInstall` doesn't use it directly:
+   * the chat adapter consumes it via env, and the handler is the
+   * single source of truth for "WhatsApp is wired" so the env-gate at
+   * construction time fails loud if either var is missing. Mirrors
+   * Teams's `appId` capture posture.
    */
   readonly appId: string;
   /** Test-only injection of the install id generator. */
   readonly idGenerator?: () => string;
-  /** Test-only override of the Meta Graph API base URL. */
-  readonly metaGraphBaseUrl?: string;
 }
 
 /** Shape persisted into `workspace_plugins.config` JSONB. */
@@ -160,10 +160,17 @@ export interface WhatsAppInstallConfig {
  * Meta Graph API `GET /{phone_number_id}` parsed response. Success returns
  * `{ id, verified_name?, display_phone_number?, ... }`; failure returns
  * `{ error: { message, type, code, fbtrace_id } }`. Normalized at parse
- * time into an explicit `kind: "ok" | "err"` discriminated union — same
- * shape Discord's handler uses, same rationale (Meta's `error.code` is a
- * real value where `0` doesn't mean "no error", so absence-of-`code` is
- * NOT a safe discriminator).
+ * time into an explicit `kind: "ok" | "err"` discriminated union.
+ *
+ * Discriminator is HTTP status: 2xx → ok, non-2xx → err. We never key on
+ * `code` presence because Meta uses `error.code: 0` for some generic
+ * failure modes (so `code === 0` doesn't mean "no error"). A 2xx
+ * response that *also* carries an `error` object (Meta has been
+ * observed to do this on partial-batch traversals / debug payloads)
+ * is treated as an upstream contract violation, not a success — the
+ * 2xx branch refuses it via `null` so the caller surfaces
+ * `WhatsAppApiUnavailableError` rather than writing an install row
+ * for a phone number Meta is actively rejecting.
  */
 type WhatsAppPhoneNumberResponse =
   | {
@@ -186,6 +193,13 @@ function parseWhatsAppPhoneNumberResponse(
   const body = raw as Record<string, unknown>;
   if (httpStatus >= 200 && httpStatus < 300) {
     if (typeof body.id !== "string" || body.id.length === 0) return null;
+    // Meta has been observed to ship 2xx responses carrying a populated
+    // `error` object on partial-batch traversals / debug-payload opt-ins
+    // / proxy-injected envelopes. Treating those as success would write
+    // a workspace_plugins row for a phone number Meta is actively
+    // rejecting — refuse and surface as upstream-contract-violation
+    // via the caller's `null`-handling branch.
+    if (typeof body.error === "object" && body.error !== null) return null;
     const displayPhoneNumber =
       typeof body.display_phone_number === "string" && body.display_phone_number.length > 0
         ? body.display_phone_number
@@ -201,9 +215,12 @@ function parseWhatsAppPhoneNumberResponse(
       ...(verifiedName !== undefined ? { verifiedName } : {}),
     };
   }
-  // Meta's failure envelope nests under `error`. A bare top-level
-  // `{ message, code }` is not what Graph API ever returns, so we don't
-  // accept it — the upstream-contract-violation path covers it.
+  // Non-2xx: Meta's failure envelope nests under `error`. A bare
+  // top-level `{ message, code }` is not what Graph API ever returns,
+  // so we don't accept it — the upstream-contract-violation path
+  // (returning `null`) covers it. The 2xx branch above returned early,
+  // so we don't need to re-guard the `message.length === 0 && code === 0`
+  // check on status.
   const err = body.error;
   if (typeof err !== "object" || err === null) return null;
   const errObj = err as Record<string, unknown>;
@@ -222,7 +239,6 @@ export class WhatsAppStaticBotInstallHandler implements StaticBotInstallHandler 
 
   private readonly accessToken: string;
   private readonly appId: string;
-  private readonly metaGraphBaseUrl: string;
   private readonly newId: () => string;
 
   constructor(config: WhatsAppStaticBotHandlerConfig) {
@@ -238,15 +254,15 @@ export class WhatsAppStaticBotInstallHandler implements StaticBotInstallHandler 
     }
     this.accessToken = config.accessToken;
     this.appId = config.appId;
-    this.metaGraphBaseUrl =
-      config.metaGraphBaseUrl ?? `https://graph.facebook.com/${META_GRAPH_API_VERSION}`;
     this.newId = config.idGenerator ?? (() => crypto.randomUUID());
   }
 
   /**
-   * Operator's Meta App ID. Exposed so the install route can build setup
-   * deep-links / manifest download URLs without re-reading env. Mirrors
-   * `TeamsStaticBotInstallHandler.applicationId`.
+   * Operator's Meta App ID. Exposed for parity with the sibling static-
+   * bot handlers' `applicationId` getter (Discord, Teams) — a future
+   * WhatsApp install route can consume it to build a setup deep-link
+   * without re-reading env. No consumer in this PR; the getter exists
+   * to keep the structural contract consistent across the family.
    */
   get applicationId(): string {
     return this.appId;
@@ -274,8 +290,10 @@ export class WhatsAppStaticBotInstallHandler implements StaticBotInstallHandler 
     // ── 2. Reachability via Meta Graph API ──────────────────────────
     // Throws on Graph API errors / network failures *before* any DB
     // write, so a failed verification never leaves a half-installed
-    // row behind.
-    const apiDisplayPhone = await this.verifyReachability(routingIdentifier);
+    // row behind. Returns the (display_phone_number, verified_name)
+    // pair so extractDisplayPhone can fall back through both before
+    // omitting the label entirely.
+    const apiFallback = await this.verifyReachability(routingIdentifier);
 
     // ── 3. Persist install row — UPSERT keyed on (workspace, catalog) ─
     // Mirrors the email-form-handler / discord-static-bot-handler /
@@ -285,7 +303,7 @@ export class WhatsAppStaticBotInstallHandler implements StaticBotInstallHandler 
     const candidateId = this.newId();
     const configPayload: WhatsAppInstallConfig = {
       phone_number_id: routingIdentifier,
-      ...extractDisplayPhone(extras, apiDisplayPhone, workspaceId),
+      ...extractDisplayPhone(extras, apiFallback, workspaceId),
     };
 
     let persistedId: string;
@@ -359,10 +377,11 @@ export class WhatsAppStaticBotInstallHandler implements StaticBotInstallHandler 
   }
 
   /**
-   * Round-trip Meta Graph API to confirm the phone_number_id is owned by
-   * the operator's Meta Business Account and the access token has the
-   * required scopes. Returns Meta's `display_phone_number` when present
-   * so the install row can fall back to it when extras don't supply one.
+   * Round-trip Meta Graph API to confirm the phone_number_id is owned
+   * by the operator's Meta Business Account and the access token has
+   * the required scopes. Returns the `(displayPhoneNumber, verifiedName)`
+   * pair when present so the install row can fall through them before
+   * omitting the label.
    *
    * Token redaction: the access token rides in the `Authorization: Bearer`
    * header — NOT in the URL path — so URL-based redaction (the kind
@@ -370,9 +389,17 @@ export class WhatsAppStaticBotInstallHandler implements StaticBotInstallHandler 
    * `cause` to preserve symmetry with the sibling static-bot handlers'
    * safe-by-default posture (a future pino serializer walking through
    * `cause` could otherwise dump the request headers).
+   *
+   * Forensic anchors: when Meta returns a non-JSON body or a non-2xx
+   * status, we capture the `x-fb-trace-id` response header into the
+   * structured log payload. Operator-facing support tickets with Meta
+   * require this id to anchor the request on Meta's side; without it,
+   * triaging a persistent Meta-side gateway issue requires a tcpdump.
    */
-  private async verifyReachability(phoneNumberId: string): Promise<string | null> {
-    const url = `${this.metaGraphBaseUrl}/${encodeURIComponent(
+  private async verifyReachability(
+    phoneNumberId: string,
+  ): Promise<WhatsAppReachabilityFallback> {
+    const url = `https://graph.facebook.com/${META_GRAPH_API_VERSION}/${encodeURIComponent(
       phoneNumberId,
     )}?fields=verified_name,display_phone_number`;
     let response: Response;
@@ -394,6 +421,8 @@ export class WhatsAppStaticBotInstallHandler implements StaticBotInstallHandler 
       });
     }
 
+    const fbTraceId = response.headers.get("x-fb-trace-id") ?? undefined;
+
     let rawBody: unknown;
     try {
       rawBody = await response.json();
@@ -403,6 +432,7 @@ export class WhatsAppStaticBotInstallHandler implements StaticBotInstallHandler 
         {
           phoneNumberIdFingerprint: fingerprintPhoneNumberId(phoneNumberId),
           status: response.status,
+          fbTraceId,
           parseError: message,
         },
         "Meta Graph API returned non-JSON response",
@@ -414,6 +444,14 @@ export class WhatsAppStaticBotInstallHandler implements StaticBotInstallHandler 
 
     const parsed = parseWhatsAppPhoneNumberResponse(rawBody, response.status);
     if (parsed === null) {
+      log.warn(
+        {
+          phoneNumberIdFingerprint: fingerprintPhoneNumberId(phoneNumberId),
+          status: response.status,
+          fbTraceId,
+        },
+        "Meta Graph API returned an unexpected response shape — upstream contract violation",
+      );
       throw new WhatsAppApiUnavailableError({
         message: `Meta Graph API returned an unexpected response shape when verifying phone_number_id "${phoneNumberId}" (status ${response.status}).`,
       });
@@ -426,17 +464,37 @@ export class WhatsAppStaticBotInstallHandler implements StaticBotInstallHandler 
       });
     }
 
-    return parsed.displayPhoneNumber ?? null;
+    return {
+      displayPhoneNumber: parsed.displayPhoneNumber ?? null,
+      verifiedName: parsed.verifiedName ?? null,
+    };
   }
 }
 
 /**
+ * Result of a successful reachability round-trip. Both fields are
+ * Meta-provided and may be null when Meta omits them on the wire (rare
+ * but documented — verified names are gated on Meta's business
+ * verification flow). Threaded through {@link extractDisplayPhone} as
+ * a two-tier fallback (display_phone_number → verified_name → omit).
+ */
+interface WhatsAppReachabilityFallback {
+  readonly displayPhoneNumber: string | null;
+  readonly verifiedName: string | null;
+}
+
+/**
  * Extract the optional `display_phone` field. Order of preference:
- *   1. `extras.display_phone` if supplied by the install caller (admin UI
- *      override, or a future install flow forwarding a custom label).
+ *   1. `extras.display_phone` if supplied by the install caller (admin
+ *      UI override, or a future install flow forwarding a custom
+ *      label).
  *   2. The `display_phone_number` returned by Meta Graph API at
  *      verification time (e.g. `+1 415 555 0100`).
- *   3. Omit — the admin UI renders the phone_number_id alone.
+ *   3. The `verified_name` returned by Meta Graph API at verification
+ *      time (e.g. `"Acme Test Co"`) — only present when Meta has
+ *      completed business verification on the number; gives a more
+ *      descriptive admin-UI label than the raw phone when available.
+ *   4. Omit — the admin UI renders the phone_number_id alone.
  *
  * Drops any other keys from `extras` silently — the catalog
  * `config_schema` declares the contract; new fields land via a new
@@ -446,7 +504,7 @@ export class WhatsAppStaticBotInstallHandler implements StaticBotInstallHandler 
  */
 function extractDisplayPhone(
   extras: Record<string, unknown> | undefined,
-  apiFallback: string | null,
+  apiFallback: WhatsAppReachabilityFallback,
   workspaceId: WorkspaceId,
 ): { display_phone?: string } {
   if (extras !== undefined && "display_phone" in extras) {
@@ -463,7 +521,12 @@ function extractDisplayPhone(
       }
     }
   }
-  if (apiFallback && apiFallback.length > 0) return { display_phone: apiFallback };
+  if (apiFallback.displayPhoneNumber && apiFallback.displayPhoneNumber.length > 0) {
+    return { display_phone: apiFallback.displayPhoneNumber };
+  }
+  if (apiFallback.verifiedName && apiFallback.verifiedName.length > 0) {
+    return { display_phone: apiFallback.verifiedName };
+  }
   return {};
 }
 

--- a/packages/api/src/lib/integrations/install/whatsapp-static-bot-handler.ts
+++ b/packages/api/src/lib/integrations/install/whatsapp-static-bot-handler.ts
@@ -1,0 +1,542 @@
+/**
+ * `WhatsAppStaticBotInstallHandler` — slice 15 of 1.5.3 Phase D (issue
+ * #2753). Fourth concrete implementation of {@link StaticBotInstallHandler}
+ * after the Telegram keystone (#2748), Discord (#2749), and Teams (#2752).
+ *
+ * WhatsApp follows the same operator-shared static-bot pattern: one
+ * operator-owned Meta Business / WhatsApp Business Cloud API account
+ * (env: `META_BUSINESS_ACCESS_TOKEN` + `META_BUSINESS_APP_ID`) serves
+ * every customer. Each workspace's routing identifier is the **WhatsApp
+ * Business phone number id** — a numeric Meta identifier (distinct from
+ * the human-readable phone number) issued when the operator adds a phone
+ * to their WhatsApp Business Account. Optional `display_phone` rides
+ * through `extras` analogous to Discord's `guild_name` / Telegram's
+ * `display_name`.
+ *
+ * Per-Workspace credential note: there isn't one. WhatsApp Cloud API
+ * auth is keyed on the operator's System User access token; phone-number
+ * IDs are routing identifiers Meta leaks in every webhook envelope's
+ * `value.metadata.phone_number_id`. This handler writes
+ * `workspace_plugins.config` directly via `internalQuery` (mirroring
+ * `teams-static-bot-handler.ts`), so `encryptSecretFields` is not in
+ * the write path at all.
+ *
+ * Reachability verification: we call Meta Graph API
+ * `GET /v21.0/{phone_number_id}` with `Authorization: Bearer <token>`.
+ * A 200 confirms the phone number is owned by the operator's Meta
+ * Business Account and the token has the requisite
+ * `whatsapp_business_management` scope; the response also returns
+ * `display_phone_number` and `verified_name`, which the install row uses
+ * as the optional `display_phone` fallback when `extras` doesn't supply
+ * one (mirrors Discord's `GET /guilds/{id}` → `guild_name` fallback).
+ *
+ * Why this scoping matters: Meta's Cloud API lets one System User token
+ * access every phone number under the Business Account it was minted
+ * from, but it CANNOT access numbers under another Business Account
+ * (Meta returns `error.code: 100` with "Tried accessing nonexisting
+ * field" or `error.code: 200` "Permissions error"). Atlas relies on this
+ * — a workspace cannot claim a phone_number_id that isn't already shared
+ * into the operator's Business Account, so a forged install attempt
+ * fails at this `getPhoneNumber` call before touching the DB.
+ *
+ * Plan gating note: WhatsApp catalog row carries `min_plan: "business"`.
+ * The handler itself doesn't enforce that — `WorkspaceInstaller` does,
+ * upstream of dispatch. The high tier reflects Meta's per-message costs:
+ * customer-initiated conversations consume operator-paid template / user-
+ * initiated conversation quota, so opening WhatsApp to lower tiers would
+ * unbound operator spend.
+ *
+ * @see ./types.ts — {@link StaticBotInstallHandler}
+ * @see ./teams-static-bot-handler.ts — the cousin shape this mirrors
+ * @see https://developers.facebook.com/docs/whatsapp/cloud-api/reference/phone-numbers
+ */
+
+import crypto from "crypto";
+import { createLogger } from "@atlas/api/lib/logger";
+import { internalQuery } from "@atlas/api/lib/db/internal";
+import {
+  WhatsAppApiUnavailableError,
+  WhatsAppPhoneNumberIdInvalidError,
+  WhatsAppReachabilityError,
+} from "@atlas/api/lib/effect/errors";
+import type { WorkspaceId } from "@useatlas/types";
+import type {
+  CatalogId,
+  InstallRecord,
+  StaticBotInstallHandler,
+} from "./types";
+
+const log = createLogger("integrations.install.whatsapp");
+
+/** Catalog slug — the dispatch key in `registerStaticBotHandler`. */
+export const WHATSAPP_SLUG: CatalogId = "whatsapp";
+
+/**
+ * Stable `plugin_catalog.id` for WhatsApp. The seeder derives row ids as
+ * `catalog:${slug}` (see `catalog-seeder.ts::upsertEntry`). Kept as a
+ * named constant so the install row's FK target stays in lockstep with
+ * the seeder rename rule.
+ */
+export const WHATSAPP_CATALOG_ID = "catalog:whatsapp";
+
+/**
+ * Meta Graph API version used for the phone-number lookup. Pinned rather
+ * than tracking `latest` so a Meta-side schema change can't silently
+ * break the install flow. Bump alongside the chat adapter's apiVersion
+ * default when the rest of the WhatsApp surface is verified against a
+ * newer release.
+ */
+const META_GRAPH_API_VERSION = "v21.0";
+
+/**
+ * WhatsApp Business phone number ids are decimal strings — Meta assigns
+ * them when a phone is added to a WhatsApp Business Account. Documented
+ * shape is "a numeric id"; current production values are 15–17 digits but
+ * Meta's docs don't bound this. The 10–30 range here is defensive — wide
+ * enough that a future Meta-side change doesn't reject valid input, tight
+ * enough to reject the obvious paste mistakes (human-readable phone
+ * numbers like `+1 415 555 0100`, the human display string, or a Meta
+ * WhatsApp Business Account ID which is a different identifier).
+ *
+ * Exported so the executeQuery dispatcher can reuse the same regex on
+ * inbound webhook envelopes — keeps the phone_number_id invariant on a
+ * single source of truth across install + receive paths.
+ *
+ * @see https://developers.facebook.com/docs/whatsapp/cloud-api/reference/phone-numbers
+ */
+export const WHATSAPP_PHONE_NUMBER_ID_RE = /^\d{10,30}$/;
+
+/**
+ * Reachability call timeout. Meta Graph API is normally sub-second; 10s
+ * gives ample headroom for transient latency while keeping the install
+ * POST bounded. Mirrors the pattern in `discord-static-bot-handler.ts`.
+ */
+const WHATSAPP_FETCH_TIMEOUT_MS = 10_000;
+
+/**
+ * Per-deploy operator config. Read once from env by `register.ts` and
+ * passed in here. The constructor refuses to build without both
+ * `accessToken` and `appId` so direct callers (tests, future programmatic
+ * install paths) get the same env-gated guarantee `register.ts` already
+ * has.
+ */
+export interface WhatsAppStaticBotHandlerConfig {
+  /**
+   * Operator-shared System User access token from the operator's Meta
+   * Business / WhatsApp Business Cloud API account
+   * (`META_BUSINESS_ACCESS_TOKEN`). Scoped to the operator's WhatsApp
+   * Business Account; carries `whatsapp_business_management` +
+   * `whatsapp_business_messaging` permissions.
+   */
+  readonly accessToken: string;
+  /**
+   * Operator's Meta App ID (`META_BUSINESS_APP_ID`). Captured at
+   * construction even though `confirmInstall` doesn't use it directly —
+   * the chat adapter and the manifest / setup-link routes need it, and
+   * the handler is the single source of truth for "WhatsApp is wired"
+   * so the env-gate at construction time fails loud if either var is
+   * missing. Mirrors Teams's `appId` capture posture.
+   */
+  readonly appId: string;
+  /** Test-only injection of the install id generator. */
+  readonly idGenerator?: () => string;
+  /** Test-only override of the Meta Graph API base URL. */
+  readonly metaGraphBaseUrl?: string;
+}
+
+/** Shape persisted into `workspace_plugins.config` JSONB. */
+export interface WhatsAppInstallConfig {
+  /** WhatsApp Business phone number id (Meta routing identifier). */
+  readonly phone_number_id: string;
+  /**
+   * Optional admin-friendly label rendered in the integrations card —
+   * falls back to Meta's `display_phone_number` (`+1 415 555 0100`)
+   * captured at verification time.
+   */
+  readonly display_phone?: string;
+}
+
+/**
+ * Meta Graph API `GET /{phone_number_id}` parsed response. Success returns
+ * `{ id, verified_name?, display_phone_number?, ... }`; failure returns
+ * `{ error: { message, type, code, fbtrace_id } }`. Normalized at parse
+ * time into an explicit `kind: "ok" | "err"` discriminated union — same
+ * shape Discord's handler uses, same rationale (Meta's `error.code` is a
+ * real value where `0` doesn't mean "no error", so absence-of-`code` is
+ * NOT a safe discriminator).
+ */
+type WhatsAppPhoneNumberResponse =
+  | {
+      readonly kind: "ok";
+      readonly id: string;
+      readonly displayPhoneNumber?: string;
+      readonly verifiedName?: string;
+    }
+  | {
+      readonly kind: "err";
+      readonly message: string;
+      readonly code: number;
+    };
+
+function parseWhatsAppPhoneNumberResponse(
+  raw: unknown,
+  httpStatus: number,
+): WhatsAppPhoneNumberResponse | null {
+  if (typeof raw !== "object" || raw === null) return null;
+  const body = raw as Record<string, unknown>;
+  if (httpStatus >= 200 && httpStatus < 300) {
+    if (typeof body.id !== "string" || body.id.length === 0) return null;
+    const displayPhoneNumber =
+      typeof body.display_phone_number === "string" && body.display_phone_number.length > 0
+        ? body.display_phone_number
+        : undefined;
+    const verifiedName =
+      typeof body.verified_name === "string" && body.verified_name.length > 0
+        ? body.verified_name
+        : undefined;
+    return {
+      kind: "ok" as const,
+      id: body.id,
+      ...(displayPhoneNumber !== undefined ? { displayPhoneNumber } : {}),
+      ...(verifiedName !== undefined ? { verifiedName } : {}),
+    };
+  }
+  // Meta's failure envelope nests under `error`. A bare top-level
+  // `{ message, code }` is not what Graph API ever returns, so we don't
+  // accept it — the upstream-contract-violation path covers it.
+  const err = body.error;
+  if (typeof err !== "object" || err === null) return null;
+  const errObj = err as Record<string, unknown>;
+  const message = typeof errObj.message === "string" ? errObj.message : "";
+  const code = typeof errObj.code === "number" ? errObj.code : 0;
+  if (message.length === 0 && code === 0) {
+    // Empty error body — let the caller treat as upstream contract
+    // violation rather than fabricating an err envelope.
+    return null;
+  }
+  return { kind: "err" as const, message, code };
+}
+
+export class WhatsAppStaticBotInstallHandler implements StaticBotInstallHandler {
+  readonly kind = "static-bot" as const;
+
+  private readonly accessToken: string;
+  private readonly appId: string;
+  private readonly metaGraphBaseUrl: string;
+  private readonly newId: () => string;
+
+  constructor(config: WhatsAppStaticBotHandlerConfig) {
+    if (!config.accessToken || config.accessToken.length === 0) {
+      throw new Error(
+        "WhatsAppStaticBotInstallHandler requires a non-empty accessToken — set META_BUSINESS_ACCESS_TOKEN in the deploy env and re-register via registerBuiltinInstallHandlers().",
+      );
+    }
+    if (!config.appId || config.appId.length === 0) {
+      throw new Error(
+        "WhatsAppStaticBotInstallHandler requires a non-empty appId — set META_BUSINESS_APP_ID in the deploy env and re-register via registerBuiltinInstallHandlers().",
+      );
+    }
+    this.accessToken = config.accessToken;
+    this.appId = config.appId;
+    this.metaGraphBaseUrl =
+      config.metaGraphBaseUrl ?? `https://graph.facebook.com/${META_GRAPH_API_VERSION}`;
+    this.newId = config.idGenerator ?? (() => crypto.randomUUID());
+  }
+
+  /**
+   * Operator's Meta App ID. Exposed so the install route can build setup
+   * deep-links / manifest download URLs without re-reading env. Mirrors
+   * `TeamsStaticBotInstallHandler.applicationId`.
+   */
+  get applicationId(): string {
+    return this.appId;
+  }
+
+  async confirmInstall(
+    workspaceId: WorkspaceId,
+    routingIdentifier: string,
+    _verificationProof?: string,
+    extras?: Record<string, unknown>,
+  ): Promise<{ readonly installRecord: InstallRecord }> {
+    // ── 1. Validate the routing identifier ─────────────────────────
+    if (!routingIdentifier || routingIdentifier.length === 0) {
+      throw new WhatsAppPhoneNumberIdInvalidError({
+        message:
+          "WhatsApp install requires a non-empty phone_number_id (Meta's numeric routing id for the phone — NOT the human-readable phone number). Find it in the Meta Business Suite under WhatsApp Manager → Phone numbers → API Setup.",
+      });
+    }
+    if (!WHATSAPP_PHONE_NUMBER_ID_RE.test(routingIdentifier)) {
+      throw new WhatsAppPhoneNumberIdInvalidError({
+        message: `WhatsApp phone_number_id "${routingIdentifier}" is not a valid Meta routing id (expected 10–30 decimal digits). Human-readable phone numbers ("+1 415 555 0100") and WhatsApp Business Account IDs aren't accepted — copy the Phone Number ID from the Meta Business Suite under WhatsApp Manager → Phone numbers → API Setup.`,
+      });
+    }
+
+    // ── 2. Reachability via Meta Graph API ──────────────────────────
+    // Throws on Graph API errors / network failures *before* any DB
+    // write, so a failed verification never leaves a half-installed
+    // row behind.
+    const apiDisplayPhone = await this.verifyReachability(routingIdentifier);
+
+    // ── 3. Persist install row — UPSERT keyed on (workspace, catalog) ─
+    // Mirrors the email-form-handler / discord-static-bot-handler /
+    // teams-static-bot-handler pattern: candidate id on INSERT,
+    // RETURNING id so a CONFLICT lands on the existing row's id
+    // (idempotent re-install).
+    const candidateId = this.newId();
+    const configPayload: WhatsAppInstallConfig = {
+      phone_number_id: routingIdentifier,
+      ...extractDisplayPhone(extras, apiDisplayPhone, workspaceId),
+    };
+
+    let persistedId: string;
+    try {
+      // Schema notes:
+      //   - `pillar` + `install_id` became NOT NULL in migration 0092
+      //     (#2739) and the auto-fill trigger was dropped in 0096
+      //     (#2744). Every writer must name both columns explicitly.
+      //   - Chat-pillar installs are singletons per (workspace, catalog),
+      //     enforced by the `workspace_plugins_singleton` partial unique
+      //     index (`WHERE pillar IN ('chat','action')` from migration
+      //     0092). We target it via the inference clause
+      //     `ON CONFLICT (workspace_id, catalog_id) WHERE pillar IN ('chat','action')`
+      //     so re-install lands on the existing row (idempotent UPSERT).
+      //   - For chat-pillar there's only one install per (workspace,
+      //     catalog), so `install_id` mirrors `id` — WorkspaceInstaller's
+      //     datasource path uses a caller-supplied installId; static-bot
+      //     chat installs don't have that surface, so we reuse the row id.
+      const rows = await internalQuery<{ id: string }>(
+        `INSERT INTO workspace_plugins
+           (id, workspace_id, catalog_id, install_id, pillar, config, enabled, installed_at)
+         VALUES ($1, $2, $3, $1, 'chat', $4::jsonb, true, NOW())
+         ON CONFLICT (workspace_id, catalog_id) WHERE pillar IN ('chat', 'action')
+         DO UPDATE
+           SET config = EXCLUDED.config,
+               enabled = true
+         RETURNING id`,
+        [candidateId, workspaceId, WHATSAPP_CATALOG_ID, JSON.stringify(configPayload)],
+      );
+      const returned = rows[0]?.id;
+      if (typeof returned !== "string" || returned.length === 0) {
+        // Postgres ≥9.5 guarantees `INSERT … ON CONFLICT … RETURNING`
+        // returns the row on both insert and update. Empty here means
+        // a driver / wrapper regression — fail loudly rather than ship
+        // a stale id back to the user (on re-install the DB row has
+        // the existing id; falling back to the fresh candidateId would
+        // strand subsequent lookups). #2807 cemented this no-fallback
+        // posture across the static-bot family.
+        throw new Error(
+          `workspace_plugins UPSERT returned no id for WhatsApp install (workspaceId=${workspaceId}). RETURNING must always populate on PG ≥9.5; this indicates a driver regression. Aborting install.`,
+        );
+      }
+      persistedId = returned;
+    } catch (err) {
+      log.error(
+        {
+          workspaceId,
+          err: err instanceof Error ? err : new Error(String(err)),
+        },
+        "Failed to persist WhatsApp install record — aborting install",
+      );
+      throw err;
+    }
+
+    log.info(
+      {
+        workspaceId,
+        installId: persistedId,
+        phoneNumberIdFingerprint: fingerprintPhoneNumberId(routingIdentifier),
+      },
+      "WhatsApp install completed (phone_number_id reachable, install row UPSERTed)",
+    );
+
+    return {
+      installRecord: {
+        id: persistedId,
+        workspaceId,
+        catalogId: WHATSAPP_SLUG,
+      },
+    };
+  }
+
+  /**
+   * Round-trip Meta Graph API to confirm the phone_number_id is owned by
+   * the operator's Meta Business Account and the access token has the
+   * required scopes. Returns Meta's `display_phone_number` when present
+   * so the install row can fall back to it when extras don't supply one.
+   *
+   * Token redaction: the access token rides in the `Authorization: Bearer`
+   * header — NOT in the URL path — so URL-based redaction (the kind
+   * Telegram needs) isn't required here. Errors are not attached as
+   * `cause` to preserve symmetry with the sibling static-bot handlers'
+   * safe-by-default posture (a future pino serializer walking through
+   * `cause` could otherwise dump the request headers).
+   */
+  private async verifyReachability(phoneNumberId: string): Promise<string | null> {
+    const url = `${this.metaGraphBaseUrl}/${encodeURIComponent(
+      phoneNumberId,
+    )}?fields=verified_name,display_phone_number`;
+    let response: Response;
+    try {
+      response = await fetchWithTimeout(url, WHATSAPP_FETCH_TIMEOUT_MS, {
+        Authorization: `Bearer ${this.accessToken}`,
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      log.warn(
+        {
+          phoneNumberIdFingerprint: fingerprintPhoneNumberId(phoneNumberId),
+          fetchError: message,
+        },
+        "Meta Graph API unreachable when verifying phone_number_id",
+      );
+      throw new WhatsAppApiUnavailableError({
+        message: `Meta Graph API unreachable when verifying phone_number_id (${message}). Retry, or check operator-side egress to graph.facebook.com and META_BUSINESS_ACCESS_TOKEN wiring.`,
+      });
+    }
+
+    let rawBody: unknown;
+    try {
+      rawBody = await response.json();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      log.warn(
+        {
+          phoneNumberIdFingerprint: fingerprintPhoneNumberId(phoneNumberId),
+          status: response.status,
+          parseError: message,
+        },
+        "Meta Graph API returned non-JSON response",
+      );
+      throw new WhatsAppApiUnavailableError({
+        message: `Meta Graph API returned a non-JSON response when verifying phone_number_id "${phoneNumberId}" (status ${response.status}).`,
+      });
+    }
+
+    const parsed = parseWhatsAppPhoneNumberResponse(rawBody, response.status);
+    if (parsed === null) {
+      throw new WhatsAppApiUnavailableError({
+        message: `Meta Graph API returned an unexpected response shape when verifying phone_number_id "${phoneNumberId}" (status ${response.status}).`,
+      });
+    }
+    if (parsed.kind === "err") {
+      const hint = hintForWhatsAppError(parsed.code, response.status, parsed.message);
+      throw new WhatsAppReachabilityError({
+        message: `Meta rejected phone_number_id "${phoneNumberId}": ${parsed.message || "unknown error"}${hint ? ` — ${hint}` : ""}`,
+        errorCode: parsed.code,
+      });
+    }
+
+    return parsed.displayPhoneNumber ?? null;
+  }
+}
+
+/**
+ * Extract the optional `display_phone` field. Order of preference:
+ *   1. `extras.display_phone` if supplied by the install caller (admin UI
+ *      override, or a future install flow forwarding a custom label).
+ *   2. The `display_phone_number` returned by Meta Graph API at
+ *      verification time (e.g. `+1 415 555 0100`).
+ *   3. Omit — the admin UI renders the phone_number_id alone.
+ *
+ * Drops any other keys from `extras` silently — the catalog
+ * `config_schema` declares the contract; new fields land via a new
+ * schema row, not via arbitrary extras injection. Logs at `warn` when
+ * `display_phone` arrives at the wrong type so the silent drop is
+ * observable in server logs.
+ */
+function extractDisplayPhone(
+  extras: Record<string, unknown> | undefined,
+  apiFallback: string | null,
+  workspaceId: WorkspaceId,
+): { display_phone?: string } {
+  if (extras !== undefined && "display_phone" in extras) {
+    const raw = extras.display_phone;
+    if (raw !== undefined && raw !== null) {
+      if (typeof raw !== "string") {
+        log.warn(
+          { workspaceId, rawType: typeof raw },
+          "WhatsApp extras.display_phone is not a string — dropping and falling back to Meta-provided value",
+        );
+      } else {
+        const trimmed = raw.trim();
+        if (trimmed.length > 0) return { display_phone: trimmed };
+      }
+    }
+  }
+  if (apiFallback && apiFallback.length > 0) return { display_phone: apiFallback };
+  return {};
+}
+
+/**
+ * Per-error-code follow-up text appended to Meta's `error.message`. Logs
+ * a warn when the code is novel so operators see observability gaps
+ * before users do — the verbatim message still propagates in the thrown
+ * error, so the user gets *some* info, but a recurring null-return
+ * signals a new failure mode worth a follow-up entry here.
+ *
+ * Meta's [WhatsApp Cloud API error codes](https://developers.facebook.com/docs/whatsapp/cloud-api/support/error-codes)
+ * are stable numeric tags; we key on `code` first and fall back to HTTP
+ * status for transport-layer issues that don't have a specific code.
+ */
+function hintForWhatsAppError(
+  code: number,
+  httpStatus: number,
+  description: string,
+): string | null {
+  if (code === 100) {
+    // "Invalid parameter" / "Tried accessing nonexisting field" — almost
+    // always means the phone_number_id isn't in the operator's WhatsApp
+    // Business Account.
+    return "this phone_number_id isn't visible to the operator's Meta Business Account — ask the operator to share the customer's WhatsApp number into their Business Account, or re-copy the id from Meta Business Suite";
+  }
+  if (code === 190 || code === 102) {
+    return "the operator-side META_BUSINESS_ACCESS_TOKEN may be expired or revoked — operator must mint a fresh System User token with whatsapp_business_management + whatsapp_business_messaging scopes";
+  }
+  if (code === 200 || code === 10) {
+    return "the operator's access token lacks the whatsapp_business_management scope — operator must regenerate the System User token with that scope";
+  }
+  if (code === 4 || httpStatus === 429) {
+    return "Meta Graph API rate-limited the verify call — wait a minute and retry";
+  }
+  if (httpStatus === 401 || httpStatus === 403) {
+    return "Meta refused the access token — operator must re-mint META_BUSINESS_ACCESS_TOKEN";
+  }
+  if (httpStatus >= 500) {
+    return "Meta Graph API is degraded — check https://metastatus.com and retry";
+  }
+  log.warn(
+    { errorCode: code, httpStatus, description },
+    "WhatsApp error code not mapped in hintForWhatsAppError — consider adding a hint branch",
+  );
+  return null;
+}
+
+/**
+ * Short, log-safe fingerprint of the phone_number_id — last 4 chars only.
+ * The phone_number_id is a routing identifier, not a secret, but logging
+ * the full value in every install line is noisy and lets log scrapers
+ * correlate Workspace ↔ phone without going through the install row.
+ */
+function fingerprintPhoneNumberId(phoneNumberId: string): string {
+  return phoneNumberId.length <= 4 ? phoneNumberId : `…${phoneNumberId.slice(-4)}`;
+}
+
+/**
+ * `fetch` with a timeout. Bun's fetch has no built-in timeout in
+ * serverless runtimes; without an AbortController-driven cap a hung Meta
+ * upstream would hold the install POST open indefinitely. Mirrors
+ * `discord-static-bot-handler.ts`'s `fetchWithTimeout`.
+ */
+async function fetchWithTimeout(
+  url: string,
+  timeoutMs: number,
+  headers: Record<string, string>,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(url, { signal: controller.signal, headers });
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/packages/types/src/approval.ts
+++ b/packages/types/src/approval.ts
@@ -46,14 +46,16 @@ export const APPROVAL_RULE_SURFACES = [
   "scheduler",
   "slack",
   "teams",
-  // #2748 — Telegram joined here in 1.5.3 Phase D; #2749 added Discord.
-  // gchat / WhatsApp will follow as their slices land; landing
+  // #2748 — Telegram joined here in 1.5.3 Phase D; #2749 added Discord;
+  // #2753 added WhatsApp. gchat will follow in #2754; landing
   // per-platform vs. one big enum-bump keeps the PR scope honest.
   // Mirrored in packages/api/src/lib/db/migrations/0095_approval_surface_telegram.sql
-  // (Telegram) and 0099_approval_surface_discord.sql (Discord), with the
-  // matching schema.ts CHECK constraints.
+  // (Telegram), 0099_approval_surface_discord.sql (Discord), and
+  // 0100_approval_surface_whatsapp.sql (WhatsApp), with the matching
+  // schema.ts CHECK constraints.
   "telegram",
   "discord",
+  "whatsapp",
   "webhook",
 ] as const;
 export type ApprovalRuleSurface = (typeof APPROVAL_RULE_SURFACES)[number];

--- a/plugins/chat/src/adapter-registry.ts
+++ b/plugins/chat/src/adapter-registry.ts
@@ -32,10 +32,12 @@ import type { Adapter } from "chat";
 import { createSlackAdapter } from "./adapters/slack";
 import { createTelegramAdapter } from "./adapters/telegram";
 import { createDiscordAdapter } from "./adapters/discord";
+import { createWhatsAppAdapter } from "./adapters/whatsapp";
 import type {
   DiscordAdapterConfig,
   SlackAdapterConfig,
   TelegramAdapterConfig,
+  WhatsAppAdapterConfig,
 } from "./config";
 
 // ---------------------------------------------------------------------------
@@ -88,7 +90,9 @@ type ChatAdapterInstance<K extends ChatAdapterName> = K extends "slack"
     ? Adapter
     : K extends "discord"
       ? Adapter
-      : { readonly name: K };
+      : K extends "whatsapp"
+        ? Adapter
+        : { readonly name: K };
 
 /**
  * Returned alongside `ChatAdapterSet` so `healthCheck` and admin
@@ -234,10 +238,72 @@ const DISCORD_BUILDER: ChatAdapterBuilder<Adapter> = {
   },
 };
 
+/**
+ * WhatsApp — fourth static-bot Platform to ship a real adapter (1.5.3
+ * #2753). Four env vars gate the chat adapter:
+ *   - `META_BUSINESS_ACCESS_TOKEN` — operator's System User access token
+ *     for Meta Cloud API calls (whatsapp_business_management +
+ *     whatsapp_business_messaging scopes). Same value the install
+ *     handler uses for `phone_number_id` reachability verification.
+ *   - `META_BUSINESS_APP_ID` — operator's Meta App ID; not strictly
+ *     required by `@chat-adapter/whatsapp` at activation time, but
+ *     gating the adapter on it keeps boot semantics consistent with the
+ *     install handler (operator-half-wires the env and the adapter
+ *     refuses to activate, mirroring the Discord + Teams pattern).
+ *   - `WHATSAPP_APP_SECRET` — Meta App Secret for HMAC-SHA256 webhook
+ *     signature verification (`X-Hub-Signature-256`).
+ *   - `WHATSAPP_VERIFY_TOKEN` — the random string the operator pasted
+ *     into the Meta webhook configuration; mirrored back in the GET
+ *     challenge handshake.
+ *
+ * `WHATSAPP_DEFAULT_PHONE_NUMBER_ID` is an optional convenience for
+ * single-tenant deploys (only one phone number on the operator's
+ * Business Account); when omitted, per-Workspace routing lives entirely
+ * in `workspace_plugins.config->>'phone_number_id'` and the adapter's
+ * inbound dispatcher pulls it from the webhook envelope. Atlas's host
+ * `executeQuery` resolves the right workspace by matching the inbound
+ * `metadata.phone_number_id` against the install rows; same
+ * fail-closed posture as Discord's `guild_id` / Telegram's `chat_id`
+ * resolvers.
+ */
+const WHATSAPP_BUILDER: ChatAdapterBuilder<Adapter> = {
+  slug: "whatsapp",
+  platform: "whatsapp",
+  requiredEnv: [
+    "META_BUSINESS_ACCESS_TOKEN",
+    "META_BUSINESS_APP_ID",
+    "WHATSAPP_APP_SECRET",
+    "WHATSAPP_VERIFY_TOKEN",
+  ],
+  build(env) {
+    const accessToken = env.META_BUSINESS_ACCESS_TOKEN;
+    const appId = env.META_BUSINESS_APP_ID;
+    const appSecret = env.WHATSAPP_APP_SECRET;
+    const verifyToken = env.WHATSAPP_VERIFY_TOKEN;
+    if (!accessToken || !appId || !appSecret || !verifyToken) return null;
+    // `phoneNumberId` is part of the @chat-adapter/whatsapp config but
+    // per-Workspace routing replaces the static value at receive time —
+    // see executeQuery's WhatsApp branch. The optional
+    // WHATSAPP_DEFAULT_PHONE_NUMBER_ID env supplies a fallback for
+    // single-tenant deploys; multi-tenant deploys leave it empty and
+    // route from the inbound envelope's metadata.phone_number_id.
+    const phoneNumberId = env.WHATSAPP_DEFAULT_PHONE_NUMBER_ID ?? "";
+    const config: WhatsAppAdapterConfig = {
+      accessToken,
+      appSecret,
+      verifyToken,
+      phoneNumberId,
+      ...(env.WHATSAPP_API_VERSION ? { apiVersion: env.WHATSAPP_API_VERSION } : {}),
+    };
+    return createWhatsAppAdapter(config);
+  },
+};
+
 const BUILDERS_BY_SLUG: Readonly<Record<string, ChatAdapterBuilder<unknown>>> = {
   slack: SLACK_BUILDER,
   telegram: TELEGRAM_BUILDER,
   discord: DISCORD_BUILDER,
+  whatsapp: WHATSAPP_BUILDER,
 };
 
 /**
@@ -383,10 +449,16 @@ export function buildChatAdapterRegistry(
         { slug: entry.slug, platform: builder.platform },
         "AdapterRegistry: chat adapter registered",
       );
+    } else if (entry.slug === "whatsapp") {
+      adapters.whatsapp = adapter as Adapter;
+      logger.info(
+        { slug: entry.slug, platform: builder.platform },
+        "AdapterRegistry: chat adapter registered",
+      );
     }
-    // Other static-bot adapters (gchat #2754, WhatsApp #2753) slot in
-    // here as their slices land. The `Partial<Record>` shape of
-    // `ChatAdapterSet` admits them without a type change.
+    // Other static-bot adapters (gchat #2754) slot in here as their
+    // slices land. The `Partial<Record>` shape of `ChatAdapterSet`
+    // admits them without a type change.
   }
 
   return {

--- a/plugins/chat/src/index.ts
+++ b/plugins/chat/src/index.ts
@@ -278,6 +278,26 @@ function catalogHasDiscordStaticBot(
   );
 }
 
+/**
+ * WhatsApp (1.5.3 #2753) mirrors Discord's / Telegram's static-bot mount
+ * story — declared + enabled in the catalog mounts the webhook route at
+ * `/api/plugins/chat-interaction/webhooks/whatsapp`. Env-var presence
+ * (and therefore the actual adapter wiring) is checked inside
+ * `initialize()` by the `AdapterRegistry`.
+ */
+function catalogHasWhatsAppStaticBot(
+  catalog: ReadonlyArray<ChatCatalogEntryInput> | undefined,
+): boolean {
+  if (!catalog) return false;
+  return catalog.some(
+    (e) =>
+      e.slug === "whatsapp" &&
+      e.type === "chat" &&
+      e.install_model === "static-bot" &&
+      e.enabled === true,
+  );
+}
+
 function buildChatPlugin(
   config: ChatPluginConfig,
 ): AtlasInteractionPlugin<ChatPluginConfig> {
@@ -286,6 +306,7 @@ function buildChatPlugin(
   let slackAdapterInstance: SlackAdapter | null = null;
   let telegramAdapterInstance: Adapter | null = null;
   let discordAdapterInstance: Adapter | null = null;
+  let whatsappAdapterInstance: Adapter | null = null;
   let log: PluginLogger | null = null;
   let initialized = false;
   /**
@@ -305,6 +326,7 @@ function buildChatPlugin(
   const slackOauthDeclared = catalogHasSlackOauth(config.catalog);
   const telegramStaticBotDeclared = catalogHasTelegramStaticBot(config.catalog);
   const discordStaticBotDeclared = catalogHasDiscordStaticBot(config.catalog);
+  const whatsappStaticBotDeclared = catalogHasWhatsAppStaticBot(config.catalog);
 
   return {
     id: "chat-interaction",
@@ -469,6 +491,89 @@ function buildChatPlugin(
           }
         });
       }
+
+      // WhatsApp (1.5.3 #2753 — fourth static-bot webhook). The Chat
+      // SDK WhatsApp adapter verifies the HMAC-SHA256 signature on
+      // every incoming webhook (`X-Hub-Signature-256`) using
+      // `WHATSAPP_APP_SECRET`, and handles the GET verify-token
+      // handshake using `WHATSAPP_VERIFY_TOKEN`. Per-Workspace routing
+      // by `phone_number_id` lives downstream in executeQuery's
+      // WhatsApp branch. Meta sends a GET to verify the webhook URL +
+      // verify_token at setup time, then POSTs all event deliveries —
+      // both verbs are mounted so the verify handshake can succeed.
+      if (whatsappStaticBotDeclared) {
+        // The two handlers share identical code paths but are
+        // registered separately so Hono's path-typed Context generic
+        // narrows cleanly (one `H<BlankEnv, "/webhooks/whatsapp", …>`
+        // overload per verb, mirroring how the Telegram + Discord
+        // branches register their single POST handler inline). Folding
+        // both into one shared closure broke type inference (the
+        // captured Context generic ended up `never`).
+        app.get("/webhooks/whatsapp", async (c) => {
+          const requestId = crypto.randomUUID();
+          if (!bridge) {
+            return c.json({ error: "Chat plugin not yet initialized", requestId }, 503);
+          }
+          const handler = bridge.webhooks.whatsapp;
+          if (!handler) {
+            (log ?? console).error(
+              { requestId, adapter: "whatsapp" },
+              "WhatsApp webhook received but adapter not configured — check META_BUSINESS_ACCESS_TOKEN + META_BUSINESS_APP_ID + WHATSAPP_APP_SECRET + WHATSAPP_VERIFY_TOKEN and AdapterRegistry boot logs",
+            );
+            return c.json({ error: "WhatsApp adapter not configured", requestId }, 404);
+          }
+          try {
+            return await handler(c.req.raw, {
+              waitUntil: (task: Promise<unknown>) => {
+                task.catch((err: unknown) => {
+                  (log ?? console).error(
+                    { err: err instanceof Error ? err : new Error(String(err)), requestId, adapter: "whatsapp" },
+                    "Chat SDK WhatsApp webhook background task failed",
+                  );
+                });
+              },
+            });
+          } catch (err) {
+            (log ?? console).error(
+              { err: err instanceof Error ? err : new Error(String(err)), requestId, adapter: "whatsapp" },
+              "WhatsApp webhook handler threw unexpectedly",
+            );
+            return c.json({ error: "Webhook processing failed", requestId }, 500);
+          }
+        });
+        app.post("/webhooks/whatsapp", async (c) => {
+          const requestId = crypto.randomUUID();
+          if (!bridge) {
+            return c.json({ error: "Chat plugin not yet initialized", requestId }, 503);
+          }
+          const handler = bridge.webhooks.whatsapp;
+          if (!handler) {
+            (log ?? console).error(
+              { requestId, adapter: "whatsapp" },
+              "WhatsApp webhook received but adapter not configured — check META_BUSINESS_ACCESS_TOKEN + META_BUSINESS_APP_ID + WHATSAPP_APP_SECRET + WHATSAPP_VERIFY_TOKEN and AdapterRegistry boot logs",
+            );
+            return c.json({ error: "WhatsApp adapter not configured", requestId }, 404);
+          }
+          try {
+            return await handler(c.req.raw, {
+              waitUntil: (task: Promise<unknown>) => {
+                task.catch((err: unknown) => {
+                  (log ?? console).error(
+                    { err: err instanceof Error ? err : new Error(String(err)), requestId, adapter: "whatsapp" },
+                    "Chat SDK WhatsApp webhook background task failed",
+                  );
+                });
+              },
+            });
+          } catch (err) {
+            (log ?? console).error(
+              { err: err instanceof Error ? err : new Error(String(err)), requestId, adapter: "whatsapp" },
+              "WhatsApp webhook handler threw unexpectedly",
+            );
+            return c.json({ error: "Webhook processing failed", requestId }, 500);
+          }
+        });
+      }
     },
 
     async initialize(ctx: AtlasPluginContext) {
@@ -501,9 +606,11 @@ function buildChatPlugin(
         });
         slackAdapterInstance = registry.adapters.slack ?? null;
         // Telegram (1.5.3 #2748 — first static-bot adapter wired here);
-        // Discord (1.5.3 #2749 — second). gchat / WhatsApp follow.
+        // Discord (1.5.3 #2749 — second); WhatsApp (1.5.3 #2753 —
+        // fourth). gchat (#2754) follows.
         telegramAdapterInstance = (registry.adapters.telegram ?? null) as Adapter | null;
         discordAdapterInstance = (registry.adapters.discord ?? null) as Adapter | null;
+        whatsappAdapterInstance = (registry.adapters.whatsapp ?? null) as Adapter | null;
         adapterDiagnostics = registry.diagnostics;
 
         // Bridge takes pre-built instances per-platform; unwired slots
@@ -513,6 +620,7 @@ function buildChatPlugin(
           slack: slackAdapterInstance,
           telegram: telegramAdapterInstance,
           discord: discordAdapterInstance,
+          whatsapp: whatsappAdapterInstance,
         });
       } catch (err) {
         ctx.logger.error(
@@ -532,6 +640,7 @@ function buildChatPlugin(
         slackAdapterInstance = null;
         telegramAdapterInstance = null;
         discordAdapterInstance = null;
+        whatsappAdapterInstance = null;
         throw err;
       }
 
@@ -539,6 +648,7 @@ function buildChatPlugin(
       if (slackAdapterInstance) enabledAdapters.push("slack");
       if (telegramAdapterInstance) enabledAdapters.push("telegram");
       if (discordAdapterInstance) enabledAdapters.push("discord");
+      if (whatsappAdapterInstance) enabledAdapters.push("whatsapp");
 
       const backend = config.state?.backend ?? "memory";
       const initFailedSilently =
@@ -586,6 +696,7 @@ function buildChatPlugin(
       if (slackAdapterInstance) enabledAdapters.push("slack");
       if (telegramAdapterInstance) enabledAdapters.push("telegram");
       if (discordAdapterInstance) enabledAdapters.push("discord");
+      if (whatsappAdapterInstance) enabledAdapters.push("whatsapp");
 
       if (enabledAdapters.length === 0) {
         // Use the diagnostics captured at init to point operators at the
@@ -665,6 +776,7 @@ function buildChatPlugin(
       slackAdapterInstance = null;
       telegramAdapterInstance = null;
       discordAdapterInstance = null;
+      whatsappAdapterInstance = null;
       log = null;
       initialized = false;
     },


### PR DESCRIPTION
## Summary

- **Fourth concrete `StaticBotInstallHandler`** after Telegram (#2748) / Discord (#2749) / Teams (#2752). Operator wires one shared Meta Business / WhatsApp Business Cloud API account (`META_BUSINESS_ACCESS_TOKEN` + `META_BUSINESS_APP_ID`, plus `WHATSAPP_APP_SECRET` + `WHATSAPP_VERIFY_TOKEN` for the webhook envelope); customer admin pastes their **Meta `phone_number_id`** into the install modal.
- **Reachability** verified via `GET /v21.0/{phone_number_id}` with the operator's System User access token in `Authorization: Bearer` — fails closed before any DB write so a rejected id never leaves a half-installed row behind. Meta's error message bubbles up verbatim with admin-actionable hints (code 100 → "not visible to operator's Business Account", 190 → "rotate the access token", etc.).
- **Per-tenant routing** matches inbound webhook `metadata.phone_number_id` against `workspace_plugins.config->>'phone_number_id'` — same fail-closed contract as Discord / Telegram (refuses on unknown tenant, DB outage, or duplicate match).
- **Plan-gated** to `min_plan: "business"` — Meta charges the operator per conversation, so opening WhatsApp to lower tiers would unbound operator spend.
- **Migration 0100** extends the approval-surface CHECK enums (`approval_rules` / `approval_queue`) and promotes the WhatsApp catalog row from `coming_soon` → `available`.

Slice 15 of 17 in 1.5.3 (PRD #2738 / milestone #51); only #2754 (gchat) remains in Phase D after this lands.

## Test plan

- [x] `bun run lint`
- [x] `bun run type`
- [x] `bun run test` (full — 467 passes; the auth / db migrate tests now expect 101 migrations and include `0100_approval_surface_whatsapp.sql` in the pre-applied set)
- [x] `bash scripts/check-schema-drift.sh` — 77 migration tables found, schema mirror in lockstep
- [x] `bash scripts/check-template-drift.sh` — 682 files clean
- [x] `bash scripts/check-test-discipline.sh` — 862 test files scanned
- [x] `bash scripts/check-ee-imports.sh` — only `lib/effect/enterprise-layer.ts` reaches `@atlas/ee`
- [x] `bun x syncpack lint` — no issues

### New tests (50 new pass / 0 fail across the three files)

- `whatsapp-static-bot-handler.test.ts` (26 tests) — kind / constructor / phone_number_id validation / Meta Graph reachability (code 100 hint, 190 rotation hint, network failure, non-JSON body, contract violations) / persistence (UPSERT shape, RETURNING idempotency, half-install refusal) / verificationProof passthrough
- `register.test.ts` — WhatsApp env-gate block (6 cases) mirroring the Telegram / Discord / Teams shape: missing token / missing appId / empty strings / both set / catalog-enabled-but-env-missing severity escalation / no-opt-in
- `execute-query.test.ts` — WhatsApp branch (5 cases): happy-path routing (`workspace_plugins.config->>'phone_number_id'` → workspace_id, actor binding, `whatsapp:` rate-limit key) / unknown tenant fail-closed / DB outage fail-closed / duplicate-match cross-tenant defense / shape validation defends rate-limit cache key

## Acceptance criteria

All AC items from #2753:

- [x] WhatsApp-specific handler registers with `WorkspaceInstaller` dispatch (`register.ts::registerWhatsAppStaticBotHandler`)
- [x] Catalog row `whatsapp` seeded with high plan tier `min_plan: "business"` + `configSchema` for `phone_number_id` (required) + `display_phone` (optional)
- [x] Install modal explains prerequisites + Meta Business setup link (docs)
- [x] `phone_number_id` verification step queries operator's Meta credentials to confirm reachability via Graph API
- [x] AdapterRegistry instantiates WhatsApp adapter when operator env vars present AND `workspace_plugins` row exists (env gate: `META_BUSINESS_ACCESS_TOKEN` + `META_BUSINESS_APP_ID` + `WHATSAPP_APP_SECRET` + `WHATSAPP_VERIFY_TOKEN`)
- [x] Per-tenant phone routing verified end-to-end with a mocked Meta webhook (`execute-query.test.ts`)
- [x] Plan gating: customer admins on plans below the threshold see the upsell state (catalog row's `min_plan: "business"` is enforced by `WorkspaceInstaller` upstream of dispatch — pre-existing infra)
- [x] Docs page at `apps/docs/content/docs/integrations/whatsapp.mdx` covering Meta Business setup + per-tenant install
- [x] `bun run type` + `bun run test` + `/ci` all green

## References

- Issue: #2753 (1.5.3 slice 15)
- Precedents: #2790 (Discord), #2781 (Telegram), #2810 (Teams)
- ADR-0006 (three-pillar taxonomy), ADR-0007 (unified install pipeline)
- Updated contract: `docs/architecture/chat-plugin-atlas-contract.md` (WhatsApp row flipped from ○ pending → ✓ verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)