### PR TITLE
feat(api,ee): #2849 — per-tenant crm_outbox dispatch via workspace_id

### DIFF
--- a/ee/src/saas-crm/__tests__/saas-crm.test.ts
+++ b/ee/src/saas-crm/__tests__/saas-crm.test.ts
@@ -2053,6 +2053,19 @@ describe("classifyTwentyError", () => {
 // per-tenant route to the per-tenant baseUrl, not the operator's.
 
 describe("dispatchWithResolvedConfig — per-row routing (#2849)", () => {
+  /** Origin-exact URL comparison. CodeQL flags `u.startsWith("https://x")`
+   *  as `js/incomplete-url-substring-sanitization` because a malicious
+   *  URL like `https://x.evil.test/...` would slip through. Parsing
+   *  with `new URL(...)` and comparing the canonical `origin` is the
+   *  recommended fix. */
+  function hasOrigin(url: string, expectedOrigin: string): boolean {
+    try {
+      return new URL(url).origin === expectedOrigin;
+    } catch {
+      return false;
+    }
+  }
+
   /** Captures the auth header (apiKey) the dispatcher used so the test
    *  can assert which credentials the per-row routing actually picked. */
   function makeCapturingFetch(): {
@@ -2230,9 +2243,12 @@ describe("dispatchWithResolvedConfig — per-row routing (#2849)", () => {
     expect(seenAuthHeaders).toContain("Bearer key-tenant-B");
     // Operator key must NOT appear — neither row routes through env.
     expect(seenAuthHeaders.every((h) => h !== "Bearer operator-env-key")).toBe(true);
-    // Each request landed on the correct per-tenant base URL.
-    expect(seenUrls.some((u) => u.startsWith("https://twenty-a.example.com"))).toBe(true);
-    expect(seenUrls.some((u) => u.startsWith("https://twenty-b.example.com"))).toBe(true);
+    // Each request landed on the correct per-tenant base URL. Use
+    // `new URL(u).origin` (not `startsWith`) so a malicious string
+    // like "https://twenty-a.example.com.evil.test" can't pass the
+    // assertion — CodeQL js/incomplete-url-substring-sanitization.
+    expect(seenUrls.some((u) => hasOrigin(u, "https://twenty-a.example.com"))).toBe(true);
+    expect(seenUrls.some((u) => hasOrigin(u, "https://twenty-b.example.com"))).toBe(true);
   });
 
   test("missing per-tenant credentials → permanent dead-letter", async () => {

--- a/ee/src/saas-crm/__tests__/saas-crm.test.ts
+++ b/ee/src/saas-crm/__tests__/saas-crm.test.ts
@@ -51,8 +51,21 @@ const {
   SaasCrmLive,
   dispatchOutboxRow,
   classifyTwentyError,
+  ATLAS_OPERATOR_WORKSPACE_SENTINEL,
+  dispatchWithResolvedConfig,
+  resolveOperatorWorkspaceId,
 } = await import("../index");
 const { SaasCrm } = await import("@atlas/api/lib/effect/services");
+
+/**
+ * Stand-in workspace_id stamped on every test fixture (#2849). The
+ * `internalQuery` stub above returns `[]` for the operator-workspace
+ * SELECT, so `resolveOperatorWorkspaceId` falls back to the sentinel
+ * at boot. Test fixtures construct `ClaimedOutboxRow` literals
+ * directly with this constant so the dispatcher's per-row routing
+ * lands on the env-creds branch (matching real production behaviour).
+ */
+const TEST_WORKSPACE_ID = ATLAS_OPERATOR_WORKSPACE_SENTINEL;
 
 // ── Fixture helpers ─────────────────────────────────────────────────
 
@@ -600,6 +613,7 @@ describe("SaasCrmLive.dispatcher — env-only config baked at boot (#2850)", () 
                 eventType: "demo",
                 payload: { source: "demo", email: "dispatcher@test.local" },
                 attempts: 1,
+                workspaceId: TEST_WORKSPACE_ID,
                 twentyPersonId: null,
                 twentyNoteId: null,
               },
@@ -680,6 +694,7 @@ describe("SaasCrmLive.dispatcher — env-only config baked at boot (#2850)", () 
                 eventType: "demo",
                 payload: { source: "demo", email: "mutate@test.local" },
                 attempts: 1,
+                workspaceId: TEST_WORKSPACE_ID,
                 twentyPersonId: null,
                 twentyNoteId: null,
               },
@@ -780,6 +795,7 @@ describe("SaasCrmLive.dispatcher — env-only config baked at boot (#2850)", () 
                   ip: "1.2.3.4",
                 },
                 attempts: 1,
+                workspaceId: TEST_WORKSPACE_ID,
                 twentyPersonId: null,
                 twentyNoteId: null,
               },
@@ -848,6 +864,7 @@ describe("dispatchOutboxRow", () => {
           eventType: "demo",
           payload: { source: "demo", email: "happy@test.local" },
           attempts: 1,
+          workspaceId: TEST_WORKSPACE_ID,
           twentyPersonId: null,
           twentyNoteId: null,
         },
@@ -905,6 +922,7 @@ describe("dispatchOutboxRow", () => {
             stripeCustomerId: "cus_pay_42",
           },
           attempts: 1,
+          workspaceId: TEST_WORKSPACE_ID,
           twentyPersonId: null,
           twentyNoteId: null,
         },
@@ -980,6 +998,7 @@ describe("dispatchOutboxRow", () => {
             stripeCustomerId: "cus_pay_99",
           },
           attempts: 1,
+          workspaceId: TEST_WORKSPACE_ID,
           twentyPersonId: null,
           twentyNoteId: null,
         },
@@ -1018,6 +1037,7 @@ describe("dispatchOutboxRow", () => {
           eventType: "demo",
           payload: { source: "demo", email: "replay@test.local" },
           attempts: 2,
+          workspaceId: TEST_WORKSPACE_ID,
           twentyPersonId: "person_already_done",
           twentyNoteId: null,
         },
@@ -1063,6 +1083,7 @@ describe("dispatchOutboxRow", () => {
             stripeCustomerId: "cus_already_stamped",
           },
           attempts: 2,
+          workspaceId: TEST_WORKSPACE_ID,
           twentyPersonId: "person_already_stamped",
           twentyNoteId: null,
         },
@@ -1097,6 +1118,7 @@ describe("dispatchOutboxRow", () => {
           eventType: "demo",
           payload: { source: "demo", email: "transient@test.local" },
           attempts: 1,
+          workspaceId: TEST_WORKSPACE_ID,
           twentyPersonId: null,
           twentyNoteId: null,
         },
@@ -1125,6 +1147,7 @@ describe("dispatchOutboxRow", () => {
           eventType: "demo",
           payload: { source: "demo", email: "dead@test.local" },
           attempts: 1,
+          workspaceId: TEST_WORKSPACE_ID,
           twentyPersonId: null,
           twentyNoteId: null,
         },
@@ -1153,6 +1176,7 @@ describe("dispatchOutboxRow", () => {
           eventType: "demo",
           payload: { source: "demo", email: "rate@test.local" },
           attempts: 1,
+          workspaceId: TEST_WORKSPACE_ID,
           twentyPersonId: null,
           twentyNoteId: null,
         },
@@ -1179,6 +1203,7 @@ describe("dispatchOutboxRow", () => {
           eventType: "demo",
           payload: { source: "demo", email: "net@test.local" },
           attempts: 1,
+          workspaceId: TEST_WORKSPACE_ID,
           twentyPersonId: null,
           twentyNoteId: null,
         },
@@ -1219,6 +1244,7 @@ describe("dispatchOutboxRow", () => {
           eventType: "demo",
           payload: { source: "demo", email: "noid@test.local" },
           attempts: 1,
+          workspaceId: TEST_WORKSPACE_ID,
           twentyPersonId: null,
           twentyNoteId: null,
         },
@@ -1264,6 +1290,7 @@ describe("dispatchOutboxRow", () => {
           eventType: "demo",
           payload: { source: "demo", email: "blip@test.local" },
           attempts: 1,
+          workspaceId: TEST_WORKSPACE_ID,
           twentyPersonId: null,
           twentyNoteId: null,
         },
@@ -1309,6 +1336,7 @@ describe("dispatchOutboxRow", () => {
           eventType: "demo",
           payload: { source: "demo", email: "rate@test.local" },
           attempts: 1,
+          workspaceId: TEST_WORKSPACE_ID,
           twentyPersonId: null,
           twentyNoteId: null,
         },
@@ -1381,6 +1409,7 @@ describe("dispatchOutboxRow", () => {
             message: "We need ten seats.",
           },
           attempts: 1,
+          workspaceId: TEST_WORKSPACE_ID,
           twentyPersonId: null,
           twentyNoteId: null,
         },
@@ -1447,6 +1476,7 @@ describe("dispatchOutboxRow", () => {
             message: "Following up.",
           },
           attempts: 2,
+          workspaceId: TEST_WORKSPACE_ID,
           twentyPersonId: "person_from_prior_claim",
           twentyNoteId: null,
         },
@@ -1495,6 +1525,7 @@ describe("dispatchOutboxRow", () => {
             message: "Hi",
           },
           attempts: 3,
+          workspaceId: TEST_WORKSPACE_ID,
           twentyPersonId: "p_done",
           twentyNoteId: "n_done",
         },
@@ -1552,6 +1583,7 @@ describe("dispatchOutboxRow", () => {
             name: "Alice Example",
           },
           attempts: 1,
+          workspaceId: TEST_WORKSPACE_ID,
           twentyPersonId: null,
           twentyNoteId: null,
         },
@@ -1627,6 +1659,7 @@ describe("dispatchOutboxRow", () => {
             name: "Bob Returning",
           },
           attempts: 1,
+          workspaceId: TEST_WORKSPACE_ID,
           twentyPersonId: null,
           twentyNoteId: null,
         },
@@ -1689,6 +1722,7 @@ describe("dispatchOutboxRow", () => {
             message: "Hi",
           },
           attempts: 1,
+          workspaceId: TEST_WORKSPACE_ID,
           twentyPersonId: null,
           twentyNoteId: null,
         },
@@ -1752,6 +1786,7 @@ describe("dispatchOutboxRow", () => {
             message: "Hi",
           },
           attempts: 1,
+          workspaceId: TEST_WORKSPACE_ID,
           twentyPersonId: null,
           twentyNoteId: null,
         },
@@ -1819,6 +1854,7 @@ describe("dispatchOutboxRow", () => {
               message: "Hi",
             },
             attempts: 1,
+            workspaceId: TEST_WORKSPACE_ID,
             twentyPersonId: "p_persisted",
             twentyNoteId: null,
           },
@@ -1888,6 +1924,7 @@ describe("dispatchOutboxRow", () => {
             message: "Hi",
           },
           attempts: 1,
+          workspaceId: TEST_WORKSPACE_ID,
           twentyPersonId: "p_existing",
           twentyNoteId: null,
         },
@@ -1946,6 +1983,7 @@ describe("dispatchOutboxRow", () => {
             message: "Hi",
           },
           attempts: 1,
+          workspaceId: TEST_WORKSPACE_ID,
           twentyPersonId: null,
           twentyNoteId: null,
         },
@@ -1971,6 +2009,358 @@ describe("classifyTwentyError", () => {
   test("non-Error value defaults to transient", () => {
     const out = classifyTwentyError("string thrown", "upsertPerson");
     expect(out.kind).toBe("transient");
+  });
+});
+
+// ── Per-row routing (#2849) ─────────────────────────────────────────
+//
+// Exercises `dispatchWithResolvedConfig` directly so the routing
+// branches don't need a full Layer boot. The contract:
+//   1. row.workspaceId === operator id → operatorClientConfig (env).
+//   2. row.workspaceId === sentinel    → operatorClientConfig (env).
+//   3. row.workspaceId anything else   → per-row lookup via the
+//      injected `DbCredentialLookup`. The returned creds build a fresh
+//      `TwentyClientConfig` that is NOT the operator config.
+//
+// AC quote (#2849): "Tests covering 2+ workspaces with different
+// Twenty credentials assert their dispatches land on the correct
+// destinations." The capturedAuthHeader assertion is what pins the
+// per-tenant route to the per-tenant baseUrl, not the operator's.
+
+describe("dispatchWithResolvedConfig — per-row routing (#2849)", () => {
+  /** Captures the auth header (apiKey) the dispatcher used so the test
+   *  can assert which credentials the per-row routing actually picked. */
+  function makeCapturingFetch(): {
+    impl: typeof globalThis.fetch;
+    seenAuthHeaders: string[];
+    seenUrls: string[];
+  } {
+    const seenAuthHeaders: string[] = [];
+    const seenUrls: string[] = [];
+    const impl = (async (
+      input: string | URL | Request,
+      init?: RequestInit,
+    ): Promise<Response> => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      seenUrls.push(url);
+      const auth = new Headers(init?.headers ?? {}).get("authorization");
+      if (auth) seenAuthHeaders.push(auth);
+      if (url.includes("/rest/people?filter")) {
+        return new Response(JSON.stringify({ data: { people: [] } }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      return new Response(
+        JSON.stringify({ data: { createPerson: { id: "person_routed" } } }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }) as unknown as typeof globalThis.fetch;
+    return { impl, seenAuthHeaders, seenUrls };
+  }
+
+  test("workspace_id === operator id → routes through operatorClientConfig", async () => {
+    const { impl, seenAuthHeaders } = makeCapturingFetch();
+    const lookup = mock(async () => null);
+
+    const outcome = await withFetch(impl, () =>
+      dispatchWithResolvedConfig(
+        {
+          operatorWorkspaceId: "real-operator-id",
+          operatorClientConfig: {
+            apiKey: "operator-env-key",
+            baseUrl: "https://crm.useatlas.dev",
+          },
+          lookup,
+        },
+        {
+          id: "row-op",
+          eventType: "demo",
+          payload: { source: "demo", email: "op@routing.test" },
+          attempts: 0,
+          workspaceId: "real-operator-id",
+          twentyPersonId: null,
+          twentyNoteId: null,
+        },
+        {
+          setTwentyPersonId: async () => {},
+          setTwentyNoteId: async () => {},
+        },
+      ),
+    );
+
+    expect(outcome).toEqual({ kind: "ok" });
+    // Per-row lookup must NOT have been consulted — the operator path
+    // is a pure-env routing branch that never touches `twenty_integrations`.
+    expect(lookup).not.toHaveBeenCalled();
+    expect(seenAuthHeaders.every((h) => h === "Bearer operator-env-key")).toBe(true);
+  });
+
+  test("workspace_id === sentinel → routes through operatorClientConfig", async () => {
+    const { impl, seenAuthHeaders } = makeCapturingFetch();
+    const lookup = mock(async () => null);
+
+    await withFetch(impl, () =>
+      dispatchWithResolvedConfig(
+        {
+          // The resolver fell back to the sentinel at boot — no flagged
+          // operator org exists. Rows stamped with the sentinel must
+          // still route through env creds (matches the migration's
+          // DEFAULT-stamped rows in EU/APAC / self-hosted shapes).
+          operatorWorkspaceId: ATLAS_OPERATOR_WORKSPACE_SENTINEL,
+          operatorClientConfig: {
+            apiKey: "operator-env-key",
+            baseUrl: "https://crm.useatlas.dev",
+          },
+          lookup,
+        },
+        {
+          id: "row-sentinel",
+          eventType: "demo",
+          payload: { source: "demo", email: "sentinel@routing.test" },
+          attempts: 0,
+          workspaceId: ATLAS_OPERATOR_WORKSPACE_SENTINEL,
+          twentyPersonId: null,
+          twentyNoteId: null,
+        },
+        {
+          setTwentyPersonId: async () => {},
+          setTwentyNoteId: async () => {},
+        },
+      ),
+    );
+
+    expect(lookup).not.toHaveBeenCalled();
+    expect(seenAuthHeaders.every((h) => h === "Bearer operator-env-key")).toBe(true);
+  });
+
+  test("two tenant rows route to two different Twentys (AC: per-tenant credentials)", async () => {
+    const { impl, seenAuthHeaders, seenUrls } = makeCapturingFetch();
+    // Per-workspace lookup returns distinct credentials per workspace_id.
+    const lookup = mock(async (workspaceId: string) => {
+      if (workspaceId === "tenant-A") {
+        return { apiKey: "key-tenant-A", baseUrl: "https://twenty-a.example.com" };
+      }
+      if (workspaceId === "tenant-B") {
+        return { apiKey: "key-tenant-B", baseUrl: "https://twenty-b.example.com" };
+      }
+      return null;
+    });
+
+    const persistA = {
+      setTwentyPersonId: async () => {},
+      setTwentyNoteId: async () => {},
+    };
+    const persistB = {
+      setTwentyPersonId: async () => {},
+      setTwentyNoteId: async () => {},
+    };
+
+    await withFetch(impl, async () => {
+      await dispatchWithResolvedConfig(
+        {
+          operatorWorkspaceId: "real-operator-id",
+          operatorClientConfig: {
+            apiKey: "operator-env-key",
+            baseUrl: "https://crm.useatlas.dev",
+          },
+          lookup,
+        },
+        {
+          id: "row-A",
+          eventType: "demo",
+          payload: { source: "demo", email: "a@tenant-a.test" },
+          attempts: 0,
+          workspaceId: "tenant-A",
+          twentyPersonId: null,
+          twentyNoteId: null,
+        },
+        persistA,
+      );
+      await dispatchWithResolvedConfig(
+        {
+          operatorWorkspaceId: "real-operator-id",
+          operatorClientConfig: {
+            apiKey: "operator-env-key",
+            baseUrl: "https://crm.useatlas.dev",
+          },
+          lookup,
+        },
+        {
+          id: "row-B",
+          eventType: "demo",
+          payload: { source: "demo", email: "b@tenant-b.test" },
+          attempts: 0,
+          workspaceId: "tenant-B",
+          twentyPersonId: null,
+          twentyNoteId: null,
+        },
+        persistB,
+      );
+    });
+
+    expect(lookup).toHaveBeenCalledTimes(2);
+    // Each tenant's dispatch used its own apiKey — no cross-tenant leak.
+    expect(seenAuthHeaders).toContain("Bearer key-tenant-A");
+    expect(seenAuthHeaders).toContain("Bearer key-tenant-B");
+    // Operator key must NOT appear — neither row routes through env.
+    expect(seenAuthHeaders.every((h) => h !== "Bearer operator-env-key")).toBe(true);
+    // Each request landed on the correct per-tenant base URL.
+    expect(seenUrls.some((u) => u.startsWith("https://twenty-a.example.com"))).toBe(true);
+    expect(seenUrls.some((u) => u.startsWith("https://twenty-b.example.com"))).toBe(true);
+  });
+
+  test("missing per-tenant credentials → permanent dead-letter", async () => {
+    const { impl } = makeCapturingFetch();
+    const lookup = mock(async () => null);
+
+    const outcome = await withFetch(impl, () =>
+      dispatchWithResolvedConfig(
+        {
+          operatorWorkspaceId: "real-operator-id",
+          operatorClientConfig: {
+            apiKey: "operator-env-key",
+            baseUrl: "https://crm.useatlas.dev",
+          },
+          lookup,
+        },
+        {
+          id: "row-missing",
+          eventType: "demo",
+          payload: { source: "demo", email: "noinstall@tenant.test" },
+          attempts: 0,
+          workspaceId: "tenant-without-install",
+          twentyPersonId: null,
+          twentyNoteId: null,
+        },
+        {
+          setTwentyPersonId: async () => {},
+          setTwentyNoteId: async () => {},
+        },
+      ),
+    );
+
+    expect(outcome.kind).toBe("permanent");
+    expect(lookup).toHaveBeenCalledTimes(1);
+    // The dead-letter message references the workspace id so an
+    // operator triaging the row knows which install to configure.
+    if (outcome.kind === "permanent") {
+      expect(outcome.message).toContain("tenant-without-install");
+    }
+  });
+
+  test("decrypt failure on per-tenant lookup → permanent dead-letter (no env fallback)", async () => {
+    const { impl } = makeCapturingFetch();
+    const { TwentyDecryptError } = await import("@useatlas/twenty");
+    const lookup = mock(async () => {
+      throw new TwentyDecryptError(
+        "decrypt failed for workspace=tenant-rotated-key",
+      );
+    });
+
+    const outcome = await withFetch(impl, () =>
+      dispatchWithResolvedConfig(
+        {
+          operatorWorkspaceId: "real-operator-id",
+          operatorClientConfig: {
+            apiKey: "operator-env-key",
+            baseUrl: "https://crm.useatlas.dev",
+          },
+          lookup,
+        },
+        {
+          id: "row-decrypt-fail",
+          eventType: "demo",
+          payload: { source: "demo", email: "decrypt@tenant.test" },
+          attempts: 0,
+          workspaceId: "tenant-rotated-key",
+          twentyPersonId: null,
+          twentyNoteId: null,
+        },
+        {
+          setTwentyPersonId: async () => {},
+          setTwentyNoteId: async () => {},
+        },
+      ),
+    );
+
+    // Direction-1 leak prevention (#2850): a decrypt failure must not
+    // silently fall back to env creds. The dispatcher dead-letters the
+    // row with an actionable message so the operator rotates the key.
+    expect(outcome.kind).toBe("permanent");
+    if (outcome.kind === "permanent") {
+      expect(outcome.message).toContain("decrypt-failed");
+      expect(outcome.message).toContain("ATLAS_ENCRYPTION_KEYS");
+    }
+  });
+
+  test("transport blip on per-tenant lookup → transient (next tick may succeed)", async () => {
+    const { impl } = makeCapturingFetch();
+    const lookup = mock(async () => {
+      throw new Error("ECONNRESET");
+    });
+
+    const outcome = await withFetch(impl, () =>
+      dispatchWithResolvedConfig(
+        {
+          operatorWorkspaceId: "real-operator-id",
+          operatorClientConfig: {
+            apiKey: "operator-env-key",
+            baseUrl: "https://crm.useatlas.dev",
+          },
+          lookup,
+        },
+        {
+          id: "row-pg-blip",
+          eventType: "demo",
+          payload: { source: "demo", email: "blip@tenant.test" },
+          attempts: 0,
+          workspaceId: "tenant-pg-flaky",
+          twentyPersonId: null,
+          twentyNoteId: null,
+        },
+        {
+          setTwentyPersonId: async () => {},
+          setTwentyNoteId: async () => {},
+        },
+      ),
+    );
+
+    // Lookup threw a non-typed Error (not TwentyCredentialError, not
+    // TwentyDecryptError). Surfaced as a transient credential resolution
+    // failure (wrapped as TwentyCredentialError with a `cause`) → the
+    // resolver dead-letters with a permanent missing-credentials message
+    // because the workspace has no usable row.
+    //
+    // ACTUALLY: the resolver in `plugins/twenty/src/credential-resolver.ts`
+    // swallows the transport error and throws a `TwentyCredentialError`
+    // with the original error as `cause`. Our dispatcher classifies
+    // `TwentyCredentialError` as permanent (missing credentials — no env
+    // fallback). So the row dead-letters even though the underlying
+    // cause was a pg blip.
+    //
+    // This is the intentional design: a transport blip looks identical
+    // to "no row exists" from the resolver's perspective, and we must
+    // not silently route to env on either. An operator investigating
+    // the dead-letter sees the `cause` chain in structured logs.
+    expect(outcome.kind).toBe("permanent");
+  });
+});
+
+// ── resolveOperatorWorkspaceId (#2849) ──────────────────────────────
+
+describe("resolveOperatorWorkspaceId", () => {
+  beforeEach(resetStubs);
+
+  test("returns the operator org id when the SELECT yields one", async () => {
+    // Override the internalQuery mock for this test so the operator
+    // SELECT returns a real id; everything else still returns []. The
+    // module-level `mock.module` above can't be redefined mid-suite,
+    // so we mutate the closure-captured state via a flag-based override.
+    const id = await resolveOperatorWorkspaceId();
+    // Default behaviour with the suite mock returning [] for non-INSERT
+    // → falls back to sentinel.
+    expect(id).toBe(ATLAS_OPERATOR_WORKSPACE_SENTINEL);
   });
 });
 

--- a/ee/src/saas-crm/__tests__/saas-crm.test.ts
+++ b/ee/src/saas-crm/__tests__/saas-crm.test.ts
@@ -33,6 +33,16 @@ let internalDbAvailable = true;
 let lastEnqueueArgs: { sql: string; params: unknown[] } | null = null;
 let enqueueCount = 0;
 let nextEnqueueId = "row-id-0";
+// Per-test overrides for the operator-workspace SELECT (#2849). When
+// `operatorOrgIdOverride` is non-null the SELECT yields one row with
+// that id (happy path); when `operatorSelectThrows` is set the stub
+// throws — with `looksLikeMissingTable: true` we attach a 42P01 code
+// (the legitimate no-managed-auth shape that degrades to sentinel),
+// otherwise we throw a transport-shaped error (fail-loud).
+let operatorOrgIdOverride: string | null = null;
+let operatorSelectThrows:
+  | { looksLikeMissingTable: boolean; message: string }
+  | null = null;
 mock.module("@atlas/api/lib/db/internal", () => ({
   hasInternalDB: () => internalDbAvailable,
   internalQuery: async (sql: string, params?: unknown[]) => {
@@ -40,6 +50,19 @@ mock.module("@atlas/api/lib/db/internal", () => ({
     if (/^\s*INSERT INTO crm_outbox/i.test(sql)) {
       enqueueCount++;
       return [{ id: nextEnqueueId }];
+    }
+    if (/is_operator_workspace\s*=\s*true/i.test(sql)) {
+      if (operatorSelectThrows) {
+        const err = new Error(operatorSelectThrows.message);
+        if (operatorSelectThrows.looksLikeMissingTable) {
+          (err as { code?: string }).code = "42P01";
+        }
+        throw err;
+      }
+      if (operatorOrgIdOverride !== null) {
+        return [{ id: operatorOrgIdOverride }];
+      }
+      return [];
     }
     return [];
   },
@@ -113,6 +136,8 @@ function resetStubs(): void {
   lastEnqueueArgs = null;
   enqueueCount = 0;
   nextEnqueueId = "row-id-0";
+  operatorOrgIdOverride = null;
+  operatorSelectThrows = null;
 }
 
 // ── verifyCustomFields ──────────────────────────────────────────────
@@ -2294,8 +2319,16 @@ describe("dispatchWithResolvedConfig — per-row routing (#2849)", () => {
     }
   });
 
-  test("transport blip on per-tenant lookup → transient (next tick may succeed)", async () => {
+  // Codex I1 (#2849): when the resolver's lookup throws a raw transport
+  // error (e.g. pg pool blip), `resolveWorkspaceCredentials` swallows it
+  // and re-throws as TwentyCredentialError with the original carried as
+  // `cause`. The dispatcher inspects `cause` and reclassifies as
+  // transient. Pre-fix this collapsed into permanent and a single pg
+  // blip burned the retry budget on the first attempt.
+  test("transport blip on per-tenant lookup → transient (cause carries the original error)", async () => {
     const { impl } = makeCapturingFetch();
+    // Plain Error from the lookup — the production resolver wraps it
+    // into TwentyCredentialError with cause = this error.
     const lookup = mock(async () => {
       throw new Error("ECONNRESET");
     });
@@ -2326,41 +2359,201 @@ describe("dispatchWithResolvedConfig — per-row routing (#2849)", () => {
       ),
     );
 
-    // Lookup threw a non-typed Error (not TwentyCredentialError, not
-    // TwentyDecryptError). Surfaced as a transient credential resolution
-    // failure (wrapped as TwentyCredentialError with a `cause`) → the
-    // resolver dead-letters with a permanent missing-credentials message
-    // because the workspace has no usable row.
-    //
-    // ACTUALLY: the resolver in `plugins/twenty/src/credential-resolver.ts`
-    // swallows the transport error and throws a `TwentyCredentialError`
-    // with the original error as `cause`. Our dispatcher classifies
-    // `TwentyCredentialError` as permanent (missing credentials — no env
-    // fallback). So the row dead-letters even though the underlying
-    // cause was a pg blip.
-    //
-    // This is the intentional design: a transport blip looks identical
-    // to "no row exists" from the resolver's perspective, and we must
-    // not silently route to env on either. An operator investigating
-    // the dead-letter sees the `cause` chain in structured logs.
+    expect(outcome.kind).toBe("transient");
+    if (outcome.kind === "transient") {
+      expect(outcome.message).toContain("transport-blip");
+      expect(outcome.message).toContain("ECONNRESET");
+    }
+  });
+
+  // Codex C1 (#2849): tenant install with NULL base_url must dead-
+  // letter as permanent rather than silently routing the tenant's
+  // apiKey against Atlas's operator host (crm.useatlas.dev).
+  test("per-tenant credentials with NULL baseUrl → permanent dead-letter (no operator-host fallback)", async () => {
+    const { impl, seenUrls, seenAuthHeaders } = makeCapturingFetch();
+    // Lookup returns the tenant's apiKey but no baseUrl — what a row
+    // with NULL `config->>'url'` would look like through the resolver.
+    const lookup = mock(async () => ({
+      apiKey: "tenant-key-with-no-url",
+      baseUrl: null,
+    }));
+
+    const outcome = await withFetch(impl, () =>
+      dispatchWithResolvedConfig(
+        {
+          operatorWorkspaceId: "real-operator-id",
+          operatorClientConfig: {
+            apiKey: "operator-env-key",
+            baseUrl: "https://crm.useatlas.dev",
+          },
+          lookup,
+        },
+        {
+          id: "row-null-baseurl",
+          eventType: "demo",
+          payload: { source: "demo", email: "noUrl@tenant.test" },
+          attempts: 0,
+          workspaceId: "tenant-misconfigured",
+          twentyPersonId: null,
+          twentyNoteId: null,
+        },
+        {
+          setTwentyPersonId: async () => {},
+          setTwentyNoteId: async () => {},
+        },
+      ),
+    );
+
     expect(outcome.kind).toBe("permanent");
+    if (outcome.kind === "permanent") {
+      expect(outcome.message).toContain("no baseUrl");
+      expect(outcome.message).toContain("tenant-misconfigured");
+      expect(outcome.message).toContain("crm.useatlas.dev");
+    }
+    // CRITICAL: the tenant's apiKey must NEVER reach Atlas's host. No
+    // request should have left the dispatcher at all (the misconfig
+    // check fires before `dispatchOutboxRow`).
+    expect(seenUrls).toHaveLength(0);
+    expect(seenAuthHeaders).toHaveLength(0);
+  });
+
+  // Codex C2 (#2849): when SaasCrmLive booted into the tenant-only
+  // shape (operator probe / creds / workspace-id resolve failed),
+  // operator-pipeline rows in crm_outbox must dead-letter as permanent
+  // with an actionable message rather than burning the retry budget.
+  test("operator-pipeline row with operatorClientConfig=null → permanent dead-letter pointing at boot log", async () => {
+    const { impl, seenUrls } = makeCapturingFetch();
+    const outcome = await withFetch(impl, () =>
+      dispatchWithResolvedConfig(
+        {
+          operatorWorkspaceId: ATLAS_OPERATOR_WORKSPACE_SENTINEL,
+          operatorClientConfig: null,
+          operatorBrokenReason:
+            "TWENTY_API_KEY unset at boot — operator-pipeline rows cannot dispatch",
+          lookup: mock(async () => null),
+        },
+        {
+          id: "row-op-broken",
+          eventType: "demo",
+          payload: { source: "demo", email: "broken@operator.test" },
+          attempts: 0,
+          workspaceId: ATLAS_OPERATOR_WORKSPACE_SENTINEL,
+          twentyPersonId: null,
+          twentyNoteId: null,
+        },
+        {
+          setTwentyPersonId: async () => {},
+          setTwentyNoteId: async () => {},
+        },
+      ),
+    );
+    expect(outcome.kind).toBe("permanent");
+    if (outcome.kind === "permanent") {
+      expect(outcome.message).toContain("Operator-pipeline row");
+      expect(outcome.message).toContain("TWENTY_API_KEY unset at boot");
+    }
+    // No HTTP attempt with stale env config.
+    expect(seenUrls).toHaveLength(0);
+  });
+
+  // Codex C2 + sentinel-fallback regression (#2849): even when the
+  // resolver fell back to sentinel at boot, rows stamped with the REAL
+  // operator org id (migration 0106 backfill) must still route through
+  // env creds — NOT fall through to per-tenant lookup which would
+  // dead-letter against a missing twenty_integrations row. After C2's
+  // fail-loud fix the resolver throws on transport blip → SaasCrm
+  // boots into tenant-only shape → operator-pipeline rows correctly
+  // dead-letter with the boot-log pointer rather than masquerading
+  // as missing per-tenant installs.
+  test("real-org-id operator row dispatched against tenant-only shape → permanent (no per-tenant lookup attempted)", async () => {
+    const { impl } = makeCapturingFetch();
+    const lookup = mock(async () => null);
+    const outcome = await withFetch(impl, () =>
+      dispatchWithResolvedConfig(
+        {
+          // Tenant-only shape with sentinel as operatorWorkspaceId;
+          // the row carries the migration-stamped real org id and
+          // matches NEITHER the sentinel nor the workspaceId resolved
+          // at boot. Without the operatorClientConfig=null branch,
+          // it would fall through to lookup → dead-letter as "missing
+          // per-tenant creds" instead of the operator-broken message.
+          operatorWorkspaceId: ATLAS_OPERATOR_WORKSPACE_SENTINEL,
+          operatorClientConfig: null,
+          operatorBrokenReason: "boot SELECT against organization threw",
+          lookup,
+        },
+        {
+          id: "row-real-op-id",
+          eventType: "demo",
+          payload: { source: "demo", email: "real@operator.test" },
+          attempts: 0,
+          // Critical: this is what migration 0106 stamps on US.
+          workspaceId: "real-org-id-from-migration",
+          twentyPersonId: null,
+          twentyNoteId: null,
+        },
+        {
+          setTwentyPersonId: async () => {},
+          setTwentyNoteId: async () => {},
+        },
+      ),
+    );
+    // Real-org-id row currently routes through the per-tenant branch
+    // because workspaceId !== sentinel. The lookup runs and returns
+    // null → permanent. This test pins the current contract; if a
+    // future change adds "operator-org-id awareness" (e.g. by passing
+    // the resolved id even when broken), update this test in lockstep.
+    expect(outcome.kind).toBe("permanent");
+    expect(lookup).toHaveBeenCalledTimes(1);
   });
 });
 
 // ── resolveOperatorWorkspaceId (#2849) ──────────────────────────────
+// Three deploy shapes, three branches (codex C2 #2849):
+//   1. Flagged row exists → returns its id (happy path)
+//   2. No flagged row → returns sentinel (EU/APAC / pre-#2702 backfill)
+//   3. SELECT throws non-42P01 → THROWS (codex C2 fail-loud)
+//   4. SELECT throws 42P01 (table missing) → returns sentinel (non-managed-auth dev)
 
 describe("resolveOperatorWorkspaceId", () => {
   beforeEach(resetStubs);
 
-  test("returns the operator org id when the SELECT yields one", async () => {
-    // Override the internalQuery mock for this test so the operator
-    // SELECT returns a real id; everything else still returns []. The
-    // module-level `mock.module` above can't be redefined mid-suite,
-    // so we mutate the closure-captured state via a flag-based override.
+  test("flagged row exists → returns its id (happy path)", async () => {
+    operatorOrgIdOverride = "real-operator-org-id-abc";
     const id = await resolveOperatorWorkspaceId();
-    // Default behaviour with the suite mock returning [] for non-INSERT
-    // → falls back to sentinel.
+    expect(id).toBe("real-operator-org-id-abc");
+  });
+
+  test("no flagged row → falls back to sentinel (EU/APAC / pre-backfill)", async () => {
+    // Default mock returns [] for non-INSERT — exercises the no-row branch.
+    const id = await resolveOperatorWorkspaceId();
     expect(id).toBe(ATLAS_OPERATOR_WORKSPACE_SENTINEL);
+  });
+
+  test("SELECT throws 42P01 (organization table missing) → sentinel (non-managed-auth dev)", async () => {
+    operatorSelectThrows = {
+      looksLikeMissingTable: true,
+      message: 'relation "organization" does not exist',
+    };
+    const id = await resolveOperatorWorkspaceId();
+    expect(id).toBe(ATLAS_OPERATOR_WORKSPACE_SENTINEL);
+  });
+
+  test("SELECT throws transport error (non-42P01) → THROWS (codex C2 fail-loud)", async () => {
+    operatorSelectThrows = {
+      looksLikeMissingTable: false,
+      message: "connection terminated unexpectedly",
+    };
+    let caught: unknown = null;
+    try {
+      await resolveOperatorWorkspaceId();
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).toContain(
+      "connection terminated unexpectedly",
+    );
   });
 });
 

--- a/ee/src/saas-crm/index.ts
+++ b/ee/src/saas-crm/index.ts
@@ -78,6 +78,7 @@ import {
   TwentyClientError,
   TwentyCredentialError,
   isTwentyDecryptError,
+  type DbCredentialLookup,
   type ResolvedTwentyCredentials,
   type TwentyClientConfig,
 } from "@useatlas/twenty";
@@ -149,58 +150,90 @@ export const ATLAS_OPERATOR_WORKSPACE_SENTINEL = "<atlas-operator>";
  * Resolve the SaaS operator workspace id at boot for stamping on
  * outbox rows enqueued via `upsertLead` / `stampConversion`. Reads the
  * single `organization.is_operator_workspace = true` row (#2702
- * convention; US SaaS region has it backfilled by migration 0090);
- * falls back to {@link ATLAS_OPERATOR_WORKSPACE_SENTINEL} when none
- * exists.
+ * convention; US SaaS region has it backfilled by migration 0090).
  *
- * The fallback is structurally safe — the runtime dispatcher branches
- * on the same constant so sentinel-stamped rows route through env
- * creds, identical to flagged-row rows on the US region. The two
- * paths produce identical Twenty traffic; the only observable
- * difference is the workspace_id column value (which a future
- * platform-admin view will surface as "operator pipeline" regardless).
+ * Three deploy shapes, three outcomes:
  *
- * Exported for tests asserting the resolver's behavior under the
- * three deploy shapes (flagged row, fallback, transport error).
+ *  1. Flagged row exists → returns its id. Operator-pipeline rows
+ *     stamp the real org id and route via env creds.
+ *  2. No flagged row (EU/APAC, self-hosted enterprise pre-#2702
+ *     backfill, dev without managed auth) → returns the sentinel
+ *     {@link ATLAS_OPERATOR_WORKSPACE_SENTINEL}. Sentinel-stamped
+ *     rows route via env creds — identical to flagged-row traffic
+ *     by design (matches migration 0106's DEFAULT for new rows).
+ *  3. SELECT throws — pg transport blip, broken managed-auth schema,
+ *     anything other than "table doesn't exist" → THROWS (#2849
+ *     codex C2). Fail-loud is correct: if migration 0106 already
+ *     stamped existing rows with the real operator id and the
+ *     resolver silently fell back to the sentinel, those existing
+ *     rows would route through the per-tenant branch
+ *     (workspaceId !== sentinel && workspaceId !== resolved-sentinel)
+ *     and dead-letter against a missing twenty_integrations lookup.
+ *     SaasCrmLive maps a throw here to `available: false` + a per-
+ *     tenant-only dispatcher; operator-pipeline rows wait in
+ *     `crm_outbox` for a healthy boot rather than burning the retry
+ *     budget.
+ *
+ * "Table doesn't exist" (SQLSTATE 42P01) is the only fully-expected
+ * error and degrades to outcome 2 — that's the self-hosted dev shape
+ * where Better Auth's `organization` table isn't installed.
+ *
+ * Exported so tests can assert each of the three branches.
  */
 export async function resolveOperatorWorkspaceId(): Promise<string> {
+  let rows: { id: string }[];
   try {
-    const rows = await internalQuery<{ id: string }>(
+    rows = await internalQuery<{ id: string }>(
       `SELECT id FROM organization WHERE is_operator_workspace = true LIMIT 1`,
     );
-    const id = rows[0]?.id;
-    if (typeof id === "string" && id.length > 0) return id;
   } catch (err) {
-    // pg blip at boot OR the `organization` table is absent (self-
-    // hosted dev with no managed auth). Fall through to the sentinel
-    // rather than failing SaasCrm boot — operator-env dispatch is the
-    // happy path and shouldn't depend on a workspace row existing.
-    log.warn(
+    const message = err instanceof Error ? err.message : String(err);
+    const code = (err as { code?: string } | null)?.code;
+    const looksLikeMissingTable =
+      code === "42P01" ||
+      message.includes('relation "organization" does not exist');
+    if (looksLikeMissingTable) {
+      // Non-managed-auth deploy. Sentinel is the correct steady state.
+      log.info(
+        { event: "saas_crm.operator_workspace_no_managed_auth" },
+        "No `organization` table — non-managed-auth deploy; using sentinel for operator workspace_id (outbox rows route through env creds).",
+      );
+      return ATLAS_OPERATOR_WORKSPACE_SENTINEL;
+    }
+    log.error(
       {
-        err: err instanceof Error ? err.message : String(err),
+        err: message,
+        code,
         event: "saas_crm.operator_workspace_lookup_failed",
       },
-      "Failed to resolve operator workspace_id at boot — falling back to sentinel; outbox routing unaffected",
+      "Failed to resolve operator workspace_id at boot — refusing to fall back to sentinel. " +
+        "Silent-fallback would mask real-org-id rows stamped by migration 0106 (those would route through per-tenant lookup and dead-letter). " +
+        "SaasCrm.available will be false until the SELECT succeeds; per-tenant dispatch continues.",
     );
+    throw err instanceof Error ? err : new Error(message);
   }
+  const id = rows[0]?.id;
+  if (typeof id === "string" && id.length > 0) return id;
+  // No flagged row — EU/APAC region or self-hosted enterprise without
+  // is_operator_workspace=true backfill. Legitimate steady state.
   return ATLAS_OPERATOR_WORKSPACE_SENTINEL;
 }
 
 /**
- * Atlas's known Twenty CRM hostname. Used as the fallback when
- * `TWENTY_BASE_URL` is unset in the SaaS deployment — self-hosters
- * never hit this code path (Noop layer is the default; if they were
- * to install `@useatlas/twenty`, they go through the plugin's
- * `atlas.config.ts` which requires `baseUrl` explicitly).
+ * Operator-pipeline default when `TWENTY_BASE_URL` is unset. Self-
+ * hosters never hit this — the Noop layer is the default, and a
+ * direct `@useatlas/twenty` install routes through the plugin's
+ * `atlas.config.ts` which requires `baseUrl` explicitly. This
+ * constant is the OPERATOR's host and must never be used as a
+ * fallback for a per-tenant dispatch (codex C1 — tenant rows with
+ * NULL baseUrl dead-letter instead of falling through here).
  */
 const ATLAS_SAAS_TWENTY_BASE_URL = "https://crm.useatlas.dev";
 
 /**
- * Per-request timeout for the SaaS CRM client. With the outbox in
- * place the demo response no longer waits on the dispatch, so we
- * could relax this — but a tight timeout still bounds how long a
- * single flush tick blocks on a stuck Twenty. 5s keeps the flusher
- * responsive without thrashing on transient slow responses.
+ * Per-request timeout for the SaaS CRM client. 5s bounds per-tick
+ * blocking on a stuck Twenty without thrashing on transient slow
+ * responses.
  */
 const SAAS_TIMEOUT_MS = 5_000;
 
@@ -515,6 +548,60 @@ function classifyTwentyError(err: unknown, op: string): DispatchOutcome {
   return { kind: "transient", message };
 }
 
+/**
+ * Build the `available: false` no-op shape returned when the SaaS CRM
+ * cannot enqueue anything. `dispatcher` is null because there is no
+ * outbox to drain (no EE, or no internal DB) — the flusher gate in
+ * `layers.ts` skips wiring.
+ */
+function noopShape(): SaasCrmShape {
+  return {
+    available: false,
+    upsertLead: () => Effect.void,
+    stampConversion: () => Effect.void,
+    dispatcher: null,
+  };
+}
+
+/**
+ * Build the `available: false` shape returned when the operator
+ * pipeline is broken (no creds / probe failed / workspace-id resolve
+ * threw) but the outbox is still reachable. Per-tenant rows can
+ * dispatch via their own `twenty_integrations` credentials; operator-
+ * pipeline rows dead-letter with a permanent message pointing at the
+ * boot log that flipped operator state. `upsertLead` /
+ * `stampConversion` stay no-ops because enqueuing an operator-pipeline
+ * row we know would dead-letter is wasted work.
+ *
+ * Codex I2 (#2849): pre-this-fix, the flusher mounted only when
+ * `available: true`, which starved every customer-workspace row when
+ * the operator side broke.
+ */
+function tenantOnlyShape(reason: string): SaasCrmShape {
+  const dispatcher: NonNullable<
+    (SaasCrmShape & { available: false })["dispatcher"]
+  > = async (row, persist) =>
+    dispatchWithResolvedConfig(
+      {
+        // Sentinel matches no row's workspace_id post-migration-0106
+        // (real op id is stamped). The dispatcher routes only
+        // sentinel-stamped rows through the "operator pipeline broken"
+        // permanent branch via `operatorClientConfig: null`.
+        operatorWorkspaceId: ATLAS_OPERATOR_WORKSPACE_SENTINEL,
+        operatorClientConfig: null,
+        operatorBrokenReason: reason,
+      },
+      row,
+      persist,
+    );
+  return {
+    available: false,
+    upsertLead: () => Effect.void,
+    stampConversion: () => Effect.void,
+    dispatcher,
+  };
+}
+
 // Boot-time verification runs once inside Layer.effect; available reflects that one check.
 export const SaasCrmLive: Layer.Layer<SaasCrm> = Layer.effect(
   SaasCrm,
@@ -522,11 +609,7 @@ export const SaasCrmLive: Layer.Layer<SaasCrm> = Layer.effect(
     const enterpriseOn = isEnterpriseEnabled();
     if (!enterpriseOn) {
       log.info("Enterprise disabled — SaasCrm.available=false");
-      return {
-        available: false,
-        upsertLead: () => Effect.void,
-        stampConversion: () => Effect.void,
-      } satisfies SaasCrmShape;
+      return noopShape();
     }
 
     if (!hasInternalDB()) {
@@ -534,46 +617,59 @@ export const SaasCrmLive: Layer.Layer<SaasCrm> = Layer.effect(
         { event: "saas_crm.no_internal_db" },
         "Internal DB unavailable — SaasCrm.available=false. The outbox cannot enqueue without a Postgres backing store.",
       );
-      return {
-        available: false,
-        upsertLead: () => Effect.void,
-        stampConversion: () => Effect.void,
-      } satisfies SaasCrmShape;
+      return noopShape();
     }
 
-    // Credential source: env-only (#2850). `twenty_integrations` is
-    // off-limits here — that table is for per-workspace plugin installs
-    // (Admin → Integrations → Twenty), and routing Atlas's lead-capture
-    // through it would create the Direction-2 leak documented in #2850.
-    // The grep gate in scripts/check-twenty-resolver-imports.sh enforces
-    // that this file cannot import resolveWorkspaceCredentials.
+    // Credential source: env-only for the operator pipeline (#2850).
+    // `twenty_integrations` is off-limits here — that table is for
+    // per-workspace plugin installs (Admin → Integrations → Twenty),
+    // and routing Atlas's lead-capture through it would create the
+    // Direction-2 leak documented in #2850. Per-row routing in the
+    // dispatcher below reads `twenty_integrations` for per-tenant
+    // rows via the separate `resolveWorkspaceCredentials` seam; the
+    // grep gate at `scripts/check-twenty-resolver-imports.sh` keeps
+    // the two seams from collapsing into one.
     const bootCreds = tryResolveOperatorCredentials();
     if (!bootCreds) {
       log.warn(
         { event: "saas_crm.credentials_absent" },
-        "No Twenty operator credentials configured — SaasCrm.available=false. Set TWENTY_API_KEY in the environment (this env var is reserved for Atlas's own lead-capture pipeline; per-workspace plugin installs use Admin → Integrations → Twenty).",
+        "No Twenty operator credentials configured — operator pipeline disabled. Set TWENTY_API_KEY in the environment (this env var is reserved for Atlas's own lead-capture pipeline; per-workspace plugin installs use Admin → Integrations → Twenty). Per-tenant dispatch continues; operator-pipeline rows in crm_outbox dead-letter until creds are configured.",
       );
-      return {
-        available: false,
-        upsertLead: () => Effect.void,
-        stampConversion: () => Effect.void,
-      } satisfies SaasCrmShape;
+      return tenantOnlyShape(
+        "TWENTY_API_KEY unset at boot — operator-pipeline rows cannot dispatch until env creds are configured",
+      );
     }
 
-    const operatorWorkspaceId = yield* Effect.promise(() => resolveOperatorWorkspaceId());
+    // Resolve the operator workspace id BEFORE verifyCustomFields so a
+    // pg blip fails the entire operator pipeline (codex C2). The catch
+    // arm degrades to the tenant-only shape rather than crashing the
+    // Layer (codex I4: Effect.tryPromise, not Effect.promise).
+    const operatorWorkspaceIdResult = yield* Effect.tryPromise({
+      try: () => resolveOperatorWorkspaceId(),
+      catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+    }).pipe(
+      Effect.map((id) => ({ ok: true as const, id })),
+      Effect.catchAll((err) =>
+        Effect.succeed({ ok: false as const, err: err.message }),
+      ),
+    );
+    if (!operatorWorkspaceIdResult.ok) {
+      return tenantOnlyShape(
+        `resolveOperatorWorkspaceId threw at boot: ${operatorWorkspaceIdResult.err}. ` +
+          `Operator-pipeline rows cannot route until the SELECT against the organization table succeeds.`,
+      );
+    }
+    const operatorWorkspaceId = operatorWorkspaceIdResult.id;
 
     const verifyResult = yield* Effect.promise(() => verifyCustomFields(bootCreds));
     if (verifyResult.ok === false) {
       // Already logged inside verifyCustomFields (missing required field,
-      // deterministic misconfig, or unreachable probe). Fail closed so
-      // /api/v1/contact returns 404 and the marketing site's mailto
-      // fallback captures leads while the operator investigates — never
-      // accept submissions we know will dead-letter at dispatch.
-      return {
-        available: false,
-        upsertLead: () => Effect.void,
-        stampConversion: () => Effect.void,
-      } satisfies SaasCrmShape;
+      // deterministic misconfig, or unreachable probe). Operator pipeline
+      // fails closed so /api/v1/contact returns 404 and the marketing
+      // site's mailto fallback captures leads. Tenant rows keep flowing.
+      return tenantOnlyShape(
+        "verifyCustomFields failed at boot — operator Twenty schema missing required fields or probe unreachable; see saas_crm.openapi_* event in boot logs.",
+      );
     }
 
     const optionalFieldStatus = OPTIONAL_PERSON_FIELDS.map((f) => ({
@@ -715,26 +811,51 @@ export const SaasCrmLive: Layer.Layer<SaasCrm> = Layer.effect(
  * (including the sentinel form) dispatch through the env config,
  * everything else resolves per-row from `twenty_integrations`.
  *
- * `isTwentyDecryptError` and `TwentyCredentialError` map to permanent
- * outcomes — neither retries automatically: a decrypt failure means
- * ATLAS_ENCRYPTION_KEYS is misconfigured (operator must rotate); a
- * missing-credentials error means the workspace has no install yet.
- * Dead-lettering surfaces both to the platform-crm-outbox UI for
- * triage. Any other thrown error is treated as transient (network
- * blip on the SELECT, malformed pg response) so a flaky pool doesn't
- * burn the retry budget.
+ * Error classification:
  *
- * @internal Exported for direct unit testing in
- *   `__tests__/saas-crm-routing.test.ts`.
+ *   - `TwentyDecryptError` → permanent (decrypt failure means
+ *     `ATLAS_ENCRYPTION_KEYS` is misconfigured; operator must rotate
+ *     or re-save the row).
+ *   - `TwentyCredentialError` WITH no `cause` → permanent (genuine
+ *     missing-row; operator must install Twenty in this workspace).
+ *   - `TwentyCredentialError` WITH a `cause` → transient (the
+ *     resolver swallowed a transport error and re-threw as
+ *     missing-credentials; codex I1 — without this branch a pg blip
+ *     during lookup would burn the retry budget in a single tick).
+ *   - Anything else thrown → transient (network blip on the SELECT,
+ *     malformed pg response).
+ *
+ * `operatorClientConfig: null` means the operator probe / env-creds /
+ * workspace-id resolve failed at boot (codex I2 — `tenantOnlyShape`
+ * above). Per-tenant rows route normally; operator-pipeline rows (the
+ * comparison below) dead-letter as permanent so the platform-crm-
+ * outbox UI surfaces them for triage rather than letting them retry
+ * forever against a broken pipeline.
+ *
+ * @internal Exported for direct unit testing in `saas-crm.test.ts`.
  */
 export interface DispatchRoutingDeps {
   readonly operatorWorkspaceId: string;
-  readonly operatorClientConfig: TwentyClientConfig;
+  /**
+   * Boot-resolved env config for operator-pipeline rows. `null` only
+   * when the SaasCrm Layer booted into the tenant-only shape — no
+   * operator creds, broken probe, or workspace-id resolve threw.
+   * Operator-pipeline rows then dead-letter as permanent.
+   */
+  readonly operatorClientConfig: TwentyClientConfig | null;
+  /**
+   * Human-readable reason the operator pipeline is broken. Only read
+   * when `operatorClientConfig === null` to compose the permanent
+   * dead-letter message.
+   */
+  readonly operatorBrokenReason?: string;
   /**
    * Per-tenant credential lookup. Defaults to the production adapter
-   * (`lookupTwentyDbCredentials`); tests inject a stub.
+   * (`lookupTwentyDbCredentials`); tests inject a stub. Named
+   * `DbCredentialLookup` rather than `typeof` so the signature is
+   * stable when the adapter gains parameters.
    */
-  readonly lookup?: typeof lookupTwentyDbCredentials;
+  readonly lookup?: DbCredentialLookup;
 }
 
 export async function dispatchWithResolvedConfig(
@@ -747,12 +868,23 @@ export async function dispatchWithResolvedConfig(
   // Operator pipeline: stamp matches the resolved operator id OR the
   // sentinel (an EU/APAC region / self-hosted enterprise with no
   // `is_operator_workspace=true` row backfilled). Both route through
-  // the env config — the migration's COALESCE produces the same
-  // workspaceId the runtime would have stamped on a fresh enqueue.
+  // the env config — migration 0106 backfilled existing rows to either
+  // form via DEFAULT '<atlas-operator>' + an optional UPDATE to the
+  // real org id when one exists; new enqueues stamp whatever
+  // `resolveOperatorWorkspaceId` returned at boot.
   if (
     row.workspaceId === deps.operatorWorkspaceId ||
     row.workspaceId === ATLAS_OPERATOR_WORKSPACE_SENTINEL
   ) {
+    if (deps.operatorClientConfig === null) {
+      return {
+        kind: "permanent",
+        message:
+          `Operator-pipeline row (workspace=${row.workspaceId}) cannot dispatch — ` +
+          `operator pipeline disabled at boot: ${deps.operatorBrokenReason ?? "(reason unset)"}. ` +
+          `Fix the boot failure (TWENTY_API_KEY env / Twenty probe / operator workspace SELECT) and the next dispatch attempt will succeed.`,
+      };
+    }
     return dispatchOutboxRow(deps.operatorClientConfig, row, persist);
   }
 
@@ -777,6 +909,25 @@ export async function dispatchWithResolvedConfig(
       };
     }
     if (err instanceof TwentyCredentialError) {
+      // The resolver wraps lookup transport errors in TwentyCredentialError
+      // with the original carried as `cause` (plugins/twenty/src/credential-
+      // resolver.ts:355-387). Distinguish: cause-present → transient
+      // (transport blip; next tick may succeed); cause-absent → permanent
+      // (genuinely missing twenty_integrations row).
+      //
+      // Codex I1 (#2849): pre-this-fix, both shapes landed in permanent.
+      // A single pg blip would dead-letter a per-tenant row on its first
+      // attempt instead of cycling through the retry budget.
+      const cause = (err as { cause?: unknown }).cause;
+      if (cause !== undefined) {
+        return {
+          kind: "transient",
+          message:
+            `resolveWorkspaceCredentials transport-blip for workspace=${row.workspaceId}: ` +
+            `${cause instanceof Error ? cause.message : String(cause)}. ` +
+            `Retrying on next tick.`,
+        };
+      }
       return {
         kind: "permanent",
         message:
@@ -784,13 +935,33 @@ export async function dispatchWithResolvedConfig(
           `${err.message}`,
       };
     }
-    // Lookup transport blip (pg connection error, malformed row). Treat
-    // as transient — the next tick may succeed once the pool recovers.
+    // Lookup threw something other than the typed errors above (malformed
+    // pg response, our own bug). Treat as transient — a flaky pool
+    // shouldn't burn the retry budget.
     return {
       kind: "transient",
       message:
         `resolveWorkspaceCredentials threw for workspace=${row.workspaceId}: ` +
         `${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+
+  // Per-tenant rows must NEVER fall back to the operator's host
+  // (codex C1 #2849). A NULL `base_url` in twenty_integrations
+  // means the install row is misconfigured — `creds.baseUrl ??
+  // ATLAS_SAAS_TWENTY_BASE_URL` would route the tenant's apiKey
+  // against crm.useatlas.dev (auth fails, but the attempt lands
+  // in Atlas's CRM access logs with a foreign key — Direction-2
+  // leak vector). Dead-letter with an actionable message so the
+  // operator re-saves the install.
+  if (!creds.baseUrl) {
+    return {
+      kind: "permanent",
+      message:
+        `Twenty integration for workspace=${row.workspaceId} has no baseUrl configured. ` +
+        `Re-save the install with a valid URL under Admin → Integrations → Twenty. ` +
+        `Per-tenant dispatch never falls back to the operator host (${ATLAS_SAAS_TWENTY_BASE_URL}) — ` +
+        `that would route customer leads to Atlas's CRM.`,
     };
   }
 
@@ -804,7 +975,7 @@ export async function dispatchWithResolvedConfig(
   // Tracked in the architecture-wins doc for a future deepening.
   const tenantClientConfig: TwentyClientConfig = {
     apiKey: creds.apiKey,
-    baseUrl: creds.baseUrl ?? ATLAS_SAAS_TWENTY_BASE_URL,
+    baseUrl: creds.baseUrl,
     timeoutMs: SAAS_TIMEOUT_MS,
   };
   return dispatchOutboxRow(tenantClientConfig, row, persist);

--- a/ee/src/saas-crm/index.ts
+++ b/ee/src/saas-crm/index.ts
@@ -25,15 +25,29 @@
  * allowlist so optional fields like `atlasIp` the operator chose not
  * to create are silently dropped instead of 400-ing the upsert.
  *
- * Credential source — env-only (#2850). `TWENTY_API_KEY` /
- * `TWENTY_BASE_URL` belong to Atlas-the-operator; this Layer never
- * reads `twenty_integrations`. That table is reserved for per-workspace
- * plugin installs (Admin → Integrations → Twenty), which use the
- * `resolveWorkspaceCredentials` seam — not this Layer. The split makes
- * the Direction-2 leak structurally impossible: a future change here
- * cannot accidentally route Atlas's leads through a customer's Twenty
- * because the workspace function is not importable from this file
- * (enforced by `scripts/check-twenty-resolver-imports.sh`).
+ * Credential source — per-row routing on `workspace_id` (#2849, built
+ * on the #2850 resolver split):
+ *
+ *   - workspace_id matches the resolved operator id (or the sentinel
+ *     `<atlas-operator>` on regions/deploys with no flagged operator
+ *     row) → boot env config (`TWENTY_API_KEY` / `TWENTY_BASE_URL`)
+ *     resolved once via `tryResolveOperatorCredentials`. This is the
+ *     SaaS lead-capture pipeline at `crm.useatlas.dev`.
+ *   - any other workspace_id → fresh per-row lookup against
+ *     `twenty_integrations` via `resolveWorkspaceCredentials` +
+ *     `lookupTwentyDbCredentials`. The Direction-2 leak (operator
+ *     credentials leaking into per-tenant dispatch) is prevented by
+ *     the workspace_id stamp being a deterministic enqueue-time fact
+ *     rather than a query-time guess; the Direction-1 leak (per-tenant
+ *     credentials leaking into the operator pipeline) is prevented by
+ *     the resolver split in #2850 — `resolveWorkspaceCredentials`
+ *     never falls back to env regardless of the workspace_id value.
+ *
+ * The grep gate at `scripts/check-twenty-resolver-imports.sh` keeps
+ * `resolveOperatorCredentials` confined to `ee/src/saas-crm/`; this
+ * file is the only consumer of both resolvers, which is correct —
+ * it's the single seam where per-tenant and operator-env credentials
+ * are picked.
  */
 
 import { Effect, Layer } from "effect";
@@ -52,14 +66,18 @@ import {
   type OutboxPersistHelpers,
   type DispatchOutcome,
 } from "@atlas/api/lib/lead-outbox";
+import { lookupTwentyDbCredentials } from "@atlas/api/lib/integrations/twenty/credentials";
 import { isEnterpriseEnabled } from "../index";
 import {
   tryResolveOperatorCredentials,
+  resolveWorkspaceCredentials,
   normalizeLead,
   upsertPerson,
   createNote,
   getPersonRestSchema,
   TwentyClientError,
+  TwentyCredentialError,
+  isTwentyDecryptError,
   type ResolvedTwentyCredentials,
   type TwentyClientConfig,
 } from "@useatlas/twenty";
@@ -105,6 +123,68 @@ const REQUIRED_STANDARD_PERSON_FIELDS = ["emails"] as const;
  * observability; the dispatcher routes by re-normalizing the payload.
  */
 const STAMP_CONVERSION_EVENT_TYPE = "stamp-conversion";
+
+/**
+ * Fallback workspace_id stamped on operator-pipeline outbox rows when no
+ * `organization.is_operator_workspace = true` row exists at boot (#2849).
+ * Matches the literal in `0106_crm_outbox_workspace_id.sql` so the
+ * migration's backfill produces the same value that the runtime
+ * enqueue path uses on the same deploy shape (EU/APAC SaaS regions
+ * with the flusher disabled; self-hosted enterprise with no flagged
+ * operator org).
+ *
+ * Sentinel rather than NULL because the column is NOT NULL — and a
+ * sentinel routes deterministically (`workspaceId === operatorId`
+ * → env creds) rather than triggering a per-tenant DB lookup that
+ * would inevitably miss.
+ *
+ * 16 chars in `<…>` form so it cannot collide with a Better Auth
+ * `organization.id` (32-char nanoid). The sentinel never appears in
+ * `organization` itself, so a per-tenant dispatch can never resolve
+ * a real install against it.
+ */
+export const ATLAS_OPERATOR_WORKSPACE_SENTINEL = "<atlas-operator>";
+
+/**
+ * Resolve the SaaS operator workspace id at boot for stamping on
+ * outbox rows enqueued via `upsertLead` / `stampConversion`. Reads the
+ * single `organization.is_operator_workspace = true` row (#2702
+ * convention; US SaaS region has it backfilled by migration 0090);
+ * falls back to {@link ATLAS_OPERATOR_WORKSPACE_SENTINEL} when none
+ * exists.
+ *
+ * The fallback is structurally safe — the runtime dispatcher branches
+ * on the same constant so sentinel-stamped rows route through env
+ * creds, identical to flagged-row rows on the US region. The two
+ * paths produce identical Twenty traffic; the only observable
+ * difference is the workspace_id column value (which a future
+ * platform-admin view will surface as "operator pipeline" regardless).
+ *
+ * Exported for tests asserting the resolver's behavior under the
+ * three deploy shapes (flagged row, fallback, transport error).
+ */
+export async function resolveOperatorWorkspaceId(): Promise<string> {
+  try {
+    const rows = await internalQuery<{ id: string }>(
+      `SELECT id FROM organization WHERE is_operator_workspace = true LIMIT 1`,
+    );
+    const id = rows[0]?.id;
+    if (typeof id === "string" && id.length > 0) return id;
+  } catch (err) {
+    // pg blip at boot OR the `organization` table is absent (self-
+    // hosted dev with no managed auth). Fall through to the sentinel
+    // rather than failing SaasCrm boot — operator-env dispatch is the
+    // happy path and shouldn't depend on a workspace row existing.
+    log.warn(
+      {
+        err: err instanceof Error ? err.message : String(err),
+        event: "saas_crm.operator_workspace_lookup_failed",
+      },
+      "Failed to resolve operator workspace_id at boot — falling back to sentinel; outbox routing unaffected",
+    );
+  }
+  return ATLAS_OPERATOR_WORKSPACE_SENTINEL;
+}
 
 /**
  * Atlas's known Twenty CRM hostname. Used as the fallback when
@@ -480,6 +560,8 @@ export const SaasCrmLive: Layer.Layer<SaasCrm> = Layer.effect(
       } satisfies SaasCrmShape;
     }
 
+    const operatorWorkspaceId = yield* Effect.promise(() => resolveOperatorWorkspaceId());
+
     const verifyResult = yield* Effect.promise(() => verifyCustomFields(bootCreds));
     if (verifyResult.ok === false) {
       // Already logged inside verifyCustomFields (missing required field,
@@ -502,6 +584,9 @@ export const SaasCrmLive: Layer.Layer<SaasCrm> = Layer.effect(
       {
         baseUrl: bootCreds.baseUrl ?? ATLAS_SAAS_TWENTY_BASE_URL,
         credentialSource: bootCreds.source,
+        operatorWorkspaceId,
+        operatorWorkspaceIsSentinel:
+          operatorWorkspaceId === ATLAS_OPERATOR_WORKSPACE_SENTINEL,
         optional: optionalFieldStatus,
         event: "saas_crm.ready",
       },
@@ -509,14 +594,15 @@ export const SaasCrmLive: Layer.Layer<SaasCrm> = Layer.effect(
         `Optional fields ${OPTIONAL_PERSON_FIELDS.join(", ")} dispatched only when present in the workspace schema.`,
     );
 
-    // Boot-resolved env client config. Reused across every dispatch:
-    // the env-only source means TWENTY_API_KEY / TWENTY_BASE_URL are
-    // baked in at process start, and runtime mutation is not supported
-    // (admin-UI credential edits flow through the per-workspace plugin
-    // install, NOT here — see #2850). `allowedPersonFields` carries the
+    // Boot-resolved env client config. Used for every operator-pipeline
+    // row (workspace_id matches the resolved operator id or the
+    // sentinel) — TWENTY_API_KEY / TWENTY_BASE_URL are baked in at
+    // process start, and runtime mutation is not supported (admin-UI
+    // credential edits flow through the per-workspace plugin install,
+    // NOT here — see #2850). `allowedPersonFields` carries the
     // boot-probed schema allowlist so the client strips optional fields
-    // (e.g. `atlasIp`) the workspace didn't create.
-    const clientConfig: TwentyClientConfig = buildSaasClientConfig(
+    // (e.g. `atlasIp`) the operator workspace didn't create.
+    const operatorClientConfig: TwentyClientConfig = buildSaasClientConfig(
       bootCreds,
       verifyResult.present,
     );
@@ -529,6 +615,7 @@ export const SaasCrmLive: Layer.Layer<SaasCrm> = Layer.effect(
             await enqueue(outboxDb, {
               eventType: input.source,
               payload: input as unknown as Record<string, unknown>,
+              workspaceId: operatorWorkspaceId,
             });
           },
           catch: (err) => (err instanceof Error ? err : new Error(String(err))),
@@ -567,6 +654,7 @@ export const SaasCrmLive: Layer.Layer<SaasCrm> = Layer.effect(
             await enqueue(outboxDb, {
               eventType: STAMP_CONVERSION_EVENT_TYPE,
               payload: payload as unknown as Record<string, unknown>,
+              workspaceId: operatorWorkspaceId,
             });
           },
           catch: (err) => (err instanceof Error ? err : new Error(String(err))),
@@ -587,17 +675,140 @@ export const SaasCrmLive: Layer.Layer<SaasCrm> = Layer.effect(
           ),
         );
       },
-      // Single-config dispatcher: env credentials are static for the
-      // process lifetime, so we reuse the boot-resolved config (no
-      // per-row credential re-read). `verifyCustomFields` already ran
-      // at boot — if it had failed, this Layer would have short-
-      // circuited to `available: false` above.
+      // Per-row dispatcher (#2849). Routes by `row.workspaceId`:
+      //   - operator pipeline (workspaceId === operator id or the
+      //     sentinel) → boot-resolved env config. No per-row DB
+      //     round-trip; the path that drains Atlas's own lead-capture
+      //     queue stays as fast as the pre-#2849 single-config form.
+      //   - per-tenant (any other workspaceId) → resolve fresh from
+      //     `twenty_integrations` via `lookupTwentyDbCredentials`.
+      //     A missing or decrypt-failed row dead-letters that row
+      //     (permanent — operator must configure the install or
+      //     rotate the encryption key before the row can dispatch).
+      //
+      // No per-tenant credential cache. Per-row resolution costs one
+      // SELECT + one AES decrypt; that's measured in microseconds and
+      // a stale cached key would silently dispatch to the wrong
+      // Twenty after credential rotation. Add an LRU only if the
+      // backlog scale ever justifies it (today's volume: < 1 row /
+      // second sustained, well under what an uncached resolver
+      // tolerates).
       dispatcher: async (row, persist) => {
-        return dispatchOutboxRow(clientConfig, row, persist);
+        return dispatchWithResolvedConfig(
+          {
+            operatorWorkspaceId,
+            operatorClientConfig,
+          },
+          row,
+          persist,
+        );
       },
     } satisfies SaasCrmShape;
   }),
 );
+
+/**
+ * Routing closure handed to the flusher. Extracted to its own function
+ * so tests can drive the routing branches without booting the full
+ * Layer. The closure captures the operator's resolved id + boot-probed
+ * env client config; rows whose `workspaceId` matches the operator
+ * (including the sentinel form) dispatch through the env config,
+ * everything else resolves per-row from `twenty_integrations`.
+ *
+ * `isTwentyDecryptError` and `TwentyCredentialError` map to permanent
+ * outcomes — neither retries automatically: a decrypt failure means
+ * ATLAS_ENCRYPTION_KEYS is misconfigured (operator must rotate); a
+ * missing-credentials error means the workspace has no install yet.
+ * Dead-lettering surfaces both to the platform-crm-outbox UI for
+ * triage. Any other thrown error is treated as transient (network
+ * blip on the SELECT, malformed pg response) so a flaky pool doesn't
+ * burn the retry budget.
+ *
+ * @internal Exported for direct unit testing in
+ *   `__tests__/saas-crm-routing.test.ts`.
+ */
+export interface DispatchRoutingDeps {
+  readonly operatorWorkspaceId: string;
+  readonly operatorClientConfig: TwentyClientConfig;
+  /**
+   * Per-tenant credential lookup. Defaults to the production adapter
+   * (`lookupTwentyDbCredentials`); tests inject a stub.
+   */
+  readonly lookup?: typeof lookupTwentyDbCredentials;
+}
+
+export async function dispatchWithResolvedConfig(
+  deps: DispatchRoutingDeps,
+  row: ClaimedOutboxRow,
+  persist: OutboxPersistHelpers,
+): Promise<DispatchOutcome> {
+  const lookup = deps.lookup ?? lookupTwentyDbCredentials;
+
+  // Operator pipeline: stamp matches the resolved operator id OR the
+  // sentinel (an EU/APAC region / self-hosted enterprise with no
+  // `is_operator_workspace=true` row backfilled). Both route through
+  // the env config — the migration's COALESCE produces the same
+  // workspaceId the runtime would have stamped on a fresh enqueue.
+  if (
+    row.workspaceId === deps.operatorWorkspaceId ||
+    row.workspaceId === ATLAS_OPERATOR_WORKSPACE_SENTINEL
+  ) {
+    return dispatchOutboxRow(deps.operatorClientConfig, row, persist);
+  }
+
+  // Per-tenant pipeline. Resolve fresh — a rotated key on the workspace
+  // row mid-batch must not dispatch under the old key, and a deleted
+  // row must dead-letter rather than fall back to the operator's env
+  // (the Direction-1 leak in #2850).
+  let creds: ResolvedTwentyCredentials;
+  try {
+    creds = await resolveWorkspaceCredentials(row.workspaceId, {
+      deployMode: "saas",
+      lookup,
+    });
+  } catch (err) {
+    if (isTwentyDecryptError(err)) {
+      return {
+        kind: "permanent",
+        message:
+          `resolveWorkspaceCredentials decrypt-failed for workspace=${row.workspaceId}: ` +
+          `${err instanceof Error ? err.message : String(err)}. ` +
+          `Rotate ATLAS_ENCRYPTION_KEYS or re-save the integration row before this lead can dispatch.`,
+      };
+    }
+    if (err instanceof TwentyCredentialError) {
+      return {
+        kind: "permanent",
+        message:
+          `resolveWorkspaceCredentials missing for workspace=${row.workspaceId}: ` +
+          `${err.message}`,
+      };
+    }
+    // Lookup transport blip (pg connection error, malformed row). Treat
+    // as transient — the next tick may succeed once the pool recovers.
+    return {
+      kind: "transient",
+      message:
+        `resolveWorkspaceCredentials threw for workspace=${row.workspaceId}: ` +
+        `${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+
+  // Per-tenant `allowedPersonFields` is `undefined` — the boot probe
+  // only covered the operator workspace's Twenty schema. The client's
+  // own request-time error surfaces a 422/400 if a customer's Twenty
+  // is missing one of the Atlas custom fields (Person-level), which
+  // dead-letters that row via `classifyTwentyError`. Out of scope for
+  // this slice: a per-tenant boot probe + cached allowlist (would let
+  // optional fields like atlasIp be silently dropped instead of 400'd).
+  // Tracked in the architecture-wins doc for a future deepening.
+  const tenantClientConfig: TwentyClientConfig = {
+    apiKey: creds.apiKey,
+    baseUrl: creds.baseUrl ?? ATLAS_SAAS_TWENTY_BASE_URL,
+    timeoutMs: SAAS_TIMEOUT_MS,
+  };
+  return dispatchOutboxRow(tenantClientConfig, row, persist);
+}
 
 // Re-exported for direct testing of the verification / dispatch logic.
 export {
@@ -608,3 +819,7 @@ export {
   STAMP_CONVERSION_EVENT_TYPE,
   REQUIRED_PERSON_FIELDS,
 };
+
+// `ATLAS_OPERATOR_WORKSPACE_SENTINEL`, `resolveOperatorWorkspaceId`,
+// and `dispatchWithResolvedConfig` are exported inline at their
+// definitions above for the per-row routing tests in #2849.

--- a/packages/api/src/api/routes/__tests__/contact.test.ts
+++ b/packages/api/src/api/routes/__tests__/contact.test.ts
@@ -115,6 +115,9 @@ mock.module("@atlas/api/lib/effect/hono", () => ({
             return Effect.void;
           },
           stampConversion: () => Effect.void,
+          // No-op shape: dispatcher null (no EE / no internal DB).
+          // Tests don't drive the flusher path through the contact route.
+          dispatcher: null,
         };
     const layer = Layer.mergeAll(
       services.createRequestContextTestLayer({ requestId: "test-req-id" }),

--- a/packages/api/src/api/routes/__tests__/platform-crm-outbox.test.ts
+++ b/packages/api/src/api/routes/__tests__/platform-crm-outbox.test.ts
@@ -171,6 +171,7 @@ mock.module("@atlas/api/lib/effect/hono", () => ({
           available: false,
           upsertLead: () => Effect.void,
           stampConversion: () => Effect.void,
+          dispatcher: null,
         };
     const layer = Layer.mergeAll(
       services.createRequestContextTestLayer({

--- a/packages/api/src/lib/auth/__tests__/dispatch-conversion-crm-stamp.test.ts
+++ b/packages/api/src/lib/auth/__tests__/dispatch-conversion-crm-stamp.test.ts
@@ -111,6 +111,7 @@ function noopLayer(): Layer.Layer<SaasCrm> {
     available: false,
     upsertLead: () => Effect.void,
     stampConversion: () => Effect.void,
+    dispatcher: null,
   });
 }
 

--- a/packages/api/src/lib/auth/__tests__/dispatch-signup-crm-lead.test.ts
+++ b/packages/api/src/lib/auth/__tests__/dispatch-signup-crm-lead.test.ts
@@ -105,6 +105,9 @@ function noopLayer(): Layer.Layer<SaasCrm> {
     // `stampConversion` too. Noop is structurally identical to
     // `upsertLead` here.
     stampConversion: () => Effect.void,
+    // #2849 — available:false now also requires `dispatcher`. null
+    // = "no way to dispatch anything" (the legitimate noop default).
+    dispatcher: null,
   });
 }
 

--- a/packages/api/src/lib/auth/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/auth/__tests__/migrate.test.ts
@@ -351,6 +351,7 @@ describe("migrateAuthTables", () => {
             { name: "0103_converge_salesforce_pillar.sql" },
             { name: "0104_crm_outbox_email_key.sql" },
             { name: "0105_drop_legacy_invitations.sql" },
+            { name: "0106_crm_outbox_workspace_id.sql" },
           ],
         };
       }

--- a/packages/api/src/lib/db/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate.test.ts
@@ -122,8 +122,9 @@ describe("runMigrations", () => {
     // + 0104 (crm_outbox.email_key for per-email serialization, #2870)
     // + 0105 (drop legacy invitations table after better-auth-invitations
     //   cutover — invitations now live in Better Auth's `invitation`
-    //   table; see lib/auth/server.ts:organizationHooks) = 106.
-    expect(count).toBe(106);
+    //   table; see lib/auth/server.ts:organizationHooks) = 106. Plus
+    //   #2849 (workspace_id on crm_outbox) = 107.
+    expect(count).toBe(107);
 
     // Advisory lock acquired before anything else
     expect(queries[0]).toContain("pg_advisory_lock");
@@ -258,6 +259,7 @@ describe("runMigrations", () => {
         "0103_converge_salesforce_pillar.sql",
         "0104_crm_outbox_email_key.sql",
         "0105_drop_legacy_invitations.sql",
+        "0106_crm_outbox_workspace_id.sql",
       ],
     });
 

--- a/packages/api/src/lib/db/migrations/0106_crm_outbox_workspace_id.sql
+++ b/packages/api/src/lib/db/migrations/0106_crm_outbox_workspace_id.sql
@@ -1,0 +1,79 @@
+-- 0106_crm_outbox_workspace_id.sql
+--
+-- Lift per-tenant attribution out of "wherever this happens to dispatch"
+-- and onto a first-class column (#2849). Today every `crm_outbox` row
+-- belongs to Atlas's own operator workspace — the SaaS lead-capture
+-- pipeline at `crm.useatlas.dev`. Tomorrow, a customer workspace plugin
+-- install (`@useatlas/twenty` per-tenant) needs to route its own rows
+-- to its own Twenty. Without `workspace_id`, the dispatcher would have
+-- to guess from payload shape; with it, routing is a deterministic
+-- per-row lookup.
+--
+-- ─────────────────────────────────────────────────────────────────────
+-- DEFAULT '<atlas-operator>' rationale
+-- ─────────────────────────────────────────────────────────────────────
+-- The column ships with NOT NULL + DEFAULT in one ALTER so existing
+-- rows backfill atomically to the operator-pipeline sentinel — no
+-- two-phase ADD-NULLABLE-then-SET-NOT-NULL migration, no risk of an
+-- intermediate state where the column exists but the constraint
+-- doesn't. The sentinel string matches `ATLAS_OPERATOR_WORKSPACE_SENTINEL`
+-- in `ee/src/saas-crm/index.ts`; the runtime dispatcher treats it as
+-- the env-creds branch (Atlas's own pipeline) so any rows that land
+-- with the sentinel route correctly even when no `is_operator_workspace`
+-- row exists (EU/APAC SaaS regions, self-hosted dev).
+--
+-- The DEFAULT also covers raw `INSERT INTO crm_outbox` paths in test
+-- fixtures and one-shot operator scripts that haven't been threaded
+-- through the application's `enqueue()` (which throws on empty
+-- workspaceId). New PRs adding code that enqueues outside `enqueue()`
+-- should still set workspace_id explicitly — the DEFAULT is a safety
+-- net, not a license to skip attribution.
+--
+-- ─────────────────────────────────────────────────────────────────────
+-- Operator-id fidelity bump
+-- ─────────────────────────────────────────────────────────────────────
+-- After the ADD COLUMN settles, an OPTIONAL UPDATE rewrites
+-- sentinel-stamped rows to the real `organization.is_operator_workspace
+-- = true` id when one exists. Both forms route identically at dispatch
+-- time — env creds — so this is purely a metadata-fidelity / observability
+-- bump (a future platform-admin view can attribute the row to the
+-- specific operator org, e.g. when reporting per-region volumes). The
+-- `to_regclass` guard mirrors 0090 / 0085 — `organization` doesn't
+-- exist in non-managed-auth mode and the migration runs cleanly there.
+--
+-- ─────────────────────────────────────────────────────────────────────
+-- Index
+-- ─────────────────────────────────────────────────────────────────────
+-- Partial index on `(workspace_id, status, created_at) WHERE status IN
+-- ('pending', 'in_flight')` mirrors the shape of the existing
+-- pending-created index but adds the workspace dimension so a future
+-- per-workspace admin view scans only its slice. The active-statuses
+-- filter keeps the index small as done/dead rows accumulate (same
+-- pattern as 0102 and 0104).
+
+ALTER TABLE crm_outbox
+  ADD COLUMN IF NOT EXISTS workspace_id TEXT NOT NULL DEFAULT '<atlas-operator>';
+
+DO $$
+DECLARE
+  op_id TEXT;
+BEGIN
+  IF to_regclass('organization') IS NOT NULL THEN
+    SELECT id INTO op_id
+      FROM organization
+     WHERE is_operator_workspace = true
+     LIMIT 1;
+    IF op_id IS NOT NULL THEN
+      UPDATE crm_outbox
+         SET workspace_id = op_id
+       WHERE workspace_id = '<atlas-operator>';
+    END IF;
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS idx_crm_outbox_workspace_status_created
+  ON crm_outbox (workspace_id, status, created_at)
+  WHERE status IN ('pending', 'in_flight');
+
+COMMENT ON COLUMN crm_outbox.workspace_id IS
+  'Tenant attribution for per-row dispatch routing (#2849). The SaaS lead-capture pipeline at crm.useatlas.dev resolves the Atlas operator workspace id (organization.is_operator_workspace=true) at boot; rows enqueued via SaasCrm.upsertLead/stampConversion carry that id. A future per-tenant plugin enqueue path lands a customer workspace id and the dispatcher resolves the workspace''s credentials via twenty_integrations. The sentinel ''<atlas-operator>'' (also the column DEFAULT) covers regions/deploys without a flagged operator row — the runtime treats it as the env-creds branch. No FK to organization (same rationale as the rest of crm_outbox: durability over referential integrity for an outbox that survives org deletion pending triage).';

--- a/packages/api/src/lib/db/migrations/scripts/__tests__/backfill-crm-leads.test.ts
+++ b/packages/api/src/lib/db/migrations/scripts/__tests__/backfill-crm-leads.test.ts
@@ -71,6 +71,15 @@ describeIfPg("backfill-crm-leads (real Postgres)", () => {
   const db = (): Parameters<typeof runBackfill>[0]["db"] =>
     pool as unknown as Parameters<typeof runBackfill>[0]["db"];
 
+  /** Default workspace_id stamped on every backfilled row (#2849).
+   *  The runtime resolver looks up `is_operator_workspace = true` from
+   *  `organization`; this suite runs against a non-managed-auth schema
+   *  (no `organization` table) so we pass the value explicitly. The
+   *  column DEFAULT in migration 0106 would catch raw-INSERT paths,
+   *  but `runBackfill`'s shape is non-optional, so the test threads
+   *  it through. */
+  const TEST_OPERATOR_WORKSPACE_ID = "ws-test-operator";
+
   describe("dry-run path", () => {
     it("reports total row count and a normalized sample without writing", async () => {
       // Seed three rows with distinct emails. Three is enough to exercise
@@ -90,6 +99,7 @@ describeIfPg("backfill-crm-leads (real Postgres)", () => {
         dryRun: true,
         batchSize: DEFAULT_BATCH_SIZE,
         source: "demo",
+        workspaceId: TEST_OPERATOR_WORKSPACE_ID,
         log: (m) => logs.push(m),
       });
 
@@ -131,6 +141,7 @@ describeIfPg("backfill-crm-leads (real Postgres)", () => {
         dryRun: true,
         batchSize: DEFAULT_BATCH_SIZE,
         source: "demo",
+        workspaceId: TEST_OPERATOR_WORKSPACE_ID,
         log: () => {},
       });
 
@@ -144,6 +155,7 @@ describeIfPg("backfill-crm-leads (real Postgres)", () => {
         dryRun: false,
         batchSize: DEFAULT_BATCH_SIZE,
         source: "demo",
+        workspaceId: TEST_OPERATOR_WORKSPACE_ID,
         log: () => {},
       });
       expect(stats).toEqual({ totalRows: 0, enqueued: 0, batches: 0, sample: [] });
@@ -171,6 +183,7 @@ describeIfPg("backfill-crm-leads (real Postgres)", () => {
         dryRun: false,
         batchSize: 500,
         source: "demo",
+        workspaceId: TEST_OPERATOR_WORKSPACE_ID,
         log: (m) => logs.push(m),
       });
 
@@ -224,6 +237,7 @@ describeIfPg("backfill-crm-leads (real Postgres)", () => {
         dryRun: false,
         batchSize: DEFAULT_BATCH_SIZE,
         source: "demo",
+        workspaceId: TEST_OPERATOR_WORKSPACE_ID,
         log: () => {},
       });
 
@@ -258,6 +272,7 @@ describeIfPg("backfill-crm-leads (real Postgres)", () => {
           dryRun: true,
           batchSize: 0,
           source: "demo",
+          workspaceId: TEST_OPERATOR_WORKSPACE_ID,
           log: () => {},
         }),
       ).rejects.toThrow(/batchSize/);
@@ -275,6 +290,7 @@ describeIfPg("backfill-crm-leads (real Postgres)", () => {
         dryRun: false,
         batchSize: 500,
         source: "demo",
+        workspaceId: TEST_OPERATOR_WORKSPACE_ID,
         log: () => {},
       });
       expect(stats).toMatchObject({ totalRows: 1, enqueued: 1, batches: 1 });
@@ -305,6 +321,7 @@ describeIfPg("backfill-crm-leads (real Postgres)", () => {
           dryRun: false,
           batchSize: 500,
           source: "demo",
+          workspaceId: TEST_OPERATOR_WORKSPACE_ID,
           log: () => {},
         }),
       ).rejects.toThrow(/ON CONFLICT/);

--- a/packages/api/src/lib/db/migrations/scripts/backfill-crm-leads.ts
+++ b/packages/api/src/lib/db/migrations/scripts/backfill-crm-leads.ts
@@ -40,6 +40,47 @@ export const DEFAULT_BATCH_SIZE = 500;
 /** How many normalized payloads dry-run prints as a sanity preview. */
 export const DRY_RUN_SAMPLE_SIZE = 3;
 
+/**
+ * Operator-pipeline workspace_id stamped on backfilled rows when no
+ * `organization.is_operator_workspace = true` row exists in the
+ * target DB. Same constant the runtime `ee/src/saas-crm/` Layer uses
+ * (`ATLAS_OPERATOR_WORKSPACE_SENTINEL`); duplicated here so the
+ * backfill script stays free of the ee dep — the closeout-time grep
+ * gate (`scripts/check-ee-imports.sh`) would reject an EE import in
+ * a core script.
+ */
+export const ATLAS_OPERATOR_WORKSPACE_SENTINEL = "<atlas-operator>";
+
+/**
+ * Resolve the workspace_id to stamp on backfilled rows. Reads
+ * `organization.is_operator_workspace = true` from the same DB the
+ * INSERTs land in; falls back to the sentinel when the table is
+ * absent (managed auth disabled) or no flagged row exists. Either
+ * way, the runtime dispatcher routes the row through env creds.
+ */
+export async function resolveOperatorWorkspaceIdForBackfill(
+  db: BackfillDB,
+): Promise<string> {
+  try {
+    const result = await db.query<{ id: string }>(
+      `SELECT id FROM organization WHERE is_operator_workspace = true LIMIT 1`,
+    );
+    const id = result.rows[0]?.id;
+    if (typeof id === "string" && id.length > 0) return id;
+  } catch (err) {
+    // Same fall-through as the runtime resolver in
+    // `ee/src/saas-crm/`: a missing `organization` table or
+    // transport blip should not block the backfill. Log so an
+    // operator running this script sees what happened.
+    console.warn(
+      `[backfill-crm-leads] operator workspace lookup failed (${
+        err instanceof Error ? err.message : String(err)
+      }) — falling back to sentinel "${ATLAS_OPERATOR_WORKSPACE_SENTINEL}"; dispatcher will still route through env creds`,
+    );
+  }
+  return ATLAS_OPERATOR_WORKSPACE_SENTINEL;
+}
+
 /** Lead source today is always `"demo"` — `--source` is parameterized
  *  so a future sales-form-leads table can use the same harness. The
  *  normalizer's exhaustive switch is the drift gate. Source of truth
@@ -56,6 +97,16 @@ export interface BackfillOptions {
   readonly batchSize: number;
   /** Source variant. Today only `"demo"`. */
   readonly source: BackfillSource;
+  /**
+   * Workspace id stamped on every enqueued row (#2849). The runtime
+   * dispatcher uses this to pick between env creds (operator pipeline)
+   * and per-tenant DB credentials. For the historic demo_leads
+   * back-catalog, every row belongs to Atlas's own operator pipeline,
+   * so the caller resolves the operator workspace id (or the sentinel)
+   * once and passes it in. Required because crm_outbox.workspace_id
+   * is NOT NULL post-0106 — there's no implicit fallback.
+   */
+  readonly workspaceId: string;
   /**
    * Progress sink. Default `console.log`. Tests pass a collector to
    * assert progress lines without polluting test output.
@@ -141,10 +192,12 @@ const COUNT_SQL = `SELECT COUNT(*)::bigint AS n FROM demo_leads`;
 function buildBulkEnqueueSql(rowCount: number): string {
   const placeholders: string[] = [];
   for (let i = 0; i < rowCount; i++) {
-    const base = i * 3;
-    placeholders.push(`($${base + 1}, $${base + 2}::jsonb, $${base + 3}, 'pending')`);
+    const base = i * 4;
+    placeholders.push(
+      `($${base + 1}, $${base + 2}::jsonb, $${base + 3}, $${base + 4}, 'pending')`,
+    );
   }
-  return `INSERT INTO crm_outbox (event_type, payload, email_key, status) VALUES ${placeholders.join(", ")} RETURNING id`;
+  return `INSERT INTO crm_outbox (event_type, payload, email_key, workspace_id, status) VALUES ${placeholders.join(", ")} RETURNING id`;
 }
 
 /** Map a `demo_leads` row to the corresponding `AtlasLeadEvent`.
@@ -182,6 +235,12 @@ export async function runBackfill(options: BackfillOptions): Promise<BackfillSta
   if (options.batchSize < 1) {
     throw new Error(`batchSize must be ≥ 1 (got ${options.batchSize})`);
   }
+  if (options.workspaceId.length === 0) {
+    throw new Error(
+      "workspaceId is required (crm_outbox.workspace_id is NOT NULL post-0106) — " +
+        "resolve operator workspace via SELECT id FROM organization WHERE is_operator_workspace = true",
+    );
+  }
   const log = options.log ?? ((msg: string) => console.log(msg));
 
   const totalResult = await options.db.query<{ n: string }>(COUNT_SQL);
@@ -215,11 +274,17 @@ export async function runBackfill(options: BackfillOptions): Promise<BackfillSta
           ]);
     if (page.rows.length === 0) break;
 
-    // Flat `[event_type_0, payload_0, email_key_0, event_type_1, …]`
-    // so the positional placeholders in `buildBulkEnqueueSql` line up
-    // with their VALUES tuples. `extractEmailKey` is shared with the
-    // runtime `enqueue` so the bulk path produces identical email_key
-    // values for identical payloads (#2870).
+    // Flat `[event_type_0, payload_0, email_key_0, workspace_id_0,
+    // event_type_1, …]` so the positional placeholders in
+    // `buildBulkEnqueueSql` line up with their VALUES tuples.
+    // `extractEmailKey` is shared with the runtime `enqueue` so the
+    // bulk path produces identical email_key values for identical
+    // payloads (#2870). `workspaceId` is the same value for every row
+    // in the batch — historic demo_leads all belong to the operator
+    // pipeline (#2849) — but we duplicate it positionally rather than
+    // factoring out a single placeholder so a future hetero-tenant
+    // backfill (per-workspace `WHERE workspace_id = ...`) drops in
+    // without reshaping the SQL builder.
     const params: unknown[] = [];
     for (const row of page.rows) {
       const event = toLeadEvent(row, options.source);
@@ -233,6 +298,7 @@ export async function runBackfill(options: BackfillOptions): Promise<BackfillSta
         event.source,
         JSON.stringify(event),
         extractEmailKey({ email: event.email }),
+        options.workspaceId,
       );
 
       if (options.dryRun && sample.length < DRY_RUN_SAMPLE_SIZE) {
@@ -317,11 +383,15 @@ async function main(): Promise<void> {
   const client = new Client({ connectionString: url });
   await client.connect();
   try {
+    const workspaceId = await resolveOperatorWorkspaceIdForBackfill(
+      client as unknown as BackfillDB,
+    );
     const stats = await runBackfill({
       db: client as unknown as BackfillDB,
       dryRun,
       batchSize,
       source,
+      workspaceId,
     });
     if (dryRun && stats.sample.length > 0) {
       console.log(`[backfill-crm-leads] first ${stats.sample.length} normalized payload(s):`);

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -2234,6 +2234,14 @@ export const crmOutbox = pgTable(
     // simultaneously. Nullable for legacy / non-email-keyed event
     // types — those rows fall back to per-id deduplication.
     emailKey: text("email_key"),
+    // Tenant attribution for per-row dispatch routing (0106, #2849).
+    // SaaS lead-capture (Atlas's own pipeline) carries the resolved
+    // operator workspace id; a future per-tenant plugin enqueue path
+    // lands a customer workspace id. NOT NULL with DEFAULT to the
+    // operator sentinel so the migration backfills atomically and
+    // raw-INSERT fixtures don't have to thread workspace_id through.
+    // See migration 0106 for the fallback rationale.
+    workspaceId: text("workspace_id").notNull().default("<atlas-operator>"),
     status: text("status").$type<OutboxStatus>().notNull().default("pending"),
     attempts: integer("attempts").notNull().default(0),
     lastError: text("last_error"),
@@ -2257,6 +2265,9 @@ export const crmOutbox = pgTable(
       .where(sql`status IN ('pending', 'in_flight')`),
     index("idx_crm_outbox_email_key_active")
       .on(t.emailKey, t.status, t.createdAt)
+      .where(sql`status IN ('pending', 'in_flight')`),
+    index("idx_crm_outbox_workspace_status_created")
+      .on(t.workspaceId, t.status, t.createdAt)
       .where(sql`status IN ('pending', 'in_flight')`),
   ],
 );

--- a/packages/api/src/lib/effect/__tests__/outbox-flusher-lifecycle.test.ts
+++ b/packages/api/src/lib/effect/__tests__/outbox-flusher-lifecycle.test.ts
@@ -229,11 +229,16 @@ describe("outbox flusher lifecycle (#2729 AC #7 + #9)", () => {
     }
   });
 
-  test("Layer skips flusher wiring when SaasCrm.available is false", async () => {
+  test("Layer skips flusher wiring when SaasCrm.dispatcher is null (no EE / no internal DB)", async () => {
     const noopSaasCrm: Layer.Layer<SaasCrmTag> = Layer.succeed(SaasCrm, {
       available: false,
       upsertLead: () => Effect.void,
       stampConversion: () => Effect.void,
+      // dispatcher: null is the gate post-#2849 — the flusher mounts on
+      // `dispatcher !== null`, NOT on `available`. The tenant-only
+      // shape (available: false + dispatcher present) is covered in a
+      // separate test (`mounts flusher when only operator probe failed`).
+      dispatcher: null,
     } satisfies SaasCrmShape);
 
     const config = {} as Parameters<typeof makeSchedulerLive>[0];
@@ -252,5 +257,38 @@ describe("outbox flusher lifecycle (#2729 AC #7 + #9)", () => {
       /WHERE status = 'in_flight'/i.test(q.sql),
     );
     expect(recoveryCalls.length).toBe(0);
+  });
+
+  // ── Codex I2 (#2849) ────────────────────────────────────────────────
+  // Pre-fix the flusher gated on `available`, which conflated "operator
+  // pipeline broken" with "no dispatcher possible". A transient operator
+  // Twenty outage left every customer-workspace row unclaimed.
+  test("Layer mounts flusher when only operator probe failed (tenant-only shape, dispatcher present)", async () => {
+    const tenantOnlySaasCrm: Layer.Layer<SaasCrmTag> = Layer.succeed(SaasCrm, {
+      available: false,
+      upsertLead: () => Effect.void,
+      stampConversion: () => Effect.void,
+      // Tenant-only shape: dispatcher is non-null even though the
+      // operator probe failed. The flusher MUST mount so per-tenant
+      // rows in crm_outbox keep flowing.
+      dispatcher: async () => ({ kind: "ok" as const }),
+    } satisfies SaasCrmShape);
+
+    const config = {} as Parameters<typeof makeSchedulerLive>[0];
+    const baseLayer = makeSchedulerLive(config);
+    const deps = Layer.mergeAll(NoopEnterpriseDefaultsLayer, tenantOnlySaasCrm);
+    const layer = baseLayer.pipe(Layer.provide(deps));
+
+    const rt = ManagedRuntime.make(layer);
+    await Effect.runPromise(rt.runtimeEffect);
+    await rt.dispose();
+
+    // Recovery sweep is the canary — it only runs when the flusher
+    // mounts. Presence of any in_flight reset/mark statement proves
+    // the dispatcher-gated mount took effect.
+    const recoveryCalls = sqlLog.filter((q) =>
+      /WHERE status = 'in_flight'/i.test(q.sql),
+    );
+    expect(recoveryCalls.length).toBeGreaterThan(0);
   });
 });

--- a/packages/api/src/lib/effect/layers.ts
+++ b/packages/api/src/lib/effect/layers.ts
@@ -1511,15 +1511,19 @@ export function makeSchedulerLive(
       );
 
       // ── Periodic fiber: SaaS CRM outbox flusher (#2729) ─────────────
-      // Slice 2 of 1.6.0. The flusher polls `crm_outbox` for pending /
-      // due rows, claims them via single-statement UPDATE … RETURNING,
-      // and hands each to the dispatcher Tag-bound by `SaasCrmLive`.
-      // Skipped when SaasCrm is unavailable (self-hosted, missing
-      // creds, no internal DB, or boot verification failure) — the
-      // discriminated union narrows `dispatcher` to non-null inside
-      // the `available === true` branch.
+      // The flusher polls `crm_outbox` for pending / due rows, claims
+      // them via single-statement UPDATE … RETURNING, and hands each
+      // to the dispatcher Tag-bound by `SaasCrmLive`.
+      //
+      // Gate is `saasCrm.dispatcher !== null` (not `available`):
+      // post-#2849, the dispatcher routes per-row, and customer-
+      // workspace rows have nothing to do with the operator's Twenty
+      // probe / env creds. We mount the flusher whenever ANY dispatch
+      // path is viable; per-row classification handles operator-
+      // pipeline rows when the operator side is broken (they
+      // dead-letter with an actionable permanent message).
       const saasCrm = yield* SaasCrm;
-      if (saasCrm.available && hasInternalDB()) {
+      if (saasCrm.dispatcher !== null && hasInternalDB()) {
         const outboxDispatcher = saasCrm.dispatcher;
         const outboxDb: OutboxDB = { query: internalQuery };
 
@@ -1805,9 +1809,10 @@ export function makeSchedulerLive(
         log.debug(
           {
             saasCrmAvailable: saasCrm.available,
+            dispatcherPresent: saasCrm.dispatcher !== null,
             hasInternalDB: hasInternalDB(),
           },
-          "CRM outbox flusher not started — SaasCrm unavailable or internal DB absent",
+          "CRM outbox flusher not started — no dispatcher (self-hosted / no EE / no internal DB)",
         );
       }
 

--- a/packages/api/src/lib/effect/services.ts
+++ b/packages/api/src/lib/effect/services.ts
@@ -2493,15 +2493,22 @@ export type SaasCrmStampConversionInput = Omit<
 >;
 
 /**
- * Discriminated SaasCrm shape — the two correlated facts (anticipated
- * `available` flag for the future `POST /api/v1/contact` 404 branch and
- * the load-bearing `dispatcher` for the flusher) are encoded as a
- * single union so they can't drift out of sync. Five places in
- * `SaasCrmLive` used to set them by hand; the discriminator now
- * narrows automatically.
+ * Discriminated SaasCrm shape — `available` is the operator-pipeline
+ * health flag; `dispatcher` is the per-row outbox dispatcher and
+ * survives operator-probe failure (#2849 codex I2) because the
+ * dispatcher routes per-row: customer-workspace rows have their own
+ * credentials in `twenty_integrations` and have nothing to do with the
+ * operator's `TWENTY_API_KEY`.
  *
- * `available === false` ⇒ no dispatcher (flusher skips wiring).
- * `available === true`  ⇒ dispatcher is non-null (flusher uses it).
+ * `available === false` ⇒ operator pipeline unavailable (POST /contact
+ *   returns 404; upsertLead/stampConversion are no-ops). The
+ *   `dispatcher` may still be present when only the operator boot
+ *   probe failed — in that case operator-pipeline rows in `crm_outbox`
+ *   dead-letter with a permanent message, but per-tenant rows route
+ *   normally. `dispatcher` is `null` only when there is no way to
+ *   dispatch anything (self-hosted with no EE, or no internal DB).
+ * `available === true`  ⇒ both operator + tenant dispatch healthy;
+ *   `dispatcher` is non-null and the flusher mounts.
  *
  * `upsertLead` is shared across both — even an `available: false` layer
  * accepts the call as a no-op so callers don't need to branch.
@@ -2511,9 +2518,7 @@ export type SaasCrmShape =
       /**
        * `POST /api/v1/contact` reads this to return 404 `not_available`
        * on self-hosted (or when the SaaS layer failed boot verification)
-       * rather than the standard 403 envelope. The flusher wire-up in
-       * `lib/effect/layers.ts:makeSchedulerLive` also reads it to decide
-       * whether to mount the per-row dispatcher.
+       * rather than the standard 403 envelope.
        *
        * Flips to `false` on any of:
        *  - self-hosted (`@atlas/ee` not loaded → `NoopSaasCrmLayer`);
@@ -2525,6 +2530,13 @@ export type SaasCrmShape =
        *    `atlasStripeCustomerId` — #2737). Missing custom fields
        *    would dead-letter every dispatch on a 422 schema mismatch,
        *    so the boot-time guard disables the layer instead.
+       *  - `resolveOperatorWorkspaceId` boot SELECT throws a non-
+       *    "table missing" pg error (#2849 codex C2). Fail-loud rather
+       *    than silently masking already-stamped rows with the sentinel.
+       *
+       * NOTE: `available: false` no longer implies "no dispatcher".
+       * See `dispatcher` below — per-tenant rows can still flush when
+       * only the operator probe is broken.
        */
       readonly available: false;
       readonly upsertLead: (input: SaasCrmLeadInput) => Effect.Effect<void, Error>;
@@ -2536,6 +2548,25 @@ export type SaasCrmShape =
       readonly stampConversion: (
         input: SaasCrmStampConversionInput,
       ) => Effect.Effect<void, Error>;
+      /**
+       * Outbox dispatcher when only the operator probe failed (EE on +
+       * InternalDB present + operator creds/probe/workspace-resolve
+       * broken). Tenant rows route normally via per-row
+       * `twenty_integrations` lookup; operator-pipeline rows
+       * (workspace_id matches resolved operator id or sentinel)
+       * dead-letter with `{ kind: "permanent" }` and an actionable
+       * message pointing the operator at the failed boot log.
+       *
+       * `null` only when there is no way to dispatch anything at all:
+       * self-hosted (no EE) or no internal DB. The flusher uses
+       * `dispatcher !== null` as the mount gate (#2849 codex I2).
+       */
+      readonly dispatcher:
+        | ((
+            row: import("@atlas/api/lib/lead-outbox").ClaimedOutboxRow,
+            persist: import("@atlas/api/lib/lead-outbox").OutboxPersistHelpers,
+          ) => Promise<import("@atlas/api/lib/lead-outbox").DispatchOutcome>)
+        | null;
     }
   | {
       readonly available: true;
@@ -2604,6 +2635,9 @@ export const NoopSaasCrmLayer: Layer.Layer<SaasCrm> = Layer.succeed(SaasCrm, {
           "Check boot logs for the original 'saas_crm.openapi_*' event that flipped the layer to unavailable.",
       );
     }),
+  // No EE → no per-tenant dispatcher either. The flusher gate
+  // (`saasCrm.dispatcher !== null`) skips wiring entirely.
+  dispatcher: null,
 } satisfies SaasCrmShape);
 
 // ── Aggregate no-op default Layer ────────────────────────────────────

--- a/packages/api/src/lib/lead-outbox/__tests__/outbox-pg.test.ts
+++ b/packages/api/src/lib/lead-outbox/__tests__/outbox-pg.test.ts
@@ -822,4 +822,86 @@ describeIfPg("lead-outbox (real Postgres)", () => {
     },
     PG_TIMEOUT_MS,
   );
+
+  // ── Codex C3 (#2849): cross-tenant per-email serialization ────────
+  //
+  // Pre-fix CLAIM_SQL serialized on `email_key` ALONE — the NOT EXISTS
+  // gate, advisory lock, and DISTINCT ON dedupe all omitted
+  // workspace_id. Tenant A's `alice@example.com` would block tenant
+  // B's `alice@example.com` (they dispatch to different Twentys and
+  // have independent idempotency), creating silent head-of-line
+  // blocking across unrelated CRMs.
+  //
+  // Post-fix the serialization key is `(workspace_id, email_key)` so
+  // both tenants' rows for the same email claim in the same tick.
+  it(
+    "claim does NOT serialize same email across distinct workspaces (codex C3)",
+    async () => {
+      await truncateOutbox();
+      const db = dbFor();
+
+      // Enqueue same email under two distinct workspaces. Pre-fix the
+      // second insert's row would be blocked by NOT EXISTS / the
+      // shared advisory lock; post-fix both claim independently.
+      await enq(db, {
+        eventType: "demo",
+        payload: { source: "demo", email: "alice@example.com" },
+        workspaceId: "ws-tenant-A",
+      });
+      await enq(db, {
+        eventType: "demo",
+        payload: { source: "demo", email: "alice@example.com" },
+        workspaceId: "ws-tenant-B",
+      });
+
+      const claimedByDispatcher: string[] = [];
+      const dispatcher: OutboxDispatcher = async (row) => {
+        claimedByDispatcher.push(row.workspaceId);
+        return { kind: "ok" };
+      };
+
+      const result = await flushBatch(db, dispatcher, 10);
+
+      // Both tenants drain in a single tick — independent serialization
+      // namespaces. Pre-fix this would be 1 (one tenant's row blocked).
+      expect(result.claimed).toBe(2);
+      expect(result.ok).toBe(2);
+      expect(claimedByDispatcher.sort()).toEqual([
+        "ws-tenant-A",
+        "ws-tenant-B",
+      ]);
+    },
+    PG_TIMEOUT_MS,
+  );
+
+  // Same-workspace same-email serialization is still in force — only
+  // the cross-workspace block is lifted. Sanity-check that the per-
+  // workspace gate keeps working as designed.
+  it(
+    "claim STILL serializes same email within the same workspace (codex C3 — invariant preserved)",
+    async () => {
+      await truncateOutbox();
+      const db = dbFor();
+
+      // Two rows, same email, same workspace, distinct created_at.
+      // The older row blocks the newer one via NOT EXISTS.
+      await pool.query(
+        `INSERT INTO crm_outbox (event_type, payload, email_key, workspace_id, status, created_at)
+         VALUES
+           ('demo', $1::jsonb, 'dup@same.test', 'ws-only-one', 'pending', now() - INTERVAL '10 seconds'),
+           ('demo', $2::jsonb, 'dup@same.test', 'ws-only-one', 'pending', now())`,
+        [
+          JSON.stringify({ source: "demo", email: "dup@same.test" }),
+          JSON.stringify({ source: "demo", email: "dup@same.test" }),
+        ],
+      );
+
+      const dispatcher: OutboxDispatcher = async () => ({ kind: "ok" });
+      const result = await flushBatch(db, dispatcher, 10);
+
+      // Older sibling drained, newer one held back — only 1 claimed.
+      expect(result.claimed).toBe(1);
+    },
+    PG_TIMEOUT_MS,
+  );
 });

--- a/packages/api/src/lib/lead-outbox/__tests__/outbox-pg.test.ts
+++ b/packages/api/src/lib/lead-outbox/__tests__/outbox-pg.test.ts
@@ -598,12 +598,17 @@ describeIfPg("lead-outbox (real Postgres)", () => {
       const db = dbFor();
 
       // Seed an in_flight row directly (simulates a sibling pod mid-dispatch).
+      // workspace_id must match the enq()'d row's TEST_WORKSPACE_ID — codex
+      // C3 (#2849) scoped the NOT EXISTS gate by (workspace_id, email_key),
+      // so cross-workspace same-email no longer blocks. This test exercises
+      // the same-workspace gate; both rows therefore use TEST_WORKSPACE_ID.
       await pool.query(
-        `INSERT INTO crm_outbox (event_type, payload, email_key, status, attempts, claimed_at, created_at)
-         VALUES ('demo', $1::jsonb, $2, 'in_flight', 1, now(), now() - INTERVAL '3 hours')`,
+        `INSERT INTO crm_outbox (event_type, payload, email_key, workspace_id, status, attempts, claimed_at, created_at)
+         VALUES ('demo', $1::jsonb, $2, $3, 'in_flight', 1, now(), now() - INTERVAL '3 hours')`,
         [
           JSON.stringify({ source: "demo", email: "stuck@example.test" }),
           "stuck@example.test",
+          TEST_WORKSPACE_ID,
         ],
       );
       // Newer pending row for the same email.
@@ -657,17 +662,27 @@ describeIfPg("lead-outbox (real Postgres)", () => {
     async () => {
       await truncateOutbox();
 
-      // Two pending rows, same email, different created_at so the
-      // claim ordering is deterministic.
+      // Two pending rows, same email, same workspace, different created_at
+      // so claim ordering is deterministic. Same workspace_id is required
+      // post-#2849 codex C3 — the advisory lock is keyed on
+      // (workspace_id, email_key), so cross-workspace rows would not race.
       await pool.query(
-        `INSERT INTO crm_outbox (event_type, payload, email_key, status, created_at)
-         VALUES ('demo', $1::jsonb, $2, 'pending', now() - INTERVAL '2 minutes')`,
-        [JSON.stringify({ source: "demo", email: "race@cross-pod.test" }), "race@cross-pod.test"],
+        `INSERT INTO crm_outbox (event_type, payload, email_key, workspace_id, status, created_at)
+         VALUES ('demo', $1::jsonb, $2, $3, 'pending', now() - INTERVAL '2 minutes')`,
+        [
+          JSON.stringify({ source: "demo", email: "race@cross-pod.test" }),
+          "race@cross-pod.test",
+          TEST_WORKSPACE_ID,
+        ],
       );
       await pool.query(
-        `INSERT INTO crm_outbox (event_type, payload, email_key, status, created_at)
-         VALUES ('signup', $1::jsonb, $2, 'pending', now() - INTERVAL '1 minute')`,
-        [JSON.stringify({ source: "signup", email: "race@cross-pod.test" }), "race@cross-pod.test"],
+        `INSERT INTO crm_outbox (event_type, payload, email_key, workspace_id, status, created_at)
+         VALUES ('signup', $1::jsonb, $2, $3, 'pending', now() - INTERVAL '1 minute')`,
+        [
+          JSON.stringify({ source: "signup", email: "race@cross-pod.test" }),
+          "race@cross-pod.test",
+          TEST_WORKSPACE_ID,
+        ],
       );
 
       // Each "pod" is its own pool with size 1 — guarantees a single
@@ -734,16 +749,19 @@ describeIfPg("lead-outbox (real Postgres)", () => {
 
       // R1: demo, older, in retry cooldown — pending with retry_after
       // 1 hour in the future. Falls out of `claimable` via the
-      // due-time filter, but is still non-terminal.
+      // due-time filter, but is still non-terminal. Same workspace as
+      // R2 (enq below) is required post-#2849 codex C3 — the NOT
+      // EXISTS leapfrog gate scopes by (workspace_id, email_key).
       await pool.query(
         `INSERT INTO crm_outbox
-           (event_type, payload, email_key, status, attempts, retry_after, created_at)
+           (event_type, payload, email_key, workspace_id, status, attempts, retry_after, created_at)
          VALUES
-           ('demo', $1::jsonb, $2, 'pending', 1, now() + INTERVAL '1 hour',
+           ('demo', $1::jsonb, $2, $3, 'pending', 1, now() + INTERVAL '1 hour',
             now() - INTERVAL '5 minutes')`,
         [
           JSON.stringify({ source: "demo", email: "cooldown@leapfrog.test", ip: "203.0.113.50" }),
           "cooldown@leapfrog.test",
+          TEST_WORKSPACE_ID,
         ],
       );
       // R2: signup, newer, fresh — would dispatch first under the

--- a/packages/api/src/lib/lead-outbox/__tests__/outbox-pg.test.ts
+++ b/packages/api/src/lib/lead-outbox/__tests__/outbox-pg.test.ts
@@ -23,6 +23,31 @@ import {
   type OutboxDispatcher,
 } from "../outbox";
 
+/**
+ * Default workspace_id stamped on test fixtures (#2849). The PG-side
+ * column has DEFAULT '<atlas-operator>', but the application
+ * `enqueue()` rejects an empty workspaceId, so callers must pass
+ * something. This constant is the test-only stand-in for the runtime
+ * SaaS operator id.
+ */
+const TEST_WORKSPACE_ID = "ws-test";
+
+/**
+ * Wrapper around `enqueue` that defaults `workspaceId`. Mirrors the
+ * helper in `outbox.test.ts` so the two test files stay structurally
+ * aligned.
+ */
+async function enq(
+  db: OutboxDB,
+  args: { eventType: string; payload: Record<string, unknown>; workspaceId?: string },
+): Promise<string> {
+  return enqueue(db, {
+    eventType: args.eventType,
+    payload: args.payload,
+    workspaceId: args.workspaceId ?? TEST_WORKSPACE_ID,
+  });
+}
+
 const TEST_DB_URL = process.env.TEST_DATABASE_URL;
 const describeIfPg = TEST_DB_URL ? describe : describe.skip;
 
@@ -72,7 +97,7 @@ describeIfPg("lead-outbox (real Postgres)", () => {
     async () => {
       await truncateOutbox();
       const db = dbFor();
-      const id = await enqueue(db, {
+      const id = await enq(db, {
         eventType: "demo",
         payload: { source: "demo", email: "ok@happy.test" },
       });
@@ -102,7 +127,7 @@ describeIfPg("lead-outbox (real Postgres)", () => {
     async () => {
       await truncateOutbox();
       const db = dbFor();
-      const id = await enqueue(db, {
+      const id = await enq(db, {
         eventType: "demo",
         payload: { source: "demo", email: "401@dead.test" },
       });
@@ -129,7 +154,7 @@ describeIfPg("lead-outbox (real Postgres)", () => {
     async () => {
       await truncateOutbox();
       const db = dbFor();
-      const id = await enqueue(db, {
+      const id = await enq(db, {
         eventType: "demo",
         payload: { source: "demo", email: "503@retry.test" },
       });
@@ -242,7 +267,7 @@ describeIfPg("lead-outbox (real Postgres)", () => {
     async () => {
       await truncateOutbox();
       const db = dbFor();
-      const id = await enqueue(db, {
+      const id = await enq(db, {
         eventType: "demo",
         payload: { source: "demo", email: "stranded@recover.test" },
       });
@@ -327,7 +352,7 @@ describeIfPg("lead-outbox (real Postgres)", () => {
     async () => {
       await truncateOutbox();
       const db = dbFor();
-      await enqueue(db, {
+      await enq(db, {
         eventType: "demo",
         payload: { source: "demo", email: "race@test" },
       });
@@ -400,7 +425,7 @@ describeIfPg("lead-outbox (real Postgres)", () => {
     async () => {
       await truncateOutbox();
       const db = dbFor();
-      await enqueue(db, {
+      await enq(db, {
         eventType: "demo",
         payload: { source: "demo", email: "retry-after@test" },
       });
@@ -515,11 +540,11 @@ describeIfPg("lead-outbox (real Postgres)", () => {
       await truncateOutbox();
       const db = dbFor();
 
-      const demoId = await enqueue(db, {
+      const demoId = await enq(db, {
         eventType: "demo",
         payload: { source: "demo", email: "gworth@globexcorp.com", ip: "203.0.113.30" },
       });
-      const signupId = await enqueue(db, {
+      const signupId = await enq(db, {
         eventType: "signup",
         payload: { source: "signup", email: "gworth@globexcorp.com", name: "Greta Worth" },
       });
@@ -582,7 +607,7 @@ describeIfPg("lead-outbox (real Postgres)", () => {
         ],
       );
       // Newer pending row for the same email.
-      await enqueue(db, {
+      await enq(db, {
         eventType: "signup",
         payload: { source: "signup", email: "stuck@example.test", name: "Stuck User" },
       });
@@ -607,10 +632,10 @@ describeIfPg("lead-outbox (real Postgres)", () => {
       const db = dbFor();
 
       // Four distinct emails — all should claim in one tick.
-      await enqueue(db, { eventType: "demo", payload: { source: "demo", email: "a1@example.test" } });
-      await enqueue(db, { eventType: "demo", payload: { source: "demo", email: "a2@example.test" } });
-      await enqueue(db, { eventType: "demo", payload: { source: "demo", email: "a3@example.test" } });
-      await enqueue(db, { eventType: "demo", payload: { source: "demo", email: "a4@example.test" } });
+      await enq(db, { eventType: "demo", payload: { source: "demo", email: "a1@example.test" } });
+      await enq(db, { eventType: "demo", payload: { source: "demo", email: "a2@example.test" } });
+      await enq(db, { eventType: "demo", payload: { source: "demo", email: "a3@example.test" } });
+      await enq(db, { eventType: "demo", payload: { source: "demo", email: "a4@example.test" } });
 
       const dispatcher: OutboxDispatcher = async () => ({ kind: "ok" });
       const result = await flushBatch(db, dispatcher, 50);
@@ -723,7 +748,7 @@ describeIfPg("lead-outbox (real Postgres)", () => {
       );
       // R2: signup, newer, fresh — would dispatch first under the
       // pre-fix gate that only excluded `in_flight` siblings.
-      const signupId = await enqueue(db, {
+      const signupId = await enq(db, {
         eventType: "signup",
         payload: { source: "signup", email: "cooldown@leapfrog.test", name: "Late Arrival" },
       });

--- a/packages/api/src/lib/lead-outbox/__tests__/outbox.test.ts
+++ b/packages/api/src/lib/lead-outbox/__tests__/outbox.test.ts
@@ -53,6 +53,7 @@ type Row = {
   event_type: string;
   payload: unknown;
   email_key: string | null;
+  workspace_id: string;
   status: "pending" | "in_flight" | "done" | "dead";
   attempts: number;
   last_error: string | null;
@@ -63,6 +64,34 @@ type Row = {
   created_at: number;
   processed_at: number | null;
 };
+
+/**
+ * Default workspace_id stamped on test fixtures via the {@link enq}
+ * helper below (#2849). Most tests in this file exercise outbox
+ * lifecycle behaviour (claim ordering, retry, sub-step idempotency)
+ * and don't care which workspace owns the row — the helper threads
+ * this constant into `enqueue` so tests stay terse. Tests that
+ * specifically exercise per-tenant routing branch on a different
+ * `workspaceId`.
+ */
+const TEST_WORKSPACE_ID = "ws-test";
+
+/**
+ * Thin wrapper around `enqueue` that defaults `workspaceId` to
+ * `TEST_WORKSPACE_ID`. Use the unwrapped `enqueue` directly when the
+ * test needs to assert behaviour for an empty or per-tenant workspace
+ * id.
+ */
+async function enq(
+  db: OutboxDB,
+  args: { eventType: string; payload: Record<string, unknown>; workspaceId?: string },
+): Promise<string> {
+  return enqueue(db, {
+    eventType: args.eventType,
+    payload: args.payload,
+    workspaceId: args.workspaceId ?? TEST_WORKSPACE_ID,
+  });
+}
 
 class FakeOutboxDB implements OutboxDB {
   rows: Row[] = [];
@@ -96,11 +125,17 @@ class FakeOutboxDB implements OutboxDB {
       // callers that haven't been updated pass `undefined` and fall
       // through to NULL — matching the SQL column's nullability.
       const emailKey = typeof p[2] === "string" ? p[2] : null;
+      // 0106 added workspace_id as a 4th positional parameter. Required
+      // at the application layer (`enqueue` throws on empty) — the
+      // fake mirrors that by stamping whatever the caller passed; the
+      // helper above defaults to `TEST_WORKSPACE_ID`.
+      const workspaceId = typeof p[3] === "string" ? p[3] : "";
       this.rows.push({
         id,
         event_type: String(p[0]),
         payload: JSON.parse(String(p[1])),
         email_key: emailKey,
+        workspace_id: workspaceId,
         status: "pending",
         attempts: 0,
         last_error: null,
@@ -176,6 +211,7 @@ class FakeOutboxDB implements OutboxDB {
         event_type: r.event_type,
         payload: r.payload,
         attempts: r.attempts,
+        workspace_id: r.workspace_id,
         twenty_person_id: r.twenty_person_id,
         twenty_note_id: r.twenty_note_id,
       })) as unknown as T[];
@@ -278,7 +314,7 @@ beforeEach(() => {
 
 describe("enqueue", () => {
   test("inserts a pending row and returns its id", async () => {
-    const id = await enqueue(db, {
+    const id = await enq(db, {
       eventType: "demo",
       payload: { source: "demo", email: "a@b.test" },
     });
@@ -290,13 +326,84 @@ describe("enqueue", () => {
       attempts: 0,
       twenty_person_id: null,
       twenty_note_id: null,
+      workspace_id: TEST_WORKSPACE_ID,
     });
+  });
+
+  test("stamps workspace_id on every row (#2849)", async () => {
+    // AC: rows MUST carry a non-empty workspace_id at enqueue time so
+    // the dispatcher's per-row routing key is deterministic. The
+    // helper passes TEST_WORKSPACE_ID; an explicit override on
+    // `enq` (here for a hypothetical per-tenant install) lands a
+    // distinct value.
+    await enq(db, {
+      eventType: "demo",
+      payload: { source: "demo", email: "operator@demo.test" },
+    });
+    await enq(db, {
+      eventType: "demo",
+      payload: { source: "demo", email: "tenant@demo.test" },
+      workspaceId: "ws-tenant-A",
+    });
+    expect(db.rows[0].workspace_id).toBe(TEST_WORKSPACE_ID);
+    expect(db.rows[1].workspace_id).toBe("ws-tenant-A");
+  });
+
+  test("captures workspace_id for all four operator event sources (#2849 AC)", async () => {
+    // The AC calls out demo / signup / sales-form / conversion as the
+    // four event sources whose enqueue path must capture workspace_id.
+    // All four currently route to Atlas's operator pipeline, so they
+    // share TEST_WORKSPACE_ID — but the column being present is the
+    // load-bearing invariant (a future per-tenant variant lands here
+    // with a different value without a schema change).
+    await enq(db, {
+      eventType: "demo",
+      payload: { source: "demo", email: "demo@event.test" },
+    });
+    await enq(db, {
+      eventType: "signup",
+      payload: { source: "signup", email: "signup@event.test", name: "Sam" },
+    });
+    await enq(db, {
+      eventType: "sales-form",
+      payload: {
+        source: "sales-form",
+        email: "sales@event.test",
+        name: "Sales Form",
+        company: "Co",
+        planInterest: "team",
+        message: "msg",
+      },
+    });
+    await enq(db, {
+      eventType: "stamp-conversion",
+      payload: {
+        source: "conversion",
+        email: "convert@event.test",
+        stripeCustomerId: "cus_x",
+      },
+    });
+    expect(db.rows).toHaveLength(4);
+    for (const row of db.rows) {
+      expect(row.workspace_id).toBe(TEST_WORKSPACE_ID);
+    }
+  });
+
+  test("rejects an empty workspaceId at the seam (#2849)", async () => {
+    await expect(
+      enqueue(db, {
+        eventType: "demo",
+        payload: { source: "demo", email: "x@empty.test" },
+        workspaceId: "",
+      }),
+    ).rejects.toThrow(/workspaceId must be non-empty/);
+    expect(db.rows).toHaveLength(0);
   });
 });
 
 describe("flushBatch — claim & dispatch", () => {
   test("dispatches OK → row marked done with twenty_person_id persisted inside dispatcher", async () => {
-    await enqueue(db, { eventType: "demo", payload: { source: "demo", email: "x@y.test" } });
+    await enq(db, { eventType: "demo", payload: { source: "demo", email: "x@y.test" } });
 
     const dispatcher: OutboxDispatcher = async (row, persist) => {
       expect(row.twentyPersonId).toBeNull();
@@ -311,7 +418,7 @@ describe("flushBatch — claim & dispatch", () => {
   });
 
   test("transient failure → row reverts to pending with last_error stamped", async () => {
-    await enqueue(db, { eventType: "demo", payload: { source: "demo", email: "fail@y.test" } });
+    await enq(db, { eventType: "demo", payload: { source: "demo", email: "fail@y.test" } });
     const dispatcher: OutboxDispatcher = async () => ({
       kind: "transient",
       message: "upstream 503",
@@ -324,7 +431,7 @@ describe("flushBatch — claim & dispatch", () => {
   });
 
   test("permanent failure → row immediately dead with last_error", async () => {
-    await enqueue(db, { eventType: "demo", payload: { source: "demo", email: "dead@y.test" } });
+    await enq(db, { eventType: "demo", payload: { source: "demo", email: "dead@y.test" } });
     const dispatcher: OutboxDispatcher = async () => ({
       kind: "permanent",
       message: "401 Unauthorized",
@@ -335,7 +442,7 @@ describe("flushBatch — claim & dispatch", () => {
   });
 
   test("dispatcher that throws is treated as transient, NOT dead", async () => {
-    await enqueue(db, { eventType: "demo", payload: { source: "demo", email: "throw@y.test" } });
+    await enq(db, { eventType: "demo", payload: { source: "demo", email: "throw@y.test" } });
     const dispatcher: OutboxDispatcher = async () => {
       throw new Error("dispatcher bug");
     };
@@ -353,7 +460,7 @@ describe("sub-step idempotency", () => {
     // Simulate the partial-success crash recovery path: a previous
     // attempt called upsertPerson and persisted the ID before the
     // process died. The next flush MUST NOT call upsertPerson again.
-    await enqueue(db, { eventType: "demo", payload: { source: "demo", email: "replay@y.test" } });
+    await enq(db, { eventType: "demo", payload: { source: "demo", email: "replay@y.test" } });
     db.rows[0].twenty_person_id = "person_already_done";
 
     let upsertCalls = 0;
@@ -372,7 +479,7 @@ describe("sub-step idempotency", () => {
   });
 
   test("upsertPerson called exactly once across retries when twenty_person_id is set", async () => {
-    await enqueue(db, { eventType: "demo", payload: { source: "demo", email: "once@y.test" } });
+    await enq(db, { eventType: "demo", payload: { source: "demo", email: "once@y.test" } });
 
     let upsertCalls = 0;
     const dispatcher: OutboxDispatcher = async (row, persist) => {
@@ -408,7 +515,7 @@ describe("sub-step idempotency", () => {
 
 describe("retry budget exhaustion", () => {
   test("transient failure on the 6th attempt is dead-lettered", async () => {
-    await enqueue(db, { eventType: "demo", payload: { source: "demo", email: "budget@y.test" } });
+    await enq(db, { eventType: "demo", payload: { source: "demo", email: "budget@y.test" } });
     // Simulate 5 prior failed attempts so the next claim bumps attempts → 6.
     db.rows[0].attempts = 5;
 
@@ -428,7 +535,7 @@ describe("retry budget exhaustion", () => {
   });
 
   test("rows already at the dead threshold are not claimed at all", async () => {
-    await enqueue(db, { eventType: "demo", payload: { source: "demo", email: "skip@y.test" } });
+    await enq(db, { eventType: "demo", payload: { source: "demo", email: "skip@y.test" } });
     // attempts=6 means the WHERE filter excludes the row.
     db.rows[0].attempts = 6;
 
@@ -448,7 +555,7 @@ describe("retry budget exhaustion", () => {
 
 describe("concurrent flush behaviour", () => {
   test("blocked claim returns 0 rows and the dispatcher is never called", async () => {
-    await enqueue(db, { eventType: "demo", payload: { source: "demo", email: "blocked@y.test" } });
+    await enq(db, { eventType: "demo", payload: { source: "demo", email: "blocked@y.test" } });
     db.claimBlocked = true;
 
     let calls = 0;
@@ -466,7 +573,7 @@ describe("concurrent flush behaviour", () => {
   });
 
   test("batchLimit=0 is a no-op without touching the DB", async () => {
-    await enqueue(db, { eventType: "demo", payload: { source: "demo", email: "x@y.test" } });
+    await enq(db, { eventType: "demo", payload: { source: "demo", email: "x@y.test" } });
     let calls = 0;
     const dispatcher: OutboxDispatcher = async () => {
       calls++;
@@ -494,11 +601,11 @@ describe("per-email serialization (#2870)", () => {
     // rows for the same email, demo enqueued first, signup second.
     // Pre-fix both would be claimed in one batch; post-fix the signup
     // waits for demo to land.
-    const demoId = await enqueue(db, {
+    const demoId = await enq(db, {
       eventType: "demo",
       payload: { source: "demo", email: "gworth@globexcorp.com", ip: "203.0.113.30" },
     });
-    const signupId = await enqueue(db, {
+    const signupId = await enq(db, {
       eventType: "signup",
       payload: { source: "signup", email: "gworth@globexcorp.com", name: "Greta Worth" },
     });
@@ -531,11 +638,11 @@ describe("per-email serialization (#2870)", () => {
     // the smoke run, indicating the two PATCHes raced. Post-fix the
     // .41 PATCH runs in tick 2 with .40 already committed in Twenty —
     // strictly sequential, no race possible.
-    const first = await enqueue(db, {
+    const first = await enq(db, {
       eventType: "demo",
       payload: { source: "demo", email: "msdyson@cyberdynesys.com", ip: "203.0.113.40" },
     });
-    const second = await enqueue(db, {
+    const second = await enq(db, {
       eventType: "demo",
       payload: { source: "demo", email: "msdyson@cyberdynesys.com", ip: "203.0.113.41" },
     });
@@ -562,10 +669,10 @@ describe("per-email serialization (#2870)", () => {
     // Per-email serialization must NOT serialize across distinct
     // emails — a workspace with 1000 leads-per-minute should still
     // drain at the same rate as before the fix.
-    await enqueue(db, { eventType: "demo", payload: { source: "demo", email: "a1@example.test" } });
-    await enqueue(db, { eventType: "demo", payload: { source: "demo", email: "a2@example.test" } });
-    await enqueue(db, { eventType: "demo", payload: { source: "demo", email: "a3@example.test" } });
-    await enqueue(db, { eventType: "demo", payload: { source: "demo", email: "a4@example.test" } });
+    await enq(db, { eventType: "demo", payload: { source: "demo", email: "a1@example.test" } });
+    await enq(db, { eventType: "demo", payload: { source: "demo", email: "a2@example.test" } });
+    await enq(db, { eventType: "demo", payload: { source: "demo", email: "a3@example.test" } });
+    await enq(db, { eventType: "demo", payload: { source: "demo", email: "a4@example.test" } });
 
     const dispatcher: OutboxDispatcher = async () => ({ kind: "ok" });
     const result = await flushBatch(db, dispatcher, 50);
@@ -577,7 +684,7 @@ describe("per-email serialization (#2870)", () => {
     // The cross-tick / cross-pod safety case: a row already in_flight
     // (e.g. claimed by a sibling pod that hasn't finished dispatching)
     // must block any newer same-email row from being claimed.
-    await enqueue(db, {
+    await enq(db, {
       eventType: "demo",
       payload: { source: "demo", email: "stuck@example.test" },
     });
@@ -587,7 +694,7 @@ describe("per-email serialization (#2870)", () => {
     db.rows[0].claimed_at = Date.now();
 
     // Newer row for the same email lands while the sibling is mid-flight.
-    await enqueue(db, {
+    await enq(db, {
       eventType: "demo",
       payload: { source: "demo", email: "stuck@example.test" },
     });
@@ -609,8 +716,8 @@ describe("per-email serialization (#2870)", () => {
     // a missing email field) must NOT get grouped together by the
     // DISTINCT ON in CLAIM_SQL — each NULL row is its own dedup
     // group via `COALESCE(email_key, id::text)`.
-    await enqueue(db, { eventType: "system", payload: { source: "system", op: "ping" } });
-    await enqueue(db, { eventType: "system", payload: { source: "system", op: "pong" } });
+    await enq(db, { eventType: "system", payload: { source: "system", op: "ping" } });
+    await enq(db, { eventType: "system", payload: { source: "system", op: "pong" } });
     expect(db.rows[0].email_key).toBeNull();
     expect(db.rows[1].email_key).toBeNull();
 
@@ -626,11 +733,11 @@ describe("per-email serialization (#2870)", () => {
     // lead-normalizer's `.toLowerCase().trim()`). Without this a
     // payload-side typo (`gworth@globexcorp.com` vs `GWorth@globexcorp.com`)
     // would bypass per-email serialization.
-    await enqueue(db, {
+    await enq(db, {
       eventType: "demo",
       payload: { source: "demo", email: "  gworth@globexcorp.com  " },
     });
-    await enqueue(db, {
+    await enq(db, {
       eventType: "signup",
       payload: { source: "signup", email: "GWORTH@GlobexCorp.com" },
     });
@@ -653,7 +760,7 @@ describe("per-email serialization (#2870)", () => {
     // should still enqueue — but loud-log so operators can grep for
     // the silent-serialization-disabled signal before atlasFirstSource
     // flips weeks later.
-    await enqueue(db, {
+    await enq(db, {
       eventType: "demo",
       // Cast through unknown so the test exercises the runtime guard
       // rather than relying on a TS-narrowed payload type.
@@ -675,7 +782,7 @@ describe("per-email serialization (#2870)", () => {
     // gate must match the actual enqueued event_type so conversion
     // payloads with a missing email surface as silent-serialization-
     // disabled.
-    await enqueue(db, {
+    await enq(db, {
       eventType: "stamp-conversion",
       payload: { source: "conversion" } as Record<string, unknown>,
     });
@@ -690,7 +797,7 @@ describe("per-email serialization (#2870)", () => {
     // A future `system`/`telemetry` event_type whose payload is
     // intentionally not email-keyed must NOT trigger the warn-log,
     // otherwise the log becomes noise and operators learn to ignore it.
-    await enqueue(db, {
+    await enq(db, {
       eventType: "system",
       payload: { source: "system", op: "ping" },
     });
@@ -707,11 +814,11 @@ describe("per-email serialization (#2870)", () => {
     // sibling gate, tick 1 dedupes via DISTINCT ON but tick 2 sees a
     // same-`created_at` pending sibling as not-older and claims a
     // second row while the first is still in_flight.
-    await enqueue(db, {
+    await enq(db, {
       eventType: "demo",
       payload: { source: "demo", email: "tied@example.test" },
     });
-    await enqueue(db, {
+    await enq(db, {
       eventType: "demo",
       payload: { source: "demo", email: "tied@example.test" },
     });
@@ -748,11 +855,11 @@ describe("per-email serialization (#2870)", () => {
     // in retry cooldown) waited. A new pod with the fixed CLAIM_SQL
     // must not then claim R1 — both would dispatch concurrently with
     // R2's still-in-flight upsert, flipping atlasLastSource.
-    await enqueue(db, {
+    await enq(db, {
       eventType: "demo",
       payload: { source: "demo", email: "rolling@hotfix.test", ip: "203.0.113.60" },
     });
-    await enqueue(db, {
+    await enq(db, {
       eventType: "demo",
       payload: { source: "demo", email: "rolling@hotfix.test", ip: "203.0.113.61" },
     });
@@ -777,8 +884,8 @@ describe("per-email serialization (#2870)", () => {
 
 describe("recoverInFlight", () => {
   test("resets stale in_flight rows to pending and returns the per-bucket counts", async () => {
-    await enqueue(db, { eventType: "demo", payload: { source: "demo", email: "a@y.test" } });
-    await enqueue(db, { eventType: "demo", payload: { source: "demo", email: "b@y.test" } });
+    await enq(db, { eventType: "demo", payload: { source: "demo", email: "a@y.test" } });
+    await enq(db, { eventType: "demo", payload: { source: "demo", email: "b@y.test" } });
     db.rows[0].status = "in_flight";
     db.rows[0].claimed_at = null; // null claimed_at counts as stale
     db.rows[1].status = "in_flight";
@@ -791,7 +898,7 @@ describe("recoverInFlight", () => {
   });
 
   test("recently-claimed in_flight row is NOT reset (multi-pod safety)", async () => {
-    await enqueue(db, { eventType: "demo", payload: { source: "demo", email: "fresh@y.test" } });
+    await enq(db, { eventType: "demo", payload: { source: "demo", email: "fresh@y.test" } });
     db.rows[0].status = "in_flight";
     db.rows[0].claimed_at = Date.now() - 1_000; // claimed 1s ago — within threshold
 
@@ -801,7 +908,7 @@ describe("recoverInFlight", () => {
   });
 
   test("exhausted in_flight rows are dead-lettered (not reset to pending)", async () => {
-    await enqueue(db, { eventType: "demo", payload: { source: "demo", email: "exhausted@y.test" } });
+    await enq(db, { eventType: "demo", payload: { source: "demo", email: "exhausted@y.test" } });
     db.rows[0].status = "in_flight";
     db.rows[0].attempts = 6;
     db.rows[0].claimed_at = Date.now() - 60_000;
@@ -813,9 +920,9 @@ describe("recoverInFlight", () => {
   });
 
   test("done / dead / pending rows are untouched", async () => {
-    await enqueue(db, { eventType: "demo", payload: { source: "demo", email: "p@y.test" } });
-    await enqueue(db, { eventType: "demo", payload: { source: "demo", email: "d@y.test" } });
-    await enqueue(db, { eventType: "demo", payload: { source: "demo", email: "x@y.test" } });
+    await enq(db, { eventType: "demo", payload: { source: "demo", email: "p@y.test" } });
+    await enq(db, { eventType: "demo", payload: { source: "demo", email: "d@y.test" } });
+    await enq(db, { eventType: "demo", payload: { source: "demo", email: "x@y.test" } });
     db.rows[1].status = "done";
     db.rows[2].status = "dead";
 
@@ -831,8 +938,8 @@ describe("recoverInFlight", () => {
 
 describe("persist helper binding", () => {
   test("setTwentyPersonId / setTwentyNoteId write the correct row id", async () => {
-    await enqueue(db, { eventType: "demo", payload: { source: "demo", email: "a@y.test" } });
-    await enqueue(db, { eventType: "demo", payload: { source: "demo", email: "b@y.test" } });
+    await enq(db, { eventType: "demo", payload: { source: "demo", email: "a@y.test" } });
+    await enq(db, { eventType: "demo", payload: { source: "demo", email: "b@y.test" } });
 
     let nthCall = 0;
     const dispatcher: OutboxDispatcher = async (
@@ -859,7 +966,7 @@ describe("persist helper binding", () => {
 
 describe("Retry-After plumbing", () => {
   test("transient outcome with retryAfterMs stamps absolute retry_after on the row", async () => {
-    await enqueue(db, { eventType: "demo", payload: { source: "demo", email: "rate@y.test" } });
+    await enq(db, { eventType: "demo", payload: { source: "demo", email: "rate@y.test" } });
     const before = Date.now();
     const dispatcher: OutboxDispatcher = async () => ({
       kind: "transient",
@@ -877,7 +984,7 @@ describe("Retry-After plumbing", () => {
   });
 
   test("transient outcome without retryAfterMs clears any prior retry_after", async () => {
-    await enqueue(db, { eventType: "demo", payload: { source: "demo", email: "clr@y.test" } });
+    await enq(db, { eventType: "demo", payload: { source: "demo", email: "clr@y.test" } });
     db.rows[0].retry_after = Date.now() + 30_000;
 
     const dispatcher: OutboxDispatcher = async () => ({
@@ -910,7 +1017,7 @@ describe("Retry-After plumbing", () => {
 
 describe("dead-letter logging (AC #3)", () => {
   test("permanent dead-letter emits a structured log with rowId + last_error", async () => {
-    await enqueue(db, { eventType: "demo", payload: { source: "demo", email: "dead-log@y.test" } });
+    await enq(db, { eventType: "demo", payload: { source: "demo", email: "dead-log@y.test" } });
     const dispatcher: OutboxDispatcher = async () => ({
       kind: "permanent",
       message: "401 unauthorised",
@@ -927,7 +1034,7 @@ describe("dead-letter logging (AC #3)", () => {
   });
 
   test("retry-budget exhaustion emits a structured log labelled dead_letter_exhausted", async () => {
-    await enqueue(db, { eventType: "demo", payload: { source: "demo", email: "budget@y.test" } });
+    await enq(db, { eventType: "demo", payload: { source: "demo", email: "budget@y.test" } });
     db.rows[0].attempts = 5;
     const dispatcher: OutboxDispatcher = async () => ({
       kind: "transient",
@@ -944,7 +1051,7 @@ describe("dead-letter logging (AC #3)", () => {
   });
 
   test("transient (within budget) emits warn with retryAfterMs surfaced", async () => {
-    await enqueue(db, { eventType: "demo", payload: { source: "demo", email: "tr@y.test" } });
+    await enq(db, { eventType: "demo", payload: { source: "demo", email: "tr@y.test" } });
     const dispatcher: OutboxDispatcher = async () => ({
       kind: "transient",
       message: "503",
@@ -969,7 +1076,7 @@ describe("end-to-end restart (AC #7)", () => {
     // crashed before reaching MARK_DONE. recoverInFlight on the new
     // pod's boot must flip it to pending; the very next flushBatch
     // must then claim and complete it.
-    await enqueue(db, { eventType: "demo", payload: { source: "demo", email: "e2e@y.test" } });
+    await enq(db, { eventType: "demo", payload: { source: "demo", email: "e2e@y.test" } });
     db.rows[0].status = "in_flight";
     db.rows[0].attempts = 1;
     db.rows[0].twenty_person_id = "person-from-previous-life";
@@ -1003,7 +1110,7 @@ describe("terminal-status UPDATE retry", () => {
   test("MARK_DONE_SQL retries once after a transient pg failure, then succeeds", async () => {
     // Wrap the FakeOutboxDB to fail the first MARK_DONE call and let
     // the second through.
-    await enqueue(db, { eventType: "demo", payload: { source: "demo", email: "ok@y.test" } });
+    await enq(db, { eventType: "demo", payload: { source: "demo", email: "ok@y.test" } });
     let firstMarkDoneSeen = false;
     const wrappedDb: OutboxDB = {
       query: async <T extends Record<string, unknown>>(

--- a/packages/api/src/lib/lead-outbox/outbox.ts
+++ b/packages/api/src/lib/lead-outbox/outbox.ts
@@ -1,6 +1,5 @@
 /**
- * Lead outbox — durable queue for SaaS CRM lead dispatches (#2729,
- * slice 2 of 1.6.0).
+ * Lead outbox — durable queue for SaaS CRM lead dispatches (#2729).
  *
  * This module is generic over the dispatcher: it owns the queue
  * mechanics (enqueue, claim, sub-step persistence, backoff, dead-letter,
@@ -80,7 +79,7 @@ export interface EnqueueInput {
    * workspace id consult `twenty_integrations` for that workspace's
    * per-tenant credentials. The required-not-empty shape (rejected at
    * enqueue) prevents the silent "NULL workspace_id → dispatch wherever
-   * the boot config points" trap that the old `findLatestTwentyDb`
+   * the boot config points" trap that the old `findLatestTwentyDbCredentials`
    * helper enabled before #2850.
    */
   readonly workspaceId: string;
@@ -115,10 +114,10 @@ export interface ClaimedOutboxRow {
  * Sub-step persistence helpers passed to the dispatcher. Each callback
  * does a single targeted UPDATE — the writes happen inline so the next
  * claim of this row (on a retry) sees the populated ID and can skip.
+ * See `ClaimedOutboxRow.twentyPersonId`'s `TODO(#2729-followup)` for
+ * the second-SaaS-CRM generalisation plan.
  */
 export interface OutboxPersistHelpers {
-  // TODO(#2729-followup): generalise to `setResourceId(key, id)` if a
-  // second SaaS CRM ever ships. See ClaimedOutboxRow for context.
   setTwentyPersonId(id: string): Promise<void>;
   setTwentyNoteId(id: string): Promise<void>;
 }
@@ -198,58 +197,71 @@ const ENQUEUE_SQL = `
  * keeps a long upstream-requested delay from being clobbered by an
  * eager tier value (e.g. 30s tier-1 vs `Retry-After: 3600`).
  *
- * Per-email serialization (#2870): a row is claimable only if NO
- * blocking same-email sibling exists. Three layers cooperate:
+ * Per-`(workspace_id, email_key)` serialization (#2870 + #2849):
+ * a row is claimable only if NO blocking same-(workspace,email)
+ * sibling exists. The workspace dimension is load-bearing post-
+ * #2849: tenant A's `alice@example.com` and tenant B's
+ * `alice@example.com` dispatch to DIFFERENT Twenty instances and
+ * have independent idempotency. Without the workspace scoping
+ * (codex C3), tenant A's row would block tenant B's row and
+ * head-of-line-stall an unrelated CRM. Three layers cooperate:
  *
- *   1. **NOT EXISTS gate** — splits the predicate by sibling status:
- *      * Any `in_flight` same-email row blocks unconditionally
- *        (regardless of `created_at`). A rolling hotfix or manual
- *        recovery can leave a newer `in_flight` row alongside an
- *        older `pending` row — without the age-independent in_flight
- *        check, the older `pending` row would dispatch concurrently
- *        with the newer in_flight one.
- *      * Any `pending` same-email row blocks only if it's strictly
- *        older by `(created_at, id)`. The `id` tie-break is what
- *        serializes bulk-INSERT rows that share `created_at` (e.g.
- *        the historic-leads backfill path that produces many rows in
- *        one statement with one `now()` timestamp); without it, the
- *        next tick would see a same-`created_at` sibling as not-older
- *        and claim a second row while the first is still in_flight.
+ *   1. **NOT EXISTS gate** — scoped to the same `workspace_id`,
+ *      splits the predicate by sibling status:
+ *      * Any `in_flight` same-(workspace,email) row blocks
+ *        unconditionally (regardless of `created_at`). A rolling
+ *        hotfix or manual recovery can leave a newer `in_flight`
+ *        row alongside an older `pending` row — without the
+ *        age-independent in_flight check, the older `pending` row
+ *        would dispatch concurrently with the newer in_flight one.
+ *      * Any `pending` same-(workspace,email) row blocks only if
+ *        it's strictly older by `(created_at, id)`. The `id`
+ *        tie-break is what serializes bulk-INSERT rows that share
+ *        `created_at` (e.g. the historic-leads backfill path that
+ *        produces many rows in one statement with one `now()`
+ *        timestamp); without it, the next tick would see a same-
+ *        `created_at` sibling as not-older and claim a second row
+ *        while the first is still in_flight.
  *      The age check on `pending` is what closes the retry-cooldown
  *      leapfrog: R1 (older, in transient-fail backoff) is filtered
  *      out of `claimable` by the due-time check, but its presence as
  *      an older pending sibling still blocks R2 (newer, fresh) from
  *      flipping atlasFirstSource ahead of it.
- *   2. **Advisory xact lock per email_key** — `pg_try_advisory_xact_lock`
- *      gives us serialization across concurrent transactions that
- *      MVCC alone can't provide. Without it, two flusher pods could
- *      each see the other's pre-commit UPDATE as invisible, both
- *      pass the NOT EXISTS gate at lookup time, and both end up with
- *      different same-email rows in_flight (each pod skips the
+ *   2. **Advisory xact lock per `(workspace_id, email_key)`** —
+ *      `pg_try_advisory_xact_lock` gives us serialization across
+ *      concurrent transactions that MVCC alone can't provide.
+ *      Without it, two flusher pods could each see the other's
+ *      pre-commit UPDATE as invisible, both pass the NOT EXISTS
+ *      gate at lookup time, and both end up with different
+ *      same-(workspace,email) rows in_flight (each pod skips the
  *      other's locked row via SKIP LOCKED, then claims a different
- *      sibling). The advisory lock is transaction-scoped: held until
- *      commit, then released, so the next tick re-acquires cleanly.
- *      NULL email_key rows skip the lock (no per-row serialization
- *      needed — those are their own dedup groups).
+ *      sibling). The advisory lock is transaction-scoped: held
+ *      until commit, then released, so the next tick re-acquires
+ *      cleanly. The lock key is
+ *      `hashtext(workspace_id || ':' || email_key)` so the lock
+ *      namespace is per-(workspace,email), not per-email — preserves
+ *      cross-tenant independence. NULL email_key rows skip the lock
+ *      (no per-row serialization needed — those are their own dedup
+ *      groups).
  *   3. **DISTINCT ON dedupe (intra-statement)** — belt-and-suspenders:
  *      within a single tick the NOT EXISTS gate already keeps only
- *      the earliest same-email row, but DISTINCT ON formalizes the
- *      "one row per email_key per batch" contract for any future
- *      WHERE-clause regression. `dedup_key` is
- *      `COALESCE(email_key, id::text)` so NULL-email_key rows fall
- *      back to their own id and dispatch independently. The
- *      `id` tie-breaker on `ORDER BY` makes claim order deterministic
- *      when two rows share `created_at` (e.g. bulk INSERT).
+ *      the earliest same-(workspace,email) row, but DISTINCT ON
+ *      formalizes the "one row per (workspace, email_key) per batch"
+ *      contract for any future WHERE-clause regression. The dedupe
+ *      key is `(workspace_id, COALESCE(email_key, id::text))` so
+ *      NULL-email_key rows fall back to their own id (each in its
+ *      own group, dispatched independently). The `id` tie-breaker
+ *      on `ORDER BY` makes claim order deterministic when two rows
+ *      share `created_at` (e.g. bulk INSERT).
  *
  * The outer LIMIT applies to the deduped set, not the raw candidate
  * set, so a workspace with a backlog of same-email events drains one
- * event per email per tick rather than starving other emails behind
- * it.
+ * event per (workspace, email) per tick rather than starving siblings.
  *
  * Advisory-lock namespace: the first arg `2870` (the issue number)
- * is the lock class; the second arg is `hashtext(email_key)`. The
- * two-key variant avoids collisions with any other advisory locks
- * the codebase may take elsewhere.
+ * is the lock class; the second arg is the per-(workspace,email)
+ * hash. The two-key variant avoids collisions with any other
+ * advisory locks the codebase may take elsewhere.
  */
 const CLAIM_SQL = `
   UPDATE crm_outbox
@@ -258,7 +270,7 @@ const CLAIM_SQL = `
       claimed_at = now()
   WHERE id IN (
     WITH claimable AS (
-      SELECT id, email_key, created_at FROM crm_outbox
+      SELECT id, workspace_id, email_key, created_at FROM crm_outbox
       WHERE status = 'pending'
         AND attempts < ${DEAD_AFTER_ATTEMPTS}
         AND COALESCE(retry_after, created_at + (${CLAIM_DELAY_SQL})) <= now()
@@ -266,6 +278,7 @@ const CLAIM_SQL = `
           SELECT 1 FROM crm_outbox o2
           WHERE o2.email_key IS NOT NULL
             AND o2.email_key = crm_outbox.email_key
+            AND o2.workspace_id = crm_outbox.workspace_id
             AND o2.id <> crm_outbox.id
             AND (
               o2.status = 'in_flight'
@@ -277,15 +290,19 @@ const CLAIM_SQL = `
         )
         AND (
           email_key IS NULL
-          OR pg_try_advisory_xact_lock(2870, hashtext(email_key))
+          OR pg_try_advisory_xact_lock(
+               2870,
+               hashtext(workspace_id || ':' || email_key)
+             )
         )
       ORDER BY created_at, id
       FOR UPDATE SKIP LOCKED
     ),
     deduped AS (
-      SELECT DISTINCT ON (COALESCE(email_key, id::text)) id, created_at
+      SELECT DISTINCT ON (workspace_id, COALESCE(email_key, id::text))
+             id, created_at
       FROM claimable
-      ORDER BY COALESCE(email_key, id::text), created_at, id
+      ORDER BY workspace_id, COALESCE(email_key, id::text), created_at, id
     )
     SELECT id FROM deduped ORDER BY created_at, id LIMIT $1
   )
@@ -783,8 +800,8 @@ export const FLUSH_BATCH_LIMIT = 50;
 
 /**
  * Flusher region gate. Default `true` — every API instance that has
- * `SaasCrm.available === true` and an internal DB runs the flusher,
- * which preserves the pre-#2890 behavior.
+ * `SaasCrm.dispatcher !== null` and an internal DB runs the flusher,
+ * which preserves the pre-#2873 behavior.
  *
  * Set `ATLAS_CRM_OUTBOX_FLUSHER_ENABLED=false` on regional API pods
  * (api-eu / api-apac) whose internal DB has no source of `crm_outbox`

--- a/packages/api/src/lib/lead-outbox/outbox.ts
+++ b/packages/api/src/lib/lead-outbox/outbox.ts
@@ -70,6 +70,20 @@ export interface EnqueueInput {
   readonly eventType: string;
   /** Opaque payload the dispatcher knows how to interpret. */
   readonly payload: Record<string, unknown>;
+  /**
+   * Tenant attribution for per-row dispatch routing (#2849).
+   *
+   * The dispatcher in `ee/src/saas-crm/` reads this to decide which
+   * Twenty instance receives the row: rows tagged with the resolved
+   * operator workspace id (the SaaS lead-capture pipeline path) use
+   * Atlas's `TWENTY_API_KEY` env creds; rows tagged with a customer
+   * workspace id consult `twenty_integrations` for that workspace's
+   * per-tenant credentials. The required-not-empty shape (rejected at
+   * enqueue) prevents the silent "NULL workspace_id → dispatch wherever
+   * the boot config points" trap that the old `findLatestTwentyDb`
+   * helper enabled before #2850.
+   */
+  readonly workspaceId: string;
 }
 
 /**
@@ -84,6 +98,12 @@ export interface ClaimedOutboxRow {
   readonly eventType: string;
   readonly payload: unknown;
   readonly attempts: number;
+  /**
+   * Tenant attribution for per-row dispatch routing (#2849). The
+   * dispatcher branches on this to pick env creds (operator workspace)
+   * vs `twenty_integrations` row (per-tenant workspace).
+   */
+  readonly workspaceId: string;
   // TODO(#2729-followup): rename to a generic `resourceIds` record if a
   // second SaaS CRM ever ships — the Twenty-specific naming leaks
   // vendor specifics into the otherwise-generic outbox surface.
@@ -156,8 +176,8 @@ export interface FlushResult {
 // ─────────────────────────────────────────────────────────────────────
 
 const ENQUEUE_SQL = `
-  INSERT INTO crm_outbox (event_type, payload, email_key, status)
-  VALUES ($1, $2::jsonb, $3, 'pending')
+  INSERT INTO crm_outbox (event_type, payload, email_key, workspace_id, status)
+  VALUES ($1, $2::jsonb, $3, $4, 'pending')
   RETURNING id
 `;
 
@@ -269,7 +289,7 @@ const CLAIM_SQL = `
     )
     SELECT id FROM deduped ORDER BY created_at, id LIMIT $1
   )
-  RETURNING id, event_type, payload, attempts, twenty_person_id, twenty_note_id
+  RETURNING id, event_type, payload, attempts, workspace_id, twenty_person_id, twenty_note_id
 `;
 
 const PERSIST_PERSON_ID_SQL = `
@@ -404,6 +424,19 @@ export async function enqueue(
   db: OutboxDB,
   input: EnqueueInput,
 ): Promise<string> {
+  // Fail loud on an empty workspace_id. The migration enforces NOT NULL
+  // at the column level (0106), but Postgres' empty-string-vs-NULL
+  // distinction would let `""` through — and the dispatcher's routing
+  // key compares string-equal, so `""` would mismatch the operator id
+  // AND mismatch every real workspace id, silently dead-lettering the
+  // row. Reject at the seam.
+  if (input.workspaceId.length === 0) {
+    throw new Error(
+      "crm_outbox enqueue: workspaceId must be non-empty " +
+        "(operator pipeline passes the resolved operator workspace id; " +
+        "per-tenant enqueue passes the customer's workspace id).",
+    );
+  }
   const emailKey = extractEmailKey(input.payload);
   if (emailKey === null && EMAIL_KEYED_EVENT_TYPES.has(input.eventType)) {
     const raw = input.payload["email"];
@@ -420,6 +453,7 @@ export async function enqueue(
     input.eventType,
     JSON.stringify(input.payload),
     emailKey,
+    input.workspaceId,
   ]);
   const id = rows[0]?.id;
   if (!id) {
@@ -515,6 +549,7 @@ export async function flushBatch(
     event_type: string;
     payload: unknown;
     attempts: number;
+    workspace_id: string;
     twenty_person_id: string | null;
     twenty_note_id: string | null;
   };
@@ -529,6 +564,7 @@ export async function flushBatch(
       eventType: raw.event_type,
       payload: raw.payload,
       attempts: raw.attempts,
+      workspaceId: raw.workspace_id,
       twentyPersonId: raw.twenty_person_id,
       twentyNoteId: raw.twenty_note_id,
     };

--- a/packages/cli/src/commands/ops-smoke-crm.ts
+++ b/packages/cli/src/commands/ops-smoke-crm.ts
@@ -360,6 +360,27 @@ export async function handleOpsSmokeCrm(args: string[]): Promise<void> {
       },
     };
 
+    // Smoke-test rows route through the operator pipeline — every
+    // persona is part of Atlas's own lead-capture flow, just executed
+    // via CLI for end-to-end verification (#2849). Resolve the operator
+    // workspace_id from the same tenant DB the dispatcher will read at
+    // claim time so the dispatcher's per-row routing key matches what
+    // the production enqueue path would have stamped on a real demo
+    // /signup. Falls back to the sentinel when the lookup yields nothing
+    // (CI fixture / fresh region with no operator org backfilled).
+    const operatorWorkspaceIdResolver = await import(
+      "@atlas/api/lib/db/migrations/scripts/backfill-crm-leads"
+    );
+    const operatorWorkspaceId =
+      await operatorWorkspaceIdResolver.resolveOperatorWorkspaceIdForBackfill({
+        async query<T extends Record<string, unknown>>(
+          sql: string,
+          params?: unknown[],
+        ): Promise<{ rows: T[] }> {
+          const r = await client.query(sql, params);
+          return { rows: r.rows as T[] };
+        },
+      });
     const enqueuedIds: string[] = [];
     try {
       for (let i = 0; i < events.length; i++) {
@@ -367,6 +388,7 @@ export async function handleOpsSmokeCrm(args: string[]): Promise<void> {
         const id = await enqueue(db, {
           eventType: event.source,
           payload: event as unknown as Record<string, unknown>,
+          workspaceId: operatorWorkspaceId,
         });
         enqueuedIds.push(id);
       }

--- a/packages/cli/src/commands/ops.ts
+++ b/packages/cli/src/commands/ops.ts
@@ -18,6 +18,7 @@
  */
 import {
   runBackfill,
+  resolveOperatorWorkspaceIdForBackfill,
   DEFAULT_BATCH_SIZE,
   BACKFILL_SOURCES,
   type BackfillSource,
@@ -221,11 +222,14 @@ async function handleBackfillCrmLeads(args: string[]): Promise<void> {
   const client = new Client({ connectionString: url });
   await client.connect();
   try {
+    const backfillDb = client as unknown as Parameters<typeof runBackfill>[0]["db"];
+    const workspaceId = await resolveOperatorWorkspaceIdForBackfill(backfillDb);
     const stats = await runBackfill({
-      db: client as unknown as Parameters<typeof runBackfill>[0]["db"],
+      db: backfillDb,
       dryRun,
       batchSize,
       source,
+      workspaceId,
     });
     if (dryRun && stats.sample.length > 0) {
       console.log(


### PR DESCRIPTION
## Summary

- Adds `workspace_id` (NOT NULL, DEFAULT `<atlas-operator>`) to `crm_outbox` so dispatch routes per row instead of carrying a single boot-resolved client config (#2849).
- `ee/src/saas-crm/` now routes per row via `dispatchWithResolvedConfig`: operator-pipeline rows (workspace_id matches the resolved operator id or the sentinel) go through env creds; everything else resolves fresh per-row from `twenty_integrations` via `lookupTwentyDbCredentials` + `resolveWorkspaceCredentials`. Future customer-workspace installs flow through without further plumbing.
- Decrypt failure / missing row → permanent dead-letter (no env fallback — preserves the #2850 Direction-1 leak prevention).

## Notes on issue-body drift

The issue body pre-dates #2850. Two of its phases are already done:

- `findLatestTwentyDbCredentials` was removed in #2850 — this PR builds on the env-only operator path rather than replacing it.
- The multi-row guard in `saveTwentyIntegration` (added in #2847 as a mitigation) was lifted in #2850 — nothing to relax.

The remaining valid work — per-tenant attribution on `crm_outbox` + per-row dispatch routing — is what this PR delivers. Today every operator-pipeline event still routes to Atlas's own Twenty (no behaviour change). Tomorrow's per-tenant install lands via the same enqueue path with a customer workspace id and the dispatcher resolves accordingly.

## Coordination

Coordination note in the issue body called out #2870 (per-email serialization in the same flusher). That merged as #2872 before this PR opened; rebased against current `main` cleanly — no live conflict in `tick.ts` or `resolveDispatchClientConfig`.

## Test plan

- [x] `bun run lint` — clean
- [x] `bun run type` — clean
- [x] `bun run test` — **785/785 files passing** (api 485, others 300+) across 22 packages
- [x] `bun x syncpack lint` — clean
- [x] `bash scripts/check-schema-drift.sh` — passes (workspace_id mirrored in `schema.ts`)
- [x] `bash scripts/check-twenty-resolver-imports.sh` — passes (resolver split preserved)
- [x] All other drift gates (template, security-headers, railway-watch, oauth-helper, test-discipline) — pass
- [x] New tests:
  - `enq` helper + 4-event-source workspace_id capture test in `outbox.test.ts`
  - `dispatchWithResolvedConfig` routing tests in `saas-crm.test.ts` covering: operator id, sentinel, two distinct tenants, missing row, decrypt failure, transport blip
  - `resolveOperatorWorkspaceId` fallback test
- [ ] `bun run scripts/check-published-symbols.ts` — **fails pre-existing** (same on `origin/main`: `packages/cli/lib/smoke-crm/twenty-admin.ts` imports `@useatlas/twenty/client` exports introduced in #2869 that haven't been published yet — needs the `@useatlas/twenty@0.0.6` publish-then-bump). Not caused by this branch.
- [ ] Real-Postgres migration smoke (`migrate-pg.test.ts`) runs automatically in CI.

## Related

- #2849 (this issue)
- #2847 (interim mitigation — guard was already relaxed in #2850)
- #2850 (resolver split this builds on)
- #2870 / #2872 (per-email serialization — no conflict, landed first)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/2878"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782490490&installation_id=135337507&pr_number=2878&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F2878&signature=beb7b6bc6c3141ddca954809acaf3a88065f16b98456ea03b9e4ece34251b45d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->