### PR TITLE
fix(web): restore a conversation's scope when it is opened (#3065)

### DIFF
--- a/packages/web/src/ui/__tests__/env-picker.test.tsx
+++ b/packages/web/src/ui/__tests__/env-picker.test.tsx
@@ -61,6 +61,7 @@ import { render, renderHook, waitFor, cleanup } from "@testing-library/react";
 import {
   ChatEnvPicker,
   pickDefaultEnvSeed,
+  resolveConversationScope,
   resolveEnvSelection,
   shouldRenderEnvPicker,
   useChatEnvGroups,
@@ -1467,6 +1468,114 @@ describe("resolveEnvSelection — sticky-preference restore vs default seed (#30
       groupId: "g_only",
       connectionId: "only",
     });
+  });
+});
+
+// ── #3065 — restore a conversation's scope on open ───────────────────
+//
+// Opening a saved conversation must restore THAT conversation's persisted
+// scope into the picker — precedence: conversation row > sticky preference >
+// default seed. `resolveConversationScope` is the pure mapping that
+// atlas-chat's `handleSelectConversation` applies; the handler then marks the
+// selection provenance `explicit` so the seed/restore effect can't clobber it
+// (that "explicit → noop" guard is locked by the resolveEnvSelection suite
+// above). These tests lock the faithful row→picker mapping, including the
+// legacy null-routing fallback and the routing-mode dimension.
+
+describe("resolveConversationScope — restore a conversation's scope on open (#3065)", () => {
+  test("restores the conversation's group, member, and routing mode verbatim", () => {
+    expect(
+      resolveConversationScope({
+        connectionGroupId: "g_prod",
+        connectionId: "eu-prod",
+        routingMode: "pin",
+      }),
+    ).toEqual({ groupId: "g_prod", connectionId: "eu-prod", routingMode: "pin" });
+  });
+
+  test("preserves an 'auto' routing mode (mode is a first-class scope dimension)", () => {
+    // Codex/CodeRabbit flagged routingMode being dropped on S1a — assert it
+    // explicitly here so a restore can never silently lose the mode.
+    expect(
+      resolveConversationScope({
+        connectionGroupId: "g_prod",
+        connectionId: "us-prod",
+        routingMode: "auto",
+      }),
+    ).toEqual({ groupId: "g_prod", connectionId: "us-prod", routingMode: "auto" });
+  });
+
+  test("preserves an 'all' routing mode", () => {
+    expect(
+      resolveConversationScope({
+        connectionGroupId: "g_prod",
+        connectionId: "us-prod",
+        routingMode: "all",
+      }),
+    ).toEqual({ groupId: "g_prod", connectionId: "us-prod", routingMode: "all" });
+  });
+
+  test("two different conversations resolve to two different scopes (switching updates the picker each time)", () => {
+    const a = resolveConversationScope({
+      connectionGroupId: "g_prod",
+      connectionId: "eu-prod",
+      routingMode: "pin",
+    });
+    const b = resolveConversationScope({
+      connectionGroupId: "g_staging",
+      connectionId: "us-staging",
+      routingMode: "auto",
+    });
+    expect(a).not.toEqual(b);
+    expect(a.connectionId).toBe("eu-prod");
+    expect(b.connectionId).toBe("us-staging");
+    expect(b.routingMode).toBe("auto");
+  });
+
+  test("legacy conversation with a null routing mode preserves null (read as pin downstream)", () => {
+    // Pre-#2518 rows carry a single connectionId and no mode. null is kept
+    // faithfully — the picker and the agent runtime both read null as "pin",
+    // so the conversation stays pinned to its connectionId.
+    expect(
+      resolveConversationScope({
+        connectionGroupId: "g_prod",
+        connectionId: "eu-prod",
+        routingMode: null,
+      }),
+    ).toEqual({ groupId: "g_prod", connectionId: "eu-prod", routingMode: null });
+  });
+
+  test("legacy conversation with an omitted routing mode defaults to null", () => {
+    // routingMode is optional on the wire type — an older SDK/peer may omit
+    // it entirely. Coalesce the missing field to null rather than undefined.
+    expect(
+      resolveConversationScope({
+        connectionGroupId: "g_prod",
+        connectionId: "eu-prod",
+      }),
+    ).toEqual({ groupId: "g_prod", connectionId: "eu-prod", routingMode: null });
+  });
+
+  test("legacy conversation with no group still pins to its connectionId", () => {
+    // Pre-1.4.4 single-connection row: no content group, just an execution
+    // target. The acceptance criterion — "treated as pin to its connectionId".
+    expect(
+      resolveConversationScope({
+        connectionGroupId: null,
+        connectionId: "warehouse",
+        routingMode: null,
+      }),
+    ).toEqual({ groupId: null, connectionId: "warehouse", routingMode: null });
+  });
+
+  test("a fully-null row resolves to an all-null scope (nothing to pin)", () => {
+    expect(
+      resolveConversationScope({
+        connectionGroupId: null,
+        connectionId: null,
+        routingMode: null,
+      }),
+    ).toEqual({ groupId: null, connectionId: null, routingMode: null });
   });
 });
 

--- a/packages/web/src/ui/__tests__/env-picker.test.tsx
+++ b/packages/web/src/ui/__tests__/env-picker.test.tsx
@@ -1494,8 +1494,8 @@ describe("resolveConversationScope — restore a conversation's scope on open (#
   });
 
   test("preserves an 'auto' routing mode (mode is a first-class scope dimension)", () => {
-    // Codex/CodeRabbit flagged routingMode being dropped on S1a — assert it
-    // explicitly here so a restore can never silently lose the mode.
+    // routingMode is a first-class scope dimension — assert it explicitly so a
+    // restore can never silently lose the mode (a prior slice regressed this).
     expect(
       resolveConversationScope({
         connectionGroupId: "g_prod",

--- a/packages/web/src/ui/components/atlas-chat.tsx
+++ b/packages/web/src/ui/components/atlas-chat.tsx
@@ -574,6 +574,14 @@ export function AtlasChat() {
       // covers both: `getConversationData` returns the same payload
       // `loadConversation` transforms, plus the persisted scope columns.
       const data = await convos.getConversationData(id);
+      // A 200 with a malformed body (no `messages` array) would otherwise
+      // throw a bare TypeError inside `transformMessages` and surface as a
+      // generic "try again" — distinguish the structural defect in the log.
+      if (!Array.isArray(data.messages)) {
+        throw new Error(
+          `Conversation ${id} returned no messages array (got ${typeof data.messages})`,
+        );
+      }
       setMessages(transformMessages(data.messages));
       setConversationId(id);
       convos.setSelectedId(id);

--- a/packages/web/src/ui/components/atlas-chat.tsx
+++ b/packages/web/src/ui/components/atlas-chat.tsx
@@ -9,7 +9,7 @@ import { useAtlasConfig } from "../context";
 import { ThemeToggle } from "./theme-toggle";
 import { UserMenu } from "./user-menu";
 import { useAtlasTransport } from "../hooks/use-atlas-transport";
-import { useConversations } from "../hooks/use-conversations";
+import { useConversations, transformMessages } from "../hooks/use-conversations";
 import { useStarterPromptsQuery } from "../hooks/use-starter-prompts-query";
 import { ErrorBanner } from "./chat/error-banner";
 import { ContextWarningBanner } from "./chat/context-warning-banner";
@@ -22,6 +22,7 @@ import { SuggestionChips } from "./chat/suggestion-chips";
 import { DeveloperChatEmptyState } from "./chat/developer-empty-state";
 import {
   ChatEnvPicker,
+  resolveConversationScope,
   resolveEnvSelection,
   useChatEnvGroups,
   type ConversationRoutingMode,
@@ -568,10 +569,24 @@ export function AtlasChat() {
     if (loadingConversation) return;
     setLoadingConversation(true);
     try {
-      const uiMessages = await convos.loadConversation(id);
-      setMessages(uiMessages);
+      // #3065 — fetch the full row (not just the messages) so the
+      // conversation's own scope can be restored into the picker. One fetch
+      // covers both: `getConversationData` returns the same payload
+      // `loadConversation` transforms, plus the persisted scope columns.
+      const data = await convos.getConversationData(id);
+      setMessages(transformMessages(data.messages));
       setConversationId(id);
       convos.setSelectedId(id);
+      // Restore the conversation's persisted scope. The conversation row is
+      // authoritative — precedence row > sticky preference > default seed — so
+      // mark the selection `explicit` (before the setState calls, so the
+      // re-running seed/restore effect already sees it) to keep that effect
+      // from clobbering the restored scope.
+      const scope = resolveConversationScope(data);
+      selectionProvenanceRef.current = "explicit";
+      setSelectedGroupId(scope.groupId);
+      setSelectedConnectionId(scope.connectionId);
+      setSelectedRoutingMode(scope.routingMode);
       setMobileSidebarOpen(false);
       // Loaded turns predate this session — no warning frames replay over
       // the wire, so any prior in-memory bucket is stale relative to the
@@ -594,6 +609,16 @@ export function AtlasChat() {
     setMobileSidebarOpen(false);
     setPythonProgress(new Map());
     warningCtl.reset();
+    // #3065 — a new chat is not bound to any conversation's scope. Reset the
+    // selection provenance and clear the picker so the seed/restore effect
+    // re-runs from scratch — seeding from the sticky preference (or the
+    // default), exactly as on a fresh page load. Without this, a
+    // just-opened conversation's `explicit` scope would carry into the new
+    // chat and the effect would no-op on it.
+    selectionProvenanceRef.current = "unset";
+    setSelectedGroupId(null);
+    setSelectedConnectionId(null);
+    setSelectedRoutingMode(null);
   }
 
   // Wait for auth mode detection before rendering — prevents flash of chat UI

--- a/packages/web/src/ui/components/chat/env-picker.tsx
+++ b/packages/web/src/ui/components/chat/env-picker.tsx
@@ -331,8 +331,10 @@ export function resolveEnvSelection(
 
 /**
  * The persisted scope columns on a conversation row — structurally a subset
- * of `ConversationWithMessages`. Declared locally so this module stays free of
- * a conversation-types import; the picker is otherwise scope-shape agnostic.
+ * of `ConversationWithMessages`. Declared locally so this module needn't import
+ * the `Conversation` / `ConversationWithMessages` row-shape types (it already
+ * depends only on the `ConversationRoutingMode` alias); the picker is otherwise
+ * scope-shape agnostic.
  */
 export interface ConversationScopeSource {
   readonly connectionGroupId: string | null;

--- a/packages/web/src/ui/components/chat/env-picker.tsx
+++ b/packages/web/src/ui/components/chat/env-picker.tsx
@@ -330,6 +330,50 @@ export function resolveEnvSelection(
 }
 
 /**
+ * The persisted scope columns on a conversation row — structurally a subset
+ * of `ConversationWithMessages`. Declared locally so this module stays free of
+ * a conversation-types import; the picker is otherwise scope-shape agnostic.
+ */
+export interface ConversationScopeSource {
+  readonly connectionGroupId: string | null;
+  readonly connectionId: string | null;
+  readonly routingMode?: ConversationRoutingMode | null;
+}
+
+/** The picker selection restored from a conversation row. */
+export interface RestoredConversationScope {
+  readonly groupId: string | null;
+  readonly connectionId: string | null;
+  readonly routingMode: ConversationRoutingMode | null;
+}
+
+/**
+ * S1b (#3065) — map a saved conversation's persisted scope onto the picker
+ * selection when the conversation is opened. The conversation row is
+ * authoritative (precedence: row > sticky preference > default seed), so its
+ * group / member / mode are applied verbatim and the caller marks the
+ * resulting selection `explicit` so the seed/restore effect can't overwrite
+ * it.
+ *
+ * The routing mode is preserved faithfully, not coerced: a null `routingMode`
+ * stays null because the picker and the agent runtime both read null as "pin"
+ * (pre-#2518 back-compat — see {@link effectiveMode}). A legacy row with a
+ * single `connectionId` and no mode therefore stays pinned to that member, and
+ * a row with no group (`connectionGroupId` null) still pins to its
+ * `connectionId`. An omitted `routingMode` (optional on the wire type) is
+ * coalesced to null rather than left undefined.
+ */
+export function resolveConversationScope(
+  source: ConversationScopeSource,
+): RestoredConversationScope {
+  return {
+    groupId: source.connectionGroupId,
+    connectionId: source.connectionId,
+    routingMode: source.routingMode ?? null,
+  };
+}
+
+/**
  * Back-compat default — NULL on the conversation row means "pin", not
  * "auto". Pre-#2518 rows carry a non-null `connection_id` and the
  * safest interpretation is "stay pinned to that member". The default


### PR DESCRIPTION
## Summary
S1b of the v0.0.4 Conversation Scope milestone. Builds on S1a (#3064).

- **The gap:** `handleSelectConversation` loaded a saved conversation's messages and set its id, but **never restored that conversation's SQL routing** (group / member / routing mode) into the picker — so the picker kept whatever the fresh-chat seed set. The per-conversation-authoritative promise was unfulfilled, and `loadConversation` discarded the routing fields the payload already carried.
- **The fix:** a pure `resolveConversationScope()` in `chat/env-picker.tsx` maps the conversation row's `connectionGroupId` / `connectionId` / `routingMode` onto the picker selection. `handleSelectConversation` now fetches the full row via the existing `getConversationData` (one fetch, no extra round-trip), applies the scope, and marks the selection **`explicit`** so the seed/restore effect can't clobber it — enforcing precedence **row > sticky preference > default seed**.
- **New chat:** `handleNewChat` resets provenance to `unset` and clears the picker so a new chat re-seeds from the sticky preference (exactly like a fresh page load) instead of inheriting the just-opened conversation's scope.
- **Routing mode** is preserved faithfully: a legacy row with `null` mode stays `null` (the picker and agent runtime both read `null` as "pin"), and a legacy row with no group still pins to its `connectionId`.

Per [ADR-0011](https://github.com/AtlasDevHQ/atlas/blob/main/docs/adr/0011-unified-conversation-scope.md) + CONTEXT.md → Conversation scope. Web-only; no API/schema change (the GET `/conversations/{id}` response already serializes `routingMode` at runtime).

## Test plan
- [x] `resolveConversationScope` unit tests: faithful restore; `auto`/`all`/`pin` modes; two conversations → two scopes (switching); legacy null mode preserved; omitted mode → null; no-group still pins; fully-null row.
- [x] Precedence (row > sticky > seed) locked by the existing `resolveEnvSelection` "explicit → noop" test + `handleSelectConversation` setting provenance `explicit`.
- [x] `bun run lint` / `bun run type` / full `bun run test` — all green.
- [x] Affected web suite (171 files) green.
- [ ] Manual: open two conversations with different scopes in a multi-env workspace, confirm the picker tracks each; reload restores the sticky pref (S1a); New Chat re-seeds.

## Follow-ups noticed during review
- Filed #3071 — `ConversationSchema` OpenAPI doc omits `routingMode` (pre-existing drift since #2518). Runtime response already includes it, so this PR is unaffected; documenting the field is a separable API/docs fix.

Closes #3065

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3072"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782913644&installation_id=135337507&pr_number=3072&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3072&signature=c1753b30ef061850aa5ab63f53a91121d5b487875c8732c87c94187e44966156"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added thorough tests covering conversation scope restoration, including routing-mode edge cases and connection-group/connection selection behavior.

* **New Features**
  * Saved conversations now restore your previously selected environment, connection, and routing mode (including legacy/omitted values).
  * Starting a new chat resets the picker to a fresh state so it doesn’t inherit prior selections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->