### PR TITLE
fix(billing): atomic chat-integration cap enforcement + real-PG coverage (#3001, #2999, #2995)

### DIFF
--- a/packages/api/src/api/__tests__/integrations-discord.test.ts
+++ b/packages/api/src/api/__tests__/integrations-discord.test.ts
@@ -56,17 +56,46 @@ const mockInternalQuery: Mock<(sql: string, params?: unknown[]) => QueryResult> 
   },
 );
 
+// A fake transaction client for the atomic chat-install gate
+// (`checkChatIntegrationLimitAndInstall`, #3001). The gate runs the cap
+// re-count + workspace_plugins UPSERT inside a transaction on a client from
+// `getInternalDB().connect()`, so the route test must supply a connectable
+// pool. Transaction-control statements (BEGIN/COMMIT/ROLLBACK + the advisory
+// lock) are no-ops; the COUNT and INSERT delegate to the same
+// `mockInternalQuery` each test already scripts, wrapped as `{ rows }`.
+const fakeTxnClient = {
+  query: async (sql: string, params?: unknown[]): Promise<{ rows: DbRow[] }> => {
+    if (
+      sql === "BEGIN" ||
+      sql === "COMMIT" ||
+      sql === "ROLLBACK" ||
+      sql.includes("pg_advisory_xact_lock")
+    ) {
+      return { rows: [] };
+    }
+    return { rows: await mockInternalQuery(sql, params) };
+  },
+  release: () => {},
+};
+
 // Partial mock — spread the real module's exports so admin auth,
 // migration helpers, encryption helpers, and the dozens of other
 // consumers in the import graph stay intact. Override `internalQuery`
-// (the read path this route uses) and `hasInternalDB` (the
+// (the read path this route uses), `hasInternalDB` (the
 // `requireOrgContext()` middleware on `integrationsCatalog` short-
-// circuits to 404 when DB is unconfigured — true in tests by default).
+// circuits to 404 when DB is unconfigured — true in tests by default),
+// and `getInternalDB` (the atomic install gate's transaction pool).
 const realInternal = await import("@atlas/api/lib/db/internal");
 mock.module("@atlas/api/lib/db/internal", () => ({
   ...realInternal,
   internalQuery: mockInternalQuery,
   hasInternalDB: mock(() => true),
+  getInternalDB: mock(() => ({
+    query: async (sql: string, params?: unknown[]) => ({ rows: await mockInternalQuery(sql, params) }),
+    connect: () => Promise.resolve(fakeTxnClient),
+    end: () => Promise.resolve(),
+    on: () => {},
+  })),
 }));
 
 // Auth — mutable for per-test admin/non-admin/unauthenticated scenarios.

--- a/packages/api/src/api/__tests__/integrations-discord.test.ts
+++ b/packages/api/src/api/__tests__/integrations-discord.test.ts
@@ -61,8 +61,12 @@ const mockInternalQuery: Mock<(sql: string, params?: unknown[]) => QueryResult> 
 // re-count + workspace_plugins UPSERT inside a transaction on a client from
 // `getInternalDB().connect()`, so the route test must supply a connectable
 // pool. Transaction-control statements (BEGIN/COMMIT/ROLLBACK + the advisory
-// lock) are no-ops; the COUNT and INSERT delegate to the same
-// `mockInternalQuery` each test already scripts, wrapped as `{ rows }`.
+// lock) are **no-ops here** — this test only proves the route → handler → gate
+// → SQL-dispatch wiring, NOT lock behaviour. Genuine advisory-lock contention
+// (two concurrent net-new installs racing the cap) is covered against real
+// Postgres in `billing/__tests__/chat-cap-pg.test.ts`. The COUNT and INSERT
+// delegate to the same `mockInternalQuery` each test already scripts, wrapped
+// as `{ rows }`.
 const fakeTxnClient = {
   query: async (sql: string, params?: unknown[]): Promise<{ rows: DbRow[] }> => {
     if (

--- a/packages/api/src/lib/billing/__tests__/chat-cap-pg.test.ts
+++ b/packages/api/src/lib/billing/__tests__/chat-cap-pg.test.ts
@@ -410,4 +410,44 @@ describeIfPg("checkChatIntegrationLimitAndInstall (real Postgres)", () => {
     },
     PG_TEST_TIMEOUT_MS,
   );
+
+  it(
+    "two concurrent SAME-platform installs at cap — both succeed, collapse to one row",
+    async () => {
+      const ws = `ws-same-${Date.now()}`;
+      await seedOrg(ws, "starter"); // cap = 1, zero installed
+
+      // The docstring claims the same-platform case was always safe — the
+      // singleton partial unique index collapses the duplicate into an UPSERT.
+      // Prove it under real contention: two concurrent Slack installs serialize
+      // on the advisory lock; the first lands net-new (allowed), the second
+      // recounts this_count=1 → reconnect → skips the cap → UPSERTs the same
+      // (workspace, catalog) row. Both allowed, exactly one row.
+      const [a, b] = await Promise.all([
+        checkChatIntegrationLimitAndInstall<{ id: string }>(
+          ws,
+          "catalog:slack",
+          slackInsert(`${ws}-slack-a`, ws),
+        ),
+        checkChatIntegrationLimitAndInstall<{ id: string }>(
+          ws,
+          "catalog:slack",
+          slackInsert(`${ws}-slack-b`, ws),
+        ),
+      ]);
+
+      expect(a.allowed).toBe(true);
+      expect(b.allowed).toBe(true);
+
+      // Exactly one Slack row — the second install collapsed onto the first via
+      // ON CONFLICT, never breaching the cap.
+      const { rows } = await pool.query<{ catalog_id: string }>(
+        `SELECT catalog_id FROM workspace_plugins WHERE workspace_id = $1 AND pillar = 'chat'`,
+        [ws],
+      );
+      expect(rows).toHaveLength(1);
+      expect(rows[0]?.catalog_id).toBe("catalog:slack");
+    },
+    PG_TEST_TIMEOUT_MS,
+  );
 });

--- a/packages/api/src/lib/billing/__tests__/chat-cap-pg.test.ts
+++ b/packages/api/src/lib/billing/__tests__/chat-cap-pg.test.ts
@@ -1,0 +1,413 @@
+/**
+ * Real-Postgres coverage for the chat-integration cap (#2999 / #2995 AC3 /
+ * #3001 AC2). Mirrors the `migrate-pg.test.ts` harness: skips cleanly when
+ * `TEST_DATABASE_URL` is unset, runs every migration into a unique per-test
+ * schema, and exercises behaviour that mock-pool tests can't see.
+ *
+ * What this catches that the mock-based `enforcement.test.ts` can't:
+ *   - #2999 — the `CHAT_INTEGRATION_COUNT_SQL` aggregate is never executed by
+ *     the unit tests (they script the count rows). A typo in the FILTER
+ *     predicate, an inverted `<>`/`=`, or a dropped `status <> 'archived'`
+ *     would pass every unit test. Here the real aggregate runs against seeded
+ *     mixed-pillar rows.
+ *   - #2995 AC3 — the chat-install handlers' `workspace_plugins` INSERT is only
+ *     asserted as a SQL *string* by the handler unit tests. Here the real
+ *     Discord handler's UPSERT runs against the real post-0096 schema, so a
+ *     NOT-NULL `pillar`/`install_id` regression or a stale `ON CONFLICT`
+ *     arbiter is caught.
+ *   - #3001 AC2 — two concurrent net-new installs at cap-minus-1: the
+ *     per-workspace `pg_advisory_xact_lock` must let exactly one through.
+ *
+ * Opt in locally with:
+ *   bun run db:up && export TEST_DATABASE_URL=postgresql://atlas:atlas@localhost:5432/atlas
+ */
+
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
+import { Pool } from "pg";
+import type { WorkspaceId } from "@useatlas/types";
+import { runMigrations } from "@atlas/api/lib/db/migrate";
+import {
+  MANAGED_AUTH_MIGRATIONS,
+  _resetPool,
+  type InternalPool,
+} from "@atlas/api/lib/db/internal";
+import {
+  CHAT_INTEGRATION_COUNT_SQL,
+  checkChatIntegrationLimitAndInstall,
+  invalidatePlanCache,
+} from "@atlas/api/lib/billing/enforcement";
+
+const TEST_DB_URL = process.env.TEST_DATABASE_URL;
+const describeIfPg = TEST_DB_URL ? describe : describe.skip;
+
+// The full migration set + transactional gate work can take several seconds on
+// shared CI runners (matches migrate-pg.test.ts's 30s budget).
+const PG_TEST_TIMEOUT_MS = 30_000;
+
+/** Seed a `plugin_catalog` row so `workspace_plugins.catalog_id` FK resolves. */
+async function seedCatalog(
+  pool: Pool,
+  slug: string,
+  pillar: "chat" | "action",
+): Promise<void> {
+  await pool.query(
+    `INSERT INTO plugin_catalog (id, name, slug, type, pillar)
+     VALUES ($1, $2, $3, $4, $4)
+     ON CONFLICT (id) DO NOTHING`,
+    [`catalog:${slug}`, slug, slug, pillar],
+  );
+}
+
+/** Seed a `workspace_plugins` row with explicit pillar + status. */
+async function seedInstall(
+  pool: Pool,
+  opts: {
+    id: string;
+    workspaceId: string;
+    catalog: string;
+    pillar: "chat" | "action";
+    status?: "published" | "draft" | "archived";
+  },
+): Promise<void> {
+  await pool.query(
+    `INSERT INTO workspace_plugins (id, workspace_id, catalog_id, install_id, pillar, config, enabled, status, installed_at)
+     VALUES ($1, $2, $3, $1, $4, '{}'::jsonb, true, $5, NOW())`,
+    [opts.id, opts.workspaceId, opts.catalog, opts.pillar, opts.status ?? "published"],
+  );
+}
+
+// ---------------------------------------------------------------------------
+// #2999 — CHAT_INTEGRATION_COUNT_SQL aggregate
+// ---------------------------------------------------------------------------
+
+describeIfPg("CHAT_INTEGRATION_COUNT_SQL (real Postgres)", () => {
+  let pool: Pool;
+  const schemaName = `chat_cap_count_${Date.now()}_${Math.floor(Math.random() * 1e6)}`;
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: TEST_DB_URL });
+    pool.on("connect", (client) => {
+      void client.query(`SET search_path TO "${schemaName}"`).catch((err) => {
+        const message = err instanceof Error ? err.message : String(err);
+        console.error(`chat-cap-pg: SET search_path failed: ${message}`);
+      });
+    });
+    await pool.query(`CREATE SCHEMA IF NOT EXISTS "${schemaName}"`);
+    await runMigrations(pool, { skip: MANAGED_AUTH_MIGRATIONS });
+    // Catalog rows for every platform referenced below (FK targets).
+    await seedCatalog(pool, "slack", "chat");
+    await seedCatalog(pool, "discord", "chat");
+    await seedCatalog(pool, "telegram", "chat");
+    await seedCatalog(pool, "gchat", "chat");
+    await seedCatalog(pool, "jira", "action");
+  }, PG_TEST_TIMEOUT_MS);
+
+  afterAll(async () => {
+    if (!pool) return;
+    await pool.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`);
+    await pool.end();
+  });
+
+  it(
+    "counts others vs this_count, excluding action / archived / other-workspace rows (#2999)",
+    async () => {
+      const ws = `ws-count-${Date.now()}`;
+      const otherWs = `ws-other-${Date.now()}`;
+      // Workspace under test:
+      await seedInstall(pool, { id: `${ws}-slack`, workspaceId: ws, catalog: "catalog:slack", pillar: "chat" });
+      await seedInstall(pool, { id: `${ws}-discord`, workspaceId: ws, catalog: "catalog:discord", pillar: "chat" });
+      await seedInstall(pool, { id: `${ws}-telegram`, workspaceId: ws, catalog: "catalog:telegram", pillar: "chat" });
+      // Action pillar — must NOT count toward the chat cap.
+      await seedInstall(pool, { id: `${ws}-jira`, workspaceId: ws, catalog: "catalog:jira", pillar: "action" });
+      // Archived chat — must NOT count.
+      await seedInstall(pool, { id: `${ws}-gchat`, workspaceId: ws, catalog: "catalog:gchat", pillar: "chat", status: "archived" });
+      // Different workspace's chat — must NOT count.
+      await seedInstall(pool, { id: `${otherWs}-slack`, workspaceId: otherWs, catalog: "catalog:slack", pillar: "chat" });
+
+      // Reconnect case — Slack IS installed for this workspace.
+      const reconnect = await pool.query<{ others: number; this_count: number }>(
+        CHAT_INTEGRATION_COUNT_SQL,
+        [ws, "catalog:slack"],
+      );
+      // others = discord + telegram (2); this_count = slack (1). Action,
+      // archived, and the other workspace's row are all excluded.
+      expect(reconnect.rows[0]?.others).toBe(2);
+      expect(reconnect.rows[0]?.this_count).toBe(1);
+
+      // Net-new case — WhatsApp is NOT installed for this workspace.
+      const netNew = await pool.query<{ others: number; this_count: number }>(
+        CHAT_INTEGRATION_COUNT_SQL,
+        [ws, "catalog:whatsapp"],
+      );
+      // others = slack + discord + telegram (3); this_count = 0 (none installed
+      // for whatsapp). Action/archived/other-workspace still excluded.
+      expect(netNew.rows[0]?.others).toBe(3);
+      expect(netNew.rows[0]?.this_count).toBe(0);
+
+      // Integer typing — `::int` casts must return JS numbers, not strings.
+      expect(typeof reconnect.rows[0]?.others).toBe("number");
+    },
+    PG_TEST_TIMEOUT_MS,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// #2995 AC3 + #3001 AC2 — the atomic gate against the real schema
+//
+// Wires the gate's module pool (`getInternalDB()` / `internalQuery`) to this
+// test's scratch-schema pool via `_resetPool`, and sets `DATABASE_URL` so
+// `hasInternalDB()` is true. A minimal `organization` table backs the plan-tier
+// lookup (`getWorkspaceDetails`); Better-Auth owns it in production, so it is
+// not in our migration set.
+// ---------------------------------------------------------------------------
+
+describeIfPg("checkChatIntegrationLimitAndInstall (real Postgres)", () => {
+  let pool: Pool;
+  const schemaName = `chat_cap_gate_${Date.now()}_${Math.floor(Math.random() * 1e6)}`;
+  const ORIGINAL_DATABASE_URL = process.env.DATABASE_URL;
+  const ORIGINAL_FETCH = globalThis.fetch;
+
+  /** Slack-handler-shaped UPSERT (mirrors slack-oauth-handler.ts). */
+  function slackInsert(installId: string, ws: string) {
+    return {
+      sql: `INSERT INTO workspace_plugins (id, workspace_id, catalog_id, install_id, pillar, config, enabled, installed_at)
+         VALUES ($1, $2, $3, $1, 'chat', $4::jsonb, true, NOW())
+         ON CONFLICT (workspace_id, catalog_id) WHERE pillar IN ('chat', 'action') DO UPDATE
+           SET config = EXCLUDED.config, enabled = true`,
+      params: [installId, ws, "catalog:slack", JSON.stringify({ team_id: "T1" })],
+    };
+  }
+
+  /** Discord-handler-shaped UPSERT with RETURNING id (mirrors discord-static-bot-handler.ts). */
+  function discordInsert(installId: string, ws: string) {
+    return {
+      sql: `INSERT INTO workspace_plugins
+           (id, workspace_id, catalog_id, install_id, pillar, config, enabled, installed_at)
+         VALUES ($1, $2, $3, $1, 'chat', $4::jsonb, true, NOW())
+         ON CONFLICT (workspace_id, catalog_id) WHERE pillar IN ('chat', 'action')
+         DO UPDATE SET config = EXCLUDED.config, enabled = true
+         RETURNING id`,
+      params: [installId, ws, "catalog:discord", JSON.stringify({ guild_id: "G1" })],
+    };
+  }
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: TEST_DB_URL });
+    pool.on("connect", (client) => {
+      void client.query(`SET search_path TO "${schemaName}"`).catch((err) => {
+        const message = err instanceof Error ? err.message : String(err);
+        console.error(`chat-cap-pg: SET search_path failed: ${message}`);
+      });
+    });
+    await pool.query(`CREATE SCHEMA IF NOT EXISTS "${schemaName}"`);
+    await runMigrations(pool, { skip: MANAGED_AUTH_MIGRATIONS });
+    // Minimal `organization` — only the columns getWorkspaceDetails reads.
+    await pool.query(
+      `CREATE TABLE organization (
+         id text PRIMARY KEY,
+         name text,
+         slug text,
+         workspace_status text NOT NULL DEFAULT 'active',
+         plan_tier text NOT NULL DEFAULT 'free',
+         byot boolean NOT NULL DEFAULT false,
+         stripe_customer_id text,
+         trial_ends_at timestamptz,
+         suspended_at timestamptz,
+         deleted_at timestamptz,
+         region text,
+         region_assigned_at timestamptz,
+         "createdAt" timestamptz NOT NULL DEFAULT now()
+       )`,
+    );
+    await seedCatalog(pool, "slack", "chat");
+    await seedCatalog(pool, "discord", "chat");
+    await seedCatalog(pool, "telegram", "chat");
+
+    // Point the gate's module pool at this scratch-schema pool.
+    process.env.DATABASE_URL = TEST_DB_URL;
+    _resetPool(pool as unknown as InternalPool, null);
+  }, PG_TEST_TIMEOUT_MS);
+
+  afterAll(async () => {
+    _resetPool(null, null);
+    if (ORIGINAL_DATABASE_URL === undefined) delete process.env.DATABASE_URL;
+    else process.env.DATABASE_URL = ORIGINAL_DATABASE_URL;
+    globalThis.fetch = ORIGINAL_FETCH;
+    if (!pool) return;
+    await pool.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`);
+    await pool.end();
+  });
+
+  afterEach(async () => {
+    invalidatePlanCache();
+    globalThis.fetch = ORIGINAL_FETCH;
+    await pool.query(`DELETE FROM workspace_plugins`);
+    await pool.query(`DELETE FROM organization`);
+  });
+
+  /** Seed an organization row with the given plan tier. */
+  async function seedOrg(id: string, planTier: string): Promise<void> {
+    await pool.query(
+      `INSERT INTO organization (id, name, slug, plan_tier) VALUES ($1, $1, $1, $2)`,
+      [id, planTier],
+    );
+  }
+
+  it(
+    "commits the chat-install UPSERT against the real post-0096 schema (#2995 AC3)",
+    async () => {
+      // No organization row → the gate treats the workspace as pre-migration
+      // and allows, so this isolates the INSERT's schema-compatibility: the
+      // NOT-NULL pillar/install_id columns and the partial-index ON CONFLICT
+      // arbiter must all be valid against the live schema.
+      const ws = `ws-insert-${Date.now()}`;
+      const gate = await checkChatIntegrationLimitAndInstall<{ id: string }>(
+        ws,
+        "catalog:slack",
+        slackInsert(`${ws}-slack`, ws),
+      );
+      expect(gate.allowed).toBe(true);
+
+      const { rows } = await pool.query<{
+        pillar: string;
+        install_id: string;
+        status: string;
+        catalog_id: string;
+      }>(
+        `SELECT pillar, install_id, status, catalog_id FROM workspace_plugins WHERE workspace_id = $1`,
+        [ws],
+      );
+      expect(rows).toHaveLength(1);
+      expect(rows[0]?.pillar).toBe("chat");
+      expect(rows[0]?.install_id).toBe(`${ws}-slack`);
+      expect(rows[0]?.status).toBe("published");
+      expect(rows[0]?.catalog_id).toBe("catalog:slack");
+    },
+    PG_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "runs the real Discord handler UPSERT end-to-end against real Postgres (#2995 AC3)",
+    async () => {
+      // Exercises the ACTUAL handler code path (validate → reachability → gate
+      // → INSERT) so handler↔schema drift on the live INSERT is caught, not a
+      // test-local copy. fetch is stubbed for the reachability round-trip.
+      const { DiscordStaticBotInstallHandler } = await import(
+        "../../integrations/install/discord-static-bot-handler"
+      );
+      const guildId = "123456789012345678";
+      globalThis.fetch = (async () =>
+        new Response(JSON.stringify({ id: guildId, name: "Acme" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        })) as unknown as typeof fetch;
+
+      const ws = `ws-discord-${Date.now()}`;
+      const handler = new DiscordStaticBotInstallHandler({
+        botToken: "tkn",
+        clientId: "111",
+        idGenerator: () => `${ws}-candidate`,
+      });
+
+      // First install commits a row.
+      const first = await handler.confirmInstall(ws as WorkspaceId, guildId);
+      expect(first.installRecord.catalogId).toBe("discord");
+
+      const afterFirst = await pool.query<{ id: string; config: { guild_name?: string } }>(
+        `SELECT id, config FROM workspace_plugins WHERE workspace_id = $1 AND catalog_id = 'catalog:discord'`,
+        [ws],
+      );
+      expect(afterFirst.rows).toHaveLength(1);
+      const persistedId = afterFirst.rows[0]!.id;
+      expect(first.installRecord.id).toBe(persistedId);
+
+      // Reconnect (same workspace + guild, new name) UPSERTs the same row.
+      const second = await handler.confirmInstall(ws as WorkspaceId, guildId, undefined, {
+        guild_name: "Acme Renamed",
+      });
+      expect(second.installRecord.id).toBe(persistedId);
+
+      const afterSecond = await pool.query<{ id: string }>(
+        `SELECT id FROM workspace_plugins WHERE workspace_id = $1 AND catalog_id = 'catalog:discord'`,
+        [ws],
+      );
+      // Idempotent — still exactly one row, same id.
+      expect(afterSecond.rows).toHaveLength(1);
+      expect(afterSecond.rows[0]?.id).toBe(persistedId);
+    },
+    PG_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "blocks a net-new platform at the cap and rolls back (no row written)",
+    async () => {
+      const ws = `ws-cap-${Date.now()}`;
+      await seedOrg(ws, "starter"); // maxChatIntegrations = 1
+      // One chat platform already installed → the slot is full.
+      await seedInstall(pool, {
+        id: `${ws}-telegram`,
+        workspaceId: ws,
+        catalog: "catalog:telegram",
+        pillar: "chat",
+      });
+
+      const gate = await checkChatIntegrationLimitAndInstall<{ id: string }>(
+        ws,
+        "catalog:slack",
+        slackInsert(`${ws}-slack`, ws),
+      );
+      expect(gate.allowed).toBe(false);
+      if (!gate.allowed) expect(gate.reason).toBe("cap_reached");
+
+      // The INSERT was rolled back — Slack never landed; only telegram remains.
+      const { rows } = await pool.query<{ catalog_id: string }>(
+        `SELECT catalog_id FROM workspace_plugins WHERE workspace_id = $1 ORDER BY catalog_id`,
+        [ws],
+      );
+      expect(rows.map((r) => r.catalog_id)).toEqual(["catalog:telegram"]);
+    },
+    PG_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "two concurrent net-new installs at cap-minus-1 — exactly one succeeds (#3001 AC2)",
+    async () => {
+      const ws = `ws-race-${Date.now()}`;
+      await seedOrg(ws, "starter"); // cap = 1, zero installed → exactly one free slot
+
+      // Slack + Discord OAuth callbacks completing in the same window. Without
+      // the per-workspace advisory lock both would count 0 and both insert,
+      // landing the workspace at 2 (over the cap of 1). With the lock the
+      // second blocks, recounts 1, and is refused.
+      const [slack, discord] = await Promise.all([
+        checkChatIntegrationLimitAndInstall<{ id: string }>(
+          ws,
+          "catalog:slack",
+          slackInsert(`${ws}-slack`, ws),
+        ),
+        checkChatIntegrationLimitAndInstall<{ id: string }>(
+          ws,
+          "catalog:discord",
+          discordInsert(`${ws}-discord`, ws),
+        ),
+      ]);
+
+      const allowed = [slack, discord].filter((r) => r.allowed);
+      const denied = [slack, discord].filter((r) => !r.allowed);
+      expect(allowed).toHaveLength(1);
+      expect(denied).toHaveLength(1);
+      const deniedResult = denied[0]!;
+      expect(deniedResult.allowed).toBe(false);
+      // The loser is refused for the cap (429 "upgrade"), not a transient blip.
+      if (!deniedResult.allowed) expect(deniedResult.reason).toBe("cap_reached");
+
+      // The DB holds exactly one chat install for the workspace.
+      const { rows } = await pool.query<{ n: number }>(
+        `SELECT COUNT(*)::int AS n FROM workspace_plugins WHERE workspace_id = $1 AND pillar = 'chat'`,
+        [ws],
+      );
+      expect(rows[0]?.n).toBe(1);
+    },
+    PG_TEST_TIMEOUT_MS,
+  );
+});

--- a/packages/api/src/lib/billing/__tests__/enforcement.test.ts
+++ b/packages/api/src/lib/billing/__tests__/enforcement.test.ts
@@ -821,6 +821,20 @@ describe("checkChatIntegrationLimitAndInstall", () => {
     expect(mockConnectCount).toBe(0);
   });
 
+  it("runs the INSERT directly (no lock) when the workspace has no organization row", async () => {
+    // orgId present + internal DB present, but no `organization` row → no plan,
+    // no cap. The ONLY deliberate fail-open: allow with a direct INSERT and
+    // never open a transaction. (A workspace lookup *error* fails closed — see
+    // the next section; a genuine *absence* allows.)
+    mockWorkspace = null;
+    mockInternalQueryResult = [{ id: "no-org-row" }];
+    const result = await checkChatIntegrationLimitAndInstall<{ id: string }>("org-1", SLACK, INSERT);
+    expect(result.allowed).toBe(true);
+    if (result.allowed) expect(result.rows).toEqual([{ id: "no-org-row" }]);
+    // No transaction opened — the fail-open path skips the lock entirely.
+    expect(mockConnectCount).toBe(0);
+  });
+
   // ── Fail-closed before/under the lock ─────────────────────────────
 
   it("fails closed (check_failed) before opening a transaction when the workspace lookup throws", async () => {

--- a/packages/api/src/lib/billing/__tests__/enforcement.test.ts
+++ b/packages/api/src/lib/billing/__tests__/enforcement.test.ts
@@ -24,6 +24,15 @@ let mockUsageShouldThrow = false;
 let mockInternalQueryResult: unknown[] = [];
 /** When true, the `internalQuery` mock throws (count-query failure path). */
 let mockInternalQueryShouldThrow = false;
+/**
+ * Fake transaction client `getInternalDB().connect()` hands back for the
+ * atomic install-gate tests (`checkChatIntegrationLimitAndInstall`). Set per
+ * test via {@link makeFakeTxnClient}; `null` means no test configured one (the
+ * gate's no-orgId / no-DB short-circuits never call `connect`).
+ */
+let mockTxnClient: ReturnType<typeof makeFakeTxnClient> | null = null;
+/** Count of `getInternalDB().connect()` calls — asserts no transaction opened. */
+let mockConnectCount = 0;
 
 mock.module("@atlas/api/lib/db/internal", () => ({
   hasInternalDB: () => mockHasInternalDB,
@@ -32,7 +41,18 @@ mock.module("@atlas/api/lib/db/internal", () => ({
     return orgId ? mockWorkspace : null;
   },
   getWorkspaceStatus: async () => mockWorkspace?.workspace_status ?? null,
-  getInternalDB: () => ({ query: mock(() => Promise.resolve({ rows: [] })), end: mock(() => {}), on: mock(() => {}) }),
+  getInternalDB: () => ({
+    query: mock(() => Promise.resolve({ rows: [] })),
+    connect: () => {
+      mockConnectCount++;
+      if (!mockTxnClient) {
+        throw new Error("test did not configure a fake txn client (mockTxnClient)");
+      }
+      return Promise.resolve(mockTxnClient.client);
+    },
+    end: mock(() => {}),
+    on: mock(() => {}),
+  }),
   internalQuery: async () => {
     if (mockInternalQueryShouldThrow) throw new Error("db error");
     return mockInternalQueryResult;
@@ -73,7 +93,7 @@ mock.module("@atlas/api/lib/logger", () => ({
 
 // --- Import under test ---
 
-import { checkChatIntegrationLimit, checkPlanLimits, checkResourceLimit, invalidatePlanCache, type PlanCheckResult, type ResourceLimitResult } from "@atlas/api/lib/billing/enforcement";
+import { checkChatIntegrationLimitAndInstall, CHAT_INTEGRATION_COUNT_SQL, checkPlanLimits, checkResourceLimit, invalidatePlanCache, type ChatIntegrationInstallResult, type PlanCheckResult, type ResourceLimitResult } from "@atlas/api/lib/billing/enforcement";
 
 /** Narrow a denied result for type-safe assertion access. */
 function expectDenied(result: PlanCheckResult): Extract<PlanCheckResult, { allowed: false }> {
@@ -94,6 +114,82 @@ function expectLimitExceeded(result: PlanCheckResult): Extract<PlanCheckResult, 
 function expectAllowed(result: PlanCheckResult): Extract<PlanCheckResult, { allowed: true }> {
   expect(result.allowed).toBe(true);
   return result as Extract<PlanCheckResult, { allowed: true }>;
+}
+
+// ---------------------------------------------------------------------------
+// Fake transaction client for the atomic install-gate tests
+// (`checkChatIntegrationLimitAndInstall`). Records every `query` call so a
+// test can assert the BEGIN → advisory-lock → COUNT → INSERT → COMMIT
+// sequence (or ROLLBACK on a denial), and exposes the `release` error so the
+// poisoned-socket destroy path can be checked.
+// ---------------------------------------------------------------------------
+
+interface FakeTxnClientOpts {
+  /** Rows returned for the chat-integration COUNT(*) FILTER query. */
+  readonly countRows?: Array<Record<string, unknown>>;
+  /** When true, the COUNT query throws. */
+  readonly countThrows?: boolean;
+  /** Rows returned for the workspace_plugins INSERT (RETURNING). */
+  readonly insertRows?: Array<Record<string, unknown>>;
+  /** When true, the INSERT throws (write-path failure → gate re-throws). */
+  readonly insertThrows?: boolean;
+  /** When true, ROLLBACK throws (poisoned socket → client destroyed on release). */
+  readonly rollbackThrows?: boolean;
+}
+
+function makeFakeTxnClient(opts: FakeTxnClientOpts = {}) {
+  const calls: Array<{ sql: string; params?: unknown[] }> = [];
+  const state: { releaseErr: Error | undefined; released: boolean } = {
+    releaseErr: undefined,
+    released: false,
+  };
+  const client = {
+    query: (sql: string, params?: unknown[]): Promise<{ rows: Record<string, unknown>[] }> => {
+      calls.push({ sql, params });
+      if (sql === "ROLLBACK") {
+        if (opts.rollbackThrows) return Promise.reject(new Error("rollback failed"));
+        return Promise.resolve({ rows: [] });
+      }
+      if (sql === "BEGIN" || sql === "COMMIT") return Promise.resolve({ rows: [] });
+      if (sql.includes("pg_advisory_xact_lock")) return Promise.resolve({ rows: [] });
+      if (sql.includes("COUNT(*) FILTER")) {
+        if (opts.countThrows) return Promise.reject(new Error("count failed"));
+        return Promise.resolve({ rows: opts.countRows ?? [] });
+      }
+      if (sql.includes("INSERT INTO workspace_plugins")) {
+        if (opts.insertThrows) return Promise.reject(new Error("insert failed"));
+        return Promise.resolve({ rows: opts.insertRows ?? [] });
+      }
+      return Promise.resolve({ rows: [] });
+    },
+    release: (err?: Error): void => {
+      state.released = true;
+      state.releaseErr = err;
+    },
+  };
+  /** SQL of every recorded call, in order — for sequence assertions. */
+  const sqls = (): string[] => calls.map((c) => c.sql);
+  /** True if any recorded call's SQL contains `needle`. */
+  const ran = (needle: string): boolean => calls.some((c) => c.sql.includes(needle));
+  return { client, calls, sqls, ran, state };
+}
+
+/** Narrow a chat-install gate cap_reached denial for `.limit` access. */
+function expectInstallCapReached<T extends Record<string, unknown>>(
+  result: ChatIntegrationInstallResult<T>,
+): Extract<ChatIntegrationInstallResult<T>, { reason: "cap_reached" }> {
+  expect(result.allowed).toBe(false);
+  if (!result.allowed) expect(result.reason).toBe("cap_reached");
+  return result as Extract<ChatIntegrationInstallResult<T>, { reason: "cap_reached" }>;
+}
+
+/** Narrow a chat-install gate check_failed (fail-closed) denial. */
+function expectInstallCheckFailed<T extends Record<string, unknown>>(
+  result: ChatIntegrationInstallResult<T>,
+): Extract<ChatIntegrationInstallResult<T>, { reason: "check_failed" }> {
+  expect(result.allowed).toBe(false);
+  if (!result.allowed) expect(result.reason).toBe("check_failed");
+  return result as Extract<ChatIntegrationInstallResult<T>, { reason: "check_failed" }>;
 }
 
 /** Create a standard workspace fixture (defaults to starter tier). */
@@ -662,11 +758,25 @@ describe("checkResourceLimit", () => {
 });
 
 // ---------------------------------------------------------------------------
-// checkChatIntegrationLimit — counts workspace_plugins(pillar='chat') (#2953)
+// checkChatIntegrationLimitAndInstall — atomic cap + INSERT gate (#2953, #3001)
+//
+// Exercises the in-transaction decision logic against a fake client that
+// records the BEGIN → advisory-lock → COUNT → (INSERT/COMMIT | ROLLBACK)
+// sequence. The COUNT and INSERT rows are scripted per test; the real-Postgres
+// aggregate + the concurrency race are covered by chat-cap-pg.test.ts (#2999).
 // ---------------------------------------------------------------------------
 
-describe("checkChatIntegrationLimit", () => {
+describe("checkChatIntegrationLimitAndInstall", () => {
   const SLACK = "catalog:slack";
+  /** A representative workspace_plugins UPSERT — the fake client matches on substring. */
+  const INSERT = {
+    sql: `INSERT INTO workspace_plugins (id, workspace_id, catalog_id, install_id, pillar, config, enabled, installed_at)
+      VALUES ($1, $2, $3, $1, 'chat', $4::jsonb, true, NOW())
+      ON CONFLICT (workspace_id, catalog_id) WHERE pillar IN ('chat', 'action') DO UPDATE
+        SET config = EXCLUDED.config, enabled = true
+      RETURNING id`,
+    params: ["install-1", "org-1", SLACK, "{}"],
+  };
 
   beforeEach(() => {
     mockHasInternalDB = true;
@@ -674,108 +784,221 @@ describe("checkChatIntegrationLimit", () => {
     mockWorkspace = null;
     mockInternalQueryResult = [];
     mockInternalQueryShouldThrow = false;
+    mockTxnClient = null;
+    mockConnectCount = 0;
     invalidatePlanCache();
   });
 
-  /** Shape the count-query row the way the SQL aliases it. */
-  function counts(others: number, thisCount: number): void {
-    mockInternalQueryResult = [{ others, this_count: thisCount }];
+  /** Configure the fake txn client with scripted COUNT + INSERT rows. */
+  function setTxn(
+    others: number,
+    thisCount: number,
+    opts: { insertRows?: Array<Record<string, unknown>>; rollbackThrows?: boolean } = {},
+  ): ReturnType<typeof makeFakeTxnClient> {
+    mockTxnClient = makeFakeTxnClient({
+      countRows: [{ others, this_count: thisCount }],
+      insertRows: opts.insertRows ?? [{ id: "persisted-1" }],
+      rollbackThrows: opts.rollbackThrows,
+    });
+    return mockTxnClient;
   }
 
-  it("allows when no orgId provided", async () => {
-    const result = await checkChatIntegrationLimit(undefined, SLACK);
+  // ── No-enforcement short-circuit (no lock / transaction) ──────────
+
+  it("runs the INSERT directly (no transaction) when no orgId", async () => {
+    mockInternalQueryResult = [{ id: "direct-1" }];
+    const result = await checkChatIntegrationLimitAndInstall<{ id: string }>(undefined, SLACK, INSERT);
     expect(result.allowed).toBe(true);
+    if (result.allowed) expect(result.rows).toEqual([{ id: "direct-1" }]);
+    expect(mockConnectCount).toBe(0);
   });
 
-  it("allows when no internal DB", async () => {
+  it("runs the INSERT directly (no transaction) when no internal DB", async () => {
     mockHasInternalDB = false;
-    const result = await checkChatIntegrationLimit("org-1", SLACK);
+    mockInternalQueryResult = [{ id: "direct-2" }];
+    const result = await checkChatIntegrationLimitAndInstall<{ id: string }>("org-1", SLACK, INSERT);
     expect(result.allowed).toBe(true);
+    expect(mockConnectCount).toBe(0);
   });
 
-  it("blocks (fail closed, check_failed) when the count query throws", async () => {
+  // ── Fail-closed before/under the lock ─────────────────────────────
+
+  it("fails closed (check_failed) before opening a transaction when the workspace lookup throws", async () => {
     mockWorkspace = makeWorkspace({ plan_tier: "starter" });
-    mockInternalQueryShouldThrow = true;
-    // Distinct fail-closed contract — check_failed (→ 503 "try again"), not
-    // cap_reached (→ 429 "upgrade"). No `limit` field.
-    const denied = expectCheckFailed(await checkChatIntegrationLimit("org-1", SLACK));
+    mockWorkspaceDetailsShouldThrow = true;
+    const denied = expectInstallCheckFailed(
+      await checkChatIntegrationLimitAndInstall<{ id: string }>("org-1", SLACK, INSERT),
+    );
     expect(denied.errorMessage).toContain("Unable to verify plan limits");
+    // Failed closed before taking the lock — no transaction opened.
+    expect(mockConnectCount).toBe(0);
   });
 
-  it("blocks (fail closed, check_failed) when the count query returns no row", async () => {
+  it("fails closed (check_failed) and rolls back when the count query throws under the lock", async () => {
     mockWorkspace = makeWorkspace({ plan_tier: "starter" });
-    // The aggregate SQL always returns one row; an empty result means a
-    // driver/query contract violation. Must NOT coerce to 0 (fail open).
-    mockInternalQueryResult = [];
-    const denied = expectCheckFailed(await checkChatIntegrationLimit("org-1", SLACK));
+    mockTxnClient = makeFakeTxnClient({ countThrows: true });
+    const denied = expectInstallCheckFailed(
+      await checkChatIntegrationLimitAndInstall<{ id: string }>("org-1", SLACK, INSERT),
+    );
     expect(denied.errorMessage).toContain("Unable to verify plan limits");
+    expect(mockTxnClient.ran("ROLLBACK")).toBe(true);
+    expect(mockTxnClient.ran("INSERT INTO workspace_plugins")).toBe(false);
+    expect(mockTxnClient.ran("COMMIT")).toBe(false);
   });
 
-  it("allows free tier regardless of count", async () => {
+  it("fails closed (check_failed) when the count returns no row (no coerce-to-0)", async () => {
+    mockWorkspace = makeWorkspace({ plan_tier: "starter" });
+    mockTxnClient = makeFakeTxnClient({ countRows: [] });
+    expectInstallCheckFailed(
+      await checkChatIntegrationLimitAndInstall<{ id: string }>("org-1", SLACK, INSERT),
+    );
+    expect(mockTxnClient.ran("ROLLBACK")).toBe(true);
+    expect(mockTxnClient.ran("INSERT INTO workspace_plugins")).toBe(false);
+  });
+
+  // ── Allowed paths — INSERT + COMMIT ───────────────────────────────
+
+  it("allows free tier net-new and commits the INSERT", async () => {
     mockWorkspace = makeWorkspace({ plan_tier: "free" });
-    counts(9, 0);
-    const result = await checkChatIntegrationLimit("org-1", SLACK);
+    const txn = setTxn(9, 0, { insertRows: [{ id: "free-row" }] });
+    const result = await checkChatIntegrationLimitAndInstall<{ id: string }>("org-1", SLACK, INSERT);
     expect(result.allowed).toBe(true);
+    if (result.allowed) expect(result.rows).toEqual([{ id: "free-row" }]);
+    expect(txn.ran("INSERT INTO workspace_plugins")).toBe(true);
+    expect(txn.ran("COMMIT")).toBe(true);
+    expect(txn.ran("ROLLBACK")).toBe(false);
+    expect(txn.state.released).toBe(true);
   });
 
-  it("allows business tier (unlimited) for a net-new platform", async () => {
+  it("allows business (unlimited) net-new and commits", async () => {
     mockWorkspace = makeWorkspace({ plan_tier: "business" });
-    counts(7, 0);
-    const result = await checkChatIntegrationLimit("org-1", SLACK);
+    const txn = setTxn(7, 0);
+    const result = await checkChatIntegrationLimitAndInstall<{ id: string }>("org-1", SLACK, INSERT);
     expect(result.allowed).toBe(true);
+    expect(txn.ran("COMMIT")).toBe(true);
   });
 
-  it("allows starter first chat install (no others, not yet installed)", async () => {
+  it("allows starter first install (no others) and commits", async () => {
     mockWorkspace = makeWorkspace({ plan_tier: "starter" });
-    counts(0, 0);
-    const result = await checkChatIntegrationLimit("org-1", SLACK);
+    const txn = setTxn(0, 0);
+    const result = await checkChatIntegrationLimitAndInstall<{ id: string }>("org-1", SLACK, INSERT);
     expect(result.allowed).toBe(true);
+    expect(txn.ran("INSERT INTO workspace_plugins")).toBe(true);
+    expect(txn.ran("COMMIT")).toBe(true);
   });
 
-  it("blocks starter from adding a 2nd distinct chat integration", async () => {
-    mockWorkspace = makeWorkspace({ plan_tier: "starter" });
-    // One other chat platform already installed; Slack is net-new → cap=1 hit.
-    counts(1, 0);
-    const denied = expectResourceDenied(await checkChatIntegrationLimit("org-1", SLACK));
-    expect(denied.limit).toBe(1);
-    expect(denied.errorMessage).toContain("1 chat integration");
+  it("allows pro under cap (2 others, net-new third) and commits", async () => {
+    mockWorkspace = makeWorkspace({ plan_tier: "pro" });
+    const txn = setTxn(2, 0);
+    const result = await checkChatIntegrationLimitAndInstall<{ id: string }>("org-1", SLACK, INSERT);
+    expect(result.allowed).toBe(true);
+    expect(txn.ran("COMMIT")).toBe(true);
   });
 
-  it("allows reconnecting an already-installed platform at the cap", async () => {
+  // ── Reconnect is never blocked (skips the cap comparison) ──────────
+
+  it("allows reconnect at cap and commits (skips the cap comparison)", async () => {
     mockWorkspace = makeWorkspace({ plan_tier: "starter" });
     // Slack itself is already installed (this_count=1) and is the only one.
-    counts(0, 1);
-    const result = await checkChatIntegrationLimit("org-1", SLACK);
+    const txn = setTxn(0, 1);
+    const result = await checkChatIntegrationLimitAndInstall<{ id: string }>("org-1", SLACK, INSERT);
     expect(result.allowed).toBe(true);
+    expect(txn.ran("INSERT INTO workspace_plugins")).toBe(true);
+    expect(txn.ran("COMMIT")).toBe(true);
   });
 
-  it("allows reconnecting an existing platform even when grandfathered over cap", async () => {
+  it("allows reconnect even when grandfathered over cap", async () => {
     mockWorkspace = makeWorkspace({ plan_tier: "starter" });
     // Over the cap (others=2) but reconnecting a platform already owned.
-    counts(2, 1);
-    const result = await checkChatIntegrationLimit("org-1", SLACK);
+    const txn = setTxn(2, 1);
+    const result = await checkChatIntegrationLimitAndInstall<{ id: string }>("org-1", SLACK, INSERT);
     expect(result.allowed).toBe(true);
+    expect(txn.ran("COMMIT")).toBe(true);
   });
 
-  it("blocks a grandfathered over-cap workspace from adding a net-new platform", async () => {
+  // ── Cap reached — ROLLBACK, no INSERT ─────────────────────────────
+
+  it("blocks starter net-new at cap, rolls back, and never INSERTs", async () => {
     mockWorkspace = makeWorkspace({ plan_tier: "starter" });
-    // Over the cap and Slack is net-new (this_count=0) → blocked.
-    counts(2, 0);
-    const result = await checkChatIntegrationLimit("org-1", SLACK);
-    expect(result.allowed).toBe(false);
+    const txn = setTxn(1, 0); // one other chat platform → cap=1 hit
+    const denied = expectInstallCapReached(
+      await checkChatIntegrationLimitAndInstall<{ id: string }>("org-1", SLACK, INSERT),
+    );
+    expect(denied.limit).toBe(1);
+    expect(denied.errorMessage).toContain("1 chat integration");
+    expect(txn.ran("ROLLBACK")).toBe(true);
+    expect(txn.ran("INSERT INTO workspace_plugins")).toBe(false);
+    expect(txn.ran("COMMIT")).toBe(false);
   });
 
-  it("allows pro under cap (2 others, net-new third)", async () => {
-    mockWorkspace = makeWorkspace({ plan_tier: "pro" });
-    counts(2, 0);
-    const result = await checkChatIntegrationLimit("org-1", SLACK);
-    expect(result.allowed).toBe(true);
+  it("blocks a grandfathered over-cap net-new and rolls back", async () => {
+    mockWorkspace = makeWorkspace({ plan_tier: "starter" });
+    const txn = setTxn(2, 0);
+    expectInstallCapReached(
+      await checkChatIntegrationLimitAndInstall<{ id: string }>("org-1", SLACK, INSERT),
+    );
+    expect(txn.ran("ROLLBACK")).toBe(true);
+    expect(txn.ran("INSERT INTO workspace_plugins")).toBe(false);
   });
 
-  it("blocks pro at cap (3 others, net-new fourth)", async () => {
+  it("blocks pro at cap (3 others) and rolls back", async () => {
     mockWorkspace = makeWorkspace({ plan_tier: "pro" });
-    counts(3, 0);
-    const result = await checkChatIntegrationLimit("org-1", SLACK);
-    expect(result.allowed).toBe(false);
+    const txn = setTxn(3, 0);
+    const denied = expectInstallCapReached(
+      await checkChatIntegrationLimitAndInstall<{ id: string }>("org-1", SLACK, INSERT),
+    );
+    expect(denied.limit).toBe(3);
+    expect(txn.ran("ROLLBACK")).toBe(true);
+  });
+
+  // ── Sequencing + write-path failures ──────────────────────────────
+
+  it("acquires the per-workspace advisory lock before counting, and runs the exact aggregate SQL", async () => {
+    mockWorkspace = makeWorkspace({ plan_tier: "starter" });
+    const txn = setTxn(0, 0);
+    await checkChatIntegrationLimitAndInstall<{ id: string }>("org-1", SLACK, INSERT);
+
+    const sqls = txn.sqls();
+    const beginAt = sqls.findIndex((s) => s === "BEGIN");
+    const lockAt = sqls.findIndex((s) => s.includes("pg_advisory_xact_lock"));
+    const countAt = sqls.findIndex((s) => s.includes("COUNT(*) FILTER"));
+    const insertAt = sqls.findIndex((s) => s.includes("INSERT INTO workspace_plugins"));
+    const commitAt = sqls.findIndex((s) => s === "COMMIT");
+    // BEGIN → lock → count → insert → commit, strictly ordered.
+    expect(beginAt).toBe(0);
+    expect(lockAt).toBeGreaterThan(beginAt);
+    expect(countAt).toBeGreaterThan(lockAt);
+    expect(insertAt).toBeGreaterThan(countAt);
+    expect(commitAt).toBeGreaterThan(insertAt);
+
+    // The recount under the lock uses the exact exported aggregate (the same
+    // SQL the real-PG #2999 test pins), parameterized on (workspace, catalog).
+    const countCall = txn.calls.find((c) => c.sql.includes("COUNT(*) FILTER"));
+    expect(countCall?.sql).toBe(CHAT_INTEGRATION_COUNT_SQL);
+    expect(countCall?.params).toEqual(["org-1", SLACK]);
+  });
+
+  it("re-throws a write-path failure (INSERT error) and rolls back", async () => {
+    mockWorkspace = makeWorkspace({ plan_tier: "starter" });
+    const txn = makeFakeTxnClient({ countRows: [{ others: 0, this_count: 0 }], insertThrows: true });
+    mockTxnClient = txn;
+    await expect(
+      checkChatIntegrationLimitAndInstall<{ id: string }>("org-1", SLACK, INSERT),
+    ).rejects.toThrow("insert failed");
+    expect(txn.ran("ROLLBACK")).toBe(true);
+    expect(txn.ran("COMMIT")).toBe(false);
+  });
+
+  it("destroys the client on a failed ROLLBACK (poisoned socket) while still returning the denial", async () => {
+    mockWorkspace = makeWorkspace({ plan_tier: "starter" });
+    // Cap reached → ROLLBACK path; the ROLLBACK itself fails.
+    const txn = setTxn(1, 0, { rollbackThrows: true });
+    const denied = expectInstallCapReached(
+      await checkChatIntegrationLimitAndInstall<{ id: string }>("org-1", SLACK, INSERT),
+    );
+    expect(denied.limit).toBe(1);
+    // release() called with the rollback error so the pool destroys the client.
+    expect(txn.state.released).toBe(true);
+    expect(txn.state.releaseErr).toBeInstanceOf(Error);
   });
 });

--- a/packages/api/src/lib/billing/enforcement.ts
+++ b/packages/api/src/lib/billing/enforcement.ts
@@ -24,6 +24,7 @@
 import { createLogger } from "@atlas/api/lib/logger";
 import {
   hasInternalDB,
+  getInternalDB,
   getWorkspaceDetails,
   internalQuery,
   type WorkspaceRow,
@@ -495,94 +496,202 @@ export async function checkResourceLimit(
 }
 
 // ---------------------------------------------------------------------------
-// Chat integration cap (#2953)
+// Chat integration cap (#2953, atomic install gate #3001)
 // ---------------------------------------------------------------------------
 
+/** Message surfaced when the count can't be determined (fail-closed → 503). */
+const CHAT_CAP_CHECK_FAILED_MSG = "Unable to verify plan limits. Please try again.";
+
 /**
- * Check whether the workspace may install one more chat-platform
- * integration without exceeding its plan's `maxChatIntegrations` cap (the
- * marketed per-tier numbers live next to the values in `billing/plans.ts`).
+ * Numeric namespace for the per-workspace install advisory lock — the
+ * `classkey` arg of the two-arg `pg_advisory_xact_lock(int4, int4)`. Keeps
+ * this lock's keyspace disjoint from the other advisory-lock users in the
+ * codebase (`lead-outbox` uses `2870`, migrations use the single-arg
+ * `hashtext('atlas_migrations')` form), so a hash collision can't cross
+ * features. Value is this issue's number.
+ */
+const CHAT_INSTALL_LOCK_NAMESPACE = 3001;
+
+/**
+ * Counts the workspace's chat-pillar installs, partitioned into the platform
+ * being installed (`this_count`) vs. every other chat platform (`others`).
  *
- * Counts the workspace's existing chat-pillar installs in
- * `workspace_plugins` (the same store the connections cap counts) and
- * delegates the cap comparison to {@link checkResourceLimit}.
- *
- * `catalogId` is the catalog row id of the platform being installed (e.g.
- * `"catalog:slack"`). It matters for two reasons:
- *  - **Reconnect is never blocked.** Re-authing a platform the workspace
- *    already has does not increase the distinct count, so a workspace that
- *    is already over a (grandfathered) cap can still re-auth what it owns.
- *  - **The new platform is excluded from the count**, so the comparison is
- *    "do the *other* chat platforms already fill the cap?".
+ * Exported so the real-Postgres test (#2999) exercises the EXACT aggregate the
+ * cap decision runs on — a typo in the FILTER predicate, an inverted `<>`/`=`,
+ * or a dropped `status <> 'archived'` would otherwise pass every mock-based
+ * test. `$1` = workspace id, `$2` = catalog id of the platform being installed.
  *
  * The cap counts every `workspace_plugins` row with `pillar = 'chat'`, so it
- * only constrains platforms whose install actually writes such a row. Today
- * that is Slack (OAuth) and Discord — both write `pillar = 'chat'` rows. The
- * legacy credential-store-only chat routes (Telegram / Teams / gchat /
- * WhatsApp) don't yet write a `workspace_plugins` row, so they are neither
- * counted nor capped until they pivot to the unified install record (#2994).
- *
- * Fails closed when the count can't be determined (query error or no row),
- * surfacing `reason: "check_failed"` — consistent with {@link checkResourceLimit}.
- *
- * KNOWN LIMITATION (TOCTOU): this is a read-only precheck; the caller does the
- * `workspace_plugins` INSERT separately, so two *distinct* net-new platforms
- * installed concurrently (e.g. Slack + Discord finishing OAuth in the same
- * window while the workspace is one under its cap) can both pass and both
- * write, landing one over the cap. The same-platform case can't breach it —
- * the `workspace_plugins_singleton` partial unique index collapses a duplicate
- * install into an UPSERT (a reconnect, always allowed). Closing the
- * cross-platform window needs a per-workspace advisory lock / transaction
- * around count+INSERT; tracked in #3001 (deferred — narrow window, heavy lift).
+ * only constrains platforms whose install writes such a row. Today that is
+ * Slack (OAuth) and Discord — both write `pillar = 'chat'`. The legacy
+ * credential-store-only chat routes (Telegram / Teams / gchat / WhatsApp)
+ * don't yet write a `workspace_plugins` row, so they are neither counted nor
+ * capped until they pivot to the unified install record (#2994).
  */
-export async function checkChatIntegrationLimit(
+export const CHAT_INTEGRATION_COUNT_SQL = `SELECT
+   COUNT(*) FILTER (WHERE catalog_id <> $2)::int AS others,
+   COUNT(*) FILTER (WHERE catalog_id = $2)::int  AS this_count
+ FROM workspace_plugins
+ WHERE workspace_id = $1
+   AND pillar = 'chat'
+   AND status <> 'archived'`;
+
+/**
+ * Outcome of {@link checkChatIntegrationLimitAndInstall}. Mirrors the
+ * {@link ResourceLimitResult} arms (so callers map `cap_reached` → 429 and
+ * `check_failed` → 503 exactly as elsewhere), but the success arm carries the
+ * INSERT's `RETURNING` rows — the Discord handler needs the upserted row id.
+ */
+export type ChatIntegrationInstallResult<T extends Record<string, unknown>> =
+  | { allowed: true; rows: T[] }
+  | { allowed: false; reason: "cap_reached"; errorMessage: string; limit: number }
+  | { allowed: false; reason: "check_failed"; errorMessage: string };
+
+/**
+ * Atomically enforce the chat-integration cap and run the `workspace_plugins`
+ * INSERT in a single transaction (#3001).
+ *
+ * The cap used to be a read-only precheck followed by a *separate* INSERT, so
+ * two **distinct** net-new chat platforms installing concurrently (e.g. Slack
+ * and Discord OAuth callbacks completing in the same window while the workspace
+ * is one under its cap) could both pass the precheck and both insert, landing
+ * the workspace one over its cap. (The same-platform case was already safe —
+ * the `workspace_plugins_singleton` partial unique index collapses a duplicate
+ * install into an UPSERT/reconnect, which is always allowed.)
+ *
+ * This closes that window:
+ *   1. Resolve the workspace plan up front (outside the transaction). This
+ *      warms the workspace cache so the in-transaction cap check reads from
+ *      cache instead of acquiring a *second* pooled connection while we hold
+ *      this transaction's client — and lets us fail closed before taking the
+ *      lock if the workspace lookup errors.
+ *   2. `pg_advisory_xact_lock(namespace, hashtext(workspaceId))` — a
+ *      transaction-scoped advisory lock keyed on the workspace, released
+ *      automatically on COMMIT/ROLLBACK. Concurrent installs for the *same*
+ *      workspace serialize on it.
+ *   3. Re-count chat installs INSIDE the lock, on the same client — this is
+ *      the read the cap decision is based on, now serialized so a concurrent
+ *      install can't slip a row in between the count and our INSERT.
+ *   4. If a net-new platform would breach the cap, ROLLBACK and return
+ *      `cap_reached`. Otherwise run the caller's INSERT and COMMIT.
+ *
+ * Reconnect is never blocked: re-auth of an already-installed platform
+ * (`this_count > 0`) skips the cap comparison, so a grandfathered over-cap
+ * workspace can still re-auth what it owns.
+ *
+ * Returns a denied result for cap / billing-check failures (mapped to 429 /
+ * 503 by the caller). **Throws** for genuine write-path failures (lock, INSERT,
+ * or COMMIT errors) so the caller surfaces a 5xx — identical to the pre-#3001
+ * behaviour where a failed INSERT re-threw.
+ *
+ * @param orgId - Workspace id. When absent (or no internal DB) there's no cap
+ *   to apply, so the INSERT runs directly with no lock.
+ * @param catalogId - Catalog row id of the platform being installed (e.g.
+ *   `"catalog:slack"`). Excluded from the `others` count.
+ * @param insert - The `workspace_plugins` INSERT to run inside the gate. Its
+ *   `RETURNING` rows (if any) come back on the success arm.
+ */
+export async function checkChatIntegrationLimitAndInstall<T extends Record<string, unknown>>(
   orgId: string | undefined,
   catalogId: string,
-): Promise<ResourceLimitResult> {
+  insert: { readonly sql: string; readonly params: readonly unknown[] },
+): Promise<ChatIntegrationInstallResult<T>> {
+  // No enforcement context — no cap to apply, nothing to serialize, so run the
+  // INSERT directly. (workspace_plugins lives in the internal DB, so when
+  // !hasInternalDB the INSERT itself can't run — internalQuery throws, matching
+  // the pre-#3001 behaviour.)
   if (!orgId || !hasInternalDB()) {
-    return { allowed: true };
+    const rows = await internalQuery<T>(insert.sql, insert.params as unknown[]);
+    return { allowed: true, rows };
   }
 
-  let counts: { others: number; this_count: number } | undefined;
+  // Resolve (and cache-warm) the workspace plan before opening the transaction
+  // so the in-transaction cap check below doesn't acquire a second pooled
+  // connection while holding this transaction's client. Fail closed if the
+  // lookup errors — before taking the lock.
   try {
-    const rows = await internalQuery<{ others: number; this_count: number }>(
-      `SELECT
-         COUNT(*) FILTER (WHERE catalog_id <> $2)::int AS others,
-         COUNT(*) FILTER (WHERE catalog_id = $2)::int  AS this_count
-       FROM workspace_plugins
-       WHERE workspace_id = $1
-         AND pillar = 'chat'
-         AND status <> 'archived'`,
-      [orgId, catalogId],
-    );
-    counts = rows[0];
+    await getCachedWorkspace(orgId);
   } catch (err) {
     log.error(
       { err: err instanceof Error ? err.message : String(err), orgId, catalogId },
-      "Failed to count chat integrations for limit check — blocking as precaution",
+      "Failed to resolve workspace for chat-integration cap — blocking as precaution",
     );
-    return { allowed: false, reason: "check_failed", errorMessage: "Unable to verify plan limits. Please try again." };
+    return { allowed: false, reason: "check_failed", errorMessage: CHAT_CAP_CHECK_FAILED_MSG };
   }
 
-  // The aggregate SQL above always returns exactly one row, so a missing
-  // row means the driver/query contract was violated. Fail closed rather
-  // than coerce the absent count to 0 — `?? 0` would silently breach the
-  // cap (treat "unknown" as "no other integrations → allow").
-  if (!counts) {
-    log.error(
-      { orgId, catalogId },
-      "Chat-integration count query returned no row — blocking as precaution",
-    );
-    return { allowed: false, reason: "check_failed", errorMessage: "Unable to verify plan limits. Please try again." };
-  }
+  const client = await getInternalDB().connect();
+  // Destroy the client on a failed ROLLBACK so a dirty socket doesn't poison
+  // the next borrower (matches cascadeWorkspaceDelete / hardDeleteWorkspace).
+  let rollbackErr: Error | null = null;
+  const rollback = async (): Promise<void> => {
+    await client.query("ROLLBACK").catch((rbErr: unknown) => {
+      rollbackErr = rbErr instanceof Error ? rbErr : new Error(String(rbErr));
+      log.warn(
+        { orgId, catalogId, err: rollbackErr.message },
+        "ROLLBACK failed during chat-integration install gate — client will be destroyed",
+      );
+    });
+  };
 
-  // Reconnecting an already-installed platform never increases the distinct
-  // count — always allow so a grandfathered over-cap workspace can re-auth
-  // what it already has.
-  if (counts.this_count > 0) {
-    return { allowed: true };
-  }
+  try {
+    await client.query("BEGIN");
+    // Transaction-scoped advisory lock keyed on the workspace. hashtext maps
+    // the text workspace id to the int4 the lock takes; a cross-workspace hash
+    // collision only costs extra serialization, never correctness. Released
+    // automatically on COMMIT/ROLLBACK.
+    await client.query("SELECT pg_advisory_xact_lock($1, hashtext($2))", [
+      CHAT_INSTALL_LOCK_NAMESPACE,
+      orgId,
+    ]);
 
-  return checkResourceLimit(orgId, "chat_integrations", counts.others);
+    // Re-count under the lock — transaction-consistent, on the SAME client (not
+    // via internalQuery, which may use a different pooled connection).
+    let counts: { others: number; this_count: number } | undefined;
+    try {
+      const res = await client.query(CHAT_INTEGRATION_COUNT_SQL, [orgId, catalogId]);
+      counts = res.rows[0] as { others: number; this_count: number } | undefined;
+    } catch (err) {
+      log.error(
+        { err: err instanceof Error ? err.message : String(err), orgId, catalogId },
+        "Failed to count chat integrations under lock — blocking as precaution",
+      );
+      await rollback();
+      return { allowed: false, reason: "check_failed", errorMessage: CHAT_CAP_CHECK_FAILED_MSG };
+    }
+    // The aggregate always returns exactly one row; an empty result means the
+    // driver/query contract was violated. Fail closed rather than coerce the
+    // absent count to 0 — that would silently breach the cap.
+    if (!counts) {
+      log.error(
+        { orgId, catalogId },
+        "Chat-integration count query returned no row under lock — blocking as precaution",
+      );
+      await rollback();
+      return { allowed: false, reason: "check_failed", errorMessage: CHAT_CAP_CHECK_FAILED_MSG };
+    }
+
+    // Net-new platform → compare the *other* chat platforms to the plan cap.
+    // Reconnect (this_count > 0) skips the comparison and is never blocked.
+    // getCachedWorkspace was warmed above, so checkResourceLimit reads from
+    // cache without a nested pool acquire.
+    if (counts.this_count === 0) {
+      const decision = await checkResourceLimit(orgId, "chat_integrations", counts.others);
+      if (!decision.allowed) {
+        await rollback();
+        return decision;
+      }
+    }
+
+    const result = await client.query(insert.sql, insert.params as unknown[]);
+    await client.query("COMMIT");
+    return { allowed: true, rows: result.rows as T[] };
+  } catch (err) {
+    // Write-path failure (lock / INSERT / COMMIT) — roll back and re-throw so
+    // the caller surfaces a 5xx, as the pre-#3001 standalone INSERT did.
+    await rollback();
+    throw err;
+  } finally {
+    client.release(rollbackErr ?? undefined);
+  }
 }
 

--- a/packages/api/src/lib/billing/enforcement.ts
+++ b/packages/api/src/lib/billing/enforcement.ts
@@ -27,6 +27,7 @@ import {
   getInternalDB,
   getWorkspaceDetails,
   internalQuery,
+  type InternalPoolClient,
   type WorkspaceRow,
 } from "@atlas/api/lib/db/internal";
 import { getCurrentPeriodUsage } from "@atlas/api/lib/metering";
@@ -504,11 +505,15 @@ const CHAT_CAP_CHECK_FAILED_MSG = "Unable to verify plan limits. Please try agai
 
 /**
  * Numeric namespace for the per-workspace install advisory lock — the
- * `classkey` arg of the two-arg `pg_advisory_xact_lock(int4, int4)`. Keeps
- * this lock's keyspace disjoint from the other advisory-lock users in the
- * codebase (`lead-outbox` uses `2870`, migrations use the single-arg
- * `hashtext('atlas_migrations')` form), so a hash collision can't cross
- * features. Value is this issue's number.
+ * `classkey` arg of the two-arg `pg_advisory_xact_lock(int4, int4)`.
+ *
+ * Postgres keeps the single-arg `pg_advisory_lock(bigint)` and two-arg
+ * `(int4, int4)` lock spaces fully disjoint, so this lock can never collide
+ * with any single-arg user regardless of value (migrations
+ * `hashtext('atlas_migrations')`, `rotate-encryption-key` `0x1f47`,
+ * `backfill-plugin-config` `0x1f42`). The only peer in the two-arg space is
+ * `lead-outbox` (`2870`), and `3001 ≠ 2870` keeps them disjoint there too.
+ * Value is this issue's number.
  */
 const CHAT_INSTALL_LOCK_NAMESPACE = 3001;
 
@@ -521,12 +526,14 @@ const CHAT_INSTALL_LOCK_NAMESPACE = 3001;
  * or a dropped `status <> 'archived'` would otherwise pass every mock-based
  * test. `$1` = workspace id, `$2` = catalog id of the platform being installed.
  *
- * The cap counts every `workspace_plugins` row with `pillar = 'chat'`, so it
- * only constrains platforms whose install writes such a row. Today that is
- * Slack (OAuth) and Discord — both write `pillar = 'chat'`. The legacy
- * credential-store-only chat routes (Telegram / Teams / gchat / WhatsApp)
- * don't yet write a `workspace_plugins` row, so they are neither counted nor
- * capped until they pivot to the unified install record (#2994).
+ * The cap counts every `workspace_plugins` row with `pillar = 'chat'`. Six
+ * chat handlers write such a row today (Slack, Discord, Telegram, Teams,
+ * gchat, WhatsApp), so all six consume a slot in this count. Only Slack and
+ * Discord run their INSERT through the atomic gate
+ * ({@link checkChatIntegrationLimitAndInstall}); the other four still persist
+ * via a direct `internalQuery` UPSERT, so they are *counted* but their own
+ * install isn't *serialized* against a concurrent net-new install — they move
+ * onto the gate when they adopt the unified install path (#2994).
  */
 export const CHAT_INTEGRATION_COUNT_SQL = `SELECT
    COUNT(*) FILTER (WHERE catalog_id <> $2)::int AS others,
@@ -537,13 +544,31 @@ export const CHAT_INTEGRATION_COUNT_SQL = `SELECT
    AND status <> 'archived'`;
 
 /**
+ * The `workspace_plugins` INSERT the gate runs inside its transaction. Raw
+ * SQL + params (rather than a structured descriptor) because the two callers
+ * own subtly different UPSERT shapes (Slack has no `RETURNING`; Discord
+ * `RETURNING id`); the gate stays agnostic and just executes it under the
+ * lock. Callers are trusted in-process code — this is internal-DB write SQL,
+ * not user analytics SQL.
+ */
+export interface WorkspacePluginInsert {
+  readonly sql: string;
+  readonly params: readonly unknown[];
+}
+
+/**
  * Outcome of {@link checkChatIntegrationLimitAndInstall}. Mirrors the
  * {@link ResourceLimitResult} arms (so callers map `cap_reached` → 429 and
  * `check_failed` → 503 exactly as elsewhere), but the success arm carries the
  * INSERT's `RETURNING` rows — the Discord handler needs the upserted row id.
+ *
+ * `rows` is the INSERT's `RETURNING` output and **may be empty even on
+ * success** when the SQL has no `RETURNING` clause (Slack's UPSERT). A caller
+ * that reads a column must guard for absence (see the Discord handler's
+ * `rows[0]?.id` check).
  */
-export type ChatIntegrationInstallResult<T extends Record<string, unknown>> =
-  | { allowed: true; rows: T[] }
+export type ChatIntegrationInstallResult<T extends Record<string, unknown> = Record<string, unknown>> =
+  | { allowed: true; readonly rows: readonly T[] }
   | { allowed: false; reason: "cap_reached"; errorMessage: string; limit: number }
   | { allowed: false; reason: "check_failed"; errorMessage: string };
 
@@ -564,7 +589,10 @@ export type ChatIntegrationInstallResult<T extends Record<string, unknown>> =
  *      warms the workspace cache so the in-transaction cap check reads from
  *      cache instead of acquiring a *second* pooled connection while we hold
  *      this transaction's client — and lets us fail closed before taking the
- *      lock if the workspace lookup errors.
+ *      lock if the workspace lookup errors. A workspace with no `organization`
+ *      row (pre-migration / Better-Auth-only) has no plan and therefore no
+ *      cap, so it short-circuits to a direct INSERT with no lock — the one
+ *      deliberate fail-open, distinct from the DB-error case which fails closed.
  *   2. `pg_advisory_xact_lock(namespace, hashtext(workspaceId))` — a
  *      transaction-scoped advisory lock keyed on the workspace, released
  *      automatically on COMMIT/ROLLBACK. Concurrent installs for the *same*
@@ -591,10 +619,12 @@ export type ChatIntegrationInstallResult<T extends Record<string, unknown>> =
  * @param insert - The `workspace_plugins` INSERT to run inside the gate. Its
  *   `RETURNING` rows (if any) come back on the success arm.
  */
-export async function checkChatIntegrationLimitAndInstall<T extends Record<string, unknown>>(
+export async function checkChatIntegrationLimitAndInstall<
+  T extends Record<string, unknown> = Record<string, unknown>,
+>(
   orgId: string | undefined,
   catalogId: string,
-  insert: { readonly sql: string; readonly params: readonly unknown[] },
+  insert: WorkspacePluginInsert,
 ): Promise<ChatIntegrationInstallResult<T>> {
   // No enforcement context — no cap to apply, nothing to serialize, so run the
   // INSERT directly. (workspace_plugins lives in the internal DB, so when
@@ -609,8 +639,9 @@ export async function checkChatIntegrationLimitAndInstall<T extends Record<strin
   // so the in-transaction cap check below doesn't acquire a second pooled
   // connection while holding this transaction's client. Fail closed if the
   // lookup errors — before taking the lock.
+  let workspace: WorkspaceRow | null;
   try {
-    await getCachedWorkspace(orgId);
+    workspace = await getCachedWorkspace(orgId);
   } catch (err) {
     log.error(
       { err: err instanceof Error ? err.message : String(err), orgId, catalogId },
@@ -619,7 +650,28 @@ export async function checkChatIntegrationLimitAndInstall<T extends Record<strin
     return { allowed: false, reason: "check_failed", errorMessage: CHAT_CAP_CHECK_FAILED_MSG };
   }
 
-  const client = await getInternalDB().connect();
+  // No `organization` row → no plan tier → no cap to enforce (pre-migration /
+  // Better-Auth-only workspace). This is the ONLY deliberate fail-open in this
+  // gate — a workspace lookup *error* fails closed above, a genuine *absence*
+  // allows. Run the INSERT directly with no lock; there's nothing to serialize.
+  if (!workspace) {
+    const rows = await internalQuery<T>(insert.sql, insert.params as unknown[]);
+    return { allowed: true, rows };
+  }
+
+  let client: InternalPoolClient;
+  try {
+    client = await getInternalDB().connect();
+  } catch (err) {
+    // Pool exhausted / DB down at acquire time — a transient infra fault, not a
+    // plan breach. Fail closed as check_failed (→ 503 "try again") rather than
+    // letting a raw pool error degrade into an unlabeled 500.
+    log.error(
+      { err: err instanceof Error ? err.message : String(err), orgId, catalogId },
+      "Failed to acquire internal DB client for chat-integration install gate — blocking as precaution",
+    );
+    return { allowed: false, reason: "check_failed", errorMessage: CHAT_CAP_CHECK_FAILED_MSG };
+  }
   // Destroy the client on a failed ROLLBACK so a dirty socket doesn't poison
   // the next borrower (matches cascadeWorkspaceDelete / hardDeleteWorkspace).
   let rollbackErr: Error | null = null;
@@ -686,8 +738,15 @@ export async function checkChatIntegrationLimitAndInstall<T extends Record<strin
     await client.query("COMMIT");
     return { allowed: true, rows: result.rows as T[] };
   } catch (err) {
-    // Write-path failure (lock / INSERT / COMMIT) — roll back and re-throw so
-    // the caller surfaces a 5xx, as the pre-#3001 standalone INSERT did.
+    // Write-path failure (lock / INSERT / COMMIT) — log with gate context, roll
+    // back, and re-throw so the caller surfaces a 5xx, as the pre-#3001
+    // standalone INSERT did. Logging the originating error here means a
+    // subsequent "ROLLBACK failed" warning isn't the only breadcrumb when COMMIT
+    // was the real cause.
+    log.error(
+      { err: err instanceof Error ? err.message : String(err), orgId, catalogId },
+      "Chat-integration install gate write-path failed — rolling back",
+    );
     await rollback();
     throw err;
   } finally {

--- a/packages/api/src/lib/billing/plans.ts
+++ b/packages/api/src/lib/billing/plans.ts
@@ -42,8 +42,8 @@ export interface PlanLimits {
    * WhatsApp). The "All 8 chat integrations" figure marketed on /pricing
    * also counts Linear + GitHub, but those are `pillar = 'action'`, so they
    * do NOT consume a chat-integration slot. Marketed tiers: Starter 1 /
-   * Pro 3 / Business unlimited. Enforced at chat install time by
-   * `checkChatIntegrationLimit` (#2953).
+   * Pro 3 / Business unlimited. Enforced atomically at chat install time by
+   * `checkChatIntegrationLimitAndInstall` (#2953, #3001).
    */
   maxChatIntegrations: number;
 }

--- a/packages/api/src/lib/effect/errors.ts
+++ b/packages/api/src/lib/effect/errors.ts
@@ -797,9 +797,11 @@ export class InvalidInstallIdError extends Data.TaggedError("InvalidInstallIdErr
  * A chat-platform install was refused because the workspace's plan tier has
  * reached its chat-integration cap (per-tier numbers live in
  * `billing/plans.ts:maxChatIntegrations`). Thrown by the chat install
- * handlers (`slack-oauth-handler`, `discord-static-bot-handler`) before the
- * `workspace_plugins` INSERT, after `checkChatIntegrationLimit` counts the
- * workspace's existing chat installs (#2953).
+ * handlers (`slack-oauth-handler`, `discord-static-bot-handler`) when
+ * `checkChatIntegrationLimitAndInstall` finds the cap reached — it counts the
+ * workspace's existing chat installs and runs the `workspace_plugins` INSERT
+ * atomically under a per-workspace advisory lock, rolling back when the cap is
+ * hit (#2953, #3001).
  *
  * Maps to HTTP 429 `plan_limit_exceeded` — the same status and wire code
  * the connections cap surfaces from `admin-connections`, plus a `limit`

--- a/packages/api/src/lib/integrations/install/__tests__/discord-static-bot-handler.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/discord-static-bot-handler.test.ts
@@ -19,10 +19,11 @@
  *     Telegram's `display_name` — admin-facing label only, dropped
  *     silently when malformed.
  *
- * `mock.module()` stubs the two module dependencies the handler reaches
- * into: `lib/db/internal` (`internalQuery`) and the global `fetch` used
- * for the Discord API call. Each mock exports every named export it
- * shadows (CLAUDE.md "mock all exports" rule).
+ * `mock.module()` stubs the module dependencies the handler reaches into:
+ * `lib/billing/enforcement` (`checkChatIntegrationLimitAndInstall` — the
+ * atomic cap-gate that owns the `workspace_plugins` UPSERT post-#3001) and
+ * the global `fetch` used for the Discord API call. Each mock exports every
+ * named export it shadows (CLAUDE.md "mock all exports" rule).
  */
 
 import { afterEach, beforeEach, describe, expect, it, mock, type Mock } from "bun:test";
@@ -32,36 +33,39 @@ import type { WorkspaceId } from "@useatlas/types";
 // Module mocks — hoist above the handler import
 // ---------------------------------------------------------------------------
 
-const mockInternalQuery: Mock<(sql: string, params?: unknown[]) => Promise<unknown[]>> = mock(() =>
-  Promise.resolve([{ id: "install-discord-row-1" }]),
-);
-
 mock.module("@atlas/api/lib/db/internal", () => ({
-  internalQuery: mockInternalQuery,
+  internalQuery: mock(() => Promise.resolve([])),
   hasInternalDB: mock(() => true),
   getInternalDB: mock(() => ({ query: mock(() => Promise.resolve({ rows: [] })) })),
 }));
 
-// The chat-integration cap (#2953) is exercised in
-// `billing/__tests__/enforcement.test.ts`; stub it to "allowed" here so
-// these handler tests stay focused on the install contract and their
-// `mockInternalQuery` call counts reflect only the UPSERT. The "blocks at
-// cap" test below overrides it via `mockImplementationOnce`.
-const mockCheckChatLimit: Mock<
-  (orgId: string | undefined, catalogId: string) =>
-    Promise<
-      | { allowed: true }
-      | { allowed: false; reason: "cap_reached"; errorMessage: string; limit: number }
-      | { allowed: false; reason: "check_failed"; errorMessage: string }
-    >
-> = mock(() => Promise.resolve({ allowed: true as const }));
+// The chat-integration cap + the workspace_plugins UPSERT now run atomically
+// through `checkChatIntegrationLimitAndInstall` (#3001) — the gate owns the
+// write and returns the RETURNING rows. We stub it to "allowed" with a
+// scripted row id so these handler tests stay focused on the install contract
+// (guild_id validation, reachability, config payload) and assert the UPSERT
+// shape via the gate's `insert` arg. The cap-enforcement decision + transaction
+// sequencing live in `billing/__tests__/enforcement.test.ts`. The cap /
+// fail-closed / RETURNING-empty / DB-error tests override it per case.
+type GateResult =
+  | { allowed: true; rows: Array<Record<string, unknown>> }
+  | { allowed: false; reason: "cap_reached"; errorMessage: string; limit: number }
+  | { allowed: false; reason: "check_failed"; errorMessage: string };
+const mockCheckChatLimitAndInstall: Mock<
+  (
+    orgId: string | undefined,
+    catalogId: string,
+    insert: { sql: string; params: readonly unknown[] },
+  ) => Promise<GateResult>
+> = mock(() => Promise.resolve({ allowed: true as const, rows: [{ id: "install-discord-row-1" }] }));
 
-// Mock every named export — a partial `mock.module()` causes a `SyntaxError`
+// Mock every value export — a partial `mock.module()` causes a `SyntaxError`
 // in other files importing the missing exports (per CLAUDE.md "Mock all
-// exports"). Only `checkChatIntegrationLimit` is exercised here; the rest are
-// inert no-ops.
+// exports"). Only `checkChatIntegrationLimitAndInstall` is exercised here; the
+// rest are inert no-ops.
 mock.module("@atlas/api/lib/billing/enforcement", () => ({
-  checkChatIntegrationLimit: mockCheckChatLimit,
+  checkChatIntegrationLimitAndInstall: mockCheckChatLimitAndInstall,
+  CHAT_INTEGRATION_COUNT_SQL: "SELECT 1",
   checkResourceLimit: () => Promise.resolve({ allowed: true }),
   checkPlanLimits: () => Promise.resolve({ allowed: true }),
   getCachedWorkspace: () => Promise.resolve(null),
@@ -112,10 +116,10 @@ function setFetchNetworkError(): void {
 }
 
 beforeEach(() => {
-  mockInternalQuery.mockClear();
-  mockInternalQuery.mockImplementation(() => Promise.resolve([{ id: "install-discord-row-1" }]));
-  mockCheckChatLimit.mockClear();
-  mockCheckChatLimit.mockImplementation(() => Promise.resolve({ allowed: true as const }));
+  mockCheckChatLimitAndInstall.mockClear();
+  mockCheckChatLimitAndInstall.mockImplementation(() =>
+    Promise.resolve({ allowed: true as const, rows: [{ id: "install-discord-row-1" }] }),
+  );
   fetchCalls.length = 0;
   setFetchOk();
 });
@@ -170,7 +174,7 @@ describe("DiscordStaticBotInstallHandler.confirmInstall — guild_id validation"
   it("rejects empty guild_id", async () => {
     const handler = new DiscordStaticBotInstallHandler({ botToken: "tkn", clientId: "111" });
     await expect(handler.confirmInstall(wsid, "")).rejects.toThrow(/guild_id/);
-    expect(mockInternalQuery).not.toHaveBeenCalled();
+    expect(mockCheckChatLimitAndInstall).not.toHaveBeenCalled();
   });
 
   it("rejects guild_id with non-numeric characters (e.g. invite codes or @handles)", async () => {
@@ -180,13 +184,13 @@ describe("DiscordStaticBotInstallHandler.confirmInstall — guild_id validation"
     // are common admin mistakes; reject before the API call.
     await expect(handler.confirmInstall(wsid, "@my-server")).rejects.toThrow(/guild_id/);
     await expect(handler.confirmInstall(wsid, "discord.gg/abc")).rejects.toThrow(/guild_id/);
-    expect(mockInternalQuery).not.toHaveBeenCalled();
+    expect(mockCheckChatLimitAndInstall).not.toHaveBeenCalled();
   });
 
   it("rejects guild_id that's too short to be a snowflake (Discord ids are 17–20 digits)", async () => {
     const handler = new DiscordStaticBotInstallHandler({ botToken: "tkn", clientId: "111" });
     await expect(handler.confirmInstall(wsid, "12345")).rejects.toThrow(/guild_id/);
-    expect(mockInternalQuery).not.toHaveBeenCalled();
+    expect(mockCheckChatLimitAndInstall).not.toHaveBeenCalled();
   });
 
   it("accepts a well-formed 18-digit Discord snowflake", async () => {
@@ -218,7 +222,7 @@ describe("DiscordStaticBotInstallHandler.confirmInstall — reachability verific
     await expect(handler.confirmInstall(wsid, "999999999999999999")).rejects.toThrow(
       /Unknown Guild/i,
     );
-    expect(mockInternalQuery).not.toHaveBeenCalled();
+    expect(mockCheckChatLimitAndInstall).not.toHaveBeenCalled();
   });
 
   it("throws with a clear error when the bot is not in the guild (403)", async () => {
@@ -227,14 +231,14 @@ describe("DiscordStaticBotInstallHandler.confirmInstall — reachability verific
     await expect(handler.confirmInstall(wsid, "123456789012345678")).rejects.toThrow(
       /missing access/i,
     );
-    expect(mockInternalQuery).not.toHaveBeenCalled();
+    expect(mockCheckChatLimitAndInstall).not.toHaveBeenCalled();
   });
 
   it("throws when the Discord API call fails at the network layer (no install row)", async () => {
     setFetchNetworkError();
     const handler = new DiscordStaticBotInstallHandler({ botToken: "tkn", clientId: "111" });
     await expect(handler.confirmInstall(wsid, "123456789012345678")).rejects.toThrow(/discord/i);
-    expect(mockInternalQuery).not.toHaveBeenCalled();
+    expect(mockCheckChatLimitAndInstall).not.toHaveBeenCalled();
   });
 
   it("treats Discord's generic 'code: 0' error as a real failure (HTTP status is the discriminator)", async () => {
@@ -247,7 +251,7 @@ describe("DiscordStaticBotInstallHandler.confirmInstall — reachability verific
     await expect(handler.confirmInstall(wsid, "123456789012345678")).rejects.toThrow(
       /Generic error from upstream/i,
     );
-    expect(mockInternalQuery).not.toHaveBeenCalled();
+    expect(mockCheckChatLimitAndInstall).not.toHaveBeenCalled();
   });
 
   it("throws unavailable when the API returns 2xx without a guild id (contract violation)", async () => {
@@ -256,7 +260,7 @@ describe("DiscordStaticBotInstallHandler.confirmInstall — reachability verific
     await expect(handler.confirmInstall(wsid, "123456789012345678")).rejects.toThrow(
       /unexpected response shape/i,
     );
-    expect(mockInternalQuery).not.toHaveBeenCalled();
+    expect(mockCheckChatLimitAndInstall).not.toHaveBeenCalled();
   });
 });
 
@@ -266,7 +270,9 @@ describe("DiscordStaticBotInstallHandler.confirmInstall — reachability verific
 
 describe("DiscordStaticBotInstallHandler.confirmInstall — chat-integration cap", () => {
   it("throws ChatIntegrationLimitError and writes no install row when at cap", async () => {
-    mockCheckChatLimit.mockImplementationOnce(() =>
+    // The gate rolls back its UPSERT internally on a cap denial and returns
+    // `cap_reached` — the row is never committed.
+    mockCheckChatLimitAndInstall.mockImplementationOnce(() =>
       Promise.resolve({
         allowed: false as const,
         reason: "cap_reached" as const,
@@ -281,13 +287,17 @@ describe("DiscordStaticBotInstallHandler.confirmInstall — chat-integration cap
       limit: 1,
     });
 
-    // Cap is checked after reachability but before the UPSERT.
-    expect(mockCheckChatLimit).toHaveBeenCalledWith(wsid, DISCORD_CATALOG_ID);
-    expect(mockInternalQuery).not.toHaveBeenCalled();
+    // The gate enforced the cap (after reachability), keyed on the workspace +
+    // Discord catalog id, with the UPSERT it would have committed.
+    expect(mockCheckChatLimitAndInstall).toHaveBeenCalledTimes(1);
+    const [gateOrg, gateCatalog, gateInsert] = mockCheckChatLimitAndInstall.mock.calls[0];
+    expect(gateOrg).toBe(wsid);
+    expect(gateCatalog).toBe(DISCORD_CATALOG_ID);
+    expect(gateInsert.sql).toMatch(/INSERT INTO workspace_plugins/);
   });
 
   it("throws BillingCheckFailedError (not the cap error) when the count check fails closed", async () => {
-    mockCheckChatLimit.mockImplementationOnce(() =>
+    mockCheckChatLimitAndInstall.mockImplementationOnce(() =>
       Promise.resolve({
         allowed: false as const,
         reason: "check_failed" as const,
@@ -300,8 +310,8 @@ describe("DiscordStaticBotInstallHandler.confirmInstall — chat-integration cap
       _tag: "BillingCheckFailedError",
     });
 
-    // Still fail closed — no install row written.
-    expect(mockInternalQuery).not.toHaveBeenCalled();
+    // Still fail closed — the gate returned check_failed without committing.
+    expect(mockCheckChatLimitAndInstall).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -310,15 +320,21 @@ describe("DiscordStaticBotInstallHandler.confirmInstall — chat-integration cap
 // ---------------------------------------------------------------------------
 
 describe("DiscordStaticBotInstallHandler.confirmInstall — persistence", () => {
+  /** Pull the gate's `insert` arg from the most recent call. */
+  function lastGateInsert(): { sql: string; params: readonly unknown[] } {
+    const calls = mockCheckChatLimitAndInstall.mock.calls;
+    return calls[calls.length - 1][2];
+  }
+
   it("UPSERTs workspace_plugins with the catalog id + guild_id config payload", async () => {
     const handler = new DiscordStaticBotInstallHandler({ botToken: "tkn", clientId: "111" });
     await handler.confirmInstall(wsid, "123456789012345678", undefined, {
       guild_name: "Acme Engineering",
     });
 
-    expect(mockInternalQuery).toHaveBeenCalledTimes(1);
-    const [sql, params] = mockInternalQuery.mock.calls[0];
-    const sqlText = String(sql);
+    expect(mockCheckChatLimitAndInstall).toHaveBeenCalledTimes(1);
+    const insert = lastGateInsert();
+    const sqlText = insert.sql;
     expect(sqlText).toMatch(/INSERT INTO workspace_plugins/);
     // Required NOT NULL columns post-0092 / 0096 (codex P0 regression
     // catcher) — the INSERT must name pillar + install_id explicitly,
@@ -329,8 +345,10 @@ describe("DiscordStaticBotInstallHandler.confirmInstall — persistence", () => 
     expect(sqlText).toMatch(/pillar/);
     expect(sqlText).toMatch(/'chat'/);
     expect(sqlText).toMatch(/ON CONFLICT.*workspace_id.*catalog_id.*WHERE.*pillar.*DO UPDATE/s);
+    // The gate runs the UPSERT under the lock, so RETURNING id must be present.
+    expect(sqlText).toMatch(/RETURNING id/);
 
-    const paramsArr = params as unknown[];
+    const paramsArr = insert.params as unknown[];
     expect(paramsArr).toContain(wsid);
     expect(paramsArr).toContain(DISCORD_CATALOG_ID);
     const configJson = paramsArr.find(
@@ -349,8 +367,7 @@ describe("DiscordStaticBotInstallHandler.confirmInstall — persistence", () => 
     setFetchOk({ id: "123456789012345678" });
     const handler = new DiscordStaticBotInstallHandler({ botToken: "tkn", clientId: "111" });
     await handler.confirmInstall(wsid, "123456789012345678");
-    const [, params] = mockInternalQuery.mock.calls[0];
-    const configJson = (params as unknown[]).find(
+    const configJson = (lastGateInsert().params as unknown[]).find(
       (p): p is string => typeof p === "string" && p.includes("guild_id"),
     );
     const parsed = JSON.parse(configJson as string) as Record<string, unknown>;
@@ -362,17 +379,16 @@ describe("DiscordStaticBotInstallHandler.confirmInstall — persistence", () => 
     setFetchOk({ id: "123456789012345678", name: "From API" });
     const handler = new DiscordStaticBotInstallHandler({ botToken: "tkn", clientId: "111" });
     await handler.confirmInstall(wsid, "123456789012345678");
-    const [, params] = mockInternalQuery.mock.calls[0];
-    const configJson = (params as unknown[]).find(
+    const configJson = (lastGateInsert().params as unknown[]).find(
       (p): p is string => typeof p === "string" && p.includes("guild_id"),
     );
     const parsed = JSON.parse(configJson as string) as Record<string, unknown>;
     expect(parsed.guild_name).toBe("From API");
   });
 
-  it("returns the persisted install id from RETURNING (re-install idempotency)", async () => {
-    mockInternalQuery.mockImplementation(() =>
-      Promise.resolve([{ id: "existing-install-row" }]),
+  it("returns the persisted install id from the gate's RETURNING rows (re-install idempotency)", async () => {
+    mockCheckChatLimitAndInstall.mockImplementation(() =>
+      Promise.resolve({ allowed: true as const, rows: [{ id: "existing-install-row" }] }),
     );
     const handler = new DiscordStaticBotInstallHandler({ botToken: "tkn", clientId: "111" });
     const result = await handler.confirmInstall(wsid, "123456789012345678");
@@ -381,8 +397,10 @@ describe("DiscordStaticBotInstallHandler.confirmInstall — persistence", () => 
     expect(result.installRecord.catalogId).toBe(DISCORD_SLUG);
   });
 
-  it("throws when RETURNING comes back empty — never ships a candidate id that doesn't match the persisted row", async () => {
-    mockInternalQuery.mockImplementation(() => Promise.resolve([]));
+  it("throws when the gate's RETURNING rows are empty — never ships a candidate id that doesn't match the persisted row", async () => {
+    mockCheckChatLimitAndInstall.mockImplementation(() =>
+      Promise.resolve({ allowed: true as const, rows: [] }),
+    );
     const handler = new DiscordStaticBotInstallHandler({
       botToken: "tkn",
       clientId: "111",
@@ -394,7 +412,8 @@ describe("DiscordStaticBotInstallHandler.confirmInstall — persistence", () => 
   });
 
   it("surfaces DB failure rather than half-installing — no return after a throw", async () => {
-    mockInternalQuery.mockImplementation(() => Promise.reject(new Error("DB down")));
+    // The gate throws on a genuine write-path failure (after rolling back).
+    mockCheckChatLimitAndInstall.mockImplementation(() => Promise.reject(new Error("DB down")));
     const handler = new DiscordStaticBotInstallHandler({ botToken: "tkn", clientId: "111" });
     await expect(handler.confirmInstall(wsid, "123456789012345678")).rejects.toThrow(/DB down/);
   });

--- a/packages/api/src/lib/integrations/install/__tests__/slack-oauth-handler.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/slack-oauth-handler.test.ts
@@ -9,13 +9,14 @@
  * (workspace_plugins INSERT succeeds, chat_cache write throws) →
  * `credentialResult.written: false` while keeping the install record.
  *
- * `mock.module()` is used to stub the three module dependencies the
- * handler reaches into: `lib/slack/api` (`slackAPI` — the
- * `oauth.v2.access` exchange), `lib/slack/store` (`saveInstallation` —
- * the per-tenant `chat_cache:slack:installation:<teamId>` write), and
- * `lib/db/internal` (`internalQuery` — the `workspace_plugins` INSERT).
- * Each mock exports every named export it shadows so other tests in
- * the suite don't see a partial module.
+ * `mock.module()` is used to stub the module dependencies the handler
+ * reaches into: `lib/slack/api` (`slackAPI` — the `oauth.v2.access`
+ * exchange), `lib/slack/store` (`saveInstallation` — the per-tenant
+ * `chat_cache:slack:installation:<teamId>` write), and
+ * `lib/billing/enforcement` (`checkChatIntegrationLimitAndInstall` — the
+ * atomic cap-gate that owns the `workspace_plugins` INSERT post-#3001).
+ * Each mock exports every named export it shadows so other tests in the
+ * suite don't see a partial module.
  */
 
 import { afterEach, beforeAll, beforeEach, describe, expect, it, mock, type Mock } from "bun:test";
@@ -75,36 +76,38 @@ mock.module("@atlas/api/lib/slack/store", () => ({
   } as const,
 }));
 
-const mockInternalQuery: Mock<(sql: string, params?: unknown[]) => Promise<unknown[]>> = mock(() =>
-  Promise.resolve([]),
-);
-
 mock.module("@atlas/api/lib/db/internal", () => ({
-  internalQuery: mockInternalQuery,
+  internalQuery: mock(() => Promise.resolve([])),
   hasInternalDB: mock(() => true),
   getInternalDB: mock(() => ({ query: mock(() => Promise.resolve({ rows: [] })) })),
 }));
 
-// The chat-integration cap (#2953) is exercised in
-// `billing/__tests__/enforcement.test.ts`; here we stub it to "allowed" so
-// these handler tests stay focused on the install/credential contract and
-// their `mockInternalQuery` call counts reflect only the INSERT. The single
-// "blocks when at cap" test below overrides it via `mockImplementationOnce`.
-const mockCheckChatLimit: Mock<
-  (orgId: string | undefined, catalogId: string) =>
-    Promise<
-      | { allowed: true }
-      | { allowed: false; reason: "cap_reached"; errorMessage: string; limit: number }
-      | { allowed: false; reason: "check_failed"; errorMessage: string }
-    >
-> = mock(() => Promise.resolve({ allowed: true as const }));
+// The chat-integration cap + the `workspace_plugins` INSERT now run atomically
+// through `checkChatIntegrationLimitAndInstall` (#3001) — the gate owns the
+// write. We stub it to "allowed" so these handler tests stay focused on the
+// OAuth/credential contract and assert the INSERT shape via the gate's `insert`
+// arg; the cap-enforcement decision + transaction sequencing live in
+// `billing/__tests__/enforcement.test.ts`. The `at cap` / `check failed` tests
+// below override it via `mockImplementationOnce`.
+type GateResult =
+  | { allowed: true; rows: Array<Record<string, unknown>> }
+  | { allowed: false; reason: "cap_reached"; errorMessage: string; limit: number }
+  | { allowed: false; reason: "check_failed"; errorMessage: string };
+const mockCheckChatLimitAndInstall: Mock<
+  (
+    orgId: string | undefined,
+    catalogId: string,
+    insert: { sql: string; params: readonly unknown[] },
+  ) => Promise<GateResult>
+> = mock(() => Promise.resolve({ allowed: true as const, rows: [] }));
 
-// Mock every named export — a partial `mock.module()` causes a `SyntaxError`
+// Mock every value export — a partial `mock.module()` causes a `SyntaxError`
 // in other files importing the missing exports (per CLAUDE.md "Mock all
-// exports"). Only `checkChatIntegrationLimit` is exercised here; the rest are
-// inert no-ops.
+// exports"). Only `checkChatIntegrationLimitAndInstall` is exercised here; the
+// rest are inert no-ops.
 mock.module("@atlas/api/lib/billing/enforcement", () => ({
-  checkChatIntegrationLimit: mockCheckChatLimit,
+  checkChatIntegrationLimitAndInstall: mockCheckChatLimitAndInstall,
+  CHAT_INTEGRATION_COUNT_SQL: "SELECT 1",
   checkResourceLimit: () => Promise.resolve({ allowed: true }),
   checkPlanLimits: () => Promise.resolve({ allowed: true }),
   getCachedWorkspace: () => Promise.resolve(null),
@@ -148,9 +151,10 @@ beforeEach(() => {
   setKeys("v1:test-key-one");
   mockSlackAPI.mockClear();
   mockSaveInstallation.mockClear();
-  mockInternalQuery.mockClear();
-  mockCheckChatLimit.mockClear();
-  mockCheckChatLimit.mockImplementation(() => Promise.resolve({ allowed: true as const }));
+  mockCheckChatLimitAndInstall.mockClear();
+  mockCheckChatLimitAndInstall.mockImplementation(() =>
+    Promise.resolve({ allowed: true as const, rows: [] }),
+  );
   // Default to the happy-path Slack response — individual tests override
   // via `mockResolvedValueOnce` / `mockImplementationOnce`.
   mockSlackAPI.mockImplementation(() =>
@@ -233,14 +237,17 @@ describe("SlackOAuthInstallHandler.handleCallback — happy path", () => {
       redirect_uri: SLACK_CONFIG.redirectUri,
     });
 
-    // workspace_plugins INSERT — happens BEFORE the chat_cache write per ADR-0003.
-    expect(mockInternalQuery).toHaveBeenCalledTimes(1);
-    const [sql, params] = mockInternalQuery.mock.calls[0];
-    expect(sql).toContain("INSERT INTO workspace_plugins");
+    // workspace_plugins INSERT — now run atomically by the cap gate, BEFORE
+    // the chat_cache write per ADR-0003. Assert the gate was called once with
+    // the workspace id + catalog id and an INSERT carrying the right params.
+    expect(mockCheckChatLimitAndInstall).toHaveBeenCalledTimes(1);
+    const [gateOrg, gateCatalog, gateInsert] = mockCheckChatLimitAndInstall.mock.calls[0];
+    expect(gateOrg).toBe(WSID);
+    expect(gateCatalog).toBe("catalog:slack");
+    expect(gateInsert.sql).toContain("INSERT INTO workspace_plugins");
     // The params include the workspaceId + catalog_id `catalog:slack`
     // (which matches the seed id pattern from catalog-seeder.ts).
-    expect(params).toBeDefined();
-    const paramsList = params as unknown[];
+    const paramsList = gateInsert.params as unknown[];
     expect(paramsList).toContain(WSID);
     expect(paramsList).toContain("catalog:slack");
 
@@ -260,8 +267,8 @@ describe("SlackOAuthInstallHandler.handleCallback — happy path", () => {
 
     await handler.handleCallback("auth-code-abc", stateToken);
 
-    const [_sql, params] = mockInternalQuery.mock.calls[0];
-    const paramsList = params as unknown[];
+    const [, , gateInsert] = mockCheckChatLimitAndInstall.mock.calls[0];
+    const paramsList = gateInsert.params as unknown[];
     // Find the JSONB config string — the only param that's a JSON object.
     const configJson = paramsList.find((p) =>
       typeof p === "string" && p.startsWith("{") && p.includes("team_id"),
@@ -293,7 +300,7 @@ describe("SlackOAuthInstallHandler.handleCallback — state rejection", () => {
 
     expect(result).toBeNull();
     expect(mockSlackAPI).not.toHaveBeenCalled();
-    expect(mockInternalQuery).not.toHaveBeenCalled();
+    expect(mockCheckChatLimitAndInstall).not.toHaveBeenCalled();
     expect(mockSaveInstallation).not.toHaveBeenCalled();
   });
 
@@ -310,7 +317,7 @@ describe("SlackOAuthInstallHandler.handleCallback — state rejection", () => {
 
     expect(result).toBeNull();
     expect(mockSlackAPI).not.toHaveBeenCalled();
-    expect(mockInternalQuery).not.toHaveBeenCalled();
+    expect(mockCheckChatLimitAndInstall).not.toHaveBeenCalled();
     expect(mockSaveInstallation).not.toHaveBeenCalled();
   });
 
@@ -342,7 +349,7 @@ describe("SlackOAuthInstallHandler.handleCallback — Slack-side failure", () =>
       upstreamError: "invalid_code",
     });
 
-    expect(mockInternalQuery).not.toHaveBeenCalled();
+    expect(mockCheckChatLimitAndInstall).not.toHaveBeenCalled();
     expect(mockSaveInstallation).not.toHaveBeenCalled();
   });
 
@@ -358,7 +365,7 @@ describe("SlackOAuthInstallHandler.handleCallback — Slack-side failure", () =>
       platform: "slack",
     });
 
-    expect(mockInternalQuery).not.toHaveBeenCalled();
+    expect(mockCheckChatLimitAndInstall).not.toHaveBeenCalled();
     expect(mockSaveInstallation).not.toHaveBeenCalled();
   });
 });
@@ -368,8 +375,10 @@ describe("SlackOAuthInstallHandler.handleCallback — Slack-side failure", () =>
 // ---------------------------------------------------------------------------
 
 describe("SlackOAuthInstallHandler.handleCallback — chat-integration cap", () => {
-  it("throws ChatIntegrationLimitError and writes neither store when at cap", async () => {
-    mockCheckChatLimit.mockImplementationOnce(() =>
+  it("throws ChatIntegrationLimitError and writes no credential when at cap", async () => {
+    // The gate rolls back the workspace_plugins INSERT internally on a cap
+    // denial, so it returns `cap_reached` with no rows written.
+    mockCheckChatLimitAndInstall.mockImplementationOnce(() =>
       Promise.resolve({
         allowed: false as const,
         reason: "cap_reached" as const,
@@ -385,16 +394,19 @@ describe("SlackOAuthInstallHandler.handleCallback — chat-integration cap", () 
       limit: 1,
     });
 
-    // The cap is enforced before either store is written.
-    expect(mockInternalQuery).not.toHaveBeenCalled();
+    // The gate enforced the cap (and rolled back its INSERT); the credential
+    // store is never reached.
+    expect(mockCheckChatLimitAndInstall).toHaveBeenCalledTimes(1);
+    const [gateOrg, gateCatalog] = mockCheckChatLimitAndInstall.mock.calls[0];
+    expect(gateOrg).toBe(WSID);
+    expect(gateCatalog).toBe("catalog:slack");
     expect(mockSaveInstallation).not.toHaveBeenCalled();
-    expect(mockCheckChatLimit).toHaveBeenCalledWith(WSID, "catalog:slack");
   });
 
   it("throws BillingCheckFailedError (not the cap error) when the count check fails closed", async () => {
     // A DB blip means we can't read the count → fail closed, but as a
     // transient 503 "try again", not a 429 "upgrade your plan".
-    mockCheckChatLimit.mockImplementationOnce(() =>
+    mockCheckChatLimitAndInstall.mockImplementationOnce(() =>
       Promise.resolve({
         allowed: false as const,
         reason: "check_failed" as const,
@@ -408,8 +420,7 @@ describe("SlackOAuthInstallHandler.handleCallback — chat-integration cap", () 
       _tag: "BillingCheckFailedError",
     });
 
-    // Still fail closed — neither store is written.
-    expect(mockInternalQuery).not.toHaveBeenCalled();
+    // Still fail closed — the credential store is never reached.
     expect(mockSaveInstallation).not.toHaveBeenCalled();
   });
 });
@@ -436,8 +447,9 @@ describe("SlackOAuthInstallHandler.handleCallback — partial failure", () => {
     expect(result!.credentialResult.reason).toBeTypeOf("string");
     expect(result!.credentialResult.reason).toContain("Reconnect");
 
-    // workspace_plugins INSERT happened.
-    expect(mockInternalQuery).toHaveBeenCalledTimes(1);
+    // The cap gate ran the workspace_plugins INSERT (and committed it);
+    // only the subsequent credential write failed.
+    expect(mockCheckChatLimitAndInstall).toHaveBeenCalledTimes(1);
     expect(mockSaveInstallation).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/api/src/lib/integrations/install/discord-static-bot-handler.ts
+++ b/packages/api/src/lib/integrations/install/discord-static-bot-handler.ts
@@ -33,7 +33,6 @@
 
 import crypto from "crypto";
 import { createLogger } from "@atlas/api/lib/logger";
-import { internalQuery } from "@atlas/api/lib/db/internal";
 import {
   BillingCheckFailedError,
   ChatIntegrationLimitError,
@@ -41,7 +40,7 @@ import {
   DiscordGuildIdInvalidError,
   DiscordReachabilityError,
 } from "@atlas/api/lib/effect/errors";
-import { checkChatIntegrationLimit } from "@atlas/api/lib/billing/enforcement";
+import { checkChatIntegrationLimitAndInstall } from "@atlas/api/lib/billing/enforcement";
 import type { WorkspaceId } from "@useatlas/types";
 import type {
   CatalogId,
@@ -225,11 +224,62 @@ export class DiscordStaticBotInstallHandler implements StaticBotInstallHandler {
     // a failed verification never leaves a half-installed row behind.
     const apiGuildName = await this.verifyReachability(routingIdentifier);
 
-    // ── 2b. Plan cap — chat-integration limit (#2953) ─────────────
-    // Block before persisting when the workspace's plan tier is at its
-    // chat-integration cap. Reconnecting Discord (already installed) is
-    // never blocked — the check excludes Discord's own row.
-    const capCheck = await checkChatIntegrationLimit(workspaceId, DISCORD_CATALOG_ID);
+    // ── 2b. Plan cap + install row — atomic (#2953, #3001) ─────────
+    // Enforce the chat-integration cap and persist the workspace_plugins row
+    // in ONE transaction guarded by a per-workspace advisory lock, so two
+    // *distinct* net-new platforms installing concurrently can't both slip
+    // past the cap. Reconnecting Discord (already installed) is never blocked
+    // — the gate excludes Discord's own row from the count, and the UPSERT
+    // collapses the duplicate.
+    //
+    // UPSERT keyed on (workspace, catalog): candidate id on INSERT, RETURNING
+    // id so a CONFLICT lands on the existing row's id (idempotent re-install).
+    //
+    // Schema notes:
+    //   - `pillar` + `install_id` became NOT NULL in migration 0092 (#2739)
+    //     and the auto-fill trigger was dropped in 0096 (#2744). Every writer
+    //     must name both columns explicitly.
+    //   - Chat-pillar installs are singletons per (workspace, catalog),
+    //     enforced by the `workspace_plugins_singleton` partial unique index
+    //     (`WHERE pillar IN ('chat','action')` from migration 0092). We target
+    //     it via the inference clause so re-install lands on the existing row.
+    //   - For chat-pillar there's only one install per (workspace, catalog),
+    //     so `install_id` mirrors `id` — WorkspaceInstaller's datasource path
+    //     uses a caller-supplied installId; static-bot chat installs don't
+    //     have that surface, so we reuse the row id.
+    const candidateId = this.newId();
+    const configPayload: DiscordInstallConfig = {
+      guild_id: routingIdentifier,
+      ...extractGuildName(extras, apiGuildName, workspaceId),
+    };
+
+    let capCheck;
+    try {
+      capCheck = await checkChatIntegrationLimitAndInstall<{ id: string }>(
+        workspaceId,
+        DISCORD_CATALOG_ID,
+        {
+          sql: `INSERT INTO workspace_plugins
+           (id, workspace_id, catalog_id, install_id, pillar, config, enabled, installed_at)
+         VALUES ($1, $2, $3, $1, 'chat', $4::jsonb, true, NOW())
+         ON CONFLICT (workspace_id, catalog_id) WHERE pillar IN ('chat', 'action')
+         DO UPDATE
+           SET config = EXCLUDED.config,
+               enabled = true
+         RETURNING id`,
+          params: [candidateId, workspaceId, DISCORD_CATALOG_ID, JSON.stringify(configPayload)],
+        },
+      );
+    } catch (err) {
+      log.error(
+        {
+          workspaceId,
+          err: err instanceof Error ? err : new Error(String(err)),
+        },
+        "Failed to persist Discord install record — aborting install",
+      );
+      throw err;
+    }
     if (!capCheck.allowed) {
       if (capCheck.reason === "check_failed") {
         // Count couldn't be determined — fail closed, but as a transient
@@ -254,66 +304,18 @@ export class DiscordStaticBotInstallHandler implements StaticBotInstallHandler {
       });
     }
 
-    // ── 3. Persist install row — UPSERT keyed on (workspace, catalog) ─
-    // Mirrors the email-form-handler and telegram-static-bot-handler
-    // pattern: candidate id on INSERT, RETURNING id so a CONFLICT lands
-    // on the existing row's id (idempotent re-install).
-    const candidateId = this.newId();
-    const configPayload: DiscordInstallConfig = {
-      guild_id: routingIdentifier,
-      ...extractGuildName(extras, apiGuildName, workspaceId),
-    };
-
-    let persistedId: string;
-    try {
-      // Schema notes:
-      //   - `pillar` + `install_id` became NOT NULL in migration 0092
-      //     (#2739) and the auto-fill trigger was dropped in 0096
-      //     (#2744). Every writer must name both columns explicitly.
-      //   - Chat-pillar installs are singletons per (workspace, catalog),
-      //     enforced by the `workspace_plugins_singleton` partial unique
-      //     index (`WHERE pillar IN ('chat','action')` from migration
-      //     0092). We target it via the inference clause
-      //     `ON CONFLICT (workspace_id, catalog_id) WHERE pillar IN ('chat','action')`
-      //     so re-install lands on the existing row (idempotent UPSERT).
-      //   - For chat-pillar there's only one install per (workspace,
-      //     catalog), so `install_id` mirrors `id` — Workspaceinstaller's
-      //     datasource path uses a caller-supplied installId; static-bot
-      //     chat installs don't have that surface, so we reuse the row id.
-      const rows = await internalQuery<{ id: string }>(
-        `INSERT INTO workspace_plugins
-           (id, workspace_id, catalog_id, install_id, pillar, config, enabled, installed_at)
-         VALUES ($1, $2, $3, $1, 'chat', $4::jsonb, true, NOW())
-         ON CONFLICT (workspace_id, catalog_id) WHERE pillar IN ('chat', 'action')
-         DO UPDATE
-           SET config = EXCLUDED.config,
-               enabled = true
-         RETURNING id`,
-        [candidateId, workspaceId, DISCORD_CATALOG_ID, JSON.stringify(configPayload)],
+    const returned = capCheck.rows[0]?.id;
+    if (typeof returned !== "string" || returned.length === 0) {
+      // Postgres ≥9.5 guarantees `INSERT … ON CONFLICT … RETURNING` returns
+      // the row on both insert and update. Empty here means a driver /
+      // wrapper regression — fail loudly rather than ship a stale id back (on
+      // re-install the DB row has the existing id; falling back to the fresh
+      // candidateId would strand subsequent lookups).
+      throw new Error(
+        `workspace_plugins UPSERT returned no id for Discord install (workspaceId=${workspaceId}). RETURNING must always populate on PG ≥9.5; this indicates a driver regression. Aborting install.`,
       );
-      const returned = rows[0]?.id;
-      if (typeof returned !== "string" || returned.length === 0) {
-        // Postgres ≥9.5 guarantees `INSERT … ON CONFLICT … RETURNING`
-        // returns the row on both insert and update. Empty here means a
-        // driver / wrapper regression — fail loudly rather than ship a
-        // stale id back (on re-install the DB row has the existing id;
-        // falling back to the fresh candidateId would strand subsequent
-        // lookups).
-        throw new Error(
-          `workspace_plugins UPSERT returned no id for Discord install (workspaceId=${workspaceId}). RETURNING must always populate on PG ≥9.5; this indicates a driver regression. Aborting install.`,
-        );
-      }
-      persistedId = returned;
-    } catch (err) {
-      log.error(
-        {
-          workspaceId,
-          err: err instanceof Error ? err : new Error(String(err)),
-        },
-        "Failed to persist Discord install record — aborting install",
-      );
-      throw err;
     }
+    const persistedId: string = returned;
 
     log.info(
       {

--- a/packages/api/src/lib/integrations/install/slack-oauth-handler.ts
+++ b/packages/api/src/lib/integrations/install/slack-oauth-handler.ts
@@ -37,11 +37,10 @@
 import crypto from "crypto";
 import { Data } from "effect";
 import { createLogger } from "@atlas/api/lib/logger";
-import { internalQuery } from "@atlas/api/lib/db/internal";
 import { slackAPI } from "@atlas/api/lib/slack/api";
 import { saveInstallation } from "@atlas/api/lib/slack/store";
 import { BillingCheckFailedError, ChatIntegrationLimitError, PlatformOAuthExchangeError } from "@atlas/api/lib/effect/errors";
-import { checkChatIntegrationLimit } from "@atlas/api/lib/billing/enforcement";
+import { checkChatIntegrationLimitAndInstall } from "@atlas/api/lib/billing/enforcement";
 import type { WorkspaceId } from "@useatlas/types";
 import {
   mintOAuthStateToken,
@@ -212,11 +211,54 @@ export class SlackOAuthInstallHandler implements OAuthPlatformInstallHandler {
       });
     }
 
-    // ── 3. Plan cap — chat-integration limit (#2953) ──────────────
-    // Block before writing either store when the workspace's plan tier
-    // is at its chat-integration cap. Reconnecting Slack (already
-    // installed) is never blocked — the check excludes Slack's own row.
-    const capCheck = await checkChatIntegrationLimit(workspaceId, SLACK_CATALOG_ID);
+    // ── 3. Plan cap + install record — atomic (#2953, #3001) ───────
+    // Enforce the chat-integration cap and write the workspace_plugins row
+    // (the first store) in ONE transaction guarded by a per-workspace
+    // advisory lock, so two *distinct* net-new platforms installing
+    // concurrently can't both slip past the cap. Reconnecting Slack
+    // (already installed) is never blocked — the gate excludes Slack's own
+    // row from the count, and the UPSERT collapses the duplicate.
+    //
+    // Schema notes (mirrors `discord-static-bot-handler.ts`):
+    //   - `pillar` + `install_id` became NOT NULL in migration 0092
+    //     (#2739) and the auto-fill trigger was dropped in 0096 (#2744),
+    //     so every writer must name both columns explicitly — and the
+    //     chat-integration cap (#2953) counts `pillar = 'chat'` rows, so
+    //     omitting `pillar` would make Slack installs invisible to it.
+    //   - Chat-pillar installs are singletons per (workspace, catalog),
+    //     enforced by the `workspace_plugins_singleton` partial unique
+    //     index (`WHERE pillar IN ('chat','action')`). We target it via
+    //     the inference clause so re-install lands on the existing row.
+    //   - One install per (workspace, catalog) for chat, so `install_id`
+    //     mirrors `id`.
+    const installId = crypto.randomUUID();
+    const installConfig = {
+      team_id: teamId,
+      team_name: teamName,
+      bot_user_id: botUserId,
+      scopes,
+      app_id: appId,
+    };
+    let capCheck;
+    try {
+      capCheck = await checkChatIntegrationLimitAndInstall(workspaceId, SLACK_CATALOG_ID, {
+        sql: `INSERT INTO workspace_plugins (id, workspace_id, catalog_id, install_id, pillar, config, enabled, installed_at)
+         VALUES ($1, $2, $3, $1, 'chat', $4::jsonb, true, NOW())
+         ON CONFLICT (workspace_id, catalog_id) WHERE pillar IN ('chat', 'action') DO UPDATE
+           SET config = EXCLUDED.config,
+               enabled = true`,
+        params: [installId, workspaceId, SLACK_CATALOG_ID, JSON.stringify(installConfig)],
+      });
+    } catch (err) {
+      log.error(
+        { workspaceId, teamId, err: err instanceof Error ? err.message : String(err) },
+        "Failed to write workspace_plugins install record — aborting install",
+      );
+      // Re-throw — the install record is the first store; without it
+      // the credential write is meaningless. Surfaced to the route as
+      // a 5xx by the runHandler bridge.
+      throw err;
+    }
     if (!capCheck.allowed) {
       if (capCheck.reason === "check_failed") {
         // We couldn't read the workspace's chat-integration count, so the
@@ -241,51 +283,6 @@ export class SlackOAuthInstallHandler implements OAuthPlatformInstallHandler {
         workspaceId,
         limit: capCheck.limit,
       });
-    }
-
-    // ── 4. Install record — workspace_plugins INSERT (first store) ──
-    // Stable id per row — derived once so retries land on the same
-    // unique-index hit. ON CONFLICT updates `config`/`enabled` rather
-    // than swapping the id, so cross-store joins stay stable.
-    //
-    // Schema notes (mirrors `discord-static-bot-handler.ts`):
-    //   - `pillar` + `install_id` became NOT NULL in migration 0092
-    //     (#2739) and the auto-fill trigger was dropped in 0096 (#2744),
-    //     so every writer must name both columns explicitly — and the
-    //     chat-integration cap (#2953) counts `pillar = 'chat'` rows, so
-    //     omitting `pillar` would make Slack installs invisible to it.
-    //   - Chat-pillar installs are singletons per (workspace, catalog),
-    //     enforced by the `workspace_plugins_singleton` partial unique
-    //     index (`WHERE pillar IN ('chat','action')`). We target it via
-    //     the inference clause so re-install lands on the existing row.
-    //   - One install per (workspace, catalog) for chat, so `install_id`
-    //     mirrors `id`.
-    const installId = crypto.randomUUID();
-    const installConfig = {
-      team_id: teamId,
-      team_name: teamName,
-      bot_user_id: botUserId,
-      scopes,
-      app_id: appId,
-    };
-    try {
-      await internalQuery(
-        `INSERT INTO workspace_plugins (id, workspace_id, catalog_id, install_id, pillar, config, enabled, installed_at)
-         VALUES ($1, $2, $3, $1, 'chat', $4::jsonb, true, NOW())
-         ON CONFLICT (workspace_id, catalog_id) WHERE pillar IN ('chat', 'action') DO UPDATE
-           SET config = EXCLUDED.config,
-               enabled = true`,
-        [installId, workspaceId, SLACK_CATALOG_ID, JSON.stringify(installConfig)],
-      );
-    } catch (err) {
-      log.error(
-        { workspaceId, teamId, err: err instanceof Error ? err.message : String(err) },
-        "Failed to write workspace_plugins install record — aborting install",
-      );
-      // Re-throw — the install record is the first store; without it
-      // the credential write is meaningless. Surfaced to the route as
-      // a 5xx by the runHandler bridge.
-      throw err;
     }
 
     const installRecord: InstallRecord = {

--- a/packages/api/src/lib/integrations/install/slack-oauth-handler.ts
+++ b/packages/api/src/lib/integrations/install/slack-oauth-handler.ts
@@ -291,7 +291,7 @@ export class SlackOAuthInstallHandler implements OAuthPlatformInstallHandler {
       catalogId: SLACK_SLUG,
     };
 
-    // ── 5. Credential — chat_cache:slack:installation:<teamId> ──
+    // ── 4. Credential — chat_cache:slack:installation:<teamId> ──
     // ADR-0003 atomicity: a failure here leaves the install row in
     // place. The admin sees "Reconnect needed" in /admin/integrations
     // and can retry — re-running this method will UPSERT the install


### PR DESCRIPTION
## Summary

The chat-integration cap (#2953) was a **read-only precheck** (`checkChatIntegrationLimit`) followed by a **separate** `workspace_plugins` INSERT. Two *distinct* net-new chat platforms installing concurrently — e.g. Slack and Discord OAuth callbacks completing in the same window while the workspace is one under its cap — could both pass the precheck and both insert, landing the workspace **one over its cap** (TOCTOU, surfaced by CodeRabbit on #2996). The same-platform case was already safe — the `workspace_plugins_singleton` partial unique index collapses a duplicate into an UPSERT/reconnect.

This replaces the precheck + separate INSERT with a single atomic gate, **`checkChatIntegrationLimitAndInstall`**, which under a per-workspace `pg_advisory_xact_lock` re-counts chat installs and runs the caller's INSERT in **one transaction** — rolling back when a net-new platform would breach the cap. Both the Slack OAuth handler and the Discord static-bot handler route their UPSERT through it.

```
resolve plan (warm cache) → BEGIN → pg_advisory_xact_lock(ns, hashtext(ws))
  → re-count under the lock → cap reached? ROLLBACK + cap_reached
  → else run the caller's INSERT → COMMIT
```

**Reconnect is unchanged**: re-auth of an owned platform (`this_count > 0`) skips the cap comparison, so a grandfathered over-cap workspace can still re-auth what it owns. The gate returns `cap_reached` / `check_failed` (mapped to 429 / 503 as before) and **throws** only on genuine write-path failures (lock / INSERT / COMMIT), matching the pre-#3001 behaviour where a failed INSERT re-threw.

## Issues addressed

- **#3001 (TOCTOU race)** — cap-check + INSERT are now atomic per workspace via the advisory lock. AC2 regression test: two concurrent net-new installs at cap-minus-1 → exactly one succeeds (real Postgres).
- **#2999 (real-PG cap query)** — new `TEST_DATABASE_URL` test executes the exact exported `CHAT_INTEGRATION_COUNT_SQL` aggregate against seeded mixed-pillar rows (a `pillar='action'` row, an `archived` chat row, and a different workspace's chat row all excluded), asserting `others`/`this_count` for both net-new and reconnect cases. A FILTER typo, inverted `<>`/`=`, or dropped `status <> 'archived'` would now fail.
- **#2995 (remaining AC)** — real-Postgres coverage for a chat-install handler INSERT: the **real Discord handler** runs end-to-end (validate → reachability → gate → UPSERT) against the live post-0096 schema, catching handler↔schema drift (NOT-NULL `pillar`/`install_id`, stale `ON CONFLICT` arbiter) that the string-only mocks couldn't.

## Tests

- `enforcement.test.ts` — the chat-cap suite now drives `checkChatIntegrationLimitAndInstall` through a fake transaction client, asserting the BEGIN → lock → COUNT → INSERT/COMMIT (or ROLLBACK) sequence, reconnect-allow, fail-closed paths, and the poisoned-socket client destroy.
- `chat-cap-pg.test.ts` (new) — real-Postgres: the COUNT aggregate (#2999), the gate's INSERT against the live schema + the real Discord handler end-to-end (#2995 AC3), cap rollback, and the concurrency regression (#3001 AC2). Skips cleanly when `TEST_DATABASE_URL` is unset.
- Slack/Discord handler unit tests updated to the gate seam.

## CI

All six `/ci` gates pass locally: lint, type, test (full suite — api 517/517 + all other packages green, with `TEST_DATABASE_URL` set so the real-PG tests ran), syncpack, template/schema/security-header/railway-watch/oauth-helper drift, test-discipline, twenty-resolver, published-symbols.

Closes #3001
Closes #2999
Closes #2995

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3004"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782700191&installation_id=135337507&pr_number=3004&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3004&signature=ef6e64f5a479e9cffe74955e620e6fb061ed173ed8bfb528be61e60581532a5d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Install flows for Discord and Slack now perform plan-limit checks and the install write atomically, preventing partial failures, rollbacks, and race conditions.

* **Tests**
  * Added extensive real-database and concurrency tests covering cap enforcement, idempotency, rollback behavior, and same-/cross-platform concurrency scenarios.

* **Documentation**
  * Updated inline docs to reference the new atomic enforcement behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AtlasDevHQ/atlas/pull/3004?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->