### PR TITLE
feat(web): staging visual marker on app shell (#2915)

### DIFF
--- a/docs/development/staging-environment.md
+++ b/docs/development/staging-environment.md
@@ -1,0 +1,69 @@
+# Staging environment
+
+Staging is the **soak environment** that sits between `main` and a tag-gated prod
+deploy. Every merge to `main` deploys to staging automatically; prod only moves
+when a release tag is cut (see [release-process.md](./release-process.md) and
+[ADR-0008](../adr/0008-versioning-and-release-tags.md)). Staging is where we
+dogfood a change against production-shaped infrastructure before it can reach
+customers.
+
+> **Status:** the staging services are provisioned and green; some repo-side
+> config and HITL provisioning slices are still in flight
+> ([milestone #57](https://github.com/AtlasDevHQ/atlas/milestone/57)). Update
+> this runbook as those land.
+
+## URLs
+
+| Surface | Staging                      | Prod                  |
+| ------- | ---------------------------- | --------------------- |
+| App     | `app.staging.useatlas.dev`   | `app.useatlas.dev`    |
+| API     | `api.staging.useatlas.dev`   | `api.useatlas.dev`    |
+| Landing | `www.staging.useatlas.dev`   | `useatlas.dev`        |
+
+## How you know you're on staging
+
+The web app shell renders a full-width **amber "Staging environment" banner** on
+every page (including pre-sign-in) whenever the API reports it is the staging
+deploy. It is driven by `StagingBanner`
+(`packages/web/src/ui/components/staging-banner.tsx`), which reads `region` from
+the public `GET /api/health` response:
+
+- The API stamps `region: "staging"` when `ATLAS_API_REGION=staging` (resolved by
+  `getApiRegion()` in `packages/api/src/lib/residency/misrouting.ts`, surfaced in
+  `health.ts`).
+- The banner renders nothing on production regions (`us` | `eu` | `apac`) and on
+  self-hosted/dev deploys (no region), so there is no layout shift outside
+  staging.
+
+If you ever see a tab with **no** amber banner that you *think* is staging, treat
+it as production until proven otherwise — check `GET /api/health` directly.
+
+## Deploy trigger model
+
+| Branch / ref         | Target                          | Trigger                                   |
+| -------------------- | ------------------------------- | ----------------------------------------- |
+| `main`               | staging (api / app / www)       | every merge, automatically                |
+| `v*.*.*` tag → `prod` | prod (api / api-eu / api-apac / web / www) | `/release` fast-forwards `prod` to the tag SHA |
+| `docs`               | docs.useatlas.dev               | direct from `main`                        |
+
+The `prod` branch is a Railway-tracking artifact advanced only by `/release`
+(`git push origin <tag-sha>^{}:prod --force-with-lease`). No PRs target `prod`.
+
+## Operational rules
+
+- **New integrations start on staging.** When adding a chat platform, action
+  target, or datasource, create the staging app/credentials first and soak there.
+  Never OAuth-register a new platform straight against prod.
+- **Staging mirrors prod config, not prod data.** Don't assume staging shares a
+  database or secrets with prod; provision its own.
+- **A red staging run blocks the tag.** `/ci` runs before a release tag is cut, so
+  a staging regression should be caught and fixed on `main` before `/release`.
+
+## Smoke check
+
+After a `main` merge deploys to staging:
+
+1. Load `app.staging.useatlas.dev` — confirm the amber banner is present.
+2. `curl https://api.staging.useatlas.dev/api/health` — confirm `200` and
+   `"region":"staging"` in the body.
+3. Sign in and run a query end-to-end against the staging datasource.

--- a/packages/plugin-sdk/README.md
+++ b/packages/plugin-sdk/README.md
@@ -130,7 +130,7 @@ register → initialize(ctx) → healthCheck() → ... → teardown()
    - `ctx.tools` — Tool registry for adding agent tools.
    - `ctx.logger` — Pino-compatible child logger scoped to the plugin.
    - `ctx.config` — Resolved Atlas configuration.
-3. **Health check** — Periodic probe. Return `{ healthy: false, message }` to signal degradation. Never throw. Results surface in the `plugins` component of `GET /api/v1/health` — a failing probe shifts the top-level status to `degraded` (HTTP 200, never 503).
+3. **Health check** — Periodic probe. Return `{ healthy: false, message }` to signal degradation. Never throw. Results surface in the `plugins` component of `GET /api/health` — a failing probe shifts the top-level status to `degraded` (HTTP 200, never 503).
 4. **Teardown** — Graceful shutdown in reverse registration order (LIFO). Use `teardown()` to release state Atlas can't see — external webhook subscriptions, third-party connections, drained queues. **Note:** `teardown()` runs on server shutdown, *not* on a per-workspace uninstall (uninstall is a DB-row removal, not a process event).
 
 > **v1.1 note:** `AtlasPluginContext` will gain `executeQuery`, `conversations`, and `actions` fields for full host-level decoupling. Currently, interaction plugins that need these inject them via config callbacks.

--- a/packages/web/src/app/layout.tsx
+++ b/packages/web/src/app/layout.tsx
@@ -4,6 +4,7 @@ import { buildThemeInitScript } from "@/ui/hooks/theme-init-script";
 import { AuthGuard } from "@/ui/components/auth-guard";
 import { QueryProvider } from "@/ui/components/query-provider";
 import { ModeBanner } from "@/ui/components/mode-banner";
+import { StagingBanner } from "@/ui/components/staging-banner";
 import { Toaster } from "@/components/ui/sonner";
 import "./globals.css";
 
@@ -24,6 +25,7 @@ export default function RootLayout({
       </head>
       <body className="flex h-dvh flex-col bg-white text-zinc-900 antialiased dark:bg-zinc-950 dark:text-zinc-100">
         <a href="#main" className="sr-only focus:not-sr-only focus:absolute focus:z-50 focus:p-4 focus:bg-background focus:text-foreground">Skip to content</a>
+        <StagingBanner />
         <QueryProvider>
           <NuqsAdapter>
             <AuthGuard>

--- a/packages/web/src/ui/components/__tests__/staging-banner.test.tsx
+++ b/packages/web/src/ui/components/__tests__/staging-banner.test.tsx
@@ -5,14 +5,24 @@ import { StagingBanner } from "@/ui/components/staging-banner";
 
 const originalFetch = globalThis.fetch;
 
-/** Replace `fetch` with a stub that resolves the health probe deterministically. */
+/** URL the component last requested — asserted to pin the `/api/health` endpoint. */
+let lastFetchUrl: string | undefined;
+
+/**
+ * Replace `fetch` with a stub that records the requested URL and resolves the
+ * health probe deterministically. Tests assert `lastFetchUrl` so a regression
+ * back to `/api/v1/health` (the original bug) fails here.
+ */
 function stubHealth(body: unknown, ok = true): void {
-  globalThis.fetch = (() =>
-    Promise.resolve({
+  lastFetchUrl = undefined;
+  globalThis.fetch = ((input: RequestInfo | URL) => {
+    lastFetchUrl = typeof input === "string" ? input : input.toString();
+    return Promise.resolve({
       ok,
       status: ok ? 200 : 503,
       json: () => Promise.resolve(body),
-    } as Response)) as typeof fetch;
+    } as Response);
+  }) as typeof fetch;
 }
 
 /** Flush the `fetch().then()` chain and the resulting React state update. */
@@ -25,6 +35,7 @@ async function flush(): Promise<void> {
 afterEach(() => {
   cleanup();
   globalThis.fetch = originalFetch;
+  lastFetchUrl = undefined;
 });
 
 describe("StagingBanner", () => {
@@ -38,6 +49,7 @@ describe("StagingBanner", () => {
     expect(banner.querySelector("a")?.getAttribute("href")).toContain(
       "staging-environment.md",
     );
+    expect(lastFetchUrl).toBe("/api/health");
   });
 
   it("renders nothing on a production region", async () => {
@@ -47,6 +59,7 @@ describe("StagingBanner", () => {
     await flush();
 
     expect(screen.queryByRole("status")).toBeNull();
+    expect(lastFetchUrl).toBe("/api/health");
   });
 
   it("renders nothing (and does not throw) when the probe omits a region", async () => {
@@ -56,6 +69,7 @@ describe("StagingBanner", () => {
     await flush();
 
     expect(screen.queryByRole("status")).toBeNull();
+    expect(lastFetchUrl).toBe("/api/health");
   });
 
   it("renders nothing when the health probe returns a non-ok status", async () => {
@@ -65,5 +79,21 @@ describe("StagingBanner", () => {
     await flush();
 
     expect(screen.queryByRole("status")).toBeNull();
+    expect(lastFetchUrl).toBe("/api/health");
+  });
+
+  it("aborts the in-flight health probe on unmount", () => {
+    let abortSignal: AbortSignal | undefined;
+    globalThis.fetch = ((_input: RequestInfo | URL, init?: RequestInit) => {
+      abortSignal = init?.signal ?? undefined;
+      // Never resolves — the probe stays in flight until unmount aborts it.
+      return new Promise<Response>(() => {});
+    }) as typeof fetch;
+
+    const { unmount } = render(<StagingBanner />);
+    expect(abortSignal?.aborted).toBe(false);
+
+    unmount();
+    expect(abortSignal?.aborted).toBe(true);
   });
 });

--- a/packages/web/src/ui/components/__tests__/staging-banner.test.tsx
+++ b/packages/web/src/ui/components/__tests__/staging-banner.test.tsx
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { act, cleanup, render, screen } from "@testing-library/react";
+
+import { StagingBanner } from "@/ui/components/staging-banner";
+
+const originalFetch = globalThis.fetch;
+
+/** Replace `fetch` with a stub that resolves the health probe deterministically. */
+function stubHealth(body: unknown, ok = true): void {
+  globalThis.fetch = (() =>
+    Promise.resolve({
+      ok,
+      status: ok ? 200 : 503,
+      json: () => Promise.resolve(body),
+    } as Response)) as typeof fetch;
+}
+
+/** Flush the `fetch().then()` chain and the resulting React state update. */
+async function flush(): Promise<void> {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
+afterEach(() => {
+  cleanup();
+  globalThis.fetch = originalFetch;
+});
+
+describe("StagingBanner", () => {
+  it("renders the amber marker when the health probe reports the staging region", async () => {
+    stubHealth({ region: "staging" });
+
+    render(<StagingBanner />);
+
+    const banner = await screen.findByRole("status");
+    expect(banner.textContent).toContain("Staging environment");
+    expect(banner.querySelector("a")?.getAttribute("href")).toContain(
+      "staging-environment.md",
+    );
+  });
+
+  it("renders nothing on a production region", async () => {
+    stubHealth({ region: "us" });
+
+    render(<StagingBanner />);
+    await flush();
+
+    expect(screen.queryByRole("status")).toBeNull();
+  });
+
+  it("renders nothing (and does not throw) when the probe omits a region", async () => {
+    stubHealth({});
+
+    render(<StagingBanner />);
+    await flush();
+
+    expect(screen.queryByRole("status")).toBeNull();
+  });
+
+  it("renders nothing when the health probe returns a non-ok status", async () => {
+    stubHealth({}, false);
+
+    render(<StagingBanner />);
+    await flush();
+
+    expect(screen.queryByRole("status")).toBeNull();
+  });
+});

--- a/packages/web/src/ui/components/staging-banner.tsx
+++ b/packages/web/src/ui/components/staging-banner.tsx
@@ -5,20 +5,21 @@ import { useEffect, useState } from "react";
 import { getApiUrl } from "@/lib/api-url";
 import { cn } from "@/lib/utils";
 import { isStagingRegion } from "@/ui/lib/staging";
-import type { DeployRegion } from "@/ui/lib/types";
 
 /**
- * GitHub source for the staging runbook. The doc itself lands in a later
- * staging slice; the link is wired now so the banner is complete when it does.
- * It lives under the repo's `docs/development/` operator docs, not the published
- * docs.useatlas.dev site.
+ * Operator runbook for the staging soak environment. Lives under the repo's
+ * `docs/development/` operator docs, not the published docs.useatlas.dev site.
  */
 const STAGING_RUNBOOK_URL =
   "https://github.com/AtlasDevHQ/atlas/blob/main/docs/development/staging-environment.md";
 
-/** Minimal shape read from the public `GET /api/v1/health` response. */
+/**
+ * Minimal shape read from the public `GET /api/health` response. `region` is a
+ * raw `string` on the wire (`z.string().optional()` server-side), wider than the
+ * `DeployRegion` union — `isStagingRegion` defends against unknown values.
+ */
 interface HealthRegionResponse {
-  region?: DeployRegion;
+  region?: string;
 }
 
 /**
@@ -26,21 +27,23 @@ interface HealthRegionResponse {
  * it is the staging deploy, so a staging tab is never mistaken for production
  * during dogfood.
  *
- * Reads `region` from the public `GET /api/v1/health` endpoint (not the
- * auth-gated `/api/v1/mode`) so it renders before sign-in — login, signup, and
- * error pages included. Renders nothing on production (`us` | `eu` | `apac`) or
+ * Reads `region` from the public `GET /api/health` endpoint (not the auth-gated
+ * `/api/v1/mode`) so it renders before sign-in — login, signup, and error pages
+ * included. Renders nothing on production (`us` | `eu` | `apac`) or
  * self-hosted/dev (no region), so there is no layout shift outside staging.
  */
 export function StagingBanner() {
-  const [region, setRegion] = useState<DeployRegion | undefined>(undefined);
+  const [region, setRegion] = useState<string | undefined>(undefined);
 
   useEffect(() => {
     const controller = new AbortController();
     const base = getApiUrl().replace(/\/$/, "");
 
-    fetch(`${base}/api/v1/health`, { signal: controller.signal })
+    fetch(`${base}/api/health`, { signal: controller.signal })
       .then(async (res) => {
-        if (!res.ok) return;
+        if (!res.ok) {
+          throw new Error(`/api/health returned ${res.status}`);
+        }
         const body = (await res.json()) as HealthRegionResponse;
         setRegion(body.region);
       })
@@ -49,7 +52,7 @@ export function StagingBanner() {
         // Cosmetic marker: fail hidden (treated as non-staging) rather than
         // render a broken banner — but never swallow the error silently.
         console.debug(
-          "[staging-banner] /api/v1/health probe failed:",
+          "[staging-banner] /api/health probe failed:",
           err instanceof Error ? err.message : String(err),
         );
       });
@@ -64,7 +67,7 @@ export function StagingBanner() {
       role="status"
       className={cn(
         "flex h-8 shrink-0 items-center justify-center gap-2 px-4",
-        "bg-amber-500/90 text-amber-950 dark:bg-amber-500/80",
+        "bg-amber-500/90 text-amber-950 dark:bg-amber-500/80 dark:text-amber-950",
         "text-xs font-bold tracking-wider uppercase",
       )}
     >

--- a/packages/web/src/ui/components/staging-banner.tsx
+++ b/packages/web/src/ui/components/staging-banner.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { getApiUrl } from "@/lib/api-url";
+import { cn } from "@/lib/utils";
+import { isStagingRegion } from "@/ui/lib/staging";
+import type { DeployRegion } from "@/ui/lib/types";
+
+/**
+ * GitHub source for the staging runbook. The doc itself lands in a later
+ * staging slice; the link is wired now so the banner is complete when it does.
+ * It lives under the repo's `docs/development/` operator docs, not the published
+ * docs.useatlas.dev site.
+ */
+const STAGING_RUNBOOK_URL =
+  "https://github.com/AtlasDevHQ/atlas/blob/main/docs/development/staging-environment.md";
+
+/** Minimal shape read from the public `GET /api/v1/health` response. */
+interface HealthRegionResponse {
+  region?: DeployRegion;
+}
+
+/**
+ * Full-width amber marker shown at the top of every page when the API reports
+ * it is the staging deploy, so a staging tab is never mistaken for production
+ * during dogfood.
+ *
+ * Reads `region` from the public `GET /api/v1/health` endpoint (not the
+ * auth-gated `/api/v1/mode`) so it renders before sign-in — login, signup, and
+ * error pages included. Renders nothing on production (`us` | `eu` | `apac`) or
+ * self-hosted/dev (no region), so there is no layout shift outside staging.
+ */
+export function StagingBanner() {
+  const [region, setRegion] = useState<DeployRegion | undefined>(undefined);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    const base = getApiUrl().replace(/\/$/, "");
+
+    fetch(`${base}/api/v1/health`, { signal: controller.signal })
+      .then(async (res) => {
+        if (!res.ok) return;
+        const body = (await res.json()) as HealthRegionResponse;
+        setRegion(body.region);
+      })
+      .catch((err: unknown) => {
+        if (controller.signal.aborted) return;
+        // Cosmetic marker: fail hidden (treated as non-staging) rather than
+        // render a broken banner — but never swallow the error silently.
+        console.debug(
+          "[staging-banner] /api/v1/health probe failed:",
+          err instanceof Error ? err.message : String(err),
+        );
+      });
+
+    return () => controller.abort();
+  }, []);
+
+  if (!isStagingRegion(region)) return null;
+
+  return (
+    <div
+      role="status"
+      className={cn(
+        "flex h-8 shrink-0 items-center justify-center gap-2 px-4",
+        "bg-amber-500/90 text-amber-950 dark:bg-amber-500/80",
+        "text-xs font-bold tracking-wider uppercase",
+      )}
+    >
+      <span aria-hidden="true">&#9888;</span>
+      <span>Staging environment</span>
+      <span aria-hidden="true" className="text-amber-950/50">
+        &middot;
+      </span>
+      <a
+        href={STAGING_RUNBOOK_URL}
+        target="_blank"
+        rel="noreferrer"
+        className={cn(
+          "rounded-sm underline underline-offset-2 hover:text-amber-900",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-950",
+        )}
+      >
+        Runbook
+      </a>
+    </div>
+  );
+}

--- a/packages/web/src/ui/lib/__tests__/staging.test.ts
+++ b/packages/web/src/ui/lib/__tests__/staging.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "bun:test";
+
+import { isStagingRegion } from "@/ui/lib/staging";
+import type { DeployRegion } from "@/ui/lib/types";
+
+describe("isStagingRegion", () => {
+  it("is true only for the staging region", () => {
+    expect(isStagingRegion("staging")).toBe(true);
+  });
+
+  it("is false for every production region", () => {
+    const prodRegions: DeployRegion[] = ["us", "eu", "apac"];
+    for (const region of prodRegions) {
+      expect(isStagingRegion(region)).toBe(false);
+    }
+  });
+
+  it("treats a missing region as non-staging", () => {
+    expect(isStagingRegion(undefined)).toBe(false);
+    expect(isStagingRegion(null)).toBe(false);
+  });
+
+  it("never mistakes an unrecognized region for staging", () => {
+    // Defensive: a region the client's union doesn't know about must never
+    // be treated as staging.
+    expect(isStagingRegion("production" as DeployRegion)).toBe(false);
+  });
+});

--- a/packages/web/src/ui/lib/__tests__/staging.test.ts
+++ b/packages/web/src/ui/lib/__tests__/staging.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "bun:test";
 
 import { isStagingRegion } from "@/ui/lib/staging";
-import type { DeployRegion } from "@/ui/lib/types";
 
 describe("isStagingRegion", () => {
   it("is true only for the staging region", () => {
@@ -9,8 +8,7 @@ describe("isStagingRegion", () => {
   });
 
   it("is false for every production region", () => {
-    const prodRegions: DeployRegion[] = ["us", "eu", "apac"];
-    for (const region of prodRegions) {
+    for (const region of ["us", "eu", "apac"]) {
       expect(isStagingRegion(region)).toBe(false);
     }
   });
@@ -21,8 +19,9 @@ describe("isStagingRegion", () => {
   });
 
   it("never mistakes an unrecognized region for staging", () => {
-    // Defensive: a region the client's union doesn't know about must never
-    // be treated as staging.
-    expect(isStagingRegion("production" as DeployRegion)).toBe(false);
+    // The wire field is a raw string, so any value outside the known regions
+    // must fail closed.
+    expect(isStagingRegion("production")).toBe(false);
+    expect(isStagingRegion("")).toBe(false);
   });
 });

--- a/packages/web/src/ui/lib/staging.ts
+++ b/packages/web/src/ui/lib/staging.ts
@@ -1,0 +1,12 @@
+import type { DeployRegion } from "@/ui/lib/types";
+
+/**
+ * True when the deploy region identifies the staging soak environment.
+ *
+ * The `region` field from `GET /api/v1/health` is optional (self-hosted deploys
+ * omit it). A missing region — or any production region (`us` | `eu` | `apac`) —
+ * is treated as non-staging so the marker stays hidden outside staging.
+ */
+export function isStagingRegion(region: DeployRegion | null | undefined): boolean {
+  return region === "staging";
+}

--- a/packages/web/src/ui/lib/staging.ts
+++ b/packages/web/src/ui/lib/staging.ts
@@ -1,12 +1,12 @@
-import type { DeployRegion } from "@/ui/lib/types";
-
 /**
  * True when the deploy region identifies the staging soak environment.
  *
- * The `region` field from `GET /api/v1/health` is optional (self-hosted deploys
- * omit it). A missing region — or any production region (`us` | `eu` | `apac`) —
- * is treated as non-staging so the marker stays hidden outside staging.
+ * The `region` field from `GET /api/health` is optional (self-hosted deploys
+ * omit it) and is a raw `string` on the wire, so this accepts `string` rather
+ * than the narrower `DeployRegion` union. A missing region — or any production
+ * region (`us` | `eu` | `apac`) — is treated as non-staging so the marker stays
+ * hidden outside staging.
  */
-export function isStagingRegion(region: DeployRegion | null | undefined): boolean {
+export function isStagingRegion(region: string | null | undefined): boolean {
   return region === "staging";
 }

--- a/packages/web/src/ui/lib/types.ts
+++ b/packages/web/src/ui/lib/types.ts
@@ -100,6 +100,7 @@ export type {
   UserActivityReport,
 } from "@useatlas/types";
 export type {
+  DeployRegion,
   DeployMode,
   DeployModeSetting,
   PlatformWorkspace,

--- a/packages/web/src/ui/lib/types.ts
+++ b/packages/web/src/ui/lib/types.ts
@@ -100,7 +100,6 @@ export type {
   UserActivityReport,
 } from "@useatlas/types";
 export type {
-  DeployRegion,
   DeployMode,
   DeployModeSetting,
   PlatformWorkspace,


### PR DESCRIPTION
## What
Adds an amber top banner on the web app shell, visible on **every page** when the deployed region is `"staging"`, so a staging tab is never confused with prod during dogfood. Implements #2915.

## How
- **`StagingBanner`** (`packages/web/src/ui/components/staging-banner.tsx`, `"use client"`) fetches `region` from the **public** `GET /api/v1/health` (not the auth-gated `/api/v1/mode`), so it renders before sign-in. Mounted in root `app/layout.tsx` **outside `AuthGuard`** (first flex child of `<body>`) → covers login/signup/error pages and every route group.
- Region gate extracted to `isStagingRegion()` (`ui/lib/staging.ts`), unit-tested first (TDD).
- Renders `null` on prod (`us`|`eu`|`apac`) and self-hosted (no region) → **no layout shift** outside staging.
- `DeployRegion` re-exported through `@/ui/lib/types` so `region === "staging"` narrows (#2897). `HealthResponse` isn't exported by `@useatlas/types`, so a minimal inline response type is used.
- Uses `getApiUrl()` from `@/lib/api-url` and `cn` from `@/lib/utils`; visual style matches the existing `ModeBanner` (amber `role="status"` bar).
- Runbook link → `docs/development/staging-environment.md` (lands in a later staging slice).

## Accessibility
`role="status"`, `text-amber-950` on `bg-amber-500` (same combo as ModeBanner, AA-compliant), bold uppercase, decorative glyphs `aria-hidden`, `focus-visible` ring on the runbook link.

## Acceptance criteria
- [x] Renders on every page when `/health` `region === "staging"`
- [x] Visible pre-sign-in (login/signup/error — mounted outside AuthGuard at root layout)
- [x] Hidden on prod (`us`|`eu`|`apac`)
- [x] No layout shift on prod (returns `null`)
- [x] Accessible (`role="status"`, AA contrast, focus ring)

## Test plan
Local gates green: type ✅ · lint ✅ · web tests ✅ (169/169 files, incl. new `staging.test.ts` TDD: red→green) · template-drift ✅. syncpack/railway unaffected (diff is `packages/web/src/**` only, no manifest or deploy-config changes).

Closes #2915

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3027"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782764224&installation_id=135337507&pr_number=3027&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3027&signature=e5fef39aa5702075c60df5a35b1bd166845d76bb80758c62ab34502dbfd4f9ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a client-side staging environment banner and integrated it into the app layout.
  * Added a small utility to detect the staging region.

* **Tests**
  * Added unit tests for the staging-region utility.
  * Added component tests verifying banner behavior, probe handling, and abort-on-unmount.

* **Documentation**
  * Added a staging environment runbook.
  * Updated plugin SDK health-check documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AtlasDevHQ/atlas/pull/3027?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->