### PR TITLE
feat(api): let data candidates declare read-safe POST operations (#3035)

### DIFF
--- a/packages/api/src/api/routes/__tests__/rest-operations.test.ts
+++ b/packages/api/src/api/routes/__tests__/rest-operations.test.ts
@@ -501,6 +501,30 @@ describe("POST /rest-operations/confirm — single-use token gate (#3007)", () =
     expect(twentyMock.requests.length).toBe(0);
   });
 
+  it("REJECTS a candidate-declared read-safe POST through the confirm endpoint (400, no dispatch) (#3035)", async () => {
+    // A demoted read-safe POST reaches `not_a_write` through a DIFFERENT validator
+    // branch than the GET above (the #3035 demotion, not the GET=read default), so
+    // it needs its own guard: the route MUST thread `readSafePostOperations` into
+    // the confirm policy. If that threading regressed, this POST would classify as a
+    // write and a minted token could fire it as a confirmed mutation. The Twenty
+    // mock has no read-over-POST, so `createOnePerson` exercises the mechanism (the
+    // realistic notion-data `post-search` case is covered by the candidate/resolver/
+    // validator tests). With an EMPTY write allowlist it is demoted, never gated.
+    const app = appWith([datasource({ readSafePostOperations: new Set(["createOnePerson"]) })]);
+    const res = await post(
+      app,
+      confirmBody({
+        datasourceId: "twenty",
+        operationId: "createOnePerson",
+        body: { name: { firstName: "Ada" } },
+      }),
+    );
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { error: string }).error).toBe("not_a_write");
+    // The demoted read was refused BEFORE any upstream call — never fired as a write.
+    expect(twentyMock.requests.length).toBe(0);
+  });
+
   it("is single-use under CONCURRENCY — two simultaneous replays yield one 200 + one 400, one write", async () => {
     // The burn is a synchronous check-and-set with no `await` between verify and
     // burn, so concurrent replays of the same token can't both reach the upstream.

--- a/packages/api/src/api/routes/rest-operations.ts
+++ b/packages/api/src/api/routes/rest-operations.ts
@@ -255,6 +255,13 @@ export function createRestOperationsRoute(deps: RestOperationsDeps = {}) {
         // covered, since `operation.sideEffecting` is read from the graph). Without
         // this, a direct confirm POST for such a GET would bypass the allowlist.
         sideEffectingOperations: datasource.sideEffectingOperations,
+        // #3035: thread the candidate's read-safe POSTs so the verdict classifies
+        // identically to the tool path. A demoted read-safe POST resolves to
+        // `requiresConfirmation: false` here and is refused below as "not a write" —
+        // the confirm endpoint fires confirmed WRITES, never reads.
+        ...(datasource.readSafePostOperations !== undefined
+          ? { readSafePostOperations: datasource.readSafePostOperations }
+          : {}),
         dispatch: true, // this IS the upstream call — debit the quota
         ...(datasource.rateLimitPerMinute !== undefined
           ? { rateLimitPerMinute: datasource.rateLimitPerMinute }

--- a/packages/api/src/lib/openapi/__tests__/data-candidates.test.ts
+++ b/packages/api/src/lib/openapi/__tests__/data-candidates.test.ts
@@ -5,6 +5,8 @@
  * registry (no forked strategy file).
  */
 import { describe, it, expect } from "bun:test";
+import * as fs from "fs";
+import * as path from "path";
 import {
   DATA_CANDIDATES,
   DATA_CANDIDATE_CATALOG_IDS,
@@ -20,6 +22,7 @@ import {
 } from "../data-candidates";
 import { OPENAPI_SUPPORTED_AUTH_KINDS } from "../catalog";
 import { defaultPaginatorRegistry } from "../strategies";
+import { buildOperationGraph } from "../spec";
 
 describe("DATA_CANDIDATES registry invariants", () => {
   it("derives every catalogId as catalog:${slug}", () => {
@@ -58,6 +61,18 @@ describe("DATA_CANDIDATES registry invariants", () => {
       // built-in strategy — a forked/unknown strategy would throw here.
       const strategy = defaultPaginatorRegistry.resolve(c.pagination);
       expect(defaultPaginatorRegistry.has(strategy.name)).toBe(true);
+    }
+  });
+
+  it("every declared readSafePostOperations list is non-empty + duplicate-free (#3035 shape)", () => {
+    // The type can't express "non-empty distinct operationIds"; lock the registry
+    // shape so a stray empty array (which the resolver treats as 'declares none')
+    // or an accidental duplicate is caught here rather than silently doing nothing.
+    for (const c of DATA_CANDIDATES) {
+      if (c.readSafePostOperations === undefined) continue;
+      expect(c.readSafePostOperations.length).toBeGreaterThan(0);
+      for (const id of c.readSafePostOperations) expect(id.length).toBeGreaterThan(0);
+      expect(new Set(c.readSafePostOperations).size).toBe(c.readSafePostOperations.length);
     }
   });
 });
@@ -164,6 +179,22 @@ describe("notion-data candidate (slice 6b, #3029 — required-header proof)", ()
     // install WITHOUT an admin write-allowlist edit (the vendor fact lives in code,
     // not in Notion API expertise the admin must supply).
     expect(NOTION_DATA_CANDIDATE.readSafePostOperations).toContain("post-search");
+  });
+
+  it("each declared read-safe id resolves to a real POST in Notion's surface (#3035 — no silent-inert misdeclaration)", () => {
+    // The demotion is POST-only, so a misdeclared non-POST (or typo'd) operationId
+    // is silently inert. Guard against that by checking the declared ids against the
+    // candidate's actual spec: every id must exist AND be a POST. The excerpt fixture
+    // is the same Notion spec edition the candidate's openapiUrl serves.
+    const NOTION_SPEC = JSON.parse(
+      fs.readFileSync(path.join(import.meta.dir, "fixtures", "notion.excerpt.json"), "utf8"),
+    );
+    const graph = buildOperationGraph(NOTION_SPEC);
+    for (const id of NOTION_DATA_CANDIDATE.readSafePostOperations ?? []) {
+      const op = graph.operations.get(id);
+      expect(op).toBeDefined();
+      expect(op?.method).toBe("POST");
+    }
   });
 });
 

--- a/packages/api/src/lib/openapi/__tests__/data-candidates.test.ts
+++ b/packages/api/src/lib/openapi/__tests__/data-candidates.test.ts
@@ -157,6 +157,14 @@ describe("notion-data candidate (slice 6b, #3029 — required-header proof)", ()
     // NOT the Stripe last-item-id dialect.
     expect(NOTION_DATA_CANDIDATE.pagination?.cursorFromLastItem).toBeUndefined();
   });
+
+  it("declares post-search as a read-safe POST (#3035 — Notion search is POST /v1/search, a READ)", () => {
+    // Notion's "list pages in my workspace" is POST /v1/search — a genuine read.
+    // The candidate declares it read-safe so it passes the read gate on a default
+    // install WITHOUT an admin write-allowlist edit (the vendor fact lives in code,
+    // not in Notion API expertise the admin must supply).
+    expect(NOTION_DATA_CANDIDATE.readSafePostOperations).toContain("post-search");
+  });
 });
 
 describe("DATA_CANDIDATE_CONFIG_SCHEMA", () => {

--- a/packages/api/src/lib/openapi/__tests__/data-candidates.test.ts
+++ b/packages/api/src/lib/openapi/__tests__/data-candidates.test.ts
@@ -177,8 +177,9 @@ describe("notion-data candidate (slice 6b, #3029 — required-header proof)", ()
     // Notion's "list pages in my workspace" is POST /v1/search — a genuine read.
     // The candidate declares it read-safe so it passes the read gate on a default
     // install WITHOUT an admin write-allowlist edit (the vendor fact lives in code,
-    // not in Notion API expertise the admin must supply).
-    expect(NOTION_DATA_CANDIDATE.readSafePostOperations).toContain("post-search");
+    // not in Notion API expertise the admin must supply). Exact equality (not
+    // toContain) so a stray extra declaration must be a deliberate edit here.
+    expect(NOTION_DATA_CANDIDATE.readSafePostOperations).toEqual(["post-search"]);
   });
 
   it("each declared read-safe id resolves to a real POST in Notion's surface (#3035 — no silent-inert misdeclaration)", () => {

--- a/packages/api/src/lib/openapi/__tests__/validate-rest-operation.read-safe-post.test.ts
+++ b/packages/api/src/lib/openapi/__tests__/validate-rest-operation.read-safe-post.test.ts
@@ -1,0 +1,170 @@
+/**
+ * #3035 — candidate-declared read-safe POST operations.
+ *
+ * A default data-candidate install resolves with an EMPTY write allowlist, and
+ * the validator classifies every non-GET/HEAD as a write — so a vendor whose
+ * READ surface uses POST (Notion's workspace search is `POST /v1/search`) is
+ * unreachable on a default install (it returns `writes-disabled` before
+ * dispatch). A {@link DataCandidate} declares its genuinely read-only POSTs
+ * (`readSafePostOperations`); the resolver threads them onto the policy as
+ * `readSafePostOperations`, and {@link isSideEffectingOperation} demotes such a
+ * POST to a READ — it passes the write allowlist (layer 2) without an entry.
+ *
+ * Curated, code-resident, and STRICTLY a safety-DROP that escalation overrides:
+ *   - only a POST is ever demoted (a misdeclared DELETE/PUT stays a write),
+ *   - a genuine (non-declared) POST is STILL gated as a write,
+ *   - an explicit side-effecting signal (the `x-atlas-side-effecting` spec
+ *     extension or the install's `side_effecting_operations` list) WINS over a
+ *     read-safe declaration — "this mutates" can never be overridden by "this
+ *     reads", preserving the monotonic-escalation invariant.
+ *
+ * Self-contained fixtures (no shared helpers), mirroring the sibling
+ * `validate-rest-operation.side-effecting.test.ts`.
+ */
+import { describe, expect, it, beforeEach } from "bun:test";
+
+import {
+  validateRestOperation,
+  isSideEffectingOperation,
+  _resetRestRateLimits,
+  type RestOperationPolicy,
+} from "../validate-rest-operation";
+import type { Operation, OperationGraph } from "../types";
+
+function makeOperation(overrides: Partial<Operation> = {}): Operation {
+  return {
+    operationId: "op",
+    method: "POST",
+    path: "/op",
+    tags: [],
+    parameters: [],
+    security: [],
+    responses: new Map(),
+    ...overrides,
+  };
+}
+
+function makeGraph(operations: Operation[]): OperationGraph {
+  return {
+    operations: new Map(operations.map((op) => [op.operationId, op])),
+    schemas: new Map(),
+    security: new Map(),
+    servers: [],
+    info: { title: "Test", version: "1.0.0", openapiVersion: "3.1.0" },
+  };
+}
+
+function makePolicy(overrides: Partial<RestOperationPolicy> = {}): RestOperationPolicy {
+  return {
+    workspaceId: "ws",
+    datasourceId: "ds",
+    writeAllowlist: new Set<string>(),
+    now: () => 0,
+    ...overrides,
+  };
+}
+
+describe("isSideEffectingOperation — read-safe POST demotion (#3035)", () => {
+  it("demotes a declared read-safe POST to a read", () => {
+    const op = makeOperation({ operationId: "post-search", method: "POST" });
+    expect(isSideEffectingOperation(op, undefined, new Set(["post-search"]))).toBe(false);
+  });
+
+  it("leaves a non-declared POST a write", () => {
+    const op = makeOperation({ operationId: "createWidget", method: "POST" });
+    expect(isSideEffectingOperation(op, undefined, new Set(["post-search"]))).toBe(true);
+  });
+
+  it("only demotes POST — a non-POST id in the set stays a write", () => {
+    // Defense-in-depth: the demotion is keyed on the POST method too, so a
+    // misdeclared DELETE/PUT operationId is inert (never silently demoted).
+    const del = makeOperation({ operationId: "deleteWidget", method: "DELETE" });
+    expect(isSideEffectingOperation(del, undefined, new Set(["deleteWidget"]))).toBe(true);
+  });
+
+  it("lets an explicit side-effecting flag (spec extension) override the read-safe declaration", () => {
+    const op = makeOperation({ operationId: "post-search", method: "POST", sideEffecting: true });
+    // "this mutates" (vendor spec) wins over "this reads" (curated demotion).
+    expect(isSideEffectingOperation(op, undefined, new Set(["post-search"]))).toBe(true);
+  });
+
+  it("lets the install's side_effecting_operations list override the read-safe declaration", () => {
+    const op = makeOperation({ operationId: "post-search", method: "POST" });
+    expect(
+      isSideEffectingOperation(op, new Set(["post-search"]), new Set(["post-search"])),
+    ).toBe(true);
+  });
+
+  it("is a no-op when no read-safe set is supplied (regression: POST stays a write)", () => {
+    const op = makeOperation({ operationId: "post-search", method: "POST" });
+    expect(isSideEffectingOperation(op)).toBe(true);
+    expect(isSideEffectingOperation(op, undefined, new Set())).toBe(true);
+  });
+});
+
+describe("validateRestOperation — read-safe POST gate (#3035)", () => {
+  beforeEach(() => {
+    _resetRestRateLimits();
+  });
+
+  it("passes a declared read-safe POST WITHOUT a write-allowlist entry", () => {
+    const graph = makeGraph([makeOperation({ operationId: "post-search", method: "POST" })]);
+    const verdict = validateRestOperation(
+      graph,
+      "post-search",
+      {},
+      makePolicy({ readSafePostOperations: new Set(["post-search"]) }),
+    );
+    expect(verdict.allowed).toBe(true);
+    if (verdict.allowed) {
+      // It is a READ — no confirm-before-write step.
+      expect(verdict.requiresConfirmation).toBe(false);
+    }
+  });
+
+  it("still gates a genuine (non-declared) POST as a write needing the allowlist", () => {
+    const graph = makeGraph([makeOperation({ operationId: "createWidget", method: "POST" })]);
+    const verdict = validateRestOperation(
+      graph,
+      "createWidget",
+      {},
+      // A different POST is declared read-safe — createWidget is not, so it's gated.
+      makePolicy({ readSafePostOperations: new Set(["post-search"]) }),
+    );
+    expect(verdict.allowed).toBe(false);
+    if (!verdict.allowed) {
+      expect(verdict.error.reason).toBe("writes-disabled");
+    }
+  });
+
+  it("re-gates a declared read-safe POST that is ALSO flagged side-effecting (escalation wins)", () => {
+    const graph = makeGraph([
+      makeOperation({ operationId: "post-search", method: "POST", sideEffecting: true }),
+    ]);
+    const verdict = validateRestOperation(
+      graph,
+      "post-search",
+      {},
+      makePolicy({ readSafePostOperations: new Set(["post-search"]) }),
+    );
+    expect(verdict.allowed).toBe(false);
+    if (!verdict.allowed) {
+      expect(verdict.error.reason).toBe("writes-disabled");
+    }
+  });
+
+  it("dispatches the declared read-safe POST (read), debiting the rate quota like any read", () => {
+    // dispatch defaults to true for a read; the verdict carries the resolved op.
+    const graph = makeGraph([makeOperation({ operationId: "post-search", method: "POST" })]);
+    const verdict = validateRestOperation(
+      graph,
+      "post-search",
+      {},
+      makePolicy({ readSafePostOperations: new Set(["post-search"]) }),
+    );
+    expect(verdict.allowed).toBe(true);
+    if (verdict.allowed) {
+      expect(verdict.operation.operationId).toBe("post-search");
+    }
+  });
+});

--- a/packages/api/src/lib/openapi/__tests__/validate-rest-operation.read-safe-post.test.ts
+++ b/packages/api/src/lib/openapi/__tests__/validate-rest-operation.read-safe-post.test.ts
@@ -5,7 +5,7 @@
  * the validator classifies every non-GET/HEAD as a write — so a vendor whose
  * READ surface uses POST (Notion's workspace search is `POST /v1/search`) is
  * unreachable on a default install (it returns `writes-disabled` before
- * dispatch). A {@link DataCandidate} declares its genuinely read-only POSTs
+ * dispatch). A {@link import("../data-candidates").DataCandidate} declares its genuinely read-only POSTs
  * (`readSafePostOperations`); the resolver threads them onto the policy as
  * `readSafePostOperations`, and {@link isSideEffectingOperation} demotes such a
  * POST to a READ — it passes the write allowlist (layer 2) without an entry.

--- a/packages/api/src/lib/openapi/__tests__/workspace-datasource.test.ts
+++ b/packages/api/src/lib/openapi/__tests__/workspace-datasource.test.ts
@@ -272,6 +272,28 @@ describe("resolveWorkspaceRestDatasources — data-candidate quirk attachment (s
     expect(result).toHaveLength(1);
     expect(result[0].quirk).toBeUndefined();
   });
+
+  it("attaches the candidate's readSafePostOperations for a notion-data install (#3035)", async () => {
+    // notion-data declares `post-search` read-safe (Notion search is POST /v1/search,
+    // a read). The resolver threads that code-resident declaration onto the
+    // RestDatasource so the validator demotes it to a read on a default install.
+    const result = await resolveWorkspaceRestDatasources("org-1", {
+      query: queryReturning([
+        { install_id: "inst-notion", catalog_id: "catalog:notion-data", config: config() },
+      ]),
+    });
+    expect(result).toHaveLength(1);
+    expect([...(result[0].readSafePostOperations ?? [])]).toContain("post-search");
+  });
+
+  it("leaves readSafePostOperations undefined for a candidate that declares none (stripe-data)", async () => {
+    const result = await resolveWorkspaceRestDatasources("org-1", {
+      query: queryReturning([
+        { install_id: "inst-stripe", catalog_id: "catalog:stripe-data", config: config() },
+      ]),
+    });
+    expect(result[0].readSafePostOperations).toBeUndefined();
+  });
 });
 
 describe("resolveWorkspacePrimaryRestDatasource", () => {

--- a/packages/api/src/lib/openapi/data-candidates.ts
+++ b/packages/api/src/lib/openapi/data-candidates.ts
@@ -69,6 +69,24 @@ export interface BaseDataCandidate {
    * wires in when pagination reaches the tool (#2970).
    */
   readonly pagination?: PaginationConfig;
+  /**
+   * `operationId`s whose POST is a GENUINE READ (#3035) — e.g. Notion's
+   * workspace search, `POST /v1/search`. The validator gates every non-GET/HEAD
+   * as a write, so without this a vendor's read-over-POST surface is unreachable
+   * on a default install (empty write allowlist → `writes-disabled`). The
+   * resolver threads this onto the {@link import("./datasource").RestDatasource}
+   * (`readSafePostOperations`) so {@link
+   * import("./validate-rest-operation").isSideEffectingOperation} DEMOTES the POST
+   * to a read — it passes the read gate WITHOUT an admin write-allowlist edit.
+   *
+   * This is a curated VENDOR FACT, in code (the admin shouldn't need Notion API
+   * expertise). It is strictly a safety-DROP: an `x-atlas-side-effecting` spec
+   * extension or a per-install `side_effecting_operations` entry always overrides
+   * it (escalation wins), and the demotion is POST-only. The slice-2 (#2926)
+   * per-operation override remains the per-INSTALL escape hatch; this is the
+   * candidate-level default. Omit for a candidate with no read-over-POST surface.
+   */
+  readonly readSafePostOperations?: ReadonlyArray<string>;
 }
 
 /**
@@ -318,6 +336,13 @@ export const NOTION_DATA_CANDIDATE: DataCandidate = {
     cursorPath: "next_cursor",
     hasMorePath: "has_more",
   },
+  // #3035: Notion's "list pages in my workspace" is `POST /v1/search` — a genuine
+  // READ. The validator gates every non-GET as a write, so without declaring it
+  // read-safe `post-search` would be unreachable on a default install (empty write
+  // allowlist). This is a curated vendor fact, in code: the resolver demotes it to a
+  // read so it passes the read gate with no admin write-allowlist edit. Genuine
+  // Notion writes (create/update pages) stay gated behind allowlist + confirm.
+  readSafePostOperations: ["post-search"],
 };
 
 /** Every built-in data candidate. Append a new vendor here (the one-line thesis). */

--- a/packages/api/src/lib/openapi/datasource.ts
+++ b/packages/api/src/lib/openapi/datasource.ts
@@ -65,6 +65,18 @@ export interface RestDatasource {
    */
   readonly sideEffectingOperations: ReadonlySet<string>;
   /**
+   * `operationId`s whose POST is a GENUINE READ (#3035), DEMOTED past the write
+   * allowlist — e.g. Notion search, `POST /v1/search`. Present only for a built-in
+   * data candidate that declares them ({@link import("./data-candidates").DataCandidate.readSafePostOperations});
+   * `undefined` for a plain `openapi-generic` install or a candidate with no
+   * read-over-POST surface. Like {@link quirk}, this is CODE-resident — the
+   * resolver looks it up from the `DATA_CANDIDATES` registry by catalog id, never
+   * from config. Unlike {@link sideEffectingOperations} (which can only ESCALATE),
+   * this is the one signal that DROPS a write classification, and it is overridden
+   * by any escalation signal. See {@link import("./validate-rest-operation").isSideEffectingOperation}.
+   */
+  readonly readSafePostOperations?: ReadonlySet<string>;
+  /**
    * Per-install rate-limit override (calls/min) for the per-operation token
    * bucket. Omitted → {@link import("./validate-rest-operation").DEFAULT_RATE_LIMIT_PER_MINUTE}
    * (60/min). Resolved from `workspace_plugins.config.rate_limit_per_minute`.

--- a/packages/api/src/lib/openapi/validate-rest-operation.ts
+++ b/packages/api/src/lib/openapi/validate-rest-operation.ts
@@ -151,9 +151,12 @@ export type RestOperationVerdict =
       readonly allowed: true;
       readonly operation: Operation;
       /**
-       * `true` for every effective write — a non-GET/HEAD method, OR a GET/HEAD
-       * escalated by an #3008 side-effecting override. The caller MUST obtain
-       * human confirmation (the confirm-before-write banner) before dispatching.
+       * `true` for every effective write — a non-GET/HEAD method (EXCEPT a
+       * candidate-declared read-safe POST, demoted to a read per #3035), OR a
+       * GET/HEAD escalated by an #3008 side-effecting override. Tracks `isWrite`,
+       * which already accounts for both the escalation and the demotion. The
+       * caller MUST obtain human confirmation (the confirm-before-write banner)
+       * before dispatching.
        */
       readonly requiresConfirmation: boolean;
       /** The effective per-request timeout the client should use. */

--- a/packages/api/src/lib/openapi/validate-rest-operation.ts
+++ b/packages/api/src/lib/openapi/validate-rest-operation.ts
@@ -111,6 +111,21 @@ export interface RestOperationPolicy {
    * config-level overrides. See #3008 and {@link isSideEffectingOperation}.
    */
   readonly sideEffectingOperations?: ReadonlySet<string>;
+  /**
+   * `operationId`s a built-in data candidate declares to be GENUINE READS over
+   * the POST method (#3035) — e.g. Notion's workspace search, `POST /v1/search`.
+   * A POST in this set is DEMOTED to a read: it passes the write allowlist
+   * (layer 2) without an entry, and never stages a confirm-before-write step.
+   * CODE-resident + curated (the vendor fact lives in `DATA_CANDIDATES`, not in
+   * admin-supplied Notion expertise); this is the ONLY signal that can DROP an
+   * operation's write classification, and it is strictly subordinate to the
+   * #3008 escalation signals — an `x-atlas-side-effecting` spec extension or a
+   * `side_effecting_operations` entry always WINS ("this mutates" can never be
+   * overridden by "this reads"). Demotion is POST-only, so a misdeclared
+   * DELETE/PUT id is inert. Omit → classification is unchanged. See
+   * {@link isSideEffectingOperation}.
+   */
+  readonly readSafePostOperations?: ReadonlySet<string>;
   /** Per-install rate-limit override (calls/min). Default {@link DEFAULT_RATE_LIMIT_PER_MINUTE}. */
   readonly rateLimitPerMinute?: number;
   /**
@@ -314,7 +329,8 @@ export function isWriteMethod(method: string): boolean {
 
 /**
  * Whether an operation must be authorized as a WRITE — gated by the write
- * allowlist and staged for human confirmation. Combines the three #3008 signals:
+ * allowlist and staged for human confirmation. Combines the #3008 escalation
+ * signals with the #3035 read-safe-POST demotion:
  *   1. its HTTP method mutates ({@link isWriteMethod} — the default), OR
  *   2. its spec carried `x-atlas-side-effecting: true` ({@link Operation.sideEffecting}), OR
  *   3. the install config lists its `operationId` in `side_effecting_operations`.
@@ -322,18 +338,40 @@ export function isWriteMethod(method: string): boolean {
  * GET=read is only a DEFAULT here, never ground truth: a mutating RPC-over-GET
  * (`GET /jobs/{id}/cancel`, `GET /admin/resetPassword`) — common in the
  * legacy/internal services this milestone targets — is escalated by (2) or (3).
- * The combination is monotonic: an override can only ADD safety (escalate a read
- * to a write), never strip it (a POST stays a write whatever the flags say).
+ *
+ * The one DEMOTION (#3035): a POST whose `operationId` a built-in data candidate
+ * declares read-safe (`readSafePostOperations` — e.g. Notion search,
+ * `POST /v1/search`) reads, so it is NOT gated as a write. This is the only
+ * way a flag can DROP the classification, and it is strictly subordinate: an
+ * explicit escalation signal — (2) or (3) — always WINS over the demotion, and
+ * the demotion fires only for the POST method (a misdeclared DELETE/PUT id is
+ * inert). So the invariant holds in both directions — "this mutates" (spec/
+ * operator) can never be overridden by "this reads" (curated), and a write
+ * method other than a declared read-safe POST stays a write.
  */
 export function isSideEffectingOperation(
   operation: Operation,
   sideEffectingOperations?: ReadonlySet<string>,
+  readSafePostOperations?: ReadonlySet<string>,
 ): boolean {
-  return (
-    isWriteMethod(operation.method) ||
+  // An explicit escalation signal (vendor spec extension or operator config)
+  // always wins — a curated read-safe declaration can never strip it.
+  if (
     operation.sideEffecting === true ||
     (sideEffectingOperations?.has(operation.operationId) ?? false)
-  );
+  ) {
+    return true;
+  }
+  // #3035: a candidate-declared read-safe POST is demoted to a read. POST-only,
+  // so a misdeclared non-POST id can never silently demote a real mutation.
+  if (
+    operation.method === "POST" &&
+    (readSafePostOperations?.has(operation.operationId) ?? false)
+  ) {
+    return false;
+  }
+  // Otherwise classify by method (GET/HEAD read; everything else writes).
+  return isWriteMethod(operation.method);
 }
 
 /**
@@ -364,8 +402,14 @@ export function validateRestOperation(
   }
 
   // Not method-only (#3008): a GET/HEAD flagged side-effecting (spec extension or
-  // install config) is authorized as a write too — allowlist + confirm.
-  const isWrite = isSideEffectingOperation(operation, policy.sideEffectingOperations);
+  // install config) is authorized as a write too — allowlist + confirm. And not
+  // method-only the other way (#3035): a candidate-declared read-safe POST is
+  // demoted to a read here, so it clears layer 2 without a write-allowlist entry.
+  const isWrite = isSideEffectingOperation(
+    operation,
+    policy.sideEffectingOperations,
+    policy.readSafePostOperations,
+  );
 
   // ── Layer 2 — write allowlist (default-deny writes) ──────────────────────
   if (isWrite && !policy.writeAllowlist.has(operationId)) {

--- a/packages/api/src/lib/openapi/workspace-datasource.ts
+++ b/packages/api/src/lib/openapi/workspace-datasource.ts
@@ -360,6 +360,16 @@ function buildDatasource(
     throw err;
   }
 
+  // #3035: a candidate's declared read-safe POSTs (e.g. notion-data's `post-search`)
+  // are CODE-resident like the quirk — resolved from the registry, never config.
+  // Threaded onto the datasource so the validator demotes those POSTs to reads.
+  // Omitted when the candidate declares none (or it's a plain generic install) so a
+  // datasource with no read-over-POST surface carries no field, mirroring `quirk`.
+  const readSafePostOperations =
+    candidate?.readSafePostOperations && candidate.readSafePostOperations.length > 0
+      ? new Set(candidate.readSafePostOperations)
+      : undefined;
+
   // Slice 6a (#3028): a built-in data-candidate install carries its declarative
   // quirk in the code-resident registry (resolved by the caller, passed in here),
   // never in config — attach it so the agent tool can thread it into the client.
@@ -376,6 +386,7 @@ function buildDatasource(
     ...(rateLimitPerMinute !== undefined ? { rateLimitPerMinute } : {}),
     ...(requestTimeoutMs !== undefined ? { requestTimeoutMs } : {}),
     ...(candidate?.quirk !== undefined ? { quirk: candidate.quirk } : {}),
+    ...(readSafePostOperations !== undefined ? { readSafePostOperations } : {}),
   };
 }
 

--- a/packages/api/src/lib/tools/__tests__/rest-operation.test.ts
+++ b/packages/api/src/lib/tools/__tests__/rest-operation.test.ts
@@ -385,6 +385,39 @@ describe("executeRestOperation — write-side opt-in", () => {
     expect(result.method).toBe("GET");
     expect(mock.requests).toHaveLength(0);
   });
+
+  // #3035 — a candidate-declared read-safe POST (e.g. Notion search) dispatches as
+  // a READ on a default install, with an EMPTY write allowlist and no confirm step.
+  // The Twenty mock has no read-over-POST, so these exercise the demotion MECHANISM
+  // through the tool's policy wiring using `createOnePerson` (the realistic vendor
+  // example, notion-data's `post-search`, is covered by the candidate + resolver +
+  // validator tests). The point is the gate, not that createOnePerson is really a read.
+  it("dispatches a declared read-safe POST as a read — no confirmation, no allowlist (#3035)", async () => {
+    const ds = datasource({ readSafePostOperations: new Set(["createOnePerson"]) });
+    const result = await call(
+      { operationId: "createOnePerson", body: { name: "Ada" } },
+      async () => ds,
+    );
+    expect(result.status).toBe("ok"); // NOT needs_confirmation, NOT writes_disabled
+    if (result.status !== "ok") return;
+    expect(result.httpStatus).toBe(201);
+    // It reached the upstream as a POST — dispatched immediately, never staged.
+    const req = mock.matching("/rest/people").at(-1);
+    expect(req?.method).toBe("POST");
+  });
+
+  it("still gates a NON-declared POST as a write (writes_disabled), never dispatching (#3035)", async () => {
+    // A different POST is declared read-safe; createOnePerson is not → gated.
+    const ds = datasource({ readSafePostOperations: new Set(["post-search"]) });
+    const result = await call(
+      { operationId: "createOnePerson", body: { name: "Ada" } },
+      async () => ds,
+    );
+    expect(result.status).toBe("writes_disabled");
+    if (result.status !== "writes_disabled") return;
+    expect(result.method).toBe("POST");
+    expect(mock.requests).toHaveLength(0); // never reached the upstream
+  });
 });
 
 // ── Multi-datasource routing (slice 2, #2926) ────────────────────────────────

--- a/packages/api/src/lib/tools/rest-operation.ts
+++ b/packages/api/src/lib/tools/rest-operation.ts
@@ -277,9 +277,16 @@ export function createExecuteRestOperationTool(deps: ExecuteRestOperationDeps = 
       // to `dispatch: true`, but layer 1 rejects it before the quota is touched.
       const peeked = datasource.graph.operations.get(operationId);
       // Side-effecting (#3008) GET/HEADs count as writes here too, so they are
-      // staged for confirmation (dispatch:false) rather than run immediately.
+      // staged for confirmation (dispatch:false) rather than run immediately. A
+      // candidate-declared read-safe POST (#3035) is demoted to a read by the same
+      // predicate, so it dispatches immediately (debits the read quota) rather than
+      // staging for a confirm that would be refused.
       const isWrite = peeked
-        ? isSideEffectingOperation(peeked, datasource.sideEffectingOperations)
+        ? isSideEffectingOperation(
+            peeked,
+            datasource.sideEffectingOperations,
+            datasource.readSafePostOperations,
+          )
         : false;
 
       const policy: RestOperationPolicy = {
@@ -292,6 +299,9 @@ export function createExecuteRestOperationTool(deps: ExecuteRestOperationDeps = 
         datasourceId: datasource.id,
         writeAllowlist: datasource.writeAllowlist,
         sideEffectingOperations: datasource.sideEffectingOperations,
+        ...(datasource.readSafePostOperations !== undefined
+          ? { readSafePostOperations: datasource.readSafePostOperations }
+          : {}),
         dispatch: !isWrite,
         ...(datasource.rateLimitPerMinute !== undefined
           ? { rateLimitPerMinute: datasource.rateLimitPerMinute }

--- a/packages/api/src/lib/tools/rest-operation.ts
+++ b/packages/api/src/lib/tools/rest-operation.ts
@@ -69,6 +69,7 @@ Use executeRestOperation to call a single operation on a connected REST API (des
 - For multi-step questions, call this tool once per step and feed each result into the next (e.g. find a person, then list their note targets, then fetch each note)
 - GET operations execute and return data immediately — UNLESS that GET is flagged side-effecting (by the datasource's spec or its admin config). Some legacy/internal APIs mutate via GET (e.g. \`GET /jobs/{id}/cancel\`); a flagged GET is treated exactly like a write — it needs allowlisting and is staged for confirmation, never run silently.
 - Write operations (POST/PATCH/PUT/DELETE) only run if the datasource's admin has allowlisted them. A non-allowlisted write returns \`writes_disabled\` — tell the user writes are off for that datasource; never claim it happened.
+- EXCEPTION: a few operations use POST for a READ (e.g. a search endpoint like Notion's \`post-search\`). When the datasource marks such a POST read-safe it executes and returns data immediately, exactly like a GET — so if the operation that answers a read question is a POST, call it. (A genuine write still comes back as \`needs_confirmation\`, never silently.)
 - An allowlisted write does NOT run immediately: it returns \`needs_confirmation\`. Tell the user plainly what the write will do (e.g. "This will permanently delete 3 people in Twenty — confirm?") and STOP. The user confirms via the banner; do not retry, and never claim the write succeeded until you see a confirmed result.`;
 
 /**
@@ -148,7 +149,7 @@ const ExecuteRestOperationInput = z.object({
     .unknown()
     .optional()
     .describe(
-      "JSON request body for an allowlisted write operation. The write is staged for the user to confirm (it does not fire immediately); a non-allowlisted write is rejected.",
+      "JSON request body. For a write (POST/PATCH/PUT/DELETE) it must be allowlisted and is staged for the user to confirm (it does not fire immediately); a non-allowlisted write is rejected. A read-safe POST (e.g. a search endpoint) takes its body too and runs immediately, like a read.",
     ),
 });
 
@@ -193,7 +194,8 @@ export function createExecuteRestOperationTool(deps: ExecuteRestOperationDeps = 
       "datasource's spec or its admin config (some legacy APIs mutate via GET). Those, like write " +
       "operations (POST/PATCH/PUT/DELETE), run only if allowlisted, and an allowlisted write / " +
       "side-effecting GET is staged for the user to confirm before it fires (never claim a write " +
-      "happened until confirmed).",
+      "happened until confirmed). A few operations use POST for a READ (e.g. a search endpoint); a " +
+      "datasource-configured read-safe POST runs immediately and returns data like a GET.",
     inputSchema: ExecuteRestOperationInput,
     execute: async ({ operationId, datasourceId, pathParams, query, header, body }): Promise<ExecuteRestOperationResult> => {
       let datasources: ReadonlyArray<RestDatasource>;


### PR DESCRIPTION
## Summary

Lets a built-in **data candidate** declare which of its POST operations are genuine **reads**, so they pass the REST read gate on a **default install** without an admin write-allowlist edit. Closes #3035.

**The problem (verified):** `validateRestOperation` classifies every non-GET/HEAD as a write (`isWriteMethod`), and a default candidate install resolves with an empty write allowlist — so a vendor whose read surface uses POST is unreachable. Notion's workspace search is `POST /v1/search`, a genuine read, so "list pages in my workspace" returned `writes_disabled` before dispatch on a default `notion-data` install. This is generic candidate machinery, not Notion-specific.

## Approach

Per the issue's decided direction: declare read-safe POSTs **on the candidate, in code** — a vendor fact (`POST /v1/search` is a read) belongs in the curated registry, not in Notion API expertise the admin must supply. No new install-form field.

- `DataCandidate.readSafePostOperations?: string[]` (operationIds) on `BaseDataCandidate`; `notion-data` declares `["post-search"]`.
- The workspace resolver threads it (code-resident, like `quirk` — never from config) onto `RestDatasource.readSafePostOperations`.
- `RestOperationPolicy.readSafePostOperations` carries it to the validator. `isSideEffectingOperation` **demotes** a POST in that set to a read — it clears layer 2 without a write-allowlist entry and never stages a confirm.

**Safety invariant preserved.** This is the only signal that *drops* a write classification, and it is strictly subordinate:

- An explicit escalation signal — the `x-atlas-side-effecting` spec extension or a per-install `side_effecting_operations` entry — **always wins** ("this mutates" can never be overridden by "this reads").
- Demotion is **POST-only**, so a misdeclared `DELETE`/`PUT` operationId is inert (stays a write).
- A genuine (non-declared) POST is still gated as a write needing allowlist + confirm.

The slice-2 (#2926) per-operation override remains the per-install escape hatch; this is the candidate-level default.

## Test coverage

- **Validator unit** (`validate-rest-operation.read-safe-post.test.ts`): a declared read-safe POST passes the gate with no allowlist (`requiresConfirmation: false`); a non-declared POST → `writes-disabled`; an escalation signal overrides the demotion; demotion is POST-only; no-op without a set (regression).
- **Tool** (`rest-operation.test.ts`): a read-safe POST dispatches as a read (no confirm, hits upstream); a non-declared POST → `writes_disabled`, never dispatched.
- **Candidate registry**: `notion-data` declares `post-search` read-safe.
- **Resolver**: a `notion-data` install resolves `readSafePostOperations` containing `post-search`; a candidate that declares none (stripe-data) carries no field.
- #3008 side-effecting tests unchanged (regression intact).

## Acceptance criteria

- [x] A candidate can declare read-only POST operations that pass the read gate without an admin write-allowlist edit.
- [x] Notion `post-search` runs on a default `notion-data` install (read); genuine writes still require allowlist + confirm.
- [x] Test coverage for a read-safe POST passing validation **and** a non-declared POST still gated.

## Notes

- #3035 noted a shared-files dependency on #3034 (probeSpec credential leak). #3034 has no branch/PR yet, and this change to the shared `data-candidates.ts` is purely additive (one optional field + one declaration); `data-candidate-form-handler.ts` is untouched (no new form field). Functionally independent — whichever lands first, the other rebases trivially.

## CI

Local gates all green: lint, type, full `bun run test`, syncpack, template drift, security headers, railway-watch, schema drift, oauth-helper drift, test discipline, twenty-resolver imports, published symbols.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3038"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782784100&installation_id=135337507&pr_number=3038&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3038&signature=f2898cc1d2e76277105f58e2d9edd8eacb723f9189a535e30dfaca2b983afe36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Datasources can declare specific POST endpoints as read-safe so they behave like reads (no write confirmation or allowlist).

* **Bug Fixes**
  * Confirm/validation now consistently treats demoted read-safe POSTs as non-writes, avoiding unintended bypasses or upstream dispatch.

* **Tests**
  * Added unit and integration tests covering read-safe POST declarations, validation, confirmation, and dispatch outcomes.

* **Documentation**
  * Updated tool and API descriptions to document read-safe POST behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->