### PR TITLE
docs(plugins): #2815 — remove deprecated adapters: field from 7 per-platform pages

### DIFF
--- a/apps/docs/content/docs/plugins/interactions/discord.mdx
+++ b/apps/docs/content/docs/plugins/interactions/discord.mdx
@@ -107,7 +107,7 @@ export default defineConfig({
 });
 ```
 
-Bot credentials come from env vars — see [Environment Variables](#environment-variables) below.
+Bot credentials come from env vars — see [Environment Variables](#environment-variables) below. To trigger mention handlers on role mentions (not just direct `@user` mentions), set `DISCORD_MENTION_ROLE_IDS` to a comma-separated list of role IDs.
 
 ### Catalog entry
 

--- a/apps/docs/content/docs/plugins/interactions/discord.mdx
+++ b/apps/docs/content/docs/plugins/interactions/discord.mdx
@@ -82,51 +82,42 @@ Generate an invite URL with the required permissions:
 
 ## Configuration
 
+<Callout type="info" title="Catalog-driven activation (1.5.2+)">
+The `adapters:` config field was removed in [#2650](https://github.com/AtlasDevHQ/atlas/pull/2650) (1.5.2). Adapter activation is driven by `catalog` rows + per-Platform env vars; `chatPlugin()` itself takes no credentials. Discord's static-bot install handler landed in 1.5.3 ([#2749](https://github.com/AtlasDevHQ/atlas/pull/2749)) — the catalog row carries `install_model: "static-bot"`, and bot credentials are read from `DISCORD_BOT_TOKEN`, `DISCORD_APPLICATION_ID`, and `DISCORD_PUBLIC_KEY`. See the [chat plugin docs](/plugins/interactions/chat#configuration) for the canonical shape.
+</Callout>
+
 ```typescript
 import { defineConfig } from "@atlas/api/lib/config";
 import { executeAgentQuery } from "@atlas/api/lib/agent-query";
 import { chatPlugin } from "@useatlas/chat";
 
+const catalog = [
+  { slug: "discord", type: "chat", install_model: "static-bot",
+    enabled: true, saas_eligible: true },
+] as const;
+
 export default defineConfig({
+  catalog,
   plugins: [
     chatPlugin({
-      adapters: {
-        discord: {
-          botToken: process.env.DISCORD_BOT_TOKEN!,
-          applicationId: process.env.DISCORD_APPLICATION_ID!,
-          publicKey: process.env.DISCORD_PUBLIC_KEY!,
-        },
-      },
+      catalog,
       executeQuery: executeAgentQuery,
     }),
   ],
 });
 ```
 
-With optional mention role IDs (to trigger on role mentions, not just direct @mentions):
+Bot credentials come from env vars — see [Environment Variables](#environment-variables) below.
 
-```typescript
-chatPlugin({
-  adapters: {
-    discord: {
-      botToken: process.env.DISCORD_BOT_TOKEN!,
-      applicationId: process.env.DISCORD_APPLICATION_ID!,
-      publicKey: process.env.DISCORD_PUBLIC_KEY!,
-      mentionRoleIds: ["1234567890"],
-    },
-  },
-  executeQuery: executeAgentQuery,
-})
-```
+### Catalog entry
 
-### Options
-
-| Option | Type | Required | Description |
-|--------|------|----------|-------------|
-| `botToken` | `string` | Yes | Discord bot token from the Developer Portal Bot page. |
-| `applicationId` | `string` | Yes | Discord application ID from the General Information page. |
-| `publicKey` | `string` | Yes | Application public key for Ed25519 webhook signature verification. |
-| `mentionRoleIds` | `string[]` | No | Role IDs that trigger mention handlers in addition to direct @mentions. |
+| Field | Value | Description |
+|-------|-------|-------------|
+| `slug` | `"discord"` | Stable platform key. |
+| `type` | `"chat"` | Required for chat dispatch. |
+| `install_model` | `"static-bot"` | Activates the static-bot install handler (1.5.3+). |
+| `enabled` | `true` | Customer can install this row. Ops can flip false to disable without removing the row. |
+| `saas_eligible` | `true` | Visible to the SaaS admin UI. |
 
 ## Mounted Routes
 

--- a/apps/docs/content/docs/plugins/interactions/gchat.mdx
+++ b/apps/docs/content/docs/plugins/interactions/gchat.mdx
@@ -90,71 +90,42 @@ The adapter automatically creates Workspace Events subscriptions when added to a
 
 ## Configuration
 
-### Basic (Service Account Credentials)
+<Callout type="info" title="Catalog-driven activation (1.5.2+)">
+The `adapters:` config field was removed in [#2650](https://github.com/AtlasDevHQ/atlas/pull/2650) (1.5.2). Adapter activation is driven by `catalog` rows + per-Platform env vars; `chatPlugin()` itself takes no credentials. Google Chat's service-account install handler landed in 1.5.3 ([#2754](https://github.com/AtlasDevHQ/atlas/pull/2754)) — the catalog row carries `install_model: "static-bot"`, and the service-account JSON + Pub/Sub topic are read from env vars. See the [chat plugin docs](/plugins/interactions/chat#configuration) for the canonical shape.
+</Callout>
 
 ```typescript
 import { defineConfig } from "@atlas/api/lib/config";
 import { executeAgentQuery } from "@atlas/api/lib/agent-query";
 import { chatPlugin } from "@useatlas/chat";
 
+const catalog = [
+  { slug: "gchat", type: "chat", install_model: "static-bot",
+    enabled: true, saas_eligible: true },
+] as const;
+
 export default defineConfig({
+  catalog,
   plugins: [
     chatPlugin({
-      adapters: {
-        gchat: {
-          credentials: JSON.parse(process.env.GOOGLE_CHAT_CREDENTIALS!),
-        },
-      },
+      catalog,
       executeQuery: executeAgentQuery,
     }),
   ],
 });
 ```
 
-### Application Default Credentials
+Service-account credentials, Pub/Sub topic, and optional impersonation come from env vars — see [Environment Variables](#environment-variables) below.
 
-Use ADC when running on GCE, Cloud Run, or with Workload Identity Federation:
+### Catalog entry
 
-```typescript
-chatPlugin({
-  adapters: {
-    gchat: {
-      useApplicationDefaultCredentials: true,
-    },
-  },
-  executeQuery: executeAgentQuery,
-})
-```
-
-### Full Configuration (With Pub/Sub)
-
-```typescript
-chatPlugin({
-  adapters: {
-    gchat: {
-      credentials: JSON.parse(process.env.GOOGLE_CHAT_CREDENTIALS!),
-      endpointUrl: "https://your-atlas-api.example.com/api/plugins/chat-interaction/webhooks/gchat",
-      pubsubTopic: "projects/my-project/topics/chat-events",
-      impersonateUser: "admin@example.com",
-    },
-  },
-  executeQuery: executeAgentQuery,
-})
-```
-
-### Options
-
-| Option | Type | Required | Description |
-|--------|------|----------|-------------|
-| `credentials` | `object` | No* | Service account credentials (`client_email`, `private_key`, optional `project_id`). |
-| `useApplicationDefaultCredentials` | `true` | No* | Use Application Default Credentials (GCE, Cloud Run, Workload Identity). |
-| `endpointUrl` | `string` | No | HTTP endpoint URL for card button click actions. Required for interactive cards. |
-| `pubsubTopic` | `string` | No | Pub/Sub topic for Workspace Events (format: `projects/{project}/topics/{topic}`). |
-| `impersonateUser` | `string` | No | User email to impersonate for Workspace Events API (domain-wide delegation). |
-
-<Callout type="info">
-\* Provide `credentials` OR `useApplicationDefaultCredentials`, or omit both for automatic detection from `GOOGLE_CHAT_CREDENTIALS` and `GOOGLE_CHAT_USE_ADC` environment variables.
-</Callout>
+| Field | Value | Description |
+|-------|-------|-------------|
+| `slug` | `"gchat"` | Stable platform key. |
+| `type` | `"chat"` | Required for chat dispatch. |
+| `install_model` | `"static-bot"` | Activates the static-bot install handler (1.5.3+). |
+| `enabled` | `true` | Customer can install this row. Ops can flip false to disable without removing the row. |
+| `saas_eligible` | `true` | Visible to the SaaS admin UI. |
 
 ## Mounted Routes
 

--- a/apps/docs/content/docs/plugins/interactions/github.mdx
+++ b/apps/docs/content/docs/plugins/interactions/github.mdx
@@ -72,74 +72,68 @@ For personal bots or testing, you can use a PAT instead of a GitHub App.
 
 ## Configuration
 
-### GitHub App (Multi-Tenant)
+<Callout type="info" title="Catalog-driven activation (1.5.2+)">
+The `adapters:` config field was removed in [#2650](https://github.com/AtlasDevHQ/atlas/pull/2650) (1.5.2). Adapter activation is driven by `catalog` rows + per-Platform env vars; `chatPlugin()` itself takes no credentials. GitHub ships two install models — the OAuth-style App row landed in 1.5.3 ([#2818](https://github.com/AtlasDevHQ/atlas/pull/2818)) and the static-bot PAT row landed alongside it ([#2807](https://github.com/AtlasDevHQ/atlas/pull/2807)). Pick exactly one row per workspace. See the [chat plugin docs](/plugins/interactions/chat#configuration) for the canonical shape.
+</Callout>
+
+### GitHub App (Recommended)
+
+The App row covers both multi-tenant (auto-detect installation from webhook payloads) and single-tenant (fixed `GITHUB_INSTALLATION_ID`) modes — set the env var to lock to one installation, or leave it unset for multi-tenant.
 
 ```typescript
 import { defineConfig } from "@atlas/api/lib/config";
 import { executeAgentQuery } from "@atlas/api/lib/agent-query";
 import { chatPlugin } from "@useatlas/chat";
 
+const catalog = [
+  { slug: "github", type: "chat", install_model: "oauth",
+    enabled: true, saas_eligible: true },
+] as const;
+
 export default defineConfig({
+  catalog,
   plugins: [
     chatPlugin({
-      adapters: {
-        github: {
-          appId: process.env.GITHUB_APP_ID!,
-          privateKey: process.env.GITHUB_PRIVATE_KEY!,
-          webhookSecret: process.env.GITHUB_WEBHOOK_SECRET!,
-        },
-      },
+      catalog,
       executeQuery: executeAgentQuery,
     }),
   ],
 });
 ```
 
-### GitHub App (Single-Tenant)
-
-```typescript
-chatPlugin({
-  adapters: {
-    github: {
-      appId: process.env.GITHUB_APP_ID!,
-      privateKey: process.env.GITHUB_PRIVATE_KEY!,
-      installationId: Number(process.env.GITHUB_INSTALLATION_ID!),
-      webhookSecret: process.env.GITHUB_WEBHOOK_SECRET!,
-    },
-  },
-  executeQuery: executeAgentQuery,
-})
-```
+App ID, private key, and webhook secret come from env vars — see [Environment Variables](#environment-variables) below. Single-tenant mode is selected by also setting `GITHUB_INSTALLATION_ID` to a fixed installation; leave it unset for multi-tenant.
 
 ### Personal Access Token
 
+For personal bots or testing, use the `github-pat` static-bot row:
+
 ```typescript
-chatPlugin({
-  adapters: {
-    github: {
-      token: process.env.GITHUB_TOKEN!,
-      webhookSecret: process.env.GITHUB_WEBHOOK_SECRET!,
-      userName: "my-bot-username",
-    },
-  },
-  executeQuery: executeAgentQuery,
-})
+const catalog = [
+  { slug: "github-pat", type: "chat", install_model: "static-bot",
+    enabled: true, saas_eligible: false },
+] as const;
+
+export default defineConfig({
+  catalog,
+  plugins: [
+    chatPlugin({
+      catalog,
+      executeQuery: executeAgentQuery,
+    }),
+  ],
+});
 ```
 
-### Options
+PAT + webhook secret come from env vars — see [Environment Variables](#environment-variables) below.
 
-| Option | Type | Required | Description |
-|--------|------|----------|-------------|
-| `appId` | `string` | Yes* | GitHub App ID. Required for App-based auth. |
-| `privateKey` | `string` | Yes* | GitHub App private key (PEM format). Required for App-based auth. |
-| `installationId` | `number` | No | Installation ID for single-tenant mode. Omit for multi-tenant (auto-detected from webhook payloads). |
-| `token` | `string` | Yes* | Personal Access Token. Alternative to App-based auth. |
-| `webhookSecret` | `string` | No | Webhook secret for HMAC-SHA256 signature verification. Strongly recommended for production. |
-| `userName` | `string` | No | Bot username for @-mention detection (e.g., `"my-bot"` or `"my-bot[bot]"`). |
+### Catalog entries
 
-<Callout type="info">
-\* Provide either `token` (PAT auth) or `appId` + `privateKey` (GitHub App auth). Do not provide both.
-</Callout>
+| Row | `slug` | `install_model` | Auth mode | Notes |
+|-----|--------|-----------------|-----------|-------|
+| GitHub App | `"github"` | `"oauth"` | App ID + private key | Recommended; covers single- and multi-tenant via env-var presence of `GITHUB_INSTALLATION_ID`. |
+| PAT | `"github-pat"` | `"static-bot"` | Fine-grained PAT | Single-account; not surfaced in the SaaS admin UI (`saas_eligible: false`). |
+
+Don't enable both rows in the same deploy — pick the auth mode that matches the workspace.
 
 ## Mounted Routes
 

--- a/apps/docs/content/docs/plugins/interactions/linear.mdx
+++ b/apps/docs/content/docs/plugins/interactions/linear.mdx
@@ -57,74 +57,66 @@ The client secret grants full access to your Linear OAuth application's permissi
 
 ## Configuration
 
-### API Key Auth
+<Callout type="info" title="Catalog-driven activation (1.5.2+)">
+The `adapters:` config field was removed in [#2650](https://github.com/AtlasDevHQ/atlas/pull/2650) (1.5.2). Adapter activation is driven by `catalog` rows + per-Platform env vars; `chatPlugin()` itself takes no credentials. Linear's OAuth install handler landed in 1.5.3 ([#2750](https://github.com/AtlasDevHQ/atlas/pull/2750)); a separate `linear-apikey` static-bot row covers personal-API-key deploys. Pick exactly one row per workspace — the OAuth row reads `LINEAR_CLIENT_ID` / `LINEAR_CLIENT_SECRET`, the API-key row reads `LINEAR_API_KEY`. Both share `LINEAR_WEBHOOK_SECRET`. See the [chat plugin docs](/plugins/interactions/chat#configuration) for the canonical shape.
+</Callout>
+
+### OAuth App (Recommended)
 
 ```typescript
 import { defineConfig } from "@atlas/api/lib/config";
 import { executeAgentQuery } from "@atlas/api/lib/agent-query";
 import { chatPlugin } from "@useatlas/chat";
 
+const catalog = [
+  { slug: "linear", type: "chat", install_model: "oauth",
+    enabled: true, saas_eligible: true },
+] as const;
+
 export default defineConfig({
+  catalog,
   plugins: [
     chatPlugin({
-      adapters: {
-        linear: {
-          apiKey: process.env.LINEAR_API_KEY!,
-          webhookSecret: process.env.LINEAR_WEBHOOK_SECRET!,
-          userName: "atlas-bot",
-        },
-      },
+      catalog,
       executeQuery: executeAgentQuery,
     }),
   ],
 });
 ```
 
-### OAuth Access Token
+OAuth client credentials come from env vars — see [Environment Variables](#environment-variables) below.
+
+### Personal API Key
+
+For personal bots or single-workspace deploys, use the `linear-apikey` static-bot row:
 
 ```typescript
-chatPlugin({
-  adapters: {
-    linear: {
-      accessToken: process.env.LINEAR_ACCESS_TOKEN!,
-      webhookSecret: process.env.LINEAR_WEBHOOK_SECRET!,
-    },
-  },
-  executeQuery: executeAgentQuery,
-})
+const catalog = [
+  { slug: "linear-apikey", type: "chat", install_model: "static-bot",
+    enabled: true, saas_eligible: false },
+] as const;
+
+export default defineConfig({
+  catalog,
+  plugins: [
+    chatPlugin({
+      catalog,
+      executeQuery: executeAgentQuery,
+    }),
+  ],
+});
 ```
 
-### OAuth App (Client Credentials)
+API key + webhook secret come from env vars — see [Environment Variables](#environment-variables) below.
 
-```typescript
-chatPlugin({
-  adapters: {
-    linear: {
-      clientId: process.env.LINEAR_CLIENT_ID!,
-      clientSecret: process.env.LINEAR_CLIENT_SECRET!,
-      webhookSecret: process.env.LINEAR_WEBHOOK_SECRET!,
-    },
-  },
-  executeQuery: executeAgentQuery,
-})
-```
+### Catalog entries
 
-### Options
+| Row | `slug` | `install_model` | Auth mode | Notes |
+|-----|--------|-----------------|-----------|-------|
+| OAuth | `"linear"` | `"oauth"` | OAuth App client credentials | Recommended; multi-workspace via the install pipeline. |
+| API key | `"linear-apikey"` | `"static-bot"` | Personal API key | Single-workspace; not surfaced in the SaaS admin UI (`saas_eligible: false`). |
 
-| Option | Type | Required | Description |
-|--------|------|----------|-------------|
-| `apiKey` | `string` | Yes* | Personal API key from Linear Settings. |
-| `accessToken` | `string` | Yes* | Pre-obtained OAuth access token. |
-| `clientId` | `string` | Yes* | OAuth application client ID. |
-| `clientSecret` | `string` | Yes* | OAuth application client secret. Required with `clientId`. |
-| `webhookSecret` | `string` | Yes** | Webhook signing secret for HMAC-SHA256 verification. Required by the upstream adapter unless `LINEAR_WEBHOOK_SECRET` env var is set. |
-| `userName` | `string` | No | Bot display name for @-mention detection. Defaults to `LINEAR_BOT_USERNAME` env var or `"linear-bot"`. |
-
-<Callout type="info">
-\* Provide exactly one auth mode: `apiKey`, `accessToken`, or `clientId` + `clientSecret`. Do not combine them.
-
-\*\* The `webhookSecret` can be provided via config or the `LINEAR_WEBHOOK_SECRET` environment variable. The upstream `@chat-adapter/linear` requires it — initialization will fail if neither is set.
-</Callout>
+Don't enable both rows in the same deploy — pick the auth mode that matches the workspace.
 
 ## Mounted Routes
 

--- a/apps/docs/content/docs/plugins/interactions/teams.mdx
+++ b/apps/docs/content/docs/plugins/interactions/teams.mdx
@@ -152,21 +152,31 @@ Teams requires Adaptive Card schema version 1.5 or lower. The plugin uses versio
 
 ## Migrating to @useatlas/chat
 
-Replace `@useatlas/teams` with the Chat SDK bridge plugin:
+Replace `@useatlas/teams` with the Chat SDK bridge plugin. The `adapters:` config field was removed in [#2650](https://github.com/AtlasDevHQ/atlas/pull/2650) (1.5.2); Teams's manifest-driven install handler landed in 1.5.3 ([#2752](https://github.com/AtlasDevHQ/atlas/pull/2752)). Activation is now driven by a `catalog` row + per-Platform env vars — `chatPlugin()` itself takes no credentials.
 
 ```typescript
 // Before:
 import { teamsPlugin } from "@useatlas/teams";
 teamsPlugin({ appId: "...", appPassword: "...", executeQuery })
 
-// After:
+// After (1.5.3+):
+import { defineConfig } from "@atlas/api/lib/config";
 import { chatPlugin } from "@useatlas/chat";
-chatPlugin({
-  adapters: {
-    teams: { appId: "...", appPassword: "...", tenantId: "..." },
-  },
-  executeQuery,
-})
+
+const catalog = [
+  { slug: "teams", type: "chat", install_model: "static-bot",
+    enabled: true, saas_eligible: true },
+] as const;
+
+export default defineConfig({
+  catalog,
+  plugins: [
+    chatPlugin({ catalog, executeQuery }),
+  ],
+});
+
+// env vars:
+//   TEAMS_APP_ID, TEAMS_APP_PASSWORD, TEAMS_TENANT_ID (optional)
 ```
 
 When using the Chat SDK bridge, update the **messaging endpoint** in your Azure Bot Configuration to:

--- a/apps/docs/content/docs/plugins/interactions/telegram.mdx
+++ b/apps/docs/content/docs/plugins/interactions/telegram.mdx
@@ -65,45 +65,42 @@ For the bot to see all messages (not just commands and @mentions), disable priva
 
 ## Configuration
 
+<Callout type="info" title="Catalog-driven activation (1.5.2+)">
+The `adapters:` config field was removed in [#2650](https://github.com/AtlasDevHQ/atlas/pull/2650) (1.5.2). Adapter activation is driven by `catalog` rows + per-Platform env vars; `chatPlugin()` itself takes no credentials. Telegram lands as the first static-bot install model in 1.5.3 ([#2748](https://github.com/AtlasDevHQ/atlas/pull/2748)) — the catalog row carries `install_model: "static-bot"`, and the bot token is read from `TELEGRAM_BOT_TOKEN`. See the [chat plugin docs](/plugins/interactions/chat#configuration) for the canonical shape.
+</Callout>
+
 ```typescript
 import { defineConfig } from "@atlas/api/lib/config";
 import { executeAgentQuery } from "@atlas/api/lib/agent-query";
 import { chatPlugin } from "@useatlas/chat";
 
+const catalog = [
+  { slug: "telegram", type: "chat", install_model: "static-bot",
+    enabled: true, saas_eligible: true },
+] as const;
+
 export default defineConfig({
+  catalog,
   plugins: [
     chatPlugin({
-      adapters: {
-        telegram: {
-          botToken: process.env.TELEGRAM_BOT_TOKEN!,
-        },
-      },
+      catalog,
       executeQuery: executeAgentQuery,
     }),
   ],
 });
 ```
 
-With optional webhook secret token:
+The bot token comes from env vars — see [Environment Variables](#environment-variables) below.
 
-```typescript
-chatPlugin({
-  adapters: {
-    telegram: {
-      botToken: process.env.TELEGRAM_BOT_TOKEN!,
-      secretToken: process.env.TELEGRAM_WEBHOOK_SECRET_TOKEN,
-    },
-  },
-  executeQuery: executeAgentQuery,
-})
-```
+### Catalog entry
 
-### Options
-
-| Option | Type | Required | Description |
-|--------|------|----------|-------------|
-| `botToken` | `string` | Yes | Telegram bot token from BotFather. |
-| `secretToken` | `string` | No | Webhook secret token for verifying incoming requests via `x-telegram-bot-api-secret-token` header. |
+| Field | Value | Description |
+|-------|-------|-------------|
+| `slug` | `"telegram"` | Stable platform key. |
+| `type` | `"chat"` | Required for chat dispatch. |
+| `install_model` | `"static-bot"` | Activates the static-bot install handler (1.5.3+). |
+| `enabled` | `true` | Customer can install this row. Ops can flip false to disable without removing the row. |
+| `saas_eligible` | `true` | Visible to the SaaS admin UI. |
 
 ## Mounted Routes
 

--- a/apps/docs/content/docs/plugins/interactions/whatsapp.mdx
+++ b/apps/docs/content/docs/plugins/interactions/whatsapp.mdx
@@ -56,38 +56,42 @@ The webhook URL must be publicly accessible over HTTPS before you configure it i
 
 ## Configuration
 
+<Callout type="info" title="Catalog-driven activation (1.5.2+)">
+The `adapters:` config field was removed in [#2650](https://github.com/AtlasDevHQ/atlas/pull/2650) (1.5.2). Adapter activation is driven by `catalog` rows + per-Platform env vars; `chatPlugin()` itself takes no credentials. WhatsApp's static-bot install handler landed in 1.5.3 ([#2753](https://github.com/AtlasDevHQ/atlas/pull/2753)) — the catalog row carries `install_model: "static-bot"`, and Cloud API credentials are read from `WHATSAPP_*` env vars. See the [chat plugin docs](/plugins/interactions/chat#configuration) for the canonical shape.
+</Callout>
+
 ```typescript
 import { defineConfig } from "@atlas/api/lib/config";
 import { executeAgentQuery } from "@atlas/api/lib/agent-query";
 import { chatPlugin } from "@useatlas/chat";
 
+const catalog = [
+  { slug: "whatsapp", type: "chat", install_model: "static-bot",
+    enabled: true, saas_eligible: true },
+] as const;
+
 export default defineConfig({
+  catalog,
   plugins: [
     chatPlugin({
-      adapters: {
-        whatsapp: {
-          phoneNumberId: process.env.WHATSAPP_PHONE_NUMBER_ID!,
-          accessToken: process.env.WHATSAPP_ACCESS_TOKEN!,
-          verifyToken: process.env.WHATSAPP_VERIFY_TOKEN!,
-          appSecret: process.env.WHATSAPP_APP_SECRET!,
-        },
-      },
+      catalog,
       executeQuery: executeAgentQuery,
     }),
   ],
 });
 ```
 
-### Options
+Cloud API credentials come from env vars — see [Environment Variables](#environment-variables) below.
 
-| Option | Type | Required | Description |
-|--------|------|----------|-------------|
-| `phoneNumberId` | `string` | Yes | WhatsApp Business phone number ID from the API Setup page. |
-| `accessToken` | `string` | Yes | System User access token with `whatsapp_business_messaging` permission. |
-| `verifyToken` | `string` | Yes | Verify token for webhook challenge-response — must match the value configured in Meta. |
-| `appSecret` | `string` | Yes | Meta App Secret for HMAC-SHA256 webhook signature verification. |
-| `userName` | `string` | No | Bot display name used for identification. |
-| `apiVersion` | `string` | No | Meta Graph API version (default: `"v21.0"`). |
+### Catalog entry
+
+| Field | Value | Description |
+|-------|-------|-------------|
+| `slug` | `"whatsapp"` | Stable platform key. |
+| `type` | `"chat"` | Required for chat dispatch. |
+| `install_model` | `"static-bot"` | Activates the static-bot install handler (1.5.3+). |
+| `enabled` | `true` | Customer can install this row. Ops can flip false to disable without removing the row. |
+| `saas_eligible` | `true` | Visible to the SaaS admin UI. |
 
 ## Mounted Routes
 


### PR DESCRIPTION
## Summary

- Replace the deprecated `adapters: { ... }` config block on seven per-platform interaction docs (`discord`, `gchat`, `github`, `linear`, `teams`, `telegram`, `whatsapp`) with the catalog-driven shape that landed in #2650 (1.5.2 cutover): `catalog: [{ slug, type: "chat", install_model, enabled, saas_eligible }]` + env-var credentials, `chatPlugin()` takes no credentials.
- Per-platform `install_model` matches the install slice that shipped in 1.5.3: `static-bot` for Discord/Telegram/WhatsApp/Google Chat/Teams, `oauth` for the Linear App (#2750) and GitHub App (#2818), and additional `static-bot` rows (`linear-apikey`, `github-pat`) for the personal-credential paths shipped in #2807.
- `chat.mdx` was already updated by #2769 in the 1.5.3 sweep; these seven were left behind.

Closes #2815. Filed a separate follow-up #2837 for env-var name drift in the existing `Environment Variables` tables — deliberately out of scope here to keep the diff focused.

## Test plan

- [x] `grep -rn "adapters: \{" apps/docs/content/docs/plugins/interactions/` returns zero hits
- [x] No cross-page links to old `#options` anchors (`grep` clean)
- [x] `bun run lint` — 0 errors
- [x] `bun run type` — 0 errors
- [x] `bun run test` — full suite green
- [x] `bun x syncpack lint` — no issues
- [x] All `scripts/check-*-drift.sh` gates pass
- [ ] Visual verify on docs.useatlas.dev once Railway deploys

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/2839"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782396497&installation_id=135337507&pr_number=2839&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F2839&signature=22146d3445ebfee62263a777b4214bbecf9b8b69e9ee30189059f7bec40e9cf6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->