### PR TITLE
fix(backups): structural verify/restore error mapping + count-assertion verify (#2989)

### DIFF
--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -68528,7 +68528,7 @@
             }
           },
           "404": {
-            "description": "Enterprise feature not enabled",
+            "description": "Enterprise feature not enabled, or the backup was purged before confirmation",
             "content": {
               "application/json": {
                 "schema": {

--- a/ee/src/backups/engine.test.ts
+++ b/ee/src/backups/engine.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, mock } from "bun:test";
+import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
 import { Effect } from "effect";
 import { createEEMock } from "../__mocks__/internal";
 
@@ -74,6 +74,7 @@ const {
   ensureTable,
   getBackupConfig,
   updateBackupConfig,
+  createBackup,
   listBackups,
   getBackupById,
   purgeExpiredBackups,
@@ -163,6 +164,67 @@ describe("updateBackupConfig", () => {
     expect(upsertQuery.sql).toContain("ON CONFLICT");
     expect(upsertQuery.params[0]).toBe("0 1 * * *"); // new schedule
     expect(upsertQuery.params[1]).toBe(30); // unchanged retention
+  });
+});
+
+describe("createBackup — expected_table_count baseline (#2989)", () => {
+  let priorDatabaseUrl: string | undefined;
+
+  beforeEach(() => {
+    ee.reset();
+    _resetTableReady();
+    mockSpawn.mockClear();
+    priorDatabaseUrl = process.env.DATABASE_URL;
+    process.env.DATABASE_URL = "postgresql://user:pass@localhost:5432/testdb";
+  });
+
+  afterEach(() => {
+    if (priorDatabaseUrl === undefined) delete process.env.DATABASE_URL;
+    else process.env.DATABASE_URL = priorDatabaseUrl;
+  });
+
+  // Query order for createBackup:
+  //   ensureTable (6) + getBackupConfig SELECT (1) + INSERT in-progress (1)
+  //   + countSourceBaseTables SELECT (1) + completed UPDATE (1) = 10 queries.
+  const completedUpdate = () =>
+    ee.capturedQueries.find((q) => q.sql.includes("status = 'completed'"));
+
+  it("persists the source's public BASE TABLE count into the completed UPDATE", async () => {
+    ee.queueMockRows(
+      [], [], [], [], [], [],            // ensureTable
+      [defaultConfigRow],                 // getBackupConfig SELECT
+      [{ id: "b1" }],                     // INSERT ... RETURNING id
+      [{ count: "5" }],                   // countSourceBaseTables
+      [],                                 // completed UPDATE
+    );
+
+    const result = await run(createBackup());
+    expect(result.status).toBe("completed");
+
+    const update = completedUpdate();
+    expect(update).toBeDefined();
+    expect(update!.sql).toContain("expected_table_count = $2");
+    // params = [size_bytes, expected_table_count, id]
+    expect(update!.params[1]).toBe(5);
+    expect(update!.params[2]).toBe("b1");
+  });
+
+  it("falls back to null (best-effort) when the table count is unreadable — backup still completes", async () => {
+    ee.queueMockRows(
+      [], [], [], [], [], [],            // ensureTable
+      [defaultConfigRow],                 // getBackupConfig SELECT
+      [{ id: "b1" }],                     // INSERT ... RETURNING id
+      [],                                 // countSourceBaseTables → no row → NaN → null
+      [],                                 // completed UPDATE
+    );
+
+    const result = await run(createBackup());
+    // A missing count must NOT abort an otherwise-good backup.
+    expect(result.status).toBe("completed");
+
+    const update = completedUpdate();
+    expect(update).toBeDefined();
+    expect(update!.params[1]).toBeNull();
   });
 });
 

--- a/ee/src/backups/engine.test.ts
+++ b/ee/src/backups/engine.test.ts
@@ -98,17 +98,19 @@ describe("ensureTable", () => {
 
   it("creates tables and seeds config on first call", async () => {
     // Queue empty results for all CREATE TABLE/ALTER/INDEX/INSERT queries
-    ee.queueMockRows([], [], [], [], []);
+    ee.queueMockRows([], [], [], [], [], []);
     await run(ensureTable());
-    // Should have run: CREATE TABLE backups, ALTER TABLE add verify_level,
-    // CREATE INDEX, CREATE TABLE backup_config, INSERT seed = 5 queries.
-    expect(ee.capturedQueries.length).toBe(5);
+    // Should have run: CREATE TABLE backups, ALTER add verify_level, ALTER add
+    // expected_table_count, CREATE INDEX, CREATE TABLE backup_config, INSERT
+    // seed = 6 queries.
+    expect(ee.capturedQueries.length).toBe(6);
     expect(ee.capturedQueries[0].sql).toContain("CREATE TABLE IF NOT EXISTS backups");
     expect(ee.capturedQueries[1].sql).toContain("ADD COLUMN IF NOT EXISTS verify_level");
+    expect(ee.capturedQueries[2].sql).toContain("ADD COLUMN IF NOT EXISTS expected_table_count");
   });
 
   it("skips creation on second call (idempotent)", async () => {
-    ee.queueMockRows([], [], [], [], []);
+    ee.queueMockRows([], [], [], [], [], []);
     await run(ensureTable());
     const firstCount = ee.capturedQueries.length;
     await run(ensureTable());
@@ -129,8 +131,8 @@ describe("getBackupConfig", () => {
   });
 
   it("returns config row from DB", async () => {
-    // ensureTable (4) + config SELECT (1)
-    ee.queueMockRows([], [], [], [], [], [defaultConfigRow]);
+    // ensureTable (6) + config SELECT (1)
+    ee.queueMockRows([], [], [], [], [], [], [defaultConfigRow]);
     const config = await run(getBackupConfig());
     expect(config.schedule).toBe("0 3 * * *");
     expect(config.retention_days).toBe(30);
@@ -138,8 +140,8 @@ describe("getBackupConfig", () => {
   });
 
   it("returns defaults when config row missing", async () => {
-    // ensureTable (4) + empty config SELECT (1)
-    ee.queueMockRows([], [], [], [], []);
+    // ensureTable (6) + empty config SELECT (1)
+    ee.queueMockRows([], [], [], [], [], []);
     const config = await run(getBackupConfig());
     expect(config.schedule).toBe("0 3 * * *");
     expect(config.retention_days).toBe(30);
@@ -153,8 +155,8 @@ describe("updateBackupConfig", () => {
   });
 
   it("upserts partial config", async () => {
-    // ensureTable (4) + config SELECT (1) + UPSERT (1)
-    ee.queueMockRows([], [], [], [], [], [defaultConfigRow], []);
+    // ensureTable (6) + config SELECT (1) + UPSERT (1)
+    ee.queueMockRows([], [], [], [], [], [], [defaultConfigRow], []);
     await run(updateBackupConfig({ schedule: "0 1 * * *" }));
     // The last query should be the upsert (not the seed from ensureTable)
     const upsertQuery = ee.capturedQueries[ee.capturedQueries.length - 1];
@@ -172,15 +174,15 @@ describe("listBackups", () => {
 
   it("returns backup rows", async () => {
     const row = { id: "b1", created_at: "2026-01-01", size_bytes: "1000", status: "completed", storage_path: "/tmp/b1.sql.gz", retention_expires_at: "2026-02-01", error_message: null };
-    // ensureTable (4) + SELECT (1)
-    ee.queueMockRows([], [], [], [], [], [row]);
+    // ensureTable (6) + SELECT (1)
+    ee.queueMockRows([], [], [], [], [], [], [row]);
     const backups = await run(listBackups());
     expect(backups).toHaveLength(1);
     expect(backups[0].id).toBe("b1");
   });
 
   it("returns empty array when no backups", async () => {
-    ee.queueMockRows([], [], [], [], []);
+    ee.queueMockRows([], [], [], [], [], []);
     const backups = await run(listBackups());
     expect(backups).toHaveLength(0);
   });
@@ -194,15 +196,15 @@ describe("getBackupById", () => {
 
   it("returns backup when found", async () => {
     const row = { id: "b1", created_at: "2026-01-01", size_bytes: "1000", status: "completed", storage_path: "/tmp/b1.sql.gz", retention_expires_at: "2026-02-01", error_message: null };
-    // ensureTable (4) + SELECT (1)
-    ee.queueMockRows([], [], [], [], [], [row]);
+    // ensureTable (6) + SELECT (1)
+    ee.queueMockRows([], [], [], [], [], [], [row]);
     const backup = await run(getBackupById("b1"));
     expect(backup).not.toBeNull();
     expect(backup!.id).toBe("b1");
   });
 
   it("returns null when not found", async () => {
-    ee.queueMockRows([], [], [], [], []);
+    ee.queueMockRows([], [], [], [], [], []);
     const backup = await run(getBackupById("nonexistent"));
     expect(backup).toBeNull();
   });
@@ -219,8 +221,8 @@ describe("purgeExpiredBackups", () => {
       { id: "b1", storage_path: "/tmp/b1.sql.gz" },
       { id: "b2", storage_path: "/tmp/b2.sql.gz" },
     ];
-    // ensureTable (4) + SELECT expired (1) + DELETE b1 (1) + DELETE b2 (1)
-    ee.queueMockRows([], [], [], [], [], expired, [], []);
+    // ensureTable (6) + SELECT expired (1) + DELETE b1 (1) + DELETE b2 (1)
+    ee.queueMockRows([], [], [], [], [], [], expired, [], []);
     mockUnlink = mock(() => Promise.resolve(undefined));
 
     const count = await run(purgeExpiredBackups());
@@ -229,8 +231,8 @@ describe("purgeExpiredBackups", () => {
 
   it("handles ENOENT — file already gone, still deletes DB record", async () => {
     const expired = [{ id: "b1", storage_path: "/tmp/gone.sql.gz" }];
-    // ensureTable (4) + SELECT expired (1) + DELETE (1)
-    ee.queueMockRows([], [], [], [], [], expired, []);
+    // ensureTable (6) + SELECT expired (1) + DELETE (1)
+    ee.queueMockRows([], [], [], [], [], [], expired, []);
     mockUnlink = mock(() => {
       const err = new Error("ENOENT") as NodeJS.ErrnoException;
       err.code = "ENOENT";
@@ -243,8 +245,8 @@ describe("purgeExpiredBackups", () => {
 
   it("skips DB deletion when file delete fails with non-ENOENT", async () => {
     const expired = [{ id: "b1", storage_path: "/tmp/locked.sql.gz" }];
-    // ensureTable (4) + SELECT expired (1) — no DELETE (file unlink fails)
-    ee.queueMockRows([], [], [], [], [], expired);
+    // ensureTable (6) + SELECT expired (1) — no DELETE (file unlink fails)
+    ee.queueMockRows([], [], [], [], [], [], expired);
     mockUnlink = mock(() => {
       const err = new Error("EACCES") as NodeJS.ErrnoException;
       err.code = "EACCES";
@@ -256,8 +258,8 @@ describe("purgeExpiredBackups", () => {
   });
 
   it("returns 0 when no expired backups", async () => {
-    // ensureTable (4) + SELECT expired returns empty (1)
-    ee.queueMockRows([], [], [], [], []);
+    // ensureTable (6) + SELECT expired returns empty (1)
+    ee.queueMockRows([], [], [], [], [], []);
     const count = await run(purgeExpiredBackups());
     expect(count).toBe(0);
   });
@@ -270,8 +272,8 @@ describe("listStorageFiles", () => {
   });
 
   it("returns only .sql.gz files", async () => {
-        // getBackupConfig: ensureTable (4) + SELECT config (1)
-    ee.queueMockRows([], [], [], [], [], [defaultConfigRow]);
+        // getBackupConfig: ensureTable (6) + SELECT config (1)
+    ee.queueMockRows([], [], [], [], [], [], [defaultConfigRow]);
     mockReaddir = mock(() => Promise.resolve(["a.sql.gz", "b.sql.gz", "notes.txt"]));
 
     const files = await run(listStorageFiles());
@@ -279,8 +281,8 @@ describe("listStorageFiles", () => {
   });
 
   it("returns empty array when directory does not exist (ENOENT)", async () => {
-        // getBackupConfig: ensureTable (4) + SELECT config (1)
-    ee.queueMockRows([], [], [], [], [], [defaultConfigRow]);
+        // getBackupConfig: ensureTable (6) + SELECT config (1)
+    ee.queueMockRows([], [], [], [], [], [], [defaultConfigRow]);
     mockReaddir = mock(() => {
       const err = new Error("ENOENT") as NodeJS.ErrnoException;
       err.code = "ENOENT";
@@ -292,8 +294,8 @@ describe("listStorageFiles", () => {
   });
 
   it("propagates non-ENOENT errors", async () => {
-        // getBackupConfig: ensureTable (4) + SELECT config (1)
-    ee.queueMockRows([], [], [], [], [], [defaultConfigRow]);
+        // getBackupConfig: ensureTable (6) + SELECT config (1)
+    ee.queueMockRows([], [], [], [], [], [], [defaultConfigRow]);
     mockReaddir = mock(() => {
       const err = new Error("EACCES") as NodeJS.ErrnoException;
       err.code = "EACCES";

--- a/ee/src/backups/engine.ts
+++ b/ee/src/backups/engine.ts
@@ -62,6 +62,19 @@ export const ensureTable = (): Effect.Effect<void, EnterpriseError | Error> =>
         `ALTER TABLE backups ADD COLUMN IF NOT EXISTS verify_level TEXT`,
       ),
     );
+    // expected_table_count records the source DB's public BASE TABLE count
+    // at backup time. verifyByRestore asserts restored >= expected to catch
+    // a dump truncated on a CLEAN statement boundary — psql exits 0 but the
+    // restore is incomplete, which the bare "> 0 base tables" check misses
+    // (#2989, follow-up to #2941). Mirrored in
+    // `packages/api/src/lib/db/schema.ts` (`expectedTableCount`) so the next
+    // `drizzle-kit generate` doesn't emit a DROP COLUMN. Idempotent ALTER
+    // adds it at runtime for deployments whose `backups` table predates this.
+    yield* Effect.promise(() =>
+      internalQuery(
+        `ALTER TABLE backups ADD COLUMN IF NOT EXISTS expected_table_count INTEGER`,
+      ),
+    );
     yield* Effect.promise(() =>
       internalQuery(
         `CREATE INDEX IF NOT EXISTS idx_backups_status ON backups (status, created_at DESC)`,
@@ -180,6 +193,37 @@ function parseDatabaseUrl(url: string): { args: string[]; password: string | und
 }
 
 /**
+ * Count the source DB's public BASE TABLE count — the verification baseline
+ * persisted on each backup (#2989). Queried via `internalQuery` (the same
+ * internal Postgres pg_dump dumps), filtered to `BASE TABLE` in the `public`
+ * schema so it lines up with what `verifyByRestore` counts after restoring.
+ *
+ * Best-effort: returns `null` (not a failure) when the count can't be read,
+ * so a transient query error never aborts an otherwise-good backup — verify
+ * simply skips the `restored >= expected` assertion for that backup.
+ */
+const countSourceBaseTables = (): Effect.Effect<number | null, never> =>
+  Effect.tryPromise({
+    try: () =>
+      internalQuery<{ count: string }>(
+        `SELECT count(*)::text AS count FROM information_schema.tables WHERE table_schema = 'public' AND table_type = 'BASE TABLE'`,
+      ),
+    catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+  }).pipe(
+    Effect.map((rows) => {
+      const n = rows[0] ? parseInt(rows[0].count, 10) : Number.NaN;
+      return Number.isNaN(n) ? null : n;
+    }),
+    Effect.catchAll((err) => {
+      log.warn(
+        { err: err instanceof Error ? err.message : String(err) },
+        "Could not count source base tables for the backup verification baseline — verify will skip the count assertion",
+      );
+      return Effect.succeed(null);
+    }),
+  );
+
+/**
  * Create a backup of the internal database.
  *
  * Uses pg_dump with plain-text format, then gzip-compresses the output.
@@ -260,17 +304,21 @@ export const createBackup = (): Effect.Effect<
         catch: (err) => err instanceof Error ? err : new Error(String(err)),
       });
 
+      // Capture the source DB's public BASE TABLE count as the verification
+      // baseline (#2989). Best-effort — null when unreadable.
+      const expectedTableCount = yield* countSourceBaseTables();
+
       // Mark as completed
       yield* Effect.tryPromise({
         try: () =>
           internalQuery(
-            `UPDATE backups SET status = 'completed', size_bytes = $1 WHERE id = $2`,
-            [fileStat.size, backupId],
+            `UPDATE backups SET status = 'completed', size_bytes = $1, expected_table_count = $2 WHERE id = $3`,
+            [fileStat.size, expectedTableCount, backupId],
           ),
         catch: (err) => err instanceof Error ? err : new Error(String(err)),
       });
 
-      log.info({ backupId, storagePath, sizeBytes: fileStat.size }, "Backup completed successfully");
+      log.info({ backupId, storagePath, sizeBytes: fileStat.size, expectedTableCount }, "Backup completed successfully");
       return { id: backupId, storagePath, sizeBytes: fileStat.size, status: "completed" as const };
     });
 
@@ -308,6 +356,13 @@ export type BackupRow = {
   error_message: string | null;
   /** Depth of the last verification — 'full-restore' | 'header-only' | null (never verified). */
   verify_level: string | null;
+  /**
+   * Source DB's public BASE TABLE count captured at backup time (#2989).
+   * `verifyByRestore` asserts the restored count is >= this. Null for
+   * backups created before this column existed, or when the count couldn't
+   * be read — verify then skips the assertion.
+   */
+  expected_table_count: number | null;
 };
 
 type BackupRowQuery = {
@@ -319,6 +374,7 @@ type BackupRowQuery = {
   retention_expires_at: string;
   error_message: string | null;
   verify_level: string | null;
+  expected_table_count: number | null;
 };
 
 export const listBackups = (limit = 50): Effect.Effect<BackupRow[], EnterpriseError | Error> =>
@@ -326,7 +382,7 @@ export const listBackups = (limit = 50): Effect.Effect<BackupRow[], EnterpriseEr
     yield* ensureTable();
     const rows = yield* Effect.promise(() =>
       internalQuery<BackupRowQuery>(
-        `SELECT id, created_at::text, size_bytes::text, status, storage_path, retention_expires_at::text, error_message, verify_level
+        `SELECT id, created_at::text, size_bytes::text, status, storage_path, retention_expires_at::text, error_message, verify_level, expected_table_count
          FROM backups
          ORDER BY created_at DESC
          LIMIT $1`,
@@ -341,7 +397,7 @@ export const getBackupById = (id: string): Effect.Effect<BackupRow | null, Enter
     yield* ensureTable();
     const rows = yield* Effect.promise(() =>
       internalQuery<BackupRowQuery>(
-        `SELECT id, created_at::text, size_bytes::text, status, storage_path, retention_expires_at::text, error_message, verify_level
+        `SELECT id, created_at::text, size_bytes::text, status, storage_path, retention_expires_at::text, error_message, verify_level, expected_table_count
          FROM backups WHERE id = $1`,
         [id],
       ),

--- a/ee/src/backups/restore.ts
+++ b/ee/src/backups/restore.ts
@@ -14,7 +14,12 @@ import { createGunzip } from "zlib";
 import { pipeline } from "stream/promises";
 import { Effect } from "effect";
 import { requireEnterpriseEffect } from "../index";
-import { EnterpriseError } from "@atlas/api/lib/effect/errors";
+import {
+  EnterpriseError,
+  BackupNotFoundError,
+  BackupInvalidStateError,
+  BackupRestoreTokenError,
+} from "@atlas/api/lib/effect/errors";
 import { requireInternalDBEffect } from "../lib/db-guard";
 import { createLogger } from "@atlas/api/lib/logger";
 import { createBackup, getBackupById, ensureTable } from "./engine";
@@ -42,11 +47,16 @@ export const requestRestore = (backupId: string): Effect.Effect<
 
     const backup = yield* getBackupById(backupId);
     if (!backup) {
-      return yield* Effect.fail(new Error("Backup not found"));
+      // Tagged → route maps to 404 structurally (#2989). Message preserved.
+      return yield* Effect.fail(new BackupNotFoundError({ message: "Backup not found" }));
     }
 
     if (backup.status !== "completed" && backup.status !== "verified") {
-      return yield* Effect.fail(new Error(`Cannot restore backup with status "${backup.status}" — only completed or verified backups can be restored`));
+      return yield* Effect.fail(
+        new BackupInvalidStateError({
+          message: `Cannot restore backup with status "${backup.status}" — only completed or verified backups can be restored`,
+        }),
+      );
     }
 
     const token = crypto.randomUUID();
@@ -82,12 +92,14 @@ export const executeRestore = (
 
     const pending = pendingRestores.get(confirmationToken);
     if (!pending) {
-      return yield* Effect.fail(new Error("Invalid or expired confirmation token"));
+      // Tagged → confirm route maps to 400 structurally (#2989), no
+      // `message.includes("Invalid or expired")`. Message preserved.
+      return yield* Effect.fail(new BackupRestoreTokenError({ message: "Invalid or expired confirmation token" }));
     }
 
     if (pending.expiresAt < Date.now()) {
       pendingRestores.delete(confirmationToken);
-      return yield* Effect.fail(new Error("Confirmation token has expired — request a new one"));
+      return yield* Effect.fail(new BackupRestoreTokenError({ message: "Confirmation token has expired — request a new one" }));
     }
 
     pendingRestores.delete(confirmationToken);
@@ -100,7 +112,8 @@ export const executeRestore = (
 
     const backup = yield* getBackupById(backupId);
     if (!backup) {
-      return yield* Effect.fail(new Error("Backup not found — it may have been purged"));
+      // Purged between request and confirm → 404 structurally (#2989).
+      return yield* Effect.fail(new BackupNotFoundError({ message: "Backup not found — it may have been purged" }));
     }
 
     log.warn({ backupId }, "Starting database restore — creating pre-restore backup first");

--- a/ee/src/backups/verify-restore.test.ts
+++ b/ee/src/backups/verify-restore.test.ts
@@ -73,7 +73,7 @@ const { verifyBackup, scratchTargetsSameAsPrimary } = await import("./verify");
 
 const run = <A, E>(effect: Effect.Effect<A, E>) => Effect.runPromise(effect as Effect.Effect<A, never>);
 
-const baseBackup = (storagePath: string) => ({
+const baseBackup = (storagePath: string, expectedTableCount: number | null = null) => ({
   id: "b1",
   created_at: "2026-01-01",
   size_bytes: "1000",
@@ -82,6 +82,8 @@ const baseBackup = (storagePath: string) => ({
   retention_expires_at: "2026-02-01",
   error_message: null,
   verify_level: null,
+  // #2989 — verification baseline. null skips the restored >= expected check.
+  expected_table_count: expectedTableCount,
 });
 
 // ── (2) Fail-loud — scratch URL set but psql can't run ───────────────
@@ -300,5 +302,42 @@ describeIfPg("verifyBackup full-restore — real Postgres smoke (#2941)", () => 
     expect(result.level).toBe("full-restore");
     expect(result.verified).toBe(false);
     expect(result.message).toContain("zero base tables");
+  });
+
+  it("REGRESSION: a clean-boundary-truncated dump now FAILS via the count assertion (#2989)", async () => {
+    // VALID_DUMP restores exactly ONE base table (widgets) and exits psql 0 —
+    // the bare "> 0 base tables" check passes. But the backup recorded that the
+    // SOURCE had 3 public base tables at creation time, so the dump must have
+    // been truncated on a clean statement boundary (the last 2 CREATE TABLEs
+    // never made it). restored (1) < expected (3) → verification FAILS.
+    const dumpPath = join(tmp, "fewer-tables.sql.gz");
+    writeFileSync(dumpPath, gzipSync(Buffer.from(VALID_DUMP)));
+    mockBackup = baseBackup(dumpPath, 3); // source had 3 public base tables
+    ee.queueMockRows([]); // status -> failed UPDATE
+
+    const result = await run(verifyBackup("b1"));
+    rmSync(tmp, { recursive: true, force: true });
+
+    expect(result.level).toBe("full-restore");
+    expect(result.verified).toBe(false);
+    expect(result.message).toContain("the source had 3");
+    expect(result.message).toMatch(/restored 1 base table/);
+  });
+
+  it("verifies a valid dump whose restored count MEETS the expected baseline (#2989)", async () => {
+    // VALID_DUMP restores 1 base table; the backup recorded expected = 1.
+    // restored (1) >= expected (1) → verified, and the success message notes
+    // the baseline was met.
+    const dumpPath = join(tmp, "meets-baseline.sql.gz");
+    writeFileSync(dumpPath, gzipSync(Buffer.from(VALID_DUMP)));
+    mockBackup = baseBackup(dumpPath, 1); // source had exactly 1 public base table
+    ee.queueMockRows([]); // status -> verified UPDATE
+
+    const result = await run(verifyBackup("b1"));
+    rmSync(tmp, { recursive: true, force: true });
+
+    expect(result.level).toBe("full-restore");
+    expect(result.verified).toBe(true);
+    expect(result.message).toContain(">= 1 expected");
   });
 });

--- a/ee/src/backups/verify.ts
+++ b/ee/src/backups/verify.ts
@@ -12,8 +12,13 @@
  *    corrupt-tailed makes psql exit non-zero (or yields zero base tables) under
  *    ON_ERROR_STOP=on, so verification FAILS — which header-only checking missed.
  *    NOTE: this is a *structural* smoke (base tables exist after restore), not a
- *    row-level completeness proof — a dump truncated on a clean statement
- *    boundary after some tables already restored can still pass. See #2941.
+ *    row-level completeness proof. #2989 hardened it with a table-COUNT
+ *    assertion: backups record the source's public BASE TABLE count at creation
+ *    time, and verification fails if fewer tables restore than the source had —
+ *    catching a dump truncated on a clean statement boundary (psql exits 0 but
+ *    drops tables) that the bare base-table check missed. A dump truncated mid-
+ *    way through the LAST table's data (same table count, fewer rows) can still
+ *    pass — row-level completeness remains out of scope. See #2941 / #2989.
  *
  *  - **header-only** (degraded fallback): when no scratch URL is configured we
  *    gunzip the first 4096 bytes and check for the pg_dump header string. This
@@ -38,7 +43,11 @@ import { createGunzip } from "zlib";
 import { pipeline } from "stream/promises";
 import { Effect } from "effect";
 import { requireEnterpriseEffect } from "../index";
-import { EnterpriseError } from "@atlas/api/lib/effect/errors";
+import {
+  EnterpriseError,
+  BackupNotFoundError,
+  BackupInvalidStateError,
+} from "@atlas/api/lib/effect/errors";
 import { requireInternalDBEffect } from "../lib/db-guard";
 import { internalQuery } from "@atlas/api/lib/db/internal";
 import { createLogger } from "@atlas/api/lib/logger";
@@ -73,11 +82,15 @@ export const verifyBackup = (
 
     const backup = yield* getBackupById(backupId);
     if (!backup) {
-      return yield* Effect.fail(new Error("Backup not found"));
+      // Tagged so the platform-backups route maps it to 404 structurally
+      // (no `message.includes("not found")`). Message preserved verbatim.
+      return yield* Effect.fail(new BackupNotFoundError({ message: "Backup not found" }));
     }
 
     if (backup.status !== "completed" && backup.status !== "verified") {
-      return yield* Effect.fail(new Error(`Cannot verify backup with status "${backup.status}"`));
+      return yield* Effect.fail(
+        new BackupInvalidStateError({ message: `Cannot verify backup with status "${backup.status}"` }),
+      );
     }
 
     const scratchUrl = process.env.ATLAS_BACKUP_VERIFY_SCRATCH_URL;
@@ -90,7 +103,7 @@ export const verifyBackup = (
 
     // Inner effect uses tryPromise so errors land in the typed channel
     const verifyWork = scratchUrl
-      ? verifyByRestore(backupId, backup.storage_path, scratchUrl)
+      ? verifyByRestore(backupId, backup.storage_path, scratchUrl, backup.expected_table_count)
       : verifyByHeader(backupId, backup.storage_path);
 
     return yield* verifyWork.pipe(
@@ -141,15 +154,21 @@ export const verifyBackup = (
  * yields zero base tables → verification fails.
  *
  * This is a *structural* smoke (base tables exist after restore), not a
- * row-level completeness proof. A dump truncated on a clean statement boundary
- * after some tables already restored can still pass — recording the source DB's
- * expected base-table count at backup time and asserting `restored >= expected`
- * is a tracked follow-up to #2941.
+ * row-level completeness proof. But it now also closes the clean-boundary gap
+ * from #2941 (resolved in #2989): when the backup recorded the source DB's
+ * `expectedTableCount` at creation time, we assert `restored >= expected`. A
+ * dump truncated on a CLEAN statement boundary (after some tables already
+ * restored) exits psql 0 yet restores FEWER tables than the source had — the
+ * bare "> 0 base tables" check missed this; the count assertion catches it.
+ * `expectedTableCount` is null for pre-#2989 backups (or when the count
+ * couldn't be read at backup time), in which case the assertion is skipped and
+ * behaviour falls back to the structural smoke alone.
  */
 const verifyByRestore = (
   backupId: string,
   storagePath: string,
   scratchUrl: string,
+  expectedTableCount: number | null,
 ): Effect.Effect<{ verified: boolean; message: string; level: VerifyLevel }, Error> =>
   Effect.gen(function* () {
     // Safety net: refuse to wipe the scratch DB if it resolves to the same
@@ -203,6 +222,26 @@ const verifyByRestore = (
       };
     }
 
+    // Count assertion (#2989): a dump truncated on a CLEAN statement boundary
+    // restores fewer tables than the source had, yet exits psql 0 — the
+    // tableCount > 0 check above can't see it. When the backup recorded the
+    // source's table count, require restored >= expected.
+    if (expectedTableCount !== null && tableCount < expectedTableCount) {
+      const message =
+        `Restore smoke restored ${tableCount} base table(s) but the source had ${expectedTableCount} at backup time — ` +
+        `the dump is incomplete (likely truncated on a clean statement boundary)`;
+      yield* Effect.tryPromise({
+        try: () =>
+          internalQuery(
+            `UPDATE backups SET status = 'failed', verify_level = 'full-restore', error_message = $1 WHERE id = $2`,
+            [message, backupId],
+          ),
+        catch: (err) => err instanceof Error ? err : new Error(String(err)),
+      });
+      log.error({ backupId, tableCount, expectedTableCount }, "Backup verification failed — restored fewer base tables than the source had");
+      return { verified: false, message, level: "full-restore" as const };
+    }
+
     yield* Effect.tryPromise({
       try: () =>
         internalQuery(
@@ -212,10 +251,11 @@ const verifyByRestore = (
       catch: (err) => err instanceof Error ? err : new Error(String(err)),
     });
 
-    log.info({ backupId, tableCount, level: "full-restore" }, "Backup verified via restore-into-scratch-DB smoke");
+    log.info({ backupId, tableCount, expectedTableCount, level: "full-restore" }, "Backup verified via restore-into-scratch-DB smoke");
+    const expectedNote = expectedTableCount !== null ? ` (>= ${expectedTableCount} expected)` : "";
     return {
       verified: true,
-      message: `Backup verified — structural smoke: ${tableCount} base table(s) restored into the scratch DB (not a row-level completeness proof)`,
+      message: `Backup verified — structural smoke: ${tableCount} base table(s) restored into the scratch DB${expectedNote} (not a row-level completeness proof)`,
       level: "full-restore" as const,
     };
   });

--- a/packages/api/src/api/routes/platform-backups.ts
+++ b/packages/api/src/api/routes/platform-backups.ts
@@ -313,29 +313,23 @@ platformBackups.openapi(verifyBackupRoute, async (c) => {
 
     const backupId = c.req.param("id");
 
-    const verifyResult = yield* backupsMod.verifyBackup(backupId).pipe(Effect.either);
-    if (verifyResult._tag === "Left") {
-      const message = verifyResult.left.message;
-      if (message.includes("not found")) {
-        return c.json({ error: "not_found", message: "Backup not found.", requestId }, 404);
-      }
-      if (message.includes("Cannot verify")) {
-        return c.json({ error: "invalid_state", message, requestId }, 400);
-      }
-      throw verifyResult.left;
-    }
-    log.info({ backupId, verified: verifyResult.right.verified, requestId }, "Backup verification completed");
+    // #2989 — `verifyBackup` fails with tagged errors (`BackupNotFoundError`
+    // → 404, `BackupInvalidStateError` → 400) that `runEffect` maps
+    // structurally via `mapTaggedError`. No `Effect.either` + message
+    // string-matching: the codebase bans string-based error classification.
+    const verifyResult = yield* backupsMod.verifyBackup(backupId);
+    log.info({ backupId, verified: verifyResult.verified, requestId }, "Backup verification completed");
 
     logAdminAction({
       actionType: ADMIN_ACTIONS.backup.verify,
       targetType: "backup",
       targetId: backupId,
       scope: "platform",
-      metadata: { verified: verifyResult.right.verified, message: verifyResult.right.message },
+      metadata: { verified: verifyResult.verified, message: verifyResult.message },
       ipAddress: c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null,
     });
 
-    return c.json(verifyResult.right, 200);
+    return c.json(verifyResult, 200);
   }), { label: "verify backup" });
 });
 
@@ -352,17 +346,10 @@ platformBackups.openapi(requestRestoreRoute, async (c) => {
 
     const backupId = c.req.param("id");
 
-    const restoreResult = yield* backupsMod.requestRestore(backupId).pipe(Effect.either);
-    if (restoreResult._tag === "Left") {
-      const message = restoreResult.left.message;
-      if (message.includes("not found")) {
-        return c.json({ error: "not_found", message: "Backup not found.", requestId }, 404);
-      }
-      if (message.includes("Cannot restore")) {
-        return c.json({ error: "invalid_state", message, requestId }, 400);
-      }
-      throw restoreResult.left;
-    }
+    // #2989 — `requestRestore` fails with tagged errors
+    // (`BackupNotFoundError` → 404, `BackupInvalidStateError` → 400)
+    // mapped structurally by `runEffect`. No message string-matching.
+    const restoreResult = yield* backupsMod.requestRestore(backupId);
     log.warn({ backupId, requestId }, "Restore requested by platform admin");
 
     logAdminAction({
@@ -373,7 +360,7 @@ platformBackups.openapi(requestRestoreRoute, async (c) => {
       ipAddress: c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null,
     });
 
-    return c.json(restoreResult.right, 200);
+    return c.json(restoreResult, 200);
   }), { label: "request restore" });
 });
 
@@ -390,29 +377,24 @@ platformBackups.openapi(confirmRestoreRoute, async (c) => {
 
     const body = c.req.valid("json");
 
-    return yield* backupsMod.executeRestore(body.confirmationToken).pipe(
-      Effect.map((result) => {
-        log.warn({ backupId: c.req.param("id"), preRestoreBackupId: result.preRestoreBackupId, requestId }, "Database restore executed by platform admin");
+    // #2989 — `executeRestore` fails with `BackupRestoreTokenError` → 400
+    // (invalid/expired token) and `BackupNotFoundError` → 404 (purged
+    // mid-flow), both mapped structurally by `runEffect`. Any other
+    // failure (the restore subprocess) is a generic Error → 500. No
+    // `message.includes(...)` token classification, no `Effect.die`.
+    const result = yield* backupsMod.executeRestore(body.confirmationToken);
+    log.warn({ backupId: c.req.param("id"), preRestoreBackupId: result.preRestoreBackupId, requestId }, "Database restore executed by platform admin");
 
-        logAdminAction({
-          actionType: ADMIN_ACTIONS.backup.confirmRestore,
-          targetType: "backup",
-          targetId: c.req.param("id"),
-          scope: "platform",
-          metadata: { preRestoreBackupId: result.preRestoreBackupId },
-          ipAddress: c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null,
-        });
+    logAdminAction({
+      actionType: ADMIN_ACTIONS.backup.confirmRestore,
+      targetType: "backup",
+      targetId: c.req.param("id"),
+      scope: "platform",
+      metadata: { preRestoreBackupId: result.preRestoreBackupId },
+      ipAddress: c.req.header("x-forwarded-for") ?? c.req.header("x-real-ip") ?? null,
+    });
 
-        return c.json(result, 200);
-      }),
-      Effect.catchAll((err) => {
-        const message = err instanceof Error ? err.message : String(err);
-        if (message.includes("Invalid or expired") || message.includes("expired")) {
-          return Effect.succeed(c.json({ error: "invalid_token", message, requestId }, 400));
-        }
-        return Effect.die(err);
-      }),
-    );
+    return c.json(result, 200);
   }), { label: "execute restore" });
 });
 

--- a/packages/api/src/api/routes/platform-backups.ts
+++ b/packages/api/src/api/routes/platform-backups.ts
@@ -157,7 +157,7 @@ const confirmRestoreRoute = createRoute({
     400: { description: "Invalid or expired token", content: { "application/json": { schema: ErrorSchema } } },
     401: { description: "Authentication required", content: { "application/json": { schema: AuthErrorSchema } } },
     403: { description: "Platform admin role required", content: { "application/json": { schema: AuthErrorSchema } } },
-    404: { description: "Enterprise feature not enabled", content: { "application/json": { schema: ErrorSchema } } },
+    404: { description: "Enterprise feature not enabled, or the backup was purged before confirmation", content: { "application/json": { schema: ErrorSchema } } },
     500: { description: "Internal server error", content: { "application/json": { schema: ErrorSchema } } },
   },
 });

--- a/packages/api/src/lib/db/schema.ts
+++ b/packages/api/src/lib/db/schema.ts
@@ -1176,6 +1176,12 @@ export const backups = pgTable(
     // idempotent ALTER in ensureTable(); this mirror keeps drizzle-kit from
     // emitting a DROP COLUMN on the next generate.
     verifyLevel: text("verify_level"),
+    // Source DB's public BASE TABLE count captured at backup time (#2989).
+    // verifyByRestore asserts restored >= expected to catch a dump truncated
+    // on a clean statement boundary (psql exits 0 but incomplete). Like
+    // verify_level, added by an idempotent ALTER in ensureTable(); mirrored
+    // here so drizzle-kit doesn't emit a DROP COLUMN.
+    expectedTableCount: integer("expected_table_count"),
   },
   (t) => [
     index("idx_backups_status").on(t.status, sql`created_at DESC`),

--- a/packages/api/src/lib/effect/__tests__/hono.test.ts
+++ b/packages/api/src/lib/effect/__tests__/hono.test.ts
@@ -64,6 +64,9 @@ const {
   InvalidInstallIdError,
   ChatIntegrationLimitError,
   BillingCheckFailedError,
+  BackupNotFoundError,
+  BackupInvalidStateError,
+  BackupRestoreTokenError,
 } = await import("../errors");
 
 // ---------------------------------------------------------------------------
@@ -477,6 +480,36 @@ describe("mapTaggedError", () => {
     expect(result.code).toBe("billing_check_failed");
     // No `limit` in the body — there's no meaningful cap to report.
     expect(result.body).toBeUndefined();
+  });
+
+  // ── Backups (#2989 — verify/restore structural error mapping) ──────
+  //
+  // The platform-backups routes drop `Effect.either` + `message.includes`
+  // and let these tagged errors propagate; `mapTaggedError` is the only
+  // place their HTTP status/code is decided.
+
+  it("maps BackupNotFoundError to 404 not_found (#2989)", () => {
+    const result = mapTaggedError(new BackupNotFoundError({ message: "Backup not found" }));
+    expect(result.status).toBe(404);
+    expect(result.code).toBe("not_found");
+    expect(result.message).toBe("Backup not found");
+  });
+
+  it("maps BackupInvalidStateError to 400 bad_request (#2989)", () => {
+    const result = mapTaggedError(
+      new BackupInvalidStateError({ message: 'Cannot verify backup with status "in_progress"' }),
+    );
+    expect(result.status).toBe(400);
+    expect(result.code).toBe("bad_request");
+    expect(result.message).toBe('Cannot verify backup with status "in_progress"');
+  });
+
+  it("maps BackupRestoreTokenError to 400 bad_request (#2989)", () => {
+    const result = mapTaggedError(
+      new BackupRestoreTokenError({ message: "Invalid or expired confirmation token" }),
+    );
+    expect(result.status).toBe(400);
+    expect(result.code).toBe("bad_request");
   });
 });
 

--- a/packages/api/src/lib/effect/errors.ts
+++ b/packages/api/src/lib/effect/errors.ts
@@ -844,6 +844,48 @@ export class BillingCheckFailedError extends Data.TaggedError("BillingCheckFaile
   readonly workspaceId: string;
 }> {}
 
+// ── Backups (#2989 — verify/restore structural error mapping) ──────
+
+/**
+ * Backup row not found for the supplied id. Surfaces from
+ * `verifyBackup` / `requestRestore` (and from `executeRestore` when the
+ * backup was purged between request and confirm). Maps to HTTP 404.
+ *
+ * Defined here (not in `ee/src/backups/`) so it participates in the
+ * `AtlasError` union and the `mapTaggedError` exhaustive switch — the
+ * platform-backups routes let it propagate and rely on the structural
+ * mapping instead of `message.includes("not found")` (#2989). The
+ * `_tag` is the load-bearing discriminant; the message is preserved
+ * verbatim for the EE unit tests' `rejects.toThrow(...)` assertions.
+ */
+export class BackupNotFoundError extends Data.TaggedError("BackupNotFoundError")<{
+  readonly message: string;
+}> {}
+
+/**
+ * Backup is not in a state that permits the requested operation —
+ * verify/restore require `completed` or `verified` status. Maps to HTTP
+ * 400 (admin-correctable: wait for the backup to finish, or pick a
+ * different one). Replaces the route's `message.includes("Cannot verify"
+ * / "Cannot restore")` classification (#2989). The message carries the
+ * offending status verbatim.
+ */
+export class BackupInvalidStateError extends Data.TaggedError("BackupInvalidStateError")<{
+  readonly message: string;
+}> {}
+
+/**
+ * Restore confirmation token is missing, unknown, or expired. The
+ * two-step request → confirm restore flow issues a short-lived token;
+ * `executeRestore` fails with this when the token can't be redeemed.
+ * Maps to HTTP 400 — request a new token and retry. Replaces the
+ * confirm route's `message.includes("Invalid or expired" / "expired")`
+ * classification (#2989).
+ */
+export class BackupRestoreTokenError extends Data.TaggedError("BackupRestoreTokenError")<{
+  readonly message: string;
+}> {}
+
 // ── Scheduler ──────────────────────────────────────────────────────
 
 /** Scheduled task execution timed out. */
@@ -920,6 +962,9 @@ export type AtlasError =
   | InvalidInstallIdError
   | ChatIntegrationLimitError
   | BillingCheckFailedError
+  | BackupNotFoundError
+  | BackupInvalidStateError
+  | BackupRestoreTokenError
   | SchedulerTaskTimeoutError
   | SchedulerExecutionError
   | DeliveryError
@@ -997,6 +1042,9 @@ export const ATLAS_ERROR_TAG_LIST = [
   "InvalidInstallIdError",
   "ChatIntegrationLimitError",
   "BillingCheckFailedError",
+  "BackupNotFoundError",
+  "BackupInvalidStateError",
+  "BackupRestoreTokenError",
   "SchedulerTaskTimeoutError",
   "SchedulerExecutionError",
   "DeliveryError",

--- a/packages/api/src/lib/effect/hono.ts
+++ b/packages/api/src/lib/effect/hono.ts
@@ -243,6 +243,17 @@ export function mapTaggedError(error: AtlasError): HttpErrorMapping {
         message: error.message,
         body: { installId: error.installId, reason: error.reason },
       };
+    // #2989 — backup not in a verifiable/restorable state (status not
+    // completed/verified), or the restore confirmation token is missing/
+    // expired. Both are admin-correctable (wait for the backup, pick
+    // another, or request a fresh token) so 400 is the right surface.
+    // Replaces the platform-backups routes' `message.includes(...)`
+    // classification with structural `_tag` mapping. The message carries
+    // the offending status / token detail verbatim — both are admin-safe
+    // (no secrets, no connection strings).
+    case "BackupInvalidStateError":
+    case "BackupRestoreTokenError":
+      return { status: 400, code: "bad_request", message: error.message };
 
     // ── 403 Forbidden — policy/permission violations ─────────────
     case "ForbiddenPatternError":
@@ -254,6 +265,11 @@ export function mapTaggedError(error: AtlasError): HttpErrorMapping {
 
     // ── 404 Not Found ────────────────────────────────────────────
     case "ConnectionNotFoundError":
+      return { status: 404, code: "not_found", message: error.message };
+    // #2989 — backup id has no matching row (never existed, or purged
+    // between a restore request and its confirm). Replaces the
+    // platform-backups routes' `message.includes("not found")` check.
+    case "BackupNotFoundError":
       return { status: 404, code: "not_found", message: error.message };
 
     // ── 409 Conflict — operation rejected because of resource state ─

--- a/packages/api/src/lib/effect/services.ts
+++ b/packages/api/src/lib/effect/services.ts
@@ -1483,6 +1483,13 @@ export type BackupRowShape = {
   readonly error_message: string | null;
   /** Depth of the last verification ('full-restore' | 'header-only') or null if never verified. */
   readonly verify_level: string | null;
+  // NOTE: `expected_table_count` (the EE `BackupRow`'s verification baseline,
+  // #2989) is intentionally NOT surfaced here. It's a verification-internal
+  // detail consumed only by `verifyByRestore` via the direct engine import —
+  // the route reads backups through this Tag and the wire `BackupEntry`, both
+  // of which render verification *depth* (`verify_level`) and *outcome*
+  // (`status` + `error_message`), never the raw expected count. Keep it off
+  // this boundary and out of `@useatlas/types` unless a consumer needs it.
 };
 
 export type CreateBackupResult = {

--- a/packages/web/src/app/platform/backups/page.tsx
+++ b/packages/web/src/app/platform/backups/page.tsx
@@ -41,7 +41,7 @@ import { BackupsResponseSchema, BackupConfigSchema } from "@/ui/lib/admin-schema
 import { ErrorBoundary } from "@/ui/components/error-boundary";
 import { LoadingState } from "@/ui/components/admin/loading-state";
 import { usePlatformAdminGuard } from "@/ui/hooks/use-platform-admin-guard";
-import type { BackupConfig, BackupStatus } from "@/ui/lib/types";
+import type { BackupConfig, BackupEntry, BackupStatus } from "@/ui/lib/types";
 import {
   Archive,
   CheckCircle2,
@@ -57,12 +57,41 @@ import {
 
 // ── Helpers ───────────────────────────────────────────────────────
 
-function statusBadge(status: BackupStatus) {
+function statusBadge(status: BackupStatus, verifyLevel: BackupEntry["verifyLevel"]) {
   switch (status) {
     case "completed":
       return <Badge variant="outline" className="gap-1 border-green-500 text-green-600"><CheckCircle2 className="size-3" />Completed</Badge>;
-    case "verified":
-      return <Badge variant="outline" className="gap-1 border-primary/50 text-primary"><ShieldCheck className="size-3" />Verified</Badge>;
+    case "verified": {
+      // Surface the verification DEPTH, not just "Verified" (#2989/#2941).
+      // full-restore = restored into a scratch DB and counted tables (proven
+      // restorable). header-only = degraded fallback (valid pg_dump header
+      // only; NOT proven restorable) — render it amber as a caution.
+      if (verifyLevel === "header-only") {
+        return (
+          <Badge
+            variant="outline"
+            className="gap-1 border-amber-500 text-amber-600"
+            title="Verified via header-only check — a valid pg_dump header, but NOT proven restorable. Set ATLAS_BACKUP_VERIFY_SCRATCH_URL to enable full restore-into-scratch-DB verification."
+          >
+            <ShieldCheck className="size-3" />Verified (header-only)
+          </Badge>
+        );
+      }
+      return (
+        <Badge
+          variant="outline"
+          className="gap-1 border-primary/50 text-primary"
+          title={
+            verifyLevel === "full-restore"
+              ? "Verified via full restore — the dump was restored into a disposable scratch DB and its tables were counted (proven restorable)."
+              : "Verified."
+          }
+        >
+          <ShieldCheck className="size-3" />
+          {verifyLevel === "full-restore" ? "Verified (full-restore)" : "Verified"}
+        </Badge>
+      );
+    }
     case "in_progress":
       return <Badge variant="outline" className="gap-1 border-amber-500 text-amber-600"><Loader2 className="size-3 animate-spin" />In Progress</Badge>;
     case "failed":
@@ -251,7 +280,7 @@ function BackupsPageContent() {
                 <TableRow key={backup.id}>
                   <TableCell className="font-medium">{formatTimestamp(backup.createdAt)}</TableCell>
                   <TableCell>
-                    {statusBadge(backup.status)}
+                    {statusBadge(backup.status, backup.verifyLevel)}
                     {backup.errorMessage && (
                       <p className="mt-1 text-xs text-destructive">{backup.errorMessage}</p>
                     )}


### PR DESCRIPTION
Closes #2989 — backups-verify polish (deferred follow-ups from #2941 / #2988). Implements **items 2, 4, 6**.

## Item 2 — structural verify/restore error mapping
The platform-backups `verify` / `request-restore` / `confirm-restore` routes classified errors by `message.includes(...)` — the codebase bans string-based error classification.

- New tagged errors in core `lib/effect/errors.ts`: `BackupNotFoundError` (→404), `BackupInvalidStateError` (→400), `BackupRestoreTokenError` (→400), wired into the `AtlasError` union, `ATLAS_ERROR_TAG_LIST`, and the exhaustive `mapTaggedError` switch.
- EE `verify.ts` / `restore.ts` fail with these (messages preserved **verbatim**, so the EE unit tests' `rejects.toThrow(...)` still pass).
- All three routes drop `Effect.either` + string-matching (and the confirm route's `Effect.die`); errors propagate through `runEffect` → `mapTaggedError`.
- **Wire-code note:** the route-local codes `invalid_state` / `invalid_token` become `bad_request` (HTTP **status unchanged** at 400). These are `platform_admin`-only routes; no test, web client, or public-stable surface keys on those code strings (the UI surfaces `message`).

## Item 4 — verification-depth badge
The backups page rendered a generic "Verified" badge. It now reads `verifyLevel` and shows **"Verified (full-restore)"** (proven restorable) vs an amber **"Verified (header-only)"** caution (valid header only — NOT proven restorable), each with an explanatory tooltip.

## Item 6 — expected-vs-restored table-count assertion
`createBackup` now records the source DB's public BASE TABLE count (`expected_table_count`, new column via idempotent `ALTER` + `schema.ts` mirror, following the `verify_level` precedent), and `verifyByRestore` asserts `restored >= expected`. This catches a dump truncated on a **clean statement boundary** (psql exits 0 but drops tables) that the bare "> 0 base tables" check missed. Best-effort/null throughout — pre-#2989 backups and count-read failures degrade gracefully (assertion skipped). Mid-table row truncation (same table count, fewer rows) remains out of scope.

## Deferred / not taken
- **Item 1 (single-source `VerifyLevel`)** explicitly deferred: a new *value* export in `@useatlas/types` trips Scaffold CI until published — avoiding the publish dance this pass.
- **Items 3 / 5** optional, not taken.

## Tests
- `mapTaggedError` unit cases for the 3 new errors; EE message-preservation assertions unchanged and passing.
- New `createBackup` tests covering the `expected_table_count` write + best-effort-null fallback (the producer was previously untested).
- New opt-in real-PG tests for the count assertion (clean-boundary truncation fails; meets-baseline passes). These skip without a scratch DB — same as the existing full-restore verdict tests.

## Review
Ran the pr-review-toolkit specialists (code-review, silent-failure-hunter, type-design, comment-analyzer, pr-test-analyzer): no bugs / no silent failures / comments accurate. Acted on their highest-value findings (createBackup test coverage, `BackupRowShape` omission comment, OpenAPI 404 description). Local gates green: type, lint, affected api tests, EE backup tests, schema-drift, openapi-drift.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3115"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783021377&installation_id=135337507&pr_number=3115&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3115&signature=2fd275fa4d77817d234673d42f87d6ca9e84621159c6bbca6b4fcb2f861f8729"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Backup verification now tracks and validates expected table counts to ensure restore completeness.
  * Backup status badges now distinguish between "header-only" and "full-restore" verification levels in the UI.

* **Improvements**
  * Enhanced error handling with more specific error messages for backup operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->