### PR TITLE
fix(docs): quiet Caddy access log + fix /architecture/audit broken link

### DIFF
--- a/apps/docs/content/docs/guides/model-routing.mdx
+++ b/apps/docs/content/docs/guides/model-routing.mdx
@@ -71,7 +71,7 @@ GET /api/v1/admin/model-config/catalog?provider=openai
 GET /api/v1/admin/model-config/catalog?provider=bedrock
 ```
 
-Pass `?fresh=true` (admin-only) to bypass the cache and force a fresh upstream fetch — every refresh is recorded against the [admin audit log](/architecture/audit) as `model_config.catalog_refresh`.
+Pass `?fresh=true` (admin-only) to bypass the cache and force a fresh upstream fetch — every refresh is recorded against the [admin audit log](/guides/audit-retention) as `model_config.catalog_refresh`.
 
 #### Two-tier cache
 

--- a/deploy/docs/Caddyfile
+++ b/deploy/docs/Caddyfile
@@ -102,8 +102,13 @@
 		file_server
 	}
 
+	# Per-request access logs were drowning real signal — every Googlebot
+	# crawl hit a structured INFO line with full headers. ERROR-level keeps
+	# Caddy startup / runtime errors visible; bump to INFO if you need to
+	# debug a specific request path.
 	log {
 		output stdout
 		format console
+		level ERROR
 	}
 }


### PR DESCRIPTION
## Summary
- Drop Caddy access-log to `level ERROR` in `deploy/docs/Caddyfile`. Every request was hitting a structured INFO line with full headers, and Googlebot crawls were drowning real signal in Railway logs. Caddy startup / runtime errors are still emitted.
- Fix `/architecture/audit` link in `apps/docs/content/docs/guides/model-routing.mdx:74` — that page has never existed; the actual audit guide lives at `/guides/audit-retention` (found via the same noisy log this PR is quieting).

The other 404 visible in the same log sample (`/platform-ops/enterprise`) is a stale Googlebot guess — `enterprise.mdx` has only ever lived at `/architecture/enterprise`. Nothing to fix in our links; will stop appearing once the log level drops.

## Test plan
- [ ] Railway docs service deploys cleanly with new Caddyfile
- [ ] Confirm Railway log volume drops noticeably (no per-200 lines, errors still visible)
- [ ] Visit `/guides/model-routing#two-tier-cache` and confirm the "admin audit log" link now resolves

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/2887"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782518051&installation_id=135337507&pr_number=2887&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F2887&signature=80448ff087e29409535d2e94d95318b9592c46bc1d4ed1bd9c6cf62973abd6dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->