### PR TITLE
fix(integrations): cap chat installs before Slack OAuth redirect

### DIFF
--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -73350,7 +73350,7 @@
         ],
         "responses": {
           "302": {
-            "description": "Redirect to Platform OAuth authorization page on success, or to `/admin/integrations?error=<platform>&reason=plan_upgrade_required` when the workspace's plan does not admit the install (browser callers)."
+            "description": "Redirect to Platform OAuth authorization page on success, or to `/admin/integrations?error=<platform>&reason=<code>` when the install is refused before the redirect (browser callers): `plan_upgrade_required` when the workspace's plan tier does not admit the install, or `plan_limit_reached` (#2998) when a chat integration would exceed the plan's chat-integration cap."
           },
           "400": {
             "description": "Platform is not OAuth-installable, or unknown",
@@ -73473,18 +73473,69 @@
             }
           },
           "429": {
-            "description": "Rate limited",
+            "description": "Chat-integration cap reached for the workspace's plan tier (`plan_limit_exceeded`, JSON-Accept caller), or rate limited.",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "additionalProperties": {}
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "error": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "requestId": {
+                          "type": "string"
+                        },
+                        "limit": {
+                          "type": "number"
+                        }
+                      },
+                      "required": [
+                        "error",
+                        "message",
+                        "limit"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "additionalProperties": {}
+                    }
+                  ]
                 }
               }
             }
           },
           "501": {
             "description": "OAuth handler not registered",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "requestId": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Billing/plan-limit check unavailable: `billing_check_failed` (pre-redirect cap precheck)",
             "content": {
               "application/json": {
                 "schema": {

--- a/packages/api/src/api/__tests__/integrations-slack-install-cap.test.ts
+++ b/packages/api/src/api/__tests__/integrations-slack-install-cap.test.ts
@@ -1,0 +1,289 @@
+/**
+ * Route-level tests for the Slack `/install` pre-redirect chat-integration cap
+ * gate (#2998).
+ *
+ *   GET /api/v1/integrations/slack/install
+ *
+ * `SlackOAuthInstallHandler.startInstall` runs a read-only chat-integration cap
+ * precheck (`checkChatIntegrationLimit`) BEFORE minting the Slack authorize URL,
+ * so an at-cap workspace is refused before completing the full OAuth dance
+ * (Slack minting a bot token + installing the app). This file proves the *route*
+ * translates the handler's thrown tagged errors:
+ *
+ *   - ChatIntegrationLimitError → 429 `plan_limit_exceeded` (JSON) /
+ *     302 `?error=slack&reason=plan_limit_reached` (browser)
+ *   - BillingCheckFailedError   → 503 `billing_check_failed`
+ *   - allowed                   → 302 to slack.com/oauth/v2/authorize
+ *
+ * Mirrors `integrations-discord.test.ts`'s harness. The cap-decision logic and
+ * the handler's throw contract are unit-tested in
+ * `billing/__tests__/enforcement.test.ts` and
+ * `integrations/install/__tests__/slack-oauth-handler.test.ts`; this file's
+ * responsibility is the *route* wiring.
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  beforeEach,
+  afterEach,
+  mock,
+  type Mock,
+} from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Module mocks (must precede app import)
+// ---------------------------------------------------------------------------
+
+type DbRow = Record<string, unknown>;
+type QueryResult = Promise<DbRow[]>;
+
+let catalogRowResponse: DbRow[] = [];
+let organizationRowResponse: DbRow[] = [];
+/** Rows the chat-integration COUNT(*) FILTER aggregate returns. */
+let countRowResponse: DbRow[] = [];
+
+const mockInternalQuery: Mock<(sql: string, params?: unknown[]) => QueryResult> = mock(
+  (sql: string) => {
+    if (sql.includes("FROM plugin_catalog")) {
+      return Promise.resolve(catalogRowResponse);
+    }
+    if (sql.includes("FROM organization")) {
+      return Promise.resolve(organizationRowResponse);
+    }
+    if (sql.includes("COUNT(*) FILTER")) {
+      return Promise.resolve(countRowResponse);
+    }
+    return Promise.resolve([]);
+  },
+);
+
+// Spread the real module so the dozens of other consumers in the import graph
+// stay intact; override the read path this route + the cap precheck use.
+// `getWorkspaceDetails` (used by the cap precheck via `getCachedWorkspace`)
+// resolves through `internalQuery` internally, so the override covers it.
+const realInternal = await import("@atlas/api/lib/db/internal");
+mock.module("@atlas/api/lib/db/internal", () => ({
+  ...realInternal,
+  internalQuery: mockInternalQuery,
+  hasInternalDB: mock(() => true),
+}));
+
+// Auth — implicit-admin "mode: none" with a user carrying activeOrganizationId
+// (the integrations router needs the org binding for the install record).
+let authResultForTests: {
+  authenticated: boolean;
+  mode: string;
+  status?: number;
+  error?: string;
+  user?: Record<string, unknown> | null;
+} = {
+  authenticated: true,
+  mode: "none",
+  user: {
+    id: "user-admin",
+    mode: "none",
+    label: "Admin",
+    role: "admin",
+    activeOrganizationId: "org-test",
+  },
+};
+
+const mockAuthenticateRequest: Mock<(req: Request) => Promise<unknown>> = mock(
+  () => Promise.resolve(authResultForTests),
+);
+
+mock.module("@atlas/api/lib/auth/middleware", () => ({
+  checkRateLimit: mock(() => ({ allowed: true })),
+  authenticateRequest: mockAuthenticateRequest,
+  getClientIP: mock(() => "127.0.0.1"),
+  rateLimitCleanupTick: mock(() => {}),
+}));
+
+// The cap is read-only — startInstall never reaches Slack — but guard against
+// an accidental real network call leaking out of the handler.
+const mockFetch: Mock<(...args: Parameters<typeof fetch>) => Promise<Response>> = mock(
+  () => Promise.resolve(new Response("{}", { status: 200 })),
+);
+globalThis.fetch = mockFetch as unknown as typeof fetch;
+
+// The real enforcement module runs (NOT mocked) so the route → handler →
+// checkChatIntegrationLimit → checkResourceLimit chain is exercised end to end.
+// Import its cache invalidator so per-test workspace state can't bleed.
+const { invalidatePlanCache } = await import("@atlas/api/lib/billing/enforcement");
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const SLACK_CATALOG_ROW: DbRow = {
+  slug: "slack",
+  install_model: "oauth",
+  enabled: true,
+  min_plan: "starter",
+};
+
+// Both `getWorkspaceEntitlement` (plan_tier + is_operator_workspace) and the
+// cap precheck's `getWorkspaceDetails` (full workspace row) read `FROM
+// organization`; one fixture satisfies both. Starter caps chat integrations at 1.
+const STARTER_ORG: DbRow = {
+  id: "org-test",
+  name: "Test",
+  slug: "test",
+  workspace_status: "active",
+  plan_tier: "starter",
+  is_operator_workspace: false,
+  byot: false,
+  trial_ends_at: null,
+  createdAt: "2026-01-01T00:00:00Z",
+};
+
+async function getApp() {
+  const { app } = await import("../../api/index");
+  return app;
+}
+
+// ---------------------------------------------------------------------------
+// Test scaffolding
+// ---------------------------------------------------------------------------
+
+describe("/api/v1/integrations/slack/install — chat-integration cap (#2998)", () => {
+  const savedClientId = process.env.SLACK_CLIENT_ID;
+  const savedClientSecret = process.env.SLACK_CLIENT_SECRET;
+  const savedPublicApiUrl = process.env.ATLAS_PUBLIC_API_URL;
+  const savedEncryptionKey = process.env.ATLAS_ENCRYPTION_KEY;
+
+  // The Slack OAuth handler registers at module load only when SLACK_CLIENT_ID /
+  // SLACK_CLIENT_SECRET / ATLAS_PUBLIC_API_URL are set (see register.ts). Since
+  // the first getApp() import is what runs registerBuiltinInstallHandlers, the
+  // env must be set BEFORE it — otherwise the route binds in 501 mode for the
+  // whole file. Warm the build here with the env set (mirrors the discord suite,
+  // #3089) so the one-time import cost doesn't race the per-test timeout.
+  beforeAll(async () => {
+    process.env.SLACK_CLIENT_ID = "test-slack-client-id";
+    process.env.SLACK_CLIENT_SECRET = "test-slack-client-secret";
+    process.env.ATLAS_PUBLIC_API_URL = "https://atlas.test";
+    if (!process.env.ATLAS_ENCRYPTION_KEY) {
+      process.env.ATLAS_ENCRYPTION_KEY = "test-encryption-key-32-bytes-long-aa";
+    }
+    await getApp();
+  }, 30_000);
+
+  beforeEach(() => {
+    process.env.SLACK_CLIENT_ID = "test-slack-client-id";
+    process.env.SLACK_CLIENT_SECRET = "test-slack-client-secret";
+    process.env.ATLAS_PUBLIC_API_URL = "https://atlas.test";
+    if (!process.env.ATLAS_ENCRYPTION_KEY) {
+      process.env.ATLAS_ENCRYPTION_KEY = "test-encryption-key-32-bytes-long-aa";
+    }
+    catalogRowResponse = [SLACK_CATALOG_ROW];
+    organizationRowResponse = [STARTER_ORG];
+    countRowResponse = [{ others: 0, this_count: 0 }];
+    authResultForTests = {
+      authenticated: true,
+      mode: "none",
+      user: {
+        id: "user-admin",
+        mode: "none",
+        label: "Admin",
+        role: "admin",
+        activeOrganizationId: "org-test",
+      },
+    };
+    mockInternalQuery.mockClear();
+    mockAuthenticateRequest.mockClear();
+    mockFetch.mockClear();
+    invalidatePlanCache();
+  });
+
+  afterEach(() => {
+    if (savedClientId !== undefined) process.env.SLACK_CLIENT_ID = savedClientId;
+    else delete process.env.SLACK_CLIENT_ID;
+    if (savedClientSecret !== undefined) process.env.SLACK_CLIENT_SECRET = savedClientSecret;
+    else delete process.env.SLACK_CLIENT_SECRET;
+    if (savedPublicApiUrl !== undefined) process.env.ATLAS_PUBLIC_API_URL = savedPublicApiUrl;
+    else delete process.env.ATLAS_PUBLIC_API_URL;
+    if (savedEncryptionKey !== undefined) process.env.ATLAS_ENCRYPTION_KEY = savedEncryptionKey;
+    else delete process.env.ATLAS_ENCRYPTION_KEY;
+  });
+
+  it("redirects to Slack's OAuth authorize URL when under the cap", async () => {
+    countRowResponse = [{ others: 0, this_count: 0 }]; // no existing chat installs
+    const app = await getApp();
+    const resp = await app.request("/api/v1/integrations/slack/install", {
+      method: "GET",
+      redirect: "manual",
+    });
+    expect(resp.status).toBe(302);
+    const location = resp.headers.get("location") ?? "";
+    expect(location).toContain("slack.com/oauth/v2/authorize");
+    expect(location).toContain("client_id=test-slack-client-id");
+    // The handler never reached out to Slack — startInstall only builds a URL.
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("returns 429 plan_limit_exceeded (with limit) for JSON callers at the cap — before any Slack redirect", async () => {
+    // One other chat platform already installed; starter cap = 1.
+    countRowResponse = [{ others: 1, this_count: 0 }];
+    const app = await getApp();
+    const resp = await app.request("/api/v1/integrations/slack/install", {
+      method: "GET",
+      headers: { accept: "application/json" },
+      redirect: "manual",
+    });
+    expect(resp.status).toBe(429);
+    const body = (await resp.json()) as Record<string, unknown>;
+    expect(body.error).toBe("plan_limit_exceeded");
+    expect(body.limit).toBe(1);
+    // Never redirected to Slack.
+    expect(resp.headers.get("location")).toBeNull();
+  });
+
+  it("redirects browser callers at the cap to /admin/integrations?reason=plan_limit_reached", async () => {
+    countRowResponse = [{ others: 1, this_count: 0 }];
+    const app = await getApp();
+    const resp = await app.request("/api/v1/integrations/slack/install", {
+      method: "GET",
+      headers: { accept: "text/html,application/xhtml+xml" },
+      redirect: "manual",
+    });
+    expect(resp.status).toBe(302);
+    const location = resp.headers.get("location") ?? "";
+    expect(location).toContain("/admin/integrations");
+    expect(location).toContain("error=slack");
+    expect(location).toContain("reason=plan_limit_reached");
+    // Redirected to the admin UI, NOT to Slack.
+    expect(location).not.toContain("slack.com");
+  });
+
+  it("allows reconnect (this_count > 0) even over the cap — redirects to Slack", async () => {
+    // Slack already installed and the workspace is over its starter cap on other
+    // platforms; re-auth must still be allowed (never increases the count).
+    countRowResponse = [{ others: 5, this_count: 1 }];
+    const app = await getApp();
+    const resp = await app.request("/api/v1/integrations/slack/install", {
+      method: "GET",
+      redirect: "manual",
+    });
+    expect(resp.status).toBe(302);
+    expect(resp.headers.get("location") ?? "").toContain("slack.com/oauth/v2/authorize");
+  });
+
+  it("returns 503 billing_check_failed when the cap count can't be read (fail closed)", async () => {
+    // Empty aggregate result → the count can't be determined → fail closed as a
+    // transient 503 "try again", NOT a 429 "upgrade".
+    countRowResponse = [];
+    const app = await getApp();
+    const resp = await app.request("/api/v1/integrations/slack/install", {
+      method: "GET",
+      headers: { accept: "application/json" },
+      redirect: "manual",
+    });
+    expect(resp.status).toBe(503);
+    const body = (await resp.json()) as Record<string, unknown>;
+    expect(body.error).toBe("billing_check_failed");
+    expect(resp.headers.get("location")).toBeNull();
+  });
+});

--- a/packages/api/src/api/__tests__/integrations-slack-install-cap.test.ts
+++ b/packages/api/src/api/__tests__/integrations-slack-install-cap.test.ts
@@ -286,4 +286,20 @@ describe("/api/v1/integrations/slack/install — chat-integration cap (#2998)", 
     expect(body.error).toBe("billing_check_failed");
     expect(resp.headers.get("location")).toBeNull();
   });
+
+  it("returns 503 (NOT a redirect) for browser callers when the count can't be read", async () => {
+    // The count-unreadable case is intentionally NOT content-type-aware: a
+    // transient infra fault is a 503 "try again" for browsers too, never a
+    // `reason=plan_limit_reached` redirect (which is reserved for a genuine
+    // cap hit). Locks the asymmetry the route comment documents.
+    countRowResponse = [];
+    const app = await getApp();
+    const resp = await app.request("/api/v1/integrations/slack/install", {
+      method: "GET",
+      headers: { accept: "text/html,application/xhtml+xml" },
+      redirect: "manual",
+    });
+    expect(resp.status).toBe(503);
+    expect(resp.headers.get("location")).toBeNull();
+  });
 });

--- a/packages/api/src/api/routes/__tests__/integrations.test.ts
+++ b/packages/api/src/api/routes/__tests__/integrations.test.ts
@@ -275,12 +275,18 @@ type ValidateResult = Awaited<ReturnType<FormBasedInstallHandler["validateConfig
 
 let callbackImpl: () => Promise<CallbackResult> = async () => null;
 
+// startInstall is swapped per test so the `/install` error-passthrough tests
+// can make it throw (#2998 — the route wraps startInstall in a try/catch that
+// must re-throw anything that isn't ChatIntegrationLimitError unchanged).
+type StartInstallResult = Awaited<ReturnType<OAuthPlatformInstallHandler["startInstall"]>>;
+let startInstallImpl: () => Promise<StartInstallResult> = async () => ({
+  redirectUrl: "https://slack.com/oauth/v2/authorize?client_id=test&state=stub",
+  stateToken: "stub",
+});
+
 const fakeHandler: OAuthPlatformInstallHandler = {
   kind: "oauth" as const,
-  startInstall: async () => ({
-    redirectUrl: "https://slack.com/oauth/v2/authorize?client_id=test&state=stub",
-    stateToken: "stub",
-  }),
+  startInstall: async () => startInstallImpl(),
   handleCallback: async () => callbackImpl(),
 };
 
@@ -343,6 +349,10 @@ afterAll(() => {
 
 beforeEach(() => {
   callbackImpl = async () => null;
+  startInstallImpl = async () => ({
+    redirectUrl: "https://slack.com/oauth/v2/authorize?client_id=test&state=stub",
+    stateToken: "stub",
+  });
   mockInternalQuery.mockImplementation(async (sql: string) => {
     if (sql.includes("FROM organization")) {
       return [{ plan_tier: "business", is_operator_workspace: false }];
@@ -407,6 +417,40 @@ function partialResult(): CallbackResult {
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
+
+describe("GET /api/v1/integrations/slack/install — startInstall error passthrough (#2998)", () => {
+  it("redirects to the handler's authorize URL on the happy path", async () => {
+    const res = await request("/api/v1/integrations/slack/install", {
+      headers: { Accept: "text/html" },
+      redirect: "manual",
+    });
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location") ?? "").toContain("slack.com/oauth/v2/authorize");
+  });
+
+  it("re-throws a non-cap error from startInstall unchanged (→ 500, NOT an admin redirect)", async () => {
+    // The route's pre-redirect try/catch (#2998) special-cases only
+    // ChatIntegrationLimitError. Every other throw — a state-token mint
+    // failure, an unexpected DB error, a logic bug — must propagate to
+    // runHandler's defect mapping (500 + requestId), never get silently
+    // converted into a `reason=plan_limit_reached` redirect. This guards the
+    // shared seam: the same route drives Salesforce / Jira / Linear / GitHub
+    // startInstall, none of which run a chat cap.
+    startInstallImpl = async () => {
+      throw new Error("boom — unexpected startInstall failure");
+    };
+    const res = await request("/api/v1/integrations/slack/install", {
+      headers: { Accept: "text/html" },
+      redirect: "manual",
+    });
+    expect(res.status).toBe(500);
+    // Did NOT degrade into a browser redirect to the admin UI.
+    expect(res.headers.get("location")).toBeNull();
+    const body = (await res.json()) as Record<string, unknown>;
+    // 500s carry a requestId for log correlation (CLAUDE.md).
+    expect(body.requestId).toBeTypeOf("string");
+  });
+});
 
 describe("GET /api/v1/integrations/slack/callback — happy path", () => {
   it("redirects to /admin/integrations?installed=slack on success", async () => {

--- a/packages/api/src/api/routes/integrations.ts
+++ b/packages/api/src/api/routes/integrations.ts
@@ -175,8 +175,11 @@ const installRoute = createRoute({
     302: {
       description:
         "Redirect to Platform OAuth authorization page on success, or to " +
-        "`/admin/integrations?error=<platform>&reason=plan_upgrade_required` " +
-        "when the workspace's plan does not admit the install (browser callers).",
+        "`/admin/integrations?error=<platform>&reason=<code>` when the install is " +
+        "refused before the redirect (browser callers): `plan_upgrade_required` " +
+        "when the workspace's plan tier does not admit the install, or " +
+        "`plan_limit_reached` (#2998) when a chat integration would exceed the " +
+        "plan's chat-integration cap.",
     },
     400: { description: "Platform is not OAuth-installable, or unknown", content: { "application/json": { schema: ErrorSchema } } },
     401: { description: "Not authenticated", content: { "application/json": { schema: AuthErrorSchema } } },
@@ -193,8 +196,27 @@ const installRoute = createRoute({
       },
     },
     404: { description: "Platform not found in catalog", content: { "application/json": { schema: ErrorSchema } } },
-    429: { description: "Rate limited", content: { "application/json": { schema: AuthErrorSchema } } },
+    // #2998 — chat-integration cap reached pre-redirect (`plan_limit_exceeded`,
+    // body carries the `limit`), OR rate limited. Browser callers get a 302 to
+    // the admin UI with `reason=plan_limit_reached` for the cap case instead.
+    429: {
+      description:
+        "Chat-integration cap reached for the workspace's plan tier " +
+        "(`plan_limit_exceeded`, JSON-Accept caller), or rate limited.",
+      content: {
+        "application/json": {
+          schema: z.union([ErrorSchema.extend({ limit: z.number() }), AuthErrorSchema]),
+        },
+      },
+    },
     501: { description: "OAuth handler not registered", content: { "application/json": { schema: ErrorSchema } } },
+    // #2998 — the chat-integration count couldn't be determined (transient DB
+    // fault), so the pre-redirect cap check failed closed: `billing_check_failed`
+    // "try again" (browser and JSON callers alike).
+    503: {
+      description: "Billing/plan-limit check unavailable: `billing_check_failed` (pre-redirect cap precheck)",
+      content: { "application/json": { schema: ErrorSchema } },
+    },
   },
 });
 
@@ -718,7 +740,36 @@ integrations.openapi(installRoute, async (c) =>
       return c.json({ error: "handler_unavailable", message: "Install handler misconfigured.", requestId }, 501);
     }
 
-    const { redirectUrl } = await handler.startInstall(workspaceId);
+    // ── Pre-redirect chat-integration cap gate (#2998) ────────────
+    // Slack's `startInstall` runs a read-only chat-integration cap precheck
+    // before minting the authorize URL, so an at-cap workspace is refused
+    // BEFORE Slack mints a bot token / installs the app — it no longer
+    // completes the whole dance only to be turned away at the callback. The
+    // callback's atomic gate stays in place as the TOCTOU guard. We translate
+    // the thrown tagged errors exactly as the callback handler does:
+    //   - ChatIntegrationLimitError → browser: 302 to the admin UI with
+    //     `reason=plan_limit_reached`; JSON callers fall through to the 429
+    //     `plan_limit_exceeded` mapping in runHandler.
+    //   - BillingCheckFailedError (count couldn't be read) → left to the 503
+    //     `billing_check_failed` mapper: a transient "try again", not an
+    //     upgrade prompt, for browser and JSON callers alike.
+    // Other OAuth handlers don't run a chat cap (they're not chat-pillar), so
+    // this catch is a no-op for them.
+    let redirectUrl: string;
+    try {
+      ({ redirectUrl } = await handler.startInstall(workspaceId));
+    } catch (err) {
+      if (err instanceof ChatIntegrationLimitError) {
+        log.info(
+          { platform, workspaceId: err.workspaceId, limit: err.limit },
+          "Install blocked pre-redirect — workspace at chat-integration cap",
+        );
+        if (prefersHtml(c.req.raw)) {
+          return c.redirect(buildPlatformAdminUrl("error", platform, { reason: "plan_limit_reached" }));
+        }
+      }
+      throw err;
+    }
     return c.redirect(redirectUrl);
   }),
 );

--- a/packages/api/src/api/routes/integrations.ts
+++ b/packages/api/src/api/routes/integrations.ts
@@ -746,15 +746,18 @@ integrations.openapi(installRoute, async (c) =>
     // BEFORE Slack mints a bot token / installs the app — it no longer
     // completes the whole dance only to be turned away at the callback. The
     // callback's atomic gate stays in place as the TOCTOU guard. We translate
-    // the thrown tagged errors exactly as the callback handler does:
+    // the cap/billing tagged errors the same way the callback handler does
+    // (`startInstall` exchanges no code, so unlike the callback it has no
+    // `PlatformOAuthExchangeError`/`upstream_error` arm):
     //   - ChatIntegrationLimitError → browser: 302 to the admin UI with
     //     `reason=plan_limit_reached`; JSON callers fall through to the 429
     //     `plan_limit_exceeded` mapping in runHandler.
     //   - BillingCheckFailedError (count couldn't be read) → left to the 503
     //     `billing_check_failed` mapper: a transient "try again", not an
     //     upgrade prompt, for browser and JSON callers alike.
-    // Other OAuth handlers don't run a chat cap (they're not chat-pillar), so
-    // this catch is a no-op for them.
+    // Handlers that don't run a chat-cap precheck never throw
+    // ChatIntegrationLimitError here, so this catch is inert for them and just
+    // re-throws — every other error propagates unchanged to runHandler.
     let redirectUrl: string;
     try {
       ({ redirectUrl } = await handler.startInstall(workspaceId));

--- a/packages/api/src/lib/billing/__tests__/enforcement.test.ts
+++ b/packages/api/src/lib/billing/__tests__/enforcement.test.ts
@@ -93,7 +93,7 @@ mock.module("@atlas/api/lib/logger", () => ({
 
 // --- Import under test ---
 
-import { checkChatIntegrationLimitAndInstall, CHAT_INTEGRATION_COUNT_SQL, checkPlanLimits, checkResourceLimit, invalidatePlanCache, type ChatIntegrationInstallResult, type PlanCheckResult, type ResourceLimitResult } from "@atlas/api/lib/billing/enforcement";
+import { checkChatIntegrationLimit, checkChatIntegrationLimitAndInstall, CHAT_INTEGRATION_COUNT_SQL, checkPlanLimits, checkResourceLimit, invalidatePlanCache, type ChatIntegrationInstallResult, type PlanCheckResult, type ResourceLimitResult } from "@atlas/api/lib/billing/enforcement";
 
 /** Narrow a denied result for type-safe assertion access. */
 function expectDenied(result: PlanCheckResult): Extract<PlanCheckResult, { allowed: false }> {
@@ -753,6 +753,113 @@ describe("checkResourceLimit", () => {
   it("allows pro tier under chat-integration limit", async () => {
     mockWorkspace = makeWorkspace({ plan_tier: "pro" });
     const result = await checkResourceLimit("org-1", "chat_integrations", 2);
+    expect(result.allowed).toBe(true);
+  });
+});
+
+// ===========================================================================
+// checkChatIntegrationLimit — read-only pre-redirect cap precheck (#2998)
+//
+// The chat handlers run this BEFORE minting the provider OAuth redirect so an
+// at-cap workspace is refused before completing the whole dance. It reuses the
+// SAME count aggregate + checkResourceLimit decision as the atomic gate, but
+// opens no transaction and runs no INSERT — `mockConnectCount` must stay 0.
+// ===========================================================================
+
+describe("checkChatIntegrationLimit (read-only precheck)", () => {
+  const SLACK = "catalog:slack";
+
+  beforeEach(() => {
+    mockHasInternalDB = true;
+    mockWorkspaceDetailsShouldThrow = false;
+    mockWorkspace = null;
+    mockInternalQueryResult = [];
+    mockInternalQueryShouldThrow = false;
+    mockTxnClient = null;
+    mockConnectCount = 0;
+    invalidatePlanCache();
+  });
+
+  // ── No-enforcement short-circuits ─────────────────────────────────
+
+  it("allows when no orgId provided (and opens no transaction)", async () => {
+    const result = await checkChatIntegrationLimit(undefined, SLACK);
+    expect(result.allowed).toBe(true);
+    expect(mockConnectCount).toBe(0);
+  });
+
+  it("allows when no internal DB", async () => {
+    mockHasInternalDB = false;
+    const result = await checkChatIntegrationLimit("org-1", SLACK);
+    expect(result.allowed).toBe(true);
+    expect(mockConnectCount).toBe(0);
+  });
+
+  it("allows when the workspace has no organization row (fail-open, no plan)", async () => {
+    mockWorkspace = null;
+    const result = await checkChatIntegrationLimit("org-1", SLACK);
+    expect(result.allowed).toBe(true);
+  });
+
+  // ── Fail-closed paths (→ 503 "try again") ─────────────────────────
+
+  it("fails closed (check_failed) when the workspace lookup throws", async () => {
+    mockWorkspace = makeWorkspace({ plan_tier: "starter" });
+    mockWorkspaceDetailsShouldThrow = true;
+    const denied = expectCheckFailed(await checkChatIntegrationLimit("org-1", SLACK));
+    expect(denied.errorMessage).toContain("Unable to verify plan limits");
+  });
+
+  it("fails closed (check_failed) when the count query throws", async () => {
+    mockWorkspace = makeWorkspace({ plan_tier: "starter" });
+    mockInternalQueryShouldThrow = true;
+    const denied = expectCheckFailed(await checkChatIntegrationLimit("org-1", SLACK));
+    expect(denied.errorMessage).toContain("Unable to verify plan limits");
+  });
+
+  it("fails closed (check_failed) when the count returns no row (no coerce-to-0)", async () => {
+    mockWorkspace = makeWorkspace({ plan_tier: "starter" });
+    mockInternalQueryResult = [];
+    expectCheckFailed(await checkChatIntegrationLimit("org-1", SLACK));
+  });
+
+  // ── Reconnect carve-out — never blocked ───────────────────────────
+
+  it("allows reconnect (this_count > 0) even when over the cap", async () => {
+    mockWorkspace = makeWorkspace({ plan_tier: "starter" });
+    // Slack already installed (this_count=1) and the workspace is over its
+    // starter cap on other platforms — reconnect must still be allowed.
+    mockInternalQueryResult = [{ others: 5, this_count: 1 }];
+    const result = await checkChatIntegrationLimit("org-1", SLACK);
+    expect(result.allowed).toBe(true);
+  });
+
+  // ── Net-new decisions ─────────────────────────────────────────────
+
+  it("allows starter net-new under the cap (others=0)", async () => {
+    mockWorkspace = makeWorkspace({ plan_tier: "starter" });
+    mockInternalQueryResult = [{ others: 0, this_count: 0 }];
+    const result = await checkChatIntegrationLimit("org-1", SLACK);
+    expect(result.allowed).toBe(true);
+    // Read-only — never opened a transaction.
+    expect(mockConnectCount).toBe(0);
+  });
+
+  it("blocks starter net-new at the cap (cap_reached, carries the limit)", async () => {
+    mockWorkspace = makeWorkspace({ plan_tier: "starter" });
+    // One other chat platform already installed; starter cap = 1.
+    mockInternalQueryResult = [{ others: 1, this_count: 0 }];
+    const denied = expectResourceDenied(await checkChatIntegrationLimit("org-1", SLACK));
+    expect(denied.limit).toBe(1);
+    expect(denied.errorMessage).toContain("Upgrade");
+    // Still read-only on the deny path.
+    expect(mockConnectCount).toBe(0);
+  });
+
+  it("allows business (unlimited) net-new", async () => {
+    mockWorkspace = makeWorkspace({ plan_tier: "business" });
+    mockInternalQueryResult = [{ others: 9, this_count: 0 }];
+    const result = await checkChatIntegrationLimit("org-1", SLACK);
     expect(result.allowed).toBe(true);
   });
 });

--- a/packages/api/src/lib/billing/enforcement.ts
+++ b/packages/api/src/lib/billing/enforcement.ts
@@ -544,6 +544,112 @@ export const CHAT_INTEGRATION_COUNT_SQL = `SELECT
    AND status <> 'archived'`;
 
 /**
+ * Read-only chat-integration cap precheck — the pre-redirect gate (#2998).
+ *
+ * {@link checkChatIntegrationLimitAndInstall} is the *atomic* check-and-INSERT
+ * the chat handlers run at OAuth callback time. But by callback time the
+ * customer has already completed the entire OAuth dance — Slack has minted a
+ * bot token and installed the app — only to be refused. This function lets a
+ * handler refuse an at-cap workspace BEFORE it mints the provider redirect, so
+ * an at-cap Starter workspace never starts a dance it can't finish.
+ *
+ * It is deliberately NOT serialized against concurrent installs and runs no
+ * INSERT: it opens no transaction and takes no advisory lock. The callback's
+ * atomic gate remains the TOCTOU guard — a workspace can reach its cap between
+ * this precheck and the callback. This is a fail-fast precheck, not the
+ * correctness boundary.
+ *
+ * Mirrors the atomic gate's enforcement skips and reconnect carve-out exactly,
+ * so the two never disagree on a workspace that isn't racing itself:
+ *   - No `orgId` / no internal DB → allowed (no enforcement context).
+ *   - Workspace lookup *error* → `check_failed` (fail closed → 503 "try again").
+ *   - No `organization` row (pre-migration / Better-Auth-only) → allowed (no
+ *     plan, no cap — the same deliberate fail-open the atomic gate makes).
+ *   - Reconnect (`this_count > 0`) → allowed: re-auth of an already-installed
+ *     platform never increases the distinct count, so a grandfathered over-cap
+ *     workspace can still re-auth what it owns.
+ *   - Otherwise compare the *other* chat platforms to the plan cap via
+ *     {@link checkResourceLimit}.
+ *
+ * Returns a {@link ResourceLimitResult}: `cap_reached` (→ 429 "upgrade") and
+ * `check_failed` (→ 503 "try again") map to the same HTTP statuses the callback
+ * path surfaces, so callers translate one set of arms regardless of which gate
+ * fired.
+ *
+ * @param orgId - Workspace id. When absent (or no internal DB) there's no cap.
+ * @param catalogId - Catalog row id of the platform being installed (e.g.
+ *   `"catalog:slack"`). Excluded from the `others` count so reconnecting the
+ *   same platform is never blocked.
+ */
+export async function checkChatIntegrationLimit(
+  orgId: string | undefined,
+  catalogId: string,
+): Promise<ResourceLimitResult> {
+  // No enforcement context — no cap to apply.
+  if (!orgId || !hasInternalDB()) {
+    return { allowed: true };
+  }
+
+  // Resolve the workspace plan. Fail closed on a lookup *error* (transient DB
+  // fault → 503), the same posture as checkResourceLimit / the atomic gate.
+  let workspace: WorkspaceRow | null;
+  try {
+    workspace = await getCachedWorkspace(orgId);
+  } catch (err) {
+    log.error(
+      { err: err instanceof Error ? err.message : String(err), orgId, catalogId },
+      "Failed to resolve workspace for chat-integration cap precheck — blocking as precaution",
+    );
+    return { allowed: false, reason: "check_failed", errorMessage: CHAT_CAP_CHECK_FAILED_MSG };
+  }
+
+  // No `organization` row → no plan → no cap. The ONLY deliberate fail-open
+  // here, matching the atomic gate (a lookup *error* fails closed above; a
+  // genuine *absence* allows).
+  if (!workspace) {
+    return { allowed: true };
+  }
+
+  // Count chat-pillar installs, partitioned the same way as the atomic gate
+  // (this platform vs. every other), via the SAME aggregate so the precheck and
+  // the callback gate never disagree.
+  let counts: { others: number; this_count: number } | undefined;
+  try {
+    const rows = await internalQuery<{ others: number; this_count: number }>(
+      CHAT_INTEGRATION_COUNT_SQL,
+      [orgId, catalogId],
+    );
+    counts = rows[0];
+  } catch (err) {
+    log.error(
+      { err: err instanceof Error ? err.message : String(err), orgId, catalogId },
+      "Failed to count chat integrations for cap precheck — blocking as precaution",
+    );
+    return { allowed: false, reason: "check_failed", errorMessage: CHAT_CAP_CHECK_FAILED_MSG };
+  }
+  // The aggregate always returns exactly one row; an empty result means the
+  // driver/query contract was violated. Fail closed rather than coerce the
+  // absent count to 0 — that would silently breach the cap.
+  if (!counts) {
+    log.error(
+      { orgId, catalogId },
+      "Chat-integration count query returned no row for cap precheck — blocking as precaution",
+    );
+    return { allowed: false, reason: "check_failed", errorMessage: CHAT_CAP_CHECK_FAILED_MSG };
+  }
+
+  // Reconnect (already installed) is never blocked — re-auth doesn't grow the
+  // distinct count, so skip the cap comparison entirely.
+  if (counts.this_count > 0) {
+    return { allowed: true };
+  }
+
+  // Net-new platform → compare the *other* chat platforms to the plan cap.
+  // getCachedWorkspace warmed the cache above, so this reads from cache.
+  return checkResourceLimit(orgId, "chat_integrations", counts.others);
+}
+
+/**
  * The `workspace_plugins` INSERT the gate runs inside its transaction. Raw
  * SQL + params (rather than a structured descriptor) because each caller owns
  * its own UPSERT shape; the gate stays agnostic and just executes it under the

--- a/packages/api/src/lib/integrations/install/__tests__/slack-oauth-handler.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/slack-oauth-handler.test.ts
@@ -105,11 +105,25 @@ const mockCheckChatLimitAndInstall: Mock<
   ) => Promise<GateResult>
 > = mock(() => Promise.resolve({ allowed: true as const, rows: [{ id: DEFAULT_PERSISTED_ID }] }));
 
+// Read-only pre-redirect cap precheck (#2998), called by `startInstall`. The
+// `at cap` / `check failed` startInstall tests override it via
+// `mockImplementationOnce`; the default is "allowed" so the happy-path
+// startInstall + every handleCallback test sails past it.
+type PrecheckResult =
+  | { allowed: true }
+  | { allowed: false; reason: "cap_reached"; errorMessage: string; limit: number }
+  | { allowed: false; reason: "check_failed"; errorMessage: string };
+const mockCheckChatLimit: Mock<
+  (orgId: string | undefined, catalogId: string) => Promise<PrecheckResult>
+> = mock(() => Promise.resolve({ allowed: true as const }));
+
 // Mock every value export — a partial `mock.module()` causes a `SyntaxError`
 // in other files importing the missing exports (per CLAUDE.md "Mock all
-// exports"). Only `checkChatIntegrationLimitAndInstall` is exercised here; the
+// exports"). `checkChatIntegrationLimit` (pre-redirect precheck) +
+// `checkChatIntegrationLimitAndInstall` (callback gate) are exercised here; the
 // rest are inert no-ops.
 mock.module("@atlas/api/lib/billing/enforcement", () => ({
+  checkChatIntegrationLimit: mockCheckChatLimit,
   checkChatIntegrationLimitAndInstall: mockCheckChatLimitAndInstall,
   CHAT_INTEGRATION_COUNT_SQL: "SELECT 1",
   checkResourceLimit: () => Promise.resolve({ allowed: true }),
@@ -155,6 +169,8 @@ beforeEach(() => {
   setKeys("v1:test-key-one");
   mockSlackAPI.mockClear();
   mockSaveInstallation.mockClear();
+  mockCheckChatLimit.mockClear();
+  mockCheckChatLimit.mockImplementation(() => Promise.resolve({ allowed: true as const }));
   mockCheckChatLimitAndInstall.mockClear();
   mockCheckChatLimitAndInstall.mockImplementation(() =>
     Promise.resolve({ allowed: true as const, rows: [{ id: DEFAULT_PERSISTED_ID }] }),
@@ -208,6 +224,51 @@ describe("SlackOAuthInstallHandler.startInstall", () => {
     expect(verifyOAuthStateToken(stateToken)).toEqual({
       workspaceId: WSID,
       catalogId: "slack",
+    });
+  });
+
+  // ── Pre-redirect chat-integration cap gate (#2998) ────────────────
+
+  it("runs the cap precheck for (workspaceId, 'catalog:slack') before minting the redirect", async () => {
+    const handler = new SlackOAuthInstallHandler(SLACK_CONFIG);
+
+    await handler.startInstall(WSID);
+
+    expect(mockCheckChatLimit).toHaveBeenCalledTimes(1);
+    const [org, catalog] = mockCheckChatLimit.mock.calls[0];
+    expect(org).toBe(WSID);
+    expect(catalog).toBe("catalog:slack");
+  });
+
+  it("throws ChatIntegrationLimitError (no redirect minted) when the workspace is at its cap", async () => {
+    mockCheckChatLimit.mockImplementationOnce(() =>
+      Promise.resolve({
+        allowed: false as const,
+        reason: "cap_reached" as const,
+        errorMessage: "Your starter plan allows up to 1 chat integration. Upgrade to add more.",
+        limit: 1,
+      }),
+    );
+    const handler = new SlackOAuthInstallHandler(SLACK_CONFIG);
+
+    await expect(handler.startInstall(WSID)).rejects.toMatchObject({
+      _tag: "ChatIntegrationLimitError",
+      limit: 1,
+    });
+  });
+
+  it("throws BillingCheckFailedError (not the cap error) when the precheck fails closed", async () => {
+    mockCheckChatLimit.mockImplementationOnce(() =>
+      Promise.resolve({
+        allowed: false as const,
+        reason: "check_failed" as const,
+        errorMessage: "Unable to verify plan limits. Please try again.",
+      }),
+    );
+    const handler = new SlackOAuthInstallHandler(SLACK_CONFIG);
+
+    await expect(handler.startInstall(WSID)).rejects.toMatchObject({
+      _tag: "BillingCheckFailedError",
     });
   });
 });

--- a/packages/api/src/lib/integrations/install/__tests__/slack-oauth-handler.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/slack-oauth-handler.test.ts
@@ -27,6 +27,7 @@ import {
   verifyOAuthStateToken,
 } from "../oauth-state-token";
 import type { WorkspaceId } from "@useatlas/types";
+import type { ResourceLimitResult } from "@atlas/api/lib/billing/enforcement";
 
 // ---------------------------------------------------------------------------
 // Module mocks (must hoist above the handler import below)
@@ -109,10 +110,12 @@ const mockCheckChatLimitAndInstall: Mock<
 // `at cap` / `check failed` startInstall tests override it via
 // `mockImplementationOnce`; the default is "allowed" so the happy-path
 // startInstall + every handleCallback test sails past it.
-type PrecheckResult =
-  | { allowed: true }
-  | { allowed: false; reason: "cap_reached"; errorMessage: string; limit: number }
-  | { allowed: false; reason: "check_failed"; errorMessage: string };
+//
+// Anchor the mock's result type to the REAL `ResourceLimitResult` (type-only
+// import — no runtime code pulled into the mock graph) so the mock can't drift
+// from the production return shape. Mirrors the drift-proof `Extract<>` pattern
+// in `billing/__tests__/enforcement.test.ts`.
+type PrecheckResult = ResourceLimitResult;
 const mockCheckChatLimit: Mock<
   (orgId: string | undefined, catalogId: string) => Promise<PrecheckResult>
 > = mock(() => Promise.resolve({ allowed: true as const }));

--- a/packages/api/src/lib/integrations/install/slack-oauth-handler.ts
+++ b/packages/api/src/lib/integrations/install/slack-oauth-handler.ts
@@ -40,7 +40,7 @@ import { createLogger } from "@atlas/api/lib/logger";
 import { slackAPI } from "@atlas/api/lib/slack/api";
 import { saveInstallation } from "@atlas/api/lib/slack/store";
 import { BillingCheckFailedError, ChatIntegrationLimitError, PlatformOAuthExchangeError } from "@atlas/api/lib/effect/errors";
-import { checkChatIntegrationLimitAndInstall } from "@atlas/api/lib/billing/enforcement";
+import { checkChatIntegrationLimit, checkChatIntegrationLimitAndInstall } from "@atlas/api/lib/billing/enforcement";
 import type { WorkspaceId } from "@useatlas/types";
 import {
   mintOAuthStateToken,
@@ -122,6 +122,40 @@ export class SlackOAuthInstallHandler implements OAuthPlatformInstallHandler {
     readonly redirectUrl: string;
     readonly stateToken: string;
   }> {
+    // ── Pre-redirect chat-integration cap gate (#2998) ─────────────
+    // Refuse an at-cap workspace BEFORE minting the Slack authorize URL, so it
+    // never completes the full OAuth dance (Slack minting a bot token +
+    // installing the app) only to be turned away at the callback. This is a
+    // read-only precheck — `handleCallback` STILL runs the atomic
+    // check-and-install gate (`checkChatIntegrationLimitAndInstall`) as the
+    // TOCTOU guard, because a workspace can reach its cap between here and the
+    // callback. Mirrors the route's existing pre-redirect `min_plan` gate.
+    const capCheck = await checkChatIntegrationLimit(workspaceId, SLACK_CATALOG_ID);
+    if (!capCheck.allowed) {
+      if (capCheck.reason === "check_failed") {
+        // Couldn't read the chat-integration count — fail closed, but as a
+        // transient 503 "try again", NOT a 429 "upgrade your plan". Same
+        // distinction the callback path draws.
+        log.error(
+          { workspaceId },
+          "Slack install blocked pre-redirect — chat-integration count check failed (failing closed)",
+        );
+        throw new BillingCheckFailedError({
+          message: capCheck.errorMessage,
+          workspaceId,
+        });
+      }
+      log.info(
+        { workspaceId, limit: capCheck.limit },
+        "Slack install blocked pre-redirect — workspace at chat-integration cap",
+      );
+      throw new ChatIntegrationLimitError({
+        message: capCheck.errorMessage,
+        workspaceId,
+        limit: capCheck.limit,
+      });
+    }
+
     const stateToken = mintOAuthStateToken(workspaceId, SLACK_SLUG);
     const url = new URL("https://slack.com/oauth/v2/authorize");
     url.searchParams.set("client_id", this.config.clientId);

--- a/packages/api/src/lib/integrations/install/slack-oauth-handler.ts
+++ b/packages/api/src/lib/integrations/install/slack-oauth-handler.ts
@@ -129,7 +129,10 @@ export class SlackOAuthInstallHandler implements OAuthPlatformInstallHandler {
     // read-only precheck — `handleCallback` STILL runs the atomic
     // check-and-install gate (`checkChatIntegrationLimitAndInstall`) as the
     // TOCTOU guard, because a workspace can reach its cap between here and the
-    // callback. Mirrors the route's existing pre-redirect `min_plan` gate.
+    // callback. Same *timing* as the route's pre-redirect `min_plan` gate
+    // (refuse before the dance), though that gate denies with 403
+    // `plan_upgrade_required` while this one surfaces 429 `plan_limit_reached`
+    // (cap hit) or 503 `billing_check_failed` (count unreadable).
     const capCheck = await checkChatIntegrationLimit(workspaceId, SLACK_CATALOG_ID);
     if (!capCheck.allowed) {
       if (capCheck.reason === "check_failed") {


### PR DESCRIPTION
## Summary

- An at-cap Starter workspace used to complete the **entire** Slack OAuth dance — Slack minting a bot token and installing the app — before Atlas refused it. The chat-integration cap (`checkChatIntegrationLimitAndInstall`) was enforced **only** in `SlackOAuthInstallHandler.handleCallback`.
- Adds a read-only cap precheck (`checkChatIntegrationLimit`) that runs in `startInstall` **before** the Slack authorize URL is minted, mirroring the existing pre-redirect `min_plan` gate. It reuses the same `CHAT_INTEGRATION_COUNT_SQL` aggregate + `checkResourceLimit` decision as the atomic gate, but opens no transaction and runs no INSERT.
- The callback's atomic gate is **retained** as the TOCTOU guard — a workspace can still reach its cap between `/install` and `/callback`.

### Behavior (consistent with the callback path)
- **Genuine cap hit** → `ChatIntegrationLimitError`: browser gets a 302 to `/admin/integrations?error=slack&reason=plan_limit_reached`; JSON callers get 429 `plan_limit_exceeded` (body carries `limit`).
- **Count unreadable** (transient DB fault) → `BillingCheckFailedError`: 503 `billing_check_failed` ("try again", not "upgrade") — fail closed.
- **Reconnect** (`this_count > 0`) is never blocked.

Other (non-chat-pillar) OAuth handlers are unaffected — the route's `startInstall` catch is a transparent passthrough for them.

## Test plan
- [x] `enforcement.test.ts` — read-only precheck: no-DB/no-org skips, fail-closed (lookup/count error, empty row), reconnect allow, net-new under/at cap, business unlimited; asserts it opens **no** transaction (11 new)
- [x] `slack-oauth-handler.test.ts` — `startInstall` runs the precheck for `(workspaceId, 'catalog:slack')` and throws `ChatIntegrationLimitError` / `BillingCheckFailedError` before minting a redirect (3 new)
- [x] `integrations-slack-install-cap.test.ts` (new) — route translation: under-cap → 302 to Slack, at-cap JSON → 429 (+`limit`), at-cap browser → 302 `reason=plan_limit_reached`, reconnect-over-cap → 302 to Slack, count-unreadable → 503
- [x] OpenAPI spec regenerated for the install route's new 302/429/503 outcomes
- [x] `/ci` — lint, type, full test (api 542 + others), syncpack, all drift/discipline checks pass

Closes #2998

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3108"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783014350&installation_id=135337507&pr_number=3108&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3108&signature=685734a6a849b52b3439ff111a8282a9eefaadb4a64849d45494ecabbe93f1e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enforced chat-integration install caps per workspace, allowing reconnections even when caps are reached.
  * Browser installs that are refused now redirect to the admin UI with a clear refusal reason.

* **Bug Fixes / Error Responses**
  * Improved API error responses: detailed 429 and new 503 responses with structured messages and request IDs.

* **Documentation**
  * OpenAPI docs updated to reflect new error scenarios and redirect behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->