### PR TITLE
fix(web): align auth client with better-auth's real return types

### DIFF
--- a/packages/types/src/auth.ts
+++ b/packages/types/src/auth.ts
@@ -77,9 +77,11 @@ export interface AtlasAuthClient {
     data?: {
       user?: {
         email?: string;
-        // Better Auth's user `role` is nullable (no role assigned yet);
-        // mirror that here so consumers narrow instead of assuming a string.
-        // `effectiveRole` below is already `string | null` for the same reason.
+        // The underlying `user.role` column is nullable (no role assigned
+        // yet). Better Auth's admin plugin types it `string | undefined`, but
+        // the DB column and the server's `customSession` merge can surface a
+        // `null`; mirror `| null` so consumers narrow instead of assuming a
+        // string. `effectiveRole` below is `string | null` for the same reason.
         role?: string | null;
         /**
          * Org-merged effective role — `max(user.role, active-org member.role)`.
@@ -93,7 +95,9 @@ export interface AtlasAuthClient {
         name?: string;
         /**
          * True when TOTP is enrolled — surfaced by the two-factor plugin.
-         * Better Auth types this column as nullable, so mirror `| null`.
+         * Better Auth's plugin type is `boolean`, but the underlying column
+         * is nullable (`required: false`), so the runtime value can be `null`
+         * before enrollment; mirror `| null`. Consumers compare `=== true`.
          */
         twoFactorEnabled?: boolean | null;
       };

--- a/packages/types/src/auth.ts
+++ b/packages/types/src/auth.ts
@@ -77,7 +77,10 @@ export interface AtlasAuthClient {
     data?: {
       user?: {
         email?: string;
-        role?: string;
+        // Better Auth's user `role` is nullable (no role assigned yet);
+        // mirror that here so consumers narrow instead of assuming a string.
+        // `effectiveRole` below is already `string | null` for the same reason.
+        role?: string | null;
         /**
          * Org-merged effective role — `max(user.role, active-org member.role)`.
          * Stamped by the server's `customSession` plugin so an org admin
@@ -88,8 +91,11 @@ export interface AtlasAuthClient {
         effectiveRole?: string | null;
         /** Display name — present at runtime, not always populated. */
         name?: string;
-        /** True when TOTP is enrolled — surfaced by the two-factor plugin. */
-        twoFactorEnabled?: boolean;
+        /**
+         * True when TOTP is enrolled — surfaced by the two-factor plugin.
+         * Better Auth types this column as nullable, so mirror `| null`.
+         */
+        twoFactorEnabled?: boolean | null;
       };
       session?: {
         /** Session row id — used to identify "this session" in revoke flows. */

--- a/packages/web/src/app/admin/users/_users-page.tsx
+++ b/packages/web/src/app/admin/users/_users-page.tsx
@@ -405,7 +405,7 @@ export function UsersPage({ scope }: UsersPageProps) {
       } catch (err) {
         if (!cancelled) {
           setInvitations([]);
-          setInvitationsError(err instanceof Error ? err.message : "Failed to load invitations");
+          setInvitationsError(err instanceof Error ? err.message : "Failed to load invitations.");
         }
       } finally {
         if (!cancelled) setInvitationsLoading(false);

--- a/packages/web/src/app/admin/users/_users-page.tsx
+++ b/packages/web/src/app/admin/users/_users-page.tsx
@@ -387,7 +387,7 @@ export function UsersPage({ scope }: UsersPageProps) {
         if (cancelled) return;
         if (result.error) {
           setInvitations([]);
-          setInvitationsError(result.error.message);
+          setInvitationsError(result.error.message ?? "Failed to load invitations.");
           return;
         }
         setInvitations(

--- a/packages/web/src/app/admin/users/columns.tsx
+++ b/packages/web/src/app/admin/users/columns.tsx
@@ -27,8 +27,11 @@ export interface Invitation {
   role: string;
   status: string;
   inviterId: string;
-  expiresAt: string;
-  createdAt: string;
+  // Better Auth types these as `Date`; over JSON the client receives ISO
+  // strings. Accept both so BA's declared type and the runtime value both
+  // type-check — the column renders them through `RelativeTimestamp`.
+  expiresAt: string | Date;
+  createdAt: string | Date;
 }
 
 // ── Shared badge styles ──────────────────────────────────────────

--- a/packages/web/src/app/oauth2/consent/page.tsx
+++ b/packages/web/src/app/oauth2/consent/page.tsx
@@ -169,14 +169,14 @@ export default function ConsentPage() {
         setError(res.error.message ?? "Consent failed.");
         return;
       }
-      const redirectURI = res?.data?.redirectURI;
-      if (!redirectURI) {
+      const redirectUrl = res?.data?.url;
+      if (!redirectUrl) {
         setError(
           "Consent succeeded but no redirect was returned. Reopen the OAuth flow from your client.",
         );
         return;
       }
-      window.location.href = redirectURI;
+      window.location.href = redirectUrl;
     } catch (err) {
       if (err instanceof TypeError) {
         setError(

--- a/packages/web/src/app/oauth2/consent/page.tsx
+++ b/packages/web/src/app/oauth2/consent/page.tsx
@@ -30,6 +30,7 @@ import { useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { authClient } from "@/lib/auth/client";
 import { getApiUrl } from "@/lib/api-url";
+import { resolveConsentOutcome } from "./resolve-consent-outcome";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -165,18 +166,12 @@ export default function ConsentPage() {
         return;
       }
       const res = (await consent({ accept })) ?? undefined;
-      if (res?.error) {
-        setError(res.error.message ?? "Consent failed.");
+      const outcome = resolveConsentOutcome(res);
+      if (outcome.kind === "error") {
+        setError(outcome.message);
         return;
       }
-      const redirectUrl = res?.data?.url;
-      if (!redirectUrl) {
-        setError(
-          "Consent succeeded but no redirect was returned. Reopen the OAuth flow from your client.",
-        );
-        return;
-      }
-      window.location.href = redirectUrl;
+      window.location.href = outcome.url;
     } catch (err) {
       if (err instanceof TypeError) {
         setError(

--- a/packages/web/src/app/oauth2/consent/resolve-consent-outcome.test.ts
+++ b/packages/web/src/app/oauth2/consent/resolve-consent-outcome.test.ts
@@ -39,6 +39,22 @@ describe("resolveConsentOutcome — error / empty", () => {
     expect(out).toMatchObject({ message: "Consent failed." });
   });
 
+  it("treats an empty/whitespace-only error message as missing (no blank UI error)", () => {
+    expect(resolveConsentOutcome({ error: { message: "" } })).toEqual({
+      kind: "error",
+      message: "Consent failed.",
+    });
+    expect(resolveConsentOutcome({ error: { message: "   " } })).toEqual({
+      kind: "error",
+      message: "Consent failed.",
+    });
+  });
+
+  it("trims surrounding whitespace from a real error message", () => {
+    const out = resolveConsentOutcome({ error: { message: "  client disabled  " } });
+    expect(out).toEqual({ kind: "error", message: "client disabled" });
+  });
+
   it("returns a 'no redirect' error when data is present but `url` is missing", () => {
     const out = resolveConsentOutcome({ data: { redirect: true } });
     expect(out.kind).toBe("error");

--- a/packages/web/src/app/oauth2/consent/resolve-consent-outcome.test.ts
+++ b/packages/web/src/app/oauth2/consent/resolve-consent-outcome.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "bun:test";
+import { resolveConsentOutcome } from "./resolve-consent-outcome";
+
+describe("resolveConsentOutcome — success", () => {
+  it("reads `.url` as the redirect target (the real @better-auth/oauth-provider field)", () => {
+    const out = resolveConsentOutcome({
+      data: { redirect: true, url: "https://client.example/cb?code=abc&state=xyz" },
+    });
+    expect(out).toEqual({
+      kind: "redirect",
+      url: "https://client.example/cb?code=abc&state=xyz",
+    });
+  });
+
+  it("regression (#3122): ignores the legacy `.redirectURI` field — it is undefined on this client", () => {
+    // The deprecated oidc-provider plugin returned `{ redirectURI }`; the
+    // oauth-provider plugin Atlas uses does not. A response carrying only
+    // `redirectURI` must NOT produce a redirect — that was the live bug.
+    const out = resolveConsentOutcome({
+      data: { redirectURI: "https://client.example/cb" },
+    } as unknown as Parameters<typeof resolveConsentOutcome>[0]);
+    expect(out.kind).toBe("error");
+    expect(out).toMatchObject({ message: expect.stringMatching(/no redirect was returned/i) });
+  });
+});
+
+describe("resolveConsentOutcome — error / empty", () => {
+  it("surfaces the server error message, taking precedence over data", () => {
+    const out = resolveConsentOutcome({
+      error: { message: "client disabled" },
+      data: { redirect: true, url: "https://client.example/cb" },
+    });
+    expect(out).toEqual({ kind: "error", message: "client disabled" });
+  });
+
+  it("falls back to a generic message when the error has no message", () => {
+    const out = resolveConsentOutcome({ error: { message: null } });
+    expect(out.kind).toBe("error");
+    expect(out).toMatchObject({ message: "Consent failed." });
+  });
+
+  it("returns a 'no redirect' error when data is present but `url` is missing", () => {
+    const out = resolveConsentOutcome({ data: { redirect: true } });
+    expect(out.kind).toBe("error");
+    expect(out).toMatchObject({ message: expect.stringMatching(/no redirect was returned/i) });
+  });
+
+  it("returns a 'no redirect' error for an undefined response", () => {
+    const out = resolveConsentOutcome(undefined);
+    expect(out.kind).toBe("error");
+    expect(out).toMatchObject({ message: expect.stringMatching(/no redirect was returned/i) });
+  });
+
+  it("treats an empty-string url as missing", () => {
+    const out = resolveConsentOutcome({ data: { redirect: true, url: "" } });
+    expect(out.kind).toBe("error");
+  });
+});

--- a/packages/web/src/app/oauth2/consent/resolve-consent-outcome.ts
+++ b/packages/web/src/app/oauth2/consent/resolve-consent-outcome.ts
@@ -1,0 +1,44 @@
+/**
+ * Maps Better Auth's `oauth2.consent` response to the consent screen's next
+ * action.
+ *
+ * Atlas runs the `@better-auth/oauth-provider` plugin (`oauthProviderClient`
+ * on the client), whose `/oauth2/consent` endpoint returns `{ redirect, url }`
+ * on success — the post-consent redirect target is `url`. The deprecated
+ * `oidc-provider` plugin's `redirectURI` field does NOT exist on this client,
+ * so reading it yields `undefined` and the redirect silently fails. Extracting
+ * the mapping here pins that contract under test (see #3122).
+ */
+
+/** Shape that `authClient.oauth2.consent()` resolves to (BA `{ redirect, url }`). */
+export interface ConsentResponse {
+  data?: { redirect?: boolean; url?: string } | null;
+  error?: { message?: string | null } | null;
+}
+
+/**
+ * Discriminated by `kind` so the caller statically reaches `url` only on the
+ * `redirect` branch and `message` only on the `error` branch.
+ */
+export type ConsentOutcome =
+  | { kind: "redirect"; url: string }
+  | { kind: "error"; message: string };
+
+export function resolveConsentOutcome(
+  res: ConsentResponse | undefined,
+): ConsentOutcome {
+  // Error envelope wins over a (possibly partial) data payload.
+  if (res?.error) {
+    return { kind: "error", message: res.error.message ?? "Consent failed." };
+  }
+  // Read `.url` — the real redirect target on `@better-auth/oauth-provider`.
+  const url = res?.data?.url;
+  if (!url) {
+    return {
+      kind: "error",
+      message:
+        "Consent succeeded but no redirect was returned. Reopen the OAuth flow from your client.",
+    };
+  }
+  return { kind: "redirect", url };
+}

--- a/packages/web/src/app/oauth2/consent/resolve-consent-outcome.ts
+++ b/packages/web/src/app/oauth2/consent/resolve-consent-outcome.ts
@@ -27,9 +27,12 @@ export type ConsentOutcome =
 export function resolveConsentOutcome(
   res: ConsentResponse | undefined,
 ): ConsentOutcome {
-  // Error envelope wins over a (possibly partial) data payload.
+  // Error envelope wins over a (possibly partial) data payload. Trim the
+  // server message and treat empty/whitespace-only as missing so a blank
+  // string never renders as an empty error in the UI.
   if (res?.error) {
-    return { kind: "error", message: res.error.message ?? "Consent failed." };
+    const message = res.error.message?.trim();
+    return { kind: "error", message: message || "Consent failed." };
   }
   // Read `.url` — the real redirect target on `@better-auth/oauth-provider`.
   const url = res?.data?.url;

--- a/packages/web/src/lib/auth/client.ts
+++ b/packages/web/src/lib/auth/client.ts
@@ -125,10 +125,12 @@ export type OrgResult<T> = {
 // switches on it.
 export type { InvitationStatus } from "better-auth/plugins/organization";
 
-// Better Auth's exported `Invitation` carries `Date` for timestamps; over
-// JSON those serialize as ISO strings. Keep the shape aligned with BA but
-// widen date fields to `string` to match what the client actually
-// receives.
+// Better Auth types these timestamps as `Date`, but over JSON the client
+// actually receives ISO strings. Accept `string | Date` so both BA's
+// declared type (which newer TS toolchains surface straight through the
+// `as OrgClient` overrides) and the runtime value type-check; render sites
+// treat the runtime value as an ISO string (`RelativeTimestamp`, `new
+// Date(...)`).
 export interface OrgInvitation {
   id: string;
   organizationId: string;
@@ -136,8 +138,8 @@ export interface OrgInvitation {
   role: string;
   status: InvitationStatus;
   inviterId: string;
-  expiresAt: string;
-  createdAt: string;
+  expiresAt: string | Date;
+  createdAt: string | Date;
 }
 
 // `getInvitation` returns the row plus inviter / organization metadata so
@@ -229,9 +231,11 @@ type OrgClient = Omit<typeof _authClient, "useSession"> & {
   };
 
   // oauthProviderClient — `oauth2.consent` resolves the consent screen.
+  // Better Auth returns `{ redirect, url }` on success (the post-consent
+  // redirect target is `url`, not the older `redirectURI`).
   oauth2?: {
     consent: (opts: { accept: boolean; scope?: string }) => Promise<{
-      data?: { redirectURI?: string };
+      data?: { redirect: boolean; url: string };
       error?: { message?: string };
     } | undefined>;
   };

--- a/packages/web/src/ui/hooks/use-platform-admin-guard.ts
+++ b/packages/web/src/ui/hooks/use-platform-admin-guard.ts
@@ -27,7 +27,9 @@ export function useUserRole(): string | undefined {
   const { authClient } = useAtlasConfig();
   const session = authClient.useSession();
   const user = session.data?.user;
-  return user?.effectiveRole ?? user?.role;
+  // `effectiveRole`/`role` are both `string | null`; collapse a null role
+  // to `undefined` so the "no role" case is a single value for callers.
+  return user?.effectiveRole ?? user?.role ?? undefined;
 }
 
 /**


### PR DESCRIPTION
## What

The web auth client wraps better-auth in `as OrgClient` type overrides that were *masking* better-auth's real return types, so several call sites compiled against types that don't match better-auth's actual API.

Most importantly — the **OAuth consent handler read `res.data.redirectURI`, but better-auth returns `{ redirect, url }`**, so `.redirectURI` is `undefined` at runtime and the post-consent redirect silently fails. This makes web honest about better-auth's real types.

## Changes
- **OAuth consent (bugfix):** read `res.data.url` (the real redirect target) instead of the non-existent `.redirectURI`; correct the override type to `{ redirect, url }`. — `oauth2/consent/page.tsx`, `lib/auth/client.ts`
- Invitation `expiresAt`/`createdAt` → `string | Date` (better-auth types them `Date`; over JSON the client receives ISO strings). — `lib/auth/client.ts`, `admin/users/columns.tsx`
- `AtlasAuthClient` user `role` + `twoFactorEnabled` → nullable, mirroring better-auth's columns (`role` now matches the adjacent `effectiveRole?: string | null`). — `packages/types/src/auth.ts`
- `useUserRole` collapses a null role to `undefined`. — `use-platform-admin-guard.ts`
- `listInvitations` error message null-guarded. — `admin/users/_users-page.tsx`

## Why now
These overrides compile on the current toolchain but break under stricter type resolution (e.g. the upcoming dependency refresh), where better-auth's real types surface straight through. Landing this now fixes the live consent bug **and** unblocks that sweep, which otherwise hits exactly these 6 mismatches.

## Notes
- `@useatlas/types` carries the nullable `role`/`twoFactorEnabled` widening (consumed via `workspace:*`). Backward-compatible type-only widening; version **not** bumped here — fold into the next types publish.
- The consent change alters runtime behavior — worth a manual smoke of the OAuth consent flow.

## Verification
- `bun run type` green · `eslint` green on changed files
- `@atlas/web` 175/175 · `@useatlas/react` 11/11

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3122"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783036760&installation_id=135337507&pr_number=3122&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3122&signature=e50902240514cd4aad9de208f3b19e776e4cb429299d0d4f30ec65fa9ad1ee31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messaging when loading user invitations—now shows a clear fallback message when details are unavailable.
  * Consent flow now reliably handles provider responses and redirects, with clearer error fallbacks when no redirect is returned.

* **Chores**
  * Invitation timestamps support both ISO strings and Date values for accurate relative-time display.
  * Role and two-factor fields normalized to handle missing/null values consistently.

* **Tests**
  * Added coverage for consent outcome resolution and related regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->