### PR TITLE
chore(deps): bump @vercel/sandbox v1 → v2.0.2 (Group B)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -249,7 +249,7 @@
         "pg-mem": "^3.0.14",
       },
       "optionalDependencies": {
-        "@vercel/sandbox": "^1.9.0",
+        "@vercel/sandbox": "^2.0.2",
       },
     },
     "packages/cli": {
@@ -2193,7 +2193,7 @@
 
     "@vercel/oidc": ["@vercel/oidc@3.2.0", "", {}, "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug=="],
 
-    "@vercel/sandbox": ["@vercel/sandbox@1.9.0", "", { "dependencies": { "@vercel/oidc": "3.2.0", "async-retry": "1.3.3", "jsonlines": "0.1.1", "ms": "2.1.3", "picocolors": "^1.1.1", "tar-stream": "3.1.7", "undici": "^7.16.0", "xdg-app-paths": "5.1.0", "zod": "3.24.4" } }, "sha512-zgr1ad0tkT1xZn/8Vxo60wOUOLqMAVGo4WqJQ8/UDcUtWynNJsBjI2tiMdWZrAo9EKH1MIqEzJNkcclF0UT1EQ=="],
+    "@vercel/sandbox": ["@vercel/sandbox@2.0.2", "", { "dependencies": { "@vercel/oidc": "3.2.0", "@workflow/serde": "4.1.0-beta.2", "async-retry": "1.3.3", "jose": "6.2.3", "jsonlines": "0.1.1", "ms": "2.1.3", "picocolors": "^1.1.1", "tar-stream": "3.1.7", "undici": "^7.16.0", "xdg-app-paths": "5.1.0", "zod": "3.24.4" } }, "sha512-Kd1gqvV4rjziFqLZMEJ7lJRZtskRohrCxkqueKY8rXO2MSGK8zSdp6/T5xApljnhDusEwEQ4+vi8e3dzFvnezg=="],
 
     "@vladfrangu/async_event_emitter": ["@vladfrangu/async_event_emitter@2.4.7", "", {}, "sha512-Xfe6rpCTxSxfbswi/W/Pz7zp1WWSNn4A0eW4mLkQUewCrXXtMj31lCg+iQyTkh/CkusZSq9eDflu7tjEDXUY6g=="],
 

--- a/create-atlas/templates/docker/package.json
+++ b/create-atlas/templates/docker/package.json
@@ -85,7 +85,7 @@
     "zustand": "^5.0.14"
   },
   "optionalDependencies": {
-    "@vercel/sandbox": "^1"
+    "@vercel/sandbox": "^2"
   },
   "devDependencies": {
     "@clack/prompts": "^1.5.0",

--- a/create-atlas/templates/nextjs-standalone/package.json
+++ b/create-atlas/templates/nextjs-standalone/package.json
@@ -82,7 +82,7 @@
     "zustand": "^5.0.14"
   },
   "optionalDependencies": {
-    "@vercel/sandbox": "^1"
+    "@vercel/sandbox": "^2"
   },
   "devDependencies": {
     "@clack/prompts": "^1.5.0",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -86,7 +86,7 @@
     "zod": "^4.4.3"
   },
   "optionalDependencies": {
-    "@vercel/sandbox": "^1.9.0"
+    "@vercel/sandbox": "^2.0.2"
   },
   "devDependencies": {
     "@ai-sdk/provider": "^3.0.10",

--- a/packages/api/scripts/verify-vercel-sandbox.ts
+++ b/packages/api/scripts/verify-vercel-sandbox.ts
@@ -59,10 +59,13 @@ console.log(
     : "[verify] using VERCEL_OIDC_TOKEN from .env.local (Vercel-platform path)",
 );
 
+// v2 persists (snapshots) by default — force ephemeral so this verification
+// run matches the runtime backends and leaves no snapshot behind.
 const createOpts = hasAccessTokenPath
   ? {
       runtime: "node24" as const,
       networkPolicy: "deny-all" as const,
+      persistent: false,
       teamId: teamId!,
       projectId: projectId!,
       token: token!,
@@ -70,6 +73,7 @@ const createOpts = hasAccessTokenPath
   : {
       runtime: "node24" as const,
       networkPolicy: "deny-all" as const,
+      persistent: false,
     };
 
 const t0 = Date.now();

--- a/packages/api/src/lib/tools/explore-sandbox.ts
+++ b/packages/api/src/lib/tools/explore-sandbox.ts
@@ -116,6 +116,9 @@ export async function createSandboxBackend(
     sandbox = await Sandbox.create({
       runtime: "node24",
       networkPolicy: "deny-all",
+      // v2 persists (snapshots) by default — force ephemeral so semantic
+      // files never linger in Vercel snapshot storage after stop().
+      persistent: false,
       ...(explicitAccess ?? {}),
     });
   } catch (err) {

--- a/packages/api/src/lib/tools/python-sandbox.ts
+++ b/packages/api/src/lib/tools/python-sandbox.ts
@@ -187,6 +187,10 @@ export function createPythonSandboxBackend(
           Sandbox.create({
             runtime: "python3.13",
             networkPolicy: "allow-all",
+            // v2 persists (snapshots) by default — force ephemeral so
+            // per-request code/data/chart files never land in Vercel
+            // snapshot storage after the sandbox is stopped.
+            persistent: false,
             ...(explicitAccess ?? {}),
           }),
         catch: (err) => {

--- a/packages/api/src/types/vercel-sandbox.d.ts
+++ b/packages/api/src/types/vercel-sandbox.d.ts
@@ -31,6 +31,14 @@ declare module "@vercel/sandbox" {
      * Actual SDK also accepts an object form for fine-grained rules.
      */
     networkPolicy?: "deny-all" | "allow-all" | (string & {});
+    /**
+     * v2 sandboxes are **persistent by default** (they snapshot their
+     * filesystem on stop and can resume). Atlas MUST pass `persistent: false`
+     * for every per-request backend so generated tenant data + semantic files
+     * never land in Vercel snapshot storage — the "ephemeral filesystem"
+     * guarantee. (v1 had no persistence; this field did not exist.)
+     */
+    persistent?: boolean;
     ports?: number[];
     timeout?: number;
   }

--- a/packages/api/src/types/vercel-sandbox.d.ts
+++ b/packages/api/src/types/vercel-sandbox.d.ts
@@ -1,10 +1,26 @@
 /**
- * Minimal type declarations for @vercel/sandbox ^1.x (optional dependency).
+ * Minimal type declarations for @vercel/sandbox ^2.x (optional dependency).
  * These declarations provide type safety on environments where the optional
  * package is not installed (e.g., self-hosted Docker deployments).
  * When @vercel/sandbox is installed, its own types take precedence.
  *
- * Last synced with: @vercel/sandbox@1.x SDK reference
+ * Last synced with: @vercel/sandbox@2.0.2 SDK reference
+ *
+ * v2 migration notes (only the surface Atlas uses is mirrored here):
+ *  - `Sandbox` stays the public class — v2 ADDED `Session` (the inner running
+ *    VM) but did NOT rename `Sandbox`. `create`/`runCommand`/`mkDir`/
+ *    `writeFiles`/`stop`/`updateNetworkPolicy` all survive.
+ *  - `writeFiles` content widened to `string | Uint8Array` (+ optional `mode`);
+ *    `Buffer` (what Atlas passes) is a `Uint8Array`, so it still satisfies it.
+ *  - `stop()` now resolves to session/snapshot metadata, not the `Sandbox`.
+ *    Atlas ignores the return, so it is typed loosely here.
+ *  - `updateNetworkPolicy` is `@deprecated` upstream in favour of
+ *    `update({ networkPolicy })`. We deliberately keep calling it (it still
+ *    works in v2, no lint rule flags it) so this dep bump stays minimal and the
+ *    `Parameters<updateNetworkPolicy>[0]` security invariant in
+ *    `tools/backends/network-allowlist.ts` is preserved verbatim. The `@deprecated`
+ *    tag is intentionally NOT mirrored here. Migrating to `.update()` is a
+ *    tracked follow-up.
  */
 declare module "@vercel/sandbox" {
   interface SandboxCreateOptions {
@@ -21,7 +37,13 @@ declare module "@vercel/sandbox" {
 
   interface WriteFileEntry {
     path: string;
-    content: Buffer;
+    /**
+     * v2 accepts `string | Uint8Array`. Atlas always passes a `Buffer`
+     * (a `Uint8Array` subclass), but the wider type mirrors the real SDK.
+     */
+    content: string | Uint8Array;
+    /** File mode (permissions), e.g. `0o755`. Added in v2; Atlas never sets it. */
+    mode?: number;
   }
 
   interface RunCommandParams {
@@ -74,7 +96,9 @@ declare module "@vercel/sandbox" {
       args?: string[],
       opts?: { signal?: AbortSignal }
     ): Promise<CommandFinished>;
-    updateNetworkPolicy(policy: NetworkPolicyUpdate): Promise<void>;
-    stop(): Promise<Sandbox>;
+    // v2 resolves to the applied NetworkPolicy; Atlas ignores the return.
+    updateNetworkPolicy(policy: NetworkPolicyUpdate): Promise<unknown>;
+    // v2 resolves to session/snapshot metadata (not the Sandbox); ignored.
+    stop(): Promise<unknown>;
   }
 }

--- a/plugins/vercel-sandbox/src/index.ts
+++ b/plugins/vercel-sandbox/src/index.ts
@@ -228,6 +228,9 @@ async function createVercelExploreBackend(
   const createOpts: Record<string, unknown> = {
     runtime: "node24",
     networkPolicy: "deny-all",
+    // v2 persists (snapshots) by default — force ephemeral so semantic files
+    // never linger in Vercel snapshot storage after stop().
+    persistent: false,
   };
   if (config.accessToken) {
     createOpts.accessToken = config.accessToken;
@@ -398,6 +401,8 @@ export function buildVercelSandboxPlugin(
             const createOpts: Record<string, unknown> = {
               runtime: "node24",
               networkPolicy: "deny-all",
+              // v2 persists by default — keep the health-check sandbox ephemeral.
+              persistent: false,
             };
             if (config.accessToken) {
               createOpts.accessToken = config.accessToken;

--- a/plugins/vercel-sandbox/src/index.ts
+++ b/plugins/vercel-sandbox/src/index.ts
@@ -154,21 +154,31 @@ const SANDBOX_SEMANTIC_CWD = "/vercel/sandbox/semantic";
 // ---------------------------------------------------------------------------
 
 /**
- * Lazily import @vercel/sandbox using require() so the peer dependency is
- * optional at install time.
+ * Lazily load @vercel/sandbox via dynamic `import()` so the peer dependency
+ * stays optional at install time.
+ *
+ * v2 is ESM-first (`"type": "module"` with a dual `import`/`require` exports
+ * map). Dynamic `import()` resolves the ESM entry — matching how the core
+ * explore/python sandbox backends load it (`tools/explore-sandbox.ts`,
+ * `tools/python-sandbox.ts`). The previous `require()` resolved the *separate*
+ * CJS build; under v2's dual-package layout that no longer shares a module
+ * record with the test's `mock.module("@vercel/sandbox")` (which resolves the
+ * ESM condition), so the mock could not intercept it. The peer's own types are
+ * intentionally not imported — the local structural `SandboxConstructor` stays
+ * the contract.
  */
-function loadSandboxModule(): { Sandbox: SandboxConstructor } {
-  let mod: { Sandbox: SandboxConstructor };
+async function loadSandboxModule(): Promise<{ Sandbox: SandboxConstructor }> {
   try {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    mod = require("@vercel/sandbox");
+    return (await import("@vercel/sandbox")) as unknown as {
+      Sandbox: SandboxConstructor;
+    };
   } catch (err) {
-    const isNotFound =
-      err != null &&
-      typeof err === "object" &&
-      "code" in err &&
-      (err as NodeJS.ErrnoException).code === "MODULE_NOT_FOUND";
-    if (isNotFound) {
+    const code =
+      err != null && typeof err === "object" && "code" in err
+        ? (err as NodeJS.ErrnoException).code
+        : undefined;
+    // `require()` threw MODULE_NOT_FOUND; dynamic import() throws ERR_MODULE_NOT_FOUND.
+    if (code === "MODULE_NOT_FOUND" || code === "ERR_MODULE_NOT_FOUND") {
       throw new Error(
         "Vercel Sandbox requires the @vercel/sandbox package. " +
           "Install it with: bun add @vercel/sandbox",
@@ -179,7 +189,6 @@ function loadSandboxModule(): { Sandbox: SandboxConstructor } {
       { cause: err },
     );
   }
-  return mod;
 }
 
 // Minimal structural type for the Sandbox class from @vercel/sandbox.
@@ -213,7 +222,7 @@ async function createVercelExploreBackend(
   log?: { warn(msg: string): void },
 ): Promise<PluginExploreBackend> {
   // 1. Load the optional dependency
-  const { Sandbox } = loadSandboxModule();
+  const { Sandbox } = await loadSandboxModule();
 
   // 2. Create the sandbox
   const createOpts: Record<string, unknown> = {
@@ -384,7 +393,7 @@ export function buildVercelSandboxPlugin(
       try {
         const result = await Promise.race([
           (async () => {
-            const { Sandbox } = loadSandboxModule();
+            const { Sandbox } = await loadSandboxModule();
 
             const createOpts: Record<string, unknown> = {
               runtime: "node24",


### PR DESCRIPTION
## Summary

v0.0.7 dependency refresh — **Group B** major bump (one PR per package, security-first). `@vercel/sandbox` is the highest-risk Group B package: it's the SaaS-pinned prod sandbox (`deploy/api/atlas.config.ts` → `sandbox.priority: ["vercel-sandbox"]`, `networkPolicy: "deny-all"`, off-Vercel `VERCEL_*` creds per Railway service).

- **`@vercel/sandbox` `^1.9.0` → `^2.0.2`** in `packages/api` (optionalDep) + both scaffold templates (`^1` → `^2`). `2.0.2` is the **gate-respected** target — `2.1.0` is the registry `latest` but is still inside the 48 h `minimumReleaseAge` quarantine, so it doesn't install.
- All `@atlas/api` consumers (`explore-sandbox`, `python-sandbox`, `network-allowlist`, `verify-vercel-sandbox`) are **v2-compatible as-is**. v2 keeps `Sandbox` as the public class (it *added* `Session` as the inner running-VM concept — it did **not** rename `Sandbox`, contrary to the GitHub releases-page summary). `Sandbox.create` / `runCommand({cmd,args,cwd,env,sudo})` / `mkDir` / `writeFiles` (our `Buffer` ⊂ `string | Uint8Array`) / `stop()` (return ignored) / `updateNetworkPolicy` / `exitCode`·`stdout()`·`stderr()` all survive.

## Notable changes beyond the version bump

- **Ambient stub `packages/api/src/types/vercel-sandbox.d.ts` synced to v2** (it's the type source under the repo's bundler resolution). `writeFiles` content widened to `string | Uint8Array` (+ optional `mode`); `stop()` return loosened (v2 returns snapshot metadata, which we ignore). **Kept `updateNetworkPolicy`** — it's `@deprecated` upstream in favour of `update({ networkPolicy })`, but it still works in v2, no lint rule flags it, and it preserves the **compile-time security invariant** in `network-allowlist.ts` (`SandboxNetworkPolicy = Parameters<updateNetworkPolicy>[0]`, record values typed `NetworkPolicyRule[]` not `unknown`). Migrating to `.update()` is a deliberate follow-up so this bump stays minimal on the security-critical lockdown path.
- **`plugins/vercel-sandbox` loader: `require()` → dynamic `import()`.** v2 is ESM-first (`"type": "module"` + a dual `import`/`require` exports map). The plugin's `require()` resolved the *separate* CJS build, which under v2's dual-package layout no longer shares a module record with the test's `mock.module("@vercel/sandbox")` — so the mock stopped intercepting and the real SDK ran (9 plugin-test failures with an OIDC-credentials error). `import()` matches how the **core** explore/python backends already load it and restores mock interception. Runtime behaviour (lazy, optional peer) is preserved; the local structural `SandboxConstructor` stays the contract.

## Test plan

- [x] `bun run type` — clean
- [x] `bun run lint` / `bun x syncpack lint` — clean
- [x] `bun run test` (full, run alone) — **0 failures** (`@useatlas/vercel-sandbox` 27/0; api sandbox consumers green)
- [x] template-drift, security-headers-drift, railway-watch, schema-drift, oauth-helper-drift, twenty-resolver, published-symbols — all pass
- [x] `bun install --frozen-lockfile` — "no changes"
- [x] standalone Turbopack build (`@atlas/nextjs-standalone`) — exit 0
- [ ] **Staging soak** before the `v0.0.7` tag — recommended for this package given it's the SaaS-pinned prod sandbox. Verify `deny-all` lockdown + off-Vercel `VERCEL_*` creds with `bun run packages/api/scripts/verify-vercel-sandbox.ts` against staging.

## Notes

- No `Closes #N` — v0.0.7 is a patch-rollup tag with no milestone (same as Group A #3123).
- Follow-ups: (1) migrate `updateNetworkPolicy` → `update({ networkPolicy })`; (2) `2.1.0` once it clears the 48 h gate.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3125"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783046084&installation_id=135337507&pr_number=3125&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3125&signature=45a273574afbe39d2b93716c1f64ff94ae9f4f0cfb53a3e67c6a9a8876ab34c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped sandbox runtime dependency to v2 across templates and packages.
* **Bug Fixes**
  * Sandboxes now run ephemerally by default (no persistent snapshots), preventing leftover snapshot state between runs and improving runtime isolation.
* **Documentation**
  * Updated inline docs and type declarations to reflect v2 behavior and options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->