### PR TITLE
fix(web): preserve legacy group-less conversation pin (#3065)

### DIFF
--- a/packages/web/src/ui/__tests__/env-picker.test.tsx
+++ b/packages/web/src/ui/__tests__/env-picker.test.tsx
@@ -1647,6 +1647,31 @@ describe("resolveConversationScope — restore a conversation's scope on open (#
     ).toEqual({ kind: "seed" });
   });
 
+  test("seeds a legacy group-less row (connectionId but null group) once groups are loaded", () => {
+    // Reachable production state (migration 0067 only backfilled the group for
+    // rows whose connection still joined): connectionId set, connectionGroupId
+    // null. With groups loaded there is no group to validate, so seed — the
+    // chat route still pins execution by reading connection_id back off the row.
+    expect(
+      resolveConversationScope(
+        { connectionGroupId: null, connectionId: "us-prod", routingMode: "pin" },
+        groups,
+      ),
+    ).toEqual({ kind: "seed" });
+  });
+
+  test("optimistically restores a legacy group-less row (null group) on cold-start", () => {
+    // Same row before groups load: can't validate, so trust it verbatim — the
+    // null group is carried through (asymmetric with the groups-loaded seed
+    // above; locks that the emptiness check requires BOTH ids null, not either).
+    expect(
+      resolveConversationScope(
+        { connectionGroupId: null, connectionId: "us-prod", routingMode: "pin" },
+        [],
+      ),
+    ).toEqual({ kind: "restore", groupId: null, connectionId: "us-prod", routingMode: "pin" });
+  });
+
   test("seeds when a resolved group has no live members (fully archived group)", () => {
     const emptyGroup: ChatEnvGroup = {
       id: "g_empty",

--- a/packages/web/src/ui/__tests__/env-picker.test.tsx
+++ b/packages/web/src/ui/__tests__/env-picker.test.tsx
@@ -1647,29 +1647,42 @@ describe("resolveConversationScope — restore a conversation's scope on open (#
     ).toEqual({ kind: "seed" });
   });
 
-  test("seeds a legacy group-less row (connectionId but null group) once groups are loaded", () => {
+  test("restores a legacy group-less row by locating the group that owns its connection", () => {
     // Reachable production state (migration 0067 only backfilled the group for
     // rows whose connection still joined): connectionId set, connectionGroupId
-    // null. With groups loaded there is no group to validate, so seed — the
-    // chat route still pins execution by reading connection_id back off the row.
+    // null. The PIN must be preserved — locate the owning group rather than
+    // seeding, which would let the effect send a different member and silently
+    // switch environments (Codex #3074). NON-primary `eu-prod` so a regression
+    // to the default can't be masked by the primary.
     expect(
       resolveConversationScope(
-        { connectionGroupId: null, connectionId: "us-prod", routingMode: "pin" },
+        { connectionGroupId: null, connectionId: "eu-prod", routingMode: "pin" },
+        groups,
+      ),
+    ).toEqual({ kind: "restore", groupId: "g_prod", connectionId: "eu-prod", routingMode: "pin" });
+  });
+
+  test("seeds a legacy group-less row only when its connection no longer exists in any group", () => {
+    // The connection was genuinely removed — nothing to pin, so defer to seed.
+    expect(
+      resolveConversationScope(
+        { connectionGroupId: null, connectionId: "deleted-conn", routingMode: "pin" },
         groups,
       ),
     ).toEqual({ kind: "seed" });
   });
 
   test("optimistically restores a legacy group-less row (null group) on cold-start", () => {
-    // Same row before groups load: can't validate, so trust it verbatim — the
-    // null group is carried through (asymmetric with the groups-loaded seed
-    // above; locks that the emptiness check requires BOTH ids null, not either).
+    // Same row before groups load: can't locate the owner yet, so trust it
+    // verbatim — the null group is carried through, and the transport sends the
+    // real connectionId so the route still pins correctly. Locks that the
+    // emptiness short-circuit requires BOTH ids null, not either.
     expect(
       resolveConversationScope(
-        { connectionGroupId: null, connectionId: "us-prod", routingMode: "pin" },
+        { connectionGroupId: null, connectionId: "eu-prod", routingMode: "pin" },
         [],
       ),
-    ).toEqual({ kind: "restore", groupId: null, connectionId: "us-prod", routingMode: "pin" });
+    ).toEqual({ kind: "restore", groupId: null, connectionId: "eu-prod", routingMode: "pin" });
   });
 
   test("seeds when a resolved group has no live members (fully archived group)", () => {

--- a/packages/web/src/ui/components/chat/env-picker.tsx
+++ b/packages/web/src/ui/components/chat/env-picker.tsx
@@ -375,7 +375,10 @@ export type ConversationScopeDecision =
  *   - a row pointing at an archived/removed group → sent verbatim and rejected
  *     by the chat route (`invalid_connection_group`).
  * Both fall back to `seed`. An archived *member* under a still-valid group is
- * repaired to the group primary rather than discarding the still-valid group.
+ * repaired to the group primary rather than discarding the still-valid group. A
+ * legacy group-less row (null group, set connection) locates the group that now
+ * owns the connection so the pin is preserved — seeding it would let the effect
+ * send a different non-null member and silently switch environments (Codex).
  *
  * The routing mode is preserved faithfully on a restore: a null `routingMode`
  * stays null because the picker and the agent runtime both read null as "pin"
@@ -401,23 +404,39 @@ export function resolveConversationScope(
     return { kind: "restore", groupId, connectionId, routingMode };
   }
 
-  // Groups loaded: the row's group must still resolve to a visible environment,
-  // else a stale group id reaches the chat route and is rejected.
-  const group = groupId !== null ? groups.find((g) => g.id === groupId) : undefined;
-  if (!group) return { kind: "seed" };
+  // Groups loaded — validate the row against the visible environments.
+  if (groupId !== null) {
+    // The row named a content group: it must still resolve, else a stale group
+    // id reaches the chat route and is rejected (invalid_connection_group).
+    const group = groups.find((g) => g.id === groupId);
+    if (!group) return { kind: "seed" };
 
-  // Group resolves. Keep the pinned member if it's still present; otherwise
-  // repair the execution target to the group primary (never send a stale id),
-  // preserving the still-valid group rather than discarding it.
-  const member = group.members.find((m) => m.connectionId === connectionId);
-  if (member) {
-    return { kind: "restore", groupId: group.id, connectionId: member.connectionId, routingMode };
+    // Group resolves. Keep the pinned member if it's still present; otherwise
+    // repair the execution target to the group primary (never send a stale id),
+    // preserving the still-valid group rather than discarding it.
+    const member = group.members.find((m) => m.connectionId === connectionId);
+    if (member) {
+      return { kind: "restore", groupId: group.id, connectionId: member.connectionId, routingMode };
+    }
+    const repaired =
+      group.members.find((m) => m.connectionId === group.primaryConnectionId) ??
+      group.members[0];
+    if (!repaired) return { kind: "seed" }; // group exists but has no live members
+    return { kind: "restore", groupId: group.id, connectionId: repaired.connectionId, routingMode };
   }
-  const repaired =
-    group.members.find((m) => m.connectionId === group.primaryConnectionId) ??
-    group.members[0];
-  if (!repaired) return { kind: "seed" }; // group exists but has no live members
-  return { kind: "restore", groupId: group.id, connectionId: repaired.connectionId, routingMode };
+
+  // Legacy group-less row (connectionGroupId null, connectionId set, e.g. a
+  // pre-0067 row whose group was never backfilled): locate the group that now
+  // owns the connection so the PIN is preserved. Returning `seed` here would
+  // clear the scope and let the seed/restore effect send the sticky preference /
+  // group primary as a non-null override — silently switching a conversation
+  // pinned to e.g. `eu-prod` onto the default environment (Codex, #3074). Only
+  // seed if the connection no longer exists in any visible group.
+  const owningGroup = groups.find((g) =>
+    g.members.some((m) => m.connectionId === connectionId),
+  );
+  if (!owningGroup) return { kind: "seed" };
+  return { kind: "restore", groupId: owningGroup.id, connectionId, routingMode };
 }
 
 /**


### PR DESCRIPTION
## Summary
Started as test-recovery for #3073, but **Codex's review caught a real regression** in #3073's validator (merged) — so this is now a fix.

A legacy conversation row with `connectionGroupId: null` but a **non-null** `connectionId` (a pre-0067 row whose group was never backfilled) returned `seed` once groups were loaded. `handleSelectConversation` then clears the scope, the seed/restore effect applies the **sticky preference / group primary as a non-null member**, and the transport sends that override — **silently switching a conversation pinned to e.g. `eu-prod` onto the default environment**. My earlier recovery test used the primary `us-prod`, which *masked* the switch (Codex flagged exactly this).

**Fix:** when a row has no group but a live connection, locate the group that now **owns** that connection and restore the pin `{owningGroup, connectionId, mode}`. Only `seed` if the connection no longer exists in any visible group.

- This both preserves the user's pin **and** supplies a valid group, so no `invalid_connection_group`.
- Cold-start (`groups: []`) still restores the row verbatim — the transport sends the real `connectionId`, so the route pins correctly.

## Test plan
- [x] Tests updated to assert the owning-group restore with the **non-primary** `eu-prod` (regression can't be masked by the primary), plus a connection-genuinely-removed → `seed` case. 85 pass / 0 fail.
- [x] `bun run lint` / `bun run type` clean; 171 affected web tests green.

## Provenance
- This is why we wait for the bots: CodeRabbit found nothing and my in-house review agents earlier judged this case "defensible," but Codex correctly identified the silent env-switch. Validates holding merges for bot review.

Refs #3065

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved restoration of previously saved and pinned conversations
  * Enhanced fallback handling when connection information is no longer available or has changed
  * Better support for legacy conversation data formats with refined recovery logic

* **Tests**
  * Expanded test coverage for conversation restoration scenarios and edge cases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->