### PR TITLE
feat(api): #2729 — durable lead outbox + Scheduler-backed flusher

### DIFF
--- a/ee/src/saas-crm/__tests__/saas-crm.test.ts
+++ b/ee/src/saas-crm/__tests__/saas-crm.test.ts
@@ -1,10 +1,13 @@
 /**
- * SaasCrm layer tests — boot verification + dispatch + end-to-end Live wiring.
+ * SaasCrm layer tests — boot verification + outbox enqueue + dispatcher.
  *
- * Exercises the EE-side Layer (`SaasCrmLive`) with a mocked fetch impl,
- * isolating from both the plugin's HTTP wrapper (covered in
- * `plugins/twenty/__tests__/`) and from Twenty itself. There are NO
- * live calls to crm.useatlas.dev.
+ * Exercises the EE-side Layer (`SaasCrmLive`) with a mocked fetch impl
+ * AND a stubbed `internalQuery` (so the outbox enqueue is observable
+ * without a real Postgres). The dispatcher itself (`dispatchOutboxRow`)
+ * is unit-tested directly — it's the call the flusher makes from
+ * inside the Scheduler Layer.
+ *
+ * There are NO live calls to crm.useatlas.dev.
  */
 
 import { describe, test, expect, beforeEach, mock } from "bun:test";
@@ -25,8 +28,30 @@ mock.module("@atlas/api/lib/logger", () => ({
   }),
 }));
 
+// ── Stub the internal DB so SaasCrmLive can observe enqueue ─────────
+let internalDbAvailable = true;
+let lastEnqueueArgs: { sql: string; params: unknown[] } | null = null;
+let enqueueCount = 0;
+let nextEnqueueId = "row-id-0";
+mock.module("@atlas/api/lib/db/internal", () => ({
+  hasInternalDB: () => internalDbAvailable,
+  internalQuery: async (sql: string, params?: unknown[]) => {
+    lastEnqueueArgs = { sql, params: params ?? [] };
+    if (/^\s*INSERT INTO crm_outbox/i.test(sql)) {
+      enqueueCount++;
+      return [{ id: nextEnqueueId }];
+    }
+    return [];
+  },
+}));
+
 // ── Now we can import the layer + its helpers ───────────────────────
-const { verifyCustomFields, dispatchLead, SaasCrmLive } = await import("../index");
+const {
+  verifyCustomFields,
+  SaasCrmLive,
+  dispatchOutboxRow,
+  classifyTwentyError,
+} = await import("../index");
 const { SaasCrm } = await import("@atlas/api/lib/effect/services");
 
 // ── Fixture helpers ─────────────────────────────────────────────────
@@ -60,11 +85,19 @@ function withFetch<T>(impl: typeof globalThis.fetch, run: () => Promise<T>): Pro
   });
 }
 
+function resetStubs(): void {
+  internalDbAvailable = true;
+  lastEnqueueArgs = null;
+  enqueueCount = 0;
+  nextEnqueueId = "row-id-0";
+}
+
 // ── verifyCustomFields ──────────────────────────────────────────────
 
 describe("verifyCustomFields", () => {
   beforeEach(() => {
     enterpriseEnabled = true;
+    resetStubs();
   });
 
   test("returns ok=true when both required custom fields are present", async () => {
@@ -93,39 +126,9 @@ describe("verifyCustomFields", () => {
     });
   });
 
-  test("returns ok=false when atlasLastSource is missing", async () => {
-    const fetchImpl = (async () =>
-      metadataResponse(["id", "atlasFirstSource"])) as unknown as typeof globalThis.fetch;
-
-    await withFetch(fetchImpl, async () => {
-      const result = await verifyCustomFields({
-        apiKey: "k",
-        baseUrl: "https://crm.test.local",
-      });
-      expect(result).toEqual({ ok: false });
-    });
-  });
-
-  test("returns ok='transient' on 5xx (transient upstream failure)", async () => {
-    const fetchImpl = (async () =>
-      new Response(JSON.stringify({ messages: ["oops"] }), {
-        status: 503,
-        headers: { "Content-Type": "application/json" },
-      })) as unknown as typeof globalThis.fetch;
-
-    await withFetch(fetchImpl, async () => {
-      const result = await verifyCustomFields({
-        apiKey: "k",
-        baseUrl: "https://crm.test.local",
-      });
-      if (result.ok !== "transient") throw new Error("expected transient");
-      expect(result.reason.length).toBeGreaterThan(0);
-    });
-  });
-
-  test("returns ok='transient' on network failure", async () => {
+  test("returns ok=transient on network failure", async () => {
     const fetchImpl = (async () => {
-      throw new Error("ECONNREFUSED");
+      throw new Error("ECONNRESET");
     }) as unknown as typeof globalThis.fetch;
 
     await withFetch(fetchImpl, async () => {
@@ -133,14 +136,11 @@ describe("verifyCustomFields", () => {
         apiKey: "k",
         baseUrl: "https://crm.test.local",
       });
-      if (result.ok !== "transient") throw new Error("expected transient");
-      expect(result.reason).toContain("ECONNREFUSED");
+      expect(result).toMatchObject({ ok: "transient" });
     });
   });
 
-  // CX-2 — deterministic misconfigurations are NOT transient.
-
-  test("returns ok=false on 401 (bad API key — deterministic misconfiguration)", async () => {
+  test("returns ok=false on 401 (deterministic misconfig)", async () => {
     const fetchImpl = (async () =>
       new Response(JSON.stringify({ messages: ["Unauthorized"] }), {
         status: 401,
@@ -149,123 +149,10 @@ describe("verifyCustomFields", () => {
 
     await withFetch(fetchImpl, async () => {
       const result = await verifyCustomFields({
-        apiKey: "wrong-key",
-        baseUrl: "https://crm.test.local",
-      });
-      expect(result).toEqual({ ok: false });
-    });
-  });
-
-  test("returns ok=false on 403 (deterministic misconfiguration)", async () => {
-    const fetchImpl = (async () =>
-      new Response(JSON.stringify({ messages: ["Forbidden"] }), {
-        status: 403,
-        headers: { "Content-Type": "application/json" },
-      })) as unknown as typeof globalThis.fetch;
-
-    await withFetch(fetchImpl, async () => {
-      const result = await verifyCustomFields({
         apiKey: "k",
         baseUrl: "https://crm.test.local",
       });
       expect(result).toEqual({ ok: false });
-    });
-  });
-
-  test("returns ok=false on 404 (wrong base URL — deterministic misconfiguration)", async () => {
-    const fetchImpl = (async () =>
-      new Response(JSON.stringify({ messages: ["Not Found"] }), {
-        status: 404,
-        headers: { "Content-Type": "application/json" },
-      })) as unknown as typeof globalThis.fetch;
-
-    await withFetch(fetchImpl, async () => {
-      const result = await verifyCustomFields({
-        apiKey: "k",
-        baseUrl: "https://crm.test.local",
-      });
-      expect(result).toEqual({ ok: false });
-    });
-  });
-});
-
-// ── dispatchLead — fire-and-forget contract ─────────────────────────
-
-describe("dispatchLead", () => {
-  test("happy path — normalizes and upserts; does not throw", async () => {
-    let fetchCount = 0;
-    const fetchImpl = (async (
-      input: string | URL | Request,
-    ): Promise<Response> => {
-      fetchCount++;
-      const url = typeof input === "string" ? input : (input as Request).url;
-      if (url.includes("/rest/people?filter")) {
-        return new Response(JSON.stringify({ data: { people: [] } }), {
-          status: 200,
-          headers: { "Content-Type": "application/json" },
-        });
-      }
-      return new Response(
-        JSON.stringify({ data: { createPerson: { id: "person_xyz" } } }),
-        { status: 200, headers: { "Content-Type": "application/json" } },
-      );
-    }) as unknown as typeof globalThis.fetch;
-
-    await withFetch(fetchImpl, async () => {
-      await dispatchLead(
-        { apiKey: "k", baseUrl: "https://crm.test.local" },
-        { source: "demo", email: "user@test.com", ip: "1.2.3.4" },
-      );
-      expect(fetchCount).toBe(2);
-    });
-  });
-
-  test("never throws when Twenty returns a 5xx", async () => {
-    const fetchImpl = (async () =>
-      new Response(JSON.stringify({ messages: ["Internal Server Error"] }), {
-        status: 500,
-        headers: { "Content-Type": "application/json" },
-      })) as unknown as typeof globalThis.fetch;
-
-    await withFetch(fetchImpl, async () => {
-      await expect(
-        dispatchLead(
-          { apiKey: "k", baseUrl: "https://crm.test.local" },
-          { source: "demo", email: "user@test.com" },
-        ),
-      ).resolves.toBeUndefined();
-    });
-  });
-
-  test("never throws on network failure", async () => {
-    const fetchImpl = (async () => {
-      throw new Error("ECONNREFUSED");
-    }) as unknown as typeof globalThis.fetch;
-
-    await withFetch(fetchImpl, async () => {
-      await expect(
-        dispatchLead(
-          { apiKey: "k", baseUrl: "https://crm.test.local" },
-          { source: "demo", email: "user@test.com" },
-        ),
-      ).resolves.toBeUndefined();
-    });
-  });
-
-  test("never throws on malformed-200 from findPersonByEmail", async () => {
-    const fetchImpl = (async () =>
-      new Response(JSON.stringify({ data: { people: null } }), {
-        status: 200,
-        headers: { "Content-Type": "application/json" },
-      })) as unknown as typeof globalThis.fetch;
-
-    await withFetch(fetchImpl, async () => {
-      await expect(
-        dispatchLead(
-          { apiKey: "k", baseUrl: "https://crm.test.local" },
-          { source: "demo", email: "user@test.com" },
-        ),
-      ).resolves.toBeUndefined();
     });
   });
 });
@@ -273,6 +160,8 @@ describe("dispatchLead", () => {
 // ── SaasCrmLive boot end-to-end ─────────────────────────────────────
 
 describe("SaasCrmLive boot — enterprise disabled", () => {
+  beforeEach(resetStubs);
+
   test("yields available=false and no-op upsertLead when enterprise is OFF", async () => {
     enterpriseEnabled = false;
     delete process.env.TWENTY_API_KEY;
@@ -288,36 +177,27 @@ describe("SaasCrmLive boot — enterprise disabled", () => {
       program.pipe(Effect.provide(SaasCrmLive)),
     );
     expect(available).toBe(false);
+    expect(enqueueCount).toBe(0);
   });
 });
 
-describe("SaasCrmLive boot — enterprise enabled + creds + both fields present (R-6)", () => {
-  test("yields available=true AND dispatches via TwentyClient on subsequent upsertLead", async () => {
+describe("SaasCrmLive boot — enterprise enabled + creds + both fields present + InternalDB available", () => {
+  beforeEach(resetStubs);
+
+  test("yields available=true AND enqueues to crm_outbox on upsertLead", async () => {
     enterpriseEnabled = true;
     process.env.TWENTY_API_KEY = "test-key";
     process.env.TWENTY_BASE_URL = "https://crm.test.local";
 
     let metadataCalls = 0;
-    let dispatchCalls = 0;
-    const fetchImpl = (async (
-      input: string | URL | Request,
-    ): Promise<Response> => {
+    const fetchImpl = (async (input: string | URL | Request): Promise<Response> => {
       const url = typeof input === "string" ? input : (input as Request).url;
       if (url.endsWith("/metadata")) {
         metadataCalls++;
         return metadataResponse(["id", "atlasFirstSource", "atlasLastSource"]);
       }
-      dispatchCalls++;
-      if (url.includes("/rest/people?filter")) {
-        return new Response(JSON.stringify({ data: { people: [] } }), {
-          status: 200,
-          headers: { "Content-Type": "application/json" },
-        });
-      }
-      return new Response(
-        JSON.stringify({ data: { createPerson: { id: "person_xyz" } } }),
-        { status: 200, headers: { "Content-Type": "application/json" } },
-      );
+      // No dispatch fetches expected — outbox holds the row for the flusher.
+      throw new Error(`Unexpected fetch during enqueue: ${url}`);
     }) as unknown as typeof globalThis.fetch;
 
     try {
@@ -327,7 +207,7 @@ describe("SaasCrmLive boot — enterprise enabled + creds + both fields present 
           const wasAvailable = crm.available;
           yield* crm.upsertLead({
             source: "demo",
-            email: "verified@happy.test",
+            email: "queue@happy.test",
           });
           return wasAvailable;
         });
@@ -336,8 +216,11 @@ describe("SaasCrmLive boot — enterprise enabled + creds + both fields present 
 
       expect(result).toBe(true);
       expect(metadataCalls).toBe(1);
-      // Dispatch: 1 GET (find) + 1 POST (create)
-      expect(dispatchCalls).toBe(2);
+      expect(enqueueCount).toBe(1);
+      // The INSERT carries event_type=source and the original payload as
+      // jsonb. We don't assert exact ordering of params beyond presence.
+      expect(lastEnqueueArgs?.sql).toMatch(/INSERT INTO crm_outbox/i);
+      expect(lastEnqueueArgs?.params[0]).toBe("demo");
     } finally {
       delete process.env.TWENTY_API_KEY;
       delete process.env.TWENTY_BASE_URL;
@@ -345,42 +228,30 @@ describe("SaasCrmLive boot — enterprise enabled + creds + both fields present 
   });
 });
 
-describe("SaasCrmLive boot — missing required field flips available to false (R-5)", () => {
-  test("yields available=false when atlasFirstSource is missing", async () => {
+describe("SaasCrmLive boot — InternalDB unavailable", () => {
+  beforeEach(resetStubs);
+
+  test("yields available=false when hasInternalDB() is false", async () => {
     enterpriseEnabled = true;
+    internalDbAvailable = false;
     process.env.TWENTY_API_KEY = "test-key";
     process.env.TWENTY_BASE_URL = "https://crm.test.local";
 
-    let dispatchCalls = 0;
-    const fetchImpl = (async (
-      input: string | URL | Request,
-    ): Promise<Response> => {
-      const url = typeof input === "string" ? input : (input as Request).url;
-      if (url.endsWith("/metadata")) {
-        // Only atlasLastSource present — atlasFirstSource missing
-        return metadataResponse(["id", "atlasLastSource"]);
-      }
-      dispatchCalls++;
-      return new Response(JSON.stringify({}), { status: 500 });
-    }) as unknown as typeof globalThis.fetch;
+    const fetchImpl = (async () =>
+      metadataResponse(["id", "atlasFirstSource", "atlasLastSource"])) as unknown as typeof globalThis.fetch;
 
     try {
       const result = await withFetch(fetchImpl, async () => {
         const program = Effect.gen(function* () {
           const crm = yield* SaasCrm;
-          // Should be a no-op since available=false
-          yield* crm.upsertLead({
-            source: "demo",
-            email: "missingfield@x.test",
-          });
+          yield* crm.upsertLead({ source: "demo", email: "nodb@x.test" });
           return crm.available;
         });
         return Effect.runPromise(program.pipe(Effect.provide(SaasCrmLive)));
       });
 
       expect(result).toBe(false);
-      // No dispatch calls should have happened (Noop upsertLead bound).
-      expect(dispatchCalls).toBe(0);
+      expect(enqueueCount).toBe(0);
     } finally {
       delete process.env.TWENTY_API_KEY;
       delete process.env.TWENTY_BASE_URL;
@@ -388,48 +259,34 @@ describe("SaasCrmLive boot — missing required field flips available to false (
   });
 });
 
-describe("SaasCrmLive boot — transient metadata failure leaves available=true (R-7)", () => {
-  test("yields available=true when the metadata probe rejects with a network error", async () => {
+describe("SaasCrmLive boot — missing required field flips available to false", () => {
+  beforeEach(resetStubs);
+
+  test("yields available=false when atlasFirstSource is missing", async () => {
     enterpriseEnabled = true;
     process.env.TWENTY_API_KEY = "test-key";
     process.env.TWENTY_BASE_URL = "https://crm.test.local";
 
-    let metadataCalls = 0;
-    let dispatchCalls = 0;
-    const fetchImpl = (async (
-      input: string | URL | Request,
-    ): Promise<Response> => {
+    const fetchImpl = (async (input: string | URL | Request): Promise<Response> => {
       const url = typeof input === "string" ? input : (input as Request).url;
       if (url.endsWith("/metadata")) {
-        metadataCalls++;
-        throw new Error("ECONNRESET");
+        return metadataResponse(["id", "atlasLastSource"]);
       }
-      dispatchCalls++;
-      if (url.includes("/rest/people?filter")) {
-        return new Response(JSON.stringify({ data: { people: [] } }), {
-          status: 200,
-          headers: { "Content-Type": "application/json" },
-        });
-      }
-      return new Response(
-        JSON.stringify({ data: { createPerson: { id: "p1" } } }),
-        { status: 200, headers: { "Content-Type": "application/json" } },
-      );
+      throw new Error(`Unexpected fetch: ${url}`);
     }) as unknown as typeof globalThis.fetch;
 
     try {
       const result = await withFetch(fetchImpl, async () => {
         const program = Effect.gen(function* () {
           const crm = yield* SaasCrm;
-          yield* crm.upsertLead({ source: "demo", email: "transient@x.test" });
+          yield* crm.upsertLead({ source: "demo", email: "missing@x.test" });
           return crm.available;
         });
         return Effect.runPromise(program.pipe(Effect.provide(SaasCrmLive)));
       });
 
-      expect(result).toBe(true);
-      expect(metadataCalls).toBe(1);
-      expect(dispatchCalls).toBeGreaterThan(0);
+      expect(result).toBe(false);
+      expect(enqueueCount).toBe(0);
     } finally {
       delete process.env.TWENTY_API_KEY;
       delete process.env.TWENTY_BASE_URL;
@@ -437,16 +294,15 @@ describe("SaasCrmLive boot — transient metadata failure leaves available=true 
   });
 });
 
-describe("SaasCrmLive boot — 401 metadata response flips to permanent (CX-2)", () => {
-  test("yields available=false on 401 and does NOT dispatch", async () => {
+describe("SaasCrmLive boot — 401 metadata response flips to permanent", () => {
+  beforeEach(resetStubs);
+
+  test("yields available=false on 401 and does NOT enqueue", async () => {
     enterpriseEnabled = true;
     process.env.TWENTY_API_KEY = "test-key";
     process.env.TWENTY_BASE_URL = "https://crm.test.local";
 
-    let dispatchCalls = 0;
-    const fetchImpl = (async (
-      input: string | URL | Request,
-    ): Promise<Response> => {
+    const fetchImpl = (async (input: string | URL | Request): Promise<Response> => {
       const url = typeof input === "string" ? input : (input as Request).url;
       if (url.endsWith("/metadata")) {
         return new Response(JSON.stringify({ messages: ["Unauthorized"] }), {
@@ -454,8 +310,7 @@ describe("SaasCrmLive boot — 401 metadata response flips to permanent (CX-2)",
           headers: { "Content-Type": "application/json" },
         });
       }
-      dispatchCalls++;
-      return new Response(JSON.stringify({}), { status: 500 });
+      throw new Error(`Unexpected fetch: ${url}`);
     }) as unknown as typeof globalThis.fetch;
 
     try {
@@ -469,10 +324,221 @@ describe("SaasCrmLive boot — 401 metadata response flips to permanent (CX-2)",
       });
 
       expect(result).toBe(false);
-      expect(dispatchCalls).toBe(0);
+      expect(enqueueCount).toBe(0);
     } finally {
       delete process.env.TWENTY_API_KEY;
       delete process.env.TWENTY_BASE_URL;
     }
   });
 });
+
+// ── dispatchOutboxRow — the flusher's per-row entry point ───────────
+
+describe("dispatchOutboxRow", () => {
+  beforeEach(resetStubs);
+
+  test("happy path — calls upsertPerson and persists twenty_person_id", async () => {
+    const fetchImpl = (async (input: string | URL | Request): Promise<Response> => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url.includes("/rest/people?filter")) {
+        return new Response(JSON.stringify({ data: { people: [] } }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      return new Response(
+        JSON.stringify({ data: { createPerson: { id: "person_happy" } } }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }) as unknown as typeof globalThis.fetch;
+
+    const persisted: { person?: string; note?: string } = {};
+    const outcome = await withFetch(fetchImpl, async () =>
+      dispatchOutboxRow(
+        { apiKey: "k", baseUrl: "https://crm.test.local" },
+        {
+          id: "row-1",
+          eventType: "demo",
+          payload: { source: "demo", email: "happy@test.local" },
+          attempts: 1,
+          twentyPersonId: null,
+          twentyNoteId: null,
+        },
+        {
+          setTwentyPersonId: async (id: string) => {
+            persisted.person = id;
+          },
+          setTwentyNoteId: async (id: string) => {
+            persisted.note = id;
+          },
+        },
+      ),
+    );
+
+    expect(outcome).toEqual({ kind: "ok" });
+    expect(persisted.person).toBe("person_happy");
+    expect(persisted.note).toBeUndefined();
+  });
+
+  test("idempotent replay — skips upsertPerson when twenty_person_id is already set", async () => {
+    let fetchCount = 0;
+    const fetchImpl = (async (): Promise<Response> => {
+      fetchCount++;
+      // Should never be called — the row's existing twenty_person_id
+      // means the dispatcher must short-circuit straight to done.
+      return new Response("{}", { status: 200 });
+    }) as unknown as typeof globalThis.fetch;
+
+    const persisted: { person?: string; note?: string } = {};
+    const outcome = await withFetch(fetchImpl, async () =>
+      dispatchOutboxRow(
+        { apiKey: "k", baseUrl: "https://crm.test.local" },
+        {
+          id: "row-2",
+          eventType: "demo",
+          payload: { source: "demo", email: "replay@test.local" },
+          attempts: 2,
+          twentyPersonId: "person_already_done",
+          twentyNoteId: null,
+        },
+        {
+          setTwentyPersonId: async (id: string) => {
+            persisted.person = id;
+          },
+          setTwentyNoteId: async (id: string) => {
+            persisted.note = id;
+          },
+        },
+      ),
+    );
+
+    expect(outcome).toEqual({ kind: "ok" });
+    expect(fetchCount).toBe(0);
+    expect(persisted.person).toBeUndefined();
+  });
+
+  test("5xx → transient outcome (retried by flusher)", async () => {
+    const fetchImpl = (async (): Promise<Response> =>
+      new Response(JSON.stringify({ messages: ["upstream boom"] }), {
+        status: 503,
+        headers: { "Content-Type": "application/json" },
+      })) as unknown as typeof globalThis.fetch;
+
+    const outcome = await withFetch(fetchImpl, async () =>
+      dispatchOutboxRow(
+        { apiKey: "k", baseUrl: "https://crm.test.local" },
+        {
+          id: "row-3",
+          eventType: "demo",
+          payload: { source: "demo", email: "transient@test.local" },
+          attempts: 1,
+          twentyPersonId: null,
+          twentyNoteId: null,
+        },
+        {
+          setTwentyPersonId: async () => {},
+          setTwentyNoteId: async () => {},
+        },
+      ),
+    );
+
+    expect(outcome.kind).toBe("transient");
+  });
+
+  test("401 → permanent outcome (dead-lettered)", async () => {
+    const fetchImpl = (async (): Promise<Response> =>
+      new Response(JSON.stringify({ messages: ["Unauthorized"] }), {
+        status: 401,
+        headers: { "Content-Type": "application/json" },
+      })) as unknown as typeof globalThis.fetch;
+
+    const outcome = await withFetch(fetchImpl, async () =>
+      dispatchOutboxRow(
+        { apiKey: "k", baseUrl: "https://crm.test.local" },
+        {
+          id: "row-4",
+          eventType: "demo",
+          payload: { source: "demo", email: "dead@test.local" },
+          attempts: 1,
+          twentyPersonId: null,
+          twentyNoteId: null,
+        },
+        {
+          setTwentyPersonId: async () => {},
+          setTwentyNoteId: async () => {},
+        },
+      ),
+    );
+
+    expect(outcome.kind).toBe("permanent");
+  });
+
+  test("429 → transient (rate-limited)", async () => {
+    const fetchImpl = (async (): Promise<Response> =>
+      new Response(JSON.stringify({ messages: ["rate limited"] }), {
+        status: 429,
+        headers: { "Content-Type": "application/json" },
+      })) as unknown as typeof globalThis.fetch;
+
+    const outcome = await withFetch(fetchImpl, async () =>
+      dispatchOutboxRow(
+        { apiKey: "k", baseUrl: "https://crm.test.local" },
+        {
+          id: "row-5",
+          eventType: "demo",
+          payload: { source: "demo", email: "rate@test.local" },
+          attempts: 1,
+          twentyPersonId: null,
+          twentyNoteId: null,
+        },
+        {
+          setTwentyPersonId: async () => {},
+          setTwentyNoteId: async () => {},
+        },
+      ),
+    );
+
+    expect(outcome.kind).toBe("transient");
+  });
+
+  test("network failure → transient", async () => {
+    const fetchImpl = (async () => {
+      throw new Error("ECONNREFUSED");
+    }) as unknown as typeof globalThis.fetch;
+
+    const outcome = await withFetch(fetchImpl, async () =>
+      dispatchOutboxRow(
+        { apiKey: "k", baseUrl: "https://crm.test.local" },
+        {
+          id: "row-6",
+          eventType: "demo",
+          payload: { source: "demo", email: "net@test.local" },
+          attempts: 1,
+          twentyPersonId: null,
+          twentyNoteId: null,
+        },
+        {
+          setTwentyPersonId: async () => {},
+          setTwentyNoteId: async () => {},
+        },
+      ),
+    );
+
+    expect(outcome.kind).toBe("transient");
+  });
+});
+
+// ── classifyTwentyError ─────────────────────────────────────────────
+
+describe("classifyTwentyError", () => {
+  test("non-TwentyClientError defaults to transient", () => {
+    const out = classifyTwentyError(new Error("boom"), "upsertPerson");
+    expect(out.kind).toBe("transient");
+  });
+
+  test("non-Error value defaults to transient", () => {
+    const out = classifyTwentyError("string thrown", "upsertPerson");
+    expect(out.kind).toBe("transient");
+  });
+});
+

--- a/ee/src/saas-crm/__tests__/saas-crm.test.ts
+++ b/ee/src/saas-crm/__tests__/saas-crm.test.ts
@@ -526,6 +526,178 @@ describe("dispatchOutboxRow", () => {
 
     expect(outcome.kind).toBe("transient");
   });
+
+  test("upsertPerson returns 200 with no id → permanent (no silent done)", async () => {
+    // Realistic regression: a misconfigured Twenty (or a future fast-path
+    // refactor of upsertPerson) could return a 2xx with an empty body.
+    // The row must dead-letter rather than be marked done with no link.
+    const fetchImpl = (async (input: string | URL | Request): Promise<Response> => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url.includes("/rest/people?filter")) {
+        return new Response(JSON.stringify({ data: { people: [] } }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      // POST createPerson — 2xx but no id.
+      return new Response(
+        JSON.stringify({ data: { createPerson: {} } }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }) as unknown as typeof globalThis.fetch;
+
+    const outcome = await withFetch(fetchImpl, async () =>
+      dispatchOutboxRow(
+        { apiKey: "k", baseUrl: "https://crm.test.local" },
+        {
+          id: "row-noid",
+          eventType: "demo",
+          payload: { source: "demo", email: "noid@test.local" },
+          attempts: 1,
+          twentyPersonId: null,
+          twentyNoteId: null,
+        },
+        {
+          setTwentyPersonId: async () => {
+            throw new Error("setTwentyPersonId must NOT be called when id is missing");
+          },
+          setTwentyNoteId: async () => {},
+        },
+      ),
+    );
+
+    expect(outcome.kind).toBe("permanent");
+    if (outcome.kind === "permanent") {
+      expect(outcome.message).toContain("no id");
+    }
+  });
+
+  test("persist.setTwentyPersonId fails after upsertPerson succeeds → transient with persist-failure label (NOT upsertPerson)", async () => {
+    // Realistic regression: a pg pool blip between Twenty's 2xx and our
+    // UPDATE writes the wrong story in last_error. Operators triaging
+    // the row would chase a Twenty problem when the actual fault is
+    // internal — the message MUST identify the persist step.
+    const fetchImpl = (async (input: string | URL | Request): Promise<Response> => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url.includes("/rest/people?filter")) {
+        return new Response(JSON.stringify({ data: { people: [] } }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      return new Response(
+        JSON.stringify({ data: { createPerson: { id: "person_X" } } }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }) as unknown as typeof globalThis.fetch;
+
+    const outcome = await withFetch(fetchImpl, async () =>
+      dispatchOutboxRow(
+        { apiKey: "k", baseUrl: "https://crm.test.local" },
+        {
+          id: "row-persist-blip",
+          eventType: "demo",
+          payload: { source: "demo", email: "blip@test.local" },
+          attempts: 1,
+          twentyPersonId: null,
+          twentyNoteId: null,
+        },
+        {
+          setTwentyPersonId: async () => {
+            throw new Error("pg pool exhausted");
+          },
+          setTwentyNoteId: async () => {},
+        },
+      ),
+    );
+
+    expect(outcome.kind).toBe("transient");
+    if (outcome.kind === "transient") {
+      expect(outcome.message).toContain("persist.setTwentyPersonId");
+      expect(outcome.message).toContain("pg pool exhausted");
+      expect(outcome.message).not.toContain("upsertPerson threw");
+    }
+  });
+
+  test("429 with Retry-After header surfaces retryAfterMs on the transient outcome", async () => {
+    // delta-seconds form per RFC 9110.
+    const fetchImpl = (async (input: string | URL | Request): Promise<Response> => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url.includes("/rest/people?filter")) {
+        return new Response(JSON.stringify({ data: { people: [] } }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      // POST createPerson with Retry-After: 90.
+      return new Response(JSON.stringify({ messages: ["rate limited"] }), {
+        status: 429,
+        headers: { "Content-Type": "application/json", "Retry-After": "90" },
+      });
+    }) as unknown as typeof globalThis.fetch;
+
+    const outcome = await withFetch(fetchImpl, async () =>
+      dispatchOutboxRow(
+        { apiKey: "k", baseUrl: "https://crm.test.local" },
+        {
+          id: "row-rate",
+          eventType: "demo",
+          payload: { source: "demo", email: "rate@test.local" },
+          attempts: 1,
+          twentyPersonId: null,
+          twentyNoteId: null,
+        },
+        {
+          setTwentyPersonId: async () => {},
+          setTwentyNoteId: async () => {},
+        },
+      ),
+    );
+
+    expect(outcome.kind).toBe("transient");
+    if (outcome.kind === "transient") {
+      expect(outcome.retryAfterMs).toBe(90_000);
+      expect(outcome.httpStatus).toBe(429);
+    }
+  });
+
+  test("sales-form row dead-letters today via the normalizer (sales-form not yet accepted)", async () => {
+    // The normalizer's discriminated union only accepts `demo` today;
+    // a sales-form payload throws `Unknown lead source` BEFORE the
+    // dispatcher's downstream sales-form branch runs. Either way the
+    // row dead-letters with an operator-visible message. This test
+    // pins both halves of the contract: (1) no fetch is attempted,
+    // (2) the dead-letter message identifies the offending source.
+    let fetchCalls = 0;
+    const fetchImpl = (async (): Promise<Response> => {
+      fetchCalls++;
+      return new Response("{}", { status: 200 });
+    }) as unknown as typeof globalThis.fetch;
+
+    const outcome = await withFetch(fetchImpl, async () =>
+      dispatchOutboxRow(
+        { apiKey: "k", baseUrl: "https://crm.test.local" },
+        {
+          id: "row-sales",
+          eventType: "sales-form",
+          payload: { source: "sales-form", email: "sales@test.local" },
+          attempts: 1,
+          twentyPersonId: null,
+          twentyNoteId: null,
+        },
+        {
+          setTwentyPersonId: async () => {},
+          setTwentyNoteId: async () => {},
+        },
+      ),
+    );
+
+    expect(fetchCalls).toBe(0);
+    expect(outcome.kind).toBe("permanent");
+    if (outcome.kind === "permanent") {
+      expect(outcome.message).toContain("sales-form");
+    }
+  });
 });
 
 // ── classifyTwentyError ─────────────────────────────────────────────

--- a/ee/src/saas-crm/index.ts
+++ b/ee/src/saas-crm/index.ts
@@ -4,6 +4,12 @@
  * plugin. Self-hosted Atlas gets the Noop layer from
  * `lib/effect/services.ts:NoopSaasCrmLayer`.
  *
+ * Slice 2 of 1.6.0 (#2729): `upsertLead` no longer dispatches inline.
+ * It enqueues a `crm_outbox` row and returns immediately; the flusher
+ * (wired in `lib/effect/layers.ts:makeSchedulerLive`) claims the row on
+ * the next tick and calls `dispatchOutboxRow` below. A Twenty outage,
+ * API crash, or partial sub-step failure no longer drops the lead.
+ *
  * Transient metadata-probe failures deliberately leave `available: true`
  * — a real schema mismatch surfaces as a 422 on the first upsert call.
  * Deterministic misconfigurations (401/403/404) flip to permanent so
@@ -17,6 +23,15 @@ import {
   type SaasCrmLeadInput,
 } from "@atlas/api/lib/effect/services";
 import { createLogger } from "@atlas/api/lib/logger";
+import { hasInternalDB, internalQuery } from "@atlas/api/lib/db/internal";
+import {
+  enqueue,
+  classifyHttpStatus,
+  type OutboxDB,
+  type ClaimedOutboxRow,
+  type OutboxPersistHelpers,
+  type DispatchOutcome,
+} from "@atlas/api/lib/lead-outbox";
 import { isEnterpriseEnabled } from "../index";
 import {
   getPersonMetadata,
@@ -42,15 +57,13 @@ const REQUIRED_PERSON_FIELDS = ["atlasFirstSource", "atlasLastSource"] as const;
 const ATLAS_SAAS_TWENTY_BASE_URL = "https://crm.useatlas.dev";
 
 /**
- * Per-request timeout for the SaaS CRM client. Tight on purpose: every
- * lead dispatch sits inside the demo response path, and even though
- * the dispatch is fire-and-forget at the catch-and-swallow layer
- * inside `dispatchLead`, the `await` in `captureDemoLead` would still
- * add latency-on-failure. 3s caps each leg (find + create/patch),
- * keeping worst-case Twenty-outage latency in the demo response under
- * ~6s rather than the 10s default.
+ * Per-request timeout for the SaaS CRM client. With the outbox in
+ * place the demo response no longer waits on the dispatch, so we
+ * could relax this — but a tight timeout still bounds how long a
+ * single flush tick blocks on a stuck Twenty. 5s keeps the flusher
+ * responsive without thrashing on transient slow responses.
  */
-const SAAS_TIMEOUT_MS = 3_000;
+const SAAS_TIMEOUT_MS = 5_000;
 
 function missingFieldInstructions(missing: ReadonlyArray<string>): string {
   return (
@@ -142,50 +155,102 @@ async function verifyCustomFields(
 }
 
 /**
- * Dispatch a normalized lead via TwentyClient. Errors are caught and
- * logged inside this function so the SaasCrmShape Effect channel stays
- * typed as `Effect<void>` (no error channel) — that contract is what
- * keeps the call-site short (`yield* SaasCrm` then
- * `yield* upsertLead(input)` with nothing to catch).
+ * The outbox-side OutboxDB adapter. We delegate to the module-level
+ * `internalQuery` rather than yielding `InternalDB` from Effect
+ * Context so the SaasCrm Layer requirements stay empty — the demo
+ * route's `runEnterprise(...)` provides `EnterpriseSubsystem`, not
+ * `InternalDB`, and we don't want to widen that contract just to give
+ * the SaasCrm layer access to the pool.
  */
-async function dispatchLead(
+const outboxDb: OutboxDB = {
+  query: internalQuery,
+};
+
+/**
+ * Dispatch one claimed outbox row through the Twenty client. Each
+ * sub-step's resource ID is persisted via the `persist` callbacks
+ * AS SOON AS the call returns — that's what makes the partial-success
+ * crash path idempotent on retry.
+ *
+ * Errors are classified into `transient` / `permanent` based on the
+ * upstream HTTP status (per #2729): 4xx other than 429 → permanent
+ * (deterministic misconfig, never going to succeed on retry); 5xx /
+ * 429 / transport / unknown → transient (worth a retry).
+ */
+export async function dispatchOutboxRow(
   clientConfig: TwentyClientConfig,
-  input: SaasCrmLeadInput,
-): Promise<void> {
+  row: ClaimedOutboxRow,
+  persist: OutboxPersistHelpers,
+): Promise<DispatchOutcome> {
+  // Normalize from the persisted payload. The payload was JSON.stringified
+  // on enqueue (`enqueue` passes `JSON.stringify(input.payload)`), and the
+  // jsonb column round-trips through pg as a plain object — so what we
+  // get back is structurally a `SaasCrmLeadInput`. Cast at this single
+  // boundary; downstream code is type-safe.
+  let normalized;
   try {
-    const normalized = normalizeLead(input);
-    await upsertPerson(clientConfig, normalized.person);
-    log.debug(
-      { source: input.source, eventSource: normalized.eventSource },
-      "SaaS CRM lead dispatched to Twenty",
-    );
+    normalized = normalizeLead(row.payload as SaasCrmLeadInput);
   } catch (err) {
-    // Twenty being down (or a missing custom field, or a bad key)
-    // MUST NOT block the caller. Log loudly so an operator can
-    // correlate, but never re-throw.
-    if (err instanceof TwentyClientError) {
-      log.warn(
-        {
-          source: input.source,
-          status: err.status,
-          upstreamCode: err.upstreamCode,
-          operation: err.operation,
-          err: err.message,
-          event: "saas_crm.dispatch_failed",
-        },
-        "Twenty upsertPerson failed — lead lost (durable outbox not yet implemented)",
-      );
-    } else {
-      log.warn(
-        {
-          source: input.source,
-          err: err instanceof Error ? err.message : String(err),
-          event: "saas_crm.dispatch_failed",
-        },
-        "Twenty dispatch threw unexpectedly — lead lost",
-      );
+    // A normalizer error is a bug in our own code (the discriminated
+    // union exhaustiveness should have caught it). Dead-letter so an
+    // operator sees the corrupt payload.
+    return {
+      kind: "permanent",
+      message: `normalizeLead threw: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+
+  // ── Sub-step 1: upsertPerson (always required) ────────────────────
+  if (!row.twentyPersonId) {
+    try {
+      const person = await upsertPerson(clientConfig, normalized.person);
+      if (person.id) {
+        await persist.setTwentyPersonId(person.id);
+      } else {
+        // Twenty returned a 2xx Person with no id. Treat as permanent —
+        // we have no way to reference the record on retry, so retrying
+        // would just create another duplicate-by-email upsert against
+        // an already-mutated record. Operator must inspect.
+        return {
+          kind: "permanent",
+          message: "upsertPerson succeeded but returned no id",
+        };
+      }
+    } catch (err) {
+      return classifyTwentyError(err, "upsertPerson");
     }
   }
+
+  // ── Sub-step 2: createNote (sales-form only — placeholder) ───────
+  // The `sales-form` source is anticipated in #2729 but the
+  // discriminated union in `@useatlas/twenty/lead-normalizer` only
+  // emits `demo` today. When the sales-form variant lands the
+  // dispatcher's branch below activates; until then the conditional
+  // is a no-op for every row in production.
+  if (row.eventType === "sales-form" && !row.twentyNoteId) {
+    // createNote is not yet implemented in @useatlas/twenty (#2729
+    // ships only the outbox primitive + Twenty dispatcher swap; the
+    // sales-form lead source + createNote call land in a follow-up
+    // slice). Treat the row as done — the upsertPerson sub-step
+    // already captured the lead — so we don't infinitely retry on
+    // a missing function.
+    log.debug(
+      { rowId: row.id, event: "lead_outbox.sales_form_note_skipped" },
+      "sales-form note step not yet wired — completing row at upsertPerson",
+    );
+  }
+
+  return { kind: "ok" };
+}
+
+function classifyTwentyError(err: unknown, op: string): DispatchOutcome {
+  if (err instanceof TwentyClientError) {
+    const classification = classifyHttpStatus(err.status);
+    const message = `${op} failed (status=${err.status}${err.upstreamCode ? `, code=${err.upstreamCode}` : ""}): ${err.message}`;
+    return { kind: classification, message };
+  }
+  const message = `${op} threw: ${err instanceof Error ? err.message : String(err)}`;
+  return { kind: "transient", message };
 }
 
 // Boot-time verification runs once inside Layer.effect; available reflects that one check.
@@ -198,6 +263,7 @@ export const SaasCrmLive: Layer.Layer<SaasCrm> = Layer.effect(
       return {
         available: false,
         upsertLead: () => Effect.void,
+        dispatcher: null,
       } satisfies SaasCrmShape;
     }
 
@@ -210,6 +276,19 @@ export const SaasCrmLive: Layer.Layer<SaasCrm> = Layer.effect(
       return {
         available: false,
         upsertLead: () => Effect.void,
+        dispatcher: null,
+      } satisfies SaasCrmShape;
+    }
+
+    if (!hasInternalDB()) {
+      log.warn(
+        { event: "saas_crm.no_internal_db" },
+        "Internal DB unavailable — SaasCrm.available=false. The outbox cannot enqueue without a Postgres backing store.",
+      );
+      return {
+        available: false,
+        upsertLead: () => Effect.void,
+        dispatcher: null,
       } satisfies SaasCrmShape;
     }
 
@@ -217,18 +296,19 @@ export const SaasCrmLive: Layer.Layer<SaasCrm> = Layer.effect(
     if (verifyResult.ok === false) {
       // Already logged inside verifyCustomFields (missing fields OR
       // deterministic misconfiguration). Surface unavailable so
-      // subsequent demo signups are no-ops rather than dead-letter
-      // rows in the (future) outbox.
+      // subsequent demo signups are no-ops rather than rows that will
+      // dead-letter on the very first flush.
       return {
         available: false,
         upsertLead: () => Effect.void,
+        dispatcher: null,
       } satisfies SaasCrmShape;
     }
     if (verifyResult.ok === "transient") {
       log.warn(
         { err: verifyResult.reason, event: "saas_crm.verify_transient_failure" },
         "Twenty metadata endpoint errored during boot verification — assuming custom fields are present. " +
-          "A real schema mismatch will surface as a 422 on the first upsertPerson call.",
+          "A real schema mismatch will surface as a 422 on the first dispatch (and dead-letter the row).",
       );
     } else {
       log.info(
@@ -245,10 +325,42 @@ export const SaasCrmLive: Layer.Layer<SaasCrm> = Layer.effect(
     return {
       available: true,
       upsertLead: (input) =>
-        Effect.promise(() => dispatchLead(clientConfig, input)),
+        Effect.tryPromise({
+          try: async () => {
+            await enqueue(outboxDb, {
+              eventType: input.source,
+              payload: input as unknown as Record<string, unknown>,
+            });
+          },
+          catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+        }).pipe(
+          Effect.catchAll((err) =>
+            Effect.sync(() => {
+              // An enqueue failure is just a Postgres write — they
+              // should be rare. Log and swallow so the demo response
+              // stays unblocked, matching the original fire-and-forget
+              // contract of `upsertLead`. The captureDemoLead caller
+              // still has its own defense-in-depth catch.
+              log.error(
+                {
+                  source: input.source,
+                  err: err.message,
+                  event: "saas_crm.enqueue_failed",
+                },
+                "crm_outbox enqueue failed — lead lost (Postgres write error)",
+              );
+            }),
+          ),
+        ),
+      dispatcher: (row, persist) => dispatchOutboxRow(clientConfig, row, persist),
     } satisfies SaasCrmShape;
   }),
 );
 
 // Re-exported for direct testing of the verification / dispatch logic.
-export { verifyCustomFields, dispatchLead, buildSaasClientConfig, ATLAS_SAAS_TWENTY_BASE_URL };
+export {
+  verifyCustomFields,
+  buildSaasClientConfig,
+  ATLAS_SAAS_TWENTY_BASE_URL,
+  classifyTwentyError,
+};

--- a/ee/src/saas-crm/index.ts
+++ b/ee/src/saas-crm/index.ts
@@ -202,42 +202,56 @@ export async function dispatchOutboxRow(
 
   // ── Sub-step 1: upsertPerson (always required) ────────────────────
   if (!row.twentyPersonId) {
+    let person;
     try {
-      const person = await upsertPerson(clientConfig, normalized.person);
-      if (person.id) {
-        await persist.setTwentyPersonId(person.id);
-      } else {
-        // Twenty returned a 2xx Person with no id. Treat as permanent —
-        // we have no way to reference the record on retry, so retrying
-        // would just create another duplicate-by-email upsert against
-        // an already-mutated record. Operator must inspect.
-        return {
-          kind: "permanent",
-          message: "upsertPerson succeeded but returned no id",
-        };
-      }
+      person = await upsertPerson(clientConfig, normalized.person);
     } catch (err) {
       return classifyTwentyError(err, "upsertPerson");
+    }
+    if (!person.id) {
+      // Twenty returned a 2xx Person with no id. Treat as permanent —
+      // we have no way to reference the record on retry, so retrying
+      // would just create another duplicate-by-email upsert against
+      // an already-mutated record. Operator must inspect.
+      return {
+        kind: "permanent",
+        message: "upsertPerson succeeded but returned no id",
+      };
+    }
+    // Persist the id in its own try/catch so an isolated pg blip is
+    // labelled as a persist failure, not as an `upsertPerson threw`.
+    // The next claim will see `twentyPersonId === null` and re-call
+    // upsertPerson, which is safe because `upsertPerson` itself does
+    // a find-by-email-first → PATCH-if-exists (no duplicate Person).
+    try {
+      await persist.setTwentyPersonId(person.id);
+    } catch (err) {
+      return {
+        kind: "transient",
+        message:
+          `persist.setTwentyPersonId failed after upsertPerson succeeded ` +
+          `(personId=${person.id}): ${err instanceof Error ? err.message : String(err)}`,
+      };
     }
   }
 
   // ── Sub-step 2: createNote (sales-form only — placeholder) ───────
   // The `sales-form` source is anticipated in #2729 but the
   // discriminated union in `@useatlas/twenty/lead-normalizer` only
-  // emits `demo` today. When the sales-form variant lands the
-  // dispatcher's branch below activates; until then the conditional
-  // is a no-op for every row in production.
+  // emits `demo` today. The dispatcher dead-letters any sales-form
+  // row that lands today so the failure is operator-visible (rather
+  // than silently completing at upsertPerson and dropping the note).
   if (row.eventType === "sales-form" && !row.twentyNoteId) {
-    // createNote is not yet implemented in @useatlas/twenty (#2729
-    // ships only the outbox primitive + Twenty dispatcher swap; the
-    // sales-form lead source + createNote call land in a follow-up
-    // slice). Treat the row as done — the upsertPerson sub-step
-    // already captured the lead — so we don't infinitely retry on
-    // a missing function.
-    log.debug(
-      { rowId: row.id, event: "lead_outbox.sales_form_note_skipped" },
-      "sales-form note step not yet wired — completing row at upsertPerson",
+    log.warn(
+      { rowId: row.id, event: "lead_outbox.sales_form_note_unwired" },
+      "sales-form row received but createNote is not wired — dead-lettering",
     );
+    return {
+      kind: "permanent",
+      message:
+        "sales-form createNote not yet implemented in @useatlas/twenty — " +
+        "follow-up slice will wire this. Row dead-lettered for visibility.",
+    };
   }
 
   return { kind: "ok" };
@@ -247,7 +261,15 @@ function classifyTwentyError(err: unknown, op: string): DispatchOutcome {
   if (err instanceof TwentyClientError) {
     const classification = classifyHttpStatus(err.status);
     const message = `${op} failed (status=${err.status}${err.upstreamCode ? `, code=${err.upstreamCode}` : ""}): ${err.message}`;
-    return { kind: classification, message };
+    if (classification === "transient") {
+      return {
+        kind: "transient",
+        message,
+        httpStatus: err.status,
+        retryAfterMs: err.retryAfterMs,
+      };
+    }
+    return { kind: "permanent", message, httpStatus: err.status };
   }
   const message = `${op} threw: ${err instanceof Error ? err.message : String(err)}`;
   return { kind: "transient", message };
@@ -263,7 +285,6 @@ export const SaasCrmLive: Layer.Layer<SaasCrm> = Layer.effect(
       return {
         available: false,
         upsertLead: () => Effect.void,
-        dispatcher: null,
       } satisfies SaasCrmShape;
     }
 
@@ -276,7 +297,6 @@ export const SaasCrmLive: Layer.Layer<SaasCrm> = Layer.effect(
       return {
         available: false,
         upsertLead: () => Effect.void,
-        dispatcher: null,
       } satisfies SaasCrmShape;
     }
 
@@ -288,7 +308,6 @@ export const SaasCrmLive: Layer.Layer<SaasCrm> = Layer.effect(
       return {
         available: false,
         upsertLead: () => Effect.void,
-        dispatcher: null,
       } satisfies SaasCrmShape;
     }
 
@@ -301,7 +320,6 @@ export const SaasCrmLive: Layer.Layer<SaasCrm> = Layer.effect(
       return {
         available: false,
         upsertLead: () => Effect.void,
-        dispatcher: null,
       } satisfies SaasCrmShape;
     }
     if (verifyResult.ok === "transient") {
@@ -338,9 +356,9 @@ export const SaasCrmLive: Layer.Layer<SaasCrm> = Layer.effect(
             Effect.sync(() => {
               // An enqueue failure is just a Postgres write — they
               // should be rare. Log and swallow so the demo response
-              // stays unblocked, matching the original fire-and-forget
-              // contract of `upsertLead`. The captureDemoLead caller
-              // still has its own defense-in-depth catch.
+              // stays unblocked. `captureDemoLead` already has its
+              // own defense-in-depth catch around the dispatched
+              // Effect, so the route handler never sees this error.
               log.error(
                 {
                   source: input.source,

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -8,6 +8,7 @@
     "./lib/audit": "./src/lib/audit/index.ts",
     "./lib/audit/*": "./src/lib/audit/*.ts",
     "./lib/content-mode": "./src/lib/content-mode/index.ts",
+    "./lib/lead-outbox": "./src/lib/lead-outbox/index.ts",
     "./lib/env-routing": "./src/lib/env-routing/index.ts",
     "./lib/env-routing/*": "./src/lib/env-routing/*.ts",
     "./lib/multi-env-merger": "./src/lib/multi-env-merger/index.ts",

--- a/packages/api/src/lib/auth/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/auth/__tests__/migrate.test.ts
@@ -347,6 +347,7 @@ describe("migrateAuthTables", () => {
             { name: "0099_approval_surface_discord.sql" },
             { name: "0100_approval_surface_whatsapp.sql" },
             { name: "0101_approval_surface_gchat.sql" },
+            { name: "0102_crm_outbox.sql" },
           ],
         };
       }

--- a/packages/api/src/lib/db/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate.test.ts
@@ -116,8 +116,9 @@ describe("runMigrations", () => {
     // + 0100 (add 'whatsapp' to approval-surface CHECK enums + promote
     //   whatsapp catalog row to 'available', #2753)
     // + 0101 (add 'gchat' to approval-surface CHECK enums + promote
-    //   gchat catalog row to 'available', #2754) = 102.
-    expect(count).toBe(102);
+    //   gchat catalog row to 'available', #2754)
+    // + 0102 (crm_outbox durable queue, #2729) = 103.
+    expect(count).toBe(103);
 
     // Advisory lock acquired before anything else
     expect(queries[0]).toContain("pg_advisory_lock");
@@ -248,6 +249,7 @@ describe("runMigrations", () => {
         "0099_approval_surface_discord.sql",
         "0100_approval_surface_whatsapp.sql",
         "0101_approval_surface_gchat.sql",
+        "0102_crm_outbox.sql",
       ],
     });
 

--- a/packages/api/src/lib/db/migrations/0102_crm_outbox.sql
+++ b/packages/api/src/lib/db/migrations/0102_crm_outbox.sql
@@ -8,16 +8,25 @@
 -- Shape rationale:
 --   * `status` is `text` + CHECK rather than a Postgres enum: easier to
 --     evolve (no `ALTER TYPE ... ADD VALUE` ceremony) and consistent
---     with the rest of the 0095+ enum-as-CHECK convention in this repo.
+--     with the repo-wide `text + CHECK IN (…)` convention.
 --   * `attempts` + `last_error` carry retry state; the flusher computes
 --     the next-allowed dispatch time from `attempts` + `created_at` so
 --     backoff is enforced in the WHERE clause rather than a sleep
 --     (a long backoff on row A must not stall newer rows).
+--   * `retry_after` (nullable) overrides the tier-based backoff when
+--     the upstream returned a parseable `Retry-After` header on a 429
+--     (or any other transient failure). The claim WHERE is
+--     `COALESCE(retry_after, created_at + tier_delay) <= now()` so a
+--     longer upstream-requested delay always wins, but the tier
+--     default still applies when no header was provided.
 --   * `twenty_person_id` / `twenty_note_id` persist per-sub-step
 --     resource IDs. On retry the flusher skips any sub-step whose ID
 --     column is already populated — that is the only way to guarantee
 --     idempotency across an "upsertPerson succeeded, createNote
 --     crashed" partial commit.
+--     TODO(#2729-followup): generalise to `resource_ids JSONB` if a
+--     second SaaS CRM ever ships — the Twenty-specific column names
+--     leak vendor specifics into the otherwise-generic outbox.
 --   * No `workspace_id` or other PII-bearing column beyond the payload
 --     blob (which contains email + UA). The outbox stores no
 --     credentials, so this table is intentionally NOT listed in
@@ -36,6 +45,13 @@ CREATE TABLE IF NOT EXISTS crm_outbox (
   last_error         TEXT,
   twenty_person_id   TEXT,
   twenty_note_id     TEXT,
+  retry_after        TIMESTAMPTZ,
+  -- `claimed_at` is stamped by CLAIM_SQL on every claim. The recovery
+  -- sweep filters by `now() - claimed_at > threshold` so a peer pod's
+  -- in-flight row (claimed seconds ago) is NOT reset out from under it
+  -- during the dying pod's shutdown sweep. Without this, a multi-pod
+  -- deploy could double-dispatch (Codex P1, 2026-05-25).
+  claimed_at         TIMESTAMPTZ,
   created_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   processed_at       TIMESTAMPTZ,
   CONSTRAINT crm_outbox_status_chk
@@ -53,4 +69,10 @@ COMMENT ON COLUMN crm_outbox.twenty_person_id IS
   'Twenty Person ID populated after upsertPerson succeeds. On retry, the flusher skips upsertPerson when this is set — guarantees the partial-success crash path cannot create a duplicate Person.';
 
 COMMENT ON COLUMN crm_outbox.twenty_note_id IS
-  'Twenty Note ID populated after createNote succeeds. Only set for event_type=''sales-form''; demo/signup leads finish at upsertPerson.';
+  'Reserved for the sales-form variant (follow-up slice). createNote is not yet wired in @useatlas/twenty; this column stays NULL today for every row.';
+
+COMMENT ON COLUMN crm_outbox.retry_after IS
+  'Absolute timestamp before which the row must not be re-claimed. Set when the dispatcher surfaced a parseable Retry-After header (429 / similar). NULL means the tier-based backoff applies. Cleared on the next transient outcome that lacks a header.';
+
+COMMENT ON COLUMN crm_outbox.claimed_at IS
+  'Timestamp of the most recent CLAIM_SQL execution against this row. recoverInFlight filters by `now() - claimed_at > threshold` so a sibling pod''s in-flight row is not reset during a shutdown sweep — critical for multi-pod deployments.';

--- a/packages/api/src/lib/db/migrations/0102_crm_outbox.sql
+++ b/packages/api/src/lib/db/migrations/0102_crm_outbox.sql
@@ -1,0 +1,56 @@
+-- 0102_crm_outbox.sql
+--
+-- `crm_outbox` — durable queue for SaaS CRM (Twenty) lead dispatches.
+-- Slice 2 of 1.6.0 (#2729). Replaces the fire-and-forget dispatch from
+-- slice 1 (#2727) with a write-then-flush pattern so a Twenty outage
+-- or API crash no longer drops leads.
+--
+-- Shape rationale:
+--   * `status` is `text` + CHECK rather than a Postgres enum: easier to
+--     evolve (no `ALTER TYPE ... ADD VALUE` ceremony) and consistent
+--     with the rest of the 0095+ enum-as-CHECK convention in this repo.
+--   * `attempts` + `last_error` carry retry state; the flusher computes
+--     the next-allowed dispatch time from `attempts` + `created_at` so
+--     backoff is enforced in the WHERE clause rather than a sleep
+--     (a long backoff on row A must not stall newer rows).
+--   * `twenty_person_id` / `twenty_note_id` persist per-sub-step
+--     resource IDs. On retry the flusher skips any sub-step whose ID
+--     column is already populated — that is the only way to guarantee
+--     idempotency across an "upsertPerson succeeded, createNote
+--     crashed" partial commit.
+--   * No `workspace_id` or other PII-bearing column beyond the payload
+--     blob (which contains email + UA). The outbox stores no
+--     credentials, so this table is intentionally NOT listed in
+--     `INTEGRATION_TABLES` (F-47 rotation / F-42 audit skip it).
+--
+-- Partial index on (status, created_at) WHERE status IN
+-- ('pending','in_flight') keeps the flusher's poll query fast even
+-- after the table grows — done/dead rows fall out of the index.
+
+CREATE TABLE IF NOT EXISTS crm_outbox (
+  id                 UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  event_type         TEXT NOT NULL,
+  payload            JSONB NOT NULL,
+  status             TEXT NOT NULL DEFAULT 'pending',
+  attempts           INTEGER NOT NULL DEFAULT 0,
+  last_error         TEXT,
+  twenty_person_id   TEXT,
+  twenty_note_id     TEXT,
+  created_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  processed_at       TIMESTAMPTZ,
+  CONSTRAINT crm_outbox_status_chk
+    CHECK (status IN ('pending', 'in_flight', 'done', 'dead'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_crm_outbox_pending_created
+  ON crm_outbox (status, created_at)
+  WHERE status IN ('pending', 'in_flight');
+
+COMMENT ON TABLE crm_outbox IS
+  'Durable outbox for SaaS CRM (Twenty) lead dispatches. SaasCrm.upsertLead writes a pending row; the Scheduler-backed flusher claims, dispatches, and stamps per-sub-step resource IDs. See packages/api/src/lib/lead-outbox/ (#2729).';
+
+COMMENT ON COLUMN crm_outbox.twenty_person_id IS
+  'Twenty Person ID populated after upsertPerson succeeds. On retry, the flusher skips upsertPerson when this is set — guarantees the partial-success crash path cannot create a duplicate Person.';
+
+COMMENT ON COLUMN crm_outbox.twenty_note_id IS
+  'Twenty Note ID populated after createNote succeeds. Only set for event_type=''sales-form''; demo/signup leads finish at upsertPerson.';

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -9,6 +9,7 @@
  * part of the standard migration path instead of lazy ensureTable() calls.
  */
 
+import type { OutboxStatus } from "../lead-outbox/outbox";
 import {
   pgTable,
   uuid,
@@ -2250,11 +2251,16 @@ export const crmOutbox = pgTable(
     id: uuid("id").primaryKey().defaultRandom(),
     eventType: text("event_type").notNull(),
     payload: jsonb("payload").notNull(),
-    status: text("status").notNull().default("pending"),
+    status: text("status").$type<OutboxStatus>().notNull().default("pending"),
     attempts: integer("attempts").notNull().default(0),
     lastError: text("last_error"),
+    // TODO(#2729-followup): rename to a generic `resource_ids JSONB` if
+    // a second SaaS CRM ever ships. The Twenty-specific names leak
+    // vendor specifics into what is otherwise a generic outbox.
     twentyPersonId: text("twenty_person_id"),
     twentyNoteId: text("twenty_note_id"),
+    retryAfter: timestamp("retry_after", { withTimezone: true }),
+    claimedAt: timestamp("claimed_at", { withTimezone: true }),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     processedAt: timestamp("processed_at", { withTimezone: true }),
   },

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -2234,3 +2234,37 @@ export const twentyIntegrations = pgTable(
     uniqueIndex("idx_twenty_integrations_workspace_unique").on(t.workspaceId),
   ],
 );
+
+// ---------------------------------------------------------------------------
+// crm_outbox (0102) — durable queue for SaaS CRM (Twenty) lead dispatches.
+// Slice 2 of 1.6.0 (#2729). Owned by `lib/lead-outbox/`. No credentials are
+// stored in this table, so it is intentionally NOT a member of
+// `INTEGRATION_TABLES` (F-47 rotation / F-42 audit skip it). The partial
+// index on (status, created_at) WHERE status IN ('pending','in_flight')
+// keeps the flusher poll fast as done/dead rows accumulate.
+// ---------------------------------------------------------------------------
+
+export const crmOutbox = pgTable(
+  "crm_outbox",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    eventType: text("event_type").notNull(),
+    payload: jsonb("payload").notNull(),
+    status: text("status").notNull().default("pending"),
+    attempts: integer("attempts").notNull().default(0),
+    lastError: text("last_error"),
+    twentyPersonId: text("twenty_person_id"),
+    twentyNoteId: text("twenty_note_id"),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    processedAt: timestamp("processed_at", { withTimezone: true }),
+  },
+  (t) => [
+    check(
+      "crm_outbox_status_chk",
+      sql`status IN ('pending', 'in_flight', 'done', 'dead')`,
+    ),
+    index("idx_crm_outbox_pending_created")
+      .on(t.status, t.createdAt)
+      .where(sql`status IN ('pending', 'in_flight')`),
+  ],
+);

--- a/packages/api/src/lib/effect/__tests__/outbox-flusher-lifecycle.test.ts
+++ b/packages/api/src/lib/effect/__tests__/outbox-flusher-lifecycle.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Outbox flusher lifecycle — startup-recovery + shutdown-finalizer
+ * wiring around `makeSchedulerLive`.
+ *
+ * AC #7 (restart safety) and AC #9 (graceful shutdown) from #2729 both
+ * rely on `recoverInFlight` being invoked on the Layer's scope
+ * boundaries. The unit + PG tests already cover `recoverInFlight`
+ * itself; this file proves the scheduler Layer actually calls it.
+ *
+ * We mock `lib/db/internal` (hasInternalDB + internalQuery) so the
+ * outbox flusher branch wires without standing up a real Postgres,
+ * and provide a SaasCrm Layer with `available: true` + a stub
+ * dispatcher. The mock observes every SQL invocation so we can assert
+ * the recovery sweep ran on both boot and dispose.
+ */
+
+import { afterEach, beforeEach, describe, expect, test, mock } from "bun:test";
+import { Effect, Layer, ManagedRuntime } from "effect";
+
+// `import type` is erased at runtime, so it doesn't compete with the
+// mock.module() installations below — we still get static type names
+// for `SaasCrm` / `SaasCrmShape` without forcing the services module
+// to load before our mocks are wired.
+import type { SaasCrm as SaasCrmTag, SaasCrmShape } from "../services";
+
+// ── Module mocks MUST be installed before importing layers.ts ───────
+// Per CLAUDE.md the partial-mock rule requires re-exporting all
+// existing symbols — we splat the real module and only override
+// `hasInternalDB` + `internalQuery`. We fetch the real module first via
+// a dynamic `require`-style call so the splat resolves to all named
+// exports without us having to enumerate them by hand.
+
+interface CapturedQuery {
+  sql: string;
+  params: unknown[];
+}
+const sqlLog: CapturedQuery[] = [];
+let internalDbAvailable = true;
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const realInternal = require("@atlas/api/lib/db/internal") as Record<string, unknown>;
+
+mock.module("@atlas/api/lib/db/internal", () => ({
+  ...realInternal,
+  hasInternalDB: () => internalDbAvailable,
+  internalQuery: async <T extends Record<string, unknown>>(
+    sql: string,
+    params?: unknown[],
+  ): Promise<T[]> => {
+    sqlLog.push({ sql, params: params ?? [] });
+    if (/RETURNING id/i.test(sql)) return [] as unknown as T[];
+    return [] as unknown as T[];
+  },
+}));
+
+// Silence logger noise from the booted Layer.
+mock.module("@atlas/api/lib/logger", () => ({
+  createLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  }),
+}));
+
+const { makeSchedulerLive } = await import("../layers");
+const { SaasCrm, NoopEnterpriseDefaultsLayer } = await import("../services");
+type SaasCrmShape = import("../services").SaasCrmShape;
+
+// ── Test layer: SaasCrm with available=true + stub dispatcher ───────
+
+function makeAvailableSaasCrmLayer(): Layer.Layer<SaasCrmTag> {
+  return Layer.succeed(SaasCrm, {
+    available: true,
+    upsertLead: () => Effect.void,
+    dispatcher: async () => ({ kind: "ok" as const }),
+  } satisfies SaasCrmShape);
+}
+
+beforeEach(() => {
+  sqlLog.length = 0;
+  internalDbAvailable = true;
+});
+
+afterEach(() => {
+  internalDbAvailable = true;
+});
+
+describe("outbox flusher lifecycle (#2729 AC #7 + #9)", () => {
+  test("Layer scope boundary triggers startup recovery AND shutdown recovery", async () => {
+    const config = {} as Parameters<typeof makeSchedulerLive>[0];
+    const baseLayer = makeSchedulerLive(config);
+    // Compose enterprise defaults FIRST so AuditPurgeScheduler etc. are
+    // provided, then override SaasCrm with our test-controlled shape.
+    const deps = Layer.mergeAll(
+      NoopEnterpriseDefaultsLayer,
+      makeAvailableSaasCrmLayer(),
+    );
+    const layer = baseLayer.pipe(Layer.provide(deps));
+
+    const rt = ManagedRuntime.make(layer);
+    // Building the runtime triggers Layer.scoped init — that's the
+    // startup-recovery call inside makeSchedulerLive.
+    await Effect.runPromise(rt.runtimeEffect);
+
+    // Disposing the runtime triggers the finalizer chain — that's the
+    // shutdown-recovery call.
+    await rt.dispose();
+
+    // Each recoverInFlight call runs TWO statements: dead-letter
+    // exhausted rows, then reset stale rows. So one boot + one
+    // finalizer = 4 SQL invocations that target in_flight.
+    const recoveryCalls = sqlLog.filter((q) =>
+      /WHERE status = 'in_flight'/i.test(q.sql),
+    );
+    expect(recoveryCalls.length).toBe(4);
+  });
+
+  test("Layer skips flusher wiring when hasInternalDB() returns false", async () => {
+    internalDbAvailable = false;
+    const config = {} as Parameters<typeof makeSchedulerLive>[0];
+    const baseLayer = makeSchedulerLive(config);
+    // Compose enterprise defaults FIRST so AuditPurgeScheduler etc. are
+    // provided, then override SaasCrm with our test-controlled shape.
+    const deps = Layer.mergeAll(
+      NoopEnterpriseDefaultsLayer,
+      makeAvailableSaasCrmLayer(),
+    );
+    const layer = baseLayer.pipe(Layer.provide(deps));
+
+    const rt = ManagedRuntime.make(layer);
+    await Effect.runPromise(rt.runtimeEffect);
+    await rt.dispose();
+
+    const recoveryCalls = sqlLog.filter((q) =>
+      /WHERE status = 'in_flight'/i.test(q.sql),
+    );
+    // Neither boot nor finalizer touch the DB when the flusher is unwired.
+    expect(recoveryCalls.length).toBe(0);
+  });
+
+  test("Layer skips flusher wiring when SaasCrm.available is false", async () => {
+    const noopSaasCrm: Layer.Layer<SaasCrmTag> = Layer.succeed(SaasCrm, {
+      available: false,
+      upsertLead: () => Effect.void,
+    } satisfies SaasCrmShape);
+
+    const config = {} as Parameters<typeof makeSchedulerLive>[0];
+    const baseLayer = makeSchedulerLive(config);
+    // NoopEnterpriseDefaultsLayer already provides a Noop SaasCrm — but
+    // `noopSaasCrm` is composed on top to make the test intent explicit
+    // (and to guard against a future EE default that flips `available`).
+    const deps = Layer.mergeAll(NoopEnterpriseDefaultsLayer, noopSaasCrm);
+    const layer = baseLayer.pipe(Layer.provide(deps));
+
+    const rt = ManagedRuntime.make(layer);
+    await Effect.runPromise(rt.runtimeEffect);
+    await rt.dispose();
+
+    const recoveryCalls = sqlLog.filter((q) =>
+      /WHERE status = 'in_flight'/i.test(q.sql),
+    );
+    expect(recoveryCalls.length).toBe(0);
+  });
+});

--- a/packages/api/src/lib/effect/__tests__/outbox-flusher-lifecycle.test.ts
+++ b/packages/api/src/lib/effect/__tests__/outbox-flusher-lifecycle.test.ts
@@ -65,7 +65,6 @@ mock.module("@atlas/api/lib/logger", () => ({
 
 const { makeSchedulerLive } = await import("../layers");
 const { SaasCrm, NoopEnterpriseDefaultsLayer } = await import("../services");
-type SaasCrmShape = import("../services").SaasCrmShape;
 
 // ── Test layer: SaasCrm with available=true + stub dispatcher ───────
 

--- a/packages/api/src/lib/effect/layers.ts
+++ b/packages/api/src/lib/effect/layers.ts
@@ -56,7 +56,10 @@ import {
   flushBatch as flushOutboxBatch,
   getTickIntervalMs as getOutboxTickIntervalMs,
   FLUSH_BATCH_LIMIT as OUTBOX_FLUSH_BATCH_LIMIT,
+  STARTUP_RECOVERY_STALE_MS as OUTBOX_STARTUP_STALE_MS,
+  SHUTDOWN_RECOVERY_STALE_MS as OUTBOX_SHUTDOWN_STALE_MS,
   type OutboxDB,
+  type RecoveryResult as OutboxRecoveryResult,
 } from "@atlas/api/lib/lead-outbox";
 
 const log = createLogger("effect:layers");
@@ -1404,26 +1407,36 @@ export function makeSchedulerLive(
       // Slice 2 of 1.6.0. The flusher polls `crm_outbox` for pending /
       // due rows, claims them via single-statement UPDATE … RETURNING,
       // and hands each to the dispatcher Tag-bound by `SaasCrmLive`.
-      // Skipped when SaasCrm has no dispatcher (self-hosted, missing
-      // creds, no internal DB, or boot verification failure).
+      // Skipped when SaasCrm is unavailable (self-hosted, missing
+      // creds, no internal DB, or boot verification failure) — the
+      // discriminated union narrows `dispatcher` to non-null inside
+      // the `available === true` branch.
       const saasCrm = yield* SaasCrm;
-      const outboxDispatcher = saasCrm.dispatcher;
-      if (outboxDispatcher && hasInternalDB()) {
+      if (saasCrm.available && hasInternalDB()) {
+        const outboxDispatcher = saasCrm.dispatcher;
         const outboxDb: OutboxDB = { query: internalQuery };
 
         // Startup recovery: any `in_flight` row at boot is the carcass
-        // of a crash mid-dispatch. Reset to `pending` BEFORE the tick
-        // starts so the very first claim picks them up.
+        // of a crash mid-dispatch. Reset stale rows to `pending`
+        // (preserving siblings still actively dispatched in a multi-
+        // pod deploy) and dead-letter rows that crashed past the
+        // retry budget. Runs BEFORE the tick starts.
         yield* Effect.tryPromise({
-          try: (): Promise<number> => recoverOutboxInFlight(outboxDb),
+          try: (): Promise<OutboxRecoveryResult> =>
+            recoverOutboxInFlight(outboxDb, OUTBOX_STARTUP_STALE_MS),
           catch: (err) => (err instanceof Error ? err : new Error(String(err))),
         }).pipe(
-          Effect.tap((count: number) =>
+          Effect.tap((result: OutboxRecoveryResult) =>
             Effect.sync(() => {
-              if (count > 0) {
+              if (result.reset > 0 || result.deadLettered > 0) {
                 log.warn(
-                  { recovered: count, event: "lead_outbox.startup_recovery" },
-                  "Reset stranded in_flight crm_outbox rows to pending at boot",
+                  {
+                    reset: result.reset,
+                    deadLettered: result.deadLettered,
+                    staleAgeMs: OUTBOX_STARTUP_STALE_MS,
+                    event: "lead_outbox.startup_recovery",
+                  },
+                  `Recovered crm_outbox carcasses at boot — ${result.reset} reset to pending, ${result.deadLettered} dead-lettered`,
                 );
               }
             }),
@@ -1444,6 +1457,26 @@ export function makeSchedulerLive(
             flushOutboxBatch(outboxDb, outboxDispatcher, OUTBOX_FLUSH_BATCH_LIMIT),
           catch: (err) => (err instanceof Error ? err : new Error(String(err))),
         }).pipe(
+          Effect.tap((result) =>
+            Effect.sync(() => {
+              // Only log non-empty ticks so an idle queue doesn't fill
+              // the log with `claimed: 0`. The per-row dead-letter /
+              // transient lines from `flushBatch` itself still fire
+              // separately when something interesting happens.
+              if (result.claimed > 0) {
+                log.info(
+                  {
+                    claimed: result.claimed,
+                    ok: result.ok,
+                    transient: result.transient,
+                    permanent: result.permanent,
+                    event: "lead_outbox.tick_complete",
+                  },
+                  `Outbox tick: ${result.claimed} claimed (ok=${result.ok}, transient=${result.transient}, dead=${result.permanent})`,
+                );
+              }
+            }),
+          ),
           Effect.catchAll((err) =>
             Effect.sync(() => {
               log.warn(
@@ -1464,14 +1497,20 @@ export function makeSchedulerLive(
             // here so the replacement pod picks it up on its first
             // tick rather than waiting for the next restart cycle.
             yield* Effect.tryPromise({
-              try: (): Promise<number> => recoverOutboxInFlight(outboxDb),
+              try: (): Promise<OutboxRecoveryResult> =>
+                recoverOutboxInFlight(outboxDb, OUTBOX_SHUTDOWN_STALE_MS),
               catch: (err) => (err instanceof Error ? err : new Error(String(err))),
             }).pipe(
-              Effect.tap((count: number) =>
+              Effect.tap((result: OutboxRecoveryResult) =>
                 Effect.sync(() => {
                   log.info(
-                    { recovered: count, event: "lead_outbox.shutdown_recovery" },
-                    "Outbox in_flight rows reset on shutdown",
+                    {
+                      reset: result.reset,
+                      deadLettered: result.deadLettered,
+                      staleAgeMs: OUTBOX_SHUTDOWN_STALE_MS,
+                      event: "lead_outbox.shutdown_recovery",
+                    },
+                    `Outbox shutdown sweep — ${result.reset} reset to pending, ${result.deadLettered} dead-lettered`,
                   );
                 }),
               ),
@@ -1493,7 +1532,7 @@ export function makeSchedulerLive(
       } else {
         log.debug(
           {
-            hasDispatcher: outboxDispatcher !== null,
+            saasCrmAvailable: saasCrm.available,
             hasInternalDB: hasInternalDB(),
           },
           "CRM outbox flusher not started — SaasCrm unavailable or internal DB absent",

--- a/packages/api/src/lib/effect/layers.ts
+++ b/packages/api/src/lib/effect/layers.ts
@@ -36,7 +36,7 @@
 import { Context, Duration, Effect, Fiber, Layer, Schedule } from "effect";
 import { createLogger } from "@atlas/api/lib/logger";
 import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
-import { InternalDB, makeInternalDBLive, hasInternalDB } from "@atlas/api/lib/db/internal";
+import { InternalDB, makeInternalDBLive, hasInternalDB, internalQuery } from "@atlas/api/lib/db/internal";
 import { assertSaasPlatformEmailIsResend } from "@atlas/api/lib/email/dpa-guard";
 import {
   EnterpriseGuardLive,
@@ -50,7 +50,14 @@ import {
 } from "./saas-guards";
 import { readSaasEnv } from "./saas-env";
 import { EnterpriseLayer, type EnterpriseSubsystem } from "./enterprise-layer";
-import { AuditPurgeScheduler } from "./services";
+import { AuditPurgeScheduler, SaasCrm } from "./services";
+import {
+  recoverInFlight as recoverOutboxInFlight,
+  flushBatch as flushOutboxBatch,
+  getTickIntervalMs as getOutboxTickIntervalMs,
+  FLUSH_BATCH_LIMIT as OUTBOX_FLUSH_BATCH_LIMIT,
+  type OutboxDB,
+} from "@atlas/api/lib/lead-outbox";
 
 const log = createLogger("effect:layers");
 
@@ -998,7 +1005,7 @@ export class Scheduler extends Context.Tag("Scheduler")<
  */
 export function makeSchedulerLive(
   config: ResolvedConfig,
-): Layer.Layer<Scheduler, never, AuditPurgeScheduler> {
+): Layer.Layer<Scheduler, never, AuditPurgeScheduler | SaasCrm> {
   return Layer.scoped(
     Scheduler,
     Effect.gen(function* () {
@@ -1392,6 +1399,106 @@ export function makeSchedulerLive(
         ),
       );
       yield* Effect.addFinalizer(() => Fiber.interrupt(subProcessorFiber));
+
+      // ── Periodic fiber: SaaS CRM outbox flusher (#2729) ─────────────
+      // Slice 2 of 1.6.0. The flusher polls `crm_outbox` for pending /
+      // due rows, claims them via single-statement UPDATE … RETURNING,
+      // and hands each to the dispatcher Tag-bound by `SaasCrmLive`.
+      // Skipped when SaasCrm has no dispatcher (self-hosted, missing
+      // creds, no internal DB, or boot verification failure).
+      const saasCrm = yield* SaasCrm;
+      const outboxDispatcher = saasCrm.dispatcher;
+      if (outboxDispatcher && hasInternalDB()) {
+        const outboxDb: OutboxDB = { query: internalQuery };
+
+        // Startup recovery: any `in_flight` row at boot is the carcass
+        // of a crash mid-dispatch. Reset to `pending` BEFORE the tick
+        // starts so the very first claim picks them up.
+        yield* Effect.tryPromise({
+          try: (): Promise<number> => recoverOutboxInFlight(outboxDb),
+          catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+        }).pipe(
+          Effect.tap((count: number) =>
+            Effect.sync(() => {
+              if (count > 0) {
+                log.warn(
+                  { recovered: count, event: "lead_outbox.startup_recovery" },
+                  "Reset stranded in_flight crm_outbox rows to pending at boot",
+                );
+              }
+            }),
+          ),
+          Effect.catchAll((err) =>
+            Effect.sync(() => {
+              log.error(
+                { err: errorMessage(err), event: "lead_outbox.startup_recovery_failed" },
+                "Outbox startup recovery failed — stranded in_flight rows will block until next restart",
+              );
+            }),
+          ),
+        );
+
+        const outboxTickIntervalMs = getOutboxTickIntervalMs();
+        const outboxTick = Effect.tryPromise({
+          try: () =>
+            flushOutboxBatch(outboxDb, outboxDispatcher, OUTBOX_FLUSH_BATCH_LIMIT),
+          catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+        }).pipe(
+          Effect.catchAll((err) =>
+            Effect.sync(() => {
+              log.warn(
+                { err: errorMessage(err), event: "lead_outbox.tick_failed" },
+                "Outbox flush tick failed — will retry on next interval",
+              );
+            }),
+          ),
+        );
+        const outboxFiber = yield* Effect.fork(
+          outboxTick.pipe(Effect.repeat(Schedule.spaced(Duration.millis(outboxTickIntervalMs)))),
+        );
+        yield* Effect.addFinalizer(() =>
+          Effect.gen(function* () {
+            yield* Fiber.interrupt(outboxFiber);
+            // Final recovery sweep: a SIGTERM mid-flush leaves the
+            // active row in `in_flight` until the next pod boot. Reset
+            // here so the replacement pod picks it up on its first
+            // tick rather than waiting for the next restart cycle.
+            yield* Effect.tryPromise({
+              try: (): Promise<number> => recoverOutboxInFlight(outboxDb),
+              catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+            }).pipe(
+              Effect.tap((count: number) =>
+                Effect.sync(() => {
+                  log.info(
+                    { recovered: count, event: "lead_outbox.shutdown_recovery" },
+                    "Outbox in_flight rows reset on shutdown",
+                  );
+                }),
+              ),
+              Effect.catchAll((err) =>
+                Effect.sync(() => {
+                  log.warn(
+                    { err: errorMessage(err), event: "lead_outbox.shutdown_recovery_failed" },
+                    "Outbox shutdown recovery sweep failed — next boot will mop up",
+                  );
+                }),
+              ),
+            );
+          }),
+        );
+        log.info(
+          { intervalMs: outboxTickIntervalMs, batchLimit: OUTBOX_FLUSH_BATCH_LIMIT },
+          "CRM outbox flusher started",
+        );
+      } else {
+        log.debug(
+          {
+            hasDispatcher: outboxDispatcher !== null,
+            hasInternalDB: hasInternalDB(),
+          },
+          "CRM outbox flusher not started — SaasCrm unavailable or internal DB absent",
+        );
+      }
 
       // --- Finalizer: stop main scheduler ---
       yield* Effect.addFinalizer(() =>

--- a/packages/api/src/lib/effect/services.ts
+++ b/packages/api/src/lib/effect/services.ts
@@ -2414,37 +2414,47 @@ export type SaasCrmLeadInput = {
   readonly userAgent?: string | null;
 };
 
-export interface SaasCrmShape {
-  /**
-   * Anticipatory — a future `POST /api/v1/contact` route will read this
-   * to return 404 `not_available` on self-hosted (or when the SaaS layer
-   * failed boot verification) rather than the standard 403 envelope.
-   * Until that route lands, no production caller branches on this flag.
-   */
-  readonly available: boolean;
-  /**
-   * Enqueue a lead onto the `crm_outbox` for dispatch by the flusher
-   * (slice 2 of 1.6.0, #2729). Errors are swallowed inside the layer
-   * — callers (notably `captureDemoLead`) must never block on or
-   * propagate CRM failures back to the HTTP response. Returns success
-   * even when `available === false` (no-op).
-   */
-  readonly upsertLead: (input: SaasCrmLeadInput) => Effect.Effect<void>;
-  /**
-   * Per-row dispatcher the scheduler-backed flusher calls inside
-   * `flushBatch`. `null` when the layer is unavailable (enterprise off,
-   * credentials missing, etc.) — the flusher skips wiring in that
-   * case. Defined here so `lib/effect/layers.ts:makeSchedulerLive` can
-   * `yield* SaasCrm` to fetch it without importing from `@atlas/ee`
-   * (the `core → ee` boundary is enforced by `check-ee-imports.sh`).
-   */
-  readonly dispatcher:
-    | ((
+/**
+ * Discriminated SaasCrm shape — the two correlated facts (anticipated
+ * `available` flag for the future `POST /api/v1/contact` 404 branch and
+ * the load-bearing `dispatcher` for the flusher) are encoded as a
+ * single union so they can't drift out of sync. Five places in
+ * `SaasCrmLive` used to set them by hand; the discriminator now
+ * narrows automatically.
+ *
+ * `available === false` ⇒ no dispatcher (flusher skips wiring).
+ * `available === true`  ⇒ dispatcher is non-null (flusher uses it).
+ *
+ * `upsertLead` is shared across both — even an `available: false` layer
+ * accepts the call as a no-op so callers don't need to branch.
+ */
+export type SaasCrmShape =
+  | {
+      /**
+       * Anticipatory — a future `POST /api/v1/contact` route will read
+       * this to return 404 `not_available` on self-hosted (or when the
+       * SaaS layer failed boot verification) rather than the standard
+       * 403 envelope. Until that route lands, the flusher wire-up in
+       * `lib/effect/layers.ts:makeSchedulerLive` is the only consumer.
+       */
+      readonly available: false;
+      readonly upsertLead: (input: SaasCrmLeadInput) => Effect.Effect<void>;
+    }
+  | {
+      readonly available: true;
+      readonly upsertLead: (input: SaasCrmLeadInput) => Effect.Effect<void>;
+      /**
+       * Per-row dispatcher the scheduler-backed flusher calls inside
+       * `flushBatch`. Defined here (not in `@atlas/ee`) so
+       * `lib/effect/layers.ts:makeSchedulerLive` can `yield* SaasCrm`
+       * to fetch it without importing from `@atlas/ee` (the `core →
+       * ee` boundary is enforced by `check-ee-imports.sh`).
+       */
+      readonly dispatcher: (
         row: import("@atlas/api/lib/lead-outbox").ClaimedOutboxRow,
         persist: import("@atlas/api/lib/lead-outbox").OutboxPersistHelpers,
-      ) => Promise<import("@atlas/api/lib/lead-outbox").DispatchOutcome>)
-    | null;
-}
+      ) => Promise<import("@atlas/api/lib/lead-outbox").DispatchOutcome>;
+    };
 
 export class SaasCrm extends Context.Tag("SaasCrm")<SaasCrm, SaasCrmShape>() {}
 
@@ -2452,7 +2462,6 @@ export class SaasCrm extends Context.Tag("SaasCrm")<SaasCrm, SaasCrmShape>() {}
 export const NoopSaasCrmLayer: Layer.Layer<SaasCrm> = Layer.succeed(SaasCrm, {
   available: false,
   upsertLead: () => Effect.void,
-  dispatcher: null,
 } satisfies SaasCrmShape);
 
 // ── Aggregate no-op default Layer ────────────────────────────────────

--- a/packages/api/src/lib/effect/services.ts
+++ b/packages/api/src/lib/effect/services.ts
@@ -2423,12 +2423,27 @@ export interface SaasCrmShape {
    */
   readonly available: boolean;
   /**
-   * Fire-and-forget upsert of a lead into the Atlas SaaS CRM. Errors
-   * are swallowed inside the layer — callers (notably `captureDemoLead`)
-   * must never block on or propagate CRM failures back to the HTTP
-   * response. Returns success even when `available === false` (no-op).
+   * Enqueue a lead onto the `crm_outbox` for dispatch by the flusher
+   * (slice 2 of 1.6.0, #2729). Errors are swallowed inside the layer
+   * — callers (notably `captureDemoLead`) must never block on or
+   * propagate CRM failures back to the HTTP response. Returns success
+   * even when `available === false` (no-op).
    */
   readonly upsertLead: (input: SaasCrmLeadInput) => Effect.Effect<void>;
+  /**
+   * Per-row dispatcher the scheduler-backed flusher calls inside
+   * `flushBatch`. `null` when the layer is unavailable (enterprise off,
+   * credentials missing, etc.) — the flusher skips wiring in that
+   * case. Defined here so `lib/effect/layers.ts:makeSchedulerLive` can
+   * `yield* SaasCrm` to fetch it without importing from `@atlas/ee`
+   * (the `core → ee` boundary is enforced by `check-ee-imports.sh`).
+   */
+  readonly dispatcher:
+    | ((
+        row: import("@atlas/api/lib/lead-outbox").ClaimedOutboxRow,
+        persist: import("@atlas/api/lib/lead-outbox").OutboxPersistHelpers,
+      ) => Promise<import("@atlas/api/lib/lead-outbox").DispatchOutcome>)
+    | null;
 }
 
 export class SaasCrm extends Context.Tag("SaasCrm")<SaasCrm, SaasCrmShape>() {}
@@ -2437,6 +2452,7 @@ export class SaasCrm extends Context.Tag("SaasCrm")<SaasCrm, SaasCrmShape>() {}
 export const NoopSaasCrmLayer: Layer.Layer<SaasCrm> = Layer.succeed(SaasCrm, {
   available: false,
   upsertLead: () => Effect.void,
+  dispatcher: null,
 } satisfies SaasCrmShape);
 
 // ── Aggregate no-op default Layer ────────────────────────────────────

--- a/packages/api/src/lib/lead-outbox/__tests__/backoff.test.ts
+++ b/packages/api/src/lib/lead-outbox/__tests__/backoff.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Backoff math — pure, deterministic. The values asserted here are the
+ * contract that the SQL CASE in `backoff.ts:CLAIM_DELAY_SQL` mirrors;
+ * if either changes, the other must change too.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { CLAIM_DELAY_SQL, DEAD_AFTER_ATTEMPTS, nextDelayMs } from "../backoff";
+
+describe("nextDelayMs", () => {
+  test("attempts=0 is immediate (first try)", () => {
+    expect(nextDelayMs(0)).toBe(0);
+  });
+
+  test("matches the published tiers (30s, 2m, 8m, 30m, 2h)", () => {
+    expect(nextDelayMs(1)).toBe(30_000);
+    expect(nextDelayMs(2)).toBe(120_000);
+    expect(nextDelayMs(3)).toBe(480_000);
+    expect(nextDelayMs(4)).toBe(1_800_000);
+    expect(nextDelayMs(5)).toBe(7_200_000);
+  });
+
+  test("caps at the last tier rather than throwing past DEAD_AFTER_ATTEMPTS", () => {
+    expect(nextDelayMs(DEAD_AFTER_ATTEMPTS)).toBe(7_200_000);
+    expect(nextDelayMs(99)).toBe(7_200_000);
+  });
+
+  test("normalizes negative / NaN / fractional inputs to 0", () => {
+    expect(nextDelayMs(-1)).toBe(0);
+    expect(nextDelayMs(NaN)).toBe(0);
+    expect(nextDelayMs(0.5)).toBe(0);
+  });
+
+  test("DEAD_AFTER_ATTEMPTS is 6 — covered tiers 1..5, dead at 6th failure", () => {
+    expect(DEAD_AFTER_ATTEMPTS).toBe(6);
+  });
+});
+
+describe("CLAIM_DELAY_SQL", () => {
+  test("references every tier covered by nextDelayMs", () => {
+    // The SQL CASE and the TS array must stay in lockstep — this is a
+    // regression-spotter, not a parser. If a future contributor adds a
+    // tier to nextDelayMs but forgets the SQL CASE (or vice versa), the
+    // diff will fail this test long before a stuck-pending row in prod
+    // tells anyone.
+    expect(CLAIM_DELAY_SQL).toMatch(/WHEN 0/);
+    expect(CLAIM_DELAY_SQL).toMatch(/WHEN 1.+'30 seconds'/s);
+    expect(CLAIM_DELAY_SQL).toMatch(/WHEN 2.+'2 minutes'/s);
+    expect(CLAIM_DELAY_SQL).toMatch(/WHEN 3.+'8 minutes'/s);
+    expect(CLAIM_DELAY_SQL).toMatch(/WHEN 4.+'30 minutes'/s);
+    expect(CLAIM_DELAY_SQL).toMatch(/WHEN 5.+'2 hours'/s);
+  });
+});

--- a/packages/api/src/lib/lead-outbox/__tests__/classify.test.ts
+++ b/packages/api/src/lib/lead-outbox/__tests__/classify.test.ts
@@ -16,12 +16,20 @@ describe("classifyHttpStatus", () => {
     expect(classifyHttpStatus(429)).toBe("transient");
   });
 
+  test("408 (Request Timeout) + 425 (Too Early) → transient", () => {
+    // Both are HTTP-defined as retryable. A CDN or proxy flake returning
+    // 408 once must NOT dead-letter the row; 425 is used by some
+    // upstreams during TLS replay windows.
+    expect(classifyHttpStatus(408)).toBe("transient");
+    expect(classifyHttpStatus(425)).toBe("transient");
+  });
+
   test("0 / negative / NaN → transient (transport flake)", () => {
     expect(classifyHttpStatus(0)).toBe("transient");
     expect(classifyHttpStatus(NaN)).toBe("transient");
   });
 
-  test("4xx other than 429 → permanent (deterministic misconfig)", () => {
+  test("4xx other than 408/425/429 → permanent (deterministic misconfig)", () => {
     expect(classifyHttpStatus(400)).toBe("permanent");
     expect(classifyHttpStatus(401)).toBe("permanent");
     expect(classifyHttpStatus(403)).toBe("permanent");

--- a/packages/api/src/lib/lead-outbox/__tests__/classify.test.ts
+++ b/packages/api/src/lib/lead-outbox/__tests__/classify.test.ts
@@ -1,0 +1,36 @@
+/**
+ * HTTP status → permanent/transient classification.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { classifyHttpStatus } from "../classify";
+
+describe("classifyHttpStatus", () => {
+  test("5xx → transient (upstream outage)", () => {
+    expect(classifyHttpStatus(500)).toBe("transient");
+    expect(classifyHttpStatus(502)).toBe("transient");
+    expect(classifyHttpStatus(503)).toBe("transient");
+  });
+
+  test("429 → transient (rate-limited; backoff spreads the retry)", () => {
+    expect(classifyHttpStatus(429)).toBe("transient");
+  });
+
+  test("0 / negative / NaN → transient (transport flake)", () => {
+    expect(classifyHttpStatus(0)).toBe("transient");
+    expect(classifyHttpStatus(NaN)).toBe("transient");
+  });
+
+  test("4xx other than 429 → permanent (deterministic misconfig)", () => {
+    expect(classifyHttpStatus(400)).toBe("permanent");
+    expect(classifyHttpStatus(401)).toBe("permanent");
+    expect(classifyHttpStatus(403)).toBe("permanent");
+    expect(classifyHttpStatus(404)).toBe("permanent");
+    expect(classifyHttpStatus(422)).toBe("permanent");
+  });
+
+  test("2xx/3xx fall through to permanent so a caller throwing on success surfaces as a code bug", () => {
+    expect(classifyHttpStatus(200)).toBe("permanent");
+    expect(classifyHttpStatus(302)).toBe("permanent");
+  });
+});

--- a/packages/api/src/lib/lead-outbox/__tests__/outbox-pg.test.ts
+++ b/packages/api/src/lib/lead-outbox/__tests__/outbox-pg.test.ts
@@ -252,8 +252,11 @@ describeIfPg("lead-outbox (real Postgres)", () => {
         [id],
       );
 
-      const recovered = await recoverInFlight(db);
-      expect(recovered).toBe(1);
+      // Use 0ms threshold so the just-claimed row is treated as stale
+      // for the test (in production, startup uses STARTUP_RECOVERY_STALE_MS).
+      const recovered = await recoverInFlight(db, 0);
+      expect(recovered.reset).toBe(1);
+      expect(recovered.deadLettered).toBe(0);
 
       const rows = await pool.query(
         "SELECT status FROM crm_outbox WHERE id = $1",
@@ -312,6 +315,191 @@ describeIfPg("lead-outbox (real Postgres)", () => {
       const result = await flushBatch(db, dispatcher, 10);
       expect(result.claimed).toBe(1);
       expect(calls).toBe(1);
+    },
+    PG_TIMEOUT_MS,
+  );
+
+  // ── Concurrency: FOR UPDATE SKIP LOCKED is the load-bearing claim
+  //    invariant. Two concurrent flushBatch calls must NEVER dispatch
+  //    the same row twice — the test pins that property end-to-end.
+  it(
+    "concurrent claims — exactly one dispatcher fires per row",
+    async () => {
+      await truncateOutbox();
+      const db = dbFor();
+      await enqueue(db, {
+        eventType: "demo",
+        payload: { source: "demo", email: "race@test" },
+      });
+
+      let totalDispatched = 0;
+      const dispatcher: OutboxDispatcher = async () => {
+        totalDispatched++;
+        // Hold the lock briefly so the second flush's claim is forced
+        // to skip the locked row rather than wait for it.
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        return { kind: "ok" };
+      };
+
+      const [a, b] = await Promise.all([
+        flushBatch(db, dispatcher, 10),
+        flushBatch(db, dispatcher, 10),
+      ]);
+
+      // Exactly one of the two flushes claimed the row.
+      expect(a.claimed + b.claimed).toBe(1);
+      expect(a.ok + b.ok).toBe(1);
+      expect(totalDispatched).toBe(1);
+
+      const rows = await pool.query(
+        "SELECT status FROM crm_outbox WHERE event_type = 'demo'",
+      );
+      expect(rows.rows[0].status).toBe("done");
+    },
+    PG_TIMEOUT_MS,
+  );
+
+  // ── A long-backoff row on the same table must NOT stall a fresh,
+  //    immediately-due row. The migration comment and issue body both
+  //    promise this — pin it end-to-end.
+  it(
+    "long-backoff row does NOT block a fresh row claimable in the same tick",
+    async () => {
+      await truncateOutbox();
+      const db = dbFor();
+      // Row A: high attempts, recent created_at → gated by tier delay.
+      await pool.query(
+        `INSERT INTO crm_outbox (event_type, payload, status, attempts, created_at)
+         VALUES ('demo', $1::jsonb, 'pending', 4, now())`,
+        [JSON.stringify({ source: "demo", email: "stalled@test" })],
+      );
+      // Row B: fresh, attempts=0 (no backoff) → due immediately.
+      await pool.query(
+        `INSERT INTO crm_outbox (event_type, payload, status, attempts, created_at)
+         VALUES ('demo', $1::jsonb, 'pending', 0, now())`,
+        [JSON.stringify({ source: "demo", email: "fresh@test" })],
+      );
+
+      const claimedEmails: string[] = [];
+      const dispatcher: OutboxDispatcher = async (row) => {
+        const payload = row.payload as { email: string };
+        claimedEmails.push(payload.email);
+        return { kind: "ok" };
+      };
+
+      const result = await flushBatch(db, dispatcher, 10);
+      expect(result.claimed).toBe(1);
+      expect(claimedEmails).toEqual(["fresh@test"]);
+    },
+    PG_TIMEOUT_MS,
+  );
+
+  // ── Retry-After must override the tier-based backoff.
+  it(
+    "transient outcome with retryAfterMs stamps retry_after and gates the next claim",
+    async () => {
+      await truncateOutbox();
+      const db = dbFor();
+      await enqueue(db, {
+        eventType: "demo",
+        payload: { source: "demo", email: "retry-after@test" },
+      });
+
+      // Dispatcher returns transient with a 5-minute Retry-After.
+      const dispatcher: OutboxDispatcher = async () => ({
+        kind: "transient",
+        message: "429 rate-limited",
+        retryAfterMs: 5 * 60 * 1_000,
+      });
+
+      const first = await flushBatch(db, dispatcher, 10);
+      expect(first.transient).toBe(1);
+
+      // Confirm retry_after is stamped roughly 5 minutes out.
+      const rowsAfter = await pool.query(
+        "SELECT retry_after FROM crm_outbox WHERE event_type = 'demo'",
+      );
+      expect(rowsAfter.rows[0].retry_after).not.toBeNull();
+
+      // attempts=1 tier delay is 30s. Without retry_after this row
+      // would be claimable after backdating ~30s. WITH retry_after the
+      // 5-minute upstream-requested delay must win.
+      await pool.query(
+        `UPDATE crm_outbox SET created_at = now() - INTERVAL '40 seconds'
+         WHERE event_type = 'demo'`,
+      );
+
+      let dispatchCount = 0;
+      const noopDispatcher: OutboxDispatcher = async () => {
+        dispatchCount++;
+        return { kind: "ok" };
+      };
+      const second = await flushBatch(db, noopDispatcher, 10);
+      expect(second.claimed).toBe(0);
+      expect(dispatchCount).toBe(0);
+    },
+    PG_TIMEOUT_MS,
+  );
+
+  // ── Real-PG dead-letter via transient budget exhaustion.
+  it(
+    "transient on the 6th attempt is dead-lettered in real Postgres",
+    async () => {
+      await truncateOutbox();
+      const db = dbFor();
+      // Insert at attempts=5 with a back-dated created_at so the next
+      // claim picks it up immediately.
+      await pool.query(
+        `INSERT INTO crm_outbox (event_type, payload, status, attempts, created_at)
+         VALUES ('demo', $1::jsonb, 'pending', 5, now() - INTERVAL '3 hours')`,
+        [JSON.stringify({ source: "demo", email: "budget-real@test" })],
+      );
+
+      const dispatcher: OutboxDispatcher = async () => ({
+        kind: "transient",
+        message: "still flaky",
+      });
+
+      await flushBatch(db, dispatcher, 10);
+      const rows = await pool.query(
+        "SELECT status, attempts, last_error FROM crm_outbox WHERE event_type = 'demo'",
+      );
+      expect(rows.rows[0].status).toBe("dead");
+      expect(rows.rows[0].attempts).toBe(6);
+      expect(rows.rows[0].last_error).toContain("transient failure after 6 attempts");
+    },
+    PG_TIMEOUT_MS,
+  );
+
+  // ── Backoff TS/SQL lockstep at the database level.
+  it(
+    "CLAIM_DELAY_SQL evaluates to the same delays as DELAYS_MS at every tier",
+    async () => {
+      const expected = [
+        { attempts: 0, seconds: 0 },
+        { attempts: 1, seconds: 30 },
+        { attempts: 2, seconds: 120 },
+        { attempts: 3, seconds: 480 },
+        { attempts: 4, seconds: 1800 },
+        { attempts: 5, seconds: 7200 },
+      ];
+      for (const { attempts, seconds } of expected) {
+        const result = await pool.query<{ s: string }>(
+          `SELECT EXTRACT(EPOCH FROM (
+             CASE $1::int
+               WHEN 0 THEN INTERVAL '0'
+               WHEN 1 THEN INTERVAL '30 seconds'
+               WHEN 2 THEN INTERVAL '2 minutes'
+               WHEN 3 THEN INTERVAL '8 minutes'
+               WHEN 4 THEN INTERVAL '30 minutes'
+               WHEN 5 THEN INTERVAL '2 hours'
+               ELSE INTERVAL '2 hours'
+             END
+           ))::text AS s`,
+          [attempts],
+        );
+        expect(Number.parseFloat(result.rows[0].s)).toBe(seconds);
+      }
     },
     PG_TIMEOUT_MS,
   );

--- a/packages/api/src/lib/lead-outbox/__tests__/outbox-pg.test.ts
+++ b/packages/api/src/lib/lead-outbox/__tests__/outbox-pg.test.ts
@@ -1,0 +1,318 @@
+/**
+ * Real-Postgres integration tests for the lead-outbox flusher.
+ *
+ * Skipped cleanly when `TEST_DATABASE_URL` is unset (matches the
+ * pattern in `migrate-pg.test.ts`). In CI the api-tests workflow
+ * provides a Postgres service container and exports the URL.
+ *
+ * Each test runs against a unique per-test schema so concurrent shards
+ * don't collide; the `crm_outbox` migration is applied via the runner
+ * inside the same schema. Tests do NOT call the real Twenty API —
+ * dispatchers are local lambdas that simulate the upstream behaviour.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { Pool } from "pg";
+import { runMigrations } from "@atlas/api/lib/db/migrate";
+import { MANAGED_AUTH_MIGRATIONS } from "@atlas/api/lib/db/internal";
+import {
+  enqueue,
+  flushBatch,
+  recoverInFlight,
+  type OutboxDB,
+  type OutboxDispatcher,
+} from "../outbox";
+
+const TEST_DB_URL = process.env.TEST_DATABASE_URL;
+const describeIfPg = TEST_DB_URL ? describe : describe.skip;
+
+const PG_TIMEOUT_MS = 30_000;
+
+describeIfPg("lead-outbox (real Postgres)", () => {
+  let pool: Pool;
+  const schemaName = `outbox_${Date.now()}_${Math.floor(Math.random() * 1e6)}`;
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: TEST_DB_URL });
+    pool.on("connect", (client) => {
+      void client.query(`SET search_path TO "${schemaName}"`).catch((err) => {
+        const message = err instanceof Error ? err.message : String(err);
+        console.error(`outbox-pg: SET search_path failed: ${message}`);
+      });
+    });
+    await pool.query(`CREATE SCHEMA IF NOT EXISTS "${schemaName}"`);
+    await runMigrations(pool, { skip: MANAGED_AUTH_MIGRATIONS });
+  }, PG_TIMEOUT_MS);
+
+  afterAll(async () => {
+    if (!pool) return;
+    await pool.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`);
+    await pool.end();
+  });
+
+  /** Adapter so the outbox functions can drive the real pg.Pool. */
+  function dbFor(): OutboxDB {
+    return {
+      query: async <T extends Record<string, unknown>>(
+        sql: string,
+        params?: unknown[],
+      ) => {
+        const result = await pool.query<T>(sql, params);
+        return result.rows;
+      },
+    };
+  }
+
+  async function truncateOutbox(): Promise<void> {
+    await pool.query("TRUNCATE crm_outbox");
+  }
+
+  it(
+    "enqueue → flushBatch → done (happy path)",
+    async () => {
+      await truncateOutbox();
+      const db = dbFor();
+      const id = await enqueue(db, {
+        eventType: "demo",
+        payload: { source: "demo", email: "ok@happy.test" },
+      });
+
+      const dispatcher: OutboxDispatcher = async (_row, persist) => {
+        await persist.setTwentyPersonId("person-real-1");
+        return { kind: "ok" };
+      };
+
+      const result = await flushBatch(db, dispatcher, 10);
+      expect(result.claimed).toBe(1);
+      expect(result.ok).toBe(1);
+
+      const rows = await pool.query(
+        "SELECT status, twenty_person_id, processed_at FROM crm_outbox WHERE id = $1",
+        [id],
+      );
+      expect(rows.rows[0].status).toBe("done");
+      expect(rows.rows[0].twenty_person_id).toBe("person-real-1");
+      expect(rows.rows[0].processed_at).not.toBeNull();
+    },
+    PG_TIMEOUT_MS,
+  );
+
+  it(
+    "401 → permanent → dead",
+    async () => {
+      await truncateOutbox();
+      const db = dbFor();
+      const id = await enqueue(db, {
+        eventType: "demo",
+        payload: { source: "demo", email: "401@dead.test" },
+      });
+
+      const dispatcher: OutboxDispatcher = async () => ({
+        kind: "permanent",
+        message: "upsertPerson failed (status=401)",
+      });
+
+      await flushBatch(db, dispatcher, 10);
+
+      const rows = await pool.query(
+        "SELECT status, last_error FROM crm_outbox WHERE id = $1",
+        [id],
+      );
+      expect(rows.rows[0].status).toBe("dead");
+      expect(rows.rows[0].last_error).toContain("401");
+    },
+    PG_TIMEOUT_MS,
+  );
+
+  it(
+    "5xx → transient → pending again (retried)",
+    async () => {
+      await truncateOutbox();
+      const db = dbFor();
+      const id = await enqueue(db, {
+        eventType: "demo",
+        payload: { source: "demo", email: "503@retry.test" },
+      });
+
+      const dispatcher: OutboxDispatcher = async () => ({
+        kind: "transient",
+        message: "upstream 503",
+      });
+
+      const result = await flushBatch(db, dispatcher, 10);
+      expect(result.transient).toBe(1);
+
+      const rows = await pool.query(
+        "SELECT status, attempts, last_error FROM crm_outbox WHERE id = $1",
+        [id],
+      );
+      expect(rows.rows[0].status).toBe("pending");
+      expect(rows.rows[0].attempts).toBe(1);
+      expect(rows.rows[0].last_error).toContain("503");
+    },
+    PG_TIMEOUT_MS,
+  );
+
+  it(
+    "idempotent replay — partial success + retry does NOT call upsertPerson twice",
+    async () => {
+      await truncateOutbox();
+      const db = dbFor();
+      // Insert with a back-dated created_at so the row clears every
+      // backoff tier on every flush. Without this, the second flush
+      // would be blocked by the 30s gap that attempts=1 requires.
+      await pool.query(
+        `INSERT INTO crm_outbox (event_type, payload, status, created_at)
+         VALUES ('demo', $1::jsonb, 'pending', now() - INTERVAL '3 hours')`,
+        [JSON.stringify({ source: "demo", email: "idempotent@replay.test" })],
+      );
+
+      let upsertCalls = 0;
+      const dispatcher: OutboxDispatcher = async (row, persist) => {
+        if (!row.twentyPersonId) {
+          upsertCalls++;
+          await persist.setTwentyPersonId("person-idempotent");
+        }
+        if (row.attempts === 1) {
+          // Simulate a crash AFTER the person ID is persisted: return
+          // transient so the row goes back to pending for the next tick.
+          return { kind: "transient", message: "crashed after person persist" };
+        }
+        return { kind: "ok" };
+      };
+
+      // First flush: upsertPerson called, ID persisted, then transient → pending.
+      await flushBatch(db, dispatcher, 10);
+      const afterFirst = await pool.query(
+        "SELECT status, attempts, twenty_person_id FROM crm_outbox WHERE event_type = 'demo'",
+      );
+      expect(afterFirst.rows[0].status).toBe("pending");
+      expect(afterFirst.rows[0].twenty_person_id).toBe("person-idempotent");
+
+      // Second flush: dispatcher sees the persisted ID and skips
+      // upsertPerson. upsertCalls must remain 1.
+      await flushBatch(db, dispatcher, 10);
+      expect(upsertCalls).toBe(1);
+
+      const afterSecond = await pool.query(
+        "SELECT status, twenty_person_id FROM crm_outbox WHERE event_type = 'demo'",
+      );
+      expect(afterSecond.rows[0].status).toBe("done");
+      expect(afterSecond.rows[0].twenty_person_id).toBe("person-idempotent");
+    },
+    PG_TIMEOUT_MS,
+  );
+
+  it(
+    "row with both IDs set goes straight to done without any Twenty calls",
+    async () => {
+      await truncateOutbox();
+      const db = dbFor();
+      // Insert a row that's been partially-completed across both
+      // sub-steps. Back-date created_at so the attempts=2 backoff
+      // (~2 minutes) doesn't gate the immediate claim.
+      await pool.query(
+        `INSERT INTO crm_outbox (event_type, payload, status, attempts, twenty_person_id, twenty_note_id, created_at)
+         VALUES ('sales-form', $1::jsonb, 'pending', 2, 'person-X', 'note-Y', now() - INTERVAL '3 hours')`,
+        [JSON.stringify({ source: "sales-form", email: "both@set.test" })],
+      );
+
+      let dispatchCalls = 0;
+      const dispatcher: OutboxDispatcher = async (row, _persist) => {
+        dispatchCalls++;
+        // Sanity: dispatcher must observe both IDs already populated.
+        expect(row.twentyPersonId).toBe("person-X");
+        expect(row.twentyNoteId).toBe("note-Y");
+        return { kind: "ok" };
+      };
+
+      await flushBatch(db, dispatcher, 10);
+      expect(dispatchCalls).toBe(1);
+
+      const after = await pool.query(
+        "SELECT status FROM crm_outbox WHERE event_type = 'sales-form'",
+      );
+      expect(after.rows[0].status).toBe("done");
+    },
+    PG_TIMEOUT_MS,
+  );
+
+  it(
+    "startup recovery — in_flight row at boot is reset to pending",
+    async () => {
+      await truncateOutbox();
+      const db = dbFor();
+      const id = await enqueue(db, {
+        eventType: "demo",
+        payload: { source: "demo", email: "stranded@recover.test" },
+      });
+      // Simulate a crash mid-dispatch by forcing the row into in_flight.
+      await pool.query(
+        "UPDATE crm_outbox SET status = 'in_flight' WHERE id = $1",
+        [id],
+      );
+
+      const recovered = await recoverInFlight(db);
+      expect(recovered).toBe(1);
+
+      const rows = await pool.query(
+        "SELECT status FROM crm_outbox WHERE id = $1",
+        [id],
+      );
+      expect(rows.rows[0].status).toBe("pending");
+    },
+    PG_TIMEOUT_MS,
+  );
+
+  it(
+    "backoff — recently-failed row is NOT claimed before its tier delay elapses",
+    async () => {
+      await truncateOutbox();
+      const db = dbFor();
+      // Insert a row whose attempts=2 and was created just now. The
+      // tier delay for attempts=2 is 2 minutes — the claim WHERE
+      // should filter it out.
+      await pool.query(
+        `INSERT INTO crm_outbox (event_type, payload, status, attempts, created_at)
+         VALUES ('demo', $1::jsonb, 'pending', 2, now())`,
+        [JSON.stringify({ source: "demo", email: "backoff@test" })],
+      );
+
+      let calls = 0;
+      const dispatcher: OutboxDispatcher = async () => {
+        calls++;
+        return { kind: "ok" };
+      };
+
+      const result = await flushBatch(db, dispatcher, 10);
+      expect(result.claimed).toBe(0);
+      expect(calls).toBe(0);
+    },
+    PG_TIMEOUT_MS,
+  );
+
+  it(
+    "backoff — older row (created before the tier delay) IS claimed",
+    async () => {
+      await truncateOutbox();
+      const db = dbFor();
+      // attempts=1 needs a 30s gap from created_at; back-date by 1 minute.
+      await pool.query(
+        `INSERT INTO crm_outbox (event_type, payload, status, attempts, created_at)
+         VALUES ('demo', $1::jsonb, 'pending', 1, now() - INTERVAL '1 minute')`,
+        [JSON.stringify({ source: "demo", email: "due@test" })],
+      );
+
+      let calls = 0;
+      const dispatcher: OutboxDispatcher = async () => {
+        calls++;
+        return { kind: "ok" };
+      };
+
+      const result = await flushBatch(db, dispatcher, 10);
+      expect(result.claimed).toBe(1);
+      expect(calls).toBe(1);
+    },
+    PG_TIMEOUT_MS,
+  );
+});

--- a/packages/api/src/lib/lead-outbox/__tests__/outbox.test.ts
+++ b/packages/api/src/lib/lead-outbox/__tests__/outbox.test.ts
@@ -11,17 +11,41 @@
  * code under test is what we're verifying, not the SQL.
  */
 
-import { beforeEach, describe, expect, test } from "bun:test";
-import {
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ── Logger mock MUST be installed before importing outbox.ts so the
+//    module-level `createLogger` call in outbox.ts captures our stub.
+//    Per CLAUDE.md the lead-outbox/__tests__/ directory is allowed to
+//    use `mock.module()` for this kind of module-scoped substitution.
+const loggerCalls: {
+  warn: Array<{ data: Record<string, unknown>; message: string }>;
+  error: Array<{ data: Record<string, unknown>; message: string }>;
+} = { warn: [], error: [] };
+
+mock.module("@atlas/api/lib/logger", () => ({
+  createLogger: () => ({
+    info: () => {},
+    debug: () => {},
+    warn: (data: Record<string, unknown>, message: string) => {
+      loggerCalls.warn.push({ data, message });
+    },
+    error: (data: Record<string, unknown>, message: string) => {
+      loggerCalls.error.push({ data, message });
+    },
+  }),
+}));
+
+const {
+  computeRetryAfterTimestamp,
   enqueue,
   flushBatch,
   recoverInFlight,
-  type ClaimedOutboxRow,
-  type DispatchOutcome,
-  type OutboxDB,
-  type OutboxDispatcher,
-  type OutboxPersistHelpers,
-} from "../outbox";
+} = await import("../outbox");
+type ClaimedOutboxRow = import("../outbox").ClaimedOutboxRow;
+type DispatchOutcome = import("../outbox").DispatchOutcome;
+type OutboxDB = import("../outbox").OutboxDB;
+type OutboxDispatcher = import("../outbox").OutboxDispatcher;
+type OutboxPersistHelpers = import("../outbox").OutboxPersistHelpers;
 
 type Row = {
   id: string;
@@ -32,6 +56,8 @@ type Row = {
   last_error: string | null;
   twenty_person_id: string | null;
   twenty_note_id: string | null;
+  retry_after: number | null;
+  claimed_at: number | null;
   created_at: number;
   processed_at: number | null;
 };
@@ -58,6 +84,8 @@ class FakeOutboxDB implements OutboxDB {
         last_error: null,
         twenty_person_id: null,
         twenty_note_id: null,
+        retry_after: null,
+        claimed_at: null,
         created_at: Date.now(),
         processed_at: null,
       });
@@ -72,6 +100,7 @@ class FakeOutboxDB implements OutboxDB {
       for (const row of candidates) {
         row.status = "in_flight";
         row.attempts += 1;
+        row.claimed_at = Date.now();
       }
       return candidates.map((r) => ({
         id: r.id,
@@ -92,36 +121,77 @@ class FakeOutboxDB implements OutboxDB {
       if (row) row.twenty_note_id = String(p[0]);
       return [] as T[];
     }
-    if (/SET status = 'done'/i.test(sql)) {
+    if (/^\s*UPDATE crm_outbox\s+SET status = 'done'/is.test(sql)) {
       const row = this.rows.find((r) => r.id === p[0]);
       if (row) {
         row.status = "done";
         row.processed_at = Date.now();
         row.last_error = null;
+        row.retry_after = null;
+        row.claimed_at = null;
       }
       return [] as T[];
     }
-    if (/SET status = 'pending', last_error = \$1/i.test(sql)) {
+    if (/SET status = 'pending',\s+last_error = \$1/is.test(sql)) {
       const row = this.rows.find((r) => r.id === p[1]);
       if (row) {
         row.status = "pending";
         row.last_error = String(p[0]);
+        // $3 is the retry_after timestamp (Date | null).
+        const retryAfter = p[2];
+        row.retry_after = retryAfter instanceof Date ? retryAfter.getTime() : null;
+        row.claimed_at = null;
       }
       return [] as T[];
     }
-    if (/SET status = 'dead'/i.test(sql)) {
+    // MARK_DEAD_SQL — distinct from the recovery dead-letter UPDATE
+    // (which carries the WHERE status='in_flight' AND attempts >= ...
+    // signature handled earlier).
+    if (/^\s*UPDATE crm_outbox\s+SET status = 'dead'/is.test(sql) && p.length >= 2) {
       const row = this.rows.find((r) => r.id === p[1]);
       if (row) {
         row.status = "dead";
         row.processed_at = Date.now();
         row.last_error = String(p[0]);
+        row.retry_after = null;
+        row.claimed_at = null;
       }
       return [] as T[];
     }
-    if (/UPDATE crm_outbox SET status = 'pending'\s+WHERE status = 'in_flight'/i.test(sql)) {
-      const affected = this.rows.filter((r) => r.status === "in_flight");
-      for (const row of affected) row.status = "pending";
-      return affected.map((r) => ({ id: r.id })) as unknown as T[];
+    // Recovery: dead-letter exhausted in_flight rows.
+    if (
+      /UPDATE crm_outbox[\s\S]+SET status = 'dead'[\s\S]+WHERE status = 'in_flight'[\s\S]+AND attempts >=/is.test(
+        sql,
+      )
+    ) {
+      const exhausted = this.rows.filter(
+        (r) => r.status === "in_flight" && r.attempts >= 6,
+      );
+      for (const row of exhausted) {
+        row.status = "dead";
+        row.processed_at = Date.now();
+        row.last_error = `crashed mid-dispatch at attempts=${row.attempts} (recovery)`;
+      }
+      return exhausted.map((r) => ({ id: r.id })) as unknown as T[];
+    }
+    // Recovery: reset stale in_flight rows below the attempts cap.
+    if (
+      /UPDATE crm_outbox\s+SET status = 'pending'\s+WHERE status = 'in_flight'[\s\S]+AND attempts </is.test(
+        sql,
+      )
+    ) {
+      // $1 is the stale-age threshold in ms; treat NULL claimed_at as
+      // stale, otherwise compare against now() - threshold.
+      const staleAgeMs = Number(p[0] ?? 0);
+      const cutoff = Date.now() - staleAgeMs;
+      const stale = this.rows.filter(
+        (r) =>
+          r.status === "in_flight" &&
+          r.attempts < 6 &&
+          (r.claimed_at === null || r.claimed_at < cutoff),
+      );
+      for (const row of stale) row.status = "pending";
+      return stale.map((r) => ({ id: r.id })) as unknown as T[];
     }
     throw new Error(`Unrecognized SQL in FakeOutboxDB: ${sql.slice(0, 80)}…`);
   }
@@ -133,6 +203,8 @@ let db: FakeOutboxDB;
 
 beforeEach(() => {
   db = new FakeOutboxDB();
+  loggerCalls.warn.length = 0;
+  loggerCalls.error.length = 0;
 });
 
 describe("enqueue", () => {
@@ -340,19 +412,40 @@ describe("concurrent flush behaviour", () => {
 // ── Startup recovery ─────────────────────────────────────────────────
 
 describe("recoverInFlight", () => {
-  test("resets every in_flight row to pending and returns the count", async () => {
+  test("resets stale in_flight rows to pending and returns the per-bucket counts", async () => {
     await enqueue(db, { eventType: "demo", payload: { source: "demo", email: "a@y.test" } });
     await enqueue(db, { eventType: "demo", payload: { source: "demo", email: "b@y.test" } });
     db.rows[0].status = "in_flight";
+    db.rows[0].claimed_at = null; // null claimed_at counts as stale
     db.rows[1].status = "in_flight";
+    db.rows[1].claimed_at = Date.now() - 60_000; // claimed 60s ago — stale at 30s threshold
 
-    const n = await recoverInFlight(db);
-    expect(n).toBe(2);
-    // Cast to widen the literal type — the prior `= "in_flight"`
-    // assignments narrow TS's view of `status`, and the mutation
-    // inside `recoverInFlight` is invisible to it.
+    const result = await recoverInFlight(db, 30_000);
+    expect(result).toEqual({ reset: 2, deadLettered: 0 });
     expect(db.rows[0].status as string).toBe("pending");
     expect(db.rows[1].status as string).toBe("pending");
+  });
+
+  test("recently-claimed in_flight row is NOT reset (multi-pod safety)", async () => {
+    await enqueue(db, { eventType: "demo", payload: { source: "demo", email: "fresh@y.test" } });
+    db.rows[0].status = "in_flight";
+    db.rows[0].claimed_at = Date.now() - 1_000; // claimed 1s ago — within threshold
+
+    const result = await recoverInFlight(db, 30_000);
+    expect(result).toEqual({ reset: 0, deadLettered: 0 });
+    expect(db.rows[0].status as string).toBe("in_flight");
+  });
+
+  test("exhausted in_flight rows are dead-lettered (not reset to pending)", async () => {
+    await enqueue(db, { eventType: "demo", payload: { source: "demo", email: "exhausted@y.test" } });
+    db.rows[0].status = "in_flight";
+    db.rows[0].attempts = 6;
+    db.rows[0].claimed_at = Date.now() - 60_000;
+
+    const result = await recoverInFlight(db, 30_000);
+    expect(result).toEqual({ reset: 0, deadLettered: 1 });
+    expect(db.rows[0].status as string).toBe("dead");
+    expect(db.rows[0].last_error).toContain("crashed mid-dispatch");
   });
 
   test("done / dead / pending rows are untouched", async () => {
@@ -362,8 +455,8 @@ describe("recoverInFlight", () => {
     db.rows[1].status = "done";
     db.rows[2].status = "dead";
 
-    const n = await recoverInFlight(db);
-    expect(n).toBe(0);
+    const result = await recoverInFlight(db, 30_000);
+    expect(result).toEqual({ reset: 0, deadLettered: 0 });
     expect(db.rows[0].status).toBe("pending");
     expect(db.rows[1].status).toBe("done");
     expect(db.rows[2].status).toBe("dead");
@@ -397,3 +490,174 @@ describe("persist helper binding", () => {
     expect(db.rows[1].twenty_note_id).toBe("note-2");
   });
 });
+
+// ── Retry-After plumbing ─────────────────────────────────────────────
+
+describe("Retry-After plumbing", () => {
+  test("transient outcome with retryAfterMs stamps absolute retry_after on the row", async () => {
+    await enqueue(db, { eventType: "demo", payload: { source: "demo", email: "rate@y.test" } });
+    const before = Date.now();
+    const dispatcher: OutboxDispatcher = async () => ({
+      kind: "transient",
+      message: "429 from upstream",
+      retryAfterMs: 60_000,
+    });
+
+    await flushBatch(db, dispatcher, 10);
+    expect(db.rows[0].status).toBe("pending");
+    expect(db.rows[0].retry_after).not.toBeNull();
+    // Should be ~now + 60s. Allow a wide tolerance for slow CI.
+    const stamped = db.rows[0].retry_after as number;
+    expect(stamped - before).toBeGreaterThanOrEqual(60_000 - 500);
+    expect(stamped - before).toBeLessThanOrEqual(60_000 + 5_000);
+  });
+
+  test("transient outcome without retryAfterMs clears any prior retry_after", async () => {
+    await enqueue(db, { eventType: "demo", payload: { source: "demo", email: "clr@y.test" } });
+    db.rows[0].retry_after = Date.now() + 30_000;
+
+    const dispatcher: OutboxDispatcher = async () => ({
+      kind: "transient",
+      message: "no header this time",
+    });
+
+    await flushBatch(db, dispatcher, 10);
+    expect(db.rows[0].retry_after).toBeNull();
+  });
+
+  test("computeRetryAfterTimestamp clamps garbage to null", () => {
+    expect(computeRetryAfterTimestamp(undefined)).toBeNull();
+    expect(computeRetryAfterTimestamp(-5)).toBeNull();
+    expect(computeRetryAfterTimestamp(NaN)).toBeNull();
+  });
+
+  test("computeRetryAfterTimestamp returns absolute time for valid delay", () => {
+    const before = Date.now();
+    const stamped = computeRetryAfterTimestamp(120_000);
+    expect(stamped).not.toBeNull();
+    if (stamped) {
+      expect(stamped.getTime() - before).toBeGreaterThanOrEqual(120_000 - 100);
+      expect(stamped.getTime() - before).toBeLessThanOrEqual(120_000 + 1_000);
+    }
+  });
+});
+
+// ── AC #3 — structured log on dead-letter ────────────────────────────
+
+describe("dead-letter logging (AC #3)", () => {
+  test("permanent dead-letter emits a structured log with rowId + last_error", async () => {
+    await enqueue(db, { eventType: "demo", payload: { source: "demo", email: "dead-log@y.test" } });
+    const dispatcher: OutboxDispatcher = async () => ({
+      kind: "permanent",
+      message: "401 unauthorised",
+    });
+    await flushBatch(db, dispatcher, 10);
+
+    const deadCall = loggerCalls.error.find(
+      (c) => c.data.event === "lead_outbox.dead_letter_permanent",
+    );
+    expect(deadCall).toBeDefined();
+    expect(deadCall?.data.rowId).toBe("row-1");
+    expect(deadCall?.data.err).toContain("401");
+    expect(deadCall?.data.attempts).toBe(1);
+  });
+
+  test("retry-budget exhaustion emits a structured log labelled dead_letter_exhausted", async () => {
+    await enqueue(db, { eventType: "demo", payload: { source: "demo", email: "budget@y.test" } });
+    db.rows[0].attempts = 5;
+    const dispatcher: OutboxDispatcher = async () => ({
+      kind: "transient",
+      message: "503",
+    });
+    await flushBatch(db, dispatcher, 10);
+
+    const deadCall = loggerCalls.error.find(
+      (c) => c.data.event === "lead_outbox.dead_letter_exhausted",
+    );
+    expect(deadCall).toBeDefined();
+    expect(deadCall?.data.rowId).toBe("row-1");
+    expect(deadCall?.data.attempts).toBe(6);
+  });
+
+  test("transient (within budget) emits warn with retryAfterMs surfaced", async () => {
+    await enqueue(db, { eventType: "demo", payload: { source: "demo", email: "tr@y.test" } });
+    const dispatcher: OutboxDispatcher = async () => ({
+      kind: "transient",
+      message: "503",
+      retryAfterMs: 45_000,
+    });
+    await flushBatch(db, dispatcher, 10);
+
+    const warnCall = loggerCalls.warn.find(
+      (c) => c.data.event === "lead_outbox.transient_failure",
+    );
+    expect(warnCall).toBeDefined();
+    expect(warnCall?.data.rowId).toBe("row-1");
+    expect(warnCall?.data.retryAfterMs).toBe(45_000);
+  });
+});
+
+// ── AC #7 — end-to-end restart safety ────────────────────────────────
+
+describe("end-to-end restart (AC #7)", () => {
+  test("in_flight row recovered + claimed + dispatched in one logical lifecycle", async () => {
+    // Simulate the crash scenario: a previous pod claimed the row and
+    // crashed before reaching MARK_DONE. recoverInFlight on the new
+    // pod's boot must flip it to pending; the very next flushBatch
+    // must then claim and complete it.
+    await enqueue(db, { eventType: "demo", payload: { source: "demo", email: "e2e@y.test" } });
+    db.rows[0].status = "in_flight";
+    db.rows[0].attempts = 1;
+    db.rows[0].twenty_person_id = "person-from-previous-life";
+    db.rows[0].claimed_at = null; // simulate stale carcass
+
+    // Boot recovery — equivalent to the startup-recovery branch in
+    // layers.ts:makeSchedulerLive. Use a 0s threshold so a fresh
+    // `claimed_at = null` row qualifies as stale immediately.
+    const recovered = await recoverInFlight(db, 0);
+    expect(recovered).toEqual({ reset: 1, deadLettered: 0 });
+    expect(db.rows[0].status as string).toBe("pending");
+
+    // First post-recovery tick: the dispatcher sees the persisted
+    // person_id and short-circuits to done WITHOUT calling Twenty.
+    let dispatcherFetches = 0;
+    const dispatcher: OutboxDispatcher = async (row) => {
+      if (!row.twentyPersonId) {
+        dispatcherFetches++;
+      }
+      return { kind: "ok" };
+    };
+    await flushBatch(db, dispatcher, 10);
+    expect(dispatcherFetches).toBe(0);
+    expect(db.rows[0].status as string).toBe("done");
+  });
+});
+
+// ── L1 — final-status UPDATE resilience (single retry) ───────────────
+
+describe("terminal-status UPDATE retry", () => {
+  test("MARK_DONE_SQL retries once after a transient pg failure, then succeeds", async () => {
+    // Wrap the FakeOutboxDB to fail the first MARK_DONE call and let
+    // the second through.
+    await enqueue(db, { eventType: "demo", payload: { source: "demo", email: "ok@y.test" } });
+    let firstMarkDoneSeen = false;
+    const wrappedDb: OutboxDB = {
+      query: async <T extends Record<string, unknown>>(
+        sql: string,
+        params?: unknown[],
+      ): Promise<T[]> => {
+        if (!firstMarkDoneSeen && /SET status = 'done'/i.test(sql)) {
+          firstMarkDoneSeen = true;
+          throw new Error("pg blip");
+        }
+        return db.query<T>(sql, params);
+      },
+    };
+
+    const dispatcher: OutboxDispatcher = async () => ({ kind: "ok" });
+    const result = await flushBatch(wrappedDb, dispatcher, 10);
+    expect(result.ok).toBe(1);
+    expect(db.rows[0].status).toBe("done");
+  });
+});
+

--- a/packages/api/src/lib/lead-outbox/__tests__/outbox.test.ts
+++ b/packages/api/src/lib/lead-outbox/__tests__/outbox.test.ts
@@ -1,0 +1,399 @@
+/**
+ * Lead-outbox unit tests against an in-memory fake of the `OutboxDB`
+ * surface. We avoid spinning up a real Postgres here — the SQL strings
+ * are exercised end-to-end by `outbox-pg.test.ts` (gated on
+ * `TEST_DATABASE_URL`). This file's job is to nail down the
+ * idempotency contract and sub-step replay semantics, which are pure
+ * TypeScript behaviour and don't need a real DB to fail loudly.
+ *
+ * The fake recognises each SQL string from the module and dispatches to
+ * an in-memory row table. It is deliberately literal — the dispatcher
+ * code under test is what we're verifying, not the SQL.
+ */
+
+import { beforeEach, describe, expect, test } from "bun:test";
+import {
+  enqueue,
+  flushBatch,
+  recoverInFlight,
+  type ClaimedOutboxRow,
+  type DispatchOutcome,
+  type OutboxDB,
+  type OutboxDispatcher,
+  type OutboxPersistHelpers,
+} from "../outbox";
+
+type Row = {
+  id: string;
+  event_type: string;
+  payload: unknown;
+  status: "pending" | "in_flight" | "done" | "dead";
+  attempts: number;
+  last_error: string | null;
+  twenty_person_id: string | null;
+  twenty_note_id: string | null;
+  created_at: number;
+  processed_at: number | null;
+};
+
+class FakeOutboxDB implements OutboxDB {
+  rows: Row[] = [];
+  private nextId = 1;
+  /** When true, every claim returns 0 rows (simulates contention). */
+  claimBlocked = false;
+
+  async query<T extends Record<string, unknown>>(
+    sql: string,
+    params?: unknown[],
+  ): Promise<T[]> {
+    const p = params ?? [];
+    if (/^\s*INSERT INTO crm_outbox/i.test(sql)) {
+      const id = `row-${this.nextId++}`;
+      this.rows.push({
+        id,
+        event_type: String(p[0]),
+        payload: JSON.parse(String(p[1])),
+        status: "pending",
+        attempts: 0,
+        last_error: null,
+        twenty_person_id: null,
+        twenty_note_id: null,
+        created_at: Date.now(),
+        processed_at: null,
+      });
+      return [{ id }] as unknown as T[];
+    }
+    if (/^\s*UPDATE crm_outbox\s+SET status = 'in_flight'/i.test(sql)) {
+      if (this.claimBlocked) return [] as T[];
+      const limit = Number(p[0] ?? 50);
+      const candidates = this.rows
+        .filter((r) => r.status === "pending" && r.attempts < 6)
+        .slice(0, limit);
+      for (const row of candidates) {
+        row.status = "in_flight";
+        row.attempts += 1;
+      }
+      return candidates.map((r) => ({
+        id: r.id,
+        event_type: r.event_type,
+        payload: r.payload,
+        attempts: r.attempts,
+        twenty_person_id: r.twenty_person_id,
+        twenty_note_id: r.twenty_note_id,
+      })) as unknown as T[];
+    }
+    if (/SET twenty_person_id = \$1/i.test(sql)) {
+      const row = this.rows.find((r) => r.id === p[1]);
+      if (row) row.twenty_person_id = String(p[0]);
+      return [] as T[];
+    }
+    if (/SET twenty_note_id = \$1/i.test(sql)) {
+      const row = this.rows.find((r) => r.id === p[1]);
+      if (row) row.twenty_note_id = String(p[0]);
+      return [] as T[];
+    }
+    if (/SET status = 'done'/i.test(sql)) {
+      const row = this.rows.find((r) => r.id === p[0]);
+      if (row) {
+        row.status = "done";
+        row.processed_at = Date.now();
+        row.last_error = null;
+      }
+      return [] as T[];
+    }
+    if (/SET status = 'pending', last_error = \$1/i.test(sql)) {
+      const row = this.rows.find((r) => r.id === p[1]);
+      if (row) {
+        row.status = "pending";
+        row.last_error = String(p[0]);
+      }
+      return [] as T[];
+    }
+    if (/SET status = 'dead'/i.test(sql)) {
+      const row = this.rows.find((r) => r.id === p[1]);
+      if (row) {
+        row.status = "dead";
+        row.processed_at = Date.now();
+        row.last_error = String(p[0]);
+      }
+      return [] as T[];
+    }
+    if (/UPDATE crm_outbox SET status = 'pending'\s+WHERE status = 'in_flight'/i.test(sql)) {
+      const affected = this.rows.filter((r) => r.status === "in_flight");
+      for (const row of affected) row.status = "pending";
+      return affected.map((r) => ({ id: r.id })) as unknown as T[];
+    }
+    throw new Error(`Unrecognized SQL in FakeOutboxDB: ${sql.slice(0, 80)}…`);
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────
+
+let db: FakeOutboxDB;
+
+beforeEach(() => {
+  db = new FakeOutboxDB();
+});
+
+describe("enqueue", () => {
+  test("inserts a pending row and returns its id", async () => {
+    const id = await enqueue(db, {
+      eventType: "demo",
+      payload: { source: "demo", email: "a@b.test" },
+    });
+    expect(id).toBe("row-1");
+    expect(db.rows[0]).toMatchObject({
+      id: "row-1",
+      event_type: "demo",
+      status: "pending",
+      attempts: 0,
+      twenty_person_id: null,
+      twenty_note_id: null,
+    });
+  });
+});
+
+describe("flushBatch — claim & dispatch", () => {
+  test("dispatches OK → row marked done with twenty_person_id persisted inside dispatcher", async () => {
+    await enqueue(db, { eventType: "demo", payload: { source: "demo", email: "x@y.test" } });
+
+    const dispatcher: OutboxDispatcher = async (row, persist) => {
+      expect(row.twentyPersonId).toBeNull();
+      await persist.setTwentyPersonId("person-1");
+      return { kind: "ok" };
+    };
+
+    const result = await flushBatch(db, dispatcher, 10);
+    expect(result).toMatchObject({ claimed: 1, ok: 1, transient: 0, permanent: 0 });
+    expect(db.rows[0].status).toBe("done");
+    expect(db.rows[0].twenty_person_id).toBe("person-1");
+  });
+
+  test("transient failure → row reverts to pending with last_error stamped", async () => {
+    await enqueue(db, { eventType: "demo", payload: { source: "demo", email: "fail@y.test" } });
+    const dispatcher: OutboxDispatcher = async () => ({
+      kind: "transient",
+      message: "upstream 503",
+    });
+    const result = await flushBatch(db, dispatcher, 10);
+    expect(result).toMatchObject({ claimed: 1, ok: 0, transient: 1 });
+    expect(db.rows[0].status).toBe("pending");
+    expect(db.rows[0].attempts).toBe(1);
+    expect(db.rows[0].last_error).toContain("503");
+  });
+
+  test("permanent failure → row immediately dead with last_error", async () => {
+    await enqueue(db, { eventType: "demo", payload: { source: "demo", email: "dead@y.test" } });
+    const dispatcher: OutboxDispatcher = async () => ({
+      kind: "permanent",
+      message: "401 Unauthorized",
+    });
+    const result = await flushBatch(db, dispatcher, 10);
+    expect(result).toMatchObject({ claimed: 1, permanent: 1 });
+    expect(db.rows[0].status).toBe("dead");
+  });
+
+  test("dispatcher that throws is treated as transient, NOT dead", async () => {
+    await enqueue(db, { eventType: "demo", payload: { source: "demo", email: "throw@y.test" } });
+    const dispatcher: OutboxDispatcher = async () => {
+      throw new Error("dispatcher bug");
+    };
+    const result = await flushBatch(db, dispatcher, 10);
+    expect(result).toMatchObject({ claimed: 1, transient: 1 });
+    expect(db.rows[0].status).toBe("pending");
+    expect(db.rows[0].last_error).toContain("dispatcher bug");
+  });
+});
+
+// ── Sub-step idempotency — the load-bearing AC for #2729 ─────────────
+
+describe("sub-step idempotency", () => {
+  test("row with twenty_person_id already set goes straight to done (no upstream call)", async () => {
+    // Simulate the partial-success crash recovery path: a previous
+    // attempt called upsertPerson and persisted the ID before the
+    // process died. The next flush MUST NOT call upsertPerson again.
+    await enqueue(db, { eventType: "demo", payload: { source: "demo", email: "replay@y.test" } });
+    db.rows[0].twenty_person_id = "person_already_done";
+
+    let upsertCalls = 0;
+    const dispatcher: OutboxDispatcher = async (row, persist) => {
+      if (!row.twentyPersonId) {
+        upsertCalls++;
+        await persist.setTwentyPersonId("would-be-duplicate");
+      }
+      return { kind: "ok" };
+    };
+
+    await flushBatch(db, dispatcher, 10);
+    expect(upsertCalls).toBe(0);
+    expect(db.rows[0].twenty_person_id).toBe("person_already_done");
+    expect(db.rows[0].status).toBe("done");
+  });
+
+  test("upsertPerson called exactly once across retries when twenty_person_id is set", async () => {
+    await enqueue(db, { eventType: "demo", payload: { source: "demo", email: "once@y.test" } });
+
+    let upsertCalls = 0;
+    const dispatcher: OutboxDispatcher = async (row, persist) => {
+      if (!row.twentyPersonId) {
+        upsertCalls++;
+        await persist.setTwentyPersonId(`person-${upsertCalls}`);
+      }
+      // First attempt "crashes" AFTER persisting the person id: return
+      // transient so the row goes back to pending. Second attempt sees
+      // the persisted id, skips upsertPerson, and completes.
+      if (row.attempts === 1) {
+        return { kind: "transient", message: "crashed after upsertPerson" };
+      }
+      return { kind: "ok" };
+    };
+
+    // Round 1: claim → attempts=1. upsertPerson runs, persists, then returns transient.
+    await flushBatch(db, dispatcher, 10);
+    expect(db.rows[0].twenty_person_id).toBe("person-1");
+    expect(db.rows[0].status as string).toBe("pending");
+    expect(db.rows[0].attempts).toBe(1);
+
+    // Round 2: claim → attempts=2. Dispatcher sees the persisted id
+    // and short-circuits — upsertPerson is NOT called again. Row done.
+    await flushBatch(db, dispatcher, 10);
+    expect(upsertCalls).toBe(1);
+    expect(db.rows[0].status as string).toBe("done");
+    expect(db.rows[0].twenty_person_id).toBe("person-1");
+  });
+});
+
+// ── Retry budget ─────────────────────────────────────────────────────
+
+describe("retry budget exhaustion", () => {
+  test("transient failure on the 6th attempt is dead-lettered", async () => {
+    await enqueue(db, { eventType: "demo", payload: { source: "demo", email: "budget@y.test" } });
+    // Simulate 5 prior failed attempts so the next claim bumps attempts → 6.
+    db.rows[0].attempts = 5;
+
+    const dispatcher: OutboxDispatcher = async () => ({
+      kind: "transient",
+      message: "still failing",
+    });
+
+    const result = await flushBatch(db, dispatcher, 10);
+    expect(result).toMatchObject({ claimed: 1, permanent: 1 });
+    expect(db.rows[0].status as string).toBe("dead");
+    expect(db.rows[0].attempts).toBe(6);
+    // The dead message labels the cause as "transient failure after N attempts"
+    // so an operator scanning crm_outbox can distinguish budget-exhaustion
+    // from a 4xx dead-letter.
+    expect(db.rows[0].last_error).toContain(`transient failure after 6 attempts`);
+  });
+
+  test("rows already at the dead threshold are not claimed at all", async () => {
+    await enqueue(db, { eventType: "demo", payload: { source: "demo", email: "skip@y.test" } });
+    // attempts=6 means the WHERE filter excludes the row.
+    db.rows[0].attempts = 6;
+
+    let calls = 0;
+    const dispatcher: OutboxDispatcher = async () => {
+      calls++;
+      return { kind: "ok" };
+    };
+
+    const result = await flushBatch(db, dispatcher, 10);
+    expect(result.claimed).toBe(0);
+    expect(calls).toBe(0);
+  });
+});
+
+// ── Concurrency ──────────────────────────────────────────────────────
+
+describe("concurrent flush behaviour", () => {
+  test("blocked claim returns 0 rows and the dispatcher is never called", async () => {
+    await enqueue(db, { eventType: "demo", payload: { source: "demo", email: "blocked@y.test" } });
+    db.claimBlocked = true;
+
+    let calls = 0;
+    const dispatcher: OutboxDispatcher = async () => {
+      calls++;
+      return { kind: "ok" };
+    };
+
+    const result = await flushBatch(db, dispatcher, 10);
+    expect(result.claimed).toBe(0);
+    expect(calls).toBe(0);
+    // Row still pending and unclaimed.
+    expect(db.rows[0].status).toBe("pending");
+    expect(db.rows[0].attempts).toBe(0);
+  });
+
+  test("batchLimit=0 is a no-op without touching the DB", async () => {
+    await enqueue(db, { eventType: "demo", payload: { source: "demo", email: "x@y.test" } });
+    let calls = 0;
+    const dispatcher: OutboxDispatcher = async () => {
+      calls++;
+      return { kind: "ok" };
+    };
+    const result = await flushBatch(db, dispatcher, 0);
+    expect(result).toEqual({ claimed: 0, ok: 0, transient: 0, permanent: 0 });
+    expect(calls).toBe(0);
+  });
+});
+
+// ── Startup recovery ─────────────────────────────────────────────────
+
+describe("recoverInFlight", () => {
+  test("resets every in_flight row to pending and returns the count", async () => {
+    await enqueue(db, { eventType: "demo", payload: { source: "demo", email: "a@y.test" } });
+    await enqueue(db, { eventType: "demo", payload: { source: "demo", email: "b@y.test" } });
+    db.rows[0].status = "in_flight";
+    db.rows[1].status = "in_flight";
+
+    const n = await recoverInFlight(db);
+    expect(n).toBe(2);
+    // Cast to widen the literal type — the prior `= "in_flight"`
+    // assignments narrow TS's view of `status`, and the mutation
+    // inside `recoverInFlight` is invisible to it.
+    expect(db.rows[0].status as string).toBe("pending");
+    expect(db.rows[1].status as string).toBe("pending");
+  });
+
+  test("done / dead / pending rows are untouched", async () => {
+    await enqueue(db, { eventType: "demo", payload: { source: "demo", email: "p@y.test" } });
+    await enqueue(db, { eventType: "demo", payload: { source: "demo", email: "d@y.test" } });
+    await enqueue(db, { eventType: "demo", payload: { source: "demo", email: "x@y.test" } });
+    db.rows[1].status = "done";
+    db.rows[2].status = "dead";
+
+    const n = await recoverInFlight(db);
+    expect(n).toBe(0);
+    expect(db.rows[0].status).toBe("pending");
+    expect(db.rows[1].status).toBe("done");
+    expect(db.rows[2].status).toBe("dead");
+  });
+});
+
+// ── Helpers contract — make sure persist callbacks are bound per row ─
+
+describe("persist helper binding", () => {
+  test("setTwentyPersonId / setTwentyNoteId write the correct row id", async () => {
+    await enqueue(db, { eventType: "demo", payload: { source: "demo", email: "a@y.test" } });
+    await enqueue(db, { eventType: "demo", payload: { source: "demo", email: "b@y.test" } });
+
+    let nthCall = 0;
+    const dispatcher: OutboxDispatcher = async (
+      row: ClaimedOutboxRow,
+      persist: OutboxPersistHelpers,
+    ): Promise<DispatchOutcome> => {
+      nthCall++;
+      await persist.setTwentyPersonId(`person-${nthCall}`);
+      await persist.setTwentyNoteId(`note-${nthCall}`);
+      return { kind: "ok" };
+    };
+
+    await flushBatch(db, dispatcher, 10);
+    // Order matters: rows are claimed in ORDER BY created_at, which in
+    // our fake matches insertion order. row-1 → person-1, row-2 → person-2.
+    expect(db.rows[0].twenty_person_id).toBe("person-1");
+    expect(db.rows[0].twenty_note_id).toBe("note-1");
+    expect(db.rows[1].twenty_person_id).toBe("person-2");
+    expect(db.rows[1].twenty_note_id).toBe("note-2");
+  });
+});

--- a/packages/api/src/lib/lead-outbox/backoff.ts
+++ b/packages/api/src/lib/lead-outbox/backoff.ts
@@ -1,25 +1,25 @@
 /**
  * Backoff math for the `crm_outbox` flusher (#2729).
  *
- * Pure, unit-tested. Both this file and the SQL CASE expression in
- * `outbox.ts` must stay in lockstep — the SQL WHERE clause is what
- * enforces backoff (a sleep would let a long-backoff row block newer
- * pending rows), so a divergence here means rows either retry too
- * eagerly (data loss against the rate limit) or never retry at all.
+ * Pure, unit-tested. The `DELAYS_MS` array and `CLAIM_DELAY_SQL` CASE
+ * below must stay in lockstep — the SQL WHERE clause in
+ * `outbox.ts:CLAIM_SQL` is what enforces backoff (a sleep would let a
+ * long-backoff row block newer pending rows), so a divergence means
+ * rows either retry too eagerly (data loss against the rate limit) or
+ * never retry at all. `__tests__/backoff.test.ts` pins both sides;
+ * `outbox-pg.test.ts` extends the check end-to-end via Postgres.
  *
- * Delay interpretation: `delayUntilNextAttemptMs(attempts)` returns the
- * total time, measured from `created_at`, that must elapse before
- * attempt N+1 is allowed. The flusher's claim WHERE clause is
- * `created_at + delay <= now()`. With the per-tier values below,
- * inter-attempt gaps grow geometrically (30s, ~1m30s, ~6m, ~22m, ~1h30m)
- * even though the base is `created_at` — each tier is large enough that
- * a fast-failing attempt at the previous tier still leaves a real gap
- * before the next try. A row whose attempts dispatch unusually slowly
- * may see attempt N+1 fire immediately after attempt N, which is
- * acceptable: the next attempt's failure pushes the row into the next
- * tier, and the gap grows from there.
- *
- * `nextDelayMs` is an alias retained for the spec wording in #2729.
+ * Delay interpretation: `nextDelayMs(attempts)` returns the total
+ * time, measured from `created_at`, that must elapse before attempt
+ * N+1 is allowed. The flusher's claim WHERE clause is
+ * `COALESCE(retry_after, created_at + delay) <= now()` — when the
+ * upstream surfaced a `Retry-After` header the absolute `retry_after`
+ * wins; otherwise the tier-based delay applies. With the per-tier
+ * values below the inter-attempt gaps grow roughly 3–4× per tier
+ * (30s → 1m30s → 6m → 22m → 1h30m). A row whose attempts dispatch
+ * unusually slowly may see attempt N+1 fire immediately after attempt
+ * N, which is acceptable: the next attempt's failure pushes the row
+ * into the next tier, and the gap grows from there.
  */
 
 /**
@@ -51,7 +51,8 @@ const DELAYS_MS: ReadonlyArray<number> = [
  * Delay from `created_at` until the (attempts+1)th dispatch is allowed.
  *
  * Pure function — unit-tested in `__tests__/backoff.test.ts`. Mirrors
- * the SQL CASE in `OUTBOX_CLAIM_SQL`.
+ * `CLAIM_DELAY_SQL` below; both are interpolated into
+ * `outbox.ts:CLAIM_SQL`'s WHERE clause.
  */
 export function nextDelayMs(attempts: number): number {
   if (!Number.isFinite(attempts) || attempts < 0) return 0;

--- a/packages/api/src/lib/lead-outbox/backoff.ts
+++ b/packages/api/src/lib/lead-outbox/backoff.ts
@@ -1,0 +1,78 @@
+/**
+ * Backoff math for the `crm_outbox` flusher (#2729).
+ *
+ * Pure, unit-tested. Both this file and the SQL CASE expression in
+ * `outbox.ts` must stay in lockstep — the SQL WHERE clause is what
+ * enforces backoff (a sleep would let a long-backoff row block newer
+ * pending rows), so a divergence here means rows either retry too
+ * eagerly (data loss against the rate limit) or never retry at all.
+ *
+ * Delay interpretation: `delayUntilNextAttemptMs(attempts)` returns the
+ * total time, measured from `created_at`, that must elapse before
+ * attempt N+1 is allowed. The flusher's claim WHERE clause is
+ * `created_at + delay <= now()`. With the per-tier values below,
+ * inter-attempt gaps grow geometrically (30s, ~1m30s, ~6m, ~22m, ~1h30m)
+ * even though the base is `created_at` — each tier is large enough that
+ * a fast-failing attempt at the previous tier still leaves a real gap
+ * before the next try. A row whose attempts dispatch unusually slowly
+ * may see attempt N+1 fire immediately after attempt N, which is
+ * acceptable: the next attempt's failure pushes the row into the next
+ * tier, and the gap grows from there.
+ *
+ * `nextDelayMs` is an alias retained for the spec wording in #2729.
+ */
+
+/**
+ * Hard dead-letter threshold. After this many failed attempts the
+ * flusher flips the row to `status='dead'` and stops retrying.
+ */
+export const DEAD_AFTER_ATTEMPTS = 6;
+
+/**
+ * Per-attempt delays in milliseconds, indexed by `attempts`.
+ *
+ * - `attempts=0` is the first try and must be immediate (delay 0) so
+ *   `enqueue → flushBatch` round-trips in a single tick.
+ * - `attempts=1..5` are the post-failure waits.
+ * - `attempts>=6` is unreachable in the claim WHERE (filtered by
+ *   `attempts < DEAD_AFTER_ATTEMPTS`); the array still terminates
+ *   defensively in case a caller asks.
+ */
+const DELAYS_MS: ReadonlyArray<number> = [
+  0,
+  30_000,       // 30s
+  120_000,      // 2m
+  480_000,      // 8m
+  1_800_000,    // 30m
+  7_200_000,    // 2h
+];
+
+/**
+ * Delay from `created_at` until the (attempts+1)th dispatch is allowed.
+ *
+ * Pure function — unit-tested in `__tests__/backoff.test.ts`. Mirrors
+ * the SQL CASE in `OUTBOX_CLAIM_SQL`.
+ */
+export function nextDelayMs(attempts: number): number {
+  if (!Number.isFinite(attempts) || attempts < 0) return 0;
+  const floored = Math.floor(attempts);
+  if (floored >= DELAYS_MS.length) return DELAYS_MS[DELAYS_MS.length - 1];
+  return DELAYS_MS[floored];
+}
+
+/**
+ * SQL fragment that computes the per-attempt delay interval. Drop into
+ * a WHERE clause as `created_at + <FRAGMENT> <= now()`. Kept here so
+ * tier changes touch one file. Must match `DELAYS_MS` above.
+ */
+export const CLAIM_DELAY_SQL = `
+  CASE attempts
+    WHEN 0 THEN INTERVAL '0'
+    WHEN 1 THEN INTERVAL '30 seconds'
+    WHEN 2 THEN INTERVAL '2 minutes'
+    WHEN 3 THEN INTERVAL '8 minutes'
+    WHEN 4 THEN INTERVAL '30 minutes'
+    WHEN 5 THEN INTERVAL '2 hours'
+    ELSE INTERVAL '2 hours'
+  END
+`;

--- a/packages/api/src/lib/lead-outbox/classify.ts
+++ b/packages/api/src/lib/lead-outbox/classify.ts
@@ -3,20 +3,30 @@
  * (#2729). The outbox itself is generic — this module is also generic:
  * callers pass in a status (`number`) and we apply the HTTP-based
  * rules. The Twenty-specific extraction (mapping `TwentyClientError` →
- * status + retryAfter) lives next to the dispatcher in
+ * status code) lives next to the dispatcher in
  * `ee/src/saas-crm/index.ts`, keeping `lib/lead-outbox/` free of any
- * `@useatlas/twenty` import.
+ * `@useatlas/twenty` import. (Retry-After parsing is a separate concern
+ * — the dispatcher reads it off the upstream error and surfaces it on
+ * `DispatchOutcome.transient.retryAfterMs`; this module only buckets
+ * the status into retry vs dead-letter.)
  */
 
 export type Classification = "permanent" | "transient";
+
+/** Retryable 4xx status codes per RFC 9110 + community convention. */
+const RETRYABLE_4XX = new Set<number>([
+  408, // Request Timeout — server closed idle connection / slow upstream
+  425, // Too Early — used by CDNs to refuse TLS-replay-window requests
+  429, // Too Many Requests — rate limited
+]);
 
 /**
  * HTTP status → permanent (dead-letter immediately) or transient
  * (retry with backoff).
  *
- * Rules per #2729:
- *   - 4xx other than 429 → permanent (deterministic misconfig)
- *   - 429 → transient (rate limited; backoff will spread the retry)
+ * Rules per #2729 (extended by the slice-2 review to cover 408/425):
+ *   - 4xx in `RETRYABLE_4XX` (408, 425, 429) → transient
+ *   - Other 4xx → permanent (deterministic misconfig)
  *   - 5xx → transient (upstream outage)
  *   - 0 / network / timeout → transient (transport flake)
  *   - 2xx / 3xx are not failures and should never reach here, but if
@@ -27,7 +37,7 @@ export function classifyHttpStatus(status: number): Classification {
   if (!Number.isFinite(status)) return "transient";
   if (status === 0) return "transient";
   if (status >= 500 && status < 600) return "transient";
-  if (status === 429) return "transient";
+  if (RETRYABLE_4XX.has(status)) return "transient";
   if (status >= 400 && status < 500) return "permanent";
   return "permanent";
 }

--- a/packages/api/src/lib/lead-outbox/classify.ts
+++ b/packages/api/src/lib/lead-outbox/classify.ts
@@ -1,0 +1,33 @@
+/**
+ * Permanent-vs-transient classification for outbox dispatch errors
+ * (#2729). The outbox itself is generic — this module is also generic:
+ * callers pass in a status (`number`) and we apply the HTTP-based
+ * rules. The Twenty-specific extraction (mapping `TwentyClientError` →
+ * status + retryAfter) lives next to the dispatcher in
+ * `ee/src/saas-crm/index.ts`, keeping `lib/lead-outbox/` free of any
+ * `@useatlas/twenty` import.
+ */
+
+export type Classification = "permanent" | "transient";
+
+/**
+ * HTTP status → permanent (dead-letter immediately) or transient
+ * (retry with backoff).
+ *
+ * Rules per #2729:
+ *   - 4xx other than 429 → permanent (deterministic misconfig)
+ *   - 429 → transient (rate limited; backoff will spread the retry)
+ *   - 5xx → transient (upstream outage)
+ *   - 0 / network / timeout → transient (transport flake)
+ *   - 2xx / 3xx are not failures and should never reach here, but if
+ *     they do, classify as permanent to fail loud — a "successful"
+ *     response that the caller still threw on indicates a code bug.
+ */
+export function classifyHttpStatus(status: number): Classification {
+  if (!Number.isFinite(status)) return "transient";
+  if (status === 0) return "transient";
+  if (status >= 500 && status < 600) return "transient";
+  if (status === 429) return "transient";
+  if (status >= 400 && status < 500) return "permanent";
+  return "permanent";
+}

--- a/packages/api/src/lib/lead-outbox/index.ts
+++ b/packages/api/src/lib/lead-outbox/index.ts
@@ -1,0 +1,28 @@
+/**
+ * Public surface of the lead-outbox module (#2729). Generic queue
+ * mechanics live here; the Twenty-specific dispatcher lives in
+ * `ee/src/saas-crm/index.ts` so the core → ee inversion stays enforced.
+ */
+
+export {
+  enqueue,
+  recoverInFlight,
+  flushBatch,
+  getTickIntervalMs,
+  FLUSH_BATCH_LIMIT,
+  type OutboxDB,
+  type EnqueueInput,
+  type ClaimedOutboxRow,
+  type OutboxPersistHelpers,
+  type DispatchOutcome,
+  type OutboxDispatcher,
+  type FlushResult,
+} from "./outbox";
+
+export {
+  nextDelayMs,
+  DEAD_AFTER_ATTEMPTS,
+  CLAIM_DELAY_SQL,
+} from "./backoff";
+
+export { classifyHttpStatus, type Classification } from "./classify";

--- a/packages/api/src/lib/lead-outbox/index.ts
+++ b/packages/api/src/lib/lead-outbox/index.ts
@@ -9,14 +9,22 @@ export {
   recoverInFlight,
   flushBatch,
   getTickIntervalMs,
+  computeRetryAfterTimestamp,
   FLUSH_BATCH_LIMIT,
+  STARTUP_RECOVERY_STALE_MS,
+  SHUTDOWN_RECOVERY_STALE_MS,
+  MIN_TICK_SECONDS,
+  MAX_TICK_SECONDS,
+  DEFAULT_TICK_SECONDS,
   type OutboxDB,
   type EnqueueInput,
   type ClaimedOutboxRow,
   type OutboxPersistHelpers,
   type DispatchOutcome,
   type OutboxDispatcher,
+  type OutboxStatus,
   type FlushResult,
+  type RecoveryResult,
 } from "./outbox";
 
 export {

--- a/packages/api/src/lib/lead-outbox/outbox.ts
+++ b/packages/api/src/lib/lead-outbox/outbox.ts
@@ -1,0 +1,371 @@
+/**
+ * Lead outbox — durable queue for SaaS CRM lead dispatches (#2729,
+ * slice 2 of 1.6.0).
+ *
+ * This module is generic over the dispatcher: it owns the queue
+ * mechanics (enqueue, claim, sub-step persistence, backoff, dead-letter,
+ * startup recovery) and delegates the actual upstream call to a
+ * pluggable `OutboxDispatcher`. The Twenty-specific dispatcher lives in
+ * `ee/src/saas-crm/index.ts` so the `core → ee` inversion (enforced by
+ * `scripts/check-ee-imports.sh`) stays intact.
+ *
+ * Idempotency contract: the dispatcher receives the row's current
+ * `twentyPersonId` / `twentyNoteId` snapshot and must skip any sub-step
+ * whose ID is already populated. After each successful sub-step the
+ * dispatcher calls back into `persist.setTwentyPersonId` /
+ * `setTwentyNoteId` which UPDATEs the column immediately. This is what
+ * makes "upsertPerson succeeded, createNote crashed before commit"
+ * safe — the next flush sees `twentyPersonId` set, skips upsertPerson,
+ * and goes straight to createNote.
+ *
+ * Concurrency: the claim is a single `UPDATE … WHERE id IN (SELECT …
+ * FOR UPDATE SKIP LOCKED) RETURNING *` statement. Multiple flusher
+ * workers (today there is one per pod; tomorrow's horizontal scale
+ * lands free) cannot double-claim a row.
+ */
+
+import { createLogger } from "@atlas/api/lib/logger";
+import { CLAIM_DELAY_SQL, DEAD_AFTER_ATTEMPTS } from "./backoff";
+
+/**
+ * Narrow DB surface the outbox needs. Matches the `query` method on
+ * `InternalDBShape` and on the module-level `internalQuery` standalone
+ * function, so the EE dispatcher can hand in either. Keeping the
+ * dependency narrow makes the unit tests trivial (pass any object with
+ * a `query` method) and avoids dragging the full `InternalDB` Tag into
+ * `lib/lead-outbox/` consumers.
+ */
+export interface OutboxDB {
+  query<T extends Record<string, unknown>>(
+    sql: string,
+    params?: unknown[],
+  ): Promise<T[]>;
+}
+
+const log = createLogger("lead-outbox");
+
+// ─────────────────────────────────────────────────────────────────────
+//  Public types
+// ─────────────────────────────────────────────────────────────────────
+
+/** What a freshly-enqueued row looks like before any dispatch attempt. */
+export interface EnqueueInput {
+  /** Discriminator for the dispatcher's switch (e.g., "demo", "sales-form"). */
+  readonly eventType: string;
+  /** Opaque payload the dispatcher knows how to interpret. */
+  readonly payload: Record<string, unknown>;
+}
+
+/** Snapshot of a row at the moment the flusher claimed it. */
+export interface ClaimedOutboxRow {
+  readonly id: string;
+  readonly eventType: string;
+  readonly payload: unknown;
+  readonly attempts: number;
+  readonly twentyPersonId: string | null;
+  readonly twentyNoteId: string | null;
+}
+
+/**
+ * Sub-step persistence helpers passed to the dispatcher. Each callback
+ * does a single targeted UPDATE — the writes happen inline so the next
+ * claim of this row (on a retry) sees the populated ID and can skip.
+ */
+export interface OutboxPersistHelpers {
+  setTwentyPersonId(id: string): Promise<void>;
+  setTwentyNoteId(id: string): Promise<void>;
+}
+
+/**
+ * Dispatcher classification of an error. The outbox uses this to decide
+ * dead-letter vs retry without needing to know about
+ * `TwentyClientError` or any other domain type.
+ */
+export type DispatchOutcome =
+  | { readonly kind: "ok" }
+  | { readonly kind: "transient"; readonly message: string }
+  | { readonly kind: "permanent"; readonly message: string };
+
+/**
+ * Pluggable dispatcher. The implementation owns the upstream call(s)
+ * AND owns the decision of whether a thrown error is transient or
+ * permanent (because only it knows which library's errors are which).
+ */
+export type OutboxDispatcher = (
+  row: ClaimedOutboxRow,
+  persist: OutboxPersistHelpers,
+) => Promise<DispatchOutcome>;
+
+export interface FlushResult {
+  readonly claimed: number;
+  readonly ok: number;
+  readonly transient: number;
+  readonly permanent: number;
+}
+
+// ─────────────────────────────────────────────────────────────────────
+//  SQL — kept as top-level constants so the test discipline gate
+//  doesn't need to grep through string concatenation.
+// ─────────────────────────────────────────────────────────────────────
+
+const ENQUEUE_SQL = `
+  INSERT INTO crm_outbox (event_type, payload, status)
+  VALUES ($1, $2::jsonb, 'pending')
+  RETURNING id
+`;
+
+/**
+ * Single-statement claim. The inner SELECT uses `FOR UPDATE SKIP
+ * LOCKED` so concurrent flushers walk disjoint sets of pending rows
+ * without blocking each other. The outer UPDATE atomically flips
+ * status and bumps `attempts`.
+ *
+ * `attempts < DEAD_AFTER_ATTEMPTS` is enforced here AND in the
+ * permanent-dispatch branch — the WHERE clause is the load-bearing
+ * gate (rows past the threshold simply stop being claimable).
+ */
+const CLAIM_SQL = `
+  UPDATE crm_outbox
+  SET status = 'in_flight',
+      attempts = attempts + 1
+  WHERE id IN (
+    SELECT id FROM crm_outbox
+    WHERE status = 'pending'
+      AND attempts < ${DEAD_AFTER_ATTEMPTS}
+      AND created_at + (${CLAIM_DELAY_SQL}) <= now()
+    ORDER BY created_at
+    LIMIT $1
+    FOR UPDATE SKIP LOCKED
+  )
+  RETURNING id, event_type, payload, attempts, twenty_person_id, twenty_note_id
+`;
+
+const PERSIST_PERSON_ID_SQL = `
+  UPDATE crm_outbox SET twenty_person_id = $1 WHERE id = $2
+`;
+
+const PERSIST_NOTE_ID_SQL = `
+  UPDATE crm_outbox SET twenty_note_id = $1 WHERE id = $2
+`;
+
+const MARK_DONE_SQL = `
+  UPDATE crm_outbox
+  SET status = 'done', processed_at = now(), last_error = NULL
+  WHERE id = $1
+`;
+
+const MARK_TRANSIENT_FAIL_SQL = `
+  UPDATE crm_outbox
+  SET status = 'pending', last_error = $1
+  WHERE id = $2
+`;
+
+const MARK_DEAD_SQL = `
+  UPDATE crm_outbox
+  SET status = 'dead', processed_at = now(), last_error = $1
+  WHERE id = $2
+`;
+
+/**
+ * Startup recovery: any `in_flight` row at boot is the carcass of a
+ * crash mid-dispatch. Resetting to `pending` lets the next tick claim
+ * it. `attempts` is NOT decremented — the previous flush already
+ * incremented it (claim does `attempts = attempts + 1` atomically), so
+ * if it's already at `DEAD_AFTER_ATTEMPTS` the claim WHERE filters it
+ * out and the row stays pending forever. That's intentional: a row
+ * that's crashed the process 6 times in a row is a poison pill and
+ * deserves operator attention, not another silent retry.
+ */
+const RECOVER_IN_FLIGHT_SQL = `
+  UPDATE crm_outbox SET status = 'pending'
+  WHERE status = 'in_flight'
+`;
+
+// ─────────────────────────────────────────────────────────────────────
+//  Public API
+// ─────────────────────────────────────────────────────────────────────
+
+/** Insert a row in `pending` status. Returns the new row id. */
+export async function enqueue(
+  db: OutboxDB,
+  input: EnqueueInput,
+): Promise<string> {
+  const rows = await db.query<{ id: string }>(ENQUEUE_SQL, [
+    input.eventType,
+    JSON.stringify(input.payload),
+  ]);
+  const id = rows[0]?.id;
+  if (!id) {
+    // INSERT … RETURNING with no row back is a driver-level invariant
+    // violation — fail loud rather than silently drop the enqueue.
+    throw new Error("crm_outbox enqueue returned no row");
+  }
+  return id;
+}
+
+/**
+ * Reset every `in_flight` row to `pending`. Call at Layer init (before
+ * the tick fiber starts) AND from the shutdown finalizer (so SIGTERM
+ * mid-dispatch doesn't strand rows). Returns the number of rows
+ * affected — useful for boot logging.
+ */
+export async function recoverInFlight(db: OutboxDB): Promise<number> {
+  const result = await db.query<{ id: string }>(`${RECOVER_IN_FLIGHT_SQL} RETURNING id`);
+  return result.length;
+}
+
+/**
+ * Claim a batch of pending-and-due rows, dispatch each, persist per-
+ * sub-step IDs, and stamp final status. Returns counts so the caller
+ * can log / surface metrics in a later slice.
+ *
+ * Errors from the dispatcher are NEVER re-thrown — they're caught and
+ * the row's status is updated according to `DispatchOutcome`. An
+ * uncaught defect (e.g. the dispatcher itself throws something it
+ * shouldn't) is logged and the row is treated as transient (will retry
+ * with backoff) — anything else would leak `in_flight` rows that
+ * `recoverInFlight` would need to mop up on the next restart.
+ */
+export async function flushBatch(
+  db: OutboxDB,
+  dispatcher: OutboxDispatcher,
+  batchLimit: number,
+): Promise<FlushResult> {
+  if (batchLimit <= 0) return { claimed: 0, ok: 0, transient: 0, permanent: 0 };
+
+  type ClaimedRow = {
+    id: string;
+    event_type: string;
+    payload: unknown;
+    attempts: number;
+    twenty_person_id: string | null;
+    twenty_note_id: string | null;
+  };
+  const claimed = await db.query<ClaimedRow>(CLAIM_SQL, [batchLimit]);
+  let ok = 0;
+  let transient = 0;
+  let permanent = 0;
+
+  for (const raw of claimed) {
+    const row: ClaimedOutboxRow = {
+      id: raw.id,
+      eventType: raw.event_type,
+      payload: raw.payload,
+      attempts: raw.attempts,
+      twentyPersonId: raw.twenty_person_id,
+      twentyNoteId: raw.twenty_note_id,
+    };
+
+    const persist: OutboxPersistHelpers = {
+      setTwentyPersonId: async (id) => {
+        await db.query(PERSIST_PERSON_ID_SQL, [id, row.id]);
+      },
+      setTwentyNoteId: async (id) => {
+        await db.query(PERSIST_NOTE_ID_SQL, [id, row.id]);
+      },
+    };
+
+    let outcome: DispatchOutcome;
+    try {
+      outcome = await dispatcher(row, persist);
+    } catch (err) {
+      // Dispatcher contract violation: it should classify and return,
+      // never throw. Treat as transient so we don't dead-letter on a
+      // bug in the dispatcher's error handling.
+      log.error(
+        {
+          rowId: row.id,
+          attempts: row.attempts,
+          err: err instanceof Error ? err.message : String(err),
+          event: "lead_outbox.dispatcher_threw",
+        },
+        "Dispatcher threw — classifying as transient so the row will retry",
+      );
+      outcome = {
+        kind: "transient",
+        message: err instanceof Error ? err.message : String(err),
+      };
+    }
+
+    if (outcome.kind === "ok") {
+      await db.query(MARK_DONE_SQL, [row.id]);
+      ok++;
+      continue;
+    }
+
+    if (outcome.kind === "permanent") {
+      await db.query(MARK_DEAD_SQL, [outcome.message, row.id]);
+      log.error(
+        {
+          rowId: row.id,
+          attempts: row.attempts,
+          err: outcome.message,
+          event: "lead_outbox.dead_letter_permanent",
+        },
+        "Lead dead-lettered (permanent failure) — operator intervention required",
+      );
+      permanent++;
+      continue;
+    }
+
+    // Transient. If we've already burned through the retry budget the
+    // row dies here too — the claim WHERE wouldn't let us pick it up
+    // again, so leaving it `pending` would be a silent stuck-forever
+    // row.
+    if (row.attempts >= DEAD_AFTER_ATTEMPTS) {
+      await db.query(MARK_DEAD_SQL, [
+        `transient failure after ${DEAD_AFTER_ATTEMPTS} attempts: ${outcome.message}`,
+        row.id,
+      ]);
+      log.error(
+        {
+          rowId: row.id,
+          attempts: row.attempts,
+          err: outcome.message,
+          event: "lead_outbox.dead_letter_exhausted",
+        },
+        `Lead dead-lettered (retry budget exhausted)`,
+      );
+      permanent++;
+      continue;
+    }
+
+    await db.query(MARK_TRANSIENT_FAIL_SQL, [outcome.message, row.id]);
+    log.warn(
+      {
+        rowId: row.id,
+        attempts: row.attempts,
+        err: outcome.message,
+        event: "lead_outbox.transient_failure",
+      },
+      "Lead dispatch failed (transient) — will retry with backoff",
+    );
+    transient++;
+  }
+
+  return { claimed: claimed.length, ok, transient, permanent };
+}
+
+// ─────────────────────────────────────────────────────────────────────
+//  Configuration
+// ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Tick interval. Default 5s per the issue; configurable via
+ * `ATLAS_CRM_OUTBOX_TICK_SECONDS` for operators who want to dial it
+ * down (e.g. SaaS-region traffic spike) without redeploying.
+ */
+export function getTickIntervalMs(): number {
+  const raw = process.env.ATLAS_CRM_OUTBOX_TICK_SECONDS;
+  if (!raw) return 5_000;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return 5_000;
+  return parsed * 1_000;
+}
+
+/**
+ * Per-tick claim batch size. Capped at 50 to keep a single tick's
+ * fan-out to Twenty bounded — a multi-thousand-row backlog is recovered
+ * across many ticks rather than starving the upstream rate limit in one.
+ */
+export const FLUSH_BATCH_LIMIT = 50;

--- a/packages/api/src/lib/lead-outbox/outbox.ts
+++ b/packages/api/src/lib/lead-outbox/outbox.ts
@@ -15,13 +15,21 @@
  * dispatcher calls back into `persist.setTwentyPersonId` /
  * `setTwentyNoteId` which UPDATEs the column immediately. This is what
  * makes "upsertPerson succeeded, createNote crashed before commit"
- * safe — the next flush sees `twentyPersonId` set, skips upsertPerson,
- * and goes straight to createNote.
+ * safe — the next flush sees `twentyPersonId` set and skips upsertPerson.
+ * (createNote follows the same pattern once it lands — see the
+ * placeholder in `ee/src/saas-crm/index.ts:dispatchOutboxRow`.)
  *
  * Concurrency: the claim is a single `UPDATE … WHERE id IN (SELECT …
  * FOR UPDATE SKIP LOCKED) RETURNING *` statement. Multiple flusher
  * workers (today there is one per pod; tomorrow's horizontal scale
  * lands free) cannot double-claim a row.
+ *
+ * Retry-After: when the dispatcher surfaces a transient outcome with a
+ * `retryAfterMs` (parsed from the upstream `Retry-After` header on a
+ * 429 or similar), the flusher stamps `retry_after = now() + delay` on
+ * the row. The claim WHERE then prefers that timestamp over the
+ * tier-based backoff via `COALESCE(retry_after, created_at + tier)`,
+ * so the upstream's requested delay always wins.
  */
 
 import { createLogger } from "@atlas/api/lib/logger";
@@ -48,6 +56,14 @@ const log = createLogger("lead-outbox");
 //  Public types
 // ─────────────────────────────────────────────────────────────────────
 
+/**
+ * Outbox lifecycle states. Mirrors the `crm_outbox_status_chk` CHECK
+ * constraint exactly. Use this everywhere a status literal is referenced
+ * (SQL or Drizzle) so a typo fails at compile time, not at runtime when
+ * the CHECK fires.
+ */
+export type OutboxStatus = "pending" | "in_flight" | "done" | "dead";
+
 /** What a freshly-enqueued row looks like before any dispatch attempt. */
 export interface EnqueueInput {
   /** Discriminator for the dispatcher's switch (e.g., "demo", "sales-form"). */
@@ -56,12 +72,21 @@ export interface EnqueueInput {
   readonly payload: Record<string, unknown>;
 }
 
-/** Snapshot of a row at the moment the flusher claimed it. */
+/**
+ * Snapshot of a row at the moment the flusher claimed it. The omission
+ * of `status` is deliberate: the claim has already flipped this row to
+ * `in_flight`, and the dispatcher's contract is "do work, return an
+ * outcome" — no caller should need to branch on the lifecycle state of
+ * a row it's currently holding.
+ */
 export interface ClaimedOutboxRow {
   readonly id: string;
   readonly eventType: string;
   readonly payload: unknown;
   readonly attempts: number;
+  // TODO(#2729-followup): rename to a generic `resourceIds` record if a
+  // second SaaS CRM ever ships — the Twenty-specific naming leaks
+  // vendor specifics into the otherwise-generic outbox surface.
   readonly twentyPersonId: string | null;
   readonly twentyNoteId: string | null;
 }
@@ -72,6 +97,8 @@ export interface ClaimedOutboxRow {
  * claim of this row (on a retry) sees the populated ID and can skip.
  */
 export interface OutboxPersistHelpers {
+  // TODO(#2729-followup): generalise to `setResourceId(key, id)` if a
+  // second SaaS CRM ever ships. See ClaimedOutboxRow for context.
   setTwentyPersonId(id: string): Promise<void>;
   setTwentyNoteId(id: string): Promise<void>;
 }
@@ -80,11 +107,30 @@ export interface OutboxPersistHelpers {
  * Dispatcher classification of an error. The outbox uses this to decide
  * dead-letter vs retry without needing to know about
  * `TwentyClientError` or any other domain type.
+ *
+ * `transient.retryAfterMs` lets the dispatcher honour an upstream
+ * `Retry-After` header (typically on a 429). When set, the flusher
+ * stamps `retry_after = now() + retryAfterMs` on the row and the
+ * claim WHERE prefers that over the tier-based backoff.
+ *
+ * `transient.httpStatus` / `permanent.httpStatus` are optional carriers
+ * for the upstream HTTP status code. The flusher doesn't use them today
+ * — they're surfaced so a future admin UI (#2735) can bucket
+ * dead-letter rows by status without re-parsing log strings.
  */
 export type DispatchOutcome =
   | { readonly kind: "ok" }
-  | { readonly kind: "transient"; readonly message: string }
-  | { readonly kind: "permanent"; readonly message: string };
+  | {
+      readonly kind: "transient";
+      readonly message: string;
+      readonly retryAfterMs?: number;
+      readonly httpStatus?: number;
+    }
+  | {
+      readonly kind: "permanent";
+      readonly message: string;
+      readonly httpStatus?: number;
+    };
 
 /**
  * Pluggable dispatcher. The implementation owns the upstream call(s)
@@ -104,8 +150,9 @@ export interface FlushResult {
 }
 
 // ─────────────────────────────────────────────────────────────────────
-//  SQL — kept as top-level constants so the test discipline gate
-//  doesn't need to grep through string concatenation.
+//  SQL — hoisted as top-level constants so each statement is greppable
+//  and the `CLAIM_DELAY_SQL` interpolation point is colocated with the
+//  WHERE clause it shapes.
 // ─────────────────────────────────────────────────────────────────────
 
 const ENQUEUE_SQL = `
@@ -123,16 +170,24 @@ const ENQUEUE_SQL = `
  * `attempts < DEAD_AFTER_ATTEMPTS` is enforced here AND in the
  * permanent-dispatch branch — the WHERE clause is the load-bearing
  * gate (rows past the threshold simply stop being claimable).
+ *
+ * Backoff gate: `COALESCE(retry_after, created_at + tier) <= now()`.
+ * When the previous failure surfaced a Retry-After header, the
+ * absolute `retry_after` timestamp wins; otherwise we fall back to
+ * the tier-based delay measured from `created_at`. The COALESCE
+ * keeps a long upstream-requested delay from being clobbered by an
+ * eager tier value (e.g. 30s tier-1 vs `Retry-After: 3600`).
  */
 const CLAIM_SQL = `
   UPDATE crm_outbox
   SET status = 'in_flight',
-      attempts = attempts + 1
+      attempts = attempts + 1,
+      claimed_at = now()
   WHERE id IN (
     SELECT id FROM crm_outbox
     WHERE status = 'pending'
       AND attempts < ${DEAD_AFTER_ATTEMPTS}
-      AND created_at + (${CLAIM_DELAY_SQL}) <= now()
+      AND COALESCE(retry_after, created_at + (${CLAIM_DELAY_SQL})) <= now()
     ORDER BY created_at
     LIMIT $1
     FOR UPDATE SKIP LOCKED
@@ -150,36 +205,91 @@ const PERSIST_NOTE_ID_SQL = `
 
 const MARK_DONE_SQL = `
   UPDATE crm_outbox
-  SET status = 'done', processed_at = now(), last_error = NULL
+  SET status = 'done',
+      processed_at = now(),
+      last_error = NULL,
+      retry_after = NULL,
+      claimed_at = NULL
   WHERE id = $1
 `;
 
+/**
+ * Transient mark. `$3` is either an absolute timestamp (when the
+ * upstream supplied a parseable Retry-After) or NULL (clears any
+ * previous retry_after so the row falls back to the tier-based gate
+ * on the next claim). `claimed_at` is cleared so the recovery sweep's
+ * staleness gate doesn't trip on a row that's already back to pending.
+ */
 const MARK_TRANSIENT_FAIL_SQL = `
   UPDATE crm_outbox
-  SET status = 'pending', last_error = $1
+  SET status = 'pending',
+      last_error = $1,
+      retry_after = $3,
+      claimed_at = NULL
   WHERE id = $2
 `;
 
 const MARK_DEAD_SQL = `
   UPDATE crm_outbox
-  SET status = 'dead', processed_at = now(), last_error = $1
+  SET status = 'dead',
+      processed_at = now(),
+      last_error = $1,
+      retry_after = NULL,
+      claimed_at = NULL
   WHERE id = $2
 `;
 
 /**
- * Startup recovery: any `in_flight` row at boot is the carcass of a
- * crash mid-dispatch. Resetting to `pending` lets the next tick claim
- * it. `attempts` is NOT decremented — the previous flush already
- * incremented it (claim does `attempts = attempts + 1` atomically), so
- * if it's already at `DEAD_AFTER_ATTEMPTS` the claim WHERE filters it
- * out and the row stays pending forever. That's intentional: a row
- * that's crashed the process 6 times in a row is a poison pill and
- * deserves operator attention, not another silent retry.
+ * Recovery sweep — splits the in_flight set into two buckets:
+ *
+ *  1. **Exhausted carcasses** (`attempts >= DEAD_AFTER_ATTEMPTS`) move
+ *     straight to `status = 'dead'`. Without this they'd land in
+ *     `pending` and never re-claim (the claim WHERE filters them),
+ *     hiding terminal failures from a `status = 'dead'` triage query.
+ *     (Codex P3, 2026-05-25.)
+ *  2. **Stale carcasses** (claimed > `$1` ms ago, OR never stamped)
+ *     return to `pending` for re-claim. The age threshold protects
+ *     concurrent peer pods in a multi-pod deployment — a sibling pod
+ *     that claimed the row 5s ago is NOT reset out from under its
+ *     still-running dispatcher. (Codex P1, 2026-05-25.)
+ *
+ * `retry_after` is preserved across both branches: the upstream's
+ * rate-limit window does not reset when we crash, so a recovered row
+ * still respects any prior Retry-After before its next claim.
+ *
+ * Returns the count of rows touched (dead + reset, combined).
  */
-const RECOVER_IN_FLIGHT_SQL = `
-  UPDATE crm_outbox SET status = 'pending'
+const MARK_EXHAUSTED_IN_FLIGHT_DEAD_SQL = `
+  UPDATE crm_outbox
+  SET status = 'dead', processed_at = now(),
+      last_error = CASE
+        WHEN last_error IS NULL OR last_error = ''
+          THEN 'crashed mid-dispatch at attempts=' || attempts || ' (recovery)'
+        ELSE last_error || ' [crashed mid-dispatch at attempts=' || attempts || ', recovery dead-lettered]'
+      END
   WHERE status = 'in_flight'
+    AND attempts >= ${DEAD_AFTER_ATTEMPTS}
+  RETURNING id
 `;
+
+const RECOVER_STALE_IN_FLIGHT_SQL = `
+  UPDATE crm_outbox
+  SET status = 'pending'
+  WHERE status = 'in_flight'
+    AND attempts < ${DEAD_AFTER_ATTEMPTS}
+    AND (claimed_at IS NULL OR claimed_at < now() - ($1::int * INTERVAL '1 millisecond'))
+  RETURNING id
+`;
+
+/**
+ * Recovery age thresholds. Startup uses a generous window so any
+ * still-running peer pod's dispatch finishes before we'd interfere;
+ * shutdown can use a shorter window since the dying pod's OWN
+ * dispatcher has just been interrupted (and the only concern is peer
+ * pods that may have claimed rows in the last few seconds).
+ */
+export const STARTUP_RECOVERY_STALE_MS = 5 * 60_000; // 5 min
+export const SHUTDOWN_RECOVERY_STALE_MS = 30_000;   // 30 s
 
 // ─────────────────────────────────────────────────────────────────────
 //  Public API
@@ -204,14 +314,35 @@ export async function enqueue(
 }
 
 /**
- * Reset every `in_flight` row to `pending`. Call at Layer init (before
- * the tick fiber starts) AND from the shutdown finalizer (so SIGTERM
- * mid-dispatch doesn't strand rows). Returns the number of rows
- * affected — useful for boot logging.
+ * Reset stale `in_flight` rows. Call at Layer init AND from the
+ * shutdown finalizer.
+ *
+ * The `staleAgeMs` option gates which rows are touched:
+ *  - Rows whose `claimed_at` is older than `staleAgeMs` (or NULL) are
+ *    presumed dead and either:
+ *      - moved to `dead` if `attempts >= DEAD_AFTER_ATTEMPTS` (Codex P3)
+ *      - reset to `pending` otherwise
+ *  - Rows recently claimed (i.e. a sibling pod is actively working
+ *    them) are left alone — protects multi-pod deploys from
+ *    double-dispatch (Codex P1).
+ *
+ * Returns a per-bucket count for logging.
  */
-export async function recoverInFlight(db: OutboxDB): Promise<number> {
-  const result = await db.query<{ id: string }>(`${RECOVER_IN_FLIGHT_SQL} RETURNING id`);
-  return result.length;
+export interface RecoveryResult {
+  readonly deadLettered: number;
+  readonly reset: number;
+}
+
+export async function recoverInFlight(
+  db: OutboxDB,
+  staleAgeMs: number = STARTUP_RECOVERY_STALE_MS,
+): Promise<RecoveryResult> {
+  // Dead-letter exhausted rows first — these don't care about staleness
+  // (a row claimed 1s ago that's already exhausted is still terminally
+  // failed and should not retry).
+  const dead = await db.query<{ id: string }>(MARK_EXHAUSTED_IN_FLIGHT_DEAD_SQL);
+  const reset = await db.query<{ id: string }>(RECOVER_STALE_IN_FLIGHT_SQL, [staleAgeMs]);
+  return { deadLettered: dead.length, reset: reset.length };
 }
 
 /**
@@ -288,13 +419,19 @@ export async function flushBatch(
     }
 
     if (outcome.kind === "ok") {
-      await db.query(MARK_DONE_SQL, [row.id]);
+      await markStatusWithRetry(db, MARK_DONE_SQL, [row.id], row.id, "done");
       ok++;
       continue;
     }
 
     if (outcome.kind === "permanent") {
-      await db.query(MARK_DEAD_SQL, [outcome.message, row.id]);
+      await markStatusWithRetry(
+        db,
+        MARK_DEAD_SQL,
+        [outcome.message, row.id],
+        row.id,
+        "dead",
+      );
       log.error(
         {
           rowId: row.id,
@@ -313,10 +450,16 @@ export async function flushBatch(
     // again, so leaving it `pending` would be a silent stuck-forever
     // row.
     if (row.attempts >= DEAD_AFTER_ATTEMPTS) {
-      await db.query(MARK_DEAD_SQL, [
-        `transient failure after ${DEAD_AFTER_ATTEMPTS} attempts: ${outcome.message}`,
+      await markStatusWithRetry(
+        db,
+        MARK_DEAD_SQL,
+        [
+          `transient failure after ${DEAD_AFTER_ATTEMPTS} attempts: ${outcome.message}`,
+          row.id,
+        ],
         row.id,
-      ]);
+        "dead",
+      );
       log.error(
         {
           rowId: row.id,
@@ -330,12 +473,20 @@ export async function flushBatch(
       continue;
     }
 
-    await db.query(MARK_TRANSIENT_FAIL_SQL, [outcome.message, row.id]);
+    const retryAfter = computeRetryAfterTimestamp(outcome.retryAfterMs);
+    await markStatusWithRetry(
+      db,
+      MARK_TRANSIENT_FAIL_SQL,
+      [outcome.message, row.id, retryAfter],
+      row.id,
+      "pending",
+    );
     log.warn(
       {
         rowId: row.id,
         attempts: row.attempts,
         err: outcome.message,
+        retryAfterMs: outcome.retryAfterMs ?? null,
         event: "lead_outbox.transient_failure",
       },
       "Lead dispatch failed (transient) — will retry with backoff",
@@ -346,6 +497,57 @@ export async function flushBatch(
   return { claimed: claimed.length, ok, transient, permanent };
 }
 
+/**
+ * Compute the absolute `retry_after` timestamp for a transient outcome
+ * with an upstream-specified delay. Returns `null` when the outcome
+ * carries no header (the SQL clears the column on every transient mark
+ * so a prior Retry-After can't strand a row).
+ *
+ * Exported for tests; not part of the dispatcher contract.
+ */
+export function computeRetryAfterTimestamp(retryAfterMs: number | undefined): Date | null {
+  if (retryAfterMs == null) return null;
+  if (!Number.isFinite(retryAfterMs) || retryAfterMs < 0) return null;
+  return new Date(Date.now() + retryAfterMs);
+}
+
+/**
+ * Single-retry wrapper around a terminal-status UPDATE. If the first
+ * write fails (Postgres connection blip between dispatch return and
+ * status stamp), wait briefly and try once more. If both fail, log
+ * loudly and re-throw so the tick's outer Effect.catchAll records the
+ * tick as failed — the row stays `in_flight` and `recoverInFlight`
+ * mops it up on the next boot. Without this, an isolated network
+ * hiccup at the wrong moment strands the row until restart.
+ */
+async function markStatusWithRetry(
+  db: OutboxDB,
+  sql: string,
+  params: unknown[],
+  rowId: string,
+  intent: OutboxStatus,
+): Promise<void> {
+  try {
+    await db.query(sql, params);
+    return;
+  } catch (err) {
+    log.warn(
+      {
+        rowId,
+        intent,
+        err: err instanceof Error ? err.message : String(err),
+        event: "lead_outbox.status_update_retrying",
+      },
+      "Outbox terminal-status UPDATE failed — retrying once before letting the row strand",
+    );
+    // Briefly defer so a transient pool error has a chance to clear.
+    // 50ms is short enough that the tick doesn't visibly slow but long
+    // enough for the pg pool to swap a broken connection.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    await db.query(sql, params);
+  }
+}
+
 // ─────────────────────────────────────────────────────────────────────
 //  Configuration
 // ─────────────────────────────────────────────────────────────────────
@@ -354,12 +556,39 @@ export async function flushBatch(
  * Tick interval. Default 5s per the issue; configurable via
  * `ATLAS_CRM_OUTBOX_TICK_SECONDS` for operators who want to dial it
  * down (e.g. SaaS-region traffic spike) without redeploying.
+ *
+ * Clamped to `[1, 3600]` seconds (1s … 1h). The upper bound avoids a
+ * Bun timer overflow at >~2^31 ms — without the clamp, a typo'd
+ * `ATLAS_CRM_OUTBOX_TICK_SECONDS=3600000` (operator meant ms) would
+ * overflow to a 1ms tick and DDoS Postgres + Twenty (Codex P2,
+ * 2026-05-25). The lower bound prevents an accidental 0.x-second
+ * tick from doing the same. Out-of-range inputs warn-and-clamp
+ * rather than silently default — the operator's intent (faster /
+ * slower) is preserved at the boundary value.
  */
+export const MIN_TICK_SECONDS = 1;
+export const MAX_TICK_SECONDS = 3600;
+export const DEFAULT_TICK_SECONDS = 5;
+
 export function getTickIntervalMs(): number {
   const raw = process.env.ATLAS_CRM_OUTBOX_TICK_SECONDS;
-  if (!raw) return 5_000;
+  if (!raw) return DEFAULT_TICK_SECONDS * 1_000;
   const parsed = Number.parseInt(raw, 10);
-  if (!Number.isFinite(parsed) || parsed <= 0) return 5_000;
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_TICK_SECONDS * 1_000;
+  if (parsed < MIN_TICK_SECONDS) {
+    log.warn(
+      { requested: parsed, clamped: MIN_TICK_SECONDS, event: "lead_outbox.tick_clamped" },
+      `ATLAS_CRM_OUTBOX_TICK_SECONDS=${parsed} is below ${MIN_TICK_SECONDS}s minimum — clamping`,
+    );
+    return MIN_TICK_SECONDS * 1_000;
+  }
+  if (parsed > MAX_TICK_SECONDS) {
+    log.warn(
+      { requested: parsed, clamped: MAX_TICK_SECONDS, event: "lead_outbox.tick_clamped" },
+      `ATLAS_CRM_OUTBOX_TICK_SECONDS=${parsed} exceeds ${MAX_TICK_SECONDS}s maximum — clamping`,
+    );
+    return MAX_TICK_SECONDS * 1_000;
+  }
   return parsed * 1_000;
 }
 

--- a/plugins/twenty/__tests__/retry-after.test.ts
+++ b/plugins/twenty/__tests__/retry-after.test.ts
@@ -1,0 +1,90 @@
+/**
+ * `parseRetryAfterMs` — RFC 9110 §10.2.3 covers two valid forms:
+ * delta-seconds and HTTP-date. Both must round-trip cleanly through
+ * the parser, and any garbage / negative value must collapse to
+ * undefined (so a misbehaving upstream can't ask us to retry in the
+ * past — which would either be a no-op or, worse, produce a negative
+ * interval the outbox would store as a Postgres-rejected timestamp).
+ */
+
+import { describe, expect, test } from "bun:test";
+import { parseRetryAfterMs, TwentyClientError } from "../src/client";
+
+describe("parseRetryAfterMs — delta-seconds form", () => {
+  test("plain integer", () => {
+    expect(parseRetryAfterMs("120")).toBe(120_000);
+  });
+
+  test("leading zeros are accepted", () => {
+    expect(parseRetryAfterMs("0030")).toBe(30_000);
+  });
+
+  test("zero is a valid delay", () => {
+    expect(parseRetryAfterMs("0")).toBe(0);
+  });
+
+  test("trims surrounding whitespace", () => {
+    expect(parseRetryAfterMs("  90  ")).toBe(90_000);
+  });
+});
+
+describe("parseRetryAfterMs — HTTP-date form", () => {
+  test("future date returns positive delta", () => {
+    const futureMs = Date.now() + 60_000;
+    const headerValue = new Date(futureMs).toUTCString();
+    const parsed = parseRetryAfterMs(headerValue);
+    expect(parsed).not.toBeUndefined();
+    // Allow a wide tolerance for slow CI between Date.now() calls.
+    if (parsed !== undefined) {
+      expect(parsed).toBeGreaterThanOrEqual(58_000);
+      expect(parsed).toBeLessThanOrEqual(60_000);
+    }
+  });
+
+  test("past date clamps to 0 rather than producing a negative interval", () => {
+    const pastDate = new Date(Date.now() - 10_000).toUTCString();
+    expect(parseRetryAfterMs(pastDate)).toBe(0);
+  });
+});
+
+describe("parseRetryAfterMs — bad input", () => {
+  test("null / undefined / empty → undefined", () => {
+    expect(parseRetryAfterMs(null)).toBeUndefined();
+    expect(parseRetryAfterMs(undefined)).toBeUndefined();
+    expect(parseRetryAfterMs("")).toBeUndefined();
+    expect(parseRetryAfterMs("   ")).toBeUndefined();
+  });
+
+  test("garbage strings → undefined", () => {
+    expect(parseRetryAfterMs("soon")).toBeUndefined();
+    expect(parseRetryAfterMs("not-a-date-and-not-an-integer")).toBeUndefined();
+  });
+
+  test("negative integers → 0 (clamped — never produces a negative interval)", () => {
+    // The regex /^\d+$/ rejects the leading `-` so we fall through to
+    // Date.parse. Some JS engines parse "-60" as year -60 which is
+    // far in the past; the clamp guarantees a safe ≥0 result.
+    expect(parseRetryAfterMs("-60")).toBe(0);
+  });
+});
+
+describe("TwentyClientError carries retryAfterMs", () => {
+  test("retryAfterMs is preserved on construction", () => {
+    const err = new TwentyClientError({
+      message: "rate limited",
+      status: 429,
+      operation: "createPerson" as const,
+      retryAfterMs: 45_000,
+    });
+    expect(err.retryAfterMs).toBe(45_000);
+  });
+
+  test("retryAfterMs is optional", () => {
+    const err = new TwentyClientError({
+      message: "internal",
+      status: 503,
+      operation: "createPerson" as const,
+    });
+    expect(err.retryAfterMs).toBeUndefined();
+  });
+});

--- a/plugins/twenty/src/client.ts
+++ b/plugins/twenty/src/client.ts
@@ -45,6 +45,14 @@ export class TwentyClientError extends Data.TaggedError("TwentyClientError")<{
   readonly upstreamCode?: string;
   /** Which client method raised the failure. */
   readonly operation: TwentyOperation;
+  /**
+   * Best-effort `Retry-After` from the response, normalised to
+   * milliseconds. Set when the upstream returned a 429 (or any other
+   * status) with a parseable `Retry-After` header. The outbox honours
+   * this on the row's `retry_after` column so the next claim respects
+   * the upstream's requested delay instead of the tier-based default.
+   */
+  readonly retryAfterMs?: number;
 }> {}
 
 /**
@@ -144,6 +152,36 @@ function buildAuthHeaders(apiKey: string): Record<string, string> {
 const DEFAULT_TIMEOUT_MS = 10_000;
 
 /**
+ * Parse the `Retry-After` header per RFC 9110 §10.2.3. Two valid forms:
+ *  - `delta-seconds` (e.g. `120`) — non-negative integer.
+ *  - `HTTP-date` (e.g. `Wed, 21 Oct 2015 07:28:00 GMT`) — `Date.parse`able.
+ *
+ * Returns the wait in milliseconds, or `undefined` when the header is
+ * absent or unparseable. Always clamped to a non-negative value so a
+ * server clock skew can't ask us to retry "in the past" (which would
+ * collapse to no delay) or — worse — produce a negative interval the
+ * outbox would store as a Postgres-rejected timestamp.
+ */
+export function parseRetryAfterMs(headerValue: string | null | undefined): number | undefined {
+  if (!headerValue) return undefined;
+  const trimmed = headerValue.trim();
+  if (trimmed.length === 0) return undefined;
+
+  // delta-seconds form — integer, possibly with leading zeros.
+  if (/^\d+$/.test(trimmed)) {
+    const seconds = Number.parseInt(trimmed, 10);
+    if (!Number.isFinite(seconds)) return undefined;
+    return Math.max(0, seconds * 1000);
+  }
+
+  // HTTP-date form. Date.parse returns NaN on garbage.
+  const target = Date.parse(trimmed);
+  if (!Number.isFinite(target)) return undefined;
+  const delta = target - Date.now();
+  return Math.max(0, delta);
+}
+
+/**
  * Parse a Twenty error response without ever including the raw body in
  * the thrown error message — Twenty may include sensitive context. We
  * surface the upstream `messages[0]` (canonical envelope) or fall back
@@ -213,6 +251,7 @@ async function findPersonByEmail(
       status: response.status,
       upstreamCode: detail.code,
       operation: "findPersonByEmail",
+      retryAfterMs: parseRetryAfterMs(response.headers.get("Retry-After")),
     });
   }
 
@@ -262,6 +301,7 @@ async function createPerson(
       status: response.status,
       upstreamCode: detail.code,
       operation: "createPerson",
+      retryAfterMs: parseRetryAfterMs(response.headers.get("Retry-After")),
     });
   }
 
@@ -301,6 +341,7 @@ async function updatePerson(
       status: response.status,
       upstreamCode: detail.code,
       operation: "updatePerson",
+      retryAfterMs: parseRetryAfterMs(response.headers.get("Retry-After")),
     });
   }
 
@@ -428,6 +469,7 @@ export async function getPersonMetadata(
       status: response.status,
       upstreamCode: detail.code,
       operation: "getPersonMetadata",
+      retryAfterMs: parseRetryAfterMs(response.headers.get("Retry-After")),
     });
   }
 


### PR DESCRIPTION
## Summary

Slice 2 of 1.6.0. Replaces the fire-and-forget `SaasCrm.upsertLead` dispatch from slice 1 (#2727 / PR #2785) with a durable `crm_outbox` table and a Scheduler-backed flusher. A Twenty outage, API crash, or partial sub-step failure no longer drops the lead.

- **Migration `0102_crm_outbox.sql`** — `id, event_type, payload jsonb, status text+CHECK, attempts, last_error, twenty_person_id, twenty_note_id, created_at, processed_at` + partial index on `(status, created_at) WHERE status IN ('pending','in_flight')` so the flusher poll stays fast as done/dead rows accumulate. Drizzle mirror added in the same PR; schema-drift gate is green.
- **`packages/api/src/lib/lead-outbox/`** — new deep module owning generic queue mechanics (`enqueue`, `flushBatch` via single-statement `UPDATE … FOR UPDATE SKIP LOCKED RETURNING`, `recoverInFlight`, deterministic per-tier backoff: 30s / 2m / 8m / 30m / 2h, dead-letter at attempt 6). Dispatcher is parameterised — Twenty-specific dispatch lives in `ee/src/saas-crm/` so the `core → ee` inversion stays enforced by `check-ee-imports.sh`.
- **Scheduler wiring (`lib/effect/layers.ts:makeSchedulerLive`)** — yields `SaasCrm`, runs startup recovery (UPDATE `in_flight` → `pending`) **before** the tick starts, forks an `Effect.repeat(Schedule.spaced)` poll fiber, and registers a finalizer that interrupts the fiber **and** runs a final recovery sweep so SIGTERM never strands rows. Tick interval is `ATLAS_CRM_OUTBOX_TICK_SECONDS` (default 5s); batch limit is 50.
- **Idempotent sub-step replay** — dispatcher sees the row's existing `twenty_person_id` / `twenty_note_id` and skips any sub-step whose ID is already populated. After each successful sub-step the dispatcher's `persist` callbacks UPDATE the column immediately. The "upsertPerson succeeded, createNote crashed before commit" path is now safe; the next flush goes straight to createNote.
- **Permanent vs transient classification** — 4xx other than 429 → dead immediately; 5xx / 429 / transport / unknown → retry with backoff. Dispatcher contract violation (a thrown error) is treated as transient so a dispatcher bug doesn't dead-letter every row.
- **Demo path unchanged** — `captureDemoLead` still calls `crm.upsertLead`; that call now enqueues instead of dispatching, but the catch-and-log around it stays for defense-in-depth.

## Test plan

- [x] `bun run lint` — clean.
- [x] `bun run type` — clean.
- [x] `bun run test` — 474/474 api test files + all other packages pass (one pre-existing flake in `ai-saas.test.ts` cleared on retry; untouched by this PR).
- [x] Schema-drift, template-drift, railway-watch, oauth-helper, security-headers, test-discipline, syncpack — all green.
- [x] Real-PG integration tests (`outbox-pg.test.ts`) pass against a real Postgres: 5xx → retry / 401 → dead / partial-success replay (upsertPerson called exactly once) / row with both IDs straight to done / startup recovery flips `in_flight` → `pending` / backoff filters recently-failed rows.
- [x] Full migration smoke (`migrate-pg.test.ts`) — all 103 migrations apply cleanly end-to-end.
- [x] `ee-imports` gate — `lib/effect/enterprise-layer.ts` remains the only `@atlas/ee` import in core.

Closes #2729