### PR TITLE
fix(docs): coerce docs root to 200 by stripping edge-injected Range (#2947)

### DIFF
--- a/deploy/docs/Caddyfile
+++ b/deploy/docs/Caddyfile
@@ -11,6 +11,18 @@
 
 	encode zstd gzip
 
+	# The HTTP edge in front of this container (Railway's router / Cloudflare)
+	# injects `Range: bytes=0-` on every upstream request. Caddy's file_server
+	# honours it and answers `206 Partial Content` with a full-body Content-Range
+	# for otherwise-complete documents, so every page — including `/` — serves as
+	# 206. Strict `== 200` uptime monitors then false-flag the site as down (#2947).
+	# The docs are a static HTML/CSS/JS/JSON export with no byte-range consumers
+	# (the Orama search client fetches /api/search whole, not via ranges), so
+	# dropping the request `Range` header is safe and makes every response a clean
+	# 200. Caddy still returns the full body either way — this only changes the
+	# status line.
+	request_header -Range
+
 	# Next.js content-hashes /_next/static URLs, so they're safe to pin immutably.
 	@nextStatic path /_next/static/*
 	header @nextStatic Cache-Control "public, max-age=31536000, immutable"


### PR DESCRIPTION
## What

Fixes #2947 — `docs.useatlas.dev/` (and every other docs page) returned **`206 Partial Content`** instead of `200`, false-flagging strict `== 200` uptime monitors (surfaced by `/prod-audit`).

One-line fix in the docs Caddyfile: **strip the inbound `Range` header** so Caddy's `file_server` always answers a clean `200`.

## Root cause (diagnosed via `/diagnose`)

`docs.useatlas.dev` is a **static Next.js export served by Caddy** (`deploy/docs/Dockerfile` → `caddy:2.10-alpine`, `file_server` with `precompressed zstd gzip`) — there is no Next.js server at runtime, so this is **not** a Next/Fumadocs streaming quirk.

The 206 is **unconditional and sitewide** in prod (every request, including `HEAD`, with no client `Range` header):

```
$ curl -sI https://docs.useatlas.dev/
HTTP/2 206
content-range: bytes 0-55979/55980   # full body, mislabeled partial
accept-ranges: bytes
```

A server must only return 206 in response to a `Range` request, so something between the client and Caddy is injecting one. I confirmed this by running the **exact repo Caddyfile** under `caddy:2.10-alpine` locally (no Cloudflare, no Railway edge):

| Request | Local Caddy (origin) | Prod (behind edge) |
|---|---|---|
| `GET /` (no Range) | **200** | 206 |
| `HEAD /` | **200** | 206 |
| `GET /` + `Range: bytes=0-` | 206 (correct) | 206 |

So Caddy is behaving correctly — **the HTTP edge in front of the container (Railway's router / Cloudflare) injects `Range: bytes=0-` on every upstream request**, and Caddy faithfully returns 206 with a full-span `Content-Range`. The body is always complete; only the status line is "wrong", which is why strict-`200` monitors flag it.

## The fix

```caddyfile
request_header -Range
```

The docs are a static HTML/CSS/JS/JSON export with **no byte-range consumers** (the Orama search client fetches `/api/search` whole, not via ranges), so dropping the request `Range` header is safe and makes every response a clean `200`. Caddy still returns the full body either way — this only changes the status line. (A full block comment in the Caddyfile explains the why.)

## Verification (against `caddy:2.10-alpine`, the prod runtime image)

A/B of original vs patched Caddyfile, with `Range: bytes=0-` injected to simulate the edge:

```
ORIG  / Rng     -> 206      FIXED / Rng     -> 200     ✅ bug fixed
ORIG  /nope     -> 404      FIXED /nope     -> 404     ✅ 404 status preserved
ORIG  /nope Rng -> 404      FIXED /nope Rng -> 404     ✅ no regression
```

- `caddy adapt` validates the patched config: **OK**
- Body integrity: full `139969` bytes served (gzip intact) with `Range` present
- `/_next/static/*` assets still serve `200`; branded 404 shell still returns `404`

## Notes

- **Scope:** only `deploy/docs/Caddyfile` changes — no TS/JS/JSON source touched, so the local lint/type/test suite cannot be affected by this change. The change was validated with `caddy adapt` (the domain-correct check) + the behavioral A/B above; GitHub's required checks (`ci`, `api-tests`, `Deploy Validation`, `Analyze`) run as the authoritative gate here.
- Severity is LOW/cosmetic — this is the proportionate, in-repo fix (issue path **a**), not an over-engineered custom server or edge rule.

Closes #2947

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3003"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782699345&installation_id=135337507&pr_number=3003&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3003&signature=be2451072f59b9fcc0cb39ec47072533a35703f51bca5f48ac25e6712ea30adb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved documentation site response consistency to ensure proper HTTP status codes are returned for all requests, enhancing compatibility with third-party tools and monitoring systems.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AtlasDevHQ/atlas/pull/3003?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->