### PR TITLE
fix(deploy): correct transposed staging apiUrl to api.staging.useatlas.dev

### DIFF
--- a/deploy/api/atlas.config.ts
+++ b/deploy/api/atlas.config.ts
@@ -955,7 +955,7 @@ export default defineConfig({
       "staging": {
         label: "Staging",
         databaseUrl: process.env.DATABASE_URL!,
-        apiUrl: "https://staging.api.useatlas.dev",
+        apiUrl: "https://api.staging.useatlas.dev",
       },
     },
   },

--- a/deploy/web/Dockerfile
+++ b/deploy/web/Dockerfile
@@ -67,7 +67,7 @@ RUN cd packages/react && bun run build
 # ARG-with-default lets Railway pass a per-service override via build args
 # (Railway maps service env vars to `--build-arg` automatically) without
 # forking the Dockerfile for each environment. Prod keeps the default;
-# staging overrides via `NEXT_PUBLIC_ATLAS_API_URL=https://staging.api.useatlas.dev`
+# staging overrides via `NEXT_PUBLIC_ATLAS_API_URL=https://api.staging.useatlas.dev`
 # on the web-staging service. Without ARG, the ENV literal would always win
 # and bake the prod URL into staging's bundle.
 ARG NEXT_PUBLIC_ATLAS_API_URL=https://api.useatlas.dev


### PR DESCRIPTION
## Summary

- The `staging` residency arm in `deploy/api/atlas.config.ts` set `apiUrl: "https://staging.api.useatlas.dev"` — the `staging.` and `api.` segments were transposed. Corrected to the peer-symmetric `https://api.staging.useatlas.dev`, matching `us`/`eu`/`apac` (`api[-region].useatlas.dev`) and every authoritative source (PRD `docs/prd/staging-environment.md:119`, `docs/development/release-process.md:40,48`, `packages/api/src/lib/auth/server.ts:690`, `rate-limit.test.ts`).
- Fixed the same transposition in the `deploy/web/Dockerfile:70` override-example comment so the documented `NEXT_PUBLIC_ATLAS_API_URL` value is correct (folded into this PR per the issue — no separate issue filed).

## Why it matters

`apiUrl` feeds the cross-region misrouting `correctApiUrl` hint (the 421 Misdirected Request from `lib/residency/`). A request judged misrouted-to-staging under strict routing would have handed clients a host that doesn't resolve. Latent today (strict staging routing isn't live), reconciled before staging traffic is real.

## Verification

- The live `api-staging` Railway service CNAME is `api.staging.useatlas.dev` (confirmed via `gh api .../commits/main/statuses`: `satisfied-creation - api-staging → Success - api.staging.useatlas.dev`), so config now agrees with the provisioned host.
- `grep -rn "staging\.api\.useatlas\.dev"` across `*.ts`/`*.md`/`Dockerfile` returns zero matches after the fix.

## Test plan

- [x] `deploy/api/atlas.config.ts` staging `apiUrl` is `https://api.staging.useatlas.dev`
- [x] Value matches the `api-staging` CNAME shape (`api.staging.useatlas.dev`)
- [x] `deploy/web/Dockerfile` comment no longer shows the transposed host
- [x] `/ci` — lint, type, test (full suite, 0 failures), syncpack, template/security-header/schema/oauth/test-discipline/twenty-resolver/published-symbols drift, railway-watch — all pass

Config/comment-only change — no runtime behavior change, no tests added (`/tdd` N/A).

Closes #2969

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3021"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782758589&installation_id=135337507&pr_number=3021&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3021&signature=606db5be96a65ded2f67207984b9c39fc6193e2894b1b2bf92ede3cd1e968b10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated staging environment API endpoint configuration for improved consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AtlasDevHQ/atlas/pull/3021?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->