### PR TITLE
test: stabilize two test-gate flakes (discord 5s timeout #3089, hosted root chmod #2821)

### DIFF
--- a/packages/api/src/api/__tests__/integrations-discord.test.ts
+++ b/packages/api/src/api/__tests__/integrations-discord.test.ts
@@ -28,6 +28,7 @@ import {
   describe,
   it,
   expect,
+  beforeAll,
   beforeEach,
   afterEach,
   mock,
@@ -187,6 +188,30 @@ describe("/api/v1/integrations/discord", () => {
   const savedBotToken = process.env.DISCORD_BOT_TOKEN;
   const savedClientId = process.env.DISCORD_CLIENT_ID;
   const savedPublicApiUrl = process.env.ATLAS_PUBLIC_API_URL;
+
+  // Warm the app/runtime build once, up front, with a generous timeout. The
+  // first `getApp()` pays the full `import("../../api/index")` build cost; the
+  // rest are cheap (module-cached). Paying it here — rather than letting it
+  // land on whichever test runs first — keeps that one-time cost from racing
+  // the default 5s per-test timeout under heavy isolated-runner concurrency
+  // (#3089).
+  //
+  // The discord install/callback routes read DISCORD_CLIENT_ID at module-load
+  // time to decide implemented (302) vs. not-configured (501) — see
+  // teams-discord-always-mount.test.ts. Since this import is what primes the
+  // module cache for every test, it must happen with the discord env set, or
+  // the routes bind in 501 mode for the whole file. Mirror the `beforeEach`
+  // env here; `beforeEach`/`afterEach` still own per-test setup and restore.
+  beforeAll(async () => {
+    process.env.DISCORD_BOT_TOKEN = "test-bot-token";
+    process.env.DISCORD_CLIENT_ID = "test-client-id";
+    process.env.DISCORD_PUBLIC_KEY = "test-public-key";
+    process.env.ATLAS_PUBLIC_API_URL = "https://atlas.test";
+    if (!process.env.ATLAS_ENCRYPTION_KEY) {
+      process.env.ATLAS_ENCRYPTION_KEY = "test-encryption-key-32-bytes-long-aa";
+    }
+    await getApp();
+  }, 30_000);
 
   beforeEach(() => {
     process.env.DISCORD_BOT_TOKEN = "test-bot-token";

--- a/plugins/mcp/__tests__/init/hosted.test.ts
+++ b/plugins/mcp/__tests__/init/hosted.test.ts
@@ -1189,14 +1189,23 @@ describe("runHostedAuthFlow — malformed JWT discriminant", () => {
 
 describe("runInit --hosted --write failure path", () => {
   it("surfaces a write failure and leaves any existing config untouched", async () => {
+    // The write failure is injected via chmod(0o500) on the target dir. Skip
+    // where those permission bits don't block writes: win32 (no POSIX perms)
+    // and root, where uid 0 bypasses POSIX permission checks entirely so the
+    // write would succeed and exitCode would be 0. Real CI runs as a non-root
+    // POSIX user, so this path stays covered there (#2821).
+    if (process.platform === "win32") return;
+    if (process.getuid?.() === 0) {
+      console.warn(
+        "[skip] hosted write-failure case: running as root (uid 0) bypasses chmod(0o500); covered by non-root CI.",
+      );
+      return;
+    }
     const dir = mkdtempSync(join(tmpdir(), "atlas-mcp-init-hosted-fail-"));
     // Pre-existing config we expect to survive the failed write.
     const target = join(dir, "claude_desktop_config.json");
     const original = `${JSON.stringify({ mcpServers: { existing: { command: "x", args: [] } } }, null, 2)}\n`;
     writeFileSync(target, original, { encoding: "utf8" });
-    // Make the directory read-only so the tmp write fails. POSIX-only —
-    // skip on win32 where chmod permission bits aren't enforced.
-    if (process.platform === "win32") return;
     chmodSync(dir, 0o500);
     const { serve, controller } = fakeServe({});
     const cap = captureStdio();
@@ -1232,6 +1241,10 @@ describe("runInit --hosted --write failure path", () => {
 
   it("surfaces a directory-creation failure with the directory in the message", async () => {
     if (process.platform === "win32") return;
+    // Note: no root guard here. Unlike the chmod-based case above, this failure
+    // is injected structurally (mkdir under a regular file → ENOTDIR), which the
+    // kernel returns regardless of uid — so root sees the same failure and this
+    // case stays meaningful under root execution (verified via `unshare -r`).
     const dir = mkdtempSync(join(tmpdir(), "atlas-mcp-init-hosted-mkdir-"));
     // Write a regular file where we want to create a subdirectory — the
     // recursive mkdir will fail with ENOTDIR.


### PR DESCRIPTION
Test-gate reliability pass — two independent, test-only flakes that erode the merge gate. No source changes.

## #3089 — `integrations-discord.test.ts` first test races the 5s timeout under concurrency

**Root cause:** the first `getApp()` pays the full `import("../../api/index")` build cost; the rest are module-cached and cheap. Under the full isolated runner (32-way) on a contended host, that one-time cost can exceed the default 5000ms per-test timeout, landing on whichever test runs first and cascading the rest to failure (the symptom in #3089: `✗ … happy path [5009.51ms]` then 12 sub-1ms cascade failures).

**Fix:** warm `getApp()` once in a `beforeAll` with a generous 30s timeout, so the build cost can never race the per-test window. The cache-priming import must run with the discord env set — the install/callback routes pick *implemented (302)* vs. *not-configured (501)* at **module-load** from `DISCORD_CLIENT_ID` (the contract `teams-discord-always-mount.test.ts` pins) — so the warm-up mirrors the `beforeEach` env. `beforeEach`/`afterEach` still own per-test setup/restore.

Verified `bun` (1.3.13) honors the `beforeAll(fn, timeout)` arg. Suite is **13/0, stable across 5 back-to-back runs**.

## #2821 — `hosted.test.ts` chmod write-failure case fails under root

**Root cause:** the write failure is injected via `chmodSync(dir, 0o500)`, which **root (uid 0) bypasses** — the write succeeds, `exitCode` is 0, and the assertion fails in any root container (cloud sandbox), though it passes in non-root CI.

**Fix:** guard the case on `process.getuid?.() === 0` with a clear skip log, mirroring the existing `win32` guard. Real (non-root) CI still exercises the full path.

**Scope note:** the issue lists *both* failure-path cases, but the sibling **directory-creation** case is intentionally **not** guarded — it fails structurally via `ENOTDIR` (recursive mkdir under a regular file), which the kernel returns regardless of uid. Guarding it would needlessly drop root coverage. Verified with `unshare -r`: before the fix that case already passed as root and #1 failed; after, the **full file is 39/0 as simulated root**, full POSIX coverage retained as non-root.

## Verification
- `bun run type` → exit 0
- `eslint` on both files → exit 0
- `#3089`: 13/0 × 5 runs
- `#2821`: 39/0 under `unshare -r` (uid 0); 6 expect() calls non-root (both cases exercised)

Closes #3089
Closes #2821

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3105"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783005054&installation_id=135337507&pr_number=3105&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3105&signature=633243ba3255feed749915da615ef08e4483732b8a0ea299f9dc4ece94402912"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved Discord integration test reliability by implementing proper API initialization setup across all test cases.
  * Enhanced cross-platform test compatibility by handling elevated privilege scenarios on Linux and macOS systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->