### PR TITLE
docs(changelog): tag-based public changelog, sunset milestone numbering

### DIFF
--- a/.claude/commands/changelog.md
+++ b/.claude/commands/changelog.md
@@ -96,9 +96,9 @@ After approval:
 
 1. Insert the new entry into `CHANGELOG.md` — below `## [Unreleased]` and above the previous entry
 2. For the public docs changelog (`apps/docs/src/components/changelog-data.ts` → `docs.useatlas.dev/changelog`): this is a **per-tag feed** (ADR-0008). Add a curated entry to the **top** of the `releases` array, keyed by the git tag (`version: "v0.0.2"`). In the normal flow `/release` does this at tag time (Step 4b) — only add it here directly if you're drafting ahead of the tag. Don't touch the `developmentHistory` array (frozen pre-versioning milestones). Don't set `githubMilestone` on tag entries — the component derives the GitHub Release link from `version`.
-3. Commit:
+3. Commit (stage the docs changelog file too if you added an entry in step 2):
    ```
-   git add CHANGELOG.md
+   git add CHANGELOG.md apps/docs/src/components/changelog-data.ts
    git commit -m "docs: changelog for X.Y.Z"
    git push
    ```

--- a/.claude/commands/changelog.md
+++ b/.claude/commands/changelog.md
@@ -95,7 +95,7 @@ Wait for approval before writing.
 After approval:
 
 1. Insert the new entry into `CHANGELOG.md` — below `## [Unreleased]` and above the previous entry
-2. If this is a customer-meaningful release, also add an entry to `apps/docs/src/components/changelog-data.ts` (the public changelog)
+2. For the public docs changelog (`apps/docs/src/components/changelog-data.ts` → `docs.useatlas.dev/changelog`): this is a **per-tag feed** (ADR-0008). Add a curated entry to the **top** of the `releases` array, keyed by the git tag (`version: "v0.0.2"`). In the normal flow `/release` does this at tag time (Step 4b) — only add it here directly if you're drafting ahead of the tag. Don't touch the `developmentHistory` array (frozen pre-versioning milestones). Don't set `githubMilestone` on tag entries — the component derives the GitHub Release link from `version`.
 3. Commit:
    ```
    git add CHANGELOG.md

--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -58,35 +58,6 @@ First dev tag. Establishes tag-gated prod deploys, stability contract,
 and the /release flow. Slice 6 bun-test-parallel cutover; docs polish.
 ```
 
-**Step 4b: Append the docs-site changelog entry (before tagging)**
-
-The public changelog at `docs.useatlas.dev/changelog` is a per-tag feed (ADR-0008 — *not* banked for `v0.1.0`). Add one entry for this tag so the docs site reflects the release. This must land on `main` **before** the tag is cut, so the tagged SHA carries its own changelog entry (the docs service deploys from `main`).
-
-1. Add a new object to the **top** of the `releases` array in `apps/docs/src/components/changelog-data.ts`:
-   ```ts
-   {
-     version: "<version>",          // the git tag, e.g. "v0.0.2"
-     title: "<theme>",              // milestone theme, e.g. "REST Datasources"
-     date: "<YYYY-MM-DD>",          // tag date
-     summary: "<2–4 sentences, customer-facing — what shipped and why it matters>",
-     highlights: ["<bullet>", "<bullet>", "..."],  // optional, 3–8 curated items
-   },
-   ```
-   Curate from the milestone scope / the Step 4 tag message — customer-facing prose, not a commit dump. The component derives the GitHub Release link from `version`, so **do not** set `githubMilestone` on tag entries (that field belongs to the `developmentHistory` track only). Use `/changelog` to help draft the prose if useful.
-
-2. Commit + push to `main`:
-   ```bash
-   git add apps/docs/src/components/changelog-data.ts
-   git commit -m "docs(changelog): <version> — <theme>"
-   git push origin main
-   ```
-
-3. Re-confirm the Step 1 invariant (clean + synced) before tagging — HEAD must now equal `origin/main` with this commit included:
-   ```bash
-   git fetch origin && [ "$(git rev-parse HEAD)" = "$(git rev-parse origin/main)" ] && echo OK
-   ```
-   The tag in Step 5 points at this commit, so the release and its docs-site changelog entry ship together.
-
 **Step 5: Create the annotated tag and push**
 
 ```bash
@@ -123,9 +94,36 @@ gh release create <version> -R AtlasDevHQ/atlas --generate-notes --verify-tag
 
 `--generate-notes` produces a commit + PR list as the body. `--verify-tag` makes sure the tag we just pushed exists on the remote (sanity check).
 
-The GitHub Release `--generate-notes` body is the raw commit/PR list; the curated, customer-facing summary lives in the docs-site changelog entry from Step 4b (`docs.useatlas.dev/changelog`), which links back to this Release. For minor tags, optionally edit the GitHub Release body to lead with that user-facing summary; patches typically ship with the auto-notes as-is.
+The GitHub Release `--generate-notes` body is the raw commit/PR list; the curated, customer-facing summary lives in the docs-site changelog entry added in the next step (`docs.useatlas.dev/changelog`), which links back to this Release. For minor tags, optionally edit the GitHub Release body to lead with that user-facing summary; patches typically ship with the auto-notes as-is.
 
-**Step 8: Watch the prod deploy**
+**Step 8: Append the docs-site changelog entry (now that the Release exists)**
+
+The public changelog at `docs.useatlas.dev/changelog` is a per-tag feed (ADR-0008 — *not* banked for `v0.1.0`). Add one entry for this tag so the docs site reflects the release. Do this **after** the GitHub Release exists (Step 7), never before: the entry links to `releases/tag/<version>`, so publishing it earlier would advertise a dead link, and a failure in tagging / prod / release-create would strand a stale entry on the live docs site.
+
+1. Add a new object to the **top** of the `releases` array in `apps/docs/src/components/changelog-data.ts`:
+   ```ts
+   {
+     version: "<version>",          // the git tag, e.g. "v0.0.2"
+     title: "<theme>",              // milestone theme, e.g. "REST Datasources"
+     date: "<YYYY-MM-DD>",          // tag date (matches the Release)
+     summary: "<2–4 sentences, customer-facing — what shipped and why it matters>",
+     highlights: ["<bullet>", "<bullet>", "..."],  // optional, 3–8 curated items
+   },
+   ```
+   Curate from the milestone scope / the Step 4 tag message — customer-facing prose, not a commit dump. The component derives the GitHub Release link from `version`, so **do not** set `githubMilestone` on tag entries (that field belongs to the `developmentHistory` track only). Use `/changelog` to help draft the prose if useful.
+
+2. Type-check the docs app so a broken entry can't reach the docs build (the docs service deploys from `main`), then commit + push:
+   ```bash
+   node_modules/.bin/tsgo --noEmit -p apps/docs/tsconfig.json   # from repo root
+   git add apps/docs/src/components/changelog-data.ts
+   git commit -m "docs(changelog): <version> — <theme>"
+   git push origin main
+   ```
+   This commit is docs-data only and is intentionally **not** part of the tagged release SHA — `/ci` (Step 3) already gated the release code, and decoupling keeps the changelog from ever advertising a release that doesn't exist.
+
+3. Rollback (rare): if the release is later superseded or rolled back, revert this commit so the changelog doesn't advertise a withdrawn release — `git revert <changelog-commit> && git push origin main`.
+
+**Step 9: Watch the prod deploy**
 
 The `prod`-branch push (step 6) triggers Railway prod deploys across the 5 services watching `prod` (`api`, `api-eu`, `api-apac`, `web`, `www`). Output the watch commands:
 
@@ -136,7 +134,7 @@ gh api repos/AtlasDevHQ/atlas/deployments?ref=prod --jq '.[0:5][] | "\(.created_
 
 Tell the user where the GitHub Release lives, and that prod deploy is in flight. Don't wait — the deploy takes ~5 min; user can monitor.
 
-**Step 9: Output summary**
+**Step 10: Output summary**
 
 ```
 Tagged: v0.0.1

--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -58,6 +58,35 @@ First dev tag. Establishes tag-gated prod deploys, stability contract,
 and the /release flow. Slice 6 bun-test-parallel cutover; docs polish.
 ```
 
+**Step 4b: Append the docs-site changelog entry (before tagging)**
+
+The public changelog at `docs.useatlas.dev/changelog` is a per-tag feed (ADR-0008 — *not* banked for `v0.1.0`). Add one entry for this tag so the docs site reflects the release. This must land on `main` **before** the tag is cut, so the tagged SHA carries its own changelog entry (the docs service deploys from `main`).
+
+1. Add a new object to the **top** of the `releases` array in `apps/docs/src/components/changelog-data.ts`:
+   ```ts
+   {
+     version: "<version>",          // the git tag, e.g. "v0.0.2"
+     title: "<theme>",              // milestone theme, e.g. "REST Datasources"
+     date: "<YYYY-MM-DD>",          // tag date
+     summary: "<2–4 sentences, customer-facing — what shipped and why it matters>",
+     highlights: ["<bullet>", "<bullet>", "..."],  // optional, 3–8 curated items
+   },
+   ```
+   Curate from the milestone scope / the Step 4 tag message — customer-facing prose, not a commit dump. The component derives the GitHub Release link from `version`, so **do not** set `githubMilestone` on tag entries (that field belongs to the `developmentHistory` track only). Use `/changelog` to help draft the prose if useful.
+
+2. Commit + push to `main`:
+   ```bash
+   git add apps/docs/src/components/changelog-data.ts
+   git commit -m "docs(changelog): <version> — <theme>"
+   git push origin main
+   ```
+
+3. Re-confirm the Step 1 invariant (clean + synced) before tagging — HEAD must now equal `origin/main` with this commit included:
+   ```bash
+   git fetch origin && [ "$(git rev-parse HEAD)" = "$(git rev-parse origin/main)" ] && echo OK
+   ```
+   The tag in Step 5 points at this commit, so the release and its docs-site changelog entry ship together.
+
 **Step 5: Create the annotated tag and push**
 
 ```bash
@@ -94,7 +123,7 @@ gh release create <version> -R AtlasDevHQ/atlas --generate-notes --verify-tag
 
 `--generate-notes` produces a commit + PR list as the body. `--verify-tag` makes sure the tag we just pushed exists on the remote (sanity check).
 
-For minor tags, edit the GitHub Release body afterward to lead with the user-facing summary; the auto-notes are good but verbose. Patches typically ship with the auto-notes as-is.
+The GitHub Release `--generate-notes` body is the raw commit/PR list; the curated, customer-facing summary lives in the docs-site changelog entry from Step 4b (`docs.useatlas.dev/changelog`), which links back to this Release. For minor tags, optionally edit the GitHub Release body to lead with that user-facing summary; patches typically ship with the auto-notes as-is.
 
 **Step 8: Watch the prod deploy**
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,7 +125,7 @@ Three independent version trains, none coordinate. See [ADR-0008](docs/adr/0008-
 
 The shipped internal milestone `1.0.0 — SaaS Launch` (#24) is **not** the future git tag `v1.0.0`. Reference it as "internal milestone 1.0.0" to disambiguate. `v1.0.0` is reserved for the moment REST + MCP + plugin SDK contracts freeze.
 
-The `/release` skill bundles `/ci` + annotated tag + push + `gh release create --generate-notes`. Customer-facing stability commitments live at [apps/docs/content/docs/reference/stability.mdx](apps/docs/content/docs/reference/stability.mdx).
+The `/release` skill bundles `/ci` + a docs-changelog entry + annotated tag + push + `gh release create --generate-notes`. The public changelog at [docs.useatlas.dev/changelog](https://docs.useatlas.dev/changelog) is a **per-tag feed** — `/release` appends one `apps/docs/src/components/changelog-data.ts` `releases[]` entry per tag (curated, links the GitHub Release), and the pre-public-versioning `1.x`/`0.x` internal milestones live in a separate `developmentHistory` track. It is **not** banked for `v0.1.0` — see [ADR-0008 § Amendment (2026-05-31)](docs/adr/0008-versioning-and-release-tags.md). Customer-facing stability commitments live at [apps/docs/content/docs/reference/stability.mdx](apps/docs/content/docs/reference/stability.mdx).
 
 **Operational rule:** when adding a new integration (chat platform, action target, datasource), create the staging app/credentials first — staging is the soak environment for tag-gated prod deploys. Don't OAuth-register a new platform straight against prod.
 

--- a/apps/docs/src/components/changelog-data.ts
+++ b/apps/docs/src/components/changelog-data.ts
@@ -9,9 +9,36 @@ export interface Release {
 
 /**
  * Changelog release data — single source of truth for the changelog page.
- * Ordered reverse chronologically, newest first.
+ *
+ * Two tracks, each ordered newest-first:
+ *  - `releases`           — the public git-tag train (`v0.0.1`, `v0.0.2`, …). Mirrors GitHub
+ *                           Releases; one entry per tag cut via `/release`.
+ *  - `developmentHistory` — internal milestone numbers (`1.6.0` … `0.1`) that predate public
+ *                           versioning. Kept as a pre-launch development record, not public semver.
+ *
+ * See ADR-0008 for the versioning model. New tags are appended to `releases` at /release time.
  */
 export const releases: Release[] = [
+  {
+    version: "v0.0.1",
+    title: "Release Process Bootstrap",
+    date: "2026-05-29",
+    summary:
+      "The first tagged release of Atlas — and the start of versioned, tag-gated production deploys. From here, prod advances only when an annotated git tag is cut, rather than auto-deploying on every merge: `main` continuously ships to staging, and a release tag promotes that exact commit to production. The headline deliverable is the customer-facing Stability Contract, which spells out what's stable to build on today (the REST API surface, the MCP tool surface, the plugin SDK, the semantic-layer wire format) and what may still change before v1.0.0. Docs + release tooling only — no runtime feature ships under this tag; it's the foundation the rest of the v0.0.x train is cut from.",
+    highlights: [
+      "Tag-gated production deploys — prod advances only on an annotated `v*.*.*` tag via the `/release` flow; `main` continuously deploys to staging, so production is always a deliberately tagged commit",
+      "Stability Contract published — explicit stability commitments for the REST API, MCP tool surface, plugin SDK, and semantic-layer wire format, at Reference → Stability",
+      "Versioning policy (ADR-0008) — the `v0.0.x` series is the pre-launch development train; `v0.1.0` is reserved to mark the public launch (target July 2026)",
+    ],
+  },
+];
+
+/**
+ * Pre-public-versioning development history. These are internal milestone numbers, not public
+ * semver — they predate the git-tag train (ADR-0008) and are kept as a record of what shipped
+ * during development. The public version train is `releases` above.
+ */
+export const developmentHistory: Release[] = [
   {
     version: "1.6.0",
     title: "CRM & lead capture",

--- a/apps/docs/src/components/changelog-timeline.tsx
+++ b/apps/docs/src/components/changelog-timeline.tsx
@@ -1,14 +1,30 @@
 "use client";
 
-import { ExternalLink, GitBranch } from "lucide-react";
+import { ExternalLink, GitBranch, Tag } from "lucide-react";
 import type { Release } from "./changelog-data";
-import { releases } from "./changelog-data";
+import { developmentHistory, releases } from "./changelog-data";
 
 // ── Helpers ────────────────────────────────────────────────
 
-function milestoneUrl(r: Release) {
-  if (!r.githubMilestone) return undefined;
-  return `https://github.com/AtlasDevHQ/atlas/milestone/${r.githubMilestone}`;
+const REPO = "https://github.com/AtlasDevHQ/atlas";
+
+/** Tag-train entries are versioned `v0.0.1`, `v0.1.0`, …; history entries are `1.6.0`, `0.9`. */
+function isTagRelease(r: Release) {
+  return /^v\d/.test(r.version);
+}
+
+/**
+ * Tag releases link to their GitHub Release; pre-versioning history entries link to the
+ * milestone that tracked the work (when one exists).
+ */
+function externalLinkFor(r: Release): { href: string; label: string } | undefined {
+  if (isTagRelease(r)) {
+    return { href: `${REPO}/releases/tag/${r.version}`, label: "GitHub Release" };
+  }
+  if (r.githubMilestone) {
+    return { href: `${REPO}/milestone/${r.githubMilestone}`, label: "GitHub Milestone" };
+  }
+  return undefined;
 }
 
 // ── Single release card ───────────────────────────────────
@@ -20,7 +36,8 @@ function ReleaseCard({
   release: Release;
   isLatest: boolean;
 }) {
-  const url = milestoneUrl(release);
+  const link = externalLinkFor(release);
+  const LinkIcon = isTagRelease(release) ? Tag : GitBranch;
 
   return (
     <div
@@ -78,18 +95,81 @@ function ReleaseCard({
       )}
 
       {/* GitHub link */}
-      {url && (
+      {link && (
         <a
-          href={url}
+          href={link.href}
           target="_blank"
           rel="noopener noreferrer"
           className="mt-3 inline-flex items-center gap-1.5 text-xs font-medium text-[var(--color-fd-muted-foreground)] transition-colors hover:text-[var(--color-fd-primary)]"
         >
-          <GitBranch className="h-3 w-3" aria-hidden="true" />
-          GitHub Milestone
+          <LinkIcon className="h-3 w-3" aria-hidden="true" />
+          {link.label}
           <ExternalLink className="h-2.5 w-2.5" aria-hidden="true" />
         </a>
       )}
+    </div>
+  );
+}
+
+// ── Timeline track (one column of cards) ──────────────────
+
+function Track({
+  items,
+  latestIndex,
+}: {
+  items: Release[];
+  /** Index within `items` to render as "latest", or -1 for none. */
+  latestIndex: number;
+}) {
+  return (
+    <div className="relative space-y-4 pl-8">
+      {/* Timeline line */}
+      <div className="absolute left-[11px] top-0 bottom-0 w-px bg-[var(--color-fd-border)]" />
+
+      {items.map((r, i) => (
+        <div key={`${r.version}-${r.title}`} className="relative">
+          {/* Dot */}
+          <div className="absolute -left-8 top-4">
+            <div
+              className={`relative z-10 flex h-6 w-6 shrink-0 items-center justify-center rounded-full border-2 ${
+                i === latestIndex
+                  ? "border-[var(--color-fd-primary)]/40 bg-[var(--color-fd-primary)]/10"
+                  : "border-[var(--color-fd-muted-foreground)]/30 bg-[var(--color-fd-background)]"
+              }`}
+            >
+              <span
+                className={`h-2 w-2 rounded-full ${
+                  i === latestIndex
+                    ? "bg-[var(--color-fd-primary)]"
+                    : "bg-[var(--color-fd-muted-foreground)]/40"
+                }`}
+              />
+            </div>
+          </div>
+          <ReleaseCard release={r} isLatest={i === latestIndex} />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ── Development-history divider ────────────────────────────
+
+function HistoryDivider() {
+  return (
+    <div className="mt-10 mb-4">
+      <div className="flex items-center gap-3">
+        <div className="h-px flex-1 bg-[var(--color-fd-border)]" />
+        <span className="shrink-0 text-xs font-medium uppercase tracking-wide text-[var(--color-fd-muted-foreground)]/70">
+          Development history
+        </span>
+        <div className="h-px flex-1 bg-[var(--color-fd-border)]" />
+      </div>
+      <p className="mt-3 text-xs leading-relaxed text-[var(--color-fd-muted-foreground)]/70">
+        Internal milestone numbers from before Atlas adopted public version tags. These predate the{" "}
+        <code>v0.0.x</code> release train above and are kept as a record of what shipped during
+        development — they are not public semver.
+      </p>
     </div>
   );
 }
@@ -131,34 +211,17 @@ function Footer() {
 export function ChangelogTimeline() {
   return (
     <div className="mx-auto max-w-2xl">
-      <div className="relative space-y-4 pl-8">
-        {/* Timeline line */}
-        <div className="absolute left-[11px] top-0 bottom-0 w-px bg-[var(--color-fd-border)]" />
+      {/* Public git-tag train — newest first; first entry is the latest release. */}
+      <Track items={releases} latestIndex={0} />
 
-        {releases.map((r, i) => (
-          <div key={`${r.version}-${r.title}`} className="relative">
-            {/* Dot */}
-            <div className="absolute -left-8 top-4">
-              <div
-                className={`relative z-10 flex h-6 w-6 shrink-0 items-center justify-center rounded-full border-2 ${
-                  i === 0
-                    ? "border-[var(--color-fd-primary)]/40 bg-[var(--color-fd-primary)]/10"
-                    : "border-[var(--color-fd-muted-foreground)]/30 bg-[var(--color-fd-background)]"
-                }`}
-              >
-                <span
-                  className={`h-2 w-2 rounded-full ${
-                    i === 0
-                      ? "bg-[var(--color-fd-primary)]"
-                      : "bg-[var(--color-fd-muted-foreground)]/40"
-                  }`}
-                />
-              </div>
-            </div>
-            <ReleaseCard release={r} isLatest={i === 0} />
-          </div>
-        ))}
-      </div>
+      {/* Pre-public-versioning development history. */}
+      {developmentHistory.length > 0 && (
+        <>
+          <HistoryDivider />
+          <Track items={developmentHistory} latestIndex={-1} />
+        </>
+      )}
+
       <Footer />
     </div>
   );

--- a/docs/adr/0008-versioning-and-release-tags.md
+++ b/docs/adr/0008-versioning-and-release-tags.md
@@ -36,7 +36,13 @@ The grilling-session decision: introduce git tags as the **third independent ver
 
 The git-tag train **starts at `v0.0.1`** (not `v0.1.0`, not `v1.0.0`), cut as soon as the v0.0.1 bundle is ready. The `v0.0.x` series is the **pre-launch development train**: each bump banks a milestone of pre-launch work (release-process bootstrap, REST datasources, …) and gives prod a real release identifier without claiming the product is publicly launched. The internal milestone `1.0.0 — SaaS Launch` (#24) keeps its number in the archive as a historical record of the SaaS-launch event but is **not** the git tag `v1.0.0`; that tag is reserved.
 
-**`v0.1.0` is the public launch (target: July 2026).** The first minor bump out of the `v0.0.x` development train marks the public launch announcement — the moment Atlas is presented to the world with a banked changelog (the accumulated `v0.0.x` train: release-process plumbing, REST datasources, staging environment live, etc.). Cutting `v0.0.x` tags now validates the release-process plumbing on low-stakes surfaces while nobody is watching; `v0.1.0` is held back so it means something. The launch event is tracked outside the tag train (#2919).
+**`v0.1.0` is the public launch (target: July 2026).** The first minor bump out of the `v0.0.x` development train marks the public launch announcement — the moment Atlas is presented to the world. The launch *announcement* aggregates the accumulated `v0.0.x` train (release-process plumbing, REST datasources, staging environment live, etc.) into a single narrative for the launch blog / marketing surface. The public **changelog page** is not held back for that moment, though — it tracks the tag train continuously (see the Amendment below). Cutting `v0.0.x` tags now validates the release-process plumbing on low-stakes surfaces while nobody is watching; `v0.1.0` is held back so it means something. The launch event is tracked outside the tag train (#2919).
+
+### Amendment (2026-05-31): the public changelog is a live per-tag feed
+
+The original cut of this ADR implied the docs-site changelog (`apps/docs/src/components/changelog-data.ts`, rendered at `docs.useatlas.dev/changelog`) was *banked* — held empty during `v0.0.x` and populated only at the `v0.1.0` launch, with each tag's customer-facing notes living solely in its GitHub Release `--generate-notes`. That left the public changelog showing stale internal milestone numbers (newest: `1.6.0`) as if they were the latest release, contradicting the tag train — a visitor saw `1.6.0` "above" `v0.0.1` and read it as a regression.
+
+**Superseded:** the docs-site changelog is now a **continuous per-tag feed**. One entry is appended to `changelog-data.ts` for every `v0.0.x`+ tag at `/release` time, newest first, each linking to its GitHub Release. The pre-public-versioning internal milestones (`1.6.0` … `0.1`) move to a separate `developmentHistory` track rendered below the tag train under a "Development history" divider, clearly labelled as not-public-semver. The GitHub Release `--generate-notes` remains the raw commit/PR list; the `changelog-data.ts` entry is the curated customer-facing summary. The `v0.1.0` launch *announcement* still aggregates the train — that's a separate marketing artifact, not the changelog page.
 
 ### Semver discipline rules for git tags
 
@@ -105,8 +111,9 @@ Bump every train together — npm package versions match the git tag, milestone 
 - The dual Railway trigger (Q5) hangs off this ADR. `main` push → staging autodeploy (3 services: api/web/www). Annotated tag → `/release` fast-forwards `prod` branch to the tag SHA → prod autodeploy across 5 services (api/api-eu/api-apac/web/www). `docs` continues watching `main` directly. See `docs/development/release-process.md`.
 - The first prod deploy under tag-gating was `v0.0.1`, cut 2026-05-29 (`9c68fc17`). The prior "every merge to `main` auto-deploys prod" flow is retired. The public launch (`v0.1.0`, July 2026) is a separate event, tracked independently.
 
-**For CHANGELOG.md:**
+**For the changelog:**
 - The existing `CHANGELOG.md` link to `CLAUDE.md#versioning--release-strategy` resolves to this ADR going forward. CHANGELOG sections will be reorganized around git tags (`## v0.0.1 — 2026-05-XX`) once tagging starts; internal-milestone-labeled sections remain in place as historical record.
+- **Docs-site changelog** (`changelog-data.ts` → `docs.useatlas.dev/changelog`): a live per-tag feed (see the 2026-05-31 Amendment above). `/release` appends one `releases[]` entry per tag, linking the GitHub Release; the pre-versioning `1.x`/`0.x` milestones live in a separate `developmentHistory` track. Not banked for `v0.1.0`.
 
 **For internal milestones:**
 - Going forward, GitHub milestone titles use the tag name as a prefix: `v0.0.2 — REST Datasources` (rename of `1.7.0 — Generic REST / Non-SQL Datasources` per [ADR-0009](./0009-tag-organized-roadmap.md)).

--- a/docs/development/release-process.md
+++ b/docs/development/release-process.md
@@ -2,7 +2,7 @@
 
 How Atlas ships to prod. Two flows: **normal release** (merge → soak → tag) and **hotfix** (merge → tag immediately).
 
-> **Live as of `v0.0.1`** (first tag of the pre-launch `v0.0.x` train, cut 2026-05-29 at `9c68fc17`): the dual Railway trigger described below is the active flow — `main` → staging, annotated tag → `prod` branch → prod. The pre-`v0.0.1` "every merge to `main` auto-deploys prod" flow is retired. The public launch (`v0.1.0`, target July 2026) is tracked separately and points at the banked changelog accumulated under the `v0.0.x` train.
+> **Live as of `v0.0.1`** (first tag of the pre-launch `v0.0.x` train, cut 2026-05-29 at `9c68fc17`): the dual Railway trigger described below is the active flow — `main` → staging, annotated tag → `prod` branch → prod. The pre-`v0.0.1` "every merge to `main` auto-deploys prod" flow is retired. The public launch (`v0.1.0`, target July 2026) is tracked separately; its announcement aggregates the work accumulated across the `v0.0.x` train (the per-tag docs changelog feed is live the whole time, not held back — [ADR-0008 § Amendment (2026-05-31)](../adr/0008-versioning-and-release-tags.md)).
 
 ## Mental model
 
@@ -66,7 +66,7 @@ The skill runs:
 4. **`git push origin <version>^{}:prod --force-with-lease`** — fast-forwards the `prod` branch to the tagged commit. This is what Railway watches; the prod-side deploy fires from this push. `--force-with-lease` (never `--force`) refuses to rewind if someone else has advanced `prod` since the local fetch — a safety net against concurrent `/release` runs.
 5. **`gh release create v0.0.1 --generate-notes`** — creates a GitHub Release with auto-generated commit + PR list.
 
-The `--generate-notes` output is the customer-facing changelog for that tag. Edit it on GitHub afterward if it needs polish.
+The curated, customer-facing changelog for each tag lives in the docs-site changelog feed (`apps/docs/src/components/changelog-data.ts` → [docs.useatlas.dev/changelog](https://docs.useatlas.dev/changelog)) — `/release` appends one entry per tag before tagging (Step 4b), and that entry links back to the GitHub Release. The `--generate-notes` body is the raw commit/PR list; edit it on GitHub if it needs polish. See [ADR-0008 § Amendment (2026-05-31)](../adr/0008-versioning-and-release-tags.md).
 
 ### 4. Watch prod
 

--- a/docs/development/release-process.md
+++ b/docs/development/release-process.md
@@ -66,7 +66,7 @@ The skill runs:
 4. **`git push origin <version>^{}:prod --force-with-lease`** — fast-forwards the `prod` branch to the tagged commit. This is what Railway watches; the prod-side deploy fires from this push. `--force-with-lease` (never `--force`) refuses to rewind if someone else has advanced `prod` since the local fetch — a safety net against concurrent `/release` runs.
 5. **`gh release create v0.0.1 --generate-notes`** — creates a GitHub Release with auto-generated commit + PR list.
 
-The curated, customer-facing changelog for each tag lives in the docs-site changelog feed (`apps/docs/src/components/changelog-data.ts` → [docs.useatlas.dev/changelog](https://docs.useatlas.dev/changelog)) — `/release` appends one entry per tag before tagging (Step 4b), and that entry links back to the GitHub Release. The `--generate-notes` body is the raw commit/PR list; edit it on GitHub if it needs polish. See [ADR-0008 § Amendment (2026-05-31)](../adr/0008-versioning-and-release-tags.md).
+The curated, customer-facing changelog for each tag lives in the docs-site changelog feed (`apps/docs/src/components/changelog-data.ts` → [docs.useatlas.dev/changelog](https://docs.useatlas.dev/changelog)) — `/release` appends one entry per tag right after the GitHub Release is created (so the entry's link is never dead), and that entry links back to the Release. The `--generate-notes` body is the raw commit/PR list; edit it on GitHub if it needs polish. See [ADR-0008 § Amendment (2026-05-31)](../adr/0008-versioning-and-release-tags.md).
 
 ### 4. Watch prod
 


### PR DESCRIPTION
## Why

The public changelog at `docs.useatlas.dev/changelog` showed internal milestone **1.6.0** as "latest" — but the actual public release train is now the git tags (`v0.0.1` released; `v0.0.2` tag-ready). A visitor saw `1.6.0` above `v0.0.1` and read it as a **regression**. The two version vocabularies were colliding on the public site.

Per the decision in this session, the docs changelog becomes a **continuous per-tag feed** that mirrors GitHub Releases, and the old internal milestone numbers move to a clearly-labeled archive track.

## What changed

**Docs site**
- `changelog-data.ts` — split into two exports: `releases` (the git-tag train, starting at `v0.0.1`, newest-first, mirrors GitHub Releases) and `developmentHistory` (the `1.6.0`…`0.1` internal milestones, preserved as a pre-public-versioning record — *not* public semver).
- `changelog-timeline.tsx` — renders both tracks with a **"Development history"** divider + explanatory note. Tag entries (`v*`) link to their **GitHub Release**; history entries link to the **GitHub Milestone**.
- Added the `v0.0.1 — Release Process Bootstrap` entry (the only currently-released tag). `v0.0.2`'s entry flows in when it's `/release`d.

**Process / docs**
- **ADR-0008** — amended the "banked changelog" decision (dated `2026-05-31` amendment). The docs changelog is a live per-tag feed, not held back for `v0.1.0`; the launch *announcement* still aggregates the train (separate marketing artifact).
- **`/release`** — new **Step 4b**: append a `changelog-data.ts` entry and push to `main` *before* tagging, so the tagged SHA carries its own changelog entry. Step 7 notes the GitHub Release links back to the curated docs entry.
- **`/changelog`**, **CLAUDE.md**, **release-process.md** — aligned with the per-tag model.

## Verification
- `tsgo --noEmit` on `apps/docs` — clean
- `eslint` on both changed components — clean
- Only consumer of `changelog-data` is `changelog-timeline.tsx` (updated)
- Full `next build` of docs not run locally — CI + the docs deploy from `main` are the final gate

## Note
This reverses the documented "bank the changelog for v0.1.0" convention (ADR-0008), by design — the dev tags are already public on GitHub, so banking the docs mirror only left it stale/misleading.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3043"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782830262&installation_id=135337507&pr_number=3043&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3043&signature=3f635d3b6c2e220ab070213f99f9b8ddc08e6f002391d80e76734d05d333a01b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Changelog shows public git-tagged releases with curated summaries, dates, highlights, and dynamic GitHub links/icons per release type.
  * Changelog timeline separates public releases and internal development history into distinct tracks.

* **Documentation**
  * Clarified release process: add one curated docs changelog entry after creating a GitHub Release (top of feed), do not set internal milestone fields for tag entries, and include rollback/check steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->