### PR TITLE
docs(www): surface REST/OpenAPI datasources on the homepage (#3053)

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ The widget supports programmatic control (`Atlas.open()`, `Atlas.ask("...")`, `A
 | **Plugin ecosystem** | 21 plugins across 5 types — extend anything | Closed | Limited |
 | **Open source** | AGPL-3.0 core, MIT client libs | Proprietary | Varies |
 | **Multi-database** | PostgreSQL, MySQL, ClickHouse, Snowflake, DuckDB, BigQuery, Salesforce | Usually one | Usually one |
+| **REST APIs as datasources** | Stripe, GitHub, Notion, any OpenAPI spec — read like a datasource, write-gated, spec auto-refreshed | None | None |
 
 ## Deploy
 

--- a/apps/www/src/components/landing/comparison.tsx
+++ b/apps/www/src/components/landing/comparison.tsx
@@ -68,6 +68,13 @@ const ROWS: ReadonlyArray<Row> = [
     bi: "Usually one",
     textToSql: "Usually one",
   },
+  {
+    feature: "REST APIs as datasources",
+    atlas:
+      "Stripe, GitHub, Notion, any OpenAPI spec — read like a datasource, write-gated, spec auto-refreshed",
+    bi: "None",
+    textToSql: "None",
+  },
 ];
 
 export function Comparison() {

--- a/apps/www/src/components/landing/primitives.tsx
+++ b/apps/www/src/components/landing/primitives.tsx
@@ -101,10 +101,10 @@ export function Primitives() {
         />
         <PrimitiveCard
           kind="db"
-          name="warehouses"
-          title="Warehouse-native"
-          blurb="One connection spec. On self-host, no data leaves your network. Atlas runs in your VPC."
-          ports={["postgres", "snowflake", "bigquery", "duckdb"]}
+          name="datasources"
+          title="Query-layer native"
+          blurb="SQL warehouses and REST/OpenAPI services are one primitive — one spec the agent reads, same 7 validators, same audit. On self-host, data stays in your VPC."
+          ports={["postgres", "snowflake", "stripe", "github", "openapi"]}
         />
         <PrimitiveCard
           kind="audit"


### PR DESCRIPTION
## Summary

REST/OpenAPI services have been first-class Atlas datasources since **v0.0.2 (REST Datasources)** + **v0.0.3 (Spec Lifecycle)**, but the marketing homepage still framed Atlas as SQL-only. This is the committed **low-risk "two surfaces" treatment** chosen for #3052 — broaden the datasource primitive card + add a comparison row. **No SVG/diagram edits** (that's the separate #3054).

- **`apps/www/.../primitives.tsx`** — broaden the `kind="db"` card from "Warehouse-native" to **"Query-layer native"** (`name` → `datasources`): SQL warehouses and REST/OpenAPI services are one primitive (one spec the agent reads, same 7 validators, same audit). Ports now `postgres / snowflake / stripe / github / openapi`. **2×2 grid preserved** — still exactly 4 cards (`md:grid-cols-2` intact).
- **`apps/www/.../comparison.tsx`** — new **"REST APIs as datasources"** row: Atlas = "Stripe, GitHub, Notion, any OpenAPI spec — read like a datasource, write-gated, spec auto-refreshed"; Traditional BI + Other text-to-SQL = "None".
- **`README.md`** — identical comparison row added **in lockstep** so the "same comparison from the README — no claim drift across surfaces" parity claim on `comparison.tsx` holds.

## Claim accuracy

All claims verified against source:
- Stripe / GitHub / Notion seeded in `packages/api/src/lib/openapi/catalog-seed.ts` (+ Twenty in `data-candidate-seed.ts`)
- `executeRestOperation` — `packages/api/src/lib/tools/rest-operation.ts` ("read like a datasource")
- `write_allowlist` + confirm-before-write — `rest-write-confirm.ts`, `validate-rest-operation.ts`
- SSRF egress guard — `ssrf-guard.ts`
- scheduled spec refresh / auto re-discovery — `scheduler/openapi-install-rediscover.ts`; breaking-change drift signal (#3049)

## Test plan

- [x] `bun run lint` — ✅
- [x] `bun run type` (tsgo) — ✅
- [x] `bun run test` (full suite) — ✅
- [x] `cd apps/www && bun run build` — ✅ compiled, 15/15 static pages (authoritative for apps/www TSX)
- [x] syncpack lint, template/security-headers/railway-watch/schema/oauth-helper/test-discipline/twenty-resolver drift, published-symbols — ✅ all pass

## Acceptance criteria (#3053)

- [x] Primitive card broadened to query-layer-native; 2×2 grid preserved; REST ports present
- [x] New comparison row added; BI + other text-to-SQL columns show no equivalent
- [x] README comparison table updated in the same PR; parity holds with `comparison.tsx`
- [x] Claims accurate (Stripe/GitHub/Notion; write allowlist + confirm; SSRF; scheduled refresh + breaking-change alert)

Closes #3053. Part of #3052.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782854982&installation_id=135337507&pr_number=3059&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3059&signature=ef4d67f9c09019f84f01b5b3ab5878a91a9f0f6c7874967e4c12e80fd18a55e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for REST APIs as datasources, including Stripe, GitHub, Notion, and OpenAPI specs with gated write behavior and auto-refreshing specs.

* **Documentation**
  * Updated comparison table and primitive descriptions to reflect REST API datasource capabilities alongside SQL warehouses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->