### PR TITLE
test(api): migrate admin-openapi-datasources route tests to Effect test layer (#2991)

### DIFF
--- a/packages/api/src/__test-utils__/layers.ts
+++ b/packages/api/src/__test-utils__/layers.ts
@@ -50,6 +50,8 @@ import {
   createPillarCatalogQueryTestLayer,
   type PillarCatalogQueryShape,
 } from "@atlas/api/lib/effect/pillar-catalog-query";
+import { _resetPool } from "@atlas/api/lib/db/internal";
+import type { SqlClient } from "@effect/sql";
 import { createConnectionTestLayer } from "../__mocks__/connection";
 
 // ── Re-exports for convenience ──────────────────────────────────────
@@ -133,6 +135,95 @@ export function createPluginRegistryTestLayer(
     };
     return service;
   });
+}
+
+// ── internalQuery() recording layer (pre-Effect route handlers) ─────
+
+/**
+ * Recording test harness returned by {@link createOpenApiDatasourceTestLayer}.
+ * `layer` installs the fake SqlClient when built (and restores the slot when the
+ * scope closes); `calls` is the ordered list of `(sql, params)` tuples the route
+ * issued — the typed replacement for `bun:test`'s `mock.fn.mock.calls`.
+ */
+export interface InternalQueryRecorder {
+  /**
+   * A scoped Layer that, while built, routes the module-level `internalQuery()`
+   * through the recording fake. Build it with a `ManagedRuntime` (or
+   * `Layer.buildWithScope`) so the slot is restored on dispose even if a test
+   * throws — no fake leaks into sibling files sharing the worker (#2799).
+   */
+  readonly layer: Layer.Layer<never>;
+  /** Every `(sql, params)` the route passed to `internalQuery()`, in order. */
+  readonly calls: ReadonlyArray<readonly [string, readonly unknown[]]>;
+  /** Drop recorded calls between tests (call in `beforeEach`). */
+  readonly clear: () => void;
+}
+
+/**
+ * Build a recording test Layer for Hono route handlers that call the
+ * module-level `internalQuery()` helper directly (rather than `yield* InternalDB`).
+ *
+ * Routes like `admin-openapi-datasources` predate the Effect migration: they're
+ * plain async handlers that call `internalQuery(sql, params)`, so the natural
+ * test seam isn't the `InternalDB` Tag (nothing yields it) but the module-level
+ * `_sqlClient` slot that `internalQuery()` prefers when set. This factory
+ * installs a recording fake into that slot via the sanctioned `_resetPool` test
+ * hook, wrapped in a SCOPED resource — so the real `internalQuery()` code path
+ * runs end-to-end, replacing a wholesale `mock.module("@atlas/api/lib/db/internal")`
+ * with a composable, leak-safe, type-checked layer per the CLAUDE.md "Effect
+ * test layers preferred" rule.
+ *
+ * `query` decides what each statement returns (emulate `WHERE workspace_id = $1`
+ * scoping, RETURNING rowcounts, etc.); `params` is the bound array so the callee
+ * can branch on the authenticated org (`params[0]`) and id (`params[1]`).
+ *
+ * @example
+ * ```ts
+ * const db = createOpenApiDatasourceTestLayer((sql, params) =>
+ *   sql.includes("LIMIT 1") && params[0] === OWNER ? [ownedRow] : [],
+ * );
+ * let rt: ManagedRuntime.ManagedRuntime<never, never>;
+ * beforeAll(async () => { rt = ManagedRuntime.make(db.layer); await rt.runPromise(Effect.void); });
+ * afterAll(async () => { await rt.dispose(); });
+ * beforeEach(() => db.clear());
+ * // …then assert against db.calls.find(([sql]) => sql.includes("UPDATE"))
+ * ```
+ */
+export function createOpenApiDatasourceTestLayer(
+  query: (sql: string, params: readonly unknown[]) => readonly unknown[],
+): InternalQueryRecorder {
+  const calls: Array<readonly [string, readonly unknown[]]> = [];
+
+  // `internalQuery()` only ever calls `_sqlClient.unsafe(sql, params)` and awaits
+  // the resulting Effect. A minimal recording stub of that one method is all the
+  // route exercises — the rest of the broad SqlClient surface is never touched,
+  // so narrowing through `unknown` is sound and confined to test infra.
+  const recordingClient = {
+    unsafe: (sql: string, params?: ReadonlyArray<unknown>) => {
+      const bound = params ?? [];
+      calls.push([sql, bound]);
+      return Effect.succeed(query(sql, bound));
+    },
+  } as unknown as SqlClient.SqlClient;
+
+  // Scoped: `_resetPool(null, null)` on release restores the slot to its
+  // pre-test null, so a thrown test (or a file that forgets to dispose) can't
+  // leak the fake into sibling files. Unit tests never boot the real Layer, so
+  // null is the correct pre-state to restore.
+  const layer = Layer.scopedDiscard(
+    Effect.acquireRelease(
+      Effect.sync(() => _resetPool(null, recordingClient)),
+      () => Effect.sync(() => _resetPool(null, null)),
+    ),
+  );
+
+  return {
+    layer,
+    calls,
+    clear: () => {
+      calls.length = 0;
+    },
+  };
 }
 
 // ── Default connection layer ────────────────────────────────────────

--- a/packages/api/src/__test-utils__/layers.ts
+++ b/packages/api/src/__test-utils__/layers.ts
@@ -153,7 +153,13 @@ export interface InternalQueryRecorder {
    * throws — no fake leaks into sibling files sharing the worker (#2799).
    */
   readonly layer: Layer.Layer<never>;
-  /** Every `(sql, params)` the route passed to `internalQuery()`, in order. */
+  /**
+   * Every `(sql, params)` the route passed to `internalQuery()`, in order.
+   * This is a LIVE view of the recorder's internal array — it grows as the
+   * route runs and is truncated by {@link clear}, so assert against it only
+   * after the request resolves. Snapshot with `[...db.calls]` if you need a
+   * frozen point-in-time copy (`readonly` blocks your writes, not the fake's).
+   */
   readonly calls: ReadonlyArray<readonly [string, readonly unknown[]]>;
   /** Drop recorded calls between tests (call in `beforeEach`). */
   readonly clear: () => void;
@@ -197,7 +203,11 @@ export function createOpenApiDatasourceTestLayer(
   // `internalQuery()` only ever calls `_sqlClient.unsafe(sql, params)` and awaits
   // the resulting Effect. A minimal recording stub of that one method is all the
   // route exercises — the rest of the broad SqlClient surface is never touched,
-  // so narrowing through `unknown` is sound and confined to test infra.
+  // so narrowing through `unknown` is sound and confined to test infra. NB this
+  // stub is route-shaped, not a general SqlClient: a SUT that reaches the other
+  // `_sqlClient` consumers in internal.ts (`internalExecute` is also `.unsafe`,
+  // but `cascadeWorkspaceDelete` uses `.withTransaction` + the tagged-template
+  // form) would hit `undefined is not a function` — extend the stub before reuse.
   const recordingClient = {
     unsafe: (sql: string, params?: ReadonlyArray<unknown>) => {
       const bound = params ?? [];

--- a/packages/api/src/api/routes/__tests__/admin-openapi-datasources.test.ts
+++ b/packages/api/src/api/routes/__tests__/admin-openapi-datasources.test.ts
@@ -14,10 +14,25 @@
  * exercised in `admin-router.test.ts`; here `./admin-router` is replaced with
  * pass-throughs (the org context comes from the per-test `CURRENT_ORG`) so the
  * assertions are about THIS file, not the perimeter.
+ *
+ * Test-infra note (#2991): the DB seam is an Effect test layer, not a
+ * `mock.module()`. `createOpenApiDatasourceTestLayer` installs a recording fake
+ * SqlClient into the module-level slot `internalQuery()` prefers, so the route's
+ * REAL `internalQuery()` runs end-to-end and every statement lands in `db.calls`
+ * (the typed replacement for `mock.fn.mock.calls`). The remaining `mock.module()`
+ * calls cover dependencies with no Effect-layer seam: `openapi/probe` (the route
+ * imports its functions directly — we need a controllable probe + a spy on
+ * `invalidateInstallGraphCache`), `../admin-router` (Hono middleware, no layer),
+ * `plugins/secrets` (a deliberate decrypt passthrough), `effect/hono` (run the
+ * handler without booting the enterprise runtime), and `audit` / `logger`
+ * (silence + keep audit's DB writes out of `db.calls`). Converting those would
+ * mean reshaping the route into an Effect program — out of scope for this chore.
  */
 
-import { afterEach, beforeEach, describe, expect, it, mock, type Mock } from "bun:test";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, mock } from "bun:test";
 import { OpenAPIHono } from "@hono/zod-openapi";
+import { Effect, ManagedRuntime } from "effect";
+import { createOpenApiDatasourceTestLayer } from "@atlas/api/__test-utils__/layers";
 
 // ── Mutable per-test state the mock factories close over ─────────────────────
 
@@ -31,10 +46,10 @@ let authResultOverride: { ok: false; rawAuthKind: string } | null = null;
 const CATALOG_ID = "catalog:openapi-generic";
 
 /**
- * One install owned by `org-owner`. The `internalQuery` mock emulates the SQL's
- * `WHERE workspace_id = $1` predicate — it only returns this row when the query
- * is scoped to its owner, so a request authenticated as any other workspace
- * resolves `[]` (→ 404), proving the scope clause is load-bearing.
+ * One install owned by `org-owner`. The `db` recorder's `query` callback (below)
+ * emulates the SQL's `WHERE workspace_id = $1` predicate — it only returns this
+ * row when the query is scoped to its owner, so a request authenticated as any
+ * other workspace resolves `[]` (→ 404), proving the scope clause is load-bearing.
  */
 const FIXTURE = {
   install_id: "ds-1",
@@ -57,33 +72,35 @@ const FIXTURE = {
   } as Record<string, unknown>,
 };
 
-// ── Mocks (declared before importing the SUT) ────────────────────────────────
+// ── DB seam — a recording Effect layer (NOT a module mock), see #2991 ────────
 
-const mockInternalQuery: Mock<(sql: string, params?: unknown[]) => Promise<unknown[]>> = mock(
-  async (sql: string, params: unknown[] = []) => {
-    const ws = params[0];
-    const ownedRow = { install_id: FIXTURE.install_id, config: FIXTURE.config, status: FIXTURE.status };
+/**
+ * Routes the route's module-level `internalQuery()` through a recording fake.
+ * The `query` callback emulates the SQL behaviour the assertions rely on: the
+ * `WHERE workspace_id = $1` scoping predicate, the DELETE `RETURNING` rowcount,
+ * and the unused UPDATE rowcount. Every statement is captured in `db.calls`.
+ * Built/disposed by the suite-level `beforeAll`/`afterAll` below.
+ */
+const db = createOpenApiDatasourceTestLayer((sql, params) => {
+  const ws = params[0];
+  const ownedRow = { install_id: FIXTURE.install_id, config: FIXTURE.config, status: FIXTURE.status };
 
-    if (sql.includes("DELETE FROM workspace_plugins")) {
-      const instId = params[1];
-      return ws === FIXTURE.owner && instId === FIXTURE.install_id ? [{ install_id: FIXTURE.install_id }] : [];
-    }
-    if (sql.includes("UPDATE workspace_plugins")) {
-      return []; // rediscover/patch UPDATE — rowcount unused (loadInstall already gated)
-    }
-    if (sql.includes("ORDER BY installed_at")) {
-      return ws === FIXTURE.owner ? [ownedRow] : []; // list
-    }
-    // loadInstall SELECT (LIMIT 1, install_id = $2)
+  if (sql.includes("DELETE FROM workspace_plugins")) {
     const instId = params[1];
-    return ws === FIXTURE.owner && instId === FIXTURE.install_id ? [ownedRow] : [];
-  },
-);
+    return ws === FIXTURE.owner && instId === FIXTURE.install_id ? [{ install_id: FIXTURE.install_id }] : [];
+  }
+  if (sql.includes("UPDATE workspace_plugins")) {
+    return []; // rediscover/patch UPDATE — rowcount unused (loadInstall already gated)
+  }
+  if (sql.includes("ORDER BY installed_at")) {
+    return ws === FIXTURE.owner ? [ownedRow] : []; // list
+  }
+  // loadInstall SELECT (LIMIT 1, install_id = $2)
+  const instId = params[1];
+  return ws === FIXTURE.owner && instId === FIXTURE.install_id ? [ownedRow] : [];
+});
 
-mock.module("@atlas/api/lib/db/internal", () => ({
-  internalQuery: mockInternalQuery,
-  hasInternalDB: () => true,
-}));
+// ── Mocks (declared before importing the SUT) ────────────────────────────────
 
 mock.module("@atlas/api/lib/effect/hono", () => ({
   runHandler: async (_c: unknown, _label: string, fn: () => unknown) => fn(),
@@ -189,10 +206,22 @@ const { adminOpenApiDatasources } = await import("../admin-openapi-datasources")
 
 const JSON_HEADERS = { "content-type": "application/json" };
 
+// Build the DB layer once for the file: `runPromise(Effect.void)` forces the
+// scoped acquire (installs the recording client into the module slot), and
+// `dispose()` runs the finalizer (restores the slot to null) so nothing leaks.
+let dbRuntime: ManagedRuntime.ManagedRuntime<never, never>;
+beforeAll(async () => {
+  dbRuntime = ManagedRuntime.make(db.layer);
+  await dbRuntime.runPromise(Effect.void);
+});
+afterAll(async () => {
+  await dbRuntime.dispose();
+});
+
 beforeEach(() => {
   CURRENT_ORG = FIXTURE.owner;
   probeShouldFail = false;
-  mockInternalQuery.mockClear();
+  db.clear();
   invalidateGraphCacheSpy.mockClear();
 });
 afterEach(() => {
@@ -226,10 +255,10 @@ describe("admin-openapi-datasources — workspace scoping", () => {
 
   it("scopes loadInstall by both workspace_id ($1) and install_id ($2), passing the authed org", async () => {
     await adminOpenApiDatasources.request("/ds-1");
-    const select = mockInternalQuery.mock.calls.find(([sql]) => sql.includes("LIMIT 1"));
+    const select = db.calls.find(([sql]) => sql.includes("LIMIT 1"));
     expect(select?.[0]).toContain("workspace_id = $1");
     expect(select?.[0]).toContain("install_id = $2");
-    expect((select?.[1] as unknown[])[0]).toBe(FIXTURE.owner); // authed org is $1
+    expect(select?.[1][0]).toBe(FIXTURE.owner); // authed org is $1
   });
 
   it("list only returns the calling workspace's datasources", async () => {
@@ -257,7 +286,7 @@ describe("admin-openapi-datasources — mutations never rewrite the credential",
       body: JSON.stringify({ representationMode: "semantic-yaml" }),
     });
     expect(res.status).toBe(200);
-    const update = mockInternalQuery.mock.calls.find(
+    const update = db.calls.find(
       ([sql]) => sql.includes("UPDATE") && sql.includes("representation_mode"),
     );
     expect(update).toBeDefined();
@@ -269,13 +298,13 @@ describe("admin-openapi-datasources — mutations never rewrite the credential",
   it("rediscover writes only openapi_snapshot — no auth_value in the SQL or the payload", async () => {
     const res = await adminOpenApiDatasources.request("/ds-1/rediscover", { method: "POST" });
     expect(res.status).toBe(200);
-    const update = mockInternalQuery.mock.calls.find(
+    const update = db.calls.find(
       ([sql]) => sql.includes("UPDATE") && sql.includes("openapi_snapshot"),
     );
     expect(update).toBeDefined();
     expect(update![0]).toContain("jsonb_build_object('openapi_snapshot'");
     expect(update![0]).not.toContain("auth_value");
-    const snapshotJson = (update![1] as unknown[])[3] as string;
+    const snapshotJson = update![1][3] as string;
     expect(snapshotJson).not.toContain("auth_value");
     expect(snapshotJson).not.toContain("should-never-be-rewritten");
   });
@@ -296,8 +325,8 @@ describe("admin-openapi-datasources — rediscover error mapping", () => {
     // proof the manual "Refresh now" triggered a live re-probe (AC: re-probe).
     const res = await adminOpenApiDatasources.request("/ds-1/rediscover", { method: "POST" });
     expect(res.status).toBe(200);
-    const update = mockInternalQuery.mock.calls.find(
-      ([sql]) => (sql as string).includes("UPDATE") && (sql as string).includes("openapi_snapshot"),
+    const update = db.calls.find(
+      ([sql]) => sql.includes("UPDATE") && sql.includes("openapi_snapshot"),
     );
     expect(update).toBeDefined();
   });
@@ -310,7 +339,7 @@ describe("admin-openapi-datasources — rediscover error mapping", () => {
     expect(body.error).toBe("bad_request");
     expect(body.message).toContain("oauth2");
     // Failed auth resolution short-circuits before the snapshot UPDATE + eviction.
-    expect(mockInternalQuery.mock.calls.find(([sql]) => (sql as string).includes("UPDATE"))).toBeUndefined();
+    expect(db.calls.find(([sql]) => sql.includes("UPDATE"))).toBeUndefined();
     expect(invalidateGraphCacheSpy).not.toHaveBeenCalled();
   });
 
@@ -362,7 +391,7 @@ describe("admin-openapi-datasources — graph-cache eviction wiring", () => {
 
 /** The merge UPDATE the PATCH handler issues, if any. */
 function findConfigUpdate() {
-  return mockInternalQuery.mock.calls.find(([sql]) => (sql as string).includes("UPDATE"));
+  return db.calls.find(([sql]) => sql.includes("UPDATE"));
 }
 
 describe("admin-openapi-datasources — spec_refresh_interval set / clear / clamp", () => {

--- a/packages/api/src/api/routes/__tests__/admin-openapi-datasources.test.ts
+++ b/packages/api/src/api/routes/__tests__/admin-openapi-datasources.test.ts
@@ -24,9 +24,10 @@
  * imports its functions directly — we need a controllable probe + a spy on
  * `invalidateInstallGraphCache`), `../admin-router` (Hono middleware, no layer),
  * `plugins/secrets` (a deliberate decrypt passthrough), `effect/hono` (run the
- * handler without booting the enterprise runtime), and `audit` / `logger`
- * (silence + keep audit's DB writes out of `db.calls`). Converting those would
- * mean reshaping the route into an Effect program — out of scope for this chore.
+ * handler without booting the enterprise runtime), the `audit` modules
+ * (`audit` + `audit/error-scrub` — silence + keep audit's DB writes out of
+ * `db.calls`), and `logger`. Converting those would mean reshaping the route
+ * into an Effect program — out of scope for this chore.
  */
 
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, mock } from "bun:test";


### PR DESCRIPTION
Closes #2991. Non-blocking polish on shipped slice 2 (#2926) — test-infrastructure only, no behavior change.

## What
Replace the route test's heavy `mock.module("@atlas/api/lib/db/internal", …)` harness with a composable, scoped Effect test layer, per the CLAUDE.md "Effect test layers preferred" rule.

- **`createOpenApiDatasourceTestLayer()`** added to `packages/api/src/__test-utils__/layers.ts`. It installs a recording fake `SqlClient` into the module-level slot `internalQuery()` prefers (via the sanctioned `_resetPool` test hook) inside a `Layer.scopedDiscard`, so the route's **real** `internalQuery()` runs end-to-end and every statement is captured in `db.calls` (the typed replacement for `mock.fn.mock.calls`). The scoped acquire/release always restores the slot, so no fake leaks across files in the isolated runner.
- **`admin-openapi-datasources.test.ts`** builds that layer via `ManagedRuntime` in `beforeAll`/`afterAll` and asserts against `db.calls`.

## Coverage preserved (22 pass / 0 fail, 62 assertions)
Every existing assertion is intact: cross-org 404 on GET/PATCH/DELETE/rediscover; `loadInstall` scoped by `workspace_id = $1` **and** `install_id = $2`; representationMode persist + invalid-enum 400; missing-snapshot 200 degrade; rediscover JSONB-merges only `openapi_snapshot` (never `auth_value`); graph-cache eviction wiring (#3009); spec-refresh interval set/clear/clamp/reject (#2977).

## Why some `mock.module()` calls remain
The route is a plain async Hono handler, not an Effect program, so dependencies with no Effect-layer seam stay mocked and are documented in the test header: `openapi/probe` (route imports its functions directly — needs a controllable probe + a spy on `invalidateInstallGraphCache`), `../admin-router` (Hono middleware), `plugins/secrets` (deliberate decrypt passthrough), `effect/hono` (run the handler without booting the enterprise runtime), `audit`/`logger`. Converting those would require reshaping the route into an Effect program — out of scope for this chore.

## Gates
`bun run lint`, `bun run type`, full `bun run test` (target file 22/0), and the template/schema/test-discipline/ee-imports drift checks all green locally.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3033"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782777683&installation_id=135337507&pr_number=3033&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3033&signature=dc1054f60abe12e0fd00c0089864e6c6a7a6e07534731f87b31b9d94bb38868a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Refactored data-access tests to use a reliable query-recording layer, improving accuracy of SQL/parameter assertions.
  * Ensured tests isolate and clear recorded queries between cases and properly initialize/teardown runtimes.
  * Updated coverage for workspace/tenant scoping, mutation protections, and rediscover flows to validate behavior via recorded queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->