### PR TITLE
fix(web): validate restored conversation scope against visible groups (#3065)

### DIFF
--- a/.claude/research/ROADMAP.md
+++ b/.claude/research/ROADMAP.md
@@ -20,15 +20,16 @@ The codebase is Hono + Next.js + TypeScript + Effect.ts + Vercel AI SDK + bun, o
 
 ## Next
 
-**`v0.0.4` — Conversation Scope** ([milestone #59](https://github.com/AtlasDevHQ/atlas/milestone/59), 5 issues) — in flight. Unifies the chat scope picker (`ChatScopePicker`, was `ChatEnvPicker`) across two axes: **SQL routing** (connection group + members + Auto/Pin/All) and **REST scope** (exclude-set + REST-only focus). Per-conversation authoritative, with a sticky workspace-scoped preference that seeds new chats; fixes the [#3063](https://github.com/AtlasDevHQ/atlas/issues/3063) reset-on-reload bug at the seed/restore seam. See [ADR-0011](../../docs/adr/0011-unified-conversation-scope.md) (supersedes ADR-0010 picker-surface only) + `CONTEXT.md` → Conversation scope.
+**`v0.0.4` — Conversation Scope** ([milestone #59](https://github.com/AtlasDevHQ/atlas/milestone/59), 6 issues — 2 shipped) — in flight. Unifies the chat scope picker (`ChatScopePicker`, was `ChatEnvPicker`) across two axes: **SQL routing** (connection group + members + Auto/Pin/All) and **REST scope** (exclude-set + REST-only focus). Per-conversation authoritative, with a sticky workspace-scoped preference that seeds new chats; fixes the [#3063](https://github.com/AtlasDevHQ/atlas/issues/3063) reset-on-reload bug at the seed/restore seam. See [ADR-0011](../../docs/adr/0011-unified-conversation-scope.md) (supersedes ADR-0010 picker-surface only) + `CONTEXT.md` → Conversation scope.
 
-Slices form a near-linear chain (S1a → S1b → S2a → S2b), with S3 independent:
+Slices form a near-linear chain (S1a → S1b → S2a → S2b), with S3 + the #3071 doc-fix independent:
 
-- [ ] S1a — Restore the sticky scope preference on a fresh chat — fixes reset-on-reload ([#3064](https://github.com/AtlasDevHQ/atlas/issues/3064), bug, no deps) ⟵ start here
-- [ ] S1b — Restore a conversation's scope when it is opened ([#3065](https://github.com/AtlasDevHQ/atlas/issues/3065), bug, blocked by #3064)
-- [ ] S2a — REST scope: exclude datasources from a conversation ([#3066](https://github.com/AtlasDevHQ/atlas/issues/3066), feature, blocked by #3065)
+- [x] S1a — Restore the sticky scope preference on a fresh chat — fixes reset-on-reload ([#3064](https://github.com/AtlasDevHQ/atlas/issues/3064), bug, no deps) — PR #3070
+- [x] S1b — Restore a conversation's scope when it is opened ([#3065](https://github.com/AtlasDevHQ/atlas/issues/3065), bug) — PR #3072 + scope-validation follow-up
+- [ ] S2a — REST scope: exclude datasources from a conversation ([#3066](https://github.com/AtlasDevHQ/atlas/issues/3066), feature, blocked by #3065) ⟵ next
 - [ ] S2b — REST-only focus: suspend SQL for a conversation ([#3067](https://github.com/AtlasDevHQ/atlas/issues/3067), feature, blocked by #3066)
 - [ ] S3 — Persist the active conversation in the URL ([#3068](https://github.com/AtlasDevHQ/atlas/issues/3068), refactor, independent — synergizes with #3065)
+- [ ] OpenAPI drift — `ConversationSchema` omits `routingMode` ([#3071](https://github.com/AtlasDevHQ/atlas/issues/3071), bug, independent doc-fix surfaced by S1b)
 
 Parent [#3063](https://github.com/AtlasDevHQ/atlas/issues/3063) stays in the Architecture Backlog (left unmodified per `/to-issues`). The **Staging environment** track (below) continues in parallel, independent of the tag train.
 

--- a/packages/web/src/ui/__tests__/env-picker.test.tsx
+++ b/packages/web/src/ui/__tests__/env-picker.test.tsx
@@ -1475,61 +1475,77 @@ describe("resolveEnvSelection — sticky-preference restore vs default seed (#30
 //
 // Opening a saved conversation must restore THAT conversation's persisted
 // scope into the picker — precedence: conversation row > sticky preference >
-// default seed. `resolveConversationScope` is the pure mapping that
-// atlas-chat's `handleSelectConversation` applies; the handler then marks the
-// selection provenance `explicit` so the seed/restore effect can't clobber it
-// (that "explicit → noop" guard is locked by the resolveEnvSelection suite
-// above). These tests lock the faithful row→picker mapping, including the
-// legacy null-routing fallback and the routing-mode dimension.
+// default seed. `resolveConversationScope` is the pure decision that
+// atlas-chat's `handleSelectConversation` applies: `restore` (apply + mark
+// provenance `explicit`, so the seed/restore effect's "explicit → noop" guard
+// keeps it) or `seed` (defer to that effect — the row carried no usable scope).
+//
+// It validates the row against the loaded env groups so a stale/empty scope is
+// NEVER made authoritative (the bug Codex flagged on the first cut): an all-null
+// legacy row, or a row pointing at an archived/removed group, falls back to
+// `seed` instead of forcing the transport to send nulls / a rejected group id.
+// An archived *member* under a still-valid group is repaired to the group
+// primary rather than discarding the whole (still-valid) group.
 
 describe("resolveConversationScope — restore a conversation's scope on open (#3065)", () => {
-  test("restores the conversation's group, member, and routing mode verbatim", () => {
+  const prodGroup: ChatEnvGroup = {
+    id: "g_prod",
+    name: "prod",
+    primaryConnectionId: "us-prod",
+    members: [
+      { connectionId: "us-prod", dbType: "postgres", description: null },
+      { connectionId: "eu-prod", dbType: "postgres", description: null },
+    ],
+  };
+  const stagingGroup: ChatEnvGroup = {
+    id: "g_staging",
+    name: "staging",
+    primaryConnectionId: null,
+    members: [{ connectionId: "us-staging", dbType: "postgres", description: null }],
+  };
+  const groups: ChatEnvGroup[] = [prodGroup, stagingGroup];
+
+  test("restores a row that resolves to a visible group + member, verbatim", () => {
     expect(
-      resolveConversationScope({
-        connectionGroupId: "g_prod",
-        connectionId: "eu-prod",
-        routingMode: "pin",
-      }),
-    ).toEqual({ groupId: "g_prod", connectionId: "eu-prod", routingMode: "pin" });
+      resolveConversationScope(
+        { connectionGroupId: "g_prod", connectionId: "eu-prod", routingMode: "pin" },
+        groups,
+      ),
+    ).toEqual({ kind: "restore", groupId: "g_prod", connectionId: "eu-prod", routingMode: "pin" });
   });
 
   test("preserves an 'auto' routing mode (mode is a first-class scope dimension)", () => {
     // routingMode is a first-class scope dimension — assert it explicitly so a
     // restore can never silently lose the mode (a prior slice regressed this).
     expect(
-      resolveConversationScope({
-        connectionGroupId: "g_prod",
-        connectionId: "us-prod",
-        routingMode: "auto",
-      }),
-    ).toEqual({ groupId: "g_prod", connectionId: "us-prod", routingMode: "auto" });
+      resolveConversationScope(
+        { connectionGroupId: "g_prod", connectionId: "us-prod", routingMode: "auto" },
+        groups,
+      ),
+    ).toEqual({ kind: "restore", groupId: "g_prod", connectionId: "us-prod", routingMode: "auto" });
   });
 
   test("preserves an 'all' routing mode", () => {
     expect(
-      resolveConversationScope({
-        connectionGroupId: "g_prod",
-        connectionId: "us-prod",
-        routingMode: "all",
-      }),
-    ).toEqual({ groupId: "g_prod", connectionId: "us-prod", routingMode: "all" });
+      resolveConversationScope(
+        { connectionGroupId: "g_prod", connectionId: "us-prod", routingMode: "all" },
+        groups,
+      ),
+    ).toEqual({ kind: "restore", groupId: "g_prod", connectionId: "us-prod", routingMode: "all" });
   });
 
   test("two different conversations resolve to two different scopes (switching updates the picker each time)", () => {
-    const a = resolveConversationScope({
-      connectionGroupId: "g_prod",
-      connectionId: "eu-prod",
-      routingMode: "pin",
-    });
-    const b = resolveConversationScope({
-      connectionGroupId: "g_staging",
-      connectionId: "us-staging",
-      routingMode: "auto",
-    });
+    const a = resolveConversationScope(
+      { connectionGroupId: "g_prod", connectionId: "eu-prod", routingMode: "pin" },
+      groups,
+    );
+    const b = resolveConversationScope(
+      { connectionGroupId: "g_staging", connectionId: "us-staging", routingMode: "auto" },
+      groups,
+    );
     expect(a).not.toEqual(b);
-    expect(a.connectionId).toBe("eu-prod");
-    expect(b.connectionId).toBe("us-staging");
-    expect(b.routingMode).toBe("auto");
+    expect(a).toMatchObject({ kind: "restore", connectionId: "eu-prod" });
+    expect(b).toMatchObject({ kind: "restore", connectionId: "us-staging", routingMode: "auto" });
   });
 
   test("legacy conversation with a null routing mode preserves null (read as pin downstream)", () => {
@@ -1537,45 +1553,113 @@ describe("resolveConversationScope — restore a conversation's scope on open (#
     // faithfully — the picker and the agent runtime both read null as "pin",
     // so the conversation stays pinned to its connectionId.
     expect(
-      resolveConversationScope({
-        connectionGroupId: "g_prod",
-        connectionId: "eu-prod",
-        routingMode: null,
-      }),
-    ).toEqual({ groupId: "g_prod", connectionId: "eu-prod", routingMode: null });
+      resolveConversationScope(
+        { connectionGroupId: "g_prod", connectionId: "eu-prod", routingMode: null },
+        groups,
+      ),
+    ).toEqual({ kind: "restore", groupId: "g_prod", connectionId: "eu-prod", routingMode: null });
   });
 
   test("legacy conversation with an omitted routing mode defaults to null", () => {
     // routingMode is optional on the wire type — an older SDK/peer may omit
     // it entirely. Coalesce the missing field to null rather than undefined.
     expect(
-      resolveConversationScope({
-        connectionGroupId: "g_prod",
-        connectionId: "eu-prod",
-      }),
-    ).toEqual({ groupId: "g_prod", connectionId: "eu-prod", routingMode: null });
+      resolveConversationScope(
+        { connectionGroupId: "g_prod", connectionId: "eu-prod" },
+        groups,
+      ),
+    ).toEqual({ kind: "restore", groupId: "g_prod", connectionId: "eu-prod", routingMode: null });
   });
 
-  test("legacy conversation with no group still pins to its connectionId", () => {
-    // Pre-1.4.4 single-connection row: no content group, just an execution
-    // target. The acceptance criterion — "treated as pin to its connectionId".
+  test("seeds (defers) for a fully-null row — never makes nulls authoritative", () => {
+    // Codex finding 1: an all-null legacy/API-created row marked `explicit`
+    // would show a fallback chip while the transport sent nulls. Defer instead.
     expect(
-      resolveConversationScope({
-        connectionGroupId: null,
-        connectionId: "warehouse",
-        routingMode: null,
-      }),
-    ).toEqual({ groupId: null, connectionId: "warehouse", routingMode: null });
+      resolveConversationScope(
+        { connectionGroupId: null, connectionId: null, routingMode: null },
+        groups,
+      ),
+    ).toEqual({ kind: "seed" });
   });
 
-  test("a fully-null row resolves to an all-null scope (nothing to pin)", () => {
+  test("seeds when the row's group has been archived / is no longer visible", () => {
+    // Codex finding 2: a since-removed group restored verbatim would be sent to
+    // the chat route and rejected (invalid_connection_group). Defer to seeding.
     expect(
-      resolveConversationScope({
-        connectionGroupId: null,
-        connectionId: null,
-        routingMode: null,
-      }),
-    ).toEqual({ groupId: null, connectionId: null, routingMode: null });
+      resolveConversationScope(
+        { connectionGroupId: "g_archived", connectionId: "old-prod", routingMode: "pin" },
+        groups,
+      ),
+    ).toEqual({ kind: "seed" });
+  });
+
+  test("repairs an archived member to the group primary when the group still resolves", () => {
+    // The group is still valid but the pinned member is gone — keep the group,
+    // repair the execution target to the primary rather than sending a stale id.
+    expect(
+      resolveConversationScope(
+        { connectionGroupId: "g_prod", connectionId: "ap-prod-archived", routingMode: "pin" },
+        groups,
+      ),
+    ).toEqual({ kind: "restore", groupId: "g_prod", connectionId: "us-prod", routingMode: "pin" });
+  });
+
+  test("repairs a group-only row (null member, e.g. Auto) to the group primary", () => {
+    // An Auto/All conversation may carry a group but no pinned member. Restore
+    // the group + its primary as the displayed target, preserving the mode.
+    expect(
+      resolveConversationScope(
+        { connectionGroupId: "g_prod", connectionId: null, routingMode: "auto" },
+        groups,
+      ),
+    ).toEqual({ kind: "restore", groupId: "g_prod", connectionId: "us-prod", routingMode: "auto" });
+  });
+
+  test("falls back to members[0] when repairing under a group with no primary", () => {
+    expect(
+      resolveConversationScope(
+        { connectionGroupId: "g_staging", connectionId: "gone", routingMode: "pin" },
+        groups,
+      ),
+    ).toEqual({ kind: "restore", groupId: "g_staging", connectionId: "us-staging", routingMode: "pin" });
+  });
+
+  test("trusts the row optimistically when groups have not loaded yet (cold-start open)", () => {
+    // We can't validate against an empty group list; losing the restore on a
+    // cold-start open is a worse, more common regression than the rare
+    // archived-env + cold-start intersection. Restore the row verbatim.
+    expect(
+      resolveConversationScope(
+        { connectionGroupId: "g_prod", connectionId: "eu-prod", routingMode: "all" },
+        [],
+      ),
+    ).toEqual({ kind: "restore", groupId: "g_prod", connectionId: "eu-prod", routingMode: "all" });
+  });
+
+  test("still seeds a fully-null row even when groups have not loaded", () => {
+    // Emptiness is decided before the groups-loaded gate — an all-null row is
+    // never authoritative regardless of load state.
+    expect(
+      resolveConversationScope(
+        { connectionGroupId: null, connectionId: null, routingMode: null },
+        [],
+      ),
+    ).toEqual({ kind: "seed" });
+  });
+
+  test("seeds when a resolved group has no live members (fully archived group)", () => {
+    const emptyGroup: ChatEnvGroup = {
+      id: "g_empty",
+      name: "empty",
+      primaryConnectionId: null,
+      members: [],
+    };
+    expect(
+      resolveConversationScope(
+        { connectionGroupId: "g_empty", connectionId: "anything", routingMode: "pin" },
+        [emptyGroup],
+      ),
+    ).toEqual({ kind: "seed" });
   });
 });
 

--- a/packages/web/src/ui/components/atlas-chat.tsx
+++ b/packages/web/src/ui/components/atlas-chat.tsx
@@ -274,6 +274,9 @@ export function AtlasChat() {
     envGroupsQuery.groups,
     selectedGroupId,
     selectedConnectionId,
+    // routingMode is part of `current` the resolver reads — keep it in deps so a
+    // mode-only change re-evaluates restore-vs-noop rather than going stale.
+    selectedRoutingMode,
     prefWorkspaceId,
     prefGroupId,
     prefConnectionId,
@@ -585,16 +588,27 @@ export function AtlasChat() {
       setMessages(transformMessages(data.messages));
       setConversationId(id);
       convos.setSelectedId(id);
-      // Restore the conversation's persisted scope. The conversation row is
-      // authoritative — precedence row > sticky preference > default seed — so
-      // mark the selection `explicit` (before the setState calls, so the
-      // re-running seed/restore effect already sees it) to keep that effect
-      // from clobbering the restored scope.
-      const scope = resolveConversationScope(data);
-      selectionProvenanceRef.current = "explicit";
-      setSelectedGroupId(scope.groupId);
-      setSelectedConnectionId(scope.connectionId);
-      setSelectedRoutingMode(scope.routingMode);
+      // Restore the conversation's persisted scope, validated against the
+      // currently-visible env groups. A `restore` decision is authoritative
+      // (precedence row > sticky preference > default seed) — mark it `explicit`
+      // (before the setState calls, so the re-running seed/restore effect
+      // already sees it) so that effect can't clobber it. A `seed` decision
+      // means the row carried no usable scope (all-null legacy row, or a group
+      // since archived): reset to `unset` and clear so the effect seeds the
+      // default / restores the sticky preference, never sending stale-or-null
+      // scope the chip would misrepresent.
+      const decision = resolveConversationScope(data, envGroupsQuery.groups);
+      if (decision.kind === "restore") {
+        selectionProvenanceRef.current = "explicit";
+        setSelectedGroupId(decision.groupId);
+        setSelectedConnectionId(decision.connectionId);
+        setSelectedRoutingMode(decision.routingMode);
+      } else {
+        selectionProvenanceRef.current = "unset";
+        setSelectedGroupId(null);
+        setSelectedConnectionId(null);
+        setSelectedRoutingMode(null);
+      }
       setMobileSidebarOpen(false);
       // Loaded turns predate this session — no warning frames replay over
       // the wire, so any prior in-memory bucket is stale relative to the

--- a/packages/web/src/ui/components/chat/env-picker.tsx
+++ b/packages/web/src/ui/components/chat/env-picker.tsx
@@ -350,29 +350,74 @@ export interface RestoredConversationScope {
 }
 
 /**
- * S1b (#3065) — map a saved conversation's persisted scope onto the picker
- * selection when the conversation is opened. The conversation row is
- * authoritative (precedence: row > sticky preference > default seed), so its
- * group / member / mode are applied verbatim and the caller marks the
- * resulting selection `explicit` so the seed/restore effect can't overwrite
- * it.
+ * What {@link resolveConversationScope} decides for an opened conversation:
+ * `restore` (apply the scope and make it authoritative) or `seed` (the row
+ * carried no usable scope — defer to the fresh-chat seed/restore effect).
+ */
+export type ConversationScopeDecision =
+  | ({ readonly kind: "restore" } & RestoredConversationScope)
+  | { readonly kind: "seed" };
+
+/**
+ * S1b (#3065) — decide how to populate the picker when a saved conversation is
+ * opened. The conversation row is authoritative (precedence: row > sticky
+ * preference > default seed), but ONLY when it carries a scope that still
+ * resolves against the visible environments. A `restore` decision is applied
+ * and marked `explicit` by the caller so the seed/restore effect can't
+ * overwrite it; a `seed` decision means the caller resets to `unset` and lets
+ * that effect seed the default (or restore the sticky preference) instead.
  *
- * The routing mode is preserved faithfully, not coerced: a null `routingMode`
+ * Validation against `groups` prevents two ways a verbatim restore would lie to
+ * the agent (both Codex-flagged):
+ *   - an all-null legacy/API-created row → `explicit` nulls show a fallback chip
+ *     while the transport sends nothing → query runs against server-default
+ *     routing, unrepairable because `explicit` forces the effect to no-op;
+ *   - a row pointing at an archived/removed group → sent verbatim and rejected
+ *     by the chat route (`invalid_connection_group`).
+ * Both fall back to `seed`. An archived *member* under a still-valid group is
+ * repaired to the group primary rather than discarding the still-valid group.
+ *
+ * The routing mode is preserved faithfully on a restore: a null `routingMode`
  * stays null because the picker and the agent runtime both read null as "pin"
- * (pre-#2518 back-compat — see {@link effectiveMode}). A legacy row with a
- * single `connectionId` and no mode therefore stays pinned to that member, and
- * a row with no group (`connectionGroupId` null) still pins to its
- * `connectionId`. An omitted `routingMode` (optional on the wire type) is
- * coalesced to null rather than left undefined.
+ * (pre-#2518 back-compat — see {@link effectiveMode}). An omitted `routingMode`
+ * (optional on the wire type) is coalesced to null rather than left undefined.
  */
 export function resolveConversationScope(
   source: ConversationScopeSource,
-): RestoredConversationScope {
-  return {
-    groupId: source.connectionGroupId,
-    connectionId: source.connectionId,
-    routingMode: source.routingMode ?? null,
-  };
+  groups: ReadonlyArray<ChatEnvGroup>,
+): ConversationScopeDecision {
+  const groupId = source.connectionGroupId;
+  const connectionId = source.connectionId;
+  const routingMode = source.routingMode ?? null;
+
+  // A row that persisted no scope at all is never authoritative — defer to the
+  // seed/restore effect (decided before the load gate so it holds either way).
+  if (groupId === null && connectionId === null) return { kind: "seed" };
+
+  // Groups not loaded yet (cold-start open): we can't validate, so trust the
+  // row optimistically. Losing the restore here would be a worse, more common
+  // regression than the rare archived-env + cold-start intersection.
+  if (groups.length === 0) {
+    return { kind: "restore", groupId, connectionId, routingMode };
+  }
+
+  // Groups loaded: the row's group must still resolve to a visible environment,
+  // else a stale group id reaches the chat route and is rejected.
+  const group = groupId !== null ? groups.find((g) => g.id === groupId) : undefined;
+  if (!group) return { kind: "seed" };
+
+  // Group resolves. Keep the pinned member if it's still present; otherwise
+  // repair the execution target to the group primary (never send a stale id),
+  // preserving the still-valid group rather than discarding it.
+  const member = group.members.find((m) => m.connectionId === connectionId);
+  if (member) {
+    return { kind: "restore", groupId: group.id, connectionId: member.connectionId, routingMode };
+  }
+  const repaired =
+    group.members.find((m) => m.connectionId === group.primaryConnectionId) ??
+    group.members[0];
+  if (!repaired) return { kind: "seed" }; // group exists but has no live members
+  return { kind: "restore", groupId: group.id, connectionId: repaired.connectionId, routingMode };
 }
 
 /**


### PR DESCRIPTION
## Summary
Follow-up to PR #3072 (merged S1b), addressing the **Codex** and **CodeRabbit** automated review on that PR. The first cut made a conversation row's scope `explicit`-authoritative *without validating it resolves* — which lies to the agent in two ways the bots correctly flagged.

`resolveConversationScope(source, groups)` now returns a **`restore | seed` decision** instead of a verbatim mapping, validated against the loaded env groups:

- **All-null legacy / API-created row → `seed`.** Previously, marking nulls `explicit` showed a fallback env in the chip while `useAtlasTransport` sent nothing → the query ran against the server's legacy/default routing, **unrepairable** because `explicit` forces the seed/restore effect to no-op. _(Codex finding 1)_
- **Row pointing at an archived/removed group → `seed`.** Previously a stale `connectionGroupId` was restored verbatim and sent to the chat route → rejected with `invalid_connection_group` on the next message. _(Codex finding 2)_
- **Archived member under a still-valid group → repair** the execution target to the group primary, preserving the still-valid group rather than discarding it.
- **Groups not loaded yet (cold-start open) → trust the row optimistically.** Losing the restore here would be a worse, more common regression than the rare archived-env × cold-start intersection (documented in the resolver).

A `seed` decision resets provenance to `unset` and clears the picker, deferring to the existing seed/restore effect (seeds the default / restores the sticky preference) — so the chip and the transport always agree.

Also: **add `selectedRoutingMode` to the seed/restore effect's dependency array** so a mode-only change re-evaluates restore-vs-noop instead of going stale. _(CodeRabbit)_

## Test plan
- [x] `resolveConversationScope` rewritten to a decision resolver — 14 unit tests: resolving restore (pin/auto/all, mode preserved); all-null → seed; archived group → seed; archived member → repair to primary; group-only (null member) → repair; no-primary → members[0]; cold-start optimistic restore; cold-start still seeds all-null; fully-archived group → seed; two-conversation switching.
- [x] `bun run lint` / `bun run type` / full `bun run test` — green (CLI flaked once under full-suite contention, passed clean in isolation 29/29 + on full re-run).
- [x] 171 affected web tests green.
- [ ] Manual: open a conversation pinned to a since-archived env in a multi-env workspace — confirm the chip shows the seeded default and the next message succeeds (no `invalid_connection_group`).

## Notes
- Web-only; no API/schema change. Builds on #3072.
- ROADMAP updated (S1a + S1b marked shipped; #3071 OpenAPI doc-fix folded into v0.0.4).

Refs #3065

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3073"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782915095&installation_id=135337507&pr_number=3073&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3073&signature=88c5dbe962c274e853519d8002035144feaabd9ec4e6c7c95bf70cb315eea091"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced conversation restoration to validate and repair saved settings (environment group, connection, routing mode) when reopening conversations.
  * Improved handling of archived or stale connection configurations by automatically falling back to primary options.
  * Fixed routing mode preservation and selection tracking during conversation recovery.
  * Better behavior when environment groups are still loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->