### PR TITLE
docs(scope): unified conversation scope — ADR-0011 + CONTEXT.md glossary

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -116,3 +116,53 @@ Atlas runs in two deploy modes: **SaaS** (one operator, many customers) and **se
 - **Operator** — the party who runs the Atlas instance. Owns the deploy, the App Registrations, the catalog seed (`atlas.config.ts`), the infrastructure choices (sandbox priority, scheduler backend, residency regions). Controls what's *possible*.
 - **Customer admin** — the party who configures a specific Workspace. Owns Workspace Connections, integration installs, per-Workspace config (channel allowlists, model selection, BYOT credentials, etc.). Controls what's *active* for their Workspace.
 - **The seam** — where Operator capability meets Customer activation. Lives at `plugin_catalog` (operator declares) → `workspace_plugins` (customer activates). Any surface that puts Customer concerns into operator-only space (e.g. requiring an `atlas.config.ts` edit to add a Platform per customer) is a **leak** of self-host shape into SaaS shape. See ADRs 0001–0003 for closing the chat-Platform leak.
+
+## Conversation scope
+
+A conversation can read from two kinds of **Datasource** (see Pillars): SQL connections and REST datasources. **Conversation scope** is the umbrella for *which* of those a given conversation can query. It has two axes — **SQL routing** and **REST scope** — surfaced together in the chat header's **scope picker** (`ChatScopePicker`, historically `ChatEnvPicker` / "env picker"). Scope is **per-conversation and authoritative**: it persists on the `conversations` row, an opened conversation restores its own scope, and a workspace-scoped browser preference (the *sticky* last selection) seeds brand-new chats. See [ADR-0011](./docs/adr/0011-unified-conversation-scope.md).
+
+- **Conversation scope**:
+  The full set of datasources a conversation can query — its SQL routing plus its REST scope. The scope picker's single source of truth.
+  _Avoid_: "env" / "environment picker" (the picker predates REST and covered SQL only); "reach" (considered, dropped in favour of "scope").
+
+- **SQL routing**:
+  The SQL axis of scope — the active **Connection group**, which of its **Members** execute, and the **routing mode** (Auto/Pin/All) that decides that. `executeSQL` only.
+  _Avoid_: "SQL scope" (the axis is named *routing*); "environment" used loosely for the group.
+
+- **Connection group**:
+  A named set of interchangeable SQL connections (e.g. a multi-region `prod` group with `apac-prod` / `eu-prod` / `us-prod`), carrying an operator-designated primary. The unit SQL routing binds to.
+  _Avoid_: "environment" (informal only), "cluster".
+
+- **Member**:
+  One SQL connection within a connection group; an `executeSQL` execution target. REST datasources are **not** members — they have no such group membership and are not run by `executeSQL`.
+
+- **Routing mode**:
+  The Auto / Pin / All value of SQL routing — **Auto** (agent decides per turn), **Pin** (one member), **All** (fan out across every member). Persisted as `routingMode`. SQL-only; it never affects REST scope.
+  _Avoid_: conflating with `executeSQL`'s per-turn **`scope`** argument (the agent's per-call member choice under Auto), or with the umbrella **Conversation scope**.
+
+- **REST scope**:
+  The REST axis of scope — which of the workspace's **REST datasources** the conversation can reach. Two states:
+  - *Default* — all in scope (workspace-global REST is reachable in every conversation, per [ADR-0010](./docs/adr/0010-rest-datasource-environment-scoping.md)), narrowed by an **exclude-set** (`rest_excluded_datasource_ids`); a newly-added REST datasource is reachable by default, and SQL routing stays active.
+  - *Focused (REST-only)* — the conversation targets exactly one REST datasource (`rest_focus_datasource_id`) and **SQL is suspended** (no `executeSQL`). The "ask Stripe only" case.
+  _Avoid_: "REST routing" (REST is scoped/focused, not routed).
+
+- **REST datasource**:
+  A **Datasource** reached over an `openapi-generic` install via `executeRestOperation` rather than SQL. Workspace-global by default, optionally group-scoped (ADR-0010). In default REST scope iff (workspace-global OR scoped to the active group) AND not in the exclude-set; in focused scope iff it is the focus target.
+
+### Relationships
+
+- A **Conversation scope** has one **SQL routing** axis and one **REST scope** axis.
+- **SQL routing** binds one **Connection group** + a **routing mode**; the group has one or more **Members**.
+- **REST scope** is either *default* (workspace in-scope **REST datasources** minus the exclude-set, SQL active) or *focused* (one REST datasource, SQL suspended).
+- A **routing mode** governs **Members** only; it never changes **REST scope** (REST scope follows the active group + exclude-set, mode-independent — ADR-0010).
+
+### Flagged ambiguities
+
+- "env picker" / "environment" — the chat-header control was built SQL-only (#2345) and named for environments; it now governs full **Conversation scope**. Canonical name: **scope picker**; "environment" survives only as an informal synonym for **Connection group**.
+- "scope" is overloaded — **Conversation scope** (this umbrella) vs `executeSQL`'s per-turn **`scope`** argument (the agent's per-call member choice under Auto routing) vs ADR-0010 "in-scope". Disambiguate in prose.
+- "reach" / "routing" as the umbrella — both considered and rejected. The umbrella is **Conversation scope**; the SQL axis is **SQL routing**; the REST axis is **REST scope**.
+
+### Example dialogue
+
+> **Dev:** "If I **Pin** a conversation to `apac-prod`, does that stop it hitting Stripe?"
+> **Maintainer:** "No — the **routing mode** only picks which **Member** runs `executeSQL`. Stripe is a workspace-global **REST datasource**, so it's in **REST scope** regardless of the pin. To take it out, **exclude** it. If you want *only* Stripe and no SQL at all, **focus** it — that suspends SQL routing for the conversation."

--- a/docs/adr/0010-rest-datasource-environment-scoping.md
+++ b/docs/adr/0010-rest-datasource-environment-scoping.md
@@ -1,6 +1,6 @@
 # ADR-0010: REST datasource environment scoping
 
-**Status:** Accepted
+**Status:** Accepted — picker-surface consequence superseded by [ADR-0011](./0011-unified-conversation-scope.md) (REST becomes pickable/excludable + a REST-only focus, not a read-only footer). The scoping model, resolver tri-state, and `catalog_id` discriminator below all stand.
 **Date:** 2026-05-31
 **Context milestone:** v0.0.3 — Spec Lifecycle (closeout of a composability gap from v0.0.2)
 **Depends on:** [ADR-0006](./0006-three-pillar-integration-taxonomy.md), [ADR-0007](./0007-unified-install-pipeline.md)

--- a/docs/adr/0011-unified-conversation-scope.md
+++ b/docs/adr/0011-unified-conversation-scope.md
@@ -1,0 +1,48 @@
+# ADR-0011: Unified conversation scope — SQL routing + REST scope (exclude-set + REST-only focus)
+
+**Status:** Accepted
+**Date:** 2026-05-31
+**Milestone:** v0.0.4 — Conversation Scope
+**Supersedes:** the "Picker surface" consequence of [ADR-0010](./0010-rest-datasource-environment-scoping.md) (REST datasources as a read-only footer, "without rendering them as pickable"). ADR-0010's scoping model, resolver tri-state, and `catalog_id` discriminator are retained and extended.
+**Builds on:** ADR-0010 (REST datasource environment scoping), #2518 (Auto/Pin/All routing), #3044 (persisted picker preference)
+**Issue:** [#3063](https://github.com/AtlasDevHQ/atlas/issues/3063)
+
+## Context
+
+ADR-0010 made a pinned conversation's REST reach *explicit* but kept REST datasources out of the picker as a read-only footer. Dogfooding (#3063) surfaced two problems the footer didn't solve:
+
+1. **No control.** The footer tells you Stripe answers in every environment but gives no way to *exclude* it from a conversation, or to ask a *REST-only* question.
+2. **"Only postgres" mental-model gap.** With zero REST datasources installed the footer doesn't render, so the picker reads as "SQL environments only" and REST feels absent rather than workspace-global-and-default-on.
+
+Separately, the picker's selection was never truly per-conversation: SQL routing is written to the `conversations` row but **never read back** into the picker when a conversation is opened, and the #3044 `localStorage` preference (meant to survive reload) loses to the default seed on a fresh mount — the single-pass seed/restore effect commits the default before the preference is honoured, and its `if (selectedConnectionId !== null) return` guard then locks that default in.
+
+## Decision
+
+**The env picker becomes the *scope picker* (`ChatScopePicker`) — a per-conversation control over Conversation scope, with two axes.** (Terminology: CONTEXT.md → *Conversation scope*. Umbrella = **Conversation scope**; axes = **SQL routing** / **REST scope**.)
+
+1. **SQL routing** — unchanged: a connection group + Auto/Pin/All routing mode over its members (`executeSQL`).
+2. **REST scope** — new, first-class, with two states:
+   - **Default** — the workspace's REST datasources render as toggleable rows (default checked = in scope). Unchecking *excludes* a datasource. Persisted as an **exclude-set** `conversations.rest_excluded_datasource_ids text[] DEFAULT '{}'`. Default `{}` = all in scope, so a newly-added REST datasource is reachable by default — preserving ADR-0010's workspace-global-by-default. SQL routing stays active.
+   - **Focused (REST-only)** — selecting a single REST datasource as the focus targets it exclusively and **suspends SQL** for the conversation (no `executeSQL`). Persisted as `conversations.rest_focus_datasource_id text` (nullable). When set, the exclude-set and SQL-routing fields are inert but retained, so clearing focus returns to the prior default-state scope.
+
+**Scope is per-conversation and authoritative, with a sticky preference for new chats.** Every scope change stamps the full scope onto the `conversations` row (authoritative for that conversation) **and** updates a workspace-scoped `localStorage` preference (the *sticky last selection*). Opening a conversation restores its scope from the row; a brand-new chat seeds from the sticky preference, else the default seed. Precedence on load: **conversation row > sticky preference > default seed.** The reset-on-reload bug is fixed at this seam — the default seed must not pre-empt a restorable preference: gate the seed on preference-store hydration (`persist.hasHydrated()`) **and** a resolved workspace id, and track seed *provenance* (default-seeded vs explicit/restored) so a later-arriving matching preference can override a default-seeded value rather than being blocked by the guard.
+
+**Resolver + agent loop.** `resolveWorkspaceRestDatasources(orgId, activeGroupId?, { excluded?, focus? })` filters by the conversation's REST scope: in *default* state, drop the exclude-set (after ADR-0010's group-scope filter and before credential resolution, preserving the never-rejects fail-soft contract); in *focused* state, resolve only the focus target. A focused conversation runs the agent **without `executeSQL`** (SQL suspended). The authorized confirm-replay path (`tools/rest-operation.ts` `resolveFromContext`, `activeGroupId === undefined`) ignores REST scope — a signed staged write replays regardless of picker state. ADR-0010's tri-state `activeGroupId` semantics and the `REST_DATASOURCE_CATALOG_IDS` discriminator are unchanged.
+
+## Consequences
+
+- **Migration.** Adds `conversations.rest_excluded_datasource_ids text[] DEFAULT '{}'` and `conversations.rest_focus_datasource_id text` (nullable) with matching Drizzle `schema.ts` mirrors in the same PR (schema-drift gate) + a real-Postgres migration smoke.
+- **Published type.** `@useatlas/types` `Conversation` gains both fields; the dependent-package ref bump is sequenced *after* publish (0.0.x exact-pin rule).
+- **Wire.** The chat request body and `GET /conversations/:id` carry the exclude-set + focus; `GET /me/connection-groups` already returns the workspace's REST datasources (ADR-0010). The sticky-preference store (`chat-routing-preference-store.ts`) gains the two REST fields.
+- **Agent.** A focused conversation suspends `executeSQL`; the toolkit/prompt must reflect a REST-only turn.
+- **Chip.** The scope chip distinguishes states — e.g. `Pin · apac-prod · 2/3 REST` (default) vs `Stripe only` (focused).
+- **ADR-0010 retained except the picker surface.** The scoping model, resolver tri-state, and discriminator stand; only "REST is a read-only footer, not pickable" is superseded.
+- **Out of scope (separate issue).** `conversationId` is in-memory `useState`, so a reload still lands in a blank chat rather than reopening the active conversation. Restoring the active conversation across reload (conversationId in URL state) is tracked separately.
+
+## Alternatives considered
+
+- **Keep footer-only (uphold ADR-0010).** Rejected in the #3063 grill — surfacing REST reach without control didn't solve the dogfooding pain.
+- **Include-set instead of exclude-set.** Rejected: a newly-added REST datasource would silently fall out of scope, fighting workspace-global-by-default.
+- **Exclude-set only, no REST-only focus.** Considered as the minimal model; rejected in favour of adding focus so a "REST-only" question (no SQL) is expressible directly rather than by unchecking every other datasource while SQL still runs.
+- **Pure client UI preference for REST.** Rejected: a conversation's REST scope would differ per browser and not survive a device switch or a shared link; scope must be per-conversation authoritative like SQL routing already is.
+- **"Reach" / "routing" as the umbrella term.** Rejected in favour of "Conversation scope" (CONTEXT.md).


### PR DESCRIPTION
## Summary
Locks the **v0.0.4 — Conversation Scope** design from the #3063 grill-with-docs session. **Docs only — no code.**

- **ADR-0011** (`docs/adr/0011-unified-conversation-scope.md`) — the env picker becomes the **scope picker** spanning two axes: **SQL routing** (connection group + members + Auto/Pin/All) and **REST scope** (exclude-set + REST-only focus). Scope is per-conversation authoritative; a sticky workspace-scoped preference seeds new chats. Supersedes ADR-0010's picker-surface consequence **only** — its scoping model / resolver tri-state / `catalog_id` discriminator are retained.
- **ADR-0010** — status line amended to point at ADR-0011.
- **CONTEXT.md** — new `## Conversation scope` glossary (scope · SQL routing · REST scope · routing mode · member · focus), with the "scope" overload flagged.

## Implementation (separate PRs)
Sliced into milestone [v0.0.4 — Conversation Scope (#59)](https://github.com/AtlasDevHQ/atlas/milestone/59):

| Slice | Issue | Blocked by |
|---|---|---|
| S1a — sticky-pref restore (reset-on-reload bug) | #3064 | — |
| S1b — conversation-open restore | #3065 | #3064 |
| S2a — REST exclude-set | #3066 | #3065 |
| S2b — REST-only focus (suspends SQL) | #3067 | #3066 |
| S3 — conversationId in URL | #3068 | — |

This is the design foundation — it does **not** close the slices above. Parent: #3063.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3069"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782869477&installation_id=135337507&pr_number=3069&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3069&signature=f89d84c66df8b2db53a75fe824631223024d0ef4f2a2892cf40e8ce89dae187e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified conversation scoping model for datasources, defining how SQL routing and REST scope govern datasource access in conversations.
  * Updated architectural guidance to reflect unified conversation-scoping approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->