### PR TITLE
chore(models): bump pinned Opus default 4.7 → 4.8 (#3076)

### DIFF
--- a/apps/docs/content/docs/integrations/llm-providers/bedrock.mdx
+++ b/apps/docs/content/docs/integrations/llm-providers/bedrock.mdx
@@ -39,7 +39,7 @@ Bedrock does not need any other permissions (no S3, no logs, no Bedrock agents).
       "Effect": "Allow",
       "Action": "bedrock:InvokeModel",
       "Resource": [
-        "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-opus-4-7",
+        "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-opus-4-8",
         "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-sonnet-4-6",
         "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-haiku-4-5"
       ]

--- a/apps/docs/content/docs/reference/environment-variables.mdx
+++ b/apps/docs/content/docs/reference/environment-variables.mdx
@@ -66,12 +66,12 @@ Each provider requires its own API key:
 
 | Provider | Default Model |
 |----------|--------------|
-| `anthropic` | `claude-opus-4-7` |
+| `anthropic` | `claude-opus-4-8` |
 | `openai` | `gpt-4o` |
 | `bedrock` | `anthropic.claude-opus-4-7` |
 | `ollama` | `llama3.1` |
 | `openai-compatible` | None — `ATLAS_MODEL` required |
-| `gateway` | `anthropic/claude-opus-4.7` |
+| `gateway` | `anthropic/claude-opus-4.8` |
 
 <Tabs items={["Anthropic", "OpenAI", "AWS Bedrock", "Ollama (local)", "OpenAI-compatible (vLLM, TGI)"]}>
 <Tab value="Anthropic">

--- a/apps/docs/content/docs/reference/environment-variables.mdx
+++ b/apps/docs/content/docs/reference/environment-variables.mdx
@@ -68,7 +68,7 @@ Each provider requires its own API key:
 |----------|--------------|
 | `anthropic` | `claude-opus-4-8` |
 | `openai` | `gpt-4o` |
-| `bedrock` | `anthropic.claude-opus-4-7` |
+| `bedrock` | `anthropic.claude-opus-4-8` |
 | `ollama` | `llama3.1` |
 | `openai-compatible` | None — `ATLAS_MODEL` required |
 | `gateway` | `anthropic/claude-opus-4.8` |

--- a/ee/src/platform/model-routing.test.ts
+++ b/ee/src/platform/model-routing.test.ts
@@ -299,7 +299,7 @@ describe("setWorkspaceModelConfig", () => {
     ee.queueMockRows([makeRow()], [makeRow()]);
     await run(setWorkspaceModelConfig("org-1", {
       provider: "anthropic",
-      model: "claude-opus-4-7",
+      model: "claude-opus-4-8",
       // apiKey intentionally omitted
     }));
     // capturedQueries[0] = transition-guard SELECT; [1] = the UPSERT.

--- a/packages/api/src/api/__tests__/admin-model-config.test.ts
+++ b/packages/api/src/api/__tests__/admin-model-config.test.ts
@@ -636,7 +636,7 @@ describe("audit emission — PUT /api/v1/admin/model-config", () => {
     const res = await app.fetch(
       adminRequest("PUT", "/api/v1/admin/model-config", {
         provider: "anthropic",
-        model: "claude-opus-4-7",
+        model: "claude-opus-4-8",
       }),
     );
     expect(res.status).toBe(200);
@@ -644,7 +644,7 @@ describe("audit emission — PUT /api/v1/admin/model-config", () => {
     const entry = lastAuditCall();
     expect(entry.metadata).toMatchObject({
       provider: "anthropic",
-      model: "claude-opus-4-7",
+      model: "claude-opus-4-8",
       hasSecret: false,
     });
   });

--- a/packages/api/src/api/__tests__/billing.test.ts
+++ b/packages/api/src/api/__tests__/billing.test.ts
@@ -268,7 +268,7 @@ describe("billing routes", () => {
     });
 
     it("uses setting override for currentModel when available", async () => {
-      mockSettingLiveValue = "anthropic/claude-opus-4.7";
+      mockSettingLiveValue = "anthropic/claude-opus-4.8";
       mockInternalQuery.mockImplementation((...args: unknown[]) => {
         const sql = args[0];
         if (typeof sql === "string" && sql.includes("member")) {
@@ -281,7 +281,7 @@ describe("billing routes", () => {
       expect(res.status).toBe(200);
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test assertions on response shape
       const body = await res.json() as any;
-      expect(body.currentModel).toBe("anthropic/claude-opus-4.7");
+      expect(body.currentModel).toBe("anthropic/claude-opus-4.8");
     });
 
     it("returns 401 when unauthenticated", async () => {

--- a/packages/api/src/lib/__tests__/anthropic-catalog.test.ts
+++ b/packages/api/src/lib/__tests__/anthropic-catalog.test.ts
@@ -44,7 +44,7 @@ describe("anthropic-catalog", () => {
   test("normalizes a live /v1/models payload", async () => {
     globalThis.fetch = mockFetchOk({
       data: [
-        { type: "model", id: "claude-opus-4-7", display_name: "Claude Opus 4.7" },
+        { type: "model", id: "claude-opus-4-8", display_name: "Claude Opus 4.8" },
         { type: "model", id: "claude-sonnet-4-6", display_name: "Claude Sonnet 4.6" },
         // Entry without id is dropped.
         { type: "model", display_name: "Phantom" },
@@ -54,8 +54,8 @@ describe("anthropic-catalog", () => {
     const res = await getAnthropicCatalog(ORG_A, KEY);
     expect(res.source).toBe("fresh");
     expect(res.models).toHaveLength(2);
-    const opus = res.models.find((m) => m.id === "claude-opus-4-7");
-    expect(opus?.name).toBe("Claude Opus 4.7");
+    const opus = res.models.find((m) => m.id === "claude-opus-4-8");
+    expect(opus?.name).toBe("Claude Opus 4.8");
     expect(opus?.provider).toBe("anthropic");
     expect(opus?.type).toBe("language");
     expect(opus?.recommended).toBe(true);
@@ -136,7 +136,7 @@ describe("anthropic-catalog", () => {
   test("caches a successful fetch per orgId", async () => {
     const fetchMock = mock(
       async () =>
-        new Response(JSON.stringify({ data: [{ id: "claude-opus-4-7" }] }), {
+        new Response(JSON.stringify({ data: [{ id: "claude-opus-4-8" }] }), {
           status: 200,
           headers: { "content-type": "application/json" },
         }),
@@ -153,7 +153,7 @@ describe("anthropic-catalog", () => {
   test("cache is scoped per orgId", async () => {
     const fetchMock = mock(
       async () =>
-        new Response(JSON.stringify({ data: [{ id: "claude-opus-4-7" }] }), {
+        new Response(JSON.stringify({ data: [{ id: "claude-opus-4-8" }] }), {
           status: 200,
           headers: { "content-type": "application/json" },
         }),
@@ -168,7 +168,7 @@ describe("anthropic-catalog", () => {
   test("opts.refresh bypasses the cache", async () => {
     const fetchMock = mock(
       async () =>
-        new Response(JSON.stringify({ data: [{ id: "claude-opus-4-7" }] }), {
+        new Response(JSON.stringify({ data: [{ id: "claude-opus-4-8" }] }), {
           status: 200,
           headers: { "content-type": "application/json" },
         }),
@@ -184,7 +184,7 @@ describe("anthropic-catalog", () => {
   test("invalidateAnthropicCatalog forces a re-fetch on next call", async () => {
     const fetchMock = mock(
       async () =>
-        new Response(JSON.stringify({ data: [{ id: "claude-opus-4-7" }] }), {
+        new Response(JSON.stringify({ data: [{ id: "claude-opus-4-8" }] }), {
           status: 200,
           headers: { "content-type": "application/json" },
         }),
@@ -209,7 +209,7 @@ describe("anthropic-catalog", () => {
 
     // Resolve the in-flight fetch once; both callers must share the result.
     (pending.resolve as ResolveBody)(
-      new Response(JSON.stringify({ data: [{ id: "claude-opus-4-7" }] }), {
+      new Response(JSON.stringify({ data: [{ id: "claude-opus-4-8" }] }), {
         status: 200,
         headers: { "content-type": "application/json" },
       }),
@@ -217,13 +217,13 @@ describe("anthropic-catalog", () => {
 
     const [r1, r2] = await Promise.all([p1, p2]);
     expect(slowFetch).toHaveBeenCalledTimes(1);
-    expect(r1.models[0].id).toBe("claude-opus-4-7");
-    expect(r2.models[0].id).toBe("claude-opus-4-7");
+    expect(r1.models[0].id).toBe("claude-opus-4-8");
+    expect(r2.models[0].id).toBe("claude-opus-4-8");
   });
 
   test("recommended set is non-empty and stable", () => {
     const ids = __getRecommendedAnthropicIdsForTests();
     expect(ids.size).toBeGreaterThan(0);
-    expect(ids.has("claude-opus-4-7")).toBe(true);
+    expect(ids.has("claude-opus-4-8")).toBe(true);
   });
 });

--- a/packages/api/src/lib/__tests__/bedrock-catalog.test.ts
+++ b/packages/api/src/lib/__tests__/bedrock-catalog.test.ts
@@ -87,8 +87,8 @@ describe("bedrock-catalog", () => {
         modelSummaries: [
           // Kept.
           {
-            modelId: "anthropic.claude-opus-4-7",
-            modelName: "Claude Opus 4.7",
+            modelId: "anthropic.claude-opus-4-8",
+            modelName: "Claude Opus 4.8",
             providerName: "Anthropic",
             outputModalities: ["TEXT"],
           },
@@ -122,8 +122,8 @@ describe("bedrock-catalog", () => {
     expect(res.source).toBe("fresh");
     expect(res.region).toBe("us-east-1");
     const ids = res.models.map((m) => m.id).sort();
-    expect(ids).toEqual(["amazon.titan-text-v1", "anthropic.claude-opus-4-7"]);
-    const opus = res.models.find((m) => m.id === "anthropic.claude-opus-4-7");
+    expect(ids).toEqual(["amazon.titan-text-v1", "anthropic.claude-opus-4-8"]);
+    const opus = res.models.find((m) => m.id === "anthropic.claude-opus-4-8");
     expect(opus?.provider).toBe("anthropic");
     expect(opus?.recommended).toBe(true);
     expect(destroyCalls).toBe(1);
@@ -180,7 +180,7 @@ describe("bedrock-catalog", () => {
       payload: {
         modelSummaries: [
           {
-            modelId: "anthropic.claude-opus-4-7",
+            modelId: "anthropic.claude-opus-4-8",
             modelName: "Opus",
             providerName: "Anthropic",
             outputModalities: ["TEXT"],
@@ -199,7 +199,7 @@ describe("bedrock-catalog", () => {
   test("opts.refresh bypasses the cache", async () => {
     setOutcome({
       kind: "ok",
-      payload: { modelSummaries: [{ modelId: "anthropic.claude-opus-4-7", outputModalities: ["TEXT"] }] },
+      payload: { modelSummaries: [{ modelId: "anthropic.claude-opus-4-8", outputModalities: ["TEXT"] }] },
     });
     await getBedrockCatalog(ORG_A, "us-east-1", CREDS);
     const refreshed = await getBedrockCatalog(ORG_A, "us-east-1", CREDS, { refresh: true });
@@ -210,7 +210,7 @@ describe("bedrock-catalog", () => {
   test("invalidate clears every region for an org", async () => {
     setOutcome({
       kind: "ok",
-      payload: { modelSummaries: [{ modelId: "anthropic.claude-opus-4-7", outputModalities: ["TEXT"] }] },
+      payload: { modelSummaries: [{ modelId: "anthropic.claude-opus-4-8", outputModalities: ["TEXT"] }] },
     });
     await getBedrockCatalog(ORG_A, "us-east-1", CREDS);
     await getBedrockCatalog(ORG_A, "us-west-2", CREDS);
@@ -224,7 +224,7 @@ describe("bedrock-catalog", () => {
   test("recommended set includes a flagship", () => {
     const ids = __getRecommendedBedrockIdsForTests();
     expect(ids.size).toBeGreaterThan(0);
-    expect(ids.has("anthropic.claude-opus-4-7")).toBe(true);
+    expect(ids.has("anthropic.claude-opus-4-8")).toBe(true);
   });
 
   test("concurrent fetches for the same (orgId, region) dedupe to one AWS call", async () => {
@@ -246,12 +246,12 @@ describe("bedrock-catalog", () => {
       const p1 = getBedrockCatalog(ORG_A, "us-east-1", CREDS);
       const p2 = getBedrockCatalog(ORG_A, "us-east-1", CREDS);
       pending.resolve({
-        modelSummaries: [{ modelId: "anthropic.claude-opus-4-7", outputModalities: ["TEXT"] }],
+        modelSummaries: [{ modelId: "anthropic.claude-opus-4-8", outputModalities: ["TEXT"] }],
       });
       const [r1, r2] = await Promise.all([p1, p2]);
       expect(sendCalls).toHaveLength(1);
-      expect(r1.models[0].id).toBe("anthropic.claude-opus-4-7");
-      expect(r2.models[0].id).toBe("anthropic.claude-opus-4-7");
+      expect(r1.models[0].id).toBe("anthropic.claude-opus-4-8");
+      expect(r2.models[0].id).toBe("anthropic.claude-opus-4-8");
     } finally {
       MockBedrockClient.prototype.send = _origSend;
       nextOutcome = originalOutcome;

--- a/packages/api/src/lib/__tests__/byot-catalog-l2-wiring.test.ts
+++ b/packages/api/src/lib/__tests__/byot-catalog-l2-wiring.test.ts
@@ -133,7 +133,7 @@ const OPENAI_PERSISTED: GatewayCatalogModel = {
 
 const BEDROCK_PERSISTED: GatewayCatalogModel = {
   ...ANTHROPIC_PERSISTED,
-  id: "anthropic.claude-opus-4-7",
+  id: "anthropic.claude-opus-4-8",
   provider: "bedrock",
 };
 
@@ -374,8 +374,8 @@ describe("byot-catalog L1↔L2 wiring — bedrock parallel smoke", () => {
     bedrockSendPayload = {
       modelSummaries: [
         {
-          modelId: "anthropic.claude-opus-4-7",
-          modelName: "Claude Opus 4.7",
+          modelId: "anthropic.claude-opus-4-8",
+          modelName: "Claude Opus 4.8",
           providerName: "Anthropic",
           outputModalities: ["TEXT"],
         },

--- a/packages/api/src/lib/__tests__/byot-catalog-l2-wiring.test.ts
+++ b/packages/api/src/lib/__tests__/byot-catalog-l2-wiring.test.ts
@@ -113,8 +113,8 @@ const BEDROCK_REGION: BedrockRegion = "us-east-1";
 const PERSISTED_FETCHED_AT = new Date(Date.now() - 60 * 60 * 1000).toISOString();
 
 const ANTHROPIC_PERSISTED: GatewayCatalogModel = {
-  id: "claude-opus-4-7",
-  name: "Claude Opus 4.7",
+  id: "claude-opus-4-8",
+  name: "Claude Opus 4.8",
   provider: "anthropic",
   type: "language",
   contextWindow: null,
@@ -189,7 +189,7 @@ describe("byot-catalog L1↔L2 wiring (anthropic representative)", () => {
     expect(res.source).toBe("cache");
     expect(res.fetchedAt).toBe(PERSISTED_FETCHED_AT);
     expect(res.models).toHaveLength(1);
-    expect(res.models[0].id).toBe("claude-opus-4-7");
+    expect(res.models[0].id).toBe("claude-opus-4-8");
     expect(loadFromDBSpy).toHaveBeenCalledTimes(1);
     expect(loadFromDBSpy.mock.calls[0][0]).toBe(ORG);
     expect(loadFromDBSpy.mock.calls[0][1]).toBe("anthropic");

--- a/packages/api/src/lib/__tests__/gateway-catalog.test.ts
+++ b/packages/api/src/lib/__tests__/gateway-catalog.test.ts
@@ -37,8 +37,8 @@ describe("gateway-catalog", () => {
     globalThis.fetch = mockFetchOk({
       data: [
         {
-          id: "anthropic/claude-opus-4.7",
-          name: "Claude Opus 4.7",
+          id: "anthropic/claude-opus-4.8",
+          name: "Claude Opus 4.8",
           type: "language",
           context_window: 200_000,
           max_tokens: 32_000,
@@ -60,7 +60,7 @@ describe("gateway-catalog", () => {
     const res = await getGatewayCatalog();
     expect(res.fallback).toBe(false);
     expect(res.models).toHaveLength(2);
-    const claude = res.models.find((m) => m.id === "anthropic/claude-opus-4.7");
+    const claude = res.models.find((m) => m.id === "anthropic/claude-opus-4.8");
     expect(claude?.provider).toBe("anthropic");
     expect(claude?.contextWindow).toBe(200_000);
     expect(claude?.maxOutputTokens).toBe(32_000);

--- a/packages/api/src/lib/anthropic-catalog.ts
+++ b/packages/api/src/lib/anthropic-catalog.ts
@@ -40,7 +40,7 @@ const FETCH_TIMEOUT_MS = 10_000;
  * Anthropic /v1/models response. Anchor on flagship + cheap-fast pair.
  */
 const RECOMMENDED_MODEL_IDS: ReadonlySet<string> = new Set([
-  "claude-opus-4-7",
+  "claude-opus-4-8",
   "claude-sonnet-4-6",
   "claude-haiku-4-5",
 ]);

--- a/packages/api/src/lib/bedrock-catalog.ts
+++ b/packages/api/src/lib/bedrock-catalog.ts
@@ -52,7 +52,7 @@ const FETCH_TIMEOUT_MS = 15_000;
 // Claude families carried. Source: AWS Bedrock model cards index
 // (https://docs.aws.amazon.com/bedrock/latest/userguide/model-cards.md).
 const RECOMMENDED_MODEL_IDS: ReadonlySet<string> = new Set([
-  "anthropic.claude-opus-4-7",
+  "anthropic.claude-opus-4-8",
   "anthropic.claude-sonnet-4-6",
   "anthropic.claude-haiku-4-5",
 ]);

--- a/packages/api/src/lib/gateway-catalog.ts
+++ b/packages/api/src/lib/gateway-catalog.ts
@@ -41,7 +41,7 @@ const FETCH_TIMEOUT_MS = 10_000;
  * so the recommended group fits without scrolling.
  */
 const RECOMMENDED_MODEL_IDS: ReadonlySet<string> = new Set([
-  "anthropic/claude-opus-4.7",
+  "anthropic/claude-opus-4.8",
   "anthropic/claude-sonnet-4.6",
   "openai/gpt-4o",
   "openai/gpt-4o-mini",
@@ -55,8 +55,8 @@ const RECOMMENDED_MODEL_IDS: ReadonlySet<string> = new Set([
  */
 const FALLBACK_MODELS: GatewayCatalogModel[] = [
   {
-    id: "anthropic/claude-opus-4.7",
-    name: "Claude Opus 4.7",
+    id: "anthropic/claude-opus-4.8",
+    name: "Claude Opus 4.8",
     provider: "anthropic",
     type: "language",
     contextWindow: 200_000,

--- a/packages/api/src/lib/providers.ts
+++ b/packages/api/src/lib/providers.ts
@@ -41,8 +41,7 @@ const VALID_PROVIDERS: ReadonlySet<ConfigProvider> = new Set([
 const PROVIDER_DEFAULTS: Record<ConfigProvider, string | undefined> = {
   anthropic: "claude-opus-4-8",
   openai: "gpt-4o",
-  // Bedrock stays on 4-7 until AWS GAs Opus 4.8 on Bedrock — see #3076.
-  bedrock: "anthropic.claude-opus-4-7",
+  bedrock: "anthropic.claude-opus-4-8",
   ollama: "llama3.1",
   "openai-compatible": undefined,
   gateway: "anthropic/claude-opus-4.8",

--- a/packages/api/src/lib/providers.ts
+++ b/packages/api/src/lib/providers.ts
@@ -39,12 +39,13 @@ const VALID_PROVIDERS: ReadonlySet<ConfigProvider> = new Set([
 ]);
 
 const PROVIDER_DEFAULTS: Record<ConfigProvider, string | undefined> = {
-  anthropic: "claude-opus-4-7",
+  anthropic: "claude-opus-4-8",
   openai: "gpt-4o",
+  // Bedrock stays on 4-7 until AWS GAs Opus 4.8 on Bedrock — see #3076.
   bedrock: "anthropic.claude-opus-4-7",
   ollama: "llama3.1",
   "openai-compatible": undefined,
-  gateway: "anthropic/claude-opus-4.7",
+  gateway: "anthropic/claude-opus-4.8",
 };
 
 /** Returns the default provider string based on runtime environment. */

--- a/packages/schemas/src/__tests__/admin-config.test.ts
+++ b/packages/schemas/src/__tests__/admin-config.test.ts
@@ -171,7 +171,7 @@ describe("WorkspaceModelConfigSchema", () => {
     const deprecated = {
       ...validModelConfig,
       modelStatus: "deprecated" as const,
-      modelSuggestedReplacement: "claude-opus-4-7",
+      modelSuggestedReplacement: "claude-opus-4-8",
     };
     expect(WorkspaceModelConfigSchema.parse(deprecated)).toEqual(deprecated);
   });
@@ -189,7 +189,7 @@ describe("WorkspaceModelConfigSchema", () => {
     const stray = {
       ...validModelConfig,
       modelStatus: "healthy" as const,
-      modelSuggestedReplacement: "claude-opus-4-7",
+      modelSuggestedReplacement: "claude-opus-4-8",
     };
     expect(() => WorkspaceModelConfigSchema.parse(stray)).toThrow();
   });

--- a/packages/web/src/app/admin/billing/page.tsx
+++ b/packages/web/src/app/admin/billing/page.tsx
@@ -84,7 +84,7 @@ function overageColor(status: string): string {
 const MODEL_OPTIONS = [
   { value: "anthropic/claude-haiku-4.5", label: "Haiku 4.5", hint: "fastest, lowest cost" },
   { value: "anthropic/claude-sonnet-4.6", label: "Sonnet 4.6", hint: "balanced" },
-  { value: "anthropic/claude-opus-4.7", label: "Opus 4.7", hint: "most capable" },
+  { value: "anthropic/claude-opus-4.8", label: "Opus 4.8", hint: "most capable" },
 ] as const;
 
 // Atlas previously stored model settings in the Anthropic-direct hyphen
@@ -95,7 +95,7 @@ const MODEL_OPTIONS = [
 const LEGACY_MODEL_ALIASES: Record<string, string> = {
   "claude-haiku-4-5": "anthropic/claude-haiku-4.5",
   "claude-sonnet-4-6": "anthropic/claude-sonnet-4.6",
-  "claude-opus-4-6": "anthropic/claude-opus-4.7",
+  "claude-opus-4-6": "anthropic/claude-opus-4.8",
 };
 
 function canonicalizeModel(value: string): string {

--- a/packages/web/src/app/admin/billing/page.tsx
+++ b/packages/web/src/app/admin/billing/page.tsx
@@ -92,10 +92,20 @@ const MODEL_OPTIONS = [
 // (`anthropic/claude-opus-4.6`). When we see a legacy hyphen value
 // stored in `ATLAS_MODEL`, map it to the canonical gateway ID so the
 // picker selects the right row and the agent loop sees a working ID.
+//
+// Two kinds of migration live here:
+//   1. Format canonicalization — hyphen → slash+dot (e.g. `claude-sonnet-4-6`).
+//   2. Version roll-forward — a deprecated Opus version that no longer has its
+//      own picker row (4.6, the prior 4.7 default) is mapped to the current
+//      flagship `anthropic/claude-opus-4.8`. This is a version upgrade, not
+//      just a format change, so the Select highlights a valid option instead
+//      of rendering blank for workspaces still on the old default (#3076).
 const LEGACY_MODEL_ALIASES: Record<string, string> = {
   "claude-haiku-4-5": "anthropic/claude-haiku-4.5",
   "claude-sonnet-4-6": "anthropic/claude-sonnet-4.6",
   "claude-opus-4-6": "anthropic/claude-opus-4.8",
+  "claude-opus-4-7": "anthropic/claude-opus-4.8",
+  "anthropic/claude-opus-4.7": "anthropic/claude-opus-4.8",
 };
 
 function canonicalizeModel(value: string): string {

--- a/packages/web/src/app/admin/model-config/page.tsx
+++ b/packages/web/src/app/admin/model-config/page.tsx
@@ -22,10 +22,12 @@ const PLATFORM_MODEL_LABELS: Record<string, string> = {
   "claude-sonnet-4-6": "Sonnet 4.6",
   "claude-opus-4-6": "Opus 4.6",
   "claude-opus-4-7": "Opus 4.7",
+  "claude-opus-4-8": "Opus 4.8",
   "anthropic/claude-haiku-4.5": "Haiku 4.5",
   "anthropic/claude-sonnet-4.6": "Sonnet 4.6",
   "anthropic/claude-opus-4.6": "Opus 4.6",
   "anthropic/claude-opus-4.7": "Opus 4.7",
+  "anthropic/claude-opus-4.8": "Opus 4.8",
 };
 
 function platformModelLabel(value: string): string {

--- a/packages/web/src/ui/components/admin/model-provider-section.tsx
+++ b/packages/web/src/ui/components/admin/model-provider-section.tsx
@@ -813,7 +813,7 @@ export function ModelProviderSection({ showByotGate = true }: ModelProviderSecti
                         <Input
                           placeholder={
                             currentProvider === "anthropic"
-                              ? "claude-opus-4-7"
+                              ? "claude-opus-4-8"
                               : currentProvider === "openai"
                                 ? "gpt-4o"
                                 : "model-name"


### PR DESCRIPTION
## Summary

Monthly freshness check (#3076) flagged drift between our pinned Opus default and Vercel AI Gateway's latest Opus. This bumps `anthropic/claude-opus-4.7` → `anthropic/claude-opus-4.8` (and the Anthropic-direct `claude-opus-4-7` → `claude-opus-4-8`) across all hardcoded default/recommendation/label sites.

**Sonnet (`claude-sonnet-4.6`) and Haiku (`claude-haiku-4.5`) are already current** — confirmed, left unchanged.

### Sites updated (the 6 from the issue + coupled spots)
1. `providers.ts` — `PROVIDER_DEFAULTS.anthropic` + `.gateway`
2. `anthropic-catalog.ts` — `RECOMMENDED_MODEL_IDS`
3. `gateway-catalog.ts` — `RECOMMENDED_MODEL_IDS` + `FALLBACK_MODELS` (id + name)
4. `admin/billing/page.tsx` — `MODEL_OPTIONS` (SaaS tier picker) **+** the `LEGACY_MODEL_ALIASES` target for `claude-opus-4-6` (it pointed at the old `…4.7` row, which would otherwise no longer exist in the picker)
5. `admin/model-config/page.tsx` — `PLATFORM_MODEL_LABELS` (additive: kept the historical 4.6/4.7 label entries, added 4.8)
6. `model-provider-section.tsx` — BYOT-direct model-name input placeholder (example of the current flagship)
- `docs/reference/environment-variables.mdx` — the provider-defaults table mirrors `PROVIDER_DEFAULTS`; updated the anthropic + gateway rows
- Test fixtures bumped to keep the suite green (two genuinely broke: `anthropic-catalog.test.ts` and `gateway-catalog.test.ts` assert `recommended: true` on the opus mock, and `anthropic-catalog.test.ts` asserts the recommended-set membership; the rest were stale current-flagship references)

### Intentionally left at 4-7
- **Bedrock** (`providers.ts` `.bedrock`, `bedrock-catalog.ts`, all bedrock test fixtures, `bedrock.mdx` ARN, the bedrock row in the env-vars table) — **AWS has not GA'd Opus 4.8 on Bedrock yet.** Bump in a follow-up once it lands.
- **`plans.ts`** — no tier pins Opus (haiku/sonnet per tier, both current), so per the issue ("only if the tier-flagship changed") it needs no edit.
- The `admin-model-config.ts` route-description **example string** (and its mirror in the auto-generated `apps/docs/openapi.json`) — illustrative format examples that include the bedrock id (staying 4-7); left untouched to avoid an OpenAPI codegen step on a free-text example.

## Test plan
- [x] `/ci` — lint, type, full test suite (EXIT 0), syncpack, template/security-headers/schema/oauth-helper drift, railway-watch, test-discipline, twenty-resolver, published-symbols — all green
- [x] `grep -rn "claude-opus-4.7\|opus-4-7" packages/ apps/ ee/` — only intentional bedrock / historical-label / illustrative-example refs remain
- [x] Touched catalog + billing + admin-model-config + schemas + ee tests pass in isolation

Closes #3076

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3080"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782935561&installation_id=135337507&pr_number=3080&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3080&signature=f18ed3662a2cba76682ff36bfec695e0487d7c86a512f4bd599a660a8a4d8bbc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Default Anthropic model bumped to Claude Opus 4.8; Bedrock and gateway defaults aligned to the 4.8 identifiers. Admin UI model picker, labels, and legacy alias mappings updated to surface Opus 4.8.

* **Documentation**
  * Environment variable reference and Bedrock integration docs updated to show Opus 4.8.

* **Tests**
  * Test fixtures and assertions updated to reference Opus 4.8 across catalogs, billing, routing, and related tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->