### PR TITLE
fix(api): fail-loud throw on empty RETURNING in form-install handlers (#2808)

### DIFF
--- a/packages/api/src/lib/integrations/install/__tests__/email-form-handler.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/email-form-handler.test.ts
@@ -79,7 +79,17 @@ beforeEach(() => {
   // assertion below would otherwise pass trivially.
   setKeys("v1:test-key-for-email-handler-unit-tests-must-be-long-enough");
   mockInternalQuery.mockClear();
-  mockInternalQuery.mockImplementation(() => Promise.resolve([]));
+  // Echo the candidate id back on `RETURNING id` so the happy path
+  // sees the row Postgres is guaranteed to emit. The previous `[]`
+  // default leaned on the now-removed candidateId fallback (#2808);
+  // an empty rowset is exclusively the fail-loud anomaly path below.
+  mockInternalQuery.mockImplementation(async (sql: string, params?: unknown[]) => {
+    if (sql.includes("RETURNING id")) {
+      const id = (params?.[0] as string | undefined) ?? "unknown";
+      return [{ id }];
+    }
+    return [];
+  });
 });
 
 afterEach(() => {
@@ -225,6 +235,33 @@ describe("EmailFormInstallHandler.validateConfig — persistence", () => {
     const handler = new EmailFormInstallHandler({ idGenerator: () => "fresh-id" });
     const result = await handler.validateConfig(WSID, validForm());
     expect(result.installRecord.id).toBe("preexisting-id");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// RETURNING-id invariant — fail loud when the upsert emits no row (#2808)
+// ---------------------------------------------------------------------------
+
+describe("EmailFormInstallHandler.validateConfig — RETURNING invariant", () => {
+  it("throws when the upsert returns no row (driver/RLS/rewrite anomaly)", async () => {
+    // INSERT ... ON CONFLICT ... DO UPDATE RETURNING is guaranteed by
+    // Postgres to emit one row. If the mock returns [] (a structural
+    // anomaly), the handler must surface a 500 rather than silently
+    // fall back to candidateId — the fallback returned a WRONG id on
+    // the DO UPDATE path and corrupted downstream lookups.
+    mockInternalQuery.mockImplementation(async () => []);
+    const handler = new EmailFormInstallHandler();
+    await expect(handler.validateConfig(WSID, validForm())).rejects.toThrow(
+      /upsert returned no id/,
+    );
+  });
+
+  it("throws when the returned id is an empty string", async () => {
+    mockInternalQuery.mockImplementation(async () => [{ id: "" }]);
+    const handler = new EmailFormInstallHandler();
+    await expect(handler.validateConfig(WSID, validForm())).rejects.toThrow(
+      /upsert returned no id/,
+    );
   });
 });
 

--- a/packages/api/src/lib/integrations/install/__tests__/linear-apikey-form-handler.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/linear-apikey-form-handler.test.ts
@@ -161,6 +161,33 @@ describe("LinearApiKeyFormInstallHandler.validateConfig — happy path", () => {
 });
 
 // ---------------------------------------------------------------------------
+// RETURNING-id invariant — fail loud when the upsert emits no row (#2808)
+// ---------------------------------------------------------------------------
+
+describe("LinearApiKeyFormInstallHandler.validateConfig — RETURNING invariant", () => {
+  it("throws when the upsert returns no row (driver/RLS/rewrite anomaly)", async () => {
+    // INSERT ... ON CONFLICT ... DO UPDATE RETURNING is guaranteed by
+    // Postgres to emit one row. If the mock returns [] (a structural
+    // anomaly), the handler must surface a 500 rather than silently
+    // fall back to candidateId — the fallback returned a WRONG id on
+    // the DO UPDATE path and corrupted downstream lookups.
+    mockInternalQuery.mockImplementation(async () => []);
+    const handler = new LinearApiKeyFormInstallHandler();
+    await expect(handler.validateConfig(WSID, validForm())).rejects.toThrow(
+      /upsert returned no id/,
+    );
+  });
+
+  it("throws when the returned id is an empty string", async () => {
+    mockInternalQuery.mockImplementation(async () => [{ id: "" }]);
+    const handler = new LinearApiKeyFormInstallHandler();
+    await expect(handler.validateConfig(WSID, validForm())).rejects.toThrow(
+      /upsert returned no id/,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
 // SaaS keyset gate — fail-closed on missing encryption keyset
 // ---------------------------------------------------------------------------
 

--- a/packages/api/src/lib/integrations/install/__tests__/linear-apikey-form-handler.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/linear-apikey-form-handler.test.ts
@@ -158,6 +158,24 @@ describe("LinearApiKeyFormInstallHandler.validateConfig — happy path", () => {
     const params = mockInternalQuery.mock.calls[0][1] as unknown[];
     expect(params).toContain("catalog:linear-apikey");
   });
+
+  it("returns the persisted id on ON CONFLICT (re-install keeps the original row id)", async () => {
+    // Simulate a re-install: the candidate id we'd insert is "fresh-id"
+    // but the DB row's existing id is "preexisting-id". RETURNING id on
+    // an UPSERT returns the row's actual id, NOT the candidate — so the
+    // handler must surface "preexisting-id". Pins that installRecord.id
+    // flows from the RETURNING row decoupled from candidateId; brings
+    // this file to parity with the email/obsidian/webhook/twenty tests
+    // so a silent revert to `persistedId = candidateId` (the bug #2808
+    // removed) is caught here, not just in the empty-rowset cases below.
+    mockInternalQuery.mockImplementation(async (sql: string) => {
+      if (sql.includes("RETURNING id")) return [{ id: "preexisting-id" }];
+      return [];
+    });
+    const handler = new LinearApiKeyFormInstallHandler({ idGenerator: () => "fresh-id" });
+    const result = await handler.validateConfig(WSID, validForm());
+    expect(result.installRecord.id).toBe("preexisting-id");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/api/src/lib/integrations/install/__tests__/obsidian-form-handler.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/obsidian-form-handler.test.ts
@@ -64,7 +64,17 @@ function validForm(overrides: Partial<Record<string, unknown>> = {}): Record<str
 beforeEach(() => {
   setKeys("v1:test-key-for-obsidian-handler-unit-tests-must-be-long-enough");
   mockInternalQuery.mockClear();
-  mockInternalQuery.mockImplementation(() => Promise.resolve([]));
+  // Echo the candidate id back on `RETURNING id` so the happy path
+  // sees the row Postgres is guaranteed to emit. The previous `[]`
+  // default leaned on the now-removed candidateId fallback (#2808);
+  // an empty rowset is exclusively the fail-loud anomaly path below.
+  mockInternalQuery.mockImplementation(async (sql: string, params?: unknown[]) => {
+    if (sql.includes("RETURNING id")) {
+      const id = (params?.[0] as string | undefined) ?? "unknown";
+      return [{ id }];
+    }
+    return [];
+  });
 });
 
 afterEach(() => {
@@ -193,6 +203,33 @@ describe("ObsidianFormInstallHandler.validateConfig — persistence", () => {
     const handler = new ObsidianFormInstallHandler({ idGenerator: () => "fresh-id" });
     const result = await handler.validateConfig(WSID, validForm());
     expect(result.installRecord.id).toBe("preexisting-id");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// RETURNING-id invariant — fail loud when the upsert emits no row (#2808)
+// ---------------------------------------------------------------------------
+
+describe("ObsidianFormInstallHandler.validateConfig — RETURNING invariant", () => {
+  it("throws when the upsert returns no row (driver/RLS/rewrite anomaly)", async () => {
+    // INSERT ... ON CONFLICT ... DO UPDATE RETURNING is guaranteed by
+    // Postgres to emit one row. If the mock returns [] (a structural
+    // anomaly), the handler must surface a 500 rather than silently
+    // fall back to candidateId — the fallback returned a WRONG id on
+    // the DO UPDATE path and corrupted downstream lookups.
+    mockInternalQuery.mockImplementation(async () => []);
+    const handler = new ObsidianFormInstallHandler();
+    await expect(handler.validateConfig(WSID, validForm())).rejects.toThrow(
+      /upsert returned no id/,
+    );
+  });
+
+  it("throws when the returned id is an empty string", async () => {
+    mockInternalQuery.mockImplementation(async () => [{ id: "" }]);
+    const handler = new ObsidianFormInstallHandler();
+    await expect(handler.validateConfig(WSID, validForm())).rejects.toThrow(
+      /upsert returned no id/,
+    );
   });
 });
 

--- a/packages/api/src/lib/integrations/install/__tests__/twenty-form-handler.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/twenty-form-handler.test.ts
@@ -278,3 +278,47 @@ describe("TwentyFormInstallHandler.validateConfig — happy path", () => {
     expect(result.installRecord.id).toBe("existing-row-id");
   });
 });
+
+// ---------------------------------------------------------------------------
+// RETURNING-id invariant — fail loud when the workspace_plugins upsert
+// emits no row (#2808). The twenty_integrations credential write lands
+// first; only the catalog-binding upsert is driven into the anomaly path,
+// so an anomaly here must surface as a 500 rather than silently falling
+// back to candidateId (which returned a WRONG id on the DO UPDATE path).
+// ---------------------------------------------------------------------------
+
+describe("TwentyFormInstallHandler.validateConfig — RETURNING invariant", () => {
+  // Credential row always lands so the handler reaches the catalog
+  // upsert; the workspace_plugins branch is what we drive into the
+  // anomaly path below.
+  function twentyRow(params?: unknown[]): Record<string, unknown> {
+    return {
+      workspace_id: params?.[0],
+      base_url: params?.[1],
+      updated_at: "2026-05-26T00:00:00.000Z",
+    };
+  }
+
+  it("throws when the workspace_plugins upsert returns no row", async () => {
+    mockInternalQuery.mockImplementation(async (sql: string, params?: unknown[]) => {
+      if (sql.includes("INSERT INTO twenty_integrations")) return [twentyRow(params)];
+      return [];
+    });
+    const handler = new TwentyFormInstallHandler();
+    await expect(handler.validateConfig(WSID, validForm())).rejects.toThrow(
+      /upsert returned no id/,
+    );
+  });
+
+  it("throws when the returned id is an empty string", async () => {
+    mockInternalQuery.mockImplementation(async (sql: string, params?: unknown[]) => {
+      if (sql.includes("INSERT INTO twenty_integrations")) return [twentyRow(params)];
+      if (sql.includes("INSERT INTO workspace_plugins")) return [{ id: "" }];
+      return [];
+    });
+    const handler = new TwentyFormInstallHandler();
+    await expect(handler.validateConfig(WSID, validForm())).rejects.toThrow(
+      /upsert returned no id/,
+    );
+  });
+});

--- a/packages/api/src/lib/integrations/install/__tests__/webhook-form-handler.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/webhook-form-handler.test.ts
@@ -65,7 +65,17 @@ function validForm(overrides: Partial<Record<string, unknown>> = {}): Record<str
 beforeEach(() => {
   setKeys("v1:test-key-for-webhook-handler-unit-tests-must-be-long-enough");
   mockInternalQuery.mockClear();
-  mockInternalQuery.mockImplementation(() => Promise.resolve([]));
+  // Echo the candidate id back on `RETURNING id` so the happy path
+  // sees the row Postgres is guaranteed to emit. The previous `[]`
+  // default leaned on the now-removed candidateId fallback (#2808);
+  // an empty rowset is exclusively the fail-loud anomaly path below.
+  mockInternalQuery.mockImplementation(async (sql: string, params?: unknown[]) => {
+    if (sql.includes("RETURNING id")) {
+      const id = (params?.[0] as string | undefined) ?? "unknown";
+      return [{ id }];
+    }
+    return [];
+  });
 });
 
 afterEach(() => {
@@ -212,6 +222,33 @@ describe("WebhookFormInstallHandler.validateConfig — persistence", () => {
     const handler = new WebhookFormInstallHandler({ idGenerator: () => "fresh-id" });
     const result = await handler.validateConfig(WSID, validForm());
     expect(result.installRecord.id).toBe("preexisting-id");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// RETURNING-id invariant — fail loud when the upsert emits no row (#2808)
+// ---------------------------------------------------------------------------
+
+describe("WebhookFormInstallHandler.validateConfig — RETURNING invariant", () => {
+  it("throws when the upsert returns no row (driver/RLS/rewrite anomaly)", async () => {
+    // INSERT ... ON CONFLICT ... DO UPDATE RETURNING is guaranteed by
+    // Postgres to emit one row. If the mock returns [] (a structural
+    // anomaly), the handler must surface a 500 rather than silently
+    // fall back to candidateId — the fallback returned a WRONG id on
+    // the DO UPDATE path and corrupted downstream lookups.
+    mockInternalQuery.mockImplementation(async () => []);
+    const handler = new WebhookFormInstallHandler();
+    await expect(handler.validateConfig(WSID, validForm())).rejects.toThrow(
+      /upsert returned no id/,
+    );
+  });
+
+  it("throws when the returned id is an empty string", async () => {
+    mockInternalQuery.mockImplementation(async () => [{ id: "" }]);
+    const handler = new WebhookFormInstallHandler();
+    await expect(handler.validateConfig(WSID, validForm())).rejects.toThrow(
+      /upsert returned no id/,
+    );
   });
 });
 

--- a/packages/api/src/lib/integrations/install/email-form-handler.ts
+++ b/packages/api/src/lib/integrations/install/email-form-handler.ts
@@ -133,17 +133,23 @@ export class EmailFormInstallHandler implements FormBasedInstallHandler {
       );
       const returned = rows[0]?.id;
       if (typeof returned !== "string" || returned.length === 0) {
-        // A RETURNING that comes back empty is a DB driver bug; the
-        // candidate id is at least known-good, so fall through with
-        // a warn rather than throw.
-        log.warn(
+        // INSERT ... ON CONFLICT ... DO UPDATE RETURNING is guaranteed
+        // by Postgres to emit exactly one row on both paths. Reaching
+        // here means a structural anomaly (driver rewrite, RLS hiding
+        // the result, partial-index miss). Falling back to candidateId
+        // would silently return a WRONG id on the DO UPDATE path
+        // (persisted row keeps its existing id, not the candidate),
+        // and downstream lookups would create phantom updates. Fail
+        // loud so the operator sees the invariant break with a 500.
+        log.error(
           { workspaceId, candidateId },
-          "workspace_plugins upsert returned no id — falling back to candidate",
+          "workspace_plugins upsert returned no id — Postgres invariant violation",
         );
-        persistedId = candidateId;
-      } else {
-        persistedId = returned;
+        throw new Error(
+          "workspace_plugins upsert returned no id from RETURNING — likely a driver/RLS/query-rewrite anomaly",
+        );
       }
+      persistedId = returned;
     } catch (err) {
       log.error(
         { workspaceId, err: err instanceof Error ? err.message : String(err) },

--- a/packages/api/src/lib/integrations/install/linear-apikey-form-handler.ts
+++ b/packages/api/src/lib/integrations/install/linear-apikey-form-handler.ts
@@ -139,14 +139,23 @@ export class LinearApiKeyFormInstallHandler implements FormBasedInstallHandler {
       );
       const returned = rows[0]?.id;
       if (typeof returned !== "string" || returned.length === 0) {
-        log.warn(
+        // INSERT ... ON CONFLICT ... DO UPDATE RETURNING is guaranteed
+        // by Postgres to emit exactly one row on both paths. Reaching
+        // here means a structural anomaly (driver rewrite, RLS hiding
+        // the result, partial-index miss). Falling back to candidateId
+        // would silently return a WRONG id on the DO UPDATE path
+        // (persisted row keeps its existing id, not the candidate),
+        // and downstream lookups would create phantom updates. Fail
+        // loud so the operator sees the invariant break with a 500.
+        log.error(
           { workspaceId, candidateId },
-          "workspace_plugins upsert returned no id — falling back to candidate",
+          "workspace_plugins upsert returned no id — Postgres invariant violation",
         );
-        persistedId = candidateId;
-      } else {
-        persistedId = returned;
+        throw new Error(
+          "workspace_plugins upsert returned no id from RETURNING — likely a driver/RLS/query-rewrite anomaly",
+        );
       }
+      persistedId = returned;
     } catch (err) {
       log.error(
         { workspaceId, err: err instanceof Error ? err.message : String(err) },

--- a/packages/api/src/lib/integrations/install/obsidian-form-handler.ts
+++ b/packages/api/src/lib/integrations/install/obsidian-form-handler.ts
@@ -137,14 +137,23 @@ export class ObsidianFormInstallHandler implements FormBasedInstallHandler {
       );
       const returned = rows[0]?.id;
       if (typeof returned !== "string" || returned.length === 0) {
-        log.warn(
+        // INSERT ... ON CONFLICT ... DO UPDATE RETURNING is guaranteed
+        // by Postgres to emit exactly one row on both paths. Reaching
+        // here means a structural anomaly (driver rewrite, RLS hiding
+        // the result, partial-index miss). Falling back to candidateId
+        // would silently return a WRONG id on the DO UPDATE path
+        // (persisted row keeps its existing id, not the candidate),
+        // and downstream lookups would create phantom updates. Fail
+        // loud so the operator sees the invariant break with a 500.
+        log.error(
           { workspaceId, candidateId },
-          "workspace_plugins upsert returned no id — falling back to candidate",
+          "workspace_plugins upsert returned no id — Postgres invariant violation",
         );
-        persistedId = candidateId;
-      } else {
-        persistedId = returned;
+        throw new Error(
+          "workspace_plugins upsert returned no id from RETURNING — likely a driver/RLS/query-rewrite anomaly",
+        );
       }
+      persistedId = returned;
     } catch (err) {
       log.error(
         { workspaceId, err: err instanceof Error ? err.message : String(err) },

--- a/packages/api/src/lib/integrations/install/twenty-form-handler.ts
+++ b/packages/api/src/lib/integrations/install/twenty-form-handler.ts
@@ -197,14 +197,23 @@ export class TwentyFormInstallHandler implements FormBasedInstallHandler {
       );
       const returned = rows[0]?.id;
       if (typeof returned !== "string" || returned.length === 0) {
-        log.warn(
+        // INSERT ... ON CONFLICT ... DO UPDATE RETURNING is guaranteed
+        // by Postgres to emit exactly one row on both paths. Reaching
+        // here means a structural anomaly (driver rewrite, RLS hiding
+        // the result, partial-index miss). Falling back to candidateId
+        // would silently return a WRONG id on the DO UPDATE path
+        // (persisted row keeps its existing id, not the candidate),
+        // and downstream lookups would create phantom updates. Fail
+        // loud so the operator sees the invariant break with a 500.
+        log.error(
           { workspaceId, candidateId },
-          "workspace_plugins upsert returned no id — falling back to candidate",
+          "workspace_plugins upsert returned no id — Postgres invariant violation",
         );
-        persistedId = candidateId;
-      } else {
-        persistedId = returned;
+        throw new Error(
+          "workspace_plugins upsert returned no id from RETURNING — likely a driver/RLS/query-rewrite anomaly",
+        );
       }
+      persistedId = returned;
     } catch (err) {
       log.error(
         { workspaceId, err: err instanceof Error ? err.message : String(err) },

--- a/packages/api/src/lib/integrations/install/webhook-form-handler.ts
+++ b/packages/api/src/lib/integrations/install/webhook-form-handler.ts
@@ -152,14 +152,23 @@ export class WebhookFormInstallHandler implements FormBasedInstallHandler {
       );
       const returned = rows[0]?.id;
       if (typeof returned !== "string" || returned.length === 0) {
-        log.warn(
+        // INSERT ... ON CONFLICT ... DO UPDATE RETURNING is guaranteed
+        // by Postgres to emit exactly one row on both paths. Reaching
+        // here means a structural anomaly (driver rewrite, RLS hiding
+        // the result, partial-index miss). Falling back to candidateId
+        // would silently return a WRONG id on the DO UPDATE path
+        // (persisted row keeps its existing id, not the candidate),
+        // and downstream lookups would create phantom updates. Fail
+        // loud so the operator sees the invariant break with a 500.
+        log.error(
           { workspaceId, candidateId },
-          "workspace_plugins upsert returned no id — falling back to candidate",
+          "workspace_plugins upsert returned no id — Postgres invariant violation",
         );
-        persistedId = candidateId;
-      } else {
-        persistedId = returned;
+        throw new Error(
+          "workspace_plugins upsert returned no id from RETURNING — likely a driver/RLS/query-rewrite anomaly",
+        );
       }
+      persistedId = returned;
     } catch (err) {
       log.error(
         { workspaceId, err: err instanceof Error ? err.message : String(err) },


### PR DESCRIPTION
## Summary

- The form-based install handlers wrapped their `INSERT … ON CONFLICT … DO UPDATE RETURNING id` upsert with a fallback that, on an empty rowset, logged a `warn` and returned `candidateId`. On the **DO UPDATE** path that returns the **wrong id** (the persisted row keeps its existing id, not the freshly-generated candidate) — yet still emitted `200` + `credentialWritten: true`. That's a silent corruption: downstream lookups key off a phantom id.
- Postgres guarantees `INSERT … ON CONFLICT … DO UPDATE RETURNING` emits exactly one row on **both** paths, so an empty RETURNING is a structural anomaly (driver rewrite / RLS hiding the result / partial-index miss). It must surface as a `500` (+ `requestId` via `classifyError`), not a wrong id.
- Replaces the fallback with `log.error` + `throw`, mirroring the already-fixed `github-pat-form-handler.ts` (#2807) exactly.

## Scope

Applies to the **4 handlers named in #2808** — `email`, `linear-apikey`, `obsidian`, `webhook` — **plus `twenty-form-handler.ts`**, which shipped the byte-identical fallback in the 1.6.0 CRM milestone *after* #2808 was filed (so the issue's "4 remaining" count was stale; this PR closes the whole class). `github-pat` was already fixed in #2807 and is untouched (used here as the reference shape + an unmodified test control).

## Test plan

- [x] Each of the 5 handlers gains a `RETURNING invariant` regression test: empty rowset **and** empty-string id both assert the handler throws (`/upsert returned no id/`) rather than returning a wrong id.
- [x] The `email` / `obsidian` / `webhook` test `beforeEach` defaults previously echoed `[]`, which leaned on the now-removed fallback to fake a successful upsert. They now echo the candidate id (matching `github-pat` / `linear-apikey`), so the happy path exercises the real RETURNING row and `[]` is reserved for the fail-loud anomaly tests. `twenty` already used the echo default (no change needed there).
- [x] `bun test` on all 6 handler test files: **77 pass, 0 fail**.
- [x] `/ci` — lint, type, full `bun run test`, syncpack, template-drift, security-headers, railway-watch, schema-drift, oauth-helper, test-discipline, twenty-resolver, published-symbols — all pass.

## Acceptance (#2808)

- [x] All handlers `log.error` + `throw` on empty RETURNING instead of falling back to `candidateId`
- [x] Each handler has a regression test for the empty-rowset path
- [x] No handler returns `200` / `credentialWritten` on the anomaly path

Closes #2808

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/2960"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782606768&installation_id=135337507&pr_number=2960&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F2960&signature=570d6af00234045c4a9d372a43da6ab1119fce58a7185598196326b9d186aa17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->