### PR TITLE
fix(api): reject data-candidate base_url_override pointed at the locked spec host (#3039)

### DIFF
--- a/packages/api/src/lib/integrations/install/__tests__/data-candidate-form-handler.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/data-candidate-form-handler.test.ts
@@ -193,6 +193,47 @@ describe("DataCandidateFormInstallHandler.validateConfig", () => {
     for (const url of probedUrls) expect(url).not.toContain("sk_live_super_secret");
   });
 
+  it("also rejects a trailing-dot FQDN form of the locked spec host (#3040 review — no normalization bypass)", async () => {
+    const { DataCandidateFormInstallHandler } = await import("../data-candidate-form-handler");
+    const { FormInstallValidationError } = await import("../email-form-handler");
+    const handler = new DataCandidateFormInstallHandler(STRIPE_DATA_CANDIDATE, {
+      idGenerator: () => "fixed-uuid",
+      now: () => "2026-05-30T00:00:00.000Z",
+      fetchImpl: (async (input: string | URL, init?: RequestInit) => {
+        probedUrls.push(typeof input === "string" ? input : input.toString());
+        const headers: Record<string, string> = {};
+        const h = init?.headers as Record<string, string> | undefined;
+        if (h) for (const [k, v] of Object.entries(h)) headers[k] = v;
+        probedHeaders.push(headers);
+        return new Response(JSON.stringify(STRIPE_FIXTURE_SPEC), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }) as unknown as typeof globalThis.fetch,
+    });
+
+    // `raw.githubusercontent.com.` (trailing FQDN dot) DNS-resolves to the same host
+    // as the locked spec, but WHATWG `URL.host` keeps the dot — an exact-host check
+    // would let it through, persist it as the ops base URL, and leak the credential
+    // to the spec CDN at query time. The normalized check must reject it too.
+    let thrown: unknown;
+    try {
+      await handler.validateConfig("ws-1" as never, {
+        auth_value: "sk_live_super_secret",
+        base_url_override: "https://raw.githubusercontent.com./anything",
+      });
+    } catch (err) {
+      thrown = err;
+    }
+
+    expect(thrown).toBeInstanceOf(FormInstallValidationError);
+    expect(
+      (thrown as InstanceType<typeof FormInstallValidationError>).fieldErrors.base_url_override,
+    ).toBeDefined();
+    for (const headers of probedHeaders) expect(headers.Authorization).toBeUndefined();
+    for (const url of probedUrls) expect(url).not.toContain("sk_live_super_secret");
+  });
+
   it("accepts a legitimate non-spec-host base_url_override (the gate is not over-broad)", async () => {
     const { DataCandidateFormInstallHandler } = await import("../data-candidate-form-handler");
     const handler = new DataCandidateFormInstallHandler(STRIPE_DATA_CANDIDATE, {

--- a/packages/api/src/lib/integrations/install/__tests__/data-candidate-form-handler.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/data-candidate-form-handler.test.ts
@@ -146,4 +146,83 @@ describe("DataCandidateFormInstallHandler.validateConfig", () => {
     expect(probedHeaders[0]?.Authorization).toBeUndefined();
     expect(probedUrls[0]).not.toContain("sk_live_super_secret");
   });
+
+  it("rejects a base_url_override pointed at the locked spec host — never leaks the credential to the spec CDN (#3039)", async () => {
+    const { DataCandidateFormInstallHandler } = await import("../data-candidate-form-handler");
+    const { FormInstallValidationError } = await import("../email-form-handler");
+    const handler = new DataCandidateFormInstallHandler(STRIPE_DATA_CANDIDATE, {
+      idGenerator: () => "fixed-uuid",
+      now: () => "2026-05-30T00:00:00.000Z",
+      fetchImpl: (async (input: string | URL, init?: RequestInit) => {
+        probedUrls.push(typeof input === "string" ? input : input.toString());
+        const headers: Record<string, string> = {};
+        const h = init?.headers as Record<string, string> | undefined;
+        if (h) for (const [k, v] of Object.entries(h)) headers[k] = v;
+        probedHeaders.push(headers);
+        return new Response(JSON.stringify(STRIPE_FIXTURE_SPEC), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }) as unknown as typeof globalThis.fetch,
+    });
+
+    // The locked spec lives on raw.githubusercontent.com. An admin sets
+    // base_url_override to THAT host — which, under the #3034 gate's
+    // `baseUrlOverride ?? apiBaseUrl` precedence, would make specHost === apiHost
+    // and attach the secret key to the public spec-CDN fetch. The candidate's spec
+    // host is never a legitimate API host for it, so the override must be rejected.
+    let thrown: unknown;
+    try {
+      await handler.validateConfig("ws-1" as never, {
+        auth_value: "sk_live_super_secret",
+        base_url_override: "https://raw.githubusercontent.com/anything",
+      });
+    } catch (err) {
+      thrown = err;
+    }
+
+    // Rejected at validation with a field-level error on base_url_override.
+    expect(thrown).toBeInstanceOf(FormInstallValidationError);
+    expect(
+      (thrown as InstanceType<typeof FormInstallValidationError>).fieldErrors.base_url_override,
+    ).toBeDefined();
+
+    // The security invariant the precedence branch defeated: the secret key never
+    // reached the spec host — no probe fetch carried it in a header or the URL.
+    for (const headers of probedHeaders) expect(headers.Authorization).toBeUndefined();
+    for (const url of probedUrls) expect(url).not.toContain("sk_live_super_secret");
+  });
+
+  it("accepts a legitimate non-spec-host base_url_override (the gate is not over-broad)", async () => {
+    const { DataCandidateFormInstallHandler } = await import("../data-candidate-form-handler");
+    const handler = new DataCandidateFormInstallHandler(STRIPE_DATA_CANDIDATE, {
+      idGenerator: () => "fixed-uuid",
+      now: () => "2026-05-30T00:00:00.000Z",
+      fetchImpl: (async (input: string | URL, init?: RequestInit) => {
+        probedUrls.push(typeof input === "string" ? input : input.toString());
+        const headers: Record<string, string> = {};
+        const h = init?.headers as Record<string, string> | undefined;
+        if (h) for (const [k, v] of Object.entries(h)) headers[k] = v;
+        probedHeaders.push(headers);
+        return new Response(JSON.stringify(STRIPE_FIXTURE_SPEC), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }) as unknown as typeof globalThis.fetch,
+    });
+
+    // A regional API host (NOT the spec host) is a legitimate override — the install
+    // succeeds, the override is persisted, and the spec fetch still carries no
+    // credential (spec host ≠ override host, so the #3034 gate withholds it).
+    const result = await handler.validateConfig("ws-1" as never, {
+      auth_value: "sk_live_super_secret",
+      base_url_override: "https://api-eu.stripe.com",
+    });
+
+    expect(result.credentialWritten).toBe(true);
+    const insertCall = queryCalls.find((c) => c.sql.includes("INSERT INTO workspace_plugins"));
+    expect(insertCall).toBeDefined();
+    expect(insertCall!.params[3]).toContain("api-eu.stripe.com");
+    expect(probedHeaders[0]?.Authorization).toBeUndefined();
+  });
 });

--- a/packages/api/src/lib/integrations/install/data-candidate-form-handler.ts
+++ b/packages/api/src/lib/integrations/install/data-candidate-form-handler.ts
@@ -43,17 +43,19 @@ const AUTH_VALUE_MAX = 8192;
  * `raw.githubusercontent.com.` would not equal `raw.githubusercontent.com`, yet
  * DNS resolves them to the same host (Codex review, PR #3040). Compares the
  * hostname only (no port): the candidate's spec host is never a legitimate API
- * host for it on ANY port, so a port-varied form must be rejected too. Returns
- * `null` for an unparseable URL ⇒ no spurious match.
+ * host for it on ANY port, so a port-varied form must be rejected too.
+ *
+ * THROWS (does not swallow) on an unparseable URL — the spec-host check is a
+ * security gate, so it must fail CLOSED. A `catch { return null }` here would be
+ * the "false negative on a security check" anti-pattern CLAUDE.md forbids: an
+ * unparseable override would read as "no match" and slip the gate. In practice
+ * neither input can throw — `base_url_override` is already validated as a
+ * well-formed http(s) URL by {@link OptionalUrlSchema}, and the spec URL is a
+ * static candidate-registry constant — so this is defense-in-depth: if either
+ * ever became unparseable the install aborts loudly (500) rather than proceeding.
  */
-function normalizedHostname(url: string): string | null {
-  try {
-    return new URL(url).hostname.toLowerCase().replace(/\.+$/, "");
-  } catch {
-    // intentionally ignored: an unparseable URL has no comparable host — the
-    // caller treats null as "no match" and lets the probe/SSRF guards handle it.
-    return null;
-  }
+function normalizedHostname(url: string): string {
+  return new URL(url).hostname.toLowerCase().replace(/\.+$/, "");
 }
 
 /**
@@ -61,12 +63,11 @@ function normalizedHostname(url: string): string | null {
  * `specUrl` (#3039) — used to reject a `base_url_override` that re-points at the
  * candidate's spec host. Both hostnames are normalized via
  * {@link normalizedHostname} so a trailing-dot / case-varied form can't bypass
- * the gate. An unparseable URL on either side ⇒ `false` (no spurious match).
+ * the gate; an unparseable URL on either side throws (fail closed), never a
+ * silent "no match".
  */
 function sharesHost(overrideUrl: string, specUrl: string): boolean {
-  const a = normalizedHostname(overrideUrl);
-  const b = normalizedHostname(specUrl);
-  return a !== null && b !== null && a === b;
+  return normalizedHostname(overrideUrl) === normalizedHostname(specUrl);
 }
 
 const OptionalUrlSchema = z

--- a/packages/api/src/lib/integrations/install/data-candidate-form-handler.ts
+++ b/packages/api/src/lib/integrations/install/data-candidate-form-handler.ts
@@ -34,6 +34,24 @@ import type { FormBasedInstallHandler, InstallRecord } from "./types";
 /** Defensive upper bound on the credential — guards against pathological pastes. */
 const AUTH_VALUE_MAX = 8192;
 
+/**
+ * True iff two URLs share the same host (`hostname[:port]`, lowercased by the URL
+ * parser) — the exact-host comparison the #3034 probe gate uses
+ * ({@link import("../../openapi/probe").probeCredentialAllowed}). Used to reject a
+ * `base_url_override` that re-points at the candidate's locked spec host (#3039).
+ * An unparseable URL ⇒ `false` (no spurious match); both inputs are already
+ * URL-validated by the time this runs (the zod refine + the candidate registry).
+ */
+function sameHost(a: string, b: string): boolean {
+  try {
+    return new URL(a).host === new URL(b).host;
+  } catch {
+    // intentionally ignored: an unparseable URL has no comparable host — treat as
+    // "no match" and let the downstream probe/SSRF guards handle a malformed URL.
+    return false;
+  }
+}
+
 const OptionalUrlSchema = z
   .string()
   .transform((raw) => raw.trim())
@@ -95,6 +113,29 @@ export class DataCandidateFormInstallHandler implements FormBasedInstallHandler 
       throw FormInstallValidationError.fromZodFlatten(parsed.error.flatten());
     }
     const data = parsed.data;
+
+    // Harden the #3034 host-match credential gate (#3039). A candidate's spec URL
+    // is LOCKED (raw.githubusercontent.com), and `persistOpenApiDatasourceInstall`
+    // resolves the gate's API host as `baseUrlOverride ?? apiBaseUrl`. So an admin
+    // who sets `base_url_override` to the candidate's OWN spec host would make
+    // specHost === apiHost — re-attaching the customer credential (e.g. sk_live_…)
+    // to the public spec-CDN fetch, defeating #3034 for this path. The candidate's
+    // spec host is a static spec location, never a legitimate API host for it (the
+    // executable API lives at `apiBaseUrl`), and an override pointed there would
+    // also misroute query-time requests — so reject it outright. The generic
+    // openapi-generic path has no locked spec, so this guard is candidate-only.
+    if (data.base_url_override && sameHost(data.base_url_override, this.candidate.openapiUrl)) {
+      throw FormInstallValidationError.fromZodFlatten({
+        fieldErrors: {
+          base_url_override: [
+            "Base URL override cannot point at this datasource's spec host — that is a static " +
+              "spec location, not an API host. Leave it blank to use the spec's declared API " +
+              "server, or set it to the real API host.",
+          ],
+        },
+        formErrors: [],
+      });
+    }
 
     // Delegate to the shared core, pre-filling the locked spec URL + auth kind
     // from the candidate registry. No forked install logic — same probe / encrypt

--- a/packages/api/src/lib/integrations/install/data-candidate-form-handler.ts
+++ b/packages/api/src/lib/integrations/install/data-candidate-form-handler.ts
@@ -35,21 +35,38 @@ import type { FormBasedInstallHandler, InstallRecord } from "./types";
 const AUTH_VALUE_MAX = 8192;
 
 /**
- * True iff two URLs share the same host (`hostname[:port]`, lowercased by the URL
- * parser) — the exact-host comparison the #3034 probe gate uses
- * ({@link import("../../openapi/probe").probeCredentialAllowed}). Used to reject a
- * `base_url_override` that re-points at the candidate's locked spec host (#3039).
- * An unparseable URL ⇒ `false` (no spurious match); both inputs are already
- * URL-validated by the time this runs (the zod refine + the candidate registry).
+ * A URL's hostname, normalized for comparison: lowercased (redundant — the URL
+ * parser already lowercases the hostname — but explicit) with any trailing FQDN
+ * dot(s) stripped. Mirrors the egress guard's hostname normalization (see
+ * `sandbox/validate.ts`) so the spec-host check below can't be slipped by an
+ * equivalent fully-qualified form: WHATWG `URL.host` KEEPS the trailing dot, so
+ * `raw.githubusercontent.com.` would not equal `raw.githubusercontent.com`, yet
+ * DNS resolves them to the same host (Codex review, PR #3040). Compares the
+ * hostname only (no port): the candidate's spec host is never a legitimate API
+ * host for it on ANY port, so a port-varied form must be rejected too. Returns
+ * `null` for an unparseable URL ⇒ no spurious match.
  */
-function sameHost(a: string, b: string): boolean {
+function normalizedHostname(url: string): string | null {
   try {
-    return new URL(a).host === new URL(b).host;
+    return new URL(url).hostname.toLowerCase().replace(/\.+$/, "");
   } catch {
-    // intentionally ignored: an unparseable URL has no comparable host — treat as
-    // "no match" and let the downstream probe/SSRF guards handle a malformed URL.
-    return false;
+    // intentionally ignored: an unparseable URL has no comparable host — the
+    // caller treats null as "no match" and lets the probe/SSRF guards handle it.
+    return null;
   }
+}
+
+/**
+ * True iff `overrideUrl` resolves to the same host as the candidate's locked
+ * `specUrl` (#3039) — used to reject a `base_url_override` that re-points at the
+ * candidate's spec host. Both hostnames are normalized via
+ * {@link normalizedHostname} so a trailing-dot / case-varied form can't bypass
+ * the gate. An unparseable URL on either side ⇒ `false` (no spurious match).
+ */
+function sharesHost(overrideUrl: string, specUrl: string): boolean {
+  const a = normalizedHostname(overrideUrl);
+  const b = normalizedHostname(specUrl);
+  return a !== null && b !== null && a === b;
 }
 
 const OptionalUrlSchema = z
@@ -124,7 +141,7 @@ export class DataCandidateFormInstallHandler implements FormBasedInstallHandler 
     // executable API lives at `apiBaseUrl`), and an override pointed there would
     // also misroute query-time requests — so reject it outright. The generic
     // openapi-generic path has no locked spec, so this guard is candidate-only.
-    if (data.base_url_override && sameHost(data.base_url_override, this.candidate.openapiUrl)) {
+    if (data.base_url_override && sharesHost(data.base_url_override, this.candidate.openapiUrl)) {
       throw FormInstallValidationError.fromZodFlatten({
         fieldErrors: {
           base_url_override: [


### PR DESCRIPTION
Fixes #3039.

## Problem

A built-in data candidate's spec URL is locked (e.g. `stripe-data` → `raw.githubusercontent.com`), so an admin can't re-point it. But `persistOpenApiDatasourceInstall` resolves the #3034 probe-credential host-match gate as `baseUrlOverride ?? apiBaseUrl`, and the slim data-candidate form accepts an optional `base_url_override`.

An admin who set `base_url_override` to the locked **spec** host made `specHost === apiHost`, so the #3034 gate then attached the customer's credential (e.g. `sk_live_…`) to the probe fetch against the public spec CDN — defeating the #3034 fix for that path.

Severity **LOW** (admin-trusted, same tenant, no cross-tenant/unauth path), but a real, previously-untested branch of the exact gate #3034 enforces.

## Fix

On the **data-candidate install path only**, reject a `base_url_override` whose host equals the candidate's locked `openapiUrl` host (`packages/api/src/lib/integrations/install/data-candidate-form-handler.ts`). The candidate's spec host is a static spec location, never a legitimate API host for it (the executable API lives at `apiBaseUrl`), and an override pointed there would also misroute query-time requests — so it's rejected with a field-level validation error rather than silently ignored.

The fix deliberately lives in the candidate handler, **not** the shared `persistOpenApiDatasourceInstall` core: for the generic `openapi-generic` path a spec and `base_url_override` sharing a host is the *designed* same-host authenticated case (Twenty's `/open-api/core`). Hardening the core would break that. The "spec host is never a legit API host" invariant holds only for data candidates with their locked public-CDN spec. `openapi-generic-form-handler.ts` and `probe.ts` are unchanged.

## Tests (TDD: red → green)

`data-candidate-form-handler.test.ts`:
- **`rejects a base_url_override pointed at the locked spec host (#3039)`** — pins the precedence branch: install with `base_url_override` == spec host throws `FormInstallValidationError` on `base_url_override`, **and** the secret never appears in any probe header/URL. (Red before the fix: the install proceeded and sent `Authorization: Bearer sk_live_…` to the spec CDN.)
- **`accepts a legitimate non-spec-host base_url_override`** — positive control so the gate isn't over-broad: a regional API host (`api-eu.stripe.com`) still installs, persists the override, and carries no credential on the spec fetch.

## Acceptance criteria

- [x] Installing a built-in data candidate with `base_url_override` set to the locked spec host does NOT send the credential to the spec host (rejected at validation).
- [x] The precedence branch is covered by a test.

## CI

Local `/ci` — lint, type, full `bun run test` (api + others), syncpack, template/security-headers/railway-watch/schema drift, oauth-helper/test-discipline/twenty-resolver/published-symbols — all pass.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3040"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782786464&installation_id=135337507&pr_number=3040&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3040&signature=55a7c8d8b005c7dcc46ab878bb3b099a2dfcd5f8948f32ef9bbf5c3206253f88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stricter validation of base URL overrides during integration installs: overrides that match the integration spec host (including trailing-dot variants) are rejected with a field-level error; valid non-spec-host overrides are accepted and persisted. Probe requests never include authorization headers or leak secrets.

* **Tests**
  * Added unit tests covering rejection/acceptance paths, hostname-normalization cases, and no-leak probe behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->