### PR TITLE
chore(plugins,ee,templates): #2850 — bump @useatlas/twenty refs to ^0.0.4 + canonical resolver name

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -718,7 +718,7 @@
     },
     "plugins/twenty": {
       "name": "@useatlas/twenty",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "devDependencies": {
         "@useatlas/plugin-sdk": "workspace:*",
         "ai": "^6.0.141",

--- a/create-atlas/templates/docker/package.json
+++ b/create-atlas/templates/docker/package.json
@@ -25,7 +25,7 @@
     "@ai-sdk/react": "^3.0.143",
     "@useatlas/react": "^0.1.0",
     "@useatlas/sdk": "^0.1.0",
-    "@useatlas/twenty": "^0.0.3",
+    "@useatlas/twenty": "^0.0.4",
     "@useatlas/types": "^0.1.0",
     "@better-auth/api-key": "^1.6.9",
     "@better-auth/oauth-provider": "^1.6.9",

--- a/create-atlas/templates/nextjs-standalone/package.json
+++ b/create-atlas/templates/nextjs-standalone/package.json
@@ -22,7 +22,7 @@
     "@ai-sdk/react": "^3.0.143",
     "@useatlas/react": "^0.1.0",
     "@useatlas/sdk": "^0.1.0",
-    "@useatlas/twenty": "^0.0.3",
+    "@useatlas/twenty": "^0.0.4",
     "@useatlas/types": "^0.1.0",
     "ai": "^6.0.141",
     "@better-auth/api-key": "^1.6.9",

--- a/ee/src/saas-crm/index.ts
+++ b/ee/src/saas-crm/index.ts
@@ -47,15 +47,7 @@ import {
 import { isEnterpriseEnabled } from "../index";
 import {
   getPersonMetadata,
-  // Legacy name kept here until @useatlas/twenty@0.0.4 publishes. The
-  // canonical name post-#2850 is `tryResolveOperatorCredentials`, but
-  // the scaffold templates pin `@useatlas/twenty@^0.0.3` (0.0.x exact-
-  // match semver per CLAUDE.md), which only exports the legacy name.
-  // In 0.0.4 `tryResolveCredentialsFromEnv` becomes a @deprecated
-  // re-export of `tryResolveOperatorCredentials` — referentially
-  // identical, env-only. The follow-up PR that ships after publish
-  // swaps this to the canonical name and bumps template refs.
-  tryResolveCredentialsFromEnv,
+  tryResolveOperatorCredentials,
   normalizeLead,
   upsertPerson,
   createNote,
@@ -394,7 +386,7 @@ export const SaasCrmLive: Layer.Layer<SaasCrm> = Layer.effect(
     // through it would create the Direction-2 leak documented in #2850.
     // The grep gate in scripts/check-twenty-resolver-imports.sh enforces
     // that this file cannot import resolveWorkspaceCredentials.
-    const bootCreds = tryResolveCredentialsFromEnv();
+    const bootCreds = tryResolveOperatorCredentials();
     if (!bootCreds) {
       log.warn(
         { event: "saas_crm.credentials_absent" },


### PR DESCRIPTION
## Summary

Follow-up to #2852 (closes the version-bump-ordering cycle). With `@useatlas/twenty@0.0.4` now published to npm, consumer refs are safe to bump and `ee/src/saas-crm/index.ts` can switch to the canonical post-#2850 import name.

| File | Change |
|------|--------|
| `create-atlas/templates/docker/package.json` | `@useatlas/twenty: ^0.0.3` → `^0.0.4` |
| `create-atlas/templates/nextjs-standalone/package.json` | same bump |
| `ee/src/saas-crm/index.ts` | `tryResolveCredentialsFromEnv` → `tryResolveOperatorCredentials` (cosmetic — referentially identical; one is a `@deprecated` re-export of the other) |
| `bun.lock` | auto-bumped by `bun install` |

## Why two PRs

Per the version-bump-ordering memory, 0.0.x semver pins exact-match (`^0.0.3` ≠ `0.0.4`), and scaffold CI installs from npm. So the cycle has to be:

1. **#2852** — Add the new exports, bump the package version, ship with legacy alias in template-tracked code.
2. **Tag + publish** — `git tag twenty-v0.0.4 && git push origin twenty-v0.0.4` → workflow publishes 0.0.4 to npm.
3. **This PR** — Bump consumer refs and align template-tracked code to the canonical name.

Skipping step 3 leaves the scaffold using a published-but-superseded version + the docs implying a transitional state — both fine, but tidier to close the loop.

## Verified

- `npm view @useatlas/twenty version` → `0.0.4` ✓
- `bash scripts/check-template-drift.sh` — pass (697 files verified after `prepare-templates.sh`)
- `bun run lint` / `bun run type` / `bun x syncpack lint` — all clean
- `bash scripts/check-twenty-resolver-imports.sh` + 16 adversarial fixtures — pass
- `bash scripts/check-ee-imports.sh` — pass
- `bash scripts/check-schema-drift.sh` — pass
- `bash scripts/check-test-discipline.sh` — pass
- 38 saas-crm tests + 43 resolver tests — pass

## Test plan

- [x] CI gates green locally
- [ ] Remote CI green (Scaffold (docker) + Scaffold (vercel) — the jobs that motivated this follow-up)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/2854"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782412228&installation_id=135337507&pr_number=2854&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F2854&signature=51033f27e01cd2b98e6d6d07def9ebfb873e11f69a841afd5ef735e7d9afcb07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->