### PR TITLE
fix(openapi): bind & single-use the REST confirm endpoint (#3007)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -300,6 +300,7 @@ ATLAS_ADMIN_EMAIL=admin@useatlas.dev
 # every allowlisted write requires an in-chat confirm-before-write step before it
 # fires. Configure the allowlist per-install in Admin → Connections.
 # ATLAS_OPENAPI_TIMEOUT=30000                 # Global OpenAPI per-request timeout CAP in ms — bounds both spec probes and operation execution; a per-install timeout above this is rejected (default: 30s)
+# ATLAS_OPENAPI_CONFIRM_TTL_SECONDS=600       # Lifetime of the single-use confirm-before-write token (#3007) — how long a staged REST write stays confirmable before it must be re-staged. Clamped [60, 3600] (default: 600 = 10m). Signed with the encryption keyset (ATLAS_ENCRYPTION_KEYS / ATLAS_ENCRYPTION_KEY / BETTER_AUTH_SECRET) — no separate signing secret
 #
 # SSRF egress guard (#3006): host-side spec probes AND operation execution are
 # blocked from reaching private / loopback / link-local / CGNAT IPs and internal

--- a/apps/docs/content/docs/plugins/datasources/openapi-generic.mdx
+++ b/apps/docs/content/docs/plugins/datasources/openapi-generic.mdx
@@ -47,6 +47,8 @@ When the agent decides to call an allowlisted write, `executeRestOperation` does
 
 The write fires only when the user clicks **Confirm write** — the request is POSTed to `/api/v1/rest-operations/confirm`, which re-validates the operation against the allowlist server-side before executing. The agent cannot self-confirm, and a non-allowlisted operation is refused at the confirm endpoint too (defense in depth). **Cancel** leaves the write un-run.
 
+The staged write carries a short-lived, server-signed, **single-use** confirm token binding it to that exact `(workspace, datasource, operation, parameters)`. The confirm endpoint verifies the token and **burns it** — so the human-in-the-loop step is enforced server-side, not just in the UI: a replayed, tampered, expired, or foreign-workspace confirm is rejected, and the same approval can never fire a second write. If a confirmation expires before the user acts, ask the agent to retry so it re-stages a fresh one. The token lifetime defaults to 10 minutes (`ATLAS_OPENAPI_CONFIRM_TTL_SECONDS`).
+
 <Callout type="warn">
 Prompting a write that is **not** allowlisted (e.g. "delete every Person") returns `writes_disabled` — the request never fires, and the agent is told not to claim it happened. Add the operation to `write_allowlist` to enable it.
 </Callout>

--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -9346,11 +9346,16 @@
                       ]
                     }
                   },
-                  "body": {}
+                  "body": {},
+                  "token": {
+                    "type": "string",
+                    "minLength": 1
+                  }
                 },
                 "required": [
                   "datasourceId",
-                  "operationId"
+                  "operationId",
+                  "token"
                 ]
               }
             }
@@ -9388,7 +9393,7 @@
             }
           },
           "400": {
-            "description": "Invalid request / no active workspace",
+            "description": "Invalid request / no active workspace / missing-invalid-expired-replayed confirm token / not a write",
             "content": {
               "application/json": {
                 "schema": {

--- a/packages/api/src/api/routes/__tests__/rest-operations.test.ts
+++ b/packages/api/src/api/routes/__tests__/rest-operations.test.ts
@@ -1,15 +1,21 @@
 /**
  * Route tests for POST /api/v1/rest-operations/confirm — the confirm-before-write
- * execution point (PRD #2868 slice 5, #2929).
+ * execution point (PRD #2868 slice 5, #2929; single-use token gate #3007).
  *
  * Mirrors validate-sql.test.ts's isolation: a minimal Hono app with only this
  * route mounted, the auth middleware mocked to an authenticated workspace user,
  * and the datasource resolver injected via the route factory (no DB) pointing at
  * the live Twenty mock server (real executeOperation path).
  *
- * The security contract under test: the endpoint is NOT a trusted fast-path — it
- * re-runs validateRestOperation, so a confirm payload for a non-allowlisted op is
- * refused with 403 and no upstream write fires.
+ * The security contract under test (#3007 — Path A, enforce):
+ *   - The endpoint is NOT a trusted fast-path — it re-runs validateRestOperation,
+ *     so a confirm payload for a non-allowlisted op is refused with 403 and no
+ *     upstream write fires.
+ *   - The staged write carries a server-signed, single-use confirm token binding
+ *     (workspace, datasource, operation, canonical params, nonce, exp). The
+ *     endpoint requires it, verifies it matches THIS re-resolved request, and
+ *     BURNS the nonce — so a missing / tampered / expired / replayed token is
+ *     rejected and the human-in-the-loop guarantee is server-verifiable.
  */
 import {
   describe,
@@ -24,6 +30,7 @@ import {
 import * as fs from "fs";
 import * as path from "path";
 import type { AuthResult } from "@atlas/api/lib/auth/types";
+import type { RestWriteConfirmRequest } from "@atlas/api/lib/openapi/rest-write-confirm";
 
 // --- Mocks (mirrors validate-sql.test.ts) ---
 
@@ -68,6 +75,9 @@ const { Hono } = await import("hono");
 const { buildOperationGraph } = await import("@atlas/api/lib/openapi/spec");
 const { createRestOperationsRoute } = await import("../rest-operations");
 const { _resetRestRateLimits } = await import("@atlas/api/lib/openapi/validate-rest-operation");
+const { mintRestConfirmToken, confirmRequestToParams, _resetRestConfirmNonces } = await import(
+  "@atlas/api/lib/openapi/rest-write-confirm"
+);
 const { startTwentyMockServer } = await import(
   "@atlas/api/lib/openapi/__tests__/twenty-acceptance/mock-server"
 );
@@ -88,19 +98,26 @@ let twentyMock: TwentyMock;
 // blocks by default. A local test server is the "internal service" case the
 // operator opt-out exists for — enable it for this file and restore it after.
 const ORIGINAL_EGRESS_FLAG = process.env.ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS;
+// The confirm token (#3007) is HMAC-signed with the resolved encryption keyset.
+// Set a signing secret so mint/verify use a real key — restored after.
+const ORIGINAL_AUTH_SECRET = process.env.BETTER_AUTH_SECRET;
 
 beforeAll(async () => {
   process.env.ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS = "true";
+  process.env.BETTER_AUTH_SECRET = "test-confirm-token-signing-secret-not-a-real-key";
   twentyMock = await startTwentyMockServer();
 });
 afterAll(async () => {
   if (ORIGINAL_EGRESS_FLAG === undefined) delete process.env.ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS;
   else process.env.ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS = ORIGINAL_EGRESS_FLAG;
+  if (ORIGINAL_AUTH_SECRET === undefined) delete process.env.BETTER_AUTH_SECRET;
+  else process.env.BETTER_AUTH_SECRET = ORIGINAL_AUTH_SECRET;
   await twentyMock.close();
 });
 beforeEach(() => {
   twentyMock.reset();
   _resetRestRateLimits();
+  _resetRestConfirmNonces();
 });
 
 /** A workspace-resolved Twenty datasource with a configurable write allowlist. */
@@ -131,6 +148,38 @@ function appWithResolver(resolveDatasources: (workspaceId: string) => Promise<Re
   return app;
 }
 
+type ConfirmInput = {
+  datasourceId: string;
+  operationId: string;
+  pathParams?: Record<string, string | number | boolean>;
+  query?: Record<string, string | number | boolean | Array<string | number | boolean>>;
+  header?: Record<string, string | number | boolean>;
+  body?: unknown;
+};
+
+/**
+ * Build a confirm POST body with a freshly-minted, binding-matching token for the
+ * authenticated workspace (ws-1) — the realistic staged-write shape. Pass
+ * `opts.token` to substitute a tampered / foreign / pre-minted token; pass
+ * `opts.omitToken` to drop it entirely (missing-token rejection).
+ */
+function confirmBody(
+  input: ConfirmInput,
+  opts: { token?: string; omitToken?: boolean } = {},
+): Record<string, unknown> {
+  if (opts.omitToken) return { ...input };
+  const params = confirmRequestToParams(input as RestWriteConfirmRequest);
+  const token =
+    opts.token ??
+    mintRestConfirmToken({
+      workspaceId: "ws-1",
+      datasourceId: input.datasourceId,
+      operationId: input.operationId,
+      params,
+    });
+  return { ...input, token };
+}
+
 async function post(app: ReturnType<typeof appWith>, body: unknown): Promise<Response> {
   return app.request("/api/v1/rest-operations/confirm", {
     method: "POST",
@@ -142,11 +191,14 @@ async function post(app: ReturnType<typeof appWith>, body: unknown): Promise<Res
 describe("POST /rest-operations/confirm", () => {
   it("executes a confirmed, ALLOWLISTED write and dispatches it upstream", async () => {
     const app = appWith([datasource({ writeAllowlist: new Set(["createOnePerson"]) })]);
-    const res = await post(app, {
-      datasourceId: "twenty",
-      operationId: "createOnePerson",
-      body: { name: { firstName: "Ada" } },
-    });
+    const res = await post(
+      app,
+      confirmBody({
+        datasourceId: "twenty",
+        operationId: "createOnePerson",
+        body: { name: { firstName: "Ada" } },
+      }),
+    );
     expect(res.status).toBe(200);
     const json = (await res.json()) as { status: string; httpStatus: number; body: unknown };
     expect(json.status).toBe("executed");
@@ -161,11 +213,10 @@ describe("POST /rest-operations/confirm", () => {
     // Defense in depth: the banner should never let an op past the allowlist,
     // but a tampered client payload is re-checked server-side.
     const app = appWith([datasource({ writeAllowlist: new Set(["createOnePerson"]) })]);
-    const res = await post(app, {
-      datasourceId: "twenty",
-      operationId: "deleteOnePerson",
-      pathParams: { id: "p-matt" },
-    });
+    const res = await post(
+      app,
+      confirmBody({ datasourceId: "twenty", operationId: "deleteOnePerson", pathParams: { id: "p-matt" } }),
+    );
     expect(res.status).toBe(403);
     const json = (await res.json()) as { error: string };
     expect(json.error).toBe("writes_disabled");
@@ -179,7 +230,7 @@ describe("POST /rest-operations/confirm", () => {
     // `sideEffectingOperations` onto the policy itself. Drop that wiring and this GET
     // slips through as an unconfirmed read — this test is the regression guard.
     const app = appWith([datasource({ sideEffectingOperations: new Set(["findManyPeople"]) })]);
-    const res = await post(app, { datasourceId: "twenty", operationId: "findManyPeople" });
+    const res = await post(app, confirmBody({ datasourceId: "twenty", operationId: "findManyPeople" }));
     expect(res.status).toBe(403);
     expect(((await res.json()) as { error: string }).error).toBe("writes_disabled");
     // Rejected before dispatch — nothing reached the upstream.
@@ -195,7 +246,7 @@ describe("POST /rest-operations/confirm", () => {
         sideEffectingOperations: new Set(["findManyPeople"]),
       }),
     ]);
-    const res = await post(app, { datasourceId: "twenty", operationId: "findManyPeople" });
+    const res = await post(app, confirmBody({ datasourceId: "twenty", operationId: "findManyPeople" }));
     expect(res.status).toBe(200);
     expect(((await res.json()) as { status: string }).status).toBe("executed");
     // The GET really reached the upstream (the re-gate allowed it through).
@@ -208,7 +259,7 @@ describe("POST /rest-operations/confirm", () => {
     const app = appWithResolver(async () => {
       throw new Error("pg down");
     });
-    const res = await post(app, { datasourceId: "twenty", operationId: "createOnePerson", body: {} });
+    const res = await post(app, confirmBody({ datasourceId: "twenty", operationId: "createOnePerson", body: {} }));
     expect(res.status).toBe(500);
     expect(((await res.json()) as { error: string }).error).toBe("datasource_unavailable");
     // Nothing reached the upstream — the failure is before dispatch.
@@ -217,21 +268,21 @@ describe("POST /rest-operations/confirm", () => {
 
   it("404s an unknown datasource", async () => {
     const app = appWith([datasource({ writeAllowlist: new Set(["createOnePerson"]) })]);
-    const res = await post(app, { datasourceId: "ghost", operationId: "createOnePerson", body: {} });
+    const res = await post(app, confirmBody({ datasourceId: "ghost", operationId: "createOnePerson", body: {} }));
     expect(res.status).toBe(404);
     expect(((await res.json()) as { error: string }).error).toBe("datasource_not_found");
   });
 
   it("404s an unknown operation", async () => {
     const app = appWith([datasource({ writeAllowlist: new Set(["createOnePerson"]) })]);
-    const res = await post(app, { datasourceId: "twenty", operationId: "nukeEverything", body: {} });
+    const res = await post(app, confirmBody({ datasourceId: "twenty", operationId: "nukeEverything", body: {} }));
     expect(res.status).toBe(404);
     expect(((await res.json()) as { error: string }).error).toBe("unknown_operation");
   });
 
   it("422s an allowlisted write missing its required body", async () => {
     const app = appWith([datasource({ writeAllowlist: new Set(["createOnePerson"]) })]);
-    const res = await post(app, { datasourceId: "twenty", operationId: "createOnePerson" });
+    const res = await post(app, confirmBody({ datasourceId: "twenty", operationId: "createOnePerson" }));
     expect(res.status).toBe(422);
     expect(((await res.json()) as { error: string }).error).toBe("invalid_params");
     expect(twentyMock.requests.some((r) => r.method !== "GET")).toBe(false);
@@ -241,9 +292,15 @@ describe("POST /rest-operations/confirm", () => {
     const app = appWith([
       datasource({ writeAllowlist: new Set(["createOnePerson"]), rateLimitPerMinute: 1 }),
     ]);
-    const first = await post(app, { datasourceId: "twenty", operationId: "createOnePerson", body: { name: { firstName: "A" } } });
+    const first = await post(
+      app,
+      confirmBody({ datasourceId: "twenty", operationId: "createOnePerson", body: { name: { firstName: "A" } } }),
+    );
     expect(first.status).toBe(200);
-    const second = await post(app, { datasourceId: "twenty", operationId: "createOnePerson", body: { name: { firstName: "B" } } });
+    const second = await post(
+      app,
+      confirmBody({ datasourceId: "twenty", operationId: "createOnePerson", body: { name: { firstName: "B" } } }),
+    );
     expect(second.status).toBe(429);
     expect(second.headers.get("retry-after")).not.toBeNull();
   });
@@ -254,7 +311,7 @@ describe("POST /rest-operations/confirm", () => {
     const app = appWith([
       datasource({ writeAllowlist: new Set(["createOnePerson"]), requestTimeoutMs: 120_000 }),
     ]);
-    const res = await post(app, { datasourceId: "twenty", operationId: "createOnePerson", body: {} });
+    const res = await post(app, confirmBody({ datasourceId: "twenty", operationId: "createOnePerson", body: {} }));
     expect(res.status).toBe(500);
     const json = (await res.json()) as { error: string; requestId?: string };
     expect(json.error).toBe("timeout_misconfigured");
@@ -262,11 +319,15 @@ describe("POST /rest-operations/confirm", () => {
     expect(twentyMock.requests.some((r) => r.method !== "GET")).toBe(false);
   });
 
-  it("never caches a write — a second identical confirm re-hits the upstream", async () => {
+  it("never caches a write — two SEPARATE confirmations both re-hit the upstream", async () => {
+    // Each staged write mints its own single-use token (distinct nonces), so two
+    // legitimate confirmations both dispatch. (Replaying the SAME token is rejected
+    // — that's the single-use test below; this one proves writes aren't cached.)
     const app = appWith([datasource({ writeAllowlist: new Set(["createOnePerson"]) })]);
-    const body = { datasourceId: "twenty", operationId: "createOnePerson", body: { name: { firstName: "Ada" } } };
-    expect((await post(app, body)).status).toBe(200);
-    expect((await post(app, body)).status).toBe(200);
+    const make = () =>
+      confirmBody({ datasourceId: "twenty", operationId: "createOnePerson", body: { name: { firstName: "Ada" } } });
+    expect((await post(app, make())).status).toBe(200);
+    expect((await post(app, make())).status).toBe(200);
     // Two confirms ⇒ two POSTs reached the upstream (a cache would have served the 2nd).
     const writes = twentyMock.matching("/rest/people").filter((r) => r.method === "POST");
     expect(writes.length).toBe(2);
@@ -281,5 +342,150 @@ describe("POST /rest-operations/confirm", () => {
     });
     // Hono rejects unparseable JSON before the handler — normalized envelope.
     expect([400, 422]).toContain(res.status);
+  });
+});
+
+// ── Single-use confirm token gate (#3007 — Path A, enforce) ──────────────────
+// The confirm endpoint is a server-verifiable single-use gate, not stateless UX:
+// the staged write's token binds (workspace, datasource, operation, params, nonce,
+// exp); a missing / tampered / expired / replayed token never reaches the upstream.
+describe("POST /rest-operations/confirm — single-use token gate (#3007)", () => {
+  it("REJECTS a confirm POST with no token (the request shape requires one)", async () => {
+    const app = appWith([datasource({ writeAllowlist: new Set(["createOnePerson"]) })]);
+    const res = await post(
+      app,
+      confirmBody(
+        { datasourceId: "twenty", operationId: "createOnePerson", body: { name: { firstName: "Ada" } } },
+        { omitToken: true },
+      ),
+    );
+    expect(res.status).toBe(422);
+    expect(((await res.json()) as { error: string }).error).toBe("validation_error");
+    // No write fired.
+    expect(twentyMock.requests.some((r) => r.method !== "GET")).toBe(false);
+  });
+
+  it("REJECTS a TAMPERED payload — params mutated after staging fail the binding (400, no write)", async () => {
+    // Token minted for { firstName: "Ada" }; the client then swaps in a different
+    // body. The token binds the canonical params, so the swap fails verification.
+    const app = appWith([datasource({ writeAllowlist: new Set(["createOnePerson"]) })]);
+    const token = mintRestConfirmToken({
+      workspaceId: "ws-1",
+      datasourceId: "twenty",
+      operationId: "createOnePerson",
+      params: confirmRequestToParams({
+        datasourceId: "twenty",
+        operationId: "createOnePerson",
+        body: { name: { firstName: "Ada" } },
+      } as RestWriteConfirmRequest),
+    });
+    const res = await post(app, {
+      datasourceId: "twenty",
+      operationId: "createOnePerson",
+      body: { name: { firstName: "Mallory" } }, // tampered after staging
+      token,
+    });
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { error: string }).error).toBe("confirm_token_invalid");
+    expect(twentyMock.requests.some((r) => r.method !== "GET")).toBe(false);
+  });
+
+  it("REJECTS a token with a tampered signature (400, no write)", async () => {
+    const app = appWith([datasource({ writeAllowlist: new Set(["createOnePerson"]) })]);
+    const good = mintRestConfirmToken({
+      workspaceId: "ws-1",
+      datasourceId: "twenty",
+      operationId: "createOnePerson",
+      params: confirmRequestToParams({
+        datasourceId: "twenty",
+        operationId: "createOnePerson",
+        body: {},
+      } as RestWriteConfirmRequest),
+    });
+    // Flip the last char of the signature segment.
+    const segs = good.split(".");
+    const last = segs[2];
+    segs[2] = last.slice(0, -1) + (last.endsWith("A") ? "B" : "A");
+    const res = await post(app, {
+      datasourceId: "twenty",
+      operationId: "createOnePerson",
+      body: {},
+      token: segs.join("."),
+    });
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { error: string }).error).toBe("confirm_token_invalid");
+    expect(twentyMock.requests.some((r) => r.method !== "GET")).toBe(false);
+  });
+
+  it("REJECTS an EXPIRED token (400, no write)", async () => {
+    const app = appWith([datasource({ writeAllowlist: new Set(["createOnePerson"]) })]);
+    // Mint with a far-past clock so the token is already expired by real now.
+    const expired = mintRestConfirmToken(
+      {
+        workspaceId: "ws-1",
+        datasourceId: "twenty",
+        operationId: "createOnePerson",
+        params: confirmRequestToParams({
+          datasourceId: "twenty",
+          operationId: "createOnePerson",
+          body: {},
+        } as RestWriteConfirmRequest),
+      },
+      { nowSeconds: 1_000, ttlSeconds: 60 }, // exp = 1060 (1970) — long past
+    );
+    const res = await post(app, { datasourceId: "twenty", operationId: "createOnePerson", body: {}, token: expired });
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { error: string }).error).toBe("confirm_token_invalid");
+    expect(twentyMock.requests.some((r) => r.method !== "GET")).toBe(false);
+  });
+
+  it("REJECTS a REPLAYED token — single-use: first fires, second is refused (one upstream write)", async () => {
+    const app = appWith([datasource({ writeAllowlist: new Set(["createOnePerson"]) })]);
+    const body = confirmBody({
+      datasourceId: "twenty",
+      operationId: "createOnePerson",
+      body: { name: { firstName: "Ada" } },
+    });
+    const first = await post(app, body);
+    expect(first.status).toBe(200);
+    expect(((await first.json()) as { status: string }).status).toBe("executed");
+    // Same token, second time — the nonce is burned.
+    const second = await post(app, body);
+    expect(second.status).toBe(400);
+    expect(((await second.json()) as { error: string }).error).toBe("confirm_token_invalid");
+    // Exactly ONE write reached the upstream.
+    const writes = twentyMock.matching("/rest/people").filter((r) => r.method === "POST");
+    expect(writes.length).toBe(1);
+  });
+
+  it("REJECTS a read driven through the write-only confirm endpoint (400, no dispatch)", async () => {
+    // A valid token can be minted for any binding; the endpoint still refuses a
+    // non-write — verdict.requiresConfirmation must hold. A plain GET is a read.
+    const app = appWith([datasource()]);
+    const res = await post(app, confirmBody({ datasourceId: "twenty", operationId: "findManyPeople" }));
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { error: string }).error).toBe("not_a_write");
+    // Nothing dispatched — the read was refused before any upstream call.
+    expect(twentyMock.requests.length).toBe(0);
+  });
+
+  it("REJECTS a token minted for a DIFFERENT workspace (binding mismatch, 400)", async () => {
+    // The auth middleware resolves ws-1; a token bound to ws-evil must not confirm
+    // a write here even if its op/params line up — the workspace is in the binding.
+    const app = appWith([datasource({ writeAllowlist: new Set(["createOnePerson"]) })]);
+    const foreign = mintRestConfirmToken({
+      workspaceId: "ws-evil",
+      datasourceId: "twenty",
+      operationId: "createOnePerson",
+      params: confirmRequestToParams({
+        datasourceId: "twenty",
+        operationId: "createOnePerson",
+        body: {},
+      } as RestWriteConfirmRequest),
+    });
+    const res = await post(app, { datasourceId: "twenty", operationId: "createOnePerson", body: {}, token: foreign });
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { error: string }).error).toBe("confirm_token_invalid");
+    expect(twentyMock.requests.some((r) => r.method !== "GET")).toBe(false);
   });
 });

--- a/packages/api/src/api/routes/__tests__/rest-operations.test.ts
+++ b/packages/api/src/api/routes/__tests__/rest-operations.test.ts
@@ -31,6 +31,7 @@ import * as fs from "fs";
 import * as path from "path";
 import type { AuthResult } from "@atlas/api/lib/auth/types";
 import type { RestWriteConfirmRequest } from "@atlas/api/lib/openapi/rest-write-confirm";
+import { _resetEncryptionKeyCache } from "@atlas/api/lib/db/encryption-keys";
 
 // --- Mocks (mirrors validate-sql.test.ts) ---
 
@@ -402,10 +403,13 @@ describe("POST /rest-operations/confirm — single-use token gate (#3007)", () =
         body: {},
       } as RestWriteConfirmRequest),
     });
-    // Flip the last char of the signature segment.
+    // Tamper at the BYTE level so the decoded signature is guaranteed to differ.
+    // (Flipping the last base64url char can be a no-op: the final char of a 32-byte
+    // sig carries unused low bits, so e.g. "A"↔"B" can decode to the SAME bytes.)
     const segs = good.split(".");
-    const last = segs[2];
-    segs[2] = last.slice(0, -1) + (last.endsWith("A") ? "B" : "A");
+    const sig = Buffer.from(segs[2], "base64url");
+    sig[0] ^= 0xff;
+    segs[2] = sig.toString("base64url");
     const res = await post(app, {
       datasourceId: "twenty",
       operationId: "createOnePerson",
@@ -467,6 +471,57 @@ describe("POST /rest-operations/confirm — single-use token gate (#3007)", () =
     expect(((await res.json()) as { error: string }).error).toBe("not_a_write");
     // Nothing dispatched — the read was refused before any upstream call.
     expect(twentyMock.requests.length).toBe(0);
+  });
+
+  it("is single-use under CONCURRENCY — two simultaneous replays yield one 200 + one 400, one write", async () => {
+    // The burn is a synchronous check-and-set with no `await` between verify and
+    // burn, so concurrent replays of the same token can't both reach the upstream.
+    const app = appWith([datasource({ writeAllowlist: new Set(["createOnePerson"]) })]);
+    const body = confirmBody({
+      datasourceId: "twenty",
+      operationId: "createOnePerson",
+      body: { name: { firstName: "Ada" } },
+    });
+    const [a, b] = await Promise.all([post(app, body), post(app, body)]);
+    expect([a.status, b.status].toSorted()).toEqual([200, 400]);
+    // Exactly one write reached the upstream.
+    const writes = twentyMock.matching("/rest/people").filter((r) => r.method === "POST");
+    expect(writes.length).toBe(1);
+  });
+
+  it("500s (confirm_token_unverifiable) when the server has no signing key — misconfig, not a client 400", async () => {
+    // A missing/rotated-to-empty signing key at confirm time is a SERVER fault — it
+    // surfaces as a correlated 500, never as the neutral "your confirmation is invalid"
+    // 400 (and still fail-closed: no write fires).
+    const app = appWith([datasource({ writeAllowlist: new Set(["createOnePerson"]) })]);
+    const saved = {
+      keys: process.env.ATLAS_ENCRYPTION_KEYS,
+      key: process.env.ATLAS_ENCRYPTION_KEY,
+      auth: process.env.BETTER_AUTH_SECRET,
+    };
+    delete process.env.ATLAS_ENCRYPTION_KEYS;
+    delete process.env.ATLAS_ENCRYPTION_KEY;
+    delete process.env.BETTER_AUTH_SECRET;
+    _resetEncryptionKeyCache();
+    try {
+      const res = await post(app, {
+        datasourceId: "twenty",
+        operationId: "createOnePerson",
+        body: {},
+        token: "any.nonempty.token",
+      });
+      expect(res.status).toBe(500);
+      expect(((await res.json()) as { error: string }).error).toBe("confirm_token_unverifiable");
+      expect(twentyMock.requests.some((r) => r.method !== "GET")).toBe(false);
+    } finally {
+      if (saved.keys === undefined) delete process.env.ATLAS_ENCRYPTION_KEYS;
+      else process.env.ATLAS_ENCRYPTION_KEYS = saved.keys;
+      if (saved.key === undefined) delete process.env.ATLAS_ENCRYPTION_KEY;
+      else process.env.ATLAS_ENCRYPTION_KEY = saved.key;
+      if (saved.auth === undefined) delete process.env.BETTER_AUTH_SECRET;
+      else process.env.BETTER_AUTH_SECRET = saved.auth;
+      _resetEncryptionKeyCache();
+    }
   });
 
   it("REJECTS a token minted for a DIFFERENT workspace (binding mismatch, 400)", async () => {

--- a/packages/api/src/api/routes/rest-operations.ts
+++ b/packages/api/src/api/routes/rest-operations.ts
@@ -30,7 +30,11 @@ import {
   validateRestOperation,
   type RestOperationPolicy,
 } from "@atlas/api/lib/openapi/validate-rest-operation";
-import { confirmRequestToParams } from "@atlas/api/lib/openapi/rest-write-confirm";
+import {
+  confirmRequestToParams,
+  verifyRestConfirmToken,
+  burnRestConfirmNonce,
+} from "@atlas/api/lib/openapi/rest-write-confirm";
 import { ErrorSchema } from "./shared-schemas";
 import { standardAuth, requestContext, type AuthEnv } from "./middleware";
 
@@ -45,6 +49,9 @@ const ConfirmRequestSchema = z.object({
   query: z.record(z.string(), z.union([queryScalar, z.array(queryScalar)])).optional(),
   header: z.record(z.string(), queryScalar).optional(),
   body: z.unknown().optional(),
+  // #3007: the single-use confirm token minted at staging. Required — a confirm
+  // POST without it is a malformed request (rejected by the validation hook).
+  token: z.string().min(1, "confirm token is required"),
 });
 
 const ConfirmResponseSchema = z.object({
@@ -82,7 +89,7 @@ const confirmRoute = createRoute({
       description: "Write executed (or upstream returned a non-2xx, surfaced as http_error)",
       content: { "application/json": { schema: ConfirmResponseSchema } },
     },
-    400: { description: "Invalid request / no active workspace", content: { "application/json": { schema: ErrorSchema } } },
+    400: { description: "Invalid request / no active workspace / missing-invalid-expired-replayed confirm token / not a write", content: { "application/json": { schema: ErrorSchema } } },
     401: { description: "Authentication required", content: { "application/json": { schema: z.record(z.string(), z.unknown()) } } },
     403: { description: "Forbidden — writes disabled for this operation", content: { "application/json": { schema: ErrorSchema } } },
     404: { description: "Datasource or operation not found", content: { "application/json": { schema: ErrorSchema } } },
@@ -164,6 +171,35 @@ export function createRestOperationsRoute(deps: RestOperationsDeps = {}) {
       }
 
       const params = confirmRequestToParams(input);
+
+      // #3007: the single-use confirm gate. The staged write carries a server-
+      // signed token binding (workspace, datasource, operation, canonical params,
+      // nonce, exp). Verify it matches THIS re-resolved request before anything
+      // else — a missing, forged, expired, or workspace-/op-/param-mismatched
+      // token never reaches the upstream. The replay (nonce burn) check runs just
+      // before dispatch. The specific failure reason is logged but never returned:
+      // a uniform 400 keeps an attacker from probing which check tripped.
+      const verification = verifyRestConfirmToken(input.token, {
+        workspaceId: orgId,
+        datasourceId: input.datasourceId,
+        operationId: input.operationId,
+        params,
+      });
+      if (!verification.ok) {
+        log.warn(
+          { orgId, datasource: datasource.id, operationId: input.operationId, reason: verification.reason, requestId },
+          "Confirm rejected: invalid confirm token",
+        );
+        return c.json(
+          {
+            error: "confirm_token_invalid",
+            message:
+              "This write confirmation is missing, invalid, expired, or already used. Ask Atlas to retry the write so it can be re-staged.",
+          },
+          400,
+        );
+      }
+
       const policy: RestOperationPolicy = {
         workspaceId: orgId,
         datasourceId: datasource.id,
@@ -208,6 +244,42 @@ export function createRestOperationsRoute(deps: RestOperationsDeps = {}) {
             );
             return c.json({ error: "timeout_misconfigured", message: error.message, requestId }, 500);
         }
+      }
+
+      // #3007: keep /confirm write-only. A valid token can be minted for any
+      // binding (the mint is binding-agnostic), so even a well-signed token for a
+      // plain read is refused here — the confirm gate exists to fire writes the
+      // human approved, not to be a general dispatch endpoint.
+      if (!verdict.requiresConfirmation) {
+        log.warn(
+          { orgId, datasource: datasource.id, operationId: input.operationId, requestId },
+          "Confirm rejected: operation is a read (confirm endpoint is write-only)",
+        );
+        return c.json(
+          {
+            error: "not_a_write",
+            message: `Operation "${input.operationId}" is a read — the confirm endpoint only executes writes.`,
+          },
+          400,
+        );
+      }
+
+      // #3007: burn the nonce — single-use. Synchronous, with no `await` between
+      // verifyRestConfirmToken above and here, so two concurrent replays of the
+      // same token can't both reach the upstream (the first burns it; the second
+      // sees it burned and is rejected as a replay).
+      if (!burnRestConfirmNonce(verification.nonce, verification.expSeconds)) {
+        log.warn(
+          { orgId, datasource: datasource.id, operationId: input.operationId, requestId },
+          "Confirm rejected: confirm token already used (replay)",
+        );
+        return c.json(
+          {
+            error: "confirm_token_invalid",
+            message: "This write confirmation was already used. Ask Atlas to retry the write so it can be re-staged.",
+          },
+          400,
+        );
       }
 
       // Execute the confirmed write via the un-cached primitive (writes are

--- a/packages/api/src/api/routes/rest-operations.ts
+++ b/packages/api/src/api/routes/rest-operations.ts
@@ -186,6 +186,29 @@ export function createRestOperationsRoute(deps: RestOperationsDeps = {}) {
         params,
       });
       if (!verification.ok) {
+        // `no-key` is a server/operator misconfiguration (no signing key configured),
+        // not an attacker-probeable token failure — surface it as a correlated 500,
+        // not the neutral client 400. (Near-unreachable in practice: mint fails loud
+        // on no-key, so a confirmable write can't have been staged without a key —
+        // reachable only if the key is removed/rotated-to-empty between stage+confirm.)
+        if (verification.reason === "no-key") {
+          log.error(
+            { orgId, datasource: datasource.id, operationId: input.operationId, requestId },
+            "Confirm rejected: no signing key configured for confirm tokens (server misconfiguration)",
+          );
+          return c.json(
+            {
+              error: "confirm_token_unverifiable",
+              message:
+                "The server can't verify write confirmations right now — its confirm-token signing key isn't configured. This is a server configuration issue, not a problem with your request.",
+              requestId,
+            },
+            500,
+          );
+        }
+        // Every attacker-probeable reason (missing / malformed / bad-signature /
+        // binding-mismatch / expired) maps to ONE neutral 400 — the specific reason
+        // is logged server-side but never returned, so it can't be probed.
         log.warn(
           { orgId, datasource: datasource.id, operationId: input.operationId, reason: verification.reason, requestId },
           "Confirm rejected: invalid confirm token",
@@ -243,6 +266,19 @@ export function createRestOperationsRoute(deps: RestOperationsDeps = {}) {
               "Confirm rejected: per-install request timeout is misconfigured (outside the cap)",
             );
             return c.json({ error: "timeout_misconfigured", message: error.message, requestId }, 500);
+          default: {
+            // Fail closed: a future RestValidationReason that isn't handled here must
+            // NOT fall through toward dispatch on this security boundary.
+            const _exhaustive: never = error.reason;
+            log.error(
+              { orgId, datasource: datasource.id, operationId: input.operationId, requestId, reason: String(_exhaustive) },
+              "Confirm rejected: unhandled validation reason (fail-closed)",
+            );
+            return c.json(
+              { error: "internal_error", message: "The write was rejected by an unhandled validation rule.", requestId },
+              500,
+            );
+          }
         }
       }
 

--- a/packages/api/src/lib/openapi/__tests__/rest-write-confirm.test.ts
+++ b/packages/api/src/lib/openapi/__tests__/rest-write-confirm.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Unit tests for the single-use confirm token primitives (#3007) in
+ * `rest-write-confirm.ts`: mint → verify round-trip, tamper / expiry / binding
+ * rejection, canonical-param order-independence, the single-use nonce burn, and
+ * the fail-loud no-signing-key path.
+ *
+ * The route tests (`api/routes/__tests__/rest-operations.test.ts`) cover the
+ * end-to-end HTTP contract; these isolate the crypto core so a regression in the
+ * binding/canonicalization shows up here, close to the cause.
+ */
+import { describe, it, expect, beforeAll, afterAll } from "bun:test";
+
+import {
+  mintRestConfirmToken,
+  verifyRestConfirmToken,
+  burnRestConfirmNonce,
+  _resetRestConfirmNonces,
+  type RestConfirmBinding,
+} from "@atlas/api/lib/openapi/rest-write-confirm";
+import { _resetEncryptionKeyCache } from "@atlas/api/lib/db/encryption-keys";
+
+const SECRET = "test-confirm-token-signing-secret-not-a-real-key";
+
+const ORIGINAL = {
+  keys: process.env.ATLAS_ENCRYPTION_KEYS,
+  key: process.env.ATLAS_ENCRYPTION_KEY,
+  auth: process.env.BETTER_AUTH_SECRET,
+};
+
+function clearKeyEnv() {
+  delete process.env.ATLAS_ENCRYPTION_KEYS;
+  delete process.env.ATLAS_ENCRYPTION_KEY;
+  delete process.env.BETTER_AUTH_SECRET;
+  _resetEncryptionKeyCache();
+}
+
+function restoreKeyEnv() {
+  if (ORIGINAL.keys === undefined) delete process.env.ATLAS_ENCRYPTION_KEYS;
+  else process.env.ATLAS_ENCRYPTION_KEYS = ORIGINAL.keys;
+  if (ORIGINAL.key === undefined) delete process.env.ATLAS_ENCRYPTION_KEY;
+  else process.env.ATLAS_ENCRYPTION_KEY = ORIGINAL.key;
+  if (ORIGINAL.auth === undefined) delete process.env.BETTER_AUTH_SECRET;
+  else process.env.BETTER_AUTH_SECRET = ORIGINAL.auth;
+  _resetEncryptionKeyCache();
+}
+
+const binding = (overrides: Partial<RestConfirmBinding> = {}): RestConfirmBinding => ({
+  workspaceId: "ws-1",
+  datasourceId: "twenty",
+  operationId: "createOnePerson",
+  params: { body: { name: { firstName: "Ada", lastName: "Lovelace" } } },
+  ...overrides,
+});
+
+describe("rest confirm token — mint/verify", () => {
+  beforeAll(() => {
+    clearKeyEnv();
+    process.env.BETTER_AUTH_SECRET = SECRET;
+    _resetEncryptionKeyCache();
+  });
+  afterAll(() => {
+    restoreKeyEnv();
+    _resetRestConfirmNonces();
+  });
+
+  it("round-trips a freshly minted token", () => {
+    const b = binding();
+    const token = mintRestConfirmToken(b);
+    const v = verifyRestConfirmToken(token, b);
+    expect(v.ok).toBe(true);
+    if (!v.ok) return;
+    expect(typeof v.nonce).toBe("string");
+    expect(v.nonce.length).toBeGreaterThan(0);
+    expect(v.expSeconds).toBeGreaterThan(Math.floor(Date.now() / 1000));
+  });
+
+  it("binds params by canonical hash — key order does NOT matter", () => {
+    // Mint over one key order; verify against the SAME logical params in a
+    // different insertion order. JSON key order isn't guaranteed to round-trip,
+    // so canonicalization must make these equal — else legit confirms get rejected.
+    const token = mintRestConfirmToken(
+      binding({ params: { body: { a: 1, b: 2, nested: { x: 1, y: 2 } } } }),
+    );
+    const v = verifyRestConfirmToken(token, binding({ params: { body: { nested: { y: 2, x: 1 }, b: 2, a: 1 } } }));
+    expect(v.ok).toBe(true);
+  });
+
+  it("rejects a token whose params were tampered after minting (binding-mismatch)", () => {
+    const token = mintRestConfirmToken(binding({ params: { body: { amount: 10 } } }));
+    const v = verifyRestConfirmToken(token, binding({ params: { body: { amount: 1_000_000 } } }));
+    expect(v).toEqual({ ok: false, reason: "binding-mismatch" });
+  });
+
+  it.each([
+    ["workspaceId", binding({ workspaceId: "ws-evil" })],
+    ["datasourceId", binding({ datasourceId: "stripe" })],
+    ["operationId", binding({ operationId: "deleteOnePerson" })],
+  ])("rejects a token minted for a different %s (binding-mismatch)", (_dim, expected) => {
+    const token = mintRestConfirmToken(binding());
+    const v = verifyRestConfirmToken(token, expected);
+    expect(v).toEqual({ ok: false, reason: "binding-mismatch" });
+  });
+
+  it("rejects a token with a tampered signature (bad-signature)", () => {
+    const token = mintRestConfirmToken(binding());
+    const segs = token.split(".");
+    segs[2] = segs[2].slice(0, -1) + (segs[2].endsWith("A") ? "B" : "A");
+    expect(verifyRestConfirmToken(segs.join("."), binding())).toEqual({ ok: false, reason: "bad-signature" });
+  });
+
+  it("rejects a tampered payload segment (signature no longer matches)", () => {
+    const token = mintRestConfirmToken(binding());
+    const segs = token.split(".");
+    // Re-encode a payload claiming a different workspace; the signature was over
+    // the original payload bytes, so it can't validate.
+    segs[1] = Buffer.from(JSON.stringify({ w: "ws-evil", ds: "twenty", op: "x", ph: "0", n: "z", exp: 9e9 })).toString(
+      "base64url",
+    );
+    expect(verifyRestConfirmToken(segs.join("."), binding()).ok).toBe(false);
+  });
+
+  it("rejects a malformed (non-three-part) token", () => {
+    expect(verifyRestConfirmToken("not-a-token", binding())).toEqual({ ok: false, reason: "malformed" });
+  });
+
+  it("rejects an empty token as missing", () => {
+    expect(verifyRestConfirmToken("", binding())).toEqual({ ok: false, reason: "missing" });
+  });
+
+  it("rejects an expired token", () => {
+    const token = mintRestConfirmToken(binding(), { nowSeconds: 1_000, ttlSeconds: 60 }); // exp = 1060
+    expect(verifyRestConfirmToken(token, binding(), 2_000)).toEqual({ ok: false, reason: "expired" });
+    // …and valid just before expiry.
+    expect(verifyRestConfirmToken(token, binding(), 1_059).ok).toBe(true);
+  });
+});
+
+describe("rest confirm nonce — single-use store", () => {
+  beforeAll(() => _resetRestConfirmNonces());
+  afterAll(() => _resetRestConfirmNonces());
+
+  it("burns a nonce exactly once (replay returns false)", () => {
+    _resetRestConfirmNonces();
+    const exp = Math.floor(Date.now() / 1000) + 600;
+    expect(burnRestConfirmNonce("nonce-A", exp)).toBe(true);
+    expect(burnRestConfirmNonce("nonce-A", exp)).toBe(false); // replay
+    expect(burnRestConfirmNonce("nonce-B", exp)).toBe(true); // a different nonce is independent
+  });
+
+  it("evicts an expired burned nonce so its slot is reclaimed", () => {
+    _resetRestConfirmNonces();
+    // Burn a nonce that expires at t=1000; at a later 'now' the eviction sweep drops
+    // it. (A token with that nonce would already be rejected by the expiry check.)
+    expect(burnRestConfirmNonce("ephemeral", 1_000, 900)).toBe(true);
+    // Re-burning the same nonce at a 'now' past its exp succeeds — it was evicted.
+    expect(burnRestConfirmNonce("ephemeral", 5_000, 2_000)).toBe(true);
+  });
+});
+
+describe("rest confirm token — no signing key (fail loud)", () => {
+  beforeAll(() => clearKeyEnv());
+  afterAll(() => restoreKeyEnv());
+
+  it("mint throws (the confirm gate can't degrade to an unsigned token)", () => {
+    expect(() => mintRestConfirmToken(binding())).toThrow(/no signing key configured/);
+  });
+
+  it("verify rejects with no-key (never validates without a key)", () => {
+    expect(verifyRestConfirmToken("a.b.c", binding())).toEqual({ ok: false, reason: "no-key" });
+  });
+});

--- a/packages/api/src/lib/openapi/__tests__/rest-write-confirm.test.ts
+++ b/packages/api/src/lib/openapi/__tests__/rest-write-confirm.test.ts
@@ -85,6 +85,44 @@ describe("rest confirm token — mint/verify", () => {
     expect(v.ok).toBe(true);
   });
 
+  it("canonical hash is order-independent across ALL param buckets (path/query/header/body)", () => {
+    // A real banner re-serializing the whole RestWriteConfirmRequest can reorder
+    // keys in any bucket; canonicalize must make all of them equal, else a legit
+    // confirm false-rejects.
+    const token = mintRestConfirmToken(
+      binding({
+        params: {
+          path: { id: "p-1", org: "o-1" },
+          query: { filter: "x", limit: 10 },
+          header: { "X-A": "1", "X-B": "2" },
+          body: { a: 1, b: 2 },
+        },
+      }),
+    );
+    const v = verifyRestConfirmToken(
+      token,
+      binding({
+        params: {
+          body: { b: 2, a: 1 },
+          header: { "X-B": "2", "X-A": "1" },
+          query: { limit: 10, filter: "x" },
+          path: { org: "o-1", id: "p-1" },
+        },
+      }),
+    );
+    expect(v.ok).toBe(true);
+  });
+
+  it("query ARRAY values are order-significant (reordering them changes the binding)", () => {
+    const token = mintRestConfirmToken(binding({ params: { query: { ids: ["a", "b", "c"] } } }));
+    expect(verifyRestConfirmToken(token, binding({ params: { query: { ids: ["a", "b", "c"] } } })).ok).toBe(true);
+    // Arrays preserve order — a reordered array is a different request.
+    expect(verifyRestConfirmToken(token, binding({ params: { query: { ids: ["c", "b", "a"] } } }))).toEqual({
+      ok: false,
+      reason: "binding-mismatch",
+    });
+  });
+
   it("rejects a token whose params were tampered after minting (binding-mismatch)", () => {
     const token = mintRestConfirmToken(binding({ params: { body: { amount: 10 } } }));
     const v = verifyRestConfirmToken(token, binding({ params: { body: { amount: 1_000_000 } } }));
@@ -104,7 +142,12 @@ describe("rest confirm token — mint/verify", () => {
   it("rejects a token with a tampered signature (bad-signature)", () => {
     const token = mintRestConfirmToken(binding());
     const segs = token.split(".");
-    segs[2] = segs[2].slice(0, -1) + (segs[2].endsWith("A") ? "B" : "A");
+    // Tamper at the BYTE level — flipping the last base64url char can be a no-op
+    // (the final char of a 32-byte sig carries unused low bits), which would let a
+    // forged token verify; XORing a decoded byte is guaranteed to differ.
+    const sig = Buffer.from(segs[2], "base64url");
+    sig[0] ^= 0xff;
+    segs[2] = sig.toString("base64url");
     expect(verifyRestConfirmToken(segs.join("."), binding())).toEqual({ ok: false, reason: "bad-signature" });
   });
 
@@ -167,5 +210,25 @@ describe("rest confirm token — no signing key (fail loud)", () => {
 
   it("verify rejects with no-key (never validates without a key)", () => {
     expect(verifyRestConfirmToken("a.b.c", binding())).toEqual({ ok: false, reason: "no-key" });
+  });
+});
+
+describe("rest confirm token — key rotation (unknown kid)", () => {
+  beforeAll(() => {
+    clearKeyEnv();
+    process.env.ATLAS_ENCRYPTION_KEYS = "v2:rotation-key-two,v1:rotation-key-one";
+    _resetEncryptionKeyCache();
+  });
+  afterAll(() => restoreKeyEnv());
+
+  it("rejects a token signed by a key that's since been rotated out (bad-signature)", () => {
+    // Minted under the active key (v2)…
+    const token = mintRestConfirmToken(binding());
+    expect(verifyRestConfirmToken(token, binding()).ok).toBe(true);
+    // …operator rotates v2 out (only v1 remains). The token's kid=2 is now unknown,
+    // so verify can't reconstruct the signing key — rejected, never silently re-keyed.
+    process.env.ATLAS_ENCRYPTION_KEYS = "v1:rotation-key-one";
+    _resetEncryptionKeyCache();
+    expect(verifyRestConfirmToken(token, binding())).toEqual({ ok: false, reason: "bad-signature" });
   });
 });

--- a/packages/api/src/lib/openapi/rest-write-confirm.ts
+++ b/packages/api/src/lib/openapi/rest-write-confirm.ts
@@ -1,10 +1,11 @@
 /**
  * Shared contract for the REST confirm-before-write flow (PRD #2868 slice 5,
- * #2929). When the agent stages an allowlisted write, `executeRestOperation`
- * returns a `needs_confirmation` result carrying a {@link RestWriteConfirmRequest}
- * — the exact replay payload the chat surface's confirm-before-write banner POSTs
- * to `POST /api/v1/rest-operations/confirm`. The write fires there, after the
- * human confirms, never silently in the agent loop.
+ * #2929; single-use token gate #3007). When the agent stages an allowlisted
+ * write, `executeRestOperation` returns a `needs_confirmation` result carrying a
+ * {@link RestWriteConfirmRequest} — the exact replay payload the chat surface's
+ * confirm-before-write banner POSTs to `POST /api/v1/rest-operations/confirm`.
+ * The write fires there, after the human confirms, never silently in the agent
+ * loop.
  *
  * This module is the single source of truth for that wire shape + the
  * human-facing summary, so the staging tool and the confirming endpoint can't
@@ -12,8 +13,36 @@
  * against the resolved datasource — the confirm endpoint is NOT a trusted
  * fast-path; it re-validates the allowlist + params server-side (defense in
  * depth: a tampered client payload still can't escalate past the allowlist).
+ *
+ * ## The single-use confirm token (#3007)
+ *
+ * The allowlist alone makes `/confirm` a stateless at-least-once endpoint: any
+ * holder of a valid staged payload (a replayed request, an XSS/CSRF against the
+ * SPA, a looping agent) could re-fire an allowlisted write. To make the
+ * human-in-the-loop guarantee SERVER-verifiable, every staged write now carries a
+ * short-lived, server-signed, single-use {@link RestWriteConfirmRequest.token}:
+ *
+ *   - {@link mintRestConfirmToken} (staging) signs a token binding
+ *     `(workspaceId, datasourceId, operationId, canonical-params, nonce, exp)`
+ *     with the resolved encryption keyset (the same HMAC-over-`BETTER_AUTH_SECRET`
+ *     -derived keyset `oauth-state-token.ts` uses — no new signing secret).
+ *   - {@link verifyRestConfirmToken} (confirm) re-derives that binding from the
+ *     re-resolved request and rejects a missing / tampered / expired token, or
+ *     one minted for a different workspace / datasource / operation / params.
+ *   - {@link burnRestConfirmNonce} consumes the nonce so a replay of the same
+ *     token is rejected — single-use.
+ *
+ * The token is OPAQUE to the banner: it lives inside the `confirm` payload, which
+ * the banner POSTs verbatim. Mirror this field on the web-local
+ * `RestWriteConfirmRequest` (`packages/web/src/ui/lib/rest-operation-types.ts`).
  */
+import * as crypto from "crypto";
+
+import { createLogger } from "@atlas/api/lib/logger";
+import { getEncryptionKeyset } from "@atlas/api/lib/db/encryption-keys";
 import type { Operation, OperationParams } from "./types";
+
+const log = createLogger("openapi.rest-write-confirm");
 
 /** A scalar param value the agent / banner may carry (matches the tool input). */
 export type RestParamScalar = string | number | boolean;
@@ -31,6 +60,14 @@ export interface RestWriteConfirmRequest {
   readonly header?: Record<string, RestParamScalar>;
   /** JSON request body for the write. */
   readonly body?: unknown;
+  /**
+   * Server-signed, single-use confirm token (#3007) binding this exact staged
+   * write to `(workspace, datasource, operation, canonical params, nonce, exp)`.
+   * Minted by {@link mintRestConfirmToken} at staging; required + verified +
+   * burned by the confirm endpoint. Opaque to the banner — it POSTs the whole
+   * `RestWriteConfirmRequest` (including this token) verbatim.
+   */
+  readonly token: string;
 }
 
 /** Convert a {@link RestWriteConfirmRequest} into the client's {@link OperationParams}. */
@@ -55,4 +92,325 @@ export function confirmRequestToParams(req: RestWriteConfirmRequest): OperationP
 export function buildRestWriteSummary(operation: Operation, datasourceName: string): string {
   const label = operation.summary?.trim() || operation.operationId;
   return `${label} — ${operation.method} ${operation.path} on ${datasourceName}`;
+}
+
+// ─────────────────────────────────────────────────────────────────────
+//  Single-use confirm token (#3007)
+// ─────────────────────────────────────────────────────────────────────
+
+const SIG_ALGORITHM = "sha256";
+const ALG = "HS256";
+/** Domain separator (in the signed header) — a confirm token can't be cross-used as another signed-token type. */
+const TYP = "AtlasRestConfirm";
+
+/**
+ * Default confirm-token lifetime. The confirm step is interactive — the agent
+ * stages the write, the human reads the banner ("this will delete 3 people") and
+ * clicks Confirm. Ten minutes covers reasonable read/deliberate latency while
+ * keeping the replay window narrow (same interactive rationale as the OAuth state
+ * token). Override via `ATLAS_OPENAPI_CONFIRM_TTL_SECONDS`, clamped [60, 3600].
+ */
+const DEFAULT_TTL_SECONDS = 10 * 60;
+const MIN_TTL_SECONDS = 60;
+const MAX_TTL_SECONDS = 60 * 60;
+const NONCE_BYTES = 16;
+
+/** The binding a confirm token is signed over and re-verified against. */
+export interface RestConfirmBinding {
+  readonly workspaceId: string;
+  readonly datasourceId: string;
+  readonly operationId: string;
+  /** The {@link OperationParams} the write dispatches with — bound via a canonical hash. */
+  readonly params: OperationParams;
+}
+
+export interface MintRestConfirmTokenOptions {
+  /** Override the TTL in seconds (≥1). Primarily for tests; production uses the env/default. */
+  readonly ttlSeconds?: number;
+  /** Override "now" in unix seconds — tests mint expired / far-future tokens deterministically. */
+  readonly nowSeconds?: number;
+  /** Override the random nonce — tests only (forces a deterministic single-use id). */
+  readonly nonce?: string;
+}
+
+interface TokenHeader {
+  readonly alg: typeof ALG;
+  readonly kid: number;
+  readonly typ: typeof TYP;
+}
+
+interface TokenPayload {
+  /** Workspace (org) id. */
+  readonly w: string;
+  /** Datasource install id. */
+  readonly ds: string;
+  /** Operation id. */
+  readonly op: string;
+  /** sha256(canonical params) — binds the exact params without embedding them. */
+  readonly ph: string;
+  /** Single-use nonce. */
+  readonly n: string;
+  /** Expiration in unix seconds. */
+  readonly exp: number;
+}
+
+/** Why a confirm token was refused. Machine-readable for server-side logging; the route maps every arm to one neutral 400. */
+export type RestConfirmTokenRejection =
+  | "missing"
+  | "malformed"
+  | "no-key"
+  | "bad-signature"
+  | "binding-mismatch"
+  | "expired";
+
+/** The result of {@link verifyRestConfirmToken}. On success it carries the nonce + exp the caller burns. */
+export type RestConfirmTokenVerification =
+  | { readonly ok: true; readonly nonce: string; readonly expSeconds: number }
+  | { readonly ok: false; readonly reason: RestConfirmTokenRejection };
+
+/**
+ * Mint a single-use confirm token binding a staged write. Always signs with the
+ * active (highest-version) key in the resolved encryption keyset.
+ *
+ * Throws when no signing key is configured — like {@link import("../integrations/install/oauth-state-token").mintOAuthStateToken},
+ * the human-in-the-loop confirm gate must NOT degrade silently to an unsigned
+ * (forgeable) token. The caller (the staging tool) maps the throw to a structured
+ * "can't stage this write" result so the operator gates this on real key material.
+ */
+export function mintRestConfirmToken(
+  binding: RestConfirmBinding,
+  options: MintRestConfirmTokenOptions = {},
+): string {
+  const keyset = getEncryptionKeyset();
+  if (!keyset) {
+    throw new Error(
+      "mintRestConfirmToken: no signing key configured — set ATLAS_ENCRYPTION_KEYS / ATLAS_ENCRYPTION_KEY / BETTER_AUTH_SECRET. " +
+        "The confirm-before-write gate cannot fall through to an unsigned token.",
+    );
+  }
+
+  const ttl = resolveConfirmTtlSeconds(options.ttlSeconds);
+  const now = options.nowSeconds ?? Math.floor(Date.now() / 1000);
+  const exp = now + ttl;
+  const nonce = options.nonce ?? crypto.randomBytes(NONCE_BYTES).toString("base64url");
+
+  const header: TokenHeader = { alg: ALG, kid: keyset.active.version, typ: TYP };
+  const payload: TokenPayload = {
+    w: binding.workspaceId,
+    ds: binding.datasourceId,
+    op: binding.operationId,
+    ph: paramsHash(binding.params),
+    n: nonce,
+    exp,
+  };
+
+  const headerB64 = encodeJson(header);
+  const payloadB64 = encodeJson(payload);
+  const signingInput = `${headerB64}.${payloadB64}`;
+  const sig = crypto.createHmac(SIG_ALGORITHM, keyset.active.key).update(signingInput).digest();
+  return `${signingInput}.${sig.toString("base64url")}`;
+}
+
+/**
+ * Verify a confirm token against the binding re-derived from THIS confirm request.
+ * Pure — it does not touch the single-use store (the caller {@link burnRestConfirmNonce}s
+ * the returned nonce once the rest of validation passes). Returns a tagged result;
+ * the route maps every `ok: false` arm to one neutral 400 (never revealing which
+ * check tripped — that would let an attacker probe the pipeline).
+ *
+ * `nowSeconds` is injectable for deterministic expiry tests; it defaults to wall-clock.
+ */
+export function verifyRestConfirmToken(
+  token: string,
+  expected: RestConfirmBinding,
+  nowSeconds: number = Math.floor(Date.now() / 1000),
+): RestConfirmTokenVerification {
+  if (typeof token !== "string" || token.length === 0) return { ok: false, reason: "missing" };
+
+  let keyset: ReturnType<typeof getEncryptionKeyset>;
+  try {
+    keyset = getEncryptionKeyset();
+  } catch (err) {
+    // getEncryptionKeyset throws on malformed ATLAS_ENCRYPTION_KEYS (operator
+    // misconfig that should normally fail at boot). Warn once, reject all tokens.
+    log.warn(
+      { err: err instanceof Error ? err.message : String(err) },
+      "verifyRestConfirmToken: keyset resolution threw — operator misconfig; rejecting",
+    );
+    return { ok: false, reason: "no-key" };
+  }
+  if (!keyset) return { ok: false, reason: "no-key" };
+
+  const parts = token.split(".");
+  if (parts.length !== 3) return { ok: false, reason: "malformed" };
+  const [headerB64, payloadB64, sigB64] = parts;
+
+  const header = decodeJson<TokenHeader>(headerB64);
+  if (!header || header.alg !== ALG || header.typ !== TYP) return { ok: false, reason: "malformed" };
+  if (typeof header.kid !== "number" || !Number.isFinite(header.kid)) return { ok: false, reason: "malformed" };
+
+  const key = keyset.byVersion.get(header.kid);
+  // Unknown kid (key rotated out) — treat like a bad signature: we can't verify it.
+  if (!key) return { ok: false, reason: "bad-signature" };
+
+  // The signature covers the received `headerB64.payloadB64` literally, so ANY
+  // tampering of either segment fails this comparison — constant-time on the sig.
+  const expectedSig = crypto.createHmac(SIG_ALGORITHM, key).update(`${headerB64}.${payloadB64}`).digest();
+  const providedSig = Buffer.from(sigB64, "base64url");
+  if (providedSig.length !== expectedSig.length) return { ok: false, reason: "bad-signature" };
+  if (!crypto.timingSafeEqual(providedSig, expectedSig)) return { ok: false, reason: "bad-signature" };
+
+  // Signature verified ⇒ the payload is trusted. Decode + structurally check it.
+  const payload = decodeJson<TokenPayload>(payloadB64);
+  if (
+    !payload ||
+    typeof payload.w !== "string" ||
+    typeof payload.ds !== "string" ||
+    typeof payload.op !== "string" ||
+    typeof payload.ph !== "string" ||
+    typeof payload.n !== "string" ||
+    payload.n.length === 0 ||
+    typeof payload.exp !== "number" ||
+    !Number.isFinite(payload.exp)
+  ) {
+    return { ok: false, reason: "malformed" };
+  }
+
+  // Binding: the signed token must match the workspace/datasource/operation/params
+  // re-resolved for THIS confirm request. A token minted for a different binding —
+  // or a payload whose params were swapped after staging (ph diverges) — is refused.
+  if (
+    payload.w !== expected.workspaceId ||
+    payload.ds !== expected.datasourceId ||
+    payload.op !== expected.operationId ||
+    payload.ph !== paramsHash(expected.params)
+  ) {
+    return { ok: false, reason: "binding-mismatch" };
+  }
+
+  if (payload.exp <= nowSeconds) return { ok: false, reason: "expired" };
+
+  return { ok: true, nonce: payload.n, expSeconds: payload.exp };
+}
+
+// ─────────────────────────────────────────────────────────────────────
+//  Single-use nonce store (in-process)
+// ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Burned-nonce store: `nonce → exp (unix seconds)`. Only holds nonces that were
+ * actually consumed, so its size tracks confirms-in-the-last-TTL-window (human-
+ * gated, tiny). An entry is evicted once past its token's `exp` — after which the
+ * expiry check in {@link verifyRestConfirmToken} rejects the token anyway.
+ *
+ * In-process, like the rate-limit token bucket in `validate-rest-operation.ts`:
+ * the single-use guarantee is exact WITHIN a process (the check-and-set is
+ * synchronous, so two concurrent replays can't both win). Across replicas a
+ * captured token could in principle be replayed on a different instance before
+ * its short TTL — the same multi-instance caveat the rate-limit bucket documents.
+ * A process restart drops the store, which only invalidates pending confirms
+ * (fail-safe). Reset between tests via {@link _resetRestConfirmNonces}.
+ */
+const burnedNonces = new Map<string, number>();
+
+/**
+ * Atomically consume a confirm nonce. Returns `true` when it was newly burned
+ * (caller may proceed to dispatch), `false` when it was already burned (a replay —
+ * caller must reject). MUST be called synchronously with no intervening `await`
+ * between token verification and dispatch, so concurrent replays of the same token
+ * can't both pass before the nonce is recorded.
+ */
+export function burnRestConfirmNonce(
+  nonce: string,
+  expSeconds: number,
+  nowSeconds: number = Math.floor(Date.now() / 1000),
+): boolean {
+  // Opportunistic eviction of expired entries (store is small — short TTL, low
+  // volume). Deleting during Map iteration is safe.
+  for (const [n, exp] of burnedNonces) {
+    if (exp <= nowSeconds) burnedNonces.delete(n);
+  }
+  if (burnedNonces.has(nonce)) return false; // replay
+  burnedNonces.set(nonce, expSeconds);
+  return true;
+}
+
+/** Clear the burned-nonce store. For tests. */
+export function _resetRestConfirmNonces(): void {
+  burnedNonces.clear();
+}
+
+// ─────────────────────────────────────────────────────────────────────
+//  Internal helpers
+// ─────────────────────────────────────────────────────────────────────
+
+/**
+ * The effective confirm-token TTL in seconds. Per-call override (tests) takes
+ * precedence; otherwise read `ATLAS_OPENAPI_CONFIRM_TTL_SECONDS`, clamped
+ * [60, 3600], defaulting to 600. Mirrors `ATLAS_OAUTH_STATE_TTL_SECONDS`.
+ */
+function resolveConfirmTtlSeconds(override?: number): number {
+  if (override !== undefined) {
+    if (Number.isFinite(override) && override >= 1) return Math.floor(override);
+    return DEFAULT_TTL_SECONDS;
+  }
+  const raw = process.env.ATLAS_OPENAPI_CONFIRM_TTL_SECONDS;
+  if (!raw) return DEFAULT_TTL_SECONDS;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed < MIN_TTL_SECONDS || parsed > MAX_TTL_SECONDS) {
+    log.warn(
+      { ATLAS_OPENAPI_CONFIRM_TTL_SECONDS: raw, min: MIN_TTL_SECONDS, max: MAX_TTL_SECONDS },
+      "Ignoring out-of-range ATLAS_OPENAPI_CONFIRM_TTL_SECONDS — using default",
+    );
+    return DEFAULT_TTL_SECONDS;
+  }
+  return parsed;
+}
+
+/** sha256 hex of the canonicalized params — order-stable, so equal params hash equally. */
+function paramsHash(params: OperationParams): string {
+  return crypto.createHash("sha256").update(canonicalize(params)).digest("hex");
+}
+
+/**
+ * Deterministic JSON serialization: object keys sorted recursively, `undefined`
+ * object values dropped, array order preserved (query array values are
+ * order-significant). So the same logical params always produce the same string
+ * (and thus the same {@link paramsHash}), regardless of key insertion order.
+ */
+function canonicalize(value: unknown): string {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value) ?? "null";
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(canonicalize).join(",")}]`;
+  }
+  const obj = value as Record<string, unknown>;
+  const keys = Object.keys(obj)
+    .filter((k) => obj[k] !== undefined)
+    .toSorted();
+  return `{${keys.map((k) => `${JSON.stringify(k)}:${canonicalize(obj[k])}`).join(",")}}`;
+}
+
+/** base64url-encode a JSON value (native — no hand-rolled regex strip). */
+function encodeJson(value: unknown): string {
+  return Buffer.from(JSON.stringify(value), "utf8").toString("base64url");
+}
+
+/**
+ * Decode a base64url JSON segment to `T`, or `null` on any parse failure. Only
+ * called AFTER signature verification, so a tampered segment has already been
+ * rejected; this just guards against a structurally-broken (but somehow signed)
+ * payload.
+ */
+function decodeJson<T>(b64: string): T | null {
+  try {
+    const parsed = JSON.parse(Buffer.from(b64, "base64url").toString("utf8")) as T;
+    if (typeof parsed !== "object" || parsed === null) return null;
+    return parsed;
+  } catch {
+    // intentionally ignored: a malformed segment collapses to null, which the
+    // caller maps to a uniform rejection — the contract is boolean-shaped.
+    return null;
+  }
 }

--- a/packages/api/src/lib/openapi/rest-write-confirm.ts
+++ b/packages/api/src/lib/openapi/rest-write-confirm.ts
@@ -24,8 +24,9 @@
  *
  *   - {@link mintRestConfirmToken} (staging) signs a token binding
  *     `(workspaceId, datasourceId, operationId, canonical-params, nonce, exp)`
- *     with the resolved encryption keyset (the same HMAC-over-`BETTER_AUTH_SECRET`
- *     -derived keyset `oauth-state-token.ts` uses — no new signing secret).
+ *     with the resolved encryption keyset (`ATLAS_ENCRYPTION_KEYS` →
+ *     `ATLAS_ENCRYPTION_KEY` → `BETTER_AUTH_SECRET`) — the same keyset
+ *     `oauth-state-token.ts` signs with, so no new signing secret is introduced.
  *   - {@link verifyRestConfirmToken} (confirm) re-derives that binding from the
  *     re-resolved request and rejects a missing / tampered / expired token, or
  *     one minted for a different workspace / datasource / operation / params.
@@ -299,9 +300,11 @@ export function verifyRestConfirmToken(
 
 /**
  * Burned-nonce store: `nonce → exp (unix seconds)`. Only holds nonces that were
- * actually consumed, so its size tracks confirms-in-the-last-TTL-window (human-
- * gated, tiny). An entry is evicted once past its token's `exp` — after which the
- * expiry check in {@link verifyRestConfirmToken} rejects the token anyway.
+ * actually consumed (human-gated confirms — tiny). Eviction is lazy / on-write:
+ * each {@link burnRestConfirmNonce} call first drops entries past their token's
+ * `exp`, so if confirm traffic stops, already-expired entries linger until the
+ * next burn — harmless, since the expiry check in {@link verifyRestConfirmToken}
+ * rejects an expired token regardless of whether its nonce is still in the store.
  *
  * In-process, like the rate-limit token bucket in `validate-rest-operation.ts`:
  * the single-use guarantee is exact WITHIN a process (the check-and-set is

--- a/packages/api/src/lib/tools/__tests__/rest-operation.test.ts
+++ b/packages/api/src/lib/tools/__tests__/rest-operation.test.ts
@@ -29,14 +29,20 @@ let mock: TwentyMock;
 // blocks by default. A local test server is the "internal service" case the
 // operator opt-out exists for — enable it for this file and restore it after.
 const ORIGINAL_EGRESS_FLAG = process.env.ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS;
+// Staging an allowlisted write now mints a signed single-use confirm token (#3007),
+// which needs a signing key resolvable from the encryption keyset. Restore after.
+const ORIGINAL_AUTH_SECRET = process.env.BETTER_AUTH_SECRET;
 
 beforeAll(async () => {
   process.env.ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS = "true";
+  process.env.BETTER_AUTH_SECRET = "test-confirm-token-signing-secret-not-a-real-key";
   mock = await startTwentyMockServer();
 });
 afterAll(async () => {
   if (ORIGINAL_EGRESS_FLAG === undefined) delete process.env.ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS;
   else process.env.ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS = ORIGINAL_EGRESS_FLAG;
+  if (ORIGINAL_AUTH_SECRET === undefined) delete process.env.BETTER_AUTH_SECRET;
+  else process.env.BETTER_AUTH_SECRET = ORIGINAL_AUTH_SECRET;
   await mock.close();
 });
 beforeEach(() => {
@@ -231,6 +237,9 @@ describe("executeRestOperation — write-side opt-in", () => {
     expect(Object.keys(result).toSorted()).toEqual(
       ["confirm", "datasourceId", "datasourceName", "method", "operationId", "status", "summary"],
     );
+    // #3007: the staged write carries a single-use confirm token the banner forwards.
+    expect(typeof result.confirm.token).toBe("string");
+    expect(result.confirm.token.length).toBeGreaterThan(0);
   });
 
   it("blocks a write whose op is NOT in the allowlist even when others are", async () => {

--- a/packages/api/src/lib/tools/__tests__/rest-operation.test.ts
+++ b/packages/api/src/lib/tools/__tests__/rest-operation.test.ts
@@ -9,6 +9,7 @@ import {
   type ExecuteRestOperationResult,
 } from "../rest-operation";
 import { _resetRestRateLimits } from "@atlas/api/lib/openapi/validate-rest-operation";
+import { _resetEncryptionKeyCache } from "@atlas/api/lib/db/encryption-keys";
 import {
   startTwentyMockServer,
   type TwentyMock,
@@ -240,6 +241,39 @@ describe("executeRestOperation — write-side opt-in", () => {
     // #3007: the staged write carries a single-use confirm token the banner forwards.
     expect(typeof result.confirm.token).toBe("string");
     expect(result.confirm.token.length).toBeGreaterThan(0);
+  });
+
+  it("REFUSES to stage a write when no confirm-token signing key is configured (client_error, no dispatch)", async () => {
+    // Fail-loud (#3007): without a signing key the confirm gate can't be enforced,
+    // so the tool must NOT stage an unverifiable confirm — it returns client_error
+    // and tells the agent not to claim the write ran.
+    const ds = datasource({ writeAllowlist: new Set(["createOnePerson"]) });
+    const saved = {
+      keys: process.env.ATLAS_ENCRYPTION_KEYS,
+      key: process.env.ATLAS_ENCRYPTION_KEY,
+      auth: process.env.BETTER_AUTH_SECRET,
+    };
+    delete process.env.ATLAS_ENCRYPTION_KEYS;
+    delete process.env.ATLAS_ENCRYPTION_KEY;
+    delete process.env.BETTER_AUTH_SECRET;
+    _resetEncryptionKeyCache();
+    try {
+      const result = await call(
+        { operationId: "createOnePerson", body: { name: { firstName: "Ada" } } },
+        async () => ds,
+      );
+      expect(result.status).toBe("client_error");
+      // Never staged as needs_confirmation, and nothing dispatched upstream.
+      expect(mock.requests.some((r) => r.method !== "GET")).toBe(false);
+    } finally {
+      if (saved.keys === undefined) delete process.env.ATLAS_ENCRYPTION_KEYS;
+      else process.env.ATLAS_ENCRYPTION_KEYS = saved.keys;
+      if (saved.key === undefined) delete process.env.ATLAS_ENCRYPTION_KEY;
+      else process.env.ATLAS_ENCRYPTION_KEY = saved.key;
+      if (saved.auth === undefined) delete process.env.BETTER_AUTH_SECRET;
+      else process.env.BETTER_AUTH_SECRET = saved.auth;
+      _resetEncryptionKeyCache();
+    }
   });
 
   it("blocks a write whose op is NOT in the allowlist even when others are", async () => {

--- a/packages/api/src/lib/tools/rest-operation.ts
+++ b/packages/api/src/lib/tools/rest-operation.ts
@@ -311,6 +311,16 @@ export function createExecuteRestOperationTool(deps: ExecuteRestOperationDeps = 
             // A misconfigured per-install timeout is an operator concern, not an
             // agent one — surface it as a client_error so the model stops.
             return { status: "client_error", reason: "timeout", message: error.message };
+          default: {
+            // Fail closed: a future RestValidationReason that isn't handled must NOT
+            // fall through to dispatch — surface it as a client_error so the agent stops.
+            const _exhaustive: never = error.reason;
+            return {
+              status: "client_error",
+              reason: "unexpected",
+              message: `Operation "${operationId}" was rejected by an unhandled validation rule (${String(_exhaustive)}).`,
+            };
+          }
         }
       }
 

--- a/packages/api/src/lib/tools/rest-operation.ts
+++ b/packages/api/src/lib/tools/rest-operation.ts
@@ -51,6 +51,7 @@ import {
 } from "@atlas/api/lib/openapi/validate-rest-operation";
 import {
   buildRestWriteSummary,
+  mintRestConfirmToken,
   type RestWriteConfirmRequest,
 } from "@atlas/api/lib/openapi/rest-write-confirm";
 import type { OperationParams } from "@atlas/api/lib/openapi/types";
@@ -315,6 +316,33 @@ export function createExecuteRestOperationTool(deps: ExecuteRestOperationDeps = 
 
       // Allowlisted write — stage for confirm-before-write; never dispatch here.
       if (verdict.requiresConfirmation) {
+        // #3007: mint the single-use confirm token binding this exact staged write.
+        // If no signing key is configured the gate can't be enforced, so we refuse
+        // to stage rather than offer an unverifiable confirm (the oauth-state-token
+        // fail-loud stance) — surfaced as a client_error so the agent stops cleanly.
+        let token: string;
+        try {
+          token = mintRestConfirmToken({
+            workspaceId: getRequestContext()?.user?.activeOrganizationId ?? "default",
+            datasourceId: datasource.id,
+            operationId,
+            params,
+          });
+        } catch (err) {
+          const requestId = getRequestContext()?.requestId;
+          const message = err instanceof Error ? err.message : String(err);
+          log.error(
+            { operationId, datasource: datasource.id, requestId, err: message },
+            "executeRestOperation could not mint a confirm token",
+          );
+          return {
+            status: "client_error",
+            reason: "unexpected",
+            message:
+              "Could not stage this write for confirmation — the server is missing a signing key for confirm tokens. " +
+              "Tell the user the write can't be confirmed right now; do not claim it ran.",
+          };
+        }
         const confirm: RestWriteConfirmRequest = {
           datasourceId: datasource.id,
           operationId,
@@ -322,6 +350,7 @@ export function createExecuteRestOperationTool(deps: ExecuteRestOperationDeps = 
           ...(query ? { query } : {}),
           ...(header ? { header } : {}),
           ...(body !== undefined ? { body } : {}),
+          token,
         };
         log.info(
           { operationId, method: verdict.operation.method, datasource: datasource.id },

--- a/packages/web/src/ui/__tests__/rest-write-confirm-card.test.tsx
+++ b/packages/web/src/ui/__tests__/rest-write-confirm-card.test.tsx
@@ -40,7 +40,12 @@ function stagedDeletePart() {
       datasourceId: "twenty",
       datasourceName: "Twenty",
       summary: "Delete a person — DELETE /people/{id} on Twenty",
-      confirm: { datasourceId: "twenty", operationId: "deleteOnePerson", pathParams: { id: "p-1" } },
+      confirm: {
+        datasourceId: "twenty",
+        operationId: "deleteOnePerson",
+        pathParams: { id: "p-1" },
+        token: "signed-confirm-token", // #3007: opaque single-use token the banner forwards verbatim
+      },
     },
   };
 }

--- a/packages/web/src/ui/lib/rest-operation-types.ts
+++ b/packages/web/src/ui/lib/rest-operation-types.ts
@@ -19,6 +19,13 @@ export interface RestWriteConfirmRequest {
   query?: Record<string, string | number | boolean | Array<string | number | boolean>>;
   header?: Record<string, string | number | boolean>;
   body?: unknown;
+  /**
+   * Server-signed, single-use confirm token (#3007). Opaque to the banner — it
+   * POSTs the whole `confirm` payload (including this token) verbatim; the confirm
+   * endpoint verifies it matches the staged write, then burns it so a replay is
+   * rejected. Always present on a `needs_confirmation` result from the API.
+   */
+  token: string;
 }
 
 /** The `needs_confirmation` arm — an allowlisted write staged for human confirmation. */


### PR DESCRIPTION
Closes #3007. **Path A — enforce** (the issue's posture decision): make `/confirm` a server-verifiable single-use gate, not stateless UX.

## Problem

The confirm-before-write flow was stateless. `executeRestOperation` returned a raw `RestWriteConfirmRequest` (no token), the banner POSTed it verbatim, and `/confirm` executed whatever validated against the allowlist. Any holder of the session — a replayed request, XSS/CSRF against the SPA, a looping agent — could re-fire an allowlisted write, bounded only by the ~60/min token bucket. The advertised "the write fires after the human confirms, never silently" property was **UX-only, not server-verifiable**, and `rest-operations.test.ts` actively asserted the replayable behavior.

## Fix (Path A)

A short-lived, server-signed, **single-use** confirm token now binds each staged write to `(workspaceId, datasourceId, operationId, canonical-params, nonce, exp)`:

- **Mint** (`mintRestConfirmToken`, staging tool) — JWT-ish HMAC token signed with the resolved encryption keyset (`ATLAS_ENCRYPTION_KEYS` → `ATLAS_ENCRYPTION_KEY` → `BETTER_AUTH_SECRET`), the **same keyset `oauth-state-token.ts` uses — no new signing secret**. Domain-separated via a `typ: "AtlasRestConfirm"` header. Params bound by an order-stable canonical SHA-256 (JSON key reordering doesn't false-reject). Fail-loud when no key is configured — the gate can't degrade to an unsigned token.
- **Verify** (`verifyRestConfirmToken`, `/confirm`) — requires the token, verifies the HMAC with `timingSafeEqual`, re-derives the binding from the re-resolved request, and rejects a missing / tampered / expired / foreign-workspace / param-mismatched token. Failure reason is logged but never returned (uniform 400 — no probing which check tripped).
- **Burn** (`burnRestConfirmNonce`) — consumes the nonce in an in-process single-use store (same posture as the rate-limit token bucket next door), synchronous and immediately before dispatch with no intervening `await`, so concurrent replays of the same token can't both reach the upstream.
- `/confirm` also now asserts `verdict.requiresConfirmation` and **400s a read** driven through the write-only endpoint.

The token rides inside the `confirm` payload — opaque to the banner, which already POSTs it verbatim. Mirrored on the web-local `RestWriteConfirmRequest`, documented in `openapi-generic.mdx` + `.env.example` (`ATLAS_OPENAPI_CONFIRM_TTL_SECONDS`, default 10m, clamp 60–3600s), regenerated `openapi.json`.

## Acceptance criteria

- [x] Mints a short-lived, server-signed, single-use token binding `(workspaceId, datasourceId, operationId, canonical-params, nonce, exp)`
- [x] `/confirm` requires the token, verifies it matches the re-resolved op+params, and burns the nonce — replay rejected, tampered payload fails HMAC
- [x] `/confirm` asserts `verdict.requiresConfirmation` and 400s a non-write op (write-only)
- [x] Negative tests: missing / tampered-sig / tampered-params / expired / replayed / foreign-workspace / non-write all rejected with **no upstream write**
- [x] The old replay test (which asserted vulnerable behavior) is replaced — replay is now refused; a separate test proves writes still aren't cached (two distinct tokens both dispatch)

## Tests

- `api/routes/__tests__/rest-operations.test.ts` — 19 route tests (existing + the new single-use gate suite)
- `lib/openapi/__tests__/rest-write-confirm.test.ts` (new) — 15 unit tests for the token primitives: round-trip, canonical-param order-independence, tamper/expiry/binding rejection, nonce burn + eviction, fail-loud no-key
- `lib/tools/__tests__/rest-operation.test.ts` — staging now mints a token (drift-guarded)

## Sequencing

Based on `main` (both #3006 SSRF egress guard and #3008 side-effecting-GET escape hatch already merged). Pairs with #3008 — a forced-confirm side-effecting GET routes through this same mint+verify+burn flow.

## CI

Local `/ci` — lint, type, full test (0 failures), syncpack, openapi-drift, schema-drift, test-discipline, twenty-resolver, railway-watch, security-headers, oauth-helper, published-symbols — **all pass**.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3016"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782752866&installation_id=135337507&pr_number=3016&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3016&signature=27df02e261363f8d2acdd7f3bae790d3a20193223ccc037d8fc2bfd5c536a7c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * REST/OpenAPI write operations now require a server-signed, single-use confirmation token. Tokens are short-lived (configurable, default 10 minutes), bound to specific operations, and rejected if tampered, expired, replayed, or used for non-write actions.

* **Documentation**
  * Added ATLAS_OPENAPI_CONFIRM_TTL_SECONDS to configure token TTL and updated API docs/spec to describe token requirements, failure modes, and retry behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AtlasDevHQ/atlas/pull/3016?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->