### PR TITLE
feat(scheduler): per-tick spans for background-work fibers (#2987)

### DIFF
--- a/packages/api/src/lib/effect/__tests__/layers.test.ts
+++ b/packages/api/src/lib/effect/__tests__/layers.test.ts
@@ -24,6 +24,7 @@ import {
   CatalogSeed,
   BuiltinDatasourceCatalogSeed,
   SCHEDULER_CLEANUP_SPAN_NAMES,
+  SCHEDULER_WORK_SPAN_NAMES,
   type ConfigShape,
   type MigrationShape,
   type SettingsShape,
@@ -316,96 +317,123 @@ describe("makeSchedulerLive", () => {
     await rt.dispose();
   });
 
-  // ── Per-tick observability spans on the cleanup fibers (#2945, #2944) ──
-  // The 9 periodic cleanup fibers are forked internally and not exposed
-  // through the `Scheduler` Tag, so the span wrapping can't be asserted by
-  // introspecting OTel without standing up an in-memory trace exporter
-  // (would add `@opentelemetry/sdk-trace-base` to @atlas/api devDeps — out
-  // of scope). Instead:
-  //   (a) the production wrap sites derive their span name from the
-  //       `SCHEDULER_CLEANUP_SPAN_NAMES` record, and the derivation/prefix
-  //       guard below pins that record's shape; and
-  //   (b) a structural source-scan guard asserts each of the 9 keys is
-  //       actually referenced by a `withEffectSpan(SCHEDULER_CLEANUP_SPAN_NAMES.<key>`
-  //       call site, and that there are exactly 9 such call sites.
+  // ── Per-tick observability spans on the periodic fibers (#2945, #2944, #2987) ──
+  // The inline-forked periodic fibers are not exposed through the `Scheduler`
+  // Tag, so the span wrapping can't be asserted by introspecting OTel without
+  // standing up an in-memory trace exporter (would add
+  // `@opentelemetry/sdk-trace-base` to @atlas/api devDeps — out of scope).
+  // Instead, for each single-source span-name record:
+  //   (a) the production wrap sites derive their span name from the record,
+  //       and the derivation/prefix guard below pins that record's shape; and
+  //   (b) a structural source-scan guard asserts each key is referenced by a
+  //       `withEffectSpan(<RECORD>.<key>` call site, and that the call-site
+  //       count matches the record exactly.
   // Together these make "rename a span" AND "delete a wrap at a call site"
-  // (the precise regression #2945 exists to prevent) both fail here.
-  describe("cleanup-fiber observability spans (#2945, #2944)", () => {
-    // The fiber keys are the real contract — each cleanup fiber must emit a
-    // per-tick span. Eight were retrofitted by #2945; `orphan_task_reconcile`
-    // (#2944) shipped with its span and is the only member that also attaches
-    // a result attribute (the orphan count).
-    const EXPECTED_FIBER_KEYS = [
-      "oauth_state_cleanup",
-      "rate_limit_cleanup",
-      "demo_rate_limit_cleanup",
-      "contact_rate_limit_cleanup",
-      "abuse_cleanup",
-      "dashboard_rate_limit_cleanup",
-      "conversation_rate_sweep",
-      "share_token_cleanup",
-      "orphan_task_reconcile",
-    ] as const;
+  // (the precise regression these spans exist to prevent) both fail here.
+  //
+  // Two records: cleanup/sweep fibers (#2945/#2944) and background-work fibers
+  // (#2987). The CRM/email outbox flushers are deliberately absent from both —
+  // they carry heartbeat + stall-watchdog liveness instead of a per-tick span
+  // (see the layers.ts block comment for the rationale and exclusion list).
+  const layersSource = readFileSync(
+    fileURLToPath(new URL("../layers.ts", import.meta.url)),
+    "utf8",
+  );
 
-    test("covers exactly the 9 named cleanup fibers", () => {
-      expect(Object.keys(SCHEDULER_CLEANUP_SPAN_NAMES).toSorted()).toEqual(
-        [...EXPECTED_FIBER_KEYS].toSorted(),
-      );
-    });
+  const SPAN_RECORDS = [
+    {
+      // Cleanup/sweep fibers. Eight were retrofitted by #2945;
+      // `orphan_task_reconcile` (#2944) shipped with its span and is the only
+      // member (of either record) that also attaches a result attribute (the
+      // orphan count).
+      constName: "SCHEDULER_CLEANUP_SPAN_NAMES",
+      record: SCHEDULER_CLEANUP_SPAN_NAMES as Record<string, string>,
+      expectedKeys: [
+        "oauth_state_cleanup",
+        "rate_limit_cleanup",
+        "demo_rate_limit_cleanup",
+        "contact_rate_limit_cleanup",
+        "abuse_cleanup",
+        "dashboard_rate_limit_cleanup",
+        "conversation_rate_sweep",
+        "share_token_cleanup",
+        "orphan_task_reconcile",
+      ],
+    },
+    {
+      // Background-work fibers spanned by #2987. `settings_refresh` is forked
+      // in `SettingsLive`; the other three in `makeSchedulerLive`. The source
+      // scan reads the whole file, so the defining function doesn't matter.
+      constName: "SCHEDULER_WORK_SPAN_NAMES",
+      record: SCHEDULER_WORK_SPAN_NAMES as Record<string, string>,
+      expectedKeys: [
+        "sub_processor_publisher",
+        "settings_refresh",
+        "onboarding_email",
+        "expert_scheduler",
+      ],
+    },
+  ] as const;
 
-    test("derives each span name as dotted atlas.scheduler.<fiber> (no bare snake_case label)", () => {
-      const entries: ReadonlyArray<[string, string]> = Object.entries(
-        SCHEDULER_CLEANUP_SPAN_NAMES,
-      );
-      for (const [fiber, span] of entries) {
-        // Convention guard from the #2945 LOW finding: the dotted prefix
-        // must survive; the op segment intentionally mirrors the fiber's
-        // `withFiberDeathLog` label (underscores within the op are fine).
-        expect(span).toBe(`atlas.scheduler.${fiber}`);
-        expect(span.startsWith("atlas.scheduler.")).toBe(true);
-        expect(span).not.toBe(fiber);
-      }
-    });
+  for (const { constName, record, expectedKeys } of SPAN_RECORDS) {
+    describe(`${constName} per-tick spans`, () => {
+      // The fiber keys are the real contract — each fiber must emit a per-tick
+      // span.
+      test("covers exactly the named fibers", () => {
+        expect(Object.keys(record).toSorted()).toEqual(
+          [...expectedKeys].toSorted(),
+        );
+      });
 
-    // Structural wiring guard: the name-set tests above prove the const is
-    // correct, but a wrap site can be deleted while every other test stays
-    // green — re-hiding the exact regression #2945 prevents. Scan the
-    // `layers.ts` source and assert each of the 9 keys is referenced by a
-    // `withEffectSpan(SCHEDULER_CLEANUP_SPAN_NAMES.<key>` call AND that there
-    // are exactly 9 such call sites, so deleting/adding a wrap fails here.
-    // (A full in-memory OTel exporter test was rejected as too heavy — see
-    // the block comment above; this source scan is the pragmatic guard.)
-    describe("wrap-site wiring guard", () => {
-      const layersSource = readFileSync(
-        fileURLToPath(new URL("../layers.ts", import.meta.url)),
-        "utf8",
-      );
-      // Matches `withEffectSpan(SCHEDULER_CLEANUP_SPAN_NAMES.<key>` tolerating
-      // arbitrary whitespace/newlines around the call paren and the dot.
-      const wrapCallRegex =
-        /withEffectSpan\s*\(\s*SCHEDULER_CLEANUP_SPAN_NAMES\s*\.\s*([A-Za-z_][A-Za-z0-9_]*)/g;
-
-      test("each of the 9 fibers has a withEffectSpan wrap site", () => {
-        for (const key of EXPECTED_FIBER_KEYS) {
-          const perKey = new RegExp(
-            `withEffectSpan\\s*\\(\\s*SCHEDULER_CLEANUP_SPAN_NAMES\\s*\\.\\s*${key}\\b`,
-          );
-          expect(layersSource).toMatch(perKey);
+      test("derives each span name as dotted atlas.scheduler.<fiber> (no bare snake_case label)", () => {
+        for (const [fiber, span] of Object.entries(record)) {
+          // Convention guard from the #2945 LOW finding: the dotted prefix
+          // must survive; the op segment intentionally mirrors the fiber's
+          // `withFiberDeathLog` label (underscores within the op are fine).
+          expect(span).toBe(`atlas.scheduler.${fiber}`);
+          expect(span.startsWith("atlas.scheduler.")).toBe(true);
+          expect(span).not.toBe(fiber);
         }
       });
 
-      test("there are exactly 9 SCHEDULER_CLEANUP_SPAN_NAMES wrap sites", () => {
-        const matchedKeys = [...layersSource.matchAll(wrapCallRegex)].map(
-          (m) => m[1],
+      // Structural wiring guard: the name-set test above proves the const is
+      // correct, but a wrap site can be deleted while every other test stays
+      // green — re-hiding the exact regression these spans prevent. Scan the
+      // `layers.ts` source and assert each key is referenced by a
+      // `withEffectSpan(<constName>.<key>` call AND that the call-site count
+      // matches the record exactly, so deleting/adding a wrap fails here.
+      // (A full in-memory OTel exporter test was rejected as too heavy — see
+      // the block comment above; this source scan is the pragmatic guard.)
+      describe("wrap-site wiring guard", () => {
+        // Matches `withEffectSpan(<constName>.<key>` tolerating arbitrary
+        // whitespace/newlines around the call paren and the dot.
+        const wrapCallRegex = new RegExp(
+          `withEffectSpan\\s*\\(\\s*${constName}\\s*\\.\\s*([A-Za-z_][A-Za-z0-9_]*)`,
+          "g",
         );
-        expect(matchedKeys).toHaveLength(9);
-        // Every matched call site references a known fiber key — guards
-        // against a typo'd `.foo` reference that wouldn't type-check anyway
-        // but keeps the scan honest if the const is widened later.
-        expect(matchedKeys.toSorted()).toEqual([...EXPECTED_FIBER_KEYS].toSorted());
+
+        test("each fiber has a withEffectSpan wrap site", () => {
+          for (const key of expectedKeys) {
+            const perKey = new RegExp(
+              `withEffectSpan\\s*\\(\\s*${constName}\\s*\\.\\s*${key}\\b`,
+            );
+            expect(layersSource).toMatch(perKey);
+          }
+        });
+
+        test(`there are exactly ${expectedKeys.length} ${constName} wrap sites`, () => {
+          const matchedKeys = [...layersSource.matchAll(wrapCallRegex)].map(
+            (m) => m[1],
+          );
+          expect(matchedKeys).toHaveLength(expectedKeys.length);
+          // Every matched call site references a known fiber key — guards
+          // against a typo'd `.foo` reference that wouldn't type-check anyway
+          // but keeps the scan honest if the const is widened later.
+          expect(matchedKeys.toSorted()).toEqual([...expectedKeys].toSorted());
+        });
       });
     });
-  });
+  }
 });
 
 // ── DpaGuardLive (#1969) ───────────────────────────────────────────

--- a/packages/api/src/lib/effect/layers.ts
+++ b/packages/api/src/lib/effect/layers.ts
@@ -124,14 +124,22 @@ function withFiberDeathLog<A, E, R>(
   );
 }
 
-// ── Per-tick observability spans for periodic cleanup fibers (#2945) ──
+// ── Per-tick observability spans for periodic scheduler fibers (#2945, #2944, #2987) ──
 // `withFiberDeathLog` (above) only fires when a defect kills the fiber.
 // A healthy tick emits nothing, so "wedged silently" and "ran fine,
 // nothing to do" are indistinguishable in traces, and a hung-but-not-
-// crashed fiber never trips the death log. Wrap each of these cleanup
+// crashed fiber never trips the death log. Wrap each of these periodic
 // tick bodies in `withEffectSpan` so every repeat iteration emits one
 // span — a wedged fiber then shows up as an absence of spans against its
 // expected cadence.
+//
+// OK-on-failure trade-off: each tick's loop-liveness `catchAll` sits INSIDE
+// the span, so a failed-but-recovered tick still records span status OK (the
+// error itself goes to `log.warn`). These spans answer "is the fiber still
+// ticking?" via presence/absence + cadence, NOT "did this tick error?". The
+// lone exception is `orphan_task_reconcile` below, which rides a result
+// attribute and so deliberately inverts the ordering (raw tick spanned,
+// `catchAll` applied OUTSIDE) to keep that attribute truthful — see its site.
 //
 // Membership splits into two single-source records, by fiber kind:
 //

--- a/packages/api/src/lib/effect/layers.ts
+++ b/packages/api/src/lib/effect/layers.ts
@@ -133,19 +133,39 @@ function withFiberDeathLog<A, E, R>(
 // span — a wedged fiber then shows up as an absence of spans against its
 // expected cadence.
 //
-// Membership: 9 cleanup fibers. Eight were retrofitted with a span by
-// #2945 (the TTL/ratelimit/state sweeps below); the ninth,
-// `orphan_task_reconcile` (#2944), shipped with its span from day one and
-// additionally attaches the orphan count as a result attribute (the only one
-// of these nine cleanup fibers that passes `setResultAttributes` — the BYOT
-// catalog-refresh fiber and the scheduler engine use that 4th arg elsewhere).
-// The other periodic fibers forked in `makeSchedulerLive` remain out of
-// scope —
-// `sub_processor_publisher`, `settings_refresh`, `onboarding_email`, and
-// `expert_scheduler` still lack a per-tick span, while the CRM/email
-// outbox flushers already have their own heartbeat + stall-watchdog
-// liveness signal. Spanning the remaining periodic fibers is tracked in
-// #2987.
+// Membership splits into two single-source records, by fiber kind:
+//
+//   • SCHEDULER_CLEANUP_SPAN_NAMES — 9 cleanup/sweep fibers (they evict
+//     expired in-memory or DB state). Eight were retrofitted with a span by
+//     #2945 (the TTL/ratelimit/state sweeps below); the ninth,
+//     `orphan_task_reconcile` (#2944), shipped with its span from day one and
+//     additionally attaches the orphan count as a result attribute (the only
+//     fiber in either record that passes `setResultAttributes` — the BYOT
+//     catalog-refresh fiber and the scheduler engine use that 4th arg
+//     elsewhere, inside their own modules).
+//
+//   • SCHEDULER_WORK_SPAN_NAMES — 4 background-work fibers (they perform
+//     recurring side-effecting work rather than evicting state):
+//     `sub_processor_publisher`, `settings_refresh`, `onboarding_email`,
+//     `expert_scheduler`. Spanned by #2987 — identical rationale and wrap
+//     shape, no result attributes (each tick returns void, matching the 8
+//     attribute-less cleanup fibers).
+//
+// Two records, not one: "cleanup sweep" vs "background work" is a real
+// distinction (it drives the log wording and the operator's mental model),
+// so each record stays the single source of truth for its own kind. Both are
+// pinned by the same parameterized guard in `layers.test.ts`.
+//
+// Deliberately NOT spanned: the CRM + transactional-email outbox flushers and
+// their stall-watchdog fibers (`lead_outbox_*`, `email_outbox_*`). They
+// already carry a STRONGER liveness signal than a presence/absence span — a
+// periodic heartbeat log when the queue is idle PLUS a separate watchdog
+// fiber that raises an error log when no tick is observed in > 2× the
+// interval. A per-tick span would be redundant with that, so #2987 leaves
+// them on heartbeat + watchdog. Self-spanning module fibers
+// (`byot_catalog_refresh`, `openapi_install_rediscover`, the scheduler engine
+// `tick`/`task.run`) define their span inside their own module and so never
+// appear in either record here.
 //
 // Span names follow the existing `atlas.<area>.<op>` dotted convention
 // (cf. `atlas.sql.execute`, `atlas.scheduler.task.run`, and the
@@ -154,11 +174,12 @@ function withFiberDeathLog<A, E, R>(
 // label; the LOW finding in #2945 is about NOT dropping the dotted
 // `atlas.scheduler.` prefix, not about the underscores within the op.
 //
-// This record is the single source of truth for the span names: each
-// wrap site below reads from it. `layers.test.ts` asserts both the exact
-// name set AND (via a structural source-scan guard) that all 9 wrap sites
-// are present, so renaming an entry OR deleting a `withEffectSpan(...)`
-// wrap at a call site is a test failure rather than a silent regression.
+// Each record is the single source of truth for its span names: every wrap
+// site below reads from it. `layers.test.ts` asserts, for each record, both
+// the exact name set AND (via a structural source-scan guard) that every key
+// has exactly one matching `withEffectSpan(<RECORD>.<key>` wrap site — so
+// renaming an entry OR deleting a wrap at a call site is a test failure
+// rather than a silent regression.
 export const SCHEDULER_CLEANUP_SPAN_NAMES = {
   oauth_state_cleanup: "atlas.scheduler.oauth_state_cleanup",
   rate_limit_cleanup: "atlas.scheduler.rate_limit_cleanup",
@@ -169,6 +190,16 @@ export const SCHEDULER_CLEANUP_SPAN_NAMES = {
   conversation_rate_sweep: "atlas.scheduler.conversation_rate_sweep",
   share_token_cleanup: "atlas.scheduler.share_token_cleanup",
   orphan_task_reconcile: "atlas.scheduler.orphan_task_reconcile",
+} as const satisfies Record<string, `atlas.scheduler.${string}`>;
+
+// Per-tick spans for the background-work fibers (#2987). Same wrap shape and
+// rationale as the cleanup record above; see the block comment for why these
+// are a separate record and why the outbox flushers are excluded.
+export const SCHEDULER_WORK_SPAN_NAMES = {
+  sub_processor_publisher: "atlas.scheduler.sub_processor_publisher",
+  settings_refresh: "atlas.scheduler.settings_refresh",
+  onboarding_email: "atlas.scheduler.onboarding_email",
+  expert_scheduler: "atlas.scheduler.expert_scheduler",
 } as const satisfies Record<string, `atlas.scheduler.${string}`>;
 
 // ══════════════════════════════════════════════════════════════════════
@@ -1249,7 +1280,9 @@ export const SettingsLive: Layer.Layer<Settings> = Layer.scoped(
       yield* Effect.forkScoped(
         withFiberDeathLog(
           "settings_refresh",
-          tick.pipe(Effect.repeat(Schedule.spaced(Duration.millis(intervalMs)))),
+          withEffectSpan(SCHEDULER_WORK_SPAN_NAMES.settings_refresh, {}, tick).pipe(
+            Effect.repeat(Schedule.spaced(Duration.millis(intervalMs))),
+          ),
         ),
       );
 
@@ -1359,7 +1392,9 @@ export function makeSchedulerLive(
         yield* Effect.forkScoped(
           withFiberDeathLog(
             "onboarding_email",
-            emailTick.pipe(Effect.repeat(Schedule.spaced(Duration.millis(DEFAULT_EMAIL_SCHEDULER_INTERVAL_MS)))),
+            withEffectSpan(SCHEDULER_WORK_SPAN_NAMES.onboarding_email, {}, emailTick).pipe(
+              Effect.repeat(Schedule.spaced(Duration.millis(DEFAULT_EMAIL_SCHEDULER_INTERVAL_MS))),
+            ),
           ),
         );
       } else {
@@ -1403,7 +1438,9 @@ export function makeSchedulerLive(
         yield* Effect.forkScoped(
           withFiberDeathLog(
             "expert_scheduler",
-            expertTick.pipe(Effect.repeat(Schedule.spaced(Duration.millis(getExpertSchedulerIntervalMs())))),
+            withEffectSpan(SCHEDULER_WORK_SPAN_NAMES.expert_scheduler, {}, expertTick).pipe(
+              Effect.repeat(Schedule.spaced(Duration.millis(getExpertSchedulerIntervalMs()))),
+            ),
           ),
         );
         log.info({ intervalMs: getExpertSchedulerIntervalMs() }, "Semantic expert scheduler started");
@@ -1853,7 +1890,11 @@ export function makeSchedulerLive(
       yield* Effect.forkScoped(
         withFiberDeathLog(
           "sub_processor_publisher",
-          subProcessorTick.pipe(
+          withEffectSpan(
+            SCHEDULER_WORK_SPAN_NAMES.sub_processor_publisher,
+            {},
+            subProcessorTick,
+          ).pipe(
             Effect.repeat(
               Schedule.spaced(
                 Duration.millis(subProcessorPublisher.SUBPROCESSOR_PUBLISH_INTERVAL_MS),


### PR DESCRIPTION
Closes #2987.

## What

Extends the per-tick `withEffectSpan("atlas.scheduler.<label>", …)` observability that #2945/#2944 gave the 9 cleanup/sweep fibers to the remaining span-less inline-forked **background-work** fibers. A healthy tick of these fibers emits nothing, so today a wedged (hung-but-not-crashed) fiber is invisible in traces — `withFiberDeathLog` only fires on a defect that *kills* the fiber.

Adds a sibling single-source record `SCHEDULER_WORK_SPAN_NAMES` and wraps 4 fibers:

| Fiber | Defining layer | Span name |
|---|---|---|
| `sub_processor_publisher` | `makeSchedulerLive` | `atlas.scheduler.sub_processor_publisher` |
| `settings_refresh` | `SettingsLive` (SaaS only) | `atlas.scheduler.settings_refresh` |
| `onboarding_email` | `makeSchedulerLive` | `atlas.scheduler.onboarding_email` |
| `expert_scheduler` | `makeSchedulerLive` | `atlas.scheduler.expert_scheduler` |

Wrap shape matches the 8 attribute-less cleanup fibers exactly — `withEffectSpan(name, {}, tick).pipe(Effect.repeat(...))` — with no result attributes (each tick returns `void`). Dotted `atlas.scheduler.` prefix preserved; op segment mirrors the `withFiberDeathLog` label (no snake_case leakage into a bare label).

## Decisions (per the issue plan)

**1. Two records, not a rename.** Rather than widening `SCHEDULER_CLEANUP_SPAN_NAMES` (a semantic lie — these aren't cleanup sweeps) or renaming it (churns 9 tested wrap sites + the #2945 guard), I added a sibling `SCHEDULER_WORK_SPAN_NAMES`. "cleanup sweep" vs "background work" is a real distinction that drives the log wording and the operator's mental model; each record stays the single source of truth for its own kind. Both are pinned by the **same parameterized guard** in `layers.test.ts`, so there's no copy-paste duplication.

**2. The other 3 work fibers → spanned (audit's recommendation).** `settings_refresh`, `onboarding_email`, `expert_scheduler` all had the same blind spot as `sub_processor_publisher`, so all four are wired.

**3. Outbox flushers/watchdogs → deliberately NOT spanned.** `lead_outbox_*` and `email_outbox_*` already carry a **stronger** liveness signal than a presence/absence span: a periodic heartbeat log when the queue is idle PLUS a separate watchdog fiber that raises an error log when no tick is observed in > 2× the interval. A per-tick span would be redundant. Documented in the `layers.ts` block comment alongside the self-spanning module fibers (`byot_catalog_refresh`, `openapi_install_rediscover`, scheduler engine `tick`/`task.run`) that define their span inside their own module.

**4. `orphan_task_reconcile` is out of scope** — it already shipped with its span from day one (#2944) and is the only fiber that attaches a result attribute.

## Test

Reuses the #2986 pattern (exact name-set + structural source-scan wrap-site guard), now parameterized over both records — each key must have exactly **one** matching `withEffectSpan(<RECORD>.<key>` call site (9 cleanup, 4 work).

- `bun run scripts/test-isolated.ts --affected` → 28 files pass (incl. `layers.test.ts` 41 tests, `outbox-flusher-lifecycle.test.ts`)
- `tsgo --noEmit` → exit 0
- `eslint` (changed files) → exit 0

## Acceptance criteria

- [x] `sub_processor_publisher` emits a per-tick span under `atlas.scheduler.<label>`
- [x] Decisions on the other 3 + the outbox flushers documented and wired where chosen
- [x] Reuses the single-source-of-truth + test-pin pattern from #2986
- [x] No snake_case leakage in span names; dotted `atlas.scheduler.` prefix preserved

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3112"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783020234&installation_id=135337507&pr_number=3112&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3112&signature=0132a96bb18286dcd397a64d7f8171f53a996c5669d51097c7615df9f14ceda2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Generalized per-tick span verification added to cover scheduler fibers, ensuring span names and instrumentation sites are present for background work.

* **Chores**
  * Background periodic tasks (settings refresh, onboarding emails, expert scheduler, sub-processor publisher) now emit per-iteration tracing spans for improved observability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->