### PR TITLE
docs(env): close .env.example gap vs reference (Salesforce, OAuth, sub-processor)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,8 @@
+# Atlas environment variables. This file covers the common self-host setup;
+# every variable (defaults, precedence, per-section detail) is documented at:
+#   https://docs.useatlas.dev/reference/environment-variables
+# All commented (#) vars below are optional — uncomment only the ones you need.
+
 # === Configuration ===
 # Atlas supports two configuration modes:
 #
@@ -157,6 +162,16 @@ ATLAS_ADMIN_EMAIL=admin@useatlas.dev
 #                                           # transport (synthetic system:mcp actor; only safe when
 #                                           # no approval rules exist). MCP fails to boot if rules
 #                                           # exist and the binding is missing — see docs/guides/mcp.
+
+# === OAuth Provider (MCP / DCR) ===
+# Atlas issues OAuth 2.1 tokens via @better-auth/oauth-provider so MCP clients
+# (Claude Desktop, ChatGPT, Cursor) connect to the hosted MCP endpoint via
+# Dynamic Client Registration + PKCE. Most operators leave these on defaults.
+# ATLAS_OAUTH_VALID_AUDIENCES=             # Comma-separated allowed JWT `aud` values. Default: derived from ATLAS_PUBLIC_API_URL/BETTER_AUTH_URL (<base>/mcp)
+# ATLAS_OAUTH_ALLOW_UNAUTH_DCR=true        # Allow unauthenticated public client registration (RFC 7591). Set false for stricter threat models
+# ATLAS_OAUTH_ACCESS_TOKEN_TTL_SECONDS=3600       # Access-token lifetime. Default: 3600 (1h). Empty/non-numeric/≤0 falls back to default
+# ATLAS_OAUTH_REFRESH_TOKEN_TTL_SECONDS=2592000   # Refresh-token lifetime. Default: 2592000 (30d). Same parse rules as access TTL
+# ATLAS_OAUTH_STATE_TTL_SECONDS=600        # TTL for OAuth state tokens during integration install flows. Default: 600 (10m), clamped [60, 3600]
 
 # === Agent ===
 # ATLAS_AGENT_MAX_STEPS=25     # Default: 25, range 1–100. Max tool-call steps per agent run
@@ -414,6 +429,13 @@ ATLAS_SANDBOX_URL=http://localhost:8080
 # LINEAR_CLIENT_ID=                              # Linear OAuth Application's Client ID
 # LINEAR_CLIENT_SECRET=                          # Linear OAuth Application's Client Secret
 
+# === Salesforce Integration (optional) ===
+# Salesforce connected-app credentials for /api/v1/integrations/salesforce/install.
+# When SALESFORCE_CLIENT_ID is unset, that endpoint returns 501.
+# SALESFORCE_CLIENT_ID=                          # Salesforce connected-app consumer key
+# SALESFORCE_CLIENT_SECRET=                      # Salesforce connected-app consumer secret (pair with CLIENT_ID)
+# SALESFORCE_LOGIN_URL=https://login.salesforce.com  # Override for sandboxes (e.g. https://test.salesforce.com). Default: production login host
+
 # === Stripe Billing (SaaS only) ===
 # Enables Stripe billing when STRIPE_SECRET_KEY is set. Self-hosted deployments
 # skip this entirely — the self-hosted experience is the free tier.
@@ -467,6 +489,13 @@ ATLAS_SANDBOX_URL=http://localhost:8080
 # status page redirects here and the app shows incident banners from the feed.
 # NEXT_PUBLIC_STATUS_URL=https://atlas.openstatus.dev
 # NEXT_PUBLIC_OPENSTATUS_SLUG=atlas        # OpenStatus status page slug for JSON feed
+
+# === Sub-Processor Publisher (optional) ===
+# Fetches Atlas's authoritative sub-processor list (third-party vendors that
+# process customer data) and surfaces it on the public docs/legal page.
+# Self-hosted operators rarely touch these — defaults mirror the SaaS config.
+# ATLAS_SUBPROCESSORS_URL=                            # Override the source URL the publisher fetches. Default: built-in source URL
+# ATLAS_SUBPROCESSOR_PUBLISH_INTERVAL_MS=21600000     # Refresh interval for the publisher loop in ms. Default: 21600000 (6h)
 
 # === Railway Custom Domains ===
 # Required for custom domain support (enterprise feature). Get these from your Railway dashboard.


### PR DESCRIPTION
## Summary

`.env.example` was already expanded to 51 sections / 476 lines by #2936 / #2949 — so #2956's premise ("only 7 vars documented") was stale. A fresh gap diff against the reference doc (`apps/docs/content/docs/reference/environment-variables.mdx`) found three reference sections with **no** `.env.example` coverage, now filled:

- **OAuth Provider (MCP / DCR)** — `ATLAS_OAUTH_VALID_AUDIENCES`, `ATLAS_OAUTH_ALLOW_UNAUTH_DCR`, `ATLAS_OAUTH_ACCESS_TOKEN_TTL_SECONDS`, `ATLAS_OAUTH_REFRESH_TOKEN_TTL_SECONDS`, `ATLAS_OAUTH_STATE_TTL_SECONDS`
- **Salesforce Integration** — `SALESFORCE_CLIENT_ID`, `SALESFORCE_CLIENT_SECRET`, `SALESFORCE_LOGIN_URL`
- **Sub-Processor Publisher** — `ATLAS_SUBPROCESSORS_URL`, `ATLAS_SUBPROCESSOR_PUBLISH_INTERVAL_MS`

Plus a top-of-file pointer to the full reference page (the prior pointer at the Sandbox section was section-local). All added vars are **commented out** with placeholder/default values mirroring the reference doc — no real secrets.

All other reference sections (Logging & Observability, Semantic Layer, Sandbox, etc.) were already represented. `.env.example` now has 54 `# === ` sections.

## Test plan

- [x] `grep -cE "^# === " .env.example` → 54 sections; gap diff vs reference doc shows full parity
- [x] All added lines are commented or blank — no uncommented assignments, no real secrets
- [x] Local gates green: lint, type, syncpack, template-drift, security-headers-drift, railway-watch, schema-drift, oauth-helper-drift, test-discipline, twenty-resolver, published-symbols
- [x] Zero tests import `.env.example` (non-executable doc file) — full suite runs on CI as the safety net

Closes #2956

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/2966"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782615088&installation_id=135337507&pr_number=2966&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F2966&signature=2f3e88fdbf9f2db9a7592fe17e5cccb3e5ae2d0d49729c852a23d9c5ad69f49f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->