### PR TITLE
refactor(webhooks): migrate webhook-action plugin onto @useatlas/webhook-publisher (#2016)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -778,14 +778,16 @@
     },
     "plugins/webhook-action": {
       "name": "@useatlas/webhook-action",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "devDependencies": {
         "@useatlas/plugin-sdk": "workspace:*",
+        "@useatlas/webhook-publisher": "workspace:*",
         "ai": "^6.0.141",
         "zod": "^4.3.6",
       },
       "peerDependencies": {
         "@useatlas/plugin-sdk": ">=0.0.1",
+        "@useatlas/webhook-publisher": ">=0.0.1",
         "ai": "^6.0.0",
         "zod": "^4.0.0",
       },

--- a/bun.lock
+++ b/bun.lock
@@ -431,6 +431,7 @@
       "version": "0.0.1",
       "devDependencies": {
         "@types/node": "^25.5.0",
+        "typescript": "^6.0.2",
       },
     },
     "plugins/bigquery": {

--- a/packages/webhook-publisher/package.json
+++ b/packages/webhook-publisher/package.json
@@ -49,6 +49,7 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@types/node": "^25.5.0"
+    "@types/node": "^25.5.0",
+    "typescript": "^6.0.2"
   }
 }

--- a/plugins/webhook-action/package.json
+++ b/plugins/webhook-action/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useatlas/webhook-action",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Atlas outbound webhook action plugin — POSTs analysis output with HMAC-SHA256 signing",
   "type": "module",
   "main": "./src/index.ts",
@@ -40,11 +40,13 @@
   "peerDependencies": {
     "ai": "^6.0.0",
     "zod": "^4.0.0",
-    "@useatlas/plugin-sdk": ">=0.0.1"
+    "@useatlas/plugin-sdk": ">=0.0.1",
+    "@useatlas/webhook-publisher": ">=0.0.1"
   },
   "devDependencies": {
     "ai": "^6.0.141",
     "zod": "^4.3.6",
-    "@useatlas/plugin-sdk": "workspace:*"
+    "@useatlas/plugin-sdk": "workspace:*",
+    "@useatlas/webhook-publisher": "workspace:*"
   }
 }

--- a/plugins/webhook-action/src/tool.ts
+++ b/plugins/webhook-action/src/tool.ts
@@ -6,9 +6,16 @@
  * computing the same MAC over the raw request body and constant-
  * time comparing against the header. This is the same shape as the
  * Stripe / GitHub / Shopify webhook conventions.
+ *
+ * The signing + retry + per-attempt timeout internals come from
+ * `@useatlas/webhook-publisher` (strategy `rawBody`) — the shared
+ * primitive that backs all three of Atlas's outbound senders. The
+ * on-the-wire format is unchanged: `rawBody` emits the same bare-hex
+ * `X-Atlas-Signature` + `Content-Type: application/json`, and the
+ * `none` / `exponential` retry policy + 30s timeout are preserved.
  */
 
-import crypto from "crypto";
+import { deliverWebhook, rawBody, type RetryPolicy } from "@useatlas/webhook-publisher";
 import { tool } from "ai";
 import { z } from "zod";
 
@@ -34,9 +41,12 @@ export interface WebhookActionPluginConfig {
 /**
  * Compute `X-Atlas-Signature` for a given body. Exported for tests and
  * for receiver-side verification helpers that ship with the docs.
+ * Delegates to the `rawBody` signing strategy from
+ * `@useatlas/webhook-publisher` — identical bare-hex
+ * `HMAC_SHA256(signing_secret, body)`.
  */
 export function hmacSign(signingSecret: string, body: string): string {
-  return crypto.createHmac("sha256", signingSecret).update(body).digest("hex");
+  return rawBody({ secret: signingSecret })(body).signature;
 }
 
 // ---------------------------------------------------------------------------
@@ -60,90 +70,63 @@ export interface WebhookPostResult {
  * ~5.25s across 4 attempts — short enough that the agent loop's
  * tool-call timeout doesn't fire mid-retry, long enough that a brief
  * destination blip recovers without surfacing as a tool failure.
+ * Supplied to `deliverWebhook` as the `delaysMs` schedule (one extra
+ * attempt than gaps → `maxAttempts = RETRY_DELAYS_MS.length + 1`).
  */
 const RETRY_DELAYS_MS = [250, 1_000, 4_000] as const;
+
+/** Per-attempt timeout — matches the pre-extraction sender. */
+const TIMEOUT_MS = 30_000;
 
 export async function executeWebhookPost(
   config: WebhookActionPluginConfig,
   params: WebhookPostParams,
 ): Promise<WebhookPostResult> {
-  const body = JSON.stringify(params.payload);
-  const signature = hmacSign(config.signing_secret, body);
   const retryPolicy = config.retry_policy ?? "exponential";
+  const retry: RetryPolicy =
+    retryPolicy === "exponential"
+      ? { maxAttempts: RETRY_DELAYS_MS.length + 1, delaysMs: RETRY_DELAYS_MS }
+      : { maxAttempts: 1, delaysMs: [] };
 
-  const attempt = async (): Promise<Response> =>
-    fetch(config.url, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "X-Atlas-Signature": signature,
-      },
-      body,
-      signal: AbortSignal.timeout(30_000),
-    });
-
-  let lastError: unknown;
-  const maxAttempts = retryPolicy === "exponential" ? RETRY_DELAYS_MS.length + 1 : 1;
-
-  for (let i = 0; i < maxAttempts; i++) {
-    let response: Response | null = null;
-    try {
-      response = await attempt();
-    } catch (err) {
-      // Network / timeout error — retryable under exponential, not under none.
-      lastError = err;
-      if (retryPolicy === "none") throw err;
-      // Plugins have no logger context handle here (initialize ctx is
-      // not threaded into the tool execute closure); console.warn is the
-      // only breadcrumb path. Visible in the agent loop's stderr so an
-      // operator can correlate retries with destination outages.
-      console.warn(
-        `[webhook-action] attempt ${i + 1}/${maxAttempts} failed: ${err instanceof Error ? err.message : String(err)}`,
-      );
-    }
-
-    if (response) {
-      if (response.ok) {
-        return { status: response.status, signature };
-      }
-      // 4xx is a destination-side rejection — surface immediately even
-      // under exponential. Only 5xx is treated as transient.
-      if (response.status < 500) {
-        const detail = await safeErrorDetail(response);
-        throw new Error(
-          `Webhook POST failed: HTTP ${response.status}${detail ? ` — ${detail}` : ""}`,
+  const outcome = await deliverWebhook({
+    url: config.url,
+    payload: params.payload,
+    sign: rawBody({ secret: config.signing_secret }),
+    retry,
+    timeoutMs: TIMEOUT_MS,
+    onFailedAttempt: ({ attempt, maxAttempts, failure }) => {
+      // Plugins have no logger context handle here (initialize ctx is not
+      // threaded into the tool execute closure); console.warn is the only
+      // breadcrumb path. Visible in the agent loop's stderr so an operator
+      // can correlate retries with destination outages. Only retryable
+      // failures log — the pre-extraction code never logged a breadcrumb
+      // for a 4xx (it threw immediately).
+      if (failure.kind === "transport_error") {
+        console.warn(
+          `[webhook-action] attempt ${attempt}/${maxAttempts} failed: ${failure.error}`,
+        );
+      } else if (failure.status >= 500) {
+        console.warn(
+          `[webhook-action] attempt ${attempt}/${maxAttempts} returned HTTP ${failure.status}`,
         );
       }
-      lastError = new Error(`Webhook POST failed: HTTP ${response.status}`);
-      console.warn(
-        `[webhook-action] attempt ${i + 1}/${maxAttempts} returned HTTP ${response.status}`,
-      );
-    }
+    },
+  });
 
-    if (i < maxAttempts - 1) {
-      await sleep(RETRY_DELAYS_MS[i] ?? RETRY_DELAYS_MS[RETRY_DELAYS_MS.length - 1]);
-    }
+  if (outcome.kind === "ok") {
+    return { status: outcome.status, signature: outcome.signature };
   }
-
-  throw lastError instanceof Error
-    ? lastError
-    : new Error(`Webhook POST failed: ${String(lastError)}`);
-}
-
-async function safeErrorDetail(response: Response): Promise<string> {
-  try {
-    const text = await response.text();
-    return text.length > 200 ? `${text.slice(0, 200)}…` : text;
-  } catch {
-    // intentionally ignored: response body is unreadable (already consumed
-    // or stream closed) — status code on the thrown error still carries
-    // the signal; the body excerpt was a best-effort breadcrumb.
-    return "";
+  if (outcome.kind === "http_error") {
+    // The package reads a bounded body excerpt only for permanent (4xx)
+    // rejections with a non-empty readable body, so `responseText` is
+    // present exactly where the old `safeErrorDetail` appended one and
+    // absent for an exhausted 5xx (or an empty/unreadable 4xx body).
+    throw new Error(
+      `Webhook POST failed: HTTP ${outcome.status}${outcome.responseText ? ` — ${outcome.responseText}` : ""}`,
+    );
   }
-}
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+  // transport_error — network blip / timeout, retries exhausted.
+  throw new Error(outcome.error);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

PR 3 of 3 of #2016 — migrate the `@useatlas/webhook-action` plugin onto the published `@useatlas/webhook-publisher@0.0.1` (strategy `rawBody`). PR 1 (#3118) + PR 2 (#3119) merged. With this, **all three** outbound webhook senders sit on one `deliverWebhook` + pluggable-`SignStrategy` primitive.

Two commits:
1. **Plugin migration** (behaviour-preserving, held green by the existing `plugin.test.ts`, 19/19 untouched).
2. **www build fix** — see below.

## Commit 1 — plugin migration

`plugins/webhook-action/src/tool.ts` delegates signing + retry + timeout to the package:
- **`hmacSign(secret, body)`** — still exported, same signature; `rawBody({ secret })(body).signature` → identical bare 64-char hex.
- **`executeWebhookPost(config, params)`** — still exported, same `Promise<WebhookPostResult>` / throw-on-failure contract; body now calls `deliverWebhook`.
- Deletes the hand-rolled `for` retry loop, `attempt()`, `safeErrorDetail()`, `sleep()`.

Byte-identical wire + behaviour: `X-Atlas-Signature: <hex hmac(rawBody)>` + `Content-Type: application/json`; `none`→1 attempt / `exponential`→4 attempts on `[250ms,1s,4s]` (default `exponential`); 30s per-attempt timeout; 4xx permanent (200-char body excerpt in thrown message, no retry), 5xx/transport retried; `console.warn` breadcrumbs reproduced via `onFailedAttempt` (4xx logs nothing, matching the old throw-immediately path). Default `fetcher` resolves global `fetch` at call time → the suite's `globalThis.fetch` mock works with zero test changes.

`package.json`: peer `@useatlas/webhook-publisher` `>=0.0.1` + dev `workspace:*` (mirrors `@useatlas/plugin-sdk`); npm version `0.0.1 → 0.0.2`; plugin-system `version: "1.0.0"` untouched. `bun.lock` committed. No `@atlas/api` internals.

## Commit 2 — fix www-staging Railway build (regression from #3118)

`www-staging` was failing (`api`/`web`/`docs` green). Root cause: the api/web **Dockerfiles** `bun ci --ignore-scripts` + build packages explicitly, so `prepare` never runs there. **www uses railpack**, which runs `bun install --frozen-lockfile` *with* scripts → `@useatlas/webhook-publisher`'s `prepare` fires `bun x tsc`. Because the package didn't declare `typescript` as its own dep, `bun x` couldn't resolve a package-local `tsc` at prepare time and fell back to downloading the deprecated `tsc` npm shim → `FileNotFound: copying file lib/lib.decorators.legacy.d.ts`. Adding webhook-publisher made it the 3rd concurrent `bun x tsc` in the workspace install (types + plugin-sdk were the prior two), tipping a bun-cache race.

Fix: declare `typescript: ^6.0.2` (matching root) in `packages/webhook-publisher/devDependencies`. That creates `packages/webhook-publisher/node_modules/.bin/tsc`, so `bun x tsc` resolves the local binary deterministically — no ephemeral download, no race — in every install environment. dist output unchanged (build verified); devDep-only so no version bump / published-artifact change; syncpack clean.

> Note: `@useatlas/types` + `@useatlas/plugin-sdk` use the same `prepare` + `bun x tsc` pattern without declaring typescript; they're back to the proven-safe 2-racer set after this fix, but hardening them the same way is a sensible optional follow-up.

## Acceptance criteria (#2016)

- [x] webhook-action wire format unchanged (`X-Atlas-Signature`, raw body)
- [x] `none`/`exponential` policy + 30s timeout preserved
- [x] `hmacSign` / `executeWebhookPost` still exported
- [x] existing plugin tests green (19/19, untouched)
- [x] no `@atlas/api` internals imported
- [x] plugin npm version bumped (0.0.1 → 0.0.2)

## Test plan

`/ci` green locally: lint, type, full test suite, syncpack, template/security/railway/schema/oauth/test-discipline/twenty drift, published-symbols (`@useatlas/webhook-publisher@^0.0.1 → 0.0.1 ok`). webhook-publisher 23/23, webhook-action 19/19. www build fix verified by the package building cleanly with `bun x tsc` resolving the now-local typescript.

Closes #2016

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped webhook-action plugin to v0.0.2 and updated package metadata and dependency declarations.
  * Adjusted development dependencies for the webhook publisher package.

* **Refactor**
  * Reworked webhook signing and delivery to use a shared publisher component, improving reliability, retry/timeout behavior, and logging while preserving external APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->