### PR TITLE
chore(templates): @useatlas/twenty ^0.0.5 → ^0.0.6

### DIFF
--- a/create-atlas/templates/docker/package.json
+++ b/create-atlas/templates/docker/package.json
@@ -25,7 +25,7 @@
     "@ai-sdk/react": "^3.0.143",
     "@useatlas/react": "^0.1.0",
     "@useatlas/sdk": "^0.1.0",
-    "@useatlas/twenty": "^0.0.5",
+    "@useatlas/twenty": "^0.0.6",
     "@useatlas/types": "^0.1.0",
     "@better-auth/api-key": "^1.6.9",
     "@better-auth/oauth-provider": "^1.6.9",

--- a/create-atlas/templates/nextjs-standalone/package.json
+++ b/create-atlas/templates/nextjs-standalone/package.json
@@ -22,7 +22,7 @@
     "@ai-sdk/react": "^3.0.143",
     "@useatlas/react": "^0.1.0",
     "@useatlas/sdk": "^0.1.0",
-    "@useatlas/twenty": "^0.0.5",
+    "@useatlas/twenty": "^0.0.6",
     "@useatlas/types": "^0.1.0",
     "ai": "^6.0.141",
     "@better-auth/api-key": "^1.6.9",


### PR DESCRIPTION
## Summary

- Second half of the publish-then-bump cycle started in #2881: bump the `@useatlas/twenty` pin in `create-atlas/templates/{docker,nextjs-standalone}/package.json` from `^0.0.5` → `^0.0.6`. Now that `@useatlas/twenty@0.0.6` is on npm, scaffolded projects can pull it and `bun install` resolves cleanly.
- `scripts/check-published-symbols.ts` flips green: the `deleteNote` / `deletePerson` / `listNotes` / `listPeople` / `wipeWorkspace` imports in `packages/cli/lib/smoke-crm/twenty-admin.ts` are now exported by the pinned-published tarball.

## Test plan

- [x] `bun install` resolves with the new ref pinned
- [x] `bun run scripts/check-published-symbols.ts` — "Published symbol check passed"
- [x] `bash scripts/check-template-drift.sh` — green
- [ ] CI green (Deploy Validation scaffold jobs in particular — they `npm install` from the registry against the bumped pin)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/2882"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782496304&installation_id=135337507&pr_number=2882&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F2882&signature=7e64a5127a958dc47a2073dc88b2b0b0922591f8fc466da2130097332a081499"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->