### PR TITLE
test(api): pin staging-region misrouting detection (#2982)

### DIFF
--- a/packages/api/src/lib/residency/__tests__/misrouting.test.ts
+++ b/packages/api/src/lib/residency/__tests__/misrouting.test.ts
@@ -251,6 +251,102 @@ describe("misrouting detection", () => {
       expect(result2).not.toBeNull();
       expect(result2!.expectedRegion).toBe("eu-west");
     });
+
+    // ── Staging region (#2982) ──────────────────────────────────────
+    //
+    // `staging` is the 4th DeployRegion (#2897). `detectMisrouting` is
+    // region-agnostic — it just compares the workspace region string against
+    // `getApiRegion()` and reads `regions[workspaceRegion]?.apiUrl` for the
+    // redirect hint — so these cases pin behavior structurally rather than
+    // exercising new code paths. The point is to lock it before the staging
+    // instance goes live so a future refactor can't silently regress routing.
+    //
+    // NOTE on the redirect hint: the issue (#2982) was filed when `staging`
+    // was intentionally ABSENT from `residency.regions`, so the hint resolved
+    // to `undefined`. PR #2925 later ADDED a `staging` arm (so the SaaS region
+    // guard accepts ATLAS_API_REGION=staging without a hard-fail boot — see
+    // deploy/api/atlas.config.ts), which means in today's prod config the hint
+    // resolves to `https://api.staging.useatlas.dev`. We pin BOTH states: the
+    // absent-arm case (issue's original premise) and the present-arm case
+    // (current deploy reality). Either way `detectMisrouting` behaves correctly
+    // — the only difference is whether a `correctApiUrl` accompanies the flag.
+    describe("staging region", () => {
+      it("does NOT flag a staging-keyed workspace on the staging instance", async () => {
+        process.env.ATLAS_API_REGION = "staging";
+        mockWorkspaceRegion = "staging";
+        const result = await detectMisrouting("org-staging", "req-1");
+        // Matches at misrouting.ts:144 (workspaceRegion === apiRegion) → null.
+        expect(result).toBeNull();
+        expect(getMisroutedCount()).toBe(0);
+      });
+
+      it("flags a staging-keyed workspace on a prod instance with NO correctApiUrl when staging is absent from residency.regions", async () => {
+        // Mirrors the issue's original premise: staging not in residency.regions.
+        process.env.ATLAS_API_REGION = "us";
+        mockWorkspaceRegion = "staging";
+        mockConfig = {
+          residency: {
+            defaultRegion: "us",
+            regions: {
+              us: { label: "United States", databaseUrl: "postgres://...", apiUrl: "https://api.useatlas.dev" },
+              eu: { label: "Europe", databaseUrl: "postgres://...", apiUrl: "https://api-eu.useatlas.dev" },
+              apac: { label: "Asia Pacific", databaseUrl: "postgres://...", apiUrl: "https://api-apac.useatlas.dev" },
+              // staging intentionally NOT present → regions["staging"]?.apiUrl is undefined
+            },
+          },
+        };
+        const result = await detectMisrouting("org-staging", "req-1");
+        expect(result).not.toBeNull();
+        expect(result!.expectedRegion).toBe("staging");
+        expect(result!.actualRegion).toBe("us");
+        // Pinned: no redirect hint when the region is absent from config.
+        expect(result!.correctApiUrl).toBeUndefined();
+        expect(getMisroutedCount()).toBe(1);
+      });
+
+      it("flags a staging-keyed workspace on a prod instance WITH a correctApiUrl when staging is present in residency.regions (current deploy config, #2925)", async () => {
+        // Mirrors today's deploy/api/atlas.config.ts: staging IS in the regions map.
+        process.env.ATLAS_API_REGION = "us";
+        mockWorkspaceRegion = "staging";
+        mockConfig = {
+          residency: {
+            defaultRegion: "us",
+            regions: {
+              us: { label: "United States", databaseUrl: "postgres://...", apiUrl: "https://api.useatlas.dev" },
+              staging: { label: "Staging", databaseUrl: "postgres://...", apiUrl: "https://api.staging.useatlas.dev" },
+            },
+          },
+        };
+        const result = await detectMisrouting("org-staging", "req-1");
+        expect(result).not.toBeNull();
+        expect(result!.expectedRegion).toBe("staging");
+        expect(result!.actualRegion).toBe("us");
+        // Present-arm reality: the hint resolves to the staging apiUrl.
+        expect(result!.correctApiUrl).toBe("https://api.staging.useatlas.dev");
+        expect(getMisroutedCount()).toBe(1);
+      });
+
+      it("flags a prod-keyed workspace on the staging instance", async () => {
+        process.env.ATLAS_API_REGION = "staging";
+        mockWorkspaceRegion = "us";
+        mockConfig = {
+          residency: {
+            defaultRegion: "staging",
+            regions: {
+              us: { label: "United States", databaseUrl: "postgres://...", apiUrl: "https://api.useatlas.dev" },
+              staging: { label: "Staging", databaseUrl: "postgres://...", apiUrl: "https://api.staging.useatlas.dev" },
+            },
+          },
+        };
+        const result = await detectMisrouting("org-prod-us", "req-1");
+        expect(result).not.toBeNull();
+        expect(result!.expectedRegion).toBe("us");
+        expect(result!.actualRegion).toBe("staging");
+        // The us workspace is redirected back to the us instance.
+        expect(result!.correctApiUrl).toBe("https://api.useatlas.dev");
+        expect(getMisroutedCount()).toBe(1);
+      });
+    });
   });
 
   // ── Counter reset ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes #2982. **Test-coverage only — no production code change.** `detectMisrouting` (`packages/api/src/lib/residency/misrouting.ts:115-168`) already handles the 4th `DeployRegion` (`staging`, #2897) **structurally** — it just compares the workspace region string against `getApiRegion()` and reads `regions[workspaceRegion]?.apiUrl` for the redirect hint. These tests pin that behavior before the staging instance goes live so a future refactor can't silently regress routing.

Four cases added under a new `describe("staging region")` block in `misrouting.test.ts`:

| Workspace region | API instance | Flagged? | `correctApiUrl` |
|---|---|---|---|
| `staging` | `staging` | **No** (match at `misrouting.ts:144`) | — |
| `staging` | `us` (staging **absent** from `regions`) | Yes | **absent** |
| `staging` | `us` (staging **present** in `regions`) | Yes | `https://api.staging.useatlas.dev` |
| `us` | `staging` | Yes | `https://api.useatlas.dev` |

## ⚠️ Finding: the issue's premise is now outdated

Issue #2982 states staging is "**intentionally absent from `residency.regions`**", so the redirect hint resolves to `undefined`. That was true when the issue was filed, but **PR #2925** (`4676a896`) later **added a `staging` arm** to `deploy/api/atlas.config.ts` — so the SaaS region guard accepts `ATLAS_API_REGION=staging` without a hard-fail boot — and **#3021** corrected its `apiUrl` to `https://api.staging.useatlas.dev`.

Net effect: in **today's** prod config, a (hypothetical) staging-keyed workspace hitting a prod instance would be flagged **with** `correctApiUrl = https://api.staging.useatlas.dev`, not `undefined`. The "future config change [that adds] a redirect" the issue wanted to guard against has effectively already landed.

**This is not a bug in `detectMisrouting`** — the function is region-agnostic and correctly reads whatever the config provides. Practical impact is nil: `strictRouting: false` in prod (so the hint only logs, never 421-redirects) and the staging arm comment notes "No real cross-region traffic ever claims residency=\"staging\"". Rather than assert the now-stale premise, I pinned **both** config states (absent-arm = issue's original intent; present-arm = current deploy reality) so the discrepancy is documented in the suite and a maintainer can decide whether prod instances *should* advertise the staging `apiUrl` as a redirect target.

## Acceptance criteria

- [x] Staging workspace on the staging instance is NOT flagged
- [x] Staging workspace on a `us|eu|apac` instance IS flagged, `correctApiUrl` absent when staging not in `residency.regions`
- [x] `us|eu|apac` workspace on the staging instance IS flagged
- [x] No change to non-staging behavior (existing 19 cases untouched, still green)

## Test plan

- `bun test src/lib/residency/__tests__/misrouting.test.ts` → 23 pass / 0 fail (was 19)
- Full `/ci`: lint, type, test (full suite, exit 0), syncpack, template/security-header/railway-watch/schema/oauth-helper drift, test-discipline, twenty-resolver, published-symbols — all pass

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3091"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782955628&installation_id=135337507&pr_number=3091&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3091&signature=566c08e62839634e75aeece55bc0778a1e323cb51529dc7697e1248bedc131de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Extended test coverage for staging region scenarios in request routing validation, including assertions for region detection accuracy and API endpoint resolution across multiple configuration states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->