### PR TITLE
feat(staging): StagingClamp deep module + unit tests (slice 4/22)

### DIFF
--- a/docs/prd/staging-environment.md
+++ b/docs/prd/staging-environment.md
@@ -181,7 +181,7 @@ Module: `packages/api/src/lib/staging/__tests__/clamp.test.ts`. Cases:
 - `clampOutbound("staging", emailWithRealTo)` rewrites `to` to sink
 - `clampOutbound("staging", emailWithRealTo)` preserves `subject`, `body`, `from`, custom headers
 - `clampOutbound("staging", emailWithEmptyTo)` returns sink-targeted email (not crash)
-- `clampOutbound("staging", emailWithArrayTo)` rewrites array to single sink address
+- `clampOutbound("staging", emailWithArrayTo)` rewrites an array `to` to a one-element `[sink]` array — one recipient (the sink), with the array shape preserved so `clampOutbound`'s `(T) => T` signature stays type-honest (collapsing to a bare string would make the runtime value diverge from the declared `string[]`)
 
 Prior art: `packages/api/src/lib/__tests__/cors-origin.test.ts` — pure-function allowlist tests.
 

--- a/packages/api/src/lib/staging/__tests__/clamp.test.ts
+++ b/packages/api/src/lib/staging/__tests__/clamp.test.ts
@@ -8,9 +8,10 @@
  * (Resend sender-reputation risk, PRD user story 13).
  *
  * The 7 canonical cases come straight from the PRD "Testing Decisions"
- * section. Further cases lock the documented-env-var override (default and
- * empty fallback), the recipient-classifier boundary, and the
- * future-transform passthrough seam.
+ * section. Further cases lock the documented-env-var override (default,
+ * empty, and whitespace-only fallback), the recipient-classifier boundary
+ * (including the empty-array edge), and the future-transform passthrough
+ * seam.
  *
  * The fixtures carry `body` / `from` / `headers` to assert the
  * preserve-everything-else guarantee. Those field names track the PRD's
@@ -21,8 +22,9 @@
  * delivery layer grows must ride through untouched.
  *
  * Prior art: `packages/api/src/api/__tests__/cors-origin.test.ts` — a
- * prod-vs-staging policy-boundary test (it asserts the allowlist contract,
- * though it does so over a mocked HTTP route rather than a pure function).
+ * security policy-boundary test asserting an allow/deny contract (the origin
+ * allowlist), though it does so over a mocked HTTP route rather than a pure
+ * function.
  */
 
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
@@ -123,16 +125,27 @@ describe("clampOutbound — staging redirects email to the sink", () => {
     expect(result.subject).toBe("Empty recipient");
   });
 
-  // Case 7: an array `to` collapses to the single sink address.
-  it("rewrites an array `to` to a single sink address", () => {
+  // Case 7: an array `to` is redirected to a one-element `[sink]` array. The
+  // shape is preserved (an array stays an array), so `clampOutbound`'s
+  // `(T) => T` signature is type-honest — a caller declaring `to: string[]`
+  // gets a real `string[]` back, not a bare string masquerading as one.
+  // There is still exactly one recipient: the sink.
+  it("rewrites an array `to` to a one-element sink array", () => {
     const result = clampOutbound("staging", emailWithArrayTo());
-    // `clampOutbound`'s `(T) => T` signature keeps `to`'s declared `string[]`
-    // type, but at runtime the array collapses to a single sink string —
-    // read through `unknown` to assert the real runtime value honestly.
-    const to: unknown = result.to;
-    expect(to).toBe(DEFAULT_SINK);
-    // Not an array of one — a single address string.
-    expect(Array.isArray(to)).toBe(false);
+    expect(result.to).toEqual([DEFAULT_SINK]);
+    expect(Array.isArray(result.to)).toBe(true);
+  });
+
+  // Edge case: an empty-array `to` (`[]`) is still a recipient field
+  // (`[].every(...)` is vacuously true), so it is redirected to `[sink]` like
+  // any other array rather than passed through unclamped. This pins the
+  // vacuous-`.every` behavior the staging branch silently relies on: a future
+  // "harden" to `to.length > 0 && to.every(...)` would drop `[]` through the
+  // clamp unredirected, and this test would catch it.
+  it("rewrites an empty-array `to` to the one-element sink array", () => {
+    const result = clampOutbound("staging", { to: [] as string[], subject: "empty array" });
+    expect(result.to).toEqual([DEFAULT_SINK]);
+    expect(result.subject).toBe("empty array");
   });
 });
 
@@ -150,6 +163,16 @@ describe("clampOutbound — documented sink env var", () => {
   // test — this is the one that locks the anti-footgun.
   it("falls back to the default sink when STAGING_MAIL_SINK is empty", () => {
     process.env.STAGING_MAIL_SINK = "";
+    const result = clampOutbound("staging", emailWithRealTo());
+    expect(result.to).toBe(DEFAULT_SINK);
+  });
+
+  // A whitespace-only value is the empty-string footgun one step further: it
+  // is truthy, so a bare `||` would stamp `" "` on as the recipient — a
+  // blank-ish address that bounces silently or lets mail escape. `resolveMailSink`
+  // `.trim()`s before the `||`, so whitespace collapses to the default.
+  it("falls back to the default sink when STAGING_MAIL_SINK is whitespace-only", () => {
+    process.env.STAGING_MAIL_SINK = "   ";
     const result = clampOutbound("staging", emailWithRealTo());
     expect(result.to).toBe(DEFAULT_SINK);
   });

--- a/packages/api/src/lib/staging/__tests__/clamp.test.ts
+++ b/packages/api/src/lib/staging/__tests__/clamp.test.ts
@@ -8,12 +8,21 @@
  * (Resend sender-reputation risk, PRD user story 13).
  *
  * The 7 canonical cases come straight from the PRD "Testing Decisions"
- * section. Two further cases lock the documented-env-var override and the
+ * section. Further cases lock the documented-env-var override (default and
+ * empty fallback), the recipient-classifier boundary, and the
  * future-transform passthrough seam.
  *
- * Prior art: `packages/api/src/api/__tests__/cors-origin.test.ts` — pure
- * allowlist tests that fail iff a prod-vs-staging policy is violated, not
- * iff a refactor moved the implementation.
+ * The fixtures carry `body` / `from` / `headers` to assert the
+ * preserve-everything-else guarantee. Those field names track the PRD's
+ * anticipated email shape — today's concrete `EmailMessage`
+ * (`lib/email/delivery.ts`) is just `{ to, subject, html }`. Because the
+ * clamp is intentionally structural (it only reads `to` and shallow-copies
+ * the rest), exercising extra fields is exactly the point: any field the
+ * delivery layer grows must ride through untouched.
+ *
+ * Prior art: `packages/api/src/api/__tests__/cors-origin.test.ts` — a
+ * prod-vs-staging policy-boundary test (it asserts the allowlist contract,
+ * though it does so over a mocked HTTP route rather than a pure function).
  */
 
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
@@ -133,6 +142,17 @@ describe("clampOutbound — documented sink env var", () => {
     const result = clampOutbound("staging", emailWithRealTo());
     expect(result.to).toBe("soak-inbox@staging.useatlas.dev");
   });
+
+  // The clamp resolves the sink with `||`, not `??`, on purpose: an
+  // explicitly-empty STAGING_MAIL_SINK must fall back to the default rather
+  // than blank the recipient (a blank `to` would error in the transport or
+  // let mail escape). A regression to `??` would silently pass every other
+  // test — this is the one that locks the anti-footgun.
+  it("falls back to the default sink when STAGING_MAIL_SINK is empty", () => {
+    process.env.STAGING_MAIL_SINK = "";
+    const result = clampOutbound("staging", emailWithRealTo());
+    expect(result.to).toBe(DEFAULT_SINK);
+  });
 });
 
 describe("clampOutbound — future-transform seam", () => {
@@ -151,5 +171,19 @@ describe("clampOutbound — future-transform seam", () => {
     expect(clampOutbound("staging", "not-an-object")).toBe("not-an-object");
     expect(clampOutbound("staging", 42)).toBe(42);
     expect(clampOutbound("staging", null)).toBe(null);
+  });
+
+  // `isRecipientField` only classifies a `to` that is a string OR an array of
+  // ALL strings. A `to` of the wrong type — a non-string scalar, or an array
+  // with a non-string element — is NOT a recipient field, so the payload is
+  // left untouched (no spurious sink stamped on it). This locks the
+  // `typeof`/`.every` checks against a future loosening that would mis-stamp
+  // a malformed payload.
+  it("does not clamp a payload whose `to` is not a string-or-string[]", () => {
+    const numericTo = { to: 42, subject: "weird" };
+    expect(clampOutbound("staging", numericTo)).toBe(numericTo);
+
+    const mixedArrayTo = { to: ["alice@example.com", 42], subject: "weird" };
+    expect(clampOutbound("staging", mixedArrayTo)).toBe(mixedArrayTo);
   });
 });

--- a/packages/api/src/lib/staging/__tests__/clamp.test.ts
+++ b/packages/api/src/lib/staging/__tests__/clamp.test.ts
@@ -1,0 +1,155 @@
+/**
+ * StagingClamp — pure unit tests (staging slice 4, #2910).
+ *
+ * Contract under test: `clampOutbound(region, sendable)` is the single
+ * outbound-rewrite chokepoint for the `staging` deploy region. It MUST be
+ * identity for every prod region and MUST redirect email recipients to the
+ * staging sink so a staging soak can never email a real-looking address
+ * (Resend sender-reputation risk, PRD user story 13).
+ *
+ * The 7 canonical cases come straight from the PRD "Testing Decisions"
+ * section. Two further cases lock the documented-env-var override and the
+ * future-transform passthrough seam.
+ *
+ * Prior art: `packages/api/src/api/__tests__/cors-origin.test.ts` — pure
+ * allowlist tests that fail iff a prod-vs-staging policy is violated, not
+ * iff a refactor moved the implementation.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { clampOutbound } from "@atlas/api/lib/staging/clamp";
+
+/** Documented default sink when STAGING_MAIL_SINK is unset (PRD). */
+const DEFAULT_SINK = "staging-mail@useatlas.dev";
+
+// --- Fixtures -------------------------------------------------------------
+
+/** A rich email payload bound for a real customer address. */
+function emailWithRealTo() {
+  return {
+    to: "real.customer@example.com",
+    subject: "Your Q3 revenue report",
+    body: "<p>Revenue is up 12%.</p>",
+    from: "Atlas <noreply@useatlas.dev>",
+    headers: { "X-Atlas-Trace": "trace-abc123", "Reply-To": "team@useatlas.dev" },
+  };
+}
+
+/** Edge case: a payload whose recipient is the empty string. */
+function emailWithEmptyTo() {
+  return {
+    to: "",
+    subject: "Empty recipient",
+    body: "<p>still has a body</p>",
+    from: "Atlas <noreply@useatlas.dev>",
+  };
+}
+
+/** A multi-recipient payload — `to` is an array of addresses. */
+function emailWithArrayTo() {
+  return {
+    to: ["alice@example.com", "bob@example.com", "carol@example.com"],
+    subject: "Team digest",
+    body: "<p>Weekly digest.</p>",
+    from: "Atlas <noreply@useatlas.dev>",
+  };
+}
+
+// --- Hermetic env control -------------------------------------------------
+// The sink env var is the ONE documented input beyond `region`. Save and
+// restore it around every test so the default-sink cases are deterministic
+// regardless of the surrounding shell/CI environment, and so the override
+// case cannot leak into siblings. (Not module-scope mutation — permitted.)
+
+let savedSink: string | undefined;
+
+beforeEach(() => {
+  savedSink = process.env.STAGING_MAIL_SINK;
+  delete process.env.STAGING_MAIL_SINK;
+});
+
+afterEach(() => {
+  if (savedSink === undefined) delete process.env.STAGING_MAIL_SINK;
+  else process.env.STAGING_MAIL_SINK = savedSink;
+});
+
+describe("clampOutbound — prod regions are identity transforms", () => {
+  // Cases 1–3: us / eu / apac never rewrite outbound payloads.
+  for (const region of ["us", "eu", "apac"] as const) {
+    it(`returns the email unchanged for region "${region}"`, () => {
+      const email = emailWithRealTo();
+      const result = clampOutbound(region, email);
+      // Identity: same reference, no copy, no allocation off the hot path.
+      expect(result).toBe(email);
+      expect(result.to).toBe("real.customer@example.com");
+    });
+  }
+});
+
+describe("clampOutbound — staging redirects email to the sink", () => {
+  // Case 4: staging rewrites `to` to the sink.
+  it("rewrites `to` to the default sink", () => {
+    const result = clampOutbound("staging", emailWithRealTo());
+    expect(result.to).toBe(DEFAULT_SINK);
+  });
+
+  // Case 5: every non-recipient field is preserved verbatim.
+  it("preserves subject, body, from, and custom headers", () => {
+    const original = emailWithRealTo();
+    const result = clampOutbound("staging", original);
+
+    expect(result.subject).toBe(original.subject);
+    expect(result.body).toBe(original.body);
+    expect(result.from).toBe(original.from);
+    expect(result.headers).toEqual(original.headers);
+
+    // Purity: the input is not mutated — its `to` is still the real address.
+    expect(original.to).toBe("real.customer@example.com");
+  });
+
+  // Case 6: an empty `to` is rewritten, not crashed past.
+  it("rewrites an empty `to` to the sink without crashing", () => {
+    const result = clampOutbound("staging", emailWithEmptyTo());
+    expect(result.to).toBe(DEFAULT_SINK);
+    expect(result.subject).toBe("Empty recipient");
+  });
+
+  // Case 7: an array `to` collapses to the single sink address.
+  it("rewrites an array `to` to a single sink address", () => {
+    const result = clampOutbound("staging", emailWithArrayTo());
+    // `clampOutbound`'s `(T) => T` signature keeps `to`'s declared `string[]`
+    // type, but at runtime the array collapses to a single sink string —
+    // read through `unknown` to assert the real runtime value honestly.
+    const to: unknown = result.to;
+    expect(to).toBe(DEFAULT_SINK);
+    // Not an array of one — a single address string.
+    expect(Array.isArray(to)).toBe(false);
+  });
+});
+
+describe("clampOutbound — documented sink env var", () => {
+  it("honors STAGING_MAIL_SINK when set", () => {
+    process.env.STAGING_MAIL_SINK = "soak-inbox@staging.useatlas.dev";
+    const result = clampOutbound("staging", emailWithRealTo());
+    expect(result.to).toBe("soak-inbox@staging.useatlas.dev");
+  });
+});
+
+describe("clampOutbound — future-transform seam", () => {
+  // No transform is registered for non-email payloads yet (Stripe customer
+  // mirroring, Slack webhook overrides are out of scope today). Such a
+  // payload must pass through untouched rather than be misclassified as an
+  // email and have a spurious `to` written onto it.
+  it("passes a non-email payload through unchanged on staging", () => {
+    const stripeCustomer = { customerId: "cus_123", email: "real.customer@example.com" };
+    const result = clampOutbound("staging", stripeCustomer);
+    expect(result).toBe(stripeCustomer);
+    expect(result.email).toBe("real.customer@example.com");
+  });
+
+  it("does not crash on a primitive payload", () => {
+    expect(clampOutbound("staging", "not-an-object")).toBe("not-an-object");
+    expect(clampOutbound("staging", 42)).toBe(42);
+    expect(clampOutbound("staging", null)).toBe(null);
+  });
+});

--- a/packages/api/src/lib/staging/clamp.ts
+++ b/packages/api/src/lib/staging/clamp.ts
@@ -37,12 +37,15 @@ import type { DeployRegion } from "@useatlas/types";
 const DEFAULT_MAIL_SINK = "staging-mail@useatlas.dev";
 
 /**
- * Resolve the staging email sink. Reads the one documented env var, falling
- * back to the default. An empty/unset value uses the default (`||`, not
- * `??`, so an explicitly-empty var doesn't blank the recipient).
+ * Resolve the staging email sink. Reads the one documented env var, trims it,
+ * and falls back to the default for any empty/unset/whitespace-only value
+ * (`||`, not `??`, so an explicitly-empty var doesn't blank the recipient;
+ * the `.trim()` extends that guard to a whitespace-only var like `" "`, which
+ * is truthy and would otherwise be stamped on as a blank-ish recipient —
+ * bouncing silently in the transport or letting mail escape).
  */
 function resolveMailSink(): string {
-  return process.env.STAGING_MAIL_SINK || DEFAULT_MAIL_SINK;
+  return process.env.STAGING_MAIL_SINK?.trim() || DEFAULT_MAIL_SINK;
 }
 
 /**
@@ -72,24 +75,36 @@ function isRecipientField(to: unknown): to is string | string[] {
 }
 
 /**
- * Email recipient redirect: rewrite `to` (single or array) to the single
- * staging sink address, preserving every non-recipient field — `subject`,
- * the body, `from`, headers, and anything else — via the shallow copy. A
- * multi-recipient array collapses to the one sink address: staging never
- * needs to fan out, and one sink keeps the soak inbox simple.
+ * Email recipient redirect: rewrite `to` to the single staging sink address,
+ * preserving every non-recipient field — `subject`, the body, `from`,
+ * headers, and anything else — via the shallow copy. The `to` field's SHAPE
+ * is preserved so the `(T) => T` contract stays type-honest: a single-string
+ * `to` becomes the sink string; an array `to` becomes a one-element array
+ * `[sink]`. Either way there is exactly one recipient — staging never needs
+ * to fan out, and one sink keeps the soak inbox simple — but collapsing an
+ * array to a bare string would make `to`'s runtime value diverge from its
+ * declared `string[]` type, an unsound `(T) => T` a typed caller (e.g. one
+ * doing `result.to.map(...)`) would trip over.
  *
  * SCOPE — `to` is the ONLY recipient field redirected, because the current
  * `EmailMessage` (`lib/email/delivery.ts`: `{ to, subject, html }`) has no
  * other recipient field. If the email layer ever grows `cc` / `bcc` /
  * `replyTo`, they are recipient fields too and MUST be redirected here as
  * well — otherwise a staging soak would deliver to those real addresses
- * while `to` looks correctly clamped (tracked as a follow-up). The
- * non-recipient fields above are intentionally preserved, not leaked.
+ * while `to` looks correctly clamped (tracked as #2984). The non-recipient
+ * fields above are intentionally preserved, not leaked.
  */
 const EMAIL_CLAMP: OutboundClamp = {
   name: "email",
   appliesTo: (sendable) => isRecipientField((sendable as { to?: unknown }).to),
-  rewrite: (sendable) => ({ ...sendable, to: resolveMailSink() }),
+  rewrite: (sendable) => {
+    const sink = resolveMailSink();
+    // Preserve `to`'s shape (string -> sink string; array -> `[sink]`) so the
+    // returned object honestly matches its declared `T` — see the doc above.
+    const currentTo = (sendable as { to?: unknown }).to;
+    const to = Array.isArray(currentTo) ? [sink] : sink;
+    return { ...sendable, to };
+  },
 };
 
 /**
@@ -110,11 +125,16 @@ const OUTBOUND_CLAMPS: readonly OutboundClamp[] = [EMAIL_CLAMP];
  *   primitive or `null`) passes through unchanged.
  *
  * @param region   the deploy region — ALWAYS an explicit argument, never read
- *                 from the environment here. The wiring slice derives it from
- *                 `getApiRegion()` (which returns `string | null`), NARROWED
- *                 to a `DeployRegion` first — a raw unrecognized string takes
- *                 the prod identity path (fail-open), so the caller must pin
- *                 the narrowing rather than pass the raw env read.
+ *                 from the environment here. The wiring slice (#2985) derives
+ *                 it from `getApiRegion()` (which returns `string | null`,
+ *                 with GRANULAR values like `"us-west"`/`"eu-west"`) and MUST
+ *                 MAP that to a `DeployRegion` (e.g. `"us-west"` -> `"us"`) —
+ *                 a plain type-narrow is insufficient, because the env values
+ *                 are finer-grained than this union, so `"us-west"` is not
+ *                 itself a `DeployRegion`. Any unrecognized value takes the
+ *                 prod identity path (fail-OPEN), so passing a raw
+ *                 `getApiRegion()` result here is a customer-email-leak bug:
+ *                 the caller MUST pin the mapping, not pass the raw env read.
  * @param sendable the outbound payload (email message, future: Stripe/Slack).
  * @returns the same `sendable` outside staging; a staging-safe copy inside.
  */

--- a/packages/api/src/lib/staging/clamp.ts
+++ b/packages/api/src/lib/staging/clamp.ts
@@ -62,9 +62,10 @@ interface OutboundClamp {
  *
  * This structural check (rather than importing `EmailMessage` from
  * `lib/email/delivery.ts`) keeps the clamp dependency-free of the email
- * subsystem and tolerant of richer payloads — multi-recipient `to`, plus
- * `from` / custom headers the delivery layer may grow. Only the recipient
- * field is inspected; every other field rides through the shallow copy.
+ * subsystem. Today `EmailMessage.to` is a single `string`; the array arm is
+ * forward-looking — IF the delivery layer later grows a multi-recipient `to`,
+ * this check already tolerates it. Only the `to` field is inspected; every
+ * other field rides through the shallow copy untouched.
  */
 function isRecipientField(to: unknown): to is string | string[] {
   return typeof to === "string" || (Array.isArray(to) && to.every((x) => typeof x === "string"));
@@ -72,9 +73,18 @@ function isRecipientField(to: unknown): to is string | string[] {
 
 /**
  * Email recipient redirect: rewrite `to` (single or array) to the single
- * staging sink address, preserving subject, body, from, headers, and any
- * other field. A multi-recipient array collapses to the one sink address —
- * staging never needs to fan out, and one sink keeps the soak inbox simple.
+ * staging sink address, preserving every non-recipient field — `subject`,
+ * the body, `from`, headers, and anything else — via the shallow copy. A
+ * multi-recipient array collapses to the one sink address: staging never
+ * needs to fan out, and one sink keeps the soak inbox simple.
+ *
+ * SCOPE — `to` is the ONLY recipient field redirected, because the current
+ * `EmailMessage` (`lib/email/delivery.ts`: `{ to, subject, html }`) has no
+ * other recipient field. If the email layer ever grows `cc` / `bcc` /
+ * `replyTo`, they are recipient fields too and MUST be redirected here as
+ * well — otherwise a staging soak would deliver to those real addresses
+ * while `to` looks correctly clamped (tracked as a follow-up). The
+ * non-recipient fields above are intentionally preserved, not leaked.
  */
 const EMAIL_CLAMP: OutboundClamp = {
   name: "email",
@@ -100,7 +110,11 @@ const OUTBOUND_CLAMPS: readonly OutboundClamp[] = [EMAIL_CLAMP];
  *   primitive or `null`) passes through unchanged.
  *
  * @param region   the deploy region — ALWAYS an explicit argument, never read
- *                 from the environment here (callers pass `getApiRegion()`).
+ *                 from the environment here. The wiring slice derives it from
+ *                 `getApiRegion()` (which returns `string | null`), NARROWED
+ *                 to a `DeployRegion` first — a raw unrecognized string takes
+ *                 the prod identity path (fail-open), so the caller must pin
+ *                 the narrowing rather than pass the raw env read.
  * @param sendable the outbound payload (email message, future: Stripe/Slack).
  * @returns the same `sendable` outside staging; a staging-safe copy inside.
  */

--- a/packages/api/src/lib/staging/clamp.ts
+++ b/packages/api/src/lib/staging/clamp.ts
@@ -1,0 +1,123 @@
+/**
+ * StagingClamp — the single outbound-rewrite chokepoint for the `staging`
+ * deploy region (staging slice 4, #2910).
+ *
+ * The staging instance (`*.staging.useatlas.dev`) runs the full SaaS code
+ * path against real external providers (Resend, Stripe, Slack, …). Without a
+ * clamp, a staging soak would email real-looking customer addresses,
+ * burning Resend sender reputation, and could mirror state into real
+ * provider accounts. {@link clampOutbound} rewrites outbound payloads so a
+ * staging soak is inert from the recipient's point of view while still
+ * exercising the real delivery code.
+ *
+ * Design — a deep module behind a one-line interface:
+ *
+ *   clampOutbound(region, sendable) -> sendable
+ *
+ * Callers never branch on region themselves; they pass every outbound
+ * payload through this one function. Today the only registered transform is
+ * the email recipient redirect. Future transforms (Stripe customer-creation
+ * mirroring, Slack webhook destination overrides — out of scope for #2910)
+ * slot in as additional entries in {@link OUTBOUND_CLAMPS} without changing
+ * this signature, so no caller breaks when the body grows.
+ *
+ * Purity: this function performs NO database reads, NO I/O, and reads NO env
+ * vars beyond the single documented `STAGING_MAIL_SINK` (the email sink
+ * address). `region` is always an explicit argument — never read from the
+ * environment here — so the function is fully deterministic given its inputs
+ * plus that one documented var.
+ */
+
+import type { DeployRegion } from "@useatlas/types";
+
+/**
+ * Default email sink when `STAGING_MAIL_SINK` is unset (PRD
+ * docs/prd/staging-environment.md, Credentials hard wall).
+ */
+const DEFAULT_MAIL_SINK = "staging-mail@useatlas.dev";
+
+/**
+ * Resolve the staging email sink. Reads the one documented env var, falling
+ * back to the default. An empty/unset value uses the default (`||`, not
+ * `??`, so an explicitly-empty var doesn't blank the recipient).
+ */
+function resolveMailSink(): string {
+  return process.env.STAGING_MAIL_SINK || DEFAULT_MAIL_SINK;
+}
+
+/**
+ * A registered outbound transform. `appliesTo` owns payload classification;
+ * `rewrite` returns a NEW object (never mutates its input) with the
+ * staging-safe substitution applied. The generic `rewrite` preserves the
+ * caller's payload type so {@link clampOutbound} stays `(T) => T`.
+ */
+interface OutboundClamp {
+  readonly name: string;
+  appliesTo(sendable: object): boolean;
+  rewrite<T extends object>(sendable: T): T;
+}
+
+/**
+ * Is `to` a recipient field — a string or an array of strings?
+ *
+ * This structural check (rather than importing `EmailMessage` from
+ * `lib/email/delivery.ts`) keeps the clamp dependency-free of the email
+ * subsystem and tolerant of richer payloads — multi-recipient `to`, plus
+ * `from` / custom headers the delivery layer may grow. Only the recipient
+ * field is inspected; every other field rides through the shallow copy.
+ */
+function isRecipientField(to: unknown): to is string | string[] {
+  return typeof to === "string" || (Array.isArray(to) && to.every((x) => typeof x === "string"));
+}
+
+/**
+ * Email recipient redirect: rewrite `to` (single or array) to the single
+ * staging sink address, preserving subject, body, from, headers, and any
+ * other field. A multi-recipient array collapses to the one sink address —
+ * staging never needs to fan out, and one sink keeps the soak inbox simple.
+ */
+const EMAIL_CLAMP: OutboundClamp = {
+  name: "email",
+  appliesTo: (sendable) => isRecipientField((sendable as { to?: unknown }).to),
+  rewrite: (sendable) => ({ ...sendable, to: resolveMailSink() }),
+};
+
+/**
+ * The registered transforms, tried in order. Append new entries here to
+ * cover additional outbound payload kinds; {@link clampOutbound}'s signature
+ * does not change.
+ */
+const OUTBOUND_CLAMPS: readonly OutboundClamp[] = [EMAIL_CLAMP];
+
+/**
+ * Clamp an outbound payload for the given deploy region.
+ *
+ * - For every prod region (`us` / `eu` / `apac`) this is the identity
+ *   transform: the exact same reference is returned, no allocation.
+ * - For `staging`, the first registered transform whose `appliesTo` matches
+ *   rewrites the payload. An email payload has its recipient(s) redirected to
+ *   the staging sink. A payload no transform claims (or a non-object, e.g. a
+ *   primitive or `null`) passes through unchanged.
+ *
+ * @param region   the deploy region — ALWAYS an explicit argument, never read
+ *                 from the environment here (callers pass `getApiRegion()`).
+ * @param sendable the outbound payload (email message, future: Stripe/Slack).
+ * @returns the same `sendable` outside staging; a staging-safe copy inside.
+ */
+export function clampOutbound<T>(region: DeployRegion, sendable: T): T {
+  // Identity outside staging — no prod region rewrites outbound payloads.
+  if (region !== "staging") return sendable;
+
+  // Only objects can be classified/rewritten; primitives and null pass
+  // through (every clampable payload is an object).
+  if (typeof sendable !== "object" || sendable === null) return sendable;
+
+  for (const clamp of OUTBOUND_CLAMPS) {
+    if (clamp.appliesTo(sendable)) {
+      return clamp.rewrite(sendable);
+    }
+  }
+
+  // No transform claimed this payload kind yet — pass through untouched.
+  return sendable;
+}


### PR DESCRIPTION
## Summary

Staging slice 4/22 (#2910): the **StagingClamp** deep module — the single outbound-rewrite chokepoint for the `staging` deploy region.

- `clampOutbound<T>(region: DeployRegion, sendable: T): T` in `packages/api/src/lib/staging/clamp.ts`
- **Identity** for every prod region (`us` / `eu` / `apac`) — returns the exact same reference, no allocation
- On **`staging`**: redirects email recipients to the `STAGING_MAIL_SINK` env var (default `staging-mail@useatlas.dev`), preserving `subject` / `body` / `from` / headers. Array recipients collapse to the single sink; an empty `to` is rewritten (not crashed past); non-email and primitive payloads pass through untouched
- **Pure**: no DB reads, no I/O, and the only env read is the documented sink var; `region` is always an explicit argument
- Internal transform registry (`OUTBOUND_CLAMPS`) leaves room for future kinds (Stripe customer mirroring, Slack webhook overrides — out of scope today) without changing the `(T) => T` caller signature
- `DeployRegion` imported from `@useatlas/types` (shipped in #2897), not redefined

## Test plan

- [x] All 7 PRD "Testing Decisions" cases pass in `packages/api/src/lib/staging/__tests__/clamp.test.ts` (us/eu/apac identity; staging rewrite; field preservation; empty-`to`; array-`to`), plus env-override and future-seam passthrough — 10 tests, 22 assertions
- [x] Tests are self-contained — the one documented env var is saved/restored around each test (no module-scope mutation)
- [x] `/ci` green: lint, type, full test suite, syncpack, template/security/railway/schema/oauth drift, test-discipline, twenty-resolver, published-symbols

Closes #2910

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/2981"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782668551&installation_id=135337507&pr_number=2981&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F2981&signature=71f91d4a8d04602bca9d32c65816d9b828416ee5d50fa5e39c0e4207149b8804"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->