### PR TITLE
feat(api,ee,plugins): #2737 — Stripe → Twenty Person conversion stamping

### DIFF
--- a/ee/src/saas-crm/__tests__/saas-crm.test.ts
+++ b/ee/src/saas-crm/__tests__/saas-crm.test.ts
@@ -102,7 +102,12 @@ describe("verifyCustomFields", () => {
 
   test("returns ok=true when both required custom fields are present", async () => {
     const fetchImpl = (async () =>
-      metadataResponse(["id", "atlasFirstSource", "atlasLastSource"])) as unknown as typeof globalThis.fetch;
+      metadataResponse([
+        "id",
+        "atlasFirstSource",
+        "atlasLastSource",
+        "atlasStripeCustomerId",
+      ])) as unknown as typeof globalThis.fetch;
 
     await withFetch(fetchImpl, async () => {
       const result = await verifyCustomFields({
@@ -194,7 +199,12 @@ describe("SaasCrmLive boot — enterprise enabled + creds + both fields present 
       const url = typeof input === "string" ? input : (input as Request).url;
       if (url.endsWith("/metadata")) {
         metadataCalls++;
-        return metadataResponse(["id", "atlasFirstSource", "atlasLastSource"]);
+        return metadataResponse([
+          "id",
+          "atlasFirstSource",
+          "atlasLastSource",
+          "atlasStripeCustomerId",
+        ]);
       }
       // No dispatch fetches expected — outbox holds the row for the flusher.
       throw new Error(`Unexpected fetch during enqueue: ${url}`);
@@ -238,7 +248,12 @@ describe("SaasCrmLive boot — InternalDB unavailable", () => {
     process.env.TWENTY_BASE_URL = "https://crm.test.local";
 
     const fetchImpl = (async () =>
-      metadataResponse(["id", "atlasFirstSource", "atlasLastSource"])) as unknown as typeof globalThis.fetch;
+      metadataResponse([
+        "id",
+        "atlasFirstSource",
+        "atlasLastSource",
+        "atlasStripeCustomerId",
+      ])) as unknown as typeof globalThis.fetch;
 
     try {
       const result = await withFetch(fetchImpl, async () => {
@@ -291,6 +306,121 @@ describe("SaasCrmLive boot — missing required field flips available to false",
       delete process.env.TWENTY_API_KEY;
       delete process.env.TWENTY_BASE_URL;
     }
+  });
+});
+
+describe("SaasCrmLive boot — missing atlasStripeCustomerId flips available to false (#2737)", () => {
+  beforeEach(resetStubs);
+
+  test("yields available=false when atlasStripeCustomerId is missing (boot-time guard)", async () => {
+    enterpriseEnabled = true;
+    process.env.TWENTY_API_KEY = "test-key";
+    process.env.TWENTY_BASE_URL = "https://crm.test.local";
+
+    const fetchImpl = (async (input: string | URL | Request): Promise<Response> => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url.endsWith("/metadata")) {
+        // Old schema — source fields present but the conversion stamp
+        // field is missing. The verification must catch it on boot so
+        // every conversion event doesn't dead-letter on a 422.
+        return metadataResponse(["id", "atlasFirstSource", "atlasLastSource"]);
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    }) as unknown as typeof globalThis.fetch;
+
+    try {
+      const result = await withFetch(fetchImpl, async () => {
+        const program = Effect.gen(function* () {
+          const crm = yield* SaasCrm;
+          yield* crm.stampConversion({
+            email: "convert@x.test",
+            stripeCustomerId: "cus_x",
+          });
+          return crm.available;
+        });
+        return Effect.runPromise(program.pipe(Effect.provide(SaasCrmLive)));
+      });
+
+      expect(result).toBe(false);
+      expect(enqueueCount).toBe(0);
+    } finally {
+      delete process.env.TWENTY_API_KEY;
+      delete process.env.TWENTY_BASE_URL;
+    }
+  });
+});
+
+describe("SaasCrmLive boot — stampConversion enqueues with eventType=stamp-conversion (#2737)", () => {
+  beforeEach(resetStubs);
+
+  test("enqueues a stamp-conversion row carrying the conversion payload", async () => {
+    enterpriseEnabled = true;
+    process.env.TWENTY_API_KEY = "test-key";
+    process.env.TWENTY_BASE_URL = "https://crm.test.local";
+
+    const fetchImpl = (async (input: string | URL | Request): Promise<Response> => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url.endsWith("/metadata")) {
+        return metadataResponse([
+          "id",
+          "atlasFirstSource",
+          "atlasLastSource",
+          "atlasStripeCustomerId",
+        ]);
+      }
+      throw new Error(`Unexpected fetch during enqueue: ${url}`);
+    }) as unknown as typeof globalThis.fetch;
+
+    try {
+      const wasAvailable = await withFetch(fetchImpl, async () => {
+        const program = Effect.gen(function* () {
+          const crm = yield* SaasCrm;
+          yield* crm.stampConversion({
+            email: "convert@happy.test",
+            stripeCustomerId: "cus_abc123",
+          });
+          return crm.available;
+        });
+        return Effect.runPromise(program.pipe(Effect.provide(SaasCrmLive)));
+      });
+
+      expect(wasAvailable).toBe(true);
+      expect(enqueueCount).toBe(1);
+      expect(lastEnqueueArgs?.sql).toMatch(/INSERT INTO crm_outbox/i);
+      // event_type is the stamp-conversion sentinel — distinct from the
+      // payload's `source` discriminator so an operator can quickly
+      // bucket outbox rows by funnel stage.
+      expect(lastEnqueueArgs?.params[0]).toBe("stamp-conversion");
+      // Payload is the canonical conversion variant.
+      const payload = JSON.parse(String(lastEnqueueArgs?.params[1]));
+      expect(payload.source).toBe("conversion");
+      expect(payload.email).toBe("convert@happy.test");
+      expect(payload.stripeCustomerId).toBe("cus_abc123");
+    } finally {
+      delete process.env.TWENTY_API_KEY;
+      delete process.env.TWENTY_BASE_URL;
+    }
+  });
+
+  test("stampConversion is a no-op when enterprise is disabled (Noop layer active)", async () => {
+    enterpriseEnabled = false;
+    delete process.env.TWENTY_API_KEY;
+    delete process.env.TWENTY_BASE_URL;
+
+    const program = Effect.gen(function* () {
+      const crm = yield* SaasCrm;
+      yield* crm.stampConversion({
+        email: "x@y.com",
+        stripeCustomerId: "cus_noop",
+      });
+      return crm.available;
+    });
+
+    const available = await Effect.runPromise(
+      program.pipe(Effect.provide(SaasCrmLive)),
+    );
+    expect(available).toBe(false);
+    expect(enqueueCount).toBe(0);
   });
 });
 
@@ -378,6 +508,139 @@ describe("dispatchOutboxRow", () => {
     expect(outcome).toEqual({ kind: "ok" });
     expect(persisted.person).toBe("person_happy");
     expect(persisted.note).toBeUndefined();
+  });
+
+  test("conversion variant — POSTs Person with CONVERSION source + atlasStripeCustomerId (#2737)", async () => {
+    // End-to-end via dispatchOutboxRow: normalizer routes the conversion
+    // payload through the existing upsertPerson code path, and the
+    // POST body must carry atlasFirstSource / atlasLastSource /
+    // atlasStripeCustomerId inline.
+    const captured: { url: string; body: string }[] = [];
+    const fetchImpl = (async (
+      input: string | URL | Request,
+      init?: RequestInit,
+    ): Promise<Response> => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      const body = init?.body ? String(init.body) : "";
+      captured.push({ url, body });
+      if (url.includes("/rest/people?filter")) {
+        return new Response(JSON.stringify({ data: { people: [] } }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      return new Response(
+        JSON.stringify({ data: { createPerson: { id: "person_convert" } } }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }) as unknown as typeof globalThis.fetch;
+
+    const persisted: { person?: string; note?: string } = {};
+    const outcome = await withFetch(fetchImpl, async () =>
+      dispatchOutboxRow(
+        { apiKey: "k", baseUrl: "https://crm.test.local" },
+        {
+          id: "row-conv",
+          eventType: "stamp-conversion",
+          payload: {
+            source: "conversion",
+            email: "convert@test.local",
+            stripeCustomerId: "cus_pay_42",
+          },
+          attempts: 1,
+          twentyPersonId: null,
+          twentyNoteId: null,
+        },
+        {
+          setTwentyPersonId: async (id: string) => {
+            persisted.person = id;
+          },
+          setTwentyNoteId: async (id: string) => {
+            persisted.note = id;
+          },
+        },
+      ),
+    );
+
+    expect(outcome).toEqual({ kind: "ok" });
+    expect(persisted.person).toBe("person_convert");
+    // No note for conversion — createNote must NOT have been called.
+    expect(persisted.note).toBeUndefined();
+    // Two HTTP calls: findPersonByEmail (GET) + createPerson (POST).
+    expect(captured).toHaveLength(2);
+    const postBody = JSON.parse(captured[1].body);
+    expect(postBody.atlasFirstSource).toBe("CONVERSION");
+    expect(postBody.atlasLastSource).toBe("CONVERSION");
+    expect(postBody.atlasStripeCustomerId).toBe("cus_pay_42");
+  });
+
+  test("conversion variant — existing Person preserves atlasFirstSource, PATCHes lastSource + stripeCustomerId (#2737)", async () => {
+    // The sticky-firstSource rule lives in upsertPerson; the conversion
+    // path inherits it for free. This test pins that behavior end-to-
+    // end through dispatchOutboxRow so a future refactor that splits
+    // out a dedicated stamp dispatcher can't silently lose it.
+    const captured: { url: string; body: string; method: string }[] = [];
+    const fetchImpl = (async (
+      input: string | URL | Request,
+      init?: RequestInit,
+    ): Promise<Response> => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      const body = init?.body ? String(init.body) : "";
+      const method = init?.method ?? "GET";
+      captured.push({ url, body, method });
+      if (url.includes("/rest/people?filter")) {
+        return new Response(
+          JSON.stringify({
+            data: {
+              people: [
+                {
+                  id: "person_demo",
+                  emails: { primaryEmail: "convert@test.local" },
+                  atlasFirstSource: "DEMO",
+                  atlasLastSource: "DEMO",
+                },
+              ],
+            },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      return new Response(
+        JSON.stringify({ data: { updatePerson: { id: "person_demo" } } }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }) as unknown as typeof globalThis.fetch;
+
+    const outcome = await withFetch(fetchImpl, async () =>
+      dispatchOutboxRow(
+        { apiKey: "k", baseUrl: "https://crm.test.local" },
+        {
+          id: "row-conv-existing",
+          eventType: "stamp-conversion",
+          payload: {
+            source: "conversion",
+            email: "convert@test.local",
+            stripeCustomerId: "cus_pay_99",
+          },
+          attempts: 1,
+          twentyPersonId: null,
+          twentyNoteId: null,
+        },
+        {
+          setTwentyPersonId: async () => {},
+          setTwentyNoteId: async () => {},
+        },
+      ),
+    );
+
+    expect(outcome).toEqual({ kind: "ok" });
+    expect(captured).toHaveLength(2);
+    expect(captured[1].method).toBe("PATCH");
+    const patchBody = JSON.parse(captured[1].body);
+    // Sticky — atlasFirstSource must NOT be in the PATCH body.
+    expect(patchBody.atlasFirstSource).toBeUndefined();
+    expect(patchBody.atlasLastSource).toBe("CONVERSION");
+    expect(patchBody.atlasStripeCustomerId).toBe("cus_pay_99");
   });
 
   test("idempotent replay — skips upsertPerson when twenty_person_id is already set", async () => {

--- a/ee/src/saas-crm/__tests__/saas-crm.test.ts
+++ b/ee/src/saas-crm/__tests__/saas-crm.test.ts
@@ -680,6 +680,51 @@ describe("dispatchOutboxRow", () => {
     expect(persisted.person).toBeUndefined();
   });
 
+  test("idempotent replay — conversion variant also skips upsertPerson when twenty_person_id is already set (#2737)", async () => {
+    // PR review gap: the demo-variant replay test above covers the
+    // pre-existing path, but adding the conversion variant means a
+    // replayed `stamp-conversion` row should also short-circuit. Pin
+    // that the dispatcher's idempotency is variant-agnostic — a future
+    // refactor that split the dispatcher per-eventType would otherwise
+    // silently re-dispatch a paid customer's stamp on every flush.
+    let fetchCount = 0;
+    const fetchImpl = (async (): Promise<Response> => {
+      fetchCount++;
+      return new Response("{}", { status: 200 });
+    }) as unknown as typeof globalThis.fetch;
+
+    const persisted: { person?: string; note?: string } = {};
+    const outcome = await withFetch(fetchImpl, async () =>
+      dispatchOutboxRow(
+        { apiKey: "k", baseUrl: "https://crm.test.local" },
+        {
+          id: "row-conv-replay",
+          eventType: "stamp-conversion",
+          payload: {
+            source: "conversion",
+            email: "paying@example.com",
+            stripeCustomerId: "cus_already_stamped",
+          },
+          attempts: 2,
+          twentyPersonId: "person_already_stamped",
+          twentyNoteId: null,
+        },
+        {
+          setTwentyPersonId: async (id: string) => {
+            persisted.person = id;
+          },
+          setTwentyNoteId: async (id: string) => {
+            persisted.note = id;
+          },
+        },
+      ),
+    );
+
+    expect(outcome).toEqual({ kind: "ok" });
+    expect(fetchCount).toBe(0);
+    expect(persisted.person).toBeUndefined();
+  });
+
   test("5xx → transient outcome (retried by flusher)", async () => {
     const fetchImpl = (async (): Promise<Response> =>
       new Response(JSON.stringify({ messages: ["upstream boom"] }), {

--- a/ee/src/saas-crm/index.ts
+++ b/ee/src/saas-crm/index.ts
@@ -87,8 +87,8 @@ function missingFieldInstructions(missing: ReadonlyArray<string>): string {
   return (
     `Twenty Person object is missing required Atlas custom field(s): ${missing.join(", ")}. ` +
     `Create them in the Twenty UI under Settings → Data Model → Person → + Add Field. ` +
-    `Each field should be of type "Text". SaaS CRM dispatch is disabled until both ` +
-    `atlasFirstSource and atlasLastSource exist on the Person object.`
+    `Each field should be of type "Text". SaaS CRM dispatch is disabled until all of ` +
+    `${REQUIRED_PERSON_FIELDS.join(", ")} exist on the Person object.`
   );
 }
 

--- a/ee/src/saas-crm/index.ts
+++ b/ee/src/saas-crm/index.ts
@@ -48,7 +48,22 @@ import {
 
 const log = createLogger("ee:saas-crm");
 
-const REQUIRED_PERSON_FIELDS = ["atlasFirstSource", "atlasLastSource"] as const;
+const REQUIRED_PERSON_FIELDS = [
+  "atlasFirstSource",
+  "atlasLastSource",
+  // #2737 — conversion stamp lands in this custom field. Boot fails-soft
+  // if it's missing so the outbox doesn't dead-letter every conversion
+  // event against a 422 schema mismatch.
+  "atlasStripeCustomerId",
+] as const;
+
+/**
+ * Outbox event-type string for Stripe → Twenty conversion stamps
+ * (#2737). Distinct from the union discriminator (`"conversion"`) on the
+ * payload — the eventType is purely for crm_outbox row triage and
+ * observability; the dispatcher routes by re-normalizing the payload.
+ */
+const STAMP_CONVERSION_EVENT_TYPE = "stamp-conversion";
 
 /**
  * Atlas's known Twenty CRM hostname. Used as the fallback when
@@ -338,6 +353,7 @@ export const SaasCrmLive: Layer.Layer<SaasCrm> = Layer.effect(
       return {
         available: false,
         upsertLead: () => Effect.void,
+        stampConversion: () => Effect.void,
       } satisfies SaasCrmShape;
     }
 
@@ -350,6 +366,7 @@ export const SaasCrmLive: Layer.Layer<SaasCrm> = Layer.effect(
       return {
         available: false,
         upsertLead: () => Effect.void,
+        stampConversion: () => Effect.void,
       } satisfies SaasCrmShape;
     }
 
@@ -361,6 +378,7 @@ export const SaasCrmLive: Layer.Layer<SaasCrm> = Layer.effect(
       return {
         available: false,
         upsertLead: () => Effect.void,
+        stampConversion: () => Effect.void,
       } satisfies SaasCrmShape;
     }
 
@@ -373,6 +391,7 @@ export const SaasCrmLive: Layer.Layer<SaasCrm> = Layer.effect(
       return {
         available: false,
         upsertLead: () => Effect.void,
+        stampConversion: () => Effect.void,
       } satisfies SaasCrmShape;
     }
     if (verifyResult.ok === "transient") {
@@ -387,7 +406,7 @@ export const SaasCrmLive: Layer.Layer<SaasCrm> = Layer.effect(
           baseUrl: creds.baseUrl ?? ATLAS_SAAS_TWENTY_BASE_URL,
           event: "saas_crm.ready",
         },
-        "SaasCrm wired up — atlasFirstSource + atlasLastSource verified on Twenty Person",
+        `SaasCrm wired up — ${REQUIRED_PERSON_FIELDS.join(" + ")} verified on Twenty Person`,
       );
     }
 
@@ -424,6 +443,41 @@ export const SaasCrmLive: Layer.Layer<SaasCrm> = Layer.effect(
             }),
           ),
         ),
+      stampConversion: (input) => {
+        // Construct the canonical `conversion` SaasCrmLeadInput payload
+        // — the normalizer is the single source of truth for the
+        // dispatch shape, and routing by re-normalizing the payload
+        // keeps the dispatcher generic over event types.
+        const payload: SaasCrmLeadInput = {
+          source: "conversion",
+          email: input.email,
+          stripeCustomerId: input.stripeCustomerId,
+        };
+        return Effect.tryPromise({
+          try: async () => {
+            await enqueue(outboxDb, {
+              eventType: STAMP_CONVERSION_EVENT_TYPE,
+              payload: payload as unknown as Record<string, unknown>,
+            });
+          },
+          catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+        }).pipe(
+          Effect.tapError((err) =>
+            Effect.sync(() => {
+              log.error(
+                {
+                  // Don't log the stripeCustomerId; bare-minimum
+                  // breadcrumb is email + the error.
+                  email: input.email,
+                  err: err.message,
+                  event: "saas_crm.stamp_conversion_enqueue_failed",
+                },
+                "crm_outbox enqueue failed for stamp-conversion — Postgres write error",
+              );
+            }),
+          ),
+        );
+      },
       dispatcher: (row, persist) => dispatchOutboxRow(clientConfig, row, persist),
     } satisfies SaasCrmShape;
   }),
@@ -435,4 +489,6 @@ export {
   buildSaasClientConfig,
   ATLAS_SAAS_TWENTY_BASE_URL,
   classifyTwentyError,
+  STAMP_CONVERSION_EVENT_TYPE,
+  REQUIRED_PERSON_FIELDS,
 };

--- a/packages/api/src/api/routes/__tests__/contact.test.ts
+++ b/packages/api/src/api/routes/__tests__/contact.test.ts
@@ -103,6 +103,7 @@ mock.module("@atlas/api/lib/effect/hono", () => ({
               ? Effect.fail(new Error("pg_connection_terminated"))
               : Effect.void;
           },
+          stampConversion: () => Effect.void,
           // dispatcher is required by the available=true union arm but
           // tests don't exercise the flusher path.
           dispatcher: async () => ({ kind: "ok" as const }),
@@ -113,6 +114,7 @@ mock.module("@atlas/api/lib/effect/hono", () => ({
             upsertLeadCalls.push(input);
             return Effect.void;
           },
+          stampConversion: () => Effect.void,
         };
     const layer = Layer.mergeAll(
       services.createRequestContextTestLayer({ requestId: "test-req-id" }),

--- a/packages/api/src/api/routes/__tests__/platform-crm-outbox.test.ts
+++ b/packages/api/src/api/routes/__tests__/platform-crm-outbox.test.ts
@@ -164,11 +164,13 @@ mock.module("@atlas/api/lib/effect/hono", () => ({
       ? {
           available: true,
           upsertLead: () => Effect.void,
+          stampConversion: () => Effect.void,
           dispatcher: async () => ({ kind: "ok" as const }),
         }
       : {
           available: false,
           upsertLead: () => Effect.void,
+          stampConversion: () => Effect.void,
         };
     const layer = Layer.mergeAll(
       services.createRequestContextTestLayer({

--- a/packages/api/src/lib/auth/__tests__/dispatch-conversion-crm-stamp.test.ts
+++ b/packages/api/src/lib/auth/__tests__/dispatch-conversion-crm-stamp.test.ts
@@ -1,0 +1,317 @@
+/**
+ * Regression coverage for the Stripe webhook → Twenty CRM conversion
+ * stamp helper ({@link dispatchConversionCrmStamp}, #2737).
+ *
+ * Contract:
+ *   - Stripe customer with an email → enqueues a `conversion` lead via
+ *     SaasCrm.stampConversion.
+ *   - Customer has no email / is deleted / retrieve fails → no-op, logs
+ *     the appropriate event, never throws (Stripe must keep ack'ing).
+ *   - Self-hosted (Noop SaasCrm) → no Twenty traffic; helper resolves.
+ *   - Enterprise runtime rejects → swallowed; helper resolves.
+ *   - stampConversion's typed `Error` channel → swallowed; helper resolves.
+ *
+ * Same caveat as `dispatch-signup-crm-lead.test.ts`: this exercises the
+ * helper in isolation. It cannot detect a refactor that removes the
+ * `dispatchConversionCrmStamp(...)` call from `onSubscriptionComplete`
+ * — Better Auth closes over its plugin options.
+ */
+
+import { describe, it, expect, beforeEach, mock, type Mock } from "bun:test";
+import { Effect, Layer } from "effect";
+import {
+  SaasCrm,
+  type SaasCrmStampConversionInput,
+  type SaasCrmShape,
+} from "@atlas/api/lib/effect/services";
+
+// ── Mock storage state (controlled per-test) ────────────────────────
+
+let runEnterpriseImpl: (p: unknown) => Promise<unknown> = async () => undefined;
+const stampConversionCalls: SaasCrmStampConversionInput[] = [];
+
+const mockLogWarn: Mock<(...args: unknown[]) => void> = mock(() => {});
+const mockLogError: Mock<(...args: unknown[]) => void> = mock(() => {});
+const mockLogInfo: Mock<(...args: unknown[]) => void> = mock(() => {});
+const mockLogDebug: Mock<(...args: unknown[]) => void> = mock(() => {});
+
+mock.module("@atlas/api/lib/effect/enterprise-layer", () => ({
+  runEnterprise: (p: unknown) => runEnterpriseImpl(p),
+  getEnterpriseRuntime: () => ({
+    runPromise: <A, E>(p: Effect.Effect<A, E, never>) => Effect.runPromise(p),
+  }),
+  EnterpriseLayer: Layer.empty,
+}));
+
+mock.module("@atlas/api/lib/logger", () => ({
+  createLogger: () => ({
+    info: mockLogInfo,
+    warn: mockLogWarn,
+    error: mockLogError,
+    debug: mockLogDebug,
+  }),
+  getLogger: () => ({
+    info: mockLogInfo,
+    warn: mockLogWarn,
+    error: mockLogError,
+    debug: mockLogDebug,
+  }),
+  withRequestContext: (_ctx: unknown, fn: () => unknown) => fn(),
+  getRequestContext: () => undefined,
+  redactPaths: [],
+  setLogLevel: () => false,
+}));
+
+// ── Import the unit under test AFTER mocks ─────────────────────────
+
+const { dispatchConversionCrmStamp } = await import("../server");
+
+// Stripe client doubles. The Better Auth Stripe plugin only calls
+// `customers.retrieve` from this helper, so we expose just that surface
+// and cast the rest. We can't import `Stripe` at the type level here
+// without the real module because the helper signature is
+// `stripeClient: Stripe`, so we lean on a structural cast.
+type StripeCustomerLike =
+  | { id: string; email?: string | null; deleted?: false }
+  | { id: string; deleted: true };
+
+interface StripeCustomersRetrieveStub {
+  retrieve: (id: string) => Promise<StripeCustomerLike>;
+}
+interface StripeStub {
+  customers: StripeCustomersRetrieveStub;
+}
+
+function makeStripe(impl: StripeCustomersRetrieveStub["retrieve"]): StripeStub {
+  return { customers: { retrieve: impl } };
+}
+
+// SaasCrm test layers — same pattern as dispatch-signup-crm-lead.test.
+function recordingLayer(): Layer.Layer<SaasCrm> {
+  return Layer.succeed(SaasCrm, {
+    available: true,
+    upsertLead: () => Effect.void,
+    stampConversion: (input: SaasCrmStampConversionInput) => {
+      stampConversionCalls.push(input);
+      return Effect.void;
+    },
+  } as unknown as SaasCrmShape);
+}
+
+function failingLayer(err: Error): Layer.Layer<SaasCrm> {
+  return Layer.succeed(SaasCrm, {
+    available: true,
+    upsertLead: () => Effect.void,
+    stampConversion: () => Effect.fail(err),
+  } as unknown as SaasCrmShape);
+}
+
+function noopLayer(): Layer.Layer<SaasCrm> {
+  return Layer.succeed(SaasCrm, {
+    available: false,
+    upsertLead: () => Effect.void,
+    stampConversion: () => Effect.void,
+  });
+}
+
+beforeEach(() => {
+  stampConversionCalls.length = 0;
+  mockLogWarn.mockClear();
+  mockLogError.mockClear();
+  mockLogInfo.mockClear();
+  mockLogDebug.mockClear();
+  runEnterpriseImpl = async (program) => {
+    await Effect.runPromise(
+      Effect.provide(program as Effect.Effect<unknown, never, SaasCrm>, recordingLayer()),
+    );
+  };
+});
+
+describe("dispatchConversionCrmStamp — happy path", () => {
+  it("retrieves Stripe customer email and enqueues a stampConversion", async () => {
+    const stripe = makeStripe(async (id) => ({
+      id,
+      email: "Paying@Example.com",
+    }));
+
+    await dispatchConversionCrmStamp({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- structural Stripe stub
+      stripeClient: stripe as any,
+      stripeCustomerId: "cus_pay_42",
+      orgId: "org_abc",
+    });
+
+    expect(stampConversionCalls).toHaveLength(1);
+    expect(stampConversionCalls[0]).toEqual({
+      // Email is lowercased + trimmed at the helper boundary.
+      email: "paying@example.com",
+      stripeCustomerId: "cus_pay_42",
+    });
+  });
+});
+
+describe("dispatchConversionCrmStamp — no-op cases", () => {
+  it("logs and skips when Stripe customer has no email", async () => {
+    const stripe = makeStripe(async (id) => ({ id, email: null }));
+
+    await dispatchConversionCrmStamp({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- structural Stripe stub
+      stripeClient: stripe as any,
+      stripeCustomerId: "cus_no_email",
+    });
+
+    expect(stampConversionCalls).toHaveLength(0);
+    expect(mockLogWarn).toHaveBeenCalledTimes(1);
+    const [logCtx] = mockLogWarn.mock.calls[0] as [Record<string, unknown>, string];
+    expect(logCtx.event).toBe("conversion_crm.customer_no_email");
+  });
+
+  it("logs and skips when Stripe customer email is whitespace-only", async () => {
+    const stripe = makeStripe(async (id) => ({ id, email: "   " }));
+
+    await dispatchConversionCrmStamp({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- structural Stripe stub
+      stripeClient: stripe as any,
+      stripeCustomerId: "cus_blank",
+    });
+
+    expect(stampConversionCalls).toHaveLength(0);
+    expect(mockLogWarn).toHaveBeenCalledTimes(1);
+  });
+
+  it("logs and skips when Stripe customer is deleted", async () => {
+    const stripe = makeStripe(async (id) => ({ id, deleted: true }));
+
+    await dispatchConversionCrmStamp({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- structural Stripe stub
+      stripeClient: stripe as any,
+      stripeCustomerId: "cus_gone",
+    });
+
+    expect(stampConversionCalls).toHaveLength(0);
+    expect(mockLogWarn).toHaveBeenCalledTimes(1);
+    const [logCtx] = mockLogWarn.mock.calls[0] as [Record<string, unknown>, string];
+    expect(logCtx.event).toBe("conversion_crm.customer_deleted");
+  });
+});
+
+describe("dispatchConversionCrmStamp — failure swallow contract", () => {
+  it("resolves and logs when customers.retrieve throws", async () => {
+    const stripe = makeStripe(async () => {
+      throw new Error("stripe blip");
+    });
+
+    await expect(
+      dispatchConversionCrmStamp({
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- structural Stripe stub
+        stripeClient: stripe as any,
+        stripeCustomerId: "cus_die",
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(stampConversionCalls).toHaveLength(0);
+    expect(mockLogWarn).toHaveBeenCalledTimes(1);
+    const [logCtx] = mockLogWarn.mock.calls[0] as [Record<string, unknown>, string];
+    expect(logCtx.event).toBe("conversion_crm.customer_retrieve_failed");
+  });
+
+  it("resolves and logs when runEnterprise throws", async () => {
+    runEnterpriseImpl = async () => {
+      throw new Error("simulated defect inside runEnterprise");
+    };
+    const stripe = makeStripe(async (id) => ({ id, email: "x@y.com" }));
+
+    await expect(
+      dispatchConversionCrmStamp({
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- structural Stripe stub
+        stripeClient: stripe as any,
+        stripeCustomerId: "cus_defect",
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(mockLogWarn).toHaveBeenCalledTimes(1);
+    const [logCtx] = mockLogWarn.mock.calls[0] as [Record<string, unknown>, string];
+    expect(logCtx.event).toBe("conversion_crm.dispatch_defect");
+  });
+
+  it("resolves and logs `conversion_crm.enqueue_failed` when stampConversion fails with a typed Error", async () => {
+    runEnterpriseImpl = async (program) => {
+      await Effect.runPromise(
+        Effect.provide(
+          program as Effect.Effect<unknown, never, SaasCrm>,
+          failingLayer(new Error("crm_outbox enqueue failed — pg blip")),
+        ),
+      );
+    };
+    const stripe = makeStripe(async (id) => ({ id, email: "x@y.com" }));
+
+    await expect(
+      dispatchConversionCrmStamp({
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- structural Stripe stub
+        stripeClient: stripe as any,
+        stripeCustomerId: "cus_pgblip",
+        orgId: "org_pg",
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(mockLogWarn).toHaveBeenCalledTimes(1);
+    const [logCtx] = mockLogWarn.mock.calls[0] as [Record<string, unknown>, string];
+    expect(logCtx.event).toBe("conversion_crm.enqueue_failed");
+    expect(logCtx.orgId).toBe("org_pg");
+  });
+});
+
+describe("dispatchConversionCrmStamp — Noop / self-hosted shape", () => {
+  it("resolves without dispatching when SaasCrm is unavailable", async () => {
+    let runs = 0;
+    runEnterpriseImpl = async (program) => {
+      runs++;
+      await Effect.runPromise(
+        Effect.provide(program as Effect.Effect<unknown, never, SaasCrm>, noopLayer()),
+      );
+    };
+    const stripe = makeStripe(async (id) => ({ id, email: "x@y.com" }));
+
+    await expect(
+      dispatchConversionCrmStamp({
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- structural Stripe stub
+        stripeClient: stripe as any,
+        stripeCustomerId: "cus_selfhosted",
+      }),
+    ).resolves.toBeUndefined();
+    expect(runs).toBe(1);
+    expect(stampConversionCalls).toHaveLength(0);
+  });
+});
+
+describe("dispatchConversionCrmStamp — stripeCustomerId is never logged", () => {
+  // Defensive contract — log scrubbing for cus_… is loose since the id
+  // isn't a secret per se, but the helper deliberately omits it from
+  // the enqueue-failed log on the rationale that the email + orgId are
+  // enough breadcrumb to triage. Pin that so a future log-context
+  // refactor doesn't silently widen the surface.
+  it("omits stripeCustomerId from the enqueue_failed log context", async () => {
+    runEnterpriseImpl = async (program) => {
+      await Effect.runPromise(
+        Effect.provide(
+          program as Effect.Effect<unknown, never, SaasCrm>,
+          failingLayer(new Error("blip")),
+        ),
+      );
+    };
+    const stripe = makeStripe(async (id) => ({ id, email: "x@y.com" }));
+
+    await dispatchConversionCrmStamp({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- structural Stripe stub
+      stripeClient: stripe as any,
+      stripeCustomerId: "cus_should_not_appear_in_logs",
+      orgId: "org_x",
+    });
+
+    // The outer helper's enqueue_failed log includes stripeCustomerId
+    // intentionally (for triage). The inner EE-side `saas_crm.stamp_
+    // conversion_enqueue_failed` log does NOT — verified in ee tests.
+    // Just pin that this helper logs at least once.
+    expect(mockLogWarn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/api/src/lib/auth/__tests__/dispatch-conversion-crm-stamp.test.ts
+++ b/packages/api/src/lib/auth/__tests__/dispatch-conversion-crm-stamp.test.ts
@@ -64,7 +64,7 @@ mock.module("@atlas/api/lib/logger", () => ({
 
 // ── Import the unit under test AFTER mocks ─────────────────────────
 
-const { dispatchConversionCrmStamp } = await import("../server");
+const { dispatchConversionCrmStamp, planConversionStamp } = await import("../server");
 
 // Stripe client doubles. The Better Auth Stripe plugin only calls
 // `customers.retrieve` from this helper, so we expose just that surface
@@ -284,13 +284,16 @@ describe("dispatchConversionCrmStamp — Noop / self-hosted shape", () => {
   });
 });
 
-describe("dispatchConversionCrmStamp — stripeCustomerId is never logged", () => {
-  // Defensive contract — log scrubbing for cus_… is loose since the id
-  // isn't a secret per se, but the helper deliberately omits it from
-  // the enqueue-failed log on the rationale that the email + orgId are
-  // enough breadcrumb to triage. Pin that so a future log-context
-  // refactor doesn't silently widen the surface.
-  it("omits stripeCustomerId from the enqueue_failed log context", async () => {
+describe("dispatchConversionCrmStamp — enqueue_failed log shape", () => {
+  // Pin the outer helper's log context for `conversion_crm.enqueue_failed`.
+  // The stripeCustomerId IS included on the outer log (operators need it
+  // to triage in Stripe directly); the inner EE-side
+  // `saas_crm.stamp_conversion_enqueue_failed` log deliberately OMITS it
+  // — that contract lives in `ee/src/saas-crm/__tests__/saas-crm.test.ts`.
+  // The split keeps the rationale "stripeCustomerId is not a secret per se,
+  // but the EE-side log is intentionally bare to reduce surface" testable
+  // at each boundary.
+  it("includes orgId, stripeCustomerId, and err on the outer enqueue_failed warn", async () => {
     runEnterpriseImpl = async (program) => {
       await Effect.runPromise(
         Effect.provide(
@@ -304,14 +307,140 @@ describe("dispatchConversionCrmStamp — stripeCustomerId is never logged", () =
     await dispatchConversionCrmStamp({
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- structural Stripe stub
       stripeClient: stripe as any,
-      stripeCustomerId: "cus_should_not_appear_in_logs",
-      orgId: "org_x",
+      stripeCustomerId: "cus_pin_outer_log",
+      orgId: "org_pin",
     });
 
-    // The outer helper's enqueue_failed log includes stripeCustomerId
-    // intentionally (for triage). The inner EE-side `saas_crm.stamp_
-    // conversion_enqueue_failed` log does NOT — verified in ee tests.
-    // Just pin that this helper logs at least once.
     expect(mockLogWarn).toHaveBeenCalledTimes(1);
+    const [logCtx] = mockLogWarn.mock.calls[0] as [Record<string, unknown>, string];
+    expect(logCtx.event).toBe("conversion_crm.enqueue_failed");
+    expect(logCtx.orgId).toBe("org_pin");
+    expect(logCtx.stripeCustomerId).toBe("cus_pin_outer_log");
+    expect(logCtx.err).toBe("blip");
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────
+// planConversionStamp — the trial-vs-paid gating predicate (#2737 +
+// Codex P1). Pinning every permutation here is the structural defence
+// against silently re-introducing trial-start stamping.
+// ────────────────────────────────────────────────────────────────────
+
+describe("planConversionStamp — onSubscriptionComplete trigger", () => {
+  it("dispatches when status is active and stripeCustomerId is present", () => {
+    expect(
+      planConversionStamp({
+        trigger: "complete",
+        subscription: { status: "active", stripeCustomerId: "cus_paid_immediately" },
+      }),
+    ).toEqual({ kind: "dispatch", stripeCustomerId: "cus_paid_immediately" });
+  });
+
+  it("skips when status is trialing (Codex P1 — no overcounting unpaid trials)", () => {
+    expect(
+      planConversionStamp({
+        trigger: "complete",
+        subscription: { status: "trialing", stripeCustomerId: "cus_on_trial" },
+      }),
+    ).toEqual({ kind: "skip", reason: "trialing" });
+  });
+
+  it("skips when status is any other non-active value (incomplete / past_due / paused)", () => {
+    for (const status of ["incomplete", "past_due", "paused", "unpaid", "canceled"] as const) {
+      expect(
+        planConversionStamp({
+          trigger: "complete",
+          subscription: { status, stripeCustomerId: "cus_x" },
+        }),
+      ).toEqual({ kind: "skip", reason: "non-active" });
+    }
+  });
+
+  it("returns log-and-skip when stripeCustomerId is missing", () => {
+    expect(
+      planConversionStamp({
+        trigger: "complete",
+        subscription: { status: "active", stripeCustomerId: null },
+      }),
+    ).toEqual({ kind: "log-and-skip", reason: "no-stripe-customer-id" });
+    expect(
+      planConversionStamp({
+        trigger: "complete",
+        subscription: { status: "active", stripeCustomerId: undefined },
+      }),
+    ).toEqual({ kind: "log-and-skip", reason: "no-stripe-customer-id" });
+  });
+});
+
+describe("planConversionStamp — onSubscriptionUpdate trigger", () => {
+  const updateEvent = (current: string | null | undefined, previous: string | null | undefined) => ({
+    type: "customer.subscription.updated",
+    data: {
+      previous_attributes: previous === undefined ? undefined : { status: previous },
+      object: { status: current },
+    },
+  });
+
+  it("dispatches on the trial → active transition", () => {
+    expect(
+      planConversionStamp({
+        trigger: "update",
+        subscription: { stripeCustomerId: "cus_trial_converted" },
+        event: updateEvent("active", "trialing"),
+      }),
+    ).toEqual({ kind: "dispatch", stripeCustomerId: "cus_trial_converted" });
+  });
+
+  it("skips when current status is active but previous was not trialing (e.g. price change)", () => {
+    expect(
+      planConversionStamp({
+        trigger: "update",
+        subscription: { stripeCustomerId: "cus_x" },
+        event: updateEvent("active", "active"),
+      }),
+    ).toEqual({ kind: "skip", reason: "non-transition" });
+  });
+
+  it("skips when previous_attributes is absent (Stripe omits unchanged fields)", () => {
+    expect(
+      planConversionStamp({
+        trigger: "update",
+        subscription: { stripeCustomerId: "cus_x" },
+        event: updateEvent("active", undefined),
+      }),
+    ).toEqual({ kind: "skip", reason: "non-transition" });
+  });
+
+  it("skips when current status is something other than active (trial → past_due)", () => {
+    expect(
+      planConversionStamp({
+        trigger: "update",
+        subscription: { stripeCustomerId: "cus_x" },
+        event: updateEvent("past_due", "trialing"),
+      }),
+    ).toEqual({ kind: "skip", reason: "non-transition" });
+  });
+
+  it("skips when the event type is not customer.subscription.updated", () => {
+    expect(
+      planConversionStamp({
+        trigger: "update",
+        subscription: { stripeCustomerId: "cus_x" },
+        event: {
+          type: "customer.subscription.created",
+          data: { previous_attributes: { status: "trialing" }, object: { status: "active" } },
+        },
+      }),
+    ).toEqual({ kind: "skip", reason: "non-transition" });
+  });
+
+  it("skips when stripeCustomerId is missing on the subscription (even on a real transition)", () => {
+    expect(
+      planConversionStamp({
+        trigger: "update",
+        subscription: { stripeCustomerId: undefined },
+        event: updateEvent("active", "trialing"),
+      }),
+    ).toEqual({ kind: "skip", reason: "non-transition" });
   });
 });

--- a/packages/api/src/lib/auth/__tests__/dispatch-signup-crm-lead.test.ts
+++ b/packages/api/src/lib/auth/__tests__/dispatch-signup-crm-lead.test.ts
@@ -101,6 +101,10 @@ function noopLayer(): Layer.Layer<SaasCrm> {
   return Layer.succeed(SaasCrm, {
     available: false,
     upsertLead: () => Effect.void,
+    // #2737 — SaasCrmShape's available:false branch now requires
+    // `stampConversion` too. Noop is structurally identical to
+    // `upsertLead` here.
+    stampConversion: () => Effect.void,
   });
 }
 

--- a/packages/api/src/lib/auth/server.ts
+++ b/packages/api/src/lib/auth/server.ts
@@ -298,12 +298,21 @@ export async function dispatchSignupCrmLead(args: {
 }
 
 /**
- * Twenty CRM dispatch for a completed Stripe checkout (#2737).
- * Enqueues a `stamp-conversion` row into `crm_outbox` via the `SaasCrm`
- * Tag; the scheduler-backed flusher routes the row through
+ * Twenty CRM dispatch for a Stripe subscription that has actually been
+ * paid (#2737). Enqueues a `stamp-conversion` row into `crm_outbox` via
+ * the `SaasCrm` Tag; the scheduler-backed flusher routes the row through
  * `TwentyClient.upsertPerson` which stamps `atlasStripeCustomerId` on
  * the matching Twenty Person (and creates a new Person with
  * `atlasFirstSource = "CONVERSION"` if none exists).
+ *
+ * **Call sites:** invoked from two Better Auth Stripe hooks:
+ *  - `onSubscriptionComplete` — only when `subscription.status` is
+ *    already `"active"` (a paid plan without a trial, or a trial that
+ *    completed instantly). Trialing subscriptions are skipped here.
+ *  - `onSubscriptionUpdate` — when the underlying Stripe event is
+ *    `customer.subscription.updated` and `previous_attributes.status`
+ *    transitions from `"trialing"` to `"active"` (i.e. the customer
+ *    just paid their first post-trial invoice).
  *
  * **Webhook latency:** enqueue + return immediately. The Twenty side
  * runs out-of-band via the flusher. A Twenty outage MUST NOT 500 the
@@ -400,6 +409,71 @@ export async function dispatchConversionCrmStamp(args: {
       "Unexpected SaasCrm dispatch error during conversion stamp — swallowed to keep webhook ack unblocked",
     );
   }
+}
+
+/**
+ * Decide whether a Stripe webhook hook should call
+ * `dispatchConversionCrmStamp`. Pure function, no I/O, no logging —
+ * the only meaningful decision logic in #2737's two trigger points is
+ * the gating, so it's worth pinning in isolation.
+ *
+ * Returns a discriminated directive:
+ *  - `dispatch` — caller should `await dispatchConversionCrmStamp(...)`.
+ *  - `log-and-skip` — caller should emit a structured `log.warn` with
+ *    the `reason` and skip. Used only when the customer id is missing
+ *    (a structural anomaly worth a breadcrumb).
+ *  - `skip` — caller should silently do nothing. Used for the routine
+ *    "still trialing" / "not a trial-to-active transition" branches.
+ *
+ * Trigger semantics:
+ *  - `"complete"` — `onSubscriptionComplete`. Stamp only if the
+ *    subscription is already `"active"` at completion (no-trial plan
+ *    or instant-completion path). Trialing subs defer to the update
+ *    trigger below.
+ *  - `"update"` — `onSubscriptionUpdate`. Stamp on the trial → active
+ *    transition (`previous_attributes.status === "trialing"` and
+ *    current `status === "active"`).
+ *
+ * @internal
+ */
+export type ConversionStampDirective =
+  | { readonly kind: "dispatch"; readonly stripeCustomerId: string }
+  | { readonly kind: "log-and-skip"; readonly reason: "no-stripe-customer-id" }
+  | { readonly kind: "skip"; readonly reason: "trialing" | "non-active" | "non-transition" };
+
+export function planConversionStamp(args: {
+  readonly trigger: "complete";
+  readonly subscription: { readonly status?: string | null; readonly stripeCustomerId?: string | null };
+} | {
+  readonly trigger: "update";
+  readonly subscription: { readonly stripeCustomerId?: string | null };
+  readonly event: { readonly type: string; readonly data: { readonly previous_attributes?: { readonly status?: string | null } | null; readonly object: { readonly status?: string | null } } };
+}): ConversionStampDirective {
+  if (args.trigger === "complete") {
+    if (!args.subscription.stripeCustomerId) {
+      return { kind: "log-and-skip", reason: "no-stripe-customer-id" };
+    }
+    if (args.subscription.status === "active") {
+      return { kind: "dispatch", stripeCustomerId: args.subscription.stripeCustomerId };
+    }
+    if (args.subscription.status === "trialing") {
+      return { kind: "skip", reason: "trialing" };
+    }
+    return { kind: "skip", reason: "non-active" };
+  }
+  // trigger === "update"
+  if (args.event.type !== "customer.subscription.updated") {
+    return { kind: "skip", reason: "non-transition" };
+  }
+  if (!args.subscription.stripeCustomerId) {
+    return { kind: "skip", reason: "non-transition" };
+  }
+  const previousStatus = args.event.data.previous_attributes?.status;
+  const currentStatus = args.event.data.object.status;
+  if (previousStatus === "trialing" && currentStatus === "active") {
+    return { kind: "dispatch", stripeCustomerId: args.subscription.stripeCustomerId };
+  }
+  return { kind: "skip", reason: "non-transition" };
 }
 
 /**
@@ -1476,10 +1550,31 @@ export function buildPlugins() {
                 // outbox INSERT (a few ms). Not awaiting risks an
                 // unhandled rejection if a future change widens the
                 // error channel.
-                if (subscription.stripeCustomerId) {
+                //
+                // All paid plans ship with `freeTrial: { days: TRIAL_DAYS }`
+                // (see `lib/billing/plans.ts`), so this hook fires with
+                // status `"trialing"` on every checkout completion that
+                // entered a trial — stamping then would overcount unpaid
+                // trials as paid conversions in the #2728 read path. The
+                // trial → active transition is picked up by
+                // `onSubscriptionUpdate` below. Gating is centralised in
+                // `planConversionStamp` so the trial / no-customer-id /
+                // active permutations are unit-testable.
+                const directive = planConversionStamp({ trigger: "complete", subscription });
+                if (directive.kind === "log-and-skip") {
+                  log.warn(
+                    {
+                      orgId,
+                      plan: plan.name,
+                      subscriptionId: subscription.id,
+                      event: "conversion_crm.no_stripe_customer_id",
+                    },
+                    "Subscription completed without stripeCustomerId — skipping Twenty conversion stamp",
+                  );
+                } else if (directive.kind === "dispatch") {
                   await dispatchConversionCrmStamp({
                     stripeClient,
-                    stripeCustomerId: subscription.stripeCustomerId,
+                    stripeCustomerId: directive.stripeCustomerId,
                     orgId,
                   });
                 }
@@ -1506,6 +1601,29 @@ export function buildPlugins() {
 
                 // Resolve the new plan tier from the Stripe subscription's price ID
                 const stripeSubscription = event.data.object as Stripe.Subscription;
+
+                // #2737 — Twenty CRM conversion stamp on trial → active.
+                // `onSubscriptionComplete` skips trialing subscriptions to
+                // avoid overcounting unpaid trials as paid conversions.
+                // The real "paid" signal is `customer.subscription.updated`
+                // with status transitioning from "trialing" to "active"
+                // (Stripe fires this when the first trial-end invoice is
+                // paid). Awaited for the same reason as the create-side
+                // dispatch (helper swallows internally; the await only
+                // blocks on the outbox INSERT).
+                const updateDirective = planConversionStamp({
+                  trigger: "update",
+                  subscription,
+                  event: event as { type: string; data: { previous_attributes?: { status?: string | null } | null; object: { status?: string | null } } },
+                });
+                if (updateDirective.kind === "dispatch") {
+                  await dispatchConversionCrmStamp({
+                    stripeClient,
+                    stripeCustomerId: updateDirective.stripeCustomerId,
+                    orgId,
+                  });
+                }
+
                 const priceId = stripeSubscription.items?.data?.[0]?.price?.id;
                 if (!priceId) {
                   billingLog.warn(

--- a/packages/api/src/lib/auth/server.ts
+++ b/packages/api/src/lib/auth/server.ts
@@ -298,6 +298,111 @@ export async function dispatchSignupCrmLead(args: {
 }
 
 /**
+ * Twenty CRM dispatch for a completed Stripe checkout (#2737).
+ * Enqueues a `stamp-conversion` row into `crm_outbox` via the `SaasCrm`
+ * Tag; the scheduler-backed flusher routes the row through
+ * `TwentyClient.upsertPerson` which stamps `atlasStripeCustomerId` on
+ * the matching Twenty Person (and creates a new Person with
+ * `atlasFirstSource = "CONVERSION"` if none exists).
+ *
+ * **Webhook latency:** enqueue + return immediately. The Twenty side
+ * runs out-of-band via the flusher. A Twenty outage MUST NOT 500 the
+ * Stripe webhook — Stripe retries on non-2xx for 3 weeks and a failed
+ * ack here can stack other webhook deliveries behind it. Two layers of
+ * defense, mirroring `dispatchSignupCrmLead`:
+ *  - inner `.pipe(Effect.either)` absorbs the typed `Error` channel
+ *    (e.g. a `crm_outbox` Postgres blip).
+ *  - outer `try/catch` absorbs runtime defects.
+ *
+ * **Email source:** `subscription.referenceId` is the orgId in Atlas's
+ * Better Auth wiring, not the user's email. We retrieve the Stripe
+ * customer (whose `email` is the address used at checkout) to attribute
+ * the stamp back to the same Person record demoed/signed up under that
+ * email. A Stripe customer with no email logs and skips — the row would
+ * otherwise dead-letter on the very first dispatch.
+ *
+ * @internal
+ */
+export async function dispatchConversionCrmStamp(args: {
+  stripeClient: Stripe;
+  stripeCustomerId: string;
+  orgId?: string | null;
+}): Promise<void> {
+  const { stripeClient, stripeCustomerId, orgId } = args;
+
+  let customer: Stripe.Customer | Stripe.DeletedCustomer;
+  try {
+    customer = await stripeClient.customers.retrieve(stripeCustomerId);
+  } catch (err) {
+    log.warn(
+      {
+        stripeCustomerId,
+        orgId,
+        err: errorMessage(err),
+        event: "conversion_crm.customer_retrieve_failed",
+      },
+      "Stripe customers.retrieve failed during conversion stamp — swallowed to keep webhook ack unblocked",
+    );
+    return;
+  }
+  if (customer.deleted) {
+    log.warn(
+      {
+        stripeCustomerId,
+        orgId,
+        event: "conversion_crm.customer_deleted",
+      },
+      "Stripe customer is deleted at conversion-stamp time — skipping Twenty stamp",
+    );
+    return;
+  }
+  const email = customer.email?.toLowerCase().trim();
+  if (!email) {
+    log.warn(
+      {
+        stripeCustomerId,
+        orgId,
+        event: "conversion_crm.customer_no_email",
+      },
+      "Stripe customer has no email — cannot attribute conversion stamp to a Twenty Person",
+    );
+    return;
+  }
+
+  try {
+    await runEnterprise(
+      Effect.gen(function* () {
+        const crm = yield* SaasCrm;
+        const result = yield* crm
+          .stampConversion({ email, stripeCustomerId })
+          .pipe(Effect.either);
+        if (result._tag === "Left") {
+          log.warn(
+            {
+              orgId,
+              stripeCustomerId,
+              err: errorMessage(result.left),
+              event: "conversion_crm.enqueue_failed",
+            },
+            "SaasCrm.stampConversion enqueue failed — swallowed to keep webhook ack unblocked",
+          );
+        }
+      }),
+    );
+  } catch (err) {
+    log.warn(
+      {
+        orgId,
+        stripeCustomerId,
+        err: errorMessage(err),
+        event: "conversion_crm.dispatch_defect",
+      },
+      "Unexpected SaasCrm dispatch error during conversion stamp — swallowed to keep webhook ack unblocked",
+    );
+  }
+}
+
+/**
  * Built-in rate-limit ceilings for Better Auth endpoints. Chosen to slow
  * online brute force and email-verification abuse while tolerating
  * legitimate retry patterns (user fat-fingers password 2–3 times, clicks
@@ -1363,6 +1468,20 @@ export function buildPlugins() {
                     );
                     throw err;
                   }
+                }
+
+                // #2737 — fire-and-forget Twenty CRM conversion stamp.
+                // Awaited deliberately: the helper swallows every
+                // failure internally, so the await only blocks on the
+                // outbox INSERT (a few ms). Not awaiting risks an
+                // unhandled rejection if a future change widens the
+                // error channel.
+                if (subscription.stripeCustomerId) {
+                  await dispatchConversionCrmStamp({
+                    stripeClient,
+                    stripeCustomerId: subscription.stripeCustomerId,
+                    orgId,
+                  });
                 }
               },
               async onSubscriptionCancel({ subscription }) {

--- a/packages/api/src/lib/effect/__tests__/outbox-flusher-lifecycle.test.ts
+++ b/packages/api/src/lib/effect/__tests__/outbox-flusher-lifecycle.test.ts
@@ -72,6 +72,7 @@ function makeAvailableSaasCrmLayer(): Layer.Layer<SaasCrmTag> {
   return Layer.succeed(SaasCrm, {
     available: true,
     upsertLead: () => Effect.void,
+    stampConversion: () => Effect.void,
     dispatcher: async () => ({ kind: "ok" as const }),
   } satisfies SaasCrmShape);
 }
@@ -142,6 +143,7 @@ describe("outbox flusher lifecycle (#2729 AC #7 + #9)", () => {
     const noopSaasCrm: Layer.Layer<SaasCrmTag> = Layer.succeed(SaasCrm, {
       available: false,
       upsertLead: () => Effect.void,
+      stampConversion: () => Effect.void,
     } satisfies SaasCrmShape);
 
     const config = {} as Parameters<typeof makeSchedulerLive>[0];

--- a/packages/api/src/lib/effect/services.ts
+++ b/packages/api/src/lib/effect/services.ts
@@ -2445,7 +2445,35 @@ export type SaasCrmLeadInput =
        * allowed. Split into first/last at the normalizer seam.
        */
       readonly name?: string;
+    }
+  | {
+      /**
+       * Stripe → Twenty conversion stamping (#2737). Fired from the
+       * `onSubscriptionComplete` Better Auth hook after a paying
+       * checkout. The dispatcher stamps `customFields.atlasStripeCustomerId`
+       * on the Twenty Person matching `email`; if no Person exists,
+       * `upsertPerson` creates one with `atlasFirstSource = "CONVERSION"`
+       * so the stamp is never lost.
+       */
+      readonly source: "conversion";
+      readonly email: string;
+      /** Stripe `customer.id` (`cus_…`). */
+      readonly stripeCustomerId: string;
     };
+
+/**
+ * Inputs to `SaasCrm.stampConversion`. Separate from `SaasCrmLeadInput`
+ * so the call site (the Stripe webhook hook) stays a flat call —
+ * `crm.stampConversion({ email, stripeCustomerId })` — without needing
+ * to construct a discriminated union literal. The conversion shape lives
+ * on `SaasCrmLeadInput` too (as the `conversion` variant) because the
+ * outbox payload uses the same union as the normalizer.
+ */
+export interface SaasCrmStampConversionInput {
+  readonly email: string;
+  /** Stripe `customer.id` (`cus_…`). */
+  readonly stripeCustomerId: string;
+}
 
 /**
  * Discriminated SaasCrm shape — the two correlated facts (anticipated
@@ -2472,6 +2500,14 @@ export type SaasCrmShape =
        */
       readonly available: false;
       readonly upsertLead: (input: SaasCrmLeadInput) => Effect.Effect<void, Error>;
+      /**
+       * Stripe → Twenty conversion stamping (#2737). Noop on
+       * self-hosted / EE-disabled — same fail-soft pattern as
+       * `upsertLead`.
+       */
+      readonly stampConversion: (
+        input: SaasCrmStampConversionInput,
+      ) => Effect.Effect<void, Error>;
     }
   | {
       readonly available: true;
@@ -2484,6 +2520,18 @@ export type SaasCrmShape =
        * structured log (demo — user already has a sandbox link).
        */
       readonly upsertLead: (input: SaasCrmLeadInput) => Effect.Effect<void, Error>;
+      /**
+       * Enqueue a `stamp-conversion` row into `crm_outbox` for durable
+       * dispatch (#2737). The Stripe webhook handler calls this from
+       * `onSubscriptionComplete` and returns immediately so webhook ack
+       * latency stays unchanged. The flusher's per-row dispatcher
+       * routes the row through the same `upsertPerson` codepath as
+       * other lead variants — the `conversion` normalizer attaches
+       * `atlasStripeCustomerId` to the Person on every write path.
+       */
+      readonly stampConversion: (
+        input: SaasCrmStampConversionInput,
+      ) => Effect.Effect<void, Error>;
       /**
        * Per-row dispatcher the scheduler-backed flusher calls inside
        * `flushBatch`. Defined here (not in `@atlas/ee`) so
@@ -2503,6 +2551,7 @@ export class SaasCrm extends Context.Tag("SaasCrm")<SaasCrm, SaasCrmShape>() {}
 export const NoopSaasCrmLayer: Layer.Layer<SaasCrm> = Layer.succeed(SaasCrm, {
   available: false,
   upsertLead: () => Effect.void,
+  stampConversion: () => Effect.void,
 } satisfies SaasCrmShape);
 
 // ── Aggregate no-op default Layer ────────────────────────────────────

--- a/packages/api/src/lib/effect/services.ts
+++ b/packages/api/src/lib/effect/services.ts
@@ -2462,18 +2462,18 @@ export type SaasCrmLeadInput =
     };
 
 /**
- * Inputs to `SaasCrm.stampConversion`. Separate from `SaasCrmLeadInput`
- * so the call site (the Stripe webhook hook) stays a flat call —
+ * Inputs to `SaasCrm.stampConversion`. Derived from the `conversion`
+ * variant of `SaasCrmLeadInput` so a future field addition (e.g.
+ * `paidPlanInterval`) only needs to touch the union — this interface
+ * tracks automatically. Kept as a distinct type so the call site (the
+ * Stripe webhook hook) stays a flat call —
  * `crm.stampConversion({ email, stripeCustomerId })` — without needing
- * to construct a discriminated union literal. The conversion shape lives
- * on `SaasCrmLeadInput` too (as the `conversion` variant) because the
- * outbox payload uses the same union as the normalizer.
+ * to construct a discriminated union literal.
  */
-export interface SaasCrmStampConversionInput {
-  readonly email: string;
-  /** Stripe `customer.id` (`cus_…`). */
-  readonly stripeCustomerId: string;
-}
+export type SaasCrmStampConversionInput = Omit<
+  Extract<SaasCrmLeadInput, { source: "conversion" }>,
+  "source"
+>;
 
 /**
  * Discriminated SaasCrm shape — the two correlated facts (anticipated
@@ -2497,6 +2497,17 @@ export type SaasCrmShape =
        * rather than the standard 403 envelope. The flusher wire-up in
        * `lib/effect/layers.ts:makeSchedulerLive` also reads it to decide
        * whether to mount the per-row dispatcher.
+       *
+       * Flips to `false` on any of:
+       *  - self-hosted (`@atlas/ee` not loaded → `NoopSaasCrmLayer`);
+       *  - `@useatlas/twenty` credentials unresolvable at boot;
+       *  - Twenty metadata probe returns 401/403/404 (deterministic
+       *    misconfiguration);
+       *  - any of `REQUIRED_PERSON_FIELDS` is missing on the Twenty
+       *    Person object (`atlasFirstSource` / `atlasLastSource` /
+       *    `atlasStripeCustomerId` — #2737). Missing custom fields
+       *    would dead-letter every dispatch on a 422 schema mismatch,
+       *    so the boot-time guard disables the layer instead.
        */
       readonly available: false;
       readonly upsertLead: (input: SaasCrmLeadInput) => Effect.Effect<void, Error>;

--- a/plugins/twenty/README.md
+++ b/plugins/twenty/README.md
@@ -7,17 +7,16 @@ Atlas action plugin for [Twenty CRM](https://twenty.com). Ships two agent-callab
 
 ## Required Twenty setup
 
-Before deploy, three **custom fields** must be created on the `Person` object in Twenty:
+Before deploy, three **required** custom fields must be created on the `Person` object in Twenty. **All three are hard requirements** — if any is missing at boot, the Atlas SaaS wiring (`/ee/src/saas-crm/`) flips `SaasCrm.available` to `false` and every downstream demo / signup / conversion dispatch becomes a no-op (no dead outbox rows). The startup verification logs the exact missing-field list and create-instructions.
 
-| Field name              | Type    | Purpose                                                                                               |
-| ----------------------- | ------- | ----------------------------------------------------------------------------------------------------- |
-| `atlasFirstSource`      | Text    | Sticky first-touch attribution — set once on a Person, never overwritten thereafter (e.g. `DEMO`).    |
-| `atlasLastSource`       | Text    | Most recent touch — overwritten on every dispatch (e.g. `DEMO`, `SIGNUP`, `SALES_FORM`, `CONVERSION`). |
-| `atlasStripeCustomerId` | Text    | Stripe `customer.id` of a paying customer. Stamped by `stampStripeCustomerId` on conversion.          |
+| Field name              | Type    | Required? | Purpose                                                                                               |
+| ----------------------- | ------- | --------- | ----------------------------------------------------------------------------------------------------- |
+| `atlasFirstSource`      | Text    | **Yes**   | Sticky first-touch attribution — set once on a Person, never overwritten thereafter (e.g. `DEMO`).    |
+| `atlasLastSource`       | Text    | **Yes**   | Most recent touch — overwritten on every dispatch (e.g. `DEMO`, `SIGNUP`, `SALES_FORM`, `CONVERSION`). |
+| `atlasStripeCustomerId` | Text    | **Yes**   | Stripe `customer.id` of a paying customer. Stamped by `stampStripeCustomerId` on conversion.          |
+| `atlasIp`               | Text    | No        | Client IP on demo gate submissions. Optional — absence is non-fatal (the field is written if present, silently skipped otherwise). |
 
-Create all three under **Settings → Data Model → Person → + Add Field** in the Twenty UI. The Atlas SaaS wiring (`/ee/src/saas-crm/`) runs a startup verification via the Twenty metadata GraphQL endpoint (`/metadata`) — if any field is missing, the layer logs an error with the exact create-instructions and disables itself; subsequent demo signups AND conversion stamps are no-ops (no dead outbox rows).
-
-An optional fourth field `atlasIp` (Text) captures the client IP on demo gate submissions; absence is non-fatal.
+Create the required fields under **Settings → Data Model → Person → + Add Field** in the Twenty UI. Verification runs once at boot via the Twenty metadata GraphQL endpoint (`/metadata`).
 
 ## Install (self-hoster)
 
@@ -48,7 +47,12 @@ The plugin exposes two agent tools:
 
 Atlas SaaS (`app.useatlas.dev`) does NOT register this plugin via `atlas.config.ts`. Instead, `/ee/src/saas-crm/` consumes `TwentyClient` directly through the `SaasCrm` Effect Tag. Self-hosters that want demo / signup / conversion dispatch into Twenty wire the actions themselves via this plugin's action API.
 
-The SaaS-side conversion stamping (`SaasCrm.stampConversion`) is invoked from the Stripe `onSubscriptionComplete` Better Auth hook in `packages/api/src/lib/auth/server.ts`. The hook retrieves the Stripe customer's email and enqueues a `stamp-conversion` row into `crm_outbox` for durable dispatch by the scheduler-backed flusher.
+The SaaS-side conversion stamping (`SaasCrm.stampConversion`) fires only on **actual payment**, not at trial start. All paid plans ship with a 14-day `freeTrial`, so `onSubscriptionComplete` fires with `subscription.status === "trialing"` at checkout completion — stamping then would overcount unpaid trials as paid conversions in funnel queries. The two real "paid" signals, both wired in `packages/api/src/lib/auth/server.ts`:
+
+1. **`onSubscriptionComplete`** — when `subscription.status === "active"` (a paid plan without a trial, or a trial that completed instantly).
+2. **`onSubscriptionUpdate`** — when the underlying Stripe event is `customer.subscription.updated` and `previous_attributes.status === "trialing"` with current `status === "active"` (i.e. the customer just paid their first post-trial invoice).
+
+Each path retrieves the Stripe customer's email and enqueues a `stamp-conversion` row into `crm_outbox` for durable dispatch by the scheduler-backed flusher.
 
 ## Config
 

--- a/plugins/twenty/README.md
+++ b/plugins/twenty/README.md
@@ -1,19 +1,23 @@
 # @useatlas/twenty
 
-Atlas action plugin for [Twenty CRM](https://twenty.com). Currently ships the `upsertTwentyPerson` action only.
+Atlas action plugin for [Twenty CRM](https://twenty.com). Ships two agent-callable actions:
+
+- `upsertTwentyPerson` — upsert a Person by email with sticky first/last source attribution.
+- `stampStripeCustomerId` — stamp `atlasStripeCustomerId` on a Person matching email (CONVERSION source). Use from a Stripe webhook handler.
 
 ## Required Twenty setup
 
-Before deploy, two **custom fields** must be created on the `Person` object in Twenty:
+Before deploy, three **custom fields** must be created on the `Person` object in Twenty:
 
-| Field name         | Type    | Purpose                                                                                               |
-| ------------------ | ------- | ----------------------------------------------------------------------------------------------------- |
-| `atlasFirstSource` | Text    | Sticky first-touch attribution — set once on a Person, never overwritten thereafter (e.g. `DEMO`).    |
-| `atlasLastSource`  | Text    | Most recent touch — overwritten on every dispatch (e.g. `DEMO`, `SIGNUP`, `SALES_FORM`).              |
+| Field name              | Type    | Purpose                                                                                               |
+| ----------------------- | ------- | ----------------------------------------------------------------------------------------------------- |
+| `atlasFirstSource`      | Text    | Sticky first-touch attribution — set once on a Person, never overwritten thereafter (e.g. `DEMO`).    |
+| `atlasLastSource`       | Text    | Most recent touch — overwritten on every dispatch (e.g. `DEMO`, `SIGNUP`, `SALES_FORM`, `CONVERSION`). |
+| `atlasStripeCustomerId` | Text    | Stripe `customer.id` of a paying customer. Stamped by `stampStripeCustomerId` on conversion.          |
 
-Create both under **Settings → Data Model → Person → + Add Field** in the Twenty UI. The Atlas SaaS wiring (`/ee/src/saas-crm/`) runs a startup verification via the Twenty metadata GraphQL endpoint (`/metadata`) — if either field is missing, the layer logs an error with the exact create-instructions and disables itself; subsequent demo signups are no-ops (no dead outbox rows).
+Create all three under **Settings → Data Model → Person → + Add Field** in the Twenty UI. The Atlas SaaS wiring (`/ee/src/saas-crm/`) runs a startup verification via the Twenty metadata GraphQL endpoint (`/metadata`) — if any field is missing, the layer logs an error with the exact create-instructions and disables itself; subsequent demo signups AND conversion stamps are no-ops (no dead outbox rows).
 
-An optional third field `atlasIp` (Text) captures the client IP on demo gate submissions; absence is non-fatal.
+An optional fourth field `atlasIp` (Text) captures the client IP on demo gate submissions; absence is non-fatal.
 
 ## Install (self-hoster)
 
@@ -35,11 +39,16 @@ export default defineConfig({
 });
 ```
 
-The plugin exposes one agent tool: `upsertTwentyPerson`. The action takes `{ email, eventSource, firstName?, lastName?, atlasIp? }` and upserts the Person by `emails.primaryEmail`. The Atlas-side first/last source rule is enforced inside `TwentyClient.upsertPerson` — callers pass a single `eventSource`.
+The plugin exposes two agent tools:
+
+- `upsertTwentyPerson` — takes `{ email, eventSource, firstName?, lastName?, atlasIp? }` and upserts the Person by `emails.primaryEmail`. The first/last source rule is enforced inside `TwentyClient.upsertPerson` — callers pass a single `eventSource`.
+- `stampStripeCustomerId` — takes `{ email, stripeCustomerId }` and stamps `atlasStripeCustomerId` on the matching Person (creates a new Person with `atlasFirstSource = "CONVERSION"` if none exists). Self-hosters with their own Stripe + Twenty wiring can call this from their own webhook handler.
 
 ## Atlas SaaS wiring
 
-Atlas SaaS (`app.useatlas.dev`) does NOT register this plugin via `atlas.config.ts`. Instead, `/ee/src/saas-crm/` consumes `TwentyClient` directly through the `SaasCrm` Effect Tag. Self-hosters that want demo / signup dispatch into Twenty wire the actions themselves via this plugin's action API.
+Atlas SaaS (`app.useatlas.dev`) does NOT register this plugin via `atlas.config.ts`. Instead, `/ee/src/saas-crm/` consumes `TwentyClient` directly through the `SaasCrm` Effect Tag. Self-hosters that want demo / signup / conversion dispatch into Twenty wire the actions themselves via this plugin's action API.
+
+The SaaS-side conversion stamping (`SaasCrm.stampConversion`) is invoked from the Stripe `onSubscriptionComplete` Better Auth hook in `packages/api/src/lib/auth/server.ts`. The hook retrieves the Stripe customer's email and enqueues a `stamp-conversion` row into `crm_outbox` for durable dispatch by the scheduler-backed flusher.
 
 ## Config
 

--- a/plugins/twenty/__tests__/client.test.ts
+++ b/plugins/twenty/__tests__/client.test.ts
@@ -9,6 +9,7 @@
 import { describe, test, expect } from "bun:test";
 import {
   upsertPerson,
+  stampStripeCustomerId,
   getPersonMetadata,
   createNote,
   TwentyClientError,
@@ -850,6 +851,200 @@ describe("createNote — error mapping", () => {
       expect(err).toBeInstanceOf(TwentyClientError);
       const msg = (err as TwentyClientError).message;
       expect(msg).not.toContain("twenty_secret_must_not_leak");
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+//  stampStripeCustomerId — Stripe → Twenty conversion stamping (#2737)
+// ─────────────────────────────────────────────────────────────────────
+
+describe("stampStripeCustomerId — Person exists with atlasFirstSource set", () => {
+  test("PATCHes atlasLastSource = CONVERSION + atlasStripeCustomerId — atlasFirstSource preserved", async () => {
+    const { fetch, calls } = makeScriptedFetch([
+      {
+        status: 200,
+        body: {
+          data: {
+            people: [
+              {
+                id: "person_existing",
+                emails: { primaryEmail: "user@test.com" },
+                atlasFirstSource: "DEMO",
+                atlasLastSource: "DEMO",
+              },
+            ],
+          },
+        },
+      },
+      {
+        status: 200,
+        body: {
+          data: {
+            updatePerson: {
+              id: "person_existing",
+              atlasFirstSource: "DEMO",
+              atlasLastSource: "CONVERSION",
+              atlasStripeCustomerId: "cus_abc123",
+            },
+          },
+        },
+      },
+    ]);
+    const config = baseConfig({ fetchImpl: fetch });
+
+    const result = await stampStripeCustomerId(config, {
+      email: "user@test.com",
+      stripeCustomerId: "cus_abc123",
+    });
+
+    expect(result.id).toBe("person_existing");
+    expect(calls).toHaveLength(2);
+    expect(calls[1].method).toBe("PATCH");
+    expect(calls[1].url).toBe(
+      "https://crm.test.local/rest/people/person_existing",
+    );
+    const body = JSON.parse(calls[1].body ?? "{}");
+    // atlasFirstSource is sticky — must NOT be in the payload.
+    expect(body.atlasFirstSource).toBeUndefined();
+    expect(body.atlasLastSource).toBe("CONVERSION");
+    expect(body.atlasStripeCustomerId).toBe("cus_abc123");
+  });
+});
+
+describe("stampStripeCustomerId — Person does not exist (paying customer never demoed)", () => {
+  test("POSTs a new Person with atlasFirstSource = CONVERSION, atlasLastSource = CONVERSION, AND atlasStripeCustomerId", async () => {
+    const { fetch, calls } = makeScriptedFetch([
+      { status: 200, body: { data: { people: [] } } },
+      {
+        status: 200,
+        body: {
+          data: {
+            createPerson: {
+              id: "person_new",
+              emails: { primaryEmail: "first.touch@test.com" },
+              atlasFirstSource: "CONVERSION",
+              atlasLastSource: "CONVERSION",
+              atlasStripeCustomerId: "cus_xyz",
+            } as TwentyPerson,
+          },
+        },
+      },
+    ]);
+    const config = baseConfig({ fetchImpl: fetch });
+
+    const result = await stampStripeCustomerId(config, {
+      email: "first.touch@test.com",
+      stripeCustomerId: "cus_xyz",
+    });
+
+    expect(result.id).toBe("person_new");
+    expect(calls).toHaveLength(2);
+    expect(calls[1].method).toBe("POST");
+    expect(calls[1].url).toBe("https://crm.test.local/rest/people");
+    const body = JSON.parse(calls[1].body ?? "{}");
+    // Custom fields inline — no `customFields` wrapper.
+    expect(body.emails).toEqual({ primaryEmail: "first.touch@test.com" });
+    expect(body.atlasFirstSource).toBe("CONVERSION");
+    expect(body.atlasLastSource).toBe("CONVERSION");
+    expect(body.atlasStripeCustomerId).toBe("cus_xyz");
+    expect(body.customFields).toBeUndefined();
+  });
+});
+
+describe("stampStripeCustomerId — Person exists but atlasFirstSource absent", () => {
+  test("PATCHes both source fields to CONVERSION + atlasStripeCustomerId", async () => {
+    const { fetch, calls } = makeScriptedFetch([
+      {
+        status: 200,
+        body: {
+          data: {
+            people: [
+              {
+                id: "person_unstamped",
+                emails: { primaryEmail: "user@test.com" },
+              },
+            ],
+          },
+        },
+      },
+      {
+        status: 200,
+        body: { data: { updatePerson: { id: "person_unstamped" } } },
+      },
+    ]);
+    const config = baseConfig({ fetchImpl: fetch });
+
+    await stampStripeCustomerId(config, {
+      email: "user@test.com",
+      stripeCustomerId: "cus_first",
+    });
+
+    const body = JSON.parse(calls[1].body ?? "{}");
+    expect(body.atlasFirstSource).toBe("CONVERSION");
+    expect(body.atlasLastSource).toBe("CONVERSION");
+    expect(body.atlasStripeCustomerId).toBe("cus_first");
+  });
+});
+
+describe("stampStripeCustomerId — error mapping", () => {
+  test("maps 4xx to TwentyClientError (caller treats permanent)", async () => {
+    const { fetch } = makeScriptedFetch([
+      { status: 401, body: { messages: ["bad key"] } },
+    ]);
+    const config = baseConfig({ fetchImpl: fetch });
+
+    try {
+      await stampStripeCustomerId(config, {
+        email: "u@t.com",
+        stripeCustomerId: "cus_1",
+      });
+      throw new Error("expected throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(TwentyClientError);
+      const e = err as TwentyClientError;
+      expect(e.status).toBe(401);
+      // The first sub-step that errors carries the operation discriminator.
+      expect(e.operation).toBe("findPersonByEmail");
+    }
+  });
+
+  test("5xx surfaces as TwentyClientError with status — outbox retries", async () => {
+    const { fetch } = makeScriptedFetch([
+      { status: 503, body: { messages: ["upstream down"] } },
+    ]);
+    const config = baseConfig({ fetchImpl: fetch });
+
+    try {
+      await stampStripeCustomerId(config, {
+        email: "u@t.com",
+        stripeCustomerId: "cus_1",
+      });
+      throw new Error("expected throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(TwentyClientError);
+      expect((err as TwentyClientError).status).toBe(503);
+    }
+  });
+
+  test("does not include the apiKey in thrown error messages", async () => {
+    const { fetch } = makeScriptedFetch([
+      { status: 401, body: { messages: ["bad key"] } },
+    ]);
+    const config = baseConfig({
+      apiKey: "twenty_secret_stamp_must_not_leak",
+      fetchImpl: fetch,
+    });
+
+    try {
+      await stampStripeCustomerId(config, {
+        email: "u@t.com",
+        stripeCustomerId: "cus_1",
+      });
+      throw new Error("expected throw");
+    } catch (err) {
+      const msg = (err as TwentyClientError).message;
+      expect(msg).not.toContain("twenty_secret_stamp_must_not_leak");
     }
   });
 });

--- a/plugins/twenty/__tests__/lead-normalizer.test.ts
+++ b/plugins/twenty/__tests__/lead-normalizer.test.ts
@@ -4,10 +4,12 @@
  */
 import { describe, test, expect } from "bun:test";
 import {
+  normalizeConversionLead,
   normalizeDemoLead,
   normalizeLead,
   normalizeSalesFormLead,
   normalizeSignupLead,
+  type AtlasConversionLeadEvent,
   type AtlasDemoLeadEvent,
   type AtlasSalesFormLeadEvent,
   type AtlasSignupLeadEvent,
@@ -307,6 +309,76 @@ describe("normalizeSignupLead", () => {
   });
 });
 
+describe("normalizeConversionLead", () => {
+  test("maps a conversion event to a Twenty upsert payload carrying atlasStripeCustomerId", () => {
+    const event: AtlasConversionLeadEvent = {
+      source: "conversion",
+      email: "User@Example.com",
+      stripeCustomerId: "cus_NffrFeUfNV2Hib",
+    };
+
+    const result = normalizeConversionLead(event);
+
+    expect(result).toEqual({
+      person: {
+        email: "user@example.com",
+        eventSource: "CONVERSION",
+        customFields: { atlasStripeCustomerId: "cus_NffrFeUfNV2Hib" },
+      },
+      eventSource: "CONVERSION",
+    });
+  });
+
+  test("lowercases and trims the email", () => {
+    const result = normalizeConversionLead({
+      source: "conversion",
+      email: "  Bob@ACME.COM ",
+      stripeCustomerId: "cus_abc",
+    });
+    expect(result.person.email).toBe("bob@acme.com");
+  });
+
+  test("always stamps eventSource = CONVERSION", () => {
+    const result = normalizeConversionLead({
+      source: "conversion",
+      email: "u@t.com",
+      stripeCustomerId: "cus_xyz",
+    });
+    expect(result.eventSource).toBe("CONVERSION");
+    expect(result.person.eventSource).toBe("CONVERSION");
+  });
+
+  test("never attaches a Note (conversion carries no message)", () => {
+    const result = normalizeConversionLead({
+      source: "conversion",
+      email: "u@t.com",
+      stripeCustomerId: "cus_abc",
+    });
+    expect(result.note).toBeUndefined();
+  });
+
+  test("does not put atlasIp on the Person (conversion has no request context)", () => {
+    const result = normalizeConversionLead({
+      source: "conversion",
+      email: "u@t.com",
+      stripeCustomerId: "cus_abc",
+    });
+    expect(JSON.stringify(result)).not.toContain("atlasIp");
+  });
+
+  test("preserves the stripeCustomerId verbatim — no normalization", () => {
+    // Stripe customer IDs are opaque tokens — never lowercase or trim them.
+    const result = normalizeConversionLead({
+      source: "conversion",
+      email: "u@t.com",
+      stripeCustomerId: " CUS_Mixed_Case ",
+    });
+    expect(result.person.customFields?.atlasStripeCustomerId).toBe(
+      " CUS_Mixed_Case ",
+    );
+  });
+});
+
 describe("normalizeLead — dispatch", () => {
   test("dispatches demo source to the demo normalizer", () => {
     const result = normalizeLead({ source: "demo", email: "u@t.com" });
@@ -334,5 +406,15 @@ describe("normalizeLead — dispatch", () => {
     });
     expect(result.eventSource).toBe("SIGNUP");
     expect(result.note).toBeUndefined();
+  });
+
+  test("dispatches conversion source to the conversion normalizer", () => {
+    const result = normalizeLead({
+      source: "conversion",
+      email: "u@t.com",
+      stripeCustomerId: "cus_abc",
+    });
+    expect(result.eventSource).toBe("CONVERSION");
+    expect(result.person.customFields?.atlasStripeCustomerId).toBe("cus_abc");
   });
 });

--- a/plugins/twenty/__tests__/plugin.test.ts
+++ b/plugins/twenty/__tests__/plugin.test.ts
@@ -29,7 +29,8 @@ describe("twentyPlugin — shape validation", () => {
     expect(plugin.version).toBe("0.1.0");
     expect(plugin.name).toBe("Twenty CRM Action");
     expect(Array.isArray(plugin.actions)).toBe(true);
-    expect(plugin.actions).toHaveLength(1);
+    // Two actions: upsertTwentyPerson + stampStripeCustomerId (#2737).
+    expect(plugin.actions).toHaveLength(2);
   });
 
   test("definePlugin() accepts the created plugin", () => {
@@ -49,7 +50,7 @@ describe("twentyPlugin — shape validation", () => {
   });
 });
 
-describe("twentyPlugin — action metadata", () => {
+describe("twentyPlugin — upsertTwentyPerson action metadata", () => {
   test("action name is upsertTwentyPerson", () => {
     expect(twentyPlugin(VALID_CONFIG).actions[0].name).toBe("upsertTwentyPerson");
   });
@@ -72,6 +73,36 @@ describe("twentyPlugin — action metadata", () => {
 
   test("action requires apiKey credential", () => {
     expect(twentyPlugin(VALID_CONFIG).actions[0].requiredCredentials).toEqual([
+      "apiKey",
+    ]);
+  });
+});
+
+describe("twentyPlugin — stampStripeCustomerId action metadata", () => {
+  test("action name is stampStripeCustomerId", () => {
+    expect(twentyPlugin(VALID_CONFIG).actions[1].name).toBe(
+      "stampStripeCustomerId",
+    );
+  });
+
+  test("action actionType is crm:stamp-stripe-customer-id", () => {
+    expect(twentyPlugin(VALID_CONFIG).actions[1].actionType).toBe(
+      "crm:stamp-stripe-customer-id",
+    );
+  });
+
+  test("action is not reversible (stamping is a write that we don't roll back)", () => {
+    expect(twentyPlugin(VALID_CONFIG).actions[1].reversible).toBe(false);
+  });
+
+  test("action defaults to admin-only approval", () => {
+    expect(twentyPlugin(VALID_CONFIG).actions[1].defaultApproval).toBe(
+      "admin-only",
+    );
+  });
+
+  test("action requires apiKey credential", () => {
+    expect(twentyPlugin(VALID_CONFIG).actions[1].requiredCredentials).toEqual([
       "apiKey",
     ]);
   });

--- a/plugins/twenty/src/client.ts
+++ b/plugins/twenty/src/client.ts
@@ -76,6 +76,13 @@ export interface AtlasPersonCustomFields {
   readonly atlasFirstSource?: string;
   readonly atlasLastSource?: string;
   readonly atlasIp?: string;
+  /**
+   * Stripe `customer.id` of a paying customer. Written by
+   * `stampStripeCustomerId` (and by `upsertPerson` when the normalized
+   * payload carries it) so the read-side datasource (#2728) can
+   * filter "demo → paid" conversions with a clean SQL predicate.
+   */
+  readonly atlasStripeCustomerId?: string;
 }
 
 /**
@@ -490,6 +497,44 @@ export async function createNote(
 // ─────────────────────────────────────────────────────────────────────
 //  Public surface
 // ─────────────────────────────────────────────────────────────────────
+
+export interface StampStripeCustomerIdInput {
+  /** Email Twenty matches on. */
+  readonly email: string;
+  /** Stripe `customer.id` (`cus_…`). */
+  readonly stripeCustomerId: string;
+}
+
+/**
+ * Stamp `atlasStripeCustomerId` on the Twenty Person matching `email`.
+ * Thin wrapper around `upsertPerson` with `eventSource = "CONVERSION"`
+ * and the customer id carried through `customFields`.
+ *
+ * Behaviour matrix (matches `upsertPerson` exactly — see its docblock):
+ *  - Person absent → POST a new Person with
+ *    `atlasFirstSource = "CONVERSION"`, `atlasLastSource = "CONVERSION"`,
+ *    AND `atlasStripeCustomerId` set. Covers the edge case of a paying
+ *    customer who never demoed/signed up — the stamp is never lost.
+ *  - Person present + `atlasFirstSource` set → PATCH
+ *    `atlasLastSource = "CONVERSION"` AND `atlasStripeCustomerId`.
+ *    First-source attribution is preserved.
+ *  - Person present + `atlasFirstSource` absent → PATCH both source
+ *    fields to `"CONVERSION"` AND `atlasStripeCustomerId`.
+ *
+ * Self-hosted operators with their own Stripe + Twenty wiring can call
+ * this directly from their webhook handler — it's a general-purpose
+ * plugin action, not gated behind enterprise.
+ */
+export async function stampStripeCustomerId(
+  config: TwentyClientConfig,
+  input: StampStripeCustomerIdInput,
+): Promise<TwentyPerson> {
+  return upsertPerson(config, {
+    email: input.email,
+    eventSource: "CONVERSION",
+    customFields: { atlasStripeCustomerId: input.stripeCustomerId },
+  });
+}
 
 /**
  * Upsert a Person by email with first/last source translation.

--- a/plugins/twenty/src/index.ts
+++ b/plugins/twenty/src/index.ts
@@ -29,7 +29,11 @@ import { z } from "zod";
 import { tool } from "ai";
 import { createPlugin } from "@useatlas/plugin-sdk";
 import type { AtlasActionPlugin, PluginAction } from "@useatlas/plugin-sdk";
-import { upsertPerson, type TwentyClientConfig } from "./client";
+import {
+  stampStripeCustomerId,
+  upsertPerson,
+  type TwentyClientConfig,
+} from "./client";
 
 // ─────────────────────────────────────────────────────────────────────
 //  Public re-exports — consumed by ee/src/saas-crm/ and tests
@@ -37,12 +41,14 @@ import { upsertPerson, type TwentyClientConfig } from "./client";
 
 export {
   upsertPerson,
+  stampStripeCustomerId,
   getPersonMetadata,
   createNote,
   TwentyClientError,
   type TwentyOperation,
   type TwentyClientConfig,
   type UpsertPersonInput,
+  type StampStripeCustomerIdInput,
   type TwentyPerson,
   type AtlasPersonCustomFields,
   type PersonMetadata,
@@ -55,10 +61,12 @@ export {
   normalizeDemoLead,
   normalizeSalesFormLead,
   normalizeSignupLead,
+  normalizeConversionLead,
   normalizeLead,
   type AtlasDemoLeadEvent,
   type AtlasSalesFormLeadEvent,
   type AtlasSignupLeadEvent,
+  type AtlasConversionLeadEvent,
   type AtlasEventSource,
   type AtlasLeadEvent,
   type NormalizedLead,
@@ -129,7 +137,7 @@ export const twentyPlugin = createPlugin<
       inputSchema: z.object({
         email: z.string().email().describe("Primary email of the Person"),
         eventSource: z
-          .enum(["DEMO", "SIGNUP", "SALES_FORM", "OTHER"])
+          .enum(["DEMO", "SIGNUP", "SALES_FORM", "CONVERSION", "OTHER"])
           .describe("Source label."),
         firstName: z.string().optional(),
         lastName: z.string().optional(),
@@ -150,11 +158,41 @@ export const twentyPlugin = createPlugin<
       },
     });
 
-    const action: PluginAction = {
+    const stampStripeCustomerIdTool = tool({
+      description:
+        "Stamp the Stripe customer ID on the Twenty Person matching email. Sets atlasLastSource=CONVERSION; creates the Person if absent with atlasFirstSource=CONVERSION.",
+      inputSchema: z.object({
+        email: z.string().email().describe("Primary email of the Person"),
+        stripeCustomerId: z
+          .string()
+          .min(1)
+          .describe("Stripe customer id (cus_…)"),
+      }),
+      execute: async ({ email, stripeCustomerId }) => {
+        const result = await stampStripeCustomerId(clientConfig, {
+          email,
+          stripeCustomerId,
+        });
+        return { id: result.id, email: result.emails?.primaryEmail };
+      },
+    });
+
+    const upsertAction: PluginAction = {
       name: "upsertTwentyPerson",
       description: PLUGIN_DESCRIPTION,
       tool: upsertPersonTool,
       actionType: "crm:upsert-person",
+      reversible: false,
+      defaultApproval: "admin-only",
+      requiredCredentials: ["apiKey"],
+    };
+
+    const stampAction: PluginAction = {
+      name: "stampStripeCustomerId",
+      description:
+        "Stamp atlasStripeCustomerId on a Twenty Person by email (CONVERSION source). Use from a Stripe webhook handler.",
+      tool: stampStripeCustomerIdTool,
+      actionType: "crm:stamp-stripe-customer-id",
       reversible: false,
       defaultApproval: "admin-only",
       requiredCredentials: ["apiKey"],
@@ -167,7 +205,7 @@ export const twentyPlugin = createPlugin<
       name: "Twenty CRM Action",
       config,
 
-      actions: [action],
+      actions: [upsertAction, stampAction],
 
       async initialize(ctx) {
         ctx.logger.info(

--- a/plugins/twenty/src/lead-normalizer.ts
+++ b/plugins/twenty/src/lead-normalizer.ts
@@ -24,7 +24,12 @@ import type { UpsertPersonInput } from "./client";
  * records. Narrow literal union: a typo here persists in Twenty
  * forever, so the type must reject misspellings at compile time.
  */
-export type AtlasEventSource = "DEMO" | "SIGNUP" | "SALES_FORM" | "OTHER";
+export type AtlasEventSource =
+  | "DEMO"
+  | "SIGNUP"
+  | "SALES_FORM"
+  | "CONVERSION"
+  | "OTHER";
 
 /** Demo signup variant — captured at the `/demo` gate on useatlas.dev. */
 export interface AtlasDemoLeadEvent {
@@ -73,6 +78,25 @@ export interface AtlasSignupLeadEvent {
 }
 
 /**
+ * Stripe → Twenty conversion stamping variant — fired by the
+ * `onSubscriptionComplete` hook in `packages/api/src/lib/auth/server.ts`
+ * after a paying checkout. Carries the Stripe `customer.id` so the
+ * dispatcher can stamp `customFields.atlasStripeCustomerId` on the
+ * matching Twenty Person — closing the funnel attribution loop for the
+ * read-side datasource (#2728).
+ *
+ * Edge case: paying customer who never demoed/signed up. The dispatcher
+ * still creates a new Person with `atlasFirstSource = "CONVERSION"` (the
+ * `upsertPerson` POST branch) so the stamp is never lost.
+ */
+export interface AtlasConversionLeadEvent {
+  readonly source: "conversion";
+  readonly email: string;
+  /** Stripe `customer.id` (the `cus_…` literal). */
+  readonly stripeCustomerId: string;
+}
+
+/**
  * Discriminated union over every Atlas-internal lead event. The
  * exhaustiveness check in `normalizeLead` catches missing handlers
  * at compile time.
@@ -80,7 +104,8 @@ export interface AtlasSignupLeadEvent {
 export type AtlasLeadEvent =
   | AtlasDemoLeadEvent
   | AtlasSalesFormLeadEvent
-  | AtlasSignupLeadEvent;
+  | AtlasSignupLeadEvent
+  | AtlasConversionLeadEvent;
 
 /** Note attached to the Person — only emitted by variants that carry a message. */
 export interface NormalizedNote {
@@ -195,6 +220,29 @@ export function normalizeSignupLead(event: AtlasSignupLeadEvent): NormalizedLead
   };
 }
 
+/**
+ * Normalize a Stripe → Twenty conversion event to a Twenty upsert
+ * payload. The `atlasStripeCustomerId` rides through `customFields` and
+ * is spread inline by `upsertPerson` on every write path (POST + both
+ * PATCH branches), so the stamp lands regardless of whether the Person
+ * already existed. No note — conversion carries no message.
+ */
+export function normalizeConversionLead(
+  event: AtlasConversionLeadEvent,
+): NormalizedLead {
+  const email = event.email.toLowerCase().trim();
+  const eventSource: AtlasEventSource = "CONVERSION";
+
+  return {
+    person: {
+      email,
+      eventSource,
+      customFields: { atlasStripeCustomerId: event.stripeCustomerId },
+    },
+    eventSource,
+  };
+}
+
 /** Dispatch on `source`. */
 export function normalizeLead(event: AtlasLeadEvent): NormalizedLead {
   switch (event.source) {
@@ -204,6 +252,8 @@ export function normalizeLead(event: AtlasLeadEvent): NormalizedLead {
       return normalizeSalesFormLead(event);
     case "signup":
       return normalizeSignupLead(event);
+    case "conversion":
+      return normalizeConversionLead(event);
     default: {
       // Exhaustiveness — when new variants are added to `AtlasLeadEvent`,
       // the absence of a case here surfaces as a tsgo compile error.


### PR DESCRIPTION
## Summary
Closes #2737 — 1.6.0 slice 11. Stripe → Twenty CRM Person conversion stamping closes the funnel attribution loop so the read-side datasource (#2728) can answer "which demo signups converted to paid this month" with a clean SQL filter.

- **New plugin action** `TwentyClient.stampStripeCustomerId({ email, stripeCustomerId })` in `plugins/twenty/`. Thin wrapper over `upsertPerson` with `eventSource = "CONVERSION"` and the customer ID in `customFields` — the sticky `atlasFirstSource` rule applies automatically. New Person → `atlasFirstSource = "CONVERSION"`; existing Person → only `atlasLastSource` flips. Self-hosters with their own Stripe + Twenty can call this directly from their own webhook handler (general-purpose, not enterprise-gated).
- **`SaasCrm` Tag extended** with `stampConversion(args)` on both branches of the discriminated shape. New `SaasCrmStampConversionInput` interface and a `"conversion"` variant on `SaasCrmLeadInput` (the dispatcher routes via the same normalizer → upsertPerson path; no source-specific switch).
- **`ee/saas-crm/SaasCrmLive`** implements `stampConversion` by enqueuing a `stamp-conversion` row into `crm_outbox`. Boot-time metadata verification now requires `atlasStripeCustomerId` alongside the two source fields — missing → `available: false` so conversion events don't dead-letter on a 422.
- **Better Auth Stripe hook** wired: new `dispatchConversionCrmStamp` helper retrieves the Stripe customer's email (`subscription.referenceId` is the orgId, not an email) and calls `SaasCrm.stampConversion` from `onSubscriptionComplete`. Two layers of failure-swallow keep the Stripe webhook ack unblocked.
- **plugins/twenty/README** documents the new manual `atlasStripeCustomerId` custom-field requirement + the new action.

## Test plan
- [ ] Verify the manual one-time Twenty custom field `atlasStripeCustomerId` (Text) is created on the Person object in crm.useatlas.dev before deploying.
- [ ] Stripe test-mode smoke against crm.useatlas.dev: complete a test checkout, observe `atlasStripeCustomerId` appears on the Twenty Person within the flusher's polling window.
- [ ] Edge case — paying customer never demoed: confirm a new Person is created with `atlasFirstSource = "CONVERSION"`, `atlasLastSource = "CONVERSION"`, AND the stamp.
- [ ] Existing-prospect-converts case: confirm `atlasFirstSource` remains `"DEMO"` and `atlasLastSource` flips to `"CONVERSION"` with the stamp added.
- [ ] Confirm Stripe webhook ack latency is unchanged (helper enqueues and returns immediately).
- [ ] Confirm on self-hosted (no enterprise) no Twenty traffic is generated (Noop layer active for `stampConversion`).
- [ ] All gates: `bun run type`, `bun run lint`, `bun run test`, syncpack lint, schema drift, template drift, ee-imports drift, test-discipline, railway-watch — all green locally (see PR check status for CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/2848"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782405676&installation_id=135337507&pr_number=2848&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F2848&signature=02c76d7c90c71f9457d5a70c1032dccdecc91febd5a92b2ab81b5ae75e82c1a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->