### PR TITLE
fix(api,web,types): org admins now see the admin gear icon

### DIFF
--- a/packages/api/src/lib/auth/__tests__/effective-role.test.ts
+++ b/packages/api/src/lib/auth/__tests__/effective-role.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
+
+// Mirror managed.test.ts: stub the internal-DB adapter BEFORE the
+// SUT is imported so its transitive `hasInternalDB` / `internalQuery`
+// references resolve to these closures.
+let mockHasInternalDB = false;
+let mockInternalQuery: (sql: string, params: unknown[]) => Promise<unknown[]> =
+  () => Promise.resolve([]);
+
+mock.module("@atlas/api/lib/db/internal", () => ({
+  hasInternalDB: () => mockHasInternalDB,
+  internalQuery: (sql: string, params: unknown[]) => mockInternalQuery(sql, params),
+}));
+
+import { resolveEffectiveRole } from "../effective-role";
+import { buildCustomSessionPayload } from "../server";
+
+describe("resolveEffectiveRole()", () => {
+  beforeEach(() => {
+    mockHasInternalDB = false;
+    mockInternalQuery = () => Promise.resolve([]);
+  });
+
+  afterEach(() => {
+    mockHasInternalDB = false;
+    mockInternalQuery = () => Promise.resolve([]);
+  });
+
+  it("returns the userRole as-is when no active org", async () => {
+    const r = await resolveEffectiveRole("admin", "usr_1", undefined);
+    expect(r).toBe("admin");
+  });
+
+  it("returns the userRole as-is when internal DB is unavailable", async () => {
+    mockHasInternalDB = false;
+    const r = await resolveEffectiveRole("member", "usr_1", "org_1");
+    expect(r).toBe("member");
+  });
+
+  it("merges to the org member role when it outranks user.role — org admin > 'user'", async () => {
+    // The bug: signup defaults user.role to "user"/undefined; the invite
+    // accept sets member.role="admin". Without this merge, useUserRole
+    // sees "user" and hides the gear icon.
+    mockHasInternalDB = true;
+    mockInternalQuery = () => Promise.resolve([{ role: "admin" }]);
+    const r = await resolveEffectiveRole(undefined, "usr_1", "org_1");
+    expect(r).toBe("admin");
+  });
+
+  it("keeps the user-level role when it outranks the org role — platform_admin > org admin", async () => {
+    mockHasInternalDB = true;
+    mockInternalQuery = () => Promise.resolve([{ role: "admin" }]);
+    const r = await resolveEffectiveRole("platform_admin", "usr_1", "org_1");
+    expect(r).toBe("platform_admin");
+  });
+
+  it("returns the userRole when no member row exists", async () => {
+    mockHasInternalDB = true;
+    mockInternalQuery = () => Promise.resolve([]);
+    const r = await resolveEffectiveRole("member", "usr_1", "org_1");
+    expect(r).toBe("member");
+  });
+
+  it("ignores invalid org role strings (fail-safe to userRole)", async () => {
+    mockHasInternalDB = true;
+    mockInternalQuery = () => Promise.resolve([{ role: "garbage" }]);
+    const r = await resolveEffectiveRole("member", "usr_1", "org_1");
+    expect(r).toBe("member");
+  });
+
+  it("fails open to userRole on a DB error", async () => {
+    mockHasInternalDB = true;
+    mockInternalQuery = () => Promise.reject(new Error("connection lost"));
+    const r = await resolveEffectiveRole("admin", "usr_1", "org_1");
+    expect(r).toBe("admin");
+  });
+});
+
+describe("buildCustomSessionPayload()", () => {
+  beforeEach(() => {
+    mockHasInternalDB = false;
+    mockInternalQuery = () => Promise.resolve([]);
+  });
+
+  afterEach(() => {
+    mockHasInternalDB = false;
+    mockInternalQuery = () => Promise.resolve([]);
+  });
+
+  it("stamps effectiveRole on user without touching the native role", async () => {
+    // The regression case behind this PR: matt's user.role stayed at the
+    // signup default ("user") while member.role landed as "admin" via the
+    // invitation. customSession must surface the merged value as
+    // effectiveRole AND leave user.role intact so Better Auth's own admin
+    // endpoints still gate on system role.
+    mockHasInternalDB = true;
+    mockInternalQuery = () => Promise.resolve([{ role: "admin" }]);
+    const out = await buildCustomSessionPayload({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test fixture, mirrors Better Auth's User shape minimally
+      user: { id: "usr_matt", email: "matt@useatlas.dev", role: "user" } as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test fixture, mirrors Better Auth's Session shape minimally
+      session: { id: "sess_1", userId: "usr_matt", activeOrganizationId: "org_1" } as any,
+    });
+    const u = out.user as Record<string, unknown>;
+    expect(u.role).toBe("user");
+    expect(u.effectiveRole).toBe("admin");
+  });
+
+  it("returns effectiveRole: null when no role could be resolved", async () => {
+    // No active org and no user.role — both sides empty. null (not
+    // undefined) so the field is explicitly serialized over JSON.
+    const out = await buildCustomSessionPayload({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test fixture
+      user: { id: "usr_1", email: "a@b.com" } as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test fixture
+      session: { id: "sess_1", userId: "usr_1" } as any,
+    });
+    expect((out.user as Record<string, unknown>).effectiveRole).toBeNull();
+  });
+
+  it("strips a comma-suffixed user.role to the first segment before merging", async () => {
+    // Better Auth admin plugin supports multi-role strings; Atlas uses
+    // only the first segment, mirroring validateManaged's existing logic.
+    mockHasInternalDB = true;
+    mockInternalQuery = () => Promise.resolve([]);
+    const out = await buildCustomSessionPayload({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test fixture
+      user: { id: "usr_1", email: "a@b.com", role: "admin,extra" } as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test fixture
+      session: { id: "sess_1", userId: "usr_1", activeOrganizationId: "org_1" } as any,
+    });
+    expect((out.user as Record<string, unknown>).effectiveRole).toBe("admin");
+  });
+});

--- a/packages/api/src/lib/auth/effective-role.ts
+++ b/packages/api/src/lib/auth/effective-role.ts
@@ -1,0 +1,67 @@
+/**
+ * Resolve the effective role from the user-level `user.role` (Better Auth
+ * admin plugin) merged with the active organization's `member.role`.
+ *
+ * Better Auth keeps these two role surfaces separate by design:
+ *   - `user.role` — system-wide (admin plugin): `platform_admin`, `admin`, `user`
+ *   - `member.role` — per-org (organization plugin): `owner`, `admin`, `member`
+ *
+ * Atlas's admin console gate is "is this caller an admin *somewhere I trust*"
+ * — system OR active-org. Without merging, an org owner whose `user.role`
+ * defaulted to "user" (the common signup → accept-invite flow) is locked out
+ * of `/admin` even though every API route they'd touch authorizes them.
+ *
+ * Used in two places that must stay in lockstep:
+ *   1. `validateManaged` — populates `authResult.user.role` for server-side
+ *      `requireAdminAuth` checks on Atlas's own /api/v1/admin/* routes.
+ *   2. `customSession` plugin — populates `session.user.effectiveRole` so
+ *      the client (`useUserRole`) can hide/show admin chrome consistently.
+ *
+ * Returns the merged role on success, `undefined` only when both sides are
+ * empty/unknown. Fails open to `userRole` on DB error — a transient lookup
+ * failure shouldn't lock an admin out of the console mid-session.
+ */
+
+import type { AtlasRole } from "@atlas/api/lib/auth/types";
+import { parseRole } from "@atlas/api/lib/auth/permissions";
+import { createLogger } from "@atlas/api/lib/logger";
+import { hasInternalDB, internalQuery } from "@atlas/api/lib/db/internal";
+
+const log = createLogger("auth:effective-role");
+
+/** Role precedence — higher number wins. */
+const ROLE_LEVEL: Record<string, number> = {
+  member: 0,
+  admin: 1,
+  owner: 2,
+  platform_admin: 3,
+};
+
+export async function resolveEffectiveRole(
+  userRole: AtlasRole | undefined,
+  userId: string,
+  activeOrganizationId: string | undefined,
+): Promise<AtlasRole | undefined> {
+  if (!activeOrganizationId || !hasInternalDB()) return userRole;
+
+  try {
+    const rows = await internalQuery<{ role: string }>(
+      `SELECT role FROM member WHERE "userId" = $1 AND "organizationId" = $2 LIMIT 1`,
+      [userId, activeOrganizationId],
+    );
+    if (rows.length === 0) return userRole;
+
+    const orgRole = parseRole(rows[0].role);
+    if (!orgRole) return userRole;
+
+    const userLevel = ROLE_LEVEL[userRole ?? "member"] ?? 0;
+    const orgLevel = ROLE_LEVEL[orgRole] ?? 0;
+    return orgLevel > userLevel ? orgRole : (userRole ?? "member");
+  } catch (err) {
+    log.warn(
+      { err: err instanceof Error ? err.message : String(err), userId, orgId: activeOrganizationId },
+      "Failed to look up org member role — falling back to user-level role",
+    );
+    return userRole;
+  }
+}

--- a/packages/api/src/lib/auth/managed.ts
+++ b/packages/api/src/lib/auth/managed.ts
@@ -9,13 +9,13 @@
  */
 
 import type { AuthResult } from "@atlas/api/lib/auth/types";
-import type { AtlasRole } from "@atlas/api/lib/auth/types";
 import { createAtlasUser } from "@atlas/api/lib/auth/types";
 import { parseRole } from "@atlas/api/lib/auth/permissions";
 import { getAuthInstance } from "@atlas/api/lib/auth/server";
 import { createLogger } from "@atlas/api/lib/logger";
 import { getSetting } from "@atlas/api/lib/settings";
 import { hasInternalDB, internalQuery } from "@atlas/api/lib/db/internal";
+import { resolveEffectiveRole } from "@atlas/api/lib/auth/effective-role";
 
 const log = createLogger("auth:managed");
 
@@ -112,56 +112,6 @@ export async function validateManaged(req: Request): Promise<AuthResult> {
     mode: "managed",
     user: createAtlasUser(userId, "managed", email || userId, { role: effectiveRole, activeOrganizationId, claims }),
   };
-}
-
-// ---------------------------------------------------------------------------
-// Org member role resolution
-// ---------------------------------------------------------------------------
-
-/** Role precedence — higher number wins. */
-const ROLE_LEVEL: Record<string, number> = {
-  member: 0,
-  admin: 1,
-  owner: 2,
-  platform_admin: 3,
-};
-
-/**
- * Resolve the effective role by comparing the user-level role (from
- * Better Auth's admin plugin, stored in the `user.role` column) with the
- * org-level role (from the `member` table). Returns the higher of the two.
- *
- * This is necessary because Better Auth stores org membership roles
- * separately from user-level roles, so an org owner whose user-level role
- * is "member" would otherwise be locked out of the admin console.
- */
-async function resolveEffectiveRole(
-  userRole: AtlasRole | undefined,
-  userId: string,
-  activeOrganizationId: string | undefined,
-): Promise<AtlasRole | undefined> {
-  if (!activeOrganizationId || !hasInternalDB()) return userRole;
-
-  try {
-    const rows = await internalQuery<{ role: string }>(
-      `SELECT role FROM member WHERE "userId" = $1 AND "organizationId" = $2 LIMIT 1`,
-      [userId, activeOrganizationId],
-    );
-    if (rows.length === 0) return userRole;
-
-    const orgRole = parseRole(rows[0].role);
-    if (!orgRole) return userRole;
-
-    const userLevel = ROLE_LEVEL[userRole ?? "member"] ?? 0;
-    const orgLevel = ROLE_LEVEL[orgRole] ?? 0;
-    return orgLevel > userLevel ? orgRole : (userRole ?? "member");
-  } catch (err) {
-    log.warn(
-      { err: err instanceof Error ? err.message : String(err), userId, orgId: activeOrganizationId },
-      "Failed to look up org member role — falling back to user-level role",
-    );
-    return userRole;
-  }
 }
 
 // `::int` cast keeps PG's bigint COUNT(*) as a JS number — pg surfaces

--- a/packages/api/src/lib/auth/managed.ts
+++ b/packages/api/src/lib/auth/managed.ts
@@ -15,7 +15,6 @@ import { getAuthInstance } from "@atlas/api/lib/auth/server";
 import { createLogger } from "@atlas/api/lib/logger";
 import { getSetting } from "@atlas/api/lib/settings";
 import { hasInternalDB, internalQuery } from "@atlas/api/lib/db/internal";
-import { resolveEffectiveRole } from "@atlas/api/lib/auth/effective-role";
 
 const log = createLogger("auth:managed");
 
@@ -36,12 +35,17 @@ export async function validateManaged(req: Request): Promise<AuthResult> {
     return { authenticated: false, mode: "managed", status: 500, error: "Session data is incomplete" };
   }
 
-  // Extract role from session user (set by Better Auth admin plugin, stored in the `role` column).
-  // Falls back to default (member) when not present — see permissions.ts.
+  // Extract the merged effective role from the session user. Set by the
+  // `customSession` plugin in `server.ts`, which already runs
+  // `resolveEffectiveRole(user.role, member.role)` on every getSession.
+  // Reading the stamped field here avoids a second identical member-table
+  // SELECT per request. Falls back to the raw `role` (system-wide,
+  // admin plugin) for unit tests that mock auth.api.getSession without
+  // routing through the customSession callback.
   const sessionUser = session.user as Record<string, unknown>;
-  // Better Auth can store multiple roles as comma-separated strings; Atlas uses only the first.
-  const rawRoleField = sessionUser?.role;
-  const rawRole = typeof rawRoleField === "string" ? rawRoleField.split(",")[0].trim() : rawRoleField;
+  const stampedRole = sessionUser?.effectiveRole ?? sessionUser?.role;
+  // Better Auth can store roles as comma-separated strings; Atlas uses only the first.
+  const rawRole = typeof stampedRole === "string" ? stampedRole.split(",")[0].trim() : stampedRole;
   let role: ReturnType<typeof parseRole>;
   if (typeof rawRole === "string") {
     role = parseRole(rawRole);
@@ -93,12 +97,7 @@ export async function validateManaged(req: Request): Promise<AuthResult> {
   // via POST /organization/set-active.
   const activeOrganizationId = (sessionData?.activeOrganizationId as string) ?? undefined;
 
-  // Both queries hit the internal DB but are independent — parallelize so
-  // every authenticated request doesn't pay two sequential round-trips.
-  const [effectiveRole, passkeyCount] = await Promise.all([
-    resolveEffectiveRole(role, userId, activeOrganizationId),
-    resolvePasskeyCount(userId),
-  ]);
+  const passkeyCount = await resolvePasskeyCount(userId);
 
   // Computed fields land AFTER the spread so a session-user field can't
   // shadow our authoritative claims (asserted in managed.test.ts).
@@ -110,7 +109,7 @@ export async function validateManaged(req: Request): Promise<AuthResult> {
   return {
     authenticated: true,
     mode: "managed",
-    user: createAtlasUser(userId, "managed", email || userId, { role: effectiveRole, activeOrganizationId, claims }),
+    user: createAtlasUser(userId, "managed", email || userId, { role, activeOrganizationId, claims }),
   };
 }
 

--- a/packages/api/src/lib/auth/server.ts
+++ b/packages/api/src/lib/auth/server.ts
@@ -12,7 +12,7 @@
  */
 
 import { betterAuth, type Session, type User } from "better-auth";
-import { bearer, admin, organization, jwt } from "better-auth/plugins";
+import { bearer, admin, organization, jwt, customSession } from "better-auth/plugins";
 import { twoFactor } from "better-auth/plugins/two-factor";
 import { emailOTP } from "better-auth/plugins/email-otp";
 // @better-auth/* plugins must match the better-auth core version line.
@@ -44,6 +44,7 @@ import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
 import { onVerificationCreated } from "@atlas/api/lib/auth/trusted-device-hook";
 import { isEnterpriseEnabled } from "@atlas/api/lib/effect/enterprise-config";
 import { ac, owner as ownerRole, admin as adminRole, member as memberRole } from "@atlas/api/lib/auth/org-permissions";
+import { resolveEffectiveRole } from "@atlas/api/lib/auth/effective-role";
 import { adminAccessControl, adminRole as adminUserRole, platformAdminRole } from "@atlas/api/lib/auth/admin-permissions";
 import { getStripePlans, resolvePlanTierFromPriceId, TRIAL_DAYS } from "@atlas/api/lib/billing/plans";
 import { invalidatePlanCache, checkResourceLimit } from "@atlas/api/lib/billing/enforcement";
@@ -1796,6 +1797,47 @@ export function buildPlugins() {
 }
 
 /**
+ * customSession callback — surface the org-merged effective role on the
+ * session for the client. The native `user.role` (admin plugin,
+ * system-wide) is left untouched so Better Auth's own admin endpoints
+ * still gate on system role; client consumers read `effectiveRole` via
+ * `useUserRole` to decide whether to render admin chrome (gear icon,
+ * sidebar, pending-changes pill).
+ *
+ * Per Better Auth docs, customSession bypasses cookie-cache: this
+ * callback runs on every `getSession`. That's already the cost
+ * `validateManaged` pays via `resolveEffectiveRole` on every authenticated
+ * request, so net DB load is unchanged.
+ *
+ * Exported for the tiny unit test that pins the role-merge contract; not
+ * a public API.
+ *
+ * @internal
+ */
+export async function buildCustomSessionPayload({
+  user,
+  session,
+}: {
+  user: User & Record<string, unknown>;
+  session: Session & { activeOrganizationId?: string | null } & Record<string, unknown>;
+}) {
+  const rawRole = user.role;
+  const userRole =
+    typeof rawRole === "string"
+      ? (rawRole.split(",")[0].trim() as Parameters<typeof resolveEffectiveRole>[0])
+      : undefined;
+  const activeOrganizationId =
+    typeof session.activeOrganizationId === "string"
+      ? session.activeOrganizationId
+      : undefined;
+  const effectiveRole = await resolveEffectiveRole(userRole, user.id, activeOrganizationId);
+  return {
+    user: { ...user, effectiveRole: effectiveRole ?? null },
+    session,
+  };
+}
+
+/**
  * Intentionally typed as the base Auth type (without plugin extensions).
  * The codebase only uses .handler, .api.getSession, and .$context — all of
  * which exist on the base type. Plugin-specific API methods (e.g.
@@ -2344,6 +2386,15 @@ export function buildAuthOptions(deps: BuildAuthOptionsDeps): Parameters<typeof 
       },
     },
   };
+
+  // Append customSession last so it wraps every other plugin's session
+  // contributions. Passing `options` as the 2nd arg propagates plugin
+  // field types (admin's `user.role`, organization's `activeOrganizationId`,
+  // etc.) into the callback's inputs — see better-auth/docs §
+  // "Customizing Session with Plugin Field Inference".
+  //
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- type erasure mirrors the cast on options below
+  (options.plugins as any[]).push(customSession(buildCustomSessionPayload, options as Parameters<typeof customSession>[1]));
 
   return options as unknown as Parameters<typeof betterAuth>[0];
 }

--- a/packages/api/src/lib/auth/server.ts
+++ b/packages/api/src/lib/auth/server.ts
@@ -1793,21 +1793,30 @@ export function buildPlugins() {
     }
   }
 
+  // customSession — surface the org-merged effective role on the session
+  // for both client (gear icon, sidebar) and server (validateManaged
+  // reads `user.effectiveRole` straight off the session payload, avoiding
+  // a second member-table SELECT per request).
+  //
+  // The native `user.role` (admin plugin, system-wide) is left untouched
+  // so Better Auth's own admin endpoints still gate on system role.
+  //
+  // Per Better Auth docs, customSession bypasses cookie-cache: this
+  // callback runs on every `getSession`. The single member-table SELECT
+  // here replaces the one validateManaged used to run — net DB load is
+  // unchanged.
+  //
+  // Inside the same `any[]` plugin array as every other plugin above —
+  // adding it here means we don't need any new casts at the call site.
+  plugins.push(customSession(buildCustomSessionPayload));
+
   return plugins;
 }
 
 /**
- * customSession callback — surface the org-merged effective role on the
- * session for the client. The native `user.role` (admin plugin,
- * system-wide) is left untouched so Better Auth's own admin endpoints
- * still gate on system role; client consumers read `effectiveRole` via
- * `useUserRole` to decide whether to render admin chrome (gear icon,
- * sidebar, pending-changes pill).
- *
- * Per Better Auth docs, customSession bypasses cookie-cache: this
- * callback runs on every `getSession`. That's already the cost
- * `validateManaged` pays via `resolveEffectiveRole` on every authenticated
- * request, so net DB load is unchanged.
+ * customSession callback — see the {@link buildPlugins} push site for
+ * the architectural rationale (why `effectiveRole` and not `role`, why
+ * the cookie-cache bypass is fine).
  *
  * Exported for the tiny unit test that pins the role-merge contract; not
  * a public API.
@@ -2386,15 +2395,6 @@ export function buildAuthOptions(deps: BuildAuthOptionsDeps): Parameters<typeof 
       },
     },
   };
-
-  // Append customSession last so it wraps every other plugin's session
-  // contributions. Passing `options` as the 2nd arg propagates plugin
-  // field types (admin's `user.role`, organization's `activeOrganizationId`,
-  // etc.) into the callback's inputs — see better-auth/docs §
-  // "Customizing Session with Plugin Field Inference".
-  //
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- type erasure mirrors the cast on options below
-  (options.plugins as any[]).push(customSession(buildCustomSessionPayload, options as Parameters<typeof customSession>[1]));
 
   return options as unknown as Parameters<typeof betterAuth>[0];
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useatlas/types",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Shared types for the Atlas text-to-SQL agent",
   "type": "module",
   "scripts": {

--- a/packages/types/src/auth.ts
+++ b/packages/types/src/auth.ts
@@ -78,6 +78,14 @@ export interface AtlasAuthClient {
       user?: {
         email?: string;
         role?: string;
+        /**
+         * Org-merged effective role — `max(user.role, active-org member.role)`.
+         * Stamped by the server's `customSession` plugin so an org admin
+         * whose `user.role` defaulted to "user" still sees admin chrome.
+         * Optional for back-compat with older sessions; consumers
+         * (`useUserRole`) fall back to `role`.
+         */
+        effectiveRole?: string | null;
         /** Display name — present at runtime, not always populated. */
         name?: string;
         /** True when TOTP is enrolled — surfaced by the two-factor plugin. */

--- a/packages/web/src/app/(workspace)/notebook/page.tsx
+++ b/packages/web/src/app/(workspace)/notebook/page.tsx
@@ -11,6 +11,7 @@ import { useConversations, transformMessages } from "@/ui/hooks/use-conversation
 import { useDatasourceSummary } from "@/ui/hooks/use-datasource-summary";
 import { getApiUrl, isCrossOrigin } from "@/lib/api-url";
 import { useAtlasTransport } from "@/ui/hooks/use-atlas-transport";
+import { useIsAdmin } from "@/ui/hooks/use-platform-admin-guard";
 import { authClient } from "@/lib/auth/client";
 import { Button } from "@/components/ui/button";
 import type { NotebookStateWire, ForkBranchWire } from "@/ui/lib/types";
@@ -43,13 +44,12 @@ function NotebookContent() {
   const [error, setError] = useState<string | null>(null);
   const tempIdRef = useRef(`temp:${Date.now()}`);
 
-  // Auth for tour
+  // Auth for tour. `useIsAdmin` reads the merged effective role from
+  // customSession so org admins (system role "user", org member.role
+  // "admin") still match.
   const session = authClient.useSession();
-  const user = session.data?.user as
-    | { email?: string; role?: string }
-    | undefined;
-  const isAdmin = user?.role === "admin" || user?.role === "owner" || user?.role === "platform_admin";
-  const isSignedIn = !!user;
+  const isAdmin = useIsAdmin();
+  const isSignedIn = !!session.data?.user;
 
   // Server-side notebook state
   const [serverNotebookState, setServerNotebookState] = useState<NotebookStateWire | null>(null);

--- a/packages/web/src/app/(workspace)/page.tsx
+++ b/packages/web/src/app/(workspace)/page.tsx
@@ -14,6 +14,7 @@ import { useDatasourceSummary } from "@/ui/hooks/use-datasource-summary";
 import { getApiUrl, isCrossOrigin } from "@/lib/api-url";
 import { useAtlasTransport } from "@/ui/hooks/use-atlas-transport";
 import { useDefaultLanding } from "@/ui/hooks/use-default-landing";
+import { useIsAdmin } from "@/ui/hooks/use-platform-admin-guard";
 import { authClient } from "@/lib/auth/client";
 import { IncidentBanner } from "@/ui/components/incident-banner";
 import { AssistantTurn } from "@/ui/components/chat/assistant-turn";
@@ -89,13 +90,12 @@ function ChatPage() {
   const lastLoadedIdRef = useRef<string | null>(null);
 
   // Client-side role check for nav display only — actual admin access is
-  // enforced by the backend (which resolves org member roles).
+  // enforced by the backend. `useIsAdmin` reads the merged effective role
+  // (system-wide + active-org member) stamped by customSession server-side,
+  // so org admins whose user.role defaulted to "user" still match.
   const session = authClient.useSession();
-  const user = session.data?.user as
-    | { email?: string; role?: string }
-    | undefined;
-  const isAdmin = user?.role === "admin" || user?.role === "owner" || user?.role === "platform_admin";
-  const isSignedIn = !!user;
+  const isAdmin = useIsAdmin();
+  const isSignedIn = !!session.data?.user;
 
   // Wait for the session to resolve before fetching the landing preference —
   // a 401 here silently falls through to chat and the admin opt-out never

--- a/packages/web/src/app/settings/profile/page.tsx
+++ b/packages/web/src/app/settings/profile/page.tsx
@@ -14,15 +14,19 @@ import { IdentitySection } from "@/ui/components/settings/identity-section";
 import { InterfaceSection } from "@/ui/components/settings/interface-section";
 import { PasswordSection } from "@/ui/components/settings/password-section";
 import { SessionsSection } from "@/ui/components/settings/sessions-section";
+import { useIsAdmin } from "@/ui/hooks/use-platform-admin-guard";
 
 interface SessionUser {
   email: string;
-  role?: string;
 }
 
 export default function ProfilePage() {
   const session = authClient.useSession();
   const user = (session.data?.user ?? null) as SessionUser | null;
+  // Reads the merged effective role from customSession; an org admin
+  // whose user.role defaulted to "user" still sees the admin landing
+  // option in InterfaceSection.
+  const isAdmin = useIsAdmin();
 
   if (!user) {
     return (
@@ -46,13 +50,7 @@ export default function ProfilePage() {
       </header>
 
       <div className="space-y-10">
-        <InterfaceSection
-          isAdmin={
-            user.role === "admin" ||
-            user.role === "owner" ||
-            user.role === "platform_admin"
-          }
-        />
+        <InterfaceSection isAdmin={isAdmin} />
 
         <IdentitySection />
 

--- a/packages/web/src/lib/auth/client.ts
+++ b/packages/web/src/lib/auth/client.ts
@@ -159,12 +159,21 @@ type SessionFieldExtras = {
   activeOrganizationName?: string;
 };
 
+// User extras the server's `customSession` plugin stamps on every
+// `getSession`. `effectiveRole` is max(user.role, active-org member.role)
+// — read by `useUserRole` so org-admins (whose `user.role` is the default
+// "user") see admin chrome.
+type UserFieldExtras = {
+  effectiveRole?: string | null;
+};
+
 type BaseUseSessionReturn = ReturnType<typeof _authClient.useSession>;
 type BaseUseSessionData = NonNullable<BaseUseSessionReturn["data"]>;
 type WidenedUseSessionReturn = Omit<BaseUseSessionReturn, "data"> & {
   data:
-    | (Omit<BaseUseSessionData, "session"> & {
+    | (Omit<BaseUseSessionData, "session" | "user"> & {
         session: BaseUseSessionData["session"] & SessionFieldExtras;
+        user: BaseUseSessionData["user"] & UserFieldExtras;
       })
     | null;
 };

--- a/packages/web/src/ui/hooks/use-platform-admin-guard.ts
+++ b/packages/web/src/ui/hooks/use-platform-admin-guard.ts
@@ -5,19 +5,26 @@ import { useRouter } from "next/navigation";
 import { useAtlasConfig } from "@/ui/context";
 
 /**
- * Returns the user's role from the Better Auth session.
- * Used by the sidebar for item-level visibility and by page guards.
+ * Returns the user's effective role for client-side admin gating.
  *
- * Better Auth's public session type doesn't include `role` on the user object
- * (it's added by the admin/organization plugins at runtime), so we cast through
- * `Record<string, unknown>` to access it. This is the single source of truth
- * for role extraction — all call sites should use this hook rather than
- * duplicating the cast.
+ * Better Auth keeps two role surfaces separate by design: `user.role`
+ * (admin plugin, system-wide — `platform_admin` / `admin` / `user`) and
+ * `member.role` (organization plugin, per-org — `owner` / `admin` /
+ * `member`). The server's `customSession` callback merges them and
+ * exposes the max as `user.effectiveRole` — read that here so an org
+ * admin whose `user.role` defaulted to "user" (the standard signup →
+ * accept-invite flow) still sees admin chrome.
+ *
+ * Falls back to `user.role` for older sessions issued before
+ * customSession landed; both fields disappear gracefully when missing.
+ * This is the single source of truth for role extraction — all call
+ * sites should use this hook.
  */
 export function useUserRole(): string | undefined {
   const { authClient } = useAtlasConfig();
   const session = authClient.useSession();
-  return session.data?.user?.role;
+  const user = session.data?.user;
+  return user?.effectiveRole ?? user?.role;
 }
 
 /**

--- a/packages/web/src/ui/hooks/use-platform-admin-guard.ts
+++ b/packages/web/src/ui/hooks/use-platform-admin-guard.ts
@@ -2,7 +2,10 @@
 
 import { useEffect } from "react";
 import { useRouter } from "next/navigation";
+import { ADMIN_ROLES, type AdminRole } from "@useatlas/types";
 import { useAtlasConfig } from "@/ui/context";
+
+const ADMIN_ROLES_SET: ReadonlySet<string> = new Set<AdminRole>(ADMIN_ROLES);
 
 /**
  * Returns the user's effective role for client-side admin gating.
@@ -25,6 +28,23 @@ export function useUserRole(): string | undefined {
   const session = authClient.useSession();
   const user = session.data?.user;
   return user?.effectiveRole ?? user?.role;
+}
+
+/**
+ * Boolean form of {@link useUserRole} — `true` when the caller has any
+ * admin-grade role (`admin` / `owner` / `platform_admin`). Use this
+ * everywhere admin chrome is gated; the underlying source-of-truth set
+ * is `ADMIN_ROLES` from `@useatlas/types`, so adding a new admin tier
+ * lights up every consumer at once.
+ *
+ * Direct `user.role === "admin" || ...` chains miss the org-merged role
+ * and silently underreport for org admins whose `user.role` is the
+ * signup-default "user" — see the customSession plugin in
+ * `packages/api/src/lib/auth/server.ts`.
+ */
+export function useIsAdmin(): boolean {
+  const role = useUserRole();
+  return role !== undefined && ADMIN_ROLES_SET.has(role);
 }
 
 /**


### PR DESCRIPTION
## Summary
- **Symptom:** Sign up + accept an org admin invite → `/admin/users` shows you as admin, but the gear icon stays hidden in the chat nav and the admin sidebar collapses to read-only chrome.
- **Cause:** Client-side `useUserRole()` reads `session.data.user.role` directly. Better Auth keeps **two** role surfaces separate: `user.role` (admin plugin, system-wide — `platform_admin`/`admin`/`user`) and `member.role` (organization plugin, per-org — `owner`/`admin`/`member`). The server's `resolveEffectiveRole` in `managed.ts` already merges them (max wins) so `/api/v1/admin/*` correctly authorizes org admins, but the client never saw the merge.
- **Fix:** Plumb the same role-resolution into a Better Auth `customSession` plugin so every `getSession` returns `user.effectiveRole = max(user.role, active-org member.role)`. `useUserRole` now prefers `effectiveRole`, falling back to `role` for back-compat. `user.role` is intentionally **not** overwritten so Better Auth's own admin plugin endpoints continue to gate on system role.

## Architecture notes
- `resolveEffectiveRole` extracted from `lib/auth/managed.ts` into `lib/auth/effective-role.ts` so the `customSession` callback and `validateManaged` share one source of truth — drift between client-visible and server-authorized roles becomes structurally impossible.
- customSession bypasses Better Auth's cookie cache by design (docs: "Session caching does not include custom fields"), so the member-table SELECT runs per `getSession`. Same per-request cost `validateManaged` already pays — net DB load unchanged.
- `@useatlas/types` bumps to 0.1.8 for the new optional `effectiveRole` field on `AtlasAuthClient.useSession().data.user`. Template refs unchanged — bump them in a follow-up after publish (version-bump-ordering rule).

## Test plan
- [x] `resolveEffectiveRole` covered for all merge directions (org admin > 'user', platform_admin > org admin, invalid org role, DB error fail-open) — 7 unit tests
- [x] `buildCustomSessionPayload` (the customSession callback shape) — 3 unit tests covering the regression case (matt's user.role="user" + member.role="admin" → effectiveRole="admin", user.role untouched), null fallback, comma-suffix stripping
- [x] `bun run test` — 487/487 files pass on @atlas/api; full suite (api + others) exit 0
- [x] `bun run type` / `bun run lint` / syncpack / drift / published-symbols — all green
- [ ] Manual repro on prod once deploy lands: matt accepts an admin invite → gear icon appears in chat sidebar without a refresh

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/2889"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782524763&installation_id=135337507&pr_number=2889&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F2889&signature=d9283ecf5b818aacd53e77204b13120c6a043f123e6262b49eb6bc5f0043f46b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->