### PR TITLE
refactor(web): unify the workspace chat onto the single AtlasChat component (#3081)

### DIFF
--- a/packages/web/src/app/(workspace)/page.tsx
+++ b/packages/web/src/app/(workspace)/page.tsx
@@ -1,41 +1,17 @@
 "use client";
 
-import { Suspense, useState, useRef, useEffect } from "react";
+import { Suspense, useEffect } from "react";
 import dynamic from "next/dynamic";
 import { useRouter } from "next/navigation";
-import { useChat } from "@ai-sdk/react";
-import { isToolUIPart, getToolName } from "ai";
-import { cn } from "@/lib/utils";
-import { computeSqlFailureDedup } from "@/ui/lib/sql-failure-dedup";
-import { useQueryStates } from "nuqs";
-import { chatSearchParams } from "./search-params";
-import { useConversations, transformMessages } from "@/ui/hooks/use-conversations";
-import { useDatasourceSummary } from "@/ui/hooks/use-datasource-summary";
 import { getApiUrl, isCrossOrigin } from "@/lib/api-url";
+import { authClient } from "@/lib/auth/client";
 import { useAtlasTransport } from "@/ui/hooks/use-atlas-transport";
+import { useDatasourceSummary } from "@/ui/hooks/use-datasource-summary";
 import { useDefaultLanding } from "@/ui/hooks/use-default-landing";
 import { useIsAdmin } from "@/ui/hooks/use-platform-admin-guard";
-import { authClient } from "@/lib/auth/client";
 import { IncidentBanner } from "@/ui/components/incident-banner";
-import { AssistantTurn } from "@/ui/components/chat/assistant-turn";
-import { ErrorBanner } from "@/ui/components/chat/error-banner";
-import { FollowUpChips } from "@/ui/components/chat/follow-up-chips";
-import { ToolPart } from "@/ui/components/chat/tool-part";
-import { Markdown } from "@/ui/components/chat/markdown";
-import { TypingIndicator } from "@/ui/components/chat/typing-indicator";
-import { ShareDialog } from "@/ui/components/chat/share-dialog";
-import {
-  ChatEnvPicker,
-  shouldRenderEnvPicker,
-  useChatEnvGroups,
-  type ConversationRoutingMode,
-} from "@/ui/components/chat/env-picker";
-import { parseSuggestions } from "@/ui/lib/helpers";
-import { ScrollArea } from "@/components/ui/scroll-area";
-import { Button } from "@/components/ui/button";
-import { AskComposer } from "@/ui/components/ask-composer";
 import { ConnectDataPrompt } from "@/ui/components/connect-data-prompt";
-import { EmptyAskHero } from "@/ui/components/empty-ask-hero";
+import { AtlasChat } from "@/ui/components/atlas-chat";
 
 const OPENSTATUS_SLUG = process.env.NEXT_PUBLIC_OPENSTATUS_SLUG;
 const STATUS_URL = process.env.NEXT_PUBLIC_STATUS_URL;
@@ -59,48 +35,25 @@ export default function Home() {
   );
 }
 
+// The hosted SaaS workspace chat is a THIN wrapper around the single canonical
+// web chat `<AtlasChat>` (#3081). Before #3081 this page carried its own inline
+// chat implementation that drifted from the embeddable component and never
+// gained Conversation REST scope; now it renders `<AtlasChat embedded>` and adds
+// only the hosted-only chrome: the incident banner, the guided tour, the admin
+// landing redirect, and the zero-table "connect data" gate. The persistent
+// `WorkspaceShell` (shared across /, /notebook, /dashboards) owns the
+// conversation rail, schema explorer, prompt library, and command palette;
+// `embedded` mode suppresses `<AtlasChat>`'s own copies of those.
 function ChatPage() {
-  const [params, setParams] = useQueryStates(chatSearchParams);
-  const conversationId = params.id || undefined;
-
-  const [input, setInput] = useState("");
-  const [error, setError] = useState<string | null>(null);
-  const [fetchErrorDismissed, setFetchErrorDismissed] = useState(false);
-  // #2345 / #2504 — chat env/member picker state, client-side. Group id
-  // is the content scope the server later persists on the conversation
-  // row; connection id is a per-turn execution-target override the
-  // server reads off the request body and does not persist. Both start
-  // `null` so an un-picked workspace sends an unset body and the server
-  // applies default routing.
-  const [selectedGroupId, setSelectedGroupId] = useState<string | null>(null);
-  const [selectedConnectionId, setSelectedConnectionId] = useState<string | null>(null);
-  // #2518 — three-state Auto/Pin/All cross-environment routing picker.
-  // `null` until the user (or the server, on conversation load) picks a
-  // mode; the transport omits the field when `null` so the server
-  // applies its NULL→"pin" back-compat default for legacy
-  // conversations.
-  const [selectedRoutingMode, setSelectedRoutingMode] =
-    useState<ConversationRoutingMode | null>(null);
-  // Adaptive empty-chat starter surface — backend composes the ranked
-  // prompt list from favorites / popular / library tiers (#1474).
-  const [starterPrompts, setStarterPrompts] = useState<
-    Array<{ id: string; text: string; provenance: string }>
-  >([]);
-  const scrollRef = useRef<HTMLDivElement>(null);
-  const lastLoadedIdRef = useRef<string | null>(null);
-
-  // Client-side role check for nav display only — actual admin access is
-  // enforced by the backend. `useIsAdmin` reads the merged effective role
-  // (system-wide + active-org member) stamped by customSession server-side,
-  // so org admins whose user.role defaulted to "user" still match.
+  const router = useRouter();
   const session = authClient.useSession();
   const isAdmin = useIsAdmin();
   const isSignedIn = !!session.data?.user;
 
-  // Wait for the session to resolve before fetching the landing preference —
-  // a 401 here silently falls through to chat and the admin opt-out never
-  // takes effect on first paint.
-  const router = useRouter();
+  // Admin landing opt-out: an admin whose default landing is the console is
+  // redirected off the chat. Route control stays in the page (the shared chat
+  // component is not a router). Wait for the session so a 401 doesn't fall
+  // through to chat and silently skip the redirect on first paint.
   const { defaultLanding, loading: landingLoading } = useDefaultLanding(
     isSignedIn && !session.isPending,
   );
@@ -111,275 +64,31 @@ function ChatPage() {
     router.replace("/admin");
   }, [landingLoading, redirectingToAdmin, router]);
 
-  const {
-    transport,
-    authMode,
-    getHeaders,
-    getCredentials,
-    healthWarning,
-    authResolved,
-  } = useAtlasTransport({
+  // Minimal transport purely to feed the datasource summary (headers + the auth
+  // gate). The WorkspaceShell does the same; the `/api/health` probe dedups via
+  // React Query, so a second instance is cheap. `<AtlasChat>` owns its own
+  // transport for the chat itself.
+  const { getHeaders, authResolved } = useAtlasTransport({
     apiUrl: getApiUrl(),
     isCrossOrigin: isCrossOrigin(),
-    getConversationId: () => conversationId ?? null,
-    onNewConversationId: (id) => {
-      setParams({ id });
-      setTimeout(() => {
-        refreshConvosRef.current().catch((err: unknown) => {
-          console.warn(
-            "Sidebar refresh failed:",
-            err instanceof Error ? err.message : String(err),
-          );
-        });
-      }, 500);
-    },
-    // #2345 / #2504 — forward picker selection on every chat request.
-    // The transport reads these refs at fetch time so a selection change
-    // reaches the agent on the next turn without rebuilding the
-    // transport.
-    getConnectionId: () => selectedConnectionId,
-    getConnectionGroupId: () => selectedGroupId,
-    getRoutingMode: () => selectedRoutingMode,
+    getConversationId: () => null,
+    onNewConversationId: () => undefined,
   });
 
-  const convos = useConversations({
-    apiUrl: getApiUrl(),
-    enabled: true,
-    getHeaders,
-    getCredentials,
-  });
-
-  // Datasource summary for the empty-state transparency line. Gated until
-  // auth resolves to avoid a guaranteed-401 round trip on first paint.
+  // Gate the chat on a connected datasource: a zero-table workspace shows the
+  // connect-data prompt (and `<AtlasChat>` hides the composer) so the user sets
+  // up data before the agent runs and fails confusingly downstream.
   const datasource = useDatasourceSummary({
     apiUrl: getApiUrl(),
     isCrossOrigin: isCrossOrigin(),
     getHeaders,
     enabled: authResolved && isSignedIn,
   });
-
-  // True only when the summary has resolved (not in-flight, not an error
-  // soft-fail to null) AND there are zero queryable tables. The composer
-  // and starter prompts are hidden in this state so the user is funneled
-  // into setting up a connection before the agent gets a chance to run
-  // and fail confusingly downstream.
   const needsDataSetup = datasource.data?.tableCount === 0;
 
-  // #2345 / #2504 — env/member picker feed. Gated on auth so the request
-  // doesn't 401 on first paint. The picker self-hides for legacy
-  // single-connection workspaces, so leaving the hook always-on is safe.
-  const envGroupsQuery = useChatEnvGroups({
-    apiUrl: getApiUrl(),
-    enabled: authResolved && isSignedIn,
-    getHeaders,
-    getCredentials,
-  });
-
-  // Collapse the wrapper row's hairline border when the picker hides
-  // itself on a legacy 1×1 workspace.
-  //
-  // #3078 — this surface's <ChatEnvPicker> is SQL-routing-only: it does NOT pass
-  // `restDatasources` / exclude / focus props (the REST-scope feature, #3066 /
-  // #3067 / #3078, is wired into the embeddable <AtlasChat> in
-  // `ui/components/atlas-chat.tsx`, not this workspace page). So the
-  // visibility flag must mirror that SQL-only picker — DON'T feed
-  // `restDatasources` here, or the row renders (predicate true) while the inner
-  // picker hides (no REST props) and leaves an empty bordered row. Surfacing
-  // REST scope on this page (or migrating it to <AtlasChat>) is tracked in #3081.
-  const showEnvPicker = shouldRenderEnvPicker({
-    groups: envGroupsQuery.groups,
-    reason: envGroupsQuery.reason,
-    error: envGroupsQuery.error,
-  });
-
-  const refreshConvosRef = useRef(convos.refresh);
-  refreshConvosRef.current = convos.refresh;
-
-  // Reset dismissed state when a new fetch error appears
-  useEffect(() => { setFetchErrorDismissed(false); }, [convos.fetchError]);
-
-  // Re-fetch conversation list when auth mode changes
-  useEffect(() => {
-    convos.fetchList().catch((err: unknown) => {
-      // TanStack Query owns the user-visible error state via convos.fetchError;
-      // log here only so a console scrub picks up the underlying failure shape
-      // when convos.fetchError itself misbehaves.
-      console.debug(
-        "[chat] convos.fetchList rejected:",
-        err instanceof Error ? err.message : String(err),
-      );
-    });
-  }, [authMode, convos.fetchList]);
-
-  const { messages, setMessages, sendMessage, status, error: chatError } = useChat({ transport });
-
-  const isLoading = status === "streaming" || status === "submitted";
-
-  // When a caller deep-links with `?prompt=...` (wizard Done, signup success
-  // starters) or the workspace shell delivers a schema-explorer / prompt-
-  // library pick, prefill the input. Auto-submit would race with auth /
-  // transport readiness; users press Enter or click Send.
-  //
-  // Key on the dispatched value, not a once-per-mount flag — the page now
-  // stays mounted across sibling navigations (the workspace shell keeps it
-  // alive), and a second pick on the same surface must re-fire.
-  const lastPrefilledRef = useRef<string | null>(null);
-  useEffect(() => {
-    if (!params.prompt) return;
-    if (params.prompt === lastPrefilledRef.current) return;
-    const text = params.prompt;
-    lastPrefilledRef.current = text;
-    setInput(text);
-    setParams({ prompt: "" }).catch((err: unknown) => {
-      console.warn("[chat] failed to clear prompt param:", err instanceof Error ? err.message : String(err));
-    });
-  }, [params.prompt, setParams]);
-
-  // Fetch adaptive starter prompts for the empty state (#1474)
-  useEffect(() => {
-    if (messages.length > 0) return;
-    let cancelled = false;
-    const apiUrl = getApiUrl();
-    const credentials: RequestCredentials = isCrossOrigin() ? "include" : "same-origin";
-    fetch(`${apiUrl}/api/v1/starter-prompts?limit=6`, {
-      credentials,
-      headers: getHeaders(),
-    })
-      .then(async (res) => {
-        if (res.ok) return res.json();
-        // Backend 5xx (e.g. settings read failure propagated per #1470) —
-        // log the correlation id so operators can trace. UI still falls
-        // through to the cold-start CTA.
-        const body = (await res.json().catch(() => ({}))) as { requestId?: string };
-        console.warn(
-          "starter-prompts endpoint returned",
-          res.status,
-          "requestId:",
-          body.requestId,
-        );
-        return null;
-      })
-      .then((data) => {
-        if (!cancelled && Array.isArray(data?.prompts)) {
-          setStarterPrompts(data.prompts);
-        }
-      })
-      .catch((err: unknown) => {
-        // HTTP 5xx is logged above with requestId. Network/parse/abort
-        // failures land here — keep them at debug since an empty starter
-        // list collapses the grid back to the bare cold-start headline,
-        // but surface the shape so "why is my empty state bare?" stays
-        // debuggable.
-        console.debug(
-          "[starter-prompts] fetch failed:",
-          err instanceof Error ? err.message : String(err),
-        );
-      });
-    return () => { cancelled = true; };
-  }, [messages.length, getHeaders]);
-
-  useEffect(() => {
-    const el = scrollRef.current;
-    if (!el) return;
-    const isNearBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 100;
-    if (isNearBottom) el.scrollTop = el.scrollHeight;
-  }, [messages, status]);
-
-  // The workspace shell drives conversation selection through `?id=...`. This
-  // surface follows the URL: load on a new id, clear on an empty id after one
-  // was loaded.
-  useEffect(() => {
-    // Clear first — when the page stays mounted across navigations (the
-    // workspace shell keeps it alive), a stale load failure for B would
-    // otherwise persist when the user returns to A.
-    setError(null);
-    if (!conversationId) {
-      if (lastLoadedIdRef.current !== null) {
-        setMessages([]);
-        lastLoadedIdRef.current = null;
-      }
-      return;
-    }
-    if (conversationId === lastLoadedIdRef.current) return;
-    let cancelled = false;
-    async function load() {
-      try {
-        const convData = await convos.getConversationData(conversationId!);
-        if (cancelled) return;
-        setMessages(transformMessages(convData.messages));
-        lastLoadedIdRef.current = conversationId!;
-      } catch (err: unknown) {
-        if (!cancelled) {
-          console.warn(
-            "Failed to load conversation:",
-            err instanceof Error ? err.message : String(err),
-          );
-          setError("Failed to load conversation. Please try again.");
-        }
-      }
-    }
-    load();
-    return () => { cancelled = true; };
-  }, [conversationId]);
-
-  function handleSend(text: string) {
-    if (!text.trim()) return;
-    const saved = text;
-    setInput("");
-    sendMessage({ text: saved }).catch((err: unknown) => {
-      console.error(
-        "Failed to send message:",
-        err instanceof Error ? err.message : String(err),
-      );
-      setInput(saved);
-      setError("Failed to send message. Please try again.");
-    });
-  }
-
-  function handleNewChat() {
-    setError(null);
-    setMessages([]);
-    setParams({ id: "" });
-    setInput("");
-  }
-
-  function handleShare(id: string, opts?: Parameters<typeof convos.shareConversation>[1]) {
-    return convos.shareConversation(id, opts);
-  }
-
-  function handleUnshare(id: string) {
-    return convos.unshareConversation(id);
-  }
-
-  function handleGetShareStatus(id: string) {
-    return convos.getShareStatus(id);
-  }
-
-  if (healthWarning) {
-    return (
-      <div className="flex h-full items-center justify-center p-8">
-        <div className="text-center">
-          <p className="text-sm text-red-600 dark:text-red-400">{healthWarning}</p>
-          <Button className="mt-4" onClick={() => window.location.reload()}>
-            Retry
-          </Button>
-        </div>
-      </div>
-    );
-  }
-
-  if (!authResolved) {
-    return (
-      <div className="flex h-full items-center justify-center">
-        <p className="text-sm text-zinc-500">Connecting...</p>
-      </div>
-    );
-  }
-
-  // Suppress the chat render during the one-frame window between the
-  // preference fetch resolving as `admin` and the router landing on /admin.
-  // Without this, the user sees a flash of the chat surface before the
-  // redirect commits.
+  // Suppress the chat during the one-frame window between the preference fetch
+  // resolving as `admin` and the router landing on /admin (avoids a flash of
+  // the chat surface before the redirect commits).
   if (redirectingToAdmin) {
     return (
       <div className="flex h-full items-center justify-center">
@@ -397,246 +106,11 @@ function ChatPage() {
     >
       <div className="flex h-full flex-1 flex-col overflow-hidden">
         <IncidentBanner slug={OPENSTATUS_SLUG} statusUrl={STATUS_URL} />
-        <div className="flex flex-1 overflow-hidden">
-          <div className="flex flex-1 flex-col overflow-hidden">
-            <div className="mx-auto flex w-full max-w-4xl flex-1 flex-col overflow-hidden px-4 pt-4">
-              {/* Top control row — env picker (left) + share dialog (right).
-                  Renders only when at least one child is visible so the
-                  hairline border doesn't appear on a legacy 1×1 workspace.
-                  The picker is how the user re-scopes a conversation on
-                  the next turn (#2345); restoring it here is #2504. */}
-              {(showEnvPicker || conversationId) && (
-                <div className="mb-3 flex items-center justify-between gap-2 border-b border-zinc-100 pb-2 dark:border-zinc-800/60">
-                  <div className="flex items-center gap-2">
-                    <ChatEnvPicker
-                      groups={envGroupsQuery.groups}
-                      emptyReason={envGroupsQuery.reason}
-                      transportError={envGroupsQuery.error}
-                      activeGroupId={selectedGroupId}
-                      activeConnectionId={selectedConnectionId}
-                      activeRoutingMode={selectedRoutingMode}
-                      onSelect={({ groupId, connectionId, routingMode }) => {
-                        setSelectedGroupId(groupId);
-                        setSelectedConnectionId(connectionId);
-                        setSelectedRoutingMode(routingMode);
-                      }}
-                    />
-                  </div>
-                  {conversationId && (
-                    <ShareDialog
-                      conversationId={conversationId}
-                      onShare={handleShare}
-                      onUnshare={handleUnshare}
-                      onGetShareStatus={handleGetShareStatus}
-                    />
-                  )}
-                </div>
-              )}
-
-              {/* Error bar */}
-              {(error || (convos.fetchError && !fetchErrorDismissed)) && (
-                <div className="mb-2 flex items-center justify-between rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-800 dark:bg-red-950 dark:text-red-300">
-                  <p>{error || convos.fetchError}</p>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => {
-                      setError(null);
-                      setFetchErrorDismissed(true);
-                    }}
-                    className="shrink-0 text-red-600 dark:text-red-400"
-                  >
-                    Dismiss
-                  </Button>
-                </div>
-              )}
-
-              {/* Messages */}
-              <ScrollArea viewportRef={scrollRef} className="min-h-0 flex-1">
-                <div className="space-y-4 pb-4">
-                  {messages.length === 0 && !chatError && (
-                    needsDataSetup ? (
-                      <ConnectDataPrompt isAdmin={isAdmin} />
-                    ) : (
-                      <EmptyAskHero
-                        heading="Ask Atlas about your data."
-                        subhead={
-                          datasource.data && datasource.data.tableCount > 0 ? (
-                            <>
-                              Grounded in your semantic layer —{" "}
-                              <span className="font-medium text-primary">
-                                {datasource.data.tableCount} table
-                                {datasource.data.tableCount === 1 ? "" : "s"}
-                              </span>{" "}
-                              ready to query.
-                            </>
-                          ) : (
-                            "Every answer cites the table it queried."
-                          )
-                        }
-                      >
-                        {starterPrompts.length > 0 && (
-                          <div className="grid w-full max-w-lg grid-cols-1 gap-2 sm:grid-cols-2">
-                            {starterPrompts.map((prompt) => (
-                              <Button
-                                key={prompt.id}
-                                variant="outline"
-                                onClick={() => handleSend(prompt.text)}
-                                className="h-auto whitespace-normal justify-start rounded-lg px-3 py-2.5 text-left text-sm"
-                              >
-                                {prompt.text}
-                              </Button>
-                            ))}
-                          </div>
-                        )}
-                      </EmptyAskHero>
-                    )
-                  )}
-
-                  {messages.map((m, msgIndex) => {
-                    if (m.role === "user") {
-                      return (
-                        <div key={m.id} className="flex justify-end" role="article" aria-label="Message from you">
-                          <div className="max-w-[85%] rounded-xl bg-primary px-4 py-3 text-sm text-primary-foreground">
-                            {m.parts?.map((part, i) =>
-                              part.type === "text" ? (
-                                <p key={i} className="whitespace-pre-wrap">
-                                  {part.text}
-                                </p>
-                              ) : null,
-                            )}
-                          </div>
-                        </div>
-                      );
-                    }
-
-                    const isLastAssistant =
-                      m.role === "assistant" &&
-                      msgIndex === messages.length - 1;
-
-                    const hasVisibleParts = m.parts?.some(
-                      (p) => (p.type === "text" && p.text.trim()) || isToolUIPart(p),
-                    );
-                    if (!hasVisibleParts && !isLastAssistant) return null;
-
-                    const lastTextWithSuggestions = m.parts
-                      ?.filter((p): p is typeof p & { type: "text"; text: string } => p.type === "text" && !!p.text.trim())
-                      .findLast((p) => parseSuggestions(p.text).suggestions.length > 0);
-                    const suggestions = lastTextWithSuggestions
-                      ? parseSuggestions(lastTextWithSuggestions.text).suggestions
-                      : [];
-
-                    const { failureRuns, skipFailureIndex } = computeSqlFailureDedup(m.parts);
-
-                    return (
-                      <AssistantTurn
-                        key={m.id}
-                        role="article"
-                        aria-label="Message from Atlas"
-                      >
-                        {m.parts?.map((part, i) => {
-                          if (skipFailureIndex.has(i)) return null;
-
-                          const prevPart = i > 0 ? m.parts?.[i - 1] : undefined;
-                          const isExplore =
-                            isToolUIPart(part) && getToolName(part) === "explore";
-                          const prevIsExplore =
-                            prevPart && isToolUIPart(prevPart) &&
-                            getToolName(prevPart) === "explore";
-                          // Consecutive explore rows sit flush; everything else gets breathing room.
-                          const spacing =
-                            i === 0 ? "" : isExplore && prevIsExplore ? "mt-0" : "mt-2";
-
-                          if (part.type === "text" && part.text.trim()) {
-                            const displayText = parseSuggestions(part.text).text;
-                            if (!displayText.trim()) return null;
-                            return (
-                              <div key={i} className={cn("max-w-[90%]", spacing)}>
-                                <div className="rounded-xl bg-zinc-100 px-4 py-3 text-sm text-zinc-800 dark:bg-zinc-800 dark:text-zinc-200">
-                                  <Markdown content={displayText} />
-                                </div>
-                              </div>
-                            );
-                          }
-                          if (isToolUIPart(part)) {
-                            return (
-                              <div key={i} className={cn("max-w-[95%]", spacing)}>
-                                <ToolPart part={part} repeatedCount={failureRuns.get(i)} />
-                              </div>
-                            );
-                          }
-                          return null;
-                        })}
-                        {isLastAssistant && !hasVisibleParts && !isLoading && chatError && (
-                          <div className="max-w-[90%]">
-                            <div className="rounded-xl bg-red-50 px-4 py-3 text-sm text-red-700 dark:bg-red-950/30 dark:text-red-400">
-                              {chatError.message
-                                ? `Response generation failed: ${chatError.message}. Try sending your message again.`
-                                : "Response generation failed. Try sending your message again."}
-                            </div>
-                          </div>
-                        )}
-                        {isLastAssistant && isLoading && !hasVisibleParts && (
-                          <TypingIndicator />
-                        )}
-                        {isLastAssistant && !isLoading && hasVisibleParts && (
-                          <FollowUpChips
-                            suggestions={suggestions}
-                            onSelect={handleSend}
-                          />
-                        )}
-                      </AssistantTurn>
-                    );
-                  })}
-
-                  {/* Anchor the typing indicator inside an AssistantTurn so it
-                      sits in the gutter rather than floating loose below. */}
-                  {isLoading &&
-                    messages.length > 0 &&
-                    messages[messages.length - 1].role === "user" && (
-                      <AssistantTurn>
-                        <TypingIndicator />
-                      </AssistantTurn>
-                    )}
-                </div>
-              </ScrollArea>
-
-              {/* Chat error banner */}
-              {chatError && (
-                <ErrorBanner
-                  error={chatError}
-                  authMode={authMode ?? "none"}
-                  onRetry={
-                    messages.some((m) => m.role === "user")
-                      ? () => {
-                          const lastUserMsg = messages.toReversed().find((m) => m.role === "user");
-                          const text = lastUserMsg?.parts
-                            ?.filter((p): p is { type: "text"; text: string } => p.type === "text")
-                            .map((p) => p.text)
-                            .join(" ");
-                          if (text) handleSend(text);
-                        }
-                      : undefined
-                  }
-                  onStartNewConversation={handleNewChat}
-                />
-              )}
-
-              {/* Input — hidden when the workspace has no data so the user
-                   sets up a connection before the agent can run. */}
-              {!(needsDataSetup && messages.length === 0) && (
-                <AskComposer
-                  value={input}
-                  onChange={setInput}
-                  onSubmit={() => handleSend(input)}
-                  disabled={isLoading}
-                  placeholder="Ask a question about your data… ⌘K for commands"
-                  inputAriaLabel="Chat message"
-                />
-              )}
-            </div>
-          </div>
-        </div>
+        <AtlasChat
+          embedded
+          needsDataSetup={needsDataSetup}
+          emptyStateOverride={<ConnectDataPrompt isAdmin={isAdmin} />}
+        />
       </div>
     </GuidedTour>
   );

--- a/packages/web/src/app/(workspace)/page.tsx
+++ b/packages/web/src/app/(workspace)/page.tsx
@@ -12,6 +12,7 @@ import { useIsAdmin } from "@/ui/hooks/use-platform-admin-guard";
 import { IncidentBanner } from "@/ui/components/incident-banner";
 import { ConnectDataPrompt } from "@/ui/components/connect-data-prompt";
 import { AtlasChat } from "@/ui/components/atlas-chat";
+import { Button } from "@/components/ui/button";
 
 const OPENSTATUS_SLUG = process.env.NEXT_PUBLIC_OPENSTATUS_SLUG;
 const STATUS_URL = process.env.NEXT_PUBLIC_STATUS_URL;
@@ -64,11 +65,13 @@ function ChatPage() {
     router.replace("/admin");
   }, [landingLoading, redirectingToAdmin, router]);
 
-  // Minimal transport purely to feed the datasource summary (headers + the auth
-  // gate). The WorkspaceShell does the same; the `/api/health` probe dedups via
-  // React Query, so a second instance is cheap. `<AtlasChat>` owns its own
-  // transport for the chat itself.
-  const { getHeaders, authResolved } = useAtlasTransport({
+  // Minimal transport to feed the datasource summary (headers + auth gate) and
+  // to surface a hard health failure before we render a dead-looking chat. The
+  // WorkspaceShell mounts its own transport too, but the `/api/health` probe is
+  // deduped by a module-level cache inside `useAtlasTransport` (`_cachedAuthMode`),
+  // so the second instance reuses the first probe and is cheap. `<AtlasChat>`
+  // owns its own transport for the chat itself.
+  const { getHeaders, authResolved, healthWarning } = useAtlasTransport({
     apiUrl: getApiUrl(),
     isCrossOrigin: isCrossOrigin(),
     getConversationId: () => null,
@@ -85,6 +88,24 @@ function ChatPage() {
     enabled: authResolved && isSignedIn,
   });
   const needsDataSetup = datasource.data?.tableCount === 0;
+
+  // A failed `/api/health` probe means the API is unreachable / misconfigured.
+  // Surface the actionable error + a Retry instead of rendering an
+  // apparently-working chat wired to a dead backend — in `embedded` mode
+  // `<AtlasChat>` only renders `healthWarning` as a faint inline hint, far too
+  // subtle for a hard failure. Restores the pre-#3081 inline page's health gate.
+  if (healthWarning) {
+    return (
+      <div className="flex h-full items-center justify-center p-8">
+        <div className="text-center">
+          <p className="text-sm text-red-600 dark:text-red-400">{healthWarning}</p>
+          <Button className="mt-4" onClick={() => window.location.reload()}>
+            Retry
+          </Button>
+        </div>
+      </div>
+    );
+  }
 
   // Suppress the chat during the one-frame window between the preference fetch
   // resolving as `admin` and the router landing on /admin (avoids a flash of

--- a/packages/web/src/app/(workspace)/search-params.ts
+++ b/packages/web/src/app/(workspace)/search-params.ts
@@ -1,8 +1,0 @@
-import { parseAsString } from "nuqs";
-
-export const chatSearchParams = {
-  id: parseAsString.withDefault(""),
-  /** When set, the chat input is prefilled and submitted on first render.
-   *  Used by /wizard's Done step and /signup/success starter prompts. */
-  prompt: parseAsString.withDefault(""),
-};

--- a/packages/web/src/ui/__tests__/prompt-delivery-url.test.ts
+++ b/packages/web/src/ui/__tests__/prompt-delivery-url.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "bun:test";
+import { buildPromptDeliveryUrl } from "../components/prompt-delivery";
+
+/**
+ * `deliverPrompt` (the WorkspaceShell modal → chat hand-off) must preserve an
+ * active conversation deep link (`?id=`) when prefilling a prompt — otherwise the
+ * chat surface reads the missing `?id=` as "new chat" and wipes the open thread
+ * (#3081). The end-to-end guarantee the `?prompt=` prefill test asserts on the
+ * clear side (clearing `prompt` keeps `id`) only holds if the *delivery* side
+ * keeps `id` too; this covers that half against the pure URL builder.
+ */
+describe("buildPromptDeliveryUrl (#3081)", () => {
+  it("preserves an active conversation ?id= on the chat surface", () => {
+    expect(buildPromptDeliveryUrl("/", "conv-1", "What's our GMV?")).toBe(
+      "/?id=conv-1&prompt=What's%20our%20GMV%3F",
+    );
+  });
+
+  it("omits id when no conversation is active on chat", () => {
+    expect(buildPromptDeliveryUrl("/", null, "hello")).toBe("/?prompt=hello");
+  });
+
+  it("preserves ?id= on the notebook surface", () => {
+    expect(buildPromptDeliveryUrl("/notebook", "conv-2", "rows by region")).toBe(
+      "/notebook?id=conv-2&prompt=rows%20by%20region",
+    );
+  });
+
+  it("treats nested notebook routes as the notebook surface", () => {
+    expect(buildPromptDeliveryUrl("/notebook/abc", "conv-3", "q")).toBe(
+      "/notebook?id=conv-3&prompt=q",
+    );
+  });
+
+  it("drops a dashboards ?id= (it's a dashboard id, not a conversation) when routing to chat", () => {
+    // On /dashboards the `?id=` is a dashboard id; carrying it into the chat
+    // deep link would open the wrong (or no) conversation, so it's dropped.
+    expect(buildPromptDeliveryUrl("/dashboards", "dash-9", "summary")).toBe(
+      "/?prompt=summary",
+    );
+  });
+
+  it("encodes special characters in both id and text", () => {
+    expect(buildPromptDeliveryUrl("/", "a b&c", "x=y&z")).toBe(
+      "/?id=a%20b%26c&prompt=x%3Dy%26z",
+    );
+  });
+});

--- a/packages/web/src/ui/__tests__/prompt-prefill.test.tsx
+++ b/packages/web/src/ui/__tests__/prompt-prefill.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect, mock, afterEach } from "bun:test";
+import { render, waitFor, cleanup } from "@testing-library/react";
+import { createElement, useEffect, useRef, type ReactNode } from "react";
+import { useQueryStates } from "nuqs";
+import { NuqsTestingAdapter } from "nuqs/adapters/testing";
+import { chatSearchParams, resolveConversationUrlAction } from "../components/search-params";
+
+/**
+ * Coverage for the `?prompt=` prefill on the unified chat surface (#3081). The
+ * hosted `WorkspaceShell` delivers a query through `?prompt=` (`deliverPrompt`);
+ * `AtlasChat`'s prefill effect must (a) put the text in the composer and
+ * (b) clear `?prompt=` WITHOUT clobbering `?id=` — nuqs merges keys, and the
+ * conversation deep link must survive a prompt delivery. As with the #3068 URL
+ * tests, this drives the REAL `chatSearchParams` parser through a real nuqs
+ * adapter and mirrors the component's effect rather than mounting the whole chat.
+ */
+function PromptHarness(props: { onPrefill: (text: string) => void }) {
+  const [params, setParams] = useQueryStates(chatSearchParams);
+  const lastPrefilledRef = useRef<string | null>(null);
+  const onPrefillRef = useRef(props.onPrefill);
+  onPrefillRef.current = props.onPrefill;
+  useEffect(() => {
+    const text = params.prompt;
+    if (!text) return;
+    if (text === lastPrefilledRef.current) return;
+    lastPrefilledRef.current = text;
+    onPrefillRef.current(text);
+    void setParams({ prompt: "" });
+  }, [params.prompt, setParams]);
+  return createElement(
+    "div",
+    null,
+    createElement("span", { "data-testid": "id" }, params.id),
+    createElement("span", { "data-testid": "prompt" }, params.prompt),
+  );
+}
+
+function wrapper(searchParams: Record<string, string>) {
+  return ({ children }: { children: ReactNode }) =>
+    createElement(NuqsTestingAdapter, { searchParams, hasMemory: true }, children);
+}
+
+afterEach(() => cleanup());
+
+describe("?prompt= prefill (#3081)", () => {
+  it("prefills the composer from ?prompt= and clears it, preserving ?id=", async () => {
+    const onPrefill = mock((_text: string) => {});
+    const { getByTestId } = render(createElement(PromptHarness, { onPrefill }), {
+      wrapper: wrapper({ id: "conv-1", prompt: "What's our GMV?" }),
+    });
+
+    // The text reaches the composer.
+    await waitFor(() => expect(onPrefill).toHaveBeenCalledWith("What's our GMV?"));
+    // `?prompt=` is cleared back to its default…
+    await waitFor(() => expect(getByTestId("prompt").textContent).toBe(""));
+    // …while the conversation deep link survives the clear (nuqs merges keys).
+    expect(getByTestId("id").textContent).toBe("conv-1");
+  });
+
+  it("does not prefill when ?prompt= is absent", async () => {
+    const onPrefill = mock((_text: string) => {});
+    render(createElement(PromptHarness, { onPrefill }), {
+      wrapper: wrapper({ id: "conv-1" }),
+    });
+    await new Promise((r) => setTimeout(r, 20));
+    expect(onPrefill).not.toHaveBeenCalled();
+  });
+
+  it("keeps the conversation-open resolver independent of the new prompt key", () => {
+    // The additive `prompt` key must not perturb the #3068 open/clear decision,
+    // which reads only `id`.
+    expect(chatSearchParams.prompt).toBeDefined();
+    expect(
+      resolveConversationUrlAction({
+        urlId: "conv-9",
+        loadedId: null,
+        authSettled: true,
+        isSignedIn: false,
+        envGroupsHasLoaded: false,
+      }),
+    ).toEqual({ kind: "open", id: "conv-9" });
+  });
+});

--- a/packages/web/src/ui/__tests__/prompt-prefill.test.tsx
+++ b/packages/web/src/ui/__tests__/prompt-prefill.test.tsx
@@ -62,7 +62,7 @@ describe("?prompt= prefill (#3081)", () => {
     render(createElement(PromptHarness, { onPrefill }), {
       wrapper: wrapper({ id: "conv-1" }),
     });
-    await new Promise((r) => setTimeout(r, 20));
+    await new Promise((r) => setTimeout(r, 50));
     expect(onPrefill).not.toHaveBeenCalled();
   });
 

--- a/packages/web/src/ui/components/atlas-chat.tsx
+++ b/packages/web/src/ui/components/atlas-chat.tsx
@@ -113,21 +113,24 @@ interface AtlasChatProps {
    * suppress the built-in conversation sidebar, the app-identity header
    * (logo/tagline/ThemeToggle/UserMenu + the prompt-library / schema-explorer
    * buttons), and the `SchemaExplorer` / `PromptLibrary` / `ChangePasswordDialog`
-   * mounts — the host `WorkspaceShell` already owns all of those (it shares the
-   * same `useUiStore` modal keys + conversation React-Query cache). The
-   * env-picker, message thread, composer, and save/share remain. Default false:
-   * the scaffold / demo render the full standalone chrome.
+   * mounts — the host shell mounts its own copies against the shared UI store, so
+   * leaving ours on would double-mount them. The env-picker, message thread,
+   * composer, and save/share (when a conversation is active) remain. Default
+   * false: the scaffold / demo render the full standalone chrome.
    */
   embedded?: boolean;
   /**
-   * Host-provided: the workspace has no queryable tables yet. When true and the
-   * thread is empty, the composer is hidden and `emptyStateOverride` is shown so
-   * the user is funnelled into connecting data before the agent can fail.
+   * Host-provided: the workspace has no queryable tables yet. The "connect data"
+   * gate engages only when this is true AND `emptyStateOverride` is supplied —
+   * then, on an empty thread, the composer is hidden and the override is shown so
+   * the user connects data before the agent can run and fail confusingly. With no
+   * override the flag is a no-op (normal chat renders) rather than a blank screen.
    */
   needsDataSetup?: boolean;
   /**
-   * Empty-state node rendered when `needsDataSetup` and there are no messages
-   * (the hosted "connect data" prompt). Ignored otherwise.
+   * Empty-state node rendered on an empty thread when `needsDataSetup` is true
+   * (the hosted "connect data" prompt). Required for the gate to engage; ignored
+   * when `needsDataSetup` is false.
    */
   emptyStateOverride?: ReactNode;
 }
@@ -142,6 +145,12 @@ export function AtlasChat({
   // hasn't drafted one yet, surface a dedicated empty state instead of
   // letting the agent fail with a confusing "no datasource" error.
   const showDevChatEmpty = useDevModeNoDrafts(["connections"]);
+  // #3081 — the host "connect data" gate engages only when BOTH a zero-table
+  // workspace is signalled AND the host supplied a node to show. Without an
+  // override we'd render `undefined` into the empty slot AND still hide the
+  // composer, stranding the user on a blank, unrecoverable screen — so require
+  // both. The lone production caller always passes both; this guards future ones.
+  const showDataSetupGate = needsDataSetup && emptyStateOverride != null;
   const [input, setInput] = useState("");
   // #3068 — the active conversation lives in the URL (`?id=`) so a reload or a
   // deep link reopens it (combined with #3065 the conversation's scope comes
@@ -320,10 +329,19 @@ export function AtlasChat({
   // header collapses to just the picker, so gate the header row on this to avoid
   // an empty bordered strip on a legacy 1×1 workspace. Standalone renders the
   // full header (logo / theme / user menu) regardless of this flag.
+  //
+  // #3081 — this MUST pass the same `restDatasources` the inner <ChatEnvPicker>
+  // below receives, or the gate and the picker disagree: a zero-group REST-only
+  // or 1×1-SQL + REST workspace has REST exclude/focus scope to show, the inner
+  // picker would render it, but a gate computed without `restDatasources` returns
+  // false and suppresses the whole header — making the REST scope controls
+  // unreachable on the hosted (embedded) surface, the exact gap this unification
+  // exists to close.
   const showEnvPicker = shouldRenderEnvPicker({
     groups: envGroupsQuery.groups,
     reason: envGroupsQuery.reason,
     error: envGroupsQuery.error,
+    restDatasources: envGroupsQuery.restDatasources,
   });
 
   // Seed / restore the env-picker selection on a fresh chat. #3064 — the
@@ -950,11 +968,18 @@ export function AtlasChat({
     );
   }
 
+  // #3081 — in `embedded` mode the host shell already provides the page's single
+  // <main id="main"> landmark (its <SidebarInset> renders a <main>), so render a
+  // plain <div> here to avoid nesting a second <main> — duplicate main landmarks
+  // make skip-to-content + screen-reader landmark navigation ambiguous.
+  // Standalone owns the only <main>.
+  const ChatRegion = embedded ? "div" : "main";
+
   return (
     <>
       {/* `embedded` fills the host shell's <SidebarInset> (h-full/flex-1)
-          instead of claiming the viewport (h-dvh) and drops the duplicate
-          `id="main"` the shell already provides. */}
+          instead of claiming the viewport (h-dvh). The inner region also drops
+          its <main>/`id="main"` in embedded mode — see `ChatRegion` above. */}
       <div className={embedded ? "flex min-h-0 flex-1" : "flex h-dvh"}>
         {!embedded && convos.available && (
           <ConversationSidebar
@@ -969,7 +994,11 @@ export function AtlasChat({
           />
         )}
 
-        <main id={embedded ? undefined : "main"} tabIndex={-1} className="flex flex-1 flex-col overflow-hidden">
+        <ChatRegion
+          id={embedded ? undefined : "main"}
+          tabIndex={embedded ? undefined : -1}
+          className="flex flex-1 flex-col overflow-hidden"
+        >
           <div className="mx-auto flex w-full max-w-4xl flex-1 flex-col overflow-hidden p-4">
             {/* In `embedded` mode the host shell owns the app-identity header
                 (logo, theme, user menu) + the sidebar/modals, so collapse this
@@ -1130,8 +1159,9 @@ export function AtlasChat({
                   {messages.length === 0 && !error && (
                     // #3081 — host-gated "connect data" empty state takes
                     // precedence: a zero-table workspace funnels into setup
-                    // before the agent can run and fail confusingly.
-                    needsDataSetup ? (
+                    // before the agent can run and fail confusingly. Gated on
+                    // `showDataSetupGate` (needs both the flag and an override).
+                    showDataSetupGate ? (
                       emptyStateOverride
                     ) : showDevChatEmpty ? (
                       <DeveloperChatEmptyState />
@@ -1328,8 +1358,10 @@ export function AtlasChat({
 
                 {/* #3081 — hide the composer on a zero-table workspace's empty
                     thread (emptyStateOverride shows above) so the user connects
-                    data before the agent runs. */}
-                {!(needsDataSetup && messages.length === 0) && (
+                    data before the agent runs. Same `showDataSetupGate` as the
+                    empty state above, so the two never disagree (composer hidden
+                    ⇔ override shown). */}
+                {!(showDataSetupGate && messages.length === 0) && (
                 <form
                   onSubmit={(e) => {
                     e.preventDefault();
@@ -1362,11 +1394,12 @@ export function AtlasChat({
               </>
             )}
           </div>
-        </main>
+        </ChatRegion>
       </div>
-      {/* In `embedded` mode the host shell mounts these against the SAME
-          `useUiStore` keys, so suppress surface #2's copies to avoid a double
-          mount; ChangePasswordDialog isn't part of the hosted chat. */}
+      {/* In `embedded` mode the host shell mounts its own SchemaExplorer /
+          PromptLibrary against the shared UI store, so suppress this component's
+          copies to avoid a double mount; ChangePasswordDialog isn't part of the
+          hosted chat. */}
       {!embedded && (
         <>
           <SchemaExplorer

--- a/packages/web/src/ui/components/atlas-chat.tsx
+++ b/packages/web/src/ui/components/atlas-chat.tsx
@@ -2,7 +2,7 @@
 
 import { useChat } from "@ai-sdk/react";
 import { isToolUIPart, getToolName } from "ai";
-import { useState, useRef, useEffect, useCallback } from "react";
+import { useState, useRef, useEffect, useCallback, type ReactNode } from "react";
 import { useQueryStates } from "nuqs";
 import { useQueryClient } from "@tanstack/react-query";
 import type { PythonProgressData } from "./chat/python-result-card";
@@ -23,6 +23,7 @@ import { SuggestionChips } from "./chat/suggestion-chips";
 import { DeveloperChatEmptyState } from "./chat/developer-empty-state";
 import {
   ChatEnvPicker,
+  shouldRenderEnvPicker,
   resolveConversationScope,
   resolveEnvSelection,
   useChatEnvGroups,
@@ -106,7 +107,36 @@ function SaveButton({
   );
 }
 
-export function AtlasChat() {
+interface AtlasChatProps {
+  /**
+   * Embedded inside a host app shell (the hosted `(workspace)` chat). When true,
+   * suppress the built-in conversation sidebar, the app-identity header
+   * (logo/tagline/ThemeToggle/UserMenu + the prompt-library / schema-explorer
+   * buttons), and the `SchemaExplorer` / `PromptLibrary` / `ChangePasswordDialog`
+   * mounts — the host `WorkspaceShell` already owns all of those (it shares the
+   * same `useUiStore` modal keys + conversation React-Query cache). The
+   * env-picker, message thread, composer, and save/share remain. Default false:
+   * the scaffold / demo render the full standalone chrome.
+   */
+  embedded?: boolean;
+  /**
+   * Host-provided: the workspace has no queryable tables yet. When true and the
+   * thread is empty, the composer is hidden and `emptyStateOverride` is shown so
+   * the user is funnelled into connecting data before the agent can fail.
+   */
+  needsDataSetup?: boolean;
+  /**
+   * Empty-state node rendered when `needsDataSetup` and there are no messages
+   * (the hosted "connect data" prompt). Ignored otherwise.
+   */
+  emptyStateOverride?: ReactNode;
+}
+
+export function AtlasChat({
+  embedded = false,
+  needsDataSetup = false,
+  emptyStateOverride,
+}: AtlasChatProps = {}) {
   const { apiUrl, isCrossOrigin, authClient } = useAtlasConfig();
   // In developer mode the chat talks to draft connections. If the admin
   // hasn't drafted one yet, surface a dedicated empty state instead of
@@ -284,6 +314,16 @@ export function AtlasChat() {
     enabled: authResolved && isSignedIn,
     getHeaders,
     getCredentials,
+  });
+
+  // Whether the env/member picker has anything to show. In `embedded` mode the
+  // header collapses to just the picker, so gate the header row on this to avoid
+  // an empty bordered strip on a legacy 1×1 workspace. Standalone renders the
+  // full header (logo / theme / user menu) regardless of this flag.
+  const showEnvPicker = shouldRenderEnvPicker({
+    groups: envGroupsQuery.groups,
+    reason: envGroupsQuery.reason,
+    error: envGroupsQuery.error,
   });
 
   // Seed / restore the env-picker selection on a fresh chat. #3064 — the
@@ -879,6 +919,29 @@ export function AtlasChat() {
     // (above), and entering it later must re-drive the open.
   }, [chatUrlParams.id, sessionResolved, isSignedIn, envGroupsQuery.hasLoaded, loadingConversation, authMode, apiKey]);
 
+  // `?prompt=` deep-link prefill. The hosted `WorkspaceShell` delivers a query
+  // through this param (`deliverPrompt`) when the user picks from the prompt
+  // library / schema explorer, and /wizard's Done step + /signup/success
+  // starters use it too. Key on the dispatched value (not a once-per-mount flag)
+  // so a second delivery of the same text re-fires — this surface stays mounted
+  // across sibling navigations. Prefill only (no auto-submit; that would race
+  // transport readiness); clearing only `prompt` leaves `?id=` intact since nuqs
+  // merges keys. Standalone (scaffold/demo) has no shell, so `prompt` stays "".
+  const lastPrefilledRef = useRef<string | null>(null);
+  useEffect(() => {
+    const text = chatUrlParams.prompt;
+    if (!text) return;
+    if (text === lastPrefilledRef.current) return;
+    lastPrefilledRef.current = text;
+    setInput(text);
+    void setChatUrlParams({ prompt: "" }).catch((err: unknown) => {
+      console.warn(
+        "[atlas-chat] failed to clear prompt param:",
+        err instanceof Error ? err.message : String(err),
+      );
+    });
+  }, [chatUrlParams.prompt, setChatUrlParams]);
+
   // Wait for auth mode detection before rendering — prevents flash of chat UI
   // when managed auth is active but session hasn't been checked yet.
   if (!authResolved || (isManaged && managedSession.isPending)) {
@@ -889,8 +952,11 @@ export function AtlasChat() {
 
   return (
     <>
-      <div className="flex h-dvh">
-        {convos.available && (
+      {/* `embedded` fills the host shell's <SidebarInset> (h-full/flex-1)
+          instead of claiming the viewport (h-dvh) and drops the duplicate
+          `id="main"` the shell already provides. */}
+      <div className={embedded ? "flex min-h-0 flex-1" : "flex h-dvh"}>
+        {!embedded && convos.available && (
           <ConversationSidebar
             conversations={convos.conversations}
             selectedId={convos.selectedId}
@@ -903,10 +969,16 @@ export function AtlasChat() {
           />
         )}
 
-        <main id="main" tabIndex={-1} className="flex flex-1 flex-col overflow-hidden">
+        <main id={embedded ? undefined : "main"} tabIndex={-1} className="flex flex-1 flex-col overflow-hidden">
           <div className="mx-auto flex w-full max-w-4xl flex-1 flex-col overflow-hidden p-4">
+            {/* In `embedded` mode the host shell owns the app-identity header
+                (logo, theme, user menu) + the sidebar/modals, so collapse this
+                header to just the env-picker — and only when it has something to
+                show, so a legacy 1×1 workspace doesn't render an empty row. */}
+            {(!embedded || showEnvPicker) && (
             <header className="mb-4 flex-none border-b border-zinc-100 pb-3 dark:border-zinc-800">
-              <div className="flex items-center justify-between">
+              <div className="flex items-center justify-between gap-2">
+                {!embedded && (
                 <div className="flex items-center gap-3">
                   {convos.available && (
                     <Button
@@ -927,6 +999,7 @@ export function AtlasChat() {
                     </div>
                   </div>
                 </div>
+                )}
                 <div className="flex items-center gap-2">
                   {/* #2345 — env/member picker. Hides itself when only
                       one member is configured (legacy single-connection
@@ -1001,6 +1074,8 @@ export function AtlasChat() {
                       });
                     }}
                   />
+                  {!embedded && (
+                  <>
                   <Button
                     variant="ghost"
                     size="icon"
@@ -1021,9 +1096,12 @@ export function AtlasChat() {
                   </Button>
                   <ThemeToggle className="size-11 sm:size-8 text-zinc-500 dark:text-zinc-400" />
                   {isSignedIn && <UserMenu />}
+                  </>
+                  )}
                 </div>
               </div>
             </header>
+            )}
 
             {(healthWarning || transientWarning || convos.fetchError) && (
               <p className="mb-2 text-xs text-zinc-400 dark:text-zinc-500">{healthWarning || transientWarning || convos.fetchError}</p>
@@ -1050,7 +1128,12 @@ export function AtlasChat() {
                 >
                 <div className="space-y-4 pb-4 pr-3">
                   {messages.length === 0 && !error && (
-                    showDevChatEmpty ? (
+                    // #3081 — host-gated "connect data" empty state takes
+                    // precedence: a zero-table workspace funnels into setup
+                    // before the agent can run and fail confusingly.
+                    needsDataSetup ? (
+                      emptyStateOverride
+                    ) : showDevChatEmpty ? (
                       <DeveloperChatEmptyState />
                     ) : (
                     <div className="flex h-full flex-col items-center justify-center gap-6">
@@ -1243,6 +1326,10 @@ export function AtlasChat() {
                   />
                 )}
 
+                {/* #3081 — hide the composer on a zero-table workspace's empty
+                    thread (emptyStateOverride shows above) so the user connects
+                    data before the agent runs. */}
+                {!(needsDataSetup && messages.length === 0) && (
                 <form
                   onSubmit={(e) => {
                     e.preventDefault();
@@ -1271,33 +1358,41 @@ export function AtlasChat() {
                     <Send className="size-4" />
                   </Button>
                 </form>
+                )}
               </>
             )}
           </div>
         </main>
       </div>
-      <SchemaExplorer
-        open={schemaExplorerOpen}
-        onOpenChange={setSchemaExplorerOpen}
-        onInsertQuery={(text) => setInput(text)}
-        getHeaders={getHeaders}
-        getCredentials={getCredentials}
-      />
-      <PromptLibrary
-        open={promptLibraryOpen}
-        onOpenChange={setPromptLibraryOpen}
-        onSendPrompt={handleSend}
-        getHeaders={getHeaders}
-        getCredentials={getCredentials}
-      />
-      <ChangePasswordDialog
-        open={
-          !passwordDialogDismissed &&
-          passwordData?.kind === "allowed" &&
-          passwordData.passwordChangeRequired
-        }
-        onComplete={() => setPasswordDialogDismissed(true)}
-      />
+      {/* In `embedded` mode the host shell mounts these against the SAME
+          `useUiStore` keys, so suppress surface #2's copies to avoid a double
+          mount; ChangePasswordDialog isn't part of the hosted chat. */}
+      {!embedded && (
+        <>
+          <SchemaExplorer
+            open={schemaExplorerOpen}
+            onOpenChange={setSchemaExplorerOpen}
+            onInsertQuery={(text) => setInput(text)}
+            getHeaders={getHeaders}
+            getCredentials={getCredentials}
+          />
+          <PromptLibrary
+            open={promptLibraryOpen}
+            onOpenChange={setPromptLibraryOpen}
+            onSendPrompt={handleSend}
+            getHeaders={getHeaders}
+            getCredentials={getCredentials}
+          />
+          <ChangePasswordDialog
+            open={
+              !passwordDialogDismissed &&
+              passwordData?.kind === "allowed" &&
+              passwordData.passwordChangeRequired
+            }
+            onComplete={() => setPasswordDialogDismissed(true)}
+          />
+        </>
+      )}
     </>
   );
 }

--- a/packages/web/src/ui/components/prompt-delivery.ts
+++ b/packages/web/src/ui/components/prompt-delivery.ts
@@ -1,0 +1,32 @@
+/**
+ * Pure URL helpers for the WorkspaceShell modal → chat prompt hand-off (#3081).
+ * Kept side-effect-free (no React, no client-only imports) so the chat surface's
+ * deep-link behavior is unit-testable without mounting the `"use client"` shell —
+ * mirrors how `resolveConversationUrlAction` lives in `search-params.ts`.
+ */
+
+export function isNotebookRoute(pathname: string): boolean {
+  return pathname === "/notebook" || pathname.startsWith("/notebook/");
+}
+
+/**
+ * Build the prompt-delivery URL for `deliverPrompt`. On the chat / notebook
+ * surfaces it preserves an active conversation deep link (`?id=`) so inserting a
+ * prompt from the library / schema explorer prefills the CURRENT conversation —
+ * the chat surface reads a missing `?id=` as "new chat" and would otherwise wipe
+ * the open thread. Dashboards' `?id=` is a dashboard id, not a conversation, so
+ * it is intentionally dropped when routing back to chat.
+ */
+export function buildPromptDeliveryUrl(
+  pathname: string,
+  conversationId: string | null,
+  text: string,
+): string {
+  const prompt = `prompt=${encodeURIComponent(text)}`;
+  const idPrefix = conversationId
+    ? `id=${encodeURIComponent(conversationId)}&`
+    : "";
+  if (pathname === "/") return `/?${idPrefix}${prompt}`;
+  if (isNotebookRoute(pathname)) return `/notebook?${idPrefix}${prompt}`;
+  return `/?${prompt}`;
+}

--- a/packages/web/src/ui/components/search-params.ts
+++ b/packages/web/src/ui/components/search-params.ts
@@ -2,12 +2,15 @@ import { parseAsString } from "nuqs";
 
 /**
  * URL state for the chat surface (`AtlasChat`). The active conversation id is
- * reflected in `?id=` so a reload / deep-link reopens it (#3068). Mirrors the
- * workspace chat surface (`app/(workspace)/search-params.ts`) so both render the
- * same `/?id=<uuid>` scheme.
+ * reflected in `?id=` so a reload / deep-link reopens it (#3068). `?prompt=`
+ * prefills the composer — the hosted `WorkspaceShell` delivers a query through
+ * it (`deliverPrompt`) from the prompt library / schema explorer, and /wizard +
+ * /signup/success starters use it too. (Was `app/(workspace)/search-params.ts`,
+ * retired now that `AtlasChat` is the single web chat.)
  */
 export const chatSearchParams = {
   id: parseAsString.withDefault(""),
+  prompt: parseAsString.withDefault(""),
 };
 
 /**

--- a/packages/web/src/ui/components/workspace-shell.tsx
+++ b/packages/web/src/ui/components/workspace-shell.tsx
@@ -18,10 +18,10 @@ import { useUserRole } from "@/ui/hooks/use-platform-admin-guard";
 import { useUiStore } from "@/lib/stores/ui-store";
 import { getApiUrl, isCrossOrigin } from "@/lib/api-url";
 import { authClient } from "@/lib/auth/client";
-
-function isNotebookRoute(pathname: string) {
-  return pathname === "/notebook" || pathname.startsWith("/notebook/");
-}
+import {
+  buildPromptDeliveryUrl,
+  isNotebookRoute,
+} from "@/ui/components/prompt-delivery";
 
 // One persistent shell above /, /notebook, and /dashboards. Mounted by the
 // (workspace) route group's server layout so the rail's collapsed/expanded
@@ -91,15 +91,17 @@ export function WorkspaceShell({
 
   // Modals route their result through a `prompt` URL param. The chat surface
   // prefills the input; the notebook surface sends as a message. Dashboards
-  // has no chat input, so we navigate to / before prefilling.
+  // has no chat input, so we navigate to / before prefilling. The active
+  // conversation `?id=` is preserved on chat/notebook (see
+  // `buildPromptDeliveryUrl`) so a prefill doesn't clear the open thread.
   function deliverPrompt(text: string) {
-    const encoded = encodeURIComponent(text);
-    if (pathname === "/") {
-      router.replace(`/?prompt=${encoded}`, { scroll: false });
-    } else if (isNotebookRoute(pathname)) {
-      router.replace(`/notebook?prompt=${encoded}`, { scroll: false });
+    const url = buildPromptDeliveryUrl(pathname, selectedConversationId, text);
+    // `replace` on the active surface so the prefill doesn't add a history
+    // entry; `push` when arriving from dashboards (a real navigation).
+    if (pathname === "/" || isNotebookRoute(pathname)) {
+      router.replace(url, { scroll: false });
     } else {
-      router.push(`/?prompt=${encoded}`);
+      router.push(url);
     }
   }
 


### PR DESCRIPTION
## Why

The web had **two full chat implementations that drifted** — the hosted `(workspace)/page.tsx` (its own inline `ChatPage`) and the canonical `ui/components/atlas-chat.tsx`. All the v0.0.4 Conversation-scope work (REST exclude-set #3066, REST-only focus #3067, zero-group picker #3078, `?id=` URL persistence #3068, scope-restore #3065, sticky seed #3064) landed in `atlas-chat.tsx`, which the hosted SaaS **never rendered** — so the milestone's flagship REST-scope feature was unreachable on `app.useatlas.dev`. This is the "migrate to a single chat implementation" option #3081 itself recommends, over re-porting scope into `page.tsx` (which would deepen the drift).

## What

Make `AtlasChat` the single canonical web chat; reduce the hosted page to a thin wrapper around it.

- **`AtlasChat` gains an `embedded` prop.** In `embedded` mode it suppresses the built-in conversation sidebar, the app-identity header (logo / `ThemeToggle` / `UserMenu` + the prompt-library/schema-explorer buttons), and the `SchemaExplorer` / `PromptLibrary` / `ChangePasswordDialog` mounts — the persistent `WorkspaceShell` already owns all of those (and they share the same `useUiStore` modal keys + the static `["conversations","list"]` React-Query cache, so no double-mount and the shell sidebar auto-refreshes). The env-picker, message thread, composer, and save/share remain. Plus `needsDataSetup` / `emptyStateOverride` for the zero-table "connect data" gate.
- **`?prompt=` prefill moves into `AtlasChat`** (the shell delivers a query via `deliverPrompt` → `?prompt=`). Added `prompt` to `ui/components/search-params.ts`; the prefill effect clears it **without clobbering `?id=`** (nuqs merges keys).
- **`(workspace)/page.tsx` is now a thin wrapper:** incident banner + guided tour + admin-landing redirect + datasource gate around `<AtlasChat embedded>`.
- **Deleted `(workspace)/search-params.ts`** (the gutted page was its only importer; the shell reads `?id=` directly, notebook has its own).

## Result

The hosted workspace chat now has **Conversation REST scope (exclude + focus), `?id=` URL persistence, and scope-restore-on-open** — closing the #3081 reachability gap. The scaffold (`<AtlasChat />`, no props) is unchanged: the new props default to full standalone chrome.

## Scope / out of scope

`/demo` and external `@useatlas/react` embedders still render the **separate** published widget (`packages/react/.../atlas-chat.tsx`), which has no scope work. Folding the unified web chat down into `@useatlas/react` so those surfaces get it too is the tracked **Phase 2** follow-up (to be filed). This PR is the "unify the web now" half.

## Verification

- `bun run type` ✓, ESLint on changed files ✓
- `bun run test` (web, isolated runner): **174/174 files pass**, incl. the new `prompt-prefill.test.tsx` (prefill + clear-without-clobbering-`id`) and the existing `conversation-url*` suites
- `scripts/check-template-drift.sh` ✓ (755 files; the scaffold template regenerates cleanly from the modified source)
- Manual QA to run on the preview: one sidebar (shell's), schema-explorer/prompt-library open from the shell, command-palette select navigates, `?prompt=` prefills, a zero-table workspace shows `ConnectDataPrompt` with the composer hidden, admin opt-out still redirects to `/admin`, and the REST scope picker now persists per-conversation + restores on reopen.

Closes #3081.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3085"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782951108&installation_id=135337507&pr_number=3085&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3085&signature=74bea5c796ea1805b00fd50211237770a1edcbfc34c8f369bfefb0b06946f23a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ?prompt= URL param to pre-fill the chat composer (clears after delivery).
  * Enhanced ?id= deep-link behavior for reopening conversations across surfaces.
  * Introduced an embedded/configurable chat mode with data-setup gating and host-provided empty-state overrides.
  * Improved prompt hand-off so prompts are correctly encoded and routed between surfaces.

* **Tests**
  * Added tests for prompt prefill behavior and prompt-delivery URL construction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->