### PR TITLE
fix(2943): recalibrate SaaS pool boot log — CRITICAL only when perOrg unset

### DIFF
--- a/packages/api/src/lib/__tests__/config-pool-defaults-warning.test.ts
+++ b/packages/api/src/lib/__tests__/config-pool-defaults-warning.test.ts
@@ -1,17 +1,20 @@
 /**
- * Tests for the inlined #1983 SaaS pool-defaults boot warning.
+ * Tests for the SaaS pool-sizing boot log (#1983, recalibrated by #2943).
  *
- * The warning lives in `applyDeployMode()` in `lib/config.ts`, alongside
- * the #1978 deploy-mode silent-downgrade warning. It fires when:
+ * The log lives in `applyDeployMode()` in `lib/config.ts`, alongside the
+ * #1978 deploy-mode silent-downgrade warning. Severity depends on intent:
  *
- *   - resolved deployMode === "saas", AND
- *   - either no `pool.perOrg` block is configured (env-var deploy with
- *     no per-org pool isolation), OR `pool.perOrg.maxConnections` is
- *     at the dev-tier floor (10).
+ *   - resolved deployMode === "saas" AND no `pool.perOrg` block → CRITICAL
+ *     `error` (the genuine forgot-to-size mistake; isolation is off).
+ *   - resolved deployMode === "saas" AND `pool.perOrg` explicitly set →
+ *     INFO, regardless of `maxConnections` value (an explicit value is an
+ *     intentional sizing decision, not a misconfiguration — #2943 stopped
+ *     this from firing CRITICAL on every boot of the deliberately-sized
+ *     prod config).
+ *   - self-hosted → silent (no log at all).
  *
- * Self-hosted is silent regardless. The warning carries the `#1983`
- * marker + `pool-defaults` label so an operator can grep boot logs and
- * find the contract.
+ * The CRITICAL carries `#1983` + `reason: "pool-defaults"`; the INFO
+ * carries `#2943` + `reason: "pool-sizing"` so operators can grep either.
  *
  * Spy is installed via `mock.module("@atlas/api/lib/logger", ...)`
  * before the dynamic `await import("../config")`.
@@ -65,6 +68,16 @@ function findPoolWarning() {
   return logCalls
     .filter((c) => c.level === "error")
     .find((c) => c.message.includes("CRITICAL") && c.message.includes("#1983"));
+}
+
+/**
+ * Find the INFO pool-sizing emission (the #2943 explicit-config path).
+ * Returns undefined if absent.
+ */
+function findPoolInfo() {
+  return logCalls
+    .filter((c) => c.level === "info")
+    .find((c) => (c.payload as Record<string, unknown> | undefined)?.reason === "pool-sizing");
 }
 
 describe("applyDeployMode: pool-defaults SaaS warning (#1983)", () => {
@@ -142,12 +155,16 @@ describe("warnPoolDefaultsInSaaS (#1983) — direct helper unit test", () => {
     const warning = findPoolWarning();
     expect(warning).toBeDefined();
     expect((warning!.payload as Record<string, unknown>).reason).toBe("pool-defaults");
-    // The "no per-org config" sub-state should be visible in the payload
-    // so an operator can disambiguate from the "at-floor" sub-state.
+    // The unset case is the only CRITICAL path — `perOrgConfigured: false`
+    // distinguishes it from the explicit-config INFO path.
     expect((warning!.payload as Record<string, unknown>).perOrgConfigured).toBe(false);
+    // And it must NOT also emit the explicit-config INFO.
+    expect(findPoolInfo()).toBeUndefined();
   });
 
-  it("emits CRITICAL when SaaS + pool.perOrg.maxConnections at the dev floor", async () => {
+  it("emits INFO (not CRITICAL) when SaaS + pool.perOrg explicitly sized at the realistic prod value (5)", async () => {
+    // This is the exact deploy/api/atlas.config.ts shape — the #2943
+    // regression was that an intentional 5 fired a permanent CRITICAL.
     const { _warnPoolDefaultsInSaaS } = await import("../config");
     _warnPoolDefaultsInSaaS({
       deployMode: "saas",
@@ -158,7 +175,7 @@ describe("warnPoolDefaultsInSaaS (#1983) — direct helper unit test", () => {
       maxTotalConnections: 100,
       pool: {
         perOrg: {
-          maxConnections: 10,
+          maxConnections: 5,
           idleTimeoutMs: 30000,
           maxOrgs: 50,
           warmupProbes: 2,
@@ -168,13 +185,16 @@ describe("warnPoolDefaultsInSaaS (#1983) — direct helper unit test", () => {
       source: "file",
     });
 
-    const warning = findPoolWarning();
-    expect(warning).toBeDefined();
-    expect((warning!.payload as Record<string, unknown>).perOrgConfigured).toBe(true);
-    expect((warning!.payload as Record<string, unknown>).maxConnections).toBe(10);
+    // No CRITICAL — an explicit value is an intentional sizing decision.
+    expect(findPoolWarning()).toBeUndefined();
+    // An INFO log surfaces the sizing for visibility.
+    const info = findPoolInfo();
+    expect(info).toBeDefined();
+    expect((info!.payload as Record<string, unknown>).perOrgConfigured).toBe(true);
+    expect((info!.payload as Record<string, unknown>).maxConnections).toBe(5);
   });
 
-  it("does NOT emit when SaaS + pool.perOrg.maxConnections above dev floor", async () => {
+  it("emits INFO (not CRITICAL) when SaaS + pool.perOrg explicitly sized higher (50)", async () => {
     const { _warnPoolDefaultsInSaaS } = await import("../config");
     _warnPoolDefaultsInSaaS({
       deployMode: "saas",
@@ -196,9 +216,10 @@ describe("warnPoolDefaultsInSaaS (#1983) — direct helper unit test", () => {
     });
 
     expect(findPoolWarning()).toBeUndefined();
+    expect((findPoolInfo()!.payload as Record<string, unknown>).maxConnections).toBe(50);
   });
 
-  it("does NOT emit when self-hosted regardless of pool config", async () => {
+  it("emits nothing (neither CRITICAL nor INFO) when self-hosted regardless of pool config", async () => {
     const { _warnPoolDefaultsInSaaS } = await import("../config");
     _warnPoolDefaultsInSaaS({
       deployMode: "self-hosted",
@@ -212,5 +233,6 @@ describe("warnPoolDefaultsInSaaS (#1983) — direct helper unit test", () => {
     });
 
     expect(findPoolWarning()).toBeUndefined();
+    expect(findPoolInfo()).toBeUndefined();
   });
 });

--- a/packages/api/src/lib/__tests__/config.test.ts
+++ b/packages/api/src/lib/__tests__/config.test.ts
@@ -690,11 +690,12 @@ describe("pool.perOrg validation", () => {
       datasources: { default: { url: "postgresql://host/db" } },
       pool: { perOrg: {} },
     });
-    // #1983 — dev floor bumped 5 → 10 so a single Business-tier org's
-    // dashboards + chat + scheduled tasks don't immediately queue. The
-    // companion `_warnPoolDefaultsInSaaS()` boot warning fires when a
-    // SaaS deploy is at this floor.
-    expect(resolved.pool!.perOrg!.maxConnections).toBe(10);
+    // #2943 — schema default realigned 10 → 5 to match the runtime
+    // registry default (DEFAULT_ORG_POOL_SETTINGS in db/connection.ts).
+    // Connections are borrowed per in-flight SQL statement, so 5 is ample
+    // for conversational load; the schema and registry defaults must agree
+    // so neither trips the other's expectations.
+    expect(resolved.pool!.perOrg!.maxConnections).toBe(5);
     expect(resolved.pool!.perOrg!.idleTimeoutMs).toBe(30000);
     expect(resolved.pool!.perOrg!.maxOrgs).toBe(50);
     expect(resolved.pool!.perOrg!.warmupProbes).toBe(2);

--- a/packages/api/src/lib/config.ts
+++ b/packages/api/src/lib/config.ts
@@ -208,24 +208,31 @@ const PythonConfigSchema = z.object({
 export type PythonConfig = z.infer<typeof PythonConfigSchema>;
 
 /**
- * The dev-tier floor for per-org pool `maxConnections`. The schema
- * default below uses this value, and `_warnPoolDefaultsInSaaS()` warns
- * when a SaaS deploy boots at or below it. Single source of truth so
- * a future bump (e.g. 10 → 15) doesn't drift the floor and the default
- * out of step. See `deploy.mdx` for the operator-facing tier sizing
- * reference (Dev / Team / Business / Enterprise).
+ * Default per-org pool `maxConnections` — the value the schema fills when
+ * a `pool.perOrg` block is present but omits `maxConnections`. Held in
+ * lockstep with `DEFAULT_ORG_POOL_SETTINGS.maxConnections` in
+ * `db/connection.ts` (the runtime registry default used when no
+ * `pool.perOrg` is configured at all) so the schema-resolved default and
+ * the registry default can't drift — they previously split 10 vs 5, which
+ * made an intentional `5` config trip a phantom "below floor" alarm (#2943).
+ *
+ * A connection is borrowed per in-flight SQL statement and released
+ * immediately (chat turns hold zero during LLM thinking; dashboard refresh
+ * is sequential), so 5 simultaneous statements per org is ample for
+ * conversational load. Raise it (per tier) only once pool-wait latency
+ * actually shows up in metrics. See `deploy.mdx#pool-default-warning`.
  */
-const POOL_DEV_FLOOR_MAX_CONNECTIONS = 10;
+const DEFAULT_ORG_POOL_MAX_CONNECTIONS = 5;
 
 /**
- * Per-org pool sizing defaults. The dev floor is sized for trial /
- * evaluation workloads. Production SaaS regions should configure
- * higher limits via `atlas.config.ts`; the boot warning surfaces
- * deploys still on the floor.
+ * Per-org pool sizing defaults, sized for conversational load. Production
+ * SaaS regions can configure higher limits via `atlas.config.ts` if
+ * pool-wait latency appears; `_warnPoolDefaultsInSaaS()` only flags the
+ * genuine mistake of omitting `pool.perOrg` entirely (isolation off).
  */
 const OrgPoolConfigSchema = z.object({
   /** Max connections per pool per org. */
-  maxConnections: z.number().int().positive().default(POOL_DEV_FLOOR_MAX_CONNECTIONS),
+  maxConnections: z.number().int().positive().default(DEFAULT_ORG_POOL_MAX_CONNECTIONS),
   /** Idle timeout in ms for per-org pool connections. Default 30000. */
   idleTimeoutMs: z.number().int().positive().default(30000),
   /** Max org pool sets before LRU eviction. Default 50. */
@@ -1399,22 +1406,25 @@ async function applyDeployMode(
 }
 
 /**
- * Boot-time CRITICAL log when a SaaS deploy is running on dev-tier pool
- * defaults. Two emission paths:
+ * Boot-time pool-sizing log for SaaS deploys. Two emission paths,
+ * deliberately at different severities (#2943):
  *
- *   1. `pool.perOrg` is undefined — operator never opted into per-org
- *      pooling; SaaS noisy-neighbor isolation is off.
- *   2. `pool.perOrg.maxConnections <= POOL_DEV_FLOOR_MAX_CONNECTIONS`
- *      — at or below the dev floor; a single Business-tier org will
- *      queue on concurrent dashboards + chat + scheduled tasks. The
- *      `<=` (not `<`) is deliberate: the floor is the trial-tier
- *      *default*, not a "safe" value — an operator who explicitly
- *      sets the floor in a SaaS region is still misconfigured and
- *      should see the warning.
+ *   1. `pool.perOrg` is undefined → **CRITICAL**. The operator never
+ *      opted into per-org pooling, so SaaS noisy-neighbor isolation is
+ *      off and a single tenant can starve every other org's connections.
+ *      This is the genuine forgot-to-size mistake worth alerting on.
+ *   2. `pool.perOrg` is explicitly configured → **INFO**, regardless of
+ *      the value. An explicit `maxConnections` is an intentional sizing
+ *      decision, not a misconfiguration — a connection is borrowed per
+ *      in-flight SQL statement and released immediately, so a small value
+ *      is ample for conversational load. Flagging it CRITICAL was alert
+ *      fatigue (it fired on every boot of the deliberately-sized prod
+ *      config). If the value is genuinely too low, pool-wait latency will
+ *      surface in metrics (now exported via #2940) — raise it then.
  *
  * Self-hosted is silent (returns early) — every AGPL operator is
- * presumptively at trial / evaluation scale where the dev floor is
- * intentional.
+ * presumptively at trial / evaluation scale where per-org pooling is
+ * optional.
  *
  * Exported because the `loadConfig()` e2e path can't easily reach the
  * SaaS-resolved branch in tests (no `@atlas/ee` build).
@@ -1431,29 +1441,26 @@ export function _warnPoolDefaultsInSaaS(resolved: ResolvedConfig): void {
       {
         reason: "pool-defaults",
         perOrgConfigured: false,
-        devFloor: POOL_DEV_FLOOR_MAX_CONNECTIONS,
       },
       `CRITICAL: SaaS deploy booted without pool.perOrg configured — per-org pool isolation is off, ` +
         `so a single noisy tenant can starve every other org's connections. Add pool.perOrg in ` +
-        `atlas.config.ts with tier-appropriate sizing (see deploy.mdx#pool-default-warning). ` +
-        `See #1983.`,
+        `atlas.config.ts (see deploy.mdx#pool-default-warning). See #1983.`,
     );
     return;
   }
 
-  if (perOrg.maxConnections <= POOL_DEV_FLOOR_MAX_CONNECTIONS) {
-    log.error(
-      {
-        reason: "pool-defaults",
-        perOrgConfigured: true,
-        maxConnections: perOrg.maxConnections,
-        devFloor: POOL_DEV_FLOOR_MAX_CONNECTIONS,
-      },
-      `CRITICAL: SaaS deploy booted with pool.perOrg.maxConnections=${perOrg.maxConnections} — at or below ` +
-        `the dev-tier floor of ${POOL_DEV_FLOOR_MAX_CONNECTIONS}. A Business-tier org running concurrent dashboards + chat + ` +
-        `scheduled tasks will queue. See deploy.mdx#pool-default-warning for tier sizing. See #1983.`,
-    );
-  }
+  // Explicitly configured → intentional sizing. INFO, not CRITICAL.
+  log.info(
+    {
+      reason: "pool-sizing",
+      perOrgConfigured: true,
+      maxConnections: perOrg.maxConnections,
+      maxOrgs: perOrg.maxOrgs,
+    },
+    `Per-org pool sized at ${perOrg.maxConnections} connection(s) × up to ${perOrg.maxOrgs} org(s) — ` +
+      `ample for conversational load (connections are borrowed per in-flight SQL statement). Raise it if ` +
+      `pool-wait latency appears in metrics. See deploy.mdx#pool-default-warning. See #2943.`,
+  );
 }
 
 export async function loadConfig(


### PR DESCRIPTION
## What

Recalibrates the SaaS pool-sizing boot log so an **intentional** `pool.perOrg.maxConnections` no longer fires a CRITICAL on every boot. Implements the decision recorded on #2943.

## Why

`deploy/api/atlas.config.ts` sets `maxConnections: 5`, and `_warnPoolDefaultsInSaaS` logged **CRITICAL** whenever the value was `≤ 10` (a dev "floor"). But:
- A connection is borrowed **per in-flight SQL statement** and released immediately — chat holds **zero** during LLM thinking, dashboard refresh is **sequential** — so 5 is ample for conversational load.
- Per-org pools target **each customer's own datasource**, not a shared DB, so raising the number just consumes the customer's own `max_connections` headroom for no benefit until real load exists.

So 5 is correct; the **alarm** was wrong — it fired on every boot of the deliberately-sized prod config (alert fatigue that desensitizes operators to a real future warning).

## Changes

- `_warnPoolDefaultsInSaaS`: **CRITICAL only when `pool.perOrg` is unset** (the genuine "isolation off" mistake). An explicitly-configured `perOrg` now logs **INFO** regardless of value.
- Realign the schema default for `maxConnections` **10 → 5** to match the runtime registry default (`DEFAULT_ORG_POOL_SETTINGS` in `db/connection.ts`). #1983 bumped the schema default but not the registry — that 10-vs-5 drift is what made an intentional `5` trip the phantom floor.
- Tier-aware sizing stays deferred behind a real signal — pool-wait latency, now observable since **#2940** wired the OTel metric exporter.

## Tests

- `config.test.ts`: schema-default expectation 10 → 5.
- `config-pool-defaults-warning.test.ts`: explicit-config cases flipped to assert **INFO (not CRITICAL)**; added `findPoolInfo` coverage; self-hosted asserts neither log fires.

`/ci` green locally (lint, type, full test 0-fail, syncpack, all drift gates).

Closes #2943
Refs #1983 #2940

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/2963"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782609266&installation_id=135337507&pr_number=2963&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F2963&signature=008f65cbf0cd13898cbcccdf5de31d5b22ba7fd8092af0abf5964ae1a8536de7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->