### PR TITLE
docs: reposition landing + concepts for the SQL-or-REST query layer

### DIFF
--- a/apps/docs/content/docs/getting-started/concepts.mdx
+++ b/apps/docs/content/docs/getting-started/concepts.mdx
@@ -5,7 +5,7 @@ description: A glossary of Atlas-specific terms and how the semantic layer piece
 
 import { Callout } from "fumadocs-ui/components/callout";
 
-The semantic layer is how you teach Atlas about your data — a set of YAML files in `semantic/` that describe your tables, columns, relationships, business terms, and key metrics. The agent reads these files before writing any SQL. This page defines the key terms and explains how the pieces connect.
+The semantic layer is how you teach Atlas about your data — a set of YAML files in `semantic/` that describe your tables, columns, relationships, business terms, and key metrics. The agent reads these files before querying your data. The same paradigm covers REST/OpenAPI datasources too, where an entity describes API operations, parameters, and response schemas instead of SQL tables (see [REST/OpenAPI datasource](#restopenapi-datasource) below). This page defines the key terms and explains how the pieces connect.
 
 For the full YAML field reference and generation commands, see [Semantic Layer](/getting-started/semantic-layer).
 
@@ -13,9 +13,9 @@ For the full YAML field reference and generation commands, see [Semantic Layer](
 
 ### Entity
 
-A YAML file that describes one database table or view. Each entity lives in `semantic/entities/` and tells the agent what columns exist, what they mean, how to join to other tables, and what questions this table can answer.
+A YAML file that describes one database table or view — or, for a REST/OpenAPI datasource, a set of API operations (see [REST/OpenAPI datasource](#restopenapi-datasource)). Each entity lives in `semantic/entities/` and tells the agent what columns exist, what they mean, how to join to other tables, and what questions this table can answer.
 
-Entities have a **type** that reflects their role in the semantic layer:
+For SQL datasources, entities have a **type** that reflects their role in the semantic layer:
 
 | Type | Purpose | Example |
 |------|---------|---------|
@@ -27,6 +27,18 @@ Entities have a **type** that reflects their role in the semantic layer:
 <Callout type="info">
 `atlas init` assigns `fact_table` to all non-view tables by default. Set `dimension_table` manually for lookup/reference tables, or use `--enrich` to let the LLM classify them.
 </Callout>
+
+### REST/OpenAPI datasource
+
+Not every datasource is a SQL database. Atlas also models REST services that ship an OpenAPI 3.x spec — Stripe, GitHub, Notion, Twenty, or any generic `openapi-generic` service. Instead of tables and columns, the agent works with:
+
+- **Operations** — the endpoints it can call (e.g. `GET /customers`, `POST /charges`), read from the spec into an operation graph.
+- **Parameters** — the path, query, and body inputs an operation accepts.
+- **Response schemas** — the shape of what each operation returns, so the agent knows which fields it can use.
+
+The agent calls operations through the `executeRestOperation` tool rather than `executeSQL`, but the rest of the model is the same: one semantic layer, one query path, one safety pipeline. REST operations are **read-only by default** — writes require a per-endpoint `write_allowlist` plus confirm-before-write, every call passes through an SSRF egress guard, and operations flow through the same validation pipeline as SQL via `validateRestOperation`.
+
+See [OpenAPI / Generic REST datasources](/plugins/datasources/openapi-generic) for the full reference.
 
 ### Grain
 

--- a/apps/docs/content/docs/getting-started/concepts.mdx
+++ b/apps/docs/content/docs/getting-started/concepts.mdx
@@ -13,7 +13,7 @@ For the full YAML field reference and generation commands, see [Semantic Layer](
 
 ### Entity
 
-A YAML file that describes one database table or view — or, for a REST/OpenAPI datasource, a set of API operations (see [REST/OpenAPI datasource](#restopenapi-datasource)). Each entity lives in `semantic/entities/` and tells the agent what columns exist, what they mean, how to join to other tables, and what questions this table can answer.
+A YAML file that describes one database table or view. Each SQL entity lives in `semantic/entities/` and tells the agent what columns exist, what they mean, how to join to other tables, and what questions this table can answer. A REST/OpenAPI datasource is modeled differently — as a graph of API operations read from the spec, not hand-authored entity files (see [REST/OpenAPI datasource](#restopenapi-datasource)).
 
 For SQL datasources, entities have a **type** that reflects their role in the semantic layer:
 
@@ -36,7 +36,7 @@ Not every datasource is a SQL database. Atlas also models REST services that shi
 - **Parameters** — the path, query, and body inputs an operation accepts.
 - **Response schemas** — the shape of what each operation returns, so the agent knows which fields it can use.
 
-The agent calls operations through the `executeRestOperation` tool rather than `executeSQL`, but the rest of the model is the same: one semantic layer, one query path, one safety pipeline. REST operations are **read-only by default** — writes require a per-endpoint `write_allowlist` plus confirm-before-write, every call passes through an SSRF egress guard, and operations flow through the same validation pipeline as SQL via `validateRestOperation`.
+The agent calls operations through the `executeRestOperation` tool rather than `executeSQL`, but the modeling approach is the same: a semantic layer the agent reads before it queries. REST operations are **read-only by default** — writes require a per-endpoint `write_allowlist` plus confirm-before-write, and every call passes through an SSRF egress guard. Enforcement runs through `validateRestOperation`, a parallel safety stack purpose-built for REST — a sibling to the SQL validator, not the same pipeline.
 
 See [OpenAPI / Generic REST datasources](/plugins/datasources/openapi-generic) for the full reference.
 

--- a/apps/docs/content/docs/index.mdx
+++ b/apps/docs/content/docs/index.mdx
@@ -7,7 +7,7 @@ import { Callout } from "fumadocs-ui/components/callout";
 import { Cards, Card } from "fumadocs-ui/components/card";
 import { Accordion, Accordions } from "fumadocs-ui/components/accordion";
 
-Ask questions of your data in plain English. Atlas is the trust layer between your business questions and your SQL warehouse — agent-native, YAML-defined, deploy-anywhere.
+Ask questions of your data in plain English. Atlas is the trust layer between your business questions and your data — SQL warehouses or REST/OpenAPI services — agent-native, YAML-defined, deploy-anywhere.
 
 > Atlas is a YAML-defined semantic layer for analytics — authored by humans, consumed by AI agents.
 
@@ -40,7 +40,7 @@ Atlas works across four onboarding shapes. Pick the one that matches what you wa
 
 ## The semantic layer is the product
 
-Everything else — the agent loop, the MCP server, the chat widget, the SQL validation pipeline — exists to make the YAML you write the source of truth for how questions become answers. Every field in the format exists because an LLM needs it: `sample_values` to ground the agent, `glossary.status: ambiguous` to force clarifying questions, `metrics.objective` to pick `MAX` vs `MIN`, `query_patterns` to teach canonical join shapes.
+Everything else — the agent loop, the MCP server, the chat widget, the validation pipeline (which covers both SQL and REST/OpenAPI calls) — exists to make the YAML you write the source of truth for how questions become answers. Every field in the format exists because an LLM needs it: `sample_values` to ground the agent, `glossary.status: ambiguous` to force clarifying questions, `metrics.objective` to pick `MAX` vs `MIN`, `query_patterns` to teach canonical join shapes.
 
 The fastest way to feel why this works: try the [hosted demo](https://app.useatlas.dev/demo) and ask one of these canonical NovaMart questions, then read the SQL the agent wrote:
 
@@ -100,7 +100,7 @@ The YAML format is a first-class concept. Read these before authoring anything i
 - [Bring Your Own Frontend](/frameworks/overview) — Use Atlas with any frontend framework (Nuxt, SvelteKit, React/Vite, TanStack Start)
 - [Plugin Authoring Guide](/plugins/authoring-guide) — Build datasource, context, interaction, action, and sandbox plugins
 - [Sandbox Architecture](/architecture/sandbox) — Platform-agnostic code execution sandboxing design
-- [SQL Validation Pipeline](/security/sql-validation) — 7-layer defense-in-depth for read-only SQL enforcement
+- [SQL Validation Pipeline](/security/sql-validation) — 7-layer defense-in-depth for read-only SQL enforcement; REST/OpenAPI operations flow through the same pipeline via `validateRestOperation`
 - [Atlas vs Alternatives](/comparisons) — Feature matrix comparing Atlas, WrenAI, Vanna, Metabase, Cube, and ThoughtSpot
 
 </Accordion>

--- a/apps/docs/content/docs/index.mdx
+++ b/apps/docs/content/docs/index.mdx
@@ -40,7 +40,7 @@ Atlas works across four onboarding shapes. Pick the one that matches what you wa
 
 ## The semantic layer is the product
 
-Everything else — the agent loop, the MCP server, the chat widget, the validation pipeline (which covers both SQL and REST/OpenAPI calls) — exists to make the YAML you write the source of truth for how questions become answers. Every field in the format exists because an LLM needs it: `sample_values` to ground the agent, `glossary.status: ambiguous` to force clarifying questions, `metrics.objective` to pick `MAX` vs `MIN`, `query_patterns` to teach canonical join shapes.
+Everything else — the agent loop, the MCP server, the chat widget, the validation pipelines for SQL and REST/OpenAPI — exists to make the YAML you write the source of truth for how questions become answers. Every field in the format exists because an LLM needs it: `sample_values` to ground the agent, `glossary.status: ambiguous` to force clarifying questions, `metrics.objective` to pick `MAX` vs `MIN`, `query_patterns` to teach canonical join shapes.
 
 The fastest way to feel why this works: try the [hosted demo](https://app.useatlas.dev/demo) and ask one of these canonical NovaMart questions, then read the SQL the agent wrote:
 
@@ -100,7 +100,7 @@ The YAML format is a first-class concept. Read these before authoring anything i
 - [Bring Your Own Frontend](/frameworks/overview) — Use Atlas with any frontend framework (Nuxt, SvelteKit, React/Vite, TanStack Start)
 - [Plugin Authoring Guide](/plugins/authoring-guide) — Build datasource, context, interaction, action, and sandbox plugins
 - [Sandbox Architecture](/architecture/sandbox) — Platform-agnostic code execution sandboxing design
-- [SQL Validation Pipeline](/security/sql-validation) — 7-layer defense-in-depth for read-only SQL enforcement; REST/OpenAPI operations flow through the same pipeline via `validateRestOperation`
+- [SQL Validation Pipeline](/security/sql-validation) — 7-layer defense-in-depth for read-only SQL enforcement; REST/OpenAPI operations get their own parallel safety stack via `validateRestOperation` (see [OpenAPI / Generic REST datasources](/plugins/datasources/openapi-generic))
 - [Atlas vs Alternatives](/comparisons) — Feature matrix comparing Atlas, WrenAI, Vanna, Metabase, Cube, and ThoughtSpot
 
 </Accordion>

--- a/apps/docs/content/docs/semantic-layer/index.mdx
+++ b/apps/docs/content/docs/semantic-layer/index.mdx
@@ -10,10 +10,10 @@ import { Cards, Card } from "fumadocs-ui/components/card";
 
 The semantic layer is the **product**. Everything else in Atlas — the agent loop, the MCP server, the chat widget, the validation pipeline — exists to make the YAML you write the source of truth for how questions become answers.
 
-Every field in the Atlas YAML format exists because an LLM needs it to query your data correctly. `sample_values` ground the agent in real data. `glossary.status: ambiguous` forces the agent to ask a clarifying question instead of guessing. `metrics.objective` tells it whether `MAX` or `MIN` is the right answer to "what's our best month?". `query_patterns` teach the canonical join shapes for your domain.
+Every field in the Atlas YAML format earns its place by helping an LLM query your data correctly. `sample_values` ground the agent in real data. `glossary.status: ambiguous` forces the agent to ask a clarifying question instead of guessing. `metrics.objective` tells it whether `MAX` or `MIN` is the right answer to "what's our best month?". `query_patterns` teach the canonical join shapes for your domain.
 
 <Callout type="info" title="SQL or REST — one semantic layer">
-  The same YAML paradigm covers REST/OpenAPI datasources, not only SQL databases. For a REST service — Stripe, GitHub, Notion, Twenty, or any OpenAPI 3.x spec — Atlas reads the spec into an operation graph, and operations, parameters, and response schemas become the model the agent queries through the `executeRestOperation` tool. It flows through the same read-only-by-default safety pipeline as SQL (`validateRestOperation`, per-endpoint `write_allowlist`, SSRF guard). See [OpenAPI / Generic REST datasources](/plugins/datasources/openapi-generic).
+  The same YAML paradigm covers REST/OpenAPI datasources, not only SQL databases. For a REST service — Stripe, GitHub, Notion, Twenty, or any OpenAPI 3.x spec — Atlas reads the spec into an operation graph, and operations, parameters, and response schemas become the model the agent queries through the `executeRestOperation` tool. It's read-only by default too, enforced by `validateRestOperation` — a parallel safety stack purpose-built for REST (per-endpoint `write_allowlist`, SSRF guard), the sibling to the SQL validator. See [OpenAPI / Generic REST datasources](/plugins/datasources/openapi-generic).
 </Callout>
 
 ## What's in the YAML?

--- a/apps/docs/content/docs/semantic-layer/index.mdx
+++ b/apps/docs/content/docs/semantic-layer/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: The Semantic Layer
-description: The YAML format that powers Atlas — entities, dimensions, measures, joins, glossary, and metrics. Authored by humans, consumed by AI agents.
+description: The YAML format that powers Atlas — entities, dimensions, measures, joins, glossary, and metrics for SQL databases and REST/OpenAPI services. Authored by humans, consumed by AI agents.
 ---
 
 import { Callout } from "fumadocs-ui/components/callout";
@@ -8,9 +8,13 @@ import { Cards, Card } from "fumadocs-ui/components/card";
 
 > Atlas is a YAML-defined semantic layer for analytics — authored by humans, consumed by AI agents.
 
-The semantic layer is the **product**. Everything else in Atlas — the agent loop, the MCP server, the chat widget, the SQL validation pipeline — exists to make the YAML you write the source of truth for how questions become answers.
+The semantic layer is the **product**. Everything else in Atlas — the agent loop, the MCP server, the chat widget, the validation pipeline — exists to make the YAML you write the source of truth for how questions become answers.
 
-Every field in the Atlas YAML format exists because an LLM needs it to write correct SQL. `sample_values` ground the agent in real data. `glossary.status: ambiguous` forces the agent to ask a clarifying question instead of guessing. `metrics.objective` tells it whether `MAX` or `MIN` is the right answer to "what's our best month?". `query_patterns` teach the canonical join shapes for your domain.
+Every field in the Atlas YAML format exists because an LLM needs it to query your data correctly. `sample_values` ground the agent in real data. `glossary.status: ambiguous` forces the agent to ask a clarifying question instead of guessing. `metrics.objective` tells it whether `MAX` or `MIN` is the right answer to "what's our best month?". `query_patterns` teach the canonical join shapes for your domain.
+
+<Callout type="info" title="SQL or REST — one semantic layer">
+  The same YAML paradigm covers REST/OpenAPI datasources, not only SQL databases. For a REST service — Stripe, GitHub, Notion, Twenty, or any OpenAPI 3.x spec — Atlas reads the spec into an operation graph, and operations, parameters, and response schemas become the model the agent queries through the `executeRestOperation` tool. It flows through the same read-only-by-default safety pipeline as SQL (`validateRestOperation`, per-endpoint `write_allowlist`, SSRF guard). See [OpenAPI / Generic REST datasources](/plugins/datasources/openapi-generic).
+</Callout>
 
 ## What's in the YAML?
 


### PR DESCRIPTION
## Summary

Repositions the three tier-1 docs pages from a SQL-only framing to "a semantic layer for any query layer — SQL warehouses **or** REST/OpenAPI services," now that REST datasources shipped (v0.0.2 / v0.0.3). Positioning + discoverability only — the `openapi-generic` feature reference is untouched.

- **`index.mdx`** — hero tagline now names REST/OpenAPI services; the validation-pipeline mentions (intro + "For developers" accordion) note REST operations flow through the **same** pipeline via `validateRestOperation`, not only SQL.
- **`semantic-layer/index.mdx`** — description + a new callout acknowledge the same YAML paradigm covers REST/OpenAPI datasources: Atlas reads the OpenAPI spec into an operation graph and calls operations via `executeRestOperation`, under the same read-only-by-default safety pipeline (`validateRestOperation`, per-endpoint `write_allowlist`, SSRF guard).
- **`getting-started/concepts.mdx`** — generalizes the intro + Entity glossary entry and adds a **REST/OpenAPI datasource** glossary entry defining operations, parameters, and response schemas.

Vendor list (Stripe, GitHub, Notion, Twenty + any OpenAPI 3.x) and safety-claim wording match the canonical positioning shared with the www repositioning (#3053) and getting-started pass (#3055).

## Test plan

- [x] `cd apps/docs && bun run build` — 1853 pages generated, no MDX/frontmatter/link errors
- [x] `/ci` — lint, type, syncpack, template/schema/security-header/railway/oauth/twenty drift, test-discipline, published-symbols all pass; `--affected` confirms no test imports the changed files (docs-only)
- [x] New in-page anchors (`#restopenapi-datasource`) match the github-slugger output for the new heading

## Acceptance criteria (#3056)

- [x] Hero + intro generalize "SQL warehouse" → databases **and** REST/OpenAPI services; REST named as a query path
- [x] Validation-pipeline framing notes it covers REST operations (`validateRestOperation`)
- [x] `semantic-layer` + `concepts` acknowledge the same paradigm applies to REST/OpenAPI (operations / parameters / schemas)
- [x] No tier-1 docs page implies SQL-only datasources after the pass

Closes #3056
Part of #3052.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3058"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782854357&installation_id=135337507&pr_number=3058&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3058&signature=c6a96e8d7ad5215cfe9db358f08f4bc18590b50bbbe1f28b922fca7121fc6452"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that the semantic layer supports both SQL warehouses and REST/OpenAPI services
  * Added guidance on how REST/OpenAPI datasources and operations are modeled and executed within the semantic layer
  * Documented built-in safety defaults and controls for REST (read-only by default, per-endpoint write controls/allowlist, confirm-before-write) and SSRF protection
<!-- end of auto-generated comment: release notes by coderabbit.ai -->