### PR TITLE
fix(deploy): point examples/docker compose seed mounts at canonical ecommerce.sql (#3024)

### DIFF
--- a/examples/docker/docker-compose.ollama.yml
+++ b/examples/docker/docker-compose.ollama.yml
@@ -21,7 +21,7 @@ services:
     volumes:
       - pgdata:/var/lib/postgresql/data
       - ../../packages/cli/data/init-demo-db.sql:/docker-entrypoint-initdb.d/00-init.sql
-      - ../../packages/cli/data/demo.sql:/data/demo.sql:ro
+      - ../../packages/cli/data/ecommerce.sql:/data/ecommerce.sql:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U atlas"]
       interval: 5s

--- a/examples/docker/docker-compose.vllm.yml
+++ b/examples/docker/docker-compose.vllm.yml
@@ -23,7 +23,7 @@ services:
     volumes:
       - pgdata:/var/lib/postgresql/data
       - ../../packages/cli/data/init-demo-db.sql:/docker-entrypoint-initdb.d/00-init.sql
-      - ../../packages/cli/data/demo.sql:/data/demo.sql:ro
+      - ../../packages/cli/data/ecommerce.sql:/data/ecommerce.sql:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U atlas"]
       interval: 5s

--- a/examples/docker/docker-compose.yml
+++ b/examples/docker/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     volumes:
       - pgdata:/var/lib/postgresql/data
       - ../../packages/cli/data/init-demo-db.sql:/docker-entrypoint-initdb.d/00-init.sql
-      - ../../packages/cli/data/demo.sql:/data/demo.sql:ro
+      - ../../packages/cli/data/ecommerce.sql:/data/ecommerce.sql:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U atlas"]
       interval: 5s


### PR DESCRIPTION
## Summary

Follow-up to #3017 / PR #3023. #3023 fixed the **root** `docker-compose.yml` seed mount (and updated the shared `packages/cli/data/init-demo-db.sql` to `\i /data/ecommerce.sql`), but the three self-hosted Docker example compose files were missed:

- `examples/docker/docker-compose.yml`
- `examples/docker/docker-compose.vllm.yml`
- `examples/docker/docker-compose.ollama.yml`

Each still bind-mounted the **deleted** `packages/cli/data/demo.sql` at `/data/demo.sql` while also mounting that same updated `init-demo-db.sql`. So the init script now reads `/data/ecommerce.sql` — a path none of them mount. Docker silently materializes the missing bind source as an empty **directory**, the `\i` fails with *"could not read from input file: Is a directory"*, postgres exits code 3, and `db:up` reports *"Postgres not ready after 30s"*. This is the self-hosted Docker path real self-hosters copy.

## Change

```diff
-      - ../../packages/cli/data/demo.sql:/data/demo.sql:ro
+      - ../../packages/cli/data/ecommerce.sql:/data/ecommerce.sql:ro
```

One line per file — mirrors exactly what #3023 (`f8680a71`) did to the root `docker-compose.yml`. `ecommerce.sql` is the canonical seed symlink (`-> seeds/ecommerce/seed.sql`).

## Scope note — why some `demo.sql` references remain under `examples/docker/`

The issue's AC #4 asks for "zero remaining `demo.sql` references under `examples/docker/`". The bind-mount references (the bug) are now gone. The **remaining** `demo.sql` references are a **different, self-consistent path** that is *not* broken:

- `examples/docker/Dockerfile:97` COPYs the real `seeds/ecommerce/seed.sql` **into the image** as `./data/demo.sql` (a COPY target, not a deleted-source bind-mount — no "Is a directory" failure).
- `examples/docker/Dockerfile:103` asserts that bundled file is non-empty.
- `examples/docker/scripts/seed-demo.ts:66` reads `/app/data/demo.sql`.

These three agree with each other, and the `demo.sql` in-image name is a **deliberate, maintained, repo-wide convention** shared with:
- the production `deploy/api/Dockerfile:151,158` (identical COPY-target + assertion),
- the `create-atlas` scaffold templates + `prepare-templates.sh:49` (explicit *"Backward-compat flat path: data/demo.sql is what docker-compose volumes mount"*),
- `e2e/surfaces/scaffold.test.ts:364,391` (asserts the scaffolded `data/demo.sql` exists).

Renaming it would diverge `examples/` from the production deploy image and ripple into the template + scaffold-test systems — well beyond the issue's stated "three files, one-line fix" scope. So this PR fixes only the broken bind-mounts and intentionally leaves the bundled-seed path alone.

## Verification

Fresh `docker compose -f examples/docker/docker-compose.yml up postgres` against an **empty** `pgdata` volume (Docker 29.1.3, throwaway project, host port dropped to avoid colliding with a running dev Postgres):

- ✅ Container comes up **healthy**, exit 0, 0 restarts
- ✅ Init reads `/data/ecommerce.sql` — **no** "could not read from input file: Is a directory"
- ✅ `atlas_demo` seeds **all 52 public tables** (`PostgreSQL init process complete; ready for start up`)
- ✅ **No** empty `packages/cli/data/demo.sql/` directory materialized on the host

`/ci` green: lint, type, full test suite, syncpack, template-drift, security-headers-drift, railway-watch, schema-drift, oauth-helper-drift, test-discipline, twenty-resolver-imports, published-symbols.

Closes #3024

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3025"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782761738&installation_id=135337507&pr_number=3025&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3025&signature=fc692338e09f0b50a3e68aced4ef74345c78ce52f0aea7b957269b13aaeb6f2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker Compose configuration files to use ecommerce sample data instead of demo data for local development environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AtlasDevHQ/atlas/pull/3025?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->