### PR TITLE
docs(datasources): surface REST/OpenAPI sources in getting-started + datasource index

### DIFF
--- a/apps/docs/content/docs/getting-started/connect-your-data.mdx
+++ b/apps/docs/content/docs/getting-started/connect-your-data.mdx
@@ -1,6 +1,6 @@
 ---
 title: Connect Your Data
-description: Connect Atlas to PostgreSQL, MySQL, BigQuery, ClickHouse, Snowflake, DuckDB, or Salesforce.
+description: Connect Atlas to PostgreSQL, MySQL, BigQuery, ClickHouse, Snowflake, DuckDB, Salesforce, or any REST/OpenAPI service (Stripe, GitHub, Notion, Twenty).
 ---
 
 import { Callout } from "fumadocs-ui/components/callout";
@@ -8,13 +8,15 @@ import { Tabs, Tab } from "fumadocs-ui/components/tabs";
 import { Steps, Step } from "fumadocs-ui/components/steps";
 import { Accordions, Accordion } from "fumadocs-ui/components/accordion";
 
-Connect Atlas to your database. Atlas has built-in support for **PostgreSQL** and **MySQL**. Additional datasources — **BigQuery**, **ClickHouse**, **Snowflake**, **DuckDB** (CSV/Parquet), and **Salesforce** — are available as plugins.
+Atlas is a semantic layer for any query layer — SQL warehouses **and** REST/OpenAPI services — answered through one model and one safety pipeline. Atlas has built-in support for **PostgreSQL** and **MySQL**. Additional SQL datasources — **BigQuery**, **ClickHouse**, **Snowflake**, **DuckDB** (CSV/Parquet), and **Salesforce** — are available as plugins.
+
+You can also connect any **REST API with an OpenAPI 3.x spec** — **Stripe**, **GitHub**, **Notion**, **Twenty**, or your own service. The agent reads the spec into an operation graph and calls operations through the `executeRestOperation` tool, under the same read-only-by-default safety model as SQL. See the [OpenAPI (Generic REST) datasource](/plugins/datasources/openapi-generic) guide, or jump to [REST & OpenAPI APIs](#rest--openapi-apis) below.
 
 <Callout type="info" title="Using app.useatlas.dev?">
   On the hosted SaaS platform, go to **Admin &gt; Connections** to add a datasource through the UI. You do not need to set environment variables or edit config files — the platform manages connection configuration, SSL, and pooling for you. The database-specific setup below (creating read-only users, SSL settings) still applies when preparing your database for Atlas access.
 </Callout>
 
-Pick your database below and follow the steps. Each section is self-contained.
+Pick your database below and follow the steps. Each section is self-contained. For non-SQL sources, see [REST & OpenAPI APIs](#rest--openapi-apis).
 
 ---
 
@@ -720,6 +722,20 @@ Confirm the health response includes a source with `dbType` set to `"salesforce"
 
 ---
 
+## REST & OpenAPI APIs
+
+Atlas datasources are not limited to SQL. Point Atlas at any REST service that publishes an **OpenAPI 3.x spec** — **Stripe**, **GitHub**, **Notion**, **Twenty**, or your own internal API — and the agent queries it the same way it queries a database.
+
+- **How it works:** Atlas reads the OpenAPI spec into an operation graph. The agent calls operations through the `executeRestOperation` tool (instead of `executeSQL`), passing an `operationId` and its parameters.
+- **Same safety model as SQL:** read-only by default. Writes require an explicit per-endpoint `write_allowlist` plus confirm-before-write, and an SSRF egress guard restricts which hosts Atlas can reach.
+- **Stays current automatically:** a per-install refresh interval (plus a "Rediscover schema" action and background auto re-discovery) keeps the operation graph in sync with the upstream spec, surfacing a structured drift diff and a breaking-change alert when the API changes.
+
+REST/OpenAPI datasources install from **Admin &gt; Connections** like any other datasource — paste the spec URL and a credential. No `bun run atlas -- init` step is needed; the operation surface comes from the spec.
+
+See the [OpenAPI (Generic REST) datasource](/plugins/datasources/openapi-generic) guide for the full walkthrough, and [Multi-Datasource Routing](/deployment/multi-datasource) for mixing REST and SQL sources in one deployment.
+
+---
+
 ## Generate the semantic layer
 
 <Callout type="info" title="Using app.useatlas.dev?">
@@ -833,7 +849,8 @@ For multi-tenant deployments, see [Row-Level Security](/security/row-level-secur
 
 ## See Also
 
-- [Multi-Datasource Routing](/deployment/multi-datasource) — Connect multiple databases in a single deployment
+- [OpenAPI (Generic REST) datasource](/plugins/datasources/openapi-generic) — Connect Stripe, GitHub, Notion, Twenty, or any OpenAPI 3.x service
+- [Multi-Datasource Routing](/deployment/multi-datasource) — Connect multiple databases and REST APIs in a single deployment
 - [Configuration](/reference/config#datasources) — Declarative datasource configuration in `atlas.config.ts`
 - [Semantic Layer](/getting-started/semantic-layer) — Generate entity YAML files from your connected database
 - [CLI Reference](/reference/cli#init) — `atlas init` command for profiling your database

--- a/apps/docs/content/docs/getting-started/connect-your-data.mdx
+++ b/apps/docs/content/docs/getting-started/connect-your-data.mdx
@@ -730,7 +730,7 @@ Atlas datasources are not limited to SQL. Point Atlas at any REST service that p
 - **Same safety model as SQL:** read-only by default. Writes require an explicit per-endpoint `write_allowlist` plus confirm-before-write, and an SSRF egress guard restricts which hosts Atlas can reach.
 - **Stays current automatically:** a per-install refresh interval (plus a "Rediscover schema" action and background auto re-discovery) keeps the operation graph in sync with the upstream spec, surfacing a structured drift diff and a breaking-change alert when the API changes.
 
-REST/OpenAPI datasources install from **Admin &gt; Connections** like any other datasource — paste the spec URL and a credential. No `bun run atlas -- init` step is needed; the operation surface comes from the spec.
+REST/OpenAPI datasources install from **Admin &gt; Connections** like any other datasource. For a generic API, paste its OpenAPI spec URL plus a credential; pre-wired vendors need less setup — Stripe and Notion take just a credential (no spec URL), and GitHub connects via OAuth. Either way, no `bun run atlas -- init` step is needed; the operation surface comes from the spec.
 
 See the [OpenAPI (Generic REST) datasource](/plugins/datasources/openapi-generic) guide for the full walkthrough, and [Multi-Datasource Routing](/deployment/multi-datasource) for mixing REST and SQL sources in one deployment.
 

--- a/apps/docs/content/docs/getting-started/hosted.mdx
+++ b/apps/docs/content/docs/getting-started/hosted.mdx
@@ -69,7 +69,7 @@ FLUSH PRIVILEGES;
 Atlas enforces SELECT-only queries at the application level, but a read-only user provides defense-in-depth.
 
 <Callout type="info">
-For BigQuery, ClickHouse, Snowflake, DuckDB, or Salesforce, see the database-specific setup in [Connect Your Data](/getting-started/connect-your-data). The database preparation steps (creating users, granting permissions) apply to all deployment modes. To connect a REST API instead — Stripe, GitHub, Notion, Twenty, or any OpenAPI 3.x service — see the [OpenAPI (Generic REST) datasource](/plugins/datasources/openapi-generic); add it from **Admin &gt; Connections** with a spec URL and a credential.
+For BigQuery, ClickHouse, Snowflake, DuckDB, or Salesforce, see the database-specific setup in [Connect Your Data](/getting-started/connect-your-data). The database preparation steps (creating users, granting permissions) apply to all deployment modes. To connect a REST API instead — Stripe, GitHub, Notion, Twenty, or any OpenAPI 3.x service — see the [OpenAPI (Generic REST) datasource](/plugins/datasources/openapi-generic); add it from **Admin &gt; Connections** (a credential for pre-wired vendors, or a spec URL plus credential for any other API).
 </Callout>
 </Step>
 

--- a/apps/docs/content/docs/getting-started/hosted.mdx
+++ b/apps/docs/content/docs/getting-started/hosted.mdx
@@ -69,7 +69,7 @@ FLUSH PRIVILEGES;
 Atlas enforces SELECT-only queries at the application level, but a read-only user provides defense-in-depth.
 
 <Callout type="info">
-For BigQuery, ClickHouse, Snowflake, DuckDB, or Salesforce, see the database-specific setup in [Connect Your Data](/getting-started/connect-your-data). The database preparation steps (creating users, granting permissions) apply to all deployment modes.
+For BigQuery, ClickHouse, Snowflake, DuckDB, or Salesforce, see the database-specific setup in [Connect Your Data](/getting-started/connect-your-data). The database preparation steps (creating users, granting permissions) apply to all deployment modes. To connect a REST API instead — Stripe, GitHub, Notion, Twenty, or any OpenAPI 3.x service — see the [OpenAPI (Generic REST) datasource](/plugins/datasources/openapi-generic); add it from **Admin &gt; Connections** with a spec URL and a credential.
 </Callout>
 </Step>
 
@@ -187,5 +187,7 @@ Yes. Your semantic layer (entity definitions, metrics, glossary) can be exported
 </Accordion>
 <Accordion title="What databases are supported?">
 PostgreSQL, MySQL, BigQuery, ClickHouse, Snowflake, DuckDB (CSV/Parquet), and Salesforce. PostgreSQL and MySQL are built-in; others are available as plugins from the [Plugin Marketplace](/guides/plugin-marketplace).
+
+Atlas is not limited to SQL — you can also connect any **REST API with an OpenAPI 3.x spec** (Stripe, GitHub, Notion, Twenty, or your own service) via the built-in [OpenAPI (Generic REST) datasource](/plugins/datasources/openapi-generic). The agent queries it through the `executeRestOperation` tool under the same read-only-by-default safety model.
 </Accordion>
 </Accordions>

--- a/apps/docs/content/docs/getting-started/quick-start.mdx
+++ b/apps/docs/content/docs/getting-started/quick-start.mdx
@@ -244,6 +244,7 @@ See [CLI Reference](/reference/cli) for all commands and flags.
 
 - **[Understand the semantic layer](/getting-started/concepts)** — learn what entities, dimensions, measures, and metrics mean
 - **[Connect your own database](/getting-started/connect-your-data)** — replace the demo with your PostgreSQL, MySQL, or other datasource
+- **[Connect a REST API](/plugins/datasources/openapi-generic)** — point Atlas at Stripe, GitHub, Notion, Twenty, or any OpenAPI 3.x service
 - **[Deploy to production](/deployment/deploy)** — Railway, Vercel, or Docker
 - **[Set up authentication](/deployment/authentication)** — API key, managed auth, or bring-your-own-token
 - **[Choose an integration](/guides/choosing-an-integration)** — not sure whether to use the widget, SDK, or API? Compare all options

--- a/apps/docs/content/docs/plugins/datasources/index.mdx
+++ b/apps/docs/content/docs/plugins/datasources/index.mdx
@@ -1,12 +1,12 @@
 ---
 title: Datasource Plugins
-description: Connect BigQuery, ClickHouse, DuckDB, MySQL, Snowflake, and Salesforce as Atlas query targets.
+description: Connect any REST/OpenAPI service (Stripe, GitHub, Notion, Twenty) plus BigQuery, ClickHouse, DuckDB, MySQL, Snowflake, and Salesforce as Atlas query targets.
 ---
 
 import { Callout } from "fumadocs-ui/components/callout";
 import { Cards, Card } from "fumadocs-ui/components/card";
 
-Atlas supports PostgreSQL and MySQL natively via `ATLAS_DATASOURCE_URL`. For other databases and APIs, use datasource plugins. Each plugin provides a connection factory, SQL dialect hints for the agent, query validation rules, and health checks.
+Atlas is a semantic layer for any query layer — SQL warehouses **and** REST/OpenAPI services. PostgreSQL and MySQL are supported natively via `ATLAS_DATASOURCE_URL`. For other SQL databases, use a datasource plugin — each provides a connection factory, SQL dialect hints for the agent, query validation rules, and health checks. To query a REST service, use the built-in **[OpenAPI (Generic REST)](/plugins/datasources/openapi-generic)** datasource: point Atlas at any OpenAPI 3.x spec (Stripe, GitHub, Notion, Twenty, or your own API) and the agent calls its operations through the `executeRestOperation` tool, under the same read-only-by-default safety model as SQL.
 
 All datasource plugins follow the same pattern:
 
@@ -21,6 +21,7 @@ Never commit credentials to version control. Use environment variables (`process
 ## Available Datasource Plugins
 
 <Cards>
+  <Card title="OpenAPI (Generic REST)" href="/plugins/datasources/openapi-generic" description="Any REST API with an OpenAPI 3.x spec (Stripe, GitHub, Notion, Twenty) — read by default, with a per-endpoint write allowlist + confirm-before-write" />
   <Card title="BigQuery" href="/plugins/datasources/bigquery" description="Google Cloud data warehouse via REST API" />
   <Card title="ClickHouse" href="/plugins/datasources/clickhouse" description="Column-oriented analytics database via HTTP transport" />
   <Card title="DuckDB" href="/plugins/datasources/duckdb" description="Embedded analytics engine, file-based or in-memory" />
@@ -28,7 +29,6 @@ Never commit credentials to version control. Use environment variables (`process
   <Card title="Snowflake" href="/plugins/datasources/snowflake" description="Snowflake Data Cloud with pool management" />
   <Card title="Salesforce" href="/plugins/datasources/salesforce" description="Salesforce CRM via SOQL (not SQL)" />
   <Card title="Obsidian Reader" href="/plugins/datasources/obsidian-reader" description="Read-only access to an Obsidian vault via the Local REST API" />
-  <Card title="OpenAPI (Generic REST)" href="/plugins/datasources/openapi-generic" description="Any REST API with an OpenAPI 3.x spec — read by default, with a per-endpoint write allowlist + confirm-before-write" />
 </Cards>
 
 ## Comparison
@@ -42,3 +42,7 @@ Never commit credentials to version control. Use environment variables (`process
 | Read-only enforcement | SQL validation + IAM | `readonly: 1` per query | `READ_ONLY` access mode (file-based only) | `READ ONLY` session | SQL validation only | SELECT-only validation |
 | Agent tool | `executeSQL` | `executeSQL` | `executeSQL` | `executeSQL` | `executeSQL` | `querySalesforce` |
 | Connection caching | No (stateless REST) | No (stateless HTTP) | Yes (in-process) | Yes (pool) | Yes (pool) | Yes (session) |
+
+<Callout type="info">
+The table above compares the **SQL** datasources. REST services are connected through the built-in [OpenAPI (Generic REST)](/plugins/datasources/openapi-generic) datasource instead — the agent calls operations via the `executeRestOperation` tool (not `executeSQL`), reads are allowed by default, and writes require a per-endpoint `write_allowlist` plus confirm-before-write. See [Multi-Datasource Routing](/deployment/multi-datasource) for mixing REST and SQL sources in one deployment.
+</Callout>

--- a/apps/docs/content/docs/plugins/datasources/meta.json
+++ b/apps/docs/content/docs/plugins/datasources/meta.json
@@ -2,13 +2,13 @@
   "title": "Datasources",
   "pages": [
     "index",
+    "openapi-generic",
     "bigquery",
     "clickhouse",
     "duckdb",
     "mysql",
     "snowflake",
     "salesforce",
-    "obsidian-reader",
-    "openapi-generic"
+    "obsidian-reader"
   ]
 }


### PR DESCRIPTION
## Summary

The REST/OpenAPI datasource reference (`plugins/datasources/openapi-generic.mdx`) is excellent but **buried two levels deep**, while every tier-1 onboarding page enumerated only SQL databases — so a reader concludes REST is unsupported. This is a **discoverability + positioning** pass only; the thorough `openapi-generic.mdx` reference is left untouched.

Atlas is framed consistently as a **semantic layer for any query layer — SQL warehouses *and* REST/OpenAPI services**, answered through one model + one safety pipeline (mirroring the prior art in `deployment/multi-datasource.mdx`).

### Changes
- **`getting-started/connect-your-data.mdx`** — meta + intro now name REST/OpenAPI (Stripe / GitHub / Notion / Twenty / any OpenAPI 3.x) alongside the databases and link the guide; adds a `## REST & OpenAPI APIs` pointer section (so it appears in the page's section nav) + a See Also entry.
- **`getting-started/hosted.mdx`** — the BigQuery+ callout and the "What databases are supported?" FAQ both now include REST/OpenAPI datasources.
- **`getting-started/quick-start.mdx`** — Next-steps gains a "Connect a REST API" link.
- **`plugins/datasources/index.mdx`** — description names REST/OpenAPI; the OpenAPI card is promoted from **last (8th)** to **first**; a note clarifies the comparison table is SQL-focused and points to the OpenAPI datasource.
- **`plugins/datasources/meta.json`** — `openapi-generic` reordered to follow `index` (out of last place).

Net: no tier-1 onboarding page implies SQL-only datasources anymore — a reader asking "what can I connect?" learns REST/OpenAPI exists without digging into the plugins tree.

## Test plan
- `cd apps/docs && bun run build` (Fumadocs) — compiled successfully, all static pages generated (validates MDX, frontmatter, and routing; `/plugins/datasources/openapi-generic` resolves).
- `bun run lint` — exit 0
- `bun run type` — exit 0
- No API tests affected (docs-only: 4 MDX + 1 JSON).

Part of #3052.
Closes #3055.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3060"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782855002&installation_id=135337507&pr_number=3060&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3060&signature=6ae4b7c6ebbfd425146fc45b0931fdff6c4f2eedb49a7f15e7d184391fd5e7e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Documentation

* **Updated getting started guides** to include connecting REST/OpenAPI services alongside SQL databases
* **Added “REST & OpenAPI APIs” section** describing operation flow, read-only-by-default safety, per-endpoint write allowlist with confirm-before-write, SSRF egress guarding, and automatic spec refresh/discovery
* **Enhanced datasource plugins docs** to present REST/OpenAPI as a first-class datasource and reordered the plugin list
* **Added quick start navigation** linking to the REST API connection guide and updated FAQ mentions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->