### PR TITLE
fix(openapi): harden host-side SSRF egress — CIDR guard + execute-time validation + redirect handling (#3006)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -300,6 +300,14 @@ ATLAS_ADMIN_EMAIL=admin@useatlas.dev
 # every allowlisted write requires an in-chat confirm-before-write step before it
 # fires. Configure the allowlist per-install in Admin → Connections.
 # ATLAS_OPENAPI_TIMEOUT=30000                 # Global OpenAPI per-request timeout CAP in ms — bounds both spec probes and operation execution; a per-install timeout above this is rejected (default: 30s)
+#
+# SSRF egress guard (#3006): host-side spec probes AND operation execution are
+# blocked from reaching private / loopback / link-local / CGNAT IPs and internal
+# hostnames (e.g. cloud metadata at 169.254.169.254). The guard is ON in every
+# deploy mode and re-validates the resolved base URL + every redirect hop right
+# before each fetch. Self-hosted operators who legitimately connect an internal
+# OpenAPI service opt OUT explicitly with the flag below — NEVER set it on SaaS.
+# ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS=false    # Set =true to allow OpenAPI datasources to target private/internal/non-HTTPS hosts (self-hosted only; default: false = fail-closed)
 
 # === Appearance ===
 # ATLAS_BRAND_COLOR=oklch(0.759 0.148 167.71)  # Primary brand color in oklch format

--- a/packages/api/src/api/routes/__tests__/rest-operations.test.ts
+++ b/packages/api/src/api/routes/__tests__/rest-operations.test.ts
@@ -84,10 +84,18 @@ const graph = buildOperationGraph(SPEC);
 
 let twentyMock: TwentyMock;
 
+// The mock REST server binds to 127.0.0.1 (loopback), which the #3006 SSRF guard
+// blocks by default. A local test server is the "internal service" case the
+// operator opt-out exists for — enable it for this file and restore it after.
+const ORIGINAL_EGRESS_FLAG = process.env.ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS;
+
 beforeAll(async () => {
+  process.env.ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS = "true";
   twentyMock = await startTwentyMockServer();
 });
 afterAll(async () => {
+  if (ORIGINAL_EGRESS_FLAG === undefined) delete process.env.ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS;
+  else process.env.ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS = ORIGINAL_EGRESS_FLAG;
   await twentyMock.close();
 });
 beforeEach(() => {

--- a/packages/api/src/lib/integrations/install/__tests__/openapi-generic-form-handler.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/openapi-generic-form-handler.test.ts
@@ -279,14 +279,9 @@ describe("OpenApiGenericFormInstallHandler — base_url_override SSRF guard", ()
     // setKeys() (beforeEach) already deletes ATLAS_DEPLOY_MODE → self-hosted. The
     // pre-#3006 guard only fired on SaaS; it now fires in every mode unless opted out.
     const handler = newHandler();
-    let caught: unknown;
-    try {
-      await handler.validateConfig(WSID, validForm({ base_url_override: "https://10.0.0.5/v1" }));
-    } catch (err) {
-      caught = err;
-    }
-    expect(caught).toBeInstanceOf(FormInstallValidationError);
-    expect((caught as InstanceType<typeof FormInstallValidationError>).fieldErrors.base_url_override).toBeDefined();
+    const result = handler.validateConfig(WSID, validForm({ base_url_override: "https://10.0.0.5/v1" }));
+    await expect(result).rejects.toBeInstanceOf(FormInstallValidationError);
+    await expect(result).rejects.toHaveProperty("fieldErrors.base_url_override");
     expect(mockInternalQuery).not.toHaveBeenCalled(); // install aborted before the insert
   });
 
@@ -299,5 +294,17 @@ describe("OpenApiGenericFormInstallHandler — base_url_override SSRF guard", ()
     );
     expect(installRecord.id).toBe("install-1");
     expect(mockInternalQuery).toHaveBeenCalled(); // install proceeded to the insert
+  });
+
+  it("rejects a PUBLIC but non-HTTPS base_url_override (cleartext-credential downgrade)", async () => {
+    // zod's OptionalUrlSchema allows http(s); the egress guard is the only thing
+    // that rejects a plaintext-scheme public host — a credential-downgrade risk
+    // (the agent would later send a credentialed request in the clear).
+    delete process.env.ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS;
+    const handler = newHandler();
+    const result = handler.validateConfig(WSID, validForm({ base_url_override: "http://public.example.com/v1" }));
+    await expect(result).rejects.toBeInstanceOf(FormInstallValidationError);
+    await expect(result).rejects.toHaveProperty("fieldErrors.base_url_override");
+    expect(mockInternalQuery).not.toHaveBeenCalled(); // aborted before the insert
   });
 });

--- a/packages/api/src/lib/integrations/install/__tests__/openapi-generic-form-handler.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/openapi-generic-form-handler.test.ts
@@ -271,3 +271,33 @@ describe("OpenApiGenericFormInstallHandler — persistence + encryption", () => 
     expect(mockInternalQuery).not.toHaveBeenCalled();
   });
 });
+
+// ── base_url_override SSRF guard (#3006) ──────────────────────────────────────
+
+describe("OpenApiGenericFormInstallHandler — base_url_override SSRF guard", () => {
+  it("rejects an internal base_url_override by default — in non-SaaS mode (guard is ON everywhere now)", async () => {
+    // setKeys() (beforeEach) already deletes ATLAS_DEPLOY_MODE → self-hosted. The
+    // pre-#3006 guard only fired on SaaS; it now fires in every mode unless opted out.
+    const handler = newHandler();
+    let caught: unknown;
+    try {
+      await handler.validateConfig(WSID, validForm({ base_url_override: "https://10.0.0.5/v1" }));
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(FormInstallValidationError);
+    expect((caught as InstanceType<typeof FormInstallValidationError>).fieldErrors.base_url_override).toBeDefined();
+    expect(mockInternalQuery).not.toHaveBeenCalled(); // install aborted before the insert
+  });
+
+  it("accepts an internal base_url_override when the operator opts out (ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS=true)", async () => {
+    process.env.ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS = "true";
+    const handler = newHandler();
+    const { installRecord } = await handler.validateConfig(
+      WSID,
+      validForm({ base_url_override: "https://10.0.0.5/v1" }),
+    );
+    expect(installRecord.id).toBe("install-1");
+    expect(mockInternalQuery).toHaveBeenCalled(); // install proceeded to the insert
+  });
+});

--- a/packages/api/src/lib/integrations/install/openapi-generic-form-handler.ts
+++ b/packages/api/src/lib/integrations/install/openapi-generic-form-handler.ts
@@ -222,8 +222,8 @@ export class OpenApiGenericFormInstallHandler implements FormBasedInstallHandler
     }
 
     // ── 2b. SSRF guard for base_url_override ────────────────────────
-    // The override becomes the operations base URL the agent later POSTs to,
-    // host-side, via `executeRestOperation`. It's admin-supplied, so block
+    // The override becomes the operations base URL the agent later sends requests
+    // to, host-side, via `executeRestOperation`. It's admin-supplied, so block
     // private/internal targets via the shared chokepoint (the spec URL itself is
     // guarded inside `probeSpec`). The guard is ON in every deploy mode;
     // self-hosted operators opt OUT via ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS (#3006).

--- a/packages/api/src/lib/integrations/install/openapi-generic-form-handler.ts
+++ b/packages/api/src/lib/integrations/install/openapi-generic-form-handler.ts
@@ -41,7 +41,7 @@ import { createLogger } from "@atlas/api/lib/logger";
 import { internalQuery } from "@atlas/api/lib/db/internal";
 import { getEncryptionKeyset } from "@atlas/api/lib/db/encryption-keys";
 import { encryptSecretFields, parseConfigSchema } from "@atlas/api/lib/plugins/secrets";
-import { isSafeExternalUrl } from "@atlas/api/lib/sandbox/validate";
+import { assertBaseUrlAllowed, EgressBlockedError } from "@atlas/api/lib/openapi/egress-guard";
 import type { WorkspaceId } from "@useatlas/types";
 import {
   OPENAPI_GENERIC_SLUG,
@@ -221,25 +221,30 @@ export class OpenApiGenericFormInstallHandler implements FormBasedInstallHandler
       );
     }
 
-    // ── 2b. SaaS SSRF guard for base_url_override ───────────────────
+    // ── 2b. SSRF guard for base_url_override ────────────────────────
     // The override becomes the operations base URL the agent later POSTs to,
-    // host-side, via `executeRestOperation`. It's admin-supplied, so on
-    // multi-tenant SaaS block private/internal targets (the spec URL itself is
-    // guarded inside `probeSpec`). Self-hosted may point at internal services.
-    if (
-      process.env.ATLAS_DEPLOY_MODE === "saas" &&
-      data.base_url_override &&
-      !isSafeExternalUrl(data.base_url_override)
-    ) {
-      throw FormInstallValidationError.fromZodFlatten({
-        fieldErrors: {
-          base_url_override: [
-            "Base URL must use HTTPS and resolve to a public host — private or " +
-              "internal addresses are blocked in hosted mode.",
-          ],
-        },
-        formErrors: [],
-      });
+    // host-side, via `executeRestOperation`. It's admin-supplied, so block
+    // private/internal targets via the shared chokepoint (the spec URL itself is
+    // guarded inside `probeSpec`). The guard is ON in every deploy mode;
+    // self-hosted operators opt OUT via ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS (#3006).
+    if (data.base_url_override) {
+      try {
+        assertBaseUrlAllowed(data.base_url_override);
+      } catch (err) {
+        if (err instanceof EgressBlockedError) {
+          throw FormInstallValidationError.fromZodFlatten({
+            fieldErrors: {
+              base_url_override: [
+                "Base URL must use HTTPS and resolve to a public host — private or internal " +
+                  "addresses are blocked. Set ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS=true to allow " +
+                  "internal targets (self-hosted only).",
+              ],
+            },
+            formErrors: [],
+          });
+        }
+        throw err;
+      }
     }
 
     // ── 3. Probe the spec (slice-0) → snapshot ──────────────────────

--- a/packages/api/src/lib/openapi/__tests__/client.test.ts
+++ b/packages/api/src/lib/openapi/__tests__/client.test.ts
@@ -449,7 +449,7 @@ describe("executeOperation — SSRF egress guard (#3006)", () => {
     let hops = 0;
     const fetchImpl = (async (url: string) => {
       hops++;
-      if (url.startsWith("https://public.example.com")) {
+      if (new URL(url).hostname === "public.example.com") {
         return new Response(null, { status: 302, headers: { location: "https://10.0.0.5/internal" } });
       }
       return new Response("should-not-reach", { status: 200 });

--- a/packages/api/src/lib/openapi/__tests__/client.test.ts
+++ b/packages/api/src/lib/openapi/__tests__/client.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, afterAll } from "bun:test";
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from "bun:test";
 import * as fs from "fs";
 import * as http from "http";
 import { type AddressInfo } from "net";
@@ -23,7 +23,15 @@ let baseUrl: string;
 let captured: CapturedRequest | null = null;
 let graph: OperationGraph;
 
+// These are integration tests against a real loopback (127.0.0.1) server — which
+// the #3006 SSRF guard blocks by default. A local test server is exactly the
+// "internal service" case the operator opt-out exists for, so enable it for the
+// whole file and restore it after. The execute-time *rejection* tests below
+// toggle it back off per-test to exercise the guard.
+const ORIGINAL_EGRESS_FLAG = process.env.ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS;
+
 beforeAll(async () => {
+  process.env.ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS = "true";
   graph = buildOperationGraph(
     JSON.parse(fs.readFileSync(path.join(FIXTURES, "client-spec.json"), "utf8")),
   );
@@ -48,6 +56,8 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
+  if (ORIGINAL_EGRESS_FLAG === undefined) delete process.env.ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS;
+  else process.env.ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS = ORIGINAL_EGRESS_FLAG;
   await new Promise<void>((resolve, reject) =>
     server.close((err) => (err ? reject(err) : resolve())),
   );
@@ -378,5 +388,91 @@ describe("parseRetryAfterMs", () => {
     expect(parseRetryAfterMs("")).toBeUndefined();
     expect(parseRetryAfterMs("   ")).toBeUndefined();
     expect(parseRetryAfterMs("not-a-date")).toBeUndefined();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+//  SSRF egress guard at execution time (#3006)
+// ─────────────────────────────────────────────────────────────────────
+
+describe("executeOperation — SSRF egress guard (#3006)", () => {
+  // Run with the guard ON (the file-wide opt-out is restored after each test).
+  beforeEach(() => {
+    delete process.env.ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS;
+  });
+  afterEach(() => {
+    process.env.ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS = "true"; // back to the file-wide setting
+  });
+
+  /** A minimal one-GET graph whose `servers[0].url` is whatever the caller wants. */
+  function graphWithServer(serverUrl: string): OperationGraph {
+    return buildOperationGraph({
+      openapi: "3.1.0",
+      info: { title: "Internal", version: "1.0.0" },
+      servers: [{ url: serverUrl }],
+      paths: {
+        "/ping": { get: { operationId: "ping", responses: { "200": { description: "ok" } } } },
+      },
+    });
+  }
+
+  it("rejects a spec whose servers[0].url is internal — at execute time, before any request", async () => {
+    const internalGraph = graphWithServer("https://169.254.169.254");
+    let fired = false;
+    const fetchImpl = (async () => {
+      fired = true;
+      return new Response("{}", { status: 200 });
+    }) as unknown as typeof globalThis.fetch;
+
+    // No baseUrl override → the client falls back to the spec-derived servers[0].url.
+    const err = await executeOperation(internalGraph, "ping", {}, { kind: "none" }, { fetchImpl }).catch((e) => e);
+    expect(err).toBeInstanceOf(OpenApiClientError);
+    expect((err as OpenApiClientError).reason).toBe("blocked-egress");
+    expect(fired).toBe(false); // rejected before the request left the box
+  });
+
+  it("rejects an internal baseUrl override too", async () => {
+    const publicGraph = graphWithServer("https://public.example.com");
+    const err = await executeOperation(
+      publicGraph,
+      "ping",
+      {},
+      { kind: "none" },
+      { baseUrl: "https://[::ffff:169.254.169.254]" },
+    ).catch((e) => e);
+    expect(err).toBeInstanceOf(OpenApiClientError);
+    expect((err as OpenApiClientError).reason).toBe("blocked-egress");
+  });
+
+  it("rejects a public→internal redirect at execute time (TOCTOU)", async () => {
+    const publicGraph = graphWithServer("https://public.example.com");
+    let hops = 0;
+    const fetchImpl = (async (url: string) => {
+      hops++;
+      if (url.startsWith("https://public.example.com")) {
+        return new Response(null, { status: 302, headers: { location: "https://10.0.0.5/internal" } });
+      }
+      return new Response("should-not-reach", { status: 200 });
+    }) as unknown as typeof globalThis.fetch;
+
+    const err = await executeOperation(publicGraph, "ping", {}, { kind: "none" }, { fetchImpl }).catch((e) => e);
+    expect(err).toBeInstanceOf(OpenApiClientError);
+    expect((err as OpenApiClientError).reason).toBe("blocked-egress");
+    expect(hops).toBe(1); // the internal hop never fired
+  });
+
+  it("still executes against a public host with the guard ON", async () => {
+    const publicGraph = graphWithServer("https://public.example.com");
+    let seenUrl = "";
+    const fetchImpl = (async (url: string) => {
+      seenUrl = url;
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }) as unknown as typeof globalThis.fetch;
+    const result = await executeOperation(publicGraph, "ping", {}, { kind: "none" }, { fetchImpl });
+    expect(result.status).toBe(200);
+    expect(seenUrl).toBe("https://public.example.com/ping");
   });
 });

--- a/packages/api/src/lib/openapi/__tests__/egress-guard.test.ts
+++ b/packages/api/src/lib/openapi/__tests__/egress-guard.test.ts
@@ -8,6 +8,7 @@ import { afterEach, describe, expect, it } from "bun:test";
 import {
   assertBaseUrlAllowed,
   guardedFetch,
+  hostForLog,
   isInternalEgressAllowed,
   EgressBlockedError,
   MAX_REDIRECTS,
@@ -82,7 +83,7 @@ describe("guardedFetch", () => {
     const hosts: string[] = [];
     const fetchImpl = (async (url: string) => {
       hosts.push(new URL(url).host);
-      if (url.startsWith("https://a.example.com")) {
+      if (new URL(url).hostname === "a.example.com") {
         return new Response(null, { status: 302, headers: { location: "https://b.example.com/final" } });
       }
       return new Response("done", { status: 200 });
@@ -97,7 +98,7 @@ describe("guardedFetch", () => {
     let hops = 0;
     const fetchImpl = (async (url: string) => {
       hops++;
-      if (url.startsWith("https://public.example.com")) {
+      if (new URL(url).hostname === "public.example.com") {
         return new Response(null, { status: 302, headers: { location: "https://169.254.169.254/latest/" } });
       }
       return new Response("should-not-reach", { status: 200 });
@@ -143,5 +144,87 @@ describe("guardedFetch", () => {
       new Response(null, { status: 304 })) as unknown as typeof globalThis.fetch;
     const res = await guardedFetch("https://public.example.com/x", {}, { fetchImpl });
     expect(res.status).toBe(304);
+  });
+
+  it("throws EgressBlockedError when the redirect Location is malformed (fail closed)", async () => {
+    delete process.env.ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS;
+    const fetchImpl = (async () =>
+      new Response(null, {
+        status: 302,
+        headers: { location: "ht!tp://::::" }, // unparseable even against the base
+      })) as unknown as typeof globalThis.fetch;
+    await expect(guardedFetch("https://public.example.com/x", {}, { fetchImpl })).rejects.toBeInstanceOf(
+      EgressBlockedError,
+    );
+  });
+
+  it("strips the credential headers on a cross-origin redirect (public→public), keeps them same-origin", async () => {
+    delete process.env.ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS;
+    const authByHost: Record<string, string | null> = {};
+    const fetchImpl = (async (url: string, init?: RequestInit) => {
+      const host = new URL(url).hostname;
+      authByHost[host] = new Headers(init?.headers).get("authorization");
+      if (host === "a.example.com") {
+        // first an in-origin hop, then bounce to a different public origin
+        return new URL(url).pathname === "/start"
+          ? new Response(null, { status: 302, headers: { location: "https://a.example.com/next" } })
+          : new Response(null, { status: 302, headers: { location: "https://b.example.com/final" } });
+      }
+      return new Response("done", { status: 200 });
+    }) as unknown as typeof globalThis.fetch;
+
+    const res = await guardedFetch(
+      "https://a.example.com/start",
+      { headers: { Authorization: "Bearer SECRET", accept: "application/json" } },
+      { fetchImpl },
+    );
+    expect(res.status).toBe(200);
+    // Same-origin hops keep the credential; the cross-origin hop to b.example.com must not see it.
+    expect(authByHost["a.example.com"]).toBe("Bearer SECRET");
+    expect(authByHost["b.example.com"]).toBeNull();
+  });
+
+  it("downgrades a 303 to GET and drops the body on the next hop", async () => {
+    delete process.env.ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS;
+    let secondHopMethod = "";
+    let secondHopHadBody = false;
+    const fetchImpl = (async (url: string, init?: RequestInit) => {
+      if (new URL(url).pathname === "/post") {
+        return new Response(null, { status: 303, headers: { location: "https://api.example.com/result" } });
+      }
+      secondHopMethod = (init?.method ?? "GET").toUpperCase();
+      secondHopHadBody = init?.body != null;
+      return new Response("ok", { status: 200 });
+    }) as unknown as typeof globalThis.fetch;
+
+    const res = await guardedFetch(
+      "https://api.example.com/post",
+      { method: "POST", body: JSON.stringify({ a: 1 }), headers: { "content-type": "application/json" } },
+      { fetchImpl },
+    );
+    expect(res.status).toBe(200);
+    expect(secondHopMethod).toBe("GET"); // 303 always becomes GET
+    expect(secondHopHadBody).toBe(false); // and drops the body
+  });
+});
+
+describe("hostForLog", () => {
+  it("returns host only — never the path or query (which can carry an apiKey-query secret)", () => {
+    expect(hostForLog("https://10.0.0.5/v1/things?api_key=SECRET")).toBe("10.0.0.5");
+    expect(hostForLog("https://api.example.com:8443/x?token=abc")).toBe("api.example.com:8443");
+  });
+
+  it("returns <unparseable> for a malformed URL (never the raw string)", () => {
+    expect(hostForLog("ht!tp://::::")).toBe("<unparseable>");
+  });
+});
+
+describe("EgressBlockedError redaction", () => {
+  it("does not leak an apiKey-query secret into the message or the host field", () => {
+    const err = new EgressBlockedError("https://169.254.169.254/latest?api_key=SUPER_SECRET");
+    expect(err.host).toBe("169.254.169.254");
+    expect(err.message).not.toContain("SUPER_SECRET");
+    expect(err.message).not.toContain("api_key");
+    expect(err.message).toContain("169.254.169.254");
   });
 });

--- a/packages/api/src/lib/openapi/__tests__/egress-guard.test.ts
+++ b/packages/api/src/lib/openapi/__tests__/egress-guard.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Tests for the shared OpenAPI SSRF chokepoint (`egress-guard.ts`, #3006): the
+ * one `assertBaseUrlAllowed` install / rediscover / resolve / execute all share,
+ * the operator opt-out flag, and the redirect-revalidating `guardedFetch`.
+ */
+
+import { afterEach, describe, expect, it } from "bun:test";
+import {
+  assertBaseUrlAllowed,
+  guardedFetch,
+  isInternalEgressAllowed,
+  EgressBlockedError,
+  MAX_REDIRECTS,
+} from "../egress-guard";
+
+const ORIGINAL = process.env.ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS;
+afterEach(() => {
+  if (ORIGINAL === undefined) delete process.env.ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS;
+  else process.env.ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS = ORIGINAL;
+});
+
+describe("assertBaseUrlAllowed", () => {
+  it("throws EgressBlockedError for every internal-address encoding", () => {
+    delete process.env.ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS;
+    for (const url of [
+      "https://[::1]/x",
+      "https://[::ffff:169.254.169.254]/x",
+      "https://metadata.google.internal/x",
+      "https://100.100.100.200/x",
+      "https://172.16.0.5/x",
+      "http://example.com/x", // non-HTTPS
+    ]) {
+      expect(() => assertBaseUrlAllowed(url), url).toThrow(EgressBlockedError);
+    }
+  });
+
+  it("allows a genuinely public HTTPS host", () => {
+    delete process.env.ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS;
+    expect(() => assertBaseUrlAllowed("https://crm.example.com/rest")).not.toThrow();
+  });
+
+  it("is bypassed when the operator opts out (ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS=true)", () => {
+    process.env.ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS = "true";
+    expect(isInternalEgressAllowed()).toBe(true);
+    expect(() => assertBaseUrlAllowed("http://10.0.0.5/x")).not.toThrow();
+    expect(() => assertBaseUrlAllowed("https://169.254.169.254/x")).not.toThrow();
+  });
+
+  it("keeps the guard ON for any non-`true` opt-out value (fail-closed)", () => {
+    process.env.ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS = "1"; // not the literal "true"
+    expect(isInternalEgressAllowed()).toBe(false);
+    expect(() => assertBaseUrlAllowed("http://10.0.0.5/x")).toThrow(EgressBlockedError);
+  });
+});
+
+describe("guardedFetch", () => {
+  it("validates the initial URL before issuing any request", async () => {
+    delete process.env.ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS;
+    let called = false;
+    const fetchImpl = (async () => {
+      called = true;
+      return new Response("{}", { status: 200 });
+    }) as unknown as typeof globalThis.fetch;
+    await expect(guardedFetch("https://127.0.0.1/x", {}, { fetchImpl })).rejects.toBeInstanceOf(EgressBlockedError);
+    expect(called).toBe(false);
+  });
+
+  it("forces redirect:'manual' and returns a non-redirect response directly", async () => {
+    delete process.env.ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS;
+    let seenRedirect: RequestInit["redirect"];
+    const fetchImpl = (async (_url: string, init?: RequestInit) => {
+      seenRedirect = init?.redirect;
+      return new Response("ok", { status: 200 });
+    }) as unknown as typeof globalThis.fetch;
+    const res = await guardedFetch("https://public.example.com/x", { method: "GET" }, { fetchImpl });
+    expect(res.status).toBe(200);
+    expect(seenRedirect).toBe("manual");
+  });
+
+  it("follows a public→public redirect, re-validating the new host", async () => {
+    delete process.env.ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS;
+    const hosts: string[] = [];
+    const fetchImpl = (async (url: string) => {
+      hosts.push(new URL(url).host);
+      if (url.startsWith("https://a.example.com")) {
+        return new Response(null, { status: 302, headers: { location: "https://b.example.com/final" } });
+      }
+      return new Response("done", { status: 200 });
+    }) as unknown as typeof globalThis.fetch;
+    const res = await guardedFetch("https://a.example.com/x", {}, { fetchImpl });
+    expect(res.status).toBe(200);
+    expect(hosts).toEqual(["a.example.com", "b.example.com"]);
+  });
+
+  it("rejects a public→internal redirect (the TOCTOU vector)", async () => {
+    delete process.env.ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS;
+    let hops = 0;
+    const fetchImpl = (async (url: string) => {
+      hops++;
+      if (url.startsWith("https://public.example.com")) {
+        return new Response(null, { status: 302, headers: { location: "https://169.254.169.254/latest/" } });
+      }
+      return new Response("should-not-reach", { status: 200 });
+    }) as unknown as typeof globalThis.fetch;
+    await expect(guardedFetch("https://public.example.com/x", {}, { fetchImpl })).rejects.toBeInstanceOf(
+      EgressBlockedError,
+    );
+    expect(hops).toBe(1); // the metadata hop never fired
+  });
+
+  it("resolves a relative Location against the current URL before validating", async () => {
+    delete process.env.ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS;
+    const urls: string[] = [];
+    const fetchImpl = (async (url: string) => {
+      urls.push(url);
+      if (url === "https://public.example.com/a") {
+        return new Response(null, { status: 301, headers: { location: "/b" } });
+      }
+      return new Response("ok", { status: 200 });
+    }) as unknown as typeof globalThis.fetch;
+    const res = await guardedFetch("https://public.example.com/a", {}, { fetchImpl });
+    expect(res.status).toBe(200);
+    expect(urls).toEqual(["https://public.example.com/a", "https://public.example.com/b"]);
+  });
+
+  it("caps redirect depth and throws rather than looping forever", async () => {
+    delete process.env.ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS;
+    let hops = 0;
+    const fetchImpl = (async () => {
+      hops++;
+      // Always redirect to another public host — a redirect loop.
+      return new Response(null, { status: 302, headers: { location: `https://public.example.com/${hops}` } });
+    }) as unknown as typeof globalThis.fetch;
+    await expect(guardedFetch("https://public.example.com/0", {}, { fetchImpl })).rejects.toBeInstanceOf(
+      EgressBlockedError,
+    );
+    expect(hops).toBe(MAX_REDIRECTS + 1); // initial + MAX_REDIRECTS hops, then bail
+  });
+
+  it("returns a 3xx with no Location unchanged (nothing to follow)", async () => {
+    delete process.env.ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS;
+    const fetchImpl = (async () =>
+      new Response(null, { status: 304 })) as unknown as typeof globalThis.fetch;
+    const res = await guardedFetch("https://public.example.com/x", {}, { fetchImpl });
+    expect(res.status).toBe(304);
+  });
+});

--- a/packages/api/src/lib/openapi/__tests__/probe.test.ts
+++ b/packages/api/src/lib/openapi/__tests__/probe.test.ts
@@ -123,40 +123,45 @@ describe("probeSpec", () => {
   });
 });
 
-describe("assertSpecUrlAllowed (SaaS SSRF guard)", () => {
-  const ORIGINAL = process.env.ATLAS_DEPLOY_MODE;
+describe("assertSpecUrlAllowed (SSRF guard, #3006)", () => {
+  const ORIGINAL = process.env.ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS;
   afterEach(() => {
-    if (ORIGINAL === undefined) delete process.env.ATLAS_DEPLOY_MODE;
-    else process.env.ATLAS_DEPLOY_MODE = ORIGINAL;
+    if (ORIGINAL === undefined) delete process.env.ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS;
+    else process.env.ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS = ORIGINAL;
   });
 
-  it("is a no-op off SaaS (self-hosted may connect internal hosts)", () => {
-    delete process.env.ATLAS_DEPLOY_MODE;
-    expect(() => assertSpecUrlAllowed("http://localhost:9000/openapi.json")).not.toThrow();
-    expect(() => assertSpecUrlAllowed("http://10.0.0.5/openapi.json")).not.toThrow();
-  });
-
-  it("rejects private/internal spec URLs in SaaS mode (metadata, localhost, RFC1918)", () => {
-    process.env.ATLAS_DEPLOY_MODE = "saas";
+  it("rejects private/internal spec URLs by default in EVERY deploy mode (no implicit non-SaaS skip)", () => {
+    // The pre-#3006 guard was a no-op off SaaS, leaving self-hosted unprotected.
+    // It is now ON everywhere unless the operator opts out explicitly.
+    delete process.env.ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS;
+    delete process.env.ATLAS_DEPLOY_MODE; // even with no deploy mode set, the guard fires
     for (const url of [
       "http://169.254.169.254/latest/meta-data/", // cloud metadata
       "https://localhost/openapi.json",
       "https://127.0.0.1/openapi.json",
       "https://10.0.0.5/openapi.json",
       "https://192.168.1.10/openapi.json",
+      "https://[::ffff:169.254.169.254]/openapi.json", // IPv4-mapped metadata
+      "https://metadata.google.internal/v1/", // GCP metadata hostname
       "http://crm.example.com/openapi.json", // non-HTTPS
     ]) {
       expect(() => assertSpecUrlAllowed(url), url).toThrow(OpenApiProbeError);
     }
   });
 
-  it("allows a public HTTPS spec URL in SaaS mode", () => {
-    process.env.ATLAS_DEPLOY_MODE = "saas";
+  it("allows a public HTTPS spec URL", () => {
+    delete process.env.ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS;
     expect(() => assertSpecUrlAllowed("https://crm.example.com/rest/open-api/core")).not.toThrow();
   });
 
-  it("probeSpec fires the guard before the host-side fetch (SaaS)", async () => {
-    process.env.ATLAS_DEPLOY_MODE = "saas";
+  it("opts the guard out when ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS=true (self-hosted internal services)", () => {
+    process.env.ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS = "true";
+    expect(() => assertSpecUrlAllowed("http://localhost:9000/openapi.json")).not.toThrow();
+    expect(() => assertSpecUrlAllowed("http://10.0.0.5/openapi.json")).not.toThrow();
+  });
+
+  it("probeSpec fires the guard before the host-side fetch", async () => {
+    delete process.env.ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS;
     let fetched = false;
     const fetchImpl = (async () => {
       fetched = true;
@@ -166,6 +171,23 @@ describe("assertSpecUrlAllowed (SaaS SSRF guard)", () => {
     expect(err).toBeInstanceOf(OpenApiProbeError);
     expect((err as OpenApiProbeError).reason).toBe("unreachable");
     expect(fetched).toBe(false); // guard rejected before any request left the box
+  });
+
+  it("probeSpec rejects a public→internal redirect (TOCTOU)", async () => {
+    delete process.env.ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS;
+    let hops = 0;
+    const fetchImpl = (async (url: string) => {
+      hops++;
+      // The up-front guard passes (public host); the upstream then 302s to metadata.
+      if (url.startsWith("https://public.example.com")) {
+        return new Response(null, { status: 302, headers: { location: "https://169.254.169.254/" } });
+      }
+      return new Response(JSON.stringify(MOCK_OPENAPI_SPEC), { status: 200 });
+    }) as unknown as typeof globalThis.fetch;
+    const err = await probeSpec("https://public.example.com/o.json", { kind: "none" }, { fetchImpl }).catch((e) => e);
+    expect(err).toBeInstanceOf(OpenApiProbeError);
+    expect((err as OpenApiProbeError).reason).toBe("unreachable");
+    expect(hops).toBe(1); // followed nothing past the blocked redirect
   });
 });
 

--- a/packages/api/src/lib/openapi/__tests__/probe.test.ts
+++ b/packages/api/src/lib/openapi/__tests__/probe.test.ts
@@ -179,7 +179,7 @@ describe("assertSpecUrlAllowed (SSRF guard, #3006)", () => {
     const fetchImpl = (async (url: string) => {
       hops++;
       // The up-front guard passes (public host); the upstream then 302s to metadata.
-      if (url.startsWith("https://public.example.com")) {
+      if (new URL(url).hostname === "public.example.com") {
         return new Response(null, { status: 302, headers: { location: "https://169.254.169.254/" } });
       }
       return new Response(JSON.stringify(MOCK_OPENAPI_SPEC), { status: 200 });

--- a/packages/api/src/lib/openapi/__tests__/twenty-acceptance.test.ts
+++ b/packages/api/src/lib/openapi/__tests__/twenty-acceptance.test.ts
@@ -223,7 +223,13 @@ let mock1: TwentyMock;
 /** The bearer + base URL the resolved Twenty datasource points at (the mock server). */
 let twentyBase: Omit<RestDatasource, "representationMode">;
 
+// The mock REST server binds to 127.0.0.1 (loopback), which the #3006 SSRF guard
+// blocks by default. A local test server is the "internal service" case the
+// operator opt-out exists for — enable it for this file and restore it after.
+const ORIGINAL_EGRESS_FLAG = process.env.ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS;
+
 beforeAll(async () => {
+  process.env.ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS = "true";
   mock1 = await startTwentyMockServer();
   twentyBase = {
     id: "twenty",
@@ -237,6 +243,8 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
+  if (ORIGINAL_EGRESS_FLAG === undefined) delete process.env.ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS;
+  else process.env.ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS = ORIGINAL_EGRESS_FLAG;
   activeDatasources = [];
   await mock1.close();
   emitMetricsTable();

--- a/packages/api/src/lib/openapi/__tests__/workspace-datasource.test.ts
+++ b/packages/api/src/lib/openapi/__tests__/workspace-datasource.test.ts
@@ -253,3 +253,56 @@ describe("resolveWorkspacePrimaryRestDatasource", () => {
     expect(primary?.id).toBe("first");
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────
+//  Resolve-time SSRF guard (#3006)
+// ─────────────────────────────────────────────────────────────────────
+
+describe("resolveWorkspaceRestDatasources — SSRF guard at resolve time", () => {
+  // A snapshot whose spec declares an INTERNAL servers[0].url — the public-spec,
+  // internal-server attack. `resolveBaseUrl` would derive a host-side base URL
+  // pointed at cloud metadata; the resolver must skip the datasource (fail-soft).
+  const internalSpec = { ...MOCK_OPENAPI_SPEC, servers: [{ url: "https://169.254.169.254" }] };
+  const internalGraph = buildOperationGraph(internalSpec);
+  function internalSnapshot(probedAt = "2026-05-29T00:00:00.000Z"): OpenApiSnapshot {
+    return buildSnapshot(internalSpec, internalGraph, probedAt);
+  }
+
+  const ORIGINAL_FLAG = process.env.ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS;
+  afterEach(() => {
+    if (ORIGINAL_FLAG === undefined) delete process.env.ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS;
+    else process.env.ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS = ORIGINAL_FLAG;
+  });
+
+  it("skips a datasource whose spec-derived servers[0].url is internal — but keeps its public siblings (fail-soft isolation)", async () => {
+    delete process.env.ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS;
+    const result = await resolveWorkspaceRestDatasources("org-1", {
+      query: queryReturning([
+        { install_id: "internal", config: config({ openapi_snapshot: internalSnapshot() }) },
+        { install_id: "public", config: config() }, // public servers[0].url
+      ]),
+    });
+    expect(result.map((d) => d.id)).toEqual(["public"]); // internal dropped, public survives
+  });
+
+  it("skips a datasource whose base_url_override is internal", async () => {
+    delete process.env.ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS;
+    const result = await resolveWorkspaceRestDatasources("org-1", {
+      query: queryReturning([
+        { install_id: "ds-1", config: config({ base_url_override: "https://10.0.0.5/v1" }) },
+      ]),
+    });
+    expect(result).toHaveLength(0);
+  });
+
+  it("resolves an internal datasource when the operator opts out (ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS=true)", async () => {
+    process.env.ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS = "true";
+    const result = await resolveWorkspaceRestDatasources("org-1", {
+      query: queryReturning([
+        { install_id: "internal", config: config({ openapi_snapshot: internalSnapshot() }) },
+      ]),
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].baseUrl).toBe("https://169.254.169.254");
+  });
+});

--- a/packages/api/src/lib/openapi/client.ts
+++ b/packages/api/src/lib/openapi/client.ts
@@ -26,6 +26,7 @@
  * deferred to slice 6 — pass `{ kind: "bearer", token }` once a token is
  * obtained out of band.
  */
+import { EgressBlockedError, guardedFetch } from "./egress-guard";
 import {
   paginate,
   type MergedPages,
@@ -95,13 +96,30 @@ export async function executeOperation(
 
   let response: Response;
   try {
-    response = await fetchImpl(url.toString(), {
-      method: operation.method,
-      headers,
-      ...(hasBody ? { body } : {}),
-      signal: AbortSignal.timeout(timeoutMs),
-    });
+    // The resolved base URL (an admin override OR the spec-derived
+    // `servers[0].url`) and every redirect hop are re-validated against the SSRF
+    // guard immediately before the request leaves the box — a public spec that
+    // declares an internal `servers[0].url`, or a public host that 302-redirects
+    // to one, is rejected here, at execution time (#3006).
+    response = await guardedFetch(
+      url.toString(),
+      {
+        method: operation.method,
+        headers,
+        ...(hasBody ? { body } : {}),
+        signal: AbortSignal.timeout(timeoutMs),
+      },
+      { fetchImpl },
+    );
   } catch (err) {
+    if (err instanceof EgressBlockedError) {
+      throw new OpenApiClientError({
+        reason: "blocked-egress",
+        operationId,
+        status: 0,
+        message: err.message,
+      });
+    }
     throw classifyTransportError(err, operationId, timeoutMs);
   }
 

--- a/packages/api/src/lib/openapi/client.ts
+++ b/packages/api/src/lib/openapi/client.ts
@@ -52,9 +52,10 @@ import {
  * Execute one operation from the graph against its target.
  *
  * @throws {OpenApiClientError} for client-side faults (unknown operation,
- *   missing base URL, missing path param, missing auth placement) and transport
- *   faults (timeout, network). A non-2xx HTTP response is NOT an error — it is
- *   returned as the result.
+ *   missing base URL, missing path param, missing auth placement, `blocked-egress`
+ *   — the resolved base URL or a redirect hop resolves to a private/internal
+ *   address, SSRF guard) and transport faults (timeout, network). A non-2xx HTTP
+ *   response is NOT an error — it is returned as the result.
  */
 export async function executeOperation(
   graph: OperationGraph,

--- a/packages/api/src/lib/openapi/egress-guard.ts
+++ b/packages/api/src/lib/openapi/egress-guard.ts
@@ -133,7 +133,7 @@ export async function guardedFetch(
         `Upstream redirected to a malformed Location (${err instanceof Error ? err.message : String(err)}).`,
       );
     }
-    log.debug({ from: safeUrlForLog(currentUrl), to: safeUrlForLog(nextUrl), hop }, "guardedFetch following redirect");
+    log.debug({ from: hostForLog(currentUrl), to: hostForLog(nextUrl), hop }, "guardedFetch following redirect");
     currentUrl = nextUrl;
   }
 
@@ -143,8 +143,13 @@ export async function guardedFetch(
   );
 }
 
-/** Host-only breadcrumb for logs — never the path/query (which may carry an apiKey-query secret). */
-function safeUrlForLog(url: string): string {
+/**
+ * Host-only breadcrumb for logs — never the path/query (which may carry an
+ * apiKey-query secret). Exported so every guard consumer logs blocked targets
+ * the same way (host only), keeping the "logs never carry a credential"
+ * invariant owned by the module that makes the SSRF decision.
+ */
+export function hostForLog(url: string): string {
   try {
     return new URL(url).host;
   } catch {

--- a/packages/api/src/lib/openapi/egress-guard.ts
+++ b/packages/api/src/lib/openapi/egress-guard.ts
@@ -1,0 +1,154 @@
+/**
+ * `openapi-egress-guard` — the single SSRF chokepoint for every host-side
+ * OpenAPI fetch (#3006). The sandbox network allowlist protects the in-sandbox
+ * Python path, but the spec probe and operation execution run *host-side*,
+ * outside it — so a workspace admin (or a public spec that declares an internal
+ * `servers[0].url`) could otherwise aim a credentialed request at cloud metadata
+ * (`169.254.169.254`) or internal services. This module is the one place that
+ * decision is made, shared by install, rediscover, resolve, and execution:
+ *
+ *   - {@link assertBaseUrlAllowed} — throws {@link EgressBlockedError} for any
+ *     URL that {@link isSafeExternalUrl} rejects (private/loopback/link-local/
+ *     CGNAT IP, internal hostname, non-HTTPS). The one validation chokepoint.
+ *   - {@link guardedFetch} — fetches with `redirect: "manual"` and re-validates
+ *     every `Location` host before following, capping redirect depth. Closes the
+ *     TOCTOU gap where a guarded public URL 302-redirects to an internal host.
+ *
+ * **Operator opt-in.** Self-hosted operators legitimately connect internal
+ * OpenAPI services. Rather than silently exempting all non-SaaS deploys (the
+ * pre-#3006 behavior, which left self-hosted unprotected by default), the guard
+ * is ON everywhere and an operator opts OUT explicitly via
+ * `ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS=true`. Fail-closed by default; the escape
+ * hatch is a deliberate, auditable env flag — never an implicit deploy-mode skip.
+ *
+ * Plain `Error` subclass (not `Data.TaggedError`): like {@link OpenApiProbeError}
+ * this is plain-async machinery whose callers branch on `instanceof` outside any
+ * Effect pipeline (the install handler → 400, the probe → `OpenApiProbeError`,
+ * the client → `OpenApiClientError`).
+ */
+
+import { createLogger } from "@atlas/api/lib/logger";
+import { isSafeExternalUrl } from "@atlas/api/lib/sandbox/validate";
+
+const log = createLogger("openapi.egress-guard");
+
+/** Max redirect hops {@link guardedFetch} follows before giving up. */
+export const MAX_REDIRECTS = 5;
+
+/**
+ * A host-side fetch target was blocked by the SSRF guard. `url` is the offending
+ * URL (or redirect target) — safe to log, never contains a credential (auth is
+ * carried in headers, not the URL, except apiKey-query, which is on the request
+ * the caller built, not this string).
+ */
+export class EgressBlockedError extends Error {
+  readonly url: string;
+  constructor(url: string, detail?: string) {
+    super(
+      `Refusing to fetch "${url}": it resolves to a private, loopback, link-local, or internal ` +
+        `address (or is not HTTPS). Point the datasource at a public HTTPS host, or set ` +
+        `ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS=true to allow internal targets (self-hosted only).` +
+        (detail ? ` ${detail}` : ""),
+    );
+    this.name = "EgressBlockedError";
+    this.url = url;
+  }
+}
+
+/**
+ * Whether the operator has opted out of the egress guard. Read at call time (not
+ * module load) so tests and runtime config changes take effect without a restart.
+ * Any value other than the literal `"true"` keeps the guard ON (fail-closed).
+ */
+export function isInternalEgressAllowed(): boolean {
+  return process.env.ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS === "true";
+}
+
+/**
+ * The single SSRF chokepoint. Throws {@link EgressBlockedError} unless `url` is a
+ * safe public target — or the operator opt-out is set. Used at install,
+ * rediscover, resolve, and (via {@link guardedFetch}) immediately before every
+ * host-side fetch.
+ */
+export function assertBaseUrlAllowed(url: string): void {
+  if (isInternalEgressAllowed()) return;
+  if (!isSafeExternalUrl(url)) {
+    throw new EgressBlockedError(url);
+  }
+}
+
+/** Options for {@link guardedFetch}. */
+export interface GuardedFetchOptions {
+  /** `fetch` override for tests. Defaults to `globalThis.fetch`. */
+  readonly fetchImpl?: typeof globalThis.fetch;
+  /** Max redirect hops to follow. Defaults to {@link MAX_REDIRECTS}. */
+  readonly maxRedirects?: number;
+}
+
+/** 3xx statuses that carry a `Location` we would follow. */
+function isRedirectStatus(status: number): boolean {
+  return status === 301 || status === 302 || status === 303 || status === 307 || status === 308;
+}
+
+/**
+ * Fetch `url` with the SSRF guard enforced at every hop. Validates the initial
+ * URL, issues the request with `redirect: "manual"`, and on a 3xx re-validates
+ * the resolved `Location` host against {@link assertBaseUrlAllowed} *before*
+ * following — so a public→internal redirect (the classic SSRF TOCTOU) is
+ * rejected even though the up-front check passed. Caps depth at `maxRedirects`.
+ *
+ * The same `init` (method, headers, body, signal) is replayed on each hop: the
+ * security goal is host re-validation, not byte-perfect HTTP redirect method
+ * semantics. The caller's `AbortSignal` (typically `AbortSignal.timeout`) bounds
+ * the whole chain. Throws {@link EgressBlockedError} when any hop is blocked;
+ * transport errors propagate from the underlying `fetch`.
+ */
+export async function guardedFetch(
+  url: string,
+  init: RequestInit,
+  options: GuardedFetchOptions = {},
+): Promise<Response> {
+  const fetchImpl = options.fetchImpl ?? globalThis.fetch;
+  const maxRedirects = options.maxRedirects ?? MAX_REDIRECTS;
+
+  let currentUrl = url;
+  for (let hop = 0; hop <= maxRedirects; hop++) {
+    // Re-validate immediately before every request leaves the box — this is the
+    // "final host" check the up-front guard cannot make for redirect targets.
+    assertBaseUrlAllowed(currentUrl);
+
+    const response = await fetchImpl(currentUrl, { ...init, redirect: "manual" });
+    if (!isRedirectStatus(response.status)) return response;
+
+    const location = response.headers.get("location");
+    if (!location) return response; // a 3xx with no Location — nothing to follow.
+
+    let nextUrl: string;
+    try {
+      nextUrl = new URL(location, currentUrl).toString();
+    } catch (err) {
+      // A malformed Location is not actionable and not safe to chase — fail closed.
+      throw new EgressBlockedError(
+        location,
+        `Upstream redirected to a malformed Location (${err instanceof Error ? err.message : String(err)}).`,
+      );
+    }
+    log.debug({ from: safeUrlForLog(currentUrl), to: safeUrlForLog(nextUrl), hop }, "guardedFetch following redirect");
+    currentUrl = nextUrl;
+  }
+
+  throw new EgressBlockedError(
+    currentUrl,
+    `Exceeded the redirect cap (${maxRedirects}) — refusing to follow further.`,
+  );
+}
+
+/** Host-only breadcrumb for logs — never the path/query (which may carry an apiKey-query secret). */
+function safeUrlForLog(url: string): string {
+  try {
+    return new URL(url).host;
+  } catch {
+    // intentionally ignored: log breadcrumb only.
+    return "<unparseable>";
+  }
+}

--- a/packages/api/src/lib/openapi/egress-guard.ts
+++ b/packages/api/src/lib/openapi/egress-guard.ts
@@ -36,22 +36,28 @@ const log = createLogger("openapi.egress-guard");
 export const MAX_REDIRECTS = 5;
 
 /**
- * A host-side fetch target was blocked by the SSRF guard. `url` is the offending
- * URL (or redirect target) — safe to log, never contains a credential (auth is
- * carried in headers, not the URL, except apiKey-query, which is on the request
- * the caller built, not this string).
+ * A host-side fetch target was blocked by the SSRF guard. The offending URL is
+ * **redacted to its host** (`hostname[:port]`) before it touches the message or
+ * the public {@link EgressBlockedError.host} field, because the URL the client
+ * builds carries the credential for apiKey-query auth (`?api_key=…`) in its query
+ * string — and this error's `message` is propagated to the agent (the
+ * `blocked-egress` tool result) and to logs. Redacting at construction keeps the
+ * "no secrets in responses / logs" invariant (CLAUDE.md) structural: it is
+ * impossible to build an `EgressBlockedError` that leaks a path/query secret.
  */
 export class EgressBlockedError extends Error {
-  readonly url: string;
+  /** Host of the blocked target (`hostname[:port]`), already redacted — never the path/query. */
+  readonly host: string;
   constructor(url: string, detail?: string) {
+    const host = hostForLog(url);
     super(
-      `Refusing to fetch "${url}": it resolves to a private, loopback, link-local, or internal ` +
+      `Refusing to fetch host "${host}": it resolves to a private, loopback, link-local, or internal ` +
         `address (or is not HTTPS). Point the datasource at a public HTTPS host, or set ` +
         `ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS=true to allow internal targets (self-hosted only).` +
         (detail ? ` ${detail}` : ""),
     );
     this.name = "EgressBlockedError";
-    this.url = url;
+    this.host = host;
   }
 }
 
@@ -91,17 +97,90 @@ function isRedirectStatus(status: number): boolean {
 }
 
 /**
+ * Request headers forwarded across an origin boundary on a redirect. Everything
+ * NOT in this set — `Authorization`, `Cookie`, `Proxy-Authorization`, and any
+ * apiKey-header (whatever its configured name) — is dropped on a cross-origin
+ * hop so the workspace credential never reaches a host other than the original
+ * target. (We strip by allow-list rather than deny-list precisely because the
+ * apiKey header name is operator-configurable and unknown to this layer.)
+ */
+const SAFE_CROSS_ORIGIN_HEADERS: ReadonlySet<string> = new Set([
+  "accept",
+  "accept-encoding",
+  "accept-language",
+  "content-type",
+  "user-agent",
+]);
+
+/** Origin of `url`, or `""` when unparseable (treated as "not the original origin" — fail-closed). */
+function originOf(url: string): string {
+  try {
+    return new URL(url).origin;
+  } catch {
+    // intentionally ignored: an unparseable URL has no comparable origin.
+    return "";
+  }
+}
+
+/**
+ * Build the `RequestInit` for the next redirect hop, applying the two transforms
+ * `fetch`'s own redirect following would do but that `redirect: "manual"` turns
+ * off:
+ *
+ *  - **Credential scoping.** The credential headers are forwarded ONLY when the
+ *    next hop is the original target origin (`toOriginalOrigin`); any other
+ *    origin gets the {@link SAFE_CROSS_ORIGIN_HEADERS} subset, so a public→public
+ *    redirect can't harvest the workspace's `Authorization` / apiKey header.
+ *  - **Method/body downgrade (RFC 9110 §15.4).** 303 → GET; a 301/302 on a POST
+ *    → GET (universal user-agent behavior); 307/308 preserve. Downgrades are
+ *    cumulative (read from `prevInit`); a body is dropped when the method becomes
+ *    GET/HEAD. Headers are sourced from `originalInit` so the credential is
+ *    re-attached if the chain redirects back to the original origin.
+ */
+function nextHopInit(
+  prevInit: RequestInit,
+  originalInit: RequestInit,
+  status: number,
+  toOriginalOrigin: boolean,
+): RequestInit {
+  let method = (prevInit.method ?? "GET").toUpperCase();
+  let body = prevInit.body;
+  if (status === 303 || ((status === 301 || status === 302) && method === "POST")) {
+    method = "GET";
+    body = undefined;
+  }
+  if (method === "GET" || method === "HEAD") body = undefined;
+
+  const source = new Headers(originalInit.headers);
+  const headers = new Headers();
+  source.forEach((value, key) => {
+    if (toOriginalOrigin || SAFE_CROSS_ORIGIN_HEADERS.has(key.toLowerCase())) {
+      headers.set(key, value);
+    }
+  });
+  if (body === undefined) {
+    headers.delete("content-type");
+    headers.delete("content-length");
+  }
+
+  return { ...originalInit, method, headers, body, redirect: "manual" };
+}
+
+/**
  * Fetch `url` with the SSRF guard enforced at every hop. Validates the initial
  * URL, issues the request with `redirect: "manual"`, and on a 3xx re-validates
  * the resolved `Location` host against {@link assertBaseUrlAllowed} *before*
  * following — so a public→internal redirect (the classic SSRF TOCTOU) is
  * rejected even though the up-front check passed. Caps depth at `maxRedirects`.
  *
- * The same `init` (method, headers, body, signal) is replayed on each hop: the
- * security goal is host re-validation, not byte-perfect HTTP redirect method
- * semantics. The caller's `AbortSignal` (typically `AbortSignal.timeout`) bounds
- * the whole chain. Throws {@link EgressBlockedError} when any hop is blocked;
- * transport errors propagate from the underlying `fetch`.
+ * Each redirect hop's `RequestInit` is rebuilt by {@link nextHopInit}: the
+ * workspace credential is forwarded only to the original target origin (a
+ * cross-origin redirect drops it — `redirect: "manual"` disables the native
+ * cross-origin `Authorization` stripping `fetch` would otherwise do), and the
+ * method/body follow the RFC 9110 §15.4 redirect rules. The caller's
+ * `AbortSignal` (typically `AbortSignal.timeout`) bounds the whole chain. Throws
+ * {@link EgressBlockedError} when any hop is blocked or the `Location` is
+ * malformed; transport errors propagate from the underlying `fetch`.
  */
 export async function guardedFetch(
   url: string,
@@ -110,14 +189,16 @@ export async function guardedFetch(
 ): Promise<Response> {
   const fetchImpl = options.fetchImpl ?? globalThis.fetch;
   const maxRedirects = options.maxRedirects ?? MAX_REDIRECTS;
+  const originalOrigin = originOf(url);
 
   let currentUrl = url;
+  let currentInit: RequestInit = { ...init, redirect: "manual" };
   for (let hop = 0; hop <= maxRedirects; hop++) {
     // Re-validate immediately before every request leaves the box — this is the
     // "final host" check the up-front guard cannot make for redirect targets.
     assertBaseUrlAllowed(currentUrl);
 
-    const response = await fetchImpl(currentUrl, { ...init, redirect: "manual" });
+    const response = await fetchImpl(currentUrl, currentInit);
     if (!isRedirectStatus(response.status)) return response;
 
     const location = response.headers.get("location");
@@ -133,7 +214,13 @@ export async function guardedFetch(
         `Upstream redirected to a malformed Location (${err instanceof Error ? err.message : String(err)}).`,
       );
     }
-    log.debug({ from: hostForLog(currentUrl), to: hostForLog(nextUrl), hop }, "guardedFetch following redirect");
+
+    const toOriginalOrigin = originalOrigin !== "" && originOf(nextUrl) === originalOrigin;
+    currentInit = nextHopInit(currentInit, init, response.status, toOriginalOrigin);
+    log.debug(
+      { from: hostForLog(currentUrl), to: hostForLog(nextUrl), hop, crossOrigin: !toOriginalOrigin },
+      "guardedFetch following redirect",
+    );
     currentUrl = nextUrl;
   }
 

--- a/packages/api/src/lib/openapi/probe.ts
+++ b/packages/api/src/lib/openapi/probe.ts
@@ -181,8 +181,9 @@ export async function probeSpec(
 ): Promise<{ readonly doc: unknown; readonly graph: OperationGraph }> {
   const fetchImpl = options.fetchImpl ?? globalThis.fetch;
 
-  // SSRF guard (SaaS only): the spec URL is admin-supplied and fetched here,
-  // host-side — block private/internal targets before the fetch.
+  // SSRF guard (all deploy modes; opt out via ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS):
+  // the spec URL is admin-supplied and fetched here, host-side — block
+  // private/internal targets before the fetch. #3006.
   assertSpecUrlAllowed(openapiUrl);
 
   // apiKey-query placement: the spec endpoint may itself need the key in the

--- a/packages/api/src/lib/openapi/probe.ts
+++ b/packages/api/src/lib/openapi/probe.ts
@@ -79,9 +79,10 @@ export class OpenApiProbeError extends Error {
  * its {@link EgressBlockedError} as {@link OpenApiProbeError} `unreachable`, so
  * callers surface the same actionable 400 they already map probe failures to.
  *
- * IP/CIDR-based (via `isSafeExternalUrl`): it does not resolve DNS, so a public
- * name that resolves to a private IP is out of scope at this layer — that
- * redirect/rebind case is caught at fetch time by {@link guardedFetch}.
+ * IP/CIDR-based (via `assertBaseUrlAllowed` → `isSafeExternalUrl`): it does not
+ * resolve DNS, so a public name that resolves to a private IP is out of scope at
+ * this layer — that redirect/rebind case is caught at fetch time by
+ * {@link guardedFetch}.
  */
 export function assertSpecUrlAllowed(specUrl: string): void {
   try {

--- a/packages/api/src/lib/openapi/probe.ts
+++ b/packages/api/src/lib/openapi/probe.ts
@@ -18,7 +18,7 @@
  * the route layer maps them to actionable 4xx/5xx envelopes instead of a 500.
  */
 
-import { isSafeExternalUrl } from "@atlas/api/lib/sandbox/validate";
+import { assertBaseUrlAllowed, guardedFetch, EgressBlockedError } from "./egress-guard";
 import { buildOperationGraph } from "./spec";
 import {
   OpenApiSpecError,
@@ -67,28 +67,30 @@ export class OpenApiProbeError extends Error {
 }
 
 /**
- * SaaS SSRF guard for the host-side spec fetch. The spec URL is admin-supplied
- * and fetched by the API server itself at install + rediscover, so on
- * multi-tenant SaaS it must point at a public HTTPS host — otherwise a workspace
- * admin could aim it at cloud-metadata (`169.254.169.254`) or internal services
- * (classic SSRF). Self-hosted operators legitimately connect internal OpenAPI
- * services, so the guard is SaaS-only — mirrors the `ATLAS_DEPLOY_MODE === "saas"`
- * credential gates in the install handlers. Throws {@link OpenApiProbeError}
- * `unreachable` so callers surface the same actionable 400 they already map
- * probe failures to.
+ * SSRF guard for the host-side spec fetch. The spec URL is admin-supplied and
+ * fetched by the API server itself at install + rediscover, so it must point at
+ * a public HTTPS host — otherwise a workspace admin could aim it at
+ * cloud-metadata (`169.254.169.254`) or internal services (classic SSRF). The
+ * guard is ON in every deploy mode; self-hosted operators who legitimately
+ * connect internal OpenAPI services opt OUT explicitly via
+ * `ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS=true` (#3006 — no implicit non-SaaS skip).
  *
- * Hostname-based (reuses {@link isSafeExternalUrl}): it does not resolve DNS, so
- * a public name that resolves to a private IP is out of scope — the same bar the
- * shared guard sets for the codebase's other store-then-fetch URL surfaces.
+ * Delegates to the shared {@link assertBaseUrlAllowed} chokepoint and rethrows
+ * its {@link EgressBlockedError} as {@link OpenApiProbeError} `unreachable`, so
+ * callers surface the same actionable 400 they already map probe failures to.
+ *
+ * IP/CIDR-based (via `isSafeExternalUrl`): it does not resolve DNS, so a public
+ * name that resolves to a private IP is out of scope at this layer — that
+ * redirect/rebind case is caught at fetch time by {@link guardedFetch}.
  */
 export function assertSpecUrlAllowed(specUrl: string): void {
-  if (process.env.ATLAS_DEPLOY_MODE !== "saas") return;
-  if (!isSafeExternalUrl(specUrl)) {
-    throw new OpenApiProbeError(
-      "unreachable",
-      "The spec URL must use HTTPS and resolve to a public host — private or internal " +
-        "addresses are blocked in hosted mode.",
-    );
+  try {
+    assertBaseUrlAllowed(specUrl);
+  } catch (err) {
+    if (err instanceof EgressBlockedError) {
+      throw new OpenApiProbeError("unreachable", err.message);
+    }
+    throw err;
   }
 }
 
@@ -200,11 +202,18 @@ export async function probeSpec(
 
   let doc: unknown;
   try {
-    const response = await fetchImpl(url, {
-      method: "GET",
-      headers: { Accept: "application/json", ...authHeadersForProbe(auth) },
-      signal: AbortSignal.timeout(probeTimeoutMs()),
-    });
+    // `guardedFetch` re-validates the URL immediately before the request leaves
+    // the box and re-checks every redirect `Location` host — closing the TOCTOU
+    // gap where a guarded public spec URL 302-redirects to an internal target.
+    const response = await guardedFetch(
+      url,
+      {
+        method: "GET",
+        headers: { Accept: "application/json", ...authHeadersForProbe(auth) },
+        signal: AbortSignal.timeout(probeTimeoutMs()),
+      },
+      { fetchImpl },
+    );
     if (!response.ok) {
       throw new OpenApiProbeError(
         "http_error",
@@ -216,6 +225,10 @@ export async function probeSpec(
     doc = await response.json();
   } catch (err) {
     if (err instanceof OpenApiProbeError) throw err;
+    if (err instanceof EgressBlockedError) {
+      // A redirect to a blocked host (the up-front guard passed; the hop didn't).
+      throw new OpenApiProbeError("unreachable", err.message);
+    }
     throw new OpenApiProbeError(
       "unreachable",
       `Could not fetch the OpenAPI spec: ${err instanceof Error ? err.message : String(err)}`,

--- a/packages/api/src/lib/openapi/types.ts
+++ b/packages/api/src/lib/openapi/types.ts
@@ -355,6 +355,7 @@ export type OpenApiClientErrorReason =
   | "missing-base-url"
   | "missing-path-param"
   | "missing-auth-placement"
+  | "blocked-egress" // target (or a redirect hop) resolves to a private/internal address — SSRF guard, #3006
   | "timeout"
   | "network"
   | "unparseable-response";

--- a/packages/api/src/lib/openapi/workspace-datasource.ts
+++ b/packages/api/src/lib/openapi/workspace-datasource.ts
@@ -183,7 +183,7 @@ function buildDatasource(
   const requestTimeoutMs = parseRequestTimeoutMs(decrypted.request_timeout_ms, installId);
 
   // Resolve-side SSRF chokepoint (#3006): the operations base URL the agent
-  // POSTs to — an admin override OR the spec-derived `servers[0].url` — must
+  // sends requests to — an admin override OR the spec-derived `servers[0].url` — must
   // pass the same guard install/rediscover apply. A public spec that declared an
   // internal `servers[0].url` would otherwise produce a credentialed host-side
   // request to internal infra. Fail-soft (skip + log), matching this resolver's

--- a/packages/api/src/lib/openapi/workspace-datasource.ts
+++ b/packages/api/src/lib/openapi/workspace-datasource.ts
@@ -37,6 +37,7 @@ import {
   parseRequestTimeoutMs,
   parseWriteAllowlist,
 } from "./catalog";
+import { assertBaseUrlAllowed, EgressBlockedError } from "./egress-guard";
 import { buildResolvedAuth, snapshotToGraph } from "./probe";
 import type { OperationGraph, ResolvedAuth } from "./types";
 
@@ -88,6 +89,16 @@ const SECRET_SCHEMA = parseConfigSchema(OPENAPI_GENERIC_CONFIG_SCHEMA);
 
 function stripTrailingSlash(s: string): string {
   return s.endsWith("/") ? s.slice(0, -1) : s;
+}
+
+/** Host-only breadcrumb for the skip log — never the path/query (apiKey-query secrets). */
+function safeHostForLog(url: string): string {
+  try {
+    return new URL(url).host;
+  } catch {
+    // intentionally ignored: log breadcrumb only.
+    return "<unparseable>";
+  }
 }
 
 /**
@@ -181,11 +192,33 @@ function buildDatasource(
   const rateLimitPerMinute = parseRateLimitPerMinute(decrypted.rate_limit_per_minute, installId);
   const requestTimeoutMs = parseRequestTimeoutMs(decrypted.request_timeout_ms, installId);
 
+  // Resolve-side SSRF chokepoint (#3006): the operations base URL the agent
+  // POSTs to — an admin override OR the spec-derived `servers[0].url` — must
+  // pass the same guard install/rediscover apply. A public spec that declared an
+  // internal `servers[0].url` would otherwise produce a credentialed host-side
+  // request to internal infra. Fail-soft (skip + log), matching this resolver's
+  // posture: one misconfigured datasource must not sink the workspace's others.
+  // `guardedFetch` in the client is the hard execution-time backstop.
+  const baseUrl = resolveBaseUrl(openapiUrl, graph, baseUrlOverride);
+  try {
+    assertBaseUrlAllowed(baseUrl);
+  } catch (err) {
+    if (err instanceof EgressBlockedError) {
+      log.warn(
+        { installId, host: safeHostForLog(baseUrl) },
+        "OpenAPI install resolves to a blocked (private/internal) base URL — skipping " +
+          "(set ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS=true to allow internal targets, self-hosted only)",
+      );
+      return null;
+    }
+    throw err;
+  }
+
   return {
     id: installId,
     displayName,
     graph,
-    baseUrl: resolveBaseUrl(openapiUrl, graph, baseUrlOverride),
+    baseUrl,
     auth,
     representationMode: coerceRepresentationMode(decrypted.representation_mode),
     writeAllowlist,

--- a/packages/api/src/lib/openapi/workspace-datasource.ts
+++ b/packages/api/src/lib/openapi/workspace-datasource.ts
@@ -37,7 +37,7 @@ import {
   parseRequestTimeoutMs,
   parseWriteAllowlist,
 } from "./catalog";
-import { assertBaseUrlAllowed, EgressBlockedError } from "./egress-guard";
+import { assertBaseUrlAllowed, EgressBlockedError, hostForLog } from "./egress-guard";
 import { buildResolvedAuth, snapshotToGraph } from "./probe";
 import type { OperationGraph, ResolvedAuth } from "./types";
 
@@ -89,16 +89,6 @@ const SECRET_SCHEMA = parseConfigSchema(OPENAPI_GENERIC_CONFIG_SCHEMA);
 
 function stripTrailingSlash(s: string): string {
   return s.endsWith("/") ? s.slice(0, -1) : s;
-}
-
-/** Host-only breadcrumb for the skip log — never the path/query (apiKey-query secrets). */
-function safeHostForLog(url: string): string {
-  try {
-    return new URL(url).host;
-  } catch {
-    // intentionally ignored: log breadcrumb only.
-    return "<unparseable>";
-  }
 }
 
 /**
@@ -205,7 +195,7 @@ function buildDatasource(
   } catch (err) {
     if (err instanceof EgressBlockedError) {
       log.warn(
-        { installId, host: safeHostForLog(baseUrl) },
+        { installId, host: hostForLog(baseUrl) },
         "OpenAPI install resolves to a blocked (private/internal) base URL — skipping " +
           "(set ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS=true to allow internal targets, self-hosted only)",
       );

--- a/packages/api/src/lib/sandbox/__tests__/validate-ssrf.test.ts
+++ b/packages/api/src/lib/sandbox/__tests__/validate-ssrf.test.ts
@@ -37,6 +37,16 @@ describe("isSafeExternalUrl — blocked (SSRF vectors)", () => {
     ["https://2130706433/x", "decimal loopback (WHATWG-normalized)"],
     ["https://localhost/x", "localhost hostname"],
     ["https://sub.localhost/x", "*.localhost hostname"],
+    ["https://metadata.google.internal./computeMetadata/v1/", "trailing-dot GCP metadata (FQDN bypass)"],
+    ["https://localhost./x", "trailing-dot localhost (FQDN bypass)"],
+    ["https://foo.internal./x", "trailing-dot *.internal (FQDN bypass)"],
+    ["https://attacker.com@169.254.169.254/x", "userinfo decoy — connects to the trailing IP, not the decoy host"],
+    ["https://user:pass@[::1]/x", "userinfo decoy over IPv6 loopback"],
+    ["https://0177.0.0.1/x", "octal loopback (WHATWG-normalized)"],
+    ["https://[::169.254.169.254]/x", "IPv4-compatible IPv6 metadata (embedded-IPv4 re-test)"],
+    ["https://[::7f00:1]/x", "IPv4-compatible IPv6 loopback, hex form"],
+    ["https://[64:ff9b::169.254.169.254]/x", "NAT64-wrapped metadata, dotted (embedded-IPv4 re-test)"],
+    ["https://[64:ff9b::a9fe:a9fe]/x", "NAT64-wrapped metadata, all-hex (embedded-IPv4 re-test)"],
     ["http://example.com/x", "non-HTTPS (credentials in clear)"],
     ["ftp://example.com/x", "non-HTTP(S) scheme"],
     ["not a url", "unparseable — fail closed"],
@@ -56,6 +66,7 @@ describe("isSafeExternalUrl — allowed (genuinely public HTTPS)", () => {
     "https://crm.example.com/rest/open-api/core",
     "https://8.8.8.8/x", // public IPv4 literal
     "https://[2001:4860:4860::8888]/x", // public IPv6 literal (Google DNS)
+    "https://[64:ff9b::8.8.8.8]/x", // NAT64 wrapping a PUBLIC IPv4 — must not over-block
     "https://api.useatlas.dev/", // a hostname we don't resolve — allowed
   ];
 

--- a/packages/api/src/lib/sandbox/__tests__/validate-ssrf.test.ts
+++ b/packages/api/src/lib/sandbox/__tests__/validate-ssrf.test.ts
@@ -1,0 +1,67 @@
+/**
+ * SSRF guard tests for `isSafeExternalUrl` (#3006). The guard is the single
+ * IP-parsing primitive every host-side fetch (OpenAPI probe + operations, Daytona
+ * validation, sub-processor webhooks) routes through. The legacy string-prefix
+ * blocklist returned `true` for a long tail of internal-address encodings — these
+ * tests lock each verified bypass closed and assert real CIDR membership.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { isSafeExternalUrl } from "../validate";
+
+describe("isSafeExternalUrl — blocked (SSRF vectors)", () => {
+  // Every entry MUST be rejected. The comment names the encoding that bypassed
+  // the legacy string-prefix guard (verified in #3006).
+  const blocked: ReadonlyArray<readonly [string, string]> = [
+    ["https://[::1]/openapi.json", "IPv6 loopback"],
+    ["https://[0:0:0:0:0:0:0:1]/x", "expanded IPv6 loopback"],
+    ["https://[::ffff:169.254.169.254]/latest/meta-data/", "IPv4-mapped AWS metadata"],
+    ["https://[::ffff:7f00:1]/x", "hex-form IPv4-mapped loopback (127.0.0.1)"],
+    ["https://metadata.google.internal/computeMetadata/v1/", "GCP metadata hostname"],
+    ["https://foo.internal/x", "*.internal hostname"],
+    ["https://100.100.100.200/x", "CGNAT 100.64.0.0/10"],
+    ["https://100.64.0.1/x", "CGNAT lower bound"],
+    ["https://172.16.0.5/x", "RFC1918 172.16/12"],
+    ["https://172.31.255.254/x", "RFC1918 172.16/12 upper"],
+    ["https://192.168.1.10/x", "RFC1918 192.168/16"],
+    ["https://10.0.0.5/x", "RFC1918 10/8"],
+    ["https://169.254.169.254/", "link-local v4 (AWS/Azure/GCP metadata)"],
+    ["https://[fe80::1]/", "link-local v6"],
+    ["https://[fc00::1]/", "ULA v6"],
+    ["https://[fd12:3456::1]/", "ULA v6 fd00::/8"],
+    ["https://0.0.0.0/", "0.0.0.0/8 literal"],
+    ["https://0.0.0.172/x", "0.0.0.0/8 (the 172. NaN-octet normalization target)"],
+    ["https://127.0.0.1/x", "loopback literal"],
+    ["https://127.1/x", "shorthand loopback (WHATWG-normalized)"],
+    ["https://0x7f000001/x", "hex loopback (WHATWG-normalized)"],
+    ["https://2130706433/x", "decimal loopback (WHATWG-normalized)"],
+    ["https://localhost/x", "localhost hostname"],
+    ["https://sub.localhost/x", "*.localhost hostname"],
+    ["http://example.com/x", "non-HTTPS (credentials in clear)"],
+    ["ftp://example.com/x", "non-HTTP(S) scheme"],
+    ["not a url", "unparseable — fail closed"],
+    ["https://172./x", "garbage octet — fail closed (normalizes into 0.0.0.0/8)"],
+  ];
+
+  for (const [url, why] of blocked) {
+    it(`rejects ${url} (${why})`, () => {
+      expect(isSafeExternalUrl(url)).toBe(false);
+    });
+  }
+});
+
+describe("isSafeExternalUrl — allowed (genuinely public HTTPS)", () => {
+  const allowed: ReadonlyArray<string> = [
+    "https://example.com/openapi.json",
+    "https://crm.example.com/rest/open-api/core",
+    "https://8.8.8.8/x", // public IPv4 literal
+    "https://[2001:4860:4860::8888]/x", // public IPv6 literal (Google DNS)
+    "https://api.useatlas.dev/", // a hostname we don't resolve — allowed
+  ];
+
+  for (const url of allowed) {
+    it(`allows ${url}`, () => {
+      expect(isSafeExternalUrl(url)).toBe(true);
+    });
+  }
+});

--- a/packages/api/src/lib/sandbox/validate.ts
+++ b/packages/api/src/lib/sandbox/validate.ts
@@ -61,6 +61,42 @@ function isBlockedHostname(host: string): boolean {
   );
 }
 
+/** Expand an IPv6 literal to its eight 16-bit groups, or `null` if malformed. */
+function expandIPv6Groups(ipv6: string): number[] | null {
+  const halves = ipv6.split("::");
+  if (halves.length > 2) return null;
+  const parse = (s: string): number[] =>
+    s.length === 0 ? [] : s.split(":").map((g) => Number.parseInt(g, 16));
+  const head = parse(halves[0] ?? "");
+  const tail = halves.length === 2 ? parse(halves[1] ?? "") : [];
+  const groups =
+    halves.length === 1 ? head : [...head, ...new Array(8 - head.length - tail.length).fill(0), ...tail];
+  if (groups.length !== 8 || groups.some((g) => !Number.isInteger(g) || g < 0 || g > 0xffff)) return null;
+  return groups;
+}
+
+/**
+ * Extract the IPv4 address embedded in the low 32 bits of an IPv4-compatible
+ * (`::a.b.c.d`, deprecated RFC 4291) or NAT64 (`64:ff9b::a.b.c.d`, RFC 6052)
+ * IPv6 literal, or `null`. The WHATWG parser canonicalizes both to compressed
+ * hex (`::a9fe:a9fe`), so we expand the groups rather than scan for a dotted
+ * quad. `net.BlockList` only canonicalizes the IPv4-*mapped* form (`::ffff:/96`)
+ * against the IPv4 subnets — so that prefix is intentionally NOT handled here
+ * (the BlockList already catches it); these two wrappers slip past it. Re-testing
+ * the embedded IPv4 against the IPv4 ranges is defense-in-depth so an internal
+ * IPv4 can't be smuggled through an IPv6 wrapper. Loopback/unspecified
+ * (`::`, `::1`) are left to the IPv6 ranges (returned as `null`).
+ */
+function extractEmbeddedIPv4(ipv6: string): string | null {
+  const g = expandIPv6Groups(ipv6);
+  if (!g) return null;
+  const highZero = g[0] === 0 && g[1] === 0 && g[2] === 0 && g[3] === 0 && g[4] === 0 && g[5] === 0;
+  const isCompatible = highZero && !(g[6] === 0 && g[7] <= 1); // exclude :: and ::1
+  const isNat64 = g[0] === 0x0064 && g[1] === 0xff9b && g[2] === 0 && g[3] === 0 && g[4] === 0 && g[5] === 0;
+  if (!isCompatible && !isNat64) return null;
+  return `${g[6] >> 8}.${g[6] & 0xff}.${g[7] >> 8}.${g[7] & 0xff}`;
+}
+
 /**
  * Validates that a user-supplied URL is safe for server-side requests.
  * Blocks non-HTTPS schemes, internal hostnames, and any address in a
@@ -88,7 +124,9 @@ export function isSafeExternalUrl(url: string): boolean {
   }
   if (parsed.protocol !== "https:") return false;
 
-  const host = parsed.hostname.toLowerCase();
+  // Normalize FQDN trailing dots ("metadata.google.internal." resolves to the
+  // same name) so the hostname denylist can't be bypassed with a trailing dot.
+  const host = parsed.hostname.toLowerCase().replace(/\.+$/, "");
   if (host.length === 0) return false;
   if (isBlockedHostname(host)) return false;
 
@@ -96,9 +134,16 @@ export function isSafeExternalUrl(url: string): boolean {
   const bare = host.startsWith("[") && host.endsWith("]") ? host.slice(1, -1) : host;
 
   if (net.isIPv4(bare)) return !PRIVATE_BLOCKLIST.check(bare, "ipv4");
-  // `check(_, "ipv6")` covers pure IPv6 ranges AND IPv4-mapped addresses, which
-  // BlockList canonicalizes back to IPv4 and tests against the IPv4 subnets.
-  if (net.isIPv6(bare)) return !PRIVATE_BLOCKLIST.check(bare, "ipv6");
+  if (net.isIPv6(bare)) {
+    // `check(_, "ipv6")` covers pure IPv6 ranges AND IPv4-mapped addresses, which
+    // BlockList canonicalizes back to IPv4 and tests against the IPv4 subnets.
+    if (PRIVATE_BLOCKLIST.check(bare, "ipv6")) return false;
+    // Re-test any IPv4 embedded in an IPv4-compatible / NAT64 wrapper against the
+    // IPv4 ranges — BlockList does not canonicalize those (see extractEmbeddedIPv4).
+    const embedded = extractEmbeddedIPv4(bare);
+    if (embedded && PRIVATE_BLOCKLIST.check(embedded, "ipv4")) return false;
+    return true;
+  }
 
   // Not an IP literal — a DNS name we deliberately do not resolve.
   return true;

--- a/packages/api/src/lib/sandbox/validate.ts
+++ b/packages/api/src/lib/sandbox/validate.ts
@@ -6,6 +6,8 @@
  * success (with display name) or failure (with error message).
  */
 
+import net from "node:net";
+
 import { createLogger } from "@atlas/api/lib/logger";
 
 const log = createLogger("sandbox-validate");
@@ -22,27 +24,84 @@ const VALIDATION_TIMEOUT_MS = 10_000;
 // ---------------------------------------------------------------------------
 
 /**
+ * CIDR blocklist of address ranges that must never be reachable from a
+ * host-side fetch. Built once at module load via `node:net`'s `BlockList` —
+ * which does the bit-level CIDR membership AND natively canonicalizes
+ * IPv4-mapped IPv6 (`::ffff:a.b.c.d` and the hex `::ffff:7f00:1` form) against
+ * the IPv4 subnets, closing the encoding bypasses the old string-prefix guard
+ * leaked (verified in #3006).
+ */
+const PRIVATE_RANGES: ReadonlyArray<readonly [string, number, "ipv4" | "ipv6"]> = [
+  ["0.0.0.0", 8, "ipv4"], // "this network" — also the target a bare `172.`-style garbage host normalizes into
+  ["10.0.0.0", 8, "ipv4"], // RFC 1918
+  ["127.0.0.0", 8, "ipv4"], // loopback
+  ["169.254.0.0", 16, "ipv4"], // link-local (cloud metadata: 169.254.169.254)
+  ["172.16.0.0", 12, "ipv4"], // RFC 1918
+  ["192.168.0.0", 16, "ipv4"], // RFC 1918
+  ["100.64.0.0", 10, "ipv4"], // CGNAT (RFC 6598)
+  ["fc00::", 7, "ipv6"], // unique local address (ULA)
+  ["fe80::", 10, "ipv6"], // link-local
+];
+
+const PRIVATE_BLOCKLIST: net.BlockList = (() => {
+  const list = new net.BlockList();
+  for (const [addr, prefix, type] of PRIVATE_RANGES) list.addSubnet(addr, prefix, type);
+  list.addAddress("::1", "ipv6"); // IPv6 loopback (no dedicated prefix length)
+  list.addAddress("::", "ipv6"); // unspecified address
+  return list;
+})();
+
+/** Hostnames that resolve to internal infra and must be rejected by name (no DNS lookup needed). */
+function isBlockedHostname(host: string): boolean {
+  return (
+    host === "localhost" ||
+    host.endsWith(".localhost") ||
+    host === "metadata.google.internal" ||
+    host.endsWith(".internal")
+  );
+}
+
+/**
  * Validates that a user-supplied URL is safe for server-side requests.
- * Blocks non-HTTPS schemes and private/internal hostnames. Exported for
- * reuse by other route handlers that store and later POST to user-
- * supplied URLs (sub-processor webhook subscriptions, etc.).
+ * Blocks non-HTTPS schemes, internal hostnames, and any address in a
+ * private / loopback / link-local / CGNAT range. Exported as the single
+ * IP-parsing SSRF primitive every store-then-fetch surface routes through
+ * (sub-processor webhook subscriptions, Daytona validation, and — via
+ * `assertBaseUrlAllowed` — the OpenAPI probe + operation paths).
+ *
+ * Parses the host with the same WHATWG `URL` the runtime's `fetch` uses, so the
+ * value we validate is the value the network stack connects to (no
+ * parser-differential TOCTOU). IP literals are tested for CIDR membership via
+ * {@link PRIVATE_BLOCKLIST}; bracketed IPv6 and IPv4-mapped IPv6 are handled.
+ * A hostname that is not an IP literal is NOT DNS-resolved — a public name that
+ * resolves to a private IP is out of scope here (a redirect to such a host is
+ * caught at fetch time by `guardedFetch`). Anything that fails to parse, uses a
+ * disallowed scheme, or lands in a blocked range fails CLOSED (`false`).
  */
 export function isSafeExternalUrl(url: string): boolean {
+  let parsed: URL;
   try {
-    const parsed = new URL(url);
-    if (parsed.protocol !== "https:") return false;
-    const host = parsed.hostname.toLowerCase();
-    if (host === "localhost" || host === "127.0.0.1" || host === "0.0.0.0" || host === "::1") return false;
-    if (host.startsWith("10.") || host.startsWith("192.168.")) return false;
-    if (host.startsWith("169.254.")) return false; // AWS metadata
-    if (host.startsWith("172.")) {
-      const second = parseInt(host.split(".")[1], 10);
-      if (second >= 16 && second <= 31) return false;
-    }
-    return true;
+    parsed = new URL(url);
   } catch {
+    // intentionally ignored: an unparseable URL is not safe — fail closed.
     return false;
   }
+  if (parsed.protocol !== "https:") return false;
+
+  const host = parsed.hostname.toLowerCase();
+  if (host.length === 0) return false;
+  if (isBlockedHostname(host)) return false;
+
+  // WHATWG brackets IPv6 hosts (`[::1]`); strip them before parsing.
+  const bare = host.startsWith("[") && host.endsWith("]") ? host.slice(1, -1) : host;
+
+  if (net.isIPv4(bare)) return !PRIVATE_BLOCKLIST.check(bare, "ipv4");
+  // `check(_, "ipv6")` covers pure IPv6 ranges AND IPv4-mapped addresses, which
+  // BlockList canonicalizes back to IPv4 and tests against the IPv4 subnets.
+  if (net.isIPv6(bare)) return !PRIVATE_BLOCKLIST.check(bare, "ipv6");
+
+  // Not an IP literal — a DNS name we deliberately do not resolve.
+  return true;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/api/src/lib/tools/__tests__/rest-operation.test.ts
+++ b/packages/api/src/lib/tools/__tests__/rest-operation.test.ts
@@ -25,10 +25,18 @@ const graph = buildOperationGraph(SPEC);
 
 let mock: TwentyMock;
 
+// The mock REST server binds to 127.0.0.1 (loopback), which the #3006 SSRF guard
+// blocks by default. A local test server is the "internal service" case the
+// operator opt-out exists for — enable it for this file and restore it after.
+const ORIGINAL_EGRESS_FLAG = process.env.ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS;
+
 beforeAll(async () => {
+  process.env.ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS = "true";
   mock = await startTwentyMockServer();
 });
 afterAll(async () => {
+  if (ORIGINAL_EGRESS_FLAG === undefined) delete process.env.ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS;
+  else process.env.ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS = ORIGINAL_EGRESS_FLAG;
   await mock.close();
 });
 beforeEach(() => {


### PR DESCRIPTION
Closes #3006. **HIGH-severity SSRF — blocks the v0.0.2 tag.**

## Problem
The sandbox network allowlist protects the in-sandbox Python path, but the **host-side** OpenAPI spec probe and operation execution run outside it. The one guard that existed — `isSafeExternalUrl` (`sandbox/validate.ts`) — was a bypassable string-prefix blocklist. Reproduced bypasses returning `true`:

| Vector | Why it slipped through |
|---|---|
| `[::1]`, `[fe80::1]`, `[fc00::1]` | no IPv6 loopback/link-local/ULA entries |
| `[::ffff:169.254.169.254]`, `[::ffff:7f00:1]` | IPv4-mapped IPv6 (dotted + hex) never canonicalized |
| `metadata.google.internal` | no hostname denylist |
| `100.100.100.200` (CGNAT) | no `100.64.0.0/10` rule |
| `172.` → `0.0.0.172` | `0.0.0.0/8` only blocked the literal `0.0.0.0` |

The resolved operations base URL (`resolveBaseUrl`, incl. the spec-derived `servers[0].url`) was fetched host-side with the datasource's credential and **no SSRF check at all**, and the probe fetch used the default `redirect: "follow"` (public→internal 302 TOCTOU).

## Fix
- **Real IP/CIDR parsing.** Rewrote `isSafeExternalUrl` with `node:net` — `net.isIPv4`/`net.isIPv6` + a `net.BlockList` of loopback / link-local / ULA / all RFC-1918 / CGNAT / `0.0.0.0/8` ranges (BlockList natively canonicalizes IPv4-mapped IPv6 against the IPv4 subnets). Hostname denylist for `localhost` / `*.localhost` / `metadata.google.internal` / `*.internal`. Unparseable / non-HTTPS / garbage octets fail **closed**. Boolean signature preserved for the existing Daytona + sub-processor-webhook callers.
- **One shared chokepoint.** New `openapi/egress-guard.ts` exports `assertBaseUrlAllowed`, used by install, rediscover (via the spec probe), resolve (`buildDatasource` skips a blocked datasource, fail-soft), and execution. The resolved base URL — including the `servers[0].url` branch — is validated at execute time and re-validated against the final host immediately before each fetch.
- **Redirect-safe fetch.** `guardedFetch` issues `redirect: "manual"`, re-validates every `Location` host before following, and caps depth (`MAX_REDIRECTS`). Used by both the probe and the client.
- **Explicit operator opt-in.** The self-hosted exemption is now `ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS=true` (documented in `.env.example`), **not** a silent non-SaaS skip — the guard is ON by default in every deploy mode (fail-closed). Hardening change: self-hosted operators who connect an internal OpenAPI service must now set this flag.
- New `blocked-egress` `OpenApiClientErrorReason`; the install handler maps a block to a `base_url_override` field error, the probe maps it to `unreachable`.

## Acceptance criteria
- [x] `isSafeExternalUrl` rewritten with real IP parsing (bracketed IPv6, IPv4-mapped canonicalization, CIDR membership, hostname denylist, fail-closed on garbage)
- [x] Resolved operations base URL (incl. spec-derived `servers[0].url`) validated at execute time + re-validated before fetch on `executeRestOperation` and confirm dispatch
- [x] Probe + operation fetches use `redirect: "manual"`; each `Location` re-validated; depth capped
- [x] Self-hosted exemption behind explicit operator opt-in
- [x] Single shared `assertBaseUrlAllowed` chokepoint for install / rediscover / resolve
- [x] Negative tests: `[::1]`, `[::ffff:169.254.169.254]`, `metadata.google.internal`, CGNAT, `172.` rejected; internal `servers[0].url` rejected at execute time; public→internal redirect rejected

## Tests
- `sandbox/__tests__/validate-ssrf.test.ts` — every bypass vector + public-host allow-list (new)
- `openapi/__tests__/egress-guard.test.ts` — chokepoint, opt-out flag (incl. fail-closed on non-`true`), `guardedFetch` redirect re-validation + depth cap (new)
- `openapi/__tests__/probe.test.ts` — guard now ON in every mode unless opted out; public→internal redirect rejected
- `openapi/__tests__/client.test.ts` — internal `servers[0].url` / override / redirect rejected at execute time; public host still executes
- Loopback-mock integration tests (twenty-acceptance / rest-operation / rest-operations) opt out via the flag (a local test server is the "internal service" case)

## CI
Local gates all green: lint, type, full test (`@atlas/api` 520/520 + all other packages), syncpack, template/security-headers/railway/schema/oauth-helper drift, test-discipline, twenty-resolver, published-symbols.

> Must land before #2978 wires scheduler-driven re-discovery (it would re-probe unattended and re-inherit any weakness).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3014"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782745924&installation_id=135337507&pr_number=3014&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3014&signature=897773ea0de3727c48551e68f56793bc409fe0a1794476c39cc8376ce764377b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Fail-closed SSRF egress guard for OpenAPI/spec fetches: blocks private/internal hosts and disallowed redirects by default.
  * Requests to blocked targets now surface a distinct "blocked egress" error.

* **Configuration**
  * Added opt-in env flag for self-hosted instances to allow internal hosts: ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS=true.

* **Tests**
  * Expanded test coverage for probe, fetch/redirect, install validation, and execution-time egress behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AtlasDevHQ/atlas/pull/3014?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->