### PR TITLE
fix(api): add routingMode to ConversationSchema OpenAPI spec (#3071)

### DIFF
--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -1838,6 +1838,18 @@
                               "null"
                             ]
                           },
+                          "routingMode": {
+                            "type": [
+                              "string",
+                              "null"
+                            ],
+                            "enum": [
+                              "auto",
+                              "pin",
+                              "all",
+                              null
+                            ]
+                          },
                           "starred": {
                             "type": "boolean"
                           },
@@ -2104,6 +2116,18 @@
                       "type": [
                         "string",
                         "null"
+                      ]
+                    },
+                    "routingMode": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "enum": [
+                        "auto",
+                        "pin",
+                        "all",
+                        null
                       ]
                     },
                     "starred": {

--- a/packages/api/src/api/routes/conversations.ts
+++ b/packages/api/src/api/routes/conversations.ts
@@ -84,6 +84,14 @@ const ConversationSchema = z.object({
    * conversations created before the multi-environment slice (#2345).
    */
   connectionGroupId: z.string().nullable(),
+  /**
+   * Three-state Auto/Pin/All routing picker state (#2518). `null` on a
+   * persisted row is read as `"pin"` by the runtime. Optional + nullable so
+   * pre-#2518 rows and external SDK consumers need not supply it. Mirrors the
+   * `Conversation` wire type — runtime already serializes this via
+   * `rowToConversation`; the spec was missing it (drift, #3071).
+   */
+  routingMode: z.enum(["auto", "pin", "all"]).nullable().optional(),
   starred: z.boolean(),
   createdAt: z.string().datetime(),
   updatedAt: z.string().datetime(),


### PR DESCRIPTION
## What

`ConversationSchema` in `packages/api/src/api/routes/conversations.ts` documented `connectionId` and `connectionGroupId` but **not** `routingMode`, even though:

- The `Conversation` wire type (`packages/types/src/conversation.ts`) declares `routingMode?: ConversationRoutingMode | null` (added in #2518).
- The runtime loader `rowToConversation` (`packages/api/src/lib/conversations.ts:136`) emits `routingMode`, and the GET `/conversations/{id}` + list routes return it via raw `c.json()`.

So the field **was** in the actual HTTP response but missing from the generated OpenAPI spec (`apps/docs/openapi.json`). SDK consumers generating types from the spec couldn't see `routingMode` on `Conversation`.

## Why now

v0.0.4 S1b (#3065) restores a conversation's scope on open by reading `routingMode` from the GET `/conversations/{id}` response. It works at runtime, but the contract should be honest — and `@hono/zod-openapi` response schemas are doc-only today; if response validation/stripping is ever enabled, the omission would silently drop the field and break scope restore.

## Fix

- Added `routingMode: z.enum(["auto", "pin", "all"]).nullable().optional()` to `ConversationSchema`, mirroring the wire type (placed after `connectionGroupId`, matching the type's field order).
- Regenerated `apps/docs/openapi.json` (`openapi:extract`) and api-reference MDX (`generate:api`). Diff is purely additive: `routingMode` added to the two inlined `ConversationSchema` response bodies (24 insertions). `check-openapi-drift.sh` green.

**No runtime behavior change** — the field was already serialized.

## Verification

- `bun run type` — clean
- 25 affected API tests pass (incl. `api/routes/__tests__/conversations.test.ts`)
- `/ci` — lint, type, test, syncpack, all drift checks, railway-watch, schema-drift — all pass
- `bash scripts/check-openapi-drift.sh` — green post-commit

## Acceptance criteria (#3071)

- [x] `ConversationSchema` includes `routingMode`.
- [x] `openapi.json` regenerated; `check-openapi-drift.sh` green.
- [x] No runtime behavior change (field already serialized).

Closes #3071

Milestone: v0.0.4 — Conversation Scope

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3075"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782917919&installation_id=135337507&pr_number=3075&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3075&signature=4d219a09cf7c536d619d7aeb3bb24f02373a34d21ef550bc8e57c34a00abad33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected API documentation to accurately reflect the `routingMode` parameter support in conversations, which accepts values of "auto", "pin", "all", or null. Documentation now aligns with actual runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->