### PR TITLE
fix(web): hard-nav after auth to dodge stale Router Cache → /login bounce

### DIFF
--- a/packages/web/src/app/accept-invitation/[id]/page.tsx
+++ b/packages/web/src/app/accept-invitation/[id]/page.tsx
@@ -18,6 +18,7 @@ import { Button } from "@/components/ui/button";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Database, Mail, AlertTriangle, LogOut } from "lucide-react";
 import { authClient, type OrgInvitationDetail } from "@/lib/auth/client";
+import { navigatePostAuth } from "@/lib/auth/post-auth-nav";
 
 interface PageProps {
   params: Promise<{ id: string }>;
@@ -121,7 +122,8 @@ export default function AcceptInvitationPage({ params }: PageProps) {
             );
           });
       }
-      router.push("/");
+      // Hard nav out of the auth boundary — see post-auth-nav for why.
+      navigatePostAuth("/");
     } catch (err) {
       setAcceptError(err instanceof Error ? err.message : "Failed to accept invitation.");
     } finally {

--- a/packages/web/src/app/login/page.test.tsx
+++ b/packages/web/src/app/login/page.test.tsx
@@ -44,12 +44,18 @@ mock.module("@/ui/hooks/use-webauthn-supported", () => ({
 }));
 
 const routerPushMock = mock((_path: string) => {});
+const navigatePostAuthMock = mock((_path: string) => {});
 // Per-test mutable search params so tests can drive the `?invitationId=…`
 // branch without re-mocking the whole module.
 const searchParamsStore: Record<string, string | null> = { invitationId: null };
 mock.module("next/navigation", () => ({
   useRouter: () => ({ push: routerPushMock, replace: () => {}, back: () => {} }),
   useSearchParams: () => ({ get: (k: string) => searchParamsStore[k] ?? null }),
+}));
+// Sign-in exits go through navigatePostAuth (hard nav) — keep one mock
+// point so tests don't have to spy on `window.location.assign` per-case.
+mock.module("@/lib/auth/post-auth-nav", () => ({
+  navigatePostAuth: navigatePostAuthMock,
 }));
 
 // `LoginPage` fetches the social-provider list + password-reset status
@@ -79,6 +85,7 @@ import LoginPage from "./page";
 beforeEach(() => {
   signInPasskeyMock.mockReset();
   routerPushMock.mockReset();
+  navigatePostAuthMock.mockReset();
   webAuthnSupportMock.mockReset();
   fetchMock.mockClear();
   searchParamsStore.invitationId = null;
@@ -169,7 +176,7 @@ describe("LoginPage — passkey button click", () => {
     expect(explicitCall[0]).toBeUndefined();
 
     await waitFor(() => {
-      expect(routerPushMock).toHaveBeenCalledWith("/");
+      expect(navigatePostAuthMock).toHaveBeenCalledWith("/");
     });
   });
 
@@ -188,6 +195,7 @@ describe("LoginPage — passkey button click", () => {
       expect(signInPasskeyMock).toHaveBeenCalledTimes(2);
     });
     expect(routerPushMock).not.toHaveBeenCalled();
+    expect(navigatePostAuthMock).not.toHaveBeenCalled();
     // Crucial: no NotAllowedError leak. The renderer must NOT show the
     // raw cancellation message.
     expect(document.body.textContent).not.toContain("NotAllowedError");
@@ -215,6 +223,7 @@ describe("LoginPage — passkey button click", () => {
     });
     expect(document.body.textContent).not.toContain("raw NotAllowedError verbose blob");
     expect(routerPushMock).not.toHaveBeenCalled();
+    expect(navigatePostAuthMock).not.toHaveBeenCalled();
   });
 
   test("network failure (TypeError) surfaces 'can't reach the server' copy", async () => {
@@ -231,6 +240,7 @@ describe("LoginPage — passkey button click", () => {
       expect(document.body.textContent).toContain("Can't reach the server");
     });
     expect(routerPushMock).not.toHaveBeenCalled();
+    expect(navigatePostAuthMock).not.toHaveBeenCalled();
   });
 });
 
@@ -249,7 +259,7 @@ describe("LoginPage — conditional UI autofill on mount", () => {
   test("autofill success navigates the user — no need for a button click", async () => {
     render(<LoginPage />);
     await waitFor(() => {
-      expect(routerPushMock).toHaveBeenCalledWith("/");
+      expect(navigatePostAuthMock).toHaveBeenCalledWith("/");
     });
   });
 
@@ -298,7 +308,7 @@ describe("LoginPage — invitationId deep-link threading", () => {
     searchParamsStore.invitationId = "inv-abc-123";
     render(<LoginPage />);
     await waitFor(() => {
-      expect(routerPushMock).toHaveBeenCalledWith("/accept-invitation/inv-abc-123");
+      expect(navigatePostAuthMock).toHaveBeenCalledWith("/accept-invitation/inv-abc-123");
     });
   });
 
@@ -306,7 +316,7 @@ describe("LoginPage — invitationId deep-link threading", () => {
     searchParamsStore.invitationId = "a/b?c";
     render(<LoginPage />);
     await waitFor(() => {
-      expect(routerPushMock).toHaveBeenCalledWith("/accept-invitation/a%2Fb%3Fc");
+      expect(navigatePostAuthMock).toHaveBeenCalledWith("/accept-invitation/a%2Fb%3Fc");
     });
   });
 
@@ -314,7 +324,7 @@ describe("LoginPage — invitationId deep-link threading", () => {
     searchParamsStore.invitationId = null;
     render(<LoginPage />);
     await waitFor(() => {
-      expect(routerPushMock).toHaveBeenCalledWith("/");
+      expect(navigatePostAuthMock).toHaveBeenCalledWith("/");
     });
   });
 });
@@ -337,5 +347,6 @@ describe("LoginPage — empty envelope on click", () => {
       );
     });
     expect(routerPushMock).not.toHaveBeenCalled();
+    expect(navigatePostAuthMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/web/src/app/login/page.tsx
+++ b/packages/web/src/app/login/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useRef } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { authClient } from "@/lib/auth/client";
+import { navigatePostAuth } from "@/lib/auth/post-auth-nav";
 import { getApiUrl } from "@/lib/api-url";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -164,7 +165,9 @@ export default function LoginPage() {
           return;
         }
         if (res.data) {
-          router.push(
+          // Hard nav out of the auth boundary — see post-auth-nav for why
+          // router.push would replay a stale 307 → /login from the cache.
+          navigatePostAuth(
             invitationId
               ? `/accept-invitation/${encodeURIComponent(invitationId)}`
               : "/",
@@ -228,7 +231,7 @@ export default function LoginPage() {
         );
         return;
       }
-      router.push(
+      navigatePostAuth(
         invitationId
           ? `/accept-invitation/${encodeURIComponent(invitationId)}`
           : "/",
@@ -272,7 +275,14 @@ export default function LoginPage() {
           );
         });
       }
-      router.push(next);
+      // 2FA branch (/login/two-factor) stays on the router so the prefilled
+      // form state survives the transition. Every other branch is an exit
+      // out of the auth gate — hard nav to dodge stale Router Cache.
+      if (next === "/login/two-factor") {
+        router.push(next);
+      } else {
+        navigatePostAuth(next);
+      }
     } catch (err) {
       console.debug(
         "Sign in failed:",
@@ -330,7 +340,7 @@ export default function LoginPage() {
           <CardContent className="space-y-4 pt-6">
             <VerifyEmailOTPForm
               email={error.attemptedEmail}
-              onVerified={() => router.push(
+              onVerified={() => navigatePostAuth(
                 invitationId
                   ? `/accept-invitation/${encodeURIComponent(invitationId)}`
                   : "/",

--- a/packages/web/src/app/login/page.tsx
+++ b/packages/web/src/app/login/page.tsx
@@ -28,7 +28,7 @@ import {
   MicrosoftIcon,
 } from "@/ui/components/social-icons";
 import { parseSignInError, type SignInErrorState } from "./parse-sign-in-error";
-import { getPostSignInRoute } from "./post-sign-in-route";
+import { getPostSignInRoute, requiresRouterPushAfterSignIn } from "./post-sign-in-route";
 import { getPasskeySignIn } from "@/lib/auth/passkey-client";
 import { parsePasskeySignInError } from "@/lib/auth/parse-passkey-sign-in-error";
 import { useWebAuthnSupported } from "@/ui/hooks/use-webauthn-supported";
@@ -275,10 +275,9 @@ export default function LoginPage() {
           );
         });
       }
-      // 2FA branch (/login/two-factor) stays on the router so the prefilled
-      // form state survives the transition. Every other branch is an exit
-      // out of the auth gate — hard nav to dodge stale Router Cache.
-      if (next === "/login/two-factor") {
+      // 2FA challenge stays on router.push; every other exit is hard nav.
+      // Decision lives in post-sign-in-route so the policy is unit-tested.
+      if (requiresRouterPushAfterSignIn(next)) {
         router.push(next);
       } else {
         navigatePostAuth(next);

--- a/packages/web/src/app/login/post-sign-in-route.test.ts
+++ b/packages/web/src/app/login/post-sign-in-route.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { getPostSignInRoute } from "./post-sign-in-route";
+import { getPostSignInRoute, requiresRouterPushAfterSignIn } from "./post-sign-in-route";
 
 describe("getPostSignInRoute", () => {
   test("routes to /login/two-factor on { twoFactorRedirect: true }", () => {
@@ -75,5 +75,40 @@ describe("getPostSignInRoute", () => {
         "/accept-invitation/a%2Fb%3Fc",
       );
     });
+  });
+});
+
+describe("requiresRouterPushAfterSignIn", () => {
+  test("true for the bare 2FA route", () => {
+    expect(requiresRouterPushAfterSignIn("/login/two-factor")).toBe(true);
+  });
+
+  test("true for the 2FA route with a callbackURL — regression: Codex catch on #2888", () => {
+    // The invited-2FA path appends `?callbackURL=…`; the bug was that an
+    // exact-equality check missed this case and hard-nav'd the user, which
+    // proxy.ts then 307'd back to /login because /login/two-factor isn't
+    // in the exact-match authRoutes list.
+    expect(
+      requiresRouterPushAfterSignIn(
+        "/login/two-factor?callbackURL=%2Faccept-invitation%2Finv-123",
+      ),
+    ).toBe(true);
+  });
+
+  test("false for the workspace home", () => {
+    expect(requiresRouterPushAfterSignIn("/")).toBe(false);
+  });
+
+  test("false for /accept-invitation deep links", () => {
+    expect(requiresRouterPushAfterSignIn("/accept-invitation/inv-123")).toBe(false);
+  });
+
+  test("false for anything that just happens to start with /login (not /login/two-factor)", () => {
+    // Defense-in-depth: a future /login/sso or /login/passkey would NOT
+    // share the partial-auth-cookie semantics of /login/two-factor and so
+    // should not be treated like one.
+    expect(requiresRouterPushAfterSignIn("/login")).toBe(false);
+    expect(requiresRouterPushAfterSignIn("/login/sso")).toBe(false);
+    expect(requiresRouterPushAfterSignIn("/login/two-factor-other")).toBe(false);
   });
 });

--- a/packages/web/src/app/login/post-sign-in-route.ts
+++ b/packages/web/src/app/login/post-sign-in-route.ts
@@ -33,3 +33,25 @@ export function getPostSignInRoute(data: unknown, invitationId?: string | null):
   }
   return acceptPath ?? "/";
 }
+
+/**
+ * Should a post-sign-in destination be reached via `router.push` (SPA nav)
+ * instead of `navigatePostAuth` (hard nav)?
+ *
+ * `true` only for the /login/two-factor branch. The `twoFactorRedirect`
+ * response doesn't set a session_token cookie — only a short-lived two-
+ * factor cookie identifying the pending user. A hard nav to /login/two-
+ * factor would hit proxy.ts as "no session", and /login/two-factor isn't
+ * in the exact-match authRoutes list, so the proxy would 307 to /login
+ * and the user would never reach the challenge.
+ *
+ * Prefix match (not exact equality) because the invited+2FA path appends
+ * `?callbackURL=…` — and that was the exact bug Codex caught on PR #2888.
+ *
+ * Every other branch (`/`, `/accept-invitation/…`) is an exit out of the
+ * auth gate where a real session cookie exists, so hard nav is correct
+ * (and necessary, to dodge Router Cache poisoning).
+ */
+export function requiresRouterPushAfterSignIn(next: string): boolean {
+  return next === "/login/two-factor" || next.startsWith("/login/two-factor?");
+}

--- a/packages/web/src/app/login/two-factor/page.test.tsx
+++ b/packages/web/src/app/login/two-factor/page.test.tsx
@@ -45,6 +45,7 @@ mock.module("@/lib/auth/two-factor-client", () => ({
 }));
 
 const routerPushMock = mock((_path: string) => {});
+const navigatePostAuthMock = mock((_path: string) => {});
 const searchParamsGetMock = mock<(_key: string) => string | null>(() => null);
 mock.module("next/navigation", () => ({
   useRouter: () => ({ push: routerPushMock, replace: () => {}, back: () => {} }),
@@ -53,6 +54,11 @@ mock.module("next/navigation", () => ({
   // when re-authing for passkey enrollment). Tests assert the safe path
   // policy is enforced.
   useSearchParams: () => ({ get: searchParamsGetMock }),
+}));
+// 2FA exits go through navigatePostAuth (hard nav). One mock point keeps
+// the policy assertions readable.
+mock.module("@/lib/auth/post-auth-nav", () => ({
+  navigatePostAuth: navigatePostAuthMock,
 }));
 
 const signInPasskeyMock = mock(
@@ -89,6 +95,7 @@ beforeEach(() => {
   verifyTotpMock.mockReset();
   verifyBackupCodeMock.mockReset();
   routerPushMock.mockReset();
+  navigatePostAuthMock.mockReset();
   searchParamsGetMock.mockReset();
   searchParamsGetMock.mockImplementation(() => null);
   getTwoFactorClientMock.mockReset();
@@ -180,7 +187,7 @@ describe("TwoFactorChallengePage — verifyTotp wiring", () => {
     ];
     expect(call[0]).toEqual({ code: "123456", trustDevice: false });
     await waitFor(() => {
-      expect(routerPushMock).toHaveBeenCalledWith("/");
+      expect(navigatePostAuthMock).toHaveBeenCalledWith("/");
     });
   });
 
@@ -202,7 +209,7 @@ describe("TwoFactorChallengePage — verifyTotp wiring", () => {
     });
 
     await waitFor(() => {
-      expect(routerPushMock).toHaveBeenCalledWith("/admin/account-security");
+      expect(navigatePostAuthMock).toHaveBeenCalledWith("/admin/account-security");
     });
   });
 
@@ -228,7 +235,7 @@ describe("TwoFactorChallengePage — verifyTotp wiring", () => {
     });
 
     await waitFor(() => {
-      expect(routerPushMock).toHaveBeenCalledWith("/");
+      expect(navigatePostAuthMock).toHaveBeenCalledWith("/");
     });
   });
 
@@ -269,6 +276,7 @@ describe("TwoFactorChallengePage — verifyTotp wiring", () => {
       expect(document.body.textContent).toContain("That code is wrong.");
     });
     expect(routerPushMock).not.toHaveBeenCalled();
+    expect(navigatePostAuthMock).not.toHaveBeenCalled();
   });
 
   test("network failure (TypeError) surfaces friendly copy and does NOT navigate", async () => {
@@ -286,6 +294,7 @@ describe("TwoFactorChallengePage — verifyTotp wiring", () => {
       expect(document.body.textContent).toContain("Can't reach the server");
     });
     expect(routerPushMock).not.toHaveBeenCalled();
+    expect(navigatePostAuthMock).not.toHaveBeenCalled();
   });
 
   test("double-click within the same tick fires verifyTotp only once (would burn backup codes otherwise)", async () => {
@@ -397,6 +406,7 @@ describe("TwoFactorChallengePage — plugin guard", () => {
     });
     expect(verifyTotpMock).not.toHaveBeenCalled();
     expect(routerPushMock).not.toHaveBeenCalled();
+    expect(navigatePostAuthMock).not.toHaveBeenCalled();
   });
 });
 
@@ -438,7 +448,7 @@ describe("TwoFactorChallengePage — passkey alternative", () => {
     expect(call[0]).toBeUndefined();
 
     await waitFor(() => {
-      expect(routerPushMock).toHaveBeenCalledWith("/");
+      expect(navigatePostAuthMock).toHaveBeenCalledWith("/");
     });
     // The TOTP path must NOT have fired — passkey is the alternative, not
     // a parallel verification.
@@ -460,6 +470,7 @@ describe("TwoFactorChallengePage — passkey alternative", () => {
       expect(signInPasskeyMock).toHaveBeenCalledTimes(1);
     });
     expect(routerPushMock).not.toHaveBeenCalled();
+    expect(navigatePostAuthMock).not.toHaveBeenCalled();
     expect(document.body.textContent).not.toContain("NotAllowedError");
     // The TOTP input should remain usable after a cancelled passkey attempt.
     expect(getCodeInput().disabled).toBe(false);
@@ -482,6 +493,7 @@ describe("TwoFactorChallengePage — passkey alternative", () => {
       );
     });
     expect(routerPushMock).not.toHaveBeenCalled();
+    expect(navigatePostAuthMock).not.toHaveBeenCalled();
   });
 
   test("missing passkey plugin surfaces actionable banner instead of silent no-op", async () => {
@@ -522,6 +534,7 @@ describe("TwoFactorChallengePage — passkey alternative", () => {
       );
     });
     expect(routerPushMock).not.toHaveBeenCalled();
+    expect(navigatePostAuthMock).not.toHaveBeenCalled();
     // The TOTP path remains usable after the failed passkey attempt.
     expect(getCodeInput().disabled).toBe(false);
   });

--- a/packages/web/src/app/login/two-factor/page.tsx
+++ b/packages/web/src/app/login/two-factor/page.tsx
@@ -16,7 +16,7 @@
  */
 
 import { Suspense, useRef, useState } from "react";
-import { useRouter, useSearchParams } from "next/navigation";
+import { useSearchParams } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -30,6 +30,7 @@ import {
   type TwoFactorApiError,
 } from "@/lib/auth/two-factor-client";
 import { getPasskeySignIn } from "@/lib/auth/passkey-client";
+import { navigatePostAuth } from "@/lib/auth/post-auth-nav";
 import { parsePasskeySignInError } from "@/lib/auth/parse-passkey-sign-in-error";
 import { useWebAuthnSupported } from "@/ui/hooks/use-webauthn-supported";
 
@@ -121,7 +122,6 @@ export default function TwoFactorChallengePage() {
 }
 
 function TwoFactorChallengeForm() {
-  const router = useRouter();
   const searchParams = useSearchParams();
   const callbackPath = safeCallbackPath(searchParams.get("callbackURL"));
   const webAuthnSupport = useWebAuthnSupported();
@@ -177,7 +177,7 @@ function TwoFactorChallengeForm() {
         );
         return;
       }
-      router.push(callbackPath);
+      navigatePostAuth(callbackPath);
     } catch (err) {
       console.warn(
         "[two-factor:sign-in] passkey sign-in threw:",
@@ -229,7 +229,7 @@ function TwoFactorChallengeForm() {
         submittingRef.current = false;
         return;
       }
-      router.push(callbackPath);
+      navigatePostAuth(callbackPath);
     } catch (err) {
       console.warn(
         "[two-factor:sign-in] verify threw:",

--- a/packages/web/src/app/signup/page.tsx
+++ b/packages/web/src/app/signup/page.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { useRouter, useSearchParams } from "next/navigation";
+import { useSearchParams } from "next/navigation";
 import { authClient } from "@/lib/auth/client";
+import { navigatePostAuth } from "@/lib/auth/post-auth-nav";
 import { getApiUrl } from "@/lib/api-url";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -28,7 +29,6 @@ function getApiBase(): string {
 }
 
 export default function SignupPage() {
-  const router = useRouter();
   // `?invitationId=…` is set when the user clicks an org-invitation
   // email link while signed out and picks "Create account". Threading it
   // through the signup + OTP flow lets us route to /accept-invitation
@@ -96,7 +96,9 @@ export default function SignupPage() {
       // dev), the response carries a token and we can push directly.
       const token = (res.data as { token?: string | null } | undefined)?.token;
       if (token) {
-        router.push(postSignupPath);
+        // Hard nav after auth — see post-auth-nav for the rationale. Same
+        // applies on the OTP-verified branch below.
+        navigatePostAuth(postSignupPath);
       } else {
         setPendingEmail(email);
       }
@@ -148,7 +150,7 @@ export default function SignupPage() {
           <CardContent className="space-y-4">
             <VerifyEmailOTPForm
               email={pendingEmail}
-              onVerified={() => router.push(postSignupPath)}
+              onVerified={() => navigatePostAuth(postSignupPath)}
             />
             <p className="text-center text-xs text-muted-foreground">
               <button

--- a/packages/web/src/lib/auth/post-auth-nav.ts
+++ b/packages/web/src/lib/auth/post-auth-nav.ts
@@ -1,0 +1,23 @@
+/**
+ * Hard navigation out of an "auth state just changed" boundary
+ * (sign-in / sign-up OTP verified / accept-invitation accepted / 2FA
+ * verified). Uses `window.location.assign` instead of Next.js's
+ * `router.push` to bypass the client-side Router Cache.
+ *
+ * Why this matters: Next.js's Router Cache is keyed by URL and survives
+ * across auth state changes. Link prefetches that fired BEFORE the user
+ * signed in (the auth page chrome links / and other guarded routes)
+ * went through `proxy.ts`, got a 307 → /login, and that redirect is
+ * cached. After the user signs in, a `router.push("/")` consults the
+ * cache and replays the stale 307 — bouncing the just-authenticated
+ * user back to /login. A hard nav is the documented Next.js workaround;
+ * we centralize it here so tests have one mock point and the rationale
+ * lives next to the call sites that need it.
+ *
+ * Don't use this for in-app navigation between two pages that share an
+ * authenticated session — `router.push` keeps the SPA experience.
+ */
+export function navigatePostAuth(url: string): void {
+  if (typeof window === "undefined") return;
+  window.location.assign(url);
+}


### PR DESCRIPTION
## Summary

After invitation signup → verify-email OTP → accept-invitation, the freshly-authenticated user was being bounced back to `/login`. Reproduced in Playwright against prod (PR for `#2885` was the symmetric companion fix; this is a different bug surfaced in dogfood after that landed).

**Root cause (not what I first thought):** the session cookie IS being set, Domain-scoped `.useatlas.dev`, sent on cross-subdomain requests, and proxy.ts DOES read it correctly. The bug is **Next.js Router Cache poisoning**:

1. User arrives at `/accept-invitation/<id>` while signed out → public-route branch renders.
2. Next.js auto-prefetches `/` (Link in the page chrome).
3. Prefetch hits `proxy.ts` → no session → **307 → /login**.
4. Next.js caches the prefetch result keyed by `/`.
5. User signs up, verifies OTP, clicks "Join Atlas" → server-side acceptance + set-active both succeed → session cookie is valid.
6. `router.push("/")` consults the cache, replays the **stale 307**, never hits the proxy again. User lands at `/login` with a valid session in the cookie jar.

This is a well-known Next.js gotcha (middleware redirect + Link prefetch + Router Cache). `Cache-Control: no-store` on the proxy redirect doesn't help — the Router Cache is in-memory client-side and ignores HTTP cache directives.

**Fix:** at every "auth state just changed" boundary, use `window.location.assign` instead of `router.push`. Hard nav drops the Router Cache entry for the destination, so the post-auth session is honored.

Centralized as `navigatePostAuth(url)` in `packages/web/src/lib/auth/post-auth-nav.ts` so the rationale lives in one place and tests have one mock point. Patched exits:

- `accept-invitation` handleAccept success
- `/signup` direct success (verification off) and post-OTP-verify
- `/login` email+password (non-2FA branch), passkey button, passkey autofill, post-OTP for email-unverified-on-sign-in
- `/login/two-factor` TOTP + backup code verify

The 2FA-redirect branch (`/login` → `/login/two-factor`) intentionally stays on `router.push` — no session exists yet there and the form needs SPA continuity for prefilled state. Documented inline.

## Test plan

- [x] `bun run lint` — 0/0
- [x] `bun run type` — 0
- [x] `bun run --filter '@atlas/web' test` — 166/166 files pass
- [x] login + 2FA page tests cover both the toHaveBeenCalledWith and not.toHaveBeenCalled assertions on `navigatePostAuthMock` (46/46)
- [x] All /ci drift gates green (lint, type, syncpack, template, security headers, railway watch, schema drift, oauth helper drift, test discipline, twenty resolver, published symbols, EE imports)
- [ ] Re-run the Playwright reproduction against this branch — bounce no longer fires

### Known pre-existing flake (unrelated)

Full `bun run test` flagged `packages/api/src/api/__tests__/admin-roles.test.ts` failing in the parallel-isolated runner. It passes 24/24 in isolation (`bun test src/api/__tests__/admin-roles.test.ts`). My changes are entirely in `packages/web/` so this cannot be related; main is currently green on this same test. Documenting per /ci's "note flake but don't ignore" rule.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/2888"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782521035&installation_id=135337507&pr_number=2888&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F2888&signature=863508d1a1f5c1aeb85be56b86ad7df08cb35b09da1dfff92f19c608a90a2b69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->