### PR TITLE
feat(api): outbox flusher heartbeat + stall watchdog

### DIFF
--- a/packages/api/src/lib/effect/layers.ts
+++ b/packages/api/src/lib/effect/layers.ts
@@ -1490,6 +1490,32 @@ export function makeSchedulerLive(
         // instance, so a sustained 101+ pending depth fires exactly
         // one log.warn per minute regardless of how many ticks elapse.
         const outboxWarnLimiter = new OutboxWarnRateLimiter(getOutboxWarnThreshold());
+
+        // Fiber-liveness state. The flusher silently stalled in prod
+        // after a permanent dead-letter (1.6.0 #DharmaIncident — 25
+        // minutes of zero ticks despite a claimable pending row); the
+        // existing logs only fire when `claimed > 0` or on raised error,
+        // making "alive idle" and "dead fiber" indistinguishable. These
+        // two values + the heartbeat tap below + the stall watchdog
+        // below close that gap so the next incident is observable
+        // BEFORE someone notices in the platform UI.
+        let outboxTickCount = 0;
+        let outboxLastTickAt = Date.now();
+        // Heartbeat cadence: log once a minute when the queue is idle.
+        // 5s tick × 12 = 60s. With OUTBOX_TICK_INTERVAL_MS overridden,
+        // the cadence stretches/shrinks proportionally.
+        const OUTBOX_HEARTBEAT_EVERY_N_TICKS = Math.max(
+          1,
+          Math.round(60_000 / Math.max(1, outboxTickIntervalMs)),
+        );
+        // Watchdog gate: only complain when we're >2× the interval past
+        // the last tick. Single-stuck-tick lag (network blip) shouldn't
+        // trip the alarm; a fiber that's actually dead will breeze past.
+        const OUTBOX_STALL_THRESHOLD_MS = Math.max(
+          15_000,
+          outboxTickIntervalMs * 2,
+        );
+
         const outboxTick = Effect.tryPromise({
           try: () =>
             runOutboxTick({
@@ -1503,15 +1529,17 @@ export function makeSchedulerLive(
             }),
           catch: (err) => (err instanceof Error ? err : new Error(String(err))),
         }).pipe(
-          Effect.tap(({ flush: result }) =>
+          Effect.tap(({ flush: result, snapshot }) =>
             Effect.sync(() => {
-              // Only log non-empty ticks so an idle queue doesn't fill
-              // the log with `claimed: 0`. The per-row dead-letter /
-              // transient lines from `flushBatch` itself still fire
-              // separately when something interesting happens.
+              outboxTickCount += 1;
+              outboxLastTickAt = Date.now();
               if (result.claimed > 0) {
+                // Active tick — fires the existing structured log so
+                // grep'ing for `tick_complete` still matches every claim
+                // cycle exactly as before.
                 log.info(
                   {
+                    tickCount: outboxTickCount,
                     claimed: result.claimed,
                     ok: result.ok,
                     transient: result.transient,
@@ -1520,13 +1548,41 @@ export function makeSchedulerLive(
                   },
                   `Outbox tick: ${result.claimed} claimed (ok=${result.ok}, transient=${result.transient}, dead=${result.permanent})`,
                 );
+                return;
+              }
+              // Idle tick — heartbeat only every N ticks so the log
+              // doesn't drown in `claimed=0`s, but a steady cadence still
+              // proves the fiber is alive. Snapshot depth rides along so
+              // operators see "fiber running, queue idle" vs "fiber
+              // running, queue building up but rows aren't claimable
+              // (backoff)" at a glance.
+              if (outboxTickCount % OUTBOX_HEARTBEAT_EVERY_N_TICKS === 0) {
+                log.info(
+                  {
+                    tickCount: outboxTickCount,
+                    pending: snapshot.pending,
+                    dead: snapshot.dead,
+                    event: "lead_outbox.heartbeat",
+                  },
+                  `Outbox heartbeat tick=${outboxTickCount} (queue idle: pending=${snapshot.pending}, dead=${snapshot.dead})`,
+                );
               }
             }),
           ),
           Effect.catchAll((err) =>
             Effect.sync(() => {
+              // Still bump the liveness counter even on failure so the
+              // watchdog can distinguish "fiber alive but the tick keeps
+              // erroring" (we'd see `tick_failed` every N seconds) from
+              // "fiber dead, nothing firing at all".
+              outboxTickCount += 1;
+              outboxLastTickAt = Date.now();
               log.warn(
-                { err: errorMessage(err), event: "lead_outbox.tick_failed" },
+                {
+                  tickCount: outboxTickCount,
+                  err: errorMessage(err),
+                  event: "lead_outbox.tick_failed",
+                },
                 "Outbox flush tick failed — will retry on next interval",
               );
             }),
@@ -1535,8 +1591,42 @@ export function makeSchedulerLive(
         const outboxFiber = yield* Effect.fork(
           outboxTick.pipe(Effect.repeat(Schedule.spaced(Duration.millis(outboxTickIntervalMs)))),
         );
+
+        // Stall watchdog — separate fiber that asserts the main tick
+        // fiber is still incrementing `outboxLastTickAt`. If the gap
+        // exceeds OUTBOX_STALL_THRESHOLD_MS we log an error so the
+        // silent-stall failure mode is at least observable in Grafana /
+        // log search. The watchdog itself does NOT restart the fiber —
+        // recovery would require unwinding shared state we don't fully
+        // understand yet; better to surface the symptom and let an
+        // operator redeploy than to mask it with auto-recovery.
+        let lastStallLogAt = 0;
+        const outboxWatchdog = Effect.sync(() => {
+          const sinceMs = Date.now() - outboxLastTickAt;
+          if (sinceMs < OUTBOX_STALL_THRESHOLD_MS) return;
+          // Throttle the stall log to once per minute so a real stall
+          // doesn't bury the rest of the deploy log.
+          const now = Date.now();
+          if (now - lastStallLogAt < 60_000) return;
+          lastStallLogAt = now;
+          log.error(
+            {
+              tickCount: outboxTickCount,
+              sinceLastTickMs: sinceMs,
+              thresholdMs: OUTBOX_STALL_THRESHOLD_MS,
+              event: "lead_outbox.tick_stall",
+            },
+            `Outbox flusher fiber appears stalled — no tick in ${Math.round(sinceMs / 1000)}s (threshold ${Math.round(OUTBOX_STALL_THRESHOLD_MS / 1000)}s). Redeploy to restart; investigate the prior tick_complete / tick_failed line for the trigger.`,
+          );
+        });
+        const outboxWatchdogFiber = yield* Effect.fork(
+          outboxWatchdog.pipe(
+            Effect.repeat(Schedule.spaced(Duration.millis(OUTBOX_STALL_THRESHOLD_MS))),
+          ),
+        );
         yield* Effect.addFinalizer(() =>
           Effect.gen(function* () {
+            yield* Fiber.interrupt(outboxWatchdogFiber);
             yield* Fiber.interrupt(outboxFiber);
             // Final recovery sweep: a SIGTERM mid-flush leaves the
             // active row in `in_flight` until the next pod boot. Reset
@@ -1572,8 +1662,13 @@ export function makeSchedulerLive(
           }),
         );
         log.info(
-          { intervalMs: outboxTickIntervalMs, batchLimit: OUTBOX_FLUSH_BATCH_LIMIT },
-          "CRM outbox flusher started",
+          {
+            intervalMs: outboxTickIntervalMs,
+            batchLimit: OUTBOX_FLUSH_BATCH_LIMIT,
+            heartbeatEveryNTicks: OUTBOX_HEARTBEAT_EVERY_N_TICKS,
+            stallThresholdMs: OUTBOX_STALL_THRESHOLD_MS,
+          },
+          "CRM outbox flusher started — heartbeat=lead_outbox.heartbeat (every ~60s when idle); stall watchdog=lead_outbox.tick_stall (fires when no tick observed in > 2× interval)",
         );
       } else {
         log.debug(

--- a/packages/api/src/lib/effect/layers.ts
+++ b/packages/api/src/lib/effect/layers.ts
@@ -1516,23 +1516,33 @@ export function makeSchedulerLive(
           outboxTickIntervalMs * 2,
         );
 
-        const outboxTick = Effect.tryPromise({
-          try: () =>
-            runOutboxTick({
-              db: outboxDb,
-              dispatcher: outboxDispatcher,
-              batchLimit: OUTBOX_FLUSH_BATCH_LIMIT,
-              limiter: outboxWarnLimiter,
-              pendingGauge: crmOutboxPendingCount,
-              deadGauge: crmOutboxDeadCount,
-              logger: log,
-            }),
-          catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+        const outboxTick = Effect.sync(() => {
+          // Update liveness AT TICK START so a legitimately long tick
+          // (sequential dispatch of up to OUTBOX_FLUSH_BATCH_LIMIT rows
+          // with per-row network calls; can exceed the 15s stall
+          // threshold under real backlogs) doesn't trip the watchdog.
+          // The watchdog asks "did the fiber wake up recently", not
+          // "did a tick complete recently". (Codex P1, 2026-05-26.)
+          outboxLastTickAt = Date.now();
         }).pipe(
+          Effect.flatMap(() =>
+            Effect.tryPromise({
+              try: () =>
+                runOutboxTick({
+                  db: outboxDb,
+                  dispatcher: outboxDispatcher,
+                  batchLimit: OUTBOX_FLUSH_BATCH_LIMIT,
+                  limiter: outboxWarnLimiter,
+                  pendingGauge: crmOutboxPendingCount,
+                  deadGauge: crmOutboxDeadCount,
+                  logger: log,
+                }),
+              catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+            }),
+          ),
           Effect.tap(({ flush: result, snapshot }) =>
             Effect.sync(() => {
               outboxTickCount += 1;
-              outboxLastTickAt = Date.now();
               if (result.claimed > 0) {
                 // Active tick — fires the existing structured log so
                 // grep'ing for `tick_complete` still matches every claim
@@ -1571,12 +1581,11 @@ export function makeSchedulerLive(
           ),
           Effect.catchAll((err) =>
             Effect.sync(() => {
-              // Still bump the liveness counter even on failure so the
-              // watchdog can distinguish "fiber alive but the tick keeps
-              // erroring" (we'd see `tick_failed` every N seconds) from
-              // "fiber dead, nothing firing at all".
+              // Bump the tick counter on failure too. Liveness was
+              // already stamped at tick start, so the watchdog stays
+              // quiet — a tick that erred out is still a "fiber awake"
+              // signal.
               outboxTickCount += 1;
-              outboxLastTickAt = Date.now();
               log.warn(
                 {
                   tickCount: outboxTickCount,
@@ -1619,9 +1628,15 @@ export function makeSchedulerLive(
             `Outbox flusher fiber appears stalled — no tick in ${Math.round(sinceMs / 1000)}s (threshold ${Math.round(OUTBOX_STALL_THRESHOLD_MS / 1000)}s). Redeploy to restart; investigate the prior tick_complete / tick_failed line for the trigger.`,
           );
         });
+        // Poll the watchdog at the tick cadence (not the stall
+        // threshold). With a 5s tick and a 15s threshold, a stall that
+        // begins just after a watchdog check would otherwise wait
+        // another ~15s before being detected — making the "no tick in
+        // > 2× interval" guarantee soft. Polling at tick cadence bounds
+        // detection lag to ~one tick interval. (Codex P2, 2026-05-26.)
         const outboxWatchdogFiber = yield* Effect.fork(
           outboxWatchdog.pipe(
-            Effect.repeat(Schedule.spaced(Duration.millis(OUTBOX_STALL_THRESHOLD_MS))),
+            Effect.repeat(Schedule.spaced(Duration.millis(outboxTickIntervalMs))),
           ),
         );
         yield* Effect.addFinalizer(() =>


### PR DESCRIPTION
## Summary

While debugging the 1.6.0 \`Dharma\` lead row that wouldn't dispatch, we discovered the SaaS CRM outbox flusher fiber went silent for 25 minutes after a permanent dead-letter — zero ticks, zero logs, zero claims, despite a claimable pending row in the queue. The redeploy that "fixed" it was just a power-cycle; the root cause of the stall is still unknown.

The diagnostic problem: the existing logs only fire on \`claimed > 0\` or raised error. "Fiber alive and idle" and "fiber dead" look identical in the logs.

## Changes (all in \`packages/api/src/lib/effect/layers.ts\`)

1. **Tick counter + last-tick timestamp** — closure-scoped state, incremented on every tick (success and failure). Lets the watchdog reason about fiber liveness.

2. **Heartbeat log** — \`lead_outbox.heartbeat\` fires once a minute when the queue is idle (\`claimed = 0\`). Cadence = \`60s / tickInterval\` ticks. Carries \`snapshot.pending\` / \`snapshot.dead\` so an operator sees "alive, idle" vs "alive, queue building, rows in backoff" at a glance. \`tick_complete\` (active) and \`tick_failed\` (raised error) keep their existing shapes; both now also carry \`tickCount\`.

3. **Stall watchdog** — separate forked fiber. Every \`2 × tickInterval\` it checks \`Date.now() - lastTickAt > stallThresholdMs\` (default 15s or 2× interval, whichever larger). If true, emits \`lead_outbox.tick_stall\` at \`error\` level, throttled to once / minute.

The watchdog **does not restart the fiber.** Recovery would require unwinding shared state we don't yet understand — better to surface the symptom and let an operator redeploy than to mask the bug with auto-recovery.

## Boot log

\`\`\`
CRM outbox flusher started — heartbeat=lead_outbox.heartbeat (every ~60s when idle); stall watchdog=lead_outbox.tick_stall (fires when no tick observed in > 2× interval)
\`\`\`

So an on-call engineer reading the boot log knows what to grep for.

## Test plan

- [x] \`bun run type\` clean
- [x] \`bun test packages/api/src/lib/lead-outbox/__tests__/\` — 64/64 pass (no behavior change in \`runOutboxTick\`)
- [ ] Post-deploy: observe \`lead_outbox.heartbeat\` in api logs at ~60s cadence when no submissions
- [ ] Post-deploy: every contact-form submission still produces \`lead_outbox.tick_complete\` with \`tickCount\` populated
- [ ] (Manual chaos test, optional) — wrap \`runOutboxTick\` with a deliberate \`process.exit\` after 10 ticks → \`tick_stall\` log should fire within 30s

## Doesn't fix yet

The underlying silent-stall bug. This PR is observability only — once we see \`tick_stall\` fire in the wild with the surrounding context (last \`tick_complete\` / \`tick_failed\` line), we'll have the trigger and can write the actual fix in a follow-up.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/2861"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782417748&installation_id=135337507&pr_number=2861&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F2861&signature=13dd5714b4534da1939ed866e1eb701f9c84b5137b0a6c13db3051dfe887b821"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->