### PR TITLE
feat(billing): enforce per-tier chat-integration caps (#2953)

### DIFF
--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -72607,7 +72607,7 @@
         ],
         "responses": {
           "302": {
-            "description": "Install complete — redirected to /admin/integrations. Success: `?installed=discord`. User cancel: `?error=discord&reason=authorization_denied`. JSON callers receive structured 4xx responses instead."
+            "description": "Install complete — redirected to /admin/integrations. Success: `?installed=discord`. User cancel: `?error=discord&reason=authorization_denied`. Chat-integration cap reached (browser caller): `?error=discord&reason=plan_limit_reached`. JSON callers receive structured 4xx/5xx responses instead."
           },
           "400": {
             "description": "Invalid state, user cancel, or missing guild_id",
@@ -72659,6 +72659,35 @@
               }
             }
           },
+          "429": {
+            "description": "Chat-integration cap reached for the workspace's plan tier: `plan_limit_exceeded` (JSON-Accept caller)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "requestId": {
+                      "type": "string"
+                    },
+                    "limit": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "error",
+                    "message",
+                    "limit"
+                  ]
+                }
+              }
+            }
+          },
           "501": {
             "description": "Discord install handler not registered",
             "content": {
@@ -72686,6 +72715,31 @@
           },
           "502": {
             "description": "Discord API unreachable while verifying the guild",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "requestId": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Billing/plan-limit check unavailable: `billing_check_failed` (JSON-Accept caller)",
             "content": {
               "application/json": {
                 "schema": {
@@ -73182,7 +73236,7 @@
         ],
         "responses": {
           "302": {
-            "description": "Install complete or failed in a recoverable way — redirected to /admin/integrations. Success: `?installed=<platform>`. Credential write missed: `?reconnect=<platform>`. Hard failure (browser caller): `?error=<platform>&reason=<code>`. JSON callers receive 400/502 instead."
+            "description": "Install complete or failed in a recoverable way — redirected to /admin/integrations. Success: `?installed=<platform>`. Credential write missed: `?reconnect=<platform>`. Hard failure (browser caller): `?error=<platform>&reason=<code>` (chat-integration cap reached → `reason=plan_limit_reached`). JSON callers receive 400/429/502/503 instead."
           },
           "400": {
             "description": "Invalid or expired state, or unknown platform (JSON-Accept caller)",
@@ -73293,6 +73347,35 @@
               }
             }
           },
+          "429": {
+            "description": "Chat-integration cap reached for the workspace's plan tier: `plan_limit_exceeded` (JSON-Accept caller)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "requestId": {
+                      "type": "string"
+                    },
+                    "limit": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "error",
+                    "message",
+                    "limit"
+                  ]
+                }
+              }
+            }
+          },
           "501": {
             "description": "OAuth handler not registered",
             "content": {
@@ -73320,6 +73403,31 @@
           },
           "502": {
             "description": "Upstream Platform rejected the OAuth exchange (JSON-Accept caller)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "requestId": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Billing/plan-limit check unavailable: `billing_check_failed` (JSON-Accept caller)",
             "content": {
               "application/json": {
                 "schema": {

--- a/packages/api/src/api/__tests__/integrations-discord.test.ts
+++ b/packages/api/src/api/__tests__/integrations-discord.test.ts
@@ -403,6 +403,13 @@ describe("/api/v1/integrations/discord", () => {
         if (sql.includes("FROM organization")) {
           return Promise.resolve(entitlementRowResponse);
         }
+        if (sql.includes("COUNT(*) FILTER")) {
+          // Chat-integration cap count (#2953) — no existing chat installs,
+          // so the cap check allows this net-new Discord install. The
+          // aggregate must return exactly one row; an empty result now
+          // fails closed (BillingCheckFailedError → 503).
+          return Promise.resolve([{ others: 0, this_count: 0 }]);
+        }
         if (sql.includes("INSERT INTO workspace_plugins")) {
           return Promise.resolve([{ id: "install-row-1" }]);
         }

--- a/packages/api/src/api/routes/__tests__/disconnect-listener-gate.test.ts
+++ b/packages/api/src/api/routes/__tests__/disconnect-listener-gate.test.ts
@@ -139,6 +139,10 @@ mock.module("@atlas/api/lib/db/internal", () => ({
   InternalDB: MockInternalDB,
   hasInternalDB: () => true,
   internalQuery: mockInternalQuery,
+  // Pulled into the graph via `billing/enforcement` (the chat install
+  // handlers' #2953 cap check). Never invoked on the disconnect path, but
+  // the named export must exist so the partial mock doesn't SyntaxError.
+  getWorkspaceDetails: mock(() => Promise.resolve(null)),
   internalExecute: mock(() => Promise.resolve()),
   makeInternalDBShimLayer: () => makeMockInternalDBShimLayer(mockInternalQuery, { available: true }),
   makeInternalDBLive: () => Layer.succeedContext(Context.empty()),

--- a/packages/api/src/api/routes/__tests__/integrations.test.ts
+++ b/packages/api/src/api/routes/__tests__/integrations.test.ts
@@ -16,7 +16,7 @@
 
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, mock } from "bun:test";
 import { Context, Effect, Layer } from "effect";
-import { PlatformOAuthExchangeError } from "@atlas/api/lib/effect/errors";
+import { BillingCheckFailedError, ChatIntegrationLimitError, PlatformOAuthExchangeError } from "@atlas/api/lib/effect/errors";
 import {
   MockInternalDB,
   makeMockInternalDBShimLayer,
@@ -502,6 +502,67 @@ describe("GET /api/v1/integrations/slack/callback — upstream Slack failure", (
     );
 
     expect(res.status).toBe(502);
+  });
+});
+
+describe("GET /api/v1/integrations/slack/callback — chat-integration cap (#2953)", () => {
+  it("redirects to ?error=slack&reason=plan_limit_reached for browser callers when at cap", async () => {
+    callbackImpl = async () => {
+      throw new ChatIntegrationLimitError({
+        message: "Your starter plan allows up to 1 chat integration. Upgrade to add more.",
+        workspaceId: "org-1",
+        limit: 1,
+      });
+    };
+
+    const res = await request(
+      "/api/v1/integrations/slack/callback?code=auth-abc&state=stub",
+      { headers: { Accept: "text/html" } },
+    );
+
+    expect(res.status).toBe(302);
+    const location = res.headers.get("location") ?? "";
+    expect(location).toContain("error=slack");
+    expect(location).toContain("reason=plan_limit_reached");
+  });
+
+  it("returns 429 plan_limit_exceeded JSON (with limit) for application/json callers", async () => {
+    callbackImpl = async () => {
+      throw new ChatIntegrationLimitError({
+        message: "Your starter plan allows up to 1 chat integration. Upgrade to add more.",
+        workspaceId: "org-1",
+        limit: 1,
+      });
+    };
+
+    const res = await request(
+      "/api/v1/integrations/slack/callback?code=auth-abc&state=stub",
+      { headers: { Accept: "application/json" } },
+    );
+
+    expect(res.status).toBe(429);
+    const body = (await res.json()) as { error?: string; limit?: number };
+    expect(body.error).toBe("plan_limit_exceeded");
+    expect(body.limit).toBe(1);
+  });
+
+  it("returns 503 billing_check_failed (NOT a redirect / not 429) when the count check fails closed", async () => {
+    // A count-check failure must surface as a transient 503 "try again",
+    // never a misleading 429/upgrade redirect.
+    callbackImpl = async () => {
+      throw new BillingCheckFailedError({
+        message: "Unable to verify plan limits. Please try again.",
+        workspaceId: "org-1",
+      });
+    };
+
+    const res = await request(
+      "/api/v1/integrations/slack/callback?code=auth-abc&state=stub",
+      { headers: { Accept: "text/html" } },
+    );
+
+    expect(res.status).not.toBe(302);
+    expect(res.status).toBe(503);
   });
 });
 

--- a/packages/api/src/api/routes/integrations-discord.ts
+++ b/packages/api/src/api/routes/integrations-discord.ts
@@ -46,6 +46,7 @@ import { getWebOrigin } from "@atlas/api/lib/web-origin";
 import { runHandler } from "@atlas/api/lib/effect/hono";
 import { getConfig } from "@atlas/api/lib/config";
 import {
+  ChatIntegrationLimitError,
   DiscordApiUnavailableError,
   DiscordGuildIdInvalidError,
   DiscordReachabilityError,
@@ -663,6 +664,23 @@ discordIntegrations.openapi(callbackRoute, async (c) =>
         return c.json(
           { error: "upstream_error", message: err.message, requestId },
           502,
+        );
+      }
+      // Workspace at its plan's chat-integration cap. Browser callers get
+      // the friendly upgrade redirect; JSON callers fall through to the 429
+      // `plan_limit_exceeded` mapping in runHandler. (A `BillingCheckFailedError`
+      // is intentionally left to the 503 JSON mapper — transient "try again".)
+      if (err instanceof ChatIntegrationLimitError) {
+        log.info(
+          { workspaceId, limit: err.limit },
+          "Discord install blocked — workspace at chat-integration cap",
+        );
+        if (prefersHtml(c.req.raw)) {
+          return c.redirect(buildAdminIntegrationsUrl("error", { reason: "plan_limit_reached" }));
+        }
+        return c.json(
+          { error: "plan_limit_exceeded", message: err.message, requestId, limit: err.limit },
+          429,
         );
       }
       throw err;

--- a/packages/api/src/api/routes/integrations-discord.ts
+++ b/packages/api/src/api/routes/integrations-discord.ts
@@ -189,7 +189,8 @@ const callbackRoute = createRoute({
       description:
         "Install complete — redirected to /admin/integrations. " +
         "Success: `?installed=discord`. User cancel: `?error=discord&reason=authorization_denied`. " +
-        "JSON callers receive structured 4xx responses instead.",
+        "Chat-integration cap reached (browser caller): `?error=discord&reason=plan_limit_reached`. " +
+        "JSON callers receive structured 4xx/5xx responses instead.",
     },
     400: {
       description: "Invalid state, user cancel, or missing guild_id",
@@ -199,12 +200,25 @@ const callbackRoute = createRoute({
       description: "Discord catalog row missing",
       content: { "application/json": { schema: ErrorSchema } },
     },
+    // #2953 — workspace at its plan's chat-integration cap (JSON callers;
+    // browsers get a 302 with `reason=plan_limit_reached`). `plan_limit_exceeded`
+    // body carries the `limit` that was hit.
+    429: {
+      description: "Chat-integration cap reached for the workspace's plan tier: `plan_limit_exceeded` (JSON-Accept caller)",
+      content: { "application/json": { schema: ErrorSchema.extend({ limit: z.number() }) } },
+    },
     501: {
       description: "Discord install handler not registered",
       content: { "application/json": { schema: ErrorSchema } },
     },
     502: {
       description: "Discord API unreachable while verifying the guild",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
+    // #2953 — the chat-integration count couldn't be determined (transient DB
+    // fault), so the cap check failed closed: `billing_check_failed` "try again".
+    503: {
+      description: "Billing/plan-limit check unavailable: `billing_check_failed` (JSON-Accept caller)",
       content: { "application/json": { schema: ErrorSchema } },
     },
   },

--- a/packages/api/src/api/routes/integrations.ts
+++ b/packages/api/src/api/routes/integrations.ts
@@ -43,7 +43,7 @@ import { createLogger } from "@atlas/api/lib/logger";
 import { getWebOrigin } from "@atlas/api/lib/web-origin";
 import { runHandler, runEffect } from "@atlas/api/lib/effect/hono";
 import { getConfig } from "@atlas/api/lib/config";
-import { PlatformOAuthExchangeError } from "@atlas/api/lib/effect/errors";
+import { ChatIntegrationLimitError, PlatformOAuthExchangeError } from "@atlas/api/lib/effect/errors";
 import {
   WorkspaceInstaller,
   WorkspaceInstallerLive,
@@ -1090,6 +1090,21 @@ integrations.openapi(callbackRoute, async (c) =>
         );
         if (prefersHtml(c.req.raw)) {
           return c.redirect(buildPlatformAdminUrl("error", platform, { reason: "upstream_error" }));
+        }
+      }
+      // Workspace at its plan's chat-integration cap. Browser callers get
+      // the friendly upgrade redirect (mirrors the min_plan deny path
+      // above); JSON callers fall through to the 429 `plan_limit_exceeded`
+      // mapping in runHandler. (A `BillingCheckFailedError` — count couldn't
+      // be read — is intentionally left to the 503 JSON mapper: it's a
+      // transient "try again", not an upgrade prompt.)
+      if (err instanceof ChatIntegrationLimitError) {
+        log.info(
+          { platform, workspaceId: err.workspaceId, limit: err.limit },
+          "Install callback blocked — workspace at chat-integration cap",
+        );
+        if (prefersHtml(c.req.raw)) {
+          return c.redirect(buildPlatformAdminUrl("error", platform, { reason: "plan_limit_reached" }));
         }
       }
       throw err;

--- a/packages/api/src/api/routes/integrations.ts
+++ b/packages/api/src/api/routes/integrations.ts
@@ -304,7 +304,8 @@ const callbackRoute = createRoute({
       description:
         "Install complete or failed in a recoverable way — redirected to /admin/integrations. " +
         "Success: `?installed=<platform>`. Credential write missed: `?reconnect=<platform>`. " +
-        "Hard failure (browser caller): `?error=<platform>&reason=<code>`. JSON callers receive 400/502 instead.",
+        "Hard failure (browser caller): `?error=<platform>&reason=<code>` (chat-integration cap reached → " +
+        "`reason=plan_limit_reached`). JSON callers receive 400/429/502/503 instead.",
     },
     400: { description: "Invalid or expired state, or unknown platform (JSON-Accept caller)", content: { "application/json": { schema: ErrorSchema } } },
     403: {
@@ -320,8 +321,21 @@ const callbackRoute = createRoute({
       },
     },
     404: { description: "Platform not found in catalog", content: { "application/json": { schema: ErrorSchema } } },
+    // #2953 — workspace at its plan's chat-integration cap (JSON callers;
+    // browsers get a 302 to the admin UI with `reason=plan_limit_reached`).
+    // `plan_limit_exceeded` body carries the `limit` that was hit.
+    429: {
+      description: "Chat-integration cap reached for the workspace's plan tier: `plan_limit_exceeded` (JSON-Accept caller)",
+      content: { "application/json": { schema: ErrorSchema.extend({ limit: z.number() }) } },
+    },
     501: { description: "OAuth handler not registered", content: { "application/json": { schema: ErrorSchema } } },
     502: { description: "Upstream Platform rejected the OAuth exchange (JSON-Accept caller)", content: { "application/json": { schema: ErrorSchema } } },
+    // #2953 — the chat-integration count couldn't be determined (transient DB
+    // fault), so the cap check failed closed: `billing_check_failed` "try again".
+    503: {
+      description: "Billing/plan-limit check unavailable: `billing_check_failed` (JSON-Accept caller)",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
   },
 });
 

--- a/packages/api/src/lib/auth/__tests__/sso-provisioning.test.ts
+++ b/packages/api/src/lib/auth/__tests__/sso-provisioning.test.ts
@@ -181,6 +181,7 @@ describe("_autoProvisionSsoMember", () => {
     setupQueryResponses({ ssoProvider: { org_id: "org-1" }, memberCount: 10 });
     mockCheckResourceLimit.mockImplementation(async () => ({
       allowed: false,
+      reason: "cap_reached",
       errorMessage: "Your starter plan allows up to 10 seats. Upgrade to add more.",
       limit: 10,
     }));
@@ -198,6 +199,7 @@ describe("_autoProvisionSsoMember", () => {
     setupQueryResponses({ ssoProvider: { org_id: "org-1" }, memberCount: 5 });
     mockCheckResourceLimit.mockImplementation(async () => ({
       allowed: false,
+      reason: "cap_reached",
       errorMessage: "Limit reached",
       limit: 5,
     }));
@@ -219,17 +221,17 @@ describe("_autoProvisionSsoMember", () => {
     expect(mockLogWarn).toHaveBeenCalled();
   });
 
-  it("fails open when checkResourceLimit returns limit=0 (infra error)", async () => {
+  it("fails open when checkResourceLimit returns reason=check_failed (infra error)", async () => {
     setupQueryResponses({ ssoProvider: { org_id: "org-1" }, memberCount: 5 });
     mockCheckResourceLimit.mockImplementation(async () => ({
       allowed: false,
+      reason: "check_failed",
       errorMessage: "Unable to verify plan limits. Please try again.",
-      limit: 0,
     }));
 
     await _autoProvisionSsoMember({ id: "user-9", email: "iris@acme.com" });
 
-    // limit=0 is the infra-error sentinel — should still insert (fail open)
+    // check_failed is the infra-error signal — should still insert (fail open)
     expect(mockDbQuery).toHaveBeenCalledTimes(1);
     // Should log warning about infra error
     expect(mockLogWarn).toHaveBeenCalled();

--- a/packages/api/src/lib/auth/server.ts
+++ b/packages/api/src/lib/auth/server.ts
@@ -2084,13 +2084,13 @@ export async function _autoProvisionSsoMember(user: { id: string; email: string 
       const currentCount = memberRows[0]?.count ?? 0;
       const limitCheck = await checkResourceLimit(orgId, "seats", currentCount);
       if (!limitCheck.allowed) {
-        // checkResourceLimit fails closed on infra errors (returns
-        // allowed: false, limit: 0). Detect this sentinel and fail open —
-        // blocking SSO login is worse than transient over-provisioning.
-        if (limitCheck.limit === 0) {
+        // checkResourceLimit fails closed on infra errors with
+        // `reason: "check_failed"`. Detect that and fail open — blocking
+        // SSO login is worse than transient over-provisioning.
+        if (limitCheck.reason === "check_failed") {
           log.warn(
             { userId: user.id, orgId },
-            "SSO auto-provisioning: billing check returned limit=0 (infra error?) — allowing provisioning",
+            "SSO auto-provisioning: billing check failed (infra error?) — allowing provisioning",
           );
         } else {
           log.warn(

--- a/packages/api/src/lib/billing/__tests__/enforcement.test.ts
+++ b/packages/api/src/lib/billing/__tests__/enforcement.test.ts
@@ -422,10 +422,22 @@ describe("billing/enforcement", () => {
 // checkResourceLimit — seat / connection plan enforcement
 // ===========================================================================
 
-/** Narrow a denied resource limit result for type-safe assertion access. */
-function expectResourceDenied(result: ResourceLimitResult): Extract<ResourceLimitResult, { allowed: false }> {
+/** Narrow a cap-reached (vs check-failed) denial for type-safe `.limit` access. */
+function expectResourceDenied(
+  result: ResourceLimitResult,
+): Extract<ResourceLimitResult, { allowed: false; reason: "cap_reached" }> {
   expect(result.allowed).toBe(false);
-  return result as Extract<ResourceLimitResult, { allowed: false }>;
+  if (!result.allowed) expect(result.reason).toBe("cap_reached");
+  return result as Extract<ResourceLimitResult, { allowed: false; reason: "cap_reached" }>;
+}
+
+/** Narrow a fail-closed (check_failed) denial. */
+function expectCheckFailed(
+  result: ResourceLimitResult,
+): Extract<ResourceLimitResult, { allowed: false; reason: "check_failed" }> {
+  expect(result.allowed).toBe(false);
+  if (!result.allowed) expect(result.reason).toBe("check_failed");
+  return result as Extract<ResourceLimitResult, { allowed: false; reason: "check_failed" }>;
 }
 
 describe("checkResourceLimit", () => {
@@ -457,10 +469,11 @@ describe("checkResourceLimit", () => {
     expect(result.allowed).toBe(true);
   });
 
-  it("blocks when workspace details fetch fails (fail closed)", async () => {
+  it("blocks when workspace details fetch fails (fail closed, check_failed)", async () => {
     mockWorkspaceDetailsShouldThrow = true;
-    const result = await checkResourceLimit("org-1", "seats", 100);
-    expect(result.allowed).toBe(false);
+    const denied = expectCheckFailed(await checkResourceLimit("org-1", "seats", 100));
+    // check_failed carries no `limit` — there's no meaningful cap to report.
+    expect(denied.errorMessage).toContain("Unable to verify plan limits");
   });
 
   // ── Free tier ─────────────────────────────────────────────────────
@@ -680,16 +693,22 @@ describe("checkChatIntegrationLimit", () => {
     expect(result.allowed).toBe(true);
   });
 
-  it("blocks (fail closed) when the count query throws", async () => {
+  it("blocks (fail closed, check_failed) when the count query throws", async () => {
     mockWorkspace = makeWorkspace({ plan_tier: "starter" });
     mockInternalQueryShouldThrow = true;
-    const result = await checkChatIntegrationLimit("org-1", SLACK);
-    expect(result.allowed).toBe(false);
-    // Distinct fail-closed contract — not the normal cap message.
-    if (!result.allowed) {
-      expect(result.errorMessage).toContain("Unable to verify plan limits");
-      expect(result.limit).toBe(0);
-    }
+    // Distinct fail-closed contract — check_failed (→ 503 "try again"), not
+    // cap_reached (→ 429 "upgrade"). No `limit` field.
+    const denied = expectCheckFailed(await checkChatIntegrationLimit("org-1", SLACK));
+    expect(denied.errorMessage).toContain("Unable to verify plan limits");
+  });
+
+  it("blocks (fail closed, check_failed) when the count query returns no row", async () => {
+    mockWorkspace = makeWorkspace({ plan_tier: "starter" });
+    // The aggregate SQL always returns one row; an empty result means a
+    // driver/query contract violation. Must NOT coerce to 0 (fail open).
+    mockInternalQueryResult = [];
+    const denied = expectCheckFailed(await checkChatIntegrationLimit("org-1", SLACK));
+    expect(denied.errorMessage).toContain("Unable to verify plan limits");
   });
 
   it("allows free tier regardless of count", async () => {
@@ -717,12 +736,9 @@ describe("checkChatIntegrationLimit", () => {
     mockWorkspace = makeWorkspace({ plan_tier: "starter" });
     // One other chat platform already installed; Slack is net-new → cap=1 hit.
     counts(1, 0);
-    const result = await checkChatIntegrationLimit("org-1", SLACK);
-    expect(result.allowed).toBe(false);
-    if (!result.allowed) {
-      expect(result.limit).toBe(1);
-      expect(result.errorMessage).toContain("1 chat integration");
-    }
+    const denied = expectResourceDenied(await checkChatIntegrationLimit("org-1", SLACK));
+    expect(denied.limit).toBe(1);
+    expect(denied.errorMessage).toContain("1 chat integration");
   });
 
   it("allows reconnecting an already-installed platform at the cap", async () => {

--- a/packages/api/src/lib/billing/__tests__/enforcement.test.ts
+++ b/packages/api/src/lib/billing/__tests__/enforcement.test.ts
@@ -20,6 +20,10 @@ let mockWorkspace: Record<string, unknown> | null = null;
 let mockUsage = { queryCount: 0, tokenCount: 0, activeUsers: 0, periodStart: "", periodEnd: "" };
 let mockWorkspaceDetailsShouldThrow = false;
 let mockUsageShouldThrow = false;
+/** Rows returned by the `internalQuery` mock (chat-integration count query). */
+let mockInternalQueryResult: unknown[] = [];
+/** When true, the `internalQuery` mock throws (count-query failure path). */
+let mockInternalQueryShouldThrow = false;
 
 mock.module("@atlas/api/lib/db/internal", () => ({
   hasInternalDB: () => mockHasInternalDB,
@@ -29,7 +33,10 @@ mock.module("@atlas/api/lib/db/internal", () => ({
   },
   getWorkspaceStatus: async () => mockWorkspace?.workspace_status ?? null,
   getInternalDB: () => ({ query: mock(() => Promise.resolve({ rows: [] })), end: mock(() => {}), on: mock(() => {}) }),
-  internalQuery: async () => [],
+  internalQuery: async () => {
+    if (mockInternalQueryShouldThrow) throw new Error("db error");
+    return mockInternalQueryResult;
+  },
   internalExecute: () => {},
   _resetPool: () => {},
   _resetCircuitBreaker: () => {},
@@ -66,7 +73,7 @@ mock.module("@atlas/api/lib/logger", () => ({
 
 // --- Import under test ---
 
-import { checkPlanLimits, checkResourceLimit, invalidatePlanCache, type PlanCheckResult, type ResourceLimitResult } from "@atlas/api/lib/billing/enforcement";
+import { checkChatIntegrationLimit, checkPlanLimits, checkResourceLimit, invalidatePlanCache, type PlanCheckResult, type ResourceLimitResult } from "@atlas/api/lib/billing/enforcement";
 
 /** Narrow a denied result for type-safe assertion access. */
 function expectDenied(result: PlanCheckResult): Extract<PlanCheckResult, { allowed: false }> {
@@ -426,6 +433,8 @@ describe("checkResourceLimit", () => {
     mockHasInternalDB = true;
     mockWorkspaceDetailsShouldThrow = false;
     mockWorkspace = null;
+    mockInternalQueryResult = [];
+    mockInternalQueryShouldThrow = false;
     invalidatePlanCache();
   });
 
@@ -580,5 +589,172 @@ describe("checkResourceLimit", () => {
     mockWorkspace = makeWorkspace({ plan_tier: "starter" });
     const result = await checkResourceLimit("org-1", "seats", 9);
     expect(result.allowed).toBe(true);
+  });
+
+  // ── Chat integrations (#2953) ─────────────────────────────────────
+
+  it("allows free tier unconditionally (chat_integrations)", async () => {
+    mockWorkspace = makeWorkspace({ plan_tier: "free" });
+    const result = await checkResourceLimit("org-1", "chat_integrations", 9999);
+    expect(result.allowed).toBe(true);
+  });
+
+  it("allows business tier unconditionally (chat_integrations)", async () => {
+    mockWorkspace = makeWorkspace({ plan_tier: "business" });
+    const result = await checkResourceLimit("org-1", "chat_integrations", 9999);
+    expect(result.allowed).toBe(true);
+  });
+
+  it("allows starter tier under chat-integration limit", async () => {
+    mockWorkspace = makeWorkspace({ plan_tier: "starter" });
+    // Starter plan maxChatIntegrations = 1
+    const result = await checkResourceLimit("org-1", "chat_integrations", 0);
+    expect(result.allowed).toBe(true);
+  });
+
+  it("blocks starter tier at chat-integration limit (singular label)", async () => {
+    mockWorkspace = makeWorkspace({ plan_tier: "starter" });
+    const denied = expectResourceDenied(
+      await checkResourceLimit("org-1", "chat_integrations", 1),
+    );
+    expect(denied.limit).toBe(1);
+    expect(denied.errorMessage).toContain("1 chat integration");
+    expect(denied.errorMessage).toContain("Upgrade");
+  });
+
+  it("blocks starter tier over chat-integration limit (grandfathered — still cannot add)", async () => {
+    mockWorkspace = makeWorkspace({ plan_tier: "starter" });
+    // Already over the new cap (e.g. installed before enforcement landed).
+    const denied = expectResourceDenied(
+      await checkResourceLimit("org-1", "chat_integrations", 5),
+    );
+    expect(denied.limit).toBe(1);
+  });
+
+  it("blocks pro tier at chat-integration limit (plural label)", async () => {
+    mockWorkspace = makeWorkspace({ plan_tier: "pro" });
+    // Pro plan maxChatIntegrations = 3
+    const denied = expectResourceDenied(
+      await checkResourceLimit("org-1", "chat_integrations", 3),
+    );
+    expect(denied.limit).toBe(3);
+    expect(denied.errorMessage).toContain("3 chat integrations");
+  });
+
+  it("allows pro tier under chat-integration limit", async () => {
+    mockWorkspace = makeWorkspace({ plan_tier: "pro" });
+    const result = await checkResourceLimit("org-1", "chat_integrations", 2);
+    expect(result.allowed).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// checkChatIntegrationLimit — counts workspace_plugins(pillar='chat') (#2953)
+// ---------------------------------------------------------------------------
+
+describe("checkChatIntegrationLimit", () => {
+  const SLACK = "catalog:slack";
+
+  beforeEach(() => {
+    mockHasInternalDB = true;
+    mockWorkspaceDetailsShouldThrow = false;
+    mockWorkspace = null;
+    mockInternalQueryResult = [];
+    mockInternalQueryShouldThrow = false;
+    invalidatePlanCache();
+  });
+
+  /** Shape the count-query row the way the SQL aliases it. */
+  function counts(others: number, thisCount: number): void {
+    mockInternalQueryResult = [{ others, this_count: thisCount }];
+  }
+
+  it("allows when no orgId provided", async () => {
+    const result = await checkChatIntegrationLimit(undefined, SLACK);
+    expect(result.allowed).toBe(true);
+  });
+
+  it("allows when no internal DB", async () => {
+    mockHasInternalDB = false;
+    const result = await checkChatIntegrationLimit("org-1", SLACK);
+    expect(result.allowed).toBe(true);
+  });
+
+  it("blocks (fail closed) when the count query throws", async () => {
+    mockWorkspace = makeWorkspace({ plan_tier: "starter" });
+    mockInternalQueryShouldThrow = true;
+    const result = await checkChatIntegrationLimit("org-1", SLACK);
+    expect(result.allowed).toBe(false);
+  });
+
+  it("allows free tier regardless of count", async () => {
+    mockWorkspace = makeWorkspace({ plan_tier: "free" });
+    counts(9, 0);
+    const result = await checkChatIntegrationLimit("org-1", SLACK);
+    expect(result.allowed).toBe(true);
+  });
+
+  it("allows business tier (unlimited) for a net-new platform", async () => {
+    mockWorkspace = makeWorkspace({ plan_tier: "business" });
+    counts(7, 0);
+    const result = await checkChatIntegrationLimit("org-1", SLACK);
+    expect(result.allowed).toBe(true);
+  });
+
+  it("allows starter first chat install (no others, not yet installed)", async () => {
+    mockWorkspace = makeWorkspace({ plan_tier: "starter" });
+    counts(0, 0);
+    const result = await checkChatIntegrationLimit("org-1", SLACK);
+    expect(result.allowed).toBe(true);
+  });
+
+  it("blocks starter from adding a 2nd distinct chat integration", async () => {
+    mockWorkspace = makeWorkspace({ plan_tier: "starter" });
+    // One other chat platform already installed; Slack is net-new → cap=1 hit.
+    counts(1, 0);
+    const result = await checkChatIntegrationLimit("org-1", SLACK);
+    expect(result.allowed).toBe(false);
+    if (!result.allowed) {
+      expect(result.limit).toBe(1);
+      expect(result.errorMessage).toContain("1 chat integration");
+    }
+  });
+
+  it("allows reconnecting an already-installed platform at the cap", async () => {
+    mockWorkspace = makeWorkspace({ plan_tier: "starter" });
+    // Slack itself is already installed (this_count=1) and is the only one.
+    counts(0, 1);
+    const result = await checkChatIntegrationLimit("org-1", SLACK);
+    expect(result.allowed).toBe(true);
+  });
+
+  it("allows reconnecting an existing platform even when grandfathered over cap", async () => {
+    mockWorkspace = makeWorkspace({ plan_tier: "starter" });
+    // Over the cap (others=2) but reconnecting a platform already owned.
+    counts(2, 1);
+    const result = await checkChatIntegrationLimit("org-1", SLACK);
+    expect(result.allowed).toBe(true);
+  });
+
+  it("blocks a grandfathered over-cap workspace from adding a net-new platform", async () => {
+    mockWorkspace = makeWorkspace({ plan_tier: "starter" });
+    // Over the cap and Slack is net-new (this_count=0) → blocked.
+    counts(2, 0);
+    const result = await checkChatIntegrationLimit("org-1", SLACK);
+    expect(result.allowed).toBe(false);
+  });
+
+  it("allows pro under cap (2 others, net-new third)", async () => {
+    mockWorkspace = makeWorkspace({ plan_tier: "pro" });
+    counts(2, 0);
+    const result = await checkChatIntegrationLimit("org-1", SLACK);
+    expect(result.allowed).toBe(true);
+  });
+
+  it("blocks pro at cap (3 others, net-new fourth)", async () => {
+    mockWorkspace = makeWorkspace({ plan_tier: "pro" });
+    counts(3, 0);
+    const result = await checkChatIntegrationLimit("org-1", SLACK);
+    expect(result.allowed).toBe(false);
   });
 });

--- a/packages/api/src/lib/billing/__tests__/enforcement.test.ts
+++ b/packages/api/src/lib/billing/__tests__/enforcement.test.ts
@@ -685,6 +685,11 @@ describe("checkChatIntegrationLimit", () => {
     mockInternalQueryShouldThrow = true;
     const result = await checkChatIntegrationLimit("org-1", SLACK);
     expect(result.allowed).toBe(false);
+    // Distinct fail-closed contract — not the normal cap message.
+    if (!result.allowed) {
+      expect(result.errorMessage).toContain("Unable to verify plan limits");
+      expect(result.limit).toBe(0);
+    }
   });
 
   it("allows free tier regardless of count", async () => {

--- a/packages/api/src/lib/billing/__tests__/plans.test.ts
+++ b/packages/api/src/lib/billing/__tests__/plans.test.ts
@@ -30,12 +30,14 @@ describe("billing/plans", () => {
       expect(isUnlimited(limits.tokenBudgetPerSeat)).toBe(true);
       expect(isUnlimited(limits.maxSeats)).toBe(true);
       expect(isUnlimited(limits.maxConnections)).toBe(true);
+      expect(isUnlimited(limits.maxChatIntegrations)).toBe(true);
     });
 
     it("business tier has unlimited seats and connections", () => {
       const limits = getPlanLimits("business");
       expect(isUnlimited(limits.maxSeats)).toBe(true);
       expect(isUnlimited(limits.maxConnections)).toBe(true);
+      expect(isUnlimited(limits.maxChatIntegrations)).toBe(true);
       expect(isUnlimited(limits.tokenBudgetPerSeat)).toBe(false);
       expect(limits.tokenBudgetPerSeat).toBe(15_000_000);
     });
@@ -46,6 +48,7 @@ describe("billing/plans", () => {
       expect(trial.tokenBudgetPerSeat).toBe(starter.tokenBudgetPerSeat);
       expect(trial.maxSeats).toBe(starter.maxSeats);
       expect(trial.maxConnections).toBe(starter.maxConnections);
+      expect(trial.maxChatIntegrations).toBe(starter.maxChatIntegrations);
     });
 
     it("starter tier has finite limits", () => {
@@ -54,6 +57,7 @@ describe("billing/plans", () => {
       expect(limits.tokenBudgetPerSeat).toBe(2_000_000);
       expect(limits.maxSeats).toBe(10);
       expect(limits.maxConnections).toBe(1);
+      expect(limits.maxChatIntegrations).toBe(1);
     });
 
     it("pro tier has expected limits", () => {
@@ -61,6 +65,7 @@ describe("billing/plans", () => {
       expect(limits.tokenBudgetPerSeat).toBe(5_000_000);
       expect(limits.maxSeats).toBe(25);
       expect(limits.maxConnections).toBe(3);
+      expect(limits.maxChatIntegrations).toBe(3);
     });
 
     it("trial definition includes trialDays", () => {

--- a/packages/api/src/lib/billing/enforcement.ts
+++ b/packages/api/src/lib/billing/enforcement.ts
@@ -516,12 +516,24 @@ export async function checkResourceLimit(
  *    "do the *other* chat platforms already fill the cap?".
  *
  * The cap counts every `workspace_plugins` row with `pillar = 'chat'`, so it
- * only constrains platforms whose install actually writes such a row. Which
- * platforms that is today (and the per-platform routing state) is tracked in
- * #2994; the Slack handler's missing-`pillar` INSERT is tracked in #2995.
+ * only constrains platforms whose install actually writes such a row. Today
+ * that is Slack (OAuth) and Discord — both write `pillar = 'chat'` rows. The
+ * legacy credential-store-only chat routes (Telegram / Teams / gchat /
+ * WhatsApp) don't yet write a `workspace_plugins` row, so they are neither
+ * counted nor capped until they pivot to the unified install record (#2994).
  *
  * Fails closed when the count can't be determined (query error or no row),
  * surfacing `reason: "check_failed"` — consistent with {@link checkResourceLimit}.
+ *
+ * KNOWN LIMITATION (TOCTOU): this is a read-only precheck; the caller does the
+ * `workspace_plugins` INSERT separately, so two *distinct* net-new platforms
+ * installed concurrently (e.g. Slack + Discord finishing OAuth in the same
+ * window while the workspace is one under its cap) can both pass and both
+ * write, landing one over the cap. The same-platform case can't breach it —
+ * the `workspace_plugins_singleton` partial unique index collapses a duplicate
+ * install into an UPSERT (a reconnect, always allowed). Closing the
+ * cross-platform window needs a per-workspace advisory lock / transaction
+ * around count+INSERT; tracked in #3001 (deferred — narrow window, heavy lift).
  */
 export async function checkChatIntegrationLimit(
   orgId: string | undefined,

--- a/packages/api/src/lib/billing/enforcement.ts
+++ b/packages/api/src/lib/billing/enforcement.ts
@@ -376,16 +376,25 @@ function isTrialExpired(workspace: WorkspaceRow): boolean {
 }
 
 // ---------------------------------------------------------------------------
-// Resource limit enforcement (seats, connections)
+// Resource limit enforcement (seats, connections, chat integrations)
 // ---------------------------------------------------------------------------
 
 export type ResourceLimitResult =
   | { allowed: true }
   | { allowed: false; errorMessage: string; limit: number };
 
+/** Plan-capped resources. Each maps to a `PlanLimits` field. */
+export type CappedResource = "seats" | "connections" | "chat_integrations";
+
 /**
- * Check whether adding one more resource (seat or connection) would
- * exceed the plan's limit for the given workspace.
+ * Check whether adding one more resource (seat, connection, or chat
+ * integration) would exceed the plan's limit for the given workspace.
+ *
+ * `currentCount` is the count of that resource the workspace already has;
+ * the check blocks when `currentCount >= cap`. Because the block fires
+ * only on *new* resource creation, a workspace that is already over a
+ * newly-introduced cap keeps what it has (grandfathered) and is simply
+ * unable to add more.
  *
  * Returns `{ allowed: true }` when the resource can be created, or
  * `{ allowed: false, errorMessage, limit }` when the plan cap has been
@@ -398,7 +407,7 @@ export type ResourceLimitResult =
  */
 export async function checkResourceLimit(
   orgId: string | undefined,
-  resource: "seats" | "connections",
+  resource: CappedResource,
   currentCount: number,
 ): Promise<ResourceLimitResult> {
   if (!orgId || !hasInternalDB()) {
@@ -429,16 +438,24 @@ export async function checkResourceLimit(
   }
 
   const limits = getPlanLimits(tier);
-  const cap = resource === "seats" ? limits.maxSeats : limits.maxConnections;
+  const cap =
+    resource === "seats"
+      ? limits.maxSeats
+      : resource === "connections"
+        ? limits.maxConnections
+        : limits.maxChatIntegrations;
 
   if (isUnlimited(cap)) {
     return { allowed: true };
   }
 
   if (currentCount >= cap) {
-    const resourceLabel = resource === "seats"
-      ? (cap === 1 ? "seat" : "seats")
-      : (cap === 1 ? "connection" : "connections");
+    const resourceLabel =
+      resource === "seats"
+        ? (cap === 1 ? "seat" : "seats")
+        : resource === "connections"
+          ? (cap === 1 ? "connection" : "connections")
+          : (cap === 1 ? "chat integration" : "chat integrations");
     log.warn(
       { orgId, resource, currentCount, limit: cap, tier },
       "Workspace at or over %s limit (%d/%d) — blocking resource creation",
@@ -454,5 +471,77 @@ export async function checkResourceLimit(
   }
 
   return { allowed: true };
+}
+
+// ---------------------------------------------------------------------------
+// Chat integration cap (#2953)
+// ---------------------------------------------------------------------------
+
+/**
+ * Check whether the workspace may install one more chat-platform
+ * integration without exceeding its plan's `maxChatIntegrations` cap
+ * (Starter 1 / Pro 3 / Business unlimited — marketed on /pricing).
+ *
+ * Counts the workspace's existing chat-pillar installs in
+ * `workspace_plugins` (the same store the connections cap counts) and
+ * delegates the cap comparison to {@link checkResourceLimit}.
+ *
+ * `catalogId` is the catalog row id of the platform being installed (e.g.
+ * `"catalog:slack"`). It matters for two reasons:
+ *  - **Reconnect is never blocked.** Re-authing a platform the workspace
+ *    already has does not increase the distinct count, so a workspace that
+ *    is already over a (grandfathered) cap can still re-auth what it owns.
+ *  - **The new platform is excluded from the count**, so the comparison is
+ *    "do the *other* chat platforms already fill the cap?".
+ *
+ * NOTE (#2953, ADR-0007 migration): this counts `workspace_plugins`, which
+ * today is written only by the chat install paths already pivoted to the
+ * unified pipeline — Slack OAuth and Discord. Telegram / Teams / Google
+ * Chat / WhatsApp still install via the legacy per-platform
+ * credential-store routes in `admin-integrations.ts` and do NOT write a
+ * `workspace_plugins` row, so they are not yet counted or enforced. The
+ * cap becomes complete once those routes pivot to the unified install
+ * record — tracked as a follow-up.
+ *
+ * Fails closed (blocks) when the count query errors, consistent with
+ * {@link checkResourceLimit}.
+ */
+export async function checkChatIntegrationLimit(
+  orgId: string | undefined,
+  catalogId: string,
+): Promise<ResourceLimitResult> {
+  if (!orgId || !hasInternalDB()) {
+    return { allowed: true };
+  }
+
+  let counts: { others: number; this_count: number } | undefined;
+  try {
+    const rows = await internalQuery<{ others: number; this_count: number }>(
+      `SELECT
+         COUNT(*) FILTER (WHERE catalog_id <> $2)::int AS others,
+         COUNT(*) FILTER (WHERE catalog_id = $2)::int  AS this_count
+       FROM workspace_plugins
+       WHERE workspace_id = $1
+         AND pillar = 'chat'
+         AND status <> 'archived'`,
+      [orgId, catalogId],
+    );
+    counts = rows[0];
+  } catch (err) {
+    log.error(
+      { err: err instanceof Error ? err.message : String(err), orgId, catalogId },
+      "Failed to count chat integrations for limit check — blocking as precaution",
+    );
+    return { allowed: false, errorMessage: "Unable to verify plan limits. Please try again.", limit: 0 };
+  }
+
+  // Reconnecting an already-installed platform never increases the distinct
+  // count — always allow so a grandfathered over-cap workspace can re-auth
+  // what it already has.
+  if ((counts?.this_count ?? 0) > 0) {
+    return { allowed: true };
+  }
+
+  return checkResourceLimit(orgId, "chat_integrations", counts?.others ?? 0);
 }
 

--- a/packages/api/src/lib/billing/enforcement.ts
+++ b/packages/api/src/lib/billing/enforcement.ts
@@ -438,24 +438,25 @@ export async function checkResourceLimit(
   }
 
   const limits = getPlanLimits(tier);
-  const cap =
-    resource === "seats"
-      ? limits.maxSeats
-      : resource === "connections"
-        ? limits.maxConnections
-        : limits.maxChatIntegrations;
+  // Record (not a ternary chain) so a new CappedResource member is a
+  // compile error here until it's mapped to a PlanLimits field — no silent
+  // fall-through into the wrong cap/label.
+  const cap = ({
+    seats: limits.maxSeats,
+    connections: limits.maxConnections,
+    chat_integrations: limits.maxChatIntegrations,
+  } satisfies Record<CappedResource, number>)[resource];
 
   if (isUnlimited(cap)) {
     return { allowed: true };
   }
 
   if (currentCount >= cap) {
-    const resourceLabel =
-      resource === "seats"
-        ? (cap === 1 ? "seat" : "seats")
-        : resource === "connections"
-          ? (cap === 1 ? "connection" : "connections")
-          : (cap === 1 ? "chat integration" : "chat integrations");
+    const resourceLabel = ({
+      seats: cap === 1 ? "seat" : "seats",
+      connections: cap === 1 ? "connection" : "connections",
+      chat_integrations: cap === 1 ? "chat integration" : "chat integrations",
+    } satisfies Record<CappedResource, string>)[resource];
     log.warn(
       { orgId, resource, currentCount, limit: cap, tier },
       "Workspace at or over %s limit (%d/%d) — blocking resource creation",
@@ -494,14 +495,17 @@ export async function checkResourceLimit(
  *  - **The new platform is excluded from the count**, so the comparison is
  *    "do the *other* chat platforms already fill the cap?".
  *
- * NOTE (#2953, ADR-0007 migration): this counts `workspace_plugins`, which
- * today is written only by the chat install paths already pivoted to the
- * unified pipeline — Slack OAuth and Discord. Telegram / Teams / Google
- * Chat / WhatsApp still install via the legacy per-platform
- * credential-store routes in `admin-integrations.ts` and do NOT write a
- * `workspace_plugins` row, so they are not yet counted or enforced. The
- * cap becomes complete once those routes pivot to the unified install
- * record — tracked as a follow-up.
+ * NOTE (#2953, ADR-0007 migration): this counts every `workspace_plugins`
+ * row with `pillar = 'chat'`, so any platform whose install writes such a
+ * row is counted. The blocking call (this function) is wired only into the
+ * two chat handlers reached by a live install route that writes a chat row:
+ * Slack (OAuth callback) and Discord (static-bot callback). The other chat
+ * platforms — Telegram / Teams / Google Chat / WhatsApp — install today via
+ * the legacy per-platform routes in `admin-integrations.ts`, which persist
+ * only the credential store; their unified static-bot handlers DO write a
+ * `pillar='chat'` row but are not yet reached by any live route. Net effect:
+ * those four are neither counted nor capped today. The cap completes once
+ * they pivot to the unified install record — tracked in #2994.
  *
  * Fails closed (blocks) when the count query errors, consistent with
  * {@link checkResourceLimit}.

--- a/packages/api/src/lib/billing/enforcement.ts
+++ b/packages/api/src/lib/billing/enforcement.ts
@@ -379,9 +379,25 @@ function isTrialExpired(workspace: WorkspaceRow): boolean {
 // Resource limit enforcement (seats, connections, chat integrations)
 // ---------------------------------------------------------------------------
 
+/**
+ * Outcome of a resource-limit check.
+ *
+ * The two `allowed: false` arms are deliberately distinct so callers can
+ * map them to different HTTP statuses — mirroring the `plan_limit_exceeded`
+ * (429) vs `billing_check_failed` (503) split in {@link checkPlanLimits}:
+ *
+ *  - `cap_reached` — the workspace is genuinely at/over its plan cap. The
+ *    actionable response is "upgrade your plan" (429). Carries `limit`, the
+ *    cap that was hit.
+ *  - `check_failed` — we could NOT determine the count (DB error, missing
+ *    row). Fail-closed: the request is blocked, but the actionable response
+ *    is "try again" (503), NOT "upgrade your plan". Carries no `limit` —
+ *    there is no meaningful cap to report.
+ */
 export type ResourceLimitResult =
   | { allowed: true }
-  | { allowed: false; errorMessage: string; limit: number };
+  | { allowed: false; reason: "cap_reached"; errorMessage: string; limit: number }
+  | { allowed: false; reason: "check_failed"; errorMessage: string };
 
 /** Plan-capped resources. Each maps to a `PlanLimits` field. */
 export type CappedResource = "seats" | "connections" | "chat_integrations";
@@ -396,9 +412,10 @@ export type CappedResource = "seats" | "connections" | "chat_integrations";
  * newly-introduced cap keeps what it has (grandfathered) and is simply
  * unable to add more.
  *
- * Returns `{ allowed: true }` when the resource can be created, or
- * `{ allowed: false, errorMessage, limit }` when the plan cap has been
- * reached.
+ * Returns `{ allowed: true }` when the resource can be created,
+ * `{ allowed: false, reason: "cap_reached", ... }` when the plan cap has
+ * been reached, or `{ allowed: false, reason: "check_failed", ... }` when
+ * the workspace lookup failed and we fail closed (see {@link ResourceLimitResult}).
  *
  * Enforcement is skipped (always allowed) when:
  * - No internal DB is configured (self-hosted without managed auth)
@@ -422,8 +439,10 @@ export async function checkResourceLimit(
       { err: err instanceof Error ? err.message : String(err), orgId, resource },
       "Failed to fetch workspace for resource limit check — blocking as precaution",
     );
-    // Fail closed: consistent with checkPlanLimits behavior per CLAUDE.md
-    return { allowed: false, errorMessage: "Unable to verify plan limits. Please try again.", limit: 0 };
+    // Fail closed: consistent with checkPlanLimits behavior per CLAUDE.md.
+    // `check_failed` (not `cap_reached`) so the caller surfaces a 503
+    // "try again", not a misleading 429 "upgrade your plan".
+    return { allowed: false, reason: "check_failed", errorMessage: "Unable to verify plan limits. Please try again." };
   }
 
   if (!workspace) {
@@ -466,6 +485,7 @@ export async function checkResourceLimit(
     );
     return {
       allowed: false,
+      reason: "cap_reached",
       errorMessage: `Your ${tier} plan allows up to ${cap} ${resourceLabel}. Upgrade to add more.`,
       limit: cap,
     };
@@ -480,8 +500,8 @@ export async function checkResourceLimit(
 
 /**
  * Check whether the workspace may install one more chat-platform
- * integration without exceeding its plan's `maxChatIntegrations` cap
- * (Starter 1 / Pro 3 / Business unlimited — marketed on /pricing).
+ * integration without exceeding its plan's `maxChatIntegrations` cap (the
+ * marketed per-tier numbers live next to the values in `billing/plans.ts`).
  *
  * Counts the workspace's existing chat-pillar installs in
  * `workspace_plugins` (the same store the connections cap counts) and
@@ -495,20 +515,13 @@ export async function checkResourceLimit(
  *  - **The new platform is excluded from the count**, so the comparison is
  *    "do the *other* chat platforms already fill the cap?".
  *
- * NOTE (#2953, ADR-0007 migration): this counts every `workspace_plugins`
- * row with `pillar = 'chat'`, so any platform whose install writes such a
- * row is counted. The blocking call (this function) is wired only into the
- * two chat handlers reached by a live install route that writes a chat row:
- * Slack (OAuth callback) and Discord (static-bot callback). The other chat
- * platforms — Telegram / Teams / Google Chat / WhatsApp — install today via
- * the legacy per-platform routes in `admin-integrations.ts`, which persist
- * only the credential store; their unified static-bot handlers DO write a
- * `pillar='chat'` row but are not yet reached by any live route. Net effect:
- * those four are neither counted nor capped today. The cap completes once
- * they pivot to the unified install record — tracked in #2994.
+ * The cap counts every `workspace_plugins` row with `pillar = 'chat'`, so it
+ * only constrains platforms whose install actually writes such a row. Which
+ * platforms that is today (and the per-platform routing state) is tracked in
+ * #2994; the Slack handler's missing-`pillar` INSERT is tracked in #2995.
  *
- * Fails closed (blocks) when the count query errors, consistent with
- * {@link checkResourceLimit}.
+ * Fails closed when the count can't be determined (query error or no row),
+ * surfacing `reason: "check_failed"` — consistent with {@link checkResourceLimit}.
  */
 export async function checkChatIntegrationLimit(
   orgId: string | undefined,
@@ -536,16 +549,28 @@ export async function checkChatIntegrationLimit(
       { err: err instanceof Error ? err.message : String(err), orgId, catalogId },
       "Failed to count chat integrations for limit check — blocking as precaution",
     );
-    return { allowed: false, errorMessage: "Unable to verify plan limits. Please try again.", limit: 0 };
+    return { allowed: false, reason: "check_failed", errorMessage: "Unable to verify plan limits. Please try again." };
+  }
+
+  // The aggregate SQL above always returns exactly one row, so a missing
+  // row means the driver/query contract was violated. Fail closed rather
+  // than coerce the absent count to 0 — `?? 0` would silently breach the
+  // cap (treat "unknown" as "no other integrations → allow").
+  if (!counts) {
+    log.error(
+      { orgId, catalogId },
+      "Chat-integration count query returned no row — blocking as precaution",
+    );
+    return { allowed: false, reason: "check_failed", errorMessage: "Unable to verify plan limits. Please try again." };
   }
 
   // Reconnecting an already-installed platform never increases the distinct
   // count — always allow so a grandfathered over-cap workspace can re-auth
   // what it already has.
-  if ((counts?.this_count ?? 0) > 0) {
+  if (counts.this_count > 0) {
     return { allowed: true };
   }
 
-  return checkResourceLimit(orgId, "chat_integrations", counts?.others ?? 0);
+  return checkResourceLimit(orgId, "chat_integrations", counts.others);
 }
 

--- a/packages/api/src/lib/billing/plans.ts
+++ b/packages/api/src/lib/billing/plans.ts
@@ -35,6 +35,13 @@ export interface PlanLimits {
   maxSeats: number;
   /** Max datasource connections. -1 = unlimited. */
   maxConnections: number;
+  /**
+   * Max distinct chat-platform integrations (Slack, Teams, Discord, Google
+   * Chat, Telegram, WhatsApp). -1 = unlimited. Marketed on /pricing
+   * (Starter 1 / Pro 3 / Business "All 8"); enforced at chat install time
+   * by `checkChatIntegrationLimit` (#2953).
+   */
+  maxChatIntegrations: number;
 }
 
 export interface PlanDefinition {
@@ -78,6 +85,7 @@ const PLANS: Record<PlanTier, PlanDefinition> = {
       tokenBudgetPerSeat: UNLIMITED,
       maxSeats: UNLIMITED,
       maxConnections: UNLIMITED,
+      maxChatIntegrations: UNLIMITED,
     },
     features: { ...NO_FEATURES },
   },
@@ -96,6 +104,7 @@ const PLANS: Record<PlanTier, PlanDefinition> = {
       tokenBudgetPerSeat: 2_000_000,
       maxSeats: 10,
       maxConnections: 1,
+      maxChatIntegrations: 1,
     },
     features: { ...NO_FEATURES },
   },
@@ -109,6 +118,7 @@ const PLANS: Record<PlanTier, PlanDefinition> = {
       tokenBudgetPerSeat: 2_000_000,
       maxSeats: 10,
       maxConnections: 1,
+      maxChatIntegrations: 1,
     },
     features: { ...NO_FEATURES },
   },
@@ -122,6 +132,7 @@ const PLANS: Record<PlanTier, PlanDefinition> = {
       tokenBudgetPerSeat: 5_000_000,
       maxSeats: 25,
       maxConnections: 3,
+      maxChatIntegrations: 3,
     },
     features: {
       customDomain: true,
@@ -140,6 +151,7 @@ const PLANS: Record<PlanTier, PlanDefinition> = {
       tokenBudgetPerSeat: 15_000_000,
       maxSeats: UNLIMITED,
       maxConnections: UNLIMITED,
+      maxChatIntegrations: UNLIMITED,
     },
     features: {
       customDomain: true,
@@ -205,6 +217,7 @@ export function getStripePlans(): Array<{
         tokenBudgetPerSeat: PLANS.starter.limits.tokenBudgetPerSeat,
         seats: PLANS.starter.limits.maxSeats,
         connections: PLANS.starter.limits.maxConnections,
+        chatIntegrations: PLANS.starter.limits.maxChatIntegrations,
       },
       freeTrial: { days: TRIAL_DAYS },
     });
@@ -220,6 +233,7 @@ export function getStripePlans(): Array<{
         tokenBudgetPerSeat: PLANS.pro.limits.tokenBudgetPerSeat,
         seats: PLANS.pro.limits.maxSeats,
         connections: PLANS.pro.limits.maxConnections,
+        chatIntegrations: PLANS.pro.limits.maxChatIntegrations,
       },
       freeTrial: { days: TRIAL_DAYS },
     });
@@ -235,6 +249,7 @@ export function getStripePlans(): Array<{
         tokenBudgetPerSeat: PLANS.business.limits.tokenBudgetPerSeat,
         seats: UNLIMITED,
         connections: UNLIMITED,
+        chatIntegrations: UNLIMITED,
       },
       freeTrial: { days: TRIAL_DAYS },
     });

--- a/packages/api/src/lib/billing/plans.ts
+++ b/packages/api/src/lib/billing/plans.ts
@@ -36,10 +36,14 @@ export interface PlanLimits {
   /** Max datasource connections. -1 = unlimited. */
   maxConnections: number;
   /**
-   * Max distinct chat-platform integrations (Slack, Teams, Discord, Google
-   * Chat, Telegram, WhatsApp). -1 = unlimited. Marketed on /pricing
-   * (Starter 1 / Pro 3 / Business "All 8"); enforced at chat install time
-   * by `checkChatIntegrationLimit` (#2953).
+   * Max distinct chat-pillar integrations a workspace may install. -1 =
+   * unlimited. The cap counts `workspace_plugins WHERE pillar = 'chat'` —
+   * the six chat platforms (Slack, Teams, Discord, Google Chat, Telegram,
+   * WhatsApp). The "All 8 chat integrations" figure marketed on /pricing
+   * also counts Linear + GitHub, but those are `pillar = 'action'`, so they
+   * do NOT consume a chat-integration slot. Marketed tiers: Starter 1 /
+   * Pro 3 / Business unlimited. Enforced at chat install time by
+   * `checkChatIntegrationLimit` (#2953).
    */
   maxChatIntegrations: number;
 }

--- a/packages/api/src/lib/effect/__tests__/hono.test.ts
+++ b/packages/api/src/lib/effect/__tests__/hono.test.ts
@@ -63,6 +63,7 @@ const {
   InstallNotFoundError,
   InvalidInstallIdError,
   ChatIntegrationLimitError,
+  BillingCheckFailedError,
 } = await import("../errors");
 
 // ---------------------------------------------------------------------------
@@ -463,6 +464,19 @@ describe("mapTaggedError", () => {
     expect(result.status).toBe(429);
     expect(result.code).toBe("plan_limit_exceeded");
     expect(result.body).toEqual({ limit: 1 });
+  });
+
+  it("maps BillingCheckFailedError to 503 billing_check_failed (not a 429 upgrade) (#2953)", () => {
+    const result = mapTaggedError(
+      new BillingCheckFailedError({
+        message: "Unable to verify plan limits. Please try again.",
+        workspaceId: "org-1",
+      }),
+    );
+    expect(result.status).toBe(503);
+    expect(result.code).toBe("billing_check_failed");
+    // No `limit` in the body — there's no meaningful cap to report.
+    expect(result.body).toBeUndefined();
   });
 });
 

--- a/packages/api/src/lib/effect/__tests__/hono.test.ts
+++ b/packages/api/src/lib/effect/__tests__/hono.test.ts
@@ -62,6 +62,7 @@ const {
   ConfigSchemaError,
   InstallNotFoundError,
   InvalidInstallIdError,
+  ChatIntegrationLimitError,
 } = await import("../errors");
 
 // ---------------------------------------------------------------------------
@@ -449,6 +450,19 @@ describe("mapTaggedError", () => {
       catalogSlug: "postgres",
       pillar: "datasource",
     });
+  });
+
+  it("maps ChatIntegrationLimitError to 429 plan_limit_exceeded with the cap in the body (#2953)", () => {
+    const result = mapTaggedError(
+      new ChatIntegrationLimitError({
+        message: "Your starter plan allows up to 1 chat integration. Upgrade to add more.",
+        workspaceId: "org-1",
+        limit: 1,
+      }),
+    );
+    expect(result.status).toBe(429);
+    expect(result.code).toBe("plan_limit_exceeded");
+    expect(result.body).toEqual({ limit: 1 });
   });
 });
 

--- a/packages/api/src/lib/effect/errors.ts
+++ b/packages/api/src/lib/effect/errors.ts
@@ -795,18 +795,23 @@ export class InvalidInstallIdError extends Data.TaggedError("InvalidInstallIdErr
 
 /**
  * A chat-platform install was refused because the workspace's plan tier has
- * reached its chat-integration cap (Starter 1 / Pro 3 / Business unlimited
- * — see `billing/plans.ts:maxChatIntegrations`). Thrown by the chat install
+ * reached its chat-integration cap (per-tier numbers live in
+ * `billing/plans.ts:maxChatIntegrations`). Thrown by the chat install
  * handlers (`slack-oauth-handler`, `discord-static-bot-handler`) before the
  * `workspace_plugins` INSERT, after `checkChatIntegrationLimit` counts the
  * workspace's existing chat installs (#2953).
  *
- * Maps to HTTP 429 `plan_limit_exceeded` — the same wire shape the
- * connections cap surfaces from `admin-connections` (the seats cap is also
+ * Maps to HTTP 429 `plan_limit_exceeded` — the same status and wire code
+ * the connections cap surfaces from `admin-connections`, plus a `limit`
+ * field in the body (the connections cap omits it). The seats cap is also
  * 429 but via Better Auth's `APIError` in `lib/auth/invitations.ts`, a
- * different envelope). Reconnecting an already-installed platform is never
+ * different envelope. Reconnecting an already-installed platform is never
  * refused (it does not increase the distinct count), so a grandfathered
  * over-cap workspace can still re-auth what it already has.
+ *
+ * Distinct from {@link BillingCheckFailedError}: this means the cap was
+ * genuinely hit (429 "upgrade"); that means we couldn't read the count and
+ * failed closed (503 "try again").
  *
  * `workspaceId` is forensic/log context only — not read by `mapTaggedError`.
  */
@@ -815,6 +820,26 @@ export class ChatIntegrationLimitError extends Data.TaggedError("ChatIntegration
   readonly workspaceId: string;
   /** The plan tier's chat-integration cap that was hit. */
   readonly limit: number;
+}> {}
+
+/**
+ * A chat-platform install was blocked because Atlas could NOT determine the
+ * workspace's current chat-integration count (internal-DB error, or the
+ * count query returned no row). The check fails closed — the install is
+ * refused — but this is a transient infrastructure fault, not a plan-cap
+ * hit, so it must NOT tell the user to "upgrade your plan".
+ *
+ * Maps to HTTP 503 `billing_check_failed` — mirroring the same-named arm of
+ * {@link import("@atlas/api/lib/billing/enforcement").PlanCheckResult} that
+ * the chat/query routes already surface for token-budget checks. The
+ * actionable message is "try again". Counterpart to
+ * {@link ChatIntegrationLimitError} (the genuine-cap-hit 429).
+ *
+ * `workspaceId` is forensic/log context only — not read by `mapTaggedError`.
+ */
+export class BillingCheckFailedError extends Data.TaggedError("BillingCheckFailedError")<{
+  readonly message: string;
+  readonly workspaceId: string;
 }> {}
 
 // ── Scheduler ──────────────────────────────────────────────────────
@@ -892,6 +917,7 @@ export type AtlasError =
   | InstallNotFoundError
   | InvalidInstallIdError
   | ChatIntegrationLimitError
+  | BillingCheckFailedError
   | SchedulerTaskTimeoutError
   | SchedulerExecutionError
   | DeliveryError
@@ -968,6 +994,7 @@ export const ATLAS_ERROR_TAG_LIST = [
   "InstallNotFoundError",
   "InvalidInstallIdError",
   "ChatIntegrationLimitError",
+  "BillingCheckFailedError",
   "SchedulerTaskTimeoutError",
   "SchedulerExecutionError",
   "DeliveryError",

--- a/packages/api/src/lib/effect/errors.ts
+++ b/packages/api/src/lib/effect/errors.ts
@@ -793,6 +793,28 @@ export class InvalidInstallIdError extends Data.TaggedError("InvalidInstallIdErr
   readonly reason: "pattern" | "reserved";
 }> {}
 
+/**
+ * A chat-platform install was refused because the workspace's plan tier has
+ * reached its chat-integration cap (Starter 1 / Pro 3 / Business unlimited
+ * — see `billing/plans.ts:maxChatIntegrations`). Thrown by the chat install
+ * handlers (`slack-oauth-handler`, `discord-static-bot-handler`) before the
+ * `workspace_plugins` INSERT, after `checkChatIntegrationLimit` counts the
+ * workspace's existing chat installs (#2953).
+ *
+ * Maps to HTTP 429 `plan_limit_exceeded` — the same wire shape the
+ * seats/connections caps surface from `admin-connections` / `invitations`
+ * — so the admin UI's upgrade affordance is uniform. Reconnecting an
+ * already-installed platform is never refused (it does not increase the
+ * distinct count), so a grandfathered over-cap workspace can still re-auth
+ * what it already has.
+ */
+export class ChatIntegrationLimitError extends Data.TaggedError("ChatIntegrationLimitError")<{
+  readonly message: string;
+  readonly workspaceId: string;
+  /** The plan tier's chat-integration cap that was hit. */
+  readonly limit: number;
+}> {}
+
 // ── Scheduler ──────────────────────────────────────────────────────
 
 /** Scheduled task execution timed out. */
@@ -867,6 +889,7 @@ export type AtlasError =
   | CatalogNotFoundError
   | InstallNotFoundError
   | InvalidInstallIdError
+  | ChatIntegrationLimitError
   | SchedulerTaskTimeoutError
   | SchedulerExecutionError
   | DeliveryError
@@ -942,6 +965,7 @@ export const ATLAS_ERROR_TAG_LIST = [
   "CatalogNotFoundError",
   "InstallNotFoundError",
   "InvalidInstallIdError",
+  "ChatIntegrationLimitError",
   "SchedulerTaskTimeoutError",
   "SchedulerExecutionError",
   "DeliveryError",

--- a/packages/api/src/lib/effect/errors.ts
+++ b/packages/api/src/lib/effect/errors.ts
@@ -802,11 +802,13 @@ export class InvalidInstallIdError extends Data.TaggedError("InvalidInstallIdErr
  * workspace's existing chat installs (#2953).
  *
  * Maps to HTTP 429 `plan_limit_exceeded` — the same wire shape the
- * seats/connections caps surface from `admin-connections` / `invitations`
- * — so the admin UI's upgrade affordance is uniform. Reconnecting an
- * already-installed platform is never refused (it does not increase the
- * distinct count), so a grandfathered over-cap workspace can still re-auth
- * what it already has.
+ * connections cap surfaces from `admin-connections` (the seats cap is also
+ * 429 but via Better Auth's `APIError` in `lib/auth/invitations.ts`, a
+ * different envelope). Reconnecting an already-installed platform is never
+ * refused (it does not increase the distinct count), so a grandfathered
+ * over-cap workspace can still re-auth what it already has.
+ *
+ * `workspaceId` is forensic/log context only — not read by `mapTaggedError`.
  */
 export class ChatIntegrationLimitError extends Data.TaggedError("ChatIntegrationLimitError")<{
   readonly message: string;

--- a/packages/api/src/lib/effect/hono.ts
+++ b/packages/api/src/lib/effect/hono.ts
@@ -86,6 +86,7 @@ type HttpErrorCode =
   | "unprocessable_entity"
   | "rate_limited"
   | "conversation_budget_exceeded"
+  | "plan_limit_exceeded"
   | "upstream_error"
   | "service_unavailable"
   | "enterprise_load_failed"
@@ -345,6 +346,17 @@ export function mapTaggedError(error: AtlasError): HttpErrorMapping {
         status: 429,
         code: "conversation_budget_exceeded",
         message: error.message,
+      };
+    // #2953 — chat-integration cap reached for the workspace's plan tier.
+    // 429 + `plan_limit_exceeded` mirrors the seats/connections caps that
+    // `admin-connections` / `invitations` surface manually, so the admin
+    // UI's upgrade affordance is uniform. Body carries the cap that was hit.
+    case "ChatIntegrationLimitError":
+      return {
+        status: 429,
+        code: "plan_limit_exceeded",
+        message: error.message,
+        body: { limit: error.limit },
       };
 
     // ── 502 Bad Gateway — upstream DB error ──────────────────────

--- a/packages/api/src/lib/effect/hono.ts
+++ b/packages/api/src/lib/effect/hono.ts
@@ -87,6 +87,7 @@ type HttpErrorCode =
   | "rate_limited"
   | "conversation_budget_exceeded"
   | "plan_limit_exceeded"
+  | "billing_check_failed"
   | "upstream_error"
   | "service_unavailable"
   | "enterprise_load_failed"
@@ -359,6 +360,17 @@ export function mapTaggedError(error: AtlasError): HttpErrorMapping {
         code: "plan_limit_exceeded",
         message: error.message,
         body: { limit: error.limit },
+      };
+    // #2953 — the chat-integration count could not be determined (DB error
+    // / missing row), so the cap check failed closed. This is a transient
+    // infra fault, NOT a plan-cap hit: 503 + `billing_check_failed` (same
+    // code the token-budget check surfaces) so the user sees "try again",
+    // not a misleading "upgrade your plan".
+    case "BillingCheckFailedError":
+      return {
+        status: 503,
+        code: "billing_check_failed",
+        message: error.message,
       };
 
     // ── 502 Bad Gateway — upstream DB error ──────────────────────

--- a/packages/api/src/lib/effect/hono.ts
+++ b/packages/api/src/lib/effect/hono.ts
@@ -348,9 +348,11 @@ export function mapTaggedError(error: AtlasError): HttpErrorMapping {
         message: error.message,
       };
     // #2953 — chat-integration cap reached for the workspace's plan tier.
-    // 429 + `plan_limit_exceeded` mirrors the seats/connections caps that
-    // `admin-connections` / `invitations` surface manually, so the admin
-    // UI's upgrade affordance is uniform. Body carries the cap that was hit.
+    // 429 + `plan_limit_exceeded` matches the connections cap
+    // (`admin-connections.ts` returns the same code/status manually). The
+    // seats cap is also 429 but via Better Auth's `APIError`
+    // (`lib/auth/invitations.ts`), so its envelope differs. Body carries
+    // the cap that was hit.
     case "ChatIntegrationLimitError":
       return {
         status: 429,

--- a/packages/api/src/lib/integrations/install/__tests__/discord-static-bot-handler.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/discord-static-bot-handler.test.ts
@@ -45,9 +45,15 @@ mock.module("@atlas/api/lib/db/internal", () => ({
 // The chat-integration cap (#2953) is exercised in
 // `billing/__tests__/enforcement.test.ts`; stub it to "allowed" here so
 // these handler tests stay focused on the install contract and their
-// `mockInternalQuery` call counts reflect only the UPSERT.
+// `mockInternalQuery` call counts reflect only the UPSERT. The "blocks at
+// cap" test below overrides it via `mockImplementationOnce`.
+const mockCheckChatLimit: Mock<
+  (orgId: string | undefined, catalogId: string) =>
+    Promise<{ allowed: true } | { allowed: false; errorMessage: string; limit: number }>
+> = mock(() => Promise.resolve({ allowed: true as const }));
+
 mock.module("@atlas/api/lib/billing/enforcement", () => ({
-  checkChatIntegrationLimit: mock(() => Promise.resolve({ allowed: true as const })),
+  checkChatIntegrationLimit: mockCheckChatLimit,
 }));
 
 // ---------------------------------------------------------------------------
@@ -94,6 +100,8 @@ function setFetchNetworkError(): void {
 beforeEach(() => {
   mockInternalQuery.mockClear();
   mockInternalQuery.mockImplementation(() => Promise.resolve([{ id: "install-discord-row-1" }]));
+  mockCheckChatLimit.mockClear();
+  mockCheckChatLimit.mockImplementation(() => Promise.resolve({ allowed: true as const }));
   fetchCalls.length = 0;
   setFetchOk();
 });
@@ -234,6 +242,32 @@ describe("DiscordStaticBotInstallHandler.confirmInstall — reachability verific
     await expect(handler.confirmInstall(wsid, "123456789012345678")).rejects.toThrow(
       /unexpected response shape/i,
     );
+    expect(mockInternalQuery).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Chat-integration cap (#2953)
+// ---------------------------------------------------------------------------
+
+describe("DiscordStaticBotInstallHandler.confirmInstall — chat-integration cap", () => {
+  it("throws ChatIntegrationLimitError and writes no install row when at cap", async () => {
+    mockCheckChatLimit.mockImplementationOnce(() =>
+      Promise.resolve({
+        allowed: false as const,
+        errorMessage: "Your starter plan allows up to 1 chat integration. Upgrade to add more.",
+        limit: 1,
+      }),
+    );
+    const handler = new DiscordStaticBotInstallHandler({ botToken: "tkn", clientId: "111" });
+
+    await expect(handler.confirmInstall(wsid, "123456789012345678")).rejects.toMatchObject({
+      _tag: "ChatIntegrationLimitError",
+      limit: 1,
+    });
+
+    // Cap is checked after reachability but before the UPSERT.
+    expect(mockCheckChatLimit).toHaveBeenCalledWith(wsid, DISCORD_CATALOG_ID);
     expect(mockInternalQuery).not.toHaveBeenCalled();
   });
 });

--- a/packages/api/src/lib/integrations/install/__tests__/discord-static-bot-handler.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/discord-static-bot-handler.test.ts
@@ -42,6 +42,14 @@ mock.module("@atlas/api/lib/db/internal", () => ({
   getInternalDB: mock(() => ({ query: mock(() => Promise.resolve({ rows: [] })) })),
 }));
 
+// The chat-integration cap (#2953) is exercised in
+// `billing/__tests__/enforcement.test.ts`; stub it to "allowed" here so
+// these handler tests stay focused on the install contract and their
+// `mockInternalQuery` call counts reflect only the UPSERT.
+mock.module("@atlas/api/lib/billing/enforcement", () => ({
+  checkChatIntegrationLimit: mock(() => Promise.resolve({ allowed: true as const })),
+}));
+
 // ---------------------------------------------------------------------------
 // Test scaffolding
 // ---------------------------------------------------------------------------

--- a/packages/api/src/lib/integrations/install/__tests__/discord-static-bot-handler.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/discord-static-bot-handler.test.ts
@@ -49,7 +49,11 @@ mock.module("@atlas/api/lib/db/internal", () => ({
 // cap" test below overrides it via `mockImplementationOnce`.
 const mockCheckChatLimit: Mock<
   (orgId: string | undefined, catalogId: string) =>
-    Promise<{ allowed: true } | { allowed: false; errorMessage: string; limit: number }>
+    Promise<
+      | { allowed: true }
+      | { allowed: false; reason: "cap_reached"; errorMessage: string; limit: number }
+      | { allowed: false; reason: "check_failed"; errorMessage: string }
+    >
 > = mock(() => Promise.resolve({ allowed: true as const }));
 
 mock.module("@atlas/api/lib/billing/enforcement", () => ({
@@ -255,6 +259,7 @@ describe("DiscordStaticBotInstallHandler.confirmInstall — chat-integration cap
     mockCheckChatLimit.mockImplementationOnce(() =>
       Promise.resolve({
         allowed: false as const,
+        reason: "cap_reached" as const,
         errorMessage: "Your starter plan allows up to 1 chat integration. Upgrade to add more.",
         limit: 1,
       }),
@@ -268,6 +273,24 @@ describe("DiscordStaticBotInstallHandler.confirmInstall — chat-integration cap
 
     // Cap is checked after reachability but before the UPSERT.
     expect(mockCheckChatLimit).toHaveBeenCalledWith(wsid, DISCORD_CATALOG_ID);
+    expect(mockInternalQuery).not.toHaveBeenCalled();
+  });
+
+  it("throws BillingCheckFailedError (not the cap error) when the count check fails closed", async () => {
+    mockCheckChatLimit.mockImplementationOnce(() =>
+      Promise.resolve({
+        allowed: false as const,
+        reason: "check_failed" as const,
+        errorMessage: "Unable to verify plan limits. Please try again.",
+      }),
+    );
+    const handler = new DiscordStaticBotInstallHandler({ botToken: "tkn", clientId: "111" });
+
+    await expect(handler.confirmInstall(wsid, "123456789012345678")).rejects.toMatchObject({
+      _tag: "BillingCheckFailedError",
+    });
+
+    // Still fail closed — no install row written.
     expect(mockInternalQuery).not.toHaveBeenCalled();
   });
 });

--- a/packages/api/src/lib/integrations/install/__tests__/discord-static-bot-handler.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/discord-static-bot-handler.test.ts
@@ -56,8 +56,18 @@ const mockCheckChatLimit: Mock<
     >
 > = mock(() => Promise.resolve({ allowed: true as const }));
 
+// Mock every named export — a partial `mock.module()` causes a `SyntaxError`
+// in other files importing the missing exports (per CLAUDE.md "Mock all
+// exports"). Only `checkChatIntegrationLimit` is exercised here; the rest are
+// inert no-ops.
 mock.module("@atlas/api/lib/billing/enforcement", () => ({
   checkChatIntegrationLimit: mockCheckChatLimit,
+  checkResourceLimit: () => Promise.resolve({ allowed: true }),
+  checkPlanLimits: () => Promise.resolve({ allowed: true }),
+  getCachedWorkspace: () => Promise.resolve(null),
+  invalidatePlanCache: () => {},
+  buildMetricStatus: () => ({ metric: "tokens", currentUsage: 0, limit: 0, usagePercent: 0, status: "ok" }),
+  severityOf: () => 0,
 }));
 
 // ---------------------------------------------------------------------------

--- a/packages/api/src/lib/integrations/install/__tests__/slack-oauth-handler.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/slack-oauth-handler.test.ts
@@ -99,8 +99,18 @@ const mockCheckChatLimit: Mock<
     >
 > = mock(() => Promise.resolve({ allowed: true as const }));
 
+// Mock every named export — a partial `mock.module()` causes a `SyntaxError`
+// in other files importing the missing exports (per CLAUDE.md "Mock all
+// exports"). Only `checkChatIntegrationLimit` is exercised here; the rest are
+// inert no-ops.
 mock.module("@atlas/api/lib/billing/enforcement", () => ({
   checkChatIntegrationLimit: mockCheckChatLimit,
+  checkResourceLimit: () => Promise.resolve({ allowed: true }),
+  checkPlanLimits: () => Promise.resolve({ allowed: true }),
+  getCachedWorkspace: () => Promise.resolve(null),
+  invalidatePlanCache: () => {},
+  buildMetricStatus: () => ({ metric: "tokens", currentUsage: 0, limit: 0, usagePercent: 0, status: "ok" }),
+  severityOf: () => 0,
 }));
 
 // ---------------------------------------------------------------------------

--- a/packages/api/src/lib/integrations/install/__tests__/slack-oauth-handler.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/slack-oauth-handler.test.ts
@@ -92,7 +92,11 @@ mock.module("@atlas/api/lib/db/internal", () => ({
 // "blocks when at cap" test below overrides it via `mockImplementationOnce`.
 const mockCheckChatLimit: Mock<
   (orgId: string | undefined, catalogId: string) =>
-    Promise<{ allowed: true } | { allowed: false; errorMessage: string; limit: number }>
+    Promise<
+      | { allowed: true }
+      | { allowed: false; reason: "cap_reached"; errorMessage: string; limit: number }
+      | { allowed: false; reason: "check_failed"; errorMessage: string }
+    >
 > = mock(() => Promise.resolve({ allowed: true as const }));
 
 mock.module("@atlas/api/lib/billing/enforcement", () => ({
@@ -358,6 +362,7 @@ describe("SlackOAuthInstallHandler.handleCallback — chat-integration cap", () 
     mockCheckChatLimit.mockImplementationOnce(() =>
       Promise.resolve({
         allowed: false as const,
+        reason: "cap_reached" as const,
         errorMessage: "Your starter plan allows up to 1 chat integration. Upgrade to add more.",
         limit: 1,
       }),
@@ -374,6 +379,28 @@ describe("SlackOAuthInstallHandler.handleCallback — chat-integration cap", () 
     expect(mockInternalQuery).not.toHaveBeenCalled();
     expect(mockSaveInstallation).not.toHaveBeenCalled();
     expect(mockCheckChatLimit).toHaveBeenCalledWith(WSID, "catalog:slack");
+  });
+
+  it("throws BillingCheckFailedError (not the cap error) when the count check fails closed", async () => {
+    // A DB blip means we can't read the count → fail closed, but as a
+    // transient 503 "try again", not a 429 "upgrade your plan".
+    mockCheckChatLimit.mockImplementationOnce(() =>
+      Promise.resolve({
+        allowed: false as const,
+        reason: "check_failed" as const,
+        errorMessage: "Unable to verify plan limits. Please try again.",
+      }),
+    );
+    const handler = new SlackOAuthInstallHandler(SLACK_CONFIG);
+    const stateToken = mintOAuthStateToken(WSID, "slack");
+
+    await expect(handler.handleCallback("auth-code", stateToken)).rejects.toMatchObject({
+      _tag: "BillingCheckFailedError",
+    });
+
+    // Still fail closed — neither store is written.
+    expect(mockInternalQuery).not.toHaveBeenCalled();
+    expect(mockSaveInstallation).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/api/src/lib/integrations/install/__tests__/slack-oauth-handler.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/slack-oauth-handler.test.ts
@@ -85,6 +85,20 @@ mock.module("@atlas/api/lib/db/internal", () => ({
   getInternalDB: mock(() => ({ query: mock(() => Promise.resolve({ rows: [] })) })),
 }));
 
+// The chat-integration cap (#2953) is exercised in
+// `billing/__tests__/enforcement.test.ts`; here we stub it to "allowed" so
+// these handler tests stay focused on the install/credential contract and
+// their `mockInternalQuery` call counts reflect only the INSERT. The single
+// "blocks when at cap" test below overrides it via `mockImplementationOnce`.
+const mockCheckChatLimit: Mock<
+  (orgId: string | undefined, catalogId: string) =>
+    Promise<{ allowed: true } | { allowed: false; errorMessage: string; limit: number }>
+> = mock(() => Promise.resolve({ allowed: true as const }));
+
+mock.module("@atlas/api/lib/billing/enforcement", () => ({
+  checkChatIntegrationLimit: mockCheckChatLimit,
+}));
+
 // ---------------------------------------------------------------------------
 // Test scaffolding — env-driven keyset (mintOAuthStateToken needs it)
 // ---------------------------------------------------------------------------
@@ -121,6 +135,8 @@ beforeEach(() => {
   mockSlackAPI.mockClear();
   mockSaveInstallation.mockClear();
   mockInternalQuery.mockClear();
+  mockCheckChatLimit.mockClear();
+  mockCheckChatLimit.mockImplementation(() => Promise.resolve({ allowed: true as const }));
   // Default to the happy-path Slack response — individual tests override
   // via `mockResolvedValueOnce` / `mockImplementationOnce`.
   mockSlackAPI.mockImplementation(() =>
@@ -330,6 +346,34 @@ describe("SlackOAuthInstallHandler.handleCallback — Slack-side failure", () =>
 
     expect(mockInternalQuery).not.toHaveBeenCalled();
     expect(mockSaveInstallation).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleCallback — chat-integration cap (#2953)
+// ---------------------------------------------------------------------------
+
+describe("SlackOAuthInstallHandler.handleCallback — chat-integration cap", () => {
+  it("throws ChatIntegrationLimitError and writes neither store when at cap", async () => {
+    mockCheckChatLimit.mockImplementationOnce(() =>
+      Promise.resolve({
+        allowed: false as const,
+        errorMessage: "Your starter plan allows up to 1 chat integration. Upgrade to add more.",
+        limit: 1,
+      }),
+    );
+    const handler = new SlackOAuthInstallHandler(SLACK_CONFIG);
+    const stateToken = mintOAuthStateToken(WSID, "slack");
+
+    await expect(handler.handleCallback("auth-code", stateToken)).rejects.toMatchObject({
+      _tag: "ChatIntegrationLimitError",
+      limit: 1,
+    });
+
+    // The cap is enforced before either store is written.
+    expect(mockInternalQuery).not.toHaveBeenCalled();
+    expect(mockSaveInstallation).not.toHaveBeenCalled();
+    expect(mockCheckChatLimit).toHaveBeenCalledWith(WSID, "catalog:slack");
   });
 });
 

--- a/packages/api/src/lib/integrations/install/discord-static-bot-handler.ts
+++ b/packages/api/src/lib/integrations/install/discord-static-bot-handler.ts
@@ -35,6 +35,7 @@ import crypto from "crypto";
 import { createLogger } from "@atlas/api/lib/logger";
 import { internalQuery } from "@atlas/api/lib/db/internal";
 import {
+  BillingCheckFailedError,
   ChatIntegrationLimitError,
   DiscordApiUnavailableError,
   DiscordGuildIdInvalidError,
@@ -230,6 +231,18 @@ export class DiscordStaticBotInstallHandler implements StaticBotInstallHandler {
     // never blocked — the check excludes Discord's own row.
     const capCheck = await checkChatIntegrationLimit(workspaceId, DISCORD_CATALOG_ID);
     if (!capCheck.allowed) {
+      if (capCheck.reason === "check_failed") {
+        // Count couldn't be determined — fail closed, but as a transient
+        // 503 "try again", not a misleading 429 "upgrade your plan".
+        log.error(
+          { workspaceId },
+          "Discord install blocked — chat-integration count check failed (failing closed)",
+        );
+        throw new BillingCheckFailedError({
+          message: capCheck.errorMessage,
+          workspaceId,
+        });
+      }
       log.info(
         { workspaceId, limit: capCheck.limit },
         "Discord install blocked — workspace at chat-integration cap",

--- a/packages/api/src/lib/integrations/install/discord-static-bot-handler.ts
+++ b/packages/api/src/lib/integrations/install/discord-static-bot-handler.ts
@@ -35,10 +35,12 @@ import crypto from "crypto";
 import { createLogger } from "@atlas/api/lib/logger";
 import { internalQuery } from "@atlas/api/lib/db/internal";
 import {
+  ChatIntegrationLimitError,
   DiscordApiUnavailableError,
   DiscordGuildIdInvalidError,
   DiscordReachabilityError,
 } from "@atlas/api/lib/effect/errors";
+import { checkChatIntegrationLimit } from "@atlas/api/lib/billing/enforcement";
 import type { WorkspaceId } from "@useatlas/types";
 import type {
   CatalogId,
@@ -221,6 +223,23 @@ export class DiscordStaticBotInstallHandler implements StaticBotInstallHandler {
     // Throws on API errors / network failures *before* any DB write, so
     // a failed verification never leaves a half-installed row behind.
     const apiGuildName = await this.verifyReachability(routingIdentifier);
+
+    // ── 2b. Plan cap — chat-integration limit (#2953) ─────────────
+    // Block before persisting when the workspace's plan tier is at its
+    // chat-integration cap. Reconnecting Discord (already installed) is
+    // never blocked — the check excludes Discord's own row.
+    const capCheck = await checkChatIntegrationLimit(workspaceId, DISCORD_CATALOG_ID);
+    if (!capCheck.allowed) {
+      log.info(
+        { workspaceId, limit: capCheck.limit },
+        "Discord install blocked — workspace at chat-integration cap",
+      );
+      throw new ChatIntegrationLimitError({
+        message: capCheck.errorMessage,
+        workspaceId,
+        limit: capCheck.limit,
+      });
+    }
 
     // ── 3. Persist install row — UPSERT keyed on (workspace, catalog) ─
     // Mirrors the email-form-handler and telegram-static-bot-handler

--- a/packages/api/src/lib/integrations/install/slack-oauth-handler.ts
+++ b/packages/api/src/lib/integrations/install/slack-oauth-handler.ts
@@ -40,7 +40,8 @@ import { createLogger } from "@atlas/api/lib/logger";
 import { internalQuery } from "@atlas/api/lib/db/internal";
 import { slackAPI } from "@atlas/api/lib/slack/api";
 import { saveInstallation } from "@atlas/api/lib/slack/store";
-import { PlatformOAuthExchangeError } from "@atlas/api/lib/effect/errors";
+import { ChatIntegrationLimitError, PlatformOAuthExchangeError } from "@atlas/api/lib/effect/errors";
+import { checkChatIntegrationLimit } from "@atlas/api/lib/billing/enforcement";
 import type { WorkspaceId } from "@useatlas/types";
 import {
   mintOAuthStateToken,
@@ -211,7 +212,24 @@ export class SlackOAuthInstallHandler implements OAuthPlatformInstallHandler {
       });
     }
 
-    // ── 3. Install record — workspace_plugins INSERT (first store) ──
+    // ── 3. Plan cap — chat-integration limit (#2953) ──────────────
+    // Block before writing either store when the workspace's plan tier
+    // is at its chat-integration cap. Reconnecting Slack (already
+    // installed) is never blocked — the check excludes Slack's own row.
+    const capCheck = await checkChatIntegrationLimit(workspaceId, SLACK_CATALOG_ID);
+    if (!capCheck.allowed) {
+      log.info(
+        { workspaceId, limit: capCheck.limit },
+        "Slack install blocked — workspace at chat-integration cap",
+      );
+      throw new ChatIntegrationLimitError({
+        message: capCheck.errorMessage,
+        workspaceId,
+        limit: capCheck.limit,
+      });
+    }
+
+    // ── 4. Install record — workspace_plugins INSERT (first store) ──
     // Stable id per row — derived once so retries land on the same
     // unique-index hit. ON CONFLICT updates `config`/`enabled` rather
     // than swapping the id, so cross-store joins stay stable.
@@ -249,7 +267,7 @@ export class SlackOAuthInstallHandler implements OAuthPlatformInstallHandler {
       catalogId: SLACK_SLUG,
     };
 
-    // ── 4. Credential — chat_cache:slack:installation:<teamId> ──
+    // ── 5. Credential — chat_cache:slack:installation:<teamId> ──
     // ADR-0003 atomicity: a failure here leaves the install row in
     // place. The admin sees "Reconnect needed" in /admin/integrations
     // and can retry — re-running this method will UPSERT the install

--- a/packages/api/src/lib/integrations/install/slack-oauth-handler.ts
+++ b/packages/api/src/lib/integrations/install/slack-oauth-handler.ts
@@ -247,6 +247,19 @@ export class SlackOAuthInstallHandler implements OAuthPlatformInstallHandler {
     // Stable id per row — derived once so retries land on the same
     // unique-index hit. ON CONFLICT updates `config`/`enabled` rather
     // than swapping the id, so cross-store joins stay stable.
+    //
+    // Schema notes (mirrors `discord-static-bot-handler.ts`):
+    //   - `pillar` + `install_id` became NOT NULL in migration 0092
+    //     (#2739) and the auto-fill trigger was dropped in 0096 (#2744),
+    //     so every writer must name both columns explicitly — and the
+    //     chat-integration cap (#2953) counts `pillar = 'chat'` rows, so
+    //     omitting `pillar` would make Slack installs invisible to it.
+    //   - Chat-pillar installs are singletons per (workspace, catalog),
+    //     enforced by the `workspace_plugins_singleton` partial unique
+    //     index (`WHERE pillar IN ('chat','action')`). We target it via
+    //     the inference clause so re-install lands on the existing row.
+    //   - One install per (workspace, catalog) for chat, so `install_id`
+    //     mirrors `id`.
     const installId = crypto.randomUUID();
     const installConfig = {
       team_id: teamId,
@@ -257,9 +270,9 @@ export class SlackOAuthInstallHandler implements OAuthPlatformInstallHandler {
     };
     try {
       await internalQuery(
-        `INSERT INTO workspace_plugins (id, workspace_id, catalog_id, config, enabled, installed_at)
-         VALUES ($1, $2, $3, $4::jsonb, true, NOW())
-         ON CONFLICT (workspace_id, catalog_id) DO UPDATE
+        `INSERT INTO workspace_plugins (id, workspace_id, catalog_id, install_id, pillar, config, enabled, installed_at)
+         VALUES ($1, $2, $3, $1, 'chat', $4::jsonb, true, NOW())
+         ON CONFLICT (workspace_id, catalog_id) WHERE pillar IN ('chat', 'action') DO UPDATE
            SET config = EXCLUDED.config,
                enabled = true`,
         [installId, workspaceId, SLACK_CATALOG_ID, JSON.stringify(installConfig)],

--- a/packages/api/src/lib/integrations/install/slack-oauth-handler.ts
+++ b/packages/api/src/lib/integrations/install/slack-oauth-handler.ts
@@ -40,7 +40,7 @@ import { createLogger } from "@atlas/api/lib/logger";
 import { internalQuery } from "@atlas/api/lib/db/internal";
 import { slackAPI } from "@atlas/api/lib/slack/api";
 import { saveInstallation } from "@atlas/api/lib/slack/store";
-import { ChatIntegrationLimitError, PlatformOAuthExchangeError } from "@atlas/api/lib/effect/errors";
+import { BillingCheckFailedError, ChatIntegrationLimitError, PlatformOAuthExchangeError } from "@atlas/api/lib/effect/errors";
 import { checkChatIntegrationLimit } from "@atlas/api/lib/billing/enforcement";
 import type { WorkspaceId } from "@useatlas/types";
 import {
@@ -218,6 +218,20 @@ export class SlackOAuthInstallHandler implements OAuthPlatformInstallHandler {
     // installed) is never blocked — the check excludes Slack's own row.
     const capCheck = await checkChatIntegrationLimit(workspaceId, SLACK_CATALOG_ID);
     if (!capCheck.allowed) {
+      if (capCheck.reason === "check_failed") {
+        // We couldn't read the workspace's chat-integration count, so the
+        // cap check failed closed. Surface this as a transient 503 "try
+        // again" — NOT a 429 "upgrade your plan", which would be wrong and
+        // non-actionable when the block is an internal-DB blip.
+        log.error(
+          { workspaceId },
+          "Slack install blocked — chat-integration count check failed (failing closed)",
+        );
+        throw new BillingCheckFailedError({
+          message: capCheck.errorMessage,
+          workspaceId,
+        });
+      }
       log.info(
         { workspaceId, limit: capCheck.limit },
         "Slack install blocked — workspace at chat-integration cap",

--- a/packages/web/src/app/admin/integrations/page.tsx
+++ b/packages/web/src/app/admin/integrations/page.tsx
@@ -90,6 +90,11 @@ function translateInstallError(platform: string, reason: string | null): string 
       return `The ${label} install session expired or was tampered with. Click Connect to start a fresh install.`;
     case "upstream_error":
       return `${label} rejected the OAuth handshake. Check the app's redirect URL matches this deploy, then retry.`;
+    case "plan_limit_reached":
+      // #2953 — workspace at its plan's chat-integration cap. The API
+      // refused the install before writing anything; the fix is to upgrade,
+      // not retry.
+      return `Your plan's chat-integration limit is reached, so ${label} couldn't be connected. Upgrade your plan or remove another integration, then try again.`;
     default:
       if (reason && process.env.NODE_ENV !== "production") {
         console.warn(


### PR DESCRIPTION
## What & why

Closes #2953. Per-tier chat-integration caps (Starter **1** / Pro **3** / Business **unlimited**) are marketed on `/pricing` but were never enforced — nothing stopped a Starter workspace installing a second chat platform. This was a revenue/enforcement gap, not a copy error (the "All 8" count is accurate), so we **enforce** rather than trim the copy.

## Changes

- **`plans.ts`** — `maxChatIntegrations` on `PlanLimits` (free −1, trial 1, starter 1, pro 3, business −1) + Stripe-plan parity.
- **`enforcement.ts`** — `checkResourceLimit` gains a `chat_integrations` resource (shares the seats/connections cap-evaluator). New `checkChatIntegrationLimit(orgId, catalogId)` counts `workspace_plugins WHERE pillar='chat' AND status<>'archived'` and delegates the cap comparison. Fails closed on a count-query error.
- **`errors.ts` / `hono.ts`** — `ChatIntegrationLimitError` → HTTP **429 `plan_limit_exceeded`** (same wire shape as the seats/connections caps surfaced by `admin-connections` / `invitations`), in the `AtlasError` union + `ATLAS_ERROR_TAG_LIST` + exhaustive `mapTaggedError`.
- **Wiring** — `slack-oauth-handler` and `discord-static-bot-handler` call the check before their `workspace_plugins` INSERT and throw on deny. **Zero edits to the install/uninstall route files** (`integrations.ts` / `admin-integrations.ts` / `admin-marketplace.ts`) so this stays clear of the #2944 uninstall work — the 429 maps via the existing `runHandler` → `mapTaggedError` bridge.

## Grandfathering & reconnect

The block fires only on a **net-new** distinct platform (`currentCount >= cap`), so a workspace already over a newly-introduced cap keeps what it has and simply can't add more. The count **excludes the platform being installed**, so reconnecting/re-authing an already-owned platform is never blocked — even for a grandfathered over-cap workspace.

## Acceptance (#2953)

- ✅ A Starter workspace installing a 2nd chat integration is blocked with an upgrade-path message.
- ✅ Business is unrestricted.
- ✅ Existing over-cap workspaces are not broken (grandfathered; can still reconnect what they own).

## Scope note (ADR-0007 migration) — important

Per the decision recorded on #2953, this counts `workspace_plugins(pillar='chat')`, which today is written **only** by the chat install paths already on the unified pipeline: **Slack (OAuth)** and **Discord**. Telegram / Teams / Google Chat / WhatsApp still install via legacy credential-store-only routes in `admin-integrations.ts` and write no `workspace_plugins` row, so they are **not yet counted or capped**. The cap completes automatically once those routes pivot to the unified install record — tracked in **#2994**.

## Incidental finding (not fixed here)

While placing the Slack enforcement I found the Slack OAuth handler's `workspace_plugins` INSERT appears incompatible with the post-0096/0097 schema (omits NOT-NULL `pillar`/`install_id`; stale non-partial `ON CONFLICT`). Its test mocks `internalQuery` so it's never run against real PG. Filed as **#2995** (out of scope here — would be an install-plumbing fix needing its own real-PG coverage). My enforcement sits *before* that INSERT, so it's correctly placed regardless.

## Tests

- `enforcement.test.ts` — `chat_integrations` cap cases + a `checkChatIntegrationLimit` block covering: no-org/no-DB pass-through, fail-closed on query error, free/business unlimited, starter first-install allowed, 2nd-distinct blocked, reconnect-at-cap allowed, **grandfathered over-cap reconnect allowed**, grandfathered over-cap net-new blocked, pro under/at cap.
- `plans.test.ts` — `maxChatIntegrations` per tier (incl. trial==starter).
- Handler tests stub the cap to "allowed" (logic is covered in `enforcement.test.ts`); Slack test adds a "throws `ChatIntegrationLimitError`, writes neither store" case.
- One unrelated test (`disconnect-listener-gate.test.ts`) needed `getWorkspaceDetails` added to its partial `internal` mock (new `handler → enforcement` import edge; the "mock all exports" rule).

## CI

`bun run type` ✅ · `bun run lint` ✅ · full `@atlas/api` suite (512 files) ✅ · schema-drift / ee-imports / twenty-resolver / test-discipline ✅. No `package.json`, migration, schema, or template changes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/2996"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782678265&installation_id=135337507&pr_number=2996&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F2996&signature=2680c12043309303ddf3b9c58734ef910ddf8a42b194f1c10636a2a9e28b80b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enforced per-workspace chat-integration limits (free/business unlimited; starter/pro capped). Over-cap installs show upgrade/remove guidance.
  * Browser installs redirect with reason=plan_limit_reached; API callers receive 429 with error and limit. Admin UI shows specific plan-cap wording.

* **Bug Fixes**
  * Install flow returns 503 when billing/count checks cannot be verified, distinguishing infrastructure failures.

* **Documentation**
  * OpenAPI updated to document 302/429/503 outcomes.

* **Tests**
  * Expanded coverage for limits, failures, and error mappings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AtlasDevHQ/atlas/pull/2996?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->