### PR TITLE
fix(api,web): scope REST datasources to cross-environment routing (#3044)

### DIFF
--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -10439,6 +10439,31 @@
                         ]
                       }
                     },
+                    "restDatasources": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "displayName": {
+                            "type": "string"
+                          },
+                          "groupId": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "displayName",
+                          "groupId"
+                        ]
+                      }
+                    },
                     "reason": {
                       "type": [
                         "string",
@@ -10453,6 +10478,7 @@
                   },
                   "required": [
                     "groups",
+                    "restDatasources",
                     "reason"
                   ]
                 }
@@ -52103,6 +52129,15 @@
                     "minLength": 1,
                     "description": "How often Atlas auto-refreshes the cached spec: 'off' (default, no auto-refresh), 'daily', 'weekly', or a custom '<N>h' interval in hours (clamped to 1–720h / 30 days). Out-of-range positive values are clamped; unparseable values are rejected with an actionable error.",
                     "example": "daily"
+                  },
+                  "groupId": {
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "minLength": 1,
+                    "description": "Connection group this REST datasource is scoped to. A group id restricts the datasource to conversations whose active environment is that group; null clears the scope back to workspace-global (available in every environment).",
+                    "example": "prod"
                   }
                 }
               }

--- a/docs/adr/0010-rest-datasource-environment-scoping.md
+++ b/docs/adr/0010-rest-datasource-environment-scoping.md
@@ -1,0 +1,72 @@
+# ADR-0010: REST datasource environment scoping
+
+**Status:** Accepted
+**Date:** 2026-05-31
+**Context milestone:** v0.0.3 — Spec Lifecycle (closeout of a composability gap from v0.0.2)
+**Depends on:** [ADR-0006](./0006-three-pillar-integration-taxonomy.md), [ADR-0007](./0007-unified-install-pipeline.md)
+**Closes:** [#3044](https://github.com/AtlasDevHQ/atlas/issues/3044) (spans v0.0.2 REST datasources × 1.4.5 cross-environment routing — PRDs [#2868](https://github.com/AtlasDevHQ/atlas/issues/2868), [#2336](https://github.com/AtlasDevHQ/atlas/issues/2336))
+
+## Context
+
+Atlas has two subsystems that were built independently and never composed:
+
+1. **Cross-environment routing** (milestones 1.4.4 / 1.4.5) — connection *groups* + an Auto/Pin/All picker. A conversation pins to one member of a group (e.g. `apac-prod`), and `executeSQL` honours that scope: `pin` routes to the current member, `all` fans out across every member, `auto` lets the agent decide. Members are SQL connection ids; the routing module (`env-routing/`) is SQL-only.
+
+2. **REST / OpenAPI datasources** (`v0.0.2`, PRD #2868) — `executeRestOperation` over an `openapi-generic` install (Twenty, Stripe, GitHub, an internal service). These were added *after* routing and resolve via `resolveWorkspaceRestDatasources(orgId)` — keyed on the **workspace only**, with no routing input.
+
+The gap: a chat **pinned to one environment can still query any connected REST datasource**, the REST datasource never appears in the env picker, and the pin doesn't constrain it. The routing-scope indicator therefore **silently overstates** what the chat is constrained to.
+
+Both subsystems already store their installs in `workspace_plugins` with `pillar = 'datasource'`. SQL connections and REST datasources are distinguished only by `catalog_id` (`catalog:postgres` / `catalog:mysql` / … vs `catalog:openapi-generic` / `catalog:{stripe,github,notion}-data`). The group-scoping plumbing for REST half-exists: `config.group_id` is a free-form JSONB string a REST install *can* already carry, but no resolver reads it.
+
+## Decision
+
+**Hybrid model: workspace-global by default, optionally environment-scoped.**
+
+A REST datasource is **workspace-global by default** (no `config.group_id`). One Stripe / GitHub / Twenty account is not region-specific, so a workspace-global REST datasource is intentionally cross-environment — it is **not** constrained by the conversation's environment pin, and that is correct.
+
+An admin **may optionally scope** a REST datasource to a connection group by assigning it the group's `group_id` (reusing the same `config.group_id` field SQL connections carry — one group identity, no parallel field). A scoped REST datasource is the per-region case (e.g. a region-local internal API).
+
+### Scope rule (resolver)
+
+A REST datasource is **in-scope for a chat turn** iff:
+
+```
+groupId == null              // workspace-global — always available
+  OR groupId === activeGroupId  // scoped — available only when its group is active
+```
+
+This is **mode-independent.** The active group is the same under `pin` / `auto` / `all`; those modes only choose which SQL member(s) execute *within* the group — they don't change which REST datasources belong to the group. `resolveWorkspaceRestDatasources*` accepts an optional **tri-state** `activeGroupId`:
+
+- **`null`** (an active-group-aware caller — the agent loop — with no group bound) → resolve only workspace-global datasources, so a scoped datasource never leaks into a context whose group can't be confirmed. The agent loop always passes `connectionGroupId ?? null`, so the chat path is strictly scoped.
+- **a string** (the active group id) → resolve workspace-global datasources plus those scoped to that exact group.
+- **omitted (`undefined`)** → apply **no** scope filter (resolve every install). Reserved for the authorized confirm-replay path (`tools/rest-operation.ts`'s `resolveFromContext`): a staged write is bound by a signed token and must replay regardless of the request's group context.
+
+Because no REST install carries a `group_id` today, **back-compat is total**: every existing datasource is workspace-global and always in scope.
+
+### Always-correct half (the bug, ships under any model)
+
+The misleading-scope half is a bug regardless of the model. The agent prompt and the env picker now make a REST datasource's cross-environment reach **explicit**:
+
+- **Workspace-global** datasources are framed as "NOT constrained by the conversation's environment selection — available in every environment."
+- **Scoped** datasources note the group they belong to.
+
+So a pinned chat never silently appears fully constrained while a workspace-global REST datasource is reachable.
+
+### Robustness: `catalog_id` discriminates SQL members from REST installs
+
+REST installs share `workspace_plugins` + `pillar = 'datasource'` with SQL connections. The two queries that resolve **SQL** routing-group members —
+`loadGroupRoutingContext` (`env-routing/lookup.ts`) and `GET /api/v1/me/connection-groups` —
+must therefore **exclude** REST `catalog_id`s. Without that exclusion, a REST install that shares a `group_id` with SQL connections would be returned as a SQL "member", and `executeSQL`'s `all`-fanout would attempt a SQL query against a connection that isn't registered in the SQL `ConnectionRegistry` (it fails soft, but degrades the fanout silently). The shared constant `REST_DATASOURCE_CATALOG_IDS` (`openapi/data-candidates.ts`) is the discriminator both queries filter on.
+
+## Consequences
+
+- **No migration.** Reuses the existing `config.group_id` JSONB field; no schema change, no drift-gate concern.
+- **Admin UX.** `/admin/connections` gains a per-datasource "Environment" control (a group picker; "Workspace-global" clears the assignment). It writes `config.group_id` via the existing JSONB-merge PATCH.
+- **Picker surface.** `/api/v1/me/connection-groups` additionally returns the workspace's REST datasources with their `groupId`, so the env picker can show "+ N workspace-global REST datasources (not env-scoped)" and list scoped ones under their group — without rendering them as pickable SQL execution targets.
+- **Resolver contract preserved.** Group filtering happens before credential resolution, so the never-rejects `[]` fail-soft contract and the `RestDatasourceReconnectError` semantics are unchanged for the in-scope set.
+
+## Alternatives considered
+
+- **(A) Pure env-scoped.** Force every REST datasource into a group. Rejected: a single Stripe account isn't apac-specific; forcing a group is busywork and wrong for the common case.
+- **(B) Pure workspace-global + surfaced.** Never scope; just make the cross-env reach explicit. This is the right *default* but can't express the genuine per-region API case, so it becomes the default arm of the hybrid rather than the whole answer.
+- **Separate `config.datasource_group_id` field.** Avoids touching the SQL-member queries but splits group identity in two and can't surface a REST datasource as "belonging to" a SQL environment group. Rejected in favour of one group identity + the `catalog_id` discriminator.

--- a/docs/adr/0010-rest-datasource-environment-scoping.md
+++ b/docs/adr/0010-rest-datasource-environment-scoping.md
@@ -30,7 +30,7 @@ An admin **may optionally scope** a REST datasource to a connection group by ass
 
 A REST datasource is **in-scope for a chat turn** iff:
 
-```
+```text
 groupId == null              // workspace-global — always available
   OR groupId === activeGroupId  // scoped — available only when its group is active
 ```

--- a/packages/api/src/api/routes/__tests__/admin-openapi-datasources.test.ts
+++ b/packages/api/src/api/routes/__tests__/admin-openapi-datasources.test.ts
@@ -45,6 +45,8 @@ let probeShouldFail = false;
 let authResultOverride: { ok: false; rawAuthKind: string } | null = null;
 /** Extra config fields merged into the loaded install row (e.g. base_url_override). */
 let configExtra: Record<string, unknown> = {};
+/** #3044 — controllable verdict for the group-existence guard on group_id assignment. */
+let mockGroupVerdict: "ok" | "not_found" | "error" | "no_db" = "ok";
 /** The `options` the route last passed to `probeSpec` — asserts the #3034 host gate is threaded. */
 let lastProbeOptions: { apiBaseUrl?: string } | undefined;
 
@@ -143,6 +145,12 @@ mock.module("@atlas/api/lib/plugins/secrets", () => ({
   decryptSecretFields: (config: Record<string, unknown>) => ({ ...config }),
 }));
 
+// #3044 — the group_id assignment guard calls verifyGroupBelongsToOrg; mock it
+// so the existence verdict is controllable without seeding the db recorder.
+mock.module("@atlas/api/lib/conversations", () => ({
+  verifyGroupBelongsToOrg: async () => mockGroupVerdict,
+}));
+
 /**
  * Spy on the graph-cache eviction so the rediscover/DELETE wiring (#3009) is
  * asserted at the ROUTE level — the unit tests in `probe.test.ts` prove the
@@ -236,6 +244,7 @@ beforeEach(() => {
   CURRENT_ORG = FIXTURE.owner;
   probeShouldFail = false;
   configExtra = {};
+  mockGroupVerdict = "ok";
   lastProbeOptions = undefined;
   db.clear();
   invalidateGraphCacheSpy.mockClear();
@@ -686,5 +695,32 @@ describe("admin-openapi-datasources — env scope (group_id, #3044)", () => {
     expect(update?.[0]).toContain("representation_mode");
     expect(update?.[0]).toContain("group_id");
     expect(update?.[1]).toEqual([FIXTURE.owner, "ds-1", CATALOG_ID, "semantic-yaml", "eu"]);
+  });
+
+  it("PATCH rejects a group_id that doesn't exist in the workspace — no UPDATE", async () => {
+    mockGroupVerdict = "not_found";
+    const res = await adminOpenApiDatasources.request("/ds-1", {
+      method: "PATCH",
+      headers: JSON_HEADERS,
+      body: JSON.stringify({ groupId: "typo-env" }),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("invalid_connection_group");
+    // The bad assignment never reached the database.
+    expect(findConfigUpdate()).toBeUndefined();
+  });
+
+  it("PATCH does NOT gate a clear-to-workspace-global on group existence", async () => {
+    // Clearing (groupId: null) must always work — even if the group-existence
+    // check would say "not_found" for some value, null is never validated.
+    mockGroupVerdict = "not_found";
+    const res = await adminOpenApiDatasources.request("/ds-1", {
+      method: "PATCH",
+      headers: JSON_HEADERS,
+      body: JSON.stringify({ groupId: null }),
+    });
+    expect(res.status).toBe(200);
+    expect(findConfigUpdate()?.[1]).toEqual([FIXTURE.owner, "ds-1", CATALOG_ID, null]);
   });
 });

--- a/packages/api/src/api/routes/__tests__/admin-openapi-datasources.test.ts
+++ b/packages/api/src/api/routes/__tests__/admin-openapi-datasources.test.ts
@@ -624,3 +624,67 @@ describe("admin-openapi-datasources — spec_refresh_interval set / clear / clam
     expect(res.status).toBe(400);
   });
 });
+
+describe("admin-openapi-datasources — env scope (group_id, #3044)", () => {
+  it("GET detail surfaces groupId from config (null when ungrouped)", async () => {
+    const ungrouped = (await (await adminOpenApiDatasources.request("/ds-1")).json()) as {
+      groupId: string | null;
+    };
+    expect(ungrouped.groupId).toBeNull();
+
+    configExtra = { group_id: "prod" };
+    const scoped = (await (await adminOpenApiDatasources.request("/ds-1")).json()) as {
+      groupId: string | null;
+    };
+    expect(scoped.groupId).toBe("prod");
+  });
+
+  it("PATCH assigns a group_id, writing only group_id (never auth_value)", async () => {
+    const res = await adminOpenApiDatasources.request("/ds-1", {
+      method: "PATCH",
+      headers: JSON_HEADERS,
+      body: JSON.stringify({ groupId: "prod" }),
+    });
+    expect(res.status).toBe(200);
+    expect((await res.json()) as { groupId: string | null }).toMatchObject({ groupId: "prod" });
+    const update = findConfigUpdate();
+    expect(update?.[0]).toContain("jsonb_build_object('group_id'");
+    expect(update?.[0]).not.toContain("auth_value");
+    expect(update?.[1]).toEqual([FIXTURE.owner, "ds-1", CATALOG_ID, "prod"]);
+  });
+
+  it("PATCH clears the scope back to workspace-global by binding null", async () => {
+    const res = await adminOpenApiDatasources.request("/ds-1", {
+      method: "PATCH",
+      headers: JSON_HEADERS,
+      body: JSON.stringify({ groupId: null }),
+    });
+    expect(res.status).toBe(200);
+    expect((await res.json()) as { groupId: string | null }).toMatchObject({ groupId: null });
+    // The merge binds null → JSON null → read back as workspace-global.
+    expect(findConfigUpdate()?.[1]).toEqual([FIXTURE.owner, "ds-1", CATALOG_ID, null]);
+  });
+
+  it("PATCH treats a whitespace-only group id as a clear (null), never a literal scope", async () => {
+    const res = await adminOpenApiDatasources.request("/ds-1", {
+      method: "PATCH",
+      headers: JSON_HEADERS,
+      body: JSON.stringify({ groupId: "   " }),
+    });
+    expect(res.status).toBe(200);
+    expect(findConfigUpdate()?.[1]).toEqual([FIXTURE.owner, "ds-1", CATALOG_ID, null]);
+  });
+
+  it("PATCH can set representation mode and group scope together", async () => {
+    const res = await adminOpenApiDatasources.request("/ds-1", {
+      method: "PATCH",
+      headers: JSON_HEADERS,
+      body: JSON.stringify({ representationMode: "semantic-yaml", groupId: "eu" }),
+    });
+    expect(res.status).toBe(200);
+    const update = findConfigUpdate();
+    expect(update?.[0]).toContain("representation_mode");
+    expect(update?.[0]).toContain("group_id");
+    expect(update?.[1]).toEqual([FIXTURE.owner, "ds-1", CATALOG_ID, "semantic-yaml", "eu"]);
+  });
+});

--- a/packages/api/src/api/routes/__tests__/me-connection-groups.test.ts
+++ b/packages/api/src/api/routes/__tests__/me-connection-groups.test.ts
@@ -63,7 +63,17 @@ type GroupRow = {
   db_type: string | null;
   description: string | null;
 };
+// #3044 — the route now also reads REST datasource installs (group_id may be
+// NULL) for the picker's scope footer. Routed by SQL content in the mock.
+type RestRow = {
+  install_id: string;
+  display_name: string | null;
+  snapshot_title: string | null;
+  group_id: string | null;
+};
 let rowsForOrg: Record<string, GroupRow[]> = {};
+let restRowsForOrg: Record<string, RestRow[]> = {};
+let capturedQueries: string[] = [];
 
 mock.module("@atlas/api/lib/db/internal", () => {
   const notUsed = () => {
@@ -71,8 +81,12 @@ mock.module("@atlas/api/lib/db/internal", () => {
   };
   return {
     hasInternalDB: () => dbAvailable,
-    internalQuery: async (_sql: string, params: unknown[]) => {
+    internalQuery: async (sql: string, params: unknown[]) => {
+      capturedQueries.push(sql);
       const [orgId] = params as [string];
+      // The REST-datasource query is the one projecting `display_name`; the
+      // SQL-member query projects `install_id AS connection_id`.
+      if (sql.includes("display_name")) return restRowsForOrg[orgId] ?? [];
       return rowsForOrg[orgId] ?? [];
     },
     getInternalDB: () => null,
@@ -153,6 +167,7 @@ async function getJson(res: Response) {
       primaryConnectionId: string | null;
       members: Array<{ connectionId: string; dbType: string; description: string | null }>;
     }>;
+    restDatasources: Array<{ id: string; displayName: string; groupId: string | null }>;
     reason: "no_active_org" | "no_internal_db" | null;
   };
 }
@@ -161,6 +176,8 @@ beforeEach(() => {
   fakeAuth = null;
   dbAvailable = true;
   rowsForOrg = {};
+  restRowsForOrg = {};
+  capturedQueries = [];
 });
 
 describe("GET /api/v1/me/connection-groups — reason field (#2422)", () => {
@@ -338,5 +355,73 @@ describe("GET /api/v1/me/connection-groups — primaryConnectionId surfacing (po
     const res = await meConnectionGroups.request("/", { method: "GET" });
     const body = await getJson(res);
     expect(body.groups[0]?.members[0]?.dbType).toBe("unknown");
+  });
+});
+
+describe("GET /api/v1/me/connection-groups — REST datasource scope (#3044)", () => {
+  it("surfaces REST datasources with their groupId (workspace-global vs scoped)", async () => {
+    fakeAuth = userAuth();
+    restRowsForOrg["org-1"] = [
+      { install_id: "stripe-1", display_name: "Stripe", snapshot_title: null, group_id: null },
+      { install_id: "intl-api", display_name: null, snapshot_title: "Intl API", group_id: "eu" },
+    ];
+    const res = await meConnectionGroups.request("/", { method: "GET" });
+    expect(res.status).toBe(200);
+    const body = await getJson(res);
+    expect(body.restDatasources).toEqual([
+      { id: "stripe-1", displayName: "Stripe", groupId: null },
+      // display_name blank → falls back to the spec title.
+      { id: "intl-api", displayName: "Intl API", groupId: "eu" },
+    ]);
+  });
+
+  it("always includes restDatasources (empty array when the workspace has none)", async () => {
+    fakeAuth = userAuth();
+    const res = await meConnectionGroups.request("/", { method: "GET" });
+    const body = await getJson(res);
+    expect(body.restDatasources).toEqual([]);
+  });
+
+  it("falls back to install_id for displayName when both display_name and spec title are blank", async () => {
+    fakeAuth = userAuth();
+    restRowsForOrg["org-1"] = [
+      { install_id: "anon-ds", display_name: null, snapshot_title: null, group_id: null },
+    ];
+    const res = await meConnectionGroups.request("/", { method: "GET" });
+    const body = await getJson(res);
+    expect(body.restDatasources).toEqual([
+      { id: "anon-ds", displayName: "anon-ds", groupId: null },
+    ]);
+  });
+
+  it("the SQL-member query excludes REST catalog_ids; the REST query selects them", async () => {
+    fakeAuth = userAuth();
+    rowsForOrg["org-1"] = [];
+    await meConnectionGroups.request("/", { method: "GET" });
+
+    const memberQuery = capturedQueries.find((q) => q.includes("install_id           AS connection_id"));
+    const restQuery = capturedQueries.find((q) => q.includes("display_name"));
+    expect(memberQuery).toBeDefined();
+    expect(restQuery).toBeDefined();
+    // Members EXCLUDE REST; the REST list INCLUDES exactly those catalogs.
+    expect(memberQuery!.replace(/\s+/g, " ")).toContain("catalog_id <> ALL($2)");
+    expect(restQuery!.replace(/\s+/g, " ")).toContain("catalog_id = ANY($2)");
+  });
+
+  it("REST datasources do NOT appear as SQL group members", async () => {
+    // A REST install scoped to a SQL group must never be returned as a pickable
+    // member (it can't run SQL). The route's catalog exclusion + separate query
+    // keep the two surfaces disjoint.
+    fakeAuth = userAuth();
+    rowsForOrg["org-1"] = [
+      { group_id: "prod", connection_id: "us-prod", db_type: "postgres", description: null },
+    ];
+    restRowsForOrg["org-1"] = [
+      { install_id: "rest-prod", display_name: "Prod API", snapshot_title: null, group_id: "prod" },
+    ];
+    const res = await meConnectionGroups.request("/", { method: "GET" });
+    const body = await getJson(res);
+    expect(body.groups[0]?.members.map((m) => m.connectionId)).toEqual(["us-prod"]);
+    expect(body.restDatasources.map((d) => d.id)).toEqual(["rest-prod"]);
   });
 });

--- a/packages/api/src/api/routes/admin-openapi-datasources.ts
+++ b/packages/api/src/api/routes/admin-openapi-datasources.ts
@@ -44,6 +44,7 @@ import {
 } from "@atlas/api/lib/openapi/probe";
 import { REPRESENTATION_MODES } from "@atlas/api/lib/openapi/representation";
 import { normalizeGroupId } from "@atlas/api/lib/openapi/datasource";
+import { verifyGroupBelongsToOrg } from "@atlas/api/lib/conversations";
 import {
   coerceSpecRefreshInterval,
   normalizeSpecRefreshInterval,
@@ -560,11 +561,35 @@ adminOpenApiDatasources.openapi(patchRoute, async (c) =>
     }
     if (groupId !== undefined) {
       // #3044 — assign (string) or clear (null → JSON null, read back as
-      // workspace-global) the cross-environment scope. The group id is free-form
-      // (mirrors SQL connections' `config.group_id` JSONB string); the admin UI
-      // sources it from the workspace's existing groups. `normalizeGroupId`
+      // workspace-global) the cross-environment scope. `normalizeGroupId`
       // collapses null / "" / whitespace to the workspace-global clear.
       const value = normalizeGroupId(groupId);
+      // A non-null assignment must reference an environment group that actually
+      // exists in this workspace — otherwise the new scope filter hides the
+      // datasource from every real environment until someone notices (Codex
+      // review on #3048). Mirror the chat route's `verifyGroupBelongsToOrg`
+      // org-scoped existence guard; clearing to workspace-global is never gated.
+      if (value !== null) {
+        const verdict = await verifyGroupBelongsToOrg(value, orgId);
+        if (verdict === "not_found") {
+          return c.json(
+            {
+              error: "invalid_connection_group",
+              message: `Environment group "${value}" doesn't exist in this workspace. Create it by assigning a connection to it first, or pick an existing environment.`,
+              requestId,
+            },
+            400,
+          );
+        }
+        if (verdict === "error") {
+          return c.json(
+            { error: "internal_error", message: "Could not verify the environment group. Please retry.", requestId },
+            500,
+          );
+        }
+        // "ok" → exists; "no_db" → can't check (self-hosted without internal DB,
+        // where REST installs can't exist anyway) → allow the write.
+      }
       updates.group_id = value;
       changed.groupId = value;
     }

--- a/packages/api/src/api/routes/admin-openapi-datasources.ts
+++ b/packages/api/src/api/routes/admin-openapi-datasources.ts
@@ -43,6 +43,7 @@ import {
   OpenApiProbeError,
 } from "@atlas/api/lib/openapi/probe";
 import { REPRESENTATION_MODES } from "@atlas/api/lib/openapi/representation";
+import { normalizeGroupId } from "@atlas/api/lib/openapi/datasource";
 import {
   coerceSpecRefreshInterval,
   normalizeSpecRefreshInterval,
@@ -90,6 +91,10 @@ function summarizeInstall(installId: string, config: Record<string, unknown> | n
     openapiUrl: typeof c.openapi_url === "string" ? c.openapi_url : null,
     baseUrlOverride: typeof c.base_url_override === "string" ? c.base_url_override : null,
     representationMode: coerceRepresentationMode(c.representation_mode),
+    // #3044 — cross-environment scope (ADR-0010). `null` ⇒ workspace-global;
+    // a string ⇒ scoped to that connection group. `normalizeGroupId` is the
+    // shared empty→workspace-global coercion the resolver also uses.
+    groupId: normalizeGroupId(c.group_id),
     // Per-install spec-refresh interval (#2977). Fail-soft display coercion so a
     // drifted / absent value renders as the `off` default rather than undefined.
     specRefreshInterval: coerceSpecRefreshInterval(c.spec_refresh_interval),
@@ -229,10 +234,28 @@ const patchRoute = createRoute({
                     "Out-of-range positive values are clamped; unparseable values are rejected with an actionable error.",
                   example: "daily",
                 }),
+              // #3044 — cross-environment scope (ADR-0010). A non-empty string
+              // scopes the datasource to that connection group; `null` clears the
+              // assignment back to workspace-global. Omitted ⇒ left unchanged.
+              groupId: z
+                .string()
+                .min(1)
+                .nullable()
+                .optional()
+                .openapi({
+                  description:
+                    "Connection group this REST datasource is scoped to. A group id restricts the " +
+                    "datasource to conversations whose active environment is that group; null clears the " +
+                    "scope back to workspace-global (available in every environment).",
+                  example: "prod",
+                }),
             })
             .refine(
-              (b) => b.representationMode !== undefined || b.specRefreshInterval !== undefined,
-              { message: "Provide representationMode and/or specRefreshInterval." },
+              (b) =>
+                b.representationMode !== undefined ||
+                b.specRefreshInterval !== undefined ||
+                b.groupId !== undefined,
+              { message: "Provide representationMode, specRefreshInterval, and/or groupId." },
             ),
         },
       },
@@ -507,7 +530,7 @@ adminOpenApiDatasources.openapi(patchRoute, async (c) =>
   runHandler(c, "update openapi datasource", async () => {
     const { orgId, requestId } = c.get("orgContext");
     const { installId } = c.req.valid("param");
-    const { representationMode, specRefreshInterval } = c.req.valid("json");
+    const { representationMode, specRefreshInterval, groupId } = c.req.valid("json");
     const row = await loadInstall(orgId, installId);
     if (!row) {
       return c.json({ error: "not_found", message: `No OpenAPI datasource "${installId}".`, requestId }, 404);
@@ -517,8 +540,9 @@ adminOpenApiDatasources.openapi(patchRoute, async (c) =>
     // (snake_case) it writes, and the camelCase wire shape echoed in the response
     // + audit metadata. Each column key is from a fixed allow-set (never user
     // input) so interpolating it into the SQL is safe; the value is always bound.
-    const updates: Record<string, string> = {};
-    const changed: Record<string, string> = {};
+    // A `null` value clears a field (writes JSON null) — used to unassign group_id.
+    const updates: Record<string, string | null> = {};
+    const changed: Record<string, string | null> = {};
     if (representationMode !== undefined) {
       updates.representation_mode = representationMode;
       changed.representationMode = representationMode;
@@ -533,6 +557,16 @@ adminOpenApiDatasources.openapi(patchRoute, async (c) =>
       }
       updates.spec_refresh_interval = normalized.value;
       changed.specRefreshInterval = normalized.value;
+    }
+    if (groupId !== undefined) {
+      // #3044 — assign (string) or clear (null → JSON null, read back as
+      // workspace-global) the cross-environment scope. The group id is free-form
+      // (mirrors SQL connections' `config.group_id` JSONB string); the admin UI
+      // sources it from the workspace's existing groups. `normalizeGroupId`
+      // collapses null / "" / whitespace to the workspace-global clear.
+      const value = normalizeGroupId(groupId);
+      updates.group_id = value;
+      changed.groupId = value;
     }
 
     // JSONB merge of only the provided fields — the encrypted auth_value is

--- a/packages/api/src/api/routes/me-connection-groups.ts
+++ b/packages/api/src/api/routes/me-connection-groups.ts
@@ -24,6 +24,8 @@ import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
 import { createLogger } from "@atlas/api/lib/logger";
 import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
 import { hasInternalDB, internalQuery } from "@atlas/api/lib/db/internal";
+import { REST_DATASOURCE_CATALOG_IDS } from "@atlas/api/lib/openapi/data-candidates";
+import { normalizeGroupId } from "@atlas/api/lib/openapi/datasource";
 import { standardAuth, type AuthEnv } from "./middleware";
 import { ErrorSchema, AuthErrorSchema } from "./shared-schemas";
 
@@ -44,6 +46,22 @@ const ConnectionGroupSchema = z.object({
 });
 
 /**
+ * A REST/OpenAPI datasource's cross-environment scope (#3044, ADR-0010), surfaced
+ * so the chat env picker can frame what a pinned conversation can actually reach.
+ * REST datasources are NOT SQL `members` (they're not execution targets for the
+ * Pin/All routing), so they ride a parallel array rather than polluting `groups`.
+ *
+ * `groupId === null` ⇒ **workspace-global** (available in every conversation,
+ * NOT constrained by the env pin). A string ⇒ **scoped** to that connection
+ * group (in-scope only when that group is active).
+ */
+const RestDatasourceScopeSchema = z.object({
+  id: z.string(),
+  displayName: z.string(),
+  groupId: z.string().nullable(),
+});
+
+/**
  * Why an empty `groups` list. `null` ⇒ the workspace genuinely has no
  * groups configured (picker stays hidden, legacy single-connection
  * routing kicks in). Anything else is a degraded state the user should
@@ -57,6 +75,9 @@ export type MeConnectionGroupsEmptyReason = "no_active_org" | "no_internal_db";
 
 const ResponseSchema = z.object({
   groups: z.array(ConnectionGroupSchema),
+  // #3044 — REST datasources + their env scope, for the picker's scope summary.
+  // Always present (possibly empty) so the frontend never branches on absence.
+  restDatasources: z.array(RestDatasourceScopeSchema),
   reason: z.enum(["no_active_org", "no_internal_db"]).nullable(),
 });
 
@@ -105,7 +126,7 @@ meConnectionGroups.openapi(listRoute, async (c) => {
   // for the load-bearing test on this precedence.
   if (!hasInternalDB()) {
     return c.json(
-      { groups: [], reason: "no_internal_db" as const },
+      { groups: [], restDatasources: [], reason: "no_internal_db" as const },
       200,
     );
   }
@@ -119,7 +140,7 @@ meConnectionGroups.openapi(listRoute, async (c) => {
       "me/connection-groups: no active organization for user",
     );
     return c.json(
-      { groups: [], reason: "no_active_org" as const },
+      { groups: [], restDatasources: [], reason: "no_active_org" as const },
       200,
     );
   }
@@ -133,24 +154,53 @@ meConnectionGroups.openapi(listRoute, async (c) => {
     // id" collapse to the same value (the JSONB string). There's no
     // `primary_connection_id` — the picker falls back to the deterministic
     // first-by-install_id ordering when no explicit pin exists.
-    const rows = await internalQuery<{
-      group_id: string;
-      connection_id: string;
-      db_type: string | null;
-      description: string | null;
-    }>(
-      `SELECT config->>'group_id' AS group_id,
-              install_id           AS connection_id,
-              config->>'db_type'   AS db_type,
-              config->>'description' AS description
-         FROM workspace_plugins
-        WHERE workspace_id = $1
-          AND pillar = 'datasource'
-          AND status != 'archived'
-          AND config->>'group_id' IS NOT NULL
-        ORDER BY config->>'group_id' ASC, install_id ASC`,
-      [orgId],
-    );
+    // #3044 — SQL connection groups + REST datasource scope resolve in one
+    // round-trip. SQL members EXCLUDE REST `catalog_id`s (REST datasources share
+    // `pillar = 'datasource'` but are not SQL execution targets — listing them as
+    // pickable members would route the agent to a connection that can't run SQL,
+    // ADR-0010); REST datasources ride their own array with their `group_id`.
+    const restCatalogIds = [...REST_DATASOURCE_CATALOG_IDS];
+    const [rows, restRows] = await Promise.all([
+      internalQuery<{
+        group_id: string;
+        connection_id: string;
+        db_type: string | null;
+        description: string | null;
+      }>(
+        `SELECT config->>'group_id' AS group_id,
+                install_id           AS connection_id,
+                config->>'db_type'   AS db_type,
+                config->>'description' AS description
+           FROM workspace_plugins
+          WHERE workspace_id = $1
+            AND pillar = 'datasource'
+            AND catalog_id <> ALL($2)
+            AND status != 'archived'
+            AND config->>'group_id' IS NOT NULL
+          ORDER BY config->>'group_id' ASC, install_id ASC`,
+        [orgId, restCatalogIds],
+      ),
+      // REST datasources — group_id may be NULL (workspace-global) or set
+      // (scoped). The picker frames the cross-env reach from this.
+      internalQuery<{
+        install_id: string;
+        display_name: string | null;
+        snapshot_title: string | null;
+        group_id: string | null;
+      }>(
+        `SELECT install_id,
+                config->>'display_name'                  AS display_name,
+                config->'openapi_snapshot'->>'title'     AS snapshot_title,
+                config->>'group_id'                      AS group_id
+           FROM workspace_plugins
+          WHERE workspace_id = $1
+            AND catalog_id = ANY($2)
+            AND pillar = 'datasource'
+            AND status != 'archived'
+          ORDER BY install_id ASC`,
+        [orgId, restCatalogIds],
+      ),
+    ]);
 
     // Pivot the flat rows into one entry per group with a `members` array.
     const byGroup = new Map<string, z.infer<typeof ConnectionGroupSchema>>();
@@ -171,12 +221,26 @@ meConnectionGroups.openapi(listRoute, async (c) => {
         description: row.description,
       });
     }
+    // Project REST datasources into the scope shape. A blank display name falls
+    // back to the spec title, then the install id — mirrors the admin summary.
+    const restDatasources = restRows.map((r) => ({
+      id: r.install_id,
+      displayName:
+        (r.display_name && r.display_name.length > 0 ? r.display_name : null) ??
+        (r.snapshot_title && r.snapshot_title.length > 0 ? r.snapshot_title : null) ??
+        r.install_id,
+      groupId: normalizeGroupId(r.group_id),
+    }));
+
     // `reason: null` covers both "workspace has groups" and the
     // ordinary "workspace has no groups configured yet" — the picker
     // treats null as "no banner; just hide if the array is empty". A
     // populated `reason` is reserved for genuinely degraded states the
     // caller couldn't reach a usable query for.
-    return c.json({ groups: Array.from(byGroup.values()), reason: null }, 200);
+    return c.json(
+      { groups: Array.from(byGroup.values()), restDatasources, reason: null },
+      200,
+    );
   } catch (err) {
     log.error(
       { err: errorMessage(err), requestId, orgId },

--- a/packages/api/src/lib/__tests__/agent-scope-prompt.test.ts
+++ b/packages/api/src/lib/__tests__/agent-scope-prompt.test.ts
@@ -95,12 +95,13 @@ mock.module("@atlas/api/lib/db/connection", () =>
 
 // Inject a fixed routing context — three members, primary us-int.
 mock.module("@atlas/api/lib/env-routing/lookup", () => ({
-  loadGroupRoutingContext: async (_orgId: string | undefined, currentMember: string) => ({
-    groupId: "prod",
-    members: ["us-int", "eu", "apac"],
-    primaryMember: "us-int",
-    currentMember,
-  }),
+  loadGroupRoutingContext: async (_orgId: string | undefined, currentMember: string) =>
+    // A sentinel connection that resolves to NO group (1×1, ungrouped) so the
+    // #3044 "no environment context" path is reachable; everything else is the
+    // 3-member `prod` group the scope-routing tests rely on.
+    currentMember === "ungrouped-conn"
+      ? { members: ["ungrouped-conn"], primaryMember: "ungrouped-conn", currentMember }
+      : { groupId: "prod", members: ["us-int", "eu", "apac"], primaryMember: "us-int", currentMember },
 }));
 
 mock.module("@atlas/api/lib/cache/index", () => ({
@@ -277,8 +278,8 @@ describe("buildSystemParam — scope guidance section (slice 2)", () => {
 });
 
 describe("buildRestDatasourceScopeNote — REST env-scope framing (#3044)", () => {
-  it("frames a workspace-global datasource as not constrained by the pin (multi-env)", () => {
-    const note = buildRestDatasourceScopeNote({}, { inMultiEnvGroup: true });
+  it("frames a workspace-global datasource as not constrained by the pin (bound to an env)", () => {
+    const note = buildRestDatasourceScopeNote({}, { boundToEnvironment: true });
     expect(note).toContain("workspace-global");
     expect(note).toContain("NOT");
     expect(note.toLowerCase()).toContain("environment selection/pin");
@@ -286,16 +287,16 @@ describe("buildRestDatasourceScopeNote — REST env-scope framing (#3044)", () =
     expect(note).toContain("Do not describe the conversation as limited to one environment");
   });
 
-  it("softens the framing in a single-env workspace (no pin to contrast)", () => {
-    const note = buildRestDatasourceScopeNote({}, { inMultiEnvGroup: false });
+  it("softens the framing in a single-connection workspace (no environment to contrast)", () => {
+    const note = buildRestDatasourceScopeNote({}, { boundToEnvironment: false });
     expect(note).toContain("workspace-global");
     expect(note).toContain("available in every environment");
-    // No pin exists, so the contrast clause is omitted.
+    // No environment selection exists, so the contrast clause is omitted.
     expect(note).not.toContain("NOT constrained");
   });
 
   it("frames a scoped datasource as bound to its environment group", () => {
-    const note = buildRestDatasourceScopeNote({ groupId: "prod" }, { inMultiEnvGroup: true });
+    const note = buildRestDatasourceScopeNote({ groupId: "prod" }, { boundToEnvironment: true });
     expect(note).toContain("`prod`");
     expect(note).toContain("only reachable");
     expect(note).not.toContain("workspace-global");
@@ -304,7 +305,7 @@ describe("buildRestDatasourceScopeNote — REST env-scope framing (#3044)", () =
   it("a provided restRepresentation is appended to the system prompt verbatim", () => {
     // The run loop prepends buildRestDatasourceScopeNote() to each datasource's
     // section; buildSystemParam appends the whole restRepresentation string.
-    const scopeNote = buildRestDatasourceScopeNote({}, { inMultiEnvGroup: true });
+    const scopeNote = buildRestDatasourceScopeNote({}, { boundToEnvironment: true });
     const rep = `${scopeNote}\n\n### REST Datasource\nuse executeRestOperation…`;
     const result = buildSystemParam(
       "openai",
@@ -460,7 +461,7 @@ describe("agent loop — REST datasource scope threading (#3044)", () => {
     process.env.ATLAS_DATASOURCE_URL = "postgresql://test:test@localhost:5432/test";
   });
 
-  it("threads the conversation's connectionGroupId into the REST resolver as activeGroupId", async () => {
+  it("threads the conversation's explicit connectionGroupId into the REST resolver", async () => {
     await withRequestContext(
       {
         requestId: "rest-1",
@@ -475,11 +476,26 @@ describe("agent loop — REST datasource scope threading (#3044)", () => {
     expect(capturedRestResolveArgs!.deps).toEqual({ activeGroupId: "prod" });
   });
 
-  it("passes activeGroupId: null (NOT undefined) when the conversation has no active group", async () => {
+  it("infers the active group from connectionId when connectionGroupId is omitted (Codex review)", async () => {
+    // A legacy / API caller sends only connectionId. The connection resolves to
+    // group `prod`, so its environment-local REST datasources stay reachable
+    // instead of being filtered out as if the turn were ungrouped.
     await withRequestContext(
       {
         requestId: "rest-2",
         connectionId: "us-int",
+        user: { id: "u1", mode: "managed", label: "u@test", role: "member", activeOrganizationId: "org-1" },
+      },
+      () => runAgent({ messages: userMessages("hello") }),
+    );
+    expect(capturedRestResolveArgs!.deps).toEqual({ activeGroupId: "prod" });
+  });
+
+  it("passes activeGroupId: null (NOT undefined) when the connection resolves to no group", async () => {
+    await withRequestContext(
+      {
+        requestId: "rest-3",
+        connectionId: "ungrouped-conn",
         user: { id: "u1", mode: "managed", label: "u@test", role: "member", activeOrganizationId: "org-1" },
       },
       () => runAgent({ messages: userMessages("hello") }),

--- a/packages/api/src/lib/__tests__/agent-scope-prompt.test.ts
+++ b/packages/api/src/lib/__tests__/agent-scope-prompt.test.ts
@@ -39,6 +39,9 @@ process.env.ATLAS_DATASOURCE_URL ??= "postgresql://test:test@localhost:5432/test
 
 let mockModel: InstanceType<typeof MockLanguageModelV3>;
 let lastSystemPrompt: string | undefined;
+// #3044 — capture how the agent loop calls the REST resolver so we can pin that
+// the conversation's `connectionGroupId` is threaded as `activeGroupId`.
+let capturedRestResolveArgs: { orgId: string; deps: unknown } | undefined;
 
 mock.module("@atlas/api/lib/providers", () => ({
   getModel: () => mockModel,
@@ -110,6 +113,20 @@ mock.module("@atlas/api/lib/cache/index", () => ({
   _resetCache: () => {},
 }));
 
+// #3044 — capture the agent loop's REST resolver call. Returns [] so the REST
+// block is a no-op (no representation built); the existing scope-routing tests
+// don't set an org id, so `agent.ts` short-circuits to [] before this is reached.
+mock.module("@atlas/api/lib/openapi/workspace-datasource", () => ({
+  resolveWorkspaceRestDatasources: async (orgId: string, deps: unknown) => {
+    capturedRestResolveArgs = { orgId, deps };
+    return [];
+  },
+  resolveWorkspaceRestDatasourcesOrThrow: async () => [],
+  resolveWorkspacePrimaryRestDatasource: async () => null,
+  defaultQuery: async () => [],
+  RestDatasourceReconnectError: class extends Error {},
+}));
+
 // Spy on the LLM `doStream` call so we can capture the rendered system prompt
 function makeSpyingModel(toolCallArgs: Record<string, unknown>): InstanceType<typeof MockLanguageModelV3> {
   let streamIdx = 0;
@@ -160,7 +177,7 @@ function makeSpyingModel(toolCallArgs: Record<string, unknown>): InstanceType<ty
 }
 
 const { runAgent } = await import("@atlas/api/lib/agent");
-const { buildSystemParam } = await import("@atlas/api/lib/agent");
+const { buildSystemParam, buildRestDatasourceScopeNote } = await import("@atlas/api/lib/agent");
 const { withRequestContext } = await import("@atlas/api/lib/logger");
 
 function userMessages(content: string): UIMessage[] {
@@ -256,6 +273,53 @@ describe("buildSystemParam — scope guidance section (slice 2)", () => {
     );
     const prompt = result as string;
     expect(prompt).toMatch(/current member is `eu`/);
+  });
+});
+
+describe("buildRestDatasourceScopeNote — REST env-scope framing (#3044)", () => {
+  it("frames a workspace-global datasource as not constrained by the pin (multi-env)", () => {
+    const note = buildRestDatasourceScopeNote({}, { inMultiEnvGroup: true });
+    expect(note).toContain("workspace-global");
+    expect(note).toContain("NOT");
+    expect(note.toLowerCase()).toContain("environment selection/pin");
+    // The crux of the bug: the model must not present the chat as env-limited.
+    expect(note).toContain("Do not describe the conversation as limited to one environment");
+  });
+
+  it("softens the framing in a single-env workspace (no pin to contrast)", () => {
+    const note = buildRestDatasourceScopeNote({}, { inMultiEnvGroup: false });
+    expect(note).toContain("workspace-global");
+    expect(note).toContain("available in every environment");
+    // No pin exists, so the contrast clause is omitted.
+    expect(note).not.toContain("NOT constrained");
+  });
+
+  it("frames a scoped datasource as bound to its environment group", () => {
+    const note = buildRestDatasourceScopeNote({ groupId: "prod" }, { inMultiEnvGroup: true });
+    expect(note).toContain("`prod`");
+    expect(note).toContain("only reachable");
+    expect(note).not.toContain("workspace-global");
+  });
+
+  it("a provided restRepresentation is appended to the system prompt verbatim", () => {
+    // The run loop prepends buildRestDatasourceScopeNote() to each datasource's
+    // section; buildSystemParam appends the whole restRepresentation string.
+    const scopeNote = buildRestDatasourceScopeNote({}, { inMultiEnvGroup: true });
+    const rep = `${scopeNote}\n\n### REST Datasource\nuse executeRestOperation…`;
+    const result = buildSystemParam(
+      "openai",
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      "developer",
+      rep,
+    );
+    const prompt = result as string;
+    expect(prompt).toContain("workspace-global");
+    expect(prompt).toContain("### REST Datasource");
   });
 });
 
@@ -355,4 +419,74 @@ describe("agent integration — scope routing via mocked LLM (slice 2)", () => {
   // `routingContext: undefined` and `routingContext.members: [x]` (current
   // member only) omit the Cross-Environment Routing section, which is the
   // same logical assertion at a stricter boundary.
+});
+
+describe("agent loop — REST datasource scope threading (#3044)", () => {
+  // A text-only model so the resolver is exercised during prompt-build without
+  // running the executeSQL path (which would need an org-aware connection mock).
+  function makeTextOnlyModel(): InstanceType<typeof MockLanguageModelV3> {
+    return new MockLanguageModelV3({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      doStream: async (opts: any) => {
+        const systemMsg = opts?.prompt?.find((p: { role: string }) => p.role === "system");
+        if (systemMsg) {
+          lastSystemPrompt =
+            typeof systemMsg.content === "string"
+              ? systemMsg.content
+              : Array.isArray(systemMsg.content)
+                ? systemMsg.content.map((c: { text?: string }) => c.text ?? "").join("")
+                : "";
+        }
+        return {
+          stream: convertArrayToReadableStream([
+            { type: "text-delta", id: "t0", delta: "Hi." },
+            {
+              type: "finish",
+              usage: {
+                inputTokens: { total: 5, noCache: 5, cacheRead: undefined, cacheWrite: undefined },
+                outputTokens: { total: 5, text: 5, reasoning: undefined },
+              },
+              finishReason: { unified: "stop", raw: "end_turn" },
+            },
+          ]),
+        };
+      },
+    });
+  }
+
+  beforeEach(() => {
+    capturedRestResolveArgs = undefined;
+    mockModel = makeTextOnlyModel();
+    process.env.ATLAS_DATASOURCE_URL = "postgresql://test:test@localhost:5432/test";
+  });
+
+  it("threads the conversation's connectionGroupId into the REST resolver as activeGroupId", async () => {
+    await withRequestContext(
+      {
+        requestId: "rest-1",
+        connectionId: "us-int",
+        connectionGroupId: "prod",
+        user: { id: "u1", mode: "managed", label: "u@test", role: "member", activeOrganizationId: "org-1" },
+      },
+      () => runAgent({ messages: userMessages("hello") }),
+    );
+    expect(capturedRestResolveArgs).toBeDefined();
+    expect(capturedRestResolveArgs!.orgId).toBe("org-1");
+    expect(capturedRestResolveArgs!.deps).toEqual({ activeGroupId: "prod" });
+  });
+
+  it("passes activeGroupId: null (NOT undefined) when the conversation has no active group", async () => {
+    await withRequestContext(
+      {
+        requestId: "rest-2",
+        connectionId: "us-int",
+        user: { id: "u1", mode: "managed", label: "u@test", role: "member", activeOrganizationId: "org-1" },
+      },
+      () => runAgent({ messages: userMessages("hello") }),
+    );
+    expect(capturedRestResolveArgs!.deps).toEqual({ activeGroupId: null });
+    // `undefined` would disable scoping in the resolver (the confirm-replay path)
+    // and re-leak a scoped datasource into the chat — the regression #3044 closes.
+    expect((capturedRestResolveArgs!.deps as { activeGroupId: unknown }).activeGroupId).not.toBeUndefined();
+  });
 });

--- a/packages/api/src/lib/agent.ts
+++ b/packages/api/src/lib/agent.ts
@@ -236,6 +236,43 @@ Each \`executeSQL\` call can carry a \`scope\` argument that decides which envir
 The result of a fanned-out query carries an \`envContributions\` array describing each environment's row count, duration, and error (if any). Use it to surface partial failures to the user instead of silently treating a failed env as zero rows.`;
 }
 
+/**
+ * #3044 — REST datasource environment-scope framing ([ADR-0010]). Returns the
+ * one-line scope banner prepended to a REST datasource's prompt section so the
+ * agent (and, downstream, the user) knows whether the datasource is constrained
+ * by the conversation's environment selection.
+ *
+ * The bug this closes: a chat pinned to one SQL environment LOOKS fully
+ * constrained, but a workspace-global REST datasource answers regardless of the
+ * pin. Making the reach explicit means the model never implies the conversation
+ * is scoped tighter than it is.
+ *
+ * Pure. `inMultiEnvGroup` toggles the extra "not constrained by the pin"
+ * emphasis — in a single-environment workspace there is no pin to contrast
+ * against, so the softer phrasing avoids implying a selection that isn't there.
+ */
+export function buildRestDatasourceScopeNote(
+  ds: { readonly groupId?: string },
+  opts: { readonly inMultiEnvGroup: boolean },
+): string {
+  if (ds.groupId) {
+    return (
+      `**Environment scope:** scoped to environment group \`${ds.groupId}\` — ` +
+      `this REST datasource is part of that environment and is only reachable ` +
+      `while that group is the conversation's active environment.`
+    );
+  }
+  const pinClause = opts.inMultiEnvGroup
+    ? " It is **NOT** constrained by this conversation's environment selection/pin — " +
+      "querying it reaches the same upstream account regardless of which SQL environment is active. " +
+      "Do not describe the conversation as limited to one environment when answering from it."
+    : "";
+  return (
+    `**Environment scope:** workspace-global — available in every environment.` +
+    pinClause
+  );
+}
+
 function buildMultiSourceSection(
   sources: ConnectionMetadata[],
 ): string {
@@ -874,6 +911,27 @@ export async function runAgent({
   // Resolve async work before entering otelContext.with() (sync callback).
   const modelMessages = await convertToModelMessages(messages);
 
+  // #2517 — load active-group routing context so the system prompt can
+  // teach the agent when to set `scope` on `executeSQL`. Falls back to
+  // a 1×1 result (no prompt section) when no group is bound or the
+  // lookup fails — single-env workspaces see no behavioural change.
+  // Resolved BEFORE the REST block (#3044) so each REST datasource's
+  // representation can be framed against whether a multi-env pin exists.
+  let scopeRoutingContext: ScopeRoutingContext | undefined;
+  if (connectionId) {
+    const ctx = await loadGroupRoutingContext(orgId, connectionId);
+    if (ctx.members.length > 1) {
+      scopeRoutingContext = {
+        members: ctx.members,
+        currentMember: ctx.currentMember,
+        ...(ctx.groupId ? { groupId: ctx.groupId } : {}),
+      };
+    }
+  }
+  // A multi-env group means a pin exists that a workspace-global REST
+  // datasource silently escapes — the framing must call that out (#3044).
+  const inMultiEnvGroup = scopeRoutingContext !== undefined;
+
   // #2926 — REST datasources (slice 2: per-workspace `openapi-generic` installs).
   // Resolve every REST datasource the workspace has installed (Twenty, Stripe,
   // an internal service…) from `workspace_plugins`, merge the
@@ -882,10 +940,19 @@ export async function runAgent({
   // common case) resolve `[]` and pay nothing. The slice-1 `ATLAS_OPENAPI_TWENTY*`
   // env path is retired. Fail-soft: a preflight error degrades to "no REST
   // datasource" rather than breaking the chat turn.
+  //
+  // #3044 — scope filter: a datasource scoped to a different environment group
+  // resolves out (the resolver keeps workspace-global + active-group matches).
+  // `connectionGroupId ?? null` ⇒ a chat with no active group sees only
+  // workspace-global datasources; a scoped one never leaks past its environment.
   let activeRegistry = toolRegistry;
   let restRepresentation: string | undefined;
   try {
-    const restDatasources = orgId ? await resolveWorkspaceRestDatasources(orgId) : [];
+    const restDatasources = orgId
+      ? await resolveWorkspaceRestDatasources(orgId, {
+          activeGroupId: connectionGroupId ?? null,
+        })
+      : [];
     if (restDatasources.length > 0) {
       const restRegistry = new ToolRegistry();
       restRegistry.register({
@@ -911,7 +978,10 @@ export async function runAgent({
           displayName: ds.displayName,
           ...(multiple ? { datasourceId: ds.id } : {}),
         });
-        sections.push(rep.promptContext);
+        // #3044 — prepend the environment-scope banner so the agent never
+        // implies the conversation is constrained tighter than it is.
+        const scopeNote = buildRestDatasourceScopeNote(ds, { inMultiEnvGroup });
+        sections.push(`${scopeNote}\n\n${rep.promptContext}`);
         if (rep.unresolvedResources.length > 0) {
           log.warn(
             { datasource: ds.id, resources: rep.unresolvedResources },
@@ -931,22 +1001,6 @@ export async function runAgent({
 
   const rawTools = activeRegistry.getAll();
   const tools = wrapToolsWithHooks(rawTools, { userId: userId ?? undefined, conversationId });
-
-  // #2517 — load active-group routing context so the system prompt can
-  // teach the agent when to set `scope` on `executeSQL`. Falls back to
-  // a 1×1 result (no prompt section) when no group is bound or the
-  // lookup fails — single-env workspaces see no behavioural change.
-  let scopeRoutingContext: ScopeRoutingContext | undefined;
-  if (connectionId) {
-    const ctx = await loadGroupRoutingContext(orgId, connectionId);
-    if (ctx.members.length > 1) {
-      scopeRoutingContext = {
-        members: ctx.members,
-        currentMember: ctx.currentMember,
-        ...(ctx.groupId ? { groupId: ctx.groupId } : {}),
-      };
-    }
-  }
 
   let result;
   try {

--- a/packages/api/src/lib/agent.ts
+++ b/packages/api/src/lib/agent.ts
@@ -247,13 +247,16 @@ The result of a fanned-out query carries an \`envContributions\` array describin
  * pin. Making the reach explicit means the model never implies the conversation
  * is scoped tighter than it is.
  *
- * Pure. `inMultiEnvGroup` toggles the extra "not constrained by the pin"
- * emphasis — in a single-environment workspace there is no pin to contrast
- * against, so the softer phrasing avoids implying a selection that isn't there.
+ * Pure. `boundToEnvironment` toggles the extra "not constrained by the pin"
+ * emphasis — it is true whenever the conversation targets a specific environment
+ * group (an explicit picker selection or the group resolved from the pinned
+ * connection, including the 0062 single-member-group shape). In a true
+ * single-connection workspace there is no environment to contrast against, so the
+ * softer phrasing avoids implying a selection that isn't there.
  */
 export function buildRestDatasourceScopeNote(
   ds: { readonly groupId?: string },
-  opts: { readonly inMultiEnvGroup: boolean },
+  opts: { readonly boundToEnvironment: boolean },
 ): string {
   if (ds.groupId) {
     return (
@@ -262,7 +265,7 @@ export function buildRestDatasourceScopeNote(
       `while that group is the conversation's active environment.`
     );
   }
-  const pinClause = opts.inMultiEnvGroup
+  const pinClause = opts.boundToEnvironment
     ? " It is **NOT** constrained by this conversation's environment selection/pin — " +
       "querying it reaches the same upstream account regardless of which SQL environment is active. " +
       "Do not describe the conversation as limited to one environment when answering from it."
@@ -918,8 +921,10 @@ export async function runAgent({
   // Resolved BEFORE the REST block (#3044) so each REST datasource's
   // representation can be framed against whether a multi-env pin exists.
   let scopeRoutingContext: ScopeRoutingContext | undefined;
+  let resolvedGroupId: string | undefined;
   if (connectionId) {
     const ctx = await loadGroupRoutingContext(orgId, connectionId);
+    resolvedGroupId = ctx.groupId;
     if (ctx.members.length > 1) {
       scopeRoutingContext = {
         members: ctx.members,
@@ -928,9 +933,17 @@ export async function runAgent({
       };
     }
   }
-  // A multi-env group means a pin exists that a workspace-global REST
-  // datasource silently escapes — the framing must call that out (#3044).
-  const inMultiEnvGroup = scopeRoutingContext !== undefined;
+  // #3044 — the environment this turn is bound to: the picker's explicit
+  // `connectionGroupId`, else (legacy / API callers that send only
+  // `connectionId`) the group resolved from the pinned connection's membership.
+  // REST datasources scoped to it are reachable; a workspace-global one escapes
+  // it. `null` ⇒ no environment context → only workspace-global datasources.
+  const activeRestGroupId = connectionGroupId ?? resolvedGroupId ?? null;
+  // The chat targets a specific environment whenever a group resolved — a
+  // multi-member group OR a single-member environment the user selected from a
+  // multi-environment picker (the 0062 1:1 backfill shape). A workspace-global
+  // REST datasource escapes that selection, so the framing must say so.
+  const chatBoundToEnvironment = activeRestGroupId !== null;
 
   // #2926 — REST datasources (slice 2: per-workspace `openapi-generic` installs).
   // Resolve every REST datasource the workspace has installed (Twenty, Stripe,
@@ -943,14 +956,15 @@ export async function runAgent({
   //
   // #3044 — scope filter: a datasource scoped to a different environment group
   // resolves out (the resolver keeps workspace-global + active-group matches).
-  // `connectionGroupId ?? null` ⇒ a chat with no active group sees only
-  // workspace-global datasources; a scoped one never leaks past its environment.
+  // `activeRestGroupId` is the explicit OR connection-inferred active group, so a
+  // chat whose environment is known (even via connectionId alone) still reaches
+  // that environment's scoped REST datasources; a scoped one never leaks past it.
   let activeRegistry = toolRegistry;
   let restRepresentation: string | undefined;
   try {
     const restDatasources = orgId
       ? await resolveWorkspaceRestDatasources(orgId, {
-          activeGroupId: connectionGroupId ?? null,
+          activeGroupId: activeRestGroupId,
         })
       : [];
     if (restDatasources.length > 0) {
@@ -980,7 +994,9 @@ export async function runAgent({
         });
         // #3044 — prepend the environment-scope banner so the agent never
         // implies the conversation is constrained tighter than it is.
-        const scopeNote = buildRestDatasourceScopeNote(ds, { inMultiEnvGroup });
+        const scopeNote = buildRestDatasourceScopeNote(ds, {
+          boundToEnvironment: chatBoundToEnvironment,
+        });
         sections.push(`${scopeNote}\n\n${rep.promptContext}`);
         if (rep.unresolvedResources.length > 0) {
           log.warn(

--- a/packages/api/src/lib/env-routing/__tests__/lookup.test.ts
+++ b/packages/api/src/lib/env-routing/__tests__/lookup.test.ts
@@ -9,6 +9,7 @@
  */
 
 import { describe, it, expect, beforeEach, mock } from "bun:test";
+import { REST_DATASOURCE_CATALOG_IDS } from "@atlas/api/lib/openapi/data-candidates";
 
 // Per-test mock state for the internal-DB module.
 let mockHasInternalDB = true;
@@ -138,5 +139,34 @@ describe("loadGroupRoutingContext — multi-member resolution (post-cutover)", (
     const ctx = await loadGroupRoutingContext("org-1", "eu");
     expect(ctx.members).toEqual(["eu"]);
     expect(ctx.primaryMember).toBe("eu");
+  });
+});
+
+describe("loadGroupRoutingContext — excludes REST datasource catalogs (#3044)", () => {
+  // REST datasources share `pillar = 'datasource'` and CAN carry a
+  // `config.group_id` (ADR-0010). Without the `catalog_id <> ALL(...)` guard a
+  // REST install sharing a SQL group's id would be returned as a SQL "member"
+  // and the agent's `scope: "all"` fanout would try to run SQL against a
+  // connection that isn't in the registry. This pins the exclusion on BOTH
+  // the install-anchor query and the member-aggregation query.
+  beforeEach(() => {
+    mockHasInternalDB = true;
+    mockConnRows = [{ group_id: "prod" }];
+    mockMemberRows = [{ id: "apac" }, { id: "eu" }];
+    mockShouldThrow = null;
+    mockQueryCalls = [];
+  });
+
+  it("passes the REST catalog-id array as the exclusion bind on both queries", async () => {
+    await loadGroupRoutingContext("org-1", "eu");
+
+    expect(mockQueryCalls).toHaveLength(2);
+    for (const call of mockQueryCalls) {
+      const flat = call.sql.replace(/\s+/g, " ");
+      expect(flat).toContain("catalog_id <> ALL($3)");
+      // The 3rd bind ($3) is the REST datasource catalog-id discriminator —
+      // never client input, so a regression that drops it is a routing-pollution hole.
+      expect(call.params?.[2]).toEqual([...REST_DATASOURCE_CATALOG_IDS]);
+    }
   });
 });

--- a/packages/api/src/lib/env-routing/lookup.ts
+++ b/packages/api/src/lib/env-routing/lookup.ts
@@ -20,6 +20,7 @@
 
 import { internalQuery, hasInternalDB } from "@atlas/api/lib/db/internal";
 import { createLogger } from "@atlas/api/lib/logger";
+import { REST_DATASOURCE_CATALOG_IDS } from "@atlas/api/lib/openapi/data-candidates";
 
 const log = createLogger("env-routing:lookup");
 
@@ -54,6 +55,15 @@ export async function loadGroupRoutingContext(
   }
 
   try {
+    // #3044 — SQL routing members are SQL connections only. REST datasources
+    // share `pillar = 'datasource'` and CAN carry a `config.group_id` (ADR-0010
+    // environment scoping), so without the `catalog_id <> ALL($N)` guard a
+    // REST install sharing a SQL group's id would be returned as a SQL "member"
+    // and `executeSQL`'s `all`-fanout would try to run SQL against a connection
+    // that isn't in the ConnectionRegistry. The exclusion list is the shared
+    // `REST_DATASOURCE_CATALOG_IDS` discriminator (never client input).
+    const restCatalogIds = [...REST_DATASOURCE_CATALOG_IDS];
+
     // Post-0096 cutover (#2744 / ADR-0007 pure-collapse): groups are
     // free-form JSONB strings in `workspace_plugins.config.group_id` with
     // no separate `connection_groups` row and no `primary_connection_id`.
@@ -63,9 +73,10 @@ export async function loadGroupRoutingContext(
         WHERE install_id = $1
           AND (workspace_id = $2 OR workspace_id = '__global__')
           AND pillar = 'datasource'
+          AND catalog_id <> ALL($3)
           AND status != 'archived'
         LIMIT 1`,
-      [currentConnectionId, orgId],
+      [currentConnectionId, orgId, restCatalogIds],
     );
     const groupId = connRows[0]?.group_id ?? null;
     if (!groupId) {
@@ -91,9 +102,10 @@ export async function loadGroupRoutingContext(
         WHERE config->>'group_id' = $1
           AND (workspace_id = $2 OR workspace_id = '__global__')
           AND pillar = 'datasource'
+          AND catalog_id <> ALL($3)
           AND status != 'archived'
         ORDER BY install_id`,
-      [groupId, orgId],
+      [groupId, orgId, restCatalogIds],
     );
 
     const members = memberRows.map((r) => r.id);

--- a/packages/api/src/lib/openapi/__tests__/workspace-datasource.test.ts
+++ b/packages/api/src/lib/openapi/__tests__/workspace-datasource.test.ts
@@ -20,7 +20,7 @@ import { buildSnapshot, __resetSnapshotGraphCacheForTests } from "../probe";
 import { __resetSharedSpecCacheForTests, sharedSpecCacheStats } from "../shared-spec-cache";
 import { MOCK_OPENAPI_SPEC } from "@atlas/api/testing/openapi-datasource";
 import { OPENAPI_GENERIC_CATALOG_ID, type OpenApiSnapshot } from "../catalog";
-import { DATA_CANDIDATE_CATALOG_IDS, STRIPE_DATA_CANDIDATE } from "../data-candidates";
+import { REST_DATASOURCE_CATALOG_IDS, STRIPE_DATA_CANDIDATE } from "../data-candidates";
 
 const graph = buildOperationGraph(MOCK_OPENAPI_SPEC);
 
@@ -357,13 +357,106 @@ describe("defaultQuery — tenant-scope clause", () => {
     );
 
     // Param ORDER is load-bearing: $1 is the caller's workspace (never client
-    // input), $2 is the array of built-in catalog ids — the generic datasource
-    // plus every data candidate (slice 6a, #3028). Flipping these would scope the
-    // query to the wrong dimension; dropping a candidate id would hide its installs.
+    // input), $2 is the array of built-in REST catalog ids — the generic
+    // datasource plus every data candidate (slice 6a, #3028). Pinned to the shared
+    // `REST_DATASOURCE_CATALOG_IDS` constant (not a stale literal) so a future
+    // reorder/extension of that source of truth can't silently drift this query
+    // apart from the env-routing exclusion lists that share it (#3044).
     expect(capturedParams).toEqual([
       "org-CALLER",
-      [OPENAPI_GENERIC_CATALOG_ID, ...DATA_CANDIDATE_CATALOG_IDS],
+      [...REST_DATASOURCE_CATALOG_IDS],
     ]);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+//  Cross-environment scope filtering (#3044, ADR-0010)
+// ─────────────────────────────────────────────────────────────────────
+
+describe("resolveWorkspaceRestDatasources — env scope (activeGroupId)", () => {
+  const rows: OpenApiInstallRow[] = [
+    { install_id: "ds-global", config: config({ display_name: "Global" }) }, // no group_id
+    { install_id: "ds-prod", config: config({ display_name: "Prod", group_id: "prod" }) },
+    { install_id: "ds-eu", config: config({ display_name: "EU", group_id: "eu" }) },
+  ];
+
+  it("populates groupId on the resolved datasource (and leaves it undefined for workspace-global)", async () => {
+    const result = await resolveWorkspaceRestDatasources("org-1", {
+      query: queryReturning(rows),
+    });
+    const byId = new Map(result.map((d) => [d.id, d]));
+    expect(byId.get("ds-global")?.groupId).toBeUndefined();
+    expect(byId.get("ds-prod")?.groupId).toBe("prod");
+    expect(byId.get("ds-eu")?.groupId).toBe("eu");
+  });
+
+  it("omitted activeGroupId resolves every install (back-compat / confirm-replay path)", async () => {
+    const result = await resolveWorkspaceRestDatasources("org-1", {
+      query: queryReturning(rows),
+    });
+    expect(result.map((d) => d.id).sort()).toEqual(["ds-eu", "ds-global", "ds-prod"]);
+  });
+
+  it("a string activeGroupId keeps workspace-global + that group's datasources only", async () => {
+    const result = await resolveWorkspaceRestDatasources("org-1", {
+      query: queryReturning(rows),
+      activeGroupId: "prod",
+    });
+    expect(result.map((d) => d.id).sort()).toEqual(["ds-global", "ds-prod"]);
+    // The off-scope (eu) datasource is gone — a pinned chat can't reach it.
+    expect(result.some((d) => d.id === "ds-eu")).toBe(false);
+  });
+
+  it("a null activeGroupId (no active group) keeps ONLY workspace-global datasources", async () => {
+    const result = await resolveWorkspaceRestDatasources("org-1", {
+      query: queryReturning(rows),
+      activeGroupId: null,
+    });
+    expect(result.map((d) => d.id)).toEqual(["ds-global"]);
+  });
+
+  it("treats a blank / whitespace group_id as workspace-global", async () => {
+    const result = await resolveWorkspaceRestDatasources("org-1", {
+      query: queryReturning([
+        { install_id: "ds-blank", config: config({ group_id: "   " }) },
+      ]),
+      activeGroupId: null,
+    });
+    expect(result.map((d) => d.id)).toEqual(["ds-blank"]);
+    expect(result[0].groupId).toBeUndefined();
+  });
+
+  it("preserves the [] fail-soft contract when every datasource is scoped out", async () => {
+    const result = await resolveWorkspaceRestDatasources("org-1", {
+      query: queryReturning([
+        { install_id: "ds-prod", config: config({ group_id: "prod" }) },
+      ]),
+      activeGroupId: "eu",
+    });
+    expect(result).toEqual([]);
+  });
+
+  it("the strict resolver returns [] (never throws) when every install is scoped out", async () => {
+    // Scope filtering runs BEFORE build, so an out-of-scope workspace resolves to
+    // an empty in-scope set without engaging the reconnect tally — the strict path
+    // can't surface a false "reconnect needed" for datasources that simply belong
+    // to another environment.
+    const result = await resolveWorkspaceRestDatasourcesOrThrow("org-1", {
+      query: queryReturning([
+        { install_id: "ds-eu", config: config({ group_id: "eu" }) },
+      ]),
+      activeGroupId: "prod",
+    });
+    expect(result).toEqual([]);
+  });
+
+  it("the primary resolver honours activeGroupId (python egress lockstep)", async () => {
+    const primary = await resolveWorkspacePrimaryRestDatasource("org-1", {
+      query: queryReturning(rows),
+      activeGroupId: "eu",
+    });
+    // Earliest in-scope install: ds-global (workspace-global) sorts before ds-eu by install order.
+    expect(primary?.id).toBe("ds-global");
   });
 });
 

--- a/packages/api/src/lib/openapi/data-candidates.ts
+++ b/packages/api/src/lib/openapi/data-candidates.ts
@@ -35,7 +35,7 @@
  */
 import type { ConfigSchemaField } from "@atlas/api/lib/plugins/registry";
 import type { CatalogInstallModel } from "@useatlas/types";
-import type { SupportedAuthKind } from "./catalog";
+import { OPENAPI_GENERIC_CATALOG_ID, type SupportedAuthKind } from "./catalog";
 import type { PaginationConfig } from "./paginator";
 import type { VendorQuirk } from "./vendor-quirk";
 
@@ -387,6 +387,25 @@ const BY_SLUG = new Map<string, DataCandidate>(DATA_CANDIDATES.map((c) => [c.slu
 export const DATA_CANDIDATE_CATALOG_IDS: ReadonlyArray<string> = DATA_CANDIDATES.map(
   (c) => c.catalogId,
 );
+
+/**
+ * Every `catalog_id` that identifies a REST / OpenAPI datasource install — the
+ * generic `openapi-generic` row plus every built-in data candidate. The single
+ * source of truth for "is this `workspace_plugins` row a REST datasource?".
+ *
+ * Two uses:
+ *  - `workspace-datasource.ts` matches ON this set to resolve the workspace's
+ *    REST datasources.
+ *  - The SQL routing-group member queries (`env-routing/lookup.ts` and
+ *    `GET /api/v1/me/connection-groups`) EXCLUDE this set so a REST install that
+ *    shares a `config.group_id` with SQL connections never pollutes the SQL
+ *    member list — SQL connections and REST installs share `pillar = 'datasource'`
+ *    and are distinguishable only by `catalog_id`. See [ADR-0010](../../../../../docs/adr/0010-rest-datasource-environment-scoping.md).
+ */
+export const REST_DATASOURCE_CATALOG_IDS: ReadonlyArray<string> = [
+  OPENAPI_GENERIC_CATALOG_ID,
+  ...DATA_CANDIDATE_CATALOG_IDS,
+];
 
 /** Look up a candidate by its `plugin_catalog.id` (resolver path), or `undefined`. */
 export function findDataCandidateByCatalogId(catalogId: string): DataCandidate | undefined {

--- a/packages/api/src/lib/openapi/datasource.ts
+++ b/packages/api/src/lib/openapi/datasource.ts
@@ -21,6 +21,23 @@ import type { RepresentationMode } from "./representation";
 import type { VendorQuirk } from "./vendor-quirk";
 
 /**
+ * Normalize a raw `workspace_plugins.config.group_id` JSONB value to its
+ * cross-environment scope identity (#3044, [ADR-0010]). Empty / whitespace /
+ * non-string ⇒ `null` (**workspace-global**); a non-empty string is trimmed and
+ * returned (**scoped** to that connection group).
+ *
+ * The single definition of "scoped vs workspace-global", so the empty-string
+ * exclusion can't be forgotten by a new read path — every site that reads
+ * `config.group_id` (the resolver build, the scope filter, the admin summary)
+ * funnels through here. Internal callers that prefer the optional idiom
+ * (`RestDatasource.groupId?: string`) map the `null` to `undefined` at their own
+ * boundary; wire/DTO callers keep the `null` (JSON has no `undefined`).
+ */
+export function normalizeGroupId(raw: unknown): string | null {
+  return typeof raw === "string" && raw.trim().length > 0 ? raw.trim() : null;
+}
+
+/**
  * A resolved REST datasource the agent can read from. The normalized operation
  * graph, the base URL operations execute against, the credential the slice-0
  * client applies, and the representation mode (#2931 bake-off knob, per-install).
@@ -32,6 +49,18 @@ export interface RestDatasource {
   readonly id: string;
   /** Human-facing name for the prompt header (the install's `display_name` or spec title). */
   readonly displayName: string;
+  /**
+   * Cross-environment scope (#3044, [ADR-0010]). `undefined` ⇒ **workspace-global**:
+   * the datasource is available in every conversation regardless of the env pin
+   * (one Stripe/GitHub/Twenty account isn't region-specific). A string ⇒
+   * **environment-scoped** to the connection group with this `group_id`: in-scope
+   * only when the conversation's active group matches. Resolved from the
+   * per-install `workspace_plugins.config.group_id` (the same field SQL
+   * connections use). The agent representation frames this so a pinned chat
+   * never silently appears constrained while a workspace-global datasource is
+   * reachable.
+   */
+  readonly groupId?: string;
   /** The normalized operation graph (slice-0), rebuilt from the cached snapshot. */
   readonly graph: OperationGraph;
   /** Base URL operations execute against, e.g. `https://crm.example.com/rest`. */

--- a/packages/api/src/lib/openapi/workspace-datasource.ts
+++ b/packages/api/src/lib/openapi/workspace-datasource.ts
@@ -26,9 +26,8 @@
 
 import { createLogger } from "@atlas/api/lib/logger";
 import { decryptSecretFields, parseConfigSchema } from "@atlas/api/lib/plugins/secrets";
-import type { RestDatasource } from "./datasource";
+import { normalizeGroupId, type RestDatasource } from "./datasource";
 import {
-  OPENAPI_GENERIC_CATALOG_ID,
   OPENAPI_GENERIC_CONFIG_SCHEMA,
   coerceRepresentationMode,
   isValidSnapshot,
@@ -38,8 +37,8 @@ import {
   parseWriteAllowlist,
 } from "./catalog";
 import {
-  DATA_CANDIDATE_CATALOG_IDS,
   DATA_CANDIDATE_CONFIG_SCHEMA,
+  REST_DATASOURCE_CATALOG_IDS,
   findDataCandidateByCatalogId,
   isOAuthDatasourceCandidate,
   type DataCandidate,
@@ -116,6 +115,45 @@ export interface ResolveWorkspaceDeps {
    * App-JWT minter runs); tests inject a stub so no network / key is needed.
    */
   readonly mintInstallationToken?: MintInstallationTokenFn;
+  /**
+   * Cross-environment scope filter (#3044, [ADR-0010]). Tri-state:
+   *   - **omitted (`undefined`)** — no scoping; resolve every install. The
+   *     authorized confirm-replay path (`tools/rest-operation.ts`'s
+   *     `resolveFromContext`) relies on this: a staged write is bound by a
+   *     signed token and must replay regardless of the request's group context.
+   *   - **`null`** — the conversation has no active connection group; resolve
+   *     ONLY workspace-global datasources (those with no `group_id`). A scoped
+   *     datasource never leaks into a context whose group can't be confirmed.
+   *   - **`string`** — the active group id; resolve workspace-global datasources
+   *     PLUS those scoped to this exact group.
+   * The agent loop always passes an explicit value (string or null) so the
+   * prompt + tool see a strictly-scoped set; only the workspace-global default
+   * carries over the legacy "always available" behaviour.
+   */
+  readonly activeGroupId?: string | null;
+}
+
+/**
+ * Tenant + cross-environment row filter. Keeps a row iff it is in scope for the
+ * caller's `activeGroupId` (see {@link ResolveWorkspaceDeps.activeGroupId}). Pure
+ * — operates on the raw `config.group_id` (plain, non-secret JSONB), so it runs
+ * before credential decryption / build and the reconnect tally is computed only
+ * over in-scope rows.
+ */
+function rowsInActiveGroup(
+  rows: ReadonlyArray<OpenApiInstallRow>,
+  activeGroupId: string | null | undefined,
+): ReadonlyArray<OpenApiInstallRow> {
+  // Omitted ⇒ no scoping (confirm-replay + any non-opted-in caller).
+  if (activeGroupId === undefined) return rows;
+  return rows.filter((row) => {
+    const rowGroupId = normalizeGroupId(row.config?.group_id);
+    // Workspace-global (no group) is always in scope.
+    if (rowGroupId === null) return true;
+    // Scoped: in scope only when the active group matches. `null` activeGroupId
+    // (no active group) admits no scoped datasource.
+    return activeGroupId !== null && rowGroupId === activeGroupId;
+  });
 }
 
 /**
@@ -158,7 +196,7 @@ export async function defaultQuery(
         AND pillar = 'datasource'
         AND status != 'archived'
       ORDER BY installed_at ASC`;
-  const params = [workspaceId, [OPENAPI_GENERIC_CATALOG_ID, ...DATA_CANDIDATE_CATALOG_IDS]];
+  const params = [workspaceId, [...REST_DATASOURCE_CATALOG_IDS]];
   if (exec) return exec(sql, params);
   const { internalQuery } = await import("@atlas/api/lib/db/internal");
   return internalQuery<OpenApiInstallRow>(sql, params);
@@ -310,6 +348,12 @@ function buildDatasource(
 
   const openapiUrl = typeof decrypted.openapi_url === "string" ? decrypted.openapi_url : "";
   const baseUrlOverride = typeof decrypted.base_url_override === "string" ? decrypted.base_url_override : undefined;
+  // #3044 — cross-environment scope. A non-empty `group_id` scopes this
+  // datasource to that connection group; absent/empty = workspace-global. The
+  // field is plain (non-secret) JSONB so it survives `decryptSecretFields`
+  // untouched. `normalizeGroupId` centralizes the empty-string exclusion; the
+  // domain object prefers the optional idiom, so `null` maps to `undefined`.
+  const groupId = normalizeGroupId(decrypted.group_id) ?? undefined;
   const displayName =
     typeof decrypted.display_name === "string" && decrypted.display_name.length > 0
       ? decrypted.display_name
@@ -390,6 +434,7 @@ function buildDatasource(
   return {
     id: installId,
     displayName,
+    ...(groupId !== undefined ? { groupId } : {}),
     graph,
     baseUrl,
     auth,
@@ -475,7 +520,10 @@ export async function resolveWorkspaceRestDatasourcesOrThrow(
   // A query failure propagates here, on purpose — the caller turns it into a
   // distinct "temporarily unavailable" signal rather than an empty result.
   const rows = await query(workspaceId);
-  return buildDatasourcesFromRows(workspaceId, rows, mint);
+  // #3044 — drop out-of-scope datasources BEFORE build, so the reconnect tally
+  // (and the never-rejects `[]` contract) is computed only over the in-scope set.
+  const scopedRows = rowsInActiveGroup(rows, deps.activeGroupId);
+  return buildDatasourcesFromRows(workspaceId, scopedRows, mint);
 }
 
 /**

--- a/packages/api/src/lib/tools/__tests__/python-rest-egress-scope.test.ts
+++ b/packages/api/src/lib/tools/__tests__/python-rest-egress-scope.test.ts
@@ -1,0 +1,74 @@
+/**
+ * #3044 — the Python sandbox egress allowlist must stay in lockstep with the
+ * agent's in-scope REST datasources. `defaultResolveRestDatasource` reads the
+ * request's `connectionGroupId` and threads it as `activeGroupId` into the
+ * primary resolver, so a datasource scoped to a different environment group is
+ * unreachable from Python too.
+ *
+ * The `?? null` is load-bearing: passing `undefined` (the omitted-arg path) would
+ * DISABLE scoping in the resolver and re-leak the datasource — the exact bug
+ * #3044 closes. This pins that the egress path always passes a defined value.
+ */
+import { describe, it, expect, beforeEach, mock } from "bun:test";
+
+// Controllable request context (default: none).
+let mockReqCtx:
+  | { user?: { activeOrganizationId?: string }; connectionGroupId?: string }
+  | undefined;
+
+mock.module("@atlas/api/lib/logger", () => ({
+  createLogger: () => ({ debug() {}, info() {}, warn() {}, error() {} }),
+  getRequestContext: () => mockReqCtx,
+}));
+
+mock.module("@atlas/api/lib/tracing", () => ({
+  withSpan: async (_n: string, _a: unknown, fn: () => Promise<unknown>) => fn(),
+  withEffectSpan: <T>(_n: string, _a: unknown, e: T) => e,
+}));
+
+// Capture how the egress path calls the primary resolver. Mock every export the
+// import graph could touch (CLAUDE.md "Mock all exports").
+let primaryCalls: Array<{ orgId: string; deps: unknown }> = [];
+mock.module("@atlas/api/lib/openapi/workspace-datasource", () => ({
+  resolveWorkspacePrimaryRestDatasource: async (orgId: string, deps: unknown) => {
+    primaryCalls.push({ orgId, deps });
+    return null;
+  },
+  resolveWorkspaceRestDatasources: async () => [],
+  resolveWorkspaceRestDatasourcesOrThrow: async () => [],
+  defaultQuery: async () => [],
+  RestDatasourceReconnectError: class extends Error {},
+}));
+
+const { defaultResolveRestDatasource } = await import("../python");
+
+describe("defaultResolveRestDatasource — env-scope lockstep (#3044)", () => {
+  beforeEach(() => {
+    mockReqCtx = undefined;
+    primaryCalls = [];
+  });
+
+  it("threads the conversation's connectionGroupId as activeGroupId", async () => {
+    mockReqCtx = { user: { activeOrganizationId: "org-1" }, connectionGroupId: "eu" };
+    await defaultResolveRestDatasource();
+    expect(primaryCalls).toHaveLength(1);
+    expect(primaryCalls[0]!.orgId).toBe("org-1");
+    expect(primaryCalls[0]!.deps).toEqual({ activeGroupId: "eu" });
+  });
+
+  it("passes activeGroupId: null (NOT undefined) when no group is bound", async () => {
+    mockReqCtx = { user: { activeOrganizationId: "org-1" } };
+    await defaultResolveRestDatasource();
+    expect(primaryCalls[0]!.deps).toEqual({ activeGroupId: null });
+    // The distinction is load-bearing: `undefined` would disable scoping in the
+    // resolver and re-leak a scoped datasource into the sandbox egress allowlist.
+    expect((primaryCalls[0]!.deps as { activeGroupId: unknown }).activeGroupId).not.toBeUndefined();
+  });
+
+  it("returns null without resolving when there is no active org", async () => {
+    mockReqCtx = { connectionGroupId: "eu" };
+    const result = await defaultResolveRestDatasource();
+    expect(result).toBeNull();
+    expect(primaryCalls).toHaveLength(0);
+  });
+});

--- a/packages/api/src/lib/tools/__tests__/python-rest-egress-scope.test.ts
+++ b/packages/api/src/lib/tools/__tests__/python-rest-egress-scope.test.ts
@@ -13,7 +13,7 @@ import { describe, it, expect, beforeEach, mock } from "bun:test";
 
 // Controllable request context (default: none).
 let mockReqCtx:
-  | { user?: { activeOrganizationId?: string }; connectionGroupId?: string }
+  | { user?: { activeOrganizationId?: string }; connectionGroupId?: string; connectionId?: string }
   | undefined;
 
 mock.module("@atlas/api/lib/logger", () => ({
@@ -24,6 +24,15 @@ mock.module("@atlas/api/lib/logger", () => ({
 mock.module("@atlas/api/lib/tracing", () => ({
   withSpan: async (_n: string, _a: unknown, fn: () => Promise<unknown>) => fn(),
   withEffectSpan: <T>(_n: string, _a: unknown, e: T) => e,
+}));
+
+// The connection→group inference: a connection in `prod` resolves to it, an
+// `ungrouped-conn` resolves to no group.
+mock.module("@atlas/api/lib/env-routing/lookup", () => ({
+  loadGroupRoutingContext: async (_orgId: string | undefined, currentMember: string) =>
+    currentMember === "ungrouped-conn"
+      ? { members: ["ungrouped-conn"], primaryMember: "ungrouped-conn", currentMember }
+      : { groupId: "prod", members: [currentMember], primaryMember: currentMember, currentMember },
 }));
 
 // Capture how the egress path calls the primary resolver. Mock every export the
@@ -56,13 +65,25 @@ describe("defaultResolveRestDatasource — env-scope lockstep (#3044)", () => {
     expect(primaryCalls[0]!.deps).toEqual({ activeGroupId: "eu" });
   });
 
-  it("passes activeGroupId: null (NOT undefined) when no group is bound", async () => {
-    mockReqCtx = { user: { activeOrganizationId: "org-1" } };
+  it("infers the active group from connectionId when connectionGroupId is omitted", async () => {
+    mockReqCtx = { user: { activeOrganizationId: "org-1" }, connectionId: "us-prod" };
+    await defaultResolveRestDatasource();
+    expect(primaryCalls[0]!.deps).toEqual({ activeGroupId: "prod" });
+  });
+
+  it("passes activeGroupId: null (NOT undefined) when the connection resolves to no group", async () => {
+    mockReqCtx = { user: { activeOrganizationId: "org-1" }, connectionId: "ungrouped-conn" };
     await defaultResolveRestDatasource();
     expect(primaryCalls[0]!.deps).toEqual({ activeGroupId: null });
     // The distinction is load-bearing: `undefined` would disable scoping in the
     // resolver and re-leak a scoped datasource into the sandbox egress allowlist.
     expect((primaryCalls[0]!.deps as { activeGroupId: unknown }).activeGroupId).not.toBeUndefined();
+  });
+
+  it("passes activeGroupId: null when there is no group and no connection to infer from", async () => {
+    mockReqCtx = { user: { activeOrganizationId: "org-1" } };
+    await defaultResolveRestDatasource();
+    expect(primaryCalls[0]!.deps).toEqual({ activeGroupId: null });
   });
 
   it("returns null without resolving when there is no active org", async () => {

--- a/packages/api/src/lib/tools/python.ts
+++ b/packages/api/src/lib/tools/python.ts
@@ -439,11 +439,17 @@ export interface ExecutePythonDeps {
  * sandbox egress is a follow-up — the read path the slice ACs exercise is the
  * host-side tool).
  */
-function defaultResolveRestDatasource(): Promise<RestDatasource | null> {
-  const orgId = getRequestContext()?.user?.activeOrganizationId;
+export function defaultResolveRestDatasource(): Promise<RestDatasource | null> {
+  const reqCtx = getRequestContext();
+  const orgId = reqCtx?.user?.activeOrganizationId;
   if (!orgId) return Promise.resolve(null);
+  // #3044 — keep the sandbox egress allowlist in lockstep with the agent's
+  // in-scope datasources: a datasource scoped to a different environment group
+  // must not be reachable from Python either. `null` (no active group) admits
+  // only workspace-global datasources.
+  const activeGroupId = reqCtx?.connectionGroupId ?? null;
   return import("@atlas/api/lib/openapi/workspace-datasource").then((m) =>
-    m.resolveWorkspacePrimaryRestDatasource(orgId),
+    m.resolveWorkspacePrimaryRestDatasource(orgId, { activeGroupId }),
   );
 }
 

--- a/packages/api/src/lib/tools/python.ts
+++ b/packages/api/src/lib/tools/python.ts
@@ -439,18 +439,27 @@ export interface ExecutePythonDeps {
  * sandbox egress is a follow-up — the read path the slice ACs exercise is the
  * host-side tool).
  */
-export function defaultResolveRestDatasource(): Promise<RestDatasource | null> {
+export async function defaultResolveRestDatasource(): Promise<RestDatasource | null> {
   const reqCtx = getRequestContext();
   const orgId = reqCtx?.user?.activeOrganizationId;
-  if (!orgId) return Promise.resolve(null);
+  if (!orgId) return null;
   // #3044 — keep the sandbox egress allowlist in lockstep with the agent's
   // in-scope datasources: a datasource scoped to a different environment group
-  // must not be reachable from Python either. `null` (no active group) admits
-  // only workspace-global datasources.
-  const activeGroupId = reqCtx?.connectionGroupId ?? null;
-  return import("@atlas/api/lib/openapi/workspace-datasource").then((m) =>
-    m.resolveWorkspacePrimaryRestDatasource(orgId, { activeGroupId }),
+  // must not be reachable from Python either. Resolve the active environment the
+  // same way the agent loop does — the explicit `connectionGroupId`, else the
+  // group inferred from the pinned connection's membership — so an
+  // environment-local REST API stays reachable for legacy connectionId-only
+  // callers. `null` (no environment context) admits only workspace-global ones.
+  let activeGroupId = reqCtx?.connectionGroupId ?? null;
+  if (activeGroupId === null && reqCtx?.connectionId) {
+    const { loadGroupRoutingContext } = await import("@atlas/api/lib/env-routing/lookup");
+    const ctx = await loadGroupRoutingContext(orgId, reqCtx.connectionId);
+    activeGroupId = ctx.groupId ?? null;
+  }
+  const { resolveWorkspacePrimaryRestDatasource } = await import(
+    "@atlas/api/lib/openapi/workspace-datasource"
   );
+  return resolveWorkspacePrimaryRestDatasource(orgId, { activeGroupId });
 }
 
 /**

--- a/packages/web/src/app/admin/connections/openapi-block.tsx
+++ b/packages/web/src/app/admin/connections/openapi-block.tsx
@@ -136,6 +136,9 @@ const DatasourceSummarySchema = z.object({
   representationMode: z.string(),
   specRefreshInterval: z.string(),
   status: z.string(),
+  // #3044 — cross-environment scope (ADR-0010). `null` ⇒ workspace-global.
+  // Optional/nullable for back-compat with responses serialized before the field.
+  groupId: z.string().nullable().optional(),
   snapshot: SnapshotSchema,
   // Optional for back-compat with any cached/old list response; absent → no banner.
   lastRefresh: LastRefreshSchema.optional(),
@@ -143,6 +146,19 @@ const DatasourceSummarySchema = z.object({
 type DatasourceSummary = z.infer<typeof DatasourceSummarySchema>;
 
 const ListSchema = z.object({ datasources: z.array(DatasourceSummarySchema) });
+
+/**
+ * #3044 — the workspace's connection groups, for the per-datasource environment
+ * picker. Sourced from `/api/v1/me/connection-groups` (admins can read it). Only
+ * the id is load-bearing; `name` drives the human label. Extra response fields
+ * (`restDatasources`, `reason`) are ignored by the non-strict object.
+ */
+const ConnectionGroupsSchema = z.object({
+  groups: z.array(z.object({ id: z.string(), name: z.string() })),
+});
+
+/** Select sentinel for "no group" — shadcn `Select` items can't carry an empty value. */
+const WORKSPACE_GLOBAL = "__workspace_global__";
 
 const OperationSchema = z.object({
   operationId: z.string(),
@@ -221,6 +237,11 @@ interface OpenApiProviderBlockProps {
 /** Block for the OpenAPI (generic REST) datasources on `/admin/connections`. */
 export function OpenApiProviderBlock({ demoReadOnly, onChange }: OpenApiProviderBlockProps) {
   const listQuery = useAdminFetch("/api/v1/admin/openapi-datasources", { schema: ListSchema });
+  // #3044 — connection groups for the per-datasource environment picker. A
+  // failure degrades to "no groups" (the picker offers only Workspace-global).
+  const groupsQuery = useAdminFetch("/api/v1/me/connection-groups", {
+    schema: ConnectionGroupsSchema,
+  });
   const [installOpen, setInstallOpen] = useState(false);
 
   const refresh = () => {
@@ -294,7 +315,12 @@ export function OpenApiProviderBlock({ demoReadOnly, onChange }: OpenApiProvider
             {addButton}
           </div>
           {datasources.map((ds) => (
-            <OpenApiInstallCard key={ds.id} ds={ds} onChange={refresh} />
+            <OpenApiInstallCard
+              key={ds.id}
+              ds={ds}
+              groups={groupsQuery.data?.groups ?? []}
+              onChange={refresh}
+            />
           ))}
         </>
       )}
@@ -313,7 +339,15 @@ export function OpenApiProviderBlock({ demoReadOnly, onChange }: OpenApiProvider
 
 // ── Per-install card ─────────────────────────────────────────────────────────
 
-function OpenApiInstallCard({ ds, onChange }: { ds: DatasourceSummary; onChange: () => void }) {
+function OpenApiInstallCard({
+  ds,
+  groups,
+  onChange,
+}: {
+  ds: DatasourceSummary;
+  groups: ReadonlyArray<{ id: string; name: string }>;
+  onChange: () => void;
+}) {
   const [opsOpen, setOpsOpen] = useState(false);
 
   const rediscover = useAdminMutation<{
@@ -331,6 +365,12 @@ function OpenApiInstallCard({ ds, onChange }: { ds: DatasourceSummary; onChange:
     invalidates: onChange,
   });
   const setRefresh = useAdminMutation<{ updated: boolean; specRefreshInterval: string }>({
+    path: `/api/v1/admin/openapi-datasources/${encodeURIComponent(ds.id)}`,
+    method: "PATCH",
+    invalidates: onChange,
+  });
+  // #3044 — assign/clear the cross-environment scope (ADR-0010).
+  const setGroup = useAdminMutation<{ updated: boolean; groupId: string | null }>({
     path: `/api/v1/admin/openapi-datasources/${encodeURIComponent(ds.id)}`,
     method: "PATCH",
     invalidates: onChange,
@@ -405,6 +445,21 @@ function OpenApiInstallCard({ ds, onChange }: { ds: DatasourceSummary; onChange:
       );
     } else {
       toast.error(friendlyErrorOrNull(result.error) ?? "Couldn't change the refresh interval");
+    }
+  }
+
+  async function handleSetGroup(nextValue: string) {
+    // Sentinel → null clears the scope back to workspace-global.
+    const groupId = nextValue === WORKSPACE_GLOBAL ? null : nextValue;
+    const result = await setGroup.mutate({ body: { groupId } });
+    if (result.ok) {
+      toast.success(
+        groupId === null
+          ? `${ds.displayName} is now workspace-global`
+          : `${ds.displayName} scoped to ${groupId}`,
+      );
+    } else {
+      toast.error(friendlyErrorOrNull(result.error) ?? "Couldn't change the environment");
     }
   }
 
@@ -530,6 +585,45 @@ function OpenApiInstallCard({ ds, onChange }: { ds: DatasourceSummary; onChange:
                   ) : null}
                 </SelectContent>
               </Select>
+            }
+          />
+          <DetailRow
+            label="Environment"
+            value={
+              <span className="flex items-center gap-2">
+                <Select
+                  value={ds.groupId ?? WORKSPACE_GLOBAL}
+                  disabled={setGroup.saving}
+                  onValueChange={handleSetGroup}
+                >
+                  <SelectTrigger
+                    className="h-7 w-44 text-xs"
+                    aria-label="Environment scope"
+                    data-testid="openapi-group-select"
+                  >
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value={WORKSPACE_GLOBAL}>Workspace-global</SelectItem>
+                    {groups.map((g) => (
+                      <SelectItem key={g.id} value={g.id}>
+                        {g.name}
+                      </SelectItem>
+                    ))}
+                    {/* Current scope points at a group not in the live list (no SQL
+                        members yet, or the groups fetch failed) — surface it so the
+                        Select shows the stored value rather than blanking. */}
+                    {ds.groupId && !groups.some((g) => g.id === ds.groupId) ? (
+                      <SelectItem value={ds.groupId}>{ds.groupId}</SelectItem>
+                    ) : null}
+                  </SelectContent>
+                </Select>
+                {ds.groupId ? null : (
+                  <span className="text-[11px] text-muted-foreground">
+                    available in every environment
+                  </span>
+                )}
+              </span>
             }
           />
         </DetailList>

--- a/packages/web/src/lib/stores/__tests__/chat-routing-preference-store.test.ts
+++ b/packages/web/src/lib/stores/__tests__/chat-routing-preference-store.test.ts
@@ -13,18 +13,21 @@ beforeEach(() => {
 describe("useChatRoutingPreferenceStore (#3044)", () => {
   it("starts empty (no remembered selection)", () => {
     const s = useChatRoutingPreferenceStore.getState();
+    expect(s.workspaceId).toBeNull();
     expect(s.groupId).toBeNull();
     expect(s.connectionId).toBeNull();
     expect(s.routingMode).toBeNull();
   });
 
-  it("setPreference records the user's last env-picker selection", () => {
+  it("setPreference records the user's last env-picker selection + workspace", () => {
     useChatRoutingPreferenceStore.getState().setPreference({
+      workspaceId: "org-1",
       groupId: "prod",
       connectionId: "eu-prod",
       routingMode: "pin",
     });
     const s = useChatRoutingPreferenceStore.getState();
+    expect(s.workspaceId).toBe("org-1");
     expect(s.groupId).toBe("prod");
     expect(s.connectionId).toBe("eu-prod");
     expect(s.routingMode).toBe("pin");
@@ -32,6 +35,7 @@ describe("useChatRoutingPreferenceStore (#3044)", () => {
 
   it("persists ONLY the preference fields to localStorage (partialize drops setters)", () => {
     useChatRoutingPreferenceStore.getState().setPreference({
+      workspaceId: "org-1",
       groupId: "prod",
       connectionId: "eu-prod",
       routingMode: "all",
@@ -40,6 +44,7 @@ describe("useChatRoutingPreferenceStore (#3044)", () => {
     expect(raw).not.toBeNull();
     const persisted = JSON.parse(raw!) as { state: Record<string, unknown> };
     expect(persisted.state).toEqual({
+      workspaceId: "org-1",
       groupId: "prod",
       connectionId: "eu-prod",
       routingMode: "all",
@@ -49,11 +54,29 @@ describe("useChatRoutingPreferenceStore (#3044)", () => {
     expect(persisted.state.clear).toBeUndefined();
   });
 
+  it("records the workspace so a consumer can ignore another workspace's preference", () => {
+    // The store itself just persists workspaceId; the consumer (atlas-chat)
+    // compares it to the active org before restoring. Pin the round-trip here.
+    useChatRoutingPreferenceStore.getState().setPreference({
+      workspaceId: "org-A",
+      groupId: "prod",
+      connectionId: "warehouse",
+      routingMode: "pin",
+    });
+    expect(useChatRoutingPreferenceStore.getState().workspaceId).toBe("org-A");
+  });
+
   it("clear() forgets the stored preference", () => {
     const store = useChatRoutingPreferenceStore.getState();
-    store.setPreference({ groupId: "prod", connectionId: "us-prod", routingMode: "auto" });
+    store.setPreference({
+      workspaceId: "org-1",
+      groupId: "prod",
+      connectionId: "us-prod",
+      routingMode: "auto",
+    });
     store.clear();
     const s = useChatRoutingPreferenceStore.getState();
+    expect(s.workspaceId).toBeNull();
     expect(s.groupId).toBeNull();
     expect(s.connectionId).toBeNull();
     expect(s.routingMode).toBeNull();

--- a/packages/web/src/lib/stores/__tests__/chat-routing-preference-store.test.ts
+++ b/packages/web/src/lib/stores/__tests__/chat-routing-preference-store.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, beforeEach } from "bun:test";
+import { useChatRoutingPreferenceStore } from "../chat-routing-preference-store";
+
+const STORAGE_KEY = "atlas:chat:routing-preference";
+
+beforeEach(() => {
+  // Fresh slate: clear persisted state + reset the in-memory store so each
+  // test sees the empty default (the persist hydration is module-singleton).
+  localStorage.clear();
+  useChatRoutingPreferenceStore.getState().clear();
+});
+
+describe("useChatRoutingPreferenceStore (#3044)", () => {
+  it("starts empty (no remembered selection)", () => {
+    const s = useChatRoutingPreferenceStore.getState();
+    expect(s.groupId).toBeNull();
+    expect(s.connectionId).toBeNull();
+    expect(s.routingMode).toBeNull();
+  });
+
+  it("setPreference records the user's last env-picker selection", () => {
+    useChatRoutingPreferenceStore.getState().setPreference({
+      groupId: "prod",
+      connectionId: "eu-prod",
+      routingMode: "pin",
+    });
+    const s = useChatRoutingPreferenceStore.getState();
+    expect(s.groupId).toBe("prod");
+    expect(s.connectionId).toBe("eu-prod");
+    expect(s.routingMode).toBe("pin");
+  });
+
+  it("persists ONLY the preference fields to localStorage (partialize drops setters)", () => {
+    useChatRoutingPreferenceStore.getState().setPreference({
+      groupId: "prod",
+      connectionId: "eu-prod",
+      routingMode: "all",
+    });
+    const raw = localStorage.getItem(STORAGE_KEY);
+    expect(raw).not.toBeNull();
+    const persisted = JSON.parse(raw!) as { state: Record<string, unknown> };
+    expect(persisted.state).toEqual({
+      groupId: "prod",
+      connectionId: "eu-prod",
+      routingMode: "all",
+    });
+    // Setters must never be serialized.
+    expect(persisted.state.setPreference).toBeUndefined();
+    expect(persisted.state.clear).toBeUndefined();
+  });
+
+  it("clear() forgets the stored preference", () => {
+    const store = useChatRoutingPreferenceStore.getState();
+    store.setPreference({ groupId: "prod", connectionId: "us-prod", routingMode: "auto" });
+    store.clear();
+    const s = useChatRoutingPreferenceStore.getState();
+    expect(s.groupId).toBeNull();
+    expect(s.connectionId).toBeNull();
+    expect(s.routingMode).toBeNull();
+  });
+});

--- a/packages/web/src/lib/stores/chat-routing-preference-store.ts
+++ b/packages/web/src/lib/stores/chat-routing-preference-store.ts
@@ -18,10 +18,20 @@ import type { ConversationRoutingMode } from "@useatlas/types/conversation";
  * preference is the seed; a stored selection that no longer matches an available
  * group/member is ignored (the picker falls back to the default seed).
  *
+ * **Workspace-scoped (#3044 Codex review).** `localStorage` is one bucket for the
+ * whole browser, but group/connection ids are only unique *within* a workspace —
+ * two workspaces can both have a `prod` group with a `warehouse` connection. The
+ * stored `workspaceId` lets the consumer ignore a preference left by a different
+ * workspace (SaaS org switch / shared browser) instead of seeding a new chat with
+ * the wrong environment. `null` workspaceId = self-hosted / no active org (a
+ * single workspace, so it always matches).
+ *
  * Follows the `tour-store.ts` pattern: `persist` + `createJSONStorage(localStorage)`,
  * `partialize` to the persisted fields only.
  */
 export interface ChatRoutingPreference {
+  /** Workspace (active org) this preference belongs to. `null` = self-hosted / no org. */
+  readonly workspaceId: string | null;
   /** Active connection group id, or null when none was chosen. */
   readonly groupId: string | null;
   /** Pinned member / execution-target connection id, or null. */
@@ -38,6 +48,7 @@ interface ChatRoutingPreferenceStore extends ChatRoutingPreference {
 }
 
 const EMPTY: ChatRoutingPreference = {
+  workspaceId: null,
   groupId: null,
   connectionId: null,
   routingMode: null,
@@ -49,6 +60,7 @@ export const useChatRoutingPreferenceStore = create<ChatRoutingPreferenceStore>(
       ...EMPTY,
       setPreference: (next) =>
         set({
+          workspaceId: next.workspaceId,
           groupId: next.groupId,
           connectionId: next.connectionId,
           routingMode: next.routingMode,
@@ -59,6 +71,7 @@ export const useChatRoutingPreferenceStore = create<ChatRoutingPreferenceStore>(
       name: "atlas:chat:routing-preference",
       storage: createJSONStorage(() => localStorage),
       partialize: (s) => ({
+        workspaceId: s.workspaceId,
         groupId: s.groupId,
         connectionId: s.connectionId,
         routingMode: s.routingMode,

--- a/packages/web/src/lib/stores/chat-routing-preference-store.ts
+++ b/packages/web/src/lib/stores/chat-routing-preference-store.ts
@@ -1,0 +1,68 @@
+import { create } from "zustand";
+import { persist, createJSONStorage } from "zustand/middleware";
+import type { ConversationRoutingMode } from "@useatlas/types/conversation";
+
+/**
+ * Persisted chat env/member/routing selection (#3044).
+ *
+ * The chat env picker's selection (`atlas-chat.tsx`) was plain `useState` —
+ * lost on every page reload, so the next visit always reverted to the default
+ * environment seed. That is wrong for a user who deliberately pinned to one
+ * environment: a reload silently widened (or moved) their scope.
+ *
+ * This store remembers the user's LAST selection in `localStorage` so a reload
+ * (or a return visit) restores it, instead of re-seeding from the first group.
+ * It is a UI *preference*, not server state: the authoritative per-conversation
+ * routing still lives on the `conversations` row (the chat request body stamps
+ * it). When a new chat opens with no conversation-restored value, this
+ * preference is the seed; a stored selection that no longer matches an available
+ * group/member is ignored (the picker falls back to the default seed).
+ *
+ * Follows the `tour-store.ts` pattern: `persist` + `createJSONStorage(localStorage)`,
+ * `partialize` to the persisted fields only.
+ */
+export interface ChatRoutingPreference {
+  /** Active connection group id, or null when none was chosen. */
+  readonly groupId: string | null;
+  /** Pinned member / execution-target connection id, or null. */
+  readonly connectionId: string | null;
+  /** Three-state Auto/Pin/All routing mode, or null (pre-#2518 back-compat). */
+  readonly routingMode: ConversationRoutingMode | null;
+}
+
+interface ChatRoutingPreferenceStore extends ChatRoutingPreference {
+  /** Persist the user's latest env-picker selection. */
+  setPreference: (next: ChatRoutingPreference) => void;
+  /** Forget the stored preference (e.g. on sign-out / workspace switch). */
+  clear: () => void;
+}
+
+const EMPTY: ChatRoutingPreference = {
+  groupId: null,
+  connectionId: null,
+  routingMode: null,
+};
+
+export const useChatRoutingPreferenceStore = create<ChatRoutingPreferenceStore>()(
+  persist(
+    (set) => ({
+      ...EMPTY,
+      setPreference: (next) =>
+        set({
+          groupId: next.groupId,
+          connectionId: next.connectionId,
+          routingMode: next.routingMode,
+        }),
+      clear: () => set({ ...EMPTY }),
+    }),
+    {
+      name: "atlas:chat:routing-preference",
+      storage: createJSONStorage(() => localStorage),
+      partialize: (s) => ({
+        groupId: s.groupId,
+        connectionId: s.connectionId,
+        routingMode: s.routingMode,
+      }),
+    },
+  ),
+);

--- a/packages/web/src/ui/__tests__/env-picker.test.tsx
+++ b/packages/web/src/ui/__tests__/env-picker.test.tsx
@@ -649,6 +649,80 @@ describe("pickDefaultEnvSeed — atlas-chat first-load seeding", () => {
 // API), and resetting reason to null on transport failure so a flaky
 // network can't pin a stale chip on screen. See #2422.
 
+describe("ChatEnvPicker — REST datasource scope footer (#3044)", () => {
+  const multiGroup: ChatEnvGroup[] = [
+    {
+      id: "prod",
+      name: "prod",
+      primaryConnectionId: null,
+      members: [
+        { connectionId: "us-prod", dbType: "postgres", description: null },
+        { connectionId: "eu-prod", dbType: "postgres", description: null },
+      ],
+    },
+  ];
+
+  test("frames workspace-global REST datasources as not limited by the pin", () => {
+    const { container } = render(
+      <ChatEnvPicker
+        groups={multiGroup}
+        activeGroupId="prod"
+        activeConnectionId="us-prod"
+        activeRoutingMode="pin"
+        restDatasources={[{ id: "stripe", displayName: "Stripe", groupId: null }]}
+        onSelect={noop}
+      />,
+    );
+    const global = container.querySelector('[data-testid="chat-env-picker-rest-global"]');
+    expect(global).not.toBeNull();
+    expect(global?.textContent).toContain("Stripe");
+    expect(global?.textContent?.toLowerCase()).toContain("every environment");
+    expect(global?.textContent?.toLowerCase()).toContain("not limited by");
+  });
+
+  test("separates in-scope (active group) from out-of-scope scoped datasources", () => {
+    const { container } = render(
+      <ChatEnvPicker
+        groups={multiGroup}
+        activeGroupId="prod"
+        activeConnectionId="us-prod"
+        activeRoutingMode="pin"
+        restDatasources={[
+          { id: "prod-api", displayName: "Prod API", groupId: "prod" },
+          { id: "eu-api", displayName: "EU API", groupId: "eu" },
+        ]}
+        onSelect={noop}
+      />,
+    );
+    expect(
+      container.querySelector('[data-testid="chat-env-picker-rest-in-scope"]')?.textContent,
+    ).toContain("Prod API");
+    const outOfScope = container.querySelector(
+      '[data-testid="chat-env-picker-rest-out-of-scope"]',
+    );
+    expect(outOfScope?.textContent).toContain("other environments");
+    // The out-of-scope datasource's name is NOT leaked into the in-scope list.
+    expect(
+      container.querySelector('[data-testid="chat-env-picker-rest-in-scope"]')?.textContent,
+    ).not.toContain("EU API");
+  });
+
+  test("renders no REST footer when the workspace has no REST datasources", () => {
+    const { container } = render(
+      <ChatEnvPicker
+        groups={multiGroup}
+        activeGroupId="prod"
+        activeConnectionId="us-prod"
+        restDatasources={[]}
+        onSelect={noop}
+      />,
+    );
+    expect(
+      container.querySelector('[data-testid="chat-env-picker-rest-global"]'),
+    ).toBeNull();
+  });
+});
+
 const originalFetch = globalThis.fetch;
 
 function mockFetch(
@@ -747,6 +821,32 @@ describe("useChatEnvGroups (#2422)", () => {
     // going to.
     await new Promise((r) => setTimeout(r, 0));
     expect(callCount()).toBe(0);
+  });
+
+  test("echoes restDatasources from the wire (#3044)", async () => {
+    mockFetch(() =>
+      jsonResponse({
+        groups: [],
+        restDatasources: [{ id: "stripe", displayName: "Stripe", groupId: null }],
+        reason: null,
+      }),
+    );
+    const { result } = renderHook(() => useChatEnvGroups(opts));
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+    expect(result.current.restDatasources).toEqual([
+      { id: "stripe", displayName: "Stripe", groupId: null },
+    ]);
+  });
+
+  test("defaults restDatasources to [] when an older API omits the field (#3044)", async () => {
+    mockFetch(() => jsonResponse({ groups: [] }));
+    const { result } = renderHook(() => useChatEnvGroups(opts));
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+    expect(result.current.restDatasources).toEqual([]);
   });
 });
 

--- a/packages/web/src/ui/components/atlas-chat.tsx
+++ b/packages/web/src/ui/components/atlas-chat.tsx
@@ -137,6 +137,7 @@ export function AtlasChat() {
   // #3044 — persisted env-picker preference so a reload restores the user's
   // last selection instead of re-seeding from the first group. Select fields
   // individually so the store object identity doesn't churn effect deps.
+  const prefWorkspaceId = useChatRoutingPreferenceStore((s) => s.workspaceId);
   const prefGroupId = useChatRoutingPreferenceStore((s) => s.groupId);
   const prefConnectionId = useChatRoutingPreferenceStore((s) => s.connectionId);
   const prefRoutingMode = useChatRoutingPreferenceStore((s) => s.routingMode);
@@ -179,6 +180,10 @@ export function AtlasChat() {
   const managedSession = authClient.useSession();
   const isManaged = authMode === "managed";
   const isSignedIn = isManaged && !!managedSession.data?.user;
+  // #3044 — the active workspace, used to scope the persisted routing preference
+  // so a different workspace (SaaS org switch / shared browser) can't seed a new
+  // chat with this one's environment. `null` for self-hosted / no active org.
+  const activeWorkspaceId = managedSession.data?.session?.activeOrganizationId ?? null;
 
   // #2345 — populate the env/member picker from the user-facing
   // `/api/v1/me/connection-groups` route. Fetched only once auth has
@@ -201,7 +206,11 @@ export function AtlasChat() {
     if (selectedConnectionId !== null) return;
     if (envGroupsQuery.groups.length === 0) return;
 
-    const prefGroup = prefGroupId
+    // Only restore a preference that belongs to the active workspace — a stored
+    // selection from another workspace must not seed this one (#3044), even when
+    // group/connection ids collide across workspaces.
+    const prefMatchesWorkspace = prefWorkspaceId === activeWorkspaceId;
+    const prefGroup = prefMatchesWorkspace && prefGroupId
       ? envGroupsQuery.groups.find((g) => g.id === prefGroupId)
       : undefined;
     const prefMember = prefGroup?.members.find(
@@ -221,9 +230,11 @@ export function AtlasChat() {
   }, [
     envGroupsQuery.groups,
     selectedConnectionId,
+    prefWorkspaceId,
     prefGroupId,
     prefConnectionId,
     prefRoutingMode,
+    activeWorkspaceId,
   ]);
 
   const convos = useConversations({
@@ -604,8 +615,14 @@ export function AtlasChat() {
                       setSelectedGroupId(groupId);
                       setSelectedConnectionId(connectionId);
                       setSelectedRoutingMode(routingMode);
-                      // #3044 — remember this pick so a reload restores it.
-                      setRoutingPreference({ groupId, connectionId, routingMode });
+                      // #3044 — remember this pick (scoped to the active
+                      // workspace) so a reload restores it.
+                      setRoutingPreference({
+                        workspaceId: activeWorkspaceId,
+                        groupId,
+                        connectionId,
+                        routingMode,
+                      });
                     }}
                   />
                   <Button

--- a/packages/web/src/ui/components/atlas-chat.tsx
+++ b/packages/web/src/ui/components/atlas-chat.tsx
@@ -44,6 +44,7 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { parseSuggestions } from "../lib/helpers";
 import { ErrorBoundary } from "./error-boundary";
 import { useUiStore } from "@/lib/stores/ui-store";
+import { useChatRoutingPreferenceStore } from "@/lib/stores/chat-routing-preference-store";
 
 /* Static SVG icons — hoisted to avoid recreation on every render */
 const MenuIcon = (
@@ -133,6 +134,13 @@ export function AtlasChat() {
   // #2518 — three-state Auto/Pin/All cross-environment routing picker.
   const [selectedRoutingMode, setSelectedRoutingMode] =
     useState<ConversationRoutingMode | null>(null);
+  // #3044 — persisted env-picker preference so a reload restores the user's
+  // last selection instead of re-seeding from the first group. Select fields
+  // individually so the store object identity doesn't churn effect deps.
+  const prefGroupId = useChatRoutingPreferenceStore((s) => s.groupId);
+  const prefConnectionId = useChatRoutingPreferenceStore((s) => s.connectionId);
+  const prefRoutingMode = useChatRoutingPreferenceStore((s) => s.routingMode);
+  const setRoutingPreference = useChatRoutingPreferenceStore((s) => s.setPreference);
   const scrollRef = useRef<HTMLDivElement>(null);
 
   const {
@@ -185,13 +193,38 @@ export function AtlasChat() {
   });
 
   // Seed selection only when empty — never override a user pick or a
-  // conversation-restored value.
+  // conversation-restored value. #3044 — prefer the persisted preference (a
+  // reload restores the user's last environment); fall back to the default
+  // seed when there is no stored preference or it no longer matches an
+  // available group/member (e.g. the connection was removed).
   useEffect(() => {
+    if (selectedConnectionId !== null) return;
+    if (envGroupsQuery.groups.length === 0) return;
+
+    const prefGroup = prefGroupId
+      ? envGroupsQuery.groups.find((g) => g.id === prefGroupId)
+      : undefined;
+    const prefMember = prefGroup?.members.find(
+      (m) => m.connectionId === prefConnectionId,
+    );
+    if (prefGroup && prefMember) {
+      setSelectedGroupId(prefGroup.id);
+      setSelectedConnectionId(prefMember.connectionId);
+      if (prefRoutingMode) setSelectedRoutingMode(prefRoutingMode);
+      return;
+    }
+
     const seed = pickDefaultEnvSeed(envGroupsQuery.groups, selectedConnectionId);
     if (!seed) return;
     setSelectedGroupId(seed.groupId);
     setSelectedConnectionId(seed.connectionId);
-  }, [envGroupsQuery.groups, selectedConnectionId]);
+  }, [
+    envGroupsQuery.groups,
+    selectedConnectionId,
+    prefGroupId,
+    prefConnectionId,
+    prefRoutingMode,
+  ]);
 
   const convos = useConversations({
     apiUrl,
@@ -566,10 +599,13 @@ export function AtlasChat() {
                     activeGroupId={selectedGroupId}
                     activeConnectionId={selectedConnectionId}
                     activeRoutingMode={selectedRoutingMode}
+                    restDatasources={envGroupsQuery.restDatasources}
                     onSelect={({ groupId, connectionId, routingMode }) => {
                       setSelectedGroupId(groupId);
                       setSelectedConnectionId(connectionId);
                       setSelectedRoutingMode(routingMode);
+                      // #3044 — remember this pick so a reload restores it.
+                      setRoutingPreference({ groupId, connectionId, routingMode });
                     }}
                   />
                   <Button

--- a/packages/web/src/ui/components/chat/env-picker.tsx
+++ b/packages/web/src/ui/components/chat/env-picker.tsx
@@ -34,7 +34,7 @@
  */
 
 import { useEffect, useState } from "react";
-import { Layers, AlertCircle, Sparkles, Pin, Globe2, Check } from "lucide-react";
+import { Layers, AlertCircle, Sparkles, Pin, Globe2, Check, Network } from "lucide-react";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -45,8 +45,13 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Button } from "@/components/ui/button";
 import { stripGroupPrefix } from "@/ui/lib/strip-group-prefix";
-import type { MeConnectionGroupsEmptyReason } from "@/ui/lib/types";
+import type {
+  ChatRestDatasourceScope,
+  MeConnectionGroupsEmptyReason,
+} from "@/ui/lib/types";
 import type { ConversationRoutingMode } from "@useatlas/types/conversation";
+
+export type { ChatRestDatasourceScope };
 
 export type { ConversationRoutingMode };
 
@@ -107,6 +112,13 @@ export interface ChatEnvPickerProps {
    * pinned to that member".
    */
   readonly activeRoutingMode?: ConversationRoutingMode | null;
+  /**
+   * #3044 — the workspace's REST datasources + their env scope. Rendered as a
+   * read-only footer so the user can see what a pinned conversation still
+   * reaches (workspace-global datasources answer regardless of the pin).
+   * Optional / defaults to empty for back-compat with callers that don't pass it.
+   */
+  readonly restDatasources?: ReadonlyArray<ChatRestDatasourceScope>;
   /**
    * Called when the user picks a new group / member / mode triple from
    * the dropdown. The parent decides whether this is a per-turn
@@ -196,6 +208,7 @@ export function ChatEnvPicker({
   activeGroupId,
   activeConnectionId,
   activeRoutingMode = null,
+  restDatasources = [],
   onSelect,
 }: ChatEnvPickerProps): React.ReactElement | null {
   // Empty list + a reason ⇒ render a diagnostic chip instead of
@@ -420,8 +433,90 @@ export function ChatEnvPicker({
             </DropdownMenuLabel>
           </>
         )}
+
+        <ChatEnvRestScopeSection
+          restDatasources={restDatasources}
+          activeGroupId={activeGroup?.id ?? null}
+        />
       </DropdownMenuContent>
     </DropdownMenu>
+  );
+}
+
+/**
+ * #3044 — read-only footer summarizing the workspace's REST datasources and
+ * their environment scope, so the routing chip never overstates what the
+ * conversation is constrained to. Workspace-global datasources answer
+ * regardless of the pin (the bug this surfaces); datasources scoped to the
+ * active group are in scope; ones scoped elsewhere are flagged out of scope.
+ */
+function ChatEnvRestScopeSection({
+  restDatasources,
+  activeGroupId,
+}: {
+  restDatasources: ReadonlyArray<ChatRestDatasourceScope>;
+  activeGroupId: string | null;
+}): React.ReactElement | null {
+  if (restDatasources.length === 0) return null;
+
+  const workspaceGlobal = restDatasources.filter((d) => d.groupId === null);
+  const inActiveGroup = restDatasources.filter(
+    (d) => d.groupId !== null && d.groupId === activeGroupId,
+  );
+  const otherScoped = restDatasources.filter(
+    (d) => d.groupId !== null && d.groupId !== activeGroupId,
+  );
+
+  return (
+    <>
+      <DropdownMenuSeparator />
+      <DropdownMenuLabel className="text-[10px] font-semibold uppercase tracking-wider text-zinc-500 dark:text-zinc-500">
+        REST datasources
+      </DropdownMenuLabel>
+
+      {workspaceGlobal.length > 0 && (
+        <div
+          className="px-2 py-1 text-[11px] leading-snug text-zinc-600 dark:text-zinc-300"
+          data-testid="chat-env-picker-rest-global"
+        >
+          <span className="flex items-center gap-1.5 font-medium text-zinc-700 dark:text-zinc-200">
+            <Globe2 className="size-3 text-zinc-400" aria-hidden />
+            Workspace-global — answers in every environment
+          </span>
+          <span className="mt-0.5 block text-zinc-500 dark:text-zinc-400">
+            {workspaceGlobal.map((d) => d.displayName).join(", ")} — not limited by
+            the routing above.
+          </span>
+        </div>
+      )}
+
+      {inActiveGroup.length > 0 && (
+        <div
+          className="px-2 py-1 text-[11px] leading-snug text-zinc-600 dark:text-zinc-300"
+          data-testid="chat-env-picker-rest-in-scope"
+        >
+          <span className="flex items-center gap-1.5 font-medium text-zinc-700 dark:text-zinc-200">
+            <Network className="size-3 text-zinc-400" aria-hidden />
+            In this environment
+          </span>
+          <span className="mt-0.5 block text-zinc-500 dark:text-zinc-400">
+            {inActiveGroup.map((d) => d.displayName).join(", ")}
+          </span>
+        </div>
+      )}
+
+      {otherScoped.length > 0 && (
+        <div
+          className="px-2 py-1 text-[11px] leading-snug text-zinc-400 dark:text-zinc-500"
+          data-testid="chat-env-picker-rest-out-of-scope"
+        >
+          <span className="flex items-center gap-1.5">
+            <Network className="size-3" aria-hidden />
+            {otherScoped.length} scoped to other environments — not reachable here
+          </span>
+        </div>
+      )}
+    </>
   );
 }
 
@@ -519,6 +614,8 @@ export interface UseChatEnvGroupsOptions {
 
 export interface UseChatEnvGroupsResult {
   readonly groups: ReadonlyArray<ChatEnvGroup>;
+  /** #3044 — REST datasources + their env scope, for the picker's scope footer. */
+  readonly restDatasources: ReadonlyArray<ChatRestDatasourceScope>;
   readonly reason: MeConnectionGroupsEmptyReason | null;
   readonly loading: boolean;
   readonly error: string | null;
@@ -535,6 +632,9 @@ export function useChatEnvGroups(
   opts: UseChatEnvGroupsOptions,
 ): UseChatEnvGroupsResult {
   const [groups, setGroups] = useState<ReadonlyArray<ChatEnvGroup>>([]);
+  const [restDatasources, setRestDatasources] = useState<
+    ReadonlyArray<ChatRestDatasourceScope>
+  >([]);
   const [reason, setReason] = useState<MeConnectionGroupsEmptyReason | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -556,10 +656,14 @@ export function useChatEnvGroups(
         }
         const body = (await res.json()) as {
           groups?: ChatEnvGroup[];
+          restDatasources?: ChatRestDatasourceScope[];
           reason?: unknown;
         };
         if (!cancelled) {
           setGroups(body.groups ?? []);
+          // #3044 — older API servers (pre-this-change) omit the field; default
+          // to empty so the scope footer simply doesn't render on mixed deploys.
+          setRestDatasources(body.restDatasources ?? []);
           // Narrow unknown / unrecognized reason values to `null` —
           // never index into `EMPTY_REASON_COPY` with a value the
           // frontend hasn't been built to render.
@@ -576,6 +680,7 @@ export function useChatEnvGroups(
           console.warn("[atlas-chat] failed to load connection groups", msg);
           setError(msg);
           setGroups([]);
+          setRestDatasources([]);
           // Don't synthesize a `reason` on transport failure — the
           // server is the only source of truth for "empty because of
           // X". A flaky network reading as "no_internal_db" would be
@@ -591,5 +696,5 @@ export function useChatEnvGroups(
     };
   }, [opts.apiUrl, opts.enabled, opts.getHeaders, opts.getCredentials]);
 
-  return { groups, reason, loading, error };
+  return { groups, restDatasources, reason, loading, error };
 }

--- a/packages/web/src/ui/lib/types.ts
+++ b/packages/web/src/ui/lib/types.ts
@@ -218,6 +218,19 @@ export type ShareStatus =
 export type MeConnectionGroupsEmptyReason = "no_active_org" | "no_internal_db";
 
 /**
+ * A REST/OpenAPI datasource's cross-environment scope (#3044, ADR-0010), mirrored
+ * from the `restDatasources` array on `GET /api/v1/me/connection-groups`. Lets the
+ * chat env picker frame what a pinned conversation can actually reach: a
+ * `groupId === null` datasource is **workspace-global** (answers in every
+ * environment, NOT constrained by the pin); a string scopes it to that group.
+ */
+export interface ChatRestDatasourceScope {
+  readonly id: string;
+  readonly displayName: string;
+  readonly groupId: string | null;
+}
+
+/**
  * Wire-compat-safe read of {@link ConnectionInfo.billable}.
  *
  * `billable: false` excludes the row from billing/trial counts;


### PR DESCRIPTION
## Summary

Closes the composability gap between two shipped subsystems: cross-environment routing (connection groups + Auto/Pin/All, milestones 1.4.4/1.4.5) was built around `executeSQL`/SQL connection-group members, while the REST/OpenAPI datasource primitive (`executeRestOperation`, v0.0.2) was added later and **didn't participate in routing at all**. A chat pinned to one environment could still query any connected REST datasource, the datasource never appeared in the env picker, and the pin didn't constrain it — the routing-scope indicator silently overstated what the chat was bound to.

**Model decision — hybrid (documented in [ADR-0010](docs/adr/0010-rest-datasource-environment-scoping.md)):** REST datasources are **workspace-global by default** (a Stripe/GitHub/Twenty account isn't region-specific, so it correctly ignores the pin) but an admin can **optionally scope** one to a connection group via the same `config.group_id` SQL connections carry. In-scope iff `groupId` is null (workspace-global) OR `groupId === activeGroupId`. Back-compat is total — no install carries a `group_id` today.

### What changed

- **Always-correct half (the bug):** the agent prompt now frames each REST datasource's scope — workspace-global datasources are labelled *not constrained by the conversation's environment pin*; scoped ones note their group (`buildRestDatasourceScopeNote`). A pinned chat never silently appears bound tighter than it is.
- **Resolver:** `RestDatasource` carries `groupId`; `resolveWorkspaceRestDatasources*` accept a tri-state `activeGroupId` (`undefined` = no filter / authorized confirm-replay, `null` = workspace-global only, string = that group). Threaded from the agent loop (`connectionGroupId ?? null`) and the Python sandbox egress so the allowlist stays in lockstep.
- **Robustness:** REST installs share `workspace_plugins` + `pillar='datasource'` with SQL connections, so the two SQL-member queries (`env-routing/lookup.ts`, `me/connection-groups`) now **exclude REST `catalog_id`s** (shared `REST_DATASOURCE_CATALOG_IDS`) — a scoped REST install can never pollute SQL routing members (which would make `scope:"all"` fanout try SQL against a non-SQL connection).
- **Admin:** `PATCH /admin/openapi-datasources/{id}` accepts `group_id` (assign/clear); `/admin/connections` gains an **Environment** picker per datasource. `me/connection-groups` now returns REST datasource scope; the chat env picker shows a workspace-global / in-scope / out-of-scope footer.
- **Selector persistence:** a persisted zustand store remembers the chat env-picker selection across reloads (was plain `useState`, lost on reload → silently reverted to the default environment).

No DB migration — reuses the existing `config.group_id` JSONB field.

## Test plan

- [x] Resolver: pin/auto/all + off-scope filtering + the `[]` fail-soft contract + tri-state `activeGroupId` (`workspace-datasource.test.ts`)
- [x] SQL↔REST composition guard: a REST install sharing a `group_id` is excluded from SQL members on both queries (`lookup.test.ts`, `me-connection-groups.test.ts`)
- [x] Agent prompt scope framing + `connectionGroupId → activeGroupId` wiring (`agent-scope-prompt.test.ts`)
- [x] Python egress scope lockstep — passes `null`, never `undefined` (`python-rest-egress-scope.test.ts`)
- [x] Admin `group_id` assign/clear/whitespace-clear PATCH (`admin-openapi-datasources.test.ts`)
- [x] Env-picker REST scope footer + hook wire-echo; persisted preference store (`env-picker.test.tsx`, `chat-routing-preference-store.test.ts`)
- [x] `/ci` — lint, type, full test (536 api + others, 0 fail), syncpack, all drift gates
- [x] `/pr-review-toolkit:review-pr` — all five specialist agents (code, tests, errors, types, comments); findings addressed

## Acceptance criteria

- [x] Intended model decided + documented (ADR-0010)
- [x] A pinned chat never silently queries a REST datasource outside scope without the representation making the cross-env reach explicit
- [x] REST datasources represented in the routing scope surface (agent prompt + env picker)
- [x] Env-scoping: `resolveWorkspaceRestDatasources*` honors the active group; admin UI to assign a group; tests cover pin/auto/all against a group with a REST member
- [x] Tests guard the SQL↔REST composition against silent regression

Closes #3044

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3048"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782838489&installation_id=135337507&pr_number=3048&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3048&signature=924866be6ac8cd81da0390a4b5fad8bcb306efb26dacdd31e2001e28e433bc9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin UI to assign/clear per-datasource environment scope; picker shows workspace-global, in‑scope, and out‑of‑scope REST datasources
  * Chat routing preferences (environment, connection, mode) now persist across reloads
  * Agent prompt now surfaces REST datasource scope notes when relevant

* **Bug Fixes**
  * REST datasource scope honored in Python egress and agent flows
  * SQL routing excludes REST installs from connection-group member queries

* **Documentation**
  * Added ADR documenting REST/OpenAPI datasource environment scoping

* **Tests**
  * Expanded test coverage for REST scope behavior across endpoints, resolver paths, and UI picker rendering
<!-- end of auto-generated comment: release notes by coderabbit.ai -->