### PR TITLE
feat(scope): REST-only focus per conversation (#3067)

### DIFF
--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -105,6 +105,12 @@
                       "type": "string"
                     }
                   },
+                  "restFocusDatasourceId": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
                   "boundDashboardId": {
                     "type": "string",
                     "format": "uuid"
@@ -1862,6 +1868,12 @@
                               "type": "string"
                             }
                           },
+                          "restFocusDatasourceId": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
                           "starred": {
                             "type": "boolean"
                           },
@@ -2147,6 +2159,12 @@
                       "items": {
                         "type": "string"
                       }
+                    },
+                    "restFocusDatasourceId": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
                     },
                     "starred": {
                       "type": "boolean"

--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -109,7 +109,8 @@
                     "type": [
                       "string",
                       "null"
-                    ]
+                    ],
+                    "minLength": 1
                   },
                   "boundDashboardId": {
                     "type": "string",

--- a/bun.lock
+++ b/bun.lock
@@ -351,7 +351,7 @@
     },
     "packages/types": {
       "name": "@useatlas/types",
-      "version": "0.1.10",
+      "version": "0.1.11",
     },
     "packages/web": {
       "name": "@atlas/web",

--- a/packages/api/src/__mocks__/api-test-mocks.ts
+++ b/packages/api/src/__mocks__/api-test-mocks.ts
@@ -618,6 +618,7 @@ export function createApiTestMocks(
     // persist the row unless they exercise the scope-picker toggle, and
     // they override locally when they do.
     updateConversationRestExcluded: mock(() => Promise.resolve({ ok: true as const })),
+    updateConversationRestFocus: mock(() => Promise.resolve({ ok: true as const })),
     // NULL → "pin" back-compat default helper used by the chat route to
     // resolve a conversation's persisted `routing_mode`. Mocked as a pure
     // pass-through so tests can simulate either an explicit mode or the

--- a/packages/api/src/api/__tests__/actions.test.ts
+++ b/packages/api/src/api/__tests__/actions.test.ts
@@ -139,6 +139,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   verifyGroupBelongsToOrg: mock(() => Promise.resolve("ok")),
   updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
   updateConversationRestExcluded: mock(() => Promise.resolve({ ok: true as const })),
+  updateConversationRestFocus: mock(() => Promise.resolve({ ok: true as const })),
   resolveRoutingMode: mock((m: "auto" | "pin" | "all" | null | undefined = null) => m ?? "pin"),
 }));
 

--- a/packages/api/src/api/__tests__/admin-email-provider-route.test.ts
+++ b/packages/api/src/api/__tests__/admin-email-provider-route.test.ts
@@ -313,6 +313,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   verifyGroupBelongsToOrg: mock(() => Promise.resolve("ok")),
   updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
   updateConversationRestExcluded: mock(() => Promise.resolve({ ok: true as const })),
+  updateConversationRestFocus: mock(() => Promise.resolve({ ok: true as const })),
   resolveRoutingMode: mock((m: "auto" | "pin" | "all" | null | undefined = null) => m ?? "pin"),
 }));
 

--- a/packages/api/src/api/__tests__/admin-integrations-byot.test.ts
+++ b/packages/api/src/api/__tests__/admin-integrations-byot.test.ts
@@ -369,6 +369,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   verifyGroupBelongsToOrg: mock(() => Promise.resolve("ok")),
   updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
   updateConversationRestExcluded: mock(() => Promise.resolve({ ok: true as const })),
+  updateConversationRestFocus: mock(() => Promise.resolve({ ok: true as const })),
   resolveRoutingMode: mock((m: "auto" | "pin" | "all" | null | undefined = null) => m ?? "pin"),
 }));
 

--- a/packages/api/src/api/__tests__/admin-integrations.test.ts
+++ b/packages/api/src/api/__tests__/admin-integrations.test.ts
@@ -293,6 +293,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   verifyGroupBelongsToOrg: mock(() => Promise.resolve("ok")),
   updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
   updateConversationRestExcluded: mock(() => Promise.resolve({ ok: true as const })),
+  updateConversationRestFocus: mock(() => Promise.resolve({ ok: true as const })),
   resolveRoutingMode: mock((m: "auto" | "pin" | "all" | null | undefined = null) => m ?? "pin"),
 }));
 

--- a/packages/api/src/api/__tests__/admin-password.test.ts
+++ b/packages/api/src/api/__tests__/admin-password.test.ts
@@ -227,6 +227,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   verifyGroupBelongsToOrg: mock(() => Promise.resolve("ok")),
   updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
   updateConversationRestExcluded: mock(() => Promise.resolve({ ok: true as const })),
+  updateConversationRestFocus: mock(() => Promise.resolve({ ok: true as const })),
   resolveRoutingMode: mock((m: "auto" | "pin" | "all" | null | undefined = null) => m ?? "pin"),
 }));
 

--- a/packages/api/src/api/__tests__/admin.test.ts
+++ b/packages/api/src/api/__tests__/admin.test.ts
@@ -584,6 +584,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   verifyGroupBelongsToOrg: mock(() => Promise.resolve("ok")),
   updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
   updateConversationRestExcluded: mock(() => Promise.resolve({ ok: true as const })),
+  updateConversationRestFocus: mock(() => Promise.resolve({ ok: true as const })),
   resolveRoutingMode: mock((m: "auto" | "pin" | "all" | null | undefined = null) => m ?? "pin"),
 }));
 

--- a/packages/api/src/api/__tests__/chat.test.ts
+++ b/packages/api/src/api/__tests__/chat.test.ts
@@ -129,6 +129,11 @@ const mockGenerateTitle = mock((q: string) => q.slice(0, 80));
 const mockUpdateConversationRestExcluded = mock(() =>
   Promise.resolve({ ok: true as const }),
 );
+// #3067 — captured so tests can assert the REST-only focus persist path,
+// incl. the clear-via-null case (the #3073 transport-omits-null bug class).
+const mockUpdateConversationRestFocus = mock(() =>
+  Promise.resolve({ ok: true as const }),
+);
 type ReservationResult =
   | { status: "ok"; totalStepsBefore: number }
   | { status: "exceeded"; totalSteps: number }
@@ -170,6 +175,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   verifyGroupBelongsToOrg: mockVerifyGroupBelongsToOrg,
   updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
   updateConversationRestExcluded: mockUpdateConversationRestExcluded,
+  updateConversationRestFocus: mockUpdateConversationRestFocus,
   resolveRoutingMode: mock((m: "auto" | "pin" | "all" | null | undefined = null) => m ?? "pin"),
 }));
 
@@ -258,6 +264,8 @@ describe("POST /api/v1/chat", () => {
     mockGetConversationChat.mockResolvedValue({ ok: false, reason: "not_found" });
     mockUpdateConversationRestExcluded.mockReset();
     mockUpdateConversationRestExcluded.mockResolvedValue({ ok: true as const });
+    mockUpdateConversationRestFocus.mockReset();
+    mockUpdateConversationRestFocus.mockResolvedValue({ ok: true as const });
     mockReserveConversationBudget.mockReset();
     mockReserveConversationBudget.mockResolvedValue({ status: "ok", totalStepsBefore: 0 });
     mockSettleConversationSteps.mockReset();
@@ -567,6 +575,130 @@ describe("POST /api/v1/chat", () => {
     );
     expect(response.status).toBe(200);
     expect(mockUpdateConversationRestExcluded).not.toHaveBeenCalled();
+  });
+
+  // #3067 — the conversation's REST-only focus must reach the agent via the ALS
+  // frame so the agent loop resolves only that datasource and suspends executeSQL.
+  it("propagates restFocusDatasourceId into the ALS frame the agent sees (#3067)", async () => {
+    const { getRequestContext } = await import("@atlas/api/lib/logger");
+    let capturedContext: ReturnType<typeof getRequestContext> | undefined;
+    mockRunAgent.mockImplementationOnce(() => {
+      capturedContext = getRequestContext();
+      return Promise.resolve({
+        toUIMessageStreamResponse: () => new Response("stream", { status: 200 }),
+        toUIMessageStream: () => new ReadableStream({ start(c) { c.close(); } }),
+        text: Promise.resolve("answer"),
+      } as unknown as Awaited<ReturnType<typeof mockRunAgent>>);
+    });
+    const response = await app.fetch(
+      makeRequest({
+        messages: [{ id: "1", role: "user", parts: [{ type: "text", text: "ask stripe only" }] }],
+        restFocusDatasourceId: "ds-stripe",
+      }),
+    );
+    expect(response.status).toBe(200);
+    expect(capturedContext?.restFocusDatasourceId).toBe("ds-stripe");
+  });
+
+  // #3067 — a null/cleared focus must NOT be stamped on the ALS frame (the
+  // agent's "not focused" / default-scope path). Keeps the legacy shape for the
+  // common case where the conversation isn't focused.
+  it("does not stamp a null restFocusDatasourceId on the ALS frame (not focused) (#3067)", async () => {
+    const { getRequestContext } = await import("@atlas/api/lib/logger");
+    let capturedContext: ReturnType<typeof getRequestContext> | undefined;
+    mockRunAgent.mockImplementationOnce(() => {
+      capturedContext = getRequestContext();
+      return Promise.resolve({
+        toUIMessageStreamResponse: () => new Response("stream", { status: 200 }),
+        toUIMessageStream: () => new ReadableStream({ start(c) { c.close(); } }),
+        text: Promise.resolve("answer"),
+      } as unknown as Awaited<ReturnType<typeof mockRunAgent>>);
+    });
+    const response = await app.fetch(
+      makeRequest({
+        messages: [{ id: "1", role: "user", parts: [{ type: "text", text: "hi" }] }],
+        restFocusDatasourceId: null,
+      }),
+    );
+    expect(response.status).toBe(200);
+    expect(capturedContext?.restFocusDatasourceId).toBeUndefined();
+  });
+
+  // #3067 / #3073 — the clear-focus path. An existing conversation is focused on
+  // ds-stripe; the user clears focus, so the body carries `null` (the transport
+  // sends null explicitly). The route distinguishes "field present as null"
+  // (persist the clear) from "field absent" (inherit the row) — without it a
+  // clear silently keeps the stale focus.
+  it("persists a clear (null nulls a prior focus) (#3067/#3073)", async () => {
+    const convId = "c3d4e5f6-a7b8-49c0-9def-0123456789ab";
+    mockGetConversationChat.mockResolvedValueOnce({
+      ok: true,
+      data: {
+        id: convId,
+        userId: null,
+        title: "Test",
+        connectionId: null,
+        connectionGroupId: null,
+        routingMode: null,
+        restExcludedDatasourceIds: [],
+        restFocusDatasourceId: "ds-stripe",
+        messages: [],
+      },
+    });
+    const response = await app.fetch(
+      makeRequest({
+        messages: [{ id: "1", role: "user", parts: [{ type: "text", text: "clear focus" }] }],
+        conversationId: convId,
+        restFocusDatasourceId: null,
+      }),
+    );
+    expect(response.status).toBe(200);
+    expect(mockUpdateConversationRestFocus).toHaveBeenCalledTimes(1);
+    const calls = mockUpdateConversationRestFocus.mock.calls as unknown as unknown[][];
+    // Second arg is the new (null) focus persisted to the row.
+    expect(calls[0]![1]).toBeNull();
+  });
+
+  // #3067 — when the body OMITS focus (the common follow-up turn), the stored
+  // focus is inherited into the ALS frame and NO redundant UPDATE fires.
+  it("inherits the stored focus and skips the UPDATE when the body omits it (#3067)", async () => {
+    const convId = "e5f6a7b8-c9d0-41e2-93f4-56789abcdef0";
+    mockGetConversationChat.mockResolvedValueOnce({
+      ok: true,
+      data: {
+        id: convId,
+        userId: null,
+        title: "Test",
+        connectionId: null,
+        connectionGroupId: null,
+        routingMode: null,
+        restExcludedDatasourceIds: [],
+        restFocusDatasourceId: "ds-stripe",
+        messages: [],
+      },
+    });
+    const { getRequestContext } = await import("@atlas/api/lib/logger");
+    let capturedContext: ReturnType<typeof getRequestContext> | undefined;
+    mockRunAgent.mockImplementationOnce(() => {
+      capturedContext = getRequestContext();
+      return Promise.resolve({
+        toUIMessageStreamResponse: () => new Response("stream", { status: 200 }),
+        toUIMessageStream: () => new ReadableStream({ start(c) { c.close(); } }),
+        text: Promise.resolve("answer"),
+      } as unknown as Awaited<ReturnType<typeof mockRunAgent>>);
+    });
+    const response = await app.fetch(
+      makeRequest({
+        messages: [{ id: "1", role: "user", parts: [{ type: "text", text: "follow up" }] }],
+        conversationId: convId,
+        // restFocusDatasourceId intentionally omitted
+      }),
+    );
+    expect(response.status).toBe(200);
+    // Inherited the stored focus into the ALS frame…
+    expect(capturedContext?.restFocusDatasourceId).toBe("ds-stripe");
+    // …and did NOT burn an UPDATE (body absent → inherit, no change).
+    expect(mockUpdateConversationRestFocus).not.toHaveBeenCalled();
   });
 
   // F-74 regression pin: the chat handler MUST pass `bucket: "chat"` so the

--- a/packages/api/src/api/__tests__/conversations.test.ts
+++ b/packages/api/src/api/__tests__/conversations.test.ts
@@ -149,6 +149,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   // locally.
   updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
   updateConversationRestExcluded: mock(() => Promise.resolve({ ok: true as const })),
+  updateConversationRestFocus: mock(() => Promise.resolve({ ok: true as const })),
   resolveRoutingMode: mock((m: "auto" | "pin" | "all" | null | undefined = null) => m ?? "pin"),
   // Type exports (no runtime value — needed so mock.module doesn't break re-exports)
 }));

--- a/packages/api/src/api/__tests__/dashboards.test.ts
+++ b/packages/api/src/api/__tests__/dashboards.test.ts
@@ -299,6 +299,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   verifyGroupBelongsToOrg: mockVerifyGroupBelongsToOrg,
   updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
   updateConversationRestExcluded: mock(() => Promise.resolve({ ok: true as const })),
+  updateConversationRestFocus: mock(() => Promise.resolve({ ok: true as const })),
   resolveRoutingMode: mock((m: "auto" | "pin" | "all" | null | undefined = null) => m ?? "pin"),
 }));
 

--- a/packages/api/src/api/__tests__/health-plugin.test.ts
+++ b/packages/api/src/api/__tests__/health-plugin.test.ts
@@ -131,6 +131,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   verifyGroupBelongsToOrg: mock(() => Promise.resolve("ok")),
   updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
   updateConversationRestExcluded: mock(() => Promise.resolve({ ok: true as const })),
+  updateConversationRestFocus: mock(() => Promise.resolve({ ok: true as const })),
   resolveRoutingMode: mock((m: "auto" | "pin" | "all" | null | undefined = null) => m ?? "pin"),
 }));
 

--- a/packages/api/src/api/__tests__/health.test.ts
+++ b/packages/api/src/api/__tests__/health.test.ts
@@ -136,6 +136,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   verifyGroupBelongsToOrg: mock(() => Promise.resolve("ok")),
   updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
   updateConversationRestExcluded: mock(() => Promise.resolve({ ok: true as const })),
+  updateConversationRestFocus: mock(() => Promise.resolve({ ok: true as const })),
   resolveRoutingMode: mock((m: "auto" | "pin" | "all" | null | undefined = null) => m ?? "pin"),
 }));
 

--- a/packages/api/src/api/__tests__/query.test.ts
+++ b/packages/api/src/api/__tests__/query.test.ts
@@ -160,6 +160,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   verifyGroupBelongsToOrg: mock(() => Promise.resolve("ok")),
   updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
   updateConversationRestExcluded: mock(() => Promise.resolve({ ok: true as const })),
+  updateConversationRestFocus: mock(() => Promise.resolve({ ok: true as const })),
   resolveRoutingMode: mock((m: "auto" | "pin" | "all" | null | undefined = null) => m ?? "pin"),
 }));
 

--- a/packages/api/src/api/__tests__/scheduled-tasks.test.ts
+++ b/packages/api/src/api/__tests__/scheduled-tasks.test.ts
@@ -122,6 +122,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   verifyGroupBelongsToOrg: mock(() => Promise.resolve("ok")),
   updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
   updateConversationRestExcluded: mock(() => Promise.resolve({ ok: true as const })),
+  updateConversationRestFocus: mock(() => Promise.resolve({ ok: true as const })),
   resolveRoutingMode: mock((m: "auto" | "pin" | "all" | null | undefined = null) => m ?? "pin"),
 }));
 

--- a/packages/api/src/api/__tests__/semantic-overlay.test.ts
+++ b/packages/api/src/api/__tests__/semantic-overlay.test.ts
@@ -347,6 +347,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   verifyGroupBelongsToOrg: mock(() => Promise.resolve("ok")),
   updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
   updateConversationRestExcluded: mock(() => Promise.resolve({ ok: true as const })),
+  updateConversationRestFocus: mock(() => Promise.resolve({ ok: true as const })),
   resolveRoutingMode: mock((m: "auto" | "pin" | "all" | null | undefined = null) => m ?? "pin"),
 }));
 

--- a/packages/api/src/api/__tests__/semantic.test.ts
+++ b/packages/api/src/api/__tests__/semantic.test.ts
@@ -277,6 +277,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   verifyGroupBelongsToOrg: mock(() => Promise.resolve("ok")),
   updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
   updateConversationRestExcluded: mock(() => Promise.resolve({ ok: true as const })),
+  updateConversationRestFocus: mock(() => Promise.resolve({ ok: true as const })),
   resolveRoutingMode: mock((m: "auto" | "pin" | "all" | null | undefined = null) => m ?? "pin"),
 }));
 

--- a/packages/api/src/api/routes/chat.ts
+++ b/packages/api/src/api/routes/chat.ts
@@ -43,6 +43,7 @@ import {
   settleConversationSteps,
   updateConversationRoutingMode,
   updateConversationRestExcluded,
+  updateConversationRestFocus,
   resolveRoutingMode,
 } from "@atlas/api/lib/conversations";
 import type { ConversationRoutingMode } from "@useatlas/types/conversation";
@@ -417,6 +418,19 @@ export const ChatRequestSchema = z.object({
     .array(z.string())
     .transform((ids) => [...new Set(ids)])
     .optional(),
+  /**
+   * #3067 — per-conversation REST-only focus. The scope picker sends the
+   * focused `install_id` (or `null` to clear focus); the route persists it
+   * onto the conversation row AND stamps it into the request context so the
+   * agent loop resolves only that datasource and suspends `executeSQL`.
+   *
+   * Presence is meaningful, like the exclude-set: an explicit `null` CLEARS
+   * focus (back to default scope), whereas an OMITTED field inherits the
+   * conversation's stored focus. The web transport must therefore send the
+   * field (including `null`) whenever the picker was touched, or a clear
+   * silently keeps the stale focus (the #3073 transport-omits-null bug class).
+   */
+  restFocusDatasourceId: z.string().nullable().optional(),
   /**
    * #2363 — bound dashboard editor. When the chat drawer opens on
    * `/dashboards/[id]` the client supplies the dashboard id once (on
@@ -819,6 +833,14 @@ chat.openapi(chatRoute, async (c) => {
         // the row (the transport-omits-null bug class, #3073).
         let effectiveRestExcluded: string[] | undefined =
           parsed.data.restExcludedDatasourceIds;
+        // #3067 — per-conversation REST-only focus. Body value (this turn,
+        // from the scope picker) > stored value on the row. PRESENCE is
+        // meaningful: an explicit `null` clears focus, an OMITTED field
+        // inherits the row's value. We keep `undefined` (omitted) vs `null`
+        // (clear) distinct all the way through so a clear actually nulls the
+        // row (the transport-omits-null bug class, #3073).
+        let effectiveRestFocus: string | null | undefined =
+          parsed.data.restFocusDatasourceId;
 
         // #2424 — when the body supplies `connectionGroupId`, verify it
         // belongs to the caller's active org BEFORE persisting it onto the
@@ -901,6 +923,13 @@ chat.openapi(chatRoute, async (c) => {
             ) {
               effectiveRestExcluded = existing.data.restExcludedDatasourceIds;
             }
+            // #3067 — inherit REST-only focus from the row when the body omits
+            // it. An explicit `null` from the body is NOT omitted (it clears
+            // focus), so the `=== undefined` guard keeps "clear" distinct from
+            // "field absent → use the row".
+            if (effectiveRestFocus === undefined) {
+              effectiveRestFocus = existing.data.restFocusDatasourceId ?? null;
+            }
             // Persist the picker mode if the body explicitly set one for
             // this turn. We compare against the stored value to avoid
             // burning an UPDATE on every chat turn when nothing changed.
@@ -954,6 +983,34 @@ chat.openapi(chatRoute, async (c) => {
                     conversationId,
                   },
                   "updateConversationRestExcluded rejected",
+                );
+              });
+            }
+            // #3067 — persist REST-only focus when the body explicitly set one
+            // this turn AND it differs from the stored value. An explicit
+            // `null` that clears a prior focus DOES persist (the clear path the
+            // transport must support); normalize the row's value with `?? null`
+            // so a string→null or null→string change is detected.
+            if (
+              parsed.data.restFocusDatasourceId !== undefined &&
+              parsed.data.restFocusDatasourceId !==
+                (existing.data.restFocusDatasourceId ?? null)
+            ) {
+              // Fire-and-forget, same contract as routing-mode / exclude-set
+              // above: the runtime honours the body's focus for this turn even
+              // if the persist fails; the helper logs its own failures.
+              updateConversationRestFocus(
+                conversationId,
+                parsed.data.restFocusDatasourceId,
+                authResult.user?.id,
+                authResult.user?.activeOrganizationId,
+              ).catch((err: unknown) => {
+                log.warn(
+                  {
+                    err: err instanceof Error ? err.message : String(err),
+                    conversationId,
+                  },
+                  "updateConversationRestFocus rejected",
                 );
               });
             }
@@ -1068,6 +1125,11 @@ chat.openapi(chatRoute, async (c) => {
                 // #3066 — persist the exclude-set the user picked at
                 // creation. Undefined ⇒ column default '{}' (all in scope).
                 restExcludedDatasourceIds: effectiveRestExcluded,
+                // #3067 — persist REST-only focus the user picked at creation.
+                // Undefined / null ⇒ NULL (not focused). The transport sends
+                // null when the picker is in default mode, so `?? null` keeps a
+                // newly-created default-mode conversation un-focused.
+                restFocusDatasourceId: effectiveRestFocus ?? null,
                 orgId: authResult.user?.activeOrganizationId,
               });
               if (created) {
@@ -1312,6 +1374,13 @@ chat.openapi(chatRoute, async (c) => {
                 effectiveRestExcluded.length > 0 && {
                   restExcludedDatasourceIds: effectiveRestExcluded,
                 }),
+              // #3067 — the resolved focus reaches the agent loop via the
+              // request context. Stamped only when truthy (a non-null
+              // install_id); a null/cleared focus keeps the legacy
+              // not-focused shape so default-scope turns are unchanged.
+              ...(effectiveRestFocus
+                ? { restFocusDatasourceId: effectiveRestFocus }
+                : {}),
             },
             () =>
               runAgent({

--- a/packages/api/src/api/routes/chat.ts
+++ b/packages/api/src/api/routes/chat.ts
@@ -429,8 +429,17 @@ export const ChatRequestSchema = z.object({
    * conversation's stored focus. The web transport must therefore send the
    * field (including `null`) whenever the picker was touched, or a clear
    * silently keeps the stale focus (the #3073 transport-omits-null bug class).
+   *
+   * An empty string is rejected (`.min(1)`): the only valid focus values are a
+   * non-empty `install_id` (set) or `null` (clear). Allowing `""` through would
+   * persist it as focus yet read back as "not focused" at the runtime truthy
+   * gate — invalid stored state with the UI and agent disagreeing (CodeRabbit).
    */
-  restFocusDatasourceId: z.string().nullable().optional(),
+  restFocusDatasourceId: z
+    .string()
+    .min(1, "restFocusDatasourceId must be a non-empty install_id or null.")
+    .nullable()
+    .optional(),
   /**
    * #2363 — bound dashboard editor. When the chat drawer opens on
    * `/dashboards/[id]` the client supplies the dashboard id once (on

--- a/packages/api/src/api/routes/conversations.ts
+++ b/packages/api/src/api/routes/conversations.ts
@@ -102,6 +102,14 @@ const ConversationSchema = z.object({
    * `routingMode`). Mirrors the `Conversation` wire type.
    */
   restExcludedDatasourceIds: z.array(z.string()).optional(),
+  /**
+   * Per-conversation REST-only focus (#3067). The single `install_id` the
+   * conversation targets exclusively (suspending `executeSQL`), or `null`
+   * when not focused. Genuinely nullable (the column is plain nullable
+   * `text`); optional so pre-#3067 rows / SDK consumers need not supply it.
+   * Mirrors the `Conversation` wire type.
+   */
+  restFocusDatasourceId: z.string().nullable().optional(),
   starred: z.boolean(),
   createdAt: z.string().datetime(),
   updatedAt: z.string().datetime(),

--- a/packages/api/src/lib/__tests__/agent-scope-prompt.test.ts
+++ b/packages/api/src/lib/__tests__/agent-scope-prompt.test.ts
@@ -24,6 +24,7 @@ import {
 import type { LanguageModelV3StreamPart } from "@ai-sdk/provider";
 import type { UIMessage } from "ai";
 import { createConnectionMock } from "@atlas/api/testing/connection";
+import type { RestDatasource } from "@atlas/api/lib/openapi/datasource";
 
 // Module-top env setup — must be set before the dynamic imports below
 // (the imported modules read env at module-load time). `??=` keeps the
@@ -39,9 +40,45 @@ process.env.ATLAS_DATASOURCE_URL ??= "postgresql://test:test@localhost:5432/test
 
 let mockModel: InstanceType<typeof MockLanguageModelV3>;
 let lastSystemPrompt: string | undefined;
+// Capture the tool NAMES handed to the LLM so #3067 tests can assert executeSQL
+// is stripped on a focused (REST-only) turn. The AI SDK passes `opts.tools` as
+// an array of tool definitions (each with a `.name`), not a name-keyed object.
+let lastToolNames: string[] | undefined;
+function captureToolNames(tools: unknown): void {
+  if (Array.isArray(tools)) {
+    lastToolNames = tools
+      .map((t) => (t as { name?: string })?.name)
+      .filter((n): n is string => typeof n === "string");
+  } else if (tools && typeof tools === "object") {
+    lastToolNames = Object.keys(tools);
+  }
+}
 // #3044 — capture how the agent loop calls the REST resolver so we can pin that
 // the conversation's `connectionGroupId` is threaded as `activeGroupId`.
 let capturedRestResolveArgs: { orgId: string; deps: unknown } | undefined;
+// #3067 — capture the THROWING resolver call (the focused-turn resolve) + drive
+// what it returns / throws. Defaults to `[]` so the existing #3044 tests (which
+// never set a focus) are unaffected.
+let capturedOrThrowArgs: { orgId: string; deps: unknown } | undefined;
+let restOrThrowResult: RestDatasource[] | Error = [];
+// What the never-rejects resolver returns (the default-scope path). Default [].
+let restResolveResult: RestDatasource[] = [];
+
+// A minimal RestDatasource stub — the representation builder is mocked below, so
+// the graph is never inspected; only id / displayName / groupId / mode are read.
+// Cast at the boundary: the test only needs the shape the focus path touches.
+function restDatasourceStub(id: string, groupId: string | null = null): RestDatasource {
+  return {
+    id,
+    displayName: id,
+    ...(groupId !== null ? { groupId } : {}),
+    graph: { servers: [], operations: [], components: {} },
+    baseUrl: `https://${id}.example.com`,
+    representationMode: "operation-list",
+    writeAllowlist: new Set<string>(),
+    sideEffectingOperations: new Set<string>(),
+  } as unknown as RestDatasource;
+}
 
 mock.module("@atlas/api/lib/providers", () => ({
   getModel: () => mockModel,
@@ -120,12 +157,26 @@ mock.module("@atlas/api/lib/cache/index", () => ({
 mock.module("@atlas/api/lib/openapi/workspace-datasource", () => ({
   resolveWorkspaceRestDatasources: async (orgId: string, deps: unknown) => {
     capturedRestResolveArgs = { orgId, deps };
-    return [];
+    return restResolveResult;
   },
-  resolveWorkspaceRestDatasourcesOrThrow: async () => [],
+  resolveWorkspaceRestDatasourcesOrThrow: async (orgId: string, deps: unknown) => {
+    capturedOrThrowArgs = { orgId, deps };
+    if (restOrThrowResult instanceof Error) throw restOrThrowResult;
+    return restOrThrowResult;
+  },
   resolveWorkspacePrimaryRestDatasource: async () => null,
   defaultQuery: async () => [],
   RestDatasourceReconnectError: class extends Error {},
+}));
+
+// #3067 — stub the REST representation builder so a focused-turn datasource stub
+// builds a prompt section without a real OperationGraph. Existing tests return
+// no datasources, so this is never exercised by them.
+mock.module("@atlas/api/lib/openapi/representation", () => ({
+  buildAgentRepresentation: () => ({
+    promptContext: "### REST Datasource (stub)\nuse executeRestOperation",
+    unresolvedResources: [],
+  }),
 }));
 
 // Spy on the LLM `doStream` call so we can capture the rendered system prompt
@@ -169,6 +220,9 @@ function makeSpyingModel(toolCallArgs: Record<string, unknown>): InstanceType<ty
             : "";
         if (content) lastSystemPrompt = content;
       }
+      // #3067 — capture the tool set so focus tests can assert executeSQL is
+      // present (default) or stripped (focused REST-only turn).
+      captureToolNames(opts?.tools);
       if (streamIdx >= allSteps.length) {
         return { stream: convertArrayToReadableStream(allSteps[allSteps.length - 1]) };
       }
@@ -504,5 +558,132 @@ describe("agent loop — REST datasource scope threading (#3044)", () => {
     // `undefined` would disable scoping in the resolver (the confirm-replay path)
     // and re-leak a scoped datasource into the chat — the regression #3044 closes.
     expect((capturedRestResolveArgs!.deps as { activeGroupId: unknown }).activeGroupId).not.toBeUndefined();
+  });
+});
+
+describe("agent loop — REST-only focus suspends executeSQL (#3067)", () => {
+  // Text-only model: emits no tool call, so the agent just builds the prompt +
+  // tool set (captured via doStream opts) and finishes.
+  function makeCapturingTextModel(): InstanceType<typeof MockLanguageModelV3> {
+    return new MockLanguageModelV3({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      doStream: async (opts: any) => {
+        const systemMsg = opts?.prompt?.find((p: { role: string }) => p.role === "system");
+        if (systemMsg) {
+          lastSystemPrompt =
+            typeof systemMsg.content === "string"
+              ? systemMsg.content
+              : Array.isArray(systemMsg.content)
+                ? systemMsg.content.map((c: { text?: string }) => c.text ?? "").join("")
+                : "";
+        }
+        captureToolNames(opts?.tools);
+        return {
+          stream: convertArrayToReadableStream([
+            { type: "text-delta", id: "t0", delta: "Hi." },
+            {
+              type: "finish",
+              usage: {
+                inputTokens: { total: 5, noCache: 5, cacheRead: undefined, cacheWrite: undefined },
+                outputTokens: { total: 5, text: 5, reasoning: undefined },
+              },
+              finishReason: { unified: "stop", raw: "end_turn" },
+            },
+          ]),
+        };
+      },
+    });
+  }
+
+  const focusUser = {
+    id: "u1",
+    mode: "managed" as const,
+    label: "u@test",
+    role: "member" as const,
+    activeOrganizationId: "org-1",
+  };
+
+  beforeEach(() => {
+    capturedRestResolveArgs = undefined;
+    capturedOrThrowArgs = undefined;
+    restOrThrowResult = [];
+    restResolveResult = [];
+    lastToolNames = undefined;
+    lastSystemPrompt = undefined;
+    mockModel = makeCapturingTextModel();
+    process.env.ATLAS_DATASOURCE_URL = "postgresql://test:test@localhost:5432/test";
+  });
+
+  it("strips executeSQL and adds the focus banner when the focus resolves", async () => {
+    restOrThrowResult = [restDatasourceStub("stripe")];
+    const result = await withRequestContext(
+      { requestId: "focus-1", user: focusUser, restFocusDatasourceId: "stripe" },
+      () => runAgent({ messages: userMessages("ask stripe only") }),
+    );
+    await result.steps; // consume the stream so doStream captures tools + prompt
+    // Resolved via the THROWING resolver, focus only (group + exclude inert).
+    expect(capturedOrThrowArgs).toBeDefined();
+    expect(capturedOrThrowArgs!.deps).toEqual({ focus: "stripe" });
+    // executeSQL is gone; explore + executeRestOperation remain.
+    expect(lastToolNames).toBeDefined();
+    expect(lastToolNames).not.toContain("executeSQL");
+    expect(lastToolNames).toContain("executeRestOperation");
+    expect(lastToolNames).toContain("explore");
+    // The REST-only focus banner is in the system prompt.
+    expect(lastSystemPrompt).toContain("REST-only focus");
+  });
+
+  it("ignores the exclude-set while focused — resolves with focus only (#3067)", async () => {
+    restOrThrowResult = [restDatasourceStub("stripe")];
+    await withRequestContext(
+      {
+        requestId: "focus-2",
+        user: focusUser,
+        restFocusDatasourceId: "stripe",
+        restExcludedDatasourceIds: ["other"],
+        connectionGroupId: "prod",
+      },
+      () => runAgent({ messages: userMessages("ask stripe only") }),
+    );
+    // No `excluded` / `activeGroupId` key — focus short-circuits both.
+    expect(capturedOrThrowArgs!.deps).toEqual({ focus: "stripe" });
+  });
+
+  it("falls back to default scope (executeSQL active) when the focus is genuinely uninstalled", async () => {
+    restOrThrowResult = []; // focus matched no install — rows loaded fine
+    restResolveResult = []; // default-scope resolve (no REST datasources here)
+    const result = await withRequestContext(
+      {
+        requestId: "focus-3",
+        user: focusUser,
+        restFocusDatasourceId: "gone",
+        connectionGroupId: "prod",
+        restExcludedDatasourceIds: ["x"],
+      },
+      () => runAgent({ messages: userMessages("hello") }),
+    );
+    await result.steps; // consume the stream so doStream captures tools + prompt
+    // The focus resolve (empty), THEN the default-scope never-rejects fallback.
+    expect(capturedOrThrowArgs!.deps).toEqual({ focus: "gone" });
+    expect(capturedRestResolveArgs!.deps).toEqual({ activeGroupId: "prod", excluded: ["x"] });
+    // executeSQL is back; no focus banner.
+    expect(lastToolNames).toContain("executeSQL");
+    expect(lastSystemPrompt).not.toContain("REST-only focus");
+  });
+
+  it("fails CLOSED (keeps executeSQL suspended) when the focus resolve throws", async () => {
+    // A load failure / reconnect-needed throws from the throwing resolver — the
+    // focus is NOT gone, so SQL must stay suspended (no silent re-enable).
+    restOrThrowResult = new Error("internal DB unavailable");
+    const result = await withRequestContext(
+      { requestId: "focus-4", user: focusUser, restFocusDatasourceId: "stripe" },
+      () => runAgent({ messages: userMessages("ask stripe only") }),
+    );
+    await result.steps; // consume the stream so doStream captures tools + prompt
+    expect(lastToolNames).not.toContain("executeSQL");
+    // No silent fallback to the default-scope resolver either.
+    expect(capturedRestResolveArgs).toBeUndefined();
+    // The model is told the focused datasource is temporarily unavailable.
+    expect(lastSystemPrompt).toContain("temporarily unavailable");
   });
 });

--- a/packages/api/src/lib/__tests__/agent-scope-prompt.test.ts
+++ b/packages/api/src/lib/__tests__/agent-scope-prompt.test.ts
@@ -23,6 +23,7 @@ import {
 } from "ai/test";
 import type { LanguageModelV3StreamPart } from "@ai-sdk/provider";
 import type { UIMessage } from "ai";
+import type { ChatContextWarning } from "@useatlas/types";
 import { createConnectionMock } from "@atlas/api/testing/connection";
 import type { RestDatasource } from "@atlas/api/lib/openapi/datasource";
 
@@ -52,6 +53,23 @@ function captureToolNames(tools: unknown): void {
   } else if (tools && typeof tools === "object") {
     lastToolNames = Object.keys(tools);
   }
+}
+// The slices of the AI SDK's `doStream` options the spies read, narrowed from
+// `unknown` (never `any`, per CLAUDE.md) — the real LanguageModelV3CallOptions is
+// far broader than these tests touch, so a local structural narrow is enough.
+function extractSystemPrompt(opts: unknown): string | undefined {
+  const prompt = (opts as { prompt?: ReadonlyArray<{ role: string; content: unknown }> })?.prompt;
+  const systemMsg = Array.isArray(prompt) ? prompt.find((p) => p.role === "system") : undefined;
+  if (!systemMsg) return undefined;
+  const content = systemMsg.content;
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return content.map((c) => (c as { text?: string })?.text ?? "").join("");
+  }
+  return "";
+}
+function extractTools(opts: unknown): unknown {
+  return (opts as { tools?: unknown })?.tools;
 }
 // #3044 — capture how the agent loop calls the REST resolver so we can pin that
 // the conversation's `connectionGroupId` is threaded as `activeGroupId`.
@@ -171,8 +189,14 @@ mock.module("@atlas/api/lib/openapi/workspace-datasource", () => ({
 
 // #3067 — stub the REST representation builder so a focused-turn datasource stub
 // builds a prompt section without a real OperationGraph. Existing tests return
-// no datasources, so this is never exercised by them.
+// no datasources, so this is never exercised by them. Every *value* export of the
+// real module is mocked (CLAUDE.md: mock all exports, or Bun loads the real
+// module for an un-mocked name). The module's three remaining exports —
+// `RepresentationMode`, `AgentRepresentation`, `BuildRepresentationOptions` — are
+// type-only and erased at runtime, so there is nothing to stub for them.
 mock.module("@atlas/api/lib/openapi/representation", () => ({
+  REPRESENTATION_MODES: ["operation-graph", "semantic-yaml"] as const,
+  RepresentationNotImplementedError: class extends Error {},
   buildAgentRepresentation: () => ({
     promptContext: "### REST Datasource (stub)\nuse executeRestOperation",
     unresolvedResources: [],
@@ -207,22 +231,14 @@ function makeSpyingModel(toolCallArgs: Record<string, unknown>): InstanceType<ty
     ],
   ];
   return new MockLanguageModelV3({
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    doStream: async (opts: any) => {
+    doStream: async (opts: unknown) => {
       // Capture the first system message rendered into the LLM call so the
       // prompt-content assertions can inspect it.
-      const systemMsg = opts?.prompt?.find((p: { role: string }) => p.role === "system");
-      if (systemMsg) {
-        const content = typeof systemMsg.content === "string"
-          ? systemMsg.content
-          : Array.isArray(systemMsg.content)
-            ? systemMsg.content.map((c: { text?: string }) => c.text ?? "").join("")
-            : "";
-        if (content) lastSystemPrompt = content;
-      }
+      const content = extractSystemPrompt(opts);
+      if (content) lastSystemPrompt = content;
       // #3067 — capture the tool set so focus tests can assert executeSQL is
       // present (default) or stripped (focused REST-only turn).
-      captureToolNames(opts?.tools);
+      captureToolNames(extractTools(opts));
       if (streamIdx >= allSteps.length) {
         return { stream: convertArrayToReadableStream(allSteps[allSteps.length - 1]) };
       }
@@ -245,13 +261,23 @@ function userMessages(content: string): UIMessage[] {
   ];
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function findToolResults(steps: any[], toolName: string): any[] {
-  const results: unknown[] = [];
+// The captured agent steps the integration tests inspect: each step may carry
+// tool results with a `toolName` + `output`. Typed structurally and narrowed
+// from `unknown` so the helper needs no `any` and no coupling to the SDK's
+// `StepResult` generic.
+interface CapturedStep {
+  readonly toolResults?: ReadonlyArray<{ toolName: string; output: unknown }>;
+}
+function findToolResults(
+  steps: ReadonlyArray<unknown>,
+  toolName: string,
+): Array<Record<string, unknown>> {
+  const results: Array<Record<string, unknown>> = [];
   for (const step of steps) {
-    if (!step.toolResults) continue;
-    for (const tr of step.toolResults) {
-      if (tr.toolName === toolName) results.push(tr.output);
+    const toolResults = (step as CapturedStep).toolResults;
+    if (!toolResults) continue;
+    for (const tr of toolResults) {
+      if (tr.toolName === toolName) results.push(tr.output as Record<string, unknown>);
     }
   }
   return results;
@@ -481,17 +507,9 @@ describe("agent loop — REST datasource scope threading (#3044)", () => {
   // running the executeSQL path (which would need an org-aware connection mock).
   function makeTextOnlyModel(): InstanceType<typeof MockLanguageModelV3> {
     return new MockLanguageModelV3({
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      doStream: async (opts: any) => {
-        const systemMsg = opts?.prompt?.find((p: { role: string }) => p.role === "system");
-        if (systemMsg) {
-          lastSystemPrompt =
-            typeof systemMsg.content === "string"
-              ? systemMsg.content
-              : Array.isArray(systemMsg.content)
-                ? systemMsg.content.map((c: { text?: string }) => c.text ?? "").join("")
-                : "";
-        }
+      doStream: async (opts: unknown) => {
+        const content = extractSystemPrompt(opts);
+        if (content !== undefined) lastSystemPrompt = content;
         return {
           stream: convertArrayToReadableStream([
             { type: "text-delta", id: "t0", delta: "Hi." },
@@ -566,18 +584,10 @@ describe("agent loop — REST-only focus suspends executeSQL (#3067)", () => {
   // tool set (captured via doStream opts) and finishes.
   function makeCapturingTextModel(): InstanceType<typeof MockLanguageModelV3> {
     return new MockLanguageModelV3({
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      doStream: async (opts: any) => {
-        const systemMsg = opts?.prompt?.find((p: { role: string }) => p.role === "system");
-        if (systemMsg) {
-          lastSystemPrompt =
-            typeof systemMsg.content === "string"
-              ? systemMsg.content
-              : Array.isArray(systemMsg.content)
-                ? systemMsg.content.map((c: { text?: string }) => c.text ?? "").join("")
-                : "";
-        }
-        captureToolNames(opts?.tools);
+      doStream: async (opts: unknown) => {
+        const content = extractSystemPrompt(opts);
+        if (content !== undefined) lastSystemPrompt = content;
+        captureToolNames(extractTools(opts));
         return {
           stream: convertArrayToReadableStream([
             { type: "text-delta", id: "t0", delta: "Hi." },
@@ -627,6 +637,9 @@ describe("agent loop — REST-only focus suspends executeSQL (#3067)", () => {
     // executeSQL is gone; explore + executeRestOperation remain.
     expect(lastToolNames).toBeDefined();
     expect(lastToolNames).not.toContain("executeSQL");
+    // #3067 (Codex review) — the SQL-card dashboard tool is suspended too, so a
+    // focused turn can't mint SQL-backed dashboard cards while SQL is off.
+    expect(lastToolNames).not.toContain("createDashboard");
     expect(lastToolNames).toContain("executeRestOperation");
     expect(lastToolNames).toContain("explore");
     // The REST-only focus banner is in the system prompt.
@@ -666,8 +679,11 @@ describe("agent loop — REST-only focus suspends executeSQL (#3067)", () => {
     // The focus resolve (empty), THEN the default-scope never-rejects fallback.
     expect(capturedOrThrowArgs!.deps).toEqual({ focus: "gone" });
     expect(capturedRestResolveArgs!.deps).toEqual({ activeGroupId: "prod", excluded: ["x"] });
-    // executeSQL is back; no focus banner.
+    // executeSQL is back; no focus banner. The SQL-card dashboard tool returns
+    // with it — proving the focused-turn absence above is the strip, not a
+    // registry that never had it (#3067 Codex review).
     expect(lastToolNames).toContain("executeSQL");
+    expect(lastToolNames).toContain("createDashboard");
     expect(lastSystemPrompt).not.toContain("REST-only focus");
   });
 
@@ -675,9 +691,10 @@ describe("agent loop — REST-only focus suspends executeSQL (#3067)", () => {
     // A load failure / reconnect-needed throws from the throwing resolver — the
     // focus is NOT gone, so SQL must stay suspended (no silent re-enable).
     restOrThrowResult = new Error("internal DB unavailable");
+    const contextWarnings: ChatContextWarning[] = [];
     const result = await withRequestContext(
       { requestId: "focus-4", user: focusUser, restFocusDatasourceId: "stripe" },
-      () => runAgent({ messages: userMessages("ask stripe only") }),
+      () => runAgent({ messages: userMessages("ask stripe only"), contextWarnings }),
     );
     await result.steps; // consume the stream so doStream captures tools + prompt
     expect(lastToolNames).not.toContain("executeSQL");
@@ -685,5 +702,12 @@ describe("agent loop — REST-only focus suspends executeSQL (#3067)", () => {
     expect(capturedRestResolveArgs).toBeUndefined();
     // The model is told the focused datasource is temporarily unavailable.
     expect(lastSystemPrompt).toContain("temporarily unavailable");
+    // #3067 (CodeRabbit review) — the fail-closed path also emits a structured
+    // context-warning frame so the UI can render a deterministic degraded banner.
+    const focusWarning = contextWarnings.find((w) => w.code === "rest_focus_unavailable");
+    expect(focusWarning).toBeDefined();
+    expect(focusWarning!.severity).toBe("warning");
+    expect(focusWarning!.title.length).toBeGreaterThan(0);
+    expect((focusWarning!.detail ?? "").length).toBeGreaterThan(0);
   });
 });

--- a/packages/api/src/lib/__tests__/agent-scope-prompt.test.ts
+++ b/packages/api/src/lib/__tests__/agent-scope-prompt.test.ts
@@ -185,6 +185,7 @@ mock.module("@atlas/api/lib/openapi/workspace-datasource", () => ({
   resolveWorkspacePrimaryRestDatasource: async () => null,
   defaultQuery: async () => [],
   RestDatasourceReconnectError: class extends Error {},
+  RestDatasourceFocusUnusableError: class extends Error {},
 }));
 
 // #3067 — stub the REST representation builder so a focused-turn datasource stub

--- a/packages/api/src/lib/__tests__/conversations.test.ts
+++ b/packages/api/src/lib/__tests__/conversations.test.ts
@@ -25,6 +25,7 @@ import {
   forkConversation,
   convertToNotebook,
   updateConversationRestExcluded,
+  updateConversationRestFocus,
 } from "../conversations";
 
 // ---------------------------------------------------------------------------
@@ -133,8 +134,8 @@ describe("conversations module", () => {
       const result = await createConversation({ userId: "u1", title: "Test" });
       expect(result).toEqual({ id: "conv-123" });
       expect(queryCalls[0].sql).toContain("INSERT INTO conversations");
-      // [user_id, title, surface, connection_id, connection_group_id, routing_mode, rest_excluded_datasource_ids, org_id]
-      expect(queryCalls[0].params).toEqual(["u1", "Test", "web", null, null, null, [], null]);
+      // [user_id, title, surface, connection_id, connection_group_id, routing_mode, rest_excluded_datasource_ids, rest_focus_datasource_id, org_id]
+      expect(queryCalls[0].params).toEqual(["u1", "Test", "web", null, null, null, [], null, null]);
     });
 
     it("returns null when no DB", async () => {
@@ -155,7 +156,7 @@ describe("conversations module", () => {
       setResults({ rows: [{ id: "conv-456" }] });
 
       await createConversation({});
-      expect(queryCalls[0].params).toEqual([null, null, "web", null, null, null, [], null]);
+      expect(queryCalls[0].params).toEqual([null, null, "web", null, null, null, [], null, null]);
     });
 
     it("accepts custom surface and connectionId", async () => {
@@ -163,7 +164,7 @@ describe("conversations module", () => {
       setResults({ rows: [{ id: "conv-789" }] });
 
       await createConversation({ surface: "api", connectionId: "wh" });
-      expect(queryCalls[0].params).toEqual([null, null, "api", "wh", null, null, [], null]);
+      expect(queryCalls[0].params).toEqual([null, null, "api", "wh", null, null, [], null, null]);
     });
 
     it("includes orgId when provided", async () => {
@@ -172,7 +173,7 @@ describe("conversations module", () => {
 
       const result = await createConversation({ userId: "u1", orgId: "org-123" });
       expect(result).toEqual({ id: "conv-org" });
-      expect(queryCalls[0].params).toEqual(["u1", null, "web", null, null, null, [], "org-123"]);
+      expect(queryCalls[0].params).toEqual(["u1", null, "web", null, null, null, [], null, "org-123"]);
     });
 
     // #2345 — group-aware routing. Both columns are independent;
@@ -196,6 +197,7 @@ describe("conversations module", () => {
         "g_prod",
         null,
         [],
+        null,
         "org-1",
       ]);
     });
@@ -221,6 +223,32 @@ describe("conversations module", () => {
         "g_prod",
         null,
         [],
+        null,
+        "org-1",
+      ]);
+    });
+
+    // #3067 — persist a REST-only focus at creation (the rest_focus_datasource_id
+    // param sits between the exclude-set and org_id).
+    it("persists restFocusDatasourceId when the conversation is created focused", async () => {
+      enableInternalDB();
+      setResults({ rows: [{ id: "conv-focus" }] });
+
+      await createConversation({
+        userId: "u1",
+        restFocusDatasourceId: "ds-stripe",
+        orgId: "org-1",
+      });
+      expect(queryCalls[0].sql).toContain("rest_focus_datasource_id");
+      expect(queryCalls[0].params).toEqual([
+        "u1",
+        null,
+        "web",
+        null,
+        null,
+        null,
+        [],
+        "ds-stripe",
         "org-1",
       ]);
     });
@@ -1399,6 +1427,44 @@ describe("conversations module", () => {
       expect(queryCalls).toHaveLength(0);
     });
 
+    // #3067 — the REST-only focus write helper. Binds the install_id (or null
+    // to clear) to the nullable text column ($1), org/user-scopes the UPDATE,
+    // and returns the same fail-soft result contract.
+    it("updateConversationRestFocus writes the install_id, scoped + parameterized", async () => {
+      enableInternalDB();
+      setResults({ rows: [{ id: "c1" }] });
+
+      const result = await updateConversationRestFocus("c1", "ds-stripe", "u1", "org-B");
+      expect(result).toEqual({ ok: true });
+      expect(queryCalls[0].sql).toContain("UPDATE conversations SET rest_focus_datasource_id = $1");
+      expect(queryCalls[0].sql).toContain("(org_id = $4 OR org_id IS NULL)");
+      expect(queryCalls[0].params).toEqual(["ds-stripe", "c1", "u1", "org-B"]);
+    });
+
+    it("updateConversationRestFocus persists null to CLEAR focus (back to default scope)", async () => {
+      enableInternalDB();
+      setResults({ rows: [{ id: "c1" }] });
+
+      const result = await updateConversationRestFocus("c1", null, "u1", "org-B");
+      expect(result).toEqual({ ok: true });
+      // $1 is null — the clear path the transport must support.
+      expect(queryCalls[0].params).toEqual([null, "c1", "u1", "org-B"]);
+    });
+
+    it("updateConversationRestFocus returns not_found when no row matches (cross-org)", async () => {
+      enableInternalDB();
+      setResults({ rows: [] });
+
+      const result = await updateConversationRestFocus("c1", "ds-stripe", "u1", "org-B");
+      expect(result).toEqual({ ok: false, reason: "not_found" });
+    });
+
+    it("updateConversationRestFocus short-circuits to no_db when the internal DB is off", async () => {
+      const result = await updateConversationRestFocus("c1", "ds-stripe");
+      expect(result).toEqual({ ok: false, reason: "no_db" });
+      expect(queryCalls).toHaveLength(0);
+    });
+
     it("shareConversation scopes the preflight SELECT by orgId (shareMode='org')", async () => {
       enableInternalDB();
       // Preflight sees no matching row because of cross-org filter.
@@ -1493,7 +1559,7 @@ describe("conversations module", () => {
         orgId: "org-B",
       });
       expect(result).toEqual({ ok: false, reason: "not_found" });
-      expect(queryCalls[0].sql).toContain("SELECT id, title, surface, connection_id, connection_group_id, routing_mode, rest_excluded_datasource_ids, org_id");
+      expect(queryCalls[0].sql).toContain("SELECT id, title, surface, connection_id, connection_group_id, routing_mode, rest_excluded_datasource_ids, rest_focus_datasource_id, org_id");
       expect(queryCalls[0].sql).toContain("(org_id = $3 OR org_id IS NULL)");
       expect(queryCalls[0].params).toEqual(["src-c1", "u1", "org-B"]);
     });
@@ -1508,7 +1574,7 @@ describe("conversations module", () => {
         orgId: "org-B",
       });
       expect(result).toEqual({ ok: false, reason: "not_found" });
-      expect(queryCalls[0].sql).toContain("SELECT id, title, surface, connection_id, connection_group_id, routing_mode, rest_excluded_datasource_ids, org_id");
+      expect(queryCalls[0].sql).toContain("SELECT id, title, surface, connection_id, connection_group_id, routing_mode, rest_excluded_datasource_ids, rest_focus_datasource_id, org_id");
       expect(queryCalls[0].sql).toContain("(org_id = $3 OR org_id IS NULL)");
       expect(queryCalls[0].params).toEqual(["src-c1", "u1", "org-B"]);
     });

--- a/packages/api/src/lib/agent.ts
+++ b/packages/api/src/lib/agent.ts
@@ -28,7 +28,7 @@ import type { ChatContextWarning } from "@useatlas/types";
 import { normalizeError } from "./effect/errors";
 import { getModel, getProviderType, getModelFromWorkspaceConfig, getWorkspaceProviderType, type ProviderType } from "./providers";
 import { defaultRegistry, ToolRegistry } from "./tools/registry";
-import { resolveWorkspaceRestDatasources } from "./openapi/workspace-datasource";
+import { resolveWorkspaceRestDatasources, resolveWorkspaceRestDatasourcesOrThrow } from "./openapi/workspace-datasource";
 import type { RestDatasource } from "./openapi/datasource";
 import { buildAgentRepresentation } from "./openapi/representation";
 import { REST_OPERATION_DESCRIPTION, createExecuteRestOperationTool } from "./tools/rest-operation";
@@ -289,9 +289,10 @@ This conversation is **focused on a single REST datasource**. SQL execution (\`e
 
 /**
  * #3067 — build a copy of a tool registry with `executeSQL` removed, for a
- * REST-only focused turn. Every other tool (explore, executePython, plugin /
- * action / REST tools merged on top) is preserved. Returns an UNFROZEN
- * registry — the caller merges the REST tool on top and freezes.
+ * REST-only focused turn. Every other tool already in the base (explore,
+ * executePython, any plugin / action tools) is preserved; the REST tool is
+ * merged on top by the caller AFTER this returns. Returns an UNFROZEN registry
+ * — the caller merges the REST tool on top and freezes.
  */
 function registryWithoutExecuteSQL(base: ToolRegistry): ToolRegistry {
   const stripped = new ToolRegistry();
@@ -1007,28 +1008,54 @@ export async function runAgent({
       if (restFocusDatasourceId) {
         // #3067 — REST-only focus: resolve ONLY the focus target. The resolver
         // short-circuits group-scope + the exclude-set (they're inert while
-        // focused). Suspend executeSQL only if the focus actually resolves.
-        const focused = await resolveWorkspaceRestDatasources(orgId, {
-          focus: restFocusDatasourceId,
-        });
-        if (focused.length > 0) {
-          restDatasources = focused;
-          sqlSuspended = true;
-        } else {
-          // Focus target gone (uninstalled / credential unresolvable) — fall
-          // back SAFELY to default scope: SQL stays active and the exclude-set
-          // applies, exactly as an un-focused conversation resolves (the
-          // "focused datasource was uninstalled" acceptance criterion).
-          log.warn(
-            { focus: restFocusDatasourceId },
-            "REST-only focus datasource did not resolve — falling back to default scope (SQL active)",
-          );
-          restDatasources = await resolveWorkspaceRestDatasources(orgId, {
-            activeGroupId: activeRestGroupId,
-            ...(restExcludedDatasourceIds && restExcludedDatasourceIds.length > 0
-              ? { excluded: restExcludedDatasourceIds }
-              : {}),
+        // focused). Use the THROWING resolver so a genuine empty (the focus
+        // matched no install → uninstalled) is distinguishable from a load
+        // failure / credential-reconnect: the never-rejects resolver would
+        // collapse all three to `[]`, letting a transient internal-DB blip
+        // masquerade as "focus gone" and silently re-enable executeSQL on a
+        // conversation the user deliberately narrowed (a scope leak).
+        let focused: ReadonlyArray<RestDatasource> | null = null;
+        try {
+          focused = await resolveWorkspaceRestDatasourcesOrThrow(orgId, {
+            focus: restFocusDatasourceId,
           });
+        } catch (err) {
+          // Load failed OR the focus install needs a reconnect — the focus is
+          // NOT gone. Fail CLOSED: keep executeSQL suspended and tell the model
+          // the focused datasource is temporarily unavailable, rather than
+          // widening scope back to SQL + the default REST set.
+          log.error(
+            { focus: restFocusDatasourceId, err: err instanceof Error ? err.message : String(err) },
+            "REST-only focus datasource temporarily unresolvable — keeping SQL suspended (not falling back)",
+          );
+          sqlSuspended = true;
+          restDatasources = [];
+          if (!warnings) warnings = [];
+          warnings.push(
+            "The datasource this conversation is focused on is temporarily unavailable. " +
+              "Tell the user it could not be reached right now and to retry shortly, or clear the focus in the scope picker to re-enable SQL. Do not attempt SQL.",
+          );
+        }
+        if (focused !== null) {
+          if (focused.length > 0) {
+            restDatasources = focused;
+            sqlSuspended = true;
+          } else {
+            // Genuinely uninstalled (rows loaded fine, focus matched no install)
+            // — fall back SAFELY to default scope: SQL stays active and the
+            // exclude-set applies, exactly as an un-focused conversation resolves
+            // (the "focused datasource was uninstalled" acceptance criterion).
+            log.warn(
+              { focus: restFocusDatasourceId },
+              "REST-only focus datasource is no longer installed — falling back to default scope (SQL active)",
+            );
+            restDatasources = await resolveWorkspaceRestDatasources(orgId, {
+              activeGroupId: activeRestGroupId,
+              ...(restExcludedDatasourceIds && restExcludedDatasourceIds.length > 0
+                ? { excluded: restExcludedDatasourceIds }
+                : {}),
+            });
+          }
         }
       } else {
         restDatasources = await resolveWorkspaceRestDatasources(orgId, {

--- a/packages/api/src/lib/agent.ts
+++ b/packages/api/src/lib/agent.ts
@@ -29,6 +29,7 @@ import { normalizeError } from "./effect/errors";
 import { getModel, getProviderType, getModelFromWorkspaceConfig, getWorkspaceProviderType, type ProviderType } from "./providers";
 import { defaultRegistry, ToolRegistry } from "./tools/registry";
 import { resolveWorkspaceRestDatasources } from "./openapi/workspace-datasource";
+import type { RestDatasource } from "./openapi/datasource";
 import { buildAgentRepresentation } from "./openapi/representation";
 import { REST_OPERATION_DESCRIPTION, createExecuteRestOperationTool } from "./tools/rest-operation";
 import { getContextFragments, getDialectHints } from "./plugins/tools";
@@ -274,6 +275,31 @@ export function buildRestDatasourceScopeNote(
     `**Environment scope:** workspace-global — available in every environment.` +
     pinClause
   );
+}
+
+/**
+ * #3067 — REST-only focus banner. Prepended to the REST representation when a
+ * conversation is focused on a single datasource and `executeSQL` is suspended,
+ * so the model knows SQL is off and answers from the API only. Exported so a
+ * unit test can pin that the focused branch frames the turn as REST-only.
+ */
+export const REST_ONLY_FOCUS_GUIDANCE = `## REST-only focus — SQL is suspended
+
+This conversation is **focused on a single REST datasource**. SQL execution (\`executeSQL\`) is **suspended** for this turn: there is no SQL tool available. Answer the user using \`executeRestOperation\` against the datasource described below, and only that datasource. Do not reference SQL tables or attempt to write SQL. If the question genuinely needs the SQL warehouse instead of this API, tell the user the conversation is focused on a single datasource and they can clear the focus in the scope picker to re-enable SQL.`;
+
+/**
+ * #3067 — build a copy of a tool registry with `executeSQL` removed, for a
+ * REST-only focused turn. Every other tool (explore, executePython, plugin /
+ * action / REST tools merged on top) is preserved. Returns an UNFROZEN
+ * registry — the caller merges the REST tool on top and freezes.
+ */
+function registryWithoutExecuteSQL(base: ToolRegistry): ToolRegistry {
+  const stripped = new ToolRegistry();
+  for (const [name, entry] of base.entries()) {
+    if (name === "executeSQL") continue;
+    stripped.register(entry);
+  }
+  return stripped;
 }
 
 function buildMultiSourceSection(
@@ -759,6 +785,10 @@ export async function runAgent({
   // REST resolver below so an excluded datasource never reaches the prompt
   // or the bound `executeRestOperation` tool. Undefined ⇒ exclude nothing.
   const restExcludedDatasourceIds = reqCtx?.restExcludedDatasourceIds;
+  // #3067 — per-conversation REST-only focus. When set, the REST block below
+  // resolves ONLY this datasource and suspends `executeSQL` (REST-only turn).
+  // Undefined / null ⇒ not focused (default scope: SQL routing + exclude-set).
+  const restFocusDatasourceId = reqCtx?.restFocusDatasourceId;
 
   // Resolve model: injected > workspace config (enterprise) > platform env vars
   let model: LanguageModel;
@@ -965,9 +995,43 @@ export async function runAgent({
   // that environment's scoped REST datasources; a scoped one never leaks past it.
   let activeRegistry = toolRegistry;
   let restRepresentation: string | undefined;
+  // #3067 — set true once a REST-only focus actually resolves to a datasource;
+  // gates executeSQL suspension + the focus prompt banner below.
+  let sqlSuspended = false;
   try {
-    const restDatasources = orgId
-      ? await resolveWorkspaceRestDatasources(orgId, {
+    // Resolve the REST datasource set this turn runs against. Default scope
+    // (group-scope + exclude-set), unless the conversation is FOCUSED on one
+    // datasource (#3067), in which case only that one resolves and SQL is off.
+    let restDatasources: ReadonlyArray<RestDatasource> = [];
+    if (orgId) {
+      if (restFocusDatasourceId) {
+        // #3067 — REST-only focus: resolve ONLY the focus target. The resolver
+        // short-circuits group-scope + the exclude-set (they're inert while
+        // focused). Suspend executeSQL only if the focus actually resolves.
+        const focused = await resolveWorkspaceRestDatasources(orgId, {
+          focus: restFocusDatasourceId,
+        });
+        if (focused.length > 0) {
+          restDatasources = focused;
+          sqlSuspended = true;
+        } else {
+          // Focus target gone (uninstalled / credential unresolvable) — fall
+          // back SAFELY to default scope: SQL stays active and the exclude-set
+          // applies, exactly as an un-focused conversation resolves (the
+          // "focused datasource was uninstalled" acceptance criterion).
+          log.warn(
+            { focus: restFocusDatasourceId },
+            "REST-only focus datasource did not resolve — falling back to default scope (SQL active)",
+          );
+          restDatasources = await resolveWorkspaceRestDatasources(orgId, {
+            activeGroupId: activeRestGroupId,
+            ...(restExcludedDatasourceIds && restExcludedDatasourceIds.length > 0
+              ? { excluded: restExcludedDatasourceIds }
+              : {}),
+          });
+        }
+      } else {
+        restDatasources = await resolveWorkspaceRestDatasources(orgId, {
           activeGroupId: activeRestGroupId,
           // #3066 — drop the conversation's excluded datasources. The tool is
           // bound to exactly this set below, so exclusion is enforced at both
@@ -977,8 +1041,16 @@ export async function runAgent({
           ...(restExcludedDatasourceIds && restExcludedDatasourceIds.length > 0
             ? { excluded: restExcludedDatasourceIds }
             : {}),
-        })
-      : [];
+        });
+      }
+    }
+    // #3067 — suspend executeSQL for a focused REST-only turn by stripping it
+    // from the base registry, so neither the prompt's tool list nor the runtime
+    // exposes a SQL tool. Default turns keep the registry untouched.
+    const baseRegistry = sqlSuspended
+      ? registryWithoutExecuteSQL(toolRegistry)
+      : toolRegistry;
+    activeRegistry = baseRegistry;
     if (restDatasources.length > 0) {
       const restRegistry = new ToolRegistry();
       restRegistry.register({
@@ -991,7 +1063,7 @@ export async function runAgent({
           resolveDatasources: async () => restDatasources,
         }),
       });
-      activeRegistry = ToolRegistry.merge(toolRegistry, restRegistry).freeze();
+      activeRegistry = ToolRegistry.merge(baseRegistry, restRegistry).freeze();
       // Representation mode is the #2931 bake-off knob, resolved per install from
       // its `workspace_plugins.config`. Path A vs Path B differ only in how the
       // surface is described; both drive the same executeRestOperation. With more
@@ -1019,6 +1091,11 @@ export async function runAgent({
         }
       }
       restRepresentation = sections.join("\n\n");
+      // #3067 — prepend the REST-only focus banner so the model treats the turn
+      // as API-only (the SQL tool is already gone from the registry above).
+      if (sqlSuspended) {
+        restRepresentation = `${REST_ONLY_FOCUS_GUIDANCE}\n\n${restRepresentation}`;
+      }
     }
   } catch (err) {
     log.warn(

--- a/packages/api/src/lib/agent.ts
+++ b/packages/api/src/lib/agent.ts
@@ -288,16 +288,34 @@ export const REST_ONLY_FOCUS_GUIDANCE = `## REST-only focus — SQL is suspended
 This conversation is **focused on a single REST datasource**. SQL execution (\`executeSQL\`) is **suspended** for this turn: there is no SQL tool available. Answer the user using \`executeRestOperation\` against the datasource described below, and only that datasource. Do not reference SQL tables or attempt to write SQL. If the question genuinely needs the SQL warehouse instead of this API, tell the user the conversation is focused on a single datasource and they can clear the focus in the scope picker to re-enable SQL.`;
 
 /**
- * #3067 — build a copy of a tool registry with `executeSQL` removed, for a
- * REST-only focused turn. Every other tool already in the base (explore,
+ * #3067 — tools that author or execute SQL, suspended together under REST-only
+ * focus. `executeSQL` runs SQL directly; `createDashboard` (default registry)
+ * and the bound dashboard editor tools `addCard` / `updateCard` / `updateCardSql`
+ * each accept SQL card definitions and stage SQL-backed cards. Removing only
+ * `executeSQL` would still let a focused turn mint SQL results via a dashboard
+ * (Codex review on #3067) — a scope leak — so all of them are stripped together.
+ * Stripping a name the base registry doesn't contain (e.g. the editor tools on a
+ * non-bound chat) is a harmless no-op.
+ */
+const SQL_DEPENDENT_TOOL_NAMES: ReadonlySet<string> = new Set([
+  "executeSQL",
+  "createDashboard",
+  "addCard",
+  "updateCard",
+  "updateCardSql",
+]);
+
+/**
+ * #3067 — build a copy of a tool registry with every SQL-dependent tool removed,
+ * for a REST-only focused turn. Every other tool already in the base (explore,
  * executePython, any plugin / action tools) is preserved; the REST tool is
  * merged on top by the caller AFTER this returns. Returns an UNFROZEN registry
  * — the caller merges the REST tool on top and freezes.
  */
-function registryWithoutExecuteSQL(base: ToolRegistry): ToolRegistry {
+function registryWithoutSqlTools(base: ToolRegistry): ToolRegistry {
   const stripped = new ToolRegistry();
   for (const [name, entry] of base.entries()) {
-    if (name === "executeSQL") continue;
+    if (SQL_DEPENDENT_TOOL_NAMES.has(name)) continue;
     stripped.register(entry);
   }
   return stripped;
@@ -1035,6 +1053,19 @@ export async function runAgent({
             "The datasource this conversation is focused on is temporarily unavailable. " +
               "Tell the user it could not be reached right now and to retry shortly, or clear the focus in the scope picker to re-enable SQL. Do not attempt SQL.",
           );
+          // Mirror the model-facing warning as a structured frame so the UI can
+          // render a deterministic "focused datasource unavailable, SQL still
+          // suspended" banner instead of relying on the model to repeat the
+          // system-prompt text — same pattern as the semantic-layer / learned-
+          // patterns degradations above (#1988 B5 / #3067 review).
+          contextWarnings?.push({
+            severity: "warning",
+            code: "rest_focus_unavailable",
+            title: "Focused datasource unavailable",
+            detail:
+              "The datasource this conversation is focused on is temporarily unavailable, so SQL stays suspended. " +
+              "Retry shortly, or clear the focus in the scope picker to re-enable SQL.",
+          });
         }
         if (focused !== null) {
           if (focused.length > 0) {
@@ -1071,11 +1102,12 @@ export async function runAgent({
         });
       }
     }
-    // #3067 — suspend executeSQL for a focused REST-only turn by stripping it
-    // from the base registry, so neither the prompt's tool list nor the runtime
-    // exposes a SQL tool. Default turns keep the registry untouched.
+    // #3067 — suspend SQL for a focused REST-only turn by stripping every
+    // SQL-dependent tool (executeSQL + the SQL-card dashboard tools) from the
+    // base registry, so neither the prompt's tool list nor the runtime exposes a
+    // way to run or stage SQL. Default turns keep the registry untouched.
     const baseRegistry = sqlSuspended
-      ? registryWithoutExecuteSQL(toolRegistry)
+      ? registryWithoutSqlTools(toolRegistry)
       : toolRegistry;
     activeRegistry = baseRegistry;
     if (restDatasources.length > 0) {

--- a/packages/api/src/lib/auth/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/auth/__tests__/migrate.test.ts
@@ -358,6 +358,7 @@ describe("migrateAuthTables", () => {
             { name: "0110_notion_data_catalog.sql" },
             { name: "0111_github_data_catalog.sql" },
             { name: "0112_conversation_rest_excluded_datasources.sql" },
+            { name: "0113_conversation_rest_focus_datasource.sql" },
           ],
         };
       }

--- a/packages/api/src/lib/conversations.ts
+++ b/packages/api/src/lib/conversations.ts
@@ -144,6 +144,12 @@ function rowToConversation(r: Record<string, unknown>): Conversation {
     restExcludedDatasourceIds: Array.isArray(r.rest_excluded_datasource_ids)
       ? (r.rest_excluded_datasource_ids as string[])
       : [],
+    // #3067 — per-conversation REST-only focus. Plain nullable text column,
+    // so NULL → null ("not focused"). Every SELECT in this file that feeds
+    // rowToConversation includes the column; a caller that omits it (e.g.
+    // getSharedConversation, which doesn't surface scope to anon viewers)
+    // reads as null, matching the column's "not focused" default.
+    restFocusDatasourceId: (r.rest_focus_datasource_id as string) ?? null,
     starred: r.starred === true,
     createdAt: String(r.created_at),
     updatedAt: String(r.updated_at),
@@ -200,6 +206,13 @@ export async function createConversation(opts: {
    * (nothing excluded = all in scope), so legacy callers are unaffected.
    */
   restExcludedDatasourceIds?: string[] | null;
+  /**
+   * #3067 — per-conversation REST-only focus (an `install_id`, or null /
+   * undefined for "not focused"). Persists NULL when omitted, so legacy
+   * callers are unaffected; an explicit string focuses that datasource and
+   * suspends `executeSQL` for the conversation.
+   */
+  restFocusDatasourceId?: string | null;
   orgId?: string | null;
 }): Promise<{ id: string } | null> {
   if (!hasInternalDB()) return null;
@@ -207,11 +220,13 @@ export async function createConversation(opts: {
   // explicit [] is equivalent (nothing excluded). pg binds a JS string[]
   // directly to the text[] column.
   const restExcluded = opts.restExcludedDatasourceIds ?? [];
+  // #3067 — null/undefined ⇒ persist NULL ("not focused").
+  const restFocus = opts.restFocusDatasourceId ?? null;
   try {
     const rows = opts.id
       ? await internalQuery<{ id: string }>(
-          `INSERT INTO conversations (id, user_id, title, surface, connection_id, connection_group_id, routing_mode, rest_excluded_datasource_ids, org_id)
-           VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+          `INSERT INTO conversations (id, user_id, title, surface, connection_id, connection_group_id, routing_mode, rest_excluded_datasource_ids, rest_focus_datasource_id, org_id)
+           VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
            RETURNING id`,
           [
             opts.id,
@@ -222,12 +237,13 @@ export async function createConversation(opts: {
             opts.connectionGroupId ?? null,
             opts.routingMode ?? null,
             restExcluded,
+            restFocus,
             opts.orgId ?? null,
           ],
         )
       : await internalQuery<{ id: string }>(
-          `INSERT INTO conversations (user_id, title, surface, connection_id, connection_group_id, routing_mode, rest_excluded_datasource_ids, org_id)
-           VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+          `INSERT INTO conversations (user_id, title, surface, connection_id, connection_group_id, routing_mode, rest_excluded_datasource_ids, rest_focus_datasource_id, org_id)
+           VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
            RETURNING id`,
           [
             opts.userId ?? null,
@@ -237,6 +253,7 @@ export async function createConversation(opts: {
             opts.connectionGroupId ?? null,
             opts.routingMode ?? null,
             restExcluded,
+            restFocus,
             opts.orgId ?? null,
           ],
         );
@@ -301,6 +318,34 @@ export async function updateConversationRestExcluded(
     return rows.length > 0 ? { ok: true } : { ok: false, reason: "not_found" };
   } catch (err) {
     log.error({ err: errorMessage(err) }, "updateConversationRestExcluded failed");
+    return { ok: false, reason: "error" };
+  }
+}
+
+/**
+ * #3067 — update the conversation's `rest_focus_datasource_id`. Same
+ * fail-open / org-scoped contract as {@link updateConversationRestExcluded}.
+ * Pass an `install_id` to focus that datasource (suspends `executeSQL`), or
+ * `null` to clear focus (return to default scope — SQL routing + exclude-set
+ * apply again). pg binds the string|null directly to the nullable text column.
+ */
+export async function updateConversationRestFocus(
+  id: string,
+  restFocusDatasourceId: string | null,
+  userId?: string | null,
+  orgId?: string | null,
+): Promise<CrudResult> {
+  if (!hasInternalDB()) return { ok: false, reason: "no_db" };
+  try {
+    const scope = scopeClause(3, userId, orgId);
+    const rows = await internalQuery<{ id: string }>(
+      `UPDATE conversations SET rest_focus_datasource_id = $1, updated_at = now()
+       WHERE id = $2${scope.sql} RETURNING id`,
+      [restFocusDatasourceId, id, ...scope.params],
+    );
+    return rows.length > 0 ? { ok: true } : { ok: false, reason: "not_found" };
+  } catch (err) {
+    log.error({ err: errorMessage(err) }, "updateConversationRestFocus failed");
     return { ok: false, reason: "error" };
   }
 }
@@ -672,7 +717,7 @@ export async function getConversation(
   try {
     const scope = scopeClause(2, userId, orgId);
     const convRows = await internalQuery<Record<string, unknown>>(
-      `SELECT id, user_id, title, surface, connection_id, connection_group_id, routing_mode, rest_excluded_datasource_ids, starred, notebook_state, created_at, updated_at
+      `SELECT id, user_id, title, surface, connection_id, connection_group_id, routing_mode, rest_excluded_datasource_ids, rest_focus_datasource_id, starred, notebook_state, created_at, updated_at
        FROM conversations WHERE id = $1${scope.sql}`,
       [id, ...scope.params],
     );
@@ -744,7 +789,7 @@ export async function listConversations(opts?: {
       params,
     );
     const dataRows = await internalQuery<Record<string, unknown>>(
-      `SELECT id, user_id, title, surface, connection_id, connection_group_id, routing_mode, rest_excluded_datasource_ids, starred, created_at, updated_at
+      `SELECT id, user_id, title, surface, connection_id, connection_group_id, routing_mode, rest_excluded_datasource_ids, rest_focus_datasource_id, starred, created_at, updated_at
        FROM conversations ${where}
        ORDER BY updated_at DESC LIMIT $${paramIdx++} OFFSET $${paramIdx++}`,
       [...params, limit, offset],
@@ -821,7 +866,7 @@ export async function forkConversation(opts: {
     // source row's org_id; scopeClause rejects mismatches (NULL-safe for legacy rows).
     const sourceScope = scopeClause(2, opts.userId, opts.orgId);
     const sourceRows = await internalQuery<Record<string, unknown>>(
-      `SELECT id, title, surface, connection_id, connection_group_id, routing_mode, rest_excluded_datasource_ids, org_id FROM conversations WHERE id = $1${sourceScope.sql}`,
+      `SELECT id, title, surface, connection_id, connection_group_id, routing_mode, rest_excluded_datasource_ids, rest_focus_datasource_id, org_id FROM conversations WHERE id = $1${sourceScope.sql}`,
       [opts.sourceId, ...sourceScope.params],
     );
     if (sourceRows.length === 0) return { ok: false, reason: "not_found" };
@@ -857,8 +902,8 @@ export async function forkConversation(opts: {
     // the user keeps the same env context after branching.
     const orgId = opts.orgId ?? (source.org_id as string) ?? null;
     const newConv = await internalQuery<{ id: string }>(
-      `INSERT INTO conversations (user_id, title, surface, connection_id, connection_group_id, routing_mode, rest_excluded_datasource_ids, org_id)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING id`,
+      `INSERT INTO conversations (user_id, title, surface, connection_id, connection_group_id, routing_mode, rest_excluded_datasource_ids, rest_focus_datasource_id, org_id)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9) RETURNING id`,
       [
         opts.userId ?? null,
         `${sourceTitle} (fork)`,
@@ -869,6 +914,8 @@ export async function forkConversation(opts: {
         // #3066 — a fork/notebook inherits the source's REST exclude-set
         // so the new conversation keeps the same scope after branching.
         (source.rest_excluded_datasource_ids as string[]) ?? [],
+        // #3067 — inherit the source's REST-only focus too.
+        (source.rest_focus_datasource_id as string) ?? null,
         orgId,
       ],
     );
@@ -1012,7 +1059,7 @@ export async function convertToNotebook(opts: {
     // Verify source exists and caller has access in both the user + org dimensions.
     const sourceScope = scopeClause(2, opts.userId, opts.orgId);
     const sourceRows = await internalQuery<Record<string, unknown>>(
-      `SELECT id, title, surface, connection_id, connection_group_id, routing_mode, rest_excluded_datasource_ids, org_id FROM conversations WHERE id = $1${sourceScope.sql}`,
+      `SELECT id, title, surface, connection_id, connection_group_id, routing_mode, rest_excluded_datasource_ids, rest_focus_datasource_id, org_id FROM conversations WHERE id = $1${sourceScope.sql}`,
       [opts.sourceId, ...sourceScope.params],
     );
     if (sourceRows.length === 0) return { ok: false, reason: "not_found" };
@@ -1025,8 +1072,8 @@ export async function convertToNotebook(opts: {
     // both routing columns + the picker mode so the notebook preserves
     // the source's env context end-to-end.
     const newConv = await internalQuery<{ id: string }>(
-      `INSERT INTO conversations (user_id, title, surface, connection_id, connection_group_id, routing_mode, rest_excluded_datasource_ids, org_id)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING id`,
+      `INSERT INTO conversations (user_id, title, surface, connection_id, connection_group_id, routing_mode, rest_excluded_datasource_ids, rest_focus_datasource_id, org_id)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9) RETURNING id`,
       [
         opts.userId ?? null,
         `${sourceTitle} (notebook)`,
@@ -1037,6 +1084,8 @@ export async function convertToNotebook(opts: {
         // #3066 — a fork/notebook inherits the source's REST exclude-set
         // so the new conversation keeps the same scope after branching.
         (source.rest_excluded_datasource_ids as string[]) ?? [],
+        // #3067 — inherit the source's REST-only focus too.
+        (source.rest_focus_datasource_id as string) ?? null,
         orgId,
       ],
     );

--- a/packages/api/src/lib/db/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate.test.ts
@@ -131,7 +131,8 @@ describe("runMigrations", () => {
     //   Plus 0111 (github-data oauth-datasource catalog row + install_model
     //   CHECK widen, slice 6c, #3030) = 112.
     //   Plus 0112 (conversations.rest_excluded_datasource_ids, S2a, #3066) = 113.
-    expect(count).toBe(113);
+    //   Plus 0113 (conversations.rest_focus_datasource_id, S2b, #3067) = 114.
+    expect(count).toBe(114);
 
     // Advisory lock acquired before anything else
     expect(queries[0]).toContain("pg_advisory_lock");
@@ -273,6 +274,7 @@ describe("runMigrations", () => {
         "0110_notion_data_catalog.sql",
         "0111_github_data_catalog.sql",
         "0112_conversation_rest_excluded_datasources.sql",
+        "0113_conversation_rest_focus_datasource.sql",
       ],
     });
 

--- a/packages/api/src/lib/db/migrations/0113_conversation_rest_focus_datasource.sql
+++ b/packages/api/src/lib/db/migrations/0113_conversation_rest_focus_datasource.sql
@@ -1,0 +1,26 @@
+-- Migration 0113: per-conversation REST-only focus (#3067, S2b).
+--
+-- v0.0.4 Conversation Scope. A conversation can FOCUS a single REST
+-- datasource so the agent targets it exclusively and SQL execution
+-- (executeSQL) is SUSPENDED for that conversation — the "ask Stripe
+-- only" case. Holds a single `workspace_plugins.install_id` value (the
+-- id the scope picker surfaces, `GET /api/v1/me/connection-groups`).
+--
+-- NULL (the default) = not focused: SQL routing (routing_mode) and the
+-- REST exclude-set (rest_excluded_datasource_ids, 0112) apply as normal.
+-- When set, those two fields are inert but RETAINED, so clearing focus
+-- (back to NULL) returns to the prior default-state scope. A focus id
+-- that no longer matches any install falls back safely to default scope
+-- at resolve time (the resolver yields no datasource → SQL stays active).
+-- See ADR-0011.
+--
+-- Nullable text with no default — unlike the exclude-set there is no
+-- NULL/[] ambiguity to avoid; NULL is the meaningful "not focused" state.
+--
+-- Idempotent: `ADD COLUMN IF NOT EXISTS` is a no-op on re-run.
+
+ALTER TABLE conversations
+  ADD COLUMN IF NOT EXISTS rest_focus_datasource_id text;
+
+COMMENT ON COLUMN conversations.rest_focus_datasource_id IS
+  'Per-conversation REST-only focus (#3067). When set, holds the single workspace_plugins.install_id the conversation targets exclusively, suspending executeSQL. NULL = not focused (SQL routing + rest_excluded_datasource_ids apply). See ADR-0011.';

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -130,6 +130,13 @@ export const conversations = pgTable(
       .array()
       .notNull()
       .default(sql`'{}'::text[]`),
+    // 0113 — per-conversation REST-only focus (#3067, S2b). When set,
+    // holds the single `workspace_plugins.install_id` the conversation
+    // targets exclusively, suspending `executeSQL`. NULL (the default) =
+    // not focused: `routing_mode` + `rest_excluded_datasource_ids` apply
+    // as normal, and they stay RETAINED-but-inert while focused so
+    // clearing focus returns to the prior scope. See ADR-0011.
+    restFocusDatasourceId: text("rest_focus_datasource_id"),
     createdAt: timestamp("created_at", { withTimezone: true }).defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow(),
     // Saved/starred

--- a/packages/api/src/lib/logger.ts
+++ b/packages/api/src/lib/logger.ts
@@ -95,6 +95,16 @@ interface RequestContext {
    * the preference store) — consumers only read it.
    */
   restExcludedDatasourceIds?: readonly string[];
+  /**
+   * #3067 — per-conversation REST-only focus. The chat route stamps this
+   * from the resolved conversation row (or the per-turn body override) when
+   * the conversation is focused on a single REST datasource. When set, the
+   * agent loop resolves only that datasource and SUSPENDS `executeSQL`;
+   * `restExcludedDatasourceIds` and SQL routing are ignored for the turn.
+   * Undefined / null here = not focused (default scope). Stamped only when
+   * truthy, so the legacy shape is unchanged for non-focused conversations.
+   */
+  restFocusDatasourceId?: string | null;
 }
 
 const requestStore = new AsyncLocalStorage<RequestContext>();

--- a/packages/api/src/lib/openapi/__tests__/workspace-datasource.test.ts
+++ b/packages/api/src/lib/openapi/__tests__/workspace-datasource.test.ts
@@ -13,6 +13,7 @@ import {
   resolveWorkspacePrimaryRestDatasource,
   defaultQuery,
   RestDatasourceReconnectError,
+  RestDatasourceFocusUnusableError,
   type OpenApiInstallRow,
 } from "../workspace-datasource";
 import { buildOperationGraph } from "../spec";
@@ -571,6 +572,42 @@ describe("resolveWorkspaceRestDatasources — REST-only focus (#3067, S2b)", () 
       focus: "ds-uninstalled",
     });
     expect(result).toEqual([]);
+  });
+
+  it("STRICT resolver throws RestDatasourceFocusUnusableError when the focus matches a present-but-unbuildable install (Codex P1)", async () => {
+    // The focused row exists but builds to nothing for a non-reconnectable reason
+    // (here a blocked/internal base URL the SSRF guard rejects). This must be
+    // distinguishable from "uninstalled" so the focus path fails CLOSED instead
+    // of the agent silently re-enabling SQL for a still-present datasource.
+    delete process.env.ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS;
+    await expect(
+      resolveWorkspaceRestDatasourcesOrThrow("org-1", {
+        query: queryReturning([
+          { install_id: "ds-blocked", config: config({ base_url_override: "https://10.0.0.5/v1" }) },
+        ]),
+        focus: "ds-blocked",
+      }),
+    ).rejects.toBeInstanceOf(RestDatasourceFocusUnusableError);
+  });
+
+  it("never-rejects resolver degrades a present-but-unbuildable focus to [] (python egress denies, never widens)", async () => {
+    // The non-claiming path can't fail closed (no SQL tool to suspend), so it
+    // returns [] — python egress then resolves a null primary and denies.
+    delete process.env.ATLAS_OPENAPI_ALLOW_INTERNAL_HOSTS;
+    const result = await resolveWorkspaceRestDatasources("org-1", {
+      query: queryReturning([
+        { install_id: "ds-blocked", config: config({ base_url_override: "https://10.0.0.5/v1" }) },
+      ]),
+      focus: "ds-blocked",
+    });
+    expect(result).toEqual([]);
+    const primary = await resolveWorkspacePrimaryRestDatasource("org-1", {
+      query: queryReturning([
+        { install_id: "ds-blocked", config: config({ base_url_override: "https://10.0.0.5/v1" }) },
+      ]),
+      focus: "ds-blocked",
+    });
+    expect(primary).toBeNull();
   });
 
   it("an empty-string focus is ignored (resolves the default scope, not 'focus on nothing')", async () => {

--- a/packages/api/src/lib/openapi/__tests__/workspace-datasource.test.ts
+++ b/packages/api/src/lib/openapi/__tests__/workspace-datasource.test.ts
@@ -528,6 +528,68 @@ describe("resolveWorkspaceRestDatasources — per-conversation exclude-set (#306
   });
 });
 
+describe("resolveWorkspaceRestDatasources — REST-only focus (#3067, S2b)", () => {
+  const rows: OpenApiInstallRow[] = [
+    { install_id: "ds-global", config: config({ display_name: "Global" }) }, // no group_id
+    { install_id: "ds-prod", config: config({ display_name: "Prod", group_id: "prod" }) },
+    { install_id: "ds-eu", config: config({ display_name: "EU", group_id: "eu" }) },
+  ];
+
+  it("resolves ONLY the focus target", async () => {
+    const result = await resolveWorkspaceRestDatasources("org-1", {
+      query: queryReturning(rows),
+      focus: "ds-prod",
+    });
+    expect(result.map((d) => d.id)).toEqual(["ds-prod"]);
+  });
+
+  it("short-circuits the activeGroupId scope filter (focus a group-scoped ds with a mismatched active group)", async () => {
+    // ds-eu is scoped to "eu"; focusing it while the active group is "prod"
+    // still resolves it — focus is an explicit single pick, group-scope is inert.
+    const result = await resolveWorkspaceRestDatasources("org-1", {
+      query: queryReturning(rows),
+      activeGroupId: "prod",
+      focus: "ds-eu",
+    });
+    expect(result.map((d) => d.id)).toEqual(["ds-eu"]);
+  });
+
+  it("short-circuits the exclude-set (focus a datasource that is also excluded)", async () => {
+    // The exclude-set is inert while focused — focusing ds-prod resolves it
+    // even though it's in the exclude-set.
+    const result = await resolveWorkspaceRestDatasources("org-1", {
+      query: queryReturning(rows),
+      excluded: ["ds-prod"],
+      focus: "ds-prod",
+    });
+    expect(result.map((d) => d.id)).toEqual(["ds-prod"]);
+  });
+
+  it("returns [] when the focus target matches no install (fall-back-to-default signal)", async () => {
+    const result = await resolveWorkspaceRestDatasources("org-1", {
+      query: queryReturning(rows),
+      focus: "ds-uninstalled",
+    });
+    expect(result).toEqual([]);
+  });
+
+  it("an empty-string focus is ignored (resolves the default scope, not 'focus on nothing')", async () => {
+    const result = await resolveWorkspaceRestDatasources("org-1", {
+      query: queryReturning(rows),
+      focus: "",
+    });
+    expect(result.map((d) => d.id).sort()).toEqual(["ds-eu", "ds-global", "ds-prod"]);
+  });
+
+  it("the primary resolver honours focus (python egress lockstep)", async () => {
+    const primary = await resolveWorkspacePrimaryRestDatasource("org-1", {
+      query: queryReturning(rows),
+      focus: "ds-eu",
+    });
+    expect(primary?.id).toBe("ds-eu");
+  });
+});
+
 // ─────────────────────────────────────────────────────────────────────
 //  Resolve-time SSRF guard (#3006)
 // ─────────────────────────────────────────────────────────────────────

--- a/packages/api/src/lib/openapi/workspace-datasource.ts
+++ b/packages/api/src/lib/openapi/workspace-datasource.ts
@@ -108,6 +108,31 @@ export class RestDatasourceReconnectError extends Error {
   }
 }
 
+/**
+ * #3067 (Codex P1) — a REST-only focus matched an install row that is PRESENT
+ * but could not be built (decrypt failure, unsupported/unhandled auth, blocked
+ * base URL — the non-reconnectable skips inside `buildDatasourcesFromRows`;
+ * reconnectable ones already surface as {@link RestDatasourceReconnectError}).
+ *
+ * This is distinct from "the focus matched no install at all" (which resolves to
+ * `[]` — the agent's safe fall-back-to-default-scope signal). A present-but-
+ * unusable focus must NOT look empty, or the agent re-enables SQL for a
+ * datasource the user deliberately narrowed to — a REST-only focus contract
+ * violation. The strict resolver throws this so the focus path fails CLOSED; the
+ * never-rejects {@link resolveWorkspaceRestDatasources} degrades it to `[]` (its
+ * callers — python egress — then deny rather than widen).
+ */
+export class RestDatasourceFocusUnusableError extends Error {
+  readonly focusId: string;
+  constructor(focusId: string) {
+    super(
+      `Focused REST datasource "${focusId}" is installed but could not be built (bad credential, unsupported auth, or blocked URL).`,
+    );
+    this.name = "RestDatasourceFocusUnusableError";
+    this.focusId = focusId;
+  }
+}
+
 export interface ResolveWorkspaceDeps {
   readonly query?: OpenApiInstallQuery;
   /**
@@ -583,7 +608,20 @@ export async function resolveWorkspaceRestDatasourcesOrThrow(
   // here, so the agent loop falls back to default scope. Guard on length so a
   // stray empty string can't be a "focus on nothing".
   if (deps.focus && deps.focus.length > 0) {
-    return buildDatasourcesFromRows(workspaceId, rowsFocused(rows, deps.focus), mint);
+    const focusedRows = rowsFocused(rows, deps.focus);
+    const built = await buildDatasourcesFromRows(workspaceId, focusedRows, mint);
+    // #3067 (Codex P1) — distinguish "focus matched no install" (genuinely
+    // uninstalled → `[]`, the agent's safe fall-back-to-default-scope case) from
+    // "focus matched an install row that built to nothing" (present but unusable:
+    // decrypt failure, unsupported auth, blocked URL). Returning `[]` for the
+    // latter would let the agent read it as uninstalled and re-enable SQL,
+    // violating the REST-only focus contract — fail CLOSED instead. Reconnectable
+    // skips already threw inside buildDatasourcesFromRows, so this covers the
+    // non-reconnectable remainder.
+    if (built.length === 0 && focusedRows.length > 0) {
+      throw new RestDatasourceFocusUnusableError(deps.focus);
+    }
+    return built;
   }
   // #3044 — drop out-of-scope datasources BEFORE build, so the reconnect tally
   // (and the never-rejects `[]` contract) is computed only over the in-scope set.
@@ -618,6 +656,17 @@ export async function resolveWorkspaceRestDatasources(
       log.warn(
         { workspaceId, reconnectableCount: err.reconnectableCount },
         "OpenAPI datasource install(s) need reconnecting — continuing with none for this non-claiming path",
+      );
+      return [];
+    }
+    // #3067 (Codex P1) — a present-but-unusable focus isn't a load failure
+    // either. This non-claiming path can't fail closed (it has no SQL tool to
+    // suspend), so it degrades to `[]`; its callers (python egress) then deny
+    // egress rather than widen. The strict resolver is where focus fails closed.
+    if (err instanceof RestDatasourceFocusUnusableError) {
+      log.warn(
+        { workspaceId, focus: err.focusId },
+        "Focused REST datasource is installed but unusable — continuing with none for this non-claiming path",
       );
       return [];
     }

--- a/packages/api/src/lib/openapi/workspace-datasource.ts
+++ b/packages/api/src/lib/openapi/workspace-datasource.ts
@@ -144,6 +144,18 @@ export interface ResolveWorkspaceDeps {
    * this — a staged write replays regardless of the conversation's scope.
    */
   readonly excluded?: ReadonlyArray<string>;
+  /**
+   * Per-conversation REST-only focus (#3067, S2b). When set to an
+   * `install_id`, resolve ONLY that datasource — the focus SHORT-CIRCUITS
+   * both {@link activeGroupId} group-scope and the {@link excluded}
+   * exclude-set (ADR-0011: those fields are inert while focused). A focus
+   * id that matches no install in the workspace's tenant-scoped rows yields
+   * `[]`, so the caller falls back safely to default scope (the agent loop
+   * keeps `executeSQL` active). Omitted / null / empty = not focused (apply
+   * group-scope + exclude-set as normal). The confirm-replay path omits this
+   * — like {@link excluded}, a staged write replays regardless of focus.
+   */
+  readonly focus?: string | null;
 }
 
 /**
@@ -183,6 +195,22 @@ function rowsNotExcluded(
   if (!excluded || excluded.length === 0) return rows;
   const excludeSet = new Set(excluded);
   return rows.filter((row) => !excludeSet.has(row.install_id));
+}
+
+/**
+ * REST-only focus filter (#3067, S2b). Keeps ONLY the install whose
+ * `install_id` matches the focus target — operating over the already
+ * tenant-scoped rows (`workspace_id = $1` in {@link defaultQuery}), so a focus
+ * can never resolve another workspace's datasource. Returns `[]` when the focus
+ * matches no install (the datasource was uninstalled), which the agent loop
+ * reads as "fall back to default scope". Pure over the raw `install_id`, so it
+ * too runs before credential build.
+ */
+function rowsFocused(
+  rows: ReadonlyArray<OpenApiInstallRow>,
+  focus: string,
+): ReadonlyArray<OpenApiInstallRow> {
+  return rows.filter((row) => row.install_id === focus);
 }
 
 /**
@@ -549,6 +577,14 @@ export async function resolveWorkspaceRestDatasourcesOrThrow(
   // A query failure propagates here, on purpose — the caller turns it into a
   // distinct "temporarily unavailable" signal rather than an empty result.
   const rows = await query(workspaceId);
+  // #3067 — REST-only focus short-circuits both filters below: a focused
+  // conversation resolves ONLY the focus target, with group-scope and the
+  // exclude-set inert (ADR-0011). A focus that matches no install yields []
+  // here, so the agent loop falls back to default scope. Guard on length so a
+  // stray empty string can't be a "focus on nothing".
+  if (deps.focus && deps.focus.length > 0) {
+    return buildDatasourcesFromRows(workspaceId, rowsFocused(rows, deps.focus), mint);
+  }
   // #3044 — drop out-of-scope datasources BEFORE build, so the reconnect tally
   // (and the never-rejects `[]` contract) is computed only over the in-scope set.
   const scopedRows = rowsInActiveGroup(rows, deps.activeGroupId);

--- a/packages/api/src/lib/tools/__tests__/action-permissions.test.ts
+++ b/packages/api/src/lib/tools/__tests__/action-permissions.test.ts
@@ -143,6 +143,7 @@ mock.module("@atlas/api/lib/conversations", () => ({
   verifyGroupBelongsToOrg: mock(() => Promise.resolve("ok")),
   updateConversationRoutingMode: mock(() => Promise.resolve({ ok: true as const })),
   updateConversationRestExcluded: mock(() => Promise.resolve({ ok: true as const })),
+  updateConversationRestFocus: mock(() => Promise.resolve({ ok: true as const })),
   resolveRoutingMode: mock((m: "auto" | "pin" | "all" | null | undefined = null) => m ?? "pin"),
 }));
 

--- a/packages/api/src/lib/tools/__tests__/python-rest-egress-scope.test.ts
+++ b/packages/api/src/lib/tools/__tests__/python-rest-egress-scope.test.ts
@@ -161,9 +161,10 @@ describe("defaultResolveRestDatasource — env-scope lockstep (#3044)", () => {
     expect(result?.id).toBe("ds-stripe");
   });
 
-  it("falls back to default scope when the focus target is gone (#3067)", async () => {
-    // Focus resolves to null (uninstalled) → egress mirrors agent.ts's safe
-    // fallback: a SECOND call resolves the default scope (activeGroupId + excluded).
+  it("DENIES egress (fails closed) when the focus target is gone — never widens to default scope (#3067)", async () => {
+    // Focus resolves to null (uninstalled or transiently unavailable). An egress
+    // allowlist must fail CLOSED: exactly ONE focus-scoped call, returns null
+    // (no egress) — it must NOT fall through to a wider default-scope resolve.
     focusResolvesTo = null;
     mockReqCtx = {
       user: { activeOrganizationId: "org-1" },
@@ -171,9 +172,9 @@ describe("defaultResolveRestDatasource — env-scope lockstep (#3044)", () => {
       restExcludedDatasourceIds: ["ds-x"],
       restFocusDatasourceId: "ds-gone",
     };
-    await defaultResolveRestDatasource();
-    expect(primaryCalls).toHaveLength(2);
+    const result = await defaultResolveRestDatasource();
+    expect(result).toBeNull();
+    expect(primaryCalls).toHaveLength(1);
     expect(primaryCalls[0]!.deps).toEqual({ focus: "ds-gone" });
-    expect(primaryCalls[1]!.deps).toEqual({ activeGroupId: "eu", excluded: ["ds-x"] });
   });
 });

--- a/packages/api/src/lib/tools/__tests__/python-rest-egress-scope.test.ts
+++ b/packages/api/src/lib/tools/__tests__/python-rest-egress-scope.test.ts
@@ -18,8 +18,13 @@ let mockReqCtx:
       connectionGroupId?: string;
       connectionId?: string;
       restExcludedDatasourceIds?: readonly string[];
+      restFocusDatasourceId?: string | null;
     }
   | undefined;
+
+// #3067 — what the primary resolver returns for a FOCUS call. Default null
+// (the focus target is gone → egress falls back to default scope).
+let focusResolvesTo: { id: string } | null = null;
 
 mock.module("@atlas/api/lib/logger", () => ({
   createLogger: () => ({ debug() {}, info() {}, warn() {}, error() {} }),
@@ -46,6 +51,9 @@ let primaryCalls: Array<{ orgId: string; deps: unknown }> = [];
 mock.module("@atlas/api/lib/openapi/workspace-datasource", () => ({
   resolveWorkspacePrimaryRestDatasource: async (orgId: string, deps: unknown) => {
     primaryCalls.push({ orgId, deps });
+    // A focus call resolves to the configured datasource (or null = gone); any
+    // other (default-scope) call resolves to null in these tests.
+    if (deps && typeof deps === "object" && "focus" in deps) return focusResolvesTo;
     return null;
   },
   resolveWorkspaceRestDatasources: async () => [],
@@ -60,6 +68,7 @@ describe("defaultResolveRestDatasource — env-scope lockstep (#3044)", () => {
   beforeEach(() => {
     mockReqCtx = undefined;
     primaryCalls = [];
+    focusResolvesTo = null;
   });
 
   it("threads the conversation's connectionGroupId as activeGroupId", async () => {
@@ -129,5 +138,38 @@ describe("defaultResolveRestDatasource — env-scope lockstep (#3044)", () => {
     };
     await defaultResolveRestDatasource();
     expect(primaryCalls[0]!.deps).toEqual({ activeGroupId: "eu" });
+  });
+
+  // #3067 — a REST-only focused conversation limits the sandbox egress to the
+  // single focus target, so Python can't probe any other host either.
+  it("resolves ONLY the focus target when focused — no fall-through (#3067)", async () => {
+    focusResolvesTo = { id: "ds-stripe" };
+    mockReqCtx = {
+      user: { activeOrganizationId: "org-1" },
+      connectionGroupId: "eu",
+      restExcludedDatasourceIds: ["ds-x"],
+      restFocusDatasourceId: "ds-stripe",
+    };
+    const result = await defaultResolveRestDatasource();
+    // Exactly one call, scoped to focus only — group + exclude are inert.
+    expect(primaryCalls).toHaveLength(1);
+    expect(primaryCalls[0]!.deps).toEqual({ focus: "ds-stripe" });
+    expect(result).toEqual({ id: "ds-stripe" });
+  });
+
+  it("falls back to default scope when the focus target is gone (#3067)", async () => {
+    // Focus resolves to null (uninstalled) → egress mirrors agent.ts's safe
+    // fallback: a SECOND call resolves the default scope (activeGroupId + excluded).
+    focusResolvesTo = null;
+    mockReqCtx = {
+      user: { activeOrganizationId: "org-1" },
+      connectionGroupId: "eu",
+      restExcludedDatasourceIds: ["ds-x"],
+      restFocusDatasourceId: "ds-gone",
+    };
+    await defaultResolveRestDatasource();
+    expect(primaryCalls).toHaveLength(2);
+    expect(primaryCalls[0]!.deps).toEqual({ focus: "ds-gone" });
+    expect(primaryCalls[1]!.deps).toEqual({ activeGroupId: "eu", excluded: ["ds-x"] });
   });
 });

--- a/packages/api/src/lib/tools/__tests__/python-rest-egress-scope.test.ts
+++ b/packages/api/src/lib/tools/__tests__/python-rest-egress-scope.test.ts
@@ -10,6 +10,7 @@
  * #3044 closes. This pins that the egress path always passes a defined value.
  */
 import { describe, it, expect, beforeEach, mock } from "bun:test";
+import type { RestDatasource } from "@atlas/api/lib/openapi/datasource";
 
 // Controllable request context (default: none).
 let mockReqCtx:
@@ -23,8 +24,9 @@ let mockReqCtx:
   | undefined;
 
 // #3067 — what the primary resolver returns for a FOCUS call. Default null
-// (the focus target is gone → egress falls back to default scope).
-let focusResolvesTo: { id: string } | null = null;
+// (the focus target is gone → egress falls back to default scope). Only the
+// `id` matters to these tests; cast to the full shape at the mock boundary.
+let focusResolvesTo: Pick<RestDatasource, "id"> | null = null;
 
 mock.module("@atlas/api/lib/logger", () => ({
   createLogger: () => ({ debug() {}, info() {}, warn() {}, error() {} }),
@@ -53,7 +55,9 @@ mock.module("@atlas/api/lib/openapi/workspace-datasource", () => ({
     primaryCalls.push({ orgId, deps });
     // A focus call resolves to the configured datasource (or null = gone); any
     // other (default-scope) call resolves to null in these tests.
-    if (deps && typeof deps === "object" && "focus" in deps) return focusResolvesTo;
+    if (deps && typeof deps === "object" && "focus" in deps) {
+      return focusResolvesTo as RestDatasource | null;
+    }
     return null;
   },
   resolveWorkspaceRestDatasources: async () => [],
@@ -154,7 +158,7 @@ describe("defaultResolveRestDatasource — env-scope lockstep (#3044)", () => {
     // Exactly one call, scoped to focus only — group + exclude are inert.
     expect(primaryCalls).toHaveLength(1);
     expect(primaryCalls[0]!.deps).toEqual({ focus: "ds-stripe" });
-    expect(result).toEqual({ id: "ds-stripe" });
+    expect(result?.id).toBe("ds-stripe");
   });
 
   it("falls back to default scope when the focus target is gone (#3067)", async () => {

--- a/packages/api/src/lib/tools/python.ts
+++ b/packages/api/src/lib/tools/python.ts
@@ -447,15 +447,16 @@ export async function defaultResolveRestDatasource(): Promise<RestDatasource | n
     "@atlas/api/lib/openapi/workspace-datasource"
   );
   // #3067 — keep the sandbox egress allowlist in lockstep with a REST-only
-  // focused conversation: when focused, the only reachable host is the focus
-  // target. Resolve ONLY it; if it resolves, that's the sole egress target. If
-  // the focus datasource is gone, fall through to default scope (mirrors
-  // agent.ts's safe fallback) rather than leaving Python with no egress while
-  // the agent loop runs in default mode.
+  // focused conversation: the only reachable host is the focus target. Resolve
+  // ONLY it and RETURN — including a `null` (focus uninstalled or transiently
+  // unavailable), which DENIES egress for the turn. An egress allowlist must
+  // fail CLOSED: falling through to the default scope here would silently widen
+  // the sandbox's reachable hosts on a conversation the user narrowed to one
+  // datasource (the wrong failure direction for a security guard). The agent
+  // loop makes its own SQL/REST decision; Python egress stays focus-only.
   const focus = reqCtx?.restFocusDatasourceId;
   if (focus) {
-    const focused = await resolveWorkspacePrimaryRestDatasource(orgId, { focus });
-    if (focused) return focused;
+    return resolveWorkspacePrimaryRestDatasource(orgId, { focus });
   }
   // #3044 — keep the sandbox egress allowlist in lockstep with the agent's
   // in-scope datasources: a datasource scoped to a different environment group

--- a/packages/api/src/lib/tools/python.ts
+++ b/packages/api/src/lib/tools/python.ts
@@ -443,6 +443,20 @@ export async function defaultResolveRestDatasource(): Promise<RestDatasource | n
   const reqCtx = getRequestContext();
   const orgId = reqCtx?.user?.activeOrganizationId;
   if (!orgId) return null;
+  const { resolveWorkspacePrimaryRestDatasource } = await import(
+    "@atlas/api/lib/openapi/workspace-datasource"
+  );
+  // #3067 — keep the sandbox egress allowlist in lockstep with a REST-only
+  // focused conversation: when focused, the only reachable host is the focus
+  // target. Resolve ONLY it; if it resolves, that's the sole egress target. If
+  // the focus datasource is gone, fall through to default scope (mirrors
+  // agent.ts's safe fallback) rather than leaving Python with no egress while
+  // the agent loop runs in default mode.
+  const focus = reqCtx?.restFocusDatasourceId;
+  if (focus) {
+    const focused = await resolveWorkspacePrimaryRestDatasource(orgId, { focus });
+    if (focused) return focused;
+  }
   // #3044 — keep the sandbox egress allowlist in lockstep with the agent's
   // in-scope datasources: a datasource scoped to a different environment group
   // must not be reachable from Python either. Resolve the active environment the
@@ -456,9 +470,6 @@ export async function defaultResolveRestDatasource(): Promise<RestDatasource | n
     const ctx = await loadGroupRoutingContext(orgId, reqCtx.connectionId);
     activeGroupId = ctx.groupId ?? null;
   }
-  const { resolveWorkspacePrimaryRestDatasource } = await import(
-    "@atlas/api/lib/openapi/workspace-datasource"
-  );
   // #3066 — keep the sandbox egress allowlist in lockstep with the conversation's
   // REST exclude-set too: a datasource the conversation excluded must not be
   // reachable from Python either, or the agent could probe an excluded host's

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useatlas/types",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "Shared types for the Atlas text-to-SQL agent",
   "type": "module",
   "scripts": {

--- a/packages/types/src/conversation.ts
+++ b/packages/types/src/conversation.ts
@@ -69,6 +69,21 @@ export interface Conversation {
    * genuinely-nullable `routingMode` this field has no null state.
    */
   restExcludedDatasourceIds?: string[];
+  /**
+   * Per-conversation REST-only focus (#3067). When set, the single
+   * `install_id` — the id the scope picker surfaces — the conversation
+   * targets exclusively; the agent runs REST-only with `executeSQL`
+   * SUSPENDED. `null` / absent = not focused: SQL routing (`routingMode`)
+   * and the exclude-set (`restExcludedDatasourceIds`) apply as normal.
+   * Those two fields stay populated-but-inert while focused, so clearing
+   * focus (back to `null`) returns to the prior default-state scope.
+   *
+   * Genuinely nullable (unlike the exclude-set): the column is plain
+   * nullable `text` with no default, and `null` is the meaningful
+   * "not focused" state. Optional so pre-#3067 fixtures / SDK consumers
+   * can omit it; the runtime treats missing the same as `null`.
+   */
+  restFocusDatasourceId?: string | null;
   starred: boolean;
   createdAt: string;
   updatedAt: string;

--- a/packages/types/src/errors.ts
+++ b/packages/types/src/errors.ts
@@ -193,6 +193,12 @@ export const CHAT_CONTEXT_WARNING_CODES = [
   // the chat silently degrades to the default agent and the user gets
   // a "agent ignores my edits" experience.
   "bound_dashboard_unavailable",
+  // #3067 — REST-only focus fail-closed. The conversation is focused on a
+  // single REST datasource but it was temporarily unresolvable (load failure
+  // / credential reconnect), so the turn keeps SQL suspended rather than
+  // widening scope back to SQL. The UI surfaces a "focused datasource
+  // unavailable" banner so the user knows to retry or clear the focus.
+  "rest_focus_unavailable",
 ] as const;
 
 export type ChatContextWarningCode = (typeof CHAT_CONTEXT_WARNING_CODES)[number];

--- a/packages/web/src/lib/stores/__tests__/chat-routing-preference-store.test.ts
+++ b/packages/web/src/lib/stores/__tests__/chat-routing-preference-store.test.ts
@@ -25,12 +25,17 @@ describe("useChatRoutingPreferenceStore (#3044)", () => {
       groupId: "prod",
       connectionId: "eu-prod",
       routingMode: "pin",
+      restExcludedDatasourceIds: ["billing-api"],
+      restFocusDatasourceId: "stripe",
     });
     const s = useChatRoutingPreferenceStore.getState();
     expect(s.workspaceId).toBe("org-1");
     expect(s.groupId).toBe("prod");
     expect(s.connectionId).toBe("eu-prod");
     expect(s.routingMode).toBe("pin");
+    // #3066 / #3067 — the REST scope fields persist too.
+    expect(s.restExcludedDatasourceIds).toEqual(["billing-api"]);
+    expect(s.restFocusDatasourceId).toBe("stripe");
   });
 
   it("persists ONLY the preference fields to localStorage (partialize drops setters)", () => {
@@ -39,6 +44,8 @@ describe("useChatRoutingPreferenceStore (#3044)", () => {
       groupId: "prod",
       connectionId: "eu-prod",
       routingMode: "all",
+      restExcludedDatasourceIds: ["billing-api"],
+      restFocusDatasourceId: "stripe",
     });
     const raw = localStorage.getItem(STORAGE_KEY);
     expect(raw).not.toBeNull();
@@ -48,6 +55,8 @@ describe("useChatRoutingPreferenceStore (#3044)", () => {
       groupId: "prod",
       connectionId: "eu-prod",
       routingMode: "all",
+      restExcludedDatasourceIds: ["billing-api"],
+      restFocusDatasourceId: "stripe",
     });
     // Setters must never be serialized.
     expect(persisted.state.setPreference).toBeUndefined();

--- a/packages/web/src/lib/stores/chat-routing-preference-store.ts
+++ b/packages/web/src/lib/stores/chat-routing-preference-store.ts
@@ -44,6 +44,13 @@ export interface ChatRoutingPreference {
    * authoritative once a conversation exists. Empty = nothing excluded.
    */
   readonly restExcludedDatasourceIds: readonly string[];
+  /**
+   * #3067 — REST-only focus the user last chose (a single `install_id`, or
+   * null = not focused). Seeds NEW chats only; the per-conversation row is
+   * authoritative once a conversation exists. When set, the conversation
+   * targets only that datasource and SQL is suspended.
+   */
+  readonly restFocusDatasourceId: string | null;
 }
 
 interface ChatRoutingPreferenceStore extends ChatRoutingPreference {
@@ -70,6 +77,7 @@ const EMPTY: ChatRoutingPreference = {
   connectionId: null,
   routingMode: null,
   restExcludedDatasourceIds: [],
+  restFocusDatasourceId: null,
 };
 
 export const useChatRoutingPreferenceStore = create<ChatRoutingPreferenceStore>()(
@@ -85,6 +93,7 @@ export const useChatRoutingPreferenceStore = create<ChatRoutingPreferenceStore>(
           connectionId: next.connectionId,
           routingMode: next.routingMode,
           restExcludedDatasourceIds: next.restExcludedDatasourceIds,
+          restFocusDatasourceId: next.restFocusDatasourceId,
         }),
       // Partial set — zustand shallow-merges, so `_hasHydrated` (absent from
       // EMPTY) is preserved. A clear must not re-close the hydration gate.
@@ -103,6 +112,7 @@ export const useChatRoutingPreferenceStore = create<ChatRoutingPreferenceStore>(
         connectionId: s.connectionId,
         routingMode: s.routingMode,
         restExcludedDatasourceIds: s.restExcludedDatasourceIds,
+        restFocusDatasourceId: s.restFocusDatasourceId,
       }),
       // Fires after rehydration (synchronously for localStorage, even when
       // storage was empty), so the consumer's gate opens exactly once the

--- a/packages/web/src/ui/__tests__/env-picker.test.tsx
+++ b/packages/web/src/ui/__tests__/env-picker.test.tsx
@@ -876,6 +876,125 @@ describe("ChatEnvPicker — REST datasource exclude-set (#3066)", () => {
   });
 });
 
+describe("ChatEnvPicker — REST-only focus (#3067)", () => {
+  const multiGroup: ChatEnvGroup[] = [
+    {
+      id: "prod",
+      name: "prod",
+      primaryConnectionId: null,
+      members: [
+        { connectionId: "us-prod", dbType: "postgres", description: null },
+        { connectionId: "eu-prod", dbType: "postgres", description: null },
+      ],
+    },
+  ];
+  const datasources = [
+    { id: "stripe", displayName: "Stripe", groupId: null },
+    { id: "prod-api", displayName: "Prod API", groupId: "prod" },
+  ];
+
+  test("the chip reads '<name> only' and marks data-focused when a datasource is focused", () => {
+    const { container } = render(
+      <ChatEnvPicker
+        groups={multiGroup}
+        activeGroupId="prod"
+        activeConnectionId="us-prod"
+        activeRoutingMode="pin"
+        restDatasources={datasources}
+        restFocusDatasourceId="stripe"
+        onRestFocusChange={noop}
+        onSelect={noop}
+      />,
+    );
+    const label =
+      container.querySelector('[data-testid="chat-env-picker-label"]')?.textContent ?? "";
+    expect(label).toContain("Stripe only");
+    // The mode/env summary is replaced — SQL routing is suspended.
+    expect(label).not.toContain("REST");
+    expect(
+      container
+        .querySelector('[data-testid="chat-env-picker-trigger"]')
+        ?.getAttribute("data-focused"),
+    ).toBe("true");
+  });
+
+  test("falls back to 'REST only' when the focused id isn't in the datasource list", () => {
+    const { container } = render(
+      <ChatEnvPicker
+        groups={multiGroup}
+        activeGroupId="prod"
+        activeConnectionId="us-prod"
+        activeRoutingMode="pin"
+        restDatasources={datasources}
+        restFocusDatasourceId="gone-ds"
+        onRestFocusChange={noop}
+        onSelect={noop}
+      />,
+    );
+    const label =
+      container.querySelector('[data-testid="chat-env-picker-label"]')?.textContent ?? "";
+    expect(label).toContain("REST only");
+  });
+
+  test("offers a 'Focus … only' option per reachable datasource; clicking focuses it", () => {
+    const onRestFocusChange = mock((_next: string | null) => {});
+    const { container } = render(
+      <ChatEnvPicker
+        groups={multiGroup}
+        activeGroupId="prod"
+        activeConnectionId="us-prod"
+        activeRoutingMode="pin"
+        restDatasources={datasources}
+        restFocusDatasourceId={null}
+        onRestFocusChange={onRestFocusChange}
+        onSelect={noop}
+      />,
+    );
+    const focusItem = container.querySelector(
+      '[data-testid="chat-env-picker-rest-focus-stripe"]',
+    ) as HTMLElement;
+    expect(focusItem).not.toBeNull();
+    fireEvent.click(focusItem);
+    expect(onRestFocusChange).toHaveBeenCalledTimes(1);
+    expect(onRestFocusChange.mock.calls[0]![0]).toBe("stripe");
+  });
+
+  test("while focused, hides the exclude checkboxes and clears via onRestFocusChange(null)", () => {
+    const onRestFocusChange = mock((_next: string | null) => {});
+    const { container } = render(
+      <ChatEnvPicker
+        groups={multiGroup}
+        activeGroupId="prod"
+        activeConnectionId="us-prod"
+        activeRoutingMode="pin"
+        restDatasources={datasources}
+        restExcludedDatasourceIds={[]}
+        onRestExcludedChange={noop}
+        restFocusDatasourceId="stripe"
+        onRestFocusChange={onRestFocusChange}
+        onSelect={noop}
+      />,
+    );
+    // The exclude-set is inert while focused → its checkboxes are not rendered.
+    expect(
+      container.querySelector('[data-testid="chat-env-picker-rest-toggle-stripe"]'),
+    ).toBeNull();
+    // The focused summary carries the focused id…
+    expect(
+      container
+        .querySelector('[data-testid="chat-env-picker-rest-focused"]')
+        ?.getAttribute("data-focus-id"),
+    ).toBe("stripe");
+    // …and the clear action nulls the focus.
+    const clear = container.querySelector(
+      '[data-testid="chat-env-picker-rest-focus-clear"]',
+    ) as HTMLElement;
+    fireEvent.click(clear);
+    expect(onRestFocusChange).toHaveBeenCalledTimes(1);
+    expect(onRestFocusChange.mock.calls[0]![0]).toBeNull();
+  });
+});
+
 const originalFetch = globalThis.fetch;
 
 function mockFetch(
@@ -1473,6 +1592,7 @@ describe("resolveEnvSelection — sticky-preference restore vs default seed (#30
       connectionId: "eu-prod",
       routingMode: "pin",
       restExcludedDatasourceIds: [],
+      restFocusDatasourceId: null,
     });
   });
 
@@ -1500,6 +1620,7 @@ describe("resolveEnvSelection — sticky-preference restore vs default seed (#30
       connectionId: "eu-prod",
       routingMode: "pin",
       restExcludedDatasourceIds: [],
+      restFocusDatasourceId: null,
     });
   });
 
@@ -1526,6 +1647,7 @@ describe("resolveEnvSelection — sticky-preference restore vs default seed (#30
       connectionId: "eu-prod",
       routingMode: "auto",
       restExcludedDatasourceIds: [],
+      restFocusDatasourceId: null,
     });
   });
 
@@ -1584,6 +1706,7 @@ describe("resolveEnvSelection — sticky-preference restore vs default seed (#30
       groupId: "g_prod",
       connectionId: "us-prod",
       restExcludedDatasourceIds: [],
+      restFocusDatasourceId: null,
     });
   });
 
@@ -1604,6 +1727,7 @@ describe("resolveEnvSelection — sticky-preference restore vs default seed (#30
       groupId: "g_prod",
       connectionId: "us-prod",
       restExcludedDatasourceIds: [],
+      restFocusDatasourceId: null,
     });
   });
 
@@ -1624,6 +1748,7 @@ describe("resolveEnvSelection — sticky-preference restore vs default seed (#30
       groupId: "g_prod",
       connectionId: "us-prod",
       restExcludedDatasourceIds: [],
+      restFocusDatasourceId: null,
     });
   });
 
@@ -1645,6 +1770,7 @@ describe("resolveEnvSelection — sticky-preference restore vs default seed (#30
       connectionId: "eu-prod",
       routingMode: "auto",
       restExcludedDatasourceIds: [],
+      restFocusDatasourceId: null,
     });
   });
 
@@ -1660,6 +1786,67 @@ describe("resolveEnvSelection — sticky-preference restore vs default seed (#30
       groupId: "g_only",
       connectionId: "only",
       restExcludedDatasourceIds: [],
+      restFocusDatasourceId: null,
+    });
+  });
+
+  // #3067 — REST-only focus is part of the sticky preference, so a fresh chat
+  // seeds the preference's focus alongside its group/member.
+  test("restores the preference's REST-only focus onto a fresh chat", () => {
+    const decision = resolveEnvSelection(
+      input({
+        preference: {
+          workspaceId: "org-1",
+          groupId: "g_prod",
+          connectionId: "eu-prod",
+          routingMode: "pin",
+          restExcludedDatasourceIds: [],
+          restFocusDatasourceId: "stripe",
+        },
+        activeWorkspaceId: "org-1",
+      }),
+    );
+    expect(decision).toEqual({
+      kind: "restore",
+      groupId: "g_prod",
+      connectionId: "eu-prod",
+      routingMode: "pin",
+      restExcludedDatasourceIds: [],
+      restFocusDatasourceId: "stripe",
+    });
+  });
+
+  // #3067 — a focus-only difference (group/member/mode/exclude all match, only
+  // focus differs) must still restore rather than no-op.
+  test("restores when only the REST-only focus differs", () => {
+    const decision = resolveEnvSelection(
+      input({
+        current: {
+          groupId: "g_prod",
+          connectionId: "eu-prod",
+          routingMode: "pin",
+          restExcludedDatasourceIds: [],
+          restFocusDatasourceId: null,
+        },
+        provenance: "default",
+        preference: {
+          workspaceId: "org-1",
+          groupId: "g_prod",
+          connectionId: "eu-prod",
+          routingMode: "pin",
+          restExcludedDatasourceIds: [],
+          restFocusDatasourceId: "stripe",
+        },
+        activeWorkspaceId: "org-1",
+      }),
+    );
+    expect(decision).toEqual({
+      kind: "restore",
+      groupId: "g_prod",
+      connectionId: "eu-prod",
+      routingMode: "pin",
+      restExcludedDatasourceIds: [],
+      restFocusDatasourceId: "stripe",
     });
   });
 });
@@ -1704,7 +1891,7 @@ describe("resolveConversationScope — restore a conversation's scope on open (#
         { connectionGroupId: "g_prod", connectionId: "eu-prod", routingMode: "pin" },
         groups,
       ),
-    ).toEqual({ kind: "restore", groupId: "g_prod", connectionId: "eu-prod", routingMode: "pin", restExcludedDatasourceIds: [] });
+    ).toEqual({ kind: "restore", groupId: "g_prod", connectionId: "eu-prod", routingMode: "pin", restExcludedDatasourceIds: [], restFocusDatasourceId: null });
   });
 
   test("preserves an 'auto' routing mode (mode is a first-class scope dimension)", () => {
@@ -1715,7 +1902,7 @@ describe("resolveConversationScope — restore a conversation's scope on open (#
         { connectionGroupId: "g_prod", connectionId: "us-prod", routingMode: "auto" },
         groups,
       ),
-    ).toEqual({ kind: "restore", groupId: "g_prod", connectionId: "us-prod", routingMode: "auto", restExcludedDatasourceIds: [] });
+    ).toEqual({ kind: "restore", groupId: "g_prod", connectionId: "us-prod", routingMode: "auto", restExcludedDatasourceIds: [], restFocusDatasourceId: null });
   });
 
   test("preserves an 'all' routing mode", () => {
@@ -1724,7 +1911,7 @@ describe("resolveConversationScope — restore a conversation's scope on open (#
         { connectionGroupId: "g_prod", connectionId: "us-prod", routingMode: "all" },
         groups,
       ),
-    ).toEqual({ kind: "restore", groupId: "g_prod", connectionId: "us-prod", routingMode: "all", restExcludedDatasourceIds: [] });
+    ).toEqual({ kind: "restore", groupId: "g_prod", connectionId: "us-prod", routingMode: "all", restExcludedDatasourceIds: [], restFocusDatasourceId: null });
   });
 
   test("two different conversations resolve to two different scopes (switching updates the picker each time)", () => {
@@ -1750,7 +1937,7 @@ describe("resolveConversationScope — restore a conversation's scope on open (#
         { connectionGroupId: "g_prod", connectionId: "eu-prod", routingMode: null },
         groups,
       ),
-    ).toEqual({ kind: "restore", groupId: "g_prod", connectionId: "eu-prod", routingMode: null, restExcludedDatasourceIds: [] });
+    ).toEqual({ kind: "restore", groupId: "g_prod", connectionId: "eu-prod", routingMode: null, restExcludedDatasourceIds: [], restFocusDatasourceId: null });
   });
 
   test("legacy conversation with an omitted routing mode defaults to null", () => {
@@ -1761,7 +1948,7 @@ describe("resolveConversationScope — restore a conversation's scope on open (#
         { connectionGroupId: "g_prod", connectionId: "eu-prod" },
         groups,
       ),
-    ).toEqual({ kind: "restore", groupId: "g_prod", connectionId: "eu-prod", routingMode: null, restExcludedDatasourceIds: [] });
+    ).toEqual({ kind: "restore", groupId: "g_prod", connectionId: "eu-prod", routingMode: null, restExcludedDatasourceIds: [], restFocusDatasourceId: null });
   });
 
   test("seeds (defers) for a fully-null row — never makes nulls authoritative", () => {
@@ -1794,7 +1981,7 @@ describe("resolveConversationScope — restore a conversation's scope on open (#
         { connectionGroupId: "g_prod", connectionId: "ap-prod-archived", routingMode: "pin" },
         groups,
       ),
-    ).toEqual({ kind: "restore", groupId: "g_prod", connectionId: "us-prod", routingMode: "pin", restExcludedDatasourceIds: [] });
+    ).toEqual({ kind: "restore", groupId: "g_prod", connectionId: "us-prod", routingMode: "pin", restExcludedDatasourceIds: [], restFocusDatasourceId: null });
   });
 
   test("repairs a group-only row (null member, e.g. Auto) to the group primary", () => {
@@ -1805,7 +1992,7 @@ describe("resolveConversationScope — restore a conversation's scope on open (#
         { connectionGroupId: "g_prod", connectionId: null, routingMode: "auto" },
         groups,
       ),
-    ).toEqual({ kind: "restore", groupId: "g_prod", connectionId: "us-prod", routingMode: "auto", restExcludedDatasourceIds: [] });
+    ).toEqual({ kind: "restore", groupId: "g_prod", connectionId: "us-prod", routingMode: "auto", restExcludedDatasourceIds: [], restFocusDatasourceId: null });
   });
 
   test("falls back to members[0] when repairing under a group with no primary", () => {
@@ -1814,7 +2001,7 @@ describe("resolveConversationScope — restore a conversation's scope on open (#
         { connectionGroupId: "g_staging", connectionId: "gone", routingMode: "pin" },
         groups,
       ),
-    ).toEqual({ kind: "restore", groupId: "g_staging", connectionId: "us-staging", routingMode: "pin", restExcludedDatasourceIds: [] });
+    ).toEqual({ kind: "restore", groupId: "g_staging", connectionId: "us-staging", routingMode: "pin", restExcludedDatasourceIds: [], restFocusDatasourceId: null });
   });
 
   test("trusts the row optimistically when groups have not loaded yet (cold-start open)", () => {
@@ -1826,7 +2013,7 @@ describe("resolveConversationScope — restore a conversation's scope on open (#
         { connectionGroupId: "g_prod", connectionId: "eu-prod", routingMode: "all" },
         [],
       ),
-    ).toEqual({ kind: "restore", groupId: "g_prod", connectionId: "eu-prod", routingMode: "all", restExcludedDatasourceIds: [] });
+    ).toEqual({ kind: "restore", groupId: "g_prod", connectionId: "eu-prod", routingMode: "all", restExcludedDatasourceIds: [], restFocusDatasourceId: null });
   });
 
   test("still seeds a fully-null row even when groups have not loaded", () => {
@@ -1852,7 +2039,7 @@ describe("resolveConversationScope — restore a conversation's scope on open (#
         { connectionGroupId: null, connectionId: "eu-prod", routingMode: "pin" },
         groups,
       ),
-    ).toEqual({ kind: "restore", groupId: "g_prod", connectionId: "eu-prod", routingMode: "pin", restExcludedDatasourceIds: [] });
+    ).toEqual({ kind: "restore", groupId: "g_prod", connectionId: "eu-prod", routingMode: "pin", restExcludedDatasourceIds: [], restFocusDatasourceId: null });
   });
 
   test("seeds a legacy group-less row only when its connection no longer exists in any group", () => {
@@ -1875,7 +2062,7 @@ describe("resolveConversationScope — restore a conversation's scope on open (#
         { connectionGroupId: null, connectionId: "eu-prod", routingMode: "pin" },
         [],
       ),
-    ).toEqual({ kind: "restore", groupId: null, connectionId: "eu-prod", routingMode: "pin", restExcludedDatasourceIds: [] });
+    ).toEqual({ kind: "restore", groupId: null, connectionId: "eu-prod", routingMode: "pin", restExcludedDatasourceIds: [], restFocusDatasourceId: null });
   });
 
   test("seeds when a resolved group has no live members (fully archived group)", () => {
@@ -1891,6 +2078,46 @@ describe("resolveConversationScope — restore a conversation's scope on open (#
         [emptyGroup],
       ),
     ).toEqual({ kind: "seed" });
+  });
+
+  // #3067 — the row's REST-only focus is restored alongside the SQL scope, the
+  // same way as the exclude-set (carried on every `restore` decision).
+  test("restores the row's REST-only focus alongside the SQL scope", () => {
+    expect(
+      resolveConversationScope(
+        {
+          connectionGroupId: "g_prod",
+          connectionId: "eu-prod",
+          routingMode: "pin",
+          restFocusDatasourceId: "stripe",
+        },
+        groups,
+      ),
+    ).toEqual({
+      kind: "restore",
+      groupId: "g_prod",
+      connectionId: "eu-prod",
+      routingMode: "pin",
+      restExcludedDatasourceIds: [],
+      restFocusDatasourceId: "stripe",
+    });
+  });
+
+  // #3067 — an absent focus column coalesces to null (not focused).
+  test("coalesces an absent REST-only focus column to null", () => {
+    expect(
+      resolveConversationScope(
+        { connectionGroupId: "g_prod", connectionId: "eu-prod", routingMode: "pin" },
+        groups,
+      ),
+    ).toEqual({
+      kind: "restore",
+      groupId: "g_prod",
+      connectionId: "eu-prod",
+      routingMode: "pin",
+      restExcludedDatasourceIds: [],
+      restFocusDatasourceId: null,
+    });
   });
 });
 

--- a/packages/web/src/ui/components/atlas-chat.tsx
+++ b/packages/web/src/ui/components/atlas-chat.tsx
@@ -140,6 +140,11 @@ export function AtlasChat() {
   // `install_id`s). Empty = all in scope. Seeded from the sticky preference on
   // a fresh chat, restored from the row when a conversation is opened.
   const [selectedRestExcluded, setSelectedRestExcluded] = useState<string[]>([]);
+  // #3067 — per-conversation REST-only focus (a single `install_id`, or null =
+  // not focused). When set, the conversation targets only that datasource and
+  // SQL is suspended. Seeded from the sticky preference on a fresh chat,
+  // restored from the row when a conversation is opened.
+  const [selectedRestFocus, setSelectedRestFocus] = useState<string | null>(null);
   // #3044 — persisted env-picker preference so a reload restores the user's
   // last selection instead of re-seeding from the first group. Select fields
   // individually so the store object identity doesn't churn effect deps.
@@ -148,6 +153,7 @@ export function AtlasChat() {
   const prefConnectionId = useChatRoutingPreferenceStore((s) => s.connectionId);
   const prefRoutingMode = useChatRoutingPreferenceStore((s) => s.routingMode);
   const prefRestExcluded = useChatRoutingPreferenceStore((s) => s.restExcludedDatasourceIds);
+  const prefRestFocus = useChatRoutingPreferenceStore((s) => s.restFocusDatasourceId);
   const prefHasHydrated = useChatRoutingPreferenceStore((s) => s._hasHydrated);
   const setRoutingPreference = useChatRoutingPreferenceStore((s) => s.setPreference);
   // #3064 — how the current picker selection was set, so the seed/restore
@@ -190,6 +196,9 @@ export function AtlasChat() {
     getRoutingMode: () => selectedRoutingMode,
     // #3066 — forward the REST exclude-set on every turn (always, even []).
     getRestExcludedDatasourceIds: () => selectedRestExcluded,
+    // #3067 — forward the REST-only focus on every turn (always, even null) so
+    // a clear actually nulls the row instead of inheriting the stale focus.
+    getRestFocusDatasourceId: () => selectedRestFocus,
   });
 
   const managedSession = authClient.useSession();
@@ -234,6 +243,7 @@ export function AtlasChat() {
         connectionId: selectedConnectionId,
         routingMode: selectedRoutingMode,
         restExcludedDatasourceIds: selectedRestExcluded,
+        restFocusDatasourceId: selectedRestFocus,
       },
       provenance: selectionProvenanceRef.current,
       preference: {
@@ -242,6 +252,7 @@ export function AtlasChat() {
         connectionId: prefConnectionId,
         routingMode: prefRoutingMode,
         restExcludedDatasourceIds: prefRestExcluded,
+        restFocusDatasourceId: prefRestFocus,
       },
       activeWorkspaceId,
       preferenceHydrated: prefHasHydrated,
@@ -257,6 +268,8 @@ export function AtlasChat() {
         setSelectedRoutingMode(decision.routingMode);
         // #3066 — seed the sticky preference's exclude-set onto this fresh chat.
         setSelectedRestExcluded(decision.restExcludedDatasourceIds);
+        // #3067 — seed the sticky preference's REST-only focus too.
+        setSelectedRestFocus(decision.restFocusDatasourceId);
         // A restored sticky preference is the user's deliberate prior choice —
         // mark it explicit so a later effect run can't seed over it.
         selectionProvenanceRef.current = "explicit";
@@ -266,6 +279,8 @@ export function AtlasChat() {
         setSelectedConnectionId(decision.connectionId);
         // #3066 — a default seed excludes nothing.
         setSelectedRestExcluded(decision.restExcludedDatasourceIds);
+        // #3067 — a default seed is not focused (SQL active).
+        setSelectedRestFocus(decision.restFocusDatasourceId);
         // Record that this was auto-seeded: a workspace-matching preference
         // arriving later is still restored over it (the resolver re-runs), but
         // a second default seed is suppressed.
@@ -293,11 +308,14 @@ export function AtlasChat() {
     // #3066 — exclude-set is part of `current`; keep it in deps so a pref-only
     // exclude change re-evaluates restore-vs-noop rather than going stale.
     selectedRestExcluded,
+    // #3067 — focus is part of `current` too; keep it in deps for the same reason.
+    selectedRestFocus,
     prefWorkspaceId,
     prefGroupId,
     prefConnectionId,
     prefRoutingMode,
     prefRestExcluded,
+    prefRestFocus,
     prefHasHydrated,
     activeWorkspaceId,
     sessionResolved,
@@ -623,6 +641,8 @@ export function AtlasChat() {
         // #3066 — restore the conversation's REST exclude-set so the picker +
         // the next turn reflect what the row actually excludes.
         setSelectedRestExcluded(decision.restExcludedDatasourceIds);
+        // #3067 — restore the conversation's REST-only focus too.
+        setSelectedRestFocus(decision.restFocusDatasourceId);
       } else {
         selectionProvenanceRef.current = "unset";
         setSelectedGroupId(null);
@@ -631,6 +651,11 @@ export function AtlasChat() {
         // #3066 — no usable scope on the row: clear the exclude-set too and let
         // the seed/restore effect re-seed from the sticky preference / default.
         setSelectedRestExcluded([]);
+        // #3067 — clear focus too on a seed decision. (A focused conversation
+        // with all-null SQL scope only arises on a zero-group workspace, which
+        // doesn't render the picker yet — see #3078; on the common ≥1-group
+        // workspace a focused conversation carries a group and restores above.)
+        setSelectedRestFocus(null);
       }
       setMobileSidebarOpen(false);
       // Loaded turns predate this session — no warning frames replay over
@@ -667,6 +692,9 @@ export function AtlasChat() {
     // #3066 — clear the exclude-set so the new chat re-seeds from the sticky
     // preference (or the empty default), matching the env reset above.
     setSelectedRestExcluded([]);
+    // #3067 — clear focus too; the new chat re-seeds focus from the sticky
+    // preference (or the not-focused default).
+    setSelectedRestFocus(null);
   }
 
   // Wait for auth mode detection before rendering — prevents flash of chat UI
@@ -744,6 +772,23 @@ export function AtlasChat() {
                         connectionId: selectedConnectionId,
                         routingMode: selectedRoutingMode,
                         restExcludedDatasourceIds: next,
+                        restFocusDatasourceId: selectedRestFocus,
+                      });
+                    }}
+                    restFocusDatasourceId={selectedRestFocus}
+                    onRestFocusChange={(next) => {
+                      // #3067 — focusing / clearing is a deliberate pick: mark
+                      // explicit and remember it in the sticky preference so new
+                      // chats inherit it. `null` clears focus (re-enables SQL).
+                      selectionProvenanceRef.current = "explicit";
+                      setSelectedRestFocus(next);
+                      setRoutingPreference({
+                        workspaceId: activeWorkspaceId,
+                        groupId: selectedGroupId,
+                        connectionId: selectedConnectionId,
+                        routingMode: selectedRoutingMode,
+                        restExcludedDatasourceIds: selectedRestExcluded,
+                        restFocusDatasourceId: next,
                       });
                     }}
                     onSelect={({ groupId, connectionId, routingMode }) => {
@@ -762,6 +807,9 @@ export function AtlasChat() {
                         connectionId,
                         routingMode,
                         restExcludedDatasourceIds: selectedRestExcluded,
+                        // #3067 — carry the current focus so an env change
+                        // doesn't drop it from the sticky preference.
+                        restFocusDatasourceId: selectedRestFocus,
                       });
                     }}
                   />

--- a/packages/web/src/ui/components/atlas-chat.tsx
+++ b/packages/web/src/ui/components/atlas-chat.tsx
@@ -651,10 +651,13 @@ export function AtlasChat() {
         // #3066 — no usable scope on the row: clear the exclude-set too and let
         // the seed/restore effect re-seed from the sticky preference / default.
         setSelectedRestExcluded([]);
-        // #3067 — clear focus too on a seed decision. (A focused conversation
-        // with all-null SQL scope only arises on a zero-group workspace, which
-        // doesn't render the picker yet — see #3078; on the common ≥1-group
-        // workspace a focused conversation carries a group and restores above.)
+        // #3067 — clear focus too on a seed decision. A `seed` fires when the
+        // row's SQL scope isn't restorable: all-null (legacy / zero-group), or
+        // its group was archived/removed / has no live members. On the common
+        // ≥1-group workspace a focused conversation normally carries a live
+        // group and `restore`s above; the all-null REST-only case (where focus
+        // would be lost) is only reachable on a zero-group workspace, which
+        // doesn't render the picker yet — see #3078.
         setSelectedRestFocus(null);
       }
       setMobileSidebarOpen(false);

--- a/packages/web/src/ui/components/chat/env-picker.tsx
+++ b/packages/web/src/ui/components/chat/env-picker.tsx
@@ -1030,7 +1030,10 @@ function ChatEnvRestScopeSection({
           {focusable.map((d) => (
             <DropdownMenuItem
               key={d.id}
-              // Keep the menu open so the user can read the chip update.
+              // Focusing is a one-shot scope change — let the menu close on
+              // select (default DropdownMenuItem behavior); the chip updates to
+              // "<name> only". (Contrast the exclude checkboxes, which
+              // preventDefault to stay open for multi-toggle.)
               onSelect={() => onRestFocusChange(d.id)}
               className="flex items-center gap-1.5 text-xs"
               data-testid={`chat-env-picker-rest-focus-${d.id}`}

--- a/packages/web/src/ui/components/chat/env-picker.tsx
+++ b/packages/web/src/ui/components/chat/env-picker.tsx
@@ -34,7 +34,7 @@
  */
 
 import { useEffect, useState } from "react";
-import { Layers, AlertCircle, Sparkles, Pin, Globe2, Check, Network } from "lucide-react";
+import { Layers, AlertCircle, Sparkles, Pin, Globe2, Check, Network, Crosshair, X } from "lucide-react";
 import {
   DropdownMenu,
   DropdownMenuCheckboxItem,
@@ -135,6 +135,20 @@ export interface ChatEnvPickerProps {
    * surface REST scope.
    */
   readonly onRestExcludedChange?: (next: string[]) => void;
+  /**
+   * #3067 — the conversation's REST-only focus (`install_id`, or null = not
+   * focused). When set, the chip reads "<name> only", SQL is suspended for the
+   * turn, and the exclude toggles are inert (focus overrides them). Defaults to
+   * null for callers that don't surface REST-only focus.
+   */
+  readonly restFocusDatasourceId?: string | null;
+  /**
+   * #3067 — called when the user focuses a datasource (`install_id`) or clears
+   * focus (`null`). Like {@link onRestExcludedChange}, the parent forwards it
+   * verbatim — `null` is meaningful (it clears focus on the row). Optional for
+   * callers that don't surface REST-only focus.
+   */
+  readonly onRestFocusChange?: (next: string | null) => void;
   /**
    * Called when the user picks a new group / member / mode triple from
    * the dropdown. The parent decides whether this is a per-turn
@@ -269,6 +283,8 @@ export interface ResolveEnvSelectionInput {
     readonly routingMode: ConversationRoutingMode | null;
     /** #3066 — current REST exclude-set, so a pref-only exclude change still restores. */
     readonly restExcludedDatasourceIds: ReadonlyArray<string>;
+    /** #3067 — current REST-only focus, so a pref-only focus change still restores. */
+    readonly restFocusDatasourceId: string | null;
   };
   /** How {@link current} was set. */
   readonly provenance: EnvSelectionProvenance;
@@ -297,6 +313,8 @@ export type EnvSelectionDecision =
       readonly routingMode: ConversationRoutingMode | null;
       /** #3066 — the sticky preference's exclude-set to seed onto this fresh chat. */
       readonly restExcludedDatasourceIds: string[];
+      /** #3067 — the sticky preference's REST-only focus to seed onto this fresh chat. */
+      readonly restFocusDatasourceId: string | null;
     }
   | {
       readonly kind: "seed";
@@ -304,6 +322,8 @@ export type EnvSelectionDecision =
       readonly connectionId: string;
       /** #3066 — a default seed excludes nothing (every in-scope datasource queryable). */
       readonly restExcludedDatasourceIds: string[];
+      /** #3067 — a default seed is not focused (SQL active). */
+      readonly restFocusDatasourceId: string | null;
     };
 
 /**
@@ -367,7 +387,12 @@ export function resolveEnvSelection(
       sameExcludeSet(
         current.restExcludedDatasourceIds ?? [],
         preference.restExcludedDatasourceIds ?? [],
-      )
+      ) &&
+      // #3067 — focus is part of the selection too, so a focus-only difference
+      // (e.g. the default seed landed on the preferred member but with no focus)
+      // must still restore.
+      (current.restFocusDatasourceId ?? null) ===
+        (preference.restFocusDatasourceId ?? null)
     ) {
       return { kind: "noop" };
     }
@@ -377,6 +402,7 @@ export function resolveEnvSelection(
       connectionId: prefMember.connectionId,
       routingMode: preference.routingMode,
       restExcludedDatasourceIds: [...(preference.restExcludedDatasourceIds ?? [])],
+      restFocusDatasourceId: preference.restFocusDatasourceId ?? null,
     };
   }
 
@@ -389,12 +415,13 @@ export function resolveEnvSelection(
   const seed = pickDefaultEnvSeed(groups, current.connectionId);
   if (!seed) return { kind: "noop" };
   // A default seed carries no exclusions — every in-scope REST datasource stays
-  // queryable until the user opts one out.
+  // queryable until the user opts one out — and is not focused (SQL active).
   return {
     kind: "seed",
     groupId: seed.groupId,
     connectionId: seed.connectionId,
     restExcludedDatasourceIds: [],
+    restFocusDatasourceId: null,
   };
 }
 
@@ -411,6 +438,8 @@ export interface ConversationScopeSource {
   readonly routingMode?: ConversationRoutingMode | null;
   /** #3066 — the row's REST exclude-set (excluded `install_id`s). Absent ⇒ none. */
   readonly restExcludedDatasourceIds?: ReadonlyArray<string> | null;
+  /** #3067 — the row's REST-only focus (`install_id`, or null = not focused). */
+  readonly restFocusDatasourceId?: string | null;
 }
 
 /** The picker selection restored from a conversation row. */
@@ -424,6 +453,12 @@ export interface RestoredConversationScope {
    * faithfully on a `restore`; an absent / null column coalesces to `[]`.
    */
   readonly restExcludedDatasourceIds: string[];
+  /**
+   * #3067 — the conversation's REST-only focus (`install_id`, or null). Carried
+   * faithfully on a `restore`, the same way as the exclude-set; null = not
+   * focused (SQL active).
+   */
+  readonly restFocusDatasourceId: string | null;
 }
 
 /**
@@ -475,6 +510,10 @@ export function resolveConversationScope(
   const restExcludedDatasourceIds = source.restExcludedDatasourceIds
     ? [...source.restExcludedDatasourceIds]
     : [];
+  // #3067 — the row's REST-only focus, restored alongside the SQL scope (null =
+  // not focused). Carried on every `restore` decision below, independent of the
+  // SQL group/member validation.
+  const restFocusDatasourceId = source.restFocusDatasourceId ?? null;
 
   // A row that persisted no scope at all is never authoritative — defer to the
   // seed/restore effect (decided before the load gate so it holds either way).
@@ -484,7 +523,7 @@ export function resolveConversationScope(
   // row optimistically. Losing the restore here would be a worse, more common
   // regression than the rare archived-env + cold-start intersection.
   if (groups.length === 0) {
-    return { kind: "restore", groupId, connectionId, routingMode, restExcludedDatasourceIds };
+    return { kind: "restore", groupId, connectionId, routingMode, restExcludedDatasourceIds, restFocusDatasourceId };
   }
 
   // Groups loaded — validate the row against the visible environments.
@@ -499,13 +538,13 @@ export function resolveConversationScope(
     // preserving the still-valid group rather than discarding it.
     const member = group.members.find((m) => m.connectionId === connectionId);
     if (member) {
-      return { kind: "restore", groupId: group.id, connectionId: member.connectionId, routingMode, restExcludedDatasourceIds };
+      return { kind: "restore", groupId: group.id, connectionId: member.connectionId, routingMode, restExcludedDatasourceIds, restFocusDatasourceId };
     }
     const repaired =
       group.members.find((m) => m.connectionId === group.primaryConnectionId) ??
       group.members[0];
     if (!repaired) return { kind: "seed" }; // group exists but has no live members
-    return { kind: "restore", groupId: group.id, connectionId: repaired.connectionId, routingMode, restExcludedDatasourceIds };
+    return { kind: "restore", groupId: group.id, connectionId: repaired.connectionId, routingMode, restExcludedDatasourceIds, restFocusDatasourceId };
   }
 
   // Legacy group-less row (connectionGroupId null, connectionId set, e.g. a
@@ -519,7 +558,7 @@ export function resolveConversationScope(
     g.members.some((m) => m.connectionId === connectionId),
   );
   if (!owningGroup) return { kind: "seed" };
-  return { kind: "restore", groupId: owningGroup.id, connectionId, routingMode, restExcludedDatasourceIds };
+  return { kind: "restore", groupId: owningGroup.id, connectionId, routingMode, restExcludedDatasourceIds, restFocusDatasourceId };
 }
 
 /**
@@ -545,6 +584,8 @@ export function ChatEnvPicker({
   restDatasources = [],
   restExcludedDatasourceIds = [],
   onRestExcludedChange,
+  restFocusDatasourceId = null,
+  onRestFocusChange,
   onSelect,
 }: ChatEnvPickerProps): React.ReactElement | null {
   // Empty list + a reason ⇒ render a diagnostic chip instead of
@@ -631,6 +672,20 @@ export function ChatEnvPicker({
     chipLabel = `${chipLabel} · ${restInScopeCount}/${reachableRest.length} REST`;
   }
 
+  // #3067 — REST-only focus overrides the chip entirely. SQL routing is
+  // suspended for a focused conversation, so the mode/env summary above is
+  // irrelevant: the chip reads "<name> only" for the datasource the agent
+  // targets. Falls back to "REST only" if the focused id isn't in the list
+  // (e.g. a datasource scoped to another env, still focusable via the resolver).
+  const focusedDatasource = restFocusDatasourceId
+    ? restDatasources.find((d) => d.id === restFocusDatasourceId)
+    : undefined;
+  const isFocused = restFocusDatasourceId !== null;
+  if (isFocused) {
+    chipLabel = `${focusedDatasource?.displayName ?? "REST"} only`;
+    ChipIcon = Crosshair;
+  }
+
   // When every group has at most one member (the 0062 backfill shape,
   // or a defensive-empty group), the dropdown has no actual
   // multi-member choice to offer. Surface a hint so admins discover
@@ -672,7 +727,12 @@ export function ChatEnvPicker({
           className="h-8 gap-1.5 rounded-full border border-zinc-200 px-2.5 text-xs font-medium text-zinc-700 hover:bg-zinc-50 dark:border-zinc-800 dark:text-zinc-300 dark:hover:bg-zinc-900"
           data-testid="chat-env-picker-trigger"
           data-mode={mode}
-          aria-label={`Cross-environment routing: ${chipLabel}. Change.`}
+          data-focused={isFocused}
+          aria-label={
+            isFocused
+              ? `Conversation scope: focused on ${chipLabel} — SQL suspended. Change.`
+              : `Cross-environment routing: ${chipLabel}. Change.`
+          }
         >
           <ChipIcon className="size-3.5 text-zinc-500" aria-hidden />
           <span data-testid="chat-env-picker-label">{chipLabel}</span>
@@ -789,6 +849,9 @@ export function ChatEnvPicker({
           activeGroupId={activeGroup?.id ?? null}
           excludedIds={restExcludedDatasourceIds}
           onRestExcludedChange={onRestExcludedChange}
+          focusedId={restFocusDatasourceId}
+          focusedDatasource={focusedDatasource}
+          onRestFocusChange={onRestFocusChange}
         />
       </DropdownMenuContent>
     </DropdownMenu>
@@ -811,13 +874,64 @@ function ChatEnvRestScopeSection({
   activeGroupId,
   excludedIds,
   onRestExcludedChange,
+  focusedId,
+  focusedDatasource,
+  onRestFocusChange,
 }: {
   restDatasources: ReadonlyArray<ChatRestDatasourceScope>;
   activeGroupId: string | null;
   excludedIds: ReadonlyArray<string>;
   onRestExcludedChange?: (next: string[]) => void;
+  /** #3067 — the focused datasource id, or null = not focused. */
+  focusedId: string | null;
+  /** #3067 — the focused datasource (for its display name), if it's in the list. */
+  focusedDatasource?: ChatRestDatasourceScope;
+  /** #3067 — focus a datasource (`install_id`) or clear focus (`null`). */
+  onRestFocusChange?: (next: string | null) => void;
 }): React.ReactElement | null {
   if (restDatasources.length === 0) return null;
+
+  // #3067 — focused state: SQL is suspended and the exclude-set is inert, so
+  // render the focus summary + a clear action INSTEAD of the exclude checkboxes
+  // (toggling exclusions while focused would be confusing — they don't apply).
+  if (focusedId !== null) {
+    return (
+      <>
+        <DropdownMenuSeparator />
+        <DropdownMenuLabel className="text-[10px] font-semibold uppercase tracking-wider text-zinc-500 dark:text-zinc-500">
+          REST-only focus
+        </DropdownMenuLabel>
+        <div
+          className="px-2 pb-1 pt-0.5 text-[11px] leading-snug text-zinc-500 dark:text-zinc-400"
+          data-testid="chat-env-picker-rest-focused"
+          data-focus-id={focusedId}
+        >
+          <span className="flex items-center gap-1.5">
+            <Crosshair className="size-3 shrink-0 text-primary" aria-hidden />
+            <span className="truncate">
+              Focused on{" "}
+              <span className="font-medium text-zinc-700 dark:text-zinc-200">
+                {focusedDatasource?.displayName ?? focusedId}
+              </span>
+            </span>
+          </span>
+          <span className="mt-0.5 block text-zinc-400 dark:text-zinc-500">
+            SQL is suspended — the agent answers from this datasource only.
+          </span>
+        </div>
+        {onRestFocusChange && (
+          <DropdownMenuItem
+            onSelect={() => onRestFocusChange(null)}
+            className="flex items-center gap-2 text-xs"
+            data-testid="chat-env-picker-rest-focus-clear"
+          >
+            <X className="size-3.5 text-zinc-500" aria-hidden />
+            <span>Clear focus — re-enable SQL</span>
+          </DropdownMenuItem>
+        )}
+      </>
+    );
+  }
 
   const workspaceGlobal = restDatasources.filter((d) => d.groupId === null);
   const inActiveGroup = restDatasources.filter(
@@ -826,6 +940,10 @@ function ChatEnvRestScopeSection({
   const otherScoped = restDatasources.filter(
     (d) => d.groupId !== null && d.groupId !== activeGroupId,
   );
+  // #3067 — the datasources reachable in the active env are the ones a user can
+  // focus (workspace-global + scoped to the active group), mirroring the exclude
+  // checkboxes. A datasource scoped to another env stays informational.
+  const focusable = [...workspaceGlobal, ...inActiveGroup];
 
   const excludedSet = new Set(excludedIds);
   // Compute the next exclude-set when one datasource is (un)checked. `checked`
@@ -897,6 +1015,30 @@ function ChatEnvRestScopeSection({
             <Network className="size-3" aria-hidden />
             {otherScoped.length} scoped to other environments — not reachable here
           </span>
+        </div>
+      )}
+
+      {/* #3067 — REST-only focus selector. Picking one targets it exclusively
+          and suspends SQL for the conversation. Only when a focus handler is
+          wired and there's a reachable datasource to focus. */}
+      {onRestFocusChange && focusable.length > 0 && (
+        <div data-testid="chat-env-picker-rest-focus-options">
+          <DropdownMenuSeparator />
+          <DropdownMenuLabel className="px-2 pb-0.5 pt-1 text-[10px] font-normal text-zinc-400 dark:text-zinc-500">
+            Focus one datasource — suspends SQL
+          </DropdownMenuLabel>
+          {focusable.map((d) => (
+            <DropdownMenuItem
+              key={d.id}
+              // Keep the menu open so the user can read the chip update.
+              onSelect={() => onRestFocusChange(d.id)}
+              className="flex items-center gap-1.5 text-xs"
+              data-testid={`chat-env-picker-rest-focus-${d.id}`}
+            >
+              <Crosshair className="size-3 shrink-0 text-zinc-400" aria-hidden />
+              <span className="truncate">{d.displayName} only</span>
+            </DropdownMenuItem>
+          ))}
         </div>
       )}
     </>

--- a/packages/web/src/ui/hooks/use-atlas-transport.ts
+++ b/packages/web/src/ui/hooks/use-atlas-transport.ts
@@ -48,6 +48,8 @@ export interface UseAtlasTransportOptions {
    * a re-include would silently keep a stale exclusion — the #3073 bug class.
    */
   getRestExcludedDatasourceIds?: () => readonly string[];
+  /** #3067 — REST-only focus (`install_id`, or null = not focused). */
+  getRestFocusDatasourceId?: () => string | null;
 }
 
 export interface UseAtlasTransportReturn {
@@ -98,6 +100,8 @@ export function useAtlasTransport(
   // rebuilding `useChat`'s transport.
   const getRestExcludedDatasourceIdsRef = useRef(opts.getRestExcludedDatasourceIds);
   getRestExcludedDatasourceIdsRef.current = opts.getRestExcludedDatasourceIds;
+  const getRestFocusDatasourceIdRef = useRef(opts.getRestFocusDatasourceId);
+  getRestFocusDatasourceIdRef.current = opts.getRestFocusDatasourceId;
 
   // --- Auth state (seed from module cache to avoid flash on client-side nav) ---
   const [authMode, setAuthModeState] = useState<AuthMode | null>(_cachedAuthMode);
@@ -285,6 +289,14 @@ export function useAtlasTransport(
         const restExcluded = getRestExcludedDatasourceIdsRef.current?.();
         if (restExcluded !== undefined) {
           body.restExcludedDatasourceIds = [...restExcluded];
+        }
+        // #3067 — REST-only focus. ALWAYS sent when the getter is present (even
+        // `null`), so a clear actually nulls the row instead of inheriting the
+        // stale focus (the #3073 transport-omits-null bug class). Absent getter
+        // → field omitted (the server falls back to the row's value).
+        const restFocus = getRestFocusDatasourceIdRef.current?.();
+        if (restFocus !== undefined) {
+          body.restFocusDatasourceId = restFocus;
         }
         return body;
       },


### PR DESCRIPTION
## What

S2b of the **v0.0.4 — Conversation Scope** milestone ([#3067](https://github.com/AtlasDevHQ/atlas/issues/3067)). A conversation can now **focus** a single REST datasource so the agent targets it exclusively and **`executeSQL` is suspended** — the "ask Stripe only" case. Focus is per-conversation, persisted, seeds new chats via the sticky preference, and clears back to the prior default scope (SQL routing + exclude-set are retained-but-inert while focused). Per [ADR-0011](https://github.com/AtlasDevHQ/atlas/blob/main/docs/adr/0011-unified-conversation-scope.md); mirrors the S2a exclude-set PR (#3077).

## How (by layer)

1. **Migration + schema** — `0113_conversation_rest_focus_datasource.sql` adds `conversations.rest_focus_datasource_id text` (nullable) + Drizzle `schema.ts` mirror (schema-drift gate) + real-Postgres `migrate-pg` smoke (migrate count 113 → 114). NULL = not focused.
2. **Resolver** — `ResolveWorkspaceDeps.focus` **short-circuits** both the group-scope filter and the exclude-set (inert while focused) and resolves **only** the focus target. A focus id that matches no install in the workspace's tenant-scoped rows yields `[]` — the agent's fall-back-to-default signal.
3. **Agent loop** — focused → resolve only the focus target, **strip `executeSQL` from the registry** (REST-only turn), and prepend a focus banner so the model answers from the API only. Focus gone (uninstalled / unresolvable) → **fall back safely to default scope** (SQL active + exclude-set). Confirm-replay (`resolveFromContext`) stays deps-free, so a staged write replays regardless of focus.
4. **Python egress** — focus resolves only the focus target, keeping the sandbox egress allowlist in lockstep; falls through to default scope if the focus is gone (mirrors agent.ts).
5. **Chat + conversations routes** — body field (`null` = clear, absent = inherit) + read-back from the row + persist (`updateConversationRestFocus`) + ALS stamp (only when truthy). `GET /conversations/:id` carries the field.
6. **`@useatlas/types`** — `Conversation.restFocusDatasourceId` (type-only; patch-bumped to `0.1.11`, `bun.lock` synced).
7. **Web** — `ChatScopePicker` gains a "Focus … only" item per reachable datasource; when focused the chip reads `<name> only` (Crosshair), the exclude checkboxes are hidden (inert), and a "Clear focus" action re-enables SQL. Threaded through `resolveEnvSelection` / `resolveConversationScope` provenance + the sticky-preference store.

### ⚠️ The #3073 bug class (transport-omits-null)
`useAtlasTransport` **always** sends `restFocusDatasourceId` (even `null`), and the route distinguishes *field present as `null`* (clear → null the row) from *field absent* (inherit the row). Omitting the null on a clear would silently keep a stale focus.

## Scope boundary (#3078)
Focus threads through the **same restore/seed provenance** as the exclude-set, so it works correctly for any workspace with **≥1 SQL group** (the common 1-Postgres + 1-REST case). The **zero-group REST-only render path** + the **all-null-SQL provenance decoupling** remain [#3078](https://github.com/AtlasDevHQ/atlas/issues/3078) (only API-reachable until then, exactly as S2a drew the line).

## Acceptance criteria
- [x] Focusing a REST datasource suspends `executeSQL`; only that datasource is reachable for the turn (resolver + registry-strip).
- [x] Chip shows the focused state (`<name> only`); focus can be cleared back to default scope.
- [x] Focus persists across reload (row) and seeds new chats (sticky preference).
- [x] Clearing focus restores the previously-selected SQL routing + exclude-set (retained-but-inert).
- [x] A focused conversation whose datasource was uninstalled falls back safely to default scope (SQL active).

## Tests
- Resolver: focus short-circuits group + exclude, gone → `[]`, empty-string ignored, primary-resolver focus.
- Chat route: ALS stamp, clear-via-`null` persists, omit-inherits-no-update.
- Python egress: focus-only (no fall-through) + fallback-when-gone.
- Data layer: `updateConversationRestFocus` (write / clear / not_found / no_db), `createConversation` focus param, SELECT column.
- Web: env-picker focus chip / select / clear / hidden-exclude-while-focused (8) + resolver restore; sticky-store persist.

OpenAPI spec regenerated for `ConversationSchema.restFocusDatasourceId`.

Closes #3067.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3079"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782929643&installation_id=135337507&pr_number=3079&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3079&signature=1bdabe32ae011cb82b54c8cec165a5061a1eed44df3c747b9b69d08e089c7291"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * REST-only focus: focus a conversation on a single REST datasource — SQL is suspended and the agent targets only that datasource.
  * Env picker UI: per-datasource “Focus … only” option, focused label, and “Clear focus” action.
  * Persistence: focus saved with conversation/preferences and restored on reopen.

* **Behavior**
  * Three-state semantics: omitted = inherit, null = clear, non-empty = set.
  * Guidance/warnings shown when a focused datasource is unavailable; missing focus falls back to default behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->