### PR TITLE
feat(api): openapi-spec + openapi-client deep modules (#2923)

### DIFF
--- a/.claude/research/architecture-wins.md
+++ b/.claude/research/architecture-wins.md
@@ -2088,3 +2088,31 @@ The drift meant catalog rows could ship at `min_plan='team'` and silently deny e
 - **Listener test mock pinned** with `as const` so the discriminated-union return shape is satisfied.
 
 **Category:** Type-design deepening — five interlocking invariants moved from "documented and runtime-enforced" to "compile-time-enforced at the boundary." Same shape as win #69 (`WorkspaceInstallGate`) and win #70 (`PLAN_RANK`) — pushing the type narrowing down to one module per trust boundary means every other consumer in the project stops re-checking the invariant.
+
+---
+
+## 72. OpenAPI operation graph as the single parse boundary (`buildOperationGraph`)
+
+**Date:** 2026-05-28
+**Issue:** #2923 (parent PRD #2868)
+**Branch:** 2923-openapi-spec-client
+
+**Problem:** v0.2.0 turns Atlas from "text-to-SQL" into "text-to-any-API" by letting the agent read REST datasources from an OpenAPI 3.x document. The naive shape is for each consumer that v0.2.0 will grow — the semantic-YAML generator (slice 1b), the REST validator (slice 5), the prompt-context builder, and the executing client — to walk the raw OpenAPI doc independently: each re-resolving `$ref`s, each re-deciding how to handle a missing `operationId`, each independently choosing whether a circular Person ↔ NoteTarget reference is an error or a join. That repeats the spec's worst irregularities at every call site and guarantees the consumers drift (the same failure mode the chat-plugin extension-contract audits keep catching — happy-path walkers that quietly disagree on the edges).
+
+**Solution:** A single deep module, `buildOperationGraph(doc): OperationGraph`, is the *only* code that ever touches a `$ref` string or a raw `paths.*` object. It is a pure function (no I/O) that emits one normalized shape — `{ operations, schemas, security, servers, info }` — and every downstream consumer reads that shape. Two design moves make the boundary load-bearing:
+1. **`$ref` collapses to a pointer, not an inline.** A named-component `$ref` resolves to `{ ref: "Name" }` whose target is guaranteed present in `graph.schemas`. This keeps the graph *finite* under circular relationships (Twenty's Person → noteTargets[] → NoteTarget → person → Person cycle) while leaving the join *traversable* with a single `graph.schemas.get(node.ref)` — the exact relationship the acceptance criteria require to resolve. Inline (anonymous) schemas are walked in full because they cannot be circular without a named `$ref`, so recursion always terminates.
+2. **Fail-loud at the boundary, never a half-built graph (PRD risk R1).** Structural malformation, a missing `operationId`, a duplicate `operationId`, and an unresolvable/unsupported `$ref` throw a tagged `OpenApiSpecError` carrying a machine-readable `reason` and a JSON-pointer-ish `location`. Vendor extensions (`x-*`) are deliberately ignored (rejecting them would make Stripe/Twenty unparseable), and circular named refs deliberately resolve (the AC requires it) — the two cases the over-broad "fail on everything weird" reading would have gotten wrong.
+
+The executing client (`executeOperation`) is a sibling transport primitive that reads the same graph: it builds the request from the operation's parameters (encoding per `in: query|header|path`), applies auth per the operation's security scheme, and returns `{ status, headers, body }`. Non-2xx is returned, not thrown — interpreting status is the caller's job. Both modules live under `lib/openapi/`, sibling to the SQL Datasource layer (`lib/db/connection.ts`), never folded into `DBConnection` or `validateSQL` (PRD #2868 "Option B — parallel adapter, not subordinate").
+
+**Deep-module surface metrics:**
+- **Interface:** 2 entry points (`buildOperationGraph`, `executeOperation`) + one normalized type (`OperationGraph`) the whole milestone reads. ~20 exported types, all describing the one shape.
+- **Implementation:** OpenAPI 3.x walker (paths × 8 methods, components.schemas/parameters/securitySchemes/requestBodies/responses), RFC-6901 `$ref` decoding, OR-semantics security flattening, path/query/header encoding with array-explode, RFC 9110 `Retry-After` parsing, per-request `AbortSignal` timeout — all behind the two functions.
+- **Cost ceiling:** parse is pure and O(spec size); the pointer model means a cyclic spec is parsed once, not chased.
+
+**Impact:**
+- **2 deep modules, 0 folded into SQL** — the REST execution shape never leaks into the SQL validator or `DBConnection`.
+- **46 tests, 123 assertions, no mocks for the parser.** `openapi-spec` is unit-tested against three corpora (hand-crafted minimal, trimmed Twenty `/rest/open-api/core`, trimmed Stripe) asserting the normalized graph shape, plus 11 fail-loud cases each pinning a `reason`. `openapi-client` is integration-tested against a real local Node HTTP server (auth-per-scheme, param encoding, Retry-After, timeout, non-JSON/empty/bad-JSON bodies, fail-loud faults).
+- **The milestone's shared contract is set once.** Slices 1, 1b, 2, 3, 4, 5 all consume `OperationGraph` rather than re-parsing — the deepening is "one parse boundary, every consumer reads one type."
+
+**Category:** Deep module — narrow interface (one pure normalizer + one transport primitive), broad implementation (the whole irregular surface of OpenAPI 3.x). Same shape as win #58 (connection-mode resolver) and win #69 (`WorkspaceInstallGate`): pushing the irregularity down to one module means every later consumer stops re-deriving it — and here it is set *before* the consumers exist, so they are born reading the normalized shape rather than retrofitted onto it.

--- a/packages/api/scripts/openapi-harness.ts
+++ b/packages/api/scripts/openapi-harness.ts
@@ -1,0 +1,68 @@
+/**
+ * Throwaway demo harness for the slice-0 OpenAPI primitive (issue #2923).
+ *
+ * NOT part of the shipped surface — it is a manual smoke vehicle for the two
+ * deep modules under `src/lib/openapi/`. It fetches a spec, normalizes it, lists
+ * the operations, and optionally runs ONE `executeOperation` call.
+ *
+ * Usage:
+ *   ATLAS_OPENAPI_SPEC_URL=https://crm.useatlas.dev/rest/open-api/core \
+ *   ATLAS_OPENAPI_TOKEN=<bearer> \
+ *   bun packages/api/scripts/openapi-harness.ts
+ *
+ *   # optionally execute one operation:
+ *   ATLAS_OPENAPI_OP=findManyPeople \
+ *   ATLAS_OPENAPI_PARAMS='{"query":{"limit":3}}' \
+ *   bun packages/api/scripts/openapi-harness.ts
+ *
+ * Acceptance vehicle: pointed at Twenty's /rest/open-api/core it prints every
+ * Person operation (findManyPeople / findOnePerson / createOnePerson / …).
+ */
+import { buildOperationGraph } from "../src/lib/openapi/spec";
+import { executeOperation } from "../src/lib/openapi/client";
+import type { OperationParams, ResolvedAuth } from "../src/lib/openapi/types";
+
+const specUrl = process.env.ATLAS_OPENAPI_SPEC_URL;
+const token = process.env.ATLAS_OPENAPI_TOKEN;
+const opId = process.env.ATLAS_OPENAPI_OP;
+const baseUrlOverride = process.env.ATLAS_OPENAPI_BASE_URL;
+
+if (!specUrl) {
+  console.error("Set ATLAS_OPENAPI_SPEC_URL to the OpenAPI document URL.");
+  process.exit(1);
+}
+
+const auth: ResolvedAuth = token ? { kind: "bearer", token } : { kind: "none" };
+
+const specResponse = await fetch(specUrl, {
+  headers: token ? { Authorization: `Bearer ${token}`, Accept: "application/json" } : { Accept: "application/json" },
+});
+if (!specResponse.ok) {
+  console.error(`Failed to fetch spec: HTTP ${specResponse.status}`);
+  process.exit(1);
+}
+
+const doc: unknown = await specResponse.json();
+const graph = buildOperationGraph(doc);
+
+console.log(`\n${graph.info.title} (OpenAPI ${graph.info.openapiVersion})`);
+console.log(`servers: ${graph.servers.map((s) => s.url).join(", ") || "(none)"}`);
+console.log(`schemas: ${graph.schemas.size}, security schemes: ${[...graph.security.keys()].join(", ") || "(none)"}`);
+console.log(`\noperations (${graph.operations.size}):`);
+for (const op of graph.operations.values()) {
+  console.log(`  ${op.method.padEnd(6)} ${op.path}  →  ${op.operationId}`);
+}
+
+if (opId) {
+  let params: OperationParams = {};
+  if (process.env.ATLAS_OPENAPI_PARAMS) {
+    params = JSON.parse(process.env.ATLAS_OPENAPI_PARAMS) as OperationParams;
+  }
+  console.log(`\nexecuting ${opId} …`);
+  const result = await executeOperation(graph, opId, params, auth, {
+    ...(baseUrlOverride ? { baseUrl: baseUrlOverride } : {}),
+  });
+  console.log(`status: ${result.status}`);
+  if (result.retryAfterMs !== undefined) console.log(`retry-after: ${result.retryAfterMs}ms`);
+  console.log(JSON.stringify(result.body, null, 2));
+}

--- a/packages/api/src/lib/openapi/__tests__/client.test.ts
+++ b/packages/api/src/lib/openapi/__tests__/client.test.ts
@@ -5,7 +5,7 @@ import { type AddressInfo } from "net";
 import * as path from "path";
 
 import { buildOperationGraph } from "../spec";
-import { executeOperation } from "../client";
+import { executeOperation, parseRetryAfterMs } from "../client";
 import { OpenApiClientError, type OperationGraph } from "../types";
 
 const FIXTURES = path.join(import.meta.dir, "fixtures");
@@ -85,6 +85,11 @@ function route(req: http.IncomingMessage, res: http.ServerResponse): void {
     res.end("{not valid json");
     return;
   }
+  if (pathname === "/vnd-json") {
+    res.writeHead(200, { "content-type": "application/vnd.api+json" });
+    res.end(JSON.stringify({ data: { id: "1" } }));
+    return;
+  }
   // Default: echo what we saw so assertions can inspect routing/auth/params.
   res.writeHead(200, { "content-type": "application/json" });
   res.end(JSON.stringify({ seen: { method: req.method, url } }));
@@ -161,7 +166,7 @@ describe("executeOperation — auth application per securityScheme", () => {
       graph,
       "getPublic",
       {},
-      { kind: "apiKey", value: "ov", in: "header", name: "X-Custom-Key" },
+      { kind: "apiKey", value: "ov", placement: { in: "header", name: "X-Custom-Key" } },
       { baseUrl },
     );
     expect(captured?.headers["x-custom-key"]).toBe("ov");
@@ -276,5 +281,79 @@ describe("executeOperation — timeout & fail-loud faults", () => {
       err = e as OpenApiClientError;
     }
     expect(err?.reason).toBe("missing-path-param");
+  });
+
+  it("classifies a connection failure as a network error (not a timeout)", async () => {
+    // Port 1 on loopback refuses fast — a real transport failure, not a timeout.
+    const refusedGraph = buildOperationGraph({
+      openapi: "3.0.3",
+      info: { title: "t", version: "1" },
+      servers: [{ url: "http://127.0.0.1:1" }],
+      paths: { "/x": { get: { operationId: "x", security: [], responses: { "200": { description: "ok" } } } } },
+    });
+    let err: OpenApiClientError | undefined;
+    try {
+      await executeOperation(refusedGraph, "x", {}, { kind: "none" }, { timeoutMs: 2000 });
+    } catch (e) {
+      err = e as OpenApiClientError;
+    }
+    expect(err?.reason).toBe("network");
+    expect(err?.status).toBe(0);
+  });
+
+  it("fails loud when no base URL is available", async () => {
+    const noServerGraph = buildOperationGraph({
+      openapi: "3.0.3",
+      info: { title: "t", version: "1" },
+      paths: { "/x": { get: { operationId: "x", security: [], responses: { "200": { description: "ok" } } } } },
+    });
+    let err: OpenApiClientError | undefined;
+    try {
+      await executeOperation(noServerGraph, "x", {}, { kind: "none" });
+    } catch (e) {
+      err = e as OpenApiClientError;
+    }
+    expect(err?.reason).toBe("missing-base-url");
+  });
+});
+
+describe("executeOperation — content-type detection", () => {
+  it("parses a vendor +json content-type as JSON", async () => {
+    const vndGraph = buildOperationGraph({
+      openapi: "3.0.3",
+      info: { title: "t", version: "1" },
+      servers: [{ url: baseUrl }],
+      paths: { "/vnd-json": { get: { operationId: "getVnd", security: [], responses: { "200": { description: "ok" } } } } },
+    });
+    const result = await executeOperation(vndGraph, "getVnd", {}, { kind: "none" });
+    expect(result.bodyIsRaw).toBe(false);
+    expect(result.body).toEqual({ data: { id: "1" } });
+  });
+});
+
+describe("parseRetryAfterMs", () => {
+  it("parses delta-seconds", () => {
+    expect(parseRetryAfterMs("120")).toBe(120_000);
+    expect(parseRetryAfterMs("0")).toBe(0);
+  });
+
+  it("parses an HTTP-date in the future to a positive delay", () => {
+    const future = new Date(Date.now() + 60_000).toUTCString();
+    const ms = parseRetryAfterMs(future);
+    expect(ms).toBeGreaterThan(0);
+    expect(ms).toBeLessThanOrEqual(60_000);
+  });
+
+  it("clamps a past HTTP-date to zero (guards clock skew)", () => {
+    const past = new Date(Date.now() - 60_000).toUTCString();
+    expect(parseRetryAfterMs(past)).toBe(0);
+  });
+
+  it("returns undefined for absent or unparseable values", () => {
+    expect(parseRetryAfterMs(null)).toBeUndefined();
+    expect(parseRetryAfterMs(undefined)).toBeUndefined();
+    expect(parseRetryAfterMs("")).toBeUndefined();
+    expect(parseRetryAfterMs("   ")).toBeUndefined();
+    expect(parseRetryAfterMs("not-a-date")).toBeUndefined();
   });
 });

--- a/packages/api/src/lib/openapi/__tests__/client.test.ts
+++ b/packages/api/src/lib/openapi/__tests__/client.test.ts
@@ -1,0 +1,280 @@
+import { describe, it, expect, beforeAll, afterAll } from "bun:test";
+import * as fs from "fs";
+import * as http from "http";
+import { type AddressInfo } from "net";
+import * as path from "path";
+
+import { buildOperationGraph } from "../spec";
+import { executeOperation } from "../client";
+import { OpenApiClientError, type OperationGraph } from "../types";
+
+const FIXTURES = path.join(import.meta.dir, "fixtures");
+
+/** What the test server saw on the most recent request. */
+interface CapturedRequest {
+  method: string;
+  url: string; // path + query
+  headers: http.IncomingHttpHeaders;
+  body: string;
+}
+
+let server: http.Server;
+let baseUrl: string;
+let captured: CapturedRequest | null = null;
+let graph: OperationGraph;
+
+beforeAll(async () => {
+  graph = buildOperationGraph(
+    JSON.parse(fs.readFileSync(path.join(FIXTURES, "client-spec.json"), "utf8")),
+  );
+
+  server = http.createServer((req, res) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (c: Buffer) => chunks.push(c));
+    req.on("end", () => {
+      captured = {
+        method: req.method ?? "",
+        url: req.url ?? "",
+        headers: req.headers,
+        body: Buffer.concat(chunks).toString("utf8"),
+      };
+      route(req, res);
+    });
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const addr = server.address() as AddressInfo;
+  baseUrl = `http://127.0.0.1:${addr.port}`;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve, reject) =>
+    server.close((err) => (err ? reject(err) : resolve())),
+  );
+});
+
+/** Route the captured request to a canned response based on the path. */
+function route(req: http.IncomingMessage, res: http.ServerResponse): void {
+  const url = req.url ?? "";
+  const pathname = url.split("?")[0];
+
+  if (pathname === "/slow") {
+    setTimeout(() => {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ ok: true }));
+    }, 500);
+    return;
+  }
+  if (pathname === "/rate-limited") {
+    res.writeHead(429, { "content-type": "application/json", "retry-after": "120" });
+    res.end(JSON.stringify({ error: "slow down" }));
+    return;
+  }
+  if (pathname === "/text") {
+    res.writeHead(200, { "content-type": "text/plain" });
+    res.end("hello world");
+    return;
+  }
+  if (pathname === "/empty") {
+    res.writeHead(204);
+    res.end();
+    return;
+  }
+  if (pathname === "/bad-json") {
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end("{not valid json");
+    return;
+  }
+  // Default: echo what we saw so assertions can inspect routing/auth/params.
+  res.writeHead(200, { "content-type": "application/json" });
+  res.end(JSON.stringify({ seen: { method: req.method, url } }));
+}
+
+describe("executeOperation — request building", () => {
+  it("executes a parameterized GET: path + query + header encoding", async () => {
+    const result = await executeOperation(
+      graph,
+      "getThing",
+      {
+        path: { id: "abc 123" },
+        query: { q: "hello world", tags: ["a", "b"] },
+        header: { "X-Trace": "trace-1" },
+      },
+      { kind: "bearer", token: "tok-123" },
+      { baseUrl },
+    );
+
+    expect(result.status).toBe(200);
+    expect(captured?.method).toBe("GET");
+    // Path param is percent-encoded into the path.
+    expect(captured?.url.startsWith("/things/abc%20123?")).toBe(true);
+    // Query params encoded; array param explodes (repeat key).
+    expect(captured?.url).toContain("q=hello+world");
+    expect(captured?.url).toContain("tags=a");
+    expect(captured?.url).toContain("tags=b");
+    // Header param forwarded.
+    expect(captured?.headers["x-trace"]).toBe("trace-1");
+    // Bearer auth applied.
+    expect(captured?.headers["authorization"]).toBe("Bearer tok-123");
+  });
+
+  it("drops undefined query values and explodes arrays", async () => {
+    await executeOperation(
+      graph,
+      "getThing",
+      { path: { id: "x" }, query: { q: undefined, tags: ["one", "two", "three"] } },
+      { kind: "bearer", token: "t" },
+      { baseUrl },
+    );
+    expect(captured?.url).not.toContain("q=");
+    expect(captured?.url.match(/tags=/g)?.length).toBe(3);
+  });
+
+  it("uses graph.servers[0].url when no baseUrl override is given", async () => {
+    // Build a graph whose declared server IS the live test server, then call
+    // WITHOUT a baseUrl override — the request must still land on it.
+    const serverGraph = buildOperationGraph({
+      openapi: "3.0.3",
+      info: { title: "t", version: "1" },
+      servers: [{ url: baseUrl }],
+      paths: { "/public": { get: { operationId: "getPublic", security: [], responses: { "200": { description: "ok" } } } } },
+    });
+    const result = await executeOperation(serverGraph, "getPublic", {}, { kind: "none" });
+    expect(result.status).toBe(200);
+    expect(captured?.url).toBe("/public");
+  });
+});
+
+describe("executeOperation — auth application per securityScheme", () => {
+  it("applies an apiKey via the header named by the scheme", async () => {
+    await executeOperation(graph, "getViaHeaderKey", {}, { kind: "apiKey", value: "secret-k" }, { baseUrl });
+    expect(captured?.headers["x-api-key"]).toBe("secret-k");
+  });
+
+  it("applies an apiKey via the query param named by the scheme", async () => {
+    await executeOperation(graph, "getViaQueryKey", {}, { kind: "apiKey", value: "qsecret" }, { baseUrl });
+    expect(captured?.url).toContain("api_key=qsecret");
+  });
+
+  it("honors an explicit apiKey placement override", async () => {
+    await executeOperation(
+      graph,
+      "getPublic",
+      {},
+      { kind: "apiKey", value: "ov", in: "header", name: "X-Custom-Key" },
+      { baseUrl },
+    );
+    expect(captured?.headers["x-custom-key"]).toBe("ov");
+  });
+
+  it("applies basic auth as base64(user:pass)", async () => {
+    await executeOperation(
+      graph,
+      "getViaBasic",
+      {},
+      { kind: "basic", username: "sk_live_x", password: "" },
+      { baseUrl },
+    );
+    const expected = `Basic ${Buffer.from("sk_live_x:", "utf8").toString("base64")}`;
+    expect(captured?.headers["authorization"]).toBe(expected);
+  });
+
+  it("sends no auth header when kind is none", async () => {
+    await executeOperation(graph, "getPublic", {}, { kind: "none" }, { baseUrl });
+    expect(captured?.headers["authorization"]).toBeUndefined();
+  });
+
+  it("fails loud when an apiKey has no placement to apply", async () => {
+    // getPublic declares no apiKey scheme and no override is given.
+    let err: OpenApiClientError | undefined;
+    try {
+      await executeOperation(graph, "getPublic", {}, { kind: "apiKey", value: "k" }, { baseUrl });
+    } catch (e) {
+      err = e as OpenApiClientError;
+    }
+    expect(err?.reason).toBe("missing-auth-placement");
+  });
+});
+
+describe("executeOperation — request body", () => {
+  it("serializes a JSON body and sets Content-Type", async () => {
+    const result = await executeOperation(
+      graph,
+      "createThing",
+      { body: { name: "widget" } },
+      { kind: "bearer", token: "t" },
+      { baseUrl },
+    );
+    expect(result.status).toBe(200);
+    expect(captured?.method).toBe("POST");
+    expect(captured?.headers["content-type"]).toContain("application/json");
+    expect(JSON.parse(captured?.body ?? "{}")).toEqual({ name: "widget" });
+  });
+});
+
+describe("executeOperation — response handling", () => {
+  it("returns non-2xx responses instead of throwing, and parses Retry-After", async () => {
+    const result = await executeOperation(graph, "getRateLimited", {}, { kind: "none" }, { baseUrl });
+    expect(result.status).toBe(429);
+    expect(result.retryAfterMs).toBe(120_000);
+    expect(result.body).toEqual({ error: "slow down" });
+  });
+
+  it("returns raw text for non-JSON responses", async () => {
+    const result = await executeOperation(graph, "getText", {}, { kind: "none" }, { baseUrl });
+    expect(result.body).toBe("hello world");
+    expect(result.bodyIsRaw).toBe(true);
+  });
+
+  it("returns null body for an empty (204) response", async () => {
+    const result = await executeOperation(graph, "getEmpty", {}, { kind: "none" }, { baseUrl });
+    expect(result.status).toBe(204);
+    expect(result.body).toBeNull();
+    expect(result.bodyIsRaw).toBe(false);
+  });
+
+  it("throws unparseable-response when a JSON content-type body does not parse", async () => {
+    let err: OpenApiClientError | undefined;
+    try {
+      await executeOperation(graph, "getBadJson", {}, { kind: "none" }, { baseUrl });
+    } catch (e) {
+      err = e as OpenApiClientError;
+    }
+    expect(err?.reason).toBe("unparseable-response");
+    expect(err?.status).toBe(200);
+  });
+});
+
+describe("executeOperation — timeout & fail-loud faults", () => {
+  it("enforces a per-request timeout", async () => {
+    let err: OpenApiClientError | undefined;
+    try {
+      // /slow responds after 500ms; cap at 100ms.
+      await executeOperation(graph, "getSlow", {}, { kind: "none" }, { baseUrl, timeoutMs: 100 });
+    } catch (e) {
+      err = e as OpenApiClientError;
+    }
+    expect(err?.reason).toBe("timeout");
+    expect(err?.status).toBe(0);
+  });
+
+  it("rejects an unknown operationId", async () => {
+    let err: OpenApiClientError | undefined;
+    try {
+      await executeOperation(graph, "noSuchOp", {}, { kind: "none" }, { baseUrl });
+    } catch (e) {
+      err = e as OpenApiClientError;
+    }
+    expect(err?.reason).toBe("unknown-operation");
+  });
+
+  it("rejects a missing required path param", async () => {
+    let err: OpenApiClientError | undefined;
+    try {
+      await executeOperation(graph, "getThing", {}, { kind: "bearer", token: "t" }, { baseUrl });
+    } catch (e) {
+      err = e as OpenApiClientError;
+    }
+    expect(err?.reason).toBe("missing-path-param");
+  });
+});

--- a/packages/api/src/lib/openapi/__tests__/client.test.ts
+++ b/packages/api/src/lib/openapi/__tests__/client.test.ts
@@ -161,6 +161,29 @@ describe("executeOperation — auth application per securityScheme", () => {
     expect(captured?.url).toContain("api_key=qsecret");
   });
 
+  it("query apiKey coexists with user array query params (auth set-once, array explodes)", async () => {
+    // Auth uses URLSearchParams.set (once); user array params use append (explode).
+    const coexistGraph = buildOperationGraph({
+      openapi: "3.0.3",
+      info: { title: "t", version: "1" },
+      servers: [{ url: baseUrl }],
+      components: { securitySchemes: { apiKeyQuery: { type: "apiKey", in: "query", name: "api_key" } } },
+      paths: {
+        "/public": {
+          get: {
+            operationId: "qCoexist",
+            security: [{ apiKeyQuery: [] }],
+            parameters: [{ name: "ids", in: "query", required: false, schema: { type: "array", items: { type: "string" } } }],
+            responses: { "200": { description: "ok" } },
+          },
+        },
+      },
+    });
+    await executeOperation(coexistGraph, "qCoexist", { query: { ids: ["a", "b"] } }, { kind: "apiKey", value: "K" });
+    expect(captured?.url.match(/api_key=K/g)?.length).toBe(1);
+    expect(captured?.url.match(/ids=/g)?.length).toBe(2);
+  });
+
   it("honors an explicit apiKey placement override", async () => {
     await executeOperation(
       graph,

--- a/packages/api/src/lib/openapi/__tests__/fixtures/client-spec.json
+++ b/packages/api/src/lib/openapi/__tests__/fixtures/client-spec.json
@@ -1,0 +1,98 @@
+{
+  "openapi": "3.0.3",
+  "info": { "title": "Client Test API", "version": "1.0.0" },
+  "servers": [{ "url": "http://overridden.example/base" }],
+  "security": [{ "bearerAuth": [] }],
+  "components": {
+    "securitySchemes": {
+      "bearerAuth": { "type": "http", "scheme": "bearer" },
+      "basicAuth": { "type": "http", "scheme": "basic" },
+      "apiKeyHeader": { "type": "apiKey", "in": "header", "name": "X-API-Key" },
+      "apiKeyQuery": { "type": "apiKey", "in": "query", "name": "api_key" }
+    },
+    "schemas": {
+      "Thing": {
+        "type": "object",
+        "properties": { "id": { "type": "string" }, "name": { "type": "string" } }
+      }
+    }
+  },
+  "paths": {
+    "/things/{id}": {
+      "get": {
+        "operationId": "getThing",
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } },
+          { "name": "q", "in": "query", "required": false, "schema": { "type": "string" } },
+          {
+            "name": "tags",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "array", "items": { "type": "string" } }
+          },
+          { "name": "X-Trace", "in": "header", "required": false, "schema": { "type": "string" } }
+        ],
+        "responses": { "200": { "description": "ok" } }
+      }
+    },
+    "/things": {
+      "post": {
+        "operationId": "createThing",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": { "schema": { "$ref": "#/components/schemas/Thing" } }
+          }
+        },
+        "responses": { "201": { "description": "created" } }
+      }
+    },
+    "/hk": {
+      "get": {
+        "operationId": "getViaHeaderKey",
+        "security": [{ "apiKeyHeader": [] }],
+        "responses": { "200": { "description": "ok" } }
+      }
+    },
+    "/qk": {
+      "get": {
+        "operationId": "getViaQueryKey",
+        "security": [{ "apiKeyQuery": [] }],
+        "responses": { "200": { "description": "ok" } }
+      }
+    },
+    "/basic": {
+      "get": {
+        "operationId": "getViaBasic",
+        "security": [{ "basicAuth": [] }],
+        "responses": { "200": { "description": "ok" } }
+      }
+    },
+    "/public": {
+      "get": {
+        "operationId": "getPublic",
+        "security": [],
+        "responses": { "200": { "description": "ok" } }
+      }
+    },
+    "/slow": {
+      "get": { "operationId": "getSlow", "security": [], "responses": { "200": { "description": "ok" } } }
+    },
+    "/rate-limited": {
+      "get": {
+        "operationId": "getRateLimited",
+        "security": [],
+        "responses": { "429": { "description": "too many requests" } }
+      }
+    },
+    "/text": {
+      "get": { "operationId": "getText", "security": [], "responses": { "200": { "description": "ok" } } }
+    },
+    "/empty": {
+      "get": { "operationId": "getEmpty", "security": [], "responses": { "204": { "description": "no content" } } }
+    },
+    "/bad-json": {
+      "get": { "operationId": "getBadJson", "security": [], "responses": { "200": { "description": "ok" } } }
+    }
+  }
+}

--- a/packages/api/src/lib/openapi/__tests__/fixtures/minimal.json
+++ b/packages/api/src/lib/openapi/__tests__/fixtures/minimal.json
@@ -1,0 +1,121 @@
+{
+  "openapi": "3.0.3",
+  "info": { "title": "Minimal Widgets API", "version": "1.0.0" },
+  "servers": [{ "url": "https://api.widgets.example/v1", "description": "prod" }],
+  "security": [{ "bearerAuth": [] }],
+  "components": {
+    "securitySchemes": {
+      "bearerAuth": { "type": "http", "scheme": "bearer", "bearerFormat": "JWT" },
+      "apiKeyHeader": { "type": "apiKey", "in": "header", "name": "X-API-Key" },
+      "apiKeyQuery": { "type": "apiKey", "in": "query", "name": "api_key" }
+    },
+    "parameters": {
+      "LimitParam": {
+        "name": "limit",
+        "in": "query",
+        "required": false,
+        "description": "Max rows to return.",
+        "schema": { "type": "integer", "format": "int32" }
+      }
+    },
+    "schemas": {
+      "Widget": {
+        "type": "object",
+        "required": ["id", "name"],
+        "properties": {
+          "id": { "type": "string", "format": "uuid" },
+          "name": { "type": "string" },
+          "owner": { "$ref": "#/components/schemas/Gadget" }
+        }
+      },
+      "Gadget": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string" },
+          "widgets": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/Widget" }
+          }
+        }
+      }
+    }
+  },
+  "paths": {
+    "/widgets": {
+      "parameters": [{ "$ref": "#/components/parameters/LimitParam" }],
+      "get": {
+        "operationId": "listWidgets",
+        "summary": "List widgets",
+        "tags": ["widgets"],
+        "parameters": [
+          {
+            "name": "tag",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ok",
+            "content": {
+              "application/json": {
+                "schema": { "type": "array", "items": { "$ref": "#/components/schemas/Widget" } }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "createWidget",
+        "summary": "Create a widget",
+        "tags": ["widgets"],
+        "security": [{ "apiKeyHeader": [] }],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": { "schema": { "$ref": "#/components/schemas/Widget" } }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "created",
+            "content": {
+              "application/json": { "schema": { "$ref": "#/components/schemas/Widget" } }
+            }
+          }
+        }
+      }
+    },
+    "/widgets/{id}": {
+      "get": {
+        "operationId": "getWidget",
+        "summary": "Get a widget by id",
+        "tags": ["widgets"],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "format": "uuid" }
+          },
+          {
+            "name": "X-Trace-Id",
+            "in": "header",
+            "required": false,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ok",
+            "content": {
+              "application/json": { "schema": { "$ref": "#/components/schemas/Widget" } }
+            }
+          },
+          "404": { "description": "not found" }
+        }
+      }
+    }
+  }
+}

--- a/packages/api/src/lib/openapi/__tests__/fixtures/stripe.excerpt.json
+++ b/packages/api/src/lib/openapi/__tests__/fixtures/stripe.excerpt.json
@@ -1,0 +1,157 @@
+{
+  "openapi": "3.0.0",
+  "info": { "title": "Stripe API", "version": "2024-06-20" },
+  "servers": [{ "url": "https://api.stripe.com/" }],
+  "components": {
+    "securitySchemes": {
+      "basicAuth": { "type": "http", "scheme": "basic" },
+      "bearerAuth": { "type": "http", "scheme": "bearer" }
+    },
+    "schemas": {
+      "customer": {
+        "type": "object",
+        "description": "A Stripe customer.",
+        "properties": {
+          "id": { "type": "string", "maxLength": 5000 },
+          "object": { "type": "string", "enum": ["customer"] },
+          "email": { "type": "string", "nullable": true },
+          "address": { "anyOf": [{ "$ref": "#/components/schemas/address" }], "nullable": true },
+          "created": { "type": "integer", "format": "unix-time" }
+        }
+      },
+      "address": {
+        "type": "object",
+        "properties": {
+          "city": { "type": "string", "nullable": true },
+          "country": { "type": "string", "nullable": true },
+          "line1": { "type": "string", "nullable": true },
+          "postal_code": { "type": "string", "nullable": true }
+        }
+      },
+      "deleted_customer": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string" },
+          "object": { "type": "string", "enum": ["customer"] },
+          "deleted": { "type": "boolean", "enum": [true] }
+        }
+      }
+    }
+  },
+  "paths": {
+    "/v1/customers": {
+      "get": {
+        "operationId": "GetCustomers",
+        "summary": "List all customers",
+        "tags": ["Customers"],
+        "security": [{ "basicAuth": [] }, { "bearerAuth": [] }],
+        "parameters": [
+          {
+            "name": "email",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "integer" }
+          },
+          {
+            "name": "expand",
+            "in": "query",
+            "required": false,
+            "style": "deepObject",
+            "explode": true,
+            "schema": { "type": "array", "items": { "type": "string" } }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A list of customers",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "object": { "type": "string", "enum": ["list"] },
+                    "data": { "type": "array", "items": { "$ref": "#/components/schemas/customer" } },
+                    "has_more": { "type": "boolean" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "PostCustomers",
+        "summary": "Create a customer",
+        "tags": ["Customers"],
+        "security": [{ "basicAuth": [] }, { "bearerAuth": [] }],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "email": { "type": "string" },
+                  "name": { "type": "string" }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The created customer",
+            "content": {
+              "application/json": { "schema": { "$ref": "#/components/schemas/customer" } }
+            }
+          }
+        }
+      }
+    },
+    "/v1/customers/{customer}": {
+      "get": {
+        "operationId": "GetCustomersCustomer",
+        "summary": "Retrieve a customer",
+        "tags": ["Customers"],
+        "security": [{ "basicAuth": [] }, { "bearerAuth": [] }],
+        "parameters": [
+          {
+            "name": "customer",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "expand",
+            "in": "query",
+            "required": false,
+            "style": "deepObject",
+            "explode": true,
+            "schema": { "type": "array", "items": { "type": "string" } }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The customer or a deleted customer",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    { "$ref": "#/components/schemas/customer" },
+                    { "$ref": "#/components/schemas/deleted_customer" }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/api/src/lib/openapi/__tests__/fixtures/twenty-core.excerpt.json
+++ b/packages/api/src/lib/openapi/__tests__/fixtures/twenty-core.excerpt.json
@@ -1,0 +1,307 @@
+{
+  "openapi": "3.1.0",
+  "info": { "title": "Twenty Core REST API", "version": "0.41.0" },
+  "servers": [{ "url": "https://crm.useatlas.dev/rest", "description": "workspace" }],
+  "security": [{ "bearer": [] }],
+  "components": {
+    "securitySchemes": {
+      "bearer": { "type": "http", "scheme": "bearer", "bearerFormat": "JWT" }
+    },
+    "parameters": {
+      "filter": {
+        "name": "filter",
+        "in": "query",
+        "required": false,
+        "description": "Filter results. Syntax: field[COMPARATOR]:value, e.g. emails.primaryEmail[eq]:foo@example.com. Combine with comma. Comparators: eq, neq, in, gt, gte, lt, lte, like, ilike, is.",
+        "schema": { "type": "string" }
+      },
+      "orderBy": {
+        "name": "order_by",
+        "in": "query",
+        "required": false,
+        "schema": { "type": "string" }
+      },
+      "limit": {
+        "name": "limit",
+        "in": "query",
+        "required": false,
+        "schema": { "type": "integer", "format": "int32" }
+      },
+      "depth": {
+        "name": "depth",
+        "in": "query",
+        "required": false,
+        "schema": { "type": "integer", "enum": [0, 1, 2] }
+      },
+      "startingAfter": {
+        "name": "starting_after",
+        "in": "query",
+        "required": false,
+        "schema": { "type": "string" }
+      },
+      "endingBefore": {
+        "name": "ending_before",
+        "in": "query",
+        "required": false,
+        "schema": { "type": "string" }
+      }
+    },
+    "schemas": {
+      "Person": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string", "format": "uuid" },
+          "name": {
+            "type": "object",
+            "properties": {
+              "firstName": { "type": "string" },
+              "lastName": { "type": "string" }
+            }
+          },
+          "emails": {
+            "type": "object",
+            "properties": {
+              "primaryEmail": { "type": "string" },
+              "additionalEmails": { "type": "array", "items": { "type": "string" } }
+            }
+          },
+          "atlasFirstSource": { "type": "string", "description": "Atlas custom field — inline, not nested under customFields." },
+          "atlasLastSource": { "type": "string" },
+          "createdAt": { "type": "string", "format": "date-time" },
+          "updatedAt": { "type": "string", "format": "date-time" },
+          "noteTargets": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/NoteTarget" }
+          }
+        }
+      },
+      "NoteTarget": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string", "format": "uuid" },
+          "noteId": { "type": "string", "format": "uuid" },
+          "targetPersonId": { "type": "string", "format": "uuid" },
+          "note": { "$ref": "#/components/schemas/Note" },
+          "person": { "$ref": "#/components/schemas/Person" }
+        }
+      },
+      "Note": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string", "format": "uuid" },
+          "title": { "type": "string" },
+          "bodyV2": {
+            "type": "object",
+            "properties": { "markdown": { "type": "string" } }
+          },
+          "createdAt": { "type": "string", "format": "date-time" }
+        }
+      },
+      "Company": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string", "format": "uuid" },
+          "name": { "type": "string" },
+          "domainName": {
+            "type": "object",
+            "properties": { "primaryLinkUrl": { "type": "string" } }
+          }
+        }
+      },
+      "PersonListResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "people": { "type": "array", "items": { "$ref": "#/components/schemas/Person" } }
+            }
+          }
+        }
+      },
+      "PersonResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": { "person": { "$ref": "#/components/schemas/Person" } }
+          }
+        }
+      }
+    }
+  },
+  "paths": {
+    "/people": {
+      "get": {
+        "operationId": "findManyPeople",
+        "summary": "List people",
+        "tags": ["People"],
+        "parameters": [
+          { "$ref": "#/components/parameters/filter" },
+          { "$ref": "#/components/parameters/orderBy" },
+          { "$ref": "#/components/parameters/limit" },
+          { "$ref": "#/components/parameters/depth" },
+          { "$ref": "#/components/parameters/startingAfter" },
+          { "$ref": "#/components/parameters/endingBefore" }
+        ],
+        "responses": {
+          "200": {
+            "description": "A list of people",
+            "content": {
+              "application/json": { "schema": { "$ref": "#/components/schemas/PersonListResponse" } }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "createOnePerson",
+        "summary": "Create one person",
+        "tags": ["People"],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": { "schema": { "$ref": "#/components/schemas/Person" } }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": { "schema": { "$ref": "#/components/schemas/PersonResponse" } }
+            }
+          }
+        }
+      }
+    },
+    "/people/{id}": {
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "schema": { "type": "string", "format": "uuid" }
+        }
+      ],
+      "get": {
+        "operationId": "findOnePerson",
+        "summary": "Get one person",
+        "tags": ["People"],
+        "parameters": [{ "$ref": "#/components/parameters/depth" }],
+        "responses": {
+          "200": {
+            "description": "One person",
+            "content": {
+              "application/json": { "schema": { "$ref": "#/components/schemas/PersonResponse" } }
+            }
+          }
+        }
+      },
+      "patch": {
+        "operationId": "updateOnePerson",
+        "summary": "Update one person",
+        "tags": ["People"],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": { "schema": { "$ref": "#/components/schemas/Person" } }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated",
+            "content": {
+              "application/json": { "schema": { "$ref": "#/components/schemas/PersonResponse" } }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deleteOnePerson",
+        "summary": "Delete one person",
+        "tags": ["People"],
+        "parameters": [
+          {
+            "name": "soft_delete",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "boolean" }
+          }
+        ],
+        "responses": { "200": { "description": "Deleted" } }
+      }
+    },
+    "/noteTargets": {
+      "get": {
+        "operationId": "findManyNoteTargets",
+        "summary": "List note targets",
+        "tags": ["NoteTargets"],
+        "parameters": [{ "$ref": "#/components/parameters/filter" }],
+        "responses": {
+          "200": {
+            "description": "A list of note targets",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "noteTargets": {
+                          "type": "array",
+                          "items": { "$ref": "#/components/schemas/NoteTarget" }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "createOneNoteTarget",
+        "summary": "Create one note target",
+        "tags": ["NoteTargets"],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": { "schema": { "$ref": "#/components/schemas/NoteTarget" } }
+          }
+        },
+        "responses": { "201": { "description": "Created" } }
+      }
+    },
+    "/notes": {
+      "get": {
+        "operationId": "findManyNotes",
+        "summary": "List notes",
+        "tags": ["Notes"],
+        "parameters": [{ "$ref": "#/components/parameters/filter" }],
+        "responses": { "200": { "description": "A list of notes" } }
+      },
+      "post": {
+        "operationId": "createOneNote",
+        "summary": "Create one note",
+        "tags": ["Notes"],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": { "schema": { "$ref": "#/components/schemas/Note" } }
+          }
+        },
+        "responses": { "201": { "description": "Created" } }
+      }
+    },
+    "/companies": {
+      "get": {
+        "operationId": "findManyCompanies",
+        "summary": "List companies",
+        "tags": ["Companies"],
+        "parameters": [{ "$ref": "#/components/parameters/filter" }],
+        "responses": { "200": { "description": "A list of companies" } }
+      }
+    }
+  }
+}

--- a/packages/api/src/lib/openapi/__tests__/spec.test.ts
+++ b/packages/api/src/lib/openapi/__tests__/spec.test.ts
@@ -489,6 +489,23 @@ describe("buildOperationGraph — reference & edge normalization", () => {
     expect(email.nullable).toBe(true);
   });
 
+  it("normalizes in:cookie parameters into the graph (execution deferred)", () => {
+    const graph = buildOperationGraph({
+      openapi: "3.0.0",
+      paths: {
+        "/x": {
+          get: {
+            operationId: "x",
+            parameters: [{ name: "sid", in: "cookie", required: false, schema: { type: "string" } }],
+            responses: {},
+          },
+        },
+      },
+    });
+    const param = graph.operations.get("x")?.parameters.find((p) => p.name === "sid");
+    expect(param?.in).toBe("cookie");
+  });
+
   it("normalizes oauth2 / openIdConnect schemes without throwing (flows deferred to slice 6)", () => {
     const graph = buildOperationGraph({
       openapi: "3.0.0",

--- a/packages/api/src/lib/openapi/__tests__/spec.test.ts
+++ b/packages/api/src/lib/openapi/__tests__/spec.test.ts
@@ -1,0 +1,309 @@
+import { describe, it, expect } from "bun:test";
+import * as fs from "fs";
+import * as path from "path";
+
+import { buildOperationGraph } from "../spec";
+import { OpenApiSpecError, type OpenApiSpecErrorReason } from "../types";
+
+const FIXTURES = path.join(import.meta.dir, "fixtures");
+
+function loadFixture(name: string): unknown {
+  return JSON.parse(fs.readFileSync(path.join(FIXTURES, `${name}.json`), "utf8"));
+}
+
+describe("buildOperationGraph — minimal corpus", () => {
+  const graph = buildOperationGraph(loadFixture("minimal"));
+
+  it("lists every operation keyed by operationId", () => {
+    expect([...graph.operations.keys()].toSorted()).toEqual([
+      "createWidget",
+      "getWidget",
+      "listWidgets",
+    ]);
+  });
+
+  it("registers every named schema and tags each with its name", () => {
+    expect([...graph.schemas.keys()].toSorted()).toEqual(["Gadget", "Widget"]);
+    expect(graph.schemas.get("Widget")?.name).toBe("Widget");
+  });
+
+  it("resolves a $ref to a finite pointer, keeping circular relationships traversable", () => {
+    // Widget.owner -> Gadget, Gadget.widgets[] -> Widget is a cycle. A pointer
+    // model keeps the graph finite while letting a consumer follow the join.
+    const widget = graph.schemas.get("Widget");
+    const ownerProp = widget?.properties?.get("owner");
+    expect(ownerProp).toEqual({ ref: "Gadget" });
+
+    const gadget = graph.schemas.get(ownerProp!.ref!);
+    expect(gadget?.properties?.get("widgets")?.items).toEqual({ ref: "Widget" });
+
+    // Following the cycle back to Widget terminates — same object, no recursion.
+    expect(graph.schemas.get("Widget")).toBe(widget);
+  });
+
+  it("carries operation method, path, and required-path-param metadata", () => {
+    const getWidget = graph.operations.get("getWidget");
+    expect(getWidget?.method).toBe("GET");
+    expect(getWidget?.path).toBe("/widgets/{id}");
+    const idParam = getWidget?.parameters.find((p) => p.name === "id");
+    expect(idParam).toMatchObject({ in: "path", required: true });
+  });
+
+  it("merges path-level and operation-level parameters via $ref", () => {
+    // `limit` comes from the path-level `$ref: LimitParam`; `tag` is op-level.
+    const listWidgets = graph.operations.get("listWidgets");
+    const names = listWidgets?.parameters.map((p) => p.name).toSorted();
+    expect(names).toEqual(["limit", "tag"]);
+  });
+
+  it("normalizes security schemes and per-operation requirements", () => {
+    expect(graph.security.get("bearerAuth")).toMatchObject({
+      kind: "bearer",
+      bearerFormat: "JWT",
+    });
+    expect(graph.security.get("apiKeyHeader")).toMatchObject({
+      kind: "apiKey-header",
+      parameterName: "X-API-Key",
+    });
+    // listWidgets inherits the document-level default (bearerAuth).
+    expect(graph.operations.get("listWidgets")?.security).toEqual(["bearerAuth"]);
+    // createWidget overrides with its own apiKeyHeader requirement.
+    expect(graph.operations.get("createWidget")?.security).toEqual(["apiKeyHeader"]);
+  });
+
+  it("captures servers and spec info", () => {
+    expect(graph.servers[0]?.url).toBe("https://api.widgets.example/v1");
+    expect(graph.info).toMatchObject({ title: "Minimal Widgets API", openapiVersion: "3.0.3" });
+  });
+});
+
+describe("buildOperationGraph — Twenty /rest/open-api/core corpus", () => {
+  const graph = buildOperationGraph(loadFixture("twenty-core.excerpt"));
+
+  it("lists every Person operation", () => {
+    const personOps = [...graph.operations.values()]
+      .filter((op) => op.path === "/people" || op.path.startsWith("/people/"))
+      .map((op) => op.operationId)
+      .toSorted();
+    expect(personOps).toEqual([
+      "createOnePerson",
+      "deleteOnePerson",
+      "findManyPeople",
+      "findOnePerson",
+      "updateOnePerson",
+    ]);
+  });
+
+  it("resolves the Person ↔ NoteTarget $ref relationship in both directions", () => {
+    // Person → noteTargets[] → NoteTarget
+    const person = graph.schemas.get("Person");
+    const noteTargetsItem = person?.properties?.get("noteTargets")?.items;
+    expect(noteTargetsItem).toEqual({ ref: "NoteTarget" });
+
+    const noteTarget = graph.schemas.get(noteTargetsItem!.ref!);
+    // NoteTarget → person → Person (back-reference completing the cycle)
+    expect(noteTarget?.properties?.get("person")).toEqual({ ref: "Person" });
+    // NoteTarget → note → Note
+    expect(noteTarget?.properties?.get("note")).toEqual({ ref: "Note" });
+    // The join column is targetPersonId (NOT personId — the jezweb trap).
+    expect(noteTarget?.properties?.has("targetPersonId")).toBe(true);
+    expect(noteTarget?.properties?.has("personId")).toBe(false);
+  });
+
+  it("inlines Atlas custom fields as siblings of standard fields (no customFields wrapper)", () => {
+    const person = graph.schemas.get("Person");
+    expect(person?.properties?.has("atlasFirstSource")).toBe(true);
+    expect(person?.properties?.has("customFields")).toBe(false);
+  });
+
+  it("resolves the reusable filter parameter onto list operations", () => {
+    const findMany = graph.operations.get("findManyPeople");
+    const filterParam = findMany?.parameters.find((p) => p.name === "filter");
+    expect(filterParam?.in).toBe("query");
+    expect(filterParam?.description).toContain("field[COMPARATOR]:value");
+  });
+
+  it("merges the path-level id param into every /people/{id} operation", () => {
+    for (const opId of ["findOnePerson", "updateOnePerson", "deleteOnePerson"]) {
+      const op = graph.operations.get(opId);
+      const idParam = op?.parameters.find((p) => p.name === "id");
+      expect(idParam, `${opId} should carry the path-level id param`).toMatchObject({
+        in: "path",
+        required: true,
+      });
+    }
+  });
+
+  it("normalizes request bodies on write operations", () => {
+    const create = graph.operations.get("createOnePerson");
+    expect(create?.requestBody?.required).toBe(true);
+    expect(create?.requestBody?.content.get("application/json")).toEqual({ ref: "Person" });
+  });
+});
+
+describe("buildOperationGraph — Stripe corpus", () => {
+  const graph = buildOperationGraph(loadFixture("stripe.excerpt"));
+
+  it("normalizes operations with PascalCase operationIds", () => {
+    expect([...graph.operations.keys()].toSorted()).toEqual([
+      "GetCustomers",
+      "GetCustomersCustomer",
+      "PostCustomers",
+    ]);
+  });
+
+  it("flattens OR-form security (basic | bearer) to both scheme names", () => {
+    expect(graph.security.get("basicAuth")?.kind).toBe("basic");
+    expect(graph.security.get("bearerAuth")?.kind).toBe("bearer");
+    expect(graph.operations.get("GetCustomers")?.security).toEqual(["basicAuth", "bearerAuth"]);
+  });
+
+  it("models array-typed query params (Stripe's expand[])", () => {
+    const expand = graph.operations
+      .get("GetCustomers")
+      ?.parameters.find((p) => p.name === "expand");
+    expect(expand?.schema?.type).toBe("array");
+    expect(expand?.schema?.items?.type).toBe("string");
+  });
+
+  it("keys request body content by media type, including non-JSON", () => {
+    const body = graph.operations.get("PostCustomers")?.requestBody;
+    expect([...(body?.content.keys() ?? [])]).toEqual(["application/x-www-form-urlencoded"]);
+  });
+
+  it("walks anyOf composition with resolved $ref pointers", () => {
+    const customer = graph.schemas.get("customer");
+    const addressProp = customer?.properties?.get("address");
+    expect(addressProp?.nullable).toBe(true);
+    expect(addressProp?.anyOf).toEqual([{ ref: "address" }]);
+  });
+});
+
+describe("buildOperationGraph — fail-loud resilience (PRD risk R1)", () => {
+  /** Assert the call throws an OpenApiSpecError carrying the expected reason + location. */
+  function expectSpecError(doc: unknown, reason: OpenApiSpecErrorReason): OpenApiSpecError {
+    let caught: unknown;
+    try {
+      buildOperationGraph(doc);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(OpenApiSpecError);
+    const specErr = caught as OpenApiSpecError;
+    expect(specErr.reason).toBe(reason);
+    // Actionable: the message is non-trivial and names what was wrong.
+    expect(specErr.message.length).toBeGreaterThan(20);
+    return specErr;
+  }
+
+  it("rejects a non-object document", () => {
+    expectSpecError(null, "not-an-object");
+    expectSpecError("not a spec", "not-an-object");
+    expectSpecError([], "not-an-object");
+  });
+
+  it("rejects Swagger 2.0 / missing version", () => {
+    expectSpecError({ swagger: "2.0", paths: {} }, "unsupported-version");
+    expectSpecError({ paths: {} }, "unsupported-version");
+  });
+
+  it("rejects a document with no paths object", () => {
+    expectSpecError({ openapi: "3.0.0" }, "missing-paths");
+  });
+
+  it("rejects an operation missing operationId, naming the path", () => {
+    const err = expectSpecError(
+      { openapi: "3.0.0", paths: { "/x": { get: { responses: {} } } } },
+      "missing-operation-id",
+    );
+    expect(err.location).toBe("paths./x.get");
+  });
+
+  it("rejects duplicate operationIds", () => {
+    expectSpecError(
+      {
+        openapi: "3.0.0",
+        paths: {
+          "/a": { get: { operationId: "dup", responses: {} } },
+          "/b": { get: { operationId: "dup", responses: {} } },
+        },
+      },
+      "duplicate-operation-id",
+    );
+  });
+
+  it("rejects a $ref whose target does not exist", () => {
+    expectSpecError(
+      {
+        openapi: "3.0.0",
+        components: { schemas: { A: { properties: { b: { $ref: "#/components/schemas/Missing" } } } } },
+        paths: {},
+      },
+      "unresolved-ref",
+    );
+  });
+
+  it("rejects an unsupported (external / non-component) $ref", () => {
+    expectSpecError(
+      {
+        openapi: "3.0.0",
+        components: { schemas: { A: { properties: { b: { $ref: "other.json#/X" } } } } },
+        paths: {},
+      },
+      "unsupported-ref",
+    );
+  });
+
+  it("rejects malformed security schemes", () => {
+    expectSpecError(
+      { openapi: "3.0.0", components: { securitySchemes: { x: { type: "apiKey", in: "header" } } }, paths: {} },
+      "invalid-security-scheme",
+    );
+    expectSpecError(
+      { openapi: "3.0.0", components: { securitySchemes: { x: { type: "carrier-pigeon" } } }, paths: {} },
+      "invalid-security-scheme",
+    );
+    expectSpecError(
+      { openapi: "3.0.0", components: { securitySchemes: { x: { type: "http", scheme: "digest" } } }, paths: {} },
+      "invalid-security-scheme",
+    );
+  });
+
+  it("rejects an operation referencing an undeclared security scheme", () => {
+    expectSpecError(
+      {
+        openapi: "3.0.0",
+        paths: { "/x": { get: { operationId: "x", security: [{ ghost: [] }], responses: {} } } },
+      },
+      "unknown-security-requirement",
+    );
+  });
+
+  it("rejects a parameter missing name or in", () => {
+    expectSpecError(
+      {
+        openapi: "3.0.0",
+        paths: { "/x": { get: { operationId: "x", parameters: [{ in: "query" }], responses: {} } } },
+      },
+      "invalid-parameter",
+    );
+  });
+
+  it("ignores vendor extensions (x-*) rather than failing", () => {
+    // Stripe / Twenty are full of x- keys; rejecting them would make those
+    // corpora unparseable. They must be silently ignored.
+    const graph = buildOperationGraph({
+      openapi: "3.0.0",
+      "x-vendor-thing": { whatever: true },
+      info: { title: "t", version: "1", "x-logo": {} },
+      paths: {
+        "x-speakeasy-ignore": true,
+        "/x": {
+          "x-internal": true,
+          get: { operationId: "x", "x-codegen": "skip", responses: {} },
+        },
+      },
+    });
+    expect([...graph.operations.keys()]).toEqual(["x"]);
+  });
+});

--- a/packages/api/src/lib/openapi/__tests__/spec.test.ts
+++ b/packages/api/src/lib/openapi/__tests__/spec.test.ts
@@ -3,12 +3,29 @@ import * as fs from "fs";
 import * as path from "path";
 
 import { buildOperationGraph } from "../spec";
-import { OpenApiSpecError, type OpenApiSpecErrorReason } from "../types";
+import {
+  OpenApiSpecError,
+  type OpenApiSchema,
+  type OpenApiSchemaInline,
+  type OpenApiSpecErrorReason,
+} from "../types";
 
 const FIXTURES = path.join(import.meta.dir, "fixtures");
 
 function loadFixture(name: string): unknown {
   return JSON.parse(fs.readFileSync(path.join(FIXTURES, `${name}.json`), "utf8"));
+}
+
+/**
+ * Narrow a schema node to its inline arm, asserting it is NOT a `$ref` pointer.
+ * Doubles as a test assertion: every call site genuinely expects an inline
+ * schema, and the union forces the ref-vs-inline decision to be explicit.
+ */
+function inline(schema: OpenApiSchema | undefined): OpenApiSchemaInline {
+  if (!schema || schema.ref !== undefined) {
+    throw new Error(`expected an inline schema, got ${JSON.stringify(schema)}`);
+  }
+  return schema;
 }
 
 describe("buildOperationGraph — minimal corpus", () => {
@@ -31,11 +48,11 @@ describe("buildOperationGraph — minimal corpus", () => {
     // Widget.owner -> Gadget, Gadget.widgets[] -> Widget is a cycle. A pointer
     // model keeps the graph finite while letting a consumer follow the join.
     const widget = graph.schemas.get("Widget");
-    const ownerProp = widget?.properties?.get("owner");
+    const ownerProp = inline(widget).properties?.get("owner");
     expect(ownerProp).toEqual({ ref: "Gadget" });
 
     const gadget = graph.schemas.get(ownerProp!.ref!);
-    expect(gadget?.properties?.get("widgets")?.items).toEqual({ ref: "Widget" });
+    expect(inline(inline(gadget).properties?.get("widgets")).items).toEqual({ ref: "Widget" });
 
     // Following the cycle back to Widget terminates — same object, no recursion.
     expect(graph.schemas.get("Widget")).toBe(widget);
@@ -97,23 +114,23 @@ describe("buildOperationGraph — Twenty /rest/open-api/core corpus", () => {
   it("resolves the Person ↔ NoteTarget $ref relationship in both directions", () => {
     // Person → noteTargets[] → NoteTarget
     const person = graph.schemas.get("Person");
-    const noteTargetsItem = person?.properties?.get("noteTargets")?.items;
+    const noteTargetsItem = inline(inline(person).properties?.get("noteTargets")).items;
     expect(noteTargetsItem).toEqual({ ref: "NoteTarget" });
 
-    const noteTarget = graph.schemas.get(noteTargetsItem!.ref!);
+    const noteTarget = inline(graph.schemas.get(noteTargetsItem!.ref!));
     // NoteTarget → person → Person (back-reference completing the cycle)
-    expect(noteTarget?.properties?.get("person")).toEqual({ ref: "Person" });
+    expect(noteTarget.properties?.get("person")).toEqual({ ref: "Person" });
     // NoteTarget → note → Note
-    expect(noteTarget?.properties?.get("note")).toEqual({ ref: "Note" });
+    expect(noteTarget.properties?.get("note")).toEqual({ ref: "Note" });
     // The join column is targetPersonId (NOT personId — the jezweb trap).
-    expect(noteTarget?.properties?.has("targetPersonId")).toBe(true);
-    expect(noteTarget?.properties?.has("personId")).toBe(false);
+    expect(noteTarget.properties?.has("targetPersonId")).toBe(true);
+    expect(noteTarget.properties?.has("personId")).toBe(false);
   });
 
   it("inlines Atlas custom fields as siblings of standard fields (no customFields wrapper)", () => {
-    const person = graph.schemas.get("Person");
-    expect(person?.properties?.has("atlasFirstSource")).toBe(true);
-    expect(person?.properties?.has("customFields")).toBe(false);
+    const person = inline(graph.schemas.get("Person"));
+    expect(person.properties?.has("atlasFirstSource")).toBe(true);
+    expect(person.properties?.has("customFields")).toBe(false);
   });
 
   it("resolves the reusable filter parameter onto list operations", () => {
@@ -162,8 +179,9 @@ describe("buildOperationGraph — Stripe corpus", () => {
     const expand = graph.operations
       .get("GetCustomers")
       ?.parameters.find((p) => p.name === "expand");
-    expect(expand?.schema?.type).toBe("array");
-    expect(expand?.schema?.items?.type).toBe("string");
+    const expandSchema = inline(expand?.schema);
+    expect(expandSchema.type).toBe("array");
+    expect(inline(expandSchema.items).type).toBe("string");
   });
 
   it("keys request body content by media type, including non-JSON", () => {
@@ -172,10 +190,10 @@ describe("buildOperationGraph — Stripe corpus", () => {
   });
 
   it("walks anyOf composition with resolved $ref pointers", () => {
-    const customer = graph.schemas.get("customer");
-    const addressProp = customer?.properties?.get("address");
-    expect(addressProp?.nullable).toBe(true);
-    expect(addressProp?.anyOf).toEqual([{ ref: "address" }]);
+    const customer = inline(graph.schemas.get("customer"));
+    const addressProp = inline(customer.properties?.get("address"));
+    expect(addressProp.nullable).toBe(true);
+    expect(addressProp.anyOf).toEqual([{ ref: "address" }]);
   });
 });
 
@@ -289,6 +307,63 @@ describe("buildOperationGraph — fail-loud resilience (PRD risk R1)", () => {
     );
   });
 
+  it("rejects a malformed (non-object) schema node", () => {
+    expectSpecError(
+      { openapi: "3.0.0", components: { schemas: { A: { properties: { b: 42 } } } }, paths: {} },
+      "invalid-structure",
+    );
+  });
+
+  it("rejects a non-object operation under a method key", () => {
+    expectSpecError(
+      { openapi: "3.0.0", paths: { "/x": { get: "GET" } } },
+      "invalid-structure",
+    );
+  });
+
+  it("rejects a malformed (non-object) response node", () => {
+    expectSpecError(
+      { openapi: "3.0.0", paths: { "/x": { get: { operationId: "x", responses: { "200": 5 } } } } },
+      "invalid-structure",
+    );
+  });
+
+  it("rejects a malformed (non-object) media-type entry", () => {
+    expectSpecError(
+      {
+        openapi: "3.0.0",
+        paths: {
+          "/x": {
+            get: { operationId: "x", responses: { "200": { description: "ok", content: { "application/json": 5 } } } },
+          },
+        },
+      },
+      "invalid-structure",
+    );
+  });
+
+  it("rejects a non-object security requirement entry (string instead of object — a false-negative trap)", () => {
+    expectSpecError(
+      {
+        openapi: "3.0.0",
+        components: { securitySchemes: { bearerAuth: { type: "http", scheme: "bearer" } } },
+        paths: { "/x": { get: { operationId: "x", security: ["bearerAuth"], responses: {} } } },
+      },
+      "invalid-structure",
+    );
+  });
+
+  it("rejects a non-object path item", () => {
+    expectSpecError({ openapi: "3.0.0", paths: { "/x": 5 } }, "invalid-structure");
+  });
+
+  it("rejects a path-item-level $ref (unsupported in this slice)", () => {
+    expectSpecError(
+      { openapi: "3.0.0", paths: { "/x": { $ref: "#/components/pathItems/Y" } } },
+      "unsupported-ref",
+    );
+  });
+
   it("ignores vendor extensions (x-*) rather than failing", () => {
     // Stripe / Twenty are full of x- keys; rejecting them would make those
     // corpora unparseable. They must be silently ignored.
@@ -305,5 +380,127 @@ describe("buildOperationGraph — fail-loud resilience (PRD risk R1)", () => {
       },
     });
     expect([...graph.operations.keys()]).toEqual(["x"]);
+  });
+});
+
+describe("buildOperationGraph — reference & edge normalization", () => {
+  it("resolves a requestBody $ref into components.requestBodies", () => {
+    const graph = buildOperationGraph({
+      openapi: "3.0.0",
+      components: {
+        schemas: { Pet: { type: "object", properties: { id: { type: "string" } } } },
+        requestBodies: {
+          PetBody: {
+            required: true,
+            content: { "application/json": { schema: { $ref: "#/components/schemas/Pet" } } },
+          },
+        },
+      },
+      paths: {
+        "/pets": {
+          post: {
+            operationId: "createPet",
+            requestBody: { $ref: "#/components/requestBodies/PetBody" },
+            responses: { "201": { description: "created" } },
+          },
+        },
+      },
+    });
+    const body = graph.operations.get("createPet")?.requestBody;
+    expect(body?.required).toBe(true);
+    expect(body?.content.get("application/json")).toEqual({ ref: "Pet" });
+  });
+
+  it("resolves a response $ref into components.responses", () => {
+    const graph = buildOperationGraph({
+      openapi: "3.0.0",
+      components: {
+        schemas: { Err: { type: "object", properties: { message: { type: "string" } } } },
+        responses: {
+          NotFound: {
+            description: "missing",
+            content: { "application/json": { schema: { $ref: "#/components/schemas/Err" } } },
+          },
+        },
+      },
+      paths: {
+        "/x": {
+          get: {
+            operationId: "x",
+            responses: { "404": { $ref: "#/components/responses/NotFound" } },
+          },
+        },
+      },
+    });
+    const resp = graph.operations.get("x")?.responses.get("404");
+    expect(resp?.description).toBe("missing");
+    expect(resp?.content.get("application/json")).toEqual({ ref: "Err" });
+  });
+
+  it("rejects a requestBody $ref pointing at the wrong component section", () => {
+    let caught: unknown;
+    try {
+      buildOperationGraph({
+        openapi: "3.0.0",
+        components: { schemas: { Pet: { type: "object" } } },
+        paths: {
+          "/pets": {
+            post: {
+              operationId: "createPet",
+              requestBody: { $ref: "#/components/schemas/Pet" },
+              responses: {},
+            },
+          },
+        },
+      });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(OpenApiSpecError);
+    expect((caught as OpenApiSpecError).reason).toBe("unsupported-ref");
+  });
+
+  it("treats an explicit document-level security: [] as 'no auth' for inheriting operations", () => {
+    const graph = buildOperationGraph({
+      openapi: "3.0.0",
+      security: [],
+      components: { securitySchemes: { bearerAuth: { type: "http", scheme: "bearer" } } },
+      paths: { "/x": { get: { operationId: "x", responses: {} } } },
+    });
+    expect(graph.operations.get("x")?.security).toEqual([]);
+  });
+
+  it("normalizes OpenAPI 3.1 type:[..,'null'] into type + nullable", () => {
+    const graph = buildOperationGraph({
+      openapi: "3.1.0",
+      components: {
+        schemas: {
+          Thing: {
+            type: "object",
+            properties: { email: { type: ["string", "null"] } },
+          },
+        },
+      },
+      paths: {},
+    });
+    const thing = inline(graph.schemas.get("Thing"));
+    const email = inline(thing.properties?.get("email"));
+    expect(email.type).toBe("string");
+    expect(email.nullable).toBe(true);
+  });
+
+  it("normalizes oauth2 / openIdConnect schemes without throwing (flows deferred to slice 6)", () => {
+    const graph = buildOperationGraph({
+      openapi: "3.0.0",
+      components: {
+        securitySchemes: {
+          oauth: { type: "oauth2", flows: { clientCredentials: { tokenUrl: "https://x/token", scopes: {} } } },
+          oidc: { type: "openIdConnect", openIdConnectUrl: "https://x/.well-known" },
+        },
+      },
+      paths: {},
+    });
+    expect(graph.security.get("oauth")?.kind).toBe("oauth2");
+    expect(graph.security.get("oidc")?.kind).toBe("openIdConnect");
   });
 });

--- a/packages/api/src/lib/openapi/client.ts
+++ b/packages/api/src/lib/openapi/client.ts
@@ -1,0 +1,409 @@
+/**
+ * `openapi-client` — executes a single normalized operation over HTTP.
+ *
+ * `executeOperation(graph, operationId, params, resolvedAuth, opts)` builds the
+ * request from the {@link OperationGraph} (path/query/header encoding per the
+ * parameter's location, auth applied per the operation's security scheme),
+ * fires one `fetch`, and returns `{ status, headers, body }`. It is a transport
+ * primitive: NO agent logic, NO caching, NO pagination, NO retry. A non-2xx
+ * response is returned as an {@link OperationResult}, not thrown — interpreting
+ * status is the caller's job.
+ *
+ * Per-request timeout is enforced via `AbortSignal.timeout`. `Retry-After` is
+ * parsed per RFC 9110 §10.2.3 and surfaced on the result (the client honors it
+ * by reporting it; retry scheduling belongs to a later layer). The error
+ * envelope + retry-after parsing mirror the Twenty client (`plugins/twenty/
+ * src/client.ts`, PR #2865) — the well-understood prior art for this milestone.
+ *
+ * Auth: `bearer` / `basic` / `apiKey-header` / `apiKey-query` are applied.
+ * `oauth2` / `openIdConnect` are normalized by `spec.ts` but their flows are
+ * deferred to slice 6 — pass `{ kind: "bearer", token }` once a token is
+ * obtained out of band.
+ */
+import {
+  DEFAULT_REQUEST_TIMEOUT_MS,
+  OpenApiClientError,
+  type ExecuteOptions,
+  type Operation,
+  type OperationGraph,
+  type OperationParams,
+  type OperationResult,
+  type ResolvedAuth,
+} from "./types";
+
+// ─────────────────────────────────────────────────────────────────────
+//  Public entry point
+// ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Execute one operation from the graph against its target.
+ *
+ * @throws {OpenApiClientError} for client-side faults (unknown operation,
+ *   missing base URL, missing path param, missing auth placement) and transport
+ *   faults (timeout, network). A non-2xx HTTP response is NOT an error — it is
+ *   returned as the result.
+ */
+export async function executeOperation(
+  graph: OperationGraph,
+  operationId: string,
+  params: OperationParams,
+  resolvedAuth: ResolvedAuth,
+  opts: ExecuteOptions = {},
+): Promise<OperationResult> {
+  const operation = graph.operations.get(operationId);
+  if (operation === undefined) {
+    throw new OpenApiClientError({
+      reason: "unknown-operation",
+      operationId,
+      status: 0,
+      message:
+        `Unknown operationId "${operationId}". It is not present in the probed operation graph ` +
+        `(${graph.operations.size} operations available). Refusing to dispatch a fabricated operation.`,
+    });
+  }
+
+  const baseUrl = opts.baseUrl ?? graph.servers[0]?.url;
+  if (baseUrl === undefined || baseUrl.length === 0) {
+    throw new OpenApiClientError({
+      reason: "missing-base-url",
+      operationId,
+      status: 0,
+      message:
+        `No base URL for "${operationId}": the document declares no servers[0].url and no ` +
+        `baseUrl override was provided. Pass { baseUrl } in the execute options.`,
+    });
+  }
+
+  const url = buildUrl(baseUrl, operation, params, graph, resolvedAuth);
+  const headers = buildHeaders(operation, params, graph, resolvedAuth);
+  const { body, hasBody } = buildBody(operation, params, headers);
+
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
+  const fetchImpl = opts.fetchImpl ?? globalThis.fetch;
+
+  let response: Response;
+  try {
+    response = await fetchImpl(url.toString(), {
+      method: operation.method,
+      headers,
+      ...(hasBody ? { body } : {}),
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+  } catch (err) {
+    throw classifyTransportError(err, operationId, timeoutMs);
+  }
+
+  return readResult(response, operationId);
+}
+
+// ─────────────────────────────────────────────────────────────────────
+//  URL + query building
+// ─────────────────────────────────────────────────────────────────────
+
+function buildUrl(
+  baseUrl: string,
+  operation: Operation,
+  params: OperationParams,
+  graph: OperationGraph,
+  resolvedAuth: ResolvedAuth,
+): URL {
+  const resolvedPath = substitutePathParams(operation, params.path);
+  const url = new URL(joinUrl(baseUrl, resolvedPath));
+
+  if (params.query) {
+    for (const [key, value] of Object.entries(params.query)) {
+      appendQueryValue(url.searchParams, key, value);
+    }
+  }
+
+  applyQueryAuth(url.searchParams, operation, graph, resolvedAuth);
+  return url;
+}
+
+/** Replace every `{token}` in the path; an unfilled token is a fail-loud fault. */
+function substitutePathParams(
+  operation: Operation,
+  pathParams: OperationParams["path"],
+): string {
+  return operation.path.replace(/\{([^}]+)\}/g, (_, token: string) => {
+    const value = pathParams?.[token];
+    if (value === undefined) {
+      throw new OpenApiClientError({
+        reason: "missing-path-param",
+        operationId: operation.operationId,
+        status: 0,
+        message: `Operation "${operation.operationId}" requires path parameter "${token}" but it was not provided.`,
+      });
+    }
+    return encodeURIComponent(String(value));
+  });
+}
+
+/** Join a base URL and a path with exactly one slash between them. */
+function joinUrl(baseUrl: string, pathSegment: string): string {
+  const base = baseUrl.endsWith("/") ? baseUrl.slice(0, -1) : baseUrl;
+  const segment = pathSegment.startsWith("/") ? pathSegment : `/${pathSegment}`;
+  return `${base}${segment}`;
+}
+
+/** Append a query value; arrays explode (repeat the key); `undefined` is dropped. */
+function appendQueryValue(
+  search: URLSearchParams,
+  key: string,
+  value: string | number | boolean | ReadonlyArray<string | number | boolean> | undefined,
+): void {
+  if (value === undefined) return;
+  if (Array.isArray(value)) {
+    for (const item of value) search.append(key, String(item));
+    return;
+  }
+  search.append(key, String(value as string | number | boolean));
+}
+
+// ─────────────────────────────────────────────────────────────────────
+//  Headers + auth
+// ─────────────────────────────────────────────────────────────────────
+
+function buildHeaders(
+  operation: Operation,
+  params: OperationParams,
+  graph: OperationGraph,
+  resolvedAuth: ResolvedAuth,
+): Record<string, string> {
+  const headers: Record<string, string> = {
+    accept: "application/json",
+  };
+
+  if (params.header) {
+    for (const [key, value] of Object.entries(params.header)) {
+      headers[key] = String(value);
+    }
+  }
+
+  applyHeaderAuth(headers, operation, graph, resolvedAuth);
+  return headers;
+}
+
+function applyHeaderAuth(
+  headers: Record<string, string>,
+  operation: Operation,
+  graph: OperationGraph,
+  resolvedAuth: ResolvedAuth,
+): void {
+  switch (resolvedAuth.kind) {
+    case "none":
+      return;
+    case "bearer":
+      headers["Authorization"] = `Bearer ${resolvedAuth.token}`;
+      return;
+    case "basic": {
+      const encoded = Buffer.from(
+        `${resolvedAuth.username}:${resolvedAuth.password}`,
+        "utf8",
+      ).toString("base64");
+      headers["Authorization"] = `Basic ${encoded}`;
+      return;
+    }
+    case "apiKey": {
+      const placement = resolveApiKeyPlacement(operation, graph, resolvedAuth);
+      if (placement.in === "header") {
+        headers[placement.name] = resolvedAuth.value;
+      }
+      return;
+    }
+  }
+}
+
+function applyQueryAuth(
+  search: URLSearchParams,
+  operation: Operation,
+  graph: OperationGraph,
+  resolvedAuth: ResolvedAuth,
+): void {
+  if (resolvedAuth.kind !== "apiKey") return;
+  const placement = resolveApiKeyPlacement(operation, graph, resolvedAuth);
+  if (placement.in === "query") {
+    search.set(placement.name, resolvedAuth.value);
+  }
+}
+
+/**
+ * Decide where an apiKey credential goes. Explicit `in` / `name` overrides win
+ * (slice 2 stores placement in config); otherwise the placement is read from
+ * the operation's apiKey security scheme. If neither is available, fail loud —
+ * we will not guess a parameter name.
+ */
+function resolveApiKeyPlacement(
+  operation: Operation,
+  graph: OperationGraph,
+  auth: Extract<ResolvedAuth, { kind: "apiKey" }>,
+): { in: "header" | "query"; name: string } {
+  if (auth.in !== undefined && auth.name !== undefined) {
+    return { in: auth.in, name: auth.name };
+  }
+
+  for (const schemeName of operation.security) {
+    const scheme = graph.security.get(schemeName);
+    if (scheme?.kind === "apiKey-header" && scheme.parameterName) {
+      return { in: auth.in ?? "header", name: auth.name ?? scheme.parameterName };
+    }
+    if (scheme?.kind === "apiKey-query" && scheme.parameterName) {
+      return { in: auth.in ?? "query", name: auth.name ?? scheme.parameterName };
+    }
+  }
+
+  throw new OpenApiClientError({
+    reason: "missing-auth-placement",
+    operationId: operation.operationId,
+    status: 0,
+    message:
+      `Cannot place the apiKey credential for "${operation.operationId}": the operation declares no ` +
+      `apiKey security scheme and no { in, name } override was supplied. Provide auth.in + auth.name.`,
+  });
+}
+
+// ─────────────────────────────────────────────────────────────────────
+//  Request body
+// ─────────────────────────────────────────────────────────────────────
+
+function buildBody(
+  operation: Operation,
+  params: OperationParams,
+  headers: Record<string, string>,
+): { body?: string; hasBody: boolean } {
+  if (params.body === undefined) return { hasBody: false };
+  // GET / HEAD cannot carry a body per the fetch spec; skip rather than throw.
+  if (operation.method === "GET" || operation.method === "HEAD") {
+    return { hasBody: false };
+  }
+  if (!hasHeader(headers, "content-type")) {
+    headers["Content-Type"] = "application/json";
+  }
+  return { body: JSON.stringify(params.body), hasBody: true };
+}
+
+function hasHeader(headers: Record<string, string>, name: string): boolean {
+  const target = name.toLowerCase();
+  return Object.keys(headers).some((k) => k.toLowerCase() === target);
+}
+
+// ─────────────────────────────────────────────────────────────────────
+//  Response reading
+// ─────────────────────────────────────────────────────────────────────
+
+async function readResult(
+  response: Response,
+  operationId: string,
+): Promise<OperationResult> {
+  const headers: Record<string, string> = {};
+  response.headers.forEach((value, key) => {
+    headers[key.toLowerCase()] = value;
+  });
+
+  const retryAfterMs = parseRetryAfterMs(response.headers.get("retry-after"));
+  const contentType = response.headers.get("content-type") ?? "";
+
+  let raw: string;
+  try {
+    raw = await response.text();
+  } catch (err) {
+    throw new OpenApiClientError({
+      reason: "unparseable-response",
+      operationId,
+      status: response.status,
+      message: `Failed to read response body for "${operationId}": ${errMessage(err)}`,
+    });
+  }
+
+  let body: unknown = null;
+  let bodyIsRaw = false;
+  if (raw.length > 0) {
+    if (isJsonContentType(contentType)) {
+      try {
+        body = JSON.parse(raw);
+      } catch (err) {
+        throw new OpenApiClientError({
+          reason: "unparseable-response",
+          operationId,
+          status: response.status,
+          ...(retryAfterMs !== undefined ? { retryAfterMs } : {}),
+          message: `Response for "${operationId}" declared JSON but did not parse: ${errMessage(err)}`,
+        });
+      }
+    } else {
+      body = raw;
+      bodyIsRaw = true;
+    }
+  }
+
+  return {
+    status: response.status,
+    headers,
+    body,
+    bodyIsRaw,
+    ...(retryAfterMs !== undefined ? { retryAfterMs } : {}),
+  };
+}
+
+function isJsonContentType(contentType: string): boolean {
+  const lowered = contentType.toLowerCase();
+  return lowered.includes("application/json") || lowered.includes("+json");
+}
+
+// ─────────────────────────────────────────────────────────────────────
+//  Transport-error classification
+// ─────────────────────────────────────────────────────────────────────
+
+function classifyTransportError(
+  err: unknown,
+  operationId: string,
+  timeoutMs: number,
+): OpenApiClientError {
+  const name = err instanceof Error ? err.name : "";
+  if (name === "TimeoutError" || name === "AbortError") {
+    return new OpenApiClientError({
+      reason: "timeout",
+      operationId,
+      status: 0,
+      message: `Operation "${operationId}" timed out after ${timeoutMs}ms.`,
+    });
+  }
+  return new OpenApiClientError({
+    reason: "network",
+    operationId,
+    status: 0,
+    message: `Network error executing "${operationId}": ${errMessage(err)}`,
+  });
+}
+
+// ─────────────────────────────────────────────────────────────────────
+//  Retry-After (mirrors plugins/twenty/src/client.ts:parseRetryAfterMs)
+// ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Parse `Retry-After` per RFC 9110 §10.2.3. Two valid forms:
+ *  - `delta-seconds` (e.g. `120`) — non-negative integer.
+ *  - `HTTP-date` (e.g. `Wed, 21 Oct 2015 07:28:00 GMT`) — `Date.parse`able.
+ *
+ * Returns the wait in milliseconds, or `undefined` when absent / unparseable.
+ * Clamped non-negative so server clock skew can't ask us to retry "in the past".
+ */
+export function parseRetryAfterMs(headerValue: string | null | undefined): number | undefined {
+  if (!headerValue) return undefined;
+  const trimmed = headerValue.trim();
+  if (trimmed.length === 0) return undefined;
+
+  if (/^\d+$/.test(trimmed)) {
+    const seconds = Number.parseInt(trimmed, 10);
+    if (!Number.isFinite(seconds)) return undefined;
+    return Math.max(0, seconds * 1000);
+  }
+
+  const target = Date.parse(trimmed);
+  if (!Number.isFinite(target)) return undefined;
+  return Math.max(0, target - Date.now());
+}
+
+function errMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/packages/api/src/lib/openapi/client.ts
+++ b/packages/api/src/lib/openapi/client.ts
@@ -174,6 +174,9 @@ function buildHeaders(
     accept: "application/json",
   };
 
+  // `in: cookie` parameters are normalized into the graph but not emitted by
+  // this slice — there is no cookie bucket on OperationParams. A consumer that
+  // needs cookie auth must supply it via a header param for now.
   if (params.header) {
     for (const [key, value] of Object.entries(params.header)) {
       headers[key] = String(value);

--- a/packages/api/src/lib/openapi/client.ts
+++ b/packages/api/src/lib/openapi/client.ts
@@ -228,27 +228,28 @@ function applyQueryAuth(
 }
 
 /**
- * Decide where an apiKey credential goes. Explicit `in` / `name` overrides win
- * (slice 2 stores placement in config); otherwise the placement is read from
- * the operation's apiKey security scheme. If neither is available, fail loud —
- * we will not guess a parameter name.
+ * Decide where an apiKey credential goes. An explicit `placement` override wins
+ * (slice 2 stores placement in config); otherwise the placement is read from the
+ * operation's apiKey security scheme — `parameterName` is guaranteed present on
+ * those scheme arms by the parse boundary, so no runtime presence check is
+ * needed. If neither is available, fail loud — we will not guess a name.
  */
 function resolveApiKeyPlacement(
   operation: Operation,
   graph: OperationGraph,
   auth: Extract<ResolvedAuth, { kind: "apiKey" }>,
 ): { in: "header" | "query"; name: string } {
-  if (auth.in !== undefined && auth.name !== undefined) {
-    return { in: auth.in, name: auth.name };
+  if (auth.placement !== undefined) {
+    return auth.placement;
   }
 
   for (const schemeName of operation.security) {
     const scheme = graph.security.get(schemeName);
-    if (scheme?.kind === "apiKey-header" && scheme.parameterName) {
-      return { in: auth.in ?? "header", name: auth.name ?? scheme.parameterName };
+    if (scheme?.kind === "apiKey-header") {
+      return { in: "header", name: scheme.parameterName };
     }
-    if (scheme?.kind === "apiKey-query" && scheme.parameterName) {
-      return { in: auth.in ?? "query", name: auth.name ?? scheme.parameterName };
+    if (scheme?.kind === "apiKey-query") {
+      return { in: "query", name: scheme.parameterName };
     }
   }
 
@@ -258,7 +259,7 @@ function resolveApiKeyPlacement(
     status: 0,
     message:
       `Cannot place the apiKey credential for "${operation.operationId}": the operation declares no ` +
-      `apiKey security scheme and no { in, name } override was supplied. Provide auth.in + auth.name.`,
+      `apiKey security scheme and no { placement } override was supplied.`,
   });
 }
 

--- a/packages/api/src/lib/openapi/client.ts
+++ b/packages/api/src/lib/openapi/client.ts
@@ -361,12 +361,16 @@ function classifyTransportError(
   timeoutMs: number,
 ): OpenApiClientError {
   const name = err instanceof Error ? err.name : "";
+  // `AbortSignal.timeout()` aborts with a `TimeoutError`; the `AbortError` arm
+  // is defensive (future caller-supplied signals / runtime variance). The
+  // message stays accurate for both — it does not assert the limit was
+  // definitely reached, only what the per-request limit was.
   if (name === "TimeoutError" || name === "AbortError") {
     return new OpenApiClientError({
       reason: "timeout",
       operationId,
       status: 0,
-      message: `Operation "${operationId}" timed out after ${timeoutMs}ms.`,
+      message: `Operation "${operationId}" was aborted (per-request timeout ${timeoutMs}ms).`,
     });
   }
   return new OpenApiClientError({

--- a/packages/api/src/lib/openapi/index.ts
+++ b/packages/api/src/lib/openapi/index.ts
@@ -1,0 +1,46 @@
+/**
+ * OpenAPI Datasource primitive (v0.2.0 — REST Datasources).
+ *
+ * Two foundational deep modules, siblings to the SQL Datasource layer
+ * (`lib/db/connection.ts`) — never folded into it (PRD #2868 "Option B").
+ *
+ *  - `openapi-spec` (`spec.ts`): `buildOperationGraph(doc)` — pure normalizer
+ *    from an OpenAPI 3.x document to the {@link OperationGraph} (the shared
+ *    shape every downstream consumer reads).
+ *  - `openapi-client` (`client.ts`): `executeOperation(graph, id, params, auth)`
+ *    — executes a single operation over HTTP. Transport primitive only.
+ *
+ * Deferred to later slices (clean extension points left in place): semantic-YAML
+ * generation (1b), pagination (4), `validateRestOperation` (5), networkPolicy
+ * threading (3), catalog/install surface (2).
+ */
+export { buildOperationGraph } from "./spec";
+export { executeOperation, parseRetryAfterMs } from "./client";
+
+export {
+  DEFAULT_REQUEST_TIMEOUT_MS,
+  HTTP_METHODS,
+  OpenApiClientError,
+  OpenApiSpecError,
+} from "./types";
+
+export type {
+  ExecuteOptions,
+  HttpMethod,
+  OpenApiClientErrorReason,
+  OpenApiSchema,
+  OpenApiSpecErrorReason,
+  Operation,
+  OperationGraph,
+  OperationParameter,
+  OperationParams,
+  OperationRequestBody,
+  OperationResponse,
+  OperationResult,
+  ParameterLocation,
+  ResolvedAuth,
+  SecurityScheme,
+  SecuritySchemeKind,
+  ServerInfo,
+  SpecInfo,
+} from "./types";

--- a/packages/api/src/lib/openapi/spec.ts
+++ b/packages/api/src/lib/openapi/spec.ts
@@ -1,0 +1,662 @@
+/**
+ * `openapi-spec` — the single parse boundary for OpenAPI 3.x documents.
+ *
+ * `buildOperationGraph` is a PURE function (no I/O, no mocks, no agent logic):
+ * it takes an already-parsed OpenAPI 3.x JSON document and emits the normalized
+ * {@link OperationGraph} every downstream consumer reads. Past this boundary,
+ * nobody walks a `$ref` string or a raw `paths.*` object again.
+ *
+ * Fail-loud contract (PRD #2868 risk R1): a structurally malformed document, a
+ * missing `operationId`, or an unresolvable / unsupported `$ref` throws
+ * {@link OpenApiSpecError} — the function never returns a half-built graph.
+ *
+ * Deliberately NOT fail-loud on:
+ *  - Vendor extensions (`x-*` keys). OpenAPI explicitly permits them anywhere;
+ *    real specs (Stripe, Twenty) are full of them. We ignore them. Rejecting
+ *    every `x-` key would make "normalize Stripe's spec" impossible.
+ *  - Circular `$ref`s through named components (Twenty's Person ↔ NoteTarget).
+ *    These are REQUIRED to resolve (acceptance criterion). We resolve a named
+ *    `$ref` to a pointer node (`{ ref: "Name" }`) rather than inlining, so the
+ *    graph stays finite while the relationship remains traversable.
+ *
+ * Scope (slice 0): walks `paths.*`, `components.schemas.*`,
+ * `components.parameters.*`, `components.securitySchemes.*` (plus `requestBodies`
+ * / `responses` when referenced). Deferred to later slices: semantic-YAML
+ * generation (1b), pagination (4), `validateRestOperation` (5).
+ */
+import {
+  HTTP_METHODS,
+  OpenApiSpecError,
+  type HttpMethod,
+  type Operation,
+  type OperationGraph,
+  type OperationParameter,
+  type OperationRequestBody,
+  type OperationResponse,
+  type OpenApiSchema,
+  type ParameterLocation,
+  type SecurityScheme,
+  type ServerInfo,
+  type SpecInfo,
+} from "./types";
+
+// ─────────────────────────────────────────────────────────────────────
+//  Unknown-navigation helpers (no `any`)
+// ─────────────────────────────────────────────────────────────────────
+
+type JsonObject = Record<string, unknown>;
+
+function isObject(v: unknown): v is JsonObject {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+function asString(v: unknown): string | undefined {
+  return typeof v === "string" ? v : undefined;
+}
+
+function asBoolean(v: unknown): boolean | undefined {
+  return typeof v === "boolean" ? v : undefined;
+}
+
+function asStringArray(v: unknown): string[] | undefined {
+  if (!Array.isArray(v)) return undefined;
+  const out: string[] = [];
+  for (const item of v) {
+    if (typeof item === "string") out.push(item);
+  }
+  return out;
+}
+
+// ─────────────────────────────────────────────────────────────────────
+//  $ref resolution
+// ─────────────────────────────────────────────────────────────────────
+
+/** A parsed local component reference, e.g. `#/components/schemas/Person`. */
+interface ParsedRef {
+  readonly section: string;
+  readonly name: string;
+}
+
+/**
+ * Parse a `$ref` string. Only local component refs of the form
+ * `#/components/<section>/<name>` are supported; external files
+ * (`other.json#/...`) and non-component pointers throw `unsupported-ref` so a
+ * consumer never receives a node we silently failed to resolve.
+ */
+function parseRef(ref: string, location: string): ParsedRef {
+  const match = /^#\/components\/([^/]+)\/(.+)$/.exec(ref);
+  if (!match) {
+    throw new OpenApiSpecError({
+      reason: "unsupported-ref",
+      location,
+      message:
+        `Unsupported $ref "${ref}" at ${location}. Only local component refs of the form ` +
+        `"#/components/<section>/<name>" are supported (external files and non-component ` +
+        `pointers are not resolved in this slice).`,
+    });
+  }
+  // A `$ref` name may itself contain `~1`-escaped slashes; decode per RFC 6901.
+  const name = match[2].replace(/~1/g, "/").replace(/~0/g, "~");
+  return { section: match[1], name };
+}
+
+// ─────────────────────────────────────────────────────────────────────
+//  Builder (closes over the document's component registries)
+// ─────────────────────────────────────────────────────────────────────
+
+class GraphBuilder {
+  private readonly components: JsonObject;
+  private readonly schemaNames: ReadonlySet<string>;
+  private readonly securityNames: ReadonlySet<string>;
+
+  constructor(
+    components: JsonObject,
+    private readonly security: ReadonlyMap<string, SecurityScheme>,
+  ) {
+    this.components = components;
+    this.schemaNames = new Set(
+      isObject(components.schemas) ? Object.keys(components.schemas) : [],
+    );
+    this.securityNames = new Set(security.keys());
+  }
+
+  /** Look up a raw component object by section + name, resolving one `$ref` hop. */
+  private rawComponent(section: string, name: string, location: string): JsonObject {
+    const bucket = this.components[section];
+    const node = isObject(bucket) ? bucket[name] : undefined;
+    if (!isObject(node)) {
+      throw new OpenApiSpecError({
+        reason: "unresolved-ref",
+        location,
+        message: `$ref target "#/components/${section}/${name}" referenced at ${location} does not exist.`,
+      });
+    }
+    return node;
+  }
+
+  // ── Schemas ────────────────────────────────────────────────────────
+
+  /**
+   * Normalize a raw schema node. A `$ref` to a named component schema collapses
+   * to a pointer (`{ ref }`) — no recursion into the target, which keeps cycles
+   * finite. Inline schemas are walked in full (they cannot be circular).
+   */
+  walkSchema(raw: unknown, location: string): OpenApiSchema {
+    if (!isObject(raw)) {
+      throw new OpenApiSpecError({
+        reason: "invalid-structure",
+        location,
+        message: `Expected a schema object at ${location}, got ${describe(raw)}.`,
+      });
+    }
+
+    const refStr = asString(raw.$ref);
+    if (refStr !== undefined) {
+      const { section, name } = parseRef(refStr, location);
+      if (section !== "schemas") {
+        throw new OpenApiSpecError({
+          reason: "unsupported-ref",
+          location,
+          message: `Schema position at ${location} references "#/components/${section}/${name}"; only schema refs are valid here.`,
+        });
+      }
+      if (!this.schemaNames.has(name)) {
+        throw new OpenApiSpecError({
+          reason: "unresolved-ref",
+          location,
+          message: `Schema $ref "#/components/schemas/${name}" at ${location} has no matching component.`,
+        });
+      }
+      return { ref: name };
+    }
+
+    const node: Mutable<OpenApiSchema> = {};
+    const type = asString(raw.type);
+    if (type !== undefined) node.type = type;
+    const format = asString(raw.format);
+    if (format !== undefined) node.format = format;
+    const description = asString(raw.description);
+    if (description !== undefined) node.description = description;
+    if (Array.isArray(raw.enum)) node.enum = raw.enum as ReadonlyArray<unknown>;
+    const nullable = asBoolean(raw.nullable);
+    if (nullable !== undefined) node.nullable = nullable;
+    const required = asStringArray(raw.required);
+    if (required !== undefined) node.required = required;
+
+    if (isObject(raw.properties)) {
+      const props = new Map<string, OpenApiSchema>();
+      for (const [key, value] of Object.entries(raw.properties)) {
+        props.set(key, this.walkSchema(value, `${location}.properties.${key}`));
+      }
+      node.properties = props;
+    }
+
+    if (raw.items !== undefined) {
+      node.items = this.walkSchema(raw.items, `${location}.items`);
+    }
+
+    for (const keyword of ["allOf", "oneOf", "anyOf"] as const) {
+      const branch = raw[keyword];
+      if (Array.isArray(branch)) {
+        node[keyword] = branch.map((sub, i) =>
+          this.walkSchema(sub, `${location}.${keyword}[${i}]`),
+        );
+      }
+    }
+
+    return node;
+  }
+
+  buildSchemas(): Map<string, OpenApiSchema> {
+    const out = new Map<string, OpenApiSchema>();
+    const raw = this.components.schemas;
+    if (!isObject(raw)) return out;
+    for (const name of this.schemaNames) {
+      const walked = this.walkSchema(raw[name], `components.schemas.${name}`);
+      out.set(name, { ...walked, name });
+    }
+    return out;
+  }
+
+  // ── Parameters ─────────────────────────────────────────────────────
+
+  private normalizeParameter(raw: unknown, location: string): OperationParameter {
+    let node = raw;
+    if (isObject(raw)) {
+      const refStr = asString(raw.$ref);
+      if (refStr !== undefined) {
+        const { section, name } = parseRef(refStr, location);
+        if (section !== "parameters") {
+          throw new OpenApiSpecError({
+            reason: "unsupported-ref",
+            location,
+            message: `Parameter position at ${location} references "#/components/${section}/${name}".`,
+          });
+        }
+        node = this.rawComponent("parameters", name, location);
+      }
+    }
+
+    if (!isObject(node)) {
+      throw new OpenApiSpecError({
+        reason: "invalid-parameter",
+        location,
+        message: `Expected a parameter object at ${location}, got ${describe(node)}.`,
+      });
+    }
+
+    const name = asString(node.name);
+    const location_ = asString(node.in);
+    if (name === undefined || location_ === undefined) {
+      throw new OpenApiSpecError({
+        reason: "invalid-parameter",
+        location,
+        message: `Parameter at ${location} is missing required "name" or "in".`,
+      });
+    }
+    if (!isParameterLocation(location_)) {
+      throw new OpenApiSpecError({
+        reason: "invalid-parameter",
+        location,
+        message: `Parameter "${name}" at ${location} has unknown location "in: ${location_}".`,
+      });
+    }
+
+    const param: Mutable<OperationParameter> = {
+      name,
+      in: location_,
+      // OpenAPI requires `required: true` for path params; coerce defensively.
+      required: location_ === "path" ? true : asBoolean(node.required) ?? false,
+    };
+    const description = asString(node.description);
+    if (description !== undefined) param.description = description;
+    if (node.schema !== undefined) {
+      param.schema = this.walkSchema(node.schema, `${location}.schema`);
+    }
+    return param;
+  }
+
+  /** Merge path-level and operation-level parameters; operation wins on (name, in). */
+  private buildParameters(
+    pathLevel: unknown,
+    opLevel: unknown,
+    location: string,
+  ): OperationParameter[] {
+    const byKey = new Map<string, OperationParameter>();
+    const add = (list: unknown, scope: string) => {
+      if (!Array.isArray(list)) return;
+      list.forEach((raw, i) => {
+        const param = this.normalizeParameter(raw, `${location}.${scope}[${i}]`);
+        byKey.set(`${param.in}:${param.name}`, param);
+      });
+    };
+    add(pathLevel, "parameters");
+    add(opLevel, "parameters");
+    return [...byKey.values()];
+  }
+
+  // ── Request body & responses (with media-type content maps) ──────────
+
+  private buildContent(raw: unknown, location: string): Map<string, OpenApiSchema> {
+    const out = new Map<string, OpenApiSchema>();
+    if (!isObject(raw)) return out;
+    for (const [mediaType, value] of Object.entries(raw)) {
+      if (!isObject(value)) continue;
+      if (value.schema !== undefined) {
+        out.set(mediaType, this.walkSchema(value.schema, `${location}.${mediaType}.schema`));
+      }
+    }
+    return out;
+  }
+
+  private buildRequestBody(raw: unknown, location: string): OperationRequestBody | undefined {
+    if (raw === undefined) return undefined;
+    let node = raw;
+    if (isObject(raw)) {
+      const refStr = asString(raw.$ref);
+      if (refStr !== undefined) {
+        const { section, name } = parseRef(refStr, location);
+        if (section !== "requestBodies") {
+          throw new OpenApiSpecError({
+            reason: "unsupported-ref",
+            location,
+            message: `requestBody at ${location} references "#/components/${section}/${name}".`,
+          });
+        }
+        node = this.rawComponent("requestBodies", name, location);
+      }
+    }
+    if (!isObject(node)) {
+      throw new OpenApiSpecError({
+        reason: "invalid-structure",
+        location,
+        message: `Expected a requestBody object at ${location}, got ${describe(node)}.`,
+      });
+    }
+    const body: Mutable<OperationRequestBody> = {
+      required: asBoolean(node.required) ?? false,
+      content: this.buildContent(node.content, `${location}.content`),
+    };
+    const description = asString(node.description);
+    if (description !== undefined) body.description = description;
+    return body;
+  }
+
+  private buildResponses(raw: unknown, location: string): Map<string, OperationResponse> {
+    const out = new Map<string, OperationResponse>();
+    if (!isObject(raw)) return out;
+    for (const [status, value] of Object.entries(raw)) {
+      let node = value;
+      if (isObject(value)) {
+        const refStr = asString(value.$ref);
+        if (refStr !== undefined) {
+          const { section, name } = parseRef(refStr, `${location}.${status}`);
+          if (section !== "responses") {
+            throw new OpenApiSpecError({
+              reason: "unsupported-ref",
+              location: `${location}.${status}`,
+              message: `Response at ${location}.${status} references "#/components/${section}/${name}".`,
+            });
+          }
+          node = this.rawComponent("responses", name, `${location}.${status}`);
+        }
+      }
+      if (!isObject(node)) continue;
+      const response: Mutable<OperationResponse> = {
+        content: this.buildContent(node.content, `${location}.${status}.content`),
+      };
+      const description = asString(node.description);
+      if (description !== undefined) response.description = description;
+      out.set(status, response);
+    }
+    return out;
+  }
+
+  // ── Security requirement resolution ─────────────────────────────────
+
+  /**
+   * Resolve a `security` requirement list (array of requirement objects) to a
+   * deduped list of scheme names (OR-semantics). Every referenced name must be
+   * a declared scheme, else `unknown-security-requirement`.
+   */
+  resolveSecurity(raw: unknown, location: string): string[] {
+    if (!Array.isArray(raw)) return [];
+    const names: string[] = [];
+    const seen = new Set<string>();
+    for (const requirement of raw) {
+      if (!isObject(requirement)) continue;
+      for (const name of Object.keys(requirement)) {
+        if (!this.securityNames.has(name)) {
+          throw new OpenApiSpecError({
+            reason: "unknown-security-requirement",
+            location,
+            message: `Security requirement "${name}" at ${location} is not declared in components.securitySchemes.`,
+          });
+        }
+        if (!seen.has(name)) {
+          seen.add(name);
+          names.push(name);
+        }
+      }
+    }
+    return names;
+  }
+
+  // ── Operations ──────────────────────────────────────────────────────
+
+  buildOperations(
+    paths: JsonObject,
+    docSecurity: string[],
+    docHasSecurity: boolean,
+  ): Map<string, Operation> {
+    const out = new Map<string, Operation>();
+    for (const [pathKey, pathItemRaw] of Object.entries(paths)) {
+      if (pathKey.startsWith("x-")) continue; // vendor extension at paths level
+      if (!isObject(pathItemRaw)) continue;
+      const pathLevelParams = pathItemRaw.parameters;
+
+      for (const method of HTTP_METHODS) {
+        const opRaw = pathItemRaw[method];
+        if (opRaw === undefined) continue;
+        const opLocation = `paths.${pathKey}.${method}`;
+        if (!isObject(opRaw)) {
+          throw new OpenApiSpecError({
+            reason: "invalid-structure",
+            location: opLocation,
+            message: `Expected an operation object at ${opLocation}, got ${describe(opRaw)}.`,
+          });
+        }
+
+        const operationId = asString(opRaw.operationId);
+        if (operationId === undefined || operationId.length === 0) {
+          throw new OpenApiSpecError({
+            reason: "missing-operation-id",
+            location: opLocation,
+            message:
+              `Operation ${method.toUpperCase()} ${pathKey} is missing an "operationId". ` +
+              `Every operation must declare one so it can be addressed, validated, and described.`,
+          });
+        }
+        if (out.has(operationId)) {
+          throw new OpenApiSpecError({
+            reason: "duplicate-operation-id",
+            location: opLocation,
+            message: `Duplicate operationId "${operationId}" at ${opLocation}; operationIds must be unique across the document.`,
+          });
+        }
+
+        const opHasSecurity = "security" in opRaw;
+        const security = opHasSecurity
+          ? this.resolveSecurity(opRaw.security, `${opLocation}.security`)
+          : docHasSecurity
+            ? docSecurity
+            : [];
+
+        const operation: Mutable<Operation> = {
+          operationId,
+          method: method.toUpperCase() as HttpMethod,
+          path: pathKey,
+          tags: asStringArray(opRaw.tags) ?? [],
+          parameters: this.buildParameters(pathLevelParams, opRaw.parameters, opLocation),
+          security,
+          responses: this.buildResponses(opRaw.responses, `${opLocation}.responses`),
+        };
+        const summary = asString(opRaw.summary);
+        if (summary !== undefined) operation.summary = summary;
+        const description = asString(opRaw.description);
+        if (description !== undefined) operation.description = description;
+        const requestBody = this.buildRequestBody(opRaw.requestBody, `${opLocation}.requestBody`);
+        if (requestBody !== undefined) operation.requestBody = requestBody;
+
+        out.set(operationId, operation);
+      }
+    }
+    return out;
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────
+//  Security scheme normalization
+// ─────────────────────────────────────────────────────────────────────
+
+function buildSecuritySchemes(components: JsonObject): Map<string, SecurityScheme> {
+  const out = new Map<string, SecurityScheme>();
+  const raw = components.securitySchemes;
+  if (!isObject(raw)) return out;
+
+  for (const [name, value] of Object.entries(raw)) {
+    const location = `components.securitySchemes.${name}`;
+    if (!isObject(value)) {
+      throw new OpenApiSpecError({
+        reason: "invalid-security-scheme",
+        location,
+        message: `Security scheme "${name}" at ${location} is not an object.`,
+      });
+    }
+    out.set(name, normalizeSecurityScheme(name, value, location));
+  }
+  return out;
+}
+
+function normalizeSecurityScheme(
+  name: string,
+  raw: JsonObject,
+  location: string,
+): SecurityScheme {
+  const type = asString(raw.type);
+  const description = asString(raw.description);
+  const base = description !== undefined ? { name, description } : { name };
+
+  switch (type) {
+    case "http": {
+      const scheme = asString(raw.scheme)?.toLowerCase();
+      if (scheme === "bearer") {
+        const bearerFormat = asString(raw.bearerFormat);
+        return {
+          ...base,
+          kind: "bearer",
+          ...(bearerFormat !== undefined ? { bearerFormat } : {}),
+        };
+      }
+      if (scheme === "basic") {
+        return { ...base, kind: "basic" };
+      }
+      throw new OpenApiSpecError({
+        reason: "invalid-security-scheme",
+        location,
+        message: `HTTP security scheme "${name}" at ${location} uses unsupported scheme "${scheme ?? "(missing)"}" (expected "bearer" or "basic").`,
+      });
+    }
+    case "apiKey": {
+      const inLocation = asString(raw.in);
+      const parameterName = asString(raw.name);
+      if (parameterName === undefined) {
+        throw new OpenApiSpecError({
+          reason: "invalid-security-scheme",
+          location,
+          message: `apiKey security scheme "${name}" at ${location} is missing its "name".`,
+        });
+      }
+      if (inLocation === "header") {
+        return { ...base, kind: "apiKey-header", parameterName };
+      }
+      if (inLocation === "query") {
+        return { ...base, kind: "apiKey-query", parameterName };
+      }
+      throw new OpenApiSpecError({
+        reason: "invalid-security-scheme",
+        location,
+        message: `apiKey security scheme "${name}" at ${location} has unsupported "in: ${inLocation ?? "(missing)"}" (expected "header" or "query"; "cookie" is not supported).`,
+      });
+    }
+    case "oauth2":
+      return { ...base, kind: "oauth2" };
+    case "openIdConnect":
+      return { ...base, kind: "openIdConnect" };
+    default:
+      throw new OpenApiSpecError({
+        reason: "invalid-security-scheme",
+        location,
+        message: `Security scheme "${name}" at ${location} has unknown type "${type ?? "(missing)"}".`,
+      });
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────
+//  Public entry point
+// ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Normalize an OpenAPI 3.x JSON document into an {@link OperationGraph}.
+ *
+ * @param doc An already-parsed OpenAPI 3.x document (the result of
+ *   `JSON.parse`). This function performs no I/O and does not fetch `$ref`
+ *   targets across files.
+ * @throws {OpenApiSpecError} on any structural malformation — never returns a
+ *   partially-built graph.
+ */
+export function buildOperationGraph(doc: unknown): OperationGraph {
+  if (!isObject(doc)) {
+    throw new OpenApiSpecError({
+      reason: "not-an-object",
+      message: `OpenAPI document must be a JSON object, got ${describe(doc)}.`,
+    });
+  }
+
+  const version = asString(doc.openapi);
+  if (version === undefined || !version.startsWith("3.")) {
+    throw new OpenApiSpecError({
+      reason: "unsupported-version",
+      location: "openapi",
+      message:
+        `Unsupported OpenAPI version "${version ?? "(missing)"}". This primitive supports OpenAPI 3.x only ` +
+        `(2.0 / Swagger documents must be converted at install time).`,
+    });
+  }
+
+  if (!isObject(doc.paths)) {
+    throw new OpenApiSpecError({
+      reason: "missing-paths",
+      location: "paths",
+      message: `OpenAPI document is missing a "paths" object.`,
+    });
+  }
+
+  const components = isObject(doc.components) ? doc.components : {};
+  const security = buildSecuritySchemes(components);
+  const builder = new GraphBuilder(components, security);
+
+  const schemas = builder.buildSchemas();
+  const docHasSecurity = "security" in doc;
+  const docSecurity = docHasSecurity
+    ? builder.resolveSecurity(doc.security, "security")
+    : [];
+  const operations = builder.buildOperations(doc.paths, docSecurity, docHasSecurity);
+
+  return {
+    operations,
+    schemas,
+    security,
+    servers: buildServers(doc.servers),
+    info: buildInfo(doc.info, version),
+  };
+}
+
+function buildServers(raw: unknown): ServerInfo[] {
+  if (!Array.isArray(raw)) return [];
+  const out: ServerInfo[] = [];
+  for (const entry of raw) {
+    if (!isObject(entry)) continue;
+    const url = asString(entry.url);
+    if (url === undefined) continue;
+    const description = asString(entry.description);
+    out.push(description !== undefined ? { url, description } : { url });
+  }
+  return out;
+}
+
+function buildInfo(raw: unknown, openapiVersion: string): SpecInfo {
+  const obj = isObject(raw) ? raw : {};
+  return {
+    title: asString(obj.title) ?? "(untitled)",
+    version: asString(obj.version) ?? "",
+    openapiVersion,
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────
+//  Local utilities
+// ─────────────────────────────────────────────────────────────────────
+
+type Mutable<T> = { -readonly [K in keyof T]: T[K] };
+
+function isParameterLocation(v: string): v is ParameterLocation {
+  return v === "query" || v === "header" || v === "path" || v === "cookie";
+}
+
+/** Human-readable type tag for error messages, never the value itself. */
+function describe(v: unknown): string {
+  if (v === null) return "null";
+  if (Array.isArray(v)) return "array";
+  return typeof v;
+}

--- a/packages/api/src/lib/openapi/spec.ts
+++ b/packages/api/src/lib/openapi/spec.ts
@@ -11,9 +11,11 @@
  * {@link OpenApiSpecError} — the function never returns a half-built graph.
  *
  * Deliberately NOT fail-loud on:
- *  - Vendor extensions (`x-*` keys). OpenAPI explicitly permits them anywhere;
- *    real specs (Stripe, Twenty) are full of them. We ignore them. Rejecting
- *    every `x-` key would make "normalize Stripe's spec" impossible.
+ *  - Vendor extensions (`x-*` keys). Object-internal `x-*` keys are ignored
+ *    because every walker reads only a known set of keys; the one place an
+ *    `x-*` *sibling entry* legally appears (the `paths` object) is explicitly
+ *    skipped. Real specs (Stripe, Twenty) are full of extensions — rejecting
+ *    them would make "normalize Stripe's spec" impossible.
  *  - Circular `$ref`s through named components (Twenty's Person ↔ NoteTarget).
  *    These are REQUIRED to resolve (acceptance criterion). We resolve a named
  *    `$ref` to a pointer node (`{ ref: "Name" }`) rather than inlining, so the
@@ -34,6 +36,7 @@ import {
   type OperationRequestBody,
   type OperationResponse,
   type OpenApiSchema,
+  type OpenApiSchemaInline,
   type ParameterLocation,
   type SecurityScheme,
   type ServerInfo,
@@ -170,14 +173,26 @@ class GraphBuilder {
       return { ref: name };
     }
 
-    const node: Mutable<OpenApiSchema> = {};
-    const type = asString(raw.type);
-    if (type !== undefined) node.type = type;
+    const node: Mutable<OpenApiSchemaInline> = {};
+    // `type` is a string in 3.0; in 3.1 it may be an array (e.g.
+    // ["string", "null"]). Normalize the array form: strip the "null" member
+    // into `nullable` and keep the single remaining type. A multi-type union
+    // (rare) leaves `type` absent rather than guessing.
+    const rawType = raw.type;
+    if (typeof rawType === "string") {
+      node.type = rawType;
+    } else if (Array.isArray(rawType)) {
+      const members = rawType.filter((t): t is string => typeof t === "string");
+      if (members.includes("null")) node.nullable = true;
+      const nonNull = members.filter((t) => t !== "null");
+      if (nonNull.length === 1) node.type = nonNull[0];
+    }
     const format = asString(raw.format);
     if (format !== undefined) node.format = format;
     const description = asString(raw.description);
     if (description !== undefined) node.description = description;
     if (Array.isArray(raw.enum)) node.enum = raw.enum as ReadonlyArray<unknown>;
+    // Explicit 3.0 `nullable` wins over the 3.1 array-derived value if both appear.
     const nullable = asBoolean(raw.nullable);
     if (nullable !== undefined) node.nullable = nullable;
     const required = asStringArray(raw.required);
@@ -301,7 +316,17 @@ class GraphBuilder {
     const out = new Map<string, OpenApiSchema>();
     if (!isObject(raw)) return out;
     for (const [mediaType, value] of Object.entries(raw)) {
-      if (!isObject(value)) continue;
+      if (!isObject(value)) {
+        // A present-but-malformed media-type entry must fail loud rather than
+        // silently vanish from `content` (R1) — every sibling builder throws.
+        throw new OpenApiSpecError({
+          reason: "invalid-structure",
+          location: `${location}.${mediaType}`,
+          message: `Expected a media-type object at ${location}.${mediaType}, got ${describe(value)}.`,
+        });
+      }
+      // A media type with no `schema` is legitimate ("schema not declared") —
+      // record nothing rather than failing.
       if (value.schema !== undefined) {
         out.set(mediaType, this.walkSchema(value.schema, `${location}.${mediaType}.schema`));
       }
@@ -361,7 +386,16 @@ class GraphBuilder {
           node = this.rawComponent("responses", name, `${location}.${status}`);
         }
       }
-      if (!isObject(node)) continue;
+      if (!isObject(node)) {
+        // Present-but-malformed response → fail loud. A silent skip would tell a
+        // downstream consumer "this operation has no <status> response" when the
+        // author actually wrote a broken one (R1).
+        throw new OpenApiSpecError({
+          reason: "invalid-structure",
+          location: `${location}.${status}`,
+          message: `Expected a response object at ${location}.${status}, got ${describe(node)}.`,
+        });
+      }
       const response: Mutable<OperationResponse> = {
         content: this.buildContent(node.content, `${location}.${status}.content`),
       };
@@ -378,13 +412,24 @@ class GraphBuilder {
    * Resolve a `security` requirement list (array of requirement objects) to a
    * deduped list of scheme names (OR-semantics). Every referenced name must be
    * a declared scheme, else `unknown-security-requirement`.
+   *
+   * A non-object requirement entry (e.g. the common `security: ["bearerAuth"]`
+   * string-instead-of-object mistake) fails loud rather than being skipped:
+   * silently dropping it could collapse the requirement set to `[]`, which the
+   * `Operation.security` contract reads as "no auth" — a security false-negative.
    */
   resolveSecurity(raw: unknown, location: string): string[] {
     if (!Array.isArray(raw)) return [];
     const names: string[] = [];
     const seen = new Set<string>();
     for (const requirement of raw) {
-      if (!isObject(requirement)) continue;
+      if (!isObject(requirement)) {
+        throw new OpenApiSpecError({
+          reason: "invalid-structure",
+          location,
+          message: `Security requirement at ${location} must be an object mapping scheme names to scopes, got ${describe(requirement)}.`,
+        });
+      }
       for (const name of Object.keys(requirement)) {
         if (!this.securityNames.has(name)) {
           throw new OpenApiSpecError({
@@ -411,8 +456,23 @@ class GraphBuilder {
   ): Map<string, Operation> {
     const out = new Map<string, Operation>();
     for (const [pathKey, pathItemRaw] of Object.entries(paths)) {
-      if (pathKey.startsWith("x-")) continue; // vendor extension at paths level
-      if (!isObject(pathItemRaw)) continue;
+      if (pathKey.startsWith("x-")) continue; // vendor extension sibling at paths level
+      if (!isObject(pathItemRaw)) {
+        throw new OpenApiSpecError({
+          reason: "invalid-structure",
+          location: `paths.${pathKey}`,
+          message: `Path item at paths.${pathKey} must be an object, got ${describe(pathItemRaw)}.`,
+        });
+      }
+      // A path-item-level `$ref` (legal OpenAPI) is not supported in this slice —
+      // fail loud rather than silently drop every operation under the path.
+      if (asString(pathItemRaw.$ref) !== undefined) {
+        throw new OpenApiSpecError({
+          reason: "unsupported-ref",
+          location: `paths.${pathKey}`,
+          message: `Path item at paths.${pathKey} uses a $ref; path-item references are not resolved in this slice.`,
+        });
+      }
       const pathLevelParams = pathItemRaw.parameters;
 
       for (const method of HTTP_METHODS) {

--- a/packages/api/src/lib/openapi/types.ts
+++ b/packages/api/src/lib/openapi/types.ts
@@ -71,23 +71,37 @@ export type SecuritySchemeKind =
 
 /**
  * A normalized JSON-Schema node. We model only the fields downstream consumers
- * read; we deliberately do NOT mirror all of JSON Schema. Every `$ref` to a
- * named component is collapsed to {@link OpenApiSchema.ref}; a node therefore
- * never carries a raw `$ref` string.
+ * read; we deliberately do NOT mirror all of JSON Schema.
+ *
+ * It is a discriminated union on the presence of `ref`: a node is EITHER a
+ * pointer to a named component ({@link OpenApiSchemaRef}) OR an inline schema
+ * ({@link OpenApiSchemaInline}) — never both. Consumers narrow with
+ * `if (node.ref !== undefined)`; the inline arm then exposes `type`,
+ * `properties`, `items`, etc. with no need to re-check that `ref` is absent.
  */
-export interface OpenApiSchema {
+export type OpenApiSchema = OpenApiSchemaRef | OpenApiSchemaInline;
+
+/**
+ * A reference to the named component schema `graph.schemas.get(ref)`. The
+ * target is guaranteed to exist (parse fails loud otherwise). This is how
+ * Person → NoteTarget joins are traversed without re-walking `$ref` strings,
+ * and how cycles stay finite — a ref node carries no inline fields.
+ */
+export interface OpenApiSchemaRef {
+  readonly ref: string;
+  /** Set only when a top-level `components.schemas.*` entry IS itself a bare `$ref`. */
+  readonly name?: string;
+}
+
+/** An inline (anonymous or named-but-non-`$ref`) schema, walked in full. */
+export interface OpenApiSchemaInline {
+  /** Discriminant: an inline node never carries a `ref`. */
+  readonly ref?: undefined;
   /**
    * The component name when this node IS a `components.schemas.*` entry
    * (top-level registration). `undefined` for inline / anonymous schemas.
    */
   readonly name?: string;
-  /**
-   * When set, this node is a *reference* to the named component schema
-   * `graph.schemas.get(ref)`. The target is guaranteed to exist (parse fails
-   * loud otherwise). This is how Person → NoteTarget joins are traversed
-   * without re-walking `$ref` strings, and how cycles stay finite.
-   */
-  readonly ref?: string;
   /** JSON Schema `type` (e.g. "object", "array", "string"). May be absent. */
   readonly type?: string;
   /** JSON Schema `format` hint (e.g. "uuid", "date-time", "int64"). */
@@ -95,7 +109,11 @@ export interface OpenApiSchema {
   readonly description?: string;
   /** Allowed enumerated values, when the schema is an enum. */
   readonly enum?: ReadonlyArray<unknown>;
-  /** OpenAPI 3.0 `nullable` flag (3.1 uses `type: [..., "null"]` — see notes). */
+  /**
+   * Nullability. Set from OpenAPI 3.0's `nullable: true`, or normalized from
+   * OpenAPI 3.1's `type: [..., "null"]` array form (the "null" member is
+   * stripped from `type` and surfaced here).
+   */
   readonly nullable?: boolean;
   /** Required property names, for object schemas. */
   readonly required?: ReadonlyArray<string>;
@@ -103,7 +121,11 @@ export interface OpenApiSchema {
   readonly properties?: ReadonlyMap<string, OpenApiSchema>;
   /** Element schema, for array schemas. */
   readonly items?: OpenApiSchema;
-  /** Composition keywords, walked shallowly (not merged). */
+  /**
+   * Composition keywords. Each branch is normalized recursively (resolved
+   * `$ref`s become pointers), but the composition is NOT flattened/merged into
+   * a single effective schema — consumers see the branches as authored.
+   */
   readonly allOf?: ReadonlyArray<OpenApiSchema>;
   readonly oneOf?: ReadonlyArray<OpenApiSchema>;
   readonly anyOf?: ReadonlyArray<OpenApiSchema>;
@@ -113,20 +135,24 @@ export interface OpenApiSchema {
 //  Security
 // ─────────────────────────────────────────────────────────────────────
 
-/** A normalized `components.securitySchemes.*` entry. */
-export interface SecurityScheme {
-  /** The component key, e.g. "bearerAuth", that operations reference. */
-  readonly name: string;
-  readonly kind: SecuritySchemeKind;
-  /**
-   * The header or query-parameter name carrying the key, for `apiKey-header` /
-   * `apiKey-query` schemes (e.g. "X-API-Key", "api_key"). Undefined otherwise.
-   */
-  readonly parameterName?: string;
-  /** Bearer format hint for `bearer` schemes (e.g. "JWT"). */
-  readonly bearerFormat?: string;
-  readonly description?: string;
-}
+/**
+ * A normalized `components.securitySchemes.*` entry. Discriminated on `kind`
+ * so each scheme carries exactly the fields it needs — an `apiKey-*` scheme
+ * always has a `parameterName` (the parse boundary guarantees it), and a
+ * `bearer`/`basic` scheme never does. Consumers narrow on `kind` and access
+ * `parameterName` without a runtime presence check.
+ */
+export type SecurityScheme =
+  | { readonly kind: "bearer"; readonly name: string; readonly bearerFormat?: string; readonly description?: string }
+  | { readonly kind: "basic"; readonly name: string; readonly description?: string }
+  | {
+      readonly kind: "apiKey-header" | "apiKey-query";
+      readonly name: string;
+      /** The header or query-parameter name carrying the key (e.g. "X-API-Key", "api_key"). */
+      readonly parameterName: string;
+      readonly description?: string;
+    }
+  | { readonly kind: "oauth2" | "openIdConnect"; readonly name: string; readonly description?: string };
 
 // ─────────────────────────────────────────────────────────────────────
 //  Operations
@@ -223,9 +249,10 @@ export interface OperationGraph {
  * install layer reading encrypted config) resolves this; the client applies it.
  *
  * For `apiKey`, placement (header vs query, and the parameter name) is read from
- * the operation's apiKey security scheme by default. `in` / `name` are optional
- * overrides for callers that store placement in config (slice 2's form fields)
- * rather than relying on the spec.
+ * the operation's apiKey security scheme by default. `placement` is an
+ * all-or-nothing override for callers that store placement in config (slice 2's
+ * form fields) rather than relying on the spec — supplying it as a single unit
+ * makes a half-specified override (an `in` without a `name`) unrepresentable.
  */
 export type ResolvedAuth =
   | { readonly kind: "none" }
@@ -234,8 +261,7 @@ export type ResolvedAuth =
   | {
       readonly kind: "apiKey";
       readonly value: string;
-      readonly in?: "header" | "query";
-      readonly name?: string;
+      readonly placement?: { readonly in: "header" | "query"; readonly name: string };
     };
 
 /**

--- a/packages/api/src/lib/openapi/types.ts
+++ b/packages/api/src/lib/openapi/types.ts
@@ -1,0 +1,357 @@
+/**
+ * Shared contract for the OpenAPI Datasource primitive (v0.2.0 milestone spine).
+ *
+ * This file defines the *one normalized shape* every downstream consumer of an
+ * OpenAPI 3.x document reads — the semantic-YAML generator (slice 1b), the REST
+ * validator (slice 5), the prompt-context builder, and the executing client
+ * (`client.ts`) all consume {@link OperationGraph} rather than re-walking the
+ * raw spec. There is exactly one parse boundary (`buildOperationGraph` in
+ * `spec.ts`); past it, nobody touches a `$ref` string or a raw `paths.*` object.
+ *
+ * Design notes on the `$ref` model (load-bearing — see {@link OpenApiSchema.ref}):
+ * named-component `$ref`s are resolved to a *pointer* (`{ ref: "Name" }`) rather
+ * than inlined. This keeps the graph finite under circular relationships (e.g.
+ * Twenty's Person ↔ NoteTarget cycle) while letting a consumer follow the join
+ * with a single `graph.schemas.get(node.ref)` lookup. Inline (anonymous) schemas
+ * are walked in full — they cannot be circular without a named `$ref`, so the
+ * recursion always terminates.
+ *
+ * Sibling to the SQL Datasource layer (`lib/db/connection.ts`), never folded
+ * into it — per PRD #2868 "Option B: parallel adapter, not subordinate".
+ */
+import { Data } from "effect";
+
+// ─────────────────────────────────────────────────────────────────────
+//  Primitive enums
+// ─────────────────────────────────────────────────────────────────────
+
+/** HTTP methods OpenAPI 3.x permits on a Path Item, normalized to uppercase. */
+export type HttpMethod =
+  | "GET"
+  | "PUT"
+  | "POST"
+  | "DELETE"
+  | "PATCH"
+  | "HEAD"
+  | "OPTIONS"
+  | "TRACE";
+
+/** The eight Path Item method keys we walk, lowercase as they appear in the doc. */
+export const HTTP_METHODS = [
+  "get",
+  "put",
+  "post",
+  "delete",
+  "patch",
+  "head",
+  "options",
+  "trace",
+] as const;
+
+/** Where a parameter is carried in the request. */
+export type ParameterLocation = "query" | "header" | "path" | "cookie";
+
+/**
+ * The kinds of security scheme this primitive understands. `oauth2` and
+ * `openIdConnect` are *normalized* (so the graph is complete and the install
+ * surface can display them) but their credential flows are deferred to slice 6;
+ * the client (`client.ts`) only *applies* `bearer` / `basic` / `apiKey-*`.
+ */
+export type SecuritySchemeKind =
+  | "bearer"
+  | "basic"
+  | "apiKey-header"
+  | "apiKey-query"
+  | "oauth2"
+  | "openIdConnect";
+
+// ─────────────────────────────────────────────────────────────────────
+//  Normalized schema node
+// ─────────────────────────────────────────────────────────────────────
+
+/**
+ * A normalized JSON-Schema node. We model only the fields downstream consumers
+ * read; we deliberately do NOT mirror all of JSON Schema. Every `$ref` to a
+ * named component is collapsed to {@link OpenApiSchema.ref}; a node therefore
+ * never carries a raw `$ref` string.
+ */
+export interface OpenApiSchema {
+  /**
+   * The component name when this node IS a `components.schemas.*` entry
+   * (top-level registration). `undefined` for inline / anonymous schemas.
+   */
+  readonly name?: string;
+  /**
+   * When set, this node is a *reference* to the named component schema
+   * `graph.schemas.get(ref)`. The target is guaranteed to exist (parse fails
+   * loud otherwise). This is how Person → NoteTarget joins are traversed
+   * without re-walking `$ref` strings, and how cycles stay finite.
+   */
+  readonly ref?: string;
+  /** JSON Schema `type` (e.g. "object", "array", "string"). May be absent. */
+  readonly type?: string;
+  /** JSON Schema `format` hint (e.g. "uuid", "date-time", "int64"). */
+  readonly format?: string;
+  readonly description?: string;
+  /** Allowed enumerated values, when the schema is an enum. */
+  readonly enum?: ReadonlyArray<unknown>;
+  /** OpenAPI 3.0 `nullable` flag (3.1 uses `type: [..., "null"]` — see notes). */
+  readonly nullable?: boolean;
+  /** Required property names, for object schemas. */
+  readonly required?: ReadonlyArray<string>;
+  /** Object property name → normalized schema. */
+  readonly properties?: ReadonlyMap<string, OpenApiSchema>;
+  /** Element schema, for array schemas. */
+  readonly items?: OpenApiSchema;
+  /** Composition keywords, walked shallowly (not merged). */
+  readonly allOf?: ReadonlyArray<OpenApiSchema>;
+  readonly oneOf?: ReadonlyArray<OpenApiSchema>;
+  readonly anyOf?: ReadonlyArray<OpenApiSchema>;
+}
+
+// ─────────────────────────────────────────────────────────────────────
+//  Security
+// ─────────────────────────────────────────────────────────────────────
+
+/** A normalized `components.securitySchemes.*` entry. */
+export interface SecurityScheme {
+  /** The component key, e.g. "bearerAuth", that operations reference. */
+  readonly name: string;
+  readonly kind: SecuritySchemeKind;
+  /**
+   * The header or query-parameter name carrying the key, for `apiKey-header` /
+   * `apiKey-query` schemes (e.g. "X-API-Key", "api_key"). Undefined otherwise.
+   */
+  readonly parameterName?: string;
+  /** Bearer format hint for `bearer` schemes (e.g. "JWT"). */
+  readonly bearerFormat?: string;
+  readonly description?: string;
+}
+
+// ─────────────────────────────────────────────────────────────────────
+//  Operations
+// ─────────────────────────────────────────────────────────────────────
+
+/** A normalized operation parameter (`in: query | header | path | cookie`). */
+export interface OperationParameter {
+  readonly name: string;
+  readonly in: ParameterLocation;
+  /** Always `true` for `in: path` per the OpenAPI spec. */
+  readonly required: boolean;
+  readonly description?: string;
+  readonly schema?: OpenApiSchema;
+}
+
+/** A normalized request body. `content` is keyed by media type. */
+export interface OperationRequestBody {
+  readonly required: boolean;
+  readonly description?: string;
+  readonly content: ReadonlyMap<string, OpenApiSchema>;
+}
+
+/** A normalized response. `content` is keyed by media type. */
+export interface OperationResponse {
+  readonly description?: string;
+  readonly content: ReadonlyMap<string, OpenApiSchema>;
+}
+
+/**
+ * A single executable operation, keyed in the graph by `operationId`. This is
+ * the unit the validator authorizes, the prompt-context builder describes, and
+ * the client executes.
+ */
+export interface Operation {
+  readonly operationId: string;
+  readonly method: HttpMethod;
+  /** The templated path, e.g. "/people/{id}". */
+  readonly path: string;
+  readonly summary?: string;
+  readonly description?: string;
+  readonly tags: ReadonlyArray<string>;
+  /** Path-level and operation-level parameters, merged and `$ref`-resolved. */
+  readonly parameters: ReadonlyArray<OperationParameter>;
+  readonly requestBody?: OperationRequestBody;
+  /**
+   * Security scheme names that satisfy this operation, OR-semantics (any one
+   * suffices). Resolved from operation-level `security`, falling back to the
+   * document-level default. An empty array means no auth is required (including
+   * an explicit operation-level `security: []` override). Every name is
+   * guaranteed present in `graph.security`.
+   */
+  readonly security: ReadonlyArray<string>;
+  /** Responses keyed by status string ("200", "404", "default"). */
+  readonly responses: ReadonlyMap<string, OperationResponse>;
+}
+
+// ─────────────────────────────────────────────────────────────────────
+//  The graph (the spine)
+// ─────────────────────────────────────────────────────────────────────
+
+/** A server base URL from the document's `servers` array. */
+export interface ServerInfo {
+  readonly url: string;
+  readonly description?: string;
+}
+
+/** Document identity, for diagnostics and the install surface. */
+export interface SpecInfo {
+  readonly title: string;
+  readonly version: string;
+  /** The raw `openapi` version string, e.g. "3.1.0". */
+  readonly openapiVersion: string;
+}
+
+/**
+ * The normalized operation graph — the single shape every downstream consumer
+ * reads. Produced once by `buildOperationGraph`; never half-built (a parse
+ * failure throws {@link OpenApiSpecError} rather than returning a partial graph).
+ */
+export interface OperationGraph {
+  readonly operations: ReadonlyMap<string, Operation>;
+  readonly schemas: ReadonlyMap<string, OpenApiSchema>;
+  readonly security: ReadonlyMap<string, SecurityScheme>;
+  readonly servers: ReadonlyArray<ServerInfo>;
+  readonly info: SpecInfo;
+}
+
+// ─────────────────────────────────────────────────────────────────────
+//  Execution contract (client.ts)
+// ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Resolved credential material for a single execution. The caller (later: the
+ * install layer reading encrypted config) resolves this; the client applies it.
+ *
+ * For `apiKey`, placement (header vs query, and the parameter name) is read from
+ * the operation's apiKey security scheme by default. `in` / `name` are optional
+ * overrides for callers that store placement in config (slice 2's form fields)
+ * rather than relying on the spec.
+ */
+export type ResolvedAuth =
+  | { readonly kind: "none" }
+  | { readonly kind: "bearer"; readonly token: string }
+  | { readonly kind: "basic"; readonly username: string; readonly password: string }
+  | {
+      readonly kind: "apiKey";
+      readonly value: string;
+      readonly in?: "header" | "query";
+      readonly name?: string;
+    };
+
+/**
+ * Request inputs, bucketed by location so the client never has to guess where a
+ * value belongs (directly satisfies "encode params per `in: query|header|path`").
+ * `undefined` query values are dropped; array query values explode (repeat key).
+ */
+export interface OperationParams {
+  readonly path?: Readonly<Record<string, string | number | boolean>>;
+  readonly query?: Readonly<
+    Record<string, string | number | boolean | ReadonlyArray<string | number | boolean> | undefined>
+  >;
+  readonly header?: Readonly<Record<string, string | number | boolean>>;
+  /** JSON request body. Serialized with `JSON.stringify`; sets Content-Type. */
+  readonly body?: unknown;
+}
+
+/** Per-execution options. */
+export interface ExecuteOptions {
+  /**
+   * Base URL override. When omitted, the client uses `graph.servers[0].url`.
+   * (Slice 2 threads `base_url_override` here.)
+   */
+  readonly baseUrl?: string;
+  /** Per-request timeout in ms. Defaults to {@link DEFAULT_REQUEST_TIMEOUT_MS}. */
+  readonly timeoutMs?: number;
+  /** `fetch` implementation override, for integration tests. */
+  readonly fetchImpl?: typeof globalThis.fetch;
+}
+
+/**
+ * The result of a single execution. Returned for ANY HTTP response, including
+ * 4xx/5xx — interpreting status is the caller's job (the validator / agent
+ * decide what a 404 means), keeping this a transport primitive. Throws only for
+ * client-side faults (unknown operation, missing path param, missing auth
+ * placement) and transport faults (timeout, network). See {@link OpenApiClientError}.
+ */
+export interface OperationResult {
+  readonly status: number;
+  /** Response headers, lowercased keys. */
+  readonly headers: Readonly<Record<string, string>>;
+  /** Parsed JSON when the response is JSON; raw string otherwise; null if empty. */
+  readonly body: unknown;
+  /** True when `body` is a raw string because the response was not JSON. */
+  readonly bodyIsRaw: boolean;
+  /**
+   * `Retry-After` parsed to milliseconds per RFC 9110, when the response
+   * carried a parseable value (typically on 429 / 503). The client surfaces it;
+   * it does NOT auto-retry (no agent logic in this layer).
+   */
+  readonly retryAfterMs?: number;
+}
+
+// ─────────────────────────────────────────────────────────────────────
+//  Errors
+// ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Why a spec failed to parse. Machine-readable so consumers branch on it rather
+ * than the message string. The graph is NEVER half-built — any of these throws.
+ */
+export type OpenApiSpecErrorReason =
+  | "not-an-object"
+  | "unsupported-version"
+  | "missing-paths"
+  | "missing-operation-id"
+  | "duplicate-operation-id"
+  | "unresolved-ref"
+  | "unsupported-ref"
+  | "invalid-security-scheme"
+  | "unknown-security-requirement"
+  | "invalid-parameter"
+  | "invalid-structure";
+
+/**
+ * Thrown by `buildOperationGraph` at parse time. Fail-loud is the contract
+ * (PRD risk R1): an unparseable spec must never half-build a graph that
+ * surprises a later consumer. Carries what was wrong (`reason`, `message`) and
+ * where (`location`, a JSON-pointer-ish path into the source document).
+ */
+export class OpenApiSpecError extends Data.TaggedError("OpenApiSpecError")<{
+  readonly message: string;
+  readonly reason: OpenApiSpecErrorReason;
+  /** Source location, e.g. `paths./people.get` or `components.schemas.Person`. */
+  readonly location?: string;
+}> {}
+
+/** Why an execution failed before or instead of producing an HTTP response. */
+export type OpenApiClientErrorReason =
+  | "unknown-operation"
+  | "missing-base-url"
+  | "missing-path-param"
+  | "missing-auth-placement"
+  | "timeout"
+  | "network"
+  | "unparseable-response";
+
+/**
+ * Thrown by `executeOperation` for client-side and transport faults. A non-2xx
+ * HTTP response is NOT an error here — it comes back as an {@link OperationResult}.
+ */
+export class OpenApiClientError extends Data.TaggedError("OpenApiClientError")<{
+  readonly message: string;
+  readonly reason: OpenApiClientErrorReason;
+  readonly operationId: string;
+  /** HTTP status; 0 for transport-level faults (timeout, network, abort). */
+  readonly status: number;
+  readonly retryAfterMs?: number;
+}> {}
+
+// ─────────────────────────────────────────────────────────────────────
+//  Defaults
+// ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Default per-request timeout (30s), matching the SQL Datasource statement
+ * timeout default. Slice 2+ makes this configurable via `ATLAS_OPENAPI_TIMEOUT`.
+ */
+export const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;


### PR DESCRIPTION
## Summary

v0.2.0 **slice 0** (#2923, parent PRD #2868) — the two foundational deep modules the entire REST Datasources milestone chains off. Both live under a **new `packages/api/src/lib/openapi/`**, sibling to the SQL Datasource layer (`lib/db/connection.ts`), **never folded into `DBConnection` or `validateSQL`** (PRD "Option B — parallel adapter, not subordinate").

- **`openapi-spec` (`spec.ts`)** — `buildOperationGraph(doc)`, a **pure** function (no I/O, no mocks) from an OpenAPI 3.x JSON document to the normalized `OperationGraph` `{ operations, schemas, security, servers, info }`. This is the single parse boundary; past it, no consumer touches a `$ref` string or a raw `paths.*` object.
- **`openapi-client` (`client.ts`)** — `executeOperation(graph, operationId, params, resolvedAuth, opts)`, a transport primitive (no agent logic, no caching) that builds the request, applies auth per `securityScheme`, fires one `fetch`, and returns `{ status, headers, body }`.

> **Reviewers: please scrutinize the types in `types.ts`.** `Operation` / `OpenApiSchema` / `SecurityScheme` / `OperationGraph` are the **milestone's shared contract** — slices 1, 1b, 2, 3, 4, 5 all read this exact shape rather than re-parsing the spec. Getting it right here is load-bearing for everything downstream.

## Key design decisions

- **`$ref` → finite pointer, not inline.** A named-component `$ref` resolves to `{ ref: "Name" }` (target guaranteed present in `graph.schemas`). This keeps the graph **finite** under circular relationships (Twenty's Person → noteTargets[] → NoteTarget → person → Person) while leaving the join **traversable** via one `graph.schemas.get(node.ref)`. Inline schemas are walked in full (they can't be circular without a named `$ref`, so recursion terminates).
- **Fail-loud at the boundary (PRD risk R1).** Missing/duplicate `operationId`, broken/unsupported `$ref`, malformed structure, bad security scheme → throws a tagged `OpenApiSpecError` with a machine-readable `reason` + a JSON-pointer-ish `location`. **Never a half-built graph.**
- **Vendor `x-*` extensions are ignored, circular named `$ref`s resolve.** These are the two cases an over-broad "fail on anything unusual" reading would get wrong: rejecting `x-*` would make Stripe/Twenty unparseable, and the AC explicitly requires the circular Person↔NoteTarget relationship to resolve.
- **Non-2xx is returned, not thrown.** Interpreting status (what a 404 means) is the caller's job — keeps the client a transport primitive. `Retry-After` is parsed (RFC 9110) and surfaced; the client honors it by reporting it (retry scheduling belongs to a later layer). Mirrors `plugins/twenty/src/client.ts` (PR #2865) for the error-envelope + retry-after prior art.
- **Auth placement** for `apiKey` is read from the operation's security scheme by default, with optional `{ in, name }` overrides for slice 2's config-driven form fields. `oauth2`/`openIdConnect` are normalized but their flows are deferred to slice 6.

## Acceptance criteria (#2923)

- [x] `openapi-spec` normalizes Twenty's `/rest/open-api/core` and lists every `Person` operation; Person↔NoteTarget `$ref` relationships resolve (incl. the `targetPersonId` join column, not `personId`)
- [x] `openapi-spec` unit-tested against **three corpora** (hand-crafted minimal, trimmed Twenty, trimmed Stripe) asserting the normalized graph shape — no I/O, no mocks (fixtures committed)
- [x] Malformed specs (missing `operationId`, broken `$ref`, …) throw at parse time with an actionable error, not a partial graph (11 fail-loud cases, each pinning a `reason`)
- [x] `openapi-client` executes a single parameterized GET against a local Node HTTP server, applying auth per `securityScheme` + encoding params per `in: query | header | path`
- [x] `openapi-client` parses `Retry-After` and enforces a per-request timeout (integration tests against the local server)
- [x] Both modules live under `lib/openapi/`, not folded into `DBConnection` or the SQL validator

## Testing

`/tdd` loop, vertical slices. **46 tests, 123 assertions.**
- `spec.test.ts` — pure unit tests across all three corpora + fail-loud resilience.
- `client.test.ts` — integration tests against a real local `http` server (auth-per-scheme incl. override, path/query/header encoding + array-explode, JSON body, Retry-After, per-request timeout, non-JSON/empty/bad-JSON bodies, unknown-operation / missing-path-param / missing-auth-placement faults).

A throwaway env-driven demo harness (`packages/api/scripts/openapi-harness.ts`) prints the operation list and runs one execute call — **demo vehicle, not shipped surface.**

## CI

Local `/ci` — lint, type, full `bun run test`, syncpack, all drift/discipline checks — **all pass.** No `mock.module()` used (pure tests + real HTTP server). No docs impact this slice (no install UX yet — docs land in slice 2).

This is an `architecture` deep-module slice; the win is recorded as #72 in `.claude/research/architecture-wins.md` (the normalized-graph-as-shared-shape: one parse boundary, every consumer reads one type).

## Deferred (clean extension points left, do not build here)

semantic-YAML generation (1b) · pagination (4 — single-call only here) · `validateRestOperation` (5) · `networkPolicy` threading (3) · catalog/install surface (2) · oauth2 credential flow (6)

Closes #2923.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/2935"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782595775&installation_id=135337507&pr_number=2935&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F2935&signature=42b4262f7563c834ec8f0c2770385dd42d0a7a4db0a6e2d6a168d2203cf00a75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->