### PR TITLE
fix(web): restore sticky scope preference on reload (#3064)

### DIFF
--- a/.claude/research/ROADMAP.md
+++ b/.claude/research/ROADMAP.md
@@ -20,7 +20,17 @@ The codebase is Hono + Next.js + TypeScript + Effect.ts + Vercel AI SDK + bun, o
 
 ## Next
 
-No `v0.0.x` dev tag is currently in flight. **v0.0.3 — Spec Lifecycle** shipped 2026-05-31 (archived below); cut the prod tag with `/release v0.0.3`. The next dev tag is undecided — run `/next` to promote a [Planned tag](#planned-tags) or a cluster out of the [Architecture Backlog](https://github.com/AtlasDevHQ/atlas/milestone/49). The active build right now is the **Staging environment** track (below), which ships independently of the tag train.
+**`v0.0.4` — Conversation Scope** ([milestone #59](https://github.com/AtlasDevHQ/atlas/milestone/59), 5 issues) — in flight. Unifies the chat scope picker (`ChatScopePicker`, was `ChatEnvPicker`) across two axes: **SQL routing** (connection group + members + Auto/Pin/All) and **REST scope** (exclude-set + REST-only focus). Per-conversation authoritative, with a sticky workspace-scoped preference that seeds new chats; fixes the [#3063](https://github.com/AtlasDevHQ/atlas/issues/3063) reset-on-reload bug at the seed/restore seam. See [ADR-0011](../../docs/adr/0011-unified-conversation-scope.md) (supersedes ADR-0010 picker-surface only) + `CONTEXT.md` → Conversation scope.
+
+Slices form a near-linear chain (S1a → S1b → S2a → S2b), with S3 independent:
+
+- [ ] S1a — Restore the sticky scope preference on a fresh chat — fixes reset-on-reload ([#3064](https://github.com/AtlasDevHQ/atlas/issues/3064), bug, no deps) ⟵ start here
+- [ ] S1b — Restore a conversation's scope when it is opened ([#3065](https://github.com/AtlasDevHQ/atlas/issues/3065), bug, blocked by #3064)
+- [ ] S2a — REST scope: exclude datasources from a conversation ([#3066](https://github.com/AtlasDevHQ/atlas/issues/3066), feature, blocked by #3065)
+- [ ] S2b — REST-only focus: suspend SQL for a conversation ([#3067](https://github.com/AtlasDevHQ/atlas/issues/3067), feature, blocked by #3066)
+- [ ] S3 — Persist the active conversation in the URL ([#3068](https://github.com/AtlasDevHQ/atlas/issues/3068), refactor, independent — synergizes with #3065)
+
+Parent [#3063](https://github.com/AtlasDevHQ/atlas/issues/3063) stays in the Architecture Backlog (left unmodified per `/to-issues`). The **Staging environment** track (below) continues in parallel, independent of the tag train.
 
 ---
 
@@ -48,6 +58,7 @@ Persistent candidate clusters (not milestoned):
 
 Shipped milestones live in [`ROADMAP-archive.md`](./ROADMAP-archive.md):
 
+- `v0.0.3` — **Spec Lifecycle** ([milestone #58](https://github.com/AtlasDevHQ/atlas/milestone/58), 6 issues) — keeps an installed OpenAPI datasource's upstream view current: per-install refresh interval, structured drift diff, shared cross-workspace spec/graph cache (credential never shared), scheduler auto re-discovery fiber, breaking-change drift signal. Split from v0.0.2 per #3013. Closed + tagged `v0.0.3` 2026-05-31.
 - `v0.0.2` — **REST Datasources** ([milestone #54](https://github.com/AtlasDevHQ/atlas/milestone/54), 24 issues) — generic OpenAPI primitive makes REST services (Twenty, Stripe, GitHub, Notion) first-class read-side datasources; per-endpoint write allowlist + confirm-before-write; SSRF egress guard. Maps 1:1 to PRD #2868. Closed 2026-05-31.
 - `v0.0.1` — **Release Process Bootstrap** ([milestone #56](https://github.com/AtlasDevHQ/atlas/milestone/56), 7 issues) — first git tag; tag-gated prod deploys (dedicated `prod`-branch trigger), customer-facing Stability Contract, ADR-0008/0009, `/release` flow. Docs + tooling only — no runtime feature.
 - `v0.1` → `v1.3` — pre-public-tag internal milestones (foundation, deploy-anywhere, semantic layer, Better Auth, Hono API, MCP, Python sandbox, integration builder, plugin refactor)

--- a/packages/web/src/lib/stores/__tests__/chat-routing-preference-store.test.ts
+++ b/packages/web/src/lib/stores/__tests__/chat-routing-preference-store.test.ts
@@ -113,4 +113,15 @@ describe("useChatRoutingPreferenceStore hydration gate (#3064)", () => {
     expect("_hasHydrated" in persisted.state).toBe(false);
     expect("setHasHydrated" in persisted.state).toBe(false);
   });
+
+  it("flips _hasHydrated true when persist rehydration runs (onRehydrateStorage wiring)", async () => {
+    // The load-bearing link between the two halves of the fix: rehydration
+    // must call setHasHydrated(true). A renamed/dropped onRehydrateStorage
+    // callback would leave the gate stuck closed (picker never seeds) while
+    // the setter-only test above still passes — so exercise the wiring.
+    useChatRoutingPreferenceStore.setState({ _hasHydrated: false });
+    await useChatRoutingPreferenceStore.persist.rehydrate();
+    expect(useChatRoutingPreferenceStore.getState()._hasHydrated).toBe(true);
+    expect(useChatRoutingPreferenceStore.persist.hasHydrated()).toBe(true);
+  });
 });

--- a/packages/web/src/lib/stores/__tests__/chat-routing-preference-store.test.ts
+++ b/packages/web/src/lib/stores/__tests__/chat-routing-preference-store.test.ts
@@ -82,3 +82,35 @@ describe("useChatRoutingPreferenceStore (#3044)", () => {
     expect(s.routingMode).toBeNull();
   });
 });
+
+describe("useChatRoutingPreferenceStore hydration gate (#3064)", () => {
+  // The reset-on-reload fix gates atlas-chat's seed/restore effect on the
+  // persist store having finished rehydrating localStorage. Without that
+  // gate the default env seed is committed before the stored preference is
+  // available and then locks it in. The store exposes a `_hasHydrated`
+  // flag (flipped true by `onRehydrateStorage`) that the consumer reads.
+
+  it("exposes setHasHydrated, which flips the _hasHydrated flag both ways", () => {
+    useChatRoutingPreferenceStore.getState().setHasHydrated(false);
+    expect(useChatRoutingPreferenceStore.getState()._hasHydrated).toBe(false);
+    useChatRoutingPreferenceStore.getState().setHasHydrated(true);
+    expect(useChatRoutingPreferenceStore.getState()._hasHydrated).toBe(true);
+  });
+
+  it("never persists the hydration flag to localStorage (partialize drops it)", () => {
+    useChatRoutingPreferenceStore.getState().setHasHydrated(true);
+    useChatRoutingPreferenceStore.getState().setPreference({
+      workspaceId: "org-1",
+      groupId: "prod",
+      connectionId: "eu-prod",
+      routingMode: "pin",
+    });
+    const raw = localStorage.getItem(STORAGE_KEY);
+    expect(raw).not.toBeNull();
+    const persisted = JSON.parse(raw!) as { state: Record<string, unknown> };
+    // The flag is transient UI state, not a preference — it must never be
+    // serialized (a persisted `true` would skip the gate on next load).
+    expect("_hasHydrated" in persisted.state).toBe(false);
+    expect("setHasHydrated" in persisted.state).toBe(false);
+  });
+});

--- a/packages/web/src/lib/stores/chat-routing-preference-store.ts
+++ b/packages/web/src/lib/stores/chat-routing-preference-store.ts
@@ -41,6 +41,17 @@ export interface ChatRoutingPreference {
 }
 
 interface ChatRoutingPreferenceStore extends ChatRoutingPreference {
+  /**
+   * Transient (non-persisted) flag: `persist` has finished rehydrating
+   * `localStorage`. Consumers (atlas-chat's seed/restore effect) gate on
+   * this so a default env seed is never committed before the stored
+   * preference is available — that ordering is the reset-on-reload bug
+   * (#3064). Starts `false`; `onRehydrateStorage` flips it `true` once
+   * rehydration completes (synchronous storage → flips during create).
+   */
+  _hasHydrated: boolean;
+  /** Flip {@link _hasHydrated} — called by `onRehydrateStorage`. */
+  setHasHydrated: (value: boolean) => void;
   /** Persist the user's latest env-picker selection. */
   setPreference: (next: ChatRoutingPreference) => void;
   /** Forget the stored preference (e.g. on sign-out / workspace switch). */
@@ -58,6 +69,8 @@ export const useChatRoutingPreferenceStore = create<ChatRoutingPreferenceStore>(
   persist(
     (set) => ({
       ...EMPTY,
+      _hasHydrated: false,
+      setHasHydrated: (value) => set({ _hasHydrated: value }),
       setPreference: (next) =>
         set({
           workspaceId: next.workspaceId,
@@ -70,12 +83,21 @@ export const useChatRoutingPreferenceStore = create<ChatRoutingPreferenceStore>(
     {
       name: "atlas:chat:routing-preference",
       storage: createJSONStorage(() => localStorage),
+      // Persist ONLY the preference fields. `_hasHydrated` + setters are
+      // transient — a persisted `_hasHydrated: true` would skip the gate
+      // on the next load and reintroduce the reset-on-reload race.
       partialize: (s) => ({
         workspaceId: s.workspaceId,
         groupId: s.groupId,
         connectionId: s.connectionId,
         routingMode: s.routingMode,
       }),
+      // Fires after rehydration (synchronously for localStorage, even when
+      // storage was empty), so the consumer's gate opens exactly once the
+      // stored preference — if any — has been read back in.
+      onRehydrateStorage: () => (state) => {
+        state?.setHasHydrated(true);
+      },
     },
   ),
 );

--- a/packages/web/src/lib/stores/chat-routing-preference-store.ts
+++ b/packages/web/src/lib/stores/chat-routing-preference-store.ts
@@ -78,14 +78,17 @@ export const useChatRoutingPreferenceStore = create<ChatRoutingPreferenceStore>(
           connectionId: next.connectionId,
           routingMode: next.routingMode,
         }),
+      // Partial set — zustand shallow-merges, so `_hasHydrated` (absent from
+      // EMPTY) is preserved. A clear must not re-close the hydration gate.
       clear: () => set({ ...EMPTY }),
     }),
     {
       name: "atlas:chat:routing-preference",
       storage: createJSONStorage(() => localStorage),
       // Persist ONLY the preference fields. `_hasHydrated` + setters are
-      // transient — a persisted `_hasHydrated: true` would skip the gate
-      // on the next load and reintroduce the reset-on-reload race.
+      // transient: persisting them is meaningless, and a stored
+      // `_hasHydrated: true` would — under any async-storage swap — report
+      // hydration complete before the read, reopening the reset-on-reload gate.
       partialize: (s) => ({
         workspaceId: s.workspaceId,
         groupId: s.groupId,

--- a/packages/web/src/ui/__tests__/env-picker.test.tsx
+++ b/packages/web/src/ui/__tests__/env-picker.test.tsx
@@ -1214,7 +1214,7 @@ describe("resolveEnvSelection — sticky-preference restore vs default seed (#30
   ): ResolveEnvSelectionInput {
     return {
       groups: [prodGroup],
-      current: { groupId: null, connectionId: null },
+      current: { groupId: null, connectionId: null, routingMode: null },
       provenance: "unset",
       preference: {
         workspaceId: null,
@@ -1296,7 +1296,7 @@ describe("resolveEnvSelection — sticky-preference restore vs default seed (#30
     // `selectedConnectionId !== null` guard no longer locks the default in.
     const decision = resolveEnvSelection(
       input({
-        current: { groupId: "g_prod", connectionId: "us-prod" },
+        current: { groupId: "g_prod", connectionId: "us-prod", routingMode: null },
         provenance: "default",
         preference: {
           workspaceId: "org-1",
@@ -1315,12 +1315,37 @@ describe("resolveEnvSelection — sticky-preference restore vs default seed (#30
     });
   });
 
+  test("restores when group + connection match but the routing mode differs", () => {
+    // A default seed lands on the preferred member (no mode), but the stored
+    // preference asked for "auto" — the mode-only difference must still
+    // restore rather than no-op (routingMode is part of the selection).
+    const decision = resolveEnvSelection(
+      input({
+        current: { groupId: "g_prod", connectionId: "eu-prod", routingMode: null },
+        provenance: "default",
+        preference: {
+          workspaceId: "org-1",
+          groupId: "g_prod",
+          connectionId: "eu-prod",
+          routingMode: "auto",
+        },
+        activeWorkspaceId: "org-1",
+      }),
+    );
+    expect(decision).toEqual({
+      kind: "restore",
+      groupId: "g_prod",
+      connectionId: "eu-prod",
+      routingMode: "auto",
+    });
+  });
+
   test("does not re-seed a default-seeded selection when there is no matching preference", () => {
     // The load-bearing role of the `default` provenance: once a default has
     // been seeded and no preference matches, leave it — don't seed again.
     const decision = resolveEnvSelection(
       input({
-        current: { groupId: "g_prod", connectionId: "us-prod" },
+        current: { groupId: "g_prod", connectionId: "us-prod", routingMode: null },
         provenance: "default",
       }),
     );
@@ -1332,7 +1357,7 @@ describe("resolveEnvSelection — sticky-preference restore vs default seed (#30
     // authoritative — the resolver must never auto-replace it.
     const decision = resolveEnvSelection(
       input({
-        current: { groupId: "g_prod", connectionId: "us-prod" },
+        current: { groupId: "g_prod", connectionId: "us-prod", routingMode: null },
         provenance: "explicit",
         preference: {
           workspaceId: "org-1",
@@ -1349,7 +1374,8 @@ describe("resolveEnvSelection — sticky-preference restore vs default seed (#30
   test("no-ops when the current selection already equals the preference (no churn)", () => {
     const decision = resolveEnvSelection(
       input({
-        current: { groupId: "g_prod", connectionId: "eu-prod" },
+        // Full match including routing mode — nothing to restore.
+        current: { groupId: "g_prod", connectionId: "eu-prod", routingMode: "pin" },
         provenance: "default",
         preference: {
           workspaceId: "org-1",

--- a/packages/web/src/ui/__tests__/env-picker.test.tsx
+++ b/packages/web/src/ui/__tests__/env-picker.test.tsx
@@ -1289,11 +1289,11 @@ describe("resolveEnvSelection — sticky-preference restore vs default seed (#30
     });
   });
 
-  test("replaces a default-seeded selection when a matching preference is present (provenance override)", () => {
-    // Belt-and-suspenders: even if a default slipped in before the
-    // preference arrived, a later-arriving workspace-matching preference
-    // still wins — the `selectedConnectionId !== null` guard no longer
-    // locks the default.
+  test("restores over a default-seeded selection when a matching preference arrives", () => {
+    // Belt-and-suspenders: even if a default slipped in before the preference
+    // rehydrated, the preference step runs before the seed step on every
+    // invocation, so a workspace-matching preference still wins — the old
+    // `selectedConnectionId !== null` guard no longer locks the default in.
     const decision = resolveEnvSelection(
       input({
         current: { groupId: "g_prod", connectionId: "us-prod" },
@@ -1313,6 +1313,18 @@ describe("resolveEnvSelection — sticky-preference restore vs default seed (#30
       connectionId: "eu-prod",
       routingMode: "pin",
     });
+  });
+
+  test("does not re-seed a default-seeded selection when there is no matching preference", () => {
+    // The load-bearing role of the `default` provenance: once a default has
+    // been seeded and no preference matches, leave it — don't seed again.
+    const decision = resolveEnvSelection(
+      input({
+        current: { groupId: "g_prod", connectionId: "us-prod" },
+        provenance: "default",
+      }),
+    );
+    expect(decision).toEqual({ kind: "noop" });
   });
 
   test("leaves an explicit user selection untouched even when a different preference exists", () => {

--- a/packages/web/src/ui/__tests__/env-picker.test.tsx
+++ b/packages/web/src/ui/__tests__/env-picker.test.tsx
@@ -61,9 +61,11 @@ import { render, renderHook, waitFor, cleanup } from "@testing-library/react";
 import {
   ChatEnvPicker,
   pickDefaultEnvSeed,
+  resolveEnvSelection,
   shouldRenderEnvPicker,
   useChatEnvGroups,
   type ChatEnvGroup,
+  type ResolveEnvSelectionInput,
 } from "../components/chat/env-picker";
 
 beforeEach(() => {
@@ -1179,6 +1181,254 @@ describe("ChatEnvPicker three-state routing mode (#2518)", () => {
       '[data-testid="chat-env-picker-member-eu"]',
     );
     expect(euInPin?.getAttribute("data-active")).toBe("true");
+  });
+});
+
+// ── #3064 — sticky-preference restore vs default seed ────────────────
+//
+// The atlas-chat seed/restore effect must restore the user's last sticky
+// selection on a fresh chat instead of reverting to the group primary
+// (the reset-on-reload bug). `resolveEnvSelection` is the pure decision
+// the effect applies: it gates on the preference store having rehydrated
+// and the active workspace id being resolved (so a default seed never
+// pre-empts a restorable preference), honours `preference > default`
+// precedence, ignores another workspace's preference, and tracks seed
+// provenance so a default-seeded value yields to a later-arriving match.
+
+describe("resolveEnvSelection — sticky-preference restore vs default seed (#3064)", () => {
+  const prodGroup: ChatEnvGroup = {
+    id: "g_prod",
+    name: "prod",
+    primaryConnectionId: "us-prod",
+    members: [
+      { connectionId: "us-prod", dbType: "postgres", description: null },
+      { connectionId: "eu-prod", dbType: "postgres", description: null },
+    ],
+  };
+
+  // Default input = fresh empty chat, hydrated + resolved, no stored
+  // preference, self-hosted (null workspace). Each test overrides the
+  // dimension it exercises.
+  function input(
+    overrides: Partial<ResolveEnvSelectionInput> = {},
+  ): ResolveEnvSelectionInput {
+    return {
+      groups: [prodGroup],
+      current: { groupId: null, connectionId: null },
+      provenance: "unset",
+      preference: {
+        workspaceId: null,
+        groupId: null,
+        connectionId: null,
+        routingMode: null,
+      },
+      activeWorkspaceId: null,
+      preferenceHydrated: true,
+      sessionResolved: true,
+      ...overrides,
+    };
+  }
+
+  test("waits — never seeds a default before the preference has rehydrated (reset-on-reload guard)", () => {
+    // The core repro: a matching preference exists but the persist store
+    // hasn't rehydrated yet. The OLD effect committed the default seed in
+    // this window and then locked it in; the resolver must hold off.
+    const decision = resolveEnvSelection(
+      input({
+        preferenceHydrated: false,
+        preference: {
+          workspaceId: "org-1",
+          groupId: "g_prod",
+          connectionId: "eu-prod",
+          routingMode: "pin",
+        },
+        activeWorkspaceId: "org-1",
+      }),
+    );
+    expect(decision.kind).toBe("wait");
+  });
+
+  test("waits until the session resolves so the active workspace id is final", () => {
+    const decision = resolveEnvSelection(
+      input({
+        sessionResolved: false,
+        preference: {
+          workspaceId: "org-1",
+          groupId: "g_prod",
+          connectionId: "eu-prod",
+          routingMode: "pin",
+        },
+        activeWorkspaceId: "org-1",
+      }),
+    );
+    expect(decision.kind).toBe("wait");
+  });
+
+  test("waits until connection groups have loaded", () => {
+    expect(resolveEnvSelection(input({ groups: [] })).kind).toBe("wait");
+  });
+
+  test("restores the hydrated workspace preference instead of the default seed", () => {
+    // Pin to the non-primary member, reload → the pin comes back.
+    const decision = resolveEnvSelection(
+      input({
+        preference: {
+          workspaceId: "org-1",
+          groupId: "g_prod",
+          connectionId: "eu-prod",
+          routingMode: "pin",
+        },
+        activeWorkspaceId: "org-1",
+      }),
+    );
+    expect(decision).toEqual({
+      kind: "restore",
+      groupId: "g_prod",
+      connectionId: "eu-prod",
+      routingMode: "pin",
+    });
+  });
+
+  test("replaces a default-seeded selection when a matching preference is present (provenance override)", () => {
+    // Belt-and-suspenders: even if a default slipped in before the
+    // preference arrived, a later-arriving workspace-matching preference
+    // still wins — the `selectedConnectionId !== null` guard no longer
+    // locks the default.
+    const decision = resolveEnvSelection(
+      input({
+        current: { groupId: "g_prod", connectionId: "us-prod" },
+        provenance: "default",
+        preference: {
+          workspaceId: "org-1",
+          groupId: "g_prod",
+          connectionId: "eu-prod",
+          routingMode: "pin",
+        },
+        activeWorkspaceId: "org-1",
+      }),
+    );
+    expect(decision).toEqual({
+      kind: "restore",
+      groupId: "g_prod",
+      connectionId: "eu-prod",
+      routingMode: "pin",
+    });
+  });
+
+  test("leaves an explicit user selection untouched even when a different preference exists", () => {
+    // A pick made this session (or a conversation-restored value) is
+    // authoritative — the resolver must never auto-replace it.
+    const decision = resolveEnvSelection(
+      input({
+        current: { groupId: "g_prod", connectionId: "us-prod" },
+        provenance: "explicit",
+        preference: {
+          workspaceId: "org-1",
+          groupId: "g_prod",
+          connectionId: "eu-prod",
+          routingMode: "pin",
+        },
+        activeWorkspaceId: "org-1",
+      }),
+    );
+    expect(decision).toEqual({ kind: "noop" });
+  });
+
+  test("no-ops when the current selection already equals the preference (no churn)", () => {
+    const decision = resolveEnvSelection(
+      input({
+        current: { groupId: "g_prod", connectionId: "eu-prod" },
+        provenance: "default",
+        preference: {
+          workspaceId: "org-1",
+          groupId: "g_prod",
+          connectionId: "eu-prod",
+          routingMode: "pin",
+        },
+        activeWorkspaceId: "org-1",
+      }),
+    );
+    expect(decision).toEqual({ kind: "noop" });
+  });
+
+  test("seeds the group primary when there is no stored preference", () => {
+    expect(resolveEnvSelection(input())).toEqual({
+      kind: "seed",
+      groupId: "g_prod",
+      connectionId: "us-prod",
+    });
+  });
+
+  test("seeds the default when the stored preference points at a removed member", () => {
+    const decision = resolveEnvSelection(
+      input({
+        preference: {
+          workspaceId: "org-1",
+          groupId: "g_prod",
+          connectionId: "gone-prod",
+          routingMode: "pin",
+        },
+        activeWorkspaceId: "org-1",
+      }),
+    );
+    expect(decision).toEqual({
+      kind: "seed",
+      groupId: "g_prod",
+      connectionId: "us-prod",
+    });
+  });
+
+  test("ignores a preference stored under a different workspace id (#3044)", () => {
+    const decision = resolveEnvSelection(
+      input({
+        preference: {
+          workspaceId: "org-B",
+          groupId: "g_prod",
+          connectionId: "eu-prod",
+          routingMode: "pin",
+        },
+        activeWorkspaceId: "org-A",
+      }),
+    );
+    expect(decision).toEqual({
+      kind: "seed",
+      groupId: "g_prod",
+      connectionId: "us-prod",
+    });
+  });
+
+  test("restores a preference saved with a null workspace id on self-hosted", () => {
+    const decision = resolveEnvSelection(
+      input({
+        preference: {
+          workspaceId: null,
+          groupId: "g_prod",
+          connectionId: "eu-prod",
+          routingMode: "auto",
+        },
+        activeWorkspaceId: null,
+      }),
+    );
+    expect(decision).toEqual({
+      kind: "restore",
+      groupId: "g_prod",
+      connectionId: "eu-prod",
+      routingMode: "auto",
+    });
+  });
+
+  test("still seeds the lone connection in a single-connection workspace (no regression to the hidden-picker path)", () => {
+    const solo: ChatEnvGroup = {
+      id: "g_only",
+      name: "only",
+      primaryConnectionId: null,
+      members: [{ connectionId: "only", dbType: "postgres", description: null }],
+    };
+    expect(resolveEnvSelection(input({ groups: [solo] }))).toEqual({
+      kind: "seed",
+      groupId: "g_only",
+      connectionId: "only",
+    });
   });
 });
 

--- a/packages/web/src/ui/components/atlas-chat.tsx
+++ b/packages/web/src/ui/components/atlas-chat.tsx
@@ -221,7 +221,11 @@ export function AtlasChat() {
   useEffect(() => {
     const decision = resolveEnvSelection({
       groups: envGroupsQuery.groups,
-      current: { groupId: selectedGroupId, connectionId: selectedConnectionId },
+      current: {
+        groupId: selectedGroupId,
+        connectionId: selectedConnectionId,
+        routingMode: selectedRoutingMode,
+      },
       provenance: selectionProvenanceRef.current,
       preference: {
         workspaceId: prefWorkspaceId,
@@ -238,7 +242,9 @@ export function AtlasChat() {
       case "restore":
         setSelectedGroupId(decision.groupId);
         setSelectedConnectionId(decision.connectionId);
-        if (decision.routingMode) setSelectedRoutingMode(decision.routingMode);
+        // Apply the stored mode faithfully, including an explicit null
+        // (pre-#2518 back-compat → "pin"); a truthy guard here would drop it.
+        setSelectedRoutingMode(decision.routingMode);
         // A restored sticky preference is the user's deliberate prior choice —
         // mark it explicit so a later effect run can't seed over it.
         selectionProvenanceRef.current = "explicit";

--- a/packages/web/src/ui/components/atlas-chat.tsx
+++ b/packages/web/src/ui/components/atlas-chat.tsx
@@ -234,19 +234,34 @@ export function AtlasChat() {
       sessionResolved,
     });
 
-    if (decision.kind === "restore") {
-      setSelectedGroupId(decision.groupId);
-      setSelectedConnectionId(decision.connectionId);
-      if (decision.routingMode) setSelectedRoutingMode(decision.routingMode);
-      // A restored sticky preference is the user's deliberate prior choice —
-      // treat it as explicit so a later effect run can't seed over it.
-      selectionProvenanceRef.current = "explicit";
-    } else if (decision.kind === "seed") {
-      setSelectedGroupId(decision.groupId);
-      setSelectedConnectionId(decision.connectionId);
-      // Default-seeded: a workspace-matching preference arriving later may
-      // still replace it (provenance override).
-      selectionProvenanceRef.current = "default";
+    switch (decision.kind) {
+      case "restore":
+        setSelectedGroupId(decision.groupId);
+        setSelectedConnectionId(decision.connectionId);
+        if (decision.routingMode) setSelectedRoutingMode(decision.routingMode);
+        // A restored sticky preference is the user's deliberate prior choice —
+        // mark it explicit so a later effect run can't seed over it.
+        selectionProvenanceRef.current = "explicit";
+        break;
+      case "seed":
+        setSelectedGroupId(decision.groupId);
+        setSelectedConnectionId(decision.connectionId);
+        // Record that this was auto-seeded: a workspace-matching preference
+        // arriving later is still restored over it (the resolver re-runs), but
+        // a second default seed is suppressed.
+        selectionProvenanceRef.current = "default";
+        break;
+      case "wait":
+      case "noop":
+        // Inputs not ready yet, or the selection is already settled — do
+        // nothing and let the effect re-run when a dependency changes.
+        break;
+      default: {
+        // Exhaustiveness guard — a new EnvSelectionDecision variant (e.g. the
+        // v0.0.4 REST-scope work on this branch's milestone) must add a branch.
+        const _exhaustive: never = decision;
+        void _exhaustive;
+      }
     }
   }, [
     envGroupsQuery.groups,

--- a/packages/web/src/ui/components/atlas-chat.tsx
+++ b/packages/web/src/ui/components/atlas-chat.tsx
@@ -22,9 +22,10 @@ import { SuggestionChips } from "./chat/suggestion-chips";
 import { DeveloperChatEmptyState } from "./chat/developer-empty-state";
 import {
   ChatEnvPicker,
-  pickDefaultEnvSeed,
+  resolveEnvSelection,
   useChatEnvGroups,
   type ConversationRoutingMode,
+  type EnvSelectionProvenance,
 } from "./chat/env-picker";
 import { useDevModeNoDrafts } from "../hooks/use-dev-mode-no-drafts";
 import type { QuerySuggestion } from "@/ui/lib/types";
@@ -141,7 +142,13 @@ export function AtlasChat() {
   const prefGroupId = useChatRoutingPreferenceStore((s) => s.groupId);
   const prefConnectionId = useChatRoutingPreferenceStore((s) => s.connectionId);
   const prefRoutingMode = useChatRoutingPreferenceStore((s) => s.routingMode);
+  const prefHasHydrated = useChatRoutingPreferenceStore((s) => s._hasHydrated);
   const setRoutingPreference = useChatRoutingPreferenceStore((s) => s.setPreference);
+  // #3064 — how the current picker selection was set, so the seed/restore
+  // effect knows whether it may replace it. A ref (not state) because it
+  // must update synchronously alongside a setSelected* call without
+  // re-triggering the effect itself.
+  const selectionProvenanceRef = useRef<EnvSelectionProvenance>("unset");
   const scrollRef = useRef<HTMLDivElement>(null);
 
   const {
@@ -184,6 +191,13 @@ export function AtlasChat() {
   // so a different workspace (SaaS org switch / shared browser) can't seed a new
   // chat with this one's environment. `null` for self-hosted / no active org.
   const activeWorkspaceId = managedSession.data?.session?.activeOrganizationId ?? null;
+  // #3064 — `activeWorkspaceId` is only final once the session has resolved.
+  // For managed auth that means the session is no longer pending; self-hosted
+  // has no session so it is always resolved (workspace id stays null). Gating
+  // the seed on this stops a default seed from being committed while the
+  // workspace id is still null-because-loading and then locked in.
+  const sessionResolved =
+    authResolved && (!isManaged || !managedSession.isPending);
 
   // #2345 — populate the env/member picker from the user-facing
   // `/api/v1/me/connection-groups` route. Fetched only once auth has
@@ -197,44 +211,54 @@ export function AtlasChat() {
     getCredentials,
   });
 
-  // Seed selection only when empty — never override a user pick or a
-  // conversation-restored value. #3044 — prefer the persisted preference (a
-  // reload restores the user's last environment); fall back to the default
-  // seed when there is no stored preference or it no longer matches an
-  // available group/member (e.g. the connection was removed).
+  // Seed / restore the env-picker selection on a fresh chat. #3064 — the
+  // decision is centralized in `resolveEnvSelection`: it waits until groups,
+  // the persisted preference, and the workspace id are all ready (so a
+  // default seed never pre-empts a restorable preference — the reset-on-reload
+  // bug), restores a workspace-matching sticky preference over the default
+  // seed, and never clobbers an explicit pick. Provenance is tracked in a ref
+  // so a default-seeded value can still yield to a later-arriving match.
   useEffect(() => {
-    if (selectedConnectionId !== null) return;
-    if (envGroupsQuery.groups.length === 0) return;
+    const decision = resolveEnvSelection({
+      groups: envGroupsQuery.groups,
+      current: { groupId: selectedGroupId, connectionId: selectedConnectionId },
+      provenance: selectionProvenanceRef.current,
+      preference: {
+        workspaceId: prefWorkspaceId,
+        groupId: prefGroupId,
+        connectionId: prefConnectionId,
+        routingMode: prefRoutingMode,
+      },
+      activeWorkspaceId,
+      preferenceHydrated: prefHasHydrated,
+      sessionResolved,
+    });
 
-    // Only restore a preference that belongs to the active workspace — a stored
-    // selection from another workspace must not seed this one (#3044), even when
-    // group/connection ids collide across workspaces.
-    const prefMatchesWorkspace = prefWorkspaceId === activeWorkspaceId;
-    const prefGroup = prefMatchesWorkspace && prefGroupId
-      ? envGroupsQuery.groups.find((g) => g.id === prefGroupId)
-      : undefined;
-    const prefMember = prefGroup?.members.find(
-      (m) => m.connectionId === prefConnectionId,
-    );
-    if (prefGroup && prefMember) {
-      setSelectedGroupId(prefGroup.id);
-      setSelectedConnectionId(prefMember.connectionId);
-      if (prefRoutingMode) setSelectedRoutingMode(prefRoutingMode);
-      return;
+    if (decision.kind === "restore") {
+      setSelectedGroupId(decision.groupId);
+      setSelectedConnectionId(decision.connectionId);
+      if (decision.routingMode) setSelectedRoutingMode(decision.routingMode);
+      // A restored sticky preference is the user's deliberate prior choice —
+      // treat it as explicit so a later effect run can't seed over it.
+      selectionProvenanceRef.current = "explicit";
+    } else if (decision.kind === "seed") {
+      setSelectedGroupId(decision.groupId);
+      setSelectedConnectionId(decision.connectionId);
+      // Default-seeded: a workspace-matching preference arriving later may
+      // still replace it (provenance override).
+      selectionProvenanceRef.current = "default";
     }
-
-    const seed = pickDefaultEnvSeed(envGroupsQuery.groups, selectedConnectionId);
-    if (!seed) return;
-    setSelectedGroupId(seed.groupId);
-    setSelectedConnectionId(seed.connectionId);
   }, [
     envGroupsQuery.groups,
+    selectedGroupId,
     selectedConnectionId,
     prefWorkspaceId,
     prefGroupId,
     prefConnectionId,
     prefRoutingMode,
+    prefHasHydrated,
     activeWorkspaceId,
+    sessionResolved,
   ]);
 
   const convos = useConversations({
@@ -612,6 +636,9 @@ export function AtlasChat() {
                     activeRoutingMode={selectedRoutingMode}
                     restDatasources={envGroupsQuery.restDatasources}
                     onSelect={({ groupId, connectionId, routingMode }) => {
+                      // #3064 — a user pick is authoritative; mark it explicit
+                      // so the seed/restore effect never replaces it.
+                      selectionProvenanceRef.current = "explicit";
                       setSelectedGroupId(groupId);
                       setSelectedConnectionId(connectionId);
                       setSelectedRoutingMode(routingMode);

--- a/packages/web/src/ui/components/chat/env-picker.tsx
+++ b/packages/web/src/ui/components/chat/env-picker.tsx
@@ -189,6 +189,135 @@ export function pickDefaultEnvSeed(
 }
 
 /**
+ * How the picker's current selection came to be — drives whether the
+ * seed/restore effect may replace it (#3064).
+ *
+ *   - `unset` — nothing selected yet (fresh chat before any seed).
+ *   - `default` — the effect applied the group-primary fallback. A
+ *     later-arriving, workspace-matching preference may still replace it
+ *     (the override that keeps a default from "winning" a reload race).
+ *   - `explicit` — the user picked it (or a conversation restored it).
+ *     Authoritative; never auto-replaced.
+ */
+export type EnvSelectionProvenance = "unset" | "default" | "explicit";
+
+/** A workspace-scoped sticky env-picker preference (mirrors the store shape). */
+export interface EnvSelectionPreference {
+  readonly workspaceId: string | null;
+  readonly groupId: string | null;
+  readonly connectionId: string | null;
+  readonly routingMode: ConversationRoutingMode | null;
+}
+
+export interface ResolveEnvSelectionInput {
+  /** Resolved groups from `/api/v1/me/connection-groups`. */
+  readonly groups: ReadonlyArray<ChatEnvGroup>;
+  /** The picker's current selection. */
+  readonly current: {
+    readonly groupId: string | null;
+    readonly connectionId: string | null;
+  };
+  /** How {@link current} was set. */
+  readonly provenance: EnvSelectionProvenance;
+  /** The persisted sticky preference for this browser. */
+  readonly preference: EnvSelectionPreference;
+  /** Active workspace id (`null` = self-hosted / no active org). */
+  readonly activeWorkspaceId: string | null;
+  /** The persist store has finished rehydrating `localStorage`. */
+  readonly preferenceHydrated: boolean;
+  /** The auth session has resolved, so {@link activeWorkspaceId} is final. */
+  readonly sessionResolved: boolean;
+}
+
+/**
+ * What the seed/restore effect should do — `wait` (data not ready),
+ * `noop` (leave the selection alone), `restore` (apply the sticky
+ * preference), or `seed` (apply the group-primary default).
+ */
+export type EnvSelectionDecision =
+  | { readonly kind: "wait" }
+  | { readonly kind: "noop" }
+  | {
+      readonly kind: "restore";
+      readonly groupId: string;
+      readonly connectionId: string;
+      readonly routingMode: ConversationRoutingMode | null;
+    }
+  | { readonly kind: "seed"; readonly groupId: string; readonly connectionId: string };
+
+/**
+ * Pure decision behind atlas-chat's fresh-chat seed/restore effect
+ * (#3064). Centralizes the precedence that the inline effect used to get
+ * wrong on reload:
+ *
+ *   1. **Gate.** Do nothing until groups have loaded, the preference store
+ *      has rehydrated, and the session has resolved. Committing a default
+ *      seed inside that window — then locking it in against the
+ *      later-arriving preference — was the reset-on-reload bug.
+ *   2. **Explicit wins.** A user pick / conversation-restored value is
+ *      never auto-replaced.
+ *   3. **Preference > default.** Restore a sticky preference that belongs
+ *      to the active workspace and still resolves to a live group+member;
+ *      a preference from another workspace is ignored (ids can collide).
+ *      A `default`-seeded selection yields to a matching preference
+ *      (provenance override), but an unmatched preference falls back to
+ *      the group-primary default seed.
+ */
+export function resolveEnvSelection(
+  input: ResolveEnvSelectionInput,
+): EnvSelectionDecision {
+  const {
+    groups,
+    current,
+    provenance,
+    preference,
+    activeWorkspaceId,
+    preferenceHydrated,
+    sessionResolved,
+  } = input;
+
+  // 1. Gate — wait until every input we need to choose correctly is ready.
+  if (groups.length === 0) return { kind: "wait" };
+  if (!preferenceHydrated) return { kind: "wait" };
+  if (!sessionResolved) return { kind: "wait" };
+
+  // 2. An explicit pick (or conversation-restored value) is authoritative.
+  if (provenance === "explicit") return { kind: "noop" };
+
+  // 3. Restore a workspace-matching, still-resolvable preference.
+  const prefMatchesWorkspace = preference.workspaceId === activeWorkspaceId;
+  const prefGroup =
+    prefMatchesWorkspace && preference.groupId
+      ? groups.find((g) => g.id === preference.groupId)
+      : undefined;
+  const prefMember = prefGroup?.members.find(
+    (m) => m.connectionId === preference.connectionId,
+  );
+  if (prefGroup && prefMember) {
+    // Already on the preferred selection — don't churn React state.
+    if (
+      current.groupId === prefGroup.id &&
+      current.connectionId === prefMember.connectionId
+    ) {
+      return { kind: "noop" };
+    }
+    return {
+      kind: "restore",
+      groupId: prefGroup.id,
+      connectionId: prefMember.connectionId,
+      routingMode: preference.routingMode,
+    };
+  }
+
+  // No restorable preference. Seed the default only when nothing is
+  // selected yet; a default-seeded value with no matching preference stays.
+  if (current.connectionId !== null) return { kind: "noop" };
+  const seed = pickDefaultEnvSeed(groups, current.connectionId);
+  if (!seed) return { kind: "noop" };
+  return { kind: "seed", groupId: seed.groupId, connectionId: seed.connectionId };
+}
+
+/**
  * Back-compat default — NULL on the conversation row means "pin", not
  * "auto". Pre-#2518 rows carry a non-null `connection_id` and the
  * safest interpretation is "stay pinned to that member". The default

--- a/packages/web/src/ui/components/chat/env-picker.tsx
+++ b/packages/web/src/ui/components/chat/env-picker.tsx
@@ -219,6 +219,7 @@ export interface ResolveEnvSelectionInput {
   readonly current: {
     readonly groupId: string | null;
     readonly connectionId: string | null;
+    readonly routingMode: ConversationRoutingMode | null;
   };
   /** How {@link current} was set. */
   readonly provenance: EnvSelectionProvenance;
@@ -298,10 +299,14 @@ export function resolveEnvSelection(
     (m) => m.connectionId === preference.connectionId,
   );
   if (prefGroup && prefMember) {
-    // Already on the preferred selection — don't churn React state.
+    // Already on the preferred selection — don't churn React state. The
+    // routing mode is part of the selection, so a mode-only difference (e.g.
+    // a default seed landed on the preferred member but with no mode) must
+    // still restore.
     if (
       current.groupId === prefGroup.id &&
-      current.connectionId === prefMember.connectionId
+      current.connectionId === prefMember.connectionId &&
+      current.routingMode === preference.routingMode
     ) {
       return { kind: "noop" };
     }

--- a/packages/web/src/ui/components/chat/env-picker.tsx
+++ b/packages/web/src/ui/components/chat/env-picker.tsx
@@ -50,6 +50,7 @@ import type {
   MeConnectionGroupsEmptyReason,
 } from "@/ui/lib/types";
 import type { ConversationRoutingMode } from "@useatlas/types/conversation";
+import type { ChatRoutingPreference } from "@/lib/stores/chat-routing-preference-store";
 
 export type { ChatRestDatasourceScope };
 
@@ -189,25 +190,27 @@ export function pickDefaultEnvSeed(
 }
 
 /**
- * How the picker's current selection came to be — drives whether the
- * seed/restore effect may replace it (#3064).
+ * How the picker's current selection came to be (#3064). Only `explicit`
+ * short-circuits the resolver; `unset` and `default` both re-evaluate the
+ * stored preference on every run (so a matching preference can still restore
+ * over them). The one thing `default` adds over `unset` is suppressing a
+ * second default seed once one has been applied.
  *
  *   - `unset` — nothing selected yet (fresh chat before any seed).
- *   - `default` — the effect applied the group-primary fallback. A
- *     later-arriving, workspace-matching preference may still replace it
- *     (the override that keeps a default from "winning" a reload race).
+ *   - `default` — the effect applied the group-primary fallback. With no
+ *     matching preference it stays; a workspace-matching preference still
+ *     restores over it (it never short-circuits the way `explicit` does).
  *   - `explicit` — the user picked it (or a conversation restored it).
  *     Authoritative; never auto-replaced.
  */
 export type EnvSelectionProvenance = "unset" | "default" | "explicit";
 
-/** A workspace-scoped sticky env-picker preference (mirrors the store shape). */
-export interface EnvSelectionPreference {
-  readonly workspaceId: string | null;
-  readonly groupId: string | null;
-  readonly connectionId: string | null;
-  readonly routingMode: ConversationRoutingMode | null;
-}
+/**
+ * A workspace-scoped sticky env-picker preference. Aliased to the store's
+ * own type so the two can't drift (the store has no back-reference to this
+ * module, so the import is cycle-free).
+ */
+export type EnvSelectionPreference = ChatRoutingPreference;
 
 export interface ResolveEnvSelectionInput {
   /** Resolved groups from `/api/v1/me/connection-groups`. */
@@ -259,8 +262,9 @@ export type EnvSelectionDecision =
  *   3. **Preference > default.** Restore a sticky preference that belongs
  *      to the active workspace and still resolves to a live group+member;
  *      a preference from another workspace is ignored (ids can collide).
- *      A `default`-seeded selection yields to a matching preference
- *      (provenance override), but an unmatched preference falls back to
+ *      Because this step runs before the seed step on every invocation, a
+ *      previously default-seeded selection is restored over as soon as a
+ *      matching preference arrives; an unmatched preference falls back to
  *      the group-primary default seed.
  */
 export function resolveEnvSelection(
@@ -309,9 +313,12 @@ export function resolveEnvSelection(
     };
   }
 
-  // No restorable preference. Seed the default only when nothing is
-  // selected yet; a default-seeded value with no matching preference stays.
-  if (current.connectionId !== null) return { kind: "noop" };
+  // No restorable preference. Seed the group-primary default only on a fresh
+  // chat (provenance "unset"); once a default has been seeded — or anything
+  // is already selected — leave it in place rather than re-seeding.
+  if (provenance === "default" || current.connectionId !== null) {
+    return { kind: "noop" };
+  }
   const seed = pickDefaultEnvSeed(groups, current.connectionId);
   if (!seed) return { kind: "noop" };
   return { kind: "seed", groupId: seed.groupId, connectionId: seed.connectionId };


### PR DESCRIPTION
## Summary

S1a of **v0.0.4 — Conversation Scope** (milestone #59). Fixes the reset-on-reload bug: the chat scope picker reverted to the connection-group primary on a fresh-chat reload instead of restoring the user's last sticky selection.

**Root cause:** the seed/restore effect in `atlas-chat.tsx` committed the group-primary default while `activeWorkspaceId` was still resolving (so the workspace-match check failed), then `if (selectedConnectionId !== null) return` locked the default in against the later-arriving preference.

**Fix — three parts:**
- **Store hydration gate** (`chat-routing-preference-store.ts`) — transient `_hasHydrated` flag flipped by `onRehydrateStorage`, kept out of `partialize` so it never persists (a persisted `true` would skip the gate next load).
- **Pure resolver `resolveEnvSelection`** (`env-picker.tsx`) — centralizes the decision: *wait* until groups + preference-hydration + session are all ready (closes the premature-seed window), *restore* a workspace-matching sticky preference over the default, *never clobber* an explicit pick, and let a `default`-seeded value yield to a later matching preference (provenance override). Preserves the #3044 cross-workspace guard.
- **Effect rewrite** (`atlas-chat.tsx`) — calls the resolver, tracks selection provenance in a ref (user picks → `explicit`), gates on `sessionResolved = authResolved && (!isManaged || !managedSession.isPending)`.

Per [ADR-0011](https://github.com/AtlasDevHQ/atlas/blob/main/docs/adr/0011-unified-conversation-scope.md). Also promotes v0.0.4 to ROADMAP `## Next` (milestone kickoff).

## Test plan

TDD — 14 new tests written red-first, then green:
- [x] `resolveEnvSelection` (12 tests): reset-on-reload guard (no default seed before hydration/session), restore-over-default, provenance override, explicit-pick protection, cross-workspace ignore (#3044), removed-member fallback, self-hosted null-workspace restore, single-connection seed.
- [x] store hydration gate (2 tests): `setHasHydrated` flips both ways; `_hasHydrated` never serialized.
- [x] Existing env-picker + store + adjacent chat tests still green (no regression to the picker self-hide / single-connection path).
- [x] Full local CI: lint · type · test (0 fail) · syncpack · template-drift · railway-watch · schema-drift · security-headers · oauth-helper · test-discipline · twenty-resolver · published-symbols.

Acceptance criteria #1–#5 from the issue all covered.

Closes #3064

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3070"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782910951&installation_id=135337507&pr_number=3070&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3070&signature=5874dc4c956902a69bcf53786b6960bdfe329d11da47fa95900fe3566d84e3ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized env/member selection logic that gates and applies restore/seed decisions while honoring explicit user choices.

* **Bug Fixes**
  * More reliable preference hydration and synchronization; prevents overwriting explicit selections and handles removed/null preferences gracefully.

* **Tests**
  * Added tests for hydration gating, persist rehydration, and many env-selection scenarios.

* **Documentation**
  * ROADMAP updated with current in-flight tag and a new milestone entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->