### PR TITLE
feat(openapi): per-install spec refresh interval + Refresh now (#2977)

### DIFF
--- a/apps/docs/content/docs/api-reference/admin-openapi-datasources/patchAdminOpenapiDatasourcesByInstallId.mdx
+++ b/apps/docs/content/docs/api-reference/admin-openapi-datasources/patchAdminOpenapiDatasourcesByInstallId.mdx
@@ -1,5 +1,5 @@
 ---
-title: Update the representation-mode toggle
+title: Update non-secret install config (representation mode, spec refresh interval)
 full: true
 _openapi:
   method: PATCH

--- a/apps/docs/content/docs/plugins/datasources/openapi-generic.mdx
+++ b/apps/docs/content/docs/plugins/datasources/openapi-generic.mdx
@@ -59,6 +59,26 @@ Every operation — read or write — is authorized by `validateRestOperation`, 
 
 Writes are **never written to any cache** — the write path uses the un-cached client primitive, and the paginating read cache refuses to store non-GET responses by construction.
 
+## Keeping the spec current
+
+Atlas caches the probed spec per install. When the upstream API ships new operations or changes a shape, the cache needs to be re-discovered so the agent's view stays accurate. Two ways to refresh it:
+
+- **Refresh now** — the **Rediscover schema** button on the datasource card (Admin → Connections) re-probes the spec endpoint immediately and replaces the cached snapshot. Use this right after the upstream API changes.
+- **Auto-refresh interval** — the **Auto-refresh** control sets how often Atlas re-discovers the spec on its own:
+
+| Value | Meaning |
+|-------|---------|
+| `off` (default) | Never auto-refresh — re-discover manually with **Rediscover schema**. |
+| `daily` | Re-discover every 24 hours. |
+| `weekly` | Re-discover every 7 days. |
+| `<N>h` | A custom interval of `N` hours, clamped to **1h … 720h** (30 days). Set via `atlas.config.ts`. |
+
+The interval is stored per install (it's not a secret, so it's a plain `workspace_plugins.config` field). An out-of-range custom value is **clamped** into the bounds; an unparseable value is **rejected** with a message — it never silently falls back to `off`.
+
+<Callout type="info">
+This release ships the setting, the manual **Refresh now**, and validation. The background fiber that walks due installs and auto-re-discovers on the interval lands in a follow-up — until then `off` and the manual button are the active paths, and any configured interval is honored once that scheduler ships.
+</Callout>
+
 ## Configuration fields
 
 Install-form fields (Admin → Connections):
@@ -80,3 +100,4 @@ Advanced overrides (set on the install's `config` via `atlas.config.ts`, not sur
 |-----|-------|
 | `rate_limit_per_minute` | Per-operation rate limit override (default 60) |
 | `request_timeout_ms` | Per-request timeout override; must be ≤ `ATLAS_OPENAPI_TIMEOUT` (the cap), else the operation is rejected |
+| `spec_refresh_interval` | How often to auto-re-discover the spec: `off` (default) / `daily` / `weekly` / `<N>h` (1h–720h, clamped). Also settable from the **Auto-refresh** control on the datasource card. |

--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -52043,7 +52043,7 @@
         "tags": [
           "Admin — OpenAPI Datasources"
         ],
-        "summary": "Update the representation-mode toggle",
+        "summary": "Update non-secret install config (representation mode, spec refresh interval)",
         "parameters": [
           {
             "schema": {
@@ -52067,11 +52067,12 @@
                       "operation-graph",
                       "semantic-yaml"
                     ]
+                  },
+                  "specRefreshInterval": {
+                    "type": "string",
+                    "minLength": 1
                   }
-                },
-                "required": [
-                  "representationMode"
-                ]
+                }
               }
             }
           }

--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -52071,7 +52071,7 @@
                   "specRefreshInterval": {
                     "type": "string",
                     "minLength": 1,
-                    "description": "Controls how often the OpenAPI spec is automatically refreshed. Accepts: 'off' (default, disables auto-refresh), named presets 'daily' or 'weekly', or custom interval '<N>h' where N is an integer between 1 and 720 hours. Out-of-range positive values are clamped to allowed bounds; invalid formats are rejected with an error.",
+                    "description": "How often Atlas auto-refreshes the cached spec: 'off' (default, no auto-refresh), 'daily', 'weekly', or a custom '<N>h' interval in hours (clamped to 1–720h / 30 days). Out-of-range positive values are clamped; unparseable values are rejected with an actionable error.",
                     "example": "daily"
                   }
                 }

--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -52070,7 +52070,9 @@
                   },
                   "specRefreshInterval": {
                     "type": "string",
-                    "minLength": 1
+                    "minLength": 1,
+                    "description": "Controls how often the OpenAPI spec is automatically refreshed. Accepts: 'off' (default, disables auto-refresh), named presets 'daily' or 'weekly', or custom interval '<N>h' where N is an integer between 1 and 720 hours. Out-of-range positive values are clamped to allowed bounds; invalid formats are rejected with an error.",
+                    "example": "daily"
                   }
                 }
               }

--- a/packages/api/src/api/routes/__tests__/admin-openapi-datasources.test.ts
+++ b/packages/api/src/api/routes/__tests__/admin-openapi-datasources.test.ts
@@ -273,4 +273,105 @@ describe("admin-openapi-datasources — rediscover error mapping", () => {
     expect(res.status).toBe(400);
     expect(((await res.json()) as { error: string }).error).toBe("probe_failed");
   });
+
+  it("Refresh now (rediscover) re-probes the upstream spec on success", async () => {
+    // The snapshot UPDATE only fires after probeSpec resolves, so its presence is
+    // proof the manual "Refresh now" triggered a live re-probe (AC: re-probe).
+    const res = await adminOpenApiDatasources.request("/ds-1/rediscover", { method: "POST" });
+    expect(res.status).toBe(200);
+    const update = mockInternalQuery.mock.calls.find(
+      ([sql]) => (sql as string).includes("UPDATE") && (sql as string).includes("openapi_snapshot"),
+    );
+    expect(update).toBeDefined();
+  });
+});
+
+// ── Per-install spec-refresh interval (#2977) ────────────────────────────────
+
+/** The merge UPDATE the PATCH handler issues, if any. */
+function findConfigUpdate() {
+  return mockInternalQuery.mock.calls.find(([sql]) => (sql as string).includes("UPDATE"));
+}
+
+describe("admin-openapi-datasources — spec_refresh_interval set / clear / clamp", () => {
+  it("GET detail surfaces specRefreshInterval (default off when the row has no key)", async () => {
+    const body = (await (await adminOpenApiDatasources.request("/ds-1")).json()) as {
+      specRefreshInterval: string;
+    };
+    // The fixture config carries no spec_refresh_interval → coerced to the default.
+    expect(body.specRefreshInterval).toBe("off");
+  });
+
+  it("PATCH sets a named preset, writing only spec_refresh_interval (never auth_value)", async () => {
+    const res = await adminOpenApiDatasources.request("/ds-1", {
+      method: "PATCH",
+      headers: JSON_HEADERS,
+      body: JSON.stringify({ specRefreshInterval: "daily" }),
+    });
+    expect(res.status).toBe(200);
+    expect((await res.json()) as { specRefreshInterval: string }).toMatchObject({
+      specRefreshInterval: "daily",
+    });
+    const update = findConfigUpdate();
+    expect(update?.[0]).toContain("jsonb_build_object('spec_refresh_interval'");
+    expect(update?.[0]).not.toContain("auth_value");
+    expect(update?.[1]).toEqual([FIXTURE.owner, "ds-1", CATALOG_ID, "daily"]);
+  });
+
+  it("PATCH clears the interval by setting it back to off", async () => {
+    const res = await adminOpenApiDatasources.request("/ds-1", {
+      method: "PATCH",
+      headers: JSON_HEADERS,
+      body: JSON.stringify({ specRefreshInterval: "off" }),
+    });
+    expect(res.status).toBe(200);
+    expect(findConfigUpdate()?.[1]).toEqual([FIXTURE.owner, "ds-1", CATALOG_ID, "off"]);
+  });
+
+  it("PATCH clamps an out-of-range custom interval to the ceiling (not a rejection)", async () => {
+    const res = await adminOpenApiDatasources.request("/ds-1", {
+      method: "PATCH",
+      headers: JSON_HEADERS,
+      body: JSON.stringify({ specRefreshInterval: "9000h" }),
+    });
+    expect(res.status).toBe(200);
+    // 30-day ceiling = 720h.
+    expect(findConfigUpdate()?.[1]).toEqual([FIXTURE.owner, "ds-1", CATALOG_ID, "720h"]);
+  });
+
+  it("PATCH rejects an unparseable interval with an actionable 400 — no silent fallback, no UPDATE", async () => {
+    const res = await adminOpenApiDatasources.request("/ds-1", {
+      method: "PATCH",
+      headers: JSON_HEADERS,
+      body: JSON.stringify({ specRefreshInterval: "soon" }),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string; message: string };
+    expect(body.error).toBe("bad_request");
+    expect(body.message).toContain("daily"); // names the valid options
+    // The bad value never reached the database.
+    expect(findConfigUpdate()).toBeUndefined();
+  });
+
+  it("PATCH can update representation mode and refresh interval together", async () => {
+    const res = await adminOpenApiDatasources.request("/ds-1", {
+      method: "PATCH",
+      headers: JSON_HEADERS,
+      body: JSON.stringify({ representationMode: "semantic-yaml", specRefreshInterval: "weekly" }),
+    });
+    expect(res.status).toBe(200);
+    const update = findConfigUpdate();
+    expect(update?.[0]).toContain("representation_mode");
+    expect(update?.[0]).toContain("spec_refresh_interval");
+    expect(update?.[1]).toEqual([FIXTURE.owner, "ds-1", CATALOG_ID, "semantic-yaml", "weekly"]);
+  });
+
+  it("PATCH with an empty body is a 400 (at least one field required)", async () => {
+    const res = await adminOpenApiDatasources.request("/ds-1", {
+      method: "PATCH",
+      headers: JSON_HEADERS,
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(400);
+  });
 });

--- a/packages/api/src/api/routes/admin-openapi-datasources.ts
+++ b/packages/api/src/api/routes/admin-openapi-datasources.ts
@@ -43,6 +43,10 @@ import {
   OpenApiProbeError,
 } from "@atlas/api/lib/openapi/probe";
 import { REPRESENTATION_MODES } from "@atlas/api/lib/openapi/representation";
+import {
+  coerceSpecRefreshInterval,
+  normalizeSpecRefreshInterval,
+} from "@atlas/api/lib/openapi/spec-refresh";
 import { ErrorSchema, AuthErrorSchema } from "./shared-schemas";
 import { createAdminRouter, requireOrgContext, requirePermission } from "./admin-router";
 
@@ -77,6 +81,9 @@ function summarizeInstall(installId: string, config: Record<string, unknown> | n
     openapiUrl: typeof c.openapi_url === "string" ? c.openapi_url : null,
     baseUrlOverride: typeof c.base_url_override === "string" ? c.base_url_override : null,
     representationMode: coerceRepresentationMode(c.representation_mode),
+    // Per-install spec-refresh interval (#2977). Fail-soft display coercion so a
+    // drifted / absent value renders as the `off` default rather than undefined.
+    specRefreshInterval: coerceSpecRefreshInterval(c.spec_refresh_interval),
     status,
     snapshot: snapshot
       ? {
@@ -145,13 +152,25 @@ const patchRoute = createRoute({
   method: "patch",
   path: "/{installId}",
   tags: ["Admin — OpenAPI Datasources"],
-  summary: "Update the representation-mode toggle",
+  summary: "Update non-secret install config (representation mode, spec refresh interval)",
   request: {
     params: z.object({ installId: z.string().min(1).openapi({ param: { name: "installId", in: "path" } }) }),
     body: {
       content: {
         "application/json": {
-          schema: z.object({ representationMode: z.enum(REPRESENTATION_MODES) }),
+          // Both fields optional — a partial PATCH updates only what's provided.
+          // `specRefreshInterval` is a free string validated + clamped in the
+          // handler (off / daily / weekly / "<N>h"); the richer parse gives an
+          // actionable 400 a bare enum couldn't (#2977).
+          schema: z
+            .object({
+              representationMode: z.enum(REPRESENTATION_MODES).optional(),
+              specRefreshInterval: z.string().min(1).optional(),
+            })
+            .refine(
+              (b) => b.representationMode !== undefined || b.specRefreshInterval !== undefined,
+              { message: "Provide representationMode and/or specRefreshInterval." },
+            ),
         },
       },
     },
@@ -358,19 +377,44 @@ adminOpenApiDatasources.openapi(patchRoute, async (c) =>
   runHandler(c, "update openapi datasource", async () => {
     const { orgId, requestId } = c.get("orgContext");
     const { installId } = c.req.valid("param");
-    const { representationMode } = c.req.valid("json");
+    const { representationMode, specRefreshInterval } = c.req.valid("json");
     const row = await loadInstall(orgId, installId);
     if (!row) {
       return c.json({ error: "not_found", message: `No OpenAPI datasource "${installId}".`, requestId }, 404);
     }
 
-    // JSONB merge of the single toggle — the encrypted auth_value is untouched.
+    // Collect the non-secret config fields this PATCH touches: the JSONB column
+    // (snake_case) it writes, and the camelCase wire shape echoed in the response
+    // + audit metadata. Each column key is from a fixed allow-set (never user
+    // input) so interpolating it into the SQL is safe; the value is always bound.
+    const updates: Record<string, string> = {};
+    const changed: Record<string, string> = {};
+    if (representationMode !== undefined) {
+      updates.representation_mode = representationMode;
+      changed.representationMode = representationMode;
+    }
+    if (specRefreshInterval !== undefined) {
+      // Validate + clamp here so an invalid interval is an actionable 400, never a
+      // silent fallback to off (#2977 / CLAUDE.md error-handling). An out-of-range
+      // but positive value is clamped (e.g. "9000h" → the 30-day ceiling).
+      const normalized = normalizeSpecRefreshInterval(specRefreshInterval);
+      if (!normalized.ok) {
+        return c.json({ error: "bad_request", message: normalized.message, requestId }, 400);
+      }
+      updates.spec_refresh_interval = normalized.value;
+      changed.specRefreshInterval = normalized.value;
+    }
+
+    // JSONB merge of only the provided fields — the encrypted auth_value is
+    // untouched. Representation-only PATCH keeps the exact single-key SQL shape.
+    const keys = Object.keys(updates);
+    const pairs = keys.map((key, i) => `'${key}', $${i + 4}::text`).join(", ");
     await internalQuery(
       `UPDATE workspace_plugins
-          SET config = config || jsonb_build_object('representation_mode', $4::text),
+          SET config = config || jsonb_build_object(${pairs}),
               updated_at = NOW()
         WHERE workspace_id = $1 AND install_id = $2 AND catalog_id = $3 AND pillar = 'datasource'`,
-      [orgId, installId, OPENAPI_GENERIC_CATALOG_ID, representationMode],
+      [orgId, installId, OPENAPI_GENERIC_CATALOG_ID, ...keys.map((k) => updates[k])],
     );
 
     logAdminAction({
@@ -379,10 +423,10 @@ adminOpenApiDatasources.openapi(patchRoute, async (c) =>
       targetId: installId,
       scope: "workspace",
       ipAddress: c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null,
-      metadata: { installId, representationMode, kind: "openapi-representation-toggle" },
+      metadata: { installId, ...changed, kind: "openapi-config-update" },
     });
 
-    return c.json({ updated: true, representationMode }, 200);
+    return c.json({ updated: true, ...changed }, 200);
   }),
 );
 

--- a/packages/api/src/api/routes/admin-openapi-datasources.ts
+++ b/packages/api/src/api/routes/admin-openapi-datasources.ts
@@ -165,7 +165,17 @@ const patchRoute = createRoute({
           schema: z
             .object({
               representationMode: z.enum(REPRESENTATION_MODES).optional(),
-              specRefreshInterval: z.string().min(1).optional(),
+              specRefreshInterval: z
+                .string()
+                .min(1)
+                .optional()
+                .openapi({
+                  description:
+                    "How often Atlas auto-refreshes the cached spec: 'off' (default, no auto-refresh), " +
+                    "'daily', 'weekly', or a custom '<N>h' interval in hours (clamped to 1–720h / 30 days). " +
+                    "Out-of-range positive values are clamped; unparseable values are rejected with an actionable error.",
+                  example: "daily",
+                }),
             })
             .refine(
               (b) => b.representationMode !== undefined || b.specRefreshInterval !== undefined,

--- a/packages/api/src/lib/openapi/__tests__/spec-refresh.test.ts
+++ b/packages/api/src/lib/openapi/__tests__/spec-refresh.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Unit tests for the per-install OpenAPI spec-refresh interval (#2977).
+ *
+ * Three contracts are load-bearing here:
+ *   - `normalizeSpecRefreshInterval` is the WRITE-path gate: it must CLAMP an
+ *     out-of-range-but-usable number and REJECT genuine garbage with an
+ *     actionable message — never silently fall back (CLAUDE.md error-handling).
+ *   - `getSpecRefreshIntervalMs` is the READ-path reader the #2978 scheduler will
+ *     consume (mirrors `getExpertSchedulerIntervalMs`): `off`/drifted → `null`
+ *     (skip), every live value → a positive, clamped millisecond count.
+ *   - `coerceSpecRefreshInterval` is the fail-soft display coercion for the
+ *     detail summary + UI Select (unknown/absent → `off`).
+ */
+import { describe, it, expect } from "bun:test";
+import {
+  coerceSpecRefreshInterval,
+  normalizeSpecRefreshInterval,
+  getSpecRefreshIntervalMs,
+  DEFAULT_SPEC_REFRESH_INTERVAL,
+  MIN_SPEC_REFRESH_HOURS,
+  MAX_SPEC_REFRESH_HOURS,
+} from "../spec-refresh";
+
+const HOUR_MS = 60 * 60 * 1000;
+
+describe("coerceSpecRefreshInterval — fail-soft display", () => {
+  it("passes known values through", () => {
+    expect(coerceSpecRefreshInterval("off")).toBe("off");
+    expect(coerceSpecRefreshInterval("daily")).toBe("daily");
+    expect(coerceSpecRefreshInterval("weekly")).toBe("weekly");
+    expect(coerceSpecRefreshInterval("6h")).toBe("6h");
+  });
+
+  it("falls back to the default (off) for unknown / absent / wrong-typed values", () => {
+    expect(coerceSpecRefreshInterval(undefined)).toBe(DEFAULT_SPEC_REFRESH_INTERVAL);
+    expect(coerceSpecRefreshInterval(null)).toBe(DEFAULT_SPEC_REFRESH_INTERVAL);
+    expect(coerceSpecRefreshInterval("")).toBe(DEFAULT_SPEC_REFRESH_INTERVAL);
+    expect(coerceSpecRefreshInterval("soon")).toBe(DEFAULT_SPEC_REFRESH_INTERVAL);
+    expect(coerceSpecRefreshInterval(42)).toBe(DEFAULT_SPEC_REFRESH_INTERVAL);
+    expect(coerceSpecRefreshInterval({})).toBe(DEFAULT_SPEC_REFRESH_INTERVAL);
+  });
+
+  it("normalizes a drifted custom value to its canonical, clamped form", () => {
+    // A hand-edited row of "5000h" displays as the clamped max, not a lie.
+    expect(coerceSpecRefreshInterval("5000h")).toBe(`${MAX_SPEC_REFRESH_HOURS}h`);
+  });
+
+  it("DEFAULT is off", () => {
+    expect(DEFAULT_SPEC_REFRESH_INTERVAL).toBe("off");
+  });
+});
+
+describe("normalizeSpecRefreshInterval — write-path validate + clamp", () => {
+  it("accepts the off sentinel + named presets verbatim", () => {
+    for (const v of ["off", "daily", "weekly"]) {
+      const r = normalizeSpecRefreshInterval(v);
+      expect(r.ok).toBe(true);
+      if (r.ok) expect(r.value).toBe(v);
+    }
+  });
+
+  it("is case-insensitive and trims surrounding whitespace", () => {
+    expect(normalizeSpecRefreshInterval("  DAILY ")).toEqual({ ok: true, value: "daily" });
+    expect(normalizeSpecRefreshInterval("Off")).toEqual({ ok: true, value: "off" });
+    expect(normalizeSpecRefreshInterval(" 6H ")).toEqual({ ok: true, value: "6h" });
+  });
+
+  it("accepts a custom interval as <N>h, a bare number string, or a number (hours)", () => {
+    expect(normalizeSpecRefreshInterval("6h")).toEqual({ ok: true, value: "6h" });
+    expect(normalizeSpecRefreshInterval("12")).toEqual({ ok: true, value: "12h" });
+    expect(normalizeSpecRefreshInterval(48)).toEqual({ ok: true, value: "48h" });
+  });
+
+  it("CLAMPS an out-of-range-but-positive interval (not a rejection)", () => {
+    // Below the floor clamps up to the minimum.
+    expect(normalizeSpecRefreshInterval("0.5h")).toEqual({ ok: true, value: `${MIN_SPEC_REFRESH_HOURS}h` });
+    // Above the ceiling clamps down to the maximum.
+    expect(normalizeSpecRefreshInterval("5000h")).toEqual({ ok: true, value: `${MAX_SPEC_REFRESH_HOURS}h` });
+    expect(normalizeSpecRefreshInterval(100000)).toEqual({ ok: true, value: `${MAX_SPEC_REFRESH_HOURS}h` });
+  });
+
+  it("REJECTS a non-positive / non-finite number with an actionable message (no silent fallback)", () => {
+    for (const bad of ["0", "0h", "-3h", -1, 0, "NaNh"]) {
+      const r = normalizeSpecRefreshInterval(bad);
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.message.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("REJECTS unrecognized garbage with a message listing the valid options", () => {
+    for (const bad of ["soon", "1 day", "weeklyish", "12x", ""]) {
+      const r = normalizeSpecRefreshInterval(bad);
+      expect(r.ok).toBe(false);
+      if (!r.ok) {
+        expect(r.message).toContain("off");
+        expect(r.message).toContain("daily");
+      }
+    }
+  });
+
+  it("REJECTS wrong-typed input (object / array / bool / null / undefined)", () => {
+    for (const bad of [{}, [], true, null, undefined] as unknown[]) {
+      expect(normalizeSpecRefreshInterval(bad).ok).toBe(false);
+    }
+  });
+});
+
+describe("getSpecRefreshIntervalMs — read-path reader (mirrors getExpertSchedulerIntervalMs)", () => {
+  it("returns null for off — the scheduler skips a null interval", () => {
+    expect(getSpecRefreshIntervalMs("off")).toBeNull();
+  });
+
+  it("returns null for unknown / drifted / wrong-typed stored values (fail-soft → off)", () => {
+    expect(getSpecRefreshIntervalMs(undefined)).toBeNull();
+    expect(getSpecRefreshIntervalMs(null)).toBeNull();
+    expect(getSpecRefreshIntervalMs("")).toBeNull();
+    expect(getSpecRefreshIntervalMs("soon")).toBeNull();
+    expect(getSpecRefreshIntervalMs("12x")).toBeNull();
+    expect(getSpecRefreshIntervalMs({})).toBeNull();
+  });
+
+  it("resolves named presets to their millisecond interval", () => {
+    expect(getSpecRefreshIntervalMs("daily")).toBe(24 * HOUR_MS);
+    expect(getSpecRefreshIntervalMs("weekly")).toBe(168 * HOUR_MS);
+  });
+
+  it("resolves a custom interval (<N>h / bare number) to milliseconds", () => {
+    expect(getSpecRefreshIntervalMs("6h")).toBe(6 * HOUR_MS);
+    expect(getSpecRefreshIntervalMs("12")).toBe(12 * HOUR_MS);
+    expect(getSpecRefreshIntervalMs(48)).toBe(48 * HOUR_MS);
+  });
+
+  it("clamps a drifted out-of-range stored value on read (defense for hand-edited rows)", () => {
+    expect(getSpecRefreshIntervalMs("5000h")).toBe(MAX_SPEC_REFRESH_HOURS * HOUR_MS);
+    expect(getSpecRefreshIntervalMs("0.5h")).toBe(MIN_SPEC_REFRESH_HOURS * HOUR_MS);
+  });
+});

--- a/packages/api/src/lib/openapi/spec-refresh.ts
+++ b/packages/api/src/lib/openapi/spec-refresh.ts
@@ -1,0 +1,139 @@
+/**
+ * `spec-refresh` — the per-install OpenAPI spec **refresh interval** knob
+ * (PRD #2868 slice, #2977). A non-secret value stored on a generic OpenAPI
+ * datasource's `workspace_plugins.config` JSONB (no migration, no encryption
+ * surface) that says how often the cached spec snapshot should be re-discovered.
+ *
+ * This slice ships only the stored setting + its validation + a read accessor —
+ * **no background scheduler**. The admin "Refresh now" reuses the existing manual
+ * re-discovery path; the periodic fiber that consumes {@link getSpecRefreshIntervalMs}
+ * lands in #2978 (modeled on the `Effect.repeat(Schedule.spaced(...))` pattern in
+ * `layers.ts`, the way `getExpertSchedulerIntervalMs` feeds the semantic-expert
+ * tick).
+ *
+ * Stored canonical value — one of:
+ *   - `"off"` (default) — never auto-refresh.
+ *   - a named preset: `"daily"` (24h) or `"weekly"` (168h).
+ *   - a bounded custom interval `"<N>h"` — N in `[MIN_SPEC_REFRESH_HOURS,
+ *     MAX_SPEC_REFRESH_HOURS]` (1h … 30d).
+ *
+ * Three contracts:
+ *   - {@link normalizeSpecRefreshInterval} — write path. CLAMPS an
+ *     out-of-range-but-positive number; REJECTS genuine garbage with an actionable
+ *     message. No silent fallback (the value matters for upstream egress timing).
+ *   - {@link getSpecRefreshIntervalMs} — read path / #2978 scheduler. `off` and any
+ *     drifted value → `null` (skip); every live value → a positive, clamped ms count.
+ *   - {@link coerceSpecRefreshInterval} — fail-soft display coercion for the detail
+ *     summary + UI Select (a non-string / unknown stored value → the `off` default).
+ */
+
+/** The sentinel value meaning "never auto-refresh" — the default. */
+export const SPEC_REFRESH_OFF = "off";
+
+/** Named presets the UI surfaces, expressed in hours. Keep in lockstep with the web Select. */
+export const SPEC_REFRESH_PRESET_HOURS: Readonly<Record<string, number>> = {
+  daily: 24,
+  weekly: 168,
+};
+
+/** Custom-interval bounds (hours): 1 hour … 30 days. An out-of-range value clamps to these. */
+export const MIN_SPEC_REFRESH_HOURS = 1;
+export const MAX_SPEC_REFRESH_HOURS = 720;
+
+/** Default stored value when nothing is configured. */
+export const DEFAULT_SPEC_REFRESH_INTERVAL = SPEC_REFRESH_OFF;
+
+const HOUR_MS = 60 * 60 * 1000;
+
+/**
+ * Actionable rejection message for the write path. Names every valid option +
+ * the custom bounds so the admin sees exactly what to enter (CLAUDE.md: no
+ * generic "something went wrong").
+ */
+const INVALID_INTERVAL_MESSAGE =
+  `Invalid refresh interval. Use "${SPEC_REFRESH_OFF}", "daily", "weekly", or a number of hours ` +
+  `between ${MIN_SPEC_REFRESH_HOURS} and ${MAX_SPEC_REFRESH_HOURS} (e.g. "6h").`;
+
+function clampHours(hours: number): number {
+  return Math.min(MAX_SPEC_REFRESH_HOURS, Math.max(MIN_SPEC_REFRESH_HOURS, hours));
+}
+
+/**
+ * Parse the CUSTOM numeric interval form — a number of hours given as a `number`,
+ * a bare numeric string (`"6"`), or a `"<N>h"` string — and return the CLAMPED
+ * hours, or `null` when the value isn't a positive finite number. Does not
+ * recognize the `off` sentinel or the named presets; the callers layer those on.
+ */
+function parseCustomHours(raw: unknown): number | null {
+  let hours: number;
+  if (typeof raw === "number") {
+    hours = raw;
+  } else if (typeof raw === "string") {
+    const match = /^(\d+(?:\.\d+)?)h?$/.exec(raw.trim().toLowerCase());
+    const digits = match?.[1];
+    if (digits === undefined) return null;
+    hours = Number.parseFloat(digits);
+  } else {
+    return null;
+  }
+  if (!Number.isFinite(hours) || hours <= 0) return null;
+  return clampHours(hours);
+}
+
+/** Result of {@link normalizeSpecRefreshInterval}. */
+export type NormalizedSpecRefreshInterval =
+  | { readonly ok: true; readonly value: string }
+  | { readonly ok: false; readonly message: string };
+
+/**
+ * Validate + clamp a refresh-interval value for the WRITE path. Accepts the `off`
+ * sentinel and named presets verbatim (case-insensitive, trimmed), a number of
+ * hours (number / `"6"` / `"6h"`) which is clamped into bounds, and rejects
+ * everything else with {@link INVALID_INTERVAL_MESSAGE}. An out-of-range positive
+ * number is CLAMPED, not rejected — only a non-positive / unparseable / wrong-typed
+ * value is refused (so a fat-fingered "90 days" never silently becomes "off").
+ */
+export function normalizeSpecRefreshInterval(raw: unknown): NormalizedSpecRefreshInterval {
+  if (typeof raw === "string") {
+    const lower = raw.trim().toLowerCase();
+    if (lower === SPEC_REFRESH_OFF) return { ok: true, value: SPEC_REFRESH_OFF };
+    if (lower in SPEC_REFRESH_PRESET_HOURS) return { ok: true, value: lower };
+  }
+  if (typeof raw === "string" || typeof raw === "number") {
+    const hours = parseCustomHours(raw);
+    if (hours !== null) return { ok: true, value: `${hours}h` };
+  }
+  return { ok: false, message: INVALID_INTERVAL_MESSAGE };
+}
+
+/**
+ * Fail-soft display coercion for the detail summary + UI Select. A stored value is
+ * always a canonical string; a non-string / unrecognized value (drifted or
+ * hand-edited row) coerces to the `off` default rather than rendering `undefined`.
+ * A drifted out-of-range `"<N>h"` is normalized to its clamped form so the UI never
+ * shows a value the scheduler wouldn't honor.
+ */
+export function coerceSpecRefreshInterval(raw: unknown): string {
+  if (typeof raw !== "string") return DEFAULT_SPEC_REFRESH_INTERVAL;
+  const result = normalizeSpecRefreshInterval(raw);
+  return result.ok ? result.value : DEFAULT_SPEC_REFRESH_INTERVAL;
+}
+
+/**
+ * Resolve a stored interval to milliseconds for the READ path — the #2978
+ * scheduler tick. Mirrors `getExpertSchedulerIntervalMs` (returns a positive ms
+ * count), with one addition: `off` (and any drifted / unparseable value) resolves
+ * to `null`, the signal for the scheduler to SKIP this install entirely rather
+ * than auto-refresh on a fabricated cadence. A drifted out-of-range `"<N>h"` is
+ * clamped on read too — defense for hand-edited rows.
+ */
+export function getSpecRefreshIntervalMs(raw: unknown): number | null {
+  if (typeof raw === "string") {
+    const lower = raw.trim().toLowerCase();
+    if (lower === SPEC_REFRESH_OFF) return null;
+    const presetHours = SPEC_REFRESH_PRESET_HOURS[lower];
+    if (presetHours !== undefined) return presetHours * HOUR_MS;
+  }
+  const hours = parseCustomHours(raw);
+  return hours === null ? null : hours * HOUR_MS;
+}

--- a/packages/web/src/app/admin/connections/openapi-block.tsx
+++ b/packages/web/src/app/admin/connections/openapi-block.tsx
@@ -99,6 +99,7 @@ const DatasourceSummarySchema = z.object({
   openapiUrl: z.string().nullable(),
   baseUrlOverride: z.string().nullable(),
   representationMode: z.string(),
+  specRefreshInterval: z.string(),
   status: z.string(),
   snapshot: SnapshotSchema,
 });
@@ -118,6 +119,26 @@ const DetailSchema = DatasourceSummarySchema.extend({
 });
 
 const AUTH_KINDS = ["none", "bearer", "basic", "apikey-header", "apikey-query"] as const;
+
+/**
+ * Auto-refresh presets the Select exposes (#2977). The agent's view of a spec
+ * stays current without a manual click; `off` (default) never auto-refreshes.
+ * The values mirror the API's `spec_refresh_interval` enum — a custom `"<N>h"`
+ * interval set via `atlas.config.ts` is still rendered (see {@link formatRefreshLabel}).
+ */
+const REFRESH_INTERVAL_OPTIONS = [
+  { value: "off", label: "Off" },
+  { value: "daily", label: "Daily" },
+  { value: "weekly", label: "Weekly" },
+] as const;
+
+/** Human label for a stored interval value — a preset name, or "Every Nh" for a custom interval. */
+function formatRefreshLabel(value: string): string {
+  const preset = REFRESH_INTERVAL_OPTIONS.find((o) => o.value === value);
+  if (preset) return preset.label;
+  const custom = /^(\d+(?:\.\d+)?)h$/.exec(value);
+  return custom ? `Every ${custom[1]}h` : value;
+}
 
 interface OpenApiProviderBlockProps {
   readonly demoReadOnly: boolean;
@@ -233,6 +254,11 @@ function OpenApiInstallCard({ ds, onChange }: { ds: DatasourceSummary; onChange:
     method: "PATCH",
     invalidates: onChange,
   });
+  const setRefresh = useAdminMutation<{ updated: boolean; specRefreshInterval: string }>({
+    path: `/api/v1/admin/openapi-datasources/${encodeURIComponent(ds.id)}`,
+    method: "PATCH",
+    invalidates: onChange,
+  });
   const remove = useAdminMutation<{ deleted: boolean }>({
     path: `/api/v1/admin/openapi-datasources/${encodeURIComponent(ds.id)}`,
     method: "DELETE",
@@ -265,6 +291,19 @@ function OpenApiInstallCard({ ds, onChange }: { ds: DatasourceSummary; onChange:
       toast.success(`Representation set to ${representationMode}`);
     } else {
       toast.error(friendlyErrorOrNull(result.error) ?? "Couldn't change representation mode");
+    }
+  }
+
+  async function handleSetRefresh(specRefreshInterval: string) {
+    const result = await setRefresh.mutate({ body: { specRefreshInterval } });
+    if (result.ok) {
+      toast.success(
+        specRefreshInterval === "off"
+          ? "Auto-refresh disabled"
+          : `Auto-refresh set to ${formatRefreshLabel(specRefreshInterval).toLowerCase()}`,
+      );
+    } else {
+      toast.error(friendlyErrorOrNull(result.error) ?? "Couldn't change the refresh interval");
     }
   }
 
@@ -343,6 +382,38 @@ function OpenApiInstallCard({ ds, onChange }: { ds: DatasourceSummary; onChange:
                 />
                 <span className="text-xs text-muted-foreground">semantic-yaml</span>
               </span>
+            }
+          />
+          <DetailRow
+            label="Auto-refresh"
+            value={
+              <Select
+                value={ds.specRefreshInterval}
+                disabled={setMode.saving || setRefresh.saving}
+                onValueChange={handleSetRefresh}
+              >
+                <SelectTrigger
+                  className="h-7 w-36 text-xs"
+                  aria-label="Spec auto-refresh interval"
+                  data-testid="openapi-refresh-interval"
+                >
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {REFRESH_INTERVAL_OPTIONS.map((o) => (
+                    <SelectItem key={o.value} value={o.value}>
+                      {o.label}
+                    </SelectItem>
+                  ))}
+                  {/* A custom "<N>h" interval (set via atlas.config.ts) isn't a preset —
+                      surface it so the Select shows the live value rather than blanking. */}
+                  {REFRESH_INTERVAL_OPTIONS.every((o) => o.value !== ds.specRefreshInterval) ? (
+                    <SelectItem value={ds.specRefreshInterval}>
+                      {formatRefreshLabel(ds.specRefreshInterval)}
+                    </SelectItem>
+                  ) : null}
+                </SelectContent>
+              </Select>
             }
           />
         </DetailList>


### PR DESCRIPTION
## What & why

Closes #2977 (v0.0.2 — REST Datasources). Adds a **per-install, customer-configurable spec-refresh interval** to a generic OpenAPI datasource, plus an explicit **manual re-discovery** ("Refresh now"). This is the foundation that unblocks the scheduler slice **#2978** — it lands the `spec_refresh_interval` field shape + reader deliberately so #2978's periodic fiber can consume it.

**No background scheduler in this slice** — just the stored setting, its validation, the manual trigger, and the read accessor. Re-discovery still happens on demand via the existing Rediscover-schema path (#2926).

## Field shape

Stored on the OpenAPI datasource's `workspace_plugins.config` JSONB. It holds no secret, so **no migration, no encryption surface** — same pattern as `rate_limit_per_minute` / `request_timeout_ms`.

Canonical value: `off` (default) · `daily` (24h) · `weekly` (168h) · `"<N>h"` custom, clamped to **1h–720h** (30 days).

## Changes

- **`lib/openapi/spec-refresh.ts`** (new) — focused module so #2978 imports a single reader:
  - `normalizeSpecRefreshInterval` — **write-path** validate + clamp. An out-of-range *positive* value is **clamped** (e.g. `9000h` → the 30-day ceiling); only non-positive / unparseable / wrong-typed input is **rejected with an actionable message** — never a silent fallback to `off` (CLAUDE.md error-handling).
  - `getSpecRefreshIntervalMs` — **read-path** reader for the #2978 scheduler, mirroring `getExpertSchedulerIntervalMs` (returns ms). `off` and any drifted/unparseable value → `null` (the signal to **skip** that install). Clamps drifted out-of-range stored values on read too.
  - `coerceSpecRefreshInterval` — fail-soft display coercion for the summary + UI Select (non-string/unknown → `off`).
- **`admin-openapi-datasources` PATCH** — now a partial update accepting `specRefreshInterval` alongside `representationMode`; representation-only PATCH keeps its exact single-key SQL shape. Surfaces `specRefreshInterval` in the list/detail summary. Encrypted `auth_value` is never round-tripped (JSONB merge of only the changed keys; keys come from a fixed allow-set, values bound).
- **`openapi-block.tsx`** — an **Auto-refresh** `<Select>` (shadcn/ui, `useAdminMutation`) on the datasource card. The existing **Rediscover schema** button is the manual "Refresh now" (reused as-is — established label, referenced in the dialog error copy).
- **Docs** — `openapi-generic.mdx`: a "Keeping the spec current" section + a `spec_refresh_interval` config-table row, with a note that the auto-refresh fiber lands in a follow-up.

## Acceptance criteria

- [x] `config` carries a validated `spec_refresh_interval`; default `off`.
- [x] Admin control to set/clear the interval + a manual "Refresh now" (Rediscover schema) button wired to re-discovery.
- [x] Write path validates + clamps; invalid input → actionable 400, no silent fallback.
- [x] Honors the install record's lifecycle (archived rows excluded by `loadInstall`); non-secret field, so no encryption surface. It's operator config, not published content, so — like the representation toggle — it isn't mode-gated.
- [x] Tests: set / clear / clamp / reject at the unit + route layers; "Refresh now" triggers a re-probe.

## Note for #2978

The scheduler reads `getSpecRefreshIntervalMs(config.spec_refresh_interval)` → ms (skip on `null`), then layers on its own last-checked watermark. Reader is shaped/named to mirror `getExpertSchedulerIntervalMs`.

## Testing

`/ci` — all gates green (lint, type, full test 517 + others 0 failures, syncpack, template/schema/test-discipline/security-headers/railway-watch/oauth-helper/twenty-resolver/published-symbols drift).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3002"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782698871&installation_id=135337507&pr_number=3002&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3002&signature=38752e77ba5dce57e2c261dc9cb31dbd8f3645106f57103252aaa7ba837c3d84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Manual schema refresh ("Rediscover schema") for OpenAPI datasources
  * Configurable Auto-refresh intervals with presets (off, daily, weekly) and custom hour values; UI selector on datasource cards
  * Admin config now persists the chosen Auto-refresh interval

* **Validation**
  * Invalid intervals are rejected with feedback; out-of-range hour values are clamped

* **Documentation**
  * Docs and API reference updated with guidance on keeping specs current and Auto-refresh behavior (background scheduler pending)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AtlasDevHQ/atlas/pull/3002?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->