### PR TITLE
chore(openapi): polish nits — plaintext-cred warning, lint comment, OQ3 docs (#3012)

### DIFF
--- a/apps/docs/content/docs/plugins/datasources/openapi-generic.mdx
+++ b/apps/docs/content/docs/plugins/datasources/openapi-generic.mdx
@@ -126,7 +126,7 @@ Install-form fields (Admin → Connections):
 | `auth_value` | — | Bearer token, API key, or `username:password`. Encrypted at rest. |
 | `auth_header_name` | — | Header name for `apikey-header`, e.g. `X-API-Key` |
 | `auth_param_name` | — | Query param for `apikey-query`, e.g. `api_key` |
-| `base_url_override` | — | When the spec's `servers[0].url` is wrong (dev/staging) |
+| `base_url_override` | — | When the spec's `servers[0].url` is wrong (dev/staging). **Security:** the configured `auth_value` is sent to whatever host this resolves to — only point `base_url_override` at a host the same credential is valid for, or you risk leaking the credential to an unintended host. |
 | `write_allowlist` | — | JSON array of `operationId`s permitted to write. Empty = read-only (default). |
 | `side_effecting_operations` | — | JSON array of `operationId`s whose GET/HEAD **mutates** state — forced through the write allowlist + confirm path. Empty = method-only classification (default). See [Side-effecting GETs](#side-effecting-gets). |
 | `display_name` | — | Friendly name shown in Admin → Connections |

--- a/packages/api/src/lib/db/secret-encryption.ts
+++ b/packages/api/src/lib/db/secret-encryption.ts
@@ -102,6 +102,25 @@ export function hasVersionedPrefix(stored: string): boolean {
   return PREFIXED_RE.test(stored);
 }
 
+/**
+ * True when the runtime is "prod-like" (`NODE_ENV=production` or
+ * `ATLAS_DEPLOY_MODE=saas`) yet no encryption keyset is configured — the
+ * exact condition under which {@link encryptSecret}'s dev passthrough would
+ * silently persist a credential in plaintext.
+ *
+ * Single source of truth for the boot-time P0 alarm below and for any
+ * credential-write boundary that wants to re-warn at the point of persist
+ * (e.g. the OpenAPI generic datasource install handler). Reuse this rather
+ * than re-deriving the `NODE_ENV` / `ATLAS_DEPLOY_MODE` check so every site
+ * stays in lockstep. Evaluated live (keyset lookup is cached internally), so
+ * a test that mutates the env and resets the keyset cache sees the new value.
+ */
+export function isPlaintextCredentialRisk(): boolean {
+  const isProdLike =
+    process.env.NODE_ENV === "production" || process.env.ATLAS_DEPLOY_MODE === "saas";
+  return isProdLike && !getEncryptionKeyset();
+}
+
 // Boot-time alarm: in production without a key configured, every new
 // credential gets stored plaintext via the passthrough in `encryptSecret`.
 // The audit-level fallback is intentional (dev + self-hosted without a
@@ -109,9 +128,7 @@ export function hasVersionedPrefix(stored: string): boolean {
 // one and the silent pass-through would otherwise only surface on a
 // read of pre-encrypted data — too late. Fire once at module load.
 (() => {
-  const isProdLike =
-    process.env.NODE_ENV === "production" || process.env.ATLAS_DEPLOY_MODE === "saas";
-  if (isProdLike && !getEncryptionKeyset()) {
+  if (isPlaintextCredentialRisk()) {
     log.error(
       "No encryption key configured (ATLAS_ENCRYPTION_KEYS / ATLAS_ENCRYPTION_KEY / BETTER_AUTH_SECRET) — " +
       "integration credentials will be written plaintext. This is a P0 in SaaS mode.",

--- a/packages/api/src/lib/integrations/install/__tests__/openapi-generic-form-handler.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/openapi-generic-form-handler.test.ts
@@ -344,6 +344,26 @@ describe("OpenApiGenericFormInstallHandler — plaintext-credential warning", ()
     );
     expect(warnedPlaintext).toBe(false);
   });
+
+  it("does not warn for a credential-less install (auth_kind 'none'), even prod-like with no keyset", async () => {
+    // The guard is `data.auth_value && isPlaintextCredentialRisk()` — no credential
+    // means nothing lands in plaintext, so the warning must stay silent.
+    delete process.env.ATLAS_ENCRYPTION_KEYS;
+    delete process.env.ATLAS_ENCRYPTION_KEY;
+    delete process.env.BETTER_AUTH_SECRET;
+    delete process.env.ATLAS_DEPLOY_MODE;
+    process.env.NODE_ENV = "production";
+    _resetEncryptionKeyCache();
+
+    const handler = newHandler();
+    const result = await handler.validateConfig(WSID, validForm({ auth_kind: "none", auth_value: undefined }));
+
+    expect(result.credentialWritten).toBe(false);
+    const warnedPlaintext = mockLogWarn.mock.calls.some(
+      (c) => typeof c[1] === "string" && (c[1] as string).includes("stored in plaintext"),
+    );
+    expect(warnedPlaintext).toBe(false);
+  });
 });
 
 // ── base_url_override SSRF guard (#3006) ──────────────────────────────────────

--- a/packages/api/src/lib/integrations/install/__tests__/openapi-generic-form-handler.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/openapi-generic-form-handler.test.ts
@@ -29,6 +29,35 @@ mock.module("@atlas/api/lib/db/internal", () => ({
   getInternalDB: mock(() => ({ query: mock(() => Promise.resolve({ rows: [] })) })),
 }));
 
+// Capture the handler's structured logger so we can assert the non-fatal
+// plaintext-credential warning fires (#3012 AC1). Mock EVERY value export of
+// the logger module — a partial mock.module() trips "Export not found" on a
+// transitive import (CLAUDE.md). Types are erased and need no mock.
+const mockLogWarn: Mock<(...args: unknown[]) => void> = mock(() => {});
+const mockLogInfo: Mock<(...args: unknown[]) => void> = mock(() => {});
+const mockLogger = {
+  warn: mockLogWarn,
+  info: mockLogInfo,
+  debug: () => {},
+  error: () => {},
+  trace: () => {},
+  fatal: () => {},
+  silent: () => {},
+  child: () => mockLogger,
+};
+mock.module("@atlas/api/lib/logger", () => ({
+  createLogger: () => mockLogger,
+  getLogger: () => mockLogger,
+  withRequestContext: <T>(_ctx: unknown, fn: () => T) => fn(),
+  getRequestContext: () => undefined,
+  setLogLevel: () => true,
+  scrubErrSerializer: (v: unknown) => v,
+  scrubLogFormatter: (obj: Record<string, unknown>) => obj,
+  hashShareToken: (token: string) => token.slice(0, 16),
+  redactPaths: [] as string[],
+  ACTOR_KINDS: ["human", "agent", "mcp", "scheduler"] as const,
+}));
+
 const WSID = "ws-openapi-1" as WorkspaceId;
 
 type HandlerCtor = typeof import("../openapi-generic-form-handler").OpenApiGenericFormInstallHandler;
@@ -87,6 +116,8 @@ function validForm(overrides: Record<string, unknown> = {}): Record<string, unkn
 
 beforeEach(() => {
   setKeys();
+  mockLogWarn.mockClear();
+  mockLogInfo.mockClear();
   mockInternalQuery.mockClear();
   mockInternalQuery.mockImplementation(async (sql: string, params?: unknown[]) => {
     if (sql.includes("RETURNING id")) {
@@ -269,6 +300,49 @@ describe("OpenApiGenericFormInstallHandler — persistence + encryption", () => 
     const handler = newHandler();
     await expect(handler.validateConfig(WSID, validForm())).rejects.toThrow(/Encryption keyset unavailable/);
     expect(mockInternalQuery).not.toHaveBeenCalled();
+  });
+});
+
+// ── Plaintext-credential warning (#3012) ─────────────────────────────────────
+
+describe("OpenApiGenericFormInstallHandler — plaintext-credential warning", () => {
+  it("warns (non-fatal) when persisting a credential in a prod-like env with no keyset", async () => {
+    // Self-hosted prod-like (NODE_ENV=production, NOT saas) with no keyset: the
+    // SaaS hard-fail gate doesn't apply, so the install proceeds — but the
+    // operator must be warned that auth_value lands in plaintext at rest.
+    delete process.env.ATLAS_ENCRYPTION_KEYS;
+    delete process.env.ATLAS_ENCRYPTION_KEY;
+    delete process.env.BETTER_AUTH_SECRET;
+    delete process.env.ATLAS_DEPLOY_MODE;
+    process.env.NODE_ENV = "production";
+    _resetEncryptionKeyCache();
+
+    const handler = newHandler();
+    const result = await handler.validateConfig(WSID, validForm());
+
+    // Non-fatal: the row is still written (dev passthrough is intentional parity).
+    expect(result.installRecord.id).toBe("install-1");
+    expect(mockInternalQuery).toHaveBeenCalledTimes(1);
+
+    // ...but the credential-boundary warning fired, mirroring the boot-time alarm.
+    const warned = mockLogWarn.mock.calls.some(
+      (c) => typeof c[1] === "string" && (c[1] as string).includes("stored in plaintext"),
+    );
+    expect(warned).toBe(true);
+  });
+
+  it("does not warn when an encryption keyset is configured", async () => {
+    // setKeys() (beforeEach) already set ATLAS_ENCRYPTION_KEYS; prod-like but safe.
+    process.env.NODE_ENV = "production";
+    _resetEncryptionKeyCache();
+
+    const handler = newHandler();
+    await handler.validateConfig(WSID, validForm());
+
+    const warnedPlaintext = mockLogWarn.mock.calls.some(
+      (c) => typeof c[1] === "string" && (c[1] as string).includes("stored in plaintext"),
+    );
+    expect(warnedPlaintext).toBe(false);
   });
 });
 

--- a/packages/api/src/lib/integrations/install/openapi-generic-form-handler.ts
+++ b/packages/api/src/lib/integrations/install/openapi-generic-form-handler.ts
@@ -40,6 +40,7 @@ import { z } from "zod";
 import { createLogger } from "@atlas/api/lib/logger";
 import { internalQuery } from "@atlas/api/lib/db/internal";
 import { getEncryptionKeyset } from "@atlas/api/lib/db/encryption-keys";
+import { isPlaintextCredentialRisk } from "@atlas/api/lib/db/secret-encryption";
 import { encryptSecretFields, parseConfigSchema } from "@atlas/api/lib/plugins/secrets";
 import { assertBaseUrlAllowed, EgressBlockedError } from "@atlas/api/lib/openapi/egress-guard";
 import type { WorkspaceId } from "@useatlas/types";
@@ -91,6 +92,8 @@ const OptionalUrlSchema = z
       const u = new URL(raw);
       return u.protocol === "https:" || u.protocol === "http:";
     } catch {
+      // intentionally ignored: URL constructor throw is the negative
+      // validation signal — the user sees the .refine message.
       return false;
     }
   }, "base_url_override must be a well-formed http(s) URL")
@@ -218,6 +221,23 @@ export class OpenApiGenericFormInstallHandler implements FormBasedInstallHandler
       throw new Error(
         "Encryption keyset unavailable in SaaS mode — refusing to persist plaintext credentials. " +
           "Set ATLAS_ENCRYPTION_KEYS and retry.",
+      );
+    }
+
+    // ── 2a. Self-hosted plaintext-credential warning (non-fatal) ────
+    // The SaaS gate above hard-fails. A self-hosted prod-like deploy with a
+    // credential and no keyset is *allowed* — the keyless dev passthrough in
+    // `encryptSecret` is intentional repo-wide parity — but it must not be
+    // silent. Mirror the boot-time P0 alarm via the shared predicate so the
+    // operator gets the same signal at the credential boundary rather than
+    // only on a later read of plaintext-at-rest. (In SaaS + no keyset we
+    // already threw above, so this only fires for self-hosted NODE_ENV=production.)
+    if (data.auth_value && isPlaintextCredentialRisk()) {
+      log.warn(
+        { workspaceId },
+        "Persisting an OpenAPI datasource credential with no encryption keyset configured in a " +
+          "prod-like environment — auth_value will be stored in plaintext. Set ATLAS_ENCRYPTION_KEYS " +
+          "(or ATLAS_ENCRYPTION_KEY / BETTER_AUTH_SECRET) to encrypt integration credentials at rest.",
       );
     }
 


### PR DESCRIPTION
Resolves #3012 — three small, unrelated OpenAPI cleanups grouped for one pass (chore + docs, surfaced by the v0.0.2 global review).

## Changes

1. **Plaintext-credential warning at the install boundary (AC1).** Extracted the boot-time P0 alarm's "prod-like + no keyset" predicate into an exported `isPlaintextCredentialRisk()` in `db/secret-encryption.ts` (single source of truth — `NODE_ENV=production || ATLAS_DEPLOY_MODE=saas` AND `!getEncryptionKeyset()`), and reused it in both the boot IIFE and the OpenAPI generic install handler. The handler now emits a **non-fatal** `log.warn` when a credential-bearing install runs in a prod-like self-hosted env with no keyset — mirroring the boot alarm. The dev/self-hosted passthrough stays intentional (repo-wide parity); the existing SaaS hard-fail gate is unchanged, so this only fires for `NODE_ENV=production` self-hosted.

2. **Lint comment (AC2).** Added `// intentionally ignored: URL constructor throw is the negative validation signal …` to the bare `catch {}` in `OptionalUrlSchema.refine`, matching the sibling `UrlSchema`'s existing comment.

3. **OQ3 docs (AC3).** The `base_url_override` row in `openapi-generic.mdx` now warns that the configured `auth_value` is sent to whatever host the override resolves to — only point it at a host the same credential is valid for (the credential-misdirection foot-gun PRD #2868 promised to document).

## Tests

Added two focused tests to `openapi-generic-form-handler.test.ts` (full logger mock): the warning fires (non-fatal — row still written) in prod-like + no-keyset, and does **not** fire when a keyset is configured. Handler suite: 17 pass, 0 fail.

## Verification

`/ci` — all gates green: lint, type, full `bun run test`, `bun x syncpack lint`, template-drift, security-headers-drift, railway-watch, schema-drift, oauth-helper-drift, test-discipline, twenty-resolver-imports, published-symbols.

Doc + chore only; files are disjoint from the OpenAPI cohesion/cache PRs (#3009/#3010), so this can land in parallel.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3020"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782756337&installation_id=135337507&pr_number=3020&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3020&signature=7e2a1eedd2616bd484bb48cfaf48a191529c873f03c2b7d143e6bec67c94ee24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified security guidance for OpenAPI datasource base URL override to warn about potential credential exposure.

* **Bug Fixes**
  * Added non-fatal warnings when authentication credentials may be persisted unencrypted in prod-like deployments.
  * Improved detection of plaintext-credential risk to alert operators.

* **Tests**
  * Added tests covering plaintext credential warning scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AtlasDevHQ/atlas/pull/3020?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->