### PR TITLE
fix(deploy): web Dockerfile NEXT_PUBLIC_* overridable via build args

### DIFF
--- a/deploy/web/Dockerfile
+++ b/deploy/web/Dockerfile
@@ -63,9 +63,17 @@ COPY . .
 RUN cd packages/types && bun run build
 RUN cd packages/sdk && bun run build
 RUN cd packages/react && bun run build
-# Bake build-time env vars into the client JS bundle
-ENV NEXT_PUBLIC_ATLAS_API_URL=https://api.useatlas.dev
-ENV NEXT_PUBLIC_ATLAS_AUTH_MODE=managed
+# Bake build-time env vars into the client JS bundle.
+# ARG-with-default lets Railway pass a per-service override via build args
+# (Railway maps service env vars to `--build-arg` automatically) without
+# forking the Dockerfile for each environment. Prod keeps the default;
+# staging overrides via `NEXT_PUBLIC_ATLAS_API_URL=https://staging.api.useatlas.dev`
+# on the web-staging service. Without ARG, the ENV literal would always win
+# and bake the prod URL into staging's bundle.
+ARG NEXT_PUBLIC_ATLAS_API_URL=https://api.useatlas.dev
+ARG NEXT_PUBLIC_ATLAS_AUTH_MODE=managed
+ENV NEXT_PUBLIC_ATLAS_API_URL=$NEXT_PUBLIC_ATLAS_API_URL
+ENV NEXT_PUBLIC_ATLAS_AUTH_MODE=$NEXT_PUBLIC_ATLAS_AUTH_MODE
 RUN cd packages/web && bun run build
 
 # --- runner ---


### PR DESCRIPTION
## Summary

- `deploy/web/Dockerfile` — convert `ENV NEXT_PUBLIC_*=...` (hardcoded, unoverridable) to `ARG ... + ENV $ARG` so Railway's per-service env vars actually flow into the Next.js client bundle.
- Fixes "Unable to reach the API server" on app-staging.useatlas.dev (was calling prod api.useatlas.dev, CORS denied).
- Prod behavior unchanged: ARG default = prior hardcoded value.

## Why

Next.js inlines `NEXT_PUBLIC_*` at `next build` time. The Dockerfile had:

```dockerfile
ENV NEXT_PUBLIC_ATLAS_API_URL=https://api.useatlas.dev
RUN cd packages/web && bun run build
```

`ENV` cannot be overridden by `--build-arg` (only `ARG` can). So the Railway service env var `NEXT_PUBLIC_ATLAS_API_URL=https://staging.api.useatlas.dev` set on web-staging was being silently dropped at build time. The staging bundle ended up with `https://api.useatlas.dev` baked in.

The fix is the standard Docker pattern:

```dockerfile
ARG NEXT_PUBLIC_ATLAS_API_URL=https://api.useatlas.dev
ARG NEXT_PUBLIC_ATLAS_AUTH_MODE=managed
ENV NEXT_PUBLIC_ATLAS_API_URL=$NEXT_PUBLIC_ATLAS_API_URL
ENV NEXT_PUBLIC_ATLAS_AUTH_MODE=$NEXT_PUBLIC_ATLAS_AUTH_MODE
RUN cd packages/web && bun run build
```

Railway automatically maps service env vars to `--build-arg <K>=<V>` on Dockerfile builds, so:
- Prod web has no `NEXT_PUBLIC_ATLAS_API_URL` set → ARG default wins → bundle inlines `https://api.useatlas.dev` (same as before)
- Staging web has the var set → Railway passes `--build-arg NEXT_PUBLIC_ATLAS_API_URL=https://staging.api.useatlas.dev` → bundle inlines the staging URL

## Test plan

- [x] Type check passes (`bun run type`)
- [x] Lint passes (`bun run lint`)
- [x] Template drift passes
- [x] Railway watchPatterns coverage passes
- [ ] After merge + redeploy of web-staging: bundle includes `staging.api.useatlas.dev` (not `api.useatlas.dev`); `app-staging.useatlas.dev` loads `/login` page without "Unable to reach API server" error
- [ ] Prod regression check: after the patch tag deploys, `app.useatlas.dev` bundle still includes `api.useatlas.dev` (default unchanged)

Refs #2921, #2894

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/2932"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782592704&installation_id=135337507&pr_number=2932&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F2932&signature=07dd0494213435303d47a95609b459ad2335dfac9d691950e71f336b5a048319"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->