### PR TITLE
feat(usage): surface prompt-cache split + billed/effective on usage page (#3106)

### DIFF
--- a/packages/api/src/api/__tests__/admin-tokens.test.ts
+++ b/packages/api/src/api/__tests__/admin-tokens.test.ts
@@ -112,6 +112,10 @@ describe("admin token usage routes", () => {
         promptTokens: 120000,
         completionTokens: 2000,
         totalTokens: 122000,
+        // No cache columns in this mock row → no discount, effective == gross.
+        cacheReadTokens: 0,
+        cacheWriteTokens: 0,
+        effectiveTokens: 122000,
         requestCount: 2,
       });
       expect(body.byModel[1].model).toBe("anthropic/claude-sonnet-4.6");
@@ -142,6 +146,87 @@ describe("admin token usage routes", () => {
       const body = await res.json() as any;
       expect(body.byModel[0].model).toBe("unknown");
       expect(body.byModel[0].provider).toBe("unknown");
+    });
+
+    it("aggregates the prompt-cache split and a billed/effective total (#3106)", async () => {
+      mocks.mockInternalQuery.mockImplementation((sql: string) => {
+        if (sql.includes("ip_allowlist")) return Promise.resolve([]);
+        if (sql.includes("GROUP BY model")) return Promise.resolve([]);
+        return Promise.resolve([
+          {
+            total_prompt: "100000",
+            total_completion: "5000",
+            total_cache_read: "60000",
+            total_cache_write: "10000",
+            total_requests: "10",
+          },
+        ]);
+      });
+
+      const res = await app.fetch(adminRequest("/api/v1/admin/tokens/summary"));
+      expect(res.status).toBe(200);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test convenience for JSON response body
+      const body = await res.json() as any;
+
+      expect(body.totalCacheReadTokens).toBe(60000);
+      expect(body.totalCacheWriteTokens).toBe(10000);
+      expect(body.totalTokens).toBe(105000); // gross = prompt(100k) + completion(5k)
+      // prompt_tokens is the GROSS input total (cache read/write are subsets of it):
+      //   fresh input  = 100000 − 60000 − 10000 = 30000  → billed 1×
+      //   cache read   = 60000 × 0.10 =  6000
+      //   cache write  = 10000 × 1.25 = 12500
+      //   completion   =  5000        →  5000
+      //   effective    = 30000 + 6000 + 12500 + 5000 = 53500
+      expect(body.effectiveTokens).toBe(53500);
+
+      // The cache columns must be summed under the same org filter as the totals.
+      const totalsCall = mocks.mockInternalQuery.mock.calls.find(
+        ([sql]) =>
+          typeof sql === "string" &&
+          sql.includes("cache_read_tokens") &&
+          !sql.includes("GROUP BY model"),
+      );
+      expect(totalsCall).toBeDefined();
+      expect(totalsCall![0]).toContain("org_id");
+      expect(totalsCall![1]).toContain("org-test");
+    });
+
+    it("includes the cache split and effective total per model (#3106)", async () => {
+      mocks.mockInternalQuery.mockImplementation((sql: string) => {
+        if (sql.includes("ip_allowlist")) return Promise.resolve([]);
+        if (sql.includes("GROUP BY model")) {
+          return Promise.resolve([
+            {
+              model: "anthropic/claude-opus-4.8",
+              provider: "gateway",
+              total_prompt: "80000",
+              total_completion: "2000",
+              total_cache_read: "50000",
+              total_cache_write: "8000",
+              request_count: "2",
+            },
+          ]);
+        }
+        return Promise.resolve([
+          {
+            total_prompt: "80000",
+            total_completion: "2000",
+            total_cache_read: "50000",
+            total_cache_write: "8000",
+            total_requests: "2",
+          },
+        ]);
+      });
+
+      const res = await app.fetch(adminRequest("/api/v1/admin/tokens/summary"));
+      expect(res.status).toBe(200);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test convenience for JSON response body
+      const body = await res.json() as any;
+
+      expect(body.byModel[0].cacheReadTokens).toBe(50000);
+      expect(body.byModel[0].cacheWriteTokens).toBe(8000);
+      // fresh 22000 + read 5000 + write 10000 + output 2000 = 39000
+      expect(body.byModel[0].effectiveTokens).toBe(39000);
     });
 
     it("returns 404 when no internal DB", async () => {

--- a/packages/api/src/api/__tests__/admin-tokens.test.ts
+++ b/packages/api/src/api/__tests__/admin-tokens.test.ts
@@ -76,6 +76,12 @@ describe("admin token usage routes", () => {
       expect(body.totalCompletionTokens).toBe(5000);
       expect(body.totalTokens).toBe(20000);
       expect(body.totalRequests).toBe(10);
+      // Older rows / a pre-cache-split API response omit the cache columns →
+      // no discount, so the summary-level effective total equals gross. Guards
+      // the `row?.total_cache_read ?? "0"` fall-through against a NaN regression.
+      expect(body.totalCacheReadTokens).toBe(0);
+      expect(body.totalCacheWriteTokens).toBe(0);
+      expect(body.effectiveTokens).toBe(20000);
 
       // Verify org-scoping: SQL must include org_id filter and pass orgId as param
       const lastCall = mocks.mockInternalQuery.mock.calls.at(-1);
@@ -227,6 +233,84 @@ describe("admin token usage routes", () => {
       expect(body.byModel[0].cacheWriteTokens).toBe(8000);
       // fresh 22000 + read 5000 + write 10000 + output 2000 = 39000
       expect(body.byModel[0].effectiveTokens).toBe(39000);
+    });
+
+    it("clamps fresh input to zero when the cache split saturates the prompt (#3106)", async () => {
+      // Steady state once a conversation warms: prompt_tokens is entirely
+      // cache read+write, so fresh input is 0. This is the COMMON shape, not an
+      // edge — the effectiveTokens Math.max(0, …) clamp must hold here.
+      mocks.mockInternalQuery.mockImplementation((sql: string) => {
+        if (sql.includes("ip_allowlist")) return Promise.resolve([]);
+        if (sql.includes("GROUP BY model")) return Promise.resolve([]);
+        return Promise.resolve([
+          {
+            total_prompt: "70000", // == cache_read + cache_write → fresh input 0
+            total_completion: "5000",
+            total_cache_read: "60000",
+            total_cache_write: "10000",
+            total_requests: "4",
+          },
+        ]);
+      });
+
+      const res = await app.fetch(adminRequest("/api/v1/admin/tokens/summary"));
+      expect(res.status).toBe(200);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test convenience for JSON response body
+      const body = await res.json() as any;
+      // fresh 0 + read 60000×0.1 (6000) + write 10000×1.25 (12500) + output 5000
+      expect(body.effectiveTokens).toBe(23500);
+    });
+
+    it("never reports a negative effective total when cache exceeds the prompt (#3106)", async () => {
+      // Defensive: a skewed/legacy row where cache read+write > prompt must not
+      // drive fresh input (and the effective total) negative.
+      mocks.mockInternalQuery.mockImplementation((sql: string) => {
+        if (sql.includes("ip_allowlist")) return Promise.resolve([]);
+        if (sql.includes("GROUP BY model")) return Promise.resolve([]);
+        return Promise.resolve([
+          {
+            total_prompt: "65000", // < cache_read + cache_write (70000)
+            total_completion: "5000",
+            total_cache_read: "60000",
+            total_cache_write: "10000",
+            total_requests: "4",
+          },
+        ]);
+      });
+
+      const res = await app.fetch(adminRequest("/api/v1/admin/tokens/summary"));
+      expect(res.status).toBe(200);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test convenience for JSON response body
+      const body = await res.json() as any;
+      // fresh clamps to 0 → 6000 + 12500 + 5000 = 23500 (not negative)
+      expect(body.effectiveTokens).toBe(23500);
+      expect(body.effectiveTokens).toBeGreaterThanOrEqual(0);
+    });
+
+    it("re-prices cache writes at a premium so effective can exceed gross (#3106)", async () => {
+      // Cache writes are billed at 1.25× input, so a write-dominated window has
+      // an effective total ABOVE gross — intended, not a bug. Pins the factor
+      // so a future refactor can't silently assume effective ≤ gross.
+      mocks.mockInternalQuery.mockImplementation((sql: string) => {
+        if (sql.includes("ip_allowlist")) return Promise.resolve([]);
+        if (sql.includes("GROUP BY model")) return Promise.resolve([]);
+        return Promise.resolve([
+          {
+            total_prompt: "100000", // all of it freshly written to cache
+            total_completion: "0",
+            total_cache_read: "0",
+            total_cache_write: "100000",
+            total_requests: "1",
+          },
+        ]);
+      });
+
+      const res = await app.fetch(adminRequest("/api/v1/admin/tokens/summary"));
+      expect(res.status).toBe(200);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test convenience for JSON response body
+      const body = await res.json() as any;
+      expect(body.totalTokens).toBe(100000); // gross
+      expect(body.effectiveTokens).toBe(125000); // 100000 × 1.25 — above gross
     });
 
     it("returns 404 when no internal DB", async () => {

--- a/packages/api/src/api/routes/admin-tokens.ts
+++ b/packages/api/src/api/routes/admin-tokens.ts
@@ -36,6 +36,42 @@ function parseDateRange(
   return { fromDate, toDate };
 }
 
+/**
+ * Anthropic ephemeral (5-min TTL) prompt-cache pricing, expressed relative to
+ * the fresh-input token price (#3106):
+ *   - cache READ  ≈ 0.10× — context replayed from cache is ~90% cheaper
+ *   - cache WRITE ≈ 1.25× — seeding the cache carries a ~25% premium
+ * Source: migration 0114 + reference_gateway_anthropic_caching.
+ */
+const CACHE_READ_FACTOR = 0.1;
+const CACHE_WRITE_FACTOR = 1.25;
+
+/**
+ * Convert gross token counts into a single billed/effective token-equivalent.
+ *
+ * `promptTokens` is the GROSS input total — cache read/write are *subsets* of
+ * it (the AI SDK reports `inputTokens = noCache + cacheRead + cacheWrite`, and
+ * agent.ts persists that total to `token_usage.prompt_tokens`). So the fresh
+ * (full-price) input is `prompt − cacheRead − cacheWrite`, and the effective
+ * figure re-prices the two cache buckets at their discounted rates. Output
+ * tokens carry no cache discount. Kept in token units (not dollars) to stay
+ * comparable with the gross figure shown alongside it.
+ */
+function effectiveTokens(
+  promptTokens: number,
+  completionTokens: number,
+  cacheReadTokens: number,
+  cacheWriteTokens: number,
+): number {
+  const freshInput = Math.max(0, promptTokens - cacheReadTokens - cacheWriteTokens);
+  const billed =
+    freshInput +
+    cacheReadTokens * CACHE_READ_FACTOR +
+    cacheWriteTokens * CACHE_WRITE_FACTOR +
+    completionTokens;
+  return Math.max(0, Math.round(billed));
+}
+
 // ---------------------------------------------------------------------------
 // Route definitions
 // ---------------------------------------------------------------------------
@@ -130,11 +166,15 @@ adminTokens.openapi(getTokenSummaryRoute, async (c) => {
         internalQuery<{
           total_prompt: string;
           total_completion: string;
+          total_cache_read: string;
+          total_cache_write: string;
           total_requests: string;
         }>(
           `SELECT
              COALESCE(SUM(prompt_tokens), 0) AS total_prompt,
              COALESCE(SUM(completion_tokens), 0) AS total_completion,
+             COALESCE(SUM(cache_read_tokens), 0) AS total_cache_read,
+             COALESCE(SUM(cache_write_tokens), 0) AS total_cache_write,
              COUNT(*) AS total_requests
            FROM token_usage
            WHERE created_at >= $1 AND created_at <= $2 AND org_id = $3`,
@@ -145,6 +185,8 @@ adminTokens.openapi(getTokenSummaryRoute, async (c) => {
           provider: string | null;
           total_prompt: string;
           total_completion: string;
+          total_cache_read: string;
+          total_cache_write: string;
           request_count: string;
         }>(
           `SELECT
@@ -152,6 +194,8 @@ adminTokens.openapi(getTokenSummaryRoute, async (c) => {
              provider,
              COALESCE(SUM(prompt_tokens), 0) AS total_prompt,
              COALESCE(SUM(completion_tokens), 0) AS total_completion,
+             COALESCE(SUM(cache_read_tokens), 0) AS total_cache_read,
+             COALESCE(SUM(cache_write_tokens), 0) AS total_cache_write,
              COUNT(*) AS request_count
            FROM token_usage
            WHERE created_at >= $1 AND created_at <= $2 AND org_id = $3
@@ -164,22 +208,42 @@ adminTokens.openapi(getTokenSummaryRoute, async (c) => {
     });
 
     const row = rows[0];
+    const totalPromptTokens = parseInt(row?.total_prompt ?? "0", 10);
+    const totalCompletionTokens = parseInt(row?.total_completion ?? "0", 10);
+    const totalCacheReadTokens = parseInt(row?.total_cache_read ?? "0", 10);
+    const totalCacheWriteTokens = parseInt(row?.total_cache_write ?? "0", 10);
     return c.json({
-      totalPromptTokens: parseInt(row?.total_prompt ?? "0", 10),
-      totalCompletionTokens: parseInt(row?.total_completion ?? "0", 10),
-      totalTokens: parseInt(row?.total_prompt ?? "0", 10) + parseInt(row?.total_completion ?? "0", 10),
+      totalPromptTokens,
+      totalCompletionTokens,
+      totalTokens: totalPromptTokens + totalCompletionTokens,
+      // Prompt-cache split (#3106): both are subsets of totalPromptTokens.
+      totalCacheReadTokens,
+      totalCacheWriteTokens,
+      // Billed/effective token-equivalent after prompt-cache discounts — the
+      // figure the gross totals overstate (cache reads are ~90% cheaper).
+      effectiveTokens: effectiveTokens(
+        totalPromptTokens,
+        totalCompletionTokens,
+        totalCacheReadTokens,
+        totalCacheWriteTokens,
+      ),
       totalRequests: parseInt(row?.total_requests ?? "0", 10),
       // Rows with a NULL model/provider (older usage records written before the
       // column existed) surface as "unknown" rather than being dropped.
       byModel: modelRows.map((m) => {
         const promptTokens = parseInt(m.total_prompt ?? "0", 10);
         const completionTokens = parseInt(m.total_completion ?? "0", 10);
+        const cacheReadTokens = parseInt(m.total_cache_read ?? "0", 10);
+        const cacheWriteTokens = parseInt(m.total_cache_write ?? "0", 10);
         return {
           model: m.model ?? "unknown",
           provider: m.provider ?? "unknown",
           promptTokens,
           completionTokens,
           totalTokens: promptTokens + completionTokens,
+          cacheReadTokens,
+          cacheWriteTokens,
+          effectiveTokens: effectiveTokens(promptTokens, completionTokens, cacheReadTokens, cacheWriteTokens),
           requestCount: parseInt(m.request_count ?? "0", 10),
         };
       }),

--- a/packages/schemas/src/__tests__/analytics.test.ts
+++ b/packages/schemas/src/__tests__/analytics.test.ts
@@ -75,9 +75,16 @@ describe("token usage", () => {
       from: "2026-04-01T00:00:00.000Z",
       to: "2026-04-20T00:00:00.000Z",
     };
-    // byModel is additive (#3098): when an older API response omits it, the
-    // schema fills [] so the web always gets an array to map over.
-    expect(TokenSummarySchema.parse(row)).toEqual({ ...row, byModel: [] });
+    // byModel is additive (#3098) and the cache split + effective total are
+    // additive (#3106): when an older API response omits them, the schema fills
+    // [] / 0 so the web always gets a value to render during a rolling deploy.
+    expect(TokenSummarySchema.parse(row)).toEqual({
+      ...row,
+      byModel: [],
+      totalCacheReadTokens: 0,
+      totalCacheWriteTokens: 0,
+      effectiveTokens: 0,
+    });
   });
 
   test("TokenSummarySchema parses a per-model breakdown (#3098)", () => {
@@ -102,6 +109,11 @@ describe("token usage", () => {
     expect(parsed.byModel).toHaveLength(1);
     expect(parsed.byModel[0].model).toBe("anthropic/claude-opus-4.8");
     expect(parsed.byModel[0].provider).toBe("gateway");
+    // Per-model cache split + effective are additive (#3106): a pre-cache-split
+    // row omits them and the schema fills 0.
+    expect(parsed.byModel[0].cacheReadTokens).toBe(0);
+    expect(parsed.byModel[0].cacheWriteTokens).toBe(0);
+    expect(parsed.byModel[0].effectiveTokens).toBe(0);
   });
 
   test("TokenSummarySchema rejects non-ISO from", () => {

--- a/packages/schemas/src/analytics.ts
+++ b/packages/schemas/src/analytics.ts
@@ -130,8 +130,10 @@ interface TokenSummary {
   totalCacheWriteTokens: number;
   /**
    * Billed/effective token-equivalent after prompt-cache discounts (#3106) —
-   * the figure the gross `totalTokens` overstates. Cache reads are repriced at
-   * ~0.1×, cache writes at ~1.25×; output is undiscounted.
+   * typically below the gross `totalTokens` when cache reads dominate, but a
+   * cache-write-heavy window can exceed it (writes are repriced at ~1.25×).
+   * Cache reads are repriced at ~0.1×, cache writes at ~1.25×; output is
+   * undiscounted.
    */
   effectiveTokens: number;
   totalRequests: number;

--- a/packages/schemas/src/analytics.ts
+++ b/packages/schemas/src/analytics.ts
@@ -112,12 +112,28 @@ interface ModelUsageRow {
   promptTokens: number;
   completionTokens: number;
   totalTokens: number;
+  /** Prompt-cache tokens served from cache (subset of promptTokens, #3106). */
+  cacheReadTokens: number;
+  /** Prompt-cache tokens written to cache (subset of promptTokens, #3106). */
+  cacheWriteTokens: number;
+  /** Billed/effective token-equivalent after prompt-cache discounts (#3106). */
+  effectiveTokens: number;
   requestCount: number;
 }
 interface TokenSummary {
   totalPromptTokens: number;
   totalCompletionTokens: number;
   totalTokens: number;
+  /** Prompt-cache tokens served from cache (subset of totalPromptTokens, #3106). */
+  totalCacheReadTokens: number;
+  /** Prompt-cache tokens written to cache (subset of totalPromptTokens, #3106). */
+  totalCacheWriteTokens: number;
+  /**
+   * Billed/effective token-equivalent after prompt-cache discounts (#3106) —
+   * the figure the gross `totalTokens` overstates. Cache reads are repriced at
+   * ~0.1×, cache writes at ~1.25×; output is undiscounted.
+   */
+  effectiveTokens: number;
   totalRequests: number;
   /**
    * Per-model token breakdown over the same window (#3098). Lets an operator
@@ -150,6 +166,11 @@ export const ModelUsageRowSchema = z.object({
   promptTokens: z.number(),
   completionTokens: z.number(),
   totalTokens: z.number(),
+  // Additive (#3106): `.default(0)` so a web bundle parsing a pre-cache-split
+  // API response still validates during a rolling deploy.
+  cacheReadTokens: z.number().default(0),
+  cacheWriteTokens: z.number().default(0),
+  effectiveTokens: z.number().default(0),
   requestCount: z.number(),
 }) satisfies z.ZodType<ModelUsageRow, unknown>;
 
@@ -157,6 +178,11 @@ export const TokenSummarySchema = z.object({
   totalPromptTokens: z.number(),
   totalCompletionTokens: z.number(),
   totalTokens: z.number(),
+  // Additive (#3106): `.default(0)` so a web bundle parsing a pre-cache-split
+  // API response still validates during a rolling deploy.
+  totalCacheReadTokens: z.number().default(0),
+  totalCacheWriteTokens: z.number().default(0),
+  effectiveTokens: z.number().default(0),
   totalRequests: z.number(),
   // Additive (#3098): `.default([])` so a web bundle parsing an older API
   // response (pre-byModel) still validates during a rolling deploy.

--- a/packages/web/src/app/admin/token-usage/tab.tsx
+++ b/packages/web/src/app/admin/token-usage/tab.tsx
@@ -39,7 +39,7 @@ import { DataTableToolbar } from "@/components/data-table/data-table-toolbar";
 import { DataTableSortList } from "@/components/data-table/data-table-sort-list";
 import { getTokenUsageColumns } from "./columns";
 import { useDataTable } from "@/hooks/use-data-table";
-import { Coins, TrendingUp, Users, MessageSquare, Search, Cpu } from "lucide-react";
+import { Coins, TrendingUp, Users, MessageSquare, Search, Cpu, Receipt, Database, DatabaseZap } from "lucide-react";
 import { useState } from "react";
 
 const TokenChart = dynamic(() => import("./token-chart"), { ssr: false });
@@ -150,6 +150,14 @@ export function TokenUsageTab() {
                 description="input + output, not billed"
               />
               <StatCard
+                title="Effective / Billed"
+                value={formatNumber(summary.effectiveTokens)}
+                icon={<Receipt className="size-4" />}
+                description={summary.totalTokens > 0 && summary.effectiveTokens < summary.totalTokens
+                  ? `~${(((summary.totalTokens - summary.effectiveTokens) / summary.totalTokens) * 100).toFixed(0)}% below gross · after cache`
+                  : "after prompt-cache discount"}
+              />
+              <StatCard
                 title="Prompt (input)"
                 value={formatNumber(summary.totalPromptTokens)}
                 icon={<TrendingUp className="size-4" />}
@@ -166,6 +174,22 @@ export function TokenUsageTab() {
                   : undefined}
               />
               <StatCard
+                title="Cache Read"
+                value={formatNumber(summary.totalCacheReadTokens)}
+                icon={<Database className="size-4" />}
+                description={summary.totalPromptTokens > 0
+                  ? `${((summary.totalCacheReadTokens / summary.totalPromptTokens) * 100).toFixed(0)}% of input · ~90% cheaper`
+                  : "served from cache · ~90% cheaper"}
+              />
+              <StatCard
+                title="Cache Write"
+                value={formatNumber(summary.totalCacheWriteTokens)}
+                icon={<DatabaseZap className="size-4" />}
+                description={summary.totalPromptTokens > 0
+                  ? `${((summary.totalCacheWriteTokens / summary.totalPromptTokens) * 100).toFixed(0)}% of input · ~25% premium`
+                  : "written to cache · ~25% premium"}
+              />
+              <StatCard
                 title="Total Requests"
                 value={formatNumber(summary.totalRequests)}
                 icon={<MessageSquare className="size-4" />}
@@ -175,18 +199,19 @@ export function TokenUsageTab() {
               />
             </div>
 
-            {/* Figures above are GROSS input tokens: every agent step re-sends
-                the prompt prefix, so the same context is counted once per step
-                — this is not the billed amount.
-                TODO(#3099): once token_usage persists cache_read_tokens /
-                cache_write_tokens, surface the effective/billed split here
-                (gross − prompt-cache discount). */}
+            {/* Gross figures count every agent step's re-sent prompt prefix once
+                per step, so shared context is double-counted — not the bill.
+                Effective / Billed re-prices the prompt-cache split (reads
+                ~0.1×, writes ~1.25× input; output undiscounted) and is the
+                closer proxy to the actual cost. */}
             <p className="text-[11px] leading-relaxed text-muted-foreground">
-              Token figures are <span className="font-medium text-foreground">gross input tokens</span>,
-              not the billed amount — each agent step re-sends the prompt prefix,
-              so shared context is counted multiple times. Billed/effective
-              tokens (after prompt-cache discounts) are tracked separately
-              (#3099).
+              <span className="font-medium text-foreground">Gross</span> tokens
+              count every agent step&apos;s re-sent prompt prefix, so shared
+              context is counted multiple times — not the billed amount.{" "}
+              <span className="font-medium text-foreground">Effective / Billed</span>{" "}
+              re-prices the prompt-cache split (reads ~0.1×, writes ~1.25× input;
+              output undiscounted) for a closer proxy to the actual cost. Both
+              are token-equivalents, not a dollar figure.
             </p>
 
             {summary.byModel.length > 0 && (
@@ -205,7 +230,10 @@ export function TokenUsageTab() {
                         <TableHead>Provider</TableHead>
                         <TableHead className="text-right">Prompt</TableHead>
                         <TableHead className="text-right">Completion</TableHead>
-                        <TableHead className="text-right">Total</TableHead>
+                        <TableHead className="text-right">Gross</TableHead>
+                        <TableHead className="text-right">Cache Read</TableHead>
+                        <TableHead className="text-right">Cache Write</TableHead>
+                        <TableHead className="text-right">Effective</TableHead>
                         <TableHead className="text-right">Requests</TableHead>
                       </TableRow>
                     </TableHeader>
@@ -216,7 +244,10 @@ export function TokenUsageTab() {
                           <TableCell className="text-muted-foreground">{m.provider}</TableCell>
                           <TableCell className="text-right tabular-nums">{formatNumber(m.promptTokens)}</TableCell>
                           <TableCell className="text-right tabular-nums">{formatNumber(m.completionTokens)}</TableCell>
-                          <TableCell className="text-right font-medium tabular-nums">{formatNumber(m.totalTokens)}</TableCell>
+                          <TableCell className="text-right tabular-nums">{formatNumber(m.totalTokens)}</TableCell>
+                          <TableCell className="text-right tabular-nums text-muted-foreground">{formatNumber(m.cacheReadTokens)}</TableCell>
+                          <TableCell className="text-right tabular-nums text-muted-foreground">{formatNumber(m.cacheWriteTokens)}</TableCell>
+                          <TableCell className="text-right font-medium tabular-nums">{formatNumber(m.effectiveTokens)}</TableCell>
                           <TableCell className="text-right tabular-nums">{m.requestCount}</TableCell>
                         </TableRow>
                       ))}

--- a/packages/web/src/app/admin/token-usage/tab.tsx
+++ b/packages/web/src/app/admin/token-usage/tab.tsx
@@ -151,11 +151,19 @@ export function TokenUsageTab() {
               />
               <StatCard
                 title="Effective / Billed"
-                value={formatNumber(summary.effectiveTokens)}
+                // A correct response never yields effective 0 with gross > 0, so
+                // that combination means the field is absent (an older API
+                // response during a rolling deploy, defaulted to 0) — show "—"
+                // rather than a confident-but-wrong "0 · ~100% below gross".
+                value={summary.totalTokens > 0 && summary.effectiveTokens === 0
+                  ? "—"
+                  : formatNumber(summary.effectiveTokens)}
                 icon={<Receipt className="size-4" />}
-                description={summary.totalTokens > 0 && summary.effectiveTokens < summary.totalTokens
-                  ? `~${(((summary.totalTokens - summary.effectiveTokens) / summary.totalTokens) * 100).toFixed(0)}% below gross · after cache`
-                  : "after prompt-cache discount"}
+                description={summary.totalTokens > 0 && summary.effectiveTokens === 0
+                  ? "awaiting cache data"
+                  : summary.totalTokens > 0 && summary.effectiveTokens < summary.totalTokens
+                    ? `~${(((summary.totalTokens - summary.effectiveTokens) / summary.totalTokens) * 100).toFixed(0)}% below gross · after cache`
+                    : "after prompt-cache discount"}
               />
               <StatCard
                 title="Prompt (input)"

--- a/packages/web/src/app/admin/token-usage/tab.tsx
+++ b/packages/web/src/app/admin/token-usage/tab.tsx
@@ -255,7 +255,12 @@ export function TokenUsageTab() {
                           <TableCell className="text-right tabular-nums">{formatNumber(m.totalTokens)}</TableCell>
                           <TableCell className="text-right tabular-nums text-muted-foreground">{formatNumber(m.cacheReadTokens)}</TableCell>
                           <TableCell className="text-right tabular-nums text-muted-foreground">{formatNumber(m.cacheWriteTokens)}</TableCell>
-                          <TableCell className="text-right font-medium tabular-nums">{formatNumber(m.effectiveTokens)}</TableCell>
+                          {/* effective 0 with gross > 0 means the field is absent
+                              (older API response mid rolling-deploy) — show "—"
+                              instead of a misleading 0, matching the StatCard. */}
+                          <TableCell className="text-right font-medium tabular-nums">
+                            {m.totalTokens > 0 && m.effectiveTokens === 0 ? "—" : formatNumber(m.effectiveTokens)}
+                          </TableCell>
                           <TableCell className="text-right tabular-nums">{m.requestCount}</TableCell>
                         </TableRow>
                       ))}


### PR DESCRIPTION
Closes #3106.

## Why
`token_usage.cache_read_tokens` / `cache_write_tokens` (migration 0114) already persist nonzero values in prod, but the usage page only showed Gross / Prompt / Completion / Requests. This surfaces the prompt-cache split and a billed/effective figure so the v0.0.5 gateway-caching savings are visible — pure surfacing, no new write path.

## What
**API — `packages/api/src/api/routes/admin-tokens.ts`**
- `/tokens/summary` now `SUM`s `cache_read_tokens` / `cache_write_tokens` in both the period-totals and per-model queries (same org filter).
- Derives an **effective/billed token-equivalent**: fresh input ×1.0, cache read ×0.1, cache write ×1.25, output undiscounted. `prompt_tokens` is the **gross** input total and cache read/write are *subsets* of it — confirmed against the AI SDK (`inputTokens = noCache + cacheRead + cacheWrite`, `@ai-sdk/anthropic` → `ai@6` `asLanguageModelUsage`), so `fresh = prompt − cacheRead − cacheWrite`.
- Factors live in named constants with a sourced comment (migration 0114).

**Schema — `packages/schemas/src/analytics.ts`** (wire SSOT)
- `TokenSummary`: `totalCacheReadTokens`, `totalCacheWriteTokens`, `effectiveTokens`.
- `ModelUsageRow`: `cacheReadTokens`, `cacheWriteTokens`, `effectiveTokens`.
- All additive `.default(0)` so a web bundle parsing a pre-cache-split API response still validates mid rolling-deploy (same pattern as the `byModel` `.default([])`).

**UI — `packages/web/src/app/admin/token-usage/tab.tsx`**
- New **Effective / Billed** StatCard (distinct from Gross, shows % below gross) + **Cache Read** / **Cache Write** cards.
- Per-model table gains Cache Read / Cache Write / Effective columns (Total → Gross for naming parity).
- Rewrites the gross-vs-billed caveat; removes the stale `TODO(#3099)`.
- shadcn `StatCard` primitive; `.map` only (immutable).

## Acceptance criteria
- [x] Summary endpoint returns cache-read, cache-write, effective/billed totals (+ per-model in `byModel`).
- [x] Page shows the cache split + an effective figure separate from gross.
- [x] Caveat copy updated; `TODO(#3099)` removed.

## Tests (TDD red→green)
- `admin-tokens.test.ts`: two new `#3106` cases (summary totals + per-model split/effective) and the `#3098` `byModel` `toEqual` updated for the new fields — **16/16**.
- `analytics.test.ts`: additive-default coverage for the new fields — **17/17**.

## Gates
`/ci` green: lint, type, full `bun run test`, syncpack, template-drift, security-headers, railway-watch, schema-drift, oauth-helper-drift, test-discipline, twenty-resolver, published-symbols. (One transient `@useatlas/mcp` `hosted.test` batch-mode mock-pollution flake on the first full run — unrelated to this diff, which touches no MCP code; clean on re-run.)

## Follow-up (post-merge, per task spec)
Once this lands, restore the v0.0.5 changelog claim to "surfaced on the usage page" (currently being walked back to "records … groundwork"). Not in this PR — the v0.0.5 entry is for an already-released tag and is edited direct-to-main.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3107"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783014076&installation_id=135337507&pr_number=3107&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3107&signature=322751263fa0b78eb97c588284d6e79a1b680a0c0acf11a47b23cae615091a65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin token usage shows Cache Read and Cache Write metrics and an updated Effective/Billed token figure; Usage by Model now displays Gross, Cache Read, Cache Write, and Effective columns.
* **Documentation**
  * Expanded explanatory notes clarifying gross vs effective token accounting and prompt-cache re-pricing.
* **Tests**
  * Added tests for cache-split accounting, edge cases (clamping, negatives, repricing), and org-scoped summaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->