### PR TITLE
refactor(residency): key region routing through Record<DeployRegion, …> (#2983)

### DIFF
--- a/ee/src/platform/residency.test.ts
+++ b/ee/src/platform/residency.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, mock } from "bun:test";
 import { Effect } from "effect";
+import { isDeployRegion } from "@useatlas/types";
 import { createEEMock } from "../__mocks__/internal";
 
 // ── Mocks ───────────────────────────────────────────────────────────
@@ -85,6 +86,7 @@ const {
   resolveRegionDatabaseUrl,
   listWorkspaceRegions,
   isConfiguredRegion,
+  DEPLOY_REGION_ROUTING,
   ResidencyError,
 } = await import("./residency");
 
@@ -244,6 +246,31 @@ describe("residency", () => {
       expect(result).toBeNull();
     });
 
+    it("a closed deploy region marked 'residency' (us) routes through the residency map (#2983)", async () => {
+      // `us` is a closed DeployRegion (isDeployRegion("us") === true) but its
+      // DEPLOY_REGION_ROUTING intent is "residency", so it must NOT short-circuit
+      // like the "local" staging arm — it falls through to the structural
+      // config.residency.regions["us"] lookup and resolves a real datasource. No
+      // staging-exclusion log fires.
+      mockConfig = {
+        residency: {
+          regions: {
+            us: { label: "US", databaseUrl: "postgresql://us/atlas", datasourceUrl: "postgresql://us/data" },
+          },
+          defaultRegion: "us",
+        },
+      };
+      mockRows.push([{ region: "us" }]);
+      const result = await run(resolveRegionDatabaseUrl("org-1"));
+      expect(result).not.toBeNull();
+      expect(result!.region).toBe("us");
+      expect(result!.databaseUrl).toBe("postgresql://us/atlas");
+      expect(result!.datasourceUrl).toBe("postgresql://us/data");
+      expect(loggerDebugs).toHaveLength(0);
+      expect(loggerWarns).toHaveLength(0);
+      expect(loggerErrors).toHaveLength(0);
+    });
+
     // ── Staging arm (#2908 / #3097) ───────────────────────────────────
     // Staging is a DeployRegion but never a residency target — a
     // staging-keyed workspace always falls through to the local DB connection
@@ -375,6 +402,44 @@ describe("residency", () => {
     it("returns false when residency is not configured", () => {
       mockConfig = {};
       expect(isConfiguredRegion("us-east")).toBe(false);
+    });
+  });
+
+  // ── Routing intent table (#2983) ──────────────────────────────────────
+  // DEPLOY_REGION_ROUTING is the SSOT for the residency-vs-local decision in
+  // resolveRegionDatabaseUrl. Its `Record<DeployRegion, …>` type is the real
+  // tripwire: adding a member to the DeployRegion union fails to compile until
+  // its routing intent is recorded here. These runtime assertions pin the
+  // *values* and confirm the table composes with (rather than duplicates) the
+  // DEPLOY_REGIONS tuple guard — every key is a genuine closed DeployRegion and
+  // every value is a recognised intent.
+  describe("DEPLOY_REGION_ROUTING (#2983)", () => {
+    it("records a routing intent for exactly the four deploy regions", () => {
+      expect(Object.keys(DEPLOY_REGION_ROUTING).toSorted()).toEqual([
+        "apac",
+        "eu",
+        "staging",
+        "us",
+      ]);
+    });
+
+    it("every key is a genuine closed DeployRegion (no open Region keys)", () => {
+      for (const region of Object.keys(DEPLOY_REGION_ROUTING)) {
+        expect(isDeployRegion(region)).toBe(true);
+      }
+    });
+
+    it("every intent is 'residency' or 'local'", () => {
+      for (const intent of Object.values(DEPLOY_REGION_ROUTING)) {
+        expect(["residency", "local"]).toContain(intent);
+      }
+    });
+
+    it("us/eu/apac route to residency; staging routes to local", () => {
+      expect(DEPLOY_REGION_ROUTING.us).toBe("residency");
+      expect(DEPLOY_REGION_ROUTING.eu).toBe("residency");
+      expect(DEPLOY_REGION_ROUTING.apac).toBe("residency");
+      expect(DEPLOY_REGION_ROUTING.staging).toBe("local");
     });
   });
 

--- a/ee/src/platform/residency.ts
+++ b/ee/src/platform/residency.ts
@@ -31,7 +31,7 @@ import {
   ResidencyError,
   type ResidencyErrorCode,
 } from "@atlas/api/lib/residency/errors";
-import type { DeployRegion, RegionStatus, WorkspaceRegion } from "@useatlas/types";
+import { isDeployRegion, type DeployRegion, type RegionStatus, type WorkspaceRegion } from "@useatlas/types";
 
 const log = createLogger("ee:residency");
 
@@ -46,6 +46,36 @@ const log = createLogger("ee:residency");
  * here rather than silently re-enabling routing.
  */
 const STAGING_REGION = "staging" satisfies DeployRegion;
+
+/**
+ * Per-deploy-region routing intent (#2983). Maps every closed first-party
+ * {@link DeployRegion} to whether `resolveRegionDatabaseUrl` routes it through
+ * the residency pool (`"residency"`) or short-circuits to a `null` route that
+ * falls through to the local DB connection (`"local"`).
+ *
+ * The point is to force a *conscious* decision per region. Because the type is
+ * keyed `Record<DeployRegion, …>`, adding a member to the `DeployRegion` union
+ * fails to type-check this table until its routing intent is recorded here — a
+ * new region can never silently inherit a default route through the structural
+ * `config.residency.regions[region]` lookup. This COMPLEMENTS, and does not
+ * duplicate, `_AssertDeployRegionsExhaustive` in `@useatlas/types`: that guard
+ * keeps the runtime `DEPLOY_REGIONS` tuple in sync with the union (tuple
+ * membership); this keeps the *routing intent* in sync with it.
+ *
+ * Today only `staging` routes `"local"` (the pre-prod soak instance — see
+ * {@link STAGING_REGION}); `us` / `eu` / `apac` are real residency targets.
+ * Mind the OPEN/CLOSED distinction (see `@useatlas/types` `deploy.ts`): only the
+ * closed `DeployRegion` union keys this table. A workspace's stored region is an
+ * OPEN `Region` string (operator-defined, e.g. `us-east`) and is NOT keyed here,
+ * so callers must narrow through `isDeployRegion` before consulting it — open
+ * regions route through the residency map directly.
+ */
+export const DEPLOY_REGION_ROUTING: Record<DeployRegion, "residency" | "local"> = {
+  us: "residency",
+  eu: "residency",
+  apac: "residency",
+  staging: "local",
+};
 
 // ── Typed errors ────────────────────────────────────────────────────
 
@@ -219,9 +249,15 @@ export const resolveRegionDatabaseUrl = (
     const region = yield* Effect.promise(() => getWorkspaceRegion(workspaceId));
     if (!region) return null;
 
-    // Staging arm (#2908): the staging deploy region is never a residency
-    // target. Return null *before* the regionConfig lookup so a staging-keyed
-    // workspace falls through to the local DB connection — without tripping
+    // Staging arm (#2983 / #2908): the per-deploy-region routing table
+    // (DEPLOY_REGION_ROUTING) marks staging `"local"`, so it is never a
+    // residency target. `region` is an OPEN `Region` string, so the guard below
+    // narrows it through `isDeployRegion` before consulting the (closed-union-
+    // keyed) table — open operator-defined regions are not keyed there and fall
+    // through to the residency map; closed deploy regions marked `"residency"`
+    // (us|eu|apac) likewise fall through, so only `"local"` regions short-
+    // circuit here. Return null *before* the regionConfig lookup so a staging-
+    // keyed workspace falls through to the local DB connection — without tripping
     // the "region no longer configured / contract may be violated" error path
     // below. Short-circuiting here also wins over any `staging` entry in
     // residency.regions, so staging can never claim to be a residency-mapped
@@ -243,7 +279,7 @@ export const resolveRegionDatabaseUrl = (
     // `stagingInResidencyConfig` is retained in the event payload for operator
     // context (it tells prod operators a dead entry sits in their map) but no
     // longer gates the log level.
-    if (region === STAGING_REGION) {
+    if (isDeployRegion(region) && DEPLOY_REGION_ROUTING[region] === "local") {
       const stagingInResidencyConfig = STAGING_REGION in config.residency.regions;
       const onStagingDeploy = resolveDeployEnv() === "staging";
       const event = {

--- a/ee/src/platform/residency.ts
+++ b/ee/src/platform/residency.ts
@@ -70,12 +70,12 @@ const STAGING_REGION = "staging" satisfies DeployRegion;
  * so callers must narrow through `isDeployRegion` before consulting it — open
  * regions route through the residency map directly.
  */
-export const DEPLOY_REGION_ROUTING: Record<DeployRegion, "residency" | "local"> = {
+export const DEPLOY_REGION_ROUTING = {
   us: "residency",
   eu: "residency",
   apac: "residency",
   staging: "local",
-};
+} as const satisfies Record<DeployRegion, "residency" | "local">;
 
 // ── Typed errors ────────────────────────────────────────────────────
 


### PR DESCRIPTION
## What

Force a *conscious* residency-vs-local routing decision for every `DeployRegion` by keying it through a `Record<DeployRegion, "residency" | "local">`. Adding a region now fails compilation until its routing intent is recorded.

Closes #2983.

## Why

Residency resolution was **structural**: `resolveRegionDatabaseUrl` (`ee/src/platform/residency.ts`) reached the `config.residency.regions[region]` dictionary lookup for every non-staging region. A newly-added `DeployRegion` would silently flow through that default route with no routing decision — exactly the seam #2983 calls out.

The existing `_AssertDeployRegionsExhaustive` guard in `@useatlas/types` (`deploy.ts`) keeps the runtime `DEPLOY_REGIONS` **tuple** in sync with the union — but it does **not** force a routing-intent decision. This table complements that guard rather than duplicating it.

## How

- New `DEPLOY_REGION_ROUTING: Record<DeployRegion, "residency" | "local">` (EE-local, in the residency module):
  - `us` / `eu` / `apac` → `"residency"`
  - `staging` → `"local"`
- `resolveRegionDatabaseUrl` routes through it: `isDeployRegion(region) && DEPLOY_REGION_ROUTING[region] === "local"` replaces the old `region === STAGING_REGION` check.
- Respects the OPEN/CLOSED distinction: the workspace's stored region is an OPEN `Region` string (operator-defined, e.g. `us-east`), so it's narrowed through `isDeployRegion` before the closed-union-keyed table is consulted. Open regions still route through the residency map directly.
- The condition is **semantically identical** to the old one today (staging is the only `"local"` region), so `us|eu|apac|staging` behavior — including the deploy-aware staging observability (#3097) — is preserved verbatim.

## Acceptance criteria

- [x] Adding a `DeployRegion` member triggers a compile error until its routing intent is recorded — **verified empirically**: temporarily adding a 5th region (`ca`) to the union *and* the tuple produced exactly `residency.ts: TS2741: Property 'ca' is missing ... required in type 'Record<DeployRegion, ...>'`, while `_AssertDeployRegionsExhaustive` in `deploy.ts` stayed silent (composition, not duplication).
- [x] `us|eu|apac|staging` behavior unchanged — full staging 2×2 truth-table tests still pass; added a `us`-routes-through-residency case.
- [x] Doesn't duplicate the `_AssertDeployRegionsExhaustive` guard — composes with it (tuple membership vs routing intent).

## Tests

- `DEPLOY_REGION_ROUTING (#2983)` describe block: tripwire + value assertions (keys are exactly the 4 deploy regions, every key passes `isDeployRegion`, every value is a recognised intent, correct mappings).
- `resolveRegionDatabaseUrl`: new case proving a closed deploy region marked `"residency"` (`us`) falls through to the structural lookup (not the staging short-circuit) with no exclusion log.

## Verification

- `ee/src/platform/residency.test.ts`: 29 pass (24 prior + 5 new)
- `cd ee && bun run scripts/test-isolated.ts --affected`: 27/27 files pass
- `bun run type`: clean (EXIT 0)
- `eslint` on both files: clean
- `scripts/check-ee-imports.sh`: passes — change stays in `ee/`, no core→ee import introduced

## Notes

EE file — the core/ee inversion is intact. The table imports `DeployRegion` / `isDeployRegion` from `@useatlas/types` (shared package), not from core. No new published-package surface (`isDeployRegion` was already exported; `DEPLOY_REGIONS` deliberately **not** exported to avoid the `@useatlas/types` publish dance).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3111"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783020168&installation_id=135337507&pr_number=3111&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3111&signature=b932f8365ef16685f0048adfe8eb7cb377a5642e6d0731330175a094ca119f81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized routing-intent configuration for deploy regions to improve residency vs. local routing decisions.

* **New Features**
  * Explicit deploy-region routing table: production regions route to residency while staging routes locally.

* **Tests**
  * Added test coverage validating the routing table entries, that regions resolve to the expected routing intent, and that residency resolution emits no unexpected logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->