### PR TITLE
feat(web): persist active conversation in the URL (#3068)

### DIFF
--- a/packages/web/src/ui/__tests__/conversation-url-open.test.tsx
+++ b/packages/web/src/ui/__tests__/conversation-url-open.test.tsx
@@ -1,0 +1,126 @@
+import { describe, it, expect, mock, afterEach } from "bun:test";
+import { render, waitFor, cleanup, fireEvent } from "@testing-library/react";
+import { createElement, useEffect, useRef, type ReactNode } from "react";
+import { useQueryStates } from "nuqs";
+import { NuqsTestingAdapter, type UrlUpdateEvent } from "nuqs/adapters/testing";
+import {
+  chatSearchParams,
+  resolveConversationUrlAction,
+} from "../components/search-params";
+
+/**
+ * Integration coverage for #3068: the conversation lives in the URL (`?id=`).
+ * These drive the REAL `chatSearchParams` parser + `resolveConversationUrlAction`
+ * through a real nuqs adapter, so a deep link / reload opens the conversation and
+ * a navigation writes the URL — the wiring `AtlasChat`'s URL-driven effect relies
+ * on, without mounting the whole chat. The harness effect mirrors that effect
+ * verbatim (open on a settled id, clear on an emptied one).
+ */
+function Harness(props: {
+  authResolved: boolean;
+  isSignedIn: boolean;
+  envGroupsHasLoaded: boolean;
+  onOpen: (id: string) => void;
+  onClear: () => void;
+}) {
+  const [params, setParams] = useQueryStates(chatSearchParams);
+  const openedRef = useRef<string | null>(null);
+  const onOpenRef = useRef(props.onOpen);
+  onOpenRef.current = props.onOpen;
+  const onClearRef = useRef(props.onClear);
+  onClearRef.current = props.onClear;
+  useEffect(() => {
+    const action = resolveConversationUrlAction({
+      urlId: params.id,
+      loadedId: openedRef.current,
+      authResolved: props.authResolved,
+      isSignedIn: props.isSignedIn,
+      envGroupsHasLoaded: props.envGroupsHasLoaded,
+    });
+    if (action.kind === "open") {
+      openedRef.current = action.id;
+      onOpenRef.current(action.id);
+    } else if (action.kind === "clear") {
+      openedRef.current = null;
+      onClearRef.current();
+    }
+  }, [params.id, props.authResolved, props.isSignedIn, props.envGroupsHasLoaded]);
+  return createElement(
+    "button",
+    { onClick: () => void setParams({ id: "conv-2" }, { history: "push" }) },
+    "go",
+  );
+}
+
+function wrapper(
+  searchParams: Record<string, string>,
+  onUrlUpdate?: (e: UrlUpdateEvent) => void,
+) {
+  return ({ children }: { children: ReactNode }) =>
+    createElement(
+      NuqsTestingAdapter,
+      { searchParams, onUrlUpdate, hasMemory: true },
+      children,
+    );
+}
+
+afterEach(() => cleanup());
+
+describe("conversation URL open/navigate (#3068)", () => {
+  it("opens the conversation named in ?id= on mount (deep link / reload)", async () => {
+    const onOpen = mock((_id: string) => {});
+    render(
+      createElement(Harness, {
+        authResolved: true,
+        // self-hosted: no groups fetch to wait on — must still open.
+        isSignedIn: false,
+        envGroupsHasLoaded: false,
+        onOpen,
+        onClear: () => {},
+      }),
+      { wrapper: wrapper({ id: "conv-1" }) },
+    );
+    await waitFor(() => expect(onOpen).toHaveBeenCalledWith("conv-1"));
+  });
+
+  it("reflects a navigation in the URL and opens the new conversation", async () => {
+    const onOpen = mock((_id: string) => {});
+    const onUrlUpdate = mock((_e: UrlUpdateEvent) => {});
+    const { getByText } = render(
+      createElement(Harness, {
+        authResolved: true,
+        isSignedIn: true,
+        envGroupsHasLoaded: true,
+        onOpen,
+        onClear: () => {},
+      }),
+      { wrapper: wrapper({}, onUrlUpdate) },
+    );
+    fireEvent.click(getByText("go"));
+    await waitFor(() =>
+      expect(onUrlUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          queryString: expect.stringContaining("id=conv-2"),
+        }),
+      ),
+    );
+    await waitFor(() => expect(onOpen).toHaveBeenCalledWith("conv-2"));
+  });
+
+  it("does not open while a signed-in user's groups fetch is still pending", async () => {
+    const onOpen = mock((_id: string) => {});
+    render(
+      createElement(Harness, {
+        authResolved: true,
+        isSignedIn: true,
+        envGroupsHasLoaded: false,
+        onOpen,
+        onClear: () => {},
+      }),
+      { wrapper: wrapper({ id: "conv-1" }) },
+    );
+    // Give the effect a tick; it must stay in "noop" until groups settle.
+    await new Promise((r) => setTimeout(r, 20));
+    expect(onOpen).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/ui/__tests__/conversation-url-open.test.tsx
+++ b/packages/web/src/ui/__tests__/conversation-url-open.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, mock, afterEach } from "bun:test";
 import { render, waitFor, cleanup, fireEvent } from "@testing-library/react";
-import { createElement, useEffect, useRef, type ReactNode } from "react";
+import { createElement, useEffect, useRef, useState, type ReactNode } from "react";
 import { useQueryStates } from "nuqs";
 import { NuqsTestingAdapter, type UrlUpdateEvent } from "nuqs/adapters/testing";
 import {
@@ -17,7 +17,7 @@ import {
  * verbatim (open on a settled id, clear on an emptied one).
  */
 function Harness(props: {
-  authResolved: boolean;
+  authSettled: boolean;
   isSignedIn: boolean;
   envGroupsHasLoaded: boolean;
   onOpen: (id: string) => void;
@@ -33,7 +33,7 @@ function Harness(props: {
     const action = resolveConversationUrlAction({
       urlId: params.id,
       loadedId: openedRef.current,
-      authResolved: props.authResolved,
+      authSettled: props.authSettled,
       isSignedIn: props.isSignedIn,
       envGroupsHasLoaded: props.envGroupsHasLoaded,
     });
@@ -44,10 +44,66 @@ function Harness(props: {
       openedRef.current = null;
       onClearRef.current();
     }
-  }, [params.id, props.authResolved, props.isSignedIn, props.envGroupsHasLoaded]);
+  }, [params.id, props.authSettled, props.isSignedIn, props.envGroupsHasLoaded]);
   return createElement(
     "button",
     { onClick: () => void setParams({ id: "conv-2" }, { history: "push" }) },
+    "go",
+  );
+}
+
+/**
+ * A fuller harness modelling handleSelectConversation's async load lifecycle —
+ * the in-flight guard, the up-front "latest requested" record + URL write, and
+ * the post-await stale bail — plus the URL-driven effect with `loading` in its
+ * deps. It lets the concurrent-navigation race be exercised end to end: `load`
+ * is the injected (controllable) fetch; `onCommitted` fires only for a load that
+ * is actually applied (i.e. not bailed as stale).
+ */
+function AsyncHarness(props: {
+  load: (id: string) => Promise<void>;
+  onCommitted: (id: string) => void;
+}) {
+  const [params, setParams] = useQueryStates(chatSearchParams);
+  const openedRef = useRef<string | null>(null);
+  const latestRef = useRef<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const loadRef = useRef(props.load);
+  loadRef.current = props.load;
+  const committedRef = useRef(props.onCommitted);
+  committedRef.current = props.onCommitted;
+
+  async function select(id: string) {
+    latestRef.current = id; // record intent up front (before the guard)
+    void setParams({ id }, { history: "push" }); // reflect it in the URL
+    if (loading) return; // defer while a load is in flight
+    openedRef.current = id;
+    setLoading(true);
+    try {
+      await loadRef.current(id);
+      if (latestRef.current !== id) return; // stale — a newer navigation won
+      committedRef.current(id);
+    } finally {
+      setLoading(false);
+    }
+  }
+  const selectRef = useRef(select);
+  selectRef.current = select;
+
+  useEffect(() => {
+    const action = resolveConversationUrlAction({
+      urlId: params.id,
+      loadedId: openedRef.current,
+      authSettled: true,
+      isSignedIn: false,
+      envGroupsHasLoaded: false,
+    });
+    if (action.kind === "open") void selectRef.current(action.id);
+  }, [params.id, loading]);
+
+  return createElement(
+    "button",
+    { onClick: () => void selectRef.current("conv-2") },
     "go",
   );
 }
@@ -71,7 +127,7 @@ describe("conversation URL open/navigate (#3068)", () => {
     const onOpen = mock((_id: string) => {});
     render(
       createElement(Harness, {
-        authResolved: true,
+        authSettled: true,
         // self-hosted: no groups fetch to wait on — must still open.
         isSignedIn: false,
         envGroupsHasLoaded: false,
@@ -88,7 +144,7 @@ describe("conversation URL open/navigate (#3068)", () => {
     const onUrlUpdate = mock((_e: UrlUpdateEvent) => {});
     const { getByText } = render(
       createElement(Harness, {
-        authResolved: true,
+        authSettled: true,
         isSignedIn: true,
         envGroupsHasLoaded: true,
         onOpen,
@@ -111,7 +167,7 @@ describe("conversation URL open/navigate (#3068)", () => {
     const onOpen = mock((_id: string) => {});
     render(
       createElement(Harness, {
-        authResolved: true,
+        authSettled: true,
         isSignedIn: true,
         envGroupsHasLoaded: false,
         onOpen,
@@ -122,5 +178,28 @@ describe("conversation URL open/navigate (#3068)", () => {
     // Give the effect a tick; it must stay in "noop" until groups settle.
     await new Promise((r) => setTimeout(r, 20));
     expect(onOpen).not.toHaveBeenCalled();
+  });
+
+  it("commits only the latest conversation when a newer ?id= arrives mid-load", async () => {
+    // Regression guard for the concurrent-nav race (both bots): deep-link conv-1
+    // with a load that hangs, navigate to conv-2 while it's in flight, then let
+    // conv-1 resolve. The stale conv-1 result must be discarded and only conv-2
+    // committed — exercising the in-flight defer, the `loading`-dep re-drive,
+    // and the post-await stale bail together. Drop any one and this fails.
+    let resolveFirst: () => void = () => {};
+    const firstLoad = new Promise<void>((res) => {
+      resolveFirst = res;
+    });
+    const committed = mock((_id: string) => {});
+    const load = (id: string) =>
+      id === "conv-1" ? firstLoad : Promise.resolve();
+    const { getByText } = render(
+      createElement(AsyncHarness, { load, onCommitted: committed }),
+      { wrapper: wrapper({ id: "conv-1" }) },
+    );
+    fireEvent.click(getByText("go")); // navigate to conv-2 mid-load
+    resolveFirst(); // conv-1's load resolves late — must bail as stale
+    await waitFor(() => expect(committed).toHaveBeenCalledWith("conv-2"));
+    expect(committed).not.toHaveBeenCalledWith("conv-1");
   });
 });

--- a/packages/web/src/ui/__tests__/conversation-url.test.ts
+++ b/packages/web/src/ui/__tests__/conversation-url.test.ts
@@ -19,7 +19,7 @@ function input(overrides: Partial<ConversationUrlInput> = {}): ConversationUrlIn
   return {
     urlId: "",
     loadedId: null,
-    authResolved: true,
+    authSettled: true,
     isSignedIn: true,
     envGroupsHasLoaded: true,
     ...overrides,
@@ -27,9 +27,9 @@ function input(overrides: Partial<ConversationUrlInput> = {}): ConversationUrlIn
 }
 
 describe("resolveConversationUrlAction", () => {
-  it("waits until auth has resolved", () => {
+  it("waits until auth is settled", () => {
     expect(
-      resolveConversationUrlAction(input({ urlId: "conv-1", authResolved: false })),
+      resolveConversationUrlAction(input({ urlId: "conv-1", authSettled: false })),
     ).toEqual({ kind: "noop" });
   });
 

--- a/packages/web/src/ui/__tests__/conversation-url.test.ts
+++ b/packages/web/src/ui/__tests__/conversation-url.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from "bun:test";
+import {
+  resolveConversationUrlAction,
+  type ConversationUrlInput,
+} from "../components/search-params";
+
+/**
+ * `resolveConversationUrlAction` is the pure decision behind AtlasChat's
+ * URL-driven conversation-open effect (#3068). It maps the current `?id=`
+ * value (plus auth/groups readiness) to open / clear / noop.
+ *
+ * The branch that matters most: a signed-in managed user must WAIT for the
+ * connection-groups fetch to settle (so #3065 scope restore validates against
+ * real groups), but a self-hosted / simple-key deploy NEVER fetches groups —
+ * gating on `envGroupsHasLoaded` there would leave a deep-linked conversation
+ * permanently unopened.
+ */
+function input(overrides: Partial<ConversationUrlInput> = {}): ConversationUrlInput {
+  return {
+    urlId: "",
+    loadedId: null,
+    authResolved: true,
+    isSignedIn: true,
+    envGroupsHasLoaded: true,
+    ...overrides,
+  };
+}
+
+describe("resolveConversationUrlAction", () => {
+  it("waits until auth has resolved", () => {
+    expect(
+      resolveConversationUrlAction(input({ urlId: "conv-1", authResolved: false })),
+    ).toEqual({ kind: "noop" });
+  });
+
+  it("does nothing for an empty URL on a fresh chat", () => {
+    expect(resolveConversationUrlAction(input({ urlId: "", loadedId: null }))).toEqual({
+      kind: "noop",
+    });
+  });
+
+  it("clears when the URL empties but a conversation is loaded (back-nav to empty)", () => {
+    expect(
+      resolveConversationUrlAction(input({ urlId: "", loadedId: "conv-1" })),
+    ).toEqual({ kind: "clear" });
+  });
+
+  it("does nothing when the URL already names the loaded conversation", () => {
+    expect(
+      resolveConversationUrlAction(input({ urlId: "conv-1", loadedId: "conv-1" })),
+    ).toEqual({ kind: "noop" });
+  });
+
+  it("opens a deep-linked conversation once groups have settled (signed in)", () => {
+    expect(
+      resolveConversationUrlAction(
+        input({
+          urlId: "conv-1",
+          loadedId: null,
+          isSignedIn: true,
+          envGroupsHasLoaded: true,
+        }),
+      ),
+    ).toEqual({ kind: "open", id: "conv-1" });
+  });
+
+  it("waits for the groups fetch to settle before opening (signed in)", () => {
+    expect(
+      resolveConversationUrlAction(
+        input({
+          urlId: "conv-1",
+          loadedId: null,
+          isSignedIn: true,
+          envGroupsHasLoaded: false,
+        }),
+      ),
+    ).toEqual({ kind: "noop" });
+  });
+
+  it("opens immediately on self-hosted / simple-key (no groups fetch to wait on)", () => {
+    // The connection-groups query is disabled when not signed in, so its
+    // `hasLoaded` never flips. Gating on it would strand the deep link forever.
+    expect(
+      resolveConversationUrlAction(
+        input({
+          urlId: "conv-1",
+          loadedId: null,
+          isSignedIn: false,
+          envGroupsHasLoaded: false,
+        }),
+      ),
+    ).toEqual({ kind: "open", id: "conv-1" });
+  });
+
+  it("opens a different conversation on back/forward navigation", () => {
+    expect(
+      resolveConversationUrlAction(
+        input({ urlId: "conv-2", loadedId: "conv-1", envGroupsHasLoaded: true }),
+      ),
+    ).toEqual({ kind: "open", id: "conv-2" });
+  });
+
+  it("still waits for groups when switching conversations while signed in", () => {
+    expect(
+      resolveConversationUrlAction(
+        input({
+          urlId: "conv-2",
+          loadedId: "conv-1",
+          isSignedIn: true,
+          envGroupsHasLoaded: false,
+        }),
+      ),
+    ).toEqual({ kind: "noop" });
+  });
+});

--- a/packages/web/src/ui/components/atlas-chat.tsx
+++ b/packages/web/src/ui/components/atlas-chat.tsx
@@ -3,6 +3,7 @@
 import { useChat } from "@ai-sdk/react";
 import { isToolUIPart, getToolName } from "ai";
 import { useState, useRef, useEffect, useCallback } from "react";
+import { useQueryStates } from "nuqs";
 import { useQueryClient } from "@tanstack/react-query";
 import type { PythonProgressData } from "./chat/python-result-card";
 import { useAtlasConfig } from "../context";
@@ -47,6 +48,7 @@ import { parseSuggestions } from "../lib/helpers";
 import { ErrorBoundary } from "./error-boundary";
 import { useUiStore } from "@/lib/stores/ui-store";
 import { useChatRoutingPreferenceStore } from "@/lib/stores/chat-routing-preference-store";
+import { chatSearchParams, resolveConversationUrlAction } from "./search-params";
 
 /* Static SVG icons — hoisted to avoid recreation on every render */
 const MenuIcon = (
@@ -111,7 +113,27 @@ export function AtlasChat() {
   // letting the agent fail with a confusing "no datasource" error.
   const showDevChatEmpty = useDevModeNoDrafts(["connections"]);
   const [input, setInput] = useState("");
-  const [conversationId, setConversationId] = useState<string | null>(null);
+  // #3068 — the active conversation lives in the URL (`?id=`) so a reload or a
+  // deep link reopens it (combined with #3065 the conversation's scope comes
+  // back too). nuqs-backed; `conversationId` keeps the same string|null shape
+  // every existing call site already expects.
+  const [chatUrlParams, setChatUrlParams] = useQueryStates(chatSearchParams);
+  const conversationId = chatUrlParams.id || null;
+  const setConversationId = useCallback(
+    (id: string | null, history: "push" | "replace" = "push") => {
+      // `push` for deliberate navigations (sidebar select, new chat) so
+      // back/forward step through conversations; `replace` when the agent mints
+      // a conversation id mid-chat — that's a continuation of the current empty
+      // chat, not a new navigation entry the back button should land on.
+      void setChatUrlParams({ id: id ?? "" }, { history });
+    },
+    [setChatUrlParams],
+  );
+  // #3068 — the conversation the message thread is currently bound to (loaded,
+  // streaming, or load-in-flight). The URL-driven open effect dedupes against
+  // this so it never re-loads the active conversation (which would clobber a
+  // live stream) nor retries a failed deep-link load on every render.
+  const openedConversationIdRef = useRef<string | null>(null);
   const [transientWarning, setTransientWarning] = useState("");
   const [loadingConversation, setLoadingConversation] = useState(false);
   const [passwordDialogDismissed, setPasswordDialogDismissed] = useState(false);
@@ -185,7 +207,12 @@ export function AtlasChat() {
     isCrossOrigin,
     getConversationId: () => conversationId,
     onNewConversationId: (id) => {
-      setConversationId(id);
+      // #3068 — the agent minted a conversation id for the in-flight chat. Mark
+      // it bound BEFORE writing the URL so the URL-driven open effect treats it
+      // as already-loaded and never re-fetches over the live stream. `replace`
+      // (not push) — this is a continuation of the current empty chat.
+      openedConversationIdRef.current = id;
+      setConversationId(id, "replace");
       setTimeout(() => {
         refreshConvosRef.current().catch((err: unknown) => {
           console.warn(
@@ -625,6 +652,10 @@ export function AtlasChat() {
 
   async function handleSelectConversation(id: string) {
     if (loadingConversation) return;
+    // #3068 — mark this conversation bound up-front (before the await) so the
+    // URL-driven open effect dedupes against it: a redundant dispatch is a
+    // no-op, and a load that fails below isn't retried on every render.
+    openedConversationIdRef.current = id;
     setLoadingConversation(true);
     try {
       // #3065 — fetch the full row (not just the messages) so the
@@ -694,6 +725,10 @@ export function AtlasChat() {
 
   function handleNewChat() {
     setMessages([]);
+    // #3068 — clear the bound-conversation ref and the URL (`?id=`) so the
+    // open effect re-seeds a fresh chat instead of treating the just-left
+    // conversation as still loaded.
+    openedConversationIdRef.current = null;
     setConversationId(null);
     convos.setSelectedId(null);
     setInput("");
@@ -721,6 +756,34 @@ export function AtlasChat() {
     // preference (or the not-focused default).
     setSelectedRestFocus(null);
   }
+
+  // #3068 — the single bridge from URL → conversation state. A deep link / page
+  // reload, a sidebar select (which writes the URL), and browser back/forward
+  // all flow through here: open the conversation named in `?id=` (restoring its
+  // scope via handleSelectConversation → #3065) or, when the id clears while one
+  // is loaded, reset to a fresh chat. The decision (including the self-hosted
+  // carve-out that must NOT wait on a groups fetch that never runs) lives in the
+  // unit-tested `resolveConversationUrlAction`. handleSelectConversation /
+  // handleNewChat are recreated each render, so reach them through refs (as
+  // refreshConvosRef does) to keep the effect deps minimal.
+  const handleSelectConversationRef = useRef(handleSelectConversation);
+  handleSelectConversationRef.current = handleSelectConversation;
+  const handleNewChatRef = useRef(handleNewChat);
+  handleNewChatRef.current = handleNewChat;
+  useEffect(() => {
+    const action = resolveConversationUrlAction({
+      urlId: chatUrlParams.id,
+      loadedId: openedConversationIdRef.current,
+      authResolved,
+      isSignedIn,
+      envGroupsHasLoaded: envGroupsQuery.hasLoaded,
+    });
+    if (action.kind === "open") {
+      void handleSelectConversationRef.current(action.id);
+    } else if (action.kind === "clear") {
+      handleNewChatRef.current();
+    }
+  }, [chatUrlParams.id, authResolved, isSignedIn, envGroupsQuery.hasLoaded]);
 
   // Wait for auth mode detection before rendering — prevents flash of chat UI
   // when managed auth is active but session hasn't been checked yet.

--- a/packages/web/src/ui/components/atlas-chat.tsx
+++ b/packages/web/src/ui/components/atlas-chat.tsx
@@ -704,8 +704,14 @@ export function AtlasChat() {
       // #3068 — the user navigated away while this was fetching: discard the
       // stale result instead of committing the wrong conversation over the newer
       // navigation (which would also flip the URL back to this id). The URL
-      // effect loads whatever the latest `?id=` now points at.
-      if (latestRequestedConversationIdRef.current !== id) return;
+      // effect loads whatever the latest `?id=` now points at. Reset the dedup
+      // ref to the still-mounted conversation first: this load never committed,
+      // so leaving `openedConversationIdRef` on `id` would let a later back-nav
+      // to `id` be skipped (urlId === loadedId → noop) and show stale content.
+      if (latestRequestedConversationIdRef.current !== id) {
+        openedConversationIdRef.current = boundConversationIdRef.current;
+        return;
+      }
       // A 200 with a malformed body (no `messages` array) would otherwise
       // throw a bare TypeError inside `transformMessages` and surface as a
       // generic "try again" — distinguish the structural defect in the log.
@@ -763,6 +769,18 @@ export function AtlasChat() {
       console.warn("Failed to load conversation:", err instanceof Error ? err.message : String(err));
       setTransientWarning("Failed to load conversation. Please try again.");
       setTimeout(() => setTransientWarning(""), 5000);
+      // #3068 — the open failed and never committed. Reset the dedup ref to the
+      // still-mounted conversation so the failed id isn't treated as loaded. If
+      // no newer navigation superseded this attempt, roll the URL + requested id
+      // back to the mounted conversation too, so the URL, the displayed thread,
+      // and the transport id stay consistent (and the URL effect doesn't loop
+      // retrying the failed id). A newer navigation is left for the effect to
+      // open once `loadingConversation` clears.
+      openedConversationIdRef.current = boundConversationIdRef.current;
+      if (latestRequestedConversationIdRef.current === id) {
+        latestRequestedConversationIdRef.current = boundConversationIdRef.current;
+        setConversationId(boundConversationIdRef.current);
+      }
     } finally {
       setLoadingConversation(false);
     }
@@ -826,8 +844,12 @@ export function AtlasChat() {
       loadedId: openedConversationIdRef.current,
       // sessionResolved (not authResolved) — for managed auth, isSignedIn isn't
       // final until the session resolves; opening before then would misread a
-      // signed-in user as self-hosted and skip the wait-for-groups gate (#3068).
-      authSettled: sessionResolved,
+      // signed-in user as self-hosted and skip the wait-for-groups gate. Also
+      // require the simple-key credential to be present, else the deep-link
+      // fetch goes out without an Authorization header and 401s; entering the
+      // key later re-drives this effect via the `apiKey` dep (#3068).
+      authSettled:
+        sessionResolved && (authMode !== "simple-key" || !!apiKey),
       isSignedIn,
       envGroupsHasLoaded: envGroupsQuery.hasLoaded,
     });
@@ -853,7 +875,9 @@ export function AtlasChat() {
     // by handleSelectConversation's in-flight guard: when the A-load settles and
     // the flag clears, this re-evaluates and opens B — otherwise the URL would
     // say `?id=B` while A stays on screen, desynced until the next navigation.
-  }, [chatUrlParams.id, sessionResolved, isSignedIn, envGroupsQuery.hasLoaded, loadingConversation]);
+    // authMode + apiKey: a simple-key deep link must wait for the key to hydrate
+    // (above), and entering it later must re-drive the open.
+  }, [chatUrlParams.id, sessionResolved, isSignedIn, envGroupsQuery.hasLoaded, loadingConversation, authMode, apiKey]);
 
   // Wait for auth mode detection before rendering — prevents flash of chat UI
   // when managed auth is active but session hasn't been checked yet.
@@ -1165,7 +1189,15 @@ export function AtlasChat() {
                                 label="Related queries"
                               />
                             )}
-                            {conversationId && convos.available && (
+                            {/* #3068 — hide Save/Share while a conversation
+                                load is pending: `conversationId` is the URL id,
+                                which already points at the conversation being
+                                opened while the previous thread is still
+                                displayed, so acting on it would star/share the
+                                wrong conversation. Once the load commits (or
+                                rolls back on failure) the URL id matches the
+                                mounted thread again. */}
+                            {conversationId && !loadingConversation && convos.available && (
                               <div className="flex items-center gap-1">
                                 <SaveButton
                                   conversationId={conversationId}

--- a/packages/web/src/ui/components/atlas-chat.tsx
+++ b/packages/web/src/ui/components/atlas-chat.tsx
@@ -134,6 +134,21 @@ export function AtlasChat() {
   // this so it never re-loads the active conversation (which would clobber a
   // live stream) nor retries a failed deep-link load on every render.
   const openedConversationIdRef = useRef<string | null>(null);
+  // #3068 — the conversation the user most recently asked for (updated up-front
+  // by handleSelectConversation, even when its in-flight guard defers the load).
+  // An in-flight load checks this after its await and bails if it no longer
+  // matches, so a quick back/forward mid-load can't commit the wrong
+  // conversation over the newer one. Distinct from `openedConversationIdRef`,
+  // which tracks what's actually loading (they diverge during a deferred nav).
+  const latestRequestedConversationIdRef = useRef<string | null>(null);
+  // #3068 — the conversation whose messages are actually mounted (committed on a
+  // successful load, on the agent minting an id for the in-flight chat, and
+  // cleared on a new chat). This — NOT the URL id — is what the transport sends:
+  // a deep link sets the URL id immediately, but until that conversation's
+  // history has loaded a send must not append to it with only the current
+  // (empty) client messages. While the load is pending this stays null so a
+  // quick send starts a fresh conversation instead of corrupting the target.
+  const boundConversationIdRef = useRef<string | null>(null);
   const [transientWarning, setTransientWarning] = useState("");
   const [loadingConversation, setLoadingConversation] = useState(false);
   const [passwordDialogDismissed, setPasswordDialogDismissed] = useState(false);
@@ -205,13 +220,21 @@ export function AtlasChat() {
   } = useAtlasTransport({
     apiUrl,
     isCrossOrigin,
-    getConversationId: () => conversationId,
+    // #3068 — send the conversation whose messages are mounted, NOT the URL id.
+    // A deep link makes the URL id non-null before its history loads; sending
+    // that id would append a turn to the conversation with only the current
+    // client messages. `boundConversationIdRef` is null until the load commits.
+    getConversationId: () => boundConversationIdRef.current,
     onNewConversationId: (id) => {
       // #3068 — the agent minted a conversation id for the in-flight chat. Mark
-      // it bound BEFORE writing the URL so the URL-driven open effect treats it
-      // as already-loaded and never re-fetches over the live stream. `replace`
-      // (not push) — this is a continuation of the current empty chat.
+      // it bound (and most-recently-requested) BEFORE writing the URL so the
+      // URL-driven open effect treats it as already-loaded and never re-fetches
+      // over the live stream. `replace` (not push) — this is a continuation of
+      // the current empty chat. The mounted messages now belong to this id, so
+      // it's the bound (transport) conversation too.
       openedConversationIdRef.current = id;
+      latestRequestedConversationIdRef.current = id;
+      boundConversationIdRef.current = id;
       setConversationId(id, "replace");
       setTimeout(() => {
         refreshConvosRef.current().catch((err: unknown) => {
@@ -626,6 +649,11 @@ export function AtlasChat() {
 
   function handleSend(text: string) {
     if (!text.trim()) return;
+    // #3068 — don't send while a conversation's history is still loading (a deep
+    // link / sidebar open). Sending now would either append to the half-loaded
+    // conversation or be clobbered when the in-flight load commits. The composer
+    // is disabled too; this also guards the chip / starter-prompt send paths.
+    if (loadingConversation) return;
     const saved = text;
     setInput("");
     // Drop any unattached warnings from a stalled earlier turn so they
@@ -651,10 +679,20 @@ export function AtlasChat() {
   }
 
   async function handleSelectConversation(id: string) {
+    // #3068 — record the requested conversation and reflect it in the URL up
+    // front, BEFORE the in-flight guard, so a navigation that arrives mid-load
+    // (a sidebar click or browser back/forward while another conversation is
+    // still loading) is never lost and the URL always shows what the user last
+    // asked for. The post-await stale check below reads this ref.
+    latestRequestedConversationIdRef.current = id;
+    setConversationId(id);
+    // A load is already in flight; bail. The URL effect re-drives this once the
+    // in-flight load settles (`loadingConversation` is one of its deps), and the
+    // stale check below stops that in-flight load from committing over this one.
     if (loadingConversation) return;
-    // #3068 — mark this conversation bound up-front (before the await) so the
-    // URL-driven open effect dedupes against it: a redundant dispatch is a
-    // no-op, and a load that fails below isn't retried on every render.
+    // Mark bound for the open effect's dedup once we actually begin loading: a
+    // redundant dispatch is then a no-op, and a load that fails below isn't
+    // retried on every render.
     openedConversationIdRef.current = id;
     setLoadingConversation(true);
     try {
@@ -663,6 +701,11 @@ export function AtlasChat() {
       // covers both: `getConversationData` returns the same payload
       // `loadConversation` transforms, plus the persisted scope columns.
       const data = await convos.getConversationData(id);
+      // #3068 — the user navigated away while this was fetching: discard the
+      // stale result instead of committing the wrong conversation over the newer
+      // navigation (which would also flip the URL back to this id). The URL
+      // effect loads whatever the latest `?id=` now points at.
+      if (latestRequestedConversationIdRef.current !== id) return;
       // A 200 with a malformed body (no `messages` array) would otherwise
       // throw a bare TypeError inside `transformMessages` and surface as a
       // generic "try again" — distinguish the structural defect in the log.
@@ -672,7 +715,9 @@ export function AtlasChat() {
         );
       }
       setMessages(transformMessages(data.messages));
-      setConversationId(id);
+      // The conversation's history is now mounted — bind the transport to it so
+      // the next turn appends here (with full context), not to a fresh chat.
+      boundConversationIdRef.current = id;
       convos.setSelectedId(id);
       // Restore the conversation's persisted scope, validated against the
       // currently-visible env groups. The SQL scope and the REST scope are
@@ -725,10 +770,15 @@ export function AtlasChat() {
 
   function handleNewChat() {
     setMessages([]);
-    // #3068 — clear the bound-conversation ref and the URL (`?id=`) so the
-    // open effect re-seeds a fresh chat instead of treating the just-left
-    // conversation as still loaded.
+    // #3068 — clear the bound + most-recently-requested refs and the URL
+    // (`?id=`) so the open effect re-seeds a fresh chat instead of treating the
+    // just-left conversation as still loaded. Clearing the requested ref also
+    // makes any conversation load still in flight bail instead of committing
+    // over this new chat. The transport is unbound so the next turn starts a
+    // fresh conversation.
     openedConversationIdRef.current = null;
+    latestRequestedConversationIdRef.current = null;
+    boundConversationIdRef.current = null;
     setConversationId(null);
     convos.setSelectedId(null);
     setInput("");
@@ -774,16 +824,36 @@ export function AtlasChat() {
     const action = resolveConversationUrlAction({
       urlId: chatUrlParams.id,
       loadedId: openedConversationIdRef.current,
-      authResolved,
+      // sessionResolved (not authResolved) — for managed auth, isSignedIn isn't
+      // final until the session resolves; opening before then would misread a
+      // signed-in user as self-hosted and skip the wait-for-groups gate (#3068).
+      authSettled: sessionResolved,
       isSignedIn,
       envGroupsHasLoaded: envGroupsQuery.hasLoaded,
     });
-    if (action.kind === "open") {
-      void handleSelectConversationRef.current(action.id);
-    } else if (action.kind === "clear") {
-      handleNewChatRef.current();
+    switch (action.kind) {
+      case "open":
+        void handleSelectConversationRef.current(action.id);
+        break;
+      case "clear":
+        handleNewChatRef.current();
+        break;
+      case "noop":
+        // Inputs not ready, already bound, or waiting on the groups fetch.
+        break;
+      default: {
+        // Exhaustiveness guard — a new ConversationUrlAction variant must add a
+        // branch (mirrors the EnvSelectionDecision consumer above).
+        const _exhaustive: never = action;
+        void _exhaustive;
+      }
     }
-  }, [chatUrlParams.id, authResolved, isSignedIn, envGroupsQuery.hasLoaded]);
+    // `loadingConversation` is a dep so a navigation that arrives mid-load (e.g.
+    // browser back/forward to B while A is still loading) isn't silently dropped
+    // by handleSelectConversation's in-flight guard: when the A-load settles and
+    // the flag clears, this re-evaluates and opens B — otherwise the URL would
+    // say `?id=B` while A stays on screen, desynced until the next navigation.
+  }, [chatUrlParams.id, sessionResolved, isSignedIn, envGroupsQuery.hasLoaded, loadingConversation]);
 
   // Wait for auth mode detection before rendering — prevents flash of chat UI
   // when managed auth is active but session hasn't been checked yet.
@@ -1153,13 +1223,15 @@ export function AtlasChat() {
                     onChange={(e) => setInput(e.target.value)}
                     placeholder="Ask a question about your data..."
                     className="min-w-0 flex-1 py-3 text-base sm:text-sm"
-                    disabled={isLoading}
+                    // #3068 — also disabled while a conversation's history loads
+                    // (deep link / sidebar open) so a send can't race the load.
+                    disabled={isLoading || loadingConversation}
                     aria-label="Chat message"
                   />
                   <Button
                     type="submit"
                     size="icon"
-                    disabled={isLoading}
+                    disabled={isLoading || loadingConversation}
                     aria-disabled={!isLoading && !input.trim() ? true : undefined}
                     aria-label="Send"
                     className="size-10 shrink-0"

--- a/packages/web/src/ui/components/search-params.ts
+++ b/packages/web/src/ui/components/search-params.ts
@@ -14,6 +14,7 @@ export const chatSearchParams = {
  * What the URL-driven open effect should do for the current `?id=` value.
  *
  *  - `open`  — load the named conversation (messages + scope restore, #3065).
+ *              `id` is always a non-empty id (emitted only past the `!urlId` guard).
  *  - `clear` — the URL has no id but one is loaded (e.g. back-nav to the empty
  *              chat) → reset to a fresh chat.
  *  - `noop`  — nothing to do: inputs not ready, already bound, or still waiting
@@ -29,8 +30,13 @@ export interface ConversationUrlInput {
   readonly urlId: string;
   /** The conversation the UI is currently bound to / loading, or null for a fresh chat. */
   readonly loadedId: string | null;
-  /** Auth mode has been detected; before this `isSignedIn` / groups are not final. */
-  readonly authResolved: boolean;
+  /**
+   * Auth is fully settled: the mode is detected AND, for managed auth, the
+   * session has resolved. `isSignedIn` is only final once this is true — gating
+   * on a mere "mode detected" would, during the managed-session-pending window,
+   * read `isSignedIn` as false and wrongly take the self-hosted carve-out below.
+   */
+  readonly authSettled: boolean;
   /** Mirrors the connection-groups query `enabled` predicate (managed auth + a signed-in user). */
   readonly isSignedIn: boolean;
   /** The connection-groups fetch has settled. Only meaningful when `isSignedIn`. */
@@ -45,10 +51,12 @@ export interface ConversationUrlInput {
 export function resolveConversationUrlAction(
   input: ConversationUrlInput,
 ): ConversationUrlAction {
-  const { urlId, loadedId, authResolved, isSignedIn, envGroupsHasLoaded } = input;
+  const { urlId, loadedId, authSettled, isSignedIn, envGroupsHasLoaded } = input;
 
-  // Before auth resolves, `isSignedIn` / groups aren't final — wait.
-  if (!authResolved) return { kind: "noop" };
+  // Until auth is fully settled, `isSignedIn` isn't final — wait, so a managed
+  // user mid-session-load isn't misread as self-hosted (which would skip the
+  // wait-for-groups gate and restore scope against an empty group set).
+  if (!authSettled) return { kind: "noop" };
 
   // No conversation in the URL: reset to a fresh chat if one was loaded
   // (e.g. back-nav to the empty state); otherwise there's nothing to do.

--- a/packages/web/src/ui/components/search-params.ts
+++ b/packages/web/src/ui/components/search-params.ts
@@ -1,0 +1,69 @@
+import { parseAsString } from "nuqs";
+
+/**
+ * URL state for the chat surface (`AtlasChat`). The active conversation id is
+ * reflected in `?id=` so a reload / deep-link reopens it (#3068). Mirrors the
+ * workspace chat surface (`app/(workspace)/search-params.ts`) so both render the
+ * same `/?id=<uuid>` scheme.
+ */
+export const chatSearchParams = {
+  id: parseAsString.withDefault(""),
+};
+
+/**
+ * What the URL-driven open effect should do for the current `?id=` value.
+ *
+ *  - `open`  — load the named conversation (messages + scope restore, #3065).
+ *  - `clear` — the URL has no id but one is loaded (e.g. back-nav to the empty
+ *              chat) → reset to a fresh chat.
+ *  - `noop`  — nothing to do: inputs not ready, already bound, or still waiting
+ *              for the connection groups a scope restore must validate against.
+ */
+export type ConversationUrlAction =
+  | { readonly kind: "open"; readonly id: string }
+  | { readonly kind: "clear" }
+  | { readonly kind: "noop" };
+
+export interface ConversationUrlInput {
+  /** The conversation id in the URL (`?id=`), or "" when absent. */
+  readonly urlId: string;
+  /** The conversation the UI is currently bound to / loading, or null for a fresh chat. */
+  readonly loadedId: string | null;
+  /** Auth mode has been detected; before this `isSignedIn` / groups are not final. */
+  readonly authResolved: boolean;
+  /** Mirrors the connection-groups query `enabled` predicate (managed auth + a signed-in user). */
+  readonly isSignedIn: boolean;
+  /** The connection-groups fetch has settled. Only meaningful when `isSignedIn`. */
+  readonly envGroupsHasLoaded: boolean;
+}
+
+/**
+ * Pure decision behind `AtlasChat`'s URL-driven conversation-open effect.
+ * Extracted (and unit-tested) like the env-picker resolvers so the gating
+ * logic — especially the self-hosted carve-out below — can't silently rot.
+ */
+export function resolveConversationUrlAction(
+  input: ConversationUrlInput,
+): ConversationUrlAction {
+  const { urlId, loadedId, authResolved, isSignedIn, envGroupsHasLoaded } = input;
+
+  // Before auth resolves, `isSignedIn` / groups aren't final — wait.
+  if (!authResolved) return { kind: "noop" };
+
+  // No conversation in the URL: reset to a fresh chat if one was loaded
+  // (e.g. back-nav to the empty state); otherwise there's nothing to do.
+  if (!urlId) return loadedId !== null ? { kind: "clear" } : { kind: "noop" };
+
+  // Already bound to this conversation (or a load for it is in flight).
+  if (urlId === loadedId) return { kind: "noop" };
+
+  // Opening restores the conversation's scope (#3065), which must validate
+  // against the real connection groups. Wait for the groups fetch to settle —
+  // but only when we'd actually fetch them. Self-hosted / simple-key never
+  // fetches groups (the query is disabled when not signed in), so its
+  // `envGroupsHasLoaded` never flips; gating on it there would strand the deep
+  // link forever.
+  if (isSignedIn && !envGroupsHasLoaded) return { kind: "noop" };
+
+  return { kind: "open", id: urlId };
+}


### PR DESCRIPTION
## Summary
`conversationId` was in-memory `useState`, so a reload inside a saved conversation landed in a **blank chat**. This backs it with the URL (`?id=`) via nuqs so a reload / deep link **reopens** it. Combined with #3065's conversation-open restore, the conversation's scope comes back too.

- **`search-params.ts`** (co-located, per the project nuqs convention): `chatSearchParams` parser mirroring the workspace chat surface (`app/(workspace)/search-params.ts`), plus a pure, unit-tested `resolveConversationUrlAction` mapping the current `?id=` (+ auth/groups readiness) to `open` / `clear` / `noop`. The branch that matters most: a signed-in managed user **waits** for the connection-groups fetch to settle (so #3065 scope restore validates against real groups), but a self-hosted / simple-key deploy **never fetches groups** — gating on `hasLoaded` there would strand the deep link forever.
- **`atlas-chat.tsx`**: `conversationId` is now URL-derived; a single URL-driven effect is the only bridge from URL → state. It opens the conversation named in `?id=` via the existing `handleSelectConversation` (so scope restore is intact), or resets to a fresh chat when the id clears (back-nav to the empty state). An `openedConversationIdRef` dedupes so the effect never re-loads the active conversation — which would **clobber a live stream** when the agent mints a new id mid-chat — nor **retries a failed deep-link load** on every render.
- **History model**: `push` for deliberate navigations (sidebar select, new chat) so back/forward step through conversations; `replace` for an agent-minted id (a continuation of the current empty chat, not a new history entry the back button should land on).

Scope note: this is the embeddable/canonical `AtlasChat` (`ui/components/atlas-chat.tsx`, synced to atlas-starter). It renders only inside NuqsAdapter-wrapped App Router apps. The stale `@useatlas/react` widget copy is a separate file and is intentionally untouched.

## Test plan
- [x] `resolveConversationUrlAction` unit test — 9 branches incl. the self-hosted carve-out, the signed-in wait-for-groups gate, back/forward switch, and clear-on-empty (`ui/__tests__/conversation-url.test.ts`).
- [x] Integration render test through a real `NuqsTestingAdapter` — deep-linked `?id=` opens; a navigation writes the URL and opens the new conversation; signed-in stays closed until groups settle (`ui/__tests__/conversation-url-open.test.tsx`).
- [x] `bun run lint`, `bun run type` — clean.
- [x] Full `bun run test` — green except one **pre-existing, unrelated** flaky api file (`db/internal.test.ts`, passes 71/0 in isolation, only flakes under the full runner's concurrency). Filed as #3083. This branch affects **zero** api tests.
- [x] All `/ci` drift gates green (syncpack, template-drift, security-headers, railway-watch, schema-drift, oauth-helper, test-discipline, twenty-resolver, published-symbols).

### Acceptance criteria (#3068)
- [x] The active conversation id is reflected in the URL.
- [x] Reloading while in a saved conversation reopens it (messages + scope via #3065).
- [x] New chat clears the URL param; back/forward navigates conversations sensibly.
- [x] Deep-linking to a conversation URL opens it.

### Testing-approach note
Following the codebase's established pattern (the `resolveEnvSelection` / `resolveConversationScope` resolvers from #3064–#3078 are unit-tested; `AtlasChat` itself is never mounted in web tests), the tricky logic is captured by the pure resolver test, with the nuqs URL-read/write proven by a focused real-adapter render test. No full-`AtlasChat` mock (it's context-heavy and would be brittle).

Closes #3068

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3084"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782941537&installation_id=135337507&pr_number=3084&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3084&signature=3287b256d0a53f98b38326aa1e676729aceecb578ddc3590964086817cf7d23d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * More reliable deep-linking via ?id=: URL-driven opens, clears, and navigation now sync predictably with conversation selection and creation.
  * Stale/late loads no longer replace newer conversations; URL updates are deduped and new chats clear URL state.
  * Composer/send controls and Save/Share are disabled/hidden while a conversation is loading to prevent actions on stale threads.

* **Tests**
  * New tests cover URL-driven navigation, race conditions (latest ?id wins), gated deep-link opening, and auth/group-loading scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->