### PR TITLE
refactor(web): drop redundant base-field cast in sessions-section

### DIFF
--- a/packages/web/src/ui/components/settings/sessions-section.tsx
+++ b/packages/web/src/ui/components/settings/sessions-section.tsx
@@ -91,10 +91,7 @@ export function summarizeUserAgent(ua: string | null): string {
 
 export function SessionsSection() {
   const session = authClient.useSession();
-  // Better Auth's typed session covers `id` as a base field, but the
-  // plugin-wrapped client occasionally erases the inferred shape — narrow
-  // here without leaking the cast across the file.
-  const currentSessionId = (session.data?.session as { id?: string } | undefined)?.id;
+  const currentSessionId = session.data?.session?.id;
 
   const { data, loading, error, refetch } = useAdminFetch("/api/v1/sessions", {
     schema: SessionsResponseSchema,


### PR DESCRIPTION
## Summary
- Follow-up to #2334, which widened `OrgClient.useSession` so consumers read base session fields (including `id`) without per-call casts.
- Replaces the local `(session.data?.session as { id?: string } | undefined)?.id` narrow at `sessions-section.tsx:97` with a direct `session.data?.session?.id` read.
- Removes the now-stale comment ("the plugin-wrapped client occasionally erases the inferred shape…"). Optional chaining preserves the prior undefined-safe behavior.

## Test plan
- [x] `bun run type` passes — proves the #2334 widening reaches `id` without the cast (the real check; this is the type-narrowing it removes)
- [x] `bun run lint`, full `bun run test`, syncpack, and all drift/discipline gates pass (`/ci`)
- [x] `currentSessionId` still flows to the three downstream `s.id === currentSessionId` uses (sign-out-everywhere filter, other-session count, current-row badge)
- No test file exists for this component; behavior confirmed via type-check.

Closes #2371

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/2958"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782606339&installation_id=135337507&pr_number=2958&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F2958&signature=be8e0e8f53617329011a300613fbb764d63bd9e83bb758cd412a660d2fbab0cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->