### PR TITLE
fix(deploy): add staging arm to residency.regions

### DIFF
--- a/deploy/api/atlas.config.ts
+++ b/deploy/api/atlas.config.ts
@@ -947,6 +947,16 @@ export default defineConfig({
         databaseUrl: process.env.ATLAS_REGION_APAC_DB_URL!,
         apiUrl: "https://api-apac.useatlas.dev",
       },
+      // Staging arm — single-region soak environment. Per PRD #2894 it shares
+      // the prod NovaMart datasource but its own Postgres (DATABASE_URL). No
+      // real cross-region traffic ever claims residency="staging"; this arm
+      // exists so the SaaS region guard at saas-guards.ts:570 accepts
+      // ATLAS_API_REGION=staging without a hard-fail boot.
+      "staging": {
+        label: "Staging",
+        databaseUrl: process.env.DATABASE_URL!,
+        apiUrl: "https://staging.api.useatlas.dev",
+      },
     },
   },
 });


### PR DESCRIPTION
## Summary

- `deploy/api/atlas.config.ts` — add `staging` region arm so api-staging boots with `ATLAS_API_REGION=staging` (PRD #2894).
- Single-line config change. Boot guard at `saas-guards.ts:570` hard-fails without it.
- Patch tag (`v0.1.1`) will follow this merge to roll staging out.

## Why

The dual-trigger Railway environment (PR #2922) wired api-staging with `ATLAS_API_REGION=staging` as the region discriminator, per PRD #2894 §"Region-keying and deploy mode". But `atlas.config.ts` only declares `[us, eu, apac]`. Runtime crashes:

```
RegionMisconfiguredError: SaaS region booted with ATLAS_API_REGION="staging"
but config.residency.regions does not declare that key. Available regions: [us, eu, apac].
```

The staging arm reuses the same shape as us/eu/apac, pointing `databaseUrl` at the staging Postgres (`DATABASE_URL`) and `apiUrl` at the staging endpoint. No customer ever claims `residency="staging"`, so the routing path is dead — this exists purely to satisfy the boot guard.

PRD #2894's longer-term `ResidencyResolver` staging-arm (returns null, falls through to local DB) is tracked separately for v0.1.x.

## Test plan

- [x] `/ci` — lint, type, syncpack, template drift, security headers drift, railway watch, schema drift, oauth helper drift, test discipline, twenty resolver imports, published symbols all pass
- [ ] Full test suite (running in background; will check before merge)
- [ ] After merge + `/release v0.1.1`: api-staging boots cleanly; `https://staging.api.useatlas.dev/api/v1/health` returns `{"region":"staging",...}` (once Cloudflare CNAMEs switched to DNS-only for Let's Encrypt to issue)

Refs #2921, #2894

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/2925"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782589109&installation_id=135337507&pr_number=2925&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F2925&signature=3fa11161f4250f3df8fe5d42c76876c1d314d91fcf462abaccee1e45aed3f543"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->