### PR TITLE
chore(create-atlas): bump @useatlas/twenty template refs ^0.0.4 → ^0.0.5

### DIFF
--- a/create-atlas/templates/docker/package.json
+++ b/create-atlas/templates/docker/package.json
@@ -25,7 +25,7 @@
     "@ai-sdk/react": "^3.0.143",
     "@useatlas/react": "^0.1.0",
     "@useatlas/sdk": "^0.1.0",
-    "@useatlas/twenty": "^0.0.4",
+    "@useatlas/twenty": "^0.0.5",
     "@useatlas/types": "^0.1.0",
     "@better-auth/api-key": "^1.6.9",
     "@better-auth/oauth-provider": "^1.6.9",

--- a/create-atlas/templates/nextjs-standalone/package.json
+++ b/create-atlas/templates/nextjs-standalone/package.json
@@ -22,7 +22,7 @@
     "@ai-sdk/react": "^3.0.143",
     "@useatlas/react": "^0.1.0",
     "@useatlas/sdk": "^0.1.0",
-    "@useatlas/twenty": "^0.0.4",
+    "@useatlas/twenty": "^0.0.5",
     "@useatlas/types": "^0.1.0",
     "ai": "^6.0.141",
     "@better-auth/api-key": "^1.6.9",


### PR DESCRIPTION
## Summary

Follow-up to #2862 (twenty-v0.0.5 publish). `@useatlas/twenty@0.0.5` is live on npm with the `getPersonRestSchema` / `allowedPersonFields` exports introduced by #2860. Bumps template refs so Scaffold (docker)/(vercel) resolve the new version from registry.

Order per CLAUDE.md "Publishing `@useatlas/*` packages" — ref bump lands AFTER publish completes, never before (otherwise scaffolds fail trying to install an unpublished version).

## Test plan

- [ ] Scaffold (docker) green on this PR
- [ ] Scaffold (vercel) green on this PR
- [ ] `npm view @useatlas/twenty version` returns `0.0.5`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/2863"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782418611&installation_id=135337507&pr_number=2863&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F2863&signature=c910e799d9a0ef5b05fc1afcf0bb191365b9cc58db06bb1de28c54c4bd5f531a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->