### PR TITLE
test(plugins/twenty): client-level mock for findPersonByEmail filter-bypass regression — closes #2871

### DIFF
--- a/ee/src/saas-crm/__tests__/saas-crm.test.ts
+++ b/ee/src/saas-crm/__tests__/saas-crm.test.ts
@@ -1597,7 +1597,12 @@ describe("dispatchOutboxRow", () => {
           JSON.stringify({
             data: {
               people: [
-                { id: "person_returning", atlasFirstSource: "DEMO", atlasLastSource: "DEMO" },
+                {
+                  id: "person_returning",
+                  emails: { primaryEmail: "returning@test.local" },
+                  atlasFirstSource: "DEMO",
+                  atlasLastSource: "DEMO",
+                },
               ],
             },
           }),

--- a/plugins/twenty/__tests__/client.test.ts
+++ b/plugins/twenty/__tests__/client.test.ts
@@ -373,6 +373,139 @@ describe("upsertPerson — malformed 200 from findPersonByEmail", () => {
 });
 
 // ─────────────────────────────────────────────────────────────────────
+//  Broken filter / email-mismatch fail-loud (regression-guard for #2865)
+//
+//  Reproduces the catastrophic-collapse signature at the client layer:
+//  if Twenty ever returns the unfiltered list (because our filter syntax
+//  regressed or Twenty's filter validator loosens), `findPersonByEmail`
+//  must refuse rather than merge to a different person's record. Pins
+//  the contract without depending on api.twenty.com's filter-tolerance.
+// ─────────────────────────────────────────────────────────────────────
+
+describe("upsertPerson — broken filter / email mismatch", () => {
+  test("throws TwentyClientError when returned Person's primaryEmail differs from queried email", async () => {
+    // Simulates Twenty silently ignoring the filter and returning the
+    // unfiltered list — `list[0]` belongs to someone else entirely.
+    const { fetch, calls } = makeScriptedFetch([
+      {
+        status: 200,
+        body: {
+          data: {
+            people: [
+              {
+                id: "person_someone_else",
+                emails: { primaryEmail: "someone-else@elsewhere.com" },
+                atlasFirstSource: "DEMO",
+              },
+            ],
+          },
+        },
+      },
+    ]);
+    const config = baseConfig({ fetchImpl: fetch });
+
+    try {
+      await upsertPerson(config, {
+        email: "queried@test.com",
+        eventSource: "DEMO",
+      });
+      throw new Error("expected throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(TwentyClientError);
+      const e = err as TwentyClientError;
+      expect(e.operation).toBe("findPersonByEmail");
+      expect(e.message).toContain("email mismatch");
+      expect(e.message).toContain("queried@test.com");
+      expect(e.message).toContain("someone-else@elsewhere.com");
+    }
+
+    // CRITICAL: no PATCH or POST may have followed the find. Only the
+    // GET filter call should have happened.
+    expect(calls).toHaveLength(1);
+    expect(calls[0].method).toBe("GET");
+
+    // Belt-and-suspenders: pin the Atlas-side filter format to Twenty's
+    // documented `field[op]:value` form. If a future change reverts to
+    // the bracket-nested `filter[field][op]=value` form (the #2865
+    // regression shape), this assertion fails alongside the mismatch
+    // guard — making the new test sufficient on its own to catch the
+    // filter line regressing, independent of api.twenty.com's filter
+    // validator hardening.
+    expect(calls[0].url).toContain("filter=emails.primaryEmail[eq]:");
+    expect(calls[0].url).not.toContain("filter[emails.primaryEmail][eq]=");
+  });
+
+  test("throws TwentyClientError when returned Person has no emails field at all", async () => {
+    const { fetch, calls } = makeScriptedFetch([
+      {
+        status: 200,
+        body: {
+          data: {
+            people: [{ id: "person_no_email", atlasFirstSource: "DEMO" }],
+          },
+        },
+      },
+    ]);
+    const config = baseConfig({ fetchImpl: fetch });
+
+    try {
+      await upsertPerson(config, {
+        email: "queried@test.com",
+        eventSource: "DEMO",
+      });
+      throw new Error("expected throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(TwentyClientError);
+      const e = err as TwentyClientError;
+      expect(e.operation).toBe("findPersonByEmail");
+      expect(e.message).toContain("email mismatch");
+    }
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].method).toBe("GET");
+  });
+
+  test("case-insensitive match — queried Foo@Bar.com vs returned foo@bar.com proceeds to PATCH", async () => {
+    // Twenty stores emails as-entered but matches case-insensitively per
+    // its docs — guard that we don't reject a legitimately-matched Person
+    // just because the case differs.
+    const { fetch, calls } = makeScriptedFetch([
+      {
+        status: 200,
+        body: {
+          data: {
+            people: [
+              {
+                id: "person_case_match",
+                emails: { primaryEmail: "foo@bar.com" },
+                atlasFirstSource: "DEMO",
+              },
+            ],
+          },
+        },
+      },
+      {
+        status: 200,
+        body: { data: { updatePerson: { id: "person_case_match" } } },
+      },
+    ]);
+    const config = baseConfig({ fetchImpl: fetch });
+
+    const result = await upsertPerson(config, {
+      email: "Foo@Bar.com",
+      eventSource: "SIGNUP",
+    });
+
+    expect(result.id).toBe("person_case_match");
+    expect(calls).toHaveLength(2);
+    expect(calls[1].method).toBe("PATCH");
+    expect(calls[1].url).toBe(
+      "https://crm.test.local/rest/people/person_case_match",
+    );
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
 //  Bearer auth header
 // ─────────────────────────────────────────────────────────────────────
 
@@ -483,7 +616,13 @@ describe("upsertPerson — error mapping", () => {
         status: 200,
         body: {
           data: {
-            people: [{ id: "p1", atlasFirstSource: "DEMO" }],
+            people: [
+              {
+                id: "p1",
+                emails: { primaryEmail: "u@t.com" },
+                atlasFirstSource: "DEMO",
+              },
+            ],
           },
         },
       },

--- a/plugins/twenty/__tests__/client.test.ts
+++ b/plugins/twenty/__tests__/client.test.ts
@@ -125,13 +125,13 @@ describe("upsertPerson — Person absent", () => {
     expect(calls).toHaveLength(2);
     expect(calls[0].method).toBe("GET");
     expect(calls[0].url).toContain("/rest/people?filter=");
-    // Twenty's documented filter syntax: `field[COMPARATOR]:value`
-    // (per its OpenAPI spec's `components.parameters.filter` description).
-    // The bracket-nested form `filter[field][op]=value` is silently
-    // ignored by Twenty and returns the unfiltered list — guard against
-    // a regression to that shape.
-    expect(calls[0].url).toContain("filter=emails.primaryEmail[eq]:");
-    expect(calls[0].url).not.toContain("filter[emails.primaryEmail][eq]=");
+    // Twenty's documented `field[op]:value` filter shape. Decoding keeps
+    // the assertion encoding-tolerant if a future refactor routes the
+    // query through URLSearchParams. See #2865 for the bracket-nested
+    // regression this guards against.
+    const decodedUrl = decodeURIComponent(calls[0].url);
+    expect(decodedUrl).toContain("filter=emails.primaryEmail[eq]:");
+    expect(decodedUrl).not.toContain("filter[emails.primaryEmail][eq]=");
     expect(calls[0].url).toContain(encodeURIComponent("user@test.com"));
 
     expect(calls[1].method).toBe("POST");
@@ -419,20 +419,17 @@ describe("upsertPerson — broken filter / email mismatch", () => {
       expect(e.message).toContain("someone-else@elsewhere.com");
     }
 
-    // CRITICAL: no PATCH or POST may have followed the find. Only the
-    // GET filter call should have happened.
     expect(calls).toHaveLength(1);
     expect(calls[0].method).toBe("GET");
 
-    // Belt-and-suspenders: pin the Atlas-side filter format to Twenty's
-    // documented `field[op]:value` form. If a future change reverts to
-    // the bracket-nested `filter[field][op]=value` form (the #2865
-    // regression shape), this assertion fails alongside the mismatch
-    // guard — making the new test sufficient on its own to catch the
-    // filter line regressing, independent of api.twenty.com's filter
-    // validator hardening.
-    expect(calls[0].url).toContain("filter=emails.primaryEmail[eq]:");
-    expect(calls[0].url).not.toContain("filter[emails.primaryEmail][eq]=");
+    // Pin Twenty's documented `field[op]:value` filter form; reject the
+    // bracket-nested `?filter[field][op]=…` shape that produced #2865.
+    // `decodeURIComponent` keeps the assertion correct if a future refactor
+    // routes the filter through URLSearchParams and percent-encodes the
+    // brackets — without it the toContain would silently never match.
+    const decodedUrl = decodeURIComponent(calls[0].url);
+    expect(decodedUrl).toContain("filter=emails.primaryEmail[eq]:");
+    expect(decodedUrl).not.toContain("filter[emails.primaryEmail][eq]=");
   });
 
   test("throws TwentyClientError when returned Person has no emails field at all", async () => {
@@ -502,6 +499,140 @@ describe("upsertPerson — broken filter / email mismatch", () => {
     expect(calls[1].url).toBe(
       "https://crm.test.local/rest/people/person_case_match",
     );
+  });
+
+  test("whitespace-tolerant match — queried ' foo@bar.com ' vs returned 'foo@bar.com' proceeds to PATCH", async () => {
+    // A CSV import or webhook payload may carry trailing whitespace.
+    // The guard normalises both sides so a legitimate Person isn't
+    // dead-lettered with a misleading "email mismatch" message.
+    const { fetch, calls } = makeScriptedFetch([
+      {
+        status: 200,
+        body: {
+          data: {
+            people: [
+              {
+                id: "person_ws_match",
+                emails: { primaryEmail: "foo@bar.com" },
+                atlasFirstSource: "DEMO",
+              },
+            ],
+          },
+        },
+      },
+      {
+        status: 200,
+        body: { data: { updatePerson: { id: "person_ws_match" } } },
+      },
+    ]);
+    const config = baseConfig({ fetchImpl: fetch });
+
+    const result = await upsertPerson(config, {
+      email: " foo@bar.com ",
+      eventSource: "SIGNUP",
+    });
+
+    expect(result.id).toBe("person_ws_match");
+    expect(calls).toHaveLength(2);
+    expect(calls[1].method).toBe("PATCH");
+  });
+
+  test("Unicode-normalisation match — queried NFD vs returned NFC composed form proceeds to PATCH", async () => {
+    // `café@bar.com` exists in two byte sequences: NFC (single é)
+    // and NFD (e + combining ́). A naive `===` after lowercase
+    // rejects the legitimate match; the guard's NFC normalisation
+    // accepts it. Locks in the rule so a future revert to bare
+    // toLowerCase() surfaces here.
+    const nfc = "café@bar.com"; // composed
+    const nfd = "café@bar.com"; // decomposed
+    expect(nfc).not.toBe(nfd);
+    expect(nfc.normalize("NFC")).toBe(nfd.normalize("NFC"));
+
+    const { fetch, calls } = makeScriptedFetch([
+      {
+        status: 200,
+        body: {
+          data: {
+            people: [
+              {
+                id: "person_nfd_match",
+                emails: { primaryEmail: nfc },
+                atlasFirstSource: "DEMO",
+              },
+            ],
+          },
+        },
+      },
+      {
+        status: 200,
+        body: { data: { updatePerson: { id: "person_nfd_match" } } },
+      },
+    ]);
+    const config = baseConfig({ fetchImpl: fetch });
+
+    const result = await upsertPerson(config, {
+      email: nfd,
+      eventSource: "SIGNUP",
+    });
+
+    expect(result.id).toBe("person_nfd_match");
+    expect(calls).toHaveLength(2);
+    expect(calls[1].method).toBe("PATCH");
+  });
+
+  test("error message distinguishes missing emails field from empty primaryEmail string", async () => {
+    // Operator-debug ergonomics: a `primaryEmail=""` log line should not
+    // be ambiguous with "Twenty omitted the field". Both cases still mean
+    // the regression-guard fired, but the operator sees which shape.
+    const { fetch: fetchMissing } = makeScriptedFetch([
+      {
+        status: 200,
+        body: {
+          data: {
+            people: [{ id: "person_a", atlasFirstSource: "DEMO" }],
+          },
+        },
+      },
+    ]);
+    try {
+      await upsertPerson(baseConfig({ fetchImpl: fetchMissing }), {
+        email: "queried@test.com",
+        eventSource: "DEMO",
+      });
+      throw new Error("expected throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(TwentyClientError);
+      expect((err as TwentyClientError).message).toContain(
+        "no emails.primaryEmail field",
+      );
+    }
+
+    const { fetch: fetchEmpty } = makeScriptedFetch([
+      {
+        status: 200,
+        body: {
+          data: {
+            people: [
+              {
+                id: "person_b",
+                emails: { primaryEmail: "" },
+                atlasFirstSource: "DEMO",
+              },
+            ],
+          },
+        },
+      },
+    ]);
+    try {
+      await upsertPerson(baseConfig({ fetchImpl: fetchEmpty }), {
+        email: "queried@test.com",
+        eventSource: "DEMO",
+      });
+      throw new Error("expected throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(TwentyClientError);
+      expect((err as TwentyClientError).message).toContain('primaryEmail=""');
+    }
   });
 });
 

--- a/plugins/twenty/src/client.ts
+++ b/plugins/twenty/src/client.ts
@@ -208,6 +208,16 @@ function buildAuthHeaders(apiKey: string): Record<string, string> {
 const DEFAULT_TIMEOUT_MS = 10_000;
 
 /**
+ * Normalize an email for case-insensitive equality. Trims surrounding
+ * whitespace, applies Unicode NFC, and lowercases. The guard in
+ * `findPersonByEmail` compares both sides through this so a Person with a
+ * trailing-space store or NFD-encoded local part isn't false-rejected.
+ */
+function normalizeEmail(value: string): string {
+  return value.trim().normalize("NFC").toLowerCase();
+}
+
+/**
  * Parse the `Retry-After` header per RFC 9110 §10.2.3. Two valid forms:
  *  - `delta-seconds` (e.g. `120`) — non-negative integer.
  *  - `HTTP-date` (e.g. `Wed, 21 Oct 2015 07:28:00 GMT`) — `Date.parse`able.
@@ -286,31 +296,16 @@ async function readErrorDetail(response: Response): Promise<{ message: string; c
  * undefined when Twenty returns a 2xx with an empty result set.
  *
  * Twenty's REST filter syntax, per its OpenAPI spec
- * (`components.parameters.filter.description`):
- *   `field[COMPARATOR]:value`
- *   e.g. `?filter=emails.primaryEmail[eq]:<email>&limit=1`
+ * (`components.parameters.filter.description`): `field[COMPARATOR]:value`,
+ * e.g. `?filter=emails.primaryEmail[eq]:<email>&limit=1`. The bracket-nested
+ * `?filter[field][op]=…` form is silently ignored by Twenty and returns the
+ * unfiltered list (the #2865 collapse shape).
  *
- * Earlier versions of this client used a bracket-nested form
- * (`?filter[emails.primaryEmail][eq]=…`) borrowed from Strapi/Sails.
- * Twenty silently ignores that form and returns the unfiltered list,
- * which caused `upsertPerson` to merge every dispatch onto whichever
- * Person was first in the table — corrupting attribution across all
- * lead sources. The fix uses Twenty's documented `field[op]:value`
- * format so the filter actually narrows.
- *
- * Throws TwentyClientError when the response body is a 2xx but its
- * shape doesn't match `{ data: { people: TwentyPerson[] } }` — silently
- * returning undefined would cause `upsertPerson` to POST a duplicate
- * Person and clobber any sticky `atlasFirstSource` on the existing one.
- *
- * Also throws when Twenty returns a non-empty array whose first Person's
- * `emails.primaryEmail` does not equal the queried email (case-insensitive).
- * That mismatch is the catastrophic-collapse signature from #2865 — if
- * Twenty ever silently ignores our filter again (or our filter syntax
- * regresses) the response is the unfiltered list, and returning `list[0]`
- * would PATCH whichever Person sorts first, corrupting attribution across
- * every lead source. This guard makes the regression fail loud at the
- * client boundary instead of depending on Twenty's filter-validation.
+ * Throws TwentyClientError when:
+ *  - the 2xx body's shape doesn't match `{ data: { people: TwentyPerson[] } }`
+ *  - the first Person's `emails.primaryEmail` doesn't equal the queried
+ *    email after `normalizeEmail` (trim + NFC + lowercase) — the #2865
+ *    regression-guard; see `normalizeEmail` for the equality rule.
  */
 async function findPersonByEmail(
   config: TwentyClientConfig,
@@ -353,10 +348,14 @@ async function findPersonByEmail(
     const first = list[0] as TwentyPerson;
     const observed = (first as { emails?: { primaryEmail?: unknown } }).emails
       ?.primaryEmail;
-    const observedStr = typeof observed === "string" ? observed : "";
-    if (observedStr.toLowerCase() !== email.toLowerCase()) {
+    const observedStr = typeof observed === "string" ? observed : undefined;
+    if (observedStr === undefined || normalizeEmail(observedStr) !== normalizeEmail(email)) {
+      const observedDescription =
+        observedStr === undefined
+          ? "no emails.primaryEmail field"
+          : `primaryEmail="${observedStr}"`;
       throw new TwentyClientError({
-        message: `findPersonByEmail: response email mismatch — queried "${email}" but Twenty returned a Person with primaryEmail="${observedStr}". Filter syntax may be broken; refusing to merge to avoid corrupting attribution.`,
+        message: `findPersonByEmail: response email mismatch — queried "${email}" but Twenty returned a Person with ${observedDescription}. Filter syntax may be broken; refusing to merge to avoid corrupting attribution.`,
         status: response.status,
         operation: "findPersonByEmail",
       });
@@ -1021,6 +1020,11 @@ export interface SearchPeopleInput extends ListOptions {
  * form and returns the unfiltered list, which silently corrupts caller
  * logic. The unit tests assert the documented shape AND forbid the
  * bracket-nested form.
+ *
+ * Unlike `findPersonByEmail`, this method does NOT carry the #2865
+ * response-shape guard — it returns the raw upstream array and a filter
+ * regression here would silently surface unrelated rows to the caller.
+ * Treat results as advisory and verify identity before any mutating write.
  *
  * When multiple criteria are supplied they are AND'd via Twenty's
  * top-level `,` join — `?filter=A[eq]:x,B[like]:%y%`.

--- a/plugins/twenty/src/client.ts
+++ b/plugins/twenty/src/client.ts
@@ -302,6 +302,15 @@ async function readErrorDetail(response: Response): Promise<{ message: string; c
  * shape doesn't match `{ data: { people: TwentyPerson[] } }` — silently
  * returning undefined would cause `upsertPerson` to POST a duplicate
  * Person and clobber any sticky `atlasFirstSource` on the existing one.
+ *
+ * Also throws when Twenty returns a non-empty array whose first Person's
+ * `emails.primaryEmail` does not equal the queried email (case-insensitive).
+ * That mismatch is the catastrophic-collapse signature from #2865 — if
+ * Twenty ever silently ignores our filter again (or our filter syntax
+ * regresses) the response is the unfiltered list, and returning `list[0]`
+ * would PATCH whichever Person sorts first, corrupting attribution across
+ * every lead source. This guard makes the regression fail loud at the
+ * client boundary instead of depending on Twenty's filter-validation.
  */
 async function findPersonByEmail(
   config: TwentyClientConfig,
@@ -340,7 +349,19 @@ async function findPersonByEmail(
 
   const list = body.data?.people;
   if (Array.isArray(list)) {
-    return list.length > 0 ? (list[0] as TwentyPerson) : undefined;
+    if (list.length === 0) return undefined;
+    const first = list[0] as TwentyPerson;
+    const observed = (first as { emails?: { primaryEmail?: unknown } }).emails
+      ?.primaryEmail;
+    const observedStr = typeof observed === "string" ? observed : "";
+    if (observedStr.toLowerCase() !== email.toLowerCase()) {
+      throw new TwentyClientError({
+        message: `findPersonByEmail: response email mismatch — queried "${email}" but Twenty returned a Person with primaryEmail="${observedStr}". Filter syntax may be broken; refusing to merge to avoid corrupting attribution.`,
+        status: response.status,
+        operation: "findPersonByEmail",
+      });
+    }
+    return first;
   }
   // Twenty returned 200 with neither an array nor a documented shape we
   // recognize. Fail loud rather than return undefined and risk a duplicate


### PR DESCRIPTION
## Summary

Closes the regression-guard gap from #2871 — adds a client-level mock test in `plugins/twenty/__tests__/client.test.ts` that pins the contract "if Twenty returns the unfiltered list, the merge must refuse" without depending on api.twenty.com's filter-tolerance behavior.

Two layered changes:

1. **Defensive guard in `plugins/twenty/src/client.ts`** — `findPersonByEmail` now validates the returned Person's primary email matches the queried email through `normalizeEmail` (trim + Unicode NFC + lowercase). On mismatch — or when `emails.primaryEmail` is absent — it throws `TwentyClientError` with `operation: "findPersonByEmail"` and a message that distinguishes the missing-field case from a `primaryEmail=""` value. Short-circuits the PATCH/POST that would otherwise PATCH the wrong record and corrupt `atlasFirstSource` / `atlasLastSource` attribution across every lead source.

2. **New tests under `upsertPerson — broken filter / email mismatch`:**
   - Twenty returns a Person with a DIFFERENT email → rejects + no follow-up write. Also pins the Atlas-side filter to Twenty's documented `field[op]:value` form via URL-shape assertion. The assertion runs against `decodeURIComponent(url)` so a future refactor that percent-encodes brackets (e.g. routing through `URLSearchParams`) doesn't silently turn it into a no-op.
   - Returned Person has no `emails` field at all → same rejection.
   - Case-insensitive match (`Foo@Bar.com` ↔ `foo@bar.com`) proceeds to PATCH — guard doesn't reject legitimate matches.
   - Whitespace-tolerant match (` foo@bar.com ` ↔ `foo@bar.com`) proceeds — CSV-import / webhook payloads with trailing whitespace aren't false-rejected into the dead-letter queue.
   - Unicode normalisation match (NFD-decomposed `café` ↔ NFC-composed `café`) proceeds — pins the NFC rule against future drift.
   - Error message distinguishes "no emails.primaryEmail field" from `primaryEmail=""` so operator logs disambiguate which shape Twenty returned.

## Why this matters

Surfaced during the #2866 closeout ([comment](https://github.com/AtlasDevHQ/atlas/issues/2866#issuecomment-4550277666)) — when Run C reverted the #2865 filter fix and re-ran the smoke, the smoke went dirty for a *different* reason (#2870 flusher-ordering), NOT the catastrophic-collapse signature the #2865 bug originally produced. The most likely explanation: api.twenty.com itself has hardened against the broken bracket-nested filter form. That makes the #2865 regression-guard implicit — we'd only catch a future Atlas client regression IF Twenty also regressed in lockstep.

This PR closes that implicit gap. The new tests catch the regression at the client boundary, independent of upstream filter-validator behavior.

## Inversion verification

Manually reverted `client.ts` to the broken bracket-nested filter form `filter[emails.primaryEmail][eq]=…` (the #2865 catastrophic-collapse shape). Under that revert two assertion layers fire simultaneously in the `throws TwentyClientError when returned Person's primaryEmail differs from queried email` test: (a) the email-mismatch guard rejects `list[0]` because the returned Person's primary email won't match the queried email, and (b) the decoded-URL assertion `decodeURIComponent(calls[0].url).toContain("filter=emails.primaryEmail[eq]:")` fails because the URL now carries the bracket-nested shape. Both layers are belt-and-suspenders against the #2865 surface — either one alone catches the bug. Restored to the documented `field[op]:value` colon-form, all 83 client tests + 41 saas-crm tests pass.

Two pre-existing fixtures had stripped-down Person shapes that the new guard correctly rejects (`p1` in `client.test.ts:609`, `person_returning` in `saas-crm.test.ts:1599`) — backfilled both with matching `emails.primaryEmail`.

## Test plan

- [x] `bun test ./plugins/twenty/__tests__/client.test.ts` — 83 pass (77 existing + 6 new)
- [x] `bun test ./plugins/twenty/__tests__/` — 192 pass across 5 files
- [x] `bun test ee/src/saas-crm/__tests__/saas-crm.test.ts` — 41 pass
- [x] `bun test packages/cli/src/__tests__/ops-smoke-crm-*.test.ts` — 43 pass
- [x] `bun test packages/api/src/lib/lead-outbox/__tests__/outbox*.test.ts` + integrations/twenty store — 57 pass
- [x] Affected `@atlas/api` tests since base — 269 pass
- [x] `bun run type` — clean
- [x] `bun run lint` — clean
- [x] Inversion exercise: reverted filter to broken form, confirmed both layers fail; restored, confirmed green

## Closes

- Closes #2871
- References #2865 (the original bug fixed) and #2866 (closeout where the gap was surfaced)
