### PR TITLE
test(auth): pin Better Auth databaseHooks/organizationHooks wiring (#2841)

### DIFF
--- a/packages/api/src/lib/auth/__tests__/databaseHooks-wiring.test.ts
+++ b/packages/api/src/lib/auth/__tests__/databaseHooks-wiring.test.ts
@@ -2,9 +2,9 @@
  * Wiring test for Better Auth's signup-time hooks (#2841).
  *
  * ── The risk this closes ────────────────────────────────────────────
- * Three helpers run from Better Auth plugin hooks at signup, each with
- * thorough unit coverage in isolation but — until this file — NO test
- * proving the composition actually attaches them:
+ * Five signup-time side effects run from two Better Auth plugin hooks,
+ * each with thorough unit coverage in isolation but — until this file —
+ * NO test proving the composition actually attaches them:
  *
  *   • organizationHooks.afterCreateOrganization (in `buildPlugins`)
  *       → promoteOrgOwnerToAdmin, assignSaasTrial
@@ -27,13 +27,15 @@
  * no welcome email, no SSO auto-join).
  *
  * ── Why we assert via downstream effects, not helper spies ───────────
- * The five helpers are defined *inside* `server.ts`, so the hook bodies
- * call them through lexical bindings (`await promoteOrgOwnerToAdmin(...)`)
- * rather than through the module's export object. `mock.module("../server")`
- * cannot intercept an intra-module call — and mocking the module under
- * test would defeat the point. So instead of spying the helpers, we drive
- * the *real, composed* hook and assert each helper's unique observable
- * side effect:
+ * Four of these are named helpers defined *inside* `server.ts`, called
+ * from the hook bodies through lexical bindings
+ * (`await promoteOrgOwnerToAdmin(...)`) rather than through the module's
+ * export object; the fifth (the welcome email) is an inline deferred block
+ * in the hook that dynamically imports `onUserSignup`.
+ * `mock.module("../server")` cannot intercept an intra-module call — and
+ * mocking the module under test would defeat the point. So instead of
+ * spying the helpers, we drive the *real, composed* hook and assert each
+ * one's unique observable side effect:
  *
  *   promoteOrgOwnerToAdmin → UPDATE "user" SET role = 'admin'
  *   assignSaasTrial        → UPDATE organization SET plan_tier = 'trial'
@@ -210,19 +212,23 @@ afterAll(() => {
 
 describe("organizationHooks.afterCreateOrganization wiring", () => {
   /**
-   * Reach the hook through the *composed* organization plugin instance —
-   * Better Auth 1.6.x exposes the passed options under `.options` (the
-   * same probe `server.test.ts` uses for `requireEmailVerificationOnInvitation`).
-   * Reading it here (rather than from an extracted helper) is what proves
-   * the `organizationHooks:` wiring is actually attached to the plugin.
+   * Reach the hook through the *composed* organization plugin instance.
+   * Better Auth stores the passed options on the constructed plugin under
+   * `.options` (1.6.x); older lines shipped them under `._config`. We probe
+   * both — the same defensive lookup `server.test.ts` uses for
+   * `requireEmailVerificationOnInvitation` — so a future Better Auth bump
+   * surfaces as a clear "hook not wired" failure rather than a confusing
+   * `undefined`. Reading it here (rather than from an extracted helper) is
+   * what proves the `organizationHooks:` wiring is attached to the plugin.
    */
   function getAfterCreateOrganization() {
     const plugins = buildPlugins();
     const org = plugins.find((p: { id?: string }) => p.id === "organization");
     expect(org, "organization plugin must be present in buildPlugins() output").toBeDefined();
-    const opts = (org as {
-      options?: { organizationHooks?: { afterCreateOrganization?: unknown } };
-    }).options;
+    type OrgOptions = { organizationHooks?: { afterCreateOrganization?: unknown } };
+    const opts =
+      (org as { options?: OrgOptions }).options
+      ?? (org as { _config?: OrgOptions })._config;
     const hook = opts?.organizationHooks?.afterCreateOrganization;
     expect(
       typeof hook,
@@ -239,24 +245,32 @@ describe("organizationHooks.afterCreateOrganization wiring", () => {
     const sqls = queries.map((q) => q.sql);
 
     // promoteOrgOwnerToAdmin: SELECT current role, then promote to admin.
+    // The UPDATE assertion binds to THIS hook's user id (not just "some
+    // role UPDATE fired") so a future code path emitting the same SQL shape
+    // for a different entity can't satisfy it — the canary stays specific.
     expect(
       sqls.some((s) => /SELECT\s+role\s+FROM\s+"user"/i.test(s)),
       "promoteOrgOwnerToAdmin should read the current role",
     ).toBe(true);
+    const roleUpdate = queries.find((q) => /UPDATE\s+"user"\s+SET\s+role\s*=\s*'admin'/i.test(q.sql));
     expect(
-      sqls.some((s) => /UPDATE\s+"user"\s+SET\s+role\s*=\s*'admin'/i.test(s)),
-      "promoteOrgOwnerToAdmin must be wired — expected the role-promotion UPDATE",
-    ).toBe(true);
+      roleUpdate?.params,
+      "promoteOrgOwnerToAdmin must be wired — expected the role-promotion UPDATE bound to the org owner's id",
+    ).toContain("user_org_1");
 
-    // assignSaasTrial: SELECT current tier, then flip free → trial.
+    // assignSaasTrial: SELECT current tier, then flip free → trial, bound
+    // to THIS hook's org id.
     expect(
       sqls.some((s) => /SELECT\s+plan_tier\s+FROM\s+organization/i.test(s)),
       "assignSaasTrial should read the current plan tier",
     ).toBe(true);
+    const trialUpdate = queries.find((q) =>
+      /UPDATE\s+organization\s+SET\s+plan_tier\s*=\s*'trial'/i.test(q.sql),
+    );
     expect(
-      sqls.some((s) => /UPDATE\s+organization\s+SET\s+plan_tier\s*=\s*'trial'/i.test(s)),
-      "assignSaasTrial must be wired — expected the trial-assignment UPDATE",
-    ).toBe(true);
+      trialUpdate?.params,
+      "assignSaasTrial must be wired — expected the trial-assignment UPDATE bound to the new org's id",
+    ).toContain("org_1");
   });
 });
 

--- a/packages/api/src/lib/auth/__tests__/databaseHooks-wiring.test.ts
+++ b/packages/api/src/lib/auth/__tests__/databaseHooks-wiring.test.ts
@@ -1,0 +1,326 @@
+/**
+ * Wiring test for Better Auth's signup-time hooks (#2841).
+ *
+ * ── The risk this closes ────────────────────────────────────────────
+ * Three helpers run from Better Auth plugin hooks at signup, each with
+ * thorough unit coverage in isolation but — until this file — NO test
+ * proving the composition actually attaches them:
+ *
+ *   • organizationHooks.afterCreateOrganization (in `buildPlugins`)
+ *       → promoteOrgOwnerToAdmin, assignSaasTrial
+ *   • databaseHooks.user.create.after (in `buildAuthOptions`)
+ *       → dispatchSignupCrmLead, the deferred welcome-email path,
+ *         _autoProvisionSsoMember
+ *
+ * The per-helper test files (`org-owner-promotion.test.ts`,
+ * `assign-saas-trial.test.ts`, `dispatch-signup-crm-lead.test.ts`,
+ * `sso-provisioning.test.ts`) each self-document the gap: "Better Auth
+ * closes over its plugin options, so the wiring isn't introspectable" and
+ * "this cannot detect a refactor that removes the helper call from the
+ * hook." That is exactly the "well-tested logic + missing wiring
+ * assertion = silent prod regression" shape that bit the chat plugin four
+ * times (#2628 channelAllowed, #2630 botToken, #2676 orgId, #2680
+ * reaction-back key mismatch). A refactor that deletes the hook
+ * composition in `buildPlugins()` / `buildAuthOptions()` would pass every
+ * existing test yet break signup in prod (org owners stuck at
+ * role="member", SaaS workspaces stuck on plan_tier="free", no CRM lead,
+ * no welcome email, no SSO auto-join).
+ *
+ * ── Why we assert via downstream effects, not helper spies ───────────
+ * The five helpers are defined *inside* `server.ts`, so the hook bodies
+ * call them through lexical bindings (`await promoteOrgOwnerToAdmin(...)`)
+ * rather than through the module's export object. `mock.module("../server")`
+ * cannot intercept an intra-module call — and mocking the module under
+ * test would defeat the point. So instead of spying the helpers, we drive
+ * the *real, composed* hook and assert each helper's unique observable
+ * side effect:
+ *
+ *   promoteOrgOwnerToAdmin → UPDATE "user" SET role = 'admin'
+ *   assignSaasTrial        → UPDATE organization SET plan_tier = 'trial'
+ *   dispatchSignupCrmLead  → SaasCrm.upsertLead({ source: "signup" })
+ *   welcome-email path     → setTimeout(…, 2000) → onUserSignup(…)
+ *   _autoProvisionSsoMember→ SELECT … FROM sso_providers
+ *
+ * This is strictly stronger than a static shape check: it proves the hook
+ * is wired into the *actual composed config* (the organization plugin
+ * instance / the options object handed to `betterAuth()`), so deleting
+ * either the `organizationHooks:` wiring or any individual `await helper()`
+ * line trips a failure here. The DB seam uses `_resetPool` (real
+ * `db/internal`, injected recording pool) — the same seam the per-helper
+ * tests use — so we don't have to enumerate that module's large export
+ * surface. The enterprise / email / CRM collaborators are `mock.module`'d
+ * with all named exports per CLAUDE.md.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, afterAll, mock } from "bun:test";
+import { Effect, Layer } from "effect";
+import { _resetPool, type InternalPool } from "@atlas/api/lib/db/internal";
+import { _setConfigForTest, type ResolvedConfig } from "@atlas/api/lib/config";
+import {
+  SaasCrm,
+  type SaasCrmLeadInput,
+  type SaasCrmShape,
+} from "@atlas/api/lib/effect/services";
+
+// ── Mock state (controlled per-test) ────────────────────────────────
+
+let runEnterpriseImpl: (p: unknown) => Promise<unknown> = async () => undefined;
+const upsertLeadCalls: SaasCrmLeadInput[] = [];
+const onUserSignupCalls: Array<{ userId: string; email: string; orgId: string }> = [];
+
+// _autoProvisionSsoMember early-returns unless enterprise is enabled —
+// force it on so the hook reaches its `sso_providers` SELECT.
+mock.module("@atlas/api/lib/effect/enterprise-config", () => ({
+  isEnterpriseEnabled: () => true,
+}));
+
+// dispatchSignupCrmLead runs its program through `runEnterprise`. Capture
+// it and resolve the `SaasCrm` Tag through a recording double. All named
+// exports mocked (CLAUDE.md) — a partial mock surfaces as a cross-file
+// SyntaxError under bun's `--parallel` workers (slice 6 / #2802).
+mock.module("@atlas/api/lib/effect/enterprise-layer", () => ({
+  runEnterprise: (p: unknown) => runEnterpriseImpl(p),
+  getEnterpriseRuntime: () => ({
+    runPromise: <A, E>(p: Effect.Effect<A, E, never>) => Effect.runPromise(p),
+  }),
+  EnterpriseLayer: Layer.empty,
+}));
+
+// The welcome-email path dynamically imports this module inside its
+// deferred setTimeout callback. Record onUserSignup; stub the rest.
+mock.module("@atlas/api/lib/email/hooks", () => ({
+  onUserSignup: (u: { userId: string; email: string; orgId: string }) => {
+    onUserSignupCalls.push(u);
+  },
+  onDatabaseConnected: () => {},
+  onFirstQueryExecuted: () => {},
+  onTeamMemberInvited: () => {},
+  onFeatureExplored: () => {},
+}));
+
+// ── Import the module under test AFTER mocks ────────────────────────
+
+const { buildPlugins, buildAuthOptions, parseAuthSecret } = await import("../server");
+
+// ── Recording internal-DB pool ──────────────────────────────────────
+
+interface RecordedQuery {
+  sql: string;
+  params?: unknown[];
+}
+
+let queries: RecordedQuery[] = [];
+
+function rows(r: Array<Record<string, unknown>>) {
+  return { rows: r, rowCount: r.length };
+}
+
+/**
+ * A pool whose `query` records every call and returns canned rows keyed
+ * by SQL shape — just enough to drive each helper down its happy path so
+ * the wiring is observable. `sso_providers` returns empty so
+ * `_autoProvisionSsoMember` proves invocation (the SELECT fires) then
+ * stops before the member-limit / INSERT machinery.
+ */
+function makeRecordingPool(): InternalPool {
+  return {
+    query: async (sql: string, params?: unknown[]) => {
+      queries.push({ sql, params });
+      if (/SELECT\s+role\s+FROM\s+"user"/i.test(sql)) return rows([{ role: "member" }]);
+      if (/SELECT\s+plan_tier\s+FROM\s+organization/i.test(sql)) return rows([{ plan_tier: "free" }]);
+      if (/FROM\s+sso_providers/i.test(sql)) return rows([]);
+      if (/FROM\s+member/i.test(sql)) return rows([{ organizationId: "org_welcome" }]);
+      return rows([]);
+    },
+  } as unknown as InternalPool;
+}
+
+function recordingSaasCrmLayer(): Layer.Layer<SaasCrm> {
+  return Layer.succeed(SaasCrm, {
+    available: true,
+    upsertLead: (input: SaasCrmLeadInput) => {
+      upsertLeadCalls.push(input);
+      return Effect.void;
+    },
+  } as unknown as SaasCrmShape);
+}
+
+function saasConfig(): ResolvedConfig {
+  // SaaS deploy mode is the only branch where assignSaasTrial writes — see
+  // assign-saas-trial.test.ts for the same shape.
+  return {
+    datasources: {},
+    tools: ["explore", "executeSQL"],
+    auth: "managed",
+    semanticLayer: "./semantic",
+    maxTotalConnections: 100,
+    source: "file",
+    deployMode: "saas",
+  };
+}
+
+function authDeps(plugins: ReturnType<typeof buildPlugins>) {
+  return {
+    env: process.env,
+    secret: parseAuthSecret("test-secret-at-least-32-characters-long"),
+    baseURL: undefined,
+    // undefined → Better Auth's in-memory adapter. `hasInternalDB()` is
+    // driven at runtime by DATABASE_URL + the injected pool, not by this.
+    database: undefined,
+    cookieDomain: undefined,
+    socialProviders: undefined,
+    plugins,
+    trustedOrigins: ["https://app.useatlas.dev"],
+    bootstrapAdmin: { mode: "none" as const },
+  };
+}
+
+const ORIGINAL_DATABASE_URL = process.env.DATABASE_URL;
+
+beforeEach(() => {
+  queries = [];
+  upsertLeadCalls.length = 0;
+  onUserSignupCalls.length = 0;
+  // hasInternalDB() reads DATABASE_URL; getInternalDB()/internalQuery use
+  // the injected pool.
+  process.env.DATABASE_URL = "postgresql://test/test";
+  _resetPool(makeRecordingPool());
+  _setConfigForTest(saasConfig());
+  runEnterpriseImpl = async (program) => {
+    await Effect.runPromise(
+      Effect.provide(program as Effect.Effect<unknown, never, SaasCrm>, recordingSaasCrmLayer()),
+    );
+  };
+});
+
+afterEach(() => {
+  _resetPool(null);
+  _setConfigForTest(null);
+});
+
+afterAll(() => {
+  if (ORIGINAL_DATABASE_URL === undefined) {
+    delete process.env.DATABASE_URL;
+  } else {
+    process.env.DATABASE_URL = ORIGINAL_DATABASE_URL;
+  }
+});
+
+// ── organizationHooks.afterCreateOrganization ───────────────────────
+
+describe("organizationHooks.afterCreateOrganization wiring", () => {
+  /**
+   * Reach the hook through the *composed* organization plugin instance —
+   * Better Auth 1.6.x exposes the passed options under `.options` (the
+   * same probe `server.test.ts` uses for `requireEmailVerificationOnInvitation`).
+   * Reading it here (rather than from an extracted helper) is what proves
+   * the `organizationHooks:` wiring is actually attached to the plugin.
+   */
+  function getAfterCreateOrganization() {
+    const plugins = buildPlugins();
+    const org = plugins.find((p: { id?: string }) => p.id === "organization");
+    expect(org, "organization plugin must be present in buildPlugins() output").toBeDefined();
+    const opts = (org as {
+      options?: { organizationHooks?: { afterCreateOrganization?: unknown } };
+    }).options;
+    const hook = opts?.organizationHooks?.afterCreateOrganization;
+    expect(
+      typeof hook,
+      "afterCreateOrganization must be wired into the organization plugin's organizationHooks",
+    ).toBe("function");
+    return hook as (args: { user: { id: string }; organization: { id: string } }) => Promise<void>;
+  }
+
+  it("invokes promoteOrgOwnerToAdmin AND assignSaasTrial", async () => {
+    const afterCreateOrganization = getAfterCreateOrganization();
+
+    await afterCreateOrganization({ user: { id: "user_org_1" }, organization: { id: "org_1" } });
+
+    const sqls = queries.map((q) => q.sql);
+
+    // promoteOrgOwnerToAdmin: SELECT current role, then promote to admin.
+    expect(
+      sqls.some((s) => /SELECT\s+role\s+FROM\s+"user"/i.test(s)),
+      "promoteOrgOwnerToAdmin should read the current role",
+    ).toBe(true);
+    expect(
+      sqls.some((s) => /UPDATE\s+"user"\s+SET\s+role\s*=\s*'admin'/i.test(s)),
+      "promoteOrgOwnerToAdmin must be wired — expected the role-promotion UPDATE",
+    ).toBe(true);
+
+    // assignSaasTrial: SELECT current tier, then flip free → trial.
+    expect(
+      sqls.some((s) => /SELECT\s+plan_tier\s+FROM\s+organization/i.test(s)),
+      "assignSaasTrial should read the current plan tier",
+    ).toBe(true);
+    expect(
+      sqls.some((s) => /UPDATE\s+organization\s+SET\s+plan_tier\s*=\s*'trial'/i.test(s)),
+      "assignSaasTrial must be wired — expected the trial-assignment UPDATE",
+    ).toBe(true);
+  });
+});
+
+// ── databaseHooks.user.create.after ─────────────────────────────────
+
+describe("databaseHooks.user.create.after wiring", () => {
+  function getUserCreateAfter() {
+    const options = buildAuthOptions(authDeps(buildPlugins()));
+    const hook = (options as {
+      databaseHooks?: { user?: { create?: { after?: unknown } } };
+    }).databaseHooks?.user?.create?.after;
+    expect(
+      typeof hook,
+      "user.create.after must be composed in buildAuthOptions",
+    ).toBe("function");
+    return hook as (user: { id: string; email: string; name?: string }) => Promise<void>;
+  }
+
+  it("invokes dispatchSignupCrmLead, the welcome-email path, and _autoProvisionSsoMember", async () => {
+    const userCreateAfter = getUserCreateAfter();
+
+    // The welcome-email path is deferred via setTimeout(…, 2000). Capture
+    // the scheduled callback instead of waiting (or flaking) on real time.
+    const realSetTimeout = globalThis.setTimeout;
+    let scheduledDelay: number | undefined;
+    let scheduledCb: (() => unknown) | undefined;
+    globalThis.setTimeout = ((cb: () => unknown, ms?: number) => {
+      scheduledCb = cb;
+      scheduledDelay = ms;
+      return 0 as unknown as ReturnType<typeof setTimeout>;
+    }) as unknown as typeof globalThis.setTimeout;
+
+    try {
+      await userCreateAfter({ id: "user_db_1", email: "newuser@acme.com", name: "New User" });
+    } finally {
+      globalThis.setTimeout = realSetTimeout;
+    }
+
+    // dispatchSignupCrmLead → SaasCrm.upsertLead with a signup-sourced lead.
+    expect(
+      upsertLeadCalls,
+      "dispatchSignupCrmLead must be wired — expected one SaasCrm.upsertLead call",
+    ).toHaveLength(1);
+    expect(upsertLeadCalls[0]).toMatchObject({ source: "signup", email: "newuser@acme.com" });
+
+    // _autoProvisionSsoMember → SELECT … FROM sso_providers (domain lookup).
+    expect(
+      queries.some((q) => /FROM\s+sso_providers/i.test(q.sql)),
+      "_autoProvisionSsoMember must be wired — expected the sso_providers lookup",
+    ).toBe(true);
+
+    // welcome-email path: scheduled at 2000ms; running the callback reaches
+    // onUserSignup with the org id resolved from the membership lookup.
+    expect(scheduledDelay, "welcome email must be deferred via setTimeout(…, 2000)").toBe(2000);
+    expect(typeof scheduledCb).toBe("function");
+    await scheduledCb?.();
+    expect(
+      onUserSignupCalls,
+      "welcome-email path must be wired — expected one onUserSignup call",
+    ).toHaveLength(1);
+    expect(onUserSignupCalls[0]).toMatchObject({
+      userId: "user_db_1",
+      email: "newuser@acme.com",
+      orgId: "org_welcome",
+    });
+  });
+});


### PR DESCRIPTION
Closes #2841.

## What

Adds a single wiring test — `packages/api/src/lib/auth/__tests__/databaseHooks-wiring.test.ts` — that proves Better Auth's signup-time hooks actually invoke their named helpers. **Additive test only; no source changes.**

## Why

Three helpers run from Better Auth plugin hooks at signup, each unit-tested in isolation but with **no test proving the composition attaches them**:

- `organizationHooks.afterCreateOrganization` (`server.ts`, via `buildPlugins`) → `promoteOrgOwnerToAdmin`, `assignSaasTrial`
- `databaseHooks.user.create.after` (`server.ts`, via `buildAuthOptions`) → `dispatchSignupCrmLead`, the deferred welcome-email path, `_autoProvisionSsoMember`

The per-helper test files self-document the gap ("Better Auth closes over its plugin options, so the wiring isn't introspectable"). A refactor that deletes a hook composition would pass every existing test yet break signup in prod (org owners stuck at `role="member"`, SaaS workspaces stuck on `plan_tier="free"`, no CRM lead, no welcome email, no SSO auto-join) — the same *well-tested-logic + missing-wiring-assertion = silent prod regression* shape that bit the chat plugin four times (#2628 / #2630 / #2676 / #2680).

## How

The test drives the **real, composed** hooks and asserts each helper's unique observable side effect — strictly stronger than a static shape check, because reading through the composed config proves the hook is actually attached:

- **organizationHooks** reached via the composed `organization` plugin's `.options` (Better Auth 1.6.x exposes passed options there — same probe `server.test.ts` already uses).
- **databaseHooks** reached via `buildAuthOptions(...)`'s returned `options.databaseHooks.user.create.after`.
- The five helpers are intra-module to `server.ts`, so they can't be spied via `mock.module` (a lexical call isn't a property access). Instead we assert downstream effects:
  - `promoteOrgOwnerToAdmin` → `UPDATE "user" SET role = 'admin'`
  - `assignSaasTrial` → `UPDATE organization SET plan_tier = 'trial'`
  - `dispatchSignupCrmLead` → `SaasCrm.upsertLead({ source: "signup" })`
  - welcome-email path → `setTimeout(…, 2000)` → `onUserSignup(…)` (captured, not waited on)
  - `_autoProvisionSsoMember` → `SELECT … FROM sso_providers`
- DB seam uses `_resetPool` (real `db/internal` + injected recording pool — same seam the per-helper tests use, avoids enumerating that module's large export surface). Enterprise / email / CRM collaborators use `mock.module` with all named exports per CLAUDE.md.

## Verification

- Five **negative-control mutations** run locally: deleting each helper call fails *its* test while the other stays green — confirming the test is a genuine wiring guard, not a tautology.
- `/ci` — lint, type, full test, syncpack, template-drift, security-headers, railway-watch, schema-drift, oauth-helper-drift, test-discipline, twenty-resolver, published-symbols — **all pass**.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/2961"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782607549&installation_id=135337507&pr_number=2961&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F2961&signature=cdca0b1e616d5bd075485d68cea479a93d575958911b63136e1402e831eb9f57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->