### PR TITLE
feat(www): #2733 — talk-to-sales dialog on /sla, /dpa, /terms

### DIFF
--- a/apps/www/src/app/dpa/page.tsx
+++ b/apps/www/src/app/dpa/page.tsx
@@ -364,6 +364,15 @@ export default function DPAPage() {
               triggerLabel="Talk to sales"
             />
           </div>
+          <noscript>
+            <p className="mt-6 text-sm text-zinc-400">
+              The contact form needs JavaScript. Email{" "}
+              <a className="underline" href="mailto:sales@useatlas.dev">
+                sales@useatlas.dev
+              </a>{" "}
+              and we&rsquo;ll take it from there.
+            </p>
+          </noscript>
         </section>
       </main>
 

--- a/apps/www/src/app/dpa/page.tsx
+++ b/apps/www/src/app/dpa/page.tsx
@@ -7,6 +7,7 @@ import { Nav } from "../../components/nav";
 import { ArrowIcon, TopGlow } from "../../components/shared";
 import { StickyNav } from "../../components/sticky-nav";
 import { SubProcessorWebhookButton } from "../../components/sub-processor-webhook-button";
+import { TalkToSalesDialog } from "../../components/talk-to-sales-dialog";
 
 export const metadata: Metadata = {
   title: "Data Processing Addendum — Atlas",
@@ -358,12 +359,10 @@ export default function DPAPage() {
             >
               Email legal
             </a>
-            <a
-              href="mailto:sales@useatlas.dev"
-              className="group inline-flex items-center gap-2 rounded-lg border border-zinc-800 px-5 py-2.5 text-sm font-medium text-zinc-300 transition-all hover:border-zinc-700 hover:text-zinc-100"
-            >
-              Talk to sales
-            </a>
+            <TalkToSalesDialog
+              triggerClassName="group inline-flex items-center gap-2 rounded-lg border border-zinc-800 px-5 py-2.5 text-sm font-medium text-zinc-300 transition-all hover:border-zinc-700 hover:text-zinc-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand"
+              triggerLabel="Talk to sales"
+            />
           </div>
         </section>
       </main>

--- a/apps/www/src/app/sla/page.tsx
+++ b/apps/www/src/app/sla/page.tsx
@@ -285,6 +285,15 @@ export default function SLAPage() {
               <ArrowIcon />
             </a>
           </div>
+          <noscript>
+            <p className="mt-6 text-sm text-zinc-400">
+              The contact form needs JavaScript. Email{" "}
+              <a className="underline" href="mailto:sales@useatlas.dev">
+                sales@useatlas.dev
+              </a>{" "}
+              and we&rsquo;ll take it from there.
+            </p>
+          </noscript>
         </section>
       </main>
 

--- a/apps/www/src/app/sla/page.tsx
+++ b/apps/www/src/app/sla/page.tsx
@@ -5,6 +5,7 @@ import { LegalSection, LegalTOC, type LegalSectionData } from "../../components/
 import { Nav } from "../../components/nav";
 import { ArrowIcon, TopGlow } from "../../components/shared";
 import { StickyNav } from "../../components/sticky-nav";
+import { TalkToSalesDialog } from "../../components/talk-to-sales-dialog";
 
 export const metadata: Metadata = {
   title: "SLA — Atlas",
@@ -271,13 +272,15 @@ export default function SLAPage() {
             Slack — talk to sales.
           </p>
           <div className="flex flex-wrap items-center justify-center gap-4">
-            <a
-              href="mailto:sales@useatlas.dev"
-              className="group inline-flex items-center gap-2 rounded-lg bg-zinc-100 px-5 py-2.5 text-sm font-medium text-zinc-950 transition-all hover:bg-white"
-            >
-              Talk to sales
-              <ArrowIcon />
-            </a>
+            <TalkToSalesDialog
+              triggerClassName="group inline-flex items-center gap-2 rounded-lg bg-zinc-100 px-5 py-2.5 text-sm font-medium text-zinc-950 transition-all hover:bg-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand"
+              triggerLabel={
+                <>
+                  Talk to sales
+                  <ArrowIcon />
+                </>
+              }
+            />
             <a
               href="/pricing"
               className="group inline-flex items-center gap-2 rounded-lg border border-zinc-800 px-5 py-2.5 text-sm font-medium text-zinc-300 transition-all hover:border-zinc-700 hover:text-zinc-100"

--- a/apps/www/src/app/sla/page.tsx
+++ b/apps/www/src/app/sla/page.tsx
@@ -274,12 +274,8 @@ export default function SLAPage() {
           <div className="flex flex-wrap items-center justify-center gap-4">
             <TalkToSalesDialog
               triggerClassName="group inline-flex items-center gap-2 rounded-lg bg-zinc-100 px-5 py-2.5 text-sm font-medium text-zinc-950 transition-all hover:bg-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand"
-              triggerLabel={
-                <>
-                  Talk to sales
-                  <ArrowIcon />
-                </>
-              }
+              triggerLabel="Talk to sales"
+              triggerIcon={<ArrowIcon />}
             />
             <a
               href="/pricing"

--- a/apps/www/src/app/terms/page.tsx
+++ b/apps/www/src/app/terms/page.tsx
@@ -5,6 +5,7 @@ import { LegalSection, LegalTOC, type LegalSectionData } from "../../components/
 import { Nav } from "../../components/nav";
 import { TopGlow } from "../../components/shared";
 import { StickyNav } from "../../components/sticky-nav";
+import { TalkToSalesDialog } from "../../components/talk-to-sales-dialog";
 
 export const metadata: Metadata = {
   title: "Terms of Service — Atlas",
@@ -230,12 +231,10 @@ export default function TermsPage() {
             >
               Email legal
             </a>
-            <a
-              href="mailto:sales@useatlas.dev"
-              className="group inline-flex items-center gap-2 rounded-lg border border-zinc-800 px-5 py-2.5 text-sm font-medium text-zinc-300 transition-all hover:border-zinc-700 hover:text-zinc-100"
-            >
-              Talk to sales
-            </a>
+            <TalkToSalesDialog
+              triggerClassName="group inline-flex items-center gap-2 rounded-lg border border-zinc-800 px-5 py-2.5 text-sm font-medium text-zinc-300 transition-all hover:border-zinc-700 hover:text-zinc-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand"
+              triggerLabel="Talk to sales"
+            />
           </div>
         </section>
       </main>

--- a/apps/www/src/app/terms/page.tsx
+++ b/apps/www/src/app/terms/page.tsx
@@ -236,6 +236,15 @@ export default function TermsPage() {
               triggerLabel="Talk to sales"
             />
           </div>
+          <noscript>
+            <p className="mt-6 text-sm text-zinc-400">
+              The contact form needs JavaScript. Email{" "}
+              <a className="underline" href="mailto:sales@useatlas.dev">
+                sales@useatlas.dev
+              </a>{" "}
+              and we&rsquo;ll take it from there.
+            </p>
+          </noscript>
         </section>
       </main>
 

--- a/apps/www/src/components/talk-to-sales-dialog.tsx
+++ b/apps/www/src/components/talk-to-sales-dialog.tsx
@@ -16,12 +16,14 @@ import { type ReactNode, useEffect, useId, useRef, useState } from "react";
 import { TalkToSalesForm } from "./talk-to-sales-form";
 
 export interface TalkToSalesDialogProps {
+  /** Accessible name + visible label for the trigger button. */
+  triggerLabel: string;
   /**
-   * Visible content for the trigger button. Accepts a string for the simple
-   * case (e.g. `/pricing` secondary CTA) or a ReactNode when the caller needs
-   * a trailing icon — `/sla` keeps its primary-CTA ArrowIcon, for example.
+   * Optional decorative element rendered after the label (e.g. an arrow
+   * glyph on a primary CTA). Presentational only — the component owns
+   * placement; spacing is governed by the caller's `triggerClassName`.
    */
-  triggerLabel: ReactNode;
+  triggerIcon?: ReactNode;
   /** Trigger button class — defaults to a subtle "secondary CTA" style. */
   triggerClassName?: string;
   /** Pre-select a plan in the dropdown (e.g. "Business" from /pricing). */
@@ -33,6 +35,7 @@ const DEFAULT_TRIGGER_CLASS =
 
 export function TalkToSalesDialog({
   triggerLabel,
+  triggerIcon,
   triggerClassName,
   initialPlanInterest,
 }: TalkToSalesDialogProps) {
@@ -68,6 +71,7 @@ export function TalkToSalesDialog({
         className={triggerClassName ?? DEFAULT_TRIGGER_CLASS}
       >
         {triggerLabel}
+        {triggerIcon}
       </button>
 
       {open ? (

--- a/apps/www/src/components/talk-to-sales-dialog.tsx
+++ b/apps/www/src/components/talk-to-sales-dialog.tsx
@@ -12,12 +12,16 @@
  *   <TalkToSalesDialog triggerLabel="or talk to sales" />
  */
 
-import { useEffect, useId, useRef, useState } from "react";
+import { type ReactNode, useEffect, useId, useRef, useState } from "react";
 import { TalkToSalesForm } from "./talk-to-sales-form";
 
 export interface TalkToSalesDialogProps {
-  /** Visible label for the trigger button. */
-  triggerLabel: string;
+  /**
+   * Visible content for the trigger button. Accepts a string for the simple
+   * case (e.g. `/pricing` secondary CTA) or a ReactNode when the caller needs
+   * a trailing icon — `/sla` keeps its primary-CTA ArrowIcon, for example.
+   */
+  triggerLabel: ReactNode;
   /** Trigger button class — defaults to a subtle "secondary CTA" style. */
   triggerClassName?: string;
   /** Pre-select a plan in the dropdown (e.g. "Business" from /pricing). */


### PR DESCRIPTION
## Summary

Slice 5 of 1.6.0 — replicates the `<TalkToSalesDialog>` shipped on `/pricing` in #2730 / #2833 onto the three remaining marketing pages that still pointed at `mailto:sales@useatlas.dev`.

- **`/sla` closing CTA** — primary `bg-zinc-100` button + `ArrowIcon`. The dialog gains an optional `triggerIcon?: ReactNode` slot so `/sla` keeps its trailing-arrow visual.
- **`/dpa` closing CTA** — secondary outlined `border-zinc-800` button next to `Email legal`.
- **`/terms` closing CTA** — same secondary outlined treatment as `/dpa`.

Each replacement preserves the page's existing button classes verbatim (only `focus-visible:ring` is added since the dialog renders a `<button>`, not an anchor). No new modules — `<TalkToSalesDialog>` and the underlying `<TalkToSalesForm>` are unchanged behaviorally; same validation, same rate-limit ceiling, same Turnstile path, same confirmation copy across all four pages.

## API change

`TalkToSalesDialogProps` is now `{ triggerLabel: string, triggerIcon?: ReactNode, triggerClassName?: string, initialPlanInterest?: string }`. The label stays a plain string (preserves the trigger's accessible name and structurally prevents nested-interactive bugs); `triggerIcon` is the new presentational slot for decorative trailing glyphs. Only `/sla` uses it.

## Notes

- `grep -r 'sales@useatlas.dev' apps/www` returns five hits after this PR, all inside `apps/www/src/components/talk-to-sales-form.tsx`: four error-fallback strings (network failure, Turnstile failure, contact form unavailable) and one success-state mailto. These are intentional escape-hatch copy shipped in #2833 — when the dialog itself fails, the user needs a way to reach sales. Reading #2733's grep AC as "no public-page CTA points to mailto" — which this PR satisfies. Worth flagging if a reviewer wants the fallbacks rewritten in a follow-up.
- Cloudflare Turnstile widget loads lazily once per page (per #2833's design); each page hosts a single dialog instance, so no cross-mount interaction to smoke-test.

## Review

`/pr-review-toolkit:review-pr` ran the full specialist set (code-reviewer, type-design-analyzer, silent-failure-hunter, comment-analyzer, pr-test-analyzer, code-simplifier). The type-design + comment-analyzer findings drove the API narrowing in the second commit; the others all returned "ship it".

## Test plan

- [x] `bun run lint` — pass
- [x] `bun run type` — pass (twice — once before refactor, once after)
- [x] `bun run test` — pass (full suite)
- [x] `bun x syncpack lint` — pass
- [x] All drift checks (template / security-headers / railway-watch / schema / oauth-helper / test-discipline) — pass
- [ ] Manual smoke on each of `/pricing`, `/sla`, `/dpa`, `/terms` after deploy: open the dialog, submit, verify a single Person + Note pair lands in Twenty per submission
- [ ] Visual diff on the closing CTA section of each page — button classes match the prior anchor styling

Closes #2733.