### PR TITLE
feat(plugins/twenty,scripts): in-repo Twenty MCP for local Claude Code

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -23,6 +23,7 @@
         "syncpack": "^14.2.1",
         "typescript": "^6.0.2",
         "typescript-eslint": "^8.57.2",
+        "zod": "^4.3.6",
       },
     },
     "apps/docs": {

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "react": "^19.2.4",
     "syncpack": "^14.2.1",
     "typescript": "^6.0.2",
-    "typescript-eslint": "^8.57.2"
+    "typescript-eslint": "^8.57.2",
+    "zod": "^4.3.6"
   }
 }

--- a/plugins/twenty/__tests__/client.test.ts
+++ b/plugins/twenty/__tests__/client.test.ts
@@ -1211,11 +1211,6 @@ describe("upsertPerson with allowedPersonFields", () => {
   });
 });
 
-// ─────────────────────────────────────────────────────────────────────
-//  Read tools — listPeople / getPerson / searchPeople / listCompanies /
-//  searchCompanies / listNotes
-// ─────────────────────────────────────────────────────────────────────
-
 describe("listPeople", () => {
   test("GETs /rest/people with optional limit + starting_after; returns the array", async () => {
     const { fetch, calls } = makeScriptedFetch([
@@ -1277,6 +1272,23 @@ describe("getPerson", () => {
     expect(calls[0].url).toBe("https://crm.test.local/rest/people/person_xyz");
   });
 
+  test("returns the whole upstream Person — no field subsetting", async () => {
+    const upstream = {
+      id: "p1",
+      emails: { primaryEmail: "x@y.com" },
+      atlasFirstSource: "DEMO",
+      atlasLastSource: "CONVERSION",
+      atlasIp: "1.2.3.4",
+      atlasStripeCustomerId: "cus_x",
+      futureCustomField: "lives",
+    };
+    const { fetch } = makeScriptedFetch([
+      { status: 200, body: { data: { person: upstream } } },
+    ]);
+    const result = await getPerson(baseConfig({ fetchImpl: fetch }), "p1");
+    expect(result).toEqual(upstream);
+  });
+
   test("returns undefined on 404", async () => {
     const { fetch } = makeScriptedFetch([
       { status: 404, body: { messages: ["not found"] } },
@@ -1297,6 +1309,16 @@ describe("getPerson", () => {
       status: 401,
     });
   });
+
+  test("fails loud when 2xx body lacks data.person — distinguishes drift from 404", async () => {
+    const { fetch } = makeScriptedFetch([{ status: 200, body: { data: {} } }]);
+    await expect(
+      getPerson(baseConfig({ fetchImpl: fetch }), "id"),
+    ).rejects.toMatchObject({
+      _tag: "TwentyClientError",
+      operation: "getPerson",
+    });
+  });
 });
 
 describe("searchPeople", () => {
@@ -1305,9 +1327,8 @@ describe("searchPeople", () => {
       { status: 200, body: { data: { people: [] } } },
     ]);
     await searchPeople(baseConfig({ fetchImpl: fetch }), { email: "find@example.com" });
-    // Twenty's documented form is `field[op]:value`. The bracket-nested
-    // form `?filter[emails.primaryEmail][eq]=…` is silently ignored —
-    // forbid it in the same shape as PR #2865.
+    // Twenty silently ignores the bracket-nested form
+    // `?filter[emails.primaryEmail][eq]=…` and returns the unfiltered list.
     expect(calls[0].url).toContain("filter=emails.primaryEmail[eq]:");
     expect(calls[0].url).not.toContain("filter[emails.primaryEmail][eq]=");
     expect(calls[0].url).toContain(encodeURIComponent("find@example.com"));
@@ -1335,12 +1356,13 @@ describe("searchPeople", () => {
     expect(url).not.toContain("filter[");
   });
 
-  test("throws when no criteria supplied", async () => {
-    const { fetch } = makeScriptedFetch([]);
+  test("throws when no criteria supplied and never issues a request", async () => {
+    const { fetch, calls } = makeScriptedFetch([]);
     await expect(searchPeople(baseConfig({ fetchImpl: fetch }), {})).rejects.toMatchObject({
       _tag: "TwentyClientError",
       operation: "searchPeople",
     });
+    expect(calls).toHaveLength(0);
   });
 });
 
@@ -1374,21 +1396,58 @@ describe("listCompanies / searchCompanies / listNotes", () => {
     expect(url).not.toContain("filter[");
   });
 
-  test("listNotes GETs /rest/notes; returns empty array when missing", async () => {
+  test("listNotes returns the array on a normal 200 response", async () => {
     const { fetch } = makeScriptedFetch([
-      { status: 200, body: { data: {} } },
+      { status: 200, body: { data: { notes: [{ id: "n1", title: "x" }] } } },
     ]);
     const result = await listNotes(baseConfig({ fetchImpl: fetch }));
-    expect(result).toEqual([]);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("n1");
+  });
+
+  test("listNotes fails loud when data.notes is missing", async () => {
+    const { fetch } = makeScriptedFetch([{ status: 200, body: { data: {} } }]);
+    await expect(listNotes(baseConfig({ fetchImpl: fetch }))).rejects.toMatchObject({
+      _tag: "TwentyClientError",
+      operation: "listNotes",
+    });
+  });
+
+  test("listCompanies fails loud when data.companies is missing", async () => {
+    const { fetch } = makeScriptedFetch([{ status: 200, body: { data: {} } }]);
+    await expect(listCompanies(baseConfig({ fetchImpl: fetch }))).rejects.toMatchObject({
+      _tag: "TwentyClientError",
+      operation: "listCompanies",
+    });
+  });
+
+  test("searchCompanies fails loud when data.companies is missing", async () => {
+    const { fetch } = makeScriptedFetch([{ status: 200, body: { data: {} } }]);
+    await expect(
+      searchCompanies(baseConfig({ fetchImpl: fetch }), { nameLike: "Acme" }),
+    ).rejects.toMatchObject({
+      _tag: "TwentyClientError",
+      operation: "searchCompanies",
+    });
   });
 });
 
-// ─────────────────────────────────────────────────────────────────────
-//  Delete tools — soft_delete=false by default, hard delete on the wire
-// ─────────────────────────────────────────────────────────────────────
+const deleteCases: Array<{
+  readonly name: "deletePerson" | "deleteNote" | "deleteCompany";
+  readonly fn: (
+    cfg: TwentyClientConfig,
+    id: string,
+    opts?: { readonly softDelete?: boolean },
+  ) => Promise<void>;
+  readonly path: string;
+}> = [
+  { name: "deletePerson", fn: deletePerson, path: "people" },
+  { name: "deleteNote", fn: deleteNote, path: "notes" },
+  { name: "deleteCompany", fn: deleteCompany, path: "companies" },
+];
 
 describe("deletePerson / deleteNote / deleteCompany", () => {
-  test("sends DELETE with ?soft_delete=false by default (hard delete)", async () => {
+  test("sends DELETE with ?soft_delete=false by default", async () => {
     const { fetch, calls } = makeScriptedFetch([
       { status: 200, body: {} },
       { status: 200, body: {} },
@@ -1403,48 +1462,58 @@ describe("deletePerson / deleteNote / deleteCompany", () => {
     expect(calls[0].url).toBe("https://crm.test.local/rest/people/p1?soft_delete=false");
     expect(calls[1].url).toBe("https://crm.test.local/rest/notes/n1?soft_delete=false");
     expect(calls[2].url).toBe("https://crm.test.local/rest/companies/c1?soft_delete=false");
-    // soft_delete must always be explicit on the wire so a future
-    // Twenty default change can't silently flip our semantics.
     for (const call of calls) {
-      expect(call.url).toContain("soft_delete=");
+      expect(call.url).toMatch(/[?&]soft_delete=(true|false)\b/);
     }
   });
 
-  test("honors softDelete:true override", async () => {
-    const { fetch, calls } = makeScriptedFetch([{ status: 200, body: {} }]);
-    await deletePerson(baseConfig({ fetchImpl: fetch }), "p1", { softDelete: true });
-    expect(calls[0].url).toBe("https://crm.test.local/rest/people/p1?soft_delete=true");
-  });
+  test.each(deleteCases)(
+    "$name honors softDelete:true override",
+    async ({ fn, path }) => {
+      const { fetch, calls } = makeScriptedFetch([{ status: 200, body: {} }]);
+      await fn(baseConfig({ fetchImpl: fetch }), "id-1", { softDelete: true });
+      expect(calls[0].url).toBe(`https://crm.test.local/rest/${path}/id-1?soft_delete=true`);
+    },
+  );
 
-  test("treats 404 as idempotent — does not throw", async () => {
+  test.each(deleteCases)("$name treats 404 as idempotent", async ({ fn }) => {
     const { fetch } = makeScriptedFetch([
       { status: 404, body: { messages: ["already gone"] } },
     ]);
-    await expect(
-      deletePerson(baseConfig({ fetchImpl: fetch }), "p1"),
-    ).resolves.toBeUndefined();
+    await expect(fn(baseConfig({ fetchImpl: fetch }), "id-1")).resolves.toBeUndefined();
   });
 
-  test("throws TwentyClientError on non-404 4xx with operation set", async () => {
-    const { fetch } = makeScriptedFetch([
-      { status: 401, body: { messages: ["unauthorized"] } },
-    ]);
-    await expect(
-      deletePerson(baseConfig({ fetchImpl: fetch }), "p1"),
-    ).rejects.toMatchObject({
-      _tag: "TwentyClientError",
-      operation: "deletePerson",
-      status: 401,
-    });
-  });
+  test.each(deleteCases)(
+    "$name throws TwentyClientError on non-404 4xx with operation set",
+    async ({ fn, name }) => {
+      const { fetch } = makeScriptedFetch([
+        { status: 401, body: { messages: ["unauthorized"] } },
+      ]);
+      await expect(fn(baseConfig({ fetchImpl: fetch }), "id-1")).rejects.toMatchObject({
+        _tag: "TwentyClientError",
+        operation: name,
+        status: 401,
+      });
+    },
+  );
 });
 
-// ─────────────────────────────────────────────────────────────────────
-//  wipeWorkspace — drains pages, dryRun samples one page per object
-// ─────────────────────────────────────────────────────────────────────
-
 describe("wipeWorkspace", () => {
-  test("drains notes → people → companies and reports counts", async () => {
+  test("defaults to dryRun:true and issues no DELETEs when called with no opts", async () => {
+    const { fetch, calls } = makeScriptedFetch([
+      { status: 200, body: { data: { notes: [{ id: "n1" }] } } },
+      { status: 200, body: { data: { people: [] } } },
+      { status: 200, body: { data: { companies: [] } } },
+    ]);
+    const result = await wipeWorkspace(baseConfig({ fetchImpl: fetch }));
+    expect(result.dryRun).toBe(true);
+    if (result.dryRun) {
+      expect(result.notesSampled).toBe(1);
+    }
+    expect(calls.filter((c) => c.method === "DELETE")).toHaveLength(0);
+  });
+
+  test("dryRun:false drains notes → people → companies in order and reports deleted counts", async () => {
     const { fetch, calls } = makeScriptedFetch([
       // notes: page 1 returns 2, delete×2, page 2 empty
       { status: 200, body: { data: { notes: [{ id: "n1" }, { id: "n2" }] } } },
@@ -1458,21 +1527,33 @@ describe("wipeWorkspace", () => {
       // companies: page 1 empty
       { status: 200, body: { data: { companies: [] } } },
     ]);
-    const result = await wipeWorkspace(baseConfig({ fetchImpl: fetch }), { pageLimit: 60 });
+    const result = await wipeWorkspace(baseConfig({ fetchImpl: fetch }), {
+      dryRun: false,
+      pageLimit: 60,
+    });
     expect(result.dryRun).toBe(false);
-    expect(result.notesDeleted).toBe(2);
-    expect(result.peopleDeleted).toBe(1);
-    expect(result.companiesDeleted).toBe(0);
-    expect(result.truncated).toBe(false);
+    if (!result.dryRun) {
+      expect(result.notesDeleted).toBe(2);
+      expect(result.peopleDeleted).toBe(1);
+      expect(result.companiesDeleted).toBe(0);
+      expect(result.truncated).toEqual({ notes: false, people: false, companies: false });
+      expect(result.errors).toEqual([]);
+    }
 
-    // Each delete URL must carry soft_delete=false (hard delete) so the
-    // wipe actually clears the workspace — soft-deleted records still
-    // trip Twenty's duplicate detection on next upsertPerson.
     const deletes = calls.filter((c) => c.method === "DELETE");
     expect(deletes.length).toBe(3);
     for (const d of deletes) {
-      expect(d.url).toContain("soft_delete=false");
+      expect(d.url).toMatch(/[?&]soft_delete=false\b/);
     }
+
+    // Iteration-order assertion — the safety property of the wipe.
+    const listUrls = calls.filter((c) => c.method === "GET").map((c) => c.url);
+    const notesIdx = listUrls.findIndex((u) => u.includes("/rest/notes"));
+    const peopleIdx = listUrls.findIndex((u) => u.includes("/rest/people"));
+    const companiesIdx = listUrls.findIndex((u) => u.includes("/rest/companies"));
+    expect(notesIdx).toBeGreaterThanOrEqual(0);
+    expect(peopleIdx).toBeGreaterThan(notesIdx);
+    expect(companiesIdx).toBeGreaterThan(peopleIdx);
   });
 
   test("dryRun=true counts one page per object type and issues no DELETEs", async () => {
@@ -1486,30 +1567,84 @@ describe("wipeWorkspace", () => {
       pageLimit: 60,
     });
     expect(result.dryRun).toBe(true);
-    expect(result.notesDeleted).toBe(2);
-    expect(result.peopleDeleted).toBe(1);
-    expect(result.companiesDeleted).toBe(0);
+    if (result.dryRun) {
+      expect(result.notesSampled).toBe(2);
+      expect(result.peopleSampled).toBe(1);
+      expect(result.companiesSampled).toBe(0);
+    }
     expect(calls.filter((c) => c.method === "DELETE")).toHaveLength(0);
   });
 
-  test("sets truncated=true when maxRecords cap is reached", async () => {
+  test("sets truncated.notes=true when notes drain hits maxRecords", async () => {
     const { fetch } = makeScriptedFetch([
-      // 3 notes returned on page 1, maxRecords=2 → only 2 processed
-      {
-        status: 200,
-        body: { data: { notes: [{ id: "n1" }, { id: "n2" }, { id: "n3" }] } },
-      },
+      { status: 200, body: { data: { notes: [{ id: "n1" }, { id: "n2" }, { id: "n3" }] } } },
       { status: 200, body: {} }, // DELETE n1
       { status: 200, body: {} }, // DELETE n2
-      // people + companies still need to drain — empty for this test
+      // people + companies still drain — maxRecords is per-object, not summed
       { status: 200, body: { data: { people: [] } } },
       { status: 200, body: { data: { companies: [] } } },
     ]);
     const result = await wipeWorkspace(baseConfig({ fetchImpl: fetch }), {
+      dryRun: false,
       pageLimit: 60,
       maxRecords: 2,
     });
-    expect(result.truncated).toBe(true);
-    expect(result.notesDeleted).toBe(2);
+    if (!result.dryRun) {
+      expect(result.notesDeleted).toBe(2);
+      expect(result.truncated).toEqual({ notes: true, people: false, companies: false });
+    }
+  });
+
+  test("maxRecords is per-object-type — people drain still gets full budget after notes saturates", async () => {
+    const { fetch } = makeScriptedFetch([
+      { status: 200, body: { data: { notes: [{ id: "n1" }, { id: "n2" }, { id: "n3" }] } } },
+      { status: 200, body: {} }, // DELETE n1
+      { status: 200, body: {} }, // DELETE n2
+      // people drain: maxRecords=2 is independent — should see all 2 deleted (3rd truncated)
+      { status: 200, body: { data: { people: [{ id: "p1" }, { id: "p2" }, { id: "p3" }] } } },
+      { status: 200, body: {} }, // DELETE p1
+      { status: 200, body: {} }, // DELETE p2
+      // companies drain still runs with fresh budget
+      { status: 200, body: { data: { companies: [{ id: "c1" }] } } },
+      { status: 200, body: {} }, // DELETE c1
+      { status: 200, body: { data: { companies: [] } } },
+    ]);
+    const result = await wipeWorkspace(baseConfig({ fetchImpl: fetch }), {
+      dryRun: false,
+      pageLimit: 60,
+      maxRecords: 2,
+    });
+    if (!result.dryRun) {
+      expect(result.notesDeleted).toBe(2);
+      expect(result.peopleDeleted).toBe(2);
+      expect(result.companiesDeleted).toBe(1);
+      expect(result.truncated.notes).toBe(true);
+      expect(result.truncated.people).toBe(true);
+      expect(result.truncated.companies).toBe(false);
+    }
+  });
+
+  test("collects per-record delete failures and continues the wipe", async () => {
+    const { fetch } = makeScriptedFetch([
+      { status: 200, body: { data: { notes: [{ id: "n1" }, { id: "n2" }] } } },
+      { status: 500, body: { messages: ["upstream blew up"] } }, // DELETE n1 fails
+      { status: 200, body: {} }, // DELETE n2 succeeds
+      { status: 200, body: { data: { notes: [] } } },
+      { status: 200, body: { data: { people: [] } } },
+      { status: 200, body: { data: { companies: [] } } },
+    ]);
+    const result = await wipeWorkspace(baseConfig({ fetchImpl: fetch }), {
+      dryRun: false,
+      pageLimit: 60,
+    });
+    if (!result.dryRun) {
+      expect(result.notesDeleted).toBe(1);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]).toMatchObject({
+        objectType: "note",
+        id: "n1",
+        status: 500,
+      });
+    }
   });
 });

--- a/plugins/twenty/__tests__/client.test.ts
+++ b/plugins/twenty/__tests__/client.test.ts
@@ -13,6 +13,16 @@ import {
   getPersonMetadata,
   getPersonRestSchema,
   createNote,
+  listPeople,
+  getPerson,
+  searchPeople,
+  listNotes,
+  listCompanies,
+  searchCompanies,
+  deletePerson,
+  deleteNote,
+  deleteCompany,
+  wipeWorkspace,
   TwentyClientError,
   type TwentyClientConfig,
   type TwentyPerson,
@@ -1198,5 +1208,308 @@ describe("upsertPerson with allowedPersonFields", () => {
     expect("atlasIp" in body).toBe(false);
     // sticky first-source not in the payload since it already had one
     expect("atlasFirstSource" in body).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+//  Read tools — listPeople / getPerson / searchPeople / listCompanies /
+//  searchCompanies / listNotes
+// ─────────────────────────────────────────────────────────────────────
+
+describe("listPeople", () => {
+  test("GETs /rest/people with optional limit + starting_after; returns the array", async () => {
+    const { fetch, calls } = makeScriptedFetch([
+      {
+        status: 200,
+        body: {
+          data: {
+            people: [
+              { id: "p1", emails: { primaryEmail: "a@x.com" } },
+              { id: "p2", emails: { primaryEmail: "b@x.com" } },
+            ],
+          },
+        },
+      },
+    ]);
+    const result = await listPeople(baseConfig({ fetchImpl: fetch }), {
+      limit: 25,
+      startingAfter: "cursor-abc",
+    });
+    expect(result).toHaveLength(2);
+    expect(result[0].id).toBe("p1");
+    expect(calls[0].method).toBe("GET");
+    expect(calls[0].url).toContain("/rest/people?");
+    expect(calls[0].url).toContain("limit=25");
+    expect(calls[0].url).toContain("starting_after=cursor-abc");
+  });
+
+  test("throws TwentyClientError with operation=listPeople on 4xx", async () => {
+    const { fetch } = makeScriptedFetch([
+      { status: 401, body: { messages: ["unauthorized"] } },
+    ]);
+    await expect(listPeople(baseConfig({ fetchImpl: fetch }))).rejects.toMatchObject({
+      _tag: "TwentyClientError",
+      operation: "listPeople",
+      status: 401,
+    });
+  });
+});
+
+describe("getPerson", () => {
+  test("GETs /rest/people/{id}; returns the person", async () => {
+    const { fetch, calls } = makeScriptedFetch([
+      {
+        status: 200,
+        body: {
+          data: {
+            person: {
+              id: "person_xyz",
+              emails: { primaryEmail: "a@x.com" },
+              atlasFirstSource: "DEMO",
+            },
+          },
+        },
+      },
+    ]);
+    const result = await getPerson(baseConfig({ fetchImpl: fetch }), "person_xyz");
+    expect(result?.id).toBe("person_xyz");
+    expect(result?.atlasFirstSource).toBe("DEMO");
+    expect(calls[0].url).toBe("https://crm.test.local/rest/people/person_xyz");
+  });
+
+  test("returns undefined on 404", async () => {
+    const { fetch } = makeScriptedFetch([
+      { status: 404, body: { messages: ["not found"] } },
+    ]);
+    const result = await getPerson(baseConfig({ fetchImpl: fetch }), "missing");
+    expect(result).toBeUndefined();
+  });
+
+  test("throws TwentyClientError on non-404 4xx", async () => {
+    const { fetch } = makeScriptedFetch([
+      { status: 401, body: { messages: ["unauthorized"] } },
+    ]);
+    await expect(
+      getPerson(baseConfig({ fetchImpl: fetch }), "id"),
+    ).rejects.toMatchObject({
+      _tag: "TwentyClientError",
+      operation: "getPerson",
+      status: 401,
+    });
+  });
+});
+
+describe("searchPeople", () => {
+  test("builds documented filter=field[op]:value syntax for email-only", async () => {
+    const { fetch, calls } = makeScriptedFetch([
+      { status: 200, body: { data: { people: [] } } },
+    ]);
+    await searchPeople(baseConfig({ fetchImpl: fetch }), { email: "find@example.com" });
+    // Twenty's documented form is `field[op]:value`. The bracket-nested
+    // form `?filter[emails.primaryEmail][eq]=…` is silently ignored —
+    // forbid it in the same shape as PR #2865.
+    expect(calls[0].url).toContain("filter=emails.primaryEmail[eq]:");
+    expect(calls[0].url).not.toContain("filter[emails.primaryEmail][eq]=");
+    expect(calls[0].url).toContain(encodeURIComponent("find@example.com"));
+  });
+
+  test("builds or() composite for nameLike + AND-joins multiple clauses", async () => {
+    const { fetch, calls } = makeScriptedFetch([
+      { status: 200, body: { data: { people: [] } } },
+    ]);
+    await searchPeople(baseConfig({ fetchImpl: fetch }), {
+      email: "matt@example.com",
+      nameLike: "Sywulak",
+      limit: 50,
+    });
+    const url = calls[0].url;
+    expect(url).toContain("filter=");
+    // email clause present
+    expect(url).toContain("emails.primaryEmail[eq]:");
+    // nameLike → or() composite over firstName + lastName
+    expect(url).toContain("or(");
+    expect(url).toContain("name.firstName[like]:");
+    expect(url).toContain("name.lastName[like]:");
+    expect(url).toContain("limit=50");
+    // never the broken nested form
+    expect(url).not.toContain("filter[");
+  });
+
+  test("throws when no criteria supplied", async () => {
+    const { fetch } = makeScriptedFetch([]);
+    await expect(searchPeople(baseConfig({ fetchImpl: fetch }), {})).rejects.toMatchObject({
+      _tag: "TwentyClientError",
+      operation: "searchPeople",
+    });
+  });
+});
+
+describe("listCompanies / searchCompanies / listNotes", () => {
+  test("listCompanies GETs /rest/companies; returns array", async () => {
+    const { fetch, calls } = makeScriptedFetch([
+      {
+        status: 200,
+        body: { data: { companies: [{ id: "c1", name: "Acme" }] } },
+      },
+    ]);
+    const result = await listCompanies(baseConfig({ fetchImpl: fetch }), { limit: 10 });
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("Acme");
+    expect(calls[0].url).toContain("/rest/companies?");
+    expect(calls[0].url).toContain("limit=10");
+  });
+
+  test("searchCompanies builds documented filter syntax for nameLike + domainLike", async () => {
+    const { fetch, calls } = makeScriptedFetch([
+      { status: 200, body: { data: { companies: [] } } },
+    ]);
+    await searchCompanies(baseConfig({ fetchImpl: fetch }), {
+      nameLike: "Acme",
+      domainLike: "acme.io",
+    });
+    const url = calls[0].url;
+    expect(url).toContain("filter=");
+    expect(url).toContain("name[like]:");
+    expect(url).toContain("domainName.primaryLinkUrl[like]:");
+    expect(url).not.toContain("filter[");
+  });
+
+  test("listNotes GETs /rest/notes; returns empty array when missing", async () => {
+    const { fetch } = makeScriptedFetch([
+      { status: 200, body: { data: {} } },
+    ]);
+    const result = await listNotes(baseConfig({ fetchImpl: fetch }));
+    expect(result).toEqual([]);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+//  Delete tools — soft_delete=false by default, hard delete on the wire
+// ─────────────────────────────────────────────────────────────────────
+
+describe("deletePerson / deleteNote / deleteCompany", () => {
+  test("sends DELETE with ?soft_delete=false by default (hard delete)", async () => {
+    const { fetch, calls } = makeScriptedFetch([
+      { status: 200, body: {} },
+      { status: 200, body: {} },
+      { status: 200, body: {} },
+    ]);
+    const config = baseConfig({ fetchImpl: fetch });
+    await deletePerson(config, "p1");
+    await deleteNote(config, "n1");
+    await deleteCompany(config, "c1");
+
+    expect(calls[0].method).toBe("DELETE");
+    expect(calls[0].url).toBe("https://crm.test.local/rest/people/p1?soft_delete=false");
+    expect(calls[1].url).toBe("https://crm.test.local/rest/notes/n1?soft_delete=false");
+    expect(calls[2].url).toBe("https://crm.test.local/rest/companies/c1?soft_delete=false");
+    // soft_delete must always be explicit on the wire so a future
+    // Twenty default change can't silently flip our semantics.
+    for (const call of calls) {
+      expect(call.url).toContain("soft_delete=");
+    }
+  });
+
+  test("honors softDelete:true override", async () => {
+    const { fetch, calls } = makeScriptedFetch([{ status: 200, body: {} }]);
+    await deletePerson(baseConfig({ fetchImpl: fetch }), "p1", { softDelete: true });
+    expect(calls[0].url).toBe("https://crm.test.local/rest/people/p1?soft_delete=true");
+  });
+
+  test("treats 404 as idempotent — does not throw", async () => {
+    const { fetch } = makeScriptedFetch([
+      { status: 404, body: { messages: ["already gone"] } },
+    ]);
+    await expect(
+      deletePerson(baseConfig({ fetchImpl: fetch }), "p1"),
+    ).resolves.toBeUndefined();
+  });
+
+  test("throws TwentyClientError on non-404 4xx with operation set", async () => {
+    const { fetch } = makeScriptedFetch([
+      { status: 401, body: { messages: ["unauthorized"] } },
+    ]);
+    await expect(
+      deletePerson(baseConfig({ fetchImpl: fetch }), "p1"),
+    ).rejects.toMatchObject({
+      _tag: "TwentyClientError",
+      operation: "deletePerson",
+      status: 401,
+    });
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+//  wipeWorkspace — drains pages, dryRun samples one page per object
+// ─────────────────────────────────────────────────────────────────────
+
+describe("wipeWorkspace", () => {
+  test("drains notes → people → companies and reports counts", async () => {
+    const { fetch, calls } = makeScriptedFetch([
+      // notes: page 1 returns 2, delete×2, page 2 empty
+      { status: 200, body: { data: { notes: [{ id: "n1" }, { id: "n2" }] } } },
+      { status: 200, body: {} }, // DELETE n1
+      { status: 200, body: {} }, // DELETE n2
+      { status: 200, body: { data: { notes: [] } } },
+      // people: page 1 returns 1, delete×1, page 2 empty
+      { status: 200, body: { data: { people: [{ id: "p1" }] } } },
+      { status: 200, body: {} }, // DELETE p1
+      { status: 200, body: { data: { people: [] } } },
+      // companies: page 1 empty
+      { status: 200, body: { data: { companies: [] } } },
+    ]);
+    const result = await wipeWorkspace(baseConfig({ fetchImpl: fetch }), { pageLimit: 60 });
+    expect(result.dryRun).toBe(false);
+    expect(result.notesDeleted).toBe(2);
+    expect(result.peopleDeleted).toBe(1);
+    expect(result.companiesDeleted).toBe(0);
+    expect(result.truncated).toBe(false);
+
+    // Each delete URL must carry soft_delete=false (hard delete) so the
+    // wipe actually clears the workspace — soft-deleted records still
+    // trip Twenty's duplicate detection on next upsertPerson.
+    const deletes = calls.filter((c) => c.method === "DELETE");
+    expect(deletes.length).toBe(3);
+    for (const d of deletes) {
+      expect(d.url).toContain("soft_delete=false");
+    }
+  });
+
+  test("dryRun=true counts one page per object type and issues no DELETEs", async () => {
+    const { fetch, calls } = makeScriptedFetch([
+      { status: 200, body: { data: { notes: [{ id: "n1" }, { id: "n2" }] } } },
+      { status: 200, body: { data: { people: [{ id: "p1" }] } } },
+      { status: 200, body: { data: { companies: [] } } },
+    ]);
+    const result = await wipeWorkspace(baseConfig({ fetchImpl: fetch }), {
+      dryRun: true,
+      pageLimit: 60,
+    });
+    expect(result.dryRun).toBe(true);
+    expect(result.notesDeleted).toBe(2);
+    expect(result.peopleDeleted).toBe(1);
+    expect(result.companiesDeleted).toBe(0);
+    expect(calls.filter((c) => c.method === "DELETE")).toHaveLength(0);
+  });
+
+  test("sets truncated=true when maxRecords cap is reached", async () => {
+    const { fetch } = makeScriptedFetch([
+      // 3 notes returned on page 1, maxRecords=2 → only 2 processed
+      {
+        status: 200,
+        body: { data: { notes: [{ id: "n1" }, { id: "n2" }, { id: "n3" }] } },
+      },
+      { status: 200, body: {} }, // DELETE n1
+      { status: 200, body: {} }, // DELETE n2
+      // people + companies still need to drain — empty for this test
+      { status: 200, body: { data: { people: [] } } },
+      { status: 200, body: { data: { companies: [] } } },
+    ]);
+    const result = await wipeWorkspace(baseConfig({ fetchImpl: fetch }), {
+      pageLimit: 60,
+      maxRecords: 2,
+    });
+    expect(result.truncated).toBe(true);
+    expect(result.notesDeleted).toBe(2);
   });
 });

--- a/plugins/twenty/src/client.ts
+++ b/plugins/twenty/src/client.ts
@@ -40,10 +40,19 @@ export type TwentyOperation =
   | "findPersonByEmail"
   | "createPerson"
   | "updatePerson"
+  | "deletePerson"
+  | "getPerson"
+  | "listPeople"
+  | "searchPeople"
   | "getPersonMetadata"
   | "getPersonRestSchema"
   | "createNote"
-  | "createNoteTarget";
+  | "createNoteTarget"
+  | "deleteNote"
+  | "listNotes"
+  | "listCompanies"
+  | "searchCompanies"
+  | "deleteCompany";
 
 /** Structured error for typed routing inside SaasCrmLayer. */
 export class TwentyClientError extends Data.TaggedError("TwentyClientError")<{
@@ -822,4 +831,514 @@ export async function getPersonRestSchema(
   }
 
   return { fields: new Set(Object.keys(properties)) };
+}
+
+// ─────────────────────────────────────────────────────────────────────
+//  Read tools — used by the internal scripts/twenty-mcp.ts MCP server
+// ─────────────────────────────────────────────────────────────────────
+//
+// These are the surface that local Claude Code sessions hit when
+// inspecting crm.useatlas.dev. None are reached by the SaaS dispatch
+// path (`ee/src/saas-crm/`) — they exist for internal dogfood. Returns
+// the full upstream record shape with NO hand-rolled subsetting (one of
+// the failure modes of the community MCP we replaced was dropping Atlas
+// custom fields like `atlasFirstSource` from its hand-rolled response
+// types — see #2843 handoff).
+
+export interface TwentyCompany {
+  readonly id?: string;
+  readonly name?: string;
+  readonly domainName?: { primaryLinkUrl?: string };
+  readonly employees?: number;
+  readonly annualRecurringRevenue?: { amountMicros?: string; currencyCode?: string };
+  readonly idealCustomerProfile?: boolean;
+  readonly createdAt?: string;
+  readonly updatedAt?: string;
+}
+
+export interface TwentyNoteFull {
+  readonly id?: string;
+  readonly title?: string;
+  readonly bodyV2?: { markdown?: string };
+  readonly createdAt?: string;
+  readonly updatedAt?: string;
+}
+
+export interface ListOptions {
+  /** Defaults to Twenty's server default (60 today, never assume it). Cap is workspace-configurable. */
+  readonly limit?: number;
+  /** Cursor for forward pagination — pass `endCursor` from a previous page. */
+  readonly startingAfter?: string;
+  /** Cursor for backward pagination. */
+  readonly endingBefore?: string;
+}
+
+function buildListQuery(opts: ListOptions | undefined, filter?: string): string {
+  const params: string[] = [];
+  if (filter) params.push(filter);
+  if (opts?.limit !== undefined) params.push(`limit=${encodeURIComponent(String(opts.limit))}`);
+  if (opts?.startingAfter) params.push(`starting_after=${encodeURIComponent(opts.startingAfter)}`);
+  if (opts?.endingBefore) params.push(`ending_before=${encodeURIComponent(opts.endingBefore)}`);
+  return params.length > 0 ? `?${params.join("&")}` : "";
+}
+
+/**
+ * List Twenty People — unfiltered. Use {@link searchPeople} for filtered
+ * lookups. Returns the array directly; pagination cursors live on the
+ * Twenty response envelope (`pageInfo`) and are NOT surfaced here — page
+ * by passing `startingAfter` / `endingBefore` from the caller side using
+ * the last/first record's id (Twenty's cursor convention).
+ */
+export async function listPeople(
+  config: TwentyClientConfig,
+  opts?: ListOptions,
+): Promise<TwentyPerson[]> {
+  const fetchImpl = config.fetchImpl ?? globalThis.fetch;
+  const url = buildRestUrl(config.baseUrl, `people${buildListQuery(opts)}`);
+  const response = await fetchImpl(url, {
+    method: "GET",
+    headers: buildAuthHeaders(config.apiKey),
+    signal: AbortSignal.timeout(config.timeoutMs ?? DEFAULT_TIMEOUT_MS),
+  });
+
+  if (!response.ok) {
+    const detail = await readErrorDetail(response);
+    throw new TwentyClientError({
+      message: `listPeople failed: ${detail.message}`,
+      status: response.status,
+      upstreamCode: detail.code,
+      operation: "listPeople",
+      retryAfterMs: parseRetryAfterMs(response.headers.get("Retry-After")),
+    });
+  }
+
+  let body: { data?: { people?: unknown } };
+  try {
+    body = (await response.json()) as typeof body;
+  } catch (err) {
+    throw new TwentyClientError({
+      message: `listPeople: unparseable response (${err instanceof Error ? err.message : String(err)})`,
+      status: response.status,
+      operation: "listPeople",
+    });
+  }
+
+  const list = body.data?.people;
+  if (Array.isArray(list)) return list as TwentyPerson[];
+  throw new TwentyClientError({
+    message: "listPeople: unexpected response shape (expected data.people to be an array)",
+    status: response.status,
+    operation: "listPeople",
+  });
+}
+
+/** Fetch a single Person by id. Returns undefined on 404. */
+export async function getPerson(
+  config: TwentyClientConfig,
+  id: string,
+): Promise<TwentyPerson | undefined> {
+  const fetchImpl = config.fetchImpl ?? globalThis.fetch;
+  const url = buildRestUrl(config.baseUrl, `people/${encodeURIComponent(id)}`);
+  const response = await fetchImpl(url, {
+    method: "GET",
+    headers: buildAuthHeaders(config.apiKey),
+    signal: AbortSignal.timeout(config.timeoutMs ?? DEFAULT_TIMEOUT_MS),
+  });
+
+  if (response.status === 404) return undefined;
+  if (!response.ok) {
+    const detail = await readErrorDetail(response);
+    throw new TwentyClientError({
+      message: `getPerson failed: ${detail.message}`,
+      status: response.status,
+      upstreamCode: detail.code,
+      operation: "getPerson",
+      retryAfterMs: parseRetryAfterMs(response.headers.get("Retry-After")),
+    });
+  }
+
+  try {
+    const body = (await response.json()) as { data?: { person?: TwentyPerson } };
+    return body.data?.person;
+  } catch (err) {
+    throw new TwentyClientError({
+      message: `getPerson: unparseable response (${err instanceof Error ? err.message : String(err)})`,
+      status: response.status,
+      operation: "getPerson",
+    });
+  }
+}
+
+export interface SearchPeopleInput extends ListOptions {
+  /** Exact match on emails.primaryEmail. */
+  readonly email?: string;
+  /** Substring match on name.firstName OR name.lastName. */
+  readonly nameLike?: string;
+}
+
+/**
+ * Search People with Twenty's documented filter syntax (`field[op]:value`).
+ *
+ * IMPORTANT: never construct a bracket-nested filter like
+ * `?filter[emails.primaryEmail][eq]=…` — Twenty silently ignores that
+ * form and returns the unfiltered list. PR #2865 fixed
+ * `findPersonByEmail`'s same regression. The unit tests assert the
+ * documented shape AND forbid the bracket-nested form.
+ *
+ * When multiple criteria are supplied they are AND'd via Twenty's
+ * top-level `,` join — `?filter=A[eq]:x,B[like]:%y%`.
+ */
+export async function searchPeople(
+  config: TwentyClientConfig,
+  input: SearchPeopleInput,
+): Promise<TwentyPerson[]> {
+  const fetchImpl = config.fetchImpl ?? globalThis.fetch;
+  const clauses: string[] = [];
+  if (input.email) {
+    clauses.push(`emails.primaryEmail[eq]:${encodeURIComponent(input.email)}`);
+  }
+  if (input.nameLike) {
+    // Twenty's `like` operator uses `%` as the SQL-style wildcard.
+    const pattern = `%${input.nameLike}%`;
+    clauses.push(
+      `or(name.firstName[like]:${encodeURIComponent(pattern)},name.lastName[like]:${encodeURIComponent(pattern)})`,
+    );
+  }
+  if (clauses.length === 0) {
+    throw new TwentyClientError({
+      message: "searchPeople: at least one of `email` or `nameLike` is required",
+      status: 0,
+      operation: "searchPeople",
+    });
+  }
+
+  const filter = `filter=${clauses.join(",")}`;
+  const url = buildRestUrl(
+    config.baseUrl,
+    `people${buildListQuery({ limit: input.limit, startingAfter: input.startingAfter, endingBefore: input.endingBefore }, filter)}`,
+  );
+  const response = await fetchImpl(url, {
+    method: "GET",
+    headers: buildAuthHeaders(config.apiKey),
+    signal: AbortSignal.timeout(config.timeoutMs ?? DEFAULT_TIMEOUT_MS),
+  });
+
+  if (!response.ok) {
+    const detail = await readErrorDetail(response);
+    throw new TwentyClientError({
+      message: `searchPeople failed: ${detail.message}`,
+      status: response.status,
+      upstreamCode: detail.code,
+      operation: "searchPeople",
+      retryAfterMs: parseRetryAfterMs(response.headers.get("Retry-After")),
+    });
+  }
+
+  let body: { data?: { people?: unknown } };
+  try {
+    body = (await response.json()) as typeof body;
+  } catch (err) {
+    throw new TwentyClientError({
+      message: `searchPeople: unparseable response (${err instanceof Error ? err.message : String(err)})`,
+      status: response.status,
+      operation: "searchPeople",
+    });
+  }
+
+  const list = body.data?.people;
+  if (Array.isArray(list)) return list as TwentyPerson[];
+  throw new TwentyClientError({
+    message: "searchPeople: unexpected response shape (expected data.people to be an array)",
+    status: response.status,
+    operation: "searchPeople",
+  });
+}
+
+/** List Notes — unfiltered. Returns the raw upstream array. */
+export async function listNotes(
+  config: TwentyClientConfig,
+  opts?: ListOptions,
+): Promise<TwentyNoteFull[]> {
+  const fetchImpl = config.fetchImpl ?? globalThis.fetch;
+  const url = buildRestUrl(config.baseUrl, `notes${buildListQuery(opts)}`);
+  const response = await fetchImpl(url, {
+    method: "GET",
+    headers: buildAuthHeaders(config.apiKey),
+    signal: AbortSignal.timeout(config.timeoutMs ?? DEFAULT_TIMEOUT_MS),
+  });
+
+  if (!response.ok) {
+    const detail = await readErrorDetail(response);
+    throw new TwentyClientError({
+      message: `listNotes failed: ${detail.message}`,
+      status: response.status,
+      upstreamCode: detail.code,
+      operation: "listNotes",
+      retryAfterMs: parseRetryAfterMs(response.headers.get("Retry-After")),
+    });
+  }
+
+  try {
+    const body = (await response.json()) as { data?: { notes?: TwentyNoteFull[] } };
+    const list = body.data?.notes;
+    if (Array.isArray(list)) return list;
+    return [];
+  } catch (err) {
+    throw new TwentyClientError({
+      message: `listNotes: unparseable response (${err instanceof Error ? err.message : String(err)})`,
+      status: response.status,
+      operation: "listNotes",
+    });
+  }
+}
+
+/** List Companies — unfiltered. Returns the raw upstream array. */
+export async function listCompanies(
+  config: TwentyClientConfig,
+  opts?: ListOptions,
+): Promise<TwentyCompany[]> {
+  const fetchImpl = config.fetchImpl ?? globalThis.fetch;
+  const url = buildRestUrl(config.baseUrl, `companies${buildListQuery(opts)}`);
+  const response = await fetchImpl(url, {
+    method: "GET",
+    headers: buildAuthHeaders(config.apiKey),
+    signal: AbortSignal.timeout(config.timeoutMs ?? DEFAULT_TIMEOUT_MS),
+  });
+
+  if (!response.ok) {
+    const detail = await readErrorDetail(response);
+    throw new TwentyClientError({
+      message: `listCompanies failed: ${detail.message}`,
+      status: response.status,
+      upstreamCode: detail.code,
+      operation: "listCompanies",
+      retryAfterMs: parseRetryAfterMs(response.headers.get("Retry-After")),
+    });
+  }
+
+  try {
+    const body = (await response.json()) as { data?: { companies?: TwentyCompany[] } };
+    const list = body.data?.companies;
+    if (Array.isArray(list)) return list;
+    return [];
+  } catch (err) {
+    throw new TwentyClientError({
+      message: `listCompanies: unparseable response (${err instanceof Error ? err.message : String(err)})`,
+      status: response.status,
+      operation: "listCompanies",
+    });
+  }
+}
+
+export interface SearchCompaniesInput extends ListOptions {
+  readonly nameLike?: string;
+  readonly domainLike?: string;
+}
+
+/** Search Companies. See {@link searchPeople} for filter-syntax discipline. */
+export async function searchCompanies(
+  config: TwentyClientConfig,
+  input: SearchCompaniesInput,
+): Promise<TwentyCompany[]> {
+  const fetchImpl = config.fetchImpl ?? globalThis.fetch;
+  const clauses: string[] = [];
+  if (input.nameLike) {
+    clauses.push(`name[like]:${encodeURIComponent(`%${input.nameLike}%`)}`);
+  }
+  if (input.domainLike) {
+    clauses.push(
+      `domainName.primaryLinkUrl[like]:${encodeURIComponent(`%${input.domainLike}%`)}`,
+    );
+  }
+  if (clauses.length === 0) {
+    throw new TwentyClientError({
+      message: "searchCompanies: at least one of `nameLike` or `domainLike` is required",
+      status: 0,
+      operation: "searchCompanies",
+    });
+  }
+
+  const filter = `filter=${clauses.join(",")}`;
+  const url = buildRestUrl(
+    config.baseUrl,
+    `companies${buildListQuery({ limit: input.limit, startingAfter: input.startingAfter, endingBefore: input.endingBefore }, filter)}`,
+  );
+  const response = await fetchImpl(url, {
+    method: "GET",
+    headers: buildAuthHeaders(config.apiKey),
+    signal: AbortSignal.timeout(config.timeoutMs ?? DEFAULT_TIMEOUT_MS),
+  });
+
+  if (!response.ok) {
+    const detail = await readErrorDetail(response);
+    throw new TwentyClientError({
+      message: `searchCompanies failed: ${detail.message}`,
+      status: response.status,
+      upstreamCode: detail.code,
+      operation: "searchCompanies",
+      retryAfterMs: parseRetryAfterMs(response.headers.get("Retry-After")),
+    });
+  }
+
+  try {
+    const body = (await response.json()) as { data?: { companies?: TwentyCompany[] } };
+    const list = body.data?.companies;
+    if (Array.isArray(list)) return list;
+    return [];
+  } catch (err) {
+    throw new TwentyClientError({
+      message: `searchCompanies: unparseable response (${err instanceof Error ? err.message : String(err)})`,
+      status: response.status,
+      operation: "searchCompanies",
+    });
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────
+//  Delete tools
+// ─────────────────────────────────────────────────────────────────────
+//
+// `DELETE /rest/{object}/{id}?soft_delete=<bool>` — Twenty defaults to
+// `false` (hard delete) per its OpenAPI spec. Soft-deleted records are
+// excluded from list resolvers but Twenty's server-side duplicate
+// detection still trips on them when creating a new Person with the
+// same primary email. Internal-tools usage (scripts/twenty-mcp.ts wipe
+// + manual cleanup) wants hard delete; we make the default explicit on
+// the wire so a future Twenty default change doesn't silently flip our
+// semantics.
+
+export interface DeleteOptions {
+  /** Defaults to false (hard delete). Pass true to send `?soft_delete=true`. */
+  readonly softDelete?: boolean;
+}
+
+function buildDeleteUrl(baseUrl: string, path: string, opts: DeleteOptions | undefined): string {
+  const soft = opts?.softDelete === true ? "true" : "false";
+  return buildRestUrl(baseUrl, `${path}?soft_delete=${soft}`);
+}
+
+async function deleteRecord(
+  config: TwentyClientConfig,
+  path: string,
+  operation: TwentyOperation,
+  opts: DeleteOptions | undefined,
+): Promise<void> {
+  const fetchImpl = config.fetchImpl ?? globalThis.fetch;
+  const url = buildDeleteUrl(config.baseUrl, path, opts);
+  const response = await fetchImpl(url, {
+    method: "DELETE",
+    headers: buildAuthHeaders(config.apiKey),
+    signal: AbortSignal.timeout(config.timeoutMs ?? DEFAULT_TIMEOUT_MS),
+  });
+
+  if (response.status === 404) return; // already gone — idempotent
+  if (!response.ok) {
+    const detail = await readErrorDetail(response);
+    throw new TwentyClientError({
+      message: `${operation} failed: ${detail.message}`,
+      status: response.status,
+      upstreamCode: detail.code,
+      operation,
+      retryAfterMs: parseRetryAfterMs(response.headers.get("Retry-After")),
+    });
+  }
+}
+
+export async function deletePerson(
+  config: TwentyClientConfig,
+  id: string,
+  opts?: DeleteOptions,
+): Promise<void> {
+  await deleteRecord(config, `people/${encodeURIComponent(id)}`, "deletePerson", opts);
+}
+
+export async function deleteNote(
+  config: TwentyClientConfig,
+  id: string,
+  opts?: DeleteOptions,
+): Promise<void> {
+  await deleteRecord(config, `notes/${encodeURIComponent(id)}`, "deleteNote", opts);
+}
+
+export async function deleteCompany(
+  config: TwentyClientConfig,
+  id: string,
+  opts?: DeleteOptions,
+): Promise<void> {
+  await deleteRecord(config, `companies/${encodeURIComponent(id)}`, "deleteCompany", opts);
+}
+
+export interface WipeWorkspaceOptions {
+  /** When true, list everything but don't delete — returns the counts only. */
+  readonly dryRun?: boolean;
+  /** Limit per page during enumeration; defaults to 60. */
+  readonly pageLimit?: number;
+  /** Safety cap on total records visited across all object types. Default 10_000. */
+  readonly maxRecords?: number;
+}
+
+export interface WipeWorkspaceResult {
+  readonly dryRun: boolean;
+  readonly peopleDeleted: number;
+  readonly notesDeleted: number;
+  readonly companiesDeleted: number;
+  readonly truncated: boolean;
+}
+
+/**
+ * Hard-delete every Person, Note, and Company in the workspace.
+ *
+ * Internal-tools only — invoked from `scripts/twenty-mcp.ts wipe`. Not
+ * called by `ee/src/saas-crm/` or any production code path. The wipe
+ * order is notes → people → companies so dangling NoteTargets don't
+ * survive (deleting a Note cascades the NoteTargets server-side per
+ * Twenty's referential rules; we don't enumerate them here). Companies
+ * last so a Person.companyId reference doesn't dangle mid-wipe.
+ *
+ * Pagination shape: lists `pageLimit` at a time, deletes the page,
+ * re-lists. Twenty's cursor pagination would also work but a simple
+ * "delete the first page until the table is empty" loop is sufficient
+ * because deletes shift the cursor.
+ */
+export async function wipeWorkspace(
+  config: TwentyClientConfig,
+  opts?: WipeWorkspaceOptions,
+): Promise<WipeWorkspaceResult> {
+  const dryRun = opts?.dryRun === true;
+  const pageLimit = opts?.pageLimit ?? 60;
+  const maxRecords = opts?.maxRecords ?? 10_000;
+
+  let visited = 0;
+  let truncated = false;
+
+  async function drain<T extends { id?: string }>(
+    list: (config: TwentyClientConfig, listOpts: ListOptions) => Promise<T[]>,
+    del: (config: TwentyClientConfig, id: string) => Promise<void>,
+  ): Promise<number> {
+    let deleted = 0;
+    // Loop until the upstream returns an empty page. Cap with maxRecords.
+    while (visited < maxRecords) {
+      const page = await list(config, { limit: pageLimit });
+      if (page.length === 0) return deleted;
+      for (const record of page) {
+        if (visited >= maxRecords) {
+          truncated = true;
+          return deleted;
+        }
+        visited++;
+        if (!record.id) continue;
+        if (!dryRun) await del(config, record.id);
+        deleted++;
+      }
+      if (dryRun) return deleted; // one page is enough to estimate
+    }
+    truncated = true;
+    return deleted;
+  }
+
+  const notesDeleted = await drain(listNotes, (c, id) => deleteNote(c, id));
+  const peopleDeleted = await drain(listPeople, (c, id) => deletePerson(c, id));
+  const companiesDeleted = await drain(listCompanies, (c, id) => deleteCompany(c, id));
+
+  return { dryRun, peopleDeleted, notesDeleted, companiesDeleted, truncated };
 }

--- a/plugins/twenty/src/client.ts
+++ b/plugins/twenty/src/client.ts
@@ -261,13 +261,19 @@ async function readErrorDetail(response: Response): Promise<{ message: string; c
     upstreamCode = typeof body.code === "string" ? body.code : undefined;
   } catch (err) {
     // Body wasn't JSON. Try text but cap length so a huge HTML 502 page
-    // from a fronting proxy doesn't bloat the log.
+    // from a fronting proxy doesn't bloat the log. Mark truncation
+    // explicitly so the reader can tell a clipped fragment from the
+    // whole body — silent slicing once hid schema-drift detail past byte 200.
     try {
       const txt = await response.text();
-      upstreamMessage = txt.slice(0, 200);
+      upstreamMessage =
+        txt.length > 200
+          ? `${txt.slice(0, 200)}… (truncated, ${txt.length} bytes total)`
+          : txt;
     } catch (textErr) {
       upstreamMessage =
-        `[body unreadable: text=${textErr instanceof Error ? textErr.message : String(textErr)}; ` +
+        `HTTP ${response.status} [body unreadable: ` +
+        `text=${textErr instanceof Error ? textErr.message : String(textErr)}; ` +
         `json=${err instanceof Error ? err.message : String(err)}]`;
     }
   }
@@ -697,6 +703,10 @@ const METADATA_FIELDS_QUERY =
  * custom fields exist before dispatch. Errors propagate as
  * TwentyClientError so the layer can distinguish transient failures
  * from configuration errors.
+ *
+ * @deprecated Prefer {@link getPersonRestSchema}. Twenty's GraphQL
+ * metadata surface is unstable across releases — the REST OpenAPI probe
+ * is the documented replacement.
  */
 export async function getPersonMetadata(
   config: TwentyClientConfig,
@@ -833,17 +843,10 @@ export async function getPersonRestSchema(
   return { fields: new Set(Object.keys(properties)) };
 }
 
-// ─────────────────────────────────────────────────────────────────────
-//  Read tools — used by the internal scripts/twenty-mcp.ts MCP server
-// ─────────────────────────────────────────────────────────────────────
-//
-// These are the surface that local Claude Code sessions hit when
-// inspecting crm.useatlas.dev. None are reached by the SaaS dispatch
-// path (`ee/src/saas-crm/`) — they exist for internal dogfood. Returns
-// the full upstream record shape with NO hand-rolled subsetting (one of
-// the failure modes of the community MCP we replaced was dropping Atlas
-// custom fields like `atlasFirstSource` from its hand-rolled response
-// types — see #2843 handoff).
+// Read-only helpers — return the full upstream record shape with no
+// field subsetting. Custom Atlas fields (`atlasFirstSource`, `atlasIp`,
+// etc.) flow through automatically; any future workspace column appears
+// without requiring a client change.
 
 export interface TwentyCompany {
   readonly id?: string;
@@ -957,9 +960,9 @@ export async function getPerson(
     });
   }
 
+  let body: { data?: { person?: unknown } };
   try {
-    const body = (await response.json()) as { data?: { person?: TwentyPerson } };
-    return body.data?.person;
+    body = (await response.json()) as typeof body;
   } catch (err) {
     throw new TwentyClientError({
       message: `getPerson: unparseable response (${err instanceof Error ? err.message : String(err)})`,
@@ -967,6 +970,19 @@ export async function getPerson(
       operation: "getPerson",
     });
   }
+
+  const data = body.data;
+  if (data && "person" in data) {
+    return data.person as TwentyPerson | undefined;
+  }
+  // Twenty returned 2xx but the response shape doesn't include
+  // data.person at all — distinguish from a 404 so a drifted upstream
+  // schema doesn't look like "record absent".
+  throw new TwentyClientError({
+    message: "getPerson: unexpected response shape (expected data.person)",
+    status: response.status,
+    operation: "getPerson",
+  });
 }
 
 export interface SearchPeopleInput extends ListOptions {
@@ -981,9 +997,9 @@ export interface SearchPeopleInput extends ListOptions {
  *
  * IMPORTANT: never construct a bracket-nested filter like
  * `?filter[emails.primaryEmail][eq]=…` — Twenty silently ignores that
- * form and returns the unfiltered list. PR #2865 fixed
- * `findPersonByEmail`'s same regression. The unit tests assert the
- * documented shape AND forbid the bracket-nested form.
+ * form and returns the unfiltered list, which silently corrupts caller
+ * logic. The unit tests assert the documented shape AND forbid the
+ * bracket-nested form.
  *
  * When multiple criteria are supplied they are AND'd via Twenty's
  * top-level `,` join — `?filter=A[eq]:x,B[like]:%y%`.
@@ -1078,11 +1094,9 @@ export async function listNotes(
     });
   }
 
+  let body: { data?: { notes?: unknown } };
   try {
-    const body = (await response.json()) as { data?: { notes?: TwentyNoteFull[] } };
-    const list = body.data?.notes;
-    if (Array.isArray(list)) return list;
-    return [];
+    body = (await response.json()) as typeof body;
   } catch (err) {
     throw new TwentyClientError({
       message: `listNotes: unparseable response (${err instanceof Error ? err.message : String(err)})`,
@@ -1090,6 +1104,16 @@ export async function listNotes(
       operation: "listNotes",
     });
   }
+
+  const list = body.data?.notes;
+  if (Array.isArray(list)) return list as TwentyNoteFull[];
+  // Fail loud on shape drift — silent `[]` would let wipeWorkspace report
+  // "nothing to delete" when the Twenty response shape actually changed.
+  throw new TwentyClientError({
+    message: "listNotes: unexpected response shape (expected data.notes to be an array)",
+    status: response.status,
+    operation: "listNotes",
+  });
 }
 
 /** List Companies — unfiltered. Returns the raw upstream array. */
@@ -1116,11 +1140,9 @@ export async function listCompanies(
     });
   }
 
+  let body: { data?: { companies?: unknown } };
   try {
-    const body = (await response.json()) as { data?: { companies?: TwentyCompany[] } };
-    const list = body.data?.companies;
-    if (Array.isArray(list)) return list;
-    return [];
+    body = (await response.json()) as typeof body;
   } catch (err) {
     throw new TwentyClientError({
       message: `listCompanies: unparseable response (${err instanceof Error ? err.message : String(err)})`,
@@ -1128,6 +1150,14 @@ export async function listCompanies(
       operation: "listCompanies",
     });
   }
+
+  const list = body.data?.companies;
+  if (Array.isArray(list)) return list as TwentyCompany[];
+  throw new TwentyClientError({
+    message: "listCompanies: unexpected response shape (expected data.companies to be an array)",
+    status: response.status,
+    operation: "listCompanies",
+  });
 }
 
 export interface SearchCompaniesInput extends ListOptions {
@@ -1180,11 +1210,9 @@ export async function searchCompanies(
     });
   }
 
+  let body: { data?: { companies?: unknown } };
   try {
-    const body = (await response.json()) as { data?: { companies?: TwentyCompany[] } };
-    const list = body.data?.companies;
-    if (Array.isArray(list)) return list;
-    return [];
+    body = (await response.json()) as typeof body;
   } catch (err) {
     throw new TwentyClientError({
       message: `searchCompanies: unparseable response (${err instanceof Error ? err.message : String(err)})`,
@@ -1192,20 +1220,21 @@ export async function searchCompanies(
       operation: "searchCompanies",
     });
   }
+
+  const list = body.data?.companies;
+  if (Array.isArray(list)) return list as TwentyCompany[];
+  throw new TwentyClientError({
+    message: "searchCompanies: unexpected response shape (expected data.companies to be an array)",
+    status: response.status,
+    operation: "searchCompanies",
+  });
 }
 
-// ─────────────────────────────────────────────────────────────────────
-//  Delete tools
-// ─────────────────────────────────────────────────────────────────────
-//
-// `DELETE /rest/{object}/{id}?soft_delete=<bool>` — Twenty defaults to
-// `false` (hard delete) per its OpenAPI spec. Soft-deleted records are
-// excluded from list resolvers but Twenty's server-side duplicate
-// detection still trips on them when creating a new Person with the
-// same primary email. Internal-tools usage (scripts/twenty-mcp.ts wipe
-// + manual cleanup) wants hard delete; we make the default explicit on
-// the wire so a future Twenty default change doesn't silently flip our
-// semantics.
+// `DELETE /rest/{object}/{id}?soft_delete=<bool>` — soft-deleted records
+// still trip Twenty's server-side duplicate detection on upsertPerson, so
+// "hard delete" is the right default for cleanup paths. The wire param
+// is sent explicitly so a future upstream default flip can't silently
+// change our semantics.
 
 export interface DeleteOptions {
   /** Defaults to false (hard delete). Pass true to send `?soft_delete=true`. */
@@ -1269,76 +1298,157 @@ export async function deleteCompany(
 }
 
 export interface WipeWorkspaceOptions {
-  /** When true, list everything but don't delete — returns the counts only. */
+  /**
+   * When true (default), list one page per object type but issue no
+   * DELETEs — returns sample counts so the caller can preview the wipe.
+   * Defaults to true so the destructive path requires explicit opt-in.
+   */
   readonly dryRun?: boolean;
   /** Limit per page during enumeration; defaults to 60. */
   readonly pageLimit?: number;
-  /** Safety cap on total records visited across all object types. Default 10_000. */
+  /**
+   * Safety cap on records visited per object type (not summed across
+   * types). Default 10_000. Hitting the cap sets `truncated` to true on
+   * the returned shape.
+   */
   readonly maxRecords?: number;
 }
 
-export interface WipeWorkspaceResult {
-  readonly dryRun: boolean;
-  readonly peopleDeleted: number;
-  readonly notesDeleted: number;
-  readonly companiesDeleted: number;
-  readonly truncated: boolean;
+/**
+ * Per-record delete failure surfaced from a live wipe. Accumulated
+ * inside the result so a transient 5xx mid-wipe can't be mistaken for
+ * a clean run — the caller sees both the progress made and the records
+ * left behind.
+ */
+export interface WipeWorkspaceError {
+  readonly objectType: "note" | "person" | "company";
+  readonly id: string;
+  readonly status: number;
+  readonly message: string;
 }
 
+interface WipeTruncation {
+  readonly notes: boolean;
+  readonly people: boolean;
+  readonly companies: boolean;
+}
+
+export type WipeWorkspaceResult =
+  | {
+      readonly dryRun: true;
+      readonly notesSampled: number;
+      readonly peopleSampled: number;
+      readonly companiesSampled: number;
+      readonly truncated: WipeTruncation;
+    }
+  | {
+      readonly dryRun: false;
+      readonly notesDeleted: number;
+      readonly peopleDeleted: number;
+      readonly companiesDeleted: number;
+      readonly truncated: WipeTruncation;
+      readonly errors: ReadonlyArray<WipeWorkspaceError>;
+    };
+
 /**
- * Hard-delete every Person, Note, and Company in the workspace.
+ * Hard-delete every Note, Person, and Company in the workspace, or in
+ * dry-run mode sample one page per object type to preview the wipe.
  *
- * Internal-tools only — invoked from `scripts/twenty-mcp.ts wipe`. Not
- * called by `ee/src/saas-crm/` or any production code path. The wipe
- * order is notes → people → companies so dangling NoteTargets don't
- * survive (deleting a Note cascades the NoteTargets server-side per
- * Twenty's referential rules; we don't enumerate them here). Companies
- * last so a Person.companyId reference doesn't dangle mid-wipe.
+ * Iteration order is notes → people → companies. Notes go first so the
+ * NoteTarget rows referencing them are released before the People they
+ * point at disappear; Companies go last because Twenty's FK behavior on
+ * Person.companyId rejects (or, depending on workspace config, leaves
+ * orphans on) Company deletes while People still reference them.
  *
- * Pagination shape: lists `pageLimit` at a time, deletes the page,
- * re-lists. Twenty's cursor pagination would also work but a simple
- * "delete the first page until the table is empty" loop is sufficient
- * because deletes shift the cursor.
+ * Pagination: lists `pageLimit` at a time, deletes the page, re-lists.
+ * Twenty's cursor pagination would also work but a "delete-then-relist"
+ * loop is sufficient because deletes shift the cursor.
+ *
+ * Safety: `dryRun` defaults to true. `maxRecords` is enforced per
+ * object type, not summed, so a large Notes table can't silently starve
+ * the People and Companies drains.
  */
 export async function wipeWorkspace(
   config: TwentyClientConfig,
   opts?: WipeWorkspaceOptions,
 ): Promise<WipeWorkspaceResult> {
-  const dryRun = opts?.dryRun === true;
+  const dryRun = opts?.dryRun !== false;
   const pageLimit = opts?.pageLimit ?? 60;
   const maxRecords = opts?.maxRecords ?? 10_000;
 
-  let visited = 0;
-  let truncated = false;
+  const errors: WipeWorkspaceError[] = [];
 
   async function drain<T extends { id?: string }>(
+    objectType: WipeWorkspaceError["objectType"],
     list: (config: TwentyClientConfig, listOpts: ListOptions) => Promise<T[]>,
     del: (config: TwentyClientConfig, id: string) => Promise<void>,
-  ): Promise<number> {
-    let deleted = 0;
-    // Loop until the upstream returns an empty page. Cap with maxRecords.
+  ): Promise<{ count: number; truncated: boolean }> {
+    let count = 0;
+    let visited = 0;
     while (visited < maxRecords) {
       const page = await list(config, { limit: pageLimit });
-      if (page.length === 0) return deleted;
+      if (page.length === 0) return { count, truncated: false };
       for (const record of page) {
         if (visited >= maxRecords) {
-          truncated = true;
-          return deleted;
+          return { count, truncated: true };
         }
         visited++;
         if (!record.id) continue;
-        if (!dryRun) await del(config, record.id);
-        deleted++;
+        if (dryRun) {
+          count++;
+          continue;
+        }
+        try {
+          await del(config, record.id);
+          count++;
+        } catch (err) {
+          if (err instanceof TwentyClientError) {
+            errors.push({
+              objectType,
+              id: record.id,
+              status: err.status,
+              message: err.message,
+            });
+          } else {
+            errors.push({
+              objectType,
+              id: record.id,
+              status: 0,
+              message: err instanceof Error ? err.message : String(err),
+            });
+          }
+        }
       }
-      if (dryRun) return deleted; // one page is enough to estimate
+      if (dryRun) return { count, truncated: false };
     }
-    truncated = true;
-    return deleted;
+    return { count, truncated: true };
   }
 
-  const notesDeleted = await drain(listNotes, (c, id) => deleteNote(c, id));
-  const peopleDeleted = await drain(listPeople, (c, id) => deletePerson(c, id));
-  const companiesDeleted = await drain(listCompanies, (c, id) => deleteCompany(c, id));
+  const notes = await drain("note", listNotes, (c, id) => deleteNote(c, id));
+  const people = await drain("person", listPeople, (c, id) => deletePerson(c, id));
+  const companies = await drain("company", listCompanies, (c, id) => deleteCompany(c, id));
 
-  return { dryRun, peopleDeleted, notesDeleted, companiesDeleted, truncated };
+  const truncated: WipeTruncation = {
+    notes: notes.truncated,
+    people: people.truncated,
+    companies: companies.truncated,
+  };
+
+  if (dryRun) {
+    return {
+      dryRun: true,
+      notesSampled: notes.count,
+      peopleSampled: people.count,
+      companiesSampled: companies.count,
+      truncated,
+    };
+  }
+  return {
+    dryRun: false,
+    notesDeleted: notes.count,
+    peopleDeleted: people.count,
+    companiesDeleted: companies.count,
+    truncated,
+    errors,
+  };
 }

--- a/scripts/twenty-mcp.ts
+++ b/scripts/twenty-mcp.ts
@@ -1,36 +1,13 @@
 #!/usr/bin/env bun
 /**
- * scripts/twenty-mcp.ts — internal-tools Twenty CRM MCP server.
- *
- * Single-file MCP server that exposes the in-repo TwentyClient
- * (`plugins/twenty/src/client.ts`) over stdio for local Claude Code
- * sessions querying or manipulating `crm.useatlas.dev`. Replaces the
- * community `twenty-mcp-server` (jezweb) we used previously — the
- * community MCP shipped multiple failure modes (silent empty-result
- * filters, broken metadata GraphQL, hand-rolled response subsetting
- * that dropped Atlas custom fields, missing delete verbs).
- *
- * INTERNAL ONLY. NOT a product surface. NOT published to npm.
- * Reuses the same TwentyClient that backs `ee/src/saas-crm/` so auth,
- * retry, filter syntax (#2865), and schema probe (#2860) stay aligned
- * with production.
+ * Internal-tools Twenty CRM MCP server. Exposes the in-repo
+ * TwentyClient over stdio for local Claude Code sessions.
  *
  * Setup:
  *   claude mcp add --scope user twenty-crm \
  *     --env TWENTY_API_KEY="$TWENTY_API_KEY" \
  *     --env TWENTY_BASE_URL=https://crm.useatlas.dev \
  *     -- bun /path/to/atlas/scripts/twenty-mcp.ts
- *
- * Or in claude_desktop_config.json:
- *   {
- *     "mcpServers": {
- *       "twenty-crm": {
- *         "command": "bun",
- *         "args": ["/path/to/atlas/scripts/twenty-mcp.ts"],
- *         "env": { "TWENTY_API_KEY": "...", "TWENTY_BASE_URL": "https://crm.useatlas.dev" }
- *       }
- *     }
- *   }
  *
  * Logging contract: stdout is reserved for JSON-RPC. All diagnostic
  * messages go to stderr so they don't corrupt the protocol stream.
@@ -58,6 +35,7 @@ import {
   TwentyClientError,
   type TwentyClientConfig,
 } from "../plugins/twenty/src/client.js";
+import type { AtlasEventSource } from "../plugins/twenty/src/lead-normalizer.js";
 
 const SERVER_NAME = "atlas-twenty-mcp";
 const SERVER_VERSION = "0.1.0";
@@ -110,6 +88,9 @@ async function run<T>(
         operation: e.operation,
         upstreamCode: e.upstreamCode,
         retryAfterMs: e.retryAfterMs,
+        // Preserve orphanedNoteId on createNote partial failures so the
+        // operator can clean up the unlinked note manually.
+        ...(e.orphanedNoteId !== undefined && { orphanedNoteId: e.orphanedNoteId }),
       });
     }
     return err(`${toolName}: ${e instanceof Error ? e.message : String(e)}`);
@@ -123,12 +104,18 @@ const eventSourceSchema = z.enum([
   "CONVERSION",
   "OTHER",
 ]);
+// Fail the build if the Zod enum drifts from the TS union exported by
+// lead-normalizer — the two are parallel definitions and would otherwise
+// silently disagree.
+type _EventSourceDriftCheck = z.infer<typeof eventSourceSchema> extends AtlasEventSource
+  ? AtlasEventSource extends z.infer<typeof eventSourceSchema>
+    ? true
+    : never
+  : never;
+const _eventSourceDriftCheck: _EventSourceDriftCheck = true;
+void _eventSourceDriftCheck;
 
 const server = new McpServer({ name: SERVER_NAME, version: SERVER_VERSION });
-
-// ─────────────────────────────────────────────────────────────────────
-//  Read tools
-// ─────────────────────────────────────────────────────────────────────
 
 server.registerTool(
   "listPeople",
@@ -225,10 +212,6 @@ server.registerTool(
     }),
 );
 
-// ─────────────────────────────────────────────────────────────────────
-//  Write tools
-// ─────────────────────────────────────────────────────────────────────
-
 server.registerTool(
   "upsertPerson",
   {
@@ -271,13 +254,9 @@ server.registerTool(
   async (args) => run("createNote", () => createNote(config, args)),
 );
 
-// ─────────────────────────────────────────────────────────────────────
-//  Delete tools — HARD DELETE by default (?soft_delete=false)
-// ─────────────────────────────────────────────────────────────────────
-//
-// Soft-deleted records still trip Twenty's server-side duplicate
-// detection on upsertPerson. For internal-tools cleanup the default
-// must be hard delete; callers who want soft delete pass softDelete:true.
+// HARD DELETE by default — soft-deleted records still trip Twenty's
+// server-side duplicate detection on upsertPerson, so cleanup paths need
+// hard delete to actually free the email for re-creation.
 
 server.registerTool(
   "deletePerson",
@@ -331,9 +310,9 @@ server.registerTool(
   "wipeWorkspace",
   {
     description:
-      "DESTRUCTIVE — hard-delete every Note, Person, and Company in the Twenty workspace. Default is dryRun:true (returns counts from a single sampled page, no deletes). Pass dryRun:false to actually delete. Capped at maxRecords (default 10000) — sets truncated:true when the cap is hit.",
+      "DESTRUCTIVE — hard-delete every Note, Person, and Company in the Twenty workspace. Defaults to dryRun:true (one sampled page per object type, no deletes). Pass dryRun:false to actually delete. Capped per-object-type at maxRecords (default 10000) — `truncated.{notes,people,companies}` flags which drains hit the cap; live runs surface per-record delete failures in `errors`.",
     inputSchema: {
-      dryRun: z.boolean().optional().default(true),
+      dryRun: z.boolean().optional(),
       pageLimit: z.number().int().positive().optional(),
       maxRecords: z.number().int().positive().optional(),
     },
@@ -341,16 +320,12 @@ server.registerTool(
   async ({ dryRun, pageLimit, maxRecords }) =>
     run("wipeWorkspace", () =>
       wipeWorkspace(config, {
-        dryRun: dryRun !== false,
+        ...(dryRun !== undefined && { dryRun }),
         ...(pageLimit !== undefined && { pageLimit }),
         ...(maxRecords !== undefined && { maxRecords }),
       }),
     ),
 );
-
-// ─────────────────────────────────────────────────────────────────────
-//  Boot
-// ─────────────────────────────────────────────────────────────────────
 
 async function main(): Promise<void> {
   const transport = new StdioServerTransport();

--- a/scripts/twenty-mcp.ts
+++ b/scripts/twenty-mcp.ts
@@ -1,0 +1,388 @@
+#!/usr/bin/env bun
+/**
+ * scripts/twenty-mcp.ts — internal-tools Twenty CRM MCP server.
+ *
+ * Single-file MCP server that exposes the in-repo TwentyClient
+ * (`plugins/twenty/src/client.ts`) over stdio for local Claude Code
+ * sessions querying or manipulating `crm.useatlas.dev`. Replaces the
+ * community `twenty-mcp-server` (jezweb) we used previously — the
+ * community MCP shipped multiple failure modes (silent empty-result
+ * filters, broken metadata GraphQL, hand-rolled response subsetting
+ * that dropped Atlas custom fields, missing delete verbs).
+ *
+ * INTERNAL ONLY. NOT a product surface. NOT published to npm.
+ * Reuses the same TwentyClient that backs `ee/src/saas-crm/` so auth,
+ * retry, filter syntax (#2865), and schema probe (#2860) stay aligned
+ * with production.
+ *
+ * Setup:
+ *   claude mcp add --scope user twenty-crm \
+ *     --env TWENTY_API_KEY="$TWENTY_API_KEY" \
+ *     --env TWENTY_BASE_URL=https://crm.useatlas.dev \
+ *     -- bun /path/to/atlas/scripts/twenty-mcp.ts
+ *
+ * Or in claude_desktop_config.json:
+ *   {
+ *     "mcpServers": {
+ *       "twenty-crm": {
+ *         "command": "bun",
+ *         "args": ["/path/to/atlas/scripts/twenty-mcp.ts"],
+ *         "env": { "TWENTY_API_KEY": "...", "TWENTY_BASE_URL": "https://crm.useatlas.dev" }
+ *       }
+ *     }
+ *   }
+ *
+ * Logging contract: stdout is reserved for JSON-RPC. All diagnostic
+ * messages go to stderr so they don't corrupt the protocol stream.
+ */
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { z } from "zod";
+
+import {
+  upsertPerson,
+  createNote,
+  listPeople,
+  getPerson,
+  searchPeople,
+  listNotes,
+  listCompanies,
+  searchCompanies,
+  deletePerson,
+  deleteNote,
+  deleteCompany,
+  wipeWorkspace,
+  getPersonRestSchema,
+  TwentyClientError,
+  type TwentyClientConfig,
+} from "../plugins/twenty/src/client.js";
+
+const SERVER_NAME = "atlas-twenty-mcp";
+const SERVER_VERSION = "0.1.0";
+
+function requireEnv(name: string): string {
+  const v = process.env[name];
+  if (!v || v.trim().length === 0) {
+    process.stderr.write(
+      `[atlas-twenty-mcp] Missing required env: ${name}. Aborting.\n`,
+    );
+    process.exit(1);
+  }
+  return v;
+}
+
+const config: TwentyClientConfig = {
+  apiKey: requireEnv("TWENTY_API_KEY"),
+  baseUrl: requireEnv("TWENTY_BASE_URL"),
+};
+
+function ok(payload: unknown): CallToolResult {
+  return {
+    content: [{ type: "text", text: JSON.stringify(payload, null, 2) }],
+  };
+}
+
+function err(message: string, extras?: Record<string, unknown>): CallToolResult {
+  return {
+    content: [
+      {
+        type: "text",
+        text: JSON.stringify({ error: message, ...extras }, null, 2),
+      },
+    ],
+    isError: true,
+  };
+}
+
+async function run<T>(
+  toolName: string,
+  fn: () => Promise<T>,
+): Promise<CallToolResult> {
+  try {
+    const result = await fn();
+    return ok(result === undefined ? { ok: true } : result);
+  } catch (e) {
+    if (e instanceof TwentyClientError) {
+      return err(`${toolName}: ${e.message}`, {
+        status: e.status,
+        operation: e.operation,
+        upstreamCode: e.upstreamCode,
+        retryAfterMs: e.retryAfterMs,
+      });
+    }
+    return err(`${toolName}: ${e instanceof Error ? e.message : String(e)}`);
+  }
+}
+
+const eventSourceSchema = z.enum([
+  "DEMO",
+  "SIGNUP",
+  "SALES_FORM",
+  "CONVERSION",
+  "OTHER",
+]);
+
+const server = new McpServer({ name: SERVER_NAME, version: SERVER_VERSION });
+
+// ─────────────────────────────────────────────────────────────────────
+//  Read tools
+// ─────────────────────────────────────────────────────────────────────
+
+server.registerTool(
+  "listPeople",
+  {
+    description:
+      "List Twenty People records. Returns the full upstream record shape including Atlas custom fields (atlasFirstSource, atlasLastSource, atlasIp, atlasStripeCustomerId). Optional pagination via limit + starting_after cursor (use the last record's id from a previous page).",
+    inputSchema: {
+      limit: z.number().int().positive().optional(),
+      startingAfter: z.string().optional(),
+      endingBefore: z.string().optional(),
+    },
+  },
+  async (args) => run("listPeople", () => listPeople(config, args)),
+);
+
+server.registerTool(
+  "getPerson",
+  {
+    description:
+      "Fetch a single Twenty Person by id. Returns the full record (including Atlas custom fields). Returns null when the id doesn't exist.",
+    inputSchema: { id: z.string().min(1) },
+  },
+  async ({ id }) =>
+    run("getPerson", async () => (await getPerson(config, id)) ?? null),
+);
+
+server.registerTool(
+  "searchPeople",
+  {
+    description:
+      "Search Twenty People by email (exact match) and/or nameLike (substring on firstName OR lastName). Uses Twenty's documented filter syntax field[op]:value. At least one of email or nameLike is required.",
+    inputSchema: {
+      email: z.string().optional(),
+      nameLike: z.string().optional(),
+      limit: z.number().int().positive().optional(),
+    },
+  },
+  async (args) => run("searchPeople", () => searchPeople(config, args)),
+);
+
+server.registerTool(
+  "listCompanies",
+  {
+    description:
+      "List Twenty Company records with optional pagination. Returns full upstream shape (name, domainName, employees, annualRecurringRevenue, etc.).",
+    inputSchema: {
+      limit: z.number().int().positive().optional(),
+      startingAfter: z.string().optional(),
+      endingBefore: z.string().optional(),
+    },
+  },
+  async (args) => run("listCompanies", () => listCompanies(config, args)),
+);
+
+server.registerTool(
+  "searchCompanies",
+  {
+    description:
+      "Search Twenty Companies by nameLike and/or domainLike (substring match). Uses Twenty's field[op]:value filter syntax.",
+    inputSchema: {
+      nameLike: z.string().optional(),
+      domainLike: z.string().optional(),
+      limit: z.number().int().positive().optional(),
+    },
+  },
+  async (args) => run("searchCompanies", () => searchCompanies(config, args)),
+);
+
+server.registerTool(
+  "listNotes",
+  {
+    description:
+      "List Twenty Note records with optional pagination. Notes are linked to People via noteTargets (targetPersonId).",
+    inputSchema: {
+      limit: z.number().int().positive().optional(),
+      startingAfter: z.string().optional(),
+      endingBefore: z.string().optional(),
+    },
+  },
+  async (args) => run("listNotes", () => listNotes(config, args)),
+);
+
+server.registerTool(
+  "getPersonRestSchema",
+  {
+    description:
+      "Fetch the Twenty workspace's Person schema by parsing /rest/open-api/core. Returns the full property name set — the authoritative answer to 'which Atlas custom fields exist on this workspace'. Use when debugging field-missing errors.",
+    inputSchema: {},
+  },
+  async () =>
+    run("getPersonRestSchema", async () => {
+      const { fields } = await getPersonRestSchema(config);
+      return { fields: Array.from(fields).sort() };
+    }),
+);
+
+// ─────────────────────────────────────────────────────────────────────
+//  Write tools
+// ─────────────────────────────────────────────────────────────────────
+
+server.registerTool(
+  "upsertPerson",
+  {
+    description:
+      "Upsert a Twenty Person by email. Preserves atlasFirstSource (sticky after first set) and updates atlasLastSource on every call. Matches the production SaaS CRM pipeline behavior (ee/src/saas-crm/) exactly — uses the same TwentyClient.",
+    inputSchema: {
+      email: z.string().email(),
+      eventSource: eventSourceSchema,
+      firstName: z.string().optional(),
+      lastName: z.string().optional(),
+      atlasIp: z.string().optional(),
+      atlasStripeCustomerId: z.string().optional(),
+    },
+  },
+  async ({ email, eventSource, firstName, lastName, atlasIp, atlasStripeCustomerId }) =>
+    run("upsertPerson", () =>
+      upsertPerson(config, {
+        email,
+        eventSource,
+        ...(firstName || lastName ? { name: { firstName, lastName } } : {}),
+        customFields: {
+          ...(atlasIp && { atlasIp }),
+          ...(atlasStripeCustomerId && { atlasStripeCustomerId }),
+        },
+      }),
+    ),
+);
+
+server.registerTool(
+  "createNote",
+  {
+    description:
+      "Create a Note in Twenty and link it to a Person via NoteTarget (two-step: POST /rest/notes then POST /rest/noteTargets). Body is stored as markdown under bodyV2.markdown.",
+    inputSchema: {
+      personId: z.string().min(1),
+      title: z.string().min(1),
+      body: z.string(),
+    },
+  },
+  async (args) => run("createNote", () => createNote(config, args)),
+);
+
+// ─────────────────────────────────────────────────────────────────────
+//  Delete tools — HARD DELETE by default (?soft_delete=false)
+// ─────────────────────────────────────────────────────────────────────
+//
+// Soft-deleted records still trip Twenty's server-side duplicate
+// detection on upsertPerson. For internal-tools cleanup the default
+// must be hard delete; callers who want soft delete pass softDelete:true.
+
+server.registerTool(
+  "deletePerson",
+  {
+    description:
+      "Hard-delete a Twenty Person by id (?soft_delete=false). 404 is treated as idempotent. Pass softDelete:true to soft-delete instead — but note that soft-deleted records still block upsertPerson duplicate detection.",
+    inputSchema: {
+      id: z.string().min(1),
+      softDelete: z.boolean().optional(),
+    },
+  },
+  async ({ id, softDelete }) =>
+    run("deletePerson", () =>
+      deletePerson(config, id, softDelete !== undefined ? { softDelete } : undefined),
+    ),
+);
+
+server.registerTool(
+  "deleteNote",
+  {
+    description:
+      "Hard-delete a Twenty Note by id (?soft_delete=false). 404 is treated as idempotent.",
+    inputSchema: {
+      id: z.string().min(1),
+      softDelete: z.boolean().optional(),
+    },
+  },
+  async ({ id, softDelete }) =>
+    run("deleteNote", () =>
+      deleteNote(config, id, softDelete !== undefined ? { softDelete } : undefined),
+    ),
+);
+
+server.registerTool(
+  "deleteCompany",
+  {
+    description:
+      "Hard-delete a Twenty Company by id (?soft_delete=false). 404 is treated as idempotent.",
+    inputSchema: {
+      id: z.string().min(1),
+      softDelete: z.boolean().optional(),
+    },
+  },
+  async ({ id, softDelete }) =>
+    run("deleteCompany", () =>
+      deleteCompany(config, id, softDelete !== undefined ? { softDelete } : undefined),
+    ),
+);
+
+server.registerTool(
+  "wipeWorkspace",
+  {
+    description:
+      "DESTRUCTIVE — hard-delete every Note, Person, and Company in the Twenty workspace. Default is dryRun:true (returns counts from a single sampled page, no deletes). Pass dryRun:false to actually delete. Capped at maxRecords (default 10000) — sets truncated:true when the cap is hit.",
+    inputSchema: {
+      dryRun: z.boolean().optional().default(true),
+      pageLimit: z.number().int().positive().optional(),
+      maxRecords: z.number().int().positive().optional(),
+    },
+  },
+  async ({ dryRun, pageLimit, maxRecords }) =>
+    run("wipeWorkspace", () =>
+      wipeWorkspace(config, {
+        dryRun: dryRun !== false,
+        ...(pageLimit !== undefined && { pageLimit }),
+        ...(maxRecords !== undefined && { maxRecords }),
+      }),
+    ),
+);
+
+// ─────────────────────────────────────────────────────────────────────
+//  Boot
+// ─────────────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+
+  let shuttingDown = false;
+  const shutdown = async (): Promise<void> => {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    try {
+      await server.close();
+    } catch (e) {
+      process.stderr.write(
+        `[atlas-twenty-mcp] Error closing server: ${e instanceof Error ? e.message : String(e)}\n`,
+      );
+    }
+    process.exit(0);
+  };
+  process.on("SIGINT", shutdown);
+  process.on("SIGTERM", shutdown);
+
+  process.stderr.write(
+    `[atlas-twenty-mcp] ${SERVER_NAME}@${SERVER_VERSION} running on stdio (base=${config.baseUrl})\n`,
+  );
+}
+
+main().catch((e) => {
+  process.stderr.write(
+    `[atlas-twenty-mcp] Fatal: ${e instanceof Error ? e.message : String(e)}\n`,
+  );
+  if (e instanceof Error && e.stack) {
+    process.stderr.write(`${e.stack}\n`);
+  }
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Single-file MCP server at `scripts/twenty-mcp.ts` that exposes the in-repo `TwentyClient` over stdio for local Claude Code sessions querying `crm.useatlas.dev`. Replaces the community `jezweb/twenty-mcp` (npm: `twenty-mcp-server`), which actively cost us hours during 1.6.0 manual verification.
- Adds 13 read/write/delete methods to `plugins/twenty/src/client.ts`: `listPeople`, `getPerson`, `searchPeople`, `listCompanies`, `searchCompanies`, `listNotes`, `deletePerson`, `deleteNote`, `deleteCompany`, `wipeWorkspace`. All write tools (`upsertPerson`, `createNote`) already existed.
- Reuses the exact same `TwentyClient` that backs `ee/src/saas-crm/`, so auth, retry, filter syntax (PR #2865), and OpenAPI schema probe (hotfix #2860) stay aligned with production.

## Why this and not `@useatlas/mcp-twenty`

Original issue #2843 scoped a product surface (`bunx @useatlas/mcp-twenty start`, OTel parity, etc.). On reframe — this is internal-only tooling for our local Claude Code sessions, not something to publish. The bigger product question ("point an agent at any OpenAPI spec and let it query through Atlas sandboxes") is being lifted into a separate PRD against milestone #54 (Generic REST / Non-SQL Datasources). Closing #2843 as resolved-by-this-shape; the OpenAPI-generic agent gets its own tracking issue.

## Why we retired jezweb

Verified during 1.6.0 manual verification (test plan A1–A4):

| Symptom | Root cause |
|---|---|
| `search_contacts` returned `[]` for known emails | Twenty's standard list resolvers apply a default soft-delete filter; community MCP read path inherited it |
| `get_field_metadata` errored `Unknown type "ObjectFilterInput"` | Twenty renamed it to `ObjectRecordFilterInput` — same drift trap that drove hotfix #2860 |
| `get_contact` omitted `atlasFirstSource` / `atlasIp` / etc. | Hand-rolled response subset dropped Atlas custom fields — the whole reason 1.6.0 exists |
| `get_activities` returned `Author: Unknown` for every Note | Queried wrong join column (`personId` vs `targetPersonId`) |
| No write-side cleanup verbs | Workspace wipe required hand-curling `DELETE /rest/{people,notes,noteTargets}/{id}` |
| No filter-syntax validation | Would have shipped the same `?filter[field][op]=value` bug PR #2865 fixed |

## Filter syntax discipline

`searchPeople` and `searchCompanies` use Twenty's documented form from its own OpenAPI spec:

```
?filter=emails.primaryEmail[eq]:foo@example.com
?filter=or(name.firstName[like]:%matt%,name.lastName[like]:%matt%)
```

The bracket-nested form `?filter[emails.primaryEmail][eq]=foo` is silently ignored by Twenty (per the PR #2865 probe table). Tests assert the documented shape AND forbid the broken form — `expect(url).not.toContain("filter[")`.

## `soft_delete` on the wire

All delete verbs send `?soft_delete=false` explicitly (hard delete by default). Soft-deleted records still trip Twenty's server-side duplicate detection on `upsertPerson`, so internal-tools cleanup needs hard delete. Pass `softDelete: true` to override. The explicit query param means a future Twenty default flip can't silently change our semantics.

## `wipeWorkspace`

Drains notes → people → companies. Iteration order matters — deleting Notes first cascades NoteTargets server-side, and Companies last so `Person.companyId` references don't dangle mid-wipe.

- `dryRun: true` (default) samples one page per object type with no DELETEs
- `maxRecords` (default 10_000) caps total records visited — returns `truncated: true` when hit
- 404 on individual delete is idempotent (already gone)

## Setup (replaces jezweb in `claude_desktop_config.json`)

```json
{
  "mcpServers": {
    "twenty-crm": {
      "command": "bun",
      "args": ["/path/to/atlas/scripts/twenty-mcp.ts"],
      "env": {
        "TWENTY_API_KEY": "...",
        "TWENTY_BASE_URL": "https://crm.useatlas.dev"
      }
    }
  }
}
```

## Test plan

- [x] `bun test plugins/twenty/__tests__/client.test.ts` — 63 pass (14 new), 0 fail
- [x] `bun run test` in `plugins/twenty/` — 161 pass, 0 fail
- [x] `bun test ee/src/saas-crm/__tests__/saas-crm.test.ts` — 41 pass, 0 fail (downstream consumer unaffected)
- [x] `bun run type` — clean
- [x] `bun run lint` — clean
- [x] `bash scripts/check-twenty-resolver-imports.sh` — passes (#2850 gate intact)
- [x] Smoke: `TWENTY_API_KEY=… TWENTY_BASE_URL=… bun scripts/twenty-mcp.ts` boots, JSON-RPC `initialize` + `tools/list` round-trip, 13 tools registered
- [ ] After merge: swap in `claude mcp add` against crm.useatlas.dev, verify read tools return real data (not jezweb's `[]` lie), delete verbs actually hard-delete

## Notes

- Internal-tools only. `scripts/twenty-mcp.ts` is excluded from the root tsconfig like other top-level scripts.
- `zod` added to root devDependencies because the script lives outside the workspace tree.
- No production code touched — `ee/src/saas-crm/` and `plugins/twenty/src/index.ts` plugin exports unchanged.

Closes #2843

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/2867"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782430889&installation_id=135337507&pr_number=2867&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F2867&signature=2f5c9a03bef9fe4c3f53c1b17e625c0167a22ca62d51a54ae7b5b438b0e13c60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->