### PR TITLE
feat(scheduler): gate BYOT catalog refresh on org dormancy (#2377)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -189,6 +189,11 @@ ATLAS_ADMIN_EMAIL=admin@useatlas.dev
 #                                           # provider catalog (Anthropic /v1/models — #2271). Discovery
 #                                           # hits upstream when the workspace's cache entry has
 #                                           # expired or admin clicks "Refresh now" on AI Provider.
+# ATLAS_BYOT_DORMANCY_DAYS=30               # Default 30. The scheduled BYOT catalog refresh skips
+#                                           # workspaces idle longer than this many days (no chat
+#                                           # activity), sparing provider rate-limits + audit noise on
+#                                           # catalogs nobody sees (#2377). Managed-auth only. Set 0 to
+#                                           # disable the gate (refresh every configured workspace).
 # ATLAS_CONVERSATION_STEP_CAP=500           # Aggregate step ceiling per conversation (F-77).
 #                                           # Default 500 = 20 follow-ups × 25 steps. Once total_steps
 #                                           # crosses this value the chat handler returns 429

--- a/packages/api/src/api/routes/chat.ts
+++ b/packages/api/src/api/routes/chat.ts
@@ -28,6 +28,7 @@ import {
   getClientIP,
 } from "@atlas/api/lib/auth/middleware";
 import { hasInternalDB } from "@atlas/api/lib/db/internal";
+import { markOrgActive } from "@atlas/api/lib/db/org-activity";
 import { checkWorkspaceStatus } from "@atlas/api/lib/workspace";
 import { checkAbuseStatus } from "@atlas/api/lib/security/abuse";
 import { checkPlanLimits } from "@atlas/api/lib/billing/enforcement";
@@ -614,6 +615,15 @@ chat.openapi(chatRoute, async (c) => {
         wsCheck.httpStatus ?? 403,
       );
     }
+
+    // #2377 — stamp workspace activity now that the org is authenticated and
+    // confirmed live (status check above). The BYOT catalog refresh scheduler
+    // reads `organization.last_active_at` to keep refreshing this workspace's
+    // model catalog; without a recent stamp the workspace ages into the
+    // dormancy gate and its catalog stops refreshing. Throttled +
+    // fire-and-forget + managed-auth-gated inside the helper — a no-op on the
+    // hot path almost always, and never able to fail the chat turn.
+    markOrgActive(authResult.user?.activeOrganizationId);
 
     // Migration write-lock — block new conversations while workspace is migrating
     const chatOrgId = authResult.user?.activeOrganizationId;

--- a/packages/api/src/lib/auth/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/auth/__tests__/migrate.test.ts
@@ -360,6 +360,7 @@ describe("migrateAuthTables", () => {
             { name: "0112_conversation_rest_excluded_datasources.sql" },
             { name: "0113_conversation_rest_focus_datasource.sql" },
             { name: "0114_token_usage_cache_tokens.sql" },
+            { name: "0115_org_last_active_at.sql" },
           ],
         };
       }

--- a/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
@@ -1946,7 +1946,9 @@ describeIfPg("migrate-pg: 0115 organization dormancy gate (#2377)", () => {
     // Column landed NOT NULL and existing rows backfilled.
     const col = await pool.query<{ is_nullable: string; data_type: string }>(
       `SELECT is_nullable, data_type FROM information_schema.columns
-        WHERE table_name = 'organization' AND column_name = 'last_active_at'`,
+        WHERE table_schema = current_schema()
+          AND table_name = 'organization'
+          AND column_name = 'last_active_at'`,
     );
     expect(col.rows[0]?.is_nullable).toBe("NO");
     expect(col.rows[0]?.data_type).toBe("timestamp with time zone");

--- a/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate-pg.test.ts
@@ -5,6 +5,7 @@ import { Pool } from "pg";
 import { z } from "zod";
 import { runMigrations } from "@atlas/api/lib/db/migrate";
 import { MANAGED_AUTH_MIGRATIONS } from "@atlas/api/lib/db/internal";
+import { buildStaleCatalogQuery } from "@atlas/api/lib/scheduler/byot-catalog-query";
 
 // Real-Postgres migration smoke. Skips cleanly when TEST_DATABASE_URL
 // is unset so local dev that hasn't run `bun run db:up` is unaffected.
@@ -1885,6 +1886,119 @@ describeIfPg("migrate-pg: 0096 step 3 demo backfill fixture (#2793 gap 1 follow-
       expect(row.config.db_type).toBe("postgres");
       expect(row.config.description).toBe("Atlas-managed demo Postgres dataset");
     }
+  }, PG_TEST_TIMEOUT_MS);
+});
+
+// #2377 — organization dormancy gate. Migration 0115 (`ALTER TABLE
+// organization ADD COLUMN last_active_at`) is Better-Auth-managed, so the
+// main run above skips it — this block applies it explicitly against a stub
+// `organization` table to validate the ALTER on real Postgres, then asserts
+// the dormancy-gate SELECT (the exact production SQL from
+// `buildStaleCatalogQuery`) actually selects active + orphaned-config orgs
+// and skips the dormant one. The scheduler unit tests mock `internalQuery`,
+// so this is the only place the `IS NULL OR last_active_at > threshold`
+// predicate runs against live rows — it guards the diff's most safety-
+// critical claim (the gate never drops a refresh the legacy query would do).
+// ─────────────────────────────────────────────────────────────────────
+
+describeIfPg("migrate-pg: 0115 organization dormancy gate (#2377)", () => {
+  let pool: Pool;
+  const schemaName = `dormancy_2377_${Date.now()}_${Math.floor(Math.random() * 1e6)}`;
+  const migrationsDir = join(import.meta.dir, "..", "migrations");
+  const ONE_DAY_MS = 86_400_000;
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: TEST_DB_URL });
+    pool.on("connect", (client) => {
+      void client.query(`SET search_path TO "${schemaName}"`).catch((err) => {
+        const message = err instanceof Error ? err.message : String(err);
+        console.error(`migrate-pg 0115 dormancy: SET search_path failed: ${message}`);
+      });
+    });
+    await pool.query(`CREATE SCHEMA IF NOT EXISTS "${schemaName}"`);
+  });
+
+  afterAll(async () => {
+    if (!pool) return;
+    await pool.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`);
+    await pool.end();
+  });
+
+  it("applies 0115 then selects active + orphan, skips dormant", async () => {
+    // Run the normal set so workspace_model_config / workspace_model_catalog
+    // exist. organization is skipped (Better-Auth-managed), so we stub it.
+    await runMigrations(pool, { skip: MANAGED_AUTH_MIGRATIONS });
+
+    // Minimal pre-0115 `organization` shape (no last_active_at yet).
+    await pool.query(`CREATE TABLE organization (id TEXT PRIMARY KEY, name TEXT)`);
+    await pool.query(
+      `INSERT INTO organization (id, name) VALUES ('org-active', 'A'), ('org-dormant', 'D')`,
+    );
+
+    // Apply the REAL migration 0115 verbatim — this exercises the ALTER
+    // (guard + NOT NULL DEFAULT now() + backfill) against live Postgres.
+    const sql0115 = readFileSync(
+      join(migrationsDir, "0115_org_last_active_at.sql"),
+      "utf-8",
+    );
+    await pool.query(sql0115);
+
+    // Column landed NOT NULL and existing rows backfilled.
+    const col = await pool.query<{ is_nullable: string; data_type: string }>(
+      `SELECT is_nullable, data_type FROM information_schema.columns
+        WHERE table_name = 'organization' AND column_name = 'last_active_at'`,
+    );
+    expect(col.rows[0]?.is_nullable).toBe("NO");
+    expect(col.rows[0]?.data_type).toBe("timestamp with time zone");
+    const backfilled = await pool.query<{ n: string }>(
+      `SELECT count(*) AS n FROM organization WHERE last_active_at IS NULL`,
+    );
+    expect(backfilled.rows[0]?.n).toBe("0");
+
+    // active = now (within window); dormant = 60 days ago (outside 30d window).
+    await pool.query(`UPDATE organization SET last_active_at = now() WHERE id = 'org-active'`);
+    await pool.query(
+      `UPDATE organization SET last_active_at = now() - interval '60 days' WHERE id = 'org-dormant'`,
+    );
+
+    // Configs for active, dormant, and an ORPHAN (no organization row).
+    await pool.query(
+      `INSERT INTO workspace_model_config (org_id, provider, model, api_key_encrypted) VALUES
+         ('org-active', 'anthropic', 'm', 'enc'),
+         ('org-dormant', 'anthropic', 'm', 'enc'),
+         ('org-orphan', 'anthropic', 'm', 'enc')`,
+    );
+    // All catalogs stale (2 days old) vs the 1-day TTL below.
+    await pool.query(
+      `INSERT INTO workspace_model_catalog (org_id, provider, region, payload, fetched_at) VALUES
+         ('org-active', 'anthropic', '', '[]'::jsonb, now() - interval '2 days'),
+         ('org-dormant', 'anthropic', '', '[]'::jsonb, now() - interval '2 days'),
+         ('org-orphan', 'anthropic', '', '[]'::jsonb, now() - interval '2 days')`,
+    );
+
+    // Gated (managed) query: stale=1d, limit=100, dormancy=30d.
+    const gated = await pool.query<{ org_id: string }>(buildStaleCatalogQuery(true), [
+      ONE_DAY_MS,
+      100,
+      30 * ONE_DAY_MS,
+    ]);
+    // active (recent) + orphan (NULL via LEFT JOIN miss → treated active);
+    // dormant (60d) is filtered out.
+    expect(gated.rows.map((r) => r.org_id).sort()).toEqual(["org-active", "org-orphan"]);
+
+    // Legacy (TTL-only) query: no dormancy filter → all three stale rows.
+    const legacy = await pool.query<{ org_id: string }>(buildStaleCatalogQuery(false), [
+      ONE_DAY_MS,
+      100,
+    ]);
+    expect(legacy.rows.map((r) => r.org_id).sort()).toEqual([
+      "org-active",
+      "org-dormant",
+      "org-orphan",
+    ]);
+
+    // 0115 is idempotent — re-applying the ALTER IF NOT EXISTS is a no-op.
+    await expect(pool.query(sql0115)).resolves.toBeDefined();
   }, PG_TEST_TIMEOUT_MS);
 });
 

--- a/packages/api/src/lib/db/__tests__/migrate.test.ts
+++ b/packages/api/src/lib/db/__tests__/migrate.test.ts
@@ -133,7 +133,8 @@ describe("runMigrations", () => {
     //   Plus 0112 (conversations.rest_excluded_datasource_ids, S2a, #3066) = 113.
     //   Plus 0113 (conversations.rest_focus_datasource_id, S2b, #3067) = 114.
     //   Plus 0114 (token_usage.cache_read_tokens/cache_write_tokens, #3099) = 115.
-    expect(count).toBe(115);
+    //   Plus 0115 (organization.last_active_at for BYOT dormancy gate, #2377) = 116.
+    expect(count).toBe(116);
 
     // Advisory lock acquired before anything else
     expect(queries[0]).toContain("pg_advisory_lock");
@@ -277,6 +278,7 @@ describe("runMigrations", () => {
         "0112_conversation_rest_excluded_datasources.sql",
         "0113_conversation_rest_focus_datasource.sql",
         "0114_token_usage_cache_tokens.sql",
+        "0115_org_last_active_at.sql",
       ],
     });
 

--- a/packages/api/src/lib/db/__tests__/org-activity.test.ts
+++ b/packages/api/src/lib/db/__tests__/org-activity.test.ts
@@ -1,0 +1,103 @@
+/**
+ * `markOrgActive` tests (#2377).
+ *
+ * Surface under test:
+ *   - No-op guards: empty orgId, no internal DB, non-managed auth.
+ *   - Per-org throttle: a second call inside the window issues no write;
+ *     clearing the throttle (window elapsed) lets the next call write again.
+ *   - Fire-and-forget: a synchronous `internalExecute` throw is swallowed.
+ */
+
+import { describe, it, expect, beforeEach, mock } from "bun:test";
+
+let mockInternalDB = true;
+let mockAuthMode = "managed";
+let executeCalls: Array<{ sql: string; params: unknown[] }> = [];
+let executeShouldThrow = false;
+
+mock.module("@atlas/api/lib/logger", () => ({
+  createLogger: () => ({ info: () => {}, warn: () => {}, error: () => {}, debug: () => {} }),
+}));
+
+mock.module("@atlas/api/lib/db/internal", () => ({
+  hasInternalDB: () => mockInternalDB,
+  internalExecute: (sql: string, params: unknown[]) => {
+    if (executeShouldThrow) throw new Error("pool init throw");
+    executeCalls.push({ sql, params });
+  },
+}));
+
+mock.module("@atlas/api/lib/auth/detect", () => ({
+  detectAuthMode: () => mockAuthMode,
+  getAuthModeSource: () => null,
+  resetAuthModeCache: () => {},
+}));
+
+const { markOrgActive, _resetOrgActivityThrottleForTests } = await import("../org-activity");
+
+function resetAll() {
+  mockInternalDB = true;
+  mockAuthMode = "managed";
+  executeCalls = [];
+  executeShouldThrow = false;
+  _resetOrgActivityThrottleForTests();
+}
+
+describe("markOrgActive", () => {
+  beforeEach(resetAll);
+
+  it("stamps last_active_at for a managed-auth org with an internal DB", () => {
+    markOrgActive("org-1");
+    expect(executeCalls.length).toBe(1);
+    expect(executeCalls[0].sql).toContain("UPDATE organization SET last_active_at = now()");
+    expect(executeCalls[0].params).toEqual(["org-1"]);
+  });
+
+  it("no-ops on an empty / nullish orgId", () => {
+    markOrgActive("");
+    markOrgActive(undefined);
+    markOrgActive(null);
+    expect(executeCalls.length).toBe(0);
+  });
+
+  it("no-ops when the internal DB is unavailable", () => {
+    mockInternalDB = false;
+    markOrgActive("org-1");
+    expect(executeCalls.length).toBe(0);
+  });
+
+  it("no-ops outside managed auth (organization table absent)", () => {
+    for (const mode of ["none", "simple-key", "byot"]) {
+      resetAll();
+      mockAuthMode = mode;
+      markOrgActive("org-1");
+      expect(executeCalls.length).toBe(0);
+    }
+  });
+
+  it("throttles repeat calls for the same org within the window", () => {
+    markOrgActive("org-1");
+    markOrgActive("org-1");
+    markOrgActive("org-1");
+    expect(executeCalls.length).toBe(1);
+  });
+
+  it("does not throttle distinct orgs against each other", () => {
+    markOrgActive("org-1");
+    markOrgActive("org-2");
+    expect(executeCalls.map((c) => c.params[0])).toEqual(["org-1", "org-2"]);
+  });
+
+  it("writes again once the throttle is cleared (window elapsed)", () => {
+    markOrgActive("org-1");
+    expect(executeCalls.length).toBe(1);
+    _resetOrgActivityThrottleForTests();
+    markOrgActive("org-1");
+    expect(executeCalls.length).toBe(2);
+  });
+
+  it("swallows a synchronous internalExecute throw (fire-and-forget)", () => {
+    executeShouldThrow = true;
+    expect(() => markOrgActive("org-1")).not.toThrow();
+  });
+});

--- a/packages/api/src/lib/db/internal.ts
+++ b/packages/api/src/lib/db/internal.ts
@@ -876,6 +876,9 @@ export const MANAGED_AUTH_MIGRATIONS = [
   // Adds is_operator_workspace column to Better Auth's "organization"
   // table (#2702).
   "0090_organization_is_operator_workspace.sql",
+  // Adds last_active_at column to Better Auth's "organization" table for
+  // BYOT-catalog dormancy gating (#2377).
+  "0115_org_last_active_at.sql",
 ];
 
 /**

--- a/packages/api/src/lib/db/migrations/0115_org_last_active_at.sql
+++ b/packages/api/src/lib/db/migrations/0115_org_last_active_at.sql
@@ -1,0 +1,43 @@
+-- 0115 — Organization activity timestamp for BYOT dormancy gating (#2377).
+--
+-- Adds `organization.last_active_at`, stamped (throttled) on every
+-- authenticated chat turn via `markOrgActive` (lib/db/org-activity.ts). The
+-- BYOT catalog refresh scheduler (lib/scheduler/byot-catalog-refresh.ts)
+-- reads it to SKIP refreshing model catalogs for workspaces nobody has
+-- touched in `ATLAS_BYOT_DORMANCY_DAYS` (default 30) — sparing upstream
+-- provider rate limits and audit-log noise for dormant orgs. Before this,
+-- the only dormancy proxy was the daily refresh TTL (a workspace nobody
+-- touches still aged out once a day; see the deferral comment retired by
+-- this change in byot-catalog-refresh.ts).
+--
+-- Better-Auth-managed table: this file is listed in MANAGED_AUTH_MIGRATIONS
+-- (db/internal.ts), so it runs ONLY when managed auth created the
+-- `organization` table. In every other auth mode (byot / simple-key / none)
+-- the table is absent, the migration is skipped, and the dormancy gate
+-- self-disables (see `detectAuthMode()` check in findStaleByotCatalogs) —
+-- dormancy is a multi-tenant concern that does not apply single-tenant.
+-- The guard below fails loudly if that ordering is ever violated (mirrors
+-- 0090).
+--
+-- NOT NULL DEFAULT now(): existing rows backfill to migration time, so every
+-- org reads as "active" for the first dormancy window post-deploy — the
+-- legacy refresh-everything behavior is preserved until real activity data
+-- accumulates. Better Auth's org INSERTs omit this column, so the default
+-- populates it for new orgs automatically.
+--
+-- No index on `last_active_at`: the dormancy query reaches `organization`
+-- via its primary key (joined from `workspace_model_config.org_id`), so
+-- `last_active_at` is a post-lookup row filter, not a scan key. An index
+-- would only add write amplification to the frequent `markOrgActive`
+-- UPDATEs without speeding up any read.
+
+DO $$ BEGIN
+  -- Scope to caller's search_path via to_regclass — see 0000_baseline.sql
+  -- comment + #2820 for the parallel-test-schema race this avoids.
+  IF to_regclass('organization') IS NULL THEN
+    RAISE EXCEPTION 'Atlas migration 0115 requires the "organization" table to exist. In managed auth mode, Better Auth migrations must run before Atlas migrations.';
+  END IF;
+END $$;
+
+ALTER TABLE organization
+  ADD COLUMN IF NOT EXISTS last_active_at TIMESTAMPTZ NOT NULL DEFAULT now();

--- a/packages/api/src/lib/db/org-activity.ts
+++ b/packages/api/src/lib/db/org-activity.ts
@@ -60,24 +60,26 @@ const _lastMarkedActive = new Map<string, number>();
  */
 export function markOrgActive(orgId: string | undefined | null): void {
   if (!orgId) return;
-  if (!hasInternalDB()) return;
-  // The `organization` table only exists under managed auth (see module
-  // doc). Cached + cheap; safe to call per request.
-  if (detectAuthMode() !== "managed") return;
-
-  const now = Date.now();
-  const last = _lastMarkedActive.get(orgId);
-  if (last !== undefined && now - last < ACTIVITY_THROTTLE_MS) return;
-
-  if (_lastMarkedActive.size >= MAX_TRACKED_ORGS) {
-    _lastMarkedActive.clear();
-  }
-  _lastMarkedActive.set(orgId, now);
-
   try {
+    if (!hasInternalDB()) return;
+    // The `organization` table only exists under managed auth (see module
+    // doc). Cached + cheap; safe to call per request. Kept INSIDE the try so
+    // the "never throws" contract holds even on an invalid ATLAS_AUTH_MODE
+    // (detectAuthMode throws on that — cached, would normally fail at boot).
+    if (detectAuthMode() !== "managed") return;
+
+    const now = Date.now();
+    const last = _lastMarkedActive.get(orgId);
+    if (last !== undefined && now - last < ACTIVITY_THROTTLE_MS) return;
+
+    if (_lastMarkedActive.size >= MAX_TRACKED_ORGS) {
+      _lastMarkedActive.clear();
+    }
+    _lastMarkedActive.set(orgId, now);
+
     // Fire-and-forget. internalExecute logs async failures + trips its own
-    // circuit breaker; the synchronous try/catch only covers a pool-init
-    // throw (already guarded by hasInternalDB above, but belt-and-braces).
+    // circuit breaker; this try also covers the synchronous pool-init throw
+    // (already guarded by hasInternalDB above, but belt-and-braces).
     internalExecute(`UPDATE organization SET last_active_at = now() WHERE id = $1`, [orgId]);
   } catch (err) {
     // A failed activity stamp must never surface to the caller — the worst
@@ -85,7 +87,7 @@ export function markOrgActive(orgId: string | undefined | null): void {
     // in fact active, which self-corrects on the next stamped request.
     log.warn(
       { err: err instanceof Error ? err.message : String(err), orgId },
-      "markOrgActive: synchronous internalExecute throw — activity not stamped",
+      "markOrgActive: activity not stamped",
     );
   }
 }

--- a/packages/api/src/lib/db/org-activity.ts
+++ b/packages/api/src/lib/db/org-activity.ts
@@ -1,0 +1,96 @@
+/**
+ * Organization activity stamping (#2377).
+ *
+ * `markOrgActive` records that a workspace was touched by an authenticated
+ * request, by bumping `organization.last_active_at`. The BYOT catalog refresh
+ * scheduler (lib/scheduler/byot-catalog-refresh.ts) reads that column to skip
+ * refreshing model catalogs for workspaces nobody has used in
+ * `ATLAS_BYOT_DORMANCY_DAYS` — keeping upstream provider rate-limit + audit
+ * noise off dormant orgs.
+ *
+ * Two properties make this safe to call on the hot path of every chat turn:
+ *
+ *   1. Throttled. The dormancy gate operates at multi-day granularity, so
+ *      sub-window freshness is irrelevant. We write at most once per org per
+ *      `ACTIVITY_THROTTLE_MS` window and short-circuit otherwise, keeping the
+ *      UPDATE off the per-request path almost always. The throttle is
+ *      per-pod (in-memory): a few redundant writes across pods are harmless.
+ *
+ *   2. Fire-and-forget. `internalExecute` never throws on async failure (it
+ *      logs + trips a circuit breaker), so a write miss can't fail or block
+ *      the request. We still guard `hasInternalDB()` first because
+ *      `internalExecute` throws *synchronously* when DATABASE_URL is unset.
+ *
+ * Managed-auth only. The `organization` table exists solely in managed-auth
+ * deployments (Better Auth owns its DDL — see MANAGED_AUTH_MIGRATIONS); an
+ * UPDATE against it in any other mode would error. Dormancy gating is a
+ * multi-tenant concern that does not apply to single-tenant self-hosted, so
+ * we no-op there.
+ */
+
+import { createLogger } from "@atlas/api/lib/logger";
+import { hasInternalDB, internalExecute } from "@atlas/api/lib/db/internal";
+import { detectAuthMode } from "@atlas/api/lib/auth/detect";
+
+const log = createLogger("org-activity");
+
+/**
+ * Minimum gap between two `last_active_at` writes for the same org. One hour
+ * is far below the dormancy threshold (days), so activity stays fresh enough
+ * to gate on while the write rate stays negligible.
+ */
+const ACTIVITY_THROTTLE_MS = 60 * 60 * 1000;
+
+/**
+ * Cap on the per-pod throttle map. Active-org cardinality is naturally
+ * bounded, but a long-lived pod serving a large fleet should not accumulate
+ * entries without limit. On overflow we clear the map wholesale — worst case
+ * every org writes once more within the next window, which is negligible.
+ */
+const MAX_TRACKED_ORGS = 100_000;
+
+/** orgId → epoch-ms of the last write we issued for it. */
+const _lastMarkedActive = new Map<string, number>();
+
+/**
+ * Stamp `organization.last_active_at = now()` for `orgId`, throttled and
+ * fire-and-forget. No-ops when `orgId` is empty, the internal DB is
+ * unavailable, the deployment is not managed-auth, or the org was already
+ * stamped within the throttle window. Never throws.
+ */
+export function markOrgActive(orgId: string | undefined | null): void {
+  if (!orgId) return;
+  if (!hasInternalDB()) return;
+  // The `organization` table only exists under managed auth (see module
+  // doc). Cached + cheap; safe to call per request.
+  if (detectAuthMode() !== "managed") return;
+
+  const now = Date.now();
+  const last = _lastMarkedActive.get(orgId);
+  if (last !== undefined && now - last < ACTIVITY_THROTTLE_MS) return;
+
+  if (_lastMarkedActive.size >= MAX_TRACKED_ORGS) {
+    _lastMarkedActive.clear();
+  }
+  _lastMarkedActive.set(orgId, now);
+
+  try {
+    // Fire-and-forget. internalExecute logs async failures + trips its own
+    // circuit breaker; the synchronous try/catch only covers a pool-init
+    // throw (already guarded by hasInternalDB above, but belt-and-braces).
+    internalExecute(`UPDATE organization SET last_active_at = now() WHERE id = $1`, [orgId]);
+  } catch (err) {
+    // A failed activity stamp must never surface to the caller — the worst
+    // consequence is the BYOT catalog skips one refresh for an org that is
+    // in fact active, which self-corrects on the next stamped request.
+    log.warn(
+      { err: err instanceof Error ? err.message : String(err), orgId },
+      "markOrgActive: synchronous internalExecute throw — activity not stamped",
+    );
+  }
+}
+
+/** Test-only: clear the in-memory throttle map. */
+export function _resetOrgActivityThrottleForTests(): void {
+  _lastMarkedActive.clear();
+}

--- a/packages/api/src/lib/scheduler/__tests__/byot-catalog-refresh.test.ts
+++ b/packages/api/src/lib/scheduler/__tests__/byot-catalog-refresh.test.ts
@@ -886,6 +886,11 @@ describe("byot catalog refresh — dormancy threshold env resolution (#2377)", (
     expect(_getDormancyThresholdMsForTests()).toBe(0);
   });
 
+  it("clamps a positive sub-day value to 1 day (does not floor to 0 / disable)", () => {
+    process.env[ENV_KEY] = "0.5";
+    expect(_getDormancyThresholdMsForTests()).toBe(ONE_DAY_MS);
+  });
+
   it("falls back to the default for garbage / negative values", () => {
     process.env[ENV_KEY] = "not-a-number";
     expect(_getDormancyThresholdMsForTests()).toBe(30 * ONE_DAY_MS);

--- a/packages/api/src/lib/scheduler/__tests__/byot-catalog-refresh.test.ts
+++ b/packages/api/src/lib/scheduler/__tests__/byot-catalog-refresh.test.ts
@@ -886,9 +886,11 @@ describe("byot catalog refresh — dormancy threshold env resolution (#2377)", (
     expect(_getDormancyThresholdMsForTests()).toBe(0);
   });
 
-  it("clamps a positive sub-day value to 1 day (does not floor to 0 / disable)", () => {
+  it("rejects a non-integer day value → default (never floors to 0 / disables)", () => {
     process.env[ENV_KEY] = "0.5";
-    expect(_getDormancyThresholdMsForTests()).toBe(ONE_DAY_MS);
+    expect(_getDormancyThresholdMsForTests()).toBe(30 * ONE_DAY_MS);
+    process.env[ENV_KEY] = "7.9";
+    expect(_getDormancyThresholdMsForTests()).toBe(30 * ONE_DAY_MS);
   });
 
   it("falls back to the default for garbage / negative values", () => {

--- a/packages/api/src/lib/scheduler/__tests__/byot-catalog-refresh.test.ts
+++ b/packages/api/src/lib/scheduler/__tests__/byot-catalog-refresh.test.ts
@@ -15,7 +15,7 @@
  *   - EE-module-missing branch routes to `ee_unavailable` skip reason.
  */
 
-import { describe, it, expect, beforeEach, mock } from "bun:test";
+import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
 import { Effect, Layer } from "effect";
 
 // Force enterprise on so `ConditionalEELayer` in
@@ -38,6 +38,14 @@ let mockInternalDB = true;
 let mockStaleRows: Array<{ org_id: string; provider: string; bedrock_region: string | null }> = [];
 let staleQueryCalls = 0;
 let staleQueryShouldThrow: Error | null = null;
+// Captures the SQL + params of the most recent stale-row query so dormancy-gate
+// tests can assert the JOIN / threshold wiring (#2377). The mock returns
+// `mockStaleRows` regardless, so the gate behavior under test lives in the SQL.
+let lastStaleQuery: { sql: string; params: unknown[] } | null = null;
+// Auth mode seen by the scheduler's dormancy branch. Defaults to "none" so the
+// legacy TTL-only query runs in every pre-existing test; the #2377 tests flip
+// it to "managed" to exercise the dormancy JOIN.
+let mockAuthMode = "none";
 
 let mockWorkspaceConfigs: Map<
   string,
@@ -77,13 +85,22 @@ mock.module("@atlas/api/lib/logger", () => ({
 
 mock.module("@atlas/api/lib/db/internal", () => ({
   hasInternalDB: () => mockInternalDB,
-  internalQuery: async () => {
+  internalQuery: async (sql: string, params: unknown[]) => {
     staleQueryCalls++;
+    lastStaleQuery = { sql, params };
     if (staleQueryShouldThrow) throw staleQueryShouldThrow;
     return mockStaleRows;
   },
   internalExecute: () => {},
   getInternalDB: () => ({}),
+}));
+
+// Mock auth-mode detection so the dormancy JOIN (managed-auth only) can be
+// driven deterministically. All exports mocked per CLAUDE.md.
+mock.module("@atlas/api/lib/auth/detect", () => ({
+  detectAuthMode: () => mockAuthMode,
+  getAuthModeSource: () => null,
+  resetAuthModeCache: () => {},
 }));
 
 mock.module("@atlas/api/lib/audit", () => ({
@@ -295,6 +312,7 @@ const {
   _resetBackoffForTests,
   _resetEeProbeForTests,
   _computeBackoffMsForTests,
+  _getDormancyThresholdMsForTests,
   triggerByotCatalogRefreshCycle,
   BYOT_CATALOG_REFRESH_ACTOR,
 } = await import("../byot-catalog-refresh");
@@ -307,6 +325,8 @@ function resetAll() {
   mockStaleRows = [];
   staleQueryCalls = 0;
   staleQueryShouldThrow = null;
+  lastStaleQuery = null;
+  mockAuthMode = "none";
   mockWorkspaceConfigs = new Map();
   anthropicFetcherCalls = [];
   openaiFetcherCalls = [];
@@ -772,5 +792,104 @@ describe("byot catalog refresh — triggerByotCatalogRefreshCycle wrapper", () =
     const result = await triggerByotCatalogRefreshCycle();
     expect(result.status).toBe("failure");
     expect(result.error).toBe("db down");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Dormancy gate (#2377)
+// ---------------------------------------------------------------------------
+
+describe("byot catalog refresh — dormancy gate (#2377)", () => {
+  beforeEach(resetAll);
+
+  const THIRTY_DAYS_MS = 30 * ONE_DAY_MS;
+
+  it("joins organization + filters last_active_at when managed-auth and threshold > 0", async () => {
+    mockAuthMode = "managed";
+    await Effect.runPromise(
+      runByotCatalogRefreshCycle({ dormancyThresholdMs: THIRTY_DAYS_MS }),
+    );
+
+    expect(lastStaleQuery).not.toBeNull();
+    expect(lastStaleQuery!.sql).toContain("LEFT JOIN organization");
+    expect(lastStaleQuery!.sql).toContain("org.last_active_at");
+    // staleThreshold ($1), limit ($2), dormancyThreshold ($3)
+    expect(lastStaleQuery!.params).toContain(THIRTY_DAYS_MS);
+    expect(lastStaleQuery!.params.length).toBe(3);
+  });
+
+  it("falls back to the TTL-only query in non-managed auth (organization absent)", async () => {
+    mockAuthMode = "byot";
+    await Effect.runPromise(
+      runByotCatalogRefreshCycle({ dormancyThresholdMs: THIRTY_DAYS_MS }),
+    );
+
+    expect(lastStaleQuery).not.toBeNull();
+    expect(lastStaleQuery!.sql).not.toContain("organization");
+    expect(lastStaleQuery!.sql).not.toContain("last_active_at");
+    expect(lastStaleQuery!.params.length).toBe(2);
+  });
+
+  it("disables the gate when the threshold is 0 even under managed auth", async () => {
+    mockAuthMode = "managed";
+    await Effect.runPromise(runByotCatalogRefreshCycle({ dormancyThresholdMs: 0 }));
+
+    expect(lastStaleQuery).not.toBeNull();
+    expect(lastStaleQuery!.sql).not.toContain("organization");
+    expect(lastStaleQuery!.params.length).toBe(2);
+  });
+
+  it("still refreshes active orgs returned by the gated query", async () => {
+    mockAuthMode = "managed";
+    mockStaleRows = [{ org_id: "org-active", provider: "anthropic", bedrock_region: null }];
+    mockWorkspaceConfigs.set("org-active", {
+      provider: "anthropic",
+      model: "x",
+      apiKey: "k",
+      baseUrl: null,
+      bedrockRegion: null,
+    });
+
+    const result = await Effect.runPromise(
+      runByotCatalogRefreshCycle({ dormancyThresholdMs: THIRTY_DAYS_MS }),
+    );
+    expect(result.refreshed).toBe(1);
+    expect(anthropicFetcherCalls).toEqual([{ orgId: "org-active", apiKey: "k" }]);
+  });
+});
+
+describe("byot catalog refresh — dormancy threshold env resolution (#2377)", () => {
+  const ENV_KEY = "ATLAS_BYOT_DORMANCY_DAYS";
+  let original: string | undefined;
+
+  beforeEach(() => {
+    original = process.env[ENV_KEY];
+    delete process.env[ENV_KEY];
+  });
+
+  afterEach(() => {
+    if (original === undefined) delete process.env[ENV_KEY];
+    else process.env[ENV_KEY] = original;
+  });
+
+  it("defaults to 30 days when unset", () => {
+    expect(_getDormancyThresholdMsForTests()).toBe(30 * ONE_DAY_MS);
+  });
+
+  it("honors a positive whole-day override", () => {
+    process.env[ENV_KEY] = "7";
+    expect(_getDormancyThresholdMsForTests()).toBe(7 * ONE_DAY_MS);
+  });
+
+  it("returns 0 (gate disabled) for an explicit 0", () => {
+    process.env[ENV_KEY] = "0";
+    expect(_getDormancyThresholdMsForTests()).toBe(0);
+  });
+
+  it("falls back to the default for garbage / negative values", () => {
+    process.env[ENV_KEY] = "not-a-number";
+    expect(_getDormancyThresholdMsForTests()).toBe(30 * ONE_DAY_MS);
+    process.env[ENV_KEY] = "-5";
+    expect(_getDormancyThresholdMsForTests()).toBe(30 * ONE_DAY_MS);
   });
 });

--- a/packages/api/src/lib/scheduler/byot-catalog-query.ts
+++ b/packages/api/src/lib/scheduler/byot-catalog-query.ts
@@ -1,0 +1,51 @@
+/**
+ * Stale BYOT-catalog query builder (#2284, dormancy gate #2377).
+ *
+ * Extracted from `byot-catalog-refresh.ts` so the real-Postgres migration
+ * smoke (`migrate-pg.test.ts`) can assert the dormancy-gate SEMANTICS against
+ * a live database using the exact production SQL — the in-process scheduler
+ * unit tests mock `internalQuery` and so can only assert the query's shape,
+ * not how its `IS NULL OR … > threshold` predicate actually selects rows.
+ * This module has no heavy imports, so the integration test can pull the
+ * builder without dragging in the scheduler's enterprise/Effect graph.
+ */
+
+/**
+ * Build the stale-catalog selection query.
+ *
+ * The interval thresholds are parameterized as milliseconds → `now() -
+ * $n::bigint * interval '1 ms'` so each is configurable without inlining the
+ * int into a string literal.
+ *
+ *   - Legacy (dormancy disabled / non-managed): `$1` = stale-TTL ms, `$2` =
+ *     limit. Selects every configured workspace whose catalog is older than
+ *     the TTL.
+ *   - Gated (`dormancyEnabled`): additionally `$3` = dormancy-window ms, and a
+ *     `LEFT JOIN organization` + `org.last_active_at IS NULL OR … > now() -
+ *     $3` filter. The dormancy predicate is ANDed onto the legacy TTL
+ *     predicate, and a missing org row (orphaned config) yields `NULL` →
+ *     treated as active. So the gate only ever ADDS skips for orgs that
+ *     demonstrably exist AND are idle — it never drops a refresh the legacy
+ *     query would have done.
+ */
+export function buildStaleCatalogQuery(dormancyEnabled: boolean): string {
+  return dormancyEnabled
+    ? `SELECT wmc.org_id, wmc.provider, wmc.bedrock_region
+       FROM workspace_model_config wmc
+       LEFT JOIN organization org ON org.id = wmc.org_id
+       LEFT JOIN workspace_model_catalog wmcat
+         ON wmcat.org_id = wmc.org_id AND wmcat.provider = wmc.provider
+       WHERE wmc.provider IN ('anthropic', 'openai', 'bedrock')
+         AND (org.last_active_at IS NULL OR org.last_active_at > now() - ($3::bigint * interval '1 ms'))
+         AND (wmcat.fetched_at IS NULL OR wmcat.fetched_at < now() - ($1::bigint * interval '1 ms'))
+       ORDER BY wmcat.fetched_at NULLS FIRST
+       LIMIT $2`
+    : `SELECT wmc.org_id, wmc.provider, wmc.bedrock_region
+       FROM workspace_model_config wmc
+       LEFT JOIN workspace_model_catalog wmcat
+         ON wmcat.org_id = wmc.org_id AND wmcat.provider = wmc.provider
+       WHERE wmc.provider IN ('anthropic', 'openai', 'bedrock')
+         AND (wmcat.fetched_at IS NULL OR wmcat.fetched_at < now() - ($1::bigint * interval '1 ms'))
+       ORDER BY wmcat.fetched_at NULLS FIRST
+       LIMIT $2`;
+}

--- a/packages/api/src/lib/scheduler/byot-catalog-refresh.ts
+++ b/packages/api/src/lib/scheduler/byot-catalog-refresh.ts
@@ -19,10 +19,15 @@
  *     with a rotated-and-broken key would otherwise be retried 365 times a
  *     year. Pod restart resets the backoff state — acceptable trade-off vs
  *     the migration that a persistent counter would require.
- *   - Dormancy gate deferred to #2377. `organization.last_active_at` does
- *     not exist on the Better-Auth-managed `organization` table; until then
- *     the daily TTL itself acts as a coarse dormancy gate (a workspace
- *     nobody is touching ages out once a day, not 144 times a day).
+ *   - Dormancy gate (#2377). On top of the daily TTL, the stale-row query
+ *     skips orgs whose `organization.last_active_at` is older than
+ *     `ATLAS_BYOT_DORMANCY_DAYS` (default 30) — a workspace nobody has
+ *     touched in a month stops burning provider rate-limit + audit noise on
+ *     refreshes its admins will never see. The gate is managed-auth-only
+ *     (the `organization` table exists only there) and self-disables when
+ *     `ATLAS_BYOT_DORMANCY_DAYS=0`; in both cases the TTL-only legacy query
+ *     runs. `last_active_at` is stamped (throttled) on authenticated chat
+ *     turns by `markOrgActive` (lib/db/org-activity.ts).
  *   - Every per-row outcome is audit-logged via the existing
  *     `model_config.catalog_refresh*` actions. Cycle-level
  *     `catalog_refresh_cycle` emits every tick — the absence of a cycle row
@@ -40,6 +45,7 @@ import { Effect } from "effect";
 import { createLogger } from "@atlas/api/lib/logger";
 import { withEffectSpan } from "@atlas/api/lib/tracing";
 import { hasInternalDB, internalQuery } from "@atlas/api/lib/db/internal";
+import { detectAuthMode } from "@atlas/api/lib/auth/detect";
 import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
 import type { AdminActionType } from "@atlas/api/lib/audit/actions";
 import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
@@ -62,11 +68,34 @@ const log = createLogger("byot-catalog-refresh");
  */
 export const BYOT_CATALOG_REFRESH_ACTOR = "system:byot-catalog-refresh" as const;
 
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+
 /** 24h — both the default tick interval and the staleness gate. */
-const DEFAULT_INTERVAL_MS = 24 * 60 * 60 * 1000;
+const DEFAULT_INTERVAL_MS = ONE_DAY_MS;
 
 /** Bound per-tick runtime; backlog catches up across ticks via `NULLS FIRST`. */
 const DEFAULT_BATCH_SIZE = 100;
+
+/** Default dormancy window (#2377): skip orgs idle longer than this. */
+const DEFAULT_DORMANCY_DAYS = 30;
+
+/**
+ * Resolve the dormancy threshold (ms) from `ATLAS_BYOT_DORMANCY_DAYS`.
+ * Default 30 days. `0` (or any non-positive / unparseable value normalizes
+ * to 0) DISABLES the gate — the cycle falls back to the TTL-only query, so
+ * operators can opt out without a code change. Returns whole-day multiples
+ * of `ONE_DAY_MS`.
+ */
+function getDormancyThresholdMs(): number {
+  const raw = process.env.ATLAS_BYOT_DORMANCY_DAYS;
+  if (raw === undefined || raw.trim() === "") return DEFAULT_DORMANCY_DAYS * ONE_DAY_MS;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0) return n === 0 ? 0 : DEFAULT_DORMANCY_DAYS * ONE_DAY_MS;
+  return Math.floor(n) * ONE_DAY_MS;
+}
+
+/** Test-only: expose the env-driven dormancy resolver. */
+export const _getDormancyThresholdMsForTests = getDormancyThresholdMs;
 
 /** Failures past this exponent stay at the cap. 2^5 = exactly 32 days. */
 const MAX_BACKOFF_EXPONENT = 5;
@@ -143,22 +172,46 @@ interface StaleRowDb extends Record<string, unknown> {
 async function findStaleByotCatalogs(
   staleThresholdMs: number,
   limit: number,
+  dormancyThresholdMs: number,
 ): Promise<StaleRow[]> {
   if (!hasInternalDB()) return [];
 
-  // Mirrors the SQL in the issue body. The interval is parameterized as
-  // milliseconds → `now() - $1::bigint * interval '1 ms'` so the threshold
-  // is configurable without inlining the int into a string literal.
+  // Dormancy gate (#2377). Only joinable when the Better-Auth `organization`
+  // table exists — i.e. managed auth. In byot / simple-key / none modes the
+  // table is absent (a JOIN would error) and dormancy is moot single-tenant,
+  // so we fall back to the TTL-only query. `dormancyThresholdMs <= 0` is the
+  // operator opt-out (ATLAS_BYOT_DORMANCY_DAYS=0).
+  const dormancyEnabled = dormancyThresholdMs > 0 && detectAuthMode() === "managed";
+
+  // The interval is parameterized as milliseconds → `now() - $n::bigint *
+  // interval '1 ms'` so each threshold is configurable without inlining the
+  // int into a string literal.
+  //
+  // LEFT JOIN organization + `last_active_at IS NULL OR …`: an orphaned
+  // config (org row missing) is treated as active and still refreshed, so the
+  // gate only ever ADDS skips for orgs that demonstrably exist AND are idle —
+  // it never silently drops a refresh that the legacy query would have done.
   const rows = await internalQuery<StaleRowDb>(
-    `SELECT wmc.org_id, wmc.provider, wmc.bedrock_region
-     FROM workspace_model_config wmc
-     LEFT JOIN workspace_model_catalog wmcat
-       ON wmcat.org_id = wmc.org_id AND wmcat.provider = wmc.provider
-     WHERE wmc.provider IN ('anthropic', 'openai', 'bedrock')
-       AND (wmcat.fetched_at IS NULL OR wmcat.fetched_at < now() - ($1::bigint * interval '1 ms'))
-     ORDER BY wmcat.fetched_at NULLS FIRST
-     LIMIT $2`,
-    [staleThresholdMs, limit],
+    dormancyEnabled
+      ? `SELECT wmc.org_id, wmc.provider, wmc.bedrock_region
+         FROM workspace_model_config wmc
+         LEFT JOIN organization org ON org.id = wmc.org_id
+         LEFT JOIN workspace_model_catalog wmcat
+           ON wmcat.org_id = wmc.org_id AND wmcat.provider = wmc.provider
+         WHERE wmc.provider IN ('anthropic', 'openai', 'bedrock')
+           AND (org.last_active_at IS NULL OR org.last_active_at > now() - ($3::bigint * interval '1 ms'))
+           AND (wmcat.fetched_at IS NULL OR wmcat.fetched_at < now() - ($1::bigint * interval '1 ms'))
+         ORDER BY wmcat.fetched_at NULLS FIRST
+         LIMIT $2`
+      : `SELECT wmc.org_id, wmc.provider, wmc.bedrock_region
+         FROM workspace_model_config wmc
+         LEFT JOIN workspace_model_catalog wmcat
+           ON wmcat.org_id = wmc.org_id AND wmcat.provider = wmc.provider
+         WHERE wmc.provider IN ('anthropic', 'openai', 'bedrock')
+           AND (wmcat.fetched_at IS NULL OR wmcat.fetched_at < now() - ($1::bigint * interval '1 ms'))
+         ORDER BY wmcat.fetched_at NULLS FIRST
+         LIMIT $2`,
+    dormancyEnabled ? [staleThresholdMs, limit, dormancyThresholdMs] : [staleThresholdMs, limit],
   );
 
   const result: StaleRow[] = [];
@@ -407,6 +460,12 @@ function zeroResult(): ByotRefreshCycleResult {
 interface CycleOptions {
   staleThresholdMs?: number;
   batchSize?: number;
+  /**
+   * Dormancy gate (#2377): orgs idle longer than this are skipped. Defaults
+   * to `ATLAS_BYOT_DORMANCY_DAYS` (30d). `0` disables the gate. Managed-auth
+   * only — see `findStaleByotCatalogs`.
+   */
+  dormancyThresholdMs?: number;
   /** Override `Date.now()` for tests. */
   nowFn?: () => number;
 }
@@ -434,10 +493,11 @@ export const runByotCatalogRefreshCycle = (
 
     const staleThresholdMs = opts.staleThresholdMs ?? DEFAULT_INTERVAL_MS;
     const batchSize = opts.batchSize ?? DEFAULT_BATCH_SIZE;
+    const dormancyThresholdMs = opts.dormancyThresholdMs ?? getDormancyThresholdMs();
     const now = opts.nowFn ?? Date.now;
 
     const fetchResult = yield* Effect.tryPromise({
-      try: () => findStaleByotCatalogs(staleThresholdMs, batchSize),
+      try: () => findStaleByotCatalogs(staleThresholdMs, batchSize, dormancyThresholdMs),
       catch: (err) => (err instanceof Error ? err : new Error(String(err))),
     }).pipe(
       Effect.map((rows) => ({ ok: true as const, rows })),

--- a/packages/api/src/lib/scheduler/byot-catalog-refresh.ts
+++ b/packages/api/src/lib/scheduler/byot-catalog-refresh.ts
@@ -46,6 +46,7 @@ import { createLogger } from "@atlas/api/lib/logger";
 import { withEffectSpan } from "@atlas/api/lib/tracing";
 import { hasInternalDB, internalQuery } from "@atlas/api/lib/db/internal";
 import { detectAuthMode } from "@atlas/api/lib/auth/detect";
+import { buildStaleCatalogQuery } from "@atlas/api/lib/scheduler/byot-catalog-query";
 import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
 import type { AdminActionType } from "@atlas/api/lib/audit/actions";
 import { errorMessage } from "@atlas/api/lib/audit/error-scrub";
@@ -81,17 +82,21 @@ const DEFAULT_DORMANCY_DAYS = 30;
 
 /**
  * Resolve the dormancy threshold (ms) from `ATLAS_BYOT_DORMANCY_DAYS`.
- * Default 30 days. `0` (or any non-positive / unparseable value normalizes
- * to 0) DISABLES the gate — the cycle falls back to the TTL-only query, so
- * operators can opt out without a code change. Returns whole-day multiples
- * of `ONE_DAY_MS`.
+ *
+ * Only an explicit `0` DISABLES the gate (the cycle falls back to the
+ * TTL-only query) — empty, negative, NaN, and unparseable values fail safe to
+ * the 30-day default rather than silently disabling. A positive value is
+ * floored to whole days and clamped to a 1-day minimum, so a sub-day value
+ * (e.g. `0.5`) gates at 1 day instead of flooring to 0 and accidentally
+ * disabling the gate.
  */
 function getDormancyThresholdMs(): number {
   const raw = process.env.ATLAS_BYOT_DORMANCY_DAYS;
   if (raw === undefined || raw.trim() === "") return DEFAULT_DORMANCY_DAYS * ONE_DAY_MS;
   const n = Number(raw);
-  if (!Number.isFinite(n) || n <= 0) return n === 0 ? 0 : DEFAULT_DORMANCY_DAYS * ONE_DAY_MS;
-  return Math.floor(n) * ONE_DAY_MS;
+  if (n === 0) return 0; // explicit operator opt-out
+  if (!Number.isFinite(n) || n < 0) return DEFAULT_DORMANCY_DAYS * ONE_DAY_MS;
+  return Math.max(1, Math.floor(n)) * ONE_DAY_MS;
 }
 
 /** Test-only: expose the env-driven dormancy resolver. */
@@ -180,37 +185,13 @@ async function findStaleByotCatalogs(
   // table exists — i.e. managed auth. In byot / simple-key / none modes the
   // table is absent (a JOIN would error) and dormancy is moot single-tenant,
   // so we fall back to the TTL-only query. `dormancyThresholdMs <= 0` is the
-  // operator opt-out (ATLAS_BYOT_DORMANCY_DAYS=0).
+  // operator opt-out (ATLAS_BYOT_DORMANCY_DAYS=0). The SQL lives in
+  // `buildStaleCatalogQuery` so the real-Postgres smoke can assert its
+  // row-selection semantics (orphan/NULL/dormant/active) against a live DB.
   const dormancyEnabled = dormancyThresholdMs > 0 && detectAuthMode() === "managed";
 
-  // The interval is parameterized as milliseconds → `now() - $n::bigint *
-  // interval '1 ms'` so each threshold is configurable without inlining the
-  // int into a string literal.
-  //
-  // LEFT JOIN organization + `last_active_at IS NULL OR …`: an orphaned
-  // config (org row missing) is treated as active and still refreshed, so the
-  // gate only ever ADDS skips for orgs that demonstrably exist AND are idle —
-  // it never silently drops a refresh that the legacy query would have done.
   const rows = await internalQuery<StaleRowDb>(
-    dormancyEnabled
-      ? `SELECT wmc.org_id, wmc.provider, wmc.bedrock_region
-         FROM workspace_model_config wmc
-         LEFT JOIN organization org ON org.id = wmc.org_id
-         LEFT JOIN workspace_model_catalog wmcat
-           ON wmcat.org_id = wmc.org_id AND wmcat.provider = wmc.provider
-         WHERE wmc.provider IN ('anthropic', 'openai', 'bedrock')
-           AND (org.last_active_at IS NULL OR org.last_active_at > now() - ($3::bigint * interval '1 ms'))
-           AND (wmcat.fetched_at IS NULL OR wmcat.fetched_at < now() - ($1::bigint * interval '1 ms'))
-         ORDER BY wmcat.fetched_at NULLS FIRST
-         LIMIT $2`
-      : `SELECT wmc.org_id, wmc.provider, wmc.bedrock_region
-         FROM workspace_model_config wmc
-         LEFT JOIN workspace_model_catalog wmcat
-           ON wmcat.org_id = wmc.org_id AND wmcat.provider = wmc.provider
-         WHERE wmc.provider IN ('anthropic', 'openai', 'bedrock')
-           AND (wmcat.fetched_at IS NULL OR wmcat.fetched_at < now() - ($1::bigint * interval '1 ms'))
-         ORDER BY wmcat.fetched_at NULLS FIRST
-         LIMIT $2`,
+    buildStaleCatalogQuery(dormancyEnabled),
     dormancyEnabled ? [staleThresholdMs, limit, dormancyThresholdMs] : [staleThresholdMs, limit],
   );
 

--- a/packages/api/src/lib/scheduler/byot-catalog-refresh.ts
+++ b/packages/api/src/lib/scheduler/byot-catalog-refresh.ts
@@ -83,20 +83,22 @@ const DEFAULT_DORMANCY_DAYS = 30;
 /**
  * Resolve the dormancy threshold (ms) from `ATLAS_BYOT_DORMANCY_DAYS`.
  *
- * Only an explicit `0` DISABLES the gate (the cycle falls back to the
- * TTL-only query) — empty, negative, NaN, and unparseable values fail safe to
- * the 30-day default rather than silently disabling. A positive value is
- * floored to whole days and clamped to a 1-day minimum, so a sub-day value
- * (e.g. `0.5`) gates at 1 day instead of flooring to 0 and accidentally
- * disabling the gate.
+ * The contract is a whole number of days. Only an explicit `0` DISABLES the
+ * gate (the cycle falls back to the TTL-only query). Every other invalid input
+ * — empty, negative, NaN, unparseable, OR a non-integer like `0.5` — fails
+ * safe to the 30-day default rather than silently disabling or guessing a
+ * fractional window. (A bare `Math.floor` would turn `0.5` into `0` and
+ * accidentally disable the gate, so non-integers are rejected outright.)
  */
 function getDormancyThresholdMs(): number {
   const raw = process.env.ATLAS_BYOT_DORMANCY_DAYS;
   if (raw === undefined || raw.trim() === "") return DEFAULT_DORMANCY_DAYS * ONE_DAY_MS;
   const n = Number(raw);
   if (n === 0) return 0; // explicit operator opt-out
-  if (!Number.isFinite(n) || n < 0) return DEFAULT_DORMANCY_DAYS * ONE_DAY_MS;
-  return Math.max(1, Math.floor(n)) * ONE_DAY_MS;
+  if (!Number.isFinite(n) || n < 0 || !Number.isInteger(n)) {
+    return DEFAULT_DORMANCY_DAYS * ONE_DAY_MS;
+  }
+  return n * ONE_DAY_MS;
 }
 
 /** Test-only: expose the env-driven dormancy resolver. */


### PR DESCRIPTION
Closes #2377.

## What

Adds `organization.last_active_at` and uses it to **skip refreshing BYOT model catalogs for dormant workspaces** — sparing upstream provider rate-limits and audit-log noise on catalogs that idle orgs' admins will never look at. Before this, the daily refresh TTL was the only (coarse) dormancy proxy; `findStaleByotCatalogs` carried a `// deferred to #2377` comment for exactly this gate.

## How

- **Migration `0115_org_last_active_at.sql`** — `ALTER TABLE organization ADD COLUMN IF NOT EXISTS last_active_at TIMESTAMPTZ NOT NULL DEFAULT now()`. `organization` is Better-Auth-managed (not a Drizzle `pgTable` — same as `is_operator_workspace`/0090, `plan_tier`/0027), so:
  - registered in **`MANAGED_AUTH_MIGRATIONS`** (`db/internal.ts`) — runs only when managed auth created the table; skipped everywhere else (so `migrate-pg.test.ts` stays green and self-hosted doesn't break).
  - no `schema.ts` change is needed/possible (drift check only validates `CREATE TABLE` → `pgTable`; verified `check-schema-drift.sh` passes).
  - existing rows backfill to migration time, so every org reads as "active" for the first dormancy window — legacy refresh-everything behavior is preserved until real activity accumulates.
- **Write path — `markOrgActive` (`lib/db/org-activity.ts`)** stamps the column on authenticated chat turns. Throttled (≤1 write/org/hour, in-memory per-pod), fire-and-forget (guards `hasInternalDB()`; `internalExecute` swallows async failures), and **managed-auth gated** (the table only exists there). Wired into the chat route right after the workspace-status check.
- **Dormancy gate — `findStaleByotCatalogs`** now `LEFT JOIN`s `organization` and filters `last_active_at > now() - ATLAS_BYOT_DORMANCY_DAYS` (default **30**, `0` disables). The gate is **managed-auth only** (a JOIN to the absent table would error in byot/simple-key/none — those fall back to the TTL-only query) and treats a **missing org row (orphan config) as active**, so it only ever *adds* skips for orgs that demonstrably exist AND are idle — never silently drops a refresh the legacy query would have done.

## Configurability

`ATLAS_BYOT_DORMANCY_DAYS` (default 30, `0` disables) — documented in `.env.example`.

## Testing

- `lib/db/__tests__/org-activity.test.ts` — guards (empty/no-DB/non-managed), per-org throttle, distinct-org isolation, write-after-window, synchronous-throw swallowed.
- `lib/scheduler/__tests__/byot-catalog-refresh.test.ts` — dormancy JOIN wiring under managed auth, TTL-only fallback for non-managed, `0` disables the gate, active orgs still refresh, env-resolution (default/override/0/garbage).
- **Real Postgres**: migration ALTER (NOT NULL + backfill + idempotent re-run) and **both** query variants validated — gated query returns active + orphan and excludes the 60-day-dormant org; legacy returns all three.
- `bun run scripts/test-isolated.ts --affected` → **220 files, 0 failed**. `tsgo --noEmit`, eslint, and `check-schema-drift.sh` all green.

## Acceptance criteria

- [x] Column added + mirrored (TS/usage layer — `organization` isn't a Drizzle table); refresh skips orgs idle > threshold.
- [x] Threshold configurable (`ATLAS_BYOT_DORMANCY_DAYS`); legacy behavior preserved for active orgs (and for non-managed deploys + the post-migration backfill window).

## Notes / scope

- Activity is stamped from the **web chat** surface (the issue's "chat handler or authenticateRequest"). MCP/Slack-proactive surfaces are also "activity" and could stamp in a follow-up, but chat is the canonical signal and keeps blast radius tight.
- No index on `last_active_at`: the dormancy query reaches `organization` by PK (joined from `workspace_model_config.org_id`), so it's a post-lookup row filter, not a scan key — an index would only add write amplification to `markOrgActive`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3113"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783020820&installation_id=135337507&pr_number=3113&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3113&signature=fd866cd35a6f06e74bf3912fa7b93b2b66ec8db355e13cf623756e99a6c1f542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * BYOT catalog refresh can skip workspaces idle beyond a configurable dormancy threshold; caller activity is recorded so active workspaces aren’t skipped.

* **Configuration**
  * Documented ATLAS_BYOT_DORMANCY_DAYS (managed-auth only). Default 30 days; set to 0 to disable; non-integer/invalid values fall back to default.

* **Database**
  * Added per-organization last-active timestamp to enable dormancy gating.

* **Tests**
  * Expanded tests for dormancy gating, env parsing, scheduler behavior, migration, and org-activity throttling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->