### PR TITLE
feat(ci): staging-smoke post-deploy workflow + personas fixture (#2898)

### DIFF
--- a/.github/workflows/staging-smoke.yml
+++ b/.github/workflows/staging-smoke.yml
@@ -1,0 +1,184 @@
+name: Staging Smoke
+
+# Post-deploy smoke for the staging environment (staging slice 10/22, #2898).
+#
+# Fires after a successful staging deploy and proves two things end-to-end:
+#   1. The deploy actually landed AND the API is wearing the staging region
+#      identity — `GET /api/v1/health` (public, no auth, already surfaces
+#      `region` via getApiRegion()) must report `region == "staging"`. We use
+#      /health rather than /api/v1/mode on purpose: /mode requires auth and
+#      would 401 here (Codex caught this on PR #2894).
+#   2. The CRM lead-capture flusher path is alive — `atlas ops smoke-crm`
+#      enqueues a tiny persona fixture into `crm_outbox`, waits for the
+#      flusher to drain, then asserts the resulting Twenty Persons match.
+#      The CLI talks to Postgres + Twenty DIRECTLY (not over HTTP), so it
+#      takes no --base-url; it is wired to the STAGING DB + Twenty via the
+#      staging-scoped secrets below.
+#
+# Result (pass or fail) is posted to the maintainer's Slack #sandbox-atlas
+# via a staging-scoped incoming-webhook secret, and the job itself goes red
+# on any failed check so the signal is visible in the Actions UI too.
+#
+# INERT UNTIL STAGING EXISTS: this workflow lands cleanly now but won't do
+# anything useful until (a) the Railway staging-deploy → GitHub
+# `repository_dispatch` webhook is wired (slice 21, #2917) and (b) the
+# staging URL + the secrets below are provisioned. Until then a manual
+# `workflow_dispatch` run will fail the health probe (no staging host yet),
+# which is expected. The Slack step no-ops cleanly when its webhook secret
+# is unset, so a pre-staging dry run never errors on the notify step.
+#
+# Required repo secrets (Settings → Secrets and variables → Actions), all
+# STAGING-scoped — never point these at prod Twenty / prod Postgres / a prod
+# Slack webhook:
+#   - STAGING_TWENTY_API_KEY    — API key for the STAGING Twenty workspace
+#   - STAGING_TWENTY_BASE_URL   — base URL of the STAGING Twenty instance
+#   - STAGING_DATABASE_URL      — STAGING tenant Postgres URL (crm_outbox)
+#   - STAGING_SLACK_WEBHOOK_URL — incoming webhook bound to #sandbox-atlas
+#
+# Workflow-injection notes (per the GitHub Actions hardening guide):
+#   - `repository_dispatch` is privileged: it can only be fired by a token
+#     with repo access (the Railway webhook's PAT), not by anonymous PR/issue
+#     actors. Even so, this workflow reads NOTHING from
+#     `github.event.client_payload.*` into any `run:` step — the dispatch is
+#     used purely as a trigger.
+#   - Every secret and outcome flows through an `env:` binding and is never
+#     spliced directly into a `run:` string. The Slack payload is assembled
+#     with `jq -n --arg`, so step outcomes / URLs can't break out of the
+#     JSON. The only `${{ }}` interpolations are `secrets.*`, `github.*`
+#     server-side metadata, and `steps.*.outcome` — all repo/GH-controlled.
+
+on:
+  repository_dispatch:
+    types: [staging-deploy-success]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  BUN_VERSION: "1.3.13"
+  STAGING_HEALTH_URL: "https://staging.useatlas.dev/api/v1/health"
+
+# Don't let two staging deploys race their smokes against the same shared
+# Twenty workspace + crm_outbox — overlapping enqueues would confuse the
+# per-email assertions. Newer deploy wins; the in-flight one is cancelled.
+concurrency:
+  group: staging-smoke
+  cancel-in-progress: true
+
+jobs:
+  staging-smoke:
+    name: staging-smoke
+    runs-on: ubuntu-latest
+    # Install (~30s) + health probe + up to 60s of outbox-drain polling. 15
+    # min is a generous ceiling that still trips on a wedged flusher.
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+
+      - uses: oven-sh/setup-bun@e3914758a49697077f7bcd190d36582a61667aad # v2 + node24 (pending release)
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Cache bun dependencies
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+
+      - name: Install dependencies
+        # `atlas ops smoke-crm` runs straight off TS via bun and pulls in the
+        # `@atlas/api` workspace + `pg` at runtime, so a full install is
+        # required even though nothing is compiled.
+        run: bun install --frozen-lockfile
+
+      - name: Health probe — deploy landed and region is staging
+        id: health
+        # continue-on-error so a failed probe still posts to Slack and still
+        # lets the CRM smoke run (it targets the DB + Twenty directly, not the
+        # API host). The final gate step re-fails the job.
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          echo "Probing ${STAGING_HEALTH_URL} for region == \"staging\"…"
+          curl -fsS "${STAGING_HEALTH_URL}" | jq -e '.region == "staging"'
+
+      - name: CRM smoke — enqueue personas and assert Twenty round-trip
+        id: smoke
+        continue-on-error: true
+        env:
+          TWENTY_API_KEY: ${{ secrets.STAGING_TWENTY_API_KEY }}
+          TWENTY_BASE_URL: ${{ secrets.STAGING_TWENTY_BASE_URL }}
+          DATABASE_URL: ${{ secrets.STAGING_DATABASE_URL }}
+        run: |
+          set -euo pipefail
+          missing=()
+          [ -n "${TWENTY_API_KEY:-}" ] || missing+=("STAGING_TWENTY_API_KEY")
+          [ -n "${TWENTY_BASE_URL:-}" ] || missing+=("STAGING_TWENTY_BASE_URL")
+          [ -n "${DATABASE_URL:-}" ] || missing+=("STAGING_DATABASE_URL")
+          if [ "${#missing[@]}" -gt 0 ]; then
+            echo "::error::Missing staging secrets: ${missing[*]}"
+            echo "::error::Configure under Settings → Secrets and variables → Actions (see this workflow's header)."
+            exit 1
+          fi
+          bun run atlas -- ops smoke-crm --personas ./scripts/staging-smoke-personas.yml
+
+      - name: Post result to Slack #sandbox-atlas
+        if: always()
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.STAGING_SLACK_WEBHOOK_URL }}
+          HEALTH_OUTCOME: ${{ steps.health.outcome }}
+          SMOKE_OUTCOME: ${{ steps.smoke.outcome }}
+          TRIGGER: ${{ github.event_name }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          if [ -z "${SLACK_WEBHOOK_URL:-}" ]; then
+            echo "::warning::STAGING_SLACK_WEBHOOK_URL is unset — skipping Slack post (expected before staging is provisioned)."
+            exit 0
+          fi
+          overall="failure"
+          if [ "${HEALTH_OUTCOME}" = "success" ] && [ "${SMOKE_OUTCOME}" = "success" ]; then
+            overall="success"
+          fi
+          # Build the payload with jq so outcomes / URLs are injected as data,
+          # never spliced into the JSON string. The webhook is bound to
+          # #sandbox-atlas at creation, so no `channel` field is needed.
+          payload="$(jq -n \
+            --arg overall "${overall}" \
+            --arg health "${HEALTH_OUTCOME}" \
+            --arg smoke "${SMOKE_OUTCOME}" \
+            --arg trigger "${TRIGGER}" \
+            --arg run "${RUN_URL}" \
+            '
+            def emoji: if . == "success" then "✅" else "❌" end;
+            {
+              text: (
+                ($overall | emoji) + " *Staging smoke — "
+                  + (if $overall == "success" then "passed" else "FAILED" end) + "*\n"
+                + "• health (region==staging): " + ($health | emoji) + " " + $health + "\n"
+                + "• crm smoke (flusher → Twenty): " + ($smoke | emoji) + " " + $smoke + "\n"
+                + "trigger: `" + $trigger + "` · <" + $run + "|run log>"
+              )
+            }')"
+          curl -fsS -X POST -H 'Content-Type: application/json' --data "${payload}" "${SLACK_WEBHOOK_URL}"
+
+      - name: Gate — fail the job if any check failed
+        if: always()
+        env:
+          HEALTH_OUTCOME: ${{ steps.health.outcome }}
+          SMOKE_OUTCOME: ${{ steps.smoke.outcome }}
+        run: |
+          set -euo pipefail
+          failed=0
+          if [ "${HEALTH_OUTCOME}" != "success" ]; then
+            echo "::error::Health probe failed (region != staging or staging unreachable)."
+            failed=1
+          fi
+          if [ "${SMOKE_OUTCOME}" != "success" ]; then
+            echo "::error::CRM smoke failed (flusher drain timeout or Twenty diff dirty)."
+            failed=1
+          fi
+          exit "${failed}"

--- a/.github/workflows/staging-smoke.yml
+++ b/.github/workflows/staging-smoke.yml
@@ -4,10 +4,12 @@ name: Staging Smoke
 #
 # Fires after a successful staging deploy and proves two things end-to-end:
 #   1. The deploy actually landed AND the API is wearing the staging region
-#      identity — `GET /api/v1/health` (public, no auth, already surfaces
+#      identity — `GET /api/health` (public, no auth, already surfaces
 #      `region` via getApiRegion()) must report `region == "staging"`. We use
-#      /health rather than /api/v1/mode on purpose: /mode requires auth and
-#      would 401 here (Codex caught this on PR #2894).
+#      /api/health rather than /api/v1/mode on purpose: /mode requires auth and
+#      would 401 here (Codex caught this on PR #2894). Note the path is
+#      /api/health, not /api/v1/health — the health router is mounted outside
+#      the /api/v1 prefix.
 #   2. The CRM lead-capture flusher path is alive — `atlas ops smoke-crm`
 #      enqueues a tiny persona fixture into `crm_outbox`, waits for the
 #      flusher to drain, then asserts the resulting Twenty Persons match.
@@ -57,7 +59,10 @@ permissions:
 
 env:
   BUN_VERSION: "1.3.13"
-  STAGING_HEALTH_URL: "https://staging.useatlas.dev/api/v1/health"
+  # The health router is mounted at /api/health (packages/api/src/api/index.ts:
+  # `app.route("/api/health", health)`), NOT under the /api/v1 prefix — there is
+  # no /api/v1/health route. The issue body said /api/v1/health, but that 404s.
+  STAGING_HEALTH_URL: "https://staging.useatlas.dev/api/health"
 
 # Don't let two staging deploys race their smokes against the same shared
 # Twenty workspace + crm_outbox — overlapping enqueues would confuse the

--- a/.github/workflows/staging-smoke.yml
+++ b/.github/workflows/staging-smoke.yml
@@ -59,10 +59,14 @@ permissions:
 
 env:
   BUN_VERSION: "1.3.13"
+  # The staging API host is `api.staging.useatlas.dev` (peer-symmetric with
+  # prod's api.useatlas.dev) — see deploy/api/atlas.config.ts and the PRD
+  # (docs/prd/staging-environment.md §health-check), NOT the bare
+  # `staging.useatlas.dev` (which is the cookie parent, not an API host).
   # The health router is mounted at /api/health (packages/api/src/api/index.ts:
-  # `app.route("/api/health", health)`), NOT under the /api/v1 prefix — there is
-  # no /api/v1/health route. The issue body said /api/v1/health, but that 404s.
-  STAGING_HEALTH_URL: "https://staging.useatlas.dev/api/health"
+  # `app.route("/api/health", health)`), OUTSIDE the /api/v1 prefix — there is
+  # no /api/v1/health route. This matches the PRD's canonical smoke command.
+  STAGING_HEALTH_URL: "https://api.staging.useatlas.dev/api/health"
 
 # Don't let two staging deploys race their smokes against the same shared
 # Twenty workspace + crm_outbox — overlapping enqueues would confuse the
@@ -79,6 +83,19 @@ jobs:
     # min is a generous ceiling that still trips on a wedged flusher.
     timeout-minutes: 15
     steps:
+      # NOTE (deployed-SHA drift, slice 21 / #2917): on `repository_dispatch`
+      # the checkout defaults to the default-branch HEAD, which can be AHEAD of
+      # the commit Railway just deployed if another commit landed on `main`
+      # while the deploy was in flight. That is acceptable here: the health
+      # probe hits the live deployed host (not checked-out code), and the CRM
+      # smoke only uses the checked-out tree as a *harness* (fixture + CLI that
+      # enqueues to crm_outbox + asserts) — the behaviour under test is the
+      # DEPLOYED flusher/dispatcher, so running the harness from latest `main`
+      # is fine. When slice 21 (#2917) defines the Railway dispatch
+      # `client_payload`, pin to the deployed SHA by passing
+      # `ref: ${{ github.event.client_payload.sha }}` here — but only after
+      # validating it against `^[0-9a-f]{40}$` (untrusted dispatch input must
+      # not flow into `ref:` unchecked).
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - uses: oven-sh/setup-bun@e3914758a49697077f7bcd190d36582a61667aad # v2 + node24 (pending release)
@@ -168,7 +185,15 @@ jobs:
                 + "trigger: `" + $trigger + "` · <" + $run + "|run log>"
               )
             }')"
-          curl -fsS -X POST -H 'Content-Type: application/json' --data "${payload}" "${SLACK_WEBHOOK_URL}"
+          # Slack delivery is best-effort: a revoked / rate-limited / down
+          # webhook must NOT fail an otherwise-green smoke. The Gate step below
+          # is the authoritative verdict on health + smoke; this notification
+          # is a courtesy. A jq/payload bug above still fails loudly (set -e),
+          # but a network/HTTP delivery failure only warns.
+          if ! curl -fsS -X POST -H 'Content-Type: application/json' \
+            --data "${payload}" "${SLACK_WEBHOOK_URL}"; then
+            echo "::warning::Slack delivery to #sandbox-atlas failed (non-fatal) — the smoke result stands on the gate step below."
+          fi
 
       - name: Gate — fail the job if any check failed
         if: always()

--- a/packages/cli/lib/smoke-crm/diff.ts
+++ b/packages/cli/lib/smoke-crm/diff.ts
@@ -185,9 +185,18 @@ export interface SmokeDiff {
   readonly unexpectedPersons: ReadonlyArray<string>;
   /**
    * Emails seen MORE THAN ONCE on the observed side — Twenty workspace
-   * has duplicate Person records for the same email. Always dirty: a
-   * dedupe regression in `findPersonByEmail` (the #2865 family) is
-   * exactly what produces this shape.
+   * has duplicate Person records for the same email. A dedupe regression
+   * in `findPersonByEmail` (the #2865 family) is exactly what produces
+   * this shape.
+   *
+   * Scoped like `unexpectedPersons`: in the default (no-wipe) mode only a
+   * duplicate of a FIXTURE email is recorded. An unattended smoke runs
+   * against a shared workspace that may already carry unrelated duplicate
+   * leads, so failing on those would be noise — and the #2865 regression
+   * still surfaces because it duplicates the fixture rows too (every upsert
+   * hits the same code path). Under `requireCleanWorkspace` (post
+   * `--wipe-twenty`) the workspace should be pristine, so EVERY duplicate
+   * is recorded. Dirty whenever non-empty (see `isClean`).
    */
   readonly duplicateObservedEmails: ReadonlyArray<string>;
   /** Per-Person field mismatches. The load-bearing slice — these mean the dispatcher wrote the wrong value. */
@@ -206,10 +215,13 @@ export interface SmokeDiff {
 
 export interface ComputeDiffOptions {
   /**
-   * When true (the CLI sets this whenever `--wipe-twenty` was passed),
-   * `unexpectedPersons` and `duplicateObservedEmails` both mark the diff
-   * dirty. The post-wipe workspace should be deterministic — residual
-   * rows mean the wipe was partial or truncated.
+   * When true (the CLI sets this whenever `--wipe-twenty` was passed), the
+   * post-wipe workspace is expected to be deterministic, so the shared-
+   * workspace tolerances tighten: `unexpectedPersons` flips from
+   * informational to dirty, and `duplicateObservedEmails` widens from
+   * fixture-scoped to GLOBAL — any duplicate email anywhere is dirty,
+   * because residual / duplicated rows mean the wipe was partial or
+   * truncated.
    */
   readonly requireCleanWorkspace?: boolean;
 }
@@ -224,12 +236,20 @@ export interface ComputeDiffOptions {
  *    Twenty data shouldn't fail the smoke unless the operator opted into
  *    `--wipe-twenty`. The CLI surfaces them in the report regardless so the
  *    operator notices, but the exit code stays clean.
+ *  - `duplicateObservedEmails` is dirty when non-empty, but fixture-scoped by
+ *    default (a shared no-wipe workspace may carry unrelated duplicates);
+ *    `requireCleanWorkspace` widens it to every observed email.
  */
 export function computeDiff(
   expected: ExpectedState,
   observed: ObservedState,
   options: ComputeDiffOptions = {},
 ): SmokeDiff {
+  // Fixture emails drive the no-wipe scoping of `duplicateObservedEmails`
+  // below, so compute the set up front.
+  const expectedEmails = new Set(expected.persons.map((p) => p.email));
+  const strict = options.requireCleanWorkspace === true;
+
   const observedByEmail = new Map<string, ObservedPerson>();
   const duplicateObservedEmails: string[] = [];
   for (const o of observed.persons) {
@@ -240,14 +260,22 @@ export function computeDiff(
       // shape. Record once per email, then keep the first row as the
       // representative for the field-comparison loop below — the duplicate
       // is already surfaced via `duplicateObservedEmails`.
-      if (!duplicateObservedEmails.includes(key)) {
-        duplicateObservedEmails.push(key);
+      //
+      // Scope (mirrors `unexpectedPersons`): by default only flag a
+      // duplicate of a fixture email. An unattended no-wipe smoke runs
+      // against a shared staging workspace that may already hold unrelated
+      // duplicate leads — failing every deploy on those would be noise, and
+      // the #2865 regression still surfaces because it duplicates the
+      // fixture rows too. Strict mode (post-wipe) widens this to every email.
+      if (strict || expectedEmails.has(key)) {
+        if (!duplicateObservedEmails.includes(key)) {
+          duplicateObservedEmails.push(key);
+        }
       }
       continue;
     }
     observedByEmail.set(key, o);
   }
-  const expectedEmails = new Set(expected.persons.map((p) => p.email));
 
   const missingPersons: string[] = [];
   const mismatchedPersons: PersonMismatch[] = [];
@@ -315,7 +343,7 @@ export function computeDiff(
     mismatchedPersons,
     missingNotes,
     noteCountMismatches,
-    strictWorkspace: options.requireCleanWorkspace === true,
+    strictWorkspace: strict,
   };
 }
 
@@ -431,8 +459,11 @@ function noteKey(email: string, title: string, body: string): string {
  * passed): after a wipe, residual rows mean the wipe was partial /
  * truncated, so unexpected Persons flip to dirty.
  *
- * `duplicateObservedEmails` is always dirty — a dedupe regression in
- * `findPersonByEmail` is exactly the #2865 failure shape.
+ * `duplicateObservedEmails` is dirty whenever non-empty — a dedupe
+ * regression in `findPersonByEmail` is exactly the #2865 failure shape.
+ * `computeDiff` decides WHICH duplicates land in that list (fixture-scoped
+ * by default, global under `strictWorkspace`); `isClean` just reacts to the
+ * result.
  */
 export function isClean(diff: SmokeDiff): boolean {
   if (

--- a/packages/cli/src/__tests__/ops-smoke-crm-diff.test.ts
+++ b/packages/cli/src/__tests__/ops-smoke-crm-diff.test.ts
@@ -388,6 +388,73 @@ describe("computeDiff — dirty diffs", () => {
     expect(isClean(diff)).toBe(false);
   });
 
+  test("no-wipe mode tolerates a duplicate on a NON-fixture email (shared staging workspace)", () => {
+    // The unattended staging smoke (#2898) runs without --wipe-twenty against
+    // a shared Twenty workspace that may already hold unrelated duplicate
+    // leads. A duplicate on an email the fixture never touched must NOT fail
+    // the smoke — otherwise one stray pre-existing dup fails every deploy.
+    // Mirrors the `unexpectedPersons` informational-by-default rule. (Codex
+    // P2 on PR #3090.)
+    const events: AtlasLeadEvent[] = [
+      { source: "demo", email: "fixture@example.com", ip: null, userAgent: null },
+    ];
+    const expected = buildExpectedState(events);
+    const observed: ObservedState = {
+      persons: [
+        { id: "p_1", email: "fixture@example.com", atlasFirstSource: "DEMO", atlasLastSource: "DEMO" },
+        { id: "p_2", email: "stranger@example.com" }, // unrelated pre-existing dup
+        { id: "p_3", email: "stranger@example.com" },
+      ],
+      notes: [],
+    };
+    const diff = computeDiff(expected, observed);
+    expect(diff.duplicateObservedEmails).toEqual([]);
+    expect(isClean(diff)).toBe(true);
+  });
+
+  test("a duplicate ON a fixture email is still dirty in no-wipe mode (#2865 still caught)", () => {
+    // Scoping duplicates to fixture emails must NOT weaken #2865 detection:
+    // the upsert-dedup regression duplicates the fixture rows too.
+    const events: AtlasLeadEvent[] = [
+      { source: "demo", email: "fixture@example.com", ip: null, userAgent: null },
+    ];
+    const expected = buildExpectedState(events);
+    const observed: ObservedState = {
+      persons: [
+        { id: "p_1", email: "fixture@example.com", atlasFirstSource: "DEMO", atlasLastSource: "DEMO" },
+        { id: "p_2", email: "fixture@example.com", atlasFirstSource: "DEMO", atlasLastSource: "DEMO" },
+      ],
+      notes: [],
+    };
+    const diff = computeDiff(expected, observed);
+    expect(diff.duplicateObservedEmails).toEqual(["fixture@example.com"]);
+    expect(isClean(diff)).toBe(false);
+  });
+
+  test("strict-workspace mode widens the duplicate check to ANY email (post-wipe must be pristine)", () => {
+    // After --wipe-twenty the workspace should be empty before the smoke runs,
+    // so a duplicate anywhere — fixture email or not — means the wipe was
+    // partial / a dedupe regression is live. Strict widens the scope to global.
+    const events: AtlasLeadEvent[] = [
+      { source: "demo", email: "fixture@example.com", ip: null, userAgent: null },
+    ];
+    const expected = buildExpectedState(events);
+    const observed: ObservedState = {
+      persons: [
+        { id: "p_1", email: "fixture@example.com", atlasFirstSource: "DEMO", atlasLastSource: "DEMO" },
+        { id: "p_2", email: "stranger@example.com" },
+        { id: "p_3", email: "stranger@example.com" },
+      ],
+      notes: [],
+    };
+    const lenient = computeDiff(expected, observed);
+    expect(lenient.duplicateObservedEmails).toEqual([]); // tolerated no-wipe
+    expect(isClean(lenient)).toBe(true);
+    const strict = computeDiff(expected, observed, { requireCleanWorkspace: true });
+    expect(strict.duplicateObservedEmails).toEqual(["stranger@example.com"]);
+    expect(isClean(strict)).toBe(false);
+  });
+
   test("strict-workspace mode flips unexpectedPersons from informational to dirty", () => {
     // Codex P2-A: after --wipe-twenty the workspace should be empty before
     // the smoke runs. Residual rows = partial/truncated wipe = dirty.

--- a/scripts/staging-smoke-personas.yml
+++ b/scripts/staging-smoke-personas.yml
@@ -1,0 +1,45 @@
+# Staging smoke fixture — drives `atlas ops smoke-crm` from
+# `.github/workflows/staging-smoke.yml` after every staging deploy.
+#
+# This is the MINIMAL counterpart to the full coverage matrix in
+# `scripts/test-fixtures/crm-personas.yml` (10 personas, used by the unit
+# tests). The staging smoke only needs to prove the end-to-end flusher path
+# is alive after a deploy: enqueue → crm_outbox → flusher drains → dispatch
+# to the (staging) Twenty workspace → Person upsert. It is not trying to
+# re-prove the full #2865 regression matrix on every deploy.
+#
+# WHY ONLY demo + signup (no sales-form / conversion) ───────────────────────
+# The smoke runs UNATTENDED on every staging deploy WITHOUT `--wipe-twenty`,
+# so it must be idempotent across repeated runs against the same shared
+# staging Twenty workspace. Two properties make demo/signup safe to repeat:
+#
+#   1. Person upsert is keyed on email — repeat dispatches update the same
+#      Person in place (no duplicate), and `atlasFirstSource` is sticky.
+#   2. demo/signup events produce ZERO Notes.
+#
+# A `sales-form` persona would break property (2): `createNote`
+# (plugins/twenty/src/client.ts) is NOT idempotent — it appends a fresh Note
+# on every dispatch. Across repeated no-wipe deploys the observed Note count
+# for that email would climb (1, 2, 3, …) while the fixture expects exactly
+# 1, tripping `noteCountMismatches` (always dirty in `isClean`, scoped to
+# fixture emails) and failing the smoke from the second deploy onward. The
+# Note path is exercised by the full fixture under the unit tests + the
+# manual `--wipe-twenty` local run, not by this unattended deploy smoke.
+#
+# The two personas use distinct, stable, obviously-synthetic emails on a
+# `smoke.useatlas.dev` subdomain so an operator eyeballing the staging Twenty
+# workspace can recognise them as fixtures and they never collide with real
+# demo/signup leads.
+
+personas:
+  # demo → exercises the demo flusher path (Person upsert, no Note).
+  - source: demo
+    email: staging-smoke-demo@smoke.useatlas.dev
+    ip: 203.0.113.1
+
+  # signup → exercises the signup flusher path (Person upsert with a name,
+  # no Note). Distinct email from the demo persona, so there is no within-run
+  # ordering dependency between the two — each asserts independently.
+  - source: signup
+    email: staging-smoke-signup@smoke.useatlas.dev
+    name: Staging Smoke


### PR DESCRIPTION
Closes #2898 (Staging Environment milestone #57, slice 10/22).

## What this adds

- **`.github/workflows/staging-smoke.yml`** — post-deploy smoke for staging.
- **`scripts/staging-smoke-personas.yml`** — minimal 2-persona fixture driving the CRM smoke.

## Workflow shape

Triggers:
- `repository_dispatch` with `types: [staging-deploy-success]` (the Railway staging-deploy success webhook).
- `workflow_dispatch` (manual, for testing).

Steps:
1. **Health probe** — `curl -fsS https://staging.useatlas.dev/api/v1/health | jq -e '.region == "staging"'`. `/api/v1/health` is public (no auth) and already surfaces `region` via `getApiRegion()`. We use `/health` rather than `/api/v1/mode` on purpose — `/mode` requires auth and would 401 (Codex caught this on PR #2894).
2. **CRM smoke** — `bun run atlas -- ops smoke-crm --personas ./scripts/staging-smoke-personas.yml`, wired to the **staging** DB + Twenty via staging-scoped secrets (`STAGING_TWENTY_API_KEY`, `STAGING_TWENTY_BASE_URL`, `STAGING_DATABASE_URL`). The CLI talks to Postgres + Twenty **directly** (not over HTTP), so there is no `--base-url`.
3. **Slack notify** — posts a pass/fail summary to `#sandbox-atlas` via a staging-scoped incoming-webhook secret (`STAGING_SLACK_WEBHOOK_URL`). Payload is built with `jq -n --arg` so outcomes/URLs are injected as data, never spliced into the JSON. No-ops cleanly when the webhook secret is unset.
4. **Gate** — re-fails the job if either the health probe or the CRM smoke failed, so the failure is visible in the Actions UI (not just Slack).

## Fixture design — why `demo` + `signup` only

The smoke runs **unattended on every staging deploy WITHOUT `--wipe-twenty`**, so it must be idempotent across repeated runs against the same shared staging Twenty workspace:

- `demo`/`signup` events upsert one Person per email (sticky `atlasFirstSource`) and produce **zero Notes** → safe to repeat.
- A `sales-form` persona would break this: `createNote` (`plugins/twenty/src/client.ts`) is **not** idempotent — it appends a fresh Note on every dispatch. Across repeated no-wipe deploys the observed Note count for that email would climb while the fixture expects exactly 1, tripping `noteCountMismatches` (always dirty in `isClean`, scoped to fixture emails) and failing the smoke from the second deploy onward.

The Note path stays covered by the full `scripts/test-fixtures/crm-personas.yml` fixture under the unit tests + the manual `--wipe-twenty` local run. Personas use stable, obviously-synthetic emails on a `smoke.useatlas.dev` subdomain so they're recognisable in the staging Twenty workspace and never collide with real leads.

## Security (GitHub Actions workflow-injection hardening)

- `repository_dispatch` is privileged (only fireable by a token with repo access — the Railway webhook's PAT), and this workflow reads **nothing** from `github.event.client_payload.*` into any `run:` step — the dispatch is a pure trigger.
- Every secret and step outcome flows through an `env:` binding; nothing is spliced directly into a `run:` string. The only `${{ }}` interpolations are `secrets.*`, `github.*` server-side metadata, and `steps.*.outcome`.

## Verification

- ✅ `actionlint` (official `rhysd/actionlint` docker image, includes shellcheck on `run:` blocks) — clean.
- ✅ Fixture parses via the real `loadFixture` (`packages/cli/lib/smoke-crm/fixture.ts`) → 2 personas, Note-free.
- ✅ Full `/ci` gate: lint, type, test (full suite, 0 fail), syncpack, template drift, security-headers, railway-watch, schema drift, oauth-helper drift, test discipline, twenty resolver, published symbols — all pass.

## ⚠️ Inert until staging exists

This workflow lands cleanly now but **won't do anything useful until the Railway staging-deploy → GitHub `repository_dispatch` webhook is wired in slice 21 (#2917)** and the staging URL + the four `STAGING_*` secrets are provisioned. Until then a manual `workflow_dispatch` run will fail the health probe (no staging host yet), which is expected; the Slack step no-ops when its webhook secret is unset, so a pre-staging dry run never errors on the notify step.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3090"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782955590&installation_id=135337507&pr_number=3090&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3090&signature=7d96cb8e32b251d23bdc671231a99383d594490193587175a990f2aed1f87590"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated staging smoke workflow to run health and CRM smoke checks after staging deploys, post best-effort Slack notifications, and gate failures when checks fail.
* **New Features**
  * Added a minimal set of staging personas to exercise end-to-end CRM flows.
* **Improvements**
  * Refined duplicate-person detection to better scope when duplicates are considered dirty.
* **Tests**
  * Added unit tests covering duplicate-person handling across workspace modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->