### PR TITLE
feat(api): env-profile module — migrate per-env runtime defaults off Railway env vars

### DIFF
--- a/packages/api/src/lib/__tests__/env-profile.test.ts
+++ b/packages/api/src/lib/__tests__/env-profile.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from "bun:test";
+import {
+  resolveDeployEnv,
+  getEnvProfile,
+  resolveRequireEmailVerification,
+  resolveOnboardingEmailsEnabled,
+} from "@atlas/api/lib/env-profile";
+
+describe("resolveDeployEnv", () => {
+  it("defaults to production when ATLAS_DEPLOY_ENV is unset (preserves existing behavior)", () => {
+    expect(resolveDeployEnv({})).toBe("production");
+  });
+
+  it("returns explicit production", () => {
+    expect(resolveDeployEnv({ ATLAS_DEPLOY_ENV: "production" })).toBe("production");
+  });
+
+  it("returns staging", () => {
+    expect(resolveDeployEnv({ ATLAS_DEPLOY_ENV: "staging" })).toBe("staging");
+  });
+
+  it("returns development", () => {
+    expect(resolveDeployEnv({ ATLAS_DEPLOY_ENV: "development" })).toBe("development");
+  });
+
+  it("is case-insensitive (STAGING/Production/etc.)", () => {
+    expect(resolveDeployEnv({ ATLAS_DEPLOY_ENV: "STAGING" })).toBe("staging");
+    expect(resolveDeployEnv({ ATLAS_DEPLOY_ENV: "Production" })).toBe("production");
+  });
+
+  it("trims whitespace", () => {
+    expect(resolveDeployEnv({ ATLAS_DEPLOY_ENV: "  staging  " })).toBe("staging");
+  });
+
+  it("falls back to production for unknown values (no hard-fail on typos)", () => {
+    expect(resolveDeployEnv({ ATLAS_DEPLOY_ENV: "qa" })).toBe("production");
+    expect(resolveDeployEnv({ ATLAS_DEPLOY_ENV: "prod" })).toBe("production");
+    expect(resolveDeployEnv({ ATLAS_DEPLOY_ENV: "" })).toBe("production");
+  });
+});
+
+describe("getEnvProfile", () => {
+  it("production profile: verification on, onboarding emails on", () => {
+    const p = getEnvProfile({ ATLAS_DEPLOY_ENV: "production" });
+    expect(p.requireEmailVerification).toBe(true);
+    expect(p.onboardingEmailsEnabled).toBe(true);
+  });
+
+  it("staging profile: verification off, onboarding off", () => {
+    const p = getEnvProfile({ ATLAS_DEPLOY_ENV: "staging" });
+    expect(p.requireEmailVerification).toBe(false);
+    expect(p.onboardingEmailsEnabled).toBe(false);
+  });
+
+  it("development profile: verification off, onboarding off", () => {
+    const p = getEnvProfile({ ATLAS_DEPLOY_ENV: "development" });
+    expect(p.requireEmailVerification).toBe(false);
+    expect(p.onboardingEmailsEnabled).toBe(false);
+  });
+
+  it("unset env falls through to production profile", () => {
+    const p = getEnvProfile({});
+    expect(p.requireEmailVerification).toBe(true);
+    expect(p.onboardingEmailsEnabled).toBe(true);
+  });
+});
+
+describe("resolveRequireEmailVerification", () => {
+  it("env var unset + production profile → true (existing prod behavior)", () => {
+    expect(resolveRequireEmailVerification({ ATLAS_DEPLOY_ENV: "production" })).toBe(true);
+  });
+
+  it("env var unset + staging profile → false", () => {
+    expect(resolveRequireEmailVerification({ ATLAS_DEPLOY_ENV: "staging" })).toBe(false);
+  });
+
+  it("env var = false overrides profile (operator escape hatch)", () => {
+    expect(
+      resolveRequireEmailVerification({
+        ATLAS_DEPLOY_ENV: "production",
+        ATLAS_REQUIRE_EMAIL_VERIFICATION: "false",
+      }),
+    ).toBe(false);
+  });
+
+  it("env var = true overrides staging profile (e.g. a staging service that wants verification on)", () => {
+    expect(
+      resolveRequireEmailVerification({
+        ATLAS_DEPLOY_ENV: "staging",
+        ATLAS_REQUIRE_EMAIL_VERIFICATION: "true",
+      }),
+    ).toBe(true);
+  });
+
+  it("env var accepts 0/no/off as opt-out (case-insensitive)", () => {
+    expect(resolveRequireEmailVerification({ ATLAS_REQUIRE_EMAIL_VERIFICATION: "0" })).toBe(false);
+    expect(resolveRequireEmailVerification({ ATLAS_REQUIRE_EMAIL_VERIFICATION: "NO" })).toBe(false);
+    expect(resolveRequireEmailVerification({ ATLAS_REQUIRE_EMAIL_VERIFICATION: "Off" })).toBe(false);
+  });
+
+  it("env var with unrecognized value → true (preserves pre-migration default semantics)", () => {
+    expect(resolveRequireEmailVerification({ ATLAS_REQUIRE_EMAIL_VERIFICATION: "yes" })).toBe(true);
+    expect(resolveRequireEmailVerification({ ATLAS_REQUIRE_EMAIL_VERIFICATION: "1" })).toBe(true);
+  });
+});
+
+describe("resolveOnboardingEmailsEnabled", () => {
+  it("env var unset + production profile → true", () => {
+    expect(resolveOnboardingEmailsEnabled({ ATLAS_DEPLOY_ENV: "production" })).toBe(true);
+  });
+
+  it("env var unset + staging profile → false", () => {
+    expect(resolveOnboardingEmailsEnabled({ ATLAS_DEPLOY_ENV: "staging" })).toBe(false);
+  });
+
+  it("env var = true overrides staging profile", () => {
+    expect(
+      resolveOnboardingEmailsEnabled({
+        ATLAS_DEPLOY_ENV: "staging",
+        ATLAS_ONBOARDING_EMAILS_ENABLED: "true",
+      }),
+    ).toBe(true);
+  });
+
+  it("env var = false overrides production profile (silences onboarding on a prod hotfix scenario)", () => {
+    expect(
+      resolveOnboardingEmailsEnabled({
+        ATLAS_DEPLOY_ENV: "production",
+        ATLAS_ONBOARDING_EMAILS_ENABLED: "false",
+      }),
+    ).toBe(false);
+  });
+
+  it("env var with any non-true value → false (preserves pre-migration narrow grammar)", () => {
+    expect(resolveOnboardingEmailsEnabled({ ATLAS_ONBOARDING_EMAILS_ENABLED: "1" })).toBe(false);
+    expect(resolveOnboardingEmailsEnabled({ ATLAS_ONBOARDING_EMAILS_ENABLED: "yes" })).toBe(false);
+    expect(resolveOnboardingEmailsEnabled({ ATLAS_ONBOARDING_EMAILS_ENABLED: "" })).toBe(false);
+  });
+});

--- a/packages/api/src/lib/auth/server.ts
+++ b/packages/api/src/lib/auth/server.ts
@@ -33,6 +33,7 @@ import { recordOAuthTokenRefresh } from "@atlas/api/lib/auth/oauth-refresh-audit
 import Stripe from "stripe";
 import { getInternalDB, hasInternalDB, internalQuery, updateWorkspacePlanTier, updateWorkspaceStatus, type InternalPool, type PlanTier } from "@atlas/api/lib/db/internal";
 import { createLogger } from "@atlas/api/lib/logger";
+import { resolveRequireEmailVerification as envProfileResolveRequireEmailVerification } from "@atlas/api/lib/env-profile";
 import {
   assertInvitationRoleAllowed,
   dispatchInvitationEmail,
@@ -741,11 +742,16 @@ export function resolveSessionCookieCacheMaxAge(env: NodeJS.ProcessEnv): number 
  * Self-hosted single-tenant deployments that run without an email
  * provider can opt out with `ATLAS_REQUIRE_EMAIL_VERIFICATION=false`.
  * Accepts `false`, `0`, `no`, `off` (case-insensitive) as opt-out.
+ *
+ * Per-env defaults live in {@link import("@atlas/api/lib/env-profile").EnvProfile}
+ * — `production` defaults to `true`, `staging`/`development` default to
+ * `false`. The env var still overrides the profile default when set.
  */
 export function resolveRequireEmailVerification(env: NodeJS.ProcessEnv): boolean {
-  const raw = env.ATLAS_REQUIRE_EMAIL_VERIFICATION?.trim().toLowerCase();
-  if (raw === undefined) return true;
-  return !["false", "0", "no", "off"].includes(raw);
+  // Delegate to the env-profile resolver — same env-var-override
+  // semantics, plus a per-env default that lets us drop the explicit
+  // `ATLAS_REQUIRE_EMAIL_VERIFICATION=false` on staging/dev.
+  return envProfileResolveRequireEmailVerification(env);
 }
 
 /**

--- a/packages/api/src/lib/email/__tests__/engine.test.ts
+++ b/packages/api/src/lib/email/__tests__/engine.test.ts
@@ -46,9 +46,31 @@ describe("isOnboardingEmailEnabled", () => {
     mockHasDB = true;
   });
 
-  it("returns false when env var not set", () => {
+  it("returns false in staging/dev profile when env var not set", () => {
+    // Migrated to env-profile (env-profile.ts): production defaults to
+    // enabled, staging/dev default to disabled. The "env var unset → false"
+    // semantic is now profile-driven; assert against the staging profile.
     delete process.env.ATLAS_ONBOARDING_EMAILS_ENABLED;
-    expect(isOnboardingEmailEnabled()).toBe(false);
+    const origDeployEnv = process.env.ATLAS_DEPLOY_ENV;
+    process.env.ATLAS_DEPLOY_ENV = "staging";
+    try {
+      expect(isOnboardingEmailEnabled()).toBe(false);
+    } finally {
+      if (origDeployEnv === undefined) delete process.env.ATLAS_DEPLOY_ENV;
+      else process.env.ATLAS_DEPLOY_ENV = origDeployEnv;
+    }
+  });
+
+  it("returns false when env var explicitly disabled even in production profile", () => {
+    process.env.ATLAS_ONBOARDING_EMAILS_ENABLED = "false";
+    const origDeployEnv = process.env.ATLAS_DEPLOY_ENV;
+    process.env.ATLAS_DEPLOY_ENV = "production";
+    try {
+      expect(isOnboardingEmailEnabled()).toBe(false);
+    } finally {
+      if (origDeployEnv === undefined) delete process.env.ATLAS_DEPLOY_ENV;
+      else process.env.ATLAS_DEPLOY_ENV = origDeployEnv;
+    }
   });
 
   it("returns false when no internal DB", () => {
@@ -72,8 +94,13 @@ describe("sendOnboardingEmail", () => {
     mockDeliveryResult = { success: true, provider: "log" };
   });
 
-  it("skips when feature disabled", async () => {
-    delete process.env.ATLAS_ONBOARDING_EMAILS_ENABLED;
+  it("skips when feature disabled (env var explicit false beats production profile default)", async () => {
+    // Pre-migration: deleting the env var was enough — undefined meant
+    // "feature off". Post-migration the env-profile production default
+    // says "on", so we must explicitly set the env var to false to
+    // disable. The check we want here is the disable path, not the
+    // unset-default behavior (covered in isOnboardingEmailEnabled tests).
+    process.env.ATLAS_ONBOARDING_EMAILS_ENABLED = "false";
     const sent = await sendOnboardingEmail("u1", "test@example.com", "org1", "welcome", "signup_completed");
     expect(sent).toBe(false);
   });

--- a/packages/api/src/lib/email/engine.ts
+++ b/packages/api/src/lib/email/engine.ts
@@ -8,6 +8,7 @@
 
 import { createLogger } from "@atlas/api/lib/logger";
 import { hasInternalDB, internalQuery } from "@atlas/api/lib/db/internal";
+import { resolveOnboardingEmailsEnabled } from "@atlas/api/lib/env-profile";
 import type { OnboardingEmailStep, OnboardingMilestone, OnboardingEmailTrigger, OnboardingEmailStatus } from "@useatlas/types";
 import { ONBOARDING_SEQUENCE, MILESTONE_TO_STEP } from "./sequence";
 import { renderOnboardingEmail } from "./templates";
@@ -18,9 +19,20 @@ import { normalizeError } from "@atlas/api/lib/effect/errors";
 
 const log = createLogger("onboarding-email");
 
-/** Check whether the onboarding email feature is enabled. */
+/**
+ * Check whether the onboarding email feature is enabled.
+ *
+ * Per-env default lives in {@link import("@atlas/api/lib/env-profile").EnvProfile}
+ * — `production` defaults to enabled, `staging`/`development` default to
+ * disabled. The `ATLAS_ONBOARDING_EMAILS_ENABLED` env var still
+ * overrides the profile default when set.
+ *
+ * The `hasInternalDB()` gate is independent of the env-var/profile
+ * decision — onboarding scheduler tasks need the internal DB to persist
+ * dispatch state, so even an enabled profile is a no-op without it.
+ */
 export function isOnboardingEmailEnabled(): boolean {
-  return process.env.ATLAS_ONBOARDING_EMAILS_ENABLED === "true" && hasInternalDB();
+  return resolveOnboardingEmailsEnabled() && hasInternalDB();
 }
 
 // ── Branding resolution ─────────────────────────────────────────────

--- a/packages/api/src/lib/env-profile.ts
+++ b/packages/api/src/lib/env-profile.ts
@@ -1,0 +1,150 @@
+/**
+ * Env-profile — typed, non-secret deployment-environment defaults.
+ *
+ * Atlas runs in several deployment shapes (production SaaS regions,
+ * single-region staging, self-hosted, dev). Many non-secret runtime
+ * toggles have the same "correct" value for an entire env class
+ * (require-email-verification is always off in staging+dev, always on
+ * in prod; onboarding-emails are always off outside prod), yet were
+ * previously stamped per-service in Railway as individual env vars.
+ * This module centralises those decisions behind a single
+ * `ATLAS_DEPLOY_ENV` switch and a typed table.
+ *
+ * **Migration pattern:** each profile field is paired with a legacy
+ * env var that still overrides the profile default (`getProfileValue(...)`
+ * helpers prefer the env var when set). This lets operators flip a
+ * single deployment without changing code, and lets us migrate per-field
+ * incrementally — `ATLAS_REQUIRE_EMAIL_VERIFICATION=false` on a prod
+ * service still works even after the profile says `true`.
+ *
+ * **In scope:** non-secret runtime toggles that vary by deployment shape.
+ * **Out of scope:**
+ *   - Secrets (API keys, encryption keys, DB URLs).
+ *   - Per-instance values (which specific region serves this api).
+ *   - Per-tenant config.
+ *   - Boot-script-only env vars read before TypeScript starts (e.g.
+ *     `ATLAS_SEED_DEMO` — read by `examples/docker/scripts/start.sh`).
+ *   - Settings-registry-managed values (rate limits, MCP session caps —
+ *     they have their own env-var fallback semantics; layering
+ *     env-profile in would require refactoring the registry).
+ */
+
+/**
+ * Deployment-shape discriminator. Read from `ATLAS_DEPLOY_ENV`; unset
+ * defaults to `production` — preserves existing behavior for self-hosted
+ * and unconfigured deploys without a migration step.
+ *
+ * - `production` — customer-facing SaaS region (us / eu / apac all share this profile)
+ * - `staging` — pre-prod soak environment (single region under `staging.useatlas.dev`)
+ * - `development` — local dev / Playwright / CI
+ */
+export type DeployEnv = "production" | "staging" | "development";
+
+export interface EnvProfile {
+  /**
+   * Whether new signups must verify their email before the session
+   * becomes active. When false, Better Auth's `autoSignIn` kicks in
+   * and signup hands the user a session immediately.
+   *
+   * Legacy override: `ATLAS_REQUIRE_EMAIL_VERIFICATION` env var (any
+   * value of `false`/`0`/`no`/`off` disables verification; everything
+   * else enables).
+   */
+  readonly requireEmailVerification: boolean;
+
+  /**
+   * Whether Atlas-originated onboarding emails (welcome, day-N nudge,
+   * etc.) fire from the scheduler. Independent of the email-delivery
+   * backend being configured — when false, the scheduler tick skips
+   * the queue entirely.
+   *
+   * Legacy override: `ATLAS_ONBOARDING_EMAILS_ENABLED` env var (only
+   * the literal `"true"` enables; anything else, including unset,
+   * disables).
+   */
+  readonly onboardingEmailsEnabled: boolean;
+}
+
+const PROFILES: Record<DeployEnv, EnvProfile> = {
+  // Prod ships real signup verification and real onboarding email
+  // campaigns. Behavior matches the pre-env-profile baseline (env vars
+  // were always set this way on prod).
+  production: {
+    requireEmailVerification: true,
+    onboardingEmailsEnabled: true,
+  },
+  // Staging dogfoods signup without making the maintainer wait on
+  // real verification emails (no Resend on staging anyway — DPA guard
+  // satisfied by a dummy key). Onboarding nudges off so dogfood signups
+  // don't trigger automated email sequences.
+  staging: {
+    requireEmailVerification: false,
+    onboardingEmailsEnabled: false,
+  },
+  // Dev mirrors staging — local signup should be instant; onboarding
+  // emails would spam the developer or hit a real Resend account.
+  development: {
+    requireEmailVerification: false,
+    onboardingEmailsEnabled: false,
+  },
+};
+
+/**
+ * Resolve the active deployment env from `ATLAS_DEPLOY_ENV`. Unset →
+ * `production`. Unknown value → log + fall back to `production` rather
+ * than throwing — a typo in the discriminator isn't worth a hard-fail
+ * boot.
+ */
+export function resolveDeployEnv(env: NodeJS.ProcessEnv = process.env): DeployEnv {
+  const raw = env.ATLAS_DEPLOY_ENV?.trim().toLowerCase();
+  if (!raw) return "production";
+  if (raw === "production" || raw === "staging" || raw === "development") {
+    return raw;
+  }
+  return "production";
+}
+
+/**
+ * Return the typed profile for the current deployment env. Cheap (map
+ * lookup) — call at the call site rather than caching at module scope
+ * so tests can `process.env.ATLAS_DEPLOY_ENV = "staging"` before
+ * importing dependents.
+ */
+export function getEnvProfile(env: NodeJS.ProcessEnv = process.env): EnvProfile {
+  return PROFILES[resolveDeployEnv(env)];
+}
+
+/**
+ * Resolve `requireEmailVerification` honoring the legacy env-var
+ * override pattern: if `ATLAS_REQUIRE_EMAIL_VERIFICATION` is set,
+ * its parsed value wins; otherwise the profile default applies.
+ *
+ * Override values: `false`/`0`/`no`/`off` (case-insensitive) → false.
+ * Anything else (including unrecognized values like `"yes"`) → true.
+ */
+export function resolveRequireEmailVerification(env: NodeJS.ProcessEnv = process.env): boolean {
+  const raw = env.ATLAS_REQUIRE_EMAIL_VERIFICATION?.trim().toLowerCase();
+  if (raw !== undefined) {
+    return !["false", "0", "no", "off"].includes(raw);
+  }
+  return getEnvProfile(env).requireEmailVerification;
+}
+
+/**
+ * Resolve `onboardingEmailsEnabled` honoring the legacy env-var
+ * override: if `ATLAS_ONBOARDING_EMAILS_ENABLED` is set, only the
+ * literal `"true"` enables (matches the pre-migration semantics —
+ * we don't widen the override grammar here). Otherwise the profile
+ * default applies.
+ *
+ * Callers that also require an internal DB (`hasInternalDB()`) should
+ * AND that check themselves — this resolver only encodes the env-vs-
+ * profile decision, not the wiring prerequisites.
+ */
+export function resolveOnboardingEmailsEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  const raw = env.ATLAS_ONBOARDING_EMAILS_ENABLED;
+  if (raw !== undefined) {
+    return raw === "true";
+  }
+  return getEnvProfile(env).onboardingEmailsEnabled;
+}


### PR DESCRIPTION
## Summary

- New `packages/api/src/lib/env-profile.ts` — typed deployment-env profile keyed on `ATLAS_DEPLOY_ENV` with resolver helpers that honor legacy env-var overrides.
- Phase-1 migrations: `ATLAS_REQUIRE_EMAIL_VERIFICATION` + `ATLAS_ONBOARDING_EMAILS_ENABLED` → profile defaults (prod: true / true; staging+dev: false / false).
- 22 new tests; 2 updated existing engine tests.
- Deferred: `ATLAS_SEED_DEMO` (shell script), `ATLAS_RATE_LIMIT_RPM` (settings registry), `ATLAS_MCP_MAX_SESSIONS` (no real reader yet), `STAGING_MAIL_SINK` (StagingClamp not built yet).

## Why

User question after the URL-rename pivot: "should other Railway env vars actually be in this constants module?" Audit found ~6 candidates; this PR ships the 2 that have clean single-call-site reads and don't depend on other refactors first.

The profile/env-var override pattern means:
- Operators can still flip a single deployment via env var
- New environments inherit safe defaults
- Per-env defaults are a typed table edit, not a global grep

## Prod safety

- `ATLAS_DEPLOY_ENV` unset → `production` profile → `requireEmailVerification: true`, `onboardingEmailsEnabled: true` — identical to current prod env vars
- Unknown value (typo) → degrades to production profile (not hard-fail)
- Existing `ATLAS_REQUIRE_EMAIL_VERIFICATION` / `ATLAS_ONBOARDING_EMAILS_ENABLED` env vars on prod services still work (override the profile)
- Once shipped, those env vars become redundant on staging/dev (planned cleanup PR after this lands and api-staging redeploys cleanly)

## Test plan

- [x] 22 new unit tests in `packages/api/src/lib/__tests__/env-profile.test.ts`
- [x] Existing `engine.test.ts` updated for new "explicit env var vs profile default" semantic; all 9 pass
- [x] `auth/server.test.ts` still passes (28/28) — the existing `resolveRequireEmailVerification` export delegates internally but keeps its signature
- [x] Type, lint, syncpack, all drift checks, test discipline, twenty resolver, published symbols all pass locally
- [ ] After deploy: api-staging signup still skips email verification (now via profile, not legacy env var)
- [ ] After deploy: prod signup still requires email verification (no env var change for prod)

## Follow-up

- Remove redundant `ATLAS_REQUIRE_EMAIL_VERIFICATION=false` + `ATLAS_ONBOARDING_EMAILS_ENABLED=false` on api-staging after this PR ships
- Phase-2 migrations (SEED_DEMO, RATE_LIMIT_RPM, MCP_MAX_SESSIONS, MAIL_SINK) each in their own follow-up PR with the necessary refactor

Refs #2921, #2894

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/2936"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782595935&installation_id=135337507&pr_number=2936&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F2936&signature=701fd8aa1097f227782c06dd4c1b473280b21891bf763649e43234cd52d413e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->