### PR TITLE
feat(api): OAuthDatasourceInstallHandler + github-data datasource (#3030)

### DIFF
--- a/.claude/research/architecture-wins.md
+++ b/.claude/research/architecture-wins.md
@@ -2229,3 +2229,26 @@ The store is an injected `PageCacheStore` interface (async, so the slice-2 Postg
 - **The graph cache is now bounded by live install count**, not install × rediscover, and never serves an uninstalled datasource's shape.
 
 **Category:** Cohesion cleanup — remove a DI seam with no consumer, consolidate duplicated glue into one shared helper, and align two sibling caches on the same tenant-scoped key so neither can drift into a cross-tenant assumption.
+
+## 77. `OAuthDatasourceInstallHandler` — OAuth credential acquisition + datasource persistence as a fourth install shape (slice 6c, #3030)
+
+**Date:** 2026-05-30
+**Issue:** #3030 (v0.0.2 slice 6c — the OQ5 deliverable) — parent #2930, PRD #2868
+**Branch:** feat/v0.0.2-slice-6c-oauth-datasource-github
+
+**Problem:** GitHub-as-datasource needs OAuth2 credential acquisition, but the existing `OAuthPlatformInstallHandler` bakes in the WRONG persistence shape for a datasource: single-instance per `(workspace_id, catalog_id)`, credential to `chat_cache`/a per-plugin store. A datasource OAuth install must be **multi-instance** (`install_id` composite PK, `pillar='datasource'`), write the credential **inline in `workspace_plugins.config`** via selective-field encryption, and **probe-on-install** to cache the `openapi_snapshot` — the `OpenApiGenericFormInstallHandler` shape, but with OAuth acquisition instead of a form. Folding OAuth-datasource into the chat/action OAuth handler would have either contorted its persistence or grown a `pillar`-branch inside one class. Separately, GitHub Apps have no long-lived bearer token: the executable credential is a ~1hr installation token minted from the App JWT — a *credential lifecycle* the form/static handlers don't model.
+
+**Solution:** A fourth install shape, dispatched by a new `oauth-datasource` `install_model` (the dispatch `switch`'s exhaustive `never` branch forces the new case; no silent drift):
+- **`OAuthDatasourceInstallHandler`** owns the datasource-multi-instance persistence path and *borrows* OAuth credential-acquisition primitives — it is not a reuse of `OAuthPlatformInstallHandler` (OQ5 resolution). The HTTP dance (`startInstall`→redirect, `handleCallback`) is method-compatible with the chat/action handler, so the install/callback route drives both through ONE code path; only the handler's persistence differs.
+- **`github-app-oauth.ts`** — the GitHub App ownership-verification primitives (user-code exchange + `/user/installations` walk, the cross-tenant binding guard) extracted from `github-oauth-handler.ts` and parametrized by `platform` + an injected `fetch`. The action handler (`github`) and the datasource handler (`github-data`) now consume ONE verified-ownership implementation instead of two copies — the datasource install inherits the exact threat-model coverage the action install already had.
+- **`github/installation-token.ts`** — a deep module that turns an `installation_id` into a usable bearer credential: sign a short App JWT (RS256), POST to `/app/installations/<id>/access_tokens`, cache the token until shortly before its stated expiry, re-mint transparently afterward. "Cache the shape, mint the secret" — the credential lifecycle lives behind `getGitHubInstallationToken(id)`, and both call sites (install health-check + query-time resolver) are oblivious to JWT signing, expiry math, and HTTP.
+- The query-time resolver (`workspace-datasource.ts`) gained ONE async credential seam (`resolveInstallAuth`): a `github-app-installation` candidate mints→`bearer`; everything else keeps the static decrypt-glue. `buildDatasource` became a pure assembler taking a pre-resolved `ResolvedAuth`, so the sync/async split is contained at the loop, not smeared through the builder.
+- A surfaced primitive gap, fixed not forked: the `link-header` strategy's `itemsPath` is now optional (defaults to the response root), so GitHub's bare-array list endpoints paginate with the existing generic strategy.
+
+**Impact:**
+- **A new install dimension lands as data + one handler class**, not a fork: `github-data` is a ~25-line `DataCandidate` registry entry; the OAuth complexity is isolated in the handler, and the query path reuses the generic walker/paginator/validator/client unchanged (OQ6 — thin wrapper).
+- **The GitHub App install dance has one verified-ownership implementation** across the action and datasource pillars — a future GitHub-App-backed pillar reuses it by passing its slug.
+- **The installation-token lifecycle is one module with one cache**; "re-mints transparently on expiry" is a property of the module, not scattered expiry checks at call sites. App-private-key-in-env never reaches the DB (only `installation_id` does).
+- **A partial install (snapshot good, mint failed) is a first-class state** (`config.status='reconnect_needed'` + `credentialResult.written=false`) the route already maps to a Reconnect affordance — the resolver re-mints regardless, so recovery needs no re-install.
+
+**Category:** Module-deepening — a new install-handler shape that separates "how the credential is acquired" (borrowed OAuth primitives) from "how the datasource is persisted + how its credential is minted at query time" (owned), with the GitHub-specific machinery confined to the install handler + a credential-minting module and never the query path.

--- a/apps/docs/content/docs/plugins/datasources/openapi-generic.mdx
+++ b/apps/docs/content/docs/plugins/datasources/openapi-generic.mdx
@@ -138,3 +138,29 @@ Advanced overrides (set on the install's `config` via `atlas.config.ts`, not sur
 | `rate_limit_per_minute` | Per-operation rate limit override (default 60) |
 | `request_timeout_ms` | Per-request timeout override; must be ≤ `ATLAS_OPENAPI_TIMEOUT` (the cap), else the operation is rejected |
 | `spec_refresh_interval` | How often to auto-re-discover the spec: `off` (default) / `daily` / `weekly` / `<N>h` (1h–720h, clamped). Also settable from the **Auto-refresh** control on the datasource card. |
+
+## Pre-wired vendor datasources
+
+Some vendors ship as their own cards in Admin → Connections, pre-wired over this same generic primitive — the spec URL and auth kind are filled in for you, so you only supply the credential. They are not separate clients: the operation graph, validator, paginator, and client are the same generic machinery.
+
+| Card | Auth | What you supply |
+|------|------|-----------------|
+| **Stripe** (`stripe-data`) | Bearer | Your Stripe secret key |
+| **GitHub** (`github-data`) | **OAuth2 (GitHub App)** | Nothing to paste — connect your GitHub App installation |
+
+### GitHub (`github-data`) — OAuth2 via GitHub App
+
+GitHub connects through **OAuth2**, not a pasted token. It reuses the **same GitHub App** as the GitHub *action* integration, so a deploy already wired for GitHub gets the datasource for free. Clicking **Connect** runs the GitHub App install dance; Atlas stores the resulting `installation_id` (encrypted) and mints a short-lived installation access token on demand at query time (re-minted automatically on ~1-hour expiry — there is no long-lived token to rotate or leak). GitHub's list endpoints are paged via the standard `Link` header.
+
+Operators must set the GitHub App env for the handler to register (the same variables the GitHub action integration uses):
+
+| Variable | Notes |
+|----------|-------|
+| `GITHUB_APP_ID` / `GITHUB_APP_SLUG` | App identity (the `iss` claim + the `github.com/apps/<slug>` install URL) |
+| `GITHUB_APP_PRIVATE_KEY` | PKCS8 PEM — signs the App JWT used to mint installation tokens |
+| `GITHUB_APP_CLIENT_ID` / `GITHUB_APP_CLIENT_SECRET` | User-OAuth-during-install credentials — used to verify the installing user owns the installation (cross-tenant binding guard) |
+| `ATLAS_PUBLIC_API_URL` | The API origin, so the OAuth callback URL resolves |
+
+If the App access is later revoked, the next query simply fails to mint a token and the datasource is skipped — reconnect from Admin → Connections to restore it.
+
+> The generic form's own `oauth2` `auth_kind` (above) remains deferred — `github-data`'s OAuth lives in its dedicated install handler, not the generic credential form.

--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -9581,6 +9581,31 @@
                 }
               }
             }
+          },
+          "503": {
+            "description": "Datasource connected but its credential needs reconnecting before the write can run (#3030)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "requestId": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error",
+                    "message"
+                  ]
+                }
+              }
+            }
           }
         },
         "operationId": "postRestOperationsConfirm"

--- a/bun.lock
+++ b/bun.lock
@@ -351,7 +351,7 @@
     },
     "packages/types": {
       "name": "@useatlas/types",
-      "version": "0.1.8",
+      "version": "0.1.9",
     },
     "packages/web": {
       "name": "@atlas/web",

--- a/packages/api/src/api/routes/__tests__/integrations.test.ts
+++ b/packages/api/src/api/routes/__tests__/integrations.test.ts
@@ -24,8 +24,10 @@ import {
 import {
   _resetInstallHandlerRegistries,
   registerFormHandler,
+  registerOAuthDatasourceHandler,
   registerOAuthHandler,
   type FormBasedInstallHandler,
+  type OAuthDatasourceInstallHandler,
   type OAuthPlatformInstallHandler,
 } from "@atlas/api/lib/integrations/install";
 import { FormInstallValidationError } from "@atlas/api/lib/integrations/install/email-form-handler";
@@ -785,6 +787,111 @@ describe("GET /api/v1/integrations/salesforce/callback — redirects to /admin/c
     expect(location).toContain("https://app.atlas.example/admin/connections");
     expect(location).toContain("error=salesforce");
     expect(location).toContain("reason=invalid_state");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// github-data — oauth-datasource callback (v0.0.2 slice 6c, #3030).
+//
+// github-data shares the OAuth install/callback route with `oauth` but is a
+// `pillar='datasource'` install that renders on `/admin/connections`. Two
+// route-level invariants this suite pins (both untested when the slice landed):
+//   1. The `install_model: 'oauth-datasource'` row is accepted on this route
+//      and the github-data callback requires BOTH code + installation_id (the
+//      same INSTALLATION_ID_PLATFORMS branch as the `github` action row).
+//   2. The success / reconnect redirect lands on `/admin/connections` — NOT
+//      `/admin/integrations` — because a datasource card lives there. A
+//      regression collapsing `adminDestinationForPlatform` back to a single
+//      path (or dropping github-data from INSTALLATION_ID_PLATFORMS) is caught
+//      here.
+// ---------------------------------------------------------------------------
+
+describe("GET /api/v1/integrations/github-data/callback — oauth-datasource flow", () => {
+  let githubDataCallbackImpl: () => Promise<CallbackResult> = async () => null;
+
+  const githubDataHandler: OAuthDatasourceInstallHandler = {
+    kind: "oauth-datasource" as const,
+    startInstall: async () => ({
+      redirectUrl: "https://github.com/apps/atlas-test/installations/new?state=stub",
+      stateToken: "stub",
+    }),
+    handleCallback: async () => githubDataCallbackImpl(),
+  };
+
+  beforeAll(() => {
+    registerOAuthDatasourceHandler("github-data", githubDataHandler);
+  });
+
+  beforeEach(() => {
+    mockInternalQuery.mockImplementation(async (sql: string) => {
+      if (sql.includes("FROM organization")) {
+        return [{ plan_tier: "business", is_operator_workspace: false }];
+      }
+      return [{ slug: "github-data", install_model: "oauth-datasource", enabled: true, min_plan: "starter" }];
+    });
+    githubDataCallbackImpl = async () => null;
+  });
+
+  it("accepts code + installation_id and redirects to /admin/connections?installed=github-data on success", async () => {
+    githubDataCallbackImpl = async () => ({
+      workspaceId: "ws-1" as never,
+      catalogId: "github-data",
+      installRecord: { id: "install-gh-data-1", workspaceId: "ws-1" as never, catalogId: "github-data" },
+      credentialResult: { written: true },
+    });
+
+    const res = await request(
+      "/api/v1/integrations/github-data/callback?code=user-oauth&installation_id=123456789&state=stub",
+      { headers: { Accept: "text/html" } },
+    );
+
+    expect(res.status).toBe(302);
+    // The fix: a datasource install lands on /admin/connections, not /admin/integrations.
+    expect(res.headers.get("location")).toBe(
+      "https://app.atlas.example/admin/connections?installed=github-data",
+    );
+  });
+
+  it("routes reconnect= to /admin/connections when the credential health-check missed", async () => {
+    githubDataCallbackImpl = async () => ({
+      workspaceId: "ws-1" as never,
+      catalogId: "github-data",
+      installRecord: { id: "install-gh-data-2", workspaceId: "ws-1" as never, catalogId: "github-data" },
+      credentialResult: { written: false, reason: "mint failed" },
+    });
+
+    const res = await request(
+      "/api/v1/integrations/github-data/callback?code=user-oauth&installation_id=123456789&state=stub",
+      { headers: { Accept: "text/html" } },
+    );
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toBe(
+      "https://app.atlas.example/admin/connections?reconnect=github-data",
+    );
+  });
+
+  it("rejects github-data callback missing `installation_id` with 400 missing_credential_identifier", async () => {
+    const res = await request(
+      "/api/v1/integrations/github-data/callback?code=user-oauth&state=stub",
+      { headers: { Accept: "application/json" } },
+    );
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string; requestId?: string };
+    expect(body.error).toBe("missing_credential_identifier");
+    expect(body.requestId).toBeDefined();
+  });
+
+  it("rejects github-data callback missing `code` with 400 missing_credential_identifier", async () => {
+    const res = await request(
+      "/api/v1/integrations/github-data/callback?installation_id=123456789&state=stub",
+      { headers: { Accept: "application/json" } },
+    );
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("missing_credential_identifier");
   });
 });
 

--- a/packages/api/src/api/routes/integrations.ts
+++ b/packages/api/src/api/routes/integrations.ts
@@ -56,6 +56,7 @@ import {
   parsePlanTier,
 } from "@atlas/api/lib/integrations/install/plan-rank";
 import { verifyOAuthStateToken } from "@atlas/api/lib/integrations/install/oauth-state-token";
+import { findDataCandidateBySlug } from "@atlas/api/lib/openapi/data-candidates";
 import {
   detectMisrouting,
   isStrictRoutingEnabled,
@@ -410,13 +411,20 @@ function prefersHtml(req: Request): boolean {
  * Per-platform admin destination for browser-facing redirects after the
  * OAuth dance (success, reconnect, plan_upgrade_required, invalid_state,
  * upstream_error). Most platforms render on `/admin/integrations`, but
- * Salesforce moved to `/admin/connections` in #2745 — sending its
- * callbacks to the old page would land users on a screen that no longer
- * lists Salesforce. Add new exceptions here when a future platform
- * follows the same pattern (Jira, etc.).
+ * datasource-pillar installs render on `/admin/connections`:
+ *   - Salesforce moved there in #2745, and
+ *   - every built-in REST data candidate (stripe-data form, github-data
+ *     oauth-datasource — #3028/#3030) is a `pillar='datasource'` card on
+ *     that page.
+ * Sending their callbacks to `/admin/integrations` would land users on a
+ * screen that doesn't list the card they just connected. Add new
+ * exceptions here when a future non-datasource platform follows the
+ * Salesforce pattern (Jira, etc.).
  */
 function adminDestinationForPlatform(platform: string): string {
   if (platform === "salesforce") return "/admin/connections";
+  // A built-in REST data candidate (e.g. github-data) is a datasource card.
+  if (findDataCandidateBySlug(platform) !== undefined) return "/admin/connections";
   return "/admin/integrations";
 }
 
@@ -1156,8 +1164,9 @@ integrations.openapi(callbackRoute, async (c) =>
     // Success — redirect to admin UI. Partial-failure (credential write
     // didn't land) flips the query param so the admin page shows a
     // Reconnect affordance per ADR-0003. Destination is per-platform
-    // (`adminDestinationForPlatform`) — Salesforce lives on
-    // `/admin/connections`, everything else on `/admin/integrations`.
+    // (`adminDestinationForPlatform`) — datasource-pillar installs
+    // (Salesforce + the REST data candidates like github-data) live on
+    // `/admin/connections`, chat/action platforms on `/admin/integrations`.
     const queryParam = result.credentialResult.written ? "installed" : "reconnect";
     return c.redirect(buildPlatformAdminUrl(queryParam, platform));
   }),

--- a/packages/api/src/api/routes/integrations.ts
+++ b/packages/api/src/api/routes/integrations.ts
@@ -92,6 +92,9 @@ const log = createLogger("integrations");
 const INSTALLATION_ID_PLATFORMS: ReadonlySet<string> = new Set([
   "github",
   "github-single-tenant",
+  // github-data (#3030) — the OAuth-datasource row reusing the SAME GitHub App
+  // install dance (code + installation_id) as the action `github` row.
+  "github-data",
 ]);
 
 /**
@@ -456,7 +459,12 @@ async function getInstallableCatalogRowBySlug(slug: string): Promise<{
   );
   if (rows.length === 0) return null;
   const row = rows[0];
-  if (row.install_model !== "oauth" && row.install_model !== "form" && row.install_model !== "static-bot") {
+  if (
+    row.install_model !== "oauth" &&
+    row.install_model !== "form" &&
+    row.install_model !== "static-bot" &&
+    row.install_model !== "oauth-datasource"
+  ) {
     log.warn({ slug, install_model: row.install_model }, "Unknown install_model in plugin_catalog row");
     return null;
   }
@@ -624,7 +632,9 @@ integrations.openapi(installRoute, async (c) =>
     if (!row) {
       return c.json({ error: "not_found", message: `Unknown platform "${platform}"`, requestId }, 404);
     }
-    if (row.install_model !== "oauth") {
+    // `oauth-datasource` (github-data, #3030) shares this OAuth install/callback
+    // route — the HTTP dance is identical; only the handler's persistence differs.
+    if (row.install_model !== "oauth" && row.install_model !== "oauth-datasource") {
       return c.json(
         { error: "wrong_install_model", message: `Platform "${platform}" uses install_model "${row.install_model}" — not OAuth-installable via this route.`, requestId },
         400,
@@ -693,10 +703,10 @@ integrations.openapi(installRoute, async (c) =>
         501,
       );
     }
-    if (handler.kind !== "oauth") {
-      // Catalog said OAuth, dispatch returned a non-OAuth handler — a
-      // config drift; treat as 500-equivalent for the route's invariants.
-      log.error({ platform, kind: handler.kind }, "Catalog install_model='oauth' but dispatch returned non-OAuth handler");
+    if (handler.kind !== "oauth" && handler.kind !== "oauth-datasource") {
+      // Catalog said OAuth(-datasource), dispatch returned a different handler —
+      // a config drift; treat as 500-equivalent for the route's invariants.
+      log.error({ platform, kind: handler.kind }, "Catalog install_model is OAuth-shaped but dispatch returned a non-OAuth handler");
       return c.json({ error: "handler_unavailable", message: "Install handler misconfigured.", requestId }, 501);
     }
 
@@ -912,7 +922,10 @@ integrations.openapi(callbackRoute, async (c) =>
     // GitHub multi-tenant. Other handlers ignore extras.
     let handlerPositionalCode: string;
     let handlerExtras: { installationId?: string } | undefined;
-    if (platform === "github") {
+    if (platform === "github" || platform === "github-data") {
+      // Multi-tenant GitHub App dance — `github` (action) and `github-data`
+      // (datasource, #3030) are identical here: both need `code` (user OAuth, for
+      // installation-ownership verification) + `installation_id` (the credential).
       if (typeof code !== "string" || code.length === 0) {
         return c.json(
           {
@@ -969,7 +982,8 @@ integrations.openapi(callbackRoute, async (c) =>
     if (!row) {
       return c.json({ error: "not_found", message: `Unknown platform "${platform}"`, requestId }, 404);
     }
-    if (row.install_model !== "oauth") {
+    // `oauth-datasource` (github-data, #3030) shares this callback route.
+    if (row.install_model !== "oauth" && row.install_model !== "oauth-datasource") {
       return c.json(
         { error: "wrong_install_model", message: `Platform "${platform}" uses install_model "${row.install_model}" — not OAuth-installable via this route.`, requestId },
         400,
@@ -989,8 +1003,8 @@ integrations.openapi(callbackRoute, async (c) =>
         501,
       );
     }
-    if (handler.kind !== "oauth") {
-      log.error({ platform, kind: handler.kind }, "Catalog install_model='oauth' but dispatch returned non-OAuth handler");
+    if (handler.kind !== "oauth" && handler.kind !== "oauth-datasource") {
+      log.error({ platform, kind: handler.kind }, "Catalog install_model is OAuth-shaped but dispatch returned a non-OAuth handler");
       return c.json({ error: "handler_unavailable", message: "Install handler misconfigured.", requestId }, 501);
     }
 

--- a/packages/api/src/api/routes/rest-operations.ts
+++ b/packages/api/src/api/routes/rest-operations.ts
@@ -25,7 +25,10 @@ import { createLogger } from "@atlas/api/lib/logger";
 import { executeOperation } from "@atlas/api/lib/openapi/client";
 import { OpenApiClientError } from "@atlas/api/lib/openapi/types";
 import type { RestDatasource } from "@atlas/api/lib/openapi/datasource";
-import { resolveWorkspaceRestDatasourcesOrThrow } from "@atlas/api/lib/openapi/workspace-datasource";
+import {
+  resolveWorkspaceRestDatasourcesOrThrow,
+  RestDatasourceReconnectError,
+} from "@atlas/api/lib/openapi/workspace-datasource";
 import {
   validateRestOperation,
   type RestOperationPolicy,
@@ -97,6 +100,7 @@ const confirmRoute = createRoute({
     429: { description: "Rate limit exceeded", content: { "application/json": { schema: ErrorSchema } } },
     500: { description: "Server / configuration error", content: { "application/json": { schema: ErrorSchema } } },
     502: { description: "Upstream REST client/transport fault", content: { "application/json": { schema: ErrorSchema } } },
+    503: { description: "Datasource connected but its credential needs reconnecting before the write can run (#3030)", content: { "application/json": { schema: ErrorSchema } } },
   },
 });
 
@@ -145,6 +149,25 @@ export function createRestOperationsRoute(deps: RestOperationsDeps = {}) {
       try {
         datasources = await resolveDatasources(orgId);
       } catch (err) {
+        // A connected datasource's credential is unresolvable (e.g. github-data's
+        // GitHub App access was revoked) — the staged write can't run until it's
+        // reconnected. 503 + reconnect guidance, not a misleading 500 "retry".
+        if (err instanceof RestDatasourceReconnectError) {
+          log.warn(
+            { orgId, operationId: input.operationId, requestId, reconnectableCount: err.reconnectableCount },
+            "Confirm blocked — the workspace's REST datasource needs reconnecting",
+          );
+          return c.json(
+            {
+              error: "datasource_unavailable",
+              message:
+                "This workspace's REST datasource needs to be reconnected before this write can run — " +
+                "reconnect it from Admin → Connections, then try again.",
+              requestId,
+            },
+            503,
+          );
+        }
         // The registry load failed (DB outage). Return a correlated 500 rather
         // than letting the throw escape to the global handler (which would mint a
         // fresh, log-unrelated requestId) or masquerade as a 404 not-found.

--- a/packages/api/src/lib/auth/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/auth/__tests__/migrate.test.ts
@@ -355,6 +355,7 @@ describe("migrateAuthTables", () => {
             { name: "0107_email_outbox.sql" },
             { name: "0108_openapi_generic_catalog.sql" },
             { name: "0109_data_candidate_catalog.sql" },
+            { name: "0111_github_data_catalog.sql" },
           ],
         };
       }

--- a/packages/api/src/lib/db/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate.test.ts
@@ -126,7 +126,10 @@ describe("runMigrations", () => {
     //   #2849 (workspace_id on crm_outbox) = 107. Plus
     //   0107 (email_outbox durable queue for transactional email, #2942) = 108.
     //   Plus 0108 (openapi-generic catalog row, #2926) = 109.
-    expect(count).toBe(110);
+    //   Plus 0109 (data-candidate catalog rows, #3028) = 110.
+    //   Plus 0111 (github-data oauth-datasource catalog row + install_model
+    //   CHECK widen, #3030 — 0110 reserved by the parallel slice-6b session) = 111.
+    expect(count).toBe(111);
 
     // Advisory lock acquired before anything else
     expect(queries[0]).toContain("pg_advisory_lock");
@@ -265,6 +268,7 @@ describe("runMigrations", () => {
         "0107_email_outbox.sql",
         "0108_openapi_generic_catalog.sql",
         "0109_data_candidate_catalog.sql",
+        "0111_github_data_catalog.sql",
       ],
     });
 

--- a/packages/api/src/lib/db/migrations/0111_github_data_catalog.sql
+++ b/packages/api/src/lib/db/migrations/0111_github_data_catalog.sql
@@ -1,0 +1,65 @@
+-- 0111_github_data_catalog — v0.0.2 slice 6c (#3030; the OQ5 deliverable)
+--
+-- Two changes, in order (the CHECK must widen before the INSERT):
+--
+-- 1. Admit a new `install_model` value `'oauth-datasource'` — the OAuth2
+--    dimension of the generic OpenAPI Datasource primitive. It acquires the
+--    credential via the same operator-owned OAuth App dance as `'oauth'` but
+--    persists DATASOURCE-style: multi-instance (`install_id` composite PK,
+--    `pillar='datasource'`), credential inline in `workspace_plugins.config` via
+--    selective-field encryption, probe-on-install caching the `openapi_snapshot`.
+--    See `lib/integrations/install/oauth-datasource-handler.ts` +
+--    `@useatlas/types` CATALOG_INSTALL_MODELS (the canonical enum) + the
+--    `chk_plugin_catalog_install_model` mirror in `schema.ts`. Postgres requires
+--    DROP + ADD to widen a CHECK enum.
+--
+-- 2. Seed the `github-data` catalog row — a thin data-candidate wrapper over the
+--    generic primitive (OQ6: GitHub's only non-generic data dimension,
+--    Link-header pagination, is ALREADY a generic strategy). Pre-wired to
+--    GitHub's published OpenAPI spec in code (lib/openapi/data-candidates.ts), so
+--    the admin installs by connecting their GitHub App — no spec URL, no token to
+--    paste. The credential (installation_id) is acquired by the OAuth dance and
+--    its bearer token minted on demand from the App JWT.
+--
+-- Per ADR-0007 this row is code-seeded — the boot pass re-asserts it idempotently
+-- (lib/openapi/data-candidate-seed.ts); this migration inserts it on fresh +
+-- already-migrated DBs. The two share the DATA_CANDIDATES registry as the single
+-- source of truth — the `migration 0111 ↔ code alignment` test asserts they match.
+--
+-- `config_schema` is INTENTIONALLY EMPTY (`[]`): an oauth-datasource install has
+-- no admin credential form — the credential comes from the OAuth dance. The
+-- installation_id's encryption is driven by a code-resident schema
+-- (GITHUB_APP_SECRET_FIELDS_SCHEMA, `installation_id` secret), not this form.
+--
+-- Idempotent: `ON CONFLICT DO NOTHING` covers both the slug unique index and the
+-- `id` primary key, so re-running on a populated catalog is a no-op.
+
+ALTER TABLE plugin_catalog
+  DROP CONSTRAINT IF EXISTS chk_plugin_catalog_install_model;
+ALTER TABLE plugin_catalog
+  ADD CONSTRAINT chk_plugin_catalog_install_model
+  CHECK (install_model IN ('oauth', 'form', 'static-bot', 'oauth-datasource'));
+
+INSERT INTO plugin_catalog
+  (id, name, slug, description, type, install_model, pillar,
+   implementation_status, auto_install, min_plan, enabled, saas_eligible,
+   config_schema, created_at, updated_at)
+VALUES
+  (
+    'catalog:github-data',
+    'GitHub',
+    'github-data',
+    'Query your GitHub organization (repositories, pull requests, issues, …) as a read-only REST datasource. Connects through your GitHub App installation — no token to paste. The agent discovers operations from GitHub''s published OpenAPI spec and queries them directly, following Link-header pagination.',
+    'datasource',
+    'oauth-datasource',
+    'datasource',
+    'available',
+    false,
+    'starter',
+    true,
+    true,
+    '[]'::jsonb,
+    NOW(),
+    NOW()
+  )
+ON CONFLICT DO NOTHING;

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -1531,7 +1531,7 @@ export const pluginCatalog = pgTable(
       .on(t.type, t.installModel)
       .where(sql`enabled = true`),
     check("chk_plugin_catalog_type", sql`type IN ('datasource', 'context', 'interaction', 'action', 'sandbox', 'chat', 'integration')`),
-    check("chk_plugin_catalog_install_model", sql`install_model IN ('oauth', 'form', 'static-bot')`),
+    check("chk_plugin_catalog_install_model", sql`install_model IN ('oauth', 'form', 'static-bot', 'oauth-datasource')`),
     check("chk_plugin_catalog_pillar", sql`pillar IN ('datasource', 'chat', 'action')`),
     check("chk_plugin_catalog_implementation_status", sql`implementation_status IN ('available', 'coming_soon')`),
   ],

--- a/packages/api/src/lib/github/__tests__/installation-token.test.ts
+++ b/packages/api/src/lib/github/__tests__/installation-token.test.ts
@@ -209,3 +209,89 @@ describe("getGitHubInstallationToken — failure modes", () => {
     expect(ok.calls).toHaveLength(1);
   });
 });
+
+const TOKEN_REFRESH_MARGIN_MS = 5 * 60_000; // mirror the module constant
+
+/** A fetch stub that returns a 201 mint WITHOUT an `expires_at` field. */
+function noExpiryFetch(token: string): {
+  fetchImpl: typeof globalThis.fetch;
+  calls: number;
+} {
+  const state = { calls: 0 };
+  const fetchImpl = (async () => {
+    state.calls++;
+    return new Response(JSON.stringify({ token }), {
+      status: 201,
+      headers: { "content-type": "application/json" },
+    });
+  }) as unknown as typeof globalThis.fetch;
+  return {
+    fetchImpl,
+    get calls() {
+      return state.calls;
+    },
+  };
+}
+
+describe("getGitHubInstallationToken — missing/unparseable expires_at fallback", () => {
+  it("returns the token and caps validity to the safety margin (re-mints after it, using the injected clock)", async () => {
+    const fetch1 = noExpiryFetch("ghs_no_expiry");
+    const first = await getGitHubInstallationToken(INSTALLATION_ID, {
+      appId: APP_ID, privateKey: APP_PRIVATE_KEY, fetchImpl: fetch1.fetchImpl, now: () => T0_MS,
+    });
+    expect(first).toBe("ghs_no_expiry");
+    expect(fetch1.calls).toBe(1);
+
+    // Capped expiry = now + margin*2, so refreshAtMs = now + margin. Within the
+    // margin the cache serves; the injected clock (not wall-clock) drives this.
+    const withinMargin = await getGitHubInstallationToken(INSTALLATION_ID, {
+      appId: APP_ID, privateKey: APP_PRIVATE_KEY, fetchImpl: fetch1.fetchImpl, now: () => T0_MS + TOKEN_REFRESH_MARGIN_MS - 1,
+    });
+    expect(withinMargin).toBe("ghs_no_expiry");
+    expect(fetch1.calls).toBe(1); // still cached — no re-mint
+
+    // Past the capped refresh point → a fresh mint.
+    const fetch2 = noExpiryFetch("ghs_no_expiry_2");
+    const afterMargin = await getGitHubInstallationToken(INSTALLATION_ID, {
+      appId: APP_ID, privateKey: APP_PRIVATE_KEY, fetchImpl: fetch2.fetchImpl, now: () => T0_MS + TOKEN_REFRESH_MARGIN_MS + 1,
+    });
+    expect(afterMargin).toBe("ghs_no_expiry_2");
+    expect(fetch2.calls).toBe(1);
+  });
+});
+
+describe("getGitHubInstallationToken — single-flight", () => {
+  it("coalesces concurrent cold-cache callers onto ONE mint", async () => {
+    const { fetchImpl, calls } = mintFetch({ token: "ghs_shared", expiresInMs: 3_600_000 });
+    // Both promises are created before either is awaited → the second sees the
+    // in-flight mint registered synchronously by the first and shares it.
+    const p1 = getGitHubInstallationToken(INSTALLATION_ID, {
+      appId: APP_ID, privateKey: APP_PRIVATE_KEY, fetchImpl, now: () => T0_MS,
+    });
+    const p2 = getGitHubInstallationToken(INSTALLATION_ID, {
+      appId: APP_ID, privateKey: APP_PRIVATE_KEY, fetchImpl, now: () => T0_MS,
+    });
+    const [t1, t2] = await Promise.all([p1, p2]);
+
+    expect(t1).toBe("ghs_shared");
+    expect(t2).toBe("ghs_shared");
+    expect(calls).toHaveLength(1); // ONE mint round-trip, not two
+  });
+
+  it("clears the in-flight entry after a failed mint so the next call retries", async () => {
+    const failing = mintFetch({ token: "", expiresInMs: 0, status: 500 });
+    await expect(
+      getGitHubInstallationToken(INSTALLATION_ID, {
+        appId: APP_ID, privateKey: APP_PRIVATE_KEY, fetchImpl: failing.fetchImpl, now: () => T0_MS,
+      }),
+    ).rejects.toBeInstanceOf(GitHubInstallationTokenError);
+
+    // The in-flight slot was released in `finally`, so a fresh mint can proceed.
+    const ok = mintFetch({ token: "ghs_after_inflight_fail", expiresInMs: 3_600_000 });
+    const token = await getGitHubInstallationToken(INSTALLATION_ID, {
+      appId: APP_ID, privateKey: APP_PRIVATE_KEY, fetchImpl: ok.fetchImpl, now: () => T0_MS,
+    });
+    expect(token).toBe("ghs_after_inflight_fail");
+    expect(ok.calls).toHaveLength(1);
+  });
+});

--- a/packages/api/src/lib/github/__tests__/installation-token.test.ts
+++ b/packages/api/src/lib/github/__tests__/installation-token.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Tests for the GitHub App installation-token minter (v0.0.2 slice 6c, #3030).
+ *
+ * The minter signs a short-lived App JWT (RS256) and exchanges it for an
+ * installation access token at `/app/installations/<id>/access_tokens`, caching
+ * the result until shortly before its ~1hr expiry. These tests use an injected
+ * `fetch` (never the network) + an injected clock so cache + re-mint behavior is
+ * deterministic, and an ephemeral RSA keypair so the JWT actually signs.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { generateKeyPairSync } from "crypto";
+import { decodeJwt } from "jose";
+import {
+  getGitHubInstallationToken,
+  GitHubInstallationTokenError,
+  __resetInstallationTokenCacheForTests,
+} from "../installation-token";
+
+// An ephemeral PKCS8 PEM private key so the App JWT actually signs in-test.
+const { privateKey: APP_PRIVATE_KEY } = generateKeyPairSync("rsa", {
+  modulusLength: 2048,
+  publicKeyEncoding: { type: "spki", format: "pem" },
+  privateKeyEncoding: { type: "pkcs8", format: "pem" },
+});
+
+const APP_ID = "123456";
+const INSTALLATION_ID = "987654321";
+
+/** A clock fixed at a known epoch so expiry math is deterministic. */
+const T0_MS = 1_900_000_000_000; // some fixed ms epoch
+
+/** Build a fetch stub that records calls and returns a fresh access-token mint. */
+function mintFetch(opts: {
+  token: string;
+  expiresInMs: number;
+  status?: number;
+  nowMs?: number;
+}): { fetchImpl: typeof globalThis.fetch; calls: Array<{ url: string; init?: RequestInit }> } {
+  const calls: Array<{ url: string; init?: RequestInit }> = [];
+  const fetchImpl = (async (input: string | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    calls.push({ url, init });
+    const expiresAtIso = new Date((opts.nowMs ?? T0_MS) + opts.expiresInMs).toISOString();
+    return new Response(
+      JSON.stringify({ token: opts.token, expires_at: expiresAtIso }),
+      { status: opts.status ?? 201, headers: { "content-type": "application/json" } },
+    );
+  }) as typeof globalThis.fetch;
+  return { fetchImpl, calls };
+}
+
+beforeEach(() => {
+  __resetInstallationTokenCacheForTests();
+});
+
+afterEach(() => {
+  __resetInstallationTokenCacheForTests();
+});
+
+describe("getGitHubInstallationToken — minting", () => {
+  it("signs an App JWT and exchanges it for an installation token", async () => {
+    const { fetchImpl, calls } = mintFetch({ token: "ghs_minted", expiresInMs: 3_600_000 });
+    const token = await getGitHubInstallationToken(INSTALLATION_ID, {
+      appId: APP_ID,
+      privateKey: APP_PRIVATE_KEY,
+      fetchImpl,
+      now: () => T0_MS,
+    });
+
+    expect(token).toBe("ghs_minted");
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.url).toBe(
+      `https://api.github.com/app/installations/${INSTALLATION_ID}/access_tokens`,
+    );
+
+    // The Authorization header carries a signed App JWT (3 dot-segments) issued
+    // by the app id, with a near-future exp.
+    const authHeader = new Headers(calls[0]!.init?.headers).get("authorization");
+    expect(authHeader).toMatch(/^Bearer \S+\.\S+\.\S+$/);
+    const jwt = authHeader!.slice("Bearer ".length);
+    const payload = decodeJwt(jwt);
+    expect(payload.iss).toBe(APP_ID);
+    expect(typeof payload.exp).toBe("number");
+    // iat is back-dated for clock-skew tolerance (≤ now).
+    expect((payload.iat as number) * 1000).toBeLessThanOrEqual(T0_MS);
+
+    // Sends the canonical GitHub API headers.
+    const accept = new Headers(calls[0]!.init?.headers).get("accept");
+    expect(accept).toContain("application/vnd.github");
+    expect(calls[0]!.init?.method).toBe("POST");
+  });
+});
+
+describe("getGitHubInstallationToken — caching", () => {
+  it("returns the cached token within the validity window without re-minting", async () => {
+    const { fetchImpl, calls } = mintFetch({ token: "ghs_cached", expiresInMs: 3_600_000 });
+
+    const first = await getGitHubInstallationToken(INSTALLATION_ID, {
+      appId: APP_ID,
+      privateKey: APP_PRIVATE_KEY,
+      fetchImpl,
+      now: () => T0_MS,
+    });
+    // 10 minutes later — still well within the 1hr token, outside the refresh margin.
+    const second = await getGitHubInstallationToken(INSTALLATION_ID, {
+      appId: APP_ID,
+      privateKey: APP_PRIVATE_KEY,
+      fetchImpl,
+      now: () => T0_MS + 10 * 60_000,
+    });
+
+    expect(first).toBe("ghs_cached");
+    expect(second).toBe("ghs_cached");
+    expect(calls).toHaveLength(1); // minted once, served from cache the second time
+  });
+
+  it("re-mints transparently once the cached token nears expiry", async () => {
+    // First mint: token valid for 1hr from T0.
+    const firstMint = mintFetch({ token: "ghs_first", expiresInMs: 3_600_000, nowMs: T0_MS });
+    const first = await getGitHubInstallationToken(INSTALLATION_ID, {
+      appId: APP_ID,
+      privateKey: APP_PRIVATE_KEY,
+      fetchImpl: firstMint.fetchImpl,
+      now: () => T0_MS,
+    });
+    expect(first).toBe("ghs_first");
+
+    // 58 minutes later the cached token is within the 5-min refresh margin → re-mint.
+    const lateMs = T0_MS + 58 * 60_000;
+    const secondMint = mintFetch({ token: "ghs_second", expiresInMs: 3_600_000, nowMs: lateMs });
+    const second = await getGitHubInstallationToken(INSTALLATION_ID, {
+      appId: APP_ID,
+      privateKey: APP_PRIVATE_KEY,
+      fetchImpl: secondMint.fetchImpl,
+      now: () => lateMs,
+    });
+
+    expect(second).toBe("ghs_second");
+    expect(secondMint.calls).toHaveLength(1); // a fresh mint happened
+  });
+
+  it("caches distinct installations independently", async () => {
+    const a = mintFetch({ token: "ghs_a", expiresInMs: 3_600_000 });
+    const tokenA = await getGitHubInstallationToken("111", {
+      appId: APP_ID, privateKey: APP_PRIVATE_KEY, fetchImpl: a.fetchImpl, now: () => T0_MS,
+    });
+    const b = mintFetch({ token: "ghs_b", expiresInMs: 3_600_000 });
+    const tokenB = await getGitHubInstallationToken("222", {
+      appId: APP_ID, privateKey: APP_PRIVATE_KEY, fetchImpl: b.fetchImpl, now: () => T0_MS,
+    });
+
+    expect(tokenA).toBe("ghs_a");
+    expect(tokenB).toBe("ghs_b");
+    expect(a.calls).toHaveLength(1);
+    expect(b.calls).toHaveLength(1);
+  });
+});
+
+describe("getGitHubInstallationToken — failure modes", () => {
+  it("throws when the App id or private key is unavailable", async () => {
+    await expect(
+      getGitHubInstallationToken(INSTALLATION_ID, {
+        appId: undefined,
+        privateKey: undefined,
+        now: () => T0_MS,
+      }),
+    ).rejects.toBeInstanceOf(GitHubInstallationTokenError);
+  });
+
+  it("throws when GitHub rejects the App JWT (non-2xx)", async () => {
+    const { fetchImpl } = mintFetch({ token: "", expiresInMs: 0, status: 401 });
+    await expect(
+      getGitHubInstallationToken(INSTALLATION_ID, {
+        appId: APP_ID,
+        privateKey: APP_PRIVATE_KEY,
+        fetchImpl,
+        now: () => T0_MS,
+      }),
+    ).rejects.toBeInstanceOf(GitHubInstallationTokenError);
+  });
+
+  it("rejects a malformed installation id rather than building a path-injecting URL", async () => {
+    const { fetchImpl, calls } = mintFetch({ token: "x", expiresInMs: 1000 });
+    await expect(
+      getGitHubInstallationToken("../../evil", {
+        appId: APP_ID,
+        privateKey: APP_PRIVATE_KEY,
+        fetchImpl,
+        now: () => T0_MS,
+      }),
+    ).rejects.toBeInstanceOf(GitHubInstallationTokenError);
+    expect(calls).toHaveLength(0); // never reached the network
+  });
+
+  it("does not cache a failed mint (next call retries)", async () => {
+    const failing = mintFetch({ token: "", expiresInMs: 0, status: 500 });
+    await expect(
+      getGitHubInstallationToken(INSTALLATION_ID, {
+        appId: APP_ID, privateKey: APP_PRIVATE_KEY, fetchImpl: failing.fetchImpl, now: () => T0_MS,
+      }),
+    ).rejects.toBeInstanceOf(GitHubInstallationTokenError);
+
+    const ok = mintFetch({ token: "ghs_recovered", expiresInMs: 3_600_000 });
+    const token = await getGitHubInstallationToken(INSTALLATION_ID, {
+      appId: APP_ID, privateKey: APP_PRIVATE_KEY, fetchImpl: ok.fetchImpl, now: () => T0_MS,
+    });
+    expect(token).toBe("ghs_recovered");
+    expect(ok.calls).toHaveLength(1);
+  });
+});

--- a/packages/api/src/lib/github/installation-token.ts
+++ b/packages/api/src/lib/github/installation-token.ts
@@ -38,7 +38,13 @@ const log = createLogger("github.installation-token");
 
 const GITHUB_API_BASE = "https://api.github.com";
 const JWT_ALG = "RS256";
-/** App-JWT lifetime. GitHub caps this at 10min; 9 leaves headroom for skew. */
+/**
+ * App-JWT lifetime measured from `now` (the `exp` claim is `now + this`). GitHub
+ * rejects a JWT whose `exp` is more than 10min after its `iat`; with the 60s
+ * back-date below the `exp − iat` span is 540 + 60 = 600s = exactly that 10min
+ * cap. Do NOT raise either constant independently — together they sit on the
+ * limit, so any increase pushes the span over it and GitHub rejects the JWT.
+ */
 const APP_JWT_TTL_SECONDS = 9 * 60;
 /** Back-date `iat` so a fast/slow clock at GitHub doesn't reject a just-minted JWT. */
 const APP_JWT_BACKDATE_SECONDS = 60;
@@ -87,9 +93,20 @@ interface CacheEntry {
 /** Process-local cache keyed by installation id. */
 const cache = new Map<string, CacheEntry>();
 
-/** @internal Test-only — drops every cached installation token. */
+/**
+ * In-flight mints keyed by installation id. Coalesces concurrent cold-cache
+ * callers (e.g. two chat turns in the same workspace racing on a just-expired
+ * token) onto ONE mint round-trip rather than each firing its own. A failed
+ * mint rejects all waiters and is removed (never cached), so the next call
+ * retries. Concurrent callers share the first caller's `deps` — fine in
+ * production where deps are env-derived and identical.
+ */
+const inFlight = new Map<string, Promise<string>>();
+
+/** @internal Test-only — drops every cached + in-flight installation token. */
 export function __resetInstallationTokenCacheForTests(): void {
   cache.clear();
+  inFlight.clear();
 }
 
 /** Minimal subset of GitHub's access-token response we consume. */
@@ -122,6 +139,26 @@ export async function getGitHubInstallationToken(
     return cached.token;
   }
 
+  // Single-flight: a concurrent caller already minting for this installation
+  // shares that promise instead of issuing a duplicate mint.
+  const existing = inFlight.get(installationId);
+  if (existing) return existing;
+
+  const minting = mintAndCache(installationId, deps, now);
+  inFlight.set(installationId, minting);
+  try {
+    return await minting;
+  } finally {
+    inFlight.delete(installationId);
+  }
+}
+
+/** Sign the App JWT, exchange it for an installation token, and cache the result. */
+async function mintAndCache(
+  installationId: string,
+  deps: InstallationTokenDeps,
+  now: () => number,
+): Promise<string> {
   const appId = deps.appId ?? process.env.GITHUB_APP_ID;
   const privateKey = deps.privateKey ?? process.env.GITHUB_APP_PRIVATE_KEY;
   if (!appId || !privateKey) {
@@ -131,13 +168,16 @@ export async function getGitHubInstallationToken(
     );
   }
 
-  const appJwt = await signAppJwt(appId, privateKey, now());
-  const minted = await mintInstallationToken(installationId, appJwt, deps.fetchImpl);
+  // Snapshot the clock once so the JWT claims, the expiry-cap fallback, and the
+  // debug log all share one timestamp.
+  const nowMs = now();
+  const appJwt = await signAppJwt(appId, privateKey, nowMs);
+  const minted = await mintInstallationToken(installationId, appJwt, deps.fetchImpl, nowMs);
 
   const refreshAtMs = minted.expiresAtMs - TOKEN_REFRESH_MARGIN_MS;
   cache.set(installationId, { token: minted.token, refreshAtMs });
   log.debug(
-    { installationIdTail: installationId.slice(-4), refreshInSeconds: Math.round((refreshAtMs - now()) / 1000) },
+    { installationIdTail: installationId.slice(-4), refreshInSeconds: Math.round((refreshAtMs - nowMs) / 1000) },
     "Minted GitHub installation token",
   );
   return minted.token;
@@ -175,6 +215,7 @@ async function mintInstallationToken(
   installationId: string,
   appJwt: string,
   fetchImpl: typeof globalThis.fetch | undefined,
+  nowMs: number,
 ): Promise<{ token: string; expiresAtMs: number }> {
   const fetcher = fetchImpl ?? globalThis.fetch;
   const url = `${GITHUB_API_BASE}/app/installations/${installationId}/access_tokens`;
@@ -241,7 +282,15 @@ async function mintInstallationToken(
   if (!Number.isFinite(expiresAtMs)) {
     // No (or unparseable) expiry — treat the token as valid only for the safety
     // margin so we re-mint promptly rather than caching an unbounded credential.
-    return { token: parsed.token, expiresAtMs: Date.now() + TOKEN_REFRESH_MARGIN_MS * 2 };
+    // Log it: GitHub always sends `expires_at`, so a miss signals an upstream
+    // contract change / a proxy stripping the field, and the cap silently ~12×es
+    // mint traffic otherwise. Use the injected clock (not wall-clock) so the
+    // capped expiry stays consistent with the cache check in the caller.
+    log.warn(
+      { installationIdTail: installationId.slice(-4) },
+      "GitHub installation-token response had no parseable expires_at — capping validity to the safety margin",
+    );
+    return { token: parsed.token, expiresAtMs: nowMs + TOKEN_REFRESH_MARGIN_MS * 2 };
   }
   return { token: parsed.token, expiresAtMs };
 }

--- a/packages/api/src/lib/github/installation-token.ts
+++ b/packages/api/src/lib/github/installation-token.ts
@@ -1,0 +1,247 @@
+/**
+ * GitHub App installation-token minting (v0.0.2 slice 6c, #3030).
+ *
+ * GitHub Apps don't carry a long-lived bearer credential. Atlas persists only
+ * the `installation_id`; the executable credential is a short-lived
+ * **installation access token** (~1hr) minted on demand:
+ *
+ *   1. Sign a short App JWT (RS256) with the App's private key
+ *      (`GITHUB_APP_PRIVATE_KEY`, operator env) — `iss = appId`, back-dated `iat`
+ *      for clock skew, ≤10min `exp`.
+ *   2. POST it (as `Authorization: Bearer <jwt>`) to
+ *      `/app/installations/<installation_id>/access_tokens`.
+ *   3. GitHub returns `{ token, expires_at }`. We cache the token in-process
+ *      until shortly before `expires_at` ({@link TOKEN_REFRESH_MARGIN_MS}) and
+ *      re-mint transparently afterward.
+ *
+ * This is the OQ5 "refresh" path: installation-token re-minting, NOT
+ * refresh-token rotation (the App private key never reaches the DB; only the
+ * installation_id does). Two call sites depend on it:
+ *
+ *   - the install handler (`oauth-datasource-handler.ts`) mints once at install
+ *     as a credential health-check (a failure flips the install to
+ *     "reconnect needed"), and
+ *   - the workspace REST datasource resolver (`workspace-datasource.ts`) mints
+ *     (or serves the cache) per chat turn to bake a `bearer` credential for the
+ *     github-data datasource — "cache the shape, mint the secret".
+ *
+ * The cache is process-local and best-effort: a miss/expiry just re-mints. A
+ * mint failure throws {@link GitHubInstallationTokenError} (never cached, so the
+ * next call retries) — callers decide whether that's fatal (install) or
+ * fail-soft skip (resolver).
+ */
+
+import { importPKCS8, SignJWT } from "jose";
+import { createLogger } from "@atlas/api/lib/logger";
+
+const log = createLogger("github.installation-token");
+
+const GITHUB_API_BASE = "https://api.github.com";
+const JWT_ALG = "RS256";
+/** App-JWT lifetime. GitHub caps this at 10min; 9 leaves headroom for skew. */
+const APP_JWT_TTL_SECONDS = 9 * 60;
+/** Back-date `iat` so a fast/slow clock at GitHub doesn't reject a just-minted JWT. */
+const APP_JWT_BACKDATE_SECONDS = 60;
+/** Re-mint this far before the installation token's stated expiry. */
+const TOKEN_REFRESH_MARGIN_MS = 5 * 60_000;
+/** Hard timeout on the mint round-trip. */
+const MINT_FETCH_TIMEOUT_MS = 15_000;
+/** GitHub installation ids are positive integers — reject anything else (path-injection guard). */
+const INSTALLATION_ID_RE = /^[1-9][0-9]{0,18}$/;
+
+/**
+ * Thrown when an installation token cannot be minted — missing App config,
+ * malformed installation id, a GitHub-side non-2xx, an unparseable response, or
+ * a transport fault. A plain `Error` subclass (no Effect `_tag`): every call
+ * site catches it locally (install → "reconnect needed"; resolver → skip), so it
+ * never needs HTTP-status mapping. The message never includes the App private
+ * key or the minted token.
+ */
+export class GitHubInstallationTokenError extends Error {
+  readonly reason: string;
+  constructor(reason: string, message: string) {
+    super(message);
+    this.name = "GitHubInstallationTokenError";
+    this.reason = reason;
+  }
+}
+
+/** Injectable seams — production reads env + the global `fetch` + the wall clock. */
+export interface InstallationTokenDeps {
+  /** GitHub App id (the `iss` claim). Defaults to `GITHUB_APP_ID`. */
+  readonly appId?: string;
+  /** GitHub App private key, PKCS8 PEM. Defaults to `GITHUB_APP_PRIVATE_KEY`. */
+  readonly privateKey?: string;
+  /** `fetch` override for tests. Defaults to `globalThis.fetch`. */
+  readonly fetchImpl?: typeof globalThis.fetch;
+  /** "now" in ms, for deterministic cache/expiry tests. Defaults to `Date.now`. */
+  readonly now?: () => number;
+}
+
+interface CacheEntry {
+  readonly token: string;
+  /** Absolute ms after which the token must be re-minted (already net of the margin). */
+  readonly refreshAtMs: number;
+}
+
+/** Process-local cache keyed by installation id. */
+const cache = new Map<string, CacheEntry>();
+
+/** @internal Test-only — drops every cached installation token. */
+export function __resetInstallationTokenCacheForTests(): void {
+  cache.clear();
+}
+
+/** Minimal subset of GitHub's access-token response we consume. */
+interface AccessTokenResponse {
+  readonly token?: string;
+  readonly expires_at?: string;
+}
+
+/**
+ * Get a valid installation access token for `installationId`, minting (or
+ * re-minting) via the App JWT when the cache is empty or near expiry. Throws
+ * {@link GitHubInstallationTokenError} on any failure.
+ */
+export async function getGitHubInstallationToken(
+  installationId: string,
+  deps: InstallationTokenDeps = {},
+): Promise<string> {
+  if (!INSTALLATION_ID_RE.test(installationId)) {
+    // Guard before the value reaches a URL path — our own config should never
+    // hold a non-integer id, but fail loud rather than build an injecting URL.
+    throw new GitHubInstallationTokenError(
+      "invalid_installation_id",
+      "GitHub installation id is not a positive integer — refusing to mint a token.",
+    );
+  }
+
+  const now = deps.now ?? (() => Date.now());
+  const cached = cache.get(installationId);
+  if (cached && now() < cached.refreshAtMs) {
+    return cached.token;
+  }
+
+  const appId = deps.appId ?? process.env.GITHUB_APP_ID;
+  const privateKey = deps.privateKey ?? process.env.GITHUB_APP_PRIVATE_KEY;
+  if (!appId || !privateKey) {
+    throw new GitHubInstallationTokenError(
+      "missing_app_config",
+      "GitHub App is not configured (GITHUB_APP_ID / GITHUB_APP_PRIVATE_KEY unset) — cannot mint an installation token.",
+    );
+  }
+
+  const appJwt = await signAppJwt(appId, privateKey, now());
+  const minted = await mintInstallationToken(installationId, appJwt, deps.fetchImpl);
+
+  const refreshAtMs = minted.expiresAtMs - TOKEN_REFRESH_MARGIN_MS;
+  cache.set(installationId, { token: minted.token, refreshAtMs });
+  log.debug(
+    { installationIdTail: installationId.slice(-4), refreshInSeconds: Math.round((refreshAtMs - now()) / 1000) },
+    "Minted GitHub installation token",
+  );
+  return minted.token;
+}
+
+/** Sign the short-lived App JWT (RS256). Throws on a malformed private key. */
+async function signAppJwt(appId: string, privateKeyPem: string, nowMs: number): Promise<string> {
+  let key: Awaited<ReturnType<typeof importPKCS8>>;
+  try {
+    key = await importPKCS8(privateKeyPem, JWT_ALG);
+  } catch (err) {
+    throw new GitHubInstallationTokenError(
+      "invalid_private_key",
+      `GITHUB_APP_PRIVATE_KEY is not a valid PKCS8 RSA key: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+  const nowS = Math.floor(nowMs / 1000);
+  try {
+    return await new SignJWT({})
+      .setProtectedHeader({ alg: JWT_ALG, typ: "JWT" })
+      .setIssuer(appId)
+      .setIssuedAt(nowS - APP_JWT_BACKDATE_SECONDS)
+      .setExpirationTime(nowS + APP_JWT_TTL_SECONDS)
+      .sign(key);
+  } catch (err) {
+    throw new GitHubInstallationTokenError(
+      "jwt_sign_failed",
+      `Failed to sign the GitHub App JWT: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
+/** POST the App JWT to mint an installation token; parse `{ token, expires_at }`. */
+async function mintInstallationToken(
+  installationId: string,
+  appJwt: string,
+  fetchImpl: typeof globalThis.fetch | undefined,
+): Promise<{ token: string; expiresAtMs: number }> {
+  const fetcher = fetchImpl ?? globalThis.fetch;
+  const url = `${GITHUB_API_BASE}/app/installations/${installationId}/access_tokens`;
+
+  let resp: Response;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), MINT_FETCH_TIMEOUT_MS);
+  try {
+    resp = await fetcher(url, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${appJwt}`,
+        Accept: "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+      signal: controller.signal,
+    });
+  } catch (err) {
+    const isAbort = err instanceof Error && err.name === "AbortError";
+    log.warn(
+      { installationIdTail: installationId.slice(-4), timedOut: isAbort },
+      isAbort ? "GitHub installation-token mint timed out" : "GitHub installation-token mint unreachable",
+    );
+    throw new GitHubInstallationTokenError(
+      isAbort ? "timeout" : "network",
+      isAbort
+        ? "GitHub timed out while minting an installation token."
+        : `Could not reach GitHub to mint an installation token: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  } finally {
+    clearTimeout(timer);
+  }
+
+  if (!resp.ok) {
+    log.warn(
+      { installationIdTail: installationId.slice(-4), status: resp.status },
+      "GitHub rejected the installation-token mint",
+    );
+    throw new GitHubInstallationTokenError(
+      `http_${resp.status}`,
+      `GitHub rejected the installation-token request (HTTP ${resp.status}). The App may have been uninstalled or its access revoked — reconnect the datasource.`,
+    );
+  }
+
+  let parsed: AccessTokenResponse;
+  try {
+    parsed = (await resp.json()) as AccessTokenResponse;
+  } catch (err) {
+    throw new GitHubInstallationTokenError(
+      "unparseable_response",
+      `GitHub returned an unparseable installation-token response: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  if (typeof parsed.token !== "string" || parsed.token.length === 0) {
+    throw new GitHubInstallationTokenError(
+      "missing_token",
+      "GitHub's installation-token response did not include a token.",
+    );
+  }
+
+  const expiresAtMs =
+    typeof parsed.expires_at === "string" ? Date.parse(parsed.expires_at) : NaN;
+  if (!Number.isFinite(expiresAtMs)) {
+    // No (or unparseable) expiry — treat the token as valid only for the safety
+    // margin so we re-mint promptly rather than caching an unbounded credential.
+    return { token: parsed.token, expiresAtMs: Date.now() + TOKEN_REFRESH_MARGIN_MS * 2 };
+  }
+  return { token: parsed.token, expiresAtMs };
+}

--- a/packages/api/src/lib/integrations/install/__tests__/dispatch.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/dispatch.test.ts
@@ -18,6 +18,7 @@ import {
   _resetInstallHandlerRegistries,
   getInstallHandler,
   registerFormHandler,
+  registerOAuthDatasourceHandler,
   registerOAuthHandler,
   registerStaticBotHandler,
 } from "../dispatch";
@@ -25,6 +26,7 @@ import type {
   CatalogRowForDispatch,
   FormBasedInstallHandler,
   InstallRecord,
+  OAuthDatasourceInstallHandler,
   OAuthPlatformInstallHandler,
   StaticBotInstallHandler,
 } from "../types";
@@ -70,6 +72,24 @@ function makeStaticBotHandler(slug: string): StaticBotInstallHandler {
     kind: "static-bot",
     async confirmInstall() {
       return { installRecord: record };
+    },
+  };
+}
+
+function makeOAuthDatasourceHandler(slug: string): OAuthDatasourceInstallHandler {
+  const record: InstallRecord = { id: `install-${slug}`, workspaceId: wsid, catalogId: slug };
+  return {
+    kind: "oauth-datasource",
+    async startInstall() {
+      return { redirectUrl: `https://example.test/${slug}/installations/new`, stateToken: "tok" };
+    },
+    async handleCallback() {
+      return {
+        workspaceId: wsid,
+        catalogId: slug,
+        installRecord: record,
+        credentialResult: { written: true },
+      };
     },
   };
 }
@@ -177,6 +197,40 @@ describe("getInstallHandler — install_model: 'static-bot'", () => {
     expect(
       getInstallHandler({ slug: "telegram", install_model: "static-bot" }),
     ).toBe(replacement);
+  });
+});
+
+describe("getInstallHandler — install_model: 'oauth-datasource'", () => {
+  it("returns the registered OAuth-datasource handler for a known slug", () => {
+    const handler = makeOAuthDatasourceHandler("github-data");
+    registerOAuthDatasourceHandler("github-data", handler);
+
+    const row: CatalogRowForDispatch = { slug: "github-data", install_model: "oauth-datasource" };
+    const resolved = getInstallHandler(row);
+    expect(resolved.kind).toBe("oauth-datasource");
+    expect(resolved).toBe(handler);
+  });
+
+  it("keeps the oauth-datasource registry distinct from the chat/action oauth registry", () => {
+    // Same slug must NOT collide across the two registries — an oauth row and an
+    // oauth-datasource row are independent install paths.
+    const datasource = makeOAuthDatasourceHandler("github-data");
+    registerOAuthDatasourceHandler("github-data", datasource);
+    // The plain-oauth registry has no "github-data" entry → dispatching the same
+    // slug as install_model: 'oauth' must throw, not return the datasource handler.
+    expect(() =>
+      getInstallHandler({ slug: "github-data", install_model: "oauth" }),
+    ).toThrow(/No OAuth install handler registered for catalog slug "github-data"/);
+    expect(
+      getInstallHandler({ slug: "github-data", install_model: "oauth-datasource" }),
+    ).toBe(datasource);
+  });
+
+  it("throws an actionable error when no oauth-datasource handler is registered", () => {
+    const row: CatalogRowForDispatch = { slug: "github-data", install_model: "oauth-datasource" };
+    expect(() => getInstallHandler(row)).toThrow(
+      /No OAuth-datasource install handler registered for catalog slug "github-data"/,
+    );
   });
 });
 

--- a/packages/api/src/lib/integrations/install/__tests__/github-app-oauth.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/github-app-oauth.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Tests for the shared GitHub App OAuth credential-acquisition primitives
+ * (`github-app-oauth.ts`, extracted in v0.0.2 slice 6c #3030). These exercise the
+ * extracted `exchangeUserCodeForToken` + `findUserInstallation` directly with an
+ * injected `fetch` (no network), covering the error-shape attribution and the
+ * paginated ownership walk — the threat-model-adjacent paths the action handler's
+ * tests only touched at the happy/multi-page level. Both pillars (the `github`
+ * action handler and the `github-data` datasource handler) consume this code, so
+ * a regression here breaks installation-ownership verification for both.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { PlatformOAuthExchangeError } from "@atlas/api/lib/effect/errors";
+import { exchangeUserCodeForToken, findUserInstallation } from "../github-app-oauth";
+
+const PLATFORM = "github-data";
+
+/** An AbortError-shaped throw, simulating the fetch timeout path without waiting. */
+function abortError(): Error {
+  const e = new Error("The operation was aborted");
+  e.name = "AbortError";
+  return e;
+}
+
+// ---------------------------------------------------------------------------
+// exchangeUserCodeForToken
+// ---------------------------------------------------------------------------
+
+describe("exchangeUserCodeForToken", () => {
+  const baseArgs = {
+    clientId: "Iv1.test",
+    clientSecret: "secret",
+    code: "user-code",
+    redirectUri: "https://atlas.test/callback",
+    platform: PLATFORM,
+  };
+
+  it("returns the access token on a 200 JSON success", async () => {
+    const fetchImpl = (async () =>
+      new Response(JSON.stringify({ access_token: "user-token", token_type: "bearer" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })) as unknown as typeof globalThis.fetch;
+
+    const token = await exchangeUserCodeForToken({ ...baseArgs, fetchImpl });
+    expect(token).toBe("user-token");
+  });
+
+  it("throws (attributed to platform) when GitHub returns an OAuth error body", async () => {
+    const fetchImpl = (async () =>
+      new Response(JSON.stringify({ error: "bad_verification_code" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })) as unknown as typeof globalThis.fetch;
+
+    await expect(exchangeUserCodeForToken({ ...baseArgs, fetchImpl })).rejects.toMatchObject({
+      platform: PLATFORM,
+      upstreamError: "bad_verification_code",
+    });
+  });
+
+  it("throws on a non-2xx with no usable access_token", async () => {
+    const fetchImpl = (async () =>
+      new Response(JSON.stringify({}), {
+        status: 401,
+        headers: { "content-type": "application/json" },
+      })) as unknown as typeof globalThis.fetch;
+
+    await expect(exchangeUserCodeForToken({ ...baseArgs, fetchImpl })).rejects.toBeInstanceOf(
+      PlatformOAuthExchangeError,
+    );
+  });
+
+  it("throws on an unparseable (non-JSON) token response", async () => {
+    const fetchImpl = (async () =>
+      new Response("<html>nope</html>", { status: 200 })) as unknown as typeof globalThis.fetch;
+
+    await expect(exchangeUserCodeForToken({ ...baseArgs, fetchImpl })).rejects.toMatchObject({
+      upstreamError: expect.stringContaining("non-json"),
+    });
+  });
+
+  it("maps an aborted fetch to a timeout error", async () => {
+    const fetchImpl = (async () => {
+      throw abortError();
+    }) as unknown as typeof globalThis.fetch;
+
+    await expect(exchangeUserCodeForToken({ ...baseArgs, fetchImpl })).rejects.toMatchObject({
+      upstreamError: "timeout",
+    });
+  });
+
+  it("maps a transport failure to a network error (not timeout)", async () => {
+    const fetchImpl = (async () => {
+      throw new Error("ECONNREFUSED");
+    }) as unknown as typeof globalThis.fetch;
+
+    await expect(exchangeUserCodeForToken({ ...baseArgs, fetchImpl })).rejects.toMatchObject({
+      upstreamError: "ECONNREFUSED",
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findUserInstallation — the cross-tenant binding guard
+// ---------------------------------------------------------------------------
+
+interface InstallationPage {
+  /** Installation ids on this page. */
+  readonly ids: number[];
+  /** Whether to emit a `Link: …; rel="next"` header pointing at the next page. */
+  readonly hasNext: boolean;
+}
+
+/**
+ * Build a `/user/installations` fetch stub that serves pages keyed by the `page`
+ * query param (defaulting to 1). Records how many pages were fetched.
+ */
+function pagedInstallationsFetch(pages: Record<number, InstallationPage>): {
+  fetchImpl: typeof globalThis.fetch;
+  pageCalls: () => number;
+} {
+  const state = { calls: 0 };
+  const fetchImpl = (async (input: string | URL) => {
+    state.calls++;
+    const url = typeof input === "string" ? input : input.toString();
+    const pageParam = new URL(url).searchParams.get("page");
+    const page = pageParam ? Number(pageParam) : 1;
+    const def = pages[page] ?? { ids: [], hasNext: false };
+    const headers: Record<string, string> = { "content-type": "application/json" };
+    if (def.hasNext) {
+      headers.link = `<https://api.github.com/user/installations?per_page=100&page=${page + 1}>; rel="next"`;
+    }
+    return new Response(
+      JSON.stringify({
+        installations: def.ids.map((id) => ({ id, account: { login: `acct-${id}`, type: "Organization" } })),
+      }),
+      { status: 200, headers },
+    );
+  }) as unknown as typeof globalThis.fetch;
+  return { fetchImpl, pageCalls: () => state.calls };
+}
+
+describe("findUserInstallation", () => {
+  it("returns the owning account when the target is on the first page", async () => {
+    const { fetchImpl, pageCalls } = pagedInstallationsFetch({ 1: { ids: [42, 7], hasNext: false } });
+    const ownership = await findUserInstallation("user-token", "42", { platform: PLATFORM, fetchImpl });
+    expect(ownership).toEqual({ login: "acct-42", type: "Organization" });
+    expect(pageCalls()).toBe(1);
+  });
+
+  it("follows the Link header and finds the target on a later page", async () => {
+    const { fetchImpl, pageCalls } = pagedInstallationsFetch({
+      1: { ids: [1, 2], hasNext: true },
+      2: { ids: [3, 99], hasNext: false },
+    });
+    const ownership = await findUserInstallation("user-token", "99", { platform: PLATFORM, fetchImpl });
+    expect(ownership).toEqual({ login: "acct-99", type: "Organization" });
+    expect(pageCalls()).toBe(2);
+  });
+
+  it("returns null when the user does not own the target (cross-tenant attempt)", async () => {
+    const { fetchImpl } = pagedInstallationsFetch({ 1: { ids: [1, 2, 3], hasNext: false } });
+    const ownership = await findUserInstallation("user-token", "404", { platform: PLATFORM, fetchImpl });
+    expect(ownership).toBeNull();
+  });
+
+  it("fails closed (null) at the page cap when the target sits past it — bounded walk", async () => {
+    // Every page advertises a next page but never contains the target → the walk
+    // stops at MAX_INSTALLATIONS_PAGES (10) and returns null rather than looping.
+    const alwaysMore: Record<number, InstallationPage> = {};
+    for (let p = 1; p <= 50; p++) alwaysMore[p] = { ids: [p * 1000], hasNext: true };
+    const { fetchImpl, pageCalls } = pagedInstallationsFetch(alwaysMore);
+
+    const ownership = await findUserInstallation("user-token", "987654321", { platform: PLATFORM, fetchImpl });
+    expect(ownership).toBeNull();
+    expect(pageCalls()).toBe(10); // capped, not unbounded
+  });
+
+  it("throws (attributed to platform) on a non-ok installations response", async () => {
+    const fetchImpl = (async () => new Response("nope", { status: 403 })) as unknown as typeof globalThis.fetch;
+    await expect(
+      findUserInstallation("user-token", "42", { platform: PLATFORM, fetchImpl }),
+    ).rejects.toMatchObject({ platform: PLATFORM, upstreamError: "user_installations_http_403" });
+  });
+
+  it("maps an aborted installations fetch to a timeout error", async () => {
+    const fetchImpl = (async () => {
+      throw abortError();
+    }) as unknown as typeof globalThis.fetch;
+    await expect(
+      findUserInstallation("user-token", "42", { platform: PLATFORM, fetchImpl }),
+    ).rejects.toMatchObject({ upstreamError: "timeout" });
+  });
+});

--- a/packages/api/src/lib/integrations/install/__tests__/oauth-datasource-handler.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/oauth-datasource-handler.test.ts
@@ -1,0 +1,304 @@
+/**
+ * Tests for `OAuthDatasourceInstallHandler` (v0.0.2 slice 6c, #3030 — the OQ5
+ * deliverable). Drives the GitHub-as-datasource OAuth install end-to-end with an
+ * injected `fetch` (no live HTTP), an injected encryption keyset, and a mocked
+ * `internalQuery`, asserting:
+ *
+ *   - state-token forgery / replay / wrong-catalog → null (no persistence)
+ *   - the user-OAuth code-exchange + installation-ownership verification (the
+ *     cross-tenant binding guard) runs against the injected fetch
+ *   - a successful install probes the pre-wired spec, mints a health-check
+ *     installation token, encrypts the installation_id, and inserts a
+ *     `pillar='datasource'` multi-instance row with `config.status='ok'`
+ *   - a failed health-check mint flips the install to "reconnect needed"
+ *     (`credentialResult.written=false`, `config.status='reconnect_needed'`)
+ *     while still persisting the row
+ *   - an installation the user does NOT own (cross-org) is rejected
+ */
+
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { generateKeyPairSync } from "crypto";
+import type { WorkspaceId } from "@useatlas/types";
+import { _resetEncryptionKeyCache } from "@atlas/api/lib/db/encryption-keys";
+import { decryptSecret } from "@atlas/api/lib/db/secret-encryption";
+import { __resetInstallationTokenCacheForTests } from "@atlas/api/lib/github/installation-token";
+import { mintOAuthStateToken } from "../oauth-state-token";
+import {
+  OAuthDatasourceInstallHandler,
+  type OAuthDatasourceHandlerConfig,
+} from "../oauth-datasource-handler";
+
+const { privateKey: APP_PRIVATE_KEY } = generateKeyPairSync("rsa", {
+  modulusLength: 2048,
+  publicKeyEncoding: { type: "spki", format: "pem" },
+  privateKeyEncoding: { type: "pkcs8", format: "pem" },
+});
+
+const WSID = "ws-github-data-1" as WorkspaceId;
+const OTHER_WSID = "ws-github-data-2" as WorkspaceId;
+const SLUG = "github-data";
+const CATALOG_ID = "catalog:github-data";
+const INSTALLATION_ID = "55667788";
+const SPEC_URL = "https://example.test/github-openapi.json";
+
+const CONFIG: OAuthDatasourceHandlerConfig = {
+  slug: SLUG,
+  catalogId: CATALOG_ID,
+  openapiUrl: SPEC_URL,
+  appSlug: "atlas-test-app",
+  appId: "424242",
+  clientId: "Iv1.testclient",
+  clientSecret: "test-client-secret",
+  privateKey: APP_PRIVATE_KEY,
+  redirectUri: "https://atlas.test/api/v1/integrations/github-data/callback",
+};
+
+/** A minimal valid OpenAPI 3.x spec the probe normalizes — GitHub-shaped. */
+const GITHUB_FIXTURE_SPEC = {
+  openapi: "3.1.0",
+  info: { title: "GitHub v3 REST API", version: "1.1.4" },
+  servers: [{ url: "https://api.github.com" }],
+  paths: {
+    "/repos/{owner}/{repo}/pulls": {
+      get: {
+        operationId: "pulls/list",
+        parameters: [
+          { name: "owner", in: "path", required: true, schema: { type: "string" } },
+          { name: "repo", in: "path", required: true, schema: { type: "string" } },
+          { name: "state", in: "query", required: false, schema: { type: "string" } },
+        ],
+        responses: { "200": { description: "ok" } },
+      },
+    },
+  },
+};
+
+interface FetchScenario {
+  /** installation ids the authenticating user owns (drives the ownership check). */
+  ownedInstallationIds?: string[];
+  /** HTTP status the installation-token mint endpoint returns (201 = success). */
+  mintStatus?: number;
+}
+
+/** Build a fetch stub routing the four GitHub round-trips a full install makes. */
+function buildFetch(scenario: FetchScenario): {
+  fetchImpl: typeof globalThis.fetch;
+  calls: string[];
+} {
+  const calls: string[] = [];
+  const owned = scenario.ownedInstallationIds ?? [INSTALLATION_ID];
+  const fetchImpl = (async (input: string | URL) => {
+    const url = typeof input === "string" ? input : input.toString();
+    calls.push(url);
+    if (url.includes("/login/oauth/access_token")) {
+      return new Response(JSON.stringify({ access_token: "user-oauth-token" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    if (url.includes("/user/installations")) {
+      return new Response(
+        JSON.stringify({
+          installations: owned.map((id) => ({
+            id: Number(id),
+            account: { login: "acme-org", type: "Organization" },
+          })),
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }
+    if (url.includes("/access_tokens")) {
+      const status = scenario.mintStatus ?? 201;
+      if (status >= 200 && status < 300) {
+        return new Response(
+          JSON.stringify({
+            token: "ghs_health_check",
+            expires_at: new Date(Date.now() + 3_600_000).toISOString(),
+          }),
+          { status, headers: { "content-type": "application/json" } },
+        );
+      }
+      return new Response("unauthorized", { status });
+    }
+    if (url === SPEC_URL) {
+      return new Response(JSON.stringify(GITHUB_FIXTURE_SPEC), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    throw new Error(`unexpected fetch in test: ${url}`);
+  }) as typeof globalThis.fetch;
+  return { fetchImpl, calls };
+}
+
+let queryCalls: Array<{ sql: string; params: unknown[] }>;
+
+beforeEach(() => {
+  queryCalls = [];
+  process.env.ATLAS_ENCRYPTION_KEYS = "v1:test-key-for-oauth-datasource-handler-unit-tests-32b";
+  delete process.env.ATLAS_ENCRYPTION_KEY;
+  delete process.env.BETTER_AUTH_SECRET;
+  delete process.env.ATLAS_DEPLOY_MODE;
+  _resetEncryptionKeyCache();
+  __resetInstallationTokenCacheForTests();
+
+  mock.module("@atlas/api/lib/db/internal", () => ({
+    internalQuery: async (sql: string, params: unknown[]) => {
+      queryCalls.push({ sql, params });
+      return [{ id: params[0] ?? "generated-id" }];
+    },
+    hasInternalDB: () => true,
+    getInternalDB: () => ({ query: async () => ({ rows: [] }) }),
+  }));
+});
+
+afterEach(() => {
+  __resetInstallationTokenCacheForTests();
+});
+
+/** Pull the persisted (encrypted) config JSON off the captured INSERT. */
+function persistedConfig(): Record<string, unknown> {
+  const insert = queryCalls.find((c) => c.sql.includes("INSERT INTO workspace_plugins"));
+  expect(insert).toBeDefined();
+  const jsonParam = insert!.params.find(
+    (p): p is string => typeof p === "string" && p.trimStart().startsWith("{"),
+  );
+  expect(jsonParam).toBeDefined();
+  return JSON.parse(jsonParam!) as Record<string, unknown>;
+}
+
+describe("OAuthDatasourceInstallHandler.startInstall", () => {
+  it("redirects to the GitHub App install URL with a state token bound to the slug", async () => {
+    const { fetchImpl } = buildFetch({});
+    const handler = new OAuthDatasourceInstallHandler(CONFIG, { fetchImpl });
+    const { redirectUrl, stateToken } = await handler.startInstall(WSID);
+    expect(redirectUrl).toContain("github.com/apps/atlas-test-app/installations/new");
+    expect(redirectUrl).toContain(`state=${encodeURIComponent(stateToken)}`);
+    expect(stateToken.length).toBeGreaterThan(0);
+  });
+});
+
+describe("OAuthDatasourceInstallHandler.handleCallback — state gate", () => {
+  it("returns null for a forged / unverifiable state token", async () => {
+    const { fetchImpl, calls } = buildFetch({});
+    const handler = new OAuthDatasourceInstallHandler(CONFIG, { fetchImpl });
+    const result = await handler.handleCallback("code", "not-a-real-token", {
+      installationId: INSTALLATION_ID,
+    });
+    expect(result).toBeNull();
+    expect(calls).toHaveLength(0); // never reached GitHub
+    expect(queryCalls).toHaveLength(0); // never persisted
+  });
+
+  it("returns null when the state token is bound to a different catalog", async () => {
+    const { fetchImpl } = buildFetch({});
+    const handler = new OAuthDatasourceInstallHandler(CONFIG, { fetchImpl });
+    const wrongState = mintOAuthStateToken(WSID, "some-other-catalog");
+    const result = await handler.handleCallback("code", wrongState, {
+      installationId: INSTALLATION_ID,
+    });
+    expect(result).toBeNull();
+  });
+});
+
+describe("OAuthDatasourceInstallHandler.handleCallback — successful install", () => {
+  it("verifies ownership, probes the spec, mints a token, and persists a datasource row", async () => {
+    const { fetchImpl, calls } = buildFetch({ ownedInstallationIds: [INSTALLATION_ID] });
+    const handler = new OAuthDatasourceInstallHandler(CONFIG, {
+      fetchImpl,
+      idGenerator: () => "fixed-install-id",
+      now: () => "2026-05-30T00:00:00.000Z",
+    });
+    const state = mintOAuthStateToken(WSID, SLUG);
+
+    const result = await handler.handleCallback("user-code", state, {
+      installationId: INSTALLATION_ID,
+    });
+
+    expect(result).not.toBeNull();
+    expect(result!.credentialResult.written).toBe(true);
+    expect(result!.catalogId).toBe(SLUG);
+    expect(result!.installRecord.id).toBe("fixed-install-id");
+
+    // The four round-trips fired: token exchange, ownership lookup, spec probe, mint.
+    expect(calls.some((u) => u.includes("/login/oauth/access_token"))).toBe(true);
+    expect(calls.some((u) => u.includes("/user/installations"))).toBe(true);
+    expect(calls.some((u) => u === SPEC_URL)).toBe(true);
+    expect(calls.some((u) => u.includes("/access_tokens"))).toBe(true);
+
+    // Persistence: pillar='datasource', multi-instance, fresh install_id.
+    const insert = queryCalls.find((c) => c.sql.includes("INSERT INTO workspace_plugins"));
+    expect(insert!.sql).toContain("'datasource'");
+    expect(insert!.sql).toMatch(/install_id/);
+
+    const config = persistedConfig();
+    // installation_id encrypted at rest, round-trips back to the plaintext id.
+    expect(typeof config.installation_id).toBe("string");
+    expect(config.installation_id as string).toContain("enc:");
+    expect(decryptSecret(config.installation_id as string)).toBe(INSTALLATION_ID);
+    // snapshot cached + credential health recorded.
+    expect(config.openapi_snapshot).toBeDefined();
+    expect(config.status).toBe("ok");
+    expect(config.openapi_url).toBe(SPEC_URL);
+    // the raw installation id never lands in plaintext anywhere in the row.
+    expect(JSON.stringify(config)).not.toContain(`"${INSTALLATION_ID}"`);
+  });
+});
+
+describe("OAuthDatasourceInstallHandler.handleCallback — partial failure", () => {
+  it("flips to reconnect-needed when the health-check mint fails, but still persists the row", async () => {
+    const { fetchImpl } = buildFetch({ ownedInstallationIds: [INSTALLATION_ID], mintStatus: 401 });
+    const handler = new OAuthDatasourceInstallHandler(CONFIG, {
+      fetchImpl,
+      idGenerator: () => "fixed-install-id",
+      now: () => "2026-05-30T00:00:00.000Z",
+    });
+    const state = mintOAuthStateToken(WSID, SLUG);
+
+    const result = await handler.handleCallback("user-code", state, {
+      installationId: INSTALLATION_ID,
+    });
+
+    expect(result).not.toBeNull();
+    expect(result!.credentialResult.written).toBe(false);
+    expect(result!.credentialResult.reason).toBeTruthy();
+
+    // The row IS persisted (snapshot + installation_id) but marked reconnect-needed.
+    const config = persistedConfig();
+    expect(config.status).toBe("reconnect_needed");
+    expect(decryptSecret(config.installation_id as string)).toBe(INSTALLATION_ID);
+  });
+});
+
+describe("OAuthDatasourceInstallHandler.handleCallback — cross-org isolation", () => {
+  it("rejects an installation the authenticating user does not own (cross-tenant binding guard)", async () => {
+    // The user owns a DIFFERENT installation than the one supplied on the callback.
+    const { fetchImpl } = buildFetch({ ownedInstallationIds: ["99999999"] });
+    const handler = new OAuthDatasourceInstallHandler(CONFIG, { fetchImpl });
+    const state = mintOAuthStateToken(WSID, SLUG);
+
+    await expect(
+      handler.handleCallback("user-code", state, { installationId: INSTALLATION_ID }),
+    ).rejects.toMatchObject({ upstreamError: "installation_not_owned" });
+
+    // Nothing persisted for the cross-tenant attempt.
+    expect(queryCalls.find((c) => c.sql.includes("INSERT INTO workspace_plugins"))).toBeUndefined();
+  });
+
+  it("binds the install to the workspace from the verified state token, not a caller-supplied one", async () => {
+    const { fetchImpl } = buildFetch({ ownedInstallationIds: [INSTALLATION_ID] });
+    const handler = new OAuthDatasourceInstallHandler(CONFIG, {
+      fetchImpl,
+      idGenerator: () => "fixed-install-id",
+      now: () => "2026-05-30T00:00:00.000Z",
+    });
+    // State minted for OTHER_WSID — the persisted row must scope to OTHER_WSID.
+    const state = mintOAuthStateToken(OTHER_WSID, SLUG);
+    const result = await handler.handleCallback("user-code", state, {
+      installationId: INSTALLATION_ID,
+    });
+    expect(result!.workspaceId).toBe(OTHER_WSID);
+    const insert = queryCalls.find((c) => c.sql.includes("INSERT INTO workspace_plugins"));
+    expect(insert!.params).toContain(OTHER_WSID);
+  });
+});

--- a/packages/api/src/lib/integrations/install/data-candidate-form-handler.ts
+++ b/packages/api/src/lib/integrations/install/data-candidate-form-handler.ts
@@ -22,7 +22,7 @@ import { z } from "zod";
 import type { WorkspaceId } from "@useatlas/types";
 import {
   DATA_CANDIDATE_CONFIG_SCHEMA,
-  type DataCandidate,
+  type FormDataCandidate,
 } from "@atlas/api/lib/openapi/data-candidates";
 import { FormInstallValidationError } from "./email-form-handler";
 import {
@@ -74,12 +74,12 @@ export type DataCandidateFormData = z.infer<typeof DataCandidateFormDataSchema>;
 export class DataCandidateFormInstallHandler implements FormBasedInstallHandler {
   readonly kind = "form" as const;
 
-  private readonly candidate: DataCandidate;
+  private readonly candidate: FormDataCandidate;
   private readonly newId: () => string;
   private readonly now: () => string;
   private readonly fetchImpl: typeof globalThis.fetch | undefined;
 
-  constructor(candidate: DataCandidate, options: OpenApiGenericFormInstallHandlerOptions = {}) {
+  constructor(candidate: FormDataCandidate, options: OpenApiGenericFormInstallHandlerOptions = {}) {
     this.candidate = candidate;
     this.newId = options.idGenerator ?? (() => crypto.randomUUID());
     this.now = options.now ?? (() => new Date().toISOString());

--- a/packages/api/src/lib/integrations/install/dispatch.ts
+++ b/packages/api/src/lib/integrations/install/dispatch.ts
@@ -30,6 +30,7 @@
 import type {
   CatalogRowForDispatch,
   FormBasedInstallHandler,
+  OAuthDatasourceInstallHandler,
   OAuthPlatformInstallHandler,
   PlatformInstallHandler,
   StaticBotInstallHandler,
@@ -42,6 +43,11 @@ import type {
 const oauthHandlers = new Map<string, OAuthPlatformInstallHandler>();
 const formHandlers = new Map<string, FormBasedInstallHandler>();
 const staticBotHandlers = new Map<string, StaticBotInstallHandler>();
+// Kept distinct from `oauthHandlers` even though the wire shape is compatible:
+// an `oauth` row (chat/action, single-instance) and an `oauth-datasource` row
+// (datasource, multi-instance) are independent install paths that may share a
+// slug namespace, so they must never collide in one map. v0.0.2 slice 6c (#3030).
+const oauthDatasourceHandlers = new Map<string, OAuthDatasourceInstallHandler>();
 
 /**
  * Register an OAuth install handler for a given catalog slug. Idempotent
@@ -84,11 +90,27 @@ export function registerStaticBotHandler(
   staticBotHandlers.set(slug, handler);
 }
 
-/** @internal Test-only — clears all three registries between tests. */
+/**
+ * Register an OAuth-datasource install handler for a given catalog slug
+ * (v0.0.2 slice 6c, #3030 — GitHub-as-datasource). Same idempotency contract
+ * as {@link registerOAuthHandler}. Distinct registry from the chat/action
+ * `oauth` one: the two install models persist differently (multi-instance
+ * datasource vs single-instance chat/action), so the same slug must not
+ * resolve across them.
+ */
+export function registerOAuthDatasourceHandler(
+  slug: string,
+  handler: OAuthDatasourceInstallHandler,
+): void {
+  oauthDatasourceHandlers.set(slug, handler);
+}
+
+/** @internal Test-only — clears all four registries between tests. */
 export function _resetInstallHandlerRegistries(): void {
   oauthHandlers.clear();
   formHandlers.clear();
   staticBotHandlers.clear();
+  oauthDatasourceHandlers.clear();
 }
 
 // ---------------------------------------------------------------------------
@@ -138,6 +160,15 @@ export function getInstallHandler(
       }
       return handler;
     }
+    case "oauth-datasource": {
+      const handler = oauthDatasourceHandlers.get(catalogRow.slug);
+      if (!handler) {
+        throw new Error(
+          `No OAuth-datasource install handler registered for catalog slug "${catalogRow.slug}". Register via registerOAuthDatasourceHandler() at module load (set the operator env vars the handler needs — GITHUB_APP_ID + GITHUB_APP_SLUG + GITHUB_APP_PRIVATE_KEY + GITHUB_APP_CLIENT_ID + GITHUB_APP_CLIENT_SECRET for github-data).`,
+        );
+      }
+      return handler;
+    }
     default: {
       const _exhaustive: never = catalogRow.install_model;
       throw new Error(
@@ -153,5 +184,6 @@ export type {
   OAuthPlatformInstallHandler,
   FormBasedInstallHandler,
   StaticBotInstallHandler,
+  OAuthDatasourceInstallHandler,
   PlatformInstallHandler,
 };

--- a/packages/api/src/lib/integrations/install/github-app-oauth.ts
+++ b/packages/api/src/lib/integrations/install/github-app-oauth.ts
@@ -1,0 +1,252 @@
+/**
+ * Shared GitHub App OAuth credential-acquisition primitives (extracted in
+ * v0.0.2 slice 6c, #3030).
+ *
+ * The GitHub App install dance (`github.com/apps/<slug>/installations/new` →
+ * callback with `?code=&installation_id=`) is identical whether the resulting
+ * install is an **action** (`GitHubOAuthInstallHandler`, pillar=action) or a
+ * **datasource** (`OAuthDatasourceInstallHandler`, pillar=datasource). Both must:
+ *
+ *   1. exchange the user-OAuth `code` for a user access token, and
+ *   2. verify the supplied `installation_id` is one the authenticating user
+ *      actually has access to (`GET /user/installations`).
+ *
+ * Step 2 is the load-bearing defense against cross-tenant binding: the state
+ * token gates only the *workspace* binding, not the *installation* binding — a
+ * tampered callback URL could substitute an `installation_id` the attacker
+ * doesn't own. Centralising the verification here means the github-data
+ * datasource install (#3030) inherits the exact same threat-model coverage the
+ * action install (#2751) already has, rather than re-deriving it.
+ *
+ * Both helpers take a `platform` slug (so the {@link PlatformOAuthExchangeError}
+ * attributes the right catalog row) and an optional `fetchImpl` resolved at call
+ * time (so tests inject a stub; production reads the live `globalThis.fetch`).
+ */
+
+import { createLogger } from "@atlas/api/lib/logger";
+import { PlatformOAuthExchangeError } from "@atlas/api/lib/effect/errors";
+
+const log = createLogger("integrations.install.github-app-oauth");
+
+const USER_OAUTH_TOKEN_URL = "https://github.com/login/oauth/access_token";
+const USER_INSTALLATIONS_URL = "https://api.github.com/user/installations";
+
+/** Hard timeout on install-time GitHub round-trips. */
+const INSTALL_FETCH_TIMEOUT_MS = 15_000;
+
+/** Cap on `/user/installations` pages we'll walk before giving up. */
+const MAX_INSTALLATIONS_PAGES = 10;
+
+// ---------------------------------------------------------------------------
+// GitHub API response shapes (narrow subsets we consume)
+// ---------------------------------------------------------------------------
+
+interface UserTokenResponse {
+  readonly access_token?: string;
+  readonly token_type?: string;
+  readonly scope?: string;
+  readonly error?: string;
+  readonly error_description?: string;
+}
+
+interface UserInstallationsResponse {
+  readonly total_count?: number;
+  readonly installations?: ReadonlyArray<{
+    readonly id?: number;
+    readonly account?: {
+      readonly login?: string;
+      readonly type?: string;
+    };
+  }>;
+}
+
+/** The owning account of a verified installation, surfaced for admin-UI display. */
+export interface InstallationOwnership {
+  readonly login: string | null;
+  readonly type: string | null;
+}
+
+async function fetchWithTimeout(
+  url: string,
+  init: RequestInit,
+  timeoutMs: number,
+  fetchImpl: typeof globalThis.fetch | undefined,
+): Promise<Response> {
+  const fetcher = fetchImpl ?? globalThis.fetch;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetcher(url, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Exchange the user OAuth `code` for a user access token. GitHub's
+ * OAuth-during-install flow uses the standard
+ * `https://github.com/login/oauth/access_token` endpoint with
+ * `client_id` + `client_secret` + `code`. Returns the parsed
+ * `access_token`; throws {@link PlatformOAuthExchangeError} on any non-success
+ * path. The error is attributed to `platform` so the route surfaces the right
+ * catalog row.
+ */
+export async function exchangeUserCodeForToken(args: {
+  readonly clientId: string;
+  readonly clientSecret: string;
+  readonly code: string;
+  readonly redirectUri: string;
+  readonly platform: string;
+  readonly fetchImpl?: typeof globalThis.fetch;
+}): Promise<string> {
+  let resp: Response;
+  try {
+    resp = await fetchWithTimeout(
+      USER_OAUTH_TOKEN_URL,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded",
+          Accept: "application/json",
+        },
+        body: new URLSearchParams({
+          client_id: args.clientId,
+          client_secret: args.clientSecret,
+          code: args.code,
+          redirect_uri: args.redirectUri,
+        }).toString(),
+      },
+      INSTALL_FETCH_TIMEOUT_MS,
+      args.fetchImpl,
+    );
+  } catch (err) {
+    const isAbort = err instanceof Error && err.name === "AbortError";
+    log.warn(
+      { err: err instanceof Error ? err.message : String(err), timedOut: isAbort },
+      isAbort
+        ? "GitHub user-OAuth token endpoint timed out"
+        : "GitHub user-OAuth token endpoint unreachable",
+    );
+    throw new PlatformOAuthExchangeError({
+      message: isAbort
+        ? "GitHub token endpoint timed out. Restart the install."
+        : "Failed to reach GitHub token endpoint. Restart the install.",
+      platform: args.platform,
+      upstreamError: isAbort ? "timeout" : err instanceof Error ? err.message : String(err),
+    });
+  }
+
+  let parsed: UserTokenResponse;
+  try {
+    parsed = (await resp.json()) as UserTokenResponse;
+  } catch {
+    throw new PlatformOAuthExchangeError({
+      message: "GitHub returned an unparseable token response. Restart the install.",
+      platform: args.platform,
+      upstreamError: `non-json ${resp.status}`,
+    });
+  }
+
+  if (!resp.ok || typeof parsed.access_token !== "string" || parsed.access_token.length === 0) {
+    throw new PlatformOAuthExchangeError({
+      message: "GitHub rejected the OAuth code. Restart the install.",
+      platform: args.platform,
+      upstreamError: parsed.error ?? `http_${resp.status}`,
+    });
+  }
+  return parsed.access_token;
+}
+
+/**
+ * Walk `/user/installations` looking for `targetInstallationId`. Returns the
+ * matching installation's account info when found, or `null` when the user does
+ * NOT have access to that installation — the signal that the callback was
+ * tampered.
+ *
+ * GitHub paginates this endpoint; we follow the `Link: <…>; rel="next"` header
+ * up to {@link MAX_INSTALLATIONS_PAGES}. A user with more installations than
+ * that and the target in a later page fails closed — acceptable; the operator
+ * can raise the cap if needed.
+ */
+export async function findUserInstallation(
+  userAccessToken: string,
+  targetInstallationId: string,
+  opts: { readonly platform: string; readonly fetchImpl?: typeof globalThis.fetch },
+): Promise<InstallationOwnership | null> {
+  let url: string | null = `${USER_INSTALLATIONS_URL}?per_page=100`;
+  let page = 0;
+  while (url !== null && page < MAX_INSTALLATIONS_PAGES) {
+    page++;
+    let resp: Response;
+    try {
+      resp = await fetchWithTimeout(
+        url,
+        {
+          method: "GET",
+          headers: {
+            Authorization: `Bearer ${userAccessToken}`,
+            Accept: "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+          },
+        },
+        INSTALL_FETCH_TIMEOUT_MS,
+        opts.fetchImpl,
+      );
+    } catch (err) {
+      const isAbort = err instanceof Error && err.name === "AbortError";
+      throw new PlatformOAuthExchangeError({
+        message: isAbort
+          ? "GitHub API timed out while verifying installation ownership. Restart the install."
+          : "Failed to reach GitHub API while verifying installation ownership. Restart the install.",
+        platform: opts.platform,
+        upstreamError: isAbort ? "timeout" : err instanceof Error ? err.message : String(err),
+      });
+    }
+
+    if (!resp.ok) {
+      throw new PlatformOAuthExchangeError({
+        message: "GitHub rejected the user-installations lookup. Restart the install.",
+        platform: opts.platform,
+        upstreamError: `user_installations_http_${resp.status}`,
+      });
+    }
+
+    let parsed: UserInstallationsResponse;
+    try {
+      parsed = (await resp.json()) as UserInstallationsResponse;
+    } catch (err) {
+      throw new PlatformOAuthExchangeError({
+        message: "GitHub returned an unparseable user-installations response. Restart the install.",
+        platform: opts.platform,
+        upstreamError: err instanceof Error ? err.message : String(err),
+      });
+    }
+
+    const match = parsed.installations?.find(
+      (i) => typeof i.id === "number" && String(i.id) === targetInstallationId,
+    );
+    if (match) {
+      return {
+        login: typeof match.account?.login === "string" ? match.account.login : null,
+        type: typeof match.account?.type === "string" ? match.account.type : null,
+      };
+    }
+    url = parseNextLinkHeader(resp.headers.get("link"));
+  }
+  return null;
+}
+
+/**
+ * Parse the `Link` header per RFC 5988 / GitHub pagination — extracts the
+ * `rel="next"` URL or returns null when absent. Permissive parser: any malformed
+ * segment is silently skipped, since GitHub's emitter is standardized but
+ * downstream proxies sometimes mangle whitespace.
+ */
+function parseNextLinkHeader(header: string | null): string | null {
+  if (!header) return null;
+  for (const segment of header.split(",")) {
+    const match = segment.match(/<([^>]+)>\s*;\s*rel="next"/);
+    if (match && typeof match[1] === "string") return match[1];
+  }
+  return null;
+}

--- a/packages/api/src/lib/integrations/install/github-app-oauth.ts
+++ b/packages/api/src/lib/integrations/install/github-app-oauth.ts
@@ -233,6 +233,18 @@ export async function findUserInstallation(
     }
     url = parseNextLinkHeader(resp.headers.get("link"));
   }
+  // Two ways out of the loop, with very different meanings — log the cap-hit so
+  // a legitimate user whose target sits past the cap (whom we fail closed below,
+  // surfacing the same "not owned" error as a genuine cross-tenant tamper) is
+  // diagnosable from logs rather than from a confused operator. `url !== null`
+  // means we stopped because we hit MAX_INSTALLATIONS_PAGES with more pages left.
+  if (url !== null) {
+    log.warn(
+      { platform: opts.platform, pagesWalked: page, installationIdTail: targetInstallationId.slice(-4) },
+      "Installation-ownership walk hit the page cap without matching — failing closed. " +
+        "If a legitimate user owns many installations, raise MAX_INSTALLATIONS_PAGES.",
+    );
+  }
   return null;
 }
 

--- a/packages/api/src/lib/integrations/install/github-oauth-handler.ts
+++ b/packages/api/src/lib/integrations/install/github-oauth-handler.ts
@@ -68,6 +68,10 @@ import {
   verifyOAuthStateToken,
 } from "./oauth-state-token";
 import {
+  exchangeUserCodeForToken,
+  findUserInstallation,
+} from "./github-app-oauth";
+import {
   GITHUB_APP_SECRET_FIELDS_SCHEMA,
   GITHUB_CATALOG_ID,
   GitHubInstallationConfigSchema,
@@ -89,14 +93,6 @@ export const GITHUB_SLUG: CatalogId = "github";
 export { GITHUB_CATALOG_ID };
 
 const APP_INSTALL_URL_BASE = "https://github.com/apps";
-const USER_OAUTH_TOKEN_URL = "https://github.com/login/oauth/access_token";
-const USER_INSTALLATIONS_URL = "https://api.github.com/user/installations";
-
-/** Hard timeout on install-time GitHub round-trips — see Jira sibling. */
-const INSTALL_FETCH_TIMEOUT_MS = 15_000;
-
-/** Cap on `/user/installations` pages we'll walk before giving up. */
-const MAX_INSTALLATIONS_PAGES = 10;
 
 /**
  * Operator-side GitHub App config. Read once from env in `register.ts`
@@ -135,211 +131,6 @@ export interface GitHubOAuthHandlerConfig {
    * AND "Callback URL" (since user-OAuth-during-install is required).
    */
   readonly redirectUri: string;
-}
-
-// ---------------------------------------------------------------------------
-// GitHub API response shapes (narrow subsets we consume)
-// ---------------------------------------------------------------------------
-
-interface UserTokenResponse {
-  readonly access_token?: string;
-  readonly token_type?: string;
-  readonly scope?: string;
-  readonly error?: string;
-  readonly error_description?: string;
-}
-
-interface UserInstallationsResponse {
-  readonly total_count?: number;
-  readonly installations?: ReadonlyArray<{
-    readonly id?: number;
-    readonly account?: {
-      readonly login?: string;
-      readonly type?: string;
-    };
-  }>;
-}
-
-async function fetchWithTimeout(
-  url: string,
-  init: RequestInit,
-  timeoutMs: number,
-): Promise<Response> {
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), timeoutMs);
-  try {
-    return await fetch(url, { ...init, signal: controller.signal });
-  } finally {
-    clearTimeout(timer);
-  }
-}
-
-/**
- * Exchange the user OAuth `code` for a user access token. GitHub's
- * OAuth-during-install flow uses the standard
- * `https://github.com/login/oauth/access_token` endpoint with
- * `client_id` + `client_secret` + `code`. Returns the parsed
- * `access_token`; throws `PlatformOAuthExchangeError` on any
- * non-success path.
- */
-async function exchangeUserCodeForToken(args: {
-  readonly clientId: string;
-  readonly clientSecret: string;
-  readonly code: string;
-  readonly redirectUri: string;
-}): Promise<string> {
-  let resp: Response;
-  try {
-    resp = await fetchWithTimeout(
-      USER_OAUTH_TOKEN_URL,
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/x-www-form-urlencoded",
-          Accept: "application/json",
-        },
-        body: new URLSearchParams({
-          client_id: args.clientId,
-          client_secret: args.clientSecret,
-          code: args.code,
-          redirect_uri: args.redirectUri,
-        }).toString(),
-      },
-      INSTALL_FETCH_TIMEOUT_MS,
-    );
-  } catch (err) {
-    const isAbort = err instanceof Error && err.name === "AbortError";
-    log.warn(
-      {
-        err: err instanceof Error ? err.message : String(err),
-        timedOut: isAbort,
-      },
-      isAbort
-        ? "GitHub user-OAuth token endpoint timed out"
-        : "GitHub user-OAuth token endpoint unreachable",
-    );
-    throw new PlatformOAuthExchangeError({
-      message: isAbort
-        ? "GitHub token endpoint timed out. Restart the install."
-        : "Failed to reach GitHub token endpoint. Restart the install.",
-      platform: GITHUB_SLUG,
-      upstreamError: isAbort ? "timeout" : err instanceof Error ? err.message : String(err),
-    });
-  }
-
-  let parsed: UserTokenResponse;
-  try {
-    parsed = (await resp.json()) as UserTokenResponse;
-  } catch {
-    throw new PlatformOAuthExchangeError({
-      message: "GitHub returned an unparseable token response. Restart the install.",
-      platform: GITHUB_SLUG,
-      upstreamError: `non-json ${resp.status}`,
-    });
-  }
-
-  if (!resp.ok || typeof parsed.access_token !== "string" || parsed.access_token.length === 0) {
-    throw new PlatformOAuthExchangeError({
-      message: "GitHub rejected the OAuth code. Restart the install.",
-      platform: GITHUB_SLUG,
-      upstreamError: parsed.error ?? `http_${resp.status}`,
-    });
-  }
-  return parsed.access_token;
-}
-
-/**
- * Walk `/user/installations` looking for `targetInstallationId`. Returns
- * the matching installation's account info when found, or `null` when
- * the user does NOT have access to that installation — the signal that
- * the callback was tampered.
- *
- * GitHub paginates this endpoint; we follow the `Link: <…>; rel="next"`
- * header up to `MAX_INSTALLATIONS_PAGES` (covers users who belong to
- * hundreds of orgs without unbounded looping). A user with more
- * installations than that limit and the target in a later page will
- * fail closed — acceptable trade-off; the operator can raise the cap
- * if needed.
- */
-async function findUserInstallation(
-  userAccessToken: string,
-  targetInstallationId: string,
-): Promise<{ login: string | null; type: string | null } | null> {
-  let url: string | null = `${USER_INSTALLATIONS_URL}?per_page=100`;
-  let page = 0;
-  while (url !== null && page < MAX_INSTALLATIONS_PAGES) {
-    page++;
-    let resp: Response;
-    try {
-      resp = await fetchWithTimeout(
-        url,
-        {
-          method: "GET",
-          headers: {
-            Authorization: `Bearer ${userAccessToken}`,
-            Accept: "application/vnd.github+json",
-            "X-GitHub-Api-Version": "2022-11-28",
-          },
-        },
-        INSTALL_FETCH_TIMEOUT_MS,
-      );
-    } catch (err) {
-      const isAbort = err instanceof Error && err.name === "AbortError";
-      throw new PlatformOAuthExchangeError({
-        message: isAbort
-          ? "GitHub API timed out while verifying installation ownership. Restart the install."
-          : "Failed to reach GitHub API while verifying installation ownership. Restart the install.",
-        platform: GITHUB_SLUG,
-        upstreamError: isAbort ? "timeout" : err instanceof Error ? err.message : String(err),
-      });
-    }
-
-    if (!resp.ok) {
-      throw new PlatformOAuthExchangeError({
-        message: "GitHub rejected the user-installations lookup. Restart the install.",
-        platform: GITHUB_SLUG,
-        upstreamError: `user_installations_http_${resp.status}`,
-      });
-    }
-
-    let parsed: UserInstallationsResponse;
-    try {
-      parsed = (await resp.json()) as UserInstallationsResponse;
-    } catch (err) {
-      throw new PlatformOAuthExchangeError({
-        message: "GitHub returned an unparseable user-installations response. Restart the install.",
-        platform: GITHUB_SLUG,
-        upstreamError: err instanceof Error ? err.message : String(err),
-      });
-    }
-
-    const match = parsed.installations?.find(
-      (i) => typeof i.id === "number" && String(i.id) === targetInstallationId,
-    );
-    if (match) {
-      return {
-        login: typeof match.account?.login === "string" ? match.account.login : null,
-        type: typeof match.account?.type === "string" ? match.account.type : null,
-      };
-    }
-    url = parseNextLinkHeader(resp.headers.get("link"));
-  }
-  return null;
-}
-
-/**
- * Parse the `Link` header per RFC 5988 / GitHub pagination — extracts
- * the `rel="next"` URL or returns null when absent. Permissive parser:
- * any malformed segment is silently skipped, since GitHub's emitter is
- * standardized but downstream proxies sometimes mangle whitespace.
- */
-function parseNextLinkHeader(header: string | null): string | null {
-  if (!header) return null;
-  for (const segment of header.split(",")) {
-    const match = segment.match(/<([^>]+)>\s*;\s*rel="next"/);
-    if (match && typeof match[1] === "string") return match[1];
-  }
-  return null;
 }
 
 export class GitHubOAuthInstallHandler implements OAuthPlatformInstallHandler {
@@ -434,8 +225,11 @@ export class GitHubOAuthInstallHandler implements OAuthPlatformInstallHandler {
       clientSecret: this.config.clientSecret,
       code,
       redirectUri: this.config.redirectUri,
+      platform: GITHUB_SLUG,
     });
-    const ownership = await findUserInstallation(userToken, installationId);
+    const ownership = await findUserInstallation(userToken, installationId, {
+      platform: GITHUB_SLUG,
+    });
     if (!ownership) {
       log.warn(
         { workspaceId, installationIdTail: installationId.slice(-4) },

--- a/packages/api/src/lib/integrations/install/index.ts
+++ b/packages/api/src/lib/integrations/install/index.ts
@@ -19,6 +19,8 @@ export type {
   CredentialResult,
   FormBasedInstallHandler,
   InstallRecord,
+  OAuthCallbackExtras,
+  OAuthDatasourceInstallHandler,
   OAuthPlatformInstallHandler,
   PlatformInstallHandler,
   StaticBotInstallHandler,
@@ -27,6 +29,7 @@ export type {
 export {
   getInstallHandler,
   registerFormHandler,
+  registerOAuthDatasourceHandler,
   registerOAuthHandler,
   registerStaticBotHandler,
   _resetInstallHandlerRegistries,

--- a/packages/api/src/lib/integrations/install/oauth-datasource-handler.ts
+++ b/packages/api/src/lib/integrations/install/oauth-datasource-handler.ts
@@ -1,0 +1,372 @@
+/**
+ * `OAuthDatasourceInstallHandler` — admin install flow for an OAuth2 REST
+ * datasource (v0.0.2 slice 6c, #3030; the OQ5 deliverable). GitHub-as-datasource
+ * is the first (and today only) consumer.
+ *
+ * ## Why a NEW handler, not a reuse of `OAuthPlatformInstallHandler` (OQ5)
+ * The existing {@link OAuthPlatformInstallHandler} is shaped for chat/action
+ * platforms: single-instance per `(workspace_id, catalog_id)`, credential to
+ * `chat_cache` / a per-plugin store. A *datasource* OAuth install is a different
+ * persistence shape — multi-instance (`install_id` composite PK,
+ * `pillar='datasource'`), credential inline in `workspace_plugins.config` via
+ * selective-field encryption, and a **probe-on-install** that caches the
+ * `openapi_snapshot` so the agent loop resolves the operation surface from the DB
+ * row. So this handler borrows the OAuth *credential-acquisition* primitives
+ * (state token + the GitHub App ownership verification in `github-app-oauth.ts`)
+ * but owns the datasource persistence path — exactly the
+ * {@link import("./openapi-generic-form-handler").persistOpenApiDatasourceInstall}
+ * shape, with OAuth-shaped credential acquisition instead of a form.
+ *
+ * ## GitHub specifics (OQ6 — thin wrapper)
+ * GitHub is a *thin* data wrapper: its only non-generic data dimension
+ * (`Link`-header pagination) is already a generic strategy, so NO GitHub-specific
+ * walker/paginator/validator exists. The GitHub-ness is confined to this install
+ * handler (and the credential resolver), never the query path:
+ *   - credential acquisition reuses GitHub's EXISTING App registration (same
+ *     `GITHUB_APP_*` env as the `github` action row) — no new vendor app,
+ *   - the persisted credential is the `installation_id`; the executable bearer
+ *     token is minted on demand from the App JWT (`github/installation-token.ts`)
+ *     and re-minted transparently on ~1hr expiry — NOT refresh-token rotation.
+ *
+ * ## Partial-failure → reconnect-needed
+ * After persisting the snapshot + installation_id, the handler mints an
+ * installation token once as a credential health-check. A mint failure does NOT
+ * abort the install (the snapshot is good); it persists `config.status =
+ * 'reconnect_needed'` and returns `credentialResult.written = false` so the route
+ * surfaces "Reconnect needed". The query-time resolver re-mints regardless, so a
+ * later-fixed App access recovers without a re-install.
+ *
+ * @see ./types.ts — {@link OAuthDatasourceInstallHandler} interface
+ * @see ./github-app-oauth.ts — shared ownership-verification primitives
+ * @see ../../github/installation-token.ts — App-JWT installation-token minting
+ * @see ./openapi-generic-form-handler.ts — the sibling datasource persistence shape
+ */
+
+import crypto from "crypto";
+import { createLogger } from "@atlas/api/lib/logger";
+import { internalQuery } from "@atlas/api/lib/db/internal";
+import { PlatformOAuthExchangeError } from "@atlas/api/lib/effect/errors";
+import { encryptSecretFields } from "@atlas/api/lib/plugins/secrets";
+import { getEncryptionKeyset } from "@atlas/api/lib/db/encryption-keys";
+import { isPlaintextCredentialRisk } from "@atlas/api/lib/db/secret-encryption";
+import {
+  buildSnapshot,
+  OpenApiProbeError,
+  probeSpec,
+  type ProbeOptions,
+} from "@atlas/api/lib/openapi/probe";
+import { DEFAULT_REPRESENTATION_MODE } from "@atlas/api/lib/openapi/catalog";
+import { getGitHubInstallationToken } from "@atlas/api/lib/github/installation-token";
+import type { WorkspaceId } from "@useatlas/types";
+import {
+  mintOAuthStateToken,
+  verifyOAuthStateToken,
+} from "./oauth-state-token";
+import { exchangeUserCodeForToken, findUserInstallation } from "./github-app-oauth";
+import {
+  GITHUB_APP_SECRET_FIELDS_SCHEMA,
+  GitHubInstallationConfigSchema,
+} from "./github-oauth-secret-schema";
+import type {
+  CatalogId,
+  CredentialResult,
+  InstallRecord,
+  OAuthCallbackExtras,
+  OAuthDatasourceInstallHandler as OAuthDatasourceInstallHandlerShape,
+} from "./types";
+
+const log = createLogger("integrations.install.oauth-datasource");
+
+const APP_INSTALL_URL_BASE = "https://github.com/apps";
+
+/**
+ * Operator + catalog config for an OAuth-datasource install. The GitHub App
+ * fields mirror {@link import("./github-oauth-handler").GitHubOAuthHandlerConfig}
+ * (the action sibling reuses the SAME App registration); the catalog fields
+ * (`slug` / `catalogId` / `openapiUrl`) come from the data-candidate registry so
+ * the pre-wired spec URL is locked — an install can never re-point it.
+ */
+export interface OAuthDatasourceHandlerConfig {
+  /** Catalog slug — dispatch key + value bound into the state token (e.g. "github-data"). */
+  readonly slug: CatalogId;
+  /** Stable `plugin_catalog.id` FK written to the row (e.g. "catalog:github-data"). */
+  readonly catalogId: string;
+  /** Pre-wired OpenAPI 3.x spec URL probed on install — the admin never pastes it. */
+  readonly openapiUrl: string;
+  /** GitHub App slug from `github.com/apps/<slug>` — builds the install URL. */
+  readonly appSlug: string;
+  /** GitHub App id — the `iss` claim for installation-token minting. */
+  readonly appId: string;
+  /** GitHub App OAuth "Client ID" (user-OAuth-during-install). */
+  readonly clientId: string;
+  /** GitHub App OAuth "Client secret". */
+  readonly clientSecret: string;
+  /** GitHub App private key (PKCS8 PEM) — signs the App JWT for the mint. */
+  readonly privateKey: string;
+  /** Public-facing OAuth callback URL — must match the App's Setup/Callback URL. */
+  readonly redirectUri: string;
+}
+
+/** Injected seams — deterministic id/clock/probe-fetch in tests. */
+export interface OAuthDatasourceHandlerOptions {
+  readonly idGenerator?: () => string;
+  /** Returns the ISO-8601 `probedAt` stamp. Defaults to `new Date().toISOString()`. */
+  readonly now?: () => string;
+  /** `fetch` override threaded into ownership verification, the probe, and the mint. */
+  readonly fetchImpl?: typeof globalThis.fetch;
+}
+
+export class OAuthDatasourceInstallHandler implements OAuthDatasourceInstallHandlerShape {
+  readonly kind = "oauth-datasource" as const;
+
+  private readonly newId: () => string;
+  private readonly now: () => string;
+  private readonly fetchImpl: typeof globalThis.fetch | undefined;
+
+  constructor(
+    private readonly config: OAuthDatasourceHandlerConfig,
+    options: OAuthDatasourceHandlerOptions = {},
+  ) {
+    this.newId = options.idGenerator ?? (() => crypto.randomUUID());
+    this.now = options.now ?? (() => new Date().toISOString());
+    this.fetchImpl = options.fetchImpl;
+  }
+
+  async startInstall(workspaceId: WorkspaceId): Promise<{
+    readonly redirectUrl: string;
+    readonly stateToken: string;
+  }> {
+    const stateToken = mintOAuthStateToken(workspaceId, this.config.slug);
+    // Same GitHub App install URL as the action sibling — the dance is identical;
+    // only the callback's persistence differs. The `code` GitHub returns is the
+    // user-OAuth artifact required for the installation-ownership check.
+    const url = new URL(`${APP_INSTALL_URL_BASE}/${this.config.appSlug}/installations/new`);
+    url.searchParams.set("state", stateToken);
+    return { redirectUrl: url.toString(), stateToken };
+  }
+
+  async handleCallback(
+    code: string,
+    stateToken: string,
+    extras?: OAuthCallbackExtras,
+  ): Promise<{
+    readonly workspaceId: WorkspaceId;
+    readonly catalogId: CatalogId;
+    readonly installRecord: InstallRecord;
+    readonly credentialResult: CredentialResult;
+  } | null> {
+    // ── 1. Verify state — null on every failure mode ─────────────
+    const verified = verifyOAuthStateToken(stateToken);
+    if (!verified) return null;
+    if (verified.catalogId !== this.config.slug) {
+      log.warn(
+        { expected: this.config.slug, got: verified.catalogId },
+        "OAuth-datasource callback received state bound to a different catalog — rejecting",
+      );
+      return null;
+    }
+    const workspaceId = verified.workspaceId as WorkspaceId;
+
+    // ── 2. Require both installation_id and the user-OAuth code ──
+    const installationIdRaw = extras?.installationId;
+    if (typeof installationIdRaw !== "string" || installationIdRaw.length === 0) {
+      throw new PlatformOAuthExchangeError({
+        message:
+          "GitHub install callback was missing installation_id. Ensure your GitHub App's Setup URL matches the Atlas callback and the App has been installed.",
+        platform: this.config.slug,
+        upstreamError: "missing_installation_id",
+      });
+    }
+    if (typeof code !== "string" || code.length === 0) {
+      throw new PlatformOAuthExchangeError({
+        message:
+          'GitHub install callback was missing the OAuth code. Enable "Request user authorization (OAuth) during installation" on your GitHub App and restart.',
+        platform: this.config.slug,
+        upstreamError: "missing_code",
+      });
+    }
+
+    // ── 3. Validate installation_id shape ────────────────────────
+    const parsedConfig = GitHubInstallationConfigSchema.safeParse({
+      installation_id: installationIdRaw,
+    });
+    if (!parsedConfig.success) {
+      throw new PlatformOAuthExchangeError({
+        message:
+          "GitHub returned an unexpected installation_id. Restart the install from your Atlas admin.",
+        platform: this.config.slug,
+        upstreamError: "invalid_installation_id",
+      });
+    }
+    const installationId = parsedConfig.data.installation_id;
+
+    // ── 4. Verify the installing user OWNS this installation ─────
+    // Cross-tenant binding guard (shared with the action sibling): the state
+    // token gates the workspace binding, NOT the installation binding — a
+    // tampered callback could substitute an installation_id the user doesn't own.
+    const userToken = await exchangeUserCodeForToken({
+      clientId: this.config.clientId,
+      clientSecret: this.config.clientSecret,
+      code,
+      redirectUri: this.config.redirectUri,
+      platform: this.config.slug,
+      ...(this.fetchImpl ? { fetchImpl: this.fetchImpl } : {}),
+    });
+    const ownership = await findUserInstallation(userToken, installationId, {
+      platform: this.config.slug,
+      ...(this.fetchImpl ? { fetchImpl: this.fetchImpl } : {}),
+    });
+    if (!ownership) {
+      log.warn(
+        { workspaceId, installationIdTail: installationId.slice(-4) },
+        "OAuth-datasource install ownership check FAILED — user does not have access to the supplied installation (possible tampered callback)",
+      );
+      throw new PlatformOAuthExchangeError({
+        message:
+          "The GitHub user authorizing this install does not have access to the supplied installation. Restart the install and grant access to your target organization.",
+        platform: this.config.slug,
+        upstreamError: "installation_not_owned",
+      });
+    }
+
+    // ── 5. SaaS keyset gate — refuse to persist plaintext ────────
+    if (process.env.ATLAS_DEPLOY_MODE === "saas" && !getEncryptionKeyset()) {
+      log.error(
+        { workspaceId, slug: this.config.slug },
+        "Refusing OAuth-datasource install: SaaS mode + no encryption keyset (would persist plaintext installation_id)",
+      );
+      throw new Error(
+        "Encryption keyset unavailable in SaaS mode — refusing to persist plaintext credentials. Set ATLAS_ENCRYPTION_KEYS and retry.",
+      );
+    }
+    // Self-hosted prod-like deploy with no keyset is allowed (dev passthrough)
+    // but must not be silent — mirror the boot-time P0 alarm.
+    if (isPlaintextCredentialRisk()) {
+      log.warn(
+        { workspaceId, slug: this.config.slug },
+        "Persisting a GitHub installation_id with no encryption keyset configured in a prod-like " +
+          "environment — it will be stored in plaintext. Set ATLAS_ENCRYPTION_KEYS to encrypt at rest.",
+      );
+    }
+
+    // ── 6. Probe the pre-wired spec → snapshot ───────────────────
+    // The GitHub OpenAPI spec is public, so the probe needs no credential. A
+    // probe failure is a hard install failure (no snapshot ⇒ no datasource).
+    let snapshot;
+    try {
+      const probeOpts: ProbeOptions = this.fetchImpl ? { fetchImpl: this.fetchImpl } : {};
+      const { doc, graph } = await probeSpec(this.config.openapiUrl, { kind: "none" }, probeOpts);
+      snapshot = buildSnapshot(doc, graph, this.now());
+    } catch (err) {
+      if (err instanceof OpenApiProbeError) {
+        log.error(
+          { workspaceId, slug: this.config.slug, reason: err.reason },
+          "OAuth-datasource install spec probe failed — aborting install",
+        );
+        throw new PlatformOAuthExchangeError({
+          message: `Could not read the ${this.config.slug} OpenAPI spec (${err.reason}). Try the install again; if it persists, the upstream spec may be temporarily unavailable.`,
+          platform: this.config.slug,
+          upstreamError: "spec_probe_failed",
+        });
+      }
+      throw err;
+    }
+
+    // ── 7. Health-check mint (credential validity) ───────────────
+    // Mint an installation token once to confirm the App can actually mint for
+    // this installation. A failure does NOT abort — the snapshot is good — but
+    // flips the install to "reconnect needed".
+    let credentialStatus: "ok" | "reconnect_needed" = "ok";
+    let credentialResult: CredentialResult = { written: true };
+    try {
+      await getGitHubInstallationToken(installationId, {
+        appId: this.config.appId,
+        privateKey: this.config.privateKey,
+        ...(this.fetchImpl ? { fetchImpl: this.fetchImpl } : {}),
+      });
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      log.warn(
+        { workspaceId, slug: this.config.slug, installationIdTail: installationId.slice(-4) },
+        "OAuth-datasource install health-check mint failed — persisting as reconnect-needed",
+      );
+      credentialStatus = "reconnect_needed";
+      credentialResult = {
+        written: false,
+        reason: "Connected, but Atlas could not mint a GitHub access token yet — reconnect to retry.",
+      };
+      // `reason` is operator-facing; the raw error stays in logs only.
+      log.debug({ workspaceId, slug: this.config.slug, mintError: reason }, "mint failure detail");
+    }
+
+    // ── 8. Assemble + encrypt config (installation_id is the secret) ──
+    const rawConfig: Record<string, unknown> = {
+      installation_id: installationId,
+      auth_kind: "oauth2",
+      openapi_url: this.config.openapiUrl,
+      representation_mode: DEFAULT_REPRESENTATION_MODE,
+      display_name: snapshot.title,
+      status: credentialStatus,
+      openapi_snapshot: snapshot,
+      ...(ownership.login ? { account_login: ownership.login } : {}),
+      ...(ownership.type ? { account_type: ownership.type } : {}),
+    };
+    const encryptedConfig = encryptSecretFields(rawConfig, GITHUB_APP_SECRET_FIELDS_SCHEMA);
+
+    // ── 9. Insert a fresh multi-instance datasource row ──────────
+    // Same UUID for `id` + `install_id`; fresh every submit (multi-instance).
+    // `status='draft'` (content-mode) surfaces the pending-changes pill for the
+    // atomic publish flow — distinct from `config.status` (credential health).
+    const installId = this.newId();
+    let persistedId: string;
+    try {
+      const rows = await internalQuery<{ id: string }>(
+        `INSERT INTO workspace_plugins
+           (id, workspace_id, catalog_id, install_id, pillar, config, enabled, status, installed_at, updated_at)
+         VALUES ($1, $2, $3, $1, 'datasource', $4::jsonb, true, 'draft', NOW(), NOW())
+         ON CONFLICT (workspace_id, catalog_id, install_id) DO UPDATE
+           SET config = EXCLUDED.config,
+               enabled = true,
+               updated_at = NOW()
+         RETURNING id`,
+        [installId, workspaceId, this.config.catalogId, JSON.stringify(encryptedConfig)],
+      );
+      const returned = rows[0]?.id;
+      if (typeof returned !== "string" || returned.length === 0) {
+        log.error(
+          { workspaceId, slug: this.config.slug, installId },
+          "workspace_plugins upsert returned no id — Postgres invariant violation",
+        );
+        throw new Error(
+          "workspace_plugins upsert returned no id from RETURNING — likely a driver/RLS/query-rewrite anomaly",
+        );
+      }
+      persistedId = returned;
+    } catch (err) {
+      log.error(
+        { workspaceId, slug: this.config.slug, installId, err: err instanceof Error ? err.message : String(err) },
+        "Failed to persist OAuth-datasource install record — aborting install",
+      );
+      throw err;
+    }
+
+    log.info(
+      {
+        workspaceId,
+        slug: this.config.slug,
+        installId: persistedId,
+        operationCount: snapshot.operationCount,
+        accountLogin: ownership.login,
+        credentialStatus,
+      },
+      "OAuth-datasource install completed",
+    );
+
+    const installRecord: InstallRecord = {
+      id: persistedId,
+      workspaceId,
+      catalogId: this.config.slug,
+    };
+    return { workspaceId, catalogId: this.config.slug, installRecord, credentialResult };
+  }
+}

--- a/packages/api/src/lib/integrations/install/register.ts
+++ b/packages/api/src/lib/integrations/install/register.ts
@@ -19,6 +19,7 @@
 import { createLogger } from "@atlas/api/lib/logger";
 import {
   registerFormHandler,
+  registerOAuthDatasourceHandler,
   registerOAuthHandler,
   registerStaticBotHandler,
 } from "./dispatch";
@@ -28,7 +29,11 @@ import { ObsidianFormInstallHandler } from "./obsidian-form-handler";
 import { OpenApiGenericFormInstallHandler } from "./openapi-generic-form-handler";
 import { OPENAPI_GENERIC_SLUG } from "@atlas/api/lib/openapi/catalog";
 import { DataCandidateFormInstallHandler } from "./data-candidate-form-handler";
-import { DATA_CANDIDATES } from "@atlas/api/lib/openapi/data-candidates";
+import { OAuthDatasourceInstallHandler } from "./oauth-datasource-handler";
+import {
+  DATA_CANDIDATES,
+  isOAuthDatasourceCandidate,
+} from "@atlas/api/lib/openapi/data-candidates";
 import { WebhookFormInstallHandler } from "./webhook-form-handler";
 import { TwentyFormInstallHandler, TWENTY_SLUG } from "./twenty-form-handler";
 import {
@@ -157,15 +162,18 @@ export function registerBuiltinInstallHandlers(): void {
   registerFormHandler(OPENAPI_GENERIC_SLUG, new OpenApiGenericFormInstallHandler());
   log.info("Registered OpenApiGenericFormInstallHandler");
   // Built-in vendor *-data candidates (#3028). Each is a thin pre-wired wrapper
-  // over the generic OpenAPI primitive — same form-handler shape, no env gate
-  // (the admin supplies the credential at install). One handler per candidate,
-  // registered under its slug (e.g. "stripe-data"). Adding a candidate is a
-  // one-line registry entry (data-candidates.ts), not a new handler class.
-  for (const candidate of DATA_CANDIDATES) {
+  // over the generic OpenAPI primitive. FORM candidates (Stripe, Notion) register
+  // a `DataCandidateFormInstallHandler` with no env gate (the admin supplies the
+  // credential at install). OAUTH-DATASOURCE candidates (github-data, #3030) need
+  // operator App env, so they register separately below. Adding a form candidate
+  // is a one-line registry entry (data-candidates.ts), not a new handler class.
+  const formCandidates = DATA_CANDIDATES.filter((c) => !isOAuthDatasourceCandidate(c));
+  for (const candidate of formCandidates) {
+    if (isOAuthDatasourceCandidate(candidate)) continue; // narrow for TS — handled below
     registerFormHandler(candidate.slug, new DataCandidateFormInstallHandler(candidate));
   }
   log.info(
-    { candidates: DATA_CANDIDATES.map((c) => c.slug) },
+    { candidates: formCandidates.map((c) => c.slug) },
     "Registered DataCandidateFormInstallHandler(s)",
   );
   registerFormHandler("webhook", new WebhookFormInstallHandler());
@@ -215,6 +223,9 @@ export function registerBuiltinInstallHandlers(): void {
   registerSalesforceOAuthHandler();
   registerGitHubAppOAuthHandler();
   registerGitHubSingleTenantOAuthHandler();
+  // GitHub-as-datasource (#3030) — OAuth-datasource install reusing the SAME
+  // GitHub App registration as the action `github` row. Env-gated identically.
+  registerGitHubDataOAuthDatasourceHandler();
 
   // ── Static-bot platforms (1.5.3 — Phase D, #2748+) ────────────────
   // Telegram (#2748 keystone), Discord (#2749), Teams (#2752), and
@@ -832,6 +843,78 @@ function registerGitHubSingleTenantOAuthHandler(): void {
   log.info(
     { publicApiUrl, appSlug },
     "Registered GitHubSingleTenantOAuthInstallHandler (no lazy builder yet — agent tool ships in follow-up)",
+  );
+}
+
+/**
+ * Register the GitHub-as-datasource OAuth-datasource handler (#3030 — the OQ5
+ * deliverable) when the operator's GitHub App env is wired. Reuses the SAME App
+ * registration as the multi-tenant `github` action row (`GITHUB_APP_*`), so a
+ * deploy that runs GitHub-as-action gets GitHub-as-datasource for free. The
+ * credential it acquires (installation_id) is persisted as a datasource install;
+ * its bearer token is minted on demand from the App JWT (`installation-token.ts`)
+ * at query time — `GITHUB_APP_PRIVATE_KEY` is required for that mint, hence gated
+ * here too.
+ */
+function registerGitHubDataOAuthDatasourceHandler(): void {
+  const candidate = DATA_CANDIDATES.find(isOAuthDatasourceCandidate);
+  if (!candidate) return; // no oauth-datasource candidate in the registry
+
+  const appId = process.env.GITHUB_APP_ID;
+  const appSlug = process.env.GITHUB_APP_SLUG;
+  const privateKey = process.env.GITHUB_APP_PRIVATE_KEY;
+  const clientId = process.env.GITHUB_APP_CLIENT_ID;
+  const clientSecret = process.env.GITHUB_APP_CLIENT_SECRET;
+  const publicApiUrl = resolvePublicApiUrl();
+
+  const required = {
+    GITHUB_APP_ID: appId,
+    GITHUB_APP_SLUG: appSlug,
+    GITHUB_APP_PRIVATE_KEY: privateKey,
+    GITHUB_APP_CLIENT_ID: clientId,
+    GITHUB_APP_CLIENT_SECRET: clientSecret,
+  };
+  const missing = Object.entries(required)
+    .filter(([, v]) => !v)
+    .map(([k]) => k);
+
+  if (missing.length > 0) {
+    if (isCatalogSlugEnabled(candidate.slug)) {
+      log.error(
+        { slug: candidate.slug, requiredEnv: Object.keys(required), missing },
+        "github-data catalog row is enabled but one of GITHUB_APP_ID / GITHUB_APP_SLUG / GITHUB_APP_PRIVATE_KEY / GITHUB_APP_CLIENT_ID / GITHUB_APP_CLIENT_SECRET is unset — the github-data install route will return 501 until configured.",
+      );
+    } else {
+      log.info(
+        "github-data OAuth-datasource handler not registered — required env unset and the 'github-data' catalog row is not enabled (operator hasn't opted in).",
+      );
+    }
+    return;
+  }
+  if (!publicApiUrl) {
+    log.warn(
+      "github-data OAuth-datasource handler not registered — ATLAS_PUBLIC_API_URL is unset, so the redirect URI cannot be resolved.",
+    );
+    return;
+  }
+
+  registerOAuthDatasourceHandler(
+    candidate.slug,
+    new OAuthDatasourceInstallHandler({
+      slug: candidate.slug,
+      catalogId: candidate.catalogId,
+      openapiUrl: candidate.openapiUrl,
+      appId: appId!,
+      appSlug: appSlug!,
+      clientId: clientId!,
+      clientSecret: clientSecret!,
+      privateKey: privateKey!,
+      redirectUri: `${publicApiUrl}/api/v1/integrations/${candidate.slug}/callback`,
+    }),
+  );
+  log.info(
+    { publicApiUrl, appSlug, slug: candidate.slug },
+    "Registered OAuthDatasourceInstallHandler for github-data",
   );
 }
 

--- a/packages/api/src/lib/integrations/install/register.ts
+++ b/packages/api/src/lib/integrations/install/register.ts
@@ -32,6 +32,7 @@ import { DataCandidateFormInstallHandler } from "./data-candidate-form-handler";
 import { OAuthDatasourceInstallHandler } from "./oauth-datasource-handler";
 import {
   DATA_CANDIDATES,
+  GITHUB_DATA_CANDIDATE,
   isOAuthDatasourceCandidate,
 } from "@atlas/api/lib/openapi/data-candidates";
 import { WebhookFormInstallHandler } from "./webhook-form-handler";
@@ -857,8 +858,11 @@ function registerGitHubSingleTenantOAuthHandler(): void {
  * here too.
  */
 function registerGitHubDataOAuthDatasourceHandler(): void {
-  const candidate = DATA_CANDIDATES.find(isOAuthDatasourceCandidate);
-  if (!candidate) return; // no oauth-datasource candidate in the registry
+  // Pinned to the github-data candidate specifically — NOT
+  // `DATA_CANDIDATES.find(isOAuthDatasourceCandidate)`, which would hand a future
+  // second oauth-datasource vendor GitHub's env gate + callback wiring. Each new
+  // oauth-datasource vendor must get its own dedicated registration helper.
+  const candidate = GITHUB_DATA_CANDIDATE;
 
   const appId = process.env.GITHUB_APP_ID;
   const appSlug = process.env.GITHUB_APP_SLUG;

--- a/packages/api/src/lib/integrations/install/types.ts
+++ b/packages/api/src/lib/integrations/install/types.ts
@@ -151,6 +151,83 @@ export interface OAuthCallbackExtras {
 }
 
 // ---------------------------------------------------------------------------
+// OAuth-datasource install handler
+// ---------------------------------------------------------------------------
+
+/**
+ * Handler for `install_model: "oauth-datasource"` catalog entries — the OAuth2
+ * dimension of the generic OpenAPI Datasource primitive (v0.0.2 slice 6c, #3030;
+ * the OQ5 deliverable). GitHub-as-datasource is the first consumer.
+ *
+ * Wire shape is method-compatible with {@link OAuthPlatformInstallHandler}
+ * (`startInstall` → redirect, `handleCallback` → install+credential result), so
+ * the integrations route drives BOTH through one HTTP dance (`/install` →
+ * provider consent → `/callback`). What differs is the PERSISTENCE shape, and
+ * that difference is the whole reason this is a distinct handler family rather
+ * than a reuse of {@link OAuthPlatformInstallHandler} (OQ5 resolution):
+ *
+ *   1. **Multi-instance.** Like {@link FormBasedInstallHandler}'s datasource
+ *      installs (`OpenApiGenericFormInstallHandler`), each install mints a fresh
+ *      `install_id` (composite PK `(workspace_id, catalog_id, install_id)`) under
+ *      `pillar='datasource'` — NOT the single-instance
+ *      `(workspace_id, catalog_id)` chat/action singleton an
+ *      {@link OAuthPlatformInstallHandler} writes.
+ *   2. **Credential in `workspace_plugins.config`.** The credential is written
+ *      inline via selective-field encryption (`encryptSecretFields`,
+ *      `secret: true`), NOT to `chat_cache` / a per-plugin store.
+ *   3. **Probe-on-install.** It fetches the (pre-wired, code-resident) OpenAPI
+ *      spec and caches the normalized `openapi_snapshot` in config so the agent
+ *      loop resolves the operation surface from the DB row, never a live re-probe.
+ *
+ * The OAuth credential acquisition itself REUSES the provider's existing App
+ * registration (GitHub: `github-app-oauth.ts` ownership verification + the same
+ * `GITHUB_APP_*` env), so no new vendor app is stood up. The "refresh" path is
+ * App-JWT installation-token minting (`github/installation-token.ts`), minted on
+ * demand and re-minted transparently on ~1hr expiry — not refresh-token rotation.
+ *
+ * Per-handler return-shape note mirrors {@link OAuthPlatformInstallHandler}: a
+ * partial install (row written, credential health-check failed) returns
+ * `credentialResult.written: false` so the route surfaces "Reconnect needed".
+ */
+export interface OAuthDatasourceInstallHandler {
+  readonly kind: "oauth-datasource";
+
+  /**
+   * Begin the OAuth dance. Mints a CSRF state token bound to
+   * `(workspaceId, catalogId)` and returns the provider's authorize/install URL
+   * with that state baked in — same contract as
+   * {@link OAuthPlatformInstallHandler.startInstall}.
+   */
+  startInstall(workspaceId: WorkspaceId): Promise<{
+    readonly redirectUrl: string;
+    readonly stateToken: string;
+  }>;
+
+  /**
+   * Handle the OAuth callback. Verifies the state token, completes provider-side
+   * credential acquisition (GitHub: user-OAuth-code ownership verification +
+   * installation-token health-check mint), probes the pre-wired spec to cache an
+   * `openapi_snapshot`, then writes the datasource install record + encrypted
+   * credential to `workspace_plugins.config`.
+   *
+   * Returns `null` on state-token failure (forged, expired, replayed). Bubbles a
+   * tagged error on provider-side failures so the route surfaces an actionable
+   * user error. `extras` carries provider-specific callback params (GitHub's
+   * `installation_id`), same slot as {@link OAuthPlatformInstallHandler}.
+   */
+  handleCallback(
+    code: string,
+    stateToken: string,
+    extras?: OAuthCallbackExtras,
+  ): Promise<{
+    readonly workspaceId: WorkspaceId;
+    readonly catalogId: CatalogId;
+    readonly installRecord: InstallRecord;
+    readonly credentialResult: CredentialResult;
+  } | null>;
+}
+
+// ---------------------------------------------------------------------------
 // Form-based install handler
 // ---------------------------------------------------------------------------
 
@@ -283,7 +360,8 @@ export interface StaticBotInstallHandler {
 export type PlatformInstallHandler =
   | OAuthPlatformInstallHandler
   | FormBasedInstallHandler
-  | StaticBotInstallHandler;
+  | StaticBotInstallHandler
+  | OAuthDatasourceInstallHandler;
 
 /**
  * Subset of the catalog row that the dispatch needs — kept narrow so

--- a/packages/api/src/lib/openapi/__tests__/data-candidate-seed.test.ts
+++ b/packages/api/src/lib/openapi/__tests__/data-candidate-seed.test.ts
@@ -1,7 +1,9 @@
 /**
- * Tests for the data-candidate catalog seed (v0.0.2 slice 6a, #3028): per-row
- * idempotency via a capturing mock db, and migration 0109 ↔ code alignment.
- * Mirrors `catalog-seed.test.ts` for the generic row.
+ * Tests for the data-candidate catalog seed (v0.0.2 slice 6a #3028, extended in
+ * 6c #3030): per-row idempotency via a capturing mock db, per-candidate
+ * install_model + config_schema binding, and migration ↔ code alignment for both
+ * the Stripe (0109, form) and GitHub (0111, oauth-datasource) rows. Mirrors
+ * `catalog-seed.test.ts` for the generic row.
  */
 import { describe, it, expect } from "bun:test";
 import * as fs from "fs";
@@ -11,6 +13,8 @@ import type { OpenApiDatasourceCatalogSeedDb } from "../catalog-seed";
 import {
   DATA_CANDIDATES,
   DATA_CANDIDATE_CONFIG_SCHEMA,
+  GITHUB_DATA_CANDIDATE,
+  OAUTH_DATASOURCE_CONFIG_SCHEMA,
   STRIPE_DATA_CANDIDATE,
 } from "../data-candidates";
 
@@ -29,22 +33,42 @@ function captureDb(returnRowsPerCall: (callIndex: number) => Array<{ slug: strin
   return { db, calls };
 }
 
+/** Find the captured INSERT for a given candidate catalog id. */
+function callForCatalogId(
+  calls: Array<{ sql: string; params?: unknown[] }>,
+  catalogId: string,
+): { sql: string; params?: unknown[] } {
+  const call = calls.find((c) => c.params?.[0] === catalogId);
+  expect(call).toBeDefined();
+  return call!;
+}
+
 describe("seedDataCandidateCatalog", () => {
-  it("INSERTs each candidate row with the canonical id/slug + shared schema", async () => {
-    const { db, calls } = captureDb(() => [{ slug: STRIPE_DATA_CANDIDATE.slug }]);
+  it("INSERTs each candidate row with its catalog id/slug + per-candidate install_model + config_schema", async () => {
+    const { db, calls } = captureDb(() => [{ slug: "x" }]);
     const result = await seedDataCandidateCatalog(db);
 
     expect(result.insertedSlugs).toEqual(DATA_CANDIDATES.map((c) => c.slug));
     expect(calls).toHaveLength(DATA_CANDIDATES.length);
 
-    const { sql, params } = calls[0];
-    expect(sql).toContain("INSERT INTO plugin_catalog");
-    expect(sql).toContain("ON CONFLICT DO NOTHING");
-    expect(sql).toContain("'datasource'"); // type + pillar literals
-    expect(sql).toContain("'form'");
-    expect(params?.[0]).toBe(STRIPE_DATA_CANDIDATE.catalogId);
-    expect(params?.[2]).toBe(STRIPE_DATA_CANDIDATE.slug);
-    expect(JSON.parse(params?.[4] as string)).toEqual(DATA_CANDIDATE_CONFIG_SCHEMA);
+    // Common SQL shape (type + pillar are literals; install_model + config_schema bound).
+    for (const { sql } of calls) {
+      expect(sql).toContain("INSERT INTO plugin_catalog");
+      expect(sql).toContain("ON CONFLICT DO NOTHING");
+      expect(sql).toContain("'datasource'"); // type + pillar literals
+    }
+
+    // Stripe — a FORM candidate carrying the shared credential schema.
+    const stripe = callForCatalogId(calls, STRIPE_DATA_CANDIDATE.catalogId);
+    expect(stripe.params?.[2]).toBe(STRIPE_DATA_CANDIDATE.slug);
+    expect(stripe.params?.[4]).toBe("form");
+    expect(JSON.parse(stripe.params?.[5] as string)).toEqual(DATA_CANDIDATE_CONFIG_SCHEMA);
+
+    // GitHub — an OAUTH-DATASOURCE candidate with an empty admin form schema.
+    const github = callForCatalogId(calls, GITHUB_DATA_CANDIDATE.catalogId);
+    expect(github.params?.[2]).toBe(GITHUB_DATA_CANDIDATE.slug);
+    expect(github.params?.[4]).toBe("oauth-datasource");
+    expect(JSON.parse(github.params?.[5] as string)).toEqual(OAUTH_DATASOURCE_CONFIG_SCHEMA);
   });
 
   it("reports no insertedSlugs when every row already existed (ON CONFLICT DO NOTHING)", async () => {
@@ -54,7 +78,7 @@ describe("seedDataCandidateCatalog", () => {
   });
 });
 
-describe("migration 0109 ↔ code alignment", () => {
+describe("migration 0109 ↔ code alignment (stripe-data)", () => {
   function migrationSql(): string {
     return fs.readFileSync(
       path.join(import.meta.dir, "..", "..", "db", "migrations", "0109_data_candidate_catalog.sql"),
@@ -80,13 +104,50 @@ describe("migration 0109 ↔ code alignment", () => {
   });
 
   it("the migration's name + description match the STRIPE_DATA_CANDIDATE registry literal", () => {
-    // On a fresh DB the migration row is authoritative (it runs before the boot
-    // seed's `ON CONFLICT DO NOTHING`), so its name/description must not drift from
-    // the registry — else the catalog card copy differs by deploy age. SQL doubles
-    // a literal `'`, so escape before substring-matching.
     const sql = migrationSql();
     const esc = (s: string) => s.replace(/'/g, "''");
     expect(sql).toContain(`'${esc(STRIPE_DATA_CANDIDATE.name)}'`);
     expect(sql).toContain(esc(STRIPE_DATA_CANDIDATE.description));
+  });
+});
+
+describe("migration 0111 ↔ code alignment (github-data)", () => {
+  function migrationSql(): string {
+    return fs.readFileSync(
+      path.join(import.meta.dir, "..", "..", "db", "migrations", "0111_github_data_catalog.sql"),
+      "utf8",
+    );
+  }
+
+  it("widens the install_model CHECK to admit 'oauth-datasource'", () => {
+    const sql = migrationSql();
+    expect(sql).toContain("chk_plugin_catalog_install_model");
+    expect(sql).toContain("'oauth-datasource'");
+  });
+
+  it("seeds the github-data canonical id + slug + install_model, idempotently", () => {
+    const sql = migrationSql();
+    expect(sql).toContain(GITHUB_DATA_CANDIDATE.catalogId);
+    expect(sql).toContain("'github-data'");
+    expect(sql).toContain("'oauth-datasource'");
+    expect(sql).toContain("ON CONFLICT DO NOTHING");
+  });
+
+  it("the migration's config_schema matches OAUTH_DATASOURCE_CONFIG_SCHEMA (empty form)", () => {
+    const sql = migrationSql();
+    // github-data has no admin form fields → the seeded config_schema is `[]`.
+    const start = sql.indexOf("'[");
+    const end = sql.indexOf("]'::jsonb");
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+    const jsonText = sql.slice(start + 1, end + 1).replace(/''/g, "'");
+    expect(JSON.parse(jsonText)).toEqual(OAUTH_DATASOURCE_CONFIG_SCHEMA);
+  });
+
+  it("the migration's name + description match the GITHUB_DATA_CANDIDATE registry literal", () => {
+    const sql = migrationSql();
+    const esc = (s: string) => s.replace(/'/g, "''");
+    expect(sql).toContain(`'${esc(GITHUB_DATA_CANDIDATE.name)}'`);
+    expect(sql).toContain(esc(GITHUB_DATA_CANDIDATE.description));
   });
 });

--- a/packages/api/src/lib/openapi/__tests__/data-candidates.test.ts
+++ b/packages/api/src/lib/openapi/__tests__/data-candidates.test.ts
@@ -9,9 +9,13 @@ import {
   DATA_CANDIDATES,
   DATA_CANDIDATE_CATALOG_IDS,
   DATA_CANDIDATE_CONFIG_SCHEMA,
+  GITHUB_DATA_CANDIDATE,
   STRIPE_DATA_CANDIDATE,
+  candidateConfigSchema,
+  candidateInstallModel,
   findDataCandidateByCatalogId,
   findDataCandidateBySlug,
+  isOAuthDatasourceCandidate,
 } from "../data-candidates";
 import { OPENAPI_SUPPORTED_AUTH_KINDS } from "../catalog";
 import { defaultPaginatorRegistry } from "../strategies";
@@ -23,8 +27,12 @@ describe("DATA_CANDIDATES registry invariants", () => {
     }
   });
 
-  it("uses only executable (non-oauth2) auth kinds in slice 6a", () => {
+  it("form candidates use only executable (non-oauth2) auth kinds", () => {
+    // OAuth-datasource candidates carry a credentialMode, not a static authKind —
+    // their credential is acquired by the OAuth dance, so the auth-kind invariant
+    // applies only to the form candidates.
     for (const c of DATA_CANDIDATES) {
+      if (isOAuthDatasourceCandidate(c)) continue;
       expect(OPENAPI_SUPPORTED_AUTH_KINDS).toContain(c.authKind);
     }
   });
@@ -78,6 +86,31 @@ describe("stripe-data candidate", () => {
       cursorItemField: "id",
       hasMorePath: "has_more",
     });
+  });
+});
+
+describe("github-data candidate (oauth-datasource)", () => {
+  it("is an oauth-datasource candidate with the github-app-installation credential mode", () => {
+    expect(isOAuthDatasourceCandidate(GITHUB_DATA_CANDIDATE)).toBe(true);
+    expect(candidateInstallModel(GITHUB_DATA_CANDIDATE)).toBe("oauth-datasource");
+    expect(GITHUB_DATA_CANDIDATE.credentialMode).toBe("github-app-installation");
+  });
+
+  it("pre-fills GitHub's published OpenAPI spec URL (admin never pastes one)", () => {
+    expect(GITHUB_DATA_CANDIDATE.openapiUrl).toMatch(/^https:\/\//);
+    expect(GITHUB_DATA_CANDIDATE.openapiUrl).toContain("github");
+  });
+
+  it("declares link-header pagination with itemsPath omitted (GitHub bare-array shape)", () => {
+    expect(GITHUB_DATA_CANDIDATE.pagination?.strategy).toBe("link-header");
+    expect(GITHUB_DATA_CANDIDATE.pagination?.itemsPath).toBeUndefined();
+    // Resolving over the GENERIC registry proves it's a thin wrapper (no forked strategy).
+    const strategy = defaultPaginatorRegistry.resolve(GITHUB_DATA_CANDIDATE.pagination!);
+    expect(strategy.name).toBe("link-header");
+  });
+
+  it("carries an EMPTY admin form schema (credential comes from the OAuth dance)", () => {
+    expect(candidateConfigSchema(GITHUB_DATA_CANDIDATE)).toEqual([]);
   });
 });
 

--- a/packages/api/src/lib/openapi/__tests__/paginator.test.ts
+++ b/packages/api/src/lib/openapi/__tests__/paginator.test.ts
@@ -354,6 +354,24 @@ const NEXT_CASES: NextCase[] = [
     response: ok({ items: [{ id: 1 }] }, { link: '<https://api.example.com/things?page=1>; rel="prev"' }),
     expected: PAGE_DONE,
   },
+  {
+    // GitHub (the canonical Link-header API) returns a TOP-LEVEL array — itemsPath
+    // omitted defaults to the response root, so the walk follows rel=next.
+    title: "link-header: itemsPath omitted defaults to the root array (GitHub shape)",
+    config: { strategy: "link-header" },
+    request: { operationId: "list", params: { query: { per_page: 2 } } },
+    response: ok([{ id: 1 }], {
+      link: '<https://api.github.com/repos/o/r/pulls?page=2&per_page=2>; rel="next"',
+    }),
+    expected: continueWith({ operationId: "list", params: { query: { per_page: "2", page: "2" } } }),
+  },
+  {
+    title: "link-header: a root array stops the walk when empty even with rel=next",
+    config: { strategy: "link-header" },
+    request: { operationId: "list", params: {} },
+    response: ok([], { link: '<https://api.github.com/repos/o/r/pulls?page=2>; rel="next"' }),
+    expected: PAGE_DONE,
+  },
 ];
 
 describe("paginator — strategy.next() (table-driven, no HTTP)", () => {

--- a/packages/api/src/lib/openapi/__tests__/twenty-acceptance.test.ts
+++ b/packages/api/src/lib/openapi/__tests__/twenty-acceptance.test.ts
@@ -103,10 +103,13 @@ mock.module("@atlas/api/lib/cache/index", () => ({
 let activeDatasources: RestDatasource[] = [];
 mock.module("@atlas/api/lib/openapi/workspace-datasource", () => ({
   // Mock ALL exports — the tool + confirm route now import the strict
-  // `…OrThrow` sibling (#2929 review); omitting it trips "export not found".
+  // `…OrThrow` sibling (#2929 review) and the `RestDatasourceReconnectError`
+  // class (#3030); omitting either trips "export not found". The resolvers here
+  // never throw it, so a stub class (matching the value-export shape) suffices.
   resolveWorkspaceRestDatasources: async () => activeDatasources,
   resolveWorkspaceRestDatasourcesOrThrow: async () => activeDatasources,
   resolveWorkspacePrimaryRestDatasource: async () => activeDatasources[0] ?? null,
+  RestDatasourceReconnectError: class RestDatasourceReconnectError extends Error {},
 }));
 
 const { runAgent } = await import("@atlas/api/lib/agent");

--- a/packages/api/src/lib/openapi/__tests__/workspace-datasource.test.ts
+++ b/packages/api/src/lib/openapi/__tests__/workspace-datasource.test.ts
@@ -12,6 +12,7 @@ import {
   resolveWorkspaceRestDatasourcesOrThrow,
   resolveWorkspacePrimaryRestDatasource,
   defaultQuery,
+  RestDatasourceReconnectError,
   type OpenApiInstallRow,
 } from "../workspace-datasource";
 import { buildOperationGraph } from "../spec";
@@ -478,5 +479,52 @@ describe("resolveWorkspaceRestDatasources — github-data (oauth-datasource)", (
     });
     expect(result).toHaveLength(0);
     expect(called).toBe(false);
+  });
+
+  // ── reconnect-needed: present-but-unresolvable, distinct from "none" ────────
+  it("STRICT resolver throws RestDatasourceReconnectError when the only datasource needs reconnect (mint fails)", async () => {
+    // A user-facing caller (the executeRestOperation tool) must be able to tell
+    // "your datasource needs reconnecting" apart from "no datasource connected".
+    await expect(
+      resolveWorkspaceRestDatasourcesOrThrow("org-1", {
+        query: queryReturning([githubRow()]),
+        mintInstallationToken: async () => {
+          throw new Error("App access revoked");
+        },
+      }),
+    ).rejects.toBeInstanceOf(RestDatasourceReconnectError);
+  });
+
+  it("STRICT resolver throws RestDatasourceReconnectError when the only datasource is missing its installation_id", async () => {
+    await expect(
+      resolveWorkspaceRestDatasourcesOrThrow("org-1", {
+        query: queryReturning([githubRow({ installation_id: undefined })]),
+        mintInstallationToken: async () => "unused",
+      }),
+    ).rejects.toBeInstanceOf(RestDatasourceReconnectError);
+  });
+
+  it("STRICT resolver does NOT throw when a healthy datasource coexists with a reconnect-needed one", async () => {
+    // Partial success — the reconnect signal fires only when nothing usable remains.
+    const result = await resolveWorkspaceRestDatasourcesOrThrow("org-1", {
+      query: queryReturning([
+        githubRow(),
+        { install_id: "ok", config: config({ openapi_snapshot: snapshot("2026-05-30T02:00:00.000Z") }) },
+      ]),
+      mintInstallationToken: async () => {
+        throw new Error("App access revoked");
+      },
+    });
+    expect(result.map((d) => d.id)).toEqual(["ok"]);
+  });
+
+  it("never-rejects resolver degrades to [] (no throw) for a reconnect-needed-only workspace", async () => {
+    const result = await resolveWorkspaceRestDatasources("org-1", {
+      query: queryReturning([githubRow()]),
+      mintInstallationToken: async () => {
+        throw new Error("App access revoked");
+      },
+    });
+    expect(result).toEqual([]);
   });
 });

--- a/packages/api/src/lib/openapi/__tests__/workspace-datasource.test.ts
+++ b/packages/api/src/lib/openapi/__tests__/workspace-datasource.test.ts
@@ -389,3 +389,94 @@ describe("resolveWorkspaceRestDatasources — SSRF guard at resolve time", () =>
     expect(result[0].baseUrl).toBe("https://169.254.169.254");
   });
 });
+
+// ── github-data (oauth-datasource): credential minted at resolve time ─────────
+describe("resolveWorkspaceRestDatasources — github-data (oauth-datasource)", () => {
+  const GITHUB_DOC = {
+    openapi: "3.1.0",
+    info: { title: "GitHub", version: "1.1.4" },
+    servers: [{ url: "https://api.github.com" }],
+    paths: {
+      "/repos/{owner}/{repo}/pulls": {
+        get: {
+          operationId: "pulls/list",
+          parameters: [
+            { name: "owner", in: "path", required: true, schema: { type: "string" } },
+            { name: "repo", in: "path", required: true, schema: { type: "string" } },
+          ],
+          responses: { "200": { description: "OK" } },
+        },
+      },
+    },
+  };
+  const githubSnapshot = () =>
+    buildSnapshot(GITHUB_DOC, buildOperationGraph(GITHUB_DOC), "2026-05-30T00:00:00.000Z");
+
+  /** A decrypted github-data install config — installation_id is plaintext here (decrypt passthrough). */
+  function githubConfig(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+    return {
+      openapi_url:
+        "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/api.github.com/api.github.com.json",
+      auth_kind: "oauth2",
+      installation_id: "987654321",
+      display_name: "GitHub",
+      representation_mode: "operation-graph",
+      status: "ok",
+      openapi_snapshot: githubSnapshot(),
+      ...overrides,
+    };
+  }
+
+  const githubRow = (overrides: Record<string, unknown> = {}): OpenApiInstallRow => ({
+    install_id: "gh-1",
+    catalog_id: "catalog:github-data",
+    config: githubConfig(overrides),
+  });
+
+  it("mints an installation token and resolves it as bearer auth against api.github.com", async () => {
+    const minted: string[] = [];
+    const result = await resolveWorkspaceRestDatasources("org-1", {
+      query: queryReturning([githubRow()]),
+      mintInstallationToken: async (installationId) => {
+        minted.push(installationId);
+        return `ghs_for_${installationId}`;
+      },
+    });
+
+    expect(result).toHaveLength(1);
+    const ds = result[0];
+    // The minter received the decrypted installation_id from THIS workspace's row.
+    expect(minted).toEqual(["987654321"]);
+    expect(ds.auth).toEqual({ kind: "bearer", token: "ghs_for_987654321" });
+    expect(ds.baseUrl).toBe("https://api.github.com"); // from the spec's servers[0]
+    expect(ds.graph.operations.has("pulls/list")).toBe(true);
+    expect(ds.displayName).toBe("GitHub");
+  });
+
+  it("skips the github-data datasource when minting fails (fail-soft), not the whole set", async () => {
+    const result = await resolveWorkspaceRestDatasources("org-1", {
+      query: queryReturning([
+        githubRow(),
+        { install_id: "ok", config: config({ openapi_snapshot: snapshot("2026-05-30T01:00:00.000Z") }) },
+      ]),
+      mintInstallationToken: async () => {
+        throw new Error("App access revoked");
+      },
+    });
+    // The healthy generic install survives; the un-mintable github-data is dropped.
+    expect(result.map((d) => d.id)).toEqual(["ok"]);
+  });
+
+  it("skips a github-data row with no installation_id (drifted/corrupt), without minting", async () => {
+    let called = false;
+    const result = await resolveWorkspaceRestDatasources("org-1", {
+      query: queryReturning([githubRow({ installation_id: undefined })]),
+      mintInstallationToken: async () => {
+        called = true;
+        return "should-not-be-called";
+      },
+    });
+    expect(result).toHaveLength(0);
+    expect(called).toBe(false);
+  });
+});

--- a/packages/api/src/lib/openapi/data-candidate-seed.ts
+++ b/packages/api/src/lib/openapi/data-candidate-seed.ts
@@ -23,7 +23,11 @@
  */
 
 import { createLogger } from "@atlas/api/lib/logger";
-import { DATA_CANDIDATES, DATA_CANDIDATE_CONFIG_SCHEMA } from "./data-candidates";
+import {
+  DATA_CANDIDATES,
+  candidateConfigSchema,
+  candidateInstallModel,
+} from "./data-candidates";
 import type { OpenApiDatasourceCatalogSeedDb } from "./catalog-seed";
 
 const log = createLogger("openapi.data-candidate-seed");
@@ -35,29 +39,39 @@ export interface DataCandidateCatalogSeedResult {
 
 /**
  * Idempotently seed every data-candidate catalog row. Column order + the
- * `'datasource'` type+pillar / `'available'` status / `'form'` install_model /
- * `'starter'` min_plan / `true` enabled+saas_eligible literals all mirror
- * migration 0109 and the generic-row seed so the admin catalog surfaces these
- * identically. One INSERT per row keeps the SQL trivial and the idempotency
- * per-row (a partially-seeded catalog converges on the next boot).
+ * `'datasource'` type+pillar / `'available'` status / `'starter'` min_plan /
+ * `true` enabled+saas_eligible literals all mirror migrations 0109 / 0111 and
+ * the generic-row seed so the admin catalog surfaces these identically. The
+ * `install_model` and `config_schema` are PER-CANDIDATE (a `form` candidate
+ * carries the credential form; an `oauth-datasource` candidate is `oauth-datasource`
+ * with an empty form), bound rather than literal so one loop seeds both shapes.
+ * One INSERT per row keeps the idempotency per-row (a partially-seeded catalog
+ * converges on the next boot).
  */
 export async function seedDataCandidateCatalog(
   db: OpenApiDatasourceCatalogSeedDb,
 ): Promise<DataCandidateCatalogSeedResult> {
   const insertedSlugs: string[] = [];
-  const configSchemaJson = JSON.stringify(DATA_CANDIDATE_CONFIG_SCHEMA);
 
   for (const candidate of DATA_CANDIDATES) {
+    const configSchemaJson = JSON.stringify(candidateConfigSchema(candidate));
     const { rows } = await db.query<{ slug: string }>(
       `INSERT INTO plugin_catalog
          (id, name, slug, description, type, install_model, pillar,
           implementation_status, auto_install, min_plan, enabled, saas_eligible,
           config_schema, created_at, updated_at)
-       VALUES ($1, $2, $3, $4, 'datasource', 'form', 'datasource', 'available',
-               false, 'starter', true, true, $5::jsonb, NOW(), NOW())
+       VALUES ($1, $2, $3, $4, 'datasource', $5, 'datasource', 'available',
+               false, 'starter', true, true, $6::jsonb, NOW(), NOW())
        ON CONFLICT DO NOTHING
        RETURNING slug`,
-      [candidate.catalogId, candidate.name, candidate.slug, candidate.description, configSchemaJson],
+      [
+        candidate.catalogId,
+        candidate.name,
+        candidate.slug,
+        candidate.description,
+        candidateInstallModel(candidate),
+        configSchemaJson,
+      ],
     );
     if (rows.length > 0) insertedSlugs.push(candidate.slug);
   }

--- a/packages/api/src/lib/openapi/data-candidates.ts
+++ b/packages/api/src/lib/openapi/data-candidates.ts
@@ -33,17 +33,18 @@
  * {@link import("./datasource").RestDatasource}.
  */
 import type { ConfigSchemaField } from "@atlas/api/lib/plugins/registry";
+import type { CatalogInstallModel } from "@useatlas/types";
 import type { SupportedAuthKind } from "./catalog";
 import type { PaginationConfig } from "./paginator";
 import type { VendorQuirk } from "./vendor-quirk";
 
 /**
- * A built-in vendor REST datasource, pre-wired over the generic primitive. The
- * `slug` / `catalogId` follow the same `catalog:${slug}` derivation the seeder
- * uses for every catalog row (so `workspace_plugins.catalog_id` FK-targets
- * `catalog:stripe-data`).
+ * Fields shared by every built-in vendor REST datasource, pre-wired over the
+ * generic primitive. The `slug` / `catalogId` follow the same `catalog:${slug}`
+ * derivation the seeder uses for every catalog row (so
+ * `workspace_plugins.catalog_id` FK-targets e.g. `catalog:stripe-data`).
  */
-export interface DataCandidate {
+export interface BaseDataCandidate {
   /** Catalog slug + install-handler dispatch key, e.g. "stripe-data". */
   readonly slug: string;
   /** Stable `plugin_catalog.id` (`catalog:${slug}`), the FK target. */
@@ -54,8 +55,6 @@ export interface DataCandidate {
   readonly description: string;
   /** Pre-filled OpenAPI 3.x spec URL — the admin never pastes this. */
   readonly openapiUrl: string;
-  /** Pre-filled auth kind — the admin only supplies the credential value. */
-  readonly authKind: SupportedAuthKind;
   /**
    * Declarative deviations the generic client applies per request (required
    * static headers / query param-shaping). Omit for a perfectly-generic API.
@@ -63,13 +62,61 @@ export interface DataCandidate {
   readonly quirk?: VendorQuirk;
   /**
    * Default pagination config for the candidate's list operations, resolved
-   * against the SAME `defaultPaginatorRegistry` (no new strategy file). Stripe's
-   * whole list surface uses one cursor dialect, so a single default suffices.
+   * against the SAME `defaultPaginatorRegistry` (no new strategy file).
    * Forward-looking: the live tool calls the un-paginated primitive today
    * (`executeOperationPaged` is dormant, see paginator.test.ts) — this is what
    * wires in when pagination reaches the tool (#2970).
    */
   readonly pagination?: PaginationConfig;
+}
+
+/**
+ * A FORM candidate (Stripe, Notion): the admin pastes a static credential. The
+ * `install_model` is `form`; the install handler pre-fills `openapiUrl` +
+ * `authKind` from here so the admin supplies only the credential value.
+ */
+export interface FormDataCandidate extends BaseDataCandidate {
+  /** Omitted = the default `form` install model. */
+  readonly installModel?: "form";
+  /** Pre-filled auth kind — the admin only supplies the credential value. */
+  readonly authKind: SupportedAuthKind;
+}
+
+/**
+ * An OAUTH-DATASOURCE candidate (GitHub, v0.0.2 slice 6c #3030): the credential
+ * is acquired via an OAuth dance, not a pasted secret, and minted on demand at
+ * query time. The install model is `oauth-datasource` (a NEW handler family —
+ * see `oauth-datasource-handler.ts`). `credentialMode` tells the workspace
+ * resolver HOW to produce the executable bearer credential.
+ */
+export interface OAuthDatasourceDataCandidate extends BaseDataCandidate {
+  readonly installModel: "oauth-datasource";
+  /**
+   * How the query-time resolver turns the persisted credential into a bearer
+   * token. `github-app-installation` = mint an installation token from the App
+   * JWT + the stored `installation_id` (`github/installation-token.ts`), cached
+   * + re-minted on ~1hr expiry.
+   */
+  readonly credentialMode: "github-app-installation";
+}
+
+/**
+ * A built-in vendor REST datasource. Discriminated on `installModel` — a `form`
+ * candidate carries a static `authKind`; an `oauth-datasource` candidate carries
+ * a `credentialMode` instead (its credential comes from the OAuth dance).
+ */
+export type DataCandidate = FormDataCandidate | OAuthDatasourceDataCandidate;
+
+/** The catalog `install_model` for a candidate (`form` unless overridden). */
+export function candidateInstallModel(candidate: DataCandidate): CatalogInstallModel {
+  return candidate.installModel ?? "form";
+}
+
+/** Narrow to an OAuth-datasource candidate (credential via OAuth, not a form field). */
+export function isOAuthDatasourceCandidate(
+  candidate: DataCandidate,
+): candidate is OAuthDatasourceDataCandidate {
+  return candidate.installModel === "oauth-datasource";
 }
 
 /**
@@ -106,6 +153,28 @@ export const DATA_CANDIDATE_CONFIG_SCHEMA: ReadonlyArray<ConfigSchemaField> = [
 ];
 
 /**
+ * The install-form `config_schema` for an OAUTH-DATASOURCE candidate (github-data,
+ * #3030). DELIBERATELY EMPTY: the credential is acquired via the OAuth dance, not
+ * a form field — the admin only clicks "Connect", so there is nothing to render.
+ * The persisted credential's encryption is driven by a code-resident schema
+ * (`GITHUB_APP_SECRET_FIELDS_SCHEMA`, `installation_id` secret), NOT this catalog
+ * form schema.
+ */
+export const OAUTH_DATASOURCE_CONFIG_SCHEMA: ReadonlyArray<ConfigSchemaField> = [];
+
+/**
+ * The catalog `config_schema` (admin form) for a candidate. Form candidates share
+ * the credential form; oauth-datasource candidates have no form fields.
+ */
+export function candidateConfigSchema(
+  candidate: DataCandidate,
+): ReadonlyArray<ConfigSchemaField> {
+  return isOAuthDatasourceCandidate(candidate)
+    ? OAUTH_DATASOURCE_CONFIG_SCHEMA
+    : DATA_CANDIDATE_CONFIG_SCHEMA;
+}
+
+/**
  * Stripe — the first data candidate (#3028). Proves three dimensions the
  * candidate set deliberately spans:
  *  - `bearer` auth (the secret key, sent as `Authorization: Bearer …`),
@@ -115,7 +184,7 @@ export const DATA_CANDIDATE_CONFIG_SCHEMA: ReadonlyArray<ConfigSchemaField> = [
  *    top-level `has_more` flag (handled by the strategy's `cursorFromLastItem` +
  *    `hasMorePath`, no new strategy file).
  */
-export const STRIPE_DATA_CANDIDATE: DataCandidate = {
+export const STRIPE_DATA_CANDIDATE: FormDataCandidate = {
   slug: "stripe-data",
   catalogId: "catalog:stripe-data",
   name: "Stripe",
@@ -142,8 +211,52 @@ export const STRIPE_DATA_CANDIDATE: DataCandidate = {
   },
 };
 
+/**
+ * GitHub — the OAuth2 data candidate (#3030; the OQ5 deliverable). Proves the
+ * OAuth dimension of the generic primitive:
+ *  - OAuth2 credential acquisition via GitHub's EXISTING App registration (no new
+ *    vendor app) — install handler `oauth-datasource-handler.ts`,
+ *  - `Link`-header pagination — ALREADY a generic strategy (`strategies/link-header.ts`),
+ *    so github-data is a thin wrapper (OQ6): no GitHub-specific walker/paginator/
+ *    validator. The GitHub-ness lives only in the install handler + the
+ *    credential resolver, never the query path.
+ *
+ * The credential is the App `installation_id`; the executable bearer token is
+ * minted on demand from the App JWT (`credentialMode: "github-app-installation"`)
+ * and re-minted transparently on ~1hr expiry — NOT a refresh-token rotation.
+ *
+ * NOTE (generalization watch, #2930 AC): GitHub's published OpenAPI document is
+ * large; probe-on-install fetches + snapshots it into `workspace_plugins.config`.
+ * If the full spec proves too big to snapshot in practice, the follow-up is a
+ * size cap or a curated subset URL — filed rather than forked (the walker/
+ * paginator/validator stay generic).
+ */
+export const GITHUB_DATA_CANDIDATE: OAuthDatasourceDataCandidate = {
+  slug: "github-data",
+  catalogId: "catalog:github-data",
+  name: "GitHub",
+  description:
+    "Query your GitHub organization (repositories, pull requests, issues, …) as a read-only REST " +
+    "datasource. Connects through your GitHub App installation — no token to paste. The agent " +
+    "discovers operations from GitHub's published OpenAPI spec and queries them directly, " +
+    "following Link-header pagination.",
+  openapiUrl:
+    "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/api.github.com/api.github.com.json",
+  installModel: "oauth-datasource",
+  credentialMode: "github-app-installation",
+  pagination: {
+    // GitHub list endpoints return a TOP-LEVEL array (no wrapper), so `itemsPath`
+    // is omitted (defaults to the response root). Next-page URL comes from the
+    // RFC 8288 `Link: …; rel="next"` header — the existing generic strategy.
+    strategy: "link-header",
+  },
+};
+
 /** Every built-in data candidate. Append a new vendor here (the one-line thesis). */
-export const DATA_CANDIDATES: ReadonlyArray<DataCandidate> = [STRIPE_DATA_CANDIDATE];
+export const DATA_CANDIDATES: ReadonlyArray<DataCandidate> = [
+  STRIPE_DATA_CANDIDATE,
+  GITHUB_DATA_CANDIDATE,
+];
 
 const BY_CATALOG_ID = new Map<string, DataCandidate>(
   DATA_CANDIDATES.map((c) => [c.catalogId, c]),

--- a/packages/api/src/lib/openapi/data-candidates.ts
+++ b/packages/api/src/lib/openapi/data-candidates.ts
@@ -25,8 +25,9 @@
  * ## Seeding + resolution
  * Each candidate is a real `plugin_catalog` row (datasource pillar) so it surfaces
  * in `/admin/connections` as its own installable card. The boot seed
- * (`data-candidate-seed.ts`) re-asserts every row idempotently; migration
- * 0109 inserts them on fresh DBs. An install writes a `workspace_plugins` row
+ * (`data-candidate-seed.ts`) re-asserts every row idempotently; migrations
+ * 0109 (stripe-data) / 0111 (github-data) insert them on fresh DBs. An install
+ * writes a `workspace_plugins` row
  * under the candidate's {@link DataCandidate.catalogId}; the workspace resolver
  * (`workspace-datasource.ts`) matches those ids alongside `openapi-generic` and
  * attaches the candidate's {@link DataCandidate.quirk} to the resolved
@@ -80,6 +81,13 @@ export interface FormDataCandidate extends BaseDataCandidate {
   readonly installModel?: "form";
   /** Pre-filled auth kind — the admin only supplies the credential value. */
   readonly authKind: SupportedAuthKind;
+  /**
+   * Never set on a form candidate — its credential is a static form field, not
+   * an OAuth dance. Present as `?: never` so the union makes the both-fields
+   * combination (`authKind` + `credentialMode`) a compile error rather than a
+   * convention the JSDoc only asserts.
+   */
+  readonly credentialMode?: never;
 }
 
 /**
@@ -98,6 +106,12 @@ export interface OAuthDatasourceDataCandidate extends BaseDataCandidate {
    * + re-minted on ~1hr expiry.
    */
   readonly credentialMode: "github-app-installation";
+  /**
+   * Never set on an oauth-datasource candidate — its credential comes from the
+   * OAuth dance, not a static `authKind`. `?: never` makes a candidate that
+   * declares both an OAuth credential mode and a static auth kind unrepresentable.
+   */
+  readonly authKind?: never;
 }
 
 /**

--- a/packages/api/src/lib/openapi/strategies/link-header.ts
+++ b/packages/api/src/lib/openapi/strategies/link-header.ts
@@ -8,7 +8,10 @@
  * `next` link is present, the walk is done.
  *
  * Config fields:
- *  - `itemsPath` (req) — dot-path to the item array (for merging).
+ *  - `itemsPath` (opt) — dot-path to the item array. DEFAULTS to the response
+ *    root (`""`), because GitHub — the canonical `Link`-header API — returns a
+ *    TOP-LEVEL array from its list endpoints (`GET /repos/{}/{}/pulls` → `[…]`),
+ *    not a wrapped `{ data: [...] }`. Set it only when a vendor wraps its list.
  *  - `rel`       (opt) — link relation to follow (default `"next"`).
  */
 import {
@@ -17,7 +20,6 @@ import {
   optionalString,
   PAGE_DONE,
   pageError,
-  requireString,
   withQuery,
   type PaginationConfig,
   type PaginationStrategy,
@@ -27,7 +29,9 @@ import {
 export const linkHeaderStrategy: PaginationStrategyFactory = {
   name: "link-header",
   create(config: PaginationConfig): PaginationStrategy {
-    const itemsPath = requireString(config, "itemsPath");
+    // Root (`""`) by default — `extractItems("")` returns the body itself, the
+    // GitHub bare-array shape. A wrapped vendor overrides with a dot-path.
+    const itemsPath = optionalString(config, "itemsPath") ?? "";
     const rel = optionalString(config, "rel") ?? "next";
 
     return {

--- a/packages/api/src/lib/openapi/workspace-datasource.ts
+++ b/packages/api/src/lib/openapi/workspace-datasource.ts
@@ -86,6 +86,28 @@ export type OpenApiInstallQuery = (
  */
 export type MintInstallationTokenFn = (installationId: string) => Promise<string>;
 
+/**
+ * Thrown by {@link resolveWorkspaceRestDatasourcesOrThrow} when a workspace HAS
+ * REST datasource installs but EVERY one resolved to a recoverable credential
+ * failure (e.g. a github-data install whose GitHub App access was revoked, or a
+ * drifted row missing its `installation_id`) — so the usable set is empty for a
+ * reason that is NOT "the workspace has none". User-facing callers surface this
+ * as "reconnect needed", distinct from `no_datasource`, so the agent never
+ * tells the user nothing is connected when something just needs reconnecting.
+ * The never-rejects {@link resolveWorkspaceRestDatasources} swallows it (degrades
+ * to `[]`, since prompt-build makes no presence claim).
+ */
+export class RestDatasourceReconnectError extends Error {
+  readonly reconnectableCount: number;
+  constructor(reconnectableCount: number) {
+    super(
+      `${reconnectableCount} REST datasource install(s) need reconnecting — their credentials could not be resolved.`,
+    );
+    this.name = "RestDatasourceReconnectError";
+    this.reconnectableCount = reconnectableCount;
+  }
+}
+
 export interface ResolveWorkspaceDeps {
   readonly query?: OpenApiInstallQuery;
   /**
@@ -158,22 +180,36 @@ function secretSchemaFor(candidate: DataCandidate | undefined) {
 }
 
 /**
- * Resolve the executable credential for one install, or `null` to skip (logged).
- * Two paths:
+ * The outcome of resolving one install's credential. `skip` distinguishes a
+ * **reconnectable** miss (a connected datasource whose credential is temporarily
+ * unresolvable — a github-data mint failure or a drifted row missing its
+ * `installation_id`; an admin reconnect fixes it) from a non-reconnectable one
+ * (an unsupported / deferred static auth kind — re-installing won't help). The
+ * caller uses this to tell "this workspace has no datasource" apart from "its
+ * datasource needs reconnecting" instead of conflating both into an empty set.
+ */
+type AuthResolution =
+  | { readonly kind: "ok"; readonly auth: ResolvedAuth }
+  | { readonly kind: "skip"; readonly reconnectable: boolean };
+
+/**
+ * Resolve the executable credential for one install. Two paths:
  *   - **github-data (oauth-datasource):** mint a GitHub App installation token
  *     from the decrypted `installation_id` (cached + re-minted on ~1hr expiry) →
- *     `bearer`. A mint failure skips this datasource fail-soft (App access
- *     revoked, key drift, transient GitHub outage) without sinking the others.
+ *     `bearer`. A mint failure or a missing `installation_id` is a
+ *     **reconnectable** skip (App access revoked, key drift, transient GitHub
+ *     outage) — fail-soft so it doesn't sink the workspace's other datasources,
+ *     but flagged so an all-reconnectable workspace surfaces "reconnect needed".
  *   - **everything else:** the static credential from config via the shared
- *     decrypt-glue — `oauth2` / unrecognized kinds resolve to skip (slice-6
- *     deferred for the generic row; github-data uses the mint path instead).
+ *     decrypt-glue — `oauth2` / unrecognized kinds are a NON-reconnectable skip
+ *     (slice-6 deferred for the generic row; github-data uses the mint path).
  */
 async function resolveInstallAuth(
   installId: string,
   candidate: DataCandidate | undefined,
   decrypted: Record<string, unknown>,
   mint: MintInstallationTokenFn,
-): Promise<ResolvedAuth | null> {
+): Promise<AuthResolution> {
   if (candidate && isOAuthDatasourceCandidate(candidate)) {
     const installationId =
       typeof decrypted.installation_id === "string" ? decrypted.installation_id : "";
@@ -182,32 +218,33 @@ async function resolveInstallAuth(
         { installId, catalogId: candidate.catalogId },
         "github-data install has no installation_id — skipping (reconnect the datasource)",
       );
-      return null;
+      return { kind: "skip", reconnectable: true };
     }
     try {
       const token = await mint(installationId);
-      return { kind: "bearer", token };
+      return { kind: "ok", auth: { kind: "bearer", token } };
     } catch (err) {
       log.warn(
         { installId, catalogId: candidate.catalogId, err: err instanceof Error ? err.message : String(err) },
         "Failed to mint a GitHub installation token — skipping this datasource (reconnect may be needed)",
       );
-      return null;
+      return { kind: "skip", reconnectable: true };
     }
   }
 
   // Static-credential path (generic + form candidates). A drifted / hand-edited
   // row could carry the deferred `oauth2` (generic) or a garbage value — both
-  // resolve to skip rather than passing a bad string to buildResolvedAuth.
+  // resolve to skip rather than passing a bad string to buildResolvedAuth. This
+  // is NOT reconnectable: it's a config/spec gap, not an expired credential.
   const authResult = resolveAuthFromDecryptedConfig(decrypted);
   if (!authResult.ok) {
     log.warn(
       { installId, authKind: authResult.rawAuthKind },
       "OpenAPI install uses an unsupported or deferred auth kind — skipping",
     );
-    return null;
+    return { kind: "skip", reconnectable: false };
   }
-  return authResult.auth;
+  return { kind: "ok", auth: authResult.auth };
 }
 
 function stripTrailingSlash(s: string): string {
@@ -349,6 +386,12 @@ function buildDatasource(
  * because a github-data install mints its credential per resolve; the per-row
  * resolution is sequential (a workspace has a handful of datasources, and the
  * minter caches, so serial keeps the code simple without meaningful latency).
+ *
+ * Throws {@link RestDatasourceReconnectError} when the resolved set is empty but
+ * ≥1 install was skipped for a **reconnectable** credential reason — so a
+ * user-facing caller can say "reconnect needed" instead of "none connected".
+ * (A partial success — some resolve, one needs reconnect — still returns the
+ * healthy ones; the throw fires only when nothing usable remains.)
  */
 async function buildDatasourcesFromRows(
   workspaceId: string,
@@ -356,6 +399,7 @@ async function buildDatasourcesFromRows(
   mint: MintInstallationTokenFn,
 ): Promise<RestDatasource[]> {
   const out: RestDatasource[] = [];
+  let reconnectableSkips = 0;
   for (const row of rows) {
     const candidate =
       row.catalog_id !== undefined ? findDataCandidateByCatalogId(row.catalog_id) : undefined;
@@ -369,10 +413,19 @@ async function buildDatasourcesFromRows(
       );
       continue;
     }
-    const auth = await resolveInstallAuth(row.install_id, candidate, decrypted, mint);
-    if (!auth) continue; // unsupported/deferred kind, missing credential, or mint failure (logged)
-    const ds = buildDatasource(workspaceId, row.install_id, candidate, decrypted, auth);
+    const resolution = await resolveInstallAuth(row.install_id, candidate, decrypted, mint);
+    if (resolution.kind === "skip") {
+      // unsupported/deferred kind, missing credential, or mint failure (logged)
+      if (resolution.reconnectable) reconnectableSkips++;
+      continue;
+    }
+    const ds = buildDatasource(workspaceId, row.install_id, candidate, decrypted, resolution.auth);
     if (ds) out.push(ds);
+  }
+  // Nothing usable resolved, but at least one install is merely awaiting a
+  // reconnect — signal that distinctly so callers don't claim "none connected".
+  if (out.length === 0 && reconnectableSkips > 0) {
+    throw new RestDatasourceReconnectError(reconnectableSkips);
   }
   return out;
 }
@@ -416,6 +469,16 @@ export async function resolveWorkspaceRestDatasources(
   try {
     return await resolveWorkspaceRestDatasourcesOrThrow(workspaceId, deps);
   } catch (err) {
+    // A reconnect-needed signal isn't a load failure — the rows loaded fine, the
+    // credential just needs refreshing. Degrade to `[]` either way (this path
+    // makes no presence claim), but log accurately.
+    if (err instanceof RestDatasourceReconnectError) {
+      log.warn(
+        { workspaceId, reconnectableCount: err.reconnectableCount },
+        "OpenAPI datasource install(s) need reconnecting — continuing with none for this non-claiming path",
+      );
+      return [];
+    }
     log.warn(
       { workspaceId, err: err instanceof Error ? err.message : String(err) },
       "Failed to load OpenAPI datasource installs — continuing with none",

--- a/packages/api/src/lib/openapi/workspace-datasource.ts
+++ b/packages/api/src/lib/openapi/workspace-datasource.ts
@@ -41,10 +41,14 @@ import {
   DATA_CANDIDATE_CATALOG_IDS,
   DATA_CANDIDATE_CONFIG_SCHEMA,
   findDataCandidateByCatalogId,
+  isOAuthDatasourceCandidate,
+  type DataCandidate,
 } from "./data-candidates";
+import { GITHUB_APP_SECRET_FIELDS_SCHEMA } from "@atlas/api/lib/integrations/install/github-oauth-secret-schema";
+import { getGitHubInstallationToken } from "@atlas/api/lib/github/installation-token";
 import { assertBaseUrlAllowed, EgressBlockedError, hostForLog } from "./egress-guard";
 import { resolveAuthFromDecryptedConfig, snapshotToGraph } from "./probe";
-import type { OperationGraph } from "./types";
+import type { OperationGraph, ResolvedAuth } from "./types";
 
 const log = createLogger("openapi.workspace-datasource");
 
@@ -74,8 +78,21 @@ export type OpenApiInstallQuery = (
   workspaceId: string,
 ) => Promise<ReadonlyArray<OpenApiInstallRow>>;
 
+/**
+ * Mint a GitHub App installation token for a github-data datasource's stored
+ * `installation_id` (v0.0.2 slice 6c, #3030). Injected so the resolver is tested
+ * without the network / App private key; production defaults to
+ * {@link getGitHubInstallationToken} (App-JWT mint, cached + re-minted on expiry).
+ */
+export type MintInstallationTokenFn = (installationId: string) => Promise<string>;
+
 export interface ResolveWorkspaceDeps {
   readonly query?: OpenApiInstallQuery;
+  /**
+   * Override the github-data credential minter. Production omits it (the real
+   * App-JWT minter runs); tests inject a stub so no network / key is needed.
+   */
+  readonly mintInstallationToken?: MintInstallationTokenFn;
 }
 
 /**
@@ -127,6 +144,72 @@ export async function defaultQuery(
 const GENERIC_SECRET_SCHEMA = parseConfigSchema(OPENAPI_GENERIC_CONFIG_SCHEMA);
 const CANDIDATE_SECRET_SCHEMA = parseConfigSchema(DATA_CANDIDATE_CONFIG_SCHEMA);
 
+/**
+ * Pick the selective-encryption schema for a row's config by candidate. The
+ * three shapes differ only in WHICH field is the secret:
+ *   - github-data (oauth-datasource): `installation_id` — reuse the App schema.
+ *   - other data candidates / generic: `auth_value`.
+ * Selecting the matching schema keeps decrypt in lockstep with the handler's
+ * encrypt (a write that encrypts more than the read decrypts corrupts the value).
+ */
+function secretSchemaFor(candidate: DataCandidate | undefined) {
+  if (candidate && isOAuthDatasourceCandidate(candidate)) return GITHUB_APP_SECRET_FIELDS_SCHEMA;
+  return candidate ? CANDIDATE_SECRET_SCHEMA : GENERIC_SECRET_SCHEMA;
+}
+
+/**
+ * Resolve the executable credential for one install, or `null` to skip (logged).
+ * Two paths:
+ *   - **github-data (oauth-datasource):** mint a GitHub App installation token
+ *     from the decrypted `installation_id` (cached + re-minted on ~1hr expiry) →
+ *     `bearer`. A mint failure skips this datasource fail-soft (App access
+ *     revoked, key drift, transient GitHub outage) without sinking the others.
+ *   - **everything else:** the static credential from config via the shared
+ *     decrypt-glue — `oauth2` / unrecognized kinds resolve to skip (slice-6
+ *     deferred for the generic row; github-data uses the mint path instead).
+ */
+async function resolveInstallAuth(
+  installId: string,
+  candidate: DataCandidate | undefined,
+  decrypted: Record<string, unknown>,
+  mint: MintInstallationTokenFn,
+): Promise<ResolvedAuth | null> {
+  if (candidate && isOAuthDatasourceCandidate(candidate)) {
+    const installationId =
+      typeof decrypted.installation_id === "string" ? decrypted.installation_id : "";
+    if (installationId.length === 0) {
+      log.warn(
+        { installId, catalogId: candidate.catalogId },
+        "github-data install has no installation_id — skipping (reconnect the datasource)",
+      );
+      return null;
+    }
+    try {
+      const token = await mint(installationId);
+      return { kind: "bearer", token };
+    } catch (err) {
+      log.warn(
+        { installId, catalogId: candidate.catalogId, err: err instanceof Error ? err.message : String(err) },
+        "Failed to mint a GitHub installation token — skipping this datasource (reconnect may be needed)",
+      );
+      return null;
+    }
+  }
+
+  // Static-credential path (generic + form candidates). A drifted / hand-edited
+  // row could carry the deferred `oauth2` (generic) or a garbage value — both
+  // resolve to skip rather than passing a bad string to buildResolvedAuth.
+  const authResult = resolveAuthFromDecryptedConfig(decrypted);
+  if (!authResult.ok) {
+    log.warn(
+      { installId, authKind: authResult.rawAuthKind },
+      "OpenAPI install uses an unsupported or deferred auth kind — skipping",
+    );
+    return null;
+  }
+  return authResult.auth;
+}
+
 function stripTrailingSlash(s: string): string {
   return s.endsWith("/") ? s.slice(0, -1) : s;
 }
@@ -162,12 +245,18 @@ function resolveBaseUrl(
   }
 }
 
-/** Build a single {@link RestDatasource} from a decrypted install row, or `null` to skip. */
+/**
+ * Build a single {@link RestDatasource} from a decrypted install row + its
+ * already-resolved credential, or `null` to skip. The credential is resolved by
+ * the caller ({@link resolveInstallAuth}) because it can be async (a github-data
+ * install mints an installation token), so this stays a synchronous assembler.
+ */
 function buildDatasource(
   workspaceId: string,
   installId: string,
-  catalogId: string | undefined,
+  candidate: DataCandidate | undefined,
   decrypted: Record<string, unknown>,
+  auth: ResolvedAuth,
 ): RestDatasource | null {
   // Validate the snapshot read back from JSONB, rather than an unchecked cast: a
   // drifted / older-builder row is treated as "no snapshot" (skip), not a
@@ -182,20 +271,6 @@ function buildDatasource(
   }
 
   const openapiUrl = typeof decrypted.openapi_url === "string" ? decrypted.openapi_url : "";
-  // Narrow + build the credential from the decrypted JSONB via the glue shared
-  // with the rediscover route. A drifted / hand-edited row could carry the
-  // deferred `oauth2` (slice 6 #2930) OR an outright unrecognized value — both
-  // resolve to `ok: false` and skip here, rather than passing a garbage string
-  // through to a buildResolvedAuth throw.
-  const authResult = resolveAuthFromDecryptedConfig(decrypted);
-  if (!authResult.ok) {
-    log.warn(
-      { installId, authKind: authResult.rawAuthKind },
-      "OpenAPI install uses an unsupported or deferred auth kind — skipping (oauth2 lands in slice 6)",
-    );
-    return null;
-  }
-  const auth = authResult.auth;
   const baseUrlOverride = typeof decrypted.base_url_override === "string" ? decrypted.base_url_override : undefined;
   const displayName =
     typeof decrypted.display_name === "string" && decrypted.display_name.length > 0
@@ -249,12 +324,9 @@ function buildDatasource(
   }
 
   // Slice 6a (#3028): a built-in data-candidate install carries its declarative
-  // quirk in the code-resident registry (keyed by catalog id), never in config —
-  // attach it so the agent tool can thread it into the client. A plain
-  // openapi-generic install (or an unknown catalog id) has none.
-  const candidate =
-    catalogId !== undefined ? findDataCandidateByCatalogId(catalogId) : undefined;
-
+  // quirk in the code-resident registry (resolved by the caller, passed in here),
+  // never in config — attach it so the agent tool can thread it into the client.
+  // A plain openapi-generic install (or an unknown catalog id) has none.
   return {
     id: installId,
     displayName,
@@ -272,28 +344,24 @@ function buildDatasource(
 
 /**
  * Decrypt + build the resolvable subset of already-loaded install rows.
- * Per-install failures (decrypt / snapshot / deferred-auth) are skipped and
- * logged — one broken install must never sink the workspace's others. Pure
- * (modulo logging); the query that loads `rows` is the caller's concern, so the
- * strict / soft variants below differ only in how a *query* failure is handled.
+ * Per-install failures (decrypt / snapshot / deferred-auth / mint) are skipped
+ * and logged — one broken install must never sink the workspace's others. Async
+ * because a github-data install mints its credential per resolve; the per-row
+ * resolution is sequential (a workspace has a handful of datasources, and the
+ * minter caches, so serial keeps the code simple without meaningful latency).
  */
-function buildDatasourcesFromRows(
+async function buildDatasourcesFromRows(
   workspaceId: string,
   rows: ReadonlyArray<OpenApiInstallRow>,
-): RestDatasource[] {
+  mint: MintInstallationTokenFn,
+): Promise<RestDatasource[]> {
   const out: RestDatasource[] = [];
   for (const row of rows) {
-    // Pick the decryption schema by catalog: a data candidate's config (slice 6a)
-    // carries fewer fields than the generic one, but both mark `auth_value` as the
-    // sole secret — so decryption is identical in practice; selecting the matching
-    // schema keeps the seam correct if a future candidate adds its own secret field.
-    const secretSchema =
-      row.catalog_id !== undefined && findDataCandidateByCatalogId(row.catalog_id) !== undefined
-        ? CANDIDATE_SECRET_SCHEMA
-        : GENERIC_SECRET_SCHEMA;
+    const candidate =
+      row.catalog_id !== undefined ? findDataCandidateByCatalogId(row.catalog_id) : undefined;
     let decrypted: Record<string, unknown>;
     try {
-      decrypted = decryptSecretFields(row.config ?? {}, secretSchema);
+      decrypted = decryptSecretFields(row.config ?? {}, secretSchemaFor(candidate));
     } catch (err) {
       log.warn(
         { workspaceId, installId: row.install_id, err: err instanceof Error ? err.message : String(err) },
@@ -301,7 +369,9 @@ function buildDatasourcesFromRows(
       );
       continue;
     }
-    const ds = buildDatasource(workspaceId, row.install_id, row.catalog_id, decrypted);
+    const auth = await resolveInstallAuth(row.install_id, candidate, decrypted, mint);
+    if (!auth) continue; // unsupported/deferred kind, missing credential, or mint failure (logged)
+    const ds = buildDatasource(workspaceId, row.install_id, candidate, decrypted, auth);
     if (ds) out.push(ds);
   }
   return out;
@@ -324,10 +394,11 @@ export async function resolveWorkspaceRestDatasourcesOrThrow(
   deps: ResolveWorkspaceDeps = {},
 ): Promise<ReadonlyArray<RestDatasource>> {
   const query = deps.query ?? defaultQuery;
+  const mint = deps.mintInstallationToken ?? ((id: string) => getGitHubInstallationToken(id));
   // A query failure propagates here, on purpose — the caller turns it into a
   // distinct "temporarily unavailable" signal rather than an empty result.
   const rows = await query(workspaceId);
-  return buildDatasourcesFromRows(workspaceId, rows);
+  return buildDatasourcesFromRows(workspaceId, rows, mint);
 }
 
 /**

--- a/packages/api/src/lib/tools/rest-operation.ts
+++ b/packages/api/src/lib/tools/rest-operation.ts
@@ -43,7 +43,10 @@ import { createLogger, getRequestContext } from "@atlas/api/lib/logger";
 import { executeOperation } from "@atlas/api/lib/openapi/client";
 import { OpenApiClientError, type OpenApiClientErrorReason } from "@atlas/api/lib/openapi/types";
 import { type RestDatasource } from "@atlas/api/lib/openapi/datasource";
-import { resolveWorkspaceRestDatasourcesOrThrow } from "@atlas/api/lib/openapi/workspace-datasource";
+import {
+  resolveWorkspaceRestDatasourcesOrThrow,
+  RestDatasourceReconnectError,
+} from "@atlas/api/lib/openapi/workspace-datasource";
 import {
   validateRestOperation,
   isSideEffectingOperation,
@@ -83,10 +86,13 @@ export type ExecuteRestOperationResult =
   | { status: "http_error"; httpStatus: number; body: unknown; message: string }
   | { status: "no_datasource"; message: string }
   /**
-   * The workspace's REST datasource registry couldn't be loaded (a transient
-   * failure reaching the config store) — distinct from `no_datasource` (the
-   * workspace genuinely has none). The agent must NOT tell the user no datasource
-   * is connected; it's temporarily unavailable. See #2929 review.
+   * The workspace's REST datasource exists but couldn't be made usable right now —
+   * either the registry couldn't be loaded (a transient config-store failure) or a
+   * connected datasource's credential is unresolvable and needs reconnecting (e.g.
+   * a github-data install whose GitHub App access was revoked, #3030). Distinct
+   * from `no_datasource` (the workspace genuinely has none): the agent must NOT
+   * tell the user no datasource is connected — the `message` says whether to retry
+   * shortly or to reconnect. See #2929 review.
    */
   | { status: "datasource_unavailable"; message: string }
   | { status: "datasource_not_found"; message: string; availableDatasources: string[] }
@@ -194,10 +200,27 @@ export function createExecuteRestOperationTool(deps: ExecuteRestOperationDeps = 
       try {
         datasources = await resolveDatasources();
       } catch (err) {
+        const requestId = getRequestContext()?.requestId;
+        // A connected datasource exists but its credential couldn't be resolved
+        // (e.g. a github-data install whose GitHub App access was revoked) — this
+        // is NOT "no datasource connected", it's "reconnect needed". Surface that
+        // distinctly so the agent points the user at a reconnect, not a dead end.
+        if (err instanceof RestDatasourceReconnectError) {
+          log.warn(
+            { requestId, reconnectableCount: err.reconnectableCount },
+            "executeRestOperation: workspace's REST datasource(s) need reconnecting — credential unresolvable",
+          );
+          return {
+            status: "datasource_unavailable",
+            message:
+              "This workspace's REST datasource is connected but Atlas couldn't authenticate to it right now — " +
+              "its credential needs to be refreshed (the connection may have been revoked or expired). Tell the " +
+              "user to reconnect it from Admin → Connections; do NOT claim no datasource is connected.",
+          };
+        }
         // The registry load failed (DB outage) — surface it as temporarily
         // unavailable, NOT as "no datasource connected". A false "none is
         // connected" claim would hide the outage from the user.
-        const requestId = getRequestContext()?.requestId;
         const message = err instanceof Error ? err.message : String(err);
         log.error(
           { requestId, err: message },

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useatlas/types",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Shared types for the Atlas text-to-SQL agent",
   "type": "module",
   "scripts": {

--- a/packages/types/src/catalog.ts
+++ b/packages/types/src/catalog.ts
@@ -34,8 +34,17 @@
  *   `guild_id`, Telegram `chat_id`, Teams `tenant_id`, WhatsApp phone
  *   number) via form. No per-Workspace bot token. Chat: Teams, Discord,
  *   Google Chat, Telegram, WhatsApp.
+ * - `oauth-datasource` — OAuth credential acquisition (the same
+ *   operator-owned App dance as `oauth`) but DATASOURCE persistence:
+ *   multi-instance (`install_id` composite PK), credential written to
+ *   `workspace_plugins.config` via selective-field encryption, and
+ *   probe-on-install caches the `openapi_snapshot`. Distinct from `oauth`
+ *   (single-instance chat/action, credential in `chat_cache` / per-plugin
+ *   store). v0.0.2 slice 6c (#3030): GitHub-as-datasource reuses GitHub's
+ *   existing App registration; the "refresh" path is App-JWT installation-
+ *   token minting, not refresh-token rotation. Pillar: datasource.
  */
-export const CATALOG_INSTALL_MODELS = ["oauth", "form", "static-bot"] as const;
+export const CATALOG_INSTALL_MODELS = ["oauth", "form", "static-bot", "oauth-datasource"] as const;
 export type CatalogInstallModel = (typeof CATALOG_INSTALL_MODELS)[number];
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #3030. v0.0.2 slice 6c — **the OQ5 deliverable** and the OAuth2 dimension of the generic-OpenAPI-datasource generalization proof (parent #2930, PRD #2868).

## OQ5 — new `OAuthDatasourceInstallHandler`, NOT a reuse of `OAuthPlatformInstallHandler`
A datasource OAuth install is a genuinely different *persistence* shape than a chat/action OAuth install: **multi-instance** (`install_id` composite PK, `pillar='datasource'`), credential **inline in `workspace_plugins.config`** via selective-field encryption, and **probe-on-install** caching the `openapi_snapshot`. So this borrows the OAuth *credential-acquisition* primitives (state token + the GitHub App ownership-verification, extracted to a shared `github-app-oauth.ts`) and owns the datasource persistence path — the same shape `OpenApiGenericFormInstallHandler` writes, with OAuth-shaped acquisition instead of a form.

A new `oauth-datasource` `install_model` (in `@useatlas/types` `CATALOG_INSTALL_MODELS`) drives a new dispatch-union member + dispatch case; the exhaustive `never` branch still holds. The OAuth install/callback **route is shared** with `oauth` (the HTTP dance is identical) — only the handler's persistence differs.

## OQ6 — `github-data` is a thin wrapper, not a plugin-extension
GitHub's only non-generic data dimension is `Link`-header pagination, which is **already a generic strategy**. No GitHub-specific walker/paginator/validator: `github-data` is a `DataCandidate` row pointing the generic primitive at GitHub's published OpenAPI spec. The OAuth-ness is an *install-handler* concern, confined to the handler + the credential resolver — never the query path.

## How the credential works (the "refresh" path)
GitHub Apps carry no long-lived bearer token. We persist only the `installation_id` (encrypted); the executable credential is a **short-lived installation access token** minted on demand from the App JWT (`github/installation-token.ts`), cached in-process and **re-minted transparently on ~1hr expiry** — not refresh-token rotation. The handler mints once at install as a health-check: a failure flips the install to **reconnect-needed** (`credentialResult.written=false`) while still persisting the row; the query-time resolver re-mints regardless, so a later-fixed App access recovers without a re-install. `github-data` reuses the **existing GitHub App registration** (same `GITHUB_APP_*` env as the `github` action row) — no new vendor app.

## Generalization gap surfaced + fixed in the primitive
GitHub's REST list endpoints return a **top-level array**, but the `link-header` strategy required a non-empty `itemsPath`. Fixed in the primitive: `itemsPath` now defaults to the response root, so GitHub's bare-array lists paginate without a forked strategy (the AC-preferred outcome).

## What's in here
- `OAuthDatasourceInstallHandler` (`oauth-datasource-handler.ts`) + shared `github-app-oauth.ts` (extracted from `github-oauth-handler.ts`, which now consumes it).
- `github/installation-token.ts` — App-JWT → installation-token mint + cache + re-mint.
- `github-data` candidate (`data-candidates.ts` is now a `FormDataCandidate | OAuthDatasourceDataCandidate` union) + per-candidate seed `install_model`/`config_schema` + migration `0111` (CHECK widen + row) + `schema.ts` mirror.
- Resolver (`workspace-datasource.ts`): github-data → mint installation token → `bearer`, fail-soft skip on mint failure (injectable minter seam).
- Route (`integrations.ts`): `oauth-datasource` accepted on the OAuth install/callback path; `github-data` joins the `installation_id`-extras branch + `INSTALLATION_ID_PLATFORMS`.
- Env-gated `registerOAuthDatasourceHandler` for github-data (same `GITHUB_APP_*` gate as the action row).
- Docs: operator-facing OAuth2/github-data section on the OpenAPI-datasource page.

## Acceptance criteria
- [x] `OAuthDatasourceInstallHandler` with multi-instance datasource persistence (not the chat-platform shape); dispatch union extended, exhaustive `never` holds
- [x] OAuth2 install completes end-to-end: authorize → callback → ownership verify → probe-on-install → installation-token mint → encrypted credential + `openapi_snapshot` cached
- [x] Installation-token expiry re-mints transparently (App-JWT path); partial install failure → reconnect-needed
- [x] `github-data` resolves a minted `bearer` credential against `api.github.com`; Link-header pagination (root-array) covered
- [x] Cross-org isolation: install row workspace-scoped; ownership check rejects an installation the user doesn't own (test)
- [x] Demonstrably a thin data-wrapper — reuses the generic walker/paginator/validator; GitHub-specific code confined to the install handler + resolver
- [x] Tests: state verify/replay, code-exchange (injected fetch), installation-token mint/cache/re-mint, probe-on-install snapshot, cross-org reject, Link-header (root array) pagination

## Generalization-gap note (#2930 AC)
GitHub's published OpenAPI document is large; probe-on-install fetches + snapshots it into `workspace_plugins.config`. If the full spec proves too big to snapshot in practice, the follow-up is a size cap or a curated subset URL — flagged in the candidate JSDoc, filed rather than forked (the walker/paginator/validator stay generic).

## Migration numbering
Uses `0111` — `0110` is reserved by the parallel slice-6b (notion-data) session. Independent of `0110` (only touches `plugin_catalog`). After both 6b and 6c land, parent #2930 + PRD #2868 can close.

## CI
lint, type, full test (api 530/530 + others), syncpack, template/security-header/railway/schema/oauth-helper drift, test-discipline, twenty-resolver, published-symbols — all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3036"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782778568&installation_id=135337507&pr_number=3036&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3036&signature=50086ee7d57b00072db43a1fcd66c0f954c969699b1a1b1301eacb48633fe447"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GitHub added as a pre-wired OAuth datasource with multi-instance installs, encrypted installation credentials, on-demand short-lived installation tokens, and coalesced concurrent token requests.

* **Bug Fixes / UX**
  * Admin redirects for built-in REST datasources go to Connections; confirm/operation endpoints return a clear "reconnect required" (503) when credentials need reauthorization. Pagination handles GitHub Link-header and root-array responses.

* **Documentation**
  * Guide for GitHub pre-wired datasource, env vars, token lifecycle, and reconnect behavior.

* **Tests**
  * Added extensive tests for OAuth-datasource install flow, token minting, pagination, and resolver behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->