### PR TITLE
fix(docs): llms.txt + llms-full.txt nav links 404 under static export

### DIFF
--- a/apps/docs/src/app/(docs)/layout.tsx
+++ b/apps/docs/src/app/(docs)/layout.tsx
@@ -54,10 +54,12 @@ export default function Layout({ children }: { children: ReactNode }) {
         {
           text: "llms.txt",
           url: "/llms.txt",
+          external: true,
         },
         {
           text: "llms-full.txt",
           url: "/llms-full.txt",
+          external: true,
         },
         {
           type: "icon" as const,


### PR DESCRIPTION
## Summary
- Add `external: true` to the `llms.txt` and `llms-full.txt` entries in the docs sidebar `links` array.
- Without it, fumadocs renders them as Next.js Link components, and under `output: "export"` + `trailingSlash: true` the client router 404s because these URLs are route handlers, not page routes.
- With `external: true` they emit as plain `<a target="_blank">` and Caddy serves the static `.txt` file directly.

## Test plan
- [x] `bun run build` in `apps/docs/`
- [x] Confirm rendered HTML emits `<a href="/llms.txt" target="_blank" ...>` (plain anchor, not Next Link)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/2884"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782503635&installation_id=135337507&pr_number=2884&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F2884&signature=27a12e964c183175340e46a1c4451895188cefa5791e9f24c46ce4af06513ef4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->