### PR TITLE
feat(api): wire StagingClamp into email delivery + fail-safe region narrowing (#2913, #2985)

### DIFF
--- a/docs/development/staging-environment.md
+++ b/docs/development/staging-environment.md
@@ -38,6 +38,33 @@ the public `GET /api/health` response:
 If you ever see a tab with **no** amber banner that you *think* is staging, treat
 it as production until proven otherwise — check `GET /api/health` directly.
 
+## Outbound mail is clamped to a sink
+
+Staging runs the **real** email-delivery code against real providers (Resend,
+etc.), so without a guard a soak could email real-looking customer addresses and
+burn sender reputation. Every outbound email is therefore redirected to a single
+sink before the provider send (#2913):
+
+- `sendEmail` (`packages/api/src/lib/email/delivery.ts`) routes every message
+  through `clampOutbound` (`packages/api/src/lib/staging/clamp.ts`), which
+  rewrites the recipient to `STAGING_MAIL_SINK` (default
+  `staging-mail@useatlas.dev`). Subject, body, and headers are preserved.
+- The clamp is **fail-closed** (#2985): it keys off `ATLAS_DEPLOY_ENV=staging`
+  (the authoritative soak-box signal), so a misconfigured or fat-fingered
+  `ATLAS_API_REGION` — even a *valid* prod value like `us` — cannot silently
+  disable it. On a staging-shaped deploy, mail is **always** clamped.
+- Boot **hard-fails** if a staging deploy doesn't also stamp
+  `ATLAS_API_REGION=staging` (`assertStagingMailRegion`, wired into
+  `StagingSeedLive`). A mislabeled staging box never serves — it exits non-zero
+  at boot rather than risk real mail.
+- If a staging box ever sends an email while `ATLAS_API_REGION` has drifted from
+  `staging`, the wiring layer logs a warn (keys only — no recipient/body) so the
+  drift is visible; fix it by setting `ATLAS_API_REGION=staging` on the service.
+
+> **cc / bcc / replyTo are not yet redirected** — the current `EmailMessage` has
+> only `to`. Adding any new recipient field means extending the clamp too
+> ([#2984](https://github.com/AtlasDevHQ/atlas/issues/2984)).
+
 ## Deploy trigger model
 
 | Branch / ref         | Target                          | Trigger                                   |
@@ -67,3 +94,6 @@ After a `main` merge deploys to staging:
 2. `curl https://api.staging.useatlas.dev/api/health` — confirm `200` and
    `"region":"staging"` in the body.
 3. Sign in and run a query end-to-end against the staging datasource.
+4. Trigger an email (e.g. a password reset) and confirm it lands in the
+   `STAGING_MAIL_SINK` inbox, **never** the real recipient — the outbound clamp
+   is working.

--- a/packages/api/src/lib/effect/layers.ts
+++ b/packages/api/src/lib/effect/layers.ts
@@ -86,7 +86,7 @@ import {
   type EmailOutboxDB,
   type RecoveryResult as EmailOutboxRecoveryResult,
 } from "@atlas/api/lib/email-outbox";
-import { sendEmail } from "@atlas/api/lib/email/delivery";
+import { sendEmail, assertStagingMailRegion } from "@atlas/api/lib/email/delivery";
 import {
   crmOutboxPendingCount,
   crmOutboxDeadCount,
@@ -1076,6 +1076,16 @@ export const StagingSeedLive: Layer.Layer<
 > = Layer.effect(
   StagingSeed,
   Effect.gen(function* () {
+    // Boot assert (#2985): a staging-shaped deploy (ATLAS_DEPLOY_ENV=staging)
+    // MUST stamp ATLAS_API_REGION=staging, else the outbound mail clamp
+    // (lib/email/delivery.ts) can't recognize the box as staging and would
+    // email real recipients. Runs BEFORE the region gate below so the
+    // dangerous "env=staging, region=us" misconfig is caught — the gate would
+    // otherwise early-return `skipped-region` and let the box serve real mail.
+    // A throw here becomes a boot-DAG defect → server.ts exits non-zero: a
+    // misconfigured staging boot is loud, never a silent skip (#2914 precedent).
+    assertStagingMailRegion();
+
     // Region gate first — non-staging boots are provably inert.
     if (getApiRegion() !== "staging") {
       return { outcome: "skipped-region" } satisfies StagingSeedResult;

--- a/packages/api/src/lib/email/__tests__/staging-clamp-wiring.test.ts
+++ b/packages/api/src/lib/email/__tests__/staging-clamp-wiring.test.ts
@@ -1,0 +1,307 @@
+/**
+ * Staging email-clamp WIRING tests (#2913 + #2985).
+ *
+ * The pure `clampOutbound` chokepoint (`lib/staging/clamp.ts`) is already
+ * unit-tested in `staging/__tests__/clamp.test.ts`. THIS suite covers the
+ * other half: that `sendEmail` actually routes every outbound message through
+ * the clamp BEFORE the provider send (#2913), and that the region the clamp
+ * receives is resolved FAIL-CLOSED so a misconfigured staging box can never
+ * silently email a real recipient (#2985).
+ *
+ * Why a separate file from `delivery.test.ts`: this suite needs a capturing
+ * logger mock (to assert the misconfig warn fires with keys only) and tight
+ * control of `ATLAS_API_REGION` / `ATLAS_DEPLOY_ENV`. bun's isolated per-file
+ * runner keeps those mocks from leaking into the sibling delivery suite.
+ *
+ * Observability of the clamp is indirect on purpose: `sendEmail` exposes no
+ * "what recipient did you send" return value, so we observe the REAL effect —
+ * the recipient handed to the provider — by capturing the Resend fetch body.
+ * That is the behavior that matters (a real address must never reach Resend
+ * from staging), not any internal call shape.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Capturing logger mock — lets the warn-observability test assert the wiring
+// layer logged the misconfig (keys only). All levels captured; tests inspect
+// `warnCalls`.
+// ---------------------------------------------------------------------------
+
+interface LogCall {
+  readonly obj: unknown;
+  readonly msg: string;
+}
+// Cleared in place (`.length = 0`) — never reassigned — because the logger
+// mock's `record(warnCalls)` closes over THIS array reference at module-load
+// time. Reassigning would leave the logger pushing into an orphaned array.
+const warnCalls: LogCall[] = [];
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- test logger shim
+const record = (sink: LogCall[]) => (obj: any, msg?: any) => {
+  sink.push({ obj, msg: typeof msg === "string" ? msg : String(obj) });
+};
+
+mock.module("@atlas/api/lib/logger", () => ({
+  createLogger: () => ({
+    info: () => {},
+    warn: record(warnCalls),
+    error: () => {},
+    debug: () => {},
+  }),
+}));
+
+const { sendEmail, assertStagingMailRegion } = await import("../delivery");
+
+// ---------------------------------------------------------------------------
+// Env snapshot + fetch capture
+// ---------------------------------------------------------------------------
+
+const ENV_KEYS = [
+  "ATLAS_API_REGION",
+  "ATLAS_DEPLOY_ENV",
+  "STAGING_MAIL_SINK",
+  "RESEND_API_KEY",
+  "ATLAS_EMAIL_FROM",
+] as const;
+const saved: Record<string, string | undefined> = {};
+const originalFetch = globalThis.fetch;
+
+/** Default sink when STAGING_MAIL_SINK is unset (mirrors clamp.ts). */
+const DEFAULT_SINK = "staging-mail@useatlas.dev";
+
+let lastResendTo: unknown;
+
+/**
+ * Mock fetch as a successful Resend send, capturing the `to` field the
+ * provider received. `to` is what the clamp rewrites; capturing it is how we
+ * assert the real address never escaped.
+ */
+function installResendCapture() {
+  lastResendTo = undefined;
+  globalThis.fetch = (async (_url: string, init?: RequestInit) => {
+    const body = init?.body ? JSON.parse(init.body as string) : {};
+    lastResendTo = body.to;
+    return new Response(JSON.stringify({ id: "msg-1" }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }) as unknown as typeof globalThis.fetch;
+}
+
+beforeEach(() => {
+  for (const key of ENV_KEYS) saved[key] = process.env[key];
+  for (const key of ENV_KEYS) delete process.env[key];
+  // A configured provider so sendEmail reaches the network path (not the
+  // no-transport log fallback) and the clamp's effect is observable.
+  process.env.RESEND_API_KEY = "re_test_key";
+  warnCalls.length = 0;
+  installResendCapture();
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  for (const key of ENV_KEYS) {
+    if (saved[key] !== undefined) process.env[key] = saved[key];
+    else delete process.env[key];
+  }
+});
+
+const REAL = "real.customer@example.com";
+
+// ---------------------------------------------------------------------------
+// #2913 — the clamp is wired into the send path
+// ---------------------------------------------------------------------------
+
+describe("sendEmail — staging clamp wiring (#2913)", () => {
+  it("rewrites the recipient to the sink before the provider send on ATLAS_API_REGION=staging", async () => {
+    process.env.ATLAS_API_REGION = "staging";
+
+    const result = await sendEmail({ to: REAL, subject: "Q3 report", html: "<p>x</p>" });
+
+    expect(result.success).toBe(true);
+    expect(result.provider).toBe("resend");
+    // Resend's payload sends `to` as an array — the real address must be gone.
+    expect(lastResendTo).toEqual([DEFAULT_SINK]);
+  });
+
+  it("honors STAGING_MAIL_SINK as the redirect target", async () => {
+    process.env.ATLAS_API_REGION = "staging";
+    process.env.STAGING_MAIL_SINK = "soak-inbox@staging.useatlas.dev";
+
+    await sendEmail({ to: REAL, subject: "x", html: "<p>x</p>" });
+
+    expect(lastResendTo).toEqual(["soak-inbox@staging.useatlas.dev"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Prod / self-hosted / dev paths are unchanged (#2913 acceptance: identity
+// for `us|eu|apac` and for an unset region off the staging env).
+// ---------------------------------------------------------------------------
+
+describe("sendEmail — non-staging regions deliver the real recipient unchanged", () => {
+  for (const region of ["us", "eu", "apac"] as const) {
+    it(`delivers to the real recipient for ATLAS_API_REGION=${region}`, async () => {
+      process.env.ATLAS_API_REGION = region;
+
+      await sendEmail({ to: REAL, subject: "x", html: "<p>x</p>" });
+
+      expect(lastResendTo).toEqual([REAL]);
+    });
+  }
+
+  it("delivers to the real recipient when ATLAS_API_REGION is unset (self-hosted / dev)", async () => {
+    // No ATLAS_API_REGION, no ATLAS_DEPLOY_ENV → getApiRegion() is null and
+    // the deploy env defaults to production → no clamp.
+    await sendEmail({ to: REAL, subject: "x", html: "<p>x</p>" });
+
+    expect(lastResendTo).toEqual([REAL]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #2985 — FAIL-CLOSED: a staging-shaped deploy (ATLAS_DEPLOY_ENV=staging) ALWAYS
+// clamps, regardless of how ATLAS_API_REGION is (mis)configured. The whole
+// point of this issue: a malformed/unknown/fat-fingered region cannot silently
+// disable the clamp on the staging deploy and email a real recipient.
+// ---------------------------------------------------------------------------
+
+describe("sendEmail — fail-closed staging clamp (#2985)", () => {
+  beforeEach(() => {
+    process.env.ATLAS_DEPLOY_ENV = "staging";
+  });
+
+  // THE load-bearing case: a region narrow alone would PASS `"us"`
+  // (isDeployRegion("us") === true) and route through the prod identity path,
+  // emailing a real recipient from the staging box. The deploy-env axis closes
+  // that gap — staging-env clamps no matter the region.
+  it("clamps even when ATLAS_API_REGION is fat-fingered to a valid prod region (us)", async () => {
+    process.env.ATLAS_API_REGION = "us";
+
+    await sendEmail({ to: REAL, subject: "x", html: "<p>x</p>" });
+
+    expect(lastResendTo).toEqual([DEFAULT_SINK]);
+  });
+
+  it("clamps when ATLAS_API_REGION is unset on a staging-shaped deploy (null must not leak)", async () => {
+    // ATLAS_API_REGION deliberately not set.
+    await sendEmail({ to: REAL, subject: "x", html: "<p>x</p>" });
+
+    expect(lastResendTo).toEqual([DEFAULT_SINK]);
+  });
+
+  // The exact misconfig vectors #2985 names: wrong case, trailing whitespace,
+  // a typo. None of these narrow to a DeployRegion, and on a staging box none
+  // may leak.
+  for (const malformed of ["Staging", "staging ", " staging", "stg", "us-west"]) {
+    it(`clamps when ATLAS_API_REGION is the malformed value ${JSON.stringify(malformed)}`, async () => {
+      process.env.ATLAS_API_REGION = malformed;
+
+      await sendEmail({ to: REAL, subject: "x", html: "<p>x</p>" });
+
+      expect(lastResendTo).toEqual([DEFAULT_SINK]);
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// #2985 — observability: surface the region/env divergence so a soak operator
+// can SEE (and fix) the misconfig that a naive region narrow would have leaked
+// on. The clamp still fires defensively (the cases above prove no leak); this
+// warn converts the otherwise-silent misconfig into a visible signal. KEYS
+// ONLY — the recipient/body never appears in the log.
+// ---------------------------------------------------------------------------
+
+/** Find the staging-region misconfig warn among captured warn calls. */
+function findMisconfigWarn() {
+  return warnCalls.find((c) => /ATLAS_API_REGION/.test(c.msg) && /staging/i.test(c.msg));
+}
+
+describe("sendEmail — staging region-misconfig warn (#2985)", () => {
+  it("warns (keys only) when ATLAS_DEPLOY_ENV=staging but ATLAS_API_REGION diverges", async () => {
+    process.env.ATLAS_DEPLOY_ENV = "staging";
+    process.env.ATLAS_API_REGION = "us"; // diverges from the expected "staging"
+
+    await sendEmail({ to: REAL, subject: "secret-subject", html: "<p>secret-body</p>" });
+
+    const warn = findMisconfigWarn();
+    expect(warn).toBeDefined();
+    // No recipient or body content may appear anywhere in the log entry.
+    const serialized = JSON.stringify(warn);
+    expect(serialized).not.toContain(REAL);
+    expect(serialized).not.toContain("secret-subject");
+    expect(serialized).not.toContain("secret-body");
+    // The diagnostic config keys an operator needs ARE present.
+    expect(serialized).toContain("us");
+    expect(serialized).toContain("staging");
+  });
+
+  it("does NOT warn when staging is correctly configured (region === 'staging')", async () => {
+    process.env.ATLAS_DEPLOY_ENV = "staging";
+    process.env.ATLAS_API_REGION = "staging";
+
+    await sendEmail({ to: REAL, subject: "x", html: "<p>x</p>" });
+
+    expect(findMisconfigWarn()).toBeUndefined();
+  });
+
+  it("does NOT warn off the staging env even when a region looks odd", async () => {
+    // Production deploy with a granular region — legitimate, not a staging
+    // misconfig, so no warn.
+    process.env.ATLAS_DEPLOY_ENV = "production";
+    process.env.ATLAS_API_REGION = "us-west";
+
+    await sendEmail({ to: REAL, subject: "x", html: "<p>x</p>" });
+
+    expect(findMisconfigWarn()).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #2985 — boot assert: a staging-shaped deploy MUST stamp ATLAS_API_REGION=staging.
+// Wired into the staging boot Layer (effect/layers.ts:StagingSeedLive); a throw
+// there dies the boot DAG so a misconfigured staging box never serves real mail.
+// ---------------------------------------------------------------------------
+
+describe("assertStagingMailRegion (#2985)", () => {
+  it("throws on a staging-shaped deploy whose ATLAS_API_REGION is fat-fingered to a prod region", () => {
+    process.env.ATLAS_DEPLOY_ENV = "staging";
+    process.env.ATLAS_API_REGION = "us";
+
+    expect(() => assertStagingMailRegion()).toThrow(/ATLAS_API_REGION/);
+  });
+
+  it("throws on a staging-shaped deploy whose ATLAS_API_REGION is unset", () => {
+    process.env.ATLAS_DEPLOY_ENV = "staging";
+    // ATLAS_API_REGION deliberately unset.
+
+    expect(() => assertStagingMailRegion()).toThrow(/staging/i);
+  });
+
+  it("throws on a staging-shaped deploy whose ATLAS_API_REGION is malformed (whitespace)", () => {
+    process.env.ATLAS_DEPLOY_ENV = "staging";
+    process.env.ATLAS_API_REGION = "staging "; // trailing whitespace
+
+    expect(() => assertStagingMailRegion()).toThrow();
+  });
+
+  it("does NOT throw when staging is correctly configured", () => {
+    process.env.ATLAS_DEPLOY_ENV = "staging";
+    process.env.ATLAS_API_REGION = "staging";
+
+    expect(() => assertStagingMailRegion()).not.toThrow();
+  });
+
+  it("is a no-op off the staging env (prod / self-hosted / dev), whatever the region", () => {
+    // Production with a real region — fine.
+    process.env.ATLAS_DEPLOY_ENV = "production";
+    process.env.ATLAS_API_REGION = "us";
+    expect(() => assertStagingMailRegion()).not.toThrow();
+
+    // Unset deploy env (defaults to production) with no region — fine.
+    delete process.env.ATLAS_DEPLOY_ENV;
+    delete process.env.ATLAS_API_REGION;
+    expect(() => assertStagingMailRegion()).not.toThrow();
+  });
+});

--- a/packages/api/src/lib/email/__tests__/staging-clamp-wiring.test.ts
+++ b/packages/api/src/lib/email/__tests__/staging-clamp-wiring.test.ts
@@ -51,7 +51,8 @@ mock.module("@atlas/api/lib/logger", () => ({
   }),
 }));
 
-const { sendEmail, assertStagingMailRegion } = await import("../delivery");
+const { sendEmail, sendEmailWithTransport, assertStagingMailRegion } = await import("../delivery");
+type EmailTransport = Parameters<typeof sendEmailWithTransport>[1];
 
 // ---------------------------------------------------------------------------
 // Env snapshot + fetch capture
@@ -63,6 +64,7 @@ const ENV_KEYS = [
   "STAGING_MAIL_SINK",
   "RESEND_API_KEY",
   "ATLAS_EMAIL_FROM",
+  "ATLAS_SMTP_URL",
 ] as const;
 const saved: Record<string, string | undefined> = {};
 const originalFetch = globalThis.fetch;
@@ -303,5 +305,79 @@ describe("assertStagingMailRegion (#2985)", () => {
     delete process.env.ATLAS_DEPLOY_ENV;
     delete process.env.ATLAS_API_REGION;
     expect(() => assertStagingMailRegion()).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The clamp is applied ONCE before the provider branch, so it must cover every
+// provider — not just Resend. These lock that invariant against a future
+// refactor that adds a provider path consuming the raw (unclamped) message.
+// ---------------------------------------------------------------------------
+
+describe("sendEmail — clamp covers the webhook provider path too", () => {
+  // Route through deliverWebhook instead of deliverResend: set ATLAS_SMTP_URL
+  // and clear RESEND_API_KEY (otherwise the platform-config path resolves a
+  // Resend transport and short-circuits before the webhook branch). Env is set
+  // inside the test body (not a describe beforeEach) so it survives the
+  // file-level beforeEach that clears every ENV_KEY regardless of hook ordering.
+  // The fetch capture records `body.to`, which the webhook sends as a bare string.
+  const WEBHOOK_URL = "https://smtp-bridge.example.com/send";
+
+  it("rewrites the recipient to the sink on staging (webhook path)", async () => {
+    delete process.env.RESEND_API_KEY;
+    process.env.ATLAS_SMTP_URL = WEBHOOK_URL;
+    process.env.ATLAS_API_REGION = "staging";
+
+    const result = await sendEmail({ to: REAL, subject: "x", html: "<p>x</p>" });
+
+    expect(result.provider).toBe("webhook");
+    expect(lastResendTo).toBe(DEFAULT_SINK); // webhook `to` is a bare string
+  });
+
+  it("delivers the real recipient off staging (webhook path, region=us)", async () => {
+    delete process.env.RESEND_API_KEY;
+    process.env.ATLAS_SMTP_URL = WEBHOOK_URL;
+    process.env.ATLAS_API_REGION = "us";
+
+    await sendEmail({ to: REAL, subject: "x", html: "<p>x</p>" });
+
+    expect(lastResendTo).toBe(REAL);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sendEmailWithTransport is the SECOND outbound entry point (admin "test
+// email" with fresh credentials). It must clamp too, or a staging admin
+// testing creds would email a real recipient (#2913/#2985).
+// ---------------------------------------------------------------------------
+
+describe("sendEmailWithTransport — clamps the admin test-email path", () => {
+  const resendTransport: EmailTransport = {
+    provider: "resend",
+    senderAddress: "Atlas <noreply@useatlas.dev>",
+    config: { provider: "resend", apiKey: "re_transport_key" },
+  };
+
+  it("rewrites the admin-supplied recipient to the sink on staging", async () => {
+    process.env.ATLAS_API_REGION = "staging";
+
+    const result = await sendEmailWithTransport(
+      { to: REAL, subject: "x", html: "<p>x</p>" },
+      resendTransport,
+    );
+
+    expect(result.success).toBe(true);
+    expect(lastResendTo).toEqual([DEFAULT_SINK]);
+  });
+
+  it("delivers to the admin-supplied recipient off staging (region=us)", async () => {
+    process.env.ATLAS_API_REGION = "us";
+
+    await sendEmailWithTransport(
+      { to: REAL, subject: "x", html: "<p>x</p>" },
+      resendTransport,
+    );
+
+    expect(lastResendTo).toEqual([REAL]);
   });
 });

--- a/packages/api/src/lib/email/__tests__/staging-clamp-wiring.test.ts
+++ b/packages/api/src/lib/email/__tests__/staging-clamp-wiring.test.ts
@@ -21,6 +21,11 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
+// Real logger module, spread into the mock below so we override ONLY
+// `createLogger` and keep every other export intact ("mock all exports" rule —
+// a partial mock would `undefined` out `withRequestContext`, `redactPaths`,
+// etc. for anything in the SUT's import graph that uses them).
+import * as actualLogger from "@atlas/api/lib/logger";
 
 // ---------------------------------------------------------------------------
 // Capturing logger mock — lets the warn-observability test assert the wiring
@@ -43,6 +48,7 @@ const record = (sink: LogCall[]) => (obj: any, msg?: any) => {
 };
 
 mock.module("@atlas/api/lib/logger", () => ({
+  ...actualLogger,
   createLogger: () => ({
     info: () => {},
     warn: record(warnCalls),

--- a/packages/api/src/lib/email/delivery.ts
+++ b/packages/api/src/lib/email/delivery.ts
@@ -38,10 +38,16 @@ const log = createLogger("email-delivery");
  * `isDeployRegion` and the template ref bumped, this local copy can be replaced
  * with the import.
  *
- * `satisfies readonly DeployRegion[]` keeps the literal set from drifting out
- * of sync with the union.
+ * Drift is guarded in BOTH directions, mirroring the canonical copy:
+ * `satisfies readonly DeployRegion[]` rejects a typo'd entry (tuple ⊆ union),
+ * and `_AssertDeployRegionsExhaustive` rejects a region added to the union
+ * without a matching entry here (union ⊆ tuple) — the direction `satisfies`
+ * alone does not catch.
  */
 const DEPLOY_REGIONS = ["us", "eu", "apac", "staging"] as const satisfies readonly DeployRegion[];
+type _AssertDeployRegionsExhaustive =
+  [Exclude<DeployRegion, (typeof DEPLOY_REGIONS)[number]>] extends [never] ? true : never;
+const _deployRegionsExhaustive: _AssertDeployRegionsExhaustive = true;
 function isDeployRegion(value: string | null): value is DeployRegion {
   return value !== null && (DEPLOY_REGIONS as readonly string[]).includes(value);
 }
@@ -181,6 +187,21 @@ function warnStagingRegionMisconfig(payload: EmailMessage): void {
       "outbound mail was clamped to the staging sink defensively, but set ATLAS_API_REGION=staging " +
       "on this service to fix the drift (#2985)",
   );
+}
+
+/**
+ * The single staging-clamp chokepoint (#2913/#2985): warn on a region/env
+ * misconfig (keys only), then redirect recipients to the staging sink when this
+ * is the staging soak box. EVERY public send entry point ({@link sendEmail} and
+ * {@link sendEmailWithTransport}) funnels through this, so no provider path can
+ * email a real recipient from staging. Identity for prod / self-hosted / dev
+ * (`resolveOutboundClampRegion` returns `null`, and `clampOutbound` is identity
+ * for the three prod regions regardless).
+ */
+function clampForOutbound(message: EmailMessage): EmailMessage {
+  warnStagingRegionMisconfig(message);
+  const clampRegion = resolveOutboundClampRegion();
+  return clampRegion ? clampOutbound(clampRegion, message) : message;
 }
 
 export interface EmailMessage {
@@ -337,12 +358,8 @@ export async function sendEmail(message: EmailMessage, orgId?: string): Promise<
   // sink BEFORE any provider send so the soak box can never email a real
   // address. `outbound` replaces `message` for the rest of the function so
   // EVERY delivery path (DB transport, platform, webhook, Resend) is covered —
-  // a path that kept using the raw `message` would leak. Identity for prod /
-  // self-hosted / dev (`resolveOutboundClampRegion()` returns `null` there, and
-  // `clampOutbound` is identity for the three prod regions anyway).
-  warnStagingRegionMisconfig(message);
-  const clampRegion = resolveOutboundClampRegion();
-  const outbound = clampRegion ? clampOutbound(clampRegion, message) : message;
+  // a path that kept using the raw `message` would leak.
+  const outbound = clampForOutbound(message);
 
   // 1. Try DB-stored config for the org
   if (orgId) {
@@ -382,12 +399,18 @@ export async function sendEmail(message: EmailMessage, orgId?: string): Promise<
 /**
  * Send an email using explicit transport credentials.
  * Used by the admin test endpoint to validate credentials before saving.
+ *
+ * Routes through the SAME staging clamp as {@link sendEmail} (#2913/#2985):
+ * this is a second outbound entry point, and the admin "test email" endpoint
+ * sends to an admin-supplied recipient — without the clamp a staging soak admin
+ * testing credentials would email a real address. On staging the test still
+ * validates the transport; the message just lands in the sink.
  */
 export async function sendEmailWithTransport(
   message: EmailMessage,
   transport: EmailTransport,
 ): Promise<DeliveryResult> {
-  return deliverViaTransport(message, transport);
+  return deliverViaTransport(clampForOutbound(message), transport);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/api/src/lib/email/delivery.ts
+++ b/packages/api/src/lib/email/delivery.ts
@@ -18,8 +18,170 @@ import {
   type EmailProvider,
   type ProviderConfig,
 } from "@atlas/api/lib/integrations/types";
+import type { DeployRegion } from "@useatlas/types";
+import { getApiRegion } from "@atlas/api/lib/residency/misrouting";
+import { resolveDeployEnv } from "@atlas/api/lib/env-profile";
+import { clampOutbound } from "@atlas/api/lib/staging/clamp";
 
 const log = createLogger("email-delivery");
+
+/**
+ * Local mirror of `isDeployRegion` from `@useatlas/types` (its canonical home,
+ * where it is also exported + unit-tested). It is duplicated here — rather than
+ * imported — ON PURPOSE: this file is scaffold-bound source (the create-atlas
+ * template regenerates from `packages/api/src`), so importing a *value* export
+ * that the pinned-published `@useatlas/types` does not yet ship would fail
+ * `scripts/check-published-symbols.ts` and break the scaffold smoke tests
+ * (value exports erase to nothing in the published tarball — the
+ * version-bump-ordering rule). `DeployRegion` is imported type-only above
+ * because types erase and are safe. Once `@useatlas/types` is published with
+ * `isDeployRegion` and the template ref bumped, this local copy can be replaced
+ * with the import.
+ *
+ * `satisfies readonly DeployRegion[]` keeps the literal set from drifting out
+ * of sync with the union.
+ */
+const DEPLOY_REGIONS = ["us", "eu", "apac", "staging"] as const satisfies readonly DeployRegion[];
+function isDeployRegion(value: string | null): value is DeployRegion {
+  return value !== null && (DEPLOY_REGIONS as readonly string[]).includes(value);
+}
+
+// ---------------------------------------------------------------------------
+// Staging outbound clamp wiring (#2913 + #2985)
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the {@link DeployRegion} to clamp outbound mail against — FAIL-CLOSED
+ * for the staging soak box (#2985). The clamp's whole job is "a staging soak
+ * can never email a real recipient," so the resolution biases hard toward
+ * clamping whenever there is any chance this is the staging box.
+ *
+ * Two independent signals are read; the deploy ENV is authoritative:
+ *
+ *  1. `resolveDeployEnv()` (the `ATLAS_DEPLOY_ENV` axis) — if this is a
+ *     staging-shaped deploy we return `"staging"` UNCONDITIONALLY, regardless
+ *     of what region is stamped. This is the load-bearing fail-closed branch:
+ *     it catches the misconfig that a plain region narrow CANNOT — a staging
+ *     box whose `ATLAS_API_REGION` was fat-fingered to a *valid* prod region
+ *     like `"us"` (which `isDeployRegion` happily accepts, so a region-only
+ *     check would route it through the prod identity path and email a real
+ *     recipient). It also covers a malformed / `"Staging"` / whitespace /
+ *     unset region on a staging box.
+ *  2. Otherwise narrow `getApiRegion()` (the `ATLAS_API_REGION` discriminator)
+ *     through {@link isDeployRegion}. An exact match (`us`/`eu`/`apac`/
+ *     `staging`) is used as-is — `clampOutbound` is identity for the three
+ *     prod regions and rewrites recipients only for `staging`. Anything else
+ *     (`null` unset → self-hosted / dev / CI; a granular `"us-west"`; an
+ *     operator-defined residency key) is NOT a deploy region off the staging
+ *     env, so we return `null` → no clamp, mail flows normally.
+ *
+ * Why the ENV axis is authoritative rather than the region: the threat is a
+ * staging box that emails a real address. `ATLAS_DEPLOY_ENV=staging` is the
+ * one signal a soak operator sets deliberately to say "this is the soak box";
+ * keying the clamp off it means no single fat-fingered `ATLAS_API_REGION` can
+ * re-open the leak. The companion {@link assertStagingMailRegion} boot assert
+ * makes the region/env divergence fail the boot outright; this runtime
+ * resolver is the defense-in-depth that still clamps if that assert is ever
+ * bypassed or disabled.
+ *
+ * @returns the region to pass to {@link clampOutbound}, or `null` when no
+ *          clamp applies (prod / self-hosted / dev / CI).
+ */
+export function resolveOutboundClampRegion(): DeployRegion | null {
+  // Authoritative fail-closed signal — a staging-shaped deploy ALWAYS clamps.
+  if (resolveDeployEnv() === "staging") return "staging";
+  const region = getApiRegion();
+  return isDeployRegion(region) ? region : null;
+}
+
+/**
+ * Is `payload` an email-shaped outbound (both `subject` and `html` present)?
+ * Pure + exported so the staging misconfig-warn decision is unit-testable
+ * without the logger. Used ONLY to decide whether to emit the observability
+ * warn — never to gate the clamp itself (the clamp is structural on `to`).
+ */
+export function isEmailShapedPayload(payload: unknown): boolean {
+  return (
+    typeof payload === "object" &&
+    payload !== null &&
+    "subject" in payload &&
+    "html" in payload
+  );
+}
+
+/**
+ * Should the wiring layer warn about a staging region misconfig for this
+ * payload? True when the deploy ENV is `staging` (the soak box) but the region
+ * discriminator (`ATLAS_API_REGION`) is NOT exactly `"staging"`, and the
+ * payload is email-shaped. Pure + exported for unit testing (#2985).
+ *
+ * This is the observable signal of the silent-leak class: a naive wiring that
+ * narrowed `ATLAS_API_REGION` without the fail-closed env branch WOULD have
+ * routed this email through the prod identity path and emailed a real
+ * recipient. {@link resolveOutboundClampRegion} forces the clamp regardless so
+ * nothing leaks, but the operator still needs to SEE — and fix — the divergent
+ * `ATLAS_API_REGION`.
+ */
+export function shouldWarnStagingRegionMisconfig(payload: unknown): boolean {
+  if (resolveDeployEnv() !== "staging") return false;
+  if (getApiRegion() === "staging") return false;
+  return isEmailShapedPayload(payload);
+}
+
+/**
+ * Boot assert (#2985): a staging-shaped deploy (`ATLAS_DEPLOY_ENV=staging`)
+ * MUST also stamp `ATLAS_API_REGION=staging`. Throws otherwise so boot fails
+ * loudly rather than serving a soak box that can't recognize itself as staging
+ * and would email real recipients.
+ *
+ * This is the hard-fail half of the #2985 fail-closed pair. The runtime
+ * {@link resolveOutboundClampRegion} ALREADY clamps unconditionally on a
+ * staging-env deploy, so a leak is prevented even without this assert — but a
+ * silently-mislabeled staging box (`ATLAS_API_REGION=us`) is itself a bug that
+ * should never ship: it breaks region-keyed routing, seeding, and metrics, not
+ * just mail. Failing the boot turns that latent misconfig into an immediate,
+ * diagnosable error instead of a box that quietly behaves like prod.
+ *
+ * No-op off the staging env (prod / self-hosted / dev), so prod boots — which
+ * legitimately carry `ATLAS_API_REGION` of `us`/`eu`/`apac` and an
+ * `ATLAS_DEPLOY_ENV` of `production` (or unset) — are never affected.
+ *
+ * Wired into the staging boot Layer (`effect/layers.ts:StagingSeedLive`),
+ * BEFORE its region gate, so the dangerous "env=staging, region=us" case is
+ * caught (the gate would otherwise early-return and let the box serve mail).
+ */
+export function assertStagingMailRegion(): void {
+  if (resolveDeployEnv() !== "staging") return;
+  const region = getApiRegion();
+  if (region === "staging") return;
+  throw new Error(
+    `Staging deploy misconfigured: ATLAS_DEPLOY_ENV=staging but ATLAS_API_REGION=${JSON.stringify(region)} ` +
+      `(expected exactly "staging"). The outbound mail clamp keys off ATLAS_API_REGION; a non-"staging" value ` +
+      `would let the staging soak box email real recipients. Set ATLAS_API_REGION=staging on this service (#2985).`,
+  );
+}
+
+/**
+ * Emit the staging region-misconfig warn (KEYS ONLY — never the recipient or
+ * body). Logs only the two config keys an operator must reconcile (`deployEnv`,
+ * `apiRegion`); the message states the clamp already fired defensively so the
+ * entry reads as "fix your config," not "mail leaked."
+ */
+function warnStagingRegionMisconfig(payload: EmailMessage): void {
+  if (!shouldWarnStagingRegionMisconfig(payload)) return;
+  log.warn(
+    {
+      // KEYS ONLY: the two config values an operator must reconcile. Both are
+      // deploy-region/env labels — NOT the recipient, subject, or body — so
+      // they are safe to log. The recipient/body are deliberately absent.
+      deployEnv: resolveDeployEnv(),
+      apiRegion: getApiRegion(),
+    },
+    "Staging deploy has ATLAS_API_REGION != 'staging' while sending an email-shaped payload — " +
+      "outbound mail was clamped to the staging sink defensively, but set ATLAS_API_REGION=staging " +
+      "on this service to fix the drift (#2985)",
+  );
+}
 
 export interface EmailMessage {
   to: string;
@@ -171,36 +333,47 @@ function getPlatformEmailConfig(): EmailTransport | null {
  * Pass `orgId` to enable DB-backed email config lookup. When omitted, falls back to platform/env settings.
  */
 export async function sendEmail(message: EmailMessage, orgId?: string): Promise<DeliveryResult> {
+  // Staging outbound clamp (#2913/#2985): redirect recipients to the staging
+  // sink BEFORE any provider send so the soak box can never email a real
+  // address. `outbound` replaces `message` for the rest of the function so
+  // EVERY delivery path (DB transport, platform, webhook, Resend) is covered —
+  // a path that kept using the raw `message` would leak. Identity for prod /
+  // self-hosted / dev (`resolveOutboundClampRegion()` returns `null` there, and
+  // `clampOutbound` is identity for the three prod regions anyway).
+  warnStagingRegionMisconfig(message);
+  const clampRegion = resolveOutboundClampRegion();
+  const outbound = clampRegion ? clampOutbound(clampRegion, message) : message;
+
   // 1. Try DB-stored config for the org
   if (orgId) {
     const transport = await getEmailTransport(orgId);
     if (transport) {
-      return deliverViaTransport(message, transport);
+      return deliverViaTransport(outbound, transport);
     }
   }
 
   // 2. Platform email provider (settings registry)
   const platformConfig = getPlatformEmailConfig();
   if (platformConfig) {
-    return deliverViaTransport(message, platformConfig);
+    return deliverViaTransport(outbound, platformConfig);
   }
 
   const fromAddress = process.env.ATLAS_EMAIL_FROM ?? "Atlas <noreply@ship.useatlas.dev>";
 
   // 3. Webhook delivery (generic email API)
   if (process.env.ATLAS_SMTP_URL) {
-    return deliverWebhook(message, fromAddress);
+    return deliverWebhook(outbound, fromAddress);
   }
 
   // 4. Resend API delivery (env-var fallback for backward compat)
   if (process.env.RESEND_API_KEY) {
-    return deliverResend(message, fromAddress);
+    return deliverResend(outbound, fromAddress);
   }
 
   // 5. Dev fallback — log instead of sending. Returns success: false so the email
   // is not recorded as sent, allowing retry when a provider is configured.
   log.warn(
-    { to: message.to, subject: message.subject },
+    { to: outbound.to, subject: outbound.subject },
     "Email delivery skipped — no email provider configured",
   );
   return { success: false, provider: "log", error: "No email delivery backend configured (configure a platform email provider or set RESEND_API_KEY)" };

--- a/packages/types/src/__tests__/deploy.test.ts
+++ b/packages/types/src/__tests__/deploy.test.ts
@@ -1,0 +1,79 @@
+/**
+ * `isDeployRegion` narrowing-guard tests (#2985).
+ *
+ * `isDeployRegion` is the type guard the staging email-clamp wiring
+ * (`packages/api/src/lib/email/delivery.ts`) uses to narrow the raw
+ * `getApiRegion(): string | null` read into a `DeployRegion` instead of an
+ * unchecked cast. Its WHOLE JOB is to be exact: only the four first-party
+ * deploy regions pass. A value that is "close" — wrong case, trailing
+ * whitespace, a granular `"us-west"`, a typo, `null` — must return `false`
+ * so the caller fails CLOSED (clamps / hard-fails) rather than treating a
+ * mislabelled staging box as a prod region and emailing a real recipient.
+ *
+ * These cases pin that exactness so a future "be lenient" edit (trim,
+ * lowercase, prefix-match) trips the suite.
+ */
+
+import { describe, test, expect } from "bun:test";
+import { isDeployRegion, type DeployRegion } from "../deploy";
+
+describe("isDeployRegion — accepts exactly the four deploy regions", () => {
+  for (const region of ["us", "eu", "apac", "staging"] as const) {
+    test(`accepts "${region}"`, () => {
+      expect(isDeployRegion(region)).toBe(true);
+    });
+  }
+});
+
+describe("isDeployRegion — rejects everything else (fail-closed inputs)", () => {
+  test("rejects null (region unset)", () => {
+    expect(isDeployRegion(null)).toBe(false);
+  });
+
+  test("rejects the empty string", () => {
+    expect(isDeployRegion("")).toBe(false);
+  });
+
+  // The exact misconfig vectors #2985 must not let leak: a staging box whose
+  // ATLAS_API_REGION is "Staging" / "staging " must NOT narrow to a
+  // DeployRegion (which would skip the clamp and email real recipients).
+  test("rejects wrong case", () => {
+    expect(isDeployRegion("Staging")).toBe(false);
+    expect(isDeployRegion("US")).toBe(false);
+  });
+
+  test("rejects leading/trailing whitespace", () => {
+    expect(isDeployRegion("staging ")).toBe(false);
+    expect(isDeployRegion(" staging")).toBe(false);
+  });
+
+  // Granular residency keys (`us-west`, `eu-west`) are the OPEN `Region`
+  // concept, not the coarse first-party `DeployRegion`. They are not
+  // DeployRegions, so they must not narrow.
+  test("rejects granular residency keys", () => {
+    expect(isDeployRegion("us-west")).toBe(false);
+    expect(isDeployRegion("eu-west")).toBe(false);
+    expect(isDeployRegion("ap-southeast")).toBe(false);
+  });
+
+  test("rejects typos / unknown strings", () => {
+    expect(isDeployRegion("stg")).toBe(false);
+    expect(isDeployRegion("prod")).toBe(false);
+    expect(isDeployRegion("production")).toBe(false);
+  });
+});
+
+describe("isDeployRegion — narrows the type for the compiler", () => {
+  // The guard's value is the static narrowing it gives the wiring site. This
+  // asserts the predicate flows: inside the `true` branch, `value` is a
+  // `DeployRegion` and is assignable to one with no cast.
+  test("narrows string | null to DeployRegion in the true branch", () => {
+    const value: string | null = "staging";
+    if (isDeployRegion(value)) {
+      const narrowed: DeployRegion = value;
+      expect(narrowed).toBe("staging");
+    } else {
+      throw new Error("expected isDeployRegion to narrow 'staging'");
+    }
+  });
+});

--- a/packages/types/src/deploy.ts
+++ b/packages/types/src/deploy.ts
@@ -33,10 +33,26 @@ export type DeployRegion = "us" | "eu" | "apac" | "staging";
 
 /**
  * The closed set of {@link DeployRegion} values, as a runtime tuple. Kept
- * adjacent to the type so the two cannot drift: a new region added to the
- * union without an entry here is a `satisfies` compile error below.
+ * adjacent to the type so the two cannot drift — enforced in BOTH directions:
+ *  - `satisfies readonly DeployRegion[]` rejects an entry here that is not a
+ *    `DeployRegion` (tuple ⊆ union — catches a typo'd tuple entry).
+ *  - `_AssertDeployRegionsExhaustive` below rejects a region added to the
+ *    `DeployRegion` union without a matching entry here (union ⊆ tuple — the
+ *    direction `satisfies` alone does NOT catch).
  */
 const DEPLOY_REGIONS = ["us", "eu", "apac", "staging"] as const satisfies readonly DeployRegion[];
+
+/**
+ * Compile-time exhaustiveness check. If a region is ever added to
+ * {@link DeployRegion} without a matching {@link DEPLOY_REGIONS} entry, the
+ * `Exclude` is non-`never`, this type collapses to `never`, and the assignment
+ * below fails to type-check — so the runtime guard can never silently fail to
+ * recognize a region the type system already knows about. (`satisfies` above
+ * only guards the opposite direction.)
+ */
+type _AssertDeployRegionsExhaustive =
+  [Exclude<DeployRegion, (typeof DEPLOY_REGIONS)[number]>] extends [never] ? true : never;
+const _deployRegionsExhaustive: _AssertDeployRegionsExhaustive = true;
 
 /**
  * Exact runtime narrowing guard for {@link DeployRegion}.

--- a/packages/types/src/deploy.ts
+++ b/packages/types/src/deploy.ts
@@ -30,3 +30,31 @@
  * clamp) can name the cases exhaustively without re-spelling the literals.
  */
 export type DeployRegion = "us" | "eu" | "apac" | "staging";
+
+/**
+ * The closed set of {@link DeployRegion} values, as a runtime tuple. Kept
+ * adjacent to the type so the two cannot drift: a new region added to the
+ * union without an entry here is a `satisfies` compile error below.
+ */
+const DEPLOY_REGIONS = ["us", "eu", "apac", "staging"] as const satisfies readonly DeployRegion[];
+
+/**
+ * Exact runtime narrowing guard for {@link DeployRegion}.
+ *
+ * The staging email-clamp wiring (`packages/api/src/lib/email/delivery.ts`,
+ * #2913/#2985) reads the deploy region from `getApiRegion(): string | null`
+ * and MUST narrow it through this guard rather than an unchecked
+ * `as DeployRegion` cast. The guard is deliberately EXACT — no trim, no
+ * lowercase, no prefix match: only the four literal first-party regions
+ * return `true`.
+ *
+ * Exactness is the safety property. A "close" value — `null`, `"Staging"`,
+ * `"staging "` with whitespace, a granular `"us-west"`, a typo — returns
+ * `false`, and the wiring site treats a `false` result as "not a known
+ * region" and fails CLOSED (clamps outbound mail / hard-fails boot) instead
+ * of mistaking a mislabelled staging box for a prod region and emailing a
+ * real recipient. Loosening this guard would silently re-open that leak.
+ */
+export function isDeployRegion(value: string | null): value is DeployRegion {
+  return value !== null && (DEPLOY_REGIONS as readonly string[]).includes(value);
+}


### PR DESCRIPTION
Closes #2913, closes #2985. Milestone: Staging Environment (#57).

## What

Wire the existing pure `StagingClamp` into the real email send path so the
staging soak box can **never** email a real recipient (#2913), with
**fail-closed** region narrowing so a misconfigured deploy defaults to clamping,
never to leaking (#2985). Both issues touch `delivery.ts` and #2985 lands with
the wiring slice, so they ship together.

## How

- **`packages/types/src/deploy.ts`** — add `isDeployRegion(s): s is DeployRegion`,
  an *exact* narrowing guard (no trim/lowercase/prefix-match) next to
  `DeployRegion`. Exactness is the safety property: a "close" value (`null`,
  `"Staging"`, `"staging "`, a granular `"us-west"`, a typo) returns `false`.

- **`packages/api/src/lib/email/delivery.ts`** — `sendEmail` now routes every
  outbound through `clampOutbound(region, message)` **before** any provider send
  (DB transport / platform / webhook / Resend), so no path can leak.
  - `resolveOutboundClampRegion()` is **fail-closed**: the deploy ENV
    (`ATLAS_DEPLOY_ENV=staging`) is authoritative — a staging-shaped deploy
    **always** clamps, regardless of `ATLAS_API_REGION`. This catches the
    misconfig a region-only narrow *cannot*: a staging box whose
    `ATLAS_API_REGION` is fat-fingered to a **valid** prod region like `"us"`
    (which `isDeployRegion` accepts). Off staging, an exact `us|eu|apac|staging`
    is used as-is and anything else (`null`, granular, operator-defined) → no clamp.
  - `assertStagingMailRegion()` boot assert — a staging-shaped deploy MUST stamp
    `ATLAS_API_REGION=staging` or boot hard-fails. Wired into `StagingSeedLive`
    **before** its region gate (the gate would otherwise early-return on
    `region=us` and let the box serve real mail).
  - Keys-only misconfig **warn** — when `ATLAS_DEPLOY_ENV=staging` but the region
    has drifted, a warn surfaces the divergence (logs only `deployEnv` +
    `apiRegion` config labels — **never** the recipient, subject, or body).

- **`packages/api/src/lib/effect/layers.ts`** — call the boot assert at the top
  of `StagingSeedLive`.

- **`docs/development/staging-environment.md`** — document the outbound mail
  clamp, fail-closed behavior, boot assert, and a smoke-check step.

### Note on `isDeployRegion`

It is exported + unit-tested in `@useatlas/types` (its canonical home), but
**mirrored locally** in `delivery.ts` rather than imported: `packages/api/src`
is scaffold-bound source, and importing a *value* export not yet on the
pinned-published `@useatlas/types` would fail `check-published-symbols`
(version-bump-ordering). `DeployRegion` is imported type-only. Once types is
published with the guard + the template ref bumped, the local copy can be
swapped for the import.

## Tests (TDD, red→green per slice)

- `packages/types/src/__tests__/deploy.test.ts` — `isDeployRegion` accepts
  exactly the four regions; rejects case/whitespace/granular/typo/null; narrows.
- `packages/api/src/lib/email/__tests__/staging-clamp-wiring.test.ts` —
  staging rewrites `to` to the sink before the provider send; honors
  `STAGING_MAIL_SINK`; `us|eu|apac`/unset deliver unchanged; **fail-closed**
  (`region=us`/unset/malformed on a staging-env deploy all clamp); keys-only
  misconfig warn (asserts no recipient/body leaks into the log); boot assert
  throws on misconfig and is a no-op off staging.

## Acceptance criteria

- [x] Delivery wrapper invokes `clampOutbound` before the provider send.
- [x] `ATLAS_API_REGION=staging` → `to` rewritten to `STAGING_MAIL_SINK`.
- [x] `ATLAS_API_REGION` unset or `us|eu|apac` (off staging env) → payload unchanged.
- [x] A non-`staging`/malformed region cannot silently disable the clamp on the
      staging deploy (fail-closed runtime guard + boot assert).
- [x] `isDeployRegion` narrowing used at the wiring site, not an unchecked cast.
- [x] Wiring layer warn-logs (keys only) when an email-shaped payload would have
      passed unclamped on a misconfigured staging deploy.
- [x] Existing email/delivery tests pass; new cases cover clamp, narrowing guard,
      and fail-open region paths.

## CI

All local gates pass: lint, type, full test, syncpack, template drift, security
headers, railway watch, schema drift, oauth-helper drift, test discipline,
twenty resolver, published symbols.

## Follow-up

#2984 (cc/bcc/replyTo redirect) intentionally **stays open** — the current
`EmailMessage` has only `to`; any new recipient field must extend the clamp too.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3094"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782956299&installation_id=135337507&pr_number=3094&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3094&signature=0540c14c24f0acaaad7859542a445693a1ce122ac744c1ee5412c53d718d54c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated staging runbook with outbound-email sink behavior and a post-merge smoke-check step to verify staging mail delivery.

* **Improvements**
  * Staging now fail-closed redirects outbound emails to a designated staging sink across all delivery paths.
  * Startup enforces stricter staging-region checks and emits limited diagnostic warnings if misconfigured.

* **Tests**
  * Added end-to-end and unit tests for staging email redirection, boot validation, and deploy-region validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->