### PR TITLE
fix(api,www): allow www.useatlas.dev origin + Cloudflare Insights beacon (1.6.0 hotfix)

### DIFF
--- a/apps/www/serve.ts
+++ b/apps/www/serve.ts
@@ -7,11 +7,14 @@ const port = parseInt(process.env.PORT || "8080");
 // hydration runtime. `style-src 'unsafe-inline'` is required by Next.js's
 // inlined critical CSS. `https://challenges.cloudflare.com` is required for
 // the Cloudflare Turnstile widget on the talk-to-sales form (script + iframe).
-// Operators who add analytics or third-party scripts will need to extend
-// this in their own deploy.
+// `https://static.cloudflareinsights.com` is the Cloudflare Web Analytics
+// beacon auto-injected when the site is proxied through Cloudflare (its
+// reports POST to `cloudflareinsights.com`, already covered by `connect-src
+// 'self' https:`). Operators who add other analytics or third-party scripts
+// will need to extend this in their own deploy.
 const WWW_CSP = [
   "default-src 'self'",
-  "script-src 'self' 'unsafe-inline' https://challenges.cloudflare.com",
+  "script-src 'self' 'unsafe-inline' https://challenges.cloudflare.com https://static.cloudflareinsights.com",
   "style-src 'self' 'unsafe-inline'",
   "img-src 'self' data: https:",
   "font-src 'self' data:",

--- a/packages/api/src/api/__tests__/cors-origin.test.ts
+++ b/packages/api/src/api/__tests__/cors-origin.test.ts
@@ -62,11 +62,15 @@ mock.module("@atlas/api/lib/auth/detect", () => ({
   resetAuthModeCache: () => {},
 }));
 
-// Return explicit origin from getSettingAuto for CORS
+// Return explicit origin from getSettingAuto for CORS — comma-separated
+// allowlist so the multi-origin path is exercised alongside the single-origin
+// path (https://app.example.com still matches, https://www.example.com is
+// the second entry).
 mock.module("@atlas/api/lib/settings", () => ({
   getSetting: () => undefined,
   getSettingAuto: (key: string) => {
-    if (key === "ATLAS_CORS_ORIGIN") return "https://app.example.com";
+    if (key === "ATLAS_CORS_ORIGIN")
+      return "https://app.example.com,https://www.example.com";
     return undefined;
   },
   getSettingLive: async () => undefined,
@@ -130,6 +134,21 @@ describe("CORS explicit origin matching", () => {
     );
 
     expect(res.headers.get("Access-Control-Allow-Origin")).toBe("https://app.example.com");
+    expect(res.headers.get("Access-Control-Allow-Credentials")).toBe("true");
+  });
+
+  it("second allowlist entry also matches and echoes the request origin", async () => {
+    const res = await app.fetch(
+      new Request("http://localhost/api/v1/chat", {
+        method: "OPTIONS",
+        headers: {
+          Origin: "https://www.example.com",
+          "Access-Control-Request-Method": "POST",
+        },
+      }),
+    );
+
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("https://www.example.com");
     expect(res.headers.get("Access-Control-Allow-Credentials")).toBe("true");
   });
 });

--- a/packages/api/src/lib/cors.ts
+++ b/packages/api/src/lib/cors.ts
@@ -47,6 +47,12 @@ export function resolveCorsOrigin(): string {
  * exact headers the streaming-response path should attach so cross-origin
  * fetches receive `Access-Control-Allow-Origin` (the browser blocks any
  * non-OPTIONS response missing this, even when the preflight succeeded).
+ *
+ * `ATLAS_CORS_ORIGIN` accepts either `"*"`, a single origin, or a
+ * comma-separated allowlist (e.g. `"https://app.useatlas.dev,https://www.useatlas.dev"`).
+ * The list form is needed when one API host serves multiple frontend
+ * surfaces — e.g. SaaS Atlas hosts the app at `app.useatlas.dev` and the
+ * marketing/talk-to-sales surface at `www.useatlas.dev`.
  */
 export function corsResponseHeaders(requestOrigin: string): Record<string, string> {
   const configured = resolveCorsOrigin();
@@ -58,7 +64,15 @@ export function corsResponseHeaders(requestOrigin: string): Record<string, strin
   if (configured === "*") {
     headers["Access-Control-Allow-Origin"] = "*";
     // Per CORS spec, credentials must NOT be set with wildcard origin.
-  } else if (configured === requestOrigin) {
+    return headers;
+  }
+
+  const allowed = configured
+    .split(",")
+    .map((o) => o.trim())
+    .filter((o) => o.length > 0);
+
+  if (allowed.includes(requestOrigin)) {
     headers["Access-Control-Allow-Origin"] = requestOrigin;
     headers["Access-Control-Allow-Credentials"] = "true";
   }


### PR DESCRIPTION
## Summary

Second 1.6.0 hotfix after #2856 — talk-to-sales form on www.useatlas.dev still fails to submit. Browser blocks the fetch with:

\`\`\`
Access to fetch at 'https://api.useatlas.dev/api/v1/contact' from origin
'https://www.useatlas.dev' has been blocked by CORS policy: Response to
preflight request doesn't pass access control check: No
'Access-Control-Allow-Origin' header is present on the requested resource.
\`\`\`

**Root cause:** the shared CORS helper (\`packages/api/src/lib/cors.ts\`) only matched a single configured origin. Production has \`ATLAS_CORS_ORIGIN=https://app.useatlas.dev\`, so requests from \`https://www.useatlas.dev\` got no \`Access-Control-Allow-Origin\` header and the browser refused the response. Verified with curl — OPTIONS preflight to \`/api/v1/contact\` returned 204 but with no Allow-Origin header.

**Bonus fix:** the marketing CSP also gets \`https://static.cloudflareinsights.com\` so the Cloudflare Web Analytics beacon (auto-injected by Cloudflare when the site is proxied) stops console-spamming.

## Changes

- \`corsResponseHeaders\` now parses \`ATLAS_CORS_ORIGIN\` as a comma-separated allowlist. Single-origin and wildcard paths unchanged
- cors-origin test gains a second-allowlist-entry case (4/4 pass)
- \`apps/www/serve.ts\` CSP: \`script-src\` += \`https://static.cloudflareinsights.com\`

## Follow-up after deploy

\`\`\`bash
railway service api
railway variables --set ATLAS_CORS_ORIGIN=\"https://app.useatlas.dev,https://www.useatlas.dev,https://useatlas.dev\"
\`\`\`

Order matters: the env update must come **after** this code deploys. The old single-string compare would treat the comma-list as one literal and break app.useatlas.dev.

## Test plan

- [ ] CI green
- [ ] After deploy + env update: \`curl -i -X OPTIONS https://api.useatlas.dev/api/v1/contact -H 'Origin: https://www.useatlas.dev' …\` returns \`Access-Control-Allow-Origin: https://www.useatlas.dev\`
- [ ] Submit \`/pricing\` talk-to-sales form → success state appears, Person + Note land in Twenty
- [ ] DevTools console clean on \`/pricing\` (no Cloudflare Insights CSP warning)
- [ ] \`app.useatlas.dev\` still works (regression check on the existing origin)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/2857"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782414259&installation_id=135337507&pr_number=2857&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F2857&signature=6a22d0e9b906daa3160c6c6ecb51b043292eff7eeca0844324a419dbcfcc182e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->