### PR TITLE
feat(types): add DeployRegion union ("us"|"eu"|"apac"|"staging") (staging slice 1/22)

### DIFF
--- a/packages/types/src/deploy.ts
+++ b/packages/types/src/deploy.ts
@@ -1,0 +1,32 @@
+/**
+ * Deploy-region identity — the fixed set of first-party Atlas deployment
+ * instances.
+ *
+ * Each Atlas API instance is stamped with exactly one of these via the
+ * `ATLAS_API_REGION` env var (read at runtime by `getApiRegion()` in
+ * `@atlas/api/lib/residency/misrouting`, falling back to
+ * `residency.defaultRegion` in atlas.config.ts). The three production SaaS
+ * instances are `us` / `eu` / `apac`; `staging` is the single pre-prod soak
+ * instance under `*.staging.useatlas.dev`.
+ *
+ * This is a CLOSED union of Atlas-operated deployments — distinct from two
+ * neighbouring concepts:
+ *
+ * - `Region` (./residency) is an OPEN `string`: an operator-defined data-
+ *   residency routing key for a *workspace*, not constrained to this set. A
+ *   self-hosted operator can name regions anything. Its companion
+ *   `WELL_KNOWN_REGIONS` suggests *finer-grained* admin-UI keys
+ *   (`us-east`, `eu-west`, …) — independent of, and not to be confused
+ *   with, the coarse first-party keys here: a `DeployRegion` of `"us"` is
+ *   the `deploy/api/atlas.config.ts` residency key, not `"us-east"`.
+ * - `DeployEnv` (`@atlas/api/lib/env-profile`, `"production" | "staging" |
+ *   "development"`) is the deployment *shape* that drives non-secret runtime
+ *   toggles (email verification, cookie prefix). The three prod regions all
+ *   share the `production` env profile; `staging` overlaps only by name —
+ *   it's a different axis (one specific instance vs. an env class).
+ *
+ * Type-only: the runtime read remains a raw `string` via `getApiRegion()`;
+ * this union exists so deploy-region-aware code (e.g. the staging outbound
+ * clamp) can name the cases exhaustively without re-spelling the literals.
+ */
+export type DeployRegion = "us" | "eu" | "apac" | "staging";

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -25,6 +25,7 @@ export * from "./sla";
 export * from "./backups";
 export * from "./crm-outbox";
 export * from "./residency";
+export * from "./deploy";
 export * from "./domain";
 export * from "./migration";
 export * from "./dashboard";


### PR DESCRIPTION
## Summary

Staging environment **slice 1/22** (milestone #57, PRD #2893). Introduces the `DeployRegion` type union in `@useatlas/types` — the foundational type change that unblocks staging slices 2/3/4/6/8.

```ts
export type DeployRegion = "us" | "eu" | "apac" | "staging";
```

## ⚠️ Divergence from the issue framing

The issue and PRD describe this as *"add a 4th value to the existing `DeployRegion` union"* — but **no such type existed**. I grepped the whole repo: the only `DeployRegion` mention was in `docs/prd/staging-environment.md` itself.

The deploy regions (`us`/`eu`/`apac`) were never enumerated as a TS union; they're operator-config strings read at runtime via `getApiRegion()` in `packages/api/src/lib/residency/misrouting.ts` (returns `string | null`, sourced from `ATLAS_API_REGION` / `residency.defaultRegion`). So this slice **creates** the closed union with all four values per the PRD's "Region-keying and deploy mode" spec, rather than editing one line.

End state is identical to the acceptance criteria (`DeployRegion` accepts `"staging"`); flagging so reviewers know the type is new, not extended.

## What this is NOT

- **Not** a runtime change. `getApiRegion()` still returns `string | null`; region resolution is untouched (per slice scope: "type-level expansion only").
- **Not** the same axis as `DeployEnv` (`"production" | "staging" | "development"` in `lib/env-profile.ts`), which already has `staging`. `DeployEnv` is the deployment *shape* (drives email-verification / cookie-prefix). `DeployRegion` is *which specific instance* is serving. The doc comment spells out the distinction (and from residency's open `Region = string`).

## No publish / version bump

`@useatlas/types` is **not** bumped and **not** published in this PR. A type-only export with zero current consumers resolves from the locally-built `dist/` across the workspace, so all packages compile. A publish (+ the `^`-ref bump dance) only becomes necessary once scaffold-bound source imports a **value** from the registry — type-only imports are erased and skipped by `check-published-symbols`. Downstream slices that consume `DeployRegion` (type-only) won't need a publish either; only a value-level companion (e.g. a `DEPLOY_REGIONS` const) would.

## Acceptance criteria

- [x] `DeployRegion` union in `@useatlas/types` accepts `"staging"`
- [x] `bun run type` passes workspace-wide
- [x] Downstream consumers (`@atlas/api`, `@atlas/web`, `@useatlas/sdk`, `@useatlas/react`) compile **without changes** (additive). No exhaustive switch over `DeployRegion` exists to break — zero consumers today.
- [x] No publish required → no `^`-ref bump (documented above)

## CI

All local `/ci` gates pass: lint, type, full test (491/491 api + others, 0 fail), syncpack, template/security/railway/schema/oauth drift, test-discipline, twenty-resolver, published-symbols. Remote `main` healthy at branch point.

Closes #2897

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/2968"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782651294&installation_id=135337507&pr_number=2968&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F2968&signature=56a4919a21e1664b13e1124959930e2fd36bb46f8490463e160c2b69b8f2693c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->