### PR TITLE
feat(api,ee): #2731 — Better Auth signup hook → Twenty Person (SIGNUP source)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -717,7 +717,7 @@
     },
     "plugins/twenty": {
       "name": "@useatlas/twenty",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "devDependencies": {
         "@useatlas/plugin-sdk": "workspace:*",
         "ai": "^6.0.141",

--- a/ee/src/saas-crm/__tests__/saas-crm.test.ts
+++ b/ee/src/saas-crm/__tests__/saas-crm.test.ts
@@ -844,6 +844,145 @@ describe("dispatchOutboxRow", () => {
     expect(fetchCount).toBe(0);
   });
 
+  test("signup happy path — upsertPerson stamps SIGNUP, NO createNote (signup carries no message)", async () => {
+    // End-to-end happy path for a brand-new Better Auth signup. The
+    // upsertPerson POST body MUST stamp both atlasFirstSource and
+    // atlasLastSource = "SIGNUP" so the new Twenty Person carries the
+    // sticky first-touch. The dispatcher MUST NOT fire any /rest/notes
+    // call — the signup variant carries no message, so the normalizer
+    // returns a `note`-less NormalizedLead.
+    const fetchSeq: string[] = [];
+    let createPersonBody: Record<string, unknown> | null = null;
+    const fetchImpl = (async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      const method = init?.method ?? "GET";
+      fetchSeq.push(`${method} ${url.replace("https://crm.test.local", "")}`);
+
+      if (method === "GET" && url.includes("/rest/people?filter")) {
+        // New email — no existing Person, so both source fields stamp.
+        return new Response(JSON.stringify({ data: { people: [] } }), {
+          status: 200, headers: { "Content-Type": "application/json" },
+        });
+      }
+      if (method === "POST" && url.endsWith("/rest/people")) {
+        createPersonBody = JSON.parse(String(init?.body ?? "{}"));
+        return new Response(
+          JSON.stringify({ data: { createPerson: { id: "person_signup_1" } } }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      throw new Error(`Unexpected fetch on signup happy path: ${method} ${url}`);
+    }) as unknown as typeof globalThis.fetch;
+
+    const persisted: { person?: string; note?: string } = {};
+    const outcome = await withFetch(fetchImpl, async () =>
+      dispatchOutboxRow(
+        { apiKey: "k", baseUrl: "https://crm.test.local" },
+        {
+          id: "row-signup-happy",
+          eventType: "signup",
+          payload: {
+            source: "signup",
+            email: "signup@test.local",
+            name: "Alice Example",
+          },
+          attempts: 1,
+          twentyPersonId: null,
+          twentyNoteId: null,
+        },
+        {
+          setTwentyPersonId: async (id: string) => { persisted.person = id; },
+          setTwentyNoteId: async (id: string) => { persisted.note = id; },
+        },
+      ),
+    );
+
+    expect(outcome).toEqual({ kind: "ok" });
+    expect(persisted.person).toBe("person_signup_1");
+    // Critical: NO note was created.
+    expect(persisted.note).toBeUndefined();
+    expect(fetchSeq).toHaveLength(2);
+    expect(fetchSeq[0]).toContain("GET /rest/people?filter");
+    expect(fetchSeq[1]).toBe("POST /rest/people");
+    // Sticky first-touch contract: brand-new email gets BOTH source
+    // fields stamped to SIGNUP.
+    expect(createPersonBody).not.toBeNull();
+    const created = createPersonBody as unknown as Record<string, unknown>;
+    expect(created.atlasFirstSource).toBe("SIGNUP");
+    expect(created.atlasLastSource).toBe("SIGNUP");
+    // Name is split at the normalizer seam.
+    expect(created.name).toEqual({
+      firstName: "Alice",
+      lastName: "Example",
+    });
+  });
+
+  test("signup preserves sticky atlasFirstSource on an email that previously demoed", async () => {
+    // AC: an email that previously demoed must keep atlasFirstSource="DEMO"
+    // and only flip atlasLastSource to "SIGNUP". This pins the
+    // first-source preservation contract that lives inside
+    // TwentyClient.upsertPerson — proves slice 4 inherits it correctly.
+    let patchBody: Record<string, unknown> | null = null;
+    const fetchImpl = (async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      const method = init?.method ?? "GET";
+      if (method === "GET" && url.includes("/rest/people?filter")) {
+        // Existing Person with sticky atlasFirstSource set by an earlier demo.
+        return new Response(
+          JSON.stringify({
+            data: {
+              people: [
+                { id: "person_returning", atlasFirstSource: "DEMO", atlasLastSource: "DEMO" },
+              ],
+            },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      if (method === "PATCH" && url.includes("/rest/people/")) {
+        patchBody = JSON.parse(String(init?.body ?? "{}"));
+        return new Response(
+          JSON.stringify({ data: { updatePerson: { id: "person_returning" } } }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      throw new Error(`Unexpected fetch on signup-returning path: ${method} ${url}`);
+    }) as unknown as typeof globalThis.fetch;
+
+    const persisted: { person?: string; note?: string } = {};
+    const outcome = await withFetch(fetchImpl, async () =>
+      dispatchOutboxRow(
+        { apiKey: "k", baseUrl: "https://crm.test.local" },
+        {
+          id: "row-signup-returning",
+          eventType: "signup",
+          payload: {
+            source: "signup",
+            email: "returning@test.local",
+            name: "Bob Returning",
+          },
+          attempts: 1,
+          twentyPersonId: null,
+          twentyNoteId: null,
+        },
+        {
+          setTwentyPersonId: async (id: string) => { persisted.person = id; },
+          setTwentyNoteId: async (id: string) => { persisted.note = id; },
+        },
+      ),
+    );
+
+    expect(outcome).toEqual({ kind: "ok" });
+    expect(persisted.person).toBe("person_returning");
+    expect(persisted.note).toBeUndefined();
+    expect(patchBody).not.toBeNull();
+    const patched = patchBody as unknown as Record<string, unknown>;
+    // Critical: atlasFirstSource is NOT in the PATCH payload — sticky.
+    expect(patched.atlasFirstSource).toBeUndefined();
+    // Only atlasLastSource is updated.
+    expect(patched.atlasLastSource).toBe("SIGNUP");
+  });
+
   test("sales-form: createNote 4xx is dead-lettered with operation=createNote in the message", async () => {
     // upsertPerson succeeds; createNote returns 422. The row must
     // dead-letter so the operator sees the malformed note payload.

--- a/ee/src/saas-crm/__tests__/saas-crm.test.ts
+++ b/ee/src/saas-crm/__tests__/saas-crm.test.ts
@@ -844,7 +844,7 @@ describe("dispatchOutboxRow", () => {
     expect(fetchCount).toBe(0);
   });
 
-  test("signup happy path — upsertPerson stamps SIGNUP, NO createNote (signup carries no message)", async () => {
+  test("signup happy path — upsertPerson stamps SIGNUP, NO createNote", async () => {
     // End-to-end happy path for a brand-new Better Auth signup. The
     // upsertPerson POST body MUST stamp both atlasFirstSource and
     // atlasLastSource = "SIGNUP" so the new Twenty Person carries the
@@ -919,9 +919,9 @@ describe("dispatchOutboxRow", () => {
 
   test("signup preserves sticky atlasFirstSource on an email that previously demoed", async () => {
     // AC: an email that previously demoed must keep atlasFirstSource="DEMO"
-    // and only flip atlasLastSource to "SIGNUP". This pins the
-    // first-source preservation contract that lives inside
-    // TwentyClient.upsertPerson — proves slice 4 inherits it correctly.
+    // and only flip atlasLastSource to "SIGNUP". Pins the first-source
+    // preservation contract that lives inside TwentyClient.upsertPerson
+    // end-to-end through dispatchOutboxRow.
     let patchBody: Record<string, unknown> | null = null;
     const fetchImpl = (async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
       const url = typeof input === "string" ? input : (input as Request).url;

--- a/packages/api/src/lib/auth/__tests__/dispatch-signup-crm-lead.test.ts
+++ b/packages/api/src/lib/auth/__tests__/dispatch-signup-crm-lead.test.ts
@@ -19,7 +19,7 @@
  * plugin options, so the wiring is not introspectable from outside.
  */
 
-import { describe, it, expect, beforeEach, mock } from "bun:test";
+import { describe, it, expect, beforeEach, mock, type Mock } from "bun:test";
 import { Effect, Layer } from "effect";
 import {
   SaasCrm,
@@ -32,6 +32,11 @@ import {
 let runEnterpriseImpl: (p: unknown) => Promise<unknown> = async () => undefined;
 const upsertLeadCalls: SaasCrmLeadInput[] = [];
 
+const mockLogWarn: Mock<(...args: unknown[]) => void> = mock(() => {});
+const mockLogError: Mock<(...args: unknown[]) => void> = mock(() => {});
+const mockLogInfo: Mock<(...args: unknown[]) => void> = mock(() => {});
+const mockLogDebug: Mock<(...args: unknown[]) => void> = mock(() => {});
+
 mock.module("@atlas/api/lib/effect/enterprise-layer", () => ({
   // Capture the program and resolve the Tag through the unit-test
   // doubles below. The default runner provides a real SaasCrm Layer
@@ -40,6 +45,30 @@ mock.module("@atlas/api/lib/effect/enterprise-layer", () => ({
   getEnterpriseRuntime: () => ({
     runPromise: <A, E>(p: Effect.Effect<A, E, never>) => Effect.runPromise(p),
   }),
+  // CLAUDE.md "Mock all exports" rule — the canonical module exports
+  // EnterpriseLayer + the EnterpriseSubsystem type. A partial mock
+  // surfaces as a cross-file SyntaxError once the test runner moves to
+  // bun's `--parallel` workers (slice 6 / #2802).
+  EnterpriseLayer: Layer.empty,
+}));
+
+mock.module("@atlas/api/lib/logger", () => ({
+  createLogger: () => ({
+    info: mockLogInfo,
+    warn: mockLogWarn,
+    error: mockLogError,
+    debug: mockLogDebug,
+  }),
+  getLogger: () => ({
+    info: mockLogInfo,
+    warn: mockLogWarn,
+    error: mockLogError,
+    debug: mockLogDebug,
+  }),
+  withRequestContext: (_ctx: unknown, fn: () => unknown) => fn(),
+  getRequestContext: () => undefined,
+  redactPaths: [],
+  setLogLevel: () => false,
 }));
 
 // ── Import the unit under test AFTER mocks ─────────────────────────
@@ -77,6 +106,10 @@ function noopLayer(): Layer.Layer<SaasCrm> {
 
 beforeEach(() => {
   upsertLeadCalls.length = 0;
+  mockLogWarn.mockClear();
+  mockLogError.mockClear();
+  mockLogInfo.mockClear();
+  mockLogDebug.mockClear();
   // Default: provide a recording Tag and run the helper's program through it.
   runEnterpriseImpl = async (program) => {
     await Effect.runPromise(
@@ -160,7 +193,7 @@ describe("dispatchSignupCrmLead — no-op cases", () => {
 });
 
 describe("dispatchSignupCrmLead — failure swallow contract", () => {
-  it("resolves even when runEnterprise throws synchronously", async () => {
+  it("resolves and logs `signup_crm.dispatch_defect` when runEnterprise throws synchronously", async () => {
     runEnterpriseImpl = async () => {
       throw new Error("simulated defect inside runEnterprise");
     };
@@ -170,9 +203,15 @@ describe("dispatchSignupCrmLead — failure swallow contract", () => {
         user: { id: "u8", email: "die@test.com", name: "X" },
       }),
     ).resolves.toBeUndefined();
+
+    // CLAUDE.md "every catch must log" — pin the defect path emits.
+    expect(mockLogWarn).toHaveBeenCalledTimes(1);
+    const [logCtx] = mockLogWarn.mock.calls[0] as [Record<string, unknown>, string];
+    expect(logCtx.event).toBe("signup_crm.dispatch_defect");
+    expect(logCtx.userId).toBe("u8");
   });
 
-  it("resolves even when runEnterprise rejects asynchronously", async () => {
+  it("resolves and logs `signup_crm.dispatch_defect` when runEnterprise rejects asynchronously", async () => {
     runEnterpriseImpl = async () => Promise.reject(new Error("async reject"));
 
     await expect(
@@ -180,9 +219,13 @@ describe("dispatchSignupCrmLead — failure swallow contract", () => {
         user: { id: "u9", email: "reject@test.com" },
       }),
     ).resolves.toBeUndefined();
+
+    expect(mockLogWarn).toHaveBeenCalledTimes(1);
+    const [logCtx] = mockLogWarn.mock.calls[0] as [Record<string, unknown>, string];
+    expect(logCtx.event).toBe("signup_crm.dispatch_defect");
   });
 
-  it("resolves when SaasCrm.upsertLead fails with a typed Error", async () => {
+  it("resolves and logs `signup_crm.enqueue_failed` when SaasCrm.upsertLead fails with a typed Error", async () => {
     runEnterpriseImpl = async (program) => {
       await Effect.runPromise(
         Effect.provide(
@@ -197,6 +240,15 @@ describe("dispatchSignupCrmLead — failure swallow contract", () => {
         user: { id: "u10", email: "pgblip@test.com", name: "X" },
       }),
     ).resolves.toBeUndefined();
+
+    // The typed `Effect.fail` path goes through `Effect.either` Left,
+    // not the outer catch — pin that branch independently so a future
+    // refactor that drops the Left-side log gets caught here, not by
+    // relying on EE's `tapError` for the audit trail.
+    expect(mockLogWarn).toHaveBeenCalledTimes(1);
+    const [logCtx] = mockLogWarn.mock.calls[0] as [Record<string, unknown>, string];
+    expect(logCtx.event).toBe("signup_crm.enqueue_failed");
+    expect(logCtx.userId).toBe("u10");
   });
 });
 

--- a/packages/api/src/lib/auth/__tests__/dispatch-signup-crm-lead.test.ts
+++ b/packages/api/src/lib/auth/__tests__/dispatch-signup-crm-lead.test.ts
@@ -1,0 +1,221 @@
+/**
+ * Regression coverage for the Better Auth signup → Twenty CRM dispatch
+ * helper ({@link dispatchSignupCrmLead}).
+ *
+ * Contract:
+ *   - Email-bearing signup → enqueues a `signup` lead via SaasCrm.upsertLead.
+ *   - Missing / empty email → no-op (the upstream auth path should already
+ *     have rejected this, but the helper must not propagate).
+ *   - `name` is forwarded as a single string; first/last split happens
+ *     downstream in the normalizer.
+ *   - Self-hosted (Noop SaasCrm) → no Twenty traffic; helper resolves.
+ *   - Enterprise runtime rejects / dies → swallowed; helper resolves.
+ *   - upsertLead's typed `Error` channel → swallowed; helper resolves.
+ *
+ * Same caveat as `assign-saas-trial.test.ts`: this exercises the helper
+ * in isolation. It cannot detect a refactor that removes the
+ * `dispatchSignupCrmLead({ user })` call from
+ * `databaseHooks.user.create.after` — Better Auth closes over its
+ * plugin options, so the wiring is not introspectable from outside.
+ */
+
+import { describe, it, expect, beforeEach, mock } from "bun:test";
+import { Effect, Layer } from "effect";
+import {
+  SaasCrm,
+  type SaasCrmLeadInput,
+  type SaasCrmShape,
+} from "@atlas/api/lib/effect/services";
+
+// ── Mock storage state (controlled per-test) ────────────────────────
+
+let runEnterpriseImpl: (p: unknown) => Promise<unknown> = async () => undefined;
+const upsertLeadCalls: SaasCrmLeadInput[] = [];
+
+mock.module("@atlas/api/lib/effect/enterprise-layer", () => ({
+  // Capture the program and resolve the Tag through the unit-test
+  // doubles below. The default runner provides a real SaasCrm Layer
+  // whose `upsertLead` pushes into `upsertLeadCalls`.
+  runEnterprise: (p: unknown) => runEnterpriseImpl(p),
+  getEnterpriseRuntime: () => ({
+    runPromise: <A, E>(p: Effect.Effect<A, E, never>) => Effect.runPromise(p),
+  }),
+}));
+
+// ── Import the unit under test AFTER mocks ─────────────────────────
+
+const { dispatchSignupCrmLead } = await import("../server");
+
+// `dispatchSignupCrmLead` only calls `upsertLead` — the per-row
+// `dispatcher` hook is flusher-side only. We cast the recording shape
+// to `SaasCrmShape` because providing a typed dispatcher stub would
+// drag the full ClaimedOutboxRow / DispatchOutcome graph into this
+// test for zero behavioural value.
+function recordingLayer(): Layer.Layer<SaasCrm> {
+  return Layer.succeed(SaasCrm, {
+    available: true,
+    upsertLead: (input: SaasCrmLeadInput) => {
+      upsertLeadCalls.push(input);
+      return Effect.void;
+    },
+  } as unknown as SaasCrmShape);
+}
+
+function failingLayer(err: Error): Layer.Layer<SaasCrm> {
+  return Layer.succeed(SaasCrm, {
+    available: true,
+    upsertLead: () => Effect.fail(err),
+  } as unknown as SaasCrmShape);
+}
+
+function noopLayer(): Layer.Layer<SaasCrm> {
+  return Layer.succeed(SaasCrm, {
+    available: false,
+    upsertLead: () => Effect.void,
+  });
+}
+
+beforeEach(() => {
+  upsertLeadCalls.length = 0;
+  // Default: provide a recording Tag and run the helper's program through it.
+  runEnterpriseImpl = async (program) => {
+    await Effect.runPromise(
+      Effect.provide(program as Effect.Effect<unknown, never, SaasCrm>, recordingLayer()),
+    );
+  };
+});
+
+describe("dispatchSignupCrmLead — happy path", () => {
+  it("enqueues a signup lead with email + name", async () => {
+    await dispatchSignupCrmLead({
+      user: { id: "u1", email: "Alice@Example.com", name: "Alice Example" },
+    });
+
+    expect(upsertLeadCalls).toHaveLength(1);
+    expect(upsertLeadCalls[0]).toEqual({
+      source: "signup",
+      email: "alice@example.com",
+      name: "Alice Example",
+    });
+  });
+
+  it("enqueues without `name` when name is null", async () => {
+    await dispatchSignupCrmLead({
+      user: { id: "u2", email: "bob@example.com", name: null },
+    });
+
+    expect(upsertLeadCalls).toHaveLength(1);
+    expect(upsertLeadCalls[0]).toEqual({
+      source: "signup",
+      email: "bob@example.com",
+    });
+    expect("name" in upsertLeadCalls[0]).toBe(false);
+  });
+
+  it("enqueues without `name` when name is undefined", async () => {
+    await dispatchSignupCrmLead({
+      user: { id: "u3", email: "carol@example.com" },
+    });
+
+    expect(upsertLeadCalls).toHaveLength(1);
+    expect("name" in upsertLeadCalls[0]).toBe(false);
+  });
+
+  it("strips empty / whitespace-only name", async () => {
+    for (const name of ["", "   ", "\t"]) {
+      upsertLeadCalls.length = 0;
+      await dispatchSignupCrmLead({
+        user: { id: "u4", email: "d@e.com", name },
+      });
+      expect(upsertLeadCalls).toHaveLength(1);
+      expect("name" in upsertLeadCalls[0]).toBe(false);
+    }
+  });
+});
+
+describe("dispatchSignupCrmLead — no-op cases", () => {
+  it("does nothing when email is missing", async () => {
+    await dispatchSignupCrmLead({
+      user: { id: "u5" },
+    });
+    expect(upsertLeadCalls).toHaveLength(0);
+  });
+
+  it("does nothing when email is null", async () => {
+    await dispatchSignupCrmLead({
+      user: { id: "u6", email: null },
+    });
+    expect(upsertLeadCalls).toHaveLength(0);
+  });
+
+  it("does nothing when email is empty / whitespace-only", async () => {
+    for (const email of ["", "   "]) {
+      upsertLeadCalls.length = 0;
+      await dispatchSignupCrmLead({
+        user: { id: "u7", email },
+      });
+      expect(upsertLeadCalls).toHaveLength(0);
+    }
+  });
+});
+
+describe("dispatchSignupCrmLead — failure swallow contract", () => {
+  it("resolves even when runEnterprise throws synchronously", async () => {
+    runEnterpriseImpl = async () => {
+      throw new Error("simulated defect inside runEnterprise");
+    };
+
+    await expect(
+      dispatchSignupCrmLead({
+        user: { id: "u8", email: "die@test.com", name: "X" },
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("resolves even when runEnterprise rejects asynchronously", async () => {
+    runEnterpriseImpl = async () => Promise.reject(new Error("async reject"));
+
+    await expect(
+      dispatchSignupCrmLead({
+        user: { id: "u9", email: "reject@test.com" },
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("resolves when SaasCrm.upsertLead fails with a typed Error", async () => {
+    runEnterpriseImpl = async (program) => {
+      await Effect.runPromise(
+        Effect.provide(
+          program as Effect.Effect<unknown, never, SaasCrm>,
+          failingLayer(new Error("crm_outbox enqueue failed — pg blip")),
+        ),
+      );
+    };
+
+    await expect(
+      dispatchSignupCrmLead({
+        user: { id: "u10", email: "pgblip@test.com", name: "X" },
+      }),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe("dispatchSignupCrmLead — Noop / self-hosted shape", () => {
+  it("resolves without dispatching when SaasCrm is unavailable", async () => {
+    let runs = 0;
+    runEnterpriseImpl = async (program) => {
+      runs++;
+      await Effect.runPromise(
+        Effect.provide(program as Effect.Effect<unknown, never, SaasCrm>, noopLayer()),
+      );
+    };
+
+    await expect(
+      dispatchSignupCrmLead({
+        user: { id: "u11", email: "selfhosted@test.com" },
+      }),
+    ).resolves.toBeUndefined();
+    expect(runs).toBe(1);
+    expect(upsertLeadCalls).toHaveLength(0);
+  });
+});

--- a/packages/api/src/lib/auth/server.ts
+++ b/packages/api/src/lib/auth/server.ts
@@ -227,6 +227,92 @@ export async function assignSaasTrial(args: {
 }
 
 /**
+ * Fire-and-forget Twenty CRM dispatch for a Better Auth signup. Enqueues
+ * a `signup` lead into `crm_outbox` via the `SaasCrm` Tag; the
+ * scheduler-backed flusher (`lib/effect/layers.ts:makeSchedulerLive`)
+ * picks it up on the next tick and calls `TwentyClient.upsertPerson`.
+ *
+ * First-source preservation is delegated to `upsertPerson` itself: a
+ * brand-new email gets both `atlasFirstSource` and `atlasLastSource`
+ * set to `SIGNUP`; an email that previously demoed keeps its sticky
+ * `atlasFirstSource=DEMO` and only `atlasLastSource` flips to `SIGNUP`.
+ *
+ * Self-hosted (no enterprise) resolves to the `NoopSaasCrm` Layer →
+ * `upsertLead` is `Effect.void` and no Twenty traffic is generated.
+ *
+ * Latency contract: this MUST stay non-blocking on the signup happy
+ * path. The enqueue is a single Postgres INSERT — fast — but any
+ * outage in the enterprise runtime (a future Layer change, a stuck
+ * runPromise, an unhandled rejection) must not turn into a 500 on the
+ * auth endpoint. Both branches are wrapped: the outer `try/catch`
+ * around `runEnterprise` absorbs runtime defects, and the inner
+ * `Effect.either` absorbs upsertLead's typed `Error` channel without
+ * a re-throw. Mirrors the swallow contract in
+ * `packages/api/src/lib/demo.ts:captureDemoLead`.
+ *
+ * Exported for direct unit testing — the Better Auth hook closes over
+ * its options inside `buildAuthOptions`, so the only way to assert
+ * the contract from outside the plugin wiring is to test the helper
+ * in isolation.
+ *
+ * @internal
+ */
+export async function dispatchSignupCrmLead(args: {
+  user: { id: string; email?: string | null; name?: string | null };
+}): Promise<void> {
+  const { user } = args;
+  const email = user.email?.toLowerCase().trim();
+  if (!email) return;
+
+  // Defer the heavy imports — keeps the auth module's top-level cost
+  // unchanged for non-SaaS deployments that never hit this path.
+  let SaasCrm: typeof import("@atlas/api/lib/effect/services").SaasCrm;
+  let runEnterprise: typeof import("@atlas/api/lib/effect/enterprise-layer").runEnterprise;
+  let Effect: typeof import("effect").Effect;
+  try {
+    ({ SaasCrm } = await import("@atlas/api/lib/effect/services"));
+    ({ runEnterprise } = await import("@atlas/api/lib/effect/enterprise-layer"));
+    ({ Effect } = await import("effect"));
+  } catch (err) {
+    log.warn(
+      { err: errorMessage(err), userId: user.id },
+      "SaasCrm dispatch skipped — enterprise runtime imports failed",
+    );
+    return;
+  }
+
+  const name = user.name?.trim() || undefined;
+
+  try {
+    await runEnterprise(
+      Effect.gen(function* () {
+        const crm = yield* SaasCrm;
+        // `Effect.either` collapses the typed Postgres-write failure
+        // into a Right/Left tuple so we don't reject the runPromise
+        // — the failure is already logged inside SaasCrmLive's
+        // `tapError` and we don't want the auth handler to see it.
+        yield* crm
+          .upsertLead({
+            source: "signup",
+            email,
+            ...(name ? { name } : {}),
+          })
+          .pipe(Effect.either);
+      }),
+    );
+  } catch (err) {
+    // Defects (runPromise died, unhandled rejection inside a future
+    // Layer change, etc.) — swallow with a structured log so a Twenty
+    // outage or an EE-layer regression never turns into a 500 on the
+    // signup endpoint.
+    log.warn(
+      { userId: user.id, err: errorMessage(err) },
+      "Unexpected SaasCrm dispatch error during signup — swallowed to keep auth response unblocked",
+    );
+  }
+}
+
+/**
  * Built-in rate-limit ceilings for Better Auth endpoints. Chosen to slow
  * online brute force and email-verification abuse while tolerating
  * legitimate retry patterns (user fat-fingers password 2–3 times, clicks
@@ -1918,6 +2004,18 @@ export function buildAuthOptions(deps: BuildAuthOptionsDeps): Parameters<typeof 
             }
           },
           after: async (user: User) => {
+            // SaaS CRM dispatch — non-blocking enqueue into crm_outbox.
+            // Self-hosted resolves to NoopSaasCrm (no Twenty traffic);
+            // SaaS enqueues a `signup` lead that the scheduler-backed
+            // flusher picks up on the next tick. Awaited deliberately:
+            // the helper internally swallows ALL failure modes (Effect
+            // defects, enqueue errors, missing enterprise runtime), so
+            // the await only blocks on the single Postgres INSERT, which
+            // is fast. Not awaiting would expose us to an unhandled
+            // promise rejection if a future change widens the error
+            // channel.
+            await dispatchSignupCrmLead({ user });
+
             // Onboarding welcome email — fire-and-forget after signup.
             // Deferred with setTimeout to allow Better Auth to create the org/membership first.
             if (user.email) {

--- a/packages/api/src/lib/auth/server.ts
+++ b/packages/api/src/lib/auth/server.ts
@@ -41,6 +41,9 @@ import { adminAccessControl, adminRole as adminUserRole, platformAdminRole } fro
 import { getStripePlans, resolvePlanTierFromPriceId, TRIAL_DAYS } from "@atlas/api/lib/billing/plans";
 import { invalidatePlanCache, checkResourceLimit } from "@atlas/api/lib/billing/enforcement";
 import { getConfig } from "@atlas/api/lib/config";
+import { SaasCrm } from "@atlas/api/lib/effect/services";
+import { runEnterprise } from "@atlas/api/lib/effect/enterprise-layer";
+import { Effect } from "effect";
 
 /**
  * Build the socialProviders config from environment variables.
@@ -227,33 +230,26 @@ export async function assignSaasTrial(args: {
 }
 
 /**
- * Fire-and-forget Twenty CRM dispatch for a Better Auth signup. Enqueues
- * a `signup` lead into `crm_outbox` via the `SaasCrm` Tag; the
- * scheduler-backed flusher (`lib/effect/layers.ts:makeSchedulerLive`)
- * picks it up on the next tick and calls `TwentyClient.upsertPerson`.
+ * Twenty CRM dispatch for a Better Auth signup. Enqueues a `signup`
+ * lead into `crm_outbox` via the `SaasCrm` Tag; the scheduler-backed
+ * flusher (`lib/effect/layers.ts:makeSchedulerLive`) picks it up and
+ * calls `TwentyClient.upsertPerson` — first/last source semantics live
+ * inside `upsertPerson`, not here. Self-hosted resolves to the no-op
+ * `SaasCrm` Layer and produces no Twenty traffic.
  *
- * First-source preservation is delegated to `upsertPerson` itself: a
- * brand-new email gets both `atlasFirstSource` and `atlasLastSource`
- * set to `SIGNUP`; an email that previously demoed keeps its sticky
- * `atlasFirstSource=DEMO` and only `atlasLastSource` flips to `SIGNUP`.
+ * A Twenty outage MUST NOT 500 the signup endpoint. Two layers of
+ * defense:
+ *  - inner `.pipe(Effect.either)` absorbs `upsertLead`'s typed `Error`
+ *    channel (e.g. a `crm_outbox` Postgres blip), with a structured
+ *    `log.warn` so the failure surfaces in this module's logs — does
+ *    NOT rely on the EE-side `tapError` for the audit trail.
+ *  - outer `try/catch` absorbs runtime defects (a stuck `runPromise`,
+ *    an unhandled rejection from a future Layer change).
  *
- * Self-hosted (no enterprise) resolves to the `NoopSaasCrm` Layer →
- * `upsertLead` is `Effect.void` and no Twenty traffic is generated.
- *
- * Latency contract: this MUST stay non-blocking on the signup happy
- * path. The enqueue is a single Postgres INSERT — fast — but any
- * outage in the enterprise runtime (a future Layer change, a stuck
- * runPromise, an unhandled rejection) must not turn into a 500 on the
- * auth endpoint. Both branches are wrapped: the outer `try/catch`
- * around `runEnterprise` absorbs runtime defects, and the inner
- * `Effect.either` absorbs upsertLead's typed `Error` channel without
- * a re-throw. Mirrors the swallow contract in
- * `packages/api/src/lib/demo.ts:captureDemoLead`.
- *
- * Exported for direct unit testing — the Better Auth hook closes over
- * its options inside `buildAuthOptions`, so the only way to assert
- * the contract from outside the plugin wiring is to test the helper
- * in isolation.
+ * Exported for direct unit testing — Better Auth closes over its
+ * options inside `buildAuthOptions`, so the only way to assert the
+ * contract from outside the plugin wiring is to test the helper in
+ * isolation. Mirrors `captureDemoLead` in `lib/demo.ts`.
  *
  * @internal
  */
@@ -264,49 +260,38 @@ export async function dispatchSignupCrmLead(args: {
   const email = user.email?.toLowerCase().trim();
   if (!email) return;
 
-  // Defer the heavy imports — keeps the auth module's top-level cost
-  // unchanged for non-SaaS deployments that never hit this path.
-  let SaasCrm: typeof import("@atlas/api/lib/effect/services").SaasCrm;
-  let runEnterprise: typeof import("@atlas/api/lib/effect/enterprise-layer").runEnterprise;
-  let Effect: typeof import("effect").Effect;
-  try {
-    ({ SaasCrm } = await import("@atlas/api/lib/effect/services"));
-    ({ runEnterprise } = await import("@atlas/api/lib/effect/enterprise-layer"));
-    ({ Effect } = await import("effect"));
-  } catch (err) {
-    log.warn(
-      { err: errorMessage(err), userId: user.id },
-      "SaasCrm dispatch skipped — enterprise runtime imports failed",
-    );
-    return;
-  }
-
   const name = user.name?.trim() || undefined;
 
   try {
     await runEnterprise(
       Effect.gen(function* () {
         const crm = yield* SaasCrm;
-        // `Effect.either` collapses the typed Postgres-write failure
-        // into a Right/Left tuple so we don't reject the runPromise
-        // — the failure is already logged inside SaasCrmLive's
-        // `tapError` and we don't want the auth handler to see it.
-        yield* crm
+        const result = yield* crm
           .upsertLead({
             source: "signup",
             email,
             ...(name ? { name } : {}),
           })
           .pipe(Effect.either);
+        if (result._tag === "Left") {
+          log.warn(
+            {
+              userId: user.id,
+              err: errorMessage(result.left),
+              event: "signup_crm.enqueue_failed",
+            },
+            "SaasCrm.upsertLead enqueue failed during signup — swallowed to keep auth response unblocked",
+          );
+        }
       }),
     );
   } catch (err) {
-    // Defects (runPromise died, unhandled rejection inside a future
-    // Layer change, etc.) — swallow with a structured log so a Twenty
-    // outage or an EE-layer regression never turns into a 500 on the
-    // signup endpoint.
     log.warn(
-      { userId: user.id, err: errorMessage(err) },
+      {
+        userId: user.id,
+        err: errorMessage(err),
+        event: "signup_crm.dispatch_defect",
+      },
       "Unexpected SaasCrm dispatch error during signup — swallowed to keep auth response unblocked",
     );
   }
@@ -2004,16 +1989,10 @@ export function buildAuthOptions(deps: BuildAuthOptionsDeps): Parameters<typeof 
             }
           },
           after: async (user: User) => {
-            // SaaS CRM dispatch — non-blocking enqueue into crm_outbox.
-            // Self-hosted resolves to NoopSaasCrm (no Twenty traffic);
-            // SaaS enqueues a `signup` lead that the scheduler-backed
-            // flusher picks up on the next tick. Awaited deliberately:
-            // the helper internally swallows ALL failure modes (Effect
-            // defects, enqueue errors, missing enterprise runtime), so
-            // the await only blocks on the single Postgres INSERT, which
-            // is fast. Not awaiting would expose us to an unhandled
-            // promise rejection if a future change widens the error
-            // channel.
+            // Awaited deliberately — the helper swallows every failure
+            // mode internally, so the await only blocks on the
+            // outbox INSERT. Not awaiting risks an unhandled rejection
+            // if a future change widens the error channel.
             await dispatchSignupCrmLead({ user });
 
             // Onboarding welcome email — fire-and-forget after signup.

--- a/packages/api/src/lib/effect/services.ts
+++ b/packages/api/src/lib/effect/services.ts
@@ -2429,6 +2429,15 @@ export type SaasCrmLeadInput =
       readonly message: string;
       readonly ip?: string | null;
       readonly userAgent?: string | null;
+    }
+  | {
+      readonly source: "signup";
+      readonly email: string;
+      /**
+       * Better Auth `user.name` — optional because email-only signup is
+       * allowed. Split into first/last at the normalizer seam.
+       */
+      readonly name?: string;
     };
 
 /**

--- a/plugins/twenty/__tests__/lead-normalizer.test.ts
+++ b/plugins/twenty/__tests__/lead-normalizer.test.ts
@@ -7,8 +7,10 @@ import {
   normalizeDemoLead,
   normalizeLead,
   normalizeSalesFormLead,
+  normalizeSignupLead,
   type AtlasDemoLeadEvent,
   type AtlasSalesFormLeadEvent,
+  type AtlasSignupLeadEvent,
 } from "../src/lead-normalizer";
 
 describe("normalizeDemoLead", () => {
@@ -208,6 +210,103 @@ describe("normalizeSalesFormLead", () => {
   });
 });
 
+describe("normalizeSignupLead", () => {
+  test("maps a full signup event to a Twenty upsert payload (no note)", () => {
+    const event: AtlasSignupLeadEvent = {
+      source: "signup",
+      email: "User@Example.com",
+      name: "Alice Example",
+    };
+
+    const result = normalizeSignupLead(event);
+
+    expect(result.eventSource).toBe("SIGNUP");
+    expect(result.person.email).toBe("user@example.com");
+    expect(result.person.eventSource).toBe("SIGNUP");
+    expect(result.person.name).toEqual({ firstName: "Alice", lastName: "Example" });
+    // Signup events carry no IP/message → no atlasIp, no Note.
+    expect(result.person.customFields).toEqual({});
+    expect(result.note).toBeUndefined();
+  });
+
+  test("lowercases and trims the email", () => {
+    const result = normalizeSignupLead({
+      source: "signup",
+      email: "  Bob@ACME.COM ",
+      name: "Bob",
+    });
+    expect(result.person.email).toBe("bob@acme.com");
+  });
+
+  test("single-word name maps to firstName only (no empty lastName)", () => {
+    const result = normalizeSignupLead({
+      source: "signup",
+      email: "u@t.com",
+      name: "Cher",
+    });
+    expect(result.person.name).toEqual({ firstName: "Cher" });
+  });
+
+  test("multi-word last name collapses everything after the first whitespace into lastName", () => {
+    const result = normalizeSignupLead({
+      source: "signup",
+      email: "u@t.com",
+      name: "Mary  Anne   Van Der Beek",
+    });
+    expect(result.person.name).toEqual({
+      firstName: "Mary",
+      lastName: "Anne Van Der Beek",
+    });
+  });
+
+  test("omits name when missing — Better Auth allows email-only signup", () => {
+    const result = normalizeSignupLead({
+      source: "signup",
+      email: "u@t.com",
+    });
+    expect(result.person.name).toBeUndefined();
+  });
+
+  test("omits name when empty / whitespace-only — never PATCH a stray empty name", () => {
+    for (const name of ["", "   ", "\t"]) {
+      const result = normalizeSignupLead({
+        source: "signup",
+        email: "u@t.com",
+        name,
+      });
+      expect(result.person.name).toBeUndefined();
+    }
+  });
+
+  test("always stamps eventSource = SIGNUP for the signup variant", () => {
+    const result = normalizeSignupLead({ source: "signup", email: "u@t.com" });
+    expect(result.eventSource).toBe("SIGNUP");
+    expect(result.person.eventSource).toBe("SIGNUP");
+  });
+
+  test("never attaches a Note (signup carries no message)", () => {
+    const result = normalizeSignupLead({
+      source: "signup",
+      email: "u@t.com",
+      name: "Alice Example",
+    });
+    expect(result.note).toBeUndefined();
+  });
+
+  test("does NOT round-trip an ip — signup doesn't capture one", () => {
+    // Future-proof: even if a caller is widened to pass ip, it must not
+    // appear on the Person — the signup variant is explicitly the
+    // "auth-side, no request context" lead.
+    const result = normalizeSignupLead({
+      source: "signup",
+      email: "u@t.com",
+      name: "Alice",
+    });
+    expect(result.person.customFields).toEqual({});
+    expect(JSON.stringify(result)).not.toContain("atlasIp");
+  });
+});
+
 describe("normalizeLead — dispatch", () => {
   test("dispatches demo source to the demo normalizer", () => {
     const result = normalizeLead({ source: "demo", email: "u@t.com" });
@@ -225,5 +324,15 @@ describe("normalizeLead — dispatch", () => {
     });
     expect(result.eventSource).toBe("SALES_FORM");
     expect(result.note?.body).toBe("Hi");
+  });
+
+  test("dispatches signup source to the signup normalizer", () => {
+    const result = normalizeLead({
+      source: "signup",
+      email: "u@t.com",
+      name: "Alice Example",
+    });
+    expect(result.eventSource).toBe("SIGNUP");
+    expect(result.note).toBeUndefined();
   });
 });

--- a/plugins/twenty/src/index.ts
+++ b/plugins/twenty/src/index.ts
@@ -54,9 +54,11 @@ export {
 export {
   normalizeDemoLead,
   normalizeSalesFormLead,
+  normalizeSignupLead,
   normalizeLead,
   type AtlasDemoLeadEvent,
   type AtlasSalesFormLeadEvent,
+  type AtlasSignupLeadEvent,
   type AtlasEventSource,
   type AtlasLeadEvent,
   type NormalizedLead,

--- a/plugins/twenty/src/lead-normalizer.ts
+++ b/plugins/twenty/src/lead-normalizer.ts
@@ -2,7 +2,7 @@
  * LeadNormalizer — pure mapping from Atlas lead events to the Twenty
  * upsert input shape.
  *
- * Ships the `demo` and `sales-form` variants. `normalizeLead`'s
+ * Ships the `demo`, `sales-form`, and `signup` variants. `normalizeLead`'s
  * exhaustive switch surfaces a compile error the moment a new union
  * member lands.
  *
@@ -54,11 +54,33 @@ export interface AtlasSalesFormLeadEvent {
 }
 
 /**
+ * Better Auth signup variant — fired by the `user.create.after` hook in
+ * `packages/api/src/lib/auth/server.ts`. No request context (no IP, no
+ * UA) since the hook runs post-commit on the auth pathway, and no
+ * attached message — first/last source semantics are owned by
+ * `TwentyClient.upsertPerson`, so a prior demo/sales-form touch keeps
+ * its `atlasFirstSource` and only `atlasLastSource` flips to `SIGNUP`.
+ */
+export interface AtlasSignupLeadEvent {
+  readonly source: "signup";
+  readonly email: string;
+  /**
+   * Full name from Better Auth's `user.name` field — split into
+   * first/last at the seam (parity with the sales-form variant).
+   * Optional because email-only signup is allowed.
+   */
+  readonly name?: string;
+}
+
+/**
  * Discriminated union over every Atlas-internal lead event. The
  * exhaustiveness check in `normalizeLead` catches missing handlers
  * at compile time.
  */
-export type AtlasLeadEvent = AtlasDemoLeadEvent | AtlasSalesFormLeadEvent;
+export type AtlasLeadEvent =
+  | AtlasDemoLeadEvent
+  | AtlasSalesFormLeadEvent
+  | AtlasSignupLeadEvent;
 
 /** Note attached to the Person — only emitted by variants that carry a message. */
 export interface NormalizedNote {
@@ -149,6 +171,31 @@ export function normalizeSalesFormLead(
   };
 }
 
+/**
+ * Normalize a Better Auth signup lead event to a Twenty upsert payload.
+ * No note — signup events don't carry a message; first vs. last source
+ * semantics are owned by `upsertPerson`, not the normalizer.
+ */
+export function normalizeSignupLead(event: AtlasSignupLeadEvent): NormalizedLead {
+  const email = event.email.toLowerCase().trim();
+  const eventSource: AtlasEventSource = "SIGNUP";
+
+  // No request context on the auth-side hook → no atlasIp.
+  const customFields: { atlasIp?: string } = {};
+
+  const name = event.name ? splitName(event.name) : undefined;
+
+  return {
+    person: {
+      email,
+      eventSource,
+      ...(name ? { name } : {}),
+      customFields,
+    },
+    eventSource,
+  };
+}
+
 /** Dispatch on `source`. */
 export function normalizeLead(event: AtlasLeadEvent): NormalizedLead {
   switch (event.source) {
@@ -156,6 +203,8 @@ export function normalizeLead(event: AtlasLeadEvent): NormalizedLead {
       return normalizeDemoLead(event);
     case "sales-form":
       return normalizeSalesFormLead(event);
+    case "signup":
+      return normalizeSignupLead(event);
     default: {
       // Exhaustiveness — when new variants are added to `AtlasLeadEvent`,
       // the absence of a case here surfaces as a tsgo compile error.

--- a/plugins/twenty/src/lead-normalizer.ts
+++ b/plugins/twenty/src/lead-normalizer.ts
@@ -180,7 +180,6 @@ export function normalizeSignupLead(event: AtlasSignupLeadEvent): NormalizedLead
   const email = event.email.toLowerCase().trim();
   const eventSource: AtlasEventSource = "SIGNUP";
 
-  // No request context on the auth-side hook → no atlasIp.
   const customFields: { atlasIp?: string } = {};
 
   const name = event.name ? splitName(event.name) : undefined;


### PR DESCRIPTION
## Summary

Slice 4 of [1.6.0 — CRM & Lead Capture](https://github.com/AtlasDevHQ/atlas/milestone/52). Closes #2731.

Wires Better Auth's `databaseHooks.user.create.after` to enqueue a `signup` lead via the `SaasCrm` Tag. Every new account on app.useatlas.dev becomes a Twenty Person stamped with the `SIGNUP` source.

- **Brand-new email**: `atlasFirstSource = atlasLastSource = "SIGNUP"`
- **Email that previously demoed**: sticky `atlasFirstSource` (e.g. `"DEMO"`) is preserved; only `atlasLastSource` flips to `"SIGNUP"` — preservation owned by `TwentyClient.upsertPerson`.
- **Self-hosted (no enterprise)**: Noop `SaasCrm` layer → no Twenty traffic.
- **Latency**: enqueue is a single Postgres INSERT into `crm_outbox`. Helper swallows all failure modes (Effect defects, typed enqueue errors, missing enterprise runtime) so a Twenty outage never 500s the signup endpoint.

## What changed

- `plugins/twenty/src/lead-normalizer.ts` — third discriminated-union variant `AtlasSignupLeadEvent`; pure-function `normalizeSignupLead` mirrors the sales-form name-split semantics (single-word → firstName only; whitespace collapses; empty/missing name omitted from the payload). No note attached — signup carries no message.
- `packages/api/src/lib/effect/services.ts` — `SaasCrmLeadInput` union widened to include `{ source: "signup", email, name? }`.
- `packages/api/src/lib/auth/server.ts` — new exported helper `dispatchSignupCrmLead({ user })` composed into the existing `user.create.after` hook (alongside the welcome email + auto-SSO provisioning). Mirrors `captureDemoLead`'s swallow contract; deferred imports keep top-level cost unchanged for non-SaaS deployments.

## Test coverage

- `plugins/twenty/__tests__/lead-normalizer.test.ts` — +9 tests for the signup variant (email lowercasing, single-word/multi-word/empty/missing name, `eventSource` stamping, no Note, no `atlasIp` round-trip, dispatch routing).
- `packages/api/src/lib/auth/__tests__/dispatch-signup-crm-lead.test.ts` — 11 tests covering happy path (with/without name), no-op cases (missing/null/empty email), and the swallow contract (sync defect, async reject, typed `Effect.fail`, Noop layer).
- `ee/src/saas-crm/__tests__/saas-crm.test.ts` — +2 dispatcher tests pinning the SIGNUP stamping rules end-to-end through `dispatchOutboxRow → upsertPerson`:
  - Brand-new email → POST `/rest/people` stamps both `atlasFirstSource` and `atlasLastSource` to `SIGNUP`, no `/rest/notes` call.
  - Email with prior `atlasFirstSource="DEMO"` → PATCH preserves `atlasFirstSource`, sets only `atlasLastSource="SIGNUP"`.

## CI gates (all green locally)

| Gate | Result |
|---|---|
| `bun run lint` | 0 errors, 0 warnings |
| `bun run type` | clean (`tsgo --noEmit`) |
| `bun run test` | full suite passes (api + others, all isolated) |
| `bun x syncpack lint` | No issues found |
| `check-schema-drift.sh` | 78 tables, passed |
| `check-ee-imports.sh` | only `enterprise-layer.ts` imports `@atlas/ee` |
| `check-template-drift.sh` | 690 files verified |
| `check-security-headers-drift.sh` | 3 mirrors match |
| `check-railway-watch.sh` | all 46 COPY sources covered |
| `check-oauth-helper-drift.sh` | OK |
| `check-test-discipline.sh` | 874 files scanned, no new offenders |

## Test plan

- [ ] After merge + Railway deploy, sign up a fresh email on app.useatlas.dev → confirm new Twenty Person at crm.useatlas.dev within the flusher polling window (`atlasFirstSource = atlasLastSource = "SIGNUP"`).
- [ ] Sign up using an email that previously hit `/demo` → confirm `atlasFirstSource = "DEMO"` is preserved and only `atlasLastSource` flips to `"SIGNUP"`.
- [ ] Verify signup latency unchanged in `api/api-eu/api-apac` logs (the helper only awaits the Postgres INSERT).
- [ ] Confirm self-hosted Atlas without enterprise stays inert — no Twenty traffic, no errors in logs on signup.

## Notes

- The `bun.lock` change reflects an existing drift: `plugins/twenty/package.json` was at 0.0.2 (slice 3 / #2835) but the lockfile still referenced 0.0.1. `bun install` in the worktree synced it.
- No new PRD-doc edit — there is no standalone SaaS-CRM docs page in `apps/docs/`; PRD #2726 is the GH issue body and gets updated at milestone closeout. JSDoc on `dispatchSignupCrmLead` provides the in-tree documentation.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/2840"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782397182&installation_id=135337507&pr_number=2840&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F2840&signature=98a0fc449edd42966ec1ca607f36053ee361746625a8567d2ee73b2eb36fee21"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->