### PR TITLE
refactor(ee): compile-time bridge guards SaasCrmLeadInput ↔ AtlasLeadEvent drift

### DIFF
--- a/ee/src/saas-crm/index.ts
+++ b/ee/src/saas-crm/index.ts
@@ -401,20 +401,31 @@ const outboxDb: OutboxDB = {
  * This `ee/src/saas-crm/` file is the one place that legitimately depends on
  * both sides (the EE inversion rule), and the `row.payload as SaasCrmLeadInput`
  * → `normalizeLead(...)` cast in `dispatchOutboxRow` below relies on the two
- * unions being interchangeable. Tuple-wrapped (`[A] extends [B]`) so the
- * conditionals compare the unions whole rather than distributing member-wise;
- * the mutual-assignability check resolves to `true` only while every variant
- * of each union is present in the other. Add a variant to one union but not
- * the other and `_LeadUnionsAreMirrors` collapses to `never`, so the `= true`
- * below fails `tsgo` HERE — instead of dead-lettering at flush with the
- * runtime `Unknown lead source` throw in `normalizeLead`.
+ * unions being interchangeable.
+ *
+ * `ExactType<A, B>` is the standard exact-equality check (the
+ * function-parameter-bivariance idiom): it resolves to `true` only when A and
+ * B are structurally *identical* — same variants, same fields, same
+ * optionality and `readonly`-ness — and to `false` on any asymmetry. That's
+ * stricter than mutual assignability (`[A] extends [B]` both ways), which
+ * would silently tolerate, e.g., one side dropping `readonly` or flipping a
+ * field optional. "Mirror" means identical, so equality is the right tool.
+ *
+ * Asserting `= true` (rather than a bare `T extends true` helper) is
+ * load-bearing: on drift the check resolves to `false`/`never`, and `never`
+ * *is* assignable to a `T extends true` constraint — so a naked helper would
+ * fail open. `const _x: ExactType<…> = true` instead forbids the drift result.
+ * Add a variant to one union but not the other — or change a field's shape on
+ * just one side — and this line goes red in `tsgo` HERE, instead of
+ * dead-lettering at flush with `normalizeLead`'s runtime `Unknown lead source`
+ * throw.
  */
-type _LeadUnionsAreMirrors = [SaasCrmLeadInput] extends [AtlasLeadEvent]
-  ? [AtlasLeadEvent] extends [SaasCrmLeadInput]
-    ? true
-    : never
-  : never;
-const _leadUnionsAreMirrors: _LeadUnionsAreMirrors = true;
+type ExactType<A, B> = (<T>() => T extends A ? 1 : 2) extends <
+  T,
+>() => T extends B ? 1 : 2
+  ? true
+  : false;
+const _leadUnionsAreMirrors: ExactType<SaasCrmLeadInput, AtlasLeadEvent> = true;
 void _leadUnionsAreMirrors;
 
 /**

--- a/ee/src/saas-crm/index.ts
+++ b/ee/src/saas-crm/index.ts
@@ -78,6 +78,7 @@ import {
   TwentyClientError,
   TwentyCredentialError,
   isTwentyDecryptError,
+  type AtlasLeadEvent,
   type DbCredentialLookup,
   type ResolvedTwentyCredentials,
   type TwentyClientConfig,
@@ -388,6 +389,33 @@ async function verifyCustomFields(
 const outboxDb: OutboxDB = {
   query: internalQuery,
 };
+
+/**
+ * Compile-time bridge between the two intentionally-duplicated lead-event
+ * unions: `SaasCrmLeadInput` (the `SaasCrm` Tag's `upsertLead` contract, in
+ * `@atlas/api`) and `AtlasLeadEvent` (the Twenty normalizer's input, in
+ * `@useatlas/twenty`). They are mirrored by hand — see the "Adding a
+ * variant" note on `SaasCrmLeadInput` — never merged, because that would
+ * drag `@useatlas/twenty` into `@atlas/api`'s public contract surface.
+ *
+ * This `ee/src/saas-crm/` file is the one place that legitimately depends on
+ * both sides (the EE inversion rule), and the `row.payload as SaasCrmLeadInput`
+ * → `normalizeLead(...)` cast in `dispatchOutboxRow` below relies on the two
+ * unions being interchangeable. Tuple-wrapped (`[A] extends [B]`) so the
+ * conditionals compare the unions whole rather than distributing member-wise;
+ * the mutual-assignability check resolves to `true` only while every variant
+ * of each union is present in the other. Add a variant to one union but not
+ * the other and `_LeadUnionsAreMirrors` collapses to `never`, so the `= true`
+ * below fails `tsgo` HERE — instead of dead-lettering at flush with the
+ * runtime `Unknown lead source` throw in `normalizeLead`.
+ */
+type _LeadUnionsAreMirrors = [SaasCrmLeadInput] extends [AtlasLeadEvent]
+  ? [AtlasLeadEvent] extends [SaasCrmLeadInput]
+    ? true
+    : never
+  : never;
+const _leadUnionsAreMirrors: _LeadUnionsAreMirrors = true;
+void _leadUnionsAreMirrors;
 
 /**
  * Dispatch one claimed outbox row through the Twenty client. Each

--- a/packages/api/src/lib/effect/services.ts
+++ b/packages/api/src/lib/effect/services.ts
@@ -2418,13 +2418,17 @@ export const NoopDeployModeResolverLayer: Layer.Layer<DeployModeResolver> =
 
 /**
  * Inputs to `SaasCrm.upsertLead`. Mirrors the discriminated union in
- * `plugins/twenty/src/lead-normalizer.ts:AtlasLeadEvent`. The normalizer's
- * exhaustiveness switch is the drift gate — when the two unions diverge,
- * the next dispatch dead-letters with `Unknown lead source` rather than
- * silently swallowing.
+ * `plugins/twenty/src/lead-normalizer.ts:AtlasLeadEvent`. Drift between the
+ * two is caught at compile time by the `_LeadUnionsAreMirrors` bridge in
+ * `ee/src/saas-crm/index.ts` (the EE layer is the only place allowed to
+ * depend on both unions) — a mutual-assignability assertion that fails
+ * `tsgo` if either union gains a variant the other lacks. The normalizer's
+ * exhaustiveness switch is the runtime backstop: were a divergence to slip
+ * past the bridge, the next dispatch dead-letters with `Unknown lead source`
+ * rather than silently swallowing.
  *
- * Adding a variant: extend BOTH this union AND `AtlasLeadEvent`. The
- * two-place duplication exists because the runtime queue
+ * Adding a variant: extend BOTH this union AND `AtlasLeadEvent`, or the
+ * bridge goes red. The two-place duplication exists because the runtime queue
  * (`lib/lead-outbox/`) and the route layer (the `SaasCrm` Tag's
  * `upsertLead` contract surface) intentionally stay free of any
  * `@useatlas/twenty` import — the EE dispatcher is the only allowed

--- a/packages/api/src/lib/effect/services.ts
+++ b/packages/api/src/lib/effect/services.ts
@@ -2419,10 +2419,11 @@ export const NoopDeployModeResolverLayer: Layer.Layer<DeployModeResolver> =
 /**
  * Inputs to `SaasCrm.upsertLead`. Mirrors the discriminated union in
  * `plugins/twenty/src/lead-normalizer.ts:AtlasLeadEvent`. Drift between the
- * two is caught at compile time by the `_LeadUnionsAreMirrors` bridge in
+ * two is caught at compile time by the `_leadUnionsAreMirrors` bridge in
  * `ee/src/saas-crm/index.ts` (the EE layer is the only place allowed to
- * depend on both unions) — a mutual-assignability assertion that fails
- * `tsgo` if either union gains a variant the other lacks. The normalizer's
+ * depend on both unions) — an exact-type-equality assertion that fails
+ * `tsgo` if the unions diverge in any way (a variant added on one side, or
+ * a field's shape changed on just one side). The normalizer's
  * exhaustiveness switch is the runtime backstop: were a divergence to slip
  * past the bridge, the next dispatch dead-letters with `Unknown lead source`
  * rather than silently swallowing.

--- a/plugins/twenty/src/lead-normalizer.ts
+++ b/plugins/twenty/src/lead-normalizer.ts
@@ -2,9 +2,9 @@
  * LeadNormalizer — pure mapping from Atlas lead events to the Twenty
  * upsert input shape.
  *
- * Ships the `demo`, `sales-form`, and `signup` variants. `normalizeLead`'s
- * exhaustive switch surfaces a compile error the moment a new union
- * member lands.
+ * Ships the `demo`, `sales-form`, `signup`, and `conversion` variants.
+ * `normalizeLead`'s exhaustive switch surfaces a compile error the moment a
+ * new union member lands.
  *
  * Design rule: the normalizer outputs a single `eventSource` field;
  * the first-source / last-source translation happens INSIDE
@@ -12,9 +12,12 @@
  * of input → payload, with no I/O and no Twenty-record-state coupling.
  *
  * Types are defined inline here and mirrored in `packages/api/src/lib/effect/services.ts`
- * (`SaasCrmLeadInput`) — the exhaustiveness switch in `normalizeLead`
- * keeps the two in lockstep. Promote to `@useatlas/types` when a second
- * consumer outside of `ee/src/saas-crm/` appears.
+ * (`SaasCrmLeadInput`). The compile-time gate that keeps the two in lockstep
+ * is the `_leadUnionsAreMirrors` exact-equality assertion in
+ * `ee/src/saas-crm/index.ts` (the one place allowed to depend on both); the
+ * exhaustiveness switch in `normalizeLead` is the runtime backstop. Promote
+ * to `@useatlas/types` when a second consumer outside of `ee/src/saas-crm/`
+ * appears.
  */
 
 import type { UpsertPersonInput } from "./client";


### PR DESCRIPTION
## Summary

- The two intentionally-duplicated lead-event unions — `SaasCrmLeadInput` (`packages/api/src/lib/effect/services.ts`, the `SaasCrm` Tag's `upsertLead` contract) and `AtlasLeadEvent` (`plugins/twenty/src/lead-normalizer.ts`, the normalizer's input) — were kept in lockstep only by a code comment, a runtime `as` cast, and `normalizeLead`'s runtime `Unknown lead source` throw. **None caught drift at compile time.**
- Adds a **compile-time exact-type-equality assertion** (`_leadUnionsAreMirrors` via `ExactType<A,B>`) in `ee/src/saas-crm/index.ts`, immediately above the `row.payload as SaasCrmLeadInput` → `normalizeLead(...)` cast it makes sound. `ee/src/saas-crm/` is the one place that legitimately depends on both sides under the EE inversion rule. Any divergence — a variant added on one side, or a field's shape changed on just one side — now fails `tsgo` at the bridge instead of dead-lettering at flush.
- **Type-only** — no new runtime code path. Unions are **not** merged or relocated. The existing "extend BOTH" comment on `SaasCrmLeadInput` now points at the new guard and reframes the exhaustiveness switch as the runtime backstop; the `lead-normalizer.ts` header was aligned to match (and its variant list corrected to include `conversion`).

### Why exact equality (not just assignability)
The issue sketched a one-directional `SaasCrmLeadInput extends AtlasLeadEvent` check. PR review (type-design-analyzer) flagged that even bidirectional mutual-assignability has a blind spot — it silently tolerates one side dropping `readonly` or flipping a field optional. "Mirror" means *identical*, so this uses the `ExactType` (function-parameter-bivariance) idiom, which is strictly stronger. The `const _x: ExactType<…> = true` form is load-bearing: a bare `type Assert<T extends true>` would fail **open** on drift because `never extends true` is `true`.

### EE inversion rule
`AtlasLeadEvent` is already re-exported from the `@useatlas/twenty` package root (the same module this file already imports `normalizeLead` from), so the bridge adds **no** new dependency — just `type AtlasLeadEvent` to the existing import. No `@atlas/ee` or `@useatlas/twenty` import added to `packages/api/src`. `scripts/check-ee-imports.sh` and `scripts/check-twenty-resolver-imports.sh` stay green.

## Test plan
- [x] `bun run type` (clean) passes — `ExactType` resolves to `true` on the real (separately-declared but structurally identical) unions
- [x] **Drift proof — variant**: temporarily added a fake `{ source: "drift-test" }` to `SaasCrmLeadInput` → `bun run type` failed `ee/src/saas-crm/index.ts: error TS2322: Type 'true' is not assignable to type 'false'` → reverted
- [x] **Drift proof — `readonly`**: temporarily dropped `readonly` from one field on one side → bridge went red **while the cast site stayed green** (readonly is bivariantly assignable), proving the bridge catches drift the cast alone cannot → reverted
- [x] `/ci` local gates: lint, type, syncpack, template-drift, security-headers-drift, railway-watch, schema-drift, oauth-helper-drift, test-discipline, twenty-resolver-imports, ee-imports, published-symbols — all pass
- [x] Full `bun run test` — 489/490 files pass; the one failure (`admin-roles.test.ts`) was a bun segfault (runtime flakiness), confirmed unrelated: passes 24/24 on isolated retry. `plugins/twenty` lead-normalizer tests 34/0.
- [x] `/pr-review-toolkit:review-pr` — code-reviewer, comment-analyzer, type-design-analyzer; no critical/important issues; suggestions addressed in follow-up commit.

Closes #2842