### PR TITLE
fix(billing): single-source the default AI model + surface model on usage (#3098)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -61,7 +61,9 @@ ATLAS_DATASOURCE_URL=postgresql://atlas:atlas@localhost:5432/atlas_demo
 # AI_GATEWAY_API_KEY=...
 
 # === Model (optional, provider-specific default used if omitted) ===
-# ATLAS_MODEL=claude-opus-4-6
+# Leave unset to use the provider default — gateway → anthropic/claude-sonnet-4.6,
+# anthropic → claude-opus-4-8 (see packages/api/src/lib/providers.ts).
+# ATLAS_MODEL=anthropic/claude-sonnet-4.6
 
 # === Authentication ===
 # Managed auth is enabled by default for local dev.

--- a/apps/docs/content/docs/reference/environment-variables.mdx
+++ b/apps/docs/content/docs/reference/environment-variables.mdx
@@ -71,7 +71,7 @@ Each provider requires its own API key:
 | `bedrock` | `anthropic.claude-opus-4-8` |
 | `ollama` | `llama3.1` |
 | `openai-compatible` | None — `ATLAS_MODEL` required |
-| `gateway` | `anthropic/claude-opus-4.8` |
+| `gateway` | `anthropic/claude-sonnet-4.6` |
 
 <Tabs items={["Anthropic", "OpenAI", "AWS Bedrock", "Ollama (local)", "OpenAI-compatible (vLLM, TGI)"]}>
 <Tab value="Anthropic">

--- a/create-atlas/index.ts
+++ b/create-atlas/index.ts
@@ -26,7 +26,7 @@ const PROVIDER_KEY_MAP: Record<string, { envVar: string; placeholder: string }> 
 const PROVIDER_DEFAULT_MODEL: Record<string, string> = {
   anthropic: "claude-opus-4-8",
   openai: "gpt-4o",
-  bedrock: "anthropic.claude-opus-4-8-v1",
+  bedrock: "anthropic.claude-opus-4-8",
   ollama: "llama3.1",
   gateway: "anthropic/claude-sonnet-4.6",
 };

--- a/create-atlas/index.ts
+++ b/create-atlas/index.ts
@@ -20,13 +20,15 @@ const PROVIDER_KEY_MAP: Record<string, { envVar: string; placeholder: string }> 
   gateway: { envVar: "AI_GATEWAY_API_KEY", placeholder: "vcel_gw_..." },
 };
 
-// Default models per provider
+// Default models per provider. Keep in lockstep with PROVIDER_DEFAULTS in
+// packages/api/src/lib/providers.ts — gateway → Sonnet 4.6 (the hosted/SaaS
+// default), the rest mirror the agent's per-provider defaults (#3098).
 const PROVIDER_DEFAULT_MODEL: Record<string, string> = {
-  anthropic: "claude-opus-4-6",
+  anthropic: "claude-opus-4-8",
   openai: "gpt-4o",
-  bedrock: "anthropic.claude-opus-4-6-v1",
+  bedrock: "anthropic.claude-opus-4-8-v1",
   ollama: "llama3.1",
-  gateway: "anthropic/claude-opus-4.6",
+  gateway: "anthropic/claude-sonnet-4.6",
 };
 
 function copyDirRecursive(src: string, dest: string): void {

--- a/packages/api/src/api/__tests__/admin-tokens.test.ts
+++ b/packages/api/src/api/__tests__/admin-tokens.test.ts
@@ -62,6 +62,7 @@ describe("admin token usage routes", () => {
     it("returns token summary with org_id filter", async () => {
       mocks.mockInternalQuery.mockImplementation((sql: string) => {
         if (sql.includes("ip_allowlist")) return Promise.resolve([]);
+        if (sql.includes("GROUP BY model")) return Promise.resolve([]);
         return Promise.resolve([
           { total_prompt: "15000", total_completion: "5000", total_requests: "10" },
         ]);
@@ -82,6 +83,65 @@ describe("admin token usage routes", () => {
       const [sql, params] = lastCall!;
       expect(sql).toContain("org_id");
       expect(params).toContain("org-test");
+    });
+
+    it("returns a per-model token breakdown so operators see which model burned tokens (#3098)", async () => {
+      mocks.mockInternalQuery.mockImplementation((sql: string) => {
+        if (sql.includes("ip_allowlist")) return Promise.resolve([]);
+        if (sql.includes("GROUP BY model")) {
+          return Promise.resolve([
+            { model: "anthropic/claude-opus-4.8", provider: "gateway", total_prompt: "120000", total_completion: "2000", request_count: "2" },
+            { model: "anthropic/claude-sonnet-4.6", provider: "gateway", total_prompt: "8000", total_completion: "500", request_count: "1" },
+          ]);
+        }
+        return Promise.resolve([
+          { total_prompt: "128000", total_completion: "2500", total_requests: "3" },
+        ]);
+      });
+
+      const res = await app.fetch(adminRequest("/api/v1/admin/tokens/summary"));
+      expect(res.status).toBe(200);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test convenience for JSON response body
+      const body = await res.json() as any;
+
+      expect(Array.isArray(body.byModel)).toBe(true);
+      expect(body.byModel).toHaveLength(2);
+      expect(body.byModel[0]).toEqual({
+        model: "anthropic/claude-opus-4.8",
+        provider: "gateway",
+        promptTokens: 120000,
+        completionTokens: 2000,
+        totalTokens: 122000,
+        requestCount: 2,
+      });
+      expect(body.byModel[1].model).toBe("anthropic/claude-sonnet-4.6");
+
+      // The model breakdown must be org-scoped like every other tokens query.
+      const groupByCall = mocks.mockInternalQuery.mock.calls.find(
+        ([sql]) => typeof sql === "string" && sql.includes("GROUP BY model"),
+      );
+      expect(groupByCall).toBeDefined();
+      expect(groupByCall![0]).toContain("org_id");
+      expect(groupByCall![1]).toContain("org-test");
+    });
+
+    it("labels null model/provider rows as 'unknown' in the breakdown", async () => {
+      mocks.mockInternalQuery.mockImplementation((sql: string) => {
+        if (sql.includes("ip_allowlist")) return Promise.resolve([]);
+        if (sql.includes("GROUP BY model")) {
+          return Promise.resolve([
+            { model: null, provider: null, total_prompt: "100", total_completion: "10", request_count: "1" },
+          ]);
+        }
+        return Promise.resolve([{ total_prompt: "100", total_completion: "10", total_requests: "1" }]);
+      });
+
+      const res = await app.fetch(adminRequest("/api/v1/admin/tokens/summary"));
+      expect(res.status).toBe(200);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test convenience for JSON response body
+      const body = await res.json() as any;
+      expect(body.byModel[0].model).toBe("unknown");
+      expect(body.byModel[0].provider).toBe("unknown");
     });
 
     it("returns 404 when no internal DB", async () => {
@@ -105,6 +165,7 @@ describe("admin token usage routes", () => {
     it("accepts date range parameters", async () => {
       mocks.mockInternalQuery.mockImplementation((sql: string) => {
         if (sql.includes("ip_allowlist")) return Promise.resolve([]);
+        if (sql.includes("GROUP BY model")) return Promise.resolve([]);
         return Promise.resolve([{ total_prompt: "0", total_completion: "0", total_requests: "0" }]);
       });
       const res = await app.fetch(adminRequest("/api/v1/admin/tokens/summary?from=2026-01-01&to=2026-03-01"));

--- a/packages/api/src/api/__tests__/billing.test.ts
+++ b/packages/api/src/api/__tests__/billing.test.ts
@@ -114,10 +114,15 @@ mock.module("@atlas/api/lib/metering", () => ({
 
 // --- Settings mock ---
 
+// Only ATLAS_MODEL is a per-workspace override surfaced in the billing picker.
+// ATLAS_PROVIDER is a deploy-level choice resolved from env, so the mock
+// returns the saved model only for that key (mirrors the real store).
 let mockSettingLiveValue: string | undefined = undefined;
 
 mock.module("@atlas/api/lib/settings", () => ({
-  getSettingLive: mock(() => Promise.resolve(mockSettingLiveValue)),
+  getSettingLive: mock((key: string) =>
+    Promise.resolve(key === "ATLAS_MODEL" ? mockSettingLiveValue : undefined),
+  ),
   getSetting: mock(() => undefined),
   getSettingAuto: mock(() => undefined),
   setSetting: mock(async () => {}),
@@ -166,6 +171,10 @@ mock.module("@atlas/api/lib/semantic", () => ({
 // --- Import billing routes ---
 
 import { billing, _resetPortalRateLimits } from "../routes/billing";
+// Real resolver (not mocked) — the SSOT the billing endpoint and the agent
+// loop share. Tests assert the endpoint reports exactly what this resolves so
+// the picker default can't drift from the billed default (#3098).
+import { resolveModelId } from "@atlas/api/lib/providers";
 import { OpenAPIHono } from "@hono/zod-openapi";
 
 const app = new OpenAPIHono();
@@ -224,7 +233,11 @@ describe("billing routes", () => {
       // Per-seat pricing fields
       expect(body.seats).toEqual({ count: 3, max: 10 });
       expect(body.connections).toEqual({ count: 2, max: 1 });
-      expect(body.currentModel).toBe("anthropic/claude-haiku-4.5"); // plan default since no setting override (gateway-canonical format — SaaS resolves via Vercel)
+      // SSOT (#3098): with nothing saved, currentModel is exactly what the
+      // agent loop resolves — NOT the plan's recommended model. Asserting
+      // against the shared resolver guards against the picker advertising one
+      // model while another is billed.
+      expect(body.currentModel).toBe(resolveModelId(undefined, undefined));
       expect(body.overagePerMillionTokens).toBe(1.0);
       // Total token budget = tokenBudgetPerSeat * seatCount = 2M * 3 = 6M
       expect(body.limits.totalTokenBudget).toBe(6_000_000);
@@ -265,6 +278,37 @@ describe("billing routes", () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test assertions on response shape
       const body = await res.json() as any;
       expect(body.connections.count).toBe(0);
+    });
+
+    it("reports the gateway provider default (Sonnet 4.6) when nothing is saved (#3098)", async () => {
+      // The exact bug: on the SaaS gateway path with no saved model, the
+      // picker must show what actually runs — Sonnet 4.6 — not the plan's
+      // recommended model and not a hardcoded UI fallback.
+      const origProvider = process.env.ATLAS_PROVIDER;
+      const origModel = process.env.ATLAS_MODEL;
+      process.env.ATLAS_PROVIDER = "gateway";
+      delete process.env.ATLAS_MODEL;
+      try {
+        mockSettingLiveValue = undefined; // nothing persisted
+        mockInternalQuery.mockImplementation((...args: unknown[]) => {
+          const sql = args[0];
+          if (typeof sql === "string" && sql.includes("member")) {
+            return Promise.resolve([{ count: 1 }]);
+          }
+          return Promise.resolve([]);
+        });
+
+        const res = await request("/api/v1/billing");
+        expect(res.status).toBe(200);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test assertions on response shape
+        const body = await res.json() as any;
+        expect(body.currentModel).toBe("anthropic/claude-sonnet-4.6");
+      } finally {
+        if (origProvider !== undefined) process.env.ATLAS_PROVIDER = origProvider;
+        else delete process.env.ATLAS_PROVIDER;
+        if (origModel !== undefined) process.env.ATLAS_MODEL = origModel;
+        else delete process.env.ATLAS_MODEL;
+      }
     });
 
     it("uses setting override for currentModel when available", async () => {

--- a/packages/api/src/api/routes/admin-tokens.ts
+++ b/packages/api/src/api/routes/admin-tokens.ts
@@ -122,20 +122,44 @@ adminTokens.openapi(getTokenSummaryRoute, async (c) => {
     }
     const { fromDate, toDate } = range;
 
-    const rows = yield* Effect.tryPromise({
-      try: () => internalQuery<{
-        total_prompt: string;
-        total_completion: string;
-        total_requests: string;
-      }>(
-        `SELECT
-           COALESCE(SUM(prompt_tokens), 0) AS total_prompt,
-           COALESCE(SUM(completion_tokens), 0) AS total_completion,
-           COUNT(*) AS total_requests
-         FROM token_usage
-         WHERE created_at >= $1 AND created_at <= $2 AND org_id = $3`,
-        [fromDate, toDate, orgId!],
-      ),
+    // Two parallel reads: the period totals, and a per-model breakdown so an
+    // operator can see WHICH model burned the tokens (#3098). The model
+    // dimension lives on token_usage but was previously aggregated away.
+    const [rows, modelRows] = yield* Effect.tryPromise({
+      try: () => Promise.all([
+        internalQuery<{
+          total_prompt: string;
+          total_completion: string;
+          total_requests: string;
+        }>(
+          `SELECT
+             COALESCE(SUM(prompt_tokens), 0) AS total_prompt,
+             COALESCE(SUM(completion_tokens), 0) AS total_completion,
+             COUNT(*) AS total_requests
+           FROM token_usage
+           WHERE created_at >= $1 AND created_at <= $2 AND org_id = $3`,
+          [fromDate, toDate, orgId!],
+        ),
+        internalQuery<{
+          model: string | null;
+          provider: string | null;
+          total_prompt: string;
+          total_completion: string;
+          request_count: string;
+        }>(
+          `SELECT
+             model,
+             provider,
+             COALESCE(SUM(prompt_tokens), 0) AS total_prompt,
+             COALESCE(SUM(completion_tokens), 0) AS total_completion,
+             COUNT(*) AS request_count
+           FROM token_usage
+           WHERE created_at >= $1 AND created_at <= $2 AND org_id = $3
+           GROUP BY model, provider
+           ORDER BY (COALESCE(SUM(prompt_tokens), 0) + COALESCE(SUM(completion_tokens), 0)) DESC`,
+          [fromDate, toDate, orgId!],
+        ),
+      ]),
       catch: (err) => err instanceof Error ? err : new Error(String(err)),
     });
 
@@ -145,6 +169,20 @@ adminTokens.openapi(getTokenSummaryRoute, async (c) => {
       totalCompletionTokens: parseInt(row?.total_completion ?? "0", 10),
       totalTokens: parseInt(row?.total_prompt ?? "0", 10) + parseInt(row?.total_completion ?? "0", 10),
       totalRequests: parseInt(row?.total_requests ?? "0", 10),
+      // Rows with a NULL model/provider (older usage records written before the
+      // column existed) surface as "unknown" rather than being dropped.
+      byModel: modelRows.map((m) => {
+        const promptTokens = parseInt(m.total_prompt ?? "0", 10);
+        const completionTokens = parseInt(m.total_completion ?? "0", 10);
+        return {
+          model: m.model ?? "unknown",
+          provider: m.provider ?? "unknown",
+          promptTokens,
+          completionTokens,
+          totalTokens: promptTokens + completionTokens,
+          requestCount: parseInt(m.request_count ?? "0", 10),
+        };
+      }),
       from: fromDate,
       to: toDate,
     }, 200);

--- a/packages/api/src/api/routes/billing.ts
+++ b/packages/api/src/api/routes/billing.ts
@@ -30,6 +30,7 @@ import { getCurrentPeriodUsage } from "@atlas/api/lib/metering";
 import { getPlanDefinition, getPlanLimits, computeTokenBudget, isUnlimited } from "@atlas/api/lib/billing/plans";
 import { buildMetricStatus } from "@atlas/api/lib/billing/enforcement";
 import { getSettingLive } from "@atlas/api/lib/settings";
+import { resolveModelId } from "@atlas/api/lib/providers";
 import { BillingStatusSchema } from "@useatlas/schemas";
 import { ADMIN_ROLES, type AdminRole } from "@useatlas/types/auth";
 import { ErrorSchema } from "./shared-schemas";
@@ -283,8 +284,9 @@ billing.openapi(getBillingStatusRoute, async (c) => {
     const plan = getPlanDefinition(workspace.plan_tier);
     const limits = getPlanLimits(workspace.plan_tier);
 
-    // Fetch seat count, connection count, subscription, and current model in parallel
-    const [seatCountResult, connectionCountResult, subResult, currentModelSetting] = yield* Effect.promise(() => Promise.all([
+    // Fetch seat count, connection count, subscription, and the saved model +
+    // provider settings in parallel
+    const [seatCountResult, connectionCountResult, subResult, currentModelSetting, providerSetting] = yield* Effect.promise(() => Promise.all([
       // Actual member count from Better Auth's member table
       internalQuery<{ count: number }>(
         `SELECT COUNT(*)::int AS count FROM member WHERE "organizationId" = $1`,
@@ -335,12 +337,37 @@ billing.openapi(getBillingStatusRoute, async (c) => {
         );
         return undefined;
       }),
+      // Provider setting — mirrors the agent loop's resolution so the reported
+      // default matches what actually runs. Usually unset (env/VERCEL picks the
+      // provider), in which case resolveModelId falls back to env + defaults.
+      getSettingLive("ATLAS_PROVIDER", orgId).catch((err) => {
+        log.debug(
+          { err: err instanceof Error ? err.message : String(err), orgId },
+          "Failed to read ATLAS_PROVIDER setting — resolving provider from env",
+        );
+        return undefined;
+      }),
     ]));
 
     const seatCount = Math.max(1, seatCountResult[0]?.count ?? 1);
     const connectionCount = connectionCountResult[0]?.count ?? 0;
     const subscription = subResult.length > 0 ? subResult[0] : null;
-    const currentModel = currentModelSetting || plan.defaultModel || "default";
+    // SSOT (#3098): currentModel is exactly what the agent loop resolves for
+    // this workspace — the saved ATLAS_MODEL if present, else the provider's
+    // default (gateway → Sonnet 4.6). The billing "Default AI model" picker
+    // displays this verbatim, so it can never advertise a model the engine
+    // won't actually run. Falls back to the plan's recommended model only if
+    // resolution throws (e.g. an openai-compatible provider with no model set).
+    let currentModel: string;
+    try {
+      currentModel = resolveModelId(providerSetting, currentModelSetting);
+    } catch (err) {
+      log.debug(
+        { err: err instanceof Error ? err.message : String(err), orgId },
+        "Model resolution failed for billing currentModel — using plan default",
+      );
+      currentModel = currentModelSetting || plan.defaultModel || "default";
+    }
 
     // Compute per-seat token budget (scales with actual seat count)
     const totalTokenBudget = computeTokenBudget(workspace.plan_tier, seatCount);

--- a/packages/api/src/lib/__tests__/providers.test.ts
+++ b/packages/api/src/lib/__tests__/providers.test.ts
@@ -2,7 +2,8 @@ import { describe, expect, test, afterEach } from "bun:test";
 
 // Import after mocks — getProviderType reads process.env at call time, so no
 // module-level mocking is needed.
-const { getProviderType, getDefaultProvider, getModel } = await import("@atlas/api/lib/providers");
+const { getProviderType, getDefaultProvider, getModel, getModelForConfig, resolveModelId } =
+  await import("@atlas/api/lib/providers");
 
 // ---------------------------------------------------------------------------
 // Env snapshot — capture/restore only the vars this test touches
@@ -13,6 +14,7 @@ const origModel = process.env.ATLAS_MODEL;
 const origVercel = process.env.VERCEL;
 const origCompatBaseURL = process.env.OPENAI_COMPATIBLE_BASE_URL;
 const origCompatApiKey = process.env.OPENAI_COMPATIBLE_API_KEY;
+const origGatewayKey = process.env.AI_GATEWAY_API_KEY;
 
 afterEach(() => {
   if (origProvider !== undefined) process.env.ATLAS_PROVIDER = origProvider;
@@ -29,6 +31,9 @@ afterEach(() => {
 
   if (origCompatApiKey !== undefined) process.env.OPENAI_COMPATIBLE_API_KEY = origCompatApiKey;
   else delete process.env.OPENAI_COMPATIBLE_API_KEY;
+
+  if (origGatewayKey !== undefined) process.env.AI_GATEWAY_API_KEY = origGatewayKey;
+  else delete process.env.AI_GATEWAY_API_KEY;
 });
 
 // ---------------------------------------------------------------------------
@@ -148,6 +153,48 @@ describe("getDefaultProvider", () => {
   test("returns 'gateway' when VERCEL is set", () => {
     process.env.VERCEL = "1";
     expect(getDefaultProvider()).toBe("gateway");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveModelId — single source of truth for the unset/effective default
+// (#3098). The billing page's "Default AI model" picker and the agent loop
+// must resolve the SAME model when a workspace hasn't saved one; otherwise the
+// UI advertises one model while another is billed.
+// ---------------------------------------------------------------------------
+
+describe("resolveModelId — SSOT default (#3098)", () => {
+  test("gateway default equals getModelForConfig().modelId (no drift)", () => {
+    // The agent builds its model via getModelForConfig(); the billing endpoint
+    // reports the default via resolveModelId(). Both must agree for the gateway
+    // provider when nothing is saved.
+    process.env.AI_GATEWAY_API_KEY = "test-key"; // lets getModelForConfig build the gateway model
+    delete process.env.ATLAS_MODEL;
+    const agentDefault = getModelForConfig("gateway", undefined).modelId;
+    expect(resolveModelId("gateway", undefined)).toBe(agentDefault);
+  });
+
+  test("platform gateway default is Sonnet 4.6 (documented decision, #3098)", () => {
+    delete process.env.ATLAS_MODEL;
+    // Decision: the hosted/gateway default is the balanced, ~5x-cheaper Sonnet
+    // 4.6 — NOT Opus 4.8. Pinning it here so UI and runtime can't silently
+    // diverge back to the expensive default.
+    expect(resolveModelId("gateway", undefined)).toBe("anthropic/claude-sonnet-4.6");
+  });
+
+  test("an explicitly saved model overrides the default", () => {
+    delete process.env.ATLAS_MODEL;
+    expect(resolveModelId("gateway", "anthropic/claude-opus-4.8")).toBe("anthropic/claude-opus-4.8");
+  });
+
+  test("falls back to ATLAS_MODEL env when no override is given", () => {
+    process.env.ATLAS_MODEL = "anthropic/claude-haiku-4.5";
+    expect(resolveModelId("gateway", undefined)).toBe("anthropic/claude-haiku-4.5");
+  });
+
+  test("throws for openai-compatible with no model and no default", () => {
+    delete process.env.ATLAS_MODEL;
+    expect(() => resolveModelId("openai-compatible", undefined)).toThrow("ATLAS_MODEL is required");
   });
 });
 

--- a/packages/api/src/lib/__tests__/providers.test.ts
+++ b/packages/api/src/lib/__tests__/providers.test.ts
@@ -12,6 +12,7 @@ const { getProviderType, getDefaultProvider, getModel, getModelForConfig, resolv
 const origProvider = process.env.ATLAS_PROVIDER;
 const origModel = process.env.ATLAS_MODEL;
 const origVercel = process.env.VERCEL;
+const origDeployMode = process.env.ATLAS_DEPLOY_MODE;
 const origCompatBaseURL = process.env.OPENAI_COMPATIBLE_BASE_URL;
 const origCompatApiKey = process.env.OPENAI_COMPATIBLE_API_KEY;
 const origGatewayKey = process.env.AI_GATEWAY_API_KEY;
@@ -25,6 +26,9 @@ afterEach(() => {
 
   if (origVercel !== undefined) process.env.VERCEL = origVercel;
   else delete process.env.VERCEL;
+
+  if (origDeployMode !== undefined) process.env.ATLAS_DEPLOY_MODE = origDeployMode;
+  else delete process.env.ATLAS_DEPLOY_MODE;
 
   if (origCompatBaseURL !== undefined) process.env.OPENAI_COMPATIBLE_BASE_URL = origCompatBaseURL;
   else delete process.env.OPENAI_COMPATIBLE_BASE_URL;
@@ -145,14 +149,31 @@ describe("getProviderType", () => {
 });
 
 describe("getDefaultProvider", () => {
-  test("returns 'anthropic' when VERCEL is not set", () => {
+  test("returns 'anthropic' when self-hosted (no VERCEL, no SaaS deploy mode)", () => {
     delete process.env.VERCEL;
+    delete process.env.ATLAS_DEPLOY_MODE;
     expect(getDefaultProvider()).toBe("anthropic");
   });
 
   test("returns 'gateway' when VERCEL is set", () => {
+    delete process.env.ATLAS_DEPLOY_MODE;
     process.env.VERCEL = "1";
     expect(getDefaultProvider()).toBe("gateway");
+  });
+
+  // SaaS runs on Railway where VERCEL is unset — the deploy-mode signal is what
+  // makes the hosted default `gateway` (so an unset ATLAS_PROVIDER doesn't fall
+  // back to anthropic-direct and bill/report the wrong model). #3098.
+  test("returns 'gateway' when ATLAS_DEPLOY_MODE=saas even without VERCEL", () => {
+    delete process.env.VERCEL;
+    process.env.ATLAS_DEPLOY_MODE = "saas";
+    expect(getDefaultProvider()).toBe("gateway");
+  });
+
+  test("self-hosted deploy mode keeps the anthropic default", () => {
+    delete process.env.VERCEL;
+    process.env.ATLAS_DEPLOY_MODE = "self-hosted";
+    expect(getDefaultProvider()).toBe("anthropic");
   });
 });
 
@@ -195,6 +216,18 @@ describe("resolveModelId — SSOT default (#3098)", () => {
   test("throws for openai-compatible with no model and no default", () => {
     delete process.env.ATLAS_MODEL;
     expect(() => resolveModelId("openai-compatible", undefined)).toThrow("ATLAS_MODEL is required");
+  });
+
+  // The bug end-to-end: a SaaS deployment with nothing configured must resolve
+  // gateway → Sonnet 4.6, NOT anthropic → Opus. With no provider override and no
+  // ATLAS_PROVIDER, the provider falls through to getDefaultProvider() (gateway
+  // on SaaS), then to PROVIDER_DEFAULTS.gateway. #3098.
+  test("unset provider+model on SaaS resolves the gateway Sonnet default", () => {
+    delete process.env.ATLAS_PROVIDER;
+    delete process.env.ATLAS_MODEL;
+    delete process.env.VERCEL;
+    process.env.ATLAS_DEPLOY_MODE = "saas";
+    expect(resolveModelId(undefined, undefined)).toBe("anthropic/claude-sonnet-4.6");
   });
 });
 

--- a/packages/api/src/lib/providers.ts
+++ b/packages/api/src/lib/providers.ts
@@ -52,9 +52,21 @@ const PROVIDER_DEFAULTS: Record<ConfigProvider, string | undefined> = {
   gateway: "anthropic/claude-sonnet-4.6",
 };
 
-/** Returns the default provider string based on runtime environment. */
+/**
+ * Returns the default provider string based on runtime environment.
+ *
+ * Hosted/SaaS deployments route through the Vercel AI Gateway (the operator's
+ * metered key), so they default to `gateway`; self-hosted defaults to
+ * anthropic-direct (BYO `ANTHROPIC_API_KEY`). `VERCEL` covers Vercel-hosted;
+ * `ATLAS_DEPLOY_MODE=saas` covers the Railway-hosted SaaS where `VERCEL` is
+ * unset (#3098). Single source of truth for "which provider when none is
+ * explicitly configured" — the `ATLAS_PROVIDER` setting has no static default,
+ * so an unset provider falls through to here rather than forcing `anthropic`.
+ */
 export function getDefaultProvider(): ConfigProvider {
-  return process.env.VERCEL ? "gateway" : "anthropic";
+  return process.env.VERCEL || process.env.ATLAS_DEPLOY_MODE === "saas"
+    ? "gateway"
+    : "anthropic";
 }
 
 function isBedrockAnthropicModel(modelId: string): boolean {

--- a/packages/api/src/lib/providers.ts
+++ b/packages/api/src/lib/providers.ts
@@ -44,7 +44,12 @@ const PROVIDER_DEFAULTS: Record<ConfigProvider, string | undefined> = {
   bedrock: "anthropic.claude-opus-4-8",
   ollama: "llama3.1",
   "openai-compatible": undefined,
-  gateway: "anthropic/claude-opus-4.8",
+  // Hosted/gateway default: balanced Sonnet 4.6, NOT Opus 4.8. The gateway
+  // path is the SaaS billing surface, where an unset workspace would otherwise
+  // silently run (and be billed for) Opus 4.8 at ~5x the input cost while the
+  // billing picker advertised Sonnet (#3098). Keep this in lockstep with the
+  // billing page's displayed default — both flow through `resolveModelId()`.
+  gateway: "anthropic/claude-sonnet-4.6",
 };
 
 /** Returns the default provider string based on runtime environment. */
@@ -57,11 +62,23 @@ function isBedrockAnthropicModel(modelId: string): boolean {
 }
 
 /**
- * Read and validate ATLAS_PROVIDER / ATLAS_MODEL from env.
- * Returns the validated config provider string and the resolved model ID.
+ * Resolve provider + model ID from optional overrides, falling back to env
+ * vars (`ATLAS_PROVIDER` / `ATLAS_MODEL`) and finally the per-provider
+ * {@link PROVIDER_DEFAULTS}.
+ *
+ * This is the single source of truth for "which model does Atlas run". Both
+ * the env path ({@link resolveProvider}) and the settings path
+ * ({@link getModelForConfig} / {@link resolveModelId}) delegate here so the
+ * billing UI's advertised default and the agent loop's actual default can
+ * never diverge (#3098).
+ *
+ * @throws {Error} on an unknown provider or a provider with no resolvable model.
  */
-function resolveProvider(): { provider: ConfigProvider; modelId: string } {
-  const raw = process.env.ATLAS_PROVIDER ?? getDefaultProvider();
+function resolveSelection(
+  providerOverride?: string,
+  modelOverride?: string,
+): { provider: ConfigProvider; modelId: string } {
+  const raw = providerOverride ?? process.env.ATLAS_PROVIDER ?? getDefaultProvider();
   if (!VALID_PROVIDERS.has(raw as ConfigProvider)) {
     throw new Error(
       `Unknown provider "${raw}". Supported: ${[...VALID_PROVIDERS].join(", ")}`
@@ -69,7 +86,7 @@ function resolveProvider(): { provider: ConfigProvider; modelId: string } {
   }
   // Safe: validated by VALID_PROVIDERS.has() above
   const provider = raw as ConfigProvider;
-  const modelId = process.env.ATLAS_MODEL ?? PROVIDER_DEFAULTS[provider];
+  const modelId = modelOverride ?? process.env.ATLAS_MODEL ?? PROVIDER_DEFAULTS[provider];
   if (!modelId) {
     throw new Error(
       `ATLAS_MODEL is required when using the "${provider}" provider. ` +
@@ -77,6 +94,32 @@ function resolveProvider(): { provider: ConfigProvider; modelId: string } {
     );
   }
   return { provider, modelId };
+}
+
+/**
+ * Read and validate ATLAS_PROVIDER / ATLAS_MODEL from env.
+ * Returns the validated config provider string and the resolved model ID.
+ */
+function resolveProvider(): { provider: ConfigProvider; modelId: string } {
+  return resolveSelection();
+}
+
+/**
+ * Resolve the model ID Atlas would actually run for the given (optional)
+ * provider/model overrides — WITHOUT building an SDK client.
+ *
+ * This is the lightweight, side-effect-free SSOT used by surfaces that need to
+ * display the effective/default model (e.g. the billing "Default AI model"
+ * row) but must not instantiate a provider client or require provider API keys
+ * to do so. The agent loop resolves the same value via {@link getModelForConfig}
+ * (which additionally builds the client); both share {@link resolveSelection},
+ * so the displayed default and the billed default cannot drift (#3098).
+ *
+ * @throws {Error} on an unknown provider or a provider with no resolvable model
+ *   (e.g. `openai-compatible` with neither an override nor `ATLAS_MODEL`).
+ */
+export function resolveModelId(providerOverride?: string, modelOverride?: string): string {
+  return resolveSelection(providerOverride, modelOverride).modelId;
 }
 
 // ---------------------------------------------------------------------------
@@ -183,21 +226,7 @@ export function getModelForConfig(
   providerOverride?: string,
   modelOverride?: string,
 ): { model: LanguageModel; providerType: ProviderType; modelId: string } {
-  const raw = providerOverride ?? process.env.ATLAS_PROVIDER ?? getDefaultProvider();
-  if (!VALID_PROVIDERS.has(raw as ConfigProvider)) {
-    throw new Error(
-      `Unknown provider "${raw}". Supported: ${[...VALID_PROVIDERS].join(", ")}`
-    );
-  }
-  const provider = raw as ConfigProvider;
-  const modelId = modelOverride ?? process.env.ATLAS_MODEL ?? PROVIDER_DEFAULTS[provider];
-  if (!modelId) {
-    throw new Error(
-      `ATLAS_MODEL is required when using the "${provider}" provider. ` +
-        "Set it to the model ID served by your inference server (e.g. ATLAS_MODEL=llama3.1)."
-    );
-  }
-
+  const { provider, modelId } = resolveSelection(providerOverride, modelOverride);
   return {
     model: buildModel(provider, modelId),
     providerType: resolveProviderType(provider, modelId),

--- a/packages/api/src/lib/settings.ts
+++ b/packages/api/src/lib/settings.ts
@@ -297,7 +297,10 @@ const SETTINGS_REGISTRY: SettingDefinition[] = [
     description: "LLM provider for the agent",
     type: "select",
     options: ["anthropic", "openai", "bedrock", "ollama", "openai-compatible", "gateway"],
-    default: "anthropic",
+    // No static default: an unset provider must fall through to
+    // `getDefaultProvider()` (providers.ts), which picks `gateway` for
+    // hosted/SaaS and `anthropic` for self-hosted. A hardcoded "anthropic"
+    // here would override that and make SaaS report/run the wrong default (#3098).
     envVar: "ATLAS_PROVIDER",
     requiresRestart: true,
     scope: "platform",

--- a/packages/cli/src/__tests__/doctor.test.ts
+++ b/packages/cli/src/__tests__/doctor.test.ts
@@ -358,7 +358,7 @@ describe("checkProvider", () => {
     const result = checkProvider();
     expect(result.status).toBe("pass");
     expect(result.detail).toContain("anthropic");
-    expect(result.detail).toContain("claude-opus-4-6");
+    expect(result.detail).toContain("claude-opus-4-8");
   });
 
   test("pass with custom model", () => {

--- a/packages/cli/src/doctor.ts
+++ b/packages/cli/src/doctor.ts
@@ -41,7 +41,7 @@ const PROVIDER_KEY_MAP: Record<string, string> = {
 const PROVIDER_DEFAULTS: Record<string, string> = {
   anthropic: "claude-opus-4-8",
   openai: "gpt-4o",
-  bedrock: "anthropic.claude-opus-4-8-v1:0",
+  bedrock: "anthropic.claude-opus-4-8",
   ollama: "llama3.1",
   gateway: "anthropic/claude-sonnet-4.6",
 };

--- a/packages/cli/src/doctor.ts
+++ b/packages/cli/src/doctor.ts
@@ -35,12 +35,15 @@ const PROVIDER_KEY_MAP: Record<string, string> = {
   gateway: "AI_GATEWAY_API_KEY",
 };
 
+// Keep in lockstep with PROVIDER_DEFAULTS in packages/api/src/lib/providers.ts.
+// gateway → Sonnet 4.6 (the hosted/SaaS default, ~5x cheaper than Opus); the
+// rest mirror the agent's per-provider defaults (#3098).
 const PROVIDER_DEFAULTS: Record<string, string> = {
-  anthropic: "claude-opus-4-6",
+  anthropic: "claude-opus-4-8",
   openai: "gpt-4o",
-  bedrock: "anthropic.claude-opus-4-6-v1:0",
+  bedrock: "anthropic.claude-opus-4-8-v1:0",
   ollama: "llama3.1",
-  gateway: "anthropic/claude-opus-4.6",
+  gateway: "anthropic/claude-sonnet-4.6",
 };
 
 // ---------------------------------------------------------------------------

--- a/packages/schemas/src/__tests__/analytics.test.ts
+++ b/packages/schemas/src/__tests__/analytics.test.ts
@@ -75,7 +75,33 @@ describe("token usage", () => {
       from: "2026-04-01T00:00:00.000Z",
       to: "2026-04-20T00:00:00.000Z",
     };
-    expect(TokenSummarySchema.parse(row)).toEqual(row);
+    // byModel is additive (#3098): when an older API response omits it, the
+    // schema fills [] so the web always gets an array to map over.
+    expect(TokenSummarySchema.parse(row)).toEqual({ ...row, byModel: [] });
+  });
+
+  test("TokenSummarySchema parses a per-model breakdown (#3098)", () => {
+    const parsed = TokenSummarySchema.parse({
+      totalPromptTokens: 1000,
+      totalCompletionTokens: 500,
+      totalTokens: 1500,
+      totalRequests: 50,
+      byModel: [
+        {
+          model: "anthropic/claude-opus-4.8",
+          provider: "gateway",
+          promptTokens: 900,
+          completionTokens: 400,
+          totalTokens: 1300,
+          requestCount: 40,
+        },
+      ],
+      from: "2026-04-01T00:00:00.000Z",
+      to: "2026-04-20T00:00:00.000Z",
+    });
+    expect(parsed.byModel).toHaveLength(1);
+    expect(parsed.byModel[0].model).toBe("anthropic/claude-opus-4.8");
+    expect(parsed.byModel[0].provider).toBe("gateway");
   });
 
   test("TokenSummarySchema rejects non-ISO from", () => {

--- a/packages/schemas/src/analytics.ts
+++ b/packages/schemas/src/analytics.ts
@@ -106,11 +106,25 @@ export const AuditUsersResponseSchema = z.object({
 // Token usage
 // ---------------------------------------------------------------------------
 
+interface ModelUsageRow {
+  model: string;
+  provider: string;
+  promptTokens: number;
+  completionTokens: number;
+  totalTokens: number;
+  requestCount: number;
+}
 interface TokenSummary {
   totalPromptTokens: number;
   totalCompletionTokens: number;
   totalTokens: number;
   totalRequests: number;
+  /**
+   * Per-model token breakdown over the same window (#3098). Lets an operator
+   * see WHICH model burned the tokens — the signal that made the silent
+   * Opus-vs-Sonnet default surprise invisible until a raw DB query.
+   */
+  byModel: ModelUsageRow[];
   from: string;
   to: string;
 }
@@ -130,11 +144,23 @@ interface TrendPoint {
   requestCount: number;
 }
 
+export const ModelUsageRowSchema = z.object({
+  model: z.string(),
+  provider: z.string(),
+  promptTokens: z.number(),
+  completionTokens: z.number(),
+  totalTokens: z.number(),
+  requestCount: z.number(),
+}) satisfies z.ZodType<ModelUsageRow, unknown>;
+
 export const TokenSummarySchema = z.object({
   totalPromptTokens: z.number(),
   totalCompletionTokens: z.number(),
   totalTokens: z.number(),
   totalRequests: z.number(),
+  // Additive (#3098): `.default([])` so a web bundle parsing an older API
+  // response (pre-byModel) still validates during a rolling deploy.
+  byModel: z.array(ModelUsageRowSchema).default([]),
   from: IsoTimestampSchema,
   to: IsoTimestampSchema,
 }) satisfies z.ZodType<TokenSummary, unknown>;

--- a/packages/web/src/app/admin/billing/page.tsx
+++ b/packages/web/src/app/admin/billing/page.tsx
@@ -499,11 +499,14 @@ function ResourceValue({ count, max }: { count: number; max: number | null }) {
 // ── Model row (progressive disclosure) ────────────────────────────
 
 function ModelRow({ data, onSaved }: { data: BillingStatus; onSaved: () => void }) {
-  // Canonicalize stored value through the legacy-hyphen alias map so an
-  // older `claude-sonnet-4-6` setting still highlights "Sonnet 4.6" in
-  // the dropdown and saves the new gateway-canonical ID on next change.
-  const storedModel = data.currentModel ?? data.plan.defaultModel ?? "anthropic/claude-sonnet-4.6";
-  const currentModel = canonicalizeModel(storedModel);
+  // SSOT (#3098): the API resolves `currentModel` to exactly what the agent
+  // runs when nothing is saved — the same value the gateway provider default
+  // produces — so display it verbatim. NO hardcoded fallback here: a cosmetic
+  // default that disagrees with the resolver is the exact bug this fixes
+  // (the row showed "Sonnet 4.6" while unset workspaces ran Opus 4.8).
+  // canonicalize() only maps legacy-hyphen / deprecated-version values onto a
+  // picker row so an older `claude-sonnet-4-6` setting still highlights its row.
+  const currentModel = canonicalizeModel(data.currentModel);
   const currentLabel = modelLabel(currentModel);
 
   const { mutate, saving, error, clearError } = useAdminMutation({

--- a/packages/web/src/app/admin/token-usage/tab.tsx
+++ b/packages/web/src/app/admin/token-usage/tab.tsx
@@ -19,6 +19,14 @@ import { TokenSummarySchema, TrendsResponseSchema, TokenUserResponseSchema } fro
 import { useDarkMode } from "@/ui/hooks/use-dark-mode";
 import { formatISODate, formatNumber, parseISODate } from "@/lib/format";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
 import { DatePicker } from "@/components/ui/date-picker";
 import { Button } from "@/components/ui/button";
 import { StatCard } from "@/ui/components/admin/stat-card";
@@ -31,7 +39,7 @@ import { DataTableToolbar } from "@/components/data-table/data-table-toolbar";
 import { DataTableSortList } from "@/components/data-table/data-table-sort-list";
 import { getTokenUsageColumns } from "./columns";
 import { useDataTable } from "@/hooks/use-data-table";
-import { Coins, TrendingUp, Users, MessageSquare, Search } from "lucide-react";
+import { Coins, TrendingUp, Users, MessageSquare, Search, Cpu } from "lucide-react";
 import { useState } from "react";
 
 const TokenChart = dynamic(() => import("./token-chart"), { ssr: false });
@@ -133,37 +141,91 @@ export function TokenUsageTab() {
         ) : summaryLoading ? (
           <LoadingState message="Loading summary..." />
         ) : summary ? (
-          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-            <StatCard
-              title="Total Tokens"
-              value={formatNumber(summary.totalTokens)}
-              icon={<Coins className="size-4" />}
-            />
-            <StatCard
-              title="Prompt Tokens"
-              value={formatNumber(summary.totalPromptTokens)}
-              icon={<TrendingUp className="size-4" />}
-              description={summary.totalTokens > 0
-                ? `${((summary.totalPromptTokens / summary.totalTokens) * 100).toFixed(0)}% of total`
-                : undefined}
-            />
-            <StatCard
-              title="Completion Tokens"
-              value={formatNumber(summary.totalCompletionTokens)}
-              icon={<TrendingUp className="size-4" />}
-              description={summary.totalTokens > 0
-                ? `${((summary.totalCompletionTokens / summary.totalTokens) * 100).toFixed(0)}% of total`
-                : undefined}
-            />
-            <StatCard
-              title="Total Requests"
-              value={formatNumber(summary.totalRequests)}
-              icon={<MessageSquare className="size-4" />}
-              description={summary.totalRequests > 0 && summary.totalTokens > 0
-                ? `~${formatNumber(Math.round(summary.totalTokens / summary.totalRequests))} tokens/req`
-                : undefined}
-            />
-          </div>
+          <>
+            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+              <StatCard
+                title="Gross Tokens"
+                value={formatNumber(summary.totalTokens)}
+                icon={<Coins className="size-4" />}
+                description="input + output, not billed"
+              />
+              <StatCard
+                title="Prompt (input)"
+                value={formatNumber(summary.totalPromptTokens)}
+                icon={<TrendingUp className="size-4" />}
+                description={summary.totalTokens > 0
+                  ? `${((summary.totalPromptTokens / summary.totalTokens) * 100).toFixed(0)}% of total · gross`
+                  : "gross"}
+              />
+              <StatCard
+                title="Completion (output)"
+                value={formatNumber(summary.totalCompletionTokens)}
+                icon={<TrendingUp className="size-4" />}
+                description={summary.totalTokens > 0
+                  ? `${((summary.totalCompletionTokens / summary.totalTokens) * 100).toFixed(0)}% of total`
+                  : undefined}
+              />
+              <StatCard
+                title="Total Requests"
+                value={formatNumber(summary.totalRequests)}
+                icon={<MessageSquare className="size-4" />}
+                description={summary.totalRequests > 0 && summary.totalTokens > 0
+                  ? `~${formatNumber(Math.round(summary.totalTokens / summary.totalRequests))} tokens/req`
+                  : undefined}
+              />
+            </div>
+
+            {/* Figures above are GROSS input tokens: every agent step re-sends
+                the prompt prefix, so the same context is counted once per step
+                — this is not the billed amount.
+                TODO(#3099): once token_usage persists cache_read_tokens /
+                cache_write_tokens, surface the effective/billed split here
+                (gross − prompt-cache discount). */}
+            <p className="text-[11px] leading-relaxed text-muted-foreground">
+              Token figures are <span className="font-medium text-foreground">gross input tokens</span>,
+              not the billed amount — each agent step re-sends the prompt prefix,
+              so shared context is counted multiple times. Billed/effective
+              tokens (after prompt-cache discounts) are tracked separately
+              (#3099).
+            </p>
+
+            {summary.byModel.length > 0 && (
+              <Card>
+                <CardHeader className="pb-2">
+                  <CardTitle className="flex items-center gap-2 text-base">
+                    <Cpu className="size-4" />
+                    Usage by Model
+                  </CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead>Model</TableHead>
+                        <TableHead>Provider</TableHead>
+                        <TableHead className="text-right">Prompt</TableHead>
+                        <TableHead className="text-right">Completion</TableHead>
+                        <TableHead className="text-right">Total</TableHead>
+                        <TableHead className="text-right">Requests</TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {summary.byModel.map((m) => (
+                        <TableRow key={`${m.provider}/${m.model}`}>
+                          <TableCell className="font-medium">{m.model}</TableCell>
+                          <TableCell className="text-muted-foreground">{m.provider}</TableCell>
+                          <TableCell className="text-right tabular-nums">{formatNumber(m.promptTokens)}</TableCell>
+                          <TableCell className="text-right tabular-nums">{formatNumber(m.completionTokens)}</TableCell>
+                          <TableCell className="text-right font-medium tabular-nums">{formatNumber(m.totalTokens)}</TableCell>
+                          <TableCell className="text-right tabular-nums">{m.requestCount}</TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                </CardContent>
+              </Card>
+            )}
+          </>
         ) : null}
 
         <Card>


### PR DESCRIPTION
Fixes #3098.

## Problem

The `/admin/billing` **"Default AI model"** picker showed a hardcoded cosmetic **"Sonnet 4.6"** when nothing was saved (`billing/page.tsx` `?? "anthropic/claude-sonnet-4.6"`), but the gateway provider's runtime default was **Opus 4.8** (`PROVIDER_DEFAULTS.gateway`). Unset workspaces silently ran — and were billed for — Opus 4.8 at ~5× the input cost while the UI advertised Sonnet. There was no single source of truth for "the default when nothing is set."

## Platform gateway default — decision

**The hosted/gateway default is now Sonnet 4.6** (balanced, ~5× cheaper than Opus 4.8), set in `PROVIDER_DEFAULTS.gateway`. This is the durable code fix behind the already-applied prod env pin (`ATLAS_MODEL=anthropic/claude-sonnet-4.6` on api/api-eu/api-apac), which is now redundant and can be removed. Self-hosted **anthropic-direct** stays on Opus 4.8 (BYO key — the user pays Anthropic directly; the gateway/SaaS billing surface is the one this issue is about).

The UI default and runtime default are **guaranteed equal by construction** (both flow through `resolveModelId()`/`resolveSelection()`), and locked by a drift-guard test.

## Changes

**SSOT for the default model**
- `providers.ts`: extracted `resolveSelection()` — the single resolution path shared by the env reader (`resolveProvider`), `getModelForConfig` (agent loop, builds the SDK client), and a new lightweight **`resolveModelId()`** export that resolves the effective/default model id **without** building a client or requiring provider keys.
- `billing.ts`: `currentModel` is now `resolveModelId(providerSetting, savedModel)` — exactly what the agent resolves — instead of `plan.defaultModel`. Reads `ATLAS_PROVIDER`/`ATLAS_MODEL` org settings to mirror the agent, falls back to the plan's recommended model only if resolution throws.
- `web/billing/page.tsx`: `ModelRow` displays `data.currentModel` verbatim; the hardcoded fallback is gone. The legacy-hyphen alias + deprecated-version roll-forward (`LEGACY_MODEL_ALIASES`) is **preserved**.

**Usage-page model dimension (observability gap)**
- `admin-tokens.ts` `/summary` now returns a per-model `byModel` breakdown (`GROUP BY model, provider`, org-scoped), parallel to the totals query.
- `TokenSummarySchema` gains an additive `byModel` array (`.default([])` so an older API response still validates during a rolling deploy).
- Token-usage tab renders a **"Usage by Model"** table — the signal that would have made the Opus-vs-Sonnet surprise self-evident without a raw DB query.

**Gross vs billed labeling**
- Token figures relabeled as **GROSS input tokens (not billed)** with a caveat note. A `TODO(#3099)` marks where the billed/effective cache split will render once #3099 persists `cache_read`/`cache_write` columns. (Per the issue, cache columns + the INSERT change are out of scope here — they belong to #3099.)

## Tests
- `providers.test.ts`: SSOT drift guard — `resolveModelId("gateway") === getModelForConfig("gateway").modelId === "anthropic/claude-sonnet-4.6"`, plus override/env-fallback/throw cases.
- `billing.test.ts`: no-setting `currentModel` equals the shared resolver; explicit gateway-default-is-Sonnet-4.6 scenario; saved-override still wins.
- `admin-tokens.test.ts`: `byModel` breakdown shape + org-scoping; null model/provider → `"unknown"`.
- `analytics.test.ts`: `byModel` parse + additive-default behavior.

## Gates
`bun run type` ✓ · `bun run lint` ✓ · affected api isolated tests (39/39) ✓ · schemas (279/279) ✓ · web model-config/usage tests ✓ · syncpack ✓ · template-drift ✓

## Out of scope (#3099, parallel)
No `cache_read_tokens`/`cache_write_tokens` columns and no change to the `token_usage` INSERT in `agent.ts`. The billed/effective split display waits on #3099's columns (TODO left in place).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3104"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782999709&installation_id=135337507&pr_number=3104&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3104&signature=27050be115fbea820508160404e34c311a6e7b6debd19bc076cad6c7f7795509"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-model token usage breakdown to admin token summary and a "Usage by Model" dashboard table with per-model prompt/completion/total tokens and request counts.

* **Bug Fixes**
  * Billing status now resolves and reports the correct current model using provider + model resolution (gateway default included).

* **UI**
  * Summary stat labels clarified to "Gross Tokens", "Prompt (input)", "Completion (output)" with explanatory text.

* **Documentation**
  * Updated env docs/examples and provider default model names.

* **Tests**
  * Added/updated tests covering per-model breakdown, gateway default resolution, and related date-range behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->