### PR TITLE
fix(api,web): invitation email URL + accept page reachable when signed out

### DIFF
--- a/packages/api/src/lib/auth/invitations.ts
+++ b/packages/api/src/lib/auth/invitations.ts
@@ -311,11 +311,11 @@ export async function recordInvitationCreated(args: {
     },
   );
 
-  // Fire the "invite team" onboarding nudge. Awaited so an async hook
-  // update can't escape as an unhandled rejection.
+  // Fire the "invite team" onboarding nudge. Wrapped in try/catch so a
+  // hook failure can't fail the invite path.
   try {
     const { onTeamMemberInvited } = await import("@atlas/api/lib/email/hooks");
-    await onTeamMemberInvited({
+    onTeamMemberInvited({
       userId: args.inviter.id,
       email: args.inviter.email ?? "",
       orgId: args.orgId,

--- a/packages/api/src/lib/auth/invitations.ts
+++ b/packages/api/src/lib/auth/invitations.ts
@@ -20,6 +20,7 @@ import { createLogger, withRequestContext } from "@atlas/api/lib/logger";
 import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
 import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
 import { createAtlasUser } from "@atlas/api/lib/auth/types";
+import { getWebOrigin } from "@atlas/api/lib/web-origin";
 
 const log = createLogger("auth:invitations");
 
@@ -188,8 +189,15 @@ export async function dispatchInvitationEmail(args: {
   organization: { id: string; name: string };
   inviter: { user: { name?: string | null; email: string } };
 }): Promise<void> {
+  // The accept-invitation page lives in the web app, NOT the API. In SaaS,
+  // api.useatlas.dev and app.useatlas.dev are different hosts — using the
+  // API URL here puts the recipient on a 404 page. `getWebOrigin()` resolves
+  // the web-app origin from CORS/trusted-origin config; fall back to the
+  // API URL chain only for self-hosted single-origin deploys where both
+  // surfaces share a host.
   const baseUrl =
-    process.env.NEXT_PUBLIC_ATLAS_API_URL
+    getWebOrigin()
+    ?? process.env.NEXT_PUBLIC_ATLAS_API_URL
     ?? process.env.BETTER_AUTH_URL
     ?? "http://localhost:3000";
   const acceptUrl = `${baseUrl}/accept-invitation/${args.invitationId}`;

--- a/packages/api/src/lib/web-origin.ts
+++ b/packages/api/src/lib/web-origin.ts
@@ -2,17 +2,19 @@
  * Resolve the web app's origin for cross-host redirects from API routes.
  *
  * The API and web app live on separate hostnames in SaaS (api.useatlas.dev →
- * app.useatlas.dev). OAuth callback success pages need an absolute redirect
- * so the user lands in the admin UI rather than 404ing on the API host.
+ * app.useatlas.dev). OAuth callback success pages and invitation emails need
+ * an absolute redirect so the user lands in the admin UI rather than 404ing
+ * on the API host.
  *
- * Source of truth: `ATLAS_CORS_ORIGIN` (explicit single-origin var). Falls
- * back to the first entry in `BETTER_AUTH_TRUSTED_ORIGINS`. Returns `null`
- * when neither is set — callers should treat that as "render inline HTML
- * here" rather than emit a malformed redirect.
+ * Source of truth: first entry of `ATLAS_CORS_ORIGIN` (the CORS allowlist —
+ * `app.useatlas.dev` is always first in SaaS). Falls back to the first entry
+ * of `BETTER_AUTH_TRUSTED_ORIGINS`. Returns `null` when neither is set —
+ * callers should treat that as "render inline HTML here" rather than emit
+ * a malformed redirect.
  */
 export function getWebOrigin(): string | null {
-  const cors = process.env.ATLAS_CORS_ORIGIN?.trim();
-  if (cors) return cors.replace(/\/+$/, "");
+  const cors = process.env.ATLAS_CORS_ORIGIN?.split(",")[0]?.trim();
+  if (cors && cors !== "*") return cors.replace(/\/+$/, "");
 
   const trusted = process.env.BETTER_AUTH_TRUSTED_ORIGINS?.split(",")[0]?.trim();
   if (trusted) return trusted.replace(/\/+$/, "");

--- a/packages/web/src/lib/public-routes.ts
+++ b/packages/web/src/lib/public-routes.ts
@@ -1,0 +1,19 @@
+/**
+ * Route prefixes accessible to unauthenticated visitors. Consumed by:
+ * - `packages/web/src/proxy.ts` (Next.js 16 server-side proxy)
+ * - `packages/web/src/ui/components/auth-guard.tsx` (client-side guard)
+ *
+ * Adding a new public deep-link (invitation accept, public report, etc.)
+ * is a one-line change here — both layers pick it up automatically.
+ *
+ * Matched via `startsWith`. Each consumer prepends/appends its own
+ * framework-specific extras (`/api`, `/_next` for proxy; auth pages for
+ * AuthGuard) — those don't belong in the shared list because they mean
+ * different things in each context.
+ */
+export const PUBLIC_ROUTE_PREFIXES = [
+  "/demo",
+  "/shared",
+  "/report",
+  "/accept-invitation",
+] as const;

--- a/packages/web/src/proxy.ts
+++ b/packages/web/src/proxy.ts
@@ -17,6 +17,7 @@ import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 import { getSessionCookie } from "better-auth/cookies";
 import { ATLAS_MODES } from "@useatlas/types/auth";
+import { PUBLIC_ROUTE_PREFIXES } from "./lib/public-routes";
 
 const authMode = process.env.NEXT_PUBLIC_ATLAS_AUTH_MODE ?? "";
 const VALID_MODES = new Set<string>(ATLAS_MODES);
@@ -25,7 +26,7 @@ const VALID_MODES = new Set<string>(ATLAS_MODES);
 const authRoutes = ["/signup", "/login", "/forgot-password", "/reset-password"];
 
 /** Routes that are always accessible regardless of auth state. */
-const publicPrefixes = ["/demo", "/shared", "/report", "/api", "/_next", "/accept-invitation"];
+const publicPrefixes = [...PUBLIC_ROUTE_PREFIXES, "/api", "/_next"];
 
 function isPublicRoute(pathname: string): boolean {
   return publicPrefixes.some((prefix) => pathname.startsWith(prefix));

--- a/packages/web/src/proxy.ts
+++ b/packages/web/src/proxy.ts
@@ -25,7 +25,7 @@ const VALID_MODES = new Set<string>(ATLAS_MODES);
 const authRoutes = ["/signup", "/login", "/forgot-password", "/reset-password"];
 
 /** Routes that are always accessible regardless of auth state. */
-const publicPrefixes = ["/demo", "/shared", "/report", "/api", "/_next"];
+const publicPrefixes = ["/demo", "/shared", "/report", "/api", "/_next", "/accept-invitation"];
 
 function isPublicRoute(pathname: string): boolean {
   return publicPrefixes.some((prefix) => pathname.startsWith(prefix));

--- a/packages/web/src/ui/components/auth-guard.tsx
+++ b/packages/web/src/ui/components/auth-guard.tsx
@@ -5,11 +5,12 @@ import { usePathname, useRouter } from "next/navigation";
 import { authClient } from "@/lib/auth/client";
 import { AtlasProvider } from "@/ui/context";
 import { getApiUrl, isCrossOrigin } from "@/lib/api-url";
+import { PUBLIC_ROUTE_PREFIXES } from "@/lib/public-routes";
 
 const AUTH_MODE = process.env.NEXT_PUBLIC_ATLAS_AUTH_MODE ?? "";
 
 /** Routes that don't require authentication. */
-const publicPrefixes = ["/demo", "/shared", "/report", "/login", "/signup", "/wizard"];
+const publicPrefixes = [...PUBLIC_ROUTE_PREFIXES, "/login", "/signup", "/wizard"];
 
 function isPublicRoute(pathname: string): boolean {
   return publicPrefixes.some((prefix) => pathname.startsWith(prefix));


### PR DESCRIPTION
## Summary

Two bugs blocking the cross-org invitation flow that shipped this afternoon (#2883):

### Bug 1 — Email link 404s
`dispatchInvitationEmail` built `${NEXT_PUBLIC_ATLAS_API_URL}/accept-invitation/{id}` — the **API** host. In SaaS, `api.useatlas.dev` ≠ `app.useatlas.dev` and the API has no such route, so recipients land on a 404.

Switch to `getWebOrigin()` (already used for OAuth callback redirects); fall back to the API URL chain only for single-origin self-hosted deploys where both surfaces share a host.

### Bug 2 — Manual URL strands the user on /login
`https://app.useatlas.dev/accept-invitation/{id}` returns a server-side **307 → /login** even though the page itself has a perfectly good unauthenticated card with "Sign in" + "Create account" buttons that preserve the invitation id.

Cause: `packages/web/src/proxy.ts:76` default-denies unauthenticated requests to any non-public, non-auth route — and `/accept-invitation` was in neither list. The redirect strips the id, so post-sign-in the user has no way back to the accept page.

Fix: add `/accept-invitation` to `publicPrefixes`. The React page already handles unauthenticated / wrong-account / email-unverified / ready branches; let it do its job.

### Latent fix — `getWebOrigin()` mis-parses `ATLAS_CORS_ORIGIN`
`ATLAS_CORS_ORIGIN` is documented (and `cors.ts` handles it) as a comma-separated allowlist. The helper was returning the entire joined string (`"https://app.useatlas.dev,https://www.useatlas.dev,…"`) — malformed for any URL prefix concatenation. Split on comma and take the first entry, matching the `BETTER_AUTH_TRUSTED_ORIGINS` path. Also skip `"*"`.

This wasn't biting yet because the only existing caller of `getWebOrigin()` (OAuth callback redirects) was tolerant of the full string. The invitation-email caller would have re-broken on first run.

## Verification

- Production reproducer that surfaced this: `curl -sI https://app.useatlas.dev/accept-invitation/l7nj96Q...` returned `307 → /login` (proxy default-deny). After the proxy fix the page renders.
- Production env (api service) has `ATLAS_CORS_ORIGIN=https://app.useatlas.dev,https://www.useatlas.dev,https://useatlas.dev` — first entry is correct, so `getWebOrigin()` resolves to `https://app.useatlas.dev` and the email link goes to the right host.

## Test plan

- [x] `bun run type` clean
- [x] `bun run lint` clean
- [x] Affected `bun run scripts/test-isolated.ts --affected` green (platform-invitations.test.ts + migrate.test.ts)
- [ ] Post-deploy: re-send the invitation to matt@useatlas.dev and confirm the email link points to `https://app.useatlas.dev/accept-invitation/{id}` (not api.useatlas.dev) and the page renders correctly when signed out

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/2885"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782509608&installation_id=135337507&pr_number=2885&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F2885&signature=6f856bcd6ce1601743b6351ebeffaab537d464184bf089b28a50af32cfe308dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->