### PR TITLE
feat(api): notion-data REST datasource candidate (#3029)

### DIFF
--- a/packages/api/src/api/routes/__tests__/rest-operations.test.ts
+++ b/packages/api/src/api/routes/__tests__/rest-operations.test.ts
@@ -210,6 +210,34 @@ describe("POST /rest-operations/confirm", () => {
     expect(req?.headers["authorization"]).toBe("Bearer confirm-token");
   });
 
+  it("forwards the datasource quirk so required headers ride the confirmed write (#3029)", async () => {
+    // A data-candidate (e.g. Notion) carries a declarative quirk — required static
+    // headers / query shaping — applied via the client's header/query seams. The
+    // confirm path must forward it exactly like the read tool path; otherwise an
+    // allowlisted, human-confirmed write reaches the upstream WITHOUT the required
+    // header (Notion-Version) and the vendor rejects it. Regression guard for the
+    // confirm-path/read-path parity gap.
+    const app = appWith([
+      datasource({
+        writeAllowlist: new Set(["createOnePerson"]),
+        quirk: { requiredHeaders: { "X-Vendor-Version": "2025-09-03" } },
+      }),
+    ]);
+    const res = await post(
+      app,
+      confirmBody({
+        datasourceId: "twenty",
+        operationId: "createOnePerson",
+        body: { name: { firstName: "Ada" } },
+      }),
+    );
+    expect(res.status).toBe(200);
+    const req = twentyMock.matching("/rest/people").at(-1);
+    // The quirk's required header rode the confirmed write, alongside bearer auth.
+    expect(req?.headers["x-vendor-version"]).toBe("2025-09-03");
+    expect(req?.headers["authorization"]).toBe("Bearer confirm-token");
+  });
+
   it("REFUSES a write that is NOT allowlisted, even on the confirm path (403, no upstream write)", async () => {
     // Defense in depth: the banner should never let an op past the allowlist,
     // but a tampered client payload is re-checked server-side.

--- a/packages/api/src/api/routes/rest-operations.ts
+++ b/packages/api/src/api/routes/rest-operations.ts
@@ -324,6 +324,12 @@ export function createRestOperationsRoute(deps: RestOperationsDeps = {}) {
         const result = await executeOperation(datasource.graph, input.operationId, params, datasource.auth, {
           baseUrl: datasource.baseUrl,
           timeoutMs: verdict.timeoutMs,
+          // #3029: forward the datasource's declarative quirk on the confirmed-write
+          // path too — same as the read tool path (lib/tools/rest-operation.ts). A
+          // candidate's required headers (Notion-Version) / query shaping (Stripe's
+          // expand[]) must ride the upstream call; without this an allowlisted,
+          // human-confirmed write would omit them and the vendor would reject it.
+          ...(datasource.quirk ? { quirk: datasource.quirk } : {}),
           ...(deps.fetchImpl ? { fetchImpl: deps.fetchImpl } : {}),
         });
 

--- a/packages/api/src/lib/auth/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/auth/__tests__/migrate.test.ts
@@ -355,6 +355,7 @@ describe("migrateAuthTables", () => {
             { name: "0107_email_outbox.sql" },
             { name: "0108_openapi_generic_catalog.sql" },
             { name: "0109_data_candidate_catalog.sql" },
+            { name: "0110_notion_data_catalog.sql" },
           ],
         };
       }

--- a/packages/api/src/lib/db/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate.test.ts
@@ -126,7 +126,9 @@ describe("runMigrations", () => {
     //   #2849 (workspace_id on crm_outbox) = 107. Plus
     //   0107 (email_outbox durable queue for transactional email, #2942) = 108.
     //   Plus 0108 (openapi-generic catalog row, #2926) = 109.
-    expect(count).toBe(110);
+    //   Plus 0109 (data-candidate catalog rows: stripe-data, #3028) = 110.
+    //   Plus 0110 (notion-data catalog row, slice 6b, #3029) = 111.
+    expect(count).toBe(111);
 
     // Advisory lock acquired before anything else
     expect(queries[0]).toContain("pg_advisory_lock");
@@ -265,6 +267,7 @@ describe("runMigrations", () => {
         "0107_email_outbox.sql",
         "0108_openapi_generic_catalog.sql",
         "0109_data_candidate_catalog.sql",
+        "0110_notion_data_catalog.sql",
       ],
     });
 

--- a/packages/api/src/lib/db/migrations/0109_data_candidate_catalog.sql
+++ b/packages/api/src/lib/db/migrations/0109_data_candidate_catalog.sql
@@ -46,7 +46,7 @@ VALUES
     true,
     true,
     '[
-      {"key": "auth_value", "type": "string", "label": "API key / token", "required": true, "secret": true, "description": "The API credential for this datasource (e.g. your Stripe secret key). Encrypted at rest."},
+      {"key": "auth_value", "type": "string", "label": "API key / token", "required": true, "secret": true, "description": "The API credential for this datasource (e.g. a secret API key or access token). Encrypted at rest."},
       {"key": "base_url_override", "type": "string", "label": "Base URL override", "description": "When the spec''s servers[0].url is wrong (dev/staging/regional host)."},
       {"key": "display_name", "type": "string", "label": "Display name", "description": "Friendly name shown in /admin/connections."}
     ]'::jsonb,

--- a/packages/api/src/lib/db/migrations/0110_notion_data_catalog.sql
+++ b/packages/api/src/lib/db/migrations/0110_notion_data_catalog.sql
@@ -1,0 +1,61 @@
+-- 0110_notion_data_catalog — v0.0.2 slice 6b (#3029)
+--
+-- Seed the `notion-data` built-in vendor `*-data` Datasource catalog row: a thin,
+-- pre-wired wrapper over the same generic OpenAPI primitive `openapi-generic`
+-- exposes (migration 0108), identical posture to the Stripe row (migration 0109).
+-- The candidate pre-fills the spec URL + auth kind in code
+-- (lib/openapi/data-candidates.ts: NOTION_DATA_CANDIDATE), so the admin installs
+-- "Notion" by pasting only their integration token — no spec URL.
+--
+-- Notion is the REQUIRED-STATIC-HEADER proof: it declares a per-vendor
+-- `Notion-Version` header via the declarative vendor-quirk hook (slice 6a). That
+-- header is DATA on the code-resident candidate, not a column here — this row only
+-- carries the install-form schema (the credential), exactly like the Stripe row.
+--
+-- Per ADR-0007 these are code-seeded — the boot pass re-asserts each row
+-- idempotently (lib/openapi/data-candidate-seed.ts, which loops DATA_CANDIDATES);
+-- this migration inserts the row on fresh + already-migrated DBs. The migration
+-- and the seed share DATA_CANDIDATE_CONFIG_SCHEMA + the DATA_CANDIDATES registry
+-- (lib/openapi/data-candidates.ts) as the single source of truth — keep this JSON
+-- in lockstep (the `migration 0110 ↔ code alignment` test asserts they match).
+--
+-- INTENTIONALLY NOT in `BUILTIN_DATASOURCE_CATALOG_SLUGS` (datasource-pool-
+-- resolver.ts): a REST datasource has no SQL pool, so the boot loader skips its
+-- installs and it resolves through the parallel workspace REST resolver instead —
+-- exactly like `openapi-generic` and the Stripe row.
+--
+-- `auth_value` carries `secret: true` so encryptSecretFields encrypts the
+-- integration token in `workspace_plugins.config` at install time. The install
+-- form omits `openapi_url` / `auth_kind` entirely (pre-filled from the registry),
+-- so a candidate install can never re-point the locked spec URL.
+--
+-- Idempotent: `ON CONFLICT DO NOTHING` covers both the slug unique index and the
+-- `id` primary key, so re-running on a populated catalog is a no-op.
+
+INSERT INTO plugin_catalog
+  (id, name, slug, description, type, install_model, pillar,
+   implementation_status, auto_install, min_plan, enabled, saas_eligible,
+   config_schema, created_at, updated_at)
+VALUES
+  (
+    'catalog:notion-data',
+    'Notion',
+    'notion-data',
+    'Query your Notion workspace (pages, databases, users, comments, …) as a read-only REST datasource. Pre-wired to Notion''s published OpenAPI spec — paste your integration token, no spec URL needed. The agent discovers operations from the spec and queries them directly.',
+    'datasource',
+    'form',
+    'datasource',
+    'available',
+    false,
+    'starter',
+    true,
+    true,
+    '[
+      {"key": "auth_value", "type": "string", "label": "API key / token", "required": true, "secret": true, "description": "The API credential for this datasource (e.g. your Stripe secret key). Encrypted at rest."},
+      {"key": "base_url_override", "type": "string", "label": "Base URL override", "description": "When the spec''s servers[0].url is wrong (dev/staging/regional host)."},
+      {"key": "display_name", "type": "string", "label": "Display name", "description": "Friendly name shown in /admin/connections."}
+    ]'::jsonb,
+    NOW(),
+    NOW()
+  )
+ON CONFLICT DO NOTHING;

--- a/packages/api/src/lib/db/migrations/0110_notion_data_catalog.sql
+++ b/packages/api/src/lib/db/migrations/0110_notion_data_catalog.sql
@@ -51,7 +51,7 @@ VALUES
     true,
     true,
     '[
-      {"key": "auth_value", "type": "string", "label": "API key / token", "required": true, "secret": true, "description": "The API credential for this datasource (e.g. your Stripe secret key). Encrypted at rest."},
+      {"key": "auth_value", "type": "string", "label": "API key / token", "required": true, "secret": true, "description": "The API credential for this datasource (e.g. a secret API key or access token). Encrypted at rest."},
       {"key": "base_url_override", "type": "string", "label": "Base URL override", "description": "When the spec''s servers[0].url is wrong (dev/staging/regional host)."},
       {"key": "display_name", "type": "string", "label": "Display name", "description": "Friendly name shown in /admin/connections."}
     ]'::jsonb,

--- a/packages/api/src/lib/openapi/__tests__/client-quirk.test.ts
+++ b/packages/api/src/lib/openapi/__tests__/client-quirk.test.ts
@@ -14,13 +14,18 @@ import * as path from "path";
 import { buildOperationGraph } from "../spec";
 import { executeOperation, executeOperationPaged } from "../client";
 import { defaultPaginatorRegistry } from "../strategies";
-import { STRIPE_DATA_CANDIDATE } from "../data-candidates";
+import { STRIPE_DATA_CANDIDATE, NOTION_DATA_CANDIDATE } from "../data-candidates";
 import type { OperationGraph } from "../types";
 
 const STRIPE_SPEC = JSON.parse(
   fs.readFileSync(path.join(import.meta.dir, "fixtures", "stripe.excerpt.json"), "utf8"),
 );
 const stripeGraph: OperationGraph = buildOperationGraph(STRIPE_SPEC);
+
+const NOTION_SPEC = JSON.parse(
+  fs.readFileSync(path.join(import.meta.dir, "fixtures", "notion.excerpt.json"), "utf8"),
+);
+const notionGraph: OperationGraph = buildOperationGraph(NOTION_SPEC);
 
 /** Capture every request URL + headers a stubbed fetch sees. */
 function capturingFetch(body: unknown) {
@@ -178,6 +183,134 @@ describe("executeOperationPaged — Stripe cursor walk (headline AC)", () => {
     for (const h of seenHeaders) {
       expect(h["stripe-version"]).toBe("2024-06-20");
       expect(h["authorization"]).toBe("Bearer sk_test_x");
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+//  Notion — the required-static-header proof (slice 6b headline AC, #3029)
+// ─────────────────────────────────────────────────────────────────────
+
+describe("executeOperation — Notion required Notion-Version header (slice 6b, #3029)", () => {
+  it("injects Notion-Version from the quirk on a GET, alongside (never clobbering) bearer auth", async () => {
+    const { fetchImpl, calls } = capturingFetch({
+      object: "list",
+      results: [],
+      next_cursor: null,
+      has_more: false,
+    });
+    await executeOperation(
+      notionGraph,
+      "get-users",
+      { query: { page_size: 2 } },
+      { kind: "bearer", token: "secret_ntn_x" },
+      { baseUrl: "https://api.notion.com", fetchImpl, quirk: NOTION_DATA_CANDIDATE.quirk },
+    );
+    expect(calls[0].headers["notion-version"]).toBe("2025-09-03");
+    expect(calls[0].headers["authorization"]).toBe("Bearer secret_ntn_x");
+  });
+
+  it("injects Notion-Version on a POST too — it's data, not a GET-only code path", async () => {
+    const { fetchImpl, calls } = capturingFetch({
+      object: "list",
+      results: [],
+      next_cursor: null,
+      has_more: false,
+    });
+    // post-search is the operation behind "list pages in my workspace".
+    await executeOperation(
+      notionGraph,
+      "post-search",
+      { body: { query: "roadmap" } },
+      { kind: "bearer", token: "secret_ntn_x" },
+      { baseUrl: "https://api.notion.com", fetchImpl, quirk: NOTION_DATA_CANDIDATE.quirk },
+    );
+    expect(calls[0].headers["notion-version"]).toBe("2025-09-03");
+    expect(calls[0].headers["authorization"]).toBe("Bearer secret_ntn_x");
+  });
+
+  it("is ABSENT without the quirk — proving the header is supplied by the quirk, not the graph", async () => {
+    const { fetchImpl, calls } = capturingFetch({
+      object: "list",
+      results: [],
+      next_cursor: null,
+      has_more: false,
+    });
+    await executeOperation(
+      notionGraph,
+      "get-users",
+      { query: { page_size: 2 } },
+      { kind: "bearer", token: "t" },
+      { baseUrl: "https://api.notion.com", fetchImpl },
+    );
+    // The spec declares Notion-Version as an OPTIONAL header param with a default,
+    // but the generic client never auto-sends a param default — so without the
+    // candidate's quirk the header would be missing. That gap is exactly what the
+    // declarative requiredHeaders descriptor closes.
+    expect(calls[0].headers["notion-version"]).toBeUndefined();
+  });
+});
+
+describe("executeOperationPaged — Notion cursor walk carries Notion-Version on every page", () => {
+  it("merges body-cursor pages (next_cursor → start_cursor) with the header on each request", async () => {
+    // The candidate's default pagination resolves over the SAME generic registry —
+    // a Notion-specific paginator would throw here.
+    const strategy = defaultPaginatorRegistry.resolve(NOTION_DATA_CANDIDATE.pagination!);
+
+    const PAGES = 3;
+    const PAGE_SIZE = 2;
+    const seen: { url: string; headers: Record<string, string> }[] = [];
+    const fetchImpl = (async (input: string | URL, init?: RequestInit) => {
+      const href = typeof input === "string" ? input : input.toString();
+      const headers: Record<string, string> = {};
+      const h = init?.headers as Record<string, string> | undefined;
+      if (h) for (const [k, v] of Object.entries(h)) headers[k.toLowerCase()] = String(v);
+      seen.push({ url: href, headers });
+
+      const after = new URL(href).searchParams.get("start_cursor");
+      // page index derives from the cursor (cursor-<n>) or 0 on the first page.
+      const pageIndex = after === null ? 0 : Number(after.replace("cursor-", ""));
+      const results = Array.from({ length: PAGE_SIZE }, (_, i) => ({
+        object: "user",
+        id: `u-${pageIndex}-${i}`,
+      }));
+      const has_more = pageIndex < PAGES - 1;
+      const next_cursor = has_more ? `cursor-${pageIndex + 1}` : null;
+      return new Response(JSON.stringify({ object: "list", results, next_cursor, has_more }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }) as unknown as typeof globalThis.fetch;
+
+    const merged = await executeOperationPaged(
+      notionGraph,
+      "get-users",
+      { query: { page_size: PAGE_SIZE } },
+      { kind: "bearer", token: "secret_ntn_x" },
+      {
+        baseUrl: "https://api.notion.com",
+        fetchImpl,
+        pagination: strategy,
+        quirk: NOTION_DATA_CANDIDATE.quirk,
+        maxPages: 10,
+      },
+    );
+
+    expect(merged.items).toHaveLength(PAGES * PAGE_SIZE);
+    expect(merged.pageCount).toBe(PAGES);
+    expect(merged.truncated).toBe(false);
+    expect(seen).toHaveLength(PAGES);
+
+    // First page has no cursor; later pages carry start_cursor = previous next_cursor.
+    expect(seen[0].url).not.toContain("start_cursor");
+    expect(seen[1].url).toContain("start_cursor=cursor-1");
+    expect(seen[2].url).toContain("start_cursor=cursor-2");
+
+    // The headline AC: the required header rides EVERY page of the walk, not just
+    // the first, alongside the bearer credential.
+    for (const { headers } of seen) {
+      expect(headers["notion-version"]).toBe("2025-09-03");
+      expect(headers["authorization"]).toBe("Bearer secret_ntn_x");
     }
   });
 });

--- a/packages/api/src/lib/openapi/__tests__/data-candidate-seed.test.ts
+++ b/packages/api/src/lib/openapi/__tests__/data-candidate-seed.test.ts
@@ -12,6 +12,7 @@ import {
   DATA_CANDIDATES,
   DATA_CANDIDATE_CONFIG_SCHEMA,
   STRIPE_DATA_CANDIDATE,
+  NOTION_DATA_CANDIDATE,
 } from "../data-candidates";
 
 function captureDb(returnRowsPerCall: (callIndex: number) => Array<{ slug: string }>): {
@@ -88,5 +89,38 @@ describe("migration 0109 ↔ code alignment", () => {
     const esc = (s: string) => s.replace(/'/g, "''");
     expect(sql).toContain(`'${esc(STRIPE_DATA_CANDIDATE.name)}'`);
     expect(sql).toContain(esc(STRIPE_DATA_CANDIDATE.description));
+  });
+});
+
+describe("migration 0110 ↔ code alignment (notion-data, slice 6b #3029)", () => {
+  function migrationSql(): string {
+    return fs.readFileSync(
+      path.join(import.meta.dir, "..", "..", "db", "migrations", "0110_notion_data_catalog.sql"),
+      "utf8",
+    );
+  }
+
+  it("the migration's config_schema matches the shared DATA_CANDIDATE_CONFIG_SCHEMA", () => {
+    const sql = migrationSql();
+    const start = sql.indexOf("'[");
+    const end = sql.indexOf("]'::jsonb");
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+    const jsonText = sql.slice(start + 1, end + 1).replace(/''/g, "'");
+    expect(JSON.parse(jsonText)).toEqual(DATA_CANDIDATE_CONFIG_SCHEMA);
+  });
+
+  it("seeds the notion-data canonical id + slug, idempotently", () => {
+    const sql = migrationSql();
+    expect(sql).toContain(NOTION_DATA_CANDIDATE.catalogId);
+    expect(sql).toContain("'notion-data'");
+    expect(sql).toContain("ON CONFLICT DO NOTHING");
+  });
+
+  it("the migration's name + description match the NOTION_DATA_CANDIDATE registry literal", () => {
+    const sql = migrationSql();
+    const esc = (s: string) => s.replace(/'/g, "''");
+    expect(sql).toContain(`'${esc(NOTION_DATA_CANDIDATE.name)}'`);
+    expect(sql).toContain(esc(NOTION_DATA_CANDIDATE.description));
   });
 });

--- a/packages/api/src/lib/openapi/__tests__/data-candidates.test.ts
+++ b/packages/api/src/lib/openapi/__tests__/data-candidates.test.ts
@@ -10,6 +10,7 @@ import {
   DATA_CANDIDATE_CATALOG_IDS,
   DATA_CANDIDATE_CONFIG_SCHEMA,
   STRIPE_DATA_CANDIDATE,
+  NOTION_DATA_CANDIDATE,
   findDataCandidateByCatalogId,
   findDataCandidateBySlug,
 } from "../data-candidates";
@@ -78,6 +79,52 @@ describe("stripe-data candidate", () => {
       cursorItemField: "id",
       hasMorePath: "has_more",
     });
+  });
+});
+
+describe("notion-data candidate (slice 6b, #3029 — required-header proof)", () => {
+  it("is registered in DATA_CANDIDATES, findable by catalogId + slug", () => {
+    // `toContain` (not exact membership) keeps this green when 6c (#3030) appends
+    // github-data in a parallel session.
+    expect(DATA_CANDIDATES.map((c) => c.slug)).toContain("notion-data");
+    expect(findDataCandidateByCatalogId("catalog:notion-data")).toBe(NOTION_DATA_CANDIDATE);
+    expect(findDataCandidateBySlug("notion-data")).toBe(NOTION_DATA_CANDIDATE);
+  });
+
+  it("is bearer-auth, pre-fills Notion's official spec URL, and never asks for one", () => {
+    expect(NOTION_DATA_CANDIDATE.authKind).toBe("bearer");
+    expect(NOTION_DATA_CANDIDATE.openapiUrl).toMatch(/^https:\/\//);
+    expect(NOTION_DATA_CANDIDATE.openapiUrl).toContain("notion-openapi.json");
+    // Same shared form as every candidate — openapi_url / auth_kind are pre-filled.
+    const formKeys = DATA_CANDIDATE_CONFIG_SCHEMA.map((f) => f.key);
+    expect(formKeys).not.toContain("openapi_url");
+    expect(formKeys).not.toContain("auth_kind");
+  });
+
+  it("declares the required Notion-Version header as a STATIC quirk (data, not a code path)", () => {
+    // The dimension this candidate exists to prove: a per-vendor required header
+    // that nothing in OpenAPI can model ("send on every request"). It is a literal
+    // in the registry, pinned to the spec edition the openapiUrl serves.
+    expect(NOTION_DATA_CANDIDATE.quirk?.requiredHeaders).toEqual({
+      "Notion-Version": "2025-09-03",
+    });
+    // The header is the ONLY deviation — no query param shaping (unlike Stripe).
+    expect(NOTION_DATA_CANDIDATE.quirk?.queryParamShaping).toBeUndefined();
+  });
+
+  it("declares body-cursor pagination (next_cursor → start_cursor, has_more) over the GENERIC strategy", () => {
+    // A DIFFERENT cursor dialect than Stripe's last-item-id: the body carries the
+    // next cursor (`next_cursor`), fed back on the `start_cursor` query param. Same
+    // `cursor` strategy file, config-only — proving the strategy is genuinely generic.
+    expect(NOTION_DATA_CANDIDATE.pagination).toMatchObject({
+      strategy: "cursor",
+      itemsPath: "results",
+      cursorParam: "start_cursor",
+      cursorPath: "next_cursor",
+      hasMorePath: "has_more",
+    });
+    // NOT the Stripe last-item-id dialect.
+    expect(NOTION_DATA_CANDIDATE.pagination?.cursorFromLastItem).toBeUndefined();
   });
 });
 

--- a/packages/api/src/lib/openapi/__tests__/fixtures/notion.excerpt.json
+++ b/packages/api/src/lib/openapi/__tests__/fixtures/notion.excerpt.json
@@ -1,0 +1,108 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Notion API",
+    "version": "2.0.0",
+    "description": "Faithful excerpt of Notion's published OpenAPI spec (makenotion/notion-mcp-server, the 2025-09-03 Data Source Edition) for v0.0.2 slice 6b (#3029). Trimmed to two operations that exercise the data-candidate axes: get-users (cursor-in-query list — the body-cursor pagination dialect) and post-search (POST — proves the required Notion-Version header is injected regardless of method). The `Notion-Version` header is modeled exactly as the real spec models it: an OPTIONAL header parameter with a default. Nothing in OpenAPI can express 'send this on every request', which is the whole reason it lives in the candidate's declarative quirk (requiredHeaders) rather than the graph."
+  },
+  "servers": [{ "url": "https://api.notion.com" }],
+  "components": {
+    "securitySchemes": {
+      "bearerAuth": { "type": "http", "scheme": "bearer" },
+      "basicAuth": { "type": "http", "scheme": "basic" }
+    },
+    "parameters": {
+      "notionVersion": {
+        "name": "Notion-Version",
+        "in": "header",
+        "required": false,
+        "schema": { "type": "string", "default": "2025-09-03" },
+        "description": "The Notion API version"
+      }
+    },
+    "schemas": {
+      "PaginatedList": {
+        "type": "object",
+        "description": "Notion's standard cursor-paginated list envelope.",
+        "properties": {
+          "object": { "type": "string", "enum": ["list"] },
+          "results": { "type": "array", "items": { "type": "object" } },
+          "next_cursor": { "type": "string", "nullable": true },
+          "has_more": { "type": "boolean" }
+        }
+      }
+    }
+  },
+  "security": [{ "bearerAuth": [] }],
+  "paths": {
+    "/v1/users": {
+      "get": {
+        "operationId": "get-users",
+        "summary": "List all users",
+        "parameters": [
+          {
+            "name": "start_cursor",
+            "in": "query",
+            "required": false,
+            "description": "If supplied, return a page of results starting after the cursor. If omitted, return the first page.",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "page_size",
+            "in": "query",
+            "required": false,
+            "description": "The number of items to return. Maximum: 100.",
+            "schema": { "type": "integer", "default": 100 }
+          },
+          { "$ref": "#/components/parameters/notionVersion" }
+        ],
+        "responses": {
+          "200": {
+            "description": "A cursor-paginated list of users.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/PaginatedList" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/search": {
+      "post": {
+        "operationId": "post-search",
+        "summary": "Search by title",
+        "description": "Search all parent or child pages and databases shared with the integration — the operation behind 'list pages in my workspace'. Cursor lives in the request body, so its deep pagination is a slice-2 per-operation override; the candidate's default pagination targets the GET list surface.",
+        "parameters": [{ "$ref": "#/components/parameters/notionVersion" }],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "query": {
+                    "type": "string",
+                    "description": "Text compared against page and database titles."
+                  },
+                  "start_cursor": { "type": "string" },
+                  "page_size": { "type": "integer", "default": 100 }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "A cursor-paginated list of pages and databases.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/PaginatedList" }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/api/src/lib/openapi/data-candidates.ts
+++ b/packages/api/src/lib/openapi/data-candidates.ts
@@ -142,8 +142,65 @@ export const STRIPE_DATA_CANDIDATE: DataCandidate = {
   },
 };
 
+/**
+ * Notion — the second data candidate (#3029, slice 6b). The **required-static-
+ * header** proof: a per-vendor header (`Notion-Version`) that nothing else in the
+ * candidate set exercises and that NO part of the OpenAPI document can express as
+ * "send on every request". The spec models it as an OPTIONAL header parameter with
+ * a default; the generic client never auto-sends a param default, and the agent
+ * constructing a call won't set it — so it MUST be supplied by the declarative
+ * {@link VendorQuirk.requiredHeaders}, applied on every request (including every
+ * page of a cursor walk) with NO Notion-specific code branch. Dimensions:
+ *  - `bearer` auth (the Notion integration token, sent as `Authorization: Bearer …`),
+ *  - the required `Notion-Version` header (the dimension this candidate proves),
+ *  - cursor pagination via the existing `cursor` strategy — Notion's BODY-cursor
+ *    dialect: the response body carries `next_cursor` + a top-level `has_more`,
+ *    fed back on the `start_cursor` query param (the strategy's `cursorPath` +
+ *    `hasMorePath`, a DIFFERENT dialect than Stripe's last-item-id, same file).
+ *
+ * The pinned `Notion-Version` (`2025-09-03`) matches the spec edition the
+ * {@link openapiUrl} serves (makenotion/notion-mcp-server's "Data Source Edition")
+ * — header and spec must agree, since that edition's data-source endpoints require
+ * the matching version. The body-cursor default targets Notion's GET list surface
+ * (`get-users`, `get-block-children`, `retrieve-a-comment`); the POST `post-search`
+ * endpoint behind "list pages in my workspace" carries its cursor in the body, a
+ * per-operation override that arrives with slice 2 (#2926) — its first page (≤100
+ * results) returns un-paginated today.
+ */
+export const NOTION_DATA_CANDIDATE: DataCandidate = {
+  slug: "notion-data",
+  catalogId: "catalog:notion-data",
+  name: "Notion",
+  description:
+    "Query your Notion workspace (pages, databases, users, comments, …) as a read-only REST " +
+    "datasource. Pre-wired to Notion's published OpenAPI spec — paste your integration token, no " +
+    "spec URL needed. The agent discovers operations from the spec and queries them directly.",
+  openapiUrl:
+    "https://raw.githubusercontent.com/makenotion/notion-mcp-server/main/scripts/notion-openapi.json",
+  authKind: "bearer",
+  quirk: {
+    // Notion mandates a version header on every request; the spec declares it as an
+    // optional `in: header` param with a default, which the client never auto-sends.
+    // The quirk supplies it as a non-clobbering default on every call. DATA, not a
+    // code branch — pinned to the spec edition `openapiUrl` serves.
+    requiredHeaders: { "Notion-Version": "2025-09-03" },
+  },
+  pagination: {
+    strategy: "cursor",
+    itemsPath: "results",
+    cursorParam: "start_cursor",
+    // Body-cursor dialect: the next cursor is the response body's `next_cursor`
+    // (vs Stripe's last list item id), with a top-level `has_more` flag.
+    cursorPath: "next_cursor",
+    hasMorePath: "has_more",
+  },
+};
+
 /** Every built-in data candidate. Append a new vendor here (the one-line thesis). */
-export const DATA_CANDIDATES: ReadonlyArray<DataCandidate> = [STRIPE_DATA_CANDIDATE];
+export const DATA_CANDIDATES: ReadonlyArray<DataCandidate> = [
+  STRIPE_DATA_CANDIDATE,
+  NOTION_DATA_CANDIDATE,
+];
 
 const BY_CATALOG_ID = new Map<string, DataCandidate>(
   DATA_CANDIDATES.map((c) => [c.catalogId, c]),

--- a/packages/api/src/lib/openapi/data-candidates.ts
+++ b/packages/api/src/lib/openapi/data-candidates.ts
@@ -89,7 +89,7 @@ export const DATA_CANDIDATE_CONFIG_SCHEMA: ReadonlyArray<ConfigSchemaField> = [
     required: true,
     secret: true,
     description:
-      "The API credential for this datasource (e.g. your Stripe secret key). Encrypted at rest.",
+      "The API credential for this datasource (e.g. a secret API key or access token). Encrypted at rest.",
   },
   {
     key: "base_url_override",

--- a/packages/api/src/lib/openapi/index.ts
+++ b/packages/api/src/lib/openapi/index.ts
@@ -136,6 +136,7 @@ export {
   DATA_CANDIDATE_CATALOG_IDS,
   DATA_CANDIDATE_CONFIG_SCHEMA,
   STRIPE_DATA_CANDIDATE,
+  NOTION_DATA_CANDIDATE,
   findDataCandidateByCatalogId,
   findDataCandidateBySlug,
 } from "./data-candidates";


### PR DESCRIPTION
## What

v0.0.2 **slice 6b** (#3029): a `notion-data` REST datasource candidate that thin-wraps the generic OpenAPI primitive. Notion is the **required-static-header proof** for the slice-6 generalization — a per-vendor `Notion-Version` header that nothing else in the candidate set exercises and that *no part of an OpenAPI document can express* as "send on every request".

Extends the slice-6a pattern (#3031). Adding the candidate is one registry entry + a one-row migration — no forked walker/paginator/validator, no changes to the install register or workspace resolver (both already iterate `DATA_CANDIDATES` generically).

## Changes

- **`NOTION_DATA_CANDIDATE`** in `data-candidates.ts` (+ barrel re-export in `index.ts`):
  - `authKind: bearer` (Notion integration token)
  - `quirk.requiredHeaders: { "Notion-Version": "2025-09-03" }` — **declarative data**, injected on every request (incl. every page of a cursor walk) via 6a's vendor-quirk hook, with no Notion-specific code branch
  - body-cursor pagination (`next_cursor` → `start_cursor`, `has_more`) resolved against the existing `defaultPaginatorRegistry` — a **different cursor dialect** than Stripe's last-item-id, same strategy file, config-only
  - pre-filled `openapiUrl` → Notion's official spec (`makenotion/notion-mcp-server`, the 2025-09-03 Data Source Edition); the pinned header version matches that edition
- **Migration `0110_notion_data_catalog.sql`** — one-row catalog INSERT mirroring 0109 (catalog-row into an existing table → no `schema.ts` change; schema-drift gate green)
- **Fixture** `__tests__/fixtures/notion.excerpt.json` — faithful 3.1.0 excerpt (`get-users` cursor-in-query list + `post-search`), modeling `Notion-Version` exactly as the real spec does: an *optional* header param with a default (which the generic client never auto-sends — the gap the quirk closes)

## Acceptance criteria

- [x] `notion-data` code-seeds at boot via the 6a wrapper pattern; surfaces in `/admin/connections` (catalog row + generic seed loop)
- [x] Every request carries the required `Notion-Version` header, sourced from the declarative quirk descriptor — asserted as **data, not a code path** (injected on GET *and* POST, and on every page of a cursor walk; absent without the quirk)
- [x] Handles cursor pagination over the generic strategy (body-cursor dialect)
- [x] Demonstrably a thin wrapper — no Notion-specific walker/paginator/validator anywhere
- [x] Unit tests: required header on every operation; cursor pagination over the generic strategy

## Testing

- `data-candidates.test.ts`, `data-candidate-seed.test.ts` (migration 0110 ↔ code alignment), `client-quirk.test.ts` (Notion-Version on every op + every page) — all green
- Real-PG migration smoke (`migrate-pg.test.ts`, scratch schema) applies all 111 migrations incl. 0110
- Migration-count bumps in `db/__tests__/migrate.test.ts` (110 → 111) + `auth/__tests__/migrate.test.ts` already-applied list
- Full `/ci`: lint, type, test, syncpack, all drift gates — green

## Coordination

Slice 6c (#3030, GitHub) runs in a parallel session and also appends to `data-candidates.ts` + the migration set (taking 0111). The array append here is order-robust (tests use `toContain`, not exact membership); a 6c-first merge is a trivial rebase.

Closes #3029.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3032"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782776843&installation_id=135337507&pr_number=3032&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3032&signature=420759279a9a6a99393c4e07c257556405a5dc7ac4fd707db0551e95e14ff442"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Notion is now available as a built-in data source with a preconfigured install form and API defaults.
  * Automatic pagination added for Notion’s cursor-based responses for seamless data retrieval.

* **Behavior Changes**
  * Vendor-specific static headers (e.g., Notion-Version) are now preserved and forwarded on confirmed REST writes and paginated requests.

* **UX**
  * Credential prompts updated to use a more generic “API key / access token” description.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->