### PR TITLE
docs: present-tense rewrite of shipped install-pipeline copy

### DIFF
--- a/apps/docs/content/docs/deployment/plugin-catalog.mdx
+++ b/apps/docs/content/docs/deployment/plugin-catalog.mdx
@@ -57,8 +57,9 @@ export default defineConfig({
       saas_eligible: true,
       min_plan: "starter",
     },
-    // 1.5.3 placeholder — visible to ops, not customer-installable until
-    // the static-bot install handler lands.
+    // Declared but held back from customers via `enabled: false` — visible
+    // to ops. Flip to `true` (with this Platform's operator env wired) to
+    // surface it; the static-bot install handler is live.
     {
       slug: "telegram",
       type: "chat",
@@ -97,8 +98,9 @@ Each entry carries:
   Examples: Email (SMTP), Webhook, Obsidian.
 - **`static-bot`** — Operator-shared bot serves every Workspace; customer
   provides only a per-Workspace routing identifier. Examples: Discord
-  `guild_id`, Telegram `chat_id`, Teams `tenant_id`. **Not installable
-  in 1.5.2** — handler ships in 1.5.3.
+  `guild_id`, Telegram `chat_id`, Teams `tenant_id`. The
+  `StaticBotInstallHandler` family is live for Discord, Telegram, WhatsApp,
+  Google Chat, and Teams.
 
 ## Boot-time seed
 
@@ -152,7 +154,7 @@ live in environment variables. The chat plugin's
 | Platform | Required env vars |
 |---|---|
 | `slack` | `SLACK_CLIENT_ID`, `SLACK_CLIENT_SECRET`, `SLACK_SIGNING_SECRET`, `SLACK_ENCRYPTION_KEY` |
-| _(other chat Platforms ship in 1.5.3)_ | — |
+| Discord, Telegram, WhatsApp, Google Chat, Teams | Each declares its own operator env vars — see the per-Platform setup in [Integrations Hub](/guides/integrations). |
 
 If a catalog entry exists with `install_model: "oauth"` and `enabled: true`
 but its env vars are missing, the AdapterRegistry logs a warn and skips

--- a/apps/docs/content/docs/guides/integrations.mdx
+++ b/apps/docs/content/docs/guides/integrations.mdx
@@ -37,7 +37,7 @@ Each catalog entry advertises one **install model** that drives how the Connect 
 |---|---|---|---|
 | `oauth` | `GET /:platform/install` → 302 to provider → `GET /:platform/callback` | Slack, Salesforce, Jira | Click **Connect**, complete the provider OAuth dance, return to `/admin/integrations` |
 | `form` | `POST /:platform/install-form` with JSON body | Email, Webhook, Obsidian | Fill in the per-platform fields the catalog declares (`configSchema`), submit |
-| `static-bot` | _placeholder_ | _(none in the install router today — Discord / Telegram / WhatsApp will move here in a future release; they currently install via the legacy BYOT path below)_ | Capture a per-Workspace routing identifier against an operator-shared bot |
+| `static-bot` | `GET /discord/install` → bot-add consent → `GET /discord/callback` (Discord); others via the legacy admin endpoints below | Discord (via the install router). Telegram, WhatsApp, Google Chat, and Teams still install via the legacy admin endpoints below. | Add the operator-shared bot to the workspace, then capture a per-Workspace routing identifier (Discord `guild_id`, Telegram `chat_id`, Teams `tenant_id`) |
 
 A request to the wrong endpoint for a catalog entry's model returns `400 wrong_install_model` — the UI picks the right surface from the catalog response, so this only fires for direct API callers.
 

--- a/apps/docs/content/docs/integrations/admin-console.mdx
+++ b/apps/docs/content/docs/integrations/admin-console.mdx
@@ -71,25 +71,33 @@ what's available on higher plans without contacting sales.
 
 ## Connect flow
 
-> **Coming in 1.5.2 — slice 5 (#2654).** This slice ships the catalog
-> read-only surface so the install flow has somewhere to land.
+Clicking **Connect** runs the install flow for the card's `installModel`:
 
-When slice 5 lands, clicking **Connect** on an OAuth integration (Slack
-today; Salesforce in a later slice) opens an authorization tab against
-the Platform. After approval, Atlas writes a `workspace_plugins` row
-and the card flips to **Installed**. Form-based integrations (e.g.
-Linear via API key) open a modal that collects the credentials inline.
+- **OAuth** (Slack, Salesforce, Jira, Linear, GitHub) — opens an
+  authorization tab against the Platform. After you approve, Atlas writes
+  a `workspace_plugins` row and the card flips to **Installed**.
+- **Form** (Email, Webhook, Obsidian, Linear via API key) — opens a modal
+  that collects the credentials inline and writes the `workspace_plugins`
+  row on submit.
+- **Static-bot** (Discord) — runs the bot-add consent flow against the
+  Platform, then captures a per-Workspace routing identifier (e.g.
+  `guild_id`) against the operator-shared bot. The remaining static-bot
+  platforms (Telegram, WhatsApp, Google Chat, Teams) install from their
+  per-platform admin blocks further down the page.
 
 ## Disconnect
 
-> **Coming in 1.5.2 — slice 6 (#2656).** Today the **Disconnect**
-> button renders but is inert; use the legacy per-platform admin blocks
-> further down `/admin/integrations` to disconnect Slack / Teams /
-> Discord / etc.
+Clicking **Disconnect** tears the install down credential-first: the
+per-Platform credential row is deleted before the `workspace_plugins` row
+(scoped to the catalog entry and your Workspace), so credentials never
+outlive the install record. Any cached plugin instance for that pair is
+evicted, so in-flight transports stop immediately. Disconnect requires an
+MFA-enrolled admin session.
 
-After slice 6, **Disconnect** deletes the `workspace_plugins` row
-(scoped to the catalog entry and your Workspace), revokes the OAuth
-grant where possible, and logs an admin-action audit row.
+Disconnect removes Atlas's stored credential and install record; it does
+**not** call the Platform's token-revocation endpoint. If you also want to
+invalidate the token Atlas held, revoke the grant from the Platform's own
+app settings (e.g. Slack or Salesforce).
 
 ## Empty state
 

--- a/apps/docs/content/docs/integrations/admin-console.mdx
+++ b/apps/docs/content/docs/integrations/admin-console.mdx
@@ -79,11 +79,11 @@ Clicking **Connect** runs the install flow for the card's `installModel`:
 - **Form** (Email, Webhook, Obsidian, Linear via API key) — opens a modal
   that collects the credentials inline and writes the `workspace_plugins`
   row on submit.
-- **Static-bot** (Discord) — runs the bot-add consent flow against the
-  Platform, then captures a per-Workspace routing identifier (e.g.
-  `guild_id`) against the operator-shared bot. The remaining static-bot
-  platforms (Telegram, WhatsApp, Google Chat, Teams) install from their
-  per-platform admin blocks further down the page.
+- **Static-bot** (Discord, Telegram, WhatsApp, Google Chat, Teams) —
+  installed from their per-platform admin blocks further down the page
+  rather than via the catalog card's Connect button (which is inert for
+  these). Each captures a per-Workspace routing identifier (e.g. Discord
+  `guild_id`) against the operator-shared bot.
 
 ## Disconnect
 
@@ -91,8 +91,8 @@ Clicking **Disconnect** tears the install down credential-first: the
 per-Platform credential row is deleted before the `workspace_plugins` row
 (scoped to the catalog entry and your Workspace), so credentials never
 outlive the install record. Any cached plugin instance for that pair is
-evicted, so in-flight transports stop immediately. Disconnect requires an
-MFA-enrolled admin session.
+evicted, so later tool dispatches can't reuse the stale transport.
+Disconnect requires an MFA-enrolled admin session.
 
 Disconnect removes Atlas's stored credential and install record; it does
 **not** call the Platform's token-revocation endpoint. If you also want to


### PR DESCRIPTION
## Summary

Three docs pages still described install-pipeline features as "coming" / "ships in 1.5.3" / "placeholder," but those features shipped (1.5.2/1.5.3 closed 2026-05-26). Rewrote the stale copy to present tense, **verified against `packages/api/src/lib/integrations/install/`**.

- **`integrations/admin-console.mdx`** — Connect flow and Disconnect sections rewritten from "Coming in 1.5.2 — slice 5/6" blockquotes to present tense.
- **`deployment/plugin-catalog.mdx`** — config-example comment, the `static-bot` install-model bullet, and the per-platform env-vars table cell de-future-framed. The dated rollout-history "What ships when" list (with PR refs) is **left unchanged** as historical record.
- **`guides/integrations.mdx`** — the `static-bot` table row updated from `_placeholder_` to the shipped behavior.

## Verification notes (read the handlers, didn't trust the issue's list blindly)

- `StaticBotInstallHandler` family is **live** for Discord, Telegram, WhatsApp, Google Chat, Teams (registered in `install/register.ts`). OAuth handlers live for Slack, Salesforce, Jira, Linear, GitHub.
- **Static-bot routing is split**, and the prose now reflects that instead of overclaiming: Discord is wired through the unified install router (`integrations-discord.ts`: `GET /discord/install` → `/discord/callback` → `confirmInstall`); **Telegram/WhatsApp/Google Chat/Teams still install via the legacy admin endpoints** (`POST /api/v1/admin/integrations/*`). The generic `/install-form` route explicitly rejects `static-bot`.

## ⚠️ Deliberate deviation from the issue's prescribed Disconnect prose

The issue text asked the Disconnect rewrite to say it "revokes the OAuth grant where possible, and logs an admin-action audit row." **The code does neither**, verified directly:
- Both credential deletes are plain `DELETE FROM` — `deleteInstallation` (`slack/store.ts:344`) and `deleteCredentialBundle` (`integrations/credentials/store.ts:168`). No call to any provider token-revocation endpoint anywhere on the disconnect path.
- The `integrations` router is a plain `OpenAPIHono` (`integrations.ts:150`), not `createAdminRouter`, and the disconnect handler only emits a pino `log.info` — there is **no `admin_action_log` write**.

Writing those two claims would have re-introduced the exact doc drift this issue exists to remove, and would fail the AC "each rewrite reflects current behavior verified against the code." So the Disconnect prose documents the **verified** behavior instead — credential-first teardown (ADR-0003 order), scoped `workspace_plugins` delete, plugin-cache eviction, MFA gate — and explicitly notes Atlas does **not** revoke the grant server-side.

## Out of scope (noted, not touched)

- `guides/integrations.mdx` `oauth` row still lists "Slack, Salesforce, Jira" (Linear/GitHub now also OAuth) and the canonical-DELETE "Coverage today: Slack, Salesforce, Jira" line is understated (Linear/GitHub/Twenty also covered). These are present-tense completeness gaps, not "coming/placeholder" framing, so they're outside #2955's scope.
- Env-var **names** left untouched (owned by #2837).

## Test plan

- [x] `grep -rniE "coming in|ships in 1\.5|placeholder|future release|not customer-installable"` over the 3 pages returns only the dated rollout-history block in `plugin-catalog.mdx` (line 185), nothing else.
- [x] `cd apps/docs && bun run build` — all 1829 static pages generated, no MDX/link errors (the new `/guides/integrations` link resolves).
- [x] `/ci` — lint, type, test, syncpack, template-drift, security-headers, railway-watch, schema-drift, oauth-helper, test-discipline, twenty-resolver, published-symbols all pass.

Closes #2955

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/2967"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782615743&installation_id=135337507&pr_number=2967&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F2967&signature=bbdaca0fed6cbb3305a26992e5950f3e709b4e75d8016f35e065088a444333e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->