### PR TITLE
fix(db): retire DISTINCT ON multi-tenant ConnectionRegistry collision (#2783)

### DIFF
--- a/packages/api/src/lib/db/__tests__/datasource-registry-bridge.test.ts
+++ b/packages/api/src/lib/db/__tests__/datasource-registry-bridge.test.ts
@@ -17,6 +17,11 @@ const registerCalls: Array<{ id: string; url: string; schema?: string; descripti
 const unregisterCalls: string[] = [];
 let registeredIds = new Set<string>();
 
+// Per-(workspace, install_id) registrations — the routing source of truth (#2783).
+const wsRegisterCalls: Array<{ workspaceId: string; installId: string; url: string; schema?: string; description?: string }> = [];
+let wsRegisteredKeys = new Set<string>();
+const wsKey = (workspaceId: string, installId: string) => `${workspaceId}::${installId}`;
+
 const mockRegister: Mock<(id: string, cfg: { url: string; schema?: string; description?: string }) => void> = mock(
   (id: string, cfg: { url: string; schema?: string; description?: string }) => {
     registerCalls.push({ id, url: cfg.url, schema: cfg.schema, description: cfg.description });
@@ -30,12 +35,23 @@ const mockUnregister: Mock<(id: string) => boolean> = mock((id: string) => {
   return had;
 });
 const mockHas: Mock<(id: string) => boolean> = mock((id: string) => registeredIds.has(id));
+const mockRegisterForWorkspace: Mock<(workspaceId: string, installId: string, cfg: { url: string; schema?: string; description?: string }) => void> = mock(
+  (workspaceId: string, installId: string, cfg: { url: string; schema?: string; description?: string }) => {
+    wsRegisterCalls.push({ workspaceId, installId, url: cfg.url, schema: cfg.schema, description: cfg.description });
+    wsRegisteredKeys.add(wsKey(workspaceId, installId));
+  },
+);
+const mockHasForWorkspace: Mock<(workspaceId: string, installId: string) => boolean> = mock(
+  (workspaceId: string, installId: string) => wsRegisteredKeys.has(wsKey(workspaceId, installId)),
+);
 
 mock.module("@atlas/api/lib/db/connection", () => ({
   connections: {
     register: mockRegister,
     unregister: mockUnregister,
     has: mockHas,
+    registerForWorkspace: mockRegisterForWorkspace,
+    hasForWorkspace: mockHasForWorkspace,
   },
 }));
 
@@ -46,16 +62,22 @@ beforeEach(async () => {
   bridge = await import("../datasource-registry-bridge");
   registerCalls.length = 0;
   unregisterCalls.length = 0;
+  wsRegisterCalls.length = 0;
   registeredIds = new Set<string>();
+  wsRegisteredKeys = new Set<string>();
   mockRegister.mockClear();
   mockUnregister.mockClear();
   mockHas.mockClear();
+  mockRegisterForWorkspace.mockClear();
+  mockHasForWorkspace.mockClear();
 });
 
 afterEach(() => {
   registerCalls.length = 0;
   unregisterCalls.length = 0;
+  wsRegisterCalls.length = 0;
   registeredIds = new Set<string>();
+  wsRegisteredKeys = new Set<string>();
 });
 
 const ROW = (slug: string) =>
@@ -108,14 +130,42 @@ describe("registerDatasourceInstall", () => {
     expect(registerCalls).toHaveLength(0);
   });
 
-  it("is idempotent — returns false when install_id is already registered", () => {
+  it("is idempotent for the same (workspace, install_id) — returns false on re-register", () => {
     bridge.registerDatasourceInstall(ROW("postgres"), { url: "postgresql://u@h/d" });
     const second = bridge.registerDatasourceInstall(ROW("postgres"), {
       url: "postgresql://u@different/d2",
     });
     expect(second).toBe(false);
-    // Only one register call landed — the existing pool wasn't torn down.
+    // Only one bare register call landed — the existing pool wasn't torn down.
     expect(registerCalls).toHaveLength(1);
+  });
+
+  it("registers two workspaces sharing an install_id independently (#2783)", () => {
+    // Pre-#2783, the bridge keyed only on install_id, so the second workspace's
+    // install collapsed onto the first's bare row. Now each (workspace,
+    // install_id) gets its own routing config.
+    const alpha = bridge.registerDatasourceInstall(
+      { ...ROW("postgres"), workspaceId: "ws-alpha" },
+      { url: "postgresql://alpha-host/wh" },
+    );
+    const beta = bridge.registerDatasourceInstall(
+      { ...ROW("postgres"), workspaceId: "ws-beta" },
+      { url: "postgresql://beta-host/wh" },
+    );
+
+    // Both are fresh registrations — no collapse.
+    expect(alpha).toBe(true);
+    expect(beta).toBe(true);
+
+    // Two distinct per-(workspace, install_id) configs, each with its own URL.
+    expect(wsRegisterCalls).toHaveLength(2);
+    expect(wsRegisterCalls[0]).toMatchObject({ workspaceId: "ws-alpha", installId: "prod", url: "postgresql://alpha-host/wh" });
+    expect(wsRegisterCalls[1]).toMatchObject({ workspaceId: "ws-beta", installId: "prod", url: "postgresql://beta-host/wh" });
+
+    // The bare install-id row is written once (first-write-wins) — it backs
+    // only install-id-keyed metadata, not routing.
+    expect(registerCalls).toHaveLength(1);
+    expect(registerCalls[0].url).toBe("postgresql://alpha-host/wh");
   });
 
   it("throws when the resolver rejects (missing required field)", () => {

--- a/packages/api/src/lib/db/__tests__/datasource-registry-bridge.test.ts
+++ b/packages/api/src/lib/db/__tests__/datasource-registry-bridge.test.ts
@@ -44,6 +44,15 @@ const mockRegisterForWorkspace: Mock<(workspaceId: string, installId: string, cf
 const mockHasForWorkspace: Mock<(workspaceId: string, installId: string) => boolean> = mock(
   (workspaceId: string, installId: string) => wsRegisteredKeys.has(wsKey(workspaceId, installId)),
 );
+const mockUnregisterForWorkspace: Mock<(workspaceId: string, installId: string) => boolean> = mock(
+  (workspaceId: string, installId: string) => wsRegisteredKeys.delete(wsKey(workspaceId, installId)),
+);
+const mockHasWorkspacePoolsFor: Mock<(installId: string) => boolean> = mock((installId: string) => {
+  for (const key of wsRegisteredKeys) {
+    if (key.endsWith(`::${installId}`)) return true;
+  }
+  return false;
+});
 
 mock.module("@atlas/api/lib/db/connection", () => ({
   connections: {
@@ -52,6 +61,8 @@ mock.module("@atlas/api/lib/db/connection", () => ({
     has: mockHas,
     registerForWorkspace: mockRegisterForWorkspace,
     hasForWorkspace: mockHasForWorkspace,
+    unregisterForWorkspace: mockUnregisterForWorkspace,
+    hasWorkspacePoolsFor: mockHasWorkspacePoolsFor,
   },
 }));
 
@@ -70,6 +81,8 @@ beforeEach(async () => {
   mockHas.mockClear();
   mockRegisterForWorkspace.mockClear();
   mockHasForWorkspace.mockClear();
+  mockUnregisterForWorkspace.mockClear();
+  mockHasWorkspacePoolsFor.mockClear();
 });
 
 afterEach(() => {
@@ -201,17 +214,35 @@ describe("registerDatasourceInstall", () => {
 });
 
 describe("unregisterDatasourceInstall", () => {
-  it("calls connections.unregister and returns true when registered", () => {
+  it("removes both the per-workspace config and the bare row when registered", () => {
     bridge.registerDatasourceInstall(ROW("postgres"), { url: "postgresql://u@h/d" });
-    const result = bridge.unregisterDatasourceInstall("prod");
+    const result = bridge.unregisterDatasourceInstall("ws-1", "prod");
     expect(result).toBe(true);
+    // Per-workspace routing config gone — no stale route survives.
+    expect(wsRegisteredKeys.has(wsKey("ws-1", "prod"))).toBe(false);
+    // Bare row removed too (no sibling workspace owns the install_id).
     expect(unregisterCalls).toContain("prod");
   });
 
+  it("keeps the shared bare row when a sibling workspace still owns the install_id", () => {
+    bridge.registerDatasourceInstall({ ...ROW("postgres"), workspaceId: "ws-a" }, { url: "postgresql://a/d" });
+    bridge.registerDatasourceInstall({ ...ROW("postgres"), workspaceId: "ws-b" }, { url: "postgresql://b/d" });
+
+    const result = bridge.unregisterDatasourceInstall("ws-a", "prod");
+    expect(result).toBe(true);
+
+    // ws-a's routing config is gone; ws-b's survives.
+    expect(wsRegisteredKeys.has(wsKey("ws-a", "prod"))).toBe(false);
+    expect(wsRegisteredKeys.has(wsKey("ws-b", "prod"))).toBe(true);
+    // Bare row is NOT torn down while ws-b still owns `prod` — sibling metadata
+    // (getDBType / getTargetHost) keeps resolving.
+    expect(unregisterCalls).not.toContain("prod");
+  });
+
   it("returns false when install_id was never registered (plugin-managed pool)", () => {
-    const result = bridge.unregisterDatasourceInstall("never-registered");
+    const result = bridge.unregisterDatasourceInstall("ws-1", "never-registered");
     expect(result).toBe(false);
-    // Never even called unregister — the has() guard short-circuits.
+    // Nothing to remove — neither the per-workspace config nor the bare row.
     expect(unregisterCalls).toHaveLength(0);
   });
 });

--- a/packages/api/src/lib/db/__tests__/internal.test.ts
+++ b/packages/api/src/lib/db/__tests__/internal.test.ts
@@ -376,12 +376,14 @@ describe("internal DB module", () => {
       pool._setResult({
         rows: [
           {
+            workspace_id: "ws-1",
             install_id: "warehouse",
             catalog_slug: "postgres",
             config: { url: "postgresql://host/wh", description: "Warehouse", schema: "analytics" },
             config_schema: POSTGRES_CONFIG_SCHEMA,
           },
           {
+            workspace_id: "ws-1",
             install_id: "reporting",
             catalog_slug: "postgres",
             config: { url: "postgresql://host/rp" },
@@ -397,6 +399,49 @@ describe("internal DB module", () => {
       expect(connections.has("reporting")).toBe(true);
     });
 
+    it("registers independent base configs for two workspaces sharing an install_id (#2783)", async () => {
+      process.env.DATABASE_URL = "postgresql://user:pass@localhost:5432/atlas";
+      const { pool } = createMockPool();
+      // Two workspaces both name their datasource `warehouse`, pointing at
+      // DIFFERENT databases. Pre-#2783, `DISTINCT ON (install_id)` collapsed
+      // these onto a single base pool — silently routing one tenant's queries
+      // to the other's DB. Now each (workspace, install_id) is registered
+      // independently.
+      pool._setResult({
+        rows: [
+          {
+            workspace_id: "ws-alpha",
+            install_id: "warehouse",
+            catalog_slug: "postgres",
+            config: { url: "postgresql://alpha-host/wh" },
+            config_schema: POSTGRES_CONFIG_SCHEMA,
+          },
+          {
+            workspace_id: "ws-beta",
+            install_id: "warehouse",
+            catalog_slug: "postgres",
+            config: { url: "postgresql://beta-host/wh" },
+            config_schema: POSTGRES_CONFIG_SCHEMA,
+          },
+        ],
+      });
+      _resetPool(pool);
+
+      const count = await loadSavedConnections();
+      // Both installs load — no collapse onto one row.
+      expect(count).toBe(2);
+
+      // Each workspace resolves its OWN base config, keyed by (workspace, install_id).
+      expect(connections.hasForWorkspace("ws-alpha", "warehouse")).toBe(true);
+      expect(connections.hasForWorkspace("ws-beta", "warehouse")).toBe(true);
+
+      // ...and to its OWN target host — the proof the collision is gone. Under
+      // the old DISTINCT ON, only one row reached the registry, so the other
+      // workspace's lookup would miss (or resolve the wrong host).
+      expect(connections.getTargetHostForWorkspace("ws-alpha", "warehouse")).toBe("alpha-host");
+      expect(connections.getTargetHostForWorkspace("ws-beta", "warehouse")).toBe("beta-host");
+    });
+
     it("skips individual install failures without aborting", async () => {
       process.env.DATABASE_URL = "postgresql://user:pass@localhost:5432/atlas";
       const { pool } = createMockPool();
@@ -404,12 +449,14 @@ describe("internal DB module", () => {
       pool._setResult({
         rows: [
           {
+            workspace_id: "ws-1",
             install_id: "good",
             catalog_slug: "postgres",
             config: { url: "postgresql://host/db" },
             config_schema: POSTGRES_CONFIG_SCHEMA,
           },
           {
+            workspace_id: "ws-1",
             install_id: "bad",
             catalog_slug: "postgres",
             config: { url: "badscheme://host/db" },
@@ -434,6 +481,7 @@ describe("internal DB module", () => {
       pool._setResult({
         rows: [
           {
+            workspace_id: "ws-1",
             install_id: "warehouse",
             catalog_slug: "snowflake",
             config: { url: "snowflake://user:pass@account/db" },
@@ -1186,6 +1234,7 @@ describe("connection URL encryption", () => {
       pool._setResult({
         rows: [
           {
+            workspace_id: "ws-1",
             install_id: "warehouse",
             catalog_slug: "postgres",
             config: { url: encryptedUrl, description: "Warehouse" },
@@ -1220,12 +1269,14 @@ describe("connection URL encryption", () => {
       pool._setResult({
         rows: [
           {
+            workspace_id: "ws-1",
             install_id: "good-conn",
             catalog_slug: "postgres",
             config: { url: goodEncrypted },
             config_schema: POSTGRES_CONFIG_SCHEMA,
           },
           {
+            workspace_id: "ws-1",
             install_id: "bad-conn",
             catalog_slug: "postgres",
             config: { url: badEncrypted },
@@ -1249,6 +1300,7 @@ describe("connection URL encryption", () => {
       pool._setResult({
         rows: [
           {
+            workspace_id: "ws-1",
             install_id: "legacy",
             catalog_slug: "postgres",
             // Bare plaintext URL — `decryptSecretFields` short-circuits

--- a/packages/api/src/lib/db/__tests__/tenant-pool.test.ts
+++ b/packages/api/src/lib/db/__tests__/tenant-pool.test.ts
@@ -91,6 +91,58 @@ describe("ConnectionRegistry org-scoped pools", () => {
       expect(() => registry.getForOrg("org-1", "nonexistent")).toThrow("not registered");
     });
 
+    // #2783 — per-(workspace, install_id) base resolution. Two workspaces
+    // sharing an install_id must clone from their OWN config, not collapse onto
+    // a single bare row.
+    it("clones each workspace's org pool from its OWN per-workspace config — no bare entry needed", () => {
+      // Only per-workspace configs registered — NO bare `entries["warehouse"]`.
+      // Pre-fix, getForOrg cloned from `entries.get(connectionId)` and would
+      // throw here; now it resolves the (workspace, install_id) composite.
+      registry.registerForWorkspace("ws-alpha", "warehouse", { url: "postgresql://alpha-host/wh" });
+      registry.registerForWorkspace("ws-beta", "warehouse", { url: "postgresql://beta-host/wh" });
+
+      const alpha = registry.getForOrg("ws-alpha", "warehouse");
+      const beta = registry.getForOrg("ws-beta", "warehouse");
+
+      expect(alpha).toBeDefined();
+      expect(beta).toBeDefined();
+      expect(alpha).not.toBe(beta); // independent pools — no collapse
+
+      // Same (workspace, install_id) returns the cached clone.
+      expect(registry.getForOrg("ws-alpha", "warehouse")).toBe(alpha);
+
+      // Each resolves its own target host — proof the clone source is the
+      // per-workspace config, not a shared bare row.
+      expect(registry.getTargetHostForWorkspace("ws-alpha", "warehouse")).toBe("alpha-host");
+      expect(registry.getTargetHostForWorkspace("ws-beta", "warehouse")).toBe("beta-host");
+    });
+
+    it("throws for a workspace with no per-workspace config and no bare fallback", () => {
+      registry.registerForWorkspace("ws-alpha", "warehouse", { url: "postgresql://alpha-host/wh" });
+      // ws-gamma never registered `warehouse`, and there is no bare entry.
+      expect(() => registry.getForOrg("ws-gamma", "warehouse")).toThrow("not registered");
+    });
+
+    it("falls back to the bare entry when no per-workspace config exists", () => {
+      // default / region / self-hosted installs live on the bare map.
+      registry.register("default", { url: "postgresql://localhost/test" });
+      const conn = registry.getForOrg("ws-any", "default");
+      expect(conn).toBeDefined();
+    });
+
+    it("unregisterForWorkspace removes only the targeted (workspace, install_id) config", () => {
+      registry.registerForWorkspace("ws-alpha", "warehouse", { url: "postgresql://alpha-host/wh" });
+      registry.registerForWorkspace("ws-beta", "warehouse", { url: "postgresql://beta-host/wh" });
+
+      expect(registry.unregisterForWorkspace("ws-alpha", "warehouse")).toBe(true);
+      // Sibling workspace's config is untouched — no cross-workspace eviction.
+      expect(registry.hasForWorkspace("ws-alpha", "warehouse")).toBe(false);
+      expect(registry.hasForWorkspace("ws-beta", "warehouse")).toBe(true);
+
+      // Idempotent: removing an absent config returns false.
+      expect(registry.unregisterForWorkspace("ws-alpha", "warehouse")).toBe(false);
+    });
+
     it("lazy-initializes default connection when orgId is used", () => {
       process.env.ATLAS_DATASOURCE_URL = "postgresql://localhost/test";
       try {

--- a/packages/api/src/lib/db/__tests__/tenant-pool.test.ts
+++ b/packages/api/src/lib/db/__tests__/tenant-pool.test.ts
@@ -7,6 +7,15 @@
 import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
 import { resolve } from "path";
 
+// Reads the connection string a cloned org pool actually connects to. The
+// cache-busting `import(...?t=)` below bypasses `mock.module("pg")`, so a real
+// pg Pool (BoundPool) backs each connection — it exposes `options.connectionString`.
+// This is the load-bearing #2783 assertion: a regression cloning from the wrong
+// config object would connect to the wrong tenant's DB.
+function poolConnString(conn: import("../connection").DBConnection): string | undefined {
+  return (conn as { _pool?: { options?: { connectionString?: string } } })._pool?.options?.connectionString;
+}
+
 // Mock pg
 mock.module("pg", () => ({
   Pool: class MockPool {
@@ -111,16 +120,38 @@ describe("ConnectionRegistry org-scoped pools", () => {
       // Same (workspace, install_id) returns the cached clone.
       expect(registry.getForOrg("ws-alpha", "warehouse")).toBe(alpha);
 
-      // Each resolves its own target host — proof the clone source is the
-      // per-workspace config, not a shared bare row.
-      expect(registry.getTargetHostForWorkspace("ws-alpha", "warehouse")).toBe("alpha-host");
-      expect(registry.getTargetHostForWorkspace("ws-beta", "warehouse")).toBe("beta-host");
+      // The cloned pools actually CONNECT to their own per-workspace URL — the
+      // load-bearing #2783 assertion (a regression cloning from the wrong
+      // config object would connect to the wrong tenant's DB).
+      expect(poolConnString(alpha)).toBe("postgresql://alpha-host/wh");
+      expect(poolConnString(beta)).toBe("postgresql://beta-host/wh");
+    });
+
+    it("per-workspace config WINS over a bare entry for the same install_id", () => {
+      // The production shape: the bridge registers BOTH a bare row and a
+      // per-workspace config. getForOrg must clone from the per-workspace URL,
+      // never the bare one.
+      registry.register("warehouse", { url: "postgresql://shared-host/wh" });
+      registry.registerForWorkspace("ws-alpha", "warehouse", { url: "postgresql://alpha-host/wh" });
+
+      const conn = registry.getForOrg("ws-alpha", "warehouse");
+      expect(poolConnString(conn)).toBe("postgresql://alpha-host/wh");
     });
 
     it("throws for a workspace with no per-workspace config and no bare fallback", () => {
       registry.registerForWorkspace("ws-alpha", "warehouse", { url: "postgresql://alpha-host/wh" });
       // ws-gamma never registered `warehouse`, and there is no bare entry.
       expect(() => registry.getForOrg("ws-gamma", "warehouse")).toThrow("not registered");
+    });
+
+    it("fail-closes on getForOrg cache-miss after unregisterForWorkspace (no stale route)", () => {
+      // Regression guard for the review finding: the per-workspace config must
+      // be removable so an uninstalled datasource can't keep routing. With no
+      // bare fallback, a post-unregister cache-miss throws rather than cloning
+      // from a stale URL.
+      registry.registerForWorkspace("ws-alpha", "warehouse", { url: "postgresql://alpha-host/wh" });
+      expect(registry.unregisterForWorkspace("ws-alpha", "warehouse")).toBe(true);
+      expect(() => registry.getForOrg("ws-alpha", "warehouse")).toThrow("not registered");
     });
 
     it("falls back to the bare entry when no per-workspace config exists", () => {

--- a/packages/api/src/lib/db/connection.ts
+++ b/packages/api/src/lib/db/connection.ts
@@ -400,6 +400,27 @@ interface RegistryEntry {
   region?: string;
 }
 
+/**
+ * Per-(workspace, install_id) base connection config.
+ *
+ * Config-only by design — holds NO live pool. `getForOrg(workspaceId, installId)`
+ * clones an org-scoped pool from `config`/`dbType` on first access, so these
+ * entries never open connections themselves (re-registration is therefore
+ * cheap, which is how a datasource config update refreshes routing).
+ *
+ * This is the routing source of truth that retires the `DISTINCT ON
+ * (install_id)` multi-tenant collision (#2783): two workspaces sharing an
+ * install_id (e.g. both naming their warehouse `warehouse`, or both auto-owning
+ * the demo at `install_id='__demo__'`) each get their own config here instead
+ * of collapsing onto a single bare `entries` row.
+ */
+interface WorkspaceBaseEntry {
+  config: ConnectionConfig;
+  dbType: DBType;
+  description?: string;
+  targetHost: string;
+}
+
 /** Configuration for per-org pool isolation. */
 export interface OrgPoolSettings {
   /** Whether org-scoped pooling is active. Only true when pool.perOrg is explicitly configured. */
@@ -441,6 +462,13 @@ export class ConnectionRegistry {
   private drainCooldownSet = new Set<string>();
   /** Tracks cooldown expiry timestamps for remaining-time messages. */
   private drainCooldownExpiry = new Map<string, number>();
+
+  /**
+   * Per-(workspace, install_id) base configs, keyed by {@link _workspaceKey}.
+   * Config-only — `getForOrg` clones org-scoped pools from these on demand, so
+   * no live connections are held here. See {@link WorkspaceBaseEntry} and #2783.
+   */
+  private workspaceEntries = new Map<string, WorkspaceBaseEntry>();
 
   // --- Org-scoped pool isolation ---
   /** Org pool entries keyed by "orgId:connectionId". */
@@ -544,12 +572,27 @@ export class ConnectionRegistry {
   }
 
   /**
+   * Composite key for per-(workspace, install_id) base configs. Uses a NUL
+   * separator — neither workspace ids (cuid/uuid) nor install ids contain it,
+   * so the key is unambiguous without escaping.
+   */
+  private _workspaceKey(workspaceId: string, installId: string): string {
+    return `${workspaceId}\u0000${installId}`;
+  }
+
+  /**
    * Get an org-scoped connection pool. Lazy-creates on first access.
    *
    * Each org gets its own pool instance using the same URL/config as the base
    * connection but with org-specific pool limits (maxConnections, idleTimeoutMs).
    * Plugin-managed connections (no config) are returned directly since plugins
    * manage their own pooling.
+   *
+   * Base config is resolved by (workspace, install_id) first (#2783): two
+   * workspaces sharing an install_id each clone from their OWN per-workspace
+   * config rather than collapsing onto a single bare `entries` row. The bare
+   * entry remains the fallback for the runtime-only `default`, region pools,
+   * plugin-managed connections, and self-hosted single-tenant installs.
    *
    * Warmup probes fire asynchronously in the background after pool creation.
    * LRU eviction removes the least recently used org's pools when maxOrgs is exceeded.
@@ -568,15 +611,34 @@ export class ConnectionRegistry {
       this.getDefault();
     }
 
+    // Resolve the base config, preferring the per-(workspace, install_id)
+    // entry (the #2783 routing fix). `orgId` IS the workspace id in Atlas.
+    const wsBase = this.workspaceEntries.get(this._workspaceKey(orgId, connectionId));
     const baseEntry = this.entries.get(connectionId);
-    if (!baseEntry) {
+    if (!wsBase && !baseEntry) {
       throw new ConnectionNotRegisteredError({ message: `Connection "${connectionId}" is not registered.`, id: connectionId });
     }
 
-    // Plugin-managed connections don't have config — return base directly
-    if (!baseEntry.config) {
+    // Plugin-managed connections don't have config — return base directly.
+    // Reached only when there's no per-workspace config to clone from (plugin
+    // pools register on the bare map via registerDirect).
+    if (!wsBase && baseEntry && !baseEntry.config) {
       return baseEntry.conn;
     }
+
+    // Per-workspace config wins; bare entry is the fallback. Plugin validators /
+    // metadata only ever live on the bare entry (native per-workspace configs
+    // carry neither). The `baseConfig`/`baseDbType` guard below can't actually
+    // fire given the checks above, but keeps the types honest without `!`.
+    const baseConfig = wsBase?.config ?? baseEntry?.config;
+    const baseDbType = wsBase?.dbType ?? baseEntry?.dbType;
+    if (!baseConfig || !baseDbType) {
+      throw new ConnectionNotRegisteredError({ message: `Connection "${connectionId}" is not registered.`, id: connectionId });
+    }
+    const baseDescription = wsBase?.description ?? baseEntry?.description;
+    const baseTargetHost = wsBase?.targetHost ?? baseEntry?.targetHost ?? "(unknown)";
+    const baseValidate = baseEntry?.validate;
+    const basePluginMeta = baseEntry?.pluginMeta;
 
     // Evict LRU org if at org-count capacity
     this._evictLRUOrg();
@@ -603,14 +665,14 @@ export class ConnectionRegistry {
 
     // Create org-scoped pool with org-specific limits
     const orgConfig: ConnectionConfig = {
-      ...baseEntry.config,
+      ...baseConfig,
       maxConnections: this.orgPoolSettings.maxConnections,
       idleTimeoutMs: this.orgPoolSettings.idleTimeoutMs,
     };
 
     let newConn: DBConnection;
     try {
-      newConn = createConnection(baseEntry.dbType, orgConfig);
+      newConn = createConnection(baseDbType, orgConfig);
     } catch (err) {
       log.error(
         { orgId, connectionId, err: errorMessage(err) },
@@ -620,16 +682,16 @@ export class ConnectionRegistry {
     }
     const entry: RegistryEntry = {
       conn: newConn,
-      dbType: baseEntry.dbType,
-      description: baseEntry.description,
+      dbType: baseDbType,
+      description: baseDescription,
       lastQueryAt: Date.now(),
       config: orgConfig,
-      targetHost: baseEntry.targetHost,
+      targetHost: baseTargetHost,
       consecutiveFailures: 0,
       lastHealth: null,
       firstFailureAt: null,
-      validate: baseEntry.validate,
-      pluginMeta: baseEntry.pluginMeta,
+      validate: baseValidate,
+      pluginMeta: basePluginMeta,
       totalQueries: 0,
       totalErrors: 0,
       totalQueryTimeMs: 0,
@@ -798,6 +860,59 @@ export class ConnectionRegistry {
         log.warn({ err: errorMessage(err), connectionId: id }, "Failed to close previous connection during re-registration");
       });
     }
+  }
+
+  /**
+   * Register a per-(workspace, install_id) base config (#2783).
+   *
+   * Config-only: stores the URL/schema/dbType so `getForOrg(workspaceId,
+   * installId)` clones an org-scoped pool from the CORRECT per-workspace URL,
+   * instead of collapsing onto a single bare `entries` row when two workspaces
+   * share an install_id. No pool is opened here — org pools are created lazily
+   * by `getForOrg` — so this is an idempotent upsert: re-registering with a new
+   * config replaces it, which is how a datasource config update refreshes
+   * routing.
+   *
+   * Throws (via `detectDBType`) on a non-native URL scheme — callers filter to
+   * postgres/mysql before invoking (plugin-managed pools register on the bare
+   * map via `registerDirect`).
+   */
+  registerForWorkspace(workspaceId: string, installId: string, config: ConnectionConfig): void {
+    const dbType = detectDBType(config.url);
+    const targetHost = extractTargetHost(config.url);
+    this.workspaceEntries.set(this._workspaceKey(workspaceId, installId), {
+      config,
+      dbType,
+      targetHost,
+      ...(config.description !== undefined ? { description: config.description } : {}),
+    });
+  }
+
+  /** Whether a per-(workspace, install_id) base config is registered. */
+  hasForWorkspace(workspaceId: string, installId: string): boolean {
+    return this.workspaceEntries.has(this._workspaceKey(workspaceId, installId));
+  }
+
+  /**
+   * Target host (no credentials) for a per-(workspace, install_id) base config,
+   * or "(unknown)" if none is registered. Used by tests / diagnostics to prove
+   * two workspaces sharing an install_id resolve to independent URLs.
+   */
+  getTargetHostForWorkspace(workspaceId: string, installId: string): string {
+    return this.workspaceEntries.get(this._workspaceKey(workspaceId, installId))?.targetHost ?? "(unknown)";
+  }
+
+  /**
+   * Remove a per-(workspace, install_id) base config. Returns true if one was
+   * present. Org pools already cloned from it are left intact — the
+   * mode-visibility gate (`isConnectionVisibleInMode`) fail-closes queries to
+   * archived installs before `getForOrg` is reached, and LRU / restart reclaims
+   * the idle clone. The bare `entries` row (shared across workspaces for an
+   * install_id) is intentionally NOT touched here so sibling workspaces keep
+   * resolving install-id-keyed metadata.
+   */
+  unregisterForWorkspace(workspaceId: string, installId: string): boolean {
+    return this.workspaceEntries.delete(this._workspaceKey(workspaceId, installId));
   }
 
   /** Register a pre-built connection (e.g. for benchmark harness or datasource plugin). */
@@ -1324,12 +1439,13 @@ export class ConnectionRegistry {
     }
     await Promise.all(closing);
     this.entries.clear();
+    this.workspaceEntries.clear();
     this.orgEntries.clear();
     this.orgAccessSeq.clear();
     _resetWhitelists();
   }
 
-  /** Clears all registered connections (base + org) and resets the table whitelist cache. Used during graceful shutdown, tests, and the benchmark harness. */
+  /** Clears all registered connections (base + per-workspace + org) and resets the table whitelist cache. Used during graceful shutdown, tests, and the benchmark harness. */
   _reset(): void {
     this.stopHealthChecks();
     this.drainCooldownSet.clear();
@@ -1345,6 +1461,7 @@ export class ConnectionRegistry {
       });
     }
     this.entries.clear();
+    this.workspaceEntries.clear();
     this.orgEntries.clear();
     this.orgAccessSeq.clear();
     _resetWhitelists();

--- a/packages/api/src/lib/db/connection.ts
+++ b/packages/api/src/lib/db/connection.ts
@@ -417,7 +417,6 @@ interface RegistryEntry {
 interface WorkspaceBaseEntry {
   config: ConnectionConfig;
   dbType: DBType;
-  description?: string;
   targetHost: string;
 }
 
@@ -635,7 +634,7 @@ export class ConnectionRegistry {
     if (!baseConfig || !baseDbType) {
       throw new ConnectionNotRegisteredError({ message: `Connection "${connectionId}" is not registered.`, id: connectionId });
     }
-    const baseDescription = wsBase?.description ?? baseEntry?.description;
+    const baseDescription = wsBase?.config.description ?? baseEntry?.description;
     const baseTargetHost = wsBase?.targetHost ?? baseEntry?.targetHost ?? "(unknown)";
     const baseValidate = baseEntry?.validate;
     const basePluginMeta = baseEntry?.pluginMeta;
@@ -884,13 +883,26 @@ export class ConnectionRegistry {
       config,
       dbType,
       targetHost,
-      ...(config.description !== undefined ? { description: config.description } : {}),
     });
   }
 
   /** Whether a per-(workspace, install_id) base config is registered. */
   hasForWorkspace(workspaceId: string, installId: string): boolean {
     return this.workspaceEntries.has(this._workspaceKey(workspaceId, installId));
+  }
+
+  /**
+   * Whether ANY workspace still has a per-workspace config for this install_id.
+   * Lets the uninstall path keep the shared bare `entries` row (and its
+   * install-id-keyed metadata) alive until the last workspace owning the
+   * install_id is gone. O(n) over `workspaceEntries` — uninstall is rare.
+   */
+  hasWorkspacePoolsFor(installId: string): boolean {
+    const suffix = `\u0000${installId}`;
+    for (const key of this.workspaceEntries.keys()) {
+      if (key.endsWith(suffix)) return true;
+    }
+    return false;
   }
 
   /**
@@ -904,11 +916,16 @@ export class ConnectionRegistry {
 
   /**
    * Remove a per-(workspace, install_id) base config. Returns true if one was
-   * present. Org pools already cloned from it are left intact — the
-   * mode-visibility gate (`isConnectionVisibleInMode`) fail-closes queries to
-   * archived installs before `getForOrg` is reached, and LRU / restart reclaims
-   * the idle clone. The bare `entries` row (shared across workspaces for an
-   * install_id) is intentionally NOT touched here so sibling workspaces keep
+   * present. Called by the bridge on uninstall / config-delete so the routing
+   * config (which `getForOrg` resolves with priority over the bare entry)
+   * doesn't outlive the install and silently route to a stale URL.
+   *
+   * Only the targeted workspace's config is removed — a sibling workspace
+   * sharing the install_id keeps its own. Org pools already cloned into
+   * `orgEntries` are left intact: the next query re-resolves on cache miss
+   * (falling through to the bare entry, or throwing), and LRU / restart
+   * reclaims the idle clone. The shared bare `entries` row is handled by the
+   * caller via the {@link hasWorkspacePoolsFor} guard so siblings keep
    * resolving install-id-keyed metadata.
    */
   unregisterForWorkspace(workspaceId: string, installId: string): boolean {

--- a/packages/api/src/lib/db/datasource-registry-bridge.ts
+++ b/packages/api/src/lib/db/datasource-registry-bridge.ts
@@ -63,25 +63,39 @@ export function registerDatasourceInstall(
     return false;
   }
 
-  // Idempotent re-register: if the install_id is already registered (boot
-  // ran, or a prior `installDatasource` registered it), keep the existing
-  // pool. The route layer pre-`healthCheck`'s a fresh pool before writing
-  // the DB row, so by the time we reach the bridge the pool is already
-  // healthy and re-registering would tear down its open connections.
-  // `loadSavedConnections` already has the same skip; this guard means the
-  // facade can call the bridge unconditionally after a successful install.
-  if (connections.has(row.installId)) {
-    return false;
-  }
-
-  connections.register(row.installId, {
+  const config = {
     url: poolConfig.url,
     ...(poolConfig.description !== undefined ? { description: poolConfig.description } : {}),
     ...(poolConfig.dbType === "postgres" && poolConfig.schema
       ? { schema: poolConfig.schema }
       : {}),
-  });
-  return true;
+  };
+
+  // Per-(workspace, install_id) config registration — the routing source of
+  // truth that retires the `DISTINCT ON (install_id)` multi-tenant collision
+  // (#2783). `getForOrg(workspaceId, installId)` clones an org pool from THIS
+  // config, so two workspaces sharing an install_id route to their own DBs.
+  // Config-only + upsert (no live pool to tear down), so it's registered
+  // unconditionally — a datasource config update refreshes routing here.
+  const compositeExisted = connections.hasForWorkspace(row.workspaceId, row.installId);
+  connections.registerForWorkspace(row.workspaceId, row.installId, config);
+
+  // Bare install-id registration keeps install-id-keyed readers
+  // (getDBType / getTargetHost / validators) and self-hosted
+  // `connections.get(installId)` working. Idempotent on the bare id so a
+  // healthy pre-registered pool isn't torn down — the route layer
+  // pre-`healthCheck`'s a fresh pool before writing the DB row, and boot's
+  // `loadSavedConnections` registers the first workspace's row. Two workspaces
+  // sharing an install_id collapse onto one bare row by design (it backs only
+  // install-id-keyed metadata, not routing — routing uses the per-workspace
+  // config above).
+  const bareExisted = connections.has(row.installId);
+  if (!bareExisted) {
+    connections.register(row.installId, config);
+  }
+
+  // Fresh if either registration newly landed — the boot loader counts these.
+  return !compositeExisted || !bareExisted;
 }
 
 /**

--- a/packages/api/src/lib/db/datasource-registry-bridge.ts
+++ b/packages/api/src/lib/db/datasource-registry-bridge.ts
@@ -39,9 +39,11 @@ import {
  * with the `ConnectionRegistry`.
  *
  * Returns:
- *   - `true`  — a fresh registration was performed
- *   - `false` — either the dbType is plugin-managed (filter short-circuit)
- *               or the install_id was already registered (idempotent re-register)
+ *   - `true`  — a fresh registration was performed (the per-(workspace,
+ *               install_id) config and/or the bare install_id row was new)
+ *   - `false` — either the dbType is plugin-managed (filter short-circuit) or
+ *               BOTH the per-(workspace, install_id) config and the bare
+ *               install_id were already registered (full idempotent re-register)
  *
  * Throws on any resolver violation (missing required field, invalid
  * schema identifier, unknown catalog slug). Resolver runs before the
@@ -76,7 +78,10 @@ export function registerDatasourceInstall(
   // (#2783). `getForOrg(workspaceId, installId)` clones an org pool from THIS
   // config, so two workspaces sharing an install_id route to their own DBs.
   // Config-only + upsert (no live pool to tear down), so it's registered
-  // unconditionally — a datasource config update refreshes routing here.
+  // unconditionally — a datasource config update replaces the base config used
+  // for SUBSEQUENT org-pool clones here (an org pool already cloned into
+  // `orgEntries` keeps the prior config until it's evicted/restarted — see
+  // #3109 for eager org-pool drain on update).
   const compositeExisted = connections.hasForWorkspace(row.workspaceId, row.installId);
   connections.registerForWorkspace(row.workspaceId, row.installId, config);
 
@@ -100,16 +105,30 @@ export function registerDatasourceInstall(
 
 /**
  * Unregister an install from the `ConnectionRegistry`. Returns `false`
- * when the install was not registered (plugin-managed pool, or a soft-
- * archived row that never landed in the registry). Mirrors
- * {@link registerDatasourceInstall} so the install / uninstall paths in
- * `WorkspaceInstaller` stay symmetric.
+ * when nothing was registered (plugin-managed pool, or a soft-archived row
+ * that never landed in the registry). Mirrors {@link registerDatasourceInstall}
+ * so the install / uninstall paths in `WorkspaceInstaller` stay symmetric.
  *
- * The registry's own `unregister` throws if the id isn't present; we
- * guard with `has()` so the soft-archive path (status → archived) is a
- * no-op when the row was never pooled (e.g. clickhouse).
+ * Symmetric with the dual-registration in {@link registerDatasourceInstall}:
+ *  1. Removes the per-(workspace, install_id) routing config — `getForOrg`
+ *     resolves it with priority over the bare entry, so leaving it would let
+ *     an uninstalled datasource keep routing to a stale URL (#2783).
+ *  2. Removes the shared bare `entries` row ONLY when no OTHER workspace still
+ *     owns the install_id (`hasWorkspacePoolsFor`). A sibling sharing the
+ *     install_id keeps the bare row so its install-id-keyed metadata
+ *     (getDBType / getTargetHost / validators) keeps resolving.
+ *
+ * The registry's own `unregister` throws if the id isn't present; we guard
+ * with `has()` so the soft-archive path (status → archived) is a no-op when
+ * the row was never pooled (e.g. clickhouse).
  */
-export function unregisterDatasourceInstall(installId: string): boolean {
-  if (!connections.has(installId)) return false;
-  return connections.unregister(installId);
+export function unregisterDatasourceInstall(workspaceId: string, installId: string): boolean {
+  const removedWorkspace = connections.unregisterForWorkspace(workspaceId, installId);
+  // Drop the shared bare row only once the last workspace owning this
+  // install_id is gone — siblings keep their install-id-keyed metadata.
+  const removedBare =
+    !connections.hasWorkspacePoolsFor(installId) &&
+    connections.has(installId) &&
+    connections.unregister(installId);
+  return removedWorkspace || removedBare;
 }

--- a/packages/api/src/lib/db/internal.ts
+++ b/packages/api/src/lib/db/internal.ts
@@ -953,17 +953,16 @@ export async function migrateInternalDB(): Promise<void> {
  * translates the resulting (row, decrypted config) pair into the typed
  * `DatasourcePoolConfig` we hand to `ConnectionRegistry.register`.
  *
- * Multi-tenant note: today's pre-cutover registry has a long-standing
- * bug where two workspaces sharing an `install_id` (e.g. both naming
- * their warehouse `warehouse`, or both auto-owning the demo at
- * `install_id='__demo__'`) collapse onto a single base URL via
- * `DISTINCT ON (id)`. The cleanest fix is per-(workspace, install_id)
- * registration, but that's a deeper ConnectionRegistry refactor than
- * this slice carries — slice 6 preserves today's behaviour (`DISTINCT
- * ON (install_id)` picks the most-recently-installed row) and #2783
- * tracks the per-(workspace, install_id) refactor. The `default`
- * connection (auto-initialised from `ATLAS_DATASOURCE_URL`) continues
- * to be runtime-only and is NOT touched here.
+ * Multi-tenant (#2783): loads EVERY non-archived datasource install — one
+ * row per (workspace_id, install_id) — and registers each via the bridge,
+ * which keys the routing config by (workspace_id, install_id). Two workspaces
+ * sharing an `install_id` (e.g. both naming their warehouse `warehouse`, or
+ * both auto-owning the demo at `install_id='__demo__'`) therefore get
+ * independent base configs instead of collapsing onto a single base URL — the
+ * old `DISTINCT ON (install_id)` hack that silently routed one workspace's
+ * queries to the other's DB is gone. The `default` connection (auto-initialised
+ * from `ATLAS_DATASOURCE_URL`) continues to be runtime-only and is NOT touched
+ * here.
  */
 export async function loadSavedConnections(): Promise<number> {
   if (!hasInternalDB()) return 0;
@@ -989,14 +988,14 @@ export async function loadSavedConnections(): Promise<number> {
       config: Record<string, unknown> | null;
       config_schema: unknown;
     };
-    // Exclude `status = 'archived'` so per-workspace demo-hide rows
-    // never feed their decrypted URL to the registry. `DISTINCT ON
-    // (install_id)` preserves today's pre-cutover behaviour where two
-    // workspaces sharing an install_id collapse onto the most-recently-
-    // installed row's URL — see the multi-tenant note above.
+    // Exclude `status = 'archived'` so per-workspace demo-hide rows never
+    // feed their decrypted URL to the registry. One row per (workspace_id,
+    // install_id) — the bridge keys routing config by that composite, so two
+    // workspaces sharing an install_id no longer collapse (#2783, retires the
+    // old `DISTINCT ON (install_id)` hack). Deterministic order so the bare
+    // install-id metadata row (first-write-wins, see the bridge) is stable.
     const rows = await internalQuery<WpRow>(
-      `SELECT DISTINCT ON (wp.install_id)
-              wp.workspace_id,
+      `SELECT wp.workspace_id,
               wp.install_id,
               pc.slug AS catalog_slug,
               wp.config,
@@ -1006,7 +1005,7 @@ export async function loadSavedConnections(): Promise<number> {
         WHERE wp.pillar = 'datasource'
           AND wp.status != 'archived'
           AND pc.slug = ANY($1::text[])
-        ORDER BY wp.install_id, wp.installed_at DESC, wp.workspace_id ASC`,
+        ORDER BY wp.install_id, wp.workspace_id ASC, wp.installed_at DESC`,
       [BUILTIN_DATASOURCE_CATALOG_SLUGS as readonly string[]],
     );
 

--- a/packages/api/src/lib/effect/__tests__/workspace-installer.test.ts
+++ b/packages/api/src/lib/effect/__tests__/workspace-installer.test.ts
@@ -181,7 +181,7 @@ const mockBridgeRegister = mock(
     return true;
   },
 );
-const mockBridgeUnregister = mock((installId: string) => {
+const mockBridgeUnregister = mock((_workspaceId: string, installId: string) => {
   bridgeUnregisterCalls.push(installId);
   return true;
 });
@@ -236,7 +236,7 @@ function resetState() {
       return true;
     },
   );
-  mockBridgeUnregister.mockImplementation((installId: string) => {
+  mockBridgeUnregister.mockImplementation((_workspaceId: string, installId: string) => {
     bridgeUnregisterCalls.push(installId);
     return true;
   });

--- a/packages/api/src/lib/effect/workspace-installer.ts
+++ b/packages/api/src/lib/effect/workspace-installer.ts
@@ -702,8 +702,8 @@ export interface WorkspaceInstallerShape {
    * tooling / migration scripts; the admin UI uses soft archive
    * exclusively.
    *
-   * Both paths call `unregisterDatasourceInstall(installId)` so live
-   * queries against the install fail-closed immediately, matching the
+   * Both paths call `unregisterDatasourceInstall(workspaceId, installId)` so
+   * live queries against the install fail-closed immediately, matching the
    * legacy route's `connections.unregister` side-effect.
    */
   readonly uninstallDatasource: (
@@ -723,8 +723,8 @@ export interface WorkspaceInstallerShape {
    *
    * URL changes are NOT registered automatically; the route owns the
    * test-connect-then-update dance. After a successful write the
-   * facade does call `unregisterDatasourceInstall(installId)` to evict
-   * the now-stale pool — the next query rebuilds from the new config.
+   * facade does call `unregisterDatasourceInstall(workspaceId, installId)` to
+   * evict the now-stale pool — the next query rebuilds from the new config.
    */
   readonly updateDatasourceConfig: (
     workspaceId: WorkspaceId,
@@ -1573,7 +1573,7 @@ function makeWorkspaceInstallerService(): WorkspaceInstallerShape {
       // Tear the pool down whichever path we took — live queries against
       // the archived install fail-closed immediately rather than at TTL.
       try {
-        lazyDatasourceBridge().unregisterDatasourceInstall(installId);
+        lazyDatasourceBridge().unregisterDatasourceInstall(workspaceId, installId);
       } catch (err) {
         log.warn(
           {
@@ -1730,7 +1730,7 @@ function makeWorkspaceInstallerService(): WorkspaceInstallerShape {
       // against an unregistered install throws `ConnectionNotRegisteredError`
       // until next boot (codex P1, #2784).
       try {
-        lazyDatasourceBridge().unregisterDatasourceInstall(installId);
+        lazyDatasourceBridge().unregisterDatasourceInstall(workspaceId, installId);
       } catch (err) {
         log.warn(
           {


### PR DESCRIPTION
## What & why

Fixes the multi-tenant `ConnectionRegistry` collision (#2783).

`loadSavedConnections` registered one base pool per `install_id` via `DISTINCT ON (install_id)`. In SaaS — where `pool.perOrg` is configured (`deploy/api/atlas.config.ts`), so org pooling is ON — **every** query routes through `getForOrg(orgId, installId)`, which cloned an org-scoped pool from that single shared base entry. Two workspaces owning datasource installs that share an `install_id` (the demo case: every workspace auto-owns the demo at `install_id='__demo__'`; or two workspaces both name their warehouse `warehouse`) therefore collapsed onto one URL — the second tenant's queries silently routed to the first's DB. That's a data-isolation defect, so correctness here trumps features.

## Approach

Blast radius kept to **registry + loader + bridge glue + tests** (per the issue's scope; the read-side `connections.get(installId)` callers are deferred to #3109).

- **`connection.ts`** — `ConnectionRegistry` gains a **config-only** `workspaceEntries` map keyed by `(workspace_id, install_id)` (holds no live pool — `getForOrg` clones on demand). `getForOrg` resolves the per-workspace config first, falling back to the bare `entries` row for the runtime-only `default`, region pools, plugin-managed connections, and self-hosted single-tenant installs. New primitives: `registerForWorkspace` / `hasForWorkspace` / `getTargetHostForWorkspace` / `unregisterForWorkspace`.
- **`internal.ts`** (`loadSavedConnections`) — drops `DISTINCT ON`, loads every non-archived datasource install (one row per `(workspace_id, install_id)`).
- **`datasource-registry-bridge.ts`** — registers per-workspace (config-only upsert) **and** keeps the bare registration, so install-id-keyed readers (`getDBType` / `getTargetHost` / validators) and self-hosted `connections.get(installId)` keep working unchanged — **no reader churn, no async, no installer changes**. Uninstall leaves a benign mode-gated-stale config entry (`isConnectionVisibleInMode` fail-closes archived installs before `getForOrg`); config updates refresh via the upsert.

The `default` connection stays runtime-only / single-instance.

## Acceptance criteria

- [x] Two workspaces sharing an `install_id` get independent base pools (no collapse) — `internal.test.ts` (loader), `datasource-registry-bridge.test.ts` (bridge), `tenant-pool.test.ts` (`getForOrg` clones independently).
- [x] `default` connection stays runtime-only / single-instance.
- [x] Regression test in `db/__tests__/internal.test.ts` asserts the collision is gone (RED-verified against the pre-fix bridge).

## Testing

- `bun run test` (full suite) — pass. Type, lint, syncpack, template/security/railway/schema/oauth/test-discipline/twenty/published-symbols drift gates — all pass.
- Regression tests verified RED: simulating the pre-fix bridge, the loader test reports `count=1` (collapse) and the bridge test's second-workspace registration returns `false`.

## Follow-up

#3109 — thread workspace context through the bare `connections.get(installId)` read paths + eager composite-entry lifecycle on uninstall/update.

Closes #2783

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3110"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783014776&installation_id=135337507&pr_number=3110&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3110&signature=291d4846175f260d69c70e27e151af33c2e085ff2cab9d437594f3235801902b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved multi-tenant routing collisions: workspaces that share the same datasource installation now keep independent connection settings, preventing config conflicts and ensuring correct connection selection per workspace.
  * Improved install/uninstall behavior so registrations and removals are workspace-aware and idempotent, reducing stale routing and improving stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->