### PR TITLE
fix(www): allow Cloudflare Turnstile in CSP (1.6.0 hotfix)

### DIFF
--- a/apps/www/serve.ts
+++ b/apps/www/serve.ts
@@ -5,15 +5,18 @@ const port = parseInt(process.env.PORT || "8080");
 
 // `script-src 'unsafe-inline'` is required by Next.js's `__NEXT_DATA__` and
 // hydration runtime. `style-src 'unsafe-inline'` is required by Next.js's
-// inlined critical CSS. Operators who add analytics or third-party scripts
-// will need to extend this in their own deploy.
+// inlined critical CSS. `https://challenges.cloudflare.com` is required for
+// the Cloudflare Turnstile widget on the talk-to-sales form (script + iframe).
+// Operators who add analytics or third-party scripts will need to extend
+// this in their own deploy.
 const WWW_CSP = [
   "default-src 'self'",
-  "script-src 'self' 'unsafe-inline'",
+  "script-src 'self' 'unsafe-inline' https://challenges.cloudflare.com",
   "style-src 'self' 'unsafe-inline'",
   "img-src 'self' data: https:",
   "font-src 'self' data:",
   "connect-src 'self' https:",
+  "frame-src https://challenges.cloudflare.com",
   "frame-ancestors 'none'",
   "base-uri 'self'",
   "form-action 'self'",


### PR DESCRIPTION
## Summary

1.6.0 talk-to-sales form (#2730 / #2733) is broken in prod — Turnstile widget never renders, submit lands on the "complete the bot check below" error with no widget visible.

Root cause: `apps/www/serve.ts` CSP allows `script-src 'self' 'unsafe-inline'` and has no `frame-src` directive. Turnstile's `api.js` lives at `challenges.cloudflare.com` and renders a challenge iframe — both blocked silently by the browser.

Fix: add `https://challenges.cloudflare.com` to `script-src` + new `frame-src` directive. Minimal opening, no wildcards.

## Test plan

- [ ] Open `/pricing` → click Business "Talk to sales" → Turnstile widget renders within ~1s
- [ ] DevTools console shows zero `Refused to load … Content Security Policy directive` warnings
- [ ] Same on `/sla`, `/dpa`, `/terms`
- [ ] Submit with completed challenge → success state appears, Person + Note land in Twenty within ~30s

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/2856"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782413453&installation_id=135337507&pr_number=2856&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F2856&signature=97343161072f452a911d879eacd04881d435d8ba74f8514deb811765231725d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->