### PR TITLE
feat(api): env-profile module — isolate staging auth cookies from prod

### DIFF
--- a/packages/api/src/lib/__tests__/env-profile.test.ts
+++ b/packages/api/src/lib/__tests__/env-profile.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "bun:test";
+import { resolveDeployEnv, getEnvProfile } from "@atlas/api/lib/env-profile";
+
+describe("resolveDeployEnv", () => {
+  it("defaults to production when ATLAS_DEPLOY_ENV is unset", () => {
+    expect(resolveDeployEnv({})).toBe("production");
+  });
+
+  it("returns production for explicit production", () => {
+    expect(resolveDeployEnv({ ATLAS_DEPLOY_ENV: "production" })).toBe("production");
+  });
+
+  it("returns staging for staging", () => {
+    expect(resolveDeployEnv({ ATLAS_DEPLOY_ENV: "staging" })).toBe("staging");
+  });
+
+  it("returns development for development", () => {
+    expect(resolveDeployEnv({ ATLAS_DEPLOY_ENV: "development" })).toBe("development");
+  });
+
+  it("is case-insensitive", () => {
+    expect(resolveDeployEnv({ ATLAS_DEPLOY_ENV: "STAGING" })).toBe("staging");
+    expect(resolveDeployEnv({ ATLAS_DEPLOY_ENV: "Production" })).toBe("production");
+  });
+
+  it("trims whitespace", () => {
+    expect(resolveDeployEnv({ ATLAS_DEPLOY_ENV: "  staging  " })).toBe("staging");
+  });
+
+  it("falls back to production for unknown values (no hard-fail)", () => {
+    expect(resolveDeployEnv({ ATLAS_DEPLOY_ENV: "qa" })).toBe("production");
+    expect(resolveDeployEnv({ ATLAS_DEPLOY_ENV: "prod" })).toBe("production");
+    expect(resolveDeployEnv({ ATLAS_DEPLOY_ENV: "" })).toBe("production");
+  });
+});
+
+describe("getEnvProfile", () => {
+  it("production uses parent cookieDomainStrategy (preserves existing behavior)", () => {
+    expect(getEnvProfile({}).cookieDomainStrategy).toBe("parent");
+    expect(getEnvProfile({ ATLAS_DEPLOY_ENV: "production" }).cookieDomainStrategy).toBe("parent");
+  });
+
+  it("staging uses host-only cookieDomainStrategy (isolates from prod parent)", () => {
+    expect(getEnvProfile({ ATLAS_DEPLOY_ENV: "staging" }).cookieDomainStrategy).toBe("host-only");
+  });
+
+  it("development uses host-only cookieDomainStrategy", () => {
+    expect(getEnvProfile({ ATLAS_DEPLOY_ENV: "development" }).cookieDomainStrategy).toBe("host-only");
+  });
+
+  it("unknown env falls through to production profile", () => {
+    expect(getEnvProfile({ ATLAS_DEPLOY_ENV: "garbage" }).cookieDomainStrategy).toBe("parent");
+  });
+});

--- a/packages/api/src/lib/auth/server.ts
+++ b/packages/api/src/lib/auth/server.ts
@@ -33,6 +33,7 @@ import { recordOAuthTokenRefresh } from "@atlas/api/lib/auth/oauth-refresh-audit
 import Stripe from "stripe";
 import { getInternalDB, hasInternalDB, internalQuery, updateWorkspacePlanTier, updateWorkspaceStatus, type InternalPool, type PlanTier } from "@atlas/api/lib/db/internal";
 import { createLogger } from "@atlas/api/lib/logger";
+import { getEnvProfile } from "@atlas/api/lib/env-profile";
 import {
   assertInvitationRoleAllowed,
   dispatchInvitationEmail,
@@ -2424,13 +2425,24 @@ export function getAuthInstance(): AuthInstance {
     );
   }
 
-  // Derive parent domain for cross-subdomain cookies (e.g. "useatlas.dev" from
-  // BETTER_AUTH_URL="https://api.useatlas.dev"). Only enabled when CORS origin
-  // is set (i.e. cross-origin deployment). Without this, cookies are scoped to
-  // the API subdomain and won't be sent from the frontend subdomain.
+  // Cookie Domain strategy is profile-driven (env-profile.ts).
+  //
+  // `parent`: derive parent domain (e.g. "useatlas.dev" from BETTER_AUTH_URL
+  //   "https://api.useatlas.dev") and set `Domain=.<parent>`. Span every
+  //   subdomain of the parent. Used by prod where the SaaS subdomain family
+  //   was set up with this assumption.
+  //
+  // `host-only`: omit the Domain attribute. Cookie binds to the exact host
+  //   that set it (e.g. `staging.api.useatlas.dev`). Cross-origin fetch
+  //   from a sibling subdomain still works via `credentials: "include"` +
+  //   `SameSite=None; Secure`. Required for staging so its cookies don't
+  //   leak to/from prod's `.useatlas.dev` space.
+  //
+  // Either strategy still requires `ATLAS_CORS_ORIGIN` to be set (cross-origin
+  // deployment); same-origin deploys don't need a Domain attribute at all.
   const corsOrigin = process.env.ATLAS_CORS_ORIGIN;
   let cookieDomain: string | undefined;
-  if (corsOrigin && process.env.BETTER_AUTH_URL) {
+  if (corsOrigin && process.env.BETTER_AUTH_URL && getEnvProfile().cookieDomainStrategy === "parent") {
     try {
       const host = new URL(process.env.BETTER_AUTH_URL).hostname;
       const parts = host.split(".");

--- a/packages/api/src/lib/env-profile.ts
+++ b/packages/api/src/lib/env-profile.ts
@@ -1,0 +1,105 @@
+/**
+ * Env-profile — typed, non-secret deployment-environment constants.
+ *
+ * Atlas runs in several deployment shapes (production SaaS regions,
+ * single-region staging, self-hosted, dev). Non-secret per-env config
+ * (cookie strategy, default region labels, feature defaults) was previously
+ * a sprawl of `process.env.X ?? "default"` reads + manual Railway-side
+ * stamping. This module centralises those decisions behind a single
+ * `ATLAS_DEPLOY_ENV` switch and a typed table — adding a new profile is
+ * a table edit, not a global grep.
+ *
+ * **In scope:** non-secret runtime defaults that vary by deployment shape.
+ * **Out of scope:** secrets (API keys, encryption keys), per-instance
+ * values (which specific region this API serves), customer-tenant config.
+ * Those stay as env vars / settings registry rows.
+ *
+ * Starts minimal — only `cookieDomainStrategy` for the cross-env cookie
+ * leak fix (#2933). Expand the `EnvProfile` interface incrementally as
+ * we migrate more per-env reads onto this seam.
+ */
+
+/**
+ * Deployment-shape discriminator. Read from `ATLAS_DEPLOY_ENV`; unset
+ * defaults to `production` (existing prod behavior — no migration risk).
+ *
+ * - `production` — customer-facing SaaS region (us / eu / apac all share this profile)
+ * - `staging` — pre-prod soak environment (single region, staging.useatlas.dev family)
+ * - `development` — local dev / Playwright / CI
+ */
+export type DeployEnv = "production" | "staging" | "development";
+
+/**
+ * Strategy for the `Domain` attribute on auth session cookies.
+ *
+ * - `parent`: derive parent domain (e.g. `useatlas.dev`) and set
+ *   `Domain=.<parent>`. Cookie spans every subdomain of the parent.
+ *   Required only when JavaScript on another subdomain needs to read
+ *   the cookie via `document.cookie` (HttpOnly cookies don't need it).
+ *   For pure cross-origin fetch-with-credentials, this is unnecessary
+ *   AND causes cookie leaks between deployments that share the parent
+ *   (e.g. prod `api.useatlas.dev` and staging `staging.api.useatlas.dev`
+ *   both derive `.useatlas.dev`, so sessions leak across).
+ *
+ * - `host-only`: omit the `Domain` attribute. Cookie is bound to the
+ *   exact host that set it (e.g. `staging.api.useatlas.dev` only).
+ *   Cross-origin fetch from a sibling subdomain still works as long
+ *   as the request targets that exact host with `credentials: "include"`
+ *   and `SameSite=None; Secure`. No cookie leakage to other subdomains.
+ */
+export type CookieDomainStrategy = "parent" | "host-only";
+
+export interface EnvProfile {
+  readonly cookieDomainStrategy: CookieDomainStrategy;
+}
+
+const PROFILES: Record<DeployEnv, EnvProfile> = {
+  // Prod keeps the existing parent-domain strategy. Switching it to
+  // host-only would require verifying every prod surface that might
+  // read cookies cross-subdomain (admin, status pages, future internal
+  // tools). Out of scope for #2933 — that's a separate audit.
+  production: {
+    cookieDomainStrategy: "parent",
+  },
+  // Staging deliberately picks host-only to isolate from prod's
+  // `.useatlas.dev` cookie space. The staging URL family
+  // (staging.api.useatlas.dev, app-staging.useatlas.dev) shares the
+  // same parent as prod, so any non-host-only choice leaks.
+  staging: {
+    cookieDomainStrategy: "host-only",
+  },
+  // Dev deploys typically use localhost or single-host setups where
+  // cross-subdomain cookies aren't relevant. Host-only is the safe
+  // default that won't surprise anyone running `bun run dev`.
+  development: {
+    cookieDomainStrategy: "host-only",
+  },
+};
+
+/**
+ * Resolve the active deployment env from `ATLAS_DEPLOY_ENV`.
+ *
+ * Unset → `production` (preserves existing behavior for self-hosted
+ * and unconfigured deploys). Unknown value → log + fall back to
+ * `production` rather than throwing — the cookie strategy isn't
+ * worth a hard-fail boot for a typo'd env var.
+ */
+export function resolveDeployEnv(env: NodeJS.ProcessEnv = process.env): DeployEnv {
+  const raw = env.ATLAS_DEPLOY_ENV?.trim().toLowerCase();
+  if (!raw) return "production";
+  if (raw === "production" || raw === "staging" || raw === "development") {
+    return raw;
+  }
+  return "production";
+}
+
+/**
+ * Return the typed profile for the current deployment env.
+ *
+ * Cheap (single map lookup) — call at the call site rather than
+ * caching at module scope so tests can `process.env.ATLAS_DEPLOY_ENV =
+ * "staging"` before importing dependents.
+ */
+export function getEnvProfile(env: NodeJS.ProcessEnv = process.env): EnvProfile {
+  return PROFILES[resolveDeployEnv(env)];
+}


### PR DESCRIPTION
## Summary

- New `packages/api/src/lib/env-profile.ts` — typed deployment-env profile keyed on `ATLAS_DEPLOY_ENV`. Start of an env-profile pattern; minimal today (only cookieDomainStrategy), expandable.
- `server.ts` cookieDomain derivation gated behind profile. Prod = `parent` (current behavior, no change). Staging = `host-only` (no Domain attribute → no cross-env cookie leak).
- 11 unit tests for the profile module.

## Why

The cookieDomain logic at `server.ts:2438` slices the last 2 hostname parts of `BETTER_AUTH_URL`. Both prod (`api.useatlas.dev`) and staging (`staging.api.useatlas.dev`) resolve to `useatlas.dev`, and the cookie ships as `Domain=.useatlas.dev`. Browser sends prod session cookies to staging hosts and vice versa, blowing up auth state when a user toggles between envs.

Host-only cookies work fine for cross-origin SaaS via `SameSite=None; Secure; credentials:"include"` — the previous "parent domain is required" comment was a misread of cookie semantics.

## Prod safety

- Default `ATLAS_DEPLOY_ENV` (unset) → `production` profile → `parent` strategy → identical to current code path
- No prod env-var changes needed for this PR to be safe to ship
- Behavior change is opt-in via `ATLAS_DEPLOY_ENV=staging` on api-staging only

## Test plan

- [x] 11 unit tests in `packages/api/src/lib/__tests__/env-profile.test.ts` (default, explicit, case-insensitive, trim, unknown fallback, all 3 profile reads)
- [x] Type, lint, syncpack, template drift, security headers, railway watch, schema drift, oauth helper, test discipline, twenty resolver, published symbols all pass locally
- [ ] After merge + `ATLAS_DEPLOY_ENV=staging` on api-staging + redeploy: clear all `.useatlas.dev` cookies, log into prod (cookie scoped to `.useatlas.dev`), open app-staging in same browser. Staging API should treat user as unauthenticated (no cookie leak), redirect to /login.
- [ ] Prod regression: after `/release v0.1.2` deploys this to prod, verify app.useatlas.dev session still works (parent strategy unchanged, no behavior delta).

Refs #2921, #2894

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/2933"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782594584&installation_id=135337507&pr_number=2933&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F2933&signature=5974337442681bf2f149fbfcb0ec7a8982420a1576b3a9631d3d2159f097320a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->