### PR TITLE
feat(scope): REST-only workspace picker + decoupled exclude-set lifecycle (#3078)

### DIFF
--- a/packages/web/src/app/(workspace)/page.tsx
+++ b/packages/web/src/app/(workspace)/page.tsx
@@ -177,12 +177,19 @@ function ChatPage() {
 
   // Collapse the wrapper row's hairline border when the picker hides
   // itself on a legacy 1×1 workspace.
+  //
+  // #3078 — this surface's <ChatEnvPicker> is SQL-routing-only: it does NOT pass
+  // `restDatasources` / exclude / focus props (the REST-scope feature, #3066 /
+  // #3067 / #3078, is wired into the embeddable <AtlasChat> in
+  // `ui/components/atlas-chat.tsx`, not this workspace page). So the
+  // visibility flag must mirror that SQL-only picker — DON'T feed
+  // `restDatasources` here, or the row renders (predicate true) while the inner
+  // picker hides (no REST props) and leaves an empty bordered row. Surfacing
+  // REST scope on this page (or migrating it to <AtlasChat>) is tracked in #3081.
   const showEnvPicker = shouldRenderEnvPicker({
     groups: envGroupsQuery.groups,
     reason: envGroupsQuery.reason,
     error: envGroupsQuery.error,
-    // #3066 — also show when there are REST datasources to exclude.
-    restDatasources: envGroupsQuery.restDatasources,
   });
 
   const refreshConvosRef = useRef(convos.refresh);

--- a/packages/web/src/ui/__tests__/env-picker.test.tsx
+++ b/packages/web/src/ui/__tests__/env-picker.test.tsx
@@ -995,6 +995,112 @@ describe("ChatEnvPicker — REST-only focus (#3067)", () => {
   });
 });
 
+// ── #3078 — zero-group (REST-only) workspace render path ──────────────
+//
+// A workspace with REST datasources but NO SQL connection groups must still
+// surface the picker so its REST scope (exclude / focus) is reachable. The
+// SQL-less render path drops the routing modes / member list / singleton hint
+// (all SQL affordances) and shows only the REST scope section; the chip reads
+// the REST count with no SQL group/member prefix.
+
+describe("ChatEnvPicker — zero-group REST-only workspace (#3078)", () => {
+  const restOnly = [
+    { id: "stripe", displayName: "Stripe", groupId: null },
+    { id: "github", displayName: "GitHub", groupId: null },
+  ];
+
+  test("renders the picker for a zero-group workspace that has REST datasources", () => {
+    const { container } = render(
+      <ChatEnvPicker
+        groups={[]}
+        activeGroupId={null}
+        activeConnectionId={null}
+        restDatasources={restOnly}
+        restExcludedDatasourceIds={[]}
+        onRestExcludedChange={noop}
+        onSelect={noop}
+      />,
+    );
+    expect(
+      container.querySelector('[data-testid="chat-env-picker-trigger"]'),
+    ).not.toBeNull();
+  });
+
+  test("the chip shows the REST count with no SQL routing / member prefix", () => {
+    const { container } = render(
+      <ChatEnvPicker
+        groups={[]}
+        activeGroupId={null}
+        activeConnectionId={null}
+        restDatasources={restOnly}
+        restExcludedDatasourceIds={["stripe"]}
+        onRestExcludedChange={noop}
+        onSelect={noop}
+      />,
+    );
+    const label =
+      container.querySelector('[data-testid="chat-env-picker-label"]')?.textContent ?? "";
+    expect(label).toContain("1/2 REST");
+    // No SQL group/member chip → no placeholder dashes or pin label leak.
+    expect(label).not.toContain("—");
+  });
+
+  test("the REST datasources are excludable; no SQL routing section is rendered", () => {
+    const onRestExcludedChange = mock((_next: string[]) => {});
+    const { container } = render(
+      <ChatEnvPicker
+        groups={[]}
+        activeGroupId={null}
+        activeConnectionId={null}
+        restDatasources={restOnly}
+        restExcludedDatasourceIds={[]}
+        onRestExcludedChange={onRestExcludedChange}
+        onSelect={noop}
+      />,
+    );
+    const toggle = container.querySelector(
+      '[data-testid="chat-env-picker-rest-toggle-stripe"]',
+    ) as HTMLElement;
+    expect(toggle).not.toBeNull();
+    fireEvent.click(toggle);
+    expect(onRestExcludedChange).toHaveBeenCalledTimes(1);
+    expect(onRestExcludedChange.mock.calls[0]![0]).toEqual(["stripe"]);
+    // SQL affordances are absent — there are no groups to route over.
+    expect(container.querySelector('[data-testid="chat-env-picker-mode-auto"]')).toBeNull();
+    expect(container.querySelector('[data-testid="chat-env-picker-mode-pin"]')).toBeNull();
+    expect(container.querySelector('[data-testid="chat-env-picker-mode-all"]')).toBeNull();
+    expect(
+      container.querySelector('[data-testid="chat-env-picker-singleton-hint"]'),
+    ).toBeNull();
+  });
+
+  test("supports REST-only focus on a zero-group workspace (pairs with #3067)", () => {
+    const { container } = render(
+      <ChatEnvPicker
+        groups={[]}
+        activeGroupId={null}
+        activeConnectionId={null}
+        restDatasources={restOnly}
+        restExcludedDatasourceIds={[]}
+        onRestExcludedChange={noop}
+        restFocusDatasourceId="stripe"
+        onRestFocusChange={noop}
+        onSelect={noop}
+      />,
+    );
+    const label =
+      container.querySelector('[data-testid="chat-env-picker-label"]')?.textContent ?? "";
+    expect(label).toContain("Stripe only");
+    expect(
+      container
+        .querySelector('[data-testid="chat-env-picker-trigger"]')
+        ?.getAttribute("data-focused"),
+    ).toBe("true");
+    // No SQL routing section while focused on a zero-group workspace.
+    expect(container.querySelector('[data-testid="chat-env-picker-mode-auto"]')).toBeNull();
+  });
+});
+
 const originalFetch = globalThis.fetch;
 
 function mockFetch(
@@ -1186,16 +1292,27 @@ describe("shouldRenderEnvPicker truth table (#2504)", () => {
     ).toBe(false);
   });
 
-  // The zero-group REST-only workspace still hides (deferred follow-up): a
-  // SQL-less render path + independent exclude-set lifecycle are out of scope.
-  test("still hides a zero-group workspace even with REST datasources (#3066 deferred)", () => {
+  // #3078 — a zero-group (REST-only) workspace now renders the picker so its
+  // REST datasources are reachable (exclude / focus) via the SQL-less render
+  // path. Supersedes the prior "#3066 deferred" hide.
+  test("renders a zero-group workspace when there are REST datasources (#3078)", () => {
     expect(
       shouldRenderEnvPicker({
         groups: [],
         reason: null,
         restDatasources: [{ id: "stripe" }],
       }),
+    ).toBe(true);
+  });
+
+  test("still hides a zero-group workspace with no REST datasources, reason, or error (#3078)", () => {
+    expect(
+      shouldRenderEnvPicker({ groups: [], reason: null, restDatasources: [] }),
     ).toBe(false);
+    // The reason / error chip paths are unaffected by the REST-only render path.
+    expect(
+      shouldRenderEnvPicker({ groups: [], reason: "no_internal_db", restDatasources: [] }),
+    ).toBe(true);
   });
 });
 
@@ -1518,14 +1635,24 @@ describe("resolveEnvSelection — sticky-preference restore vs default seed (#30
   ): ResolveEnvSelectionInput {
     return {
       groups: [prodGroup],
-      current: { groupId: null, connectionId: null, routingMode: null, restExcludedDatasourceIds: [] },
+      current: {
+        groupId: null,
+        connectionId: null,
+        routingMode: null,
+        restExcludedDatasourceIds: [],
+        restFocusDatasourceId: null,
+      },
       provenance: "unset",
+      // #3078 — REST scope provenance defaults to "unset" (follows the SQL
+      // seed/restore). Tests that exercise the decoupled lifecycle override it.
+      restProvenance: "unset",
       preference: {
         workspaceId: null,
         groupId: null,
         connectionId: null,
         routingMode: null,
         restExcludedDatasourceIds: [],
+        restFocusDatasourceId: null,
       },
       activeWorkspaceId: null,
       preferenceHydrated: true,
@@ -1849,6 +1976,198 @@ describe("resolveEnvSelection — sticky-preference restore vs default seed (#30
       restFocusDatasourceId: "stripe",
     });
   });
+
+  // ── #3078 — REST scope has its OWN provenance, decoupled from SQL ──────
+  //
+  // Opening an all-null-SQL conversation that carried a non-empty exclude-set
+  // restores the exclude-set (marked `restProvenance: "explicit"`) but defers
+  // the SQL scope to a seed. The seed/restore effect re-runs with SQL
+  // provenance "unset" — and MUST NOT clobber the explicit REST scope with the
+  // default-seed empty set (the data-loss bug) nor with the sticky preference.
+
+  test("preserves the current exclude-set on a SQL seed when restProvenance is explicit (#3078)", () => {
+    const decision = resolveEnvSelection(
+      input({
+        current: {
+          groupId: null,
+          connectionId: null,
+          routingMode: null,
+          restExcludedDatasourceIds: ["stripe"],
+          restFocusDatasourceId: null,
+        },
+        provenance: "unset",
+        restProvenance: "explicit",
+      }),
+    );
+    // SQL seeds the group primary; the explicit REST scope is preserved, NOT
+    // reset to [] — this is the #3078 data-loss fix.
+    expect(decision).toEqual({
+      kind: "seed",
+      groupId: "g_prod",
+      connectionId: "us-prod",
+      restExcludedDatasourceIds: ["stripe"],
+      restFocusDatasourceId: null,
+    });
+  });
+
+  test("preserves the current REST-only focus on a SQL seed when restProvenance is explicit (#3078)", () => {
+    const decision = resolveEnvSelection(
+      input({
+        current: {
+          groupId: null,
+          connectionId: null,
+          routingMode: null,
+          restExcludedDatasourceIds: [],
+          restFocusDatasourceId: "stripe",
+        },
+        provenance: "unset",
+        restProvenance: "explicit",
+      }),
+    );
+    expect(decision).toEqual({
+      kind: "seed",
+      groupId: "g_prod",
+      connectionId: "us-prod",
+      restExcludedDatasourceIds: [],
+      restFocusDatasourceId: "stripe",
+    });
+  });
+
+  test("an explicit REST scope wins over the sticky preference's REST on a SQL restore (#3078)", () => {
+    // SQL restores from the workspace-matching preference, but the explicit REST
+    // scope (e.g. just restored from the opened conversation) is authoritative —
+    // the preference's REST must NOT overwrite it.
+    const decision = resolveEnvSelection(
+      input({
+        current: {
+          groupId: null,
+          connectionId: null,
+          routingMode: null,
+          restExcludedDatasourceIds: ["stripe"],
+          restFocusDatasourceId: null,
+        },
+        provenance: "unset",
+        restProvenance: "explicit",
+        preference: {
+          workspaceId: "org-1",
+          groupId: "g_prod",
+          connectionId: "eu-prod",
+          routingMode: "pin",
+          restExcludedDatasourceIds: [],
+          restFocusDatasourceId: null,
+        },
+        activeWorkspaceId: "org-1",
+      }),
+    );
+    expect(decision).toEqual({
+      kind: "restore",
+      groupId: "g_prod",
+      connectionId: "eu-prod",
+      routingMode: "pin",
+      restExcludedDatasourceIds: ["stripe"],
+      restFocusDatasourceId: null,
+    });
+  });
+
+  test("no-ops (no churn) when SQL already matches and the explicit REST scope is unchanged (#3078)", () => {
+    // After the seed/restore effect has applied the SQL scope, a re-run with the
+    // same explicit REST scope must settle to noop rather than loop forever
+    // (the passthrough must agree with the no-churn guard).
+    const decision = resolveEnvSelection(
+      input({
+        current: {
+          groupId: "g_prod",
+          connectionId: "eu-prod",
+          routingMode: "pin",
+          restExcludedDatasourceIds: ["stripe"],
+          restFocusDatasourceId: null,
+        },
+        provenance: "explicit",
+        restProvenance: "explicit",
+        preference: {
+          workspaceId: "org-1",
+          groupId: "g_prod",
+          connectionId: "eu-prod",
+          routingMode: "pin",
+          restExcludedDatasourceIds: [],
+          restFocusDatasourceId: null,
+        },
+        activeWorkspaceId: "org-1",
+      }),
+    );
+    expect(decision).toEqual({ kind: "noop" });
+  });
+
+  test("no-ops on the RESTORE branch when SQL already matches and explicit REST is unchanged (#3078 loop guard)", () => {
+    // Distinct from the test above, which short-circuits at the
+    // `provenance === "explicit"` early-return. Here `provenance` is "default"
+    // (NOT "explicit"), so the resolver actually REACHES the restore-branch
+    // no-churn guard — the one most prone to a loop, because `restExplicit`
+    // derives `nextRestExcluded` from `current` and compares it back against
+    // `current`. If that derivation ever diverged from the returned decision's
+    // REST fields, the effect would re-write state every run and churn forever.
+    // The exclude-set differs from the preference's, so the passthrough is what
+    // makes the guard agree → noop.
+    const decision = resolveEnvSelection(
+      input({
+        current: {
+          groupId: "g_prod",
+          connectionId: "eu-prod",
+          routingMode: "pin",
+          restExcludedDatasourceIds: ["stripe"],
+          restFocusDatasourceId: null,
+        },
+        provenance: "default",
+        restProvenance: "explicit",
+        preference: {
+          workspaceId: "org-1",
+          groupId: "g_prod",
+          connectionId: "eu-prod",
+          routingMode: "pin",
+          restExcludedDatasourceIds: [],
+          restFocusDatasourceId: null,
+        },
+        activeWorkspaceId: "org-1",
+      }),
+    );
+    expect(decision).toEqual({ kind: "noop" });
+  });
+
+  test("an explicit REST-only focus wins over the preference's focus on a SQL restore (#3078)", () => {
+    // Symmetric to the exclude-set passthrough on restore: the explicit focus
+    // (e.g. restored from the opened conversation) survives the SQL restore-from-
+    // preference rather than being overwritten by the preference's focus.
+    const decision = resolveEnvSelection(
+      input({
+        current: {
+          groupId: null,
+          connectionId: null,
+          routingMode: null,
+          restExcludedDatasourceIds: [],
+          restFocusDatasourceId: "stripe",
+        },
+        provenance: "unset",
+        restProvenance: "explicit",
+        preference: {
+          workspaceId: "org-1",
+          groupId: "g_prod",
+          connectionId: "eu-prod",
+          routingMode: "pin",
+          restExcludedDatasourceIds: [],
+          restFocusDatasourceId: "github",
+        },
+        activeWorkspaceId: "org-1",
+      }),
+    );
+    expect(decision).toEqual({
+      kind: "restore",
+      groupId: "g_prod",
+      connectionId: "eu-prod",
+      routingMode: "pin",
+      restExcludedDatasourceIds: [],
+      restFocusDatasourceId: "stripe",
+    });
+  });
 });
 
 // ── #3065 — restore a conversation's scope on open ───────────────────
@@ -1959,7 +2278,7 @@ describe("resolveConversationScope — restore a conversation's scope on open (#
         { connectionGroupId: null, connectionId: null, routingMode: null },
         groups,
       ),
-    ).toEqual({ kind: "seed" });
+    ).toEqual({ kind: "seed", restExcludedDatasourceIds: [], restFocusDatasourceId: null });
   });
 
   test("seeds when the row's group has been archived / is no longer visible", () => {
@@ -1970,7 +2289,7 @@ describe("resolveConversationScope — restore a conversation's scope on open (#
         { connectionGroupId: "g_archived", connectionId: "old-prod", routingMode: "pin" },
         groups,
       ),
-    ).toEqual({ kind: "seed" });
+    ).toEqual({ kind: "seed", restExcludedDatasourceIds: [], restFocusDatasourceId: null });
   });
 
   test("repairs an archived member to the group primary when the group still resolves", () => {
@@ -2024,7 +2343,7 @@ describe("resolveConversationScope — restore a conversation's scope on open (#
         { connectionGroupId: null, connectionId: null, routingMode: null },
         [],
       ),
-    ).toEqual({ kind: "seed" });
+    ).toEqual({ kind: "seed", restExcludedDatasourceIds: [], restFocusDatasourceId: null });
   });
 
   test("restores a legacy group-less row by locating the group that owns its connection", () => {
@@ -2049,7 +2368,7 @@ describe("resolveConversationScope — restore a conversation's scope on open (#
         { connectionGroupId: null, connectionId: "deleted-conn", routingMode: "pin" },
         groups,
       ),
-    ).toEqual({ kind: "seed" });
+    ).toEqual({ kind: "seed", restExcludedDatasourceIds: [], restFocusDatasourceId: null });
   });
 
   test("optimistically restores a legacy group-less row (null group) on cold-start", () => {
@@ -2077,7 +2396,7 @@ describe("resolveConversationScope — restore a conversation's scope on open (#
         { connectionGroupId: "g_empty", connectionId: "anything", routingMode: "pin" },
         [emptyGroup],
       ),
-    ).toEqual({ kind: "seed" });
+    ).toEqual({ kind: "seed", restExcludedDatasourceIds: [], restFocusDatasourceId: null });
   });
 
   // #3067 — the row's REST-only focus is restored alongside the SQL scope, the
@@ -2116,6 +2435,70 @@ describe("resolveConversationScope — restore a conversation's scope on open (#
       connectionId: "eu-prod",
       routingMode: "pin",
       restExcludedDatasourceIds: [],
+      restFocusDatasourceId: null,
+    });
+  });
+
+  // ── #3078 — REST scope survives an all-null SQL seed (data-loss fix) ───
+  //
+  // The REST scope is independent of SQL routing, so it must be carried on the
+  // `seed` decision too — not just `restore`. Before #3078, a `seed` dropped the
+  // exclude-set, and `handleSelectConversation` then cleared it; because the
+  // transport always sends the array, the next turn sent `[]` and wiped the
+  // persisted exclusions. The row's REST scope must come back regardless of the
+  // SQL-scope decision.
+
+  test("carries a non-empty exclude-set on a seed when the SQL scope is all-null (#3078)", () => {
+    expect(
+      resolveConversationScope(
+        {
+          connectionGroupId: null,
+          connectionId: null,
+          routingMode: null,
+          restExcludedDatasourceIds: ["stripe"],
+        },
+        groups,
+      ),
+    ).toEqual({
+      kind: "seed",
+      restExcludedDatasourceIds: ["stripe"],
+      restFocusDatasourceId: null,
+    });
+  });
+
+  test("carries REST-only focus on a seed when the SQL scope is all-null (#3078)", () => {
+    expect(
+      resolveConversationScope(
+        {
+          connectionGroupId: null,
+          connectionId: null,
+          restFocusDatasourceId: "stripe",
+        },
+        groups,
+      ),
+    ).toEqual({
+      kind: "seed",
+      restExcludedDatasourceIds: [],
+      restFocusDatasourceId: "stripe",
+    });
+  });
+
+  test("carries the exclude-set on a seed when the row's group is archived (#3078)", () => {
+    // The SQL group is gone (→ seed), but the REST exclude-set is still valid and
+    // independent of the SQL group, so it must survive.
+    expect(
+      resolveConversationScope(
+        {
+          connectionGroupId: "g_archived",
+          connectionId: "old-prod",
+          routingMode: "pin",
+          restExcludedDatasourceIds: ["stripe", "github"],
+        },
+        groups,
+      ),
+    ).toEqual({
+      kind: "seed",
+      restExcludedDatasourceIds: ["stripe", "github"],
       restFocusDatasourceId: null,
     });
   });

--- a/packages/web/src/ui/__tests__/env-picker.test.tsx
+++ b/packages/web/src/ui/__tests__/env-picker.test.tsx
@@ -1074,6 +1074,42 @@ describe("ChatEnvPicker — zero-group REST-only workspace (#3078)", () => {
     ).toBeNull();
   });
 
+  test("makes a group-scoped REST datasource reachable too when there's no SQL env (#3078 Codex)", () => {
+    // A REST datasource with a non-null groupId in a zero-group workspace has no
+    // SQL env to scope against, so it must still be toggleable — not classified
+    // as "scoped to another environment" / counted as 0/0.
+    const onRestExcludedChange = mock((_next: string[]) => {});
+    const mixed = [
+      { id: "stripe", displayName: "Stripe", groupId: null },
+      { id: "scoped-api", displayName: "Scoped API", groupId: "g_gone" },
+    ];
+    const { container } = render(
+      <ChatEnvPicker
+        groups={[]}
+        activeGroupId={null}
+        activeConnectionId={null}
+        restDatasources={mixed}
+        restExcludedDatasourceIds={[]}
+        onRestExcludedChange={onRestExcludedChange}
+        onSelect={noop}
+      />,
+    );
+    // Both datasources counted as reachable on the chip.
+    const label =
+      container.querySelector('[data-testid="chat-env-picker-label"]')?.textContent ?? "";
+    expect(label).toContain("2/2 REST");
+    // The group-scoped one is toggleable, NOT shoved into "other environments".
+    const scopedToggle = container.querySelector(
+      '[data-testid="chat-env-picker-rest-toggle-scoped-api"]',
+    ) as HTMLElement;
+    expect(scopedToggle).not.toBeNull();
+    expect(
+      container.querySelector('[data-testid="chat-env-picker-rest-out-of-scope"]'),
+    ).toBeNull();
+    fireEvent.click(scopedToggle);
+    expect(onRestExcludedChange.mock.calls[0]![0]).toEqual(["scoped-api"]);
+  });
+
   test("supports REST-only focus on a zero-group workspace (pairs with #3067)", () => {
     const { container } = render(
       <ChatEnvPicker
@@ -1657,6 +1693,9 @@ describe("resolveEnvSelection — sticky-preference restore vs default seed (#30
       activeWorkspaceId: null,
       preferenceHydrated: true,
       sessionResolved: true,
+      // #3078 — default to "groups fetch settled" so the with-groups tests run
+      // the normal path; the zero-group tests override groups + this flag.
+      groupsLoaded: true,
       ...overrides,
     };
   }
@@ -1696,8 +1735,13 @@ describe("resolveEnvSelection — sticky-preference restore vs default seed (#30
     expect(decision.kind).toBe("wait");
   });
 
-  test("waits until connection groups have loaded", () => {
-    expect(resolveEnvSelection(input({ groups: [] })).kind).toBe("wait");
+  test("waits until connection groups have loaded (groups empty AND fetch not settled)", () => {
+    // #3078 — emptiness alone is no longer "wait": a *loaded-empty* group list is
+    // a real zero-group workspace (REST-only path). It only waits while the
+    // fetch hasn't settled yet.
+    expect(
+      resolveEnvSelection(input({ groups: [], groupsLoaded: false })).kind,
+    ).toBe("wait");
   });
 
   test("restores the hydrated workspace preference instead of the default seed", () => {
@@ -2168,6 +2212,162 @@ describe("resolveEnvSelection — sticky-preference restore vs default seed (#30
       restFocusDatasourceId: "stripe",
     });
   });
+
+  // ── #3078 — zero-group (REST-only) workspace: REST-only seed/restore ───
+  //
+  // With no SQL groups there's nothing to seed for SQL, but the sticky REST
+  // preference must still seed a fresh chat (ADR-0011). Codex flagged that the
+  // old `groups.length === 0 → wait` gate blocked this, so a zero-group user's
+  // exclusions never carried to a new chat.
+
+  test("waits on an empty group list until the fetch has settled (no premature REST seed)", () => {
+    expect(
+      resolveEnvSelection(
+        input({
+          groups: [],
+          groupsLoaded: false,
+          preference: {
+            workspaceId: null,
+            groupId: null,
+            connectionId: null,
+            routingMode: null,
+            restExcludedDatasourceIds: ["stripe"],
+            restFocusDatasourceId: null,
+          },
+        }),
+      ).kind,
+    ).toBe("wait");
+  });
+
+  test("restores the sticky REST preference on a fresh chat in a zero-group workspace (#3078)", () => {
+    const decision = resolveEnvSelection(
+      input({
+        groups: [],
+        groupsLoaded: true,
+        preference: {
+          workspaceId: "org-1",
+          groupId: null,
+          connectionId: null,
+          routingMode: null,
+          restExcludedDatasourceIds: ["stripe"],
+          restFocusDatasourceId: null,
+        },
+        activeWorkspaceId: "org-1",
+      }),
+    );
+    // SQL stays null (no groups); the REST exclude-set is seeded from the pref.
+    expect(decision).toEqual({
+      kind: "restore",
+      groupId: null,
+      connectionId: null,
+      routingMode: null,
+      restExcludedDatasourceIds: ["stripe"],
+      restFocusDatasourceId: null,
+    });
+  });
+
+  test("restores the sticky REST-only focus on a fresh chat in a zero-group workspace (#3078)", () => {
+    const decision = resolveEnvSelection(
+      input({
+        groups: [],
+        groupsLoaded: true,
+        preference: {
+          workspaceId: "org-1",
+          groupId: null,
+          connectionId: null,
+          routingMode: null,
+          restExcludedDatasourceIds: [],
+          restFocusDatasourceId: "stripe",
+        },
+        activeWorkspaceId: "org-1",
+      }),
+    );
+    expect(decision).toEqual({
+      kind: "restore",
+      groupId: null,
+      connectionId: null,
+      routingMode: null,
+      restExcludedDatasourceIds: [],
+      restFocusDatasourceId: "stripe",
+    });
+  });
+
+  test("ignores a different workspace's REST preference in a zero-group workspace (#3078)", () => {
+    expect(
+      resolveEnvSelection(
+        input({
+          groups: [],
+          groupsLoaded: true,
+          preference: {
+            workspaceId: "org-B",
+            groupId: null,
+            connectionId: null,
+            routingMode: null,
+            restExcludedDatasourceIds: ["stripe"],
+            restFocusDatasourceId: null,
+          },
+          activeWorkspaceId: "org-A",
+        }),
+      ),
+    ).toEqual({ kind: "noop" });
+  });
+
+  test("no-ops a zero-group workspace when the current REST scope already matches the preference (#3078)", () => {
+    expect(
+      resolveEnvSelection(
+        input({
+          groups: [],
+          groupsLoaded: true,
+          current: {
+            groupId: null,
+            connectionId: null,
+            routingMode: null,
+            restExcludedDatasourceIds: ["stripe"],
+            restFocusDatasourceId: null,
+          },
+          preference: {
+            workspaceId: "org-1",
+            groupId: null,
+            connectionId: null,
+            routingMode: null,
+            restExcludedDatasourceIds: ["stripe"],
+            restFocusDatasourceId: null,
+          },
+          activeWorkspaceId: "org-1",
+        }),
+      ),
+    ).toEqual({ kind: "noop" });
+  });
+
+  test("does not clobber an explicit REST scope in a zero-group workspace (#3078)", () => {
+    // A conversation-open restore / user toggle marked REST explicit; the
+    // sticky preference must not overwrite it even on a zero-group workspace.
+    expect(
+      resolveEnvSelection(
+        input({
+          groups: [],
+          groupsLoaded: true,
+          current: {
+            groupId: null,
+            connectionId: null,
+            routingMode: null,
+            restExcludedDatasourceIds: ["github"],
+            restFocusDatasourceId: null,
+          },
+          restProvenance: "explicit",
+          preference: {
+            workspaceId: "org-1",
+            groupId: null,
+            connectionId: null,
+            routingMode: null,
+            restExcludedDatasourceIds: ["stripe"],
+            restFocusDatasourceId: null,
+          },
+          activeWorkspaceId: "org-1",
+        }),
+      ),
+    ).toEqual({ kind: "noop" });
+  });
 });
 
 // ── #3065 — restore a conversation's scope on open ───────────────────
@@ -2500,6 +2700,26 @@ describe("resolveConversationScope — restore a conversation's scope on open (#
       kind: "seed",
       restExcludedDatasourceIds: ["stripe", "github"],
       restFocusDatasourceId: null,
+    });
+  });
+
+  test("carries REST-only focus on a seed when the row's group is archived (#3078)", () => {
+    // Symmetric to the exclude-set case — a regression that dropped focus
+    // specifically on the archived-group seed path would otherwise slip through.
+    expect(
+      resolveConversationScope(
+        {
+          connectionGroupId: "g_archived",
+          connectionId: "old-prod",
+          routingMode: "pin",
+          restFocusDatasourceId: "stripe",
+        },
+        groups,
+      ),
+    ).toEqual({
+      kind: "seed",
+      restExcludedDatasourceIds: [],
+      restFocusDatasourceId: "stripe",
     });
   });
 });

--- a/packages/web/src/ui/components/atlas-chat.tsx
+++ b/packages/web/src/ui/components/atlas-chat.tsx
@@ -270,6 +270,10 @@ export function AtlasChat() {
       activeWorkspaceId,
       preferenceHydrated: prefHasHydrated,
       sessionResolved,
+      // #3078 — a settled fetch means an empty `groups` is a real zero-group
+      // (REST-only) workspace, not a cold start; lets the resolver seed the
+      // sticky REST preference there instead of waiting forever.
+      groupsLoaded: envGroupsQuery.hasLoaded,
     });
 
     switch (decision.kind) {
@@ -313,6 +317,9 @@ export function AtlasChat() {
     }
   }, [
     envGroupsQuery.groups,
+    // #3078 — re-evaluate once the fetch settles, so the zero-group REST-only
+    // path can seed the sticky preference instead of staying in `wait`.
+    envGroupsQuery.hasLoaded,
     selectedGroupId,
     selectedConnectionId,
     // routingMode is part of `current` the resolver reads — keep it in deps so a

--- a/packages/web/src/ui/components/atlas-chat.tsx
+++ b/packages/web/src/ui/components/atlas-chat.tsx
@@ -156,11 +156,19 @@ export function AtlasChat() {
   const prefRestFocus = useChatRoutingPreferenceStore((s) => s.restFocusDatasourceId);
   const prefHasHydrated = useChatRoutingPreferenceStore((s) => s._hasHydrated);
   const setRoutingPreference = useChatRoutingPreferenceStore((s) => s.setPreference);
-  // #3064 — how the current picker selection was set, so the seed/restore
-  // effect knows whether it may replace it. A ref (not state) because it
-  // must update synchronously alongside a setSelected* call without
+  // #3064 — how the current picker SQL scope (group / member / mode) was set, so
+  // the seed/restore effect knows whether it may replace it. A ref (not state)
+  // because it must update synchronously alongside a setSelected* call without
   // re-triggering the effect itself.
   const selectionProvenanceRef = useRef<EnvSelectionProvenance>("unset");
+  // #3078 — the REST scope (exclude-set + focus) has its OWN provenance,
+  // decoupled from the SQL `selectionProvenanceRef`. Opening a conversation
+  // makes the row's REST scope authoritative ("explicit") even when its SQL
+  // scope must be seeded (an all-null row), and a REST toggle marks it explicit
+  // too. While it's explicit, `resolveEnvSelection` passes the current REST scope
+  // through any SQL seed/restore instead of clobbering it — the seam that fixes
+  // the all-null-SQL exclude-set data loss. `handleNewChat` resets it to "unset".
+  const restScopeProvenanceRef = useRef<EnvSelectionProvenance>("unset");
   const scrollRef = useRef<HTMLDivElement>(null);
 
   const {
@@ -246,6 +254,11 @@ export function AtlasChat() {
         restFocusDatasourceId: selectedRestFocus,
       },
       provenance: selectionProvenanceRef.current,
+      // #3078 — REST scope provenance is independent of the SQL provenance. When
+      // it's "explicit" (a conversation-open restore or a user toggle), the
+      // resolver passes the current REST scope through instead of clobbering it
+      // with the default seed / sticky preference while SQL seeds or restores.
+      restProvenance: restScopeProvenanceRef.current,
       preference: {
         workspaceId: prefWorkspaceId,
         groupId: prefGroupId,
@@ -624,41 +637,39 @@ export function AtlasChat() {
       setConversationId(id);
       convos.setSelectedId(id);
       // Restore the conversation's persisted scope, validated against the
-      // currently-visible env groups. A `restore` decision is authoritative
-      // (precedence row > sticky preference > default seed) — mark it `explicit`
-      // (before the setState calls, so the re-running seed/restore effect
-      // already sees it) so that effect can't clobber it. A `seed` decision
-      // means the row carried no usable scope (all-null legacy row, or a group
-      // since archived): reset to `unset` and clear so the effect seeds the
-      // default / restores the sticky preference, never sending stale-or-null
-      // scope the chip would misrepresent.
+      // currently-visible env groups. The SQL scope and the REST scope are
+      // restored INDEPENDENTLY (#3078):
+      //
+      //   - REST scope (exclude-set + focus) is always restored from the row and
+      //     marked `restProvenance: "explicit"` regardless of the SQL decision —
+      //     it is not tied to SQL routing. Marking it explicit (before the
+      //     setState calls, so the re-running seed/restore effect already sees
+      //     it) is what stops that effect from clobbering a restored exclude-set
+      //     when the SQL scope must be seeded. Before #3078 a `seed` cleared the
+      //     exclude-set and the always-sent transport array then wiped it on the
+      //     next turn (the data-loss bug).
+      //   - SQL scope: a `restore` is authoritative (precedence row > sticky
+      //     preference > default seed) — mark it `explicit` so the effect can't
+      //     replace it. A `seed` means the row carried no usable SQL scope
+      //     (all-null legacy row, or a group since archived): reset to `unset` so
+      //     the effect seeds the default / restores the sticky preference,
+      //     never sending stale-or-null routing the chip would misrepresent.
       const decision = resolveConversationScope(data, envGroupsQuery.groups);
+      // REST scope — restored on BOTH decision kinds, made authoritative.
+      restScopeProvenanceRef.current = "explicit";
+      setSelectedRestExcluded(decision.restExcludedDatasourceIds);
+      setSelectedRestFocus(decision.restFocusDatasourceId);
+      // SQL scope — restore vs defer-to-seed.
       if (decision.kind === "restore") {
         selectionProvenanceRef.current = "explicit";
         setSelectedGroupId(decision.groupId);
         setSelectedConnectionId(decision.connectionId);
         setSelectedRoutingMode(decision.routingMode);
-        // #3066 — restore the conversation's REST exclude-set so the picker +
-        // the next turn reflect what the row actually excludes.
-        setSelectedRestExcluded(decision.restExcludedDatasourceIds);
-        // #3067 — restore the conversation's REST-only focus too.
-        setSelectedRestFocus(decision.restFocusDatasourceId);
       } else {
         selectionProvenanceRef.current = "unset";
         setSelectedGroupId(null);
         setSelectedConnectionId(null);
         setSelectedRoutingMode(null);
-        // #3066 — no usable scope on the row: clear the exclude-set too and let
-        // the seed/restore effect re-seed from the sticky preference / default.
-        setSelectedRestExcluded([]);
-        // #3067 — clear focus too on a seed decision. A `seed` fires when the
-        // row's SQL scope isn't restorable: all-null (legacy / zero-group), or
-        // its group was archived/removed / has no live members. On the common
-        // ≥1-group workspace a focused conversation normally carries a live
-        // group and `restore`s above; the all-null REST-only case (where focus
-        // would be lost) is only reachable on a zero-group workspace, which
-        // doesn't render the picker yet — see #3078.
-        setSelectedRestFocus(null);
       }
       setMobileSidebarOpen(false);
       // Loaded turns predate this session — no warning frames replay over
@@ -689,6 +700,10 @@ export function AtlasChat() {
     // just-opened conversation's `explicit` scope would carry into the new
     // chat and the effect would no-op on it.
     selectionProvenanceRef.current = "unset";
+    // #3078 — reset the REST scope provenance too, so a just-opened
+    // conversation's `explicit` REST scope doesn't carry into the new chat and
+    // block the seed/restore effect from seeding the sticky preference / default.
+    restScopeProvenanceRef.current = "unset";
     setSelectedGroupId(null);
     setSelectedConnectionId(null);
     setSelectedRoutingMode(null);
@@ -766,8 +781,12 @@ export function AtlasChat() {
                       // selection explicit (so the seed/restore effect can't
                       // re-seed over it) and remember it in the sticky
                       // preference so new chats inherit it. The full next set
-                      // (incl. []) is forwarded verbatim.
+                      // (incl. []) is forwarded verbatim. #3078 — mark the REST
+                      // scope's own provenance explicit too (keeping the SQL
+                      // provenance explicit avoids a stray pref-restore of SQL as
+                      // a side effect of a REST toggle).
                       selectionProvenanceRef.current = "explicit";
+                      restScopeProvenanceRef.current = "explicit";
                       setSelectedRestExcluded(next);
                       setRoutingPreference({
                         workspaceId: activeWorkspaceId,
@@ -783,7 +802,9 @@ export function AtlasChat() {
                       // #3067 — focusing / clearing is a deliberate pick: mark
                       // explicit and remember it in the sticky preference so new
                       // chats inherit it. `null` clears focus (re-enables SQL).
+                      // #3078 — mark the REST scope's own provenance explicit too.
                       selectionProvenanceRef.current = "explicit";
+                      restScopeProvenanceRef.current = "explicit";
                       setSelectedRestFocus(next);
                       setRoutingPreference({
                         workspaceId: activeWorkspaceId,

--- a/packages/web/src/ui/components/chat/env-picker.tsx
+++ b/packages/web/src/ui/components/chat/env-picker.tsx
@@ -192,15 +192,21 @@ export interface ShouldRenderEnvPickerArgs {
    * the picker worth showing even when SQL routing is trivial (one group / one
    * member), so the exclude toggles stay reachable — otherwise the exclude-set
    * feature is dead for the common one-Postgres + one-REST-datasource
-   * workspace. (A zero-group, REST-only workspace still hides the picker; that
-   * shape needs the SQL-less render path + an independent exclude-set lifecycle,
-   * tracked as a follow-up.)
+   * workspace. #3078 — also surfaces the picker for a zero-group, REST-only
+   * workspace via the SQL-less render path, so its REST datasources are
+   * excludable / focusable with no SQL group/member chip.
    */
   readonly restDatasources?: ReadonlyArray<unknown>;
 }
 
 export function shouldRenderEnvPicker(args: ShouldRenderEnvPickerArgs): boolean {
-  if (args.groups.length === 0) return args.reason !== null || args.error != null;
+  if (args.groups.length === 0) {
+    // #3078 — a zero-group (REST-only) workspace still has REST datasources to
+    // exclude / focus, so render the SQL-less scope section. Otherwise show
+    // only for a diagnostic reason / transport error (#2422 / #2504).
+    if ((args.restDatasources?.length ?? 0) > 0) return true;
+    return args.reason !== null || args.error != null;
+  }
   if (args.groups.length > 1) return true;
   if ((args.groups[0]?.members.length ?? 0) > 1) return true;
   // #3066 — single group + single member, but there are REST datasources to
@@ -286,8 +292,20 @@ export interface ResolveEnvSelectionInput {
     /** #3067 — current REST-only focus, so a pref-only focus change still restores. */
     readonly restFocusDatasourceId: string | null;
   };
-  /** How {@link current} was set. */
+  /** How {@link current}'s SQL scope (group / member / mode) was set. */
   readonly provenance: EnvSelectionProvenance;
+  /**
+   * #3078 — how {@link current}'s REST scope (exclude-set + focus) was set,
+   * independent of the SQL {@link provenance}. When `"explicit"` the REST scope
+   * is authoritative — a conversation-open restore made the row's exclude-set /
+   * focus the source of truth, or the user toggled it — so the resolver passes
+   * the *current* REST values through instead of clobbering them with the
+   * default-seed empty set / the sticky preference, even while the SQL scope is
+   * seeded or restored. `"unset"` / `"default"` mean "REST follows the SQL
+   * seed/restore" (pre-#3078 behaviour). Required (like {@link provenance}): a
+   * silent default in a precedence resolver is how the clobber bug returns.
+   */
+  readonly restProvenance: EnvSelectionProvenance;
   /** The persisted sticky preference for this browser. */
   readonly preference: EnvSelectionPreference;
   /** Active workspace id (`null` = self-hosted / no active org). */
@@ -352,11 +370,19 @@ export function resolveEnvSelection(
     groups,
     current,
     provenance,
+    restProvenance,
     preference,
     activeWorkspaceId,
     preferenceHydrated,
     sessionResolved,
   } = input;
+
+  // #3078 — when the REST scope is authoritative (conversation-open restore, or
+  // a user toggle), pass the CURRENT exclude-set / focus through any
+  // seed/restore decision below instead of overwriting it. This keeps the SQL
+  // scope free to seed/restore while the REST scope stays put — the seam that
+  // fixes the all-null-SQL exclude-set data loss.
+  const restExplicit = restProvenance === "explicit";
 
   // 1. Gate — wait until every input we need to choose correctly is ready.
   if (groups.length === 0) return { kind: "wait" };
@@ -364,6 +390,8 @@ export function resolveEnvSelection(
   if (!sessionResolved) return { kind: "wait" };
 
   // 2. An explicit pick (or conversation-restored value) is authoritative.
+  // (When SQL is explicit the REST scope is already settled too, so there is no
+  // divergent REST action to take here — the early noop is safe.)
   if (provenance === "explicit") return { kind: "noop" };
 
   // 3. Restore a workspace-matching, still-resolvable preference.
@@ -376,23 +404,27 @@ export function resolveEnvSelection(
     (m) => m.connectionId === preference.connectionId,
   );
   if (prefGroup && prefMember) {
+    // The REST scope this restore would apply: the preference's, UNLESS the REST
+    // scope is explicit (#3078) — then the current exclude-set / focus is
+    // authoritative and passes through untouched. Computed once so the no-churn
+    // guard and the returned decision agree (a mismatch would loop forever).
+    const nextRestExcluded = restExplicit
+      ? [...(current.restExcludedDatasourceIds ?? [])]
+      : [...(preference.restExcludedDatasourceIds ?? [])];
+    const nextRestFocus = restExplicit
+      ? current.restFocusDatasourceId ?? null
+      : preference.restFocusDatasourceId ?? null;
+
     // Already on the preferred selection — don't churn React state. The
-    // routing mode AND the exclude-set (#3066) are part of the selection, so a
-    // mode-only or exclude-only difference (e.g. a default seed landed on the
+    // routing mode AND the REST scope (#3066/#3067) are part of the selection,
+    // so a mode-only or REST-only difference (e.g. a default seed landed on the
     // preferred member but with no mode / empty exclude-set) must still restore.
     if (
       current.groupId === prefGroup.id &&
       current.connectionId === prefMember.connectionId &&
       current.routingMode === preference.routingMode &&
-      sameExcludeSet(
-        current.restExcludedDatasourceIds ?? [],
-        preference.restExcludedDatasourceIds ?? [],
-      ) &&
-      // #3067 — focus is part of the selection too, so a focus-only difference
-      // (e.g. the default seed landed on the preferred member but with no focus)
-      // must still restore.
-      (current.restFocusDatasourceId ?? null) ===
-        (preference.restFocusDatasourceId ?? null)
+      sameExcludeSet(current.restExcludedDatasourceIds ?? [], nextRestExcluded) &&
+      (current.restFocusDatasourceId ?? null) === nextRestFocus
     ) {
       return { kind: "noop" };
     }
@@ -401,8 +433,8 @@ export function resolveEnvSelection(
       groupId: prefGroup.id,
       connectionId: prefMember.connectionId,
       routingMode: preference.routingMode,
-      restExcludedDatasourceIds: [...(preference.restExcludedDatasourceIds ?? [])],
-      restFocusDatasourceId: preference.restFocusDatasourceId ?? null,
+      restExcludedDatasourceIds: nextRestExcluded,
+      restFocusDatasourceId: nextRestFocus,
     };
   }
 
@@ -416,12 +448,17 @@ export function resolveEnvSelection(
   if (!seed) return { kind: "noop" };
   // A default seed carries no exclusions — every in-scope REST datasource stays
   // queryable until the user opts one out — and is not focused (SQL active).
+  // #3078 — UNLESS the REST scope is explicit (e.g. an all-null-SQL conversation
+  // whose exclude-set / focus was just restored): pass it through so seeding the
+  // SQL default doesn't wipe it.
   return {
     kind: "seed",
     groupId: seed.groupId,
     connectionId: seed.connectionId,
-    restExcludedDatasourceIds: [],
-    restFocusDatasourceId: null,
+    restExcludedDatasourceIds: restExplicit
+      ? [...(current.restExcludedDatasourceIds ?? [])]
+      : [],
+    restFocusDatasourceId: restExplicit ? current.restFocusDatasourceId ?? null : null,
   };
 }
 
@@ -442,42 +479,69 @@ export interface ConversationScopeSource {
   readonly restFocusDatasourceId?: string | null;
 }
 
-/** The picker selection restored from a conversation row. */
-export interface RestoredConversationScope {
-  readonly groupId: string | null;
-  readonly connectionId: string | null;
-  readonly routingMode: ConversationRoutingMode | null;
+/**
+ * #3078 — the REST half of a conversation's restored scope (exclude-set +
+ * focus). Carried on EVERY {@link ConversationScopeDecision} regardless of the
+ * SQL decision, because REST scope is independent of SQL routing. Shared by
+ * {@link RestoredConversationScope} (the `restore` arm) and the `seed` arm so the
+ * two arms' REST fields can't drift — the union's consumers read them without
+ * narrowing on `kind`.
+ */
+export interface RestoredRestScope {
   /**
-   * #3066 — the conversation's REST exclude-set. The SQL scope (group/member)
-   * can fall back to a `seed` decision while the exclude-set is still carried
-   * faithfully on a `restore`; an absent / null column coalesces to `[]`.
+   * #3066 — the conversation's REST exclude-set (excluded `install_id`s). The SQL
+   * scope (group/member) can fall back to a `seed` decision while the exclude-set
+   * is still carried faithfully; an absent / null column coalesces to `[]`.
    */
   readonly restExcludedDatasourceIds: string[];
   /**
-   * #3067 — the conversation's REST-only focus (`install_id`, or null). Carried
-   * faithfully on a `restore`, the same way as the exclude-set; null = not
-   * focused (SQL active).
+   * #3067 — the conversation's REST-only focus (`install_id`, or null = not
+   * focused). Carried the same way as the exclude-set.
    */
   readonly restFocusDatasourceId: string | null;
 }
 
+/** The picker selection restored from a conversation row — SQL scope + REST scope. */
+export interface RestoredConversationScope extends RestoredRestScope {
+  readonly groupId: string | null;
+  readonly connectionId: string | null;
+  readonly routingMode: ConversationRoutingMode | null;
+}
+
 /**
- * What {@link resolveConversationScope} decides for an opened conversation:
- * `restore` (apply the scope and make it authoritative) or `seed` (the row
- * carried no usable scope — defer to the fresh-chat seed/restore effect).
+ * What {@link resolveConversationScope} decides for an opened conversation's
+ * **SQL scope**: `restore` (apply the group/member/mode and make it
+ * authoritative) or `seed` (the row carried no usable SQL scope — defer to the
+ * fresh-chat seed/restore effect).
+ *
+ * #3078 — the **REST scope** (exclude-set + focus, {@link RestoredRestScope}) is
+ * carried on BOTH decisions: it is independent of SQL routing, so the row's REST
+ * scope is restored even when the SQL scope must be seeded (an all-null /
+ * archived-group row). The caller applies the REST fields regardless of `kind`
+ * and marks the REST scope authoritative, so the seed/restore effect can't
+ * clobber it.
  */
 export type ConversationScopeDecision =
   | ({ readonly kind: "restore" } & RestoredConversationScope)
-  | { readonly kind: "seed" };
+  | ({ readonly kind: "seed" } & RestoredRestScope);
 
 /**
  * S1b (#3065) — decide how to populate the picker when a saved conversation is
  * opened. The conversation row is authoritative (precedence: row > sticky
- * preference > default seed), but ONLY when it carries a scope that still
- * resolves against the visible environments. A `restore` decision is applied
- * and marked `explicit` by the caller so the seed/restore effect can't
- * overwrite it; a `seed` decision means the caller resets to `unset` and lets
- * that effect seed the default (or restore the sticky preference) instead.
+ * preference > default seed), but ONLY when it carries an SQL scope that still
+ * resolves against the visible environments. A `restore` decision applies the
+ * SQL scope and is marked `explicit` by the caller so the seed/restore effect
+ * can't overwrite it; a `seed` decision means the caller resets the SQL scope to
+ * `unset` and lets that effect seed the default (or restore the sticky
+ * preference) instead.
+ *
+ * #3078 — the REST scope (exclude-set + focus) is **independent of SQL routing**
+ * and is therefore carried on BOTH decisions. The caller restores it and marks
+ * its own provenance `explicit` regardless of the SQL `kind`, so a row's
+ * exclude-set survives even when its SQL scope is all-null (defers to `seed`).
+ * Before #3078 the `seed` decision dropped the exclude-set and the caller
+ * cleared it; the always-sent transport array then wiped the persisted
+ * exclusions on the next turn (the data-loss bug this fixes).
  *
  * Validation against `groups` prevents two ways a verbatim restore would lie to
  * the agent (both Codex-flagged):
@@ -504,20 +568,22 @@ export function resolveConversationScope(
   const groupId = source.connectionGroupId;
   const connectionId = source.connectionId;
   const routingMode = source.routingMode ?? null;
-  // #3066 — the row's REST exclude-set, restored alongside the SQL scope.
-  // Coalesce an absent / null column to `[]` (no exclusions). Cloned so the
-  // caller owns a mutable array.
+  // #3066 — the row's REST exclude-set. Coalesce an absent / null column to `[]`
+  // (no exclusions). Cloned so the caller owns a mutable array. #3078 — carried
+  // on EVERY decision below (restore AND seed), independent of the SQL
+  // group/member validation: REST scope is not tied to SQL routing.
   const restExcludedDatasourceIds = source.restExcludedDatasourceIds
     ? [...source.restExcludedDatasourceIds]
     : [];
-  // #3067 — the row's REST-only focus, restored alongside the SQL scope (null =
-  // not focused). Carried on every `restore` decision below, independent of the
-  // SQL group/member validation.
+  // #3067 — the row's REST-only focus (null = not focused). Carried on every
+  // decision the same way as the exclude-set (#3078).
   const restFocusDatasourceId = source.restFocusDatasourceId ?? null;
 
-  // A row that persisted no scope at all is never authoritative — defer to the
-  // seed/restore effect (decided before the load gate so it holds either way).
-  if (groupId === null && connectionId === null) return { kind: "seed" };
+  // A row that persisted no SQL scope is never authoritative for routing — defer
+  // to the seed/restore effect (decided before the load gate so it holds either
+  // way). The REST scope still rides along, so an all-null-SQL conversation with
+  // an exclude-set keeps it (#3078).
+  if (groupId === null && connectionId === null) return { kind: "seed", restExcludedDatasourceIds, restFocusDatasourceId };
 
   // Groups not loaded yet (cold-start open): we can't validate, so trust the
   // row optimistically. Losing the restore here would be a worse, more common
@@ -531,7 +597,7 @@ export function resolveConversationScope(
     // The row named a content group: it must still resolve, else a stale group
     // id reaches the chat route and is rejected (invalid_connection_group).
     const group = groups.find((g) => g.id === groupId);
-    if (!group) return { kind: "seed" };
+    if (!group) return { kind: "seed", restExcludedDatasourceIds, restFocusDatasourceId };
 
     // Group resolves. Keep the pinned member if it's still present; otherwise
     // repair the execution target to the group primary (never send a stale id),
@@ -543,7 +609,7 @@ export function resolveConversationScope(
     const repaired =
       group.members.find((m) => m.connectionId === group.primaryConnectionId) ??
       group.members[0];
-    if (!repaired) return { kind: "seed" }; // group exists but has no live members
+    if (!repaired) return { kind: "seed", restExcludedDatasourceIds, restFocusDatasourceId }; // group exists but has no live members
     return { kind: "restore", groupId: group.id, connectionId: repaired.connectionId, routingMode, restExcludedDatasourceIds, restFocusDatasourceId };
   }
 
@@ -557,7 +623,7 @@ export function resolveConversationScope(
   const owningGroup = groups.find((g) =>
     g.members.some((m) => m.connectionId === connectionId),
   );
-  if (!owningGroup) return { kind: "seed" };
+  if (!owningGroup) return { kind: "seed", restExcludedDatasourceIds, restFocusDatasourceId };
   return { kind: "restore", groupId: owningGroup.id, connectionId, routingMode, restExcludedDatasourceIds, restFocusDatasourceId };
 }
 
@@ -634,56 +700,70 @@ export function ChatEnvPicker({
     activeGroup?.members.find((m) => m.connectionId === activeGroup.primaryConnectionId) ??
     activeGroup?.members[0];
 
+  // #3078 — a zero-group (REST-only) workspace has no SQL routing to display.
+  // `activeGroup` is undefined there, so the chip / dropdown drop the SQL
+  // routing modes, member list, and singleton hint and show only the REST
+  // scope. `hasSqlScope` gates every SQL affordance below.
+  const hasSqlScope = activeGroup != null;
   const mode = effectiveMode(activeRoutingMode);
   const groupLabel = activeGroup ? stripGroupPrefix(activeGroup.name) : "—";
   const memberLabel = activeMember?.connectionId ?? "—";
 
-  // Chip label tracks the picker's mode so the trigger always reflects
-  // the routing the next turn will use. The compact forms keep the
-  // chip readable when group/member names are long.
-  let chipLabel: string;
-  let ChipIcon: typeof Layers;
-  if (mode === "auto") {
-    chipLabel = `Auto · ${groupLabel}`;
-    ChipIcon = Sparkles;
-  } else if (mode === "all") {
-    chipLabel = `All · ${groupLabel}`;
-    ChipIcon = Globe2;
-  } else {
-    // Pin — show the member name. Collapse "warehouse / warehouse" →
-    // "warehouse" when the stripped group name and the member id match
-    // (the common 0062 backfill shape: g_<connId> + one member named
-    // <connId>).
-    chipLabel = groupLabel === memberLabel ? memberLabel : `${groupLabel} / ${memberLabel}`;
-    ChipIcon = Pin;
-  }
-
-  // #3066 — REST scope summary on the chip (e.g. `Pin · apac-prod · 2/3 REST`).
-  // "Relevant" = the datasources actually reachable in the active env
-  // (workspace-global + scoped to the active group); excluded ones reduce the
-  // in-scope count. Appended only when the workspace has at least one reachable
-  // REST datasource, so SQL-only workspaces keep their byte-identical chip.
+  // #3066 — REST scope summary (e.g. `2/3` in-scope of reachable). "Reachable" =
+  // the datasources actually reachable in the active env (workspace-global +
+  // scoped to the active group); excluded ones reduce the in-scope count. For a
+  // zero-group workspace `activeGroup` is null, so only workspace-global
+  // datasources are reachable — exactly the REST-only shape.
   const excludedRestSet = new Set(restExcludedDatasourceIds);
   const reachableRest = restDatasources.filter(
     (d) => d.groupId === null || d.groupId === (activeGroup?.id ?? null),
   );
   const restInScopeCount = reachableRest.filter((d) => !excludedRestSet.has(d.id)).length;
-  if (reachableRest.length > 0) {
-    chipLabel = `${chipLabel} · ${restInScopeCount}/${reachableRest.length} REST`;
-  }
 
-  // #3067 — REST-only focus overrides the chip entirely. SQL routing is
-  // suspended for a focused conversation, so the mode/env summary above is
-  // irrelevant: the chip reads "<name> only" for the datasource the agent
-  // targets. Falls back to "REST only" if the focused id isn't in the list
-  // (e.g. a datasource scoped to another env, still focusable via the resolver).
+  // #3067 — REST-only focus, looked up for the chip / dropdown summary. Falls
+  // back to "REST only" if the focused id isn't in the list (e.g. a datasource
+  // scoped to another env, still focusable via the resolver).
   const focusedDatasource = restFocusDatasourceId
     ? restDatasources.find((d) => d.id === restFocusDatasourceId)
     : undefined;
   const isFocused = restFocusDatasourceId !== null;
+
+  // Chip label. Precedence: REST-only focus (SQL suspended) > SQL routing chip
+  // (with the REST count appended) > SQL-less REST count (zero-group workspace).
+  let chipLabel: string;
+  let ChipIcon: typeof Layers;
   if (isFocused) {
+    // #3067 — focus overrides the chip entirely: SQL routing is suspended, so the
+    // chip reads "<name> only" for the datasource the agent targets.
     chipLabel = `${focusedDatasource?.displayName ?? "REST"} only`;
     ChipIcon = Crosshair;
+  } else if (hasSqlScope) {
+    // SQL routing chip — tracks the mode so the trigger reflects the next turn's
+    // routing. The compact forms keep the chip readable for long names.
+    if (mode === "auto") {
+      chipLabel = `Auto · ${groupLabel}`;
+      ChipIcon = Sparkles;
+    } else if (mode === "all") {
+      chipLabel = `All · ${groupLabel}`;
+      ChipIcon = Globe2;
+    } else {
+      // Pin — show the member name. Collapse "warehouse / warehouse" →
+      // "warehouse" when the stripped group name and the member id match (the
+      // common 0062 backfill shape: g_<connId> + one member named <connId>).
+      chipLabel = groupLabel === memberLabel ? memberLabel : `${groupLabel} / ${memberLabel}`;
+      ChipIcon = Pin;
+    }
+    // #3066 — append the REST count (e.g. `Pin · apac-prod · 2/3 REST`) only when
+    // the workspace has a reachable REST datasource, so SQL-only workspaces keep
+    // their byte-identical chip.
+    if (reachableRest.length > 0) {
+      chipLabel = `${chipLabel} · ${restInScopeCount}/${reachableRest.length} REST`;
+    }
+  } else {
+    // #3078 — zero-group (REST-only) workspace: no SQL group/member to show, so
+    // the chip is just the REST count.
+    chipLabel = `${restInScopeCount}/${reachableRest.length} REST`;
+    ChipIcon = Network;
   }
 
   // When every group has at most one member (the 0062 backfill shape,
@@ -728,10 +808,13 @@ export function ChatEnvPicker({
           data-testid="chat-env-picker-trigger"
           data-mode={mode}
           data-focused={isFocused}
+          data-sql-scope={hasSqlScope}
           aria-label={
             isFocused
               ? `Conversation scope: focused on ${chipLabel} — SQL suspended. Change.`
-              : `Cross-environment routing: ${chipLabel}. Change.`
+              : hasSqlScope
+                ? `Cross-environment routing: ${chipLabel}. Change.`
+                : `Conversation scope: ${chipLabel}. Change.`
           }
         >
           <ChipIcon className="size-3.5 text-zinc-500" aria-hidden />
@@ -743,34 +826,40 @@ export function ChatEnvPicker({
         className="w-72"
         data-testid="chat-env-picker-menu"
       >
-        {/* Mode section — three states with the current mode marked. */}
-        <DropdownMenuLabel className="text-[10px] font-semibold uppercase tracking-wider text-zinc-500 dark:text-zinc-500">
-          Routing
-        </DropdownMenuLabel>
-        <ChatEnvModeItem
-          mode="auto"
-          active={mode === "auto"}
-          icon={Sparkles}
-          title="Auto"
-          subtitle="Agent decides per turn"
-          onSelect={() => handleModeSelect("auto")}
-        />
-        <ChatEnvModeItem
-          mode="pin"
-          active={mode === "pin"}
-          icon={Pin}
-          title={`Pin to ${memberLabel}`}
-          subtitle="Lock execution to one member"
-          onSelect={() => handleModeSelect("pin")}
-        />
-        <ChatEnvModeItem
-          mode="all"
-          active={mode === "all"}
-          icon={Globe2}
-          title="All envs"
-          subtitle="Fan out to every member"
-          onSelect={() => handleModeSelect("all")}
-        />
+        {/* Mode section — three SQL-routing states with the current mode marked.
+            #3078 — hidden for a zero-group (REST-only) workspace: there is no SQL
+            to route, so the dropdown shows only the REST scope section below. */}
+        {hasSqlScope && (
+          <>
+            <DropdownMenuLabel className="text-[10px] font-semibold uppercase tracking-wider text-zinc-500 dark:text-zinc-500">
+              Routing
+            </DropdownMenuLabel>
+            <ChatEnvModeItem
+              mode="auto"
+              active={mode === "auto"}
+              icon={Sparkles}
+              title="Auto"
+              subtitle="Agent decides per turn"
+              onSelect={() => handleModeSelect("auto")}
+            />
+            <ChatEnvModeItem
+              mode="pin"
+              active={mode === "pin"}
+              icon={Pin}
+              title={`Pin to ${memberLabel}`}
+              subtitle="Lock execution to one member"
+              onSelect={() => handleModeSelect("pin")}
+            />
+            <ChatEnvModeItem
+              mode="all"
+              active={mode === "all"}
+              icon={Globe2}
+              title="All envs"
+              subtitle="Fan out to every member"
+              onSelect={() => handleModeSelect("all")}
+            />
+          </>
+        )}
 
         {activeGroup && activeMembers.length > 0 && (
           <>
@@ -828,7 +917,10 @@ export function ChatEnvPicker({
           </>
         )}
 
-        {allSingletons && (
+        {/* #3078 — the singleton hint is an SQL-connections affordance; suppress
+            it on a zero-group (REST-only) workspace, where `allSingletons` would
+            be vacuously true for the empty group list. */}
+        {hasSqlScope && allSingletons && (
           <>
             <DropdownMenuSeparator />
             <DropdownMenuLabel
@@ -852,6 +944,10 @@ export function ChatEnvPicker({
           focusedId={restFocusDatasourceId}
           focusedDatasource={focusedDatasource}
           onRestFocusChange={onRestFocusChange}
+          // #3078 — when there's an SQL routing section above, lead with a
+          // separator; on a zero-group workspace the REST section is first, so
+          // suppress the leading separator (no dangling rule at the top).
+          precededBySection={hasSqlScope}
         />
       </DropdownMenuContent>
     </DropdownMenu>
@@ -877,6 +973,7 @@ function ChatEnvRestScopeSection({
   focusedId,
   focusedDatasource,
   onRestFocusChange,
+  precededBySection = true,
 }: {
   restDatasources: ReadonlyArray<ChatRestDatasourceScope>;
   activeGroupId: string | null;
@@ -888,6 +985,14 @@ function ChatEnvRestScopeSection({
   focusedDatasource?: ChatRestDatasourceScope;
   /** #3067 — focus a datasource (`install_id`) or clear focus (`null`). */
   onRestFocusChange?: (next: string | null) => void;
+  /**
+   * #3078 — whether an SQL routing section renders above this one. When true the
+   * REST section leads with a separator (divides it from the SQL section); when
+   * false (a zero-group REST-only workspace) the REST section is the first
+   * dropdown content, so the leading separator is suppressed. Defaults to true
+   * for back-compat with callers that always render the SQL section.
+   */
+  precededBySection?: boolean;
 }): React.ReactElement | null {
   if (restDatasources.length === 0) return null;
 
@@ -897,7 +1002,7 @@ function ChatEnvRestScopeSection({
   if (focusedId !== null) {
     return (
       <>
-        <DropdownMenuSeparator />
+        {precededBySection && <DropdownMenuSeparator />}
         <DropdownMenuLabel className="text-[10px] font-semibold uppercase tracking-wider text-zinc-500 dark:text-zinc-500">
           REST-only focus
         </DropdownMenuLabel>
@@ -983,7 +1088,7 @@ function ChatEnvRestScopeSection({
 
   return (
     <>
-      <DropdownMenuSeparator />
+      {precededBySection && <DropdownMenuSeparator />}
       <DropdownMenuLabel className="text-[10px] font-semibold uppercase tracking-wider text-zinc-500 dark:text-zinc-500">
         REST datasources
       </DropdownMenuLabel>

--- a/packages/web/src/ui/components/chat/env-picker.tsx
+++ b/packages/web/src/ui/components/chat/env-picker.tsx
@@ -314,6 +314,15 @@ export interface ResolveEnvSelectionInput {
   readonly preferenceHydrated: boolean;
   /** The auth session has resolved, so {@link activeWorkspaceId} is final. */
   readonly sessionResolved: boolean;
+  /**
+   * #3078 — a `/me/connection-groups` fetch has settled at least once, so an
+   * empty `groups` is a genuine zero-group (REST-only) workspace rather than a
+   * not-yet-loaded cold start. Gates the REST-only seed/restore path: with no
+   * SQL groups there's nothing to seed for SQL, but the sticky REST preference
+   * should still seed a fresh chat (per ADR-0011). Until the fetch settles, the
+   * resolver waits rather than seeding against a transiently-empty list.
+   */
+  readonly groupsLoaded: boolean;
 }
 
 /**
@@ -326,8 +335,13 @@ export type EnvSelectionDecision =
   | { readonly kind: "noop" }
   | {
       readonly kind: "restore";
-      readonly groupId: string;
-      readonly connectionId: string;
+      /**
+       * The restored SQL scope. Non-null for a normal (with-groups) restore.
+       * #3078 — `null` for a zero-group (REST-only) workspace restore, where
+       * there is no SQL group/member and only the REST scope is seeded.
+       */
+      readonly groupId: string | null;
+      readonly connectionId: string | null;
       readonly routingMode: ConversationRoutingMode | null;
       /** #3066 — the sticky preference's exclude-set to seed onto this fresh chat. */
       readonly restExcludedDatasourceIds: string[];
@@ -362,6 +376,13 @@ export type EnvSelectionDecision =
  *      previously default-seeded selection is restored over as soon as a
  *      matching preference arrives; an unmatched preference falls back to
  *      the group-primary default seed.
+ *
+ * #3078 — **zero-group (REST-only) workspace.** When `groups` is *loaded-empty*
+ * (`groupsLoaded` true) there is no SQL to seed, but the sticky REST preference
+ * still seeds a fresh chat: the resolver restores the workspace-matching
+ * preference's exclude-set / focus with a null SQL scope. Until the fetch
+ * settles it waits (so it never seeds against a transiently-empty list), and an
+ * explicit SQL/REST scope is left untouched.
  */
 export function resolveEnvSelection(
   input: ResolveEnvSelectionInput,
@@ -375,6 +396,7 @@ export function resolveEnvSelection(
     activeWorkspaceId,
     preferenceHydrated,
     sessionResolved,
+    groupsLoaded,
   } = input;
 
   // #3078 — when the REST scope is authoritative (conversation-open restore, or
@@ -384,10 +406,46 @@ export function resolveEnvSelection(
   // fixes the all-null-SQL exclude-set data loss.
   const restExplicit = restProvenance === "explicit";
 
-  // 1. Gate — wait until every input we need to choose correctly is ready.
-  if (groups.length === 0) return { kind: "wait" };
+  // 1. Gate — wait until the inputs we need to choose correctly are ready.
+  // (Group readiness is handled per-branch below: a *loaded-empty* group list is
+  // a real zero-group workspace, not a cold start, so it must not block forever.)
   if (!preferenceHydrated) return { kind: "wait" };
   if (!sessionResolved) return { kind: "wait" };
+
+  // #3078 — zero-group (REST-only) workspace. There's no SQL to seed/restore, but
+  // the sticky REST preference should still seed a fresh chat (ADR-0011). Wait
+  // until a fetch has settled so we don't seed against a transiently-empty list;
+  // then run a REST-only restore (SQL stays null).
+  if (groups.length === 0) {
+    if (!groupsLoaded) return { kind: "wait" };
+    // An explicit selection (user pick / conversation restore) is authoritative,
+    // and an explicit REST scope must not be clobbered — leave both alone.
+    if (provenance === "explicit" || restExplicit) return { kind: "noop" };
+    // Restore the workspace-matching preference's REST scope; another workspace's
+    // preference is ignored (ids can collide). SQL scope stays null (no groups).
+    const prefMatchesWorkspace = preference.workspaceId === activeWorkspaceId;
+    const nextRestExcluded = prefMatchesWorkspace
+      ? [...(preference.restExcludedDatasourceIds ?? [])]
+      : [];
+    const nextRestFocus = prefMatchesWorkspace
+      ? preference.restFocusDatasourceId ?? null
+      : null;
+    // Already on the target REST scope — don't churn (and don't loop).
+    if (
+      sameExcludeSet(current.restExcludedDatasourceIds ?? [], nextRestExcluded) &&
+      (current.restFocusDatasourceId ?? null) === nextRestFocus
+    ) {
+      return { kind: "noop" };
+    }
+    return {
+      kind: "restore",
+      groupId: null,
+      connectionId: null,
+      routingMode: null,
+      restExcludedDatasourceIds: nextRestExcluded,
+      restFocusDatasourceId: nextRestFocus,
+    };
+  }
 
   // 2. An explicit pick (or conversation-restored value) is authoritative.
   // (When SQL is explicit the REST scope is already settled too, so there is no
@@ -710,14 +768,15 @@ export function ChatEnvPicker({
   const memberLabel = activeMember?.connectionId ?? "—";
 
   // #3066 — REST scope summary (e.g. `2/3` in-scope of reachable). "Reachable" =
-  // the datasources actually reachable in the active env (workspace-global +
-  // scoped to the active group); excluded ones reduce the in-scope count. For a
-  // zero-group workspace `activeGroup` is null, so only workspace-global
-  // datasources are reachable — exactly the REST-only shape.
+  // the datasources actually reachable in scope; excluded ones reduce the
+  // in-scope count. With an active group it's workspace-global + datasources
+  // scoped to that group. #3078 — on a zero-group (REST-only) workspace there's
+  // no SQL env to scope against, so EVERY REST datasource is reachable (else a
+  // group-scoped install would show "0/0 REST" with no toggle).
   const excludedRestSet = new Set(restExcludedDatasourceIds);
-  const reachableRest = restDatasources.filter(
-    (d) => d.groupId === null || d.groupId === (activeGroup?.id ?? null),
-  );
+  const reachableRest = hasSqlScope
+    ? restDatasources.filter((d) => d.groupId === null || d.groupId === activeGroup?.id)
+    : restDatasources;
   const restInScopeCount = reachableRest.filter((d) => !excludedRestSet.has(d.id)).length;
 
   // #3067 — REST-only focus, looked up for the chip / dropdown summary. Falls
@@ -939,15 +998,12 @@ export function ChatEnvPicker({
         <ChatEnvRestScopeSection
           restDatasources={restDatasources}
           activeGroupId={activeGroup?.id ?? null}
+          hasSqlScope={hasSqlScope}
           excludedIds={restExcludedDatasourceIds}
           onRestExcludedChange={onRestExcludedChange}
           focusedId={restFocusDatasourceId}
           focusedDatasource={focusedDatasource}
           onRestFocusChange={onRestFocusChange}
-          // #3078 — when there's an SQL routing section above, lead with a
-          // separator; on a zero-group workspace the REST section is first, so
-          // suppress the leading separator (no dangling rule at the top).
-          precededBySection={hasSqlScope}
         />
       </DropdownMenuContent>
     </DropdownMenu>
@@ -968,15 +1024,25 @@ export function ChatEnvPicker({
 function ChatEnvRestScopeSection({
   restDatasources,
   activeGroupId,
+  hasSqlScope = true,
   excludedIds,
   onRestExcludedChange,
   focusedId,
   focusedDatasource,
   onRestFocusChange,
-  precededBySection = true,
 }: {
   restDatasources: ReadonlyArray<ChatRestDatasourceScope>;
   activeGroupId: string | null;
+  /**
+   * #3078 — whether the workspace has an active SQL scope (a connection group).
+   * `false` for a zero-group REST-only workspace. Drives two things: (1) the
+   * leading separator is suppressed when false (the REST section is the first
+   * dropdown content, so no dangling rule); (2) when false there is no SQL env
+   * to scope against, so EVERY REST datasource is reachable (toggleable /
+   * focusable) rather than partitioned by `activeGroupId`. Defaults to true for
+   * back-compat with callers that always render the SQL section.
+   */
+  hasSqlScope?: boolean;
   excludedIds: ReadonlyArray<string>;
   onRestExcludedChange?: (next: string[]) => void;
   /** #3067 — the focused datasource id, or null = not focused. */
@@ -985,14 +1051,6 @@ function ChatEnvRestScopeSection({
   focusedDatasource?: ChatRestDatasourceScope;
   /** #3067 — focus a datasource (`install_id`) or clear focus (`null`). */
   onRestFocusChange?: (next: string | null) => void;
-  /**
-   * #3078 — whether an SQL routing section renders above this one. When true the
-   * REST section leads with a separator (divides it from the SQL section); when
-   * false (a zero-group REST-only workspace) the REST section is the first
-   * dropdown content, so the leading separator is suppressed. Defaults to true
-   * for back-compat with callers that always render the SQL section.
-   */
-  precededBySection?: boolean;
 }): React.ReactElement | null {
   if (restDatasources.length === 0) return null;
 
@@ -1002,7 +1060,7 @@ function ChatEnvRestScopeSection({
   if (focusedId !== null) {
     return (
       <>
-        {precededBySection && <DropdownMenuSeparator />}
+        {hasSqlScope && <DropdownMenuSeparator />}
         <DropdownMenuLabel className="text-[10px] font-semibold uppercase tracking-wider text-zinc-500 dark:text-zinc-500">
           REST-only focus
         </DropdownMenuLabel>
@@ -1039,15 +1097,21 @@ function ChatEnvRestScopeSection({
   }
 
   const workspaceGlobal = restDatasources.filter((d) => d.groupId === null);
+  // #3078 — group-scoped datasources reachable in the current scope. With an
+  // active SQL group, that's the ones scoped to it; on a zero-group REST-only
+  // workspace there's no env to scope against, so ALL group-scoped installs are
+  // reachable (otherwise they'd be unreachable with no SQL group to match).
   const inActiveGroup = restDatasources.filter(
-    (d) => d.groupId !== null && d.groupId === activeGroupId,
+    (d) => d.groupId !== null && (!hasSqlScope || d.groupId === activeGroupId),
   );
-  const otherScoped = restDatasources.filter(
-    (d) => d.groupId !== null && d.groupId !== activeGroupId,
-  );
-  // #3067 — the datasources reachable in the active env are the ones a user can
-  // focus (workspace-global + scoped to the active group), mirroring the exclude
-  // checkboxes. A datasource scoped to another env stays informational.
+  // Out of scope only exists when there IS an SQL env to be "other" than; a
+  // zero-group workspace has no other environments.
+  const otherScoped = hasSqlScope
+    ? restDatasources.filter((d) => d.groupId !== null && d.groupId !== activeGroupId)
+    : [];
+  // #3067 — the datasources reachable in the current scope are the ones a user
+  // can focus (workspace-global + the reachable scoped ones), mirroring the
+  // exclude checkboxes. A datasource scoped to another env stays informational.
   const focusable = [...workspaceGlobal, ...inActiveGroup];
 
   const excludedSet = new Set(excludedIds);
@@ -1088,7 +1152,7 @@ function ChatEnvRestScopeSection({
 
   return (
     <>
-      {precededBySection && <DropdownMenuSeparator />}
+      {hasSqlScope && <DropdownMenuSeparator />}
       <DropdownMenuLabel className="text-[10px] font-semibold uppercase tracking-wider text-zinc-500 dark:text-zinc-500">
         REST datasources
       </DropdownMenuLabel>
@@ -1105,7 +1169,9 @@ function ChatEnvRestScopeSection({
       {inActiveGroup.length > 0 && (
         <div data-testid="chat-env-picker-rest-in-scope">
           <DropdownMenuLabel className="px-2 pb-0.5 pt-1 text-[10px] font-normal text-zinc-400 dark:text-zinc-500">
-            In this environment
+            {/* #3078 — "this environment" only reads right when there IS an SQL
+                env; a zero-group workspace just has in-scope datasources. */}
+            {hasSqlScope ? "In this environment" : "In scope"}
           </DropdownMenuLabel>
           {inActiveGroup.map((d) => renderRow(d, { global: false }))}
         </div>
@@ -1251,6 +1317,14 @@ export interface UseChatEnvGroupsResult {
   readonly restDatasources: ReadonlyArray<ChatRestDatasourceScope>;
   readonly reason: MeConnectionGroupsEmptyReason | null;
   readonly loading: boolean;
+  /**
+   * #3078 — `true` once a fetch has settled (success or error) at least once,
+   * so a consumer can tell "groups loaded and are genuinely empty" (a zero-group
+   * REST-only workspace) from "groups not fetched yet" (cold start). The seed/
+   * restore effect needs this to seed the sticky REST preference on a fresh chat
+   * in a zero-group workspace without racing the in-flight fetch.
+   */
+  readonly hasLoaded: boolean;
   readonly error: string | null;
 }
 
@@ -1270,6 +1344,8 @@ export function useChatEnvGroups(
   >([]);
   const [reason, setReason] = useState<MeConnectionGroupsEmptyReason | null>(null);
   const [loading, setLoading] = useState(false);
+  // #3078 — flips true once the first fetch settles (see UseChatEnvGroupsResult).
+  const [hasLoaded, setHasLoaded] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -1322,12 +1398,17 @@ export function useChatEnvGroups(
         }
       })
       .finally(() => {
-        if (!cancelled) setLoading(false);
+        if (!cancelled) {
+          setLoading(false);
+          // #3078 — a fetch has now settled; the empty state (if any) is real,
+          // not a not-yet-loaded one.
+          setHasLoaded(true);
+        }
       });
     return () => {
       cancelled = true;
     };
   }, [opts.apiUrl, opts.enabled, opts.getHeaders, opts.getCredentials]);
 
-  return { groups, restDatasources, reason, loading, error };
+  return { groups, restDatasources, reason, loading, hasLoaded, error };
 }


### PR DESCRIPTION
## Summary
Last REST-scope slice of v0.0.4 (follows S2a #3066/#3077, S2b #3067/#3079). Fixes the two linked Codex findings deferred from S2a.

**Problem 1 — zero-group (REST-only) workspaces couldn't reach the exclude/focus toggles.**
- `shouldRenderEnvPicker` now renders on `groups: []` when there are REST datasources (was: only on a diagnostic reason / transport error).
- `ChatEnvPicker` gains a **SQL-less render path** (gated by `hasSqlScope = activeGroup != null`): the chip shows just the REST count (`2/3 REST`) with no SQL group/member prefix, and the dropdown drops the Auto/Pin/All routing modes, member list, and singleton hint — showing only the REST scope section. The leading separator is suppressed when the REST section is the first content.

**Problem 2 — the exclude-set was lost when the SQL scope was all-null (DATA LOSS).**
- The REST scope (exclude-set + REST-only focus) now has its **own provenance**, decoupled from the SQL-scope provenance:
  - `resolveConversationScope` carries the REST scope on the **`seed`** decision too (not just `restore`) — REST is independent of SQL routing.
  - `resolveEnvSelection` gains a required `restProvenance`; when it's `"explicit"` it **passes the current REST scope through** any SQL seed/restore instead of clobbering it with the default-empty set / sticky preference (the no-churn guard shares the passthrough values, so no effect loop).
  - `atlas-chat` adds `restScopeProvenanceRef`: opening a conversation restores the row's REST scope and marks it explicit regardless of the SQL decision; a REST toggle marks it explicit; `handleNewChat` resets it.
- Before this, opening a conversation with a non-empty exclude-set + all-null SQL returned `seed`, the handler cleared the exclusions, and the always-sent transport array then wiped the persisted set on the next turn.

**page.tsx (primary workspace chat).** That surface's `<ChatEnvPicker>` is SQL-routing-only (never passed `restDatasources`/exclude/focus props). #3066 had fed `restDatasources` to its outer `shouldRenderEnvPicker` flag only, leaving a latent **empty bordered row** for 1×1+REST / zero-group workspaces. Dropped `restDatasources` from that call so the flag mirrors the SQL-only inner picker. Wiring full REST scope into this surface (or migrating it to `<AtlasChat>`) is tracked in **#3081**.

## Test plan
- [x] TDD: failing regression test first for problem #2, then green.
- [x] `resolveConversationScope` — carries the exclude-set / focus on a `seed` (all-null SQL, archived group); existing `seed` shapes updated.
- [x] `resolveEnvSelection` — `restProvenance: "explicit"` passes the current REST scope through on both SQL **seed** and SQL **restore**; no-churn guards on both the early-return and the restore-branch paths (loop prevention); focus passthrough symmetric to exclude-set.
- [x] `ChatEnvPicker` — zero-group + REST renders, chip shows REST count (no `—` placeholder), exclusions settable, no SQL routing section / singleton hint, REST-only focus works (pairs with #3067).
- [x] `shouldRenderEnvPicker` truth table updated (zero-group + REST → renders).
- [x] `bun run test` (full, exit 0) · web suite 171/171 · env-picker 114/114 · `bun run type` 0 · `bun run lint` 0 · syncpack · template-drift · railway-watch — all green.
- [x] In-house review (code-reviewer, type-design-analyzer, pr-test-analyzer): no blocking issues; adopted the type-consolidation (`RestoredConversationScope extends RestoredRestScope`), required `restProvenance`, and the restore-branch loop-guard + focus-passthrough tests.

## Notes for reviewers
- No schema / wire / `@useatlas/types` changes — purely frontend (consumes the S2a/S2b row columns already on `Conversation`). REST scope is unreleased (no tag), so docs land at `/release v0.0.4`.
- Effect-loop safety is the highest-risk area: `resolveEnvSelection` runs in a `useEffect` with the REST state in its deps; the passthrough values are shared between the no-churn guard and the returned decision so it always settles in ≤2 runs.

Closes #3078

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3082"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782936870&installation_id=135337507&pr_number=3082&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3082&signature=e190c17ec58e2673300b5ca335e3805ae04fec2f5c5a3cf7d3d53da47b30db9d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Environment picker now supports zero-group (REST-only) workspaces and shows REST counts and controls.
  * REST-only controls (mode selectors, exclude/focus) behave independently when SQL routing is absent.

* **Bug Fixes**
  * REST datasource exclusions and focus persist across conversation restore/seed and are no longer overwritten by SQL routing changes.
  * Picker visibility and wording now correctly reflect REST-only scenarios and loading state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->