### PR TITLE
feat(plugins): publish @useatlas/twenty 0.0.2 — createNote + sales-form

### DIFF
--- a/ee/src/saas-crm/__tests__/saas-crm.test.ts
+++ b/ee/src/saas-crm/__tests__/saas-crm.test.ts
@@ -661,43 +661,12 @@ describe("dispatchOutboxRow", () => {
     }
   });
 
-  test("sales-form row dead-letters today via the normalizer (sales-form not yet accepted)", async () => {
-    // The normalizer's discriminated union only accepts `demo` today;
-    // a sales-form payload throws `Unknown lead source` BEFORE the
-    // dispatcher's downstream sales-form branch runs. Either way the
-    // row dead-letters with an operator-visible message. This test
-    // pins both halves of the contract: (1) no fetch is attempted,
-    // (2) the dead-letter message identifies the offending source.
-    let fetchCalls = 0;
-    const fetchImpl = (async (): Promise<Response> => {
-      fetchCalls++;
-      return new Response("{}", { status: 200 });
-    }) as unknown as typeof globalThis.fetch;
-
-    const outcome = await withFetch(fetchImpl, async () =>
-      dispatchOutboxRow(
-        { apiKey: "k", baseUrl: "https://crm.test.local" },
-        {
-          id: "row-sales",
-          eventType: "sales-form",
-          payload: { source: "sales-form", email: "sales@test.local" },
-          attempts: 1,
-          twentyPersonId: null,
-          twentyNoteId: null,
-        },
-        {
-          setTwentyPersonId: async () => {},
-          setTwentyNoteId: async () => {},
-        },
-      ),
-    );
-
-    expect(fetchCalls).toBe(0);
-    expect(outcome.kind).toBe("permanent");
-    if (outcome.kind === "permanent") {
-      expect(outcome.message).toContain("sales-form");
-    }
-  });
+  // (Stale test removed: `@useatlas/twenty` 0.0.2 normalizes the
+  // sales-form variant via `normalizeSalesFormLead`, so the prior
+  // "sales-form row dead-letters today via the normalizer" assertion
+  // no longer holds. The dispatcher's full sales-form happy-path,
+  // resumed-claim, and orphan-note coverage lives on the slice-3
+  // branch (#2833) alongside the consumer wiring.)
 });
 
 // ── classifyTwentyError ─────────────────────────────────────────────

--- a/plugins/twenty/__tests__/client.test.ts
+++ b/plugins/twenty/__tests__/client.test.ts
@@ -10,6 +10,7 @@ import { describe, test, expect } from "bun:test";
 import {
   upsertPerson,
   getPersonMetadata,
+  createNote,
   TwentyClientError,
   type TwentyClientConfig,
   type TwentyPerson,
@@ -645,6 +646,210 @@ describe("getPersonMetadata", () => {
     } catch (err) {
       expect(err).toBeInstanceOf(TwentyClientError);
       expect((err as TwentyClientError).status).toBe(404);
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+//  createNote — happy path + error mapping
+// ─────────────────────────────────────────────────────────────────────
+
+describe("createNote — happy path", () => {
+  test("POSTs /rest/notes with bodyV2.markdown, then POSTs /rest/noteTargets with noteId + targetPersonId, returns the noteId", async () => {
+    const { fetch, calls } = makeScriptedFetch([
+      {
+        status: 200,
+        body: { data: { createNote: { id: "note_abc" } } },
+      },
+      {
+        status: 200,
+        body: { data: { createNoteTarget: { id: "nt_def", noteId: "note_abc", targetPersonId: "person_xyz" } } },
+      },
+    ]);
+    const config = baseConfig({ fetchImpl: fetch });
+
+    const result = await createNote(config, {
+      personId: "person_xyz",
+      title: "Talk to sales — Acme (Business)",
+      body: "We need ten seats and SSO.",
+    });
+
+    expect(result.id).toBe("note_abc");
+    expect(calls).toHaveLength(2);
+
+    // First call — create note
+    expect(calls[0].method).toBe("POST");
+    expect(calls[0].url).toBe("https://crm.test.local/rest/notes");
+    const noteBody = JSON.parse(calls[0].body ?? "{}");
+    expect(noteBody.title).toBe("Talk to sales — Acme (Business)");
+    // bodyV2.markdown is the canonical input shape — Twenty generates blocknote.
+    expect(noteBody.bodyV2).toEqual({ markdown: "We need ten seats and SSO." });
+    expect(noteBody.body).toBeUndefined();
+
+    // Second call — link to person
+    expect(calls[1].method).toBe("POST");
+    expect(calls[1].url).toBe("https://crm.test.local/rest/noteTargets");
+    const linkBody = JSON.parse(calls[1].body ?? "{}");
+    expect(linkBody).toEqual({ noteId: "note_abc", targetPersonId: "person_xyz" });
+  });
+
+  test("sends Authorization: Bearer <apiKey> on both calls", async () => {
+    const { fetch, calls } = makeScriptedFetch([
+      { status: 200, body: { data: { createNote: { id: "n1" } } } },
+      { status: 200, body: { data: { createNoteTarget: { id: "nt1" } } } },
+    ]);
+    const config = baseConfig({
+      apiKey: "twenty_secret_xyz",
+      fetchImpl: fetch,
+    });
+
+    await createNote(config, {
+      personId: "p1",
+      title: "t",
+      body: "b",
+    });
+
+    expect(calls[0].headers.Authorization).toBe("Bearer twenty_secret_xyz");
+    expect(calls[1].headers.Authorization).toBe("Bearer twenty_secret_xyz");
+  });
+});
+
+describe("createNote — error mapping", () => {
+  test("maps 401 on createNote to TwentyClientError with operation=createNote", async () => {
+    const { fetch, calls } = makeScriptedFetch([
+      { status: 401, body: { messages: ["Unauthorized"] } },
+    ]);
+    const config = baseConfig({ fetchImpl: fetch });
+
+    try {
+      await createNote(config, { personId: "p", title: "t", body: "b" });
+      throw new Error("expected throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(TwentyClientError);
+      const e = err as TwentyClientError;
+      expect(e.status).toBe(401);
+      expect(e.operation).toBe("createNote");
+      expect(e.message).toContain("Unauthorized");
+    }
+    // noteTarget link must NOT be attempted when note creation fails.
+    expect(calls).toHaveLength(1);
+  });
+
+  test("maps 422 on createNote (e.g. missing required field) to TwentyClientError with upstream code", async () => {
+    const { fetch } = makeScriptedFetch([
+      {
+        status: 422,
+        body: { messages: ["title is required"], code: "FIELD_REQUIRED" },
+      },
+    ]);
+    const config = baseConfig({ fetchImpl: fetch });
+
+    try {
+      await createNote(config, { personId: "p", title: "", body: "" });
+      throw new Error("expected throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(TwentyClientError);
+      const e = err as TwentyClientError;
+      expect(e.status).toBe(422);
+      expect(e.upstreamCode).toBe("FIELD_REQUIRED");
+      expect(e.operation).toBe("createNote");
+    }
+  });
+
+  test("maps 5xx on createNote to transient-friendly TwentyClientError", async () => {
+    const { fetch } = makeScriptedFetch([
+      { status: 503, body: { messages: ["upstream down"] } },
+    ]);
+    const config = baseConfig({ fetchImpl: fetch });
+
+    try {
+      await createNote(config, { personId: "p", title: "t", body: "b" });
+      throw new Error("expected throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(TwentyClientError);
+      expect((err as TwentyClientError).status).toBe(503);
+    }
+  });
+
+  test("createNote succeeds but noteTarget link fails → TwentyClientError with operation=createNoteTarget", async () => {
+    // Realistic regression: the note is created but the link step fails.
+    // The caller (dispatchOutboxRow) needs to see operation=createNoteTarget
+    // so the retry policy classifies correctly. (The note is orphaned in
+    // Twenty — operator cleans up; cost is acceptable vs. dropping the lead.)
+    const { fetch, calls } = makeScriptedFetch([
+      { status: 200, body: { data: { createNote: { id: "orphan_note" } } } },
+      { status: 500, body: { messages: ["link failed"] } },
+    ]);
+    const config = baseConfig({ fetchImpl: fetch });
+
+    try {
+      await createNote(config, { personId: "p", title: "t", body: "b" });
+      throw new Error("expected throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(TwentyClientError);
+      const e = err as TwentyClientError;
+      expect(e.status).toBe(500);
+      expect(e.operation).toBe("createNoteTarget");
+    }
+    expect(calls).toHaveLength(2);
+  });
+
+  test("createNote 200 with no id → TwentyClientError (no silent success)", async () => {
+    // Defense against a future Twenty fast-path that returns 2xx + empty body.
+    // Without the id we can't link the noteTarget, so this MUST fail loud
+    // rather than return a meaningless result.
+    const { fetch, calls } = makeScriptedFetch([
+      { status: 200, body: { data: { createNote: {} } } },
+    ]);
+    const config = baseConfig({ fetchImpl: fetch });
+
+    try {
+      await createNote(config, { personId: "p", title: "t", body: "b" });
+      throw new Error("expected throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(TwentyClientError);
+      expect((err as TwentyClientError).operation).toBe("createNote");
+      expect((err as TwentyClientError).message).toContain("no id");
+    }
+    // No link attempt — we have no noteId.
+    expect(calls).toHaveLength(1);
+  });
+
+  test("retry-after on 429 surfaces through TwentyClientError.retryAfterMs", async () => {
+    const fetchImpl = (async () =>
+      new Response(JSON.stringify({ messages: ["rate limited"] }), {
+        status: 429,
+        headers: { "Content-Type": "application/json", "Retry-After": "120" },
+      })) as unknown as typeof globalThis.fetch;
+    const config = baseConfig({ fetchImpl });
+
+    try {
+      await createNote(config, { personId: "p", title: "t", body: "b" });
+      throw new Error("expected throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(TwentyClientError);
+      const e = err as TwentyClientError;
+      expect(e.status).toBe(429);
+      expect(e.retryAfterMs).toBe(120_000);
+    }
+  });
+
+  test("does not include the apiKey in thrown error messages", async () => {
+    const { fetch } = makeScriptedFetch([
+      { status: 401, body: { messages: ["bad key"] } },
+    ]);
+    const config = baseConfig({
+      apiKey: "twenty_secret_must_not_leak",
+      fetchImpl: fetch,
+    });
+
+    try {
+      await createNote(config, { personId: "p", title: "t", body: "b" });
+      throw new Error("expected throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(TwentyClientError);
+      const msg = (err as TwentyClientError).message;
+      expect(msg).not.toContain("twenty_secret_must_not_leak");
     }
   });
 });

--- a/plugins/twenty/__tests__/lead-normalizer.test.ts
+++ b/plugins/twenty/__tests__/lead-normalizer.test.ts
@@ -1,12 +1,14 @@
 /**
  * LeadNormalizer unit tests — pure-function snapshot-style coverage of
- * the demo variant.
+ * the demo and sales-form variants.
  */
 import { describe, test, expect } from "bun:test";
 import {
   normalizeDemoLead,
   normalizeLead,
+  normalizeSalesFormLead,
   type AtlasDemoLeadEvent,
+  type AtlasSalesFormLeadEvent,
 } from "../src/lead-normalizer";
 
 describe("normalizeDemoLead", () => {
@@ -83,9 +85,145 @@ describe("normalizeDemoLead", () => {
   });
 });
 
+describe("normalizeSalesFormLead", () => {
+  test("maps a full sales-form event to a Twenty upsert payload + note", () => {
+    const event: AtlasSalesFormLeadEvent = {
+      source: "sales-form",
+      email: "User@Example.com",
+      name: "Alice Example",
+      company: "Acme Co",
+      planInterest: "Business",
+      message: "We need ten seats and SSO.",
+      ip: "203.0.113.42",
+    };
+
+    const result = normalizeSalesFormLead(event);
+
+    expect(result.eventSource).toBe("SALES_FORM");
+    expect(result.person.email).toBe("user@example.com");
+    expect(result.person.eventSource).toBe("SALES_FORM");
+    // First/last names split from the single `name` input.
+    expect(result.person.name).toEqual({ firstName: "Alice", lastName: "Example" });
+    expect(result.person.customFields).toEqual({ atlasIp: "203.0.113.42" });
+    // Note body is the message text verbatim.
+    expect(result.note).toBeDefined();
+    expect(result.note?.body).toBe("We need ten seats and SSO.");
+    // Title carries useful triage context (company + planInterest).
+    expect(result.note?.title).toContain("Acme Co");
+    expect(result.note?.title).toContain("Business");
+  });
+
+  test("lowercases and trims the email", () => {
+    const result = normalizeSalesFormLead({
+      source: "sales-form",
+      email: "  Bob@ACME.COM ",
+      name: "Bob",
+      company: "Acme",
+      planInterest: "Pro",
+      message: "Hi",
+    });
+    expect(result.person.email).toBe("bob@acme.com");
+  });
+
+  test("single-word name maps to firstName only (no empty lastName)", () => {
+    const result = normalizeSalesFormLead({
+      source: "sales-form",
+      email: "u@t.com",
+      name: "Cher",
+      company: "C",
+      planInterest: "Starter",
+      message: "Hello",
+    });
+    expect(result.person.name).toEqual({ firstName: "Cher" });
+  });
+
+  test("multi-word last name collapses everything after the first whitespace into lastName", () => {
+    const result = normalizeSalesFormLead({
+      source: "sales-form",
+      email: "u@t.com",
+      name: "Mary  Anne   Van Der Beek",
+      company: "C",
+      planInterest: "Starter",
+      message: "Hello",
+    });
+    expect(result.person.name).toEqual({
+      firstName: "Mary",
+      lastName: "Anne Van Der Beek",
+    });
+  });
+
+  test("omits atlasIp when ip is null/undefined/empty", () => {
+    for (const ip of [null, undefined, ""] as const) {
+      const result = normalizeSalesFormLead({
+        source: "sales-form",
+        email: "u@t.com",
+        name: "X",
+        company: "Y",
+        planInterest: "Pro",
+        message: "Hi",
+        ip,
+      });
+      expect(result.person.customFields).toEqual({});
+    }
+  });
+
+  test("note body preserves whitespace and newlines from the message exactly", () => {
+    const message = "Line one.\n\nLine two with  spaces.\n\tIndented.";
+    const result = normalizeSalesFormLead({
+      source: "sales-form",
+      email: "u@t.com",
+      name: "X",
+      company: "Y",
+      planInterest: "Pro",
+      message,
+    });
+    expect(result.note?.body).toBe(message);
+  });
+
+  test("always stamps eventSource = SALES_FORM for the sales-form variant", () => {
+    const result = normalizeSalesFormLead({
+      source: "sales-form",
+      email: "u@t.com",
+      name: "X",
+      company: "Y",
+      planInterest: "Pro",
+      message: "Hi",
+    });
+    expect(result.eventSource).toBe("SALES_FORM");
+    expect(result.person.eventSource).toBe("SALES_FORM");
+  });
+
+  test("does NOT round-trip userAgent into Twenty (parity with demo variant)", () => {
+    const result = normalizeSalesFormLead({
+      source: "sales-form",
+      email: "u@t.com",
+      name: "X",
+      company: "Y",
+      planInterest: "Pro",
+      message: "Hi",
+      userAgent: "Mozilla/5.0",
+    });
+    expect(JSON.stringify(result)).not.toContain("Mozilla");
+    expect(JSON.stringify(result)).not.toContain("userAgent");
+  });
+});
+
 describe("normalizeLead — dispatch", () => {
   test("dispatches demo source to the demo normalizer", () => {
     const result = normalizeLead({ source: "demo", email: "u@t.com" });
     expect(result.eventSource).toBe("DEMO");
+  });
+
+  test("dispatches sales-form source to the sales-form normalizer", () => {
+    const result = normalizeLead({
+      source: "sales-form",
+      email: "u@t.com",
+      name: "X",
+      company: "Y",
+      planInterest: "Pro",
+      message: "Hi",
+    });
+    expect(result.eventSource).toBe("SALES_FORM");
+    expect(result.note?.body).toBe("Hi");
   });
 });

--- a/plugins/twenty/package.json
+++ b/plugins/twenty/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useatlas/twenty",
-  "version": "0.0.1",
-  "description": "Atlas Twenty CRM action plugin (upsertPerson)",
+  "version": "0.0.2",
+  "description": "Atlas Twenty CRM action plugin (upsertPerson, createNote, sales-form normalization)",
   "type": "module",
   "main": "./src/index.ts",
   "types": "./src/index.ts",

--- a/plugins/twenty/src/client.ts
+++ b/plugins/twenty/src/client.ts
@@ -34,7 +34,9 @@ export type TwentyOperation =
   | "findPersonByEmail"
   | "createPerson"
   | "updatePerson"
-  | "getPersonMetadata";
+  | "getPersonMetadata"
+  | "createNote"
+  | "createNoteTarget";
 
 /** Structured error for typed routing inside SaasCrmLayer. */
 export class TwentyClientError extends Data.TaggedError("TwentyClientError")<{
@@ -357,6 +359,123 @@ async function updatePerson(
       operation: "updatePerson",
     });
   }
+}
+
+// ─────────────────────────────────────────────────────────────────────
+//  Notes — POST /rest/notes + POST /rest/noteTargets
+// ─────────────────────────────────────────────────────────────────────
+//
+// Twenty's Note entity stores rich text under `bodyV2.markdown` (the
+// `body` field was retired in favor of the BlockNote-shaped `bodyV2`).
+// Linking a Note to a Person is a SECOND request to `/rest/noteTargets`
+// with `{ noteId, targetPersonId }` — Twenty does not expose a combined
+// create-and-link primitive. The two-step shape is mirrored in
+// `dispatchOutboxRow`'s sub-step idempotency: if the link step fails
+// after the note is created, the note is orphaned but the lead is NOT
+// lost (the row stays `in_flight` and the next claim re-runs the link
+// step against a fresh note — operator cleans up the orphan; acceptable
+// cost vs. dropping the lead).
+
+export interface CreateNoteInput {
+  /** Person id returned by upsertPerson — the note attaches to this Person. */
+  readonly personId: string;
+  /** Title surfaced in Twenty's note list view. */
+  readonly title: string;
+  /** Note body as markdown. Stored under `bodyV2.markdown`. */
+  readonly body: string;
+}
+
+export interface TwentyNote {
+  readonly id: string;
+}
+
+/**
+ * Create a Note in Twenty and link it to a Person via NoteTarget.
+ * Returns the created note's id so the caller (outbox dispatcher) can
+ * persist it for idempotent replay.
+ */
+export async function createNote(
+  config: TwentyClientConfig,
+  input: CreateNoteInput,
+): Promise<TwentyNote> {
+  const fetchImpl = config.fetchImpl ?? globalThis.fetch;
+
+  // ── Step 1: POST /rest/notes ──────────────────────────────────────
+  const noteUrl = buildRestUrl(config.baseUrl, "notes");
+  const noteResponse = await fetchImpl(noteUrl, {
+    method: "POST",
+    headers: buildAuthHeaders(config.apiKey),
+    body: JSON.stringify({
+      title: input.title,
+      bodyV2: { markdown: input.body },
+    }),
+    signal: AbortSignal.timeout(config.timeoutMs ?? DEFAULT_TIMEOUT_MS),
+  });
+
+  if (!noteResponse.ok) {
+    const detail = await readErrorDetail(noteResponse);
+    throw new TwentyClientError({
+      message: `createNote failed: ${detail.message}`,
+      status: noteResponse.status,
+      upstreamCode: detail.code,
+      operation: "createNote",
+      retryAfterMs: parseRetryAfterMs(noteResponse.headers.get("Retry-After")),
+    });
+  }
+
+  let noteId: string | undefined;
+  try {
+    const noteBody = (await noteResponse.json()) as {
+      data?: { createNote?: TwentyNote; note?: TwentyNote };
+    };
+    noteId = noteBody.data?.createNote?.id ?? noteBody.data?.note?.id;
+  } catch (err) {
+    throw new TwentyClientError({
+      message: `createNote: unparseable success response (${err instanceof Error ? err.message : String(err)})`,
+      status: noteResponse.status,
+      operation: "createNote",
+    });
+  }
+
+  if (!noteId) {
+    // Twenty returned 2xx with no id — we can't link the noteTarget
+    // without it. Fail loud rather than silently complete; the row will
+    // retry (transient) and create a duplicate note on the next attempt,
+    // which is preferable to a missing note that the operator never
+    // notices.
+    throw new TwentyClientError({
+      message: "createNote: 2xx response had no id",
+      status: noteResponse.status,
+      operation: "createNote",
+    });
+  }
+
+  // ── Step 2: POST /rest/noteTargets ────────────────────────────────
+  const linkUrl = buildRestUrl(config.baseUrl, "noteTargets");
+  const linkResponse = await fetchImpl(linkUrl, {
+    method: "POST",
+    headers: buildAuthHeaders(config.apiKey),
+    body: JSON.stringify({
+      noteId,
+      targetPersonId: input.personId,
+    }),
+    signal: AbortSignal.timeout(config.timeoutMs ?? DEFAULT_TIMEOUT_MS),
+  });
+
+  if (!linkResponse.ok) {
+    const detail = await readErrorDetail(linkResponse);
+    throw new TwentyClientError({
+      message: `createNoteTarget failed (note=${noteId}): ${detail.message}`,
+      status: linkResponse.status,
+      upstreamCode: detail.code,
+      operation: "createNoteTarget",
+      retryAfterMs: parseRetryAfterMs(linkResponse.headers.get("Retry-After")),
+    });
+  }
+
+  // We don't need the noteTarget id for anything — the noteId is the
+  // load-bearing identifier the outbox persists for idempotency.
+  return { id: noteId };
 }
 
 // ─────────────────────────────────────────────────────────────────────

--- a/plugins/twenty/src/index.ts
+++ b/plugins/twenty/src/index.ts
@@ -38,6 +38,7 @@ import { upsertPerson, type TwentyClientConfig } from "./client";
 export {
   upsertPerson,
   getPersonMetadata,
+  createNote,
   TwentyClientError,
   type TwentyOperation,
   type TwentyClientConfig,
@@ -46,15 +47,20 @@ export {
   type AtlasPersonCustomFields,
   type PersonMetadata,
   type PersonMetadataField,
+  type CreateNoteInput,
+  type TwentyNote,
 } from "./client";
 
 export {
   normalizeDemoLead,
+  normalizeSalesFormLead,
   normalizeLead,
   type AtlasDemoLeadEvent,
+  type AtlasSalesFormLeadEvent,
   type AtlasEventSource,
   type AtlasLeadEvent,
   type NormalizedLead,
+  type NormalizedNote,
 } from "./lead-normalizer";
 
 export {

--- a/plugins/twenty/src/lead-normalizer.ts
+++ b/plugins/twenty/src/lead-normalizer.ts
@@ -2,15 +2,16 @@
  * LeadNormalizer — pure mapping from Atlas lead events to the Twenty
  * upsert input shape.
  *
- * Currently ships the demo variant only — `normalizeLead`'s exhaustive
- * switch surfaces a compile error the moment a new union member lands.
+ * Ships the `demo` and `sales-form` variants. `normalizeLead`'s
+ * exhaustive switch surfaces a compile error the moment a new union
+ * member lands.
  *
  * Design rule: the normalizer outputs a single `eventSource` field;
  * the first-source / last-source translation happens INSIDE
  * `TwentyClient.upsertPerson`. That keeps this module a pure function
  * of input → payload, with no I/O and no Twenty-record-state coupling.
  *
- * Types are defined inline here for 0.0.1; they will move to
+ * Types are defined inline here for 0.1.x; they will move to
  * `@useatlas/types` in a subsequent release so the dispatch boundary
  * (`@useatlas/twenty` → SaaS CRM seam) can share one source of truth.
  */
@@ -33,18 +34,47 @@ export interface AtlasDemoLeadEvent {
 }
 
 /**
+ * Sales-form variant — captured by the Talk-to-sales dialog on
+ * `/pricing`. Carries the free-text message that becomes a Twenty Note
+ * attached to the Person.
+ */
+export interface AtlasSalesFormLeadEvent {
+  readonly source: "sales-form";
+  readonly email: string;
+  /** Full name as typed by the prospect. Split into first/last at the seam. */
+  readonly name: string;
+  readonly company: string;
+  /** Plan label they're interested in (e.g. "Starter" / "Pro" / "Business"). */
+  readonly planInterest: string;
+  /** Free-text message. Becomes the Note body verbatim. */
+  readonly message: string;
+  readonly ip?: string | null;
+  readonly userAgent?: string | null;
+}
+
+/**
  * Discriminated union over every Atlas-internal lead event.
  *
- * Extended in subsequent slices: signup hook (`source: "signup"`),
- * sales-form (`source: "sales-form"`), etc. The exhaustiveness check
- * in `normalizeLead` catches missing handlers at compile time.
+ * Extended in subsequent slices: signup hook (`source: "signup"`), etc.
+ * The exhaustiveness check in `normalizeLead` catches missing handlers
+ * at compile time.
  */
-export type AtlasLeadEvent = AtlasDemoLeadEvent;
+export type AtlasLeadEvent = AtlasDemoLeadEvent | AtlasSalesFormLeadEvent;
+
+/** Note attached to the Person — only emitted by variants that carry a message. */
+export interface NormalizedNote {
+  /** Short title surfaced in Twenty's note list view. */
+  readonly title: string;
+  /** Free-text body. Twenty stores as markdown. */
+  readonly body: string;
+}
 
 export interface NormalizedLead {
   readonly person: UpsertPersonInput;
   /** Mirror of `person.eventSource` — surfaced so the caller can log / route. */
   readonly eventSource: AtlasEventSource;
+  /** Optional Note to attach to the Person after upsert. */
+  readonly note?: NormalizedNote;
 }
 
 /** Normalize a demo lead event to a Twenty upsert payload. */
@@ -72,15 +102,65 @@ export function normalizeDemoLead(event: AtlasDemoLeadEvent): NormalizedLead {
   };
 }
 
+/**
+ * Split a single free-text name into first/last components. Whitespace
+ * runs collapse to a single space; the first token becomes firstName,
+ * everything after it becomes lastName. Single-word names emit
+ * firstName only — Twenty distinguishes "absent" from "" on its name
+ * subfield, and a stray empty lastName would clobber an existing one on
+ * PATCH.
+ */
+function splitName(raw: string): { firstName: string; lastName?: string } | undefined {
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return undefined;
+  const parts = trimmed.split(/\s+/);
+  const [first, ...rest] = parts;
+  if (rest.length === 0) return { firstName: first };
+  return { firstName: first, lastName: rest.join(" ") };
+}
+
+/** Normalize a sales-form lead event to a Twenty upsert payload + note. */
+export function normalizeSalesFormLead(
+  event: AtlasSalesFormLeadEvent,
+): NormalizedLead {
+  const email = event.email.toLowerCase().trim();
+  const eventSource: AtlasEventSource = "SALES_FORM";
+
+  const customFields: { atlasIp?: string } = {};
+  if (event.ip && event.ip.length > 0) {
+    customFields.atlasIp = event.ip;
+  }
+
+  const name = splitName(event.name);
+
+  return {
+    person: {
+      email,
+      eventSource,
+      ...(name ? { name } : {}),
+      customFields,
+    },
+    eventSource,
+    note: {
+      // Title pins the triage context — company + plan label — so the
+      // sales team can scan the Note list without opening every body.
+      title: `Talk to sales — ${event.company} (${event.planInterest})`,
+      body: event.message,
+    },
+  };
+}
+
 /** Dispatch on `source`. */
 export function normalizeLead(event: AtlasLeadEvent): NormalizedLead {
   switch (event.source) {
     case "demo":
       return normalizeDemoLead(event);
+    case "sales-form":
+      return normalizeSalesFormLead(event);
     default: {
       // Exhaustiveness — when new variants are added to `AtlasLeadEvent`,
       // the absence of a case here surfaces as a tsgo compile error.
-      const _exhaustive: never = event.source;
+      const _exhaustive: never = event;
       void _exhaustive;
       throw new Error(`Unknown lead source: ${String((event as { source?: unknown }).source)}`);
     }


### PR DESCRIPTION
## Summary

Publish-only PR for `@useatlas/twenty` 0.0.2 so it lands on npm ahead of PR #2833 (slice 3 of 1.6.0). Without 0.0.2 on the registry, the Scaffold (docker) and Scaffold (vercel) checks on #2833 fail when the scaffolded tree's `bun install` against the npm registry can't resolve the new `createNote` export imported by `ee/src/saas-crm/index.ts`.

Per CLAUDE.md "Publishing @useatlas/* packages" — publish first, then update template refs in a follow-up. This PR is **publish-only** — the new `src/` + tests carry forward from #2833 verbatim, **no consumer wiring, no template ref bumps**. #2833 owns the consumer wiring and the follow-up bump from `^0.0.1` → `^0.0.2` after this lands on npm.

## Surface added in 0.0.2 (vs 0.0.1)

- `createNote(config, { personId, title, body })` — two-call sequence POSTs `/rest/notes` (`bodyV2.markdown`), then `/rest/noteTargets` (`{ noteId, targetPersonId }`). 4xx → permanent, 5xx → transient via `classifyTwentyError`.
- `normalizeSalesFormLead` + `AtlasSalesFormLeadEvent` + `NormalizedNote` — sales-form discriminated-union variant emits `{ person, note, eventSource: "SALES_FORM" }`. Note body is the message verbatim; title carries `company` + `planInterest` for triage.
- `CreateNoteInput`, `TwentyNote`, `AtlasSalesFormLeadEvent`, `NormalizedNote` types re-exported from index.

## Test plan

- [x] `cd plugins/twenty && bun test` — 86 pass / 0 fail
- [ ] Merge → tag `twenty-v0.0.2` → wait for publish workflow to complete
- [ ] Then bump template refs `^0.0.1` → `^0.0.2` on #2833 to unblock Scaffold

## Sequencing

1. **This PR lands** → 0.0.2 source on `main`
2. `git tag twenty-v0.0.2 && git push origin twenty-v0.0.2` → publish workflow ships to npm
3. #2833 rebases on main, bumps `create-atlas/templates/{docker,nextjs-standalone}/package.json` to `^0.0.2`
4. Scaffold (docker)/(vercel) go green on #2833

Refs #2833.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/2835"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782391725&installation_id=135337507&pr_number=2835&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F2835&signature=eb229d18202f221e2d31dbc6790b5cfb68fc6e1687968278177594815a588a91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->