### PR TITLE
fix(api): periodic Layer fibers — Effect.fork → Effect.forkScoped (1.6.0 hotfix)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -718,7 +718,7 @@
     },
     "plugins/twenty": {
       "name": "@useatlas/twenty",
-      "version": "0.0.4",
+      "version": "0.0.5",
       "devDependencies": {
         "@useatlas/plugin-sdk": "workspace:*",
         "ai": "^6.0.141",

--- a/packages/api/src/lib/effect/__tests__/outbox-flusher-lifecycle.test.ts
+++ b/packages/api/src/lib/effect/__tests__/outbox-flusher-lifecycle.test.ts
@@ -139,8 +139,8 @@ describe("outbox flusher lifecycle (#2729 AC #7 + #9)", () => {
     expect(recoveryCalls.length).toBe(0);
   });
 
-  test("forked tick fiber actually runs (regression: #DharmaIncident fork→forkScoped)", async () => {
-    // Regression test for the #DharmaIncident silent stall: the outbox
+  test("forked tick fiber actually runs (regression: #2864 fork→forkScoped)", async () => {
+    // Regression test for the #2864 silent stall: the outbox
     // flusher's tick fiber was spawned with `Effect.fork`, which links
     // the child fiber to the gen's parent fiber and interrupts it the
     // moment the gen returns. Result: zero ticks from boot, indefinitely.
@@ -163,11 +163,11 @@ describe("outbox flusher lifecycle (#2729 AC #7 + #9)", () => {
       const rt = ManagedRuntime.make(layer);
       await Effect.runPromise(rt.runtimeEffect);
 
-      // Wait > 1× tick interval (1s minimum-clamped) so the first
+      // Wait > 2× tick interval (1s minimum-clamped) so the first
       // scheduled iteration of `Effect.repeat(Schedule.spaced)` has
-      // time to fire. The depth snapshot SELECT is the tick's first
-      // observable side effect.
-      await new Promise((r) => setTimeout(r, 1_500));
+      // comfortable slack on contended CI runners. The depth snapshot
+      // SELECT is the tick's first observable side effect.
+      await new Promise((r) => setTimeout(r, 2_500));
       await rt.dispose();
 
       // queryDepthSnapshot reads from crm_outbox without an in_flight

--- a/packages/api/src/lib/effect/__tests__/outbox-flusher-lifecycle.test.ts
+++ b/packages/api/src/lib/effect/__tests__/outbox-flusher-lifecycle.test.ts
@@ -139,6 +139,49 @@ describe("outbox flusher lifecycle (#2729 AC #7 + #9)", () => {
     expect(recoveryCalls.length).toBe(0);
   });
 
+  test("forked tick fiber actually runs (regression: #DharmaIncident fork→forkScoped)", async () => {
+    // Regression test for the #DharmaIncident silent stall: the outbox
+    // flusher's tick fiber was spawned with `Effect.fork`, which links
+    // the child fiber to the gen's parent fiber and interrupts it the
+    // moment the gen returns. Result: zero ticks from boot, indefinitely.
+    // `Effect.forkScoped` binds to the Layer scope instead.
+    //
+    // This test asserts the fiber actually runs by checking that the
+    // tick's queryDepthSnapshot SELECT fires within a window slightly
+    // longer than the tick interval. Without forkScoped this test would
+    // see zero depth-snapshot queries — proving the regression canary.
+    process.env.ATLAS_CRM_OUTBOX_TICK_SECONDS = "1";
+    try {
+      const config = {} as Parameters<typeof makeSchedulerLive>[0];
+      const baseLayer = makeSchedulerLive(config);
+      const deps = Layer.mergeAll(
+        NoopEnterpriseDefaultsLayer,
+        makeAvailableSaasCrmLayer(),
+      );
+      const layer = baseLayer.pipe(Layer.provide(deps));
+
+      const rt = ManagedRuntime.make(layer);
+      await Effect.runPromise(rt.runtimeEffect);
+
+      // Wait > 1× tick interval (1s minimum-clamped) so the first
+      // scheduled iteration of `Effect.repeat(Schedule.spaced)` has
+      // time to fire. The depth snapshot SELECT is the tick's first
+      // observable side effect.
+      await new Promise((r) => setTimeout(r, 1_500));
+      await rt.dispose();
+
+      // queryDepthSnapshot reads from crm_outbox without an in_flight
+      // filter — distinguishes it from the recovery sweep queries.
+      const depthSnapshotCalls = sqlLog.filter(
+        (q) =>
+          /FROM crm_outbox/i.test(q.sql) && !/WHERE status = 'in_flight'/i.test(q.sql),
+      );
+      expect(depthSnapshotCalls.length).toBeGreaterThan(0);
+    } finally {
+      delete process.env.ATLAS_CRM_OUTBOX_TICK_SECONDS;
+    }
+  });
+
   test("Layer skips flusher wiring when SaasCrm.available is false", async () => {
     const noopSaasCrm: Layer.Layer<SaasCrmTag> = Layer.succeed(SaasCrm, {
       available: false,

--- a/packages/api/src/lib/effect/__tests__/service-lifecycle.test.ts
+++ b/packages/api/src/lib/effect/__tests__/service-lifecycle.test.ts
@@ -7,7 +7,7 @@
  * - makeConnectionRegistryLive creates a working layer
  */
 import { describe, it, expect } from "bun:test";
-import { Effect, Scope, Exit } from "effect";
+import { Effect, Layer, ManagedRuntime, Scope, Exit } from "effect";
 import {
   ConnectionRegistry,
   makeConnectionRegistryLive,
@@ -116,6 +116,36 @@ describe("ConnectionRegistry Live Layer lifecycle", () => {
     await Effect.runPromise(Scope.close(scope, Exit.void));
 
     expect(mockRegistry._calls).toContain("shutdown");
+  });
+
+  it("health-check fiber actually runs (regression: #2864 fork→forkScoped)", async () => {
+    // Companion to outbox-flusher-lifecycle.test.ts:#2864 — the outbox
+    // test covers the scheduler Layer. This one covers ConnectionRegistry
+    // health-check Layer, which is a separate fork site (services.ts).
+    // A targeted human revert of forkScoped → fork at services.ts:190
+    // would not be caught by the outbox test; this one catches it.
+    //
+    // `Effect.repeat(Schedule.spaced(60s))` runs the effect eagerly on
+    // fork *before* the spaced wait kicks in, so the first health check
+    // fires within milliseconds of layer boot. Without forkScoped the
+    // fiber is interrupted at gen completion and the mock's
+    // healthCheckCount stays at 0.
+    const mockRegistry = createMockRegistryClass();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test-only cast to class interface
+    const layer = makeConnectionRegistryLive(() => mockRegistry as any);
+
+    const rt = ManagedRuntime.make(Layer.scopedDiscard(Effect.gen(function* () {
+      yield* ConnectionRegistry;
+    })).pipe(Layer.provide(layer)));
+    await Effect.runPromise(rt.runtimeEffect);
+
+    // Wait long enough for the eager first iteration to resolve. The
+    // mock's healthCheck is async but settles immediately on the next
+    // microtask; 2.5s gives comfortable slack on contended CI runners.
+    await new Promise((r) => setTimeout(r, 2_500));
+    await rt.dispose();
+
+    expect(mockRegistry._getHealthCheckCount()).toBeGreaterThan(0);
   });
 
   it("delegates register() to underlying impl", async () => {

--- a/packages/api/src/lib/effect/layers.ts
+++ b/packages/api/src/lib/effect/layers.ts
@@ -70,6 +70,34 @@ import {
 
 const log = createLogger("effect:layers");
 
+// ── Defect-canary wrapper for forked periodic fibers (#2864) ──────────
+// Inner `Effect.catchAll(...)` blocks at each tick body normalize
+// expected Promise rejections into typed `Cause.Fail` so the
+// `Effect.repeat(Schedule.spaced(...))` loop survives them. But a
+// genuine defect — a synchronous throw inside the `Effect.sync` log
+// handler, an Effect runtime fault, or any non-`tryPromise` path — lands
+// in `Cause.Die`, escapes the inner `catchAll`, exits `repeat`, and
+// kills the fiber **silently** (the original #2864 failure mode, just
+// reached via a different door). Wrap each `tick.pipe(Effect.repeat(...))`
+// with this outer catch so a defect-induced fiber death emits a single
+// `periodic_fiber.died` error log entry before the fiber unwinds.
+function withFiberDeathLog<A, E, R>(
+  fiber: string,
+  eff: Effect.Effect<A, E, R>,
+): Effect.Effect<void, never, R> {
+  return eff.pipe(
+    Effect.catchAllCause((cause) =>
+      Effect.sync(() => {
+        log.error(
+          { err: cause.toString(), event: "periodic_fiber.died", fiber },
+          `Periodic fiber "${fiber}" died — defect escaped tick body`,
+        );
+      }),
+    ),
+    Effect.asVoid,
+  );
+}
+
 // ══════════════════════════════════════════════════════════════════════
 // ██  Enterprise gate (#2563 slice 1/11 of #2017; #2564 slice 2/11)
 // ══════════════════════════════════════════════════════════════════════
@@ -985,11 +1013,14 @@ export const SettingsLive: Layer.Layer<Settings> = Layer.scoped(
       // after the fork. With `Effect.fork` the first scheduled iteration
       // of `Effect.repeat(Schedule.spaced)` never runs because the child
       // is interrupted at gen completion (verified by repro; diagnosed
-      // in #DharmaIncident). `forkScoped` binds to the Scope provided
+      // in #2864). `forkScoped` binds to the Scope provided
       // by `Layer.scoped`, so the fiber lives until layer shutdown. No
       // companion `addFinalizer(Fiber.interrupt)` needed — scope handles it.
       yield* Effect.forkScoped(
-        tick.pipe(Effect.repeat(Schedule.spaced(Duration.millis(intervalMs)))),
+        withFiberDeathLog(
+          "settings_refresh",
+          tick.pipe(Effect.repeat(Schedule.spaced(Duration.millis(intervalMs)))),
+        ),
       );
 
       log.info({ intervalMs }, "Started periodic settings refresh fiber");
@@ -1096,7 +1127,10 @@ export function makeSchedulerLive(
         );
         // forkScoped, not fork — see SettingsLive for rationale.
         yield* Effect.forkScoped(
-          emailTick.pipe(Effect.repeat(Schedule.spaced(Duration.millis(DEFAULT_EMAIL_SCHEDULER_INTERVAL_MS)))),
+          withFiberDeathLog(
+            "onboarding_email",
+            emailTick.pipe(Effect.repeat(Schedule.spaced(Duration.millis(DEFAULT_EMAIL_SCHEDULER_INTERVAL_MS)))),
+          ),
         );
       } else {
         log.debug("Onboarding email scheduler not started — feature disabled");
@@ -1137,7 +1171,10 @@ export function makeSchedulerLive(
         );
         // forkScoped, not fork — see SettingsLive for rationale.
         yield* Effect.forkScoped(
-          expertTick.pipe(Effect.repeat(Schedule.spaced(Duration.millis(getExpertSchedulerIntervalMs())))),
+          withFiberDeathLog(
+            "expert_scheduler",
+            expertTick.pipe(Effect.repeat(Schedule.spaced(Duration.millis(getExpertSchedulerIntervalMs())))),
+          ),
         );
         log.info({ intervalMs: getExpertSchedulerIntervalMs() }, "Semantic expert scheduler started");
       } else {
@@ -1203,7 +1240,10 @@ export function makeSchedulerLive(
       );
       // forkScoped, not fork — see SettingsLive for rationale.
       yield* Effect.forkScoped(
-        oauthTick.pipe(Effect.repeat(Schedule.spaced(Duration.minutes(10)))),
+        withFiberDeathLog(
+          "oauth_state_cleanup",
+          oauthTick.pipe(Effect.repeat(Schedule.spaced(Duration.minutes(10)))),
+        ),
       );
 
       // ── Periodic fiber: rate-limit cleanup (#1274) — every 60s ──────
@@ -1229,7 +1269,10 @@ export function makeSchedulerLive(
       );
       // forkScoped, not fork — see SettingsLive for rationale.
       yield* Effect.forkScoped(
-        rateLimitTick.pipe(Effect.repeat(Schedule.spaced(Duration.seconds(60)))),
+        withFiberDeathLog(
+          "rate_limit_cleanup",
+          rateLimitTick.pipe(Effect.repeat(Schedule.spaced(Duration.seconds(60)))),
+        ),
       );
 
       // ── Periodic fiber: demo rate-limit cleanup — interval from DEMO_CLEANUP_INTERVAL_MS ──
@@ -1258,7 +1301,10 @@ export function makeSchedulerLive(
       };
       // forkScoped, not fork — see SettingsLive for rationale.
       yield* Effect.forkScoped(
-        demoTick.pipe(Effect.repeat(Schedule.spaced(Duration.millis(DEMO_CLEANUP_INTERVAL_MS)))),
+        withFiberDeathLog(
+          "demo_rate_limit_cleanup",
+          demoTick.pipe(Effect.repeat(Schedule.spaced(Duration.millis(DEMO_CLEANUP_INTERVAL_MS)))),
+        ),
       );
 
       // ── Periodic fiber: contact rate-limit cleanup — every 60s ────
@@ -1286,7 +1332,10 @@ export function makeSchedulerLive(
       );
       // forkScoped, not fork — see SettingsLive for rationale.
       yield* Effect.forkScoped(
-        contactTick.pipe(Effect.repeat(Schedule.spaced(Duration.seconds(60)))),
+        withFiberDeathLog(
+          "contact_rate_limit_cleanup",
+          contactTick.pipe(Effect.repeat(Schedule.spaced(Duration.seconds(60)))),
+        ),
       );
 
       // ── Periodic fiber: abuse detection cleanup — every 5 min ──────
@@ -1315,7 +1364,10 @@ export function makeSchedulerLive(
       };
       // forkScoped, not fork — see SettingsLive for rationale.
       yield* Effect.forkScoped(
-        abuseTick.pipe(Effect.repeat(Schedule.spaced(Duration.millis(ABUSE_CLEANUP_INTERVAL_MS)))),
+        withFiberDeathLog(
+          "abuse_cleanup",
+          abuseTick.pipe(Effect.repeat(Schedule.spaced(Duration.millis(ABUSE_CLEANUP_INTERVAL_MS)))),
+        ),
       );
 
       // ── Periodic fiber: dashboard public rate-limit cleanup — every 60s ─
@@ -1350,7 +1402,10 @@ export function makeSchedulerLive(
       }
       // forkScoped, not fork — see SettingsLive for rationale.
       yield* Effect.forkScoped(
-        dashboardTick.pipe(Effect.repeat(Schedule.spaced(Duration.millis(dashboardCleanupIntervalMs)))),
+        withFiberDeathLog(
+          "dashboard_rate_limit_cleanup",
+          dashboardTick.pipe(Effect.repeat(Schedule.spaced(Duration.millis(dashboardCleanupIntervalMs)))),
+        ),
       );
 
       // ── Periodic fiber: conversation public rate sweep — every 60s ──
@@ -1380,7 +1435,10 @@ export function makeSchedulerLive(
       };
       // forkScoped, not fork — see SettingsLive for rationale.
       yield* Effect.forkScoped(
-        convSweepTick.pipe(Effect.repeat(Schedule.spaced(Duration.millis(CONVERSATION_RATE_SWEEP_INTERVAL_MS)))),
+        withFiberDeathLog(
+          "conversation_rate_sweep",
+          convSweepTick.pipe(Effect.repeat(Schedule.spaced(Duration.millis(CONVERSATION_RATE_SWEEP_INTERVAL_MS)))),
+        ),
       );
 
       // ── Periodic fiber: share token cleanup — every 60 min ─────────
@@ -1405,7 +1463,10 @@ export function makeSchedulerLive(
       );
       // forkScoped, not fork — see SettingsLive for rationale.
       yield* Effect.forkScoped(
-        shareCleanupEffect.pipe(Effect.repeat(Schedule.spaced(Duration.millis(SHARE_CLEANUP_INTERVAL_MS)))),
+        withFiberDeathLog(
+          "share_token_cleanup",
+          shareCleanupEffect.pipe(Effect.repeat(Schedule.spaced(Duration.millis(SHARE_CLEANUP_INTERVAL_MS)))),
+        ),
       );
 
       // ── Periodic fiber: sub-processor change-feed publisher (#1924) ──
@@ -1436,10 +1497,13 @@ export function makeSchedulerLive(
       );
       // forkScoped, not fork — see SettingsLive for rationale.
       yield* Effect.forkScoped(
-        subProcessorTick.pipe(
-          Effect.repeat(
-            Schedule.spaced(
-              Duration.millis(subProcessorPublisher.SUBPROCESSOR_PUBLISH_INTERVAL_MS),
+        withFiberDeathLog(
+          "sub_processor_publisher",
+          subProcessorTick.pipe(
+            Effect.repeat(
+              Schedule.spaced(
+                Duration.millis(subProcessorPublisher.SUBPROCESSOR_PUBLISH_INTERVAL_MS),
+              ),
             ),
           ),
         ),
@@ -1491,6 +1555,53 @@ export function makeSchedulerLive(
               );
             }),
           ),
+        );
+
+        // Shutdown-recovery finalizer — registered BEFORE the two
+        // `Effect.forkScoped` calls below. Effect scope finalizers run
+        // LIFO; the `forkScoped` calls each register an implicit
+        // fiber-interrupt finalizer at their fork point, so this
+        // ordering guarantees: tick + watchdog fibers are interrupted
+        // (and `Fiber.interrupt` awaits cleanup completion) BEFORE the
+        // recovery sweep runs. If we registered the finalizer AFTER
+        // the forks, LIFO would invert the order — the sweep would
+        // race an in-flight tick + dead-letter branch, leaving the
+        // active row in an inconsistent terminal state (Codex P1 on
+        // #2864).
+        yield* Effect.addFinalizer(() =>
+          Effect.gen(function* () {
+            // Final recovery sweep: a SIGTERM mid-flush leaves the
+            // active row in `in_flight` until the next pod boot. Reset
+            // here so the replacement pod picks it up on its first
+            // tick rather than waiting for the next restart cycle.
+            yield* Effect.tryPromise({
+              try: (): Promise<OutboxRecoveryResult> =>
+                recoverOutboxInFlight(outboxDb, OUTBOX_SHUTDOWN_STALE_MS),
+              catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+            }).pipe(
+              Effect.tap((result: OutboxRecoveryResult) =>
+                Effect.sync(() => {
+                  log.info(
+                    {
+                      reset: result.reset,
+                      deadLettered: result.deadLettered,
+                      staleAgeMs: OUTBOX_SHUTDOWN_STALE_MS,
+                      event: "lead_outbox.shutdown_recovery",
+                    },
+                    `Outbox shutdown sweep — ${result.reset} reset to pending, ${result.deadLettered} dead-lettered`,
+                  );
+                }),
+              ),
+              Effect.catchAll((err) =>
+                Effect.sync(() => {
+                  log.warn(
+                    { err: errorMessage(err), event: "lead_outbox.shutdown_recovery_failed" },
+                    "Outbox shutdown recovery sweep failed — next boot will mop up",
+                  );
+                }),
+              ),
+            );
+          }),
         );
 
         const outboxTickIntervalMs = getOutboxTickIntervalMs();
@@ -1606,11 +1717,14 @@ export function makeSchedulerLive(
           ),
         );
         // forkScoped, not fork — see SettingsLive for rationale.
-        // The recovery sweep still needs its own addFinalizer below
-        // because it's not a fiber interrupt — it's an orderly cleanup
-        // that must run on layer shutdown regardless.
+        // The recovery sweep finalizer is registered ABOVE this fork
+        // (not below) so LIFO finalizer order interrupts this fiber
+        // (and the watchdog below) before the sweep runs.
         yield* Effect.forkScoped(
-          outboxTick.pipe(Effect.repeat(Schedule.spaced(Duration.millis(outboxTickIntervalMs)))),
+          withFiberDeathLog(
+            "lead_outbox_flusher",
+            outboxTick.pipe(Effect.repeat(Schedule.spaced(Duration.millis(outboxTickIntervalMs)))),
+          ),
         );
 
         // Stall watchdog — separate fiber that asserts the main tick
@@ -1648,49 +1762,12 @@ export function makeSchedulerLive(
         // detection lag to ~one tick interval. (Codex P2, 2026-05-26.)
         // forkScoped, not fork — see SettingsLive for rationale.
         yield* Effect.forkScoped(
-          outboxWatchdog.pipe(
-            Effect.repeat(Schedule.spaced(Duration.millis(outboxTickIntervalMs))),
+          withFiberDeathLog(
+            "lead_outbox_watchdog",
+            outboxWatchdog.pipe(
+              Effect.repeat(Schedule.spaced(Duration.millis(outboxTickIntervalMs))),
+            ),
           ),
-        );
-        // Recovery-sweep finalizer. The two forked fibers above are
-        // already cleaned up by the layer scope (forkScoped); this
-        // finalizer only owns the in_flight reset sweep, which is an
-        // orderly cleanup that must run on layer shutdown so the next
-        // pod boot doesn't see stranded `in_flight` carcasses.
-        yield* Effect.addFinalizer(() =>
-          Effect.gen(function* () {
-            // Final recovery sweep: a SIGTERM mid-flush leaves the
-            // active row in `in_flight` until the next pod boot. Reset
-            // here so the replacement pod picks it up on its first
-            // tick rather than waiting for the next restart cycle.
-            yield* Effect.tryPromise({
-              try: (): Promise<OutboxRecoveryResult> =>
-                recoverOutboxInFlight(outboxDb, OUTBOX_SHUTDOWN_STALE_MS),
-              catch: (err) => (err instanceof Error ? err : new Error(String(err))),
-            }).pipe(
-              Effect.tap((result: OutboxRecoveryResult) =>
-                Effect.sync(() => {
-                  log.info(
-                    {
-                      reset: result.reset,
-                      deadLettered: result.deadLettered,
-                      staleAgeMs: OUTBOX_SHUTDOWN_STALE_MS,
-                      event: "lead_outbox.shutdown_recovery",
-                    },
-                    `Outbox shutdown sweep — ${result.reset} reset to pending, ${result.deadLettered} dead-lettered`,
-                  );
-                }),
-              ),
-              Effect.catchAll((err) =>
-                Effect.sync(() => {
-                  log.warn(
-                    { err: errorMessage(err), event: "lead_outbox.shutdown_recovery_failed" },
-                    "Outbox shutdown recovery sweep failed — next boot will mop up",
-                  );
-                }),
-              ),
-            );
-          }),
         );
         log.info(
           {

--- a/packages/api/src/lib/effect/layers.ts
+++ b/packages/api/src/lib/effect/layers.ts
@@ -33,7 +33,7 @@
  * share token cleanup) that are interrupted when their Layer scope closes.
  */
 
-import { Context, Duration, Effect, Fiber, Layer, Schedule } from "effect";
+import { Context, Duration, Effect, Layer, Schedule } from "effect";
 import { createLogger } from "@atlas/api/lib/logger";
 import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
 import { InternalDB, makeInternalDBLive, hasInternalDB, internalQuery } from "@atlas/api/lib/db/internal";
@@ -979,10 +979,18 @@ export const SettingsLive: Layer.Layer<Settings> = Layer.scoped(
         ),
       );
 
-      const fiber = yield* Effect.fork(
+      // `forkScoped`, not `fork` — the bare `fork` API links the child
+      // fiber to the *parent fiber's* lifetime, and the parent here is
+      // this gen function which returns the service shape immediately
+      // after the fork. With `Effect.fork` the first scheduled iteration
+      // of `Effect.repeat(Schedule.spaced)` never runs because the child
+      // is interrupted at gen completion (verified by repro; diagnosed
+      // in #DharmaIncident). `forkScoped` binds to the Scope provided
+      // by `Layer.scoped`, so the fiber lives until layer shutdown. No
+      // companion `addFinalizer(Fiber.interrupt)` needed — scope handles it.
+      yield* Effect.forkScoped(
         tick.pipe(Effect.repeat(Schedule.spaced(Duration.millis(intervalMs)))),
       );
-      yield* Effect.addFinalizer(() => Fiber.interrupt(fiber));
 
       log.info({ intervalMs }, "Started periodic settings refresh fiber");
     }
@@ -1086,10 +1094,10 @@ export function makeSchedulerLive(
             }),
           ),
         );
-        const emailFiber = yield* Effect.fork(
+        // forkScoped, not fork — see SettingsLive for rationale.
+        yield* Effect.forkScoped(
           emailTick.pipe(Effect.repeat(Schedule.spaced(Duration.millis(DEFAULT_EMAIL_SCHEDULER_INTERVAL_MS)))),
         );
-        yield* Effect.addFinalizer(() => Fiber.interrupt(emailFiber));
       } else {
         log.debug("Onboarding email scheduler not started — feature disabled");
       }
@@ -1127,10 +1135,10 @@ export function makeSchedulerLive(
             }),
           ),
         );
-        const expertFiber = yield* Effect.fork(
+        // forkScoped, not fork — see SettingsLive for rationale.
+        yield* Effect.forkScoped(
           expertTick.pipe(Effect.repeat(Schedule.spaced(Duration.millis(getExpertSchedulerIntervalMs())))),
         );
-        yield* Effect.addFinalizer(() => Fiber.interrupt(expertFiber));
         log.info({ intervalMs: getExpertSchedulerIntervalMs() }, "Semantic expert scheduler started");
       } else {
         log.debug("Semantic expert scheduler not started — feature disabled");
@@ -1193,10 +1201,10 @@ export function makeSchedulerLive(
           }),
         ),
       );
-      const oauthFiber = yield* Effect.fork(
+      // forkScoped, not fork — see SettingsLive for rationale.
+      yield* Effect.forkScoped(
         oauthTick.pipe(Effect.repeat(Schedule.spaced(Duration.minutes(10)))),
       );
-      yield* Effect.addFinalizer(() => Fiber.interrupt(oauthFiber));
 
       // ── Periodic fiber: rate-limit cleanup (#1274) — every 60s ──────
       // Interval matches WINDOW_MS in middleware.ts (sliding-window duration).
@@ -1219,10 +1227,10 @@ export function makeSchedulerLive(
           }),
         ),
       );
-      const rateLimitFiber = yield* Effect.fork(
+      // forkScoped, not fork — see SettingsLive for rationale.
+      yield* Effect.forkScoped(
         rateLimitTick.pipe(Effect.repeat(Schedule.spaced(Duration.seconds(60)))),
       );
-      yield* Effect.addFinalizer(() => Fiber.interrupt(rateLimitFiber));
 
       // ── Periodic fiber: demo rate-limit cleanup — interval from DEMO_CLEANUP_INTERVAL_MS ──
       const demoTick = Effect.try({
@@ -1248,10 +1256,10 @@ export function makeSchedulerLive(
       const { DEMO_CLEANUP_INTERVAL_MS } = require("@atlas/api/lib/demo") as {
         DEMO_CLEANUP_INTERVAL_MS: number;
       };
-      const demoFiber = yield* Effect.fork(
+      // forkScoped, not fork — see SettingsLive for rationale.
+      yield* Effect.forkScoped(
         demoTick.pipe(Effect.repeat(Schedule.spaced(Duration.millis(DEMO_CLEANUP_INTERVAL_MS)))),
       );
-      yield* Effect.addFinalizer(() => Fiber.interrupt(demoFiber));
 
       // ── Periodic fiber: contact rate-limit cleanup — every 60s ────
       // Unauthenticated public endpoint with a per-IP map; without
@@ -1276,10 +1284,10 @@ export function makeSchedulerLive(
           }),
         ),
       );
-      const contactFiber = yield* Effect.fork(
+      // forkScoped, not fork — see SettingsLive for rationale.
+      yield* Effect.forkScoped(
         contactTick.pipe(Effect.repeat(Schedule.spaced(Duration.seconds(60)))),
       );
-      yield* Effect.addFinalizer(() => Fiber.interrupt(contactFiber));
 
       // ── Periodic fiber: abuse detection cleanup — every 5 min ──────
       const abuseTick = Effect.try({
@@ -1305,10 +1313,10 @@ export function makeSchedulerLive(
       const { ABUSE_CLEANUP_INTERVAL_MS } = require("@atlas/api/lib/security/abuse") as {
         ABUSE_CLEANUP_INTERVAL_MS: number;
       };
-      const abuseFiber = yield* Effect.fork(
+      // forkScoped, not fork — see SettingsLive for rationale.
+      yield* Effect.forkScoped(
         abuseTick.pipe(Effect.repeat(Schedule.spaced(Duration.millis(ABUSE_CLEANUP_INTERVAL_MS)))),
       );
-      yield* Effect.addFinalizer(() => Fiber.interrupt(abuseFiber));
 
       // ── Periodic fiber: dashboard public rate-limit cleanup — every 60s ─
       const dashboardTick = Effect.try({
@@ -1340,10 +1348,10 @@ export function makeSchedulerLive(
       } catch {
         // intentionally ignored: use default interval if module can't be resolved
       }
-      const dashboardFiber = yield* Effect.fork(
+      // forkScoped, not fork — see SettingsLive for rationale.
+      yield* Effect.forkScoped(
         dashboardTick.pipe(Effect.repeat(Schedule.spaced(Duration.millis(dashboardCleanupIntervalMs)))),
       );
-      yield* Effect.addFinalizer(() => Fiber.interrupt(dashboardFiber));
 
       // ── Periodic fiber: conversation public rate sweep — every 60s ──
       const convSweepTick = Effect.try({
@@ -1370,10 +1378,10 @@ export function makeSchedulerLive(
         CONVERSATION_RATE_SWEEP_INTERVAL_MS: number;
         SHARE_CLEANUP_INTERVAL_MS: number;
       };
-      const convSweepFiber = yield* Effect.fork(
+      // forkScoped, not fork — see SettingsLive for rationale.
+      yield* Effect.forkScoped(
         convSweepTick.pipe(Effect.repeat(Schedule.spaced(Duration.millis(CONVERSATION_RATE_SWEEP_INTERVAL_MS)))),
       );
-      yield* Effect.addFinalizer(() => Fiber.interrupt(convSweepFiber));
 
       // ── Periodic fiber: share token cleanup — every 60 min ─────────
       const shareCleanupEffect = Effect.tryPromise({
@@ -1395,10 +1403,10 @@ export function makeSchedulerLive(
           }),
         ),
       );
-      const shareCleanupFiber = yield* Effect.fork(
+      // forkScoped, not fork — see SettingsLive for rationale.
+      yield* Effect.forkScoped(
         shareCleanupEffect.pipe(Effect.repeat(Schedule.spaced(Duration.millis(SHARE_CLEANUP_INTERVAL_MS)))),
       );
-      yield* Effect.addFinalizer(() => Fiber.interrupt(shareCleanupFiber));
 
       // ── Periodic fiber: sub-processor change-feed publisher (#1924) ──
       // Cron sweep, not build-hook: the source JSON can be hot-edited
@@ -1426,7 +1434,8 @@ export function makeSchedulerLive(
           }),
         ),
       );
-      const subProcessorFiber = yield* Effect.fork(
+      // forkScoped, not fork — see SettingsLive for rationale.
+      yield* Effect.forkScoped(
         subProcessorTick.pipe(
           Effect.repeat(
             Schedule.spaced(
@@ -1435,7 +1444,6 @@ export function makeSchedulerLive(
           ),
         ),
       );
-      yield* Effect.addFinalizer(() => Fiber.interrupt(subProcessorFiber));
 
       // ── Periodic fiber: SaaS CRM outbox flusher (#2729) ─────────────
       // Slice 2 of 1.6.0. The flusher polls `crm_outbox` for pending /
@@ -1597,7 +1605,11 @@ export function makeSchedulerLive(
             }),
           ),
         );
-        const outboxFiber = yield* Effect.fork(
+        // forkScoped, not fork — see SettingsLive for rationale.
+        // The recovery sweep still needs its own addFinalizer below
+        // because it's not a fiber interrupt — it's an orderly cleanup
+        // that must run on layer shutdown regardless.
+        yield* Effect.forkScoped(
           outboxTick.pipe(Effect.repeat(Schedule.spaced(Duration.millis(outboxTickIntervalMs)))),
         );
 
@@ -1634,15 +1646,19 @@ export function makeSchedulerLive(
         // another ~15s before being detected — making the "no tick in
         // > 2× interval" guarantee soft. Polling at tick cadence bounds
         // detection lag to ~one tick interval. (Codex P2, 2026-05-26.)
-        const outboxWatchdogFiber = yield* Effect.fork(
+        // forkScoped, not fork — see SettingsLive for rationale.
+        yield* Effect.forkScoped(
           outboxWatchdog.pipe(
             Effect.repeat(Schedule.spaced(Duration.millis(outboxTickIntervalMs))),
           ),
         );
+        // Recovery-sweep finalizer. The two forked fibers above are
+        // already cleaned up by the layer scope (forkScoped); this
+        // finalizer only owns the in_flight reset sweep, which is an
+        // orderly cleanup that must run on layer shutdown so the next
+        // pod boot doesn't see stranded `in_flight` carcasses.
         yield* Effect.addFinalizer(() =>
           Effect.gen(function* () {
-            yield* Fiber.interrupt(outboxWatchdogFiber);
-            yield* Fiber.interrupt(outboxFiber);
             // Final recovery sweep: a SIGTERM mid-flush leaves the
             // active row in `in_flight` until the next pod boot. Reset
             // here so the replacement pod picks it up on its first

--- a/packages/api/src/lib/effect/services.ts
+++ b/packages/api/src/lib/effect/services.ts
@@ -180,12 +180,27 @@ export function makeConnectionRegistryLive(
         );
       });
 
+      // Shutdown finalizer — registered BEFORE the forkScoped health
+      // fiber below. Effect scope finalizers run LIFO; `forkScoped`
+      // registers an implicit fiber-interrupt finalizer at its fork
+      // point, so this ordering guarantees the health fiber is
+      // interrupted (and `Fiber.interrupt` awaits cleanup completion)
+      // BEFORE `impl.shutdown()` tears down pools. Registered the
+      // other way around, the shutdown would race a concurrent health
+      // cycle against pools being torn down (Codex P2 on #2864).
+      yield* Effect.addFinalizer(() =>
+        Effect.gen(function* () {
+          yield* Effect.promise(() => impl.shutdown());
+          log.info("ConnectionRegistry shut down via Effect scope");
+        }),
+      );
+
       // forkScoped, not fork — the bare `fork` API links the child fiber
       // to the parent fiber's lifetime, and the parent here is this gen
       // which returns the service shape immediately. With `Effect.fork`
       // the periodic health-check never runs because the child is
       // interrupted at gen completion (verified by repro; diagnosed in
-      // #DharmaIncident on the outbox flusher). forkScoped binds to the
+      // #2864 on the outbox flusher). forkScoped binds to the
       // Layer scope, so the fiber lives until layer shutdown.
       yield* Effect.forkScoped(
         healthCheckAll.pipe(
@@ -200,16 +215,6 @@ export function makeConnectionRegistryLive(
           Effect.repeat(Schedule.spaced(Duration.millis(HEALTH_CHECK_INTERVAL_MS))),
           Effect.asVoid,
         ),
-      );
-
-      // --- Scope finalizer for graceful shutdown ---
-      // The fiber above is interrupted by the Layer scope automatically
-      // (forkScoped). This finalizer only owns the impl.shutdown() call.
-      yield* Effect.addFinalizer(() =>
-        Effect.gen(function* () {
-          yield* Effect.promise(() => impl.shutdown());
-          log.info("ConnectionRegistry shut down via Effect scope");
-        }),
       );
 
       // --- Build service interface ---
@@ -391,6 +396,28 @@ function buildPluginService(impl: PluginRegistryClass) {
       }),
     );
 
+    // Teardown finalizer — registered BEFORE the forkScoped health
+    // fiber below. Scope finalizers are LIFO; this ordering guarantees
+    // the health fiber is interrupted (awaiting cleanup completion)
+    // BEFORE `impl.teardownAll()` dismantles plugins. The reverse order
+    // would let a concurrent health cycle mutate plugin statuses or
+    // probe plugins mid-teardown (Codex P2 on #2864). `teardownAll`
+    // iterates plugins LIFO internally, which is a separate concern.
+    yield* Effect.addFinalizer(() =>
+      Effect.gen(function* () {
+        yield* Effect.tryPromise({
+          try: () => impl.teardownAll(),
+          catch: (err) => (err instanceof Error ? err.message : String(err)),
+        }).pipe(
+          Effect.catchAll((errMsg) => {
+            pluginLog.error({ err: errMsg }, "PluginRegistry teardownAll failed during shutdown");
+            return Effect.void;
+          }),
+        );
+        pluginLog.info("PluginRegistry shut down via Effect scope");
+      }),
+    );
+
     // forkScoped, not fork — see ConnectionRegistry's healthFiber for rationale.
     yield* Effect.forkScoped(
       healthCheckCycle.pipe(
@@ -406,25 +433,6 @@ function buildPluginService(impl: PluginRegistryClass) {
         ),
         Effect.asVoid,
       ),
-    );
-
-    // --- Scope finalizer for graceful shutdown ---
-    // The fiber above is interrupted by the Layer scope automatically
-    // (forkScoped). This finalizer only owns the teardownAll call,
-    // which iterates plugins in reverse registration order (LIFO).
-    yield* Effect.addFinalizer(() =>
-      Effect.gen(function* () {
-        yield* Effect.tryPromise({
-          try: () => impl.teardownAll(),
-          catch: (err) => (err instanceof Error ? err.message : String(err)),
-        }).pipe(
-          Effect.catchAll((errMsg) => {
-            pluginLog.error({ err: errMsg }, "PluginRegistry teardownAll failed during shutdown");
-            return Effect.void;
-          }),
-        );
-        pluginLog.info("PluginRegistry shut down via Effect scope");
-      }),
     );
 
     // --- Build service interface (delegates to underlying impl) ---

--- a/packages/api/src/lib/effect/services.ts
+++ b/packages/api/src/lib/effect/services.ts
@@ -16,7 +16,7 @@
  * - Wired layer variant with type-level ConnectionRegistry dependency
  */
 
-import { Context, Effect, Layer, Duration, Schedule, Fiber } from "effect";
+import { Context, Effect, Layer, Duration, Schedule } from "effect";
 import type {
   ConnectionRegistry as ConnectionRegistryClass,
   DBConnection,
@@ -180,7 +180,14 @@ export function makeConnectionRegistryLive(
         );
       });
 
-      const healthFiber = yield* Effect.fork(
+      // forkScoped, not fork — the bare `fork` API links the child fiber
+      // to the parent fiber's lifetime, and the parent here is this gen
+      // which returns the service shape immediately. With `Effect.fork`
+      // the periodic health-check never runs because the child is
+      // interrupted at gen completion (verified by repro; diagnosed in
+      // #DharmaIncident on the outbox flusher). forkScoped binds to the
+      // Layer scope, so the fiber lives until layer shutdown.
+      yield* Effect.forkScoped(
         healthCheckAll.pipe(
           // Catch expected failures but let defects (programming errors) crash the fiber.
           // The inner forEach already catches individual health check failures, so this
@@ -196,9 +203,10 @@ export function makeConnectionRegistryLive(
       );
 
       // --- Scope finalizer for graceful shutdown ---
+      // The fiber above is interrupted by the Layer scope automatically
+      // (forkScoped). This finalizer only owns the impl.shutdown() call.
       yield* Effect.addFinalizer(() =>
         Effect.gen(function* () {
-          yield* Fiber.interrupt(healthFiber);
           yield* Effect.promise(() => impl.shutdown());
           log.info("ConnectionRegistry shut down via Effect scope");
         }),
@@ -383,7 +391,8 @@ function buildPluginService(impl: PluginRegistryClass) {
       }),
     );
 
-    const healthFiber = yield* Effect.fork(
+    // forkScoped, not fork — see ConnectionRegistry's healthFiber for rationale.
+    yield* Effect.forkScoped(
       healthCheckCycle.pipe(
         Effect.catchAllCause((cause) => {
           pluginLog.warn(
@@ -400,11 +409,11 @@ function buildPluginService(impl: PluginRegistryClass) {
     );
 
     // --- Scope finalizer for graceful shutdown ---
-    // addFinalizer triggers teardownAll on scope close;
-    // teardownAll iterates plugins in reverse registration order (LIFO) internally.
+    // The fiber above is interrupted by the Layer scope automatically
+    // (forkScoped). This finalizer only owns the teardownAll call,
+    // which iterates plugins in reverse registration order (LIFO).
     yield* Effect.addFinalizer(() =>
       Effect.gen(function* () {
-        yield* Fiber.interrupt(healthFiber);
         yield* Effect.tryPromise({
           try: () => impl.teardownAll(),
           catch: (err) => (err instanceof Error ? err.message : String(err)),


### PR DESCRIPTION
## Summary

- **#DharmaIncident root cause:** `Effect.fork` in 14 sites across `layers.ts` + 2 in `services.ts` was interrupting every periodic fiber at gen completion. The companion `addFinalizer(Fiber.interrupt)` calls were doing nothing — fibers were already dead.
- Converted to `Effect.forkScoped`, which binds child fiber lifetime to the surrounding `Scope` (which `Layer.scoped` keeps open for the layer's full lifetime).
- Added a regression test that fails with `Received: 0` if anyone reverts to `Effect.fork`.

## Diagnosis trail (worth preserving)

The c7acef6a heartbeat + watchdog observability landed at 16:23 EDT today expecting to surface a stalled-fiber incident. Both heartbeat AND watchdog stayed silent for 10+ minutes after deploy. That's the smoking gun: even a wedged tick fiber should let the *independent* watchdog fiber log every 60 seconds. Two silent fibers = neither is running.

Confirmed by direct DB inspection:
- `crm_outbox` target row stayed `pending`, `claimed_at=NULL`, untouched
- `pg_stat_activity` showed zero active connections from the api service — not even the settings-refresh fiber (every 30s) was hitting the DB

Reproduced the failure in a 30-line script:

| Pattern | Iterations in 16s |
|---|---|
| `Effect.fork(tick.pipe(repeat(spaced(2s))))` | **0** |
| `Effect.forkScoped(tick.pipe(repeat(spaced(2s))))` | 8 |

## Scope of the bug

Every periodic fiber in these gens was silently broken:

- `SettingsLive` — periodic settings refresh
- `makeSchedulerLive` — email + expert + oauth + rateLimit + demo + contact + abuse + dashboard + convSweep + shareCleanup + subProcessor + outbox + watchdog
- `ConnectionRegistry` — health-check fiber
- `PluginRegistry` — health-check fiber

Most of these log only on action / error, so silent fiber death looked identical to \"nothing to do.\" The outbox flusher's 5-second cadence made it the first to be obviously broken.

## Test plan

- [x] Repro reproduces (`bun run jobs/a68983a2/fork-repro.ts` → 0 ticks; `fork-repro-scoped.ts` → 8 ticks)
- [x] New regression test in `outbox-flusher-lifecycle.test.ts` passes (\`forkScoped\`) and fails when temporarily reverted to \`fork\` (verified: \`Expected: > 0, Received: 0\`)
- [x] All /ci gates pass (lint, type, test, syncpack, template-drift, security-headers, railway-watch, schema-drift, oauth-helper, test-discipline, twenty-resolver, published-symbols)
- [ ] Post-deploy: observe `lead_outbox.heartbeat` fire every ~60s on the api service in Railway; observe outbox dispatching the currently-pending row

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/2864"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782421055&installation_id=135337507&pr_number=2864&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F2864&signature=a6d1e4ccc083cb335d5647d746ac8586d4fe722fdfe641ea45aba113bc1daea9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->