### PR TITLE
refactor(config): migrate 4 remaining per-env defaults onto env-profile (#2937)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -93,7 +93,9 @@ ATLAS_ADMIN_EMAIL=admin@useatlas.dev
 # ATLAS_AUTH_AUDIENCE=                     # BYOT mode — expected JWT audience (optional)
 # ATLAS_AUTH_ROLE_CLAIM=role              # JWT claim path for BYOT role extraction (supports nested: app_metadata.role)
 # ATLAS_API_KEY_ROLE=analyst              # Role for simple-key auth (viewer/analyst/admin)
-# ATLAS_RATE_LIMIT_RPM=30                 # Max requests per minute per user (0 = disabled)
+# ATLAS_RATE_LIMIT_RPM=30                 # Max requests per minute per user (0/empty = disabled). Default: from
+#                                         # ATLAS_DEPLOY_ENV profile (prod/dev: disabled, staging: 300). A platform-level
+#                                         # DB override and this env var both win over the profile default.
 # ATLAS_RATE_LIMIT_RPM_CHAT=               # Chat-stream RPM ceiling, separate bucket from cheap reads (F-74).
 #                                         # Defaults to max(5, RPM/4) so a 25-step LLM call does not deplete
 #                                         # the same allowance that serves audit-log scrolling and similar
@@ -537,9 +539,15 @@ ATLAS_SANDBOX_URL=http://localhost:8080
 # ATLAS_DEPLOY_ENV=production                 # Deployment shape: production | staging | development (unset = production).
 #                                             # Drives non-secret per-env defaults via packages/api/src/lib/env-profile.ts —
 #                                             # prod defaults email-verification ON + onboarding-emails ON; staging/dev default both OFF;
-#                                             # session-cookie prefix prod=atlas, staging=atlas-staging, dev=atlas-dev.
+#                                             # session-cookie prefix prod=atlas, staging=atlas-staging, dev=atlas-dev;
+#                                             # rate-limit RPM (prod/dev: disabled, staging: 300). It ALSO centralizes
+#                                             # hosted-MCP max sessions, the staging mail sink, and demo-seed-on-boot —
+#                                             # but those are identical across every env today (flat 100, the sink below,
+#                                             # off) and only live here so a future env can diverge; ATLAS_DEPLOY_ENV
+#                                             # does not change them yet.
 #                                             # The per-var legacy overrides (ATLAS_REQUIRE_EMAIL_VERIFICATION,
-#                                             # ATLAS_ONBOARDING_EMAILS_ENABLED, ATLAS_COOKIE_PREFIX) still win when explicitly set.
+#                                             # ATLAS_ONBOARDING_EMAILS_ENABLED, ATLAS_COOKIE_PREFIX, ATLAS_RATE_LIMIT_RPM,
+#                                             # ATLAS_MCP_MAX_SESSIONS, STAGING_MAIL_SINK, ATLAS_SEED_DEMO) still win when explicitly set.
 # ATLAS_COOKIE_PREFIX=                        # Override the per-env session-cookie name prefix (advanced.cookiePrefix). Non-empty wins over the ATLAS_DEPLOY_ENV profile.
 #                                             # MUST equal the web service's NEXT_PUBLIC_ATLAS_COOKIE_PREFIX. Distinct prefixes keep prod & staging
 #                                             # (which share the .useatlas.dev cookie zone) from colliding on one cookie slot.

--- a/deploy/api/Dockerfile
+++ b/deploy/api/Dockerfile
@@ -150,6 +150,10 @@ RUN mkdir -p /app/plugins/chat/node_modules/@useatlas && \
 # Demo seeding (ATLAS_SEED_DEMO=true) — single canonical seed since 1.4.0 (#2021)
 COPY --from=builder --chown=atlas:atlas /app/packages/cli/data/seeds/ecommerce/seed.sql ./data/demo.sql
 COPY --chown=atlas:atlas examples/docker/scripts/seed-demo.ts ./scripts/seed-demo.ts
+# Profile-aware seed gate (#2937): start.sh shells out to this to resolve
+# ATLAS_SEED_DEMO through the env-profile. Dependency-free (imports only
+# @atlas/api/lib/env-profile), so it needs no extra node_modules symlink.
+COPY --chown=atlas:atlas examples/docker/scripts/resolve-seed-demo.ts ./scripts/resolve-seed-demo.ts
 COPY --chown=atlas:atlas deploy/api/atlas.config.ts ./atlas.config.ts
 COPY --chown=atlas:atlas deploy/api/scripts/start.sh ./scripts/start.sh
 # Build-time assertion: canonical seed must be non-empty and the bundled
@@ -157,6 +161,13 @@ COPY --chown=atlas:atlas deploy/api/scripts/start.sh ./scripts/start.sh
 # time rather than booting against an empty DB. (#2021 review-pass)
 RUN test -s ./data/demo.sql || (echo "ERROR: ./data/demo.sql is empty or missing" >&2 && exit 1)
 RUN test -d ./semantic/entities && [ "$(ls -A ./semantic/entities 2>/dev/null)" ] || (echo "ERROR: ./semantic/entities is missing or empty" >&2 && exit 1)
+# Build-time assertion (#2937): the profile-aware seed shim must resolve its
+# @atlas/api/lib/env-profile import in the image layout and print a clean
+# boolean. Run WITHOUT redirecting stderr so a broken import (exports-map drift,
+# a regressed COPY, a moved module) fails the build loudly here — otherwise
+# start.sh's `2>/dev/null` would silently degrade the seed gate to the legacy
+# raw check forever, with no log line anywhere.
+RUN out="$(bun /app/scripts/resolve-seed-demo.ts)"; [ "$out" = "true" ] || [ "$out" = "false" ] || (echo "ERROR: resolve-seed-demo.ts did not print a clean boolean: [$out]" >&2 && exit 1)
 # pg is installed in packages/api/node_modules (not hoisted to root).
 # seed-demo.ts runs from /app/scripts/ and needs pg — symlink it so
 # bun's module resolution finds it from the root node_modules.

--- a/deploy/api/Dockerfile
+++ b/deploy/api/Dockerfile
@@ -151,8 +151,11 @@ RUN mkdir -p /app/plugins/chat/node_modules/@useatlas && \
 COPY --from=builder --chown=atlas:atlas /app/packages/cli/data/seeds/ecommerce/seed.sql ./data/demo.sql
 COPY --chown=atlas:atlas examples/docker/scripts/seed-demo.ts ./scripts/seed-demo.ts
 # Profile-aware seed gate (#2937): start.sh shells out to this to resolve
-# ATLAS_SEED_DEMO through the env-profile. Dependency-free (imports only
-# @atlas/api/lib/env-profile), so it needs no extra node_modules symlink.
+# ATLAS_SEED_DEMO through the env-profile. It imports env-profile by RELATIVE
+# path (../packages/api/src/lib/env-profile) because a script under /app/scripts/
+# is outside the @atlas/api package and there is no node_modules/@atlas/api to
+# resolve here; env-profile is dependency-free so the relative import is
+# self-contained. The build-time assertion below proves it resolves.
 COPY --chown=atlas:atlas examples/docker/scripts/resolve-seed-demo.ts ./scripts/resolve-seed-demo.ts
 COPY --chown=atlas:atlas deploy/api/atlas.config.ts ./atlas.config.ts
 COPY --chown=atlas:atlas deploy/api/scripts/start.sh ./scripts/start.sh

--- a/deploy/api/scripts/start.sh
+++ b/deploy/api/scripts/start.sh
@@ -3,10 +3,23 @@
 # AtlasDevHQ production deployment (api.useatlas.dev).
 set -e
 
-# Seed demo data if ATLAS_SEED_DEMO is enabled.
+# Resolve whether to seed demo data through the env-profile (#2937):
+# ATLAS_SEED_DEMO override → deploy-env profile default. resolve-seed-demo.ts
+# prints "true"/"false". If it can't run (empty output), fall back to the
+# legacy raw check so the "Atlas Demo" template (ATLAS_SEED_DEMO=true) never
+# silently stops seeding.
+SEED_DEMO="$(bun /app/scripts/resolve-seed-demo.ts 2>/dev/null || true)"
+# Trust ONLY the two known-good tokens. Empty output (shim failed to run) or any
+# unexpected value routes through the legacy raw check, so the "Atlas Demo"
+# template (ATLAS_SEED_DEMO=true) can never silently stop seeding.
+if [ "$SEED_DEMO" != "true" ] && [ "$SEED_DEMO" != "false" ]; then
+    [ "$ATLAS_SEED_DEMO" = "true" ] && SEED_DEMO="true" || SEED_DEMO="false"
+fi
+
+# Seed demo data if enabled.
 # Retries up to 5 times with 3s intervals to wait for Postgres readiness.
 # Note: seed command is inside `if`, so set -e does not apply to it (POSIX spec).
-if [ "$ATLAS_SEED_DEMO" = "true" ] && [ -n "$ATLAS_DATASOURCE_URL" ]; then
+if [ "$SEED_DEMO" = "true" ] && [ -n "$ATLAS_DATASOURCE_URL" ]; then
     SEED_OK=false
     for i in 1 2 3 4 5; do
         if bun /app/scripts/seed-demo.ts; then SEED_OK=true; break; fi

--- a/examples/docker/Dockerfile
+++ b/examples/docker/Dockerfile
@@ -97,8 +97,11 @@ COPY --chown=atlas:atlas examples/docker/scripts/start.sh ./scripts/start.sh
 COPY --from=builder --chown=atlas:atlas /app/packages/cli/data/seeds/ecommerce/seed.sql ./data/demo.sql
 COPY --chown=atlas:atlas examples/docker/scripts/seed-demo.ts ./scripts/seed-demo.ts
 # Profile-aware seed gate (#2937): start.sh shells out to this to resolve
-# ATLAS_SEED_DEMO through the env-profile. Dependency-free (imports only
-# @atlas/api/lib/env-profile), so it needs no extra node_modules symlink.
+# ATLAS_SEED_DEMO through the env-profile. It imports env-profile by RELATIVE
+# path (../packages/api/src/lib/env-profile) because a script under /app/scripts/
+# is outside the @atlas/api package and there is no node_modules/@atlas/api to
+# resolve here; env-profile is dependency-free so the relative import is
+# self-contained. The build-time assertion below proves it resolves.
 COPY --chown=atlas:atlas examples/docker/scripts/resolve-seed-demo.ts ./scripts/resolve-seed-demo.ts
 # Build-time assertion: the canonical seed must be non-empty and the bundled
 # semantic layer must contain entities. Catches a regressed COPY or a truncated

--- a/examples/docker/Dockerfile
+++ b/examples/docker/Dockerfile
@@ -96,12 +96,23 @@ COPY --chown=atlas:atlas examples/docker/scripts/start.sh ./scripts/start.sh
 # Demo seeding (Railway "Atlas Demo" template — ATLAS_SEED_DEMO=true)
 COPY --from=builder --chown=atlas:atlas /app/packages/cli/data/seeds/ecommerce/seed.sql ./data/demo.sql
 COPY --chown=atlas:atlas examples/docker/scripts/seed-demo.ts ./scripts/seed-demo.ts
+# Profile-aware seed gate (#2937): start.sh shells out to this to resolve
+# ATLAS_SEED_DEMO through the env-profile. Dependency-free (imports only
+# @atlas/api/lib/env-profile), so it needs no extra node_modules symlink.
+COPY --chown=atlas:atlas examples/docker/scripts/resolve-seed-demo.ts ./scripts/resolve-seed-demo.ts
 # Build-time assertion: the canonical seed must be non-empty and the bundled
 # semantic layer must contain entities. Catches a regressed COPY or a truncated
 # seed file at build time rather than producing an image that boots against
 # an empty database. (#2021 review-pass)
 RUN test -s ./data/demo.sql || (echo "ERROR: ./data/demo.sql is empty or missing" >&2 && exit 1)
 RUN test -d ./semantic/entities && [ "$(ls -A ./semantic/entities 2>/dev/null)" ] || (echo "ERROR: ./semantic/entities is missing or empty" >&2 && exit 1)
+# Build-time assertion (#2937): the profile-aware seed shim must resolve its
+# @atlas/api/lib/env-profile import in the image layout and print a clean
+# boolean. Run WITHOUT redirecting stderr so a broken import (exports-map drift,
+# a regressed COPY, a moved module) fails the build loudly here — otherwise
+# start.sh's `2>/dev/null` would silently degrade the seed gate to the legacy
+# raw check forever, with no log line anywhere.
+RUN out="$(bun /app/scripts/resolve-seed-demo.ts)"; [ "$out" = "true" ] || [ "$out" = "false" ] || (echo "ERROR: resolve-seed-demo.ts did not print a clean boolean: [$out]" >&2 && exit 1)
 # pg is installed in packages/api/node_modules (not hoisted to root).
 # seed-demo.ts runs from /app/scripts/ and needs pg — symlink it so
 # bun's module resolution finds it from the root node_modules.

--- a/examples/docker/scripts/resolve-seed-demo.ts
+++ b/examples/docker/scripts/resolve-seed-demo.ts
@@ -1,0 +1,18 @@
+/**
+ * Boot-time shim: print `true` or `false` for whether the deployed container
+ * should seed the demo dataset, resolved through the env-profile
+ * (`ATLAS_SEED_DEMO` override → deploy-env profile default). `scripts/start.sh`
+ * can't evaluate the TypeScript env-profile directly, so it shells out here and
+ * reads stdout. See `packages/api/src/lib/env-profile.ts :: resolveSeedDemo`.
+ *
+ * COPYed into both the deploy/api and examples/docker images alongside
+ * seed-demo.ts. Imports only the dependency-free env-profile module — no DB, no
+ * network — so it resolves quickly and can't fail on connectivity.
+ *
+ * start.sh treats empty/garbage stdout as "resolver unavailable" and falls back
+ * to the legacy raw `[ "$ATLAS_SEED_DEMO" = "true" ]` check, so a failure here
+ * never silently disables demo seeding for the Railway "Atlas Demo" template.
+ */
+import { resolveSeedDemo } from "@atlas/api/lib/env-profile";
+
+process.stdout.write(resolveSeedDemo() ? "true" : "false");

--- a/examples/docker/scripts/resolve-seed-demo.ts
+++ b/examples/docker/scripts/resolve-seed-demo.ts
@@ -5,14 +5,25 @@
  * can't evaluate the TypeScript env-profile directly, so it shells out here and
  * reads stdout. See `packages/api/src/lib/env-profile.ts :: resolveSeedDemo`.
  *
- * COPYed into both the deploy/api and examples/docker images alongside
- * seed-demo.ts. Imports only the dependency-free env-profile module — no DB, no
- * network — so it resolves quickly and can't fail on connectivity.
+ * IMPORTANT — the import is RELATIVE, not `@atlas/api/lib/env-profile`. This
+ * file is COPYed into the deploy/api and examples/docker images at
+ * `/app/scripts/` and only ever runs from there (via `bun /app/scripts/...`).
+ * From outside the `@atlas/api` package there is no `node_modules/@atlas/api`
+ * to resolve (bun's package self-reference only works for files *inside* the
+ * package, and COPY doesn't reliably preserve workspace symlinks across Docker
+ * drivers — see the symlink-rebuild notes in the Dockerfiles). The relative
+ * path `../packages/api/...` resolves by filesystem against this file's runtime
+ * location `/app/scripts/` → `/app/packages/api/src/lib/env-profile.ts`, which
+ * is always COPYed. env-profile.ts is dependency-free, so the relative import
+ * pulls in nothing else. The repo path (examples/docker/scripts/) is excluded
+ * from tsconfig, so the path is never type-checked against the repo layout; the
+ * Dockerfiles assert it resolves at build time.
  *
- * start.sh treats empty/garbage stdout as "resolver unavailable" and falls back
- * to the legacy raw `[ "$ATLAS_SEED_DEMO" = "true" ]` check, so a failure here
- * never silently disables demo seeding for the Railway "Atlas Demo" template.
+ * start.sh treats any output other than exactly `true`/`false` as "resolver
+ * unavailable" and falls back to the legacy raw `[ "$ATLAS_SEED_DEMO" = "true" ]`
+ * check, so a failure here never silently disables demo seeding for the Railway
+ * "Atlas Demo" template.
  */
-import { resolveSeedDemo } from "@atlas/api/lib/env-profile";
+import { resolveSeedDemo } from "../packages/api/src/lib/env-profile";
 
 process.stdout.write(resolveSeedDemo() ? "true" : "false");

--- a/examples/docker/scripts/start.sh
+++ b/examples/docker/scripts/start.sh
@@ -5,10 +5,23 @@
 # For full-stack deployment (API + Next.js frontend), see examples/nextjs-standalone/.
 set -e
 
-# Seed demo data if ATLAS_SEED_DEMO is enabled (Railway "Atlas Demo" template).
+# Resolve whether to seed demo data through the env-profile (#2937):
+# ATLAS_SEED_DEMO override → deploy-env profile default. resolve-seed-demo.ts
+# prints "true"/"false". If it can't run (empty output), fall back to the
+# legacy raw check so the Railway "Atlas Demo" template (ATLAS_SEED_DEMO=true)
+# never silently stops seeding.
+SEED_DEMO="$(bun /app/scripts/resolve-seed-demo.ts 2>/dev/null || true)"
+# Trust ONLY the two known-good tokens. Empty output (shim failed to run) or any
+# unexpected value routes through the legacy raw check, so the "Atlas Demo"
+# template (ATLAS_SEED_DEMO=true) can never silently stop seeding.
+if [ "$SEED_DEMO" != "true" ] && [ "$SEED_DEMO" != "false" ]; then
+    [ "$ATLAS_SEED_DEMO" = "true" ] && SEED_DEMO="true" || SEED_DEMO="false"
+fi
+
+# Seed demo data if enabled (Railway "Atlas Demo" template sets ATLAS_SEED_DEMO=true).
 # Retries up to 5 times with 3s intervals to wait for Postgres readiness.
 # Note: seed command is inside `if`, so set -e does not apply to it (POSIX spec).
-if [ "$ATLAS_SEED_DEMO" = "true" ] && [ -n "$ATLAS_DATASOURCE_URL" ]; then
+if [ "$SEED_DEMO" = "true" ] && [ -n "$ATLAS_DATASOURCE_URL" ]; then
     SEED_OK=false
     for i in 1 2 3 4 5; do
         if bun /app/scripts/seed-demo.ts; then SEED_OK=true; break; fi

--- a/packages/api/src/lib/__tests__/env-profile.test.ts
+++ b/packages/api/src/lib/__tests__/env-profile.test.ts
@@ -5,6 +5,10 @@ import {
   resolveRequireEmailVerification,
   resolveOnboardingEmailsEnabled,
   resolveCookiePrefix,
+  resolveRateLimitRpm,
+  resolveMcpMaxSessions,
+  resolveMailSink,
+  resolveSeedDemo,
 } from "@atlas/api/lib/env-profile";
 
 describe("resolveDeployEnv", () => {
@@ -46,6 +50,12 @@ describe("getEnvProfile", () => {
     expect(p.requireEmailVerification).toBe(true);
     expect(p.onboardingEmailsEnabled).toBe(true);
     expect(p.cookiePrefix).toBe("atlas");
+    // Phase 2 (#2937): production/dev have NO managed rate-limit default so
+    // self-hosted stays disabled-by-default; mcp cap 100; sink + seed defaults.
+    expect(p.rateLimitRpm).toBeNull();
+    expect(p.mcpMaxSessions).toBe(100);
+    expect(p.mailSink).toBe("staging-mail@useatlas.dev");
+    expect(p.seedDemo).toBe(false);
   });
 
   it("staging profile: verification off, onboarding off, cookiePrefix atlas-staging", () => {
@@ -53,6 +63,12 @@ describe("getEnvProfile", () => {
     expect(p.requireEmailVerification).toBe(false);
     expect(p.onboardingEmailsEnabled).toBe(false);
     expect(p.cookiePrefix).toBe("atlas-staging");
+    // Staging carries a real rate-limit default (300); same sink as every
+    // profile (region↔env-mismatch leak guard); cap 100; no auto-seed.
+    expect(p.rateLimitRpm).toBe(300);
+    expect(p.mcpMaxSessions).toBe(100);
+    expect(p.mailSink).toBe("staging-mail@useatlas.dev");
+    expect(p.seedDemo).toBe(false);
   });
 
   it("development profile: verification off, onboarding off, cookiePrefix atlas-dev", () => {
@@ -60,6 +76,10 @@ describe("getEnvProfile", () => {
     expect(p.requireEmailVerification).toBe(false);
     expect(p.onboardingEmailsEnabled).toBe(false);
     expect(p.cookiePrefix).toBe("atlas-dev");
+    expect(p.rateLimitRpm).toBeNull();
+    expect(p.mcpMaxSessions).toBe(100);
+    expect(p.mailSink).toBe("staging-mail@useatlas.dev");
+    expect(p.seedDemo).toBe(false);
   });
 
   it("unset env falls through to production profile", () => {
@@ -167,5 +187,106 @@ describe("resolveCookiePrefix", () => {
       "atlas-staging",
     );
     expect(resolveCookiePrefix({ ATLAS_COOKIE_PREFIX: "" })).toBe("atlas");
+  });
+});
+
+describe("resolveRateLimitRpm (#2937)", () => {
+  it("production/development profile → undefined (no managed default; self-hosted disabled)", () => {
+    expect(resolveRateLimitRpm({ ATLAS_DEPLOY_ENV: "production" })).toBeUndefined();
+    expect(resolveRateLimitRpm({ ATLAS_DEPLOY_ENV: "development" })).toBeUndefined();
+    // Unset env → production profile → undefined (the self-hosted default path).
+    expect(resolveRateLimitRpm({})).toBeUndefined();
+  });
+
+  it("staging profile → '300' (string, slots into getSetting's string contract)", () => {
+    expect(resolveRateLimitRpm({ ATLAS_DEPLOY_ENV: "staging" })).toBe("300");
+  });
+
+  it("env var overrides the profile default verbatim", () => {
+    expect(resolveRateLimitRpm({ ATLAS_DEPLOY_ENV: "staging", ATLAS_RATE_LIMIT_RPM: "500" })).toBe(
+      "500",
+    );
+    // Override a production deploy to opt into a limit.
+    expect(
+      resolveRateLimitRpm({ ATLAS_DEPLOY_ENV: "production", ATLAS_RATE_LIMIT_RPM: "120" }),
+    ).toBe("120");
+  });
+
+  it("explicit empty env var wins (operator's deliberate 'disable'), not the profile", () => {
+    // "" is a set value → returned verbatim so getRpmLimit() treats it as
+    // disabled, rather than falling through to the staging profile's 300.
+    expect(resolveRateLimitRpm({ ATLAS_DEPLOY_ENV: "staging", ATLAS_RATE_LIMIT_RPM: "" })).toBe("");
+  });
+});
+
+describe("resolveMcpMaxSessions (#2937)", () => {
+  it("every profile defaults to 100 (preserves the historical flat default)", () => {
+    expect(resolveMcpMaxSessions({ ATLAS_DEPLOY_ENV: "production" })).toBe(100);
+    expect(resolveMcpMaxSessions({ ATLAS_DEPLOY_ENV: "staging" })).toBe(100);
+    expect(resolveMcpMaxSessions({ ATLAS_DEPLOY_ENV: "development" })).toBe(100);
+    expect(resolveMcpMaxSessions({})).toBe(100);
+  });
+
+  it("a positive-integer env var overrides the profile default", () => {
+    expect(resolveMcpMaxSessions({ ATLAS_MCP_MAX_SESSIONS: "250" })).toBe(250);
+    expect(resolveMcpMaxSessions({ ATLAS_MCP_MAX_SESSIONS: "  42  " })).toBe(42);
+  });
+
+  it("malformed / non-positive overrides fall back to the profile default", () => {
+    expect(resolveMcpMaxSessions({ ATLAS_MCP_MAX_SESSIONS: "abc" })).toBe(100);
+    expect(resolveMcpMaxSessions({ ATLAS_MCP_MAX_SESSIONS: "0" })).toBe(100);
+    expect(resolveMcpMaxSessions({ ATLAS_MCP_MAX_SESSIONS: "-5" })).toBe(100);
+    expect(resolveMcpMaxSessions({ ATLAS_MCP_MAX_SESSIONS: "" })).toBe(100);
+    expect(resolveMcpMaxSessions({ ATLAS_MCP_MAX_SESSIONS: "   " })).toBe(100);
+  });
+
+  it("parseInt-truncates a decimal override (parity with the legacy parser)", () => {
+    // Number.parseInt("12.9", 10) === 12 — same as the prior raw read.
+    expect(resolveMcpMaxSessions({ ATLAS_MCP_MAX_SESSIONS: "12.9" })).toBe(12);
+  });
+});
+
+describe("resolveMailSink (#2937)", () => {
+  it("every profile default is the same sink (region↔env-mismatch leak guard)", () => {
+    expect(resolveMailSink({ ATLAS_DEPLOY_ENV: "production" })).toBe("staging-mail@useatlas.dev");
+    expect(resolveMailSink({ ATLAS_DEPLOY_ENV: "staging" })).toBe("staging-mail@useatlas.dev");
+    expect(resolveMailSink({ ATLAS_DEPLOY_ENV: "development" })).toBe("staging-mail@useatlas.dev");
+    expect(resolveMailSink({})).toBe("staging-mail@useatlas.dev");
+  });
+
+  it("honors STAGING_MAIL_SINK when set", () => {
+    expect(resolveMailSink({ STAGING_MAIL_SINK: "soak-inbox@staging.useatlas.dev" })).toBe(
+      "soak-inbox@staging.useatlas.dev",
+    );
+  });
+
+  it("empty / whitespace-only STAGING_MAIL_SINK falls back to the default (|| not ??)", () => {
+    // The anti-footgun the staging clamp relies on: a blank override must not
+    // blank the recipient. `.trim()` collapses a whitespace-only value too.
+    expect(resolveMailSink({ STAGING_MAIL_SINK: "" })).toBe("staging-mail@useatlas.dev");
+    expect(resolveMailSink({ STAGING_MAIL_SINK: "   " })).toBe("staging-mail@useatlas.dev");
+  });
+});
+
+describe("resolveSeedDemo (#2937)", () => {
+  it("every profile defaults to false (demo seeding is opt-in via the env var)", () => {
+    expect(resolveSeedDemo({ ATLAS_DEPLOY_ENV: "production" })).toBe(false);
+    expect(resolveSeedDemo({ ATLAS_DEPLOY_ENV: "staging" })).toBe(false);
+    expect(resolveSeedDemo({ ATLAS_DEPLOY_ENV: "development" })).toBe(false);
+    expect(resolveSeedDemo({})).toBe(false);
+  });
+
+  it("ATLAS_SEED_DEMO=true enables (the demo template's explicit opt-in)", () => {
+    expect(resolveSeedDemo({ ATLAS_SEED_DEMO: "true" })).toBe(true);
+  });
+
+  it("mirrors the shell `= \"true\"` check EXACTLY: any other set value is false, never the profile", () => {
+    // A set-but-not-"true" value means "do not seed" and must NOT fall through
+    // to the profile default — matching `[ "$ATLAS_SEED_DEMO" = "true" ]`.
+    expect(resolveSeedDemo({ ATLAS_SEED_DEMO: "false" })).toBe(false);
+    expect(resolveSeedDemo({ ATLAS_SEED_DEMO: "1" })).toBe(false);
+    expect(resolveSeedDemo({ ATLAS_SEED_DEMO: "TRUE" })).toBe(false); // case-sensitive, like shell
+    expect(resolveSeedDemo({ ATLAS_SEED_DEMO: "" })).toBe(false);
+    expect(resolveSeedDemo({ ATLAS_SEED_DEMO: " true " })).toBe(false); // shell wouldn't match with spaces
   });
 });

--- a/packages/api/src/lib/auth/__tests__/middleware.test.ts
+++ b/packages/api/src/lib/auth/__tests__/middleware.test.ts
@@ -547,15 +547,24 @@ describe("authenticateRequest()", () => {
 
 describe("checkRateLimit()", () => {
   const origRpm = process.env.ATLAS_RATE_LIMIT_RPM;
+  const origDeployEnv = process.env.ATLAS_DEPLOY_ENV;
 
   beforeEach(() => {
     resetRateLimits();
     process.env.ATLAS_RATE_LIMIT_RPM = "5"; // low limit for tests
+    // The limiter now falls back to the ATLAS_DEPLOY_ENV profile default when
+    // ATLAS_RATE_LIMIT_RPM is unset (#2937). Pin the deploy env to the
+    // production profile (disabled default) so the env-var-driven cases below
+    // are deterministic regardless of the ambient ATLAS_DEPLOY_ENV; the
+    // profile-fallback cases set it explicitly.
+    delete process.env.ATLAS_DEPLOY_ENV;
   });
 
   afterEach(() => {
     if (origRpm !== undefined) process.env.ATLAS_RATE_LIMIT_RPM = origRpm;
     else delete process.env.ATLAS_RATE_LIMIT_RPM;
+    if (origDeployEnv !== undefined) process.env.ATLAS_DEPLOY_ENV = origDeployEnv;
+    else delete process.env.ATLAS_DEPLOY_ENV;
     resetRateLimits();
   });
 
@@ -636,6 +645,46 @@ describe("checkRateLimit()", () => {
 
     for (let i = 0; i < 100; i++) {
       expect(checkRateLimit("user6").allowed).toBe(true);
+    }
+  });
+
+  // #2937 — profile-fallback wiring: when ATLAS_RATE_LIMIT_RPM is unset, the
+  // limit comes from the ATLAS_DEPLOY_ENV profile (resolveRateLimitRpm). These
+  // exercise the `getSetting(...) ?? resolveRateLimitRpm()` seam in getRpmLimit,
+  // which the env-var-driven tests above never reach (they set the env var, so
+  // getSetting short-circuits before the fallback).
+  it("unset RPM on the production profile stays disabled (no behavior change for self-hosted)", () => {
+    delete process.env.ATLAS_RATE_LIMIT_RPM;
+    process.env.ATLAS_DEPLOY_ENV = "production";
+    resetRateLimits();
+
+    for (let i = 0; i < 100; i++) {
+      expect(checkRateLimit("prod-user").allowed).toBe(true);
+    }
+  });
+
+  it("unset RPM on the staging profile engages the 300 default", () => {
+    delete process.env.ATLAS_RATE_LIMIT_RPM;
+    process.env.ATLAS_DEPLOY_ENV = "staging";
+    resetRateLimits();
+
+    // 300 allowed, then the 301st is blocked — proves the staging profile
+    // default flows through getRpmLimit without the env var being stamped.
+    for (let i = 0; i < 300; i++) {
+      expect(checkRateLimit("staging-user").allowed).toBe(true);
+    }
+    expect(checkRateLimit("staging-user").allowed).toBe(false);
+  });
+
+  it("explicit empty RPM disables even on the staging profile (operator override wins)", () => {
+    // An explicitly-empty env var is the operator's deliberate "disable" — it
+    // must NOT fall through to the staging profile's 300 default.
+    process.env.ATLAS_RATE_LIMIT_RPM = "";
+    process.env.ATLAS_DEPLOY_ENV = "staging";
+    resetRateLimits();
+
+    for (let i = 0; i < 100; i++) {
+      expect(checkRateLimit("staging-disabled").allowed).toBe(true);
     }
   });
 

--- a/packages/api/src/lib/auth/middleware.ts
+++ b/packages/api/src/lib/auth/middleware.ts
@@ -15,6 +15,7 @@ import { validateManaged } from "@atlas/api/lib/auth/managed";
 import { validateBYOT } from "@atlas/api/lib/auth/byot";
 import { createLogger } from "@atlas/api/lib/logger";
 import { getSetting } from "@atlas/api/lib/settings";
+import { resolveRateLimitRpm } from "@atlas/api/lib/env-profile";
 import { Effect } from "effect";
 import { SSOPolicy } from "@atlas/api/lib/effect/services";
 import { runEnterprise } from "@atlas/api/lib/effect/enterprise-layer";
@@ -37,7 +38,14 @@ let lastWarnedChatRpmValue: string | undefined;
 let lastWarnedAdminRpmValue: string | undefined;
 
 function getRpmLimit(): number {
-  const raw = getSetting("ATLAS_RATE_LIMIT_RPM");
+  // Precedence: platform DB override > env var > deploy-env profile default.
+  // `getSetting` is called WITHOUT an orgId here, so only a platform-level DB
+  // override (Tier 2) is consulted — never a workspace-level one — and it
+  // returns the env var (Tier 3) when no DB override is set. It yields
+  // `undefined` only when neither is set, at which point the env-profile
+  // default fills the gap (`resolveRateLimitRpm` → `undefined` for the
+  // production/development profiles, so self-hosted stays disabled-by-default).
+  const raw = getSetting("ATLAS_RATE_LIMIT_RPM") ?? resolveRateLimitRpm();
   if (raw === undefined || raw === "") return 0; // disabled
   const n = Number(raw);
   if (!Number.isFinite(n) || n < 0) {

--- a/packages/api/src/lib/env-profile.ts
+++ b/packages/api/src/lib/env-profile.ts
@@ -11,7 +11,7 @@
  * `ATLAS_DEPLOY_ENV` switch and a typed table.
  *
  * **Migration pattern:** each profile field is paired with a legacy
- * env var that still overrides the profile default (`getProfileValue(...)`
+ * env var that still overrides the profile default (the `resolve*(...)`
  * helpers prefer the env var when set). This lets operators flip a
  * single deployment without changing code, and lets us migrate per-field
  * incrementally — `ATLAS_REQUIRE_EMAIL_VERIFICATION=false` on a prod
@@ -22,11 +22,28 @@
  *   - Secrets (API keys, encryption keys, DB URLs).
  *   - Per-instance values (which specific region serves this api).
  *   - Per-tenant config.
- *   - Boot-script-only env vars read before TypeScript starts (e.g.
- *     `ATLAS_SEED_DEMO` — read by `examples/docker/scripts/start.sh`).
- *   - Settings-registry-managed values (rate limits, MCP session caps —
- *     they have their own env-var fallback semantics; layering
- *     env-profile in would require refactoring the registry).
+ *
+ * **Phase 2 (#2937)** folded in four runtime defaults Phase 1 had deferred.
+ * Each keeps its legacy env-var override, so self-hosted operators see no
+ * behavior change:
+ *   - `ATLAS_SEED_DEMO` — was boot-script-only (`scripts/start.sh`, read
+ *     before TypeScript starts). Now resolved via {@link resolveSeedDemo};
+ *     the boot scripts shell out to `scripts/resolve-seed-demo.ts` and fall
+ *     back to the legacy raw `= "true"` check only if the resolver can't run,
+ *     so the Railway "Atlas Demo" template can never silently stop seeding.
+ *   - `ATLAS_RATE_LIMIT_RPM` — settings-registry-managed. The registry entry
+ *     keeps NO static `default` (a static default would shadow the profile in
+ *     `getSetting`'s precedence — same pattern as `ATLAS_PROVIDER`); the
+ *     deploy-env default is applied downstream by `getRpmLimit()` (auth/
+ *     middleware.ts) via {@link resolveRateLimitRpm}, preserving the
+ *     DB-override > env-var > profile-default precedence. The SaaS boot guard
+ *     (`saas-guards.ts :: RateLimitGuardLive`) deliberately still reads the
+ *     raw env var — its operator contract is "the var MUST be set at deploy
+ *     time", independent of any profile fallback.
+ *   - `ATLAS_MCP_MAX_SESSIONS` — was a raw `process.env` read in the hosted
+ *     MCP route. Now resolved via {@link resolveMcpMaxSessions}.
+ *   - `STAGING_MAIL_SINK` — was a raw read in the staging clamp. Now resolved
+ *     via {@link resolveMailSink}.
  */
 
 /**
@@ -89,6 +106,67 @@ export interface EnvProfile {
    * invalidating every active session there once (users re-login).
    */
   readonly cookiePrefix: string;
+
+  /**
+   * Per-user requests-per-minute rate-limit default, or `null` for "no
+   * managed default" (the limiter stays disabled until an operator opts in).
+   *
+   * `null` for `production` + `development` preserves the long-standing
+   * self-hosted behavior: an unconfigured deploy (which resolves to the
+   * `production` profile) has NO rate limit, matching the registry entry that
+   * carried no static default. SaaS prod regions stamp `ATLAS_RATE_LIMIT_RPM`
+   * explicitly (and the SaaS boot guard refuses to start without it), so this
+   * default is never reached there. `staging` carries a real value so a
+   * self-hosted-shaped staging soak gets a sane limit without stamping the
+   * env var; in SaaS-mode staging the env var is required by the boot guard
+   * and shadows this anyway.
+   *
+   * Legacy override: `ATLAS_RATE_LIMIT_RPM` env var (and, in self-hosted, a
+   * platform/workspace DB override) — both take precedence via
+   * {@link resolveRateLimitRpm} wired through `getRpmLimit()`.
+   */
+  readonly rateLimitRpm: number | null;
+
+  /**
+   * Maximum concurrent hosted-MCP sessions before new connections are
+   * rejected (after an idle sweep). Identical across profiles today — the
+   * historical default was a flat `100` regardless of deployment shape — but
+   * encoded here so a future env can diverge (e.g. a smaller dev cap) in one
+   * place.
+   *
+   * Legacy override: `ATLAS_MCP_MAX_SESSIONS` env var (a positive integer;
+   * anything malformed falls back to this default). Resolved via
+   * {@link resolveMcpMaxSessions}.
+   */
+  readonly mcpMaxSessions: number;
+
+  /**
+   * Email sink address the staging outbound clamp redirects every recipient
+   * to (so a staging soak exercises real delivery without emailing real
+   * addresses). Intentionally IDENTICAL across all three profiles: the clamp
+   * only consults it on the `staging` deploy *region* (`clampOutbound`), but a
+   * deploy could in principle run that region with `ATLAS_DEPLOY_ENV` left at
+   * the default `production` — keeping the value identical means such a
+   * region↔env mismatch still redirects to the sink rather than leaking real
+   * mail. Only the staging clamp path ever reads it.
+   *
+   * Legacy override: `STAGING_MAIL_SINK` env var (trimmed; empty / whitespace
+   * falls back to this default — see {@link resolveMailSink}).
+   */
+  readonly mailSink: string;
+
+  /**
+   * Whether the deployed container seeds the canonical demo dataset on boot.
+   * `false` for every profile today: demo seeding is opt-in via the explicit
+   * `ATLAS_SEED_DEMO=true` env var the Railway "Atlas Demo" template sets, and
+   * neither prod, staging, nor dev should auto-seed without it. Encoded here
+   * so a future env can default to seeding without stamping the var.
+   *
+   * Legacy override: `ATLAS_SEED_DEMO` env var, matched EXACTLY against
+   * `"true"` to mirror the boot script's `[ "$ATLAS_SEED_DEMO" = "true" ]`
+   * check — see {@link resolveSeedDemo}.
+   */
+  readonly seedDemo: boolean;
 }
 
 const PROFILES: Record<DeployEnv, EnvProfile> = {
@@ -102,6 +180,13 @@ const PROFILES: Record<DeployEnv, EnvProfile> = {
     // unset → "atlas"), so self-hosted deploys — which run this profile — stay
     // in lockstep without any extra wiring.
     cookiePrefix: "atlas",
+    // null = no managed default → self-hosted (which resolves here when
+    // ATLAS_DEPLOY_ENV is unset) keeps the limiter off unless the operator
+    // sets ATLAS_RATE_LIMIT_RPM. SaaS prod stamps the env var explicitly.
+    rateLimitRpm: null,
+    mcpMaxSessions: 100,
+    mailSink: "staging-mail@useatlas.dev",
+    seedDemo: false,
   },
   // Staging dogfoods signup without making the maintainer wait on
   // real verification emails (no Resend on staging anyway — DPA guard
@@ -114,6 +199,13 @@ const PROFILES: Record<DeployEnv, EnvProfile> = {
     // `*.staging.useatlas.dev` because staging is a subdomain of it) is ignored
     // here. web-staging must set NEXT_PUBLIC_ATLAS_COOKIE_PREFIX=atlas-staging.
     cookiePrefix: "atlas-staging",
+    // A real limit so a self-hosted-shaped staging soak is protected without
+    // stamping the env var; matches the SaaS boot-smoke fixture / guard's
+    // suggested 300. In SaaS-mode staging the env var is required and shadows it.
+    rateLimitRpm: 300,
+    mcpMaxSessions: 100,
+    mailSink: "staging-mail@useatlas.dev",
+    seedDemo: false,
   },
   // Dev mirrors staging — local signup should be instant; onboarding
   // emails would spam the developer or hit a real Resend account.
@@ -123,8 +215,32 @@ const PROFILES: Record<DeployEnv, EnvProfile> = {
     // Local dev sets NEXT_PUBLIC_ATLAS_COOKIE_PREFIX=atlas-dev (see .env.example)
     // so the web proxy and API agree.
     cookiePrefix: "atlas-dev",
+    // Dev leaves the limiter off by default — local loops would trip a limit.
+    rateLimitRpm: null,
+    mcpMaxSessions: 100,
+    mailSink: "staging-mail@useatlas.dev",
+    seedDemo: false,
   },
 };
+
+// Construction-time guard: the resolvers validate the *override* path but
+// return the table value unchecked on the *default* path (e.g. resolveMailSink
+// returns `profile.mailSink` as-is, resolveMcpMaxSessions returns
+// `profile.mcpMaxSessions` as-is). The field types (`number`, `string`) permit
+// semantically-illegal values (`0`, `""`) the resolvers exist to prevent, so a
+// typo in PROFILES above would otherwise produce a silently-illegal default no
+// override-path test would catch. Fail loudly at import instead. Runs once.
+for (const [env, profile] of Object.entries(PROFILES)) {
+  if (profile.rateLimitRpm !== null && !(Number.isInteger(profile.rateLimitRpm) && profile.rateLimitRpm >= 1)) {
+    throw new Error(`env-profile: ${env}.rateLimitRpm must be null or a positive integer, got ${profile.rateLimitRpm}`);
+  }
+  if (!(Number.isInteger(profile.mcpMaxSessions) && profile.mcpMaxSessions >= 1)) {
+    throw new Error(`env-profile: ${env}.mcpMaxSessions must be a positive integer, got ${profile.mcpMaxSessions}`);
+  }
+  if (profile.mailSink.trim() === "") {
+    throw new Error(`env-profile: ${env}.mailSink must be a non-empty address`);
+  }
+}
 
 /**
  * Resolve the active deployment env from `ATLAS_DEPLOY_ENV`. Unset →
@@ -197,4 +313,75 @@ export function resolveCookiePrefix(env: NodeJS.ProcessEnv = process.env): strin
   const raw = env.ATLAS_COOKIE_PREFIX?.trim();
   if (raw) return raw;
   return getEnvProfile(env).cookiePrefix;
+}
+
+/**
+ * Resolve the per-user rate-limit RPM honoring the `ATLAS_RATE_LIMIT_RPM`
+ * env-var override: a set env var wins verbatim (including `""`, the
+ * operator's explicit "disable"); otherwise the deploy-env profile default
+ * applies (`null` → `undefined`, i.e. no managed default).
+ *
+ * Returns a `string | undefined` rather than a number so it slots in as the
+ * fallback to `getSetting("ATLAS_RATE_LIMIT_RPM")` in `getRpmLimit()` without
+ * reshaping the existing parse path — and so the DB-override > env-var >
+ * profile-default precedence stays intact (`getSetting` already returns a DB
+ * override or the env var when present; this only fills the `undefined` gap).
+ *
+ * NOTE: the SaaS boot guard (`saas-guards.ts :: RateLimitGuardLive`) reads the
+ * raw env var directly, NOT this resolver — its contract is that the var must
+ * be set at deploy time, so it must not be satisfiable by a profile fallback.
+ */
+export function resolveRateLimitRpm(env: NodeJS.ProcessEnv = process.env): string | undefined {
+  const raw = env.ATLAS_RATE_LIMIT_RPM;
+  if (raw !== undefined) return raw;
+  const def = getEnvProfile(env).rateLimitRpm;
+  return def === null ? undefined : String(def);
+}
+
+/**
+ * Resolve the hosted-MCP max concurrent sessions honoring the
+ * `ATLAS_MCP_MAX_SESSIONS` env-var override: a positive integer wins;
+ * anything malformed (non-numeric, `< 1`, empty/whitespace) falls back to the
+ * deploy-env profile default.
+ *
+ * Pure (no logging) so it can live in this dependency-free module — the hosted
+ * MCP route keeps a `log.warn` for the malformed-override case at its call site
+ * (`packages/mcp/src/hosted.ts`), where a logger is available.
+ */
+export function resolveMcpMaxSessions(env: NodeJS.ProcessEnv = process.env): number {
+  const raw = env.ATLAS_MCP_MAX_SESSIONS?.trim();
+  if (raw) {
+    const parsed = Number.parseInt(raw, 10);
+    if (Number.isFinite(parsed) && parsed >= 1) return parsed;
+  }
+  return getEnvProfile(env).mcpMaxSessions;
+}
+
+/**
+ * Resolve the staging email-sink address honoring the `STAGING_MAIL_SINK`
+ * env-var override, then the deploy-env profile default. Uses `||` (not `??`)
+ * after a `.trim()` on purpose: an explicitly-empty or whitespace-only
+ * override must fall back to the default rather than blank the recipient (a
+ * blank `to` would bounce silently in the transport or let mail escape). The
+ * staging outbound clamp (`lib/staging/clamp.ts`) is the only caller.
+ */
+export function resolveMailSink(env: NodeJS.ProcessEnv = process.env): string {
+  return env.STAGING_MAIL_SINK?.trim() || getEnvProfile(env).mailSink;
+}
+
+/**
+ * Resolve whether the deployed container should seed the demo dataset.
+ *
+ * The override grammar mirrors the boot script's `[ "$ATLAS_SEED_DEMO" = "true" ]`
+ * EXACTLY: when `ATLAS_SEED_DEMO` is set to ANY value, only the literal
+ * `"true"` enables (every other set value — `"false"`, `"0"`, `"1"`, … — means
+ * "do not seed", and never falls through to the profile). Only when the var is
+ * unset does the deploy-env profile default apply. This keeps behavior
+ * identical to the legacy shell check (all profiles default `false` today, and
+ * unset → no seed).
+ */
+export function resolveSeedDemo(env: NodeJS.ProcessEnv = process.env): boolean {
+  const raw = env.ATLAS_SEED_DEMO;
+  if (raw !== undefined) return raw === "true";
+  return getEnvProfile(env).seedDemo;
 }

--- a/packages/api/src/lib/settings.ts
+++ b/packages/api/src/lib/settings.ts
@@ -99,6 +99,13 @@ const SETTINGS_REGISTRY: SettingDefinition[] = [
     label: "Rate Limit (RPM)",
     description: "Max requests per minute per user (0 or empty = disabled in self-hosted; SaaS rejects at boot)",
     type: "number",
+    // No static default: a hardcoded value here would be returned by
+    // getSetting() (Tier 4) BEFORE the deploy-env profile default could apply,
+    // shadowing it — same reason ATLAS_PROVIDER omits one. The per-env default
+    // (#2937) is supplied downstream by getRpmLimit() in auth/middleware.ts via
+    // resolveRateLimitRpm() (env-profile.ts), which keeps the DB-override >
+    // env-var > profile-default precedence intact. SaaS regions still stamp the
+    // env var explicitly (RateLimitGuardLive reads it raw and fails boot if unset).
     envVar: "ATLAS_RATE_LIMIT_RPM",
     // RateLimitGuardLive runs once at boot and refuses to start a SaaS
     // region with the limiter disabled. Hot-reloading this key would

--- a/packages/api/src/lib/staging/clamp.ts
+++ b/packages/api/src/lib/staging/clamp.ts
@@ -21,32 +21,16 @@
  * slot in as additional entries in {@link OUTBOUND_CLAMPS} without changing
  * this signature, so no caller breaks when the body grows.
  *
- * Purity: this function performs NO database reads, NO I/O, and reads NO env
- * vars beyond the single documented `STAGING_MAIL_SINK` (the email sink
- * address). `region` is always an explicit argument — never read from the
- * environment here — so the function is fully deterministic given its inputs
- * plus that one documented var.
+ * Purity: this function performs NO database reads and NO I/O. `region` is
+ * always an explicit argument — never read from the environment here — so the
+ * function is deterministic given its inputs plus the sink resolution. The
+ * only env reads happen inside {@link resolveMailSink} (the `STAGING_MAIL_SINK`
+ * override and, for its profile default, `ATLAS_DEPLOY_ENV`); both are
+ * documented, non-secret, and read only on the `staging` rewrite path.
  */
 
 import type { DeployRegion } from "@useatlas/types";
-
-/**
- * Default email sink when `STAGING_MAIL_SINK` is unset (PRD
- * docs/prd/staging-environment.md, Credentials hard wall).
- */
-const DEFAULT_MAIL_SINK = "staging-mail@useatlas.dev";
-
-/**
- * Resolve the staging email sink. Reads the one documented env var, trims it,
- * and falls back to the default for any empty/unset/whitespace-only value
- * (`||`, not `??`, so an explicitly-empty var doesn't blank the recipient;
- * the `.trim()` extends that guard to a whitespace-only var like `" "`, which
- * is truthy and would otherwise be stamped on as a blank-ish recipient —
- * bouncing silently in the transport or letting mail escape).
- */
-function resolveMailSink(): string {
-  return process.env.STAGING_MAIL_SINK?.trim() || DEFAULT_MAIL_SINK;
-}
+import { resolveMailSink } from "@atlas/api/lib/env-profile";
 
 /**
  * A registered outbound transform. `appliesTo` owns payload classification;

--- a/packages/mcp/src/hosted.ts
+++ b/packages/mcp/src/hosted.ts
@@ -115,7 +115,10 @@ let pendingReservations = 0;
 // The resolver is pure and cannot log, so the malformed-override warn lives
 // here at the call site where a logger is available.
 function maxSessions(): number {
-  const raw = process.env.ATLAS_MCP_MAX_SESSIONS;
+  // Mirror resolveMcpMaxSessions's `.trim()` so a whitespace-only value is
+  // treated as unset (no spurious warn) — the warn fires only for a genuinely
+  // malformed non-empty override, matching what the resolver actually rejects.
+  const raw = process.env.ATLAS_MCP_MAX_SESSIONS?.trim();
   if (raw) {
     const parsed = Number.parseInt(raw, 10);
     if (!Number.isFinite(parsed) || parsed < 1) {

--- a/packages/mcp/src/hosted.ts
+++ b/packages/mcp/src/hosted.ts
@@ -67,6 +67,7 @@ import { verifyAccessToken } from "better-auth/oauth2";
 import { getApiRegion } from "@atlas/api/lib/residency/misrouting";
 import { getWorkspaceRegion } from "@atlas/api/lib/db/internal";
 import { getConfig } from "@atlas/api/lib/config";
+import { resolveMcpMaxSessions } from "@atlas/api/lib/env-profile";
 import { withRequestContext, createLogger } from "@atlas/api/lib/logger";
 import { logAdminAction, ADMIN_ACTIONS } from "@atlas/api/lib/audit";
 import { createAtlasUser, type AtlasUser } from "@atlas/api/lib/auth/types";
@@ -108,20 +109,23 @@ const sessions = new Map<string, SessionEntry>();
 // the session is registered.
 let pendingReservations = 0;
 
-const DEFAULT_MAX_SESSIONS = 100;
-
+// The concurrent-session cap resolves through the env-profile
+// (`resolveMcpMaxSessions`): the `ATLAS_MCP_MAX_SESSIONS` override wins when a
+// positive integer, otherwise the deploy-env profile default (100) applies.
+// The resolver is pure and cannot log, so the malformed-override warn lives
+// here at the call site where a logger is available.
 function maxSessions(): number {
   const raw = process.env.ATLAS_MCP_MAX_SESSIONS;
-  if (!raw) return DEFAULT_MAX_SESSIONS;
-  const parsed = Number.parseInt(raw, 10);
-  if (!Number.isFinite(parsed) || parsed < 1) {
-    log.warn(
-      { raw },
-      "ATLAS_MCP_MAX_SESSIONS is not a positive integer — falling back to default",
-    );
-    return DEFAULT_MAX_SESSIONS;
+  if (raw) {
+    const parsed = Number.parseInt(raw, 10);
+    if (!Number.isFinite(parsed) || parsed < 1) {
+      log.warn(
+        { raw },
+        "ATLAS_MCP_MAX_SESSIONS is not a positive integer — falling back to the deploy-env profile default",
+      );
+    }
   }
-  return parsed;
+  return resolveMcpMaxSessions();
 }
 
 // ── Idle-session sweep ─────────────────────────────────────────────


### PR DESCRIPTION
Closes #2937. Phase 2 of the env-profile consolidation (Phase 1 = #2936). Routes the last four ad-hoc per-deploy-env runtime defaults through the typed `ATLAS_DEPLOY_ENV` resolver in `packages/api/src/lib/env-profile.ts`. **Each var keeps its legacy env-var override, so self-hosted operators see no behavior change.**

## The 4 vars

| Var | Resolver | Reader repointed | Profile defaults |
|-----|----------|------------------|------------------|
| `ATLAS_RATE_LIMIT_RPM` | `resolveRateLimitRpm` | `auth/middleware.ts` `getRpmLimit()` | prod/dev: disabled (`null`), staging: 300 |
| `ATLAS_MCP_MAX_SESSIONS` | `resolveMcpMaxSessions` | `packages/mcp/src/hosted.ts` `maxSessions()` | flat 100 |
| `STAGING_MAIL_SINK` | `resolveMailSink` | `staging/clamp.ts` | identical sink across all profiles |
| `ATLAS_SEED_DEMO` | `resolveSeedDemo` | both `start.sh` (via shim) | off (opt-in via the env var) |

### Design notes
- **Rate limit precedence stays DB-override > env-var > profile-default.** `getRpmLimit()` becomes `getSetting(...) ?? resolveRateLimitRpm()`. The settings registry intentionally keeps **no static `default`** — a static default would shadow the profile via `getSetting` Tier 4 (same pattern as `ATLAS_PROVIDER`). The SaaS boot guard (`RateLimitGuardLive`) still reads the raw env var on purpose; the staging profile default cannot satisfy it.
- **MCP cap**: resolver is pure (no logging); the malformed-override `log.warn` stays at the call site where a logger exists.
- **Mail sink**: identical across all three profiles so a `region`↔`ATLAS_DEPLOY_ENV` mismatch can't leak real mail (the clamp keys on region, the profile on deploy-env — independent inputs).
- **Seed demo**: `resolveSeedDemo` mirrors the shell `[ "$X" = "true" ]` check exactly. The boot scripts shell out to a dependency-free shim (`examples/docker/scripts/resolve-seed-demo.ts`, COPYed in both Dockerfiles) and fall back to the legacy raw check on any non-`true`/`false` output, so the Railway "Atlas Demo" template can never silently stop seeding.

## Acceptance criteria (#2937)
- [x] All 4 vars resolve through env-profile with profile defaults
- [x] Each retains its legacy env-var override (no behavior change for self-hosted)
- [x] Registry default for `ATLAS_RATE_LIMIT_RPM` reconciled with the profile

## From the review-toolkit pass (all addressed)
- Fixed an inaccurate "workspace DB override" comment → `getRpmLimit` calls `getSetting` without `orgId`, so only **platform** overrides apply at runtime (`middleware.ts` + `.env.example`).
- `.env.example` "what ATLAS_DEPLOY_ENV drives" list annotated so MCP-sessions/mail-sink/seed aren't implied to vary by env today.
- Added a **build-time Dockerfile assertion** that runs the shim and asserts a clean boolean (no stderr redirect) — converts a future silent shim-import breakage into a loud build failure.
- Tightened both `start.sh` gates to a **positive** `true`/`false` token check (malformed-non-empty output also routes to the legacy fallback).
- Added **construction-time `PROFILES` validation** (rejects illegal table defaults like `0`/`""` at import).
- Added a **`getRpmLimit()` staging-fallback integration test** (+ explicit-empty-disables-on-staging) and made the rate-limit test block hermetic for `ATLAS_DEPLOY_ENV`.

## Testing
- `env-profile` + `middleware` + `clamp`: 119 pass
- api `--affected`: 94 files pass · mcp `--affected`: 17 files pass
- `bun run type`: clean · `bun run lint`: clean · template drift: 756 files verified

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3116"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783021539&installation_id=135337507&pr_number=3116&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3116&signature=f5685c7ea7210190cc10a7e6210985f7a09b4552227ae9f3a16e3be6aec235b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Profile-aware defaults: staging rate-limit defaults to 300 RPM (prod/dev disabled), profile-driven MCP max-sessions, and profile-controlled demo-data seeding.

* **Chores**
  * Centralized deployment default resolution with clear override precedence for environment variables.

* **Documentation**
  * Updated environment guidance clarifying rate-limit, deploy-profile effects, and legacy override behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->