### PR TITLE
chore(twenty): @useatlas/twenty 0.0.5 → 0.0.6

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -720,7 +720,7 @@
     },
     "plugins/twenty": {
       "name": "@useatlas/twenty",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "devDependencies": {
         "@useatlas/plugin-sdk": "workspace:*",
         "ai": "^6.0.141",

--- a/plugins/twenty/package.json
+++ b/plugins/twenty/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useatlas/twenty",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Atlas Twenty CRM action plugin (upsertPerson, createNote, sales-form normalization)",
   "type": "module",
   "main": "./src/index.ts",


### PR DESCRIPTION
## Summary

- Bump `@useatlas/twenty` from 0.0.5 → 0.0.6 so the next tarball includes the client exports added since 0.0.5: `deleteNote`, `deletePerson`, `listNotes`, `listPeople`, `wipeWorkspace`. Today `packages/cli/lib/smoke-crm/twenty-admin.ts` imports them from `@useatlas/twenty/client`, but the published 0.0.5 tarball doesn't expose them — `scripts/check-published-symbols.ts` (the local pre-PR gate) has been red on main for ~24h.
- Once this lands, I'll tag `twenty-v0.0.6` on main and the existing OIDC publish workflow takes over. A follow-up PR will bump the `^0.0.5` pin to `^0.0.6` in `create-atlas/templates/{docker,nextjs-standalone}/package.json` so scaffolded projects pick up the new tarball.

This is the standard publish-then-bump cycle documented in [npm-publish playbook](../blob/main/CLAUDE.md) — split into two PRs so the template ref bump never points at a version that isn't on npm yet (otherwise Deploy Validation scaffold jobs fail).

## Test plan

- [x] `bun install` updates bun.lock (workspace pin stays `workspace:*` — no consumer changes here)
- [ ] CI green (required: `ci`, `api-tests (1-4/4)`, `Deploy Validation` umbrella, `Analyze (javascript-typescript)`, `Symlink Stub Build`)
- [ ] After merge: `git tag twenty-v0.0.6 && git push origin twenty-v0.0.6` → publish workflow → npm 0.0.6
- [ ] Follow-up PR bumps `^0.0.5` → `^0.0.6` in templates

## Not in this PR

- Template ref bump (deferred until 0.0.6 is on npm — bumping the pin earlier would fail the scaffold jobs)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/2881"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782495770&installation_id=135337507&pr_number=2881&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F2881&signature=9f0e434ce10e1f224e2b64b70b6c49217403eb312cd91a8b766cf7e013884f35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->