### PR TITLE
fix(api): #2820 — rotate workspace_plugins.config JSONB secrets in F-47

### DIFF
--- a/apps/docs/content/docs/platform-ops/encryption-key-rotation.mdx
+++ b/apps/docs/content/docs/platform-ops/encryption-key-rotation.mdx
@@ -89,18 +89,28 @@ silently destroys every encrypted credential. Set a dedicated
    Deploy. Every new write now stamps ciphertext as `enc:v2:…`. Old
    rows still decrypt because v1 is still in the keyset.
 
-4. **Re-encrypt existing rows.** Run the rotation script — it walks
-   every encrypted column, decrypts under whichever keyset entry the
-   ciphertext carries, re-encrypts under v2, and stamps the companion
-   `_key_version` column.
+4. **Re-encrypt existing rows.** Run the rotation script — it walks:
+
+   - Every F-41 `*_encrypted` column (workspace_model_config + every
+     integration credential table), decrypts under whichever keyset
+     entry the ciphertext carries, re-encrypts under v2, and stamps
+     the companion `_key_version` column.
+   - Every selective-field secret inside `workspace_plugins.config`
+     JSONB (post-#2744). Datasource credentials and other plugin
+     secrets are walked via a JOIN against `plugin_catalog.config_schema`
+     — every catalog row's `secret: true` fields are re-encrypted
+     in-place. There is no companion `_key_version` column on the
+     JSONB row; idempotence is gated per-field on the `enc:v<N>:`
+     prefix instead.
 
    ```bash
    bun run packages/api/scripts/rotate-encryption-key.ts
    ```
 
-   The script is idempotent — it filters rows by
-   `<col>_key_version < $active`, so re-runs after partial progress
-   pick up where the previous run left off.
+   The script is idempotent for both shapes — column targets filter
+   rows by `<col>_key_version < $active`, and JSONB targets skip
+   fields whose prefix already names the active version. Re-runs
+   after partial progress pick up where the previous run left off.
 
 5. **Verify.** Each column-rotated table has a companion `*_key_version`
    column. The script should have left every row at the active version
@@ -161,11 +171,34 @@ silently destroys every encrypted credential. Set a dedicated
    -- Every row should report `below_active = 0`.
    ```
 
-   Note: datasource credentials live inside `workspace_plugins.config`
-   JSONB via selective-field encryption (post-#2744 cutover). They are
-   not column-rotated by this script — operators re-save the install
-   from `/admin/connections` to re-encrypt under the active key, or
-   wait for the next admin write to migrate organically.
+   Datasource credentials and other plugin secrets live inside
+   `workspace_plugins.config` JSONB via selective-field encryption
+   (post-#2744 cutover). They participate in the same rotation pass,
+   so the same script suffices — no per-install re-save needed. To
+   verify that every JSONB secret-field ciphertext is at v2, count
+   `enc:v<N>:` prefixes where `N < active` across every catalog row
+   whose schema marks a field `secret: true`:
+
+   ```sql
+   WITH plugin_secret_fields AS (
+     SELECT pc.id AS catalog_id,
+            jsonb_array_elements(pc.config_schema) ->> 'key' AS field_key,
+            (jsonb_array_elements(pc.config_schema) ->> 'secret')::boolean AS is_secret
+       FROM plugin_catalog pc
+      WHERE jsonb_typeof(pc.config_schema) = 'array'
+   )
+   SELECT 'workspace_plugins.config[secret-field]' AS col,
+          COUNT(*) FILTER (
+            WHERE wp.config ->> psf.field_key ~ '^enc:v[0-9]+:'
+              AND (SUBSTRING(wp.config ->> psf.field_key FROM 'enc:v(\d+):'))::int < 2
+          ) AS below_active
+     FROM workspace_plugins wp
+     JOIN plugin_secret_fields psf ON psf.catalog_id = wp.catalog_id
+    WHERE psf.is_secret = true;
+   -- Should report `below_active = 0`. A non-zero count means a JSONB
+   -- secret field is still pinned to a legacy key — re-run the
+   -- rotation script (or check exit code 2 for orphans before re-running).
+   ```
 
    The rotation script also exits `2` if any row was orphaned (stored
    ciphertext references a version missing from the keyset); if you
@@ -245,17 +278,22 @@ the escrow copy is a compromise target too.
 - [ ] Second deploy completed
 - [ ] `scripts/rotate-encryption-key.ts` run to completion
 - [ ] Per-column verification query shows `below_active = 0`
+- [ ] JSONB secret-field verification query shows `below_active = 0`
 - [ ] Legacy key dropped from config and revoked in the secret manager
 
 ## Known limitations
 
 - **OIDC SSO client secrets are not included in the rotation script.**
   `sso_providers.config` is a JSONB blob with the `clientSecret`
-  ciphertext embedded inside; rotating it requires walking the JSON
-  rather than a column-oriented UPDATE. Operators can re-save OIDC
-  provider configs via the admin UI after rotation to re-encrypt them
-  under the active key. The `enc:v<N>:` prefix keeps the ciphertext
-  readable as long as the legacy key stays in `ATLAS_ENCRYPTION_KEYS`.
+  ciphertext embedded under a hand-rolled field name, not the
+  catalog-driven `config_schema` walker that handles
+  `workspace_plugins.config`. Operators can re-save OIDC provider
+  configs via the admin UI after rotation to re-encrypt them under
+  the active key. The `enc:v<N>:` prefix keeps the ciphertext
+  readable as long as the legacy key stays in
+  `ATLAS_ENCRYPTION_KEYS`. (A future `oidc-jsonb` target kind would
+  close this gap; #2820 added the JSONB rotation shape it would
+  extend.)
 - **Dev-mode rows (no key configured) stamp `_key_version = 1`.** When
   no key is set, `encryptSecret` passes plaintext through unchanged,
   but the companion `_key_version` column still defaults to

--- a/packages/api/scripts/rotate-encryption-key.ts
+++ b/packages/api/scripts/rotate-encryption-key.ts
@@ -1,13 +1,24 @@
 /**
  * F-47 re-encryption script.
  *
- * Iterates every encrypted column in the internal database, decrypts
- * under whichever keyset entry the ciphertext carries, re-encrypts
- * under the active key, and stamps the companion `_key_version` column
- * with the new version.
+ * Two rotation shapes share the same operator entry point:
  *
- * Idempotent via the `<col>_key_version < $active` guard — rows already
- * at the active version are skipped. Safe to run repeatedly.
+ *   • **Column-oriented** — every F-41 `*_encrypted` column (Teams,
+ *     Discord, Telegram, gchat, GitHub, Linear, WhatsApp, Email,
+ *     Sandbox, sub-processor subscriptions, integration_credentials,
+ *     Twenty CRM, workspace_model_config). One ciphertext per row,
+ *     gated by a companion `_key_version` column for cheap idempotent
+ *     re-runs (`WHERE <col>_key_version < $active`).
+ *
+ *   • **JSONB selective-field** — `workspace_plugins.config` post-#2744
+ *     cutover. Datasource credentials and every other plugin secret
+ *     (Linear api_key #2750, GitHub-PAT #2807, …) live inside the JSONB
+ *     blob, with the catalog row's `config_schema` `secret: true` flag
+ *     driving which fields to walk. No companion `_key_version` column
+ *     — idempotence is gated per-field on the `enc:v<N>:` prefix.
+ *
+ * Safe to run repeatedly: both shapes skip rows that are already at the
+ * active version.
  *
  * Usage:
  *   # Before: ATLAS_ENCRYPTION_KEYS carries the new key in position 0.
@@ -20,15 +31,12 @@
  *
  * Not covered by this script (by design):
  *   • OIDC `sso_providers.config` — `clientSecret` is encrypted inside
- *     a JSONB blob with no companion `_key_version` column, so the
- *     column-oriented UPDATE pattern here doesn't apply. The ciphertext
- *     carries the `enc:v<N>:` prefix so it stays readable while the
- *     legacy key is in the keyset. Operators re-save OIDC configs via
- *     admin UI to re-encrypt them under the active key.
- *   • Integration tests against a seeded DB — this file's unit tests
- *     use a mock pg client to pin per-row behavior. An end-to-end test
- *     against the live migration + row fixtures is worthwhile future
- *     work, but not currently wired up.
+ *     a JSONB blob keyed by a hand-rolled `clientSecret` field, not the
+ *     catalog-driven selective-field walker. The ciphertext carries
+ *     the `enc:v<N>:` prefix so it stays readable while the legacy key
+ *     is in the keyset. Operators re-save OIDC configs via admin UI to
+ *     re-encrypt them under the active key. A future generalization
+ *     (`oidc-jsonb` target kind) would close this gap.
  */
 
 import { Pool, type PoolClient } from "pg";
@@ -47,6 +55,7 @@ import {
   INTEGRATION_TABLES,
   type IntegrationTable,
 } from "@atlas/api/lib/db/integration-tables";
+import { parseConfigSchema } from "@atlas/api/lib/plugins/secrets";
 
 const log = createLogger("rotate-encryption-key");
 
@@ -55,27 +64,73 @@ const log = createLogger("rotate-encryption-key");
 // ---------------------------------------------------------------------------
 
 /**
- * A column whose ciphertext the rotation script should re-encrypt. Every
- * rotation target uses the `db/secret-encryption.ts` helper pair
- * (versioned-prefix-only `encryptSecret` / `decryptSecret`).
- *
- * Pre-1.5.3 the script also rotated `connections.url` via the URL-aware
- * `db/internal.ts` helper (with plaintext `postgres://…` first-time
- * encryption fallback). That table was dropped in 0096 / #2744 per
- * ADR-0007; datasource URLs now live inside `workspace_plugins.config`
- * JSONB and are not in scope for this column-oriented rotation pass.
- * The two remaining `db/internal.ts` consumers (`workspace_model_config`,
- * `sso_providers`) read identically through the versioned-prefix
- * decryptor — ciphertext format is shared across both helper pairs.
+ * Column-oriented rotation target — the F-41 shape. One encrypted
+ * column per row, with a companion `_key_version` column used to gate
+ * idempotent re-runs (`WHERE <col>_key_version < $active`).
  */
-type RotateTarget = IntegrationTable;
+interface ColumnTarget extends IntegrationTable {
+  readonly kind: "column";
+}
+
+/**
+ * Selective-field-inside-JSONB rotation target — the post-#2744 shape.
+ * `workspace_plugins.config` is a JSONB blob; the catalog row's
+ * `config_schema` declares which fields are `secret: true`. Those
+ * ciphertext values carry the `enc:v<N>:` prefix per field, and there
+ * is no companion `_key_version` column — idempotence is gated on the
+ * prefix itself (an `enc:v<N>:` value with N < active triggers
+ * rotation; anything at the active version is a no-op).
+ *
+ * The JOIN against `plugin_catalog` makes the rotation generic across
+ * every plugin install: datasource URLs (slice 5 / #2744), Linear
+ * api_key (#2750), GitHub-PAT (#2807), and every future
+ * selective-field secret all get covered by the same walk.
+ */
+interface JsonbSelectiveFieldTarget {
+  readonly kind: "jsonb-selective-field";
+  /** Table holding the JSONB column (`workspace_plugins`). */
+  readonly table: string;
+  /** Primary-key column used to scope per-row UPDATEs. */
+  readonly pk: string;
+  /** JSONB column carrying selective-field-encrypted secrets (`config`). */
+  readonly jsonbColumn: string;
+  /** FK column joining to the catalog table (`catalog_id`). */
+  readonly catalogIdColumn: string;
+  /** Catalog table (`plugin_catalog`). */
+  readonly catalogTable: string;
+  /** Catalog PK column referenced by `catalogIdColumn` (`id`). */
+  readonly catalogPk: string;
+  /** Catalog JSONB column carrying the per-plugin schema (`config_schema`). */
+  readonly catalogSchemaColumn: string;
+}
+
+/**
+ * A rotation target. Two shapes today (column / JSONB selective-field);
+ * a third (`oidc-jsonb`) is plausible if `sso_providers.config.clientSecret`
+ * ever needs to participate without a manual admin re-save.
+ */
+type RotateTarget = ColumnTarget | JsonbSelectiveFieldTarget;
 
 const ROTATION_TABLES: readonly RotateTarget[] = [
-  { table: "workspace_model_config", pk: "id", encrypted: "api_key_encrypted", keyVersionColumn: "api_key_key_version" },
+  { kind: "column", table: "workspace_model_config", pk: "id", encrypted: "api_key_encrypted", keyVersionColumn: "api_key_key_version" },
   // Derive from F-41's INTEGRATION_TABLES so adding a new integration
   // in one place covers rotation, audit, and any future column-walking
   // tooling — matches the "single source of truth" convention.
-  ...INTEGRATION_TABLES,
+  ...INTEGRATION_TABLES.map((t) => ({ kind: "column" as const, ...t })),
+  // 0096 / #2744 — datasource credentials live inside this JSONB column
+  // post-cutover. Coverage is generic via `plugin_catalog.config_schema`:
+  // every future plugin install that flags a field `secret: true` is
+  // rotated by the same walk (no per-integration entry needed here).
+  {
+    kind: "jsonb-selective-field",
+    table: "workspace_plugins",
+    pk: "id",
+    jsonbColumn: "config",
+    catalogIdColumn: "catalog_id",
+    catalogTable: "plugin_catalog",
+    catalogPk: "id",
+    catalogSchemaColumn: "config_schema",
+  },
 ];
 
 // Parameterize table / column names into validated identifiers — we
@@ -146,12 +201,13 @@ export interface RotateResult {
 }
 
 /**
- * Re-encrypt every row in one table whose `_key_version < $active`.
- * Runs in a single transaction — mid-batch failure rolls back cleanly.
+ * Re-encrypt every row in one column-shaped table whose
+ * `_key_version < $active`. Runs in a single transaction — mid-batch
+ * failure rolls back cleanly.
  */
 export async function rotateTable(
   client: PoolClient,
-  target: RotateTarget,
+  target: ColumnTarget,
   activeVersion: number,
 ): Promise<RotateResult> {
   assertIdentifier(target.table, "table");
@@ -231,6 +287,205 @@ export async function rotateTable(
 }
 
 // ---------------------------------------------------------------------------
+// JSONB selective-field rotation (workspace_plugins.config post-#2744)
+// ---------------------------------------------------------------------------
+
+/**
+ * Capture the `<N>` from an `enc:v<N>:` prefix without buying into the
+ * full body parse — cheap idempotence gate inside the per-field loop.
+ * Production reads rely on `decryptSecret`'s parse; this regex stays
+ * separate so a malformed body still routes through the orphan path
+ * via the `decryptSecret` throw, not silently here.
+ */
+const VERSION_PREFIX_RE = /^enc:v(\d+):/;
+
+/**
+ * Re-encrypt every `secret: true` field inside a JSONB column whose
+ * ciphertext is at a version below the active key. Catalog-driven —
+ * the rotation set per row is determined by joining to `plugin_catalog`
+ * and parsing `config_schema`, so a future plugin that declares a new
+ * `secret: true` field is covered without code changes here.
+ *
+ * Row-level outcome accounting (matches `rotateTable` for symmetry):
+ *
+ *   • `updated`     — row had ≥1 secret field rotated, no errors. One
+ *                     UPDATE issued with the merged JSONB.
+ *   • `orphaned`    — row had ≥1 secret field whose ciphertext could not
+ *                     be decrypted (legacy key missing from keyset). No
+ *                     UPDATE issued for the row — partial rotation
+ *                     would leave the row at mixed versions; safer to
+ *                     refuse until the operator re-adds the legacy key.
+ *   • `unprefixed`  — row had ≥1 non-empty secret field whose value
+ *                     lacked the `enc:v<N>:` prefix. Either legacy
+ *                     plaintext or corrupted prefix; both refuse
+ *                     rotation. No UPDATE issued for the row.
+ *   • `skippedEmpty` — row had no secret fields (schema absent, empty
+ *                      catalog schema, or no secret-marked field had a
+ *                      non-empty string value), or every secret field
+ *                      was already at the active version. Idempotent
+ *                      re-runs land all rows here.
+ *
+ * Worst-outcome wins per row: a row with both an orphan and a
+ * rotatable field is counted as `orphaned` and not updated. Operator
+ * fixes the keyset and re-runs to converge.
+ *
+ * Runs in a single transaction — mid-batch UPDATE failure rolls back.
+ */
+export async function rotateJsonbSelectiveField(
+  client: PoolClient,
+  target: JsonbSelectiveFieldTarget,
+  activeVersion: number,
+): Promise<RotateResult> {
+  assertIdentifier(target.table, "table");
+  assertIdentifier(target.pk, "pk");
+  assertIdentifier(target.jsonbColumn, "jsonbColumn");
+  assertIdentifier(target.catalogIdColumn, "catalogIdColumn");
+  assertIdentifier(target.catalogTable, "catalogTable");
+  assertIdentifier(target.catalogPk, "catalogPk");
+  assertIdentifier(target.catalogSchemaColumn, "catalogSchemaColumn");
+
+  try {
+    await client.query("BEGIN");
+
+    // No row-level filter analogous to `<col>_key_version < $active`
+    // for column targets — the version is embedded per-field inside
+    // the JSONB blob, so we walk every row and gate per-field below.
+    // Bounded by workspace × installs (sub-100k in practice).
+    const rows = (
+      await client.query(
+        `SELECT t.${target.pk} AS pk,
+                t.${target.jsonbColumn} AS config,
+                c.${target.catalogSchemaColumn} AS config_schema
+           FROM ${target.table} t
+           JOIN ${target.catalogTable} c
+             ON c.${target.catalogPk} = t.${target.catalogIdColumn}`,
+      )
+    ).rows as Array<{ pk: string; config: unknown; config_schema: unknown }>;
+
+    let updated = 0;
+    let skippedEmpty = 0;
+    let orphaned = 0;
+    let unprefixed = 0;
+    for (const row of rows) {
+      // A drifted JSONB shape (non-object) gets skipped — same posture
+      // as the masking / encryption walkers in `lib/plugins/secrets.ts`.
+      if (row.config == null || typeof row.config !== "object" || Array.isArray(row.config)) {
+        skippedEmpty += 1;
+        continue;
+      }
+      const config = row.config as Record<string, unknown>;
+      const schema = parseConfigSchema(row.config_schema);
+
+      // Fields to walk. `corrupt` falls back to every string field —
+      // mirrors `encryptSecretFields`' fail-closed posture. `absent`
+      // / empty: nothing to rotate.
+      const secretKeys = pickSecretKeysForRotation(schema, config);
+      if (secretKeys.length === 0) {
+        skippedEmpty += 1;
+        continue;
+      }
+
+      const merged: Record<string, unknown> = { ...config };
+      let rowUpdated = false;
+      let rowOrphaned = false;
+      let rowUnprefixed = false;
+
+      for (const key of secretKeys) {
+        const value = config[key];
+        if (typeof value !== "string" || value.length === 0) continue;
+
+        if (!hasVersionedPrefix(value)) {
+          // Legacy plaintext or corrupted prefix. Refuse — same
+          // reasoning as the column path's `unprefixed` counter.
+          log.error(
+            { table: target.table, pk: row.pk, field: key },
+            "JSONB secret field missing enc:v<N>: prefix — manual intervention required",
+          );
+          rowUnprefixed = true;
+          continue;
+        }
+
+        // Cheap idempotence: parse `enc:v<N>:` once, skip if N is
+        // already active. Avoids a decrypt + re-encrypt round-trip on
+        // already-rotated fields and lets the re-run walk be entirely
+        // allocation-free for healthy rows.
+        const versionMatch = value.match(VERSION_PREFIX_RE);
+        if (versionMatch && Number.parseInt(versionMatch[1], 10) >= activeVersion) {
+          continue;
+        }
+
+        try {
+          merged[key] = encryptSecret(decryptSecret(value));
+          rowUpdated = true;
+        } catch (err) {
+          log.error(
+            { table: target.table, pk: row.pk, field: key, err },
+            "Failed to rotate JSONB secret field — legacy key likely dropped from ATLAS_ENCRYPTION_KEYS",
+          );
+          rowOrphaned = true;
+        }
+      }
+
+      // Worst-outcome wins per row. Orphan beats unprefixed beats
+      // updated, because the remediation order matches: fix the
+      // keyset first (orphan), then re-save through admin UI to clear
+      // unprefixed fields, then re-run rotation to land updates.
+      if (rowOrphaned) {
+        orphaned += 1;
+      } else if (rowUnprefixed) {
+        unprefixed += 1;
+      } else if (rowUpdated) {
+        await client.query(
+          `UPDATE ${target.table}
+             SET ${target.jsonbColumn} = $1::jsonb
+           WHERE ${target.pk} = $2`,
+          [JSON.stringify(merged), row.pk],
+        );
+        updated += 1;
+      } else {
+        // Every secret field was already at the active version —
+        // typical for idempotent re-runs.
+        skippedEmpty += 1;
+      }
+    }
+
+    await client.query("COMMIT");
+    return { table: target.table, scanned: rows.length, updated, skippedEmpty, orphaned, unprefixed };
+  } catch (err) {
+    await client.query("ROLLBACK").catch(() => {
+      // Rollback failure is secondary — the original error is what matters.
+    });
+    throw err;
+  }
+}
+
+/**
+ * Resolve the set of config keys this rotation pass should walk. Mirrors
+ * `encryptSecretFields` (`lib/plugins/secrets.ts`) so the rotation
+ * surface and the write path can't drift apart:
+ *
+ *   • `absent` / `parsed` with no `secret: true` fields → empty (nothing
+ *     to rotate; the row's config is entirely non-secret).
+ *   • `parsed` with secret fields → those keys.
+ *   • `corrupt` → every string-valued key in the config blob. Fail
+ *     closed — the catalog schema is broken and we can't trust the
+ *     `secret: true` flag, so rotate every string just like the write
+ *     path encrypts every string.
+ */
+function pickSecretKeysForRotation(
+  schema: ReturnType<typeof parseConfigSchema>,
+  config: Record<string, unknown>,
+): string[] {
+  if (schema.state === "corrupt") {
+    // Every string field — broad but matches the write path's
+    // fail-closed encrypt-every-string behavior.
+    return Object.keys(config).filter((k) => typeof config[k] === "string");
+  }
+  if (schema.state === "absent" || schema.fields.length === 0) return [];
+  return schema.fields.filter((f) => f.secret === true).map((f) => f.key);
+}
+
+// ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
 
@@ -292,8 +547,11 @@ async function main(): Promise<void> {
     for (const target of ROTATION_TABLES) {
       const client = await pool.connect();
       try {
-        log.info({ table: target.table }, "rotate starting");
-        const result = await rotateTable(client, target, active);
+        log.info({ table: target.table, kind: target.kind }, "rotate starting");
+        const result =
+          target.kind === "column"
+            ? await rotateTable(client, target, active)
+            : await rotateJsonbSelectiveField(client, target, active);
         totalUpdated += result.updated;
         totalSkippedEmpty += result.skippedEmpty;
         totalOrphaned += result.orphaned;

--- a/packages/api/scripts/rotate-encryption-key.ts
+++ b/packages/api/scripts/rotate-encryption-key.ts
@@ -351,6 +351,13 @@ export async function rotateJsonbSelectiveField(
     // for column targets — the version is embedded per-field inside
     // the JSONB blob, so we walk every row and gate per-field below.
     // Bounded by workspace × installs (sub-100k in practice).
+    //
+    // FOR UPDATE OF t holds row locks on the target table for the
+    // duration of this transaction so a concurrent admin save / OAuth
+    // token refresh can't land between our read and the whole-blob
+    // UPDATE below — without it, the stale `merged` payload would
+    // silently overwrite the concurrent change. We don't lock the
+    // catalog (`OF t` only) because catalog rows aren't being mutated.
     const rows = (
       await client.query(
         `SELECT t.${target.pk} AS pk,
@@ -358,7 +365,8 @@ export async function rotateJsonbSelectiveField(
                 c.${target.catalogSchemaColumn} AS config_schema
            FROM ${target.table} t
            JOIN ${target.catalogTable} c
-             ON c.${target.catalogPk} = t.${target.catalogIdColumn}`,
+             ON c.${target.catalogPk} = t.${target.catalogIdColumn}
+           FOR UPDATE OF t`,
       )
     ).rows as Array<{ pk: string; config: unknown; config_schema: unknown }>;
 
@@ -467,19 +475,28 @@ export async function rotateJsonbSelectiveField(
  *   • `absent` / `parsed` with no `secret: true` fields → empty (nothing
  *     to rotate; the row's config is entirely non-secret).
  *   • `parsed` with secret fields → those keys.
- *   • `corrupt` → every string-valued key in the config blob. Fail
- *     closed — the catalog schema is broken and we can't trust the
- *     `secret: true` flag, so rotate every string just like the write
- *     path encrypts every string.
+ *   • `corrupt` → every string-valued key carrying an `enc:v<N>:`
+ *     prefix. Fail closed but rotate-asymmetric: the write path
+ *     encrypts every string on a corrupt schema (it has plaintext to
+ *     work with), but the rotate path can only rotate values that are
+ *     already ciphertext. Including plaintext non-secrets (e.g.
+ *     `name`, `region`) would flag them as `unprefixed`, blocking the
+ *     whole row from rotating its legitimate ciphertext. See Codex
+ *     review on #2832 and #2820 acceptance criterion.
  */
 function pickSecretKeysForRotation(
   schema: ReturnType<typeof parseConfigSchema>,
   config: Record<string, unknown>,
 ): string[] {
   if (schema.state === "corrupt") {
-    // Every string field — broad but matches the write path's
-    // fail-closed encrypt-every-string behavior.
-    return Object.keys(config).filter((k) => typeof config[k] === "string");
+    // Only fields that are already ciphertext — plaintext non-secrets
+    // on a corrupt-schema row are not in scope for rotation. If a
+    // field genuinely was a broken secret (lost its prefix), the
+    // operator must fix the catalog schema first, then re-run.
+    return Object.keys(config).filter((k) => {
+      const v = config[k];
+      return typeof v === "string" && hasVersionedPrefix(v);
+    });
   }
   if (schema.state === "absent" || schema.fields.length === 0) return [];
   return schema.fields.filter((f) => f.secret === true).map((f) => f.key);

--- a/packages/api/src/lib/db/__tests__/rotate-encryption-key.test.ts
+++ b/packages/api/src/lib/db/__tests__/rotate-encryption-key.test.ts
@@ -501,11 +501,14 @@ describe("rotateJsonbSelectiveField (F-47 JSONB selective-field rotation)", () =
     expect(queries.filter((q) => q.sql.startsWith("UPDATE"))).toHaveLength(0);
   });
 
-  it("fail-closed on corrupt config_schema — encrypts every string field", async () => {
-    // Mirrors `encryptSecretFields` fail-closed posture: if the
-    // catalog's `config_schema` is unparseable, treat every string as
-    // a potential secret. Operator should fix the catalog row, but in
-    // the meantime over-encryption is safer than missing a credential.
+  it("corrupt config_schema — rotates already-encrypted strings, leaves plaintext non-secrets alone", async () => {
+    // The rotate path is asymmetric with the write path on corrupt
+    // schemas: the write path encrypts every string fail-closed (it
+    // has plaintext to work with), but rotate can only re-encrypt
+    // values that already carry `enc:v<N>:`. Treating plaintext
+    // non-secrets (e.g. `name`, `region`) as candidate-secrets would
+    // flag them as `unprefixed` and block the row from rotating its
+    // legitimate ciphertext. See Codex review on #2832.
     process.env.ATLAS_ENCRYPTION_KEYS = "v1:old-raw";
     _resetEncryptionKeyCache();
     const v1Token = encryptSecret("rotatable-under-v1");
@@ -516,7 +519,10 @@ describe("rotateJsonbSelectiveField (F-47 JSONB selective-field rotation)", () =
     const { client, queries } = createJsonbMockClient([
       {
         pk: "wp_corrupt",
-        config: { token: v1Token, port: 5432 },
+        // Mixed shape: one ciphertext (token), one plaintext non-secret
+        // (name), one non-string (port). Pre-fix, `name` landed in the
+        // `unprefixed` bucket and blocked the row entirely.
+        config: { token: v1Token, name: "prod-us", port: 5432 },
         // Not an array — `parseConfigSchema` flags this as `corrupt`.
         config_schema: { broken: true },
       },
@@ -526,11 +532,17 @@ describe("rotateJsonbSelectiveField (F-47 JSONB selective-field rotation)", () =
 
     expect(result.scanned).toBe(1);
     expect(result.updated).toBe(1);
+    // `name` must NOT be classified as unprefixed — it's plaintext on
+    // a corrupt-schema row and presumed to be a non-secret.
+    expect(result.unprefixed).toBe(0);
+    expect(result.orphaned).toBe(0);
     const updates = queries.filter((q) => q.sql.startsWith("UPDATE"));
     expect(updates).toHaveLength(1);
     const merged = JSON.parse(String(updates[0].params![0])) as Record<string, unknown>;
-    // String field rotated despite the schema corruption.
+    // Ciphertext rotated despite the schema corruption.
     expect(String(merged.token)).toMatch(/^enc:v2:/);
+    // Plaintext non-secret preserved verbatim by the JSONB merge.
+    expect(merged.name).toBe("prod-us");
     // Non-string field untouched.
     expect(merged.port).toBe(5432);
   });

--- a/packages/api/src/lib/db/__tests__/rotate-encryption-key.test.ts
+++ b/packages/api/src/lib/db/__tests__/rotate-encryption-key.test.ts
@@ -8,9 +8,15 @@
  * guard that makes the script safe to run repeatedly.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from "bun:test";
-import { rotateTable, UnprefixedSecretError } from "../../../../scripts/rotate-encryption-key";
-import { _resetEncryptionKeyCache } from "../internal";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test";
+import { Pool } from "pg";
+import {
+  rotateJsonbSelectiveField,
+  rotateTable,
+  UnprefixedSecretError,
+} from "../../../../scripts/rotate-encryption-key";
+import { _resetEncryptionKeyCache, MANAGED_AUTH_MIGRATIONS } from "../internal";
+import { runMigrations } from "../migrate";
 import {
   encryptSecret,
   decryptSecret,
@@ -62,6 +68,7 @@ describe("rotateTable (F-47 re-encryption)", () => {
 
     const { client, queries } = createMockClient([{ pk: "T1", encrypted: legacyCiphertext }]);
     const result = await rotateTable(client, {
+      kind: "column",
       table: "slack_installations",
       pk: "team_id",
       encrypted: "bot_token_encrypted",
@@ -95,6 +102,7 @@ describe("rotateTable (F-47 re-encryption)", () => {
     const { client, queries } = createMockClient([]);
 
     await rotateTable(client, {
+      kind: "column",
       table: "slack_installations",
       pk: "team_id",
       encrypted: "bot_token_encrypted",
@@ -127,6 +135,7 @@ describe("rotateTable (F-47 re-encryption)", () => {
       { pk: "healthy", encrypted: healthy },
     ]);
     const result = await rotateTable(client, {
+      kind: "column",
       table: "slack_installations",
       pk: "team_id",
       encrypted: "bot_token_encrypted",
@@ -158,6 +167,7 @@ describe("rotateTable (F-47 re-encryption)", () => {
       { pk: "nully", encrypted: null as unknown as string },
     ]);
     const result = await rotateTable(client, {
+      kind: "column",
       table: "slack_installations",
       pk: "team_id",
       encrypted: "bot_token_encrypted",
@@ -189,6 +199,7 @@ describe("rotateTable (F-47 re-encryption)", () => {
     ]);
 
     const result = await rotateTable(client, {
+      kind: "column",
       table: "workspace_model_config",
       pk: "id",
       encrypted: "api_key_encrypted",
@@ -221,6 +232,7 @@ describe("rotateTable (F-47 re-encryption)", () => {
     const { client } = createMockClient([]);
     await expect(
       rotateTable(client, {
+        kind: "column",
         table: "slack_installations; DROP TABLE x",
         pk: "team_id",
         encrypted: "bot_token_encrypted",
@@ -260,6 +272,7 @@ describe("rotateTable (F-47 re-encryption)", () => {
 
     await expect(
       rotateTable(client, {
+        kind: "column",
         table: "slack_installations",
         pk: "team_id",
         encrypted: "bot_token_encrypted",
@@ -271,4 +284,518 @@ describe("rotateTable (F-47 re-encryption)", () => {
       queries.map((q) => q.sql).filter((s) => s === "BEGIN" || s === "COMMIT" || s === "ROLLBACK"),
     ).toEqual(["BEGIN", "ROLLBACK"]);
   });
+});
+
+// ---------------------------------------------------------------------------
+// rotateJsonbSelectiveField — workspace_plugins.config post-#2744
+// ---------------------------------------------------------------------------
+
+/**
+ * Mock pg client for JSONB rotation. The SELECT returns rows shaped
+ * like the production JOIN (`{ pk, config, config_schema }`); UPDATE
+ * captures params so the test can assert the merged JSONB payload.
+ */
+function createJsonbMockClient(
+  selectRows: Array<{ pk: string; config: unknown; config_schema: unknown }>,
+) {
+  const queries: Array<{ sql: string; params?: unknown[] }> = [];
+  return {
+    queries,
+    client: {
+      query: async (sql: string, params?: unknown[]) => {
+        queries.push({ sql, params });
+        if (sql.startsWith("SELECT")) return { rows: selectRows };
+        return { rows: [] };
+      },
+      release: () => {},
+    } as unknown as import("pg").PoolClient,
+  };
+}
+
+const JSONB_TARGET = {
+  kind: "jsonb-selective-field" as const,
+  table: "workspace_plugins",
+  pk: "id",
+  jsonbColumn: "config",
+  catalogIdColumn: "catalog_id",
+  catalogTable: "plugin_catalog",
+  catalogPk: "id",
+  catalogSchemaColumn: "config_schema",
+};
+
+describe("rotateJsonbSelectiveField (F-47 JSONB selective-field rotation)", () => {
+  const savedKey = process.env.ATLAS_ENCRYPTION_KEY;
+  const savedKeys = process.env.ATLAS_ENCRYPTION_KEYS;
+
+  beforeEach(() => {
+    delete process.env.ATLAS_ENCRYPTION_KEY;
+    delete process.env.ATLAS_ENCRYPTION_KEYS;
+    _resetEncryptionKeyCache();
+  });
+
+  afterEach(() => {
+    if (savedKey !== undefined) process.env.ATLAS_ENCRYPTION_KEY = savedKey;
+    else delete process.env.ATLAS_ENCRYPTION_KEY;
+    if (savedKeys !== undefined) process.env.ATLAS_ENCRYPTION_KEYS = savedKeys;
+    else delete process.env.ATLAS_ENCRYPTION_KEYS;
+    _resetEncryptionKeyCache();
+  });
+
+  it("re-encrypts a v1 secret field under v2 and preserves non-secret fields", async () => {
+    // Phase A — encrypt under v1.
+    process.env.ATLAS_ENCRYPTION_KEYS = "v1:old-raw";
+    _resetEncryptionKeyCache();
+    const v1Url = encryptSecret("postgres://user:pw@host:5432/db");
+
+    // Phase B — rotate.
+    process.env.ATLAS_ENCRYPTION_KEYS = "v2:new-raw,v1:old-raw";
+    _resetEncryptionKeyCache();
+
+    const { client, queries } = createJsonbMockClient([
+      {
+        pk: "wp_abc",
+        config: { url: v1Url, name: "prod-us", port: 5432 },
+        config_schema: [
+          { key: "url", type: "string", secret: true },
+          { key: "name", type: "string" },
+          { key: "port", type: "number" },
+        ],
+      },
+    ]);
+
+    const result = await rotateJsonbSelectiveField(client, JSONB_TARGET, 2);
+
+    expect(result.table).toBe("workspace_plugins");
+    expect(result.scanned).toBe(1);
+    expect(result.updated).toBe(1);
+    expect(result.skippedEmpty).toBe(0);
+    expect(result.orphaned).toBe(0);
+    expect(result.unprefixed).toBe(0);
+
+    const updates = queries.filter((q) => q.sql.startsWith("UPDATE"));
+    expect(updates).toHaveLength(1);
+    const merged = JSON.parse(String(updates[0].params![0])) as Record<string, unknown>;
+    expect(String(merged.url)).toMatch(/^enc:v2:/);
+    // Non-secret fields preserved verbatim.
+    expect(merged.name).toBe("prod-us");
+    expect(merged.port).toBe(5432);
+    expect(updates[0].params![1]).toBe("wp_abc");
+
+    // Round-trip: the re-encrypted ciphertext decrypts back to the original.
+    expect(decryptSecret(String(merged.url))).toBe("postgres://user:pw@host:5432/db");
+  });
+
+  it("is idempotent — a v2-already-encrypted row is a skippedEmpty no-op", async () => {
+    // Production wins here: re-running rotation against a cleanly-rotated
+    // DB must not issue UPDATEs (otherwise the script wastes write
+    // bandwidth and clutters the audit log). Pin this hard.
+    process.env.ATLAS_ENCRYPTION_KEYS = "v2:new-raw,v1:old-raw";
+    _resetEncryptionKeyCache();
+    const v2Url = encryptSecret("postgres://already-rotated");
+
+    const { client, queries } = createJsonbMockClient([
+      {
+        pk: "wp_clean",
+        config: { url: v2Url },
+        config_schema: [{ key: "url", type: "string", secret: true }],
+      },
+    ]);
+
+    const result = await rotateJsonbSelectiveField(client, JSONB_TARGET, 2);
+
+    expect(result.scanned).toBe(1);
+    expect(result.updated).toBe(0);
+    expect(result.skippedEmpty).toBe(1);
+    expect(queries.filter((q) => q.sql.startsWith("UPDATE"))).toHaveLength(0);
+  });
+
+  it("skips rows whose schema has no secret fields (skippedEmpty)", async () => {
+    // A catalog row with `config_schema` declared but no `secret: true`
+    // field has nothing to rotate. The row still SELECTs but never
+    // UPDATEs — keeps the JOIN pattern cheap when most rows are
+    // configuration-only (e.g. dashboard layout plugins).
+    process.env.ATLAS_ENCRYPTION_KEYS = "v2:new,v1:old";
+    _resetEncryptionKeyCache();
+
+    const { client, queries } = createJsonbMockClient([
+      {
+        pk: "wp_nosecret",
+        config: { region: "us-east-1", tier: "standard" },
+        config_schema: [
+          { key: "region", type: "string" },
+          { key: "tier", type: "string" },
+        ],
+      },
+    ]);
+
+    const result = await rotateJsonbSelectiveField(client, JSONB_TARGET, 2);
+
+    expect(result.scanned).toBe(1);
+    expect(result.skippedEmpty).toBe(1);
+    expect(result.updated).toBe(0);
+    expect(queries.filter((q) => q.sql.startsWith("UPDATE"))).toHaveLength(0);
+  });
+
+  it("counts an orphan row as orphaned and refuses to partial-update", async () => {
+    // Encrypt one secret field under a ghost key, another under the
+    // active reader. Row has BOTH a rotatable and an orphan field.
+    // Worst-outcome-wins: the row is counted as `orphaned` and no
+    // UPDATE issued — partial rotation would leave mixed versions.
+    process.env.ATLAS_ENCRYPTION_KEYS = "v3:ghost";
+    _resetEncryptionKeyCache();
+    const orphan = encryptSecret("orphaned-secret");
+
+    process.env.ATLAS_ENCRYPTION_KEYS = "v4:fresh";
+    _resetEncryptionKeyCache();
+    const healthy = encryptSecret("rotatable-secret");
+
+    process.env.ATLAS_ENCRYPTION_KEYS = "v5:newer,v4:fresh";
+    _resetEncryptionKeyCache();
+
+    const { client, queries } = createJsonbMockClient([
+      {
+        pk: "wp_orphan_row",
+        config: { token_a: orphan, token_b: healthy },
+        config_schema: [
+          { key: "token_a", type: "string", secret: true },
+          { key: "token_b", type: "string", secret: true },
+        ],
+      },
+    ]);
+
+    const result = await rotateJsonbSelectiveField(client, JSONB_TARGET, 5);
+
+    expect(result.scanned).toBe(1);
+    expect(result.orphaned).toBe(1);
+    expect(result.updated).toBe(0);
+    expect(result.unprefixed).toBe(0);
+    expect(result.skippedEmpty).toBe(0);
+    // No UPDATE issued — operator must add v3:ghost back to the keyset
+    // and re-run before the row converges.
+    expect(queries.filter((q) => q.sql.startsWith("UPDATE"))).toHaveLength(0);
+  });
+
+  it("counts an unprefixed-secret-field row as unprefixed (no UPDATE)", async () => {
+    // A `secret: true` field that holds a legacy-plaintext value (or
+    // a corrupted prefix) gets the same refuse-and-flag treatment as
+    // the column path. The script never silently re-encrypts an
+    // un-prefixed string — round-tripping decrypt→encrypt would emit
+    // ciphertext-of-the-broken-string with no recovery path.
+    process.env.ATLAS_ENCRYPTION_KEYS = "v2:new,v1:old";
+    _resetEncryptionKeyCache();
+
+    const { client, queries } = createJsonbMockClient([
+      {
+        pk: "wp_legacy_pt",
+        config: { api_key: "sk-just-a-raw-key" },
+        config_schema: [{ key: "api_key", type: "string", secret: true }],
+      },
+    ]);
+
+    const result = await rotateJsonbSelectiveField(client, JSONB_TARGET, 2);
+
+    expect(result.scanned).toBe(1);
+    expect(result.unprefixed).toBe(1);
+    expect(result.updated).toBe(0);
+    expect(result.orphaned).toBe(0);
+    expect(queries.filter((q) => q.sql.startsWith("UPDATE"))).toHaveLength(0);
+  });
+
+  it("fail-closed on corrupt config_schema — encrypts every string field", async () => {
+    // Mirrors `encryptSecretFields` fail-closed posture: if the
+    // catalog's `config_schema` is unparseable, treat every string as
+    // a potential secret. Operator should fix the catalog row, but in
+    // the meantime over-encryption is safer than missing a credential.
+    process.env.ATLAS_ENCRYPTION_KEYS = "v1:old-raw";
+    _resetEncryptionKeyCache();
+    const v1Token = encryptSecret("rotatable-under-v1");
+
+    process.env.ATLAS_ENCRYPTION_KEYS = "v2:new-raw,v1:old-raw";
+    _resetEncryptionKeyCache();
+
+    const { client, queries } = createJsonbMockClient([
+      {
+        pk: "wp_corrupt",
+        config: { token: v1Token, port: 5432 },
+        // Not an array — `parseConfigSchema` flags this as `corrupt`.
+        config_schema: { broken: true },
+      },
+    ]);
+
+    const result = await rotateJsonbSelectiveField(client, JSONB_TARGET, 2);
+
+    expect(result.scanned).toBe(1);
+    expect(result.updated).toBe(1);
+    const updates = queries.filter((q) => q.sql.startsWith("UPDATE"));
+    expect(updates).toHaveLength(1);
+    const merged = JSON.parse(String(updates[0].params![0])) as Record<string, unknown>;
+    // String field rotated despite the schema corruption.
+    expect(String(merged.token)).toMatch(/^enc:v2:/);
+    // Non-string field untouched.
+    expect(merged.port).toBe(5432);
+  });
+
+  it("absent config_schema (null) skips the row entirely", async () => {
+    // Catalog rows with `config_schema = NULL` (no selective-field
+    // contract) get walked but yield no rotation work. Distinct from
+    // the `corrupt` branch — `null` is a legitimate "no schema",
+    // `corrupt` is "schema column is broken".
+    process.env.ATLAS_ENCRYPTION_KEYS = "v1:old";
+    _resetEncryptionKeyCache();
+    const cipher = encryptSecret("secret");
+
+    process.env.ATLAS_ENCRYPTION_KEYS = "v2:new,v1:old";
+    _resetEncryptionKeyCache();
+
+    const { client, queries } = createJsonbMockClient([
+      {
+        pk: "wp_noschema",
+        config: { token: cipher },
+        config_schema: null,
+      },
+    ]);
+
+    const result = await rotateJsonbSelectiveField(client, JSONB_TARGET, 2);
+
+    expect(result.scanned).toBe(1);
+    expect(result.skippedEmpty).toBe(1);
+    expect(result.updated).toBe(0);
+    expect(queries.filter((q) => q.sql.startsWith("UPDATE"))).toHaveLength(0);
+  });
+
+  it("rejects unvetted SQL identifiers (table / pk / jsonbColumn / catalog fields)", async () => {
+    process.env.ATLAS_ENCRYPTION_KEYS = "v1:k";
+    _resetEncryptionKeyCache();
+    const { client } = createJsonbMockClient([]);
+    await expect(
+      rotateJsonbSelectiveField(
+        client,
+        { ...JSONB_TARGET, table: "workspace_plugins; DROP TABLE x" },
+        1,
+      ),
+    ).rejects.toThrow(/not a valid SQL identifier/);
+  });
+
+  it("rolls back the transaction on UPDATE failure (no partial rotation)", async () => {
+    // Same belt-and-braces invariant as the column path. The merged
+    // JSONB UPDATE must be atomic — a mid-batch crash leaves the row
+    // exactly as it was, so the operator can re-run after fixing the
+    // failure cause without worrying about half-rotated rows.
+    process.env.ATLAS_ENCRYPTION_KEYS = "v1:old";
+    _resetEncryptionKeyCache();
+    const v1 = encryptSecret("before");
+
+    process.env.ATLAS_ENCRYPTION_KEYS = "v2:new,v1:old";
+    _resetEncryptionKeyCache();
+
+    const queries: Array<{ sql: string; params?: unknown[] }> = [];
+    const client = {
+      query: async (sql: string, params?: unknown[]) => {
+        queries.push({ sql, params });
+        if (sql.startsWith("SELECT")) {
+          return {
+            rows: [{
+              pk: "wp_disk_full",
+              config: { token: v1 },
+              config_schema: [{ key: "token", type: "string", secret: true }],
+            }],
+          };
+        }
+        if (sql.startsWith("UPDATE")) throw new Error("disk full");
+        return { rows: [] };
+      },
+      release: () => {},
+    } as unknown as import("pg").PoolClient;
+
+    await expect(
+      rotateJsonbSelectiveField(client, JSONB_TARGET, 2),
+    ).rejects.toThrow("disk full");
+
+    expect(
+      queries.map((q) => q.sql).filter((s) => s === "BEGIN" || s === "COMMIT" || s === "ROLLBACK"),
+    ).toEqual(["BEGIN", "ROLLBACK"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Real-Postgres integration smoke (#2820 acceptance criterion)
+// ---------------------------------------------------------------------------
+
+/**
+ * End-to-end JSONB rotation against a real Postgres. The acceptance
+ * criterion from #2820 calls out the failure mode mock-pool tests can't
+ * catch: the SELECT joins workspace_plugins to plugin_catalog and the
+ * UPDATE writes a `$1::jsonb` payload — both shapes only fully exercise
+ * against the real schema (the JOIN walker, the JSONB cast, the FK).
+ *
+ * Skips cleanly when TEST_DATABASE_URL is unset so local dev that hasn't
+ * run `bun run db:up` is unaffected. CI provides Postgres via a service
+ * container in the api-tests workflow.
+ */
+const PG_INT_TEST_DB_URL = process.env.TEST_DATABASE_URL;
+const describeIfPg = PG_INT_TEST_DB_URL ? describe : describe.skip;
+const PG_INT_TEST_TIMEOUT_MS = 30_000;
+
+describeIfPg("rotateJsonbSelectiveField (real Postgres, #2820)", () => {
+  let pool: Pool;
+  const schemaName = `rotate_jsonb_${Date.now()}_${Math.floor(Math.random() * 1e6)}`;
+  const savedKey = process.env.ATLAS_ENCRYPTION_KEY;
+  const savedKeys = process.env.ATLAS_ENCRYPTION_KEYS;
+  // Stable across the whole describe block — every test in here runs
+  // against a single migrated schema.
+  const target = {
+    kind: "jsonb-selective-field" as const,
+    table: "workspace_plugins",
+    pk: "id",
+    jsonbColumn: "config",
+    catalogIdColumn: "catalog_id",
+    catalogTable: "plugin_catalog",
+    catalogPk: "id",
+    catalogSchemaColumn: "config_schema",
+  };
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: PG_INT_TEST_DB_URL });
+    // Per-test schema isolation — same pattern as migrate-pg.test.ts.
+    pool.on("connect", (client) => {
+      void client.query(`SET search_path TO "${schemaName}"`).catch((err) => {
+        const message = err instanceof Error ? err.message : String(err);
+        console.error(`rotate-jsonb: SET search_path failed: ${message}`);
+      });
+    });
+    await pool.query(`CREATE SCHEMA IF NOT EXISTS "${schemaName}"`);
+    // Migrations create plugin_catalog + workspace_plugins (post-#2744).
+    // Better-Auth-dependent migrations are skipped — this test doesn't
+    // need the auth tables and skipping keeps the smoke fast.
+    await runMigrations(pool, { skip: MANAGED_AUTH_MIGRATIONS });
+  }, PG_INT_TEST_TIMEOUT_MS);
+
+  afterAll(async () => {
+    if (!pool) return;
+    await pool.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`);
+    await pool.end();
+    // Restore env at the end so other tests in the suite aren't
+    // affected by the rotation key juggling below.
+    if (savedKey !== undefined) process.env.ATLAS_ENCRYPTION_KEY = savedKey;
+    else delete process.env.ATLAS_ENCRYPTION_KEY;
+    if (savedKeys !== undefined) process.env.ATLAS_ENCRYPTION_KEYS = savedKeys;
+    else delete process.env.ATLAS_ENCRYPTION_KEYS;
+    _resetEncryptionKeyCache();
+  });
+
+  /**
+   * Seed a catalog row with a `secret: true` field and a workspace_plugins
+   * install whose `config.url` is an `enc:v1:` ciphertext for the given
+   * plaintext. Returns the install's primary key so the caller can
+   * SELECT it back after rotation.
+   */
+  async function seedInstallWithV1Secret(plaintext: string): Promise<string> {
+    // Encrypt under v1 BEFORE rotating the keyset — otherwise the
+    // ciphertext lands at whatever the active version is.
+    process.env.ATLAS_ENCRYPTION_KEYS = "v1:int-test-old";
+    _resetEncryptionKeyCache();
+    const v1Cipher = encryptSecret(plaintext);
+    expect(v1Cipher.startsWith("enc:v1:")).toBe(true);
+
+    const catalogId = `cat-${Math.random().toString(36).slice(2, 10)}`;
+    const installPk = `wp-${Math.random().toString(36).slice(2, 10)}`;
+
+    // plugin_catalog row — config_schema marks `url` as secret.
+    await pool.query(
+      `INSERT INTO plugin_catalog (id, name, slug, type, pillar, install_model, config_schema)
+       VALUES ($1, 'Test Datasource', $2, 'datasource', 'datasource', 'form', $3::jsonb)`,
+      [
+        catalogId,
+        `test-ds-${catalogId}`,
+        JSON.stringify([
+          { key: "url", type: "string", secret: true },
+          { key: "name", type: "string" },
+        ]),
+      ],
+    );
+
+    // workspace_plugins row — config.url is the v1 ciphertext.
+    await pool.query(
+      `INSERT INTO workspace_plugins (id, workspace_id, catalog_id, install_id, pillar, config, status)
+       VALUES ($1, $2, $3, $4, 'datasource', $5::jsonb, 'published')`,
+      [
+        installPk,
+        `ws-${installPk}`,
+        catalogId,
+        `inst-${installPk}`,
+        JSON.stringify({ url: v1Cipher, name: "prod-us" }),
+      ],
+    );
+
+    return installPk;
+  }
+
+  it("rotates a v1-encrypted JSONB secret field under v2 (acceptance test)", async () => {
+    const plaintext = "postgres://u:p@db.example:5432/atlas";
+    const installPk = await seedInstallWithV1Secret(plaintext);
+
+    // Stage v2 as the active reader/writer; keep v1 around for the
+    // legacy ciphertext read.
+    process.env.ATLAS_ENCRYPTION_KEYS = "v2:int-test-new,v1:int-test-old";
+    _resetEncryptionKeyCache();
+
+    const client = await pool.connect();
+    let result;
+    try {
+      result = await rotateJsonbSelectiveField(client, target, 2);
+    } finally {
+      client.release();
+    }
+
+    expect(result.table).toBe("workspace_plugins");
+    expect(result.updated).toBeGreaterThanOrEqual(1);
+    expect(result.orphaned).toBe(0);
+    expect(result.unprefixed).toBe(0);
+
+    const { rows } = await pool.query<{ config: Record<string, unknown> }>(
+      `SELECT config FROM workspace_plugins WHERE id = $1`,
+      [installPk],
+    );
+    const cfg = rows[0]!.config;
+    expect(String(cfg.url)).toMatch(/^enc:v2:/);
+    // Non-secret fields preserved verbatim by the JSONB merge.
+    expect(cfg.name).toBe("prod-us");
+    // Round-trip through the active keyset returns the original plaintext.
+    expect(decryptSecret(String(cfg.url))).toBe(plaintext);
+  }, PG_INT_TEST_TIMEOUT_MS);
+
+  it("is idempotent — a second rotation pass issues no UPDATEs", async () => {
+    // Re-running rotation against an already-rotated DB must be a
+    // no-op. The acceptance criterion calls this out explicitly:
+    // "Idempotent — re-running rotation is a no-op."
+    const plaintext = "postgres://idem:p@db.example:5432/atlas";
+    await seedInstallWithV1Secret(plaintext);
+
+    process.env.ATLAS_ENCRYPTION_KEYS = "v2:int-test-new,v1:int-test-old";
+    _resetEncryptionKeyCache();
+
+    // First pass — rotates everything not at v2.
+    const client1 = await pool.connect();
+    try {
+      await rotateJsonbSelectiveField(client1, target, 2);
+    } finally {
+      client1.release();
+    }
+
+    // Second pass — every row is already at v2, so no UPDATE issues.
+    const client2 = await pool.connect();
+    let secondResult;
+    try {
+      secondResult = await rotateJsonbSelectiveField(client2, target, 2);
+    } finally {
+      client2.release();
+    }
+
+    expect(secondResult.updated).toBe(0);
+    expect(secondResult.orphaned).toBe(0);
+    expect(secondResult.unprefixed).toBe(0);
+    // Every scanned row landed in skippedEmpty — either "no secret
+    // fields" or "every secret field already at active".
+    expect(secondResult.skippedEmpty).toBe(secondResult.scanned);
+  }, PG_INT_TEST_TIMEOUT_MS);
 });

--- a/packages/api/src/lib/db/migrations/0000_baseline.sql
+++ b/packages/api/src/lib/db/migrations/0000_baseline.sql
@@ -335,9 +335,17 @@ CREATE INDEX IF NOT EXISTS idx_query_suggestions_tables ON query_suggestions USI
 -- NOTE: These ALTER TABLEs are conditional — they only run if the organization
 -- table already exists (created by Better Auth migrations, which run separately).
 -- On first boot they are skipped; applied on subsequent restarts.
+--
+-- `to_regclass('organization')` resolves the unqualified name against the
+-- caller's search_path — so a concurrent test schema that happens to have
+-- its own `organization` table (e.g. migrate-pg-with-auth.test.ts) can't
+-- trick this block into running ALTERs in a different schema. The
+-- information_schema.tables variant was globally scoped and triggered the
+-- THEN branch even when `organization` lived in a sibling schema, leaving
+-- the ALTER to fail with "relation does not exist". See #2820 fix-CI.
 
 DO $$ BEGIN
-  IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'organization') THEN
+  IF to_regclass('organization') IS NOT NULL THEN
     ALTER TABLE organization ADD COLUMN IF NOT EXISTS workspace_status TEXT NOT NULL DEFAULT 'active';
     ALTER TABLE organization ADD COLUMN IF NOT EXISTS plan_tier TEXT NOT NULL DEFAULT 'free';
     ALTER TABLE organization ADD COLUMN IF NOT EXISTS suspended_at TIMESTAMPTZ;

--- a/packages/api/src/lib/db/migrations/0020_plan_tier_rename.sql
+++ b/packages/api/src/lib/db/migrations/0020_plan_tier_rename.sql
@@ -6,7 +6,10 @@
 -- the baseline ran, the column won't exist yet. Add it first.
 
 DO $$ BEGIN
-  IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'organization') THEN
+  -- to_regclass scopes the lookup to the caller's search_path so a sibling
+  -- test schema with its own `organization` table can't trick this into
+  -- ALTERing the wrong row. See 0000_baseline.sql comment + #2820 fix-CI.
+  IF to_regclass('organization') IS NOT NULL THEN
     -- Ensure all baseline columns exist (may have been skipped by baseline's conditional block
     -- if organization table was created by Better Auth AFTER baseline migration ran)
     ALTER TABLE organization ADD COLUMN IF NOT EXISTS workspace_status TEXT NOT NULL DEFAULT 'active';

--- a/packages/api/src/lib/db/migrations/0027_organization_saas_columns.sql
+++ b/packages/api/src/lib/db/migrations/0027_organization_saas_columns.sql
@@ -20,7 +20,12 @@
 -- half-migrated state.
 
 DO $$ BEGIN
-  IF NOT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'organization') THEN
+  -- Scope the existence check to the caller's search_path via to_regclass.
+  -- A global information_schema lookup would pass when `organization` lives
+  -- in a sibling schema (e.g. a concurrent test schema), then ALTER TABLE
+  -- below would fail because the table isn't actually reachable from
+  -- search_path. See 0000_baseline.sql comment + #2820 fix-CI.
+  IF to_regclass('organization') IS NULL THEN
     RAISE EXCEPTION 'Atlas migration 0027 requires the "organization" table to exist. In managed auth mode, Better Auth migrations must run before Atlas migrations. See https://github.com/AtlasDevHQ/atlas/issues/1472.';
   END IF;
 END $$;

--- a/packages/api/src/lib/db/migrations/0090_organization_is_operator_workspace.sql
+++ b/packages/api/src/lib/db/migrations/0090_organization_is_operator_workspace.sql
@@ -41,7 +41,9 @@
 -- org is the default (`trial`).
 
 DO $$ BEGIN
-  IF NOT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'organization') THEN
+  -- Scope to caller's search_path via to_regclass — see 0000_baseline.sql
+  -- comment + #2820 fix-CI for the parallel-test-schema race this avoids.
+  IF to_regclass('organization') IS NULL THEN
     RAISE EXCEPTION 'Atlas migration 0090 requires the "organization" table to exist. In managed auth mode, Better Auth migrations must run before Atlas migrations.';
   END IF;
 END $$;


### PR DESCRIPTION
## Summary
- Extends `packages/api/scripts/rotate-encryption-key.ts` with a discriminated `kind:"jsonb-selective-field"` rotation target that JOINs `workspace_plugins` to `plugin_catalog.config_schema` and re-encrypts every `secret: true` field in-place. Idempotence is gated per-field on the `enc:v<N>:` prefix (no companion `_key_version` column on JSONB rows). Catalog-driven — future plugin secrets (Teams `bot_secret`, Twenty `apiKey`, etc.) are covered without code changes here.
- Closes the 1.5.3 closeout gap (#2755 / #2819) where post-0096 datasource credentials would orphan when the legacy key dropped from `ATLAS_ENCRYPTION_KEYS`. Replaces the "re-save the install from `/admin/connections`" operator workaround documented in `encryption-key-rotation.mdx`.
- Runbook step 4 now documents both rotation shapes; verification SQL + checklist gain the JSONB secret-field row.

## Test plan
- [x] 9 mock-pg unit tests covering rotate / idempotent / orphan / unprefixed / no-secret-fields / corrupt-schema / absent-schema / identifier-injection / rollback paths
- [x] 2 real-Postgres integration tests (`describeIfPg`, skips when `TEST_DATABASE_URL` unset) — v1→v2 round-trip + idempotent re-run; verified locally against a clean `postgres:16-alpine`
- [x] Existing 8 column-rotation tests updated for the new `kind: "column"` discriminator and re-verified
- [x] `/ci` gates green: lint, type, test, syncpack, template-drift, security-headers, railway-watch, schema-drift, oauth-helper-drift, test-discipline

## Notes
- OIDC `sso_providers.config.clientSecret` is still out of scope — its ciphertext lives under a hand-rolled field name rather than the catalog-driven schema walker. The runbook flags a future `oidc-jsonb` target kind that would extend the shape added here.

Closes #2820