### PR TITLE
feat(api): StagingSeed module + boot wiring (#2911, #2914)

### DIFF
--- a/packages/api/src/lib/effect/layers.ts
+++ b/packages/api/src/lib/effect/layers.ts
@@ -38,6 +38,13 @@ import { createLogger } from "@atlas/api/lib/logger";
 import { withEffectSpan } from "@atlas/api/lib/tracing";
 import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
 import { InternalDB, makeInternalDBLive, hasInternalDB, internalQuery } from "@atlas/api/lib/db/internal";
+import { getApiRegion } from "@atlas/api/lib/residency/misrouting";
+import {
+  StagingSeed,
+  StagingSeedError,
+  ensureStagingSeed,
+  type StagingSeedResult,
+} from "@atlas/api/lib/staging/seed";
 import { assertSaasPlatformEmailIsResend } from "@atlas/api/lib/email/dpa-guard";
 import {
   EnterpriseGuardLive,
@@ -1036,6 +1043,61 @@ export const ConnectionsHydrateLive: Layer.Layer<
   never,
   InternalDB | Migration
 > = makeConnectionsHydrateLive();
+
+// ══════════════════════════════════════════════════════════════════════
+// ██  Staging Seed Layer (#2914 — staging slice 7)
+// ══════════════════════════════════════════════════════════════════════
+
+/**
+ * Boot wiring for {@link ensureStagingSeed}. Runs after migrations + the
+ * catalog seeders, before the HTTP server binds (`server.ts` awaits
+ * `runtime.runtimeEffect` before `Bun.serve`).
+ *
+ * Unlike the non-fatal seeders above, a genuine seed failure is NOT
+ * swallowed: the `StagingSeedError` propagates so `buildAppLayer`'s DAG
+ * fails and `server.ts` exits non-zero. A misconfigured staging boot is
+ * loud (#2914 acceptance: "Boot failure surfaces ... not swallowed").
+ *
+ * Dependencies:
+ *   - `InternalDB` / `Migration` — the readiness gate (mirrors the other
+ *     boot layers; a not-ready DB yields `skipped-gate` rather than a crash).
+ *   - `BuiltinDatasourceCatalogSeed` — an ordering barrier so the
+ *     `demo-postgres` catalog row exists before the staging org installs it.
+ *     Effect memoizes the same-Tag layer, so this does not re-run the seed.
+ *
+ * The region gate is the FIRST statement: on `us`/`eu`/`apac` (or region
+ * unset) this returns immediately, touching no DB and emitting no log line
+ * (#2914 acceptance: "seed code does not execute").
+ */
+export const StagingSeedLive: Layer.Layer<
+  StagingSeed,
+  StagingSeedError,
+  InternalDB | Migration | BuiltinDatasourceCatalogSeed
+> = Layer.effect(
+  StagingSeed,
+  Effect.gen(function* () {
+    // Region gate first — non-staging boots are provably inert.
+    if (getApiRegion() !== "staging") {
+      return { outcome: "skipped-region" } satisfies StagingSeedResult;
+    }
+
+    const db = yield* InternalDB;
+    const migration = yield* Migration;
+    // Ordering barrier — see the dependency note above.
+    yield* BuiltinDatasourceCatalogSeed;
+
+    if (!db.available || !migration.migrated) {
+      log.info(
+        { available: db.available, migrated: migration.migrated },
+        "Staging seed skipped — upstream gate (InternalDB or Migration) not satisfied",
+      );
+      return { outcome: "skipped-gate" } satisfies StagingSeedResult;
+    }
+
+    // Let StagingSeedError propagate — boot fails loudly, never silently.
+    return yield* ensureStagingSeed();
+  }),
+);
 
 // ══════════════════════════════════════════════════════════════════════
 // ██  Semantic Sync Layer
@@ -2444,6 +2506,7 @@ export function buildAppLayer(config: ResolvedConfig): Layer.Layer<
   | BuiltinDatasourceCatalogSeed
   | ImplementationStatusOverride
   | ConnectionsHydrate
+  | StagingSeed
   | SemanticSync
   | Settings
   | Scheduler
@@ -2509,6 +2572,16 @@ export function buildAppLayer(config: ResolvedConfig): Layer.Layer<
     Layer.provide(Layer.merge(internalDBLayer, migrationLayer)),
   );
 
+  // StagingSeedLive (#2914) — depends on Migration (so 0093's demo-postgres
+  // catalog row exists) + the builtin datasource seeder (ordering barrier so
+  // the row is re-asserted before the staging org installs it). Region-gated
+  // to `staging`, so prod / self-hosted boots run it as an immediate no-op.
+  const stagingSeedLayer = StagingSeedLive.pipe(
+    Layer.provide(
+      Layer.mergeAll(internalDBLayer, migrationLayer, builtinDatasourceCatalogSeedLayer),
+    ),
+  );
+
   // Independent layers (no Effect-level deps)
   const semanticSyncLayer = SemanticSyncLive;
   const settingsLayer = SettingsLive;
@@ -2570,6 +2643,7 @@ export function buildAppLayer(config: ResolvedConfig): Layer.Layer<
     openApiDatasourceCatalogSeedLayer,
     implementationStatusOverrideLayer,
     connectionsHydrateLayer,
+    stagingSeedLayer,
     semanticSyncLayer,
     settingsLayer,
     schedulerLayer,

--- a/packages/api/src/lib/staging/__tests__/seed.test.ts
+++ b/packages/api/src/lib/staging/__tests__/seed.test.ts
@@ -1,0 +1,324 @@
+/**
+ * StagingSeed — region-gate unit tests + real-Postgres integration tests
+ * (staging slice 6, #2911).
+ *
+ * Two layers of coverage, mirroring the project's split between pure unit
+ * tests and the `migrate-pg.test.ts` real-Postgres smoke:
+ *
+ *   1. Region gate (always runs, no DB): {@link ensureStagingSeed} must do
+ *      ZERO DB work and emit no writes when `getApiRegion()` is not
+ *      `"staging"`. Proven with a tracking pool that records every query —
+ *      the assertion is `queries.length === 0` (#2911 acceptance: "skips all
+ *      DB touches", unit-tested with the env var unset / set to "us").
+ *
+ *   2. Real Postgres (gated on `TEST_DATABASE_URL`, skipped cleanly when
+ *      unset): bootstraps the full Better Auth + Atlas schema into a scratch
+ *      schema via `migrateAuthTables()` — the same boot path production uses —
+ *      then seeds and asserts the four created entities, idempotency (second
+ *      call = zero writes), and that the seeded admin is sign-in-able with the
+ *      seeded password.
+ *
+ * The auth instance and `internalQuery` both read the module-level pool
+ * (`getInternalDB()`), so a single schema-scoped pool injected via
+ * `_resetPool` serves Better Auth's migrator + createUser/createOrganization
+ * AND the seed's own queries — keeping every write inside the scratch schema.
+ */
+
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test";
+import { Effect } from "effect";
+import { Pool } from "pg";
+import {
+  _resetPool,
+  type InternalPool,
+} from "@atlas/api/lib/db/internal";
+import { resetAuthModeCache } from "@atlas/api/lib/auth/detect";
+import { _setAuthInstance, getAuthInstance } from "@atlas/api/lib/auth/server";
+import { migrateAuthTables, resetMigrationState } from "@atlas/api/lib/auth/migrate";
+import {
+  ensureStagingSeed,
+  STAGING_ADMIN_EMAIL,
+  STAGING_ORG_SLUG,
+} from "@atlas/api/lib/staging/seed";
+
+// ───────────────────────────────────────────────────────────────────
+// 1. Region gate — no DB. Proves non-staging boots are inert.
+// ───────────────────────────────────────────────────────────────────
+
+/**
+ * A pool stub that records every query. If the region gate is correct, the
+ * seed returns before issuing any query, so `queries` stays empty.
+ */
+function createTrackingPool() {
+  const queries: string[] = [];
+  async function queryFn(sql: string) {
+    queries.push(sql);
+    return { rows: [] };
+  }
+  const pool = {
+    query: queryFn,
+    async connect() {
+      return { query: queryFn, release() {} };
+    },
+    async end() {},
+    on() {},
+  };
+  return { pool: pool as unknown as InternalPool, queries };
+}
+
+describe("ensureStagingSeed — region gate (no DB)", () => {
+  let savedRegion: string | undefined;
+  let savedDbUrl: string | undefined;
+
+  beforeEach(() => {
+    savedRegion = process.env.ATLAS_API_REGION;
+    savedDbUrl = process.env.DATABASE_URL;
+    // No config loaded in this file, so getApiRegion() falls back to the
+    // env var alone — deleting it yields the "unset" case.
+    delete process.env.ATLAS_API_REGION;
+    delete process.env.DATABASE_URL;
+  });
+
+  afterEach(() => {
+    if (savedRegion !== undefined) process.env.ATLAS_API_REGION = savedRegion;
+    else delete process.env.ATLAS_API_REGION;
+    if (savedDbUrl !== undefined) process.env.DATABASE_URL = savedDbUrl;
+    else delete process.env.DATABASE_URL;
+    _resetPool();
+  });
+
+  it("returns skipped-region and touches no DB when ATLAS_API_REGION is unset", async () => {
+    const { pool, queries } = createTrackingPool();
+    _resetPool(pool);
+
+    const result = await Effect.runPromise(ensureStagingSeed());
+
+    expect(result.outcome).toBe("skipped-region");
+    expect(result.created).toBeUndefined();
+    expect(queries.length).toBe(0);
+  });
+
+  it("returns skipped-region and touches no DB when ATLAS_API_REGION is a prod region", async () => {
+    process.env.ATLAS_API_REGION = "us";
+    const { pool, queries } = createTrackingPool();
+    _resetPool(pool);
+
+    const result = await Effect.runPromise(ensureStagingSeed());
+
+    expect(result.outcome).toBe("skipped-region");
+    expect(queries.length).toBe(0);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────
+// 2. Real Postgres — full seed against Better Auth + Atlas schema.
+// ───────────────────────────────────────────────────────────────────
+
+const TEST_DB_URL = process.env.TEST_DATABASE_URL;
+const describeIfPg = TEST_DB_URL ? describe : describe.skip;
+
+// Better Auth migrations + the full Atlas migration set + the seed itself
+// (which creates a user + org via Better Auth) — comfortably under a minute
+// on local hardware, with headroom for shared CI runners.
+const PG_TEST_TIMEOUT_MS = 60_000;
+
+const STAGING_ADMIN_PASSWORD = "staging-admin-pw-901234";
+
+/** Env keys this suite owns — snapshotted and restored around the block. */
+const ENV_KEYS = [
+  "DATABASE_URL",
+  "BETTER_AUTH_SECRET",
+  "BETTER_AUTH_URL",
+  "ATLAS_ENCRYPTION_KEY",
+  "ATLAS_API_REGION",
+  "ATLAS_ADMIN_EMAIL",
+  "STAGING_ADMIN_PASSWORD",
+  "STAGING_TWENTY_API_KEY",
+  "STAGING_TWENTY_BASE_URL",
+] as const;
+
+describeIfPg("ensureStagingSeed — real Postgres", () => {
+  let pool: Pool;
+  const schemaName = `staging_seed_${Date.now()}_${Math.floor(Math.random() * 1e6)}`;
+  const savedEnv: Record<string, string | undefined> = {};
+  /** Result of the single first-boot seed, asserted across the cases below. */
+  let firstSeed: Awaited<ReturnType<typeof runSeed>>;
+
+  function runSeed() {
+    return Effect.runPromise(ensureStagingSeed());
+  }
+
+  /** Row counts for the tables a seed writes — for the idempotency check. */
+  async function seedTableCounts(): Promise<Record<string, number>> {
+    const out: Record<string, number> = {};
+    for (const table of ["user", "organization", "twenty_integrations", "workspace_plugins"]) {
+      const { rows } = await pool.query<{ c: string }>(
+        `SELECT COUNT(*)::int AS c FROM "${table}"`,
+      );
+      out[table] = Number(rows[0]?.c ?? 0);
+    }
+    return out;
+  }
+
+  beforeAll(async () => {
+    for (const k of ENV_KEYS) savedEnv[k] = process.env[k];
+
+    process.env.DATABASE_URL = TEST_DB_URL;
+    process.env.BETTER_AUTH_SECRET = "staging-seed-test-better-auth-secret-0001";
+    // Better Auth's oauth-provider plugin parses this at init (`new URL`) —
+    // an unset value makes the instance build throw, so the auth migrator
+    // never runs. A valid URL is all it needs in-test.
+    process.env.BETTER_AUTH_URL = "http://localhost:3001";
+    process.env.ATLAS_ENCRYPTION_KEY = "staging-seed-test-encryption-key-000001";
+    process.env.ATLAS_API_REGION = "staging";
+    process.env.STAGING_ADMIN_PASSWORD = STAGING_ADMIN_PASSWORD;
+    process.env.STAGING_TWENTY_API_KEY = "staging-twenty-api-key";
+    process.env.STAGING_TWENTY_BASE_URL = "https://staging-crm.example.com";
+    // Critical: ATLAS_ADMIN_EMAIL unset so the dev-seed path in
+    // migrateAuthTables() is a no-op and leaves the DB free of users —
+    // the staging seed is the only thing that creates rows here.
+    delete process.env.ATLAS_ADMIN_EMAIL;
+
+    // Scratch schema, created on a one-shot client before the long-lived
+    // pool so the search_path-scoped connections have a real target.
+    const bootstrap = new Pool({ connectionString: TEST_DB_URL });
+    try {
+      await bootstrap.query(`CREATE SCHEMA IF NOT EXISTS "${schemaName}"`);
+    } finally {
+      await bootstrap.end();
+    }
+
+    // libpq `options` pins search_path at connection startup (server-side,
+    // before any query) — both the scratch schema and public so extensions
+    // / system catalogs still resolve. Better Auth's migrator + every seed
+    // query run on this pool, so all DDL/DML lands in the scratch schema.
+    pool = new Pool({
+      connectionString: TEST_DB_URL,
+      options: `-c search_path="${schemaName}",public`,
+    });
+
+    // Reset caches and inject the scratch pool BEFORE building the auth
+    // instance, so Better Auth binds to this pool (getInternalDB()).
+    resetMigrationState();
+    resetAuthModeCache();
+    _setAuthInstance(null);
+    _resetPool(pool as unknown as InternalPool);
+
+    // Run the production boot migration path: Better Auth schema first,
+    // then the full Atlas migration set (incl. 0093's demo-postgres catalog
+    // row). Dev seed is skipped (no ATLAS_ADMIN_EMAIL).
+    await migrateAuthTables();
+
+    firstSeed = await runSeed();
+  }, PG_TEST_TIMEOUT_MS);
+
+  afterAll(async () => {
+    resetMigrationState();
+    resetAuthModeCache();
+    _setAuthInstance(null);
+    _resetPool();
+    for (const k of ENV_KEYS) {
+      if (savedEnv[k] !== undefined) process.env[k] = savedEnv[k];
+      else delete process.env[k];
+    }
+    if (pool) {
+      await pool.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`);
+      await pool.end();
+    }
+  });
+
+  it("first call reports a fresh seed of all four entities", () => {
+    expect(firstSeed.outcome).toBe("seeded");
+    expect(firstSeed.created).toEqual({
+      org: true,
+      admin: true,
+      datasource: true,
+      twenty: true,
+    });
+  });
+
+  it("seeds the staging-internal organization", async () => {
+    const { rows } = await pool.query<{ id: string; name: string }>(
+      `SELECT id, name FROM organization WHERE slug = $1`,
+      [STAGING_ORG_SLUG],
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.name).toBe("Staging Internal");
+  }, PG_TEST_TIMEOUT_MS);
+
+  it("seeds a pre-verified platform_admin user", async () => {
+    const { rows } = await pool.query<{
+      id: string;
+      emailVerified: boolean;
+      role: string | null;
+    }>(
+      `SELECT id, "emailVerified", role FROM "user" WHERE LOWER(email) = $1`,
+      [STAGING_ADMIN_EMAIL],
+    );
+    expect(rows).toHaveLength(1);
+    // emailVerified is what makes the admin sign-in-able with no manual step.
+    expect(rows[0]?.emailVerified).toBe(true);
+    expect(rows[0]?.role).toContain("platform_admin");
+  }, PG_TEST_TIMEOUT_MS);
+
+  it("installs the shared demo datasource for the staging org", async () => {
+    const org = await pool.query<{ id: string }>(
+      `SELECT id FROM organization WHERE slug = $1`,
+      [STAGING_ORG_SLUG],
+    );
+    const orgId = org.rows[0]?.id as string;
+    const { rows } = await pool.query<{ catalog_id: string; status: string }>(
+      `SELECT catalog_id, status FROM workspace_plugins
+        WHERE workspace_id = $1 AND pillar = 'datasource'`,
+      [orgId],
+    );
+    expect(rows.length).toBeGreaterThanOrEqual(1);
+    expect(rows.some((r) => r.catalog_id.includes("demo-postgres"))).toBe(true);
+    expect(rows.every((r) => r.status === "published")).toBe(true);
+  }, PG_TEST_TIMEOUT_MS);
+
+  it("installs the staging Twenty integration for the staging org", async () => {
+    const org = await pool.query<{ id: string }>(
+      `SELECT id FROM organization WHERE slug = $1`,
+      [STAGING_ORG_SLUG],
+    );
+    const orgId = org.rows[0]?.id as string;
+    const { rows } = await pool.query<{ base_url: string; api_key_encrypted: string }>(
+      `SELECT base_url, api_key_encrypted FROM twenty_integrations WHERE workspace_id = $1`,
+      [orgId],
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.base_url).toBe("https://staging-crm.example.com");
+    // Stored encrypted at rest — never the plaintext key.
+    expect(rows[0]?.api_key_encrypted).not.toBe("staging-twenty-api-key");
+    expect(rows[0]?.api_key_encrypted).toMatch(/^enc:/);
+  }, PG_TEST_TIMEOUT_MS);
+
+  it("is idempotent — a second call short-circuits with zero DB writes", async () => {
+    const before = await seedTableCounts();
+    const second = await runSeed();
+    const after = await seedTableCounts();
+
+    expect(second.outcome).toBe("already-seeded");
+    expect(second.created).toBeUndefined();
+    expect(after).toEqual(before);
+  }, PG_TEST_TIMEOUT_MS);
+
+  it("seeded admin is sign-in-able with STAGING_ADMIN_PASSWORD", async () => {
+    const auth = getAuthInstance();
+    const api = auth.api as Record<string, unknown>;
+    const signInEmail = api.signInEmail as (opts: {
+      body: { email: string; password: string };
+    }) => Promise<{ token?: string; user?: { email?: string } } | undefined>;
+
+    const ok = await signInEmail({
+      body: { email: STAGING_ADMIN_EMAIL, password: STAGING_ADMIN_PASSWORD },
+    });
+    // A successful sign-in returns a session token + the user.
+    expect(ok?.token ?? ok?.user?.email).toBeTruthy();
+
+    // Wrong password must NOT sign in.
+    await expect(
+      signInEmail({ body: { email: STAGING_ADMIN_EMAIL, password: "definitely-wrong" } }),
+    ).rejects.toBeDefined();
+  }, PG_TEST_TIMEOUT_MS);
+});

--- a/packages/api/src/lib/staging/seed.ts
+++ b/packages/api/src/lib/staging/seed.ts
@@ -1,0 +1,371 @@
+/**
+ * StagingSeed — idempotent first-boot bootstrap for the `staging` deploy
+ * region (staging slice 6, #2911).
+ *
+ * The staging instance (`*.staging.useatlas.dev`) runs the full SaaS code
+ * path but starts from an empty internal database. A human soaking a
+ * tag-gated release needs a known-good tenant the moment the API boots:
+ * an admin they can sign in as, a datasource to query, and a CRM install
+ * to exercise the lead pipeline. {@link ensureStagingSeed} creates exactly
+ * that, once, on the first boot against an empty staging DB.
+ *
+ * Design — a deep module behind a one-line interface:
+ *
+ *   ensureStagingSeed() -> Effect<StagingSeedResult, StagingSeedError>
+ *
+ * On the first call against an empty staging DB it creates, in order:
+ *   1. admin user        `admin@staging.useatlas.dev` (password from
+ *                        `STAGING_ADMIN_PASSWORD`, email pre-verified so
+ *                        it is sign-in-able with no manual SQL)
+ *   2. organization      slug `staging-internal` (the idempotency marker)
+ *   3. datasource        the shared `__demo__` NovaMart connection
+ *                        (`demo-postgres` catalog row, shared across
+ *                        workspaces)
+ *   4. Twenty install    pointing at the separate Twenty Cloud workspace
+ *                        (`STAGING_TWENTY_API_KEY` / `STAGING_TWENTY_BASE_URL`)
+ *
+ * Idempotent on three axes:
+ *   - Region: a no-op when {@link getApiRegion} !== `"staging"`. The gate is
+ *     the very first statement so a prod (`us`/`eu`/`apac`) or self-hosted
+ *     (region unset) boot does zero DB work and emits no log line.
+ *   - Marker: subsequent staging boots detect the `staging-internal`
+ *     organization and short-circuit BEFORE any write. A second call is a
+ *     single `SELECT` and nothing more.
+ *   - Steps: each create step tolerates a prior partial boot — the admin
+ *     user is reused if it already exists, and the datasource / Twenty rows
+ *     upsert. A failure mid-sequence leaves the marker absent, so the next
+ *     boot retries cleanly rather than wedging.
+ *
+ * Failure surfaces as a {@link StagingSeedError}. The boot wiring
+ * (`StagingSeedLive` in `effect/layers.ts`) lets that error propagate so
+ * the Layer DAG fails and `server.ts` exits non-zero — a misconfigured
+ * staging boot is loud, never a silent skip (#2914).
+ *
+ * This module never reads operator env vars in a way that could leak into a
+ * customer path: it runs only in the `staging` region, against Atlas's own
+ * staging tenant, mirroring the dev-seed shape in `lib/auth/migrate.ts`.
+ */
+
+import { Context, Data, Effect } from "effect";
+import { createLogger } from "@atlas/api/lib/logger";
+import { getApiRegion } from "@atlas/api/lib/residency/misrouting";
+import { internalQuery } from "@atlas/api/lib/db/internal";
+
+const log = createLogger("staging-seed");
+
+// ── Deterministic identities ───────────────────────────────────────
+
+/**
+ * Organization slug that doubles as the idempotency marker. Its presence
+ * means "this staging DB is already seeded" — the single source of truth
+ * the short-circuit reads (#2911 acceptance: detect `org.slug` and skip).
+ */
+export const STAGING_ORG_SLUG = "staging-internal";
+
+/** Deterministic admin email — paired with `STAGING_ADMIN_PASSWORD`. */
+export const STAGING_ADMIN_EMAIL = "admin@staging.useatlas.dev";
+
+/**
+ * Catalog slug of the shared demo dataset. Migration 0093 seeds this row
+ * (`Atlas-managed demo Postgres dataset, shared across all workspaces`) —
+ * the canonical `__demo__` NovaMart connection. Installing it for the
+ * staging org points that org at the shared demo data.
+ */
+const STAGING_DEMO_DATASOURCE_SLUG = "demo-postgres";
+
+// ── Result + error types ───────────────────────────────────────────
+
+/**
+ * Discriminated outcome of a seed attempt.
+ *
+ * - `skipped-region`  — not the staging region; zero DB touches, no log.
+ * - `skipped-gate`    — staging, but InternalDB/Migration not ready (only
+ *                       produced by the boot Layer, never by this fn).
+ * - `already-seeded`  — the `staging-internal` marker exists; zero writes.
+ * - `seeded`          — a fresh seed ran; `created` reports what landed.
+ */
+export type StagingSeedOutcome =
+  | "skipped-region"
+  | "skipped-gate"
+  | "already-seeded"
+  | "seeded";
+
+export interface StagingSeedResult {
+  readonly outcome: StagingSeedOutcome;
+  /** Present only when `outcome === "seeded"`. */
+  readonly created?: {
+    readonly org: boolean;
+    readonly admin: boolean;
+    readonly datasource: boolean;
+    readonly twenty: boolean;
+  };
+}
+
+/** The step that was running when the seed failed — for log correlation. */
+export type StagingSeedPhase =
+  | "marker"
+  | "admin"
+  | "org"
+  | "datasource"
+  | "twenty";
+
+/**
+ * Boot-time failure of the staging seed. Mirrors the SaaS boot-guard
+ * tagged-error precedent in `effect/saas-guards.ts`: it stays OUT of the
+ * HTTP `mapTaggedError` / `ATLAS_ERROR_TAG_LIST` exhaustiveness set because
+ * it can only occur during the boot Layer DAG, never inside a request
+ * handler. A `Data.TaggedError` is an `Error` subtype, so it unifies under
+ * `buildAppLayer`'s `Error` channel.
+ */
+export class StagingSeedError extends Data.TaggedError("StagingSeedError")<{
+  readonly message: string;
+  readonly phase: StagingSeedPhase;
+}> {}
+
+/**
+ * Effect-Context Tag for the boot Layer in `effect/layers.ts`. The Tag's
+ * value is the {@link StagingSeedResult} so a future `/health` or admin
+ * surface can read the boot outcome without re-grepping logs (mirrors
+ * `CatalogSeed`).
+ */
+export class StagingSeed extends Context.Tag("StagingSeed")<
+  StagingSeed,
+  StagingSeedResult
+>() {}
+
+// ── Public entry point ─────────────────────────────────────────────
+
+/**
+ * Seed the staging tenant if (a) this is the staging region and (b) it has
+ * not been seeded yet. See the module doc for the full contract.
+ *
+ * R = `never`: this Effect drives the work through the module-level
+ * `internalQuery` / Better Auth instance (same helpers the dev seed uses),
+ * not through Context Tags — so it is callable directly in tests against a
+ * real Postgres without standing up the full Layer DAG. The boot Layer that
+ * wraps it owns the InternalDB / Migration readiness gate.
+ */
+export function ensureStagingSeed(): Effect.Effect<StagingSeedResult, StagingSeedError> {
+  return Effect.gen(function* () {
+    // 1. Region gate — first statement, before any DB touch or log line, so
+    //    non-staging boots are provably inert (#2911 / #2914).
+    if (getApiRegion() !== "staging") {
+      return { outcome: "skipped-region" } satisfies StagingSeedResult;
+    }
+
+    // 2. Marker — a single SELECT. If present, this DB is already seeded and
+    //    we short-circuit with zero writes (idempotency).
+    const alreadySeeded = yield* step("marker", markerExists);
+    if (alreadySeeded) {
+      log.info(
+        { slug: STAGING_ORG_SLUG },
+        "Staging seed: marker organization present — already seeded, skipping",
+      );
+      return { outcome: "already-seeded" } satisfies StagingSeedResult;
+    }
+
+    log.info("Staging seed: empty staging DB — seeding admin + org + datasource + Twenty");
+
+    // 3. Seed. Order matters: the org needs the admin as owner, and the
+    //    datasource / Twenty installs are scoped to the org. Each step is
+    //    individually idempotent so a prior partial boot retries cleanly.
+    const userId = yield* step("admin", createAdminUser);
+    yield* step("admin", () => verifyAdminEmail(userId));
+    const orgId = yield* step("org", () => createStagingOrg(userId));
+    const datasource = yield* step("datasource", () => seedDemoDatasource(orgId));
+    const twenty = yield* step("twenty", () => seedTwentyInstall(orgId));
+
+    log.info(
+      { orgId, userId, datasource, twenty },
+      "Staging seed: complete",
+    );
+    return {
+      outcome: "seeded",
+      created: { org: true, admin: true, datasource, twenty },
+    } satisfies StagingSeedResult;
+  });
+}
+
+// ── Step runner ────────────────────────────────────────────────────
+
+/**
+ * Wrap one async seed step as an Effect, normalizing any throw into a
+ * phase-tagged {@link StagingSeedError}. Never swallows: the error
+ * propagates so the boot Layer can fail loudly.
+ */
+function step<A>(
+  phase: StagingSeedPhase,
+  fn: () => Promise<A>,
+): Effect.Effect<A, StagingSeedError> {
+  return Effect.tryPromise({
+    try: fn,
+    catch: (err) =>
+      new StagingSeedError({
+        phase,
+        message: err instanceof Error ? err.message : String(err),
+      }),
+  });
+}
+
+// ── Steps ──────────────────────────────────────────────────────────
+
+/** Does the `staging-internal` organization already exist? */
+async function markerExists(): Promise<boolean> {
+  const rows = await internalQuery<{ exists: boolean }>(
+    `SELECT EXISTS (SELECT 1 FROM organization WHERE slug = $1) AS exists`,
+    [STAGING_ORG_SLUG],
+  );
+  return rows[0]?.exists === true;
+}
+
+/**
+ * Create (or reuse) the deterministic staging admin. Returns the user id.
+ * Reuses an existing `admin@staging.useatlas.dev` row so a re-run after a
+ * partial boot does not trip Better Auth's duplicate-email guard.
+ */
+async function createAdminUser(): Promise<string> {
+  const existing = await internalQuery<{ id: string }>(
+    `SELECT id FROM "user" WHERE LOWER(email) = $1 LIMIT 1`,
+    [STAGING_ADMIN_EMAIL],
+  );
+  if (existing.length > 0) return existing[0].id;
+
+  const password = process.env.STAGING_ADMIN_PASSWORD?.trim();
+  if (!password) {
+    throw new Error(
+      "STAGING_ADMIN_PASSWORD is not set — cannot seed the staging admin user. " +
+        "Set it to the deterministic credential for admin@staging.useatlas.dev.",
+    );
+  }
+
+  const auth = await getAuth();
+  // Better Auth's typed `api` surface doesn't expose the admin/organization
+  // plugin endpoints, so reach them through the same loose cast the dev seed
+  // uses (`lib/auth/migrate.ts`).
+  const api = auth.api as Record<string, unknown>;
+  const createUser = api.createUser as
+    | ((opts: {
+        body: { email: string; password: string; name: string; role: string };
+      }) => Promise<{ user?: { id: string } } | undefined>)
+    | undefined;
+  if (!createUser) {
+    throw new Error("Staging seed: admin createUser API unavailable on the auth instance");
+  }
+
+  const result = await createUser({
+    body: {
+      email: STAGING_ADMIN_EMAIL,
+      password,
+      name: "Staging Admin",
+      role: "platform_admin",
+    },
+  });
+  const userId = result?.user?.id;
+  if (!userId) {
+    throw new Error("Staging seed: createUser returned no user id");
+  }
+  return userId;
+}
+
+/**
+ * Mark the seeded admin's email verified so it is sign-in-able with no
+ * manual step. The staging admin keeps its deterministic password (no
+ * `password_change_required` flag) so repeated smoke logins keep working.
+ */
+async function verifyAdminEmail(userId: string): Promise<void> {
+  await internalQuery(`UPDATE "user" SET "emailVerified" = true WHERE id = $1`, [userId]);
+}
+
+/** Create the `staging-internal` organization with the admin as owner. */
+async function createStagingOrg(userId: string): Promise<string> {
+  const auth = await getAuth();
+  const api = auth.api as Record<string, unknown>;
+  const createOrg = api.createOrganization as
+    | ((opts: {
+        body: { name: string; slug: string; userId: string };
+      }) => Promise<{ id?: string } | undefined>)
+    | undefined;
+  if (!createOrg) {
+    throw new Error("Staging seed: organization createOrganization API unavailable");
+  }
+  const org = await createOrg({
+    body: { name: "Staging Internal", slug: STAGING_ORG_SLUG, userId },
+  });
+  const orgId = org?.id;
+  if (!orgId) {
+    throw new Error("Staging seed: createOrganization returned no org id");
+  }
+  return orgId;
+}
+
+/**
+ * Install the shared `__demo__` NovaMart datasource (`demo-postgres`
+ * catalog row) for the staging org. Mirrors the dev-seed workspace_plugins
+ * upsert in `lib/auth/migrate.ts`. The demo dataset is operator/env-managed
+ * (empty `config_schema`), so the install carries an empty config — the
+ * connection URL resolves from `ATLAS_DATASOURCE_URL` at runtime.
+ *
+ * Returns `false` (non-fatal) if the catalog row is missing — that means
+ * migration 0093 / the builtin datasource seeder has not run, which the
+ * boot Layer's ordering dependency is meant to prevent.
+ */
+async function seedDemoDatasource(orgId: string): Promise<boolean> {
+  const rows = await internalQuery<{ id: string }>(
+    `SELECT id FROM plugin_catalog WHERE slug = $1 AND pillar = 'datasource' LIMIT 1`,
+    [STAGING_DEMO_DATASOURCE_SLUG],
+  );
+  if (rows.length === 0) {
+    log.warn(
+      { slug: STAGING_DEMO_DATASOURCE_SLUG },
+      "Staging seed: demo datasource catalog row missing — skipping datasource install",
+    );
+    return false;
+  }
+  await internalQuery(
+    `INSERT INTO workspace_plugins
+       (id, workspace_id, catalog_id, install_id, pillar, config, enabled, installed_at, status)
+     VALUES ($1, $2, $3, 'default', 'datasource', '{}'::jsonb, true, NOW(), 'published')
+     ON CONFLICT (workspace_id, catalog_id, install_id)
+       DO UPDATE SET status = 'published', updated_at = NOW()`,
+    [`cn_${orgId}_demo`, orgId, rows[0].id],
+  );
+  return true;
+}
+
+/**
+ * Install the staging Twenty integration pointing at the separate Twenty
+ * Cloud workspace. Uses the canonical encrypted-at-rest store
+ * (`saveTwentyIntegration`, `twenty_integrations` table) rather than a
+ * hand-rolled INSERT, so the apiKey lands encrypted exactly like an admin
+ * install. Best-effort: if the staging Twenty credentials are unset, the
+ * rest of the seed still succeeds (a Twenty outage must not wedge the
+ * staging boot), and the gap is logged.
+ */
+async function seedTwentyInstall(orgId: string): Promise<boolean> {
+  const apiKey = process.env.STAGING_TWENTY_API_KEY?.trim();
+  const baseUrl = process.env.STAGING_TWENTY_BASE_URL?.trim();
+  if (!apiKey || !baseUrl) {
+    log.warn(
+      "Staging seed: STAGING_TWENTY_API_KEY / STAGING_TWENTY_BASE_URL unset — skipping Twenty install",
+    );
+    return false;
+  }
+  const { saveTwentyIntegration } = await import(
+    "@atlas/api/lib/integrations/twenty/store"
+  );
+  await saveTwentyIntegration(orgId, { apiKey, baseUrl });
+  return true;
+}
+
+// ── Auth instance accessor ─────────────────────────────────────────
+
+/**
+ * Lazily resolve the Better Auth instance — the same accessor the dev seed
+ * uses. Dynamic import keeps this module free of a static auth dependency
+ * (auth init pulls in the full Better Auth + DB stack) so it loads cheaply
+ * in the non-staging path and in unit tests.
+ */
+async function getAuth() {
+  const { getAuthInstance } = await import("@atlas/api/lib/auth/server");
+  return getAuthInstance();
+}


### PR DESCRIPTION
## Summary

Staging Environment slices **6** (#2911) and **7** (#2914). Adds a region-gated, idempotent first-boot seed so the `staging` instance (`*.staging.useatlas.dev`) bootstraps a known-good tenant the moment the API boots — the soak target for tag-gated prod releases.

- **New deep module** `packages/api/src/lib/staging/seed.ts` — `ensureStagingSeed(): Effect<StagingSeedResult, StagingSeedError>`.
- **Boot wiring** — `StagingSeedLive` in `effect/layers.ts`, inserted into `buildAppLayer` after migrations + the catalog seeders, before the HTTP server binds.

## #2911 — `ensureStagingSeed`

Idempotent on three axes:
- **Region**: a no-op when `getApiRegion() !== "staging"` (reads the existing `ATLAS_API_REGION` discriminator via `lib/residency/misrouting`). The gate is the first statement — prod / self-hosted boots do zero DB work and emit no log line.
- **Marker**: subsequent staging boots detect the `staging-internal` organization and short-circuit *before any write* (a second call is a single `SELECT`).
- **Steps**: each create step tolerates a prior partial boot — the admin user is reused if present, the datasource / Twenty rows upsert.

On a fresh staging DB it creates, in order:
1. Pre-verified admin `admin@staging.useatlas.dev` (password from `STAGING_ADMIN_PASSWORD`, `emailVerified=true` so it is sign-in-able with no manual step).
2. Organization `staging-internal` (the idempotency marker).
3. The shared `__demo__` NovaMart datasource (`demo-postgres` catalog row, shared across workspaces) as a `workspace_plugins` install.
4. The staging Twenty install (`STAGING_TWENTY_API_KEY` / `STAGING_TWENTY_BASE_URL`), pointing at the separate Twenty Cloud workspace.

Mirrors the dev-seed shape in `lib/auth/migrate.ts` (Better Auth `createUser` / `createOrganization`).

**Acceptance**
- [x] `ensureStagingSeed` exported from `lib/staging/seed.ts`
- [x] Integration test cases pass against real PG (7 cases)
- [x] Idempotency: second call has zero DB writes (verified via row counts)
- [x] Early-return on `getApiRegion() !== "staging"` skips all DB touches (2 unit tests, env unset / `"us"`, tracking pool asserts 0 queries)
- [x] Seeded admin is sign-in-able with the seeded password (Better Auth `signInEmail`; wrong password rejected)

## #2914 — boot wiring

- `StagingSeedLive` depends on `InternalDB` + `Migration` (readiness gate) and `BuiltinDatasourceCatalogSeed` (ordering barrier so the `demo-postgres` catalog row exists before the staging org installs it).
- A genuine seed failure is **not** swallowed: the `StagingSeedError` propagates so `buildAppLayer`'s DAG fails and `server.ts` exits non-zero (`Bun.serve` runs *after* `await Effect.runPromise(runtime.runtimeEffect)`). A misconfigured staging boot is loud.
- Region gate is the first statement, so `us`/`eu`/`apac` (or unset) boots run it as an immediate no-op — no DB read, no log line.

**Acceptance**
- [x] `ATLAS_API_REGION=staging` boot runs `ensureStagingSeed` (creates or short-circuits)
- [x] `us`/`eu`/`apac` boot (or unset) does not execute seed code
- [x] Boot failure surfaces (propagated `StagingSeedError`, not swallowed)
- [x] Existing `startup.ts` tests pass (unchanged; 30✓)

## Deviations from the literal issue text

Both grounded in what the code actually is — flagging for review:

1. **Wired into `effect/layers.ts:buildAppLayer`, not `lib/startup.ts`.** `startup.ts` is diagnostics-only (`validateEnvironment`), runs lazily on the *first request*, and has no migration/catalog ordering and no pre-bind hook. The real boot Layer DAG — the only place that can run "after migrations + catalog seeder, before HTTP binds" and surface a boot failure — is `buildAppLayer`. `migrateAuthTables` (incl. the existing dev seed) already runs there via `MigrationLive`.
2. **Twenty install uses the canonical `twenty_integrations` store** (`saveTwentyIntegration`, encrypted at rest via `encryptSecret`), not a hand-rolled `workspace_plugins` row — that dedicated table is where Twenty installs actually live (#2850).

## Notes
- No migration / new table — writes to existing `organization`, `user`, `workspace_plugins`, `twenty_integrations`. `check-schema-drift.sh` clean.
- `StagingSeedError` is boot-only, so (like the `saas-guards.ts` boot errors) it stays out of the HTTP `mapTaggedError` / `ATLAS_ERROR_TAG_LIST` exhaustiveness set.

## Testing
Local `/ci` — all gates green: lint, type (0 errors), full test (api 168 files + others, 0 failures), syncpack, template/security-header/railway-watch/schema/oauth-helper/test-discipline/twenty-resolver/published-symbols drift checks. Real-PG tests run via `TEST_DATABASE_URL` against the dev Postgres.

Closes #2911
Closes #2914

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3026"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782762835&installation_id=135337507&pr_number=3026&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3026&signature=fe4a759c83a083d85d897f061f4111bb29af7ca2f8f06c4984ebe487f732df4b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated initialization for the staging environment that creates necessary base entities and configurations on first boot. The process is idempotent and prevents duplicate creation on subsequent boots. Critical initialization failures cause the staging server to exit to maintain data consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AtlasDevHQ/atlas/pull/3026?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->