### PR TITLE
fix(integrations): Slack OAuth handler returns the persisted install id on reconnect (#3005)

### DIFF
--- a/packages/api/src/lib/billing/__tests__/chat-cap-pg.test.ts
+++ b/packages/api/src/lib/billing/__tests__/chat-cap-pg.test.ts
@@ -254,6 +254,107 @@ describeIfPg("checkChatIntegrationLimitAndInstall (real Postgres)", () => {
     );
   }
 
+  /**
+   * Drive the REAL `SlackOAuthInstallHandler.handleCallback` end-to-end against
+   * Postgres for a first-install + reconnect, asserting `installRecord.id`
+   * matches the persisted row id both times and the row stays idempotent
+   * (#3005). On reconnect the `ON CONFLICT DO UPDATE` never touches `id`, so the
+   * row keeps its ORIGINAL id — the handler must return that, not the fresh
+   * `crypto.randomUUID()` candidate it mints each call.
+   *
+   * Shared by the fail-open (no org → gate's `internalQuery` INSERT) and the
+   * transactional (org seeded → gate's `client.query` INSERT) cases so the
+   * `RETURNING id` round-trip the fix depends on is covered through BOTH gate
+   * sources. Each caller passes a distinct `teamId` because `afterEach` clears
+   * `workspace_plugins`/`organization` but not `chat_cache`, and
+   * `saveInstallation`'s hijack guard rejects a team already bound to another
+   * workspace. Saves/restores the keyset + slack-encryption env (the file's
+   * hermetic-env discipline).
+   */
+  async function assertSlackReconnectReturnsPersistedId(ws: string, teamId: string): Promise<void> {
+    const { SlackOAuthInstallHandler } = await import(
+      "../../integrations/install/slack-oauth-handler"
+    );
+    const { mintOAuthStateToken } = await import(
+      "../../integrations/install/oauth-state-token"
+    );
+    const { _resetEncryptionKeyCache } = await import("../../db/encryption-keys");
+    const { resetSlackEncryptionKeyCache } = await import(
+      "../../slack/installation-encryption"
+    );
+
+    // The state-token mint/verify needs a keyset; the chat_cache write needs
+    // SLACK_ENCRYPTION_KEY *unset* (plaintext path). Save/restore both.
+    const prior = {
+      keys: process.env.ATLAS_ENCRYPTION_KEYS,
+      key: process.env.ATLAS_ENCRYPTION_KEY,
+      authSecret: process.env.BETTER_AUTH_SECRET,
+      slackKey: process.env.SLACK_ENCRYPTION_KEY,
+    };
+    process.env.ATLAS_ENCRYPTION_KEYS = "v1:slack-reconnect-test-key";
+    delete process.env.ATLAS_ENCRYPTION_KEY;
+    delete process.env.BETTER_AUTH_SECRET;
+    delete process.env.SLACK_ENCRYPTION_KEY;
+    _resetEncryptionKeyCache();
+    resetSlackEncryptionKeyCache();
+
+    // The handler's only outbound fetch is the Slack oauth.v2.access exchange.
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify({
+          ok: true,
+          team: { id: teamId, name: "Reconnect Co" },
+          access_token: "xoxb-token",
+          bot_user_id: "U-BOT",
+          scope: "commands,chat:write,app_mentions:read",
+          app_id: "A1",
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      )) as unknown as typeof fetch;
+
+    try {
+      const handler = new SlackOAuthInstallHandler({
+        clientId: "cid",
+        clientSecret: "csecret",
+        redirectUri: "https://atlas.example/cb",
+      });
+
+      // First install commits a row.
+      const first = await handler.handleCallback("code-1", mintOAuthStateToken(ws, "slack"));
+      expect(first).not.toBeNull();
+      expect(first!.credentialResult.written).toBe(true);
+
+      const afterFirst = await pool.query<{ id: string }>(
+        `SELECT id FROM workspace_plugins WHERE workspace_id = $1 AND catalog_id = 'catalog:slack'`,
+        [ws],
+      );
+      expect(afterFirst.rows).toHaveLength(1);
+      const persistedId = afterFirst.rows[0]!.id;
+      expect(first!.installRecord.id).toBe(persistedId);
+
+      // Reconnect (same workspace + team) UPSERTs the same row → same id.
+      const second = await handler.handleCallback("code-2", mintOAuthStateToken(ws, "slack"));
+      expect(second).not.toBeNull();
+      expect(second!.installRecord.id).toBe(persistedId);
+
+      const afterSecond = await pool.query<{ id: string }>(
+        `SELECT id FROM workspace_plugins WHERE workspace_id = $1 AND catalog_id = 'catalog:slack'`,
+        [ws],
+      );
+      // Idempotent — still exactly one row, same id.
+      expect(afterSecond.rows).toHaveLength(1);
+      expect(afterSecond.rows[0]?.id).toBe(persistedId);
+    } finally {
+      if (prior.keys === undefined) delete process.env.ATLAS_ENCRYPTION_KEYS;
+      else process.env.ATLAS_ENCRYPTION_KEYS = prior.keys;
+      if (prior.key !== undefined) process.env.ATLAS_ENCRYPTION_KEY = prior.key;
+      if (prior.authSecret !== undefined) process.env.BETTER_AUTH_SECRET = prior.authSecret;
+      if (prior.slackKey !== undefined) process.env.SLACK_ENCRYPTION_KEY = prior.slackKey;
+      _resetEncryptionKeyCache();
+      resetSlackEncryptionKeyCache();
+    }
+  }
+
   it(
     "commits the chat-install UPSERT against the real post-0096 schema (#2995 AC3)",
     async () => {
@@ -340,99 +441,31 @@ describeIfPg("checkChatIntegrationLimitAndInstall (real Postgres)", () => {
   );
 
   it(
-    "Slack handler hands back the persisted workspace_plugins id across first-install + reconnect (#3005)",
+    "Slack handler hands back the persisted id across first-install + reconnect — fail-open path, no org (#3005)",
     async () => {
-      // Exercises the ACTUAL SlackOAuthInstallHandler.handleCallback against
-      // real Postgres so handler↔schema drift on the live UPSERT is caught (not
-      // a test-local SQL copy). On reconnect the row keeps its ORIGINAL id (the
-      // ON CONFLICT DO UPDATE never touches `id`), so the handler must return
-      // that id — not the fresh `crypto.randomUUID()` candidate it mints each
-      // call. No `organization` row → the gate fail-opens to a direct INSERT,
-      // isolating the id round-trip from cap enforcement.
-      const { SlackOAuthInstallHandler } = await import(
-        "../../integrations/install/slack-oauth-handler"
+      // No `organization` row → the gate fail-opens to a direct `internalQuery`
+      // INSERT (enforcement.ts), isolating the id round-trip from cap
+      // enforcement. Covers the `internalQuery` RETURNING source.
+      await assertSlackReconnectReturnsPersistedId(
+        `ws-slack-reconnect-noorg-${Date.now()}`,
+        "T-RECONNECT-NOORG",
       );
-      const { mintOAuthStateToken } = await import(
-        "../../integrations/install/oauth-state-token"
-      );
-      const { _resetEncryptionKeyCache } = await import("../../db/encryption-keys");
-      const { resetSlackEncryptionKeyCache } = await import(
-        "../../slack/installation-encryption"
-      );
+    },
+    PG_TEST_TIMEOUT_MS,
+  );
 
-      // The state-token mint/verify needs a keyset; the chat_cache write needs
-      // SLACK_ENCRYPTION_KEY *unset* (plaintext path). Save/restore both so the
-      // file's hermetic-env discipline holds.
-      const prior = {
-        keys: process.env.ATLAS_ENCRYPTION_KEYS,
-        key: process.env.ATLAS_ENCRYPTION_KEY,
-        authSecret: process.env.BETTER_AUTH_SECRET,
-        slackKey: process.env.SLACK_ENCRYPTION_KEY,
-      };
-      process.env.ATLAS_ENCRYPTION_KEYS = "v1:slack-reconnect-test-key";
-      delete process.env.ATLAS_ENCRYPTION_KEY;
-      delete process.env.BETTER_AUTH_SECRET;
-      delete process.env.SLACK_ENCRYPTION_KEY;
-      _resetEncryptionKeyCache();
-      resetSlackEncryptionKeyCache();
-
-      // The handler's only outbound fetch is the Slack oauth.v2.access exchange.
-      const teamId = "T-RECONNECT";
-      globalThis.fetch = (async () =>
-        new Response(
-          JSON.stringify({
-            ok: true,
-            team: { id: teamId, name: "Reconnect Co" },
-            access_token: "xoxb-token",
-            bot_user_id: "U-BOT",
-            scope: "commands,chat:write,app_mentions:read",
-            app_id: "A1",
-          }),
-          { status: 200, headers: { "content-type": "application/json" } },
-        )) as unknown as typeof fetch;
-
-      try {
-        const ws = `ws-slack-reconnect-${Date.now()}`;
-        const handler = new SlackOAuthInstallHandler({
-          clientId: "cid",
-          clientSecret: "csecret",
-          redirectUri: "https://atlas.example/cb",
-        });
-
-        // First install commits a row.
-        const first = await handler.handleCallback("code-1", mintOAuthStateToken(ws, "slack"));
-        expect(first).not.toBeNull();
-        expect(first!.credentialResult.written).toBe(true);
-
-        const afterFirst = await pool.query<{ id: string }>(
-          `SELECT id FROM workspace_plugins WHERE workspace_id = $1 AND catalog_id = 'catalog:slack'`,
-          [ws],
-        );
-        expect(afterFirst.rows).toHaveLength(1);
-        const persistedId = afterFirst.rows[0]!.id;
-        expect(first!.installRecord.id).toBe(persistedId);
-
-        // Reconnect (same workspace + team) UPSERTs the same row → same id.
-        const second = await handler.handleCallback("code-2", mintOAuthStateToken(ws, "slack"));
-        expect(second).not.toBeNull();
-        expect(second!.installRecord.id).toBe(persistedId);
-
-        const afterSecond = await pool.query<{ id: string }>(
-          `SELECT id FROM workspace_plugins WHERE workspace_id = $1 AND catalog_id = 'catalog:slack'`,
-          [ws],
-        );
-        // Idempotent — still exactly one row, same id.
-        expect(afterSecond.rows).toHaveLength(1);
-        expect(afterSecond.rows[0]?.id).toBe(persistedId);
-      } finally {
-        if (prior.keys === undefined) delete process.env.ATLAS_ENCRYPTION_KEYS;
-        else process.env.ATLAS_ENCRYPTION_KEYS = prior.keys;
-        if (prior.key !== undefined) process.env.ATLAS_ENCRYPTION_KEY = prior.key;
-        if (prior.authSecret !== undefined) process.env.BETTER_AUTH_SECRET = prior.authSecret;
-        if (prior.slackKey !== undefined) process.env.SLACK_ENCRYPTION_KEY = prior.slackKey;
-        _resetEncryptionKeyCache();
-        resetSlackEncryptionKeyCache();
-      }
+  it(
+    "Slack handler hands back the persisted id across first-install + reconnect — transactional path, org seeded (#3005)",
+    async () => {
+      // A provisioned workspace (organization row present) routes the INSERT
+      // through the gate's transactional `client.query` path under the advisory
+      // lock — the path a real customer hits, and a DIFFERENT RETURNING source
+      // than the fail-open case above. starter cap = 1: the first install
+      // (this_count = 0) fits, and reconnect (this_count = 1) skips the cap
+      // comparison, so BOTH calls run the transactional RETURNING INSERT.
+      const ws = `ws-slack-reconnect-org-${Date.now()}`;
+      await seedOrg(ws, "starter");
+      await assertSlackReconnectReturnsPersistedId(ws, "T-RECONNECT-ORG");
     },
     PG_TEST_TIMEOUT_MS,
   );

--- a/packages/api/src/lib/billing/__tests__/chat-cap-pg.test.ts
+++ b/packages/api/src/lib/billing/__tests__/chat-cap-pg.test.ts
@@ -167,13 +167,14 @@ describeIfPg("checkChatIntegrationLimitAndInstall (real Postgres)", () => {
   const ORIGINAL_DATABASE_URL = process.env.DATABASE_URL;
   const ORIGINAL_FETCH = globalThis.fetch;
 
-  /** Slack-handler-shaped UPSERT (mirrors slack-oauth-handler.ts). */
+  /** Slack-handler-shaped UPSERT with RETURNING id (mirrors slack-oauth-handler.ts, #3005). */
   function slackInsert(installId: string, ws: string) {
     return {
       sql: `INSERT INTO workspace_plugins (id, workspace_id, catalog_id, install_id, pillar, config, enabled, installed_at)
          VALUES ($1, $2, $3, $1, 'chat', $4::jsonb, true, NOW())
          ON CONFLICT (workspace_id, catalog_id) WHERE pillar IN ('chat', 'action') DO UPDATE
-           SET config = EXCLUDED.config, enabled = true`,
+           SET config = EXCLUDED.config, enabled = true
+         RETURNING id`,
       params: [installId, ws, "catalog:slack", JSON.stringify({ team_id: "T1" })],
     };
   }
@@ -334,6 +335,104 @@ describeIfPg("checkChatIntegrationLimitAndInstall (real Postgres)", () => {
       // Idempotent — still exactly one row, same id.
       expect(afterSecond.rows).toHaveLength(1);
       expect(afterSecond.rows[0]?.id).toBe(persistedId);
+    },
+    PG_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "Slack handler hands back the persisted workspace_plugins id across first-install + reconnect (#3005)",
+    async () => {
+      // Exercises the ACTUAL SlackOAuthInstallHandler.handleCallback against
+      // real Postgres so handler↔schema drift on the live UPSERT is caught (not
+      // a test-local SQL copy). On reconnect the row keeps its ORIGINAL id (the
+      // ON CONFLICT DO UPDATE never touches `id`), so the handler must return
+      // that id — not the fresh `crypto.randomUUID()` candidate it mints each
+      // call. No `organization` row → the gate fail-opens to a direct INSERT,
+      // isolating the id round-trip from cap enforcement.
+      const { SlackOAuthInstallHandler } = await import(
+        "../../integrations/install/slack-oauth-handler"
+      );
+      const { mintOAuthStateToken } = await import(
+        "../../integrations/install/oauth-state-token"
+      );
+      const { _resetEncryptionKeyCache } = await import("../../db/encryption-keys");
+      const { resetSlackEncryptionKeyCache } = await import(
+        "../../slack/installation-encryption"
+      );
+
+      // The state-token mint/verify needs a keyset; the chat_cache write needs
+      // SLACK_ENCRYPTION_KEY *unset* (plaintext path). Save/restore both so the
+      // file's hermetic-env discipline holds.
+      const prior = {
+        keys: process.env.ATLAS_ENCRYPTION_KEYS,
+        key: process.env.ATLAS_ENCRYPTION_KEY,
+        authSecret: process.env.BETTER_AUTH_SECRET,
+        slackKey: process.env.SLACK_ENCRYPTION_KEY,
+      };
+      process.env.ATLAS_ENCRYPTION_KEYS = "v1:slack-reconnect-test-key";
+      delete process.env.ATLAS_ENCRYPTION_KEY;
+      delete process.env.BETTER_AUTH_SECRET;
+      delete process.env.SLACK_ENCRYPTION_KEY;
+      _resetEncryptionKeyCache();
+      resetSlackEncryptionKeyCache();
+
+      // The handler's only outbound fetch is the Slack oauth.v2.access exchange.
+      const teamId = "T-RECONNECT";
+      globalThis.fetch = (async () =>
+        new Response(
+          JSON.stringify({
+            ok: true,
+            team: { id: teamId, name: "Reconnect Co" },
+            access_token: "xoxb-token",
+            bot_user_id: "U-BOT",
+            scope: "commands,chat:write,app_mentions:read",
+            app_id: "A1",
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        )) as unknown as typeof fetch;
+
+      try {
+        const ws = `ws-slack-reconnect-${Date.now()}`;
+        const handler = new SlackOAuthInstallHandler({
+          clientId: "cid",
+          clientSecret: "csecret",
+          redirectUri: "https://atlas.example/cb",
+        });
+
+        // First install commits a row.
+        const first = await handler.handleCallback("code-1", mintOAuthStateToken(ws, "slack"));
+        expect(first).not.toBeNull();
+        expect(first!.credentialResult.written).toBe(true);
+
+        const afterFirst = await pool.query<{ id: string }>(
+          `SELECT id FROM workspace_plugins WHERE workspace_id = $1 AND catalog_id = 'catalog:slack'`,
+          [ws],
+        );
+        expect(afterFirst.rows).toHaveLength(1);
+        const persistedId = afterFirst.rows[0]!.id;
+        expect(first!.installRecord.id).toBe(persistedId);
+
+        // Reconnect (same workspace + team) UPSERTs the same row → same id.
+        const second = await handler.handleCallback("code-2", mintOAuthStateToken(ws, "slack"));
+        expect(second).not.toBeNull();
+        expect(second!.installRecord.id).toBe(persistedId);
+
+        const afterSecond = await pool.query<{ id: string }>(
+          `SELECT id FROM workspace_plugins WHERE workspace_id = $1 AND catalog_id = 'catalog:slack'`,
+          [ws],
+        );
+        // Idempotent — still exactly one row, same id.
+        expect(afterSecond.rows).toHaveLength(1);
+        expect(afterSecond.rows[0]?.id).toBe(persistedId);
+      } finally {
+        if (prior.keys === undefined) delete process.env.ATLAS_ENCRYPTION_KEYS;
+        else process.env.ATLAS_ENCRYPTION_KEYS = prior.keys;
+        if (prior.key !== undefined) process.env.ATLAS_ENCRYPTION_KEY = prior.key;
+        if (prior.authSecret !== undefined) process.env.BETTER_AUTH_SECRET = prior.authSecret;
+        if (prior.slackKey !== undefined) process.env.SLACK_ENCRYPTION_KEY = prior.slackKey;
+        _resetEncryptionKeyCache();
+        resetSlackEncryptionKeyCache();
+      }
     },
     PG_TEST_TIMEOUT_MS,
   );

--- a/packages/api/src/lib/billing/enforcement.ts
+++ b/packages/api/src/lib/billing/enforcement.ts
@@ -545,11 +545,11 @@ export const CHAT_INTEGRATION_COUNT_SQL = `SELECT
 
 /**
  * The `workspace_plugins` INSERT the gate runs inside its transaction. Raw
- * SQL + params (rather than a structured descriptor) because the two callers
- * own subtly different UPSERT shapes (Slack has no `RETURNING`; Discord
- * `RETURNING id`); the gate stays agnostic and just executes it under the
- * lock. Callers are trusted in-process code — this is internal-DB write SQL,
- * not user analytics SQL.
+ * SQL + params (rather than a structured descriptor) because each caller owns
+ * its own UPSERT shape; the gate stays agnostic and just executes it under the
+ * lock. Both current callers (Slack and Discord) append `RETURNING id` so the
+ * handler can read back the persisted row id (#3005). Callers are trusted
+ * in-process code — this is internal-DB write SQL, not user analytics SQL.
  */
 export interface WorkspacePluginInsert {
   readonly sql: string;
@@ -560,12 +560,12 @@ export interface WorkspacePluginInsert {
  * Outcome of {@link checkChatIntegrationLimitAndInstall}. Mirrors the
  * {@link ResourceLimitResult} arms (so callers map `cap_reached` → 429 and
  * `check_failed` → 503 exactly as elsewhere), but the success arm carries the
- * INSERT's `RETURNING` rows — the Discord handler needs the upserted row id.
+ * INSERT's `RETURNING` rows — the Slack and Discord handlers read the upserted
+ * row id from them (#3005).
  *
  * `rows` is the INSERT's `RETURNING` output and **may be empty even on
- * success** when the SQL has no `RETURNING` clause (Slack's UPSERT). A caller
- * that reads a column must guard for absence (see the Discord handler's
- * `rows[0]?.id` check).
+ * success** when the SQL omits a `RETURNING` clause. A caller that reads a
+ * column must guard for absence (see the handlers' `rows[0]?.id` check).
  */
 export type ChatIntegrationInstallResult<T extends Record<string, unknown> = Record<string, unknown>> =
   | { allowed: true; readonly rows: readonly T[] }

--- a/packages/api/src/lib/integrations/install/__tests__/slack-oauth-handler.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/slack-oauth-handler.test.ts
@@ -93,13 +93,17 @@ type GateResult =
   | { allowed: true; rows: Array<Record<string, unknown>> }
   | { allowed: false; reason: "cap_reached"; errorMessage: string; limit: number }
   | { allowed: false; reason: "check_failed"; errorMessage: string };
+// The persisted `workspace_plugins` id the gate's `RETURNING id` would surface
+// on the happy path. The handler now reads `installRecord.id` from this (#3005)
+// — the default arm must carry a row so the non-empty guard doesn't trip.
+const DEFAULT_PERSISTED_ID = "wp-default-install-id";
 const mockCheckChatLimitAndInstall: Mock<
   (
     orgId: string | undefined,
     catalogId: string,
     insert: { sql: string; params: readonly unknown[] },
   ) => Promise<GateResult>
-> = mock(() => Promise.resolve({ allowed: true as const, rows: [] }));
+> = mock(() => Promise.resolve({ allowed: true as const, rows: [{ id: DEFAULT_PERSISTED_ID }] }));
 
 // Mock every value export — a partial `mock.module()` causes a `SyntaxError`
 // in other files importing the missing exports (per CLAUDE.md "Mock all
@@ -153,7 +157,7 @@ beforeEach(() => {
   mockSaveInstallation.mockClear();
   mockCheckChatLimitAndInstall.mockClear();
   mockCheckChatLimitAndInstall.mockImplementation(() =>
-    Promise.resolve({ allowed: true as const, rows: [] }),
+    Promise.resolve({ allowed: true as const, rows: [{ id: DEFAULT_PERSISTED_ID }] }),
   );
   // Default to the happy-path Slack response — individual tests override
   // via `mockResolvedValueOnce` / `mockImplementationOnce`.
@@ -225,6 +229,9 @@ describe("SlackOAuthInstallHandler.handleCallback — happy path", () => {
     expect(result!.credentialResult).toEqual({ written: true });
     expect(result!.installRecord.workspaceId).toBe(WSID);
     expect(result!.installRecord.catalogId).toBe("slack");
+    // The install record id is the persisted row id from the gate's RETURNING,
+    // not the candidate UUID the handler minted (#3005).
+    expect(result!.installRecord.id).toBe(DEFAULT_PERSISTED_ID);
 
     // oauth.v2.access called with the configured client id/secret + code.
     expect(mockSlackAPI).toHaveBeenCalledTimes(1);
@@ -428,6 +435,47 @@ describe("SlackOAuthInstallHandler.handleCallback — chat-integration cap", () 
 // ---------------------------------------------------------------------------
 // handleCallback — partial failure (ADR-0003 Reconnect path)
 // ---------------------------------------------------------------------------
+
+describe("SlackOAuthInstallHandler.handleCallback — install record id (#3005)", () => {
+  it("returns the persisted workspace_plugins id from the gate's RETURNING row, not a fresh UUID", async () => {
+    // #3005: on reconnect the UPSERT lands on the existing row, which keeps
+    // its ORIGINAL id (ON CONFLICT DO UPDATE never touches `id`). The handler
+    // must hand back the persisted id (gate `rows[0].id`), not the freshly
+    // minted `crypto.randomUUID()` it passes IN as the candidate.
+    const persistedId = "wp-existing-reconnect-id";
+    mockCheckChatLimitAndInstall.mockImplementationOnce(() =>
+      Promise.resolve({ allowed: true as const, rows: [{ id: persistedId }] }),
+    );
+    const handler = new SlackOAuthInstallHandler(SLACK_CONFIG);
+    const stateToken = mintOAuthStateToken(WSID, "slack");
+
+    const result = await handler.handleCallback("auth-code", stateToken);
+
+    expect(result).not.toBeNull();
+    expect(result!.installRecord.id).toBe(persistedId);
+    // The candidate id the handler generated is the INSERT's `$1` param — it
+    // must NOT be the value returned when the row already existed.
+    const [, , gateInsert] = mockCheckChatLimitAndInstall.mock.calls[0];
+    const candidateId = (gateInsert.params as unknown[])[0];
+    expect(candidateId).not.toBe(persistedId);
+  });
+
+  it("throws when the gate returns no id (RETURNING empty — driver regression), and writes no credential", async () => {
+    // Postgres ≥9.5 guarantees INSERT … ON CONFLICT … RETURNING populates on
+    // both insert and update. An empty row signals a driver/wrapper regression
+    // — fail loud rather than ship a stale candidate id back. Mirrors the
+    // Discord handler's non-empty guard.
+    mockCheckChatLimitAndInstall.mockImplementationOnce(() =>
+      Promise.resolve({ allowed: true as const, rows: [] }),
+    );
+    const handler = new SlackOAuthInstallHandler(SLACK_CONFIG);
+    const stateToken = mintOAuthStateToken(WSID, "slack");
+
+    await expect(handler.handleCallback("auth-code", stateToken)).rejects.toThrow();
+    // The credential store is never reached when the install row id is missing.
+    expect(mockSaveInstallation).not.toHaveBeenCalled();
+  });
+});
 
 describe("SlackOAuthInstallHandler.handleCallback — partial failure", () => {
   it("returns credentialResult.written=false when workspace_plugins write succeeds but chat_cache write throws", async () => {

--- a/packages/api/src/lib/integrations/install/__tests__/slack-oauth-handler.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/slack-oauth-handler.test.ts
@@ -441,7 +441,10 @@ describe("SlackOAuthInstallHandler.handleCallback — install record id (#3005)"
     // #3005: on reconnect the UPSERT lands on the existing row, which keeps
     // its ORIGINAL id (ON CONFLICT DO UPDATE never touches `id`). The handler
     // must hand back the persisted id (gate `rows[0].id`), not the freshly
-    // minted `crypto.randomUUID()` it passes IN as the candidate.
+    // minted `crypto.randomUUID()` it passes IN as the candidate. With the gate
+    // mocked, this pins the HANDLER contract (reads `rows[0].id`, not the
+    // candidate); the end-to-end two-call reconnect semantics against a real
+    // `ON CONFLICT DO UPDATE` row live in `billing/__tests__/chat-cap-pg.test.ts`.
     const persistedId = "wp-existing-reconnect-id";
     mockCheckChatLimitAndInstall.mockImplementationOnce(() =>
       Promise.resolve({ allowed: true as const, rows: [{ id: persistedId }] }),

--- a/packages/api/src/lib/integrations/install/slack-oauth-handler.ts
+++ b/packages/api/src/lib/integrations/install/slack-oauth-handler.ts
@@ -231,6 +231,11 @@ export class SlackOAuthInstallHandler implements OAuthPlatformInstallHandler {
     //     the inference clause so re-install lands on the existing row.
     //   - One install per (workspace, catalog) for chat, so `install_id`
     //     mirrors `id`.
+    //   - `RETURNING id` so we hand back the PERSISTED row id, not this
+    //     candidate (#3005): on reconnect the UPSERT lands on the existing
+    //     row, which keeps its original id (ON CONFLICT DO UPDATE never
+    //     touches `id`), so the freshly-minted candidate would not match the
+    //     DB row. The gate surfaces the INSERT's RETURNING rows on success.
     const installId = crypto.randomUUID();
     const installConfig = {
       team_id: teamId,
@@ -241,12 +246,13 @@ export class SlackOAuthInstallHandler implements OAuthPlatformInstallHandler {
     };
     let capCheck;
     try {
-      capCheck = await checkChatIntegrationLimitAndInstall(workspaceId, SLACK_CATALOG_ID, {
+      capCheck = await checkChatIntegrationLimitAndInstall<{ id: string }>(workspaceId, SLACK_CATALOG_ID, {
         sql: `INSERT INTO workspace_plugins (id, workspace_id, catalog_id, install_id, pillar, config, enabled, installed_at)
          VALUES ($1, $2, $3, $1, 'chat', $4::jsonb, true, NOW())
          ON CONFLICT (workspace_id, catalog_id) WHERE pillar IN ('chat', 'action') DO UPDATE
            SET config = EXCLUDED.config,
-               enabled = true`,
+               enabled = true
+         RETURNING id`,
         params: [installId, workspaceId, SLACK_CATALOG_ID, JSON.stringify(installConfig)],
       });
     } catch (err) {
@@ -285,8 +291,26 @@ export class SlackOAuthInstallHandler implements OAuthPlatformInstallHandler {
       });
     }
 
+    // Read the id back from the UPSERT's RETURNING row rather than reusing the
+    // candidate `installId` (#3005). On reconnect the row already exists and
+    // keeps its ORIGINAL id, so the candidate would be wrong. Mirrors the
+    // non-empty guard in `discord-static-bot-handler.ts`.
+    const returned = capCheck.rows[0]?.id;
+    if (typeof returned !== "string" || returned.length === 0) {
+      // Postgres ≥9.5 guarantees `INSERT … ON CONFLICT … RETURNING` returns the
+      // row on both insert and update. Empty here means a driver / wrapper
+      // regression — fail loudly rather than hand back a stale candidate id
+      // (on re-install the DB row has the existing id; falling back to the
+      // fresh candidate would strand subsequent lookups and the credential
+      // write below).
+      throw new Error(
+        `workspace_plugins UPSERT returned no id for Slack install (workspaceId=${workspaceId}). RETURNING must always populate on PG ≥9.5; this indicates a driver regression. Aborting install.`,
+      );
+    }
+    const persistedId: string = returned;
+
     const installRecord: InstallRecord = {
-      id: installId,
+      id: persistedId,
       workspaceId,
       catalogId: SLACK_SLUG,
     };


### PR DESCRIPTION
Fixes #3005.

## Problem

`SlackOAuthInstallHandler.handleCallback` returned a fresh `crypto.randomUUID()` as `installRecord.id` even on **reconnect**. The `workspace_plugins` UPSERT (`ON CONFLICT (workspace_id, catalog_id) WHERE pillar IN ('chat','action') DO UPDATE`) only sets `config` + `enabled` — it never touches `id`. So on re-install the persisted row keeps its **original** id, while the handler handed back a non-matching new UUID. Slack was the lone chat/datasource handler that never adopted the `RETURNING id` read-back every sibling uses.

## Fix

Mirror `discord-static-bot-handler.ts` (~L307–318):
- Append `RETURNING id` to the Slack UPSERT.
- Type the gate call `checkChatIntegrationLimitAndInstall<{ id: string }>`.
- Set `installRecord.id` from `capCheck.rows[0]?.id`, with a non-empty guard that **fails loud** on an empty RETURNING (a PG ≥9.5 driver regression) rather than shipping the stale candidate id.

The atomic gate from #3004 already surfaces the INSERT's `RETURNING` rows on its success arm, so **`enforcement.ts` has no logic change** — only its two now-stale doc comments ("Slack has no `RETURNING`") are corrected to reflect that both callers now read back the id.

## Diagnosis

Confirmed by tracing the code (and reproduced in the new tests): a second `handleCallback` for the same workspace+team returned a freshly-minted UUID (`07b86075-…`) instead of the persisted row id.

## Tests

- **`slack-oauth-handler.test.ts`** (unit): asserts `installRecord.id` comes from the gate's `RETURNING` row, not the candidate UUID; adds a guard test that an empty `RETURNING` throws and writes no credential. Existing happy-path mocks updated to return a persisted row id (the new guard rejects empty `rows`).
- **`chat-cap-pg.test.ts`** (real Postgres): drives the **actual** `SlackOAuthInstallHandler.handleCallback` end-to-end across **first-install + reconnect**, asserting the returned id matches the DB row both times and stays idempotent (one row). The `slackInsert` helper gains `RETURNING id` to keep mirroring the handler.

## Acceptance criteria

- [x] Slack INSERT adds `RETURNING id`; `installRecord.id` set from `gate.rows[0]?.id` with a non-empty guard mirroring Discord.
- [x] A reconnect returns the **original** persisted id, not a new UUID (proven by the real-PG test).
- [x] Real-PG coverage asserts the returned id matches the DB row across first-install + reconnect.

## CI

All local `/ci` gates pass: lint, type, full test suite (0 failures), syncpack, template/security-header/railway/schema/oauth-helper drift, test-discipline, twenty-resolver, published-symbols.

## Incidental finding

Filed #3017 — `docker-compose.yml:23` still bind-mounts `packages/cli/data/demo.sql` (deleted in #2036), which breaks first-time `db:up` on a fresh volume. Not fixed here (out of scope).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3018"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782755689&installation_id=135337507&pr_number=3018&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3018&signature=9ce562dc55d301ee4c11021cb6280638aef0a141f1258f493b3bd9e104d754bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Slack OAuth reconnection now preserves the original workspace-plugin identifier, preventing duplicate configurations and ensuring idempotent reconnects; installs now fail loudly if persistence is not observed.

* **Tests**
  * Added end-to-end and integration tests covering first-install + reconnect paths and error cases around missing persisted IDs.

* **Documentation**
  * Clarified comments around chat-integration persistence behavior and result handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AtlasDevHQ/atlas/pull/3018?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->