### PR TITLE
fix(api): derive WebAuthn rpID from web origin, fail loud on mismatch (#3045)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -117,9 +117,17 @@ ATLAS_ADMIN_EMAIL=admin@useatlas.dev
 #                                         # overridable via env by design.
 # ATLAS_MFA_ISSUER=Atlas                  # Issuer label shown in TOTP authenticator apps when users
 #                                         # enroll an MFA device. Default: "Atlas".
-# ATLAS_RPID=app.useatlas.dev             # WebAuthn Relying Party ID — the registrable domain that
-#                                         # passkeys are bound to. Self-hosted: set to your auth domain.
-#                                         # Changing this AFTER passkeys are enrolled invalidates them.
+# ATLAS_RPID=app.useatlas.dev             # WebAuthn Relying Party ID — the registrable domain passkeys are
+#                                         # bound to. When UNSET, it is derived from the configured web origin's
+#                                         # host (first ATLAS_CORS_ORIGIN entry, then BETTER_AUTH_TRUSTED_ORIGINS):
+#                                         # prod → app.useatlas.dev, staging → app.staging.useatlas.dev, localhost → localhost.
+#                                         # If no web origin is configured, falls back to app.useatlas.dev.
+#                                         # Boot FAILS LOUD if the effective rpID isn't valid for the web origin
+#                                         # (must equal the origin host or be a parent domain) — no silent browser breakage.
+#                                         # SaaS multi-region: ALWAYS set this explicitly so a reorder of
+#                                         # ATLAS_CORS_ORIGIN can't shift the derived value. Self-hosted on a custom
+#                                         # domain: set to your auth domain. Changing this AFTER passkeys are
+#                                         # enrolled invalidates every enrolled passkey.
 # ATLAS_RPNAME=Atlas                      # Human-readable string the OS shows in the passkey prompt
 #                                         # ("Use your saved passkey for <ATLAS_RPNAME>?"). Default: "Atlas".
 # ATLAS_ABUSE_QUERY_RATE=200              # Max queries per workspace per sliding window (abuse prevention)

--- a/packages/api/src/lib/__tests__/startup.test.ts
+++ b/packages/api/src/lib/__tests__/startup.test.ts
@@ -64,6 +64,8 @@ const MANAGED_VARS = [
   "BETTER_AUTH_SECRET",
   "BETTER_AUTH_URL",
   "BETTER_AUTH_TRUSTED_ORIGINS",
+  "ATLAS_CORS_ORIGIN",
+  "ATLAS_RPID",
   "ATLAS_AUTH_JWKS_URL",
   "ATLAS_AUTH_ISSUER",
   "ATLAS_AUTH_AUDIENCE",
@@ -91,6 +93,8 @@ beforeEach(() => {
   delete process.env.BETTER_AUTH_SECRET;
   delete process.env.BETTER_AUTH_URL;
   delete process.env.BETTER_AUTH_TRUSTED_ORIGINS;
+  delete process.env.ATLAS_CORS_ORIGIN;
+  delete process.env.ATLAS_RPID;
   delete process.env.ATLAS_AUTH_JWKS_URL;
   delete process.env.ATLAS_AUTH_ISSUER;
   delete process.env.ATLAS_AUTH_AUDIENCE;
@@ -225,6 +229,51 @@ describe("auth diagnostics — mode managed", () => {
     const dbErr = errors.find((e) => e.code === "INTERNAL_DB_UNREACHABLE");
     expect(dbErr).toBeDefined();
     expect(dbErr!.message).toContain("session storage");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Auth mode: managed — WebAuthn rpID validity (#3045)
+//
+// The passkey rpID throw lives in buildPlugins() (lazy / boot-migration, where
+// the migration path swallows it into a generic log), so startup diagnostics
+// resolve the same env/origin pair eagerly and surface an actionable error.
+// ---------------------------------------------------------------------------
+
+describe("auth diagnostics — mode managed — rpID (#3045)", () => {
+  beforeEach(() => {
+    delete process.env.ATLAS_API_KEY;
+    delete process.env.ATLAS_AUTH_JWKS_URL;
+    delete process.env.ATLAS_AUTH_ISSUER;
+    process.env.BETTER_AUTH_SECRET = "a".repeat(32); // managed mode, valid secret
+  });
+
+  it("reports INVALID_RP_ID when explicit ATLAS_RPID can't be valid for the web origin", async () => {
+    process.env.BETTER_AUTH_TRUSTED_ORIGINS = "https://app.staging.useatlas.dev";
+    process.env.ATLAS_RPID = "app.useatlas.dev"; // prod rpID on a staging origin
+
+    const errors = await validateEnvironment();
+    const rpErr = errors.find((e) => e.code === "INVALID_RP_ID");
+    expect(rpErr).toBeDefined();
+    expect(rpErr!.message).toContain("app.staging.useatlas.dev"); // the origin host
+    expect(rpErr!.message).toContain("ATLAS_RPID"); // the env var to fix
+  });
+
+  it("no INVALID_RP_ID when ATLAS_RPID is unset (derived from origin)", async () => {
+    process.env.BETTER_AUTH_TRUSTED_ORIGINS = "https://app.staging.useatlas.dev";
+    delete process.env.ATLAS_RPID;
+
+    const errors = await validateEnvironment();
+    expect(errors.some((e) => e.code === "INVALID_RP_ID")).toBe(false);
+  });
+
+  it("no INVALID_RP_ID when no web origin is configured (single-origin / self-hosted)", async () => {
+    delete process.env.BETTER_AUTH_TRUSTED_ORIGINS;
+    delete process.env.ATLAS_CORS_ORIGIN;
+    process.env.ATLAS_RPID = "auth.example.com"; // arbitrary, but nothing to validate against
+
+    const errors = await validateEnvironment();
+    expect(errors.some((e) => e.code === "INVALID_RP_ID")).toBe(false);
   });
 });
 

--- a/packages/api/src/lib/auth/__tests__/server.test.ts
+++ b/packages/api/src/lib/auth/__tests__/server.test.ts
@@ -9,6 +9,8 @@ import {
   assertInvitationRoleAllowed,
   isTransportError,
   buildPlugins,
+  resolvePasskeyRpId,
+  DEFAULT_RP_ID,
 } from "../server";
 
 describe("Better Auth instance shape", () => {
@@ -187,5 +189,121 @@ describe("organization plugin wiring", () => {
     const plugins = buildPlugins();
     const org = plugins.find((p: { id?: string }) => p.id === "organization");
     expect(org).toBeDefined();
+  });
+});
+
+// #3045 — WebAuthn rpID silently defaulted to the prod domain on every deploy
+// whose ATLAS_RPID was unset, breaking passkeys with an opaque browser error
+// on staging / self-hosted custom domains / preview envs. The resolver derives
+// the rpID from the configured web origin when ATLAS_RPID is unset and fails
+// loud at boot when the effective rpID can't be valid for that origin.
+//
+// resolvePasskeyRpId takes (env, webOrigin) explicitly so these cases are pure
+// — no process.env / getWebOrigin() mutation, no shared-state leakage between
+// the subprocess-isolated test files.
+describe("resolvePasskeyRpId (#3045)", () => {
+  describe("ATLAS_RPID unset → derive from the web origin host", () => {
+    it("prod web origin derives app.useatlas.dev — unchanged from the legacy default, no passkey invalidation", () => {
+      expect(resolvePasskeyRpId({}, "https://app.useatlas.dev")).toBe("app.useatlas.dev");
+      // The pre-#3045 hardcoded default; deriving must reproduce it exactly so
+      // no enrolled prod passkey is invalidated.
+      expect(resolvePasskeyRpId({}, "https://app.useatlas.dev")).toBe(DEFAULT_RP_ID);
+    });
+
+    it("staging web origin derives app.staging.useatlas.dev (the value silently wrong before)", () => {
+      expect(resolvePasskeyRpId({}, "https://app.staging.useatlas.dev")).toBe(
+        "app.staging.useatlas.dev",
+      );
+    });
+
+    it("localhost dev origin derives localhost — passkeys now work locally without an explicit override", () => {
+      expect(resolvePasskeyRpId({}, "http://localhost:3000")).toBe("localhost");
+    });
+
+    it("an empty ATLAS_RPID is treated as unset (falls through to derive)", () => {
+      expect(resolvePasskeyRpId({ ATLAS_RPID: "" }, "https://app.staging.useatlas.dev")).toBe(
+        "app.staging.useatlas.dev",
+      );
+      expect(resolvePasskeyRpId({ ATLAS_RPID: "   " }, "https://app.staging.useatlas.dev")).toBe(
+        "app.staging.useatlas.dev",
+      );
+    });
+  });
+
+  describe("explicit ATLAS_RPID always overrides", () => {
+    it("explicit value wins over the derived origin host", () => {
+      // Origin host is app.useatlas.dev (what derivation would pick), but the
+      // operator pins the parent domain — the explicit value must win.
+      expect(
+        resolvePasskeyRpId({ ATLAS_RPID: "useatlas.dev" }, "https://app.useatlas.dev"),
+      ).toBe("useatlas.dev");
+    });
+
+    it("explicit value is trimmed", () => {
+      expect(
+        resolvePasskeyRpId({ ATLAS_RPID: "  app.useatlas.dev  " }, "https://app.useatlas.dev"),
+      ).toBe("app.useatlas.dev");
+    });
+  });
+
+  describe("registrable-domain suffix is valid", () => {
+    it("a parent domain of the origin host is accepted", () => {
+      // useatlas.dev is a registrable-domain suffix of app.staging.useatlas.dev.
+      expect(
+        resolvePasskeyRpId({ ATLAS_RPID: "useatlas.dev" }, "https://app.staging.useatlas.dev"),
+      ).toBe("useatlas.dev");
+      expect(
+        resolvePasskeyRpId({ ATLAS_RPID: "staging.useatlas.dev" }, "https://app.staging.useatlas.dev"),
+      ).toBe("staging.useatlas.dev");
+    });
+  });
+
+  describe("invalid explicit rpID for the web origin → fail loud at boot", () => {
+    it("prod rpID on a staging origin throws an actionable error", () => {
+      expect(() =>
+        resolvePasskeyRpId({ ATLAS_RPID: "app.useatlas.dev" }, "https://app.staging.useatlas.dev"),
+      ).toThrow(/not valid for the configured web origin/);
+    });
+
+    it("error names both the rpID and the origin host, and how to fix it", () => {
+      try {
+        resolvePasskeyRpId({ ATLAS_RPID: "app.useatlas.dev" }, "https://app.staging.useatlas.dev");
+        throw new Error("expected resolvePasskeyRpId to throw");
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        expect(message).toContain("app.useatlas.dev"); // the bad rpID
+        expect(message).toContain("app.staging.useatlas.dev"); // the origin host
+        expect(message).toContain("ATLAS_RPID"); // the env var to fix
+      }
+    });
+
+    it("an unrelated registrable domain throws (suffix without a dot boundary is not a match)", () => {
+      // "useatlas.dev" must NOT validate against "notuseatlas.dev" — a plain
+      // endsWith would falsely accept it; the dot-boundary check rejects it.
+      expect(() =>
+        resolvePasskeyRpId({ ATLAS_RPID: "useatlas.dev" }, "https://notuseatlas.dev"),
+      ).toThrow(/not valid for the configured web origin/);
+    });
+  });
+
+  describe("no web origin configured → legacy default, never a hard-fail", () => {
+    it("null web origin + ATLAS_RPID unset → legacy default, no throw", () => {
+      expect(resolvePasskeyRpId({}, null)).toBe(DEFAULT_RP_ID);
+    });
+
+    it("null web origin + explicit ATLAS_RPID → explicit wins, no assertion", () => {
+      // Self-hosted single-origin: nothing to validate against, so even an
+      // arbitrary explicit value is honored rather than rejected.
+      expect(resolvePasskeyRpId({ ATLAS_RPID: "auth.example.com" }, null)).toBe("auth.example.com");
+    });
+
+    it("malformed web origin is treated as no-origin (no throw, no validation)", () => {
+      // A bad CORS/trusted-origin entry surfaces through CORS itself; the rpID
+      // resolver degrades to the explicit/default value rather than crashing.
+      expect(resolvePasskeyRpId({ ATLAS_RPID: "auth.example.com" }, "not-a-url")).toBe(
+        "auth.example.com",
+      );
+      expect(resolvePasskeyRpId({}, "not-a-url")).toBe(DEFAULT_RP_ID);
+    });
   });
 });

--- a/packages/api/src/lib/auth/__tests__/server.test.ts
+++ b/packages/api/src/lib/auth/__tests__/server.test.ts
@@ -342,4 +342,25 @@ describe("resolvePasskeyRpId (#3045)", () => {
       );
     });
   });
+
+  describe("IP-literal origin → resolves but does not throw (passkeys can't work on an IP)", () => {
+    it("an IPv4 origin derives the IP rpID without throwing (suffix-equal), logged loud elsewhere", () => {
+      // WebAuthn rpIDs can't be IPs, so passkeys are effectively disabled here —
+      // but we must NOT throw (that would break non-passkey managed auth for a
+      // dev on an IP host, and there's no valid rpID to substitute).
+      expect(resolvePasskeyRpId({}, "http://127.0.0.1:3000")).toBe("127.0.0.1");
+      expect(resolvePasskeyRpId({}, "http://192.168.1.50:3000")).toBe("192.168.1.50");
+    });
+
+    it("an explicit IP rpID matching an IP origin resolves without throwing", () => {
+      expect(resolvePasskeyRpId({ ATLAS_RPID: "127.0.0.1" }, "http://127.0.0.1:3000")).toBe(
+        "127.0.0.1",
+      );
+    });
+
+    it("localhost (a name, not an IP) derives normally", () => {
+      // Regression guard: the IP check must not catch the valid `localhost` rpID.
+      expect(resolvePasskeyRpId({}, "http://localhost:3000")).toBe("localhost");
+    });
+  });
 });

--- a/packages/api/src/lib/auth/__tests__/server.test.ts
+++ b/packages/api/src/lib/auth/__tests__/server.test.ts
@@ -258,6 +258,30 @@ describe("resolvePasskeyRpId (#3045)", () => {
     });
   });
 
+  describe("hostname comparison is case-insensitive (DNS)", () => {
+    it("a mixed-case explicit rpID is valid for a lowercase origin host — no false-positive fail-loud", () => {
+      // new URL().hostname lowercases the origin host; the operator-typed
+      // explicit value may carry case. The boot assertion must compare
+      // case-insensitively or it would wrongly refuse to boot a correctly
+      // configured deploy. The returned value is left verbatim (rpID stability).
+      expect(
+        resolvePasskeyRpId({ ATLAS_RPID: "App.UseAtlas.DEV" }, "https://app.useatlas.dev"),
+      ).toBe("App.UseAtlas.DEV");
+      expect(
+        resolvePasskeyRpId({ ATLAS_RPID: "UseAtlas.DEV" }, "https://app.staging.useatlas.dev"),
+      ).toBe("UseAtlas.DEV");
+    });
+
+    it("a mixed-case origin host derives a lowercase rpID (URL normalization is pinned)", () => {
+      // Locks in that derivation goes through new URL().hostname (which
+      // lowercases) — a future refactor to raw string slicing would silently
+      // shift the rpID and invalidate enrolled keys.
+      expect(resolvePasskeyRpId({}, "https://App.Staging.UseAtlas.DEV")).toBe(
+        "app.staging.useatlas.dev",
+      );
+    });
+  });
+
   describe("invalid explicit rpID for the web origin → fail loud at boot", () => {
     it("prod rpID on a staging origin throws an actionable error", () => {
       expect(() =>
@@ -297,13 +321,25 @@ describe("resolvePasskeyRpId (#3045)", () => {
       expect(resolvePasskeyRpId({ ATLAS_RPID: "auth.example.com" }, null)).toBe("auth.example.com");
     });
 
-    it("malformed web origin is treated as no-origin (no throw, no validation)", () => {
-      // A bad CORS/trusted-origin entry surfaces through CORS itself; the rpID
-      // resolver degrades to the explicit/default value rather than crashing.
+    it("unparseable web origin is treated as no-origin (no throw, no validation)", () => {
+      // An unparseable CORS/trusted-origin entry can't be validated against;
+      // the resolver logs at error level and degrades to the explicit/default
+      // value rather than crashing.
       expect(resolvePasskeyRpId({ ATLAS_RPID: "auth.example.com" }, "not-a-url")).toBe(
         "auth.example.com",
       );
       expect(resolvePasskeyRpId({}, "not-a-url")).toBe(DEFAULT_RP_ID);
+    });
+
+    it("scheme-less host:port origin parses to an empty host → no-origin, no throw", () => {
+      // "app.example.com:3000" parses as protocol "app.example.com:" with an
+      // empty hostname — not the validatable case, so validation is skipped
+      // (logged at error level) and an explicit-but-arbitrary value is honored
+      // rather than triggering a false fail-loud.
+      expect(resolvePasskeyRpId({}, "app.example.com:3000")).toBe(DEFAULT_RP_ID);
+      expect(resolvePasskeyRpId({ ATLAS_RPID: "auth.example.com" }, "localhost:3000")).toBe(
+        "auth.example.com",
+      );
     });
   });
 });

--- a/packages/api/src/lib/auth/rpid.ts
+++ b/packages/api/src/lib/auth/rpid.ts
@@ -1,0 +1,202 @@
+/**
+ * WebAuthn Relying Party ID (`rpID`) resolution for the passkey plugin.
+ *
+ * Extracted from `server.ts` so the resolver stays a pure, dependency-light
+ * unit (no `better-auth` import): it's consumed both at auth-instance
+ * construction (`buildPlugins` in `server.ts`) and eagerly at startup
+ * (`checkManagedAuthMode` in `startup.ts`), so neither path has to drag the
+ * Better Auth module graph around to validate the rpID. See #3045.
+ */
+
+import { createLogger } from "@atlas/api/lib/logger";
+
+const log = createLogger("auth:rpid");
+
+/**
+ * Legacy WebAuthn rpID default. Retained as the fallback for single-origin /
+ * self-hosted deploys that configure neither `ATLAS_CORS_ORIGIN` nor
+ * `BETTER_AUTH_TRUSTED_ORIGINS` — there is no web origin to derive from, so
+ * preserving the historical value keeps minimal setups working unchanged.
+ * Prod also resolves to exactly this string, but *because* its first
+ * `ATLAS_CORS_ORIGIN` entry is `https://app.useatlas.dev` (deploy/README.md) —
+ * so the derive path below is a no-op for prod only as long as that stays
+ * true. If prod ever prepends a different origin, the derived rpID shifts and
+ * `ATLAS_RPID` must be pinned explicitly to avoid invalidating enrolled keys.
+ */
+export const DEFAULT_RP_ID = "app.useatlas.dev";
+
+/**
+ * WebAuthn's "registrable domain suffix of, or equal to" rule: `rpID` is valid
+ * for `host` when it equals the host or is a parent domain (dot-boundary
+ * suffix) of it — e.g. `useatlas.dev` is valid for `app.staging.useatlas.dev`,
+ * but `app.useatlas.dev` is NOT (the exact footgun this module fixes: prod's
+ * rpID silently inherited on a staging host).
+ *
+ * No public-suffix-list awareness (same caveat as `deriveCookieDomain`): a
+ * plain dotted-label check. Atlas's app host and rpID are always the same
+ * registrable domain, and the browser is the backstop for a pathological rpID
+ * like a bare public suffix.
+ */
+function isRegistrableDomainSuffixOrEqual(rpID: string, host: string): boolean {
+  // Hostnames are case-insensitive (DNS), and browsers lowercase the rpID
+  // before matching it against the page origin — so compare case-insensitively.
+  // An explicit `ATLAS_RPID=App.useatlas.dev` is valid for origin host
+  // `app.useatlas.dev` and must NOT trip the boot assertion. (`originHost` is
+  // already lowercased by `new URL().hostname`; only the operator-typed
+  // explicit rpID can carry case. The *returned* rpID is left verbatim — see
+  // `resolvePasskeyRpId` — so this comparison never mutates the enrolled value.)
+  const r = rpID.toLowerCase();
+  const h = host.toLowerCase();
+  if (r === h) return true;
+  return h.endsWith(`.${r}`);
+}
+
+/**
+ * True when `host` is an IP literal rather than a domain name. WebAuthn rpIDs
+ * MUST be domain names — an IP can never be a valid rpID — so an IP-derived (or
+ * explicitly-IP) rpID means passkeys will fail in the browser regardless of
+ * what we return. We detect it so the caller can surface a loud, actionable
+ * boot signal instead of letting it fail silently in the ceremony.
+ *
+ * `new URL().hostname` keeps IPv6 literals bracketed (`[::1]`), so the colon /
+ * bracket test catches them; the dotted-quad test catches IPv4 (`127.0.0.1`).
+ * `localhost` is a *name*, not an IP, and is a valid rpID, so it is not matched.
+ */
+function isIpLiteralHost(host: string): boolean {
+  if (host.includes(":") || host.startsWith("[")) return true; // IPv6 literal
+  return /^\d{1,3}(\.\d{1,3}){3}$/.test(host); // dotted IPv4
+}
+
+/**
+ * Extract the host from a configured web origin so the rpID can be validated
+ * against it, or `null` (with a loud error log) when the origin is unusable.
+ *
+ * `getWebOrigin()` returns the operator's raw `ATLAS_CORS_ORIGIN` /
+ * `BETTER_AUTH_TRUSTED_ORIGINS` entry — it does NOT guarantee an absolute URL.
+ * Two realistic misconfigurations yield no host: a scheme-less bare host
+ * (`new URL` throws) and a scheme-less host:port like `app.example.com:3000`
+ * (`new URL` parses it as a protocol, leaving `hostname === ""`). Both mean
+ * the rpID can't be validated, so a wrong rpID would still break passkeys in
+ * the browser — exactly the silent failure this module exists to prevent.
+ * We log at error level (not warn — this belongs above boot noise) and name
+ * the consequence + fix, then return null so the caller degrades to the
+ * explicit/default rpID rather than crashing. This is the only logged path;
+ * the caller does not double-log.
+ */
+function parseOriginHostForRpId(webOrigin: string): string | null {
+  let host: string;
+  try {
+    host = new URL(webOrigin).hostname;
+  } catch (err) {
+    log.error(
+      { webOrigin, err: err instanceof Error ? err.message : String(err) },
+      "Configured web origin is not a parseable absolute URL while resolving the WebAuthn rpID — "
+        + "the rpID can't be validated against it, so a wrong rpID will break passkeys in the browser "
+        + "with no further server signal. Ensure the first ATLAS_CORS_ORIGIN / BETTER_AUTH_TRUSTED_ORIGINS "
+        + "entry includes the scheme (e.g. https://app.example.com).",
+    );
+    return null;
+  }
+  if (!host) {
+    log.error(
+      { webOrigin },
+      "Configured web origin has no host while resolving the WebAuthn rpID (scheme missing? — a value "
+        + 'like "app.example.com:3000" parses as a protocol, not a host) — the rpID can\'t be validated '
+        + "against it, so a wrong rpID will break passkeys in the browser with no further server signal. "
+        + "Ensure the first ATLAS_CORS_ORIGIN / BETTER_AUTH_TRUSTED_ORIGINS entry includes the scheme "
+        + "(e.g. https://app.example.com).",
+    );
+    return null;
+  }
+  return host;
+}
+
+/**
+ * Resolve the WebAuthn Relying Party ID (`rpID`) for the passkey plugin, and
+ * fail loud if it can't possibly be valid for the deploy's web origin.
+ *
+ * `rpID` is the registrable domain a passkey is bound to. It MUST stay stable
+ * across enrollment — changing the *effective* value invalidates every passkey
+ * already registered (see the comment above the `passkey({...})` call in
+ * `server.ts`). The resolution order is therefore deliberately conservative:
+ *
+ *   1. Explicit `ATLAS_RPID` always wins. SaaS multi-region deploys MUST set
+ *      it so a reorder of `ATLAS_CORS_ORIGIN` (which `getWebOrigin()` reads)
+ *      can never shift the derived rpID out from under enrolled keys.
+ *   2. Otherwise derive it from the configured web origin's host
+ *      (`getWebOrigin()` — first `ATLAS_CORS_ORIGIN`, then the first trusted
+ *      origin). Prod's app origin is `https://app.useatlas.dev`, so the
+ *      derived value is exactly `app.useatlas.dev` — identical to the old
+ *      hardcoded default, so no prod passkey is invalidated. Staging now
+ *      derives `app.staging.useatlas.dev` instead of silently inheriting
+ *      prod's rpID and breaking every staging passkey.
+ *   3. If no web origin is configured (single-origin / self-hosted with
+ *      neither var set), fall back to {@link DEFAULT_RP_ID} so minimal setups
+ *      keep working unchanged — no hard-fail.
+ *
+ * The failure this guards against — `The RP ID "..." is invalid for this
+ * domain` — fires only at ceremony time, in the user's browser, with no
+ * boot-time signal. So whenever a web origin IS configured we assert the
+ * effective rpID is valid for it and throw with an actionable message
+ * otherwise. (This is stronger than the cross-origin cookie-domain check in
+ * `getAuthInstance()`, which only `log.warn`s — a wrong rpID can't work at
+ * all, so it warrants a hard fail.) A bogus *explicit* `ATLAS_RPID` is caught
+ * here too; the derived path can never produce an invalid value, so unset
+ * deploys never throw. Hostnames aren't secrets (CLAUDE.md), so they're safe
+ * to log/surface.
+ *
+ * Throwing alone isn't a true hard boot-fail — `buildPlugins()` runs lazily
+ * (first managed-auth request / boot migration), and the migration path
+ * catches the throw into a generic log. So `checkManagedAuthMode` in
+ * `startup.ts` ALSO calls this and turns a throw into a startup diagnostic,
+ * surfacing the actionable message eagerly on `/health` and route 503s.
+ */
+export function resolvePasskeyRpId(env: NodeJS.ProcessEnv, webOrigin: string | null): string {
+  const explicit = env.ATLAS_RPID?.trim();
+
+  // The web origin's host, when one is configured and usable. A configured but
+  // UNUSABLE origin (unparseable, or scheme-less so `new URL` yields an empty
+  // host — e.g. "app.example.com:3000" parses as a protocol, not a host) is a
+  // misconfiguration, NOT the "no origin configured" minimal-setup case — so
+  // `parseOriginHostForRpId` logs it at error level with the consequence
+  // spelled out, rather than letting it slip past as a silent null. We still
+  // degrade to the explicit/default rpID (no host → nothing to validate
+  // against → can't assert), but the boot log is loud instead of silent.
+  const originHost = webOrigin ? parseOriginHostForRpId(webOrigin) : null;
+
+  // 1. explicit env  >  2. derive from origin host  >  3. legacy default.
+  const rpID = explicit || originHost || DEFAULT_RP_ID;
+
+  // Fail loud when the effective rpID cannot be valid for the configured
+  // origin. Only reachable when an origin is configured AND parseable; the
+  // derived path always equals originHost (so always passes), meaning in
+  // practice this only trips on an explicit-but-wrong ATLAS_RPID.
+  if (originHost && !isRegistrableDomainSuffixOrEqual(rpID, originHost)) {
+    throw new Error(
+      `WebAuthn rpID "${rpID}" is not valid for the configured web origin "${webOrigin}" `
+        + `(host "${originHost}"): rpID must equal the origin host or be a parent domain of it. `
+        + (explicit
+          ? `ATLAS_RPID="${explicit}" is set explicitly but is not a registrable-domain suffix of `
+            + `the origin — set ATLAS_RPID to "${originHost}" (or a parent domain), or correct the `
+            + `first ATLAS_CORS_ORIGIN / BETTER_AUTH_TRUSTED_ORIGINS entry.`
+          : `Set ATLAS_RPID explicitly to "${originHost}" (or a parent domain), or correct the web origin.`),
+    );
+  }
+
+  // An IP-literal rpID passes the suffix check (it equals the origin host) but
+  // can never work — WebAuthn rejects IP rpIDs in the browser. We don't throw
+  // (that would break non-passkey managed auth for a dev on an IP host, and
+  // there's no valid rpID to substitute when the page itself is served from an
+  // IP), but we surface it loudly so the operator isn't left chasing an opaque
+  // browser error. Serve the app from a hostname (e.g. `localhost`) to fix it.
+  if (isIpLiteralHost(rpID)) {
+    log.error(
+      { rpID, webOrigin },
+      "Resolved WebAuthn rpID is an IP address — rpIDs must be domain names, not IPs, so passkeys "
+        + "will fail in the browser regardless. Serve the app from a hostname (e.g. localhost in dev) "
+        + "or set ATLAS_RPID to a registrable domain; passkeys are effectively disabled for this origin.",
+    );
+  }
+
+  return rpID;
+}

--- a/packages/api/src/lib/auth/server.ts
+++ b/packages/api/src/lib/auth/server.ts
@@ -744,6 +744,107 @@ export function deriveCookieDomain(
 }
 
 /**
+ * Legacy WebAuthn rpID default. Retained as the fallback for single-origin /
+ * self-hosted deploys that configure neither `ATLAS_CORS_ORIGIN` nor
+ * `BETTER_AUTH_TRUSTED_ORIGINS` — there is no web origin to derive from, so
+ * preserving the historical value keeps minimal setups working unchanged.
+ * Prod also resolves to exactly this string (its web origin host IS
+ * `app.useatlas.dev`), so the derive path below is a no-op for prod.
+ */
+export const DEFAULT_RP_ID = "app.useatlas.dev";
+
+/**
+ * WebAuthn's "registrable domain suffix of, or equal to" rule: `rpID` is valid
+ * for `host` when it equals the host or is a parent domain (dot-boundary
+ * suffix) of it — e.g. `useatlas.dev` is valid for `app.staging.useatlas.dev`,
+ * but `app.useatlas.dev` is NOT (the exact footgun this module fixes: prod's
+ * rpID silently inherited on a staging host).
+ *
+ * No public-suffix-list awareness (same caveat as `deriveCookieDomain`): a
+ * plain dotted-label check. Atlas's app host and rpID are always the same
+ * registrable domain, and the browser is the backstop for a pathological rpID
+ * like a bare public suffix.
+ */
+function isRegistrableDomainSuffixOrEqual(rpID: string, host: string): boolean {
+  if (rpID === host) return true;
+  return host.endsWith(`.${rpID}`);
+}
+
+/**
+ * Resolve the WebAuthn Relying Party ID (`rpID`) for the passkey plugin, and
+ * fail loud at boot if it can't possibly be valid for the deploy's web origin.
+ *
+ * `rpID` is the registrable domain a passkey is bound to. It MUST stay stable
+ * across enrollment — changing the *effective* value invalidates every passkey
+ * already registered (see the comment above the `passkey({...})` call). The
+ * resolution order is therefore deliberately conservative:
+ *
+ *   1. Explicit `ATLAS_RPID` always wins. SaaS multi-region deploys MUST set
+ *      it so a reorder of `ATLAS_CORS_ORIGIN` (which `getWebOrigin()` reads)
+ *      can never shift the derived rpID out from under enrolled keys.
+ *   2. Otherwise derive it from the configured web origin's host
+ *      (`getWebOrigin()` — first `ATLAS_CORS_ORIGIN`, then the first trusted
+ *      origin). Prod's app origin is `https://app.useatlas.dev`, so the
+ *      derived value is exactly `app.useatlas.dev` — identical to the old
+ *      hardcoded default, so no prod passkey is invalidated. Staging now
+ *      derives `app.staging.useatlas.dev` instead of silently inheriting
+ *      prod's rpID and breaking every staging passkey.
+ *   3. If no web origin is configured (single-origin / self-hosted with
+ *      neither var set), fall back to {@link DEFAULT_RP_ID} so minimal setups
+ *      keep working unchanged — no hard-fail.
+ *
+ * The failure this guards against — `The RP ID "..." is invalid for this
+ * domain` — fires only at ceremony time, in the user's browser, with no
+ * boot-time signal. So whenever a web origin IS configured we assert the
+ * effective rpID is valid for it and throw with an actionable message
+ * otherwise, mirroring the cross-origin cookie-domain fail-loud in
+ * `getAuthInstance()`. A bogus *explicit* `ATLAS_RPID` is caught here too; the
+ * derived path can never produce an invalid value, so unset deploys never
+ * throw. Hostnames aren't secrets (CLAUDE.md), so they're safe to log/surface.
+ */
+export function resolvePasskeyRpId(env: NodeJS.ProcessEnv, webOrigin: string | null): string {
+  const explicit = env.ATLAS_RPID?.trim();
+
+  // The web origin's host, when one is configured and parseable. A malformed
+  // origin is treated as "no origin" (legacy behavior) rather than a crash —
+  // a bad CORS/trusted-origin URL surfaces through CORS itself, not here.
+  let originHost: string | null = null;
+  if (webOrigin) {
+    try {
+      originHost = new URL(webOrigin).hostname || null;
+    } catch (err) {
+      log.warn(
+        { webOrigin, err: err instanceof Error ? err.message : String(err) },
+        "Could not parse the configured web origin while resolving the WebAuthn rpID — "
+          + "skipping rpID/origin validation and using the explicit or default value. Verify the "
+          + "first ATLAS_CORS_ORIGIN / BETTER_AUTH_TRUSTED_ORIGINS entry is an absolute URL.",
+      );
+    }
+  }
+
+  // 1. explicit env  >  2. derive from origin host  >  3. legacy default.
+  const rpID = explicit || originHost || DEFAULT_RP_ID;
+
+  // Fail loud when the effective rpID cannot be valid for the configured
+  // origin. Only reachable when an origin is configured AND parseable; the
+  // derived path always equals originHost (so always passes), meaning in
+  // practice this only trips on an explicit-but-wrong ATLAS_RPID.
+  if (originHost && !isRegistrableDomainSuffixOrEqual(rpID, originHost)) {
+    throw new Error(
+      `WebAuthn rpID "${rpID}" is not valid for the configured web origin "${webOrigin}" `
+        + `(host "${originHost}"): rpID must equal the origin host or be a parent domain of it. `
+        + (explicit
+          ? `ATLAS_RPID="${explicit}" is set explicitly but is not a registrable-domain suffix of `
+            + `the origin — set ATLAS_RPID to "${originHost}" (or a parent domain), or correct the `
+            + `first ATLAS_CORS_ORIGIN / BETTER_AUTH_TRUSTED_ORIGINS entry.`
+          : `Set ATLAS_RPID explicitly to "${originHost}" (or a parent domain), or correct the web origin.`),
+    );
+  }
+
+  return rpID;
+}
+
+/**
  * Default Better Auth `session.cookieCache.maxAge`, in seconds.
  *
  * F-07 — the earlier value of 5 minutes meant `auth.api.banUser(...)` and
@@ -1454,12 +1555,18 @@ export function buildPlugins() {
   );
 
   // Passkeys — loaded unconditionally (see `twoFactor()` above for rationale:
-  // schema must persist for already-enrolled users). Changing `rpID` after
-  // enrollment invalidates every existing passkey, so the default is fixed
-  // and self-hosted overrides go through `ATLAS_RPID` / `ATLAS_RPNAME`.
+  // schema must persist for already-enrolled users). Changing the *effective*
+  // `rpID` after enrollment invalidates every existing passkey, so resolution
+  // is deliberately conservative — explicit `ATLAS_RPID` always wins, else we
+  // derive from the configured web origin's host (prod stays exactly
+  // `app.useatlas.dev`; staging becomes `app.staging.useatlas.dev` instead of
+  // silently inheriting prod's rpID), else the legacy default. The resolver
+  // also fails loud at boot if the effective rpID can't be valid for the web
+  // origin — turning an opaque browser-side "RP ID is invalid for this domain"
+  // into an actionable boot error. See `resolvePasskeyRpId`.
   plugins.push(
     passkey({
-      rpID: process.env.ATLAS_RPID ?? "app.useatlas.dev",
+      rpID: resolvePasskeyRpId(process.env, getWebOrigin()),
       rpName: process.env.ATLAS_RPNAME ?? "Atlas",
     }),
   );

--- a/packages/api/src/lib/auth/server.ts
+++ b/packages/api/src/lib/auth/server.ts
@@ -748,8 +748,11 @@ export function deriveCookieDomain(
  * self-hosted deploys that configure neither `ATLAS_CORS_ORIGIN` nor
  * `BETTER_AUTH_TRUSTED_ORIGINS` — there is no web origin to derive from, so
  * preserving the historical value keeps minimal setups working unchanged.
- * Prod also resolves to exactly this string (its web origin host IS
- * `app.useatlas.dev`), so the derive path below is a no-op for prod.
+ * Prod also resolves to exactly this string, but *because* its first
+ * `ATLAS_CORS_ORIGIN` entry is `https://app.useatlas.dev` (deploy/README.md) —
+ * so the derive path below is a no-op for prod only as long as that stays
+ * true. If prod ever prepends a different origin, the derived rpID shifts and
+ * `ATLAS_RPID` must be pinned explicitly to avoid invalidating enrolled keys.
  */
 export const DEFAULT_RP_ID = "app.useatlas.dev";
 
@@ -766,8 +769,61 @@ export const DEFAULT_RP_ID = "app.useatlas.dev";
  * like a bare public suffix.
  */
 function isRegistrableDomainSuffixOrEqual(rpID: string, host: string): boolean {
-  if (rpID === host) return true;
-  return host.endsWith(`.${rpID}`);
+  // Hostnames are case-insensitive (DNS), and browsers lowercase the rpID
+  // before matching it against the page origin — so compare case-insensitively.
+  // An explicit `ATLAS_RPID=App.useatlas.dev` is valid for origin host
+  // `app.useatlas.dev` and must NOT trip the boot assertion. (`originHost` is
+  // already lowercased by `new URL().hostname`; only the operator-typed
+  // explicit rpID can carry case. The *returned* rpID is left verbatim — see
+  // `resolvePasskeyRpId` — so this comparison never mutates the enrolled value.)
+  const r = rpID.toLowerCase();
+  const h = host.toLowerCase();
+  if (r === h) return true;
+  return h.endsWith(`.${r}`);
+}
+
+/**
+ * Extract the host from a configured web origin so the rpID can be validated
+ * against it, or `null` (with a loud error log) when the origin is unusable.
+ *
+ * `getWebOrigin()` returns the operator's raw `ATLAS_CORS_ORIGIN` /
+ * `BETTER_AUTH_TRUSTED_ORIGINS` entry — it does NOT guarantee an absolute URL.
+ * Two realistic misconfigurations yield no host: a scheme-less bare host
+ * (`new URL` throws) and a scheme-less host:port like `app.example.com:3000`
+ * (`new URL` parses it as a protocol, leaving `hostname === ""`). Both mean
+ * the rpID can't be validated, so a wrong rpID would still break passkeys in
+ * the browser — exactly the silent failure this module exists to prevent.
+ * We log at error level (not warn — this belongs above boot noise) and name
+ * the consequence + fix, then return null so the caller degrades to the
+ * explicit/default rpID rather than crashing. This is the only logged path;
+ * the caller does not double-log.
+ */
+function parseOriginHostForRpId(webOrigin: string): string | null {
+  let host: string;
+  try {
+    host = new URL(webOrigin).hostname;
+  } catch (err) {
+    log.error(
+      { webOrigin, err: err instanceof Error ? err.message : String(err) },
+      "Configured web origin is not a parseable absolute URL while resolving the WebAuthn rpID — "
+        + "the rpID can't be validated against it, so a wrong rpID will break passkeys in the browser "
+        + "with no further server signal. Ensure the first ATLAS_CORS_ORIGIN / BETTER_AUTH_TRUSTED_ORIGINS "
+        + "entry includes the scheme (e.g. https://app.example.com).",
+    );
+    return null;
+  }
+  if (!host) {
+    log.error(
+      { webOrigin },
+      "Configured web origin has no host while resolving the WebAuthn rpID (scheme missing? — a value "
+        + 'like "app.example.com:3000" parses as a protocol, not a host) — the rpID can\'t be validated '
+        + "against it, so a wrong rpID will break passkeys in the browser with no further server signal. "
+        + "Ensure the first ATLAS_CORS_ORIGIN / BETTER_AUTH_TRUSTED_ORIGINS entry includes the scheme "
+        + "(e.g. https://app.example.com).",
+    );
+    return null;
+  }
+  return host;
 }
 
 /**
@@ -797,30 +853,25 @@ function isRegistrableDomainSuffixOrEqual(rpID: string, host: string): boolean {
  * domain` — fires only at ceremony time, in the user's browser, with no
  * boot-time signal. So whenever a web origin IS configured we assert the
  * effective rpID is valid for it and throw with an actionable message
- * otherwise, mirroring the cross-origin cookie-domain fail-loud in
- * `getAuthInstance()`. A bogus *explicit* `ATLAS_RPID` is caught here too; the
- * derived path can never produce an invalid value, so unset deploys never
- * throw. Hostnames aren't secrets (CLAUDE.md), so they're safe to log/surface.
+ * otherwise. (This is stronger than the cross-origin cookie-domain check in
+ * `getAuthInstance()`, which only `log.warn`s — a wrong rpID can't work at
+ * all, so it warrants a hard fail.) A bogus *explicit* `ATLAS_RPID` is caught
+ * here too; the derived path can never produce an invalid value, so unset
+ * deploys never throw. Hostnames aren't secrets (CLAUDE.md), so they're safe
+ * to log/surface.
  */
 export function resolvePasskeyRpId(env: NodeJS.ProcessEnv, webOrigin: string | null): string {
   const explicit = env.ATLAS_RPID?.trim();
 
-  // The web origin's host, when one is configured and parseable. A malformed
-  // origin is treated as "no origin" (legacy behavior) rather than a crash —
-  // a bad CORS/trusted-origin URL surfaces through CORS itself, not here.
-  let originHost: string | null = null;
-  if (webOrigin) {
-    try {
-      originHost = new URL(webOrigin).hostname || null;
-    } catch (err) {
-      log.warn(
-        { webOrigin, err: err instanceof Error ? err.message : String(err) },
-        "Could not parse the configured web origin while resolving the WebAuthn rpID — "
-          + "skipping rpID/origin validation and using the explicit or default value. Verify the "
-          + "first ATLAS_CORS_ORIGIN / BETTER_AUTH_TRUSTED_ORIGINS entry is an absolute URL.",
-      );
-    }
-  }
+  // The web origin's host, when one is configured and usable. A configured but
+  // UNUSABLE origin (unparseable, or scheme-less so `new URL` yields an empty
+  // host — e.g. "app.example.com:3000" parses as a protocol, not a host) is a
+  // misconfiguration, NOT the "no origin configured" minimal-setup case — so
+  // `parseOriginHostForRpId` logs it at error level with the consequence
+  // spelled out, rather than letting it slip past as a silent null. We still
+  // degrade to the explicit/default rpID (no host → nothing to validate
+  // against → can't assert), but the boot log is loud instead of silent.
+  const originHost = webOrigin ? parseOriginHostForRpId(webOrigin) : null;
 
   // 1. explicit env  >  2. derive from origin host  >  3. legacy default.
   const rpID = explicit || originHost || DEFAULT_RP_ID;

--- a/packages/api/src/lib/auth/server.ts
+++ b/packages/api/src/lib/auth/server.ts
@@ -38,6 +38,11 @@ import {
   resolveCookiePrefix,
 } from "@atlas/api/lib/env-profile";
 import { getWebOrigin } from "@atlas/api/lib/web-origin";
+// rpID resolution lives in its own pure module so `startup.ts` can validate it
+// eagerly without importing better-auth (#3045). Re-exported here so the auth
+// surface (and its tests) keep a single import site.
+import { resolvePasskeyRpId } from "@atlas/api/lib/auth/rpid";
+export { resolvePasskeyRpId, DEFAULT_RP_ID } from "@atlas/api/lib/auth/rpid";
 import {
   assertInvitationRoleAllowed,
   dispatchInvitationEmail,
@@ -741,158 +746,6 @@ export function deriveCookieDomain(
   if (common.every((label) => /^\d+$/.test(label))) return undefined; // bare IPv4
 
   return common.reverse().join(".");
-}
-
-/**
- * Legacy WebAuthn rpID default. Retained as the fallback for single-origin /
- * self-hosted deploys that configure neither `ATLAS_CORS_ORIGIN` nor
- * `BETTER_AUTH_TRUSTED_ORIGINS` — there is no web origin to derive from, so
- * preserving the historical value keeps minimal setups working unchanged.
- * Prod also resolves to exactly this string, but *because* its first
- * `ATLAS_CORS_ORIGIN` entry is `https://app.useatlas.dev` (deploy/README.md) —
- * so the derive path below is a no-op for prod only as long as that stays
- * true. If prod ever prepends a different origin, the derived rpID shifts and
- * `ATLAS_RPID` must be pinned explicitly to avoid invalidating enrolled keys.
- */
-export const DEFAULT_RP_ID = "app.useatlas.dev";
-
-/**
- * WebAuthn's "registrable domain suffix of, or equal to" rule: `rpID` is valid
- * for `host` when it equals the host or is a parent domain (dot-boundary
- * suffix) of it — e.g. `useatlas.dev` is valid for `app.staging.useatlas.dev`,
- * but `app.useatlas.dev` is NOT (the exact footgun this module fixes: prod's
- * rpID silently inherited on a staging host).
- *
- * No public-suffix-list awareness (same caveat as `deriveCookieDomain`): a
- * plain dotted-label check. Atlas's app host and rpID are always the same
- * registrable domain, and the browser is the backstop for a pathological rpID
- * like a bare public suffix.
- */
-function isRegistrableDomainSuffixOrEqual(rpID: string, host: string): boolean {
-  // Hostnames are case-insensitive (DNS), and browsers lowercase the rpID
-  // before matching it against the page origin — so compare case-insensitively.
-  // An explicit `ATLAS_RPID=App.useatlas.dev` is valid for origin host
-  // `app.useatlas.dev` and must NOT trip the boot assertion. (`originHost` is
-  // already lowercased by `new URL().hostname`; only the operator-typed
-  // explicit rpID can carry case. The *returned* rpID is left verbatim — see
-  // `resolvePasskeyRpId` — so this comparison never mutates the enrolled value.)
-  const r = rpID.toLowerCase();
-  const h = host.toLowerCase();
-  if (r === h) return true;
-  return h.endsWith(`.${r}`);
-}
-
-/**
- * Extract the host from a configured web origin so the rpID can be validated
- * against it, or `null` (with a loud error log) when the origin is unusable.
- *
- * `getWebOrigin()` returns the operator's raw `ATLAS_CORS_ORIGIN` /
- * `BETTER_AUTH_TRUSTED_ORIGINS` entry — it does NOT guarantee an absolute URL.
- * Two realistic misconfigurations yield no host: a scheme-less bare host
- * (`new URL` throws) and a scheme-less host:port like `app.example.com:3000`
- * (`new URL` parses it as a protocol, leaving `hostname === ""`). Both mean
- * the rpID can't be validated, so a wrong rpID would still break passkeys in
- * the browser — exactly the silent failure this module exists to prevent.
- * We log at error level (not warn — this belongs above boot noise) and name
- * the consequence + fix, then return null so the caller degrades to the
- * explicit/default rpID rather than crashing. This is the only logged path;
- * the caller does not double-log.
- */
-function parseOriginHostForRpId(webOrigin: string): string | null {
-  let host: string;
-  try {
-    host = new URL(webOrigin).hostname;
-  } catch (err) {
-    log.error(
-      { webOrigin, err: err instanceof Error ? err.message : String(err) },
-      "Configured web origin is not a parseable absolute URL while resolving the WebAuthn rpID — "
-        + "the rpID can't be validated against it, so a wrong rpID will break passkeys in the browser "
-        + "with no further server signal. Ensure the first ATLAS_CORS_ORIGIN / BETTER_AUTH_TRUSTED_ORIGINS "
-        + "entry includes the scheme (e.g. https://app.example.com).",
-    );
-    return null;
-  }
-  if (!host) {
-    log.error(
-      { webOrigin },
-      "Configured web origin has no host while resolving the WebAuthn rpID (scheme missing? — a value "
-        + 'like "app.example.com:3000" parses as a protocol, not a host) — the rpID can\'t be validated '
-        + "against it, so a wrong rpID will break passkeys in the browser with no further server signal. "
-        + "Ensure the first ATLAS_CORS_ORIGIN / BETTER_AUTH_TRUSTED_ORIGINS entry includes the scheme "
-        + "(e.g. https://app.example.com).",
-    );
-    return null;
-  }
-  return host;
-}
-
-/**
- * Resolve the WebAuthn Relying Party ID (`rpID`) for the passkey plugin, and
- * fail loud at boot if it can't possibly be valid for the deploy's web origin.
- *
- * `rpID` is the registrable domain a passkey is bound to. It MUST stay stable
- * across enrollment — changing the *effective* value invalidates every passkey
- * already registered (see the comment above the `passkey({...})` call). The
- * resolution order is therefore deliberately conservative:
- *
- *   1. Explicit `ATLAS_RPID` always wins. SaaS multi-region deploys MUST set
- *      it so a reorder of `ATLAS_CORS_ORIGIN` (which `getWebOrigin()` reads)
- *      can never shift the derived rpID out from under enrolled keys.
- *   2. Otherwise derive it from the configured web origin's host
- *      (`getWebOrigin()` — first `ATLAS_CORS_ORIGIN`, then the first trusted
- *      origin). Prod's app origin is `https://app.useatlas.dev`, so the
- *      derived value is exactly `app.useatlas.dev` — identical to the old
- *      hardcoded default, so no prod passkey is invalidated. Staging now
- *      derives `app.staging.useatlas.dev` instead of silently inheriting
- *      prod's rpID and breaking every staging passkey.
- *   3. If no web origin is configured (single-origin / self-hosted with
- *      neither var set), fall back to {@link DEFAULT_RP_ID} so minimal setups
- *      keep working unchanged — no hard-fail.
- *
- * The failure this guards against — `The RP ID "..." is invalid for this
- * domain` — fires only at ceremony time, in the user's browser, with no
- * boot-time signal. So whenever a web origin IS configured we assert the
- * effective rpID is valid for it and throw with an actionable message
- * otherwise. (This is stronger than the cross-origin cookie-domain check in
- * `getAuthInstance()`, which only `log.warn`s — a wrong rpID can't work at
- * all, so it warrants a hard fail.) A bogus *explicit* `ATLAS_RPID` is caught
- * here too; the derived path can never produce an invalid value, so unset
- * deploys never throw. Hostnames aren't secrets (CLAUDE.md), so they're safe
- * to log/surface.
- */
-export function resolvePasskeyRpId(env: NodeJS.ProcessEnv, webOrigin: string | null): string {
-  const explicit = env.ATLAS_RPID?.trim();
-
-  // The web origin's host, when one is configured and usable. A configured but
-  // UNUSABLE origin (unparseable, or scheme-less so `new URL` yields an empty
-  // host — e.g. "app.example.com:3000" parses as a protocol, not a host) is a
-  // misconfiguration, NOT the "no origin configured" minimal-setup case — so
-  // `parseOriginHostForRpId` logs it at error level with the consequence
-  // spelled out, rather than letting it slip past as a silent null. We still
-  // degrade to the explicit/default rpID (no host → nothing to validate
-  // against → can't assert), but the boot log is loud instead of silent.
-  const originHost = webOrigin ? parseOriginHostForRpId(webOrigin) : null;
-
-  // 1. explicit env  >  2. derive from origin host  >  3. legacy default.
-  const rpID = explicit || originHost || DEFAULT_RP_ID;
-
-  // Fail loud when the effective rpID cannot be valid for the configured
-  // origin. Only reachable when an origin is configured AND parseable; the
-  // derived path always equals originHost (so always passes), meaning in
-  // practice this only trips on an explicit-but-wrong ATLAS_RPID.
-  if (originHost && !isRegistrableDomainSuffixOrEqual(rpID, originHost)) {
-    throw new Error(
-      `WebAuthn rpID "${rpID}" is not valid for the configured web origin "${webOrigin}" `
-        + `(host "${originHost}"): rpID must equal the origin host or be a parent domain of it. `
-        + (explicit
-          ? `ATLAS_RPID="${explicit}" is set explicitly but is not a registrable-domain suffix of `
-            + `the origin — set ATLAS_RPID to "${originHost}" (or a parent domain), or correct the `
-            + `first ATLAS_CORS_ORIGIN / BETTER_AUTH_TRUSTED_ORIGINS entry.`
-          : `Set ATLAS_RPID explicitly to "${originHost}" (or a parent domain), or correct the web origin.`),
-    );
-  }
-
-  return rpID;
 }
 
 /**

--- a/packages/api/src/lib/startup.ts
+++ b/packages/api/src/lib/startup.ts
@@ -600,10 +600,13 @@ function checkManagedAuthMode(errors: DiagnosticError[]): void {
   try {
     resolvePasskeyRpId(process.env, getWebOrigin());
   } catch (err) {
-    errors.push({
-      code: "INVALID_RP_ID",
-      message: err instanceof Error ? err.message : String(err),
-    });
+    const message = err instanceof Error ? err.message : String(err);
+    // Surface in the server log too, not just the diagnostics response —
+    // resolvePasskeyRpId throws (it doesn't log) and the lazy buildPlugins
+    // path buries the same throw under a generic "migration failed" line, so
+    // without this the misconfig is invisible in logs.
+    log.warn({ err: message }, "Invalid WebAuthn rpID for the configured web origin");
+    errors.push({ code: "INVALID_RP_ID", message });
   }
 }
 

--- a/packages/api/src/lib/startup.ts
+++ b/packages/api/src/lib/startup.ts
@@ -12,6 +12,8 @@ import { detectDBType, resolveDatasourceUrl } from "./db/connection";
 import { maskConnectionUrl } from "./security";
 import { getDefaultProvider } from "./providers";
 import { detectAuthMode, getAuthModeSource } from "./auth/detect";
+import { resolvePasskeyRpId } from "./auth/rpid";
+import { getWebOrigin } from "./web-origin";
 import { createLogger } from "./logger";
 import { errorMessage } from "./audit/error-scrub";
 import { getSemanticRoot as getDefaultSemanticRoot } from "./semantic/files";
@@ -24,6 +26,7 @@ export type DiagnosticCode =
   | "WEAK_AUTH_SECRET" | "INVALID_JWKS_URL" | "MISSING_AUTH_ISSUER"
   | "MISSING_AUTH_PREREQ"
   | "ACTIONS_REQUIRE_AUTH" | "ACTIONS_MISSING_CREDENTIALS"
+  | "INVALID_RP_ID"
   | "INVALID_CONFIG";
 
 export interface DiagnosticError {
@@ -584,6 +587,23 @@ function checkManagedAuthMode(errors: DiagnosticError[]): void {
       _startupWarnings.push(msg);
     }
     log.warn(msg);
+  }
+
+  // WebAuthn rpID validity (#3045). The passkey plugin's rpID throw lives in
+  // `buildPlugins()`, which only runs lazily (first managed-auth request / boot
+  // migration, where the migration path catches the throw into a generic log).
+  // Resolve it here too so an rpID that can't be valid for the configured web
+  // origin surfaces as an eager, actionable startup diagnostic (on /health and
+  // route 503s) instead of an opaque browser-side error later. resolvePasskeyRpId
+  // is the single source of truth — it throws only on an explicit-but-invalid
+  // ATLAS_RPID; the derived path and a null origin never throw.
+  try {
+    resolvePasskeyRpId(process.env, getWebOrigin());
+  } catch (err) {
+    errors.push({
+      code: "INVALID_RP_ID",
+      message: err instanceof Error ? err.message : String(err),
+    });
   }
 }
 

--- a/packages/web/src/lib/auth/parse-passkey-sign-in-error.test.ts
+++ b/packages/web/src/lib/auth/parse-passkey-sign-in-error.test.ts
@@ -109,6 +109,59 @@ describe("parsePasskeySignInError — thrown branch", () => {
   });
 });
 
+describe("parsePasskeySignInError — invalid rpID (#3045)", () => {
+  // The browser throws a SecurityError when the page origin isn't valid for
+  // the configured rpID. The server-side resolvePasskeyRpId boot assertion
+  // makes this unreachable on deploys that configure a web origin; this branch
+  // covers the residual self-hosted / single-origin case and turns the raw
+  // DOMException blob into actionable "contact your administrator" copy.
+  test("thrown SecurityError (Chrome phrasing) → setup-issue copy, not the raw blob", () => {
+    const result = parsePasskeySignInError({
+      kind: "thrown",
+      value: new Error('The RP ID "app.useatlas.dev" is invalid for this domain.'),
+    });
+    expect(result.kind).toBe("user");
+    if (result.kind === "user") {
+      expect(result.message).toContain("aren't set up correctly for this site");
+      expect(result.message).not.toContain("app.useatlas.dev"); // raw rpID never leaks
+    }
+  });
+
+  test("thrown 'registrable domain suffix' phrasing → setup-issue copy", () => {
+    const result = parsePasskeySignInError({
+      kind: "thrown",
+      value: new Error(
+        "SecurityError: The relying party ID is not a registrable domain suffix of the origin.",
+      ),
+    });
+    expect(result.kind).toBe("user");
+    if (result.kind === "user") {
+      expect(result.message).toContain("aren't set up correctly for this site");
+    }
+  });
+
+  test("wire envelope carrying the invalid-rpID message → setup-issue copy", () => {
+    const result = parsePasskeySignInError({
+      kind: "wire",
+      error: { message: 'The RP ID "x" is invalid for this domain', status: 0 },
+    });
+    expect(result.kind).toBe("user");
+    if (result.kind === "user") {
+      expect(result.message).toContain("aren't set up correctly for this site");
+    }
+  });
+
+  test("a message that merely mentions 'domain' (no RP term) does NOT match", () => {
+    // Guards the two-term requirement: 'domain' alone must not hijack an
+    // unrelated error into the rpID branch.
+    const result = parsePasskeySignInError({
+      kind: "thrown",
+      value: new Error("Your session expired on this domain"),
+    });
+    expect(result).toEqual({ kind: "user", message: "Your session expired on this domain" });
+  });
+});
+
 describe("parsePasskeySignInError — branch ordering invariant", () => {
   test("status 429 with 'cancelled' in body still routes to rate-limited (not silent)", () => {
     // A 429 response that happens to mention 'cancelled' must NOT fall

--- a/packages/web/src/lib/auth/parse-passkey-sign-in-error.test.ts
+++ b/packages/web/src/lib/auth/parse-passkey-sign-in-error.test.ts
@@ -151,6 +151,34 @@ describe("parsePasskeySignInError — invalid rpID (#3045)", () => {
     }
   });
 
+  test("invalid-rpID message UNDER a cancellation code → setup-issue copy, not silent", () => {
+    // rpID misconfig can wear the NotAllowedError/AUTH_CANCELLED shape. The
+    // cancellation fast-path must not silently swallow it when the message
+    // clearly identifies an rpID/domain mismatch.
+    const result = parsePasskeySignInError({
+      kind: "wire",
+      error: {
+        code: "AUTH_CANCELLED",
+        message: 'The RP ID "app.useatlas.dev" is invalid for this domain',
+        status: 400,
+      },
+    });
+    expect(result.kind).toBe("user");
+    if (result.kind === "user") {
+      expect(result.message).toContain("aren't set up correctly for this site");
+    }
+  });
+
+  test("a genuine cancellation (generic message) under AUTH_CANCELLED stays silent", () => {
+    // Guards the two-term boundary: a real cancellation must not be hijacked.
+    expect(
+      parsePasskeySignInError({
+        kind: "wire",
+        error: { code: "AUTH_CANCELLED", message: "The operation was not allowed", status: 400 },
+      }),
+    ).toEqual({ kind: "silent" });
+  });
+
   test("a message that merely mentions 'domain' (no RP term) does NOT match", () => {
     // Guards the two-term requirement: 'domain' alone must not hijack an
     // unrelated error into the rpID branch.

--- a/packages/web/src/lib/auth/parse-passkey-sign-in-error.ts
+++ b/packages/web/src/lib/auth/parse-passkey-sign-in-error.ts
@@ -51,6 +51,18 @@ export type PasskeySignInOutcome =
 
 const FALLBACK_MESSAGE = "Passkey sign-in didn't complete. Try again, or use email and password.";
 
+// Server-misconfiguration copy for the `SecurityError` the browser throws
+// synchronously when the page origin isn't valid for the configured rpID
+// ("The RP ID \"...\" is invalid for this domain"). This is a deploy setup
+// issue (rpID ≠ the deploy's origin), not anything the end user can fix — so
+// route it to a clear "contact your administrator" message instead of leaking
+// the raw DOMException string. The server-side `resolvePasskeyRpId` boot
+// assertion (packages/api) makes this unreachable on deploys that DO configure
+// a web origin; this branch covers the residual self-hosted / single-origin
+// case where no origin is configured to validate against.
+const INVALID_RP_ID_MESSAGE =
+  "Passkeys aren't set up correctly for this site — the server's WebAuthn domain doesn't match this address. Contact your administrator, or sign in with email and password.";
+
 export function parsePasskeySignInError(input: PasskeySignInErrorInput): PasskeySignInOutcome {
   if (input.kind === "thrown") {
     if (input.value instanceof TypeError) {
@@ -60,6 +72,11 @@ export function parsePasskeySignInError(input: PasskeySignInErrorInput): Passkey
       };
     }
     if (input.value instanceof Error && input.value.message) {
+      // Misconfigured rpID surfaces here as a thrown SecurityError/DOMException.
+      // Catch it before the raw message bubbles to the user.
+      if (isInvalidRpIdError(input.value.message)) {
+        return { kind: "user", message: INVALID_RP_ID_MESSAGE };
+      }
       return { kind: "user", message: input.value.message };
     }
     return { kind: "user", message: FALLBACK_MESSAGE };
@@ -104,6 +121,13 @@ export function parsePasskeySignInError(input: PasskeySignInErrorInput): Passkey
     return { kind: "user", message: "The sign-in challenge expired. Tap the passkey button again." };
   }
 
+  // Misconfigured rpID — the browser's SecurityError ("The RP ID is invalid
+  // for this domain") can also arrive folded into the wire envelope's message.
+  // Checked before the fuzzy-cancellation match so it routes to actionable
+  // setup copy rather than the raw blob (it doesn't match the cancellation
+  // substrings, but keep it ahead to make the precedence explicit).
+  if (isInvalidRpIdError(message)) return { kind: "user", message: INVALID_RP_ID_MESSAGE };
+
   // Fuzzy-message cancellation — older browsers / pre-`@simplewebauthn/
   // browser` v9 wiring surface NotAllowedError in the message field
   // without a stable code. Treat as silent.
@@ -115,4 +139,19 @@ export function parsePasskeySignInError(input: PasskeySignInErrorInput): Passkey
 function isFuzzyCancellation(message: string): boolean {
   const m = message.toLowerCase();
   return m.includes("notallowed") || m.includes("cancelled") || m.includes("canceled");
+}
+
+/**
+ * Detect the WebAuthn invalid-rpID `SecurityError` across browser phrasings:
+ * Chrome/Safari say `The RP ID "x" is invalid for this domain`; some engines
+ * say the rpID `is not a registrable domain suffix of` the origin. Both pair a
+ * relying-party term with a domain-mismatch term, so require one of each to
+ * avoid false-positives on unrelated messages that merely mention "domain".
+ */
+function isInvalidRpIdError(message: string): boolean {
+  const m = message.toLowerCase();
+  const mentionsRp = m.includes("rp id") || m.includes("relying party");
+  const mentionsDomainMismatch =
+    m.includes("invalid for this domain") || m.includes("registrable domain");
+  return mentionsRp && mentionsDomainMismatch;
 }

--- a/packages/web/src/lib/auth/parse-passkey-sign-in-error.ts
+++ b/packages/web/src/lib/auth/parse-passkey-sign-in-error.ts
@@ -91,6 +91,13 @@ export function parsePasskeySignInError(input: PasskeySignInErrorInput): Passkey
   // user-cancelled WebAuthn assertions as `AUTH_CANCELLED` regardless of
   // the HTTP status (some browsers report 401 here, others 400).
   if (code === "AUTH_CANCELLED" || code === "REGISTRATION_CANCELLED") {
+    // A misconfigured rpID can surface UNDER a cancellation code carrying the
+    // browser's "RP ID invalid for this domain" message (see the outcome doc
+    // above — rpID misconfig wears the same NotAllowedError shape). That's a
+    // setup error, not a user cancellation, so surface it instead of silently
+    // swallowing it. Genuine cancellations carry generic messages and won't
+    // match the two-term guard, so this can't hijack a real cancellation.
+    if (isInvalidRpIdError(message)) return { kind: "user", message: INVALID_RP_ID_MESSAGE };
     return { kind: "silent" };
   }
 


### PR DESCRIPTION
## Summary

`rpID` fell back to the hardcoded prod constant `app.useatlas.dev` whenever `ATLAS_RPID` was unset, so **every non-prod deploy silently inherited prod's RP ID** and passkeys broke with an opaque browser error (`The RP ID "app.useatlas.dev" is invalid for this domain`) on staging, self-hosted custom domains, and preview envs.

- **Derive-from-origin fallback** — new `resolvePasskeyRpId(env, webOrigin)`: explicit `ATLAS_RPID` always wins → else derive from the configured web origin's host via `getWebOrigin()` → else the legacy default. Prod's web origin is `https://app.useatlas.dev`, so the derived value is **exactly `app.useatlas.dev` — unchanged, no passkey invalidation**. Staging now derives `app.staging.useatlas.dev`; localhost derives `localhost`.
- **Fail loud at boot** — whenever a web origin is configured, asserts the effective rpID is equal to or a registrable-domain suffix of the origin host, and throws an actionable error otherwise. (This is *stronger* than the cross-origin cookie-domain check in `getAuthInstance()`, which only warns — a wrong rpID can't work at all.) A bogus explicit `ATLAS_RPID` is caught here too; the derived path can never produce an invalid value, so unset deploys never throw.
- **Case-insensitive comparison** — DNS hostnames are case-insensitive and browsers lowercase the rpID before matching, so a valid mixed-case explicit `ATLAS_RPID` doesn't false-positive fail-loud. The returned rpID is left verbatim (rpID stability — never mutate the enrolled value).
- **No silent skip on a broken origin** — a configured-but-unusable origin (unparseable, or scheme-less `host:port` that `new URL()` parses as a protocol → empty host) is logged at **error** level naming the consequence + fix, rather than slipping past as a silent `null`.
- **No regression for minimal setups** — a `null` web origin (single-origin / self-hosted with neither var set) preserves today's behavior: legacy default, no hard-fail.
- **Clearer client error** — routes the browser's invalid-rpID `SecurityError` to actionable "contact your administrator" copy in `parsePasskeySignInError` (the residual self-hosted case the boot assertion can't reach).
- Updates `.env.example` rpID guidance + adds unit coverage.

## rpID stability (hard constraint)

Prod verified unchanged: `deploy/README.md` sets `ATLAS_CORS_ORIGIN=https://app.useatlas.dev`, and prod does not set `ATLAS_RPID` — both paths resolve to exactly `app.useatlas.dev`, so no enrolled passkey is invalidated. Explicit `ATLAS_RPID` always overrides. The e2e passkey tests set `ATLAS_RPID=localhost` explicitly, which still wins and validates against the `localhost` origin.

## Test plan

- [x] `ATLAS_RPID` unset + web origin → derives origin host (prod `app.useatlas.dev`, staging `app.staging.useatlas.dev`, localhost `localhost`)
- [x] explicit `ATLAS_RPID` always overrides (incl. parent-domain pin); mixed-case explicit value valid for origin → no false fail-loud
- [x] registrable-domain suffix valid (e.g. `useatlas.dev` for `app.staging.useatlas.dev`); mixed-case origin derives lowercase rpID
- [x] explicit `ATLAS_RPID` invalid for origin → throws at boot with actionable message
- [x] unrelated-domain suffix without dot boundary rejected (`useatlas.dev` ✗ for `notuseatlas.dev`)
- [x] `getWebOrigin()` null → legacy default, no hard-fail
- [x] unparseable / scheme-less `host:port` origin → no crash, validation skipped (logged at error), degrades to explicit/default
- [x] client parser routes invalid-rpID `SecurityError` to setup-issue copy (Chrome + suffix phrasings, wire + thrown)
- [x] `/ci` — lint, type, full test (api 535 + others), syncpack, all drift/discipline gates green
- [x] full `/pr-review-toolkit:review-pr` pass (code, tests, comments, errors); review findings addressed in the second commit

## Notes

This does **not** unblock staging passkeys on its own — staging still needs `ATLAS_RPID=app.staging.useatlas.dev` set in Railway (tracked on #2917, HITL). This change is the general hardening so the footgun never silently bites again.

Closes #3045

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded WebAuthn/passkey guidance: detailed rpID derivation, origin mappings, multi-region/custom domain notes, and implications of changing rpID after passkeys are enrolled.

* **Bug Fixes**
  * Improved detection and clearer user-facing messages for misconfigured passkey (rpID) setups; advises contacting admin or using alternate sign-in.
  * Startup diagnostics now surface explicit invalid rpID errors.

* **Tests**
  * Added coverage for rpID resolution and related error-handling scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->