### PR TITLE
fix(dev): point docker-compose seed mount at canonical ecommerce.sql (#3017)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     volumes:
       - pgdata:/var/lib/postgresql/data
       - ./packages/cli/data/init-demo-db.sql:/docker-entrypoint-initdb.d/00-init.sql
-      - ./packages/cli/data/demo.sql:/data/demo.sql:ro
+      - ./packages/cli/data/ecommerce.sql:/data/ecommerce.sql:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U atlas"]
       interval: 5s

--- a/docs/guides/deploy.md
+++ b/docs/guides/deploy.md
@@ -59,7 +59,7 @@ ATLAS_DATASOURCE_URL=postgresql://user:pass@your-analytics-host:5432/mydb
 
 ```bash
 # Option A: Canonical demo dataset (NovaMart e-commerce — 13 entities, 52 tables, ~480K rows)
-psql "$ATLAS_DATASOURCE_URL" < data/demo.sql
+psql "$ATLAS_DATASOURCE_URL" < data/ecommerce.sql
 
 # Option B: Your own data
 ATLAS_DATASOURCE_URL="$ATLAS_DATASOURCE_URL" bun run atlas -- init
@@ -233,7 +233,7 @@ ATLAS_DATASOURCE_URL=postgresql://user:pass@your-analytics-host:5432/mydb
 
 ```bash
 # Option A: Canonical demo dataset (NovaMart e-commerce — 13 entities, 52 tables, ~480K rows)
-psql "$ATLAS_DATASOURCE_URL" < data/demo.sql
+psql "$ATLAS_DATASOURCE_URL" < data/ecommerce.sql
 
 # Option B: Your own data (skip seeding, just generate semantic layer)
 ATLAS_DATASOURCE_URL="$ATLAS_DATASOURCE_URL" bun run atlas -- init

--- a/packages/cli/data/init-demo-db.sql
+++ b/packages/cli/data/init-demo-db.sql
@@ -1,8 +1,8 @@
 -- Create the demo analytics database alongside the Atlas internal DB.
 -- Runs as superuser during postgres container initialization (mounted as 00-init.sql).
--- demo.sql is mounted at /data/demo.sql (outside docker-entrypoint-initdb.d
+-- ecommerce.sql is mounted at /data/ecommerce.sql (outside docker-entrypoint-initdb.d
 -- to prevent Docker from also running it against the default 'atlas' database).
 CREATE DATABASE atlas_demo;
 GRANT ALL PRIVILEGES ON DATABASE atlas_demo TO atlas;
 \connect atlas_demo;
-\i /data/demo.sql
+\i /data/ecommerce.sql


### PR DESCRIPTION
## Summary

Fixes #3017 — a first-time `bun run db:up` / `db:reset` on a fresh checkout failed because `docker-compose.yml` bind-mounted `./packages/cli/data/demo.sql`, a file **deleted** in #2036 (`ac2da4bc`, "collapse to canonical ecommerce seed"). Docker silently materializes a nonexistent bind-mount source as an empty **directory**, so on a fresh (empty `pgdata`) volume the postgres init script's `\i /data/demo.sql` errored with `could not read from input file: Is a directory`, postgres exited code 3, and `db:up` reported `Postgres not ready after 30s`. Every container (re)create also polluted the working tree with an empty `packages/cli/data/demo.sql/` directory.

The canonical seed is now `packages/cli/data/ecommerce.sql` (a symlink → `seeds/ecommerce/seed.sql`).

## Changes

- **`docker-compose.yml`** — mount the canonical seed at `/data/ecommerce.sql` instead of the deleted `demo.sql`.
- **`packages/cli/data/init-demo-db.sql`** — update the `\i` target (and its comment) to `/data/ecommerce.sql`.
- **`docs/guides/deploy.md`** — point both manual `psql < data/...` load commands (Option A, lines 62 and 236) at `data/ecommerce.sql` so the deploy guide matches reality. *(Folded in per the issue — same root cause, no separate issue.)*

## Verification

Reproduced and fixed against a real, isolated Postgres (no published port, so no clash with a running dev stack):

**Before (broken mount, empty volume):** container `Exited (3)`; log `psql:/data/demo.sql: error: could not read from input file: Is a directory`; empty `packages/cli/data/demo.sql/` directory created.

**After (this PR, fresh empty volume):**
- container `running`, `exit=0`, `0 restarts`, healthy
- `/data/ecommerce.sql` resolves to the real **1693-line** seed inside the container (symlink bind-mount resolves correctly)
- `atlas_demo` created and seeded — **52 public tables** (customers, orders, products, categories, warehouses, …), matching the documented "13 entities, 52 tables, ~480K rows"
- init log clean, ends `database system is ready to accept connections`
- **no** empty `packages/cli/data/demo.sql/` directory created

## CI

`lint`, `type`, `test` (`--affected`: 3 changed files, 0 tests import them — config/docs-only), `bun x syncpack lint`, `check-template-drift.sh`, `check-railway-watch.sh` — all green. (`check-railway-watch.sh` re-checked since `docker-compose.yml` was touched: all deploy Dockerfile COPY sources still covered.)

## Acceptance criteria

- [x] `docker-compose.yml` mounts the canonical seed, not the deleted `demo.sql`
- [x] `init-demo-db.sql`'s `\i` target matches the new mount
- [x] Fresh `db:up`/`db:reset` against an empty `pgdata` volume seeds `atlas_demo` without error
- [x] No empty `packages/cli/data/demo.sql/` directory is created on container start
- [x] `docs/guides/deploy.md` no longer references the deleted `demo.sql`

## Related (out of scope — not changed here)

The same stale mount exists in `examples/docker/docker-compose.yml`, `docker-compose.vllm.yml`, and `docker-compose.ollama.yml` (each mounts `../../packages/cli/data/demo.sql`). The `create-atlas` templates are unaffected — `prepare-templates.sh` generates `data/demo.sql` for them. Flagging for a possible follow-up; kept out of this PR to stay scoped to #3017.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3023"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782760132&installation_id=135337507&pr_number=3023&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3023&signature=8e2bd478ae019c49940b5d6bc47fe41b200058c25677de1eb24a3a976f2e91f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated demo database initialization to use the ecommerce dataset across Docker configuration and deployment scripts.
  * Updated deployment documentation to reflect the new demo dataset configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AtlasDevHQ/atlas/pull/3023?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->