### PR TITLE
fix(api): tear down circuit-breaker recovery fiber on _resetPool (#3083)

### DIFF
--- a/packages/api/src/lib/db/__tests__/internal.test.ts
+++ b/packages/api/src/lib/db/__tests__/internal.test.ts
@@ -19,6 +19,7 @@ import {
   hardDeleteWorkspace,
   _resetPool,
   _resetCircuitBreaker,
+  _hasRecoveryFiber,
   encryptSecret,
   decryptSecret,
   getEncryptionKey,
@@ -35,6 +36,12 @@ import { connections } from "../connection";
 // (1.5.4 / #2800).
 afterAll(() => {
   connections._reset();
+  // Tear down any circuit-breaker recovery fiber left by the last test in the
+  // file (e.g. the SqlClient-path circuit test). Without this, a fiber sleeping
+  // out its 30s recovery probe survives past the suite — harmless within this
+  // isolated process, but we keep the file fiber-clean as a matter of hygiene
+  // (#3083). Within-file cross-test leaks are prevented by _resetPool itself.
+  _resetCircuitBreaker();
 });
 
 /** Mirrors migration 0093's `postgres` catalog `config_schema`. Pinned
@@ -573,6 +580,51 @@ describe("internal DB module", () => {
       internalExecute("INSERT INTO audit_log (auth_mode) VALUES ($1)", ["none"]);
       await new Promise((r) => setTimeout(r, 10));
       expect(freshCalls.queries.length).toBe(1); // query went through
+    });
+
+    // Regression for #3083. Tripping the breaker forks a recovery fiber that
+    // sleeps 30s of wall-clock and then probes `getInternalDB().query("SELECT 1")`
+    // against whatever pool is *currently* installed. Before the fix, _resetPool
+    // reset the circuit flags but left that fiber running — so ~30s later it
+    // fired a spurious SELECT 1 into the next test's mock pool. That only
+    // surfaced under the isolated runner's 32-way concurrency, where the file
+    // runs slowly enough to still be executing 30s after the trip; in isolation
+    // the file finishes first and the probe lands harmlessly. We pin the
+    // mechanism (fiber torn down on reset) rather than the 30s behaviour so the
+    // regression stays fast and deterministic.
+    it("tears down the recovery fiber on reset so it can't probe a swapped-out pool (#3083)", async () => {
+      process.env.DATABASE_URL = "postgresql://user:pass@localhost:5432/atlas";
+      const { pool } = createMockPool();
+      pool._setError(new Error("connection refused"));
+      _resetPool(pool);
+
+      // No fiber until the breaker actually trips.
+      expect(_hasRecoveryFiber()).toBe(false);
+
+      for (let i = 0; i < 5; i++) {
+        internalExecute("INSERT INTO audit_log (auth_mode) VALUES ($1)", ["none"]);
+      }
+      // Let the fire-and-forget rejections settle so the breaker opens and forks
+      // the recovery fiber (the trip happens in the .catch microtask).
+      await new Promise((r) => setTimeout(r, 50));
+      expect(_hasRecoveryFiber()).toBe(true);
+
+      // Installing a fresh pool must kill the fiber — otherwise it survives to
+      // probe `freshPool` 30s later.
+      const { pool: freshPool } = createMockPool();
+      _resetPool(freshPool);
+      expect(_hasRecoveryFiber()).toBe(false);
+
+      // And _resetCircuitBreaker tears it down too (re-trip, then reset).
+      pool._setError(new Error("connection refused"));
+      _resetPool(pool);
+      for (let i = 0; i < 5; i++) {
+        internalExecute("INSERT INTO audit_log (auth_mode) VALUES ($1)", ["none"]);
+      }
+      await new Promise((r) => setTimeout(r, 50));
+      expect(_hasRecoveryFiber()).toBe(true);
+      _resetCircuitBreaker();
+      expect(_hasRecoveryFiber()).toBe(false);
     });
   });
 });

--- a/packages/api/src/lib/db/internal.ts
+++ b/packages/api/src/lib/db/internal.ts
@@ -590,7 +590,19 @@ export async function closeInternalDB(): Promise<void> {
   }
 }
 
-/** Reset singleton for testing. Optionally inject a mock pool and/or SqlClient. */
+/**
+ * Reset singleton for testing. Optionally inject a mock pool and/or SqlClient.
+ *
+ * Also tears down any in-flight circuit-breaker recovery fiber. A recovery
+ * fiber sleeps 30s of wall-clock and then probes `getInternalDB().query("SELECT 1")`
+ * against whatever pool is currently installed. If we swap `_pool` here but
+ * leave the fiber running, ~30s later it fires a spurious `SELECT 1` into the
+ * *next* test's mock pool — a cross-test timing flake that only surfaces when
+ * the suite runs slowly enough (e.g. under the isolated runner's 32-way
+ * concurrency) for the file to still be executing 30s after the circuit
+ * tripped. Resetting the pool must reset the full circuit state, fiber
+ * included (#3083).
+ */
 export function _resetPool(mockPool?: InternalPool | null, mockSql?: SqlClient.SqlClient | null): void {
   _pool = mockPool ?? null;
   _sqlClient = mockSql ?? null;
@@ -598,6 +610,7 @@ export function _resetPool(mockPool?: InternalPool | null, mockSql?: SqlClient.S
   _consecutiveFailures = 0;
   _circuitOpen = false;
   _droppedCount = 0;
+  _interruptRecoveryFiber();
 }
 
 /**
@@ -753,15 +766,35 @@ export function internalExecute(sqlStr: string, params?: unknown[]): void {
   }
 }
 
+/**
+ * Interrupt the in-flight recovery fiber (if any) and clear the reference.
+ *
+ * Shared by `_resetCircuitBreaker` and `_resetPool` so neither can leave a
+ * fiber alive to probe a swapped-out pool 30s later (#3083). The fiber is
+ * sleeping in `Effect.sleep(30s)` at this point, so interruption is prompt —
+ * the probe never runs. We null the reference synchronously; the forked
+ * interrupt completes in the background.
+ */
+function _interruptRecoveryFiber(): void {
+  if (_recoveryFiber) {
+    Effect.runFork(Fiber.interrupt(_recoveryFiber));
+    _recoveryFiber = null;
+  }
+}
+
 /** Reset circuit breaker state. For testing only. */
 export function _resetCircuitBreaker(): void {
   _consecutiveFailures = 0;
   _circuitOpen = false;
   _droppedCount = 0;
-  if (_recoveryFiber) {
-    Effect.runFork(Fiber.interrupt(_recoveryFiber));
-    _recoveryFiber = null;
-  }
+  _interruptRecoveryFiber();
+}
+
+/** @internal — test seam. True when a background recovery fiber is in flight.
+ *  Lets the #3083 regression test assert that a pool/circuit reset tears the
+ *  fiber down, without waiting out the 30s recovery sleep. */
+export function _hasRecoveryFiber(): boolean {
+  return _recoveryFiber !== null;
 }
 
 /**


### PR DESCRIPTION
Closes #3083.

## The flake
`packages/api/src/lib/db/__tests__/internal.test.ts` intermittently reported `1 fail` under the full isolated runner (concurrency 32) but passed **71/0** in isolation. Confirmed test-level timing flake (mocked clients, no real Postgres).

## Root cause — leaked Effect recovery fiber
When a circuit-breaker test trips the breaker, `internalExecute` forks a recovery fiber that `Effect.sleep`s 30s and then probes `getInternalDB().query("SELECT 1")` against **whatever pool is currently installed**.

- `_resetCircuitBreaker()` interrupts that fiber.
- `_resetPool()` reset the circuit *flags* (`_circuitOpen`, counters) but **left the fiber running** (`internal.ts` `_resetPool` vs `_resetCircuitBreaker`).

The last circuit-breaker test (`"_resetPool() also resets circuit breaker state"`) resets via `_resetPool`, so its recovery fiber survived. ~30s later the probe fired a spurious `SELECT 1` into a *later* test's mock pool — e.g. `cascadeWorkspaceDelete` `"returns settings: 0…"` asserts `calls.queries.length === 8`; the stray query makes it 9.

Why only under concurrency: in isolation the whole file finishes in <1s, so the 30s probe lands harmlessly after the suite (`_pool` is null). Under 32-way concurrency the file's wall-clock stretches past 30s, so the probe lands mid-test.

### Proof
A focused 31s reproduction (trip circuit on pool A → `_resetPool(poolB)` → wait 31s) showed `poolB queries: [{"sql":"SELECT 1"}]`, `sawProbe: true` **before** the fix, and `poolB queries: []`, `sawProbe: false` **after**. Log confirmed the circuit opening then `"circuit breaker recovered"` firing exactly 30s later.

## Fix
Route both `_resetPool` and `_resetCircuitBreaker` through a shared `_interruptRecoveryFiber()` so neither can leave a recovery fiber alive to probe a swapped-out pool. This **removes the wall-clock dependency entirely** — no test ever waits on or races the 30s timer — rather than widening a timeout (a longer wait is still a flake, just rarer).

- `_resetPool` now does a complete circuit reset (flags **and** fiber).
- File-level `afterAll` tears down the last test's fiber (hygiene).
- New `_hasRecoveryFiber()` test seam backs a **deterministic** regression test that pins "tripping the breaker forks a fiber; both resets tear it down" — fast, no 30s wait.

## Validation
- `bun test src/lib/db/__tests__/internal.test.ts` → **72/0** in isolation (+1 regression test).
- `for i in 1..5; do bun run scripts/test-isolated.ts --affected; done` (197 files, ~265–468s each) → `internal.test.ts` **PASS every run**, well past the 30s window.
- Full `bun run test` (539 files) → `internal.test.ts` **PASS**.
- 31s behavioral repro: contaminates pre-fix, clean post-fix.
- `/ci` local gates: lint, type, syncpack, template/security/railway/schema/oauth drift, test-discipline, twenty-resolver, published-symbols — **all pass**.

## Note on the full-suite run
My local full `bun run test` ran on an overloaded host (load avg 38 on 32 cores) at ~26.5 min (normal ~11 min) and saw **5 unrelated failures** — all `src/api/__tests__/*` route tests that race the 5s default timeout on first `getApp()` build under starvation. All 5 pass in isolation (<1.5s each), and the failing set is non-deterministic run-to-run, so they are environmental timeout flakes, **not** related to this change (which only touches `internal.ts`/`internal.test.ts`). Filed and characterized separately as **#3089**. The sharded GitHub `api-tests` checks are the authoritative full-suite gate.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3092"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782955951&installation_id=135337507&pr_number=3092&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3092&signature=cbed992a3da9e110dc1cf815b0f80d4d771b7520e431c1cd26a91d275c8c0e42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Fixed database circuit-breaker test isolation to prevent resource leaks between test cases and ensure proper cleanup of background recovery mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->