### PR TITLE
feat(observability): per-tick spans on the 8 periodic cleanup fibers (#2945)

### DIFF
--- a/packages/api/src/lib/effect/__tests__/layers.test.ts
+++ b/packages/api/src/lib/effect/__tests__/layers.test.ts
@@ -21,6 +21,7 @@ import {
   ImplementationStatusOverrideLive,
   CatalogSeed,
   BuiltinDatasourceCatalogSeed,
+  SCHEDULER_CLEANUP_SPAN_NAMES,
   type ConfigShape,
   type MigrationShape,
   type SettingsShape,
@@ -311,6 +312,50 @@ describe("makeSchedulerLive", () => {
 
     // Disposing should not throw
     await rt.dispose();
+  });
+
+  // ── Per-tick observability spans on the cleanup fibers (#2945) ──────
+  // The 8 periodic cleanup fibers are forked internally and not exposed
+  // through the `Scheduler` Tag, so the span wrapping can't be asserted by
+  // introspecting OTel. Instead the production wrap sites read their span
+  // name from `SCHEDULER_CLEANUP_SPAN_NAMES`, and these tests pin that
+  // record so dropping or renaming a span — which would re-hide a wedged
+  // fiber in traces — fails here rather than silently regressing.
+  describe("cleanup-fiber observability spans (#2945)", () => {
+    const EXPECTED_SPAN_NAMES = {
+      oauth_state_cleanup: "atlas.scheduler.oauth_state_cleanup",
+      rate_limit_cleanup: "atlas.scheduler.rate_limit_cleanup",
+      demo_rate_limit_cleanup: "atlas.scheduler.demo_rate_limit_cleanup",
+      contact_rate_limit_cleanup: "atlas.scheduler.contact_rate_limit_cleanup",
+      abuse_cleanup: "atlas.scheduler.abuse_cleanup",
+      dashboard_rate_limit_cleanup: "atlas.scheduler.dashboard_rate_limit_cleanup",
+      conversation_rate_sweep: "atlas.scheduler.conversation_rate_sweep",
+      share_token_cleanup: "atlas.scheduler.share_token_cleanup",
+    } as const;
+
+    test("covers exactly the 8 named cleanup fibers", () => {
+      expect(Object.keys(SCHEDULER_CLEANUP_SPAN_NAMES).toSorted()).toEqual(
+        Object.keys(EXPECTED_SPAN_NAMES).toSorted(),
+      );
+    });
+
+    test("maps each fiber to its dotted atlas.scheduler.<op> span name", () => {
+      expect(SCHEDULER_CLEANUP_SPAN_NAMES).toEqual(EXPECTED_SPAN_NAMES);
+    });
+
+    test("every span name keeps the atlas.scheduler. prefix (no bare snake_case label)", () => {
+      const entries: ReadonlyArray<[string, string]> = Object.entries(
+        SCHEDULER_CLEANUP_SPAN_NAMES,
+      );
+      for (const [fiber, span] of entries) {
+        // Convention guard from the #2945 LOW finding: the dotted prefix
+        // must survive; the op segment intentionally mirrors the fiber's
+        // `withFiberDeathLog` label (underscores within the op are fine).
+        expect(span).toBe(`atlas.scheduler.${fiber}`);
+        expect(span.startsWith("atlas.scheduler.")).toBe(true);
+        expect(span).not.toBe(fiber);
+      }
+    });
   });
 });
 

--- a/packages/api/src/lib/effect/__tests__/layers.test.ts
+++ b/packages/api/src/lib/effect/__tests__/layers.test.ts
@@ -1,4 +1,6 @@
 import { describe, test, expect } from "bun:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { Effect, Layer, Exit, ManagedRuntime } from "effect";
 import {
   Telemetry,
@@ -317,33 +319,38 @@ describe("makeSchedulerLive", () => {
   // ── Per-tick observability spans on the cleanup fibers (#2945) ──────
   // The 8 periodic cleanup fibers are forked internally and not exposed
   // through the `Scheduler` Tag, so the span wrapping can't be asserted by
-  // introspecting OTel. Instead the production wrap sites read their span
-  // name from `SCHEDULER_CLEANUP_SPAN_NAMES`, and these tests pin that
-  // record so dropping or renaming a span — which would re-hide a wedged
-  // fiber in traces — fails here rather than silently regressing.
+  // introspecting OTel without standing up an in-memory trace exporter
+  // (would add `@opentelemetry/sdk-trace-base` to @atlas/api devDeps — out
+  // of scope). Instead:
+  //   (a) the production wrap sites derive their span name from the
+  //       `SCHEDULER_CLEANUP_SPAN_NAMES` record, and the derivation/prefix
+  //       guard below pins that record's shape; and
+  //   (b) a structural source-scan guard asserts each of the 8 keys is
+  //       actually referenced by a `withEffectSpan(SCHEDULER_CLEANUP_SPAN_NAMES.<key>`
+  //       call site, and that there are exactly 8 such call sites.
+  // Together these make "rename a span" AND "delete a wrap at a call site"
+  // (the precise regression #2945 exists to prevent) both fail here.
   describe("cleanup-fiber observability spans (#2945)", () => {
-    const EXPECTED_SPAN_NAMES = {
-      oauth_state_cleanup: "atlas.scheduler.oauth_state_cleanup",
-      rate_limit_cleanup: "atlas.scheduler.rate_limit_cleanup",
-      demo_rate_limit_cleanup: "atlas.scheduler.demo_rate_limit_cleanup",
-      contact_rate_limit_cleanup: "atlas.scheduler.contact_rate_limit_cleanup",
-      abuse_cleanup: "atlas.scheduler.abuse_cleanup",
-      dashboard_rate_limit_cleanup: "atlas.scheduler.dashboard_rate_limit_cleanup",
-      conversation_rate_sweep: "atlas.scheduler.conversation_rate_sweep",
-      share_token_cleanup: "atlas.scheduler.share_token_cleanup",
-    } as const;
+    // The 8 fiber keys are the real contract — these are the cleanup fibers
+    // named in #2945 that each must emit a per-tick span.
+    const EXPECTED_FIBER_KEYS = [
+      "oauth_state_cleanup",
+      "rate_limit_cleanup",
+      "demo_rate_limit_cleanup",
+      "contact_rate_limit_cleanup",
+      "abuse_cleanup",
+      "dashboard_rate_limit_cleanup",
+      "conversation_rate_sweep",
+      "share_token_cleanup",
+    ] as const;
 
     test("covers exactly the 8 named cleanup fibers", () => {
       expect(Object.keys(SCHEDULER_CLEANUP_SPAN_NAMES).toSorted()).toEqual(
-        Object.keys(EXPECTED_SPAN_NAMES).toSorted(),
+        [...EXPECTED_FIBER_KEYS].toSorted(),
       );
     });
 
-    test("maps each fiber to its dotted atlas.scheduler.<op> span name", () => {
-      expect(SCHEDULER_CLEANUP_SPAN_NAMES).toEqual(EXPECTED_SPAN_NAMES);
-    });
-
-    test("every span name keeps the atlas.scheduler. prefix (no bare snake_case label)", () => {
+    test("derives each span name as dotted atlas.scheduler.<fiber> (no bare snake_case label)", () => {
       const entries: ReadonlyArray<[string, string]> = Object.entries(
         SCHEDULER_CLEANUP_SPAN_NAMES,
       );
@@ -355,6 +362,45 @@ describe("makeSchedulerLive", () => {
         expect(span.startsWith("atlas.scheduler.")).toBe(true);
         expect(span).not.toBe(fiber);
       }
+    });
+
+    // Structural wiring guard: the name-set tests above prove the const is
+    // correct, but a wrap site can be deleted while every other test stays
+    // green — re-hiding the exact regression #2945 prevents. Scan the
+    // `layers.ts` source and assert each of the 8 keys is referenced by a
+    // `withEffectSpan(SCHEDULER_CLEANUP_SPAN_NAMES.<key>` call AND that there
+    // are exactly 8 such call sites, so deleting/adding a wrap fails here.
+    // (A full in-memory OTel exporter test was rejected as too heavy — see
+    // the block comment above; this source scan is the pragmatic guard.)
+    describe("wrap-site wiring guard", () => {
+      const layersSource = readFileSync(
+        fileURLToPath(new URL("../layers.ts", import.meta.url)),
+        "utf8",
+      );
+      // Matches `withEffectSpan(SCHEDULER_CLEANUP_SPAN_NAMES.<key>` tolerating
+      // arbitrary whitespace/newlines around the call paren and the dot.
+      const wrapCallRegex =
+        /withEffectSpan\s*\(\s*SCHEDULER_CLEANUP_SPAN_NAMES\s*\.\s*([A-Za-z_][A-Za-z0-9_]*)/g;
+
+      test("each of the 8 fibers has a withEffectSpan wrap site", () => {
+        for (const key of EXPECTED_FIBER_KEYS) {
+          const perKey = new RegExp(
+            `withEffectSpan\\s*\\(\\s*SCHEDULER_CLEANUP_SPAN_NAMES\\s*\\.\\s*${key}\\b`,
+          );
+          expect(layersSource).toMatch(perKey);
+        }
+      });
+
+      test("there are exactly 8 SCHEDULER_CLEANUP_SPAN_NAMES wrap sites", () => {
+        const matchedKeys = [...layersSource.matchAll(wrapCallRegex)].map(
+          (m) => m[1],
+        );
+        expect(matchedKeys).toHaveLength(8);
+        // Every matched call site references a known fiber key — guards
+        // against a typo'd `.foo` reference that wouldn't type-check anyway
+        // but keeps the scan honest if the const is widened later.
+        expect(matchedKeys.toSorted()).toEqual([...EXPECTED_FIBER_KEYS].toSorted());
+      });
     });
   });
 });

--- a/packages/api/src/lib/effect/layers.ts
+++ b/packages/api/src/lib/effect/layers.ts
@@ -121,9 +121,18 @@ function withFiberDeathLog<A, E, R>(
 // `withFiberDeathLog` (above) only fires when a defect kills the fiber.
 // A healthy tick emits nothing, so "wedged silently" and "ran fine,
 // nothing to do" are indistinguishable in traces, and a hung-but-not-
-// crashed fiber never trips the death log. Wrap each tick body in
-// `withEffectSpan` so every repeat iteration emits one span — a wedged
-// fiber then shows up as an absence of spans against its expected cadence.
+// crashed fiber never trips the death log. Wrap each of these 8 cleanup
+// tick bodies in `withEffectSpan` so every repeat iteration emits one
+// span — a wedged fiber then shows up as an absence of spans against its
+// expected cadence.
+//
+// Scope: only these 8 cleanup fibers. The other periodic fibers forked in
+// `makeSchedulerLive` are intentionally out of scope for this pass —
+// `sub_processor_publisher`, `settings_refresh`, `onboarding_email`, and
+// `expert_scheduler` still lack a per-tick span, while the CRM/email
+// outbox flushers already have their own heartbeat + stall-watchdog
+// liveness signal. Spanning the remaining periodic fibers is tracked in
+// #2987.
 //
 // Span names follow the existing `atlas.<area>.<op>` dotted convention
 // (cf. `atlas.sql.execute`, `atlas.scheduler.task.run`, and the
@@ -133,9 +142,10 @@ function withFiberDeathLog<A, E, R>(
 // `atlas.scheduler.` prefix, not about the underscores within the op.
 //
 // This record is the single source of truth for the span names: each
-// wrap site below reads from it, and `layers.test.ts` asserts the exact
-// set, so dropping or renaming a span is a test failure rather than a
-// silent regression.
+// wrap site below reads from it. `layers.test.ts` asserts both the exact
+// name set AND (via a structural source-scan guard) that all 8 wrap sites
+// are present, so renaming an entry OR deleting a `withEffectSpan(...)`
+// wrap at a call site is a test failure rather than a silent regression.
 export const SCHEDULER_CLEANUP_SPAN_NAMES = {
   oauth_state_cleanup: "atlas.scheduler.oauth_state_cleanup",
   rate_limit_cleanup: "atlas.scheduler.rate_limit_cleanup",

--- a/packages/api/src/lib/effect/layers.ts
+++ b/packages/api/src/lib/effect/layers.ts
@@ -35,6 +35,7 @@
 
 import { Context, Duration, Effect, Layer, Schedule } from "effect";
 import { createLogger } from "@atlas/api/lib/logger";
+import { withEffectSpan } from "@atlas/api/lib/tracing";
 import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
 import { InternalDB, makeInternalDBLive, hasInternalDB, internalQuery } from "@atlas/api/lib/db/internal";
 import { assertSaasPlatformEmailIsResend } from "@atlas/api/lib/email/dpa-guard";
@@ -115,6 +116,36 @@ function withFiberDeathLog<A, E, R>(
     Effect.asVoid,
   );
 }
+
+// ── Per-tick observability spans for periodic cleanup fibers (#2945) ──
+// `withFiberDeathLog` (above) only fires when a defect kills the fiber.
+// A healthy tick emits nothing, so "wedged silently" and "ran fine,
+// nothing to do" are indistinguishable in traces, and a hung-but-not-
+// crashed fiber never trips the death log. Wrap each tick body in
+// `withEffectSpan` so every repeat iteration emits one span — a wedged
+// fiber then shows up as an absence of spans against its expected cadence.
+//
+// Span names follow the existing `atlas.<area>.<op>` dotted convention
+// (cf. `atlas.sql.execute`, `atlas.scheduler.task.run`, and the
+// already-landed `atlas.scheduler.byot_catalog_refresh` from #2949).
+// The snake_case op segment matches the fiber's `withFiberDeathLog`
+// label; the LOW finding in #2945 is about NOT dropping the dotted
+// `atlas.scheduler.` prefix, not about the underscores within the op.
+//
+// This record is the single source of truth for the span names: each
+// wrap site below reads from it, and `layers.test.ts` asserts the exact
+// set, so dropping or renaming a span is a test failure rather than a
+// silent regression.
+export const SCHEDULER_CLEANUP_SPAN_NAMES = {
+  oauth_state_cleanup: "atlas.scheduler.oauth_state_cleanup",
+  rate_limit_cleanup: "atlas.scheduler.rate_limit_cleanup",
+  demo_rate_limit_cleanup: "atlas.scheduler.demo_rate_limit_cleanup",
+  contact_rate_limit_cleanup: "atlas.scheduler.contact_rate_limit_cleanup",
+  abuse_cleanup: "atlas.scheduler.abuse_cleanup",
+  dashboard_rate_limit_cleanup: "atlas.scheduler.dashboard_rate_limit_cleanup",
+  conversation_rate_sweep: "atlas.scheduler.conversation_rate_sweep",
+  share_token_cleanup: "atlas.scheduler.share_token_cleanup",
+} as const satisfies Record<string, `atlas.scheduler.${string}`>;
 
 // ══════════════════════════════════════════════════════════════════════
 // ██  Enterprise gate (#2563 slice 1/11 of #2017; #2564 slice 2/11)
@@ -1260,7 +1291,9 @@ export function makeSchedulerLive(
       yield* Effect.forkScoped(
         withFiberDeathLog(
           "oauth_state_cleanup",
-          oauthTick.pipe(Effect.repeat(Schedule.spaced(Duration.minutes(10)))),
+          withEffectSpan(SCHEDULER_CLEANUP_SPAN_NAMES.oauth_state_cleanup, {}, oauthTick).pipe(
+            Effect.repeat(Schedule.spaced(Duration.minutes(10))),
+          ),
         ),
       );
 
@@ -1289,7 +1322,9 @@ export function makeSchedulerLive(
       yield* Effect.forkScoped(
         withFiberDeathLog(
           "rate_limit_cleanup",
-          rateLimitTick.pipe(Effect.repeat(Schedule.spaced(Duration.seconds(60)))),
+          withEffectSpan(SCHEDULER_CLEANUP_SPAN_NAMES.rate_limit_cleanup, {}, rateLimitTick).pipe(
+            Effect.repeat(Schedule.spaced(Duration.seconds(60))),
+          ),
         ),
       );
 
@@ -1321,7 +1356,9 @@ export function makeSchedulerLive(
       yield* Effect.forkScoped(
         withFiberDeathLog(
           "demo_rate_limit_cleanup",
-          demoTick.pipe(Effect.repeat(Schedule.spaced(Duration.millis(DEMO_CLEANUP_INTERVAL_MS)))),
+          withEffectSpan(SCHEDULER_CLEANUP_SPAN_NAMES.demo_rate_limit_cleanup, {}, demoTick).pipe(
+            Effect.repeat(Schedule.spaced(Duration.millis(DEMO_CLEANUP_INTERVAL_MS))),
+          ),
         ),
       );
 
@@ -1352,7 +1389,9 @@ export function makeSchedulerLive(
       yield* Effect.forkScoped(
         withFiberDeathLog(
           "contact_rate_limit_cleanup",
-          contactTick.pipe(Effect.repeat(Schedule.spaced(Duration.seconds(60)))),
+          withEffectSpan(SCHEDULER_CLEANUP_SPAN_NAMES.contact_rate_limit_cleanup, {}, contactTick).pipe(
+            Effect.repeat(Schedule.spaced(Duration.seconds(60))),
+          ),
         ),
       );
 
@@ -1384,7 +1423,9 @@ export function makeSchedulerLive(
       yield* Effect.forkScoped(
         withFiberDeathLog(
           "abuse_cleanup",
-          abuseTick.pipe(Effect.repeat(Schedule.spaced(Duration.millis(ABUSE_CLEANUP_INTERVAL_MS)))),
+          withEffectSpan(SCHEDULER_CLEANUP_SPAN_NAMES.abuse_cleanup, {}, abuseTick).pipe(
+            Effect.repeat(Schedule.spaced(Duration.millis(ABUSE_CLEANUP_INTERVAL_MS))),
+          ),
         ),
       );
 
@@ -1422,7 +1463,9 @@ export function makeSchedulerLive(
       yield* Effect.forkScoped(
         withFiberDeathLog(
           "dashboard_rate_limit_cleanup",
-          dashboardTick.pipe(Effect.repeat(Schedule.spaced(Duration.millis(dashboardCleanupIntervalMs)))),
+          withEffectSpan(SCHEDULER_CLEANUP_SPAN_NAMES.dashboard_rate_limit_cleanup, {}, dashboardTick).pipe(
+            Effect.repeat(Schedule.spaced(Duration.millis(dashboardCleanupIntervalMs))),
+          ),
         ),
       );
 
@@ -1455,7 +1498,9 @@ export function makeSchedulerLive(
       yield* Effect.forkScoped(
         withFiberDeathLog(
           "conversation_rate_sweep",
-          convSweepTick.pipe(Effect.repeat(Schedule.spaced(Duration.millis(CONVERSATION_RATE_SWEEP_INTERVAL_MS)))),
+          withEffectSpan(SCHEDULER_CLEANUP_SPAN_NAMES.conversation_rate_sweep, {}, convSweepTick).pipe(
+            Effect.repeat(Schedule.spaced(Duration.millis(CONVERSATION_RATE_SWEEP_INTERVAL_MS))),
+          ),
         ),
       );
 
@@ -1483,7 +1528,9 @@ export function makeSchedulerLive(
       yield* Effect.forkScoped(
         withFiberDeathLog(
           "share_token_cleanup",
-          shareCleanupEffect.pipe(Effect.repeat(Schedule.spaced(Duration.millis(SHARE_CLEANUP_INTERVAL_MS)))),
+          withEffectSpan(SCHEDULER_CLEANUP_SPAN_NAMES.share_token_cleanup, {}, shareCleanupEffect).pipe(
+            Effect.repeat(Schedule.spaced(Duration.millis(SHARE_CLEANUP_INTERVAL_MS))),
+          ),
         ),
       );
 


### PR DESCRIPTION
## Summary

Closes the gap-#1 half of #2945 (Observability / prod-audit findings M-1/L-1): the 8 periodic cleanup fibers in `makeSchedulerLive` now emit a **per-tick OTel span**, so a wedged-but-not-crashed fiber is detectable in traces.

Before this change the 8 fibers were wrapped only in `withFiberDeathLog(...)` — a `catchAllCause` death logger. A healthy tick emitted nothing, so "ran 0 times because the fiber silently wedged" was indistinguishable from "ran fine, nothing to do", and a hung (non-crashing) fiber never fired the death log. This is the exact failure class the CRM-outbox stall watchdog was added to catch; the 8 cleanup fibers never got equivalent liveness signal. A per-tick span — what the issue's acceptance criteria call for — makes a wedged fiber show up as an *absence* of spans against its expected cadence.

## What changed

`packages/api/src/lib/effect/layers.ts`
- Imported `withEffectSpan` from `@atlas/api/lib/tracing` (was not previously imported).
- Added a `SCHEDULER_CLEANUP_SPAN_NAMES` record (single source of truth for the span names, `as const satisfies Record<string, \`atlas.scheduler.${string}\`>`).
- Wrapped the **per-tick** effect of each of the 8 fibers: `withEffectSpan(SCHEDULER_CLEANUP_SPAN_NAMES.<label>, {}, <tick>).pipe(Effect.repeat(Schedule.spaced(...)))`. The span is **inside** the repeat (one span per iteration), not around the whole repeat (which would be one infinite span).

The change is **additive**: `withFiberDeathLog("<label>", ...)` is preserved verbatim at every site (defect-death logging still fires — acceptance criterion). The new shape is `withFiberDeathLog("<label>", withEffectSpan(..., tick).pipe(Effect.repeat(...)))`.

### The 8 span names added (lines touched)
| Fiber label | Span name | wrap site |
|---|---|---|
| `oauth_state_cleanup` | `atlas.scheduler.oauth_state_cleanup` | layers.ts:1294 |
| `rate_limit_cleanup` | `atlas.scheduler.rate_limit_cleanup` | layers.ts:1325 |
| `demo_rate_limit_cleanup` | `atlas.scheduler.demo_rate_limit_cleanup` | layers.ts:1359 |
| `contact_rate_limit_cleanup` | `atlas.scheduler.contact_rate_limit_cleanup` | layers.ts:1392 |
| `abuse_cleanup` | `atlas.scheduler.abuse_cleanup` | layers.ts:1426 |
| `dashboard_rate_limit_cleanup` | `atlas.scheduler.dashboard_rate_limit_cleanup` | layers.ts:1466 |
| `conversation_rate_sweep` | `atlas.scheduler.conversation_rate_sweep` | layers.ts:1501 |
| `share_token_cleanup` | `atlas.scheduler.share_token_cleanup` | layers.ts:1531 |

### Naming-convention rationale (#2945 LOW finding)
Span names use the existing `atlas.<area>.<op>` dotted convention, matching the already-landed `atlas.scheduler.byot_catalog_refresh` precedent (and `atlas.sql.execute`, `atlas.scheduler.task.run`). The "no snake_case leakage" rule means: do **not** name the span the bare fiber label (`"rate_limit_cleanup"`) — keep the dotted `atlas.scheduler.` prefix. Underscores *within* the op segment are the existing convention and intentionally mirror each fiber's `withFiberDeathLog` label.

## Gap #2 already landed (not redone)
The issue's second gap — wrapping the BYOT catalog-refresh cycle in `withEffectSpan("atlas.scheduler.byot_catalog_refresh", ...)` — was already shipped by **#2949** (the v0.0.1 prod-audit pass). Confirmed present at `packages/api/src/lib/scheduler/byot-catalog-refresh.ts:425`, follows the naming convention. Left untouched.

## Tests
`packages/api/src/lib/effect/__tests__/layers.test.ts` — new `describe("cleanup-fiber observability spans (#2945)")` block. The 8 fibers are forked internally and not exposed through the `Scheduler` Tag, so the span wrapping can't be asserted by introspecting OTel (this is also why #2949's BYOT span has no direct span assertion). Instead the production wrap sites read their span name from the exported `SCHEDULER_CLEANUP_SPAN_NAMES` record and three tests pin that record:
- covers exactly the 8 named cleanup fibers,
- maps each fiber to its dotted `atlas.scheduler.<op>` span name,
- every span keeps the `atlas.scheduler.` prefix (no bare snake_case label).

Dropping or renaming a span — which would re-hide a wedged fiber in traces — fails here rather than silently regressing.

## Scope discipline
Only the 8 cleanup fibers named in the issue are touched. The adjacent `sub_processor_publisher` fiber and the settings-refresh / CRM+email outbox flushers (which already have heartbeat+watchdog) were intentionally left alone — see follow-up note below.

## Gates (all green, run from worktree root)
- `bun run lint` — clean
- `bun run type` — exit 0, 0 errors
- `cd packages/api && bun run scripts/test-isolated.ts --affected` — 27/27 files passed
- `bun run test` (full — required since layers.ts is central startup wiring) — `@atlas/api` 506/506, other workspaces 167/167, 0 failed

## Follow-up (not in this PR)
Spanning the remaining periodic fibers — `sub_processor_publisher`, `settings_refresh`, `onboarding_email`, `expert_scheduler` (the outbox flushers/watchdogs already have their own heartbeat + stall-watchdog liveness) — is tracked in **#2987**.

## Review fixes (PR review, applied in second commit)
The pr-review-toolkit (test-analyzer + comment-analyzer) found no blockers but converged on three cheap, high-value fixes, now applied:
1. **Structural wiring guard (test-analyzer Finding A, sev 6).** The original name-set tests pinned the const but a wrap site could be deleted while staying green — re-hiding the exact regression #2945 prevents. Added a source-scan guard that reads `layers.ts` and asserts each of the 8 keys has a `withEffectSpan(SCHEDULER_CLEANUP_SPAN_NAMES.<key>` call site AND that there are exactly 8 such sites. Verified by hand: temporarily deleting one wrap fails the guard (2 tests red), restoring it returns to green.
2. **Dropped the tautological test (Finding B, sev 4).** Removed the `toEqual(EXPECTED_SPAN_NAMES)` test and its verbatim hand-copy mirror; kept an explicit `EXPECTED_FIBER_KEYS` key-set assertion (the real contract) + the derivation/prefix guard.
3. **Comment tightening (comment-analyzer).** Clarified the `layers.ts` block reads "each of these 8 cleanup tick bodies", noted the other periodic fibers are out of scope and tracked in #2987, and updated the guard description to reflect that BOTH renaming an entry AND removing a wrap site are now test failures.

Re-ran gates after the fixes: `bun run lint` clean, `bun run type` 0 errors, `layers.test.ts` 37 pass / 0 fail, `--affected` 27/27.

Refs #2945

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/2986"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782670018&installation_id=135337507&pr_number=2986&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F2986&signature=70d93f1509395008f610f9b9b90e6c3ebb76b3ef45ac427b6519e9a61c4388b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
