### PR TITLE
fix(plugins/twenty): correct findPersonByEmail filter syntax (1.6.0 hotfix)

### DIFF
--- a/plugins/twenty/__tests__/client.test.ts
+++ b/plugins/twenty/__tests__/client.test.ts
@@ -114,9 +114,14 @@ describe("upsertPerson — Person absent", () => {
     expect(result.id).toBe("person_123");
     expect(calls).toHaveLength(2);
     expect(calls[0].method).toBe("GET");
-    expect(calls[0].url).toContain("/rest/people?filter");
-    // Twenty's bracket-nested filter syntax — verified against Twenty REST docs.
-    expect(calls[0].url).toContain("filter[emails.primaryEmail][eq]=");
+    expect(calls[0].url).toContain("/rest/people?filter=");
+    // Twenty's documented filter syntax: `field[COMPARATOR]:value`
+    // (per its OpenAPI spec's `components.parameters.filter` description).
+    // The bracket-nested form `filter[field][op]=value` is silently
+    // ignored by Twenty and returns the unfiltered list — guard against
+    // a regression to that shape.
+    expect(calls[0].url).toContain("filter=emails.primaryEmail[eq]:");
+    expect(calls[0].url).not.toContain("filter[emails.primaryEmail][eq]=");
     expect(calls[0].url).toContain(encodeURIComponent("user@test.com"));
 
     expect(calls[1].method).toBe("POST");

--- a/plugins/twenty/src/client.ts
+++ b/plugins/twenty/src/client.ts
@@ -270,8 +270,18 @@ async function readErrorDetail(response: Response): Promise<{ message: string; c
  * Look up a Person by primary email. Returns the first match or
  * undefined when Twenty returns a 2xx with an empty result set.
  *
- * Twenty's REST filter syntax (bracket-nested, per their docs):
- *   ?filter[emails.primaryEmail][eq]=<email>&limit=1
+ * Twenty's REST filter syntax, per its OpenAPI spec
+ * (`components.parameters.filter.description`):
+ *   `field[COMPARATOR]:value`
+ *   e.g. `?filter=emails.primaryEmail[eq]:<email>&limit=1`
+ *
+ * Earlier versions of this client used a bracket-nested form
+ * (`?filter[emails.primaryEmail][eq]=…`) borrowed from Strapi/Sails.
+ * Twenty silently ignores that form and returns the unfiltered list,
+ * which caused `upsertPerson` to merge every dispatch onto whichever
+ * Person was first in the table — corrupting attribution across all
+ * lead sources. The fix uses Twenty's documented `field[op]:value`
+ * format so the filter actually narrows.
  *
  * Throws TwentyClientError when the response body is a 2xx but its
  * shape doesn't match `{ data: { people: TwentyPerson[] } }` — silently
@@ -283,7 +293,7 @@ async function findPersonByEmail(
   email: string,
 ): Promise<TwentyPerson | undefined> {
   const fetchImpl = config.fetchImpl ?? globalThis.fetch;
-  const filter = `filter[emails.primaryEmail][eq]=${encodeURIComponent(email)}`;
+  const filter = `filter=emails.primaryEmail[eq]:${encodeURIComponent(email)}`;
   const url = buildRestUrl(config.baseUrl, `people?${filter}&limit=1`);
   const response = await fetchImpl(url, {
     method: "GET",


### PR DESCRIPTION
## Summary

- `TwentyClient.findPersonByEmail` was building the filter as `?filter[emails.primaryEmail][eq]=<email>` (Strapi/Sails-style nested brackets). Twenty's REST API silently ignores that form and returns the **unfiltered** Person list. With `&limit=1` that meant `findPersonByEmail` returned whichever Person was first in the workspace — regardless of the email argument.
- Swapped to Twenty's documented syntax from its own OpenAPI spec (`components.parameters.filter.description`): `field[COMPARATOR]:value`, e.g. `?filter=emails.primaryEmail[eq]:foo@example.com`.
- Added a regression-guard assertion in `client.test.ts` that requires the correct shape AND forbids the bracket-nested shape, so a future "fix that looks like the old fix" can't sneak back in.

## Why this is P0 for 1.6.0

In production every dispatch after the first Person was ever created collapsed onto that Person via `upsertPerson`'s PATCH branch:
- `name`, `atlasLastSource`, `atlasIp`, `atlasStripeCustomerId` got overwritten on each dispatch.
- `emails.primaryEmail` stayed the first one ever inserted (the PATCH branch doesn't write to emails — by design, on the assumption that the find matched by email).
- Notes for every subsequent lead piled up on that one record.

Manual verification probes against `api.twenty.com` (1 Person in the workspace at the time):

| Filter form                                                     | Result |
|-----------------------------------------------------------------|--------|
| `?filter[emails.primaryEmail][eq]=<real-email>`                 | 1 (matched the only Person) |
| `?filter[emails.primaryEmail][eq]=<one-char-off>`               | 1 (still matched — filter ignored) |
| `?filter[emails.primaryEmail][eq]=nobody@nowhere.invalid`       | 1 (still matched — filter ignored) |
| `?filter[emails.primaryEmail][eq]=` (empty)                     | 1 (still matched — filter ignored) |
| `?filter=emails.primaryEmail[eq]:<real-email>`                  | 1 ✅ |
| `?filter=emails.primaryEmail[eq]:nobody@nowhere.invalid`        | 0 ✅ |

## How it was diagnosed

Surfaced during 1.6.0 manual verification (test plan A1–A4 in `/tmp/atlas-1.6.0-test-plan.md`). Submitted four Talk-to-sales forms across `/pricing`, `/sla`, `/dpa`, `/terms` with four different personas (distinct names, emails, companies). Outbox showed five `ok=1` dispatches with distinct payload emails. Twenty showed exactly **one Person** record, name = last submission's name, primaryEmail = first submission's email, four Notes all linked to that one Person.

Trash, duplicate-detector quirks, browser autofill were ruled out by direct REST probes. The filter-syntax mismatch was the only mechanism consistent with every data point.

## Test plan

- [x] `bun test` in `plugins/twenty/` — 154 pass, 0 fail
- [x] `bun run lint` clean
- [x] `bun run type` clean
- [ ] After merge + deploy: re-run A1–A4 with four distinct personas → expect **4 Persons + 4 Notes** in Twenty (1:1).
- [ ] Spot-check B7 (`/demo`) and C9 (signup) hit distinct Persons.

## Notes

- No schema change. No migration. No data backfill — production Twenty data corruption can be cleaned up manually by an operator (the affected Person record carries Atlas-stamped fields, so it's identifiable).
- The PATCH branch's "doesn't touch email" semantics are correct given a *correctly* matching find. We could optionally harden `findPersonByEmail` to assert the returned record's `emails.primaryEmail` actually matches the requested email and treat a mismatch as a fail-loud bug. Not in this PR — keeping it small.

Refs: milestone #52

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/2865"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782428972&installation_id=135337507&pr_number=2865&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F2865&signature=93fafe7cb100c265fff60168a688adf63c915e4aa4c72c029d743310094f1509"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->