### PR TITLE
fix(api,web): admin semantic detail routes by storage key (#2891)

### DIFF
--- a/packages/api/src/api/__tests__/admin.test.ts
+++ b/packages/api/src/api/__tests__/admin.test.ts
@@ -72,6 +72,23 @@ dimensions:
 `,
   );
 
+  // #2891 fixture — YAML's `name:` ("AuditLog") deliberately differs
+  // from the file stem ("audit_log") so list→detail roundtrip tests
+  // exercise the storage-key path. Pre-fix this was the production
+  // failure mode reported on app.useatlas.dev: clicking the entity
+  // hit `/api/v1/admin/semantic/entities/AuditLog` and 404'd because
+  // the DB row / file stem stored `audit_log`.
+  fs.writeFileSync(
+    path.join(tmpRoot, "entities", "audit_log.yml"),
+    `name: AuditLog
+table: audit_log
+description: Audit trail rows
+dimensions:
+  id:
+    type: integer
+`,
+  );
+
   fs.writeFileSync(
     path.join(tmpRoot, "metrics", "total_companies.yml"),
     `name: total_companies
@@ -756,8 +773,10 @@ describe("GET /api/v1/admin/overview", () => {
     // an org context the helper falls through to runtime `default` (which
     // exists in the test mock), so we still see 1.
     expect(body.connections).toBe(1);
-    // 2 disk entities (companies + warehouse/orders) via `listAdminEntities`.
-    expect(body.entities).toBe(2);
+    // 3 disk entities (companies + warehouse/orders + audit_log) via
+    // `listAdminEntities`. `audit_log` is the #2891 fixture whose YAML
+    // `name:` deliberately differs from its file stem.
+    expect(body.entities).toBe(3);
     expect(body.plugins).toBe(1);
     // Deployment-scaffold tiles (metrics, glossaryTerms, pluginHealth)
     // moved to /api/v1/platform/overview per #2489 — assert they're gone
@@ -879,7 +898,8 @@ describe("GET /api/v1/admin/semantic/entities", () => {
     expect(res.status).toBe(200);
 
     const body = (await res.json()) as { entities: Array<Record<string, unknown>> };
-    expect(body.entities.length).toBe(2);
+    // Count covers all three fixtures (companies, orders, audit_log).
+    expect(body.entities.length).toBe(3);
 
     const companies = body.entities.find((e) => e.table === "companies");
     expect(companies).toBeDefined();
@@ -892,6 +912,15 @@ describe("GET /api/v1/admin/semantic/entities", () => {
     expect(orders).toBeDefined();
     expect(orders!.source).toBe("warehouse");
     expect(orders!.connection).toBe("warehouse");
+
+    // #2891: list response must carry both the storage `name` (file
+    // stem) and the YAML's `displayName`. The frontend routes URLs by
+    // `name` (so detail lookup matches the DB / disk key), but
+    // renders the file tree off `displayName`.
+    const auditLog = body.entities.find((e) => e.table === "audit_log");
+    expect(auditLog).toBeDefined();
+    expect(auditLog!.name).toBe("audit_log");
+    expect(auditLog!.displayName).toBe("AuditLog");
   });
 });
 
@@ -1232,6 +1261,29 @@ describe("GET /api/v1/admin/semantic/entities/:name", () => {
 
     const body = (await res.json()) as { entity: Record<string, unknown> };
     expect(body.entity.table).toBe("orders");
+  });
+
+  // #2891: every storage `name` returned by the list endpoint must
+  // resolve to a 200 on the detail endpoint. Pre-fix the list was
+  // returning the YAML's display `name:` while the detail handler keyed
+  // on the file stem / DB row `name`, so the click-to-load path 404'd
+  // for any entity whose YAML name differed from its filename. Iterates
+  // every row instead of pinning a single fixture so a future
+  // entity that drifts on display vs. storage trips this immediately.
+  it("every name from the list endpoint resolves on the detail endpoint (#2891)", async () => {
+    const listRes = await app.fetch(adminRequest("/api/v1/admin/semantic/entities"));
+    expect(listRes.status).toBe(200);
+    const listBody = (await listRes.json()) as { entities: Array<Record<string, unknown>> };
+    expect(listBody.entities.length).toBeGreaterThan(0);
+
+    for (const entry of listBody.entities) {
+      const name = entry.name;
+      expect(typeof name).toBe("string");
+      const detailRes = await app.fetch(
+        adminRequest(`/api/v1/admin/semantic/entities/${encodeURIComponent(String(name))}`),
+      );
+      expect(detailRes.status).toBe(200);
+    }
   });
 });
 
@@ -1714,9 +1766,9 @@ describe("GET /api/v1/admin/semantic/stats", () => {
     expect(res.status).toBe(200);
 
     const body = (await res.json()) as Record<string, unknown>;
-    // 2 entities: companies (3 cols) + orders (2 cols) = 5 total columns
-    expect(body.totalEntities).toBe(2);
-    expect(body.totalColumns).toBe(5);
+    // 3 entities: companies (3 cols) + orders (2 cols) + audit_log (1 col) = 6 total columns
+    expect(body.totalEntities).toBe(3);
+    expect(body.totalColumns).toBe(6);
     expect(body.totalJoins).toBe(1);
     expect(body.totalMeasures).toBe(1);
     expect(body.coverageGaps).toBeDefined();

--- a/packages/api/src/api/__tests__/semantic-overlay.test.ts
+++ b/packages/api/src/api/__tests__/semantic-overlay.test.ts
@@ -50,8 +50,10 @@ let detailResult: { entity: Record<string, unknown>; status: string; source: str
 let detailThrow: Error | null = null;
 
 function makeDbSummary(over: Partial<AdminEntitySummary> & Pick<AdminEntitySummary, "table">): AdminEntitySummary {
+  const name = over.name ?? over.table;
   return {
-    name: over.name ?? over.table,
+    name,
+    displayName: over.displayName ?? name,
     table: over.table,
     description: over.description ?? "",
     columnCount: over.columnCount ?? 0,
@@ -68,8 +70,10 @@ function makeDbSummary(over: Partial<AdminEntitySummary> & Pick<AdminEntitySumma
 }
 
 function makeDiskSummary(over: Partial<AdminEntitySummary> & Pick<AdminEntitySummary, "table">): AdminEntitySummary {
+  const name = over.name ?? over.table;
   return {
-    name: over.name ?? over.table,
+    name,
+    displayName: over.displayName ?? name,
     table: over.table,
     description: over.description ?? "",
     columnCount: over.columnCount ?? 0,

--- a/packages/api/src/lib/semantic/__tests__/admin-source.test.ts
+++ b/packages/api/src/lib/semantic/__tests__/admin-source.test.ts
@@ -20,6 +20,12 @@ const dbRow = (over: Partial<SemanticEntityRow> & Pick<SemanticEntityRow, "name"
 });
 
 const diskSummary = (over: Partial<EntitySummary> & Pick<EntitySummary, "table">): EntitySummary => ({
+  // #2891: `name` is the file stem (storage key). Default to `table` so
+  // existing fixtures that only specify `table` keep working — that
+  // matches the convention in the rest of the suite where filename ≡
+  // table.
+  name: over.name ?? over.table,
+  displayName: over.displayName ?? over.table,
   table: over.table,
   description: over.description ?? "",
   columnCount: over.columnCount ?? 0,
@@ -58,6 +64,7 @@ measures:
     expect(summary).not.toBeNull();
     expect(summary).toEqual({
       name: "users",
+      displayName: "users",
       table: "users",
       description: "User accounts",
       columnCount: 2,
@@ -73,18 +80,25 @@ measures:
     } satisfies AdminEntitySummary);
   });
 
-  it("uses the entity's `name` field when distinct from `table`", () => {
+  it("`displayName` is the YAML `name:` field, `name` is the row storage key (#2891)", () => {
+    // The headline bug: pre-#2891 the wire `name` was the YAML's `name:`
+    // field, but the detail handler queries by `row.name` (file stem /
+    // table name). Every CamelCase entity 404'd. Post-fix `name` is the
+    // storage key — the value the detail route uses for lookup.
     const row = dbRow({
-      name: "user_accounts",
-      yaml_content: "table: users\nname: user_accounts\n",
+      name: "audit_log",
+      yaml_content: "table: audit_log\nname: AuditLog\n",
     });
-    expect(parseRowToAdminSummary(row)?.name).toBe("user_accounts");
-    expect(parseRowToAdminSummary(row)?.table).toBe("users");
+    const summary = parseRowToAdminSummary(row);
+    expect(summary?.name).toBe("audit_log");
+    expect(summary?.displayName).toBe("AuditLog");
+    expect(summary?.table).toBe("audit_log");
   });
 
-  it("falls back to the row name when the YAML has no `name` field", () => {
+  it("falls back `displayName` to the table when the YAML has no `name` field", () => {
     const row = dbRow({ name: "orders", yaml_content: "table: orders\n" });
     expect(parseRowToAdminSummary(row)?.name).toBe("orders");
+    expect(parseRowToAdminSummary(row)?.displayName).toBe("orders");
   });
 
   it("returns null and skips rows with unparseable YAML", () => {
@@ -189,6 +203,7 @@ describe("mergeAdminEntities", () => {
     // every consumer of the shape, not just `toMatchObject` subsets.
     expect(result.entities[0]).toEqual({
       name: "users",
+      displayName: "users",
       table: "users",
       description: "From DB",
       columnCount: 0,
@@ -225,10 +240,12 @@ describe("mergeAdminEntities", () => {
     expect(result.entities[0].description).toBe("From DB draft");
   });
 
-  it("dedup key is summary `name`, not DB row `name` — divergent names produce two entries", () => {
-    // A DB row with display name "user_accounts" over `table: users` and a
-    // disk entity with `table: users` are genuinely different things and
-    // should both appear. Collapsing them would hide one from the file tree.
+  it("dedup keys on the storage `name` — divergent storage keys produce two entries", () => {
+    // A DB row stored as `user_accounts` (with `table: users`) and a
+    // disk entity stored as `users.yml` are genuinely different things
+    // and should both appear. Collapsing them would hide one from the
+    // file tree. #2891 codified that `summary.name` is the storage key,
+    // so this also pins the dedup semantic to it explicitly.
     const result = mergeAdminEntities({
       dbRows: [
         dbRow({

--- a/packages/api/src/lib/semantic/__tests__/admin-source.test.ts
+++ b/packages/api/src/lib/semantic/__tests__/admin-source.test.ts
@@ -391,6 +391,37 @@ describe("mergeAdminEntities", () => {
     expect(result.entities[0].description).toBe("From DB null");
   });
 
+  it("preserves both disk rows when the same stem lives in two source dirs (#2891)", () => {
+    // Pre-#2891 the disk dedup was `(table, null)` — different tables
+    // surfaced both rows. Post-#2891 the storage `name` is the file
+    // stem, so same-stem files would collide if `connectionId` weren't
+    // populated. The disk projector lifts `source` into `connectionId`
+    // (when not "default") so per-source variants stay distinct.
+    const result = mergeAdminEntities({
+      dbRows: [],
+      diskEntities: [
+        diskSummary({ name: "orders", table: "shopify_orders", source: "shopify" }),
+        diskSummary({ name: "orders", table: "stripe_orders", source: "stripe" }),
+      ],
+      diskWarnings: [],
+    });
+
+    expect(result.entities).toHaveLength(2);
+    const byGroup = new Map(result.entities.map((e) => [e.connectionId, e]));
+    expect(byGroup.get("shopify")?.table).toBe("shopify_orders");
+    expect(byGroup.get("stripe")?.table).toBe("stripe_orders");
+  });
+
+  it("default-source disk rows keep `connectionId: null` (badge-free rendering)", () => {
+    const result = mergeAdminEntities({
+      dbRows: [],
+      diskEntities: [diskSummary({ name: "users", table: "users", source: "default" })],
+      diskWarnings: [],
+    });
+    expect(result.entities).toHaveLength(1);
+    expect(result.entities[0].connectionId).toBeNull();
+  });
+
   it("sort is deterministic — same name across groups orders by name then group", () => {
     // Two `users` (g_prod_eu, g_prod_us) and one `orders` (g_prod_us)
     // — name asc, then group asc. Without a stable secondary key the

--- a/packages/api/src/lib/semantic/admin-source.ts
+++ b/packages/api/src/lib/semantic/admin-source.ts
@@ -102,7 +102,14 @@ export type AdminEntitySummary =
   | (AdminEntitySummaryShared & {
       readonly sourceKind: "disk";
       readonly status: "published";
-      readonly connectionId: null;
+      /**
+       * `null` for the default `entities/` dir. Per-source disk dirs
+       * (`semantic/<source>/entities/`) lift their source name into
+       * `connectionId` (#2891) — same-stem files under different sources
+       * would otherwise collide on the `(name, connectionId)` dedup key.
+       * Read-only for the file tree's env badge.
+       */
+      readonly connectionId: string | null;
       readonly updatedAt: null;
     });
 
@@ -255,10 +262,20 @@ export function parseRowToAdminSummary(row: SemanticEntityRow): AdminEntitySumma
 }
 
 function diskToAdminSummary(e: EntitySummary): AdminEntitySummary {
+  // #2891: disk lookups go through `findEntityFile(root, name)` which
+  // expects the file stem — so `name` must be the file stem, not the
+  // table. `displayName` keeps the existing UX label.
+  //
+  // Per-source disk dirs (`semantic/<source>/entities/<stem>.yml`) can
+  // hold the same file stem under different sources — the merge dedup
+  // is `(name, connectionId)`, so leaving `connectionId: null` for
+  // every disk row would collapse them. Treating `source` as a virtual
+  // group keeps both rows in the list and surfaces the source label as
+  // the file-tree env badge (which is what the admin actually wants to
+  // see for multi-source self-hosted layouts). "default" stays null so
+  // single-source orgs keep the unchanged badge-free rendering.
+  const groupAsSource = e.source !== "default" ? e.source : null;
   return {
-    // #2891: disk lookups go through `findEntityFile(root, name)` which
-    // expects the file stem — so `name` must be the file stem, not the
-    // table. `displayName` keeps the existing UX label.
     name: e.name,
     displayName: e.displayName,
     table: e.table,
@@ -271,7 +288,7 @@ function diskToAdminSummary(e: EntitySummary): AdminEntitySummary {
     type: e.type,
     status: "published",
     sourceKind: "disk",
-    connectionId: null,
+    connectionId: groupAsSource,
     updatedAt: null,
   };
 }

--- a/packages/api/src/lib/semantic/admin-source.ts
+++ b/packages/api/src/lib/semantic/admin-source.ts
@@ -62,14 +62,24 @@ export type AdminEntityStatus = "published" | "draft";
  * `status === "published"` at the type level — invariants that hold by
  * construction but used to be expressible only in comments.
  *
- * `name` is the display name (the YAML `name:` field if present, otherwise
- * the table). `table` is always the SQL table. Some entities deliberately
- * differ (e.g. a metric `name: mrr` over `table: subscription_events`).
+ * `name` is the storage key — the DB row's `name` column (DB branch) or
+ * the YAML file stem (disk branch). The detail / edit / delete routes
+ * look up by this exact value, so the frontend must roundtrip it through
+ * URLs unchanged. #2891.
+ *
+ * `displayName` is what the file tree renders — the YAML `name:` field
+ * if present, otherwise the `table:` value. Pre-#2891 this was overloaded
+ * onto `name` and 404'd every detail lookup whose YAML name didn't match
+ * the storage key.
+ *
+ * `table` is always the SQL table. Some entities deliberately differ on
+ * `name` / `table` (e.g. a metric `name: mrr` over `table: subscription_events`).
  * Collapsing the two was the conflation bug the frontend shape-normalizer
  * was masking before #2312.
  */
 interface AdminEntitySummaryShared {
   readonly name: string;
+  readonly displayName: string;
   readonly table: string;
   readonly description: string;
   readonly columnCount: number;
@@ -223,7 +233,12 @@ export function parseRowToAdminSummary(row: SemanticEntityRow): AdminEntitySumma
   const status: AdminEntityStatus = row.status === "draft" ? "draft" : "published";
 
   return {
-    name: nameField ?? parsed.data.table,
+    // #2891: `name` is the storage key (`row.name`) so the URL the
+    // frontend builds from this response roundtrips to a successful
+    // `getEntity(... name)` lookup. `displayName` carries what the file
+    // tree used to render off `name` (YAML `name:` field or table).
+    name: row.name,
+    displayName: nameField ?? parsed.data.table,
     table: parsed.data.table,
     description: typeof data.description === "string" ? data.description : "",
     columnCount: sectionLength(data.dimensions),
@@ -241,7 +256,11 @@ export function parseRowToAdminSummary(row: SemanticEntityRow): AdminEntitySumma
 
 function diskToAdminSummary(e: EntitySummary): AdminEntitySummary {
   return {
-    name: e.table,
+    // #2891: disk lookups go through `findEntityFile(root, name)` which
+    // expects the file stem — so `name` must be the file stem, not the
+    // table. `displayName` keeps the existing UX label.
+    name: e.name,
+    displayName: e.displayName,
     table: e.table,
     description: e.description,
     columnCount: e.columnCount,

--- a/packages/api/src/lib/semantic/files.ts
+++ b/packages/api/src/lib/semantic/files.ts
@@ -58,6 +58,22 @@ export function readYamlFile(filePath: string): unknown {
 }
 
 export interface EntitySummary {
+  /**
+   * Storage key — the YAML file stem (`audit_log` for `audit_log.yml`).
+   * This is the identifier the detail/edit/delete routes look up by
+   * (`getAdminEntity` → `findEntityFile` on disk, `getEntity` against the
+   * `semantic_entities.name` column in the DB). #2891: keeping this
+   * distinct from `displayName` so URL routing can't drift from the
+   * stored row whenever a YAML's `name:` field disagrees with its filename.
+   */
+  name: string;
+  /**
+   * Display label — the YAML `name:` field if present, otherwise the
+   * `table:` value. Pre-#2891 this was the only "name" surfaced and
+   * doubled as the URL routing key, which 404'd on every YAML whose
+   * `name:` differed from the filename. Now strictly for rendering.
+   */
+  displayName: string;
   table: string;
   description: string;
   columnCount: number;
@@ -95,7 +111,12 @@ export function discoverEntities(root: string): DiscoverEntitiesResult {
     const joins = Array.isArray(raw.joins) ? raw.joins : (raw.joins && typeof raw.joins === "object" ? Object.keys(raw.joins) : []);
     const measures = Array.isArray(raw.measures) ? raw.measures : (raw.measures && typeof raw.measures === "object" ? Object.keys(raw.measures) : []);
 
+    const fileStem = path.basename(filePath, ".yml");
+    const displayName =
+      typeof raw.name === "string" && raw.name ? raw.name : String(raw.table);
     entities.push({
+      name: fileStem,
+      displayName,
       table: String(raw.table),
       description: typeof raw.description === "string" ? raw.description : "",
       columnCount: dimensions.length,

--- a/packages/web/src/app/admin/semantic/__tests__/drift-routing.test.ts
+++ b/packages/web/src/app/admin/semantic/__tests__/drift-routing.test.ts
@@ -8,12 +8,17 @@ import { describe, expect, test } from "bun:test";
 import { driftDrawerTargetFor } from "../drift-routing";
 
 const entities = [
-  { name: "orders", connectionGroupId: null, drift: { state: "changed" as const, changeCount: 2 } },
-  { name: "users", connectionGroupId: null, drift: { state: "in-sync" as const } },
-  { name: "legacy", connectionGroupId: null, drift: { state: "removed" as const } },
-  { name: "dbonly", connectionGroupId: null, drift: { state: "new" as const } },
-  { name: "no_drift_data", connectionGroupId: null, drift: null },
-  { name: "orders", connectionGroupId: "g_prod", drift: { state: "changed" as const, changeCount: 1 } },
+  { name: "orders", table: "orders", connectionGroupId: null, drift: { state: "changed" as const, changeCount: 2 } },
+  { name: "users", table: "users", connectionGroupId: null, drift: { state: "in-sync" as const } },
+  { name: "legacy", table: "legacy", connectionGroupId: null, drift: { state: "removed" as const } },
+  { name: "dbonly", table: "dbonly", connectionGroupId: null, drift: { state: "new" as const } },
+  { name: "no_drift_data", table: "no_drift_data", connectionGroupId: null, drift: null },
+  { name: "orders", table: "orders", connectionGroupId: "g_prod", drift: { state: "changed" as const, changeCount: 1 } },
+  // #2891: storage `name` deliberately differs from SQL `table`. Drift
+  // is keyed by table both server-side (`attachDrift`) and in the
+  // drawer body (`tableDiffs[].table`), so the predicate must surface
+  // the table — not the name — to keep the drawer's lookup working.
+  { name: "audit_log_v2", table: "audit_log", connectionGroupId: null, drift: { state: "changed" as const, changeCount: 1 } },
 ];
 
 describe("driftDrawerTargetFor", () => {
@@ -89,5 +94,17 @@ describe("driftDrawerTargetFor", () => {
     expect(
       driftDrawerTargetFor({ type: "entity", name: "orders" }, entities),
     ).toBe("orders");
+  });
+
+  test("returns the matched entity's table — not the selection's storage name (#2891)", () => {
+    // When the storage `name` differs from the SQL `table` (e.g. a
+    // DB-backed entity stored under `audit_log_v2` whose YAML declares
+    // `table: audit_log`), routing the drawer by the storage name
+    // would land on `tableDiffs[].table === "audit_log_v2"` and miss.
+    // The drawer keys diff lookups by table, so the predicate must
+    // return the table.
+    expect(
+      driftDrawerTargetFor({ type: "entity", name: "audit_log_v2" }, entities),
+    ).toBe("audit_log");
   });
 });

--- a/packages/web/src/app/admin/semantic/drift-routing.ts
+++ b/packages/web/src/app/admin/semantic/drift-routing.ts
@@ -4,19 +4,28 @@ import type {
 } from "@/ui/components/admin/semantic-file-tree";
 
 /**
- * Minimal lookup row — name + group qualifier + drift state. Kept narrower
- * than `EntitySummary` so a future schema growth on the page can't drift
- * this predicate's input shape without an explicit edit.
+ * Minimal lookup row — name + group qualifier + drift state + table.
+ * Kept narrower than `EntitySummary` so a future schema growth on the
+ * page can't drift this predicate's input shape without an explicit
+ * edit.
+ *
+ * `table` is required (#2891) because the drift drawer keys diff lookups
+ * by SQL table (`tableDiffs[].table`, `removedTables[]`, `newTables[]`),
+ * not the entity storage `name`. When the two diverge (e.g. DB row
+ * `name = audit_log_v2` with YAML `table: audit_log`, or any YAML whose
+ * `name:` field doesn't match `table:`), routing the drawer by `name`
+ * would open it to "no drift detected".
  */
 export interface DriftRoutingEntity {
   readonly name: string;
+  readonly table: string;
   readonly connectionGroupId: string | null;
   readonly drift?: SemanticTreeDrift | null;
 }
 
 /**
- * Returns the entity name to open the drift drawer for, or `null` if the
- * click should fall through to the regular entity-detail view.
+ * Returns the SQL table name to open the drift drawer for, or `null` if
+ * the click should fall through to the regular entity-detail view.
  *
  * The drawer opens for `changed`, `removed`, or `new` rows (#2461). `new`
  * doesn't currently appear in the YAML-side file tree but is included so
@@ -25,7 +34,8 @@ export interface DriftRoutingEntity {
  * Match keys on both `name` and `connectionGroupId` to keep multi-
  * environment orgs (#2412) coherent — the same `name` under two groups
  * is two rows, and a stale group qualifier shouldn't open a drawer for
- * the other env's drift.
+ * the other env's drift. The returned value is the matched entity's
+ * `table` (#2891) so the drawer's drift lookup hits.
  */
 export function driftDrawerTargetFor(
   selection: SemanticSelection,
@@ -37,9 +47,10 @@ export function driftDrawerTargetFor(
       e.name === selection.name &&
       e.connectionGroupId === (selection.connectionGroupId ?? null),
   );
-  const state = match?.drift?.state;
+  if (!match) return null;
+  const state = match.drift?.state;
   if (state === "changed" || state === "removed" || state === "new") {
-    return selection.name;
+    return match.table;
   }
   return null;
 }

--- a/packages/web/src/app/admin/semantic/page.tsx
+++ b/packages/web/src/app/admin/semantic/page.tsx
@@ -66,8 +66,16 @@ import { driftDrawerTargetFor } from "./drift-routing";
 // ── Types ─────────────────────────────────────────────────────────
 
 interface EntitySummary {
-  /** Display name — the YAML `name:` if present, otherwise the table. */
+  /**
+   * Storage key (#2891) — the DB row's `name` column or the disk file
+   * stem. The detail / edit / delete handlers look up by this exact
+   * value, so all URLs and `SemanticSelection.name` must roundtrip it
+   * unchanged. Previously `name` doubled as the display label; that
+   * 404'd every entity whose YAML `name:` differed from the file stem.
+   */
   name: string;
+  /** Display label — the YAML `name:` field if present, otherwise the table. */
+  displayName: string;
   table: string;
   description: string;
   columnCount: number;
@@ -528,6 +536,16 @@ export default function SemanticPage() {
             typeof e.name === "string" && e.name
               ? e.name
               : tableField;
+          // #2891: `displayName` is the new server-side field. Pre-#2891
+          // (and any older mirror) only sends `name`, which was already
+          // the display label — fall back to it so the tree keeps
+          // rendering CamelCase even before the API rolls out the new
+          // field. The `name` we routed by used to be display too, so
+          // the fallback URL still works on those mirrors.
+          const displayField =
+            typeof e.displayName === "string" && e.displayName
+              ? e.displayName
+              : nameField;
           // `connectionId` is the server's group-id slot (named that way
           // because the response shape predates the rename). `null` /
           // missing → legacy unscoped row. (#2412)
@@ -536,6 +554,7 @@ export default function SemanticPage() {
             typeof rawGroup === "string" && rawGroup.length > 0 ? rawGroup : null;
           return {
             name: nameField,
+            displayName: displayField,
             table: tableField || nameField,
             description: typeof e.description === "string" ? e.description : "",
             columnCount: typeof e.columnCount === "number" ? e.columnCount : 0,
@@ -752,16 +771,20 @@ export default function SemanticPage() {
   };
 
   // Sort matches the backend's mergeAdminEntities order so paging is
-  // stable across server/client (#2412).
+  // stable across server/client (#2412). #2891: tree rows expose both
+  // `name` (storage key — used for selection roundtrip + URL) and
+  // `displayName` (rendered label). Sorted by display so the file-tree
+  // alphabet matches what the user reads.
   const treeEntities = entities
     .map((e) => ({
       name: e.name,
+      displayName: e.displayName,
       connectionGroupId: e.connectionGroupId,
       draft: e.draft,
       drift: e.drift,
     }))
     .toSorted((a, b) => {
-      const byName = a.name.localeCompare(b.name);
+      const byName = a.displayName.localeCompare(b.displayName);
       if (byName !== 0) return byName;
       const ag = a.connectionGroupId ?? "";
       const bg = b.connectionGroupId ?? "";

--- a/packages/web/src/ui/components/admin/semantic-file-tree.tsx
+++ b/packages/web/src/ui/components/admin/semantic-file-tree.tsx
@@ -45,9 +45,16 @@ export type SemanticTreeDrift =
  * same `name` under multiple `connectionGroupId`s — keying off the pair
  * keeps React keys unique and lets the badge tell the admin which
  * environment a row belongs to (#2412).
+ *
+ * #2891: `name` is the storage key the detail / edit / delete handlers
+ * look up by — `SemanticSelection.name` and the URL `?file=` param
+ * must roundtrip it unchanged. `displayName` is the label rendered as
+ * `<name>.yml`; falls back to `name` when missing so older API
+ * responses keep rendering.
  */
 export interface SemanticTreeEntity {
   readonly name: string;
+  readonly displayName?: string;
   /** Group id (e.g. `g_prod_us`) or `null` for the legacy / unscoped row. */
   readonly connectionGroupId: string | null;
   /** `true` when the row carries a draft overlay; renders the amber accent. */
@@ -260,10 +267,12 @@ export function SemanticFileTree({
                   name: entry.name,
                   connectionGroupId: entry.connectionGroupId,
                 };
+                // #2891: render display label, route by storage key.
+                const label = entry.displayName ?? entry.name;
                 return (
                   <FileItem
                     key={key}
-                    name={`${entry.name}.yml`}
+                    name={`${label}.yml`}
                     selected={isSelected(selection, target)}
                     onClick={() => onSelect(target)}
                     indent={1}


### PR DESCRIPTION
## Summary

- **Bug** ([#2891](https://github.com/AtlasDevHQ/atlas/issues/2891)): clicking any entity on `/admin/semantic` in production 404'd. The list returned the YAML `name:` (display) field but the detail handler queried `WHERE name = $1` against the storage column (the file stem / table name). For demo-data style YAMLs where `name: Customers` over `table: customers`, the URL routed by "Customers" while the DB row stored "customers" → 404.
- **Fix**: split the wire shape. `name` is the storage key; new `displayName` field carries the label the file tree renders. URLs route by `name` (matches the detail handler's lookup); the file tree continues to render the YAML display name via `displayName`.
- **Surfaces**: `parseRowToAdminSummary` returns `row.name`; `diskToAdminSummary` returns the file stem; `discoverEntities` populates both; `page.tsx` + `SemanticFileTree` consume both. Frontend falls back to `name` when `displayName` is absent so older mirrors keep rendering.

## Test plan

- [x] `bun run test` (full `packages/api` isolated suite — 487 files green)
- [x] `bun run test` in `packages/web` (166 files green)
- [x] `bun run lint`, `bun run type`
- [x] `scripts/check-schema-drift.sh`, `check-ee-imports.sh`, `check-template-drift.sh`, `check-test-discipline.sh`, `check-twenty-resolver-imports.sh`
- [x] New unit test `parseRowToAdminSummary: displayName is YAML name, name is storage key (#2891)` pins the bug.
- [x] New integration test `every name from the list endpoint resolves on the detail endpoint (#2891)` iterates the fixture list so any future drift between display + storage trips immediately.
- [x] New disk fixture `audit_log.yml` with `name: AuditLog` reproduces the production-bug shape; existing `companies` / `orders` fixtures keep passing.
- [ ] Verified on `app.useatlas.dev/admin/semantic` post-deploy — every entity in the file tree loads its detail on click.

Closes #2891.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/2892"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782565764&installation_id=135337507&pr_number=2892&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F2892&signature=b5e18b0f4e6f5f0e5f37b8dd4046bf802abe83be72e43f62208879936b4eb7f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->