### PR TITLE
feat(openapi): side-effecting-GET classification escape hatch (#3008)

### DIFF
--- a/apps/docs/content/docs/plugins/datasources/openapi-generic.mdx
+++ b/apps/docs/content/docs/plugins/datasources/openapi-generic.mdx
@@ -17,6 +17,10 @@ A workspace can install several OpenAPI datasources side by side (one for Twenty
 
 GET (and HEAD) operations execute immediately. The agent calls `executeRestOperation` with an `operationId` from the spec plus its parameters, and gets the response back as data. Multi-step questions ("show me Matt's notes") run as a sequence of operations across agent steps.
 
+<Callout type="warn">
+Read vs write is classified by HTTP **method** by default — but only as a default, not ground truth. Some legacy / RPC-style APIs **mutate state through a GET** (e.g. `GET /jobs/{id}/cancel`, `GET /admin/resetPassword`). If yours does, you **must** mark those operations side-effecting so Atlas gates them like writes — see [Side-effecting GETs](#side-effecting-gets) below. An unmarked mutating GET runs as an unconfirmed read.
+</Callout>
+
 ## Writing — opt-in, then confirm
 
 **Writes are off by default.** A non-GET operation (POST / PATCH / PUT / DELETE) only runs if its `operationId` is in that install's **write allowlist** — and even then, never silently.
@@ -47,12 +51,42 @@ The write fires only when the user clicks **Confirm write** — the request is P
 Prompting a write that is **not** allowlisted (e.g. "delete every Person") returns `writes_disabled` — the request never fires, and the agent is told not to claim it happened. Add the operation to `write_allowlist` to enable it.
 </Callout>
 
+## Side-effecting GETs
+
+Atlas classifies read vs write by HTTP method **as a default, not ground truth**. A GET or HEAD that actually mutates state (a "mutating RPC-over-GET", common in legacy / internal services) can be flagged side-effecting, and is then forced through the **same write allowlist + confirm path** as a POST — it must be allowlisted, and it stages for confirmation rather than running silently.
+
+There are two ways to flag one, and they combine (either is enough). The classification is **monotonic**: a flag can only ever *escalate* a read to a write, never downgrade a write method to a read.
+
+**1. In the spec — `x-atlas-side-effecting: true`.** If you control the OpenAPI document, mark the operation directly:
+
+```yaml
+paths:
+  /jobs/{id}/cancel:
+    get:
+      operationId: cancelJob
+      x-atlas-side-effecting: true   # this GET mutates — gate it like a write
+```
+
+Only an explicit boolean `true` escalates; `false` (or absent) leaves classification to the method. A present-but-non-boolean value (e.g. the string `"true"`) is **rejected at probe time** — a mistyped flag fails the install loudly rather than silently leaving the GET ungated.
+
+**2. In the install config — `side_effecting_operations`.** When you don't own the spec, list the offending `operationId`s as a JSON array on the install:
+
+```json
+["cancelJob", "resetPassword"]
+```
+
+A malformed value degrades to "none" (classification stays method-only) and is logged. Note this is **not** fail-closed the way `write_allowlist` is: an empty or broken side-effecting list leaves a mutating GET running unconfirmed, so fix a logged parse warning promptly.
+
+<Callout type="warn">
+This is an **operator-validated security boundary**. Atlas cannot know which of an API's GETs mutate state — you must. If a GET on your API changes data and you don't flag it (either way above), the agent will run it as an unconfirmed read.
+</Callout>
+
 ## The safety stack (`validateRestOperation`)
 
 Every operation — read or write — is authorized by `validateRestOperation`, the REST sibling to Atlas's SQL validator. Five layers, in order:
 
 1. **Operation in graph** — an `operationId` not in the probed spec is rejected (`unknown_operation`); Atlas never dispatches a fabricated operation.
-2. **Method allowlist** — GET/HEAD always pass; any other method requires the `operationId` in `write_allowlist`, else `writes_disabled` (default-deny).
+2. **Write allowlist** — GET/HEAD pass **unless flagged side-effecting** (see above); any other method, or a side-effecting GET/HEAD, requires the `operationId` in `write_allowlist`, else `writes_disabled` (default-deny).
 3. **Parameter shape** — required parameters and request body must be present; parameters the spec doesn't declare are rejected (`invalid_params`).
 4. **Rate limit** — a per-`(workspace, datasource, operation)` token bucket, **60 calls/min** by default, overridable per install via the config-only `rate_limit_per_minute` key. Throttles runaway agent loops on a paid upstream (`rate_limited`, with a retry hint).
 5. **Timeout** — each request is capped at `ATLAS_OPENAPI_TIMEOUT` (default **30s**). A per-install `request_timeout_ms` (config-only) above the cap is rejected.
@@ -92,6 +126,7 @@ Install-form fields (Admin → Connections):
 | `auth_param_name` | — | Query param for `apikey-query`, e.g. `api_key` |
 | `base_url_override` | — | When the spec's `servers[0].url` is wrong (dev/staging) |
 | `write_allowlist` | — | JSON array of `operationId`s permitted to write. Empty = read-only (default). |
+| `side_effecting_operations` | — | JSON array of `operationId`s whose GET/HEAD **mutates** state — forced through the write allowlist + confirm path. Empty = method-only classification (default). See [Side-effecting GETs](#side-effecting-gets). |
 | `display_name` | — | Friendly name shown in Admin → Connections |
 
 Advanced overrides (set on the install's `config` via `atlas.config.ts`, not surfaced in the install form):

--- a/packages/api/src/__mocks__/openapi-datasource.ts
+++ b/packages/api/src/__mocks__/openapi-datasource.ts
@@ -105,6 +105,11 @@ export interface OpenApiDatasourceMockOptions {
    * (read-only / default-deny)** — pass e.g. `["createWidget"]` to opt a write in.
    */
   readonly writeAllowlist?: Iterable<string>;
+  /**
+   * operationIds whose GET/HEAD mutates state (#3008) — forced through the write
+   * allowlist + confirm path. Defaults to **empty** (classification is method-only).
+   */
+  readonly sideEffectingOperations?: Iterable<string>;
   /** Per-install rate-limit override (calls/min); default 60 in the validator. */
   readonly rateLimitPerMinute?: number;
 }
@@ -127,6 +132,7 @@ export function createOpenApiDatasourceMock(
     auth: options.auth ?? { kind: "bearer", token: "test-token" },
     representationMode: options.representationMode ?? "operation-graph",
     writeAllowlist: new Set(options.writeAllowlist ?? []),
+    sideEffectingOperations: new Set(options.sideEffectingOperations ?? []),
     ...(options.rateLimitPerMinute !== undefined ? { rateLimitPerMinute: options.rateLimitPerMinute } : {}),
   };
 }

--- a/packages/api/src/api/routes/__tests__/rest-operations.test.ts
+++ b/packages/api/src/api/routes/__tests__/rest-operations.test.ts
@@ -105,6 +105,7 @@ function datasource(overrides: Partial<RestDatasource> = {}): RestDatasource {
     auth: { kind: "bearer", token: "confirm-token" },
     representationMode: "operation-graph",
     writeAllowlist: new Set<string>(),
+    sideEffectingOperations: new Set<string>(),
     ...overrides,
   };
 }
@@ -161,6 +162,36 @@ describe("POST /rest-operations/confirm", () => {
     const json = (await res.json()) as { error: string };
     expect(json.error).toBe("writes_disabled");
     expect(twentyMock.requests.some((r) => r.method !== "GET")).toBe(false);
+  });
+
+  it("re-gates a CONFIG-flagged side-effecting GET on the confirm replay (the bypass this closes, #3008)", async () => {
+    // A direct confirm POST for a GET the install config marks side-effecting must
+    // still hit the write allowlist. The config flag does NOT live on the graph
+    // (unlike the x-atlas-side-effecting spec extension), so the route has to thread
+    // `sideEffectingOperations` onto the policy itself. Drop that wiring and this GET
+    // slips through as an unconfirmed read — this test is the regression guard.
+    const app = appWith([datasource({ sideEffectingOperations: new Set(["findManyPeople"]) })]);
+    const res = await post(app, { datasourceId: "twenty", operationId: "findManyPeople" });
+    expect(res.status).toBe(403);
+    expect(((await res.json()) as { error: string }).error).toBe("writes_disabled");
+    // Rejected before dispatch — nothing reached the upstream.
+    expect(twentyMock.requests.length).toBe(0);
+  });
+
+  it("dispatches an ALLOWLISTED config-flagged side-effecting GET on confirm (#3008)", async () => {
+    // The re-gate must not over-block: once the side-effecting GET is allowlisted,
+    // a confirm replay dispatches it upstream like any other confirmed write.
+    const app = appWith([
+      datasource({
+        writeAllowlist: new Set(["findManyPeople"]),
+        sideEffectingOperations: new Set(["findManyPeople"]),
+      }),
+    ]);
+    const res = await post(app, { datasourceId: "twenty", operationId: "findManyPeople" });
+    expect(res.status).toBe(200);
+    expect(((await res.json()) as { status: string }).status).toBe("executed");
+    // The GET really reached the upstream (the re-gate allowed it through).
+    expect(twentyMock.matching("/rest/people").at(-1)?.method).toBe("GET");
   });
 
   it("500s (datasource_unavailable) when the registry load fails — not a misleading 404", async () => {

--- a/packages/api/src/api/routes/rest-operations.ts
+++ b/packages/api/src/api/routes/rest-operations.ts
@@ -172,9 +172,7 @@ export function createRestOperationsRoute(deps: RestOperationsDeps = {}) {
         // allowlist on the confirm replay too (the spec-extension path is already
         // covered, since `operation.sideEffecting` is read from the graph). Without
         // this, a direct confirm POST for such a GET would bypass the allowlist.
-        ...(datasource.sideEffectingOperations !== undefined
-          ? { sideEffectingOperations: datasource.sideEffectingOperations }
-          : {}),
+        sideEffectingOperations: datasource.sideEffectingOperations,
         dispatch: true, // this IS the upstream call — debit the quota
         ...(datasource.rateLimitPerMinute !== undefined
           ? { rateLimitPerMinute: datasource.rateLimitPerMinute }

--- a/packages/api/src/api/routes/rest-operations.ts
+++ b/packages/api/src/api/routes/rest-operations.ts
@@ -168,6 +168,13 @@ export function createRestOperationsRoute(deps: RestOperationsDeps = {}) {
         workspaceId: orgId,
         datasourceId: datasource.id,
         writeAllowlist: datasource.writeAllowlist,
+        // #3008: a config-flagged side-effecting GET must be re-gated by the
+        // allowlist on the confirm replay too (the spec-extension path is already
+        // covered, since `operation.sideEffecting` is read from the graph). Without
+        // this, a direct confirm POST for such a GET would bypass the allowlist.
+        ...(datasource.sideEffectingOperations !== undefined
+          ? { sideEffectingOperations: datasource.sideEffectingOperations }
+          : {}),
         dispatch: true, // this IS the upstream call — debit the quota
         ...(datasource.rateLimitPerMinute !== undefined
           ? { rateLimitPerMinute: datasource.rateLimitPerMinute }

--- a/packages/api/src/lib/db/migrations/0108_openapi_generic_catalog.sql
+++ b/packages/api/src/lib/db/migrations/0108_openapi_generic_catalog.sql
@@ -46,6 +46,7 @@ VALUES
       {"key": "auth_param_name", "type": "string", "label": "API key query param", "description": "For apikey-query auth, e.g. api_key."},
       {"key": "base_url_override", "type": "string", "label": "Base URL override", "description": "When the spec''s servers[0].url is wrong (dev/staging)."},
       {"key": "write_allowlist", "type": "string", "label": "Write allowlist (JSON)", "description": "JSON array of operationIds permitted to execute non-GET (write) requests, e.g. [\"createOnePerson\",\"createOneNote\"]. Empty/omitted = read-only (default). Every allowlisted write still requires an in-chat confirm-before-write step before it fires."},
+      {"key": "side_effecting_operations", "type": "string", "label": "Side-effecting GET operations (JSON)", "description": "JSON array of operationIds whose GET/HEAD method MUTATES state (e.g. [\"cancelJob\"] for GET /jobs/{id}/cancel). Listing one forces it through the write allowlist + confirm flow, exactly like a POST. SECURITY: read vs write is classified by HTTP method by DEFAULT — when a GET on this API changes data (common for legacy / RPC-style services), you MUST list it here (or set x-atlas-side-effecting: true on the operation in the spec), or the agent will run it as an unconfirmed read."},
       {"key": "display_name", "type": "string", "label": "Display name", "description": "Friendly name shown in /admin/connections."}
     ]'::jsonb,
     NOW(),

--- a/packages/api/src/lib/openapi/__tests__/catalog.test.ts
+++ b/packages/api/src/lib/openapi/__tests__/catalog.test.ts
@@ -12,6 +12,7 @@
 import { describe, it, expect } from "bun:test";
 import {
   parseWriteAllowlist,
+  parseSideEffectingOperations,
   narrowSupportedAuthKind,
   coerceRepresentationMode,
   isValidSnapshot,
@@ -61,6 +62,55 @@ describe("parseWriteAllowlist — fail-closed write gate", () => {
   it("drops non-string / empty-string elements, keeping only valid op ids", () => {
     const set = parseWriteAllowlist(["createOnePerson", "", 7, null, "createOneNote"] as unknown);
     expect([...set].toSorted()).toEqual(["createOneNote", "createOnePerson"]);
+  });
+});
+
+describe("parseSideEffectingOperations — #3008 escape-hatch parse", () => {
+  // Mirrors the parseWriteAllowlist suite: this is the canonical fail-closed
+  // normalization that feeds the write allowlist + confirm gate for a config-
+  // flagged side-effecting GET. A regression that made it lenient (e.g. treating a
+  // bare string as a one-op list) would mis-stage operations and leave every
+  // Set-constructing test still green — so these assertions are load-bearing.
+  it("parses a form-stored JSON string array into a Set", () => {
+    const set = parseSideEffectingOperations('["cancelJob","resetPassword"]');
+    expect(set.has("cancelJob")).toBe(true);
+    expect(set.has("resetPassword")).toBe(true);
+    expect(set.size).toBe(2);
+  });
+
+  it("accepts an already-parsed array (the atlas.config.ts plugins path)", () => {
+    const set = parseSideEffectingOperations(["cancelJob"]);
+    expect(set.has("cancelJob")).toBe(true);
+    expect(set.size).toBe(1);
+  });
+
+  it("treats absent / empty config as no overrides (empty set, method-only classification)", () => {
+    expect(parseSideEffectingOperations(undefined).size).toBe(0);
+    expect(parseSideEffectingOperations(null).size).toBe(0);
+    expect(parseSideEffectingOperations("").size).toBe(0);
+  });
+
+  it("degrades to empty on malformed JSON — never a permissive / fabricated list", () => {
+    expect(parseSideEffectingOperations("not json{").size).toBe(0);
+    expect(parseSideEffectingOperations("[unterminated").size).toBe(0);
+  });
+
+  it("degrades to empty when the JSON is not an array (object / number / bool)", () => {
+    expect(parseSideEffectingOperations('{"cancelJob":true}').size).toBe(0);
+    expect(parseSideEffectingOperations("42").size).toBe(0);
+    expect(parseSideEffectingOperations("true").size).toBe(0);
+  });
+
+  it("does NOT treat a bare string as a single-op list", () => {
+    // A raw bare string isn't valid JSON → empty set.
+    expect(parseSideEffectingOperations("cancelJob").size).toBe(0);
+    // A JSON string-literal parses to a string (not an array) → still empty set.
+    expect(parseSideEffectingOperations('"cancelJob"').size).toBe(0);
+  });
+
+  it("drops non-string / empty-string elements, keeping only valid op ids", () => {
+    const set = parseSideEffectingOperations(["cancelJob", "", 7, null, "resetPassword"] as unknown);
+    expect([...set].toSorted()).toEqual(["cancelJob", "resetPassword"]);
   });
 });
 

--- a/packages/api/src/lib/openapi/__tests__/spec.side-effecting.test.ts
+++ b/packages/api/src/lib/openapi/__tests__/spec.side-effecting.test.ts
@@ -1,0 +1,58 @@
+/**
+ * #3008 — `buildOperationGraph` reads the `x-atlas-side-effecting` operation
+ * extension into {@link Operation.sideEffecting}. This is the ONE vendor
+ * extension the parse boundary surfaces; only an explicit `true` escalates (a
+ * missing or `false` value leaves classification to the HTTP method, and can
+ * never DOWNGRADE a write to a read).
+ */
+import { describe, expect, it } from "bun:test";
+
+import { buildOperationGraph } from "../spec";
+
+function doc() {
+  return {
+    openapi: "3.1.0",
+    info: { title: "Jobs", version: "1.0.0" },
+    paths: {
+      "/jobs/{id}/cancel": {
+        get: {
+          operationId: "cancelJob",
+          "x-atlas-side-effecting": true,
+          parameters: [{ name: "id", in: "path", required: true, schema: { type: "string" } }],
+          responses: { "200": { description: "ok" } },
+        },
+      },
+      "/people": {
+        get: {
+          operationId: "listPeople",
+          responses: { "200": { description: "ok" } },
+        },
+      },
+      "/jobs/{id}": {
+        get: {
+          operationId: "getJob",
+          "x-atlas-side-effecting": false,
+          parameters: [{ name: "id", in: "path", required: true, schema: { type: "string" } }],
+          responses: { "200": { description: "ok" } },
+        },
+      },
+    },
+  };
+}
+
+describe("buildOperationGraph — x-atlas-side-effecting (#3008)", () => {
+  it("sets sideEffecting:true when the extension is true", () => {
+    const graph = buildOperationGraph(doc());
+    expect(graph.operations.get("cancelJob")?.sideEffecting).toBe(true);
+  });
+
+  it("leaves sideEffecting undefined when the extension is absent", () => {
+    const graph = buildOperationGraph(doc());
+    expect(graph.operations.get("listPeople")?.sideEffecting).toBeUndefined();
+  });
+
+  it("does not escalate when the extension is explicitly false", () => {
+    const graph = buildOperationGraph(doc());
+    expect(graph.operations.get("getJob")?.sideEffecting).toBeUndefined();
+  });
+});

--- a/packages/api/src/lib/openapi/__tests__/spec.side-effecting.test.ts
+++ b/packages/api/src/lib/openapi/__tests__/spec.side-effecting.test.ts
@@ -55,4 +55,37 @@ describe("buildOperationGraph — x-atlas-side-effecting (#3008)", () => {
     const graph = buildOperationGraph(doc());
     expect(graph.operations.get("getJob")?.sideEffecting).toBeUndefined();
   });
+
+  // #3008 fail-closed: a present-but-non-boolean value is a security-load-bearing
+  // misconfiguration (e.g. the string "true" from a YAML/templating round-trip),
+  // NOT silently dropped. Dropping it would leave a side-effecting GET classified
+  // as an unconfirmed read — the exact false negative this feature prevents.
+  function docWithSideEffecting(value: unknown) {
+    return {
+      openapi: "3.1.0",
+      info: { title: "Jobs", version: "1.0.0" },
+      paths: {
+        "/jobs/{id}/cancel": {
+          get: {
+            operationId: "cancelJob",
+            "x-atlas-side-effecting": value,
+            parameters: [{ name: "id", in: "path", required: true, schema: { type: "string" } }],
+            responses: { "200": { description: "ok" } },
+          },
+        },
+      },
+    };
+  }
+
+  it("throws on a non-boolean x-atlas-side-effecting (string) — fail-closed, not silently dropped", () => {
+    expect(() => buildOperationGraph(docWithSideEffecting("true"))).toThrow(/must be a boolean/);
+  });
+
+  it("throws on a non-boolean x-atlas-side-effecting (number)", () => {
+    expect(() => buildOperationGraph(docWithSideEffecting(1))).toThrow(/must be a boolean/);
+  });
+
+  it("throws on a non-boolean x-atlas-side-effecting (object)", () => {
+    expect(() => buildOperationGraph(docWithSideEffecting({}))).toThrow(/x-atlas-side-effecting/);
+  });
 });

--- a/packages/api/src/lib/openapi/__tests__/twenty-acceptance.test.ts
+++ b/packages/api/src/lib/openapi/__tests__/twenty-acceptance.test.ts
@@ -233,6 +233,7 @@ beforeAll(async () => {
     auth: { kind: "bearer", token: "acceptance-bearer" },
     // The acceptance suite exercises the read surface — writes stay opted out.
     writeAllowlist: new Set<string>(),
+    sideEffectingOperations: new Set<string>(),
   };
 });
 

--- a/packages/api/src/lib/openapi/__tests__/validate-rest-operation.side-effecting.test.ts
+++ b/packages/api/src/lib/openapi/__tests__/validate-rest-operation.side-effecting.test.ts
@@ -1,0 +1,161 @@
+/**
+ * #3008 — side-effecting-GET classification escape hatch.
+ *
+ * GET=read is only a DEFAULT, never ground truth. A mutating RPC-over-GET
+ * (`GET /jobs/{id}/cancel`) can be flagged side-effecting — via the
+ * `x-atlas-side-effecting: true` spec extension ({@link Operation.sideEffecting})
+ * or the install config's `side_effecting_operations` list (threaded onto the
+ * policy as `sideEffectingOperations`) — and is then forced through the SAME
+ * write allowlist + confirm path as a POST.
+ *
+ * Self-contained fixtures (no shared helpers) so this file is robust on its own.
+ */
+import { describe, expect, it, beforeEach } from "bun:test";
+
+import {
+  validateRestOperation,
+  isSideEffectingOperation,
+  _resetRestRateLimits,
+  type RestOperationPolicy,
+} from "../validate-rest-operation";
+import type { Operation, OperationGraph } from "../types";
+
+function makeOperation(overrides: Partial<Operation> = {}): Operation {
+  return {
+    operationId: "op",
+    method: "GET",
+    path: "/op",
+    tags: [],
+    parameters: [],
+    security: [],
+    responses: new Map(),
+    ...overrides,
+  };
+}
+
+function makeGraph(operations: Operation[]): OperationGraph {
+  return {
+    operations: new Map(operations.map((op) => [op.operationId, op])),
+    schemas: new Map(),
+    security: new Map(),
+    servers: [],
+    info: { title: "Test", version: "1.0.0", openapiVersion: "3.1.0" },
+  };
+}
+
+function makePolicy(overrides: Partial<RestOperationPolicy> = {}): RestOperationPolicy {
+  return {
+    workspaceId: "ws",
+    datasourceId: "ds",
+    writeAllowlist: new Set<string>(),
+    now: () => 0,
+    ...overrides,
+  };
+}
+
+describe("isSideEffectingOperation (#3008)", () => {
+  it("treats a plain GET/HEAD as a read", () => {
+    expect(isSideEffectingOperation(makeOperation({ method: "GET" }))).toBe(false);
+    expect(isSideEffectingOperation(makeOperation({ method: "HEAD" }))).toBe(false);
+  });
+
+  it("treats every non-GET/HEAD method as a write regardless of flags", () => {
+    expect(isSideEffectingOperation(makeOperation({ method: "POST" }))).toBe(true);
+    // De-escalation is impossible: sideEffecting:false on a write stays a write.
+    expect(
+      isSideEffectingOperation(makeOperation({ method: "DELETE", sideEffecting: false })),
+    ).toBe(true);
+  });
+
+  it("escalates a GET flagged via the x-atlas-side-effecting spec extension", () => {
+    expect(isSideEffectingOperation(makeOperation({ method: "GET", sideEffecting: true }))).toBe(
+      true,
+    );
+  });
+
+  it("escalates a GET listed in the install config's side_effecting_operations", () => {
+    const op = makeOperation({ operationId: "cancelJob", method: "GET" });
+    expect(isSideEffectingOperation(op, new Set(["cancelJob"]))).toBe(true);
+    expect(isSideEffectingOperation(op, new Set(["other"]))).toBe(false);
+  });
+});
+
+describe("validateRestOperation — side-effecting overrides (#3008)", () => {
+  beforeEach(() => {
+    _resetRestRateLimits();
+  });
+
+  it("rejects a side-effecting GET (spec extension) absent from the allowlist", () => {
+    const graph = makeGraph([
+      makeOperation({ operationId: "cancelJob", method: "GET", sideEffecting: true }),
+    ]);
+    const verdict = validateRestOperation(graph, "cancelJob", {}, makePolicy());
+    expect(verdict.allowed).toBe(false);
+    if (!verdict.allowed) {
+      expect(verdict.error.reason).toBe("writes-disabled");
+      // The message names the side-effecting flag, not the misleading "GET (write)".
+      expect(verdict.error.message).toContain("side-effecting");
+    }
+  });
+
+  it("requires confirmation for an allowlisted side-effecting GET (spec extension)", () => {
+    const graph = makeGraph([
+      makeOperation({ operationId: "cancelJob", method: "GET", sideEffecting: true }),
+    ]);
+    const verdict = validateRestOperation(
+      graph,
+      "cancelJob",
+      {},
+      makePolicy({ writeAllowlist: new Set(["cancelJob"]) }),
+    );
+    expect(verdict.allowed).toBe(true);
+    if (verdict.allowed) {
+      expect(verdict.requiresConfirmation).toBe(true);
+    }
+  });
+
+  it("rejects a side-effecting GET (config list) absent from the allowlist", () => {
+    const graph = makeGraph([makeOperation({ operationId: "cancelJob", method: "GET" })]);
+    const verdict = validateRestOperation(
+      graph,
+      "cancelJob",
+      {},
+      makePolicy({ sideEffectingOperations: new Set(["cancelJob"]) }),
+    );
+    expect(verdict.allowed).toBe(false);
+    if (!verdict.allowed) {
+      expect(verdict.error.reason).toBe("writes-disabled");
+    }
+  });
+
+  it("requires confirmation for an allowlisted side-effecting GET (config list)", () => {
+    const graph = makeGraph([makeOperation({ operationId: "cancelJob", method: "GET" })]);
+    const verdict = validateRestOperation(
+      graph,
+      "cancelJob",
+      {},
+      makePolicy({
+        writeAllowlist: new Set(["cancelJob"]),
+        sideEffectingOperations: new Set(["cancelJob"]),
+      }),
+    );
+    expect(verdict.allowed).toBe(true);
+    if (verdict.allowed) {
+      expect(verdict.requiresConfirmation).toBe(true);
+    }
+  });
+
+  it("leaves an unmarked GET a read needing neither allowlist nor confirmation (regression)", () => {
+    const graph = makeGraph([makeOperation({ operationId: "getPerson", method: "GET" })]);
+    const verdict = validateRestOperation(
+      graph,
+      "getPerson",
+      {},
+      makePolicy({ sideEffectingOperations: new Set(["somethingElse"]) }),
+    );
+    expect(verdict.allowed).toBe(true);
+    if (verdict.allowed) {
+      expect(verdict.requiresConfirmation).toBe(false);
+    }
+  });
+});

--- a/packages/api/src/lib/openapi/catalog.ts
+++ b/packages/api/src/lib/openapi/catalog.ts
@@ -316,9 +316,19 @@ export function parseWriteAllowlist(raw: unknown, installId?: string): ReadonlyS
  * extension does the same per-operation). Accepts the form-stored JSON **string**
  * (`'["cancelJob"]'`) or an already-parsed **array** (an `atlas.config.ts` plugins
  * entry); anything malformed resolves to the **empty set** — classification stays
- * method-only — logged for the operator. Same fail-closed normalization as
- * {@link parseWriteAllowlist}: a broken list can only ever ADD safety, never strip
- * it, so degrading to "none" is the safe default.
+ * method-only — logged for the operator.
+ *
+ * NOTE: degrading-to-empty here is NOT "fail-closed" in the {@link
+ * parseWriteAllowlist} sense, and the security semantics are inverted. An empty
+ * *allowlist* means default-deny writes (safe); an empty *side-effecting list*
+ * means a GET the operator INTENDED to gate is left classified as a plain read
+ * and runs unconfirmed (the less-safe outcome for that operation). We degrade to
+ * empty + warn rather than throw because the config is a free-text JSON blob — we
+ * can't infer which ops a malformed list meant, and a hard throw would take the
+ * whole datasource offline for one fat-fingered entry. The operator must fix the
+ * config; the warn log surfaces it. (Contrast the spec extension, a single named
+ * scalar the parser CAN pinpoint and so rejects loudly — see {@link
+ * import("./spec").buildOperationGraph}.)
  */
 export function parseSideEffectingOperations(raw: unknown, installId?: string): ReadonlySet<string> {
   if (raw === undefined || raw === null || raw === "") return new Set();

--- a/packages/api/src/lib/openapi/catalog.ts
+++ b/packages/api/src/lib/openapi/catalog.ts
@@ -108,7 +108,8 @@ export const DEFAULT_REPRESENTATION_MODE: RepresentationMode = "operation-graph"
  * `secret: true` flag on `auth_value` is the single thing that drives
  * `encryptSecretFields` / `decryptSecretFields` — adding a new auth field is a
  * one-line schema change, never a hand-wired encryption call (AC3, user story
- * 19). `write_allowlist` is honored by `validateRestOperation` (slice 5, #2929).
+ * 19). `write_allowlist` (and `side_effecting_operations`, #3008) are honored by
+ * `validateRestOperation` (slice 5, #2929).
  *
  * `auth_kind` is a `select` so the admin UI renders a dropdown bound to
  * {@link OPENAPI_AUTH_KINDS}; the handler re-validates against
@@ -165,6 +166,18 @@ export const OPENAPI_GENERIC_CONFIG_SCHEMA: ReadonlyArray<ConfigSchemaField> = [
       "JSON array of operationIds permitted to execute non-GET (write) requests, e.g. " +
       '["createOnePerson","createOneNote"]. Empty/omitted = read-only (default). Every ' +
       "allowlisted write still requires an in-chat confirm-before-write step before it fires.",
+  },
+  {
+    key: "side_effecting_operations",
+    type: "string",
+    label: "Side-effecting GET operations (JSON)",
+    description:
+      "JSON array of operationIds whose GET/HEAD method MUTATES state (e.g. " +
+      '["cancelJob"] for GET /jobs/{id}/cancel). Listing one forces it through the write ' +
+      "allowlist + confirm flow, exactly like a POST. SECURITY: read vs write is classified by " +
+      "HTTP method by DEFAULT — when a GET on this API changes data (common for legacy / RPC-style " +
+      "services), you MUST list it here (or set x-atlas-side-effecting: true on the operation in " +
+      "the spec), or the agent will run it as an unconfirmed read.",
   },
   {
     key: "display_name",
@@ -291,6 +304,54 @@ export function parseWriteAllowlist(raw: unknown, installId?: string): ReadonlyS
     log.warn(
       { installId },
       "OpenAPI install write_allowlist contained non-string / empty entries — they were ignored",
+    );
+  }
+  return ops;
+}
+
+/**
+ * Parse the `side_effecting_operations` config value (#3008): operationIds whose
+ * read-method (GET/HEAD) MUTATES state and must therefore be forced through the
+ * write allowlist + confirm path (the per-spec `x-atlas-side-effecting: true`
+ * extension does the same per-operation). Accepts the form-stored JSON **string**
+ * (`'["cancelJob"]'`) or an already-parsed **array** (an `atlas.config.ts` plugins
+ * entry); anything malformed resolves to the **empty set** — classification stays
+ * method-only — logged for the operator. Same fail-closed normalization as
+ * {@link parseWriteAllowlist}: a broken list can only ever ADD safety, never strip
+ * it, so degrading to "none" is the safe default.
+ */
+export function parseSideEffectingOperations(raw: unknown, installId?: string): ReadonlySet<string> {
+  if (raw === undefined || raw === null || raw === "") return new Set();
+
+  let value: unknown = raw;
+  if (typeof raw === "string") {
+    try {
+      value = JSON.parse(raw);
+    } catch {
+      log.warn(
+        { installId },
+        "OpenAPI install side_effecting_operations is not valid JSON — ignoring (classification stays method-only)",
+      );
+      return new Set();
+    }
+  }
+
+  if (!Array.isArray(value)) {
+    log.warn(
+      { installId },
+      "OpenAPI install side_effecting_operations is not a JSON array — ignoring (classification stays method-only)",
+    );
+    return new Set();
+  }
+
+  const ops = new Set<string>();
+  for (const item of value) {
+    if (typeof item === "string" && item.length > 0) ops.add(item);
+  }
+  if (ops.size !== value.length) {
+    log.warn(
+      { installId },
+      "OpenAPI install side_effecting_operations contained non-string / empty entries — they were ignored",
     );
   }
   return ops;

--- a/packages/api/src/lib/openapi/datasource.ts
+++ b/packages/api/src/lib/openapi/datasource.ts
@@ -51,6 +51,14 @@ export interface RestDatasource {
    */
   readonly writeAllowlist: ReadonlySet<string>;
   /**
+   * `operationId`s the operator marked side-effecting in install config — forced
+   * through the write allowlist + confirm path even though their HTTP method
+   * reads (a mutating RPC-over-GET). The `x-atlas-side-effecting: true` spec
+   * extension does the same per-op. Omit/empty → classification is method-only.
+   * Resolved from `workspace_plugins.config.side_effecting_operations`. See #3008.
+   */
+  readonly sideEffectingOperations?: ReadonlySet<string>;
+  /**
    * Per-install rate-limit override (calls/min) for the per-operation token
    * bucket. Omitted → {@link import("./validate-rest-operation").DEFAULT_RATE_LIMIT_PER_MINUTE}
    * (60/min). Resolved from `workspace_plugins.config.rate_limit_per_minute`.

--- a/packages/api/src/lib/openapi/datasource.ts
+++ b/packages/api/src/lib/openapi/datasource.ts
@@ -54,10 +54,13 @@ export interface RestDatasource {
    * `operationId`s the operator marked side-effecting in install config — forced
    * through the write allowlist + confirm path even though their HTTP method
    * reads (a mutating RPC-over-GET). The `x-atlas-side-effecting: true` spec
-   * extension does the same per-op. Omit/empty → classification is method-only.
-   * Resolved from `workspace_plugins.config.side_effecting_operations`. See #3008.
+   * extension does the same per-op. **Empty = no config-level overrides**
+   * (classification is method-only). Resolved from
+   * `workspace_plugins.config.side_effecting_operations`. Required (always a Set,
+   * possibly empty) so it mirrors {@link writeAllowlist} and callers never branch
+   * on `undefined`. See #3008.
    */
-  readonly sideEffectingOperations?: ReadonlySet<string>;
+  readonly sideEffectingOperations: ReadonlySet<string>;
   /**
    * Per-install rate-limit override (calls/min) for the per-operation token
    * bucket. Omitted → {@link import("./validate-rest-operation").DEFAULT_RATE_LIMIT_PER_MINUTE}

--- a/packages/api/src/lib/openapi/spec.ts
+++ b/packages/api/src/lib/openapi/spec.ts
@@ -529,10 +529,27 @@ class GraphBuilder {
         if (description !== undefined) operation.description = description;
         // #3008: the `x-atlas-side-effecting: true` vendor extension escalates a
         // read-method operation (a mutating RPC-over-GET) to the write path. Only
-        // an explicit `true` sets it — a missing/false value leaves classification
-        // to the method, and the flag can never DOWNGRADE a write method to a read.
-        if (asBoolean(opRaw["x-atlas-side-effecting"]) === true) {
-          operation.sideEffecting = true;
+        // an explicit `true` sets it — an explicit `false` (or a missing value)
+        // leaves classification to the method, and the flag can never DOWNGRADE a
+        // write method to a read. A present-but-non-boolean value (e.g. the string
+        // "true" from a YAML/templating round-trip) is REJECTED, not silently
+        // dropped: this is a security-load-bearing signal, so we fail loud here —
+        // matching every other malformed scalar in this parser — rather than let a
+        // mistyped flag leave a side-effecting GET classified as an unconfirmed
+        // read (the write-safety false negative this feature exists to prevent).
+        if ("x-atlas-side-effecting" in opRaw) {
+          const sideEffecting = asBoolean(opRaw["x-atlas-side-effecting"]);
+          if (sideEffecting === undefined) {
+            throw new OpenApiSpecError({
+              reason: "invalid-structure",
+              location: `${opLocation}.x-atlas-side-effecting`,
+              message:
+                `x-atlas-side-effecting at ${opLocation} must be a boolean, got ` +
+                `${describe(opRaw["x-atlas-side-effecting"])}. A mistyped value (e.g. the ` +
+                `string "true") would silently leave a side-effecting GET ungated.`,
+            });
+          }
+          if (sideEffecting) operation.sideEffecting = true;
         }
         const requestBody = this.buildRequestBody(opRaw.requestBody, `${opLocation}.requestBody`);
         if (requestBody !== undefined) operation.requestBody = requestBody;

--- a/packages/api/src/lib/openapi/spec.ts
+++ b/packages/api/src/lib/openapi/spec.ts
@@ -15,7 +15,9 @@
  *    because every walker reads only a known set of keys; the one place an
  *    `x-*` *sibling entry* legally appears (the `paths` object) is explicitly
  *    skipped. Real specs (Stripe, Twenty) are full of extensions — rejecting
- *    them would make "normalize Stripe's spec" impossible.
+ *    them would make "normalize Stripe's spec" impossible. The ONE extension this
+ *    builder reads is `x-atlas-side-effecting` on an operation (#3008), surfaced
+ *    as {@link Operation.sideEffecting}; all other `x-*` keys are still ignored.
  *  - Circular `$ref`s through named components (Twenty's Person ↔ NoteTarget).
  *    These are REQUIRED to resolve (acceptance criterion). We resolve a named
  *    `$ref` to a pointer node (`{ ref: "Name" }`) rather than inlining, so the
@@ -525,6 +527,13 @@ class GraphBuilder {
         if (summary !== undefined) operation.summary = summary;
         const description = asString(opRaw.description);
         if (description !== undefined) operation.description = description;
+        // #3008: the `x-atlas-side-effecting: true` vendor extension escalates a
+        // read-method operation (a mutating RPC-over-GET) to the write path. Only
+        // an explicit `true` sets it — a missing/false value leaves classification
+        // to the method, and the flag can never DOWNGRADE a write method to a read.
+        if (asBoolean(opRaw["x-atlas-side-effecting"]) === true) {
+          operation.sideEffecting = true;
+        }
         const requestBody = this.buildRequestBody(opRaw.requestBody, `${opLocation}.requestBody`);
         if (requestBody !== undefined) operation.requestBody = requestBody;
 

--- a/packages/api/src/lib/openapi/types.ts
+++ b/packages/api/src/lib/openapi/types.ts
@@ -195,6 +195,11 @@ export interface Operation {
    * state even if its {@link method} is a GET/HEAD (a mutating RPC-over-GET, e.g.
    * `GET /jobs/{id}/cancel`), so the validator forces it through the write
    * allowlist + confirm path. Absent → classify by method (the GET=read default).
+   * Only `true` is ever set by the parser: an explicit `x-atlas-side-effecting:
+   * false` is accepted but equivalent to absent (it leaves classification to the
+   * method), so the two observable behaviors are "escalated" (`true`) vs "method-
+   * default" (`false`/absent). A present-but-non-boolean value is rejected at parse
+   * time — see {@link import("./spec").buildOperationGraph}.
    * De-escalation is impossible by design: a write method stays a write whatever
    * this flag says — see {@link import("./validate-rest-operation").isSideEffectingOperation}.
    */

--- a/packages/api/src/lib/openapi/types.ts
+++ b/packages/api/src/lib/openapi/types.ts
@@ -189,6 +189,16 @@ export interface OperationResponse {
 export interface Operation {
   readonly operationId: string;
   readonly method: HttpMethod;
+  /**
+   * Operator-asserted override (#3008): `true` when the operation's spec carried
+   * the `x-atlas-side-effecting: true` vendor extension. Such an operation MUTATES
+   * state even if its {@link method} is a GET/HEAD (a mutating RPC-over-GET, e.g.
+   * `GET /jobs/{id}/cancel`), so the validator forces it through the write
+   * allowlist + confirm path. Absent → classify by method (the GET=read default).
+   * De-escalation is impossible by design: a write method stays a write whatever
+   * this flag says — see {@link import("./validate-rest-operation").isSideEffectingOperation}.
+   */
+  readonly sideEffecting?: boolean;
   /** The templated path, e.g. "/people/{id}". */
   readonly path: string;
   readonly summary?: string;

--- a/packages/api/src/lib/openapi/validate-rest-operation.ts
+++ b/packages/api/src/lib/openapi/validate-rest-operation.ts
@@ -6,8 +6,9 @@
  * adapter, not subordinate").
  *
  * This is a SECURITY boundary. Treat it like `validateSQL`:
- *   - default-deny on writes (a non-GET only executes if its `operationId` is in
- *     the install's `write_allowlist`),
+ *   - default-deny on writes (a non-GET — or a GET/HEAD flagged side-effecting,
+ *     #3008 — only executes if its `operationId` is in the install's
+ *     `write_allowlist`),
  *   - fail loud on an operation that isn't in the probed graph (never dispatch a
  *     fabricated operation),
  *   - never a silent fallback — every rejection is an explicit

--- a/packages/api/src/lib/openapi/validate-rest-operation.ts
+++ b/packages/api/src/lib/openapi/validate-rest-operation.ts
@@ -18,8 +18,12 @@
  * the sandbox boundary, before any of this runs):
  *
  *   1. **Operation in graph.** Unknown `operationId` → `unknown-operation`.
- *   2. **Method allowlist.** GET/HEAD always pass; any other method requires
+ *   2. **Write allowlist.** A read (GET/HEAD) passes; a write requires
  *      `policy.writeAllowlist.has(operationId)` → `writes-disabled` otherwise.
+ *      "Write" is NOT method-only (#3008): a GET/HEAD flagged side-effecting —
+ *      via the `x-atlas-side-effecting: true` spec extension or the install's
+ *      `side_effecting_operations` list — is gated here too. See
+ *      {@link isSideEffectingOperation}.
  *   3. **Parameter shape.** Required params + required body present; no params
  *      that the spec doesn't declare → `invalid-params`.
  *   4. **Rate limit.** A per-`(workspace, datasource, operation)` token bucket
@@ -38,8 +42,9 @@
  * quota throttles real upstream dispatches, not pre-flight rejections.
  *
  * On success the verdict carries the resolved {@link Operation}, whether the
- * caller must obtain human confirmation before dispatching (every non-GET/HEAD),
- * and the effective `timeoutMs` to pass to the client.
+ * caller must obtain human confirmation before dispatching (every effective
+ * write — see {@link isSideEffectingOperation}), and the effective `timeoutMs`
+ * to pass to the client.
  */
 import { Data } from "effect";
 
@@ -97,6 +102,14 @@ export interface RestOperationPolicy {
   readonly datasourceId: string;
   /** The `operationId`s permitted to execute a non-GET method. Empty = read-only. */
   readonly writeAllowlist: ReadonlySet<string>;
+  /**
+   * `operationId`s the install config marks side-effecting (the
+   * `side_effecting_operations` list). A GET/HEAD in this set — like one whose
+   * spec carries `x-atlas-side-effecting: true` — is forced through the write
+   * allowlist + confirm path even though its method reads. Omit → no
+   * config-level overrides. See #3008 and {@link isSideEffectingOperation}.
+   */
+  readonly sideEffectingOperations?: ReadonlySet<string>;
   /** Per-install rate-limit override (calls/min). Default {@link DEFAULT_RATE_LIMIT_PER_MINUTE}. */
   readonly rateLimitPerMinute?: number;
   /**
@@ -122,8 +135,9 @@ export type RestOperationVerdict =
       readonly allowed: true;
       readonly operation: Operation;
       /**
-       * `true` for every non-GET/HEAD method — the caller MUST obtain human
-       * confirmation (the confirm-before-write banner) before dispatching.
+       * `true` for every effective write — a non-GET/HEAD method, OR a GET/HEAD
+       * escalated by an #3008 side-effecting override. The caller MUST obtain
+       * human confirmation (the confirm-before-write banner) before dispatching.
        */
       readonly requiresConfirmation: boolean;
       /** The effective per-request timeout the client should use. */
@@ -298,6 +312,30 @@ export function isWriteMethod(method: string): boolean {
 }
 
 /**
+ * Whether an operation must be authorized as a WRITE — gated by the write
+ * allowlist and staged for human confirmation. Combines the three #3008 signals:
+ *   1. its HTTP method mutates ({@link isWriteMethod} — the default), OR
+ *   2. its spec carried `x-atlas-side-effecting: true` ({@link Operation.sideEffecting}), OR
+ *   3. the install config lists its `operationId` in `side_effecting_operations`.
+ *
+ * GET=read is only a DEFAULT here, never ground truth: a mutating RPC-over-GET
+ * (`GET /jobs/{id}/cancel`, `GET /admin/resetPassword`) — common in the
+ * legacy/internal services this milestone targets — is escalated by (2) or (3).
+ * The combination is monotonic: an override can only ADD safety (escalate a read
+ * to a write), never strip it (a POST stays a write whatever the flags say).
+ */
+export function isSideEffectingOperation(
+  operation: Operation,
+  sideEffectingOperations?: ReadonlySet<string>,
+): boolean {
+  return (
+    isWriteMethod(operation.method) ||
+    operation.sideEffecting === true ||
+    (sideEffectingOperations?.has(operation.operationId) ?? false)
+  );
+}
+
+/**
  * Authorize a single REST operation against the install policy. See the module
  * doc for the layer ordering and security contract. Pure except for the layer-4
  * token bucket (the only stateful layer, and only when `dispatch !== false`).
@@ -324,17 +362,24 @@ export function validateRestOperation(
     };
   }
 
-  const isWrite = isWriteMethod(operation.method);
+  // Not method-only (#3008): a GET/HEAD flagged side-effecting (spec extension or
+  // install config) is authorized as a write too — allowlist + confirm.
+  const isWrite = isSideEffectingOperation(operation, policy.sideEffectingOperations);
 
-  // ── Layer 2 — method allowlist (default-deny writes) ─────────────────────
+  // ── Layer 2 — write allowlist (default-deny writes) ──────────────────────
   if (isWrite && !policy.writeAllowlist.has(operationId)) {
+    // A GET/HEAD reaches here only via a side-effecting override; name that,
+    // rather than the misleading "is a GET (write)".
+    const why = isWriteMethod(operation.method)
+      ? `is a ${operation.method} (write)`
+      : `is a ${operation.method} flagged as side-effecting`;
     return {
       allowed: false,
       error: new RestValidationError({
         reason: "writes-disabled",
         operationId,
         message:
-          `Operation "${operationId}" is a ${operation.method} (write). Writes are disabled for this ` +
+          `Operation "${operationId}" ${why}. Writes are disabled for this ` +
           `datasource — add "${operationId}" to its write allowlist to enable it. Do not claim it succeeded.`,
       }),
     };

--- a/packages/api/src/lib/openapi/workspace-datasource.ts
+++ b/packages/api/src/lib/openapi/workspace-datasource.ts
@@ -181,6 +181,9 @@ function buildDatasource(
   const writeAllowlist = parseWriteAllowlist(decrypted.write_allowlist, installId);
   // #3008: operationIds the operator marks side-effecting (a mutating RPC-over-GET) —
   // forced through the write allowlist + confirm path even though their method reads.
+  // A malformed list degrades to empty (classification stays method-only) — note
+  // this is NOT the "fails closed to read-only" posture above: an empty side-effecting
+  // list LEAVES an intended-to-gate GET running unconfirmed. See parseSideEffectingOperations.
   const sideEffectingOperations = parseSideEffectingOperations(decrypted.side_effecting_operations, installId);
   const rateLimitPerMinute = parseRateLimitPerMinute(decrypted.rate_limit_per_minute, installId);
   const requestTimeoutMs = parseRequestTimeoutMs(decrypted.request_timeout_ms, installId);

--- a/packages/api/src/lib/openapi/workspace-datasource.ts
+++ b/packages/api/src/lib/openapi/workspace-datasource.ts
@@ -35,6 +35,7 @@ import {
   narrowSupportedAuthKind,
   parseRateLimitPerMinute,
   parseRequestTimeoutMs,
+  parseSideEffectingOperations,
   parseWriteAllowlist,
 } from "./catalog";
 import { buildResolvedAuth, snapshotToGraph } from "./probe";
@@ -178,6 +179,9 @@ function buildDatasource(
   // form's JSON string; an `atlas.config.ts` plugins entry may pass an array.
   // Both normalize to a Set; anything malformed fails closed to read-only.
   const writeAllowlist = parseWriteAllowlist(decrypted.write_allowlist, installId);
+  // #3008: operationIds the operator marks side-effecting (a mutating RPC-over-GET) —
+  // forced through the write allowlist + confirm path even though their method reads.
+  const sideEffectingOperations = parseSideEffectingOperations(decrypted.side_effecting_operations, installId);
   const rateLimitPerMinute = parseRateLimitPerMinute(decrypted.rate_limit_per_minute, installId);
   const requestTimeoutMs = parseRequestTimeoutMs(decrypted.request_timeout_ms, installId);
 
@@ -189,6 +193,7 @@ function buildDatasource(
     auth,
     representationMode: coerceRepresentationMode(decrypted.representation_mode),
     writeAllowlist,
+    sideEffectingOperations,
     ...(rateLimitPerMinute !== undefined ? { rateLimitPerMinute } : {}),
     ...(requestTimeoutMs !== undefined ? { requestTimeoutMs } : {}),
   };

--- a/packages/api/src/lib/tools/__tests__/python-rest-egress.test.ts
+++ b/packages/api/src/lib/tools/__tests__/python-rest-egress.test.ts
@@ -85,6 +85,7 @@ function makeDatasource(id: string, baseUrl: string): RestDatasource {
     auth: { kind: "bearer", token: "tok" },
     representationMode: "operation-graph",
     writeAllowlist: new Set<string>(),
+    sideEffectingOperations: new Set<string>(),
   };
 }
 

--- a/packages/api/src/lib/tools/__tests__/rest-operation.test.ts
+++ b/packages/api/src/lib/tools/__tests__/rest-operation.test.ts
@@ -47,6 +47,7 @@ function datasource(overrides: Partial<RestDatasource> = {}): RestDatasource {
     auth: { kind: "bearer", token: "test-token" },
     representationMode: "operation-graph",
     writeAllowlist: new Set<string>(),
+    sideEffectingOperations: new Set<string>(),
     ...overrides,
   };
 }
@@ -122,7 +123,7 @@ describe("executeRestOperation tool", () => {
     });
     const result = await call(
       { operationId: "listWithHeader", header: { "X-Schema-Version": "2024-01" } },
-      async () => ({ id: "twenty", displayName: "Twenty", graph: headerGraph, baseUrl: mock.restBaseUrl, auth: { kind: "bearer", token: "test-token" }, representationMode: "operation-graph", writeAllowlist: new Set<string>() }),
+      async () => ({ id: "twenty", displayName: "Twenty", graph: headerGraph, baseUrl: mock.restBaseUrl, auth: { kind: "bearer", token: "test-token" }, representationMode: "operation-graph", writeAllowlist: new Set<string>(), sideEffectingOperations: new Set<string>() }),
     );
     expect(result.status).toBe("ok");
     const req = mock.matching("/rest/people").at(-1);
@@ -251,6 +252,32 @@ describe("executeRestOperation — write-side opt-in", () => {
     expect(second.status).toBe("rate_limited");
     if (second.status !== "rate_limited") return;
     expect(second.retryAfterMs).toBeGreaterThan(0);
+  });
+
+  it("stages a config-flagged side-effecting GET as needs_confirmation, never dispatching it (#3008)", async () => {
+    // A GET the install marks side-effecting is treated exactly like a write: it
+    // stages with dispatch:false, so it never hits the upstream and never burns the
+    // per-operation quota at stage time (the same GET runs as a plain read sans flag).
+    const ds = datasource({
+      writeAllowlist: new Set(["findManyPeople"]),
+      sideEffectingOperations: new Set(["findManyPeople"]),
+    });
+    const result = await call({ operationId: "findManyPeople" }, async () => ds);
+    expect(result.status).toBe("needs_confirmation");
+    if (result.status !== "needs_confirmation") return;
+    expect(result.method).toBe("GET");
+    expect(result.operationId).toBe("findManyPeople");
+    // dispatch:false — the flagged GET did NOT reach the upstream (quota untouched).
+    expect(mock.requests).toHaveLength(0);
+  });
+
+  it("blocks a config-flagged side-effecting GET that is NOT allowlisted (writes_disabled, #3008)", async () => {
+    const ds = datasource({ sideEffectingOperations: new Set(["findManyPeople"]) });
+    const result = await call({ operationId: "findManyPeople" }, async () => ds);
+    expect(result.status).toBe("writes_disabled");
+    if (result.status !== "writes_disabled") return;
+    expect(result.method).toBe("GET");
+    expect(mock.requests).toHaveLength(0);
   });
 });
 

--- a/packages/api/src/lib/tools/rest-operation.ts
+++ b/packages/api/src/lib/tools/rest-operation.ts
@@ -46,7 +46,7 @@ import { type RestDatasource } from "@atlas/api/lib/openapi/datasource";
 import { resolveWorkspaceRestDatasourcesOrThrow } from "@atlas/api/lib/openapi/workspace-datasource";
 import {
   validateRestOperation,
-  isWriteMethod,
+  isSideEffectingOperation,
   type RestOperationPolicy,
 } from "@atlas/api/lib/openapi/validate-rest-operation";
 import {
@@ -63,7 +63,7 @@ Use executeRestOperation to call a single operation on a connected REST API (des
 - When more than one REST datasource is connected, pass \`datasourceId\` (shown in each datasource's header) to pick which one
 - Compose the filter \`query\` value yourself in the documented \`field[op]:value\` syntax — do NOT invent a bracketed form
 - For multi-step questions, call this tool once per step and feed each result into the next (e.g. find a person, then list their note targets, then fetch each note)
-- GET operations execute and return data immediately.
+- GET operations execute and return data immediately — UNLESS the datasource's admin marked a specific GET as side-effecting. Some legacy/internal APIs mutate via GET (e.g. \`GET /jobs/{id}/cancel\`); a flagged GET is treated exactly like a write — it needs allowlisting and is staged for confirmation, never run silently.
 - Write operations (POST/PATCH/PUT/DELETE) only run if the datasource's admin has allowlisted them. A non-allowlisted write returns \`writes_disabled\` — tell the user writes are off for that datasource; never claim it happened.
 - An allowlisted write does NOT run immediately: it returns \`needs_confirmation\`. Tell the user plainly what the write will do (e.g. "This will permanently delete 3 people in Twenty — confirm?") and STOP. The user confirms via the banner; do not retry, and never claim the write succeeded until you see a confirmed result.`;
 
@@ -182,8 +182,10 @@ export function createExecuteRestOperationTool(deps: ExecuteRestOperationDeps = 
   return tool({
     description:
       "Call a single operation on a connected REST datasource by operationId. GET operations " +
-      "execute and return data; write operations run only if allowlisted, and an allowlisted " +
-      "write is staged for the user to confirm before it fires (never claim a write happened until confirmed).",
+      "execute and return data immediately, UNLESS the admin marked a GET as side-effecting (some " +
+      "legacy APIs mutate via GET) — those, like write operations (POST/PATCH/PUT/DELETE), run only " +
+      "if allowlisted, and an allowlisted write / side-effecting GET is staged for the user to " +
+      "confirm before it fires (never claim a write happened until confirmed).",
     inputSchema: ExecuteRestOperationInput,
     execute: async ({ operationId, datasourceId, pathParams, query, header, body }): Promise<ExecuteRestOperationResult> => {
       let datasources: ReadonlyArray<RestDatasource>;
@@ -249,7 +251,11 @@ export function createExecuteRestOperationTool(deps: ExecuteRestOperationDeps = 
       // Staging a write for confirmation must not burn quota. An unknown op falls
       // to `dispatch: true`, but layer 1 rejects it before the quota is touched.
       const peeked = datasource.graph.operations.get(operationId);
-      const isWrite = peeked ? isWriteMethod(peeked.method) : false;
+      // Side-effecting (#3008) GET/HEADs count as writes here too, so they are
+      // staged for confirmation (dispatch:false) rather than run immediately.
+      const isWrite = peeked
+        ? isSideEffectingOperation(peeked, datasource.sideEffectingOperations)
+        : false;
 
       const policy: RestOperationPolicy = {
         // The rate-limit bucket is keyed (workspace, datasource, operation). In
@@ -260,6 +266,9 @@ export function createExecuteRestOperationTool(deps: ExecuteRestOperationDeps = 
         workspaceId: getRequestContext()?.user?.activeOrganizationId ?? "default",
         datasourceId: datasource.id,
         writeAllowlist: datasource.writeAllowlist,
+        ...(datasource.sideEffectingOperations !== undefined
+          ? { sideEffectingOperations: datasource.sideEffectingOperations }
+          : {}),
         dispatch: !isWrite,
         ...(datasource.rateLimitPerMinute !== undefined
           ? { rateLimitPerMinute: datasource.rateLimitPerMinute }

--- a/packages/api/src/lib/tools/rest-operation.ts
+++ b/packages/api/src/lib/tools/rest-operation.ts
@@ -63,7 +63,7 @@ Use executeRestOperation to call a single operation on a connected REST API (des
 - When more than one REST datasource is connected, pass \`datasourceId\` (shown in each datasource's header) to pick which one
 - Compose the filter \`query\` value yourself in the documented \`field[op]:value\` syntax — do NOT invent a bracketed form
 - For multi-step questions, call this tool once per step and feed each result into the next (e.g. find a person, then list their note targets, then fetch each note)
-- GET operations execute and return data immediately — UNLESS the datasource's admin marked a specific GET as side-effecting. Some legacy/internal APIs mutate via GET (e.g. \`GET /jobs/{id}/cancel\`); a flagged GET is treated exactly like a write — it needs allowlisting and is staged for confirmation, never run silently.
+- GET operations execute and return data immediately — UNLESS that GET is flagged side-effecting (by the datasource's spec or its admin config). Some legacy/internal APIs mutate via GET (e.g. \`GET /jobs/{id}/cancel\`); a flagged GET is treated exactly like a write — it needs allowlisting and is staged for confirmation, never run silently.
 - Write operations (POST/PATCH/PUT/DELETE) only run if the datasource's admin has allowlisted them. A non-allowlisted write returns \`writes_disabled\` — tell the user writes are off for that datasource; never claim it happened.
 - An allowlisted write does NOT run immediately: it returns \`needs_confirmation\`. Tell the user plainly what the write will do (e.g. "This will permanently delete 3 people in Twenty — confirm?") and STOP. The user confirms via the banner; do not retry, and never claim the write succeeded until you see a confirmed result.`;
 
@@ -182,10 +182,11 @@ export function createExecuteRestOperationTool(deps: ExecuteRestOperationDeps = 
   return tool({
     description:
       "Call a single operation on a connected REST datasource by operationId. GET operations " +
-      "execute and return data immediately, UNLESS the admin marked a GET as side-effecting (some " +
-      "legacy APIs mutate via GET) — those, like write operations (POST/PATCH/PUT/DELETE), run only " +
-      "if allowlisted, and an allowlisted write / side-effecting GET is staged for the user to " +
-      "confirm before it fires (never claim a write happened until confirmed).",
+      "execute and return data immediately, UNLESS a GET is flagged side-effecting — by the " +
+      "datasource's spec or its admin config (some legacy APIs mutate via GET). Those, like write " +
+      "operations (POST/PATCH/PUT/DELETE), run only if allowlisted, and an allowlisted write / " +
+      "side-effecting GET is staged for the user to confirm before it fires (never claim a write " +
+      "happened until confirmed).",
     inputSchema: ExecuteRestOperationInput,
     execute: async ({ operationId, datasourceId, pathParams, query, header, body }): Promise<ExecuteRestOperationResult> => {
       let datasources: ReadonlyArray<RestDatasource>;
@@ -266,9 +267,7 @@ export function createExecuteRestOperationTool(deps: ExecuteRestOperationDeps = 
         workspaceId: getRequestContext()?.user?.activeOrganizationId ?? "default",
         datasourceId: datasource.id,
         writeAllowlist: datasource.writeAllowlist,
-        ...(datasource.sideEffectingOperations !== undefined
-          ? { sideEffectingOperations: datasource.sideEffectingOperations }
-          : {}),
+        sideEffectingOperations: datasource.sideEffectingOperations,
         dispatch: !isWrite,
         ...(datasource.rateLimitPerMinute !== undefined
           ? { rateLimitPerMinute: datasource.rateLimitPerMinute }


### PR DESCRIPTION
## What & why

Closes #3008 (MED-severity security gap, surfaced by the v0.0.2 global review).

Write/read classification was **method-only**: `isWriteMethod` treated every GET/HEAD as an unconditional read needing no allowlist and no confirm. A **mutating RPC-over-GET** (`GET /admin/resetPassword`, `GET /jobs/{id}/cancel`) — common in the internal/legacy services this milestone explicitly targets — executed immediately with the write-safety boundary silently absent.

## Approach

Make method→read/write a **default, not ground truth**. A GET/HEAD can be marked side-effecting two ways, both forcing it through the **same write allowlist + confirm-before-write path** as a POST:

1. **`x-atlas-side-effecting: true`** operation-level spec extension — parsed at the single parse boundary (`spec.ts`) onto `Operation.sideEffecting`. It's now the one vendor extension `buildOperationGraph` reads; all other `x-*` keys stay ignored. Only an explicit `true` escalates — it can never *downgrade* a write method to a read.
2. **`side_effecting_operations`** install-config list (openapi-generic config schema) — a JSON array of operationIds, normalized fail-closed (same parser shape as `write_allowlist`), threaded `RestDatasource` → `RestOperationPolicy.sideEffectingOperations`.

New `isSideEffectingOperation(op, set)` combines the three signals (method OR spec-flag OR config-list). It is **monotonic**: an override can only *add* safety (escalate a read to a write), never strip it.

Wired into **both** write-gate sites:
- the `executeRestOperation` tool (stages the flagged GET for confirmation, `dispatch:false` so quota isn't burned),
- the `/rest-operations/confirm` route (re-gates the replay against the config list too — closing a bypass where a direct confirm POST for a config-flagged GET would skip the allowlist).

GET=read is documented as an **operator-validated security boundary**: tool description, the `side_effecting_operations` config-field help ("SECURITY: …you MUST list it here"), and module JSDoc.

## Acceptance criteria
- [x] Method→read/write is a default, not ground truth (extension AND/OR config list force allowlist + confirm)
- [x] GET=read documented prominently as a security boundary the operator must validate
- [x] Test: a side-effecting GET (via extension AND via config) requires allowlist + confirm; an unmarked GET stays a read (no regression)

## Tests
- `validate-rest-operation.side-effecting.test.ts` (new) — `isSideEffectingOperation` unit + validator-level allowlist/confirm behavior for both flag paths; unmarked-GET regression.
- `spec.side-effecting.test.ts` (new) — `x-atlas-side-effecting` parsed onto `Operation.sideEffecting` (true / absent / explicit-false).
- Migration `0108` `config_schema` kept in lockstep with `OPENAPI_GENERIC_CONFIG_SCHEMA` (catalog-seed alignment test).

## Checks
`bun run type` ✅ · `bun run lint` ✅ · affected suite **117/117 files pass** ✅ · drift gates (test-discipline, schema-drift, ee-imports, twenty-resolver) ✅

## Coordination
Per the issue: touches `rest-operation.ts:290-298` (tool description) — a different region than #3006's execute-call-site guard, so it rebases cleanly. The forced-confirm path reuses the existing #3007 confirm flow (no contract change).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3015"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782746841&installation_id=135337507&pr_number=3015&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3015&signature=0863f23942a4439e298824a9f46e314063a3bfe55a7782a6f0a6dd8b28f4d1bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GET/HEAD operations can be flagged as side-effecting; such operations are treated like writes and require confirmation plus write-allowlist validation.
  * Admin install config can list side-effecting operationIds to enforce the same behavior.

* **Documentation**
  * Docs updated to describe Side-effecting GETs and the new install config field.

* **Tests**
  * Extensive tests added for detection, parsing, validation, and confirm/replay behavior.

* **Chores**
  * Database seed updated to include the new config schema field.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AtlasDevHQ/atlas/pull/3015?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->