### PR TITLE
feat(cli): atlas ops smoke-crm — automated CRM lead-capture verification

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -203,6 +203,7 @@
         "@clickhouse/client": "^1.18.2",
         "@duckdb/node-api": "^1.5.1-r.1",
         "@modelcontextprotocol/sdk": "^1.28.0",
+        "@useatlas/twenty": "workspace:*",
         "@useatlas/types": "workspace:*",
         "ai": "^6.0.141",
         "hono": "^4.12.9",

--- a/docs/development/verify-crm-changes-locally.md
+++ b/docs/development/verify-crm-changes-locally.md
@@ -66,19 +66,21 @@ bun run atlas -- ops smoke-crm \
 
 Pinned so chained scripts can branch on the failure mode:
 
-| Code | Meaning                                                    |
-|------|------------------------------------------------------------|
-| 0    | Clean diff — every expected Person + Note matches Twenty.  |
-| 1    | Usage error — bad args, missing env, fixture parse failure |
-| 2    | `crm_outbox` did not drain within `--timeout-seconds`.     |
-| 3    | Diff dirty — what Twenty observed ≠ what the fixture said. |
-| 4    | Wipe phase failed (FK cascade, network, etc.).             |
+| Code | Meaning                                                      |
+|------|--------------------------------------------------------------|
+| 0    | Clean diff — every expected Person + Note matches Twenty.    |
+| 1    | Usage error — bad args, missing env, fixture parse failure.  |
+| 2    | `crm_outbox` did not drain within `--timeout-seconds`.       |
+| 3    | Diff dirty — what Twenty observed ≠ what the fixture said.   |
+| 4    | Wipe phase failed (FK cascade, network, etc.).               |
+| 5    | Infrastructure failure — tenant DB unreachable, enqueue failed, outbox poll errored. Distinct from `1` so chained scripts can tell "bad CLI invocation" from "Postgres is down". |
 
 A diff-dirty exit (3) prints a structured report identifying:
 
 - Missing Persons (expected emails that aren't in Twenty).
-- Field mismatches (`atlasFirstSource` / `atlasLastSource` / `name.*`).
-- Missing Notes (expected note titles not attached to the right Person).
+- Field mismatches (`atlasFirstSource` / `atlasLastSource` / `atlasIp` / `atlasStripeCustomerId` / `name.*`).
+- Missing Notes (expected `title` + `body` not attached to the right Person — matched with multiplicity).
+- Duplicate observed Persons (same primary email appears more than once in Twenty — a `findPersonByEmail` dedupe regression).
 - Note count mismatches per Person (the signature of the #2865 bug —
   all expected Persons collapse onto one observed Person, and every
   expected Note piles up on it).

--- a/docs/development/verify-crm-changes-locally.md
+++ b/docs/development/verify-crm-changes-locally.md
@@ -1,0 +1,118 @@
+# How to verify CRM changes locally
+
+The `atlas ops smoke-crm` CLI mechanizes the manual A1–A4 / B7 / C9 / D12
+verification flow used during the 1.6.0 milestone. It exists because the
+filter-syntax regression in PR #2865 silently corrupted every customer
+Person record in production for several days before manual smoke caught
+it. Running this command on every PR that touches the CRM dispatch
+pipeline turns that into a one-line check.
+
+## When to run
+
+Run before opening any PR that touches:
+
+- `plugins/twenty/src/client.ts` — the Twenty REST client.
+- `plugins/twenty/src/lead-normalizer.ts` — the `AtlasLeadEvent`
+  → Twenty payload translation.
+- `ee/src/saas-crm/index.ts` — the SaaS dispatcher Layer.
+- `packages/api/src/lib/lead-outbox/outbox.ts` — the outbox flusher and
+  retry / dead-letter logic.
+- Anything that changes the wire format on `crm_outbox.payload`.
+
+It's a local-only check. The smoke command runs against your local
+Atlas dev DB and the live `crm.useatlas.dev` Twenty workspace, and is
+not wired into CI today (the CI integration depends on a CI-only
+Twenty workspace + secret-rotation strategy that isn't built yet).
+
+## Prerequisites
+
+1. `bun run db:up` — local Postgres + sandbox sidecar running.
+2. `bun run dev:api` — Atlas API booting, which starts the `crm_outbox`
+   flusher. The smoke command enqueues rows and waits for that flusher
+   to drain them.
+3. A Twenty API bearer token in the env (or pass `--twenty-api-key`).
+   For Atlas's own SaaS workspace, the token lives in the api service
+   on Railway as `TWENTY_API_KEY`; for a self-hosted Twenty, generate one
+   under Twenty → Settings → API & Webhooks.
+
+## Usage
+
+```bash
+# Required: a persona fixture. Default fixture lives at
+# scripts/test-fixtures/crm-personas.yml and covers 10 personas across
+# every lead variant (4× sales-form, 1 demo, 1 signup, 1 demo→signup
+# stickiness pair, 1 demo→demo idempotency pair).
+bun run atlas -- ops smoke-crm \
+  --personas ./scripts/test-fixtures/crm-personas.yml \
+  --twenty-api-key "$TWENTY_API_KEY"
+
+# Wipe the Twenty workspace before running — DESTRUCTIVE. Mirrors the
+# `ops wipe` double-confirm gate: needs BOTH the flag AND
+# ATLAS_SMOKE_WIPE_OK=1 in the env.
+ATLAS_SMOKE_WIPE_OK=1 \
+  bun run atlas -- ops smoke-crm \
+    --personas ./scripts/test-fixtures/crm-personas.yml \
+    --twenty-api-key "$TWENTY_API_KEY" \
+    --wipe-twenty
+
+# Tune the drain timeout (default 60s). The Twenty hosted instance can
+# be slow under spike load — raise this if you see TIMEOUT exits.
+bun run atlas -- ops smoke-crm \
+  --personas ./scripts/test-fixtures/crm-personas.yml \
+  --timeout-seconds 120
+```
+
+## Exit codes
+
+Pinned so chained scripts can branch on the failure mode:
+
+| Code | Meaning                                                    |
+|------|------------------------------------------------------------|
+| 0    | Clean diff — every expected Person + Note matches Twenty.  |
+| 1    | Usage error — bad args, missing env, fixture parse failure |
+| 2    | `crm_outbox` did not drain within `--timeout-seconds`.     |
+| 3    | Diff dirty — what Twenty observed ≠ what the fixture said. |
+| 4    | Wipe phase failed (FK cascade, network, etc.).             |
+
+A diff-dirty exit (3) prints a structured report identifying:
+
+- Missing Persons (expected emails that aren't in Twenty).
+- Field mismatches (`atlasFirstSource` / `atlasLastSource` / `name.*`).
+- Missing Notes (expected note titles not attached to the right Person).
+- Note count mismatches per Person (the signature of the #2865 bug —
+  all expected Persons collapse onto one observed Person, and every
+  expected Note piles up on it).
+
+## What this catches that the unit tests don't
+
+Mock-based unit tests can verify the URL the client constructs, but they
+can't verify Twenty actually interprets that URL correctly. The #2865
+filter syntax bug was invisible to mock tests because the URL substring
+matched both the correct and broken forms. The smoke command is the
+first check that asserts on Twenty's actual response — `N` distinct
+enqueues → `N` distinct Persons.
+
+## What this doesn't cover (manual still required)
+
+- **Form-layer concerns** — Cloudflare Turnstile, CSP, `<noscript>`
+  fallback, and the `/api/v1/contact` route's auth + rate-limit. These
+  remain manual steps A5 / A6 in `/tmp/atlas-1.6.0-test-plan.md`.
+- **Read-side datasource verification** — the analytics-side `demo_leads`
+  / `crm_outbox` query semantics live under a separate slice (#2728).
+- **Stripe → Twenty conversion stamping (D12)** — parked behind a flag
+  in the default fixture pending Stripe test-fixture wiring.
+
+## Extending the fixture
+
+Adding a persona is one block under `personas:` in
+`scripts/test-fixtures/crm-personas.yml`. The shape is the same as the
+`AtlasLeadEvent` discriminated union — `parseFixtureYaml` validates each
+persona's required-field set against its `source`. The parser fails
+loudly on the first invalid persona with a per-index error message;
+there's no "best-effort" parsing mode.
+
+The shipped fixture is deliberately small (10 personas) so the smoke
+command runs in under a minute on a local Postgres. If your change
+needs broader coverage, prefer a second fixture file over expanding the
+default — separate fixtures keep the manual + automated runs from
+diverging.

--- a/docs/development/verify-crm-changes-locally.md
+++ b/docs/development/verify-crm-changes-locally.md
@@ -94,9 +94,11 @@ enqueues → `N` distinct Persons.
 
 ## What this doesn't cover (manual still required)
 
-- **Form-layer concerns** — Cloudflare Turnstile, CSP, `<noscript>`
-  fallback, and the `/api/v1/contact` route's auth + rate-limit. These
-  remain manual steps A5 / A6 in `/tmp/atlas-1.6.0-test-plan.md`.
+- **Form-layer concerns** — Cloudflare Turnstile siteverify, CSP, the
+  `<noscript>` mailto fallback, and the `/api/v1/contact` route's auth +
+  rate-limit. The smoke command injects leads BELOW the form, so any
+  bug in the form layer itself needs a manual test (submit a form on
+  `/pricing` and confirm the resulting `crm_outbox` row).
 - **Read-side datasource verification** — the analytics-side `demo_leads`
   / `crm_outbox` query semantics live under a separate slice (#2728).
 - **Stripe → Twenty conversion stamping (D12)** — parked behind a flag

--- a/packages/cli/lib/smoke-crm/diff.ts
+++ b/packages/cli/lib/smoke-crm/diff.ts
@@ -49,6 +49,8 @@ export interface ObservedPerson {
   readonly email: string;
   readonly atlasFirstSource?: string;
   readonly atlasLastSource?: string;
+  readonly atlasIp?: string;
+  readonly atlasStripeCustomerId?: string;
   readonly name?: { firstName?: string; lastName?: string };
 }
 
@@ -80,8 +82,9 @@ export interface ObservedState {
  *    that carries them; later events win (matches the dispatcher's PATCH-
  *    every-write behaviour).
  *  - Notes: one per `sales-form` event. Same email with two sales-form
- *    events produces two Notes (the dispatcher creates a fresh note per
- *    dispatch — see #2729's idempotency contract).
+ *    events produces two Notes — each event lands in its own `crm_outbox`
+ *    row and each row produces one note. (#2729's idempotency contract
+ *    prevents double-create on retry *within* a row, not across rows.)
  */
 export function buildExpectedState(events: ReadonlyArray<AtlasLeadEvent>): ExpectedState {
   const persons = new Map<string, ExpectedPerson>();
@@ -154,6 +157,8 @@ export interface PersonMismatch {
   readonly field:
     | "atlasFirstSource"
     | "atlasLastSource"
+    | "atlasIp"
+    | "atlasStripeCustomerId"
     | "name.firstName"
     | "name.lastName";
   readonly expected: string;
@@ -216,6 +221,24 @@ export function computeDiff(
     }
     pushFieldMismatch(mismatchedPersons, e.email, "atlasFirstSource", e.atlasFirstSource, o.atlasFirstSource);
     pushFieldMismatch(mismatchedPersons, e.email, "atlasLastSource", e.atlasLastSource, o.atlasLastSource);
+    // Compare atlasIp / atlasStripeCustomerId ONLY when the fixture set them.
+    // The dispatcher writes through whatever the lead event carries; expected-
+    // side absence means "we didn't dispatch one, so don't care what Twenty has".
+    // The presence-only check catches the load-bearing case (#2737 — Stripe
+    // stamp lands on the wrong Twenty Person) without false-positiving on
+    // sales-form personas that don't supply an IP.
+    if (e.atlasIp) {
+      pushFieldMismatch(mismatchedPersons, e.email, "atlasIp", e.atlasIp, o.atlasIp);
+    }
+    if (e.atlasStripeCustomerId) {
+      pushFieldMismatch(
+        mismatchedPersons,
+        e.email,
+        "atlasStripeCustomerId",
+        e.atlasStripeCustomerId,
+        o.atlasStripeCustomerId,
+      );
+    }
     if (e.name?.firstName) {
       pushFieldMismatch(
         mismatchedPersons,
@@ -312,11 +335,13 @@ function diffNotes(
 
   // Total count check per email — surfaces the cases where the same email
   // has the right titles but a different count (e.g. dispatcher created two
-  // notes when the fixture only declared one, or vice versa).
-  const allEmails = new Set<string>([
-    ...expectedCounts.keys(),
-    ...[...observedCounts.keys()].filter((e) => expectedCounts.has(e)),
-  ]);
+  // notes when the fixture only declared one, or vice versa). Scoped to
+  // emails the fixture declared — Notes attached to unexpected workspace
+  // Persons are informational only, like `unexpectedPersons`. The
+  // `missingNotes` check above is the load-bearing assertion for the
+  // #2865-shaped misattribution case (a Note created against the wrong
+  // Person surfaces there as a missing-on-the-right-Person finding).
+  const allEmails = new Set(expectedCounts.keys());
   for (const email of allEmails) {
     const expectedTotal = sumCounts(expectedCounts.get(email));
     const observedTotal = sumCounts(observedCounts.get(email));

--- a/packages/cli/lib/smoke-crm/diff.ts
+++ b/packages/cli/lib/smoke-crm/diff.ts
@@ -175,18 +175,43 @@ export interface SmokeDiff {
   /** Expected emails not present in Twenty. */
   readonly missingPersons: ReadonlyArray<string>;
   /**
-   * Emails present in Twenty but not in the fixture. Often noise (workspace
-   * had pre-existing rows when --wipe-twenty wasn't used) — surfaced so the
-   * operator can decide whether it matters, but does NOT mark the diff as
-   * "dirty" by itself (see `isClean`).
+   * Emails present in Twenty but not in the fixture. Default behaviour:
+   * informational (workspace had pre-existing rows when --wipe-twenty
+   * wasn't used). When `requireCleanWorkspace` is set (the smoke ran with
+   * `--wipe-twenty`), these flip to dirty — a wiped workspace shouldn't
+   * have leftover rows, and treating them as informational would mask
+   * partial / truncated wipes. See `isClean`.
    */
   readonly unexpectedPersons: ReadonlyArray<string>;
+  /**
+   * Emails seen MORE THAN ONCE on the observed side — Twenty workspace
+   * has duplicate Person records for the same email. Always dirty: a
+   * dedupe regression in `findPersonByEmail` (the #2865 family) is
+   * exactly what produces this shape.
+   */
+  readonly duplicateObservedEmails: ReadonlyArray<string>;
   /** Per-Person field mismatches. The load-bearing slice — these mean the dispatcher wrote the wrong value. */
   readonly mismatchedPersons: ReadonlyArray<PersonMismatch>;
-  /** Notes the fixture says should exist but weren't observed (matched by title + personEmail). */
+  /** Notes the fixture says should exist but weren't observed (matched by title + body + personEmail, multiplicity-aware). */
   readonly missingNotes: ReadonlyArray<ExpectedNote>;
   /** Per-Person Note count mismatches (e.g. expected 1 note, observed 2). */
   readonly noteCountMismatches: ReadonlyArray<NoteCountMismatch>;
+  /**
+   * Set when the caller asked for a strict workspace (post-wipe). Flips
+   * `unexpectedPersons` from informational to dirty. Stored on the diff
+   * so the renderer can format the appropriate severity label.
+   */
+  readonly strictWorkspace: boolean;
+}
+
+export interface ComputeDiffOptions {
+  /**
+   * When true (the CLI sets this whenever `--wipe-twenty` was passed),
+   * `unexpectedPersons` and `duplicateObservedEmails` both mark the diff
+   * dirty. The post-wipe workspace should be deterministic — residual
+   * rows mean the wipe was partial or truncated.
+   */
+  readonly requireCleanWorkspace?: boolean;
 }
 
 /**
@@ -203,10 +228,24 @@ export interface SmokeDiff {
 export function computeDiff(
   expected: ExpectedState,
   observed: ObservedState,
+  options: ComputeDiffOptions = {},
 ): SmokeDiff {
   const observedByEmail = new Map<string, ObservedPerson>();
+  const duplicateObservedEmails: string[] = [];
   for (const o of observed.persons) {
-    observedByEmail.set(o.email.toLowerCase().trim(), o);
+    const key = o.email.toLowerCase().trim();
+    if (observedByEmail.has(key)) {
+      // Duplicate observed Person — a dedupe regression in upsertPerson
+      // (`findPersonByEmail` returning null when it shouldn't) creates this
+      // shape. Record once per email, then keep the first row as the
+      // representative for the field-comparison loop below — the duplicate
+      // is already surfaced via `duplicateObservedEmails`.
+      if (!duplicateObservedEmails.includes(key)) {
+        duplicateObservedEmails.push(key);
+      }
+      continue;
+    }
+    observedByEmail.set(key, o);
   }
   const expectedEmails = new Set(expected.persons.map((p) => p.email));
 
@@ -272,9 +311,11 @@ export function computeDiff(
   return {
     missingPersons,
     unexpectedPersons,
+    duplicateObservedEmails,
     mismatchedPersons,
     missingNotes,
     noteCountMismatches,
+    strictWorkspace: options.requireCleanWorkspace === true,
   };
 }
 
@@ -306,45 +347,59 @@ function diffNotes(
   expected: ReadonlyArray<ExpectedNote>,
   observed: ReadonlyArray<ObservedNote>,
 ): NoteDiff {
-  // Group expected notes by personEmail, then by title.
-  const expectedCounts = new Map<string, Map<string, number>>();
+  // Key notes by `personEmail‖title‖body` so multiplicity AND body content
+  // both participate in the diff. Two same-titled-but-different-body notes
+  // on the same email are distinct keys; a body corruption regression (right
+  // title, wrong body) surfaces as both `missingNotes` (expected key absent)
+  // AND an inflated `noteCountMismatches` total for that email.
+  const expectedKeys = new Map<string, { count: number; sample: ExpectedNote }>();
   for (const e of expected) {
-    const byTitle = expectedCounts.get(e.personEmail) ?? new Map<string, number>();
-    byTitle.set(e.title, (byTitle.get(e.title) ?? 0) + 1);
-    expectedCounts.set(e.personEmail, byTitle);
+    const k = noteKey(e.personEmail, e.title, e.body);
+    const prior = expectedKeys.get(k);
+    expectedKeys.set(k, { count: (prior?.count ?? 0) + 1, sample: e });
   }
 
-  const observedCounts = new Map<string, Map<string, number>>();
+  const observedKeys = new Map<string, number>();
   for (const o of observed) {
     if (o.personEmail == null) continue;
-    const byTitle = observedCounts.get(o.personEmail) ?? new Map<string, number>();
-    byTitle.set(o.title, (byTitle.get(o.title) ?? 0) + 1);
-    observedCounts.set(o.personEmail, byTitle);
+    const k = noteKey(o.personEmail, o.title, o.body);
+    observedKeys.set(k, (observedKeys.get(k) ?? 0) + 1);
   }
 
+  // Multiplicity-aware missing check: if expected says "alice@x.com has 2
+  // notes with title T and body B", and observed has only 1, the missing
+  // count is 1. Codex P2-B/D.
   const missingNotes: ExpectedNote[] = [];
-  const noteCountMismatches: NoteCountMismatch[] = [];
-
-  for (const e of expected) {
-    const observedForEmail = observedCounts.get(e.personEmail);
-    const observedForTitle = observedForEmail?.get(e.title) ?? 0;
-    if (observedForTitle === 0) {
-      missingNotes.push(e);
+  for (const [k, { count: expectedCount, sample }] of expectedKeys) {
+    const observedCount = observedKeys.get(k) ?? 0;
+    for (let i = 0; i < expectedCount - observedCount; i++) {
+      missingNotes.push(sample);
     }
   }
 
-  // Total count check per email — surfaces the cases where the same email
-  // has the right titles but a different count (e.g. dispatcher created two
-  // notes when the fixture only declared one, or vice versa). Scoped to
-  // emails the fixture declared — Notes attached to unexpected workspace
-  // Persons are informational only, like `unexpectedPersons`. The
-  // `missingNotes` check above is the load-bearing assertion for the
-  // #2865-shaped misattribution case (a Note created against the wrong
-  // Person surfaces there as a missing-on-the-right-Person finding).
-  const allEmails = new Set(expectedCounts.keys());
-  for (const email of allEmails) {
-    const expectedTotal = sumCounts(expectedCounts.get(email));
-    const observedTotal = sumCounts(observedCounts.get(email));
+  // Per-email TOTAL count check — surfaces "right titles but wrong count"
+  // and (with the body keying above) "right title but wrong body, leaving
+  // the total clean". Scoped to fixture emails — Notes attached to
+  // unexpected workspace Persons are informational, like `unexpectedPersons`.
+  const noteCountMismatches: NoteCountMismatch[] = [];
+  const expectedTotalByEmail = new Map<string, number>();
+  for (const e of expected) {
+    expectedTotalByEmail.set(
+      e.personEmail,
+      (expectedTotalByEmail.get(e.personEmail) ?? 0) + 1,
+    );
+  }
+  const observedTotalByEmail = new Map<string, number>();
+  for (const o of observed) {
+    if (o.personEmail == null) continue;
+    observedTotalByEmail.set(
+      o.personEmail,
+      (observedTotalByEmail.get(o.personEmail) ?? 0) + 1,
+    );
+  }
+  for (const email of expectedTotalByEmail.keys()) {
+    const expectedTotal = expectedTotalByEmail.get(email) ?? 0;
+    const observedTotal = observedTotalByEmail.get(email) ?? 0;
     if (expectedTotal !== observedTotal) {
       noteCountMismatches.push({
         personEmail: email,
@@ -357,21 +412,40 @@ function diffNotes(
   return { missingNotes, noteCountMismatches };
 }
 
-function sumCounts(byTitle: Map<string, number> | undefined): number {
-  if (!byTitle) return 0;
-  let n = 0;
-  for (const c of byTitle.values()) n += c;
-  return n;
+/**
+ * Stable composite key for note identity. Newlines in title or body are
+ * escaped so the key is unambiguous (a body containing `‖` won't collide
+ * with the email/title separator); a literal U+2016 byte is unlikely in
+ * sales-form copy but cheap to guard against.
+ */
+function noteKey(email: string, title: string, body: string): string {
+  return [email, title, body].map((s) => s.replace(/‖/g, "‖‖")).join("‖");
 }
 
-/** True when no load-bearing mismatch was found (`unexpectedPersons` is ignored). */
+/**
+ * True when no load-bearing mismatch was found.
+ *
+ * `unexpectedPersons` is informational by default — workspaces have
+ * pre-existing data that the smoke shouldn't fail on. The exception is
+ * `strictWorkspace` mode (set by the CLI when `--wipe-twenty` was
+ * passed): after a wipe, residual rows mean the wipe was partial /
+ * truncated, so unexpected Persons flip to dirty.
+ *
+ * `duplicateObservedEmails` is always dirty — a dedupe regression in
+ * `findPersonByEmail` is exactly the #2865 failure shape.
+ */
 export function isClean(diff: SmokeDiff): boolean {
-  return (
-    diff.missingPersons.length === 0 &&
-    diff.mismatchedPersons.length === 0 &&
-    diff.missingNotes.length === 0 &&
-    diff.noteCountMismatches.length === 0
-  );
+  if (
+    diff.missingPersons.length > 0 ||
+    diff.mismatchedPersons.length > 0 ||
+    diff.missingNotes.length > 0 ||
+    diff.noteCountMismatches.length > 0 ||
+    diff.duplicateObservedEmails.length > 0
+  ) {
+    return false;
+  }
+  if (diff.strictWorkspace && diff.unexpectedPersons.length > 0) return false;
+  return true;
 }
 
 /** Human-readable diff report — output suitable for the CLI's stderr. */
@@ -391,10 +465,23 @@ export function formatDiff(diff: SmokeDiff, options?: { totals?: { expectedPerso
   }
 
   if (diff.unexpectedPersons.length > 0) {
-    lines.push(
-      `ℹ Unexpected Persons in workspace (${diff.unexpectedPersons.length}) — not in fixture, ignored:`,
-    );
+    if (diff.strictWorkspace) {
+      lines.push(
+        `✗ Unexpected Persons in workspace (${diff.unexpectedPersons.length}) — wipe did not fully drain:`,
+      );
+    } else {
+      lines.push(
+        `ℹ Unexpected Persons in workspace (${diff.unexpectedPersons.length}) — not in fixture, ignored:`,
+      );
+    }
     for (const email of diff.unexpectedPersons) lines.push(`  - ${email}`);
+  }
+
+  if (diff.duplicateObservedEmails.length > 0) {
+    lines.push(
+      `✗ Duplicate observed Persons (${diff.duplicateObservedEmails.length}) — same email appears more than once in Twenty:`,
+    );
+    for (const email of diff.duplicateObservedEmails) lines.push(`  - ${email}`);
   }
 
   if (diff.mismatchedPersons.length > 0) {

--- a/packages/cli/lib/smoke-crm/diff.ts
+++ b/packages/cli/lib/smoke-crm/diff.ts
@@ -1,0 +1,401 @@
+/**
+ * Expected/observed state model + diff for the CRM smoke-test.
+ *
+ * The shape mirrors the manual repro in PR #2865's comment thread:
+ *   - N distinct personas (collapsed by email) → N distinct Twenty Persons
+ *   - First persona's eventSource → `atlasFirstSource` (sticky)
+ *   - Last persona's eventSource → `atlasLastSource`
+ *   - Each sales-form persona → one Note on the matching Person
+ *
+ * The diff is pure — input/output only — so the tests can exercise every
+ * branch without touching the network. The CLI's exit code is derived from
+ * `isClean(diff)`.
+ */
+
+import {
+  normalizeLead,
+  type AtlasEventSource,
+  type AtlasLeadEvent,
+  type NormalizedNote,
+} from "@useatlas/twenty/lead-normalizer";
+
+/** Expected end-state of a single Twenty Person after all dispatches. */
+export interface ExpectedPerson {
+  /** Lowercased email — Twenty matches on this. */
+  readonly email: string;
+  readonly atlasFirstSource: AtlasEventSource;
+  readonly atlasLastSource: AtlasEventSource;
+  /** Optional standard fields the dispatcher may have written. */
+  readonly name?: { firstName?: string; lastName?: string };
+  readonly atlasIp?: string;
+  readonly atlasStripeCustomerId?: string;
+}
+
+/** Expected Note attached to a Person. */
+export interface ExpectedNote {
+  readonly personEmail: string;
+  readonly title: string;
+  readonly body: string;
+}
+
+export interface ExpectedState {
+  readonly persons: ReadonlyArray<ExpectedPerson>;
+  readonly notes: ReadonlyArray<ExpectedNote>;
+}
+
+/** What we read back from Twenty. Shape is the subset we need to match against. */
+export interface ObservedPerson {
+  readonly id: string;
+  readonly email: string;
+  readonly atlasFirstSource?: string;
+  readonly atlasLastSource?: string;
+  readonly name?: { firstName?: string; lastName?: string };
+}
+
+export interface ObservedNote {
+  readonly id: string;
+  readonly title: string;
+  readonly body: string;
+  /** Email of the Person this Note is linked to (resolved via NoteTarget). */
+  readonly personEmail: string | null;
+}
+
+export interface ObservedState {
+  readonly persons: ReadonlyArray<ObservedPerson>;
+  readonly notes: ReadonlyArray<ObservedNote>;
+}
+
+// ─────────────────────────────────────────────────────────────────────
+//  Build expected state from a fixture
+// ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Collapse a list of lead events into the expected Twenty end-state.
+ *
+ * Rules (mirror `TwentyClient.upsertPerson`):
+ *  - One Person per distinct email (lowercased + trimmed).
+ *  - `atlasFirstSource` = first event's source (sticky — never overwritten).
+ *  - `atlasLastSource` = last event's source.
+ *  - `name` / `atlasIp` / `atlasStripeCustomerId` are merged from any event
+ *    that carries them; later events win (matches the dispatcher's PATCH-
+ *    every-write behaviour).
+ *  - Notes: one per `sales-form` event. Same email with two sales-form
+ *    events produces two Notes (the dispatcher creates a fresh note per
+ *    dispatch — see #2729's idempotency contract).
+ */
+export function buildExpectedState(events: ReadonlyArray<AtlasLeadEvent>): ExpectedState {
+  const persons = new Map<string, ExpectedPerson>();
+  const notes: ExpectedNote[] = [];
+
+  for (const event of events) {
+    const normalized = normalizeLead(event);
+    const email = normalized.person.email;
+    const eventSource = normalized.eventSource;
+
+    const existing = persons.get(email);
+    if (!existing) {
+      const next: ExpectedPerson = {
+        email,
+        atlasFirstSource: eventSource,
+        atlasLastSource: eventSource,
+        ...(normalized.person.name ? { name: normalized.person.name } : {}),
+        ...(normalized.person.customFields?.atlasIp
+          ? { atlasIp: normalized.person.customFields.atlasIp }
+          : {}),
+        ...(normalized.person.customFields?.atlasStripeCustomerId
+          ? {
+              atlasStripeCustomerId:
+                normalized.person.customFields.atlasStripeCustomerId,
+            }
+          : {}),
+      };
+      persons.set(email, next);
+    } else {
+      // Merge — atlasFirstSource stays sticky; everything else is last-write-wins.
+      const merged: ExpectedPerson = {
+        email: existing.email,
+        atlasFirstSource: existing.atlasFirstSource,
+        atlasLastSource: eventSource,
+        name: normalized.person.name ?? existing.name,
+        atlasIp:
+          normalized.person.customFields?.atlasIp ?? existing.atlasIp,
+        atlasStripeCustomerId:
+          normalized.person.customFields?.atlasStripeCustomerId ??
+          existing.atlasStripeCustomerId,
+      };
+      persons.set(email, merged);
+    }
+
+    if (normalized.note) {
+      notes.push(buildExpectedNote(email, normalized.note));
+    }
+  }
+
+  return {
+    persons: [...persons.values()],
+    notes,
+  };
+}
+
+function buildExpectedNote(email: string, note: NormalizedNote): ExpectedNote {
+  return {
+    personEmail: email,
+    title: note.title,
+    body: note.body,
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────
+//  Diff
+// ─────────────────────────────────────────────────────────────────────
+
+export interface PersonMismatch {
+  readonly email: string;
+  readonly field:
+    | "atlasFirstSource"
+    | "atlasLastSource"
+    | "name.firstName"
+    | "name.lastName";
+  readonly expected: string;
+  readonly observed: string;
+}
+
+export interface NoteCountMismatch {
+  readonly personEmail: string;
+  readonly expected: number;
+  readonly observed: number;
+}
+
+export interface SmokeDiff {
+  /** Expected emails not present in Twenty. */
+  readonly missingPersons: ReadonlyArray<string>;
+  /**
+   * Emails present in Twenty but not in the fixture. Often noise (workspace
+   * had pre-existing rows when --wipe-twenty wasn't used) — surfaced so the
+   * operator can decide whether it matters, but does NOT mark the diff as
+   * "dirty" by itself (see `isClean`).
+   */
+  readonly unexpectedPersons: ReadonlyArray<string>;
+  /** Per-Person field mismatches. The load-bearing slice — these mean the dispatcher wrote the wrong value. */
+  readonly mismatchedPersons: ReadonlyArray<PersonMismatch>;
+  /** Notes the fixture says should exist but weren't observed (matched by title + personEmail). */
+  readonly missingNotes: ReadonlyArray<ExpectedNote>;
+  /** Per-Person Note count mismatches (e.g. expected 1 note, observed 2). */
+  readonly noteCountMismatches: ReadonlyArray<NoteCountMismatch>;
+}
+
+/**
+ * Diff the expected state against what we observed in Twenty.
+ *
+ * Symmetry decisions:
+ *  - `missingPersons` AND `mismatchedPersons` mark a diff dirty (see `isClean`).
+ *  - `missingNotes` AND `noteCountMismatches` mark a diff dirty.
+ *  - `unexpectedPersons` is informational only — a workspace with pre-existing
+ *    Twenty data shouldn't fail the smoke unless the operator opted into
+ *    `--wipe-twenty`. The CLI surfaces them in the report regardless so the
+ *    operator notices, but the exit code stays clean.
+ */
+export function computeDiff(
+  expected: ExpectedState,
+  observed: ObservedState,
+): SmokeDiff {
+  const observedByEmail = new Map<string, ObservedPerson>();
+  for (const o of observed.persons) {
+    observedByEmail.set(o.email.toLowerCase().trim(), o);
+  }
+  const expectedEmails = new Set(expected.persons.map((p) => p.email));
+
+  const missingPersons: string[] = [];
+  const mismatchedPersons: PersonMismatch[] = [];
+
+  for (const e of expected.persons) {
+    const o = observedByEmail.get(e.email);
+    if (!o) {
+      missingPersons.push(e.email);
+      continue;
+    }
+    pushFieldMismatch(mismatchedPersons, e.email, "atlasFirstSource", e.atlasFirstSource, o.atlasFirstSource);
+    pushFieldMismatch(mismatchedPersons, e.email, "atlasLastSource", e.atlasLastSource, o.atlasLastSource);
+    if (e.name?.firstName) {
+      pushFieldMismatch(
+        mismatchedPersons,
+        e.email,
+        "name.firstName",
+        e.name.firstName,
+        o.name?.firstName,
+      );
+    }
+    if (e.name?.lastName) {
+      pushFieldMismatch(
+        mismatchedPersons,
+        e.email,
+        "name.lastName",
+        e.name.lastName,
+        o.name?.lastName,
+      );
+    }
+  }
+
+  const unexpectedPersons: string[] = [];
+  for (const o of observed.persons) {
+    const normEmail = o.email.toLowerCase().trim();
+    if (!expectedEmails.has(normEmail)) {
+      unexpectedPersons.push(o.email);
+    }
+  }
+
+  const { missingNotes, noteCountMismatches } = diffNotes(expected.notes, observed.notes);
+
+  return {
+    missingPersons,
+    unexpectedPersons,
+    mismatchedPersons,
+    missingNotes,
+    noteCountMismatches,
+  };
+}
+
+function pushFieldMismatch(
+  out: PersonMismatch[],
+  email: string,
+  field: PersonMismatch["field"],
+  expected: string | undefined,
+  observed: string | undefined,
+): void {
+  // `undefined` becomes the literal `"(unset)"` so the diff renderer doesn't
+  // print "expected DEMO, got undefined" — explicit "(unset)" reads better
+  // when the cause is a missing custom field rather than a wrong value.
+  if (expected === observed) return;
+  out.push({
+    email,
+    field,
+    expected: expected ?? "(unset)",
+    observed: observed ?? "(unset)",
+  });
+}
+
+interface NoteDiff {
+  missingNotes: ExpectedNote[];
+  noteCountMismatches: NoteCountMismatch[];
+}
+
+function diffNotes(
+  expected: ReadonlyArray<ExpectedNote>,
+  observed: ReadonlyArray<ObservedNote>,
+): NoteDiff {
+  // Group expected notes by personEmail, then by title.
+  const expectedCounts = new Map<string, Map<string, number>>();
+  for (const e of expected) {
+    const byTitle = expectedCounts.get(e.personEmail) ?? new Map<string, number>();
+    byTitle.set(e.title, (byTitle.get(e.title) ?? 0) + 1);
+    expectedCounts.set(e.personEmail, byTitle);
+  }
+
+  const observedCounts = new Map<string, Map<string, number>>();
+  for (const o of observed) {
+    if (o.personEmail == null) continue;
+    const byTitle = observedCounts.get(o.personEmail) ?? new Map<string, number>();
+    byTitle.set(o.title, (byTitle.get(o.title) ?? 0) + 1);
+    observedCounts.set(o.personEmail, byTitle);
+  }
+
+  const missingNotes: ExpectedNote[] = [];
+  const noteCountMismatches: NoteCountMismatch[] = [];
+
+  for (const e of expected) {
+    const observedForEmail = observedCounts.get(e.personEmail);
+    const observedForTitle = observedForEmail?.get(e.title) ?? 0;
+    if (observedForTitle === 0) {
+      missingNotes.push(e);
+    }
+  }
+
+  // Total count check per email — surfaces the cases where the same email
+  // has the right titles but a different count (e.g. dispatcher created two
+  // notes when the fixture only declared one, or vice versa).
+  const allEmails = new Set<string>([
+    ...expectedCounts.keys(),
+    ...[...observedCounts.keys()].filter((e) => expectedCounts.has(e)),
+  ]);
+  for (const email of allEmails) {
+    const expectedTotal = sumCounts(expectedCounts.get(email));
+    const observedTotal = sumCounts(observedCounts.get(email));
+    if (expectedTotal !== observedTotal) {
+      noteCountMismatches.push({
+        personEmail: email,
+        expected: expectedTotal,
+        observed: observedTotal,
+      });
+    }
+  }
+
+  return { missingNotes, noteCountMismatches };
+}
+
+function sumCounts(byTitle: Map<string, number> | undefined): number {
+  if (!byTitle) return 0;
+  let n = 0;
+  for (const c of byTitle.values()) n += c;
+  return n;
+}
+
+/** True when no load-bearing mismatch was found (`unexpectedPersons` is ignored). */
+export function isClean(diff: SmokeDiff): boolean {
+  return (
+    diff.missingPersons.length === 0 &&
+    diff.mismatchedPersons.length === 0 &&
+    diff.missingNotes.length === 0 &&
+    diff.noteCountMismatches.length === 0
+  );
+}
+
+/** Human-readable diff report — output suitable for the CLI's stderr. */
+export function formatDiff(diff: SmokeDiff, options?: { totals?: { expectedPersons: number; observedPersons: number; expectedNotes: number; observedNotes: number } }): string {
+  const lines: string[] = [];
+  if (options?.totals) {
+    const t = options.totals;
+    lines.push(
+      `Totals: persons expected=${t.expectedPersons} observed=${t.observedPersons}, ` +
+        `notes expected=${t.expectedNotes} observed=${t.observedNotes}`,
+    );
+  }
+
+  if (diff.missingPersons.length > 0) {
+    lines.push(`✗ Missing Persons (${diff.missingPersons.length}):`);
+    for (const email of diff.missingPersons) lines.push(`  - ${email}`);
+  }
+
+  if (diff.unexpectedPersons.length > 0) {
+    lines.push(
+      `ℹ Unexpected Persons in workspace (${diff.unexpectedPersons.length}) — not in fixture, ignored:`,
+    );
+    for (const email of diff.unexpectedPersons) lines.push(`  - ${email}`);
+  }
+
+  if (diff.mismatchedPersons.length > 0) {
+    lines.push(`✗ Field mismatches (${diff.mismatchedPersons.length}):`);
+    for (const m of diff.mismatchedPersons) {
+      lines.push(`  - ${m.email} :: ${m.field}: expected="${m.expected}", observed="${m.observed}"`);
+    }
+  }
+
+  if (diff.missingNotes.length > 0) {
+    lines.push(`✗ Missing Notes (${diff.missingNotes.length}):`);
+    for (const n of diff.missingNotes) {
+      lines.push(`  - ${n.personEmail} :: "${n.title}"`);
+    }
+  }
+
+  if (diff.noteCountMismatches.length > 0) {
+    lines.push(`✗ Note count mismatches (${diff.noteCountMismatches.length}):`);
+    for (const m of diff.noteCountMismatches) {
+      lines.push(`  - ${m.personEmail}: expected ${m.expected}, observed ${m.observed}`);
+    }
+  }
+
+  if (isClean(diff)) {
+    lines.push(`✓ Diff is clean — all expected Persons + Notes match.`);
+  }
+
+  return lines.join("\n");
+}

--- a/packages/cli/lib/smoke-crm/fixture.ts
+++ b/packages/cli/lib/smoke-crm/fixture.ts
@@ -1,0 +1,186 @@
+/**
+ * Persona fixture parser for `atlas ops smoke-crm`.
+ *
+ * Reads a YAML document of personas and returns the discriminated union of
+ * `AtlasLeadEvent` variants the saas-crm dispatcher consumes. Validation is
+ * intentionally manual (rather than zod / similar) so the error messages
+ * point at the offending persona index — a typo on persona 7 of 10 should
+ * say "persona[6].planInterest is required for source=sales-form", not a
+ * generic schema-violation blob.
+ *
+ * The fixture is operator-authored, not user input, so it's safe to fail
+ * loudly on the first invalid persona — there's no "partial best-effort"
+ * mode here. A broken fixture is always an operator typo.
+ */
+import { readFileSync } from "node:fs";
+
+import { load as parseYaml } from "js-yaml";
+
+import type {
+  AtlasConversionLeadEvent,
+  AtlasDemoLeadEvent,
+  AtlasLeadEvent,
+  AtlasSalesFormLeadEvent,
+  AtlasSignupLeadEvent,
+} from "@useatlas/twenty/lead-normalizer";
+
+/** Top-level YAML shape. */
+interface FixtureDoc {
+  readonly personas: ReadonlyArray<Record<string, unknown>>;
+}
+
+export class FixtureParseError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "FixtureParseError";
+  }
+}
+
+/** Path-prefixed throw helper — keeps the index visible at every error. */
+function fail(personaIndex: number, message: string): never {
+  throw new FixtureParseError(`persona[${personaIndex}]: ${message}`);
+}
+
+function requireString(
+  personaIndex: number,
+  obj: Record<string, unknown>,
+  key: string,
+): string {
+  const value = obj[key];
+  if (typeof value !== "string" || value.trim().length === 0) {
+    fail(personaIndex, `${key} is required and must be a non-empty string`);
+  }
+  return value.trim();
+}
+
+function optionalString(
+  personaIndex: number,
+  obj: Record<string, unknown>,
+  key: string,
+): string | undefined {
+  const value = obj[key];
+  if (value === undefined || value === null) return undefined;
+  if (typeof value !== "string") {
+    fail(personaIndex, `${key} must be a string when present`);
+  }
+  return value;
+}
+
+function parseSalesFormPersona(
+  personaIndex: number,
+  raw: Record<string, unknown>,
+): AtlasSalesFormLeadEvent {
+  return {
+    source: "sales-form",
+    email: requireString(personaIndex, raw, "email"),
+    name: requireString(personaIndex, raw, "name"),
+    company: requireString(personaIndex, raw, "company"),
+    planInterest: requireString(personaIndex, raw, "planInterest"),
+    message: requireString(personaIndex, raw, "message"),
+    ip: optionalString(personaIndex, raw, "ip") ?? null,
+    userAgent: optionalString(personaIndex, raw, "userAgent") ?? null,
+  };
+}
+
+function parseDemoPersona(
+  personaIndex: number,
+  raw: Record<string, unknown>,
+): AtlasDemoLeadEvent {
+  return {
+    source: "demo",
+    email: requireString(personaIndex, raw, "email"),
+    ip: optionalString(personaIndex, raw, "ip") ?? null,
+    userAgent: optionalString(personaIndex, raw, "userAgent") ?? null,
+  };
+}
+
+function parseSignupPersona(
+  personaIndex: number,
+  raw: Record<string, unknown>,
+): AtlasSignupLeadEvent {
+  const name = optionalString(personaIndex, raw, "name");
+  return {
+    source: "signup",
+    email: requireString(personaIndex, raw, "email"),
+    ...(name ? { name } : {}),
+  };
+}
+
+function parseConversionPersona(
+  personaIndex: number,
+  raw: Record<string, unknown>,
+): AtlasConversionLeadEvent {
+  return {
+    source: "conversion",
+    email: requireString(personaIndex, raw, "email"),
+    stripeCustomerId: requireString(personaIndex, raw, "stripeCustomerId"),
+  };
+}
+
+/** Pure entry point — `text` is a YAML string. Throws `FixtureParseError`. */
+export function parseFixtureYaml(text: string): AtlasLeadEvent[] {
+  let doc: unknown;
+  try {
+    doc = parseYaml(text);
+  } catch (err) {
+    throw new FixtureParseError(
+      `YAML parse failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+  if (!doc || typeof doc !== "object") {
+    throw new FixtureParseError("fixture root must be an object with a `personas` key");
+  }
+  const personas = (doc as FixtureDoc).personas;
+  if (!Array.isArray(personas)) {
+    throw new FixtureParseError("fixture root must have a `personas` array");
+  }
+  if (personas.length === 0) {
+    throw new FixtureParseError("fixture must contain at least one persona");
+  }
+
+  const out: AtlasLeadEvent[] = [];
+  for (let i = 0; i < personas.length; i++) {
+    const raw = personas[i];
+    if (!raw || typeof raw !== "object") {
+      throw new FixtureParseError(`persona[${i}]: must be an object`);
+    }
+    const source = (raw as Record<string, unknown>).source;
+    if (typeof source !== "string") {
+      fail(i, "source is required and must be a string");
+    }
+    const record = raw as Record<string, unknown>;
+    switch (source) {
+      case "sales-form":
+        out.push(parseSalesFormPersona(i, record));
+        break;
+      case "demo":
+        out.push(parseDemoPersona(i, record));
+        break;
+      case "signup":
+        out.push(parseSignupPersona(i, record));
+        break;
+      case "conversion":
+        out.push(parseConversionPersona(i, record));
+        break;
+      default:
+        fail(
+          i,
+          `unknown source "${source}" — expected one of: sales-form, demo, signup, conversion`,
+        );
+    }
+  }
+  return out;
+}
+
+/** Read fixture from disk and parse. Errors surface unchanged. */
+export function loadFixture(path: string): AtlasLeadEvent[] {
+  let text: string;
+  try {
+    text = readFileSync(path, "utf-8");
+  } catch (err) {
+    throw new FixtureParseError(
+      `cannot read fixture file at ${path}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+  return parseFixtureYaml(text);
+}

--- a/packages/cli/lib/smoke-crm/twenty-admin.ts
+++ b/packages/cli/lib/smoke-crm/twenty-admin.ts
@@ -1,0 +1,222 @@
+/**
+ * TwentyAdmin — narrow interface the smoke-crm CLI uses to read / wipe a
+ * Twenty workspace. Delegates to `@useatlas/twenty/client` for everything
+ * the client surface exposes; Note → Person attribution is the one piece
+ * the client doesn't yet expose (see `listAllNotesWithPersonEmail` below)
+ * and is implemented inline against Twenty's `/rest/noteTargets` endpoint.
+ *
+ * Why this layer exists at all:
+ *  - Lets the CLI handler hold a single `TwentyAdmin` value and remain
+ *    unit-testable with a fake — the fake is a small object, no fetch
+ *    mocking required.
+ *  - Adapts the client's pagination + Person-attribution semantics to the
+ *    `ObservedPerson` / `ObservedNote` shapes the diff reporter consumes,
+ *    so the diff code never sees raw Twenty types.
+ *  - Centralises the inline `/rest/noteTargets` fetch behind a single
+ *    function — when a future Twenty client extension exposes a
+ *    `listNoteTargets` verb, the inline fetch becomes a one-line delegate.
+ */
+import {
+  deleteNote,
+  deletePerson,
+  listNotes,
+  listPeople,
+  wipeWorkspace,
+  type TwentyClientConfig,
+  type TwentyNoteFull,
+  type TwentyPerson,
+  type WipeWorkspaceResult,
+} from "@useatlas/twenty/client";
+
+import type { ObservedNote, ObservedPerson } from "./diff";
+
+/**
+ * Soft cap on records visited per object type during enumeration. Smoke
+ * runs operate on workspaces with at most a few hundred records (the
+ * default fixture is 10 personas); the cap exists so a runaway
+ * pagination bug doesn't ddos Twenty.
+ */
+export const SMOKE_MAX_RECORDS_PER_TYPE = 1_000;
+const PAGE_LIMIT = 60;
+
+export interface TwentyAdmin {
+  /**
+   * List every Person in the workspace. Paginates via Twenty's
+   * `starting_after` cursor; bounded by `SMOKE_MAX_RECORDS_PER_TYPE`.
+   */
+  listAllPeople(): Promise<ObservedPerson[]>;
+
+  /**
+   * List every Note in the workspace, joined to its target Person's
+   * email via the NoteTarget link table. Notes whose target Person isn't
+   * in the workspace (orphans) appear with `personEmail = null`.
+   */
+  listAllNotes(): Promise<ObservedNote[]>;
+
+  /** Hard-delete a Person by id. */
+  deletePerson(id: string): Promise<void>;
+
+  /** Hard-delete a Note by id. */
+  deleteNote(id: string): Promise<void>;
+
+  /**
+   * Drain every Person, Note, and Company in the workspace via the
+   * client's `wipeWorkspace`. Returns the result struct so the caller
+   * can log per-object-type deletion counts.
+   */
+  wipeWorkspace(opts?: { readonly dryRun?: boolean }): Promise<WipeWorkspaceResult>;
+}
+
+/**
+ * Build a live `TwentyAdmin` against the supplied Twenty workspace config.
+ * The returned object holds no state — each call is a fresh REST round
+ * trip.
+ */
+export function createTwentyAdmin(config: TwentyClientConfig): TwentyAdmin {
+  return {
+    listAllPeople: () => listAllPeoplePaged(config),
+    listAllNotes: () => listAllNotesWithPersonEmail(config),
+    deletePerson: (id) => deletePerson(config, id),
+    deleteNote: (id) => deleteNote(config, id),
+    wipeWorkspace: (opts) =>
+      wipeWorkspace(config, {
+        dryRun: opts?.dryRun ?? false,
+        pageLimit: PAGE_LIMIT,
+        maxRecords: SMOKE_MAX_RECORDS_PER_TYPE * 3,
+      }),
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────
+//  Pagination — Person + Note
+// ─────────────────────────────────────────────────────────────────────
+
+async function listAllPeoplePaged(config: TwentyClientConfig): Promise<ObservedPerson[]> {
+  const out: ObservedPerson[] = [];
+  let cursor: string | undefined;
+  while (out.length < SMOKE_MAX_RECORDS_PER_TYPE) {
+    const page: TwentyPerson[] = await listPeople(config, {
+      limit: PAGE_LIMIT,
+      startingAfter: cursor,
+    });
+    for (const p of page) {
+      if (!p.id) continue;
+      const email = p.emails?.primaryEmail;
+      if (!email) continue;
+      out.push({
+        id: p.id,
+        email,
+        atlasFirstSource: p.atlasFirstSource,
+        atlasLastSource: p.atlasLastSource,
+        ...(p.name ? { name: p.name } : {}),
+      });
+    }
+    if (page.length < PAGE_LIMIT) break;
+    const last = page[page.length - 1];
+    if (!last?.id) break;
+    cursor = last.id;
+  }
+  return out;
+}
+
+async function listAllNotesPaged(config: TwentyClientConfig): Promise<TwentyNoteFull[]> {
+  const out: TwentyNoteFull[] = [];
+  let cursor: string | undefined;
+  while (out.length < SMOKE_MAX_RECORDS_PER_TYPE) {
+    const page: TwentyNoteFull[] = await listNotes(config, {
+      limit: PAGE_LIMIT,
+      startingAfter: cursor,
+    });
+    out.push(...page);
+    if (page.length < PAGE_LIMIT) break;
+    const last = page[page.length - 1];
+    if (!last?.id) break;
+    cursor = last.id;
+  }
+  return out;
+}
+
+// ─────────────────────────────────────────────────────────────────────
+//  Note → Person attribution via inline /rest/noteTargets fetch
+//
+//  #2867 ships listPeople / listNotes but not a noteTargets list verb.
+//  We need the Note → Person join for the diff to catch #2865-shaped
+//  regressions (all Notes piling onto one Person). This is a thin direct
+//  fetch against Twenty's documented `/rest/noteTargets` endpoint —
+//  replace with a client export when one lands.
+// ─────────────────────────────────────────────────────────────────────
+
+interface TwentyNoteTarget {
+  readonly id?: string;
+  readonly noteId?: string;
+  readonly targetPersonId?: string;
+}
+
+async function listAllNoteTargetsRaw(
+  config: TwentyClientConfig,
+): Promise<TwentyNoteTarget[]> {
+  const fetchImpl = config.fetchImpl ?? globalThis.fetch;
+  const out: TwentyNoteTarget[] = [];
+  let cursor: string | undefined;
+  const baseUrl = config.baseUrl.replace(/\/+$/, "");
+  while (out.length < SMOKE_MAX_RECORDS_PER_TYPE) {
+    const qs = new URLSearchParams({ limit: String(PAGE_LIMIT) });
+    if (cursor) qs.set("starting_after", cursor);
+    const url = `${baseUrl}/rest/noteTargets?${qs.toString()}`;
+    const response = await fetchImpl(url, {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${config.apiKey}`,
+        Accept: "application/json",
+      },
+      signal: AbortSignal.timeout(config.timeoutMs ?? 10_000),
+    });
+    if (!response.ok) {
+      throw new Error(
+        `[smoke-crm] listAllNoteTargets failed: HTTP ${response.status} from ${url}`,
+      );
+    }
+    const body = (await response.json()) as {
+      data?: { noteTargets?: TwentyNoteTarget[] };
+    };
+    const page = body.data?.noteTargets ?? [];
+    out.push(...page);
+    if (page.length < PAGE_LIMIT) break;
+    const last = page[page.length - 1];
+    if (!last?.id) break;
+    cursor = last.id;
+  }
+  return out;
+}
+
+async function listAllNotesWithPersonEmail(
+  config: TwentyClientConfig,
+): Promise<ObservedNote[]> {
+  // Fetch all three in parallel — they're independent reads.
+  const [notes, targets, people] = await Promise.all([
+    listAllNotesPaged(config),
+    listAllNoteTargetsRaw(config),
+    listAllPeoplePaged(config),
+  ]);
+  const emailByPersonId = new Map<string, string>();
+  for (const p of people) emailByPersonId.set(p.id, p.email);
+  // Build noteId → personEmail (first link wins — Notes typically have one target).
+  const emailByNoteId = new Map<string, string>();
+  for (const t of targets) {
+    if (!t.noteId || !t.targetPersonId) continue;
+    if (emailByNoteId.has(t.noteId)) continue;
+    const email = emailByPersonId.get(t.targetPersonId);
+    if (email) emailByNoteId.set(t.noteId, email);
+  }
+  const out: ObservedNote[] = [];
+  for (const n of notes) {
+    if (!n.id) continue;
+    out.push({
+      id: n.id,
+      title: n.title ?? "",
+      body: n.bodyV2?.markdown ?? "",
+      personEmail: emailByNoteId.get(n.id) ?? null,
+    });
+  }
+  return out;
+}

--- a/packages/cli/lib/smoke-crm/twenty-admin.ts
+++ b/packages/cli/lib/smoke-crm/twenty-admin.ts
@@ -1,20 +1,16 @@
 /**
  * TwentyAdmin — narrow interface the smoke-crm CLI uses to read / wipe a
  * Twenty workspace. Delegates to `@useatlas/twenty/client` for everything
- * the client surface exposes; Note → Person attribution is the one piece
- * the client doesn't yet expose (see `listAllNotesWithPersonEmail` below)
- * and is implemented inline against Twenty's `/rest/noteTargets` endpoint.
+ * the client surface exposes; Note → Person attribution is implemented
+ * inline against Twenty's `/rest/noteTargets` endpoint (see the block
+ * comment above `listAllNoteTargetsRaw` below).
  *
  * Why this layer exists at all:
  *  - Lets the CLI handler hold a single `TwentyAdmin` value and remain
- *    unit-testable with a fake — the fake is a small object, no fetch
- *    mocking required.
+ *    unit-testable with a fake.
  *  - Adapts the client's pagination + Person-attribution semantics to the
  *    `ObservedPerson` / `ObservedNote` shapes the diff reporter consumes,
  *    so the diff code never sees raw Twenty types.
- *  - Centralises the inline `/rest/noteTargets` fetch behind a single
- *    function — when a future Twenty client extension exposes a
- *    `listNoteTargets` verb, the inline fetch becomes a one-line delegate.
  */
 import {
   deleteNote,
@@ -31,13 +27,17 @@ import {
 import type { ObservedNote, ObservedPerson } from "./diff";
 
 /**
- * Soft cap on records visited per object type during enumeration. Smoke
- * runs operate on workspaces with at most a few hundred records (the
- * default fixture is 10 personas); the cap exists so a runaway
- * pagination bug doesn't ddos Twenty.
+ * Soft cap on records VISITED per object type during enumeration. Bounds
+ * both `out.length` and the page iteration count (`pages * PAGE_LIMIT`)
+ * so that a workspace with many rows we filter out (e.g. emailless
+ * Persons skipped by `listAllPeoplePaged`) still hits the cap before
+ * ddosing Twenty. Smoke runs operate on workspaces with at most a few
+ * hundred records (the default fixture is 10 personas); the cap exists
+ * to bound the blast radius of a runaway pagination bug.
  */
 export const SMOKE_MAX_RECORDS_PER_TYPE = 1_000;
 const PAGE_LIMIT = 60;
+const MAX_PAGES = Math.ceil(SMOKE_MAX_RECORDS_PER_TYPE / PAGE_LIMIT) + 1;
 
 export interface TwentyAdmin {
   /**
@@ -94,7 +94,7 @@ export function createTwentyAdmin(config: TwentyClientConfig): TwentyAdmin {
 async function listAllPeoplePaged(config: TwentyClientConfig): Promise<ObservedPerson[]> {
   const out: ObservedPerson[] = [];
   let cursor: string | undefined;
-  while (out.length < SMOKE_MAX_RECORDS_PER_TYPE) {
+  for (let pages = 0; pages < MAX_PAGES && out.length < SMOKE_MAX_RECORDS_PER_TYPE; pages++) {
     const page: TwentyPerson[] = await listPeople(config, {
       limit: PAGE_LIMIT,
       startingAfter: cursor,
@@ -108,6 +108,8 @@ async function listAllPeoplePaged(config: TwentyClientConfig): Promise<ObservedP
         email,
         atlasFirstSource: p.atlasFirstSource,
         atlasLastSource: p.atlasLastSource,
+        atlasIp: p.atlasIp,
+        atlasStripeCustomerId: p.atlasStripeCustomerId,
         ...(p.name ? { name: p.name } : {}),
       });
     }
@@ -122,7 +124,7 @@ async function listAllPeoplePaged(config: TwentyClientConfig): Promise<ObservedP
 async function listAllNotesPaged(config: TwentyClientConfig): Promise<TwentyNoteFull[]> {
   const out: TwentyNoteFull[] = [];
   let cursor: string | undefined;
-  while (out.length < SMOKE_MAX_RECORDS_PER_TYPE) {
+  for (let pages = 0; pages < MAX_PAGES && out.length < SMOKE_MAX_RECORDS_PER_TYPE; pages++) {
     const page: TwentyNoteFull[] = await listNotes(config, {
       limit: PAGE_LIMIT,
       startingAfter: cursor,
@@ -159,7 +161,7 @@ async function listAllNoteTargetsRaw(
   const out: TwentyNoteTarget[] = [];
   let cursor: string | undefined;
   const baseUrl = config.baseUrl.replace(/\/+$/, "");
-  while (out.length < SMOKE_MAX_RECORDS_PER_TYPE) {
+  for (let pages = 0; pages < MAX_PAGES && out.length < SMOKE_MAX_RECORDS_PER_TYPE; pages++) {
     const qs = new URLSearchParams({ limit: String(PAGE_LIMIT) });
     if (cursor) qs.set("starting_after", cursor);
     const url = `${baseUrl}/rest/noteTargets?${qs.toString()}`;

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "@atlas/api": "workspace:*",
     "@atlas/mcp": "workspace:*",
+    "@useatlas/twenty": "workspace:*",
     "@useatlas/types": "workspace:*",
     "@modelcontextprotocol/sdk": "^1.28.0",
     "@clickhouse/client": "^1.18.2",

--- a/packages/cli/src/__tests__/ops-smoke-crm-cli.test.ts
+++ b/packages/cli/src/__tests__/ops-smoke-crm-cli.test.ts
@@ -1,0 +1,283 @@
+/**
+ * Unit tests for the ops-smoke-crm arg parser, wipe gate, and the outbox
+ * polling helper. Live-network phases (Twenty list + wipe) are NOT
+ * exercised here — those depend on the Twenty client extensions landing
+ * in a parallel PR. The smoke command's other phases (parse, gate, poll)
+ * are fully covered.
+ */
+import { describe, expect, test } from "bun:test";
+
+import {
+  checkSmokeWipeGate,
+  parseSmokeCrmArgs,
+  pollOutboxUntilDrained,
+  SMOKE_EXIT,
+  type SmokeCrmDB,
+} from "../commands/ops-smoke-crm";
+import { createTwentyAdmin } from "../../lib/smoke-crm/twenty-admin";
+
+// ─────────────────────────────────────────────────────────────────────
+//  parseSmokeCrmArgs
+// ─────────────────────────────────────────────────────────────────────
+
+describe("parseSmokeCrmArgs — required fields", () => {
+  test("rejects missing --personas", () => {
+    const r = parseSmokeCrmArgs(["ops", "smoke-crm"], {
+      TWENTY_API_KEY: "k",
+      DATABASE_URL: "postgresql://x/y",
+    } as NodeJS.ProcessEnv);
+    expect("error" in r && r.error).toMatch(/--personas/);
+  });
+
+  test("rejects missing Twenty API key (no flag, no env)", () => {
+    const r = parseSmokeCrmArgs(
+      ["ops", "smoke-crm", "--personas", "./f.yml"],
+      { DATABASE_URL: "postgresql://x/y" } as NodeJS.ProcessEnv,
+    );
+    expect("error" in r && r.error).toMatch(/--twenty-api-key.*TWENTY_API_KEY/);
+  });
+
+  test("rejects missing tenant DB URL", () => {
+    const r = parseSmokeCrmArgs(
+      ["ops", "smoke-crm", "--personas", "./f.yml"],
+      { TWENTY_API_KEY: "k" } as NodeJS.ProcessEnv,
+    );
+    expect("error" in r && r.error).toMatch(/--database-url.*ATLAS_TEAM_PG_URL.*DATABASE_URL/);
+  });
+
+  test("rejects non-numeric --timeout-seconds", () => {
+    const r = parseSmokeCrmArgs(
+      ["ops", "smoke-crm", "--personas", "./f.yml", "--timeout-seconds", "abc"],
+      { TWENTY_API_KEY: "k", DATABASE_URL: "postgresql://x/y" } as NodeJS.ProcessEnv,
+    );
+    expect("error" in r && r.error).toMatch(/--timeout-seconds.*positive integer/);
+  });
+});
+
+describe("parseSmokeCrmArgs — happy path + defaults", () => {
+  test("--twenty-base-url defaults to api.twenty.com", () => {
+    const r = parseSmokeCrmArgs(
+      ["ops", "smoke-crm", "--personas", "./f.yml"],
+      { TWENTY_API_KEY: "k", DATABASE_URL: "postgresql://x/y" } as NodeJS.ProcessEnv,
+    );
+    if ("error" in r) throw new Error(r.error);
+    expect(r.twentyBaseUrl).toBe("https://api.twenty.com");
+    expect(r.timeoutSeconds).toBe(60);
+    expect(r.wipeTwenty).toBe(false);
+  });
+
+  test("flag wins over env (precedence pinned — flag is operator's explicit override)", () => {
+    const r = parseSmokeCrmArgs(
+      [
+        "ops",
+        "smoke-crm",
+        "--personas",
+        "./f.yml",
+        "--twenty-base-url",
+        "https://crm.example.com",
+        "--twenty-api-key",
+        "flag-key",
+        "--database-url",
+        "postgresql://flag/db",
+      ],
+      {
+        TWENTY_API_KEY: "env-key",
+        TWENTY_BASE_URL: "https://env.twenty.com",
+        ATLAS_TEAM_PG_URL: "postgresql://env/db",
+      } as NodeJS.ProcessEnv,
+    );
+    if ("error" in r) throw new Error(r.error);
+    expect(r.twentyBaseUrl).toBe("https://crm.example.com");
+    expect(r.twentyApiKey).toBe("flag-key");
+    expect(r.databaseUrl).toBe("postgresql://flag/db");
+  });
+
+  test("ATLAS_TEAM_PG_URL wins over DATABASE_URL", () => {
+    const r = parseSmokeCrmArgs(
+      ["ops", "smoke-crm", "--personas", "./f.yml"],
+      {
+        TWENTY_API_KEY: "k",
+        ATLAS_TEAM_PG_URL: "postgresql://team/db",
+        DATABASE_URL: "postgresql://other/db",
+      } as NodeJS.ProcessEnv,
+    );
+    if ("error" in r) throw new Error(r.error);
+    expect(r.databaseUrl).toBe("postgresql://team/db");
+  });
+
+  test("--wipe-twenty toggles the flag", () => {
+    const r = parseSmokeCrmArgs(
+      ["ops", "smoke-crm", "--personas", "./f.yml", "--wipe-twenty"],
+      { TWENTY_API_KEY: "k", DATABASE_URL: "postgresql://x/y" } as NodeJS.ProcessEnv,
+    );
+    if ("error" in r) throw new Error(r.error);
+    expect(r.wipeTwenty).toBe(true);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+//  checkSmokeWipeGate
+// ─────────────────────────────────────────────────────────────────────
+
+describe("checkSmokeWipeGate", () => {
+  test("returns null when --wipe-twenty is absent (gate doesn't apply)", () => {
+    expect(checkSmokeWipeGate(["ops", "smoke-crm"], {} as NodeJS.ProcessEnv)).toBeNull();
+  });
+
+  test("rejects --wipe-twenty without ATLAS_SMOKE_WIPE_OK", () => {
+    expect(
+      checkSmokeWipeGate(["ops", "smoke-crm", "--wipe-twenty"], {} as NodeJS.ProcessEnv),
+    ).toContain("ATLAS_SMOKE_WIPE_OK=1");
+  });
+
+  test("rejects ATLAS_SMOKE_WIPE_OK with non-`1` value (parity with ops wipe rule)", () => {
+    // Catch the shell-truthy footgun: `ATLAS_SMOKE_WIPE_OK=true` should NOT
+    // cleared the gate. The literal "1" requirement keeps it explicit.
+    expect(
+      checkSmokeWipeGate(
+        ["ops", "smoke-crm", "--wipe-twenty"],
+        { ATLAS_SMOKE_WIPE_OK: "true" } as NodeJS.ProcessEnv,
+      ),
+    ).toContain("ATLAS_SMOKE_WIPE_OK=1");
+  });
+
+  test("clears when both gates are present", () => {
+    expect(
+      checkSmokeWipeGate(
+        ["ops", "smoke-crm", "--wipe-twenty"],
+        { ATLAS_SMOKE_WIPE_OK: "1" } as NodeJS.ProcessEnv,
+      ),
+    ).toBeNull();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+//  pollOutboxUntilDrained
+// ─────────────────────────────────────────────────────────────────────
+
+interface FakeRow {
+  id: string;
+  status: "pending" | "in_flight" | "done" | "dead";
+  last_error: string | null;
+}
+
+function makeFakeDb(states: ReadonlyArray<ReadonlyArray<FakeRow>>): SmokeCrmDB {
+  let i = 0;
+  return {
+    async query<T extends Record<string, unknown>>() {
+      const rows = states[Math.min(i, states.length - 1)];
+      i++;
+      return rows as unknown as T[];
+    },
+  };
+}
+
+describe("pollOutboxUntilDrained", () => {
+  test("returns immediately when all ids are terminal on first poll", async () => {
+    const db = makeFakeDb([
+      [
+        { id: "a", status: "done", last_error: null },
+        { id: "b", status: "done", last_error: null },
+      ],
+    ]);
+    const result = await pollOutboxUntilDrained(db, ["a", "b"], 5, async () => {
+      throw new Error("sleep should not be called when first poll drains");
+    });
+    expect(result.timedOut).toBe(false);
+    expect(result.statuses.get("a")).toBe("done");
+    expect(result.deadErrors).toEqual([]);
+  });
+
+  test("collects per-id last_error when an id ends `dead`", async () => {
+    const db = makeFakeDb([
+      [
+        { id: "a", status: "done", last_error: null },
+        { id: "b", status: "dead", last_error: "twenty 503" },
+      ],
+    ]);
+    const result = await pollOutboxUntilDrained(db, ["a", "b"], 5, async () => {});
+    expect(result.timedOut).toBe(false);
+    expect(result.deadErrors).toEqual([{ id: "b", error: "twenty 503" }]);
+  });
+
+  test("times out when ids stay pending past the deadline — clock-injected", async () => {
+    // Inject `now` so the test runs in real-time microseconds rather than
+    // depending on wall-clock pacing.
+    const db = makeFakeDb([
+      [{ id: "a", status: "pending", last_error: null }],
+      [{ id: "a", status: "pending", last_error: null }],
+      [{ id: "a", status: "pending", last_error: null }],
+    ]);
+    let virtualNow = 0;
+    const result = await pollOutboxUntilDrained(
+      db,
+      ["a"],
+      1, // 1 second budget
+      async () => {
+        virtualNow += 2_000; // jump past the deadline on each tick
+      },
+      () => virtualNow,
+    );
+    expect(result.timedOut).toBe(true);
+    expect(result.statuses.get("a")).toBe("pending");
+  });
+
+  test("returns dead+done mixed when one row finishes successfully and one fails", async () => {
+    const db = makeFakeDb([
+      [
+        { id: "a", status: "pending", last_error: null },
+        { id: "b", status: "in_flight", last_error: null },
+      ],
+      [
+        { id: "a", status: "done", last_error: null },
+        { id: "b", status: "dead", last_error: "permanent: bad payload" },
+      ],
+    ]);
+    const result = await pollOutboxUntilDrained(db, ["a", "b"], 5, async () => {});
+    expect(result.timedOut).toBe(false);
+    expect(result.statuses.get("a")).toBe("done");
+    expect(result.statuses.get("b")).toBe("dead");
+    expect(result.deadErrors).toEqual([
+      { id: "b", error: "permanent: bad payload" },
+    ]);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+//  TwentyAdmin — live adapter shape
+//
+//  The live admin delegates to `@useatlas/twenty/client` exports (per PR
+//  #2867). Behaviour of those exports is tested in plugins/twenty/__tests__;
+//  here we just confirm the factory returns something with the expected
+//  method surface so a future signature drift surfaces as a type error.
+// ─────────────────────────────────────────────────────────────────────
+
+describe("createTwentyAdmin — adapter shape", () => {
+  test("returns an admin object with every TwentyAdmin method", () => {
+    const admin = createTwentyAdmin({
+      baseUrl: "https://api.twenty.com",
+      apiKey: "test-key",
+    });
+    expect(typeof admin.listAllPeople).toBe("function");
+    expect(typeof admin.listAllNotes).toBe("function");
+    expect(typeof admin.deletePerson).toBe("function");
+    expect(typeof admin.deleteNote).toBe("function");
+    expect(typeof admin.wipeWorkspace).toBe("function");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+//  Exit code surface
+// ─────────────────────────────────────────────────────────────────────
+
+describe("SMOKE_EXIT", () => {
+  test("exit codes are pinned for chained scripts", () => {
+    // A change here is a contract break — any script grepping for code 3
+    // on a diff dirty would silently start reporting clean.
+    expect(SMOKE_EXIT.OK).toBe(0);
+    expect(SMOKE_EXIT.USAGE).toBe(1);
+    expect(SMOKE_EXIT.TIMEOUT).toBe(2);
+    expect(SMOKE_EXIT.DIFF).toBe(3);
+    expect(SMOKE_EXIT.WIPE_FAIL).toBe(4);
+  });
+});

--- a/packages/cli/src/__tests__/ops-smoke-crm-cli.test.ts
+++ b/packages/cli/src/__tests__/ops-smoke-crm-cli.test.ts
@@ -241,6 +241,54 @@ describe("pollOutboxUntilDrained", () => {
       { id: "b", error: "permanent: bad payload" },
     ]);
   });
+
+  test("empty ids short-circuits — no DB call, returns immediately", async () => {
+    // Defensive guard for any future code path that polls with an empty list
+    // (e.g. `--dry-run` that skips enqueue). Without the early return the
+    // for-loop trivially completes `allDone=true` on the first iteration, but
+    // the DB query still fires — which would be a no-op against `WHERE id =
+    // ANY('{}')` but wastes a roundtrip. Pin the short-circuit.
+    let queried = false;
+    const db: SmokeCrmDB = {
+      async query() {
+        queried = true;
+        return [];
+      },
+    };
+    const result = await pollOutboxUntilDrained(db, [], 5, async () => {
+      throw new Error("sleep must not be called");
+    });
+    expect(queried).toBe(false);
+    expect(result.timedOut).toBe(false);
+    expect(result.statuses.size).toBe(0);
+    expect(result.missingFromDb).toEqual([]);
+  });
+
+  test("missingFromDb lists ids never seen in any poll response", async () => {
+    // Simulates a row deleted out-of-band during the poll (admin TRUNCATE,
+    // out-of-band cleanup, etc.). Without this, the timeout report would
+    // silently omit the missing ids and the operator wouldn't know which row
+    // to chase. Catches the silent-failure-hunter MEDIUM finding.
+    const db = makeFakeDb([
+      [
+        { id: "a", status: "done", last_error: null },
+        // "b" never appears in any response — was deleted before the poll.
+      ],
+    ]);
+    const result = await pollOutboxUntilDrained(
+      db,
+      ["a", "b"],
+      1,
+      async () => {},
+      (() => {
+        let n = 0;
+        return () => (n++ === 0 ? 0 : 999_999);
+      })(),
+    );
+    expect(result.timedOut).toBe(true);
+    expect(result.missingFromDb).toEqual(["b"]);
+    expect(result.statuses.get("a")).toBe("done");
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────

--- a/packages/cli/src/__tests__/ops-smoke-crm-diff.test.ts
+++ b/packages/cli/src/__tests__/ops-smoke-crm-diff.test.ts
@@ -357,6 +357,150 @@ describe("computeDiff — dirty diffs", () => {
     expect(isClean(diff)).toBe(false);
   });
 
+  test("duplicate observed Persons surface as duplicateObservedEmails (#2865 dedupe regression)", () => {
+    // Codex P2-E: a dedupe regression in upsertPerson can leave two Person
+    // rows with the same primary email. The first one wins the Map lookup
+    // and the second is silently dropped — masking the real bug. Surface
+    // as a dedicated category.
+    const events: AtlasLeadEvent[] = [
+      { source: "demo", email: "alice@example.com", ip: null, userAgent: null },
+    ];
+    const expected = buildExpectedState(events);
+    const observed: ObservedState = {
+      persons: [
+        {
+          id: "p_1",
+          email: "alice@example.com",
+          atlasFirstSource: "DEMO",
+          atlasLastSource: "DEMO",
+        },
+        {
+          id: "p_2",
+          email: "alice@example.com",
+          atlasFirstSource: "SIGNUP",
+          atlasLastSource: "SIGNUP",
+        },
+      ],
+      notes: [],
+    };
+    const diff = computeDiff(expected, observed);
+    expect(diff.duplicateObservedEmails).toEqual(["alice@example.com"]);
+    expect(isClean(diff)).toBe(false);
+  });
+
+  test("strict-workspace mode flips unexpectedPersons from informational to dirty", () => {
+    // Codex P2-A: after --wipe-twenty the workspace should be empty before
+    // the smoke runs. Residual rows = partial/truncated wipe = dirty.
+    const events: AtlasLeadEvent[] = [
+      { source: "demo", email: "alice@example.com", ip: null, userAgent: null },
+    ];
+    const expected = buildExpectedState(events);
+    const observed: ObservedState = {
+      persons: [
+        {
+          id: "p_1",
+          email: "alice@example.com",
+          atlasFirstSource: "DEMO",
+          atlasLastSource: "DEMO",
+        },
+        {
+          id: "p_2",
+          email: "leftover@example.com", // residual — wipe missed it
+        },
+      ],
+      notes: [],
+    };
+    const lenient = computeDiff(expected, observed);
+    expect(isClean(lenient)).toBe(true); // informational by default
+    const strict = computeDiff(expected, observed, { requireCleanWorkspace: true });
+    expect(strict.unexpectedPersons).toEqual(["leftover@example.com"]);
+    expect(strict.strictWorkspace).toBe(true);
+    expect(isClean(strict)).toBe(false);
+  });
+
+  test("note diff matches on body too — right title, wrong body is dirty (Codex P2-D)", () => {
+    // Catches the case where a Note's title is correct (so a title-only
+    // check would pass) but the body got swapped — exactly what would
+    // happen if a dispatcher dropped the message field on a sales-form.
+    const events: AtlasLeadEvent[] = [
+      {
+        source: "sales-form",
+        email: "alice@example.com",
+        name: "Alice A",
+        company: "Acme",
+        planInterest: "Pro",
+        message: "I want the right body",
+        ip: null,
+        userAgent: null,
+      },
+    ];
+    const expected = buildExpectedState(events);
+    const observed: ObservedState = {
+      persons: [
+        {
+          id: "p_1",
+          email: "alice@example.com",
+          atlasFirstSource: "SALES_FORM",
+          atlasLastSource: "SALES_FORM",
+          name: { firstName: "Alice", lastName: "A" },
+        },
+      ],
+      notes: [
+        {
+          id: "n_1",
+          title: "Talk to sales — Acme (Pro)", // right title
+          body: "WRONG BODY",
+          personEmail: "alice@example.com",
+        },
+      ],
+    };
+    const diff = computeDiff(expected, observed);
+    expect(diff.missingNotes).toHaveLength(1);
+    expect(diff.missingNotes[0].body).toBe("I want the right body");
+    expect(isClean(diff)).toBe(false);
+  });
+
+  test("note diff multiplicity — expected 2 same-titled notes, observed 1 is dirty (Codex P2-B)", () => {
+    // Same-titled sales-form events on the same email = 2 distinct notes
+    // (per #2729 idempotency contract within row, distinct rows produce
+    // distinct notes). A title-only contains-check would pass.
+    const events: AtlasLeadEvent[] = [
+      makeSalesForm("a@b.com", "Alice A", "Acme"),
+      makeSalesForm("a@b.com", "Alice A", "Acme"),
+    ];
+    const expected = buildExpectedState(events);
+    const observed: ObservedState = {
+      persons: [
+        {
+          id: "p_1",
+          email: "a@b.com",
+          atlasFirstSource: "SALES_FORM",
+          atlasLastSource: "SALES_FORM",
+          name: { firstName: "Alice", lastName: "A" },
+        },
+      ],
+      notes: [
+        {
+          id: "n_1",
+          title: "Talk to sales — Acme (Pro)",
+          body: "msg",
+          personEmail: "a@b.com",
+        },
+        // The second note is missing.
+      ],
+    };
+    const diff = computeDiff(expected, observed);
+    // missingNotes counts the multiplicity gap (expected 2, observed 1 = 1 missing).
+    expect(diff.missingNotes).toHaveLength(1);
+    // noteCountMismatches also fires on the per-email total.
+    expect(diff.noteCountMismatches).toContainEqual({
+      personEmail: "a@b.com",
+      expected: 2,
+      observed: 1,
+    });
+    expect(isClean(diff)).toBe(false);
+  });
+
   test("atlasIp absent from fixture → no atlasIp check is emitted (no false positive)", () => {
     // Many personas don't carry an IP. The diff must not fire a mismatch on
     // `expected="(unset)", observed="(unset)"` in that case.
@@ -421,9 +565,11 @@ describe("formatDiff", () => {
       {
         missingPersons: [],
         unexpectedPersons: [],
+        duplicateObservedEmails: [],
         mismatchedPersons: [],
         missingNotes: [],
         noteCountMismatches: [],
+        strictWorkspace: false,
       },
       {
         totals: {
@@ -442,11 +588,13 @@ describe("formatDiff", () => {
     const out = formatDiff({
       missingPersons: ["a@b.com"],
       unexpectedPersons: ["pre@x.com"],
+      duplicateObservedEmails: ["dup@x.com"],
       mismatchedPersons: [
         { email: "c@d.com", field: "atlasFirstSource", expected: "DEMO", observed: "SIGNUP" },
       ],
       missingNotes: [{ personEmail: "e@f.com", title: "T", body: "B" }],
       noteCountMismatches: [{ personEmail: "g@h.com", expected: 1, observed: 2 }],
+      strictWorkspace: false,
     });
     expect(out).toContain("Missing Persons (1)");
     expect(out).toContain("Unexpected Persons");
@@ -455,6 +603,8 @@ describe("formatDiff", () => {
     expect(out).toContain("Missing Notes (1)");
     expect(out).toContain("Note count mismatches (1)");
     expect(out).toContain("g@h.com: expected 1, observed 2");
+    expect(out).toContain("Duplicate observed Persons (1)");
+    expect(out).toContain("dup@x.com");
     expect(out).not.toContain("✓ Diff is clean");
   });
 
@@ -463,14 +613,32 @@ describe("formatDiff", () => {
     const out = formatDiff({
       missingPersons: [],
       unexpectedPersons: [],
+      duplicateObservedEmails: [],
       mismatchedPersons: [
         { email: "a@b.com", field: "atlasFirstSource", expected: "DEMO", observed: "(unset)" },
       ],
       missingNotes: [],
       noteCountMismatches: [],
+      strictWorkspace: false,
     });
     expect(out).toContain('observed="(unset)"');
     expect(out).not.toContain("undefined");
+  });
+
+  test("unexpectedPersons label flips to ✗ in strictWorkspace mode (post-wipe)", () => {
+    // Codex P2-A: after --wipe-twenty the workspace is supposed to be
+    // deterministic; residual rows mean partial / truncated wipe.
+    const out = formatDiff({
+      missingPersons: [],
+      unexpectedPersons: ["leftover@x.com"],
+      duplicateObservedEmails: [],
+      mismatchedPersons: [],
+      missingNotes: [],
+      noteCountMismatches: [],
+      strictWorkspace: true,
+    });
+    expect(out).toContain("✗ Unexpected Persons");
+    expect(out).toContain("wipe did not fully drain");
   });
 });
 

--- a/packages/cli/src/__tests__/ops-smoke-crm-diff.test.ts
+++ b/packages/cli/src/__tests__/ops-smoke-crm-diff.test.ts
@@ -1,0 +1,397 @@
+/**
+ * Unit tests for the smoke-crm diff reporter.
+ *
+ * These pin the exact diagnostic shape from PR #2865's comment thread:
+ *  - N distinct personas → N distinct expected Persons (collapsed by email).
+ *  - atlasFirstSource is sticky across the same email; atlasLastSource isn't.
+ *  - A demo→signup pair on the same email collapses to ONE expected Person
+ *    with first=DEMO, last=SIGNUP.
+ *  - Each sales-form persona produces exactly one expected Note on its
+ *    matching Person; duplicate sales-form events on the same email produce
+ *    two Notes (per #2729's idempotency contract).
+ *  - The bug #2865 surfaces as: every expected email is `missingPersons`
+ *    except the one Person the workspace collapsed onto, plus a
+ *    `noteCountMismatch` reading the inflated count.
+ */
+import { describe, expect, test } from "bun:test";
+
+import type { AtlasLeadEvent } from "@useatlas/twenty/lead-normalizer";
+
+import {
+  buildExpectedState,
+  computeDiff,
+  formatDiff,
+  isClean,
+  type ObservedState,
+  type ExpectedNote,
+} from "../../lib/smoke-crm/diff";
+
+// ─────────────────────────────────────────────────────────────────────
+//  buildExpectedState
+// ─────────────────────────────────────────────────────────────────────
+
+describe("buildExpectedState — single-event cases", () => {
+  test("demo persona → one Person, no Notes", () => {
+    const state = buildExpectedState([
+      { source: "demo", email: "a@b.com", ip: null, userAgent: null },
+    ]);
+    expect(state.persons).toHaveLength(1);
+    expect(state.persons[0]).toEqual({
+      email: "a@b.com",
+      atlasFirstSource: "DEMO",
+      atlasLastSource: "DEMO",
+    });
+    expect(state.notes).toEqual([]);
+  });
+
+  test("sales-form persona → one Person, one Note", () => {
+    const state = buildExpectedState([
+      {
+        source: "sales-form",
+        email: "alice@acme.com",
+        name: "Alice Anderson",
+        company: "Acme",
+        planInterest: "Pro",
+        message: "interested",
+        ip: "1.2.3.4",
+        userAgent: null,
+      },
+    ]);
+    expect(state.persons).toHaveLength(1);
+    expect(state.persons[0].atlasFirstSource).toBe("SALES_FORM");
+    expect(state.persons[0].atlasLastSource).toBe("SALES_FORM");
+    expect(state.persons[0].name).toEqual({ firstName: "Alice", lastName: "Anderson" });
+    expect(state.persons[0].atlasIp).toBe("1.2.3.4");
+    expect(state.notes).toEqual([
+      {
+        personEmail: "alice@acme.com",
+        title: "Talk to sales — Acme (Pro)",
+        body: "interested",
+      },
+    ]);
+  });
+});
+
+describe("buildExpectedState — multi-event email collapses", () => {
+  test("demo → signup on the same email keeps atlasFirstSource sticky", () => {
+    // This is the C10 stickiness pair from the default fixture.
+    const events: AtlasLeadEvent[] = [
+      { source: "demo", email: "g@globex.com", ip: null, userAgent: null },
+      { source: "signup", email: "g@globex.com", name: "Greta Worth" },
+    ];
+    const state = buildExpectedState(events);
+    expect(state.persons).toHaveLength(1);
+    expect(state.persons[0]).toMatchObject({
+      email: "g@globex.com",
+      atlasFirstSource: "DEMO",
+      atlasLastSource: "SIGNUP",
+      name: { firstName: "Greta", lastName: "Worth" },
+    });
+  });
+
+  test("demo → demo idempotency pair collapses to one Person", () => {
+    // B8 idempotency pair — duplicate dispatches must not produce duplicate Persons.
+    const events: AtlasLeadEvent[] = [
+      { source: "demo", email: "m@cyberdyne.com", ip: "1.1.1.1", userAgent: null },
+      { source: "demo", email: "m@cyberdyne.com", ip: "2.2.2.2", userAgent: null },
+    ];
+    const state = buildExpectedState(events);
+    expect(state.persons).toHaveLength(1);
+    expect(state.persons[0]).toEqual({
+      email: "m@cyberdyne.com",
+      atlasFirstSource: "DEMO",
+      atlasLastSource: "DEMO",
+      atlasIp: "2.2.2.2", // last-write-wins on the customField
+    });
+    expect(state.notes).toEqual([]);
+  });
+
+  test("two sales-form events on the same email produce TWO Notes", () => {
+    // Per #2729 idempotency contract: createNote runs once per dispatch.
+    // Same email → one Person but two Notes.
+    const events: AtlasLeadEvent[] = [
+      {
+        source: "sales-form",
+        email: "a@b.com",
+        name: "Alice A",
+        company: "Acme",
+        planInterest: "Pro",
+        message: "first",
+        ip: null,
+        userAgent: null,
+      },
+      {
+        source: "sales-form",
+        email: "a@b.com",
+        name: "Alice A",
+        company: "Acme",
+        planInterest: "Pro",
+        message: "second",
+        ip: null,
+        userAgent: null,
+      },
+    ];
+    const state = buildExpectedState(events);
+    expect(state.persons).toHaveLength(1);
+    expect(state.notes).toHaveLength(2);
+    expect(state.notes.map((n) => n.body).sort()).toEqual(["first", "second"]);
+  });
+
+  test("10-persona default-fixture shape → 8 distinct Persons + 4 Notes", () => {
+    // Mirror of the default fixture (without re-reading the file).
+    const events: AtlasLeadEvent[] = [
+      // 4 sales-form
+      makeSalesForm("dlockhart@initech.com", "David Lockhart", "Initech"),
+      makeSalesForm("wbell@massivedynamic.com", "Walter Bell", "Massive Dynamic"),
+      makeSalesForm("vmiller@veridiandynamics.com", "Veronica Miller", "Veridian Dynamics"),
+      makeSalesForm("kflynn@encom.com", "Kevin Flynn", "ENCOM"),
+      // 1 demo
+      { source: "demo", email: "jvalois@pendantpub.com", ip: null, userAgent: null },
+      // 1 signup
+      { source: "signup", email: "lallworth@wayneent.com", name: "Lucius Allworth" },
+      // 1 demo→signup pair (same email)
+      { source: "demo", email: "g@globex.com", ip: null, userAgent: null },
+      { source: "signup", email: "g@globex.com", name: "Greta Worth" },
+      // 1 demo→demo pair (same email)
+      { source: "demo", email: "m@cyberdyne.com", ip: null, userAgent: null },
+      { source: "demo", email: "m@cyberdyne.com", ip: null, userAgent: null },
+    ];
+    const state = buildExpectedState(events);
+    // 4 sales-form emails + jvalois + lallworth + g@globex.com + m@cyberdyne.com = 8 distinct
+    expect(state.persons).toHaveLength(8);
+    expect(state.notes).toHaveLength(4); // one per sales-form persona
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+//  computeDiff + isClean
+// ─────────────────────────────────────────────────────────────────────
+
+describe("computeDiff — clean diff", () => {
+  test("isClean is true when expected matches observed exactly", () => {
+    const expected = buildExpectedState([
+      { source: "demo", email: "a@b.com", ip: null, userAgent: null },
+    ]);
+    const observed: ObservedState = {
+      persons: [
+        { id: "p_1", email: "a@b.com", atlasFirstSource: "DEMO", atlasLastSource: "DEMO" },
+      ],
+      notes: [],
+    };
+    const diff = computeDiff(expected, observed);
+    expect(isClean(diff)).toBe(true);
+  });
+
+  test("unexpectedPersons (workspace had pre-existing rows) does NOT mark diff dirty", () => {
+    // The smoke command runs against a workspace that may have unrelated
+    // rows; without --wipe-twenty we shouldn't fail just because the
+    // workspace isn't pristine.
+    const expected = buildExpectedState([
+      { source: "demo", email: "a@b.com", ip: null, userAgent: null },
+    ]);
+    const observed: ObservedState = {
+      persons: [
+        { id: "p_1", email: "a@b.com", atlasFirstSource: "DEMO", atlasLastSource: "DEMO" },
+        { id: "p_2", email: "pre-existing@example.com" }, // unrelated
+      ],
+      notes: [],
+    };
+    const diff = computeDiff(expected, observed);
+    expect(diff.unexpectedPersons).toEqual(["pre-existing@example.com"]);
+    expect(isClean(diff)).toBe(true);
+  });
+});
+
+describe("computeDiff — dirty diffs", () => {
+  test("missing Person marks the diff dirty", () => {
+    const expected = buildExpectedState([
+      { source: "demo", email: "a@b.com", ip: null, userAgent: null },
+    ]);
+    const observed: ObservedState = { persons: [], notes: [] };
+    const diff = computeDiff(expected, observed);
+    expect(diff.missingPersons).toEqual(["a@b.com"]);
+    expect(isClean(diff)).toBe(false);
+  });
+
+  test("wrong atlasFirstSource (the #2865 stickiness break) marks the diff dirty", () => {
+    const expected = buildExpectedState([
+      { source: "demo", email: "a@b.com", ip: null, userAgent: null },
+      { source: "signup", email: "a@b.com", name: "Alice" },
+    ]);
+    // Pretend the dispatcher OVERWROTE atlasFirstSource — what the
+    // pre-#2865 filter bug effectively caused on subsequent dispatches.
+    const observed: ObservedState = {
+      persons: [
+        {
+          id: "p_1",
+          email: "a@b.com",
+          atlasFirstSource: "SIGNUP", // wrong — should still be DEMO
+          atlasLastSource: "SIGNUP",
+          name: { firstName: "Alice" },
+        },
+      ],
+      notes: [],
+    };
+    const diff = computeDiff(expected, observed);
+    expect(diff.mismatchedPersons).toEqual([
+      {
+        email: "a@b.com",
+        field: "atlasFirstSource",
+        expected: "DEMO",
+        observed: "SIGNUP",
+      },
+    ]);
+    expect(isClean(diff)).toBe(false);
+  });
+
+  test("the #2865 bug — N expected Persons all collapse onto one observed Person", () => {
+    // 10 distinct emails → 1 Person in observed (the filter bug). The diff
+    // surfaces this as 9 missing Persons AND a noteCountMismatch on the
+    // one observed Person whose Notes ballooned to 10.
+    const events: AtlasLeadEvent[] = [];
+    for (let i = 0; i < 10; i++) {
+      events.push(makeSalesForm(`p${i}@example.com`, `Person ${i}`, `Co ${i}`));
+    }
+    const expected = buildExpectedState(events);
+    const observed: ObservedState = {
+      persons: [
+        {
+          id: "p_collapsed",
+          email: "p0@example.com",
+          atlasFirstSource: "SALES_FORM",
+          atlasLastSource: "SALES_FORM",
+        },
+      ],
+      notes: events.map((e, i) => ({
+        id: `n_${i}`,
+        title: `Talk to sales — Co ${i} (Pro)`,
+        body: "msg",
+        personEmail: "p0@example.com", // all linked to the one collapsed Person
+      })),
+    };
+    const diff = computeDiff(expected, observed);
+    expect(diff.missingPersons).toHaveLength(9);
+    // Note-count mismatch on the collapsed Person: expected 1 note for p0,
+    // observed 10 notes (all the other personas' notes piled on).
+    expect(diff.noteCountMismatches).toContainEqual({
+      personEmail: "p0@example.com",
+      expected: 1,
+      observed: 10,
+    });
+    expect(isClean(diff)).toBe(false);
+  });
+
+  test("note count mismatch (expected 1, observed 2) is dirty", () => {
+    const expected: ExpectedNote[] = [
+      { personEmail: "a@b.com", title: "T", body: "B" },
+    ];
+    const observed: ObservedState = {
+      persons: [{ id: "p_1", email: "a@b.com", atlasFirstSource: "SALES_FORM", atlasLastSource: "SALES_FORM" }],
+      notes: [
+        { id: "n_1", title: "T", body: "B", personEmail: "a@b.com" },
+        { id: "n_2", title: "T", body: "B", personEmail: "a@b.com" }, // duplicate
+      ],
+    };
+    const diff = computeDiff(
+      {
+        persons: [
+          {
+            email: "a@b.com",
+            atlasFirstSource: "SALES_FORM",
+            atlasLastSource: "SALES_FORM",
+          },
+        ],
+        notes: expected,
+      },
+      observed,
+    );
+    expect(diff.noteCountMismatches).toEqual([
+      { personEmail: "a@b.com", expected: 1, observed: 2 },
+    ]);
+    expect(isClean(diff)).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+//  formatDiff
+// ─────────────────────────────────────────────────────────────────────
+
+describe("formatDiff", () => {
+  test("clean diff renders a single ✓ line", () => {
+    const out = formatDiff(
+      {
+        missingPersons: [],
+        unexpectedPersons: [],
+        mismatchedPersons: [],
+        missingNotes: [],
+        noteCountMismatches: [],
+      },
+      {
+        totals: {
+          expectedPersons: 1,
+          observedPersons: 1,
+          expectedNotes: 0,
+          observedNotes: 0,
+        },
+      },
+    );
+    expect(out).toContain("✓ Diff is clean");
+    expect(out).toContain("Totals:");
+  });
+
+  test("dirty diff lists every category that has at least one finding", () => {
+    const out = formatDiff({
+      missingPersons: ["a@b.com"],
+      unexpectedPersons: ["pre@x.com"],
+      mismatchedPersons: [
+        { email: "c@d.com", field: "atlasFirstSource", expected: "DEMO", observed: "SIGNUP" },
+      ],
+      missingNotes: [{ personEmail: "e@f.com", title: "T", body: "B" }],
+      noteCountMismatches: [{ personEmail: "g@h.com", expected: 1, observed: 2 }],
+    });
+    expect(out).toContain("Missing Persons (1)");
+    expect(out).toContain("Unexpected Persons");
+    expect(out).toContain("Field mismatches (1)");
+    expect(out).toContain("c@d.com :: atlasFirstSource");
+    expect(out).toContain("Missing Notes (1)");
+    expect(out).toContain("Note count mismatches (1)");
+    expect(out).toContain("g@h.com: expected 1, observed 2");
+    expect(out).not.toContain("✓ Diff is clean");
+  });
+
+  test("renders (unset) when observed field is missing", () => {
+    // Catches a regression where missing observed fields render as "undefined".
+    const out = formatDiff({
+      missingPersons: [],
+      unexpectedPersons: [],
+      mismatchedPersons: [
+        { email: "a@b.com", field: "atlasFirstSource", expected: "DEMO", observed: "(unset)" },
+      ],
+      missingNotes: [],
+      noteCountMismatches: [],
+    });
+    expect(out).toContain('observed="(unset)"');
+    expect(out).not.toContain("undefined");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+//  Helpers
+// ─────────────────────────────────────────────────────────────────────
+
+function makeSalesForm(
+  email: string,
+  name: string,
+  company: string,
+): AtlasLeadEvent {
+  return {
+    source: "sales-form",
+    email,
+    name,
+    company,
+    planInterest: "Pro",
+    message: "msg",
+    ip: null,
+    userAgent: null,
+  };
+}

--- a/packages/cli/src/__tests__/ops-smoke-crm-diff.test.ts
+++ b/packages/cli/src/__tests__/ops-smoke-crm-diff.test.ts
@@ -271,6 +271,19 @@ describe("computeDiff — dirty diffs", () => {
     };
     const diff = computeDiff(expected, observed);
     expect(diff.missingPersons).toHaveLength(9);
+    // Source fields on p0 happen to match (both SALES_FORM) but name fields
+    // don't because the observed payload was constructed without a name —
+    // i.e. the dispatcher's PATCH-every-write merged inconsistent names
+    // across dispatches. Pin that the SOURCE fields specifically didn't
+    // mismatch: that's how the diagnostic visually separates "wrong Person
+    // entirely" (missingPersons) from "wrong attribution on the right
+    // Person" (mismatchedPersons on atlasFirstSource / atlasLastSource).
+    const sourceMismatches = diff.mismatchedPersons.filter(
+      (m) =>
+        m.email === "p0@example.com" &&
+        (m.field === "atlasFirstSource" || m.field === "atlasLastSource"),
+    );
+    expect(sourceMismatches).toHaveLength(0);
     // Note-count mismatch on the collapsed Person: expected 1 note for p0,
     // observed 10 notes (all the other personas' notes piled on).
     expect(diff.noteCountMismatches).toContainEqual({
@@ -279,6 +292,92 @@ describe("computeDiff — dirty diffs", () => {
       observed: 10,
     });
     expect(isClean(diff)).toBe(false);
+  });
+
+  test("atlasIp mismatch on an existing Person is surfaced", () => {
+    // The #2737-shape regression: dispatcher writes atlasIp on the wrong
+    // Person. The fixture supplied 1.2.3.4 but Twenty has 9.9.9.9.
+    const events: AtlasLeadEvent[] = [
+      { source: "demo", email: "alice@example.com", ip: "1.2.3.4", userAgent: null },
+    ];
+    const expected = buildExpectedState(events);
+    const observed: ObservedState = {
+      persons: [
+        {
+          id: "p_1",
+          email: "alice@example.com",
+          atlasFirstSource: "DEMO",
+          atlasLastSource: "DEMO",
+          atlasIp: "9.9.9.9",
+        },
+      ],
+      notes: [],
+    };
+    const diff = computeDiff(expected, observed);
+    expect(diff.mismatchedPersons).toContainEqual({
+      email: "alice@example.com",
+      field: "atlasIp",
+      expected: "1.2.3.4",
+      observed: "9.9.9.9",
+    });
+    expect(isClean(diff)).toBe(false);
+  });
+
+  test("atlasStripeCustomerId mismatch on an existing Person is surfaced", () => {
+    // The #2737-shape regression: Stripe conversion stamps the wrong cus_
+    // on the matching Twenty Person. Without this check the smoke would
+    // report clean on a real attribution bug.
+    const events: AtlasLeadEvent[] = [
+      {
+        source: "conversion",
+        email: "paying@example.com",
+        stripeCustomerId: "cus_expected",
+      },
+    ];
+    const expected = buildExpectedState(events);
+    const observed: ObservedState = {
+      persons: [
+        {
+          id: "p_1",
+          email: "paying@example.com",
+          atlasFirstSource: "CONVERSION",
+          atlasLastSource: "CONVERSION",
+          atlasStripeCustomerId: "cus_wrong",
+        },
+      ],
+      notes: [],
+    };
+    const diff = computeDiff(expected, observed);
+    expect(diff.mismatchedPersons).toContainEqual({
+      email: "paying@example.com",
+      field: "atlasStripeCustomerId",
+      expected: "cus_expected",
+      observed: "cus_wrong",
+    });
+    expect(isClean(diff)).toBe(false);
+  });
+
+  test("atlasIp absent from fixture → no atlasIp check is emitted (no false positive)", () => {
+    // Many personas don't carry an IP. The diff must not fire a mismatch on
+    // `expected="(unset)", observed="(unset)"` in that case.
+    const events: AtlasLeadEvent[] = [
+      { source: "demo", email: "alice@example.com", ip: null, userAgent: null },
+    ];
+    const expected = buildExpectedState(events);
+    const observed: ObservedState = {
+      persons: [
+        {
+          id: "p_1",
+          email: "alice@example.com",
+          atlasFirstSource: "DEMO",
+          atlasLastSource: "DEMO",
+        },
+      ],
+      notes: [],
+    };
+    const diff = computeDiff(expected, observed);
+    expect(diff.mismatchedPersons).toEqual([]);
+    expect(isClean(diff)).toBe(true);
   });
 
   test("note count mismatch (expected 1, observed 2) is dirty", () => {

--- a/packages/cli/src/__tests__/ops-smoke-crm-fixture.test.ts
+++ b/packages/cli/src/__tests__/ops-smoke-crm-fixture.test.ts
@@ -1,0 +1,259 @@
+/**
+ * Unit tests for the persona fixture parser.
+ *
+ * The fixture is operator-authored, so the tests focus on:
+ *  - Happy path: every AtlasLeadEvent variant round-trips correctly.
+ *  - Error path: every required-field omission and unknown-source case
+ *    surfaces a per-persona-indexed error (not a generic schema blob).
+ *  - The shipped default fixture (`scripts/test-fixtures/crm-personas.yml`)
+ *    matches the coverage matrix declared in issue #2866.
+ */
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import {
+  FixtureParseError,
+  loadFixture,
+  parseFixtureYaml,
+} from "../../lib/smoke-crm/fixture";
+
+describe("parseFixtureYaml — happy path", () => {
+  test("parses a sales-form persona with all fields", () => {
+    const yaml = `
+personas:
+  - source: sales-form
+    email: alice@example.com
+    name: Alice Anderson
+    company: Acme Corp
+    planInterest: Pro
+    message: |
+      Multi-line
+      message body.
+    ip: 1.2.3.4
+`;
+    const events = parseFixtureYaml(yaml);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      source: "sales-form",
+      email: "alice@example.com",
+      name: "Alice Anderson",
+      company: "Acme Corp",
+      planInterest: "Pro",
+      ip: "1.2.3.4",
+      userAgent: null,
+    });
+    // js-yaml's literal block scalar (`|`) chomping keeps interior newlines;
+    // exact trailing-newline behaviour depends on the chomp indicator and the
+    // trailing-line presence, so we assert on substrings rather than equality.
+    const msg = (events[0] as Extract<typeof events[0], { source: "sales-form" }>).message;
+    expect(msg).toContain("Multi-line");
+    expect(msg).toContain("message body.");
+  });
+
+  test("parses a demo persona with optional ip omitted", () => {
+    const yaml = `
+personas:
+  - source: demo
+    email: bob@example.com
+`;
+    const events = parseFixtureYaml(yaml);
+    expect(events[0]).toEqual({
+      source: "demo",
+      email: "bob@example.com",
+      ip: null,
+      userAgent: null,
+    });
+  });
+
+  test("parses a signup persona; name is optional", () => {
+    const yamlNoName = `
+personas:
+  - source: signup
+    email: carol@example.com
+`;
+    const events = parseFixtureYaml(yamlNoName);
+    expect(events[0]).toEqual({ source: "signup", email: "carol@example.com" });
+
+    const yamlWithName = `
+personas:
+  - source: signup
+    email: dan@example.com
+    name: Dan Davies
+`;
+    const events2 = parseFixtureYaml(yamlWithName);
+    expect(events2[0]).toEqual({
+      source: "signup",
+      email: "dan@example.com",
+      name: "Dan Davies",
+    });
+  });
+
+  test("parses a conversion persona", () => {
+    const yaml = `
+personas:
+  - source: conversion
+    email: eve@example.com
+    stripeCustomerId: cus_test_xyz
+`;
+    const events = parseFixtureYaml(yaml);
+    expect(events[0]).toEqual({
+      source: "conversion",
+      email: "eve@example.com",
+      stripeCustomerId: "cus_test_xyz",
+    });
+  });
+});
+
+describe("parseFixtureYaml — error paths", () => {
+  test("rejects empty personas array", () => {
+    expect(() => parseFixtureYaml(`personas: []`)).toThrow(/at least one persona/);
+  });
+
+  test("rejects missing personas key", () => {
+    expect(() => parseFixtureYaml(`foo: bar`)).toThrow(/personas/);
+  });
+
+  test("rejects non-string source", () => {
+    const yaml = `
+personas:
+  - source: 42
+    email: x@y.com
+`;
+    expect(() => parseFixtureYaml(yaml)).toThrow(/persona\[0\].*source/);
+  });
+
+  test("rejects unknown source — error message lists the valid set", () => {
+    const yaml = `
+personas:
+  - source: webhook
+    email: x@y.com
+`;
+    expect(() => parseFixtureYaml(yaml)).toThrow(
+      /persona\[0\].*unknown source "webhook".*sales-form, demo, signup, conversion/,
+    );
+  });
+
+  test("error message includes the persona index for late personas", () => {
+    // Catches a regression where the index resets per-persona.
+    const yaml = `
+personas:
+  - source: demo
+    email: a@b.com
+  - source: demo
+    email: c@d.com
+  - source: sales-form
+    email: e@f.com
+    # missing name / company / planInterest / message
+`;
+    expect(() => parseFixtureYaml(yaml)).toThrow(/persona\[2\]/);
+  });
+
+  test("sales-form requires every field — name", () => {
+    const yaml = `
+personas:
+  - source: sales-form
+    email: x@y.com
+    company: A
+    planInterest: Pro
+    message: hi
+`;
+    expect(() => parseFixtureYaml(yaml)).toThrow(/persona\[0\].*name/);
+  });
+
+  test("sales-form rejects empty-string fields", () => {
+    // Empty strings would be uselessly written to Twenty Person.name —
+    // catch them at the parser rather than letting the dispatcher PATCH
+    // an empty name over an existing one.
+    const yaml = `
+personas:
+  - source: sales-form
+    email: x@y.com
+    name: "  "
+    company: A
+    planInterest: Pro
+    message: hi
+`;
+    expect(() => parseFixtureYaml(yaml)).toThrow(/persona\[0\].*name/);
+  });
+
+  test("YAML syntax error surfaces with the file context", () => {
+    expect(() => parseFixtureYaml(`personas: [\n  not closed`)).toThrow(FixtureParseError);
+  });
+});
+
+describe("loadFixture — default fixture coverage matrix", () => {
+  const fixturePath = resolve(
+    import.meta.dir,
+    "../../../../scripts/test-fixtures/crm-personas.yml",
+  );
+
+  test("default fixture exists and parses cleanly", () => {
+    // Sanity — the shipped fixture must always parse, regardless of edits.
+    const text = readFileSync(fixturePath, "utf-8");
+    expect(() => parseFixtureYaml(text)).not.toThrow();
+  });
+
+  test("default fixture matches the issue #2866 coverage matrix", () => {
+    // 4 sales-form + 1 demo + 1 signup + 2 (demo→signup) + 2 (demo→demo) = 10
+    const events = loadFixture(fixturePath);
+    expect(events).toHaveLength(10);
+    const counts = events.reduce<Record<string, number>>((acc, e) => {
+      acc[e.source] = (acc[e.source] ?? 0) + 1;
+      return acc;
+    }, {});
+    expect(counts["sales-form"]).toBe(4);
+    expect(counts.demo).toBe(4); // 1 standalone + 1 (stickiness pair) + 2 (idempotency pair)
+    expect(counts.signup).toBe(2); // 1 standalone + 1 (stickiness pair)
+    expect(counts.conversion).toBeUndefined();
+  });
+
+  test("default fixture has a demo→signup stickiness pair on the same email", () => {
+    const events = loadFixture(fixturePath);
+    const pairs = new Map<string, string[]>();
+    for (const e of events) {
+      const sources = pairs.get(e.email) ?? [];
+      sources.push(e.source);
+      pairs.set(e.email, sources);
+    }
+    const stickinessPairs = [...pairs.values()].filter(
+      (sources) => sources.length === 2 && sources[0] === "demo" && sources[1] === "signup",
+    );
+    expect(stickinessPairs).toHaveLength(1);
+  });
+
+  test("default fixture has a demo→demo idempotency pair on the same email", () => {
+    const events = loadFixture(fixturePath);
+    const pairs = new Map<string, string[]>();
+    for (const e of events) {
+      const sources = pairs.get(e.email) ?? [];
+      sources.push(e.source);
+      pairs.set(e.email, sources);
+    }
+    const idempotencyPairs = [...pairs.values()].filter(
+      (sources) => sources.length === 2 && sources[0] === "demo" && sources[1] === "demo",
+    );
+    expect(idempotencyPairs).toHaveLength(1);
+  });
+
+  test("default fixture matches PR #2865 comment thread company list", () => {
+    // The companies are pinned so manual smoke and automated smoke converge
+    // on the same dataset — operators can spot-check Twenty against this
+    // list. A future PR adding personas should extend, not replace.
+    const events = loadFixture(fixturePath);
+    const companies = events
+      .filter((e): e is Extract<typeof e, { source: "sales-form" }> => e.source === "sales-form")
+      .map((e) => e.company);
+    expect(companies.sort()).toEqual(
+      ["Initech", "Massive Dynamic", "Veridian Dynamics", "ENCOM"].sort(),
+    );
+  });
+});
+
+describe("loadFixture — file errors", () => {
+  test("missing file surfaces an actionable FixtureParseError", () => {
+    expect(() => loadFixture("/nonexistent/path/personas.yml")).toThrow(
+      /cannot read fixture file/,
+    );
+  });
+});

--- a/packages/cli/src/__tests__/ops-smoke-crm-fixture.test.ts
+++ b/packages/cli/src/__tests__/ops-smoke-crm-fixture.test.ts
@@ -177,6 +177,59 @@ personas:
     expect(() => parseFixtureYaml(yaml)).toThrow(/persona\[0\].*name/);
   });
 
+  // The remaining error-path tests below pin every required field for every
+  // variant. Closes pr-test-analyzer G4 — without these, a future refactor
+  // that drops a required field from one variant ships green.
+
+  test.each([
+    ["company", "personas:\n  - source: sales-form\n    email: x@y.com\n    name: A B\n    planInterest: Pro\n    message: hi\n"],
+    ["planInterest", "personas:\n  - source: sales-form\n    email: x@y.com\n    name: A B\n    company: Co\n    message: hi\n"],
+    ["message", "personas:\n  - source: sales-form\n    email: x@y.com\n    name: A B\n    company: Co\n    planInterest: Pro\n"],
+    ["email", "personas:\n  - source: sales-form\n    name: A B\n    company: Co\n    planInterest: Pro\n    message: hi\n"],
+  ])("sales-form requires %s", (field, yaml) => {
+    expect(() => parseFixtureYaml(yaml)).toThrow(new RegExp(`persona\\[0\\].*${field}`));
+  });
+
+  test("demo requires email", () => {
+    expect(() => parseFixtureYaml(`personas:\n  - source: demo\n`)).toThrow(
+      /persona\[0\].*email/,
+    );
+  });
+
+  test("signup requires email", () => {
+    expect(() => parseFixtureYaml(`personas:\n  - source: signup\n    name: Alice\n`)).toThrow(
+      /persona\[0\].*email/,
+    );
+  });
+
+  test("conversion requires stripeCustomerId", () => {
+    // The variant exists in the parser today even though the default fixture
+    // doesn't ship one yet (parked behind Stripe test-fixture wiring per
+    // #2866). When that ships, this guard catches a drop of stripeCustomerId.
+    expect(
+      () => parseFixtureYaml(`personas:\n  - source: conversion\n    email: x@y.com\n`),
+    ).toThrow(/persona\[0\].*stripeCustomerId/);
+  });
+
+  test("conversion requires email", () => {
+    expect(
+      () => parseFixtureYaml(`personas:\n  - source: conversion\n    stripeCustomerId: cus_x\n`),
+    ).toThrow(/persona\[0\].*email/);
+  });
+
+  test("optionalString rejects non-string values (e.g. YAML coerces unquoted numerics)", () => {
+    // YAML autoescapes `ip: 12345` into a JS number. Without the guard, the
+    // parser would silently coerce it to "12345" — masking the operator's
+    // likely typo (intended quoted IP literal).
+    const yaml = `
+personas:
+  - source: demo
+    email: x@y.com
+    ip: 12345
+`;
+    expect(() => parseFixtureYaml(yaml)).toThrow(/persona\[0\].*ip.*must be a string/);
+  });
+
   test("YAML syntax error surfaces with the file context", () => {
     expect(() => parseFixtureYaml(`personas: [\n  not closed`)).toThrow(FixtureParseError);
   });

--- a/packages/cli/src/commands/ops-smoke-crm.ts
+++ b/packages/cli/src/commands/ops-smoke-crm.ts
@@ -9,9 +9,9 @@
  * Scope (per issue #2866):
  *   - Below Turnstile only — no form-layer scripting (manual A5/A6).
  *   - Live-network only locally; this CLI never runs in CI.
- *   - Unit tests cover fixture parsing + diff reporting; live phases are
- *     guarded by the `TwentyAdmin` interface (stubbed today, wired after
- *     the parallel Twenty client extensions PR merges).
+ *   - Unit tests cover fixture parsing + diff reporting; the live Twenty
+ *     round-trip and the inline `/rest/noteTargets` join run only on a
+ *     local invocation against a real workspace.
  *
  * Flow:
  *   1. Parse args + fixture.
@@ -53,10 +53,13 @@ export interface SmokeCrmArgs {
 /**
  * Exit codes — pinned so chained scripts can branch on the failure mode:
  *   0  clean
- *   1  argument / fixture / unexpected error
+ *   1  argument / fixture / parse error (USAGE — operator fixable on the CLI line)
  *   2  outbox drain timed out
  *   3  diff dirty (dispatcher misbehaved or Twenty wasn't reachable)
  *   4  wipe phase failed (operator data corruption guard)
+ *   5  infrastructure failure — tenant DB unreachable, enqueue INSERT failed,
+ *      or poll query errored. Distinct from USAGE so chained scripts don't
+ *      treat "Postgres is down" the same as "bad argv".
  */
 export const SMOKE_EXIT = {
   OK: 0,
@@ -64,6 +67,7 @@ export const SMOKE_EXIT = {
   TIMEOUT: 2,
   DIFF: 3,
   WIPE_FAIL: 4,
+  INFRA: 5,
 } as const;
 
 // ─────────────────────────────────────────────────────────────────────
@@ -177,17 +181,25 @@ interface OutboxPollRow extends Record<string, unknown> {
 }
 
 /**
- * Poll `crm_outbox` for the given ids until every row reaches a terminal
- * state (`done` or `dead`) or the timeout is hit. Returns the final per-id
- * status map plus the number of `dead` rows so the caller can surface them
- * in the report even when the diff is otherwise clean.
+ * Result of `pollOutboxUntilDrained`. `statuses` carries the latest status
+ * for every id THE DB returned a row for; ids never seen in any poll
+ * response land in `missingFromDb` instead — silently dropping those
+ * would let an out-of-band TRUNCATE / DELETE corrupt the smoke report
+ * (the timeout would print only "the rows that survived" and the gap
+ * would not be visible to the operator).
  */
 export interface PollResult {
   readonly statuses: ReadonlyMap<string, "done" | "dead" | "pending" | "in_flight">;
+  readonly missingFromDb: ReadonlyArray<string>;
   readonly deadErrors: ReadonlyArray<{ id: string; error: string }>;
   readonly timedOut: boolean;
 }
 
+/**
+ * Poll `crm_outbox` for the given ids until every row reaches a terminal
+ * state (`done` or `dead`) or the timeout is hit. Empty `ids` returns
+ * immediately — the caller might be running a no-personas dry-run.
+ */
 export async function pollOutboxUntilDrained(
   db: SmokeCrmDB,
   ids: ReadonlyArray<string>,
@@ -195,6 +207,14 @@ export async function pollOutboxUntilDrained(
   sleep: (ms: number) => Promise<void> = (ms) => new Promise((r) => setTimeout(r, ms)),
   now: () => number = () => Date.now(),
 ): Promise<PollResult> {
+  if (ids.length === 0) {
+    return {
+      statuses: new Map(),
+      missingFromDb: [],
+      deadErrors: [],
+      timedOut: false,
+    };
+  }
   const deadline = now() + timeoutSeconds * 1_000;
   while (true) {
     const rows = await db.query<OutboxPollRow>(
@@ -218,11 +238,12 @@ export async function pollOutboxUntilDrained(
         });
       }
     }
+    const missingFromDb = ids.filter((id) => !statuses.has(id));
     if (allDone) {
-      return { statuses, deadErrors, timedOut: false };
+      return { statuses, missingFromDb, deadErrors, timedOut: false };
     }
     if (now() >= deadline) {
-      return { statuses, deadErrors, timedOut: true };
+      return { statuses, missingFromDb, deadErrors, timedOut: true };
     }
     await sleep(POLL_INTERVAL_MS);
   }
@@ -236,17 +257,23 @@ export async function pollOutboxUntilDrained(
  * Top-level CLI entry point. Exit codes use `SMOKE_EXIT`. Catches every
  * known failure shape and prints an actionable message; an unhandled
  * defect bubbles out to bin/atlas.ts's top-level catch.
+ *
+ * Uses `process.exitCode = X; return;` rather than `process.exit(X)` so
+ * the `finally` block runs and the pg client is cleanly closed even on
+ * error paths.
  */
 export async function handleOpsSmokeCrm(args: string[]): Promise<void> {
   const parsed = parseSmokeCrmArgs(args, process.env);
   if ("error" in parsed) {
     console.error(`[ops:smoke-crm] ${parsed.error}`);
-    process.exit(SMOKE_EXIT.USAGE);
+    process.exitCode = SMOKE_EXIT.USAGE;
+    return;
   }
   const gateError = checkSmokeWipeGate(args, process.env);
   if (gateError) {
     console.error(`[ops:smoke-crm] ${gateError}`);
-    process.exit(SMOKE_EXIT.USAGE);
+    process.exitCode = SMOKE_EXIT.USAGE;
+    return;
   }
 
   let events: AtlasLeadEvent[];
@@ -255,7 +282,8 @@ export async function handleOpsSmokeCrm(args: string[]): Promise<void> {
   } catch (err) {
     if (err instanceof FixtureParseError) {
       console.error(`[ops:smoke-crm] fixture error: ${err.message}`);
-      process.exit(SMOKE_EXIT.USAGE);
+      process.exitCode = SMOKE_EXIT.USAGE;
+      return;
     }
     throw err;
   }
@@ -280,14 +308,25 @@ export async function handleOpsSmokeCrm(args: string[]): Promise<void> {
       console.error(
         `[ops:smoke-crm] wipe failed: ${err instanceof Error ? err.message : String(err)}`,
       );
-      process.exit(SMOKE_EXIT.WIPE_FAIL);
+      process.exitCode = SMOKE_EXIT.WIPE_FAIL;
+      return;
     }
   }
 
-  // Connect to the tenant DB for the enqueue + poll phases.
+  // Connect to the tenant DB for the enqueue + poll phases. The connect
+  // itself can fail (DB down, wrong URL) — surface that as INFRA, not as
+  // an unhandled rejection at the top of bin/atlas.ts.
   const { Client } = await import("pg");
   const client = new Client({ connectionString: parsed.databaseUrl });
-  await client.connect();
+  try {
+    await client.connect();
+  } catch (err) {
+    console.error(
+      `[ops:smoke-crm] tenant DB connect failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    process.exitCode = SMOKE_EXIT.INFRA;
+    return;
+  }
   try {
     const db: SmokeCrmDB = {
       async query<T extends Record<string, unknown>>(
@@ -300,31 +339,57 @@ export async function handleOpsSmokeCrm(args: string[]): Promise<void> {
     };
 
     const enqueuedIds: string[] = [];
-    for (const event of events) {
-      const id = await enqueue(db, {
-        eventType: event.source,
-        payload: event as unknown as Record<string, unknown>,
-      });
-      enqueuedIds.push(id);
+    try {
+      for (let i = 0; i < events.length; i++) {
+        const event = events[i];
+        const id = await enqueue(db, {
+          eventType: event.source,
+          payload: event as unknown as Record<string, unknown>,
+        });
+        enqueuedIds.push(id);
+      }
+    } catch (err) {
+      // Persona-N attribution matters here — `crm_outbox` schema breakage
+      // or pg pool failure is invisible without knowing how far we got.
+      console.error(
+        `[ops:smoke-crm] enqueue failed at persona ${enqueuedIds.length + 1}/${events.length}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      process.exitCode = SMOKE_EXIT.INFRA;
+      return;
     }
     console.log(
       `[ops:smoke-crm] enqueued ${enqueuedIds.length} outbox row(s) — waiting up to ${parsed.timeoutSeconds}s for the flusher to drain`,
     );
 
-    const drainResult = await pollOutboxUntilDrained(
-      db,
-      enqueuedIds,
-      parsed.timeoutSeconds,
-    );
-    if (drainResult.timedOut) {
-      console.error(
-        `[ops:smoke-crm] timed out waiting for crm_outbox to drain — final statuses: ${[
-          ...drainResult.statuses.entries(),
-        ]
-          .map(([id, s]) => `${id.slice(0, 8)}=${s}`)
-          .join(", ")}`,
+    let drainResult;
+    try {
+      drainResult = await pollOutboxUntilDrained(
+        db,
+        enqueuedIds,
+        parsed.timeoutSeconds,
       );
-      process.exit(SMOKE_EXIT.TIMEOUT);
+    } catch (err) {
+      console.error(
+        `[ops:smoke-crm] outbox poll failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      process.exitCode = SMOKE_EXIT.INFRA;
+      return;
+    }
+    if (drainResult.timedOut) {
+      const statusList = [...drainResult.statuses.entries()]
+        .map(([id, s]) => `${id.slice(0, 8)}=${s}`)
+        .join(", ");
+      const missingList =
+        drainResult.missingFromDb.length > 0
+          ? ` missing-from-db=[${drainResult.missingFromDb
+              .map((id) => id.slice(0, 8))
+              .join(", ")}]`
+          : "";
+      console.error(
+        `[ops:smoke-crm] timed out waiting for crm_outbox to drain — final statuses: ${statusList}${missingList}`,
+      );
+      process.exitCode = SMOKE_EXIT.TIMEOUT;
+      return;
     }
     if (drainResult.deadErrors.length > 0) {
       console.error(
@@ -349,7 +414,8 @@ export async function handleOpsSmokeCrm(args: string[]): Promise<void> {
       console.error(
         `[ops:smoke-crm] failed to list Twenty workspace: ${err instanceof Error ? err.message : String(err)}`,
       );
-      process.exit(SMOKE_EXIT.DIFF);
+      process.exitCode = SMOKE_EXIT.DIFF;
+      return;
     }
 
     const expected = buildExpectedState(events);
@@ -363,10 +429,12 @@ export async function handleOpsSmokeCrm(args: string[]): Promise<void> {
     const report = formatDiff(diff, { totals });
     if (isClean(diff)) {
       console.log(report);
-      process.exit(SMOKE_EXIT.OK);
+      process.exitCode = SMOKE_EXIT.OK;
+      return;
     }
     console.error(report);
-    process.exit(SMOKE_EXIT.DIFF);
+    process.exitCode = SMOKE_EXIT.DIFF;
+    return;
   } finally {
     await client.end().catch((closeErr) => {
       console.warn(

--- a/packages/cli/src/commands/ops-smoke-crm.ts
+++ b/packages/cli/src/commands/ops-smoke-crm.ts
@@ -74,8 +74,7 @@ export const SMOKE_EXIT = {
 //  Arg parsing (unit-tested in isolation)
 // ─────────────────────────────────────────────────────────────────────
 
-function parsePositiveInt(raw: string | undefined, flag: string): number | { error: string } {
-  if (raw === undefined) return { error: `${flag} requires a value` };
+function parsePositiveInt(raw: string, flag: string): number | { error: string } {
   const n = Number.parseInt(raw, 10);
   if (!Number.isFinite(n) || n < 1) return { error: `${flag} must be a positive integer (got "${raw}")` };
   return n;

--- a/packages/cli/src/commands/ops-smoke-crm.ts
+++ b/packages/cli/src/commands/ops-smoke-crm.ts
@@ -1,0 +1,377 @@
+/**
+ * `atlas ops smoke-crm` — automated CRM lead-capture verification.
+ *
+ * Mechanizes the 10-persona manual repro from PR #2865's comment thread:
+ * inject leads BELOW the form/Turnstile layer via `enqueue`, wait for the
+ * flusher to drain, then assert against Twenty REST that the resulting
+ * Persons + Notes match what the fixture declared.
+ *
+ * Scope (per issue #2866):
+ *   - Below Turnstile only — no form-layer scripting (manual A5/A6).
+ *   - Live-network only locally; this CLI never runs in CI.
+ *   - Unit tests cover fixture parsing + diff reporting; live phases are
+ *     guarded by the `TwentyAdmin` interface (stubbed today, wired after
+ *     the parallel Twenty client extensions PR merges).
+ *
+ * Flow:
+ *   1. Parse args + fixture.
+ *   2. Optional wipe (--wipe-twenty + ATLAS_SMOKE_WIPE_OK=1 double-confirm).
+ *   3. Enqueue each persona via `enqueue` from @atlas/api/lib/lead-outbox.
+ *   4. Poll crm_outbox by the enqueued IDs until all reach done/dead, bound
+ *      by --timeout-seconds.
+ *   5. List Twenty → build observed state → diff against expected → exit.
+ */
+import { enqueue } from "@atlas/api/lib/lead-outbox/outbox";
+
+import { getFlag } from "../../lib/cli-utils";
+import { loadFixture, FixtureParseError } from "../../lib/smoke-crm/fixture";
+import {
+  buildExpectedState,
+  computeDiff,
+  formatDiff,
+  isClean,
+  type ObservedNote,
+  type ObservedPerson,
+  type ObservedState,
+} from "../../lib/smoke-crm/diff";
+import { createTwentyAdmin } from "../../lib/smoke-crm/twenty-admin";
+import type { AtlasLeadEvent } from "@useatlas/twenty/lead-normalizer";
+
+const DEFAULT_TIMEOUT_SECONDS = 60;
+const POLL_INTERVAL_MS = 1_000;
+
+/** Args block — kept as a struct so unit tests can construct one without `process.argv` cosplay. */
+export interface SmokeCrmArgs {
+  readonly personasPath: string;
+  readonly wipeTwenty: boolean;
+  readonly twentyBaseUrl: string;
+  readonly twentyApiKey: string;
+  readonly timeoutSeconds: number;
+  readonly databaseUrl: string;
+}
+
+/**
+ * Exit codes — pinned so chained scripts can branch on the failure mode:
+ *   0  clean
+ *   1  argument / fixture / unexpected error
+ *   2  outbox drain timed out
+ *   3  diff dirty (dispatcher misbehaved or Twenty wasn't reachable)
+ *   4  wipe phase failed (operator data corruption guard)
+ */
+export const SMOKE_EXIT = {
+  OK: 0,
+  USAGE: 1,
+  TIMEOUT: 2,
+  DIFF: 3,
+  WIPE_FAIL: 4,
+} as const;
+
+// ─────────────────────────────────────────────────────────────────────
+//  Arg parsing (unit-tested in isolation)
+// ─────────────────────────────────────────────────────────────────────
+
+function parsePositiveInt(raw: string | undefined, flag: string): number | { error: string } {
+  if (raw === undefined) return { error: `${flag} requires a value` };
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isFinite(n) || n < 1) return { error: `${flag} must be a positive integer (got "${raw}")` };
+  return n;
+}
+
+/**
+ * Parse the CLI args. Returns either the struct or an actionable error
+ * string. Pure — never touches `process.env` directly (caller passes env).
+ *
+ * Required:
+ *   --personas <path>
+ * Optional with sane defaults from `env`:
+ *   --twenty-base-url     | TWENTY_BASE_URL          | https://api.twenty.com
+ *   --twenty-api-key      | TWENTY_API_KEY           | (required if not in env)
+ *   --database-url        | ATLAS_TEAM_PG_URL | DATABASE_URL (required if not in env)
+ *   --timeout-seconds N   | (default 60)
+ *   --wipe-twenty         (boolean — needs ATLAS_SMOKE_WIPE_OK=1)
+ */
+export function parseSmokeCrmArgs(
+  args: string[],
+  env: NodeJS.ProcessEnv,
+): SmokeCrmArgs | { error: string } {
+  const personasPath = getFlag(args, "--personas");
+  if (!personasPath) {
+    return { error: "--personas <path> is required" };
+  }
+  const wipeTwenty = args.includes("--wipe-twenty");
+  const twentyBaseUrl =
+    getFlag(args, "--twenty-base-url") ??
+    env.TWENTY_BASE_URL ??
+    "https://api.twenty.com";
+  const twentyApiKey = getFlag(args, "--twenty-api-key") ?? env.TWENTY_API_KEY ?? "";
+  if (!twentyApiKey) {
+    return {
+      error:
+        "Twenty API key is required: pass --twenty-api-key or set TWENTY_API_KEY in the env",
+    };
+  }
+  const databaseUrl =
+    getFlag(args, "--database-url") ??
+    env.ATLAS_TEAM_PG_URL ??
+    env.DATABASE_URL ??
+    "";
+  if (!databaseUrl) {
+    return {
+      error:
+        "Tenant DB URL is required: pass --database-url or set ATLAS_TEAM_PG_URL / DATABASE_URL",
+    };
+  }
+  const timeoutRaw = getFlag(args, "--timeout-seconds");
+  let timeoutSeconds = DEFAULT_TIMEOUT_SECONDS;
+  if (timeoutRaw !== undefined) {
+    const parsed = parsePositiveInt(timeoutRaw, "--timeout-seconds");
+    if (typeof parsed === "object") return parsed;
+    timeoutSeconds = parsed;
+  }
+  return {
+    personasPath,
+    wipeTwenty,
+    twentyBaseUrl,
+    twentyApiKey,
+    timeoutSeconds,
+    databaseUrl,
+  };
+}
+
+/**
+ * Double-confirm gate for the destructive wipe phase. Mirrors the
+ * `checkWipeGate` rule in ops.ts: requires BOTH `ATLAS_SMOKE_WIPE_OK=1`
+ * in the env AND `--wipe-twenty` on the command line. Returns null when
+ * cleared, otherwise an actionable string.
+ *
+ * This gate fires ONLY when `--wipe-twenty` was passed. A smoke run
+ * without the flag skips the wipe phase entirely and bypasses this check.
+ */
+export function checkSmokeWipeGate(
+  args: string[],
+  env: NodeJS.ProcessEnv,
+): string | null {
+  if (!args.includes("--wipe-twenty")) return null;
+  if (env.ATLAS_SMOKE_WIPE_OK !== "1") {
+    return "Refusing to wipe Twenty: set ATLAS_SMOKE_WIPE_OK=1 in the env to confirm.";
+  }
+  return null;
+}
+
+// ─────────────────────────────────────────────────────────────────────
+//  Outbox polling (unit-testable — depends only on the OutboxDB shape)
+// ─────────────────────────────────────────────────────────────────────
+
+/** Minimal db surface this command needs — matches `OutboxDB` plus the poll SELECT. */
+export interface SmokeCrmDB {
+  query<T extends Record<string, unknown>>(
+    sql: string,
+    params?: unknown[],
+  ): Promise<T[]>;
+}
+
+interface OutboxPollRow extends Record<string, unknown> {
+  readonly id: string;
+  readonly status: "pending" | "in_flight" | "done" | "dead";
+  readonly last_error: string | null;
+}
+
+/**
+ * Poll `crm_outbox` for the given ids until every row reaches a terminal
+ * state (`done` or `dead`) or the timeout is hit. Returns the final per-id
+ * status map plus the number of `dead` rows so the caller can surface them
+ * in the report even when the diff is otherwise clean.
+ */
+export interface PollResult {
+  readonly statuses: ReadonlyMap<string, "done" | "dead" | "pending" | "in_flight">;
+  readonly deadErrors: ReadonlyArray<{ id: string; error: string }>;
+  readonly timedOut: boolean;
+}
+
+export async function pollOutboxUntilDrained(
+  db: SmokeCrmDB,
+  ids: ReadonlyArray<string>,
+  timeoutSeconds: number,
+  sleep: (ms: number) => Promise<void> = (ms) => new Promise((r) => setTimeout(r, ms)),
+  now: () => number = () => Date.now(),
+): Promise<PollResult> {
+  const deadline = now() + timeoutSeconds * 1_000;
+  while (true) {
+    const rows = await db.query<OutboxPollRow>(
+      `SELECT id, status, last_error FROM crm_outbox WHERE id = ANY($1::uuid[])`,
+      [ids],
+    );
+    const statuses = new Map<string, OutboxPollRow["status"]>();
+    for (const r of rows) statuses.set(r.id, r.status);
+    const deadErrors: { id: string; error: string }[] = [];
+    let allDone = true;
+    for (const id of ids) {
+      const s = statuses.get(id);
+      if (!s || s === "pending" || s === "in_flight") {
+        allDone = false;
+        continue;
+      }
+      if (s === "dead") {
+        deadErrors.push({
+          id,
+          error: rows.find((r) => r.id === id)?.last_error ?? "(no last_error recorded)",
+        });
+      }
+    }
+    if (allDone) {
+      return { statuses, deadErrors, timedOut: false };
+    }
+    if (now() >= deadline) {
+      return { statuses, deadErrors, timedOut: true };
+    }
+    await sleep(POLL_INTERVAL_MS);
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────
+//  Handler — wires it all together
+// ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Top-level CLI entry point. Exit codes use `SMOKE_EXIT`. Catches every
+ * known failure shape and prints an actionable message; an unhandled
+ * defect bubbles out to bin/atlas.ts's top-level catch.
+ */
+export async function handleOpsSmokeCrm(args: string[]): Promise<void> {
+  const parsed = parseSmokeCrmArgs(args, process.env);
+  if ("error" in parsed) {
+    console.error(`[ops:smoke-crm] ${parsed.error}`);
+    process.exit(SMOKE_EXIT.USAGE);
+  }
+  const gateError = checkSmokeWipeGate(args, process.env);
+  if (gateError) {
+    console.error(`[ops:smoke-crm] ${gateError}`);
+    process.exit(SMOKE_EXIT.USAGE);
+  }
+
+  let events: AtlasLeadEvent[];
+  try {
+    events = loadFixture(parsed.personasPath);
+  } catch (err) {
+    if (err instanceof FixtureParseError) {
+      console.error(`[ops:smoke-crm] fixture error: ${err.message}`);
+      process.exit(SMOKE_EXIT.USAGE);
+    }
+    throw err;
+  }
+  console.log(
+    `[ops:smoke-crm] loaded ${events.length} persona(s) from ${parsed.personasPath}`,
+  );
+
+  const admin = createTwentyAdmin({
+    baseUrl: parsed.twentyBaseUrl,
+    apiKey: parsed.twentyApiKey,
+  });
+
+  if (parsed.wipeTwenty) {
+    try {
+      const result = await admin.wipeWorkspace({ dryRun: false });
+      console.log(
+        `[ops:smoke-crm] wiped Twenty workspace — notes=${result.notesDeleted} ` +
+          `people=${result.peopleDeleted} companies=${result.companiesDeleted}` +
+          (result.truncated ? " (truncated — maxRecords reached)" : ""),
+      );
+    } catch (err) {
+      console.error(
+        `[ops:smoke-crm] wipe failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      process.exit(SMOKE_EXIT.WIPE_FAIL);
+    }
+  }
+
+  // Connect to the tenant DB for the enqueue + poll phases.
+  const { Client } = await import("pg");
+  const client = new Client({ connectionString: parsed.databaseUrl });
+  await client.connect();
+  try {
+    const db: SmokeCrmDB = {
+      async query<T extends Record<string, unknown>>(
+        sql: string,
+        params: unknown[] = [],
+      ): Promise<T[]> {
+        const r = await client.query(sql, params);
+        return r.rows as T[];
+      },
+    };
+
+    const enqueuedIds: string[] = [];
+    for (const event of events) {
+      const id = await enqueue(db, {
+        eventType: event.source,
+        payload: event as unknown as Record<string, unknown>,
+      });
+      enqueuedIds.push(id);
+    }
+    console.log(
+      `[ops:smoke-crm] enqueued ${enqueuedIds.length} outbox row(s) — waiting up to ${parsed.timeoutSeconds}s for the flusher to drain`,
+    );
+
+    const drainResult = await pollOutboxUntilDrained(
+      db,
+      enqueuedIds,
+      parsed.timeoutSeconds,
+    );
+    if (drainResult.timedOut) {
+      console.error(
+        `[ops:smoke-crm] timed out waiting for crm_outbox to drain — final statuses: ${[
+          ...drainResult.statuses.entries(),
+        ]
+          .map(([id, s]) => `${id.slice(0, 8)}=${s}`)
+          .join(", ")}`,
+      );
+      process.exit(SMOKE_EXIT.TIMEOUT);
+    }
+    if (drainResult.deadErrors.length > 0) {
+      console.error(
+        `[ops:smoke-crm] ${drainResult.deadErrors.length} row(s) dead-lettered before assertion:`,
+      );
+      for (const d of drainResult.deadErrors) {
+        console.error(`  - ${d.id}: ${d.error}`);
+      }
+      // Still continue to the diff phase — the dead rows will surface as
+      // missing Persons / Notes, which is the more useful diagnostic.
+    } else {
+      console.log(`[ops:smoke-crm] all ${enqueuedIds.length} row(s) reached status=done`);
+    }
+
+    // Assertion phase: read Twenty and diff.
+    let observed: ObservedState;
+    try {
+      const persons: ObservedPerson[] = await admin.listAllPeople();
+      const notes: ObservedNote[] = await admin.listAllNotes();
+      observed = { persons, notes };
+    } catch (err) {
+      console.error(
+        `[ops:smoke-crm] failed to list Twenty workspace: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      process.exit(SMOKE_EXIT.DIFF);
+    }
+
+    const expected = buildExpectedState(events);
+    const diff = computeDiff(expected, observed);
+    const totals = {
+      expectedPersons: expected.persons.length,
+      observedPersons: observed.persons.length,
+      expectedNotes: expected.notes.length,
+      observedNotes: observed.notes.length,
+    };
+    const report = formatDiff(diff, { totals });
+    if (isClean(diff)) {
+      console.log(report);
+      process.exit(SMOKE_EXIT.OK);
+    }
+    console.error(report);
+    process.exit(SMOKE_EXIT.DIFF);
+  } finally {
+    await client.end().catch((closeErr) => {
+      console.warn(
+        `[ops:smoke-crm] connection close failed: ${closeErr instanceof Error ? closeErr.message : String(closeErr)}`,
+      );
+    });
+  }
+}

--- a/packages/cli/src/commands/ops-smoke-crm.ts
+++ b/packages/cli/src/commands/ops-smoke-crm.ts
@@ -299,11 +299,34 @@ export async function handleOpsSmokeCrm(args: string[]): Promise<void> {
   if (parsed.wipeTwenty) {
     try {
       const result = await admin.wipeWorkspace({ dryRun: false });
+      if (result.dryRun) {
+        // Defensive — we asked for dryRun=false. If the underlying client
+        // returns the dry-run shape anyway, the wipe didn't run.
+        console.error(
+          `[ops:smoke-crm] wipe returned dry-run result despite dryRun=false — refusing to proceed`,
+        );
+        process.exitCode = SMOKE_EXIT.WIPE_FAIL;
+        return;
+      }
+      const truncated =
+        result.truncated.notes || result.truncated.people || result.truncated.companies
+          ? ` (truncated: notes=${result.truncated.notes} people=${result.truncated.people} companies=${result.truncated.companies})`
+          : "";
       console.log(
         `[ops:smoke-crm] wiped Twenty workspace — notes=${result.notesDeleted} ` +
-          `people=${result.peopleDeleted} companies=${result.companiesDeleted}` +
-          (result.truncated ? " (truncated — maxRecords reached)" : ""),
+          `people=${result.peopleDeleted} companies=${result.companiesDeleted}${truncated}`,
       );
+      if (result.errors.length > 0) {
+        // Per-record delete failures surface to the operator but don't abort —
+        // the post-wipe strict-clean diff (see computeDiff call below) catches
+        // any residual rows that actually matter for the smoke result.
+        console.warn(
+          `[ops:smoke-crm] wipe completed with ${result.errors.length} per-record error(s)`,
+        );
+        for (const e of result.errors) {
+          console.warn(`  - ${e.objectType} ${e.id} (HTTP ${e.status}): ${e.message}`);
+        }
+      }
     } catch (err) {
       console.error(
         `[ops:smoke-crm] wipe failed: ${err instanceof Error ? err.message : String(err)}`,
@@ -419,7 +442,12 @@ export async function handleOpsSmokeCrm(args: string[]): Promise<void> {
     }
 
     const expected = buildExpectedState(events);
-    const diff = computeDiff(expected, observed);
+    // Strict mode when --wipe-twenty is set: a wiped workspace should be
+    // deterministic afterwards, so residual rows / duplicates flip from
+    // informational to dirty. Closes Codex P2-A.
+    const diff = computeDiff(expected, observed, {
+      requireCleanWorkspace: parsed.wipeTwenty,
+    });
     const totals = {
       expectedPersons: expected.persons.length,
       observedPersons: observed.persons.length,

--- a/packages/cli/src/commands/ops.ts
+++ b/packages/cli/src/commands/ops.ts
@@ -253,13 +253,21 @@ export async function handleOps(args: string[]): Promise<void> {
   const subcommand = args[1];
   if (subcommand === "wipe") return handleWipe(args);
   if (subcommand === "backfill-crm-leads") return handleBackfillCrmLeads(args);
+  if (subcommand === "smoke-crm") {
+    const { handleOpsSmokeCrm } = await import("./ops-smoke-crm");
+    return handleOpsSmokeCrm(args);
+  }
 
   console.error(
-    "Usage: atlas ops <wipe|backfill-crm-leads> [options]\n\n" +
+    "Usage: atlas ops <wipe|backfill-crm-leads|smoke-crm> [options]\n\n" +
       "Subcommands:\n" +
       "  wipe                 TRUNCATE every public table in the tenant DB. DESTRUCTIVE — requires ATLAS_WIPE_OK=1 + --confirm.\n" +
       "  backfill-crm-leads   Enqueue every demo_leads row into crm_outbox for dispatch to Twenty.\n" +
-      "                       Flags: --dry-run, --batch-size N (default 500), --source demo, --database-url <url>\n",
+      "                       Flags: --dry-run, --batch-size N (default 500), --source demo, --database-url <url>\n" +
+      "  smoke-crm            End-to-end CRM lead-capture verification (below Turnstile).\n" +
+      "                       Flags: --personas <path> (required), --wipe-twenty (requires ATLAS_SMOKE_WIPE_OK=1),\n" +
+      "                              --twenty-base-url <url>, --twenty-api-key <key>, --timeout-seconds N (default 60),\n" +
+      "                              --database-url <url>\n",
   );
   process.exit(1);
 }

--- a/scripts/test-fixtures/crm-personas.yml
+++ b/scripts/test-fixtures/crm-personas.yml
@@ -1,0 +1,98 @@
+# CRM smoke-test fixture — drives `atlas ops smoke-crm`.
+#
+# Each persona enqueues one `crm_outbox` row that the flusher dispatches to
+# Twenty. The smoke command asserts that after the flusher drains:
+#
+#   - Distinct emails → distinct Twenty Persons (this is what #2865 broke).
+#   - First persona's source for an email stamps `atlasFirstSource` and
+#     never gets overwritten by later events (stickiness).
+#   - Last persona's source for an email stamps `atlasLastSource`.
+#   - Each sales-form persona produces one Note attached to its Person.
+#
+# Coverage (per issue #2866):
+#   - 4× sales-form  (A1–A4) — the scaled #2865 repro
+#   - 1× demo        (B7)
+#   - 1× signup      (C9)
+#   - 1× demo→signup stickiness pair (C10) — same email, different sources
+#   - 1× demo→demo idempotency pair  (B8) — same email, same source
+#
+# The companies match PR #2865's comment thread so the manual + automated
+# runs converge on the same dataset and operators can spot-check Twenty
+# against the same lookup list.
+#
+# Conversion (D12) is intentionally not in this fixture — it's parked
+# behind Stripe test-fixture wiring per issue #2866.
+
+personas:
+  # ── A1–A4: four distinct sales-form personas ───────────────────────────
+  - source: sales-form
+    email: dlockhart@initech.com
+    name: David Lockhart
+    company: Initech
+    planInterest: Pro
+    message: |
+      We're evaluating Atlas for our internal data team — interested in the
+      Pro tier and want to understand the SLA story for scheduled queries.
+    ip: 203.0.113.10
+
+  - source: sales-form
+    email: wbell@massivedynamic.com
+    name: Walter Bell
+    company: Massive Dynamic
+    planInterest: Business
+    message: |
+      Looking at Business tier for ~30 seats. Need SSO + audit retention
+      questions answered before we move forward.
+    ip: 203.0.113.11
+
+  - source: sales-form
+    email: vmiller@veridiandynamics.com
+    name: Veronica Miller
+    company: Veridian Dynamics
+    planInterest: Pro
+    message: |
+      Migrating off a hand-rolled BI stack — what does Atlas's onboarding
+      look like for an existing Postgres + ClickHouse footprint?
+    ip: 203.0.113.12
+
+  - source: sales-form
+    email: kflynn@encom.com
+    name: Kevin Flynn
+    company: ENCOM
+    planInterest: Starter
+    message: |
+      Small team (4 people) trying Starter — can we upgrade mid-cycle if
+      we land Atlas as our primary analytics surface?
+    ip: 203.0.113.13
+
+  # ── B7: standalone demo persona ────────────────────────────────────────
+  - source: demo
+    email: jvalois@pendantpub.com
+    ip: 203.0.113.20
+
+  # ── C9: standalone signup persona ──────────────────────────────────────
+  - source: signup
+    email: lallworth@wayneent.com
+    name: Lucius Allworth
+
+  # ── C10: demo → signup stickiness pair (same email) ────────────────────
+  # Expectation: one Person with atlasFirstSource=DEMO, atlasLastSource=SIGNUP.
+  # This catches a regression where the dispatcher overwrites atlasFirstSource
+  # on subsequent dispatches.
+  - source: demo
+    email: gworth@globexcorp.com
+    ip: 203.0.113.30
+  - source: signup
+    email: gworth@globexcorp.com
+    name: Greta Worth
+
+  # ── B8: demo → demo idempotency pair (same email) ──────────────────────
+  # Expectation: one Person with atlasFirstSource=DEMO, atlasLastSource=DEMO,
+  # zero Notes (demo events don't produce Notes). Catches a regression where
+  # repeat dispatches create duplicate Persons.
+  - source: demo
+    email: msdyson@cyberdynesys.com
+    ip: 203.0.113.40
+  - source: demo
+    email: msdyson@cyberdynesys.com
+    ip: 203.0.113.41


### PR DESCRIPTION
## Summary

- New `atlas ops smoke-crm` subcommand that mechanizes the 10-persona manual repro from PR #2865's comment thread. Injects leads BELOW the form / Turnstile layer via `enqueue` from `@atlas/api/lib/lead-outbox`, polls `crm_outbox` until drained, then asserts against Twenty REST that the resulting Persons + Notes match what the fixture declared.
- Catches #2865-shape regressions (filter syntax, attribution collapse, stickiness break) on every PR that touches the CRM dispatch pipeline — rather than once a milestone during manual smoke.
- Ships a 10-persona default fixture at `scripts/test-fixtures/crm-personas.yml` matching the company list from PR #2865's comment thread (Initech, Massive Dynamic, Veridian Dynamics, ENCOM, Pendant Publishing, Wayne Enterprises, Globex Corp, Cyberdyne Systems) so manual + automated runs converge on the same dataset.
- Operator doc at `docs/development/verify-crm-changes-locally.md` — when to run, prerequisites, exit-code surface.

Closes #2866.

## Base branch — stacked on #2867

This PR builds on the Twenty client extensions in #2867 (`listPeople`, `listNotes`, `deletePerson`, `deleteNote`, `wipeWorkspace`). To keep the diff focused on the CLI work, the PR's base is `worktree-twenty-mcp-script`. **Rebase to `main` once #2867 merges.**

## Scope (per issue #2866)

| In scope | Out of scope |
|---|---|
| Below-Turnstile lead injection (outbox enqueue path) | Form-layer / Cloudflare Turnstile scripting (manual A5/A6) |
| Live Twenty REST list + diff | Read-side analytics datasource (#2728) |
| Wipe phase (double-confirm gated) | CI integration (needs CI-only Twenty workspace) |
| Sales-form / demo / signup variants | Conversion (D12) — parked behind Stripe test-fixture wiring |

## Diff catches the #2865 signal

The smoke diff surfaces #2865-shaped breakage explicitly:

| Symptom in Twenty | Diff finding |
|---|---|
| 10 enqueues → 1 collapsed Person | 9 × `missingPersons` |
| `atlasFirstSource` overwritten on subsequent dispatch | `mismatchedPersons[].field = "atlasFirstSource"` |
| All Notes piled onto the one collapsed Person | `noteCountMismatch{ expected: 1, observed: 10 }` |

`unexpectedPersons` (workspace had pre-existing rows) is informational only — does NOT mark the diff dirty unless `--wipe-twenty` was used. Avoids false positives when running against a non-pristine workspace.

## Wipe gate

Mirrors the `ops wipe` double-confirm rule — needs BOTH `ATLAS_SMOKE_WIPE_OK=1` in the env AND `--wipe-twenty` on the command line. `ATLAS_SMOKE_WIPE_OK=true` does NOT clear the gate (parity with the `ops wipe` belt-and-braces check).

## Exit codes (pinned for chained scripts)

| Code | Meaning |
|---|---|
| 0 | Clean diff |
| 1 | Usage error (bad args, missing env, fixture parse failure) |
| 2 | `crm_outbox` did not drain within `--timeout-seconds` |
| 3 | Diff dirty |
| 4 | Wipe phase failed |

## Note → Person attribution

`@useatlas/twenty/client` (post-#2867) doesn't yet expose a `listNoteTargets` verb, so `lib/smoke-crm/twenty-admin.ts` does a thin direct fetch against `/rest/noteTargets` to build the Note → Person join the diff needs. Becomes a one-line delegate once a client export lands.

## Test plan

- [x] `bun test packages/cli/src/__tests__/ops-smoke-crm-*.test.ts` — 51 pass (fixture parsing, diff shape, args, gate, polling, admin adapter shape)
- [x] `bun test packages/cli/src/__tests__/ops.test.ts` — 36 pass (existing ops handler still wires correctly after subcommand routing change)
- [x] `bun run type` — clean
- [x] `bun run lint` — clean
- [x] `bun run test:others` — clean
- [x] `bun x syncpack lint` — clean
- [x] `bash scripts/check-template-drift.sh` — 697 files verified
- [x] `bash scripts/check-schema-drift.sh` — clean
- [x] `bash scripts/check-ee-imports.sh` — clean
- [x] `bash scripts/check-test-discipline.sh` — clean
- [x] `bash scripts/check-twenty-resolver-imports.sh` — clean
- [x] `bash scripts/check-railway-watch.sh` — clean
- [ ] **After this lands + #2867 lands:** `ATLAS_SMOKE_WIPE_OK=1 bun run atlas -- ops smoke-crm --personas scripts/test-fixtures/crm-personas.yml --wipe-twenty` against the real `api.twenty.com` workspace → exit 0 with 8 distinct Persons + 4 distinct Notes
- [ ] **Regression-guard:** the same command run on a branch with #2865 reverted should exit 3 with a readable diff (9 missing Persons + note-count-mismatch on the collapsed one)

## Notes

- Unit tests cover fixture parsing + diff reporting + arg parsing + polling + admin adapter shape. Live-network tests are local-only by design — no Twenty creds in CI.
- The fixture is operator-authored: invalid YAML or a missing required field fails loud with a per-persona-indexed error message (`persona[6]: planInterest is required for source=sales-form`) rather than a generic schema-violation blob.
- Doc points operators at exactly when to run this (before any PR touching `plugins/twenty/src/client.ts`, `plugins/twenty/src/lead-normalizer.ts`, `ee/src/saas-crm/index.ts`, or `packages/api/src/lib/lead-outbox/outbox.ts`).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/2869"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782431711&installation_id=135337507&pr_number=2869&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F2869&signature=d42edb96466d472cfaa3ddaf893675bdc69bae9ffbd3f2a16e3b46075ed7189a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->