### PR TITLE
docs(www): correct REST/OpenAPI accuracy claims on homepage (#3053)

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ The widget supports programmatic control (`Atlas.open()`, `Atlas.ask("...")`, `A
 | **Plugin ecosystem** | 21 plugins across 5 types — extend anything | Closed | Limited |
 | **Open source** | AGPL-3.0 core, MIT client libs | Proprietary | Varies |
 | **Multi-database** | PostgreSQL, MySQL, ClickHouse, Snowflake, DuckDB, BigQuery, Salesforce | Usually one | Usually one |
-| **REST APIs as datasources** | Stripe, GitHub, Notion, any OpenAPI spec — read like a datasource, write-gated, spec auto-refreshed | None | None |
+| **REST APIs as datasources** | Stripe, GitHub, Notion, any OpenAPI spec — read like a datasource, write-gated; generic OpenAPI installs auto-refresh | None | None |
 
 ## Deploy
 

--- a/apps/www/src/components/landing/comparison.tsx
+++ b/apps/www/src/components/landing/comparison.tsx
@@ -71,7 +71,7 @@ const ROWS: ReadonlyArray<Row> = [
   {
     feature: "REST APIs as datasources",
     atlas:
-      "Stripe, GitHub, Notion, any OpenAPI spec — read like a datasource, write-gated, spec auto-refreshed",
+      "Stripe, GitHub, Notion, any OpenAPI spec — read like a datasource, write-gated; generic OpenAPI installs auto-refresh",
     bi: "None",
     textToSql: "None",
   },

--- a/apps/www/src/components/landing/primitives.tsx
+++ b/apps/www/src/components/landing/primitives.tsx
@@ -103,7 +103,7 @@ export function Primitives() {
           kind="db"
           name="datasources"
           title="Query-layer native"
-          blurb="SQL warehouses and REST/OpenAPI services are one primitive — one spec the agent reads, same 7 validators, same audit. On self-host, data stays in your VPC."
+          blurb="SQL warehouses and REST/OpenAPI services are one primitive — one spec the agent reads. SQL runs 7 validators; REST a parallel write-gated guard. Self-host and Atlas runs in your network."
           ports={["postgres", "snowflake", "stripe", "github", "openapi"]}
         />
         <PrimitiveCard


### PR DESCRIPTION
## What

Corrects four inaccurate REST/OpenAPI claims that shipped in #3059 (homepage + README). The reviewers (Codex, CodeRabbit) flagged these on #3059 but the PR was merged before they were addressed — this is the fix-forward.

## Findings addressed

1. **"same 7 validators"** — REST/OpenAPI does **not** run the SQL validator stack. It uses the parallel `packages/api/src/lib/openapi/validate-rest-operation.ts` guard (write-allowlist per endpoint + SSRF). Reworded to distinguish the two paths.
2. **"same audit"** — SQL execution writes the searchable `audit_log` via `logQueryAudit`; the REST/OpenAPI tool path does not. Dropped the audit claim from this card (the dedicated audit card still stands for SQL).
3. **"data stays in your VPC"** — REST datasources (Stripe/GitHub/Notion) call external API hosts, so data does leave the network. Qualified to "Atlas runs in your network".
4. **"spec auto-refreshed"** (comparison + README) — per-install rediscovery/drift only runs for **generic OpenAPI** installs (`OPENAPI_GENERIC_CATALOG_ID`); vendor specs use a process-local shared cache that never mutates the persisted snapshot. Narrowed to "generic OpenAPI installs auto-refresh".

## Surfaces kept in sync

`comparison.tsx` and `README.md` carry identical cell text per the "no claim drift across surfaces" rule.

Refs #3053. Follow-up to #3059.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3061"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782860064&installation_id=135337507&pr_number=3061&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3061&signature=679c4dd9e205bcfb32a037eddf7f416bff38cf88894809ff591696a53cc35ad3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated REST APIs as datasources documentation and UI messaging to explicitly clarify generic OpenAPI installs auto-refresh behavior.
  * Refined datasource feature descriptions across comparison tables and component cards.
  * Enhanced messaging around write-gating and self-hosting capabilities to provide clearer information about datasource behavior and deployment options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->