### PR TITLE
fix(api): per-email serialization in crm_outbox CLAIM_SQL (1.6.0 hotfix)

### DIFF
--- a/packages/api/src/lib/auth/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/auth/__tests__/migrate.test.ts
@@ -349,6 +349,7 @@ describe("migrateAuthTables", () => {
             { name: "0101_approval_surface_gchat.sql" },
             { name: "0102_crm_outbox.sql" },
             { name: "0103_converge_salesforce_pillar.sql" },
+            { name: "0104_crm_outbox_email_key.sql" },
           ],
         };
       }

--- a/packages/api/src/lib/db/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate.test.ts
@@ -118,8 +118,9 @@ describe("runMigrations", () => {
     // + 0101 (add 'gchat' to approval-surface CHECK enums + promote
     //   gchat catalog row to 'available', #2754)
     // + 0102 (crm_outbox durable queue, #2729)
-    // + 0103 (converge salesforce row to ADR-0006 canonical pillar) = 104.
-    expect(count).toBe(104);
+    // + 0103 (converge salesforce row to ADR-0006 canonical pillar)
+    // + 0104 (crm_outbox.email_key for per-email serialization, #2870) = 105.
+    expect(count).toBe(105);
 
     // Advisory lock acquired before anything else
     expect(queries[0]).toContain("pg_advisory_lock");
@@ -252,6 +253,7 @@ describe("runMigrations", () => {
         "0101_approval_surface_gchat.sql",
         "0102_crm_outbox.sql",
         "0103_converge_salesforce_pillar.sql",
+        "0104_crm_outbox_email_key.sql",
       ],
     });
 

--- a/packages/api/src/lib/db/migrations/0104_crm_outbox_email_key.sql
+++ b/packages/api/src/lib/db/migrations/0104_crm_outbox_email_key.sql
@@ -37,19 +37,24 @@ ALTER TABLE crm_outbox ADD COLUMN IF NOT EXISTS email_key TEXT;
 -- backfill is idempotent (`WHERE email_key IS NULL`) so running this
 -- migration twice is a no-op.
 --
--- `NULLIF(LOWER(TRIM(...)), '')` mirrors the runtime `extractEmailKey`
--- helper exactly: a whitespace-only payload (`"   "`) passes a naive
--- pre-TRIM `<> ''` check but collapses to `''` after TRIM. We MUST
--- land NULL rather than `''` for those rows — a non-NULL empty-string
+-- Mirror the runtime `extractEmailKey` helper exactly:
+--   `NULLIF(LOWER(REGEXP_REPLACE(value, '^\s+|\s+$', '', 'g')), '')`
+-- A whitespace-only payload (`"   "`, `"\t\n"`, etc.) collapses to ''
+-- after the trim and we MUST land NULL — a non-NULL empty-string
 -- email_key would collide with every other whitespace-only row in
 -- CLAIM_SQL's NOT EXISTS gate, causing all such rows to mutually
--- block each other and drain at one-per-tick globally. `jsonb_typeof`
--- guards against `"email": null` and non-string types up front.
+-- block each other and drain at one-per-tick globally. The regex
+-- form matches JavaScript `String.prototype.trim()` for ASCII
+-- whitespace (space, tab, newline, CR, FF, VT); plain `TRIM()` in
+-- Postgres only strips spaces by default and would leak rows whose
+-- payload uses tabs/newlines, asymmetric with what `extractEmailKey`
+-- writes at runtime. `jsonb_typeof` guards against `"email": null`
+-- and non-string types up front.
 UPDATE crm_outbox
-SET email_key = NULLIF(LOWER(TRIM(payload->>'email')), '')
+SET email_key = NULLIF(LOWER(REGEXP_REPLACE(payload->>'email', '^\s+|\s+$', '', 'g')), '')
 WHERE email_key IS NULL
   AND jsonb_typeof(payload->'email') = 'string'
-  AND NULLIF(LOWER(TRIM(payload->>'email')), '') IS NOT NULL;
+  AND NULLIF(LOWER(REGEXP_REPLACE(payload->>'email', '^\s+|\s+$', '', 'g')), '') IS NOT NULL;
 
 -- Partial index supports both the DISTINCT-ON dedupe inside CLAIM_SQL
 -- and the NOT EXISTS gate. Filtering on the active statuses keeps the

--- a/packages/api/src/lib/db/migrations/0104_crm_outbox_email_key.sql
+++ b/packages/api/src/lib/db/migrations/0104_crm_outbox_email_key.sql
@@ -1,0 +1,52 @@
+-- 0104_crm_outbox_email_key.sql
+--
+-- Add `email_key` for per-email serialization at claim time (#2870).
+--
+-- Without this column, two `crm_outbox` rows for the same email can be
+-- claimed in the same flusher tick (or by different pods) and dispatch
+-- to Twenty in arbitrary order. That flips `atlasFirstSource` /
+-- `atlasLastSource` (the C10 stickiness contract) and leaks last-write-
+-- wins fields like `atlasIp` to whichever dispatch happens to finish
+-- last. CLAIM_SQL post-migration dedupes by `email_key` AND gates each
+-- claim on `NOT EXISTS (in_flight row for same email_key)` so:
+--
+--   1. Within a single tick batch, only the EARLIEST pending row per
+--      email is claimed. Siblings wait for the next tick after the
+--      claimed row reaches a terminal state.
+--   2. Across ticks / pods, a row for an email already in_flight is
+--      excluded from the candidate set (the partial index makes this
+--      check cheap as the table grows).
+--
+-- `email_key` is application-populated by `enqueue` rather than a
+-- `GENERATED ALWAYS AS` column so legacy payloads with a missing /
+-- malformed `email` field stay claimable (NULL email_key never matches
+-- another NULL in the NOT EXISTS clause, so those rows are treated as
+-- independent — matching today's behaviour for any future event types
+-- that aren't email-keyed). Lowercased + trimmed to match
+-- `normalizeLead`'s email normalization, so casing differences in the
+-- payload don't accidentally bypass serialization.
+
+ALTER TABLE crm_outbox ADD COLUMN IF NOT EXISTS email_key TEXT;
+
+-- Backfill existing rows from their payload. The flusher might already
+-- be running against pre-migration rows when the deploy lands — without
+-- this UPDATE those rows would have NULL email_key and dispatch
+-- concurrently (same as the pre-fix behaviour, which is the bug). The
+-- backfill is idempotent (`WHERE email_key IS NULL`) so running this
+-- migration twice is a no-op.
+UPDATE crm_outbox
+SET email_key = LOWER(TRIM(payload->>'email'))
+WHERE email_key IS NULL
+  AND payload ? 'email'
+  AND payload->>'email' IS NOT NULL
+  AND payload->>'email' <> '';
+
+-- Partial index supports both the DISTINCT-ON dedupe inside CLAIM_SQL
+-- and the NOT EXISTS gate. Filtering on the active statuses keeps the
+-- index small as done/dead rows accumulate.
+CREATE INDEX IF NOT EXISTS idx_crm_outbox_email_key_active
+  ON crm_outbox (email_key, status, created_at)
+  WHERE status IN ('pending', 'in_flight');
+
+COMMENT ON COLUMN crm_outbox.email_key IS
+  'Lowercased+trimmed primary email extracted from payload at enqueue time. CLAIM_SQL serializes per-email: only one row per email_key can be in_flight at a time, and only the earliest pending row per email is claimed each tick. Without this, demo→signup pairs and demo→demo repeats for the same email could be dispatched concurrently and apply to Twenty in arbitrary order — flipping atlasFirstSource and leaking atlasIp to whichever dispatch finished last (#2870).';

--- a/packages/api/src/lib/db/migrations/0104_crm_outbox_email_key.sql
+++ b/packages/api/src/lib/db/migrations/0104_crm_outbox_email_key.sql
@@ -18,13 +18,15 @@
 --      check cheap as the table grows).
 --
 -- `email_key` is application-populated by `enqueue` rather than a
--- `GENERATED ALWAYS AS` column so legacy payloads with a missing /
--- malformed `email` field stay claimable (NULL email_key never matches
--- another NULL in the NOT EXISTS clause, so those rows are treated as
--- independent — matching today's behaviour for any future event types
--- that aren't email-keyed). Lowercased + trimmed to match
--- `normalizeLead`'s email normalization, so casing differences in the
--- payload don't accidentally bypass serialization.
+-- `GENERATED ALWAYS AS` column so legacy payloads with a missing or
+-- malformed `email` field stay claimable. NULL rows skip the
+-- NOT EXISTS gate (`o2.email_key IS NOT NULL` short-circuits) and are
+-- their own dedup group in CLAIM_SQL via `COALESCE(email_key, id::text)`,
+-- so they dispatch independently — matching today's behaviour for any
+-- future event types that aren't email-keyed. Lowercased + trimmed to
+-- match the runtime `extractEmailKey` helper (`.trim().toLowerCase()`)
+-- and the lead-normalizer's email handling, so casing/whitespace
+-- differences in the payload don't accidentally bypass serialization.
 
 ALTER TABLE crm_outbox ADD COLUMN IF NOT EXISTS email_key TEXT;
 
@@ -34,12 +36,20 @@ ALTER TABLE crm_outbox ADD COLUMN IF NOT EXISTS email_key TEXT;
 -- concurrently (same as the pre-fix behaviour, which is the bug). The
 -- backfill is idempotent (`WHERE email_key IS NULL`) so running this
 -- migration twice is a no-op.
+--
+-- `NULLIF(LOWER(TRIM(...)), '')` mirrors the runtime `extractEmailKey`
+-- helper exactly: a whitespace-only payload (`"   "`) passes a naive
+-- pre-TRIM `<> ''` check but collapses to `''` after TRIM. We MUST
+-- land NULL rather than `''` for those rows — a non-NULL empty-string
+-- email_key would collide with every other whitespace-only row in
+-- CLAIM_SQL's NOT EXISTS gate, causing all such rows to mutually
+-- block each other and drain at one-per-tick globally. `jsonb_typeof`
+-- guards against `"email": null` and non-string types up front.
 UPDATE crm_outbox
-SET email_key = LOWER(TRIM(payload->>'email'))
+SET email_key = NULLIF(LOWER(TRIM(payload->>'email')), '')
 WHERE email_key IS NULL
-  AND payload ? 'email'
-  AND payload->>'email' IS NOT NULL
-  AND payload->>'email' <> '';
+  AND jsonb_typeof(payload->'email') = 'string'
+  AND NULLIF(LOWER(TRIM(payload->>'email')), '') IS NOT NULL;
 
 -- Partial index supports both the DISTINCT-ON dedupe inside CLAIM_SQL
 -- and the NOT EXISTS gate. Filtering on the active statuses keeps the

--- a/packages/api/src/lib/db/migrations/scripts/backfill-crm-leads.ts
+++ b/packages/api/src/lib/db/migrations/scripts/backfill-crm-leads.ts
@@ -22,6 +22,7 @@
 
 import { Client } from "pg";
 import { normalizeLead, type AtlasLeadEvent, type NormalizedLead } from "@useatlas/twenty/lead-normalizer";
+import { extractEmailKey } from "../../../lead-outbox/outbox";
 
 /** Surface every code path the script touches — keeps the unit tests
  *  decoupled from `pg.Client`. The `pg` driver's `query` returns a
@@ -124,18 +125,26 @@ const COUNT_SQL = `SELECT COUNT(*)::bigint AS n FROM demo_leads`;
 /**
  * Build a multi-row VALUES INSERT for one batch — one round trip per
  * batch instead of one per row. Positional placeholders
- * (`($1, $2::jsonb), ($3, $4::jsonb), …`) avoid binding the payload
- * JSON through `text[]`: JSON contains `{`, `,`, `"` — characters
- * that collide with Postgres's array-literal syntax and cause silent
- * row-count inflation under driver-side array serialization.
+ * (`($1, $2::jsonb, $3), ($4, $5::jsonb, $6), …`) avoid binding the
+ * payload JSON through `text[]`: JSON contains `{`, `,`, `"` —
+ * characters that collide with Postgres's array-literal syntax and
+ * cause silent row-count inflation under driver-side array
+ * serialization.
+ *
+ * `email_key` is the third per-row column (since 0104, #2870) so the
+ * historic backfill participates in per-email serialization. Without
+ * it, demo_leads rows with duplicate emails would land with NULL
+ * email_key, fall into `COALESCE(email_key, id::text)`'s per-id dedup
+ * group, and dispatch concurrently — exactly the atlasFirstSource
+ * source-swap class of bug the hotfix is designed to prevent.
  */
 function buildBulkEnqueueSql(rowCount: number): string {
   const placeholders: string[] = [];
   for (let i = 0; i < rowCount; i++) {
-    const base = i * 2;
-    placeholders.push(`($${base + 1}, $${base + 2}::jsonb, 'pending')`);
+    const base = i * 3;
+    placeholders.push(`($${base + 1}, $${base + 2}::jsonb, $${base + 3}, 'pending')`);
   }
-  return `INSERT INTO crm_outbox (event_type, payload, status) VALUES ${placeholders.join(", ")} RETURNING id`;
+  return `INSERT INTO crm_outbox (event_type, payload, email_key, status) VALUES ${placeholders.join(", ")} RETURNING id`;
 }
 
 /** Map a `demo_leads` row to the corresponding `AtlasLeadEvent`.
@@ -206,9 +215,11 @@ export async function runBackfill(options: BackfillOptions): Promise<BackfillSta
           ]);
     if (page.rows.length === 0) break;
 
-    // Flat `[event_type_0, payload_0, event_type_1, payload_1, …]` so
-    // the positional placeholders in `buildBulkEnqueueSql` line up with
-    // their VALUES tuples.
+    // Flat `[event_type_0, payload_0, email_key_0, event_type_1, …]`
+    // so the positional placeholders in `buildBulkEnqueueSql` line up
+    // with their VALUES tuples. `extractEmailKey` is shared with the
+    // runtime `enqueue` so the bulk path produces identical email_key
+    // values for identical payloads (#2870).
     const params: unknown[] = [];
     for (const row of page.rows) {
       const event = toLeadEvent(row, options.source);
@@ -218,7 +229,11 @@ export async function runBackfill(options: BackfillOptions): Promise<BackfillSta
       // Mirroring the runtime path means a normalizer change post-deploy
       // doesn't strand backfilled rows in `payload` shapes the dispatcher
       // can't interpret.
-      params.push(event.source, JSON.stringify(event));
+      params.push(
+        event.source,
+        JSON.stringify(event),
+        extractEmailKey({ email: event.email }),
+      );
 
       if (options.dryRun && sample.length < DRY_RUN_SAMPLE_SIZE) {
         sample.push(normalized);

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -2251,6 +2251,13 @@ export const crmOutbox = pgTable(
     id: uuid("id").primaryKey().defaultRandom(),
     eventType: text("event_type").notNull(),
     payload: jsonb("payload").notNull(),
+    // Per-email serialization key (0104, #2870). Lowercased+trimmed
+    // primary email extracted from `payload` at enqueue. CLAIM_SQL
+    // dedupes by this column and gates each claim on a no-in_flight
+    // check so concurrent rows for the same email never dispatch
+    // simultaneously. Nullable for legacy / non-email-keyed event
+    // types — those rows fall back to per-id deduplication.
+    emailKey: text("email_key"),
     status: text("status").$type<OutboxStatus>().notNull().default("pending"),
     attempts: integer("attempts").notNull().default(0),
     lastError: text("last_error"),
@@ -2271,6 +2278,9 @@ export const crmOutbox = pgTable(
     ),
     index("idx_crm_outbox_pending_created")
       .on(t.status, t.createdAt)
+      .where(sql`status IN ('pending', 'in_flight')`),
+    index("idx_crm_outbox_email_key_active")
+      .on(t.emailKey, t.status, t.createdAt)
       .where(sql`status IN ('pending', 'in_flight')`),
   ],
 );

--- a/packages/api/src/lib/lead-outbox/__tests__/outbox-pg.test.ts
+++ b/packages/api/src/lib/lead-outbox/__tests__/outbox-pg.test.ts
@@ -503,4 +503,116 @@ describeIfPg("lead-outbox (real Postgres)", () => {
     },
     PG_TIMEOUT_MS,
   );
+
+  // ── Per-email serialization (#2870) — real-PG variant.
+  // Mirrors the unit test in `outbox.test.ts` but exercises the actual
+  // CLAIM_SQL CTE (DISTINCT ON + NOT EXISTS) against Postgres so a
+  // regression in the SQL shape (e.g. wrong column quoting, forgotten
+  // index reference) trips here instead of only in the in-memory fake.
+  it(
+    "claim dedupes same-email rows: gworth demo→signup pair drains across two ticks",
+    async () => {
+      await truncateOutbox();
+      const db = dbFor();
+
+      const demoId = await enqueue(db, {
+        eventType: "demo",
+        payload: { source: "demo", email: "gworth@globexcorp.com", ip: "203.0.113.30" },
+      });
+      const signupId = await enqueue(db, {
+        eventType: "signup",
+        payload: { source: "signup", email: "gworth@globexcorp.com", name: "Greta Worth" },
+      });
+
+      // Both rows should have email_key populated by enqueue.
+      const seeded = await pool.query<{ id: string; email_key: string | null }>(
+        "SELECT id, email_key FROM crm_outbox ORDER BY created_at",
+      );
+      expect(seeded.rows).toHaveLength(2);
+      expect(seeded.rows[0].email_key).toBe("gworth@globexcorp.com");
+      expect(seeded.rows[1].email_key).toBe("gworth@globexcorp.com");
+
+      const dispatcher: OutboxDispatcher = async () => ({ kind: "ok" });
+
+      // Tick 1: only demo claimed; signup blocked by demo's in_flight presence
+      // mid-statement (the CTE locks demo first, then NOT EXISTS sees it as
+      // about-to-be in_flight for signup's slot). DISTINCT ON also dedupes
+      // within the same batch.
+      const tick1 = await flushBatch(db, dispatcher, 50);
+      expect(tick1.claimed).toBe(1);
+      expect(tick1.ok).toBe(1);
+
+      const afterTick1 = await pool.query<{ id: string; status: string }>(
+        "SELECT id, status FROM crm_outbox ORDER BY created_at",
+      );
+      expect(afterTick1.rows.find((r) => r.id === demoId)?.status).toBe("done");
+      expect(afterTick1.rows.find((r) => r.id === signupId)?.status).toBe("pending");
+
+      // Tick 2: demo is done, signup is now claimable.
+      const tick2 = await flushBatch(db, dispatcher, 50);
+      expect(tick2.claimed).toBe(1);
+      expect(tick2.ok).toBe(1);
+
+      const afterTick2 = await pool.query<{ status: string }>(
+        "SELECT status FROM crm_outbox WHERE id = $1",
+        [signupId],
+      );
+      expect(afterTick2.rows[0].status).toBe("done");
+    },
+    PG_TIMEOUT_MS,
+  );
+
+  it(
+    "claim NOT EXISTS gate: in_flight row blocks newer same-email claims (cross-pod safety)",
+    async () => {
+      await truncateOutbox();
+      const db = dbFor();
+
+      // Seed an in_flight row directly (simulates a sibling pod mid-dispatch).
+      await pool.query(
+        `INSERT INTO crm_outbox (event_type, payload, email_key, status, attempts, claimed_at, created_at)
+         VALUES ('demo', $1::jsonb, $2, 'in_flight', 1, now(), now() - INTERVAL '3 hours')`,
+        [
+          JSON.stringify({ source: "demo", email: "stuck@example.test" }),
+          "stuck@example.test",
+        ],
+      );
+      // Newer pending row for the same email.
+      await enqueue(db, {
+        eventType: "signup",
+        payload: { source: "signup", email: "stuck@example.test", name: "Stuck User" },
+      });
+
+      const dispatcher: OutboxDispatcher = async () => ({ kind: "ok" });
+      const result = await flushBatch(db, dispatcher, 50);
+      // No row claimable — sibling is in_flight for this email_key.
+      expect(result.claimed).toBe(0);
+
+      const rows = await pool.query<{ event_type: string; status: string }>(
+        "SELECT event_type, status FROM crm_outbox ORDER BY created_at",
+      );
+      expect(rows.rows.find((r) => r.event_type === "signup")?.status).toBe("pending");
+    },
+    PG_TIMEOUT_MS,
+  );
+
+  it(
+    "claim does not serialize across distinct emails (throughput preserved)",
+    async () => {
+      await truncateOutbox();
+      const db = dbFor();
+
+      // Four distinct emails — all should claim in one tick.
+      await enqueue(db, { eventType: "demo", payload: { source: "demo", email: "a1@example.test" } });
+      await enqueue(db, { eventType: "demo", payload: { source: "demo", email: "a2@example.test" } });
+      await enqueue(db, { eventType: "demo", payload: { source: "demo", email: "a3@example.test" } });
+      await enqueue(db, { eventType: "demo", payload: { source: "demo", email: "a4@example.test" } });
+
+      const dispatcher: OutboxDispatcher = async () => ({ kind: "ok" });
+      const result = await flushBatch(db, dispatcher, 50);
+      expect(result.claimed).toBe(4);
+      expect(result.ok).toBe(4);
+    },
+    PG_TIMEOUT_MS,
+  );
 });

--- a/packages/api/src/lib/lead-outbox/__tests__/outbox-pg.test.ts
+++ b/packages/api/src/lib/lead-outbox/__tests__/outbox-pg.test.ts
@@ -772,13 +772,16 @@ describeIfPg("lead-outbox (real Postgres)", () => {
         ],
       );
 
-      // Re-run the migration UPDATE — idempotent by design.
+      // Re-run the migration UPDATE — idempotent by design. Mirrors
+      // 0104 exactly: regex-based trim for JS `String.trim()` parity
+      // (plain Postgres `TRIM()` only strips spaces, would leak the
+      // tab/newline row).
       await pool.query(
         `UPDATE crm_outbox
-            SET email_key = NULLIF(LOWER(TRIM(payload->>'email')), '')
+            SET email_key = NULLIF(LOWER(REGEXP_REPLACE(payload->>'email', '^\\s+|\\s+$', '', 'g')), '')
           WHERE email_key IS NULL
             AND jsonb_typeof(payload->'email') = 'string'
-            AND NULLIF(LOWER(TRIM(payload->>'email')), '') IS NOT NULL`,
+            AND NULLIF(LOWER(REGEXP_REPLACE(payload->>'email', '^\\s+|\\s+$', '', 'g')), '') IS NOT NULL`,
       );
 
       const rows = await pool.query<{ email_key: string | null }>(

--- a/packages/api/src/lib/lead-outbox/__tests__/outbox-pg.test.ts
+++ b/packages/api/src/lib/lead-outbox/__tests__/outbox-pg.test.ts
@@ -534,10 +534,14 @@ describeIfPg("lead-outbox (real Postgres)", () => {
 
       const dispatcher: OutboxDispatcher = async () => ({ kind: "ok" });
 
-      // Tick 1: only demo claimed; signup blocked by demo's in_flight presence
-      // mid-statement (the CTE locks demo first, then NOT EXISTS sees it as
-      // about-to-be in_flight for signup's slot). DISTINCT ON also dedupes
-      // within the same batch.
+      // Tick 1: only demo is claimed. Both rows enter the `claimable`
+      // CTE scan (neither is in_flight yet — the outer UPDATE hasn't
+      // flipped statuses). The NOT EXISTS gate filters signup out
+      // because demo, its older same-email sibling, is still `pending`
+      // in the snapshot, and DISTINCT ON belt-and-suspenders collapses
+      // any same-email residual to the earliest by created_at. The
+      // NOT EXISTS gate is also what blocks cross-statement / cross-pod
+      // races — see the next two tests.
       const tick1 = await flushBatch(db, dispatcher, 50);
       expect(tick1.claimed).toBe(1);
       expect(tick1.ok).toBe(1);
@@ -612,6 +616,181 @@ describeIfPg("lead-outbox (real Postgres)", () => {
       const result = await flushBatch(db, dispatcher, 50);
       expect(result.claimed).toBe(4);
       expect(result.ok).toBe(4);
+    },
+    PG_TIMEOUT_MS,
+  );
+
+  // ── Cross-pod race (Codex P1 #1 follow-up). Two concurrent
+  //    transactions each open their own snapshot; without the
+  //    advisory lock on `(2870, hashtext(email_key))`, each pod's
+  //    NOT EXISTS would still see the peer's pre-commit row as
+  //    `pending` and claim a different same-email sibling. The
+  //    advisory lock is transaction-scoped — Pod B's
+  //    pg_try_advisory_xact_lock returns false while Pod A holds it.
+  it(
+    "claim is serialized across concurrent transactions for same email_key",
+    async () => {
+      await truncateOutbox();
+
+      // Two pending rows, same email, different created_at so the
+      // claim ordering is deterministic.
+      await pool.query(
+        `INSERT INTO crm_outbox (event_type, payload, email_key, status, created_at)
+         VALUES ('demo', $1::jsonb, $2, 'pending', now() - INTERVAL '2 minutes')`,
+        [JSON.stringify({ source: "demo", email: "race@cross-pod.test" }), "race@cross-pod.test"],
+      );
+      await pool.query(
+        `INSERT INTO crm_outbox (event_type, payload, email_key, status, created_at)
+         VALUES ('signup', $1::jsonb, $2, 'pending', now() - INTERVAL '1 minute')`,
+        [JSON.stringify({ source: "signup", email: "race@cross-pod.test" }), "race@cross-pod.test"],
+      );
+
+      // Each "pod" is its own pool with size 1 — guarantees a single
+      // long-lived connection so the holding-transaction stays open
+      // across the slow dispatcher's await.
+      const podA = new Pool({ connectionString: TEST_DB_URL, max: 1 });
+      const podB = new Pool({ connectionString: TEST_DB_URL, max: 1 });
+      podA.on("connect", (c) => void c.query(`SET search_path TO "${schemaName}"`));
+      podB.on("connect", (c) => void c.query(`SET search_path TO "${schemaName}"`));
+      const dbFromPool = (p: Pool): OutboxDB => ({
+        query: async <T extends Record<string, unknown>>(sql: string, params?: unknown[]) =>
+          (await p.query<T>(sql, params)).rows,
+      });
+
+      let inFlightSnapshotMax = 0;
+      const dispatcher: OutboxDispatcher = async () => {
+        // Sample the live in_flight count while the holding tx is
+        // still open. If both pods both claimed a row, this would see
+        // 2; with the advisory lock in place it stays at 1.
+        const live = await pool.query<{ n: string }>(
+          "SELECT COUNT(*)::bigint AS n FROM crm_outbox WHERE status = 'in_flight'",
+        );
+        inFlightSnapshotMax = Math.max(inFlightSnapshotMax, Number(live.rows[0].n));
+        await new Promise((resolve) => setTimeout(resolve, 200));
+        return { kind: "ok" };
+      };
+
+      try {
+        const [a, b] = await Promise.all([
+          flushBatch(dbFromPool(podA), dispatcher, 50),
+          flushBatch(dbFromPool(podB), dispatcher, 50),
+        ]);
+
+        // Exactly one pod claimed; the other walked away empty
+        // because the advisory lock held.
+        expect(a.claimed + b.claimed).toBe(1);
+        expect(a.ok + b.ok).toBe(1);
+        expect(inFlightSnapshotMax).toBe(1);
+
+        // After both pods commit, one row is done, the other still pending.
+        const after = await pool.query<{ status: string }>(
+          "SELECT status FROM crm_outbox WHERE email_key = $1 ORDER BY created_at",
+          ["race@cross-pod.test"],
+        );
+        const statuses = after.rows.map((r) => r.status).toSorted();
+        expect(statuses).toEqual(["done", "pending"]);
+      } finally {
+        await podA.end();
+        await podB.end();
+      }
+    },
+    PG_TIMEOUT_MS,
+  );
+
+  // ── Retry-cooldown leapfrog (Codex P1 #2 follow-up). An older
+  //    same-email row in transient-backoff cooldown must still block
+  //    a newer same-email row even though the older row is filtered
+  //    out of `claimable` by the due-time check.
+  it(
+    "older same-email row in retry cooldown blocks a newer fresh row",
+    async () => {
+      await truncateOutbox();
+      const db = dbFor();
+
+      // R1: demo, older, in retry cooldown — pending with retry_after
+      // 1 hour in the future. Falls out of `claimable` via the
+      // due-time filter, but is still non-terminal.
+      await pool.query(
+        `INSERT INTO crm_outbox
+           (event_type, payload, email_key, status, attempts, retry_after, created_at)
+         VALUES
+           ('demo', $1::jsonb, $2, 'pending', 1, now() + INTERVAL '1 hour',
+            now() - INTERVAL '5 minutes')`,
+        [
+          JSON.stringify({ source: "demo", email: "cooldown@leapfrog.test", ip: "203.0.113.50" }),
+          "cooldown@leapfrog.test",
+        ],
+      );
+      // R2: signup, newer, fresh — would dispatch first under the
+      // pre-fix gate that only excluded `in_flight` siblings.
+      const signupId = await enqueue(db, {
+        eventType: "signup",
+        payload: { source: "signup", email: "cooldown@leapfrog.test", name: "Late Arrival" },
+      });
+
+      let calls = 0;
+      const dispatcher: OutboxDispatcher = async () => {
+        calls++;
+        return { kind: "ok" };
+      };
+      const result = await flushBatch(db, dispatcher, 50);
+      // Neither row is claimable: R1 is in cooldown, R2 is gated by
+      // the broadened NOT EXISTS (older non-terminal sibling exists).
+      expect(result.claimed).toBe(0);
+      expect(calls).toBe(0);
+      const signupAfter = await pool.query<{ status: string }>(
+        "SELECT status FROM crm_outbox WHERE id = $1",
+        [signupId],
+      );
+      expect(signupAfter.rows[0].status).toBe("pending");
+    },
+    PG_TIMEOUT_MS,
+  );
+
+  // ── Migration 0104 whitespace-only email backfill (silent-failure
+  //    finding). A `"   "` payload must land email_key=NULL, NOT
+  //    empty-string — non-NULL `''` would collide with every other
+  //    whitespace-only row in NOT EXISTS and serialize them globally.
+  it(
+    "migration 0104 backfills whitespace-only email as NULL, not empty string",
+    async () => {
+      await truncateOutbox();
+
+      // Insert with email_key NULL and a whitespace-only email — what
+      // the pre-0104 production state could look like for malformed
+      // payloads. The migration UPDATE will re-evaluate this row.
+      await pool.query(
+        `INSERT INTO crm_outbox (event_type, payload, email_key, status, created_at)
+         VALUES
+           ('demo', $1::jsonb, NULL, 'pending', now()),
+           ('demo', $2::jsonb, NULL, 'pending', now()),
+           ('demo', $3::jsonb, NULL, 'pending', now())`,
+        [
+          JSON.stringify({ source: "demo", email: "   " }),
+          JSON.stringify({ source: "demo", email: "\t\n" }),
+          JSON.stringify({ source: "demo", email: null }),
+        ],
+      );
+
+      // Re-run the migration UPDATE — idempotent by design.
+      await pool.query(
+        `UPDATE crm_outbox
+            SET email_key = NULLIF(LOWER(TRIM(payload->>'email')), '')
+          WHERE email_key IS NULL
+            AND jsonb_typeof(payload->'email') = 'string'
+            AND NULLIF(LOWER(TRIM(payload->>'email')), '') IS NOT NULL`,
+      );
+
+      const rows = await pool.query<{ email_key: string | null }>(
+        "SELECT email_key FROM crm_outbox ORDER BY created_at",
+      );
+      // All three remain NULL — the whitespace-only emails were
+      // correctly rejected by the NULLIF guard, the JSON-null email
+      // was rejected by jsonb_typeof.
+      expect(rows.rows).toHaveLength(3);
+      for (const r of rows.rows) {
+        expect(r.email_key).toBeNull();
+      }
     },
     PG_TIMEOUT_MS,
   );

--- a/packages/api/src/lib/lead-outbox/__tests__/outbox.test.ts
+++ b/packages/api/src/lib/lead-outbox/__tests__/outbox.test.ts
@@ -120,20 +120,30 @@ class FakeOutboxDB implements OutboxDB {
     if (/^\s*UPDATE crm_outbox\s+SET status = 'in_flight'/i.test(sql)) {
       if (this.claimBlocked) return [] as T[];
       const limit = Number(p[0] ?? 50);
-      // Mirror CLAIM_SQL (0104): exclude rows whose email_key already
-      // has an in_flight sibling, then dedupe by email_key (NULL falls
-      // back to id), preserving created_at order for the final LIMIT.
-      const inFlightEmailKeys = new Set(
-        this.rows
-          .filter((r) => r.status === "in_flight" && r.email_key != null)
-          .map((r) => r.email_key as string),
-      );
+      // Mirror CLAIM_SQL (0104 + #2872 follow-up): a row is claimable
+      // only if NO older non-terminal same-email sibling exists. This
+      // gates both the in_flight-sibling-blocks-newer case AND the
+      // retry-cooldown-leapfrog case (older sibling in `pending` with
+      // future retry_after still blocks the newer fresh row). NULL
+      // email_key rows skip the gate (`o2.email_key IS NOT NULL`
+      // short-circuits) — each NULL row is its own dedup group via
+      // COALESCE(email_key, id::text).
+      const hasOlderNonTerminalSibling = (r: Row): boolean => {
+        if (r.email_key == null) return false;
+        return this.rows.some(
+          (o) =>
+            o.id !== r.id &&
+            o.email_key === r.email_key &&
+            (o.status === "pending" || o.status === "in_flight") &&
+            o.created_at < r.created_at,
+        );
+      };
       const candidates = this.rows
         .filter(
           (r) =>
             r.status === "pending" &&
             r.attempts < 6 &&
-            (r.email_key == null || !inFlightEmailKeys.has(r.email_key)),
+            !hasOlderNonTerminalSibling(r),
         )
         .sort((a, b) => a.created_at - b.created_at);
       const seenDedupKeys = new Set<string>();
@@ -624,6 +634,42 @@ describe("per-email serialization (#2870)", () => {
     const tick1 = await flushBatch(db, dispatcher, 50);
     expect(tick1.claimed).toBe(1);
     expect(dispatched).toBe(1);
+  });
+
+  test("enqueue warn-logs when an email-keyed event type lands without an email", async () => {
+    // A `demo` event-type payload that's missing/malformed `email`
+    // (type-system bypass, schema drift, plugin payload corruption)
+    // should still enqueue — but loud-log so operators can grep for
+    // the silent-serialization-disabled signal before atlasFirstSource
+    // flips weeks later.
+    await enqueue(db, {
+      eventType: "demo",
+      // Cast through unknown so the test exercises the runtime guard
+      // rather than relying on a TS-narrowed payload type.
+      payload: { source: "demo" } as Record<string, unknown>,
+    });
+    expect(db.rows[0].email_key).toBeNull();
+    const warn = loggerCalls.warn.find(
+      (c) => c.data.event === "lead_outbox.email_key_missing",
+    );
+    expect(warn).toBeDefined();
+    expect(warn?.data.eventType).toBe("demo");
+    expect(warn?.data.rawType).toBe("undefined");
+  });
+
+  test("enqueue does NOT warn-log for non-email-keyed event types", async () => {
+    // A future `system`/`telemetry` event_type whose payload is
+    // intentionally not email-keyed must NOT trigger the warn-log,
+    // otherwise the log becomes noise and operators learn to ignore it.
+    await enqueue(db, {
+      eventType: "system",
+      payload: { source: "system", op: "ping" },
+    });
+    expect(db.rows[0].email_key).toBeNull();
+    const warn = loggerCalls.warn.find(
+      (c) => c.data.event === "lead_outbox.email_key_missing",
+    );
+    expect(warn).toBeUndefined();
   });
 });
 

--- a/packages/api/src/lib/lead-outbox/__tests__/outbox.test.ts
+++ b/packages/api/src/lib/lead-outbox/__tests__/outbox.test.ts
@@ -120,30 +120,40 @@ class FakeOutboxDB implements OutboxDB {
     if (/^\s*UPDATE crm_outbox\s+SET status = 'in_flight'/i.test(sql)) {
       if (this.claimBlocked) return [] as T[];
       const limit = Number(p[0] ?? 50);
-      // Mirror CLAIM_SQL (0104 + #2872 follow-up): a row is claimable
-      // only if NO older non-terminal same-email sibling exists. This
-      // gates both the in_flight-sibling-blocks-newer case AND the
-      // retry-cooldown-leapfrog case (older sibling in `pending` with
-      // future retry_after still blocks the newer fresh row). NULL
-      // email_key rows skip the gate (`o2.email_key IS NOT NULL`
-      // short-circuits) — each NULL row is its own dedup group via
-      // COALESCE(email_key, id::text).
-      const hasOlderNonTerminalSibling = (r: Row): boolean => {
+      // Mirror CLAIM_SQL (0104 + #2872 follow-ups): a row is claimable
+      // only if NO blocking same-email sibling exists.
+      //   - Any in_flight sibling blocks regardless of age (rolling
+      //     hotfix / manual recovery state where a newer row is
+      //     already in_flight).
+      //   - Any pending sibling that is strictly older by
+      //     (created_at, id) blocks — closes both the retry-cooldown
+      //     leapfrog (older row in backoff still gates the newer one)
+      //     AND the same-`created_at` bulk-INSERT tie-break (two rows
+      //     sharing a timestamp must still serialize).
+      //   - NULL email_key rows skip the gate; each is its own dedup
+      //     group via COALESCE(email_key, id::text).
+      const hasBlockingSibling = (r: Row): boolean => {
         if (r.email_key == null) return false;
-        return this.rows.some(
-          (o) =>
-            o.id !== r.id &&
-            o.email_key === r.email_key &&
-            (o.status === "pending" || o.status === "in_flight") &&
-            o.created_at < r.created_at,
-        );
+        return this.rows.some((o) => {
+          if (o.id === r.id) return false;
+          if (o.email_key !== r.email_key) return false;
+          if (o.status === "in_flight") return true;
+          if (o.status === "pending") {
+            // (o.created_at, o.id) < (r.created_at, r.id) — row-wise.
+            return (
+              o.created_at < r.created_at ||
+              (o.created_at === r.created_at && o.id < r.id)
+            );
+          }
+          return false;
+        });
       };
       const candidates = this.rows
         .filter(
           (r) =>
             r.status === "pending" &&
             r.attempts < 6 &&
-            !hasOlderNonTerminalSibling(r),
+            !hasBlockingSibling(r),
         )
         .sort((a, b) => a.created_at - b.created_at);
       const seenDedupKeys = new Set<string>();
@@ -657,6 +667,24 @@ describe("per-email serialization (#2870)", () => {
     expect(warn?.data.rawType).toBe("undefined");
   });
 
+  test("enqueue warn-logs for stamp-conversion (Twenty-side event_type, not upstream source)", async () => {
+    // Conversion stamps land in crm_outbox with event_type
+    // `"stamp-conversion"` (the `STAMP_CONVERSION_EVENT_TYPE` constant
+    // in `ee/src/saas-crm/index.ts`), NOT `"conversion"`. The warn-log
+    // gate must match the actual enqueued event_type so conversion
+    // payloads with a missing email surface as silent-serialization-
+    // disabled.
+    await enqueue(db, {
+      eventType: "stamp-conversion",
+      payload: { source: "conversion" } as Record<string, unknown>,
+    });
+    const warn = loggerCalls.warn.find(
+      (c) => c.data.event === "lead_outbox.email_key_missing",
+    );
+    expect(warn).toBeDefined();
+    expect(warn?.data.eventType).toBe("stamp-conversion");
+  });
+
   test("enqueue does NOT warn-log for non-email-keyed event types", async () => {
     // A future `system`/`telemetry` event_type whose payload is
     // intentionally not email-keyed must NOT trigger the warn-log,
@@ -670,6 +698,77 @@ describe("per-email serialization (#2870)", () => {
       (c) => c.data.event === "lead_outbox.email_key_missing",
     );
     expect(warn).toBeUndefined();
+  });
+
+  test("same-created_at siblings serialize via the (created_at, id) tie-break", async () => {
+    // Bulk-INSERT scenario: backfill-crm-leads.ts produces many rows
+    // with one `now()` value. Without an id tie-break on the older-
+    // sibling gate, tick 1 dedupes via DISTINCT ON but tick 2 sees a
+    // same-`created_at` pending sibling as not-older and claims a
+    // second row while the first is still in_flight.
+    await enqueue(db, {
+      eventType: "demo",
+      payload: { source: "demo", email: "tied@example.test" },
+    });
+    await enqueue(db, {
+      eventType: "demo",
+      payload: { source: "demo", email: "tied@example.test" },
+    });
+    // Force identical timestamps to exercise the row-wise compare.
+    db.rows[0].created_at = 1000;
+    db.rows[1].created_at = 1000;
+    const lowerIdRowId = db.rows[0].id < db.rows[1].id ? db.rows[0].id : db.rows[1].id;
+    const higherIdRowId =
+      db.rows[0].id < db.rows[1].id ? db.rows[1].id : db.rows[0].id;
+
+    const slowDispatcher: OutboxDispatcher = async () => ({ kind: "ok" });
+    // Tick 1: only the lower-id row is claimable; the higher-id row
+    // is blocked because its same-`created_at` sibling with a smaller
+    // id is still pending.
+    const tick1 = await flushBatch(db, slowDispatcher, 50);
+    expect(tick1.claimed).toBe(1);
+    expect(db.rows.find((r) => r.id === lowerIdRowId)!.status as string).toBe("done");
+    expect(db.rows.find((r) => r.id === higherIdRowId)!.status as string).toBe(
+      "pending",
+    );
+
+    // Tick 2: the lower-id row is done; higher-id now has no blocking
+    // sibling and becomes claimable.
+    const tick2 = await flushBatch(db, slowDispatcher, 50);
+    expect(tick2.claimed).toBe(1);
+    expect(db.rows.find((r) => r.id === higherIdRowId)!.status as string).toBe(
+      "done",
+    );
+  });
+
+  test("newer in_flight sibling blocks an older pending row (rolling-hotfix safety)", async () => {
+    // Rolling-hotfix scenario: an old pod with the pre-fix CLAIM_SQL
+    // already leapfrogged R2 (newer) into in_flight while R1 (older,
+    // in retry cooldown) waited. A new pod with the fixed CLAIM_SQL
+    // must not then claim R1 — both would dispatch concurrently with
+    // R2's still-in-flight upsert, flipping atlasLastSource.
+    await enqueue(db, {
+      eventType: "demo",
+      payload: { source: "demo", email: "rolling@hotfix.test", ip: "203.0.113.60" },
+    });
+    await enqueue(db, {
+      eventType: "demo",
+      payload: { source: "demo", email: "rolling@hotfix.test", ip: "203.0.113.61" },
+    });
+    // R1 is older + pending; R2 is newer + in_flight (already claimed
+    // by the legacy pod). The gate must still block R1.
+    db.rows[1].status = "in_flight";
+    db.rows[1].claimed_at = Date.now();
+
+    let dispatched = 0;
+    const dispatcher: OutboxDispatcher = async () => {
+      dispatched++;
+      return { kind: "ok" };
+    };
+    const result = await flushBatch(db, dispatcher, 50);
+    expect(result.claimed).toBe(0);
+    expect(dispatched).toBe(0);
+    expect(db.rows[0].status as string).toBe("pending");
   });
 });
 

--- a/packages/api/src/lib/lead-outbox/__tests__/outbox.test.ts
+++ b/packages/api/src/lib/lead-outbox/__tests__/outbox.test.ts
@@ -51,6 +51,7 @@ type Row = {
   id: string;
   event_type: string;
   payload: unknown;
+  email_key: string | null;
   status: "pending" | "in_flight" | "done" | "dead";
   attempts: number;
   last_error: string | null;
@@ -65,8 +66,23 @@ type Row = {
 class FakeOutboxDB implements OutboxDB {
   rows: Row[] = [];
   private nextId = 1;
+  /** Monotonic clock for `created_at` — see `clockTick`. */
+  private clock = 0;
   /** When true, every claim returns 0 rows (simulates contention). */
   claimBlocked = false;
+
+  /**
+   * Strictly-monotonic timestamp for `created_at`. The previous
+   * implementation used `Date.now()`, which ticks at ms resolution and
+   * tied for back-to-back enqueues — non-deterministic `ORDER BY
+   * created_at` then masked claim-ordering regressions in tests. The
+   * monotonic counter is the test-side analogue of Postgres' `now()`
+   * statement-start microsecond clock.
+   */
+  private clockTick(): number {
+    this.clock += 1;
+    return this.clock;
+  }
 
   async query<T extends Record<string, unknown>>(
     sql: string,
@@ -75,10 +91,15 @@ class FakeOutboxDB implements OutboxDB {
     const p = params ?? [];
     if (/^\s*INSERT INTO crm_outbox/i.test(sql)) {
       const id = `row-${this.nextId++}`;
+      // 0104 added email_key as a 3rd positional parameter; older
+      // callers that haven't been updated pass `undefined` and fall
+      // through to NULL — matching the SQL column's nullability.
+      const emailKey = typeof p[2] === "string" ? p[2] : null;
       this.rows.push({
         id,
         event_type: String(p[0]),
         payload: JSON.parse(String(p[1])),
+        email_key: emailKey,
         status: "pending",
         attempts: 0,
         last_error: null,
@@ -86,7 +107,12 @@ class FakeOutboxDB implements OutboxDB {
         twenty_note_id: null,
         retry_after: null,
         claimed_at: null,
-        created_at: Date.now(),
+        // `created_at` resolution: increment a monotonic counter so
+        // back-to-back enqueues in a single test step still get
+        // distinct, ordered timestamps. `Date.now()` ticks at ms
+        // resolution and the unit tests fire enqueues faster than
+        // that, which made `ORDER BY created_at` non-deterministic.
+        created_at: this.clockTick(),
         processed_at: null,
       });
       return [{ id }] as unknown as T[];
@@ -94,15 +120,37 @@ class FakeOutboxDB implements OutboxDB {
     if (/^\s*UPDATE crm_outbox\s+SET status = 'in_flight'/i.test(sql)) {
       if (this.claimBlocked) return [] as T[];
       const limit = Number(p[0] ?? 50);
+      // Mirror CLAIM_SQL (0104): exclude rows whose email_key already
+      // has an in_flight sibling, then dedupe by email_key (NULL falls
+      // back to id), preserving created_at order for the final LIMIT.
+      const inFlightEmailKeys = new Set(
+        this.rows
+          .filter((r) => r.status === "in_flight" && r.email_key != null)
+          .map((r) => r.email_key as string),
+      );
       const candidates = this.rows
-        .filter((r) => r.status === "pending" && r.attempts < 6)
-        .slice(0, limit);
+        .filter(
+          (r) =>
+            r.status === "pending" &&
+            r.attempts < 6 &&
+            (r.email_key == null || !inFlightEmailKeys.has(r.email_key)),
+        )
+        .sort((a, b) => a.created_at - b.created_at);
+      const seenDedupKeys = new Set<string>();
+      const deduped: Row[] = [];
       for (const row of candidates) {
+        const key = row.email_key ?? row.id;
+        if (seenDedupKeys.has(key)) continue;
+        seenDedupKeys.add(key);
+        deduped.push(row);
+      }
+      const claimed = deduped.slice(0, limit);
+      for (const row of claimed) {
         row.status = "in_flight";
         row.attempts += 1;
         row.claimed_at = Date.now();
       }
-      return candidates.map((r) => ({
+      return claimed.map((r) => ({
         id: r.id,
         event_type: r.event_type,
         payload: r.payload,
@@ -406,6 +454,176 @@ describe("concurrent flush behaviour", () => {
     const result = await flushBatch(db, dispatcher, 0);
     expect(result).toEqual({ claimed: 0, ok: 0, transient: 0, permanent: 0 });
     expect(calls).toBe(0);
+  });
+});
+
+// ── Per-email serialization (#2870) ───────────────────────────────────
+//
+// Two rows for the same email enqueued back-to-back must dispatch in
+// claim order, never concurrently. Before 0104 the flusher claimed
+// both same-email rows in a single batch and dispatched them sequentially
+// (still risky if any concurrency lands), AND a future multi-pod deploy
+// could grab them in parallel. The fix dedupes by `email_key` inside
+// CLAIM_SQL so only the earliest pending row per email is claimed per
+// tick — the rest wait for the claimed row to reach a terminal state.
+
+describe("per-email serialization (#2870)", () => {
+  test("gworth demo→signup pair: only the first row is claimed per tick", async () => {
+    // C10 fixture from scripts/test-fixtures/crm-personas.yml. Two
+    // rows for the same email, demo enqueued first, signup second.
+    // Pre-fix both would be claimed in one batch; post-fix the signup
+    // waits for demo to land.
+    const demoId = await enqueue(db, {
+      eventType: "demo",
+      payload: { source: "demo", email: "gworth@globexcorp.com", ip: "203.0.113.30" },
+    });
+    const signupId = await enqueue(db, {
+      eventType: "signup",
+      payload: { source: "signup", email: "gworth@globexcorp.com", name: "Greta Worth" },
+    });
+
+    const dispatchOrder: string[] = [];
+    const dispatcher: OutboxDispatcher = async (row) => {
+      dispatchOrder.push((row.payload as { source: string }).source);
+      return { kind: "ok" };
+    };
+
+    // Tick 1 — only the demo row is claimed; signup is still pending.
+    const tick1 = await flushBatch(db, dispatcher, 50);
+    expect(tick1.claimed).toBe(1);
+    expect(tick1.ok).toBe(1);
+    expect(dispatchOrder).toEqual(["demo"]);
+    expect(db.rows.find((r) => r.id === demoId)!.status as string).toBe("done");
+    expect(db.rows.find((r) => r.id === signupId)!.status as string).toBe("pending");
+
+    // Tick 2 — demo is done, signup is now claimable.
+    const tick2 = await flushBatch(db, dispatcher, 50);
+    expect(tick2.claimed).toBe(1);
+    expect(tick2.ok).toBe(1);
+    expect(dispatchOrder).toEqual(["demo", "signup"]);
+    expect(db.rows.find((r) => r.id === signupId)!.status as string).toBe("done");
+  });
+
+  test("msdyson demo→demo idempotency pair: same-source repeats serialize too", async () => {
+    // B8 fixture. Two demo events for the same email with different IPs.
+    // The reported bug surfaced as `atlasIp` showing the FIRST IP after
+    // the smoke run, indicating the two PATCHes raced. Post-fix the
+    // .41 PATCH runs in tick 2 with .40 already committed in Twenty —
+    // strictly sequential, no race possible.
+    const first = await enqueue(db, {
+      eventType: "demo",
+      payload: { source: "demo", email: "msdyson@cyberdynesys.com", ip: "203.0.113.40" },
+    });
+    const second = await enqueue(db, {
+      eventType: "demo",
+      payload: { source: "demo", email: "msdyson@cyberdynesys.com", ip: "203.0.113.41" },
+    });
+
+    const dispatchedIps: string[] = [];
+    const dispatcher: OutboxDispatcher = async (row) => {
+      dispatchedIps.push((row.payload as { ip: string }).ip);
+      return { kind: "ok" };
+    };
+
+    const tick1 = await flushBatch(db, dispatcher, 50);
+    expect(tick1.claimed).toBe(1);
+    expect(dispatchedIps).toEqual(["203.0.113.40"]);
+    expect(db.rows.find((r) => r.id === first)!.status as string).toBe("done");
+    expect(db.rows.find((r) => r.id === second)!.status as string).toBe("pending");
+
+    const tick2 = await flushBatch(db, dispatcher, 50);
+    expect(tick2.claimed).toBe(1);
+    expect(dispatchedIps).toEqual(["203.0.113.40", "203.0.113.41"]);
+    expect(db.rows.find((r) => r.id === second)!.status as string).toBe("done");
+  });
+
+  test("distinct emails dispatch in the same tick (no throughput regression)", async () => {
+    // Per-email serialization must NOT serialize across distinct
+    // emails — a workspace with 1000 leads-per-minute should still
+    // drain at the same rate as before the fix.
+    await enqueue(db, { eventType: "demo", payload: { source: "demo", email: "a1@example.test" } });
+    await enqueue(db, { eventType: "demo", payload: { source: "demo", email: "a2@example.test" } });
+    await enqueue(db, { eventType: "demo", payload: { source: "demo", email: "a3@example.test" } });
+    await enqueue(db, { eventType: "demo", payload: { source: "demo", email: "a4@example.test" } });
+
+    const dispatcher: OutboxDispatcher = async () => ({ kind: "ok" });
+    const result = await flushBatch(db, dispatcher, 50);
+    expect(result.claimed).toBe(4);
+    expect(result.ok).toBe(4);
+  });
+
+  test("in_flight sibling blocks subsequent claims for the same email", async () => {
+    // The cross-tick / cross-pod safety case: a row already in_flight
+    // (e.g. claimed by a sibling pod that hasn't finished dispatching)
+    // must block any newer same-email row from being claimed.
+    await enqueue(db, {
+      eventType: "demo",
+      payload: { source: "demo", email: "stuck@example.test" },
+    });
+    // Force the first row into in_flight without going through dispatch
+    // — simulates a sibling pod mid-dispatch.
+    db.rows[0].status = "in_flight";
+    db.rows[0].claimed_at = Date.now();
+
+    // Newer row for the same email lands while the sibling is mid-flight.
+    await enqueue(db, {
+      eventType: "demo",
+      payload: { source: "demo", email: "stuck@example.test" },
+    });
+
+    let calls = 0;
+    const dispatcher: OutboxDispatcher = async () => {
+      calls++;
+      return { kind: "ok" };
+    };
+    const result = await flushBatch(db, dispatcher, 50);
+    // No row claimable — sibling already in_flight for this email.
+    expect(result.claimed).toBe(0);
+    expect(calls).toBe(0);
+    expect(db.rows[1].status as string).toBe("pending");
+  });
+
+  test("rows with NULL email_key dispatch independently (no spurious dedup)", async () => {
+    // Future event types that aren't email-keyed (or legacy rows with
+    // a missing email field) must NOT get grouped together by the
+    // DISTINCT ON in CLAIM_SQL — each NULL row is its own dedup
+    // group via `COALESCE(email_key, id::text)`.
+    await enqueue(db, { eventType: "system", payload: { source: "system", op: "ping" } });
+    await enqueue(db, { eventType: "system", payload: { source: "system", op: "pong" } });
+    expect(db.rows[0].email_key).toBeNull();
+    expect(db.rows[1].email_key).toBeNull();
+
+    const dispatcher: OutboxDispatcher = async () => ({ kind: "ok" });
+    const result = await flushBatch(db, dispatcher, 50);
+    expect(result.claimed).toBe(2);
+    expect(result.ok).toBe(2);
+  });
+
+  test("enqueue normalizes email_key — case and whitespace collapse together", async () => {
+    // Two payloads with cosmetically different email casing must
+    // collide on email_key so they serialize together (matches the
+    // lead-normalizer's `.toLowerCase().trim()`). Without this a
+    // payload-side typo (`gworth@globexcorp.com` vs `GWorth@globexcorp.com`)
+    // would bypass per-email serialization.
+    await enqueue(db, {
+      eventType: "demo",
+      payload: { source: "demo", email: "  gworth@globexcorp.com  " },
+    });
+    await enqueue(db, {
+      eventType: "signup",
+      payload: { source: "signup", email: "GWORTH@GlobexCorp.com" },
+    });
+    expect(db.rows[0].email_key).toBe("gworth@globexcorp.com");
+    expect(db.rows[1].email_key).toBe("gworth@globexcorp.com");
+
+    let dispatched = 0;
+    const dispatcher: OutboxDispatcher = async () => {
+      dispatched++;
+      return { kind: "ok" };
+    };
+    const tick1 = await flushBatch(db, dispatcher, 50);
+    expect(tick1.claimed).toBe(1);
+    expect(dispatched).toBe(1);
   });
 });
 

--- a/packages/api/src/lib/lead-outbox/outbox.ts
+++ b/packages/api/src/lib/lead-outbox/outbox.ts
@@ -178,17 +178,47 @@ const ENQUEUE_SQL = `
  * keeps a long upstream-requested delay from being clobbered by an
  * eager tier value (e.g. 30s tier-1 vs `Retry-After: 3600`).
  *
- * Per-email serialization (#2870): two rows for the same email are
- * never claimed concurrently. The candidate set excludes any row whose
- * `email_key` already has an `in_flight` sibling (the NOT EXISTS
- * clause), and within each tick the inner `DISTINCT ON (dedup_key)`
- * picks only the earliest pending row per email. `dedup_key` is
- * `COALESCE(email_key, id::text)` so NULL-email_key rows (legacy or
- * non-email-keyed future event types) fall back to their own id and
- * are never grouped — each NULL row dispatches independently. The
- * outer LIMIT applies to the deduped set, not the raw candidate set,
- * so a workspace with a backlog of same-email events drains one event
- * per email per tick rather than starving other emails behind it.
+ * Per-email serialization (#2870): a row is claimable only if NO
+ * older non-terminal same-email sibling exists. Three layers cooperate:
+ *
+ *   1. **NOT EXISTS gate (older-sibling)** — excludes the row from
+ *      `claimable` if any older same-email row is still `pending` or
+ *      `in_flight`. The `o2.created_at < crm_outbox.created_at`
+ *      clause is essential — without it every row would block itself
+ *      and the queue would stall. This closes the retry-cooldown
+ *      leapfrog where R1 (older, in transient-fail backoff) is
+ *      filtered out of `claimable` by the due-time check, letting R2
+ *      (newer, fresh) be claimed first and flip atlasFirstSource.
+ *   2. **Advisory xact lock per email_key** — `pg_try_advisory_xact_lock`
+ *      gives us serialization across concurrent transactions that
+ *      MVCC alone can't provide. Without it, two flusher pods could
+ *      each see the other's pre-commit UPDATE as invisible, both
+ *      pass the NOT EXISTS gate at lookup time, and both end up with
+ *      different same-email rows in_flight (each pod skips the
+ *      other's locked row via SKIP LOCKED, then claims a different
+ *      sibling). The advisory lock is transaction-scoped: held until
+ *      commit, then released, so the next tick re-acquires cleanly.
+ *      NULL email_key rows skip the lock (no per-row serialization
+ *      needed — those are their own dedup groups).
+ *   3. **DISTINCT ON dedupe (intra-statement)** — belt-and-suspenders:
+ *      within a single tick the NOT EXISTS gate already keeps only
+ *      the earliest same-email row, but DISTINCT ON formalizes the
+ *      "one row per email_key per batch" contract for any future
+ *      WHERE-clause regression. `dedup_key` is
+ *      `COALESCE(email_key, id::text)` so NULL-email_key rows fall
+ *      back to their own id and dispatch independently. The
+ *      `id` tie-breaker on `ORDER BY` makes claim order deterministic
+ *      when two rows share `created_at` (e.g. bulk INSERT).
+ *
+ * The outer LIMIT applies to the deduped set, not the raw candidate
+ * set, so a workspace with a backlog of same-email events drains one
+ * event per email per tick rather than starving other emails behind
+ * it.
+ *
+ * Advisory-lock namespace: the first arg `2870` (the issue number)
+ * is the lock class; the second arg is `hashtext(email_key)`. The
+ * two-key variant avoids collisions with any other advisory locks
+ * the codebase may take elsewhere.
  */
 const CLAIM_SQL = `
   UPDATE crm_outbox
@@ -205,17 +235,23 @@ const CLAIM_SQL = `
           SELECT 1 FROM crm_outbox o2
           WHERE o2.email_key IS NOT NULL
             AND o2.email_key = crm_outbox.email_key
-            AND o2.status = 'in_flight'
+            AND o2.id <> crm_outbox.id
+            AND o2.status IN ('pending', 'in_flight')
+            AND o2.created_at < crm_outbox.created_at
         )
-      ORDER BY created_at
+        AND (
+          email_key IS NULL
+          OR pg_try_advisory_xact_lock(2870, hashtext(email_key))
+        )
+      ORDER BY created_at, id
       FOR UPDATE SKIP LOCKED
     ),
     deduped AS (
       SELECT DISTINCT ON (COALESCE(email_key, id::text)) id, created_at
       FROM claimable
-      ORDER BY COALESCE(email_key, id::text), created_at
+      ORDER BY COALESCE(email_key, id::text), created_at, id
     )
-    SELECT id FROM deduped ORDER BY created_at LIMIT $1
+    SELECT id FROM deduped ORDER BY created_at, id LIMIT $1
   )
   RETURNING id, event_type, payload, attempts, twenty_person_id, twenty_note_id
 `;
@@ -320,15 +356,47 @@ export const SHUTDOWN_RECOVERY_STALE_MS = 30_000;   // 30 s
 //  Public API
 // ─────────────────────────────────────────────────────────────────────
 
+/**
+ * Event types whose payload is contractually email-keyed. A row of one
+ * of these types landing with a NULL email_key is almost always a bug
+ * — a type-system bypass, schema drift, or upstream payload corruption
+ * — and we lose per-email serialization for that row (it dispatches
+ * concurrently with siblings). Warn-log so operators can grep and
+ * investigate before atlasFirstSource flips weeks later.
+ *
+ * New email-keyed event types must be added here AND have an `email`
+ * field on their payload type — the runtime check is the only defense
+ * against a TypeScript cast or `unknown`-laundered payload silently
+ * disabling serialization.
+ */
+const EMAIL_KEYED_EVENT_TYPES: ReadonlySet<string> = new Set([
+  "demo",
+  "signup",
+  "sales-form",
+  "conversion",
+]);
+
 /** Insert a row in `pending` status. Returns the new row id. */
 export async function enqueue(
   db: OutboxDB,
   input: EnqueueInput,
 ): Promise<string> {
+  const emailKey = extractEmailKey(input.payload);
+  if (emailKey === null && EMAIL_KEYED_EVENT_TYPES.has(input.eventType)) {
+    const raw = input.payload["email"];
+    log.warn(
+      {
+        eventType: input.eventType,
+        rawType: typeof raw,
+        event: "lead_outbox.email_key_missing",
+      },
+      "Email-keyed event enqueued with no extractable email — per-email serialization disabled for this row",
+    );
+  }
   const rows = await db.query<{ id: string }>(ENQUEUE_SQL, [
     input.eventType,
     JSON.stringify(input.payload),
-    extractEmailKey(input.payload),
+    emailKey,
   ]);
   const id = rows[0]?.id;
   if (!id) {
@@ -347,14 +415,18 @@ export async function enqueue(
  * (`COALESCE(email_key, id::text)` makes NULL rows their own dedup
  * group).
  *
- * Normalization matches `normalizeLead` in `@useatlas/twenty`'s
- * lead-normalizer (`.toLowerCase().trim()`) so casing/whitespace
- * differences across event payloads for the same prospect don't
- * accidentally bypass per-email serialization.
+ * Normalization is `.trim().toLowerCase()`. The SQL backfill in
+ * migration 0104 uses the equivalent `NULLIF(LOWER(TRIM(...)), '')`
+ * so both code paths produce identical email_key values for the
+ * same input. Note: the lead-normalizer in `@useatlas/twenty` uses
+ * the reverse order (`.toLowerCase().trim()`) — for ASCII emails
+ * both orders produce identical output, but if you ever extend
+ * either path to non-ASCII inputs the orders should be reconciled.
  *
- * Exported for the migration backfill script (kept in lockstep with
- * the SQL `LOWER(TRIM(payload->>'email'))` in 0104). Not part of the
- * public outbox surface; new callers should pass payloads through
+ * Exported so unit tests can assert lockstep with the 0104 backfill
+ * and so the bulk-enqueue path in `backfill-crm-leads.ts` populates
+ * email_key the same way `enqueue` does. Not part of the public
+ * outbox surface; new callers should pass payloads through
  * `enqueue`, not call this directly.
  */
 export function extractEmailKey(payload: Record<string, unknown>): string | null {

--- a/packages/api/src/lib/lead-outbox/outbox.ts
+++ b/packages/api/src/lib/lead-outbox/outbox.ts
@@ -156,8 +156,8 @@ export interface FlushResult {
 // ─────────────────────────────────────────────────────────────────────
 
 const ENQUEUE_SQL = `
-  INSERT INTO crm_outbox (event_type, payload, status)
-  VALUES ($1, $2::jsonb, 'pending')
+  INSERT INTO crm_outbox (event_type, payload, email_key, status)
+  VALUES ($1, $2::jsonb, $3, 'pending')
   RETURNING id
 `;
 
@@ -177,6 +177,18 @@ const ENQUEUE_SQL = `
  * the tier-based delay measured from `created_at`. The COALESCE
  * keeps a long upstream-requested delay from being clobbered by an
  * eager tier value (e.g. 30s tier-1 vs `Retry-After: 3600`).
+ *
+ * Per-email serialization (#2870): two rows for the same email are
+ * never claimed concurrently. The candidate set excludes any row whose
+ * `email_key` already has an `in_flight` sibling (the NOT EXISTS
+ * clause), and within each tick the inner `DISTINCT ON (dedup_key)`
+ * picks only the earliest pending row per email. `dedup_key` is
+ * `COALESCE(email_key, id::text)` so NULL-email_key rows (legacy or
+ * non-email-keyed future event types) fall back to their own id and
+ * are never grouped — each NULL row dispatches independently. The
+ * outer LIMIT applies to the deduped set, not the raw candidate set,
+ * so a workspace with a backlog of same-email events drains one event
+ * per email per tick rather than starving other emails behind it.
  */
 const CLAIM_SQL = `
   UPDATE crm_outbox
@@ -184,13 +196,26 @@ const CLAIM_SQL = `
       attempts = attempts + 1,
       claimed_at = now()
   WHERE id IN (
-    SELECT id FROM crm_outbox
-    WHERE status = 'pending'
-      AND attempts < ${DEAD_AFTER_ATTEMPTS}
-      AND COALESCE(retry_after, created_at + (${CLAIM_DELAY_SQL})) <= now()
-    ORDER BY created_at
-    LIMIT $1
-    FOR UPDATE SKIP LOCKED
+    WITH claimable AS (
+      SELECT id, email_key, created_at FROM crm_outbox
+      WHERE status = 'pending'
+        AND attempts < ${DEAD_AFTER_ATTEMPTS}
+        AND COALESCE(retry_after, created_at + (${CLAIM_DELAY_SQL})) <= now()
+        AND NOT EXISTS (
+          SELECT 1 FROM crm_outbox o2
+          WHERE o2.email_key IS NOT NULL
+            AND o2.email_key = crm_outbox.email_key
+            AND o2.status = 'in_flight'
+        )
+      ORDER BY created_at
+      FOR UPDATE SKIP LOCKED
+    ),
+    deduped AS (
+      SELECT DISTINCT ON (COALESCE(email_key, id::text)) id, created_at
+      FROM claimable
+      ORDER BY COALESCE(email_key, id::text), created_at
+    )
+    SELECT id FROM deduped ORDER BY created_at LIMIT $1
   )
   RETURNING id, event_type, payload, attempts, twenty_person_id, twenty_note_id
 `;
@@ -303,6 +328,7 @@ export async function enqueue(
   const rows = await db.query<{ id: string }>(ENQUEUE_SQL, [
     input.eventType,
     JSON.stringify(input.payload),
+    extractEmailKey(input.payload),
   ]);
   const id = rows[0]?.id;
   if (!id) {
@@ -311,6 +337,31 @@ export async function enqueue(
     throw new Error("crm_outbox enqueue returned no row");
   }
   return id;
+}
+
+/**
+ * Pull the lead's primary email out of a free-form payload and
+ * normalize it for `email_key` storage. Returns `null` when the
+ * payload has no recognizable email field — those rows fall back to
+ * "every row dispatches independently" semantics in CLAIM_SQL
+ * (`COALESCE(email_key, id::text)` makes NULL rows their own dedup
+ * group).
+ *
+ * Normalization matches `normalizeLead` in `@useatlas/twenty`'s
+ * lead-normalizer (`.toLowerCase().trim()`) so casing/whitespace
+ * differences across event payloads for the same prospect don't
+ * accidentally bypass per-email serialization.
+ *
+ * Exported for the migration backfill script (kept in lockstep with
+ * the SQL `LOWER(TRIM(payload->>'email'))` in 0104). Not part of the
+ * public outbox surface; new callers should pass payloads through
+ * `enqueue`, not call this directly.
+ */
+export function extractEmailKey(payload: Record<string, unknown>): string | null {
+  const raw = payload["email"];
+  if (typeof raw !== "string") return null;
+  const normalized = raw.trim().toLowerCase();
+  return normalized.length > 0 ? normalized : null;
 }
 
 /**

--- a/packages/api/src/lib/lead-outbox/outbox.ts
+++ b/packages/api/src/lib/lead-outbox/outbox.ts
@@ -179,16 +179,27 @@ const ENQUEUE_SQL = `
  * eager tier value (e.g. 30s tier-1 vs `Retry-After: 3600`).
  *
  * Per-email serialization (#2870): a row is claimable only if NO
- * older non-terminal same-email sibling exists. Three layers cooperate:
+ * blocking same-email sibling exists. Three layers cooperate:
  *
- *   1. **NOT EXISTS gate (older-sibling)** — excludes the row from
- *      `claimable` if any older same-email row is still `pending` or
- *      `in_flight`. The `o2.created_at < crm_outbox.created_at`
- *      clause is essential — without it every row would block itself
- *      and the queue would stall. This closes the retry-cooldown
- *      leapfrog where R1 (older, in transient-fail backoff) is
- *      filtered out of `claimable` by the due-time check, letting R2
- *      (newer, fresh) be claimed first and flip atlasFirstSource.
+ *   1. **NOT EXISTS gate** — splits the predicate by sibling status:
+ *      * Any `in_flight` same-email row blocks unconditionally
+ *        (regardless of `created_at`). A rolling hotfix or manual
+ *        recovery can leave a newer `in_flight` row alongside an
+ *        older `pending` row — without the age-independent in_flight
+ *        check, the older `pending` row would dispatch concurrently
+ *        with the newer in_flight one.
+ *      * Any `pending` same-email row blocks only if it's strictly
+ *        older by `(created_at, id)`. The `id` tie-break is what
+ *        serializes bulk-INSERT rows that share `created_at` (e.g.
+ *        the historic-leads backfill path that produces many rows in
+ *        one statement with one `now()` timestamp); without it, the
+ *        next tick would see a same-`created_at` sibling as not-older
+ *        and claim a second row while the first is still in_flight.
+ *      The age check on `pending` is what closes the retry-cooldown
+ *      leapfrog: R1 (older, in transient-fail backoff) is filtered
+ *      out of `claimable` by the due-time check, but its presence as
+ *      an older pending sibling still blocks R2 (newer, fresh) from
+ *      flipping atlasFirstSource ahead of it.
  *   2. **Advisory xact lock per email_key** — `pg_try_advisory_xact_lock`
  *      gives us serialization across concurrent transactions that
  *      MVCC alone can't provide. Without it, two flusher pods could
@@ -236,8 +247,13 @@ const CLAIM_SQL = `
           WHERE o2.email_key IS NOT NULL
             AND o2.email_key = crm_outbox.email_key
             AND o2.id <> crm_outbox.id
-            AND o2.status IN ('pending', 'in_flight')
-            AND o2.created_at < crm_outbox.created_at
+            AND (
+              o2.status = 'in_flight'
+              OR (
+                o2.status = 'pending'
+                AND (o2.created_at, o2.id) < (crm_outbox.created_at, crm_outbox.id)
+              )
+            )
         )
         AND (
           email_key IS NULL
@@ -364,6 +380,13 @@ export const SHUTDOWN_RECOVERY_STALE_MS = 30_000;   // 30 s
  * concurrently with siblings). Warn-log so operators can grep and
  * investigate before atlasFirstSource flips weeks later.
  *
+ * The literals must match the `eventType` strings that actually land
+ * in `crm_outbox.event_type`, NOT the upstream `AtlasLeadEvent.source`
+ * variants — they coincide for `demo` / `signup` / `sales-form` (the
+ * dispatcher passes `input.source` through verbatim) but diverge for
+ * conversions, which enqueue as `"stamp-conversion"` (the
+ * `STAMP_CONVERSION_EVENT_TYPE` constant in `ee/src/saas-crm/index.ts`).
+ *
  * New email-keyed event types must be added here AND have an `email`
  * field on their payload type — the runtime check is the only defense
  * against a TypeScript cast or `unknown`-laundered payload silently
@@ -373,7 +396,7 @@ const EMAIL_KEYED_EVENT_TYPES: ReadonlySet<string> = new Set([
   "demo",
   "signup",
   "sales-form",
-  "conversion",
+  "stamp-conversion",
 ]);
 
 /** Insert a row in `pending` status. Returns the new row id. */


### PR DESCRIPTION
## Summary

- **Migration `0104_crm_outbox_email_key.sql`**: adds `email_key TEXT` to `crm_outbox`, backfills from `payload->>'email'`, indexes `(email_key, status, created_at) WHERE status IN ('pending', 'in_flight')`.
- **`enqueue`**: populates `email_key` via `extractEmailKey(payload)` — lowercase + trim, matching the lead normalizer; returns `null` for payloads without `email`.
- **`CLAIM_SQL`**: rewritten as a CTE. Inner SELECT excludes any row whose `email_key` already has an `in_flight` sibling; `DISTINCT ON (COALESCE(email_key, id::text))` then picks the earliest pending row per email per tick. NULL email_key rows fall back to per-id dedup so non-email-keyed future event types stay independent.
- **Drizzle schema**: mirrors the new column + index (drift check passes).
- **Coverage**: 6 new in-memory unit tests + 3 new real-Postgres tests covering the C10 gworth swap, B8 msdyson idempotency, NULL independence, throughput preservation, and the cross-tick NOT EXISTS gate.

Closes #2870.

## Why this fix (vs. options 2 / 3 in the issue body)

- **Option 1 (this PR)** — fixes the bug at the durable layer (DB-side claim), works across pods, no Twenty schema changes, throughput preserved for distinct emails. Worst case for a workspace: same-email events drain one-per-tick (5s default).
- **Option 2 (order-insensitive merge-PATCH)** — would require a new `atlasLastEventAt` custom field on Twenty Person + dispatcher changes to read existing state and compare timestamps. Heavier; introduces an external schema dependency.
- **Option 3 (smoke band-aid)** — doesn't fix the underlying ordering risk; rejected per the issue body ("(1) or (2) fix the real bug; (3) is band-aid").

## Test plan

- [x] `bun run lint`
- [x] `bun run type` 
- [x] `bash scripts/check-schema-drift.sh`
- [x] `bash scripts/check-test-discipline.sh`
- [x] `bash scripts/check-ee-imports.sh`
- [x] `bun run syncpack lint --dependency-types prod,dev`
- [x] In-memory: `bun test src/lib/lead-outbox/__tests__/outbox.test.ts` — 31/31 pass (was 25, +6 for #2870)
- [x] Real-PG (via `TEST_DATABASE_URL=postgresql://atlas:atlas@localhost:5432/atlas`): `bun test src/lib/lead-outbox/__tests__/outbox-pg.test.ts` — 16/16 pass (was 13, +3 for #2870)
- [ ] `atlas ops smoke-crm` against `api.twenty.com` (DoD #1 from the issue — owner verification, needs the SaaS `TWENTY_API_KEY` which isn't in this worktree)
- [ ] CI green

## Notes

- The unit test for the gworth swap is deterministic: tick 1 claims only `demo`; tick 2 claims `signup`. The for-loop in `flushBatch` then guarantees `upsertPerson` for `demo` (POST: first=DEMO, last=DEMO) lands before `signup`'s PATCH (last=SIGNUP, first stays DEMO sticky). Source-swap is impossible post-fix.
- `migrate-pg.test.ts` will exercise 0104 against real Postgres in CI as part of the existing per-PR smoke.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/2872"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782437484&installation_id=135337507&pr_number=2872&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F2872&signature=1f66f36bf74f183635d9cb1e93f862f7503e98c49aec9ad79dd5cea453e442a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->