### PR TITLE
feat(api): data-candidate wrapper + vendor-quirk hook + stripe-data (#3028)

### DIFF
--- a/packages/api/src/lib/auth/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/auth/__tests__/migrate.test.ts
@@ -354,6 +354,7 @@ describe("migrateAuthTables", () => {
             { name: "0106_crm_outbox_workspace_id.sql" },
             { name: "0107_email_outbox.sql" },
             { name: "0108_openapi_generic_catalog.sql" },
+            { name: "0109_data_candidate_catalog.sql" },
           ],
         };
       }

--- a/packages/api/src/lib/db/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate.test.ts
@@ -126,7 +126,7 @@ describe("runMigrations", () => {
     //   #2849 (workspace_id on crm_outbox) = 107. Plus
     //   0107 (email_outbox durable queue for transactional email, #2942) = 108.
     //   Plus 0108 (openapi-generic catalog row, #2926) = 109.
-    expect(count).toBe(109);
+    expect(count).toBe(110);
 
     // Advisory lock acquired before anything else
     expect(queries[0]).toContain("pg_advisory_lock");
@@ -264,6 +264,7 @@ describe("runMigrations", () => {
         "0106_crm_outbox_workspace_id.sql",
         "0107_email_outbox.sql",
         "0108_openapi_generic_catalog.sql",
+        "0109_data_candidate_catalog.sql",
       ],
     });
 

--- a/packages/api/src/lib/db/migrations/0109_data_candidate_catalog.sql
+++ b/packages/api/src/lib/db/migrations/0109_data_candidate_catalog.sql
@@ -1,0 +1,56 @@
+-- 0109_data_candidate_catalog — v0.0.2 slice 6a (#3028)
+--
+-- Seed the built-in vendor `*-data` Datasource catalog rows: thin, pre-wired
+-- wrappers over the same generic OpenAPI primitive `openapi-generic` exposes
+-- (migration 0108). A candidate row pre-fills the spec URL + auth kind in code
+-- (lib/openapi/data-candidates.ts), so the admin installs e.g. "Stripe" by
+-- pasting only their secret key — no spec URL. Stripe is the first candidate;
+-- Notion (#3029) and GitHub (#3030) add their own rows.
+--
+-- Per ADR-0007 these are code-seeded — the boot pass re-asserts each row
+-- idempotently (lib/openapi/data-candidate-seed.ts, run from the openapi-generic
+-- seed boot wrapper); this migration inserts them on fresh + already-migrated
+-- DBs. The two share DATA_CANDIDATE_CONFIG_SCHEMA + the DATA_CANDIDATES registry
+-- (lib/openapi/data-candidates.ts) as the single source of truth — keep this JSON
+-- in lockstep (the `migration 0109 ↔ code alignment` test asserts they match).
+--
+-- These rows are INTENTIONALLY NOT in `BUILTIN_DATASOURCE_CATALOG_SLUGS`
+-- (datasource-pool-resolver.ts): a REST datasource has no SQL pool, so the boot
+-- loader skips its installs and they resolve through the parallel workspace REST
+-- resolver instead — exactly like `openapi-generic`.
+--
+-- `auth_value` carries `secret: true` so encryptSecretFields encrypts the
+-- credential in `workspace_plugins.config` at install time. The install form
+-- omits `openapi_url` / `auth_kind` entirely (pre-filled from the registry), so a
+-- candidate install can never re-point the locked spec URL.
+--
+-- Idempotent: `ON CONFLICT DO NOTHING` covers both the slug unique index and the
+-- `id` primary key, so re-running on a populated catalog is a no-op.
+
+INSERT INTO plugin_catalog
+  (id, name, slug, description, type, install_model, pillar,
+   implementation_status, auto_install, min_plan, enabled, saas_eligible,
+   config_schema, created_at, updated_at)
+VALUES
+  (
+    'catalog:stripe-data',
+    'Stripe',
+    'stripe-data',
+    'Query your Stripe account (customers, charges, invoices, subscriptions, …) as a read-only REST datasource. Pre-wired to Stripe''s published OpenAPI spec — paste your secret key, no spec URL needed. The agent discovers operations from the spec and queries them directly.',
+    'datasource',
+    'form',
+    'datasource',
+    'available',
+    false,
+    'starter',
+    true,
+    true,
+    '[
+      {"key": "auth_value", "type": "string", "label": "API key / token", "required": true, "secret": true, "description": "The API credential for this datasource (e.g. your Stripe secret key). Encrypted at rest."},
+      {"key": "base_url_override", "type": "string", "label": "Base URL override", "description": "When the spec''s servers[0].url is wrong (dev/staging/regional host)."},
+      {"key": "display_name", "type": "string", "label": "Display name", "description": "Friendly name shown in /admin/connections."}
+    ]'::jsonb,
+    NOW(),
+    NOW()
+  )
+ON CONFLICT DO NOTHING;

--- a/packages/api/src/lib/integrations/install/__tests__/data-candidate-form-handler.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/data-candidate-form-handler.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Tests for `DataCandidateFormInstallHandler` (v0.0.2 slice 6a, #3028). Drives
+ * the slim candidate install path with an injected probe `fetch` (no live HTTP) +
+ * a mocked `internalQuery`, asserting: the slim form rejects spec-URL / auth-kind
+ * fields (locked), the probe uses the candidate's pre-filled URL, `auth_value` is
+ * encrypted, and the row is inserted under the candidate's catalog id.
+ */
+import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
+import { _resetEncryptionKeyCache } from "@atlas/api/lib/db/encryption-keys";
+import { DataCandidateFormDataSchema } from "../data-candidate-form-handler";
+import { STRIPE_DATA_CANDIDATE } from "@atlas/api/lib/openapi/data-candidates";
+
+describe("DataCandidateFormDataSchema", () => {
+  it("accepts a minimal credential-only install", () => {
+    const parsed = DataCandidateFormDataSchema.safeParse({ auth_value: "sk_live_x" });
+    expect(parsed.success).toBe(true);
+  });
+
+  it("requires auth_value", () => {
+    const parsed = DataCandidateFormDataSchema.safeParse({});
+    expect(parsed.success).toBe(false);
+  });
+
+  it("rejects a locked field (openapi_url / auth_kind) via the strict schema", () => {
+    expect(
+      DataCandidateFormDataSchema.safeParse({ auth_value: "x", openapi_url: "https://evil/spec" })
+        .success,
+    ).toBe(false);
+    expect(
+      DataCandidateFormDataSchema.safeParse({ auth_value: "x", auth_kind: "none" }).success,
+    ).toBe(false);
+  });
+});
+
+describe("DataCandidateFormInstallHandler.validateConfig", () => {
+  const STRIPE_FIXTURE_SPEC = {
+    openapi: "3.0.0",
+    info: { title: "Stripe API", version: "2024-06-20" },
+    servers: [{ url: "https://api.stripe.com/" }],
+    paths: {
+      "/v1/customers": {
+        get: { operationId: "GetCustomers", responses: { "200": { description: "ok" } } },
+      },
+    },
+  };
+
+  let queryCalls: Array<{ sql: string; params: unknown[] }>;
+  let probedUrls: string[];
+  const ORIGINAL_ENV = { ...process.env };
+
+  beforeEach(() => {
+    queryCalls = [];
+    probedUrls = [];
+    // Set an encryption keyset so auth_value is actually encrypted at rest
+    // (mirrors openapi-generic-form-handler.test.ts:setKeys) — without it the
+    // keyless dev passthrough stores plaintext and the encryption assertions fail.
+    process.env.ATLAS_ENCRYPTION_KEYS = "v1:test-key-for-data-candidate-handler-unit-tests-32b";
+    delete process.env.ATLAS_ENCRYPTION_KEY;
+    delete process.env.BETTER_AUTH_SECRET;
+    delete process.env.ATLAS_DEPLOY_MODE;
+    _resetEncryptionKeyCache();
+    // Mock every export the install graph might import (partial mock.module trips
+    // "Export not found" on a transitive import — CLAUDE.md).
+    mock.module("@atlas/api/lib/db/internal", () => ({
+      internalQuery: async (sql: string, params: unknown[]) => {
+        queryCalls.push({ sql, params });
+        return [{ id: (params[0] as string) ?? "generated-id" }];
+      },
+      hasInternalDB: () => true,
+      getInternalDB: () => ({ query: async () => ({ rows: [] }) }),
+    }));
+  });
+
+  afterEach(() => {
+    mock.restore();
+    process.env = { ...ORIGINAL_ENV };
+    _resetEncryptionKeyCache();
+  });
+
+  it("probes the candidate's locked spec URL, encrypts auth_value, inserts under its catalog id", async () => {
+    const { DataCandidateFormInstallHandler } = await import("../data-candidate-form-handler");
+    const handler = new DataCandidateFormInstallHandler(STRIPE_DATA_CANDIDATE, {
+      idGenerator: () => "fixed-uuid",
+      now: () => "2026-05-30T00:00:00.000Z",
+      fetchImpl: (async (input: string | URL) => {
+        probedUrls.push(typeof input === "string" ? input : input.toString());
+        return new Response(JSON.stringify(STRIPE_FIXTURE_SPEC), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }) as unknown as typeof globalThis.fetch,
+    });
+
+    const result = await handler.validateConfig("ws-1" as never, { auth_value: "sk_live_secret" });
+
+    expect(result.credentialWritten).toBe(true);
+    expect(result.installRecord.id).toBe("fixed-uuid");
+    // InstallRecord carries the candidate slug.
+    expect(result.installRecord.catalogId).toBe("stripe-data");
+    // The probe used the candidate's pre-filled spec URL (admin never supplied one).
+    expect(probedUrls[0]).toBe(STRIPE_DATA_CANDIDATE.openapiUrl);
+
+    const insertCall = queryCalls.find((c) => c.sql.includes("INSERT INTO workspace_plugins"));
+    expect(insertCall).toBeDefined();
+    // Row inserted under the candidate catalog id (catalog:stripe-data), encrypted.
+    expect(insertCall!.params[2]).toBe(STRIPE_DATA_CANDIDATE.catalogId);
+    const configJson = insertCall!.params[3] as string;
+    expect(configJson).toContain("enc:"); // versioned ciphertext prefix
+    expect(configJson).not.toContain("sk_live_secret");
+    // The locked spec URL + auth kind are persisted from the candidate, not the form.
+    expect(configJson).toContain(STRIPE_DATA_CANDIDATE.openapiUrl);
+  });
+});

--- a/packages/api/src/lib/integrations/install/__tests__/data-candidate-form-handler.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/data-candidate-form-handler.test.ts
@@ -21,6 +21,10 @@ describe("DataCandidateFormDataSchema", () => {
     expect(parsed.success).toBe(false);
   });
 
+  it("rejects a whitespace-only auth_value (trim runs before min(1))", () => {
+    expect(DataCandidateFormDataSchema.safeParse({ auth_value: "   " }).success).toBe(false);
+  });
+
   it("rejects a locked field (openapi_url / auth_kind) via the strict schema", () => {
     expect(
       DataCandidateFormDataSchema.safeParse({ auth_value: "x", openapi_url: "https://evil/spec" })

--- a/packages/api/src/lib/integrations/install/data-candidate-form-handler.ts
+++ b/packages/api/src/lib/integrations/install/data-candidate-form-handler.ts
@@ -59,9 +59,11 @@ export const DataCandidateFormDataSchema = z
   .object({
     auth_value: z
       .string()
+      // Trim BEFORE min/max so a whitespace-only paste (e.g. "   ") is rejected by
+      // .min(1) rather than passing the length check and trimming to "" downstream.
+      .trim()
       .min(1, "auth_value is required")
-      .max(AUTH_VALUE_MAX, `auth_value must be ${AUTH_VALUE_MAX} characters or fewer`)
-      .transform((raw) => raw.trim()),
+      .max(AUTH_VALUE_MAX, `auth_value must be ${AUTH_VALUE_MAX} characters or fewer`),
     base_url_override: OptionalUrlSchema,
     display_name: z.string().trim().max(256).optional(),
   })

--- a/packages/api/src/lib/integrations/install/data-candidate-form-handler.ts
+++ b/packages/api/src/lib/integrations/install/data-candidate-form-handler.ts
@@ -1,0 +1,115 @@
+/**
+ * `DataCandidateFormInstallHandler` — admin install flow for a built-in vendor
+ * `*-data` REST datasource (v0.0.2 slice 6a, #3028; Stripe today, Notion #3029 /
+ * GitHub #3030 next).
+ *
+ * The "thin wrapper" the slice exists to prove: this handler owns NO install
+ * logic of its own. It parses a SLIM form (just the credential + optional
+ * overrides — no `openapi_url`, no `auth_kind` field, because those are pre-filled
+ * from the {@link DataCandidate} registry), then delegates to the SAME
+ * {@link persistOpenApiDatasourceInstall} core the generic OpenAPI handler uses
+ * (probe → snapshot → schema-driven encryption → multi-instance INSERT). The only
+ * per-candidate inputs are the registry's `openapiUrl` / `authKind` / `catalogId`
+ * / `slug` — there is no forked probe, encryption, or persistence path.
+ *
+ * One handler instance per candidate (constructed with its {@link DataCandidate}),
+ * registered under the candidate's slug in `register.ts`. The admin installs
+ * "Stripe" by pasting only their secret key — the spec URL is locked.
+ */
+
+import crypto from "crypto";
+import { z } from "zod";
+import type { WorkspaceId } from "@useatlas/types";
+import {
+  DATA_CANDIDATE_CONFIG_SCHEMA,
+  type DataCandidate,
+} from "@atlas/api/lib/openapi/data-candidates";
+import { FormInstallValidationError } from "./email-form-handler";
+import {
+  persistOpenApiDatasourceInstall,
+  type OpenApiGenericFormInstallHandlerOptions,
+} from "./openapi-generic-form-handler";
+import type { FormBasedInstallHandler, InstallRecord } from "./types";
+
+/** Defensive upper bound on the credential — guards against pathological pastes. */
+const AUTH_VALUE_MAX = 8192;
+
+const OptionalUrlSchema = z
+  .string()
+  .transform((raw) => raw.trim())
+  .refine((raw) => {
+    if (raw.length === 0) return true;
+    try {
+      const u = new URL(raw);
+      return u.protocol === "https:" || u.protocol === "http:";
+    } catch {
+      // intentionally ignored: URL-constructor throw is the negative signal.
+      return false;
+    }
+  }, "base_url_override must be a well-formed http(s) URL")
+  .optional();
+
+/**
+ * The slim candidate install form. Mirrors {@link DATA_CANDIDATE_CONFIG_SCHEMA}:
+ * the admin supplies only the credential (+ optional overrides). `openapi_url` and
+ * `auth_kind` are DELIBERATELY absent — pre-filled from the candidate so an
+ * install can never re-point the locked spec URL or change the auth scheme.
+ */
+export const DataCandidateFormDataSchema = z
+  .object({
+    auth_value: z
+      .string()
+      .min(1, "auth_value is required")
+      .max(AUTH_VALUE_MAX, `auth_value must be ${AUTH_VALUE_MAX} characters or fewer`)
+      .transform((raw) => raw.trim()),
+    base_url_override: OptionalUrlSchema,
+    display_name: z.string().trim().max(256).optional(),
+  })
+  .strict();
+
+export type DataCandidateFormData = z.infer<typeof DataCandidateFormDataSchema>;
+
+export class DataCandidateFormInstallHandler implements FormBasedInstallHandler {
+  readonly kind = "form" as const;
+
+  private readonly candidate: DataCandidate;
+  private readonly newId: () => string;
+  private readonly now: () => string;
+  private readonly fetchImpl: typeof globalThis.fetch | undefined;
+
+  constructor(candidate: DataCandidate, options: OpenApiGenericFormInstallHandlerOptions = {}) {
+    this.candidate = candidate;
+    this.newId = options.idGenerator ?? (() => crypto.randomUUID());
+    this.now = options.now ?? (() => new Date().toISOString());
+    this.fetchImpl = options.fetchImpl;
+  }
+
+  async validateConfig(
+    workspaceId: WorkspaceId,
+    formData: unknown,
+  ): Promise<{ readonly installRecord: InstallRecord; readonly credentialWritten: boolean }> {
+    const parsed = DataCandidateFormDataSchema.safeParse(formData);
+    if (!parsed.success) {
+      throw FormInstallValidationError.fromZodFlatten(parsed.error.flatten());
+    }
+    const data = parsed.data;
+
+    // Delegate to the shared core, pre-filling the locked spec URL + auth kind
+    // from the candidate registry. No forked install logic — same probe / encrypt
+    // / insert path the generic handler runs.
+    return persistOpenApiDatasourceInstall({
+      workspaceId,
+      catalogId: this.candidate.catalogId,
+      catalogSlug: this.candidate.slug,
+      configSchema: DATA_CANDIDATE_CONFIG_SCHEMA,
+      openapiUrl: this.candidate.openapiUrl,
+      authKind: this.candidate.authKind,
+      authValue: data.auth_value,
+      ...(data.base_url_override ? { baseUrlOverride: data.base_url_override } : {}),
+      ...(data.display_name ? { displayName: data.display_name } : {}),
+      newId: this.newId,
+      now: this.now,
+      ...(this.fetchImpl ? { fetchImpl: this.fetchImpl } : {}),
+    });
+  }
+}

--- a/packages/api/src/lib/integrations/install/openapi-generic-form-handler.ts
+++ b/packages/api/src/lib/integrations/install/openapi-generic-form-handler.ts
@@ -43,6 +43,7 @@ import { getEncryptionKeyset } from "@atlas/api/lib/db/encryption-keys";
 import { isPlaintextCredentialRisk } from "@atlas/api/lib/db/secret-encryption";
 import { encryptSecretFields, parseConfigSchema } from "@atlas/api/lib/plugins/secrets";
 import { assertBaseUrlAllowed, EgressBlockedError } from "@atlas/api/lib/openapi/egress-guard";
+import type { ConfigSchemaField } from "@atlas/api/lib/plugins/registry";
 import type { WorkspaceId } from "@useatlas/types";
 import {
   OPENAPI_GENERIC_SLUG,
@@ -52,6 +53,7 @@ import {
   OPENAPI_SUPPORTED_AUTH_KINDS,
   DEFAULT_REPRESENTATION_MODE,
   narrowSupportedAuthKind,
+  type SupportedAuthKind,
 } from "@atlas/api/lib/openapi/catalog";
 import {
   buildResolvedAuth,
@@ -212,69 +214,10 @@ export class OpenApiGenericFormInstallHandler implements FormBasedInstallHandler
     }
     const data = parsed.data;
 
-    // ── 2. SaaS keyset gate ─────────────────────────────────────────
-    if (process.env.ATLAS_DEPLOY_MODE === "saas" && !getEncryptionKeyset()) {
-      log.error(
-        { workspaceId },
-        "Refusing form install: SaaS mode + no encryption keyset (would persist plaintext auth_value)",
-      );
-      throw new Error(
-        "Encryption keyset unavailable in SaaS mode — refusing to persist plaintext credentials. " +
-          "Set ATLAS_ENCRYPTION_KEYS and retry.",
-      );
-    }
-
-    // ── 2a. Self-hosted plaintext-credential warning (non-fatal) ────
-    // The SaaS gate above hard-fails. A self-hosted prod-like deploy with a
-    // credential and no keyset is *allowed* — the keyless dev passthrough in
-    // `encryptSecret` is intentional repo-wide parity — but it must not be
-    // silent. Mirror the boot-time P0 alarm via the shared predicate so the
-    // operator gets the same signal at the credential boundary rather than
-    // only on a later read of plaintext-at-rest. (In SaaS + no keyset we
-    // already threw above, so this only fires for self-hosted NODE_ENV=production.)
-    if (data.auth_value && isPlaintextCredentialRisk()) {
-      log.warn(
-        { workspaceId },
-        "Persisting an OpenAPI datasource credential with no encryption keyset configured in a " +
-          "prod-like environment — auth_value will be stored in plaintext. Set ATLAS_ENCRYPTION_KEYS " +
-          "(or ATLAS_ENCRYPTION_KEY / BETTER_AUTH_SECRET) to encrypt integration credentials at rest.",
-      );
-    }
-
-    // ── 2b. SSRF guard for base_url_override ────────────────────────
-    // The override becomes the operations base URL the agent later sends requests
-    // to, host-side, via `executeRestOperation`. It's admin-supplied, so block
-    // private/internal targets via the shared chokepoint (the spec URL itself is
-    // guarded inside `probeSpec`). The guard is ON in every deploy mode;
-    // self-hosted operators opt OUT via ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS (#3006).
-    if (data.base_url_override) {
-      try {
-        assertBaseUrlAllowed(data.base_url_override);
-      } catch (err) {
-        if (err instanceof EgressBlockedError) {
-          throw FormInstallValidationError.fromZodFlatten({
-            fieldErrors: {
-              base_url_override: [
-                "Base URL must use HTTPS and resolve to a public host — private or internal " +
-                  "addresses are blocked. Set ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS=true to allow " +
-                  "internal targets (self-hosted only).",
-              ],
-            },
-            formErrors: [],
-          });
-        }
-        throw err;
-      }
-    }
-
-    // ── 3. Probe the spec (slice-0) → snapshot ──────────────────────
-    // The credential is needed because some specs (Twenty) require auth to read
-    // `/open-api/core`. A probe failure is a user-fixable input error → 400 on
-    // the offending field, not a 500.
-    //
-    // `data.auth_kind` is guaranteed non-oauth2 here (the schema's superRefine
-    // fails the parse for oauth2 above); narrow to SupportedAuthKind so
-    // buildResolvedAuth is called total. The `null` arm is unreachable.
+    // ── 2. Narrow the form's auth kind to the executable subset ─────
+    // oauth2 is rejected by the schema's superRefine above; the `null` arm is
+    // unreachable but kept total so `persistOpenApiDatasourceInstall` receives a
+    // {@link SupportedAuthKind}, never a raw form string.
     const supportedKind = narrowSupportedAuthKind(data.auth_kind);
     if (!supportedKind) {
       throw FormInstallValidationError.fromZodFlatten({
@@ -284,111 +227,241 @@ export class OpenApiGenericFormInstallHandler implements FormBasedInstallHandler
         formErrors: [],
       });
     }
-    const auth = buildResolvedAuth(
-      supportedKind,
-      data.auth_value,
-      data.auth_header_name,
-      data.auth_param_name,
+
+    // ── 3. Shared probe → encrypt → insert core ─────────────────────
+    // Everything past form parsing (keyset gate, plaintext warning, SSRF guard,
+    // probe→snapshot, schema-driven encryption, multi-instance INSERT) is the
+    // SAME for every OpenAPI datasource install — the generic row here AND the
+    // built-in data candidates (slice 6a, #3028) — so it lives in one shared
+    // function. A candidate handler is then a thin wrapper that pre-fills
+    // openapi_url + auth_kind and calls the same core (no forked install path).
+    return persistOpenApiDatasourceInstall({
+      workspaceId,
+      catalogId: OPENAPI_GENERIC_CATALOG_ID,
+      catalogSlug: OPENAPI_GENERIC_SLUG,
+      configSchema: OPENAPI_GENERIC_CONFIG_SCHEMA,
+      openapiUrl: data.openapi_url,
+      authKind: supportedKind,
+      ...(data.auth_value ? { authValue: data.auth_value } : {}),
+      ...(data.auth_header_name ? { authHeaderName: data.auth_header_name } : {}),
+      ...(data.auth_param_name ? { authParamName: data.auth_param_name } : {}),
+      ...(data.base_url_override ? { baseUrlOverride: data.base_url_override } : {}),
+      ...(data.write_allowlist ? { writeAllowlist: data.write_allowlist } : {}),
+      ...(data.display_name ? { displayName: data.display_name } : {}),
+      newId: this.newId,
+      now: this.now,
+      ...(this.fetchImpl ? { fetchImpl: this.fetchImpl } : {}),
+    });
+  }
+}
+
+/**
+ * Params for {@link persistOpenApiDatasourceInstall} — the resolved (post-form)
+ * inputs every OpenAPI datasource install shares. `authKind` is the already-
+ * narrowed {@link SupportedAuthKind} (oauth2 unrepresentable). `catalogId` is the
+ * `catalog:*` FK written to the row; `catalogSlug` is the bare slug returned on
+ * the {@link InstallRecord}. `configSchema`'s `secret: true` flags drive
+ * encryption — never named here.
+ */
+export interface PersistOpenApiDatasourceInstallParams {
+  readonly workspaceId: WorkspaceId;
+  readonly catalogId: string;
+  readonly catalogSlug: string;
+  readonly configSchema: ReadonlyArray<ConfigSchemaField>;
+  readonly openapiUrl: string;
+  readonly authKind: SupportedAuthKind;
+  readonly authValue?: string;
+  readonly authHeaderName?: string;
+  readonly authParamName?: string;
+  readonly baseUrlOverride?: string;
+  readonly writeAllowlist?: string;
+  readonly displayName?: string;
+  readonly newId: () => string;
+  readonly now: () => string;
+  readonly fetchImpl?: typeof globalThis.fetch;
+}
+
+/**
+ * The shared OpenAPI datasource install core: keyset gate → plaintext warning →
+ * SSRF guard → probe→snapshot → schema-driven encryption → multi-instance
+ * INSERT. Extracted from {@link OpenApiGenericFormInstallHandler.validateConfig}
+ * (slice 6a, #3028) so the generic handler AND every built-in data-candidate
+ * handler share ONE install path — the candidate is a thin wrapper that pre-fills
+ * `openapiUrl` + `authKind` and calls this, never a fork.
+ *
+ * A probe failure surfaces as a field-level {@link FormInstallValidationError} on
+ * `openapi_url`; the SaaS keyset gate hard-fails; a self-hosted prod deploy with
+ * no keyset warns (non-fatal). Inserts a fresh `install_id` every call
+ * (multi-instance) under `status='draft'`.
+ */
+export async function persistOpenApiDatasourceInstall(
+  params: PersistOpenApiDatasourceInstallParams,
+): Promise<{ readonly installRecord: InstallRecord; readonly credentialWritten: boolean }> {
+  const {
+    workspaceId,
+    catalogId,
+    catalogSlug,
+    configSchema,
+    openapiUrl,
+    authKind,
+    authValue,
+    authHeaderName,
+    authParamName,
+    baseUrlOverride,
+    writeAllowlist,
+    displayName,
+    newId,
+    now,
+    fetchImpl,
+  } = params;
+
+  // ── SaaS keyset gate ──────────────────────────────────────────────
+  if (process.env.ATLAS_DEPLOY_MODE === "saas" && !getEncryptionKeyset()) {
+    log.error(
+      { workspaceId, catalogSlug },
+      "Refusing form install: SaaS mode + no encryption keyset (would persist plaintext auth_value)",
     );
-    const probeOpts: ProbeOptions = this.fetchImpl ? { fetchImpl: this.fetchImpl } : {};
-    let snapshot;
+    throw new Error(
+      "Encryption keyset unavailable in SaaS mode — refusing to persist plaintext credentials. " +
+        "Set ATLAS_ENCRYPTION_KEYS and retry.",
+    );
+  }
+
+  // ── Self-hosted plaintext-credential warning (non-fatal) ──────────
+  // The SaaS gate above hard-fails. A self-hosted prod-like deploy with a
+  // credential and no keyset is *allowed* (keyless dev passthrough is intentional
+  // repo-wide parity) but must not be silent — mirror the boot-time P0 alarm.
+  if (authValue && isPlaintextCredentialRisk()) {
+    log.warn(
+      { workspaceId, catalogSlug },
+      "Persisting an OpenAPI datasource credential with no encryption keyset configured in a " +
+        "prod-like environment — auth_value will be stored in plaintext. Set ATLAS_ENCRYPTION_KEYS " +
+        "(or ATLAS_ENCRYPTION_KEY / BETTER_AUTH_SECRET) to encrypt integration credentials at rest.",
+    );
+  }
+
+  // ── SSRF guard for base_url_override ──────────────────────────────
+  // The override becomes the operations base URL the agent later sends requests
+  // to, host-side, via `executeRestOperation`. Block private/internal targets via
+  // the shared chokepoint (the spec URL itself is guarded inside `probeSpec`).
+  // Self-hosted operators opt OUT via ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS (#3006).
+  if (baseUrlOverride) {
     try {
-      const { doc, graph } = await probeSpec(data.openapi_url, auth, probeOpts);
-      snapshot = buildSnapshot(doc, graph, this.now());
+      assertBaseUrlAllowed(baseUrlOverride);
     } catch (err) {
-      if (err instanceof OpenApiProbeError) {
-        log.warn(
-          { workspaceId, reason: err.reason },
-          "OpenAPI install probe failed — surfacing as field validation error",
-        );
-        // Point the modal at openapi_url for every probe failure class
-        // (unreachable / http_error / unparseable / no_operations) — the spec
-        // URL is the field the admin can act on; the message carries the detail.
+      if (err instanceof EgressBlockedError) {
         throw FormInstallValidationError.fromZodFlatten({
-          fieldErrors: { openapi_url: [err.message] },
+          fieldErrors: {
+            base_url_override: [
+              "Base URL must use HTTPS and resolve to a public host — private or internal " +
+                "addresses are blocked. Set ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS=true to allow " +
+                "internal targets (self-hosted only).",
+            ],
+          },
           formErrors: [],
         });
       }
-      log.error(
-        { workspaceId, err: err instanceof Error ? err.message : String(err) },
-        "OpenAPI install probe threw unexpectedly",
-      );
       throw err;
     }
-
-    // ── 4. Assemble config + encrypt secret fields ──────────────────
-    // The catalog `config_schema`'s `secret: true` flag drives encryption — we
-    // never name `auth_value` explicitly here. Operational metadata
-    // (representation_mode, openapi_snapshot) is non-secret and passes through.
-    const rawConfig: Record<string, unknown> = {
-      openapi_url: data.openapi_url,
-      auth_kind: data.auth_kind,
-      ...(data.auth_value ? { auth_value: data.auth_value } : {}),
-      ...(data.auth_header_name ? { auth_header_name: data.auth_header_name } : {}),
-      ...(data.auth_param_name ? { auth_param_name: data.auth_param_name } : {}),
-      ...(data.base_url_override ? { base_url_override: data.base_url_override } : {}),
-      ...(data.write_allowlist ? { write_allowlist: data.write_allowlist } : {}),
-      display_name: data.display_name || snapshot.title,
-      representation_mode: DEFAULT_REPRESENTATION_MODE,
-      openapi_snapshot: snapshot,
-    };
-    const schema = parseConfigSchema(OPENAPI_GENERIC_CONFIG_SCHEMA);
-    const encryptedConfig = encryptSecretFields(rawConfig, schema);
-
-    // ── 5. Insert a fresh multi-instance datasource row ─────────────
-    // Same UUID for `id` and `install_id` (mirrors the Twenty handler). Fresh
-    // every submit — multi-instance, so no `(workspace_id, catalog_id)`
-    // conflict. The `(workspace_id, catalog_id, install_id)` DO UPDATE is
-    // belt-and-suspenders idempotency on the UUID (which never collides).
-    // `status='draft'` matches the SQL-connection convention (#2177): the
-    // pending-changes pill surfaces it and the admin publishes atomically.
-    const installId = this.newId();
-    let persistedId: string;
-    try {
-      const rows = await internalQuery<{ id: string }>(
-        `INSERT INTO workspace_plugins
-           (id, workspace_id, catalog_id, install_id, pillar, config, enabled, status, installed_at, updated_at)
-         VALUES ($1, $2, $3, $1, 'datasource', $4::jsonb, true, 'draft', NOW(), NOW())
-         ON CONFLICT (workspace_id, catalog_id, install_id) DO UPDATE
-           SET config = EXCLUDED.config,
-               enabled = true,
-               updated_at = NOW()
-         RETURNING id`,
-        [installId, workspaceId, OPENAPI_GENERIC_CATALOG_ID, JSON.stringify(encryptedConfig)],
-      );
-      const returned = rows[0]?.id;
-      if (typeof returned !== "string" || returned.length === 0) {
-        log.error(
-          { workspaceId, installId },
-          "workspace_plugins upsert returned no id — Postgres invariant violation",
-        );
-        throw new Error(
-          "workspace_plugins upsert returned no id from RETURNING — likely a driver/RLS/query-rewrite anomaly",
-        );
-      }
-      persistedId = returned;
-    } catch (err) {
-      log.error(
-        { workspaceId, installId, err: err instanceof Error ? err.message : String(err) },
-        "Failed to persist OpenAPI datasource install record — aborting install",
-      );
-      throw err;
-    }
-
-    log.info(
-      {
-        workspaceId,
-        installId: persistedId,
-        operationCount: snapshot.operationCount,
-        specHost: safeHost(data.openapi_url),
-      },
-      "OpenAPI generic datasource install completed",
-    );
-    return {
-      installRecord: { id: persistedId, workspaceId, catalogId: OPENAPI_GENERIC_SLUG },
-      credentialWritten: data.auth_kind !== "none",
-    };
   }
+
+  // ── Probe the spec (slice-0) → snapshot ───────────────────────────
+  // The credential is needed because some specs require auth to read. A probe
+  // failure is a user-fixable input error → 400 on `openapi_url`, not a 500.
+  const auth = buildResolvedAuth(authKind, authValue, authHeaderName, authParamName);
+  const probeOpts: ProbeOptions = fetchImpl ? { fetchImpl } : {};
+  let snapshot;
+  try {
+    const { doc, graph } = await probeSpec(openapiUrl, auth, probeOpts);
+    snapshot = buildSnapshot(doc, graph, now());
+  } catch (err) {
+    if (err instanceof OpenApiProbeError) {
+      log.warn(
+        { workspaceId, catalogSlug, reason: err.reason },
+        "OpenAPI install probe failed — surfacing as field validation error",
+      );
+      throw FormInstallValidationError.fromZodFlatten({
+        fieldErrors: { openapi_url: [err.message] },
+        formErrors: [],
+      });
+    }
+    log.error(
+      { workspaceId, catalogSlug, err: err instanceof Error ? err.message : String(err) },
+      "OpenAPI install probe threw unexpectedly",
+    );
+    throw err;
+  }
+
+  // ── Assemble config + encrypt secret fields ───────────────────────
+  // The `config_schema`'s `secret: true` flag drives encryption — never naming
+  // `auth_value` here. Operational metadata is non-secret and passes through.
+  const rawConfig: Record<string, unknown> = {
+    openapi_url: openapiUrl,
+    auth_kind: authKind,
+    ...(authValue ? { auth_value: authValue } : {}),
+    ...(authHeaderName ? { auth_header_name: authHeaderName } : {}),
+    ...(authParamName ? { auth_param_name: authParamName } : {}),
+    ...(baseUrlOverride ? { base_url_override: baseUrlOverride } : {}),
+    ...(writeAllowlist ? { write_allowlist: writeAllowlist } : {}),
+    display_name: displayName || snapshot.title,
+    representation_mode: DEFAULT_REPRESENTATION_MODE,
+    openapi_snapshot: snapshot,
+  };
+  const schema = parseConfigSchema(configSchema);
+  const encryptedConfig = encryptSecretFields(rawConfig, schema);
+
+  // ── Insert a fresh multi-instance datasource row ──────────────────
+  // Same UUID for `id` and `install_id`. Fresh every submit (multi-instance);
+  // the `(workspace_id, catalog_id, install_id)` DO UPDATE is belt-and-suspenders
+  // idempotency on the never-colliding UUID. `status='draft'` (the #2177
+  // convention) surfaces the pending-changes pill for atomic publish.
+  const installId = newId();
+  let persistedId: string;
+  try {
+    const rows = await internalQuery<{ id: string }>(
+      `INSERT INTO workspace_plugins
+         (id, workspace_id, catalog_id, install_id, pillar, config, enabled, status, installed_at, updated_at)
+       VALUES ($1, $2, $3, $1, 'datasource', $4::jsonb, true, 'draft', NOW(), NOW())
+       ON CONFLICT (workspace_id, catalog_id, install_id) DO UPDATE
+         SET config = EXCLUDED.config,
+             enabled = true,
+             updated_at = NOW()
+       RETURNING id`,
+      [installId, workspaceId, catalogId, JSON.stringify(encryptedConfig)],
+    );
+    const returned = rows[0]?.id;
+    if (typeof returned !== "string" || returned.length === 0) {
+      log.error(
+        { workspaceId, catalogSlug, installId },
+        "workspace_plugins upsert returned no id — Postgres invariant violation",
+      );
+      throw new Error(
+        "workspace_plugins upsert returned no id from RETURNING — likely a driver/RLS/query-rewrite anomaly",
+      );
+    }
+    persistedId = returned;
+  } catch (err) {
+    log.error(
+      { workspaceId, catalogSlug, installId, err: err instanceof Error ? err.message : String(err) },
+      "Failed to persist OpenAPI datasource install record — aborting install",
+    );
+    throw err;
+  }
+
+  log.info(
+    {
+      workspaceId,
+      catalogSlug,
+      installId: persistedId,
+      operationCount: snapshot.operationCount,
+      specHost: safeHost(openapiUrl),
+    },
+    "OpenAPI datasource install completed",
+  );
+  return {
+    installRecord: { id: persistedId, workspaceId, catalogId: catalogSlug },
+    credentialWritten: authKind !== "none",
+  };
 }
 
 /** Best-effort host extraction for log breadcrumbs — never throws, never leaks the path. */

--- a/packages/api/src/lib/integrations/install/register.ts
+++ b/packages/api/src/lib/integrations/install/register.ts
@@ -27,6 +27,8 @@ import { EmailFormInstallHandler } from "./email-form-handler";
 import { ObsidianFormInstallHandler } from "./obsidian-form-handler";
 import { OpenApiGenericFormInstallHandler } from "./openapi-generic-form-handler";
 import { OPENAPI_GENERIC_SLUG } from "@atlas/api/lib/openapi/catalog";
+import { DataCandidateFormInstallHandler } from "./data-candidate-form-handler";
+import { DATA_CANDIDATES } from "@atlas/api/lib/openapi/data-candidates";
 import { WebhookFormInstallHandler } from "./webhook-form-handler";
 import { TwentyFormInstallHandler, TWENTY_SLUG } from "./twenty-form-handler";
 import {
@@ -154,6 +156,18 @@ export function registerBuiltinInstallHandlers(): void {
   // `ATLAS_OPENAPI_TWENTY*` env shortcut.
   registerFormHandler(OPENAPI_GENERIC_SLUG, new OpenApiGenericFormInstallHandler());
   log.info("Registered OpenApiGenericFormInstallHandler");
+  // Built-in vendor *-data candidates (#3028). Each is a thin pre-wired wrapper
+  // over the generic OpenAPI primitive — same form-handler shape, no env gate
+  // (the admin supplies the credential at install). One handler per candidate,
+  // registered under its slug (e.g. "stripe-data"). Adding a candidate is a
+  // one-line registry entry (data-candidates.ts), not a new handler class.
+  for (const candidate of DATA_CANDIDATES) {
+    registerFormHandler(candidate.slug, new DataCandidateFormInstallHandler(candidate));
+  }
+  log.info(
+    { candidates: DATA_CANDIDATES.map((c) => c.slug) },
+    "Registered DataCandidateFormInstallHandler(s)",
+  );
   registerFormHandler("webhook", new WebhookFormInstallHandler());
   log.info("Registered WebhookFormInstallHandler");
   // Twenty CRM form-install. Per-workspace credentials land in the

--- a/packages/api/src/lib/openapi/__tests__/client-quirk.test.ts
+++ b/packages/api/src/lib/openapi/__tests__/client-quirk.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Client ↔ vendor-quirk integration (v0.0.2 slice 6a, #3028). Proves the generic
+ * `executeOperation` / `executeOperationPaged` apply a declarative
+ * {@link VendorQuirk} through the existing header + query seams — required headers
+ * and query param-shaping (Stripe `expand[]`) — with NO per-vendor code branch,
+ * and the headline AC: a Stripe-style cursor walk merges across pages using the
+ * SAME generic cursor strategy (last-item-id dialect), expand[] shaped on every
+ * page, cursor (`starting_after`) advancing by the last returned object's id.
+ */
+import { describe, it, expect } from "bun:test";
+import * as fs from "fs";
+import * as path from "path";
+
+import { buildOperationGraph } from "../spec";
+import { executeOperation, executeOperationPaged } from "../client";
+import { defaultPaginatorRegistry } from "../strategies";
+import { STRIPE_DATA_CANDIDATE } from "../data-candidates";
+import type { OperationGraph } from "../types";
+
+const STRIPE_SPEC = JSON.parse(
+  fs.readFileSync(path.join(import.meta.dir, "fixtures", "stripe.excerpt.json"), "utf8"),
+);
+const stripeGraph: OperationGraph = buildOperationGraph(STRIPE_SPEC);
+
+/** Capture every request URL + headers a stubbed fetch sees. */
+function capturingFetch(body: unknown) {
+  const calls: { url: string; headers: Record<string, string> }[] = [];
+  const fetchImpl = (async (input: string | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    const headers: Record<string, string> = {};
+    const h = init?.headers as Record<string, string> | undefined;
+    if (h) for (const [k, v] of Object.entries(h)) headers[k.toLowerCase()] = String(v);
+    calls.push({ url, headers });
+    return new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  }) as unknown as typeof globalThis.fetch;
+  return { fetchImpl, calls };
+}
+
+describe("executeOperation — vendor quirk application", () => {
+  it("shapes a bracketArray query param (expand → expand[]) per the quirk", async () => {
+    const { fetchImpl, calls } = capturingFetch({ object: "list", data: [], has_more: false });
+    await executeOperation(
+      stripeGraph,
+      "GetCustomers",
+      { query: { expand: ["data.subscriptions"], limit: 3 } },
+      { kind: "bearer", token: "sk_test_x" },
+      { baseUrl: "https://api.stripe.com", fetchImpl, quirk: STRIPE_DATA_CANDIDATE.quirk },
+    );
+    const url = calls[0].url;
+    // The expand array is emitted under expand[] (Stripe form-encoding), limit untouched.
+    expect(url).toContain("expand%5B%5D=data.subscriptions"); // expand[]=…
+    expect(url).not.toContain("expand=data.subscriptions"); // not the un-bracketed key
+    expect(url).toContain("limit=3");
+  });
+
+  it("applies a required static header as a non-clobbering default", async () => {
+    const { fetchImpl, calls } = capturingFetch({ data: [], has_more: false });
+    await executeOperation(
+      stripeGraph,
+      "GetCustomers",
+      {},
+      { kind: "bearer", token: "t" },
+      {
+        baseUrl: "https://api.stripe.com",
+        fetchImpl,
+        quirk: { requiredHeaders: { "Stripe-Version": "2024-06-20" } },
+      },
+    );
+    expect(calls[0].headers["stripe-version"]).toBe("2024-06-20");
+    // Bearer auth still applied alongside the quirk header.
+    expect(calls[0].headers["authorization"]).toBe("Bearer t");
+  });
+
+  it("is a transparent no-op when no quirk is supplied", async () => {
+    const { fetchImpl, calls } = capturingFetch({ data: [], has_more: false });
+    await executeOperation(
+      stripeGraph,
+      "GetCustomers",
+      { query: { expand: ["data.x"] } },
+      { kind: "bearer", token: "t" },
+      { baseUrl: "https://api.stripe.com", fetchImpl },
+    );
+    // Without a quirk, expand explodes under its plain key (no brackets).
+    expect(calls[0].url).toContain("expand=data.x");
+    expect(calls[0].url).not.toContain("expand%5B%5D");
+  });
+});
+
+describe("executeOperationPaged — Stripe cursor walk (headline AC)", () => {
+  it("merges pages via starting_after=<last id>, shaping expand[] on every page", async () => {
+    const strategy = defaultPaginatorRegistry.resolve(STRIPE_DATA_CANDIDATE.pagination!);
+
+    const PAGES = 3;
+    const PAGE_SIZE = 2;
+    const calls: string[] = [];
+    const fetchImpl = (async (input: string | URL) => {
+      const href = typeof input === "string" ? input : input.toString();
+      calls.push(href);
+      const url = new URL(href);
+      const after = url.searchParams.get("starting_after");
+      // page index derives from the cursor (cus-<page>-<last>) or 0 on first page.
+      const pageIndex = after === null ? 0 : Number(after.split("-")[1]) + 1;
+      const data = Array.from({ length: PAGE_SIZE }, (_, i) => ({ id: `cus-${pageIndex}-${i}` }));
+      const has_more = pageIndex < PAGES - 1;
+      return new Response(JSON.stringify({ object: "list", data, has_more }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }) as unknown as typeof globalThis.fetch;
+
+    const merged = await executeOperationPaged(
+      stripeGraph,
+      "GetCustomers",
+      { query: { expand: ["data.subscriptions"], limit: PAGE_SIZE } },
+      { kind: "bearer", token: "sk_test_x" },
+      {
+        baseUrl: "https://api.stripe.com",
+        fetchImpl,
+        pagination: strategy,
+        quirk: STRIPE_DATA_CANDIDATE.quirk,
+        maxPages: 10,
+      },
+    );
+
+    expect(merged.items).toHaveLength(PAGES * PAGE_SIZE);
+    expect(merged.pageCount).toBe(PAGES);
+    expect(merged.truncated).toBe(false);
+    expect(calls).toHaveLength(PAGES);
+    // First page has no cursor; later pages carry starting_after = previous page's last id.
+    expect(calls[0]).not.toContain("starting_after");
+    expect(calls[1]).toContain("starting_after=cus-0-1"); // last id of page 0
+    expect(calls[2]).toContain("starting_after=cus-1-1"); // last id of page 1
+    // expand[] shaping applied on every page, including paginated follow-ups.
+    for (const c of calls) expect(c).toContain("expand%5B%5D=data.subscriptions");
+  });
+});

--- a/packages/api/src/lib/openapi/__tests__/client-quirk.test.ts
+++ b/packages/api/src/lib/openapi/__tests__/client-quirk.test.ts
@@ -136,4 +136,48 @@ describe("executeOperationPaged — Stripe cursor walk (headline AC)", () => {
     // expand[] shaping applied on every page, including paginated follow-ups.
     for (const c of calls) expect(c).toContain("expand%5B%5D=data.subscriptions");
   });
+
+  it("sends the quirk's required headers on every page of a cursor walk", async () => {
+    const strategy = defaultPaginatorRegistry.resolve(STRIPE_DATA_CANDIDATE.pagination!);
+
+    const PAGES = 3;
+    const seenHeaders: Record<string, string>[] = [];
+    const fetchImpl = (async (input: string | URL, init?: RequestInit) => {
+      const href = typeof input === "string" ? input : input.toString();
+      const headers: Record<string, string> = {};
+      const h = init?.headers as Record<string, string> | undefined;
+      if (h) for (const [k, v] of Object.entries(h)) headers[k.toLowerCase()] = String(v);
+      seenHeaders.push(headers);
+      const after = new URL(href).searchParams.get("starting_after");
+      const pageIndex = after === null ? 0 : Number(after.split("-")[1]) + 1;
+      const data = [{ id: `cus-${pageIndex}-0` }];
+      return new Response(
+        JSON.stringify({ object: "list", data, has_more: pageIndex < PAGES - 1 }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }) as unknown as typeof globalThis.fetch;
+
+    await executeOperationPaged(
+      stripeGraph,
+      "GetCustomers",
+      { query: { limit: 1 } },
+      { kind: "bearer", token: "sk_test_x" },
+      {
+        baseUrl: "https://api.stripe.com",
+        fetchImpl,
+        pagination: strategy,
+        // A required-header quirk (the Notion #3029 shape) threaded through the walk.
+        quirk: { requiredHeaders: { "Stripe-Version": "2024-06-20" } },
+        maxPages: 10,
+      },
+    );
+
+    expect(seenHeaders).toHaveLength(PAGES);
+    // The required header is present on the first AND every paginated follow-up,
+    // alongside the bearer credential.
+    for (const h of seenHeaders) {
+      expect(h["stripe-version"]).toBe("2024-06-20");
+      expect(h["authorization"]).toBe("Bearer sk_test_x");
+    }
+  });
 });

--- a/packages/api/src/lib/openapi/__tests__/data-candidate-seed.test.ts
+++ b/packages/api/src/lib/openapi/__tests__/data-candidate-seed.test.ts
@@ -78,4 +78,15 @@ describe("migration 0109 ↔ code alignment", () => {
     expect(sql).toContain("'stripe-data'");
     expect(sql).toContain("ON CONFLICT DO NOTHING");
   });
+
+  it("the migration's name + description match the STRIPE_DATA_CANDIDATE registry literal", () => {
+    // On a fresh DB the migration row is authoritative (it runs before the boot
+    // seed's `ON CONFLICT DO NOTHING`), so its name/description must not drift from
+    // the registry — else the catalog card copy differs by deploy age. SQL doubles
+    // a literal `'`, so escape before substring-matching.
+    const sql = migrationSql();
+    const esc = (s: string) => s.replace(/'/g, "''");
+    expect(sql).toContain(`'${esc(STRIPE_DATA_CANDIDATE.name)}'`);
+    expect(sql).toContain(esc(STRIPE_DATA_CANDIDATE.description));
+  });
 });

--- a/packages/api/src/lib/openapi/__tests__/data-candidate-seed.test.ts
+++ b/packages/api/src/lib/openapi/__tests__/data-candidate-seed.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Tests for the data-candidate catalog seed (v0.0.2 slice 6a, #3028): per-row
+ * idempotency via a capturing mock db, and migration 0109 ↔ code alignment.
+ * Mirrors `catalog-seed.test.ts` for the generic row.
+ */
+import { describe, it, expect } from "bun:test";
+import * as fs from "fs";
+import * as path from "path";
+import { seedDataCandidateCatalog } from "../data-candidate-seed";
+import type { OpenApiDatasourceCatalogSeedDb } from "../catalog-seed";
+import {
+  DATA_CANDIDATES,
+  DATA_CANDIDATE_CONFIG_SCHEMA,
+  STRIPE_DATA_CANDIDATE,
+} from "../data-candidates";
+
+function captureDb(returnRowsPerCall: (callIndex: number) => Array<{ slug: string }>): {
+  db: OpenApiDatasourceCatalogSeedDb;
+  calls: Array<{ sql: string; params?: unknown[] }>;
+} {
+  const calls: Array<{ sql: string; params?: unknown[] }> = [];
+  const db: OpenApiDatasourceCatalogSeedDb = {
+    async query<T = unknown>(sql: string, params?: unknown[]) {
+      const rows = returnRowsPerCall(calls.length);
+      calls.push({ sql, params });
+      return { rows: rows as T[] };
+    },
+  };
+  return { db, calls };
+}
+
+describe("seedDataCandidateCatalog", () => {
+  it("INSERTs each candidate row with the canonical id/slug + shared schema", async () => {
+    const { db, calls } = captureDb(() => [{ slug: STRIPE_DATA_CANDIDATE.slug }]);
+    const result = await seedDataCandidateCatalog(db);
+
+    expect(result.insertedSlugs).toEqual(DATA_CANDIDATES.map((c) => c.slug));
+    expect(calls).toHaveLength(DATA_CANDIDATES.length);
+
+    const { sql, params } = calls[0];
+    expect(sql).toContain("INSERT INTO plugin_catalog");
+    expect(sql).toContain("ON CONFLICT DO NOTHING");
+    expect(sql).toContain("'datasource'"); // type + pillar literals
+    expect(sql).toContain("'form'");
+    expect(params?.[0]).toBe(STRIPE_DATA_CANDIDATE.catalogId);
+    expect(params?.[2]).toBe(STRIPE_DATA_CANDIDATE.slug);
+    expect(JSON.parse(params?.[4] as string)).toEqual(DATA_CANDIDATE_CONFIG_SCHEMA);
+  });
+
+  it("reports no insertedSlugs when every row already existed (ON CONFLICT DO NOTHING)", async () => {
+    const { db } = captureDb(() => []); // no RETURNING rows = conflict path for every row
+    const result = await seedDataCandidateCatalog(db);
+    expect(result.insertedSlugs).toEqual([]);
+  });
+});
+
+describe("migration 0109 ↔ code alignment", () => {
+  function migrationSql(): string {
+    return fs.readFileSync(
+      path.join(import.meta.dir, "..", "..", "db", "migrations", "0109_data_candidate_catalog.sql"),
+      "utf8",
+    );
+  }
+
+  it("the migration's config_schema matches DATA_CANDIDATE_CONFIG_SCHEMA", () => {
+    const sql = migrationSql();
+    const start = sql.indexOf("'[");
+    const end = sql.indexOf("]'::jsonb");
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+    const jsonText = sql.slice(start + 1, end + 1).replace(/''/g, "'");
+    expect(JSON.parse(jsonText)).toEqual(DATA_CANDIDATE_CONFIG_SCHEMA);
+  });
+
+  it("the migration seeds the stripe-data canonical id + slug, idempotently", () => {
+    const sql = migrationSql();
+    expect(sql).toContain(STRIPE_DATA_CANDIDATE.catalogId);
+    expect(sql).toContain("'stripe-data'");
+    expect(sql).toContain("ON CONFLICT DO NOTHING");
+  });
+});

--- a/packages/api/src/lib/openapi/__tests__/data-candidates.test.ts
+++ b/packages/api/src/lib/openapi/__tests__/data-candidates.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Tests for the data-candidate registry (v0.0.2 slice 6a, #3028): the registry
+ * invariants, the shared config schema, and the "thin wrapper" property — a
+ * candidate's pagination config must resolve against the SAME generic paginator
+ * registry (no forked strategy file).
+ */
+import { describe, it, expect } from "bun:test";
+import {
+  DATA_CANDIDATES,
+  DATA_CANDIDATE_CATALOG_IDS,
+  DATA_CANDIDATE_CONFIG_SCHEMA,
+  STRIPE_DATA_CANDIDATE,
+  findDataCandidateByCatalogId,
+  findDataCandidateBySlug,
+} from "../data-candidates";
+import { OPENAPI_SUPPORTED_AUTH_KINDS } from "../catalog";
+import { defaultPaginatorRegistry } from "../strategies";
+
+describe("DATA_CANDIDATES registry invariants", () => {
+  it("derives every catalogId as catalog:${slug}", () => {
+    for (const c of DATA_CANDIDATES) {
+      expect(c.catalogId).toBe(`catalog:${c.slug}`);
+    }
+  });
+
+  it("uses only executable (non-oauth2) auth kinds in slice 6a", () => {
+    for (const c of DATA_CANDIDATES) {
+      expect(OPENAPI_SUPPORTED_AUTH_KINDS).toContain(c.authKind);
+    }
+  });
+
+  it("exposes every catalogId in DATA_CANDIDATE_CATALOG_IDS", () => {
+    expect([...DATA_CANDIDATE_CATALOG_IDS].toSorted()).toEqual(
+      DATA_CANDIDATES.map((c) => c.catalogId).toSorted(),
+    );
+  });
+
+  it("looks candidates up by catalogId and slug, undefined otherwise", () => {
+    expect(findDataCandidateByCatalogId("catalog:stripe-data")).toBe(STRIPE_DATA_CANDIDATE);
+    expect(findDataCandidateBySlug("stripe-data")).toBe(STRIPE_DATA_CANDIDATE);
+    expect(findDataCandidateByCatalogId("catalog:nope")).toBeUndefined();
+    expect(findDataCandidateBySlug("nope")).toBeUndefined();
+  });
+
+  it("every candidate's pagination config resolves over the GENERIC registry (no forked strategy)", () => {
+    for (const c of DATA_CANDIDATES) {
+      if (c.pagination === undefined) continue;
+      // Resolving against the default registry proves the candidate reuses a
+      // built-in strategy — a forked/unknown strategy would throw here.
+      const strategy = defaultPaginatorRegistry.resolve(c.pagination);
+      expect(defaultPaginatorRegistry.has(strategy.name)).toBe(true);
+    }
+  });
+});
+
+describe("stripe-data candidate", () => {
+  it("is bearer-auth, pre-fills a spec URL, and never asks for one", () => {
+    expect(STRIPE_DATA_CANDIDATE.authKind).toBe("bearer");
+    expect(STRIPE_DATA_CANDIDATE.openapiUrl).toMatch(/^https?:\/\//);
+    // openapi_url + auth_kind are pre-filled, so the install form must NOT carry them.
+    const formKeys = DATA_CANDIDATE_CONFIG_SCHEMA.map((f) => f.key);
+    expect(formKeys).not.toContain("openapi_url");
+    expect(formKeys).not.toContain("auth_kind");
+  });
+
+  it("declares the expand[] bracket-array query quirk", () => {
+    expect(STRIPE_DATA_CANDIDATE.quirk?.queryParamShaping).toEqual([
+      { param: "expand", bracketArray: true },
+    ]);
+  });
+
+  it("declares cursor pagination keyed on the last item's id + has_more", () => {
+    expect(STRIPE_DATA_CANDIDATE.pagination).toMatchObject({
+      strategy: "cursor",
+      itemsPath: "data",
+      cursorParam: "starting_after",
+      cursorFromLastItem: true,
+      cursorItemField: "id",
+      hasMorePath: "has_more",
+    });
+  });
+});
+
+describe("DATA_CANDIDATE_CONFIG_SCHEMA", () => {
+  it("marks auth_value as the sole secret field (drives encryptSecretFields)", () => {
+    const secretKeys = DATA_CANDIDATE_CONFIG_SCHEMA.filter((f) => f.secret === true).map((f) => f.key);
+    expect(secretKeys).toEqual(["auth_value"]);
+  });
+
+  it("requires only auth_value (everything else pre-filled or optional)", () => {
+    const required = DATA_CANDIDATE_CONFIG_SCHEMA.filter((f) => f.required === true).map((f) => f.key);
+    expect(required).toEqual(["auth_value"]);
+  });
+});

--- a/packages/api/src/lib/openapi/__tests__/paginator.test.ts
+++ b/packages/api/src/lib/openapi/__tests__/paginator.test.ts
@@ -138,6 +138,66 @@ const NEXT_CASES: NextCase[] = [
     expected: PAGE_DONE,
   },
 
+  // ── cursor: last-item-id dialect (Stripe, #3028) ──────────────────────
+  {
+    title: "cursor(last-item): next cursor is the last item's id while has_more",
+    config: {
+      strategy: "cursor",
+      itemsPath: "data",
+      cursorParam: "starting_after",
+      cursorFromLastItem: true,
+      cursorItemField: "id",
+      hasMorePath: "has_more",
+    },
+    request: { operationId: "GetCustomers", params: { query: { limit: 2 } } },
+    response: ok({ object: "list", data: [{ id: "cus_1" }, { id: "cus_2" }], has_more: true }),
+    expected: continueWith({
+      operationId: "GetCustomers",
+      params: { query: { limit: 2, starting_after: "cus_2" } },
+    }),
+  },
+  {
+    title: "cursor(last-item): stops when has_more is false",
+    config: {
+      strategy: "cursor",
+      itemsPath: "data",
+      cursorParam: "starting_after",
+      cursorFromLastItem: true,
+      cursorItemField: "id",
+      hasMorePath: "has_more",
+    },
+    request: { operationId: "GetCustomers", params: { query: { starting_after: "cus_2" } } },
+    response: ok({ object: "list", data: [{ id: "cus_3" }], has_more: false }),
+    expected: PAGE_DONE,
+  },
+  {
+    title: "cursor(last-item): stops on an empty page even if has_more is true",
+    config: {
+      strategy: "cursor",
+      itemsPath: "data",
+      cursorParam: "starting_after",
+      cursorFromLastItem: true,
+      cursorItemField: "id",
+      hasMorePath: "has_more",
+    },
+    request: { operationId: "GetCustomers", params: {} },
+    response: ok({ object: "list", data: [], has_more: true }),
+    expected: PAGE_DONE,
+  },
+  {
+    title: "cursor(last-item): stops when the last item lacks the cursor field",
+    config: {
+      strategy: "cursor",
+      itemsPath: "data",
+      cursorParam: "starting_after",
+      cursorFromLastItem: true,
+      cursorItemField: "id",
+    },
+    request: { operationId: "GetCustomers", params: {} },
+    response: ok({ object: "list", data: [{ notId: "x" }] }),
+    expected: PAGE_DONE,
+  },
+
   // ── offset ──────────────────────────────────────────────────────────
   {
     title: "offset: advances offset by limit on a full page",

--- a/packages/api/src/lib/openapi/__tests__/paginator.test.ts
+++ b/packages/api/src/lib/openapi/__tests__/paginator.test.ts
@@ -197,6 +197,23 @@ const NEXT_CASES: NextCase[] = [
     response: ok({ object: "list", data: [{ notId: "x" }] }),
     expected: PAGE_DONE,
   },
+  {
+    title: "cursor(last-item): coerces a numeric last-item id to a string cursor",
+    config: {
+      strategy: "cursor",
+      itemsPath: "data",
+      cursorParam: "starting_after",
+      cursorFromLastItem: true,
+      cursorItemField: "id",
+      hasMorePath: "has_more",
+    },
+    request: { operationId: "GetCustomers", params: { query: { limit: 2 } } },
+    response: ok({ object: "list", data: [{ id: 41 }, { id: 42 }], has_more: true }),
+    expected: continueWith({
+      operationId: "GetCustomers",
+      params: { query: { limit: 2, starting_after: "42" } },
+    }),
+  },
 
   // ── offset ──────────────────────────────────────────────────────────
   {

--- a/packages/api/src/lib/openapi/__tests__/vendor-quirk.test.ts
+++ b/packages/api/src/lib/openapi/__tests__/vendor-quirk.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Unit tests for the declarative vendor-quirk apply helpers (v0.0.2 slice 6a,
+ * #3028). These pin the contract the generic client depends on: required headers
+ * apply as non-clobbering defaults, and query param-shaping re-keys matched
+ * params (Stripe `expand` → `expand[]`) while leaving everything else — including
+ * a later pagination cursor — verbatim. A regression here would silently change
+ * what the client sends upstream, which no client-layer test would catch as
+ * directly.
+ */
+import { describe, it, expect } from "bun:test";
+import {
+  applyQuirkHeaders,
+  applyQuirkQueryShaping,
+  type VendorQuirk,
+} from "../vendor-quirk";
+
+describe("applyQuirkHeaders", () => {
+  it("adds the quirk's required headers", () => {
+    const headers: Record<string, string> = { accept: "application/json" };
+    applyQuirkHeaders(headers, { requiredHeaders: { "Notion-Version": "2022-06-28" } });
+    expect(headers["Notion-Version"]).toBe("2022-06-28");
+  });
+
+  it("does not clobber a header the caller already set (case-insensitive)", () => {
+    const headers: Record<string, string> = { "notion-version": "caller-set" };
+    applyQuirkHeaders(headers, { requiredHeaders: { "Notion-Version": "2022-06-28" } });
+    // The caller's value survives; no duplicate key is introduced.
+    expect(headers["notion-version"]).toBe("caller-set");
+    expect(headers["Notion-Version"]).toBeUndefined();
+  });
+
+  it("is a no-op for an absent quirk or absent requiredHeaders", () => {
+    const a: Record<string, string> = { accept: "application/json" };
+    applyQuirkHeaders(a, undefined);
+    expect(a).toEqual({ accept: "application/json" });
+
+    const b: Record<string, string> = { accept: "application/json" };
+    applyQuirkHeaders(b, {});
+    expect(b).toEqual({ accept: "application/json" });
+  });
+});
+
+describe("applyQuirkQueryShaping", () => {
+  const STRIPE_QUIRK: VendorQuirk = {
+    queryParamShaping: [{ param: "expand", bracketArray: true }],
+  };
+
+  it("rewrites a bracketArray param key, preserving the (array) value", () => {
+    const shaped = applyQuirkQueryShaping(
+      { expand: ["data.customer", "data.invoice"], limit: 10 },
+      STRIPE_QUIRK,
+    );
+    expect(shaped).toEqual({ "expand[]": ["data.customer", "data.invoice"], limit: 10 });
+  });
+
+  it("renames a param outright (rename wins over bracketArray)", () => {
+    const shaped = applyQuirkQueryShaping(
+      { expand: ["x"] },
+      { queryParamShaping: [{ param: "expand", bracketArray: true, rename: "expand[0]" }] },
+    );
+    expect(shaped).toEqual({ "expand[0]": ["x"] });
+  });
+
+  it("leaves params no rule names untouched (e.g. a pagination cursor)", () => {
+    const shaped = applyQuirkQueryShaping(
+      { expand: ["data.x"], starting_after: "cus_123", limit: 5 },
+      STRIPE_QUIRK,
+    );
+    expect(shaped).toEqual({ "expand[]": ["data.x"], starting_after: "cus_123", limit: 5 });
+  });
+
+  it("returns the input unchanged when there are no rules", () => {
+    const query = { a: 1, b: "two" };
+    expect(applyQuirkQueryShaping(query, undefined)).toBe(query);
+    expect(applyQuirkQueryShaping(query, {})).toBe(query);
+    expect(applyQuirkQueryShaping(query, { queryParamShaping: [] })).toBe(query);
+  });
+
+  it("returns undefined for an undefined query", () => {
+    expect(applyQuirkQueryShaping(undefined, STRIPE_QUIRK)).toBeUndefined();
+  });
+});

--- a/packages/api/src/lib/openapi/__tests__/workspace-datasource.test.ts
+++ b/packages/api/src/lib/openapi/__tests__/workspace-datasource.test.ts
@@ -18,6 +18,7 @@ import { buildOperationGraph } from "../spec";
 import { buildSnapshot, __resetSnapshotGraphCacheForTests } from "../probe";
 import { MOCK_OPENAPI_SPEC } from "@atlas/api/testing/openapi-datasource";
 import { OPENAPI_GENERIC_CATALOG_ID, type OpenApiSnapshot } from "../catalog";
+import { DATA_CANDIDATE_CATALOG_IDS } from "../data-candidates";
 
 const graph = buildOperationGraph(MOCK_OPENAPI_SPEC);
 
@@ -240,6 +241,38 @@ describe("resolveWorkspaceRestDatasourcesOrThrow (strict)", () => {
   });
 });
 
+describe("resolveWorkspaceRestDatasources — data-candidate quirk attachment (slice 6a, #3028)", () => {
+  it("attaches the candidate's declarative quirk for a candidate-catalog install", async () => {
+    // A stripe-data install row carries the candidate catalog id; the resolver
+    // looks the candidate up in the code-resident registry and attaches its quirk
+    // — the quirk is never stored in (or read from) the encrypted config.
+    const result = await resolveWorkspaceRestDatasources("org-1", {
+      query: queryReturning([
+        { install_id: "inst-stripe", catalog_id: "catalog:stripe-data", config: config() },
+      ]),
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].quirk?.queryParamShaping).toEqual([{ param: "expand", bracketArray: true }]);
+  });
+
+  it("leaves quirk undefined for a plain openapi-generic install", async () => {
+    const result = await resolveWorkspaceRestDatasources("org-1", {
+      query: queryReturning([
+        { install_id: "inst-generic", catalog_id: OPENAPI_GENERIC_CATALOG_ID, config: config() },
+      ]),
+    });
+    expect(result[0].quirk).toBeUndefined();
+  });
+
+  it("treats a row with no catalog_id as the generic datasource (no quirk)", async () => {
+    const result = await resolveWorkspaceRestDatasources("org-1", {
+      query: queryReturning([{ install_id: "inst-legacy", config: config() }]),
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].quirk).toBeUndefined();
+  });
+});
+
 describe("resolveWorkspacePrimaryRestDatasource", () => {
   it("returns the first install, or null when none", async () => {
     expect(
@@ -268,7 +301,7 @@ describe("resolveWorkspacePrimaryRestDatasource", () => {
 // ─────────────────────────────────────────────────────────────────────
 
 describe("defaultQuery — tenant-scope clause", () => {
-  it("scopes the SELECT to the caller's workspace + openapi-generic catalog, non-archived datasources (#3011)", async () => {
+  it("scopes the SELECT to the caller's workspace + generic & data-candidate catalogs, non-archived datasources (#3011 / #3028)", async () => {
     let capturedSql = "";
     let capturedParams: unknown[] = [];
     await defaultQuery("org-CALLER", async (sql, params) => {
@@ -281,7 +314,7 @@ describe("defaultQuery — tenant-scope clause", () => {
     expect(flat).toContain("FROM workspace_plugins");
     // Each conjunct is load-bearing — dropping any one is a tenant-isolation hole.
     expect(flat).toContain("workspace_id = $1");
-    expect(flat).toContain("catalog_id = $2");
+    expect(flat).toContain("catalog_id = ANY($2)");
     expect(flat).toContain("pillar = 'datasource'");
     expect(flat).toContain("status != 'archived'");
     // Assert the conjuncts as ONE contiguous AND-joined WHERE clause, not just
@@ -290,13 +323,17 @@ describe("defaultQuery — tenant-scope clause", () => {
     // WHERE) — both of which are tenant-isolation holes. Pinning the full clause
     // catches the connective + membership, not only the presence, of each guard.
     expect(flat).toContain(
-      "WHERE workspace_id = $1 AND catalog_id = $2 AND pillar = 'datasource' AND status != 'archived'",
+      "WHERE workspace_id = $1 AND catalog_id = ANY($2) AND pillar = 'datasource' AND status != 'archived'",
     );
 
     // Param ORDER is load-bearing: $1 is the caller's workspace (never client
-    // input), $2 is the built-in openapi-generic catalog id. Flipping these
-    // would scope the query to the wrong dimension.
-    expect(capturedParams).toEqual(["org-CALLER", OPENAPI_GENERIC_CATALOG_ID]);
+    // input), $2 is the array of built-in catalog ids — the generic datasource
+    // plus every data candidate (slice 6a, #3028). Flipping these would scope the
+    // query to the wrong dimension; dropping a candidate id would hide its installs.
+    expect(capturedParams).toEqual([
+      "org-CALLER",
+      [OPENAPI_GENERIC_CATALOG_ID, ...DATA_CANDIDATE_CATALOG_IDS],
+    ]);
   });
 });
 

--- a/packages/api/src/lib/openapi/catalog-seed.ts
+++ b/packages/api/src/lib/openapi/catalog-seed.ts
@@ -30,6 +30,7 @@ import {
   OPENAPI_GENERIC_DESCRIPTION,
   OPENAPI_GENERIC_CONFIG_SCHEMA,
 } from "./catalog";
+import { seedDataCandidateCatalog } from "./data-candidate-seed";
 
 const log = createLogger("openapi.catalog-seed");
 
@@ -89,6 +90,12 @@ export type OpenApiDatasourceCatalogSeedBootResult =
  * Boot-pass wrapper. Log-and-continue posture (mirrors
  * `runBuiltinDatasourceCatalogSeedBoot`): a seed failure leaves the
  * migration-inserted row authoritative rather than crashing the API.
+ *
+ * Slice 6a (#3028): this also seeds the vendor `*-data` candidate rows
+ * (`data-candidate-seed.ts`) in the same boot pass / DB session, so no extra
+ * boot DAG node is needed. The returned `inserted` flag still reflects the
+ * generic row; candidate inserts are logged by their own seed. A candidate seed
+ * failure propagates into this wrapper's catch (same non-fatal posture).
  */
 export async function runOpenApiDatasourceCatalogSeedBoot(): Promise<OpenApiDatasourceCatalogSeedBootResult> {
   const { hasInternalDB, getInternalDB } = await import("@atlas/api/lib/db/internal");
@@ -108,12 +115,15 @@ export async function runOpenApiDatasourceCatalogSeedBoot(): Promise<OpenApiData
 
   try {
     const result = await seedOpenApiDatasourceCatalog(db);
+    // Slice 6a (#3028): seed the vendor *-data candidate rows (Stripe today;
+    // Notion/GitHub next) in the same pass. Same idempotent ON CONFLICT posture.
+    await seedDataCandidateCatalog(db);
     return { kind: "seeded", inserted: result.inserted };
   } catch (err) {
     const normalized = err instanceof Error ? err : new Error(String(err));
     log.error(
       { err: normalized },
-      "openapi-generic catalog seed failed — migration-inserted row remains authoritative",
+      "openapi-generic / data-candidate catalog seed failed — migration-inserted rows remain authoritative",
     );
     return { kind: "error", message: normalized.message };
   }

--- a/packages/api/src/lib/openapi/client.ts
+++ b/packages/api/src/lib/openapi/client.ts
@@ -43,6 +43,11 @@ import {
   type OperationResult,
   type ResolvedAuth,
 } from "./types";
+import {
+  applyQuirkHeaders,
+  applyQuirkQueryShaping,
+  type VendorQuirk,
+} from "./vendor-quirk";
 
 // ─────────────────────────────────────────────────────────────────────
 //  Public entry point
@@ -88,8 +93,8 @@ export async function executeOperation(
     });
   }
 
-  const url = buildUrl(baseUrl, operation, params, graph, resolvedAuth);
-  const headers = buildHeaders(operation, params, graph, resolvedAuth);
+  const url = buildUrl(baseUrl, operation, params, graph, resolvedAuth, opts.quirk);
+  const headers = buildHeaders(operation, params, graph, resolvedAuth, opts.quirk);
   const { body, hasBody } = buildBody(operation, params, headers);
 
   const timeoutMs = opts.timeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
@@ -195,6 +200,10 @@ export async function executeOperationPaged(
     ...(opts.baseUrl !== undefined ? { baseUrl: opts.baseUrl } : {}),
     ...(opts.timeoutMs !== undefined ? { timeoutMs: opts.timeoutMs } : {}),
     ...(opts.fetchImpl !== undefined ? { fetchImpl: opts.fetchImpl } : {}),
+    // Thread the vendor quirk into every page request (slice 6a, #3028) so a
+    // paginated walk shapes expand[] / sends required headers on each page, not
+    // just the first — the cursor param the strategy adds is left unshaped.
+    ...(opts.quirk !== undefined ? { quirk: opts.quirk } : {}),
   };
 
   return paginate(
@@ -222,12 +231,17 @@ function buildUrl(
   params: OperationParams,
   graph: OperationGraph,
   resolvedAuth: ResolvedAuth,
+  quirk: VendorQuirk | undefined,
 ): URL {
   const resolvedPath = substitutePathParams(operation, params.path);
   const url = new URL(joinUrl(baseUrl, resolvedPath));
 
-  if (params.query) {
-    for (const [key, value] of Object.entries(params.query)) {
+  // Apply the vendor's query param-shaping (slice 6a, #3028) BEFORE encoding, so
+  // a matched param (Stripe `expand` → `expand[]`) is emitted under its reshaped
+  // key. Pure: a NEW record (or the input unchanged when there's no quirk).
+  const query = applyQuirkQueryShaping(params.query, quirk);
+  if (query) {
+    for (const [key, value] of Object.entries(query)) {
       appendQueryValue(url.searchParams, key, value);
     }
   }
@@ -285,6 +299,7 @@ function buildHeaders(
   params: OperationParams,
   graph: OperationGraph,
   resolvedAuth: ResolvedAuth,
+  quirk: VendorQuirk | undefined,
 ): Record<string, string> {
   const headers: Record<string, string> = {
     accept: "application/json",
@@ -299,6 +314,11 @@ function buildHeaders(
     }
   }
 
+  // The vendor's required static headers (slice 6a, #3028) apply as
+  // NON-clobbering defaults — set before auth so an explicit `in: header` param
+  // above wins, and so a quirk header can't shadow the Authorization header auth
+  // applies next (a quirk that names "Authorization" is ignored by the guard).
+  applyQuirkHeaders(headers, quirk);
   applyHeaderAuth(headers, operation, graph, resolvedAuth);
   return headers;
 }

--- a/packages/api/src/lib/openapi/client.ts
+++ b/packages/api/src/lib/openapi/client.ts
@@ -46,6 +46,7 @@ import {
 import {
   applyQuirkHeaders,
   applyQuirkQueryShaping,
+  type QueryValue,
   type VendorQuirk,
 } from "./vendor-quirk";
 
@@ -277,11 +278,7 @@ function joinUrl(baseUrl: string, pathSegment: string): string {
 }
 
 /** Append a query value; arrays explode (repeat the key); `undefined` is dropped. */
-function appendQueryValue(
-  search: URLSearchParams,
-  key: string,
-  value: string | number | boolean | ReadonlyArray<string | number | boolean> | undefined,
-): void {
+function appendQueryValue(search: URLSearchParams, key: string, value: QueryValue): void {
   if (value === undefined) return;
   if (Array.isArray(value)) {
     for (const item of value) search.append(key, String(item));

--- a/packages/api/src/lib/openapi/data-candidate-seed.ts
+++ b/packages/api/src/lib/openapi/data-candidate-seed.ts
@@ -1,0 +1,70 @@
+/**
+ * Boot-time idempotent seed for the built-in vendor `*-data` Datasource catalog
+ * rows (v0.0.2 slice 6a, #3028). The data-candidate analogue of
+ * `catalog-seed.ts::seedOpenApiDatasourceCatalog` — same posture, one row per
+ * {@link DATA_CANDIDATES} entry:
+ *
+ *   - Each candidate is a real `plugin_catalog` datasource-pillar row so it
+ *     surfaces in `/admin/connections` as its own card ("Stripe").
+ *   - Like `openapi-generic`, these rows are INTENTIONALLY NOT in
+ *     `BUILTIN_DATASOURCE_CATALOG_SLUGS` (the SQL pool allowlist) — a REST
+ *     datasource has no SQL pool; it resolves through the parallel REST resolver
+ *     (`workspace-datasource.ts`). Keeping them out means the SQL boot loader
+ *     skips their installs for free.
+ *   - Bare `ON CONFLICT DO NOTHING` (covers both the `slug` unique index and the
+ *     `id` primary key) so a re-boot on a populated catalog is a no-op and an
+ *     operator's out-of-band `name`/`description` edits survive.
+ *
+ * Re-asserts the same rows migration 0109 inserts on fresh DBs; the migration and
+ * this seed share {@link DATA_CANDIDATE_CONFIG_SCHEMA} + the {@link DATA_CANDIDATES}
+ * registry as the single source of truth (the `migration 0109 ↔ code alignment`
+ * test asserts they match). Invoked from `catalog-seed.ts`'s boot wrapper so the
+ * generic row and the candidate rows seed in one boot pass with no extra DAG node.
+ */
+
+import { createLogger } from "@atlas/api/lib/logger";
+import { DATA_CANDIDATES, DATA_CANDIDATE_CONFIG_SCHEMA } from "./data-candidates";
+import type { OpenApiDatasourceCatalogSeedDb } from "./catalog-seed";
+
+const log = createLogger("openapi.data-candidate-seed");
+
+export interface DataCandidateCatalogSeedResult {
+  /** Slugs the `ON CONFLICT DO NOTHING` actually inserted (were missing). */
+  readonly insertedSlugs: ReadonlyArray<string>;
+}
+
+/**
+ * Idempotently seed every data-candidate catalog row. Column order + the
+ * `'datasource'` type+pillar / `'available'` status / `'form'` install_model /
+ * `'starter'` min_plan / `true` enabled+saas_eligible literals all mirror
+ * migration 0109 and the generic-row seed so the admin catalog surfaces these
+ * identically. One INSERT per row keeps the SQL trivial and the idempotency
+ * per-row (a partially-seeded catalog converges on the next boot).
+ */
+export async function seedDataCandidateCatalog(
+  db: OpenApiDatasourceCatalogSeedDb,
+): Promise<DataCandidateCatalogSeedResult> {
+  const insertedSlugs: string[] = [];
+  const configSchemaJson = JSON.stringify(DATA_CANDIDATE_CONFIG_SCHEMA);
+
+  for (const candidate of DATA_CANDIDATES) {
+    const { rows } = await db.query<{ slug: string }>(
+      `INSERT INTO plugin_catalog
+         (id, name, slug, description, type, install_model, pillar,
+          implementation_status, auto_install, min_plan, enabled, saas_eligible,
+          config_schema, created_at, updated_at)
+       VALUES ($1, $2, $3, $4, 'datasource', 'form', 'datasource', 'available',
+               false, 'starter', true, true, $5::jsonb, NOW(), NOW())
+       ON CONFLICT DO NOTHING
+       RETURNING slug`,
+      [candidate.catalogId, candidate.name, candidate.slug, candidate.description, configSchemaJson],
+    );
+    if (rows.length > 0) insertedSlugs.push(candidate.slug);
+  }
+
+  log.info(
+    { insertedCount: insertedSlugs.length, total: DATA_CANDIDATES.length, insertedSlugs },
+    "data-candidate catalog seed complete",
+  );
+  return { insertedSlugs };
+}

--- a/packages/api/src/lib/openapi/data-candidates.ts
+++ b/packages/api/src/lib/openapi/data-candidates.ts
@@ -1,0 +1,166 @@
+/**
+ * `data-candidates` — the declarative registry of built-in vendor `*-data` REST
+ * Datasource catalog rows (v0.0.2 slice 6a, #3028; the foundational pattern
+ * #3029 / #3030 extend).
+ *
+ * ## What a "data candidate" is
+ * A thin, pre-wired wrapper over the SAME generic OpenAPI primitive the
+ * `openapi-generic` catalog row exposes (`catalog.ts`). The generic row makes an
+ * admin paste a spec URL + pick an auth kind; a data candidate pre-fills both
+ * from this registry so the admin installs "Stripe" by pasting only their secret
+ * key — no spec URL, no auth-kind dropdown. Everything else (probe, snapshot,
+ * operation graph, validator, paginator, client) is the unchanged generic
+ * machinery — there is NO forked walker / paginator / validator per vendor. The
+ * only vendor-specific data is:
+ *   - the pre-filled {@link DataCandidate.openapiUrl} + {@link DataCandidate.authKind},
+ *   - an optional declarative {@link DataCandidate.quirk} (required headers /
+ *     query param-shaping the generic client applies, see `vendor-quirk.ts`),
+ *   - an optional default {@link DataCandidate.pagination} config (resolved
+ *     against the SAME `defaultPaginatorRegistry` — no new strategy file).
+ *
+ * Adding a candidate is one entry in {@link DATA_CANDIDATES} (~a dozen lines) +
+ * a one-row migration mirroring this registry. That is the "thin catalog-seed
+ * wrapper (~50 LoC) over the generic primitive" thesis #2930 set.
+ *
+ * ## Seeding + resolution
+ * Each candidate is a real `plugin_catalog` row (datasource pillar) so it surfaces
+ * in `/admin/connections` as its own installable card. The boot seed
+ * (`data-candidate-seed.ts`) re-asserts every row idempotently; migration
+ * 0109 inserts them on fresh DBs. An install writes a `workspace_plugins` row
+ * under the candidate's {@link DataCandidate.catalogId}; the workspace resolver
+ * (`workspace-datasource.ts`) matches those ids alongside `openapi-generic` and
+ * attaches the candidate's {@link DataCandidate.quirk} to the resolved
+ * {@link import("./datasource").RestDatasource}.
+ */
+import type { ConfigSchemaField } from "@atlas/api/lib/plugins/registry";
+import type { SupportedAuthKind } from "./catalog";
+import type { PaginationConfig } from "./paginator";
+import type { VendorQuirk } from "./vendor-quirk";
+
+/**
+ * A built-in vendor REST datasource, pre-wired over the generic primitive. The
+ * `slug` / `catalogId` follow the same `catalog:${slug}` derivation the seeder
+ * uses for every catalog row (so `workspace_plugins.catalog_id` FK-targets
+ * `catalog:stripe-data`).
+ */
+export interface DataCandidate {
+  /** Catalog slug + install-handler dispatch key, e.g. "stripe-data". */
+  readonly slug: string;
+  /** Stable `plugin_catalog.id` (`catalog:${slug}`), the FK target. */
+  readonly catalogId: string;
+  /** Friendly card name in `/admin/connections`, e.g. "Stripe". */
+  readonly name: string;
+  /** Card description. */
+  readonly description: string;
+  /** Pre-filled OpenAPI 3.x spec URL — the admin never pastes this. */
+  readonly openapiUrl: string;
+  /** Pre-filled auth kind — the admin only supplies the credential value. */
+  readonly authKind: SupportedAuthKind;
+  /**
+   * Declarative deviations the generic client applies per request (required
+   * static headers / query param-shaping). Omit for a perfectly-generic API.
+   */
+  readonly quirk?: VendorQuirk;
+  /**
+   * Default pagination config for the candidate's list operations, resolved
+   * against the SAME `defaultPaginatorRegistry` (no new strategy file). Stripe's
+   * whole list surface uses one cursor dialect, so a single default suffices.
+   * Forward-looking: the live tool calls the un-paginated primitive today
+   * (`executeOperationPaged` is dormant, see paginator.test.ts) — this is what
+   * wires in when pagination reaches the tool (#2970).
+   */
+  readonly pagination?: PaginationConfig;
+}
+
+/**
+ * The install-form `config_schema` shared by EVERY data-candidate row. The admin
+ * supplies only the credential (+ optional overrides) — `openapi_url` and
+ * `auth_kind` are pre-filled from the {@link DataCandidate} by the install
+ * handler, so they are deliberately ABSENT here (a candidate install must never
+ * let the admin re-point the locked spec URL). `auth_value`'s `secret: true` is
+ * the single flag that drives `encryptSecretFields` — same one-line-to-add-a-
+ * secret contract as the generic schema.
+ */
+export const DATA_CANDIDATE_CONFIG_SCHEMA: ReadonlyArray<ConfigSchemaField> = [
+  {
+    key: "auth_value",
+    type: "string",
+    label: "API key / token",
+    required: true,
+    secret: true,
+    description:
+      "The API credential for this datasource (e.g. your Stripe secret key). Encrypted at rest.",
+  },
+  {
+    key: "base_url_override",
+    type: "string",
+    label: "Base URL override",
+    description: "When the spec's servers[0].url is wrong (dev/staging/regional host).",
+  },
+  {
+    key: "display_name",
+    type: "string",
+    label: "Display name",
+    description: "Friendly name shown in /admin/connections.",
+  },
+];
+
+/**
+ * Stripe — the first data candidate (#3028). Proves three dimensions the
+ * candidate set deliberately spans:
+ *  - `bearer` auth (the secret key, sent as `Authorization: Bearer …`),
+ *  - the `expand[]` query quirk (Stripe's bracket-array form encoding),
+ *  - cursor pagination via the existing `cursor` strategy — Stripe's cursor is
+ *    the LAST returned object's `id` fed back as `starting_after`, with a
+ *    top-level `has_more` flag (handled by the strategy's `cursorFromLastItem` +
+ *    `hasMorePath`, no new strategy file).
+ */
+export const STRIPE_DATA_CANDIDATE: DataCandidate = {
+  slug: "stripe-data",
+  catalogId: "catalog:stripe-data",
+  name: "Stripe",
+  description:
+    "Query your Stripe account (customers, charges, invoices, subscriptions, …) as a read-only " +
+    "REST datasource. Pre-wired to Stripe's published OpenAPI spec — paste your secret key, no " +
+    "spec URL needed. The agent discovers operations from the spec and queries them directly.",
+  openapiUrl: "https://raw.githubusercontent.com/stripe/openapi/master/openapi/spec3.json",
+  authKind: "bearer",
+  quirk: {
+    // Stripe wants array params as `expand[]=a&expand[]=b`; the spec declares a
+    // bare `expand` (style: deepObject, explode: true), so the `[]` is a shaping
+    // rule, not graph data.
+    queryParamShaping: [{ param: "expand", bracketArray: true }],
+  },
+  pagination: {
+    strategy: "cursor",
+    itemsPath: "data",
+    cursorParam: "starting_after",
+    // Stripe has no `endCursor` field — the next cursor is the last list item's id.
+    cursorFromLastItem: true,
+    cursorItemField: "id",
+    hasMorePath: "has_more",
+  },
+};
+
+/** Every built-in data candidate. Append a new vendor here (the one-line thesis). */
+export const DATA_CANDIDATES: ReadonlyArray<DataCandidate> = [STRIPE_DATA_CANDIDATE];
+
+const BY_CATALOG_ID = new Map<string, DataCandidate>(
+  DATA_CANDIDATES.map((c) => [c.catalogId, c]),
+);
+const BY_SLUG = new Map<string, DataCandidate>(DATA_CANDIDATES.map((c) => [c.slug, c]));
+
+/** The catalog ids the workspace resolver must match alongside `openapi-generic`. */
+export const DATA_CANDIDATE_CATALOG_IDS: ReadonlyArray<string> = DATA_CANDIDATES.map(
+  (c) => c.catalogId,
+);
+
+/** Look up a candidate by its `plugin_catalog.id` (resolver path), or `undefined`. */
+export function findDataCandidateByCatalogId(catalogId: string): DataCandidate | undefined {
+  return BY_CATALOG_ID.get(catalogId);
+}
+
+/** Look up a candidate by its slug (install-handler registration path), or `undefined`. */
+export function findDataCandidateBySlug(slug: string): DataCandidate | undefined {
+  return BY_SLUG.get(slug);
+}

--- a/packages/api/src/lib/openapi/datasource.ts
+++ b/packages/api/src/lib/openapi/datasource.ts
@@ -18,6 +18,7 @@
  */
 import type { OperationGraph, ResolvedAuth } from "./types";
 import type { RepresentationMode } from "./representation";
+import type { VendorQuirk } from "./vendor-quirk";
 
 /**
  * A resolved REST datasource the agent can read from. The normalized operation
@@ -75,4 +76,14 @@ export interface RestDatasource {
    * `workspace_plugins.config.request_timeout_ms`.
    */
   readonly requestTimeoutMs?: number;
+  /**
+   * The vendor's declarative quirk (slice 6a, #3028) — required static headers /
+   * query param-shaping the client applies on every request. Present only for a
+   * built-in data-candidate install (e.g. `stripe-data` → `expand[]` shaping);
+   * `undefined` for a plain `openapi-generic` install. CODE-resident: the resolver
+   * looks it up from the `DATA_CANDIDATES` registry by the install's catalog id —
+   * it is never stored in (or read from) the encrypted config. The agent tool
+   * threads it into `executeOperation` via {@link import("./types").ExecuteOptions.quirk}.
+   */
+  readonly quirk?: VendorQuirk;
 }

--- a/packages/api/src/lib/openapi/index.ts
+++ b/packages/api/src/lib/openapi/index.ts
@@ -126,3 +126,21 @@ export type {
   PageCacheIdentity,
 } from "./paginator";
 export { defaultPaginatorRegistry, BUILT_IN_STRATEGIES } from "./strategies";
+
+// ── Data candidates + vendor quirks (slice 6a, #3028) ────────────────────────
+// Thin pre-wired vendor `*-data` datasource wrappers (Stripe; Notion/GitHub
+// next) over the generic primitive, plus the declarative vendor-quirk descriptor
+// the client applies through its header/query seams. The pattern 6b/6c extend.
+export {
+  DATA_CANDIDATES,
+  DATA_CANDIDATE_CATALOG_IDS,
+  DATA_CANDIDATE_CONFIG_SCHEMA,
+  STRIPE_DATA_CANDIDATE,
+  findDataCandidateByCatalogId,
+  findDataCandidateBySlug,
+} from "./data-candidates";
+export type { DataCandidate } from "./data-candidates";
+export { applyQuirkHeaders, applyQuirkQueryShaping } from "./vendor-quirk";
+export type { VendorQuirk, QueryParamShapeRule } from "./vendor-quirk";
+export { seedDataCandidateCatalog } from "./data-candidate-seed";
+export type { DataCandidateCatalogSeedResult } from "./data-candidate-seed";

--- a/packages/api/src/lib/openapi/strategies/cursor.ts
+++ b/packages/api/src/lib/openapi/strategies/cursor.ts
@@ -21,6 +21,8 @@
  *  - `cursorItemField`    (opt) — with `cursorFromLastItem`, the dot-path to the
  *                                 cursor field ON the last item, e.g. `"id"`.
  *                                 Omit to use the last item itself as the cursor.
+ *                                 A numeric id is coerced to its string form; any
+ *                                 other non-string value ends the walk fail-soft.
  *  - `hasMorePath`        (opt) — dot-path to a boolean "more pages" flag, e.g.
  *                                 `"pageInfo.hasNextPage"` / `"has_more"`. When set,
  *                                 the walk stops unless it is exactly `true`.
@@ -70,7 +72,17 @@ export const cursorStrategy: PaginationStrategyFactory = {
           const items = extractItems(response.body, itemsPath);
           if (items.length === 0) return PAGE_DONE;
           const lastItem = items[items.length - 1];
-          cursor = cursorItemField !== undefined ? dotGet(lastItem, cursorItemField) : lastItem;
+          const rawCursor =
+            cursorItemField !== undefined ? dotGet(lastItem, cursorItemField) : lastItem;
+          // The last-item cursor is commonly a numeric id (Stripe uses string ids
+          // like `cus_…`, but other vendors of this dialect number them). Coerce a
+          // finite number to its string form so the walk continues; anything else
+          // (object, null, NaN) falls through to the typeof guard below and ends
+          // the walk fail-soft rather than fetching a garbage cursor.
+          cursor =
+            typeof rawCursor === "number" && Number.isFinite(rawCursor)
+              ? String(rawCursor)
+              : rawCursor;
         } else {
           // `cursorPath` is non-undefined here: the non-last-item branch took the
           // `requireString` path above (fail-loud at create time otherwise).

--- a/packages/api/src/lib/openapi/strategies/cursor.ts
+++ b/packages/api/src/lib/openapi/strategies/cursor.ts
@@ -1,25 +1,39 @@
 /**
  * `cursor` pagination strategy — opaque next-cursor token.
  *
- * The dialect Twenty uses: each page carries an `endCursor` (and a `hasNextPage`
- * flag) in its body; the next page is fetched by setting that cursor on a query
- * param (`starting_after`). Stripe's `starting_after`/`ending_before` is the same
- * shape — a fifth strategy file is usually unnecessary for it.
+ * Two dialects, one strategy (no fork):
+ *  - **endCursor-in-body** (Twenty): each page carries an `endCursor` (and a
+ *    `hasNextPage` flag) in its body; the next page sets that cursor on a query
+ *    param (`starting_after`). Configure `cursorPath` (+ optional `hasMorePath`).
+ *  - **last-item-id** (Stripe, #3028): the body has NO cursor field — the next
+ *    cursor IS the LAST returned list item's id, fed back as `starting_after`,
+ *    with a top-level `has_more` boolean. Set `cursorFromLastItem: true`
+ *    (+ `cursorItemField` for the id field, + `hasMorePath: "has_more"`). This is
+ *    a common REST dialect, declared via config — not a Stripe-specific code path.
  *
  * Config fields:
- *  - `itemsPath`   (req) — dot-path to the item array, e.g. `"data.people"`.
- *  - `cursorParam` (req) — query param the next cursor is set on, e.g. `"starting_after"`.
- *  - `cursorPath`  (req) — dot-path to the next cursor in the body, e.g. `"pageInfo.endCursor"`.
- *  - `hasMorePath` (opt) — dot-path to a boolean "more pages" flag, e.g. `"pageInfo.hasNextPage"`.
- *                          When set, the walk stops unless it is exactly `true`.
+ *  - `itemsPath`          (req) — dot-path to the item array, e.g. `"data.people"` or `"data"`.
+ *  - `cursorParam`        (req) — query param the next cursor is set on, e.g. `"starting_after"`.
+ *  - `cursorPath`         (req unless `cursorFromLastItem`) — dot-path to the next
+ *                                 cursor in the body, e.g. `"pageInfo.endCursor"`.
+ *  - `cursorFromLastItem` (opt) — when `true`, derive the cursor from the LAST
+ *                                 item in `itemsPath` instead of `cursorPath`.
+ *  - `cursorItemField`    (opt) — with `cursorFromLastItem`, the dot-path to the
+ *                                 cursor field ON the last item, e.g. `"id"`.
+ *                                 Omit to use the last item itself as the cursor.
+ *  - `hasMorePath`        (opt) — dot-path to a boolean "more pages" flag, e.g.
+ *                                 `"pageInfo.hasNextPage"` / `"has_more"`. When set,
+ *                                 the walk stops unless it is exactly `true`.
  *
  * Termination: stops when `hasMorePath` (if configured) isn't `true`, when the
- * cursor is absent/empty, or when the returned cursor equals the one already on
- * the request (no progress — an upstream echoing its cursor can't loop forever).
+ * item array is empty (last-item dialect), when the cursor is absent/empty, or
+ * when the returned cursor equals the one already on the request (no progress —
+ * an upstream echoing its cursor can't loop forever).
  */
 import {
   continueWith,
   dotGet,
+  extractItems,
   optionalString,
   PAGE_DONE,
   requireString,
@@ -34,8 +48,14 @@ export const cursorStrategy: PaginationStrategyFactory = {
   create(config: PaginationConfig): PaginationStrategy {
     const itemsPath = requireString(config, "itemsPath");
     const cursorParam = requireString(config, "cursorParam");
-    const cursorPath = requireString(config, "cursorPath");
     const hasMorePath = optionalString(config, "hasMorePath");
+    const cursorFromLastItem = config.cursorFromLastItem === true;
+    const cursorItemField = optionalString(config, "cursorItemField");
+    // `cursorPath` is required only for the body-cursor dialect; the last-item
+    // dialect derives the cursor from the item array instead.
+    const cursorPath = cursorFromLastItem
+      ? optionalString(config, "cursorPath")
+      : requireString(config, "cursorPath");
 
     return {
       name: "cursor",
@@ -44,7 +64,19 @@ export const cursorStrategy: PaginationStrategyFactory = {
         if (hasMorePath !== undefined && dotGet(response.body, hasMorePath) !== true) {
           return PAGE_DONE;
         }
-        const cursor = dotGet(response.body, cursorPath);
+
+        let cursor: unknown;
+        if (cursorFromLastItem) {
+          const items = extractItems(response.body, itemsPath);
+          if (items.length === 0) return PAGE_DONE;
+          const lastItem = items[items.length - 1];
+          cursor = cursorItemField !== undefined ? dotGet(lastItem, cursorItemField) : lastItem;
+        } else {
+          // `cursorPath` is non-undefined here: the non-last-item branch took the
+          // `requireString` path above (fail-loud at create time otherwise).
+          cursor = dotGet(response.body, cursorPath as string);
+        }
+
         if (typeof cursor !== "string" || cursor.length === 0) return PAGE_DONE;
         // No-progress guard: if the upstream echoes the same cursor, stop.
         if (cursor === request.params.query?.[cursorParam]) return PAGE_DONE;

--- a/packages/api/src/lib/openapi/types.ts
+++ b/packages/api/src/lib/openapi/types.ts
@@ -20,6 +20,7 @@
  * into it — per PRD #2868 "Option B: parallel adapter, not subordinate".
  */
 import { Data } from "effect";
+import type { VendorQuirk } from "./vendor-quirk";
 
 // ─────────────────────────────────────────────────────────────────────
 //  Primitive enums
@@ -305,6 +306,14 @@ export interface ExecuteOptions {
   readonly timeoutMs?: number;
   /** `fetch` implementation override, for integration tests. */
   readonly fetchImpl?: typeof globalThis.fetch;
+  /**
+   * A vendor's declarative deviations from plain REST (slice 6a, #3028): required
+   * static headers + query param-shaping the client applies to THIS request
+   * through its header / query seams. Data, not a code branch — a data candidate
+   * (`data-candidates.ts`) supplies its {@link VendorQuirk} here via the resolved
+   * {@link import("./datasource").RestDatasource}. Omit for a perfectly-generic API.
+   */
+  readonly quirk?: VendorQuirk;
 }
 
 /**

--- a/packages/api/src/lib/openapi/vendor-quirk.ts
+++ b/packages/api/src/lib/openapi/vendor-quirk.ts
@@ -29,7 +29,7 @@
  */
 
 /** A query value as the client models it — scalar, exploding array, or dropped. */
-type QueryValue =
+export type QueryValue =
   | string
   | number
   | boolean

--- a/packages/api/src/lib/openapi/vendor-quirk.ts
+++ b/packages/api/src/lib/openapi/vendor-quirk.ts
@@ -1,0 +1,126 @@
+/**
+ * `vendor-quirk` — a declarative description of a vendor REST API's deviations
+ * from "plain" OpenAPI that the generic client (`client.ts`) must honor on every
+ * request (v0.0.2 slice 6a, #3028).
+ *
+ * The whole point is that a vendor quirk is **DATA, not a code branch.** A data
+ * candidate (`data-candidates.ts`: Stripe today; Notion #3029, GitHub #3030
+ * next) declares its quirk once as a {@link VendorQuirk} literal; the generic
+ * client applies it through the existing header/query seams in
+ * `executeOperation` with NO per-vendor `if (vendor === "stripe")` branch. Adding
+ * a candidate's required header is a one-line entry in that literal — the
+ * acceptance criterion this module exists to satisfy.
+ *
+ * Two axes, the only deviations the candidate set surfaces so far:
+ *  - {@link VendorQuirk.requiredHeaders} — static headers the API mandates on
+ *    every call regardless of the operation (e.g. Notion's
+ *    `Notion-Version: 2022-06-28`). Nothing in the OpenAPI document models a
+ *    "send this header on every request" requirement, so it lives here.
+ *  - {@link VendorQuirk.queryParamShaping} — per-parameter key encoding the
+ *    OpenAPI `style`/`explode` model doesn't capture for a vendor. Stripe expects
+ *    array params in the bracket-repeat form `expand[]=a&expand[]=b`; the spec
+ *    only declares `style: deepObject, explode: true` on a bare `expand`, so the
+ *    `[]` suffix is a shaping rule, not something the graph carries.
+ *
+ * Pure + dependency-free on purpose: `types.ts` imports {@link VendorQuirk} for
+ * `ExecuteOptions.quirk`, so this module must not import from `types.ts` (that
+ * would be a cycle). The two apply helpers operate over plain header / query
+ * records and are unit-tested in isolation.
+ */
+
+/** A query value as the client models it — scalar, exploding array, or dropped. */
+type QueryValue =
+  | string
+  | number
+  | boolean
+  | ReadonlyArray<string | number | boolean>
+  | undefined;
+
+/**
+ * One query-parameter shaping rule: rewrite the KEY a param is emitted under.
+ * The value (and the client's array-explode behavior) is untouched — only the
+ * key changes — so an array still serializes as repeated keys, now under the
+ * reshaped name.
+ */
+export interface QueryParamShapeRule {
+  /** The query parameter this rule reshapes, by its OpenAPI name (e.g. "expand"). */
+  readonly param: string;
+  /**
+   * Emit the param under a bracket-suffixed key (`expand` → `expand[]`) so an
+   * array value serializes as `expand[]=a&expand[]=b` — Stripe's (and Rails'
+   * form-encoding) array convention. Ignored when {@link rename} is set.
+   */
+  readonly bracketArray?: boolean;
+  /** Rename the param key outright. Takes precedence over {@link bracketArray}. */
+  readonly rename?: string;
+}
+
+/**
+ * A vendor's declarative deviations from plain REST. Both axes are optional — a
+ * candidate with no quirk (a perfectly generic API) simply omits this and the
+ * apply helpers are no-ops.
+ */
+export interface VendorQuirk {
+  /**
+   * Static headers the API mandates on every request. Applied as defaults: a
+   * header the caller already set (an `in: header` param) wins, so a quirk header
+   * never clobbers an explicit per-request value.
+   */
+  readonly requiredHeaders?: Readonly<Record<string, string>>;
+  /** Per-parameter key-encoding overrides. Applied to the query bucket pre-encode. */
+  readonly queryParamShaping?: ReadonlyArray<QueryParamShapeRule>;
+}
+
+/** Case-insensitive header presence check (HTTP header names are case-insensitive). */
+function hasHeader(headers: Record<string, string>, name: string): boolean {
+  const target = name.toLowerCase();
+  return Object.keys(headers).some((k) => k.toLowerCase() === target);
+}
+
+/**
+ * Merge a quirk's {@link VendorQuirk.requiredHeaders} into a header bag IN PLACE.
+ * A header already present (case-insensitively) is left untouched — the quirk is
+ * a default, not an override, so an explicit `in: header` param the caller set
+ * always wins. No-op when the quirk (or its `requiredHeaders`) is absent.
+ */
+export function applyQuirkHeaders(
+  headers: Record<string, string>,
+  quirk: VendorQuirk | undefined,
+): void {
+  const required = quirk?.requiredHeaders;
+  if (required === undefined) return;
+  for (const [name, value] of Object.entries(required)) {
+    if (!hasHeader(headers, name)) headers[name] = value;
+  }
+}
+
+/**
+ * Rewrite a query-param record per the quirk's {@link VendorQuirk.queryParamShaping}
+ * rules. Pure: returns a NEW record (the input is read-only) — or the input
+ * unchanged when there are no rules. A param with no matching rule passes through
+ * verbatim; a matched param is re-keyed (`rename` wins over `bracketArray`)
+ * carrying its original value (arrays preserved, so the client's explode still
+ * applies under the new key). Params a rule doesn't name — including a
+ * pagination cursor added later in the walk — are never touched.
+ */
+export function applyQuirkQueryShaping(
+  query: Readonly<Record<string, QueryValue>> | undefined,
+  quirk: VendorQuirk | undefined,
+): Readonly<Record<string, QueryValue>> | undefined {
+  if (query === undefined) return undefined;
+  const rules = quirk?.queryParamShaping;
+  if (rules === undefined || rules.length === 0) return query;
+
+  const ruleByParam = new Map(rules.map((r) => [r.param, r]));
+  const out: Record<string, QueryValue> = {};
+  for (const [key, value] of Object.entries(query)) {
+    const rule = ruleByParam.get(key);
+    if (rule === undefined) {
+      out[key] = value;
+      continue;
+    }
+    const reshapedKey = rule.rename ?? (rule.bracketArray ? `${key}[]` : key);
+    out[reshapedKey] = value;
+  }
+  return out;
+}

--- a/packages/api/src/lib/openapi/workspace-datasource.ts
+++ b/packages/api/src/lib/openapi/workspace-datasource.ts
@@ -90,14 +90,17 @@ export type OpenApiInstallQueryExecutor = (
 ) => Promise<ReadonlyArray<OpenApiInstallRow>>;
 
 /**
- * Default query: the workspace's non-archived `openapi-generic` installs.
+ * Default query: the workspace's non-archived REST datasource installs — the
+ * built-in `openapi-generic` row AND every data candidate (slice 6a, #3028),
+ * matched via `catalog_id = ANY($2)` over one code-resident array of catalog ids.
  * Lazily imports `internalQuery` so the resolver's static graph stays free of
  * the DB module (admin-route tests partial-mock it heavily).
  *
  * The `WHERE` clause is the load-bearing tenant-scope guard: every conjunct
- * (`workspace_id = $1`, `catalog_id = $2`, `pillar = 'datasource'`,
+ * (`workspace_id = $1`, `catalog_id = ANY($2)`, `pillar = 'datasource'`,
  * `status != 'archived'`) must hold, or the resolver leaks another tenant's
- * datasources / credentials. Every other test injects `deps.query` and so
+ * datasources / credentials. The `$2` array holds only built-in catalog
+ * constants (never client input). Every other test injects `deps.query` and so
  * bypasses this SQL — the `exec` seam lets a unit test drive it directly and
  * fail loudly if the scope or param order regresses (#3011).
  */

--- a/packages/api/src/lib/openapi/workspace-datasource.ts
+++ b/packages/api/src/lib/openapi/workspace-datasource.ts
@@ -37,6 +37,11 @@ import {
   parseSideEffectingOperations,
   parseWriteAllowlist,
 } from "./catalog";
+import {
+  DATA_CANDIDATE_CATALOG_IDS,
+  DATA_CANDIDATE_CONFIG_SCHEMA,
+  findDataCandidateByCatalogId,
+} from "./data-candidates";
 import { assertBaseUrlAllowed, EgressBlockedError, hostForLog } from "./egress-guard";
 import { resolveAuthFromDecryptedConfig, snapshotToGraph } from "./probe";
 import type { OperationGraph } from "./types";
@@ -47,9 +52,16 @@ const log = createLogger("openapi.workspace-datasource");
  * A `workspace_plugins` row this resolver reads. `config` is the raw (encrypted)
  * JSONB. A `type` (not `interface`) so it satisfies `internalQuery`'s
  * `Record<string, unknown>` row constraint via TS's implicit index signature.
+ *
+ * `catalog_id` distinguishes a plain `openapi-generic` install from a built-in
+ * data-candidate install (e.g. `catalog:stripe-data`, slice 6a #3028) so the
+ * resolver can attach the candidate's code-resident quirk + decrypt with the
+ * matching config schema. Optional for back-compat: a row that omits it is
+ * treated as the generic datasource (no quirk).
  */
 export type OpenApiInstallRow = {
   readonly install_id: string;
+  readonly catalog_id?: string;
   readonly config: Record<string, unknown> | null;
 };
 
@@ -93,20 +105,24 @@ export async function defaultQuery(
   workspaceId: string,
   exec?: OpenApiInstallQueryExecutor,
 ): Promise<ReadonlyArray<OpenApiInstallRow>> {
-  const sql = `SELECT install_id, config
+  // Match the generic datasource AND every built-in data candidate (slice 6a,
+  // #3028) — `catalog_id = ANY($2)` over one array keeps the scope a single
+  // bind. The per-conjunct tenant guard is otherwise unchanged.
+  const sql = `SELECT install_id, catalog_id, config
        FROM workspace_plugins
       WHERE workspace_id = $1
-        AND catalog_id = $2
+        AND catalog_id = ANY($2)
         AND pillar = 'datasource'
         AND status != 'archived'
       ORDER BY installed_at ASC`;
-  const params = [workspaceId, OPENAPI_GENERIC_CATALOG_ID];
+  const params = [workspaceId, [OPENAPI_GENERIC_CATALOG_ID, ...DATA_CANDIDATE_CATALOG_IDS]];
   if (exec) return exec(sql, params);
   const { internalQuery } = await import("@atlas/api/lib/db/internal");
   return internalQuery<OpenApiInstallRow>(sql, params);
 }
 
-const SECRET_SCHEMA = parseConfigSchema(OPENAPI_GENERIC_CONFIG_SCHEMA);
+const GENERIC_SECRET_SCHEMA = parseConfigSchema(OPENAPI_GENERIC_CONFIG_SCHEMA);
+const CANDIDATE_SECRET_SCHEMA = parseConfigSchema(DATA_CANDIDATE_CONFIG_SCHEMA);
 
 function stripTrailingSlash(s: string): string {
   return s.endsWith("/") ? s.slice(0, -1) : s;
@@ -147,6 +163,7 @@ function resolveBaseUrl(
 function buildDatasource(
   workspaceId: string,
   installId: string,
+  catalogId: string | undefined,
   decrypted: Record<string, unknown>,
 ): RestDatasource | null {
   // Validate the snapshot read back from JSONB, rather than an unchecked cast: a
@@ -228,6 +245,13 @@ function buildDatasource(
     throw err;
   }
 
+  // Slice 6a (#3028): a built-in data-candidate install carries its declarative
+  // quirk in the code-resident registry (keyed by catalog id), never in config —
+  // attach it so the agent tool can thread it into the client. A plain
+  // openapi-generic install (or an unknown catalog id) has none.
+  const candidate =
+    catalogId !== undefined ? findDataCandidateByCatalogId(catalogId) : undefined;
+
   return {
     id: installId,
     displayName,
@@ -239,6 +263,7 @@ function buildDatasource(
     sideEffectingOperations,
     ...(rateLimitPerMinute !== undefined ? { rateLimitPerMinute } : {}),
     ...(requestTimeoutMs !== undefined ? { requestTimeoutMs } : {}),
+    ...(candidate?.quirk !== undefined ? { quirk: candidate.quirk } : {}),
   };
 }
 
@@ -255,9 +280,17 @@ function buildDatasourcesFromRows(
 ): RestDatasource[] {
   const out: RestDatasource[] = [];
   for (const row of rows) {
+    // Pick the decryption schema by catalog: a data candidate's config (slice 6a)
+    // carries fewer fields than the generic one, but both mark `auth_value` as the
+    // sole secret — so decryption is identical in practice; selecting the matching
+    // schema keeps the seam correct if a future candidate adds its own secret field.
+    const secretSchema =
+      row.catalog_id !== undefined && findDataCandidateByCatalogId(row.catalog_id) !== undefined
+        ? CANDIDATE_SECRET_SCHEMA
+        : GENERIC_SECRET_SCHEMA;
     let decrypted: Record<string, unknown>;
     try {
-      decrypted = decryptSecretFields(row.config ?? {}, SECRET_SCHEMA);
+      decrypted = decryptSecretFields(row.config ?? {}, secretSchema);
     } catch (err) {
       log.warn(
         { workspaceId, installId: row.install_id, err: err instanceof Error ? err.message : String(err) },
@@ -265,7 +298,7 @@ function buildDatasourcesFromRows(
       );
       continue;
     }
-    const ds = buildDatasource(workspaceId, row.install_id, decrypted);
+    const ds = buildDatasource(workspaceId, row.install_id, row.catalog_id, decrypted);
     if (ds) out.push(ds);
   }
   return out;

--- a/packages/api/src/lib/tools/rest-operation.ts
+++ b/packages/api/src/lib/tools/rest-operation.ts
@@ -381,6 +381,10 @@ export function createExecuteRestOperationTool(deps: ExecuteRestOperationDeps = 
         const result = await executeOperation(datasource.graph, operationId, params, datasource.auth, {
           baseUrl: datasource.baseUrl,
           timeoutMs: verdict.timeoutMs,
+          // Slice 6a (#3028): a built-in data-candidate datasource (e.g. Stripe)
+          // carries a declarative quirk — required headers / query param-shaping
+          // (expand[]). The client applies it through its header/query seams.
+          ...(datasource.quirk ? { quirk: datasource.quirk } : {}),
           ...(deps.fetchImpl ? { fetchImpl: deps.fetchImpl } : {}),
         });
 


### PR DESCRIPTION
Closes #3028 (v0.0.2 slice 6a — foundational, blocks 6b #3029 / 6c #3030).

## What this lands

The first expansion-target slice for REST datasources. Proves the "thin catalog-seed wrapper (~50 LoC) over the generic OpenAPI primitive" thesis with **Stripe** as the first candidate, and ships the **two reusable mechanisms** every other candidate consumes — all as a thin wrapper over the existing generic primitive (no forked OpenAPI walker, paginator, or validator).

### 1. Declarative vendor-quirk hook — `lib/openapi/vendor-quirk.ts`
A per-candidate `VendorQuirk` descriptor (required static headers + query param-shaping) the generic client applies through its **existing** seams:
- `buildHeaders` → required static headers as non-clobbering defaults (Notion's `Notion-Version` later).
- `buildUrl` → query param-shaping (Stripe's `expand` → `expand[]` bracket-array form).

Wired via `ExecuteOptions.quirk` and threaded through `executeOperationPaged` so a paginated walk shapes `expand[]` / sends required headers on **every** page (the cursor param the strategy adds is left unshaped). Declarative **data, not a per-vendor `if` branch** — adding a candidate's required header is a one-line literal entry.

### 2. Data-candidate scaffolding — `lib/openapi/data-candidates.ts` + `data-candidate-seed.ts` + migration `0109`
A declarative `DataCandidate` registry (slug, `catalog:${slug}` id, pre-filled `openapi_url` + `auth_kind`, optional quirk + pagination) so an admin installs "Stripe" by pasting **only their secret key** — no spec URL. Each candidate is a real `plugin_catalog` datasource-pillar row that surfaces in `/admin/connections`. The boot seed re-asserts rows idempotently (`ON CONFLICT DO NOTHING`, run in the same pass as the `openapi-generic` row); migration 0109 inserts them on fresh DBs. **No `schema.ts` change** — same `plugin_catalog` table, new rows.

### 3. `stripe-data` candidate
`auth_kind: bearer` (secret key), the `expand[]` query quirk, and cursor pagination via the **existing** `cursor` strategy — extended with a backward-compatible **last-item-id dialect** (`cursorFromLastItem` / `cursorItemField` + `has_more`) so Stripe's "next cursor = the last returned object's `id`" works with **no new strategy file**.

### Thin install path (no fork)
Extracted the shared probe → schema-driven encryption → multi-instance INSERT core out of the generic form handler into `persistOpenApiDatasourceInstall`; the new `DataCandidateFormInstallHandler` is a thin wrapper that pre-fills the **locked** spec URL + auth kind and calls the same core. The workspace resolver matches candidate catalog ids alongside `openapi-generic` and attaches the **code-resident** quirk (never stored in / read from encrypted config); the `executeRestOperation` tool threads it into the client.

## Acceptance criteria
- [x] `stripe-data` catalog row code-seeds at boot (idempotent, mirrors `seedOpenApiDatasourceCatalog`) and surfaces in `/admin/connections`
- [x] Vendor-quirk descriptor is declarative data consumed by the generic client; adding a required header is a one-liner
- [x] `stripe-data` handles `expand[]` + cursor pagination over the generic strategy (headline AC test: multi-page Stripe cursor walk)
- [x] Demonstrably a thin wrapper — candidate pagination resolves over the **generic** paginator registry (asserted); shared install core; no forked modules
- [x] Unit tests: catalog-seed idempotency, quirk header/param application, Stripe cursor pagination, migration↔code alignment, slim install handler

## Testing
Full `/ci`: lint, type, test (528 files / 0 fail after bumping the two migration-count constants for 0109), syncpack, template-drift, security-headers-drift, railway-watch, schema-drift, oauth-helper-drift, test-discipline, twenty-resolver, published-symbols — all pass.

## Notes
- Live pagination (`executeOperationPaged`) stays dormant at the tool layer per slice 4 / #2970 — the tool calls the un-paginated `executeOperation` primitive; the quirk threads through both. The Stripe cursor walk is covered via the paged composer in tests, ready for the #2970 wiring.
- The `expand[]` shaping is declared as a quirk because the spec only models `style: deepObject, explode: true` on a bare `expand` — the `[]` suffix is a form-encoding rule, not graph data.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3031"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782773256&installation_id=135337507&pr_number=3031&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3031&signature=6a8ef0e363b0ff13fd470a4849fba4cd11c3c817c39c9d048cfb3aed26e7bea5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added built-in Stripe data candidate and form-based credential install for vendor datasources.
  * Datasources can declare vendor "quirks" so requests and headers are shaped per-API; client and executor apply them.
  * Cursor pagination extended to support last-item-id dialect.

* **Database**
  * Migration and boot-time seeding add idempotent catalog entries for data candidates.

* **Tests**
  * Expanded test coverage for installs, seeding, quirks, and pagination.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AtlasDevHQ/atlas/pull/3031?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->