### PR TITLE
fix(email): durable email_outbox for transactional sends (#2942)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -253,6 +253,14 @@ ATLAS_ADMIN_EMAIL=admin@useatlas.dev
 # ATLAS_ONBOARDING_EMAILS_ENABLED=false           # Enable automated onboarding drip campaign for new signups. Default: from ATLAS_DEPLOY_ENV profile (prod: true, staging/dev: false).
 # ATLAS_UNSUBSCRIBE_TOKEN_TTL_MS=2592000000       # TTL for signed unsubscribe links (default: 30 days; range: 60s–1y)
 
+# === Transactional email durable outbox (#2942) ===
+# Password-reset / signup-verification emails are sent via a durable `email_outbox`: when the
+# in-process retry (fetchWithRetry, #2949) is exhausted on a SUSTAINED provider outage, the send is
+# enqueued and a Scheduler-backed flusher re-sends it on a later tick, rather than being dropped.
+# ATLAS_EMAIL_OUTBOX_TICK_SECONDS=5           # Flusher poll interval. Default 5s; clamped to [1, 3600]. Out-of-range values clamp and log a warn.
+# ATLAS_EMAIL_OUTBOX_WARN_THRESHOLD=50        # Pending-row threshold for the rate-limited backlog warning. Above this many `email_outbox` rows in `pending`, the flusher emits one `log.warn`/minute with the depth + oldest pending age. Pair with the `atlas.email_outbox.pending_count` gauge. Out-of-range clamps to [1, 1_000_000].
+# ATLAS_EMAIL_OUTBOX_FLUSHER_ENABLED=true     # Opt-out for the polling flusher. Default true on any pod with an internal DB. Recovery sweeps still run on boot/shutdown regardless, so flipping back to `true` inherits clean state. Requires DATABASE_URL (no internal DB = nothing to queue, flusher not started).
+
 # === Twenty CRM (SaaS-side lead capture — #2727) ===
 # TWENTY_BASE_URL=https://crm.useatlas.dev   # Twenty REST base URL (defaults to crm.useatlas.dev). Self-hosters set to their own Twenty hostname.
 # TWENTY_API_KEY=                            # Bearer key from Twenty Settings → API & Webhooks. Required for SaaS demo / signup / contact-form dispatch into Twenty; unset = SaasCrm.available is false. Twenty Person object must have custom fields `atlasFirstSource` AND `atlasLastSource` (verified at boot).

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -9,6 +9,7 @@
     "./lib/audit/*": "./src/lib/audit/*.ts",
     "./lib/content-mode": "./src/lib/content-mode/index.ts",
     "./lib/lead-outbox": "./src/lib/lead-outbox/index.ts",
+    "./lib/email-outbox": "./src/lib/email-outbox/index.ts",
     "./lib/env-routing": "./src/lib/env-routing/index.ts",
     "./lib/env-routing/*": "./src/lib/env-routing/*.ts",
     "./lib/multi-env-merger": "./src/lib/multi-env-merger/index.ts",

--- a/packages/api/src/lib/auth/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/auth/__tests__/migrate.test.ts
@@ -352,6 +352,7 @@ describe("migrateAuthTables", () => {
             { name: "0104_crm_outbox_email_key.sql" },
             { name: "0105_drop_legacy_invitations.sql" },
             { name: "0106_crm_outbox_workspace_id.sql" },
+            { name: "0107_email_outbox.sql" },
           ],
         };
       }

--- a/packages/api/src/lib/auth/__tests__/rate-limit.test.ts
+++ b/packages/api/src/lib/auth/__tests__/rate-limit.test.ts
@@ -348,6 +348,10 @@ describe("deriveCookieDomain", () => {
 });
 
 describe("_sendVerificationOTP", () => {
+  // Captures the `opts` the durable wrapper receives so we can assert the
+  // per-type TTL the caller passes (#2942). Reset per test.
+  const capturedOpts: Array<{ emailType: string; orgId?: string; ttlMs?: number }> = [];
+
   // Full delivery-module mock so partial-mock SyntaxErrors in unrelated
   // test files don't surface; plus the fire-and-forget contract
   // assertions so a thrown rejection from the OTP send can never
@@ -359,22 +363,27 @@ describe("_sendVerificationOTP", () => {
       error?: string;
     }>,
   ): void => {
+    capturedOpts.length = 0;
     mock.module("@atlas/api/lib/email/delivery", () => ({
       sendEmail,
       // _sendVerificationOTP now sends via the durable wrapper (#2942).
       // Delegate to the captured `sendEmail` so the message-capture and
-      // fire-and-forget assertions below are unchanged; the wrapper's
-      // outbox-enqueue side effect is exercised in delivery.test.ts.
+      // fire-and-forget assertions below are unchanged; capture `opts` so
+      // the TTL wiring is asserted. The wrapper's outbox-enqueue side
+      // effect itself is exercised in delivery.test.ts.
       sendTransactionalEmail: async (
         msg: { to: string; subject: string; html: string },
-        _opts: { emailType: string; orgId?: string },
-      ) => sendEmail(msg),
+        opts: { emailType: string; orgId?: string; ttlMs?: number },
+      ) => {
+        capturedOpts.push(opts);
+        return sendEmail(msg);
+      },
       sendEmailWithTransport: async () => ({ success: true, provider: "resend" as const }),
       getEmailTransport: async () => null,
     }));
   };
 
-  it("renders the OTP into the email body", async () => {
+  it("renders the OTP into the email body and passes the 10-minute TTL", async () => {
     const calls: Array<{ to: string; subject: string; html: string }> = [];
     installDeliveryMock(async (msg) => {
       calls.push(msg);
@@ -386,6 +395,10 @@ describe("_sendVerificationOTP", () => {
     expect(calls).toHaveLength(1);
     expect(calls[0].to).toBe("otp@example.com");
     expect(calls[0].subject.toLowerCase()).toContain("verification");
+    // The outbox TTL must match the "expires in 10 minutes" body copy so a
+    // post-outage re-send never delivers a dead code (#2942).
+    expect(capturedOpts[0]?.emailType).toBe("verification-otp");
+    expect(capturedOpts[0]?.ttlMs).toBe(10 * 60_000);
     // Surface the literal OTP — `<a href>` parsing is intentionally
     // absent here since OTP emails should NEVER carry a clickable
     // verification link (that's the magic-link path we're moving away

--- a/packages/api/src/lib/auth/__tests__/rate-limit.test.ts
+++ b/packages/api/src/lib/auth/__tests__/rate-limit.test.ts
@@ -361,6 +361,14 @@ describe("_sendVerificationOTP", () => {
   ): void => {
     mock.module("@atlas/api/lib/email/delivery", () => ({
       sendEmail,
+      // _sendVerificationOTP now sends via the durable wrapper (#2942).
+      // Delegate to the captured `sendEmail` so the message-capture and
+      // fire-and-forget assertions below are unchanged; the wrapper's
+      // outbox-enqueue side effect is exercised in delivery.test.ts.
+      sendTransactionalEmail: async (
+        msg: { to: string; subject: string; html: string },
+        _opts: { emailType: string; orgId?: string },
+      ) => sendEmail(msg),
       sendEmailWithTransport: async () => ({ success: true, provider: "resend" as const }),
       getEmailTransport: async () => null,
     }));

--- a/packages/api/src/lib/auth/server.ts
+++ b/packages/api/src/lib/auth/server.ts
@@ -906,10 +906,15 @@ export function resolveBootstrapAdminConfig(
  */
 export async function _sendVerificationOTP(opts: { to: string; otp: string }): Promise<void> {
   try {
-    const { sendEmail } = await import("@atlas/api/lib/email/delivery");
-    const result = await sendEmail({
-      to: opts.to,
-      subject: "Your Atlas verification code",
+    const { sendTransactionalEmail } = await import("@atlas/api/lib/email/delivery");
+    // Durable send (#2942): if the in-process retry path is exhausted on
+    // a sustained provider outage, the message lands in email_outbox and
+    // the flusher re-sends it — rather than being lost. The response
+    // stays 200 either way (enumeration-safe, fire-and-forget).
+    const result = await sendTransactionalEmail(
+      {
+        to: opts.to,
+        subject: "Your Atlas verification code",
       html: `<!doctype html>
 <html>
   <body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif; max-width: 560px; margin: 0 auto; padding: 24px; color: #222;">
@@ -919,7 +924,9 @@ export async function _sendVerificationOTP(opts: { to: string; otp: string }): P
     <p>— Atlas</p>
   </body>
 </html>`,
-    });
+      },
+      { emailType: "verification-otp" },
+    );
     if (!result.success) {
       log.warn(
         { to: opts.to, provider: result.provider, error: result.error },
@@ -951,11 +958,17 @@ export async function _sendPasswordResetEmail(opts: {
   url: string;
 }): Promise<void> {
   try {
-    const { sendEmail } = await import("@atlas/api/lib/email/delivery");
-    const result = await sendEmail({
-      to: opts.to,
-      subject: "Reset your Atlas password",
-      html: `<!doctype html>
+    const { sendTransactionalEmail } = await import("@atlas/api/lib/email/delivery");
+    // Durable send (#2942): password reset is the sole self-serve
+    // recovery path, so a sustained provider outage must not silently
+    // drop it. sendTransactionalEmail enqueues to email_outbox when the
+    // in-process retry path is exhausted; the flusher re-sends later. The
+    // request still returns 200 regardless (enumeration-safe, F-09).
+    const result = await sendTransactionalEmail(
+      {
+        to: opts.to,
+        subject: "Reset your Atlas password",
+        html: `<!doctype html>
 <html>
   <body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif; max-width: 560px; margin: 0 auto; padding: 24px; color: #222;">
     <p>We received a request to reset the password for your Atlas account.</p>
@@ -964,7 +977,9 @@ export async function _sendPasswordResetEmail(opts: {
     <p>— Atlas</p>
   </body>
 </html>`,
-    });
+      },
+      { emailType: "password-reset" },
+    );
     if (!result.success) {
       log.warn(
         { to: opts.to, provider: result.provider, error: result.error },

--- a/packages/api/src/lib/auth/server.ts
+++ b/packages/api/src/lib/auth/server.ts
@@ -925,7 +925,9 @@ export async function _sendVerificationOTP(opts: { to: string; otp: string }): P
   </body>
 </html>`,
       },
-      { emailType: "verification-otp" },
+      // 10m TTL matches the "expires in 10 minutes" copy above — the
+      // flusher won't deliver a dead code after a long outage (#2942).
+      { emailType: "verification-otp", ttlMs: 10 * 60_000 },
     );
     if (!result.success) {
       log.warn(
@@ -978,7 +980,9 @@ export async function _sendPasswordResetEmail(opts: {
   </body>
 </html>`,
       },
-      { emailType: "password-reset" },
+      // 1h TTL matches the "expires in one hour" copy above — the flusher
+      // won't deliver a dead reset link after a long outage (#2942).
+      { emailType: "password-reset", ttlMs: 60 * 60_000 },
     );
     if (!result.success) {
       log.warn(

--- a/packages/api/src/lib/db/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate.test.ts
@@ -123,8 +123,9 @@ describe("runMigrations", () => {
     // + 0105 (drop legacy invitations table after better-auth-invitations
     //   cutover — invitations now live in Better Auth's `invitation`
     //   table; see lib/auth/server.ts:organizationHooks) = 106. Plus
-    //   #2849 (workspace_id on crm_outbox) = 107.
-    expect(count).toBe(107);
+    //   #2849 (workspace_id on crm_outbox) = 107. Plus
+    //   0107 (email_outbox durable queue for transactional email, #2942) = 108.
+    expect(count).toBe(108);
 
     // Advisory lock acquired before anything else
     expect(queries[0]).toContain("pg_advisory_lock");
@@ -260,6 +261,7 @@ describe("runMigrations", () => {
         "0104_crm_outbox_email_key.sql",
         "0105_drop_legacy_invitations.sql",
         "0106_crm_outbox_workspace_id.sql",
+        "0107_email_outbox.sql",
       ],
     });
 

--- a/packages/api/src/lib/db/migrations/0107_email_outbox.sql
+++ b/packages/api/src/lib/db/migrations/0107_email_outbox.sql
@@ -1,0 +1,97 @@
+-- 0107_email_outbox.sql
+--
+-- `email_outbox` — durable queue for transactional email (password
+-- reset, signup verification OTP) so a SUSTAINED upstream outage no
+-- longer permanently loses a send (#2942, residual scope).
+--
+-- Context: PR #2949 already added bounded exponential-backoff retry on
+-- 429/5xx/network inside `email/delivery.ts:fetchWithRetry` — that
+-- covers a transient blip. This table is the backstop for the case
+-- retry can't cover: the provider is down longer than the in-process
+-- retry window. `sendTransactionalEmail` enqueues a `pending` row when
+-- the in-process retry path is exhausted; the Scheduler-backed flusher
+-- (see `packages/api/src/lib/email-outbox/`) claims, re-sends, and
+-- stamps terminal status. The password-reset path stays enumeration-
+-- safe (F-09): `/request-password-reset` returns 200 whether or not the
+-- send succeeded — the outbox only changes WHERE the failed send goes
+-- (durable queue vs dropped), never the response.
+--
+-- Shape rationale — deliberately a STRIPPED-DOWN mirror of `crm_outbox`
+-- (0102). Both are write-then-flush durable queues with `attempts` +
+-- `last_error` + `retry_after` + `claimed_at` carrying retry/recovery
+-- state, and a partial index on the active statuses. What `email_outbox`
+-- DROPS vs `crm_outbox`, and why:
+--   * No `email_key` / per-email serialization (0104). CRM ordering
+--     mattered because concurrent dispatches flipped `atlasFirstSource`;
+--     transactional email has no cross-row ordering contract and an
+--     at-least-once duplicate send is acceptable, so rows dispatch
+--     independently.
+--   * No `workspace_id` routing (0106). These are operator-level
+--     transactional sends, not per-tenant plugin dispatches. `org_id`
+--     (nullable) is carried only so the flusher can re-resolve a
+--     per-org transport override via the same `sendEmail(msg, orgId)`
+--     path; the password-reset flow has no org and lands NULL.
+--   * No `twenty_person_id` / `twenty_note_id` sub-step resource IDs.
+--     A send is a single operation — there is no partial-success
+--     sub-step to make idempotent.
+--
+-- `status` is the OUTBOX LIFECYCLE status (pending/in_flight/done/dead),
+-- NOT the content-mode status (draft/published/archived). `email_outbox`
+-- is an operational queue, not user-surfaced content, so it is
+-- intentionally OUTSIDE the content-mode system (no mode resolution, no
+-- publish-transaction promotion). See CLAUDE.md § Content Mode System
+-- for the carve-out rule.
+--
+-- Credentials: the `payload` JSONB stores the rendered message
+-- (to/subject/html). The password-reset html embeds a SINGLE-USE,
+-- one-hour-expiry reset URL token — an ephemeral capability, not a
+-- long-lived credential — so it is NOT encrypted at rest (encryptSecret
+-- is reserved for durable secrets; a short-TTL one-time token in a
+-- short-lived queue row does not qualify). No API keys, connection
+-- strings, or provider secrets are ever written here. The table is
+-- therefore intentionally NOT a member of `INTEGRATION_TABLES`.
+
+CREATE TABLE IF NOT EXISTS email_outbox (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  -- Send classification for observability / metrics bucketing
+  -- (e.g. 'password-reset', 'verification-otp'). Never used for routing.
+  email_type    TEXT NOT NULL,
+  -- Rendered EmailMessage: { to, subject, html }. The flusher hands this
+  -- straight to `sendEmail`.
+  payload       JSONB NOT NULL,
+  -- Optional org scope so the flusher re-resolves a per-org transport
+  -- override on re-send. NULL for session-less flows (password reset).
+  org_id        TEXT,
+  status        TEXT NOT NULL DEFAULT 'pending',
+  attempts      INTEGER NOT NULL DEFAULT 0,
+  last_error    TEXT,
+  -- Absolute timestamp before which the row must not be re-claimed. Set
+  -- when a transient outcome carried an upstream-requested delay; NULL
+  -- means the tier-based backoff (CLAIM_DELAY_SQL) applies. Mirrors
+  -- crm_outbox.retry_after.
+  retry_after   TIMESTAMPTZ,
+  -- Stamped by CLAIM_SQL on every claim. The recovery sweep filters by
+  -- `now() - claimed_at > threshold` so a peer pod's freshly-claimed row
+  -- is not reset out from under it during a shutdown sweep (multi-pod
+  -- double-send guard). Mirrors crm_outbox.claimed_at.
+  claimed_at    TIMESTAMPTZ,
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  processed_at  TIMESTAMPTZ,
+  CONSTRAINT email_outbox_status_chk
+    CHECK (status IN ('pending', 'in_flight', 'done', 'dead'))
+);
+
+-- Partial index keeps the flusher poll + depth snapshot fast as
+-- done/dead rows accumulate (same shape as idx_crm_outbox_pending_created).
+CREATE INDEX IF NOT EXISTS idx_email_outbox_pending_created
+  ON email_outbox (status, created_at)
+  WHERE status IN ('pending', 'in_flight');
+
+COMMENT ON TABLE email_outbox IS
+  'Durable outbox for transactional email (password reset, signup verification OTP). sendTransactionalEmail enqueues a pending row when the in-process retry path is exhausted; the Scheduler-backed flusher claims, re-sends via sendEmail, and stamps terminal status. Stripped-down mirror of crm_outbox — no email_key/workspace_id/sub-step columns. Stores no credentials (the reset-link token is single-use + short-TTL). See packages/api/src/lib/email-outbox/ (#2942).';
+
+COMMENT ON COLUMN email_outbox.retry_after IS
+  'Absolute timestamp before which the row must not be re-claimed. Set when a transient outcome carried an upstream-requested delay; NULL means the tier-based backoff applies. Cleared on the next transient outcome that lacks a delay.';
+
+COMMENT ON COLUMN email_outbox.claimed_at IS
+  'Timestamp of the most recent CLAIM_SQL execution against this row. recoverInFlight filters by `now() - claimed_at > threshold` so a sibling pod''s in-flight row is not reset during a shutdown sweep — critical for multi-pod deployments.';

--- a/packages/api/src/lib/db/migrations/0107_email_outbox.sql
+++ b/packages/api/src/lib/db/migrations/0107_email_outbox.sql
@@ -80,10 +80,12 @@ CREATE TABLE IF NOT EXISTS email_outbox (
   status        TEXT NOT NULL DEFAULT 'pending',
   attempts      INTEGER NOT NULL DEFAULT 0,
   last_error    TEXT,
-  -- Absolute timestamp before which the row must not be re-claimed. Set
-  -- when a transient outcome carried an upstream-requested delay; NULL
-  -- means the tier-based backoff (CLAIM_DELAY_SQL) applies. Mirrors
-  -- crm_outbox.retry_after.
+  -- Absolute earliest re-claim time. Stamped on EVERY transient failure
+  -- as GREATEST(now() + tier(attempts), upstream_retry_after) — measured
+  -- from the failure moment, so a long-pending row can't burst through
+  -- its budget. NULL only on a never-failed row, where the claim gate
+  -- falls back to created_at + tier (immediate at attempts=0). Cleared
+  -- back to NULL on a terminal done/dead.
   retry_after   TIMESTAMPTZ,
   -- Stamped by CLAIM_SQL on every claim. The recovery sweep filters by
   -- `now() - claimed_at > threshold` so a peer pod's freshly-claimed row
@@ -112,7 +114,7 @@ COMMENT ON COLUMN email_outbox.expires_at IS
   'Hard delivery deadline derived from the email type TTL at enqueue (reset link 1h, OTP 10m). The flusher dead-letters a row past this instead of delivering a dead token. NULL = no deadline.';
 
 COMMENT ON COLUMN email_outbox.retry_after IS
-  'Absolute timestamp before which the row must not be re-claimed. Set when a transient outcome carried an upstream-requested delay; NULL means the tier-based backoff applies. Cleared on the next transient outcome that lacks a delay.';
+  'Absolute earliest re-claim time. Stamped on every transient failure as GREATEST(now() + tier, upstream_retry_after) — measured from the failure moment, not created_at, so a row that sat pending a long time before its first claim cannot burst through its retry budget. NULL only on a never-failed row (claim gate then uses created_at + tier; immediate at attempts=0). Cleared to NULL on a terminal done/dead.';
 
 COMMENT ON COLUMN email_outbox.claimed_at IS
   'Timestamp of the most recent CLAIM_SQL execution against this row. recoverInFlight filters by `now() - claimed_at > threshold` so a sibling pod''s in-flight row is not reset during a shutdown sweep — critical for multi-pod deployments.';

--- a/packages/api/src/lib/db/migrations/0107_email_outbox.sql
+++ b/packages/api/src/lib/db/migrations/0107_email_outbox.sql
@@ -42,26 +42,41 @@
 -- publish-transaction promotion). See CLAUDE.md § Content Mode System
 -- for the carve-out rule.
 --
--- Credentials: the `payload` JSONB stores the rendered message
--- (to/subject/html). The password-reset html embeds a SINGLE-USE,
--- one-hour-expiry reset URL token — an ephemeral capability, not a
--- long-lived credential — so it is NOT encrypted at rest (encryptSecret
--- is reserved for durable secrets; a short-TTL one-time token in a
--- short-lived queue row does not qualify). No API keys, connection
--- strings, or provider secrets are ever written here. The table is
--- therefore intentionally NOT a member of `INTEGRATION_TABLES`.
+-- Credentials: the `payload` TEXT stores the rendered message
+-- (to/subject/html) ENCRYPTED AT REST via `encryptSecret` (versioned
+-- AES-256-GCM `enc:v<N>:...`). The password-reset html embeds a
+-- single-use reset URL token and the verification html embeds an OTP —
+-- both are live bearer capabilities for the TTL window, so anyone with
+-- read access to the internal DB or a backup could replay them. The
+-- queue therefore encrypts the payload (codex review on #2972). When no
+-- encryption key is configured (self-hosted dev), `encryptSecret`
+-- degrades to plaintext passthrough and `decryptSecret` round-trips it
+-- unchanged. Still NOT a member of `INTEGRATION_TABLES` (no long-lived
+-- provider credential; nothing for F-47 rotation to re-key).
+--
+-- `expires_at`: the reset link expires in 1h and the OTP in 10m, so a
+-- send that can't go out before then would deliver a dead token. The
+-- enqueue stamps a per-type TTL; the flusher dead-letters (does NOT
+-- send) a row past its `expires_at` rather than delivering an unusable
+-- link/code (codex review on #2972).
 
 CREATE TABLE IF NOT EXISTS email_outbox (
   id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   -- Send classification for observability / metrics bucketing
   -- (e.g. 'password-reset', 'verification-otp'). Never used for routing.
   email_type    TEXT NOT NULL,
-  -- Rendered EmailMessage: { to, subject, html }. The flusher hands this
-  -- straight to `sendEmail`.
-  payload       JSONB NOT NULL,
+  -- Rendered EmailMessage { to, subject, html }, JSON-serialized then
+  -- encrypted via encryptSecret (enc:v<N>:... AES-256-GCM). TEXT, not
+  -- JSONB, because the stored value is opaque ciphertext. The flusher
+  -- decrypts before handing it to `sendEmail`.
+  payload       TEXT NOT NULL,
   -- Optional org scope so the flusher re-resolves a per-org transport
   -- override on re-send. NULL for session-less flows (password reset).
   org_id        TEXT,
+  -- Hard delivery deadline: past this the embedded token/OTP is dead, so
+  -- the flusher dead-letters rather than sending a useless email. NULL =
+  -- no deadline (non-expiring sends).
+  expires_at    TIMESTAMPTZ,
   status        TEXT NOT NULL DEFAULT 'pending',
   attempts      INTEGER NOT NULL DEFAULT 0,
   last_error    TEXT,
@@ -88,7 +103,13 @@ CREATE INDEX IF NOT EXISTS idx_email_outbox_pending_created
   WHERE status IN ('pending', 'in_flight');
 
 COMMENT ON TABLE email_outbox IS
-  'Durable outbox for transactional email (password reset, signup verification OTP). sendTransactionalEmail enqueues a pending row when the in-process retry path is exhausted; the Scheduler-backed flusher claims, re-sends via sendEmail, and stamps terminal status. Stripped-down mirror of crm_outbox — no email_key/workspace_id/sub-step columns. Stores no credentials (the reset-link token is single-use + short-TTL). See packages/api/src/lib/email-outbox/ (#2942).';
+  'Durable outbox for transactional email (password reset, signup verification OTP). sendTransactionalEmail enqueues a pending row when the in-process retry path is exhausted; the Scheduler-backed flusher claims, re-sends via sendEmail, and stamps terminal status. Stripped-down mirror of crm_outbox — no email_key/workspace_id/sub-step columns; adds expires_at (TTL) + encrypted payload because the body carries a live reset link / OTP. payload is encryptSecret-encrypted at rest. See packages/api/src/lib/email-outbox/ (#2942).';
+
+COMMENT ON COLUMN email_outbox.payload IS
+  'JSON-serialized rendered EmailMessage { to, subject, html }, encrypted at rest via encryptSecret (enc:v<N>:... AES-256-GCM; plaintext passthrough when no key is configured). Holds a live reset link / OTP for the TTL window, hence encryption. Decrypted by the flusher before sendEmail.';
+
+COMMENT ON COLUMN email_outbox.expires_at IS
+  'Hard delivery deadline derived from the email type TTL at enqueue (reset link 1h, OTP 10m). The flusher dead-letters a row past this instead of delivering a dead token. NULL = no deadline.';
 
 COMMENT ON COLUMN email_outbox.retry_after IS
   'Absolute timestamp before which the row must not be re-claimed. Set when a transient outcome carried an upstream-requested delay; NULL means the tier-based backoff applies. Cleared on the next transient outcome that lacks a delay.';

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -2283,8 +2283,10 @@ export const crmOutbox = pgTable(
 // `status` here is the OUTBOX LIFECYCLE status, NOT the content-mode status
 // (draft/published/archived). email_outbox is an operational queue, not
 // user-surfaced content, so it is intentionally OUTSIDE the content-mode
-// system (CLAUDE.md § Content Mode System carve-out). It stores no credentials
-// (the reset-link token is single-use + short-TTL), so it is NOT a member of
+// system (CLAUDE.md § Content Mode System carve-out). The payload IS a
+// bearer credential for the TTL window (a live reset link / OTP) — hence
+// encrypted at rest — but it holds no LONG-LIVED provider credential, so
+// there is nothing for F-47 rotation to re-key: it is NOT a member of
 // `INTEGRATION_TABLES`.
 // ---------------------------------------------------------------------------
 

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -2295,11 +2295,17 @@ export const emailOutbox = pgTable(
     // Send classification for observability / metrics bucketing
     // (e.g. 'password-reset', 'verification-otp'). Never used for routing.
     emailType: text("email_type").notNull(),
-    // Rendered EmailMessage: { to, subject, html }. Handed straight to sendEmail.
-    payload: jsonb("payload").notNull(),
+    // Rendered EmailMessage { to, subject, html }, JSON-serialized then
+    // encrypted via encryptSecret (enc:v<N>:... AES-256-GCM) — TEXT, not
+    // JSONB, because the stored value is opaque ciphertext. Holds a live
+    // reset link / OTP for the TTL window, hence encryption at rest.
+    payload: text("payload").notNull(),
     // Optional org scope so the flusher re-resolves a per-org transport
     // override on re-send. NULL for session-less flows (password reset).
     orgId: text("org_id"),
+    // Hard delivery deadline (per-type TTL). The flusher dead-letters a
+    // row past this rather than delivering an expired token. NULL = none.
+    expiresAt: timestamp("expires_at", { withTimezone: true }),
     status: text("status").$type<EmailOutboxStatus>().notNull().default("pending"),
     attempts: integer("attempts").notNull().default(0),
     lastError: text("last_error"),

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -10,6 +10,7 @@
  */
 
 import type { OutboxStatus } from "../lead-outbox/outbox";
+import type { EmailOutboxStatus } from "../email-outbox/outbox";
 import {
   pgTable,
   uuid,
@@ -2268,6 +2269,52 @@ export const crmOutbox = pgTable(
       .where(sql`status IN ('pending', 'in_flight')`),
     index("idx_crm_outbox_workspace_status_created")
       .on(t.workspaceId, t.status, t.createdAt)
+      .where(sql`status IN ('pending', 'in_flight')`),
+  ],
+);
+
+// ---------------------------------------------------------------------------
+// email_outbox (0107) — durable queue for transactional email (password reset,
+// signup verification OTP). Slice for #2942 residual scope. Owned by
+// `lib/email-outbox/`. A stripped-down mirror of `crm_outbox`: no email_key
+// serialization, no workspace_id routing, no sub-step resource-id columns —
+// transactional sends are single, independent, at-least-once operations.
+//
+// `status` here is the OUTBOX LIFECYCLE status, NOT the content-mode status
+// (draft/published/archived). email_outbox is an operational queue, not
+// user-surfaced content, so it is intentionally OUTSIDE the content-mode
+// system (CLAUDE.md § Content Mode System carve-out). It stores no credentials
+// (the reset-link token is single-use + short-TTL), so it is NOT a member of
+// `INTEGRATION_TABLES`.
+// ---------------------------------------------------------------------------
+
+export const emailOutbox = pgTable(
+  "email_outbox",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    // Send classification for observability / metrics bucketing
+    // (e.g. 'password-reset', 'verification-otp'). Never used for routing.
+    emailType: text("email_type").notNull(),
+    // Rendered EmailMessage: { to, subject, html }. Handed straight to sendEmail.
+    payload: jsonb("payload").notNull(),
+    // Optional org scope so the flusher re-resolves a per-org transport
+    // override on re-send. NULL for session-less flows (password reset).
+    orgId: text("org_id"),
+    status: text("status").$type<EmailOutboxStatus>().notNull().default("pending"),
+    attempts: integer("attempts").notNull().default(0),
+    lastError: text("last_error"),
+    retryAfter: timestamp("retry_after", { withTimezone: true }),
+    claimedAt: timestamp("claimed_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    processedAt: timestamp("processed_at", { withTimezone: true }),
+  },
+  (t) => [
+    check(
+      "email_outbox_status_chk",
+      sql`status IN ('pending', 'in_flight', 'done', 'dead')`,
+    ),
+    index("idx_email_outbox_pending_created")
+      .on(t.status, t.createdAt)
       .where(sql`status IN ('pending', 'in_flight')`),
   ],
 );

--- a/packages/api/src/lib/effect/__tests__/outbox-flusher-lifecycle.test.ts
+++ b/packages/api/src/lib/effect/__tests__/outbox-flusher-lifecycle.test.ts
@@ -110,8 +110,13 @@ describe("outbox flusher lifecycle (#2729 AC #7 + #9)", () => {
     // Each recoverInFlight call runs TWO statements: dead-letter
     // exhausted rows, then reset stale rows. So one boot + one
     // finalizer = 4 SQL invocations that target in_flight.
-    const recoveryCalls = sqlLog.filter((q) =>
-      /WHERE status = 'in_flight'/i.test(q.sql),
+    // CRM-specific canary: the email_outbox flusher (#2942) also runs an
+    // in_flight recovery sweep and mounts independently (gated on
+    // hasInternalDB, not SaasCrm), so the bare `WHERE status =
+    // 'in_flight'` predicate now matches both. Scope to `crm_outbox` so
+    // this test still counts only the CRM sweeps it's asserting about.
+    const recoveryCalls = sqlLog.filter(
+      (q) => q.sql.includes("crm_outbox") && /WHERE status = 'in_flight'/i.test(q.sql),
     );
     expect(recoveryCalls.length).toBe(4);
   });
@@ -132,8 +137,13 @@ describe("outbox flusher lifecycle (#2729 AC #7 + #9)", () => {
     await Effect.runPromise(rt.runtimeEffect);
     await rt.dispose();
 
-    const recoveryCalls = sqlLog.filter((q) =>
-      /WHERE status = 'in_flight'/i.test(q.sql),
+    // CRM-specific canary: the email_outbox flusher (#2942) also runs an
+    // in_flight recovery sweep and mounts independently (gated on
+    // hasInternalDB, not SaasCrm), so the bare `WHERE status =
+    // 'in_flight'` predicate now matches both. Scope to `crm_outbox` so
+    // this test still counts only the CRM sweeps it's asserting about.
+    const recoveryCalls = sqlLog.filter(
+      (q) => q.sql.includes("crm_outbox") && /WHERE status = 'in_flight'/i.test(q.sql),
     );
     // Neither boot nor finalizer touch the DB when the flusher is unwired.
     expect(recoveryCalls.length).toBe(0);
@@ -219,8 +229,10 @@ describe("outbox flusher lifecycle (#2729 AC #7 + #9)", () => {
 
       // Recovery sweeps must still have fired: one boot + one shutdown
       // = 2 × 2 statements (dead-letter + reset) = 4 in_flight queries.
-      const recoveryCalls = sqlLog.filter((q) =>
-        /WHERE status = 'in_flight'/i.test(q.sql),
+      // CRM-specific (see note above) — the email_outbox flusher's own
+      // recovery sweep must not inflate this CRM-gate assertion.
+      const recoveryCalls = sqlLog.filter(
+        (q) => q.sql.includes("crm_outbox") && /WHERE status = 'in_flight'/i.test(q.sql),
       );
       expect(recoveryCalls.length).toBe(4);
     } finally {
@@ -253,8 +265,13 @@ describe("outbox flusher lifecycle (#2729 AC #7 + #9)", () => {
     await Effect.runPromise(rt.runtimeEffect);
     await rt.dispose();
 
-    const recoveryCalls = sqlLog.filter((q) =>
-      /WHERE status = 'in_flight'/i.test(q.sql),
+    // CRM-specific canary: the email_outbox flusher (#2942) also runs an
+    // in_flight recovery sweep and mounts independently (gated on
+    // hasInternalDB, not SaasCrm), so the bare `WHERE status =
+    // 'in_flight'` predicate now matches both. Scope to `crm_outbox` so
+    // this test still counts only the CRM sweeps it's asserting about.
+    const recoveryCalls = sqlLog.filter(
+      (q) => q.sql.includes("crm_outbox") && /WHERE status = 'in_flight'/i.test(q.sql),
     );
     expect(recoveryCalls.length).toBe(0);
   });
@@ -286,8 +303,13 @@ describe("outbox flusher lifecycle (#2729 AC #7 + #9)", () => {
     // Recovery sweep is the canary — it only runs when the flusher
     // mounts. Presence of any in_flight reset/mark statement proves
     // the dispatcher-gated mount took effect.
-    const recoveryCalls = sqlLog.filter((q) =>
-      /WHERE status = 'in_flight'/i.test(q.sql),
+    // CRM-specific canary: the email_outbox flusher (#2942) also runs an
+    // in_flight recovery sweep and mounts independently (gated on
+    // hasInternalDB, not SaasCrm), so the bare `WHERE status =
+    // 'in_flight'` predicate now matches both. Scope to `crm_outbox` so
+    // this test still counts only the CRM sweeps it's asserting about.
+    const recoveryCalls = sqlLog.filter(
+      (q) => q.sql.includes("crm_outbox") && /WHERE status = 'in_flight'/i.test(q.sql),
     );
     expect(recoveryCalls.length).toBeGreaterThan(0);
   });

--- a/packages/api/src/lib/effect/__tests__/outbox-flusher-lifecycle.test.ts
+++ b/packages/api/src/lib/effect/__tests__/outbox-flusher-lifecycle.test.ts
@@ -314,3 +314,129 @@ describe("outbox flusher lifecycle (#2729 AC #7 + #9)", () => {
     expect(recoveryCalls.length).toBeGreaterThan(0);
   });
 });
+
+// ═══════════════════════════════════════════════════════════════════════
+// Email outbox flusher lifecycle (#2942)
+// ═══════════════════════════════════════════════════════════════════════
+//
+// The email_outbox flusher (transactional-email durability) is wired in
+// the SAME scheduler Layer as the CRM flusher but gated differently: it
+// mounts on `hasInternalDB()` ALONE — there is no SaasCrm / enterprise
+// gate, because password-reset / verification email happens in every
+// deploy mode with a DB. The CRM-side tests above were scoped to
+// `crm_outbox` so they don't observe this flusher; these tests assert the
+// email flusher's mount + recovery + tick-gate directly.
+
+describe("email outbox flusher lifecycle (#2942)", () => {
+  // email_outbox recovery sweeps (MARK_EXHAUSTED + RECOVER_STALE) — the
+  // only email statements carrying `WHERE status = 'in_flight'`.
+  const emailRecoverySweeps = () =>
+    sqlLog.filter(
+      (q) => q.sql.includes("email_outbox") && /WHERE status = 'in_flight'/i.test(q.sql),
+    );
+  // email tick observable side effects: the depth-snapshot SELECT and the
+  // CLAIM UPDATE both read `FROM email_outbox` and neither contains the
+  // `WHERE status = 'in_flight'` recovery predicate.
+  const emailTickCalls = () =>
+    sqlLog.filter(
+      (q) => /FROM email_outbox/i.test(q.sql) && !/WHERE status = 'in_flight'/i.test(q.sql),
+    );
+
+  test("runs email_outbox recovery sweeps on boot AND shutdown", async () => {
+    const config = {} as Parameters<typeof makeSchedulerLive>[0];
+    const layer = makeSchedulerLive(config).pipe(
+      Layer.provide(Layer.mergeAll(NoopEnterpriseDefaultsLayer, makeAvailableSaasCrmLayer())),
+    );
+    const rt = ManagedRuntime.make(layer);
+    await Effect.runPromise(rt.runtimeEffect);
+    await rt.dispose();
+
+    // One boot + one finalizer × two statements (dead-letter exhausted +
+    // reset stale) = 4 email_outbox in_flight sweeps.
+    expect(emailRecoverySweeps().length).toBe(4);
+  });
+
+  test("mounts INDEPENDENTLY of SaasCrm — fires even when SaasCrm.dispatcher is null", async () => {
+    // The key divergence from crm_outbox: a self-hosted / no-EE deploy has
+    // a null SaasCrm dispatcher (CRM flusher skipped) but still sends
+    // password-reset email, so the email flusher MUST mount on the DB gate
+    // alone. The dispatcher-null shape would skip the CRM flusher entirely.
+    const noopSaasCrm: Layer.Layer<SaasCrmTag> = Layer.succeed(SaasCrm, {
+      available: false,
+      upsertLead: () => Effect.void,
+      stampConversion: () => Effect.void,
+      dispatcher: null,
+    } satisfies SaasCrmShape);
+    const config = {} as Parameters<typeof makeSchedulerLive>[0];
+    const layer = makeSchedulerLive(config).pipe(
+      Layer.provide(Layer.mergeAll(NoopEnterpriseDefaultsLayer, noopSaasCrm)),
+    );
+    const rt = ManagedRuntime.make(layer);
+    await Effect.runPromise(rt.runtimeEffect);
+    await rt.dispose();
+
+    // CRM sweeps must be zero (dispatcher null), email sweeps must fire.
+    const crmSweeps = sqlLog.filter(
+      (q) => q.sql.includes("crm_outbox") && /WHERE status = 'in_flight'/i.test(q.sql),
+    );
+    expect(crmSweeps.length).toBe(0);
+    expect(emailRecoverySweeps().length).toBeGreaterThan(0);
+  });
+
+  test("does NOT mount when hasInternalDB() returns false", async () => {
+    internalDbAvailable = false;
+    const config = {} as Parameters<typeof makeSchedulerLive>[0];
+    const layer = makeSchedulerLive(config).pipe(
+      Layer.provide(Layer.mergeAll(NoopEnterpriseDefaultsLayer, makeAvailableSaasCrmLayer())),
+    );
+    const rt = ManagedRuntime.make(layer);
+    await Effect.runPromise(rt.runtimeEffect);
+    await rt.dispose();
+
+    expect(emailRecoverySweeps().length).toBe(0);
+    expect(emailTickCalls().length).toBe(0);
+  });
+
+  test("forked email tick fiber actually runs (regression: forkScoped not fork)", async () => {
+    // Mirror of the CRM #2864 canary for the email fiber: prove the tick
+    // fiber survives the gen returning. Without forkScoped we'd see zero
+    // `FROM email_outbox` depth-snapshot queries.
+    process.env.ATLAS_EMAIL_OUTBOX_TICK_SECONDS = "1";
+    try {
+      const config = {} as Parameters<typeof makeSchedulerLive>[0];
+      const layer = makeSchedulerLive(config).pipe(
+        Layer.provide(Layer.mergeAll(NoopEnterpriseDefaultsLayer, makeAvailableSaasCrmLayer())),
+      );
+      const rt = ManagedRuntime.make(layer);
+      await Effect.runPromise(rt.runtimeEffect);
+      await new Promise((r) => setTimeout(r, 2_500));
+      await rt.dispose();
+      expect(emailTickCalls().length).toBeGreaterThan(0);
+    } finally {
+      delete process.env.ATLAS_EMAIL_OUTBOX_TICK_SECONDS;
+    }
+  });
+
+  test("ATLAS_EMAIL_OUTBOX_FLUSHER_ENABLED=false skips the tick but keeps recovery sweeps", async () => {
+    process.env.ATLAS_EMAIL_OUTBOX_FLUSHER_ENABLED = "false";
+    process.env.ATLAS_EMAIL_OUTBOX_TICK_SECONDS = "1";
+    try {
+      const config = {} as Parameters<typeof makeSchedulerLive>[0];
+      const layer = makeSchedulerLive(config).pipe(
+        Layer.provide(Layer.mergeAll(NoopEnterpriseDefaultsLayer, makeAvailableSaasCrmLayer())),
+      );
+      const rt = ManagedRuntime.make(layer);
+      await Effect.runPromise(rt.runtimeEffect);
+      await new Promise((r) => setTimeout(r, 2_500));
+      await rt.dispose();
+
+      // Tick gated off → no FROM email_outbox tick queries.
+      expect(emailTickCalls().length).toBe(0);
+      // Recovery sweeps run regardless of the gate → boot + shutdown = 4.
+      expect(emailRecoverySweeps().length).toBe(4);
+    } finally {
+      delete process.env.ATLAS_EMAIL_OUTBOX_FLUSHER_ENABLED;
+      delete process.env.ATLAS_EMAIL_OUTBOX_TICK_SECONDS;
+    }
+  });
+});

--- a/packages/api/src/lib/effect/layers.ts
+++ b/packages/api/src/lib/effect/layers.ts
@@ -65,8 +65,25 @@ import {
   type RecoveryResult as OutboxRecoveryResult,
 } from "@atlas/api/lib/lead-outbox";
 import {
+  recoverInFlight as recoverEmailOutboxInFlight,
+  runEmailOutboxTick,
+  makeEmailDispatcher,
+  getTickIntervalMs as getEmailOutboxTickIntervalMs,
+  getWarnThreshold as getEmailOutboxWarnThreshold,
+  isFlusherEnabled as isEmailOutboxFlusherEnabled,
+  OutboxWarnRateLimiter as EmailOutboxWarnRateLimiter,
+  FLUSH_BATCH_LIMIT as EMAIL_OUTBOX_FLUSH_BATCH_LIMIT,
+  STARTUP_RECOVERY_STALE_MS as EMAIL_OUTBOX_STARTUP_STALE_MS,
+  SHUTDOWN_RECOVERY_STALE_MS as EMAIL_OUTBOX_SHUTDOWN_STALE_MS,
+  type EmailOutboxDB,
+  type RecoveryResult as EmailOutboxRecoveryResult,
+} from "@atlas/api/lib/email-outbox";
+import { sendEmail } from "@atlas/api/lib/email/delivery";
+import {
   crmOutboxPendingCount,
   crmOutboxDeadCount,
+  emailOutboxPendingCount,
+  emailOutboxDeadCount,
 } from "@atlas/api/lib/metrics";
 
 const log = createLogger("effect:layers");
@@ -1813,6 +1830,233 @@ export function makeSchedulerLive(
             hasInternalDB: hasInternalDB(),
           },
           "CRM outbox flusher not started — no dispatcher (self-hosted / no EE / no internal DB)",
+        );
+      }
+
+      // ── Periodic fiber: transactional-email outbox flusher (#2942) ──
+      // Durable at-least-once delivery for password-reset / verification
+      // emails so a SUSTAINED provider outage no longer drops a send.
+      // `sendTransactionalEmail` enqueues a pending row when the
+      // in-process retry path is exhausted; this flusher claims, re-sends
+      // via the RAW `sendEmail` (no re-enqueue loop), and stamps terminal
+      // status. Unlike the CRM flusher this is NOT enterprise-gated — the
+      // dispatcher is core `sendEmail`, and transactional auth email
+      // happens in every deploy mode that has an internal DB. Gate is
+      // therefore `hasInternalDB()` only.
+      if (hasInternalDB()) {
+        const emailOutboxDb: EmailOutboxDB = { query: internalQuery };
+        const emailDispatcher = makeEmailDispatcher(sendEmail);
+
+        // Startup recovery: reset stale `in_flight` carcasses from a
+        // crash mid-send, dead-letter rows past the retry budget. Runs
+        // BEFORE the tick starts.
+        yield* Effect.tryPromise({
+          try: (): Promise<EmailOutboxRecoveryResult> =>
+            recoverEmailOutboxInFlight(emailOutboxDb, EMAIL_OUTBOX_STARTUP_STALE_MS),
+          catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+        }).pipe(
+          Effect.tap((result: EmailOutboxRecoveryResult) =>
+            Effect.sync(() => {
+              if (result.reset > 0 || result.deadLettered > 0) {
+                log.warn(
+                  {
+                    reset: result.reset,
+                    deadLettered: result.deadLettered,
+                    staleAgeMs: EMAIL_OUTBOX_STARTUP_STALE_MS,
+                    event: "email_outbox.startup_recovery",
+                  },
+                  `Recovered email_outbox carcasses at boot — ${result.reset} reset to pending, ${result.deadLettered} dead-lettered`,
+                );
+              }
+            }),
+          ),
+          Effect.catchAll((err) =>
+            Effect.sync(() => {
+              log.error(
+                { err: errorMessage(err), event: "email_outbox.startup_recovery_failed" },
+                "Email outbox startup recovery failed — stranded in_flight rows will block until next restart",
+              );
+            }),
+          ),
+        );
+
+        // Shutdown-recovery finalizer — registered BEFORE the forks below
+        // so LIFO finalizer order interrupts the tick + watchdog fibers
+        // (awaiting their cleanup) before this sweep runs, avoiding a race
+        // with an in-flight tick. Same ordering rationale as the CRM block.
+        yield* Effect.addFinalizer(() =>
+          Effect.gen(function* () {
+            yield* Effect.tryPromise({
+              try: (): Promise<EmailOutboxRecoveryResult> =>
+                recoverEmailOutboxInFlight(emailOutboxDb, EMAIL_OUTBOX_SHUTDOWN_STALE_MS),
+              catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+            }).pipe(
+              Effect.tap((result: EmailOutboxRecoveryResult) =>
+                Effect.sync(() => {
+                  log.info(
+                    {
+                      reset: result.reset,
+                      deadLettered: result.deadLettered,
+                      staleAgeMs: EMAIL_OUTBOX_SHUTDOWN_STALE_MS,
+                      event: "email_outbox.shutdown_recovery",
+                    },
+                    `Email outbox shutdown sweep — ${result.reset} reset to pending, ${result.deadLettered} dead-lettered`,
+                  );
+                }),
+              ),
+              Effect.catchAll((err) =>
+                Effect.sync(() => {
+                  log.warn(
+                    { err: errorMessage(err), event: "email_outbox.shutdown_recovery_failed" },
+                    "Email outbox shutdown recovery sweep failed — next boot will mop up",
+                  );
+                }),
+              ),
+            );
+          }),
+        );
+
+        // Region/opt-out gate. Recovery sweeps above + the shutdown
+        // finalizer stay wired regardless so a flip-back-on inherits clean
+        // state. Nested-if (not early-return) so we don't skip the main
+        // scheduler finalizer below.
+        const emailFlusherEnabled = isEmailOutboxFlusherEnabled();
+        if (!emailFlusherEnabled) {
+          log.info(
+            { event: "email_outbox.flusher_disabled_by_env" },
+            "Email outbox flusher disabled by ATLAS_EMAIL_OUTBOX_FLUSHER_ENABLED=false — recovery sweeps still run on boot/shutdown",
+          );
+        }
+
+        if (emailFlusherEnabled) {
+          const emailTickIntervalMs = getEmailOutboxTickIntervalMs();
+          const emailWarnLimiter = new EmailOutboxWarnRateLimiter(getEmailOutboxWarnThreshold());
+          let emailTickCount = 0;
+          let emailLastTickAt = Date.now();
+          const EMAIL_HEARTBEAT_EVERY_N_TICKS = Math.max(
+            1,
+            Math.round(60_000 / Math.max(1, emailTickIntervalMs)),
+          );
+          const EMAIL_STALL_THRESHOLD_MS = Math.max(15_000, emailTickIntervalMs * 2);
+
+          const emailTick = Effect.sync(() => {
+            // Liveness stamped at tick START so a legitimately long tick
+            // (sequential re-sends with per-row network calls) doesn't
+            // trip the watchdog.
+            emailLastTickAt = Date.now();
+          }).pipe(
+            Effect.flatMap(() =>
+              Effect.tryPromise({
+                try: () =>
+                  runEmailOutboxTick({
+                    db: emailOutboxDb,
+                    dispatcher: emailDispatcher,
+                    batchLimit: EMAIL_OUTBOX_FLUSH_BATCH_LIMIT,
+                    limiter: emailWarnLimiter,
+                    pendingGauge: emailOutboxPendingCount,
+                    deadGauge: emailOutboxDeadCount,
+                    logger: log,
+                  }),
+                catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+              }),
+            ),
+            Effect.tap(({ flush: result, snapshot }) =>
+              Effect.sync(() => {
+                emailTickCount += 1;
+                if (result.claimed > 0) {
+                  log.info(
+                    {
+                      tickCount: emailTickCount,
+                      claimed: result.claimed,
+                      ok: result.ok,
+                      transient: result.transient,
+                      permanent: result.permanent,
+                      event: "email_outbox.tick_complete",
+                    },
+                    `Email outbox tick: ${result.claimed} claimed (ok=${result.ok}, transient=${result.transient}, dead=${result.permanent})`,
+                  );
+                  return;
+                }
+                if (emailTickCount % EMAIL_HEARTBEAT_EVERY_N_TICKS === 0) {
+                  log.info(
+                    {
+                      tickCount: emailTickCount,
+                      pending: snapshot.pending,
+                      dead: snapshot.dead,
+                      event: "email_outbox.heartbeat",
+                    },
+                    `Email outbox heartbeat tick=${emailTickCount} (queue idle: pending=${snapshot.pending}, dead=${snapshot.dead})`,
+                  );
+                }
+              }),
+            ),
+            Effect.catchAll((err) =>
+              Effect.sync(() => {
+                emailTickCount += 1;
+                log.warn(
+                  {
+                    tickCount: emailTickCount,
+                    err: errorMessage(err),
+                    event: "email_outbox.tick_failed",
+                  },
+                  "Email outbox flush tick failed — will retry on next interval",
+                );
+              }),
+            ),
+          );
+          // forkScoped, not fork — see SettingsLive. Recovery finalizer is
+          // registered ABOVE this fork so LIFO interrupts this fiber before
+          // the sweep runs.
+          yield* Effect.forkScoped(
+            withFiberDeathLog(
+              "email_outbox_flusher",
+              emailTick.pipe(Effect.repeat(Schedule.spaced(Duration.millis(emailTickIntervalMs)))),
+            ),
+          );
+
+          // Stall watchdog — surfaces a silently-dead fiber as an error
+          // log without auto-restarting (operator redeploys). Polls at
+          // tick cadence to bound detection lag.
+          let emailLastStallLogAt = 0;
+          const emailWatchdog = Effect.sync(() => {
+            const sinceMs = Date.now() - emailLastTickAt;
+            if (sinceMs < EMAIL_STALL_THRESHOLD_MS) return;
+            const now = Date.now();
+            if (now - emailLastStallLogAt < 60_000) return;
+            emailLastStallLogAt = now;
+            log.error(
+              {
+                tickCount: emailTickCount,
+                sinceLastTickMs: sinceMs,
+                thresholdMs: EMAIL_STALL_THRESHOLD_MS,
+                event: "email_outbox.tick_stall",
+              },
+              `Email outbox flusher fiber appears stalled — no tick in ${Math.round(sinceMs / 1000)}s (threshold ${Math.round(EMAIL_STALL_THRESHOLD_MS / 1000)}s). Redeploy to restart.`,
+            );
+          });
+          // forkScoped, not fork — see SettingsLive for rationale.
+          yield* Effect.forkScoped(
+            withFiberDeathLog(
+              "email_outbox_watchdog",
+              emailWatchdog.pipe(
+                Effect.repeat(Schedule.spaced(Duration.millis(emailTickIntervalMs))),
+              ),
+            ),
+          );
+          log.info(
+            {
+              intervalMs: emailTickIntervalMs,
+              batchLimit: EMAIL_OUTBOX_FLUSH_BATCH_LIMIT,
+              heartbeatEveryNTicks: EMAIL_HEARTBEAT_EVERY_N_TICKS,
+              stallThresholdMs: EMAIL_STALL_THRESHOLD_MS,
+            },
+            "Email outbox flusher started — heartbeat=email_outbox.heartbeat (every ~60s when idle); stall watchdog=email_outbox.tick_stall",
+          );
+        } // close `if (emailFlusherEnabled)`
+      } else {
+        log.debug(
+          { hasInternalDB: hasInternalDB() },
+          "Email outbox flusher not started — no internal DB",
         );
       }
 

--- a/packages/api/src/lib/email-outbox/__tests__/backoff.test.ts
+++ b/packages/api/src/lib/email-outbox/__tests__/backoff.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Backoff math — pure, deterministic. The values asserted here are the
+ * contract that the SQL CASE in `backoff.ts:CLAIM_DELAY_SQL` mirrors;
+ * if either changes, the other must change too. (Same tier schedule as
+ * lead-outbox — a sustained-outage backstop wants the same widening
+ * gaps so a down provider isn't hammered.)
+ */
+
+import { describe, expect, test } from "bun:test";
+import { CLAIM_DELAY_SQL, DEAD_AFTER_ATTEMPTS, nextDelayMs } from "../backoff";
+
+describe("nextDelayMs", () => {
+  test("attempts=0 is immediate (first try)", () => {
+    expect(nextDelayMs(0)).toBe(0);
+  });
+
+  test("matches the published tiers (30s, 2m, 8m, 30m, 2h)", () => {
+    expect(nextDelayMs(1)).toBe(30_000);
+    expect(nextDelayMs(2)).toBe(120_000);
+    expect(nextDelayMs(3)).toBe(480_000);
+    expect(nextDelayMs(4)).toBe(1_800_000);
+    expect(nextDelayMs(5)).toBe(7_200_000);
+  });
+
+  test("caps at the last tier rather than throwing past DEAD_AFTER_ATTEMPTS", () => {
+    expect(nextDelayMs(DEAD_AFTER_ATTEMPTS)).toBe(7_200_000);
+    expect(nextDelayMs(99)).toBe(7_200_000);
+  });
+
+  test("normalizes negative / NaN / fractional inputs to 0", () => {
+    expect(nextDelayMs(-1)).toBe(0);
+    expect(nextDelayMs(NaN)).toBe(0);
+    expect(nextDelayMs(0.5)).toBe(0);
+  });
+
+  test("DEAD_AFTER_ATTEMPTS is 6 — covered tiers 1..5, dead at 6th failure", () => {
+    expect(DEAD_AFTER_ATTEMPTS).toBe(6);
+  });
+});
+
+describe("CLAIM_DELAY_SQL", () => {
+  test("references every tier covered by nextDelayMs", () => {
+    // The SQL CASE and the TS array must stay in lockstep — a divergence
+    // means rows retry too eagerly (hammer a down provider) or never
+    // retry at all (stuck pending). This regression-spotter fails the
+    // diff long before a stuck row tells anyone.
+    expect(CLAIM_DELAY_SQL).toMatch(/WHEN 0/);
+    expect(CLAIM_DELAY_SQL).toMatch(/WHEN 1.+'30 seconds'/s);
+    expect(CLAIM_DELAY_SQL).toMatch(/WHEN 2.+'2 minutes'/s);
+    expect(CLAIM_DELAY_SQL).toMatch(/WHEN 3.+'8 minutes'/s);
+    expect(CLAIM_DELAY_SQL).toMatch(/WHEN 4.+'30 minutes'/s);
+    expect(CLAIM_DELAY_SQL).toMatch(/WHEN 5.+'2 hours'/s);
+  });
+});

--- a/packages/api/src/lib/email-outbox/__tests__/depth.test.ts
+++ b/packages/api/src/lib/email-outbox/__tests__/depth.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Depth snapshot + threshold rate-limiter for the email_outbox flusher.
+ * Pure behaviour against a stub DB / injected clock — no real Postgres.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+
+mock.module("@atlas/api/lib/logger", () => ({
+  createLogger: () => ({ info() {}, debug() {}, warn() {}, error() {} }),
+}));
+
+const {
+  queryDepthSnapshot,
+  getWarnThreshold,
+  OutboxWarnRateLimiter,
+  DEFAULT_WARN_THRESHOLD,
+  WARN_INTERVAL_MS,
+} = await import("../depth");
+type EmailOutboxDB = import("../outbox").EmailOutboxDB;
+
+function stubDb(row: Record<string, unknown> | null): EmailOutboxDB {
+  return {
+    async query<T extends Record<string, unknown>>(): Promise<T[]> {
+      return (row === null ? [] : [row]) as unknown as T[];
+    },
+  };
+}
+
+describe("queryDepthSnapshot", () => {
+  test("parses string counts (pg numeric) and the oldest pending timestamp", async () => {
+    const at = new Date("2026-05-29T00:00:00Z");
+    const snap = await queryDepthSnapshot(
+      stubDb({ pending_count: "7", dead_count: "2", oldest_pending_at: at.toISOString() }),
+    );
+    expect(snap.pending).toBe(7);
+    expect(snap.dead).toBe(2);
+    expect(snap.oldestPendingCreatedAt?.getTime()).toBe(at.getTime());
+  });
+
+  test("tolerates numeric counts and a null oldest timestamp", async () => {
+    const snap = await queryDepthSnapshot(
+      stubDb({ pending_count: 0, dead_count: 0, oldest_pending_at: null }),
+    );
+    expect(snap.pending).toBe(0);
+    expect(snap.dead).toBe(0);
+    expect(snap.oldestPendingCreatedAt).toBeNull();
+  });
+
+  test("throws when the aggregate returns no row (driver/pool invariant violated)", async () => {
+    await expect(queryDepthSnapshot(stubDb(null))).rejects.toThrow(/no aggregate row/i);
+  });
+});
+
+describe("getWarnThreshold", () => {
+  test("defaults when unset and rejects a non-integer", () => {
+    delete process.env.ATLAS_EMAIL_OUTBOX_WARN_THRESHOLD;
+    expect(getWarnThreshold()).toBe(DEFAULT_WARN_THRESHOLD);
+    process.env.ATLAS_EMAIL_OUTBOX_WARN_THRESHOLD = "100abc";
+    expect(getWarnThreshold()).toBe(DEFAULT_WARN_THRESHOLD);
+    delete process.env.ATLAS_EMAIL_OUTBOX_WARN_THRESHOLD;
+  });
+
+  test("honours a valid override", () => {
+    process.env.ATLAS_EMAIL_OUTBOX_WARN_THRESHOLD = "10";
+    expect(getWarnThreshold()).toBe(10);
+    delete process.env.ATLAS_EMAIL_OUTBOX_WARN_THRESHOLD;
+  });
+});
+
+describe("OutboxWarnRateLimiter", () => {
+  const oldest = new Date("2026-05-29T00:00:00Z");
+
+  test("returns null when depth is at or below threshold", () => {
+    const lim = new OutboxWarnRateLimiter(5);
+    expect(lim.evaluate({ pending: 5, dead: 0, oldestPendingCreatedAt: null }, 0)).toBeNull();
+  });
+
+  test("emits a decision above threshold and rate-limits within the interval", () => {
+    const lim = new OutboxWarnRateLimiter(5);
+    // Baseline must exceed WARN_INTERVAL_MS — lastWarnAt starts at 0, so
+    // the very first warn only fires once `now` is past one interval (in
+    // production `now` is Date.now(), always far past it).
+    const t0 = WARN_INTERVAL_MS + 1_000;
+    const first = lim.evaluate({ pending: 6, dead: 0, oldestPendingCreatedAt: oldest }, t0);
+    expect(first).not.toBeNull();
+    expect(first!.depth).toBe(6);
+    expect(first!.threshold).toBe(5);
+    // Still elevated, but within WARN_INTERVAL_MS → suppressed.
+    const second = lim.evaluate(
+      { pending: 7, dead: 0, oldestPendingCreatedAt: oldest },
+      t0 + WARN_INTERVAL_MS - 1,
+    );
+    expect(second).toBeNull();
+    // After the interval elapses → re-warns.
+    const third = lim.evaluate(
+      { pending: 7, dead: 0, oldestPendingCreatedAt: oldest },
+      t0 + WARN_INTERVAL_MS + 1,
+    );
+    expect(third).not.toBeNull();
+  });
+
+  test("computes oldest pending age from the injected clock", () => {
+    const lim = new OutboxWarnRateLimiter(0);
+    const now = oldest.getTime() + 90_000;
+    const decision = lim.evaluate({ pending: 1, dead: 0, oldestPendingCreatedAt: oldest }, now);
+    expect(decision!.oldestPendingAgeMs).toBe(90_000);
+  });
+});

--- a/packages/api/src/lib/email-outbox/__tests__/dispatch.test.ts
+++ b/packages/api/src/lib/email-outbox/__tests__/dispatch.test.ts
@@ -19,6 +19,7 @@ const ROW: ClaimedEmailRow = {
   message: { to: "user@example.com", subject: "Reset", html: "<p>x</p>" },
   orgId: null,
   attempts: 1,
+  expiresAt: null,
 };
 
 describe("makeEmailDispatcher", () => {

--- a/packages/api/src/lib/email-outbox/__tests__/dispatch.test.ts
+++ b/packages/api/src/lib/email-outbox/__tests__/dispatch.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Concrete email dispatcher — maps a `sendEmail` DeliveryResult onto the
+ * outbox's DispatchOutcome. The send function is injected so this test
+ * needs no module mock of the (heavy) delivery layer.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+
+mock.module("@atlas/api/lib/logger", () => ({
+  createLogger: () => ({ info() {}, debug() {}, warn() {}, error() {} }),
+}));
+
+const { makeEmailDispatcher } = await import("../dispatch");
+type ClaimedEmailRow = import("../outbox").ClaimedEmailRow;
+
+const ROW: ClaimedEmailRow = {
+  id: "row-1",
+  emailType: "password-reset",
+  message: { to: "user@example.com", subject: "Reset", html: "<p>x</p>" },
+  orgId: null,
+  attempts: 1,
+};
+
+describe("makeEmailDispatcher", () => {
+  test("forwards the message + orgId to the send fn and maps success to ok", async () => {
+    const calls: Array<{ to: string; orgId: string | undefined }> = [];
+    const dispatcher = makeEmailDispatcher(async (msg, orgId) => {
+      calls.push({ to: msg.to, orgId });
+      return { success: true, provider: "resend", messageId: "m1" };
+    });
+    const outcome = await dispatcher({ ...ROW, orgId: "org-9" });
+    expect(outcome.kind).toBe("ok");
+    expect(calls).toEqual([{ to: "user@example.com", orgId: "org-9" }]);
+  });
+
+  test("passes undefined (not null) orgId for session-less sends", async () => {
+    let seen: string | undefined = "sentinel";
+    const dispatcher = makeEmailDispatcher(async (_msg, orgId) => {
+      seen = orgId;
+      return { success: true, provider: "resend" };
+    });
+    await dispatcher(ROW);
+    expect(seen).toBeUndefined();
+  });
+
+  test("maps a delivery failure to a transient outcome carrying the provider error", async () => {
+    const dispatcher = makeEmailDispatcher(async () => ({
+      success: false,
+      provider: "resend",
+      error: "Resend API returned 503: upstream down",
+    }));
+    const outcome = await dispatcher(ROW);
+    expect(outcome.kind).toBe("transient");
+    if (outcome.kind === "transient") {
+      expect(outcome.message).toMatch(/503/);
+    }
+  });
+
+  test("synthesizes a message when a failure carries no error string", async () => {
+    const dispatcher = makeEmailDispatcher(async () => ({ success: false, provider: "log" }));
+    const outcome = await dispatcher(ROW);
+    expect(outcome.kind).toBe("transient");
+    if (outcome.kind === "transient") {
+      expect(outcome.message).toMatch(/log/);
+    }
+  });
+});

--- a/packages/api/src/lib/email-outbox/__tests__/outbox-pg.test.ts
+++ b/packages/api/src/lib/email-outbox/__tests__/outbox-pg.test.ts
@@ -100,21 +100,22 @@ describeIfPg("email-outbox (real Postgres)", () => {
       const db = dbFor();
       const id = await enqueue(db, { emailType: "password-reset", message: MSG });
 
-      // First flush fails transiently → attempts=1, tier=30s from created_at.
+      // First flush fails transiently → MARK_TRANSIENT stamps
+      // retry_after = now() + tier(1) = now()+30s (measured from the
+      // failure moment, via the GREATEST(now() + CASE..., $3) SQL).
       const first = await flushBatch(db, transient, 10);
       expect(first.transient).toBe(1);
       expect((await statusOf(id)).status).toBe("pending");
 
-      // Immediately: created_at ≈ now, so created_at + 30s > now → the
-      // real CLAIM_SQL WHERE excludes it.
+      // Immediately: retry_after (now+30s) > now → CLAIM_SQL excludes it.
       const second = await flushBatch(db, transient, 10);
       expect(second.claimed).toBe(0);
 
-      // Backdate created_at past the 30s tier — now the COALESCE gate
-      // admits it. Proves the CASE-based CLAIM_DELAY_SQL actually
-      // evaluates in Postgres.
+      // Backdate retry_after into the past — now the COALESCE gate admits
+      // it. Proves the real `GREATEST(now() + CASE..., $3)` retry_after was
+      // stamped and the claim WHERE honors it.
       await pool.query(
-        "UPDATE email_outbox SET created_at = now() - interval '31 seconds' WHERE id = $1",
+        "UPDATE email_outbox SET retry_after = now() - interval '1 second' WHERE id = $1",
         [id],
       );
       const third = await flushBatch(db, ok, 10);
@@ -159,22 +160,29 @@ describeIfPg("email-outbox (real Postgres)", () => {
   );
 
   it(
-    "recoverInFlight resets a stale in_flight row and dead-letters an exhausted one",
+    "recoverInFlight resets a stale in_flight row and dead-letters a stale exhausted one, but leaves a fresh exhausted row for the active sender",
     async () => {
       await truncate();
       const db = dbFor();
       const staleId = await enqueue(db, { emailType: "password-reset", message: MSG });
       const exhaustedId = await enqueue(db, { emailType: "verification-otp", message: MSG });
+      const freshExhaustedId = await enqueue(db, { emailType: "password-reset", message: MSG });
 
       // Stale: in_flight, claimed long ago, attempts under budget → reset.
       await pool.query(
         "UPDATE email_outbox SET status='in_flight', attempts=1, claimed_at = now() - interval '10 minutes' WHERE id = $1",
         [staleId],
       );
-      // Exhausted: in_flight at the budget, freshly claimed → dead.
+      // Stale + exhausted: in_flight at budget, claimed long ago → dead.
+      await pool.query(
+        "UPDATE email_outbox SET status='in_flight', attempts=6, claimed_at = now() - interval '10 minutes' WHERE id = $1",
+        [exhaustedId],
+      );
+      // Fresh + exhausted: a peer just claimed it for its final attempt and
+      // is mid-send → recovery must NOT dead-letter it (codex #2972).
       await pool.query(
         "UPDATE email_outbox SET status='in_flight', attempts=6, claimed_at = now() WHERE id = $1",
-        [exhaustedId],
+        [freshExhaustedId],
       );
 
       const result = await recoverInFlight(db);
@@ -182,6 +190,7 @@ describeIfPg("email-outbox (real Postgres)", () => {
       expect(result.deadLettered).toBe(1);
       expect((await statusOf(staleId)).status).toBe("pending");
       expect((await statusOf(exhaustedId)).status).toBe("dead");
+      expect((await statusOf(freshExhaustedId)).status).toBe("in_flight");
     },
     PG_TIMEOUT_MS,
   );
@@ -198,6 +207,53 @@ describeIfPg("email-outbox (real Postgres)", () => {
       expect(result.claimed).toBe(2);
       const pending = await pool.query("SELECT count(*)::int AS n FROM email_outbox WHERE status='pending'");
       expect(pending.rows[0].n).toBe(2);
+    },
+    PG_TIMEOUT_MS,
+  );
+
+  it(
+    "round-trips the message through the encrypt-at-rest path (decrypt yields the original)",
+    async () => {
+      await truncate();
+      const db = dbFor();
+      const secret = { ...MSG, html: "<a href='https://x/reset?token=SECRET123'>reset</a>" };
+      await enqueue(db, { emailType: "password-reset", message: secret });
+
+      // The flusher decrypts before dispatch — the dispatched message
+      // equals the original even though the stored column is opaque.
+      const delivered: Array<{ to: string; subject: string; html: string }> = [];
+      const capturing: EmailDispatcher = async (row) => {
+        delivered.push(row.message);
+        return { kind: "ok" };
+      };
+      const result = await flushBatch(db, capturing, 10);
+      expect(result.ok).toBe(1);
+      expect(delivered[0]).toEqual(secret);
+    },
+    PG_TIMEOUT_MS,
+  );
+
+  it(
+    "dead-letters an expired row WITHOUT dispatching it",
+    async () => {
+      await truncate();
+      const db = dbFor();
+      const id = await enqueue(db, {
+        emailType: "password-reset",
+        message: MSG,
+        expiresAt: new Date(Date.now() - 1_000), // already past
+      });
+      let dispatched = false;
+      const dispatcher: EmailDispatcher = async () => {
+        dispatched = true;
+        return { kind: "ok" };
+      };
+      const result = await flushBatch(db, dispatcher, 10);
+      expect(dispatched).toBe(false);
+      expect(result.permanent).toBe(1);
+      const row = await statusOf(id);
+      expect(row.status).toBe("dead");
+      expect(row.last_error).toMatch(/expired before delivery/);
     },
     PG_TIMEOUT_MS,
   );

--- a/packages/api/src/lib/email-outbox/__tests__/outbox-pg.test.ts
+++ b/packages/api/src/lib/email-outbox/__tests__/outbox-pg.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Real-Postgres integration tests for the email-outbox flusher.
+ *
+ * Skipped cleanly when `TEST_DATABASE_URL` is unset (matches
+ * `migrate-pg.test.ts` + the lead-outbox PG test). Exercises the actual
+ * CLAIM_SQL backoff gate (the `COALESCE(retry_after, created_at +
+ * CASE...)` WHERE clause), MARK_* statements, and the recovery sweep
+ * against real Postgres — the regex-matching FakeEmailOutboxDB in
+ * `outbox.test.ts` can't catch a SQL planning error.
+ *
+ * Each test runs against a unique per-test schema so concurrent shards
+ * don't collide; the email_outbox migration is applied via the runner
+ * inside that schema. Dispatchers are local lambdas — no real provider.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { Pool } from "pg";
+import { runMigrations } from "@atlas/api/lib/db/migrate";
+import { MANAGED_AUTH_MIGRATIONS } from "@atlas/api/lib/db/internal";
+import {
+  enqueue,
+  flushBatch,
+  recoverInFlight,
+  type EmailOutboxDB,
+  type EmailDispatcher,
+} from "../outbox";
+
+const MSG = { to: "user@example.com", subject: "Reset", html: "<p>link</p>" };
+
+const TEST_DB_URL = process.env.TEST_DATABASE_URL;
+const describeIfPg = TEST_DB_URL ? describe : describe.skip;
+const PG_TIMEOUT_MS = 30_000;
+
+describeIfPg("email-outbox (real Postgres)", () => {
+  let pool: Pool;
+  const schemaName = `email_outbox_${Date.now()}_${Math.floor(Math.random() * 1e6)}`;
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: TEST_DB_URL });
+    pool.on("connect", (client) => {
+      void client.query(`SET search_path TO "${schemaName}"`).catch((err) => {
+        const message = err instanceof Error ? err.message : String(err);
+        console.error(`email-outbox-pg: SET search_path failed: ${message}`);
+      });
+    });
+    await pool.query(`CREATE SCHEMA IF NOT EXISTS "${schemaName}"`);
+    await runMigrations(pool, { skip: MANAGED_AUTH_MIGRATIONS });
+  }, PG_TIMEOUT_MS);
+
+  afterAll(async () => {
+    if (!pool) return;
+    await pool.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`);
+    await pool.end();
+  });
+
+  function dbFor(): EmailOutboxDB {
+    return {
+      query: async <T extends Record<string, unknown>>(sql: string, params?: unknown[]) => {
+        const result = await pool.query<T>(sql, params);
+        return result.rows;
+      },
+    };
+  }
+
+  async function truncate(): Promise<void> {
+    await pool.query("TRUNCATE email_outbox");
+  }
+
+  async function statusOf(id: string): Promise<{ status: string; attempts: number; last_error: string | null }> {
+    const r = await pool.query<{ status: string; attempts: number; last_error: string | null }>(
+      "SELECT status, attempts, last_error FROM email_outbox WHERE id = $1",
+      [id],
+    );
+    return r.rows[0];
+  }
+
+  const ok: EmailDispatcher = async () => ({ kind: "ok" });
+  const transient: EmailDispatcher = async () => ({ kind: "transient", message: "Resend 503" });
+  const permanent: EmailDispatcher = async () => ({ kind: "permanent", message: "bad api key" });
+
+  it(
+    "enqueue → flushBatch → done (happy path against real SQL)",
+    async () => {
+      await truncate();
+      const db = dbFor();
+      const id = await enqueue(db, { emailType: "password-reset", message: MSG });
+      const result = await flushBatch(db, ok, 10);
+      expect(result).toEqual({ claimed: 1, ok: 1, transient: 0, permanent: 0 });
+      const row = await statusOf(id);
+      expect(row.status).toBe("done");
+      expect(row.attempts).toBe(1);
+    },
+    PG_TIMEOUT_MS,
+  );
+
+  it(
+    "transient failure returns to pending and is NOT re-claimable until the backoff tier elapses",
+    async () => {
+      await truncate();
+      const db = dbFor();
+      const id = await enqueue(db, { emailType: "password-reset", message: MSG });
+
+      // First flush fails transiently → attempts=1, tier=30s from created_at.
+      const first = await flushBatch(db, transient, 10);
+      expect(first.transient).toBe(1);
+      expect((await statusOf(id)).status).toBe("pending");
+
+      // Immediately: created_at ≈ now, so created_at + 30s > now → the
+      // real CLAIM_SQL WHERE excludes it.
+      const second = await flushBatch(db, transient, 10);
+      expect(second.claimed).toBe(0);
+
+      // Backdate created_at past the 30s tier — now the COALESCE gate
+      // admits it. Proves the CASE-based CLAIM_DELAY_SQL actually
+      // evaluates in Postgres.
+      await pool.query(
+        "UPDATE email_outbox SET created_at = now() - interval '31 seconds' WHERE id = $1",
+        [id],
+      );
+      const third = await flushBatch(db, ok, 10);
+      expect(third.claimed).toBe(1);
+      expect((await statusOf(id)).status).toBe("done");
+    },
+    PG_TIMEOUT_MS,
+  );
+
+  it(
+    "retry_after overrides the tier — a far-future retry_after blocks an otherwise-due row",
+    async () => {
+      await truncate();
+      const db = dbFor();
+      const id = await enqueue(db, { emailType: "password-reset", message: MSG });
+      // attempts=0 + created_at now → would be immediately due, but a
+      // future retry_after must win via COALESCE.
+      await pool.query(
+        "UPDATE email_outbox SET retry_after = now() + interval '1 hour' WHERE id = $1",
+        [id],
+      );
+      const result = await flushBatch(db, ok, 10);
+      expect(result.claimed).toBe(0);
+      expect((await statusOf(id)).status).toBe("pending");
+    },
+    PG_TIMEOUT_MS,
+  );
+
+  it(
+    "permanent failure dead-letters immediately",
+    async () => {
+      await truncate();
+      const db = dbFor();
+      const id = await enqueue(db, { emailType: "password-reset", message: MSG });
+      const result = await flushBatch(db, permanent, 10);
+      expect(result.permanent).toBe(1);
+      const row = await statusOf(id);
+      expect(row.status).toBe("dead");
+      expect(row.last_error).toBe("bad api key");
+    },
+    PG_TIMEOUT_MS,
+  );
+
+  it(
+    "recoverInFlight resets a stale in_flight row and dead-letters an exhausted one",
+    async () => {
+      await truncate();
+      const db = dbFor();
+      const staleId = await enqueue(db, { emailType: "password-reset", message: MSG });
+      const exhaustedId = await enqueue(db, { emailType: "verification-otp", message: MSG });
+
+      // Stale: in_flight, claimed long ago, attempts under budget → reset.
+      await pool.query(
+        "UPDATE email_outbox SET status='in_flight', attempts=1, claimed_at = now() - interval '10 minutes' WHERE id = $1",
+        [staleId],
+      );
+      // Exhausted: in_flight at the budget, freshly claimed → dead.
+      await pool.query(
+        "UPDATE email_outbox SET status='in_flight', attempts=6, claimed_at = now() WHERE id = $1",
+        [exhaustedId],
+      );
+
+      const result = await recoverInFlight(db);
+      expect(result.reset).toBe(1);
+      expect(result.deadLettered).toBe(1);
+      expect((await statusOf(staleId)).status).toBe("pending");
+      expect((await statusOf(exhaustedId)).status).toBe("dead");
+    },
+    PG_TIMEOUT_MS,
+  );
+
+  it(
+    "claims in created_at order up to the batch limit",
+    async () => {
+      await truncate();
+      const db = dbFor();
+      for (let i = 0; i < 4; i++) {
+        await enqueue(db, { emailType: "password-reset", message: { ...MSG, to: `u${i}@x.co` } });
+      }
+      const result = await flushBatch(db, ok, 2);
+      expect(result.claimed).toBe(2);
+      const pending = await pool.query("SELECT count(*)::int AS n FROM email_outbox WHERE status='pending'");
+      expect(pending.rows[0].n).toBe(2);
+    },
+    PG_TIMEOUT_MS,
+  );
+});

--- a/packages/api/src/lib/email-outbox/__tests__/outbox.test.ts
+++ b/packages/api/src/lib/email-outbox/__tests__/outbox.test.ts
@@ -432,6 +432,30 @@ describe("flushBatch", () => {
     expect(loggerCalls.warn.some((c) => c.data.event === "email_outbox.dead_letter_expired")).toBe(true);
   });
 
+  test("a decrypt failure is RETRYABLE (stays pending), not a permanent dead-letter (codex #2972)", async () => {
+    const db = new FakeEmailOutboxDB();
+    await enqueue(db, { emailType: "password-reset", message: MSG });
+    // Simulate a row whose payload references a key version that's no
+    // longer configured (rotation drift): a versioned-prefix value that
+    // decryptSecret can't decrypt → it throws → coerceMessage returns
+    // "retryable". A fixable key-config error must NOT irreversibly
+    // dead-letter the queued auth email.
+    db.rows[0].payload = "enc:v1:aaaa:bbbb:cccc";
+    let dispatched = false;
+    const dispatcher: EmailDispatcher = async () => {
+      dispatched = true;
+      return { kind: "ok" };
+    };
+    const result = await flushBatch(db, dispatcher, 10);
+    expect(dispatched).toBe(false); // never handed to the dispatcher
+    expect(result.transient).toBe(1);
+    expect(result.permanent).toBe(0);
+    const row = db.byId("row-1")!;
+    expect(row.status).toBe("pending"); // recoverable — NOT dead
+    expect(row.attempts).toBe(1);
+    expect(loggerCalls.error.some((c) => c.data.event === "email_outbox.decrypt_failed")).toBe(true);
+  });
+
   test("delivers a not-yet-expired row normally", async () => {
     const db = new FakeEmailOutboxDB();
     await enqueue(db, {

--- a/packages/api/src/lib/email-outbox/__tests__/outbox.test.ts
+++ b/packages/api/src/lib/email-outbox/__tests__/outbox.test.ts
@@ -51,8 +51,10 @@ type EmailOutboxDB = import("../outbox").EmailOutboxDB;
 type Row = {
   id: string;
   email_type: string;
-  payload: unknown;
+  /** Raw stored payload string (encryptSecret output; plaintext JSON when no key). */
+  payload: string;
   org_id: string | null;
+  expires_at: number | null;
   status: "pending" | "in_flight" | "done" | "dead";
   attempts: number;
   last_error: string | null;
@@ -110,12 +112,14 @@ class FakeEmailOutboxDB implements EmailOutboxDB {
     }
 
     if (/^\s*INSERT INTO email_outbox/i.test(sql)) {
+      // params: [email_type, payload(string), org_id, expires_at(Date|null)]
       const id = `row-${this.nextId++}`;
       this.rows.push({
         id,
         email_type: String(p[0]),
-        payload: typeof p[1] === "string" ? JSON.parse(p[1] as string) : p[1],
+        payload: String(p[1]),
         org_id: (p[2] as string | null) ?? null,
+        expires_at: p[3] instanceof Date ? (p[3] as Date).getTime() : null,
         status: "pending",
         attempts: 0,
         last_error: null,
@@ -153,6 +157,7 @@ class FakeEmailOutboxDB implements EmailOutboxDB {
         email_type: r.email_type,
         payload: r.payload,
         org_id: r.org_id,
+        expires_at: r.expires_at === null ? null : new Date(r.expires_at),
         attempts: r.attempts,
       })) as unknown as T[];
     }
@@ -170,12 +175,17 @@ class FakeEmailOutboxDB implements EmailOutboxDB {
     }
 
     if (/SET status = 'pending',\s*last_error/i.test(sql)) {
-      // MARK_TRANSIENT_FAIL: [last_error, id, retry_after(Date|null)]
+      // MARK_TRANSIENT_FAIL: [last_error, id, upstreamRetryAfter(Date|null)].
+      // Mirrors `retry_after = GREATEST(now() + tier(attempts), $3)` — the
+      // next-due time is measured from the failure moment (`this.now`),
+      // taking the max with any upstream-requested delay.
       const r = this.byId(String(p[1]));
       if (r) {
         r.status = "pending";
         r.last_error = (p[0] as string) ?? null;
-        r.retry_after = p[2] instanceof Date ? (p[2] as Date).getTime() : null;
+        const tierDue = this.now + nextDelayMs(r.attempts);
+        const upstreamDue = p[2] instanceof Date ? (p[2] as Date).getTime() : 0;
+        r.retry_after = Math.max(tierDue, upstreamDue);
         r.claimed_at = null;
       }
       return [] as unknown as T[];
@@ -195,9 +205,15 @@ class FakeEmailOutboxDB implements EmailOutboxDB {
     }
 
     if (/SET status = 'dead', processed_at = now\(\),\s*\n?\s*last_error = CASE/i.test(sql)) {
-      // MARK_EXHAUSTED_IN_FLIGHT_DEAD (no params)
+      // MARK_EXHAUSTED_IN_FLIGHT_DEAD: [staleAgeMs]. Only dead-letters
+      // exhausted in_flight rows that are ALSO stale, so a peer mid-send on
+      // its final attempt is left alone (codex #2972).
+      const staleMs = Number(p[0]);
       const hit = this.rows.filter(
-        (r) => r.status === "in_flight" && r.attempts >= DEAD_AFTER_ATTEMPTS,
+        (r) =>
+          r.status === "in_flight" &&
+          r.attempts >= DEAD_AFTER_ATTEMPTS &&
+          (r.claimed_at === null || r.claimed_at < this.now - staleMs),
       );
       for (const r of hit) {
         r.status = "dead";
@@ -244,8 +260,33 @@ describe("enqueue", () => {
     expect(row.status).toBe("pending");
     expect(row.attempts).toBe(0);
     expect(row.email_type).toBe("password-reset");
-    expect(row.payload).toEqual(MSG);
+    // payload is stored as an opaque (encrypted-or-passthrough) string;
+    // the round-trip back to MSG is asserted in the decrypt test below.
+    expect(typeof row.payload).toBe("string");
     expect(row.org_id).toBeNull();
+    expect(row.expires_at).toBeNull();
+  });
+
+  test("encrypts the payload at rest and flush decrypts it back to the original message", async () => {
+    const db = new FakeEmailOutboxDB();
+    await enqueue(db, { emailType: "password-reset", message: MSG });
+    const delivered: Array<{ to: string; subject: string; html: string }> = [];
+    const capturing: EmailDispatcher = async (row) => {
+      delivered.push(row.message);
+      return { kind: "ok" };
+    };
+    await flushBatch(db, capturing, 10);
+    // The dispatcher receives the message coerceMessage decrypted+parsed
+    // out of the stored payload — proving the enqueue→store→claim→decrypt
+    // round-trip is lossless.
+    expect(delivered[0]).toEqual(MSG);
+  });
+
+  test("stamps expires_at from the enqueue input", async () => {
+    const db = new FakeEmailOutboxDB();
+    const exp = new Date(Date.now() + 3_600_000);
+    const id = await enqueue(db, { emailType: "password-reset", message: MSG, expiresAt: exp });
+    expect(db.byId(id)!.expires_at).toBe(exp.getTime());
   });
 
   test("threads orgId through when provided", async () => {
@@ -282,7 +323,9 @@ describe("flushBatch", () => {
     expect(row.status).toBe("pending");
     expect(row.attempts).toBe(1);
     expect(row.last_error).toBe("Resend 503");
-    expect(row.retry_after).toBeNull();
+    // retry_after is now ALWAYS stamped from the failure moment (tier 1 =
+    // 30s), so a long-pending row can't burst through its budget.
+    expect(row.retry_after).toBe(db.now + nextDelayMs(1));
   });
 
   test("a transient failure with a retryAfterMs stamps retry_after", async () => {
@@ -355,8 +398,9 @@ describe("flushBatch", () => {
   test("a malformed payload dead-letters without burning the retry budget", async () => {
     const db = new FakeEmailOutboxDB();
     await enqueue(db, { emailType: "password-reset", message: MSG });
-    // Corrupt the stored payload as if it were written by a buggy path.
-    db.rows[0].payload = { subject: "no recipient" };
+    // Corrupt the stored payload as if it were written by a buggy path:
+    // valid JSON (decrypt passthrough) but missing the required fields.
+    db.rows[0].payload = JSON.stringify({ subject: "no recipient" });
     let dispatched = false;
     const dispatcher: EmailDispatcher = async () => {
       dispatched = true;
@@ -366,6 +410,38 @@ describe("flushBatch", () => {
     expect(dispatched).toBe(false); // never handed to the dispatcher
     expect(result.permanent).toBe(1);
     expect(db.rows[0].status).toBe("dead");
+  });
+
+  test("dead-letters an expired row WITHOUT dispatching it (no dead-token delivery)", async () => {
+    const db = new FakeEmailOutboxDB();
+    await enqueue(db, {
+      emailType: "password-reset",
+      message: MSG,
+      expiresAt: new Date(Date.now() - 1_000), // already past
+    });
+    let dispatched = false;
+    const dispatcher: EmailDispatcher = async () => {
+      dispatched = true;
+      return { kind: "ok" };
+    };
+    const result = await flushBatch(db, dispatcher, 10);
+    expect(dispatched).toBe(false); // never sent a dead link
+    expect(result.permanent).toBe(1);
+    expect(db.byId("row-1")!.status).toBe("dead");
+    expect(db.byId("row-1")!.last_error).toMatch(/expired before delivery/);
+    expect(loggerCalls.warn.some((c) => c.data.event === "email_outbox.dead_letter_expired")).toBe(true);
+  });
+
+  test("delivers a not-yet-expired row normally", async () => {
+    const db = new FakeEmailOutboxDB();
+    await enqueue(db, {
+      emailType: "password-reset",
+      message: MSG,
+      expiresAt: new Date(Date.now() + 3_600_000), // 1h out
+    });
+    const result = await flushBatch(db, okDispatcher, 10);
+    expect(result.ok).toBe(1);
+    expect(db.byId("row-1")!.status).toBe("done");
   });
 
   test("claims up to the batch limit and no more", async () => {
@@ -443,15 +519,27 @@ describe("recoverInFlight", () => {
     expect(db.byId("row-1")!.status).toBe("in_flight");
   });
 
-  test("dead-letters an exhausted in_flight carcass regardless of staleness", async () => {
+  test("dead-letters a STALE exhausted in_flight carcass", async () => {
     const db = new FakeEmailOutboxDB();
     await enqueue(db, { emailType: "password-reset", message: MSG });
     db.rows[0].status = "in_flight";
     db.rows[0].attempts = DEAD_AFTER_ATTEMPTS;
-    db.rows[0].claimed_at = db.now; // fresh, but exhausted
+    db.rows[0].claimed_at = db.now;
+    db.advance(10 * 60_000); // 10 min — past the 5 min startup window
     const result = await recoverInFlight(db);
     expect(result.deadLettered).toBe(1);
     expect(db.byId("row-1")!.status).toBe("dead");
+  });
+
+  test("leaves a FRESH exhausted in_flight row alone — a peer may be mid-final-send (codex #2972)", async () => {
+    const db = new FakeEmailOutboxDB();
+    await enqueue(db, { emailType: "password-reset", message: MSG });
+    db.rows[0].status = "in_flight";
+    db.rows[0].attempts = DEAD_AFTER_ATTEMPTS;
+    db.rows[0].claimed_at = db.now; // just claimed → NOT stale
+    const result = await recoverInFlight(db);
+    expect(result.deadLettered).toBe(0);
+    expect(db.byId("row-1")!.status).toBe("in_flight");
   });
 });
 

--- a/packages/api/src/lib/email-outbox/__tests__/outbox.test.ts
+++ b/packages/api/src/lib/email-outbox/__tests__/outbox.test.ts
@@ -1,0 +1,450 @@
+/**
+ * Email-outbox unit tests against an in-memory fake of the
+ * `EmailOutboxDB` surface. We avoid a real Postgres here — the SQL
+ * strings are exercised end-to-end in `outbox-pg.test.ts` (gated on
+ * `TEST_DATABASE_URL`). This file nails the enqueue / flush / recover
+ * lifecycle, which is pure TypeScript behaviour.
+ *
+ * The fake recognises each SQL string from the module and dispatches to
+ * an in-memory row table with a controllable monotonic clock so backoff
+ * gating is deterministic.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// Logger mock MUST be installed before importing outbox.ts so the
+// module-level createLogger() call captures our stub. Per CLAUDE.md the
+// email-outbox/__tests__/ directory is allowed mock.module() for this.
+const loggerCalls: {
+  warn: Array<{ data: Record<string, unknown>; message: string }>;
+  error: Array<{ data: Record<string, unknown>; message: string }>;
+} = { warn: [], error: [] };
+
+mock.module("@atlas/api/lib/logger", () => ({
+  createLogger: () => ({
+    info: () => {},
+    debug: () => {},
+    warn: (data: Record<string, unknown>, message: string) => {
+      loggerCalls.warn.push({ data, message });
+    },
+    error: (data: Record<string, unknown>, message: string) => {
+      loggerCalls.error.push({ data, message });
+    },
+  }),
+}));
+
+const {
+  computeRetryAfterTimestamp,
+  enqueue,
+  flushBatch,
+  getTickIntervalMs,
+  isFlusherEnabled,
+  recoverInFlight,
+  DEFAULT_TICK_SECONDS,
+  MAX_TICK_SECONDS,
+  MIN_TICK_SECONDS,
+} = await import("../outbox");
+const { DEAD_AFTER_ATTEMPTS, nextDelayMs } = await import("../backoff");
+type EmailDispatcher = import("../outbox").EmailDispatcher;
+type EmailOutboxDB = import("../outbox").EmailOutboxDB;
+
+type Row = {
+  id: string;
+  email_type: string;
+  payload: unknown;
+  org_id: string | null;
+  status: "pending" | "in_flight" | "done" | "dead";
+  attempts: number;
+  last_error: string | null;
+  retry_after: number | null;
+  claimed_at: number | null;
+  created_at: number;
+  processed_at: number | null;
+};
+
+const MSG = { to: "user@example.com", subject: "Reset", html: "<p>link</p>" };
+
+/**
+ * In-memory EmailOutboxDB. `now` is a controllable monotonic clock so
+ * the backoff gate (`created_at + tier(attempts) <= now`) is
+ * deterministic. created_at is stamped from `now` at insert; `now`
+ * does not auto-advance.
+ */
+class FakeEmailOutboxDB implements EmailOutboxDB {
+  rows: Row[] = [];
+  now = 1_000_000; // arbitrary baseline (ms)
+  private nextId = 1;
+
+  advance(ms: number): void {
+    this.now += ms;
+  }
+
+  byId(id: string): Row | undefined {
+    return this.rows.find((r) => r.id === id);
+  }
+
+  async query<T extends Record<string, unknown>>(
+    sql: string,
+    params?: unknown[],
+  ): Promise<T[]> {
+    const p = params ?? [];
+
+    if (/^\s*INSERT INTO email_outbox/i.test(sql)) {
+      const id = `row-${this.nextId++}`;
+      this.rows.push({
+        id,
+        email_type: String(p[0]),
+        payload: typeof p[1] === "string" ? JSON.parse(p[1] as string) : p[1],
+        org_id: (p[2] as string | null) ?? null,
+        status: "pending",
+        attempts: 0,
+        last_error: null,
+        retry_after: null,
+        claimed_at: null,
+        created_at: this.now,
+        processed_at: null,
+      });
+      return [{ id }] as unknown as T[];
+    }
+
+    if (/^\s*UPDATE email_outbox\s+SET status = 'in_flight'/i.test(sql)) {
+      // CLAIM: pending + attempts < DEAD + due (COALESCE(retry_after,
+      // created_at + tier(attempts)) <= now), ordered by created_at,id,
+      // limited.
+      const limit = Number(p[0]);
+      const due = this.rows
+        .filter(
+          (r) =>
+            r.status === "pending" &&
+            r.attempts < DEAD_AFTER_ATTEMPTS &&
+            (r.retry_after ?? r.created_at + nextDelayMs(r.attempts)) <= this.now,
+        )
+        .sort((a, b) => a.created_at - b.created_at || a.id.localeCompare(b.id))
+        .slice(0, limit);
+      const claimed: Row[] = [];
+      for (const r of due) {
+        r.status = "in_flight";
+        r.attempts += 1;
+        r.claimed_at = this.now;
+        claimed.push(r);
+      }
+      return claimed.map((r) => ({
+        id: r.id,
+        email_type: r.email_type,
+        payload: r.payload,
+        org_id: r.org_id,
+        attempts: r.attempts,
+      })) as unknown as T[];
+    }
+
+    if (/SET status = 'done'/i.test(sql)) {
+      const r = this.byId(String(p[0]));
+      if (r) {
+        r.status = "done";
+        r.processed_at = this.now;
+        r.last_error = null;
+        r.retry_after = null;
+        r.claimed_at = null;
+      }
+      return [] as unknown as T[];
+    }
+
+    if (/SET status = 'pending',\s*last_error/i.test(sql)) {
+      // MARK_TRANSIENT_FAIL: [last_error, id, retry_after(Date|null)]
+      const r = this.byId(String(p[1]));
+      if (r) {
+        r.status = "pending";
+        r.last_error = (p[0] as string) ?? null;
+        r.retry_after = p[2] instanceof Date ? (p[2] as Date).getTime() : null;
+        r.claimed_at = null;
+      }
+      return [] as unknown as T[];
+    }
+
+    if (/SET status = 'dead',\s*processed_at = now\(\),\s*\n?\s*last_error = \$1/i.test(sql)) {
+      // MARK_DEAD: [last_error, id]
+      const r = this.byId(String(p[1]));
+      if (r) {
+        r.status = "dead";
+        r.processed_at = this.now;
+        r.last_error = (p[0] as string) ?? null;
+        r.retry_after = null;
+        r.claimed_at = null;
+      }
+      return [] as unknown as T[];
+    }
+
+    if (/SET status = 'dead', processed_at = now\(\),\s*\n?\s*last_error = CASE/i.test(sql)) {
+      // MARK_EXHAUSTED_IN_FLIGHT_DEAD (no params)
+      const hit = this.rows.filter(
+        (r) => r.status === "in_flight" && r.attempts >= DEAD_AFTER_ATTEMPTS,
+      );
+      for (const r of hit) {
+        r.status = "dead";
+        r.processed_at = this.now;
+        r.last_error = r.last_error ?? `crashed mid-send at attempts=${r.attempts} (recovery)`;
+      }
+      return hit.map((r) => ({ id: r.id })) as unknown as T[];
+    }
+
+    if (/^\s*UPDATE email_outbox\s+SET status = 'pending'\s+WHERE status = 'in_flight'/i.test(sql)) {
+      // RECOVER_STALE_IN_FLIGHT: [staleAgeMs]
+      const staleMs = Number(p[0]);
+      const hit = this.rows.filter(
+        (r) =>
+          r.status === "in_flight" &&
+          r.attempts < DEAD_AFTER_ATTEMPTS &&
+          (r.claimed_at === null || r.claimed_at < this.now - staleMs),
+      );
+      for (const r of hit) r.status = "pending";
+      return hit.map((r) => ({ id: r.id })) as unknown as T[];
+    }
+
+    throw new Error(`FakeEmailOutboxDB: unrecognized SQL:\n${sql}`);
+  }
+}
+
+const okDispatcher: EmailDispatcher = async () => ({ kind: "ok" });
+const transientDispatcher: EmailDispatcher = async () => ({
+  kind: "transient",
+  message: "Resend 503",
+});
+
+beforeEach(() => {
+  loggerCalls.warn.length = 0;
+  loggerCalls.error.length = 0;
+});
+
+describe("enqueue", () => {
+  test("inserts a pending row and returns its id", async () => {
+    const db = new FakeEmailOutboxDB();
+    const id = await enqueue(db, { emailType: "password-reset", message: MSG });
+    expect(id).toBe("row-1");
+    const row = db.byId(id)!;
+    expect(row.status).toBe("pending");
+    expect(row.attempts).toBe(0);
+    expect(row.email_type).toBe("password-reset");
+    expect(row.payload).toEqual(MSG);
+    expect(row.org_id).toBeNull();
+  });
+
+  test("threads orgId through when provided", async () => {
+    const db = new FakeEmailOutboxDB();
+    const id = await enqueue(db, { emailType: "invite", message: MSG, orgId: "org-7" });
+    expect(db.byId(id)!.org_id).toBe("org-7");
+  });
+
+  test("rejects an empty recipient at the seam", async () => {
+    const db = new FakeEmailOutboxDB();
+    await expect(
+      enqueue(db, { emailType: "password-reset", message: { ...MSG, to: "  " } }),
+    ).rejects.toThrow(/non-empty recipient/);
+    expect(db.rows).toHaveLength(0);
+  });
+});
+
+describe("flushBatch", () => {
+  test("delivers a due row and marks it done", async () => {
+    const db = new FakeEmailOutboxDB();
+    await enqueue(db, { emailType: "password-reset", message: MSG });
+    const result = await flushBatch(db, okDispatcher, 10);
+    expect(result).toEqual({ claimed: 1, ok: 1, transient: 0, permanent: 0 });
+    expect(db.rows[0].status).toBe("done");
+    expect(db.rows[0].attempts).toBe(1);
+  });
+
+  test("a transient failure returns the row to pending with the error recorded", async () => {
+    const db = new FakeEmailOutboxDB();
+    await enqueue(db, { emailType: "password-reset", message: MSG });
+    const result = await flushBatch(db, transientDispatcher, 10);
+    expect(result).toEqual({ claimed: 1, ok: 0, transient: 1, permanent: 0 });
+    const row = db.rows[0];
+    expect(row.status).toBe("pending");
+    expect(row.attempts).toBe(1);
+    expect(row.last_error).toBe("Resend 503");
+    expect(row.retry_after).toBeNull();
+  });
+
+  test("a transient failure with a retryAfterMs stamps retry_after", async () => {
+    const db = new FakeEmailOutboxDB();
+    await enqueue(db, { emailType: "password-reset", message: MSG });
+    const dispatcher: EmailDispatcher = async () => ({
+      kind: "transient",
+      message: "rate limited",
+      retryAfterMs: 60_000,
+    });
+    await flushBatch(db, dispatcher, 10);
+    expect(db.rows[0].retry_after).not.toBeNull();
+  });
+
+  test("a permanent failure dead-letters the row immediately", async () => {
+    const db = new FakeEmailOutboxDB();
+    await enqueue(db, { emailType: "password-reset", message: MSG });
+    const dispatcher: EmailDispatcher = async () => ({
+      kind: "permanent",
+      message: "bad api key",
+    });
+    const result = await flushBatch(db, dispatcher, 10);
+    expect(result.permanent).toBe(1);
+    expect(db.rows[0].status).toBe("dead");
+    expect(db.rows[0].last_error).toBe("bad api key");
+  });
+
+  test("backoff: a freshly-failed row is not re-claimed until its tier elapses", async () => {
+    const db = new FakeEmailOutboxDB();
+    await enqueue(db, { emailType: "password-reset", message: MSG });
+    // First flush fails transiently → attempts=1, tier=30s.
+    await flushBatch(db, transientDispatcher, 10);
+    // Immediately: not due (created_at + 30s > now).
+    const second = await flushBatch(db, transientDispatcher, 10);
+    expect(second.claimed).toBe(0);
+    // After 30s elapses it becomes claimable again.
+    db.advance(nextDelayMs(1));
+    const third = await flushBatch(db, okDispatcher, 10);
+    expect(third.claimed).toBe(1);
+    expect(db.rows[0].status).toBe("done");
+  });
+
+  test("dead-letters on the final transient failure once the budget is exhausted", async () => {
+    const db = new FakeEmailOutboxDB();
+    await enqueue(db, { emailType: "password-reset", message: MSG });
+    // Drive attempts up to DEAD_AFTER_ATTEMPTS via repeated transient
+    // failures, advancing the clock past each tier so the row re-claims.
+    for (let i = 0; i < DEAD_AFTER_ATTEMPTS; i++) {
+      const r = await flushBatch(db, transientDispatcher, 10);
+      if (db.rows[0].status === "dead") break;
+      expect(r.claimed).toBe(1);
+      db.advance(nextDelayMs(db.rows[0].attempts));
+    }
+    expect(db.rows[0].status).toBe("dead");
+    expect(db.rows[0].last_error).toMatch(/retry budget|after \d+ attempts/i);
+  });
+
+  test("a dispatcher that throws is treated as transient, not a crash", async () => {
+    const db = new FakeEmailOutboxDB();
+    await enqueue(db, { emailType: "password-reset", message: MSG });
+    const throwing: EmailDispatcher = async () => {
+      throw new Error("boom");
+    };
+    const result = await flushBatch(db, throwing, 10);
+    expect(result.transient).toBe(1);
+    expect(db.rows[0].status).toBe("pending");
+    expect(loggerCalls.error.some((c) => c.data.event === "email_outbox.dispatcher_threw")).toBe(true);
+  });
+
+  test("a malformed payload dead-letters without burning the retry budget", async () => {
+    const db = new FakeEmailOutboxDB();
+    await enqueue(db, { emailType: "password-reset", message: MSG });
+    // Corrupt the stored payload as if it were written by a buggy path.
+    db.rows[0].payload = { subject: "no recipient" };
+    let dispatched = false;
+    const dispatcher: EmailDispatcher = async () => {
+      dispatched = true;
+      return { kind: "ok" };
+    };
+    const result = await flushBatch(db, dispatcher, 10);
+    expect(dispatched).toBe(false); // never handed to the dispatcher
+    expect(result.permanent).toBe(1);
+    expect(db.rows[0].status).toBe("dead");
+  });
+
+  test("claims up to the batch limit and no more", async () => {
+    const db = new FakeEmailOutboxDB();
+    for (let i = 0; i < 5; i++) {
+      await enqueue(db, { emailType: "password-reset", message: MSG });
+    }
+    const result = await flushBatch(db, okDispatcher, 3);
+    expect(result.claimed).toBe(3);
+    expect(db.rows.filter((r) => r.status === "pending")).toHaveLength(2);
+  });
+
+  test("a non-positive batch limit claims nothing", async () => {
+    const db = new FakeEmailOutboxDB();
+    await enqueue(db, { emailType: "password-reset", message: MSG });
+    expect(await flushBatch(db, okDispatcher, 0)).toEqual({
+      claimed: 0,
+      ok: 0,
+      transient: 0,
+      permanent: 0,
+    });
+    expect(db.rows[0].status).toBe("pending");
+  });
+});
+
+describe("recoverInFlight", () => {
+  test("resets a stale in_flight row to pending", async () => {
+    const db = new FakeEmailOutboxDB();
+    await enqueue(db, { emailType: "password-reset", message: MSG });
+    db.rows[0].status = "in_flight";
+    db.rows[0].attempts = 1;
+    db.rows[0].claimed_at = db.now;
+    db.advance(10 * 60_000); // 10 min — past the 5 min startup window
+    const result = await recoverInFlight(db);
+    expect(result.reset).toBe(1);
+    // Read via byId() so the status union isn't narrowed by the literal
+    // assignment above (tsgo can't see recoverInFlight mutates it).
+    expect(db.byId("row-1")!.status).toBe("pending");
+  });
+
+  test("leaves a freshly-claimed in_flight row alone (multi-pod guard)", async () => {
+    const db = new FakeEmailOutboxDB();
+    await enqueue(db, { emailType: "password-reset", message: MSG });
+    db.rows[0].status = "in_flight";
+    db.rows[0].attempts = 1;
+    db.rows[0].claimed_at = db.now; // just claimed
+    const result = await recoverInFlight(db);
+    expect(result.reset).toBe(0);
+    expect(db.byId("row-1")!.status).toBe("in_flight");
+  });
+
+  test("dead-letters an exhausted in_flight carcass regardless of staleness", async () => {
+    const db = new FakeEmailOutboxDB();
+    await enqueue(db, { emailType: "password-reset", message: MSG });
+    db.rows[0].status = "in_flight";
+    db.rows[0].attempts = DEAD_AFTER_ATTEMPTS;
+    db.rows[0].claimed_at = db.now; // fresh, but exhausted
+    const result = await recoverInFlight(db);
+    expect(result.deadLettered).toBe(1);
+    expect(db.byId("row-1")!.status).toBe("dead");
+  });
+});
+
+describe("computeRetryAfterTimestamp", () => {
+  test("returns null for undefined / negative / non-finite delays", () => {
+    expect(computeRetryAfterTimestamp(undefined)).toBeNull();
+    expect(computeRetryAfterTimestamp(-1)).toBeNull();
+    expect(computeRetryAfterTimestamp(Number.POSITIVE_INFINITY)).toBeNull();
+  });
+
+  test("returns a future Date for a finite positive delay", () => {
+    const before = Date.now();
+    const got = computeRetryAfterTimestamp(60_000);
+    expect(got).toBeInstanceOf(Date);
+    expect(got!.getTime()).toBeGreaterThanOrEqual(before + 60_000);
+  });
+});
+
+describe("config helpers", () => {
+  test("getTickIntervalMs defaults to 5s and clamps out-of-range input", () => {
+    delete process.env.ATLAS_EMAIL_OUTBOX_TICK_SECONDS;
+    expect(getTickIntervalMs()).toBe(DEFAULT_TICK_SECONDS * 1_000);
+    process.env.ATLAS_EMAIL_OUTBOX_TICK_SECONDS = "999999";
+    expect(getTickIntervalMs()).toBe(MAX_TICK_SECONDS * 1_000);
+    process.env.ATLAS_EMAIL_OUTBOX_TICK_SECONDS = "0";
+    expect(getTickIntervalMs()).toBe(DEFAULT_TICK_SECONDS * 1_000);
+    delete process.env.ATLAS_EMAIL_OUTBOX_TICK_SECONDS;
+    void MIN_TICK_SECONDS;
+  });
+
+  test("isFlusherEnabled is default-true and honours the off switches", () => {
+    delete process.env.ATLAS_EMAIL_OUTBOX_FLUSHER_ENABLED;
+    expect(isFlusherEnabled()).toBe(true);
+    for (const off of ["false", "0", "no", "off", "OFF"]) {
+      process.env.ATLAS_EMAIL_OUTBOX_FLUSHER_ENABLED = off;
+      expect(isFlusherEnabled()).toBe(false);
+    }
+    process.env.ATLAS_EMAIL_OUTBOX_FLUSHER_ENABLED = "true";
+    expect(isFlusherEnabled()).toBe(true);
+    delete process.env.ATLAS_EMAIL_OUTBOX_FLUSHER_ENABLED;
+  });
+});

--- a/packages/api/src/lib/email-outbox/__tests__/outbox.test.ts
+++ b/packages/api/src/lib/email-outbox/__tests__/outbox.test.ts
@@ -74,6 +74,13 @@ class FakeEmailOutboxDB implements EmailOutboxDB {
   rows: Row[] = [];
   now = 1_000_000; // arbitrary baseline (ms)
   private nextId = 1;
+  /**
+   * Make the next N flush-terminal status writes (MARK_DONE /
+   * MARK_TRANSIENT / MARK_DEAD) throw, simulating a Postgres blip between
+   * dispatch return and status stamp. Drives the markStatusWithRetry
+   * retry-once-then-strand path.
+   */
+  failNextMarks = 0;
 
   advance(ms: number): void {
     this.now += ms;
@@ -88,6 +95,19 @@ class FakeEmailOutboxDB implements EmailOutboxDB {
     params?: unknown[],
   ): Promise<T[]> {
     const p = params ?? [];
+
+    // Inject terminal-write failures for the markStatusWithRetry path.
+    // Flush-terminal marks carry `last_error`/`processed_at` (done/dead)
+    // or `SET status = 'pending', last_error` (transient) — distinct from
+    // the recovery sweeps, which this test never triggers.
+    const isFlushTerminalMark =
+      /SET status = 'done'/i.test(sql) ||
+      /SET status = 'pending',\s*last_error/i.test(sql) ||
+      /SET status = 'dead',\s*processed_at = now\(\),\s*\n?\s*last_error = \$1/i.test(sql);
+    if (isFlushTerminalMark && this.failNextMarks > 0) {
+      this.failNextMarks--;
+      throw new Error("simulated terminal-status UPDATE failure");
+    }
 
     if (/^\s*INSERT INTO email_outbox/i.test(sql)) {
       const id = `row-${this.nextId++}`;
@@ -368,6 +388,32 @@ describe("flushBatch", () => {
       permanent: 0,
     });
     expect(db.rows[0].status).toBe("pending");
+  });
+});
+
+describe("markStatusWithRetry (terminal-status write resilience)", () => {
+  test("retries a terminal-status write once and still reaches the terminal state", async () => {
+    const db = new FakeEmailOutboxDB();
+    await enqueue(db, { emailType: "password-reset", message: MSG });
+    db.failNextMarks = 1; // first MARK_DONE throws, retry succeeds
+    const result = await flushBatch(db, okDispatcher, 10);
+    expect(result.ok).toBe(1);
+    expect(db.byId("row-1")!.status).toBe("done");
+    expect(
+      loggerCalls.warn.some((c) => c.data.event === "email_outbox.status_update_retrying"),
+    ).toBe(true);
+  });
+
+  test("re-throws when the terminal-status write fails twice — row strands in_flight for recovery", async () => {
+    const db = new FakeEmailOutboxDB();
+    await enqueue(db, { emailType: "password-reset", message: MSG });
+    db.failNextMarks = 2; // both attempts throw → flushBatch propagates
+    await expect(flushBatch(db, okDispatcher, 10)).rejects.toThrow(
+      /simulated terminal-status UPDATE failure/,
+    );
+    // The claim already flipped it to in_flight; the failed mark leaves it
+    // there so recoverInFlight mops it up on the next boot (no silent loss).
+    expect(db.byId("row-1")!.status).toBe("in_flight");
   });
 });
 

--- a/packages/api/src/lib/email-outbox/__tests__/tick.test.ts
+++ b/packages/api/src/lib/email-outbox/__tests__/tick.test.ts
@@ -128,7 +128,16 @@ describe("runEmailOutboxTick", () => {
 
   test("dispatches claimed rows through flushBatch", async () => {
     const { db } = makeDb([
-      { id: "row-1", email_type: "password-reset", payload: { to: "a@b.co", subject: "s", html: "h" }, org_id: null, attempts: 1 },
+      {
+        id: "row-1",
+        email_type: "password-reset",
+        // payload is stored as a string (encryptSecret output; plaintext
+        // passthrough with no key) and decrypted+parsed by coerceMessage.
+        payload: JSON.stringify({ to: "a@b.co", subject: "s", html: "h" }),
+        org_id: null,
+        expires_at: null,
+        attempts: 1,
+      },
     ]);
     const result = await runEmailOutboxTick({
       db,

--- a/packages/api/src/lib/email-outbox/__tests__/tick.test.ts
+++ b/packages/api/src/lib/email-outbox/__tests__/tick.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Per-tick orchestrator: snapshot → gauges → threshold warn → flush.
+ * Driven with structural stubs (no Effect runtime, no OTel, no pino) —
+ * exactly the Layer-handoff contract: layers.ts builds the deps,
+ * runEmailOutboxTick does the work.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+
+mock.module("@atlas/api/lib/logger", () => ({
+  createLogger: () => ({ info() {}, debug() {}, warn() {}, error() {} }),
+}));
+
+const { runEmailOutboxTick } = await import("../tick");
+const { OutboxWarnRateLimiter } = await import("../depth");
+type EmailOutboxDB = import("../outbox").EmailOutboxDB;
+type EmailDispatcher = import("../outbox").EmailDispatcher;
+
+const SNAPSHOT_ROW = { pending_count: "3", dead_count: "1", oldest_pending_at: null };
+
+/**
+ * Stub DB recording the order of SQL kinds so we can assert the
+ * snapshot happens before the claim.
+ */
+function makeDb(claimRows: Array<Record<string, unknown>> = []): {
+  db: EmailOutboxDB;
+  order: string[];
+} {
+  const order: string[] = [];
+  const db: EmailOutboxDB = {
+    async query<T extends Record<string, unknown>>(sql: string): Promise<T[]> {
+      // CLAIM_SQL also contains `SELECT id FROM email_outbox`, so match
+      // the UPDATE form first and key the snapshot off its unique
+      // `COUNT(*) FILTER` aggregate.
+      if (/UPDATE email_outbox\s+SET status = 'in_flight'/i.test(sql)) {
+        order.push("claim");
+        return claimRows as unknown as T[];
+      }
+      if (/COUNT\(\*\) FILTER/i.test(sql)) {
+        order.push("snapshot");
+        return [SNAPSHOT_ROW] as unknown as T[];
+      }
+      order.push("other");
+      return [] as unknown as T[];
+    },
+  };
+  return { db, order };
+}
+
+function gauge() {
+  const values: number[] = [];
+  return { record: (v: number) => values.push(v), values };
+}
+
+const okDispatcher: EmailDispatcher = async () => ({ kind: "ok" });
+
+describe("runEmailOutboxTick", () => {
+  test("snapshots before flushing and records both gauges", async () => {
+    const { db, order } = makeDb([]);
+    const pendingGauge = gauge();
+    const deadGauge = gauge();
+    const result = await runEmailOutboxTick({
+      db,
+      dispatcher: okDispatcher,
+      batchLimit: 10,
+      limiter: new OutboxWarnRateLimiter(100),
+      pendingGauge,
+      deadGauge,
+      logger: { warn() {} },
+    });
+    expect(order[0]).toBe("snapshot");
+    expect(order).toContain("claim");
+    expect(order.indexOf("snapshot")).toBeLessThan(order.indexOf("claim"));
+    expect(pendingGauge.values).toEqual([3]);
+    expect(deadGauge.values).toEqual([1]);
+    expect(result.snapshot.pending).toBe(3);
+    expect(result.flush.claimed).toBe(0);
+    expect(result.warned).toBe(false);
+  });
+
+  test("emits the depth warning when the limiter trips", async () => {
+    const { db } = makeDb([]);
+    const warnings: Array<{ data: Record<string, unknown>; msg: string }> = [];
+    const result = await runEmailOutboxTick({
+      db,
+      dispatcher: okDispatcher,
+      batchLimit: 10,
+      // threshold 1, pending=3 → trips; injected now far past the
+      // interval so the first warn fires.
+      limiter: new OutboxWarnRateLimiter(1),
+      pendingGauge: gauge(),
+      deadGauge: gauge(),
+      logger: { warn: (data, msg) => warnings.push({ data, msg }) },
+      now: () => 10_000_000,
+    });
+    expect(result.warned).toBe(true);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].data.event).toBe("email_outbox.depth_threshold_warn");
+  });
+
+  test("dispatches claimed rows through flushBatch", async () => {
+    const { db } = makeDb([
+      { id: "row-1", email_type: "password-reset", payload: { to: "a@b.co", subject: "s", html: "h" }, org_id: null, attempts: 1 },
+    ]);
+    const result = await runEmailOutboxTick({
+      db,
+      dispatcher: okDispatcher,
+      batchLimit: 10,
+      limiter: new OutboxWarnRateLimiter(100),
+      pendingGauge: gauge(),
+      deadGauge: gauge(),
+      logger: { warn() {} },
+    });
+    expect(result.flush.claimed).toBe(1);
+    expect(result.flush.ok).toBe(1);
+  });
+});

--- a/packages/api/src/lib/email-outbox/__tests__/tick.test.ts
+++ b/packages/api/src/lib/email-outbox/__tests__/tick.test.ts
@@ -98,6 +98,34 @@ describe("runEmailOutboxTick", () => {
     expect(warnings[0].data.event).toBe("email_outbox.depth_threshold_warn");
   });
 
+  test("propagates a snapshot failure and does NOT record gauges (no-silent-zero invariant)", async () => {
+    // If the depth snapshot throws (e.g. a sticky pool failure), the tick
+    // must propagate so the caller records tick_failed and the gauges keep
+    // their last value — resetting them to 0 would make a broken queue
+    // look healthy. Assert the throw propagates and neither gauge fired.
+    const pendingGauge = gauge();
+    const deadGauge = gauge();
+    const db: EmailOutboxDB = {
+      async query<T extends Record<string, unknown>>(sql: string): Promise<T[]> {
+        if (/COUNT\(\*\) FILTER/i.test(sql)) throw new Error("pool exploded");
+        return [] as unknown as T[];
+      },
+    };
+    await expect(
+      runEmailOutboxTick({
+        db,
+        dispatcher: okDispatcher,
+        batchLimit: 10,
+        limiter: new OutboxWarnRateLimiter(100),
+        pendingGauge,
+        deadGauge,
+        logger: { warn() {} },
+      }),
+    ).rejects.toThrow(/pool exploded/);
+    expect(pendingGauge.values).toEqual([]);
+    expect(deadGauge.values).toEqual([]);
+  });
+
   test("dispatches claimed rows through flushBatch", async () => {
     const { db } = makeDb([
       { id: "row-1", email_type: "password-reset", payload: { to: "a@b.co", subject: "s", html: "h" }, org_id: null, attempts: 1 },

--- a/packages/api/src/lib/email-outbox/backoff.ts
+++ b/packages/api/src/lib/email-outbox/backoff.ts
@@ -1,0 +1,72 @@
+/**
+ * Backoff math for the `email_outbox` flusher (#2942).
+ *
+ * Pure, unit-tested. The `DELAYS_MS` array and `CLAIM_DELAY_SQL` CASE
+ * below must stay in lockstep — the SQL WHERE clause in
+ * `outbox.ts:CLAIM_SQL` is what enforces backoff (a sleep would let a
+ * long-backoff row block newer pending rows), so a divergence means
+ * rows either retry too eagerly (hammer a down provider) or never retry
+ * at all. `__tests__/backoff.test.ts` pins both sides.
+ *
+ * Tier schedule is intentionally identical to lead-outbox: an
+ * email_outbox row only exists because the in-process `fetchWithRetry`
+ * window (PR #2949) was already exhausted, so the next attempts are
+ * spaced to ride out a SUSTAINED outage (30s → 2m → 8m → 30m → 2h)
+ * rather than re-hammer a provider that's still down.
+ */
+
+/**
+ * Hard dead-letter threshold. After this many failed attempts the
+ * flusher flips the row to `status='dead'` and stops retrying.
+ */
+export const DEAD_AFTER_ATTEMPTS = 6;
+
+/**
+ * Per-attempt delays in milliseconds, indexed by `attempts`.
+ *
+ * - `attempts=0` is the first flush after enqueue and must be immediate
+ *   (delay 0) so `enqueue → flushBatch` round-trips in a single tick.
+ * - `attempts=1..5` are the post-failure waits.
+ * - `attempts>=6` is unreachable in the claim WHERE (filtered by
+ *   `attempts < DEAD_AFTER_ATTEMPTS`); the array still terminates
+ *   defensively in case a caller asks.
+ */
+const DELAYS_MS: ReadonlyArray<number> = [
+  0,
+  30_000, // 30s
+  120_000, // 2m
+  480_000, // 8m
+  1_800_000, // 30m
+  7_200_000, // 2h
+];
+
+/**
+ * Delay from `created_at` until the (attempts+1)th dispatch is allowed.
+ *
+ * Pure function — unit-tested in `__tests__/backoff.test.ts`. Mirrors
+ * `CLAIM_DELAY_SQL` below; both are interpolated into
+ * `outbox.ts:CLAIM_SQL`'s WHERE clause.
+ */
+export function nextDelayMs(attempts: number): number {
+  if (!Number.isFinite(attempts) || attempts < 0) return 0;
+  const floored = Math.floor(attempts);
+  if (floored >= DELAYS_MS.length) return DELAYS_MS[DELAYS_MS.length - 1];
+  return DELAYS_MS[floored];
+}
+
+/**
+ * SQL fragment that computes the per-attempt delay interval. Drop into
+ * a WHERE clause as `created_at + <FRAGMENT> <= now()`. Kept here so
+ * tier changes touch one file. Must match `DELAYS_MS` above.
+ */
+export const CLAIM_DELAY_SQL = `
+  CASE attempts
+    WHEN 0 THEN INTERVAL '0'
+    WHEN 1 THEN INTERVAL '30 seconds'
+    WHEN 2 THEN INTERVAL '2 minutes'
+    WHEN 3 THEN INTERVAL '8 minutes'
+    WHEN 4 THEN INTERVAL '30 minutes'
+    WHEN 5 THEN INTERVAL '2 hours'
+    ELSE INTERVAL '2 hours'
+  END
+`;

--- a/packages/api/src/lib/email-outbox/backoff.ts
+++ b/packages/api/src/lib/email-outbox/backoff.ts
@@ -41,11 +41,14 @@ const DELAYS_MS: ReadonlyArray<number> = [
 ];
 
 /**
- * Delay from `created_at` until the (attempts+1)th dispatch is allowed.
+ * Per-attempt backoff interval (ms) before the (attempts+1)th dispatch.
+ * Added to `now()` at the failure moment by `MARK_TRANSIENT_FAIL_SQL`
+ * (`retry_after = now() + tier`), and to `created_at` only for the
+ * never-failed (attempts=0) first-claim gate.
  *
  * Pure function — unit-tested in `__tests__/backoff.test.ts`. Mirrors
- * `CLAIM_DELAY_SQL` below; both are interpolated into
- * `outbox.ts:CLAIM_SQL`'s WHERE clause.
+ * `CLAIM_DELAY_SQL` below; both are interpolated into `outbox.ts`'s
+ * CLAIM and MARK_TRANSIENT statements.
  */
 export function nextDelayMs(attempts: number): number {
   if (!Number.isFinite(attempts) || attempts < 0) return 0;

--- a/packages/api/src/lib/email-outbox/depth.ts
+++ b/packages/api/src/lib/email-outbox/depth.ts
@@ -1,0 +1,188 @@
+/**
+ * Email-outbox depth metrics + threshold alerting (#2942).
+ *
+ * Two responsibilities (mirrors `lib/lead-outbox/depth.ts`):
+ *
+ *  1. `queryDepthSnapshot` — one round-trip to count `pending` / `dead`
+ *     rows and grab the oldest pending row's `created_at`. The flusher
+ *     tick calls this BEFORE dispatch so the gauges reflect pre-tick
+ *     queue depth.
+ *  2. `OutboxWarnRateLimiter` — once-per-minute gate on the "pending
+ *     depth exceeds threshold" `log.warn` so a sustained backlog (a
+ *     long email-provider outage) doesn't fill the log stream.
+ *
+ * Threshold default is 50 (lower than crm_outbox's 100 — transactional
+ * email is low-volume, so even a modest pending backlog signals a
+ * sustained provider outage worth surfacing). Override via
+ * `ATLAS_EMAIL_OUTBOX_WARN_THRESHOLD` with the same clamp-and-warn
+ * discipline as `getTickIntervalMs`.
+ */
+
+import { createLogger } from "@atlas/api/lib/logger";
+import type { EmailOutboxDB } from "./outbox";
+
+const log = createLogger("email-outbox:depth");
+
+// ─────────────────────────────────────────────────────────────────────
+//  Snapshot
+// ─────────────────────────────────────────────────────────────────────
+
+export interface OutboxDepthSnapshot {
+  readonly pending: number;
+  readonly dead: number;
+  readonly oldestPendingCreatedAt: Date | null;
+}
+
+/**
+ * Single aggregate row — keeps the snapshot to one round-trip. The
+ * outer `WHERE status IN ('pending', 'dead')` scopes the scan to the
+ * two statuses we report on, so cost doesn't scale with the unbounded
+ * history of `done` rows. The `pending` side hits the
+ * `idx_email_outbox_pending_created` partial index (mig 0107).
+ */
+const SNAPSHOT_SQL = `
+  SELECT
+    COUNT(*) FILTER (WHERE status = 'pending')        AS pending_count,
+    COUNT(*) FILTER (WHERE status = 'dead')           AS dead_count,
+    MIN(created_at) FILTER (WHERE status = 'pending') AS oldest_pending_at
+  FROM email_outbox
+  WHERE status IN ('pending', 'dead')
+`;
+
+interface SnapshotRow extends Record<string, unknown> {
+  pending_count: string | number;
+  dead_count: string | number;
+  oldest_pending_at: Date | string | null;
+}
+
+export async function queryDepthSnapshot(db: EmailOutboxDB): Promise<OutboxDepthSnapshot> {
+  const rows = await db.query<SnapshotRow>(SNAPSHOT_SQL);
+  const row = rows[0];
+  if (!row) {
+    // PG's contract: `SELECT COUNT(*)` with no GROUP BY always returns
+    // exactly one row. Zero rows means something below the SQL layer
+    // broke (driver/pool short-circuit). Throw so the caller's
+    // Effect.catchAll emits `email_outbox.tick_failed` and the gauges
+    // keep their last value rather than being reset to a misleading
+    // zero — a sticky pool failure must NOT make the queue look healthy.
+    throw new Error(
+      "email_outbox snapshot returned no aggregate row — driver/pool invariant violated",
+    );
+  }
+  return {
+    pending: parseCount(row.pending_count),
+    dead: parseCount(row.dead_count),
+    oldestPendingCreatedAt: parseTimestamp(row.oldest_pending_at),
+  };
+}
+
+function parseCount(v: string | number): number {
+  if (typeof v === "number") {
+    if (Number.isFinite(v)) return v;
+    log.warn(
+      { raw: v, event: "email_outbox.snapshot_count_unparseable" },
+      "email_outbox aggregate count is NaN/Infinity — clamping to 0",
+    );
+    return 0;
+  }
+  const n = Number.parseInt(v, 10);
+  if (Number.isFinite(n)) return n;
+  log.warn(
+    { raw: v, event: "email_outbox.snapshot_count_unparseable" },
+    "email_outbox aggregate count is not a valid integer — clamping to 0",
+  );
+  return 0;
+}
+
+function parseTimestamp(v: Date | string | null): Date | null {
+  if (v == null) return null;
+  if (v instanceof Date) return v;
+  const d = new Date(v);
+  if (Number.isNaN(d.getTime())) {
+    log.warn(
+      { raw: v, event: "email_outbox.snapshot_timestamp_unparseable" },
+      "email_outbox oldest_pending_at could not be parsed as a Date — dropping",
+    );
+    return null;
+  }
+  return d;
+}
+
+// ─────────────────────────────────────────────────────────────────────
+//  Threshold + rate-limit
+// ─────────────────────────────────────────────────────────────────────
+
+export const DEFAULT_WARN_THRESHOLD = 50;
+export const WARN_INTERVAL_MS = 60_000;
+export const MIN_WARN_THRESHOLD = 1;
+export const MAX_WARN_THRESHOLD = 1_000_000;
+
+export function getWarnThreshold(): number {
+  const raw = process.env.ATLAS_EMAIL_OUTBOX_WARN_THRESHOLD;
+  if (!raw) return DEFAULT_WARN_THRESHOLD;
+  // Reject operator typos like "100abc" — parseInt is forgiving and
+  // would silently accept `100`, masking a misconfigured env var.
+  if (!/^-?\d+$/.test(raw)) {
+    log.warn(
+      { requested: raw, event: "email_outbox.threshold_unparseable" },
+      `ATLAS_EMAIL_OUTBOX_WARN_THRESHOLD=${raw} is not a valid integer — using default ${DEFAULT_WARN_THRESHOLD}`,
+    );
+    return DEFAULT_WARN_THRESHOLD;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed)) return DEFAULT_WARN_THRESHOLD;
+  if (parsed < MIN_WARN_THRESHOLD) {
+    log.warn(
+      { requested: parsed, clamped: MIN_WARN_THRESHOLD, event: "email_outbox.threshold_clamped" },
+      `ATLAS_EMAIL_OUTBOX_WARN_THRESHOLD=${parsed} below ${MIN_WARN_THRESHOLD} — clamping`,
+    );
+    return MIN_WARN_THRESHOLD;
+  }
+  if (parsed > MAX_WARN_THRESHOLD) {
+    log.warn(
+      { requested: parsed, clamped: MAX_WARN_THRESHOLD, event: "email_outbox.threshold_clamped" },
+      `ATLAS_EMAIL_OUTBOX_WARN_THRESHOLD=${parsed} exceeds ${MAX_WARN_THRESHOLD} — clamping`,
+    );
+    return MAX_WARN_THRESHOLD;
+  }
+  return parsed;
+}
+
+export interface WarnDecision {
+  readonly depth: number;
+  readonly threshold: number;
+  readonly oldestPendingCreatedAt: Date | null;
+  readonly oldestPendingAgeMs: number | null;
+}
+
+/**
+ * Stateful gate on the "depth exceeds threshold" warning. Holds the
+ * timestamp of the last emitted warn; suppresses subsequent calls
+ * within `intervalMs`. One instance per flusher Layer scope. The gate
+ * is time-based, not edge-based: re-emission happens once the interval
+ * elapses, regardless of intervening dips.
+ */
+export class OutboxWarnRateLimiter {
+  private lastWarnAt = 0;
+
+  constructor(
+    private readonly threshold: number,
+    private readonly intervalMs: number = WARN_INTERVAL_MS,
+  ) {}
+
+  evaluate(snapshot: OutboxDepthSnapshot, now: number = Date.now()): WarnDecision | null {
+    if (snapshot.pending <= this.threshold) return null;
+    if (now - this.lastWarnAt < this.intervalMs) return null;
+    this.lastWarnAt = now;
+    const oldestAgeMs =
+      snapshot.oldestPendingCreatedAt == null
+        ? null
+        : Math.max(0, now - snapshot.oldestPendingCreatedAt.getTime());
+    return {
+      depth: snapshot.pending,
+      threshold: this.threshold,
+      oldestPendingCreatedAt: snapshot.oldestPendingCreatedAt,
+      oldestPendingAgeMs: oldestAgeMs,
+    };
+  }
+}

--- a/packages/api/src/lib/email-outbox/depth.ts
+++ b/packages/api/src/lib/email-outbox/depth.ts
@@ -37,8 +37,11 @@ export interface OutboxDepthSnapshot {
  * Single aggregate row — keeps the snapshot to one round-trip. The
  * outer `WHERE status IN ('pending', 'dead')` scopes the scan to the
  * two statuses we report on, so cost doesn't scale with the unbounded
- * history of `done` rows. The `pending` side hits the
- * `idx_email_outbox_pending_created` partial index (mig 0107).
+ * history of `done` rows. The `idx_email_outbox_pending_created`
+ * partial index (mig 0107) can accelerate the `pending` predicate; the
+ * `dead` count falls outside that index (it's filtered to
+ * pending/in_flight) and is a small bounded scan absent a sustained
+ * outage.
  */
 const SNAPSHOT_SQL = `
   SELECT

--- a/packages/api/src/lib/email-outbox/dispatch.ts
+++ b/packages/api/src/lib/email-outbox/dispatch.ts
@@ -1,0 +1,52 @@
+/**
+ * Concrete email-outbox dispatcher (#2942).
+ *
+ * Bridges the generic queue (`outbox.ts`) to the email delivery layer.
+ * The send function is INJECTED (`makeEmailDispatcher(sendEmail)`) so
+ * the queue mechanics stay decoupled from `email/delivery.ts` and the
+ * unit test can drive it with a fake — and, importantly, so the flusher
+ * re-send path calls the RAW `sendEmail` (no `sendTransactionalEmail`
+ * wrapper), which means a re-send failure does NOT re-enqueue and
+ * create an unbounded duplication loop.
+ *
+ * Classification: `sendEmail` returns a `DeliveryResult` without an HTTP
+ * status, and the in-process `fetchWithRetry` (PR #2949) already
+ * exhausted transient retries before a row was ever enqueued. So every
+ * flusher-time failure is classified `transient` and rides the backoff
+ * schedule to wait out a SUSTAINED outage. A genuinely permanent
+ * failure (bad API key, malformed payload) still terminates — it
+ * dead-letters once the retry budget is exhausted, with the provider's
+ * error message preserved on the row for triage. We deliberately do NOT
+ * thread the HTTP status through `DeliveryResult` to distinguish
+ * permanent-vs-transient here: it would ripple through every delivery
+ * call site for a marginal latency win on a rare misconfiguration, and
+ * the retry budget already bounds the cost.
+ */
+
+import type { DeliveryResult, EmailMessage } from "@atlas/api/lib/email/delivery";
+import type { ClaimedEmailRow, EmailDispatcher, EmailDispatchOutcome } from "./outbox";
+
+/**
+ * Shape of `email/delivery.ts:sendEmail`. Declared structurally so
+ * `dispatch.ts` has only a type-level dependency on the delivery layer
+ * (no runtime import) — keeps the unit test light and the module graph
+ * acyclic.
+ */
+export type EmailSendFn = (message: EmailMessage, orgId?: string) => Promise<DeliveryResult>;
+
+export function makeEmailDispatcher(send: EmailSendFn): EmailDispatcher {
+  return async (row: ClaimedEmailRow): Promise<EmailDispatchOutcome> => {
+    const result = await send(
+      { to: row.message.to, subject: row.message.subject, html: row.message.html },
+      // `orgId` is nullable on the row but `sendEmail` expects
+      // `string | undefined` — normalize so the DB-config lookup path
+      // is taken only when an org actually scopes the send.
+      row.orgId ?? undefined,
+    );
+    if (result.success) return { kind: "ok" };
+    return {
+      kind: "transient",
+      message: result.error ?? `email delivery failed via ${result.provider}`,
+    };
+  };
+}

--- a/packages/api/src/lib/email-outbox/dispatch.ts
+++ b/packages/api/src/lib/email-outbox/dispatch.ts
@@ -24,7 +24,26 @@
  */
 
 import type { DeliveryResult, EmailMessage } from "@atlas/api/lib/email/delivery";
-import type { ClaimedEmailRow, EmailDispatcher, EmailDispatchOutcome } from "./outbox";
+import type {
+  ClaimedEmailRow,
+  EmailDispatcher,
+  EmailDispatchOutcome,
+  EmailOutboxMessage,
+} from "./outbox";
+
+/**
+ * Compile-time lockstep guard: `EmailOutboxMessage` (the locally-defined
+ * row payload shape, kept decoupled from the delivery layer) must carry
+ * every field `EmailMessage` does. If someone adds a field to
+ * `EmailMessage` (e.g. `cc`, `replyTo`, `text`) without also adding it to
+ * `EmailOutboxMessage` + `coerceMessage`, the outbox would silently drop
+ * it on the enqueue→re-send round-trip. This turns that silent field-drop
+ * into a red build. (`Exclude<...> extends never` is `true` only when
+ * EmailOutboxMessage's keys are a superset of EmailMessage's.)
+ */
+type _EmailOutboxMessageCoversEmailMessage =
+  Exclude<keyof EmailMessage, keyof EmailOutboxMessage> extends never ? true : never;
+const _emailOutboxMessageLockstep: _EmailOutboxMessageCoversEmailMessage = true;
 
 /**
  * Shape of `email/delivery.ts:sendEmail`. Declared structurally so

--- a/packages/api/src/lib/email-outbox/index.ts
+++ b/packages/api/src/lib/email-outbox/index.ts
@@ -1,0 +1,56 @@
+/**
+ * Public surface of the email-outbox module (#2942). A stripped-down
+ * mirror of `lib/lead-outbox/`: durable queue for transactional email
+ * (password reset, signup verification OTP) so a SUSTAINED provider
+ * outage no longer permanently drops a send. Generic queue mechanics
+ * live in `outbox.ts`; the concrete dispatcher (wrapping `sendEmail`)
+ * lives in `dispatch.ts`.
+ */
+
+export {
+  enqueue,
+  recoverInFlight,
+  flushBatch,
+  getTickIntervalMs,
+  isFlusherEnabled,
+  computeRetryAfterTimestamp,
+  FLUSH_BATCH_LIMIT,
+  STARTUP_RECOVERY_STALE_MS,
+  SHUTDOWN_RECOVERY_STALE_MS,
+  MIN_TICK_SECONDS,
+  MAX_TICK_SECONDS,
+  DEFAULT_TICK_SECONDS,
+  type EmailOutboxDB,
+  type EmailOutboxMessage,
+  type EnqueueEmailInput,
+  type ClaimedEmailRow,
+  type EmailDispatchOutcome,
+  type EmailDispatcher,
+  type EmailOutboxStatus,
+  type FlushResult,
+  type RecoveryResult,
+} from "./outbox";
+
+export { nextDelayMs, DEAD_AFTER_ATTEMPTS, CLAIM_DELAY_SQL } from "./backoff";
+
+export {
+  queryDepthSnapshot,
+  getWarnThreshold,
+  OutboxWarnRateLimiter,
+  DEFAULT_WARN_THRESHOLD,
+  WARN_INTERVAL_MS,
+  MIN_WARN_THRESHOLD,
+  MAX_WARN_THRESHOLD,
+  type OutboxDepthSnapshot,
+  type WarnDecision,
+} from "./depth";
+
+export {
+  runEmailOutboxTick,
+  type OutboxTickDeps,
+  type OutboxTickResult,
+  type GaugeRecorder,
+  type OutboxTickLogger,
+} from "./tick";
+
+export { makeEmailDispatcher, type EmailSendFn } from "./dispatch";

--- a/packages/api/src/lib/email-outbox/outbox.ts
+++ b/packages/api/src/lib/email-outbox/outbox.ts
@@ -88,6 +88,12 @@ export interface EnqueueEmailInput {
    * the flusher dead-letters the row instead of delivering an unusable
    * link/code. Omit / null for non-expiring sends. The caller derives
    * this from the email type's TTL (reset link 1h, OTP 10m).
+   *
+   * Anchor: this is stamped at ENQUEUE time (`now() + ttlMs`), i.e. the
+   * failed-send moment — a few seconds AFTER the token was actually
+   * minted. So it slightly over-estimates true token life (safe
+   * direction: we may attempt a send whose token died seconds earlier and
+   * the auth layer rejects it; we never refuse a still-valid token).
    */
   readonly expiresAt?: Date | null;
 }
@@ -165,8 +171,11 @@ const ENQUEUE_SQL = `
  * and bumps `attempts`.
  *
  * Backoff gate: `COALESCE(retry_after, created_at + tier) <= now()`.
- * When a prior failure surfaced a delay, the absolute `retry_after`
- * wins; otherwise the tier-based delay (CLAIM_DELAY_SQL) applies.
+ * Post-#2972 `retry_after` is stamped on every transient failure, so for
+ * any row that has failed at least once the COALESCE resolves to
+ * `retry_after`. The `created_at + tier` fallback only applies to a
+ * never-failed row (retry_after NULL) — where tier(0)=0 makes it
+ * immediately due on the first claim.
  *
  * No per-email serialization / advisory locks (cf. crm_outbox) — each
  * transactional send is independent and an at-least-once duplicate is
@@ -368,32 +377,12 @@ export async function flushBatch(
   let permanent = 0;
 
   for (const raw of claimed) {
-    const message = coerceMessage(raw.payload);
-    if (message === null) {
-      // A row whose payload can't be decrypted/parsed into an
-      // EmailMessage is unrecoverable — re-sending will never succeed.
-      // Dead-letter it immediately rather than burning the retry budget.
-      // (coerceMessage already logs the specific decrypt/parse cause.)
-      await markStatusWithRetry(
-        db,
-        MARK_DEAD_SQL,
-        ["email_outbox payload could not be decrypted/parsed into an EmailMessage", raw.id],
-        raw.id,
-        "dead",
-      );
-      log.error(
-        { rowId: raw.id, event: "email_outbox.dead_letter_malformed" },
-        "Email outbox row dead-lettered — payload is not a recoverable EmailMessage",
-      );
-      permanent++;
-      continue;
-    }
-
     // Expiry gate (codex #2972): the body embeds a live reset link / OTP
     // that dies at `expires_at`. If a sustained outage outlasted the TTL,
     // delivering it would just give the user a dead link — dead-letter
-    // instead of sending. Checked AFTER decrypt so a malformed row gets
-    // the more-actionable malformed error.
+    // instead of sending. `expires_at` is a plaintext column, so this is
+    // checked BEFORE decrypt: a dead-token row is dead-lettered regardless
+    // of whether its (encrypted) body can currently be decrypted.
     const expiresAt = coerceDate(raw.expires_at);
     if (expiresAt !== null && Date.now() >= expiresAt.getTime()) {
       await markStatusWithRetry(
@@ -416,51 +405,89 @@ export async function flushBatch(
       continue;
     }
 
-    const row: ClaimedEmailRow = {
-      id: raw.id,
-      emailType: raw.email_type,
-      message,
-      orgId: raw.org_id,
-      attempts: raw.attempts,
-      expiresAt,
-    };
+    const coerced = coerceMessage(raw.payload);
 
-    let outcome: EmailDispatchOutcome;
-    try {
-      outcome = await dispatcher(row);
-    } catch (err) {
-      // Dispatcher contract violation: it should classify and return,
-      // never throw. Treat as transient so we don't dead-letter on a
-      // bug in the dispatcher's error handling.
-      log.error(
-        {
-          rowId: row.id,
-          attempts: row.attempts,
-          err: err instanceof Error ? err.message : String(err),
-          event: "email_outbox.dispatcher_threw",
-        },
-        "Dispatcher threw — classifying as transient so the row will retry",
+    // Structurally-broken payload (decrypted fine but isn't a valid
+    // EmailMessage) is unrecoverable — re-sending will never fix it.
+    // Dead-letter immediately.
+    if (coerced.kind === "malformed") {
+      await markStatusWithRetry(
+        db,
+        MARK_DEAD_SQL,
+        [`email_outbox payload is not a valid EmailMessage: ${coerced.reason}`, raw.id],
+        raw.id,
+        "dead",
       );
-      outcome = {
-        kind: "transient",
-        message: err instanceof Error ? err.message : String(err),
-      };
+      log.error(
+        { rowId: raw.id, reason: coerced.reason, event: "email_outbox.dead_letter_malformed" },
+        "Email outbox row dead-lettered — payload is not a recoverable EmailMessage",
+      );
+      permanent++;
+      continue;
     }
 
+    let outcome: EmailDispatchOutcome;
+    if (coerced.kind === "retryable") {
+      // Decrypt THREW (e.g. a key version was dropped from
+      // ATLAS_ENCRYPTION_KEYS mid-rotation — recoverable by restoring it,
+      // or genuine ciphertext corruption). Classify as transient rather
+      // than dead-lettering (codex #2972): a fixable key-config error must
+      // NOT irreversibly destroy the queued auth email. The retry budget
+      // still bounds it — if the key is never restored the row dead-letters
+      // after DEAD_AFTER_ATTEMPTS rather than spinning forever.
+      log.error(
+        { rowId: raw.id, reason: coerced.reason, event: "email_outbox.decrypt_failed" },
+        "email_outbox payload decrypt failed — RETRYABLE (restore the key version in ATLAS_ENCRYPTION_KEYS); row stays pending until the retry budget is exhausted",
+      );
+      outcome = { kind: "transient", message: coerced.reason };
+    } else {
+      const row: ClaimedEmailRow = {
+        id: raw.id,
+        emailType: raw.email_type,
+        message: coerced.message,
+        orgId: raw.org_id,
+        attempts: raw.attempts,
+        expiresAt,
+      };
+      try {
+        outcome = await dispatcher(row);
+      } catch (err) {
+        // Dispatcher contract violation: it should classify and return,
+        // never throw. Treat as transient so we don't dead-letter on a
+        // bug in the dispatcher's error handling.
+        log.error(
+          {
+            rowId: row.id,
+            attempts: row.attempts,
+            err: err instanceof Error ? err.message : String(err),
+            event: "email_outbox.dispatcher_threw",
+          },
+          "Dispatcher threw — classifying as transient so the row will retry",
+        );
+        outcome = {
+          kind: "transient",
+          message: err instanceof Error ? err.message : String(err),
+        };
+      }
+    }
+
+    // Final-status handling is keyed off `raw` (always defined) so it
+    // works for both the dispatched path and the decrypt-retryable path
+    // (which has no constructed `row`).
     if (outcome.kind === "ok") {
-      await markStatusWithRetry(db, MARK_DONE_SQL, [row.id], row.id, "done");
+      await markStatusWithRetry(db, MARK_DONE_SQL, [raw.id], raw.id, "done");
       ok++;
       continue;
     }
 
     if (outcome.kind === "permanent") {
-      await markStatusWithRetry(db, MARK_DEAD_SQL, [outcome.message, row.id], row.id, "dead");
+      await markStatusWithRetry(db, MARK_DEAD_SQL, [outcome.message, raw.id], raw.id, "dead");
       log.error(
         {
-          rowId: row.id,
-          attempts: row.attempts,
+          rowId: raw.id,
+          attempts: raw.attempts,
           err: outcome.message,
-          emailType: row.emailType,
+          emailType: raw.email_type,
           event: "email_outbox.dead_letter_permanent",
         },
         "Transactional email dead-lettered (permanent failure) — operator intervention required",
@@ -472,20 +499,20 @@ export async function flushBatch(
     // Transient. If we've already burned through the retry budget the
     // row dies here — the claim WHERE wouldn't let us pick it up again,
     // so leaving it `pending` would be a silent stuck-forever row.
-    if (row.attempts >= DEAD_AFTER_ATTEMPTS) {
+    if (raw.attempts >= DEAD_AFTER_ATTEMPTS) {
       await markStatusWithRetry(
         db,
         MARK_DEAD_SQL,
-        [`transient failure after ${DEAD_AFTER_ATTEMPTS} attempts: ${outcome.message}`, row.id],
-        row.id,
+        [`transient failure after ${DEAD_AFTER_ATTEMPTS} attempts: ${outcome.message}`, raw.id],
+        raw.id,
         "dead",
       );
       log.error(
         {
-          rowId: row.id,
-          attempts: row.attempts,
+          rowId: raw.id,
+          attempts: raw.attempts,
           err: outcome.message,
-          emailType: row.emailType,
+          emailType: raw.email_type,
           event: "email_outbox.dead_letter_exhausted",
         },
         "Transactional email dead-lettered (retry budget exhausted)",
@@ -498,17 +525,17 @@ export async function flushBatch(
     await markStatusWithRetry(
       db,
       MARK_TRANSIENT_FAIL_SQL,
-      [outcome.message, row.id, retryAfter],
-      row.id,
+      [outcome.message, raw.id, retryAfter],
+      raw.id,
       "pending",
     );
     log.warn(
       {
-        rowId: row.id,
-        attempts: row.attempts,
+        rowId: raw.id,
+        attempts: raw.attempts,
         err: outcome.message,
         retryAfterMs: outcome.retryAfterMs ?? null,
-        emailType: row.emailType,
+        emailType: raw.email_type,
         event: "email_outbox.transient_failure",
       },
       "Transactional email send failed (transient) — will retry with backoff",
@@ -520,39 +547,56 @@ export async function flushBatch(
 }
 
 /**
- * Read a claimed row's `payload` column back into an
- * `EmailOutboxMessage`: decrypt (encryptSecret round-trip; plaintext
- * passthrough when no key is configured) then JSON-parse and validate.
- * The `payload` TEXT column is always a string; a non-string indicates a
- * driver/schema regression. Returns `null` when the value isn't a usable
- * message so `flushBatch` can dead-letter it rather than crash.
+ * Result of decoding a claimed row's `payload` column:
+ *  - `ok`        — decrypted + parsed into a valid EmailMessage.
+ *  - `retryable` — decrypt THREW (a dropped/missing key version mid-
+ *                  rotation, or ciphertext corruption). The key case is
+ *                  RECOVERABLE by restoring the key, so flushBatch routes
+ *                  this through the transient path (bounded by the retry
+ *                  budget) rather than permanently dead-lettering — a
+ *                  fixable key-config error must not irreversibly destroy
+ *                  queued auth emails (codex #2972).
+ *  - `malformed` — decrypt SUCCEEDED but the plaintext isn't a valid
+ *                  EmailMessage (bad JSON / missing fields). Structurally
+ *                  broken and unrecoverable → permanent dead-letter.
  */
-function coerceMessage(payload: unknown): EmailOutboxMessage | null {
-  if (typeof payload !== "string") return null;
+type CoercedPayload =
+  | { readonly kind: "ok"; readonly message: EmailOutboxMessage }
+  | { readonly kind: "retryable"; readonly reason: string }
+  | { readonly kind: "malformed"; readonly reason: string };
+
+/**
+ * Decode a claimed row's `payload`: decrypt (encryptSecret round-trip;
+ * plaintext passthrough when no key is configured) then JSON-parse and
+ * validate. The `payload` TEXT column is always a string; a non-string
+ * indicates a driver/schema regression. See {@link CoercedPayload} for
+ * how each failure mode is classified (decrypt-throw = retryable,
+ * decrypted-but-invalid = malformed).
+ */
+function coerceMessage(payload: unknown): CoercedPayload {
+  if (typeof payload !== "string") {
+    return { kind: "malformed", reason: "payload column is not a string (schema/driver regression)" };
+  }
   let json: string;
   try {
     json = decryptSecret(payload as RawSecret);
   } catch (err) {
-    // decryptSecret throws when an enc:v<N>: row references a key version
-    // that's no longer configured (rotation drift). Unrecoverable without
-    // the key — log loudly and let flushBatch dead-letter rather than
-    // crash the tick or retry forever.
-    log.error(
-      { err: err instanceof Error ? err.message : String(err), event: "email_outbox.decrypt_failed" },
-      "email_outbox payload decrypt failed (missing key version?) — dead-lettering row",
-    );
-    return null;
+    // Recoverable-or-corrupt: don't dead-letter here. flushBatch treats
+    // this as transient so a restored key revives delivery; the retry
+    // budget still terminates a permanently-missing key.
+    return { kind: "retryable", reason: `decrypt failed: ${err instanceof Error ? err.message : String(err)}` };
   }
   let obj: unknown;
   try {
     obj = JSON.parse(json);
   } catch {
-    // intentionally ignored: an unparseable payload is unrecoverable;
-    // returning null routes the row to flushBatch's dead-letter branch
-    // (which logs email_outbox.dead_letter_malformed at error level).
-    return null;
+    // intentionally ignored: decrypt succeeded but the plaintext isn't
+    // JSON — structurally broken, never recoverable → malformed.
+    return { kind: "malformed", reason: "decrypted payload is not valid JSON" };
   }
-  if (obj === null || typeof obj !== "object") return null;
+  if (obj === null || typeof obj !== "object") {
+    return { kind: "malformed", reason: "decrypted payload is not an object" };
+  }
   const rec = obj as Record<string, unknown>;
   if (
     typeof rec.to !== "string" ||
@@ -560,9 +604,9 @@ function coerceMessage(payload: unknown): EmailOutboxMessage | null {
     typeof rec.html !== "string" ||
     rec.to.trim().length === 0
   ) {
-    return null;
+    return { kind: "malformed", reason: "missing/invalid to/subject/html" };
   }
-  return { to: rec.to, subject: rec.subject, html: rec.html };
+  return { kind: "ok", message: { to: rec.to, subject: rec.subject, html: rec.html } };
 }
 
 /**
@@ -572,16 +616,31 @@ function coerceMessage(payload: unknown): EmailOutboxMessage | null {
  */
 function coerceDate(v: Date | string | null): Date | null {
   if (v == null) return null;
-  if (v instanceof Date) return Number.isNaN(v.getTime()) ? null : v;
-  const d = new Date(v);
-  return Number.isNaN(d.getTime()) ? null : d;
+  if (v instanceof Date) {
+    if (!Number.isNaN(v.getTime())) return v;
+  } else {
+    const d = new Date(v);
+    if (!Number.isNaN(d.getTime())) return d;
+  }
+  // Non-null but unparseable: log rather than silently treating it as "no
+  // deadline" (which would let a possibly-dead token deliver). A real
+  // timestamptz column should never hit this — it'd signal a driver/schema
+  // regression — so mirror depth.ts:parseTimestamp's discipline.
+  log.warn(
+    { raw: v, event: "email_outbox.expires_at_unparseable" },
+    "email_outbox expires_at could not be parsed as a Date — treating as no deadline this tick",
+  );
+  return null;
 }
 
 /**
- * Compute the absolute `retry_after` timestamp for a transient outcome
- * with an upstream-specified delay. Returns `null` when the outcome
- * carries no delay (the SQL clears the column on every transient mark
- * so a prior Retry-After can't strand a row). Exported for tests.
+ * Compute the absolute `retry_after` candidate for a transient outcome
+ * that carried an upstream-specified delay (e.g. a 429 `Retry-After`).
+ * Returns `null` when the outcome carries no delay — in which case the
+ * SQL's `GREATEST(now() + tier, $3)` uses just the tier-based floor (it
+ * does NOT clear the column: every transient mark overwrites retry_after
+ * with a fresh now-based value, so a prior Retry-After can't strand a
+ * row). Exported for tests.
  */
 export function computeRetryAfterTimestamp(retryAfterMs: number | undefined): Date | null {
   if (retryAfterMs == null) return null;

--- a/packages/api/src/lib/email-outbox/outbox.ts
+++ b/packages/api/src/lib/email-outbox/outbox.ts
@@ -30,6 +30,7 @@
  */
 
 import { createLogger } from "@atlas/api/lib/logger";
+import { encryptSecret, decryptSecret, type RawSecret } from "@atlas/api/lib/db/secret-encryption";
 import { CLAIM_DELAY_SQL, DEAD_AFTER_ATTEMPTS } from "./backoff";
 
 /**
@@ -82,6 +83,13 @@ export interface EnqueueEmailInput {
    * override on re-send. Session-less flows (password reset) pass null.
    */
   readonly orgId?: string | null;
+  /**
+   * Hard delivery deadline. Past this the embedded token/OTP is dead, so
+   * the flusher dead-letters the row instead of delivering an unusable
+   * link/code. Omit / null for non-expiring sends. The caller derives
+   * this from the email type's TTL (reset link 1h, OTP 10m).
+   */
+  readonly expiresAt?: Date | null;
 }
 
 /** Snapshot of a row at the moment the flusher claimed it. */
@@ -91,6 +99,8 @@ export interface ClaimedEmailRow {
   readonly message: EmailOutboxMessage;
   readonly orgId: string | null;
   readonly attempts: number;
+  /** Hard delivery deadline (see EnqueueEmailInput.expiresAt); null = none. */
+  readonly expiresAt: Date | null;
 }
 
 /**
@@ -143,8 +153,8 @@ export interface RecoveryResult {
 // ─────────────────────────────────────────────────────────────────────
 
 const ENQUEUE_SQL = `
-  INSERT INTO email_outbox (email_type, payload, org_id, status)
-  VALUES ($1, $2::jsonb, $3, 'pending')
+  INSERT INTO email_outbox (email_type, payload, org_id, expires_at, status)
+  VALUES ($1, $2, $3, $4, 'pending')
   RETURNING id
 `;
 
@@ -176,7 +186,7 @@ const CLAIM_SQL = `
     FOR UPDATE SKIP LOCKED
     LIMIT $1
   )
-  RETURNING id, email_type, payload, org_id, attempts
+  RETURNING id, email_type, payload, org_id, expires_at, attempts
 `;
 
 const MARK_DONE_SQL = `
@@ -190,17 +200,23 @@ const MARK_DONE_SQL = `
 `;
 
 /**
- * Transient mark. `$3` is either an absolute timestamp (when the send
- * outcome supplied a parseable delay) or NULL (clears any previous
- * retry_after so the row falls back to the tier-based gate on the next
- * claim). `claimed_at` is cleared so the recovery sweep's staleness
- * gate doesn't trip on a row that's already back to pending.
+ * Transient mark. Stamps `retry_after` on EVERY transient failure as
+ * `GREATEST(now() + tier(attempts), $3)` — the next-due time is measured
+ * from the FAILURE moment (`now()`), not from `created_at`. This closes
+ * the codex #2972 finding: a row that sat pending a long time before its
+ * first claim (flusher disabled, app down, delayed migrations) would
+ * otherwise have `created_at + tier` already in the past for every tier
+ * and burn its whole retry budget in a back-to-back burst. `$3` is the
+ * optional upstream-requested delay (a 429 `Retry-After`); GREATEST lets
+ * a longer upstream window win and ignores NULL when there's none.
+ * `claimed_at` is cleared so the recovery sweep's staleness gate doesn't
+ * trip on a row that's already back to pending.
  */
 const MARK_TRANSIENT_FAIL_SQL = `
   UPDATE email_outbox
   SET status = 'pending',
       last_error = $1,
-      retry_after = $3,
+      retry_after = GREATEST(now() + (${CLAIM_DELAY_SQL}), $3),
       claimed_at = NULL
   WHERE id = $2
 `;
@@ -216,17 +232,22 @@ const MARK_DEAD_SQL = `
 `;
 
 /**
- * Recovery sweep — splits the in_flight set into two buckets:
+ * Recovery sweep — splits the STALE in_flight set into two buckets
+ * (both gated on `claimed > $1 ms ago OR never stamped`, so a peer pod
+ * that just claimed a row is never touched mid-send):
  *
  *  1. **Exhausted carcasses** (`attempts >= DEAD_AFTER_ATTEMPTS`) move
  *     straight to `status = 'dead'`. Without this they'd land in
  *     `pending` and never re-claim (the claim WHERE filters them out),
  *     hiding terminal failures from a `status = 'dead'` triage query.
- *  2. **Stale carcasses** (claimed > `$1` ms ago, OR never stamped)
- *     return to `pending` for re-claim. The age threshold protects a
- *     concurrent peer pod in a multi-pod deployment — a sibling that
- *     claimed the row seconds ago is NOT reset out from under its
- *     still-running send.
+ *     The staleness gate here is the codex #2972 fix: in a multi-pod
+ *     deploy a peer that just claimed a row for its LAST allowed attempt
+ *     (attempts already incremented to the budget, mid-send) must NOT be
+ *     dead-lettered out from under the active sender — that would race
+ *     its final status write and emit a false dead-letter. An abandoned
+ *     exhausted row is still dead-lettered once it goes stale.
+ *  2. **Stale carcasses** (under budget) return to `pending` for
+ *     re-claim. Same age threshold, same multi-pod protection.
  *
  * `retry_after` is preserved across both branches.
  */
@@ -240,6 +261,7 @@ const MARK_EXHAUSTED_IN_FLIGHT_DEAD_SQL = `
       END
   WHERE status = 'in_flight'
     AND attempts >= ${DEAD_AFTER_ATTEMPTS}
+    AND (claimed_at IS NULL OR claimed_at < now() - ($1::int * INTERVAL '1 millisecond'))
   RETURNING id
 `;
 
@@ -279,10 +301,15 @@ export async function enqueue(
       "email_outbox enqueue: message.to must be a non-empty recipient address",
     );
   }
+  // Encrypt the rendered body at rest: it carries a live reset link / OTP
+  // for the TTL window (codex #2972). encryptSecret degrades to plaintext
+  // passthrough when no key is configured; decryptSecret round-trips it.
+  const encryptedPayload = encryptSecret(JSON.stringify(input.message));
   const rows = await db.query<{ id: string }>(ENQUEUE_SQL, [
     input.emailType,
-    JSON.stringify(input.message),
+    encryptedPayload,
     input.orgId ?? null,
+    input.expiresAt ?? null,
   ]);
   const id = rows[0]?.id;
   if (!id) {
@@ -301,10 +328,11 @@ export async function recoverInFlight(
   db: EmailOutboxDB,
   staleAgeMs: number = STARTUP_RECOVERY_STALE_MS,
 ): Promise<RecoveryResult> {
-  // Dead-letter exhausted rows first — these don't care about staleness
-  // (a row claimed 1s ago that's already exhausted is still terminally
-  // failed and should not retry).
-  const dead = await db.query<{ id: string }>(MARK_EXHAUSTED_IN_FLIGHT_DEAD_SQL);
+  // Dead-letter exhausted rows that are ALSO stale — a peer pod actively
+  // sending its final attempt (claimed within the window) is left alone
+  // so we don't race its terminal write (codex #2972). Both sweeps share
+  // the same staleness threshold.
+  const dead = await db.query<{ id: string }>(MARK_EXHAUSTED_IN_FLIGHT_DEAD_SQL, [staleAgeMs]);
   const reset = await db.query<{ id: string }>(RECOVER_STALE_IN_FLIGHT_SQL, [staleAgeMs]);
   return { deadLettered: dead.length, reset: reset.length };
 }
@@ -331,6 +359,7 @@ export async function flushBatch(
     email_type: string;
     payload: unknown;
     org_id: string | null;
+    expires_at: Date | string | null;
     attempts: number;
   };
   const claimed = await db.query<ClaimedRow>(CLAIM_SQL, [batchLimit]);
@@ -341,20 +370,47 @@ export async function flushBatch(
   for (const raw of claimed) {
     const message = coerceMessage(raw.payload);
     if (message === null) {
-      // A row whose payload can't be read as an EmailMessage is
-      // unrecoverable — re-sending will never succeed. Dead-letter it
-      // immediately with an actionable error rather than burning the
-      // retry budget on a malformed row.
+      // A row whose payload can't be decrypted/parsed into an
+      // EmailMessage is unrecoverable — re-sending will never succeed.
+      // Dead-letter it immediately rather than burning the retry budget.
+      // (coerceMessage already logs the specific decrypt/parse cause.)
       await markStatusWithRetry(
         db,
         MARK_DEAD_SQL,
-        ["email_outbox payload is not a valid EmailMessage (missing to/subject/html)", raw.id],
+        ["email_outbox payload could not be decrypted/parsed into an EmailMessage", raw.id],
         raw.id,
         "dead",
       );
       log.error(
         { rowId: raw.id, event: "email_outbox.dead_letter_malformed" },
-        "Email outbox row dead-lettered — payload is not a valid EmailMessage",
+        "Email outbox row dead-lettered — payload is not a recoverable EmailMessage",
+      );
+      permanent++;
+      continue;
+    }
+
+    // Expiry gate (codex #2972): the body embeds a live reset link / OTP
+    // that dies at `expires_at`. If a sustained outage outlasted the TTL,
+    // delivering it would just give the user a dead link — dead-letter
+    // instead of sending. Checked AFTER decrypt so a malformed row gets
+    // the more-actionable malformed error.
+    const expiresAt = coerceDate(raw.expires_at);
+    if (expiresAt !== null && Date.now() >= expiresAt.getTime()) {
+      await markStatusWithRetry(
+        db,
+        MARK_DEAD_SQL,
+        [`expired before delivery (expires_at=${expiresAt.toISOString()})`, raw.id],
+        raw.id,
+        "dead",
+      );
+      log.warn(
+        {
+          rowId: raw.id,
+          emailType: raw.email_type,
+          expiresAt: expiresAt.toISOString(),
+          event: "email_outbox.dead_letter_expired",
+        },
+        "Transactional email dead-lettered — embedded token/OTP expired before delivery (outage outlasted the TTL); not sending a dead link",
       );
       permanent++;
       continue;
@@ -366,6 +422,7 @@ export async function flushBatch(
       message,
       orgId: raw.org_id,
       attempts: raw.attempts,
+      expiresAt,
     };
 
     let outcome: EmailDispatchOutcome;
@@ -464,22 +521,36 @@ export async function flushBatch(
 
 /**
  * Read a claimed row's `payload` column back into an
- * `EmailOutboxMessage`. The pg driver may hand the JSONB column back as
- * an already-parsed object (normal path) or as a string (some pool
- * configs); accept both. Returns `null` when the value isn't a usable
+ * `EmailOutboxMessage`: decrypt (encryptSecret round-trip; plaintext
+ * passthrough when no key is configured) then JSON-parse and validate.
+ * The `payload` TEXT column is always a string; a non-string indicates a
+ * driver/schema regression. Returns `null` when the value isn't a usable
  * message so `flushBatch` can dead-letter it rather than crash.
  */
 function coerceMessage(payload: unknown): EmailOutboxMessage | null {
-  let obj: unknown = payload;
-  if (typeof payload === "string") {
-    try {
-      obj = JSON.parse(payload);
-    } catch {
-      // intentionally ignored: an unparseable payload is unrecoverable;
-      // returning null routes the row to flushBatch's dead-letter branch
-      // (which logs email_outbox.dead_letter_malformed at error level).
-      return null;
-    }
+  if (typeof payload !== "string") return null;
+  let json: string;
+  try {
+    json = decryptSecret(payload as RawSecret);
+  } catch (err) {
+    // decryptSecret throws when an enc:v<N>: row references a key version
+    // that's no longer configured (rotation drift). Unrecoverable without
+    // the key — log loudly and let flushBatch dead-letter rather than
+    // crash the tick or retry forever.
+    log.error(
+      { err: err instanceof Error ? err.message : String(err), event: "email_outbox.decrypt_failed" },
+      "email_outbox payload decrypt failed (missing key version?) — dead-lettering row",
+    );
+    return null;
+  }
+  let obj: unknown;
+  try {
+    obj = JSON.parse(json);
+  } catch {
+    // intentionally ignored: an unparseable payload is unrecoverable;
+    // returning null routes the row to flushBatch's dead-letter branch
+    // (which logs email_outbox.dead_letter_malformed at error level).
+    return null;
   }
   if (obj === null || typeof obj !== "object") return null;
   const rec = obj as Record<string, unknown>;
@@ -492,6 +563,18 @@ function coerceMessage(payload: unknown): EmailOutboxMessage | null {
     return null;
   }
   return { to: rec.to, subject: rec.subject, html: rec.html };
+}
+
+/**
+ * Coerce a claimed row's `expires_at` (Date from the pg driver, or a
+ * string under some pool configs) into a Date. Returns `null` for an
+ * absent or unparseable deadline (treated as "no deadline").
+ */
+function coerceDate(v: Date | string | null): Date | null {
+  if (v == null) return null;
+  if (v instanceof Date) return Number.isNaN(v.getTime()) ? null : v;
+  const d = new Date(v);
+  return Number.isNaN(d.getTime()) ? null : d;
 }
 
 /**

--- a/packages/api/src/lib/email-outbox/outbox.ts
+++ b/packages/api/src/lib/email-outbox/outbox.ts
@@ -1,0 +1,594 @@
+/**
+ * Email outbox — durable queue for transactional email (#2942).
+ *
+ * This is a STRIPPED-DOWN mirror of `lib/lead-outbox/`. It owns the
+ * queue mechanics (enqueue, claim, backoff, dead-letter, startup
+ * recovery) and delegates the actual send to a pluggable
+ * `EmailDispatcher` (wired to `email/delivery.ts:sendEmail` in
+ * `lib/email-outbox/dispatch.ts`). Keeping the dispatcher injectable
+ * makes `flushBatch` trivial to unit-test with a fake.
+ *
+ * What it DOESN'T carry, vs `crm_outbox`, and why:
+ *   - No `email_key` per-email serialization: transactional sends have
+ *     no cross-row ordering contract, and an at-least-once duplicate
+ *     send is acceptable. Rows dispatch independently.
+ *   - No `workspace_id` routing / advisory locks: these are
+ *     operator-level transactional sends, not per-tenant plugin
+ *     dispatches. `orgId` is carried only so the flusher re-resolves a
+ *     per-org transport override on re-send.
+ *   - No sub-step resource IDs (`twenty_person_id` etc.): a send is a
+ *     single operation; there is no partial-success sub-step.
+ *
+ * Concurrency: the claim is a single `UPDATE … WHERE id IN (SELECT …
+ * FOR UPDATE SKIP LOCKED) RETURNING *` statement, so multiple flusher
+ * workers (one per pod) cannot double-claim a row.
+ *
+ * Retry-After: when a transient outcome carries a `retryAfterMs`, the
+ * flusher stamps `retry_after = now() + delay` and the claim WHERE
+ * prefers it over the tier-based backoff via
+ * `COALESCE(retry_after, created_at + tier)`.
+ */
+
+import { createLogger } from "@atlas/api/lib/logger";
+import { CLAIM_DELAY_SQL, DEAD_AFTER_ATTEMPTS } from "./backoff";
+
+/**
+ * Narrow DB surface the outbox needs. Matches the `query` method on
+ * `InternalDBShape` and the module-level `internalQuery` standalone, so
+ * the layers.ts wiring can hand in either. Keeping the dependency narrow
+ * makes unit tests trivial (pass any object with a `query` method).
+ */
+export interface EmailOutboxDB {
+  query<T extends Record<string, unknown>>(
+    sql: string,
+    params?: unknown[],
+  ): Promise<T[]>;
+}
+
+const log = createLogger("email-outbox");
+
+// ─────────────────────────────────────────────────────────────────────
+//  Public types
+// ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Outbox lifecycle states. Mirrors the `email_outbox_status_chk` CHECK
+ * constraint exactly. This is the QUEUE lifecycle status, NOT the
+ * content-mode status (draft/published/archived) — email_outbox is an
+ * operational queue, deliberately outside the content-mode system.
+ */
+export type EmailOutboxStatus = "pending" | "in_flight" | "done" | "dead";
+
+/**
+ * The rendered message stored in a row's `payload`. Structurally an
+ * `EmailMessage` (`email/delivery.ts`); kept local so the outbox module
+ * has no static dependency on the delivery layer (the concrete
+ * dispatcher in `dispatch.ts` bridges the two).
+ */
+export interface EmailOutboxMessage {
+  readonly to: string;
+  readonly subject: string;
+  readonly html: string;
+}
+
+/** What a freshly-enqueued row looks like before any send attempt. */
+export interface EnqueueEmailInput {
+  /** Send classification for observability (e.g. "password-reset"). */
+  readonly emailType: string;
+  /** The rendered message to deliver. */
+  readonly message: EmailOutboxMessage;
+  /**
+   * Optional org scope so the flusher re-resolves a per-org transport
+   * override on re-send. Session-less flows (password reset) pass null.
+   */
+  readonly orgId?: string | null;
+}
+
+/** Snapshot of a row at the moment the flusher claimed it. */
+export interface ClaimedEmailRow {
+  readonly id: string;
+  readonly emailType: string;
+  readonly message: EmailOutboxMessage;
+  readonly orgId: string | null;
+  readonly attempts: number;
+}
+
+/**
+ * Dispatcher classification of a send outcome. The outbox uses this to
+ * decide dead-letter vs retry without knowing anything about HTTP
+ * status codes or provider specifics.
+ *
+ * `transient.retryAfterMs` lets the dispatcher honour an upstream
+ * delay (e.g. a 429 `Retry-After`). When set, the flusher stamps
+ * `retry_after = now() + retryAfterMs` and the claim WHERE prefers it.
+ */
+export type EmailDispatchOutcome =
+  | { readonly kind: "ok" }
+  | {
+      readonly kind: "transient";
+      readonly message: string;
+      readonly retryAfterMs?: number;
+    }
+  | { readonly kind: "permanent"; readonly message: string };
+
+/**
+ * Pluggable dispatcher. The implementation owns the send and the
+ * decision of whether a failure is transient or permanent. The concrete
+ * dispatcher (`dispatch.ts`) wraps `sendEmail`.
+ */
+export type EmailDispatcher = (row: ClaimedEmailRow) => Promise<EmailDispatchOutcome>;
+
+export interface FlushResult {
+  readonly claimed: number;
+  readonly ok: number;
+  readonly transient: number;
+  readonly permanent: number;
+}
+
+export interface RecoveryResult {
+  readonly deadLettered: number;
+  readonly reset: number;
+}
+
+// ─────────────────────────────────────────────────────────────────────
+//  SQL — hoisted as top-level constants so each statement is greppable.
+// ─────────────────────────────────────────────────────────────────────
+
+const ENQUEUE_SQL = `
+  INSERT INTO email_outbox (email_type, payload, org_id, status)
+  VALUES ($1, $2::jsonb, $3, 'pending')
+  RETURNING id
+`;
+
+/**
+ * Single-statement claim. The inner SELECT uses `FOR UPDATE SKIP
+ * LOCKED` so concurrent flushers walk disjoint sets of pending rows
+ * without blocking each other. The outer UPDATE atomically flips status
+ * and bumps `attempts`.
+ *
+ * Backoff gate: `COALESCE(retry_after, created_at + tier) <= now()`.
+ * When a prior failure surfaced a delay, the absolute `retry_after`
+ * wins; otherwise the tier-based delay (CLAIM_DELAY_SQL) applies.
+ *
+ * No per-email serialization / advisory locks (cf. crm_outbox) — each
+ * transactional send is independent and an at-least-once duplicate is
+ * acceptable, so the claim is a plain age-ordered batch.
+ */
+const CLAIM_SQL = `
+  UPDATE email_outbox
+  SET status = 'in_flight',
+      attempts = attempts + 1,
+      claimed_at = now()
+  WHERE id IN (
+    SELECT id FROM email_outbox
+    WHERE status = 'pending'
+      AND attempts < ${DEAD_AFTER_ATTEMPTS}
+      AND COALESCE(retry_after, created_at + (${CLAIM_DELAY_SQL})) <= now()
+    ORDER BY created_at, id
+    FOR UPDATE SKIP LOCKED
+    LIMIT $1
+  )
+  RETURNING id, email_type, payload, org_id, attempts
+`;
+
+const MARK_DONE_SQL = `
+  UPDATE email_outbox
+  SET status = 'done',
+      processed_at = now(),
+      last_error = NULL,
+      retry_after = NULL,
+      claimed_at = NULL
+  WHERE id = $1
+`;
+
+/**
+ * Transient mark. `$3` is either an absolute timestamp (when the send
+ * outcome supplied a parseable delay) or NULL (clears any previous
+ * retry_after so the row falls back to the tier-based gate on the next
+ * claim). `claimed_at` is cleared so the recovery sweep's staleness
+ * gate doesn't trip on a row that's already back to pending.
+ */
+const MARK_TRANSIENT_FAIL_SQL = `
+  UPDATE email_outbox
+  SET status = 'pending',
+      last_error = $1,
+      retry_after = $3,
+      claimed_at = NULL
+  WHERE id = $2
+`;
+
+const MARK_DEAD_SQL = `
+  UPDATE email_outbox
+  SET status = 'dead',
+      processed_at = now(),
+      last_error = $1,
+      retry_after = NULL,
+      claimed_at = NULL
+  WHERE id = $2
+`;
+
+/**
+ * Recovery sweep — splits the in_flight set into two buckets:
+ *
+ *  1. **Exhausted carcasses** (`attempts >= DEAD_AFTER_ATTEMPTS`) move
+ *     straight to `status = 'dead'`. Without this they'd land in
+ *     `pending` and never re-claim (the claim WHERE filters them out),
+ *     hiding terminal failures from a `status = 'dead'` triage query.
+ *  2. **Stale carcasses** (claimed > `$1` ms ago, OR never stamped)
+ *     return to `pending` for re-claim. The age threshold protects a
+ *     concurrent peer pod in a multi-pod deployment — a sibling that
+ *     claimed the row seconds ago is NOT reset out from under its
+ *     still-running send.
+ *
+ * `retry_after` is preserved across both branches.
+ */
+const MARK_EXHAUSTED_IN_FLIGHT_DEAD_SQL = `
+  UPDATE email_outbox
+  SET status = 'dead', processed_at = now(),
+      last_error = CASE
+        WHEN last_error IS NULL OR last_error = ''
+          THEN 'crashed mid-send at attempts=' || attempts || ' (recovery)'
+        ELSE last_error || ' [crashed mid-send at attempts=' || attempts || ', recovery dead-lettered]'
+      END
+  WHERE status = 'in_flight'
+    AND attempts >= ${DEAD_AFTER_ATTEMPTS}
+  RETURNING id
+`;
+
+const RECOVER_STALE_IN_FLIGHT_SQL = `
+  UPDATE email_outbox
+  SET status = 'pending'
+  WHERE status = 'in_flight'
+    AND attempts < ${DEAD_AFTER_ATTEMPTS}
+    AND (claimed_at IS NULL OR claimed_at < now() - ($1::int * INTERVAL '1 millisecond'))
+  RETURNING id
+`;
+
+/**
+ * Recovery age thresholds. Startup uses a generous window so any
+ * still-running peer pod's send finishes before we'd interfere;
+ * shutdown can use a shorter window since the dying pod's OWN send has
+ * just been interrupted.
+ */
+export const STARTUP_RECOVERY_STALE_MS = 5 * 60_000; // 5 min
+export const SHUTDOWN_RECOVERY_STALE_MS = 30_000; // 30 s
+
+// ─────────────────────────────────────────────────────────────────────
+//  Public API
+// ─────────────────────────────────────────────────────────────────────
+
+/** Insert a row in `pending` status. Returns the new row id. */
+export async function enqueue(
+  db: EmailOutboxDB,
+  input: EnqueueEmailInput,
+): Promise<string> {
+  // Fail loud on an empty recipient. A row whose payload has no `to`
+  // can never deliver — it would just burn the retry budget and
+  // dead-letter. Reject at the seam so the bug surfaces where it
+  // originates, not six attempts later in the dead-letter log.
+  if (input.message.to.trim().length === 0) {
+    throw new Error(
+      "email_outbox enqueue: message.to must be a non-empty recipient address",
+    );
+  }
+  const rows = await db.query<{ id: string }>(ENQUEUE_SQL, [
+    input.emailType,
+    JSON.stringify(input.message),
+    input.orgId ?? null,
+  ]);
+  const id = rows[0]?.id;
+  if (!id) {
+    // INSERT … RETURNING with no row back is a driver-level invariant
+    // violation — fail loud rather than silently drop the enqueue.
+    throw new Error("email_outbox enqueue returned no row");
+  }
+  return id;
+}
+
+/**
+ * Reset stale `in_flight` rows. Call at Layer init AND from the shutdown
+ * finalizer. Returns a per-bucket count for logging.
+ */
+export async function recoverInFlight(
+  db: EmailOutboxDB,
+  staleAgeMs: number = STARTUP_RECOVERY_STALE_MS,
+): Promise<RecoveryResult> {
+  // Dead-letter exhausted rows first — these don't care about staleness
+  // (a row claimed 1s ago that's already exhausted is still terminally
+  // failed and should not retry).
+  const dead = await db.query<{ id: string }>(MARK_EXHAUSTED_IN_FLIGHT_DEAD_SQL);
+  const reset = await db.query<{ id: string }>(RECOVER_STALE_IN_FLIGHT_SQL, [staleAgeMs]);
+  return { deadLettered: dead.length, reset: reset.length };
+}
+
+/**
+ * Claim a batch of pending-and-due rows, dispatch each, and stamp final
+ * status. Returns counts so the caller can log / surface metrics.
+ *
+ * Errors from the dispatcher are NEVER re-thrown — they're caught and
+ * the row's status is updated per `EmailDispatchOutcome`. An uncaught
+ * defect (the dispatcher itself throwing) is logged and treated as
+ * transient (will retry with backoff) — anything else would leak
+ * `in_flight` rows that `recoverInFlight` would need to mop up.
+ */
+export async function flushBatch(
+  db: EmailOutboxDB,
+  dispatcher: EmailDispatcher,
+  batchLimit: number,
+): Promise<FlushResult> {
+  if (batchLimit <= 0) return { claimed: 0, ok: 0, transient: 0, permanent: 0 };
+
+  type ClaimedRow = {
+    id: string;
+    email_type: string;
+    payload: unknown;
+    org_id: string | null;
+    attempts: number;
+  };
+  const claimed = await db.query<ClaimedRow>(CLAIM_SQL, [batchLimit]);
+  let ok = 0;
+  let transient = 0;
+  let permanent = 0;
+
+  for (const raw of claimed) {
+    const message = coerceMessage(raw.payload);
+    if (message === null) {
+      // A row whose payload can't be read as an EmailMessage is
+      // unrecoverable — re-sending will never succeed. Dead-letter it
+      // immediately with an actionable error rather than burning the
+      // retry budget on a malformed row.
+      await markStatusWithRetry(
+        db,
+        MARK_DEAD_SQL,
+        ["email_outbox payload is not a valid EmailMessage (missing to/subject/html)", raw.id],
+        raw.id,
+        "dead",
+      );
+      log.error(
+        { rowId: raw.id, event: "email_outbox.dead_letter_malformed" },
+        "Email outbox row dead-lettered — payload is not a valid EmailMessage",
+      );
+      permanent++;
+      continue;
+    }
+
+    const row: ClaimedEmailRow = {
+      id: raw.id,
+      emailType: raw.email_type,
+      message,
+      orgId: raw.org_id,
+      attempts: raw.attempts,
+    };
+
+    let outcome: EmailDispatchOutcome;
+    try {
+      outcome = await dispatcher(row);
+    } catch (err) {
+      // Dispatcher contract violation: it should classify and return,
+      // never throw. Treat as transient so we don't dead-letter on a
+      // bug in the dispatcher's error handling.
+      log.error(
+        {
+          rowId: row.id,
+          attempts: row.attempts,
+          err: err instanceof Error ? err.message : String(err),
+          event: "email_outbox.dispatcher_threw",
+        },
+        "Dispatcher threw — classifying as transient so the row will retry",
+      );
+      outcome = {
+        kind: "transient",
+        message: err instanceof Error ? err.message : String(err),
+      };
+    }
+
+    if (outcome.kind === "ok") {
+      await markStatusWithRetry(db, MARK_DONE_SQL, [row.id], row.id, "done");
+      ok++;
+      continue;
+    }
+
+    if (outcome.kind === "permanent") {
+      await markStatusWithRetry(db, MARK_DEAD_SQL, [outcome.message, row.id], row.id, "dead");
+      log.error(
+        {
+          rowId: row.id,
+          attempts: row.attempts,
+          err: outcome.message,
+          emailType: row.emailType,
+          event: "email_outbox.dead_letter_permanent",
+        },
+        "Transactional email dead-lettered (permanent failure) — operator intervention required",
+      );
+      permanent++;
+      continue;
+    }
+
+    // Transient. If we've already burned through the retry budget the
+    // row dies here — the claim WHERE wouldn't let us pick it up again,
+    // so leaving it `pending` would be a silent stuck-forever row.
+    if (row.attempts >= DEAD_AFTER_ATTEMPTS) {
+      await markStatusWithRetry(
+        db,
+        MARK_DEAD_SQL,
+        [`transient failure after ${DEAD_AFTER_ATTEMPTS} attempts: ${outcome.message}`, row.id],
+        row.id,
+        "dead",
+      );
+      log.error(
+        {
+          rowId: row.id,
+          attempts: row.attempts,
+          err: outcome.message,
+          emailType: row.emailType,
+          event: "email_outbox.dead_letter_exhausted",
+        },
+        "Transactional email dead-lettered (retry budget exhausted)",
+      );
+      permanent++;
+      continue;
+    }
+
+    const retryAfter = computeRetryAfterTimestamp(outcome.retryAfterMs);
+    await markStatusWithRetry(
+      db,
+      MARK_TRANSIENT_FAIL_SQL,
+      [outcome.message, row.id, retryAfter],
+      row.id,
+      "pending",
+    );
+    log.warn(
+      {
+        rowId: row.id,
+        attempts: row.attempts,
+        err: outcome.message,
+        retryAfterMs: outcome.retryAfterMs ?? null,
+        emailType: row.emailType,
+        event: "email_outbox.transient_failure",
+      },
+      "Transactional email send failed (transient) — will retry with backoff",
+    );
+    transient++;
+  }
+
+  return { claimed: claimed.length, ok, transient, permanent };
+}
+
+/**
+ * Read a claimed row's `payload` column back into an
+ * `EmailOutboxMessage`. The pg driver may hand the JSONB column back as
+ * an already-parsed object (normal path) or as a string (some pool
+ * configs); accept both. Returns `null` when the value isn't a usable
+ * message so `flushBatch` can dead-letter it rather than crash.
+ */
+function coerceMessage(payload: unknown): EmailOutboxMessage | null {
+  let obj: unknown = payload;
+  if (typeof payload === "string") {
+    try {
+      obj = JSON.parse(payload);
+    } catch {
+      return null;
+    }
+  }
+  if (obj === null || typeof obj !== "object") return null;
+  const rec = obj as Record<string, unknown>;
+  if (
+    typeof rec.to !== "string" ||
+    typeof rec.subject !== "string" ||
+    typeof rec.html !== "string" ||
+    rec.to.trim().length === 0
+  ) {
+    return null;
+  }
+  return { to: rec.to, subject: rec.subject, html: rec.html };
+}
+
+/**
+ * Compute the absolute `retry_after` timestamp for a transient outcome
+ * with an upstream-specified delay. Returns `null` when the outcome
+ * carries no delay (the SQL clears the column on every transient mark
+ * so a prior Retry-After can't strand a row). Exported for tests.
+ */
+export function computeRetryAfterTimestamp(retryAfterMs: number | undefined): Date | null {
+  if (retryAfterMs == null) return null;
+  if (!Number.isFinite(retryAfterMs) || retryAfterMs < 0) return null;
+  return new Date(Date.now() + retryAfterMs);
+}
+
+/**
+ * Single-retry wrapper around a terminal-status UPDATE. If the first
+ * write fails (a Postgres blip between dispatch return and status
+ * stamp), wait briefly and try once more. If both fail, log loudly and
+ * re-throw so the tick's outer catch records the tick as failed — the
+ * row stays `in_flight` and `recoverInFlight` mops it up on the next
+ * boot. Without this, an isolated network hiccup at the wrong moment
+ * strands the row until restart.
+ */
+async function markStatusWithRetry(
+  db: EmailOutboxDB,
+  sql: string,
+  params: unknown[],
+  rowId: string,
+  intent: EmailOutboxStatus,
+): Promise<void> {
+  try {
+    await db.query(sql, params);
+    return;
+  } catch (err) {
+    log.warn(
+      {
+        rowId,
+        intent,
+        err: err instanceof Error ? err.message : String(err),
+        event: "email_outbox.status_update_retrying",
+      },
+      "Email outbox terminal-status UPDATE failed — retrying once before letting the row strand",
+    );
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    await db.query(sql, params);
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────
+//  Configuration
+// ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Tick interval. Default 5s; configurable via
+ * `ATLAS_EMAIL_OUTBOX_TICK_SECONDS`. Clamped to `[1, 3600]` seconds —
+ * the upper bound avoids a Bun timer overflow and the lower bound
+ * prevents an accidental sub-second tick from hammering Postgres.
+ * Out-of-range inputs warn-and-clamp rather than silently default so
+ * the operator's intent (faster / slower) is preserved at the boundary.
+ */
+export const MIN_TICK_SECONDS = 1;
+export const MAX_TICK_SECONDS = 3600;
+export const DEFAULT_TICK_SECONDS = 5;
+
+export function getTickIntervalMs(): number {
+  const raw = process.env.ATLAS_EMAIL_OUTBOX_TICK_SECONDS;
+  if (!raw) return DEFAULT_TICK_SECONDS * 1_000;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_TICK_SECONDS * 1_000;
+  if (parsed < MIN_TICK_SECONDS) {
+    log.warn(
+      { requested: parsed, clamped: MIN_TICK_SECONDS, event: "email_outbox.tick_clamped" },
+      `ATLAS_EMAIL_OUTBOX_TICK_SECONDS=${parsed} is below ${MIN_TICK_SECONDS}s minimum — clamping`,
+    );
+    return MIN_TICK_SECONDS * 1_000;
+  }
+  if (parsed > MAX_TICK_SECONDS) {
+    log.warn(
+      { requested: parsed, clamped: MAX_TICK_SECONDS, event: "email_outbox.tick_clamped" },
+      `ATLAS_EMAIL_OUTBOX_TICK_SECONDS=${parsed} exceeds ${MAX_TICK_SECONDS}s maximum — clamping`,
+    );
+    return MAX_TICK_SECONDS * 1_000;
+  }
+  return parsed * 1_000;
+}
+
+/**
+ * Per-tick claim batch size. Transactional email is low-volume; 25 is
+ * plenty to drain a backlog after an outage without a single tick
+ * fanning out an unbounded number of provider calls.
+ */
+export const FLUSH_BATCH_LIMIT = 25;
+
+/**
+ * Flusher region gate. Default `true` — every API instance with an
+ * internal DB runs the flusher. Set `ATLAS_EMAIL_OUTBOX_FLUSHER_ENABLED=false`
+ * on pods whose internal DB never accumulates email_outbox rows (e.g. a
+ * regional read replica that doesn't serve auth) to skip the idle poll.
+ * Disabling the flusher does NOT skip the boot/shutdown recovery sweep.
+ */
+export function isFlusherEnabled(): boolean {
+  const raw = process.env.ATLAS_EMAIL_OUTBOX_FLUSHER_ENABLED;
+  if (raw === undefined) return true;
+  const normalized = raw.trim().toLowerCase();
+  return !(
+    normalized === "false" ||
+    normalized === "0" ||
+    normalized === "no" ||
+    normalized === "off"
+  );
+}

--- a/packages/api/src/lib/email-outbox/outbox.ts
+++ b/packages/api/src/lib/email-outbox/outbox.ts
@@ -109,6 +109,14 @@ export type EmailDispatchOutcome =
       readonly message: string;
       readonly retryAfterMs?: number;
     }
+  // NOTE: the current concrete dispatcher (`makeEmailDispatcher`) never
+  // emits `permanent` — `sendEmail` surfaces no HTTP status, so every
+  // live failure is classified `transient` and dead-letters via budget
+  // exhaustion instead. This arm is retained for queue-mechanic
+  // completeness and for a future status-aware dispatcher (cf. the
+  // lead-outbox dispatcher, which distinguishes 4xx-permanent). The
+  // `flushBatch` permanent branch is exercised by tests via a synthetic
+  // dispatcher.
   | { readonly kind: "permanent"; readonly message: string };
 
 /**
@@ -467,6 +475,9 @@ function coerceMessage(payload: unknown): EmailOutboxMessage | null {
     try {
       obj = JSON.parse(payload);
     } catch {
+      // intentionally ignored: an unparseable payload is unrecoverable;
+      // returning null routes the row to flushBatch's dead-letter branch
+      // (which logs email_outbox.dead_letter_malformed at error level).
       return null;
     }
   }

--- a/packages/api/src/lib/email-outbox/tick.ts
+++ b/packages/api/src/lib/email-outbox/tick.ts
@@ -1,0 +1,92 @@
+/**
+ * Email-outbox flusher per-tick orchestrator (#2942).
+ *
+ * Composes `flushBatch` with the depth snapshot + threshold warning.
+ * Lives in its own module so the unit test can drive a single async
+ * function with stub deps — no `mock.module`, no Effect runtime, no
+ * global gauge provider — which is the Layer-handoff contract:
+ * `layers.ts` builds the deps, `runEmailOutboxTick` does the work.
+ *
+ * Order of operations matters. Snapshot runs BEFORE dispatch so the
+ * gauge value an operator sees between ticks is "queue depth as of tick
+ * start". Reversing it would make the gauge under-report during a
+ * backlog (dispatch drains some rows, the snapshot then sees the
+ * residual, depth-warn never trips even when the queue is growing).
+ */
+
+import { flushBatch, type EmailOutboxDB, type EmailDispatcher, type FlushResult } from "./outbox";
+import {
+  queryDepthSnapshot,
+  type OutboxDepthSnapshot,
+  OutboxWarnRateLimiter,
+  type WarnDecision,
+} from "./depth";
+
+/**
+ * Minimal OTel Gauge shape. Typed structurally rather than imported
+ * from `@opentelemetry/api` so tests can hand in a plain recorder and
+ * the production wiring still type-checks against the real `Gauge`.
+ */
+export interface GaugeRecorder {
+  record(value: number): void;
+}
+
+/**
+ * Logger shape used by the tick. Structurally typed so the test can
+ * substitute a stub without depending on `pino`.
+ */
+export interface OutboxTickLogger {
+  warn(obj: Record<string, unknown>, msg: string): void;
+}
+
+export interface OutboxTickDeps {
+  readonly db: EmailOutboxDB;
+  readonly dispatcher: EmailDispatcher;
+  readonly batchLimit: number;
+  readonly limiter: OutboxWarnRateLimiter;
+  readonly pendingGauge: GaugeRecorder;
+  readonly deadGauge: GaugeRecorder;
+  readonly logger: OutboxTickLogger;
+  /** Injected for deterministic tests; defaults to `Date.now`. */
+  readonly now?: () => number;
+}
+
+export interface OutboxTickResult {
+  readonly snapshot: OutboxDepthSnapshot;
+  readonly flush: FlushResult;
+  readonly warned: boolean;
+}
+
+/**
+ * Run a single flusher cycle: snapshot → gauges → threshold warn →
+ * dispatch. Returns enough context for the caller (production: the
+ * scheduler Layer; tests: assertions) to surface tick results.
+ *
+ * Exceptions from `queryDepthSnapshot` or `flushBatch` propagate so the
+ * caller's outer `Effect.tryPromise` records a tick failure.
+ */
+export async function runEmailOutboxTick(deps: OutboxTickDeps): Promise<OutboxTickResult> {
+  const { db, dispatcher, batchLimit, limiter, pendingGauge, deadGauge, logger } = deps;
+  const now = deps.now ?? Date.now;
+
+  const snapshot = await queryDepthSnapshot(db);
+  pendingGauge.record(snapshot.pending);
+  deadGauge.record(snapshot.dead);
+
+  const warn: WarnDecision | null = limiter.evaluate(snapshot, now());
+  if (warn) {
+    logger.warn(
+      {
+        depth: warn.depth,
+        threshold: warn.threshold,
+        oldestPendingCreatedAt: warn.oldestPendingCreatedAt?.toISOString() ?? null,
+        oldestPendingAgeMs: warn.oldestPendingAgeMs,
+        event: "email_outbox.depth_threshold_warn",
+      },
+      `email_outbox pending depth ${warn.depth} exceeds threshold ${warn.threshold} — transactional email delivery may be backed up`,
+    );
+  }
+
+  const flush = await flushBatch(db, dispatcher, batchLimit);
+  return { snapshot, flush, warned: warn != null };
+}

--- a/packages/api/src/lib/email/__tests__/delivery.test.ts
+++ b/packages/api/src/lib/email/__tests__/delivery.test.ts
@@ -29,6 +29,7 @@ const {
   sendTransactionalEmail,
   shouldEnqueueFailedSend,
   enqueueFailedTransactionalEmail,
+  computeExpiresAt,
 } = await import("../delivery");
 type DeliveryResult = import("../delivery").DeliveryResult;
 type EmailMessage = import("../delivery").EmailMessage;
@@ -273,7 +274,54 @@ describe("shouldEnqueueFailedSend", () => {
   });
 });
 
+describe("computeExpiresAt", () => {
+  it("returns null for an absent / non-finite TTL (no Invalid Date row)", () => {
+    expect(computeExpiresAt(undefined)).toBeNull();
+    expect(computeExpiresAt(Number.NaN)).toBeNull();
+    expect(computeExpiresAt(Number.POSITIVE_INFINITY)).toBeNull();
+  });
+
+  it("stamps now + ttlMs for a finite TTL (correct sign + unit)", () => {
+    const before = Date.now();
+    const got = computeExpiresAt(600_000); // 10m
+    expect(got).toBeInstanceOf(Date);
+    // Future, not past — guards against a sign flip silently dead-lettering sends.
+    expect(got!.getTime()).toBeGreaterThanOrEqual(before + 600_000);
+    expect(got!.getTime()).toBeLessThan(before + 600_000 + 5_000);
+  });
+});
+
 describe("sendTransactionalEmail", () => {
+  it("threads emailType + ttlMs through to the enqueue path on failure", async () => {
+    const captured: Array<{ emailType: string; ttlMs?: number }> = [];
+    await sendTransactionalEmail(
+      MSG,
+      { emailType: "password-reset", ttlMs: 3_600_000 },
+      {
+        send: async () => ({ success: false, provider: "resend", error: "503" }),
+        enqueueFailed: async (_m, o) => {
+          captured.push({ emailType: o.emailType, ttlMs: o.ttlMs });
+        },
+      },
+    );
+    expect(captured).toEqual([{ emailType: "password-reset", ttlMs: 3_600_000 }]);
+  });
+
+  it("treats a thrown send as a failed send and still resolves 200-safe (F-09)", async () => {
+    const result = await sendTransactionalEmail(
+      MSG,
+      { emailType: "password-reset" },
+      {
+        send: async () => {
+          throw new Error("sendEmail blew up unexpectedly");
+        },
+        enqueueFailed: async () => {},
+      },
+    );
+    expect(result.success).toBe(false);
+    expect(result.provider).toBe("log");
+  });
+
   it("returns the send result and does NOT enqueue on success", async () => {
     let enqueued = 0;
     const result = await sendTransactionalEmail(

--- a/packages/api/src/lib/email/__tests__/delivery.test.ts
+++ b/packages/api/src/lib/email/__tests__/delivery.test.ts
@@ -23,7 +23,15 @@ mock.module("@atlas/api/lib/logger", () => ({
   }),
 }));
 
-const { sendEmail, isAuthEmailDeliveryConfigured } = await import("../delivery");
+const {
+  sendEmail,
+  isAuthEmailDeliveryConfigured,
+  sendTransactionalEmail,
+  shouldEnqueueFailedSend,
+  enqueueFailedTransactionalEmail,
+} = await import("../delivery");
+type DeliveryResult = import("../delivery").DeliveryResult;
+type EmailMessage = import("../delivery").EmailMessage;
 
 // ---------------------------------------------------------------------------
 // Env snapshot + fetch mock
@@ -238,5 +246,106 @@ describe("isAuthEmailDeliveryConfigured", () => {
     // sends email into a black hole.
     settingsStore["ATLAS_EMAIL_PROVIDER"] = "resend";
     expect(isAuthEmailDeliveryConfigured()).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Durable transactional email — sendTransactionalEmail (#2942)
+// ---------------------------------------------------------------------------
+
+const MSG: EmailMessage = { to: "user@example.com", subject: "Reset", html: "<p>x</p>" };
+
+describe("shouldEnqueueFailedSend", () => {
+  it("enqueues a real-transport failure", () => {
+    expect(
+      shouldEnqueueFailedSend({ success: false, provider: "resend", error: "503" } as DeliveryResult),
+    ).toBe(true);
+  });
+
+  it("does NOT enqueue a success", () => {
+    expect(shouldEnqueueFailedSend({ success: true, provider: "resend" } as DeliveryResult)).toBe(false);
+  });
+
+  it("does NOT enqueue the log/no-transport fallback (nowhere to deliver)", () => {
+    expect(
+      shouldEnqueueFailedSend({ success: false, provider: "log", error: "none" } as DeliveryResult),
+    ).toBe(false);
+  });
+});
+
+describe("sendTransactionalEmail", () => {
+  it("returns the send result and does NOT enqueue on success", async () => {
+    let enqueued = 0;
+    const result = await sendTransactionalEmail(
+      MSG,
+      { emailType: "password-reset" },
+      {
+        send: async () => ({ success: true, provider: "resend", messageId: "m1" }),
+        enqueueFailed: async () => {
+          enqueued++;
+        },
+      },
+    );
+    expect(result.success).toBe(true);
+    expect(enqueued).toBe(0);
+  });
+
+  it("enqueues for durable retry when a real transport fails (sustained outage)", async () => {
+    const enqueuedWith: Array<{ to: string; emailType: string }> = [];
+    const result = await sendTransactionalEmail(
+      MSG,
+      { emailType: "password-reset", orgId: "org-1" },
+      {
+        send: async () => ({ success: false, provider: "resend", error: "Resend 503" }),
+        enqueueFailed: async (m, o) => {
+          enqueuedWith.push({ to: m.to, emailType: o.emailType });
+        },
+      },
+    );
+    // Caller still sees the original failed result (it stays 200-safe).
+    expect(result.success).toBe(false);
+    expect(enqueuedWith).toEqual([{ to: "user@example.com", emailType: "password-reset" }]);
+  });
+
+  it("does NOT enqueue when no transport is configured (provider=log)", async () => {
+    let enqueued = 0;
+    await sendTransactionalEmail(
+      MSG,
+      { emailType: "password-reset" },
+      {
+        send: async () => ({ success: false, provider: "log", error: "no backend" }),
+        enqueueFailed: async () => {
+          enqueued++;
+        },
+      },
+    );
+    expect(enqueued).toBe(0);
+  });
+
+  it("never throws even if enqueue throws — preserves the enumeration-safe 200 (F-09)", async () => {
+    const result = await sendTransactionalEmail(
+      MSG,
+      { emailType: "password-reset" },
+      {
+        send: async () => ({ success: false, provider: "resend", error: "503" }),
+        enqueueFailed: async () => {
+          throw new Error("DB exploded");
+        },
+      },
+    );
+    // Resolved (not rejected) with the original result.
+    expect(result.success).toBe(false);
+    expect(result.provider).toBe("resend");
+  });
+});
+
+describe("enqueueFailedTransactionalEmail", () => {
+  it("does not throw and skips enqueue when no internal DB is configured", async () => {
+    // No DATABASE_URL in the unit-test env → hasInternalDB() is false →
+    // the function warns and returns rather than throwing. This pins the
+    // F-09 no-throw contract on the real (non-injected) path.
+    await expect(
+      enqueueFailedTransactionalEmail(MSG, { emailType: "password-reset" }),
+    ).resolves.toBeUndefined();
   });
 });

--- a/packages/api/src/lib/email/delivery.ts
+++ b/packages/api/src/lib/email/delivery.ts
@@ -256,6 +256,18 @@ export function shouldEnqueueFailedSend(result: DeliveryResult): boolean {
 }
 
 /**
+ * Derive the outbox row's absolute `expires_at` from a per-type TTL.
+ * Returns `null` (no deadline) when `ttlMs` is absent or non-finite — a
+ * `NaN`/`Infinity` slip must NOT produce an `Invalid Date` row. Pure +
+ * exported so the date math is unit-testable in isolation (a sign flip
+ * or unit slip here would silently stamp a PAST deadline and the flusher
+ * would dead-letter the send without delivering — #2942 regression risk).
+ */
+export function computeExpiresAt(ttlMs: number | undefined): Date | null {
+  return ttlMs != null && Number.isFinite(ttlMs) ? new Date(Date.now() + ttlMs) : null;
+}
+
+/**
  * Enqueue a failed transactional send to `email_outbox` for durable
  * at-least-once retry. CONTRACT: never throws — the caller's response
  * must stay 200 to preserve signup-enumeration protection (F-09). Skips
@@ -280,10 +292,7 @@ export async function enqueueFailedTransactionalEmail(
       return;
     }
     const { enqueue } = await import("@atlas/api/lib/email-outbox");
-    const expiresAt =
-      opts.ttlMs != null && Number.isFinite(opts.ttlMs)
-        ? new Date(Date.now() + opts.ttlMs)
-        : null;
+    const expiresAt = computeExpiresAt(opts.ttlMs);
     const outboxId = await enqueue(
       { query: internalQuery },
       { emailType: opts.emailType, message, orgId: opts.orgId ?? null, expiresAt },
@@ -339,7 +348,21 @@ export async function sendTransactionalEmail(
 ): Promise<DeliveryResult> {
   const send = deps.send ?? sendEmail;
   const enqueueFailed = deps.enqueueFailed ?? enqueueFailedTransactionalEmail;
-  const result = await send(message, opts.orgId);
+  // Enforce the F-09 never-throw contract LOCALLY rather than depending on
+  // `sendEmail`'s leaf functions all catching internally (true today, but
+  // a future refactor of delivery.ts could regress it). A throw here is
+  // treated as a failed send so the caller's response still stays 200.
+  let result: DeliveryResult;
+  try {
+    result = await send(message, opts.orgId);
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    log.error(
+      { to: message.to, emailType: opts.emailType, err: error },
+      "Transactional email send threw — treating as a failed send; response stays 200 (F-09)",
+    );
+    result = { success: false, provider: "log", error };
+  }
   if (shouldEnqueueFailedSend(result)) {
     try {
       await enqueueFailed(message, opts);

--- a/packages/api/src/lib/email/delivery.ts
+++ b/packages/api/src/lib/email/delivery.ts
@@ -217,6 +217,135 @@ export async function sendEmailWithTransport(
   return deliverViaTransport(message, transport);
 }
 
+// ---------------------------------------------------------------------------
+// Durable transactional email (#2942)
+// ---------------------------------------------------------------------------
+
+export interface TransactionalEmailOptions {
+  /**
+   * Send classification stamped on the outbox row for observability
+   * (e.g. "password-reset", "verification-otp"). Never used for routing.
+   */
+  emailType: string;
+  /** Optional org scope, threaded to `sendEmail` and the outbox row. */
+  orgId?: string;
+}
+
+/**
+ * Should a failed send be enqueued to the durable outbox? Pure so the
+ * decision is unit-testable in isolation.
+ *
+ * `provider === "log"` means NO transport is configured — the send went
+ * to the dev/log fallback, so there is nowhere to deliver and a durable
+ * queue would just dead-letter the row after exhausting the budget.
+ * Only enqueue when a REAL transport was attempted and failed (the
+ * in-process `fetchWithRetry` retry path, #2949, is already exhausted by
+ * the time we see `success: false`).
+ */
+export function shouldEnqueueFailedSend(result: DeliveryResult): boolean {
+  return !result.success && result.provider !== "log";
+}
+
+/**
+ * Enqueue a failed transactional send to `email_outbox` for durable
+ * at-least-once retry. CONTRACT: never throws — the caller's response
+ * must stay 200 to preserve signup-enumeration protection (F-09). Skips
+ * silently (with a warn) when no internal DB is configured (nowhere to
+ * queue). Dynamic imports keep delivery.ts's static module graph
+ * unchanged (no cycle with email-outbox, which the flusher's dispatcher
+ * wires back to `sendEmail`).
+ *
+ * @internal — exported for testing.
+ */
+export async function enqueueFailedTransactionalEmail(
+  message: EmailMessage,
+  opts: TransactionalEmailOptions,
+): Promise<void> {
+  try {
+    const { hasInternalDB, internalQuery } = await import("@atlas/api/lib/db/internal");
+    if (!hasInternalDB()) {
+      log.warn(
+        { to: message.to, emailType: opts.emailType },
+        "Failed transactional email NOT enqueued — no internal DB configured for the durable outbox; send is lost",
+      );
+      return;
+    }
+    const { enqueue } = await import("@atlas/api/lib/email-outbox");
+    const outboxId = await enqueue(
+      { query: internalQuery },
+      { emailType: opts.emailType, message, orgId: opts.orgId ?? null },
+    );
+    log.info(
+      { to: message.to, emailType: opts.emailType, outboxId },
+      "Transactional email send failed — enqueued to email_outbox for durable retry",
+    );
+  } catch (err) {
+    // Never rethrow — a failure to even queue the row must not break the
+    // enumeration-safe 200. Loud error so the lost send is observable.
+    log.error(
+      {
+        to: message.to,
+        emailType: opts.emailType,
+        err: err instanceof Error ? err.message : String(err),
+      },
+      "Failed to enqueue transactional email to the outbox — send is lost",
+    );
+  }
+}
+
+/** Injection seam for {@link sendTransactionalEmail} — test-only. */
+export interface TransactionalEmailDeps {
+  send?: (message: EmailMessage, orgId?: string) => Promise<DeliveryResult>;
+  enqueueFailed?: (message: EmailMessage, opts: TransactionalEmailOptions) => Promise<void>;
+}
+
+/**
+ * Send a transactional email (password reset, signup verification OTP)
+ * with DURABLE at-least-once delivery.
+ *
+ * Calls {@link sendEmail}; if the in-process retry path (#2949) is
+ * exhausted and a real transport failed, the rendered message is
+ * enqueued to `email_outbox` so a SUSTAINED provider outage no longer
+ * permanently drops the send — the Scheduler-backed flusher
+ * (`lib/email-outbox/`) re-sends it on a later tick.
+ *
+ * This is the opt-in wrapper for transactional auth emails. Bulk /
+ * agent / admin-test callers keep using the raw {@link sendEmail} so
+ * they don't accidentally fan failures into the outbox. The flusher's
+ * dispatcher also re-sends via raw `sendEmail`, so a re-send failure
+ * does NOT re-enqueue (no duplication loop).
+ *
+ * Enumeration safety (F-09): never throws and always returns the
+ * original `DeliveryResult`. The caller's response stays 200 whether the
+ * send succeeded, failed-then-queued, or failed-then-couldn't-queue.
+ */
+export async function sendTransactionalEmail(
+  message: EmailMessage,
+  opts: TransactionalEmailOptions,
+  deps: TransactionalEmailDeps = {},
+): Promise<DeliveryResult> {
+  const send = deps.send ?? sendEmail;
+  const enqueueFailed = deps.enqueueFailed ?? enqueueFailedTransactionalEmail;
+  const result = await send(message, opts.orgId);
+  if (shouldEnqueueFailedSend(result)) {
+    try {
+      await enqueueFailed(message, opts);
+    } catch (err) {
+      // `enqueueFailed` already swallows; this is defense-in-depth so a
+      // future refactor that drops its try/catch can't break the 200.
+      log.error(
+        {
+          to: message.to,
+          emailType: opts.emailType,
+          err: err instanceof Error ? err.message : String(err),
+        },
+        "Transactional email outbox enqueue threw — send is lost but response stays 200",
+      );
+    }
+  }
+  return result;
+}
+
 /**
  * Deliver an email using a transport config (DB-stored or platform settings).
  */

--- a/packages/api/src/lib/email/delivery.ts
+++ b/packages/api/src/lib/email/delivery.ts
@@ -229,6 +229,15 @@ export interface TransactionalEmailOptions {
   emailType: string;
   /** Optional org scope, threaded to `sendEmail` and the outbox row. */
   orgId?: string;
+  /**
+   * Time-to-live (ms) for the embedded token/OTP, used to stamp the
+   * outbox row's `expires_at`. The flusher dead-letters (does NOT send) a
+   * row past its deadline so a sustained outage can't deliver a dead reset
+   * link / expired code (#2942 codex review). Pass the SAME value the
+   * email body states (reset link 1h, OTP 10m). Omit for non-expiring
+   * sends.
+   */
+  ttlMs?: number;
 }
 
 /**
@@ -271,9 +280,13 @@ export async function enqueueFailedTransactionalEmail(
       return;
     }
     const { enqueue } = await import("@atlas/api/lib/email-outbox");
+    const expiresAt =
+      opts.ttlMs != null && Number.isFinite(opts.ttlMs)
+        ? new Date(Date.now() + opts.ttlMs)
+        : null;
     const outboxId = await enqueue(
       { query: internalQuery },
-      { emailType: opts.emailType, message, orgId: opts.orgId ?? null },
+      { emailType: opts.emailType, message, orgId: opts.orgId ?? null, expiresAt },
     );
     log.info(
       { to: message.to, emailType: opts.emailType, outboxId },

--- a/packages/api/src/lib/metrics.ts
+++ b/packages/api/src/lib/metrics.ts
@@ -231,3 +231,34 @@ export const crmOutboxDeadCount: Gauge = meter.createGauge(
       "Current crm_outbox rows in dead status, observed per flusher tick (#2734)",
   },
 );
+
+/**
+ * `atlas.email_outbox.pending_count` — current `email_outbox` rows in
+ * `pending` status. Updated by the transactional-email outbox flusher
+ * (#2942) on every tick, BEFORE dispatch, so the value reflects the
+ * queue depth an operator sees between ticks. A sustained value past
+ * `ATLAS_EMAIL_OUTBOX_WARN_THRESHOLD` (default 50) also fires a
+ * rate-limited `log.warn` — pair the two signals in dashboards.
+ */
+export const emailOutboxPendingCount: Gauge = meter.createGauge(
+  "atlas.email_outbox.pending_count",
+  {
+    description:
+      "Current email_outbox rows in pending status, observed per flusher tick (#2942)",
+  },
+);
+
+/**
+ * `atlas.email_outbox.dead_count` — current `email_outbox` rows in
+ * `dead` status. A growing value means transactional sends are
+ * exhausting the retry budget across a sustained provider outage (or a
+ * permanent misconfig). Join with the `email_outbox.dead_letter_*` log
+ * events for per-row triage.
+ */
+export const emailOutboxDeadCount: Gauge = meter.createGauge(
+  "atlas.email_outbox.dead_count",
+  {
+    description:
+      "Current email_outbox rows in dead status, observed per flusher tick (#2942)",
+  },
+);


### PR DESCRIPTION
## Summary

Implements the **residual scope of #2942** — a durable `email_outbox` for at-least-once delivery of transactional email across a **sustained** provider outage. The cheap mitigation (bounded exponential-backoff retry on 429/5xx/network in `fetchWithRetry`) already shipped in #2949 and is left intact; this PR is the backstop for an outage longer than the in-process retry window.

Closes the durable-queue half of #2942 (retry half already shipped).

## What changed

- **New `packages/api/src/lib/email-outbox/`** — a stripped-down mirror of `lib/lead-outbox/`:
  - `outbox.ts` — `enqueue`, single-statement `FOR UPDATE SKIP LOCKED` claim, `flushBatch` (ok / transient-retry / permanent / budget-exhausted dead-letter / malformed-payload dead-letter), `recoverInFlight` crash-recovery sweep, config helpers.
  - `backoff.ts` — bounded tier schedule (30s → 2m → 8m → 30m → 2h, dead at 6 attempts); SQL `CASE` kept in lockstep with the TS array.
  - `depth.ts` — depth snapshot + once-per-minute backlog warn limiter.
  - `tick.ts` — per-tick orchestrator (snapshot → gauges → warn → flush).
  - `dispatch.ts` — concrete dispatcher bridging the queue to `sendEmail` (injected, so the flusher re-send uses the **raw** `sendEmail` → no re-enqueue loop).
  - **Deliberately drops** `email_key` serialization, `workspace_id` routing, and sub-step resource-id columns vs `crm_outbox`: transactional sends are single, independent, at-least-once operations.
- **Migration `0107_email_outbox.sql` + matching `schema.ts` `pgTable`** in the same PR (schema-drift check). Operational queue — explicitly carved out of the content-mode system; stores no credentials (the reset-link token is single-use + short-TTL).
- **`sendTransactionalEmail` wrapper** in `email/delivery.ts` — enqueues on retry-exhausted failure (only when a real transport was attempted; `provider === "log"` / no-backend is skipped). Password-reset + verification-OTP callers switched to it. **F-09 preserved**: never throws, `/request-password-reset` still returns 200 regardless.
- **Flusher fiber + `pending`/`dead` gauges** wired in `effect/layers.ts`, gated on `hasInternalDB()` only — transactional email happens in every deploy mode with a DB (not enterprise-gated, unlike `crm_outbox`). Startup + shutdown crash-recovery sweeps + stall watchdog mirror the CRM flusher.

## Design notes

- **No re-enqueue loop**: the wrapper enqueues; the flusher re-sends via raw `sendEmail` which does not enqueue.
- **Failure classification**: `sendEmail` doesn't surface an HTTP status, and `fetchWithRetry` already exhausted transient retries before enqueue, so the flusher classifies every failure `transient` and rides the backoff to wait out a sustained outage. A genuinely permanent failure still terminates — it dead-letters once the budget is exhausted, with the provider error preserved.
- New env knobs documented in `.env.example`: `ATLAS_EMAIL_OUTBOX_TICK_SECONDS`, `ATLAS_EMAIL_OUTBOX_WARN_THRESHOLD`, `ATLAS_EMAIL_OUTBOX_FLUSHER_ENABLED`.

## Acceptance criteria

- ✅ A simulated sustained Resend outage no longer permanently loses a password-reset send — it lands in `email_outbox` and is delivered on a later tick (covered by `delivery.test.ts` + `email-outbox/__tests__/`).
- ✅ Real-Postgres migration smoke (`migrate-pg.test.ts`) applies 0107 end-to-end. 0107 doesn't reference Better Auth tables, so no `MANAGED_AUTH_MIGRATIONS` entry needed.
- ✅ Unit tests for enqueue + backoff + flush + recover + depth + tick + dispatch + wrapper, plus a `TEST_DATABASE_URL`-gated real-PG integration test exercising the CLAIM backoff gate / `retry_after` override / recovery sweep.

## Testing

`/ci` green locally: **lint, type, test, syncpack, template-drift, railway-watch**. Full `@atlas/api` suite passes (497 files). Real-PG migration smoke + email-outbox PG test pass against Postgres 16.

Updated assertions that a new migration / a second outbox necessarily shift: the migration-count checks in `db/migrate.test.ts` + `auth/migrate.test.ts`, and the CRM-flusher recovery-sweep canary in `outbox-flusher-lifecycle.test.ts` (now scoped to the `crm_outbox` table so the new email sweeps don't inflate it).

## Deferred (noted, not in scope)

- Platform retry/mark-dead **admin UI** (the `crm_outbox` precedent has `platform-crm-outbox.ts`) — out of scope for this slice; the durable enqueue+flush path is the priority. Dead rows are observable via the `atlas.email_outbox.dead_count` gauge + `email_outbox.dead_letter_*` log events.
- `auth/invitations.ts` could opt into the same wrapper later (same gap, different flow) — left untouched to keep this PR focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/2972"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782652900&installation_id=135337507&pr_number=2972&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F2972&signature=c7762cb43872dd00f090b55b4b295b4ca7e3a6f52f23640e919da5f764928a5e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->