### PR TITLE
feat(api): gate CRM outbox flusher via ATLAS_CRM_OUTBOX_FLUSHER_ENABLED

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -242,6 +242,7 @@ ATLAS_ADMIN_EMAIL=admin@useatlas.dev
 # TWENTY_BASE_URL=https://crm.useatlas.dev   # Twenty REST base URL (defaults to crm.useatlas.dev). Self-hosters set to their own Twenty hostname.
 # TWENTY_API_KEY=                            # Bearer key from Twenty Settings → API & Webhooks. Required for SaaS demo / signup / contact-form dispatch into Twenty; unset = SaasCrm.available is false. Twenty Person object must have custom fields `atlasFirstSource` AND `atlasLastSource` (verified at boot).
 # ATLAS_CRM_OUTBOX_WARN_THRESHOLD=100        # Pending-row threshold for the rate-limited backlog warning (#2734). When the flusher sees more than this many `crm_outbox` rows in `pending` status, it emits one `log.warn` per minute with the depth + oldest pending row's age. Pair with the `atlas.crm_outbox.pending_count` gauge for dashboards. Out-of-range values clamp to [1, 1_000_000] and log a warn.
+# ATLAS_CRM_OUTBOX_FLUSHER_ENABLED=true      # Region gate for the polling flusher. Default true. Set `false` on regional API pods (e.g. api-eu / api-apac) whose internal `crm_outbox` is permanently empty — the lead-capture pipeline at crm.useatlas.dev writes only to US, so EU/APAC otherwise burn ~17k idle `UPDATE` statements per region per day. Recovery sweeps still run on boot/shutdown regardless of this flag, so flipping it back to `true` later inherits clean state.
 
 # === Talk-to-sales form (#2730) ===
 # Server side (api): verifies Cloudflare Turnstile tokens submitted by the

--- a/packages/api/src/lib/effect/__tests__/outbox-flusher-lifecycle.test.ts
+++ b/packages/api/src/lib/effect/__tests__/outbox-flusher-lifecycle.test.ts
@@ -182,6 +182,53 @@ describe("outbox flusher lifecycle (#2729 AC #7 + #9)", () => {
     }
   });
 
+  test("ATLAS_CRM_OUTBOX_FLUSHER_ENABLED=false skips the tick fork but keeps recovery sweeps", async () => {
+    // Region-gate path (#2890): EU/APAC API pods set this to `false`
+    // because the lead-capture pipeline only writes to US's internal
+    // Postgres. The flusher polling loop is skipped, but the boot +
+    // shutdown recovery sweeps must still run so a future flip-back-on
+    // inherits clean state.
+    process.env.ATLAS_CRM_OUTBOX_FLUSHER_ENABLED = "false";
+    // Short tick so a regression (gate not honored) would surface
+    // ticks quickly inside the wait window.
+    process.env.ATLAS_CRM_OUTBOX_TICK_SECONDS = "1";
+    try {
+      const config = {} as Parameters<typeof makeSchedulerLive>[0];
+      const baseLayer = makeSchedulerLive(config);
+      const deps = Layer.mergeAll(
+        NoopEnterpriseDefaultsLayer,
+        makeAvailableSaasCrmLayer(),
+      );
+      const layer = baseLayer.pipe(Layer.provide(deps));
+
+      const rt = ManagedRuntime.make(layer);
+      await Effect.runPromise(rt.runtimeEffect);
+      // Window > 2× tick interval — if the fork ran we'd see depth
+      // snapshot queries pile up here. With the gate honored we see zero.
+      await new Promise((r) => setTimeout(r, 2_500));
+      await rt.dispose();
+
+      // queryDepthSnapshot from the tick reads `FROM crm_outbox` WITHOUT
+      // the `WHERE status = 'in_flight'` filter; the recovery sweeps do
+      // the opposite. Splitting on that filter cleanly partitions the two.
+      const tickCalls = sqlLog.filter(
+        (q) =>
+          /FROM crm_outbox/i.test(q.sql) && !/WHERE status = 'in_flight'/i.test(q.sql),
+      );
+      expect(tickCalls.length).toBe(0);
+
+      // Recovery sweeps must still have fired: one boot + one shutdown
+      // = 2 × 2 statements (dead-letter + reset) = 4 in_flight queries.
+      const recoveryCalls = sqlLog.filter((q) =>
+        /WHERE status = 'in_flight'/i.test(q.sql),
+      );
+      expect(recoveryCalls.length).toBe(4);
+    } finally {
+      delete process.env.ATLAS_CRM_OUTBOX_FLUSHER_ENABLED;
+      delete process.env.ATLAS_CRM_OUTBOX_TICK_SECONDS;
+    }
+  });
+
   test("Layer skips flusher wiring when SaasCrm.available is false", async () => {
     const noopSaasCrm: Layer.Layer<SaasCrmTag> = Layer.succeed(SaasCrm, {
       available: false,

--- a/packages/api/src/lib/effect/layers.ts
+++ b/packages/api/src/lib/effect/layers.ts
@@ -56,6 +56,7 @@ import {
   runOutboxTick,
   getTickIntervalMs as getOutboxTickIntervalMs,
   getWarnThreshold as getOutboxWarnThreshold,
+  isFlusherEnabled as isOutboxFlusherEnabled,
   OutboxWarnRateLimiter,
   FLUSH_BATCH_LIMIT as OUTBOX_FLUSH_BATCH_LIMIT,
   STARTUP_RECOVERY_STALE_MS as OUTBOX_STARTUP_STALE_MS,
@@ -1604,6 +1605,27 @@ export function makeSchedulerLive(
           }),
         );
 
+        // Region gate. EU/APAC API pods set `ATLAS_CRM_OUTBOX_FLUSHER_ENABLED=false`
+        // because the lead-capture pipeline at crm.useatlas.dev only
+        // writes to US's internal Postgres — EU/APAC `crm_outbox`
+        // tables stay permanently empty, and a 5s polling loop there
+        // burns ~17k idle UPDATE statements per region per day. The
+        // recovery sweeps above + the shutdown finalizer above stay
+        // wired regardless so a future flip-back-on inherits clean
+        // state (and a region that DOES get crm_outbox rows enqueued
+        // via some other path still mops up crash carcasses at boot).
+        // Nested-if (rather than early-return) because we're inside
+        // the outer Effect.gen that registers the scheduler finalizer
+        // below — bailing out here with `return` would skip that wiring.
+        const flusherEnabled = isOutboxFlusherEnabled();
+        if (!flusherEnabled) {
+          log.info(
+            { event: "lead_outbox.flusher_disabled_by_env" },
+            "CRM outbox flusher disabled by ATLAS_CRM_OUTBOX_FLUSHER_ENABLED=false — recovery sweeps still run on boot/shutdown",
+          );
+        }
+
+        if (flusherEnabled) {
         const outboxTickIntervalMs = getOutboxTickIntervalMs();
         // One rate limiter per Layer scope — `lastWarnAt` lives on the
         // instance, so a sustained 101+ pending depth fires exactly
@@ -1778,6 +1800,7 @@ export function makeSchedulerLive(
           },
           "CRM outbox flusher started — heartbeat=lead_outbox.heartbeat (every ~60s when idle); stall watchdog=lead_outbox.tick_stall (fires when no tick observed in > 2× interval)",
         );
+        } // close `if (flusherEnabled)`
       } else {
         log.debug(
           {

--- a/packages/api/src/lib/lead-outbox/__tests__/outbox.test.ts
+++ b/packages/api/src/lib/lead-outbox/__tests__/outbox.test.ts
@@ -39,6 +39,7 @@ const {
   computeRetryAfterTimestamp,
   enqueue,
   flushBatch,
+  isFlusherEnabled,
   recoverInFlight,
 } = await import("../outbox");
 type ClaimedOutboxRow = import("../outbox").ClaimedOutboxRow;
@@ -658,6 +659,57 @@ describe("terminal-status UPDATE retry", () => {
     const result = await flushBatch(wrappedDb, dispatcher, 10);
     expect(result.ok).toBe(1);
     expect(db.rows[0].status).toBe("done");
+  });
+});
+
+describe("isFlusherEnabled — region gate", () => {
+  const KEY = "ATLAS_CRM_OUTBOX_FLUSHER_ENABLED";
+
+  // Snapshot + restore the env around each case so the test order
+  // doesn't matter (the broader bun-test isolation also resets vars
+  // between files, but within-file we set/clear explicitly).
+  let original: string | undefined;
+  beforeEach(() => {
+    original = process.env[KEY];
+    delete process.env[KEY];
+  });
+  // Use a per-test cleanup rather than afterEach so a failure mid-test
+  // still restores the env for the rest of this describe.
+  const restore = () => {
+    if (original === undefined) delete process.env[KEY];
+    else process.env[KEY] = original;
+  };
+
+  test("default (env unset) is enabled — preserves pre-gate behavior", () => {
+    expect(isFlusherEnabled()).toBe(true);
+    restore();
+  });
+
+  test("recognized falsey strings disable", () => {
+    for (const v of ["false", "FALSE", "False", "0", "no", "NO", "off", " false "]) {
+      process.env[KEY] = v;
+      expect(isFlusherEnabled()).toBe(false);
+    }
+    restore();
+  });
+
+  test("recognized truthy strings keep enabled", () => {
+    for (const v of ["true", "TRUE", "True", "1", "yes", "on"]) {
+      process.env[KEY] = v;
+      expect(isFlusherEnabled()).toBe(true);
+    }
+    restore();
+  });
+
+  test("unrecognized values default-true (avoid silent disable on typos)", () => {
+    // An operator who types "disable" or "off-by-default" should NOT
+    // accidentally silence the flusher — the env semantic is opt-out,
+    // and only the explicit affordances above flip it off.
+    for (const v of ["disable", "0.0", "", "  ", "false-ish"]) {
+      process.env[KEY] = v;
+      expect(isFlusherEnabled()).toBe(true);
+    }
+    restore();
   });
 });
 

--- a/packages/api/src/lib/lead-outbox/index.ts
+++ b/packages/api/src/lib/lead-outbox/index.ts
@@ -9,6 +9,7 @@ export {
   recoverInFlight,
   flushBatch,
   getTickIntervalMs,
+  isFlusherEnabled,
   computeRetryAfterTimestamp,
   FLUSH_BATCH_LIMIT,
   STARTUP_RECOVERY_STALE_MS,

--- a/packages/api/src/lib/lead-outbox/outbox.ts
+++ b/packages/api/src/lib/lead-outbox/outbox.ts
@@ -598,3 +598,39 @@ export function getTickIntervalMs(): number {
  * across many ticks rather than starving the upstream rate limit in one.
  */
 export const FLUSH_BATCH_LIMIT = 50;
+
+/**
+ * Flusher region gate. Default `true` — every API instance that has
+ * `SaasCrm.available === true` and an internal DB runs the flusher,
+ * which preserves the pre-#2890 behavior.
+ *
+ * Set `ATLAS_CRM_OUTBOX_FLUSHER_ENABLED=false` on regional API pods
+ * (api-eu / api-apac) whose internal DB has no source of `crm_outbox`
+ * rows: the SaaS lead-capture pipeline at `crm.useatlas.dev` only
+ * writes to US, so EU/APAC tick 12×/min against a permanently-empty
+ * table — ~17k wasted `UPDATE ... SELECT ... FOR UPDATE SKIP LOCKED`
+ * statements per region per day, plus log noise (`lead_outbox.heartbeat`
+ * every 60s).
+ *
+ * Disabling the flusher does NOT skip the recovery sweep finalizer:
+ * boot-time `recoverInFlight` still resets stranded `in_flight` rows
+ * from a previous deploy's crash. So flipping the env on a region that
+ * previously had the flusher running is safe.
+ *
+ * Future direction (eventize): replace the always-on poll loop with
+ * edge-triggered enqueue-kick + per-row retry_after timer + 5min
+ * backstop sweep. Until then this env is the cheapest dial.
+ */
+export function isFlusherEnabled(): boolean {
+  const raw = process.env.ATLAS_CRM_OUTBOX_FLUSHER_ENABLED;
+  if (raw === undefined) return true;
+  const normalized = raw.trim().toLowerCase();
+  // Accept the usual boolean affordances; default-true semantics mean
+  // anything we don't recognize as a "no" stays enabled.
+  return !(
+    normalized === "false" ||
+    normalized === "0" ||
+    normalized === "no" ||
+    normalized === "off"
+  );
+}


### PR DESCRIPTION
## Summary

- Add `ATLAS_CRM_OUTBOX_FLUSHER_ENABLED` env (default `true`, preserves current behavior).
- Layer-level gate at `packages/api/src/lib/effect/layers.ts` skips the polling tick + watchdog forks when `false`.
- Recovery sweeps (boot + shutdown) still run regardless — flipping the flag back on later inherits clean state.
- `.env.example` documents the new var; helper exported from `@atlas/api/lib/lead-outbox`.

## Why

Railway logs across the three regional API pods (current 8-hour window):

| Service  | `lead_outbox.heartbeat` (idle) | `lead_outbox.tick_complete` (active) |
|----------|-------------------------------|--------------------------------------|
| api (US) | 165                           | 0                                    |
| api-eu   | 492                           | **0**                                |
| api-apac | 492                           | **0**                                |

The SaaS lead-capture pipeline at `crm.useatlas.dev` only writes to US's internal Postgres (`us-int-postgres`). EU/APAC have their own internal DBs (`eu-int-postgres`, `apac-int-postgres`) whose `crm_outbox` tables stay permanently empty — yet they tick every 5s and emit a heartbeat every 60s plus a depth-gauge metric. That's ~17,280 idle `UPDATE crm_outbox SET status='in_flight' WHERE id IN (SELECT … FOR UPDATE SKIP LOCKED)` per region per day — ~34,560 wasted statements across EU+APAC daily — plus continuous log/metric noise.

## Behavior

| `ATLAS_CRM_OUTBOX_FLUSHER_ENABLED` | Polling fork | Watchdog fork | Boot recovery sweep | Shutdown recovery sweep |
|---|---|---|---|---|
| unset / `true` (default) | ✅ runs | ✅ runs | ✅ runs | ✅ runs |
| `false` / `0` / `no` / `off` | ❌ skipped | ❌ skipped | ✅ runs | ✅ runs |
| anything else (typos) | ✅ runs (default-true) | ✅ runs | ✅ runs | ✅ runs |

On disable, the boot log carries `lead_outbox.flusher_disabled_by_env` so the state is observable.

## Deployment

After merge, set `ATLAS_CRM_OUTBOX_FLUSHER_ENABLED=false` on the `api-eu` and `api-apac` Railway services. US (`api`) stays default-on. Recovery sweeps continue to run, so the flip is safely reversible.

## Future direction

Replace the polling loop with edge-triggered: inline kick on `enqueue`, per-row `retry_after` timer, low-frequency (~5min) backstop sweep for crash recovery + retry deadlines the in-memory timer forgot across restarts. Tracked in a separate issue.

## Test plan

- [x] `bun run lint`
- [x] `bun run type`
- [x] `bash scripts/check-test-discipline.sh`
- [x] `bash scripts/check-ee-imports.sh`
- [x] `bun test src/lib/lead-outbox/__tests__/outbox.test.ts` — 29 pass (4 new env-parser cases)
- [x] `bun test src/lib/effect/__tests__/outbox-flusher-lifecycle.test.ts` — 5 pass (1 new gate test asserting tick fork is skipped while recovery sweeps still run)
- [x] `bun run scripts/test-isolated.ts --affected` — 30/30 files
- [ ] CI green

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/2873"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782477518&installation_id=135337507&pr_number=2873&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F2873&signature=3f1b39acae956b826b2203debf611e6b9088c2e4818cfc06a4013293755e9031"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->