### PR TITLE
fix(create-atlas): pin transitive kysely to 0.28.17 in scaffold templates (#2997)

### DIFF
--- a/create-atlas/templates/docker/package.json
+++ b/create-atlas/templates/docker/package.json
@@ -106,5 +106,8 @@
     "picocolors": "^1.1.1",
     "typescript": "^6.0.2",
     "typescript-eslint": "^8.57.2"
+  },
+  "overrides": {
+    "kysely": "0.28.17"
   }
 }

--- a/create-atlas/templates/nextjs-standalone/package.json
+++ b/create-atlas/templates/nextjs-standalone/package.json
@@ -103,5 +103,8 @@
     "picocolors": "^1.1.1",
     "typescript": "^6.0.2",
     "typescript-eslint": "^8.57.2"
+  },
+  "overrides": {
+    "kysely": "0.28.17"
   }
 }


### PR DESCRIPTION
## Summary

Fixes the broken **Scaffold (docker)** and **Scaffold (vercel)** jobs under the required **Deploy Validation** umbrella, which fail at `next build`:

```
Export DEFAULT_MIGRATION_TABLE doesn't exist in target module
The export DEFAULT_MIGRATION_TABLE was not found in module .../node_modules/kysely/dist/index.js
Import trace: @better-auth/kysely-adapter → better-auth → src/lib/auth/server.ts
```

## Root cause (upstream dependency drift — not a code bug)

- **2026-05-29T21:31Z**, `better-auth` and `@better-auth/kysely-adapter` published **1.6.12** (exactly the breakage window in #2997). The new adapter widened its kysely peer to `"^0.28.17 || ^0.29.0"`.
- The scaffold templates pin `better-auth: ^1.6.9`. The Scaffold jobs do a **fresh install**, so they now resolve better-auth **1.6.12** → and the *highest* matching kysely = **0.29.2**.
- **kysely 0.29.0** restructured its build into a single bundled `dist/index.js` and **dropped `DEFAULT_MIGRATION_TABLE` / `DEFAULT_MIGRATION_LOCK_TABLE` from the public barrel** (verified: 0.28.17 still exports them via `dist/esm/migration/migrator.js`; 0.29.x does not). The adapter@1.6.12 still imports those constants → build breaks.
- The in-repo `Standalone Example Build` stays green because it's `bun.lock`-pinned (better-auth 1.6.9 + kysely 0.28.14). Purely a fresh-install drift; it would also break the next `main` push (Scaffold runs on push too).

## Fix

Add `overrides: { "kysely": "0.28.17" }` to **both** scaffold template manifests:
- `create-atlas/templates/nextjs-standalone/package.json` (vercel)
- `create-atlas/templates/docker/package.json` (docker / railway / other)

`0.28.17` is the **last version that exports `DEFAULT_MIGRATION_TABLE`** and is the floor of the adapter's `^0.28.17 || ^0.29.0` peer range — so it satisfies every declared range (no peer warnings) while restoring the missing export. Bumping better-auth is **not** viable: `1.6.12` is the latest *stable* (1.7.0 is beta-only) and is itself the broken release.

### Why no root / `bun.lock` pin

The templates are **not** workspace members, so this change does not touch the monorepo `bun.lock`. The monorepo is `--frozen-lockfile`-pinned (better-auth 1.6.9 + kysely 0.28.14) and is unaffected — a plain `bun install` won't drift it; only a deliberate `bun update` would, which is CI-gated. A root override was tested and only introduced **unrelated** lockfile churn (deduping `@atlas/embedded-mcp-onboarding-example` nested entries) for nominal parity, since the monorepo doesn't consume kysely directly. Kept the fix surgical.

## Verification

- ✅ `bash create-atlas/smoke-test.sh vercel` → `next build` succeeds (kysely resolves to 0.28.17)
- ✅ `bash create-atlas/smoke-test.sh docker` → `Compiled successfully`, `.next/standalone` present
- ✅ `bun x syncpack lint` — no issues
- ✅ `scripts/check-template-drift.sh` — 731 files verified (package.json is not regenerated; `src/` unchanged)
- ✅ `scripts/check-published-symbols.ts` — passed

lint/type/test are unaffected (no monorepo workspace source or lockfile changed); the PR's `ci` check verifies them authoritatively.

Refs #2997

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3000"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782692046&installation_id=135337507&pr_number=3000&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3000&signature=1ed1a504d01e3cbcd43282b03bd31f9805ab99c585ba3cb6bf6b7a3e958d82b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->