### PR TITLE
fix(test): flaky parallel-load sweep — discord/teams ESM cache + DuckDB/rate-limit timeouts

### DIFF
--- a/packages/api/src/api/__tests__/teams-discord-always-mount.test.ts
+++ b/packages/api/src/api/__tests__/teams-discord-always-mount.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Locks the always-mount contract for /api/v1/teams and /api/v1/discord.
+ *
+ * The PR-#2831 fix removed import-time `if (process.env.TEAMS_APP_ID)` and
+ * `if (process.env.DISCORD_CLIENT_ID)` gates around `app.route(...)` because
+ * ESM modules are cached per realm — under a shared-worker `bun test
+ * --parallel` cutover (#2802), whichever env value won the import race froze
+ * the routing decision for the worker's lifetime.
+ *
+ * The other test files (`teams.test.ts`, `discord.test.ts`) set the env in
+ * `beforeEach` BEFORE the first `getApp()` call, then `delete` it inside the
+ * 501 test. That proves the request-time check works but doesn't catch a
+ * regression that re-adds the import-time gate (the routes would still be
+ * mounted because env was set at the moment of import; the request-time
+ * delete would still yield 501).
+ *
+ * This file flips the order: delete the env vars BEFORE the dynamic import
+ * runs. A revert to the import-time gate would skip `app.route(...)` and the
+ * request would 404 — failing here loudly. Subprocess-per-file isolation
+ * gives this file a fresh module realm.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, mock } from "bun:test";
+
+// --- Mocks (must be at module top before app import) ---
+
+mock.module("@atlas/api/lib/teams/store", () => ({
+  saveTeamsInstallation: mock(() => Promise.resolve()),
+  getTeamsInstallation: mock(() => Promise.resolve(null)),
+  getTeamsInstallationByOrg: mock(() => Promise.resolve(null)),
+  deleteTeamsInstallation: mock(() => Promise.resolve()),
+  deleteTeamsInstallationByOrg: mock(() => Promise.resolve(false)),
+}));
+
+mock.module("@atlas/api/lib/discord/store", () => ({
+  saveDiscordInstallation: mock(() => Promise.resolve()),
+  getDiscordInstallation: mock(() => Promise.resolve(null)),
+  getDiscordInstallationByOrg: mock(() => Promise.resolve(null)),
+  deleteDiscordInstallation: mock(() => Promise.resolve()),
+  deleteDiscordInstallationByOrg: mock(() => Promise.resolve(false)),
+}));
+
+mock.module("@atlas/api/lib/auth/middleware", () => ({
+  checkRateLimit: mock(() => ({ allowed: true })),
+  authenticateRequest: mock(() =>
+    Promise.resolve({ authenticated: true, mode: "none", user: null }),
+  ),
+  getClientIP: mock(() => "127.0.0.1"),
+  rateLimitCleanupTick: mock(() => {}),
+}));
+
+describe("/api/v1/{teams,discord} always-mount contract", () => {
+  const savedTeamsAppId = process.env.TEAMS_APP_ID;
+  const savedDiscordClientId = process.env.DISCORD_CLIENT_ID;
+  const savedDiscordClientSecret = process.env.DISCORD_CLIENT_SECRET;
+  let app: { request: (path: string, init?: RequestInit) => Promise<Response> };
+
+  beforeAll(async () => {
+    // Unset BEFORE the dynamic import — the assertion is that the routes
+    // mount even when the platform env is missing at module-evaluation time.
+    delete process.env.TEAMS_APP_ID;
+    delete process.env.DISCORD_CLIENT_ID;
+    delete process.env.DISCORD_CLIENT_SECRET;
+
+    const mod = (await import("../../api/index")) as {
+      app: { request: (path: string, init?: RequestInit) => Promise<Response> };
+    };
+    app = mod.app;
+  });
+
+  afterAll(() => {
+    if (savedTeamsAppId !== undefined) process.env.TEAMS_APP_ID = savedTeamsAppId;
+    if (savedDiscordClientId !== undefined)
+      process.env.DISCORD_CLIENT_ID = savedDiscordClientId;
+    if (savedDiscordClientSecret !== undefined)
+      process.env.DISCORD_CLIENT_SECRET = savedDiscordClientSecret;
+  });
+
+  it("/api/v1/teams/install returns 501 (not 404) when TEAMS_APP_ID unset at import", async () => {
+    const resp = await app.request("/api/v1/teams/install", { method: "GET" });
+    expect(resp.status).toBe(501);
+  });
+
+  it("/api/v1/discord/install returns 501 (not 404) when DISCORD_CLIENT_ID unset at import", async () => {
+    const resp = await app.request("/api/v1/discord/install", { method: "GET" });
+    expect(resp.status).toBe(501);
+  });
+});

--- a/packages/api/src/api/index.ts
+++ b/packages/api/src/api/index.ts
@@ -526,19 +526,21 @@ try {
   );
 }
 
-// Teams + Discord routes — always mount. The handlers in routes/teams.ts
-// and routes/discord.ts read env at REQUEST time and return 501 when the
-// platform credentials are unset, so unconfigured deployments still get
-// the discoverable 501 response. Gating at import time made route
-// registration order-dependent under shared-worker test runs (#2710 / #2776):
-// once any sibling file triggered api/index.ts evaluation with the env
-// unset, the routes were never registered for the rest of that worker's
-// lifetime. ESM modules are cached per realm, so the conditional only
-// executed once and the cached result was wrong for every subsequent test.
+// Teams + Discord routes — always mount. Handlers read env per-request
+// and return 501 when unconfigured, so import-time gating would freeze
+// a stale "unconfigured" routing decision into the cached ESM module
+// for any caller that evaluates this file before env is set.
 const { teams } = await import("./routes/teams");
 app.route("/api/v1/teams", teams);
 const { discord } = await import("./routes/discord");
 app.route("/api/v1/discord", discord);
+log.info(
+  {
+    teams: Boolean(process.env.TEAMS_APP_ID),
+    discord: Boolean(process.env.DISCORD_CLIENT_ID),
+  },
+  "platform integrations",
+);
 
 // Hosted MCP endpoint — mounts the MCP server as a Hono route under
 // /mcp/{workspace_id}/sse so the same per-region API instance that

--- a/packages/api/src/api/index.ts
+++ b/packages/api/src/api/index.ts
@@ -526,25 +526,19 @@ try {
   );
 }
 
-// Teams routes — lazy import, only loaded if TEAMS_APP_ID is set.
-// Dynamic import avoids pulling teams dependencies into the module graph
-// when Teams is disabled, and prevents mock.module leaks in test suites.
-if (process.env.TEAMS_APP_ID) {
-  const { teams } = await import("./routes/teams");
-  app.route("/api/v1/teams", teams);
-  log.info("Teams integration enabled");
-} else {
-  log.debug("Teams integration disabled (TEAMS_APP_ID not set)");
-}
-
-// Discord routes — lazy import, only loaded if DISCORD_CLIENT_ID is set.
-if (process.env.DISCORD_CLIENT_ID) {
-  const { discord } = await import("./routes/discord");
-  app.route("/api/v1/discord", discord);
-  log.info("Discord integration enabled");
-} else {
-  log.debug("Discord integration disabled (DISCORD_CLIENT_ID not set)");
-}
+// Teams + Discord routes — always mount. The handlers in routes/teams.ts
+// and routes/discord.ts read env at REQUEST time and return 501 when the
+// platform credentials are unset, so unconfigured deployments still get
+// the discoverable 501 response. Gating at import time made route
+// registration order-dependent under shared-worker test runs (#2710 / #2776):
+// once any sibling file triggered api/index.ts evaluation with the env
+// unset, the routes were never registered for the rest of that worker's
+// lifetime. ESM modules are cached per realm, so the conditional only
+// executed once and the cached result was wrong for every subsequent test.
+const { teams } = await import("./routes/teams");
+app.route("/api/v1/teams", teams);
+const { discord } = await import("./routes/discord");
+app.route("/api/v1/discord", discord);
 
 // Hosted MCP endpoint — mounts the MCP server as a Hono route under
 // /mcp/{workspace_id}/sse so the same per-region API instance that

--- a/packages/api/src/lib/auth/__tests__/rate-limit-integration.test.ts
+++ b/packages/api/src/lib/auth/__tests__/rate-limit-integration.test.ts
@@ -367,13 +367,9 @@ describe("live rate-limit loop — /sign-in/email", () => {
     // returns 429. If `rateLimit:` is dropped, all 11 stay 401 — red.
     expect(statuses.slice(0, 10)).toEqual(Array.from({ length: 10 }, () => 401));
     expect(statuses[10]).toBe(429);
-  });
+  }, 15_000);
 
-  // 15s timeout (default 5s) — 11 sequential Better Auth handler invocations
-  // through the live rate-limit middleware blow past 5s when the api-tests
-  // shard is contended with sibling real-PG tests (#2694). The matching
-  // ATLAS_AUTH_RATE_LIMIT_MAX=9999 keeps the per-endpoint rule
-  // (max=10) as the only source of the trailing 429 — see assertion below.
+  // 11 sequential Better Auth calls — shard contention pushes p99 past the 5s default.
   it("rate-limits by x-atlas-client-ip even when x-forwarded-for rotates (F-06 spoof resistance)", async () => {
     // If `advanced` is dropped, Better Auth falls back to default IP
     // detection — which reads `x-forwarded-for`. An attacker rotating

--- a/packages/api/src/lib/auth/__tests__/rate-limit-integration.test.ts
+++ b/packages/api/src/lib/auth/__tests__/rate-limit-integration.test.ts
@@ -369,6 +369,11 @@ describe("live rate-limit loop — /sign-in/email", () => {
     expect(statuses[10]).toBe(429);
   });
 
+  // 15s timeout (default 5s) — 11 sequential Better Auth handler invocations
+  // through the live rate-limit middleware blow past 5s when the api-tests
+  // shard is contended with sibling real-PG tests (#2694). The matching
+  // ATLAS_AUTH_RATE_LIMIT_MAX=9999 keeps the per-endpoint rule
+  // (max=10) as the only source of the trailing 429 — see assertion below.
   it("rate-limits by x-atlas-client-ip even when x-forwarded-for rotates (F-06 spoof resistance)", async () => {
     // If `advanced` is dropped, Better Auth falls back to default IP
     // detection — which reads `x-forwarded-for`. An attacker rotating
@@ -400,7 +405,7 @@ describe("live rate-limit loop — /sign-in/email", () => {
 
     expect(statuses.slice(0, 10)).toEqual(Array.from({ length: 10 }, () => 401));
     expect(statuses[10]).toBe(429);
-  });
+  }, 15_000);
 });
 
 describe("signup enumeration response parity — /sign-up/email", () => {

--- a/packages/cli/bin/__tests__/fatal-error-propagation.test.ts
+++ b/packages/cli/bin/__tests__/fatal-error-propagation.test.ts
@@ -172,23 +172,26 @@ describe("DuckDB profiler — error propagation behavior", () => {
     expect(exitCode).toBe(0);
   });
 
+  // DuckDB native-module cold start dominates first-run wall time under
+  // parallel-suite contention; bound the elapsed assertion well below the
+  // bumped timeout so a real cold-start regression (e.g. native module
+  // load doubling) still fires red instead of riding the 30s ceiling.
   it("valid database profiles successfully with all columns", async () => {
-    // A valid database should profile without errors — all columns resolve
     const csvPath = path.join(tmpDir, "data.csv");
     fs.writeFileSync(csvPath, "id,value\n1,hello\n2,world\n");
 
     const dbPath = path.join(tmpDir, "test.duckdb");
     await ingestIntoDuckDB(dbPath, [{ path: csvPath, format: "csv" }]);
 
+    const t0 = performance.now();
     const result = await profileDuckDB(dbPath);
+    const elapsed = performance.now() - t0;
+
     expect(result.profiles).toHaveLength(1);
     expect(result.errors).toHaveLength(0);
     expect(result.profiles[0].columns.length).toBe(2);
+    expect(elapsed).toBeLessThan(25_000);
   }, 30_000);
-  // ^ 30s timeout (default 5s) — DuckDB native-module cold start +
-  // CSV ingest + profile blows past 5s when the full suite runs
-  // in parallel and the host is under contention (#2716). The test
-  // asserts behavior, not performance; the bump preserves coverage.
 });
 
 describe("column-level catch re-throw contract", () => {

--- a/packages/cli/bin/__tests__/fatal-error-propagation.test.ts
+++ b/packages/cli/bin/__tests__/fatal-error-propagation.test.ts
@@ -184,7 +184,11 @@ describe("DuckDB profiler — error propagation behavior", () => {
     expect(result.profiles).toHaveLength(1);
     expect(result.errors).toHaveLength(0);
     expect(result.profiles[0].columns.length).toBe(2);
-  });
+  }, 30_000);
+  // ^ 30s timeout (default 5s) — DuckDB native-module cold start +
+  // CSV ingest + profile blows past 5s when the full suite runs
+  // in parallel and the host is under contention (#2716). The test
+  // asserts behavior, not performance; the bump preserves coverage.
 });
 
 describe("column-level catch re-throw contract", () => {


### PR DESCRIPTION
## Summary

Closes #2710, #2776, #2716, #2694. Prerequisite for the 1.5.4 slice 6 cutover (#2802) — `bun test --parallel` shares workers across files and amplifies any test that wasn't fully self-contained.

- **discord + teams** (#2776 / #2710): drop the top-level env gate in `api/index.ts`. The route-mount conditional `if (process.env.DISCORD_CLIENT_ID)` and its `TEAMS_APP_ID` twin ran ONCE at module evaluation; because ESM modules are cached per realm, whichever env value was set on first import froze the routing decision for the rest of that worker's lifetime. In a shared-worker run, any sibling file that triggered `api/index.ts` evaluation while the env was unset left discord + teams routes unregistered for the entire worker — every subsequent test got 404 instead of 302/501/etc. The route handlers already read env at REQUEST time and return 501 when credentials are unset, so unconfigured deployments still get a discoverable 501. The top-level gate was redundant for behavior and load-bearing for the flake.
- **duckdb** (#2716): bump the "valid database profiles successfully" timeout to 30s. Cold-start native module + CSV ingest + profile is ~850ms in isolation but blows past 5s under parallel-suite contention. Test asserts behavior, not performance — bump preserves coverage.
- **rate-limit** (#2694): bump the "x-atlas-client-ip even when x-forwarded-for rotates" timeout to 15s. 11 sequential Better Auth handler invocations through the live rate-limit middleware blow past 5s when the api-tests shard is contended with the real-PG smoke tests added in #2655. Surrounding tests in the same file already use 15s for the same reason.

The discord/teams root cause matches the slice 3/4 pattern from #2813 (1.5.4 slices 0–5b) — module-level state read once at import time vs. mutated by tests' `beforeEach`, except here the state is the ROUTING DECISION rather than a singleton registry. Drop the import-time read, defer to the request-time check that was already present.

## Test plan

- [x] discord + teams pass together in both orders (12/12) — was 6 pass + 6 fail before
- [x] 5x consecutive `bun test --parallel` on all 3 api flakes — 23/23 each run
- [x] 5x consecutive isolated runs of DuckDB test — 30/30 each, ~440ms
- [x] 5x consecutive isolated runs of rate-limit-integration — 11/11 each, ~1.5s
- [x] All 120 api route tests pass via isolated runner
- [x] All 31 lib/auth tests pass via isolated runner
- [x] lint, type, schema-drift, test-discipline, ee-imports, template-drift, syncpack all green