### PR TITLE
feat(www): answer-led hero redesign + SQL-or-REST repositioning

### DIFF
--- a/apps/www/src/components/landing/data.ts
+++ b/apps/www/src/components/landing/data.ts
@@ -19,3 +19,10 @@ export const CATEGORY_ROWS: ReadonlyArray<CategoryRow> = [
   { category: "Outdoor",     gmv: "$71,288",  orders: "812"   },
   { category: "Accessories", gmv: "$54,011",  orders: "693"   },
 ];
+
+/**
+ * The canonical demo question. Shared by the hero answer card and the YAML
+ * section's reply pane so the prompt text never drifts between surfaces.
+ */
+export const TOP_CATEGORY_QUESTION =
+  "What's our top-performing category by GMV this month?";

--- a/apps/www/src/components/landing/hero.tsx
+++ b/apps/www/src/components/landing/hero.tsx
@@ -1,291 +1,196 @@
-import { type CSSProperties } from "react";
+import { Fragment } from "react";
+
+import { CATEGORY_ROWS, TOP_CATEGORY_QUESTION } from "./data";
 
 const HEADLINE_LINES = ["A semantic layer", "for analytics,", "agent-native."] as const;
 const ITALIC_LINE_INDEX = 2;
 
 const SUBHEAD =
-  "Atlas is a YAML-defined semantic layer for analytics — authored by humans, consumed by AI agents. Entities, glossary, and metrics live in your repo; the agent reads them, writes deterministic SQL, and runs it through a 7-stage validation pipeline — read-only, table-whitelisted, statement-timed.";
+  "Your semantic layer lives in YAML, versioned in your repo. Ask in plain English; Atlas writes the query and runs it read-only, returning grounded answers from SQL warehouses and REST/OpenAPI services alike.";
 
-type NodeKind =
-  | "input"
-  | "yaml"
-  | "process"
-  | "gate"
-  | "db"
-  | "result"
-  | "audit"
-  | "widget";
+/**
+ * The hero's payload: a plain-English question and the validated answer it
+ * returns. No SQL here — the mechanism (YAML + generated SQL) lives in the
+ * YAML section below, so the two surfaces don't duplicate.
+ */
+function AnswerCard() {
+  return (
+    <div
+      className="relative overflow-hidden rounded-xl border border-white/10"
+      style={{ background: "oklch(0.14 0 0)" }}
+    >
+      <div
+        className="flex items-center gap-2 border-b border-white/5 px-3.5 py-2.5"
+        style={{ background: "oklch(0.16 0 0)" }}
+      >
+        <span className="h-2 w-2 rounded-full" style={{ background: "var(--atlas-brand)" }} />
+        <span className="font-mono text-[11px] text-zinc-400">atlas · agent reply</span>
+        <span className="ml-auto rounded border border-white/10 px-2 py-[2px] font-mono text-[10px] text-zinc-400">
+          chat · mcp · widget
+        </span>
+      </div>
 
-type SchemaNode = {
-  readonly id: string;
-  readonly x: number;
-  readonly y: number;
-  readonly w: number;
-  readonly label: string;
-  readonly value: string;
-  readonly kind: NodeKind;
-};
+      <div className="flex flex-col gap-4 px-4 py-5">
+        <div>
+          <p className="mb-1.5 font-mono text-[11px] tracking-[0.06em] text-brand">
+            // asked in plain english
+          </p>
+          <p className="m-0 text-[15px] leading-snug text-zinc-100">{TOP_CATEGORY_QUESTION}</p>
+        </div>
 
-const NODES = [
-  { id: "prompt",     x: 600,  y: 560, w: 220, label: "prompt",                value: '"top categories by gmv…"',   kind: "input"   },
-  { id: "semantic",   x: 620,  y: 100, w: 240, label: "semantic_layer.yaml",   value: "entities · metrics · glossary", kind: "yaml"  },
-  { id: "compiler",   x: 640,  y: 320, w: 200, label: "compiler",              value: "AST → SQL",                    kind: "process" },
-  { id: "validators", x: 900,  y: 320, w: 240, label: "7 validators",          value: "ast · perms · row_limit · …",  kind: "gate"    },
-  { id: "warehouse",  x: 1190, y: 200, w: 220, label: "warehouse",             value: "postgres / snowflake / bq",    kind: "db"      },
-  { id: "result",     x: 1190, y: 460, w: 220, label: "result",                value: "rows · read-only",             kind: "result"  },
-  { id: "audit",      x: 900,  y: 560, w: 240, label: "audit_log",             value: "every query · every op",       kind: "audit"   },
-  { id: "widget",     x: 640,  y: 460, w: 200, label: "<AtlasChat />",         value: "react widget",                 kind: "widget"  },
-] as const satisfies ReadonlyArray<SchemaNode>;
+        <div>
+          <p className="mb-2 font-mono text-[11px] tracking-[0.06em] text-zinc-400">
+            // validated answer
+          </p>
+          <div
+            className="overflow-hidden rounded-md border border-white/10"
+            style={{ background: "oklch(0.10 0 0)" }}
+          >
+            <div className="grid grid-cols-[1fr_auto_auto] gap-4 border-b border-white/5 px-3 py-2 font-mono text-[11px] uppercase tracking-[0.06em] text-zinc-400">
+              <span>category</span>
+              <span className="text-right">gmv</span>
+              <span className="text-right">orders</span>
+            </div>
+            {CATEGORY_ROWS.slice(0, 3).map((row, i) => (
+              <div
+                key={row.category}
+                className="grid grid-cols-[1fr_auto_auto] gap-4 px-3 py-2 font-mono text-[12.5px] text-zinc-200"
+                style={{ background: i % 2 ? "oklch(0.12 0 0)" : "transparent" }}
+              >
+                <span>{row.category}</span>
+                <span className="text-right text-brand">{row.gmv}</span>
+                <span className="text-right text-zinc-400">{row.orders}</span>
+              </div>
+            ))}
+          </div>
+        </div>
 
-type NodeId = (typeof NODES)[number]["id"];
+        <div className="flex flex-wrap items-center gap-x-2.5 gap-y-1.5 font-mono text-[11px] text-zinc-400">
+          <span className="flex items-center gap-1.5 text-brand">
+            <span aria-hidden>✓</span> 7 validators
+          </span>
+          <span className="text-zinc-700">·</span>
+          <span>read-only</span>
+          <span className="text-zinc-700">·</span>
+          <span>row-limited</span>
+          <span className="text-zinc-700">·</span>
+          <span>audited</span>
+        </div>
+      </div>
+    </div>
+  );
+}
 
-const NODE_BY_ID: Record<NodeId, SchemaNode> = Object.fromEntries(
-  NODES.map((n) => [n.id, n]),
-) as Record<NodeId, SchemaNode>;
+type Stage = { readonly label: string; readonly value: string; readonly highlight: boolean };
 
-type Edge = { readonly from: NodeId; readonly to: NodeId; readonly label: string };
-
-const EDGES: ReadonlyArray<Edge> = [
-  { from: "prompt",     to: "compiler",   label: "01"  },
-  { from: "semantic",   to: "compiler",   label: "02"  },
-  { from: "compiler",   to: "validators", label: "03"  },
-  { from: "validators", to: "warehouse",  label: "04"  },
-  { from: "warehouse",  to: "result",     label: "05"  },
-  { from: "result",     to: "widget",     label: "06"  },
-  { from: "validators", to: "audit",      label: "log" },
-  { from: "result",     to: "audit",      label: "log" },
+const STAGES: ReadonlyArray<Stage> = [
+  { label: "ask",            value: '"top category by gmv…"', highlight: false },
+  { label: "semantic layer", value: "entities · metrics",     highlight: false },
+  { label: "datasources",    value: "sql · rest/openapi",     highlight: true  },
+  { label: "answer",         value: "validated · audited",    highlight: false },
 ];
 
-const EDGE_DELAY_MS: ReadonlyArray<number> = [0, 300, 600, 900, 1200, 1500, 1800, 2100];
-const NODE_DELAY_MS: Record<NodeId, number> = {
-  prompt: 0,
-  semantic: 0,
-  compiler: 300,
-  validators: 600,
-  warehouse: 900,
-  result: 1200,
-  widget: 1500,
-  audit: 1800,
-};
-
-const NODE_TINTS: Record<NodeKind, string> = {
-  input:   "color-mix(in oklch, var(--atlas-brand) 14%, transparent)",
-  yaml:    "oklch(0.18 0 0)",
-  process: "oklch(0.18 0 0)",
-  gate:    "oklch(0.2 0.04 167)",
-  db:      "oklch(0.18 0 0)",
-  result:  "oklch(0.18 0 0)",
-  audit:   "oklch(0.18 0 0)",
-  widget:  "oklch(0.18 0 0)",
-};
-const NODE_ACCENTS: Record<NodeKind, string> = {
-  input:   "var(--atlas-brand)",
-  yaml:    "oklch(0.85 0.18 70)",
-  process: "oklch(0.78 0.13 280)",
-  gate:    "var(--atlas-brand)",
-  db:      "oklch(0.78 0.13 280)",
-  result:  "var(--atlas-brand)",
-  audit:   "oklch(0.708 0 0)",
-  widget:  "oklch(0.85 0.18 70)",
-};
-
-function SchemaMap() {
-  const W = 1440;
-  const H = 720;
-
+/**
+ * The four-stage path, replacing the old hand-positioned schema graph. One
+ * straight read left-to-right; the datasources stage carries the SQL-or-REST
+ * repositioning.
+ */
+function PipelineStrip() {
   return (
-    <svg
-      viewBox={`0 0 ${W} ${H}`}
-      preserveAspectRatio="xMidYMid meet"
-      className="block w-full"
-      role="img"
-      aria-label="Atlas system diagram: prompt and semantic layer feed the compiler, the compiler runs through 7 validators, then the warehouse, result, audit log, and React widget"
-    >
-      <defs>
-        <linearGradient id="hero-wire-grad" x1="0" y1="0" x2="1" y2="0">
-          <stop offset="0%" stopColor="var(--atlas-brand)" stopOpacity="0.7" />
-          <stop offset="100%" stopColor="var(--atlas-brand)" stopOpacity="0.2" />
-        </linearGradient>
-        <pattern id="hero-dot-grid" width="32" height="32" patternUnits="userSpaceOnUse">
-          <circle cx="1" cy="1" r="0.8" fill="oklch(1 0 0 / 0.06)" />
-        </pattern>
-        <radialGradient id="hero-halo" cx="50%" cy="50%" r="50%">
-          <stop offset="0%" stopColor="var(--atlas-brand)" stopOpacity="0.18" />
-          <stop offset="100%" stopColor="var(--atlas-brand)" stopOpacity="0" />
-        </radialGradient>
-      </defs>
-
-      <rect width={W} height={H} fill="url(#hero-dot-grid)" />
-      <ellipse cx="980" cy="380" rx="420" ry="300" fill="url(#hero-halo)" />
-
-      {EDGES.map((e, i) => {
-        const a = NODE_BY_ID[e.from];
-        const b = NODE_BY_ID[e.to];
-        const ax = a.x + a.w / 2;
-        const ay = a.y + 32;
-        const bx = b.x + b.w / 2;
-        const by = b.y + 32;
-        const midX = (ax + bx) / 2;
-        const path = `M ${ax} ${ay} C ${midX} ${ay}, ${midX} ${by}, ${bx} ${by}`;
-        const delay = EDGE_DELAY_MS[i] ?? 0;
-        const litStyle = { "--schema-delay": `${delay}ms` } as CSSProperties;
-
-        return (
-          <g key={`${e.from}-${e.to}-${i}`} className="schema-edge" style={litStyle}>
-            {/* Faint baseline so the path is always visible even in reduced-motion */}
-            <path d={path} fill="none" stroke="oklch(1 0 0 / 0.08)" strokeWidth="1" />
-            <path
-              d={path}
-              fill="none"
-              stroke="url(#hero-wire-grad)"
-              strokeWidth="1.4"
-              strokeDasharray="2 6"
+    <div className="mt-12 md:mt-16">
+      <p className="mb-3.5 font-mono text-[11px] tracking-[0.04em] text-zinc-500">
+        // the same path, every datasource
+      </p>
+      <div className="grid gap-3 md:grid-cols-[1fr_auto_1fr_auto_1fr_auto_1fr] md:items-center">
+        {STAGES.map((stage, i) => (
+          <Fragment key={stage.label}>
+            <div
+              className="flex flex-col gap-1 rounded-lg border px-4 py-3.5"
+              style={{
+                background: "oklch(0.16 0 0)",
+                borderColor: stage.highlight
+                  ? "color-mix(in oklch, var(--atlas-brand) 35%, transparent)"
+                  : "oklch(1 0 0 / 0.1)",
+              }}
             >
-              <animate
-                attributeName="stroke-dashoffset"
-                from="16"
-                to="0"
-                dur="2s"
-                repeatCount="indefinite"
-              />
-            </path>
-            <g transform={`translate(${midX - 14}, ${(ay + by) / 2 - 8})`}>
-              <rect
-                width="28"
-                height="16"
-                rx="3"
-                fill="#0C0C10"
-                stroke="color-mix(in oklch, var(--atlas-brand) 40%, transparent)"
-              />
-              <text
-                x="14"
-                y="11"
-                textAnchor="middle"
-                fontSize="9"
-                fontFamily="var(--font-mono)"
-                fill="var(--atlas-brand)"
-                letterSpacing="0.06em"
-              >
-                {e.label}
-              </text>
-            </g>
-          </g>
-        );
-      })}
-
-      {NODES.map((n) => {
-        const acc = NODE_ACCENTS[n.kind];
-        const bg = NODE_TINTS[n.kind];
-        const delay = NODE_DELAY_MS[n.id] ?? 0;
-        const style = { "--schema-delay": `${delay}ms` } as CSSProperties;
-        return (
-          <g
-            key={n.id}
-            transform={`translate(${n.x}, ${n.y})`}
-            className="schema-node"
-            style={style}
-          >
-            <rect
-              width={n.w}
-              height="74"
-              rx="8"
-              fill={bg}
-              stroke="oklch(1 0 0 / 0.1)"
-              strokeWidth="1"
-            />
-            <circle cx="14" cy="32" r="4" fill={acc} />
-            <circle cx={n.w - 14} cy="32" r="4" fill={acc} stroke="#0C0C10" strokeWidth="2" />
-            <g transform="translate(28, 18)">
-              <rect
-                width={n.kind.length * 6.5 + 12}
-                height="14"
-                rx="3"
-                fill="oklch(0 0 0 / 0.4)"
-                stroke="oklch(1 0 0 / 0.08)"
-              />
-              <text
-                x="6"
-                y="10"
-                fontSize="9"
-                fontFamily="var(--font-mono)"
-                fill={acc}
-                letterSpacing="0.08em"
-              >
-                {n.kind.toUpperCase()}
-              </text>
-            </g>
-            <text
-              x="28"
-              y="50"
-              fontSize="14"
-              fontFamily="var(--font-sans)"
-              fill="oklch(0.985 0 0)"
-              fontWeight="600"
-            >
-              {n.label}
-            </text>
-            <text
-              x="28"
-              y="65"
-              fontSize="11"
-              fontFamily="var(--font-mono)"
-              fill="oklch(0.65 0 0)"
-            >
-              {n.value}
-            </text>
-          </g>
-        );
-      })}
-    </svg>
+              <span className="text-[13px] font-semibold text-zinc-50">{stage.label}</span>
+              <span className="font-mono text-[11px]">
+                {stage.highlight ? (
+                  <>
+                    <span className="text-zinc-400">sql · </span>
+                    <span className="text-brand">rest/openapi</span>
+                  </>
+                ) : (
+                  <span className="text-zinc-400">{stage.value}</span>
+                )}
+              </span>
+            </div>
+            {i < STAGES.length - 1 && (
+              <span aria-hidden className="hidden justify-center font-mono text-brand md:flex">
+                →
+              </span>
+            )}
+          </Fragment>
+        ))}
+      </div>
+    </div>
   );
 }
 
 export function Hero() {
   return (
-    <section className="relative overflow-hidden border-b border-white/5">
-      {/* Absolute over the SVG on desktop, stacked above on mobile where the SVG shrinks. */}
-      <div className="relative md:absolute md:top-20 md:left-20 md:z-[2] md:max-w-[460px] px-6 pt-16 md:px-0 md:pt-0">
-        <p className="mb-[18px] font-mono text-[11.5px] uppercase tracking-[0.16em] text-brand">
-          // the schema is the product
-        </p>
-        <h1 className="m-0 text-[44px] sm:text-[56px] md:text-[64px] font-semibold leading-[1.02] tracking-[-0.035em] text-zinc-50">
-          {HEADLINE_LINES.map((line, i) => (
-            <span key={line} className="block">
-              {i === ITALIC_LINE_INDEX ? (
-                <em className="font-semibold text-brand">{line}</em>
-              ) : (
-                line
-              )}
-            </span>
-          ))}
-        </h1>
-        <p className="mt-6 max-w-[420px] text-base leading-[1.6] text-zinc-400">
-          {SUBHEAD}
-        </p>
-        <div className="mt-7 flex flex-wrap gap-2.5">
-          <a
-            href="https://app.useatlas.dev/demo"
-            className="inline-flex items-center gap-2 rounded-lg bg-brand px-[18px] py-[11px] text-[13.5px] font-semibold text-zinc-950 transition-colors hover:bg-brand-hover"
-          >
-            Try the demo →
-          </a>
-          <a
-            href="https://docs.useatlas.dev/getting-started/quick-start"
-            className="inline-flex items-center rounded-lg border border-white/10 bg-zinc-900 px-3.5 py-2.5 text-zinc-50 transition-colors hover:border-white/20"
-          >
-            <code className="font-mono text-[12.5px]">
-              $ bun create atlas-agent
-            </code>
-          </a>
+    <section className="relative overflow-hidden border-b border-white/5 px-6 pt-16 pb-16 md:px-16 md:pt-24 md:pb-20">
+      <div
+        aria-hidden
+        className="pointer-events-none absolute -top-32 right-0 h-[560px] w-[560px] rounded-full"
+        style={{
+          background:
+            "radial-gradient(circle, color-mix(in oklch, var(--atlas-brand) 10%, transparent), transparent 70%)",
+        }}
+      />
+
+      <div className="relative grid gap-10 md:grid-cols-2 md:items-center md:gap-12">
+        <div className="max-w-[520px]">
+          <p className="mb-[18px] font-mono text-[11.5px] uppercase tracking-[0.16em] text-brand">
+            // ask in plain english
+          </p>
+          <h1 className="m-0 text-[44px] sm:text-[56px] md:text-[64px] font-semibold leading-[1.02] tracking-[-0.035em] text-zinc-50">
+            {HEADLINE_LINES.map((line, i) => (
+              <span key={line} className="block">
+                {i === ITALIC_LINE_INDEX ? (
+                  <em className="font-semibold text-brand">{line}</em>
+                ) : (
+                  line
+                )}
+              </span>
+            ))}
+          </h1>
+          <p className="mt-6 max-w-[460px] text-base leading-[1.6] text-zinc-400">{SUBHEAD}</p>
+          <div className="mt-7 flex flex-wrap gap-2.5">
+            <a
+              href="https://app.useatlas.dev/demo"
+              className="inline-flex items-center gap-2 rounded-lg bg-brand px-[18px] py-[11px] text-[13.5px] font-semibold text-zinc-950 transition-colors hover:bg-brand-hover"
+            >
+              Try the demo →
+            </a>
+            <a
+              href="https://docs.useatlas.dev/getting-started/quick-start"
+              className="inline-flex items-center rounded-lg border border-white/10 bg-zinc-900 px-3.5 py-2.5 text-zinc-50 transition-colors hover:border-white/20"
+            >
+              <code className="font-mono text-[12.5px]">$ bun create atlas-agent</code>
+            </a>
+          </div>
+          <p className="mt-3.5 font-mono text-[11px] tracking-[0.04em] text-zinc-400">
+            self-host is free · MCP server for claude desktop, cursor, continue · slack-native
+          </p>
         </div>
-        <p className="mt-3.5 font-mono text-[11px] tracking-[0.04em] text-zinc-400">
-          self-host is free · MCP server for claude desktop, cursor, continue · slack-native
-        </p>
+
+        <div className="relative">
+          <AnswerCard />
+        </div>
       </div>
 
-      <div className="md:pt-0 pt-8">
-        <SchemaMap />
-      </div>
+      <PipelineStrip />
     </section>
   );
 }

--- a/apps/www/src/components/landing/trace-section.tsx
+++ b/apps/www/src/components/landing/trace-section.tsx
@@ -23,9 +23,17 @@ export function TraceSection() {
 
       <Trace />
 
-      <div className="mt-4 flex flex-wrap gap-3 font-mono text-[11px] tracking-[0.04em] text-zinc-400">
-        <span className="text-brand">// playback</span>
-        <span>autoplays on scroll · click any step or gate to inspect</span>
+      <div className="mt-4 flex flex-col gap-1.5 font-mono text-[11px] tracking-[0.04em] text-zinc-400">
+        <div className="flex flex-wrap gap-3">
+          <span className="text-brand">// playback</span>
+          <span>autoplays on scroll · click any step or gate to inspect</span>
+        </div>
+        <div className="flex flex-wrap gap-3">
+          <span className="text-brand">// rest/openapi</span>
+          <span>
+            the same trace, with a parallel write-gated guard in place of the SQL validators
+          </span>
+        </div>
       </div>
     </section>
   );

--- a/apps/www/src/components/landing/trace.tsx
+++ b/apps/www/src/components/landing/trace.tsx
@@ -52,7 +52,7 @@ const TRACE_STEPS: ReadonlyArray<TraceStep> = [
     kind: "gate",
     n: 1,
     detail:
-      "Statement parses cleanly to a single SELECT with one CTE. Anything unparseable is rejected before reaching the warehouse.",
+      "Statement parses cleanly to a single SELECT with one CTE. Anything unparseable is rejected before it reaches your datasource.",
   },
   {
     t: 0.146,
@@ -70,7 +70,7 @@ const TRACE_STEPS: ReadonlyArray<TraceStep> = [
     kind: "gate",
     n: 3,
     detail:
-      "Every referenced table is checked against the operator's role. Atlas mirrors warehouse RBAC; if you can't query it directly, you can't query it through Atlas.",
+      "Every referenced table is checked against the operator's role. Atlas mirrors your datasource's RBAC; if you can't query it directly, you can't query it through Atlas.",
   },
   {
     t: 0.174,

--- a/apps/www/src/components/landing/yaml-section.tsx
+++ b/apps/www/src/components/landing/yaml-section.tsx
@@ -1,4 +1,4 @@
-import { CATEGORY_ROWS } from "./data";
+import { CATEGORY_ROWS, TOP_CATEGORY_QUESTION } from "./data";
 
 const YAML_LINES: ReadonlyArray<string> = [
   "name: Orders",
@@ -96,7 +96,7 @@ function YamlPane() {
   );
 }
 
-const QUESTION = "What's our top-performing category by GMV this month?";
+const QUESTION = TOP_CATEGORY_QUESTION;
 
 function AnswerPane() {
   return (
@@ -214,7 +214,7 @@ export function YamlSection() {
           The YAML format is the moat.
         </h2>
         <p className="m-0 text-base leading-[1.65] text-zinc-400">
-          Entities, dimensions, measures, joins, virtual dimensions, query patterns, glossary terms, and authoritative metrics — all in YAML, in your repo, code-reviewed in pull requests. Every field exists because an LLM needs it: <code className="font-mono text-zinc-300">sample_values</code> ground the agent in real data, <code className="font-mono text-zinc-300">glossary.status: ambiguous</code> forces clarifying questions, <code className="font-mono text-zinc-300">metrics.objective</code> picks <code className="font-mono text-zinc-300">MAX</code> vs <code className="font-mono text-zinc-300">MIN</code>.
+          Entities, dimensions, measures, joins, glossary terms, and authoritative metrics: all in YAML, in your repo, code-reviewed in pull requests. Every field exists because an LLM needs it. <code className="font-mono text-zinc-300">sample_values</code> ground the agent in real data, <code className="font-mono text-zinc-300">glossary.status: ambiguous</code> forces clarifying questions, <code className="font-mono text-zinc-300">metrics.objective</code> picks <code className="font-mono text-zinc-300">MAX</code> vs <code className="font-mono text-zinc-300">MIN</code>. The same semantic layer fronts REST/OpenAPI services too: Atlas reads their operation graph the way it reads your SQL entities, so databases and APIs answer through one model.
         </p>
       </header>
 


### PR DESCRIPTION
## Summary

Reworks the `apps/www` home page so a visitor understands Atlas at a glance — *ask a plain-English question, get a validated answer grounded in your data* — and finishes the SQL→query-layer repositioning (C2 of #3052; the optional deep-pass child).

- **Answer-led hero** (`hero.tsx`): drops the hand-positioned 8-node SVG schema graph (also kills its mobile fragility) and replaces it with a plain-English **question → validated-answer** card + a slim **4-stage pipeline strip** (`ask → semantic layer → datasources [sql · rest/openapi] → answer`). Subhead tightened to name SQL warehouses **and** REST/OpenAPI services. Headline/identity preserved.
- **No-drift data** (`data.ts`): hoisted the canonical demo question to `TOP_CATEGORY_QUESTION`, now shared by the hero and the YAML section.
- **YAML section** (`yaml-section.tsx`): generalized the "schema is the product" framing to cover REST/OpenAPI operation graphs; tightened the intro; resolved the duplicate `// the schema is the product` eyebrow.
- **Trace** (`trace.tsx` + `trace-section.tsx`): gate-1 ("before reaching the warehouse" → "before it reaches your datasource") and gate-3 ("warehouse RBAC" → "your datasource's RBAC") made datasource-agnostic; added a light `// rest/openapi` note that REST runs a parallel write-gated guard.

**Accuracy held:** REST is framed as a *parallel write-gated guard*, not the SQL 7-validator pipeline (matches the C1 primitives card). The SQL-specific 94% stat is left unchanged.

## Test plan

- [x] `next build` — compiled + TypeScript pass
- [x] `bun run lint` (packages/ + ee/) — clean
- [x] `bun run type` (monorepo) — exit 0, no errors
- [x] Visually verified at **desktop (1440)** + **mobile (390)**; mobile pipeline strip confirmed single-column stacked with arrows hidden (`grid-template-columns: 342px`, arrows `display:none`)
- [ ] CI green on head SHA before merge

Part of #3052.

Closes #3054

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3062"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782862185&installation_id=135337507&pr_number=3062&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3062&signature=dfbb695dbfea508319fc6cd9948c099870297e1d56e87c9a2a7db0e5dadb585d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned hero section with visual answer example and multi-stage pipeline visualization
  * Added REST/OpenAPI service integration documentation

* **Improvements**
  * Updated landing page messaging to highlight YAML-backed semantic layer and read-only grounded querying
  * Enhanced trace documentation with clearer gate validation descriptions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->