### PR TITLE
test(openapi): close tenant-scoping + truncation coverage gaps (#3011)

### DIFF
--- a/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
@@ -1330,6 +1330,42 @@ describeIfPg("migrate-pg (real Postgres)", () => {
   // `status` column) is covered structurally by the `0096: cutover`
   // describe + the full migration replay at `beforeAll`.
 
+  // ─────────────────────────────────────────────────────────────────────
+  // 0108 — openapi-generic Datasource catalog seed (#2926 / #3011 GAP 3)
+  //
+  // The end-to-end run above only asserts count>0; an `INSERT ... ON CONFLICT
+  // DO NOTHING` that silently no-ops (a constraint collision on a future
+  // schema drift) would still "pass" with this catalog row ABSENT. SELECT the
+  // row back and pin the columns the install pipeline reads: type + pillar
+  // route it through the OpenApiDatasourceRegistry (no SQL pool), install_model
+  // drives the admin form, and the `secret:true` field is what
+  // encryptSecretFields encrypts at rest (a dropped flag plaintexts the token).
+  // ─────────────────────────────────────────────────────────────────────
+  it("0108: seeds the openapi-generic datasource catalog row with the credential field marked secret (#3011)", async () => {
+    const { rows } = await pool.query<{
+      type: string;
+      pillar: string;
+      install_model: string;
+      config_schema: Array<{ key: string; secret?: boolean }>;
+    }>(
+      `SELECT type, pillar, install_model, config_schema
+         FROM plugin_catalog
+        WHERE id = 'catalog:openapi-generic'`,
+    );
+    // The INSERT actually landed a row — not a silent ON CONFLICT no-op.
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.type).toBe("datasource");
+    expect(rows[0]?.pillar).toBe("datasource");
+    expect(rows[0]?.install_model).toBe("form");
+
+    // Exactly the credential field carries secret:true, so encryptSecretFields
+    // encrypts `auth_value` in workspace_plugins.config at install time.
+    const secretKeys = rows[0]!.config_schema
+      .filter((f) => f.secret === true)
+      .map((f) => f.key);
+    expect(secretKeys).toEqual(["auth_value"]);
+  }, PG_TEST_TIMEOUT_MS);
+
 
   // ─────────────────────────────────────────────────────────────────────
   // 0096: connections / connection_groups cutover (#2744, 1.5.3 slice 6)

--- a/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
@@ -1335,11 +1335,16 @@ describeIfPg("migrate-pg (real Postgres)", () => {
   //
   // The end-to-end run above only asserts count>0; an `INSERT ... ON CONFLICT
   // DO NOTHING` that silently no-ops (a constraint collision on a future
-  // schema drift) would still "pass" with this catalog row ABSENT. SELECT the
-  // row back and pin the columns the install pipeline reads: type + pillar
-  // route it through the OpenApiDatasourceRegistry (no SQL pool), install_model
-  // drives the admin form, and the `secret:true` field is what
-  // encryptSecretFields encrypts at rest (a dropped flag plaintexts the token).
+  // schema drift) would still "pass" with this catalog row ABSENT. The NOVEL
+  // coverage here is the `toHaveLength(1)` row-presence check after the full
+  // migration replay — that the INSERT actually landed. The column pins below
+  // (type/pillar/install_model + the `secret:true` field) overlap with
+  // catalog-seed.test.ts's static `migration 0108 ↔ code alignment` assertions;
+  // they ride along as cheap insurance against a partial-landing drift. Pinned
+  // because the install pipeline reads them: type + pillar route the row through
+  // the OpenApiDatasourceRegistry (no SQL pool), install_model drives the admin
+  // form, and `secret:true` is what encryptSecretFields encrypts at rest (a
+  // dropped flag plaintexts the token).
   // ─────────────────────────────────────────────────────────────────────
   it("0108: seeds the openapi-generic datasource catalog row with the credential field marked secret (#3011)", async () => {
     const { rows } = await pool.query<{
@@ -1360,12 +1365,11 @@ describeIfPg("migrate-pg (real Postgres)", () => {
 
     // Exactly the credential field carries secret:true, so encryptSecretFields
     // encrypts `auth_value` in workspace_plugins.config at install time.
-    const secretKeys = rows[0]!.config_schema
+    const secretKeys = (rows[0]?.config_schema ?? [])
       .filter((f) => f.secret === true)
       .map((f) => f.key);
     expect(secretKeys).toEqual(["auth_value"]);
   }, PG_TEST_TIMEOUT_MS);
-
 
   // ─────────────────────────────────────────────────────────────────────
   // 0096: connections / connection_groups cutover (#2744, 1.5.3 slice 6)

--- a/packages/api/src/lib/openapi/__tests__/paginator.test.ts
+++ b/packages/api/src/lib/openapi/__tests__/paginator.test.ts
@@ -532,6 +532,19 @@ function countingExecute() {
 
 const FIRST: PageRequest = { operationId: "findManyThings", params: { query: {} } };
 
+// NOTE (#3011 / #2970): the per-page cache exercised below — including its
+// per-(workspace, install) `identity` keying and the cross-install isolation
+// asserted in "the cache_invalidated_at watermark flushes the install's cache"
+// — currently covers a NOT-YET-REACHABLE path. No production caller passes a
+// `cache` binding: `executeOperationPaged` is dormant and the live tool
+// (lib/tools/rest-operation.ts) calls the un-paginated `executeOperation`
+// primitive directly (see the single-page-truncation test in
+// tools/__tests__/rest-operation.test.ts). These tests pin the cache's
+// tenant-scoping contract ahead of that wiring. When #2970 wires
+// `executeOperationPaged` + a real (Postgres) page store into the live tool,
+// add a real-store CROSS-POD tenant-isolation test alongside this block
+// (mirroring the scoped graph-cache test in probe.test.ts) — the in-memory
+// store here cannot catch a key collision across pods sharing one L2 store.
 describe("paginator — page cache (per-page, TTL, watermark)", () => {
   it("caches each page so a second walk does zero fetches within TTL", async () => {
     const store = new InMemoryPageCacheStore();

--- a/packages/api/src/lib/openapi/__tests__/paginator.test.ts
+++ b/packages/api/src/lib/openapi/__tests__/paginator.test.ts
@@ -534,8 +534,8 @@ const FIRST: PageRequest = { operationId: "findManyThings", params: { query: {} 
 
 // NOTE (#3011 / #2970): the per-page cache exercised below — including its
 // per-(workspace, install) `identity` keying and the cross-install isolation
-// asserted in "the cache_invalidated_at watermark flushes the install's cache"
-// — currently covers a NOT-YET-REACHABLE path. No production caller passes a
+// asserted in "the cache_invalidated_at watermark flushes the install's cache
+// (Rediscover schema)" — currently covers a NOT-YET-REACHABLE path. No production caller passes a
 // `cache` binding: `executeOperationPaged` is dormant and the live tool
 // (lib/tools/rest-operation.ts) calls the un-paginated `executeOperation`
 // primitive directly (see the single-page-truncation test in

--- a/packages/api/src/lib/openapi/__tests__/workspace-datasource.test.ts
+++ b/packages/api/src/lib/openapi/__tests__/workspace-datasource.test.ts
@@ -11,12 +11,13 @@ import {
   resolveWorkspaceRestDatasources,
   resolveWorkspaceRestDatasourcesOrThrow,
   resolveWorkspacePrimaryRestDatasource,
+  defaultQuery,
   type OpenApiInstallRow,
 } from "../workspace-datasource";
 import { buildOperationGraph } from "../spec";
 import { buildSnapshot, __resetSnapshotGraphCacheForTests } from "../probe";
 import { MOCK_OPENAPI_SPEC } from "@atlas/api/testing/openapi-datasource";
-import type { OpenApiSnapshot } from "../catalog";
+import { OPENAPI_GENERIC_CATALOG_ID, type OpenApiSnapshot } from "../catalog";
 
 const graph = buildOperationGraph(MOCK_OPENAPI_SPEC);
 
@@ -251,6 +252,43 @@ describe("resolveWorkspacePrimaryRestDatasource", () => {
       ]),
     });
     expect(primary?.id).toBe("first");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+//  defaultQuery tenant-scope clause (#3011 GAP 2)
+//
+//  Every test above injects `deps.query`, so the production `defaultQuery`
+//  SQL — the only place the per-tenant scope is enforced — is NEVER exercised.
+//  A regression that weakened any conjunct (dropping `pillar`, `status`, or
+//  the `workspace_id`/`catalog_id` bind) is a cross-tenant datasource /
+//  credential leak that would pass the whole suite unnoticed. Drive the real
+//  SQL through the `exec` seam and pin both the scope clause and the param
+//  order — the prod path (no `exec`) still runs `internalQuery` unchanged.
+// ─────────────────────────────────────────────────────────────────────
+
+describe("defaultQuery — tenant-scope clause", () => {
+  it("scopes the SELECT to the caller's workspace + openapi-generic catalog, non-archived datasources (#3011)", async () => {
+    let capturedSql = "";
+    let capturedParams: unknown[] = [];
+    await defaultQuery("org-CALLER", async (sql, params) => {
+      capturedSql = sql;
+      capturedParams = params;
+      return [];
+    });
+
+    const flat = capturedSql.replace(/\s+/g, " ").trim();
+    expect(flat).toContain("FROM workspace_plugins");
+    // Each conjunct is load-bearing — dropping any one is a tenant-isolation hole.
+    expect(flat).toContain("workspace_id = $1");
+    expect(flat).toContain("catalog_id = $2");
+    expect(flat).toContain("pillar = 'datasource'");
+    expect(flat).toContain("status != 'archived'");
+
+    // Param ORDER is load-bearing: $1 is the caller's workspace (never client
+    // input), $2 is the built-in openapi-generic catalog id. Flipping these
+    // would scope the query to the wrong dimension.
+    expect(capturedParams).toEqual(["org-CALLER", OPENAPI_GENERIC_CATALOG_ID]);
   });
 });
 

--- a/packages/api/src/lib/openapi/__tests__/workspace-datasource.test.ts
+++ b/packages/api/src/lib/openapi/__tests__/workspace-datasource.test.ts
@@ -284,6 +284,14 @@ describe("defaultQuery — tenant-scope clause", () => {
     expect(flat).toContain("catalog_id = $2");
     expect(flat).toContain("pillar = 'datasource'");
     expect(flat).toContain("status != 'archived'");
+    // Assert the conjuncts as ONE contiguous AND-joined WHERE clause, not just
+    // four independent substrings: the per-conjunct checks above pass even if a
+    // regression swapped an `AND` for an `OR` (or moved a conjunct out of the
+    // WHERE) — both of which are tenant-isolation holes. Pinning the full clause
+    // catches the connective + membership, not only the presence, of each guard.
+    expect(flat).toContain(
+      "WHERE workspace_id = $1 AND catalog_id = $2 AND pillar = 'datasource' AND status != 'archived'",
+    );
 
     // Param ORDER is load-bearing: $1 is the caller's workspace (never client
     // input), $2 is the built-in openapi-generic catalog id. Flipping these

--- a/packages/api/src/lib/openapi/workspace-datasource.ts
+++ b/packages/api/src/lib/openapi/workspace-datasource.ts
@@ -67,22 +67,43 @@ export interface ResolveWorkspaceDeps {
 }
 
 /**
+ * Executor seam for {@link defaultQuery}. Production omits it (the lazily-imported
+ * `internalQuery` runs against the real pool); tests pass one to assert the SQL +
+ * param binding without a DB — the existing `deps.query` seam injects at the
+ * resolver level and so never exercises this function's own scope clause.
+ */
+export type OpenApiInstallQueryExecutor = (
+  sql: string,
+  params: unknown[],
+) => Promise<ReadonlyArray<OpenApiInstallRow>>;
+
+/**
  * Default query: the workspace's non-archived `openapi-generic` installs.
  * Lazily imports `internalQuery` so the resolver's static graph stays free of
  * the DB module (admin-route tests partial-mock it heavily).
+ *
+ * The `WHERE` clause is the load-bearing tenant-scope guard: every conjunct
+ * (`workspace_id = $1`, `catalog_id = $2`, `pillar = 'datasource'`,
+ * `status != 'archived'`) must hold, or the resolver leaks another tenant's
+ * datasources / credentials. Every other test injects `deps.query` and so
+ * bypasses this SQL — the `exec` seam lets a unit test drive it directly and
+ * fail loudly if the scope or param order regresses (#3011).
  */
-async function defaultQuery(workspaceId: string): Promise<ReadonlyArray<OpenApiInstallRow>> {
-  const { internalQuery } = await import("@atlas/api/lib/db/internal");
-  return internalQuery<OpenApiInstallRow>(
-    `SELECT install_id, config
+export async function defaultQuery(
+  workspaceId: string,
+  exec?: OpenApiInstallQueryExecutor,
+): Promise<ReadonlyArray<OpenApiInstallRow>> {
+  const sql = `SELECT install_id, config
        FROM workspace_plugins
       WHERE workspace_id = $1
         AND catalog_id = $2
         AND pillar = 'datasource'
         AND status != 'archived'
-      ORDER BY installed_at ASC`,
-    [workspaceId, OPENAPI_GENERIC_CATALOG_ID],
-  );
+      ORDER BY installed_at ASC`;
+  const params = [workspaceId, OPENAPI_GENERIC_CATALOG_ID];
+  if (exec) return exec(sql, params);
+  const { internalQuery } = await import("@atlas/api/lib/db/internal");
+  return internalQuery<OpenApiInstallRow>(sql, params);
 }
 
 const SECRET_SCHEMA = parseConfigSchema(OPENAPI_GENERIC_CONFIG_SCHEMA);

--- a/packages/api/src/lib/tools/__tests__/rest-operation.test.ts
+++ b/packages/api/src/lib/tools/__tests__/rest-operation.test.ts
@@ -191,6 +191,57 @@ describe("executeRestOperation tool", () => {
   });
 });
 
+// ── Single-page truncation (#3011 GAP 1) ─────────────────────────────────────
+// The live tool calls the un-paginated `executeOperation` primitive directly
+// (see rest-operation.ts). The paginating composer `executeOperationPaged`
+// (lib/openapi/client.ts) is DORMANT — no production caller passes a cache, and
+// wiring it + a real cross-pod page store is #2970's job, not this tool's. So a
+// large `findMany` silently returns ONLY page 1 even when the upstream
+// advertises more pages. This pins that as a KNOWN, asserted property rather
+// than a latent surprise — the day #2970 wires pagination here, this test flips
+// (and a real-store cross-pod tenant-isolation test joins it; see the note in
+// openapi/__tests__/paginator.test.ts).
+describe("executeRestOperation — single-page truncation (executeOperationPaged dormant, #2970)", () => {
+  it("returns ONLY page 1 of a multi-page upstream and does not follow the next-page cursor", async () => {
+    let fetchCount = 0;
+    const fetchImpl = (async () => {
+      fetchCount += 1;
+      return new Response(
+        JSON.stringify({
+          data: { people: [{ id: "p-1" }, { id: "p-2" }] },
+          // The upstream advertises a next page — a paginating client WOULD walk it.
+          pageInfo: { hasNextPage: true, endCursor: "CURSOR_TO_PAGE_2" },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }) as unknown as typeof globalThis.fetch;
+
+    const t = createExecuteRestOperationTool({
+      resolveDatasource: async () => datasource(),
+      fetchImpl,
+    });
+    const result = (await t.execute!(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ToolCallOptions stub
+      { operationId: "findManyPeople" } as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ToolCallOptions stub
+      { toolCallId: "t1", messages: [] } as any,
+    )) as ExecuteRestOperationResult;
+
+    expect(result.status).toBe("ok");
+    if (result.status !== "ok") return;
+    // Exactly one upstream request — the live tool does NOT paginate.
+    expect(fetchCount).toBe(1);
+    const body = result.body as {
+      data: { people: unknown[] };
+      pageInfo: { hasNextPage: boolean };
+    };
+    // Only page 1's rows come back, even though the upstream signals more exist.
+    expect(body.data.people).toHaveLength(2);
+    // The truncation is observable: hasNextPage is true yet no further fetch fired.
+    expect(body.pageInfo.hasNextPage).toBe(true);
+  });
+});
+
 // ── Write-side opt-in (slice 5, #2929) ───────────────────────────────────────
 // The agent stages writes; it never dispatches them. An allowlisted write comes
 // back as `needs_confirmation` (the confirm-before-write banner fires it later);

--- a/packages/api/src/lib/tools/__tests__/rest-operation.test.ts
+++ b/packages/api/src/lib/tools/__tests__/rest-operation.test.ts
@@ -233,12 +233,16 @@ describe("executeRestOperation — single-page truncation (executeOperationPaged
     expect(fetchCount).toBe(1);
     const body = result.body as {
       data: { people: unknown[] };
-      pageInfo: { hasNextPage: boolean };
+      pageInfo: { hasNextPage: boolean; endCursor: string };
     };
     // Only page 1's rows come back, even though the upstream signals more exist.
     expect(body.data.people).toHaveLength(2);
     // The truncation is observable: hasNextPage is true yet no further fetch fired.
     expect(body.pageInfo.hasNextPage).toBe(true);
+    // The next-page cursor is surfaced verbatim but NOT followed — the contract
+    // the day #2970 wires pagination flips: a paginating client would consume
+    // this cursor for the second fetch.
+    expect(body.pageInfo.endCursor).toBe("CURSOR_TO_PAGE_2");
   });
 });
 


### PR DESCRIPTION
## Summary

Closes the three OpenAPI coverage gaps surfaced by the v0.0.2 global review — the high-risk primitives are well-tested individually; these sit at the seams between them. **Test + doc only**; the one source touch (GAP 2) is a behavior-preserving test seam.

- **GAP 1 — live-tool single-page truncation (MED).** The live `executeRestOperation` tool calls the un-paginated `executeOperation` directly; `executeOperationPaged` (the paginating composer) is **dormant** (no production caller — wiring it + a real L2 store is #2970, not this issue). A new `rest-operation.test.ts` test asserts the tool returns **only page 1** of a multi-page upstream and does **not** follow the next-page cursor, making the truncation a known, asserted property. Added a note in `paginator.test.ts` that the page-cache isolation tests currently cover a **not-yet-reachable path**, with a pointer to #2970 (where a real-store cross-pod tenant-isolation test joins them).
- **GAP 2 — resolver scoping clause unasserted (LOW, cross-tenant leak risk).** Every resolver test injects `deps.query`, so the load-bearing `WHERE workspace_id = $1 AND catalog_id = $2 AND pillar = 'datasource' AND status != 'archived'` was never exercised. Exported `defaultQuery` with an optional executor seam (production path byte-identical — still lazily imports `internalQuery`) and added a unit test asserting the scope clause **and** the param order `[workspaceId, OPENAPI_GENERIC_CATALOG_ID]`.
- **GAP 3 — 0108 migration row not SELECT-verified (LOW).** The migrate-pg end-to-end run only asserts `count>0`; an `INSERT ... ON CONFLICT DO NOTHING` that no-ops would still "pass" with the catalog row absent. Added a real-PG `SELECT ... WHERE id='catalog:openapi-generic'` asserting `type='datasource'` / `pillar='datasource'` / `install_model='form'` and a `config_schema` whose `secret` field is `auth_value`.

## Test plan

- [x] `bun test` on the four affected suites — 107 pass (workspace-datasource, rest-operation, paginator)
- [x] `TEST_DATABASE_URL=… bun test … migrate-pg.test.ts` — 58 pass incl. the new 0108 assertion (and the test fails meaningfully when the row is absent, e.g. under a name filter that skips the migration runner)
- [x] Full `bun run test` — 763 files pass, 0 fail
- [x] `/ci` — lint, type, test, syncpack, template-drift, security-headers, railway-watch, schema-drift, oauth-helper, test-discipline, twenty-resolver, published-symbols all pass

Scope note: #3013 (ready-for-human) tracks a possible reframe of #2991 + a spec-lifecycle scope split — out of scope here.

Closes #3011

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3022"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782759187&installation_id=135337507&pr_number=3022&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3022&signature=5ee5928d782b2ccc54629c7cde23c7beefdd3ae96cfdf63a6788e42714f9bb76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a real Postgres migration smoke test for the OpenAPI generic datasource catalog.
  * Added a REST operation test ensuring single-page truncation behavior is preserved.
  * Added a workspace datasource test verifying tenant-scoped query isolation.
  * Clarified paginator test documentation about per-page cache behavior and future isolation concerns.

* **Refactor**
  * Made the workspace datasource query executor pluggable to support better testing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AtlasDevHQ/atlas/pull/3022?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->