### PR TITLE
fix(api): gate breaking-change classifier on effective-required ancestry (#3050)

### DIFF
--- a/packages/api/src/lib/openapi/__tests__/breaking-change.test.ts
+++ b/packages/api/src/lib/openapi/__tests__/breaking-change.test.ts
@@ -397,6 +397,155 @@ describe("classifyBreakingChanges — mixed changesets", () => {
   });
 });
 
+// ── #3050: effective-required gating (optional containers + ref'd components) ─
+
+describe("classifyBreakingChanges — effective-required gating (#3050)", () => {
+  /** Classify the diff between two arbitrary docs (not clones of BASE_DOC). */
+  function classifyBetween(prev: OpenApiDoc, next: OpenApiDoc) {
+    return classifyBreakingChanges(diffOperationGraphs(graph(prev), graph(next)));
+  }
+  /** A doc with one POST whose request body wraps `bodySchema` at the given requiredness. */
+  function postBodyDoc(bodyRequired: boolean, bodySchema: SchemaNode): OpenApiDoc {
+    return {
+      openapi: "3.0.0",
+      info: { title: "T", version: "1.0.0" },
+      paths: {
+        "/things": {
+          post: {
+            operationId: "createThing",
+            requestBody: { required: bodyRequired, content: { "application/json": { schema: bodySchema } } },
+            responses: { "200": { description: "ok" } },
+          },
+        },
+      },
+      components: { schemas: {} },
+    };
+  }
+
+  it("adding a required child to an OPTIONAL request body is additive", () => {
+    const prev = postBodyDoc(false, { type: "object", required: ["a"], properties: { a: { type: "string" } } });
+    const next = postBodyDoc(false, {
+      type: "object",
+      required: ["a", "b"],
+      properties: { a: { type: "string" }, b: { type: "string" } },
+    });
+    expect(classifyBetween(prev, next).breaking).toBe(false);
+  });
+
+  it("adding a required child under an OPTIONAL ancestor (in a required body) is additive", () => {
+    // Body IS required, but `address` is optional → a caller omitting it keeps working.
+    const addr = (zipRequired: boolean): SchemaNode => ({
+      type: "object",
+      ...(zipRequired ? { required: ["zip"] } : {}),
+      properties: { street: { type: "string" }, ...(zipRequired ? { zip: { type: "string" } } : {}) },
+    });
+    const prev = postBodyDoc(true, { type: "object", required: [], properties: { address: addr(false) } });
+    const next = postBodyDoc(true, { type: "object", required: [], properties: { address: addr(true) } });
+    expect(classifyBetween(prev, next).breaking).toBe(false);
+  });
+
+  it("adding a required child under a REQUIRED ancestor (in a required body) IS breaking", () => {
+    const addr = (zipRequired: boolean): SchemaNode => ({
+      type: "object",
+      ...(zipRequired ? { required: ["zip"] } : {}),
+      properties: { street: { type: "string" }, ...(zipRequired ? { zip: { type: "string" } } : {}) },
+    });
+    const prev = postBodyDoc(true, { type: "object", required: ["address"], properties: { address: addr(false) } });
+    const next = postBodyDoc(true, { type: "object", required: ["address"], properties: { address: addr(true) } });
+    const a = classifyBetween(prev, next);
+    expect(a.breaking).toBe(true);
+    expect(
+      hasReason(a.reasons, "field_required_added", {
+        operationId: "createThing",
+        path: "requestBody:application/json.address.zip",
+      }),
+    ).toBe(true);
+  });
+
+  /** A doc using `WidgetInput` only on a required request body — request-EXCLUSIVE. */
+  function requestOnlyComponentDoc(inputRequired: string[], extraProp?: string): OpenApiDoc {
+    const props: Record<string, SchemaNode> = { name: { type: "string" } };
+    if (extraProp) props[extraProp] = { type: "string" };
+    return {
+      openapi: "3.0.0",
+      info: { title: "T", version: "1.0.0" },
+      paths: {
+        "/widgets": {
+          post: {
+            operationId: "createWidget",
+            requestBody: {
+              required: true,
+              content: { "application/json": { schema: { $ref: "#/components/schemas/WidgetInput" } } },
+            },
+            responses: { "200": { description: "ok" } },
+          },
+        },
+      },
+      components: { schemas: { WidgetInput: { type: "object", required: inputRequired, properties: props } } },
+    };
+  }
+
+  it("adding a required prop to a request-EXCLUSIVE component IS breaking", () => {
+    const prev = requestOnlyComponentDoc(["name"]);
+    const next = requestOnlyComponentDoc(["name", "sku"], "sku");
+    const a = classifyBetween(prev, next);
+    expect(a.breaking).toBe(true);
+    expect(hasReason(a.reasons, "field_required_added", { schema: "WidgetInput", path: "sku" })).toBe(true);
+  });
+
+  /** A doc using `Widget` on a response (and optionally also a required request body). */
+  function widgetDoc(opts: { alsoRequest: boolean; required: string[]; extraProp?: string }): OpenApiDoc {
+    const props: Record<string, SchemaNode> = { id: { type: "string" } };
+    if (opts.extraProp) props[opts.extraProp] = { type: "string" };
+    const paths: Record<string, PathItem> = {
+      "/widgets/{id}": {
+        get: {
+          operationId: "getWidget",
+          parameters: [{ name: "id", in: "path", required: true, schema: { type: "string" } }],
+          responses: {
+            "200": {
+              description: "ok",
+              content: { "application/json": { schema: { $ref: "#/components/schemas/Widget" } } },
+            },
+          },
+        },
+      },
+    };
+    if (opts.alsoRequest) {
+      paths["/widgets"] = {
+        post: {
+          operationId: "createWidget",
+          requestBody: {
+            required: true,
+            content: { "application/json": { schema: { $ref: "#/components/schemas/Widget" } } },
+          },
+          responses: { "200": { description: "ok" } },
+        },
+      };
+    }
+    return {
+      openapi: "3.0.0",
+      info: { title: "T", version: "1.0.0" },
+      paths,
+      components: { schemas: { Widget: { type: "object", required: opts.required, properties: props } } },
+    };
+  }
+
+  it("adding a required prop to a RESPONSE-reachable component stays quiet (no false positive)", () => {
+    const prev = widgetDoc({ alsoRequest: false, required: ["id"] });
+    const next = widgetDoc({ alsoRequest: false, required: ["id", "color"], extraProp: "color" });
+    expect(classifyBetween(prev, next).breaking).toBe(false);
+  });
+
+  it("a component used by BOTH a required request body AND a response stays quiet on added-required", () => {
+    // Response reachability dominates: the conservative policy keeps an ambiguous
+    // (read-too) surface quiet rather than nagging on a benign response-shape growth.
+    const prev = widgetDoc({ alsoRequest: true, required: ["id"] });
+    const next = widgetDoc({ alsoRequest: true, required: ["id", "sku"], extraProp: "sku" });
+    expect(classifyBetween(prev, next).breaking).toBe(false);
+  });
+});
+
 // ── resolveDriftAlertWrite — the trigger-aware raise/clear/leave lifecycle ────
 
 describe("resolveDriftAlertWrite — signal lifecycle decision", () => {

--- a/packages/api/src/lib/openapi/__tests__/breaking-change.test.ts
+++ b/packages/api/src/lib/openapi/__tests__/breaking-change.test.ts
@@ -677,6 +677,111 @@ describe("classifyBreakingChanges — effective-required gating (#3050)", () => 
       }),
     ).toBe(true);
   });
+
+  // ── breaking = breaks a PRE-EXISTING caller (seed from the prior spec) ────────
+
+  it("gaining an all-optional allOf branch on a required body is additive (branch root not flagged)", () => {
+    // The newly-added `…|allOf[1]` branch ROOT carries chainRequired but is not itself
+    // a required field — it must not surface as field_required_added, and its only
+    // (optional) member `b` is additive too.
+    const body = (withBranch: boolean): SchemaNode => ({
+      allOf: [
+        { type: "object", properties: { a: { type: "string" } } },
+        ...(withBranch ? [{ type: "object", properties: { b: { type: "string" } } } as SchemaNode] : []),
+      ],
+    });
+    expect(classifyBetween(postBodyDoc(true, body(false)), postBodyDoc(true, body(true))).breaking).toBe(false);
+  });
+
+  it("a NEW required op reusing a previously response-only component + an added required prop is additive", () => {
+    // Codex P2 (#3050 follow-up): the new operation has no existing callers, so a
+    // required prop added to the component it newly references can't break anyone.
+    // Thing is response-only in `prev` → not a prior request-exclusive surface.
+    const doc = (withCreate: boolean, sku: boolean): OpenApiDoc => {
+      const paths: Record<string, PathItem> = {
+        "/things/{id}": {
+          get: {
+            operationId: "getThing",
+            parameters: [{ name: "id", in: "path", required: true, schema: { type: "string" } }],
+            responses: {
+              "200": { description: "ok", content: { "application/json": { schema: { $ref: "#/components/schemas/Thing" } } } },
+            },
+          },
+        },
+      };
+      if (withCreate) {
+        paths["/things"] = {
+          post: {
+            operationId: "createThing",
+            requestBody: { required: true, content: { "application/json": { schema: { $ref: "#/components/schemas/Thing" } } } },
+            responses: { "200": { description: "ok" } },
+          },
+        };
+      }
+      return {
+        openapi: "3.0.0",
+        info: { title: "T", version: "1.0.0" },
+        paths,
+        components: {
+          schemas: {
+            Thing: {
+              type: "object",
+              required: sku ? ["id", "sku"] : ["id"],
+              properties: { id: { type: "string" }, ...(sku ? { sku: { type: "string" } } : {}) },
+            },
+          },
+        },
+      };
+    };
+    // prev: Thing response-only; next: a new createThing reuses it AND it gains required `sku`.
+    expect(classifyBetween(doc(false, false), doc(true, true)).breaking).toBe(false);
+  });
+
+  it("a NEW response on a PRE-EXISTING required-request component does NOT mask an added required prop", () => {
+    // Codex P2 (#3050 follow-up): Thing was already on createThing's required body, so
+    // existing callers break when it gains a required prop — a freshly-added response
+    // surface in the same diff must not suppress that signal.
+    const doc = (withGet: boolean, sku: boolean): OpenApiDoc => {
+      const paths: Record<string, PathItem> = {
+        "/things": {
+          post: {
+            operationId: "createThing",
+            requestBody: { required: true, content: { "application/json": { schema: { $ref: "#/components/schemas/Thing" } } } },
+            responses: { "200": { description: "ok" } },
+          },
+        },
+      };
+      if (withGet) {
+        paths["/things/{id}"] = {
+          get: {
+            operationId: "getThing",
+            parameters: [{ name: "id", in: "path", required: true, schema: { type: "string" } }],
+            responses: {
+              "200": { description: "ok", content: { "application/json": { schema: { $ref: "#/components/schemas/Thing" } } } },
+            },
+          },
+        };
+      }
+      return {
+        openapi: "3.0.0",
+        info: { title: "T", version: "1.0.0" },
+        paths,
+        components: {
+          schemas: {
+            Thing: {
+              type: "object",
+              required: sku ? ["id", "sku"] : ["id"],
+              properties: { id: { type: "string" }, ...(sku ? { sku: { type: "string" } } : {}) },
+            },
+          },
+        },
+      };
+    };
+    // prev: Thing on required request only; next: a new getThing also returns it AND it gains required `sku`.
+    const a = classifyBetween(doc(false, false), doc(true, true));
+    expect(a.breaking).toBe(true);
+    expect(hasReason(a.reasons, "field_required_added", { schema: "Thing", path: "sku" })).toBe(true);
+  });
 });
 
 // ── resolveDriftAlertWrite — the trigger-aware raise/clear/leave lifecycle ────

--- a/packages/api/src/lib/openapi/__tests__/breaking-change.test.ts
+++ b/packages/api/src/lib/openapi/__tests__/breaking-change.test.ts
@@ -39,6 +39,9 @@ interface SchemaNode {
   enum?: unknown[];
   properties?: Record<string, SchemaNode>;
   items?: SchemaNode;
+  allOf?: SchemaNode[];
+  oneOf?: SchemaNode[];
+  anyOf?: SchemaNode[];
 }
 interface MediaType {
   schema: SchemaNode;
@@ -543,6 +546,136 @@ describe("classifyBreakingChanges — effective-required gating (#3050)", () => 
     const prev = widgetDoc({ alsoRequest: true, required: ["id"] });
     const next = widgetDoc({ alsoRequest: true, required: ["id", "sku"], extraProp: "sku" });
     expect(classifyBetween(prev, next).breaking).toBe(false);
+  });
+
+  // ── chain-propagation edges: items + allOf preserve, oneOf/anyOf break ───────
+
+  it("a required field added under an array's items (in a required body) IS breaking", () => {
+    // "array present ⟹ its elements present" — the chain propagates through items.
+    const items = (zip: boolean): SchemaNode => ({
+      type: "object",
+      ...(zip ? { required: ["zip"] } : {}),
+      properties: { street: { type: "string" }, ...(zip ? { zip: { type: "string" } } : {}) },
+    });
+    const body = (zip: boolean): SchemaNode => ({
+      type: "object",
+      required: ["tags"],
+      properties: { tags: { type: "array", items: items(zip) } },
+    });
+    const a = classifyBetween(postBodyDoc(true, body(false)), postBodyDoc(true, body(true)));
+    expect(a.breaking).toBe(true);
+    expect(
+      hasReason(a.reasons, "field_required_added", {
+        operationId: "createThing",
+        path: "requestBody:application/json.tags[].zip",
+      }),
+    ).toBe(true);
+  });
+
+  it("a required field added under an allOf branch (in a required body) IS breaking", () => {
+    // allOf is an intersection — every branch applies, so the chain is preserved.
+    const body = (zip: boolean): SchemaNode => ({
+      allOf: [
+        { type: "object", ...(zip ? { required: ["zip"] } : {}), properties: zip ? { zip: { type: "string" } } : {} },
+      ],
+    });
+    const a = classifyBetween(postBodyDoc(true, body(false)), postBodyDoc(true, body(true)));
+    expect(a.breaking).toBe(true);
+    expect(hasReason(a.reasons, "field_required_added", { operationId: "createThing" })).toBe(true);
+  });
+
+  it("a required field added under a oneOf branch (in a required body) is additive", () => {
+    // oneOf is a union — a branch member is not guaranteed present, so the chain breaks.
+    const body = (sku: boolean): SchemaNode => ({
+      oneOf: [
+        { type: "object", ...(sku ? { required: ["sku"] } : {}), properties: sku ? { sku: { type: "string" } } : {} },
+      ],
+    });
+    expect(classifyBetween(postBodyDoc(true, body(false)), postBodyDoc(true, body(true))).breaking).toBe(false);
+  });
+
+  // ── cyclic $ref must terminate (the Twenty Person↔NoteTarget shape) ──────────
+
+  it("a self-referential request-exclusive component terminates AND flags an added-required prop", () => {
+    // `Node.child` -> $ref Node is a cycle; the reachability walk's visited-set guard
+    // must terminate. Node is request-exclusive (required body $ref, never a response).
+    const nodeDoc = (sku: boolean): OpenApiDoc => ({
+      openapi: "3.0.0",
+      info: { title: "T", version: "1.0.0" },
+      paths: {
+        "/nodes": {
+          post: {
+            operationId: "createNode",
+            requestBody: {
+              required: true,
+              content: { "application/json": { schema: { $ref: "#/components/schemas/Node" } } },
+            },
+            responses: { "200": { description: "ok" } },
+          },
+        },
+      },
+      components: {
+        schemas: {
+          Node: {
+            type: "object",
+            required: sku ? ["child", "sku"] : ["child"],
+            properties: {
+              child: { $ref: "#/components/schemas/Node" },
+              ...(sku ? { sku: { type: "string" } } : {}),
+            },
+          },
+        },
+      },
+    });
+    const a = classifyBetween(nodeDoc(false), nodeDoc(true));
+    expect(a.breaking).toBe(true);
+    expect(hasReason(a.reasons, "field_required_added", { schema: "Node", path: "sku" })).toBe(true);
+  });
+
+  // ── AC4: a dotted media type must not break the (now path-parse-free) verdict ─
+
+  it("a required field under a dotted media type (application/vnd.api+json) IS breaking", () => {
+    // Pins AC4: the verdict reads `effectiveRequired`, never parses the dotted path —
+    // a media type containing `.`/`+` can't desync the request-surface determination.
+    const doc = (zip: boolean): OpenApiDoc => ({
+      openapi: "3.0.0",
+      info: { title: "T", version: "1.0.0" },
+      paths: {
+        "/things": {
+          post: {
+            operationId: "createThing",
+            requestBody: {
+              required: true,
+              content: {
+                "application/vnd.api+json": {
+                  schema: {
+                    type: "object",
+                    required: ["address"],
+                    properties: {
+                      address: {
+                        type: "object",
+                        ...(zip ? { required: ["zip"] } : {}),
+                        properties: { street: { type: "string" }, ...(zip ? { zip: { type: "string" } } : {}) },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+            responses: { "200": { description: "ok" } },
+          },
+        },
+      },
+      components: { schemas: {} },
+    });
+    const a = classifyBetween(doc(false), doc(true));
+    expect(a.breaking).toBe(true);
+    expect(
+      hasReason(a.reasons, "field_required_added", {
+        operationId: "createThing",
+        path: "requestBody:application/vnd.api+json.address.zip",
+      }),
+    ).toBe(true);
   });
 });
 

--- a/packages/api/src/lib/openapi/__tests__/diff.test.ts
+++ b/packages/api/src/lib/openapi/__tests__/diff.test.ts
@@ -445,6 +445,50 @@ describe("diffOperationGraphs — required flip", () => {
     expect(idField.before).toMatchObject({ required: true });
     expect(idField.after.required).toBeUndefined();
   });
+
+  it("an ANCESTOR-only requiredness flip does NOT retype the unchanged descendant", () => {
+    // #3050 invariant: `effectiveRequired` is a derived classification hint excluded
+    // from `descriptorsEqual`. When `address` flips optional→required, its child
+    // `zip`'s `effectiveRequired` flips false→true, but `zip`'s structural descriptor
+    // is unchanged — so the diff must emit a retype at `address` (it gained required)
+    // and NOTHING at `address.zip`. If the hint ever leaked into equality, the child
+    // would spuriously retype (and the breaking signal would misattribute the change).
+    const doc = (addressRequired: boolean): OpenApiDoc => ({
+      openapi: "3.0.0",
+      info: { title: "T", version: "1.0.0" },
+      paths: {
+        "/things": {
+          post: {
+            operationId: "createThing",
+            requestBody: {
+              required: true,
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    ...(addressRequired ? { required: ["address"] } : {}),
+                    properties: {
+                      address: { type: "object", required: ["zip"], properties: { zip: { type: "string" } } },
+                    },
+                  },
+                },
+              },
+            },
+            responses: { "200": { description: "ok" } },
+          },
+        },
+      },
+      components: { schemas: {} },
+    });
+    const diff = diffOperationGraphs(graph(doc(false)), graph(doc(true)));
+    const change = diff.operations.changed.find((c) => c.operationId === "createThing");
+    expect(change).toBeDefined();
+    // `address` gained `required` → a retype.
+    expectChange(change!.fields, "requestBody:application/json.address", "retyped");
+    // `zip` is structurally identical on both sides → NOT in the changeset, despite
+    // its `effectiveRequired` having flipped.
+    expect(change!.fields.find((f) => f.path === "requestBody:application/json.address.zip")).toBeUndefined();
+  });
 });
 
 // ── Enum descriptors — sorted, so member order is not drift ──────────────────

--- a/packages/api/src/lib/openapi/breaking-change.ts
+++ b/packages/api/src/lib/openapi/breaking-change.ts
@@ -35,20 +35,27 @@
  *   - **Removed / retyped field** (param, request body, response, or named-schema
  *     field) → a field the agent read/sent is gone, or its type/`$ref`/`required`
  *     changed under it.
- *   - **Added REQUIRED field on a REQUEST surface** (`param:*` / `requestBody:*`) →
- *     calls the agent already composes omit it and now fail.
+ *   - **Added EFFECTIVELY-REQUIRED field on a REQUEST surface** → the field is
+ *     required AND every enclosing container up to the request is too, so calls the
+ *     agent already composes omit it and now fail. The diff proves this with its
+ *     `effectiveRequired` flag (#3050) — set on a required param, a required child of
+ *     a REQUIRED request body, or a field on a request-exclusive named component —
+ *     so this layer reads a boolean rather than parsing the dotted path.
  *   - **Removed named schema** → a shape the agent's representation referenced is gone.
  *
  * ADDITIVE (quiet) — the agent's existing contract still holds:
  *   - **Added operation / added named schema** → new capability, nothing broke.
- *   - **Added OPTIONAL request field, or ANY added RESPONSE field** → the agent can
- *     read more or send more, but every existing call still type-checks.
- *   - **Added field on a NAMED SCHEMA** → a named component is reachable from BOTH
- *     request and response surfaces, and the diff's bare schema-field path carries
- *     no surface prefix to tell which. Rather than guess "request" and nag on a
- *     benign response-shape growth, an *added* schema field is treated as additive.
- *     (Removed / retyped schema fields are still breaking — those break a read no
- *     matter the surface.)
+ *   - **Added field whose chain is NOT effectively-required** → an optional request
+ *     field, a required child of an OPTIONAL request body / optional ancestor (a
+ *     caller omitting the optional container keeps working — #3050), or ANY added
+ *     RESPONSE field. The agent can read more or send more, but every existing call
+ *     still type-checks.
+ *   - **Added field on a NAMED SCHEMA reachable from a RESPONSE (or unreachable)** →
+ *     a read surface (or dead component); growing it can't break a caller, so it
+ *     stays quiet. Only a schema the diff proved request-EXCLUSIVE (reachable from a
+ *     required request chain and never a response) carries `effectiveRequired` on its
+ *     added fields and so flags. (Removed / retyped schema fields are still breaking —
+ *     those break a read no matter the surface.)
  *
  * ## `MAX_FIELD_DEPTH` caveat (inherited from `diff.ts`)
  * The diff's field walk is bounded by `MAX_FIELD_DEPTH`; two specs differing ONLY
@@ -128,16 +135,6 @@ const ZERO_COUNTS: DiffCounts = {
 //  Internals — per-change classification
 // ─────────────────────────────────────────────────────────────────────
 
-/**
- * A field path the agent SENDS on a request (a query/header/path/cookie param, or
- * a request-body field). An added-required field here breaks calls that omit it.
- * A response-body path (`response:*`) or a bare named-schema path is NOT a request
- * surface — see the module header for why an added schema field stays quiet.
- */
-function isRequestSurfacePath(path: string): boolean {
-  return path.startsWith("param:") || path.startsWith("requestBody:");
-}
-
 /** Whether an operation-attribute change is contract-breaking (see module header). */
 function isBreakingAttribute(attr: AttributeChange): boolean {
   switch (attr.name) {
@@ -182,7 +179,14 @@ function classifyField(
     case "retyped":
       return { kind: "field_retyped", ...locate, detail: `Field "${fc.path}" was retyped on ${where}` };
     case "added":
-      if (fc.after.required === true && isRequestSurfacePath(fc.path)) {
+      // `effectiveRequired` is the diff's verdict that this added field is required
+      // AND every enclosing container up to a request surface is too (#3050): a
+      // required param, a required child of a REQUIRED request body, or a field on a
+      // request-exclusive named component. A required child of an OPTIONAL container,
+      // or any response/ambiguous-surface field, has it absent → additive. Reading
+      // the boolean replaces the old request-surface path-prefix sniff — no dotted
+      // media-type / property-name parsing, so no false negatives on `.`-bearing names.
+      if (fc.after.effectiveRequired === true) {
         return {
           kind: "field_required_added",
           ...locate,

--- a/packages/api/src/lib/openapi/breaking-change.ts
+++ b/packages/api/src/lib/openapi/breaking-change.ts
@@ -39,7 +39,8 @@
  *     required AND every enclosing container up to the request is too, so calls the
  *     agent already composes omit it and now fail. The diff proves this with its
  *     `effectiveRequired` flag (#3050) — set on a required param, a required child of
- *     a REQUIRED request body, or a field on a request-exclusive named component —
+ *     a REQUIRED request body, or a required field on a named component that was
+ *     request-exclusive in the PRIOR spec (so an existing caller already sends it) —
  *     so this layer reads a boolean rather than parsing the dotted path.
  *   - **Removed named schema** → a shape the agent's representation referenced is gone.
  *

--- a/packages/api/src/lib/openapi/diff.ts
+++ b/packages/api/src/lib/openapi/diff.ts
@@ -208,8 +208,14 @@ function normalizeEnum(values: ReadonlyArray<unknown>): ReadonlyArray<string> {
 /**
  * Describe a single schema node as the minimal comparable {@link FieldDescriptor}.
  * `required` is the immediate-parent flag (structural, compared); `chainRequired`
- * is the whole-chain flag surfaced as {@link FieldDescriptor.effectiveRequired}
- * (a classification hint, NOT compared).
+ * is whether the chain ABOVE this node is required. {@link FieldDescriptor.effectiveRequired}
+ * (a classification hint, NOT compared) is set only when BOTH hold — i.e. this node
+ * is itself required AND every enclosing container is too. The `required` conjunct is
+ * load-bearing: a container the chain passes THROUGH (an `allOf` branch root, an
+ * array-items node) has `chainRequired: true` but `required: false`, and must NOT be
+ * flagged — gaining an `allOf` branch of all-optional fields forces no existing
+ * caller to send anything new (#3050 follow-up: the classifier would otherwise emit a
+ * false `field_required_added` on the `…|allOf[n]` root).
  */
 function describeNode(
   schema: OpenApiSchema,
@@ -235,7 +241,7 @@ function describeNode(
     if (schema.enum !== undefined) d.enum = normalizeEnum(schema.enum);
   }
   if (required) d.required = true;
-  if (chainRequired) d.effectiveRequired = true;
+  if (required && chainRequired) d.effectiveRequired = true;
   return d;
 }
 
@@ -346,12 +352,15 @@ function stableSchemaKey(schema: OpenApiSchema, depth: number): string {
 
 /**
  * Flatten a named component schema's fields (root under the empty path).
- * `requestExclusive` seeds the chain-required flag: it is `true` only when the
- * named schema is reachable from a request surface via an all-required chain and
- * NEVER from a response (see {@link computeRequestExclusiveSchemas}) — so a
- * newly-required field on it breaks request callers (#3050). For any other schema
- * (response-reachable, or unreachable) the chain starts broken, so added fields
- * stay quiet, preserving the conservative "ambiguous surface ⇒ additive" policy.
+ * `requestExclusive` seeds the chain-required flag and is the caller's verdict that
+ * the schema was request-exclusive *in the prior spec* — reachable from a request
+ * surface via an all-required chain and NEVER from a response (see
+ * {@link computeRequestExclusiveSchemas}). True ⇒ a newly-required field on it breaks
+ * the spec's pre-existing request callers (#3050). For any other schema
+ * (response-reachable, unreachable, or only newly request-reachable in this diff) the
+ * chain starts broken, so added fields stay quiet — preserving both the conservative
+ * "ambiguous surface ⇒ additive" policy and the "additive change can't break an
+ * existing caller" rule.
  */
 function flattenSchemaFields(
   schema: OpenApiSchema,
@@ -586,11 +595,20 @@ export function diffOperationGraphs(
   const removedSchemas: string[] = [];
   const changedSchemas: SchemaChange[] = [];
 
-  // Which named schemas are request-exclusive on each side — seeds the per-side
-  // `effectiveRequired` so an added-required field on a request-only component
-  // reads as breaking while one on a response-reachable component stays quiet (#3050).
-  const prevExclusive = computeRequestExclusiveSchemas(prev);
-  const nextExclusive = computeRequestExclusiveSchemas(next);
+  // Which named schemas were request-exclusive in the PRIOR spec — seeds the
+  // `effectiveRequired` for a schema present in BOTH graphs (a "changed" schema). A
+  // breaking change is one that breaks a PRE-EXISTING caller, and a caller exists only
+  // for a request surface that already existed; so an added-required field on a
+  // component reads as breaking iff the component was *already* a request-exclusive
+  // surface — NOT iff it merely becomes one in this diff (#3050 follow-up). Seeding
+  // from `next` would both false-POSITIVE (a brand-new required request body referencing
+  // a previously-unused/response-only component + a new required prop has no existing
+  // callers to break) and false-NEGATIVE (a component already on a required request
+  // body that newly also appears in a response would have its real request break masked
+  // by the fresh response reachability). Both flatten sides use the same prior seed —
+  // `effectiveRequired` is excluded from equality, so the seed never perturbs detection;
+  // it only sets the verdict on the `added` side.
+  const priorRequestExclusive = computeRequestExclusiveSchemas(prev);
 
   for (const name of [...next.schemas.keys()].toSorted()) {
     if (!prev.schemas.has(name)) addedSchemas.push(name);
@@ -602,10 +620,8 @@ export function diffOperationGraphs(
     const prevSchema = prev.schemas.get(name);
     const nextSchema = next.schemas.get(name);
     if (!prevSchema || !nextSchema) continue;
-    const fields = diffFieldMaps(
-      flattenSchemaFields(prevSchema, prevExclusive.has(name)),
-      flattenSchemaFields(nextSchema, nextExclusive.has(name)),
-    );
+    const seed = priorRequestExclusive.has(name);
+    const fields = diffFieldMaps(flattenSchemaFields(prevSchema, seed), flattenSchemaFields(nextSchema, seed));
     if (fields.length > 0) changedSchemas.push({ name, fields });
   }
 

--- a/packages/api/src/lib/openapi/diff.ts
+++ b/packages/api/src/lib/openapi/diff.ts
@@ -66,6 +66,27 @@ export interface FieldDescriptor {
    * `undefined !== false` comparison never reads a non-required field as changed.
    */
   readonly required?: boolean;
+  /**
+   * True when this field is required AND *every enclosing container* up to the
+   * request surface is also required — i.e. an existing caller must already be
+   * sending this field's whole parent chain, so newly requiring it breaks them
+   * (#3050). Distinct from {@link required} (the IMMEDIATE-parent flag): a required
+   * child of an OPTIONAL request body / optional ancestor has `required: true` but
+   * `effectiveRequired` ABSENT, because a caller omitting the optional container
+   * keeps working. Set on request surfaces (the operation's params + required
+   * request body) and on named-component fields the diff has proven reachable from
+   * a request surface *exclusively* (never also a response — see
+   * {@link computeRequestExclusiveSchemas}). Always ABSENT on response/quiet
+   * surfaces. It is the SINGLE input the #2979 classifier reads to decide an
+   * added-field-is-breaking, so the rule needs no dotted-path parsing.
+   *
+   * DELIBERATELY EXCLUDED from {@link descriptorsEqual} / {@link serializeDescriptor}:
+   * it is a derived classification hint, not a structural fact. A node flipping
+   * `effectiveRequired` because an *ancestor* gained/lost `required` must not read as
+   * a retype (the requiredness change at the actual node is already caught via
+   * {@link required}); and composition-branch keys must stay stable.
+   */
+  readonly effectiveRequired?: boolean;
   /** Allowed enumerated values, normalized to a sorted string array for stable comparison. */
   readonly enum?: ReadonlyArray<string>;
 }
@@ -184,14 +205,24 @@ function normalizeEnum(values: ReadonlyArray<unknown>): ReadonlyArray<string> {
   return values.map((v) => (typeof v === "string" ? v : JSON.stringify(v))).toSorted();
 }
 
-/** Describe a single schema node as the minimal comparable {@link FieldDescriptor}. */
-function describeNode(schema: OpenApiSchema, required: boolean): FieldDescriptor {
+/**
+ * Describe a single schema node as the minimal comparable {@link FieldDescriptor}.
+ * `required` is the immediate-parent flag (structural, compared); `chainRequired`
+ * is the whole-chain flag surfaced as {@link FieldDescriptor.effectiveRequired}
+ * (a classification hint, NOT compared).
+ */
+function describeNode(
+  schema: OpenApiSchema,
+  required: boolean,
+  chainRequired: boolean,
+): FieldDescriptor {
   const d: {
     type?: string;
     format?: string;
     ref?: string;
     nullable?: boolean;
     required?: boolean;
+    effectiveRequired?: boolean;
     enum?: ReadonlyArray<string>;
   } = {};
   if (schema.ref !== undefined) {
@@ -204,6 +235,7 @@ function describeNode(schema: OpenApiSchema, required: boolean): FieldDescriptor
     if (schema.enum !== undefined) d.enum = normalizeEnum(schema.enum);
   }
   if (required) d.required = true;
+  if (chainRequired) d.effectiveRequired = true;
   return d;
 }
 
@@ -212,7 +244,9 @@ function describeNode(schema: OpenApiSchema, required: boolean): FieldDescriptor
  * Fields are emitted positionally in a FIXED order (and `enum` is pre-sorted by
  * {@link normalizeEnum}), so the output is deterministic — equal descriptors
  * always serialize to equal strings, and `undefined` members are preserved as
- * `null` by `JSON.stringify` so position never shifts.
+ * `null` by `JSON.stringify` so position never shifts. `effectiveRequired` is
+ * DELIBERATELY omitted (mirroring {@link descriptorsEqual}): a derived
+ * classification hint must not perturb branch keys (see {@link FieldDescriptor}).
  */
 function serializeDescriptor(d: FieldDescriptor): string {
   return JSON.stringify([d.type, d.format, d.ref, d.nullable, d.required, d.enum]);
@@ -233,6 +267,15 @@ function joinItems(base: string): string {
  * a terminal leaf (the named target is diffed in the schema pass — following it
  * here would both double-count and risk a cycle). Inline objects/arrays/
  * compositions recurse with a dotted path, bounded by {@link MAX_FIELD_DEPTH}.
+ *
+ * `required` is the immediate-parent flag (folded into the descriptor + compared);
+ * `chainRequired` is whether the WHOLE chain from the request surface down to and
+ * including this node is required, surfaced as `effectiveRequired` (#3050). It
+ * propagates only through required-preserving edges: a required object property
+ * (`chainRequired && requiredNames.has(name)`), array items (an array present ⟹ its
+ * elements present), and `allOf` branches (an intersection — every branch applies).
+ * `oneOf`/`anyOf` branches break the chain (a union member is not guaranteed), so
+ * they recurse with `chainRequired: false`.
  */
 function flattenSchema(
   schema: OpenApiSchema,
@@ -240,19 +283,22 @@ function flattenSchema(
   out: Map<string, FieldDescriptor>,
   depth: number,
   required: boolean,
+  chainRequired: boolean,
 ): void {
-  out.set(path, describeNode(schema, required));
+  out.set(path, describeNode(schema, required, chainRequired));
   if (schema.ref !== undefined || depth >= MAX_FIELD_DEPTH) return;
 
   if (schema.properties) {
     const requiredNames = new Set(schema.required ?? []);
     for (const name of [...schema.properties.keys()].toSorted()) {
       const child = schema.properties.get(name);
-      if (child) flattenSchema(child, joinProp(path, name), out, depth + 1, requiredNames.has(name));
+      const childRequired = requiredNames.has(name);
+      if (child)
+        flattenSchema(child, joinProp(path, name), out, depth + 1, childRequired, chainRequired && childRequired);
     }
   }
   if (schema.items) {
-    flattenSchema(schema.items, joinItems(path), out, depth + 1, false);
+    flattenSchema(schema.items, joinItems(path), out, depth + 1, false, chainRequired);
   }
   for (const [keyword, branches] of [
     ["allOf", schema.allOf],
@@ -260,6 +306,7 @@ function flattenSchema(
     ["anyOf", schema.anyOf],
   ] as const) {
     if (!branches) continue;
+    const branchChainRequired = keyword === "allOf" && chainRequired;
     // Composition branches are an UNORDERED set — `allOf` is an intersection,
     // `oneOf`/`anyOf` a union; JSON Schema assigns no meaning to their array
     // order. A generator that merely reorders branches between probes must
@@ -275,7 +322,7 @@ function flattenSchema(
     }));
     keyed.sort((a, b) => (a.key < b.key ? -1 : a.key > b.key ? 1 : 0));
     keyed.forEach(({ branch }, i) =>
-      flattenSchema(branch, `${path}|${keyword}[${i}]`, out, depth + 1, false),
+      flattenSchema(branch, `${path}|${keyword}[${i}]`, out, depth + 1, false, branchChainRequired),
     );
   }
 }
@@ -290,36 +337,52 @@ function flattenSchema(
  */
 function stableSchemaKey(schema: OpenApiSchema, depth: number): string {
   const tmp = new Map<string, FieldDescriptor>();
-  flattenSchema(schema, "", tmp, depth, false);
+  flattenSchema(schema, "", tmp, depth, false, false);
   return [...tmp.keys()]
     .toSorted()
     .map((p) => `${p}=${serializeDescriptor(tmp.get(p)!)}`)
     .join("|");
 }
 
-/** Flatten a named component schema's fields (root under the empty path). */
-function flattenSchemaFields(schema: OpenApiSchema): Map<string, FieldDescriptor> {
+/**
+ * Flatten a named component schema's fields (root under the empty path).
+ * `requestExclusive` seeds the chain-required flag: it is `true` only when the
+ * named schema is reachable from a request surface via an all-required chain and
+ * NEVER from a response (see {@link computeRequestExclusiveSchemas}) — so a
+ * newly-required field on it breaks request callers (#3050). For any other schema
+ * (response-reachable, or unreachable) the chain starts broken, so added fields
+ * stay quiet, preserving the conservative "ambiguous surface ⇒ additive" policy.
+ */
+function flattenSchemaFields(
+  schema: OpenApiSchema,
+  requestExclusive: boolean,
+): Map<string, FieldDescriptor> {
   const out = new Map<string, FieldDescriptor>();
-  flattenSchema(schema, "", out, 0, false);
+  flattenSchema(schema, "", out, 0, false, requestExclusive);
   return out;
 }
 
 /**
  * Flatten an operation's agent-relevant fields: query-pattern parameters, the
  * request body, and every response body — each under a location-prefixed path so
- * a `limit` query param and a `limit` response field never collide.
+ * a `limit` query param and a `limit` response field never collide. Request
+ * surfaces seed `chainRequired` from their own requiredness (a param's `required`,
+ * the request body's `required`); responses seed it `false` (an added response
+ * field can never break a caller). #3050: a required child of an OPTIONAL request
+ * body therefore carries `required: true` but NOT `effectiveRequired`.
  */
 function flattenOperationFields(op: Operation): Map<string, FieldDescriptor> {
   const out = new Map<string, FieldDescriptor>();
   for (const p of op.parameters) {
     const base = `param:${p.in}:${p.name}`;
-    if (p.schema) flattenSchema(p.schema, base, out, 0, p.required);
-    else out.set(base, p.required ? { required: true } : {});
+    if (p.schema) flattenSchema(p.schema, base, out, 0, p.required, p.required);
+    else out.set(base, p.required ? { required: true, effectiveRequired: true } : {});
   }
   if (op.requestBody) {
     for (const media of [...op.requestBody.content.keys()].toSorted()) {
       const schema = op.requestBody.content.get(media);
-      if (schema) flattenSchema(schema, `requestBody:${media}`, out, 0, op.requestBody.required);
+      if (schema)
+        flattenSchema(schema, `requestBody:${media}`, out, 0, op.requestBody.required, op.requestBody.required);
     }
   }
   for (const status of [...op.responses.keys()].toSorted()) {
@@ -327,10 +390,90 @@ function flattenOperationFields(op: Operation): Map<string, FieldDescriptor> {
     if (!resp) continue;
     for (const media of [...resp.content.keys()].toSorted()) {
       const schema = resp.content.get(media);
-      if (schema) flattenSchema(schema, `response:${status}:${media}`, out, 0, false);
+      if (schema) flattenSchema(schema, `response:${status}:${media}`, out, 0, false, false);
     }
   }
   return out;
+}
+
+// ─────────────────────────────────────────────────────────────────────
+//  Internals — named-schema request/response reachability (#3050)
+// ─────────────────────────────────────────────────────────────────────
+
+/**
+ * The named component schemas reachable from a request surface via an ALL-REQUIRED
+ * chain and NEVER from a response surface. An added-required field on such a schema
+ * breaks request callers exactly as an inline required request field would (#3050),
+ * so {@link flattenSchemaFields} seeds those fields' `effectiveRequired`. A schema
+ * also reachable from a response (a read surface) is excluded — matching the
+ * standing conservative policy that an added field on an ambiguous surface is
+ * additive (the agent reads more, not less).
+ *
+ * Pure graph walk over `$ref` pointers, bounded by per-side visited sets so a
+ * cyclic spec (Twenty's Person ↔ NoteTarget) terminates. The required walk only
+ * follows required-preserving edges (required properties, array items, `allOf`
+ * branches); `oneOf`/`anyOf` members and optional properties break the chain. The
+ * response walk follows EVERY edge — any response appearance makes a schema a read
+ * surface, which is enough to keep it quiet.
+ */
+function computeRequestExclusiveSchemas(graph: OperationGraph): ReadonlySet<string> {
+  const requestRequired = new Set<string>();
+  const response = new Set<string>();
+
+  // Required walk: contributes a ref target only while the chain stays required.
+  const visitedReq = new Set<string>();
+  function walkRequired(schema: OpenApiSchema, chainRequired: boolean): void {
+    if (!chainRequired) return;
+    if (schema.ref !== undefined) {
+      if (visitedReq.has(schema.ref)) return;
+      visitedReq.add(schema.ref);
+      requestRequired.add(schema.ref);
+      const target = graph.schemas.get(schema.ref);
+      if (target) walkRequired(target, true);
+      return;
+    }
+    if (schema.properties) {
+      const requiredNames = new Set(schema.required ?? []);
+      for (const [name, child] of schema.properties) walkRequired(child, requiredNames.has(name));
+    }
+    if (schema.items) walkRequired(schema.items, true);
+    if (schema.allOf) for (const branch of schema.allOf) walkRequired(branch, true);
+    // oneOf/anyOf members are not guaranteed present → the chain breaks (skip).
+  }
+
+  // Response walk: any appearance under a response marks a schema a read surface.
+  const visitedResp = new Set<string>();
+  function walkResponse(schema: OpenApiSchema): void {
+    if (schema.ref !== undefined) {
+      if (visitedResp.has(schema.ref)) return;
+      visitedResp.add(schema.ref);
+      response.add(schema.ref);
+      const target = graph.schemas.get(schema.ref);
+      if (target) walkResponse(target);
+      return;
+    }
+    if (schema.properties) for (const child of schema.properties.values()) walkResponse(child);
+    if (schema.items) walkResponse(schema.items);
+    for (const branches of [schema.allOf, schema.oneOf, schema.anyOf]) {
+      if (branches) for (const branch of branches) walkResponse(branch);
+    }
+  }
+
+  for (const op of graph.operations.values()) {
+    for (const p of op.parameters) {
+      if (p.required && p.schema) walkRequired(p.schema, true);
+    }
+    if (op.requestBody?.required) {
+      for (const schema of op.requestBody.content.values()) walkRequired(schema, true);
+    }
+    for (const resp of op.responses.values()) {
+      for (const schema of resp.content.values()) walkResponse(schema);
+    }
+  }
+
+  const exclusive = new Set<string>();
+  for (const name of requestRequired) if (!response.has(name)) exclusive.add(name);
+  return exclusive;
 }
 
 // ─────────────────────────────────────────────────────────────────────
@@ -443,6 +586,12 @@ export function diffOperationGraphs(
   const removedSchemas: string[] = [];
   const changedSchemas: SchemaChange[] = [];
 
+  // Which named schemas are request-exclusive on each side — seeds the per-side
+  // `effectiveRequired` so an added-required field on a request-only component
+  // reads as breaking while one on a response-reachable component stays quiet (#3050).
+  const prevExclusive = computeRequestExclusiveSchemas(prev);
+  const nextExclusive = computeRequestExclusiveSchemas(next);
+
   for (const name of [...next.schemas.keys()].toSorted()) {
     if (!prev.schemas.has(name)) addedSchemas.push(name);
   }
@@ -453,7 +602,10 @@ export function diffOperationGraphs(
     const prevSchema = prev.schemas.get(name);
     const nextSchema = next.schemas.get(name);
     if (!prevSchema || !nextSchema) continue;
-    const fields = diffFieldMaps(flattenSchemaFields(prevSchema), flattenSchemaFields(nextSchema));
+    const fields = diffFieldMaps(
+      flattenSchemaFields(prevSchema, prevExclusive.has(name)),
+      flattenSchemaFields(nextSchema, nextExclusive.has(name)),
+    );
     if (fields.length > 0) changedSchemas.push({ name, fields });
   }
 

--- a/packages/api/src/lib/openapi/diff.ts
+++ b/packages/api/src/lib/openapi/diff.ts
@@ -73,8 +73,8 @@ export interface FieldDescriptor {
    * (#3050). Distinct from {@link required} (the IMMEDIATE-parent flag): a required
    * child of an OPTIONAL request body / optional ancestor has `required: true` but
    * `effectiveRequired` ABSENT, because a caller omitting the optional container
-   * keeps working. Set on request surfaces (the operation's params + required
-   * request body) and on named-component fields the diff has proven reachable from
+   * keeps working. Set on request surfaces (the operation's REQUIRED params +
+   * required request body) and on named-component fields the diff has proven reachable from
    * a request surface *exclusively* (never also a response — see
    * {@link computeRequestExclusiveSchemas}). Always ABSENT on response/quiet
    * surfaces. It is the SINGLE input the #2979 classifier reads to decide an


### PR DESCRIPTION
Closes #3050. The last pre-tag follow-up gating the **v0.0.3 — Spec Lifecycle** milestone.

## Problem

The breaking-change classifier (`classifyBreakingChanges`) flagged **any** added required field on a request surface as breaking, regardless of whether the *enclosing* container was optional. Two related defects, both deferred from #3049 (Codex review) because a correct fix needs structured ancestry rather than a string-path hack:

1. **Over-flag (false positive).** An upstream adds an **optional** request body (`requestBody.required: false`) whose schema has a required property — or a required child under an optional ancestor. Existing calls omit the whole container and keep working, yet a spurious (dismissible, auto-clearing) drift alert was raised on scheduled re-discovery.
2. **Inverse miss (false negative).** When a request body/param is a `$ref` to a component, an added required property surfaced only as a bare schema-field path and was treated as additive — so a genuinely-breaking required field on a request-only component went unsignalled.

## Fix

Thread an `effectiveRequired` flag through the diff layer (`diff.ts`): **true only when a field is required AND every enclosing container up to a request surface is also required.** It propagates through required-preserving edges (required object properties, array items, `allOf` branches); optional containers and `oneOf`/`anyOf` members break the chain.

For `$ref`'d components, a graph walk (`computeRequestExclusiveSchemas`) marks schemas reachable from a **required request chain and never a response** as request-exclusive, seeding their fields' `effectiveRequired`. A schema also reachable from a response stays quiet (the standing conservative "ambiguous surface ⇒ additive" policy).

The classifier now reads the boolean instead of sniffing the dotted path — **no false negatives on media types / property names that contain dots** (`application/vnd.api+json`, dotted prop names).

`effectiveRequired` is deliberately **excluded** from `descriptorsEqual` / `serializeDescriptor`: it is a derived classification hint, so an ancestor's requiredness change must not read as a child retype, and composition-branch keys stay stable.

## Acceptance criteria (all covered by new tests)

- [x] Adding an optional request body with a required child does **not** raise a breaking signal.
- [x] Adding a required child to an already-required request container still **is** breaking (no false negative) — incl. the nested optional-vs-required-ancestor pair.
- [x] A newly-required property on a component reachable only from request surfaces is breaking; one reachable from a response surface stays quiet (+ the both-surfaces no-false-positive case).
- [x] No reliance on string-path parsing of dotted media types / property names.

## Tests

7 new cases in `breaking-change.test.ts` (built through the real `buildOperationGraph` + `diffOperationGraphs`). Full local `/ci` green (lint, type, test, syncpack, all drift gates, twenty-resolver, published-symbols).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3051"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782850304&installation_id=135337507&pr_number=3051&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3051&signature=d0aff715c92d6f2aed0e32462f920604837fc6a3d5ad7a342a5860969716a6dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More accurate breaking-change detection for added request fields: classification now uses whole-chain "effective required" semantics, respects unions vs. intersections, propagates through arrays/allOf, handles cycles, and ignores dotted media-type quirks so response-only components aren’t misclassified as request-breaking.

* **Tests**
  * Expanded test coverage validating required-field classification across nested schemas, $ref reachability, arrays, allOf/oneOf behavior, and invariants preventing spurious descendant changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->