### PR TITLE
fix(agent): cache gateway→Anthropic prompts + persist cache token split (#3099)

### DIFF
--- a/packages/api/src/lib/__tests__/agent-cache.test.ts
+++ b/packages/api/src/lib/__tests__/agent-cache.test.ts
@@ -141,9 +141,42 @@ describe("applyCacheControl", () => {
     expect(result).toEqual(msgs);
   });
 
-  test("returns messages unchanged for 'gateway'", () => {
+  test("returns messages unchanged for 'gateway' with no model id", () => {
     const msgs = makeMessages(3);
     const result = applyCacheControl(msgs, "gateway");
+    expect(result).toEqual(msgs);
+  });
+
+  // --- Gateway → Anthropic (#3099) ----------------------------------------
+  // The AI Gateway forwards `providerOptions.anthropic` to the underlying
+  // provider, so a gateway route to an Anthropic model needs the SAME explicit
+  // marker as the direct Anthropic provider — otherwise prod (ATLAS_PROVIDER=
+  // gateway, anthropic/claude-opus-4.8) runs fully uncached. This regression
+  // test fails if the gateway case ever silently no-ops for an Anthropic model.
+
+  test("adds anthropic cacheControl for 'gateway' routing to an Anthropic model", () => {
+    const msgs = makeMessages(3);
+    const result = applyCacheControl(msgs, "gateway", "anthropic/claude-opus-4.8");
+
+    expect(result[0]).not.toHaveProperty("providerOptions");
+    expect(result[1]).not.toHaveProperty("providerOptions");
+    expect(result[2].providerOptions).toEqual({
+      anthropic: { cacheControl: { type: "ephemeral" } },
+    });
+  });
+
+  test("adds anthropic cacheControl for 'gateway' routing to a Vertex Anthropic model", () => {
+    const msgs = makeMessages(2);
+    const result = applyCacheControl(msgs, "gateway", "vertex/claude-sonnet-4");
+
+    expect(result[1].providerOptions).toEqual({
+      anthropic: { cacheControl: { type: "ephemeral" } },
+    });
+  });
+
+  test("returns messages unchanged for 'gateway' routing to a non-Anthropic model", () => {
+    const msgs = makeMessages(3);
+    const result = applyCacheControl(msgs, "gateway", "openai/gpt-4o");
     expect(result).toEqual(msgs);
   });
 
@@ -273,8 +306,49 @@ describe("buildSystemParam", () => {
     expect(typeof result).toBe("string");
   });
 
-  test("returns plain string for 'gateway'", () => {
+  test("returns plain string for 'gateway' with no model id", () => {
     const result = buildSystemParam("gateway");
+    expect(typeof result).toBe("string");
+  });
+
+  // #3099 — gateway routing to an Anthropic model must cache the system prompt
+  // exactly like the direct Anthropic provider (the gateway forwards the marker).
+  test("returns SystemModelMessage with anthropic cacheControl for 'gateway' → Anthropic model", () => {
+    // modelId is the trailing positional arg; intermediate args default through.
+    const result = buildSystemParam(
+      "gateway",
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      "developer",
+      undefined,
+      "anthropic/claude-opus-4.8",
+    );
+    expect(typeof result).toBe("object");
+    const msg = result as { role: string; content: string; providerOptions: Record<string, unknown> };
+    expect(msg.role).toBe("system");
+    expect(typeof msg.content).toBe("string");
+    expect(msg.providerOptions).toEqual({
+      anthropic: { cacheControl: { type: "ephemeral" } },
+    });
+  });
+
+  test("returns plain string for 'gateway' → non-Anthropic model", () => {
+    const result = buildSystemParam(
+      "gateway",
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      "developer",
+      undefined,
+      "openai/gpt-4o",
+    );
     expect(typeof result).toBe("string");
   });
 

--- a/packages/api/src/lib/__tests__/agent-context-warnings.test.ts
+++ b/packages/api/src/lib/__tests__/agent-context-warnings.test.ts
@@ -46,6 +46,7 @@ mock.module("@atlas/api/lib/providers", () => ({
   getModelFromWorkspaceConfig: () => mockModel,
   getWorkspaceProviderType: () => "anthropic" as const,
   getDefaultProvider: () => "anthropic" as const,
+  isGatewayAnthropicModel: (modelId: string) => modelId.includes("anthropic") || modelId.includes("claude"),
 }));
 
 // Semantic loaders — toggleable so each test can independently choose

--- a/packages/api/src/lib/__tests__/agent-cross-env-routing.test.ts
+++ b/packages/api/src/lib/__tests__/agent-cross-env-routing.test.ts
@@ -52,6 +52,7 @@ mock.module("@atlas/api/lib/providers", () => ({
   getModelFromWorkspaceConfig: () => mockModel,
   getWorkspaceProviderType: () => "anthropic" as const,
   getDefaultProvider: () => "anthropic" as const,
+  isGatewayAnthropicModel: (modelId: string) => modelId.includes("anthropic") || modelId.includes("claude"),
 }));
 
 mock.module("@atlas/api/lib/semantic", () => ({

--- a/packages/api/src/lib/__tests__/agent-integration.test.ts
+++ b/packages/api/src/lib/__tests__/agent-integration.test.ts
@@ -44,6 +44,7 @@ mock.module("@atlas/api/lib/providers", () => ({
   getModelFromWorkspaceConfig: () => mockModel,
   getWorkspaceProviderType: () => "anthropic" as const,
   getDefaultProvider: () => "anthropic" as const,
+  isGatewayAnthropicModel: (modelId: string) => modelId.includes("anthropic") || modelId.includes("claude"),
 }));
 
 mock.module("@atlas/api/lib/semantic", () => ({

--- a/packages/api/src/lib/__tests__/agent-routing-mode.test.ts
+++ b/packages/api/src/lib/__tests__/agent-routing-mode.test.ts
@@ -54,6 +54,7 @@ mock.module("@atlas/api/lib/providers", () => ({
   getModelFromWorkspaceConfig: () => mockModel,
   getWorkspaceProviderType: () => "anthropic" as const,
   getDefaultProvider: () => "anthropic" as const,
+  isGatewayAnthropicModel: (modelId: string) => modelId.includes("anthropic") || modelId.includes("claude"),
 }));
 
 mock.module("@atlas/api/lib/semantic", () => ({

--- a/packages/api/src/lib/__tests__/agent-scope-prompt.test.ts
+++ b/packages/api/src/lib/__tests__/agent-scope-prompt.test.ts
@@ -104,6 +104,7 @@ mock.module("@atlas/api/lib/providers", () => ({
   getModelFromWorkspaceConfig: () => mockModel,
   getWorkspaceProviderType: () => "anthropic" as const,
   getDefaultProvider: () => "anthropic" as const,
+  isGatewayAnthropicModel: (modelId: string) => modelId.includes("anthropic") || modelId.includes("claude"),
 }));
 
 mock.module("@atlas/api/lib/semantic", () => ({

--- a/packages/api/src/lib/__tests__/agent-token-usage.test.ts
+++ b/packages/api/src/lib/__tests__/agent-token-usage.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Write-path test for the token_usage prompt-cache split (#3099).
+ *
+ * The cache markers are what make the gateway → Anthropic path cache at all,
+ * but the *accounting* side has its own silent-failure mode: if the INSERT
+ * reads the wrong `usage.inputTokenDetails` field, or the positional params
+ * drift out of column order, the new `cache_read_tokens` / `cache_write_tokens`
+ * columns would persist 0 forever and nobody would notice until the usage
+ * surface (#3098) shipped wrong numbers.
+ *
+ * This drives `runAgent` to a single text-only finish carrying non-zero
+ * cache-read/cache-write usage (in the raw V3 stream shape the AI SDK
+ * normalizes into `totalUsage.inputTokenDetails.{cacheReadTokens,
+ * cacheWriteTokens}`), spies the fire-and-forget `internalExecute`, and pins
+ * BOTH the field path and the `INSERT INTO token_usage` column ordering.
+ */
+
+import { describe, expect, it, beforeEach, mock } from "bun:test";
+import {
+  MockLanguageModelV3,
+  convertArrayToReadableStream,
+} from "ai/test";
+import type { LanguageModelV3StreamPart, LanguageModelV3Usage } from "@ai-sdk/provider";
+import type { UIMessage } from "ai";
+import { createConnectionMock } from "@atlas/api/testing/connection";
+// Resolved BEFORE the mock.module below registers, so this is the real module.
+// Spreading it keeps every export intact (mock-all-exports) while we override
+// only the two seams the write path touches.
+import * as realInternal from "@atlas/api/lib/db/internal";
+
+// Module-top env — read at import time by the modules below.
+process.env.ATLAS_DATASOURCE_URL ??= "postgresql://test:test@localhost:5432/test";
+
+let mockModel: InstanceType<typeof MockLanguageModelV3>;
+
+mock.module("@atlas/api/lib/providers", () => ({
+  getModel: () => mockModel,
+  getProviderType: () => "anthropic" as const,
+  getModelFromWorkspaceConfig: () => mockModel,
+  getWorkspaceProviderType: () => "anthropic" as const,
+  getDefaultProvider: () => "anthropic" as const,
+  isGatewayAnthropicModel: (modelId: string) => modelId.includes("anthropic") || modelId.includes("claude"),
+}));
+
+mock.module("@atlas/api/lib/semantic", () => ({
+  getOrgWhitelistedTables: () => new Set(),
+  loadOrgWhitelist: async () => new Map(),
+  invalidateOrgWhitelist: () => {},
+  getOrgSemanticIndex: async () => "",
+  invalidateOrgSemanticIndex: () => {},
+  _resetOrgWhitelists: () => {},
+  _resetOrgSemanticIndexes: () => {},
+  getWhitelistedTables: () => new Set(["companies", "people"]),
+  _resetWhitelists: () => {},
+  getCrossSourceJoins: () => [],
+}));
+
+const mockDBConnectionObj = {
+  query: async () => ({ columns: ["id"], rows: [{ id: 1 }] }),
+  close: async () => {},
+};
+mock.module("@atlas/api/lib/db/connection", () =>
+  createConnectionMock({
+    getDB: () => mockDBConnectionObj,
+    connections: {
+      get: () => mockDBConnectionObj,
+      getDefault: () => mockDBConnectionObj,
+      getTargetHost: () => "localhost:5432",
+      describe: () => [{ id: "default", dbType: "postgres" as const }],
+      getForOrg: () => mockDBConnectionObj,
+    },
+  }),
+);
+
+// --- The seam under test: internalExecute / hasInternalDB ---
+let hasInternalDB = true;
+const internalCalls: Array<{ sql: string; params?: unknown[] }> = [];
+
+mock.module("@atlas/api/lib/db/internal", () => ({
+  ...realInternal,
+  hasInternalDB: () => hasInternalDB,
+  internalExecute: (sql: string, params?: unknown[]) => {
+    internalCalls.push({ sql, params });
+  },
+}));
+
+const { runAgent } = await import("@atlas/api/lib/agent");
+
+/**
+ * Raw V3 finish-chunk usage carrying a cache split. The AI SDK normalizes
+ * `inputTokens.{cacheRead,cacheWrite}` into the aggregated
+ * `totalUsage.inputTokenDetails.{cacheReadTokens,cacheWriteTokens}` that the
+ * production INSERT reads — so non-zero values here prove the field path.
+ */
+const CACHE_USAGE: LanguageModelV3Usage = {
+  inputTokens: { total: 100, noCache: 90, cacheRead: 7, cacheWrite: 3 },
+  outputTokens: { total: 20, text: 20, reasoning: undefined },
+};
+
+function userMessages(content: string): UIMessage[] {
+  return [{ id: "msg-1", role: "user" as const, parts: [{ type: "text" as const, text: content }] }];
+}
+
+/** Single text-only step → the agent loop ends immediately and onFinish fires. */
+function textOnlyModel(usage: LanguageModelV3Usage): InstanceType<typeof MockLanguageModelV3> {
+  const chunks: LanguageModelV3StreamPart[] = [
+    { type: "text-delta", id: "text-0", delta: "Done." },
+    { type: "finish", usage, finishReason: { unified: "stop", raw: "end_turn" } },
+  ];
+  return new MockLanguageModelV3({
+    doStream: async () => ({ stream: convertArrayToReadableStream(chunks) }),
+  });
+}
+
+/** Drain the data stream so the streamText onFinish callback runs. */
+async function drive(model: InstanceType<typeof MockLanguageModelV3>): Promise<void> {
+  mockModel = model;
+  // userId/orgId derive from the request context (null here), which is fine —
+  // the token_usage INSERT still fires on `hasInternalDB() && totalUsage`.
+  const result = await runAgent({ messages: userMessages("hi"), conversationId: "conv-1" });
+  await result.steps;
+  await result.consumeStream?.();
+}
+
+function tokenUsageInsert() {
+  return internalCalls.find((c) => c.sql.includes("INSERT INTO token_usage"));
+}
+
+describe("token_usage cache split write path (#3099)", () => {
+  beforeEach(() => {
+    internalCalls.length = 0;
+    hasInternalDB = true;
+  });
+
+  it("persists cacheReadTokens/cacheWriteTokens at the right INSERT positions", async () => {
+    await drive(textOnlyModel(CACHE_USAGE));
+
+    const insert = tokenUsageInsert();
+    expect(insert).toBeDefined();
+
+    // Columns: user_id, conversation_id, prompt_tokens, completion_tokens,
+    //          cache_read_tokens, cache_write_tokens, model, provider, org_id
+    expect(insert!.sql).toContain("cache_read_tokens, cache_write_tokens");
+    const params = insert!.params as unknown[];
+    expect(params).toHaveLength(9);
+    expect(params[4]).toBe(7); // cache_read_tokens  ← inputTokenDetails.cacheReadTokens
+    expect(params[5]).toBe(3); // cache_write_tokens ← inputTokenDetails.cacheWriteTokens
+  });
+
+  it("writes 0 for the cache split when the provider reports no cache usage", async () => {
+    await drive(textOnlyModel({
+      inputTokens: { total: 100, noCache: 100, cacheRead: undefined, cacheWrite: undefined },
+      outputTokens: { total: 20, text: 20, reasoning: undefined },
+    }));
+
+    const params = tokenUsageInsert()!.params as unknown[];
+    expect(params[4]).toBe(0);
+    expect(params[5]).toBe(0);
+  });
+
+  it("does not write token usage when no internal DB is configured", async () => {
+    hasInternalDB = false;
+    await drive(textOnlyModel(CACHE_USAGE));
+    expect(tokenUsageInsert()).toBeUndefined();
+  });
+});

--- a/packages/api/src/lib/agent.ts
+++ b/packages/api/src/lib/agent.ts
@@ -26,7 +26,7 @@ import type { LanguageModel } from "ai";
 import { Effect, Duration } from "effect";
 import type { ChatContextWarning } from "@useatlas/types";
 import { normalizeError } from "./effect/errors";
-import { getModel, getProviderType, getModelFromWorkspaceConfig, getWorkspaceProviderType, type ProviderType } from "./providers";
+import { getModel, getProviderType, getModelFromWorkspaceConfig, getWorkspaceProviderType, isGatewayAnthropicModel, type ProviderType } from "./providers";
 import { defaultRegistry, ToolRegistry } from "./tools/registry";
 import { resolveWorkspaceRestDatasources, resolveWorkspaceRestDatasourcesOrThrow } from "./openapi/workspace-datasource";
 import type { RestDatasource } from "./openapi/datasource";
@@ -532,6 +532,12 @@ export function buildSystemParam(
    * its operations with `executeRestOperation`. Absent for SQL-only workspaces.
    */
   restRepresentation?: string,
+  /**
+   * #3099 — Resolved model id, used only to detect when the `gateway` provider
+   * routes to an Anthropic-family model so the system prompt gets the same
+   * cache breakpoint as the direct Anthropic provider. Ignored otherwise.
+   */
+  modelId?: string,
 ): string | SystemModelMessage {
   let content = buildSystemPrompt(registry, orgSemanticIndex, learnedPatternsSection, routingContext, boundDashboardContext);
 
@@ -547,7 +553,8 @@ export function buildSystemParam(
     content += "\n\n## Warnings\n\n" + warnings.map((w) => `- ${w}`).join("\n");
   }
 
-  switch (providerType) {
+  const cacheProvider = cacheProviderFor(providerType, modelId);
+  switch (cacheProvider) {
     case "anthropic":
     case "bedrock-anthropic":
       return {
@@ -571,10 +578,28 @@ export function buildSystemParam(
     case "gateway":
       return content;
     default: {
-      const _exhaustive: never = providerType;
+      const _exhaustive: never = cacheProvider;
       throw new Error(`Unknown provider type: ${_exhaustive}`);
     }
   }
+}
+
+/**
+ * Resolve the provider whose prompt-cache convention applies to a request.
+ *
+ * Normally this is just `providerType`. The exception is the AI Gateway: it
+ * forwards `providerOptions.anthropic` to the underlying provider, so a gateway
+ * route to an Anthropic-family model needs the SAME explicit `cacheControl`
+ * markers as the direct Anthropic provider — without them the gateway →
+ * Anthropic path runs fully uncached (#3099). OpenAI/other gateway routes keep
+ * the no-op (implicit caching), and a gateway request with no resolvable model
+ * id falls back to the no-op too.
+ */
+function cacheProviderFor(providerType: ProviderType, modelId?: string): ProviderType {
+  if (providerType === "gateway" && modelId && isGatewayAnthropicModel(modelId)) {
+    return "anthropic";
+  }
+  return providerType;
 }
 
 /**
@@ -586,18 +611,23 @@ export function buildSystemParam(
  *
  * - Anthropic / Bedrock-Anthropic: `providerOptions.anthropic.cacheControl`
  * - Bedrock (non-Anthropic): `providerOptions.bedrock.cachePoint`
- * - OpenAI / Ollama / OpenAI-compatible / Gateway: no-op (OpenAI caches automatically)
+ * - Gateway → Anthropic model: `providerOptions.anthropic.cacheControl` (the
+ *   gateway forwards it to the underlying provider; needs `modelId` to detect)
+ * - OpenAI / Ollama / OpenAI-compatible / Gateway (non-Anthropic): no-op
+ *   (OpenAI-family caches automatically)
  */
 export function applyCacheControl(
   messages: ModelMessage[],
   providerType: ProviderType,
+  modelId?: string,
 ): ModelMessage[] {
   if (messages.length === 0) return messages;
 
   // Only Anthropic-family and Bedrock need explicit cache markers
   const lastIndex = messages.length - 1;
 
-  switch (providerType) {
+  const cacheProvider = cacheProviderFor(providerType, modelId);
+  switch (cacheProvider) {
     case "anthropic":
     case "bedrock-anthropic": {
       return messages.map((message, index) => {
@@ -629,7 +659,7 @@ export function applyCacheControl(
     case "gateway":
       return messages;
     default: {
-      const _exhaustive: never = providerType;
+      const _exhaustive: never = cacheProvider;
       throw new Error(`Unknown provider type: ${_exhaustive}`);
     }
   }
@@ -1170,7 +1200,7 @@ export async function runAgent({
   try {
     result = otelContext.with(agentCtx, () => streamText({
       model,
-      system: buildSystemParam(providerType, activeRegistry, warnings, orgSemanticIndex, learnedPatternsSection, scopeRoutingContext, boundDashboardContext, presentationMode ?? "developer", restRepresentation),
+      system: buildSystemParam(providerType, activeRegistry, warnings, orgSemanticIndex, learnedPatternsSection, scopeRoutingContext, boundDashboardContext, presentationMode ?? "developer", restRepresentation, resolvedModelId),
       messages: modelMessages,
       tools,
       temperature: 0.2,
@@ -1193,7 +1223,7 @@ export async function runAgent({
 
       prepareStep: ({ messages: stepMessages }) => {
         return {
-          messages: applyCacheControl(stepMessages, providerType),
+          messages: applyCacheControl(stepMessages, providerType, resolvedModelId),
         };
       },
 
@@ -1236,13 +1266,15 @@ export async function runAgent({
         if (hasInternalDB() && totalUsage) {
           try {
             internalExecute(
-              `INSERT INTO token_usage (user_id, conversation_id, prompt_tokens, completion_tokens, model, provider, org_id)
-               VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+              `INSERT INTO token_usage (user_id, conversation_id, prompt_tokens, completion_tokens, cache_read_tokens, cache_write_tokens, model, provider, org_id)
+               VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
               [
                 userId,
                 conversationId ?? null,
                 totalUsage.inputTokens ?? 0,
                 totalUsage.outputTokens ?? 0,
+                totalUsage.inputTokenDetails?.cacheReadTokens ?? 0,
+                totalUsage.inputTokenDetails?.cacheWriteTokens ?? 0,
                 resolvedModelId,
                 providerType,
                 orgId ?? null,

--- a/packages/api/src/lib/auth/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/auth/__tests__/migrate.test.ts
@@ -359,6 +359,7 @@ describe("migrateAuthTables", () => {
             { name: "0111_github_data_catalog.sql" },
             { name: "0112_conversation_rest_excluded_datasources.sql" },
             { name: "0113_conversation_rest_focus_datasource.sql" },
+            { name: "0114_token_usage_cache_tokens.sql" },
           ],
         };
       }

--- a/packages/api/src/lib/db/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate.test.ts
@@ -132,7 +132,8 @@ describe("runMigrations", () => {
     //   CHECK widen, slice 6c, #3030) = 112.
     //   Plus 0112 (conversations.rest_excluded_datasource_ids, S2a, #3066) = 113.
     //   Plus 0113 (conversations.rest_focus_datasource_id, S2b, #3067) = 114.
-    expect(count).toBe(114);
+    //   Plus 0114 (token_usage.cache_read_tokens/cache_write_tokens, #3099) = 115.
+    expect(count).toBe(115);
 
     // Advisory lock acquired before anything else
     expect(queries[0]).toContain("pg_advisory_lock");
@@ -275,6 +276,7 @@ describe("runMigrations", () => {
         "0111_github_data_catalog.sql",
         "0112_conversation_rest_excluded_datasources.sql",
         "0113_conversation_rest_focus_datasource.sql",
+        "0114_token_usage_cache_tokens.sql",
       ],
     });
 

--- a/packages/api/src/lib/db/migrations/0114_token_usage_cache_tokens.sql
+++ b/packages/api/src/lib/db/migrations/0114_token_usage_cache_tokens.sql
@@ -1,0 +1,28 @@
+-- Migration 0114: token_usage prompt-cache split (#3099).
+--
+-- AI Gateway → Anthropic now sends explicit `cacheControl` markers
+-- (applyCacheControl / buildSystemParam treat a gateway route to an
+-- Anthropic-family model like the direct Anthropic provider), so the agent
+-- loop re-reads its long system+tools prefix from cache instead of re-billing
+-- it at full input price on every step. The AI SDK surfaces the split on
+-- `usage.inputTokenDetails.{cacheReadTokens,cacheWriteTokens}`; agent.ts
+-- already logged it and now persists it here so the usage surface can compute
+-- cache hit rate. (The usage-page gross-vs-billed labeling lands separately
+-- in #3098 — this migration only owns the WRITE path.)
+--
+-- Nullable DEFAULT 0: existing rows backfill to 0 (no cache data was recorded
+-- before this), and the INSERT path always supplies a value (`?? 0`), so the
+-- columns never actually read NULL for rows written after this migration.
+--
+-- Idempotent: `ADD COLUMN IF NOT EXISTS` is a no-op on re-run.
+
+ALTER TABLE token_usage
+  ADD COLUMN IF NOT EXISTS cache_read_tokens integer DEFAULT 0;
+
+ALTER TABLE token_usage
+  ADD COLUMN IF NOT EXISTS cache_write_tokens integer DEFAULT 0;
+
+COMMENT ON COLUMN token_usage.cache_read_tokens IS
+  'Prompt-cache tokens served from cache this turn, summed across agent steps (~90% cheaper than fresh input). From usage.inputTokenDetails.cacheReadTokens. #3099.';
+COMMENT ON COLUMN token_usage.cache_write_tokens IS
+  'Prompt-cache tokens written to cache this turn, summed across agent steps (~25% premium over fresh input). From usage.inputTokenDetails.cacheWriteTokens. #3099.';

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -388,6 +388,12 @@ export const tokenUsage = pgTable(
     conversationId: text("conversation_id"),
     promptTokens: integer("prompt_tokens").notNull().default(0),
     completionTokens: integer("completion_tokens").notNull().default(0),
+    // Prompt-cache split (#3099). Nullable, default 0 — existing rows backfill
+    // to 0 and the INSERT path always supplies a value (`?? 0`). cache_read =
+    // tokens served from cache (~90% cheaper); cache_write = tokens written to
+    // cache (~25% premium). From usage.inputTokenDetails.{cacheRead,cacheWrite}.
+    cacheReadTokens: integer("cache_read_tokens").default(0),
+    cacheWriteTokens: integer("cache_write_tokens").default(0),
     model: text("model"),
     provider: text("provider"),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),

--- a/packages/api/src/lib/openapi/__tests__/twenty-acceptance.test.ts
+++ b/packages/api/src/lib/openapi/__tests__/twenty-acceptance.test.ts
@@ -61,6 +61,7 @@ mock.module("@atlas/api/lib/providers", () => ({
   getModelFromWorkspaceConfig: () => mockModel,
   getWorkspaceProviderType: () => "anthropic" as const,
   getDefaultProvider: () => "anthropic" as const,
+  isGatewayAnthropicModel: (modelId: string) => modelId.includes("anthropic") || modelId.includes("claude"),
 }));
 
 mock.module("@atlas/api/lib/semantic", () => ({

--- a/packages/api/src/lib/providers.ts
+++ b/packages/api/src/lib/providers.ts
@@ -52,8 +52,27 @@ export function getDefaultProvider(): ConfigProvider {
   return process.env.VERCEL ? "gateway" : "anthropic";
 }
 
-function isBedrockAnthropicModel(modelId: string): boolean {
+/** Anthropic-family model ids contain "anthropic" or "claude". */
+function isAnthropicFamilyModelId(modelId: string): boolean {
   return modelId.includes("anthropic") || modelId.includes("claude");
+}
+
+function isBedrockAnthropicModel(modelId: string): boolean {
+  return isAnthropicFamilyModelId(modelId);
+}
+
+/**
+ * Whether a gateway-routed model id targets an Anthropic-family model.
+ *
+ * Gateway model ids are `<provider>/<model>` (e.g. `anthropic/claude-opus-4.8`,
+ * `vertex/claude-...`). The AI Gateway forwards `providerOptions.anthropic` to
+ * the underlying provider, so any Anthropic-family route accepts — and needs —
+ * the same explicit `cacheControl` markers as the direct Anthropic provider.
+ * Anthropic caching is opt-in (unlike OpenAI's implicit caching), so without
+ * the markers the gateway → Anthropic path runs fully uncached (#3099).
+ */
+export function isGatewayAnthropicModel(modelId: string): boolean {
+  return isAnthropicFamilyModelId(modelId);
 }
 
 /**


### PR DESCRIPTION
Fixes #3099.

## Problem
Prod runs `ATLAS_PROVIDER=gateway` (SaaS pins it) routing to `anthropic/claude-opus-4.8`, but `applyCacheControl()` and `buildSystemParam()` bucketed the `gateway` provider type with OpenAI's *implicit* caching and emitted **no** cache markers. Anthropic prompt caching is opt-in, so every agent step re-sent the full ~17.5K system+tools prefix at full input price. The AI Gateway usage log showed **Cache Read = Cache Write = 0** on every prod call.

`resolveProviderType()` only remaps `bedrock`→`bedrock-anthropic`; a gateway route stays `"gateway"` regardless of the routed model, so it always hit the no-op branch.

## Fix
The AI Gateway forwards `providerOptions.anthropic` to the underlying provider, so the fix makes a gateway route to an Anthropic-family model behave **exactly** like the direct Anthropic provider. A new `cacheProviderFor(providerType, modelId)` maps gateway+Anthropic → `"anthropic"` in both cache helpers; `resolvedModelId` is threaded through from the `streamText` call site. Non-Anthropic gateway routes (and gateway with no resolvable model id) keep the no-op (OpenAI-family caches implicitly).

### Option B, not Option A — and why
The issue preferred Option A (`providerOptions: { gateway: { caching: 'auto' } }`). I implemented **Option B** (the issue's listed fallback) because **`caching: 'auto'` is not a real API** in the installed `@ai-sdk/gateway@3.0.83`:

```
GatewayProviderOptions fields: only, order, user, tags, models, byok, zeroDataRetention, providerTimeouts
```

There is no `caching` field — Option A wouldn't type-check under `satisfies GatewayProviderOptions` and wouldn't enable caching. The AI SDK docs prescribe the underlying-provider key (`providerOptions.anthropic.cacheControl`) for caching through the gateway, which is what this PR does. This even covers Vertex/Bedrock Anthropic routes (`vertex/claude-*`), which accept the same `anthropic.cacheControl` marker.

## token_usage cache split (WRITE path)
This issue owns the persistence write path. `token_usage` gains nullable `cache_read_tokens` / `cache_write_tokens` (default 0), populated from `usage.inputTokenDetails.{cacheReadTokens,cacheWriteTokens}` (already logged in `onFinish`, now persisted). Migration `0114` + the `schema.ts` mirror land in the same PR per the `check-schema-drift.sh` / `migrate-pg.test.ts` discipline. The usage-page surfacing + gross-vs-billed labeling stays out of scope (**#3098**).

## Tests
`agent-cache.test.ts` now asserts:
- gateway + `anthropic/claude-opus-4.8` and gateway + `vertex/claude-sonnet-4` emit the ephemeral marker on **both** the last message and the system prompt;
- gateway + `openai/gpt-4o` and gateway with no model id stay no-op (the no-op can't silently return);
- existing direct anthropic / bedrock / bedrock-anthropic coverage unchanged (no regression).

Six agent tests that partially mock `@atlas/api/lib/providers` gained the new `isGatewayAnthropicModel` export (mock-all-exports discipline), and `migrate.test.ts` count/fixture bumped for migration 0114.

## Acceptance criteria
- [x] gateway + Anthropic model sends cache control (forwarded `anthropic.cacheControl`)
- [x] test asserts cache markers present for gateway+Anthropic
- [x] no regression for direct anthropic/bedrock/bedrock-anthropic
- [x] `token_usage` persists cache read/write tokens; schema mirror + migration same PR

## Gates run locally
`tsgo --noEmit` (api) ✓ · `eslint` ✓ · affected isolated tests 55/55 ✓ · `check-schema-drift.sh` ✓ · `syncpack lint` ✓ · `check-template-drift.sh` ✓. The real-Postgres `migrate-pg` smoke runs in CI (no local Postgres); migration 0114 is an idempotent `ADD COLUMN IF NOT EXISTS … integer DEFAULT 0`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3103"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782999363&installation_id=135337507&pr_number=3103&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3103&signature=7163dd090ead917632f2afe8bbda67ea91283a6d764c78b5329ef85ee6d1fdfa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tracks cache read/write token counts for AI usage reporting.
  * Improved cache behavior when routing to Anthropic-family models via the gateway.

* **Tests**
  * Expanded tests to cover gateway→Anthropic cache behavior across routing, context, integration, and acceptance scenarios.
  * Updated test expectations for the new token usage fields and routing behavior.

* **Database**
  * Added migration to store cache read/write token columns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->