### PR TITLE
feat(openapi): scheduler-driven Tier-2 per-install spec re-discovery (#2978)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -310,6 +310,14 @@ ATLAS_ADMIN_EMAIL=admin@useatlas.dev
 # ATLAS_OPENAPI_SHARED_SPEC_TTL_MS=3600000    # Freshness window for the install-time short-circuit — within it a fresh install of an already-cached public upstream skips the network entirely (default: 1h)
 # ATLAS_OPENAPI_SPEC_REFRESH_INTERVAL_HOURS=24 # Cadence of the periodic conditional-GET refresh of the shared public-spec cache (mirrors the BYOT / semantic-expert scheduler; default: 24h)
 #
+# Per-install auto re-discovery (#2978, Tier-2): a separate scheduler re-probes each
+# installed generic OpenAPI datasource whose per-install spec_refresh_interval (set
+# in Admin → Connections: off / daily / weekly / "<N>h") has elapsed, refreshing its
+# persisted snapshot + drift diff. Distinct from the shared-cache refresh above — it
+# mutates each install's own snapshot. This tunes the LOOP wake cadence, not the
+# per-install interval; keep it at/below the smallest per-install interval you set.
+# ATLAS_OPENAPI_REDISCOVER_INTERVAL_HOURS=1   # How often the loop wakes to scan for due installs (default: 1h)
+#
 # SSRF egress guard (#3006): host-side spec probes AND operation execution are
 # blocked from reaching private / loopback / link-local / CGNAT IPs and internal
 # hostnames (e.g. cloud metadata at 169.254.169.254). The guard is ON in every

--- a/packages/api/src/api/routes/admin-openapi-datasources.ts
+++ b/packages/api/src/api/routes/admin-openapi-datasources.ts
@@ -23,45 +23,29 @@ import { createLogger } from "@atlas/api/lib/logger";
 import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
 import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
 import { internalQuery } from "@atlas/api/lib/db/internal";
-import { decryptSecretFields, parseConfigSchema } from "@atlas/api/lib/plugins/secrets";
 import { runHandler } from "@atlas/api/lib/effect/hono";
 import {
   OPENAPI_GENERIC_CATALOG_ID,
-  OPENAPI_GENERIC_CONFIG_SCHEMA,
   coerceRepresentationMode,
   isValidSnapshot,
-  type OpenApiSnapshot,
   type OpenApiAuthKind,
 } from "@atlas/api/lib/openapi/catalog";
 import {
-  resolveAuthFromDecryptedConfig,
-  probeSpec,
-  buildSnapshot,
   snapshotToGraph,
   invalidateInstallGraphCache,
   summarizeOperations,
-  OpenApiProbeError,
 } from "@atlas/api/lib/openapi/probe";
 import { REPRESENTATION_MODES } from "@atlas/api/lib/openapi/representation";
 import {
   coerceSpecRefreshInterval,
   normalizeSpecRefreshInterval,
 } from "@atlas/api/lib/openapi/spec-refresh";
-import { buildOperationGraph } from "@atlas/api/lib/openapi/spec";
-import {
-  diffOperationGraphs,
-  summarizeSpecDiffRecord,
-  baselineSpecDiffRecord,
-  unparseablePriorDiffRecord,
-  type SpecDiffRecord,
-} from "@atlas/api/lib/openapi/diff";
-import type { OperationGraph } from "@atlas/api/lib/openapi/types";
+import { performRediscovery, persistRediscoverySnapshot } from "@atlas/api/lib/openapi/rediscover";
+import { summarizeSpecDiffRecord } from "@atlas/api/lib/openapi/diff";
 import { ErrorSchema, AuthErrorSchema } from "./shared-schemas";
 import { createAdminRouter, requireOrgContext, requirePermission } from "./admin-router";
 
 const log = createLogger("admin.openapi-datasources");
-
-const SECRET_SCHEMA = parseConfigSchema(OPENAPI_GENERIC_CONFIG_SCHEMA);
 
 /**
  * Raw install row shape this router reads. A `type` (not `interface`) so it
@@ -107,46 +91,6 @@ function summarizeInstall(installId: string, config: Record<string, unknown> | n
     // / malformed `openapi_last_diff` projects to `null` (no banner) instead of
     // rendering NaN counts. The full structured diff stays in config for #2979.
     lastRefresh: summarizeSpecDiffRecord(c.openapi_last_diff),
-  };
-}
-
-/**
- * Compute the spec-diff record (#2976) for a re-discovery: rebuild the PRIOR
- * snapshot's graph and diff it against the freshly re-probed `nextGraph`. Returns
- * a BASELINE (`diff: null`) when there's no valid prior snapshot to compare
- * against, or when the prior snapshot's cached doc no longer parses — in either
- * case the fresh snapshot still persists; we just can't show what moved. Pure
- * apart from the warn log; the caller stamps `currentProbedAt` and persists.
- */
-function buildSpecDiffRecord(
-  priorConfig: Record<string, unknown>,
-  nextGraph: OperationGraph,
-  currentProbedAt: string,
-  installId: string,
-): SpecDiffRecord {
-  const rawPrior = priorConfig.openapi_snapshot;
-  if (!isValidSnapshot(rawPrior)) {
-    return baselineSpecDiffRecord(currentProbedAt);
-  }
-  let priorGraph: OperationGraph;
-  try {
-    priorGraph = buildOperationGraph(rawPrior.doc);
-  } catch (err) {
-    // Older builder / corrupt cached doc — record a baseline rather than failing
-    // the rediscover. The fresh snapshot is still written by the caller. Flag it
-    // `priorParseFailed` so the UI/audit show "comparison unavailable" instead of
-    // mistaking a dropped compare for a clean first-ever baseline (drift may have
-    // gone unseen).
-    log.warn(
-      { installId, err: errorMessage(err) },
-      "Prior OpenAPI snapshot no longer parses — recording an unparseable-prior baseline diff",
-    );
-    return unparseablePriorDiffRecord(rawPrior.probedAt, currentProbedAt);
-  }
-  return {
-    previousProbedAt: rawPrior.probedAt,
-    currentProbedAt,
-    diff: diffOperationGraphs(priorGraph, nextGraph),
   };
 }
 
@@ -355,15 +299,22 @@ adminOpenApiDatasources.openapi(rediscoverRoute, async (c) =>
       return c.json({ error: "not_found", message: `No OpenAPI datasource "${installId}".`, requestId }, 404);
     }
 
-    // Decrypt ONLY to read the credential + URL for the upstream probe; the
-    // snapshot we write back is non-secret, merged via JSONB || so the encrypted
-    // auth_value never round-trips through this layer. A decrypt failure (e.g. a
-    // rotated-away key version) is surfaced as an actionable 400, not a generic 500.
-    let decrypted: Record<string, unknown>;
+    // Re-probe + re-normalize + diff via the shared core (#2978) — the exact same
+    // egress-guarded path the scheduler uses, so manual and scheduled refreshes
+    // can't drift. Decrypt happens inside (the encrypted `auth_value` never
+    // round-trips through this layer); the result is a discriminated outcome we map
+    // to an actionable 4xx, never a generic 500.
+    let result: Awaited<ReturnType<typeof performRediscovery>>;
     try {
-      decrypted = decryptSecretFields(row.config ?? {}, SECRET_SCHEMA);
+      result = await performRediscovery(row.config, installId);
     } catch (err) {
-      log.warn({ installId, err: errorMessage(err) }, "Rediscover credential decrypt failed");
+      // Unexpected fault from probe / snapshot-build / diff — attach the install
+      // context before letting runHandler map it to a 500.
+      log.warn({ installId, err: errorMessage(err) }, "Rediscover failed unexpectedly");
+      throw err;
+    }
+
+    if (result.kind === "decrypt_failed") {
       return c.json(
         {
           error: "decrypt_failed",
@@ -375,73 +326,31 @@ adminOpenApiDatasources.openapi(rediscoverRoute, async (c) =>
         400,
       );
     }
-    const openapiUrl = typeof decrypted.openapi_url === "string" ? decrypted.openapi_url : "";
-    if (!openapiUrl) {
+    if (result.kind === "no_url") {
       return c.json({ error: "bad_request", message: "Datasource has no spec URL to rediscover.", requestId }, 400);
     }
-    // Narrow + build the credential via the glue shared with the workspace
-    // resolver. A drifted row could carry the deferred oauth2 kind (or garbage) —
-    // `ok: false` becomes an actionable 400 rather than letting buildResolvedAuth's
-    // exhaustiveness guard 500. Tailor the remediation: a deferred oauth2 row is
-    // "coming later"; any other unsupported/drifted kind needs the operator to fix
-    // the config, so don't tell them it's oauth2 when it isn't.
-    const authResult = resolveAuthFromDecryptedConfig(decrypted);
-    if (!authResult.ok) {
+    if (result.kind === "unsupported_auth") {
+      // Tailor the remediation: a deferred oauth2 row is "coming later"; any other
+      // unsupported/drifted kind needs the operator to fix the config, so don't tell
+      // them it's oauth2 when it isn't.
       const message =
-        authResult.rawAuthKind === "oauth2"
+        result.rawAuthKind === "oauth2"
           ? "This datasource uses oauth2 auth, which is not supported yet — rediscover is unavailable."
-          : `This datasource has an unsupported auth kind ("${authResult.rawAuthKind}") — fix its config before rediscovering.`;
+          : `This datasource has an unsupported auth kind ("${result.rawAuthKind}") — fix its config before rediscovering.`;
       return c.json({ error: "bad_request", message, requestId }, 400);
     }
-    const auth = authResult.auth;
-
-    // Host-match credential gate (#3034): the re-probe attaches the stored
-    // credential ONLY when the spec host matches the datasource's API host. This
-    // route manages generic OpenAPI installs, whose API host is the admin-supplied
-    // `base_url_override` (absent ⇒ the credential is withheld — the same fail-safe
-    // the install path applies, so install + rediscover stay symmetric).
-    const baseUrlOverride =
-      typeof decrypted.base_url_override === "string" ? decrypted.base_url_override : undefined;
-
-    let snapshot: OpenApiSnapshot;
-    let diffRecord: SpecDiffRecord;
-    try {
-      const { doc, graph } = await probeSpec(openapiUrl, auth, {
-        ...(baseUrlOverride ? { apiBaseUrl: baseUrlOverride } : {}),
-      });
-      snapshot = buildSnapshot(doc, graph, new Date().toISOString());
-      // Spec-drift diff (#2976): compare the freshly-probed graph against the
-      // PRIOR snapshot (still in `row.config`, pre-update). A first-ever
-      // discovery / unparseable prior records a baseline (`diff: null`).
-      diffRecord = buildSpecDiffRecord(row.config ?? {}, graph, snapshot.probedAt, installId);
-    } catch (err) {
-      if (err instanceof OpenApiProbeError) {
-        log.warn({ installId, reason: err.reason }, "Rediscover probe failed");
-        return c.json({ error: "probe_failed", message: err.message, requestId }, 400);
-      }
-      // Unexpected fault from probe / snapshot-build / diff — attach the install
-      // context its siblings log before letting runHandler map it to a 500.
-      log.warn({ installId, err: errorMessage(err) }, "Rediscover failed unexpectedly");
-      throw err;
+    if (result.kind === "probe_failed") {
+      log.warn({ installId, reason: result.reason }, "Rediscover probe failed");
+      return c.json({ error: "probe_failed", message: result.message, requestId }, 400);
     }
 
+    const { snapshot, diffRecord, drift } = result;
+
     // Persist the fresh snapshot AND the computed diff against the install in one
-    // JSONB merge (AC2). Both are non-secret, so the encrypted `auth_value` is
-    // never round-tripped through this write.
-    await internalQuery(
-      `UPDATE workspace_plugins
-          SET config = config || jsonb_build_object('openapi_snapshot', $4::jsonb, 'openapi_last_diff', $5::jsonb),
-              updated_at = NOW()
-        WHERE workspace_id = $1 AND install_id = $2 AND catalog_id = $3 AND pillar = 'datasource'`,
-      [orgId, installId, OPENAPI_GENERIC_CATALOG_ID, JSON.stringify(snapshot), JSON.stringify(diffRecord)],
-    );
+    // JSONB merge (AC2) + evict the in-process graph cache (#3009). The manual route
+    // passes no watermark, so the merge is the pre-#2978 statement byte-for-byte.
+    await persistRediscoverySnapshot(orgId, installId, snapshot, diffRecord);
 
-    // Drop the in-process graph cache for this install: the re-probe bumped
-    // `probedAt`, so the next resolve rebuilds under the fresh key and the now-
-    // orphaned prior-`probedAt` entry is reclaimed instead of leaking (#3009).
-    invalidateInstallGraphCache(orgId, installId);
-
-    const drift = summarizeSpecDiffRecord(diffRecord);
     if (!drift) {
       // We just built and persisted `diffRecord`; if it fails to project, the
       // writer/reader contract has drifted (or the record is corrupt). The UI

--- a/packages/api/src/lib/audit/actions.ts
+++ b/packages/api/src/lib/audit/actions.ts
@@ -109,6 +109,19 @@ export const ADMIN_ACTIONS = {
     probe: "connection.probe",
     healthCheck: "connection.health_check",
     poolDrain: "connection.pool_drain",
+    /**
+     * `specRefreshCycle` (#2978) — emitted once per tick by the Tier-2 OpenAPI
+     * per-install re-discovery scheduler, even at zero candidates. The absence of a
+     * cycle row over a multi-tick window is the signal the loop stopped (same
+     * forensic invariant as `model_config.catalog_refresh_cycle` /
+     * `audit_log.purge_cycle`). Status is `success` on a healthy cycle; `failure` if
+     * the candidate query itself threw before producing per-install counts. Uses the
+     * reserved `system:openapi-install-rediscover` actor; metadata carries the full
+     * `RediscoverCycleResult` counts. The per-install re-probes themselves reuse
+     * `connection.probe` with `triggeredBy: "scheduler"`, so an operator filtering by
+     * install id sees manual and scheduled refreshes uniformly.
+     */
+    specRefreshCycle: "connection.spec_refresh_cycle",
   },
   /**
    * Connection-group admin actions. Renames are display-label changes

--- a/packages/api/src/lib/effect/layers.ts
+++ b/packages/api/src/lib/effect/layers.ts
@@ -1462,6 +1462,30 @@ export function makeSchedulerLive(
         }),
       );
 
+      // Start Tier-2 per-install OpenAPI re-discovery scheduler (#2978) — periodic
+      // re-probe of each installed openapi-generic datasource whose per-install
+      // `spec_refresh_interval` has elapsed, updating the persisted snapshot + drift
+      // diff + watermark. Orthogonal to the Tier-1 shared-cache refresh above (this
+      // one mutates per-install snapshots; that one only warms the process-local
+      // public-spec cache). No-ops when the internal DB is unavailable.
+      yield* Effect.tryPromise({
+        try: async () => {
+          const { startOpenApiInstallRediscoverScheduler } = await import(
+            "@atlas/api/lib/scheduler/openapi-install-rediscover"
+          );
+          startOpenApiInstallRediscoverScheduler();
+        },
+        catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+      }).pipe(
+        Effect.catchAll((err) => {
+          log.error(
+            { err: errorMessage(err) },
+            "OpenAPI install rediscover scheduler failed to start",
+          );
+          return Effect.void;
+        }),
+      );
+
       // ── Periodic fiber: OAuth state cleanup (#1273) — every 10 min ──
       const oauthTick = Effect.tryPromise({
         try: async () => {
@@ -2418,6 +2442,27 @@ export function makeSchedulerLive(
               log.warn(
                 { err: errorMessage(err) },
                 "Failed to stop shared OpenAPI spec refresh scheduler",
+              );
+              return Effect.void;
+            }),
+          );
+
+          // Stop the Tier-2 OpenAPI re-discovery scheduler (#2978) symmetrically —
+          // clear its setInterval so the `unref()`'d handle is released and a test
+          // process (or a re-created ManagedRuntime) exits cleanly.
+          yield* Effect.tryPromise({
+            try: async () => {
+              const { stopOpenApiInstallRediscoverScheduler } = await import(
+                "@atlas/api/lib/scheduler/openapi-install-rediscover"
+              );
+              stopOpenApiInstallRediscoverScheduler();
+            },
+            catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+          }).pipe(
+            Effect.catchAll((err) => {
+              log.warn(
+                { err: errorMessage(err) },
+                "Failed to stop OpenAPI install rediscover scheduler",
               );
               return Effect.void;
             }),

--- a/packages/api/src/lib/openapi/__tests__/rediscover.test.ts
+++ b/packages/api/src/lib/openapi/__tests__/rediscover.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Unit tests for the shared re-discovery core (`rediscover.ts`, #2978).
+ *
+ * The admin-route test already drives `performRediscovery`'s happy path + probe /
+ * unsupported-auth branches and the no-watermark `persistRediscoverySnapshot` SQL.
+ * This file covers the bits ONLY the scheduler reaches:
+ *   - `stampSpecLastChecked` — the watermark-only write that must NOT touch the
+ *     snapshot (the "a failed scheduled probe never degrades the live snapshot" AC).
+ *   - `persistRediscoverySnapshot` WITH a watermark — the success write that bumps
+ *     `spec_last_checked_at` alongside the snapshot + diff.
+ *   - `performRediscovery` `decrypt_failed` / `no_url` branches (the route's
+ *     passthrough-decrypt fixture can't reach them).
+ *
+ * Probe is injected via the `deps.probe` seam (no module mock needed); `secrets` is a
+ * controllable passthrough; `db/internal` records the issued SQL.
+ */
+
+import { describe, it, expect, beforeEach, mock } from "bun:test";
+
+let queryCalls: Array<{ sql: string; params: unknown[] }> = [];
+let decryptShouldThrow = false;
+
+mock.module("@atlas/api/lib/logger", () => {
+  const noop = () => {};
+  const logger = { info: noop, warn: noop, error: noop, debug: noop, child: () => logger };
+  return { createLogger: () => logger, getRequestContext: () => undefined };
+});
+
+mock.module("@atlas/api/lib/db/internal", () => ({
+  hasInternalDB: () => true,
+  internalQuery: async (sql: string, params: unknown[]) => {
+    queryCalls.push({ sql, params });
+    return [];
+  },
+  internalExecute: () => {},
+  getInternalDB: () => ({}),
+}));
+
+mock.module("@atlas/api/lib/plugins/secrets", () => ({
+  parseConfigSchema: () => [],
+  decryptSecretFields: (config: Record<string, unknown>) => {
+    if (decryptShouldThrow) throw new Error("key rotated");
+    return { ...config };
+  },
+}));
+
+mock.module("@atlas/api/lib/audit/error-scrub", () => ({
+  errorMessage: (err: unknown) => (err instanceof Error ? err.message : String(err)),
+  causeToError: (_c: unknown) => undefined,
+}));
+
+const {
+  performRediscovery,
+  persistRediscoverySnapshot,
+  stampSpecLastChecked,
+  buildSpecDiffRecord,
+} = await import("../rediscover");
+
+type OperationGraph = import("../types").OperationGraph;
+type OpenApiSnapshot = import("../catalog").OpenApiSnapshot;
+type SpecDiffRecord = import("../diff").SpecDiffRecord;
+
+const NOW_ISO = "2026-05-31T12:00:00.000Z";
+
+const snapshot: OpenApiSnapshot = {
+  probedAt: NOW_ISO,
+  title: "Widget API",
+  version: "1.0.0",
+  openapiVersion: "3.1.0",
+  operationCount: 2,
+  doc: { openapi: "3.1.0" },
+};
+const diffRecord: SpecDiffRecord = { previousProbedAt: null, currentProbedAt: NOW_ISO, diff: null };
+
+const emptyGraph: OperationGraph = {
+  operations: new Map(),
+  schemas: new Map(),
+  info: { title: "Widget API", version: "1.0.0", openapiVersion: "3.1.0" },
+  servers: [],
+} as unknown as OperationGraph;
+
+beforeEach(() => {
+  queryCalls = [];
+  decryptShouldThrow = false;
+});
+
+describe("persistRediscoverySnapshot — success write", () => {
+  it("without a watermark writes only snapshot + diff (the manual route's shape)", async () => {
+    await persistRediscoverySnapshot("ws-1", "ds-1", snapshot, diffRecord);
+    expect(queryCalls).toHaveLength(1);
+    const { sql, params } = queryCalls[0];
+    expect(sql).toContain("jsonb_build_object('openapi_snapshot', $4::jsonb, 'openapi_last_diff', $5::jsonb)");
+    expect(sql).not.toContain("spec_last_checked_at");
+    expect(sql).not.toContain("auth_value");
+    expect(params).toHaveLength(5);
+    expect(params[0]).toBe("ws-1");
+    expect(params[1]).toBe("ds-1");
+  });
+
+  it("with a watermark appends spec_last_checked_at ($6::text) — the scheduler's success write", async () => {
+    await persistRediscoverySnapshot("ws-1", "ds-1", snapshot, diffRecord, NOW_ISO);
+    expect(queryCalls).toHaveLength(1);
+    const { sql, params } = queryCalls[0];
+    expect(sql).toContain("'openapi_snapshot', $4::jsonb");
+    expect(sql).toContain("'openapi_last_diff', $5::jsonb");
+    expect(sql).toContain("'spec_last_checked_at', $6::text");
+    expect(params).toHaveLength(6);
+    expect(params[5]).toBe(NOW_ISO);
+  });
+});
+
+describe("stampSpecLastChecked — watermark-only write (fail-soft negative cache)", () => {
+  it("writes ONLY spec_last_checked_at and never touches the snapshot or credential", async () => {
+    await stampSpecLastChecked("ws-1", "ds-1", NOW_ISO);
+    expect(queryCalls).toHaveLength(1);
+    const { sql, params } = queryCalls[0];
+    expect(sql).toContain("jsonb_build_object('spec_last_checked_at', $4::text)");
+    // The live snapshot + diff + credential are left intact.
+    expect(sql).not.toContain("openapi_snapshot");
+    expect(sql).not.toContain("openapi_last_diff");
+    expect(sql).not.toContain("auth_value");
+    expect(params).toEqual(["ws-1", "ds-1", "catalog:openapi-generic", NOW_ISO]);
+  });
+});
+
+describe("performRediscovery — branches the route fixture can't reach", () => {
+  it("returns no_url when the install has no spec URL", async () => {
+    const result = await performRediscovery({ auth_kind: "none" }, "ds-1", {
+      probe: async () => ({ doc: {}, graph: emptyGraph }),
+      now: () => NOW_ISO,
+    });
+    expect(result.kind).toBe("no_url");
+  });
+
+  it("returns decrypt_failed when the credential cannot be decrypted", async () => {
+    decryptShouldThrow = true;
+    const result = await performRediscovery({ openapi_url: "https://x/openapi.json" }, "ds-1", {
+      probe: async () => ({ doc: {}, graph: emptyGraph }),
+      now: () => NOW_ISO,
+    });
+    expect(result.kind).toBe("decrypt_failed");
+  });
+
+  it("re-probes via the injected probe and returns ok with a baseline diff (no prior snapshot)", async () => {
+    let probedUrl = "";
+    const result = await performRediscovery(
+      { openapi_url: "https://x/openapi.json", auth_kind: "none" },
+      "ds-1",
+      {
+        probe: async (url) => {
+          probedUrl = url;
+          return { doc: { openapi: "3.1.0" }, graph: emptyGraph };
+        },
+        now: () => NOW_ISO,
+      },
+    );
+    expect(probedUrl).toBe("https://x/openapi.json");
+    expect(result.kind).toBe("ok");
+    if (result.kind === "ok") {
+      expect(result.snapshot.probedAt).toBe(NOW_ISO);
+      expect(result.diffRecord.diff).toBeNull(); // first-ever discovery → baseline
+      expect(result.drift?.baseline).toBe(true);
+    }
+  });
+});
+
+describe("buildSpecDiffRecord — baseline when no valid prior snapshot", () => {
+  it("records a first-ever baseline (previousProbedAt null) when prior config has no snapshot", () => {
+    const record = buildSpecDiffRecord({}, emptyGraph, NOW_ISO, "ds-1");
+    expect(record).toEqual({ previousProbedAt: null, currentProbedAt: NOW_ISO, diff: null });
+  });
+});

--- a/packages/api/src/lib/openapi/__tests__/spec-refresh.test.ts
+++ b/packages/api/src/lib/openapi/__tests__/spec-refresh.test.ts
@@ -10,18 +10,25 @@
  *     (skip), every live value → a positive, clamped millisecond count.
  *   - `coerceSpecRefreshInterval` is the fail-soft display coercion for the
  *     detail summary + UI Select (unknown/absent → `off`).
+ *   - `evaluateSpecRefreshDue` (#2978) is the scheduler's per-install due-check:
+ *     `off`/garbage is NEVER due, and "due" means an interval has elapsed since the
+ *     `max(spec_last_checked_at, snapshot.probedAt)` activity watermark.
  */
 import { describe, it, expect } from "bun:test";
 import {
   coerceSpecRefreshInterval,
   normalizeSpecRefreshInterval,
   getSpecRefreshIntervalMs,
+  evaluateSpecRefreshDue,
+  parseIsoToMs,
+  SPEC_LAST_CHECKED_AT_FIELD,
   DEFAULT_SPEC_REFRESH_INTERVAL,
   MIN_SPEC_REFRESH_HOURS,
   MAX_SPEC_REFRESH_HOURS,
 } from "../spec-refresh";
 
 const HOUR_MS = 60 * 60 * 1000;
+const DAY_MS = 24 * HOUR_MS;
 
 describe("coerceSpecRefreshInterval — fail-soft display", () => {
   it("passes known values through", () => {
@@ -133,5 +140,92 @@ describe("getSpecRefreshIntervalMs — read-path reader (mirrors getExpertSchedu
   it("clamps a drifted out-of-range stored value on read (defense for hand-edited rows)", () => {
     expect(getSpecRefreshIntervalMs("5000h")).toBe(MAX_SPEC_REFRESH_HOURS * HOUR_MS);
     expect(getSpecRefreshIntervalMs("0.5h")).toBe(MIN_SPEC_REFRESH_HOURS * HOUR_MS);
+  });
+});
+
+const NOW = 1_700_000_000_000; // fixed clock for due-calc determinism
+const iso = (ms: number) => new Date(ms).toISOString();
+
+describe("parseIsoToMs — JSONB timestamp reader", () => {
+  it("parses a valid ISO string to epoch ms", () => {
+    expect(parseIsoToMs("2026-05-29T00:00:00.000Z")).toBe(Date.parse("2026-05-29T00:00:00.000Z"));
+  });
+
+  it("returns null for non-string / absent / unparseable values (never NaN)", () => {
+    expect(parseIsoToMs(undefined)).toBeNull();
+    expect(parseIsoToMs(null)).toBeNull();
+    expect(parseIsoToMs(123)).toBeNull();
+    expect(parseIsoToMs("not-a-date")).toBeNull();
+    expect(parseIsoToMs({})).toBeNull();
+  });
+});
+
+describe("evaluateSpecRefreshDue — scheduler due-check (#2978)", () => {
+  it("off / absent / garbage interval is NEVER due (the off-skip AC, enforced app-side)", () => {
+    for (const interval of ["off", undefined, "soon", "12x", ""]) {
+      const d = evaluateSpecRefreshDue({ spec_refresh_interval: interval }, NOW);
+      expect(d.intervalMs).toBeNull();
+      expect(d.due).toBe(false);
+    }
+    // No interval key at all → off by default → never due.
+    expect(evaluateSpecRefreshDue({}, NOW).due).toBe(false);
+    expect(evaluateSpecRefreshDue(null, NOW).due).toBe(false);
+  });
+
+  it("is due when the interval has fully elapsed since the last check", () => {
+    const config = {
+      spec_refresh_interval: "daily",
+      [SPEC_LAST_CHECKED_AT_FIELD]: iso(NOW - DAY_MS - 1),
+    };
+    const d = evaluateSpecRefreshDue(config, NOW);
+    expect(d.intervalMs).toBe(DAY_MS);
+    expect(d.due).toBe(true);
+  });
+
+  it("is NOT due when the interval has not yet elapsed", () => {
+    const config = {
+      spec_refresh_interval: "daily",
+      [SPEC_LAST_CHECKED_AT_FIELD]: iso(NOW - HOUR_MS), // 1h ago, interval is 24h
+    };
+    expect(evaluateSpecRefreshDue(config, NOW).due).toBe(false);
+  });
+
+  it("treats exactly-elapsed as due (>= boundary)", () => {
+    const config = {
+      spec_refresh_interval: "daily",
+      [SPEC_LAST_CHECKED_AT_FIELD]: iso(NOW - DAY_MS),
+    };
+    expect(evaluateSpecRefreshDue(config, NOW).due).toBe(true);
+  });
+
+  it("a freshly-installed datasource (recent probedAt, no watermark) is NOT immediately due", () => {
+    // probedAt acts as the activity watermark when no scheduler check has run yet —
+    // so an install probed moments ago at install time isn't re-probed on tick 1.
+    const config = {
+      spec_refresh_interval: "daily",
+      openapi_snapshot: { probedAt: iso(NOW - HOUR_MS) },
+    };
+    const d = evaluateSpecRefreshDue(config, NOW);
+    expect(d.lastActivityMs).toBe(NOW - HOUR_MS);
+    expect(d.due).toBe(false);
+  });
+
+  it("uses the MAX of watermark and snapshot.probedAt (a recent manual refresh resets the clock)", () => {
+    // spec_last_checked_at is stale (2 days ago) but a manual 'Refresh now' just
+    // bumped probedAt (1h ago) — max() means the recent activity wins → not due.
+    const config = {
+      spec_refresh_interval: "daily",
+      [SPEC_LAST_CHECKED_AT_FIELD]: iso(NOW - 2 * DAY_MS),
+      openapi_snapshot: { probedAt: iso(NOW - HOUR_MS) },
+    };
+    const d = evaluateSpecRefreshDue(config, NOW);
+    expect(d.lastActivityMs).toBe(NOW - HOUR_MS);
+    expect(d.due).toBe(false);
+  });
+
+  it("with neither watermark nor probedAt, lastActivity is 0 → an interval-configured install is due", () => {
+    const d = evaluateSpecRefreshDue({ spec_refresh_interval: "weekly" }, NOW);
+    expect(d.lastActivityMs).toBe(0);
+    expect(d.due).toBe(true);
   });
 });

--- a/packages/api/src/lib/openapi/__tests__/spec-refresh.test.ts
+++ b/packages/api/src/lib/openapi/__tests__/spec-refresh.test.ts
@@ -143,6 +143,26 @@ describe("getSpecRefreshIntervalMs — read-path reader (mirrors getExpertSchedu
   });
 });
 
+describe("preset lookup is prototype-pollution safe (own-keys only)", () => {
+  // `toString` / `constructor` / `__proto__` are inherited keys on the preset
+  // object — `in` would match them and `obj[key] * HOUR_MS` → NaN. Both the write
+  // gate and the read path must treat them as garbage, not presets.
+  for (const proto of ["toString", "constructor", "__proto__", "valueOf", "hasOwnProperty"]) {
+    it(`rejects "${proto}" on the write path (not accepted as a preset)`, () => {
+      expect(normalizeSpecRefreshInterval(proto).ok).toBe(false);
+    });
+    it(`reads "${proto}" as null (never a non-finite interval)`, () => {
+      expect(getSpecRefreshIntervalMs(proto)).toBeNull();
+    });
+  }
+
+  it("a prototype-key interval is never due (no NaN leaks into the scheduler)", () => {
+    const d = evaluateSpecRefreshDue({ spec_refresh_interval: "toString" }, 1_700_000_000_000);
+    expect(d.intervalMs).toBeNull();
+    expect(d.due).toBe(false);
+  });
+});
+
 const NOW = 1_700_000_000_000; // fixed clock for due-calc determinism
 const iso = (ms: number) => new Date(ms).toISOString();
 

--- a/packages/api/src/lib/openapi/rediscover.ts
+++ b/packages/api/src/lib/openapi/rediscover.ts
@@ -1,0 +1,288 @@
+/**
+ * `rediscover` — the shared per-install OpenAPI re-discovery core (PRD #2868).
+ *
+ * Re-discovery is "re-probe the spec endpoint → re-normalize to an
+ * {@link OperationGraph} → rebuild the persisted snapshot → diff it against the
+ * prior snapshot". Slice #3002 shipped it inline in the admin "Refresh now" route
+ * (`api/routes/admin-openapi-datasources.ts`); #2978 adds an AUTOMATED sibling — the
+ * Tier-2 periodic scheduler (`scheduler/openapi-install-rediscover.ts`). Both must
+ * do the same thing, but `lib/` may not import from `api/routes/` (CLAUDE.md), so
+ * the logic lives here and both call it. The route maps the result to HTTP; the
+ * scheduler maps it to an audit row + a watermark bump.
+ *
+ * Why this is the RIGHT seam for "respect the SaaS egress allowlist": the spec
+ * fetch goes through {@link probeSpec}, which runs the same SSRF guard
+ * (`assertSpecUrlAllowed`) + redirect-revalidating `guardedFetch` + #3034 host-match
+ * credential gate as a resolve-time probe. Scheduled probing is therefore the
+ * SAME server-side egress as resolve-time, just on a timer — sharing this function
+ * is what guarantees that, rather than re-deriving (and risking divergence in) the
+ * egress posture in the scheduler.
+ *
+ * {@link performRediscovery} is pure of side effects (no DB write, no audit) and
+ * returns a discriminated {@link RediscoveryResult}. Persistence is split out into
+ * {@link persistRediscoverySnapshot} (success: snapshot + diff + optional watermark,
+ * then evict the in-process graph cache) and {@link stampSpecLastChecked}
+ * (watermark-only: the scheduler's fail-soft / config-skip negative-cache write,
+ * which deliberately leaves the live snapshot untouched).
+ */
+
+import { createLogger } from "@atlas/api/lib/logger";
+import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
+import { decryptSecretFields, parseConfigSchema } from "@atlas/api/lib/plugins/secrets";
+import { internalQuery } from "@atlas/api/lib/db/internal";
+import {
+  OPENAPI_GENERIC_CATALOG_ID,
+  OPENAPI_GENERIC_CONFIG_SCHEMA,
+  isValidSnapshot,
+  type OpenApiSnapshot,
+} from "./catalog";
+import {
+  resolveAuthFromDecryptedConfig,
+  probeSpec,
+  buildSnapshot,
+  invalidateInstallGraphCache,
+  OpenApiProbeError,
+  type OpenApiProbeErrorReason,
+} from "./probe";
+import { buildOperationGraph } from "./spec";
+import {
+  diffOperationGraphs,
+  summarizeSpecDiffRecord,
+  baselineSpecDiffRecord,
+  unparseablePriorDiffRecord,
+  type SpecDiffRecord,
+  type SpecDiffSummary,
+} from "./diff";
+import { SPEC_LAST_CHECKED_AT_FIELD } from "./spec-refresh";
+import type { OperationGraph } from "./types";
+
+const log = createLogger("openapi.rediscover");
+
+/**
+ * Selective-encryption schema for a generic OpenAPI install's config — the same
+ * one the admin route used inline. Built once at module load. Only `auth_value` is
+ * marked `secret: true`, so a decrypt round-trips just the credential; the snapshot
+ * / diff / interval / watermark fields stay plaintext JSONB.
+ */
+const SECRET_SCHEMA = parseConfigSchema(OPENAPI_GENERIC_CONFIG_SCHEMA);
+
+/**
+ * Compute the spec-diff record (#2976) for a re-discovery: rebuild the PRIOR
+ * snapshot's graph and diff it against the freshly re-probed `nextGraph`. Returns a
+ * BASELINE (`diff: null`) when there's no valid prior snapshot to compare against,
+ * or when the prior snapshot's cached doc no longer parses — in either case the
+ * fresh snapshot still persists; we just can't show what moved. Pure apart from the
+ * warn log; the caller stamps `currentProbedAt` and persists. (Moved out of the
+ * admin route in #2978 so the scheduler computes an identical record.)
+ */
+export function buildSpecDiffRecord(
+  priorConfig: Record<string, unknown>,
+  nextGraph: OperationGraph,
+  currentProbedAt: string,
+  installId: string,
+): SpecDiffRecord {
+  const rawPrior = priorConfig.openapi_snapshot;
+  if (!isValidSnapshot(rawPrior)) {
+    return baselineSpecDiffRecord(currentProbedAt);
+  }
+  let priorGraph: OperationGraph;
+  try {
+    priorGraph = buildOperationGraph(rawPrior.doc);
+  } catch (err) {
+    // Older builder / corrupt cached doc — record a baseline rather than failing
+    // the rediscover. The fresh snapshot is still written by the caller. Flag it
+    // `priorParseFailed` so the UI/audit show "comparison unavailable" instead of
+    // mistaking a dropped compare for a clean first-ever baseline (drift may have
+    // gone unseen).
+    log.warn(
+      { installId, err: errorMessage(err) },
+      "Prior OpenAPI snapshot no longer parses — recording an unparseable-prior baseline diff",
+    );
+    return unparseablePriorDiffRecord(rawPrior.probedAt, currentProbedAt);
+  }
+  return {
+    previousProbedAt: rawPrior.probedAt,
+    currentProbedAt,
+    diff: diffOperationGraphs(priorGraph, nextGraph),
+  };
+}
+
+/**
+ * The outcome of re-discovering one install. Discriminated so callers branch on a
+ * stable tag rather than message-matching:
+ *   - `ok` — re-probe succeeded; carries the fresh snapshot, the computed diff
+ *     record, and its projected summary (or `null` if projection somehow fails).
+ *   - `decrypt_failed` — the stored credential couldn't be decrypted (a rotated-away
+ *     key). Route → 400; scheduler → fail-soft skip (admin must reconnect).
+ *   - `no_url` — no spec URL to probe (a drifted row).
+ *   - `unsupported_auth` — a deferred (`oauth2`) or drifted auth kind; carries the
+ *     raw kind so the route can tailor its 400 message.
+ *   - `probe_failed` — the upstream spec fetch / parse failed; carries the
+ *     {@link OpenApiProbeErrorReason} + message. Route → 400; scheduler → fail-soft.
+ *
+ * An UNEXPECTED fault (a non-{@link OpenApiProbeError} thrown by the probe/build
+ * path) is deliberately NOT a variant — it propagates so the route maps it to a 500
+ * and the scheduler's per-install catch records it as a failure. We never invent a
+ * "success" out of an unexpected crash.
+ */
+export type RediscoveryResult =
+  | {
+      readonly kind: "ok";
+      readonly snapshot: OpenApiSnapshot;
+      readonly diffRecord: SpecDiffRecord;
+      readonly drift: SpecDiffSummary | null;
+    }
+  | { readonly kind: "decrypt_failed" }
+  | { readonly kind: "no_url" }
+  | { readonly kind: "unsupported_auth"; readonly rawAuthKind: string }
+  | { readonly kind: "probe_failed"; readonly reason: OpenApiProbeErrorReason; readonly message: string };
+
+/** Test/override seams for {@link performRediscovery}. Production omits them. */
+export interface PerformRediscoveryDeps {
+  /** Probe override (tests). Defaults to the real {@link probeSpec} (real egress guards). */
+  readonly probe?: typeof probeSpec;
+  /** ISO-timestamp source for the fresh snapshot's `probedAt`. Defaults to wall clock. */
+  readonly now?: () => string;
+}
+
+/**
+ * Re-discover one install from its RAW (encrypted) `workspace_plugins.config`:
+ * decrypt the credential → resolve auth → re-probe the spec (egress-guarded) →
+ * build the fresh snapshot → diff it against the prior snapshot. Side-effect-free
+ * (no DB write, no cache eviction, no audit) — the caller persists.
+ *
+ * The prior snapshot for the diff is read from the RAW config (`openapi_snapshot`
+ * is a non-secret field, so no decrypt is needed to compare against it) — matching
+ * the admin route's behavior exactly.
+ */
+export async function performRediscovery(
+  rawConfig: Record<string, unknown> | null,
+  installId: string,
+  deps: PerformRediscoveryDeps = {},
+): Promise<RediscoveryResult> {
+  const config = rawConfig ?? {};
+
+  // Decrypt ONLY to read the credential + URL for the upstream probe; the snapshot
+  // written back is non-secret. A decrypt failure (rotated-away key version) is a
+  // recoverable, actionable state — surface it as a tag, never a thrown 500.
+  let decrypted: Record<string, unknown>;
+  try {
+    decrypted = decryptSecretFields(config, SECRET_SCHEMA);
+  } catch (err) {
+    log.warn({ installId, err: errorMessage(err) }, "OpenAPI rediscover credential decrypt failed");
+    return { kind: "decrypt_failed" };
+  }
+
+  const openapiUrl = typeof decrypted.openapi_url === "string" ? decrypted.openapi_url : "";
+  if (!openapiUrl) return { kind: "no_url" };
+
+  // Narrow + build the credential via the glue shared with the workspace resolver.
+  // A drifted row could carry the deferred `oauth2` kind (or garbage) — surfaced as
+  // `unsupported_auth` (with the raw kind) rather than letting buildResolvedAuth's
+  // exhaustiveness guard throw.
+  const authResult = resolveAuthFromDecryptedConfig(decrypted);
+  if (!authResult.ok) {
+    return { kind: "unsupported_auth", rawAuthKind: authResult.rawAuthKind };
+  }
+
+  // Host-match credential gate (#3034): the re-probe attaches the stored credential
+  // ONLY when the spec host matches the datasource's API host. For a generic install
+  // the API host is the admin-supplied `base_url_override` (absent ⇒ withheld) — the
+  // same fail-safe the install path applies, so install / manual / scheduled probes
+  // stay symmetric.
+  const baseUrlOverride =
+    typeof decrypted.base_url_override === "string" ? decrypted.base_url_override : undefined;
+
+  const probe = deps.probe ?? probeSpec;
+  const now = deps.now ?? (() => new Date().toISOString());
+
+  let doc: unknown;
+  let graph: OperationGraph;
+  try {
+    ({ doc, graph } = await probe(openapiUrl, authResult.auth, {
+      ...(baseUrlOverride ? { apiBaseUrl: baseUrlOverride } : {}),
+    }));
+  } catch (err) {
+    if (err instanceof OpenApiProbeError) {
+      return { kind: "probe_failed", reason: err.reason, message: err.message };
+    }
+    // Unexpected fault — let it propagate (route → 500, scheduler → per-install
+    // failure). Never fabricate a successful snapshot out of a crash.
+    throw err;
+  }
+
+  const snapshot = buildSnapshot(doc, graph, now());
+  // Diff against the PRIOR snapshot still in `config` (pre-update). A first-ever
+  // discovery / unparseable prior records a baseline (`diff: null`).
+  const diffRecord = buildSpecDiffRecord(config, graph, snapshot.probedAt, installId);
+  return { kind: "ok", snapshot, diffRecord, drift: summarizeSpecDiffRecord(diffRecord) };
+}
+
+/**
+ * Persist a successful re-discovery against an install in one JSONB merge: the fresh
+ * `openapi_snapshot`, the computed `openapi_last_diff`, and — when `lastCheckedAtIso`
+ * is supplied (the scheduler) — the {@link SPEC_LAST_CHECKED_AT_FIELD} watermark.
+ * The manual route omits the watermark, so its merge is byte-for-byte the pre-#2978
+ * statement. All written fields are non-secret, so the encrypted `auth_value` is
+ * never round-tripped through this write.
+ *
+ * Then evicts the install's in-process graph cache: the re-probe bumped `probedAt`,
+ * so the next resolve rebuilds under the fresh key and the now-orphaned prior-
+ * `probedAt` entry is reclaimed instead of leaking (#3009). Scoped to
+ * `(workspaceId, installId)` — the same tenant isolation the load/delete paths use.
+ *
+ * The interpolated field names are code-resident constants (never user input), so
+ * splicing them into `jsonb_build_object` is safe; every value is bound.
+ */
+export async function persistRediscoverySnapshot(
+  workspaceId: string,
+  installId: string,
+  snapshot: OpenApiSnapshot,
+  diffRecord: SpecDiffRecord,
+  lastCheckedAtIso?: string,
+): Promise<void> {
+  const params: unknown[] = [
+    workspaceId,
+    installId,
+    OPENAPI_GENERIC_CATALOG_ID,
+    JSON.stringify(snapshot),
+    JSON.stringify(diffRecord),
+  ];
+  let pairs = `'openapi_snapshot', $4::jsonb, 'openapi_last_diff', $5::jsonb`;
+  if (lastCheckedAtIso !== undefined) {
+    pairs += `, '${SPEC_LAST_CHECKED_AT_FIELD}', $6::text`;
+    params.push(lastCheckedAtIso);
+  }
+  await internalQuery(
+    `UPDATE workspace_plugins
+        SET config = config || jsonb_build_object(${pairs}),
+            updated_at = NOW()
+      WHERE workspace_id = $1 AND install_id = $2 AND catalog_id = $3 AND pillar = 'datasource'`,
+    params,
+  );
+
+  invalidateInstallGraphCache(workspaceId, installId);
+}
+
+/**
+ * Watermark-only write: stamp {@link SPEC_LAST_CHECKED_AT_FIELD} = `lastCheckedAtIso`
+ * WITHOUT touching the snapshot. This is the scheduler's fail-soft / config-skip
+ * path — a failed scheduled probe must "never overwrite/degrade the live snapshot"
+ * (AC), and bumping the watermark is the persisted negative-cache that keeps a down
+ * upstream from being re-probed until its interval elapses again. No graph-cache
+ * eviction: the snapshot (and its `probedAt`) is unchanged, so the cached graph is
+ * still valid.
+ */
+export async function stampSpecLastChecked(
+  workspaceId: string,
+  installId: string,
+  lastCheckedAtIso: string,
+): Promise<void> {
+  await internalQuery(
+    `UPDATE workspace_plugins
+        SET config = config || jsonb_build_object('${SPEC_LAST_CHECKED_AT_FIELD}', $4::text),
+            updated_at = NOW()
+      WHERE workspace_id = $1 AND install_id = $2 AND catalog_id = $3 AND pillar = 'datasource'`,
+    [workspaceId, installId, OPENAPI_GENERIC_CATALOG_ID, lastCheckedAtIso],
+  );
+}

--- a/packages/api/src/lib/openapi/rediscover.ts
+++ b/packages/api/src/lib/openapi/rediscover.ts
@@ -10,13 +10,15 @@
  * the logic lives here and both call it. The route maps the result to HTTP; the
  * scheduler maps it to an audit row + a watermark bump.
  *
- * Why this is the RIGHT seam for "respect the SaaS egress allowlist": the spec
- * fetch goes through {@link probeSpec}, which runs the same SSRF guard
- * (`assertSpecUrlAllowed`) + redirect-revalidating `guardedFetch` + #3034 host-match
- * credential gate as a resolve-time probe. Scheduled probing is therefore the
- * SAME server-side egress as resolve-time, just on a timer — sharing this function
- * is what guarantees that, rather than re-deriving (and risking divergence in) the
- * egress posture in the scheduler.
+ * Why this is the RIGHT seam for honoring the egress controls: the spec fetch goes
+ * through {@link probeSpec}, which runs the same fail-closed SSRF guard
+ * (`assertSpecUrlAllowed` → `isSafeExternalUrl` — private/loopback/link-local/CGNAT
+ * IPs + internal hostnames blocked unless `ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS` opts
+ * out) + redirect-revalidating `guardedFetch` + #3034 host-match credential gate as a
+ * resolve-time probe. Scheduled probing is therefore the SAME server-side egress as
+ * resolve-time, just on a timer — sharing this function is what guarantees that,
+ * rather than re-deriving (and risking divergence in) the egress posture in the
+ * scheduler.
  *
  * {@link performRediscovery} is pure of side effects (no DB write, no audit) and
  * returns a discriminated {@link RediscoveryResult}. Persistence is split out into
@@ -130,6 +132,10 @@ export type RediscoveryResult =
       readonly kind: "ok";
       readonly snapshot: OpenApiSnapshot;
       readonly diffRecord: SpecDiffRecord;
+      // The projected summary of `diffRecord`, carried so both consumers (route
+      // response + scheduler audit) avoid re-projecting. `null` is defensive only:
+      // a record just built by `buildSpecDiffRecord` always has a `currentProbedAt`,
+      // so `summarizeSpecDiffRecord` can't actually return null on this path.
       readonly drift: SpecDiffSummary | null;
     }
   | { readonly kind: "decrypt_failed" }

--- a/packages/api/src/lib/openapi/spec-refresh.ts
+++ b/packages/api/src/lib/openapi/spec-refresh.ts
@@ -25,10 +25,29 @@
  *     drifted value → `null` (skip); every live value → a positive, clamped ms count.
  *   - {@link coerceSpecRefreshInterval} — fail-soft display coercion for the detail
  *     summary + UI Select (a non-string / unknown stored value → the `off` default).
+ *
+ * The #2978 scheduler (`scheduler/openapi-install-rediscover.ts`) also consumes the
+ * watermark helpers added below — {@link SPEC_LAST_CHECKED_AT_FIELD},
+ * {@link parseIsoToMs}, {@link evaluateSpecRefreshDue} — which together answer "is
+ * this install due for an auto re-discovery?" without re-implementing the interval
+ * grammar. They live here (next to the interval parser, in a dependency-free module)
+ * rather than in the scheduler so the WRITE path and the READ/DUE path share one
+ * source of truth for the stored shape.
  */
 
 /** The sentinel value meaning "never auto-refresh" — the default. */
 export const SPEC_REFRESH_OFF = "off";
+
+/**
+ * The `workspace_plugins.config` JSONB key holding the ISO-8601 timestamp of the
+ * last SCHEDULED re-discovery check for an install (#2978). Written by the Tier-2
+ * scheduler on every terminal per-install outcome (success, fail-soft, or
+ * config-skip) — never by the manual "Refresh now" route, which instead bumps the
+ * snapshot's `probedAt` (see {@link evaluateSpecRefreshDue} for why both count as
+ * recent activity). Non-secret, so it merges into config via plain `jsonb` /
+ * `text` writes alongside `spec_refresh_interval` — no encryption surface.
+ */
+export const SPEC_LAST_CHECKED_AT_FIELD = "spec_last_checked_at";
 
 /** Named presets the UI surfaces, expressed in hours. Keep in lockstep with the web Select. */
 export const SPEC_REFRESH_PRESET_HOURS: Readonly<Record<string, number>> = {
@@ -136,4 +155,73 @@ export function getSpecRefreshIntervalMs(raw: unknown): number | null {
   }
   const hours = parseCustomHours(raw);
   return hours === null ? null : hours * HOUR_MS;
+}
+
+/**
+ * Parse an ISO-8601 timestamp read back from JSONB to epoch ms, or `null` when the
+ * value is absent / not a string / unparseable. Used to read both the
+ * {@link SPEC_LAST_CHECKED_AT_FIELD} watermark and a snapshot's `probedAt` at the
+ * untyped JSONB trust boundary — a drifted / hand-edited value resolves to `null`
+ * (treated as "no activity recorded") rather than `NaN`, which would make every
+ * comparison against it false and silently freeze the install's due-ness.
+ */
+export function parseIsoToMs(raw: unknown): number | null {
+  if (typeof raw !== "string") return null;
+  const ms = Date.parse(raw);
+  return Number.isFinite(ms) ? ms : null;
+}
+
+/** The decision the #2978 scheduler makes for one candidate install per tick. */
+export interface SpecRefreshDueDecision {
+  /**
+   * The configured interval in ms, or `null` when the install is `off` (or its
+   * stored value drifted to something unparseable) — `null` means NEVER due, the
+   * hard gate the scheduler honors so an `off` install is never auto-refreshed.
+   */
+  readonly intervalMs: number | null;
+  /**
+   * The most recent activity watermark in epoch ms — `max(spec_last_checked_at,
+   * snapshot.probedAt)`, or `0` when neither is present. See {@link evaluateSpecRefreshDue}.
+   */
+  readonly lastActivityMs: number;
+  /** `true` iff an interval is configured AND that interval has elapsed since `lastActivityMs`. */
+  readonly due: boolean;
+}
+
+/**
+ * Decide whether an install is due for a SCHEDULED re-discovery (#2978), from its
+ * raw `workspace_plugins.config` JSONB and the current epoch ms.
+ *
+ * The "last activity" watermark is the MAX of two timestamps, so two different
+ * write paths both reset the scheduler clock without coordinating:
+ *   - {@link SPEC_LAST_CHECKED_AT_FIELD} — stamped by the scheduler on every
+ *     terminal per-install outcome (including a fail-soft probe failure, which is
+ *     the persisted negative-cache: a down upstream is not re-probed until its own
+ *     interval elapses again, instead of being hammered every tick).
+ *   - `openapi_snapshot.probedAt` — bumped by BOTH a scheduled success and a manual
+ *     "Refresh now". Folding it in means a freshly-installed datasource (recent
+ *     `probedAt`, no watermark yet) is NOT immediately re-probed on the first tick,
+ *     and a manual refresh resets the clock so the scheduler won't redundantly
+ *     re-probe moments later — all without the manual route having to write the
+ *     watermark itself.
+ *
+ * `off` (or a drifted/garbage interval) → `intervalMs: null` → `due: false`: the
+ * AC's "off installs are never auto-refreshed", enforced here rather than relying
+ * on the SQL pre-filter alone (defense in depth for a hand-edited row).
+ */
+export function evaluateSpecRefreshDue(
+  config: Record<string, unknown> | null | undefined,
+  nowMs: number,
+): SpecRefreshDueDecision {
+  const c = config ?? {};
+  const intervalMs = getSpecRefreshIntervalMs(c.spec_refresh_interval);
+  const lastChecked = parseIsoToMs(c[SPEC_LAST_CHECKED_AT_FIELD]);
+  const snapshot = c.openapi_snapshot;
+  const probedAt =
+    typeof snapshot === "object" && snapshot !== null
+      ? parseIsoToMs((snapshot as Record<string, unknown>).probedAt)
+      : null;
+  const lastActivityMs = Math.max(lastChecked ?? 0, probedAt ?? 0);
+  const due = intervalMs !== null && nowMs - lastActivityMs >= intervalMs;
+  return { intervalMs, lastActivityMs, due };
 }

--- a/packages/api/src/lib/openapi/spec-refresh.ts
+++ b/packages/api/src/lib/openapi/spec-refresh.ts
@@ -116,7 +116,11 @@ export function normalizeSpecRefreshInterval(raw: unknown): NormalizedSpecRefres
   if (typeof raw === "string") {
     const lower = raw.trim().toLowerCase();
     if (lower === SPEC_REFRESH_OFF) return { ok: true, value: SPEC_REFRESH_OFF };
-    if (lower in SPEC_REFRESH_PRESET_HOURS) return { ok: true, value: lower };
+    // `Object.hasOwn`, not `in` — `in` matches inherited prototype keys
+    // (`toString`, `constructor`, `__proto__`), which would otherwise pass
+    // validation here and then index to a non-number (→ NaN) in
+    // `getSpecRefreshIntervalMs`. Only the real preset keys are valid.
+    if (Object.hasOwn(SPEC_REFRESH_PRESET_HOURS, lower)) return { ok: true, value: lower };
   }
   if (typeof raw === "string" || typeof raw === "number") {
     const hours = parseCustomHours(raw);
@@ -150,7 +154,12 @@ export function getSpecRefreshIntervalMs(raw: unknown): number | null {
   if (typeof raw === "string") {
     const lower = raw.trim().toLowerCase();
     if (lower === SPEC_REFRESH_OFF) return null;
-    const presetHours = SPEC_REFRESH_PRESET_HOURS[lower];
+    // Own-property guard (not bracket-index alone): a prototype key like
+    // `"toString"` would index to a function and `fn * HOUR_MS` → NaN, which
+    // would then leak a non-finite interval into the scheduler's due-check.
+    const presetHours = Object.hasOwn(SPEC_REFRESH_PRESET_HOURS, lower)
+      ? SPEC_REFRESH_PRESET_HOURS[lower]
+      : undefined;
     if (presetHours !== undefined) return presetHours * HOUR_MS;
   }
   const hours = parseCustomHours(raw);

--- a/packages/api/src/lib/openapi/spec-refresh.ts
+++ b/packages/api/src/lib/openapi/spec-refresh.ts
@@ -5,11 +5,11 @@
  * surface) that says how often the cached spec snapshot should be re-discovered.
  *
  * This slice ships only the stored setting + its validation + a read accessor —
- * **no background scheduler**. The admin "Refresh now" reuses the existing manual
- * re-discovery path; the periodic fiber that consumes {@link getSpecRefreshIntervalMs}
- * lands in #2978 (modeled on the `Effect.repeat(Schedule.spaced(...))` pattern in
- * `layers.ts`, the way `getExpertSchedulerIntervalMs` feeds the semantic-expert
- * tick).
+ * **no background scheduler in this module**. The admin "Refresh now" reuses the
+ * existing manual re-discovery path; the periodic fiber that consumes the due-check
+ * ({@link evaluateSpecRefreshDue}, which wraps {@link getSpecRefreshIntervalMs})
+ * shipped in #2978 as `scheduler/openapi-install-rediscover.ts` — a `setInterval`-
+ * based loop mirroring `byot-catalog-refresh.ts`.
  *
  * Stored canonical value — one of:
  *   - `"off"` (default) — never auto-refresh.

--- a/packages/api/src/lib/scheduler/__tests__/openapi-install-rediscover.test.ts
+++ b/packages/api/src/lib/scheduler/__tests__/openapi-install-rediscover.test.ts
@@ -29,6 +29,7 @@ import { Effect } from "effect";
 
 let mockHasDB = true;
 let auditCalls: Array<Record<string, unknown>> = [];
+let dbQueryCalls: Array<{ sql: string; params: unknown[] }> = [];
 
 // ── Mocks (declared before importing the SUT) ────────────────────────────────
 
@@ -44,7 +45,10 @@ mock.module("@atlas/api/lib/logger", () => {
 
 mock.module("@atlas/api/lib/db/internal", () => ({
   hasInternalDB: () => mockHasDB,
-  internalQuery: async () => [],
+  internalQuery: async (sql: string, params: unknown[]) => {
+    dbQueryCalls.push({ sql, params });
+    return [];
+  },
   internalExecute: () => {},
   getInternalDB: () => ({}),
 }));
@@ -190,6 +194,7 @@ function resetAll() {
   _resetOpenApiInstallRediscoverScheduler();
   mockHasDB = true;
   auditCalls = [];
+  dbQueryCalls = [];
 }
 
 const cycleRows = () => auditCalls.filter((c) => c.actionType === "connection.spec_refresh_cycle");
@@ -291,6 +296,22 @@ describe("openapi install rediscover — cycle behavior", () => {
     expect(cycleRows()[0].targetType).toBe("connection");
     expect(cycleRows()[0].targetId).toBe("scheduler");
     expect(cycleRows()[0].status).toBe("success");
+  });
+
+  it("default candidate query orders by effective activity (GREATEST of watermark + probedAt), not the bare watermark", async () => {
+    // No injected `query` → the real defaultQuery runs against the mocked
+    // internalQuery, so we can assert the SELECT it issues. Ordering by the bare
+    // `spec_last_checked_at NULLS FIRST` would starve due rows behind not-yet-due
+    // fresh installs (#3046 Codex review); GREATEST(watermark, probedAt) mirrors
+    // evaluateSpecRefreshDue so the most-overdue install sorts first.
+    await Effect.runPromise(runOpenApiInstallRediscoverCycle({ now: () => NOW }));
+    const select = dbQueryCalls.find((c) => c.sql.includes("FROM workspace_plugins"));
+    expect(select).toBeDefined();
+    expect(select!.sql).toContain("GREATEST(config->>'spec_last_checked_at', config->'openapi_snapshot'->>'probedAt')");
+    expect(select!.sql).toContain("NULLS FIRST");
+    expect(select!.sql).toContain("<> 'off'");
+    expect(select!.sql).toContain("status != 'archived'");
+    expect(select!.params).toEqual(["catalog:openapi-generic", 100]);
   });
 
   it("survives an internal-DB-disabled state — emits a success cycle row with zero counts", async () => {

--- a/packages/api/src/lib/scheduler/__tests__/openapi-install-rediscover.test.ts
+++ b/packages/api/src/lib/scheduler/__tests__/openapi-install-rediscover.test.ts
@@ -1,0 +1,541 @@
+/**
+ * Tier-2 OpenAPI per-install re-discovery scheduler tests (#2978).
+ *
+ * The cycle is exercised through its dependency seams (`query` / `rediscover` /
+ * `persistSuccess` / `stampChecked` / `now`) so the test is fully hermetic — no DB,
+ * no probe, no encryption. The only module mocks are the cross-cutting ones with no
+ * injection seam: `logger`, `db/internal` (just `hasInternalDB`), and `audit`.
+ *
+ * Surface under test:
+ *   - Due-selection: only installs whose interval has elapsed get re-discovered;
+ *     the real `evaluateSpecRefreshDue` decides (not a stub).
+ *   - off-skip: an `off` install is never re-discovered even if the query returns it.
+ *   - Watermark bump on success: a successful re-probe persists snapshot + diff +
+ *     the cycle's `nowIso` watermark.
+ *   - Fail-soft on a down upstream: a probe failure stamps the watermark
+ *     (negative-cache) WITHOUT persisting a snapshot, and the loop continues.
+ *   - Per-install failure containment: a thrown install never aborts the rest.
+ *   - Config skips (decrypt/no-url/unsupported-auth) stamp + audit as failures.
+ *   - Persist failure does NOT stamp (the next tick retries).
+ *   - Cycle-level audit emits every tick (success / failure), the scheduler-stopped
+ *     forensic invariant.
+ *   - Lifecycle: start/stop, double-start, idempotent stop, no-DB refusal, actor.
+ */
+
+import { describe, it, expect, beforeEach, mock } from "bun:test";
+import { Effect } from "effect";
+
+// ── Mutable per-test state the mock factories close over ─────────────────────
+
+let mockHasDB = true;
+let auditCalls: Array<Record<string, unknown>> = [];
+
+// ── Mocks (declared before importing the SUT) ────────────────────────────────
+
+mock.module("@atlas/api/lib/logger", () => {
+  const noop = () => {};
+  const logger = { info: noop, warn: noop, error: noop, debug: noop, child: () => logger };
+  return {
+    createLogger: () => logger,
+    getRequestContext: () => undefined,
+    runWithRequestContext: <T>(_ctx: unknown, fn: () => T): T => fn(),
+  };
+});
+
+mock.module("@atlas/api/lib/db/internal", () => ({
+  hasInternalDB: () => mockHasDB,
+  internalQuery: async () => [],
+  internalExecute: () => {},
+  getInternalDB: () => ({}),
+}));
+
+mock.module("@atlas/api/lib/audit", () => ({
+  logAdminAction: (entry: Record<string, unknown>) => {
+    auditCalls.push(entry);
+  },
+  logAdminActionAwait: async (entry: Record<string, unknown>) => {
+    auditCalls.push(entry);
+  },
+  ADMIN_ACTIONS: {
+    connection: {
+      probe: "connection.probe",
+      specRefreshCycle: "connection.spec_refresh_cycle",
+    },
+  },
+}));
+
+mock.module("@atlas/api/lib/audit/error-scrub", () => ({
+  errorMessage: (err: unknown) => (err instanceof Error ? err.message : String(err)),
+  causeToError: (_cause: unknown) => undefined,
+}));
+
+const {
+  runOpenApiInstallRediscoverCycle,
+  triggerOpenApiInstallRediscoverCycle,
+  startOpenApiInstallRediscoverScheduler,
+  stopOpenApiInstallRediscoverScheduler,
+  isOpenApiInstallRediscoverSchedulerRunning,
+  _resetOpenApiInstallRediscoverScheduler,
+  getInstallRediscoverIntervalMs,
+  OPENAPI_REDISCOVER_ACTOR,
+  DEFAULT_REDISCOVER_INTERVAL_MS,
+} = await import("../openapi-install-rediscover");
+
+type DueCandidateRow = import("../openapi-install-rediscover").DueCandidateRow;
+type RediscoveryResult = import("@atlas/api/lib/openapi/rediscover").RediscoveryResult;
+type OpenApiSnapshot = import("@atlas/api/lib/openapi/catalog").OpenApiSnapshot;
+type SpecDiffRecord = import("@atlas/api/lib/openapi/diff").SpecDiffRecord;
+type SpecDiffSummary = import("@atlas/api/lib/openapi/diff").SpecDiffSummary;
+
+// ── Fixtures / helpers ───────────────────────────────────────────────────────
+
+const NOW = 1_700_000_000_000;
+const HOUR_MS = 60 * 60 * 1000;
+const DAY_MS = 24 * HOUR_MS;
+const iso = (ms: number) => new Date(ms).toISOString();
+const NOW_ISO = iso(NOW);
+
+/** A config that makes an install DUE at NOW (daily interval, no prior activity). */
+const dueConfig = (extra: Record<string, unknown> = {}) => ({ spec_refresh_interval: "daily", ...extra });
+/** A config that is NOT yet due (checked 1h ago, daily interval). */
+const notDueConfig = () => ({ spec_refresh_interval: "daily", spec_last_checked_at: iso(NOW - HOUR_MS) });
+
+function candidate(installId: string, config: Record<string, unknown>): DueCandidateRow {
+  return { workspace_id: `ws-${installId}`, install_id: installId, config };
+}
+
+function snapshot(operationCount: number): OpenApiSnapshot {
+  return {
+    probedAt: NOW_ISO,
+    title: "Widget API",
+    version: "1.0.0",
+    openapiVersion: "3.1.0",
+    operationCount,
+    doc: { openapi: "3.1.0" },
+  };
+}
+
+const ZERO_COUNTS = {
+  operationsAdded: 0,
+  operationsRemoved: 0,
+  operationsChanged: 0,
+  schemasAdded: 0,
+  schemasRemoved: 0,
+  schemasChanged: 0,
+  fieldsAdded: 0,
+  fieldsRemoved: 0,
+  fieldsRetyped: 0,
+};
+
+function changedDrift(operationsAdded: number): SpecDiffSummary {
+  return {
+    previousProbedAt: iso(NOW - DAY_MS),
+    currentProbedAt: NOW_ISO,
+    baseline: false,
+    priorParseFailed: false,
+    unchanged: operationsAdded === 0,
+    counts: { ...ZERO_COUNTS, operationsAdded },
+  };
+}
+
+const diffRecord: SpecDiffRecord = { previousProbedAt: null, currentProbedAt: NOW_ISO, diff: null };
+
+function okResult(operationCount = 3, drift: SpecDiffSummary | null = null): RediscoveryResult {
+  return { kind: "ok", snapshot: snapshot(operationCount), diffRecord, drift };
+}
+
+/** Recording fakes for the persistence seams. */
+interface Recorder {
+  persistCalls: Array<{ workspaceId: string; installId: string; snapshot: OpenApiSnapshot; lastCheckedAtIso: string }>;
+  stampCalls: Array<{ workspaceId: string; installId: string; lastCheckedAtIso: string }>;
+  rediscoverCalls: Array<{ installId: string; config: Record<string, unknown> | null }>;
+}
+
+function makeRecorder(): Recorder {
+  return { persistCalls: [], stampCalls: [], rediscoverCalls: [] };
+}
+
+interface RunArgs {
+  rows: DueCandidateRow[];
+  rec: Recorder;
+  rediscover: (config: Record<string, unknown> | null, installId: string) => Promise<RediscoveryResult>;
+  persistThrows?: boolean;
+  queryThrows?: Error;
+}
+
+function runCycle(args: RunArgs) {
+  return Effect.runPromise(
+    runOpenApiInstallRediscoverCycle({
+      now: () => NOW,
+      query: async () => {
+        if (args.queryThrows) throw args.queryThrows;
+        return args.rows;
+      },
+      rediscover: (config, installId) => {
+        args.rec.rediscoverCalls.push({ installId, config });
+        return args.rediscover(config, installId);
+      },
+      persistSuccess: async (workspaceId, installId, snap, _diff, lastCheckedAtIso) => {
+        if (args.persistThrows) throw new Error("persist boom");
+        args.rec.persistCalls.push({ workspaceId, installId, snapshot: snap, lastCheckedAtIso });
+      },
+      stampChecked: async (workspaceId, installId, lastCheckedAtIso) => {
+        args.rec.stampCalls.push({ workspaceId, installId, lastCheckedAtIso });
+      },
+    }),
+  );
+}
+
+function resetAll() {
+  _resetOpenApiInstallRediscoverScheduler();
+  mockHasDB = true;
+  auditCalls = [];
+}
+
+const cycleRows = () => auditCalls.filter((c) => c.actionType === "connection.spec_refresh_cycle");
+const probeRows = () => auditCalls.filter((c) => c.actionType === "connection.probe");
+
+// ── Lifecycle ─────────────────────────────────────────────────────────────
+
+describe("openapi install rediscover — lifecycle", () => {
+  beforeEach(resetAll);
+
+  it("starts and stops cleanly", () => {
+    expect(isOpenApiInstallRediscoverSchedulerRunning()).toBe(false);
+    startOpenApiInstallRediscoverScheduler(60_000);
+    expect(isOpenApiInstallRediscoverSchedulerRunning()).toBe(true);
+    stopOpenApiInstallRediscoverScheduler();
+    expect(isOpenApiInstallRediscoverSchedulerRunning()).toBe(false);
+  });
+
+  it("does not double-start", () => {
+    startOpenApiInstallRediscoverScheduler(60_000);
+    startOpenApiInstallRediscoverScheduler(60_000);
+    expect(isOpenApiInstallRediscoverSchedulerRunning()).toBe(true);
+    stopOpenApiInstallRediscoverScheduler();
+  });
+
+  it("stop is idempotent — calling stop twice or without start is a no-op", () => {
+    stopOpenApiInstallRediscoverScheduler();
+    expect(isOpenApiInstallRediscoverSchedulerRunning()).toBe(false);
+    startOpenApiInstallRediscoverScheduler(60_000);
+    stopOpenApiInstallRediscoverScheduler();
+    stopOpenApiInstallRediscoverScheduler();
+    expect(isOpenApiInstallRediscoverSchedulerRunning()).toBe(false);
+  });
+
+  it("refuses to start without an internal DB (it reads workspace_plugins)", () => {
+    mockHasDB = false;
+    startOpenApiInstallRediscoverScheduler(60_000);
+    expect(isOpenApiInstallRediscoverSchedulerRunning()).toBe(false);
+  });
+
+  it("reserved system actor matches the audit pattern + is distinct from siblings", () => {
+    expect(OPENAPI_REDISCOVER_ACTOR).toBe("system:openapi-install-rediscover");
+    expect(OPENAPI_REDISCOVER_ACTOR).toMatch(/^system:[a-z0-9][a-z0-9_-]*$/);
+    expect(OPENAPI_REDISCOVER_ACTOR).not.toBe("system:byot-catalog-refresh");
+  });
+});
+
+describe("getInstallRediscoverIntervalMs — env-tunable global tick", () => {
+  const KEY = "ATLAS_OPENAPI_REDISCOVER_INTERVAL_HOURS";
+  let saved: string | undefined;
+  beforeEach(() => {
+    saved = process.env[KEY];
+    delete process.env[KEY];
+  });
+  const restore = () => {
+    if (saved === undefined) delete process.env[KEY];
+    else process.env[KEY] = saved;
+  };
+
+  it("defaults to 1 hour", () => {
+    expect(getInstallRediscoverIntervalMs()).toBe(DEFAULT_REDISCOVER_INTERVAL_MS);
+    expect(DEFAULT_REDISCOVER_INTERVAL_MS).toBe(HOUR_MS);
+    restore();
+  });
+
+  it("honors a positive override (hours → ms)", () => {
+    process.env[KEY] = "6";
+    expect(getInstallRediscoverIntervalMs()).toBe(6 * HOUR_MS);
+    restore();
+  });
+
+  it("falls back to the default on a non-positive / non-finite value", () => {
+    for (const bad of ["0", "-3", "abc"]) {
+      process.env[KEY] = bad;
+      expect(getInstallRediscoverIntervalMs()).toBe(DEFAULT_REDISCOVER_INTERVAL_MS);
+    }
+    restore();
+  });
+});
+
+// ── Cycle behavior ──────────────────────────────────────────────────────────
+
+describe("openapi install rediscover — cycle behavior", () => {
+  beforeEach(resetAll);
+
+  it("empty queue → success, zero counts, one success cycle audit row", async () => {
+    const rec = makeRecorder();
+    const result = await runCycle({ rows: [], rec, rediscover: async () => okResult() });
+
+    expect(result.status).toBe("success");
+    expect(result.inspected).toBe(0);
+    expect(result.due).toBe(0);
+    expect(result.refreshed).toBe(0);
+    expect(rec.rediscoverCalls).toHaveLength(0);
+
+    expect(cycleRows()).toHaveLength(1);
+    expect(cycleRows()[0].systemActor).toBe(OPENAPI_REDISCOVER_ACTOR);
+    expect(cycleRows()[0].scope).toBe("platform");
+    expect(cycleRows()[0].targetType).toBe("connection");
+    expect(cycleRows()[0].targetId).toBe("scheduler");
+    expect(cycleRows()[0].status).toBe("success");
+  });
+
+  it("survives an internal-DB-disabled state — emits a success cycle row with zero counts", async () => {
+    mockHasDB = false;
+    const result = await Effect.runPromise(runOpenApiInstallRediscoverCycle());
+    expect(result.status).toBe("success");
+    expect(result.inspected).toBe(0);
+    expect(cycleRows()).toHaveLength(1);
+    expect(cycleRows()[0].status).toBe("success");
+  });
+
+  it("candidate query throw emits a FAILURE cycle row with error metadata", async () => {
+    const rec = makeRecorder();
+    const result = await runCycle({
+      rows: [],
+      rec,
+      rediscover: async () => okResult(),
+      queryThrows: new Error("connection refused"),
+    });
+    expect(result.status).toBe("failure");
+    expect(result.error).toBe("connection refused");
+    expect(cycleRows()).toHaveLength(1);
+    expect(cycleRows()[0].status).toBe("failure");
+    expect((cycleRows()[0].metadata as Record<string, unknown>).error).toBe("connection refused");
+  });
+
+  it("DUE-SELECTION: re-discovers only the installs whose interval has elapsed", async () => {
+    const rec = makeRecorder();
+    const rows = [
+      candidate("due-1", dueConfig()),
+      candidate("not-due", notDueConfig()),
+      candidate("due-2", dueConfig()),
+    ];
+    const result = await runCycle({ rows, rec, rediscover: async () => okResult(2) });
+
+    expect(result.inspected).toBe(3);
+    expect(result.due).toBe(2);
+    expect(result.refreshed).toBe(2);
+    expect(result.skippedNotDue).toBe(1);
+    // Only the two due installs were probed — the not-due one was never touched.
+    expect(rec.rediscoverCalls.map((c) => c.installId)).toEqual(["due-1", "due-2"]);
+    expect(rec.stampCalls).toHaveLength(0);
+  });
+
+  it("OFF-SKIP: an off install is never re-discovered even if the query returns it", async () => {
+    const rec = makeRecorder();
+    const rows = [
+      candidate("off-1", { spec_refresh_interval: "off" }),
+      candidate("due-1", dueConfig()),
+    ];
+    const result = await runCycle({ rows, rec, rediscover: async () => okResult() });
+
+    expect(result.skippedNotDue).toBe(1);
+    expect(result.refreshed).toBe(1);
+    expect(rec.rediscoverCalls.map((c) => c.installId)).toEqual(["due-1"]);
+  });
+
+  it("WATERMARK BUMP ON SUCCESS: persists snapshot + diff + the cycle's nowIso watermark", async () => {
+    const rec = makeRecorder();
+    const rows = [candidate("ds-1", dueConfig())];
+    const result = await runCycle({ rows, rec, rediscover: async () => okResult(5, changedDrift(2)) });
+
+    expect(result.refreshed).toBe(1);
+    expect(rec.persistCalls).toHaveLength(1);
+    expect(rec.persistCalls[0].workspaceId).toBe("ws-ds-1");
+    expect(rec.persistCalls[0].installId).toBe("ds-1");
+    expect(rec.persistCalls[0].snapshot.operationCount).toBe(5);
+    expect(rec.persistCalls[0].lastCheckedAtIso).toBe(NOW_ISO);
+    // Success path stamps via the snapshot write, NOT the watermark-only write.
+    expect(rec.stampCalls).toHaveLength(0);
+
+    // Audit: connection.probe, scheduler-triggered, with drift roll-up.
+    const row = probeRows().find((c) => c.targetId === "ds-1");
+    expect(row).toBeDefined();
+    expect(row!.systemActor).toBe(OPENAPI_REDISCOVER_ACTOR);
+    expect(row!.status).toBe("success");
+    const meta = row!.metadata as Record<string, unknown>;
+    expect(meta.workspaceId).toBe("ws-ds-1");
+    expect(meta.kind).toBe("openapi-rediscover");
+    expect(meta.triggeredBy).toBe("scheduler");
+    expect(meta.operationCount).toBe(5);
+    expect(meta.operationsAdded).toBe(2);
+  });
+
+  it("FAIL-SOFT: a down upstream stamps the watermark, leaves the snapshot untouched, keeps going", async () => {
+    const rec = makeRecorder();
+    const rows = [
+      candidate("down-1", dueConfig()),
+      candidate("ok-1", dueConfig()),
+    ];
+    const result = await runCycle({
+      rows,
+      rec,
+      rediscover: async (_config, installId) =>
+        installId === "down-1"
+          ? { kind: "probe_failed", reason: "unreachable", message: "ETIMEDOUT" }
+          : okResult(),
+    });
+
+    expect(result.failed).toBe(1);
+    expect(result.refreshed).toBe(1);
+    // The failed install got a watermark-only stamp (negative-cache), NOT a snapshot write.
+    expect(rec.stampCalls.map((c) => c.installId)).toEqual(["down-1"]);
+    expect(rec.stampCalls[0].lastCheckedAtIso).toBe(NOW_ISO);
+    expect(rec.persistCalls.map((c) => c.installId)).toEqual(["ok-1"]);
+
+    const failRow = probeRows().find((c) => c.targetId === "down-1");
+    expect(failRow!.status).toBe("failure");
+    expect((failRow!.metadata as Record<string, unknown>).reason).toBe("probe_failed");
+    expect((failRow!.metadata as Record<string, unknown>).probeReason).toBe("unreachable");
+  });
+
+  it("PER-INSTALL CONTAINMENT: a thrown middle install does not abort the rest", async () => {
+    const rec = makeRecorder();
+    const rows = [
+      candidate("a", dueConfig()),
+      candidate("b", dueConfig()),
+      candidate("c", dueConfig()),
+    ];
+    const result = await runCycle({
+      rows,
+      rec,
+      rediscover: async (_config, installId) => {
+        if (installId === "b") throw new Error("kaboom");
+        return okResult();
+      },
+    });
+
+    expect(rec.rediscoverCalls.map((c) => c.installId)).toEqual(["a", "b", "c"]);
+    expect(result.refreshed).toBe(2);
+    expect(result.failed).toBe(1);
+    // The thrown install is fail-soft negative-cached (watermark stamped).
+    expect(rec.stampCalls.map((c) => c.installId)).toEqual(["b"]);
+    const failRow = probeRows().find((c) => c.targetId === "b");
+    expect(failRow!.status).toBe("failure");
+    expect((failRow!.metadata as Record<string, unknown>).reason).toBe("error");
+  });
+
+  it("CONFIG SKIP: decrypt/no-url/unsupported-auth stamp the watermark + audit as failures", async () => {
+    const rec = makeRecorder();
+    const rows = [
+      candidate("decrypt", dueConfig()),
+      candidate("nourl", dueConfig()),
+      candidate("oauth", dueConfig()),
+    ];
+    const result = await runCycle({
+      rows,
+      rec,
+      rediscover: async (_config, installId) => {
+        if (installId === "decrypt") return { kind: "decrypt_failed" };
+        if (installId === "nourl") return { kind: "no_url" };
+        return { kind: "unsupported_auth", rawAuthKind: "oauth2" };
+      },
+    });
+
+    expect(result.skippedConfig).toBe(3);
+    expect(result.refreshed).toBe(0);
+    expect(result.failed).toBe(0);
+    // Every config-skip is negative-cached so it isn't re-evaluated every tick.
+    expect(rec.stampCalls.map((c) => c.installId).sort()).toEqual(["decrypt", "nourl", "oauth"]);
+    expect(rec.persistCalls).toHaveLength(0);
+
+    const oauthRow = probeRows().find((c) => c.targetId === "oauth");
+    expect(oauthRow!.status).toBe("failure");
+    expect((oauthRow!.metadata as Record<string, unknown>).reason).toBe("unsupported_auth");
+    expect((oauthRow!.metadata as Record<string, unknown>).authKind).toBe("oauth2");
+  });
+
+  it("PERSIST FAILURE: a failed snapshot write does NOT stamp (so the next tick retries)", async () => {
+    const rec = makeRecorder();
+    const rows = [candidate("ds-1", dueConfig())];
+    const result = await runCycle({
+      rows,
+      rec,
+      rediscover: async () => okResult(),
+      persistThrows: true,
+    });
+
+    expect(result.failed).toBe(1);
+    expect(result.refreshed).toBe(0);
+    // Neither a snapshot write (it threw) nor a watermark stamp — the install stays
+    // due so the next tick retries rather than caching a half-applied refresh.
+    expect(rec.persistCalls).toHaveLength(0);
+    expect(rec.stampCalls).toHaveLength(0);
+    const failRow = probeRows().find((c) => c.targetId === "ds-1");
+    expect(failRow!.status).toBe("failure");
+  });
+
+  it("emits one cycle audit row carrying the full RediscoverCycleResult counts", async () => {
+    const rec = makeRecorder();
+    const rows = [
+      candidate("ok-1", dueConfig()),
+      candidate("down-1", dueConfig()),
+      candidate("not-due", notDueConfig()),
+      candidate("oauth", dueConfig()),
+    ];
+    await runCycle({
+      rows,
+      rec,
+      rediscover: async (_c, installId) => {
+        if (installId === "down-1") return { kind: "probe_failed", reason: "unreachable", message: "x" };
+        if (installId === "oauth") return { kind: "unsupported_auth", rawAuthKind: "oauth2" };
+        return okResult();
+      },
+    });
+
+    expect(cycleRows()).toHaveLength(1);
+    expect(cycleRows()[0].metadata).toEqual({
+      status: "success",
+      inspected: 4,
+      due: 3,
+      refreshed: 1,
+      failed: 1,
+      skippedNotDue: 1,
+      skippedConfig: 1,
+    });
+  });
+});
+
+describe("openapi install rediscover — triggerOpenApiInstallRediscoverCycle wrapper", () => {
+  beforeEach(resetAll);
+
+  it("returns the cycle result on the happy path", async () => {
+    const rec = makeRecorder();
+    const result = await triggerOpenApiInstallRediscoverCycle({
+      now: () => NOW,
+      query: async () => [candidate("ds-1", dueConfig())],
+      rediscover: async () => okResult(),
+      persistSuccess: async (workspaceId, installId, snap, _diff, lastCheckedAtIso) => {
+        rec.persistCalls.push({ workspaceId, installId, snapshot: snap, lastCheckedAtIso });
+      },
+      stampChecked: async () => {},
+    });
+    expect(result.status).toBe("success");
+    expect(result.refreshed).toBe(1);
+    expect(rec.persistCalls).toHaveLength(1);
+  });
+
+  it("resolves with status: failure (does not reject) when the candidate query throws", async () => {
+    const result = await triggerOpenApiInstallRediscoverCycle({
+      query: async () => {
+        throw new Error("db down");
+      },
+    });
+    expect(result.status).toBe("failure");
+    expect(result.error).toBe("db down");
+  });
+});

--- a/packages/api/src/lib/scheduler/__tests__/openapi-install-rediscover.test.ts
+++ b/packages/api/src/lib/scheduler/__tests__/openapi-install-rediscover.test.ts
@@ -447,7 +447,8 @@ describe("openapi install rediscover — cycle behavior", () => {
     expect(rec.stampCalls.map((c) => c.installId)).toEqual(["b"]);
     const failRow = probeRows().find((c) => c.targetId === "b");
     expect(failRow!.status).toBe("failure");
-    expect((failRow!.metadata as Record<string, unknown>).reason).toBe("error");
+    // A rediscover-phase fault is negative-cached (stamped) → deferred a full interval.
+    expect((failRow!.metadata as Record<string, unknown>).reason).toBe("rediscover_fault");
   });
 
   it("CONFIG SKIP: decrypt/no-url/unsupported-auth stamp the watermark + audit as failures", async () => {
@@ -498,6 +499,9 @@ describe("openapi install rediscover — cycle behavior", () => {
     expect(rec.stampCalls).toHaveLength(0);
     const failRow = probeRows().find((c) => c.targetId === "ds-1");
     expect(failRow!.status).toBe("failure");
+    // persist-phase failure is the retry-next-tick mode, distinct from a deferred
+    // rediscover fault — the audit reason must reflect that.
+    expect((failRow!.metadata as Record<string, unknown>).reason).toBe("persist_failed");
   });
 
   it("emits one cycle audit row carrying the full RediscoverCycleResult counts", async () => {

--- a/packages/api/src/lib/scheduler/openapi-install-rediscover.ts
+++ b/packages/api/src/lib/scheduler/openapi-install-rediscover.ts
@@ -1,0 +1,621 @@
+/**
+ * Scheduler-driven Tier-2 per-install OpenAPI re-discovery (#2978, v0.0.3).
+ *
+ * The AUTOMATED sibling of the manual admin "Refresh now" (#3002): on a timer it
+ * walks every installed `openapi-generic` datasource whose per-install
+ * `spec_refresh_interval` (#2977) has elapsed since its last check, re-probes the
+ * spec endpoint, re-normalizes to an {@link OperationGraph}, updates the persisted
+ * per-install snapshot, records the structured drift diff (#2976), and bumps the
+ * `spec_last_checked_at` watermark. All of that is the shared core in
+ * `openapi/rediscover.ts` — this module is just the periodic loop + due-selection +
+ * fail-soft + audit around it.
+ *
+ * ## Scope guard — Tier-2, NOT Tier-1
+ * `scheduler/openapi-spec-refresh.ts` is the TIER-1 shared, cross-workspace cache
+ * refresh (#2970): it conditional-GETs PUBLIC catalog specs (Stripe/GitHub/Notion)
+ * into a process-local cache and NEVER mutates any workspace's persisted snapshot.
+ * THIS module is Tier-2: per-install, customer-configurable, and it DOES mutate the
+ * persisted per-install snapshot + records a drift diff. The two loops are
+ * orthogonal — Tier-1 keeps the shared working set warm; Tier-2 keeps each
+ * private/custom install's own snapshot current. Tier-2 is the arm the Tier-1
+ * docstring names (#2978 scheduler + #2979 breaking-change signal).
+ *
+ * ## Egress posture
+ * Re-discovery goes through `performRediscovery` → `probeSpec`, which runs the
+ * identical SSRF guard + redirect-revalidating `guardedFetch` + #3034 host-match
+ * credential gate as a resolve-time probe. Scheduled probing is therefore the SAME
+ * server-side egress as resolve-time, just on a timer — including the SaaS egress
+ * allowlist and the per-tenant `base_url_override` host gate.
+ *
+ * ## Due-selection (per-install interval, not a global TTL)
+ * Unlike `byot-catalog-refresh.ts` (one global TTL) the interval is PER INSTALL, so
+ * a single `now() - $1::interval` SQL gate doesn't fit. A coarse SQL pre-filter
+ * selects non-`off` candidates ordered least-recently-checked-first (bounded by
+ * `batchSize`); the precise "interval elapsed?" decision is `evaluateSpecRefreshDue`
+ * in `openapi/spec-refresh.ts`, the single source of truth for the interval grammar
+ * and the `max(spec_last_checked_at, snapshot.probedAt)` activity watermark.
+ *
+ * ## Fail-soft
+ * Per-install failures are isolated: a down/slow upstream (the probe is
+ * `AbortSignal.timeout`-bounded) stamps the watermark — the persisted negative-cache
+ * that defers its next re-probe by a full interval — leaves the live snapshot
+ * UNTOUCHED, and never aborts the loop or the workspace's other installs. A persist
+ * failure deliberately does NOT stamp, so the next tick retries rather than
+ * negatively-caching a half-applied refresh.
+ *
+ * ## Lifecycle
+ * `setInterval`-based with `unref()` (doesn't pin the process), an initial cycle on
+ * start, a single-running guard (double-start is a no-op), and an in-flight guard so
+ * a slow cycle never overlaps the next tick — mirrors `byot-catalog-refresh.ts` +
+ * `openapi-spec-refresh.ts`. No-op without an internal DB (it reads
+ * `workspace_plugins`).
+ *
+ * @see ./byot-catalog-refresh.ts — the periodic-fiber pattern this follows.
+ * @see ./openapi-spec-refresh.ts — the Tier-1 sibling this is deliberately NOT.
+ * @see ../openapi/rediscover.ts — the shared re-probe → snapshot → diff core.
+ */
+
+import { Effect } from "effect";
+import { createLogger } from "@atlas/api/lib/logger";
+import { withEffectSpan } from "@atlas/api/lib/tracing";
+import { hasInternalDB, internalQuery } from "@atlas/api/lib/db/internal";
+import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
+import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
+import { OPENAPI_GENERIC_CATALOG_ID, type OpenApiSnapshot } from "@atlas/api/lib/openapi/catalog";
+import { evaluateSpecRefreshDue } from "@atlas/api/lib/openapi/spec-refresh";
+import type { SpecDiffRecord, SpecDiffSummary } from "@atlas/api/lib/openapi/diff";
+import type { RediscoveryResult } from "@atlas/api/lib/openapi/rediscover";
+
+const log = createLogger("openapi-install-rediscover");
+
+/**
+ * Reserved system-actor string for every audit row written by the Tier-2
+ * re-discovery scheduler. Matches `^system:[a-z0-9][a-z0-9_-]*$` (enforced by
+ * `assertSystemActor`). Distinct from the Tier-1 cache and the BYOT job so forensic
+ * queries can isolate this loop's writes.
+ */
+export const OPENAPI_REDISCOVER_ACTOR = "system:openapi-install-rediscover" as const;
+
+/** Default global tick: 1 hour — matches the MIN per-install interval so an hourly
+ * install is honored. Most installs use daily/weekly, so the hourly query is a cheap
+ * no-op in the common case. */
+export const DEFAULT_REDISCOVER_INTERVAL_MS = 60 * 60 * 1000;
+
+/** Bound per-tick work; the backlog catches up across ticks via `NULLS FIRST` ordering. */
+const DEFAULT_BATCH_SIZE = 100;
+
+/**
+ * The global tick interval (ms). Reads `ATLAS_OPENAPI_REDISCOVER_INTERVAL_HOURS`,
+ * defaults to 1h. Mirrors `getExpertSchedulerIntervalMs` so the cadence is
+ * operator-tunable without a code change. NOTE: this is the LOOP wake cadence, NOT
+ * the per-install interval (which lives in each install's `spec_refresh_interval`).
+ */
+export function getInstallRediscoverIntervalMs(): number {
+  const raw = process.env.ATLAS_OPENAPI_REDISCOVER_INTERVAL_HOURS;
+  if (!raw) return DEFAULT_REDISCOVER_INTERVAL_MS;
+  const hours = Number.parseFloat(raw);
+  if (!Number.isFinite(hours) || hours <= 0) return DEFAULT_REDISCOVER_INTERVAL_MS;
+  return hours * 60 * 60 * 1000;
+}
+
+// ---------------------------------------------------------------------------
+// Candidate selection
+// ---------------------------------------------------------------------------
+
+/**
+ * A `workspace_plugins` row this loop considers. `config` is the raw JSONB; the
+ * credential stays encrypted (decrypted only inside `performRediscovery`). A `type`
+ * (not `interface`) so it satisfies `internalQuery`'s `Record<string, unknown>`
+ * row constraint.
+ */
+export type DueCandidateRow = {
+  readonly workspace_id: string;
+  readonly install_id: string;
+  readonly config: Record<string, unknown> | null;
+};
+
+/**
+ * The coarse SQL pre-filter: every non-archived generic OpenAPI datasource install,
+ * across all workspaces, whose `spec_refresh_interval` is set and not `'off'`,
+ * ordered least-recently-checked-first so a backlog drains fairly under the batch
+ * cap. The canonical stored interval is exactly `'off'`/`'daily'`/`'weekly'`/`'<N>h'`
+ * (see `normalizeSpecRefreshInterval`), so excluding `'off'` here is safe; a drifted
+ * value slips through and is rejected app-side by `evaluateSpecRefreshDue` (defense
+ * in depth). `$2` is the catalog id (a code constant, never client input).
+ */
+const CANDIDATE_QUERY_SQL = `SELECT workspace_id, install_id, config
+     FROM workspace_plugins
+    WHERE catalog_id = $1
+      AND pillar = 'datasource'
+      AND status != 'archived'
+      AND config->>'spec_refresh_interval' IS NOT NULL
+      AND config->>'spec_refresh_interval' <> 'off'
+    ORDER BY config->>'spec_last_checked_at' ASC NULLS FIRST
+    LIMIT $2`;
+
+async function defaultQuery(limit: number): Promise<ReadonlyArray<DueCandidateRow>> {
+  return internalQuery<DueCandidateRow>(CANDIDATE_QUERY_SQL, [OPENAPI_GENERIC_CATALOG_ID, limit]);
+}
+
+// ---------------------------------------------------------------------------
+// Re-discovery + persistence seams (lazily imported defaults)
+// ---------------------------------------------------------------------------
+// Lazy `import()` keeps the heavy probe/secrets/diff chain out of this module's
+// static graph (the scheduler test injects fakes and never triggers it) — mirrors
+// the way `byot-catalog-refresh.ts` lazily imports its catalog fetchers.
+
+type RediscoverFn = (
+  rawConfig: Record<string, unknown> | null,
+  installId: string,
+) => Promise<RediscoveryResult>;
+
+type PersistSuccessFn = (
+  workspaceId: string,
+  installId: string,
+  snapshot: OpenApiSnapshot,
+  diffRecord: SpecDiffRecord,
+  lastCheckedAtIso: string,
+) => Promise<void>;
+
+type StampCheckedFn = (
+  workspaceId: string,
+  installId: string,
+  lastCheckedAtIso: string,
+) => Promise<void>;
+
+const defaultRediscover: RediscoverFn = async (rawConfig, installId) => {
+  const { performRediscovery } = await import("@atlas/api/lib/openapi/rediscover");
+  return performRediscovery(rawConfig, installId);
+};
+
+const defaultPersistSuccess: PersistSuccessFn = async (
+  workspaceId,
+  installId,
+  snapshot,
+  diffRecord,
+  lastCheckedAtIso,
+) => {
+  const { persistRediscoverySnapshot } = await import("@atlas/api/lib/openapi/rediscover");
+  await persistRediscoverySnapshot(workspaceId, installId, snapshot, diffRecord, lastCheckedAtIso);
+};
+
+const defaultStampChecked: StampCheckedFn = async (workspaceId, installId, lastCheckedAtIso) => {
+  const { stampSpecLastChecked } = await import("@atlas/api/lib/openapi/rediscover");
+  await stampSpecLastChecked(workspaceId, installId, lastCheckedAtIso);
+};
+
+// ---------------------------------------------------------------------------
+// Per-install processing
+// ---------------------------------------------------------------------------
+
+/** Terminal outcome for one candidate install — drives both the tally + the audit. */
+type InstallOutcome =
+  | { readonly kind: "not_due" }
+  | { readonly kind: "refreshed"; readonly operationCount: number; readonly drift: SpecDiffSummary | null }
+  | { readonly kind: "probe_failed"; readonly reason: string }
+  | { readonly kind: "config_skip"; readonly reason: "decrypt_failed" | "no_url" | "unsupported_auth"; readonly detail?: string }
+  | { readonly kind: "failed"; readonly error: string };
+
+interface CycleDeps {
+  readonly rediscover: RediscoverFn;
+  readonly persistSuccess: PersistSuccessFn;
+  readonly stampChecked: StampCheckedFn;
+}
+
+/**
+ * Stamp the watermark, swallowing (and logging) any write failure so a stamp error
+ * never propagates out of {@link runInstall} — the negative-cache write is
+ * best-effort; if it fails the worst case is the next tick re-evaluates this install.
+ */
+async function safeStamp(
+  deps: CycleDeps,
+  row: DueCandidateRow,
+  lastCheckedAtIso: string,
+): Promise<void> {
+  try {
+    await deps.stampChecked(row.workspace_id, row.install_id, lastCheckedAtIso);
+  } catch (err) {
+    log.warn(
+      { workspaceId: row.workspace_id, installId: row.install_id, err: errorMessage(err) },
+      "OpenAPI rediscover: failed to stamp spec_last_checked_at watermark",
+    );
+  }
+}
+
+/**
+ * Evaluate + (if due) re-discover one install. NEVER throws — every failure path
+ * resolves to an {@link InstallOutcome}. On a due install:
+ *   - success → persist snapshot + diff + watermark, evict graph cache.
+ *   - probe failure → stamp watermark (negative-cache), leave snapshot intact.
+ *   - config skip (decrypt/no-url/unsupported auth) → stamp watermark; admin must fix.
+ *   - persist failure after a good probe → report failed WITHOUT stamping, so the
+ *     next tick retries the persist rather than caching a half-applied refresh.
+ */
+async function runInstall(
+  row: DueCandidateRow,
+  nowMs: number,
+  nowIso: string,
+  deps: CycleDeps,
+): Promise<InstallOutcome> {
+  const decision = evaluateSpecRefreshDue(row.config, nowMs);
+  if (!decision.due) return { kind: "not_due" };
+
+  let result: RediscoveryResult;
+  try {
+    result = await deps.rediscover(row.config, row.install_id);
+  } catch (err) {
+    // Unexpected fault during re-probe/normalize — fail-soft: negative-cache it,
+    // leave the live snapshot intact.
+    await safeStamp(deps, row, nowIso);
+    return { kind: "failed", error: errorMessage(err) };
+  }
+
+  switch (result.kind) {
+    case "ok":
+      try {
+        await deps.persistSuccess(
+          row.workspace_id,
+          row.install_id,
+          result.snapshot,
+          result.diffRecord,
+          nowIso,
+        );
+      } catch (err) {
+        // The re-probe succeeded but persisting the fresh snapshot failed. Do NOT
+        // stamp the watermark — leaving it stale means the next tick retries the
+        // persist instead of negatively-caching a half-applied refresh.
+        return { kind: "failed", error: errorMessage(err) };
+      }
+      return { kind: "refreshed", operationCount: result.snapshot.operationCount, drift: result.drift };
+    case "probe_failed":
+      await safeStamp(deps, row, nowIso);
+      return { kind: "probe_failed", reason: result.reason };
+    case "decrypt_failed":
+    case "no_url":
+      await safeStamp(deps, row, nowIso);
+      return { kind: "config_skip", reason: result.kind };
+    case "unsupported_auth":
+      await safeStamp(deps, row, nowIso);
+      return { kind: "config_skip", reason: "unsupported_auth", detail: result.rawAuthKind };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Cycle result + audit
+// ---------------------------------------------------------------------------
+
+/** Structured outcome of one scheduler cycle — also the cycle audit row's metadata. */
+export interface RediscoverCycleResult {
+  status: "success" | "failure";
+  /** Candidate rows examined (post SQL pre-filter, pre due-check). */
+  inspected: number;
+  /** Of `inspected`, how many were actually due (interval elapsed). */
+  due: number;
+  /** Successful re-probes (snapshot + watermark written). */
+  refreshed: number;
+  /** Probe/network/persist failures — fail-soft, snapshot left intact. */
+  failed: number;
+  /** Selected by the SQL pre-filter but not yet due app-side. */
+  skippedNotDue: number;
+  /** Due, but un-probeable this cycle: decrypt/no-url/unsupported-auth (admin must fix). */
+  skippedConfig: number;
+  /** Set only when `status === "failure"` (the candidate query itself threw). */
+  error?: string;
+}
+
+const ZERO_COUNTS = {
+  inspected: 0,
+  due: 0,
+  refreshed: 0,
+  failed: 0,
+  skippedNotDue: 0,
+  skippedConfig: 0,
+} as const;
+
+interface RediscoverCycleOptions {
+  /** `Date.now()` override (ms) for due-calc + the watermark stamp. */
+  readonly now?: () => number;
+  readonly batchSize?: number;
+  readonly query?: (limit: number) => Promise<ReadonlyArray<DueCandidateRow>>;
+  readonly rediscover?: RediscoverFn;
+  readonly persistSuccess?: PersistSuccessFn;
+  readonly stampChecked?: StampCheckedFn;
+}
+
+/** Drift roll-up tallies for an audit row — the same counts the manual route emits. */
+function driftMetadata(drift: SpecDiffSummary | null): Record<string, unknown> {
+  if (drift && !drift.baseline) {
+    return {
+      driftUnchanged: drift.unchanged,
+      operationsAdded: drift.counts.operationsAdded,
+      operationsRemoved: drift.counts.operationsRemoved,
+      operationsChanged: drift.counts.operationsChanged,
+      schemasAdded: drift.counts.schemasAdded,
+      schemasRemoved: drift.counts.schemasRemoved,
+      schemasChanged: drift.counts.schemasChanged,
+      fieldsAdded: drift.counts.fieldsAdded,
+      fieldsRemoved: drift.counts.fieldsRemoved,
+      fieldsRetyped: drift.counts.fieldsRetyped,
+    };
+  }
+  return { baseline: true, ...(drift?.priorParseFailed ? { priorParseFailed: true } : {}) };
+}
+
+/**
+ * Emit a per-install audit row under the same `connection.probe` action the manual
+ * route uses (so an operator filtering by install id sees manual + scheduled probes
+ * uniformly), distinguished by `triggeredBy: "scheduler"`. `scope: "platform"` +
+ * `workspaceId` in metadata mirrors the BYOT job's system-actor convention — there's
+ * no request context, so the `org_id` column is null and the workspace is carried in
+ * the target id + metadata. Fire-and-forget; a thrown audit must not sink the loop.
+ */
+function emitInstallAudit(
+  row: DueCandidateRow,
+  status: "success" | "failure",
+  metadata: Record<string, unknown>,
+): void {
+  try {
+    logAdminAction({
+      actionType: ADMIN_ACTIONS.connection.probe,
+      targetType: "connection",
+      targetId: row.install_id,
+      scope: "platform",
+      systemActor: OPENAPI_REDISCOVER_ACTOR,
+      status,
+      metadata: {
+        workspaceId: row.workspace_id,
+        installId: row.install_id,
+        kind: "openapi-rediscover",
+        triggeredBy: "scheduler",
+        ...metadata,
+      },
+    });
+  } catch (err) {
+    log.warn(
+      { workspaceId: row.workspace_id, installId: row.install_id, err: errorMessage(err) },
+      "OpenAPI rediscover: per-install audit emission threw",
+    );
+  }
+}
+
+function emitCycleAudit(result: RediscoverCycleResult): void {
+  try {
+    logAdminAction({
+      actionType: ADMIN_ACTIONS.connection.specRefreshCycle,
+      targetType: "connection",
+      targetId: "scheduler",
+      scope: "platform",
+      systemActor: OPENAPI_REDISCOVER_ACTOR,
+      status: result.status,
+      metadata: { ...result },
+    });
+  } catch (err) {
+    log.error(
+      { err: errorMessage(err) },
+      "OpenAPI rediscover: cycle audit emission threw — counts preserved in pino",
+    );
+  }
+}
+
+/**
+ * Run a single re-discovery cycle. Never throws — a failure in the candidate query
+ * surfaces as `status: "failure"` + an emitted cycle row; per-install failures are
+ * isolated and counted. Returns the structured {@link RediscoverCycleResult}.
+ */
+export const runOpenApiInstallRediscoverCycle = (
+  opts: RediscoverCycleOptions = {},
+): Effect.Effect<RediscoverCycleResult> =>
+  // Span the whole cycle so a slow/failing upstream re-probe shows up in the trace
+  // waterfall alongside the other scheduler ticks.
+  withEffectSpan(
+    "atlas.scheduler.openapi_install_rediscover",
+    {},
+    Effect.gen(function* () {
+      if (!hasInternalDB()) {
+        const result: RediscoverCycleResult = { status: "success", ...ZERO_COUNTS };
+        emitCycleAudit(result);
+        return result;
+      }
+
+      const nowFn = opts.now ?? Date.now;
+      const batchSize = opts.batchSize ?? DEFAULT_BATCH_SIZE;
+      const query = opts.query ?? defaultQuery;
+      const deps: CycleDeps = {
+        rediscover: opts.rediscover ?? defaultRediscover,
+        persistSuccess: opts.persistSuccess ?? defaultPersistSuccess,
+        stampChecked: opts.stampChecked ?? defaultStampChecked,
+      };
+
+      const fetchResult = yield* Effect.tryPromise({
+        try: () => query(batchSize),
+        catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+      }).pipe(
+        Effect.map((rows) => ({ ok: true as const, rows })),
+        Effect.catchAll((err) => {
+          log.error(
+            { err: errorMessage(err) },
+            "OpenAPI rediscover: failed to query due candidates",
+          );
+          return Effect.succeed({ ok: false as const, error: errorMessage(err) });
+        }),
+      );
+
+      if (!fetchResult.ok) {
+        const failed: RediscoverCycleResult = {
+          status: "failure",
+          ...ZERO_COUNTS,
+          error: fetchResult.error,
+        };
+        emitCycleAudit(failed);
+        return failed;
+      }
+
+      const rows = fetchResult.rows;
+      const result: RediscoverCycleResult = { status: "success", ...ZERO_COUNTS, inspected: rows.length };
+
+      if (rows.length === 0) {
+        emitCycleAudit(result);
+        return result;
+      }
+
+      // Stamp one ISO timestamp for the whole cycle so every watermark written this
+      // tick is consistent (and the due-calc uses the same instant).
+      const nowMs = nowFn();
+      const nowIso = new Date(nowMs).toISOString();
+
+      log.info({ count: rows.length }, "OpenAPI rediscover: cycle starting");
+
+      // Sequential — one upstream probe at a time (concurrency: 1), so a noisy
+      // install can't fan out egress and a fiber interrupt cancels cleanly
+      // mid-cycle. Each probe is `AbortSignal.timeout`-bounded, so a slow upstream
+      // delays (but does not stall) the rest; per-install failures are contained.
+      yield* Effect.forEach(
+        rows,
+        (row) =>
+          Effect.gen(function* () {
+            const outcome = yield* Effect.tryPromise({
+              try: () => runInstall(row, nowMs, nowIso, deps),
+              catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+            }).pipe(
+              // runInstall is designed never to throw; this is belt-and-braces so a
+              // surprise defect counts as a failure rather than aborting the loop.
+              Effect.catchAll((err) =>
+                Effect.succeed({ kind: "failed" as const, error: errorMessage(err) }),
+              ),
+            );
+
+            switch (outcome.kind) {
+              case "not_due":
+                result.skippedNotDue++;
+                return;
+              case "refreshed":
+                result.due++;
+                result.refreshed++;
+                emitInstallAudit(row, "success", {
+                  operationCount: outcome.operationCount,
+                  ...driftMetadata(outcome.drift),
+                });
+                return;
+              case "probe_failed":
+                result.due++;
+                result.failed++;
+                emitInstallAudit(row, "failure", { reason: "probe_failed", probeReason: outcome.reason });
+                return;
+              case "config_skip":
+                result.due++;
+                result.skippedConfig++;
+                emitInstallAudit(row, "failure", {
+                  reason: outcome.reason,
+                  ...(outcome.detail !== undefined ? { authKind: outcome.detail } : {}),
+                });
+                return;
+              case "failed":
+                result.due++;
+                result.failed++;
+                emitInstallAudit(row, "failure", { reason: "error", error: outcome.error });
+                return;
+            }
+          }),
+        { concurrency: 1 },
+      );
+
+      log.info({ ...result }, "OpenAPI rediscover: cycle complete");
+      emitCycleAudit(result);
+      return result;
+    }),
+    (result) => ({
+      "atlas.openapi_rediscover.status": result.status,
+      "atlas.openapi_rediscover.inspected": result.inspected,
+      "atlas.openapi_rediscover.due": result.due,
+      "atlas.openapi_rediscover.refreshed": result.refreshed,
+      "atlas.openapi_rediscover.failed": result.failed,
+    }),
+  );
+
+// ---------------------------------------------------------------------------
+// Lifecycle (setInterval-based, mirrors byot-catalog-refresh.ts + openapi-spec-refresh.ts)
+// ---------------------------------------------------------------------------
+
+let _timer: ReturnType<typeof setInterval> | null = null;
+let _running = false;
+/** A still-running cycle, so a slow tick (network I/O) never overlaps the next one. */
+let _inFlight = false;
+
+function runCycleWithDefectGuard(): void {
+  if (_inFlight) {
+    log.debug("OpenAPI rediscover cycle still in flight — skipping this tick");
+    return;
+  }
+  _inFlight = true;
+  Effect.runPromise(runOpenApiInstallRediscoverCycle())
+    .catch((err: unknown) => {
+      // The cycle catches its own errors; this only fires on an unexpected defect so
+      // the loop survives and the next tick still runs.
+      log.error(
+        { err: err instanceof Error ? err.message : String(err) },
+        "OpenAPI rediscover cycle defected past its internal catch",
+      );
+    })
+    .finally(() => {
+      _inFlight = false;
+    });
+}
+
+/**
+ * Start the Tier-2 OpenAPI re-discovery scheduler. Runs an initial cycle
+ * immediately, then repeats at the configured interval. No-op if already running or
+ * if the internal DB is unavailable (it reads `workspace_plugins`). A non-positive /
+ * non-finite `intervalMs` falls back to the configured default rather than
+ * hot-looping `setInterval`.
+ */
+export function startOpenApiInstallRediscoverScheduler(intervalMs?: number): void {
+  if (_running) {
+    log.debug("OpenAPI rediscover scheduler already running — skipping start");
+    return;
+  }
+  if (!hasInternalDB()) {
+    log.debug("No internal database — OpenAPI rediscover scheduler not started");
+    return;
+  }
+
+  const interval =
+    intervalMs !== undefined && Number.isFinite(intervalMs) && intervalMs > 0
+      ? intervalMs
+      : getInstallRediscoverIntervalMs();
+  _running = true;
+  log.info({ intervalMs: interval }, "Starting OpenAPI install rediscover scheduler");
+
+  runCycleWithDefectGuard();
+  _timer = setInterval(runCycleWithDefectGuard, interval);
+  _timer.unref();
+}
+
+export function stopOpenApiInstallRediscoverScheduler(): void {
+  if (_timer) {
+    clearInterval(_timer);
+    _timer = null;
+  }
+  _running = false;
+  log.info("OpenAPI install rediscover scheduler stopped");
+}
+
+export function isOpenApiInstallRediscoverSchedulerRunning(): boolean {
+  return _running;
+}
+
+/** Test-only: reset scheduler state. */
+export function _resetOpenApiInstallRediscoverScheduler(): void {
+  stopOpenApiInstallRediscoverScheduler();
+  _inFlight = false;
+}
+
+/**
+ * Manual-trigger entry point (admin scheduler page / tests). Runs a single cycle and
+ * returns its structured result. `status` distinguishes a healthy cycle from one
+ * that died in the candidate query.
+ */
+export async function triggerOpenApiInstallRediscoverCycle(
+  opts: RediscoverCycleOptions = {},
+): Promise<RediscoverCycleResult> {
+  return Effect.runPromise(runOpenApiInstallRediscoverCycle(opts));
+}

--- a/packages/api/src/lib/scheduler/openapi-install-rediscover.ts
+++ b/packages/api/src/lib/scheduler/openapi-install-rediscover.ts
@@ -50,6 +50,14 @@
  * `openapi-spec-refresh.ts`. No-op without an internal DB (it reads
  * `workspace_plugins`).
  *
+ * Like every other per-process scheduler here (BYOT, Tier-1, semantic-expert), this
+ * takes no distributed lock — it relies on the deploy invariant that each regional
+ * API service runs `numReplicas: 1` (`deploy/README.md`: "intentional, not
+ * aspirational"). Re-discovery is idempotent regardless (a duplicate re-probe writes
+ * the same snapshot + watermark), so the worst case under an accidental scale-up is
+ * duplicate egress + audit rows, not corruption. A cross-scheduler distributed
+ * singleton is the right home for replica gating if that invariant is ever lifted.
+ *
  * @see ./byot-catalog-refresh.ts — the periodic-fiber pattern this follows.
  * @see ./openapi-spec-refresh.ts — the Tier-1 sibling this is deliberately NOT.
  * @see ../openapi/rediscover.ts — the shared re-probe → snapshot → diff core.
@@ -117,11 +125,28 @@ export type DueCandidateRow = {
 /**
  * The coarse SQL pre-filter: every non-archived generic OpenAPI datasource install,
  * across all workspaces, whose `spec_refresh_interval` is set and not `'off'`,
- * ordered least-recently-checked-first so a backlog drains fairly under the batch
- * cap. The canonical stored interval is exactly `'off'`/`'daily'`/`'weekly'`/`'<N>h'`
- * (see `normalizeSpecRefreshInterval`), so excluding `'off'` here is safe; a drifted
- * value slips through and is rejected app-side by `evaluateSpecRefreshDue` (defense
- * in depth). `$2` is the catalog id (a code constant, never client input).
+ * ordered most-overdue-first so a backlog drains fairly under the batch cap. The
+ * canonical stored interval is exactly `'off'`/`'daily'`/`'weekly'`/`'<N>h'` (see
+ * `normalizeSpecRefreshInterval`), so excluding `'off'` here is safe; a drifted value
+ * slips through and is rejected app-side by `evaluateSpecRefreshDue` (defense in
+ * depth). `$1` is the catalog id (a code constant, never client input).
+ *
+ * **Ordering matches the due-check watermark.** The order key is
+ * `GREATEST(spec_last_checked_at, openapi_snapshot.probedAt)` — the SAME effective
+ * activity `evaluateSpecRefreshDue` compares against — so a freshly-installed
+ * datasource (no watermark yet but a recent `probedAt`) sorts by its `probedAt` and
+ * does NOT crowd genuinely-overdue installs out of the batch. Ordering by the bare
+ * watermark `NULLS FIRST` would repeatedly select those not-yet-due fresh rows
+ * (which `runInstall` returns `not_due` for, without stamping), starving older due
+ * rows past the `LIMIT`. ISO-8601 strings sort lexicographically = chronologically;
+ * Postgres `GREATEST` ignores NULLs and yields NULL only when both are NULL (a
+ * never-probed install → `NULLS FIRST` → most due).
+ *
+ * **Status-only scope, by design.** This mirrors the datasource RESOLVER
+ * (`workspace-datasource.ts`, also `status != 'archived'`, NOT `enabled`): the
+ * scheduler must refresh exactly the set the agent is served, or a still-served
+ * install would carry a stale snapshot. If the resolver ever gains an `enabled`
+ * gate, this predicate must move in lockstep.
  */
 const CANDIDATE_QUERY_SQL = `SELECT workspace_id, install_id, config
      FROM workspace_plugins
@@ -130,7 +155,7 @@ const CANDIDATE_QUERY_SQL = `SELECT workspace_id, install_id, config
       AND status != 'archived'
       AND config->>'spec_refresh_interval' IS NOT NULL
       AND config->>'spec_refresh_interval' <> 'off'
-    ORDER BY config->>'spec_last_checked_at' ASC NULLS FIRST
+    ORDER BY GREATEST(config->>'spec_last_checked_at', config->'openapi_snapshot'->>'probedAt') ASC NULLS FIRST
     LIMIT $2`;
 
 async function defaultQuery(limit: number): Promise<ReadonlyArray<DueCandidateRow>> {

--- a/packages/api/src/lib/scheduler/openapi-install-rediscover.ts
+++ b/packages/api/src/lib/scheduler/openapi-install-rediscover.ts
@@ -24,8 +24,9 @@
  * Re-discovery goes through `performRediscovery` → `probeSpec`, which runs the
  * identical SSRF guard + redirect-revalidating `guardedFetch` + #3034 host-match
  * credential gate as a resolve-time probe. Scheduled probing is therefore the SAME
- * server-side egress as resolve-time, just on a timer — including the SaaS egress
- * allowlist and the per-tenant `base_url_override` host gate.
+ * server-side egress as resolve-time, just on a timer — the same fail-closed SSRF
+ * guard (private/internal targets blocked unless `ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS`
+ * opts out) and the per-tenant `base_url_override` host gate.
  *
  * ## Due-selection (per-install interval, not a global TTL)
  * Unlike `byot-catalog-refresh.ts` (one global TTL) the interval is PER INSTALL, so
@@ -219,7 +220,12 @@ type InstallOutcome =
   | { readonly kind: "refreshed"; readonly operationCount: number; readonly drift: SpecDiffSummary | null }
   | { readonly kind: "probe_failed"; readonly reason: string }
   | { readonly kind: "config_skip"; readonly reason: "decrypt_failed" | "no_url" | "unsupported_auth"; readonly detail?: string }
-  | { readonly kind: "failed"; readonly error: string };
+  // `phase` distinguishes the two failure modes, which have OPPOSITE retry
+  // semantics an operator must tell apart: `"rediscover"` (probe/normalize fault)
+  // is negative-cached (watermark stamped) → not retried until the full interval
+  // elapses; `"persist"` (a good snapshot that failed to write) is NOT stamped →
+  // retried on the very next tick.
+  | { readonly kind: "failed"; readonly phase: "rediscover" | "persist"; readonly error: string };
 
 interface CycleDeps {
   readonly rediscover: RediscoverFn;
@@ -272,7 +278,7 @@ async function runInstall(
     // Unexpected fault during re-probe/normalize — fail-soft: negative-cache it,
     // leave the live snapshot intact.
     await safeStamp(deps, row, nowIso);
-    return { kind: "failed", error: errorMessage(err) };
+    return { kind: "failed", phase: "rediscover", error: errorMessage(err) };
   }
 
   switch (result.kind) {
@@ -288,8 +294,15 @@ async function runInstall(
       } catch (err) {
         // The re-probe succeeded but persisting the fresh snapshot failed. Do NOT
         // stamp the watermark — leaving it stale means the next tick retries the
-        // persist instead of negatively-caching a half-applied refresh.
-        return { kind: "failed", error: errorMessage(err) };
+        // persist instead of negatively-caching a half-applied refresh. Log it
+        // directly: unlike the negative-cached paths this one retries immediately,
+        // and we're discarding a good snapshot, so a sustained DB problem should be
+        // visible beyond the audit row (which writes to the same DB that just failed).
+        log.warn(
+          { workspaceId: row.workspace_id, installId: row.install_id, err: errorMessage(err) },
+          "OpenAPI rediscover: persisting a freshly re-probed snapshot failed — discarding it, will retry next tick",
+        );
+        return { kind: "failed", phase: "persist", error: errorMessage(err) };
       }
       return { kind: "refreshed", operationCount: result.snapshot.operationCount, drift: result.drift };
     case "probe_failed":
@@ -504,8 +517,10 @@ export const runOpenApiInstallRediscoverCycle = (
             }).pipe(
               // runInstall is designed never to throw; this is belt-and-braces so a
               // surprise defect counts as a failure rather than aborting the loop.
+              // Phase it "rediscover": runInstall stamps internally on its own fault
+              // paths, so a defect that escapes it left nothing persisted.
               Effect.catchAll((err) =>
-                Effect.succeed({ kind: "failed" as const, error: errorMessage(err) }),
+                Effect.succeed({ kind: "failed" as const, phase: "rediscover" as const, error: errorMessage(err) }),
               ),
             );
 
@@ -537,7 +552,12 @@ export const runOpenApiInstallRediscoverCycle = (
               case "failed":
                 result.due++;
                 result.failed++;
-                emitInstallAudit(row, "failure", { reason: "error", error: outcome.error });
+                // Surface the retry semantics in the audit `reason`: `persist_failed`
+                // retries next tick; `rediscover_fault` is deferred a full interval.
+                emitInstallAudit(row, "failure", {
+                  reason: outcome.phase === "persist" ? "persist_failed" : "rediscover_fault",
+                  error: outcome.error,
+                });
                 return;
             }
           }),


### PR DESCRIPTION
## What

Implements **#2978** (v0.0.3 — Spec Lifecycle): a Tier-2, per-install periodic scheduler that keeps each installed `openapi-generic` datasource's persisted spec snapshot current — the **automated sibling of the manual "Refresh now"** (#3002).

On a timer it walks every install whose per-install `spec_refresh_interval` (#2977) has elapsed since its last check, re-probes the spec endpoint, re-normalizes to an `OperationGraph`, updates the persisted snapshot, records the structured drift diff (#2976), and bumps a new `spec_last_checked_at` watermark.

### Scope boundary (Tier-2, not Tier-1)
- `scheduler/openapi-spec-refresh.ts` (#2970) is the **Tier-1 SHARED cross-workspace cache** refresh — conditional-GETs public catalog specs, **never mutates a workspace snapshot**. Left untouched.
- This is **Tier-2**: per-install, customer-configurable, **mutates the persisted per-install snapshot** + records a drift diff. New, orthogonal loop — exactly the arm the Tier-1 docstring names.

## How

- **Shared core** `lib/openapi/rediscover.ts` — `performRediscovery` (decrypt → auth → `probeSpec` → snapshot → diff, discriminated result) + `persistRediscoverySnapshot` + `stampSpecLastChecked`. The manual route is refactored to call it; its HTTP responses, persist SQL, cache eviction, and audit are **byte-for-byte unchanged** (route shrinks ~120 lines). Because re-discovery flows through the same `probeSpec`, scheduled probing inherits the **identical SSRF guard + redirect-revalidating fetch + #3034 host-match credential gate + SaaS egress allowlist** as resolve-time — sharing the path is what prevents divergence.
- **Due-selection** — the interval is *per-install*, so a single SQL `now() - interval` gate doesn't fit. A coarse SQL pre-filter selects non-`off` candidates (ordered least-recently-checked-first, batch-bounded); the precise "elapsed?" decision is `evaluateSpecRefreshDue` (new, in `spec-refresh.ts`) against `max(spec_last_checked_at, snapshot.probedAt)` — so a fresh install **and** a manual "Refresh now" both reset the clock without the route having to write the watermark.
- **Fail-soft** — a down/slow upstream (probe is `AbortSignal.timeout`-bounded) stamps the watermark (persisted negative-cache → not re-probed until its interval elapses again) and **leaves the live snapshot intact**; a persist failure deliberately does **not** stamp, so the next tick retries rather than caching a half-applied refresh. Per-install failures never abort the loop or the workspace's other installs.
- **Observability** — per-install `connection.probe` audit rows (`triggeredBy: "scheduler"`, so an operator filtering by install id sees manual + scheduled uniformly) + a per-tick `connection.spec_refresh_cycle` row (scheduler-stopped forensic invariant, mirrors BYOT). Global tick env-tunable via `ATLAS_OPENAPI_REDISCOVER_INTERVAL_HOURS` (default 1h, mirrors `getExpertSchedulerIntervalMs`).
- **Wiring** — start + finalizer-stop in the startup Layer DAG, alongside the Tier-1 fiber; `setInterval` + `unref()` + single-running + in-flight overlap guards, no-op without an internal DB.
- **No migration** — the watermark lives in `workspace_plugins.config` JSONB (selective-field pattern), like `spec_refresh_interval` and `openapi_last_diff`.

## Acceptance criteria
- [x] Selects installs whose interval has elapsed since last check and re-discovers each (re-probe → snapshot update → watermark bump)
- [x] `off` installs are never auto-refreshed; global tick interval is env-configurable
- [x] Slow/failing upstream fails soft for that install (negative-cache/skip) without stalling the loop or other installs; a failed scheduled probe never overwrites/degrades the live snapshot
- [x] Per-install last-checked + outcome observable (per-install + cycle audit rows, pino)
- [x] Tests over: due-selection, off-skip, fail-soft on a down upstream, watermark bump on success

## Tests
New: scheduler cycle + lifecycle (`openapi-install-rediscover.test.ts`), `evaluateSpecRefreshDue`/`parseIsoToMs` units, and the real watermark-write SQL helpers (`rediscover.test.ts`). Existing `admin-openapi-datasources.test.ts` stays green through the refactor.

`/ci`: lint, type, **test (api 537 files / 0 failed + others)**, syncpack, template/security/railway/schema/oauth drift, test-discipline, twenty-resolver, published-symbols — all pass. `main` CI + Railway staging green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3046"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782836475&installation_id=135337507&pr_number=3046&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3046&signature=612600d3947c6513d6622ae5e1eb1e6df0a9c210fa69432ecbbe4f94d5260826"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shared OpenAPI rediscovery core and a background scheduler to periodically rediscover per-install specs, persist snapshots/diffs, and emit audited cycle summaries.
  * New audit action for scheduler-driven spec refresh cycles.

* **Configuration**
  * New env option to control rediscovery interval in hours.

* **Documentation**
  * Example env file updated to document the new interval setting.

* **Tests**
  * Expanded unit and integration tests covering rediscovery, scheduling, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->