### PR TITLE
feat(api,ee): ResidencyResolver staging no-op arm (staging slice 2/22)

### DIFF
--- a/ee/src/platform/residency.test.ts
+++ b/ee/src/platform/residency.test.ts
@@ -25,11 +25,24 @@ const ee = createEEMock({
       return { assigned: true };
     },
   },
+  // Capture `log.error` calls so the staging-arm tests can assert the
+  // "region no longer configured / contract may be violated" path does NOT
+  // fire — distinguishing the intentional staging short-circuit from the
+  // misconfiguration path (which also returns null, but loudly).
+  logger: {
+    createLogger: () => ({
+      info: () => {},
+      warn: () => {},
+      error: (...args: unknown[]) => { loggerErrors.push(args); },
+      debug: () => {},
+    }),
+  },
 });
 
 // Extra state for the custom overrides above
 const mockRows: Record<string, unknown>[][] = [];
 let queryCallCount = 0;
+const loggerErrors: unknown[][] = [];
 
 mock.module("../index", () => ee.enterpriseMock);
 const hasDB = () => (ee.internalDBMock.hasInternalDB as () => boolean)();
@@ -80,6 +93,7 @@ function resetMocks() {
   ee.reset();
   mockRows.length = 0;
   queryCallCount = 0;
+  loggerErrors.length = 0;
   mockConfig = {
     residency: {
       regions: {
@@ -202,6 +216,42 @@ describe("residency", () => {
       mockRows.push([{ region: null }]);
       const result = await run(resolveRegionDatabaseUrl("org-1"));
       expect(result).toBeNull();
+    });
+
+    // ── Staging arm (#2908) ───────────────────────────────────────────
+    // Staging is a DeployRegion but never a residency target — a
+    // staging-keyed workspace falls through to the local DB connection.
+
+    it("returns null for a staging-keyed workspace without logging a contract violation", async () => {
+      // "staging" is absent from the configured residency.regions (us-east /
+      // eu-west). The staging arm must short-circuit to null BEFORE the
+      // regionConfig lookup — i.e. without tripping the loud "region no
+      // longer configured / contract may be violated" error log that the
+      // misconfiguration path would emit. The log assertion is what pins the
+      // new arm: both paths return null, only the staging arm stays quiet.
+      mockRows.push([{ region: "staging" }]);
+      const result = await run(resolveRegionDatabaseUrl("org-1"));
+      expect(result).toBeNull();
+      expect(loggerErrors).toHaveLength(0);
+    });
+
+    it("excludes staging even when it is present in residency config (never a residency target)", async () => {
+      // Defensive: even if an operator accidentally adds a `staging` entry to
+      // the regions map, the staging arm wins and routing stays null. Without
+      // it, this would resolve a non-null staging datasource.
+      mockConfig = {
+        residency: {
+          regions: {
+            "us-east": { label: "US East", databaseUrl: "postgresql://us-east/atlas" },
+            staging: { label: "Staging", databaseUrl: "postgresql://staging/atlas", datasourceUrl: "postgresql://staging/data" },
+          },
+          defaultRegion: "us-east",
+        },
+      };
+      mockRows.push([{ region: "staging" }]);
+      const result = await run(resolveRegionDatabaseUrl("org-1"));
+      expect(result).toBeNull();
+      expect(loggerErrors).toHaveLength(0);
     });
   });
 

--- a/ee/src/platform/residency.test.ts
+++ b/ee/src/platform/residency.test.ts
@@ -25,16 +25,19 @@ const ee = createEEMock({
       return { assigned: true };
     },
   },
-  // Capture `log.error` calls so the staging-arm tests can assert the
-  // "region no longer configured / contract may be violated" path does NOT
-  // fire — distinguishing the intentional staging short-circuit from the
-  // misconfiguration path (which also returns null, but loudly).
+  // Capture log calls by level so the staging-arm tests can pin observability.
+  // `error` distinguishes the intentional staging short-circuit from the
+  // "region no longer configured / contract may be violated" misconfiguration
+  // path (which also returns null, but logs error). `warn` / `debug` pin the
+  // deploy-aware level: staging-keying is debug-quiet only on the staging
+  // deploy, and a loud warn everywhere else (impossible-by-policy state) or
+  // whenever a dead `staging` entry sits in residency.regions.
   logger: {
     createLogger: () => ({
       info: () => {},
-      warn: () => {},
+      warn: (...args: unknown[]) => { loggerWarns.push(args); },
       error: (...args: unknown[]) => { loggerErrors.push(args); },
-      debug: () => {},
+      debug: (...args: unknown[]) => { loggerDebugs.push(args); },
     }),
   },
 });
@@ -43,6 +46,8 @@ const ee = createEEMock({
 const mockRows: Record<string, unknown>[][] = [];
 let queryCallCount = 0;
 const loggerErrors: unknown[][] = [];
+const loggerWarns: unknown[][] = [];
+const loggerDebugs: unknown[][] = [];
 
 mock.module("../index", () => ee.enterpriseMock);
 const hasDB = () => (ee.internalDBMock.hasInternalDB as () => boolean)();
@@ -89,11 +94,32 @@ const {
 const run = <A, E>(effect: Effect.Effect<A, E>) =>
   Effect.runPromise(effect as Effect.Effect<A, never>);
 
+/**
+ * Run `fn` with `ATLAS_DEPLOY_ENV` pinned to `value` (or unset), restoring the
+ * prior value afterward. `resolveDeployEnv()` reads `process.env` at call time
+ * (not cached at module scope), so this deterministically drives the staging
+ * arm's deploy-aware log level without depending on the parent env. Kept in a
+ * try/finally so a failing assertion can't leak the override into sibling tests.
+ */
+async function withDeployEnv<T>(value: string | undefined, fn: () => Promise<T>): Promise<T> {
+  const prev = process.env.ATLAS_DEPLOY_ENV;
+  if (value === undefined) delete process.env.ATLAS_DEPLOY_ENV;
+  else process.env.ATLAS_DEPLOY_ENV = value;
+  try {
+    return await fn();
+  } finally {
+    if (prev === undefined) delete process.env.ATLAS_DEPLOY_ENV;
+    else process.env.ATLAS_DEPLOY_ENV = prev;
+  }
+}
+
 function resetMocks() {
   ee.reset();
   mockRows.length = 0;
   queryCallCount = 0;
   loggerErrors.length = 0;
+  loggerWarns.length = 0;
+  loggerDebugs.length = 0;
   mockConfig = {
     residency: {
       regions: {
@@ -220,25 +246,44 @@ describe("residency", () => {
 
     // ── Staging arm (#2908) ───────────────────────────────────────────
     // Staging is a DeployRegion but never a residency target — a
-    // staging-keyed workspace falls through to the local DB connection.
+    // staging-keyed workspace always falls through to the local DB connection
+    // (result is null, never an error). What varies is the *observability*
+    // level, which is deploy-aware. These four tests are the full 2×2 truth
+    // table of (on staging deploy?) × (staging present in residency.regions?):
+    //   • the loud "contract may be violated" error path NEVER fires (the
+    //     log assertion is what distinguishes the staging arm from the
+    //     misconfiguration path — both return null), and
+    //   • the arm is debug-quiet ONLY when staging-keying is routine, i.e. on
+    //     the staging deploy with no dead `staging` config; otherwise it warns
+    //     with a structured `event` so prod mis-keying / dead config is
+    //     alertable rather than a silent fall-through to the default pool.
+    // `STAGING_REGION` is anchored via `satisfies DeployRegion`, so a mis-cased
+    // literal can't reach the equality check — no case-variant test needed.
 
-    it("returns null for a staging-keyed workspace without logging a contract violation", async () => {
-      // "staging" is absent from the configured residency.regions (us-east /
-      // eu-west). The staging arm must short-circuit to null BEFORE the
-      // regionConfig lookup — i.e. without tripping the loud "region no
-      // longer configured / contract may be violated" error log that the
-      // misconfiguration path would emit. The log assertion is what pins the
-      // new arm: both paths return null, only the staging arm stays quiet.
+    it("off the staging deploy: returns null and warns (no contract-violation error)", async () => {
+      // "staging" is absent from residency.regions (us-east / eu-west) and we
+      // are NOT on the staging deploy — an impossible-by-policy state, so the
+      // arm short-circuits to null (before the regionConfig lookup, so no loud
+      // "contract may be violated" error) but surfaces a structured warn.
       mockRows.push([{ region: "staging" }]);
-      const result = await run(resolveRegionDatabaseUrl("org-1"));
+      const result = await withDeployEnv("production", () => run(resolveRegionDatabaseUrl("org-1")));
       expect(result).toBeNull();
       expect(loggerErrors).toHaveLength(0);
+      expect(loggerDebugs).toHaveLength(0);
+      expect(loggerWarns).toHaveLength(1);
+      expect(loggerWarns[0][0]).toMatchObject({
+        region: "staging",
+        event: "residency.staging_excluded",
+        stagingInResidencyConfig: false,
+      });
     });
 
-    it("excludes staging even when it is present in residency config (never a residency target)", async () => {
-      // Defensive: even if an operator accidentally adds a `staging` entry to
-      // the regions map, the staging arm wins and routing stays null. Without
-      // it, this would resolve a non-null staging datasource.
+    it("off the staging deploy: warns and flags dead config when staging is present in residency.regions", async () => {
+      // Defensive: even if an operator adds a `staging` entry to the regions
+      // map, the staging arm wins and routing stays null (without it, this
+      // would resolve a non-null staging datasource). The dead entry is
+      // surfaced via `stagingInResidencyConfig: true` so the operator learns
+      // it is silently ignored.
       mockConfig = {
         residency: {
           regions: {
@@ -249,9 +294,51 @@ describe("residency", () => {
         },
       };
       mockRows.push([{ region: "staging" }]);
-      const result = await run(resolveRegionDatabaseUrl("org-1"));
+      const result = await withDeployEnv("production", () => run(resolveRegionDatabaseUrl("org-1")));
       expect(result).toBeNull();
       expect(loggerErrors).toHaveLength(0);
+      expect(loggerWarns).toHaveLength(1);
+      expect(loggerWarns[0][0]).toMatchObject({
+        event: "residency.staging_excluded",
+        stagingInResidencyConfig: true,
+      });
+    });
+
+    it("on the staging deploy: stays debug-quiet (staging-keying is routine)", async () => {
+      // On the staging deploy every residency-configured request is staging-
+      // keyed, so the exclusion is routine — debug-level, no warn, no error.
+      mockRows.push([{ region: "staging" }]);
+      const result = await withDeployEnv("staging", () => run(resolveRegionDatabaseUrl("org-1")));
+      expect(result).toBeNull();
+      expect(loggerErrors).toHaveLength(0);
+      expect(loggerWarns).toHaveLength(0);
+      expect(loggerDebugs).toHaveLength(1);
+      expect(loggerDebugs[0][0]).toMatchObject({
+        event: "residency.staging_excluded",
+        stagingInResidencyConfig: false,
+      });
+    });
+
+    it("on the staging deploy: still warns when staging is dead config in residency.regions", async () => {
+      // Dead config is loud regardless of deploy env — a `staging` entry in
+      // residency.regions is never routed, so the operator should hear about it
+      // even on the staging deploy where staging-keying is otherwise routine.
+      mockConfig = {
+        residency: {
+          regions: {
+            "us-east": { label: "US East", databaseUrl: "postgresql://us-east/atlas" },
+            staging: { label: "Staging", databaseUrl: "postgresql://staging/atlas", datasourceUrl: "postgresql://staging/data" },
+          },
+          defaultRegion: "us-east",
+        },
+      };
+      mockRows.push([{ region: "staging" }]);
+      const result = await withDeployEnv("staging", () => run(resolveRegionDatabaseUrl("org-1")));
+      expect(result).toBeNull();
+      expect(loggerErrors).toHaveLength(0);
+      expect(loggerDebugs).toHaveLength(0);
+      expect(loggerWarns).toHaveLength(1);
+      expect(loggerWarns[0][0]).toMatchObject({ stagingInResidencyConfig: true });
     });
   });
 

--- a/ee/src/platform/residency.ts
+++ b/ee/src/platform/residency.ts
@@ -22,6 +22,7 @@ import {
   setWorkspaceRegion,
 } from "@atlas/api/lib/db/internal";
 import { createLogger } from "@atlas/api/lib/logger";
+import { resolveDeployEnv } from "@atlas/api/lib/env-profile";
 import {
   ResidencyResolver,
   type ResidencyResolverShape,
@@ -35,7 +36,7 @@ import type { DeployRegion, RegionStatus, WorkspaceRegion } from "@useatlas/type
 const log = createLogger("ee:residency");
 
 /**
- * The pre-prod soak deploy region (#2897 / #2908). Staging is a 4th
+ * The pre-prod soak deploy region (#2897 / #2908). Staging is a
  * `DeployRegion` keyed `"staging"` (under `*.staging.useatlas.dev`) but is
  * deliberately *excluded* from the residency router: a workspace keyed here
  * resolves to a `null` region route and falls through to the local DB
@@ -225,8 +226,34 @@ export const resolveRegionDatabaseUrl = (
     // below. Short-circuiting here also wins over any accidental `staging`
     // entry in residency.regions, so staging can never claim to be a
     // residency-mapped region. us|eu|apac are untouched.
+    //
+    // Observability is deploy-aware. `region === "staging"` is only routine on
+    // the staging deploy itself (every residency-configured request lands
+    // here) — there it's debug-level noise. On any other deploy it is an
+    // impossible-by-policy state: `assignWorkspaceRegion` rejects `"staging"`
+    // via `isValidRegion`, so the only way a workspace carries it is an
+    // unguarded write (direct DB / backfill / region migration). That means a
+    // workspace believed residency-pinned is being silently served the default
+    // pool — a compliance signal that must be loud + alertable in prod, not a
+    // debug whisper. Likewise, a `staging` entry in residency.regions is dead
+    // config (it is never routed): flag it (`stagingInResidencyConfig`) and
+    // warn even on the staging deploy so the operator learns it is ignored.
     if (region === STAGING_REGION) {
-      log.debug({ workspaceId, region }, "Workspace keyed to staging region — excluded from residency routing, falling through to local DB");
+      const stagingInResidencyConfig = STAGING_REGION in config.residency.regions;
+      const routineOnStagingDeploy = resolveDeployEnv() === "staging" && !stagingInResidencyConfig;
+      const event = {
+        workspaceId,
+        region,
+        event: "residency.staging_excluded",
+        stagingInResidencyConfig,
+      };
+      const message =
+        "Workspace keyed to staging region — excluded from residency routing, falling through to local DB";
+      if (routineOnStagingDeploy) {
+        log.debug(event, message);
+      } else {
+        log.warn(event, message);
+      }
       return null;
     }
 

--- a/ee/src/platform/residency.ts
+++ b/ee/src/platform/residency.ts
@@ -30,9 +30,21 @@ import {
   ResidencyError,
   type ResidencyErrorCode,
 } from "@atlas/api/lib/residency/errors";
-import type { RegionStatus, WorkspaceRegion } from "@useatlas/types";
+import type { DeployRegion, RegionStatus, WorkspaceRegion } from "@useatlas/types";
 
 const log = createLogger("ee:residency");
+
+/**
+ * The pre-prod soak deploy region (#2897 / #2908). Staging is a 4th
+ * `DeployRegion` keyed `"staging"` (under `*.staging.useatlas.dev`) but is
+ * deliberately *excluded* from the residency router: a workspace keyed here
+ * resolves to a `null` region route and falls through to the local DB
+ * connection rather than any residency-mapped pool — see
+ * `resolveRegionDatabaseUrl`. `satisfies DeployRegion` anchors the literal to
+ * the union so dropping `"staging"` from `@useatlas/types` fails compilation
+ * here rather than silently re-enabling routing.
+ */
+const STAGING_REGION = "staging" satisfies DeployRegion;
 
 // ── Typed errors ────────────────────────────────────────────────────
 
@@ -205,6 +217,18 @@ export const resolveRegionDatabaseUrl = (
 
     const region = yield* Effect.promise(() => getWorkspaceRegion(workspaceId));
     if (!region) return null;
+
+    // Staging arm (#2908): the staging deploy region is never a residency
+    // target. Return null *before* the regionConfig lookup so a staging-keyed
+    // workspace falls through to the local DB connection — without tripping
+    // the "region no longer configured / contract may be violated" error path
+    // below. Short-circuiting here also wins over any accidental `staging`
+    // entry in residency.regions, so staging can never claim to be a
+    // residency-mapped region. us|eu|apac are untouched.
+    if (region === STAGING_REGION) {
+      log.debug({ workspaceId, region }, "Workspace keyed to staging region — excluded from residency routing, falling through to local DB");
+      return null;
+    }
 
     const regionConfig = config.residency.regions[region];
     if (!regionConfig) {

--- a/packages/api/src/lib/db/__tests__/region-aware-connection.test.ts
+++ b/packages/api/src/lib/db/__tests__/region-aware-connection.test.ts
@@ -194,12 +194,15 @@ describe("getRegionAwareConnection", () => {
     expect(connections.hasOrgPool("org-1", "default")).toBe(true);
   });
 
-  it("staging-keyed workspace falls through to local DB and never registers a residency pool", async () => {
-    // The live EE staging arm (#2908) returns null from
-    // resolveRegionDatabaseUrl for a workspace keyed to the "staging" deploy
-    // region. Simulate that contract here: a null route must fall through to
-    // the default/local pool and never register a `region:*` connection, so
-    // staging traffic can never be mis-routed to a residency-mapped region.
+  it("null route falls through to local DB and never registers a residency pool (no region leak on metrics)", async () => {
+    // Pins the *consumer-side* null-route contract that the EE staging arm
+    // (#2908) relies on: when resolveRegionDatabaseUrl returns null — as it
+    // does for a "staging"-keyed workspace — getRegionAwareConnection must fall
+    // through to the default/local pool, register no `region:*` connection, and
+    // leave the org pool untagged. This does NOT exercise the staging arm
+    // itself (that lives in residency.test.ts); the trigger is the generic null
+    // route. Its delta over the line-132 "no region configured" test is the two
+    // assertions below — no leaked region pool, and no region on the metrics.
     mockResolveFn = () => null;
 
     const { db, resolvedConnId } = await getRegionAwareConnection("staging-workspace", "default");

--- a/packages/api/src/lib/db/__tests__/region-aware-connection.test.ts
+++ b/packages/api/src/lib/db/__tests__/region-aware-connection.test.ts
@@ -194,6 +194,29 @@ describe("getRegionAwareConnection", () => {
     expect(connections.hasOrgPool("org-1", "default")).toBe(true);
   });
 
+  it("staging-keyed workspace falls through to local DB and never registers a residency pool", async () => {
+    // The live EE staging arm (#2908) returns null from
+    // resolveRegionDatabaseUrl for a workspace keyed to the "staging" deploy
+    // region. Simulate that contract here: a null route must fall through to
+    // the default/local pool and never register a `region:*` connection, so
+    // staging traffic can never be mis-routed to a residency-mapped region.
+    mockResolveFn = () => null;
+
+    const { db, resolvedConnId } = await getRegionAwareConnection("staging-workspace", "default");
+    expect(db).toBeDefined();
+    expect(resolvedConnId).toBe("default");
+
+    // No residency-mapped region connection registered…
+    expect(connections.list().some((id) => id.startsWith("region:"))).toBe(false);
+    // …and the org uses the default (local) pool.
+    expect(connections.hasOrgPool("staging-workspace", "default")).toBe(true);
+
+    // Org pool carries no region — it was not routed to any residency target.
+    const metrics = connections.getOrgPoolMetrics("staging-workspace");
+    expect(metrics).toHaveLength(1);
+    expect(metrics[0].region).toBeUndefined();
+  });
+
   it("different orgs in different regions get separate pools", async () => {
     // org-1 → us-east-1
     mockResolveFn = (orgId: string) => {


### PR DESCRIPTION
## Summary

Staging slice 2/22 of the Staging Environment milestone (#57). Extends the live EE `ResidencyResolver` to handle the new `"staging"` deploy region — **purely additive**, `us|eu|apac` paths untouched.

- **`ee/src/platform/residency.ts`** — `resolveRegionDatabaseUrl` gains a `staging` arm: a workspace keyed to the staging region resolves to `null` and falls through to the local DB connection, never routing to a residency-mapped pool. It short-circuits *before* the `regionConfig` lookup, so staging is treated as an intentional non-residency region rather than tripping the loud `"region no longer configured / contract may be violated"` error path — and it wins even if `staging` is accidentally present in `residency.regions`, so staging can never claim to be a residency target.
- `STAGING_REGION` is anchored via `satisfies DeployRegion` (`@useatlas/types`, shipped #2897), so dropping the union member fails compilation here rather than silently re-enabling routing.
- **`packages/api/src/lib/db/connection.ts`** — no change needed: `getRegionAwareConnection`'s existing null-handling already falls through to the default/local pool when the resolver returns `null` (verified).

Reads through the `ResidencyResolver` Context.Tag, so no core→ee import is introduced (ee-stub-build stays green).

## Test plan

- [x] `resolveRegionDatabaseUrl` returns `null` for a staging-keyed workspace **without** logging a contract violation (EE resolver test — log assertion distinguishes the intentional arm from the misconfiguration path, since both return null)
- [x] Defensive: staging excluded even when present in `residency.regions` (would otherwise resolve a non-null staging datasource)
- [x] `us|eu|apac` behavior unchanged (existing EE resolver tests stay green)
- [x] A staging-keyed request is not mis-routed: `region-aware-connection.test.ts` pins that a `null` route registers no `region:*` connection and the org pool carries no region
- [x] Verified both new EE tests fail with the arm removed (they genuinely pin the new code)
- [x] `/ci` — lint, type, full test, syncpack, all drift gates green; remote CI + Railway staging green

Closes #2908

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/2980"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782668472&installation_id=135337507&pr_number=2980&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F2980&signature=576c8a9f72494261a81ddb97ef209fb186d582a2ffab22d884427c28ef84ea44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->