### PR TITLE
docs(model-routing): refresh example payloads to claude-opus-4-8 (#3101)

### DIFF
--- a/apps/docs/content/docs/guides/model-routing.mdx
+++ b/apps/docs/content/docs/guides/model-routing.mdx
@@ -48,7 +48,7 @@ When the agent loop starts a new conversation:
 When `provider=gateway`, the admin UI swaps the free-form model input for a searchable picker over the live Vercel AI Gateway catalog. The picker:
 
 - Surfaces a curated **Recommended** group at the top (Claude Opus / Sonnet, GPT-4o family, Gemini 2.0 Flash) and groups the rest by provider
-- Searches across model ID, display name, provider, and context window — `claude opus 200k` matches `anthropic/claude-opus-4.6` with a 200K window
+- Searches across model ID, display name, provider, and context window — `claude opus 200k` matches `anthropic/claude-opus-4.8` with a 200K window
 - Falls back to a small bundled subset if the live catalog endpoint is unreachable; the picker surfaces a "showing a curated subset" banner with a retry button
 
 The catalog is fetched server-side (`GET https://ai-gateway.vercel.sh/v1/models`) and cached in-memory for the configured TTL — see [Configuration](#configuration).
@@ -95,7 +95,7 @@ If a saved model disappears from the upstream catalog (provider deprecation, reg
 
 Atlas computes a best-effort closest-match suggestion using a family-stem-then-edit-distance heuristic:
 
-1. **Tier 1 — same family stem, same provider.** Extract the family stem (`claude`, `gpt`, `gemini`, `anthropic.claude`, …) from the saved model ID, then pick the closest live candidate by normalized Levenshtein distance. High confidence — e.g. `claude-3-opus-20240229` → `claude-opus-4-6`.
+1. **Tier 1 — same family stem, same provider.** Extract the family stem (`claude`, `gpt`, `gemini`, `anthropic.claude`, …) from the saved model ID, then pick the closest live candidate by normalized Levenshtein distance. High confidence — e.g. `claude-3-opus-20240229` → `claude-opus-4-8`.
 2. **Tier 2 — same provider, any stem.** Accepted only when the normalized edit distance is ≤ 30%.
 3. **Tier 3 — cross-provider.** Same 30% threshold. Catches bedrock-vs-direct-Anthropic patterns when a workspace switched providers without re-saving.
 
@@ -132,7 +132,7 @@ Navigate to **Admin > AI Provider** in the admin console. From here you can:
 | Field | Required | Description |
 |-------|----------|-------------|
 | Provider | Yes | One of: Anthropic, OpenAI, Azure OpenAI, Custom, Vercel AI Gateway |
-| Model | Yes | Model identifier (e.g. `claude-opus-4-6`, `gpt-4o`, `anthropic/claude-opus-4.6` for gateway) |
+| Model | Yes | Model identifier (e.g. `claude-opus-4-8`, `gpt-4o`, `anthropic/claude-opus-4.8` for gateway) |
 | API Key | BYOT providers | Provider API key (encrypted at rest). Omit for gateway-on-platform-credits. |
 | Base URL | For Azure/Custom | Endpoint URL for Azure OpenAI or custom providers |
 
@@ -158,7 +158,7 @@ Returns the workspace's custom model configuration, or `null` if using platform 
     "id": "550e8400-e29b-41d4-a716-446655440000",
     "orgId": "org_abc123",
     "provider": "anthropic",
-    "model": "claude-opus-4-6",
+    "model": "claude-opus-4-8",
     "baseUrl": null,
     "apiKeyMasked": "***********api0",
     "createdAt": "2026-03-22T00:00:00.000Z",
@@ -175,7 +175,7 @@ Content-Type: application/json
 
 {
   "provider": "anthropic",
-  "model": "claude-opus-4-6",
+  "model": "claude-opus-4-8",
   "apiKey": "sk-ant-...",
   "baseUrl": null
 }
@@ -199,7 +199,7 @@ Content-Type: application/json
 
 {
   "provider": "anthropic",
-  "model": "claude-opus-4-6",
+  "model": "claude-opus-4-8",
   "apiKey": "sk-ant-...",
 }
 ```
@@ -220,8 +220,8 @@ Returns the cached Vercel AI Gateway model catalog (no authentication beyond the
 {
   "models": [
     {
-      "id": "anthropic/claude-opus-4.6",
-      "name": "Claude Opus 4.6",
+      "id": "anthropic/claude-opus-4.8",
+      "name": "Claude Opus 4.8",
       "provider": "anthropic",
       "type": "language",
       "contextWindow": 200000,
@@ -242,7 +242,7 @@ Returns the cached Vercel AI Gateway model catalog (no authentication beyond the
 {
   "success": true,
   "message": "Connection successful.",
-  "modelName": "claude-opus-4-6"
+  "modelName": "claude-opus-4-8"
 }
 ```
 


### PR DESCRIPTION
## What

Refreshes the example model payloads in `apps/docs/content/docs/guides/model-routing.mdx` from `claude-opus-4-6` / `4.6` to `claude-opus-4-8` / `4.8`.

Closes #3101.

## Changes

9 version-string references updated across the guide (JSON request/response examples, the gateway catalog sample, the config-fields table, and the closest-match heuristic example):

- `claude-opus-4-6` → `claude-opus-4-8` (6×)
- `anthropic/claude-opus-4.6` → `anthropic/claude-opus-4.8` (3×)
- `"name": "Claude Opus 4.6"` → `"name": "Claude Opus 4.8"`

## Verification

- `grep` confirms zero `4.6`/`4-6` references remain in the file.
- `bun run build` in `apps/docs` succeeds — all 1853 static pages generated, including the model-routing page.

Docs-only; no code, schema, or config changes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3102"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782998662&installation_id=135337507&pr_number=3102&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3102&signature=af544e7c4a0ff589a9cc0da84ae6a56b8399964bdf090a56542fc4754a7e6895"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated workspace model routing documentation with the latest Claude Opus model version in configuration examples, gateway model picker examples, and API request/response samples.
  * Revised model mapping examples to reflect current model availability and context window specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->