### PR TITLE
feat(api): #2734 — crm_outbox depth gauges + threshold warn

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -241,6 +241,7 @@ ATLAS_ADMIN_EMAIL=admin@useatlas.dev
 # === Twenty CRM (SaaS-side lead capture — #2727) ===
 # TWENTY_BASE_URL=https://crm.useatlas.dev   # Twenty REST base URL (defaults to crm.useatlas.dev). Self-hosters set to their own Twenty hostname.
 # TWENTY_API_KEY=                            # Bearer key from Twenty Settings → API & Webhooks. Required for SaaS demo / signup / contact-form dispatch into Twenty; unset = SaasCrm.available is false. Twenty Person object must have custom fields `atlasFirstSource` AND `atlasLastSource` (verified at boot).
+# ATLAS_CRM_OUTBOX_WARN_THRESHOLD=100        # Pending-row threshold for the rate-limited backlog warning (#2734). When the flusher sees more than this many `crm_outbox` rows in `pending` status, it emits one `log.warn` per minute with the depth + oldest pending row's age. Pair with the `atlas.crm_outbox.pending_count` gauge for dashboards. Out-of-range values clamp to [1, 1_000_000] and log a warn.
 
 # === Talk-to-sales form (#2730) ===
 # Server side (api): verifies Cloudflare Turnstile tokens submitted by the

--- a/packages/api/src/lib/effect/layers.ts
+++ b/packages/api/src/lib/effect/layers.ts
@@ -53,14 +53,20 @@ import { EnterpriseLayer, type EnterpriseSubsystem } from "./enterprise-layer";
 import { AuditPurgeScheduler, SaasCrm } from "./services";
 import {
   recoverInFlight as recoverOutboxInFlight,
-  flushBatch as flushOutboxBatch,
+  runOutboxTick,
   getTickIntervalMs as getOutboxTickIntervalMs,
+  getWarnThreshold as getOutboxWarnThreshold,
+  OutboxWarnRateLimiter,
   FLUSH_BATCH_LIMIT as OUTBOX_FLUSH_BATCH_LIMIT,
   STARTUP_RECOVERY_STALE_MS as OUTBOX_STARTUP_STALE_MS,
   SHUTDOWN_RECOVERY_STALE_MS as OUTBOX_SHUTDOWN_STALE_MS,
   type OutboxDB,
   type RecoveryResult as OutboxRecoveryResult,
 } from "@atlas/api/lib/lead-outbox";
+import {
+  crmOutboxPendingCount,
+  crmOutboxDeadCount,
+} from "@atlas/api/lib/metrics";
 
 const log = createLogger("effect:layers");
 
@@ -1480,12 +1486,24 @@ export function makeSchedulerLive(
         );
 
         const outboxTickIntervalMs = getOutboxTickIntervalMs();
+        // One rate limiter per Layer scope — `lastWarnAt` lives on the
+        // instance, so a sustained 101+ pending depth fires exactly
+        // one log.warn per minute regardless of how many ticks elapse.
+        const outboxWarnLimiter = new OutboxWarnRateLimiter(getOutboxWarnThreshold());
         const outboxTick = Effect.tryPromise({
           try: () =>
-            flushOutboxBatch(outboxDb, outboxDispatcher, OUTBOX_FLUSH_BATCH_LIMIT),
+            runOutboxTick({
+              db: outboxDb,
+              dispatcher: outboxDispatcher,
+              batchLimit: OUTBOX_FLUSH_BATCH_LIMIT,
+              limiter: outboxWarnLimiter,
+              pendingGauge: crmOutboxPendingCount,
+              deadGauge: crmOutboxDeadCount,
+              logger: log,
+            }),
           catch: (err) => (err instanceof Error ? err : new Error(String(err))),
         }).pipe(
-          Effect.tap((result) =>
+          Effect.tap(({ flush: result }) =>
             Effect.sync(() => {
               // Only log non-empty ticks so an idle queue doesn't fill
               // the log with `claimed: 0`. The per-row dead-letter /

--- a/packages/api/src/lib/lead-outbox/__tests__/depth.test.ts
+++ b/packages/api/src/lib/lead-outbox/__tests__/depth.test.ts
@@ -21,8 +21,11 @@
 import { describe, expect, mock, test } from "bun:test";
 import {
   DEFAULT_WARN_THRESHOLD,
+  MAX_WARN_THRESHOLD,
+  MIN_WARN_THRESHOLD,
   OutboxWarnRateLimiter,
   WARN_INTERVAL_MS,
+  getWarnThreshold,
   queryDepthSnapshot,
   type OutboxDepthSnapshot,
 } from "../depth";
@@ -59,7 +62,7 @@ function makeStubDB(opts: StubDBOptions = {}): OutboxDB & {
       params?: unknown[],
     ): Promise<T[]> => {
       calls.push({ sql, params: params ?? [] });
-      if (/FROM crm_outbox\s*$/i.test(sql.trim())) {
+      if (/FROM crm_outbox\s+WHERE status IN/i.test(sql)) {
         return (opts.snapshotRows ?? []) as unknown as T[];
       }
       if (/RETURNING id, event_type/i.test(sql)) {
@@ -153,14 +156,49 @@ describe("queryDepthSnapshot", () => {
     expect(snap.dead).toBe(0);
   });
 
-  test("missing aggregate row falls back to zeros (driver invariant violation)", async () => {
+  test("missing aggregate row throws (driver invariant violation surfaces as tick_failed)", async () => {
+    // Per Codex P2: zero-fallback would leak a misleading "queue
+    // empty" reading on a sticky pool failure. Throwing forces the
+    // existing `lead_outbox.tick_failed` alert path and lets the
+    // OTel gauges keep their last-recorded values until the next
+    // successful tick.
     const db = makeStubDB({ snapshotRows: [] });
-    const snap = await queryDepthSnapshot(db);
-    expect(snap).toEqual({
-      pending: 0,
-      dead: 0,
-      oldestPendingCreatedAt: null,
+    await expect(queryDepthSnapshot(db)).rejects.toThrow(
+      /driver\/pool invariant violated/,
+    );
+  });
+
+  test("NaN/Infinity count clamps to 0 with structured warn (defensive path)", async () => {
+    const db = makeStubDB({
+      snapshotRows: [
+        { pending_count: Number.NaN, dead_count: 0, oldest_pending_at: null },
+      ],
     });
+    const snap = await queryDepthSnapshot(db);
+    expect(snap.pending).toBe(0);
+    expect(snap.dead).toBe(0);
+  });
+
+  test("non-integer count string clamps to 0", async () => {
+    const db = makeStubDB({
+      snapshotRows: [
+        { pending_count: "not-a-number", dead_count: "5", oldest_pending_at: null },
+      ],
+    });
+    const snap = await queryDepthSnapshot(db);
+    expect(snap.pending).toBe(0);
+    expect(snap.dead).toBe(5);
+  });
+
+  test("unparseable oldest_pending_at string yields null without throwing", async () => {
+    const db = makeStubDB({
+      snapshotRows: [
+        { pending_count: "1", dead_count: "0", oldest_pending_at: "garbage-timestamp" },
+      ],
+    });
+    const snap = await queryDepthSnapshot(db);
+    expect(snap.pending).toBe(1);
+    expect(snap.oldestPendingCreatedAt).toBeNull();
   });
 });
 
@@ -203,12 +241,19 @@ describe("OutboxWarnRateLimiter", () => {
     expect(limiter.evaluate(snap(500), baseTime + WARN_INTERVAL_MS - 1)).toBeNull();
   });
 
-  test("evaluation at exactly 60s does NOT re-emit; strictly past does", () => {
+  test("strict-less-than window: -1ms suppresses, exact boundary and +1ms re-emit", () => {
     const limiter = new OutboxWarnRateLimiter(100);
     limiter.evaluate(snap(101), baseTime);
-    // `now - lastWarnAt < intervalMs` — equality means still inside the window.
+    // Gate is `now - lastWarnAt < intervalMs`. Strict less-than → equality
+    // is OUTSIDE the window and re-emits. This matches the "elapsed
+    // interval = ready to fire again" convention.
     expect(limiter.evaluate(snap(101), baseTime + WARN_INTERVAL_MS - 1)).toBeNull();
     expect(limiter.evaluate(snap(101), baseTime + WARN_INTERVAL_MS)).not.toBeNull();
+    // Reset internal lastWarnAt to baseTime (we just emitted at the boundary)
+    // so the +1ms assertion measures the same edge cleanly.
+    const fresh = new OutboxWarnRateLimiter(100);
+    fresh.evaluate(snap(101), baseTime);
+    expect(fresh.evaluate(snap(101), baseTime + WARN_INTERVAL_MS + 1)).not.toBeNull();
   });
 
   test("falling below threshold then back above re-emits if window has passed", () => {
@@ -247,6 +292,66 @@ describe("OutboxWarnRateLimiter", () => {
 });
 
 // ─────────────────────────────────────────────────────────────────────
+//  getWarnThreshold (env-var parser — AC #3)
+// ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Save/restore the env var inside try/finally per the CLAUDE.md
+ * testing rule: no top-level `process.env.X = ...` at module scope.
+ * `getWarnThreshold` reads at call-time, so there is no import-hoist
+ * requirement — the wrapper is sufficient and survives the future
+ * `bun test --parallel` worker-reuse cutover.
+ */
+function withEnv<T>(value: string | undefined, fn: () => T): T {
+  const KEY = "ATLAS_CRM_OUTBOX_WARN_THRESHOLD";
+  const prev = process.env[KEY];
+  try {
+    if (value === undefined) delete process.env[KEY];
+    else process.env[KEY] = value;
+    return fn();
+  } finally {
+    if (prev === undefined) delete process.env[KEY];
+    else process.env[KEY] = prev;
+  }
+}
+
+describe("getWarnThreshold (env-var parser)", () => {
+  test("unset env returns DEFAULT_WARN_THRESHOLD", () => {
+    expect(withEnv(undefined, () => getWarnThreshold())).toBe(DEFAULT_WARN_THRESHOLD);
+  });
+
+  test("valid override is honoured (AC #3 override path)", () => {
+    expect(withEnv("200", () => getWarnThreshold())).toBe(200);
+    expect(withEnv("50", () => getWarnThreshold())).toBe(50);
+  });
+
+  test("non-numeric input falls back to default", () => {
+    expect(withEnv("abc", () => getWarnThreshold())).toBe(DEFAULT_WARN_THRESHOLD);
+    expect(withEnv("", () => getWarnThreshold())).toBe(DEFAULT_WARN_THRESHOLD);
+  });
+
+  test("parseInt-prefix typos like '100abc' fall back to default (not silent 100)", () => {
+    // `Number.parseInt("100abc", 10) === 100` — without strict regex
+    // validation, operator fat-finger would silently accept the
+    // truncation. Verify the stricter `/^-?\d+$/` gate.
+    expect(withEnv("100abc", () => getWarnThreshold())).toBe(DEFAULT_WARN_THRESHOLD);
+    expect(withEnv("50.5", () => getWarnThreshold())).toBe(DEFAULT_WARN_THRESHOLD);
+    expect(withEnv(" 100", () => getWarnThreshold())).toBe(DEFAULT_WARN_THRESHOLD);
+  });
+
+  test("below minimum clamps to MIN_WARN_THRESHOLD (zero / negative)", () => {
+    // Zero would defeat rate-limiting entirely (warn on every tick),
+    // so the clamp at 1 is load-bearing.
+    expect(withEnv("0", () => getWarnThreshold())).toBe(MIN_WARN_THRESHOLD);
+    expect(withEnv("-5", () => getWarnThreshold())).toBe(MIN_WARN_THRESHOLD);
+  });
+
+  test("above maximum clamps to MAX_WARN_THRESHOLD", () => {
+    expect(withEnv("2000000", () => getWarnThreshold())).toBe(MAX_WARN_THRESHOLD);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
 //  runOutboxTick
 // ─────────────────────────────────────────────────────────────────────
 
@@ -280,15 +385,19 @@ describe("runOutboxTick", () => {
     expect(logger.warnCalls).toEqual([]);
 
     // Order check: snapshot SELECT precedes any UPDATE attempt.
-    const snapshotIdx = db.calls.findIndex((c) => /FROM crm_outbox\s*$/i.test(c.sql.trim()));
+    const snapshotIdx = db.calls.findIndex((c) =>
+      /FROM crm_outbox\s+WHERE status IN/i.test(c.sql),
+    );
     const claimIdx = db.calls.findIndex((c) => /RETURNING id, event_type/i.test(c.sql));
     expect(snapshotIdx).toBeGreaterThanOrEqual(0);
     expect(claimIdx).toBeGreaterThan(snapshotIdx);
   });
 
   test("101 pending across two within-window ticks emits exactly one warn", async () => {
-    const oldest = new Date("2026-05-26T09:55:00.000Z");
     const tickTime = 1_700_000_000_000;
+    // `oldest` precedes `tickTime` by 5 min so `oldestPendingAgeMs` is
+    // a positive duration (300_000 ms), not the clock-skew clamp.
+    const oldest = new Date(tickTime - 5 * 60_000);
     const db = makeStubDB({
       snapshotRows: [
         { pending_count: "101", dead_count: "0", oldest_pending_at: oldest },
@@ -316,6 +425,14 @@ describe("runOutboxTick", () => {
     expect(logger.warnCalls[0]!.obj.depth).toBe(101);
     expect(logger.warnCalls[0]!.obj.threshold).toBe(100);
     expect(logger.warnCalls[0]!.obj.oldestPendingCreatedAt).toBe(oldest.toISOString());
+    // AC #2 requires "depth + oldest pending row's age" — humans read
+    // age faster than ISO timestamps, dashboards plot age. Lock the
+    // payload field so a destructure-and-forget refactor in
+    // `tick.ts:84-94` can't silently drop it.
+    expect(typeof logger.warnCalls[0]!.obj.oldestPendingAgeMs).toBe("number");
+    expect(logger.warnCalls[0]!.obj.oldestPendingAgeMs).toBe(
+      tickTime - oldest.getTime(),
+    );
 
     // Tick 2: still 101, 5s later — still inside the 60s window.
     const r2 = await runOutboxTick({
@@ -362,6 +479,30 @@ describe("runOutboxTick", () => {
     expect(result.flush.claimed).toBe(1);
     expect(result.flush.ok).toBe(1);
     expect(dispatchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("propagates snapshot errors so the caller's Effect.tryPromise records tick_failed", async () => {
+    // Contract from `tick.ts:74`: exceptions from `queryDepthSnapshot`
+    // (or `flushBatch`) propagate so the outer `Effect.catchAll` in
+    // `layers.ts` logs `lead_outbox.tick_failed`. A future "let's be
+    // resilient" refactor that wraps the snapshot in try/catch and
+    // returns zeros would silence the transient-DB alert path.
+    const db: OutboxDB = {
+      query: async () => {
+        throw new Error("connection terminated unexpectedly");
+      },
+    };
+    await expect(
+      runOutboxTick({
+        db,
+        dispatcher: NEVER_DISPATCH,
+        batchLimit: 50,
+        limiter: new OutboxWarnRateLimiter(100),
+        pendingGauge: makeGauge(),
+        deadGauge: makeGauge(),
+        logger: makeLogger(),
+      }),
+    ).rejects.toThrow("connection terminated unexpectedly");
   });
 
   test("snapshot under threshold never warns, regardless of depth=threshold edge", async () => {

--- a/packages/api/src/lib/lead-outbox/__tests__/depth.test.ts
+++ b/packages/api/src/lib/lead-outbox/__tests__/depth.test.ts
@@ -1,0 +1,384 @@
+/**
+ * Outbox depth metrics + threshold alerting (#2734, slice 8 of 1.6.0).
+ *
+ * Three suites in one file:
+ *   1. `queryDepthSnapshot` — translates the PG aggregate row into a
+ *      typed `OutboxDepthSnapshot` across the shapes the `pg` driver
+ *      actually returns (string counts, Date / ISO-string timestamps,
+ *      empty result).
+ *   2. `OutboxWarnRateLimiter` — emit-then-suppress within the 60s
+ *      window, re-emit just past it, and never emit below threshold.
+ *   3. `runOutboxTick` — proves the orchestrator records both gauges
+ *      and emits exactly one log.warn for a sustained 101+ pending
+ *      depth across two within-window ticks.
+ *
+ * No `mock.module` — every test wires deps explicitly so the slice's
+ * contract is enforced at the type level (not at the module-mock
+ * level). Per the slice 1.5.4 #2796 lessons, this also keeps the file
+ * safe under bun's subprocess-per-file isolation runner.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+import {
+  DEFAULT_WARN_THRESHOLD,
+  OutboxWarnRateLimiter,
+  WARN_INTERVAL_MS,
+  queryDepthSnapshot,
+  type OutboxDepthSnapshot,
+} from "../depth";
+import { runOutboxTick, type GaugeRecorder, type OutboxTickLogger } from "../tick";
+import type { OutboxDB, OutboxDispatcher } from "../outbox";
+
+// ─────────────────────────────────────────────────────────────────────
+//  Test helpers
+// ─────────────────────────────────────────────────────────────────────
+
+interface StubDBOptions {
+  snapshotRows?: Array<Record<string, unknown>>;
+  claimRows?: Array<Record<string, unknown>>;
+}
+
+/**
+ * Minimal `OutboxDB` that routes by SQL fingerprint:
+ *   - the slice-8 aggregate SELECT → `snapshotRows`
+ *   - the slice-2 `UPDATE … RETURNING id, event_type, …` claim → `claimRows`
+ *   - anything else → `[]`
+ *
+ * Each call appends to `db.calls` so a test can assert ordering
+ * (snapshot must run BEFORE claim — see the order-of-operations
+ * comment in `tick.ts`).
+ */
+function makeStubDB(opts: StubDBOptions = {}): OutboxDB & {
+  calls: Array<{ sql: string; params: unknown[] }>;
+} {
+  const calls: Array<{ sql: string; params: unknown[] }> = [];
+  const db: OutboxDB & { calls: typeof calls } = {
+    calls,
+    query: async <T extends Record<string, unknown>>(
+      sql: string,
+      params?: unknown[],
+    ): Promise<T[]> => {
+      calls.push({ sql, params: params ?? [] });
+      if (/FROM crm_outbox\s*$/i.test(sql.trim())) {
+        return (opts.snapshotRows ?? []) as unknown as T[];
+      }
+      if (/RETURNING id, event_type/i.test(sql)) {
+        return (opts.claimRows ?? []) as unknown as T[];
+      }
+      return [] as unknown as T[];
+    },
+  };
+  return db;
+}
+
+const NEVER_DISPATCH: OutboxDispatcher = async () => ({
+  kind: "ok",
+});
+
+function makeGauge(): GaugeRecorder & { values: number[] } {
+  const values: number[] = [];
+  return {
+    values,
+    record(value: number) {
+      values.push(value);
+    },
+  };
+}
+
+function makeLogger(): OutboxTickLogger & {
+  warnCalls: Array<{ obj: Record<string, unknown>; msg: string }>;
+} {
+  const warnCalls: Array<{ obj: Record<string, unknown>; msg: string }> = [];
+  return {
+    warnCalls,
+    warn(obj, msg) {
+      warnCalls.push({ obj, msg });
+    },
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────
+//  queryDepthSnapshot
+// ─────────────────────────────────────────────────────────────────────
+
+describe("queryDepthSnapshot", () => {
+  test("parses PG string counts + Date oldest_pending_at", async () => {
+    const oldest = new Date("2026-05-26T10:00:00.000Z");
+    const db = makeStubDB({
+      snapshotRows: [
+        { pending_count: "50", dead_count: "5", oldest_pending_at: oldest },
+      ],
+    });
+    const snap = await queryDepthSnapshot(db);
+    expect(snap).toEqual({
+      pending: 50,
+      dead: 5,
+      oldestPendingCreatedAt: oldest,
+    } satisfies OutboxDepthSnapshot);
+  });
+
+  test("parses ISO string oldest_pending_at (driver-config-dependent)", async () => {
+    const isoString = "2026-05-26T10:00:00.000Z";
+    const db = makeStubDB({
+      snapshotRows: [
+        { pending_count: "200", dead_count: "0", oldest_pending_at: isoString },
+      ],
+    });
+    const snap = await queryDepthSnapshot(db);
+    expect(snap.pending).toBe(200);
+    expect(snap.dead).toBe(0);
+    expect(snap.oldestPendingCreatedAt?.toISOString()).toBe(isoString);
+  });
+
+  test("null oldest_pending_at when no pending rows exist", async () => {
+    const db = makeStubDB({
+      snapshotRows: [
+        { pending_count: "0", dead_count: "12", oldest_pending_at: null },
+      ],
+    });
+    const snap = await queryDepthSnapshot(db);
+    expect(snap).toEqual({
+      pending: 0,
+      dead: 12,
+      oldestPendingCreatedAt: null,
+    });
+  });
+
+  test("handles numeric (not string) count values without coercion bug", async () => {
+    const db = makeStubDB({
+      snapshotRows: [{ pending_count: 7, dead_count: 0, oldest_pending_at: null }],
+    });
+    const snap = await queryDepthSnapshot(db);
+    expect(snap.pending).toBe(7);
+    expect(snap.dead).toBe(0);
+  });
+
+  test("missing aggregate row falls back to zeros (driver invariant violation)", async () => {
+    const db = makeStubDB({ snapshotRows: [] });
+    const snap = await queryDepthSnapshot(db);
+    expect(snap).toEqual({
+      pending: 0,
+      dead: 0,
+      oldestPendingCreatedAt: null,
+    });
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+//  OutboxWarnRateLimiter
+// ─────────────────────────────────────────────────────────────────────
+
+describe("OutboxWarnRateLimiter", () => {
+  const baseTime = 1_700_000_000_000;
+  const oldestPending = new Date(baseTime - 5 * 60_000);
+
+  function snap(pending: number): OutboxDepthSnapshot {
+    return {
+      pending,
+      dead: 0,
+      oldestPendingCreatedAt: pending > 0 ? oldestPending : null,
+    };
+  }
+
+  test("returns null when pending equals threshold (strictly greater required)", () => {
+    const limiter = new OutboxWarnRateLimiter(100);
+    expect(limiter.evaluate(snap(100), baseTime)).toBeNull();
+    expect(limiter.evaluate(snap(99), baseTime)).toBeNull();
+  });
+
+  test("first cross-threshold evaluation emits with age in ms", () => {
+    const limiter = new OutboxWarnRateLimiter(100);
+    const decision = limiter.evaluate(snap(101), baseTime);
+    expect(decision).not.toBeNull();
+    expect(decision!.depth).toBe(101);
+    expect(decision!.threshold).toBe(100);
+    expect(decision!.oldestPendingCreatedAt).toBe(oldestPending);
+    expect(decision!.oldestPendingAgeMs).toBe(5 * 60_000);
+  });
+
+  test("second evaluation within 60s window is suppressed", () => {
+    const limiter = new OutboxWarnRateLimiter(100);
+    expect(limiter.evaluate(snap(101), baseTime)).not.toBeNull();
+    expect(limiter.evaluate(snap(150), baseTime + 5_000)).toBeNull();
+    expect(limiter.evaluate(snap(500), baseTime + WARN_INTERVAL_MS - 1)).toBeNull();
+  });
+
+  test("evaluation at exactly 60s does NOT re-emit; strictly past does", () => {
+    const limiter = new OutboxWarnRateLimiter(100);
+    limiter.evaluate(snap(101), baseTime);
+    // `now - lastWarnAt < intervalMs` — equality means still inside the window.
+    expect(limiter.evaluate(snap(101), baseTime + WARN_INTERVAL_MS - 1)).toBeNull();
+    expect(limiter.evaluate(snap(101), baseTime + WARN_INTERVAL_MS)).not.toBeNull();
+  });
+
+  test("falling below threshold then back above re-emits if window has passed", () => {
+    const limiter = new OutboxWarnRateLimiter(100);
+    limiter.evaluate(snap(101), baseTime);
+    expect(limiter.evaluate(snap(0), baseTime + 30_000)).toBeNull(); // below threshold
+    expect(limiter.evaluate(snap(150), baseTime + 70_000)).not.toBeNull(); // past window
+  });
+
+  test("oldestPendingAgeMs is clamped at 0 (defends against clock skew)", () => {
+    const limiter = new OutboxWarnRateLimiter(100);
+    const futureOldest = new Date(baseTime + 5_000);
+    const decision = limiter.evaluate(
+      {
+        pending: 101,
+        dead: 0,
+        oldestPendingCreatedAt: futureOldest,
+      },
+      baseTime,
+    );
+    expect(decision!.oldestPendingAgeMs).toBe(0);
+  });
+
+  test("snapshot with null oldestPendingCreatedAt yields null age", () => {
+    const limiter = new OutboxWarnRateLimiter(100);
+    const decision = limiter.evaluate(
+      { pending: 101, dead: 0, oldestPendingCreatedAt: null },
+      baseTime,
+    );
+    expect(decision!.oldestPendingAgeMs).toBeNull();
+  });
+
+  test("default threshold matches AC #3 (100)", () => {
+    expect(DEFAULT_WARN_THRESHOLD).toBe(100);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+//  runOutboxTick
+// ─────────────────────────────────────────────────────────────────────
+
+describe("runOutboxTick", () => {
+  test("records both gauges from the snapshot, before claiming rows", async () => {
+    const oldest = new Date("2026-05-26T10:00:00.000Z");
+    const db = makeStubDB({
+      snapshotRows: [
+        { pending_count: "50", dead_count: "5", oldest_pending_at: oldest },
+      ],
+      claimRows: [], // idle queue post-snapshot
+    });
+    const pendingGauge = makeGauge();
+    const deadGauge = makeGauge();
+    const logger = makeLogger();
+
+    const result = await runOutboxTick({
+      db,
+      dispatcher: NEVER_DISPATCH,
+      batchLimit: 50,
+      limiter: new OutboxWarnRateLimiter(100),
+      pendingGauge,
+      deadGauge,
+      logger,
+    });
+
+    expect(pendingGauge.values).toEqual([50]);
+    expect(deadGauge.values).toEqual([5]);
+    expect(result.snapshot.pending).toBe(50);
+    expect(result.warned).toBe(false);
+    expect(logger.warnCalls).toEqual([]);
+
+    // Order check: snapshot SELECT precedes any UPDATE attempt.
+    const snapshotIdx = db.calls.findIndex((c) => /FROM crm_outbox\s*$/i.test(c.sql.trim()));
+    const claimIdx = db.calls.findIndex((c) => /RETURNING id, event_type/i.test(c.sql));
+    expect(snapshotIdx).toBeGreaterThanOrEqual(0);
+    expect(claimIdx).toBeGreaterThan(snapshotIdx);
+  });
+
+  test("101 pending across two within-window ticks emits exactly one warn", async () => {
+    const oldest = new Date("2026-05-26T09:55:00.000Z");
+    const tickTime = 1_700_000_000_000;
+    const db = makeStubDB({
+      snapshotRows: [
+        { pending_count: "101", dead_count: "0", oldest_pending_at: oldest },
+      ],
+    });
+    const pendingGauge = makeGauge();
+    const deadGauge = makeGauge();
+    const logger = makeLogger();
+    const limiter = new OutboxWarnRateLimiter(100);
+
+    // Tick 1: depth 101, should warn.
+    const r1 = await runOutboxTick({
+      db,
+      dispatcher: NEVER_DISPATCH,
+      batchLimit: 50,
+      limiter,
+      pendingGauge,
+      deadGauge,
+      logger,
+      now: () => tickTime,
+    });
+    expect(r1.warned).toBe(true);
+    expect(logger.warnCalls).toHaveLength(1);
+    expect(logger.warnCalls[0]!.obj.event).toBe("lead_outbox.depth_threshold_warn");
+    expect(logger.warnCalls[0]!.obj.depth).toBe(101);
+    expect(logger.warnCalls[0]!.obj.threshold).toBe(100);
+    expect(logger.warnCalls[0]!.obj.oldestPendingCreatedAt).toBe(oldest.toISOString());
+
+    // Tick 2: still 101, 5s later — still inside the 60s window.
+    const r2 = await runOutboxTick({
+      db,
+      dispatcher: NEVER_DISPATCH,
+      batchLimit: 50,
+      limiter,
+      pendingGauge,
+      deadGauge,
+      logger,
+      now: () => tickTime + 5_000,
+    });
+    expect(r2.warned).toBe(false);
+    expect(logger.warnCalls).toHaveLength(1);
+
+    // Both ticks still recorded the gauge — observability never blinks.
+    expect(pendingGauge.values).toEqual([101, 101]);
+    expect(deadGauge.values).toEqual([0, 0]);
+  });
+
+  test("propagates dispatcher results in `flush` so caller can log claim counts", async () => {
+    const dispatchSpy = mock(async () => ({ kind: "ok" as const }));
+    const claimRow = {
+      id: "row-1",
+      event_type: "demo",
+      payload: {},
+      attempts: 0,
+      twenty_person_id: null,
+      twenty_note_id: null,
+    };
+    const db = makeStubDB({
+      snapshotRows: [{ pending_count: "1", dead_count: "0", oldest_pending_at: null }],
+      claimRows: [claimRow],
+    });
+    const result = await runOutboxTick({
+      db,
+      dispatcher: dispatchSpy,
+      batchLimit: 50,
+      limiter: new OutboxWarnRateLimiter(100),
+      pendingGauge: makeGauge(),
+      deadGauge: makeGauge(),
+      logger: makeLogger(),
+    });
+    expect(result.flush.claimed).toBe(1);
+    expect(result.flush.ok).toBe(1);
+    expect(dispatchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("snapshot under threshold never warns, regardless of depth=threshold edge", async () => {
+    const db = makeStubDB({
+      snapshotRows: [{ pending_count: "100", dead_count: "0", oldest_pending_at: null }],
+    });
+    const logger = makeLogger();
+    const result = await runOutboxTick({
+      db,
+      dispatcher: NEVER_DISPATCH,
+      batchLimit: 50,
+      limiter: new OutboxWarnRateLimiter(100),
+      pendingGauge: makeGauge(),
+      deadGauge: makeGauge(),
+      logger,
+    });
+    expect(result.warned).toBe(false);
+    expect(logger.warnCalls).toEqual([]);
+  });
+});

--- a/packages/api/src/lib/lead-outbox/depth.ts
+++ b/packages/api/src/lib/lead-outbox/depth.ts
@@ -1,0 +1,161 @@
+/**
+ * Outbox depth metrics + threshold alerting (#2734, slice 8 of 1.6.0).
+ *
+ * Two responsibilities:
+ *
+ *  1. `queryDepthSnapshot` — one round-trip to count `pending` /
+ *     `dead` rows and grab the oldest pending row's `created_at`. The
+ *     flusher tick calls this BEFORE dispatch so the gauges reflect
+ *     pre-tick queue depth (the value an operator sees in the metrics
+ *     endpoint between ticks).
+ *
+ *  2. `OutboxWarnRateLimiter` — once-per-minute gate on the
+ *     "pending depth exceeds threshold" `log.warn` so a sustained
+ *     backlog doesn't fill the log stream. Stateful by design; one
+ *     instance is allocated per scheduler Layer scope and drops when
+ *     the scope finalizes.
+ *
+ * Threshold default is 100; `ATLAS_CRM_OUTBOX_WARN_THRESHOLD` overrides
+ * with the same clamp-and-warn discipline as `getTickIntervalMs` — an
+ * out-of-range value lands at the boundary rather than silently
+ * defaulting, so the operator's intent is preserved.
+ */
+
+import { createLogger } from "@atlas/api/lib/logger";
+import type { OutboxDB } from "./outbox";
+
+const log = createLogger("lead-outbox:depth");
+
+// ─────────────────────────────────────────────────────────────────────
+//  Snapshot
+// ─────────────────────────────────────────────────────────────────────
+
+export interface OutboxDepthSnapshot {
+  readonly pending: number;
+  readonly dead: number;
+  readonly oldestPendingCreatedAt: Date | null;
+}
+
+/**
+ * Single aggregate row — keeps the snapshot to one round-trip even
+ * under contention. `FILTER` clauses avoid the cost (and PG plan
+ * branching) of GROUP BY + a client-side bucket lookup.
+ */
+const SNAPSHOT_SQL = `
+  SELECT
+    COUNT(*) FILTER (WHERE status = 'pending')        AS pending_count,
+    COUNT(*) FILTER (WHERE status = 'dead')           AS dead_count,
+    MIN(created_at) FILTER (WHERE status = 'pending') AS oldest_pending_at
+  FROM crm_outbox
+`;
+
+interface SnapshotRow extends Record<string, unknown> {
+  pending_count: string | number;
+  dead_count: string | number;
+  oldest_pending_at: Date | string | null;
+}
+
+export async function queryDepthSnapshot(db: OutboxDB): Promise<OutboxDepthSnapshot> {
+  const rows = await db.query<SnapshotRow>(SNAPSHOT_SQL);
+  const row = rows[0];
+  if (!row) {
+    // PG always returns one aggregate row for COUNT() — a missing row
+    // here means the driver/pool short-circuited. Return zeros so the
+    // tick stays alive; the operator-side ratio alert on
+    // `lead_outbox.tick_failed` (slice 2) picks up the actual cause.
+    return { pending: 0, dead: 0, oldestPendingCreatedAt: null };
+  }
+  return {
+    pending: parseCount(row.pending_count),
+    dead: parseCount(row.dead_count),
+    oldestPendingCreatedAt: parseTimestamp(row.oldest_pending_at),
+  };
+}
+
+function parseCount(v: string | number): number {
+  if (typeof v === "number") return Number.isFinite(v) ? v : 0;
+  const n = Number.parseInt(v, 10);
+  return Number.isFinite(n) ? n : 0;
+}
+
+function parseTimestamp(v: Date | string | null): Date | null {
+  if (v == null) return null;
+  if (v instanceof Date) return v;
+  const d = new Date(v);
+  return Number.isNaN(d.getTime()) ? null : d;
+}
+
+// ─────────────────────────────────────────────────────────────────────
+//  Threshold + rate-limit
+// ─────────────────────────────────────────────────────────────────────
+
+export const DEFAULT_WARN_THRESHOLD = 100;
+export const WARN_INTERVAL_MS = 60_000;
+export const MIN_WARN_THRESHOLD = 1;
+export const MAX_WARN_THRESHOLD = 1_000_000;
+
+export function getWarnThreshold(): number {
+  const raw = process.env.ATLAS_CRM_OUTBOX_WARN_THRESHOLD;
+  if (!raw) return DEFAULT_WARN_THRESHOLD;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed)) return DEFAULT_WARN_THRESHOLD;
+  if (parsed < MIN_WARN_THRESHOLD) {
+    log.warn(
+      { requested: parsed, clamped: MIN_WARN_THRESHOLD, event: "lead_outbox.threshold_clamped" },
+      `ATLAS_CRM_OUTBOX_WARN_THRESHOLD=${parsed} below ${MIN_WARN_THRESHOLD} — clamping`,
+    );
+    return MIN_WARN_THRESHOLD;
+  }
+  if (parsed > MAX_WARN_THRESHOLD) {
+    log.warn(
+      { requested: parsed, clamped: MAX_WARN_THRESHOLD, event: "lead_outbox.threshold_clamped" },
+      `ATLAS_CRM_OUTBOX_WARN_THRESHOLD=${parsed} exceeds ${MAX_WARN_THRESHOLD} — clamping`,
+    );
+    return MAX_WARN_THRESHOLD;
+  }
+  return parsed;
+}
+
+export interface WarnDecision {
+  readonly depth: number;
+  readonly threshold: number;
+  readonly oldestPendingCreatedAt: Date | null;
+  readonly oldestPendingAgeMs: number | null;
+}
+
+/**
+ * Stateful gate on the "depth exceeds threshold" warning. Holds the
+ * timestamp of the last emitted warn; suppresses subsequent calls
+ * within `intervalMs`. One instance per flusher Layer scope.
+ *
+ * `evaluate(snapshot, now)` returns `null` when the operator should
+ * NOT see a warn (depth under threshold OR still inside the rate-limit
+ * window) and the fully-shaped payload otherwise. Updating the
+ * `lastWarnAt` field happens on emit, so a 101+ pending depth that
+ * resolves to 0 and re-rises immediately would correctly re-warn (the
+ * gate is time-based, not edge-based).
+ */
+export class OutboxWarnRateLimiter {
+  private lastWarnAt = 0;
+
+  constructor(
+    private readonly threshold: number,
+    private readonly intervalMs: number = WARN_INTERVAL_MS,
+  ) {}
+
+  evaluate(snapshot: OutboxDepthSnapshot, now: number = Date.now()): WarnDecision | null {
+    if (snapshot.pending <= this.threshold) return null;
+    if (now - this.lastWarnAt < this.intervalMs) return null;
+    this.lastWarnAt = now;
+    const oldestAgeMs =
+      snapshot.oldestPendingCreatedAt == null
+        ? null
+        : Math.max(0, now - snapshot.oldestPendingCreatedAt.getTime());
+    return {
+      depth: snapshot.pending,
+      threshold: this.threshold,
+      oldestPendingCreatedAt: snapshot.oldestPendingCreatedAt,
+      oldestPendingAgeMs: oldestAgeMs,
+    };
+  }
+}

--- a/packages/api/src/lib/lead-outbox/depth.ts
+++ b/packages/api/src/lib/lead-outbox/depth.ts
@@ -38,8 +38,15 @@ export interface OutboxDepthSnapshot {
 
 /**
  * Single aggregate row — keeps the snapshot to one round-trip even
- * under contention. `FILTER` clauses avoid the cost (and PG plan
- * branching) of GROUP BY + a client-side bucket lookup.
+ * under contention. The outer `WHERE status IN ('pending', 'dead')`
+ * scopes the scan to the only two statuses we report on, so the
+ * snapshot's cost does NOT scale with the unbounded history of
+ * `done` rows that accumulate over the lifetime of the table. The
+ * `pending` side of the scan hits the
+ * `idx_crm_outbox_pending_created` partial index (mig 0102); the
+ * `dead` side falls back to a sequential walk of dead rows only —
+ * small in practice (a few hundred at most absent a sustained
+ * upstream outage).
  */
 const SNAPSHOT_SQL = `
   SELECT
@@ -47,6 +54,7 @@ const SNAPSHOT_SQL = `
     COUNT(*) FILTER (WHERE status = 'dead')           AS dead_count,
     MIN(created_at) FILTER (WHERE status = 'pending') AS oldest_pending_at
   FROM crm_outbox
+  WHERE status IN ('pending', 'dead')
 `;
 
 interface SnapshotRow extends Record<string, unknown> {
@@ -59,11 +67,18 @@ export async function queryDepthSnapshot(db: OutboxDB): Promise<OutboxDepthSnaps
   const rows = await db.query<SnapshotRow>(SNAPSHOT_SQL);
   const row = rows[0];
   if (!row) {
-    // PG always returns one aggregate row for COUNT() — a missing row
-    // here means the driver/pool short-circuited. Return zeros so the
-    // tick stays alive; the operator-side ratio alert on
-    // `lead_outbox.tick_failed` (slice 2) picks up the actual cause.
-    return { pending: 0, dead: 0, oldestPendingCreatedAt: null };
+    // PG's contract: `SELECT COUNT(*) FROM x` with no GROUP BY always
+    // returns exactly one row. Zero rows here means something below
+    // the SQL layer broke — driver/pool short-circuit, adapter
+    // regression, or a custom OutboxDB stub violating the contract.
+    // Throw so the caller's `Effect.catchAll` emits
+    // `lead_outbox.tick_failed` (slice 2) and the OTel gauges retain
+    // their last-recorded values rather than being reset to a
+    // misleading zero — a sticky pool failure must NOT make the
+    // queue look healthy.
+    throw new Error(
+      "crm_outbox snapshot returned no aggregate row — driver/pool invariant violated",
+    );
   }
   return {
     pending: parseCount(row.pending_count),
@@ -73,16 +88,35 @@ export async function queryDepthSnapshot(db: OutboxDB): Promise<OutboxDepthSnaps
 }
 
 function parseCount(v: string | number): number {
-  if (typeof v === "number") return Number.isFinite(v) ? v : 0;
+  if (typeof v === "number") {
+    if (Number.isFinite(v)) return v;
+    log.warn(
+      { raw: v, event: "lead_outbox.snapshot_count_unparseable" },
+      "crm_outbox aggregate count is NaN/Infinity — clamping to 0; pg type-parser config drifted",
+    );
+    return 0;
+  }
   const n = Number.parseInt(v, 10);
-  return Number.isFinite(n) ? n : 0;
+  if (Number.isFinite(n)) return n;
+  log.warn(
+    { raw: v, event: "lead_outbox.snapshot_count_unparseable" },
+    "crm_outbox aggregate count is not a valid integer — clamping to 0",
+  );
+  return 0;
 }
 
 function parseTimestamp(v: Date | string | null): Date | null {
   if (v == null) return null;
   if (v instanceof Date) return v;
   const d = new Date(v);
-  return Number.isNaN(d.getTime()) ? null : d;
+  if (Number.isNaN(d.getTime())) {
+    log.warn(
+      { raw: v, event: "lead_outbox.snapshot_timestamp_unparseable" },
+      "crm_outbox oldest_pending_at could not be parsed as a Date — dropping; depth_threshold_warn ageMs will be null this tick",
+    );
+    return null;
+  }
+  return d;
 }
 
 // ─────────────────────────────────────────────────────────────────────
@@ -97,6 +131,17 @@ export const MAX_WARN_THRESHOLD = 1_000_000;
 export function getWarnThreshold(): number {
   const raw = process.env.ATLAS_CRM_OUTBOX_WARN_THRESHOLD;
   if (!raw) return DEFAULT_WARN_THRESHOLD;
+  // Reject operator typos like "100abc" — `parseInt` is forgiving and
+  // would silently accept `100`, masking a misconfigured env var. The
+  // strict integer regex rejects anything that isn't a clean optional
+  // sign followed by digits.
+  if (!/^-?\d+$/.test(raw)) {
+    log.warn(
+      { requested: raw, event: "lead_outbox.threshold_unparseable" },
+      `ATLAS_CRM_OUTBOX_WARN_THRESHOLD=${raw} is not a valid integer — using default ${DEFAULT_WARN_THRESHOLD}`,
+    );
+    return DEFAULT_WARN_THRESHOLD;
+  }
   const parsed = Number.parseInt(raw, 10);
   if (!Number.isFinite(parsed)) return DEFAULT_WARN_THRESHOLD;
   if (parsed < MIN_WARN_THRESHOLD) {
@@ -130,10 +175,12 @@ export interface WarnDecision {
  *
  * `evaluate(snapshot, now)` returns `null` when the operator should
  * NOT see a warn (depth under threshold OR still inside the rate-limit
- * window) and the fully-shaped payload otherwise. Updating the
- * `lastWarnAt` field happens on emit, so a 101+ pending depth that
- * resolves to 0 and re-rises immediately would correctly re-warn (the
- * gate is time-based, not edge-based).
+ * window) and the fully-shaped payload otherwise. The gate is
+ * time-based, not edge-based: a depth that crosses the threshold,
+ * drops below, and re-crosses within `intervalMs` is suppressed on
+ * the second cross — re-emission happens once the interval elapses,
+ * regardless of intervening dips. After the interval, a still-elevated
+ * depth (or a fresh re-rise) re-warns.
  */
 export class OutboxWarnRateLimiter {
   private lastWarnAt = 0;

--- a/packages/api/src/lib/lead-outbox/index.ts
+++ b/packages/api/src/lib/lead-outbox/index.ts
@@ -34,3 +34,23 @@ export {
 } from "./backoff";
 
 export { classifyHttpStatus, type Classification } from "./classify";
+
+export {
+  queryDepthSnapshot,
+  getWarnThreshold,
+  OutboxWarnRateLimiter,
+  DEFAULT_WARN_THRESHOLD,
+  WARN_INTERVAL_MS,
+  MIN_WARN_THRESHOLD,
+  MAX_WARN_THRESHOLD,
+  type OutboxDepthSnapshot,
+  type WarnDecision,
+} from "./depth";
+
+export {
+  runOutboxTick,
+  type OutboxTickDeps,
+  type OutboxTickResult,
+  type GaugeRecorder,
+  type OutboxTickLogger,
+} from "./tick";

--- a/packages/api/src/lib/lead-outbox/tick.ts
+++ b/packages/api/src/lib/lead-outbox/tick.ts
@@ -3,10 +3,10 @@
  *
  * Composes the slice-2 `flushBatch` with the slice-8 depth snapshot +
  * threshold warning. Lives in its own module so the unit test in
- * `__tests__/tick.test.ts` can drive a single async function with
+ * `__tests__/depth.test.ts` can drive a single async function with
  * stub deps — no `mock.module`, no Effect runtime, no global gauge
  * provider — which is exactly the Layer-handoff contract: `layers.ts`
- * builds the deps, `runTick` does the work.
+ * builds the deps, `runOutboxTick` does the work.
  *
  * Order of operations matters. Snapshot runs BEFORE dispatch so the
  * gauge value an operator sees between ticks is "queue depth as of

--- a/packages/api/src/lib/lead-outbox/tick.ts
+++ b/packages/api/src/lib/lead-outbox/tick.ts
@@ -1,0 +1,98 @@
+/**
+ * Outbox flusher per-tick orchestrator (#2734, slice 8 of 1.6.0).
+ *
+ * Composes the slice-2 `flushBatch` with the slice-8 depth snapshot +
+ * threshold warning. Lives in its own module so the unit test in
+ * `__tests__/tick.test.ts` can drive a single async function with
+ * stub deps — no `mock.module`, no Effect runtime, no global gauge
+ * provider — which is exactly the Layer-handoff contract: `layers.ts`
+ * builds the deps, `runTick` does the work.
+ *
+ * Order of operations matters. Snapshot runs BEFORE dispatch so the
+ * gauge value an operator sees between ticks is "queue depth as of
+ * tick start". Reversing the order would make the gauge under-report
+ * during a backlog (the dispatch drains some rows, the snapshot then
+ * sees the residual, depth-warn never trips even when the queue is
+ * actually growing tick-over-tick).
+ */
+
+import { flushBatch, type OutboxDB, type OutboxDispatcher, type FlushResult } from "./outbox";
+import {
+  queryDepthSnapshot,
+  type OutboxDepthSnapshot,
+  type OutboxWarnRateLimiter,
+  type WarnDecision,
+} from "./depth";
+
+/**
+ * Minimal OTel Gauge shape. Typed structurally rather than imported
+ * from `@opentelemetry/api` so tests can hand in a Bun `mock.fn()` and
+ * the production wiring still type-checks against the real `Gauge`
+ * interface in `lib/metrics.ts`.
+ */
+export interface GaugeRecorder {
+  record(value: number): void;
+}
+
+/**
+ * Logger shape used by the tick. Structurally typed so the test can
+ * substitute a Bun mock without depending on `pino`.
+ */
+export interface OutboxTickLogger {
+  warn(obj: Record<string, unknown>, msg: string): void;
+}
+
+export interface OutboxTickDeps {
+  readonly db: OutboxDB;
+  readonly dispatcher: OutboxDispatcher;
+  readonly batchLimit: number;
+  readonly limiter: OutboxWarnRateLimiter;
+  readonly pendingGauge: GaugeRecorder;
+  readonly deadGauge: GaugeRecorder;
+  readonly logger: OutboxTickLogger;
+  /** Injected for deterministic tests; defaults to `Date.now`. */
+  readonly now?: () => number;
+}
+
+export interface OutboxTickResult {
+  readonly snapshot: OutboxDepthSnapshot;
+  readonly flush: FlushResult;
+  readonly warned: boolean;
+}
+
+/**
+ * Run a single flusher cycle: snapshot → gauges → threshold warn →
+ * dispatch. Returns enough context for the caller (production: the
+ * scheduler Layer; tests: assertions) to surface tick results.
+ *
+ * Exceptions from `queryDepthSnapshot` or `flushBatch` propagate so the
+ * caller's outer `Effect.tryPromise` records a tick failure. The warn
+ * emission itself is best-effort — if the logger throws (it shouldn't,
+ * pino never does) the rate-limit state is already advanced so the
+ * next tick won't double-warn.
+ */
+export async function runOutboxTick(deps: OutboxTickDeps): Promise<OutboxTickResult> {
+  const { db, dispatcher, batchLimit, limiter, pendingGauge, deadGauge, logger } = deps;
+  const now = deps.now ?? Date.now;
+
+  const snapshot = await queryDepthSnapshot(db);
+  pendingGauge.record(snapshot.pending);
+  deadGauge.record(snapshot.dead);
+
+  const warn: WarnDecision | null = limiter.evaluate(snapshot, now());
+  if (warn) {
+    logger.warn(
+      {
+        depth: warn.depth,
+        threshold: warn.threshold,
+        oldestPendingCreatedAt: warn.oldestPendingCreatedAt?.toISOString() ?? null,
+        oldestPendingAgeMs: warn.oldestPendingAgeMs,
+        event: "lead_outbox.depth_threshold_warn",
+      },
+      `crm_outbox pending depth ${warn.depth} exceeds threshold ${warn.threshold} — Twenty dispatch may be backed up`,
+    );
+  }
+
+  const flush = await flushBatch(db, dispatcher, batchLimit);
+  return { snapshot, flush, warned: warn != null };
+}

--- a/packages/api/src/lib/metrics.ts
+++ b/packages/api/src/lib/metrics.ts
@@ -16,7 +16,7 @@
  * Grafana board need to extend telemetry.ts with an OTLP metrics exporter.
  */
 
-import { metrics, type Counter, type Histogram } from "@opentelemetry/api";
+import { metrics, type Counter, type Gauge, type Histogram } from "@opentelemetry/api";
 
 const meter = metrics.getMeter("@atlas/api");
 
@@ -192,5 +192,42 @@ export const mcpPromptCalls: Counter = meter.createCounter(
   {
     description:
       "MCP prompts surface dispatch count by method + prompt + source",
+  },
+);
+
+/**
+ * `atlas.crm_outbox.pending_count` — current `crm_outbox` rows in
+ * `pending` status. Updated by the SaaS-CRM outbox flusher (#2734) on
+ * every tick, BEFORE dispatch, so the value reflects the queue depth
+ * an operator sees between ticks.
+ *
+ * No `workspace.id` attribute — the flusher is process-global and the
+ * queue is single-tenant (SaaS-only; the self-hosted Noop SaasCrm
+ * never starts a flusher fiber so no observations land here).
+ *
+ * A sustained value past `ATLAS_CRM_OUTBOX_WARN_THRESHOLD` (default
+ * 100) also fires a rate-limited `log.warn` with the oldest pending
+ * row's age — pair the two signals in dashboards.
+ */
+export const crmOutboxPendingCount: Gauge = meter.createGauge(
+  "atlas.crm_outbox.pending_count",
+  {
+    description:
+      "Current crm_outbox rows in pending status, observed per flusher tick (#2734)",
+  },
+);
+
+/**
+ * `atlas.crm_outbox.dead_count` — current `crm_outbox` rows in `dead`
+ * status. A monotonically-growing value means the dispatcher is
+ * surfacing permanent failures (or exhausting the retry budget). For
+ * per-row triage, join with the `lead_outbox.dead_letter_permanent` /
+ * `_exhausted` log events emitted by slice 2 (#2729).
+ */
+export const crmOutboxDeadCount: Gauge = meter.createGauge(
+  "atlas.crm_outbox.dead_count",
+  {
+    description:
+      "Current crm_outbox rows in dead status, observed per flusher tick (#2734)",
   },
 );


### PR DESCRIPTION
## Summary

- `atlas.crm_outbox.pending_count` and `atlas.crm_outbox.dead_count` synchronous OTel gauges, recorded by the slice-2 flusher (#2729) on every tick BEFORE dispatch — so the value an operator sees between ticks reflects queue depth at tick start, not residual depth after the dispatch drains some rows.
- Rate-limited `log.warn` (`event: lead_outbox.depth_threshold_warn`) once per 60s per pod when pending depth crosses `ATLAS_CRM_OUTBOX_WARN_THRESHOLD` (default 100). Payload carries `depth`, `threshold`, `oldestPendingCreatedAt` (ISO), and `oldestPendingAgeMs` so a dashboard can plot backlog age without parsing log strings.
- Per-tick logic extracted to `runOutboxTick(deps)` in `lib/lead-outbox/tick.ts` — pure async function the unit test drives with stub DB / dispatcher / gauges / logger, so the slice's contract is enforced at the type level instead of via `mock.module`. `layers.ts` wires production deps and allocates one `OutboxWarnRateLimiter` per scheduler Layer scope.

## Acceptance criteria — issue #2734

- [x] `atlas.crm_outbox.pending_count` + `.dead_count` gauges exposed via the existing Telemetry path (`@atlas/api` meter, identical to the abuse/MCP counters)
- [x] Both gauges update on each flusher tick — no separate counting job (one aggregate `SELECT ... FROM crm_outbox` with `FILTER (WHERE status = ...)` clauses, single round-trip per tick)
- [x] 101+ pending rows triggers one `log.warn` per minute with depth + oldest pending row's age (verified by `runOutboxTick` test — two within-window ticks emit exactly one warn)
- [x] `ATLAS_CRM_OUTBOX_WARN_THRESHOLD` env var overrides the default 100 (with clamp-and-warn discipline matching `getTickIntervalMs`)
- [x] No new dependencies — uses the existing OTel meter in `lib/metrics.ts` and the Scheduler Layer in `lib/effect/layers.ts`
- [x] Unit test: gauge values reflect underlying row counts across PG-shaped result variants (string counts, Date / ISO oldest, null oldest, missing row)
- [x] `bun run lint`, `bun run type`, `bun run test` all pass

## Notes

- Snapshot order: snapshot SELECT runs **before** dispatch. Reversing would make the gauge under-report during a sustained backlog (the dispatch drains some rows, the snapshot sees the residual, depth-warn never trips even when the queue is growing tick-over-tick).
- Rate-limit is time-based, not edge-based: a 101+ depth that drops to 0 and re-rises within 60s does not re-warn (gate is `now - lastWarnAt < intervalMs`); past the window, it re-warns.
- The lifecycle test (`outbox-flusher-lifecycle.test.ts`) still passes — its `WHERE status = 'in_flight'` regex correctly ignores the new `FILTER (WHERE status = 'pending')` snapshot SQL.
- Self-hosted is unaffected: the `NoopSaasCrm` layer makes `saasCrm.available === false`, so the flusher fiber never forks and no observations land on the gauges.

## Test plan

- [x] `bun run lint` — 0 warnings
- [x] `bun run type` — 0 errors
- [x] `bun run test` — full suite, 220+ files, 0 failures
- [x] `bun x syncpack lint` — no issues
- [x] All drift gates: template / security-headers / railway-watch / schema / oauth-helper / test-discipline — green
- [x] `bun test packages/api/src/lib/lead-outbox/__tests__/depth.test.ts` — 17/17 pass (5 snapshot, 8 rate-limiter, 4 orchestrator)
- [ ] Post-merge: confirm `atlas.crm_outbox.pending_count` lights up on Grafana for `api`/`api-eu`/`api-apac` after next dispatch tick

Closes #2734.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/2844"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782401162&installation_id=135337507&pr_number=2844&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F2844&signature=a6de93472d645d9d31b0a9a7ec970db7ce9cefaec948f440d6b8ed40b1fdce2b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->