### PR TITLE
feat(observability): orphan plugin-task drift signal + gated reconcile (#2944)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -311,6 +311,7 @@ ATLAS_ADMIN_EMAIL=admin@useatlas.dev
 # ATLAS_SCHEDULER_MAX_CONCURRENT=5            # Max concurrent scheduled task executions
 # ATLAS_SCHEDULER_TIMEOUT=60000               # Scheduled task timeout in ms (default: 60s)
 # ATLAS_SCHEDULER_TICK_INTERVAL=60            # Tick engine interval in seconds (default: 60)
+# ATLAS_ORPHAN_TASK_RECONCILE=false           # Auto-delete plugin scheduled_tasks orphaned by a failed uninstall (default: off — the orphan count is always observed via the atlas.scheduler.orphan_task_reconcile span + log.warn; only the destructive sweep is gated)
 
 # === Networking ===
 # ATLAS_PUBLIC_URL=https://api.example.com    # Public base URL for action approval URLs (derived from request headers when unset)

--- a/apps/docs/content/docs/plugins/authoring-guide.mdx
+++ b/apps/docs/content/docs/plugins/authoring-guide.mdx
@@ -578,7 +578,7 @@ When an admin removes a plugin from a workspace via `DELETE /api/v1/admin/market
 | State | Action on uninstall |
 |-------|--------------------|
 | `workspace_plugins` row | **Deleted.** The installation record itself is the canonical "is this plugin installed?" signal — its absence is the uninstall. |
-| `scheduled_tasks` rows tagged with the plugin's `catalog_id` | **Deleted** in a separate statement after the install row is removed, scoped to the workspace's `org_id`. **Cleanup is best-effort, not atomic** — if the cleanup statement fails, the uninstall still succeeds (HTTP 200) and the failure is recorded as an audit event with `status: "failure"` and `metadata.cleanupFailed: true`. Orphans stay in `scheduled_tasks` until purged manually. |
+| `scheduled_tasks` rows tagged with the plugin's `catalog_id` | **Deleted** in a separate statement after the install row is removed, scoped to the workspace's `org_id`. **Cleanup is best-effort, not atomic** — if the cleanup statement fails, the uninstall still succeeds (HTTP 200) and the failure is recorded as an audit event with `status: "failure"` and `metadata.cleanupFailed: true`. Any orphans left behind are caught by the recurring orphan-reconcile signal (see [Orphan-task drift signal](#orphan-task-drift-signal)) rather than going unnoticed. |
 | `scheduled_task_runs` for the deleted tasks | **Deleted** automatically via the `task_id` foreign-key cascade. |
 | In-process hook registrations (`beforeQuery`, `afterToolCall`, `onRequest`, …) | **Not detached.** Hooks live in the process-global registry and uninstall does not invoke `teardown()` (which runs only at server shutdown). They become inert for the uninstalled workspace because hook dispatch checks `workspace_plugins` for the installation, which is now gone. No DB rows to clean. |
 
@@ -588,7 +588,7 @@ When an admin removes a plugin from a workspace via `DELETE /api/v1/admin/market
 |-------|----------|-----|
 | `plugin_<pluginId>_*` tables declared via the `schema` property | **Yes** | Reinstalling the plugin should pick up where it left off — cached digest history, sync cursors, whatever your plugin persists. Operators who need a hard reset use the workspace purge path, not uninstall. |
 | Catalog row in `plugin_catalog` | **Yes** | The catalog is platform-scoped. Uninstall is a per-workspace operation; the catalog only goes away when an admin explicitly deletes it. |
-| Webhook subscriptions you registered with external platforms (Slack, GitHub, etc.) | **Yes — unless your `teardown()` removes them** | Atlas has no visibility into your plugin's external state. If your plugin subscribes a webhook with a third party, your `teardown()` is the only place to unsubscribe it. Otherwise the external service will keep delivering events to a workspace that no longer has the plugin installed. |
+| Webhook subscriptions you registered with external platforms (Slack, GitHub, etc.) | **Yes — your plugin must revoke them** | Atlas has no visibility into your plugin's external state and cannot revoke a third-party webhook for you. **Expectation:** revoke the subscription from the route or hook that owns it as part of the uninstall flow (see below) — `teardown()` runs only at server shutdown, not on a per-workspace uninstall, so it is not a substitute. An un-revoked webhook keeps delivering events to a workspace that no longer has the plugin installed. |
 | Encrypted credentials in `workspace_plugins.config` | **No — removed with the row** | The config blob lives on the `workspace_plugins` row and is deleted with it. There is no separate credential store to clean up. |
 
 ### Tagging scheduled tasks for cleanup
@@ -604,6 +604,15 @@ INSERT INTO scheduled_tasks (
 ```
 
 Untagged tasks (`plugin_id IS NULL`) are user-created and survive uninstall — Atlas only cleans up tasks that explicitly opt in to plugin ownership.
+
+### Orphan-task drift signal
+
+Because the `scheduled_tasks` cleanup is best-effort (and the older `WorkspaceInstaller` disconnect path never cleaned tasks at all), a failed uninstall can leave a task with its `plugin_id` set but no matching `workspace_plugins` row. A recurring scheduler fiber — `orphan_task_reconcile` — closes that gap for operators:
+
+- **Always measures.** Every tick it counts orphaned plugin tasks (rows where `plugin_id IS NOT NULL` and no live `workspace_plugins` row matches on `catalog_id` + `workspace_id`). The count rides the per-tick OpenTelemetry span `atlas.scheduler.orphan_task_reconcile` as the `atlas.orphan_tasks.count` attribute, and a structured `log.warn` fires whenever the count is above zero — so orphan accumulation is visible in traces and logs without a dedicated dashboard.
+- **Optionally sweeps.** When the operator sets `ATLAS_ORPHAN_TASK_RECONCILE=true`, the same fiber deletes the confirmed orphans using the exact `(plugin_id, org_id)` predicate the uninstall path uses. It defaults off (measure-only) so a transient read blip can't trigger a destructive sweep; a NULL-`org_id` plugin task is reported but never auto-deleted.
+
+This is an operator concern, not a plugin-author one — but it's why a missed cleanup no longer silently fires forever. You still get the cleanest result by tagging tasks correctly (above) and revoking external webhooks yourself (below).
 
 ### Implementing `teardown()`
 

--- a/packages/api/src/api/routes/admin-marketplace.ts
+++ b/packages/api/src/api/routes/admin-marketplace.ts
@@ -1018,9 +1018,13 @@ workspaceMarketplace.openapi(uninstallRoute, async (c) => {
       //   • Webhook subscriptions registered with external platforms (Slack,
       //     GitHub, Stripe, …) are invisible to Atlas — the plugin author's
       //     `teardown()` is the only place to unsubscribe, but that runs at
-      //     server shutdown, not on a per-workspace uninstall. Plugin
-      //     authors who need workspace-scoped external cleanup must wire it
-      //     into the route or hook that owns the resource.
+      //     server shutdown, not on a per-workspace uninstall. EXPECTATION:
+      //     a plugin that subscribes an external webhook MUST revoke it from
+      //     the route or hook that owns the resource (uninstall is a DB-row
+      //     removal, not a process event). Atlas cannot revoke it for you;
+      //     an un-revoked webhook keeps delivering events to a workspace that
+      //     no longer has the plugin installed. Documented in the uninstall
+      //     contract (apps/docs/.../authoring-guide.mdx#uninstall-contract).
       //
       // Failure mode: the two DELETEs are deliberately NOT atomic. If this
       // cleanup rejects after workspace_plugins has already committed, the
@@ -1034,8 +1038,12 @@ workspaceMarketplace.openapi(uninstallRoute, async (c) => {
       // We chose best-effort cleanup over a multi-statement transaction
       // because making the cleanup load-bearing would block uninstall on
       // internal-DB hiccups and surface partial-failure to admins as a 500.
-      // Audit + log is the operator surface; there is no /health dashboard
-      // signal for orphan-task accumulation today (potential follow-up).
+      // Audit + log is the per-request operator surface. Accumulation across
+      // requests is caught by the `orphan_task_reconcile` scheduler fiber
+      // (#2944, lib/scheduler/orphan-task-reconcile.ts): it counts orphaned
+      // plugin tasks every tick, rides the count on an OTel span, and warns
+      // when > 0 — and, when ATLAS_ORPHAN_TASK_RECONCILE=true, sweeps them
+      // using this same (plugin_id, org_id) predicate.
       let scheduledTasksDeleted: number;
       try {
         const taskRows = yield* queryEffect<{ id: string }>(

--- a/packages/api/src/lib/effect/__tests__/layers.test.ts
+++ b/packages/api/src/lib/effect/__tests__/layers.test.ts
@@ -316,8 +316,8 @@ describe("makeSchedulerLive", () => {
     await rt.dispose();
   });
 
-  // ── Per-tick observability spans on the cleanup fibers (#2945) ──────
-  // The 8 periodic cleanup fibers are forked internally and not exposed
+  // ── Per-tick observability spans on the cleanup fibers (#2945, #2944) ──
+  // The 9 periodic cleanup fibers are forked internally and not exposed
   // through the `Scheduler` Tag, so the span wrapping can't be asserted by
   // introspecting OTel without standing up an in-memory trace exporter
   // (would add `@opentelemetry/sdk-trace-base` to @atlas/api devDeps — out
@@ -325,14 +325,16 @@ describe("makeSchedulerLive", () => {
   //   (a) the production wrap sites derive their span name from the
   //       `SCHEDULER_CLEANUP_SPAN_NAMES` record, and the derivation/prefix
   //       guard below pins that record's shape; and
-  //   (b) a structural source-scan guard asserts each of the 8 keys is
+  //   (b) a structural source-scan guard asserts each of the 9 keys is
   //       actually referenced by a `withEffectSpan(SCHEDULER_CLEANUP_SPAN_NAMES.<key>`
-  //       call site, and that there are exactly 8 such call sites.
+  //       call site, and that there are exactly 9 such call sites.
   // Together these make "rename a span" AND "delete a wrap at a call site"
   // (the precise regression #2945 exists to prevent) both fail here.
-  describe("cleanup-fiber observability spans (#2945)", () => {
-    // The 8 fiber keys are the real contract — these are the cleanup fibers
-    // named in #2945 that each must emit a per-tick span.
+  describe("cleanup-fiber observability spans (#2945, #2944)", () => {
+    // The fiber keys are the real contract — each cleanup fiber must emit a
+    // per-tick span. Eight were retrofitted by #2945; `orphan_task_reconcile`
+    // (#2944) shipped with its span and is the only member that also attaches
+    // a result attribute (the orphan count).
     const EXPECTED_FIBER_KEYS = [
       "oauth_state_cleanup",
       "rate_limit_cleanup",
@@ -342,9 +344,10 @@ describe("makeSchedulerLive", () => {
       "dashboard_rate_limit_cleanup",
       "conversation_rate_sweep",
       "share_token_cleanup",
+      "orphan_task_reconcile",
     ] as const;
 
-    test("covers exactly the 8 named cleanup fibers", () => {
+    test("covers exactly the 9 named cleanup fibers", () => {
       expect(Object.keys(SCHEDULER_CLEANUP_SPAN_NAMES).toSorted()).toEqual(
         [...EXPECTED_FIBER_KEYS].toSorted(),
       );
@@ -367,9 +370,9 @@ describe("makeSchedulerLive", () => {
     // Structural wiring guard: the name-set tests above prove the const is
     // correct, but a wrap site can be deleted while every other test stays
     // green — re-hiding the exact regression #2945 prevents. Scan the
-    // `layers.ts` source and assert each of the 8 keys is referenced by a
+    // `layers.ts` source and assert each of the 9 keys is referenced by a
     // `withEffectSpan(SCHEDULER_CLEANUP_SPAN_NAMES.<key>` call AND that there
-    // are exactly 8 such call sites, so deleting/adding a wrap fails here.
+    // are exactly 9 such call sites, so deleting/adding a wrap fails here.
     // (A full in-memory OTel exporter test was rejected as too heavy — see
     // the block comment above; this source scan is the pragmatic guard.)
     describe("wrap-site wiring guard", () => {
@@ -382,7 +385,7 @@ describe("makeSchedulerLive", () => {
       const wrapCallRegex =
         /withEffectSpan\s*\(\s*SCHEDULER_CLEANUP_SPAN_NAMES\s*\.\s*([A-Za-z_][A-Za-z0-9_]*)/g;
 
-      test("each of the 8 fibers has a withEffectSpan wrap site", () => {
+      test("each of the 9 fibers has a withEffectSpan wrap site", () => {
         for (const key of EXPECTED_FIBER_KEYS) {
           const perKey = new RegExp(
             `withEffectSpan\\s*\\(\\s*SCHEDULER_CLEANUP_SPAN_NAMES\\s*\\.\\s*${key}\\b`,
@@ -391,11 +394,11 @@ describe("makeSchedulerLive", () => {
         }
       });
 
-      test("there are exactly 8 SCHEDULER_CLEANUP_SPAN_NAMES wrap sites", () => {
+      test("there are exactly 9 SCHEDULER_CLEANUP_SPAN_NAMES wrap sites", () => {
         const matchedKeys = [...layersSource.matchAll(wrapCallRegex)].map(
           (m) => m[1],
         );
-        expect(matchedKeys).toHaveLength(8);
+        expect(matchedKeys).toHaveLength(9);
         // Every matched call site references a known fiber key — guards
         // against a typo'd `.foo` reference that wouldn't type-check anyway
         // but keeps the scan honest if the const is widened later.

--- a/packages/api/src/lib/effect/layers.ts
+++ b/packages/api/src/lib/effect/layers.ts
@@ -121,13 +121,17 @@ function withFiberDeathLog<A, E, R>(
 // `withFiberDeathLog` (above) only fires when a defect kills the fiber.
 // A healthy tick emits nothing, so "wedged silently" and "ran fine,
 // nothing to do" are indistinguishable in traces, and a hung-but-not-
-// crashed fiber never trips the death log. Wrap each of these 8 cleanup
+// crashed fiber never trips the death log. Wrap each of these cleanup
 // tick bodies in `withEffectSpan` so every repeat iteration emits one
 // span — a wedged fiber then shows up as an absence of spans against its
 // expected cadence.
 //
-// Scope: only these 8 cleanup fibers. The other periodic fibers forked in
-// `makeSchedulerLive` are intentionally out of scope for this pass —
+// Membership: 9 cleanup fibers. Eight were retrofitted with a span by
+// #2945 (the TTL/ratelimit/state sweeps below); the ninth,
+// `orphan_task_reconcile` (#2944), shipped with its span from day one and
+// additionally attaches the orphan count as a result attribute (the only
+// member that uses `withEffectSpan`'s 4th arg). The other periodic fibers
+// forked in `makeSchedulerLive` remain out of scope —
 // `sub_processor_publisher`, `settings_refresh`, `onboarding_email`, and
 // `expert_scheduler` still lack a per-tick span, while the CRM/email
 // outbox flushers already have their own heartbeat + stall-watchdog
@@ -143,7 +147,7 @@ function withFiberDeathLog<A, E, R>(
 //
 // This record is the single source of truth for the span names: each
 // wrap site below reads from it. `layers.test.ts` asserts both the exact
-// name set AND (via a structural source-scan guard) that all 8 wrap sites
+// name set AND (via a structural source-scan guard) that all 9 wrap sites
 // are present, so renaming an entry OR deleting a `withEffectSpan(...)`
 // wrap at a call site is a test failure rather than a silent regression.
 export const SCHEDULER_CLEANUP_SPAN_NAMES = {
@@ -155,6 +159,7 @@ export const SCHEDULER_CLEANUP_SPAN_NAMES = {
   dashboard_rate_limit_cleanup: "atlas.scheduler.dashboard_rate_limit_cleanup",
   conversation_rate_sweep: "atlas.scheduler.conversation_rate_sweep",
   share_token_cleanup: "atlas.scheduler.share_token_cleanup",
+  orphan_task_reconcile: "atlas.scheduler.orphan_task_reconcile",
 } as const satisfies Record<string, `atlas.scheduler.${string}`>;
 
 // ══════════════════════════════════════════════════════════════════════
@@ -1632,6 +1637,65 @@ export function makeSchedulerLive(
           "share_token_cleanup",
           withEffectSpan(SCHEDULER_CLEANUP_SPAN_NAMES.share_token_cleanup, {}, shareCleanupEffect).pipe(
             Effect.repeat(Schedule.spaced(Duration.millis(SHARE_CLEANUP_INTERVAL_MS))),
+          ),
+        ),
+      );
+
+      // ── Periodic fiber: orphan plugin-task reconcile (#2944) — hourly ──
+      // Counts `scheduled_tasks` whose `plugin_id` has no live
+      // `workspace_plugins` row — the residue a non-atomic plugin uninstall
+      // leaves when the post-DELETE task cleanup fails. The count rides the
+      // per-tick span as a result attribute (the only cleanup fiber that
+      // attaches one), so an operator querying traces sees orphan
+      // accumulation; a `log.warn` fires on the same tick when > 0. The
+      // destructive sweep is gated behind `ATLAS_ORPHAN_TASK_RECONCILE`
+      // (default off — measure-only); the module no-ops when the internal DB
+      // is absent. catchAll keeps the loop alive on a DB blip and reports a
+      // zero result so the span still emits (liveness preserved).
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { ORPHAN_TASK_RECONCILE_INTERVAL_MS } = require("@atlas/api/lib/scheduler/orphan-task-reconcile") as {
+        ORPHAN_TASK_RECONCILE_INTERVAL_MS: number;
+      };
+      const orphanReconcileTick = Effect.tryPromise({
+        try: async () => {
+          const { runOrphanTaskReconcileTick } = await import(
+            "@atlas/api/lib/scheduler/orphan-task-reconcile"
+          );
+          return runOrphanTaskReconcileTick();
+        },
+        catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+      }).pipe(
+        Effect.catchAll((err) =>
+          Effect.sync(() => {
+            log.warn(
+              { err: errorMessage(err) },
+              "Orphan plugin-task reconcile tick failed",
+            );
+            return {
+              orphanedTasks: 0,
+              orphanedInstalls: 0,
+              reconcileEnabled: false,
+              deleted: 0,
+            };
+          }),
+        ),
+      );
+      // forkScoped, not fork — see SettingsLive for rationale.
+      yield* Effect.forkScoped(
+        withFiberDeathLog(
+          "orphan_task_reconcile",
+          withEffectSpan(
+            SCHEDULER_CLEANUP_SPAN_NAMES.orphan_task_reconcile,
+            {},
+            orphanReconcileTick,
+            (result) => ({
+              "atlas.orphan_tasks.count": result.orphanedTasks,
+              "atlas.orphan_tasks.installs": result.orphanedInstalls,
+              "atlas.orphan_tasks.reconcile_enabled": result.reconcileEnabled,
+              "atlas.orphan_tasks.deleted": result.deleted,
+            }),
+          ).pipe(
+            Effect.repeat(Schedule.spaced(Duration.millis(ORPHAN_TASK_RECONCILE_INTERVAL_MS))),
           ),
         ),
       );

--- a/packages/api/src/lib/effect/layers.ts
+++ b/packages/api/src/lib/effect/layers.ts
@@ -129,9 +129,11 @@ function withFiberDeathLog<A, E, R>(
 // Membership: 9 cleanup fibers. Eight were retrofitted with a span by
 // #2945 (the TTL/ratelimit/state sweeps below); the ninth,
 // `orphan_task_reconcile` (#2944), shipped with its span from day one and
-// additionally attaches the orphan count as a result attribute (the only
-// member that uses `withEffectSpan`'s 4th arg). The other periodic fibers
-// forked in `makeSchedulerLive` remain out of scope —
+// additionally attaches the orphan count as a result attribute (the only one
+// of these nine cleanup fibers that passes `setResultAttributes` — the BYOT
+// catalog-refresh fiber and the scheduler engine use that 4th arg elsewhere).
+// The other periodic fibers forked in `makeSchedulerLive` remain out of
+// scope —
 // `sub_processor_publisher`, `settings_refresh`, `onboarding_email`, and
 // `expert_scheduler` still lack a per-tick span, while the CRM/email
 // outbox flushers already have their own heartbeat + stall-watchdog
@@ -1645,38 +1647,50 @@ export function makeSchedulerLive(
       // Counts `scheduled_tasks` whose `plugin_id` has no live
       // `workspace_plugins` row — the residue a non-atomic plugin uninstall
       // leaves when the post-DELETE task cleanup fails. The count rides the
-      // per-tick span as a result attribute (the only cleanup fiber that
-      // attaches one), so an operator querying traces sees orphan
+      // per-tick span as a result attribute (the only one of these cleanup
+      // fibers that attaches one), so an operator querying traces sees orphan
       // accumulation; a `log.warn` fires on the same tick when > 0. The
       // destructive sweep is gated behind `ATLAS_ORPHAN_TASK_RECONCILE`
       // (default off — measure-only); the module no-ops when the internal DB
-      // is absent. catchAll keeps the loop alive on a DB blip and reports a
-      // zero result so the span still emits (liveness preserved).
+      // is absent.
+      //
+      // Error ordering matters: `withEffectSpan` wraps the RAW tick, so a
+      // failed tick records span status ERROR + the exception (rather than a
+      // misleading status-OK span carrying a fabricated `count=0`). The
+      // loop-liveness `catchAll` is applied OUTSIDE the span — it logs the
+      // failure and lets the hourly fiber survive a DB blip without painting
+      // the failed tick green or asserting a false-healthy zero into traces.
       // eslint-disable-next-line @typescript-eslint/no-require-imports
       const { ORPHAN_TASK_RECONCILE_INTERVAL_MS } = require("@atlas/api/lib/scheduler/orphan-task-reconcile") as {
         ORPHAN_TASK_RECONCILE_INTERVAL_MS: number;
       };
-      const orphanReconcileTick = Effect.tryPromise({
-        try: async () => {
-          const { runOrphanTaskReconcileTick } = await import(
-            "@atlas/api/lib/scheduler/orphan-task-reconcile"
-          );
-          return runOrphanTaskReconcileTick();
-        },
-        catch: (err) => (err instanceof Error ? err : new Error(String(err))),
-      }).pipe(
+      const orphanReconcileTick = withEffectSpan(
+        SCHEDULER_CLEANUP_SPAN_NAMES.orphan_task_reconcile,
+        {},
+        Effect.tryPromise({
+          try: async () => {
+            const { runOrphanTaskReconcileTick } = await import(
+              "@atlas/api/lib/scheduler/orphan-task-reconcile"
+            );
+            return runOrphanTaskReconcileTick();
+          },
+          catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+        }),
+        (result) => ({
+          "atlas.orphan_tasks.count": result.orphanedTasks,
+          "atlas.orphan_tasks.installs": result.orphanedInstalls,
+          "atlas.orphan_tasks.reconcile_enabled": result.reconcileEnabled,
+          "atlas.orphan_tasks.deleted": result.deleted,
+        }),
+      ).pipe(
+        // Recover AFTER the span has recorded any error, so the trace shows
+        // ERROR (not OK-with-zero) while the loop stays alive.
         Effect.catchAll((err) =>
           Effect.sync(() => {
             log.warn(
               { err: errorMessage(err) },
               "Orphan plugin-task reconcile tick failed",
             );
-            return {
-              orphanedTasks: 0,
-              orphanedInstalls: 0,
-              reconcileEnabled: false,
-              deleted: 0,
-            };
           }),
         ),
       );
@@ -1684,17 +1698,7 @@ export function makeSchedulerLive(
       yield* Effect.forkScoped(
         withFiberDeathLog(
           "orphan_task_reconcile",
-          withEffectSpan(
-            SCHEDULER_CLEANUP_SPAN_NAMES.orphan_task_reconcile,
-            {},
-            orphanReconcileTick,
-            (result) => ({
-              "atlas.orphan_tasks.count": result.orphanedTasks,
-              "atlas.orphan_tasks.installs": result.orphanedInstalls,
-              "atlas.orphan_tasks.reconcile_enabled": result.reconcileEnabled,
-              "atlas.orphan_tasks.deleted": result.deleted,
-            }),
-          ).pipe(
+          orphanReconcileTick.pipe(
             Effect.repeat(Schedule.spaced(Duration.millis(ORPHAN_TASK_RECONCILE_INTERVAL_MS))),
           ),
         ),

--- a/packages/api/src/lib/scheduler/__tests__/orphan-task-reconcile.test.ts
+++ b/packages/api/src/lib/scheduler/__tests__/orphan-task-reconcile.test.ts
@@ -1,0 +1,336 @@
+/**
+ * Orphan plugin-task reconcile (#2944).
+ *
+ * Two layers of coverage:
+ *
+ *   1. Unit tests with injected fakes (`reconcileOrphanTasks`) — exercise the
+ *      orchestration (no-op gate, count, gated delete, drift signal) without a
+ *      live DB. The headline case simulates the issue's acceptance scenario:
+ *      "workspace_plugins DELETE commits but scheduled_tasks cleanup fails" →
+ *      an orphan remains → the signal fires (count > 0 + log.warn).
+ *
+ *   2. A real-Postgres integration test (`describeIfPg`, skipped unless
+ *      `TEST_DATABASE_URL` is set — it runs in the api-tests PG service
+ *      container) — exercises the actual orphan-detection JOIN + NULL-org
+ *      semantics against real Postgres, the part a mock query can't verify.
+ */
+
+import { describe, test, expect, beforeAll, afterAll, mock } from "bun:test";
+import { Pool } from "pg";
+import {
+  countOrphanedPluginTasks,
+  deleteOrphanedPluginTasks,
+  isOrphanTaskReconcileEnabled,
+  reconcileOrphanTasks,
+  type OrphanReconcileQuery,
+  type OrphanReconcileDeps,
+  type ReconcileLogger,
+} from "@atlas/api/lib/scheduler/orphan-task-reconcile";
+
+// ---------------------------------------------------------------------------
+// Test doubles
+// ---------------------------------------------------------------------------
+
+/** A recording fake query routed by SQL substring. */
+function fakeQuery(
+  handler: (sql: string, params: unknown[] | undefined) => unknown[],
+): { query: OrphanReconcileQuery; calls: Array<{ sql: string; params: unknown[] | undefined }> } {
+  const calls: Array<{ sql: string; params: unknown[] | undefined }> = [];
+  const query = (async (sql: string, params?: unknown[]) => {
+    calls.push({ sql, params });
+    return handler(sql, params);
+  }) as OrphanReconcileQuery;
+  return { query, calls };
+}
+
+function recordingLogger(): {
+  log: ReconcileLogger;
+  warn: ReturnType<typeof mock>;
+  debug: ReturnType<typeof mock>;
+} {
+  const warn = mock((_obj: Record<string, unknown>, _msg: string) => {});
+  const debug = mock((_obj: Record<string, unknown>, _msg: string) => {});
+  return { log: { warn, debug }, warn, debug };
+}
+
+const isCountSql = (sql: string) => /COUNT\(\*\)/.test(sql);
+const isDeleteSql = (sql: string) => /DELETE\s+FROM\s+scheduled_tasks/.test(sql);
+
+function deps(
+  partial: Partial<OrphanReconcileDeps> & Pick<OrphanReconcileDeps, "query" | "log">,
+): OrphanReconcileDeps {
+  return {
+    hasInternalDB: () => true,
+    reconcileEnabled: () => false,
+    ...partial,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// countOrphanedPluginTasks — SQL shape + parsing
+// ---------------------------------------------------------------------------
+
+describe("countOrphanedPluginTasks", () => {
+  test("runs a single read-only SELECT with the orphan predicate and returns parsed counts", async () => {
+    const { query, calls } = fakeQuery((sql) => {
+      expect(isCountSql(sql)).toBe(true);
+      // Predicate: plugin-owned tasks with no matching live install.
+      expect(sql).toContain("st.plugin_id IS NOT NULL");
+      expect(sql).toContain("NOT EXISTS");
+      expect(sql).toContain("wp.catalog_id = st.plugin_id");
+      expect(sql).toContain("wp.workspace_id = st.org_id");
+      // Read-only: never mutates.
+      expect(sql).not.toMatch(/\b(DELETE|UPDATE|INSERT)\b/);
+      return [{ orphaned_tasks: 3, orphaned_installs: 2 }];
+    });
+
+    const report = await countOrphanedPluginTasks(query);
+
+    expect(report).toEqual({ orphanedTasks: 3, orphanedInstalls: 2 });
+    expect(calls).toHaveLength(1);
+  });
+
+  test("defaults missing/empty result rows to zero", async () => {
+    const { query } = fakeQuery(() => []);
+    expect(await countOrphanedPluginTasks(query)).toEqual({
+      orphanedTasks: 0,
+      orphanedInstalls: 0,
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// deleteOrphanedPluginTasks — sweep predicate + NULL-org guard
+// ---------------------------------------------------------------------------
+
+describe("deleteOrphanedPluginTasks", () => {
+  test("deletes via the same predicate plus an org_id NOT NULL guard, returns row count", async () => {
+    const { query, calls } = fakeQuery((sql) => {
+      expect(isDeleteSql(sql)).toBe(true);
+      // The sweep must NOT touch NULL-org rows — the uninstall predicate
+      // can't target them either.
+      expect(sql).toContain("st.org_id IS NOT NULL");
+      expect(sql).toContain("st.plugin_id IS NOT NULL");
+      expect(sql).toContain("NOT EXISTS");
+      expect(sql).toContain("RETURNING id");
+      return [{ id: "t1" }, { id: "t2" }];
+    });
+
+    expect(await deleteOrphanedPluginTasks(query)).toBe(2);
+    expect(calls).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isOrphanTaskReconcileEnabled — env flag
+// ---------------------------------------------------------------------------
+
+describe("isOrphanTaskReconcileEnabled", () => {
+  test("only true for the exact string 'true' (default off)", () => {
+    const prev = process.env.ATLAS_ORPHAN_TASK_RECONCILE;
+    try {
+      delete process.env.ATLAS_ORPHAN_TASK_RECONCILE;
+      expect(isOrphanTaskReconcileEnabled()).toBe(false);
+      process.env.ATLAS_ORPHAN_TASK_RECONCILE = "1";
+      expect(isOrphanTaskReconcileEnabled()).toBe(false);
+      process.env.ATLAS_ORPHAN_TASK_RECONCILE = "TRUE";
+      expect(isOrphanTaskReconcileEnabled()).toBe(false);
+      process.env.ATLAS_ORPHAN_TASK_RECONCILE = "true";
+      expect(isOrphanTaskReconcileEnabled()).toBe(true);
+    } finally {
+      if (prev === undefined) delete process.env.ATLAS_ORPHAN_TASK_RECONCILE;
+      else process.env.ATLAS_ORPHAN_TASK_RECONCILE = prev;
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// reconcileOrphanTasks — orchestration + the #2944 acceptance scenario
+// ---------------------------------------------------------------------------
+
+describe("reconcileOrphanTasks", () => {
+  test("no-ops to a zero report when the internal DB is unconfigured (never queries)", async () => {
+    const { query, calls } = fakeQuery(() => {
+      throw new Error("must not query when internal DB is absent");
+    });
+    const { log, warn, debug } = recordingLogger();
+
+    const result = await reconcileOrphanTasks(
+      deps({ hasInternalDB: () => false, query, log }),
+    );
+
+    expect(result).toEqual({
+      orphanedTasks: 0,
+      orphanedInstalls: 0,
+      reconcileEnabled: false,
+      deleted: 0,
+    });
+    expect(calls).toHaveLength(0);
+    expect(warn).not.toHaveBeenCalled();
+    expect(debug).not.toHaveBeenCalled();
+  });
+
+  test("ACCEPTANCE: partial-failure uninstall leaves an orphan → signal fires (measure-only)", async () => {
+    // Simulates "workspace_plugins DELETE committed but scheduled_tasks
+    // cleanup failed": the install row is gone, so the plugin's task is now
+    // an orphan and the count query surfaces it.
+    const { query, calls } = fakeQuery((sql) => {
+      if (isCountSql(sql)) return [{ orphaned_tasks: 1, orphaned_installs: 1 }];
+      throw new Error(`unexpected query: ${sql}`);
+    });
+    const { log, warn, debug } = recordingLogger();
+
+    const result = await reconcileOrphanTasks(
+      deps({ query, reconcileEnabled: () => false, log }),
+    );
+
+    // The signal: the count rides the result (→ span attribute) ...
+    expect(result.orphanedTasks).toBe(1);
+    expect(result.orphanedInstalls).toBe(1);
+    // ... measure-only, so nothing is deleted and no DELETE is issued ...
+    expect(result.reconcileEnabled).toBe(false);
+    expect(result.deleted).toBe(0);
+    expect(calls.some((c) => isDeleteSql(c.sql))).toBe(false);
+    // ... and the structured drift log fires (the stdout-scraper signal).
+    expect(warn).toHaveBeenCalledTimes(1);
+    const [obj, msg] = warn.mock.calls[0]!;
+    expect(obj).toMatchObject({
+      orphanedTasks: 1,
+      reconcileEnabled: false,
+      deleted: 0,
+      event: "plugin_task.orphan_detected",
+    });
+    expect(msg).toContain("clean manually");
+    expect(debug).not.toHaveBeenCalled();
+  });
+
+  test("sweeps the orphan when ATLAS_ORPHAN_TASK_RECONCILE is on", async () => {
+    let deleteCalled = false;
+    const { query } = fakeQuery((sql) => {
+      if (isCountSql(sql)) return [{ orphaned_tasks: 2, orphaned_installs: 1 }];
+      if (isDeleteSql(sql)) {
+        deleteCalled = true;
+        return [{ id: "a" }, { id: "b" }];
+      }
+      throw new Error(`unexpected query: ${sql}`);
+    });
+    const { log, warn } = recordingLogger();
+
+    const result = await reconcileOrphanTasks(
+      deps({ query, reconcileEnabled: () => true, log }),
+    );
+
+    expect(deleteCalled).toBe(true);
+    expect(result.deleted).toBe(2);
+    expect(result.reconcileEnabled).toBe(true);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0]![1]).toContain("reconciled");
+  });
+
+  test("does not issue a DELETE when enabled but there are no orphans", async () => {
+    const { query, calls } = fakeQuery((sql) => {
+      if (isCountSql(sql)) return [{ orphaned_tasks: 0, orphaned_installs: 0 }];
+      throw new Error(`unexpected query: ${sql}`);
+    });
+    const { log, warn, debug } = recordingLogger();
+
+    const result = await reconcileOrphanTasks(
+      deps({ query, reconcileEnabled: () => true, log }),
+    );
+
+    expect(result.deleted).toBe(0);
+    expect(calls.some((c) => isDeleteSql(c.sql))).toBe(false);
+    // Clean scan → debug, not warn (no false drift alarm).
+    expect(warn).not.toHaveBeenCalled();
+    expect(debug).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Real-Postgres integration — the orphan JOIN + NULL-org semantics
+// ---------------------------------------------------------------------------
+
+const TEST_DB_URL = process.env.TEST_DATABASE_URL;
+const describeIfPg = TEST_DB_URL ? describe : describe.skip;
+const PG_TEST_TIMEOUT_MS = 30_000;
+
+describeIfPg("orphan-task-reconcile (real Postgres)", () => {
+  let pool: Pool;
+  const schemaName = `orphan_reconcile_${Date.now()}_${Math.floor(Math.random() * 1e6)}`;
+
+  // Adapter matching `OrphanReconcileQuery` so the production count/delete
+  // SQL runs verbatim against the seeded minimal tables.
+  const query: OrphanReconcileQuery = async <T extends Record<string, unknown>>(
+    sql: string,
+    params?: unknown[],
+  ) => {
+    const result = await pool.query(sql, params);
+    return result.rows as T[];
+  };
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: TEST_DB_URL });
+    pool.on("connect", (client) => {
+      void client.query(`SET search_path TO "${schemaName}"`).catch((err) => {
+        const message = err instanceof Error ? err.message : String(err);
+        console.error(`orphan-reconcile: SET search_path failed: ${message}`);
+      });
+    });
+    await pool.query(`CREATE SCHEMA IF NOT EXISTS "${schemaName}"`);
+    // Minimal columns the orphan JOIN touches (migration 0044 shape):
+    //   scheduled_tasks.plugin_id  == workspace_plugins.catalog_id
+    //   scheduled_tasks.org_id     == workspace_plugins.workspace_id
+    await pool.query(
+      `CREATE TABLE scheduled_tasks (id TEXT PRIMARY KEY, plugin_id TEXT, org_id TEXT)`,
+    );
+    await pool.query(
+      `CREATE TABLE workspace_plugins (catalog_id TEXT NOT NULL, workspace_id TEXT NOT NULL)`,
+    );
+  });
+
+  afterAll(async () => {
+    if (!pool) return;
+    await pool.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`);
+    await pool.end();
+  });
+
+  test(
+    "counts orphans (incl. NULL-org), sweeps only org-scoped orphans, leaves live/user/NULL-org tasks",
+    async () => {
+      // One live install: plugin p-live in workspace o1.
+      await pool.query(
+        `INSERT INTO workspace_plugins (catalog_id, workspace_id) VALUES ('p-live', 'o1')`,
+      );
+      await pool.query(
+        `INSERT INTO scheduled_tasks (id, plugin_id, org_id) VALUES
+           ('t-orphan',  'p-dead', 'o1'),   -- orphan: install for p-dead/o1 is gone
+           ('t-live',    'p-live', 'o1'),   -- not an orphan: matches the live install
+           ('t-user',    NULL,     'o1'),   -- user task: plugin_id NULL, never an orphan
+           ('t-nullorg', 'p-dead', NULL)    -- orphan, but NULL org → counted, not swept`,
+      );
+
+      // Count surfaces both orphans (the org-scoped one + the NULL-org one).
+      const before = await countOrphanedPluginTasks(query);
+      expect(before.orphanedTasks).toBe(2);
+      expect(before.orphanedInstalls).toBe(2);
+
+      // Sweep removes only the org-scoped orphan.
+      const deleted = await deleteOrphanedPluginTasks(query);
+      expect(deleted).toBe(1);
+
+      const remaining = await pool.query<{ id: string }>(
+        `SELECT id FROM scheduled_tasks ORDER BY id`,
+      );
+      expect(remaining.rows.map((r) => r.id)).toEqual([
+        "t-live",
+        "t-nullorg",
+        "t-user",
+      ]);
+
+      // The NULL-org orphan is still reported (it just isn't auto-deleted).
+      const after = await countOrphanedPluginTasks(query);
+      expect(after.orphanedTasks).toBe(1);
+    },
+    PG_TEST_TIMEOUT_MS,
+  );
+});

--- a/packages/api/src/lib/scheduler/__tests__/orphan-task-reconcile.test.ts
+++ b/packages/api/src/lib/scheduler/__tests__/orphan-task-reconcile.test.ts
@@ -90,12 +90,22 @@ describe("countOrphanedPluginTasks", () => {
     expect(calls).toHaveLength(1);
   });
 
-  test("defaults missing/empty result rows to zero", async () => {
-    const { query } = fakeQuery(() => []);
-    expect(await countOrphanedPluginTasks(query)).toEqual({
-      orphanedTasks: 0,
-      orphanedInstalls: 0,
-    });
+  test("throws on an unexpected result shape (empty / non-numeric) instead of reporting a false-healthy zero", async () => {
+    // A COUNT(*) aggregate always returns one row with numeric columns, so an
+    // empty result (or a column-alias drift) is a structural failure — it must
+    // surface as an error (recorded on the fiber span) rather than silently
+    // coalescing to `0 orphans`, which reads identical to a clean scan.
+    const empty = fakeQuery(() => []);
+    await expect(countOrphanedPluginTasks(empty.query)).rejects.toThrow(
+      /unexpected shape/,
+    );
+
+    const nonNumeric = fakeQuery(() => [
+      { orphaned_tasks: null, orphaned_installs: null },
+    ]);
+    await expect(countOrphanedPluginTasks(nonNumeric.query)).rejects.toThrow(
+      /unexpected shape/,
+    );
   });
 });
 
@@ -202,6 +212,30 @@ describe("reconcileOrphanTasks", () => {
     });
     expect(msg).toContain("clean manually");
     expect(debug).not.toHaveBeenCalled();
+  });
+
+  test("propagates a count-query failure (so the fiber span records ERROR, never a false-healthy zero)", async () => {
+    // Locks in the contract the `layers.ts` wrap depends on: when the count
+    // query rejects (internal-DB circuit open, statement timeout, …),
+    // reconcileOrphanTasks must REJECT so `withEffectSpan` records span status
+    // ERROR + the exception. The fiber's OUTER catchAll (in layers.ts, applied
+    // after the span) is what keeps the hourly loop alive — but the error must
+    // reach the span first, not be swallowed into a zeroed report here.
+    const { query, calls } = fakeQuery((sql) => {
+      if (isCountSql(sql)) throw new Error("internal DB circuit open");
+      throw new Error(`unexpected query: ${sql}`);
+    });
+    const { log, warn, debug } = recordingLogger();
+
+    await expect(reconcileOrphanTasks(deps({ query, log }))).rejects.toThrow(
+      "internal DB circuit open",
+    );
+
+    // No drift signal is fabricated on failure — neither the warn nor the
+    // clean-scan debug fired, and no DELETE was attempted.
+    expect(warn).not.toHaveBeenCalled();
+    expect(debug).not.toHaveBeenCalled();
+    expect(calls.some((c) => isDeleteSql(c.sql))).toBe(false);
   });
 
   test("sweeps the orphan when ATLAS_ORPHAN_TASK_RECONCILE is on", async () => {

--- a/packages/api/src/lib/scheduler/orphan-task-reconcile.ts
+++ b/packages/api/src/lib/scheduler/orphan-task-reconcile.ts
@@ -84,8 +84,11 @@ export interface OrphanTaskReport {
   /**
    * Distinct `(plugin_id, org_id)` pairs with orphans — i.e. how many
    * uninstalls left tasks behind. Coarse: computed via a `plugin_id || ':' ||
-   * org_id` key, which is exact for the catalog-id / org-id values Atlas
-   * writes (no `:` in either).
+   * org_id` key. `plugin_id` is a catalog id (`catalog:<slug>` — a
+   * fixed-position colon over a colon-free slug) and `org_id` is colon-free
+   * (enforced at write — see the `orgId` guard in `db/connection.ts`), so the
+   * concatenation is unambiguous and the DISTINCT count is exact. It's a
+   * coarse metric, not a correctness-critical value.
    */
   readonly orphanedInstalls: number;
 }
@@ -146,9 +149,24 @@ export async function countOrphanedPluginTasks(
     COUNT_ORPHANED_TASKS_SQL,
   );
   const row = rows[0];
+  // A COUNT(*) aggregate always returns exactly one row with numeric columns
+  // (0/0 when nothing matches). A missing row or a non-numeric column means a
+  // structural failure — driver returned nothing, column-alias drift, etc.
+  // Surface it as an error (the fiber wrap in `layers.ts` records it on the
+  // span + logs, keeping the loop alive) rather than coalescing to a
+  // false-healthy `0 orphans`, which is indistinguishable from a clean scan.
+  if (
+    !row ||
+    typeof row.orphaned_tasks !== "number" ||
+    typeof row.orphaned_installs !== "number"
+  ) {
+    throw new Error(
+      "Orphan-task count query returned an unexpected shape (expected one row with numeric orphaned_tasks/orphaned_installs)",
+    );
+  }
   return {
-    orphanedTasks: row?.orphaned_tasks ?? 0,
-    orphanedInstalls: row?.orphaned_installs ?? 0,
+    orphanedTasks: row.orphaned_tasks,
+    orphanedInstalls: row.orphaned_installs,
   };
 }
 
@@ -187,20 +205,33 @@ export interface OrphanReconcileDeps {
 }
 
 /**
+ * The canonical zero/no-op result: no orphans, sweep not run. Returned when
+ * the tick can't do work (no internal DB). Centralized so the only
+ * internally-consistent "did nothing" shape — `reconcileEnabled: false` paired
+ * with `deleted: 0` — lives in one place rather than being hand-written at
+ * each no-op site (`OrphanReconcileResult` is a flat record, so the
+ * `reconcileEnabled`/`deleted` pairing is an invariant held by construction).
+ */
+function emptyReconcileResult(): OrphanReconcileResult {
+  return { orphanedTasks: 0, orphanedInstalls: 0, reconcileEnabled: false, deleted: 0 };
+}
+
+/**
  * One reconcile tick: count (always) → optionally delete (when enabled) →
  * emit the drift signal. Returns the result so the `withEffectSpan` wrap in
  * `layers.ts` can attach the counts as span attributes.
  *
  * No-ops to a zero report when the internal DB is not configured (self-hosted
  * without `DATABASE_URL` has no `scheduled_tasks` / `workspace_plugins`
- * tables). DB errors propagate — the fiber wrap in `layers.ts` logs and
- * recovers, keeping the loop alive while still recording the failure.
+ * tables). DB errors propagate — the fiber wrap in `layers.ts` records the
+ * failure on the span and recovers, keeping the loop alive while the trace
+ * shows ERROR (never a false-healthy zero).
  */
 export async function reconcileOrphanTasks(
   deps: OrphanReconcileDeps,
 ): Promise<OrphanReconcileResult> {
   if (!deps.hasInternalDB()) {
-    return { orphanedTasks: 0, orphanedInstalls: 0, reconcileEnabled: false, deleted: 0 };
+    return emptyReconcileResult();
   }
 
   const reconcileEnabled = deps.reconcileEnabled();

--- a/packages/api/src/lib/scheduler/orphan-task-reconcile.ts
+++ b/packages/api/src/lib/scheduler/orphan-task-reconcile.ts
@@ -1,0 +1,246 @@
+/**
+ * Orphan plugin-task reconcile (#2944).
+ *
+ * Plugin uninstall (`DELETE /api/v1/admin/marketplace/:id`) is deliberately
+ * NON-atomic: the `workspace_plugins` row DELETE commits first, then the
+ * plugin-owned `scheduled_tasks` cleanup runs as a separate, best-effort
+ * statement (see `admin-marketplace.ts` — "best-effort cleanup over a
+ * multi-statement transaction because making the cleanup load-bearing would
+ * block uninstall on internal-DB hiccups"). If that cleanup rejects AFTER the
+ * install row is gone, the plugin's tasks are orphaned — `plugin_id` set, but
+ * no live `workspace_plugins` row — and the scheduler keeps firing them.
+ *
+ * The uninstall path already logs a failure audit + `log.error` for the
+ * single request that failed. The gap #2944 closes is the lack of a recurring
+ * signal for orphan *accumulation* across all workspaces (and across BOTH
+ * uninstall paths — the marketplace DELETE handler, and `WorkspaceInstaller`
+ * disconnects, which never cleaned `scheduled_tasks` at all). A failed
+ * cleanup that drops its audit row on an internal-DB circuit-open would
+ * otherwise leave no durable trace.
+ *
+ * This module is that recurring counterpart. Forked as a periodic scheduler
+ * fiber in `makeSchedulerLive`, every tick:
+ *
+ *   1. COUNTS orphaned plugin tasks — always — and surfaces the count as a
+ *      per-tick OpenTelemetry span attribute (the wrap site in `layers.ts`)
+ *      plus a structured `log.warn` when the count is > 0. This is the
+ *      operator-facing drift signal, emitted the same way the per-tick
+ *      cleanup spans (#2945) and the uninstall failure log already are — a
+ *      stdout-scraping or trace-querying operator sees orphan accumulation
+ *      without a dedicated admin route.
+ *   2. Optionally DELETES the confirmed orphans, scoped by EXACTLY the same
+ *      `(plugin_id, org_id)` predicate the uninstall path uses — but only
+ *      when `ATLAS_ORPHAN_TASK_RECONCILE=true`. The default is measure-only:
+ *      auto-deleting on a timer could mask a transient `workspace_plugins`
+ *      read blip, and the original design deliberately favors best-effort
+ *      over load-bearing cleanup, so the destructive sweep is opt-in.
+ *
+ * ## What counts as an orphan
+ *
+ * A `scheduled_tasks` row where `plugin_id IS NOT NULL` and there is NO
+ * `workspace_plugins` row with `(catalog_id = plugin_id, workspace_id =
+ * org_id)`. Per migration 0044, `scheduled_tasks.plugin_id` stores the
+ * plugin's `catalog_id` (NOT the per-install `workspace_plugins.id`, which
+ * gets a fresh value on every reinstall), and `workspace_plugins.workspace_id`
+ * is the same value as `scheduled_tasks.org_id` (both the workspace/org id).
+ *
+ * A plugin task with a NULL `org_id` can never match a live install
+ * (`workspace_plugins.workspace_id` is NOT NULL), so it is COUNTED as an
+ * orphan. The destructive sweep, however, SKIPS NULL-org rows — the uninstall
+ * predicate (`... AND org_id = $2`) can't target a NULL org either (SQL
+ * `NULL = $2` never matches), so deleting them here would clean up state the
+ * uninstall path itself would never touch. Measure broadly, delete
+ * conservatively.
+ */
+
+import { createLogger } from "@atlas/api/lib/logger";
+import { hasInternalDB, internalQuery } from "@atlas/api/lib/db/internal";
+
+const log = createLogger("orphan-task-reconcile");
+
+/**
+ * How often the reconcile fiber ticks. Orphan accumulation is rare (only a
+ * failed uninstall produces one) and slow, so an hourly cadence is ample —
+ * frequent enough that drift surfaces the same day, infrequent enough that
+ * the (cheap, indexed) scan is negligible. Exported so `layers.ts` references
+ * the same value the fiber is documented around.
+ */
+export const ORPHAN_TASK_RECONCILE_INTERVAL_MS = 60 * 60 * 1000;
+
+/**
+ * Minimal query surface shared with `internalQuery` so callers (and tests)
+ * can inject a pool adapter. Matches `internalQuery`'s signature exactly, so
+ * the production wiring passes `internalQuery` directly.
+ */
+export type OrphanReconcileQuery = <T extends Record<string, unknown>>(
+  sql: string,
+  params?: unknown[],
+) => Promise<T[]>;
+
+/** Point-in-time count of orphaned plugin scheduled tasks. */
+export interface OrphanTaskReport {
+  /** Total orphaned `scheduled_tasks` rows (`plugin_id` set, no live install). */
+  readonly orphanedTasks: number;
+  /**
+   * Distinct `(plugin_id, org_id)` pairs with orphans — i.e. how many
+   * uninstalls left tasks behind. Coarse: computed via a `plugin_id || ':' ||
+   * org_id` key, which is exact for the catalog-id / org-id values Atlas
+   * writes (no `:` in either).
+   */
+  readonly orphanedInstalls: number;
+}
+
+/** Result of one reconcile tick — the report plus what the sweep did. */
+export interface OrphanReconcileResult extends OrphanTaskReport {
+  /** Whether the destructive sweep ran this tick (`ATLAS_ORPHAN_TASK_RECONCILE=true`). */
+  readonly reconcileEnabled: boolean;
+  /** Rows the sweep deleted (0 when measure-only, or nothing to delete). */
+  readonly deleted: number;
+}
+
+/**
+ * `true` when the destructive reconcile sweep is enabled. Read at call time
+ * (never at module top-level) so test discipline + per-process env overrides
+ * hold. Default OFF — the signal is always emitted; only the DELETE is gated.
+ */
+export function isOrphanTaskReconcileEnabled(): boolean {
+  return process.env.ATLAS_ORPHAN_TASK_RECONCILE === "true";
+}
+
+// The orphan predicate, shared verbatim between the count and the delete so
+// the two can never drift. A task is an orphan iff it is plugin-owned and no
+// live install row matches on BOTH catalog_id and workspace_id — the exact
+// pair the uninstall cleanup scopes by.
+const ORPHAN_PREDICATE = `st.plugin_id IS NOT NULL
+    AND NOT EXISTS (
+      SELECT 1 FROM workspace_plugins wp
+      WHERE wp.catalog_id = st.plugin_id
+        AND wp.workspace_id = st.org_id
+    )`;
+
+const COUNT_ORPHANED_TASKS_SQL = `
+  SELECT
+    COUNT(*)::int AS orphaned_tasks,
+    COUNT(DISTINCT (st.plugin_id || ':' || COALESCE(st.org_id, '')))::int AS orphaned_installs
+  FROM scheduled_tasks st
+  WHERE ${ORPHAN_PREDICATE}
+`;
+
+// The sweep adds `org_id IS NOT NULL` to the count predicate: a NULL-org
+// plugin task is an orphan we report but never auto-delete (see module doc).
+const DELETE_ORPHANED_TASKS_SQL = `
+  DELETE FROM scheduled_tasks st
+  WHERE st.org_id IS NOT NULL
+    AND ${ORPHAN_PREDICATE}
+  RETURNING id
+`;
+
+/**
+ * Count orphaned plugin scheduled tasks. Read-only, single SELECT. `query`
+ * defaults to the internal pool; tests inject an adapter.
+ */
+export async function countOrphanedPluginTasks(
+  query: OrphanReconcileQuery = internalQuery,
+): Promise<OrphanTaskReport> {
+  const rows = await query<{ orphaned_tasks: number; orphaned_installs: number }>(
+    COUNT_ORPHANED_TASKS_SQL,
+  );
+  const row = rows[0];
+  return {
+    orphanedTasks: row?.orphaned_tasks ?? 0,
+    orphanedInstalls: row?.orphaned_installs ?? 0,
+  };
+}
+
+/**
+ * Delete confirmed orphan plugin tasks (org-scoped only — see module doc).
+ * Returns the number of rows deleted. Idempotent: the `NOT EXISTS` is
+ * re-evaluated at delete time, so concurrent ticks (multi-pod) and a
+ * reinstall-between-count-and-delete race are both safe — only still-orphaned
+ * rows are removed.
+ */
+export async function deleteOrphanedPluginTasks(
+  query: OrphanReconcileQuery = internalQuery,
+): Promise<number> {
+  const rows = await query<{ id: string }>(DELETE_ORPHANED_TASKS_SQL);
+  return rows.length;
+}
+
+/** Minimal structured-logger surface the tick needs — satisfied by the pino
+ * logger in production and a recording fake in tests. */
+export interface ReconcileLogger {
+  warn: (obj: Record<string, unknown>, msg: string) => void;
+  debug: (obj: Record<string, unknown>, msg: string) => void;
+}
+
+/**
+ * Injectable dependencies for one reconcile tick. The production tick
+ * (`runOrphanTaskReconcileTick`) wires the real internal-DB pool + env flag +
+ * logger; tests inject fakes so the orchestration (no-op gate, count, gated
+ * delete, drift signal) is exercised without a live DB or `mock.module`.
+ */
+export interface OrphanReconcileDeps {
+  readonly hasInternalDB: () => boolean;
+  readonly query: OrphanReconcileQuery;
+  readonly reconcileEnabled: () => boolean;
+  readonly log: ReconcileLogger;
+}
+
+/**
+ * One reconcile tick: count (always) → optionally delete (when enabled) →
+ * emit the drift signal. Returns the result so the `withEffectSpan` wrap in
+ * `layers.ts` can attach the counts as span attributes.
+ *
+ * No-ops to a zero report when the internal DB is not configured (self-hosted
+ * without `DATABASE_URL` has no `scheduled_tasks` / `workspace_plugins`
+ * tables). DB errors propagate — the fiber wrap in `layers.ts` logs and
+ * recovers, keeping the loop alive while still recording the failure.
+ */
+export async function reconcileOrphanTasks(
+  deps: OrphanReconcileDeps,
+): Promise<OrphanReconcileResult> {
+  if (!deps.hasInternalDB()) {
+    return { orphanedTasks: 0, orphanedInstalls: 0, reconcileEnabled: false, deleted: 0 };
+  }
+
+  const reconcileEnabled = deps.reconcileEnabled();
+  const report = await countOrphanedPluginTasks(deps.query);
+
+  let deleted = 0;
+  if (reconcileEnabled && report.orphanedTasks > 0) {
+    deleted = await deleteOrphanedPluginTasks(deps.query);
+  }
+
+  if (report.orphanedTasks > 0) {
+    deps.log.warn(
+      {
+        orphanedTasks: report.orphanedTasks,
+        orphanedInstalls: report.orphanedInstalls,
+        reconcileEnabled,
+        deleted,
+        event: "plugin_task.orphan_detected",
+      },
+      reconcileEnabled
+        ? `Orphaned plugin scheduled tasks detected and reconciled (${deleted} deleted) — a plugin uninstall left tasks with no live workspace_plugins row`
+        : "Orphaned plugin scheduled tasks detected — a plugin uninstall left tasks with no live workspace_plugins row. Set ATLAS_ORPHAN_TASK_RECONCILE=true to auto-purge, or clean manually.",
+    );
+  } else {
+    deps.log.debug({ event: "plugin_task.orphan_scan" }, "Orphan plugin-task scan: none found");
+  }
+
+  return { ...report, reconcileEnabled, deleted };
+}
+
+/**
+ * Production entry point for the scheduler fiber: `reconcileOrphanTasks` wired
+ * to the real internal-DB pool, the `ATLAS_ORPHAN_TASK_RECONCILE` flag, and
+ * the module logger.
+ */
+export function runOrphanTaskReconcileTick(): Promise<OrphanReconcileResult> {
+  return reconcileOrphanTasks({
+    hasInternalDB,
+    query: internalQuery,
+    reconcileEnabled: isOrphanTaskReconcileEnabled,
+    log,
+  });
+}


### PR DESCRIPTION
## Summary

Closes the operational gap in #2944: plugin uninstall is **deliberately** non-atomic (the `workspace_plugins` DELETE commits, then the plugin-owned `scheduled_tasks` cleanup runs best-effort), but a failed cleanup left orphaned tasks — `plugin_id` set, no live `workspace_plugins` row — firing forever with **no recurring operational signal**. The deliberate non-atomic behavior is unchanged; this adds the missing signal.

- **`lib/scheduler/orphan-task-reconcile.ts`** — counts `scheduled_tasks` whose `plugin_id` has no matching live `workspace_plugins` row (on `catalog_id` + `workspace_id`, the exact uninstall predicate; `plugin_id` stores the catalog_id per migration 0044). Optional reconcile sweep deletes confirmed orphans, scoped to org-bearing rows only.
- **`layers.ts`** — forks the `orphan_task_reconcile` scheduler fiber (hourly), following the per-tick-span style of #2945. The orphan count rides the per-tick OTel span `atlas.scheduler.orphan_task_reconcile` as a result attribute (the only cleanup fiber that attaches one) + a `log.warn` when > 0, so operators see drift in traces and logs. Added to `SCHEDULER_CLEANUP_SPAN_NAMES` (8 → 9) so the existing structural wiring guard covers it.
- **Reconcile sweep gated/observable** — destructive DELETE only when `ATLAS_ORPHAN_TASK_RECONCILE=true` (default off, measure-only): auto-deleting on a timer could mask a transient `workspace_plugins` read blip. A NULL-`org_id` orphan is reported but never auto-deleted (the uninstall predicate can't target it either). Idempotent `NOT EXISTS` makes multi-pod ticks safe.
- **Uninstall contract** — strengthened the external-webhook revocation expectation (`admin-marketplace.ts` comment + `authoring-guide.mdx#uninstall-contract`), added an "Orphan-task drift signal" doc section, and an `.env.example` flag.

### Surface decision

The signal is an **OTel span attribute + structured `log.warn`** (the established pattern for this orphan concern — the uninstall handler already logs to stdout-scrapers), per the issue's steer to "follow [bbafc78b's per-tick scheduler span] style." Surfacing it on `/api/v1/platform/overview` was considered but rejected: it would touch published `@useatlas/types` + `@useatlas/schemas`, triggering the version-bump/publish-coordination dance — scope creep beyond this issue. (`/health` is public/unauthenticated, so per-org orphan counts don't belong there.)

## Test plan

- [x] Unit (injected fakes, no `mock.module`): no-DB gate; **partial-failure acceptance scenario** (orphan present → count > 0 + `log.warn` fires, no DELETE in measure-only); gated sweep on/off; clean scan → `debug` not `warn`; env-flag exactness.
- [x] **Real-Postgres integration** (`describeIfPg`, runs in api-tests PG container): seeds the post-partial-failure state and asserts the orphan JOIN counts both the org-scoped + NULL-org orphans, the sweep deletes **only** the org-scoped one, and live/user/NULL-org tasks survive. Verified locally against a real DB (9/9 pass).
- [x] `layers.test.ts` 8 → 9 fiber guard updated (37 pass).
- [x] `/ci` — lint, type, full test suite, syncpack, all drift/discipline gates — all pass.

Closes #2944

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/2992"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782677232&installation_id=135337507&pr_number=2992&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F2992&signature=2c4940c50630e732dfe472eb3ed62193acd51837f54c343892ff7e692d86549e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->