### PR TITLE
fix(api): gate OpenAPI probe credential on spec-host match (#3034)

### DIFF
--- a/packages/api/src/api/routes/__tests__/admin-openapi-datasources.test.ts
+++ b/packages/api/src/api/routes/__tests__/admin-openapi-datasources.test.ts
@@ -43,6 +43,10 @@ let CURRENT_ORG = "org-owner";
 let probeShouldFail = false;
 /** Force resolveAuthFromDecryptedConfig to its ok:false arm (rediscover 400 tests). */
 let authResultOverride: { ok: false; rawAuthKind: string } | null = null;
+/** Extra config fields merged into the loaded install row (e.g. base_url_override). */
+let configExtra: Record<string, unknown> = {};
+/** The `options` the route last passed to `probeSpec` — asserts the #3034 host gate is threaded. */
+let lastProbeOptions: { apiBaseUrl?: string } | undefined;
 
 const CATALOG_ID = "catalog:openapi-generic";
 
@@ -84,7 +88,11 @@ const FIXTURE = {
  */
 const db = createOpenApiDatasourceTestLayer((sql, params) => {
   const ws = params[0];
-  const ownedRow = { install_id: FIXTURE.install_id, config: FIXTURE.config, status: FIXTURE.status };
+  const ownedRow = {
+    install_id: FIXTURE.install_id,
+    config: { ...FIXTURE.config, ...configExtra },
+    status: FIXTURE.status,
+  };
 
   if (sql.includes("DELETE FROM workspace_plugins")) {
     const instId = params[1];
@@ -170,7 +178,8 @@ mock.module("@atlas/api/lib/openapi/probe", () => {
     // auth_kind is "none", so the success arm (ok: true) is the relevant one;
     // the 400 (ok: false) branch is exercised by the workspace-resolver tests.
     resolveAuthFromDecryptedConfig: () => authResultOverride ?? { ok: true, auth: { kind: "none" } },
-    probeSpec: async () => {
+    probeSpec: async (_url: string, _auth: unknown, options?: { apiBaseUrl?: string }) => {
+      lastProbeOptions = options;
       if (probeShouldFail) throw new OpenApiProbeError("unreachable", "probe boom");
       return { doc: { openapi: "3.1.0" }, graph: emptyGraph };
     },
@@ -222,6 +231,8 @@ afterAll(async () => {
 beforeEach(() => {
   CURRENT_ORG = FIXTURE.owner;
   probeShouldFail = false;
+  configExtra = {};
+  lastProbeOptions = undefined;
   db.clear();
   invalidateGraphCacheSpy.mockClear();
 });
@@ -229,6 +240,8 @@ afterEach(() => {
   CURRENT_ORG = FIXTURE.owner;
   probeShouldFail = false;
   authResultOverride = null;
+  configExtra = {};
+  lastProbeOptions = undefined;
 });
 
 // ── Workspace scoping (tenant isolation) ─────────────────────────────────────
@@ -330,6 +343,25 @@ describe("admin-openapi-datasources — rediscover error mapping", () => {
       ([sql]) => sql.includes("UPDATE") && sql.includes("openapi_snapshot"),
     );
     expect(update).toBeDefined();
+  });
+
+  it("threads base_url_override as the probe host gate (apiBaseUrl) on re-probe (#3034)", async () => {
+    // The stored API host is the admin's base_url_override. The route must forward
+    // it to probeSpec so the host-match gate decides whether to re-attach the
+    // credential — install + rediscover stay symmetric. A regression that drops the
+    // `{ apiBaseUrl }` thread would silently re-open the leak on the refresh path.
+    configExtra = { base_url_override: "https://crm.example.com" };
+    const res = await adminOpenApiDatasources.request("/ds-1/rediscover", { method: "POST" });
+    expect(res.status).toBe(200);
+    expect(lastProbeOptions?.apiBaseUrl).toBe("https://crm.example.com");
+  });
+
+  it("passes NO apiBaseUrl when the stored config has no base_url_override (fail-safe withhold)", async () => {
+    // The fixture config has no base_url_override → the gate host is unknown, so the
+    // re-probe must withhold the credential (probeSpec receives no apiBaseUrl).
+    const res = await adminOpenApiDatasources.request("/ds-1/rediscover", { method: "POST" });
+    expect(res.status).toBe(200);
+    expect(lastProbeOptions?.apiBaseUrl).toBeUndefined();
   });
 
   it("maps a deferred oauth2 row to a 400 with the oauth2-specific message (no UPDATE)", async () => {

--- a/packages/api/src/api/routes/admin-openapi-datasources.ts
+++ b/packages/api/src/api/routes/admin-openapi-datasources.ts
@@ -342,9 +342,19 @@ adminOpenApiDatasources.openapi(rediscoverRoute, async (c) =>
     }
     const auth = authResult.auth;
 
+    // Host-match credential gate (#3034): the re-probe attaches the stored
+    // credential ONLY when the spec host matches the datasource's API host. This
+    // route manages generic OpenAPI installs, whose API host is the admin-supplied
+    // `base_url_override` (absent ⇒ the credential is withheld — the same fail-safe
+    // the install path applies, so install + rediscover stay symmetric).
+    const baseUrlOverride =
+      typeof decrypted.base_url_override === "string" ? decrypted.base_url_override : undefined;
+
     let snapshot: OpenApiSnapshot;
     try {
-      const { doc, graph } = await probeSpec(openapiUrl, auth);
+      const { doc, graph } = await probeSpec(openapiUrl, auth, {
+        ...(baseUrlOverride ? { apiBaseUrl: baseUrlOverride } : {}),
+      });
       snapshot = buildSnapshot(doc, graph, new Date().toISOString());
     } catch (err) {
       if (err instanceof OpenApiProbeError) {

--- a/packages/api/src/lib/integrations/install/__tests__/data-candidate-form-handler.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/data-candidate-form-handler.test.ts
@@ -50,11 +50,13 @@ describe("DataCandidateFormInstallHandler.validateConfig", () => {
 
   let queryCalls: Array<{ sql: string; params: unknown[] }>;
   let probedUrls: string[];
+  let probedHeaders: Array<Record<string, string>>;
   const ORIGINAL_ENV = { ...process.env };
 
   beforeEach(() => {
     queryCalls = [];
     probedUrls = [];
+    probedHeaders = [];
     // Set an encryption keyset so auth_value is actually encrypted at rest
     // (mirrors openapi-generic-form-handler.test.ts:setKeys) — without it the
     // keyless dev passthrough stores plaintext and the encryption assertions fail.
@@ -113,5 +115,35 @@ describe("DataCandidateFormInstallHandler.validateConfig", () => {
     expect(configJson).not.toContain("sk_live_secret");
     // The locked spec URL + auth kind are persisted from the candidate, not the form.
     expect(configJson).toContain(STRIPE_DATA_CANDIDATE.openapiUrl);
+  });
+
+  it("does NOT send the customer credential to the third-party spec host (#3034)", async () => {
+    const { DataCandidateFormInstallHandler } = await import("../data-candidate-form-handler");
+    const handler = new DataCandidateFormInstallHandler(STRIPE_DATA_CANDIDATE, {
+      idGenerator: () => "fixed-uuid",
+      now: () => "2026-05-30T00:00:00.000Z",
+      fetchImpl: (async (input: string | URL, init?: RequestInit) => {
+        probedUrls.push(typeof input === "string" ? input : input.toString());
+        const headers: Record<string, string> = {};
+        const h = init?.headers as Record<string, string> | undefined;
+        if (h) for (const [k, v] of Object.entries(h)) headers[k] = v;
+        probedHeaders.push(headers);
+        return new Response(JSON.stringify(STRIPE_FIXTURE_SPEC), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }) as unknown as typeof globalThis.fetch,
+    });
+
+    await handler.validateConfig("ws-1" as never, { auth_value: "sk_live_super_secret" });
+
+    // The spec is fetched from raw.githubusercontent.com while the secret key is
+    // for api.stripe.com — the probe must carry NO Authorization header and the key
+    // must never appear in the spec-fetch URL. The credential reaches Stripe only at
+    // query time, host-side.
+    expect(probedUrls[0]).toBe(STRIPE_DATA_CANDIDATE.openapiUrl);
+    expect(probedUrls[0]).toContain("raw.githubusercontent.com");
+    expect(probedHeaders[0]?.Authorization).toBeUndefined();
+    expect(probedUrls[0]).not.toContain("sk_live_super_secret");
   });
 });

--- a/packages/api/src/lib/integrations/install/__tests__/openapi-generic-form-handler.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/openapi-generic-form-handler.test.ts
@@ -279,7 +279,26 @@ describe("OpenApiGenericFormInstallHandler — persistence + encryption", () => 
     expect(snapshot.doc).toBeDefined();
   });
 
-  it("sends the bearer credential when probing the spec", async () => {
+  it("sends the bearer credential when the spec host matches the API host (base_url_override)", async () => {
+    const probe = makeProbeFetch();
+    const handler = new OpenApiGenericFormInstallHandler({
+      idGenerator: () => "x",
+      now: () => "2026-05-29T00:00:00.000Z",
+      fetchImpl: probe.fetchImpl,
+    });
+    // The credential is attached only when the spec is on the API host (#3034) — a
+    // same-host base_url_override (Twenty's posture) makes the gate send it.
+    await handler.validateConfig(
+      WSID,
+      validForm({ auth_value: "probe-token", base_url_override: "https://widgets.example.com/v1" }),
+    );
+    expect(probe.calls).toHaveLength(1);
+    expect(probe.calls[0].headers.Authorization).toBe("Bearer probe-token");
+  });
+
+  it("withholds the credential from the spec fetch when no base_url_override is given (#3034)", async () => {
+    // Without a base_url_override the API host is unknown at probe time, so the
+    // gate fails safe and never sends the workspace credential to the spec host.
     const probe = makeProbeFetch();
     const handler = new OpenApiGenericFormInstallHandler({
       idGenerator: () => "x",
@@ -288,7 +307,7 @@ describe("OpenApiGenericFormInstallHandler — persistence + encryption", () => 
     });
     await handler.validateConfig(WSID, validForm({ auth_value: "probe-token" }));
     expect(probe.calls).toHaveLength(1);
-    expect(probe.calls[0].headers.Authorization).toBe("Bearer probe-token");
+    expect(probe.calls[0].headers.Authorization).toBeUndefined();
   });
 
   it("refuses to persist in SaaS mode without an encryption keyset", async () => {

--- a/packages/api/src/lib/integrations/install/data-candidate-form-handler.ts
+++ b/packages/api/src/lib/integrations/install/data-candidate-form-handler.ts
@@ -107,6 +107,9 @@ export class DataCandidateFormInstallHandler implements FormBasedInstallHandler 
       openapiUrl: this.candidate.openapiUrl,
       authKind: this.candidate.authKind,
       authValue: data.auth_value,
+      // The candidate's real API host — gates the probe credential (#3034) so the
+      // customer key never reaches the public spec host (raw.githubusercontent.com).
+      apiBaseUrl: this.candidate.apiBaseUrl,
       ...(data.base_url_override ? { baseUrlOverride: data.base_url_override } : {}),
       ...(data.display_name ? { displayName: data.display_name } : {}),
       newId: this.newId,

--- a/packages/api/src/lib/integrations/install/openapi-generic-form-handler.ts
+++ b/packages/api/src/lib/integrations/install/openapi-generic-form-handler.ts
@@ -274,6 +274,14 @@ export interface PersistOpenApiDatasourceInstallParams {
   readonly authHeaderName?: string;
   readonly authParamName?: string;
   readonly baseUrlOverride?: string;
+  /**
+   * The candidate's declared API base URL (host), used only to gate the probe
+   * credential (#3034): the credential is sent to the spec host iff it matches
+   * this host (or the `baseUrlOverride` host, which takes precedence). Absent for
+   * a generic install with no `baseUrlOverride` ⇒ the credential is withheld
+   * (fail-safe). See {@link import("../../openapi/probe").ProbeOptions.apiBaseUrl}.
+   */
+  readonly apiBaseUrl?: string;
   readonly writeAllowlist?: string;
   readonly displayName?: string;
   readonly newId: () => string;
@@ -308,6 +316,7 @@ export async function persistOpenApiDatasourceInstall(
     authHeaderName,
     authParamName,
     baseUrlOverride,
+    apiBaseUrl,
     writeAllowlist,
     displayName,
     newId,
@@ -366,10 +375,18 @@ export async function persistOpenApiDatasourceInstall(
   }
 
   // ── Probe the spec (slice-0) → snapshot ───────────────────────────
-  // The credential is needed because some specs require auth to read. A probe
+  // Some specs require the credential to read (Twenty's same-host /open-api/core);
+  // others are public (the built-in candidates pin their spec to GitHub's raw CDN).
+  // The probe attaches the credential ONLY when the spec host matches the resolved
+  // API host (#3034): `base_url_override` if the admin supplied one, else the
+  // candidate's declared `apiBaseUrl`, else unknown ⇒ withheld (fail-safe). A probe
   // failure is a user-fixable input error → 400 on `openapi_url`, not a 500.
   const auth = buildResolvedAuth(authKind, authValue, authHeaderName, authParamName);
-  const probeOpts: ProbeOptions = fetchImpl ? { fetchImpl } : {};
+  const resolvedApiBaseUrl = baseUrlOverride ?? apiBaseUrl;
+  const probeOpts: ProbeOptions = {
+    ...(fetchImpl ? { fetchImpl } : {}),
+    ...(resolvedApiBaseUrl ? { apiBaseUrl: resolvedApiBaseUrl } : {}),
+  };
   let snapshot;
   try {
     const { doc, graph } = await probeSpec(openapiUrl, auth, probeOpts);

--- a/packages/api/src/lib/openapi/__tests__/data-candidates.test.ts
+++ b/packages/api/src/lib/openapi/__tests__/data-candidates.test.ts
@@ -51,6 +51,19 @@ describe("DATA_CANDIDATES registry invariants", () => {
     expect(findDataCandidateBySlug("nope")).toBeUndefined();
   });
 
+  it("every candidate declares an apiBaseUrl whose host differs from its spec host (#3034 contract)", () => {
+    // Every built-in candidate pins its spec to a public host (raw.githubusercontent.com)
+    // while its API lives elsewhere. That host gap is exactly what makes the probe
+    // host-match gate WITHHOLD the customer credential from the spec fetch — so this
+    // invariant guards the leak fix at the registry level.
+    for (const c of DATA_CANDIDATES) {
+      const specHost = new URL(c.openapiUrl).host;
+      const apiHost = new URL(c.apiBaseUrl).host;
+      expect(apiHost, `${c.slug} apiBaseUrl must be well-formed`).not.toBe("");
+      expect(specHost, `${c.slug}: spec host must differ from API host`).not.toBe(apiHost);
+    }
+  });
+
   it("every candidate's pagination config resolves over the GENERIC registry (no forked strategy)", () => {
     for (const c of DATA_CANDIDATES) {
       if (c.pagination === undefined) continue;

--- a/packages/api/src/lib/openapi/__tests__/probe.test.ts
+++ b/packages/api/src/lib/openapi/__tests__/probe.test.ts
@@ -82,13 +82,18 @@ describe("probeSpec", () => {
     expect(graph.info.title).toBe("Mock Widget API");
   });
 
-  it("sends bearer auth on the probe request", async () => {
+  it("sends bearer auth on the probe request (spec host == API host)", async () => {
     let seen: Record<string, string> = {};
     const fetchImpl = (async (_url: unknown, init?: RequestInit) => {
       seen = (init?.headers as Record<string, string>) ?? {};
       return new Response(JSON.stringify(MOCK_OPENAPI_SPEC), { status: 200 });
     }) as unknown as typeof globalThis.fetch;
-    await probeSpec("https://x.com/o.json", { kind: "bearer", token: "abc" }, { fetchImpl });
+    // The credential is only attached when the spec is on the API host (#3034) —
+    // pass a same-host apiBaseUrl so this asserts the happy-path send.
+    await probeSpec("https://x.com/o.json", { kind: "bearer", token: "abc" }, {
+      fetchImpl,
+      apiBaseUrl: "https://x.com",
+    });
     expect(seen.Authorization).toBe("Bearer abc");
   });
 
@@ -122,6 +127,89 @@ describe("probeSpec", () => {
       fetchImpl: fetchReturning(empty),
     }).catch((e) => e);
     expect((err as OpenApiProbeError).reason).toBe("no_operations");
+  });
+});
+
+describe("probeSpec — credential-host gate (#3034)", () => {
+  /** A probe `fetch` that serves the mock spec and captures the URL + headers it saw. */
+  function capturingFetch(spec: unknown = MOCK_OPENAPI_SPEC): {
+    fetchImpl: typeof globalThis.fetch;
+    calls: Array<{ url: string; headers: Record<string, string> }>;
+  } {
+    const calls: Array<{ url: string; headers: Record<string, string> }> = [];
+    const fetchImpl = (async (input: unknown, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : String(input);
+      const headers: Record<string, string> = {};
+      const h = init?.headers as Record<string, string> | undefined;
+      if (h) for (const [k, v] of Object.entries(h)) headers[k] = v;
+      calls.push({ url, headers });
+      return new Response(JSON.stringify(spec), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }) as unknown as typeof globalThis.fetch;
+    return { fetchImpl, calls };
+  }
+
+  it("withholds the credential when the spec host differs from the API host (third-party spec)", async () => {
+    // The leak the issue describes: a built-in data candidate (stripe-data) pins its
+    // spec to raw.githubusercontent.com while its API lives on api.stripe.com — the
+    // customer's bearer token must NOT reach GitHub.
+    const { fetchImpl, calls } = capturingFetch();
+    await probeSpec(
+      "https://raw.githubusercontent.com/stripe/openapi/master/openapi/spec3.json",
+      { kind: "bearer", token: "sk_live_super_secret" },
+      { fetchImpl, apiBaseUrl: "https://api.stripe.com" },
+    );
+    expect(calls).toHaveLength(1);
+    expect(calls[0].headers.Authorization).toBeUndefined();
+  });
+
+  it("sends the credential when the spec host equals the API host (Twenty same-host spec)", async () => {
+    const { fetchImpl, calls } = capturingFetch();
+    await probeSpec(
+      "https://api.twenty.example/rest/open-api/core",
+      { kind: "bearer", token: "twenty-token" },
+      { fetchImpl, apiBaseUrl: "https://api.twenty.example/rest" },
+    );
+    expect(calls[0].headers.Authorization).toBe("Bearer twenty-token");
+  });
+
+  it("withholds the credential when the API host is unknown (no apiBaseUrl — fail-safe)", async () => {
+    const { fetchImpl, calls } = capturingFetch();
+    await probeSpec("https://spec.example.com/o.json", { kind: "bearer", token: "tok" }, { fetchImpl });
+    expect(calls[0].headers.Authorization).toBeUndefined();
+  });
+
+  it("withholds the apiKey-query credential from a cross-origin spec URL (no key in the query string)", async () => {
+    const { fetchImpl, calls } = capturingFetch();
+    await probeSpec(
+      "https://raw.githubusercontent.com/x/spec.json",
+      { kind: "apiKey", value: "secret-query-key", placement: { in: "query", name: "api_key" } },
+      { fetchImpl, apiBaseUrl: "https://api.vendor.com" },
+    );
+    expect(calls[0].url).not.toContain("api_key");
+    expect(calls[0].url).not.toContain("secret-query-key");
+  });
+
+  it("appends the apiKey-query credential to a same-host spec URL", async () => {
+    const { fetchImpl, calls } = capturingFetch();
+    await probeSpec(
+      "https://api.vendor.com/open-api",
+      { kind: "apiKey", value: "secret-query-key", placement: { in: "query", name: "api_key" } },
+      { fetchImpl, apiBaseUrl: "https://api.vendor.com" },
+    );
+    expect(calls[0].url).toContain("api_key=secret-query-key");
+  });
+
+  it("withholds an apikey-header credential from a cross-origin spec host", async () => {
+    const { fetchImpl, calls } = capturingFetch();
+    await probeSpec(
+      "https://raw.githubusercontent.com/x/spec.json",
+      { kind: "apiKey", value: "secret-hdr-key", placement: { in: "header", name: "X-API-Key" } },
+      { fetchImpl, apiBaseUrl: "https://api.vendor.com" },
+    );
+    expect(calls[0].headers["X-API-Key"]).toBeUndefined();
   });
 });
 

--- a/packages/api/src/lib/openapi/__tests__/probe.test.ts
+++ b/packages/api/src/lib/openapi/__tests__/probe.test.ts
@@ -202,6 +202,19 @@ describe("probeSpec — credential-host gate (#3034)", () => {
     expect(calls[0].url).toContain("api_key=secret-query-key");
   });
 
+  it("withholds the credential when the API base host is an empty-host URL (opaque scheme, fail-safe)", async () => {
+    // `urlHost` collapses both unparseable AND empty-host (opaque-scheme) URLs to
+    // null, so two empty hosts must never compare equal and send the credential —
+    // the gate stays fail-safe without leaning on an upstream scheme check.
+    const { fetchImpl, calls } = capturingFetch();
+    await probeSpec(
+      "https://spec.example.com/o.json",
+      { kind: "bearer", token: "tok" },
+      { fetchImpl, apiBaseUrl: "data:text/plain,not-a-host" },
+    );
+    expect(calls[0].headers.Authorization).toBeUndefined();
+  });
+
   it("withholds an apikey-header credential from a cross-origin spec host", async () => {
     const { fetchImpl, calls } = capturingFetch();
     await probeSpec(

--- a/packages/api/src/lib/openapi/data-candidates.ts
+++ b/packages/api/src/lib/openapi/data-candidates.ts
@@ -57,6 +57,16 @@ export interface BaseDataCandidate {
   /** Pre-filled OpenAPI 3.x spec URL — the admin never pastes this. */
   readonly openapiUrl: string;
   /**
+   * The candidate's real API base URL (host), e.g. `https://api.stripe.com`.
+   * Used SOLELY to gate the install/rediscover probe credential (#3034): the
+   * credential is sent to {@link openapiUrl} iff the two share a host. Every
+   * built-in candidate pins its spec to a public host (raw.githubusercontent.com)
+   * while its API lives elsewhere, so this differs from {@link openapiUrl}'s host
+   * — which is exactly why the customer credential must NOT be sent to the spec
+   * host. An admin `base_url_override` takes precedence over this at probe time.
+   */
+  readonly apiBaseUrl: string;
+  /**
    * Declarative deviations the generic client applies per request (required
    * static headers / query param-shaping). Omit for a perfectly-generic API.
    */
@@ -207,6 +217,10 @@ export const STRIPE_DATA_CANDIDATE: FormDataCandidate = {
     "REST datasource. Pre-wired to Stripe's published OpenAPI spec — paste your secret key, no " +
     "spec URL needed. The agent discovers operations from the spec and queries them directly.",
   openapiUrl: "https://raw.githubusercontent.com/stripe/openapi/master/openapi/spec3.json",
+  // The spec is on GitHub; the API (and the only host the secret key may reach) is
+  // api.stripe.com — so the host-match gate (#3034) withholds the key from the
+  // spec fetch and only sends it at query time.
+  apiBaseUrl: "https://api.stripe.com",
   authKind: "bearer",
   quirk: {
     // Stripe wants array params as `expand[]=a&expand[]=b`; the spec declares a
@@ -256,6 +270,11 @@ export const GITHUB_DATA_CANDIDATE: OAuthDatasourceDataCandidate = {
     "following Link-header pagination.",
   openapiUrl:
     "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/api.github.com/api.github.com.json",
+  // The published spec is on GitHub's raw CDN; the API host is api.github.com.
+  // github-data probes with `{ kind: "none" }` (no credential at probe — the
+  // installation token is minted at query time), so the gate is moot here, but the
+  // real API host is declared for accuracy + the host-match contract (#3034).
+  apiBaseUrl: "https://api.github.com",
   installModel: "oauth-datasource",
   credentialMode: "github-app-installation",
   pagination: {
@@ -301,6 +320,10 @@ export const NOTION_DATA_CANDIDATE: DataCandidate = {
     "spec URL needed. The agent discovers operations from the spec and queries them directly.",
   openapiUrl:
     "https://raw.githubusercontent.com/makenotion/notion-mcp-server/main/scripts/notion-openapi.json",
+  // The spec is on GitHub; the API (and the only host the integration token may
+  // reach) is api.notion.com — the host-match gate (#3034) withholds the token
+  // from the spec fetch.
+  apiBaseUrl: "https://api.notion.com",
   authKind: "bearer",
   quirk: {
     // Notion mandates a version header on every request; the spec declares it as an

--- a/packages/api/src/lib/openapi/data-candidates.ts
+++ b/packages/api/src/lib/openapi/data-candidates.ts
@@ -58,12 +58,15 @@ export interface BaseDataCandidate {
   readonly openapiUrl: string;
   /**
    * The candidate's real API base URL (host), e.g. `https://api.stripe.com`.
-   * Used SOLELY to gate the install/rediscover probe credential (#3034): the
-   * credential is sent to {@link openapiUrl} iff the two share a host. Every
-   * built-in candidate pins its spec to a public host (raw.githubusercontent.com)
-   * while its API lives elsewhere, so this differs from {@link openapiUrl}'s host
-   * — which is exactly why the customer credential must NOT be sent to the spec
-   * host. An admin `base_url_override` takes precedence over this at probe time.
+   * Used SOLELY to gate the install-time probe credential (#3034) — only its HOST
+   * is consulted, and NOT at query time (the executable base URL is re-derived from
+   * the spec's `servers[]` / `base_url_override`; see `workspace-datasource.ts`).
+   * The probe credential is sent to {@link openapiUrl} iff the two share a host.
+   * Today every built-in candidate pins its spec to a public host
+   * (raw.githubusercontent.com) while its API lives elsewhere, so for them this
+   * differs from {@link openapiUrl}'s host — exactly the case the gate is designed
+   * to catch (withhold the credential from the spec host). An admin
+   * `base_url_override` takes precedence over this at probe time.
    */
   readonly apiBaseUrl: string;
   /**

--- a/packages/api/src/lib/openapi/probe.ts
+++ b/packages/api/src/lib/openapi/probe.ts
@@ -115,10 +115,18 @@ export interface ProbeOptions {
   readonly apiBaseUrl?: string;
 }
 
-/** A URL's host (`hostname[:port]`, already lowercased by the URL parser), or `null` when unparseable. */
+/**
+ * A URL's host (`hostname[:port]`, already lowercased by the URL parser), or
+ * `null` when the URL is unparseable OR has no host (opaque-scheme URLs like
+ * `data:` / `javascript:` parse successfully with an empty host). Collapsing both
+ * "unparseable" and "empty host" to `null` keeps {@link probeCredentialAllowed}
+ * self-defending: two empty hosts must never compare equal and send the
+ * credential — the gate fails safe without depending on an upstream scheme check.
+ */
 function urlHost(url: string): string | null {
   try {
-    return new URL(url).host;
+    const host = new URL(url).host;
+    return host.length > 0 ? host : null;
   } catch {
     // intentionally ignored: an unparseable URL has no comparable host — the
     // caller treats null as "no host match" and withholds the credential.
@@ -136,6 +144,11 @@ function urlHost(url: string): string | null {
  * unparseable, ⇒ `false` (fail-safe: never send the credential to an un-vetted
  * host). Deliberately NO opt-in flag — the bug was an unsafe default, and the fix
  * must not add a lever that re-enables sending to an arbitrary host.
+ *
+ * Match is intentionally EXACT host (`hostname[:port]`) — `api.stripe.com` does
+ * NOT match `files.stripe.com` or `stripe.com`. Only the host is compared (scheme
+ * and path are ignored, so a same-host spec on a sub-path still authenticates).
+ * Relaxing this to suffix/subdomain matching would be a security regression.
  */
 function probeCredentialAllowed(specUrl: string, apiBaseUrl: string | undefined): boolean {
   if (!apiBaseUrl) return false;

--- a/packages/api/src/lib/openapi/probe.ts
+++ b/packages/api/src/lib/openapi/probe.ts
@@ -18,6 +18,7 @@
  * the route layer maps them to actionable 4xx/5xx envelopes instead of a 500.
  */
 
+import { createLogger } from "@atlas/api/lib/logger";
 import { assertBaseUrlAllowed, guardedFetch, EgressBlockedError } from "./egress-guard";
 import { buildOperationGraph } from "./spec";
 import {
@@ -31,6 +32,8 @@ import {
   type OpenApiSnapshot,
   type DiscoveredOperationSummary,
 } from "./catalog";
+
+const log = createLogger("openapi.probe");
 
 /** Per-probe fetch timeout. Configurable via `ATLAS_OPENAPI_TIMEOUT` (ms). */
 function probeTimeoutMs(): number {
@@ -99,6 +102,46 @@ export function assertSpecUrlAllowed(specUrl: string): void {
 export interface ProbeOptions {
   /** `fetch` override for tests. Defaults to `globalThis.fetch`. */
   readonly fetchImpl?: typeof globalThis.fetch;
+  /**
+   * The datasource's resolved API base URL (or any URL on its API host) — the
+   * admin's `base_url_override` if supplied, else a candidate-declared
+   * `apiBaseUrl`. Used SOLELY to gate the probe credential (#3034): the
+   * credential is attached to the spec fetch iff this URL's host equals the spec
+   * URL's host. ABSENT ⇒ the credential is never attached (fail-safe) — so a spec
+   * pinned to a public third-party host (raw.githubusercontent.com for
+   * stripe-data / notion-data) cannot receive the workspace credential, while a
+   * same-host authenticated spec (Twenty's `/open-api/core`) still authenticates.
+   */
+  readonly apiBaseUrl?: string;
+}
+
+/** A URL's host (`hostname[:port]`, already lowercased by the URL parser), or `null` when unparseable. */
+function urlHost(url: string): string | null {
+  try {
+    return new URL(url).host;
+  } catch {
+    // intentionally ignored: an unparseable URL has no comparable host — the
+    // caller treats null as "no host match" and withholds the credential.
+    return null;
+  }
+}
+
+/**
+ * The host-match credential gate (#3034). The probe credential may be attached to
+ * the spec fetch ONLY when the resolved API host is known AND equals the spec
+ * URL's host — so a same-host authenticated spec (Twenty: `/open-api/core` on the
+ * API host) still authenticates, while a spec pinned to a public third-party host
+ * (stripe-data / notion-data both fetch from raw.githubusercontent.com) never
+ * receives the workspace credential. An unknown API host, or either URL
+ * unparseable, ⇒ `false` (fail-safe: never send the credential to an un-vetted
+ * host). Deliberately NO opt-in flag — the bug was an unsafe default, and the fix
+ * must not add a lever that re-enables sending to an arbitrary host.
+ */
+function probeCredentialAllowed(specUrl: string, apiBaseUrl: string | undefined): boolean {
+  if (!apiBaseUrl) return false;
+  const specHost = urlHost(specUrl);
+  const apiHost = urlHost(apiBaseUrl);
+  return specHost !== null && apiHost !== null && specHost === apiHost;
 }
 
 /**
@@ -201,6 +244,11 @@ export function resolveAuthFromDecryptedConfig(
  * endpoint is usually unauthenticated, but some APIs (Twenty) require the same
  * credential to read `/open-api/core`, so we send it. apiKey-query placement is
  * applied to the URL by {@link probeSpec}; this only handles header-borne auth.
+ *
+ * Whether the credential is attached at all is decided UPSTREAM by
+ * {@link probeSpec}'s host-match gate (#3034) — this helper is called only when
+ * the spec host equals the datasource's API host. It always emits the header for
+ * the kind it's given.
  */
 function authHeadersForProbe(auth: ResolvedAuth): Record<string, string> {
   switch (auth.kind) {
@@ -236,10 +284,26 @@ export async function probeSpec(
   // private/internal targets before the fetch. #3006.
   assertSpecUrlAllowed(openapiUrl);
 
+  // Host-match credential gate (#3034): the credential is attached to the spec
+  // fetch ONLY when the spec is hosted on the datasource's API host. A spec pinned
+  // to a public third-party host (raw.githubusercontent.com for stripe-data /
+  // notion-data) must NEVER receive the workspace credential; a same-host
+  // authenticated spec (Twenty) still does. Gates BOTH the header credential and
+  // the apiKey-query string param below.
+  const hasCredential = auth.kind !== "none";
+  const sendCredential = hasCredential && probeCredentialAllowed(openapiUrl, options.apiBaseUrl);
+  if (hasCredential && !sendCredential) {
+    log.debug(
+      { specHost: urlHost(openapiUrl) ?? "<unparseable>", authKind: auth.kind },
+      "Withholding probe credential: spec host does not match the datasource API host (#3034)",
+    );
+  }
+
   // apiKey-query placement: the spec endpoint may itself need the key in the
-  // query string. Append it without clobbering an existing query.
+  // query string. Append it only when the host-match gate allows — and without
+  // clobbering an existing query.
   let url = openapiUrl;
-  if (auth.kind === "apiKey" && auth.placement?.in === "query") {
+  if (sendCredential && auth.kind === "apiKey" && auth.placement?.in === "query") {
     try {
       const u = new URL(openapiUrl);
       u.searchParams.set(auth.placement.name, auth.value);
@@ -260,7 +324,10 @@ export async function probeSpec(
       url,
       {
         method: "GET",
-        headers: { Accept: "application/json", ...authHeadersForProbe(auth) },
+        headers: {
+          Accept: "application/json",
+          ...(sendCredential ? authHeadersForProbe(auth) : {}),
+        },
         signal: AbortSignal.timeout(probeTimeoutMs()),
       },
       { fetchImpl },


### PR DESCRIPTION
## Summary

Fixes #3034 — the REST-datasource spec probe leaked the customer credential to third-party spec hosts.

`probeSpec` attached the workspace API credential to the spec-fetch request **unconditionally**. The built-in data candidates pin their `openapiUrl` to a public host — both **stripe-data** and **notion-data** fetch from `raw.githubusercontent.com` — so installing (or re-probing) one sent the customer's secret key/token to GitHub. stripe-data is already merged, so this was a **live leak**.

## Fix — host-match gate (no opt-in flag)

The probe credential (the `Authorization` header **and** the apiKey-query string param) is attached **only** when the spec URL's host equals the datasource's resolved API host. The API host is resolved *before* the fetch:

1. `base_url_override` if the admin supplied one, else
2. a candidate-declared `apiBaseUrl` (new field; set to the real API host for every candidate), else
3. unknown → **withheld** (fail-safe).

Same-host authenticated specs (Twenty's `/open-api/core`, which lives on the API host) still authenticate; specs pinned to a public third-party host never receive the credential. Deliberately **no `probeAuth` opt-in** — the bug was an unsafe default, and the fix must not add a lever that re-enables sending to an arbitrary host.

## Changes

- **`probe.ts`** — `ProbeOptions.apiBaseUrl` + `probeCredentialAllowed()` host comparison (parse-failure → no match → withhold); gates both the header credential and the apiKey-query param; debug-logs when a present credential is withheld.
- **`data-candidates.ts`** — required `apiBaseUrl` on every candidate (`api.stripe.com` / `api.notion.com` / `api.github.com`), distinct from the public spec host.
- **`persistOpenApiDatasourceInstall` + data-candidate handler** — thread the resolved API base URL into the probe (`base_url_override` precedence over candidate `apiBaseUrl`).
- **rediscover route** — thread the stored `base_url_override` host into the re-probe so install + rediscover stay symmetric.

## Tests

- `probe.test.ts` — withhold/send across cross-origin vs same-host, for header + apiKey-query + apikey-header; fail-safe when API host unknown.
- `data-candidate-form-handler.test.ts` — regression: installing stripe-data sends **no** `Authorization` header (and no key in the URL) to `raw.githubusercontent.com`.
- `openapi-generic-form-handler.test.ts` — same-host `base_url_override` sends the credential; no override → withheld.
- `data-candidates.test.ts` — registry invariant: every candidate's spec host differs from its API host (#3034 contract).

## Acceptance criteria (from #3034)

- [x] Installing/re-probing stripe-data or notion-data does NOT send the customer credential to the spec host (raw.githubusercontent.com).
- [x] Twenty (same-host authenticated spec) still probes successfully with its credential.
- [x] Test asserting a cross-origin spec-host probe carries no `Authorization` header (and a same-host probe does).

## Scope

Credential-host gate only. The SSRF guard (#3006), redirect handling, and the confirm endpoint are already done and untouched.

## CI

All local `/ci` gates pass: lint, type, full `bun run test` (0 failures), syncpack, template drift, security-headers, railway-watch, schema drift, oauth-helper drift, test discipline, twenty-resolver, published-symbols.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3037"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782783980&installation_id=135337507&pr_number=3037&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3037&signature=f2b8d3b2b6b40114d3c3356f8353a51f048d77056f4e5f6ec2fb33147dea8d09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OpenAPI probing security: credentials (API keys, bearer tokens) are only sent when the spec host matches the API host (including when an explicit base-URL override is used), preventing credential leakage to third-party spec hosts.

* **Tests**
  * Added extensive tests and registry checks to validate credential-gating behavior across auth methods, same-host vs cross-host probes, and rediscovery scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->