### PR TITLE
feat(scope): REST datasource exclude-set per conversation (#3066)

### DIFF
--- a/.claude/research/ROADMAP.md
+++ b/.claude/research/ROADMAP.md
@@ -26,10 +26,10 @@ Slices form a near-linear chain (S1a → S1b → S2a → S2b), with S3 + the #30
 
 - [x] S1a — Restore the sticky scope preference on a fresh chat — fixes reset-on-reload ([#3064](https://github.com/AtlasDevHQ/atlas/issues/3064), bug, no deps) — PR #3070
 - [x] S1b — Restore a conversation's scope when it is opened ([#3065](https://github.com/AtlasDevHQ/atlas/issues/3065), bug) — PR #3072 + scope-validation follow-up
-- [ ] S2a — REST scope: exclude datasources from a conversation ([#3066](https://github.com/AtlasDevHQ/atlas/issues/3066), feature, blocked by #3065) ⟵ next
+- [ ] S2a — REST scope: exclude datasources from a conversation ([#3066](https://github.com/AtlasDevHQ/atlas/issues/3066), feature, blocked by #3065) ⟵ in flight (branch `feat/3066-rest-scope-exclude-set`)
 - [ ] S2b — REST-only focus: suspend SQL for a conversation ([#3067](https://github.com/AtlasDevHQ/atlas/issues/3067), feature, blocked by #3066)
 - [ ] S3 — Persist the active conversation in the URL ([#3068](https://github.com/AtlasDevHQ/atlas/issues/3068), refactor, independent — synergizes with #3065)
-- [ ] OpenAPI drift — `ConversationSchema` omits `routingMode` ([#3071](https://github.com/AtlasDevHQ/atlas/issues/3071), bug, independent doc-fix surfaced by S1b)
+- [x] OpenAPI drift — `ConversationSchema` omits `routingMode` ([#3071](https://github.com/AtlasDevHQ/atlas/issues/3071), bug, independent doc-fix surfaced by S1b) — PR #3075
 
 Parent [#3063](https://github.com/AtlasDevHQ/atlas/issues/3063) stays in the Architecture Backlog (left unmodified per `/to-issues`). The **Staging environment** track (below) continues in parallel, independent of the tag train.
 

--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -1857,10 +1857,7 @@
                             ]
                           },
                           "restExcludedDatasourceIds": {
-                            "type": [
-                              "array",
-                              "null"
-                            ],
+                            "type": "array",
                             "items": {
                               "type": "string"
                             }
@@ -2146,10 +2143,7 @@
                       ]
                     },
                     "restExcludedDatasourceIds": {
-                      "type": [
-                        "array",
-                        "null"
-                      ],
+                      "type": "array",
                       "items": {
                         "type": "string"
                       }

--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -99,6 +99,12 @@
                       "all"
                     ]
                   },
+                  "restExcludedDatasourceIds": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
                   "boundDashboardId": {
                     "type": "string",
                     "format": "uuid"
@@ -1850,6 +1856,15 @@
                               null
                             ]
                           },
+                          "restExcludedDatasourceIds": {
+                            "type": [
+                              "array",
+                              "null"
+                            ],
+                            "items": {
+                              "type": "string"
+                            }
+                          },
                           "starred": {
                             "type": "boolean"
                           },
@@ -2129,6 +2144,15 @@
                         "all",
                         null
                       ]
+                    },
+                    "restExcludedDatasourceIds": {
+                      "type": [
+                        "array",
+                        "null"
+                      ],
+                      "items": {
+                        "type": "string"
+                      }
                     },
                     "starred": {
                       "type": "boolean"

--- a/packages/api/src/__mocks__/api-test-mocks.ts
+++ b/packages/api/src/__mocks__/api-test-mocks.ts
@@ -613,6 +613,11 @@ export function createApiTestMocks(
     // exercise the picker toggle path, and they override locally when
     // they do.
     updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
+    // #3066 — per-conversation REST exclude-set write path. Same no-op
+    // success default as the routing-mode write: chat-route tests don't
+    // persist the row unless they exercise the scope-picker toggle, and
+    // they override locally when they do.
+    updateConversationRestExcluded: mock(() => Promise.resolve({ ok: true as const })),
     // NULL → "pin" back-compat default helper used by the chat route to
     // resolve a conversation's persisted `routing_mode`. Mocked as a pure
     // pass-through so tests can simulate either an explicit mode or the

--- a/packages/api/src/api/__tests__/actions.test.ts
+++ b/packages/api/src/api/__tests__/actions.test.ts
@@ -138,6 +138,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   resolveGroupForConnection: mock(() => Promise.resolve(null)),
   verifyGroupBelongsToOrg: mock(() => Promise.resolve("ok")),
   updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
+  updateConversationRestExcluded: mock(() => Promise.resolve({ ok: true as const })),
   resolveRoutingMode: mock((m: "auto" | "pin" | "all" | null | undefined = null) => m ?? "pin"),
 }));
 

--- a/packages/api/src/api/__tests__/admin-email-provider-route.test.ts
+++ b/packages/api/src/api/__tests__/admin-email-provider-route.test.ts
@@ -312,6 +312,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   resolveGroupForConnection: mock(() => Promise.resolve(null)),
   verifyGroupBelongsToOrg: mock(() => Promise.resolve("ok")),
   updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
+  updateConversationRestExcluded: mock(() => Promise.resolve({ ok: true as const })),
   resolveRoutingMode: mock((m: "auto" | "pin" | "all" | null | undefined = null) => m ?? "pin"),
 }));
 

--- a/packages/api/src/api/__tests__/admin-integrations-byot.test.ts
+++ b/packages/api/src/api/__tests__/admin-integrations-byot.test.ts
@@ -368,6 +368,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   resolveGroupForConnection: mock(() => Promise.resolve(null)),
   verifyGroupBelongsToOrg: mock(() => Promise.resolve("ok")),
   updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
+  updateConversationRestExcluded: mock(() => Promise.resolve({ ok: true as const })),
   resolveRoutingMode: mock((m: "auto" | "pin" | "all" | null | undefined = null) => m ?? "pin"),
 }));
 

--- a/packages/api/src/api/__tests__/admin-integrations.test.ts
+++ b/packages/api/src/api/__tests__/admin-integrations.test.ts
@@ -292,6 +292,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   resolveGroupForConnection: mock(() => Promise.resolve(null)),
   verifyGroupBelongsToOrg: mock(() => Promise.resolve("ok")),
   updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
+  updateConversationRestExcluded: mock(() => Promise.resolve({ ok: true as const })),
   resolveRoutingMode: mock((m: "auto" | "pin" | "all" | null | undefined = null) => m ?? "pin"),
 }));
 

--- a/packages/api/src/api/__tests__/admin-password.test.ts
+++ b/packages/api/src/api/__tests__/admin-password.test.ts
@@ -226,6 +226,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   resolveGroupForConnection: mock(() => Promise.resolve(null)),
   verifyGroupBelongsToOrg: mock(() => Promise.resolve("ok")),
   updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
+  updateConversationRestExcluded: mock(() => Promise.resolve({ ok: true as const })),
   resolveRoutingMode: mock((m: "auto" | "pin" | "all" | null | undefined = null) => m ?? "pin"),
 }));
 

--- a/packages/api/src/api/__tests__/admin.test.ts
+++ b/packages/api/src/api/__tests__/admin.test.ts
@@ -583,6 +583,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   resolveGroupForConnection: mock(() => Promise.resolve(null)),
   verifyGroupBelongsToOrg: mock(() => Promise.resolve("ok")),
   updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
+  updateConversationRestExcluded: mock(() => Promise.resolve({ ok: true as const })),
   resolveRoutingMode: mock((m: "auto" | "pin" | "all" | null | undefined = null) => m ?? "pin"),
 }));
 

--- a/packages/api/src/api/__tests__/chat.test.ts
+++ b/packages/api/src/api/__tests__/chat.test.ts
@@ -538,6 +538,37 @@ describe("POST /api/v1/chat", () => {
     expect(mockUpdateConversationRestExcluded).not.toHaveBeenCalled();
   });
 
+  // #3066 — the `sameStringSet` gate: a body that sends a non-empty set EQUAL
+  // to the stored set (here reordered) must NOT burn an UPDATE. A regression to
+  // order-sensitive (e.g. JSON.stringify) comparison would bump `updated_at`
+  // and reshuffle the conversation list on every turn.
+  it("skips the UPDATE when the body's exclude-set equals the stored set (reordered) (#3066)", async () => {
+    const convId = "d4e5f6a7-b8c9-4def-89ab-cdef01234567";
+    mockGetConversationChat.mockResolvedValueOnce({
+      ok: true,
+      data: {
+        id: convId,
+        userId: null,
+        title: "Test",
+        connectionId: null,
+        connectionGroupId: null,
+        routingMode: null,
+        restExcludedDatasourceIds: ["ds-1", "ds-2"],
+        messages: [],
+      },
+    });
+    const response = await app.fetch(
+      makeRequest({
+        messages: [{ id: "1", role: "user", parts: [{ type: "text", text: "same set" }] }],
+        conversationId: convId,
+        // Same set, different order — set-equality must treat it as unchanged.
+        restExcludedDatasourceIds: ["ds-2", "ds-1"],
+      }),
+    );
+    expect(response.status).toBe(200);
+    expect(mockUpdateConversationRestExcluded).not.toHaveBeenCalled();
+  });
+
   // F-74 regression pin: the chat handler MUST pass `bucket: "chat"` so the
   // request lands in the chat-scoped sliding window. Without this option a
   // 25-step agent run drains the same allowance that serves cheap admin

--- a/packages/api/src/api/__tests__/chat.test.ts
+++ b/packages/api/src/api/__tests__/chat.test.ts
@@ -124,6 +124,11 @@ const mockCreateConversation = mock((): Promise<{ id: string } | null> =>
 const mockAddMessage = mock(() => {});
 const mockGetConversationChat = mock((): Promise<{ ok: boolean; reason?: string; data?: unknown }> => Promise.resolve({ ok: false, reason: "not_found" }));
 const mockGenerateTitle = mock((q: string) => q.slice(0, 80));
+// #3066 — captured so tests can assert the REST exclude-set persist path
+// (incl. the re-include `[]` case, the #3073 transport-omits-null bug class).
+const mockUpdateConversationRestExcluded = mock(() =>
+  Promise.resolve({ ok: true as const }),
+);
 type ReservationResult =
   | { status: "ok"; totalStepsBefore: number }
   | { status: "exceeded"; totalSteps: number }
@@ -164,6 +169,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   resolveGroupForConnection: mock(() => Promise.resolve(null)),
   verifyGroupBelongsToOrg: mockVerifyGroupBelongsToOrg,
   updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
+  updateConversationRestExcluded: mockUpdateConversationRestExcluded,
   resolveRoutingMode: mock((m: "auto" | "pin" | "all" | null | undefined = null) => m ?? "pin"),
 }));
 
@@ -250,6 +256,8 @@ describe("POST /api/v1/chat", () => {
     mockAddMessage.mockReset();
     mockGetConversationChat.mockReset();
     mockGetConversationChat.mockResolvedValue({ ok: false, reason: "not_found" });
+    mockUpdateConversationRestExcluded.mockReset();
+    mockUpdateConversationRestExcluded.mockResolvedValue({ ok: true as const });
     mockReserveConversationBudget.mockReset();
     mockReserveConversationBudget.mockResolvedValue({ status: "ok", totalStepsBefore: 0 });
     mockSettleConversationSteps.mockReset();
@@ -402,6 +410,132 @@ describe("POST /api/v1/chat", () => {
     const response = await app.fetch(makeRequest()); // No routingMode in body
     expect(response.status).toBe(200);
     expect(capturedContext?.routingMode).toBe("pin");
+  });
+
+  // #3066 — the conversation's REST exclude-set must reach the agent via the
+  // ALS frame so the REST datasource resolver (agent.ts) drops the excluded
+  // installs before the prompt + the bound executeRestOperation tool see them.
+  it("propagates restExcludedDatasourceIds into the ALS frame the agent sees (#3066)", async () => {
+    const { getRequestContext } = await import("@atlas/api/lib/logger");
+    let capturedContext: ReturnType<typeof getRequestContext> | undefined;
+    mockRunAgent.mockImplementationOnce(() => {
+      capturedContext = getRequestContext();
+      return Promise.resolve({
+        toUIMessageStreamResponse: () => new Response("stream", { status: 200 }),
+        toUIMessageStream: () => new ReadableStream({ start(c) { c.close(); } }),
+        text: Promise.resolve("answer"),
+      } as unknown as Awaited<ReturnType<typeof mockRunAgent>>);
+    });
+    const response = await app.fetch(
+      makeRequest({
+        messages: [{ id: "1", role: "user", parts: [{ type: "text", text: "hi" }] }],
+        restExcludedDatasourceIds: ["ds-excluded-1"],
+      }),
+    );
+    expect(response.status).toBe(200);
+    expect(capturedContext?.restExcludedDatasourceIds).toEqual(["ds-excluded-1"]);
+  });
+
+  // #3066 — an empty exclude-set excludes nothing, so it must NOT be stamped
+  // on the ALS frame (the resolver's `undefined` = "no exclusions" path). This
+  // keeps the legacy "every in-scope datasource queryable" shape for the
+  // common case where the user never touched the scope picker.
+  it("strips an empty restExcludedDatasourceIds from the ALS frame (empty = exclude nothing) (#3066)", async () => {
+    const { getRequestContext } = await import("@atlas/api/lib/logger");
+    let capturedContext: ReturnType<typeof getRequestContext> | undefined;
+    mockRunAgent.mockImplementationOnce(() => {
+      capturedContext = getRequestContext();
+      return Promise.resolve({
+        toUIMessageStreamResponse: () => new Response("stream", { status: 200 }),
+        toUIMessageStream: () => new ReadableStream({ start(c) { c.close(); } }),
+        text: Promise.resolve("answer"),
+      } as unknown as Awaited<ReturnType<typeof mockRunAgent>>);
+    });
+    const response = await app.fetch(
+      makeRequest({
+        messages: [{ id: "1", role: "user", parts: [{ type: "text", text: "hi" }] }],
+        restExcludedDatasourceIds: [],
+      }),
+    );
+    expect(response.status).toBe(200);
+    expect(capturedContext?.restExcludedDatasourceIds).toBeUndefined();
+  });
+
+  // #3066 / #3073 — the re-include path. An existing conversation already
+  // excludes ds-1; the user re-includes it, so the body carries `[]`. Because
+  // the web transport drops null/undefined fields, the route distinguishes
+  // "field present as []" (persist the cleared set) from "field absent"
+  // (inherit the row). This pins the present-`[]` branch — without it a
+  // re-include silently keeps the stale exclusion.
+  it("persists a re-include ([] clears a prior non-empty exclusion) (#3066/#3073)", async () => {
+    const convId = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
+    mockGetConversationChat.mockResolvedValueOnce({
+      ok: true,
+      data: {
+        id: convId,
+        userId: null,
+        title: "Test",
+        connectionId: null,
+        connectionGroupId: null,
+        routingMode: null,
+        restExcludedDatasourceIds: ["ds-1"],
+        messages: [],
+      },
+    });
+    const response = await app.fetch(
+      makeRequest({
+        messages: [{ id: "1", role: "user", parts: [{ type: "text", text: "re-include" }] }],
+        conversationId: convId,
+        restExcludedDatasourceIds: [],
+      }),
+    );
+    expect(response.status).toBe(200);
+    expect(mockUpdateConversationRestExcluded).toHaveBeenCalledTimes(1);
+    const calls = mockUpdateConversationRestExcluded.mock.calls as unknown as unknown[][];
+    // Second arg is the new (now-empty) set persisted to the row.
+    expect(calls[0]![1]).toEqual([]);
+  });
+
+  // #3066 — when the body OMITS the exclude-set (the common follow-up turn),
+  // the stored set is inherited and NO redundant UPDATE fires (sameStringSet
+  // gate). This is the counterpart to the re-include test above.
+  it("inherits the stored exclude-set and skips the UPDATE when the body omits it (#3066)", async () => {
+    const convId = "b2c3d4e5-f6a7-8901-bcde-f12345678901";
+    mockGetConversationChat.mockResolvedValueOnce({
+      ok: true,
+      data: {
+        id: convId,
+        userId: null,
+        title: "Test",
+        connectionId: null,
+        connectionGroupId: null,
+        routingMode: null,
+        restExcludedDatasourceIds: ["ds-1"],
+        messages: [],
+      },
+    });
+    const { getRequestContext } = await import("@atlas/api/lib/logger");
+    let capturedContext: ReturnType<typeof getRequestContext> | undefined;
+    mockRunAgent.mockImplementationOnce(() => {
+      capturedContext = getRequestContext();
+      return Promise.resolve({
+        toUIMessageStreamResponse: () => new Response("stream", { status: 200 }),
+        toUIMessageStream: () => new ReadableStream({ start(c) { c.close(); } }),
+        text: Promise.resolve("answer"),
+      } as unknown as Awaited<ReturnType<typeof mockRunAgent>>);
+    });
+    const response = await app.fetch(
+      makeRequest({
+        messages: [{ id: "1", role: "user", parts: [{ type: "text", text: "follow up" }] }],
+        conversationId: convId,
+        // restExcludedDatasourceIds intentionally omitted
+      }),
+    );
+    expect(response.status).toBe(200);
+    // Inherited the stored set into the ALS frame…
+    expect(capturedContext?.restExcludedDatasourceIds).toEqual(["ds-1"]);
+    // …and did NOT burn an UPDATE (body matched the stored set / was absent).
+    expect(mockUpdateConversationRestExcluded).not.toHaveBeenCalled();
   });
 
   // F-74 regression pin: the chat handler MUST pass `bucket: "chat"` so the

--- a/packages/api/src/api/__tests__/conversations.test.ts
+++ b/packages/api/src/api/__tests__/conversations.test.ts
@@ -148,6 +148,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   // success — tests that exercise the picker write path override
   // locally.
   updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
+  updateConversationRestExcluded: mock(() => Promise.resolve({ ok: true as const })),
   resolveRoutingMode: mock((m: "auto" | "pin" | "all" | null | undefined = null) => m ?? "pin"),
   // Type exports (no runtime value — needed so mock.module doesn't break re-exports)
 }));

--- a/packages/api/src/api/__tests__/dashboards.test.ts
+++ b/packages/api/src/api/__tests__/dashboards.test.ts
@@ -298,6 +298,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   resolveGroupForConnection: mock(() => Promise.resolve(null)),
   verifyGroupBelongsToOrg: mockVerifyGroupBelongsToOrg,
   updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
+  updateConversationRestExcluded: mock(() => Promise.resolve({ ok: true as const })),
   resolveRoutingMode: mock((m: "auto" | "pin" | "all" | null | undefined = null) => m ?? "pin"),
 }));
 

--- a/packages/api/src/api/__tests__/health-plugin.test.ts
+++ b/packages/api/src/api/__tests__/health-plugin.test.ts
@@ -130,6 +130,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   resolveGroupForConnection: mock(() => Promise.resolve(null)),
   verifyGroupBelongsToOrg: mock(() => Promise.resolve("ok")),
   updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
+  updateConversationRestExcluded: mock(() => Promise.resolve({ ok: true as const })),
   resolveRoutingMode: mock((m: "auto" | "pin" | "all" | null | undefined = null) => m ?? "pin"),
 }));
 

--- a/packages/api/src/api/__tests__/health.test.ts
+++ b/packages/api/src/api/__tests__/health.test.ts
@@ -135,6 +135,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   resolveGroupForConnection: mock(() => Promise.resolve(null)),
   verifyGroupBelongsToOrg: mock(() => Promise.resolve("ok")),
   updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
+  updateConversationRestExcluded: mock(() => Promise.resolve({ ok: true as const })),
   resolveRoutingMode: mock((m: "auto" | "pin" | "all" | null | undefined = null) => m ?? "pin"),
 }));
 

--- a/packages/api/src/api/__tests__/query.test.ts
+++ b/packages/api/src/api/__tests__/query.test.ts
@@ -159,6 +159,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   resolveGroupForConnection: mock(() => Promise.resolve(null)),
   verifyGroupBelongsToOrg: mock(() => Promise.resolve("ok")),
   updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
+  updateConversationRestExcluded: mock(() => Promise.resolve({ ok: true as const })),
   resolveRoutingMode: mock((m: "auto" | "pin" | "all" | null | undefined = null) => m ?? "pin"),
 }));
 

--- a/packages/api/src/api/__tests__/scheduled-tasks.test.ts
+++ b/packages/api/src/api/__tests__/scheduled-tasks.test.ts
@@ -121,6 +121,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   resolveGroupForConnection: mock(() => Promise.resolve(null)),
   verifyGroupBelongsToOrg: mock(() => Promise.resolve("ok")),
   updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
+  updateConversationRestExcluded: mock(() => Promise.resolve({ ok: true as const })),
   resolveRoutingMode: mock((m: "auto" | "pin" | "all" | null | undefined = null) => m ?? "pin"),
 }));
 

--- a/packages/api/src/api/__tests__/semantic-overlay.test.ts
+++ b/packages/api/src/api/__tests__/semantic-overlay.test.ts
@@ -346,6 +346,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   resolveGroupForConnection: mock(() => Promise.resolve(null)),
   verifyGroupBelongsToOrg: mock(() => Promise.resolve("ok")),
   updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
+  updateConversationRestExcluded: mock(() => Promise.resolve({ ok: true as const })),
   resolveRoutingMode: mock((m: "auto" | "pin" | "all" | null | undefined = null) => m ?? "pin"),
 }));
 

--- a/packages/api/src/api/__tests__/semantic.test.ts
+++ b/packages/api/src/api/__tests__/semantic.test.ts
@@ -276,6 +276,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   resolveGroupForConnection: mock(() => Promise.resolve(null)),
   verifyGroupBelongsToOrg: mock(() => Promise.resolve("ok")),
   updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
+  updateConversationRestExcluded: mock(() => Promise.resolve({ ok: true as const })),
   resolveRoutingMode: mock((m: "auto" | "pin" | "all" | null | undefined = null) => m ?? "pin"),
 }));
 

--- a/packages/api/src/api/routes/__tests__/rest-operations.test.ts
+++ b/packages/api/src/api/routes/__tests__/rest-operations.test.ts
@@ -210,6 +210,33 @@ describe("POST /rest-operations/confirm", () => {
     expect(req?.headers["authorization"]).toBe("Bearer confirm-token");
   });
 
+  it("#3066 — replay resolves the FULL set: the resolver is called with only orgId (no exclude-set)", async () => {
+    // The confirm-replay path must IGNORE the conversation's REST exclude-set —
+    // a user-confirmed staged write replays regardless of read-side scope.
+    // Structurally that holds because the route calls resolveDatasources(orgId)
+    // with NO second (deps/excluded) argument. A future refactor that threads
+    // the request-context exclude-set into this call would pass a 2nd arg and
+    // trip this guard — the exact silent-regression the contract risks.
+    let callArgCount = -1;
+    const spyResolver = (async (...args: unknown[]) => {
+      callArgCount = args.length;
+      return args[0] === "ws-1"
+        ? [datasource({ writeAllowlist: new Set(["createOnePerson"]) })]
+        : [];
+    }) as (workspaceId: string) => Promise<RestDatasource[]>;
+    const app = appWithResolver(spyResolver);
+    const res = await post(
+      app,
+      confirmBody({
+        datasourceId: "twenty",
+        operationId: "createOnePerson",
+        body: { name: { firstName: "Ada" } },
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect(callArgCount).toBe(1);
+  });
+
   it("forwards the datasource quirk so required headers ride the confirmed write (#3029)", async () => {
     // A data-candidate (e.g. Notion) carries a declarative quirk — required static
     // headers / query shaping — applied via the client's header/query seams. The

--- a/packages/api/src/api/routes/chat.ts
+++ b/packages/api/src/api/routes/chat.ts
@@ -408,8 +408,15 @@ export const ChatRequestSchema = z.object({
    * body fields, so the client must send the array (even `[]`) whenever
    * the picker was touched — otherwise a re-include silently keeps the
    * stale exclusion (the #3073 transport-omits-null bug class).
+   *
+   * Normalized to a canonical set at validation (`[...new Set(ids)]`) so the
+   * persisted value can't carry duplicates for a set-shaped contract; `undefined`
+   * (omitted) is preserved so the inherit-vs-clear branch still works.
    */
-  restExcludedDatasourceIds: z.array(z.string()).optional(),
+  restExcludedDatasourceIds: z
+    .array(z.string())
+    .transform((ids) => [...new Set(ids)])
+    .optional(),
   /**
    * #2363 — bound dashboard editor. When the chat drawer opens on
    * `/dashboards/[id]` the client supplies the dashboard id once (on

--- a/packages/api/src/api/routes/chat.ts
+++ b/packages/api/src/api/routes/chat.ts
@@ -42,6 +42,7 @@ import {
   resolveGroupForConnection,
   settleConversationSteps,
   updateConversationRoutingMode,
+  updateConversationRestExcluded,
   resolveRoutingMode,
 } from "@atlas/api/lib/conversations";
 import type { ConversationRoutingMode } from "@useatlas/types/conversation";
@@ -68,6 +69,21 @@ const DEFAULT_AGENT_MAX_STEPS = 25;
  * 0 ("disabled") when the setting is `0`, an empty string, or invalid —
  * any non-positive integer disables the cap. F-77.
  */
+/**
+ * #3066 — order-independent equality for two string sets. Used to decide
+ * whether the body's REST exclude-set differs from the conversation's
+ * stored set before burning an UPDATE. Duplicates collapse (a set, not a
+ * list), so `["a","a"]` and `["a"]` compare equal — which is correct for
+ * an exclude-set keyed on `install_id`.
+ */
+function sameStringSet(a: readonly string[], b: readonly string[]): boolean {
+  const setA = new Set(a);
+  const setB = new Set(b);
+  if (setA.size !== setB.size) return false;
+  for (const v of setA) if (!setB.has(v)) return false;
+  return true;
+}
+
 function getConversationStepCap(): number {
   const raw = getSetting("ATLAS_CONVERSATION_STEP_CAP");
   if (raw === undefined) return DEFAULT_CONVERSATION_STEP_CAP;
@@ -379,6 +395,21 @@ export const ChatRequestSchema = z.object({
    * migration 0077).
    */
   routingMode: z.enum(["auto", "pin", "all"]).optional(),
+  /**
+   * #3066 — per-conversation REST datasource exclude-set. The scope
+   * picker sends the excluded `install_id`s; the route persists them
+   * onto the conversation row AND stamps them into the request context
+   * so the REST resolver drops them for this turn. SQL routing is
+   * unaffected.
+   *
+   * Presence is meaningful: an explicitly-sent `[]` clears any prior
+   * exclusion (re-includes everything), whereas an OMITTED field inherits
+   * the conversation's stored set. The web transport drops null/undefined
+   * body fields, so the client must send the array (even `[]`) whenever
+   * the picker was touched — otherwise a re-include silently keeps the
+   * stale exclusion (the #3073 transport-omits-null bug class).
+   */
+  restExcludedDatasourceIds: z.array(z.string()).optional(),
   /**
    * #2363 — bound dashboard editor. When the chat drawer opens on
    * `/dashboards/[id]` the client supplies the dashboard id once (on
@@ -773,6 +804,14 @@ chat.openapi(chatRoute, async (c) => {
         // The runtime treats undefined here as 'pin' to preserve
         // pre-#2518 single-execution semantics for legacy conversations.
         let effectiveRoutingMode: ConversationRoutingMode | undefined = parsed.data.routingMode;
+        // #3066 — per-conversation REST exclude-set. Body value (this
+        // turn, from the scope picker) > stored value on the row.
+        // PRESENCE is meaningful: an explicit `[]` re-includes everything,
+        // an OMITTED field inherits the row's set. We keep `undefined` vs
+        // `[]` distinct all the way through so a re-include actually clears
+        // the row (the transport-omits-null bug class, #3073).
+        let effectiveRestExcluded: string[] | undefined =
+          parsed.data.restExcludedDatasourceIds;
 
         // #2424 — when the body supplies `connectionGroupId`, verify it
         // belongs to the caller's active org BEFORE persisting it onto the
@@ -845,6 +884,16 @@ chat.openapi(chatRoute, async (c) => {
             if (effectiveRoutingMode === undefined && existing.data.routingMode) {
               effectiveRoutingMode = existing.data.routingMode;
             }
+            // #3066 — inherit the exclude-set from the row when the body
+            // omits it. An explicit `[]` from the body is NOT omitted (it
+            // re-includes everything), so the `=== undefined` guard keeps
+            // that distinct from "field absent → use the row".
+            if (
+              effectiveRestExcluded === undefined &&
+              Array.isArray(existing.data.restExcludedDatasourceIds)
+            ) {
+              effectiveRestExcluded = existing.data.restExcludedDatasourceIds;
+            }
             // Persist the picker mode if the body explicitly set one for
             // this turn. We compare against the stored value to avoid
             // burning an UPDATE on every chat turn when nothing changed.
@@ -868,6 +917,36 @@ chat.openapi(chatRoute, async (c) => {
                     conversationId,
                   },
                   "updateConversationRoutingMode rejected",
+                );
+              });
+            }
+            // #3066 — persist the exclude-set when the body explicitly set
+            // one this turn AND it differs from the stored set. Set-equality
+            // is order-independent so a reorder doesn't burn an UPDATE; an
+            // explicit `[]` that clears a prior non-empty set DOES persist
+            // (that's the re-include path the transport must support).
+            if (
+              parsed.data.restExcludedDatasourceIds !== undefined &&
+              !sameStringSet(
+                parsed.data.restExcludedDatasourceIds,
+                existing.data.restExcludedDatasourceIds ?? [],
+              )
+            ) {
+              // Fire-and-forget, same contract as routing-mode above: the
+              // runtime honours the body's set for this turn even if the
+              // persist fails; the helper logs its own failures.
+              updateConversationRestExcluded(
+                conversationId,
+                parsed.data.restExcludedDatasourceIds,
+                authResult.user?.id,
+                authResult.user?.activeOrganizationId,
+              ).catch((err: unknown) => {
+                log.warn(
+                  {
+                    err: err instanceof Error ? err.message : String(err),
+                    conversationId,
+                  },
+                  "updateConversationRestExcluded rejected",
                 );
               });
             }
@@ -979,6 +1058,9 @@ chat.openapi(chatRoute, async (c) => {
                 // for back-compat, so omitting this on legacy callers
                 // is structurally safe.
                 routingMode: effectiveRoutingMode ?? null,
+                // #3066 — persist the exclude-set the user picked at
+                // creation. Undefined ⇒ column default '{}' (all in scope).
+                restExcludedDatasourceIds: effectiveRestExcluded,
                 orgId: authResult.user?.activeOrganizationId,
               });
               if (created) {
@@ -1215,6 +1297,14 @@ chat.openapi(chatRoute, async (c) => {
               // kicks in for non-chat callers (MCP / scheduler / direct
               // tool tests).
               routingMode: resolveRoutingMode(effectiveRoutingMode),
+              // #3066 — the resolved exclude-set reaches the REST datasource
+              // resolver (agent.ts) via the request context. Stripped when
+              // undefined (and when empty — an empty set excludes nothing,
+              // so omitting it keeps the legacy "no exclusions" shape).
+              ...(effectiveRestExcluded !== undefined &&
+                effectiveRestExcluded.length > 0 && {
+                  restExcludedDatasourceIds: effectiveRestExcluded,
+                }),
             },
             () =>
               runAgent({

--- a/packages/api/src/api/routes/chat.ts
+++ b/packages/api/src/api/routes/chat.ts
@@ -69,6 +69,15 @@ const DEFAULT_AGENT_MAX_STEPS = 25;
  * 0 ("disabled") when the setting is `0`, an empty string, or invalid —
  * any non-positive integer disables the cap. F-77.
  */
+function getConversationStepCap(): number {
+  const raw = getSetting("ATLAS_CONVERSATION_STEP_CAP");
+  if (raw === undefined) return DEFAULT_CONVERSATION_STEP_CAP;
+  if (raw === "") return 0;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n < 0) return DEFAULT_CONVERSATION_STEP_CAP;
+  return Math.floor(n);
+}
+
 /**
  * #3066 — order-independent equality for two string sets. Used to decide
  * whether the body's REST exclude-set differs from the conversation's
@@ -82,15 +91,6 @@ function sameStringSet(a: readonly string[], b: readonly string[]): boolean {
   if (setA.size !== setB.size) return false;
   for (const v of setA) if (!setB.has(v)) return false;
   return true;
-}
-
-function getConversationStepCap(): number {
-  const raw = getSetting("ATLAS_CONVERSATION_STEP_CAP");
-  if (raw === undefined) return DEFAULT_CONVERSATION_STEP_CAP;
-  if (raw === "") return 0;
-  const n = Number(raw);
-  if (!Number.isFinite(n) || n < 0) return DEFAULT_CONVERSATION_STEP_CAP;
-  return Math.floor(n);
 }
 
 /**

--- a/packages/api/src/api/routes/conversations.ts
+++ b/packages/api/src/api/routes/conversations.ts
@@ -92,6 +92,15 @@ const ConversationSchema = z.object({
    * `rowToConversation`; the spec was missing it (drift, #3071).
    */
   routingMode: z.enum(["auto", "pin", "all"]).nullable().optional(),
+  /**
+   * Per-conversation REST datasource exclude-set (#3066). Excluded
+   * `install_id`s the agent must NOT query for this conversation. Empty
+   * (`[]`, the column default) = every in-scope REST datasource is
+   * queryable. Optional + nullable so pre-#3066 rows and external SDK
+   * consumers need not supply it. Mirrors the `Conversation` wire type;
+   * the runtime serializes it via `rowToConversation`.
+   */
+  restExcludedDatasourceIds: z.array(z.string()).nullable().optional(),
   starred: z.boolean(),
   createdAt: z.string().datetime(),
   updatedAt: z.string().datetime(),

--- a/packages/api/src/api/routes/conversations.ts
+++ b/packages/api/src/api/routes/conversations.ts
@@ -96,11 +96,12 @@ const ConversationSchema = z.object({
    * Per-conversation REST datasource exclude-set (#3066). Excluded
    * `install_id`s the agent must NOT query for this conversation. Empty
    * (`[]`, the column default) = every in-scope REST datasource is
-   * queryable. Optional + nullable so pre-#3066 rows and external SDK
-   * consumers need not supply it. Mirrors the `Conversation` wire type;
-   * the runtime serializes it via `rowToConversation`.
+   * queryable. Optional (NOT nullable) — the column is `NOT NULL DEFAULT
+   * '{}'` and `rowToConversation` always serializes a `string[]` (or `[]`),
+   * so the response is never null (unlike the genuinely-nullable
+   * `routingMode`). Mirrors the `Conversation` wire type.
    */
-  restExcludedDatasourceIds: z.array(z.string()).nullable().optional(),
+  restExcludedDatasourceIds: z.array(z.string()).optional(),
   starred: z.boolean(),
   createdAt: z.string().datetime(),
   updatedAt: z.string().datetime(),

--- a/packages/api/src/lib/__tests__/conversations.test.ts
+++ b/packages/api/src/lib/__tests__/conversations.test.ts
@@ -133,7 +133,7 @@ describe("conversations module", () => {
       expect(result).toEqual({ id: "conv-123" });
       expect(queryCalls[0].sql).toContain("INSERT INTO conversations");
       // [user_id, title, surface, connection_id, connection_group_id, routing_mode, org_id]
-      expect(queryCalls[0].params).toEqual(["u1", "Test", "web", null, null, null, null]);
+      expect(queryCalls[0].params).toEqual(["u1", "Test", "web", null, null, null, [], null]);
     });
 
     it("returns null when no DB", async () => {
@@ -154,7 +154,7 @@ describe("conversations module", () => {
       setResults({ rows: [{ id: "conv-456" }] });
 
       await createConversation({});
-      expect(queryCalls[0].params).toEqual([null, null, "web", null, null, null, null]);
+      expect(queryCalls[0].params).toEqual([null, null, "web", null, null, null, [], null]);
     });
 
     it("accepts custom surface and connectionId", async () => {
@@ -162,7 +162,7 @@ describe("conversations module", () => {
       setResults({ rows: [{ id: "conv-789" }] });
 
       await createConversation({ surface: "api", connectionId: "wh" });
-      expect(queryCalls[0].params).toEqual([null, null, "api", "wh", null, null, null]);
+      expect(queryCalls[0].params).toEqual([null, null, "api", "wh", null, null, [], null]);
     });
 
     it("includes orgId when provided", async () => {
@@ -171,7 +171,7 @@ describe("conversations module", () => {
 
       const result = await createConversation({ userId: "u1", orgId: "org-123" });
       expect(result).toEqual({ id: "conv-org" });
-      expect(queryCalls[0].params).toEqual(["u1", null, "web", null, null, null, "org-123"]);
+      expect(queryCalls[0].params).toEqual(["u1", null, "web", null, null, null, [], "org-123"]);
     });
 
     // #2345 — group-aware routing. Both columns are independent;
@@ -194,6 +194,7 @@ describe("conversations module", () => {
         "us-int",
         "g_prod",
         null,
+        [],
         "org-1",
       ]);
     });
@@ -218,6 +219,7 @@ describe("conversations module", () => {
         null,
         "g_prod",
         null,
+        [],
         "org-1",
       ]);
     });
@@ -1460,7 +1462,7 @@ describe("conversations module", () => {
         orgId: "org-B",
       });
       expect(result).toEqual({ ok: false, reason: "not_found" });
-      expect(queryCalls[0].sql).toContain("SELECT id, title, surface, connection_id, connection_group_id, routing_mode, org_id");
+      expect(queryCalls[0].sql).toContain("SELECT id, title, surface, connection_id, connection_group_id, routing_mode, rest_excluded_datasource_ids, org_id");
       expect(queryCalls[0].sql).toContain("(org_id = $3 OR org_id IS NULL)");
       expect(queryCalls[0].params).toEqual(["src-c1", "u1", "org-B"]);
     });
@@ -1475,7 +1477,7 @@ describe("conversations module", () => {
         orgId: "org-B",
       });
       expect(result).toEqual({ ok: false, reason: "not_found" });
-      expect(queryCalls[0].sql).toContain("SELECT id, title, surface, connection_id, connection_group_id, routing_mode, org_id");
+      expect(queryCalls[0].sql).toContain("SELECT id, title, surface, connection_id, connection_group_id, routing_mode, rest_excluded_datasource_ids, org_id");
       expect(queryCalls[0].sql).toContain("(org_id = $3 OR org_id IS NULL)");
       expect(queryCalls[0].params).toEqual(["src-c1", "u1", "org-B"]);
     });

--- a/packages/api/src/lib/__tests__/conversations.test.ts
+++ b/packages/api/src/lib/__tests__/conversations.test.ts
@@ -133,7 +133,7 @@ describe("conversations module", () => {
       const result = await createConversation({ userId: "u1", title: "Test" });
       expect(result).toEqual({ id: "conv-123" });
       expect(queryCalls[0].sql).toContain("INSERT INTO conversations");
-      // [user_id, title, surface, connection_id, connection_group_id, routing_mode, org_id]
+      // [user_id, title, surface, connection_id, connection_group_id, routing_mode, rest_excluded_datasource_ids, org_id]
       expect(queryCalls[0].params).toEqual(["u1", "Test", "web", null, null, null, [], null]);
     });
 

--- a/packages/api/src/lib/__tests__/conversations.test.ts
+++ b/packages/api/src/lib/__tests__/conversations.test.ts
@@ -24,6 +24,7 @@ import {
   renameBranch,
   forkConversation,
   convertToNotebook,
+  updateConversationRestExcluded,
 } from "../conversations";
 
 // ---------------------------------------------------------------------------
@@ -1366,6 +1367,36 @@ describe("conversations module", () => {
       expect(queryCalls[0].sql).toContain("(org_id = $4 OR org_id IS NULL)");
       expect(queryCalls[0].params?.[2]).toBe("u1");
       expect(queryCalls[0].params?.[3]).toBe("org-B");
+    });
+
+    // #3066 — the REST exclude-set write helper. Binds the JS array directly to
+    // the text[] column ($1), org/user-scopes the UPDATE, and returns the same
+    // fail-soft result contract as updateConversationRoutingMode.
+    it("updateConversationRestExcluded writes the array, scoped + parameterized", async () => {
+      enableInternalDB();
+      setResults({ rows: [{ id: "c1" }] });
+
+      const result = await updateConversationRestExcluded("c1", ["ds-1", "ds-2"], "u1", "org-B");
+      expect(result).toEqual({ ok: true });
+      expect(queryCalls[0].sql).toContain("UPDATE conversations SET rest_excluded_datasource_ids = $1");
+      expect(queryCalls[0].sql).toContain("(org_id = $4 OR org_id IS NULL)");
+      // $1 is the array bound directly; $2 the id; $3 user; $4 org.
+      expect(queryCalls[0].params).toEqual([["ds-1", "ds-2"], "c1", "u1", "org-B"]);
+    });
+
+    it("updateConversationRestExcluded returns not_found when no row matches (cross-org)", async () => {
+      enableInternalDB();
+      setResults({ rows: [] });
+
+      const result = await updateConversationRestExcluded("c1", [], "u1", "org-B");
+      expect(result).toEqual({ ok: false, reason: "not_found" });
+    });
+
+    it("updateConversationRestExcluded short-circuits to no_db when the internal DB is off", async () => {
+      // No enableInternalDB() — hasInternalDB() is false.
+      const result = await updateConversationRestExcluded("c1", ["ds-1"]);
+      expect(result).toEqual({ ok: false, reason: "no_db" });
+      expect(queryCalls).toHaveLength(0);
     });
 
     it("shareConversation scopes the preflight SELECT by orgId (shareMode='org')", async () => {

--- a/packages/api/src/lib/agent.ts
+++ b/packages/api/src/lib/agent.ts
@@ -972,8 +972,11 @@ export async function runAgent({
           // #3066 — drop the conversation's excluded datasources. The tool is
           // bound to exactly this set below, so exclusion is enforced at both
           // prompt-build and tool-execution (the agent can't route to an id
-          // that isn't in the bound set). Omitted ⇒ exclude nothing.
-          ...(restExcludedDatasourceIds ? { excluded: restExcludedDatasourceIds } : {}),
+          // that isn't in the bound set). Empty / omitted ⇒ exclude nothing
+          // (guard on length, not truthiness — `[]` is truthy).
+          ...(restExcludedDatasourceIds && restExcludedDatasourceIds.length > 0
+            ? { excluded: restExcludedDatasourceIds }
+            : {}),
         })
       : [];
     if (restDatasources.length > 0) {

--- a/packages/api/src/lib/agent.ts
+++ b/packages/api/src/lib/agent.ts
@@ -755,6 +755,10 @@ export async function runAgent({
   // connection behavior, matching the prompt's acceptance criterion.
   const connectionId = reqCtx?.connectionId;
   const connectionGroupId = reqCtx?.connectionGroupId;
+  // #3066 — per-conversation REST datasource exclude-set. Threads into the
+  // REST resolver below so an excluded datasource never reaches the prompt
+  // or the bound `executeRestOperation` tool. Undefined ⇒ exclude nothing.
+  const restExcludedDatasourceIds = reqCtx?.restExcludedDatasourceIds;
 
   // Resolve model: injected > workspace config (enterprise) > platform env vars
   let model: LanguageModel;
@@ -965,6 +969,11 @@ export async function runAgent({
     const restDatasources = orgId
       ? await resolveWorkspaceRestDatasources(orgId, {
           activeGroupId: activeRestGroupId,
+          // #3066 — drop the conversation's excluded datasources. The tool is
+          // bound to exactly this set below, so exclusion is enforced at both
+          // prompt-build and tool-execution (the agent can't route to an id
+          // that isn't in the bound set). Omitted ⇒ exclude nothing.
+          ...(restExcludedDatasourceIds ? { excluded: restExcludedDatasourceIds } : {}),
         })
       : [];
     if (restDatasources.length > 0) {

--- a/packages/api/src/lib/auth/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/auth/__tests__/migrate.test.ts
@@ -357,6 +357,7 @@ describe("migrateAuthTables", () => {
             { name: "0109_data_candidate_catalog.sql" },
             { name: "0110_notion_data_catalog.sql" },
             { name: "0111_github_data_catalog.sql" },
+            { name: "0112_conversation_rest_excluded_datasources.sql" },
           ],
         };
       }

--- a/packages/api/src/lib/conversations.ts
+++ b/packages/api/src/lib/conversations.ts
@@ -136,6 +136,13 @@ function rowToConversation(r: Record<string, unknown>): Conversation {
     routingMode: isConversationRoutingMode(r.routing_mode)
       ? r.routing_mode
       : null,
+    // #3066 — per-conversation REST datasource exclude-set. The `pg`
+    // driver returns a `text[]` column as a JS string[]; a SELECT that
+    // omits the column (e.g. the list view) leaves it undefined → []
+    // (empty = all in scope), which the wire type permits.
+    restExcludedDatasourceIds: Array.isArray(r.rest_excluded_datasource_ids)
+      ? (r.rest_excluded_datasource_ids as string[])
+      : [],
     starred: r.starred === true,
     createdAt: String(r.created_at),
     updatedAt: String(r.updated_at),
@@ -186,14 +193,24 @@ export async function createConversation(opts: {
    * explicit `"auto"` / `"pin"` / `"all"` opt into the new wiring.
    */
   routingMode?: import("@useatlas/types/conversation").ConversationRoutingMode | null;
+  /**
+   * #3066 — per-conversation REST datasource exclude-set (excluded
+   * `install_id`s). Omitted / undefined persists the column default `'{}'`
+   * (nothing excluded = all in scope), so legacy callers are unaffected.
+   */
+  restExcludedDatasourceIds?: string[] | null;
   orgId?: string | null;
 }): Promise<{ id: string } | null> {
   if (!hasInternalDB()) return null;
+  // #3066 — null/undefined ⇒ let the column default ('{}') apply; an
+  // explicit [] is equivalent (nothing excluded). pg binds a JS string[]
+  // directly to the text[] column.
+  const restExcluded = opts.restExcludedDatasourceIds ?? [];
   try {
     const rows = opts.id
       ? await internalQuery<{ id: string }>(
-          `INSERT INTO conversations (id, user_id, title, surface, connection_id, connection_group_id, routing_mode, org_id)
-           VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+          `INSERT INTO conversations (id, user_id, title, surface, connection_id, connection_group_id, routing_mode, rest_excluded_datasource_ids, org_id)
+           VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
            RETURNING id`,
           [
             opts.id,
@@ -203,12 +220,13 @@ export async function createConversation(opts: {
             opts.connectionId ?? null,
             opts.connectionGroupId ?? null,
             opts.routingMode ?? null,
+            restExcluded,
             opts.orgId ?? null,
           ],
         )
       : await internalQuery<{ id: string }>(
-          `INSERT INTO conversations (user_id, title, surface, connection_id, connection_group_id, routing_mode, org_id)
-           VALUES ($1, $2, $3, $4, $5, $6, $7)
+          `INSERT INTO conversations (user_id, title, surface, connection_id, connection_group_id, routing_mode, rest_excluded_datasource_ids, org_id)
+           VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
            RETURNING id`,
           [
             opts.userId ?? null,
@@ -217,6 +235,7 @@ export async function createConversation(opts: {
             opts.connectionId ?? null,
             opts.connectionGroupId ?? null,
             opts.routingMode ?? null,
+            restExcluded,
             opts.orgId ?? null,
           ],
         );
@@ -252,6 +271,35 @@ export async function updateConversationRoutingMode(
     return rows.length > 0 ? { ok: true } : { ok: false, reason: "not_found" };
   } catch (err) {
     log.error({ err: errorMessage(err) }, "updateConversationRoutingMode failed");
+    return { ok: false, reason: "error" };
+  }
+}
+
+/**
+ * #3066 — update the conversation's `rest_excluded_datasource_ids`. Same
+ * fail-open / org-scoped contract as {@link updateConversationRoutingMode}:
+ * a no-DB / error result is logged but the chat turn still proceeds (the
+ * runtime honours the body's exclude-set for this turn even if the persist
+ * fails). pg binds the JS string[] directly to the text[] column; `[]`
+ * clears any prior exclusion (re-includes everything).
+ */
+export async function updateConversationRestExcluded(
+  id: string,
+  restExcludedDatasourceIds: string[],
+  userId?: string | null,
+  orgId?: string | null,
+): Promise<CrudResult> {
+  if (!hasInternalDB()) return { ok: false, reason: "no_db" };
+  try {
+    const scope = scopeClause(3, userId, orgId);
+    const rows = await internalQuery<{ id: string }>(
+      `UPDATE conversations SET rest_excluded_datasource_ids = $1, updated_at = now()
+       WHERE id = $2${scope.sql} RETURNING id`,
+      [restExcludedDatasourceIds, id, ...scope.params],
+    );
+    return rows.length > 0 ? { ok: true } : { ok: false, reason: "not_found" };
+  } catch (err) {
+    log.error({ err: errorMessage(err) }, "updateConversationRestExcluded failed");
     return { ok: false, reason: "error" };
   }
 }
@@ -623,7 +671,7 @@ export async function getConversation(
   try {
     const scope = scopeClause(2, userId, orgId);
     const convRows = await internalQuery<Record<string, unknown>>(
-      `SELECT id, user_id, title, surface, connection_id, connection_group_id, routing_mode, starred, notebook_state, created_at, updated_at
+      `SELECT id, user_id, title, surface, connection_id, connection_group_id, routing_mode, rest_excluded_datasource_ids, starred, notebook_state, created_at, updated_at
        FROM conversations WHERE id = $1${scope.sql}`,
       [id, ...scope.params],
     );
@@ -695,7 +743,7 @@ export async function listConversations(opts?: {
       params,
     );
     const dataRows = await internalQuery<Record<string, unknown>>(
-      `SELECT id, user_id, title, surface, connection_id, connection_group_id, routing_mode, starred, created_at, updated_at
+      `SELECT id, user_id, title, surface, connection_id, connection_group_id, routing_mode, rest_excluded_datasource_ids, starred, created_at, updated_at
        FROM conversations ${where}
        ORDER BY updated_at DESC LIMIT $${paramIdx++} OFFSET $${paramIdx++}`,
       [...params, limit, offset],
@@ -772,7 +820,7 @@ export async function forkConversation(opts: {
     // source row's org_id; scopeClause rejects mismatches (NULL-safe for legacy rows).
     const sourceScope = scopeClause(2, opts.userId, opts.orgId);
     const sourceRows = await internalQuery<Record<string, unknown>>(
-      `SELECT id, title, surface, connection_id, connection_group_id, routing_mode, org_id FROM conversations WHERE id = $1${sourceScope.sql}`,
+      `SELECT id, title, surface, connection_id, connection_group_id, routing_mode, rest_excluded_datasource_ids, org_id FROM conversations WHERE id = $1${sourceScope.sql}`,
       [opts.sourceId, ...sourceScope.params],
     );
     if (sourceRows.length === 0) return { ok: false, reason: "not_found" };
@@ -808,8 +856,8 @@ export async function forkConversation(opts: {
     // the user keeps the same env context after branching.
     const orgId = opts.orgId ?? (source.org_id as string) ?? null;
     const newConv = await internalQuery<{ id: string }>(
-      `INSERT INTO conversations (user_id, title, surface, connection_id, connection_group_id, routing_mode, org_id)
-       VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING id`,
+      `INSERT INTO conversations (user_id, title, surface, connection_id, connection_group_id, routing_mode, rest_excluded_datasource_ids, org_id)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING id`,
       [
         opts.userId ?? null,
         `${sourceTitle} (fork)`,
@@ -817,6 +865,9 @@ export async function forkConversation(opts: {
         (source.connection_id as string) ?? null,
         (source.connection_group_id as string) ?? null,
         (source.routing_mode as string) ?? null,
+        // #3066 — a fork/notebook inherits the source's REST exclude-set
+        // so the new conversation keeps the same scope after branching.
+        (source.rest_excluded_datasource_ids as string[]) ?? [],
         orgId,
       ],
     );
@@ -960,7 +1011,7 @@ export async function convertToNotebook(opts: {
     // Verify source exists and caller has access in both the user + org dimensions.
     const sourceScope = scopeClause(2, opts.userId, opts.orgId);
     const sourceRows = await internalQuery<Record<string, unknown>>(
-      `SELECT id, title, surface, connection_id, connection_group_id, routing_mode, org_id FROM conversations WHERE id = $1${sourceScope.sql}`,
+      `SELECT id, title, surface, connection_id, connection_group_id, routing_mode, rest_excluded_datasource_ids, org_id FROM conversations WHERE id = $1${sourceScope.sql}`,
       [opts.sourceId, ...sourceScope.params],
     );
     if (sourceRows.length === 0) return { ok: false, reason: "not_found" };
@@ -973,8 +1024,8 @@ export async function convertToNotebook(opts: {
     // both routing columns + the picker mode so the notebook preserves
     // the source's env context end-to-end.
     const newConv = await internalQuery<{ id: string }>(
-      `INSERT INTO conversations (user_id, title, surface, connection_id, connection_group_id, routing_mode, org_id)
-       VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING id`,
+      `INSERT INTO conversations (user_id, title, surface, connection_id, connection_group_id, routing_mode, rest_excluded_datasource_ids, org_id)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING id`,
       [
         opts.userId ?? null,
         `${sourceTitle} (notebook)`,
@@ -982,6 +1033,9 @@ export async function convertToNotebook(opts: {
         (source.connection_id as string) ?? null,
         (source.connection_group_id as string) ?? null,
         (source.routing_mode as string) ?? null,
+        // #3066 — a fork/notebook inherits the source's REST exclude-set
+        // so the new conversation keeps the same scope after branching.
+        (source.rest_excluded_datasource_ids as string[]) ?? [],
         orgId,
       ],
     );

--- a/packages/api/src/lib/conversations.ts
+++ b/packages/api/src/lib/conversations.ts
@@ -137,9 +137,10 @@ function rowToConversation(r: Record<string, unknown>): Conversation {
       ? r.routing_mode
       : null,
     // #3066 — per-conversation REST datasource exclude-set. The `pg`
-    // driver returns a `text[]` column as a JS string[]; a SELECT that
-    // omits the column (e.g. the list view) leaves it undefined → []
-    // (empty = all in scope), which the wire type permits.
+    // driver returns a `text[]` column as a JS string[]. Every SELECT in
+    // this file includes the column; the defensive `Array.isArray` guard
+    // covers a hypothetical caller that omits it (undefined → [], empty =
+    // all in scope), which the wire type permits.
     restExcludedDatasourceIds: Array.isArray(r.rest_excluded_datasource_ids)
       ? (r.rest_excluded_datasource_ids as string[])
       : [],

--- a/packages/api/src/lib/db/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate.test.ts
@@ -130,7 +130,8 @@ describe("runMigrations", () => {
     //   Plus 0110 (notion-data catalog row, slice 6b, #3029) = 111.
     //   Plus 0111 (github-data oauth-datasource catalog row + install_model
     //   CHECK widen, slice 6c, #3030) = 112.
-    expect(count).toBe(112);
+    //   Plus 0112 (conversations.rest_excluded_datasource_ids, S2a, #3066) = 113.
+    expect(count).toBe(113);
 
     // Advisory lock acquired before anything else
     expect(queries[0]).toContain("pg_advisory_lock");
@@ -271,6 +272,7 @@ describe("runMigrations", () => {
         "0109_data_candidate_catalog.sql",
         "0110_notion_data_catalog.sql",
         "0111_github_data_catalog.sql",
+        "0112_conversation_rest_excluded_datasources.sql",
       ],
     });
 

--- a/packages/api/src/lib/db/migrations/0112_conversation_rest_excluded_datasources.sql
+++ b/packages/api/src/lib/db/migrations/0112_conversation_rest_excluded_datasources.sql
@@ -1,0 +1,23 @@
+-- Migration 0112: per-conversation REST datasource exclude-set (#3066, S2a).
+--
+-- v0.0.4 Conversation Scope. REST datasources are in scope by default;
+-- a conversation can EXCLUDE specific ones so the agent stops querying
+-- them. The set holds `workspace_plugins.install_id` values — the id the
+-- scope picker surfaces (`GET /api/v1/me/connection-groups`). Empty
+-- (`'{}'`, the default) means nothing is excluded: every in-scope REST
+-- datasource is queryable, so a newly-installed datasource is reachable
+-- with no action. SQL routing (Auto/Pin/All on `routing_mode`) is
+-- unaffected. Authoritative per-conversation; the web sticky preference
+-- only seeds NEW chats. See ADR-0011.
+--
+-- NOT NULL DEFAULT '{}' so every existing row reads as "all in scope"
+-- without a backfill. The resolver treats an absent set as empty, but the
+-- not-null default keeps the row shape honest (no NULL/[] ambiguity).
+--
+-- Idempotent: `ADD COLUMN IF NOT EXISTS` is a no-op on re-run.
+
+ALTER TABLE conversations
+  ADD COLUMN IF NOT EXISTS rest_excluded_datasource_ids text[] NOT NULL DEFAULT '{}';
+
+COMMENT ON COLUMN conversations.rest_excluded_datasource_ids IS
+  'Per-conversation REST datasource exclude-set (#3066). Holds workspace_plugins.install_id values the agent must NOT query for this conversation. Empty = every in-scope REST datasource is queryable. SQL routing (routing_mode) unaffected. See ADR-0011.';

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -119,6 +119,17 @@ export const conversations = pgTable(
     // single-execution behavior. Validation lives in the chat route's
     // Zod schema (single source of truth) rather than a CHECK here.
     routingMode: text("routing_mode"),
+    // 0112 — per-conversation REST datasource exclude-set (#3066, S2a).
+    // Holds `workspace_plugins.install_id` values the agent must NOT query
+    // for this conversation. Empty (`'{}'`, the default) = every in-scope
+    // REST datasource is queryable, so a newly-installed one is reachable
+    // with no action. SQL routing (`routing_mode`) is unaffected. See
+    // ADR-0011. NOT NULL DEFAULT '{}' so existing rows read as "all in
+    // scope" without a backfill.
+    restExcludedDatasourceIds: text("rest_excluded_datasource_ids")
+      .array()
+      .notNull()
+      .default(sql`'{}'::text[]`),
     createdAt: timestamp("created_at", { withTimezone: true }).defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow(),
     // Saved/starred

--- a/packages/api/src/lib/logger.ts
+++ b/packages/api/src/lib/logger.ts
@@ -90,9 +90,11 @@ interface RequestContext {
    * override) so the REST datasource resolver drops these `install_id`s
    * BEFORE the prompt + the bound `executeRestOperation` tool see them.
    * Undefined here = exclude nothing (every in-scope REST datasource stays
-   * queryable). SQL routing (`routingMode`) is unaffected.
+   * queryable). SQL routing (`routingMode`) is unaffected. `readonly` to match
+   * the rest of the internal exclude-set vocabulary (`ResolveWorkspaceDeps`,
+   * the preference store) — consumers only read it.
    */
-  restExcludedDatasourceIds?: string[];
+  restExcludedDatasourceIds?: readonly string[];
 }
 
 const requestStore = new AsyncLocalStorage<RequestContext>();

--- a/packages/api/src/lib/logger.ts
+++ b/packages/api/src/lib/logger.ts
@@ -84,6 +84,15 @@ interface RequestContext {
    * single member keep single-execution semantics.
    */
   routingMode?: import("@atlas/api/lib/env-routing").RoutingMode;
+  /**
+   * #3066 — per-conversation REST datasource exclude-set. The chat route
+   * stamps this from the resolved conversation row (or the per-turn body
+   * override) so the REST datasource resolver drops these `install_id`s
+   * BEFORE the prompt + the bound `executeRestOperation` tool see them.
+   * Undefined here = exclude nothing (every in-scope REST datasource stays
+   * queryable). SQL routing (`routingMode`) is unaffected.
+   */
+  restExcludedDatasourceIds?: string[];
 }
 
 const requestStore = new AsyncLocalStorage<RequestContext>();

--- a/packages/api/src/lib/openapi/__tests__/workspace-datasource.test.ts
+++ b/packages/api/src/lib/openapi/__tests__/workspace-datasource.test.ts
@@ -460,6 +460,74 @@ describe("resolveWorkspaceRestDatasources — env scope (activeGroupId)", () => 
   });
 });
 
+describe("resolveWorkspaceRestDatasources — per-conversation exclude-set (#3066, S2a)", () => {
+  const rows: OpenApiInstallRow[] = [
+    { install_id: "ds-global", config: config({ display_name: "Global" }) }, // no group_id
+    { install_id: "ds-prod", config: config({ display_name: "Prod", group_id: "prod" }) },
+    { install_id: "ds-eu", config: config({ display_name: "EU", group_id: "eu" }) },
+  ];
+
+  it("omitted excluded resolves every install (default = all in scope / confirm-replay path)", async () => {
+    const result = await resolveWorkspaceRestDatasources("org-1", {
+      query: queryReturning(rows),
+    });
+    expect(result.map((d) => d.id).sort()).toEqual(["ds-eu", "ds-global", "ds-prod"]);
+  });
+
+  it("an empty excluded set excludes nothing", async () => {
+    const result = await resolveWorkspaceRestDatasources("org-1", {
+      query: queryReturning(rows),
+      excluded: [],
+    });
+    expect(result.map((d) => d.id).sort()).toEqual(["ds-eu", "ds-global", "ds-prod"]);
+  });
+
+  it("drops every install whose id is in the exclude-set", async () => {
+    const result = await resolveWorkspaceRestDatasources("org-1", {
+      query: queryReturning(rows),
+      excluded: ["ds-prod"],
+    });
+    expect(result.map((d) => d.id).sort()).toEqual(["ds-eu", "ds-global"]);
+    expect(result.some((d) => d.id === "ds-prod")).toBe(false);
+  });
+
+  it("applies the exclude-set AFTER the activeGroupId scope filter", async () => {
+    // ds-global + ds-prod are in scope for "prod"; excluding ds-prod leaves only ds-global.
+    const result = await resolveWorkspaceRestDatasources("org-1", {
+      query: queryReturning(rows),
+      activeGroupId: "prod",
+      excluded: ["ds-prod"],
+    });
+    expect(result.map((d) => d.id)).toEqual(["ds-global"]);
+  });
+
+  it("an excluded id that matches no install is a harmless no-op", async () => {
+    const result = await resolveWorkspaceRestDatasources("org-1", {
+      query: queryReturning(rows),
+      excluded: ["ds-does-not-exist"],
+    });
+    expect(result.map((d) => d.id).sort()).toEqual(["ds-eu", "ds-global", "ds-prod"]);
+  });
+
+  it("preserves the [] fail-soft contract when every datasource is excluded", async () => {
+    const result = await resolveWorkspaceRestDatasources("org-1", {
+      query: queryReturning(rows),
+      excluded: ["ds-global", "ds-prod", "ds-eu"],
+    });
+    expect(result).toEqual([]);
+  });
+
+  it("the strict resolver returns [] (never throws) when every install is excluded", async () => {
+    // Exclusion runs BEFORE build, like the group-scope filter, so a fully-excluded
+    // workspace resolves to an empty in-scope set without engaging the reconnect tally.
+    const result = await resolveWorkspaceRestDatasourcesOrThrow("org-1", {
+      query: queryReturning(rows),
+      excluded: ["ds-global", "ds-prod", "ds-eu"],
+    });
+    expect(result).toEqual([]);
+  });
+});
+
 // ─────────────────────────────────────────────────────────────────────
 //  Resolve-time SSRF guard (#3006)
 // ─────────────────────────────────────────────────────────────────────

--- a/packages/api/src/lib/openapi/workspace-datasource.ts
+++ b/packages/api/src/lib/openapi/workspace-datasource.ts
@@ -131,6 +131,19 @@ export interface ResolveWorkspaceDeps {
    * carries over the legacy "always available" behaviour.
    */
   readonly activeGroupId?: string | null;
+  /**
+   * Per-conversation REST datasource exclude-set (#3066, S2a). Holds the
+   * `install_id`s the conversation has excluded — the id the scope picker
+   * surfaces (`GET /api/v1/me/connection-groups`). Dropped AFTER the
+   * {@link activeGroupId} scope filter and BEFORE credential build, so an
+   * excluded datasource never reaches decryption and the reconnect tally is
+   * computed only over the surviving set. Omitted / empty = exclude nothing
+   * (every in-scope datasource stays queryable, so a newly-installed one is
+   * reachable with no action). The authorized confirm-replay path
+   * (`tools/rest-operation.ts`'s `resolveFromContext`) intentionally omits
+   * this — a staged write replays regardless of the conversation's scope.
+   */
+  readonly excluded?: ReadonlyArray<string>;
 }
 
 /**
@@ -154,6 +167,22 @@ function rowsInActiveGroup(
     // (no active group) admits no scoped datasource.
     return activeGroupId !== null && rowGroupId === activeGroupId;
   });
+}
+
+/**
+ * Per-conversation exclude-set filter (#3066, S2a). Drops every install whose
+ * `install_id` the conversation has excluded. Pure over the raw `install_id`
+ * (no config / credential access), mirroring {@link rowsInActiveGroup}, so it
+ * runs BEFORE credential build and an excluded datasource never reaches
+ * decryption. An omitted / empty set excludes nothing.
+ */
+function rowsNotExcluded(
+  rows: ReadonlyArray<OpenApiInstallRow>,
+  excluded: ReadonlyArray<string> | undefined,
+): ReadonlyArray<OpenApiInstallRow> {
+  if (!excluded || excluded.length === 0) return rows;
+  const excludeSet = new Set(excluded);
+  return rows.filter((row) => !excludeSet.has(row.install_id));
 }
 
 /**
@@ -523,7 +552,12 @@ export async function resolveWorkspaceRestDatasourcesOrThrow(
   // #3044 — drop out-of-scope datasources BEFORE build, so the reconnect tally
   // (and the never-rejects `[]` contract) is computed only over the in-scope set.
   const scopedRows = rowsInActiveGroup(rows, deps.activeGroupId);
-  return buildDatasourcesFromRows(workspaceId, scopedRows, mint);
+  // #3066 — then drop the conversation's per-conversation exclude-set. Order
+  // matters: exclusion is over the already-group-scoped set, and both filters
+  // run before build so an excluded/off-scope datasource never reaches
+  // credential decryption.
+  const inScopeRows = rowsNotExcluded(scopedRows, deps.excluded);
+  return buildDatasourcesFromRows(workspaceId, inScopeRows, mint);
 }
 
 /**

--- a/packages/api/src/lib/tools/__tests__/action-permissions.test.ts
+++ b/packages/api/src/lib/tools/__tests__/action-permissions.test.ts
@@ -142,6 +142,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   resolveGroupForConnection: mock(() => Promise.resolve(null)),
   verifyGroupBelongsToOrg: mock(() => Promise.resolve("ok")),
   updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
+  updateConversationRestExcluded: mock(() => Promise.resolve({ ok: true as const })),
   resolveRoutingMode: mock((m: "auto" | "pin" | "all" | null | undefined = null) => m ?? "pin"),
 }));
 

--- a/packages/api/src/lib/tools/__tests__/python-rest-egress-scope.test.ts
+++ b/packages/api/src/lib/tools/__tests__/python-rest-egress-scope.test.ts
@@ -117,4 +117,17 @@ describe("defaultResolveRestDatasource — env-scope lockstep (#3044)", () => {
     // No `excluded` key — the resolver excludes nothing for egress.
     expect(primaryCalls[0]!.deps).toEqual({ activeGroupId: "eu" });
   });
+
+  it("treats an empty exclude-set the same as omitted — no `excluded` key (#3066)", async () => {
+    // `[]` is truthy in JS; the resolver must guard on length so an empty set
+    // (the common production value — the transport always sends the array)
+    // resolves to "exclude nothing", consistent with the undefined path.
+    mockReqCtx = {
+      user: { activeOrganizationId: "org-1" },
+      connectionGroupId: "eu",
+      restExcludedDatasourceIds: [],
+    };
+    await defaultResolveRestDatasource();
+    expect(primaryCalls[0]!.deps).toEqual({ activeGroupId: "eu" });
+  });
 });

--- a/packages/api/src/lib/tools/__tests__/python-rest-egress-scope.test.ts
+++ b/packages/api/src/lib/tools/__tests__/python-rest-egress-scope.test.ts
@@ -13,7 +13,12 @@ import { describe, it, expect, beforeEach, mock } from "bun:test";
 
 // Controllable request context (default: none).
 let mockReqCtx:
-  | { user?: { activeOrganizationId?: string }; connectionGroupId?: string; connectionId?: string }
+  | {
+      user?: { activeOrganizationId?: string };
+      connectionGroupId?: string;
+      connectionId?: string;
+      restExcludedDatasourceIds?: readonly string[];
+    }
   | undefined;
 
 mock.module("@atlas/api/lib/logger", () => ({
@@ -91,5 +96,25 @@ describe("defaultResolveRestDatasource — env-scope lockstep (#3044)", () => {
     const result = await defaultResolveRestDatasource();
     expect(result).toBeNull();
     expect(primaryCalls).toHaveLength(0);
+  });
+
+  // #3066 — the sandbox egress allowlist must honour the conversation's REST
+  // exclude-set too, or Python could probe a datasource the conversation
+  // excluded (if it's the workspace primary).
+  it("threads the conversation's REST exclude-set into the egress resolver (#3066)", async () => {
+    mockReqCtx = {
+      user: { activeOrganizationId: "org-1" },
+      connectionGroupId: "eu",
+      restExcludedDatasourceIds: ["ds-excluded"],
+    };
+    await defaultResolveRestDatasource();
+    expect(primaryCalls[0]!.deps).toEqual({ activeGroupId: "eu", excluded: ["ds-excluded"] });
+  });
+
+  it("omits `excluded` when the conversation has no exclude-set (#3066)", async () => {
+    mockReqCtx = { user: { activeOrganizationId: "org-1" }, connectionGroupId: "eu" };
+    await defaultResolveRestDatasource();
+    // No `excluded` key — the resolver excludes nothing for egress.
+    expect(primaryCalls[0]!.deps).toEqual({ activeGroupId: "eu" });
   });
 });

--- a/packages/api/src/lib/tools/python.ts
+++ b/packages/api/src/lib/tools/python.ts
@@ -463,10 +463,13 @@ export async function defaultResolveRestDatasource(): Promise<RestDatasource | n
   // REST exclude-set too: a datasource the conversation excluded must not be
   // reachable from Python either, or the agent could probe an excluded host's
   // network egress via `executePython`. Omitted ⇒ exclude nothing.
+  // Treat an empty set as "exclude nothing" (omit the key), matching the chat
+  // route's ALS stamping and `agent.ts` — `[]` is truthy in JS, so guard on
+  // length, not truthiness, to keep all three threading sites consistent.
   const excluded = reqCtx?.restExcludedDatasourceIds;
   return resolveWorkspacePrimaryRestDatasource(orgId, {
     activeGroupId,
-    ...(excluded ? { excluded } : {}),
+    ...(excluded && excluded.length > 0 ? { excluded } : {}),
   });
 }
 

--- a/packages/api/src/lib/tools/python.ts
+++ b/packages/api/src/lib/tools/python.ts
@@ -459,7 +459,15 @@ export async function defaultResolveRestDatasource(): Promise<RestDatasource | n
   const { resolveWorkspacePrimaryRestDatasource } = await import(
     "@atlas/api/lib/openapi/workspace-datasource"
   );
-  return resolveWorkspacePrimaryRestDatasource(orgId, { activeGroupId });
+  // #3066 — keep the sandbox egress allowlist in lockstep with the conversation's
+  // REST exclude-set too: a datasource the conversation excluded must not be
+  // reachable from Python either, or the agent could probe an excluded host's
+  // network egress via `executePython`. Omitted ⇒ exclude nothing.
+  const excluded = reqCtx?.restExcludedDatasourceIds;
+  return resolveWorkspacePrimaryRestDatasource(orgId, {
+    activeGroupId,
+    ...(excluded ? { excluded } : {}),
+  });
 }
 
 /**

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useatlas/types",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "Shared types for the Atlas text-to-SQL agent",
   "type": "module",
   "scripts": {

--- a/packages/types/src/conversation.ts
+++ b/packages/types/src/conversation.ts
@@ -62,11 +62,13 @@ export interface Conversation {
    * Authoritative per-conversation; the web sticky preference only seeds
    * NEW chats. SQL routing (`routingMode`) is independent and unaffected.
    *
-   * Optional + nullable so pre-#3066 test fixtures and external SDK
-   * consumers can construct a `Conversation` without it; the runtime treats
-   * missing the same as `[]`.
+   * Optional (not nullable) so pre-#3066 test fixtures and external SDK
+   * consumers can omit it; the runtime treats missing the same as `[]`. The
+   * server NEVER serializes null — the column is `NOT NULL DEFAULT '{}'` and
+   * `rowToConversation` always yields a `string[]` (or `[]`), so unlike the
+   * genuinely-nullable `routingMode` this field has no null state.
    */
-  restExcludedDatasourceIds?: string[] | null;
+  restExcludedDatasourceIds?: string[];
   starred: boolean;
   createdAt: string;
   updatedAt: string;

--- a/packages/types/src/conversation.ts
+++ b/packages/types/src/conversation.ts
@@ -52,6 +52,21 @@ export interface Conversation {
    * the field; the runtime treats missing the same as `null`.
    */
   routingMode?: ConversationRoutingMode | null;
+  /**
+   * Per-conversation REST datasource exclude-set (#3066). The excluded
+   * `install_id`s — the id the scope picker surfaces — that the agent must
+   * NOT query for this conversation. Empty / absent = every in-scope REST
+   * datasource stays queryable (the column default `'{}'`), so a
+   * newly-installed datasource is reachable with no action.
+   *
+   * Authoritative per-conversation; the web sticky preference only seeds
+   * NEW chats. SQL routing (`routingMode`) is independent and unaffected.
+   *
+   * Optional + nullable so pre-#3066 test fixtures and external SDK
+   * consumers can construct a `Conversation` without it; the runtime treats
+   * missing the same as `[]`.
+   */
+  restExcludedDatasourceIds?: string[] | null;
   starred: boolean;
   createdAt: string;
   updatedAt: string;

--- a/packages/web/src/app/(workspace)/page.tsx
+++ b/packages/web/src/app/(workspace)/page.tsx
@@ -181,6 +181,8 @@ function ChatPage() {
     groups: envGroupsQuery.groups,
     reason: envGroupsQuery.reason,
     error: envGroupsQuery.error,
+    // #3066 — also show when there are REST datasources to exclude.
+    restDatasources: envGroupsQuery.restDatasources,
   });
 
   const refreshConvosRef = useRef(convos.refresh);

--- a/packages/web/src/lib/stores/chat-routing-preference-store.ts
+++ b/packages/web/src/lib/stores/chat-routing-preference-store.ts
@@ -38,6 +38,12 @@ export interface ChatRoutingPreference {
   readonly connectionId: string | null;
   /** Three-state Auto/Pin/All routing mode, or null (pre-#2518 back-compat). */
   readonly routingMode: ConversationRoutingMode | null;
+  /**
+   * #3066 — REST datasource exclude-set the user last chose (excluded
+   * `install_id`s). Seeds NEW chats only; the per-conversation row is
+   * authoritative once a conversation exists. Empty = nothing excluded.
+   */
+  readonly restExcludedDatasourceIds: readonly string[];
 }
 
 interface ChatRoutingPreferenceStore extends ChatRoutingPreference {
@@ -63,6 +69,7 @@ const EMPTY: ChatRoutingPreference = {
   groupId: null,
   connectionId: null,
   routingMode: null,
+  restExcludedDatasourceIds: [],
 };
 
 export const useChatRoutingPreferenceStore = create<ChatRoutingPreferenceStore>()(
@@ -77,6 +84,7 @@ export const useChatRoutingPreferenceStore = create<ChatRoutingPreferenceStore>(
           groupId: next.groupId,
           connectionId: next.connectionId,
           routingMode: next.routingMode,
+          restExcludedDatasourceIds: next.restExcludedDatasourceIds,
         }),
       // Partial set — zustand shallow-merges, so `_hasHydrated` (absent from
       // EMPTY) is preserved. A clear must not re-close the hydration gate.
@@ -94,6 +102,7 @@ export const useChatRoutingPreferenceStore = create<ChatRoutingPreferenceStore>(
         groupId: s.groupId,
         connectionId: s.connectionId,
         routingMode: s.routingMode,
+        restExcludedDatasourceIds: s.restExcludedDatasourceIds,
       }),
       // Fires after rehydration (synchronously for localStorage, even when
       // storage was empty), so the consumer's gate opens exactly once the

--- a/packages/web/src/ui/__tests__/env-picker.test.tsx
+++ b/packages/web/src/ui/__tests__/env-picker.test.tsx
@@ -38,6 +38,36 @@ mock.module("@/components/ui/dropdown-menu", () => {
       },
       children as React.ReactNode,
     );
+  // #3066 — checkbox items wire BOTH `onSelect` (with a preventDefault-able
+  // event, since the component calls `e.preventDefault()` to keep the menu
+  // open) and `onCheckedChange` (toggled value), mirroring Radix's
+  // CheckboxItem. `checked` is consumed (not spread onto the div) so it
+  // doesn't leak as a DOM attribute.
+  const checkboxItem = ({
+    children,
+    checked,
+    onSelect,
+    onCheckedChange,
+    asChild: _asChild,
+    ...rest
+  }: {
+    children?: ReactNode;
+    asChild?: boolean;
+    checked?: boolean;
+    onSelect?: (e: { preventDefault: () => void }) => void;
+    onCheckedChange?: (checked: boolean) => void;
+  } & Record<string, unknown>) =>
+    React.createElement(
+      "div",
+      {
+        ...rest,
+        onClick: () => {
+          if (typeof onSelect === "function") onSelect({ preventDefault: () => {} });
+          if (typeof onCheckedChange === "function") onCheckedChange(checked !== true);
+        },
+      },
+      children as React.ReactNode,
+    );
   return {
     DropdownMenu: div,
     DropdownMenuPortal: div,
@@ -45,7 +75,7 @@ mock.module("@/components/ui/dropdown-menu", () => {
     DropdownMenuContent: div,
     DropdownMenuGroup: div,
     DropdownMenuItem: itemWithSelect,
-    DropdownMenuCheckboxItem: itemWithSelect,
+    DropdownMenuCheckboxItem: checkboxItem,
     DropdownMenuRadioGroup: div,
     DropdownMenuRadioItem: itemWithSelect,
     DropdownMenuLabel: div,
@@ -57,7 +87,7 @@ mock.module("@/components/ui/dropdown-menu", () => {
   };
 });
 
-import { render, renderHook, waitFor, cleanup } from "@testing-library/react";
+import { render, renderHook, waitFor, cleanup, fireEvent } from "@testing-library/react";
 import {
   ChatEnvPicker,
   pickDefaultEnvSeed,
@@ -665,7 +695,7 @@ describe("ChatEnvPicker — REST datasource scope footer (#3044)", () => {
     },
   ];
 
-  test("frames workspace-global REST datasources as not limited by the pin", () => {
+  test("surfaces workspace-global REST datasources as an in-scope checkbox", () => {
     const { container } = render(
       <ChatEnvPicker
         groups={multiGroup}
@@ -680,7 +710,10 @@ describe("ChatEnvPicker — REST datasource scope footer (#3044)", () => {
     expect(global).not.toBeNull();
     expect(global?.textContent).toContain("Stripe");
     expect(global?.textContent?.toLowerCase()).toContain("every environment");
-    expect(global?.textContent?.toLowerCase()).toContain("not limited by");
+    // #3066 — the datasource renders as a checkbox, in scope (not excluded) by default.
+    const toggle = container.querySelector('[data-testid="chat-env-picker-rest-toggle-stripe"]');
+    expect(toggle).not.toBeNull();
+    expect(toggle?.getAttribute("data-in-scope")).toBe("true");
   });
 
   test("separates in-scope (active group) from out-of-scope scoped datasources", () => {
@@ -723,6 +756,123 @@ describe("ChatEnvPicker — REST datasource scope footer (#3044)", () => {
     expect(
       container.querySelector('[data-testid="chat-env-picker-rest-global"]'),
     ).toBeNull();
+  });
+});
+
+describe("ChatEnvPicker — REST datasource exclude-set (#3066)", () => {
+  const multiGroup: ChatEnvGroup[] = [
+    {
+      id: "prod",
+      name: "prod",
+      primaryConnectionId: null,
+      members: [
+        { connectionId: "us-prod", dbType: "postgres", description: null },
+        { connectionId: "eu-prod", dbType: "postgres", description: null },
+      ],
+    },
+  ];
+  const datasources = [
+    { id: "stripe", displayName: "Stripe", groupId: null },
+    { id: "prod-api", displayName: "Prod API", groupId: "prod" },
+  ];
+
+  test("the chip reflects the in-scope REST count (e.g. 2/2, then 1/2 when one is excluded)", () => {
+    const { container, rerender } = render(
+      <ChatEnvPicker
+        groups={multiGroup}
+        activeGroupId="prod"
+        activeConnectionId="us-prod"
+        activeRoutingMode="pin"
+        restDatasources={datasources}
+        restExcludedDatasourceIds={[]}
+        onSelect={noop}
+      />,
+    );
+    const label = () =>
+      container.querySelector('[data-testid="chat-env-picker-label"]')?.textContent ?? "";
+    expect(label()).toContain("2/2 REST");
+
+    rerender(
+      <ChatEnvPicker
+        groups={multiGroup}
+        activeGroupId="prod"
+        activeConnectionId="us-prod"
+        activeRoutingMode="pin"
+        restDatasources={datasources}
+        restExcludedDatasourceIds={["stripe"]}
+        onSelect={noop}
+      />,
+    );
+    expect(label()).toContain("1/2 REST");
+  });
+
+  test("an excluded datasource renders unchecked (data-in-scope=false)", () => {
+    const { container } = render(
+      <ChatEnvPicker
+        groups={multiGroup}
+        activeGroupId="prod"
+        activeConnectionId="us-prod"
+        activeRoutingMode="pin"
+        restDatasources={datasources}
+        restExcludedDatasourceIds={["stripe"]}
+        onSelect={noop}
+      />,
+    );
+    expect(
+      container
+        .querySelector('[data-testid="chat-env-picker-rest-toggle-stripe"]')
+        ?.getAttribute("data-in-scope"),
+    ).toBe("false");
+    expect(
+      container
+        .querySelector('[data-testid="chat-env-picker-rest-toggle-prod-api"]')
+        ?.getAttribute("data-in-scope"),
+    ).toBe("true");
+  });
+
+  test("unchecking an in-scope datasource adds it to the exclude-set (full next set)", () => {
+    const onRestExcludedChange = mock((_next: string[]) => {});
+    const { container } = render(
+      <ChatEnvPicker
+        groups={multiGroup}
+        activeGroupId="prod"
+        activeConnectionId="us-prod"
+        activeRoutingMode="pin"
+        restDatasources={datasources}
+        restExcludedDatasourceIds={[]}
+        onRestExcludedChange={onRestExcludedChange}
+        onSelect={noop}
+      />,
+    );
+    const toggle = container.querySelector(
+      '[data-testid="chat-env-picker-rest-toggle-stripe"]',
+    ) as HTMLElement;
+    fireEvent.click(toggle);
+    expect(onRestExcludedChange).toHaveBeenCalledTimes(1);
+    expect(onRestExcludedChange.mock.calls[0]![0]).toEqual(["stripe"]);
+  });
+
+  test("re-checking an excluded datasource clears it from the set (sends the remaining set)", () => {
+    const onRestExcludedChange = mock((_next: string[]) => {});
+    const { container } = render(
+      <ChatEnvPicker
+        groups={multiGroup}
+        activeGroupId="prod"
+        activeConnectionId="us-prod"
+        activeRoutingMode="pin"
+        restDatasources={datasources}
+        restExcludedDatasourceIds={["stripe", "prod-api"]}
+        onRestExcludedChange={onRestExcludedChange}
+        onSelect={noop}
+      />,
+    );
+    const toggle = container.querySelector(
+      '[data-testid="chat-env-picker-rest-toggle-stripe"]',
+    ) as HTMLElement;
+    // It's currently excluded (unchecked); clicking re-includes it.
+    fireEvent.click(toggle);
+    expect(onRestExcludedChange).toHaveBeenCalledTimes(1);
+    expect(onRestExcludedChange.mock.calls[0]![0]).toEqual(["prod-api"]);
   });
 });
 
@@ -1215,13 +1365,14 @@ describe("resolveEnvSelection — sticky-preference restore vs default seed (#30
   ): ResolveEnvSelectionInput {
     return {
       groups: [prodGroup],
-      current: { groupId: null, connectionId: null, routingMode: null },
+      current: { groupId: null, connectionId: null, routingMode: null, restExcludedDatasourceIds: [] },
       provenance: "unset",
       preference: {
         workspaceId: null,
         groupId: null,
         connectionId: null,
         routingMode: null,
+        restExcludedDatasourceIds: [],
       },
       activeWorkspaceId: null,
       preferenceHydrated: true,
@@ -1287,6 +1438,7 @@ describe("resolveEnvSelection — sticky-preference restore vs default seed (#30
       groupId: "g_prod",
       connectionId: "eu-prod",
       routingMode: "pin",
+      restExcludedDatasourceIds: [],
     });
   });
 
@@ -1313,6 +1465,7 @@ describe("resolveEnvSelection — sticky-preference restore vs default seed (#30
       groupId: "g_prod",
       connectionId: "eu-prod",
       routingMode: "pin",
+      restExcludedDatasourceIds: [],
     });
   });
 
@@ -1338,6 +1491,7 @@ describe("resolveEnvSelection — sticky-preference restore vs default seed (#30
       groupId: "g_prod",
       connectionId: "eu-prod",
       routingMode: "auto",
+      restExcludedDatasourceIds: [],
     });
   });
 
@@ -1395,6 +1549,7 @@ describe("resolveEnvSelection — sticky-preference restore vs default seed (#30
       kind: "seed",
       groupId: "g_prod",
       connectionId: "us-prod",
+      restExcludedDatasourceIds: [],
     });
   });
 
@@ -1414,6 +1569,7 @@ describe("resolveEnvSelection — sticky-preference restore vs default seed (#30
       kind: "seed",
       groupId: "g_prod",
       connectionId: "us-prod",
+      restExcludedDatasourceIds: [],
     });
   });
 
@@ -1433,6 +1589,7 @@ describe("resolveEnvSelection — sticky-preference restore vs default seed (#30
       kind: "seed",
       groupId: "g_prod",
       connectionId: "us-prod",
+      restExcludedDatasourceIds: [],
     });
   });
 
@@ -1453,6 +1610,7 @@ describe("resolveEnvSelection — sticky-preference restore vs default seed (#30
       groupId: "g_prod",
       connectionId: "eu-prod",
       routingMode: "auto",
+      restExcludedDatasourceIds: [],
     });
   });
 
@@ -1467,6 +1625,7 @@ describe("resolveEnvSelection — sticky-preference restore vs default seed (#30
       kind: "seed",
       groupId: "g_only",
       connectionId: "only",
+      restExcludedDatasourceIds: [],
     });
   });
 });
@@ -1511,7 +1670,7 @@ describe("resolveConversationScope — restore a conversation's scope on open (#
         { connectionGroupId: "g_prod", connectionId: "eu-prod", routingMode: "pin" },
         groups,
       ),
-    ).toEqual({ kind: "restore", groupId: "g_prod", connectionId: "eu-prod", routingMode: "pin" });
+    ).toEqual({ kind: "restore", groupId: "g_prod", connectionId: "eu-prod", routingMode: "pin", restExcludedDatasourceIds: [] });
   });
 
   test("preserves an 'auto' routing mode (mode is a first-class scope dimension)", () => {
@@ -1522,7 +1681,7 @@ describe("resolveConversationScope — restore a conversation's scope on open (#
         { connectionGroupId: "g_prod", connectionId: "us-prod", routingMode: "auto" },
         groups,
       ),
-    ).toEqual({ kind: "restore", groupId: "g_prod", connectionId: "us-prod", routingMode: "auto" });
+    ).toEqual({ kind: "restore", groupId: "g_prod", connectionId: "us-prod", routingMode: "auto", restExcludedDatasourceIds: [] });
   });
 
   test("preserves an 'all' routing mode", () => {
@@ -1531,7 +1690,7 @@ describe("resolveConversationScope — restore a conversation's scope on open (#
         { connectionGroupId: "g_prod", connectionId: "us-prod", routingMode: "all" },
         groups,
       ),
-    ).toEqual({ kind: "restore", groupId: "g_prod", connectionId: "us-prod", routingMode: "all" });
+    ).toEqual({ kind: "restore", groupId: "g_prod", connectionId: "us-prod", routingMode: "all", restExcludedDatasourceIds: [] });
   });
 
   test("two different conversations resolve to two different scopes (switching updates the picker each time)", () => {
@@ -1557,7 +1716,7 @@ describe("resolveConversationScope — restore a conversation's scope on open (#
         { connectionGroupId: "g_prod", connectionId: "eu-prod", routingMode: null },
         groups,
       ),
-    ).toEqual({ kind: "restore", groupId: "g_prod", connectionId: "eu-prod", routingMode: null });
+    ).toEqual({ kind: "restore", groupId: "g_prod", connectionId: "eu-prod", routingMode: null, restExcludedDatasourceIds: [] });
   });
 
   test("legacy conversation with an omitted routing mode defaults to null", () => {
@@ -1568,7 +1727,7 @@ describe("resolveConversationScope — restore a conversation's scope on open (#
         { connectionGroupId: "g_prod", connectionId: "eu-prod" },
         groups,
       ),
-    ).toEqual({ kind: "restore", groupId: "g_prod", connectionId: "eu-prod", routingMode: null });
+    ).toEqual({ kind: "restore", groupId: "g_prod", connectionId: "eu-prod", routingMode: null, restExcludedDatasourceIds: [] });
   });
 
   test("seeds (defers) for a fully-null row — never makes nulls authoritative", () => {
@@ -1601,7 +1760,7 @@ describe("resolveConversationScope — restore a conversation's scope on open (#
         { connectionGroupId: "g_prod", connectionId: "ap-prod-archived", routingMode: "pin" },
         groups,
       ),
-    ).toEqual({ kind: "restore", groupId: "g_prod", connectionId: "us-prod", routingMode: "pin" });
+    ).toEqual({ kind: "restore", groupId: "g_prod", connectionId: "us-prod", routingMode: "pin", restExcludedDatasourceIds: [] });
   });
 
   test("repairs a group-only row (null member, e.g. Auto) to the group primary", () => {
@@ -1612,7 +1771,7 @@ describe("resolveConversationScope — restore a conversation's scope on open (#
         { connectionGroupId: "g_prod", connectionId: null, routingMode: "auto" },
         groups,
       ),
-    ).toEqual({ kind: "restore", groupId: "g_prod", connectionId: "us-prod", routingMode: "auto" });
+    ).toEqual({ kind: "restore", groupId: "g_prod", connectionId: "us-prod", routingMode: "auto", restExcludedDatasourceIds: [] });
   });
 
   test("falls back to members[0] when repairing under a group with no primary", () => {
@@ -1621,7 +1780,7 @@ describe("resolveConversationScope — restore a conversation's scope on open (#
         { connectionGroupId: "g_staging", connectionId: "gone", routingMode: "pin" },
         groups,
       ),
-    ).toEqual({ kind: "restore", groupId: "g_staging", connectionId: "us-staging", routingMode: "pin" });
+    ).toEqual({ kind: "restore", groupId: "g_staging", connectionId: "us-staging", routingMode: "pin", restExcludedDatasourceIds: [] });
   });
 
   test("trusts the row optimistically when groups have not loaded yet (cold-start open)", () => {
@@ -1633,7 +1792,7 @@ describe("resolveConversationScope — restore a conversation's scope on open (#
         { connectionGroupId: "g_prod", connectionId: "eu-prod", routingMode: "all" },
         [],
       ),
-    ).toEqual({ kind: "restore", groupId: "g_prod", connectionId: "eu-prod", routingMode: "all" });
+    ).toEqual({ kind: "restore", groupId: "g_prod", connectionId: "eu-prod", routingMode: "all", restExcludedDatasourceIds: [] });
   });
 
   test("still seeds a fully-null row even when groups have not loaded", () => {
@@ -1659,7 +1818,7 @@ describe("resolveConversationScope — restore a conversation's scope on open (#
         { connectionGroupId: null, connectionId: "eu-prod", routingMode: "pin" },
         groups,
       ),
-    ).toEqual({ kind: "restore", groupId: "g_prod", connectionId: "eu-prod", routingMode: "pin" });
+    ).toEqual({ kind: "restore", groupId: "g_prod", connectionId: "eu-prod", routingMode: "pin", restExcludedDatasourceIds: [] });
   });
 
   test("seeds a legacy group-less row only when its connection no longer exists in any group", () => {
@@ -1682,7 +1841,7 @@ describe("resolveConversationScope — restore a conversation's scope on open (#
         { connectionGroupId: null, connectionId: "eu-prod", routingMode: "pin" },
         [],
       ),
-    ).toEqual({ kind: "restore", groupId: null, connectionId: "eu-prod", routingMode: "pin" });
+    ).toEqual({ kind: "restore", groupId: null, connectionId: "eu-prod", routingMode: "pin", restExcludedDatasourceIds: [] });
   });
 
   test("seeds when a resolved group has no live members (fully archived group)", () => {

--- a/packages/web/src/ui/__tests__/env-picker.test.tsx
+++ b/packages/web/src/ui/__tests__/env-picker.test.tsx
@@ -1044,6 +1044,40 @@ describe("shouldRenderEnvPicker truth table (#2504)", () => {
       }),
     ).toBe(true);
   });
+
+  // #3066 — the exclude-set must be reachable on the common one-Postgres +
+  // one-REST workspace, where SQL routing alone is trivial (1 group / 1 member).
+  test("renders the trivial 1×1 case when there are REST datasources to exclude (#3066)", () => {
+    expect(
+      shouldRenderEnvPicker({
+        groups: [{ members: oneMember }],
+        reason: null,
+        restDatasources: [{ id: "stripe" }],
+      }),
+    ).toBe(true);
+  });
+
+  test("still hides 1×1 when there are no REST datasources (#3066)", () => {
+    expect(
+      shouldRenderEnvPicker({
+        groups: [{ members: oneMember }],
+        reason: null,
+        restDatasources: [],
+      }),
+    ).toBe(false);
+  });
+
+  // The zero-group REST-only workspace still hides (deferred follow-up): a
+  // SQL-less render path + independent exclude-set lifecycle are out of scope.
+  test("still hides a zero-group workspace even with REST datasources (#3066 deferred)", () => {
+    expect(
+      shouldRenderEnvPicker({
+        groups: [],
+        reason: null,
+        restDatasources: [{ id: "stripe" }],
+      }),
+    ).toBe(false);
+  });
 });
 
 describe("ChatEnvPicker transportError (#2504)", () => {

--- a/packages/web/src/ui/components/atlas-chat.tsx
+++ b/packages/web/src/ui/components/atlas-chat.tsx
@@ -136,6 +136,10 @@ export function AtlasChat() {
   // #2518 — three-state Auto/Pin/All cross-environment routing picker.
   const [selectedRoutingMode, setSelectedRoutingMode] =
     useState<ConversationRoutingMode | null>(null);
+  // #3066 — per-conversation REST datasource exclude-set (excluded
+  // `install_id`s). Empty = all in scope. Seeded from the sticky preference on
+  // a fresh chat, restored from the row when a conversation is opened.
+  const [selectedRestExcluded, setSelectedRestExcluded] = useState<string[]>([]);
   // #3044 — persisted env-picker preference so a reload restores the user's
   // last selection instead of re-seeding from the first group. Select fields
   // individually so the store object identity doesn't churn effect deps.
@@ -143,6 +147,7 @@ export function AtlasChat() {
   const prefGroupId = useChatRoutingPreferenceStore((s) => s.groupId);
   const prefConnectionId = useChatRoutingPreferenceStore((s) => s.connectionId);
   const prefRoutingMode = useChatRoutingPreferenceStore((s) => s.routingMode);
+  const prefRestExcluded = useChatRoutingPreferenceStore((s) => s.restExcludedDatasourceIds);
   const prefHasHydrated = useChatRoutingPreferenceStore((s) => s._hasHydrated);
   const setRoutingPreference = useChatRoutingPreferenceStore((s) => s.setPreference);
   // #3064 — how the current picker selection was set, so the seed/restore
@@ -183,6 +188,8 @@ export function AtlasChat() {
     getConnectionId: () => selectedConnectionId,
     getConnectionGroupId: () => selectedGroupId,
     getRoutingMode: () => selectedRoutingMode,
+    // #3066 — forward the REST exclude-set on every turn (always, even []).
+    getRestExcludedDatasourceIds: () => selectedRestExcluded,
   });
 
   const managedSession = authClient.useSession();
@@ -226,6 +233,7 @@ export function AtlasChat() {
         groupId: selectedGroupId,
         connectionId: selectedConnectionId,
         routingMode: selectedRoutingMode,
+        restExcludedDatasourceIds: selectedRestExcluded,
       },
       provenance: selectionProvenanceRef.current,
       preference: {
@@ -233,6 +241,7 @@ export function AtlasChat() {
         groupId: prefGroupId,
         connectionId: prefConnectionId,
         routingMode: prefRoutingMode,
+        restExcludedDatasourceIds: prefRestExcluded,
       },
       activeWorkspaceId,
       preferenceHydrated: prefHasHydrated,
@@ -246,6 +255,8 @@ export function AtlasChat() {
         // Apply the stored mode faithfully, including an explicit null
         // (pre-#2518 back-compat → "pin"); a truthy guard here would drop it.
         setSelectedRoutingMode(decision.routingMode);
+        // #3066 — seed the sticky preference's exclude-set onto this fresh chat.
+        setSelectedRestExcluded(decision.restExcludedDatasourceIds);
         // A restored sticky preference is the user's deliberate prior choice —
         // mark it explicit so a later effect run can't seed over it.
         selectionProvenanceRef.current = "explicit";
@@ -253,6 +264,8 @@ export function AtlasChat() {
       case "seed":
         setSelectedGroupId(decision.groupId);
         setSelectedConnectionId(decision.connectionId);
+        // #3066 — a default seed excludes nothing.
+        setSelectedRestExcluded(decision.restExcludedDatasourceIds);
         // Record that this was auto-seeded: a workspace-matching preference
         // arriving later is still restored over it (the resolver re-runs), but
         // a second default seed is suppressed.
@@ -277,10 +290,14 @@ export function AtlasChat() {
     // routingMode is part of `current` the resolver reads — keep it in deps so a
     // mode-only change re-evaluates restore-vs-noop rather than going stale.
     selectedRoutingMode,
+    // #3066 — exclude-set is part of `current`; keep it in deps so a pref-only
+    // exclude change re-evaluates restore-vs-noop rather than going stale.
+    selectedRestExcluded,
     prefWorkspaceId,
     prefGroupId,
     prefConnectionId,
     prefRoutingMode,
+    prefRestExcluded,
     prefHasHydrated,
     activeWorkspaceId,
     sessionResolved,
@@ -603,11 +620,17 @@ export function AtlasChat() {
         setSelectedGroupId(decision.groupId);
         setSelectedConnectionId(decision.connectionId);
         setSelectedRoutingMode(decision.routingMode);
+        // #3066 — restore the conversation's REST exclude-set so the picker +
+        // the next turn reflect what the row actually excludes.
+        setSelectedRestExcluded(decision.restExcludedDatasourceIds);
       } else {
         selectionProvenanceRef.current = "unset";
         setSelectedGroupId(null);
         setSelectedConnectionId(null);
         setSelectedRoutingMode(null);
+        // #3066 — no usable scope on the row: clear the exclude-set too and let
+        // the seed/restore effect re-seed from the sticky preference / default.
+        setSelectedRestExcluded([]);
       }
       setMobileSidebarOpen(false);
       // Loaded turns predate this session — no warning frames replay over
@@ -641,6 +664,9 @@ export function AtlasChat() {
     setSelectedGroupId(null);
     setSelectedConnectionId(null);
     setSelectedRoutingMode(null);
+    // #3066 — clear the exclude-set so the new chat re-seeds from the sticky
+    // preference (or the empty default), matching the env reset above.
+    setSelectedRestExcluded([]);
   }
 
   // Wait for auth mode detection before rendering — prevents flash of chat UI
@@ -703,6 +729,23 @@ export function AtlasChat() {
                     activeConnectionId={selectedConnectionId}
                     activeRoutingMode={selectedRoutingMode}
                     restDatasources={envGroupsQuery.restDatasources}
+                    restExcludedDatasourceIds={selectedRestExcluded}
+                    onRestExcludedChange={(next) => {
+                      // #3066 — a scope toggle is a deliberate pick: mark the
+                      // selection explicit (so the seed/restore effect can't
+                      // re-seed over it) and remember it in the sticky
+                      // preference so new chats inherit it. The full next set
+                      // (incl. []) is forwarded verbatim.
+                      selectionProvenanceRef.current = "explicit";
+                      setSelectedRestExcluded(next);
+                      setRoutingPreference({
+                        workspaceId: activeWorkspaceId,
+                        groupId: selectedGroupId,
+                        connectionId: selectedConnectionId,
+                        routingMode: selectedRoutingMode,
+                        restExcludedDatasourceIds: next,
+                      });
+                    }}
                     onSelect={({ groupId, connectionId, routingMode }) => {
                       // #3064 — a user pick is authoritative; mark it explicit
                       // so the seed/restore effect never replaces it.
@@ -711,12 +754,14 @@ export function AtlasChat() {
                       setSelectedConnectionId(connectionId);
                       setSelectedRoutingMode(routingMode);
                       // #3044 — remember this pick (scoped to the active
-                      // workspace) so a reload restores it.
+                      // workspace) so a reload restores it. #3066 — carry the
+                      // current exclude-set so an env change doesn't drop it.
                       setRoutingPreference({
                         workspaceId: activeWorkspaceId,
                         groupId,
                         connectionId,
                         routingMode,
+                        restExcludedDatasourceIds: selectedRestExcluded,
                       });
                     }}
                   />

--- a/packages/web/src/ui/components/chat/env-picker.tsx
+++ b/packages/web/src/ui/components/chat/env-picker.tsx
@@ -153,9 +153,13 @@ export function sameExcludeSet(
   a: ReadonlyArray<string>,
   b: ReadonlyArray<string>,
 ): boolean {
-  if (a.length !== b.length) return false;
+  // Compare as SETS, not lists — dedupe each side first. Comparing raw lengths
+  // would false-positive `["a","a"]` (1 distinct) against `["a","b"]` (2
+  // distinct). Mirrors the API route's `sameStringSet` exactly.
+  const setA = new Set(a);
   const setB = new Set(b);
-  for (const v of a) if (!setB.has(v)) return false;
+  if (setA.size !== setB.size) return false;
+  for (const v of setA) if (!setB.has(v)) return false;
   return true;
 }
 
@@ -169,12 +173,25 @@ export interface ShouldRenderEnvPickerArgs {
   readonly groups: ReadonlyArray<{ readonly members: ReadonlyArray<unknown> }>;
   readonly reason: MeConnectionGroupsEmptyReason | null;
   readonly error?: string | null;
+  /**
+   * #3066 — REST datasources the conversation can exclude. Their presence makes
+   * the picker worth showing even when SQL routing is trivial (one group / one
+   * member), so the exclude toggles stay reachable — otherwise the exclude-set
+   * feature is dead for the common one-Postgres + one-REST-datasource
+   * workspace. (A zero-group, REST-only workspace still hides the picker; that
+   * shape needs the SQL-less render path + an independent exclude-set lifecycle,
+   * tracked as a follow-up.)
+   */
+  readonly restDatasources?: ReadonlyArray<unknown>;
 }
 
 export function shouldRenderEnvPicker(args: ShouldRenderEnvPickerArgs): boolean {
   if (args.groups.length === 0) return args.reason !== null || args.error != null;
   if (args.groups.length > 1) return true;
-  return (args.groups[0]?.members.length ?? 0) > 1;
+  if ((args.groups[0]?.members.length ?? 0) > 1) return true;
+  // #3066 — single group + single member, but there are REST datasources to
+  // toggle: show the picker so the exclude-set is reachable.
+  return (args.restDatasources?.length ?? 0) > 0;
 }
 
 const EMPTY_REASON_COPY: Record<MeConnectionGroupsEmptyReason, string> = {
@@ -563,7 +580,7 @@ export function ChatEnvPicker({
     );
   }
 
-  if (!shouldRenderEnvPicker({ groups, reason: emptyReason, error: transportError })) {
+  if (!shouldRenderEnvPicker({ groups, reason: emptyReason, error: transportError, restDatasources })) {
     return null;
   }
 

--- a/packages/web/src/ui/components/chat/env-picker.tsx
+++ b/packages/web/src/ui/components/chat/env-picker.tsx
@@ -37,6 +37,7 @@ import { useEffect, useState } from "react";
 import { Layers, AlertCircle, Sparkles, Pin, Globe2, Check, Network } from "lucide-react";
 import {
   DropdownMenu,
+  DropdownMenuCheckboxItem,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuLabel,
@@ -114,12 +115,26 @@ export interface ChatEnvPickerProps {
    */
   readonly activeRoutingMode?: ConversationRoutingMode | null;
   /**
-   * #3044 — the workspace's REST datasources + their env scope. Rendered as a
-   * read-only footer so the user can see what a pinned conversation still
-   * reaches (workspace-global datasources answer regardless of the pin).
+   * #3044 — the workspace's REST datasources + their env scope. Rendered in the
+   * dropdown so the user can see (and, #3066, toggle) what the conversation
+   * reaches. Workspace-global datasources answer regardless of the SQL pin.
    * Optional / defaults to empty for back-compat with callers that don't pass it.
    */
   readonly restDatasources?: ReadonlyArray<ChatRestDatasourceScope>;
+  /**
+   * #3066 — the conversation's REST datasource exclude-set (excluded
+   * `install_id`s). A datasource in this set is unchecked in the picker and
+   * the agent will not query it. Defaults to empty (all in scope).
+   */
+  readonly restExcludedDatasourceIds?: ReadonlyArray<string>;
+  /**
+   * #3066 — called when the user checks / unchecks a REST datasource. Receives
+   * the FULL next exclude-set (not a delta) so the parent persists it verbatim
+   * — sending `[]` when everything is re-included is meaningful (it clears the
+   * row), so the parent must forward it as-is. Optional for callers that don't
+   * surface REST scope.
+   */
+  readonly onRestExcludedChange?: (next: string[]) => void;
   /**
    * Called when the user picks a new group / member / mode triple from
    * the dropdown. The parent decides whether this is a per-turn
@@ -127,6 +142,21 @@ export interface ChatEnvPickerProps {
    * server stamps the new value onto the conversation row).
    */
   readonly onSelect: (next: ChatEnvSelection) => void;
+}
+
+/**
+ * #3066 — order-independent equality for two string sets (excluded
+ * `install_id`s). Mirrors the API route's `sameStringSet` so the picker's
+ * "did the exclude-set actually change" checks agree with the server's.
+ */
+export function sameExcludeSet(
+  a: ReadonlyArray<string>,
+  b: ReadonlyArray<string>,
+): boolean {
+  if (a.length !== b.length) return false;
+  const setB = new Set(b);
+  for (const v of a) if (!setB.has(v)) return false;
+  return true;
 }
 
 /**
@@ -220,6 +250,8 @@ export interface ResolveEnvSelectionInput {
     readonly groupId: string | null;
     readonly connectionId: string | null;
     readonly routingMode: ConversationRoutingMode | null;
+    /** #3066 — current REST exclude-set, so a pref-only exclude change still restores. */
+    readonly restExcludedDatasourceIds: ReadonlyArray<string>;
   };
   /** How {@link current} was set. */
   readonly provenance: EnvSelectionProvenance;
@@ -246,8 +278,16 @@ export type EnvSelectionDecision =
       readonly groupId: string;
       readonly connectionId: string;
       readonly routingMode: ConversationRoutingMode | null;
+      /** #3066 — the sticky preference's exclude-set to seed onto this fresh chat. */
+      readonly restExcludedDatasourceIds: string[];
     }
-  | { readonly kind: "seed"; readonly groupId: string; readonly connectionId: string };
+  | {
+      readonly kind: "seed";
+      readonly groupId: string;
+      readonly connectionId: string;
+      /** #3066 — a default seed excludes nothing (every in-scope datasource queryable). */
+      readonly restExcludedDatasourceIds: string[];
+    };
 
 /**
  * Pure decision behind atlas-chat's fresh-chat seed/restore effect
@@ -300,13 +340,17 @@ export function resolveEnvSelection(
   );
   if (prefGroup && prefMember) {
     // Already on the preferred selection — don't churn React state. The
-    // routing mode is part of the selection, so a mode-only difference (e.g.
-    // a default seed landed on the preferred member but with no mode) must
-    // still restore.
+    // routing mode AND the exclude-set (#3066) are part of the selection, so a
+    // mode-only or exclude-only difference (e.g. a default seed landed on the
+    // preferred member but with no mode / empty exclude-set) must still restore.
     if (
       current.groupId === prefGroup.id &&
       current.connectionId === prefMember.connectionId &&
-      current.routingMode === preference.routingMode
+      current.routingMode === preference.routingMode &&
+      sameExcludeSet(
+        current.restExcludedDatasourceIds ?? [],
+        preference.restExcludedDatasourceIds ?? [],
+      )
     ) {
       return { kind: "noop" };
     }
@@ -315,6 +359,7 @@ export function resolveEnvSelection(
       groupId: prefGroup.id,
       connectionId: prefMember.connectionId,
       routingMode: preference.routingMode,
+      restExcludedDatasourceIds: [...(preference.restExcludedDatasourceIds ?? [])],
     };
   }
 
@@ -326,7 +371,14 @@ export function resolveEnvSelection(
   }
   const seed = pickDefaultEnvSeed(groups, current.connectionId);
   if (!seed) return { kind: "noop" };
-  return { kind: "seed", groupId: seed.groupId, connectionId: seed.connectionId };
+  // A default seed carries no exclusions — every in-scope REST datasource stays
+  // queryable until the user opts one out.
+  return {
+    kind: "seed",
+    groupId: seed.groupId,
+    connectionId: seed.connectionId,
+    restExcludedDatasourceIds: [],
+  };
 }
 
 /**
@@ -340,6 +392,8 @@ export interface ConversationScopeSource {
   readonly connectionGroupId: string | null;
   readonly connectionId: string | null;
   readonly routingMode?: ConversationRoutingMode | null;
+  /** #3066 — the row's REST exclude-set (excluded `install_id`s). Absent ⇒ none. */
+  readonly restExcludedDatasourceIds?: ReadonlyArray<string> | null;
 }
 
 /** The picker selection restored from a conversation row. */
@@ -347,6 +401,12 @@ export interface RestoredConversationScope {
   readonly groupId: string | null;
   readonly connectionId: string | null;
   readonly routingMode: ConversationRoutingMode | null;
+  /**
+   * #3066 — the conversation's REST exclude-set. The SQL scope (group/member)
+   * can fall back to a `seed` decision while the exclude-set is still carried
+   * faithfully on a `restore`; an absent / null column coalesces to `[]`.
+   */
+  readonly restExcludedDatasourceIds: string[];
 }
 
 /**
@@ -392,6 +452,12 @@ export function resolveConversationScope(
   const groupId = source.connectionGroupId;
   const connectionId = source.connectionId;
   const routingMode = source.routingMode ?? null;
+  // #3066 — the row's REST exclude-set, restored alongside the SQL scope.
+  // Coalesce an absent / null column to `[]` (no exclusions). Cloned so the
+  // caller owns a mutable array.
+  const restExcludedDatasourceIds = source.restExcludedDatasourceIds
+    ? [...source.restExcludedDatasourceIds]
+    : [];
 
   // A row that persisted no scope at all is never authoritative — defer to the
   // seed/restore effect (decided before the load gate so it holds either way).
@@ -401,7 +467,7 @@ export function resolveConversationScope(
   // row optimistically. Losing the restore here would be a worse, more common
   // regression than the rare archived-env + cold-start intersection.
   if (groups.length === 0) {
-    return { kind: "restore", groupId, connectionId, routingMode };
+    return { kind: "restore", groupId, connectionId, routingMode, restExcludedDatasourceIds };
   }
 
   // Groups loaded — validate the row against the visible environments.
@@ -416,13 +482,13 @@ export function resolveConversationScope(
     // preserving the still-valid group rather than discarding it.
     const member = group.members.find((m) => m.connectionId === connectionId);
     if (member) {
-      return { kind: "restore", groupId: group.id, connectionId: member.connectionId, routingMode };
+      return { kind: "restore", groupId: group.id, connectionId: member.connectionId, routingMode, restExcludedDatasourceIds };
     }
     const repaired =
       group.members.find((m) => m.connectionId === group.primaryConnectionId) ??
       group.members[0];
     if (!repaired) return { kind: "seed" }; // group exists but has no live members
-    return { kind: "restore", groupId: group.id, connectionId: repaired.connectionId, routingMode };
+    return { kind: "restore", groupId: group.id, connectionId: repaired.connectionId, routingMode, restExcludedDatasourceIds };
   }
 
   // Legacy group-less row (connectionGroupId null, connectionId set, e.g. a
@@ -436,7 +502,7 @@ export function resolveConversationScope(
     g.members.some((m) => m.connectionId === connectionId),
   );
   if (!owningGroup) return { kind: "seed" };
-  return { kind: "restore", groupId: owningGroup.id, connectionId, routingMode };
+  return { kind: "restore", groupId: owningGroup.id, connectionId, routingMode, restExcludedDatasourceIds };
 }
 
 /**
@@ -460,6 +526,8 @@ export function ChatEnvPicker({
   activeConnectionId,
   activeRoutingMode = null,
   restDatasources = [],
+  restExcludedDatasourceIds = [],
+  onRestExcludedChange,
   onSelect,
 }: ChatEnvPickerProps): React.ReactElement | null {
   // Empty list + a reason ⇒ render a diagnostic chip instead of
@@ -530,6 +598,20 @@ export function ChatEnvPicker({
     // <connId>).
     chipLabel = groupLabel === memberLabel ? memberLabel : `${groupLabel} / ${memberLabel}`;
     ChipIcon = Pin;
+  }
+
+  // #3066 — REST scope summary on the chip (e.g. `Pin · apac-prod · 2/3 REST`).
+  // "Relevant" = the datasources actually reachable in the active env
+  // (workspace-global + scoped to the active group); excluded ones reduce the
+  // in-scope count. Appended only when the workspace has at least one reachable
+  // REST datasource, so SQL-only workspaces keep their byte-identical chip.
+  const excludedRestSet = new Set(restExcludedDatasourceIds);
+  const reachableRest = restDatasources.filter(
+    (d) => d.groupId === null || d.groupId === (activeGroup?.id ?? null),
+  );
+  const restInScopeCount = reachableRest.filter((d) => !excludedRestSet.has(d.id)).length;
+  if (reachableRest.length > 0) {
+    chipLabel = `${chipLabel} · ${restInScopeCount}/${reachableRest.length} REST`;
   }
 
   // When every group has at most one member (the 0062 backfill shape,
@@ -688,6 +770,8 @@ export function ChatEnvPicker({
         <ChatEnvRestScopeSection
           restDatasources={restDatasources}
           activeGroupId={activeGroup?.id ?? null}
+          excludedIds={restExcludedDatasourceIds}
+          onRestExcludedChange={onRestExcludedChange}
         />
       </DropdownMenuContent>
     </DropdownMenu>
@@ -695,18 +779,26 @@ export function ChatEnvPicker({
 }
 
 /**
- * #3044 — read-only footer summarizing the workspace's REST datasources and
- * their environment scope, so the routing chip never overstates what the
- * conversation is constrained to. Workspace-global datasources answer
- * regardless of the pin (the bug this surfaces); datasources scoped to the
- * active group are in scope; ones scoped elsewhere are flagged out of scope.
+ * #3044 / #3066 — REST datasource scope section. Each datasource reachable in
+ * the active env (workspace-global, or scoped to the active group) renders as a
+ * checkbox: checked = in scope, unchecking EXCLUDES it from the conversation so
+ * the agent stops querying it (#3066). Datasources scoped to *other*
+ * environments aren't reachable here, so they stay informational (excluding
+ * them would be a no-op). Toggling sends the FULL next exclude-set to the
+ * parent — `[]` when everything is re-included is meaningful (it clears the
+ * row). When no `onRestExcludedChange` is supplied the rows fall back to a
+ * read-only summary (back-compat with #3044 callers).
  */
 function ChatEnvRestScopeSection({
   restDatasources,
   activeGroupId,
+  excludedIds,
+  onRestExcludedChange,
 }: {
   restDatasources: ReadonlyArray<ChatRestDatasourceScope>;
   activeGroupId: string | null;
+  excludedIds: ReadonlyArray<string>;
+  onRestExcludedChange?: (next: string[]) => void;
 }): React.ReactElement | null {
   if (restDatasources.length === 0) return null;
 
@@ -718,6 +810,42 @@ function ChatEnvRestScopeSection({
     (d) => d.groupId !== null && d.groupId !== activeGroupId,
   );
 
+  const excludedSet = new Set(excludedIds);
+  // Compute the next exclude-set when one datasource is (un)checked. `checked`
+  // = in scope, so checking removes it from the set and unchecking adds it.
+  const toggle = (id: string, checked: boolean) => {
+    if (!onRestExcludedChange) return;
+    const next = new Set(excludedSet);
+    if (checked) next.delete(id);
+    else next.add(id);
+    onRestExcludedChange([...next]);
+  };
+
+  const renderRow = (
+    d: ChatRestDatasourceScope,
+    opts: { readonly global: boolean },
+  ): React.ReactElement => {
+    const inScope = !excludedSet.has(d.id);
+    const Icon = opts.global ? Globe2 : Network;
+    return (
+      <DropdownMenuCheckboxItem
+        key={d.id}
+        checked={inScope}
+        // Keep the menu open so several datasources can be toggled in one pass.
+        onSelect={(e) => e.preventDefault()}
+        onCheckedChange={(checked) => toggle(d.id, checked === true)}
+        className="text-xs"
+        data-testid={`chat-env-picker-rest-toggle-${d.id}`}
+        data-in-scope={inScope}
+      >
+        <span className="flex min-w-0 items-center gap-1.5 truncate">
+          <Icon className="size-3 shrink-0 text-zinc-400" aria-hidden />
+          <span className="truncate">{d.displayName}</span>
+        </span>
+      </DropdownMenuCheckboxItem>
+    );
+  };
+
   return (
     <>
       <DropdownMenuSeparator />
@@ -726,33 +854,20 @@ function ChatEnvRestScopeSection({
       </DropdownMenuLabel>
 
       {workspaceGlobal.length > 0 && (
-        <div
-          className="px-2 py-1 text-[11px] leading-snug text-zinc-600 dark:text-zinc-300"
-          data-testid="chat-env-picker-rest-global"
-        >
-          <span className="flex items-center gap-1.5 font-medium text-zinc-700 dark:text-zinc-200">
-            <Globe2 className="size-3 text-zinc-400" aria-hidden />
+        <div data-testid="chat-env-picker-rest-global">
+          <DropdownMenuLabel className="px-2 pb-0.5 pt-1 text-[10px] font-normal text-zinc-400 dark:text-zinc-500">
             Workspace-global — answers in every environment
-          </span>
-          <span className="mt-0.5 block text-zinc-500 dark:text-zinc-400">
-            {workspaceGlobal.map((d) => d.displayName).join(", ")} — not limited by
-            the routing above.
-          </span>
+          </DropdownMenuLabel>
+          {workspaceGlobal.map((d) => renderRow(d, { global: true }))}
         </div>
       )}
 
       {inActiveGroup.length > 0 && (
-        <div
-          className="px-2 py-1 text-[11px] leading-snug text-zinc-600 dark:text-zinc-300"
-          data-testid="chat-env-picker-rest-in-scope"
-        >
-          <span className="flex items-center gap-1.5 font-medium text-zinc-700 dark:text-zinc-200">
-            <Network className="size-3 text-zinc-400" aria-hidden />
+        <div data-testid="chat-env-picker-rest-in-scope">
+          <DropdownMenuLabel className="px-2 pb-0.5 pt-1 text-[10px] font-normal text-zinc-400 dark:text-zinc-500">
             In this environment
-          </span>
-          <span className="mt-0.5 block text-zinc-500 dark:text-zinc-400">
-            {inActiveGroup.map((d) => d.displayName).join(", ")}
-          </span>
+          </DropdownMenuLabel>
+          {inActiveGroup.map((d) => renderRow(d, { global: false }))}
         </div>
       )}
 

--- a/packages/web/src/ui/hooks/use-atlas-transport.ts
+++ b/packages/web/src/ui/hooks/use-atlas-transport.ts
@@ -40,6 +40,14 @@ export interface UseAtlasTransportOptions {
    * default for legacy conversations).
    */
   getRoutingMode?: () => "auto" | "pin" | "all" | null;
+  /**
+   * #3066 — the conversation's REST datasource exclude-set (excluded
+   * `install_id`s). When provided, the transport ALWAYS sends it (even `[]`),
+   * because the chat route distinguishes "field present as []" (re-include —
+   * clear the row) from "field absent" (inherit the row). Omitting the field on
+   * a re-include would silently keep a stale exclusion — the #3073 bug class.
+   */
+  getRestExcludedDatasourceIds?: () => readonly string[];
 }
 
 export interface UseAtlasTransportReturn {
@@ -84,6 +92,12 @@ export function useAtlasTransport(
   // (which would cancel the in-flight stream).
   const getRoutingModeRef = useRef(opts.getRoutingMode);
   getRoutingModeRef.current = opts.getRoutingMode;
+
+  // #3066 — REST exclude-set getter. Ref for the same reason as the routing
+  // getters: a scope toggle between turns reaches the next request without
+  // rebuilding `useChat`'s transport.
+  const getRestExcludedDatasourceIdsRef = useRef(opts.getRestExcludedDatasourceIds);
+  getRestExcludedDatasourceIdsRef.current = opts.getRestExcludedDatasourceIds;
 
   // --- Auth state (seed from module cache to avoid flash on client-side nav) ---
   const [authMode, setAuthModeState] = useState<AuthMode | null>(_cachedAuthMode);
@@ -241,7 +255,7 @@ export function useAtlasTransport(
       headers,
       credentials: isCrossOrigin ? "include" : undefined,
       body: () => {
-        const body: Record<string, string> = {};
+        const body: Record<string, unknown> = {};
         if (conversationIdRef.current) {
           body.conversationId = conversationIdRef.current;
         }
@@ -263,6 +277,14 @@ export function useAtlasTransport(
         const routingMode = getRoutingModeRef.current?.();
         if (routingMode) {
           body.routingMode = routingMode;
+        }
+        // #3066 — REST exclude-set. ALWAYS sent when the getter is present
+        // (even `[]`), so a re-include actually clears the row instead of
+        // inheriting the stale set. API/SDK callers that don't supply the
+        // getter omit the field and the server falls back to the row value.
+        const restExcluded = getRestExcludedDatasourceIdsRef.current?.();
+        if (restExcluded !== undefined) {
+          body.restExcludedDatasourceIds = [...restExcluded];
         }
         return body;
       },


### PR DESCRIPTION
## What

S2a of the **v0.0.4 — Conversation Scope** milestone ([#3066](https://github.com/AtlasDevHQ/atlas/issues/3066)). REST datasources are in scope by default; a conversation can now **exclude** specific ones via the scope picker so the agent stops querying them. **SQL routing (Auto/Pin/All) is unaffected.** Per [ADR-0011](https://github.com/AtlasDevHQ/atlas/blob/main/docs/adr/0011-unified-conversation-scope.md).

## How (by layer)

1. **Migration + schema** — `0112_conversation_rest_excluded_datasources.sql` adds `conversations.rest_excluded_datasource_ids text[] NOT NULL DEFAULT '{}'` with a matching Drizzle `schema.ts` mirror (schema-drift gate) + real-Postgres `migrate-pg` smoke (passes). Empty `{}` = all in scope, so a newly-installed REST datasource is reachable with no action.
2. **Resolver** — `ResolveWorkspaceDeps.excluded` drops excluded `install_id`s **after** ADR-0010's group-scope filter and **before** credential build (never-rejects fail-soft contract preserved). The agent binds `executeRestOperation` to exactly the filtered set, so exclusion is enforced at **both** prompt-build and tool-execution. The confirm-replay path (`resolveFromContext`) stays deps-free, so a staged write replays regardless of the exclude-set.
3. **Chat + conversations routes** — mirror the `routingMode` pattern: body field + read-back from the row + persist (`updateConversationRestExcluded`, gated by `sameStringSet`). `GET /conversations/:id` carries the field.
4. **`@useatlas/types`** — `Conversation.restExcludedDatasourceIds` (type-only; patch-bumped to `0.1.10`).
5. **Web** — REST datasources render as **checkboxes** (default checked = in scope; unchecking excludes). The chip shows the in-scope count (e.g. `Pin · prod · 2/3 REST`). Threaded through `resolveEnvSelection` / `resolveConversationScope` provenance + the sticky-preference store (seeds new chats; restores on conversation open).

### ⚠️ The #3073 bug class (transport-omits-null)
`useAtlasTransport` **always** sends `restExcludedDatasourceIds` (even `[]`), and the route distinguishes *field present as `[]`* (re-include → clear the row) from *field absent* (inherit the row). Omitting the empty array on a re-include would silently keep a stale exclusion. Covered by a chat-route regression test.

## Acceptance criteria
- [x] Migration adds the column with a matching Drizzle mirror; `migrate-pg` smoke passes.
- [x] Unchecking a REST datasource excludes it for that conversation; the agent does not query it (resolver + bound-tool tests).
- [x] Default (`'{}'`) = all in scope; a newly-installed REST datasource is reachable without action.
- [x] Exclusion persists across reload (row) and seeds new chats (sticky preference).
- [x] Confirm-replay of a staged write ignores the exclude-set.
- [x] Re-including a previously-excluded datasource (`[]`) clears it on the row (no stale-exclusion fallback).

## Tests
- Resolver exclude-set (7 cases incl. group-scope ordering, fail-soft, strict-resolver).
- Chat route: ALS-frame propagation, empty-set stripped, **re-include `[]` persists**, omit-inherits-no-update.
- Data layer: `createConversation` / `getConversation` / fork param + SELECT updates.
- Web picker: chip count, excluded renders unchecked, toggle sends the full next set, re-check clears.

## CI
Local gates all green: lint, type, full test suite, syncpack, template/security/railway/schema/oauth drift, test-discipline, twenty-resolver, published-symbols.

## Follow-ups (not this PR)
- S2b [#3067](https://github.com/AtlasDevHQ/atlas/issues/3067) — REST-only focus (`rest_focus_datasource_id`, suspends `executeSQL`). Reuses these seams.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3077"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782921576&installation_id=135337507&pr_number=3077&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3077&signature=3df17f87cd19bd928d4d46c8357b7fc73841f1fb15373a903696b9887bacf262"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-conversation REST datasource exclusion: pick/exclude REST datasources in the chat env picker; exclusions persist with conversations, restore on reopen, can be cleared, and are honored during chats and agent runs.

* **Tests**
  * Expanded unit/integration tests covering exclude-set lifecycle, route behavior, transport payloads, resolver logic, tooling, and egress resolution.

* **Chores**
  * DB migration, schema/types, and OpenAPI/docs updated to store and document the per-conversation exclude-set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->