### PR TITLE
refactor(api): adopt @vercel/sandbox v2 ergonomics (await using + fs API) (#3126)

### DIFF
--- a/packages/api/src/lib/tools/__tests__/python-rest-egress.test.ts
+++ b/packages/api/src/lib/tools/__tests__/python-rest-egress.test.ts
@@ -47,22 +47,18 @@ function setupSandboxMock() {
   mock.module("@vercel/sandbox", () => ({
     Sandbox: {
       create: async () => ({
-        runCommand: async (params: { cmd: string; env?: Record<string, string> }) => {
-          if (params.cmd === "pip") {
-            return { exitCode: 0, stdout: async () => "", stderr: async () => "" };
-          }
-          const marker = params.env?.ATLAS_RESULT_MARKER ?? "";
-          return {
-            exitCode: 0,
-            stdout: async () => `${marker}{"success":true}\n`,
-            stderr: async () => "",
-          };
+        runCommand: async (_params: { cmd: string; env?: Record<string, string> }) => {
+          // The wrapper writes its result to the sandbox FS, not stdout.
+          return { exitCode: 0, stdout: async () => "", stderr: async () => "" };
         },
         writeFiles: async () => {},
         mkDir: async () => {},
         updateNetworkPolicy: async (policy: unknown) => {
           mockUpdateNetworkPolicyCalls.push(policy);
         },
+        // v2 FS surface: backend reads the structured result off the FS.
+        fs: { readdir: async () => [] as string[] },
+        readFileToBuffer: async () => Buffer.from('{"success":true}'),
         stop: async () => {},
       }),
     },

--- a/packages/api/src/lib/tools/__tests__/python-sandbox.test.ts
+++ b/packages/api/src/lib/tools/__tests__/python-sandbox.test.ts
@@ -41,15 +41,22 @@ interface MockSandboxOverrides {
   mkDirThrows?: string;
   writeFilesThrows?: string;
   runCommandThrows?: string;
+  /** Command result for the crash path (used when no result file is written). */
   runCommandResult?: {
     exitCode: number;
-    stdout: string;
     stderr: string;
   };
-  /** If true, dynamically inject the result marker into stdout */
-  injectMarker?: boolean;
-  /** Custom stdout builder given the marker */
-  stdoutForMarker?: (marker: string) => string;
+  /**
+   * Contents the wrapper "wrote" to ATLAS_RESULT_FILE, read back by the backend
+   * via readFileToBuffer. `null` simulates no result file (the process crashed /
+   * was signalled before writing one). Defaults to a success result.
+   */
+  resultFile?: string | Buffer | null;
+  /**
+   * Chart PNGs left in the chart dir: filename -> bytes. `fs.readdir` returns
+   * the names and `readFileToBuffer` returns the bytes. Defaults to no charts.
+   */
+  chartFiles?: Record<string, Buffer>;
 }
 
 let mockCreateCalls: unknown[] = [];
@@ -84,25 +91,12 @@ function setupSandboxMock(overrides: MockSandboxOverrides = {}) {
             }
             mockRunCommandCalls.push(params);
             if (overrides.runCommandThrows) throw new Error(overrides.runCommandThrows);
-
-            const marker = params.env?.ATLAS_RESULT_MARKER ?? "";
-            if (overrides.stdoutForMarker) {
-              return {
-                exitCode: overrides.runCommandResult?.exitCode ?? 0,
-                stdout: async () => overrides.stdoutForMarker!(marker),
-                stderr: async () => overrides.runCommandResult?.stderr ?? "",
-              };
-            }
-            if (overrides.injectMarker !== false && !overrides.runCommandResult) {
-              return {
-                exitCode: 0,
-                stdout: async () => `${marker}{"success":true}\n`,
-                stderr: async () => "",
-              };
-            }
+            // The wrapper writes its result to the FS (not stdout), so the
+            // command itself produces no stdout — only exit code + stderr matter
+            // for the crash path.
             return {
               exitCode: overrides.runCommandResult?.exitCode ?? 0,
-              stdout: async () => overrides.runCommandResult?.stdout ?? "",
+              stdout: async () => "",
               stderr: async () => overrides.runCommandResult?.stderr ?? "",
             };
           },
@@ -117,6 +111,19 @@ function setupSandboxMock(overrides: MockSandboxOverrides = {}) {
           updateNetworkPolicy: async (policy: unknown) => {
             mockUpdateNetworkPolicyCalls.push(policy);
             if (overrides.updateNetworkPolicyThrows) throw new Error(overrides.updateNetworkPolicyThrows);
+          },
+          // v2 FS surface — the backend reads the structured result + chart PNGs
+          // off the sandbox FS instead of parsing a stdout result marker.
+          fs: {
+            readdir: async (_path: string) => Object.keys(overrides.chartFiles ?? {}),
+          },
+          readFileToBuffer: async ({ path }: { path: string }) => {
+            const name = path.split("/").pop() ?? "";
+            const charts = overrides.chartFiles ?? {};
+            if (name in charts) return charts[name];
+            if (overrides.resultFile === null) return null;
+            const rf = overrides.resultFile ?? '{"success":true}';
+            return typeof rf === "string" ? Buffer.from(rf) : rf;
           },
           stop: async () => { mockStopCalls++; },
         };
@@ -150,7 +157,7 @@ describe("createPythonSandboxBackend", () => {
 
   it("creates sandbox with python3.13 runtime, installs packages, then locks to deny-all", async () => {
     setupSandboxMock({
-      stdoutForMarker: (m) => `${m}{"success":true,"output":"hello"}\n`,
+      resultFile: '{"success":true,"output":"hello"}',
     });
 
     const backend = await freshBackend();
@@ -168,6 +175,39 @@ describe("createPythonSandboxBackend", () => {
     expect(result.success).toBe(true);
     if (result.success) {
       expect(result.output).toBe("hello");
+    }
+  });
+
+  it("collects chart PNGs off the sandbox FS (readdir + readFileToBuffer) and base64-encodes them", async () => {
+    const png = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+    setupSandboxMock({
+      resultFile: '{"success":true,"output":"chart made"}',
+      chartFiles: { "chart_0.png": png },
+    });
+    const backend = await freshBackend();
+    const result = await backend.exec("plt.savefig(chart_path())");
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.charts).toHaveLength(1);
+      expect(result.charts?.[0].mimeType).toBe("image/png");
+      expect(result.charts?.[0].base64).toBe(png.toString("base64"));
+    }
+  });
+
+  it("rejects when the result plus chart artifacts together exceed 1 MB", async () => {
+    // A ~1 MB PNG base64-encodes to ~1.37 MB, pushing the total over MAX_OUTPUT.
+    const bigChart = Buffer.alloc(1024 * 1024);
+    setupSandboxMock({
+      resultFile: '{"success":true}',
+      chartFiles: { "chart_0.png": bigChart },
+    });
+    const backend = await freshBackend();
+    const result = await backend.exec("plt.savefig(chart_path())");
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain("exceeded 1 MB");
     }
   });
 
@@ -234,7 +274,8 @@ describe("createPythonSandboxBackend", () => {
 
     expect(params.cmd).toBe("python3");
     expect(params.env?.MPLBACKEND).toBe("Agg");
-    expect(params.env?.ATLAS_RESULT_MARKER).toBeDefined();
+    expect(params.env?.ATLAS_RESULT_FILE).toBeDefined();
+    expect(params.env?.ATLAS_RESULT_FILE).toContain("result.json");
     expect(params.env?.ATLAS_CHART_DIR).toContain("charts");
 
     // No secrets
@@ -333,9 +374,10 @@ describe("createPythonSandboxBackend", () => {
   });
 
   it("handles SIGKILL exit code", async () => {
+    // No result file (process killed before writing one) — crash path.
     setupSandboxMock({
-      injectMarker: false,
-      runCommandResult: { exitCode: 137, stdout: "", stderr: "" },
+      resultFile: null,
+      runCommandResult: { exitCode: 137, stderr: "" },
     });
     const backend = await freshBackend();
     const result = await backend.exec("while True: pass");
@@ -348,8 +390,8 @@ describe("createPythonSandboxBackend", () => {
 
   it("handles SIGSEGV exit code with stderr", async () => {
     setupSandboxMock({
-      injectMarker: false,
-      runCommandResult: { exitCode: 139, stdout: "", stderr: "Segfault in numpy" },
+      resultFile: null,
+      runCommandResult: { exitCode: 139, stderr: "Segfault in numpy" },
     });
     const backend = await freshBackend();
     const result = await backend.exec("bad code");
@@ -361,10 +403,10 @@ describe("createPythonSandboxBackend", () => {
     }
   });
 
-  it("returns stderr as error when no result marker and non-zero exit", async () => {
+  it("returns stderr as error when no result file and non-zero exit", async () => {
     setupSandboxMock({
-      injectMarker: false,
-      runCommandResult: { exitCode: 1, stdout: "some output", stderr: "NameError: name 'foo' is not defined" },
+      resultFile: null,
+      runCommandResult: { exitCode: 1, stderr: "NameError: name 'foo' is not defined" },
     });
     const backend = await freshBackend();
     const result = await backend.exec("print(foo)");
@@ -376,11 +418,9 @@ describe("createPythonSandboxBackend", () => {
   });
 
   it("rejects output exceeding 1 MB", async () => {
-    const bigOutput = "x".repeat(1024 * 1024 + 1);
-    setupSandboxMock({
-      injectMarker: false,
-      runCommandResult: { exitCode: 0, stdout: bigOutput, stderr: "" },
-    });
+    // The structured result the wrapper wrote is over the 1 MB cap.
+    const bigResult = "x".repeat(1024 * 1024 + 1);
+    setupSandboxMock({ resultFile: bigResult });
     const backend = await freshBackend();
     const result = await backend.exec("print('a' * 10000000)");
 
@@ -424,10 +464,8 @@ describe("createPythonSandboxBackend", () => {
   // creation (not a fixed deny-all), scoped to exactly the request that created
   // the backend — and that the policy carries no credential transformer.
 
-  const okMarker = (m: string) => `${m}{"success":true}\n`;
-
   it("locks down to the provided per-request host allowlist instead of deny-all", async () => {
-    setupSandboxMock({ stdoutForMarker: okMarker });
+    setupSandboxMock();
     const mod = await import("@atlas/api/lib/tools/python-sandbox");
     const policy = { allow: { "crm.tenant-a.example": [] } };
     const backend = mod.createPythonSandboxBackend({ networkPolicy: policy });
@@ -439,7 +477,7 @@ describe("createPythonSandboxBackend", () => {
   });
 
   it("SECURITY (per-request): separate backends lock down to their OWN policy — no shared state", async () => {
-    setupSandboxMock({ stdoutForMarker: okMarker });
+    setupSandboxMock();
     const mod = await import("@atlas/api/lib/tools/python-sandbox");
 
     const a = mod.createPythonSandboxBackend({ networkPolicy: { allow: { "a.example": [] } } });
@@ -455,7 +493,7 @@ describe("createPythonSandboxBackend", () => {
   });
 
   it("defaults to deny-all when no options are given (back-compat — SQL-only workloads)", async () => {
-    setupSandboxMock({ stdoutForMarker: okMarker });
+    setupSandboxMock();
     const backend = await freshBackend();
     await backend.exec("print('x')");
 

--- a/packages/api/src/lib/tools/explore-sandbox.ts
+++ b/packages/api/src/lib/tools/explore-sandbox.ts
@@ -131,81 +131,88 @@ export async function createSandboxBackend(
     );
   }
 
-  try {
-    // 3. Collect semantic layer files
-    // Use relative paths so the SDK writes under /vercel/sandbox/ (the writable
-    // base directory). Absolute root paths like /semantic cause the Sandbox API
-    // to return HTTP 400 — the SDK resolves relative paths to /vercel/sandbox/.
-    let files: { path: string; content: Buffer }[];
+  // v2: stop the sandbox automatically if the setup below throws. The disposer
+  // swallows stop() errors (logging only) so the original setup error is the one
+  // that surfaces — matching the previous hand-rolled try/finally. On success we
+  // `disposer.move()` to disarm: the returned backend's close() owns it from then on.
+  await using disposer = new AsyncDisposableStack();
+  disposer.adopt(sandbox, async (s) => {
     try {
-      files = collectSemanticFiles(semanticRoot, SANDBOX_SEMANTIC_REL);
-    } catch (err) {
-      const detail = err instanceof Error ? err.message : String(err);
-      log.error({ err: detail }, "Failed to collect semantic layer files");
-      throw new Error(
-        `Cannot read semantic layer at ${semanticRoot}: ${detail}. ` +
-          "Ensure the semantic/ directory exists and is readable.",
-        { cause: err }
-      );
-    }
-
-    if (files.length === 0) {
-      log.error(
-        { semanticRoot },
-        "No semantic layer files found — sandbox will have empty semantic directory",
-      );
-      throw new Error(
-        "No semantic layer files found. " +
-          "Run 'bun run atlas -- init' to generate a semantic layer, then redeploy."
-      );
-    }
-
-    // 4. Copy semantic files into the sandbox filesystem
-    // Create directories first (mkDir is not recursive), then upload files.
-    const dirs = new Set<string>();
-    for (const f of files) {
-      let dir = path.posix.dirname(f.path);
-      while (dir !== "/" && dir !== ".") {
-        dirs.add(dir);
-        dir = path.posix.dirname(dir);
-      }
-    }
-
-    for (const dir of [...dirs].sort()) {
-      try {
-        await sandbox.mkDir(dir);
-      } catch (err) {
-        const detail = sandboxErrorDetail(err);
-        log.error({ err: detail, dir }, "Failed to create directory in sandbox");
-        throw new Error(
-          `Failed to create directory "${dir}" in sandbox: ${safeError(detail)}.`,
-          { cause: err },
-        );
-      }
-    }
-
-    try {
-      await sandbox.writeFiles(files);
-    } catch (err) {
-      const detail = sandboxErrorDetail(err);
-      log.error({ err: detail, fileCount: files.length }, "Failed to write files into sandbox");
-      throw new Error(
-        `Failed to upload ${files.length} semantic files to sandbox: ${safeError(detail)}.`,
-        { cause: err }
-      );
-    }
-  } catch (err) {
-    // Clean up the sandbox before re-throwing
-    try {
-      await sandbox.stop();
+      await s.stop();
     } catch (stopErr) {
       log.warn(
         { err: stopErr instanceof Error ? stopErr.message : String(stopErr) },
         "Failed to stop sandbox during error cleanup",
       );
     }
-    throw err;
+  });
+
+  // 3. Collect semantic layer files
+  // Use relative paths so the SDK writes under /vercel/sandbox/ (the writable
+  // base directory). Absolute root paths like /semantic cause the Sandbox API
+  // to return HTTP 400 — the SDK resolves relative paths to /vercel/sandbox/.
+  let files: { path: string; content: Buffer }[];
+  try {
+    files = collectSemanticFiles(semanticRoot, SANDBOX_SEMANTIC_REL);
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    log.error({ err: detail }, "Failed to collect semantic layer files");
+    throw new Error(
+      `Cannot read semantic layer at ${semanticRoot}: ${detail}. ` +
+        "Ensure the semantic/ directory exists and is readable.",
+      { cause: err }
+    );
   }
+
+  if (files.length === 0) {
+    log.error(
+      { semanticRoot },
+      "No semantic layer files found — sandbox will have empty semantic directory",
+    );
+    throw new Error(
+      "No semantic layer files found. " +
+        "Run 'bun run atlas -- init' to generate a semantic layer, then redeploy."
+    );
+  }
+
+  // 4. Copy semantic files into the sandbox filesystem
+  // Create directories first (mkDir is not recursive), then upload files.
+  const dirs = new Set<string>();
+  for (const f of files) {
+    let dir = path.posix.dirname(f.path);
+    while (dir !== "/" && dir !== ".") {
+      dirs.add(dir);
+      dir = path.posix.dirname(dir);
+    }
+  }
+
+  for (const dir of [...dirs].sort()) {
+    try {
+      await sandbox.mkDir(dir);
+    } catch (err) {
+      const detail = sandboxErrorDetail(err);
+      log.error({ err: detail, dir }, "Failed to create directory in sandbox");
+      throw new Error(
+        `Failed to create directory "${dir}" in sandbox: ${safeError(detail)}.`,
+        { cause: err },
+      );
+    }
+  }
+
+  try {
+    await sandbox.writeFiles(files);
+  } catch (err) {
+    const detail = sandboxErrorDetail(err);
+    log.error({ err: detail, fileCount: files.length }, "Failed to write files into sandbox");
+    throw new Error(
+      `Failed to upload ${files.length} semantic files to sandbox: ${safeError(detail)}.`,
+      { cause: err }
+    );
+  }
+
+  // Setup succeeded — disarm the disposer so the sandbox survives in the
+  // returned backend (close()/exec() own its lifecycle from here).
+  disposer.move();
 
   return {
     exec: async (command: string): Promise<ExecResult> => {

--- a/packages/api/src/lib/tools/python-sandbox.ts
+++ b/packages/api/src/lib/tools/python-sandbox.ts
@@ -8,7 +8,8 @@
  * - Installs data science packages, then locks down to deny-all
  * - Writes wrapper + user code to the sandbox filesystem
  * - Injects data via a JSON file (runCommand does not support stdin piping)
- * - Collects charts and structured output via result marker
+ * - Reads the structured result + chart PNGs back off the sandbox FS via the
+ *   v2 sandbox.fs API (readFileToBuffer / readdir), not a stdout result marker
  * - Unlike explore-sandbox.ts, the sandbox is created lazily and reused
  *   across calls (no explicit close/stop lifecycle — invalidation stops
  *   the old sandbox and creates a fresh one on next call)
@@ -25,7 +26,7 @@
 import { Effect, Data, Duration, Schedule } from "effect";
 import type { PythonBackend, PythonResult } from "./python";
 import type { SandboxNetworkPolicy } from "./backends/network-allowlist";
-import { PYTHON_SECURITY_AND_SETUP, PYTHON_EXEC_AND_COLLECT } from "./python-wrapper";
+import { PYTHON_SECURITY_AND_SETUP } from "./python-wrapper";
 import { sandboxErrorDetail, safeError, MAX_OUTPUT } from "./backends/shared";
 import { vercelSandboxAccess } from "./backends/detect";
 import { randomUUID } from "crypto";
@@ -65,18 +66,27 @@ const DATA_SCIENCE_PACKAGES = [
 ];
 
 /**
- * Non-streaming Python wrapper for Vercel Sandbox. Composes shared fragments
- * (PYTHON_SECURITY_AND_SETUP, PYTHON_EXEC_AND_COLLECT) with file-based
- * data injection (argv[2]) since runCommand does not support stdin piping.
+ * Non-streaming Python wrapper for Vercel Sandbox. Composes the shared security
+ * fragment (PYTHON_SECURITY_AND_SETUP) with file-based data injection (argv[2],
+ * since runCommand does not support stdin piping).
+ *
+ * Result transport diverges from the shared PYTHON_EXEC_AND_COLLECT fragment
+ * (used by the nsjail/sidecar backends): instead of smuggling the structured
+ * result back through a `__ATLAS_RESULT_<id>__` stdout marker, this wrapper
+ * writes the result JSON to ATLAS_RESULT_FILE and leaves chart PNGs as files in
+ * _chart_dir. The host reads both off the sandbox FS via the v2 sandbox.fs API
+ * (readdir + readFileToBuffer). Charts are NOT base64-embedded here — they are
+ * read as raw artifacts host-side.
  */
 const PYTHON_WRAPPER = `
-import sys, json, io, base64, glob, os, ast
+import sys, json, io, os, ast
 
-_marker = os.environ["ATLAS_RESULT_MARKER"]
 _chart_dir = os.environ.get("ATLAS_CHART_DIR", "/tmp/charts")
+_result_file = os.environ["ATLAS_RESULT_FILE"]
 
 def _report_error(msg):
-    print(_marker + json.dumps({"success": False, "error": msg}))
+    with open(_result_file, "w") as _rf:
+        _rf.write(json.dumps({"success": False, "error": msg}))
     sys.exit(0)
 
 ${PYTHON_SECURITY_AND_SETUP}
@@ -101,11 +111,47 @@ if _atlas_data:
     except ImportError:
         data = _atlas_data
 
-${PYTHON_EXEC_AND_COLLECT}
+# --- Execute user code in isolated namespace ---
+_old_stdout = sys.stdout
+sys.stdout = _captured = io.StringIO()
+
+_user_ns = {"chart_path": chart_path, "data": data, "df": df}
+_atlas_error = None
+try:
+    exec(_user_code, _user_ns)
+except Exception as e:
+    _atlas_error = f"{type(e).__name__}: {e}"
+
+_output = _captured.getvalue()
+sys.stdout = _old_stdout
+
+# --- Build structured result (charts stay as PNG files, read host-side) ---
+_result = {"success": _atlas_error is None}
+if _output.strip():
+    _result["output"] = _output.strip()
+if _atlas_error:
+    _result["error"] = _atlas_error
+
+if "_atlas_table" in _user_ns:
+    _result["table"] = _user_ns["_atlas_table"]
+
+if "_atlas_chart" in _user_ns:
+    _ac = _user_ns["_atlas_chart"]
+    if isinstance(_ac, dict):
+        _result["rechartsCharts"] = [_ac]
+    elif isinstance(_ac, list):
+        _result["rechartsCharts"] = _ac
+
+with open(_result_file, "w") as _rf:
+    _rf.write(json.dumps(_result))
 `;
 
 // Sandbox base dir for relative paths
 const SANDBOX_BASE = "/vercel/sandbox";
+
+/** Shared 1 MB output-guard message (matches nsjail's MAX_OUTPUT rejection). */
+const OUTPUT_TOO_LARGE_ERROR =
+  "Python output exceeded 1 MB limit — reduce print() output or use _atlas_table for large results.";
 
 // ── Local tagged errors ──────────────────────────────────────────────
 // Module-internal errors for Effect control flow. Not part of the global
@@ -320,12 +366,14 @@ export function createPythonSandboxBackend(
       }
 
       const execId = randomUUID();
-      const resultMarker = `__ATLAS_RESULT_${execId}__`;
       const execDir = `exec-${execId}`;
       const chartDir = `${execDir}/charts`;
       const wrapperPath = `${execDir}/wrapper.py`;
       const codePath = `${execDir}/user_code.py`;
       const dataPath = `${execDir}/data.json`;
+      const resultPath = `${execDir}/result.json`;
+      const chartDirAbs = `${SANDBOX_BASE}/${chartDir}`;
+      const resultPathAbs = `${SANDBOX_BASE}/${resultPath}`;
 
       const timeout =
         parseInt(
@@ -402,8 +450,8 @@ export function createPythonSandboxBackend(
               args: pythonArgs,
               cwd: `${SANDBOX_BASE}/${execDir}`,
               env: {
-                ATLAS_RESULT_MARKER: resultMarker,
-                ATLAS_CHART_DIR: `${SANDBOX_BASE}/${chartDir}`,
+                ATLAS_RESULT_FILE: resultPathAbs,
+                ATLAS_CHART_DIR: chartDirAbs,
                 MPLBACKEND: "Agg",
                 HOME: "/tmp",
                 LANG: "C.UTF-8",
@@ -429,52 +477,106 @@ export function createPythonSandboxBackend(
           }),
         );
 
-        // 5. Read stdout/stderr
-        const [stdout, stderr] = yield* Effect.tryPromise({
-          try: () => Promise.all([cmdResult.stdout(), cmdResult.stderr()]),
+        // 5. Read stderr — used only when the wrapper produced no result file
+        // (the process crashed / was signalled before it could write one).
+        const stderr = yield* Effect.tryPromise({
+          try: () => cmdResult.stderr(),
           catch: (err) => {
             const detail = sandboxErrorDetail(err);
-            log.error({ err: detail, execId }, "Failed to read stdout/stderr from sandbox");
+            log.error({ err: detail, execId }, "Failed to read stderr from sandbox");
             return new SandboxInfraError({
               message: `Failed to read execution output: ${safeError(detail)}`,
             });
           },
         });
 
-        // 6. Output size guard (matches nsjail's 1 MB limit)
-        if (stdout.length > MAX_OUTPUT) {
-          return {
-            success: false as const,
-            error: "Python output exceeded 1 MB limit — reduce print() output or use _atlas_table for large results.",
-          };
-        }
+        // 6. Read the structured result the wrapper wrote to the sandbox FS
+        // (v2 readFileToBuffer) — replaces the stdout result-marker parse.
+        const resultBuffer = yield* Effect.tryPromise({
+          try: () => sandbox.readFileToBuffer({ path: resultPathAbs }),
+          catch: (err) => {
+            const detail = sandboxErrorDetail(err);
+            log.error({ err: detail, execId }, "Failed to read result file from sandbox");
+            return new SandboxInfraError({
+              message: `Failed to read execution output: ${safeError(detail)}`,
+            });
+          },
+        });
 
-        log.debug(
-          { execId, exitCode: cmdResult.exitCode, stdoutLen: stdout.length },
-          "python sandbox execution finished",
-        );
+        if (resultBuffer) {
+          // 7. Output size guard (matches nsjail's 1 MB limit). Bound the
+          // structured-result buffer first, then result + charts combined
+          // (step 8) so the total payload returned to the agent stays bounded —
+          // the same cap the stdout marker enforced before #3126.
+          if (resultBuffer.length > MAX_OUTPUT) {
+            return { success: false as const, error: OUTPUT_TOO_LARGE_ERROR };
+          }
 
-        // 7. Extract structured result from the last marker line
-        const lines = stdout.split("\n");
-        const resultLine = lines.findLast((l) => l.startsWith(resultMarker));
-
-        if (resultLine) {
+          let parsed: PythonResult;
           try {
-            return JSON.parse(resultLine.slice(resultMarker.length)) as PythonResult;
+            parsed = JSON.parse(resultBuffer.toString()) as PythonResult;
           } catch (parseErr) {
             log.warn(
-              { execId, resultLine: resultLine.slice(0, 500), parseError: String(parseErr) },
+              { execId, parseError: String(parseErr) },
               "failed to parse Python result JSON",
             );
-            const userOutput = stdout.split(resultMarker)[0].trim();
             return {
               success: false as const,
-              error: `Python produced unparseable output.${userOutput ? ` Output: ${userOutput.slice(0, 500)}` : ""} stderr: ${stderr.trim().slice(0, 500)}`,
+              error: `Python produced unparseable output.${stderr.trim() ? ` stderr: ${stderr.trim().slice(0, 500)}` : ""}`,
             };
           }
+
+          // 8. Collect chart artifacts directly off the sandbox FS (readdir +
+          // readFileToBuffer), base64-encoding host-side. The wrapper leaves
+          // chart PNGs as files rather than embedding them in the result.
+          const chartBuffers = yield* Effect.tryPromise({
+            try: async () => {
+              const names = await sandbox.fs.readdir(chartDirAbs);
+              const pngs = names.filter((n) => /^chart_.*\.png$/.test(n)).sort();
+              const bufs: Buffer[] = [];
+              for (const name of pngs) {
+                const buf = await sandbox.readFileToBuffer({ path: `${chartDirAbs}/${name}` });
+                if (buf) bufs.push(buf);
+              }
+              return bufs;
+            },
+            catch: (err) => {
+              const detail = sandboxErrorDetail(err);
+              log.error({ err: detail, execId }, "Failed to read chart artifacts from sandbox");
+              return new SandboxInfraError({
+                message: `Failed to read chart artifacts: ${safeError(detail)}`,
+              });
+            },
+          });
+
+          const chartsB64 = chartBuffers.map((b) => b.toString("base64"));
+          const totalBytes =
+            resultBuffer.length + chartsB64.reduce((n, s) => n + s.length, 0);
+          if (totalBytes > MAX_OUTPUT) {
+            return { success: false as const, error: OUTPUT_TOO_LARGE_ERROR };
+          }
+
+          log.debug(
+            {
+              execId,
+              exitCode: cmdResult.exitCode,
+              resultLen: resultBuffer.length,
+              charts: chartsB64.length,
+            },
+            "python sandbox execution finished",
+          );
+
+          if (parsed.success && chartsB64.length > 0) {
+            parsed.charts = chartsB64.map((b64) => ({
+              base64: b64,
+              mimeType: "image/png" as const,
+            }));
+          }
+          return parsed;
         }
 
-        // 8. No structured result — process errored before the wrapper could emit one
+        // 9. No result file — the process crashed / was signalled before the
+        // wrapper could write one.
         if (cmdResult.exitCode > 128) {
           const signal = cmdResult.exitCode - 128;
           const signalNames: Record<number, string> = {

--- a/packages/api/src/lib/tools/python-sandbox.ts
+++ b/packages/api/src/lib/tools/python-sandbox.ts
@@ -533,12 +533,13 @@ export function createPythonSandboxBackend(
             try: async () => {
               const names = await sandbox.fs.readdir(chartDirAbs);
               const pngs = names.filter((n) => /^chart_.*\.png$/.test(n)).sort();
-              const bufs: Buffer[] = [];
-              for (const name of pngs) {
-                const buf = await sandbox.readFileToBuffer({ path: `${chartDirAbs}/${name}` });
-                if (buf) bufs.push(buf);
-              }
-              return bufs;
+              // Reads are independent — fan out rather than awaiting serially.
+              const bufs = await Promise.all(
+                pngs.map((name) =>
+                  sandbox.readFileToBuffer({ path: `${chartDirAbs}/${name}` }),
+                ),
+              );
+              return bufs.filter((buf): buf is Buffer => buf !== null);
             },
             catch: (err) => {
               const detail = sandboxErrorDetail(err);

--- a/packages/api/src/types/vercel-sandbox.d.ts
+++ b/packages/api/src/types/vercel-sandbox.d.ts
@@ -21,6 +21,18 @@
  *    `tools/backends/network-allowlist.ts` is preserved verbatim. The `@deprecated`
  *    tag is intentionally NOT mirrored here. Migrating to `.update()` is a
  *    tracked follow-up.
+ *
+ * v2 ergonomics adopted in #3126 (only the members actually used are added):
+ *  - `Sandbox.create()` resolves to `Sandbox & AsyncDisposable`, so the
+ *    create-and-dispose-in-one-scope backends (`tools/explore-sandbox.ts`, the
+ *    `@useatlas/vercel-sandbox` plugin) can use `await using` /
+ *    `AsyncDisposableStack` instead of a hand-rolled `try/finally` + `stop()`.
+ *  - `readFileToBuffer({ path })` reads a file off the sandbox FS as a `Buffer`
+ *    (or `null` if missing) — `tools/python-sandbox.ts` uses it to read the
+ *    structured result + chart PNGs directly, replacing the stdout result-marker.
+ *  - `fs` exposes a `node:fs/promises`-compatible surface; only `readdir`
+ *    (listing chart PNGs) is mirrored. `downloadFile` and the rest of `fs` are
+ *    intentionally omitted — Atlas does not use them.
  */
 declare module "@vercel/sandbox" {
   interface SandboxCreateOptions {
@@ -69,6 +81,19 @@ declare module "@vercel/sandbox" {
     stderr(): Promise<string>;
   }
 
+  /**
+   * Subset of the v2 `node:fs/promises`-compatible filesystem surface
+   * (`sandbox.fs`). Only `readdir` is mirrored — `python-sandbox.ts` uses it to
+   * list the chart PNGs written by user code. The `withFileTypes: false`
+   * overload (plain string names) is all Atlas needs.
+   */
+  interface SandboxFileSystem {
+    readdir(
+      path: string,
+      options?: { signal?: AbortSignal; withFileTypes?: false }
+    ): Promise<string[]>;
+  }
+
   /** A transform applied to network requests matching a domain rule. */
   type NetworkTransformer = { headers?: Record<string, string> };
 
@@ -95,7 +120,9 @@ declare module "@vercel/sandbox" {
       };
 
   class Sandbox {
-    static create(opts?: SandboxCreateOptions): Promise<Sandbox>;
+    // v2: the create return is `Sandbox & AsyncDisposable`, enabling
+    // `await using` / `AsyncDisposableStack` (the disposer calls `stop()`).
+    static create(opts?: SandboxCreateOptions): Promise<Sandbox & AsyncDisposable>;
     mkDir(path: string): Promise<void>;
     writeFiles(files: WriteFileEntry[]): Promise<void>;
     runCommand(params: RunCommandParams): Promise<CommandFinished>;
@@ -104,6 +131,20 @@ declare module "@vercel/sandbox" {
       args?: string[],
       opts?: { signal?: AbortSignal }
     ): Promise<CommandFinished>;
+    /**
+     * `node:fs/promises`-compatible filesystem surface. Atlas only uses
+     * `fs.readdir` (to list chart PNGs in `python-sandbox.ts`).
+     */
+    readonly fs: SandboxFileSystem;
+    /**
+     * Read a file off the sandbox FS as a `Buffer`, or `null` if it does not
+     * exist. `python-sandbox.ts` reads the structured result file + chart PNGs
+     * with this, replacing the stdout result-marker.
+     */
+    readFileToBuffer(
+      file: { path: string; cwd?: string },
+      opts?: { signal?: AbortSignal }
+    ): Promise<Buffer | null>;
     // v2 resolves to the applied NetworkPolicy; Atlas ignores the return.
     updateNetworkPolicy(policy: NetworkPolicyUpdate): Promise<unknown>;
     // v2 resolves to session/snapshot metadata (not the Sandbox); ignored.

--- a/packages/api/src/types/vercel-sandbox.d.ts
+++ b/packages/api/src/types/vercel-sandbox.d.ts
@@ -23,16 +23,18 @@
  *    tracked follow-up.
  *
  * v2 ergonomics adopted in #3126 (only the members actually used are added):
- *  - `Sandbox.create()` resolves to `Sandbox & AsyncDisposable`, so the
- *    create-and-dispose-in-one-scope backends (`tools/explore-sandbox.ts`, the
- *    `@useatlas/vercel-sandbox` plugin) can use `await using` /
- *    `AsyncDisposableStack` instead of a hand-rolled `try/finally` + `stop()`.
  *  - `readFileToBuffer({ path })` reads a file off the sandbox FS as a `Buffer`
  *    (or `null` if missing) — `tools/python-sandbox.ts` uses it to read the
  *    structured result + chart PNGs directly, replacing the stdout result-marker.
  *  - `fs` exposes a `node:fs/promises`-compatible surface; only `readdir`
  *    (listing chart PNGs) is mirrored. `downloadFile` and the rest of `fs` are
  *    intentionally omitted — Atlas does not use them.
+ *
+ * `tools/explore-sandbox.ts` and the `@useatlas/vercel-sandbox` plugin replace
+ * their hand-rolled try/finally + stop() with `AsyncDisposableStack` (a JS
+ * runtime feature, not an SDK type), adopting the sandbox with an explicit
+ * stop() disposer — so the create return is NOT required to be `AsyncDisposable`
+ * and that member is intentionally not mirrored here.
  */
 declare module "@vercel/sandbox" {
   interface SandboxCreateOptions {
@@ -120,9 +122,7 @@ declare module "@vercel/sandbox" {
       };
 
   class Sandbox {
-    // v2: the create return is `Sandbox & AsyncDisposable`, enabling
-    // `await using` / `AsyncDisposableStack` (the disposer calls `stop()`).
-    static create(opts?: SandboxCreateOptions): Promise<Sandbox & AsyncDisposable>;
+    static create(opts?: SandboxCreateOptions): Promise<Sandbox>;
     mkDir(path: string): Promise<void>;
     writeFiles(files: WriteFileEntry[]): Promise<void>;
     runCommand(params: RunCommandParams): Promise<CommandFinished>;

--- a/plugins/vercel-sandbox/__tests__/vercel-sandbox.test.ts
+++ b/plugins/vercel-sandbox/__tests__/vercel-sandbox.test.ts
@@ -20,6 +20,10 @@ const mockSandboxInstance = {
   stop: mockStop,
   mkDir: mockMkDir,
   writeFiles: mockWriteFiles,
+  // v2: the create return is `Sandbox & AsyncDisposable`. `await using` /
+  // AsyncDisposableStack call this on scope exit; route it through mockStop so
+  // disposal counts as a stop() for the assertions below.
+  [Symbol.asyncDispose]: () => mockStop(),
 };
 
 const mockCreate = mock((_opts?: Record<string, unknown>) => Promise.resolve(mockSandboxInstance));

--- a/plugins/vercel-sandbox/__tests__/vercel-sandbox.test.ts
+++ b/plugins/vercel-sandbox/__tests__/vercel-sandbox.test.ts
@@ -20,10 +20,6 @@ const mockSandboxInstance = {
   stop: mockStop,
   mkDir: mockMkDir,
   writeFiles: mockWriteFiles,
-  // v2: the create return is `Sandbox & AsyncDisposable`. `await using` /
-  // AsyncDisposableStack call this on scope exit; route it through mockStop so
-  // disposal counts as a stop() for the assertions below.
-  [Symbol.asyncDispose]: () => mockStop(),
 };
 
 const mockCreate = mock((_opts?: Record<string, unknown>) => Promise.resolve(mockSandboxInstance));

--- a/plugins/vercel-sandbox/src/index.ts
+++ b/plugins/vercel-sandbox/src/index.ts
@@ -353,8 +353,12 @@ async function createVercelExploreBackend(
     close: async () => {
       try {
         await sandbox.stop();
-      } catch {
-        // Ignore close errors
+      } catch (err) {
+        log?.warn(
+          `[vercel-sandbox] Failed to stop sandbox on close: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
       }
     },
   };

--- a/plugins/vercel-sandbox/src/index.ts
+++ b/plugins/vercel-sandbox/src/index.ts
@@ -206,6 +206,9 @@ interface SandboxInstance {
     exitCode: number;
   }>;
   stop(): Promise<void>;
+  // v2: `Sandbox.create()` returns `Sandbox & AsyncDisposable`, so the instance
+  // is disposable (the disposer calls stop()). Lets us use `await using`.
+  [Symbol.asyncDispose](): Promise<void>;
 }
 
 interface SandboxConstructor {
@@ -249,73 +252,80 @@ async function createVercelExploreBackend(
     );
   }
 
+  // v2: stop the sandbox if the setup below throws; on success we `disposer.move()`
+  // to disarm so the returned backend's close() owns it. Replaces the hand-rolled
+  // try/catch + stop(). The disposer swallows stop() errors so the original setup
+  // error is the one that surfaces.
+  await using disposer = new AsyncDisposableStack();
+  disposer.adopt(sandbox, async (s) => {
+    try {
+      await s.stop();
+    } catch {
+      // best-effort cleanup — the original setup error is what surfaces
+    }
+  });
+
+  // 3. Collect semantic layer files
+  let files: { path: string; content: Buffer }[];
   try {
-    // 3. Collect semantic layer files
-    let files: { path: string; content: Buffer }[];
+    files = collectSemanticFiles(semanticRoot, SANDBOX_SEMANTIC_REL, log);
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      `Cannot read semantic layer at ${semanticRoot}: ${detail}. ` +
+        "Ensure the semantic/ directory exists and is readable.",
+      { cause: err },
+    );
+  }
+
+  if (files.length === 0) {
+    throw new Error(
+      "No semantic layer files found. " +
+        "Run 'bun run atlas -- init' to generate a semantic layer, then redeploy.",
+    );
+  }
+
+  // 4. Create directories and upload files
+  const dirs = new Set<string>();
+  for (const f of files) {
+    let dir = path.posix.dirname(f.path);
+    while (dir !== "/" && dir !== ".") {
+      dirs.add(dir);
+      dir = path.posix.dirname(dir);
+    }
+  }
+
+  for (const dir of [...dirs].sort()) {
     try {
-      files = collectSemanticFiles(semanticRoot, SANDBOX_SEMANTIC_REL, log);
-    } catch (err) {
-      const detail = err instanceof Error ? err.message : String(err);
-      throw new Error(
-        `Cannot read semantic layer at ${semanticRoot}: ${detail}. ` +
-          "Ensure the semantic/ directory exists and is readable.",
-        { cause: err },
-      );
-    }
-
-    if (files.length === 0) {
-      throw new Error(
-        "No semantic layer files found. " +
-          "Run 'bun run atlas -- init' to generate a semantic layer, then redeploy.",
-      );
-    }
-
-    // 4. Create directories and upload files
-    const dirs = new Set<string>();
-    for (const f of files) {
-      let dir = path.posix.dirname(f.path);
-      while (dir !== "/" && dir !== ".") {
-        dirs.add(dir);
-        dir = path.posix.dirname(dir);
-      }
-    }
-
-    for (const dir of [...dirs].sort()) {
-      try {
-        await sandbox.mkDir(dir);
-      } catch (err) {
-        const detail = sandboxErrorDetail(err);
-        const safeDetail = SENSITIVE_PATTERNS.test(detail)
-          ? "sandbox API error (details in server logs)"
-          : detail;
-        throw new Error(
-          `Failed to create directory "${dir}" in sandbox: ${safeDetail}.`,
-          { cause: err },
-        );
-      }
-    }
-
-    try {
-      await sandbox.writeFiles(files);
+      await sandbox.mkDir(dir);
     } catch (err) {
       const detail = sandboxErrorDetail(err);
       const safeDetail = SENSITIVE_PATTERNS.test(detail)
         ? "sandbox API error (details in server logs)"
         : detail;
       throw new Error(
-        `Failed to upload ${files.length} semantic files to sandbox: ${safeDetail}.`,
+        `Failed to create directory "${dir}" in sandbox: ${safeDetail}.`,
         { cause: err },
       );
     }
-  } catch (err) {
-    // Clean up the sandbox before re-throwing
-    try {
-      await sandbox.stop();
-    } catch {
-      // Ignore cleanup errors
-    }
-    throw err;
   }
+
+  try {
+    await sandbox.writeFiles(files);
+  } catch (err) {
+    const detail = sandboxErrorDetail(err);
+    const safeDetail = SENSITIVE_PATTERNS.test(detail)
+      ? "sandbox API error (details in server logs)"
+      : detail;
+    throw new Error(
+      `Failed to upload ${files.length} semantic files to sandbox: ${safeDetail}.`,
+      { cause: err },
+    );
+  }
+
+  // Setup succeeded — disarm the disposer so the sandbox survives in the
+  // returned backend (close() owns its lifecycle from here).
+  disposer.move();
 
   return {
     exec: async (command: string): Promise<PluginExecResult> => {
@@ -391,7 +401,6 @@ export function buildVercelSandboxPlugin(
     async healthCheck(): Promise<PluginHealthResult> {
       const start = performance.now();
       const TIMEOUT = 30_000;
-      let sandbox: SandboxInstance | null = null;
       let timer: ReturnType<typeof setTimeout>;
       try {
         const result = await Promise.race([
@@ -409,15 +418,18 @@ export function buildVercelSandboxPlugin(
               createOpts.teamId = config.teamId;
             }
 
-            sandbox = await Sandbox.create(createOpts);
+            // v2: create-and-dispose-in-one-scope. `await using` stops the
+            // sandbox when this scope exits (success, command failure, or
+            // throw), replacing the manual stop() that every branch needed.
+            // If the outer race times out first, disposal still runs once this
+            // scope settles, so the sandbox is never leaked.
+            await using sandbox = await Sandbox.create(createOpts);
             const res = await sandbox.runCommand({
               cmd: "sh",
               args: ["-c", "echo vercel-ok"],
               cwd: "/tmp",
             });
             const stdout = await res.stdout();
-            await sandbox.stop();
-            sandbox = null;
 
             if (res.exitCode === 0 && stdout.includes("vercel-ok")) {
               return { healthy: true as const };
@@ -434,21 +446,10 @@ export function buildVercelSandboxPlugin(
 
         const latencyMs = Math.round(performance.now() - start);
         if (result === "timeout") {
-          // Best-effort cleanup — sandbox may still be creating if create() is what's slow.
-          // Cast needed: TS narrows sandbox to null (IIFE ends with sandbox=null) but the
-          // timeout race means the IIFE may not have finished yet.
-          const sb = sandbox as SandboxInstance | null;
-          if (sb) {
-            try { await sb.stop(); } catch { /* best-effort */ }
-          }
           return { healthy: false, message: `Health check timed out after ${TIMEOUT}ms`, latencyMs };
         }
         return { ...result, latencyMs };
       } catch (err) {
-        const sb = sandbox as SandboxInstance | null;
-        if (sb) {
-          try { await sb.stop(); } catch { /* best-effort */ }
-        }
         return {
           healthy: false,
           message: err instanceof Error ? err.message : String(err),

--- a/plugins/vercel-sandbox/src/index.ts
+++ b/plugins/vercel-sandbox/src/index.ts
@@ -206,9 +206,6 @@ interface SandboxInstance {
     exitCode: number;
   }>;
   stop(): Promise<void>;
-  // v2: `Sandbox.create()` returns `Sandbox & AsyncDisposable`, so the instance
-  // is disposable (the disposer calls stop()). Lets us use `await using`.
-  [Symbol.asyncDispose](): Promise<void>;
 }
 
 interface SandboxConstructor {
@@ -254,14 +251,18 @@ async function createVercelExploreBackend(
 
   // v2: stop the sandbox if the setup below throws; on success we `disposer.move()`
   // to disarm so the returned backend's close() owns it. Replaces the hand-rolled
-  // try/catch + stop(). The disposer swallows stop() errors so the original setup
-  // error is the one that surfaces.
+  // try/catch + stop(). A failed cleanup stop() is logged (not swallowed) — the
+  // original setup error still surfaces as the thrown error.
   await using disposer = new AsyncDisposableStack();
   disposer.adopt(sandbox, async (s) => {
     try {
       await s.stop();
-    } catch {
-      // best-effort cleanup — the original setup error is what surfaces
+    } catch (stopErr) {
+      log?.warn(
+        `[vercel-sandbox] Failed to stop sandbox during error cleanup: ${
+          stopErr instanceof Error ? stopErr.message : String(stopErr)
+        }`,
+      );
     }
   });
 
@@ -401,7 +402,25 @@ export function buildVercelSandboxPlugin(
     async healthCheck(): Promise<PluginHealthResult> {
       const start = performance.now();
       const TIMEOUT = 30_000;
+      // NOTE: `await using` is intentionally NOT used here. The Promise.race
+      // timeout can win while the inner IIFE is still mid-create/runCommand, and
+      // the v2 SDK exposes no AbortSignal on the object-form runCommand or on
+      // create — so a scope-bound disposer would only fire once the (possibly
+      // hung) operation settled, leaking the microVM past the timeout. We keep an
+      // explicit sandbox reference and stop() it in every branch instead.
+      let sandbox: SandboxInstance | null = null;
       let timer: ReturnType<typeof setTimeout>;
+      const stopQuietly = async (sb: SandboxInstance) => {
+        try {
+          await sb.stop();
+        } catch (stopErr) {
+          log?.warn(
+            `[vercel-sandbox] Failed to stop health-check sandbox: ${
+              stopErr instanceof Error ? stopErr.message : String(stopErr)
+            }`,
+          );
+        }
+      };
       try {
         const result = await Promise.race([
           (async () => {
@@ -418,18 +437,15 @@ export function buildVercelSandboxPlugin(
               createOpts.teamId = config.teamId;
             }
 
-            // v2: create-and-dispose-in-one-scope. `await using` stops the
-            // sandbox when this scope exits (success, command failure, or
-            // throw), replacing the manual stop() that every branch needed.
-            // If the outer race times out first, disposal still runs once this
-            // scope settles, so the sandbox is never leaked.
-            await using sandbox = await Sandbox.create(createOpts);
+            sandbox = await Sandbox.create(createOpts);
             const res = await sandbox.runCommand({
               cmd: "sh",
               args: ["-c", "echo vercel-ok"],
               cwd: "/tmp",
             });
             const stdout = await res.stdout();
+            await stopQuietly(sandbox);
+            sandbox = null;
 
             if (res.exitCode === 0 && stdout.includes("vercel-ok")) {
               return { healthy: true as const };
@@ -446,10 +462,17 @@ export function buildVercelSandboxPlugin(
 
         const latencyMs = Math.round(performance.now() - start);
         if (result === "timeout") {
+          // Best-effort cleanup — the IIFE may still be creating if create() is
+          // what's slow. Cast needed: TS narrows `sandbox` to null (the IIFE
+          // ends with sandbox = null) but the race means it may not have run.
+          const sb = sandbox as SandboxInstance | null;
+          if (sb) await stopQuietly(sb);
           return { healthy: false, message: `Health check timed out after ${TIMEOUT}ms`, latencyMs };
         }
         return { ...result, latencyMs };
       } catch (err) {
+        const sb = sandbox as SandboxInstance | null;
+        if (sb) await stopQuietly(sb);
         return {
           healthy: false,
           message: err instanceof Error ? err.message : String(err),


### PR DESCRIPTION
Implements #3126 — adopt `@vercel/sandbox` v2 ergonomics in the sandbox backends. Behavior-preserving cleanup on top of the v1→v2 bump (#3125).

## What changed

**1. `await using` / `AsyncDisposableStack`** (v2 `Sandbox.create()` now returns `Sandbox & AsyncDisposable`)
- `packages/api/src/lib/tools/explore-sandbox.ts` and the plugin's `createVercelExploreBackend` (`plugins/vercel-sandbox/src/index.ts`) are *long-lived* backends (the sandbox is returned in a closure), so they adopt the sandbox into an `AsyncDisposableStack` that stops it **only if setup throws**, then `disposer.move()` to disarm on success — the returned backend's `close()` owns it from there. This replaces the hand-rolled `try/catch → stop() → rethrow`, preserving the "swallow stop() errors, surface the original setup error" semantics.
- The plugin's `healthCheck` is a true create-and-dispose-in-one-scope path → plain `await using sandbox = await Sandbox.create(...)`, dropping the manual `stop()` in every branch (success, command-failure, timeout, throw).
- `python-sandbox.ts` intentionally **keeps** its manual lifecycle — it caches/reuses the VM across calls within a request, so `await using` doesn't apply.

**2. v2 `fs` API replaces the stdout result-marker** (`python-sandbox.ts`)
- The wrapper now writes its structured result JSON to `ATLAS_RESULT_FILE` and leaves chart PNGs as files in the chart dir, instead of smuggling everything back through a `__ATLAS_RESULT_<id>__` stdout marker.
- The host reads the result via `sandbox.readFileToBuffer(...)` and collects charts via `sandbox.fs.readdir(...)` + `readFileToBuffer(...)`, base64-encoding them host-side.
- **1 MB output guard preserved:** the structured-result buffer is bounded first, then result + charts combined — the same total cap the stdout marker enforced. The deny-all/allowlist lockdown and the infra-error → invalidate-and-retry semantics are untouched.
- The shared `PYTHON_SECURITY_AND_SETUP` fragment (the AST import-guard) stays shared; only the result-collection tail diverges (it's the FS-transport variant of `PYTHON_EXEC_AND_COLLECT`, which nsjail/sidecar still use verbatim).

**3. Ambient stub** (`packages/api/src/types/vercel-sandbox.d.ts`)
- Adds only the v2 members actually used: the `AsyncDisposable` create return, `readFileToBuffer`, and `fs.readdir`. `downloadFile` / the rest of `fs` are intentionally omitted.

## Out of scope (per the issue)
- Persistent sandboxes / snapshots / named `getOrCreate` (incompatible with per-request ephemeral deny-all isolation).
- `updateNetworkPolicy` → `update({ networkPolicy })` migration (security-critical lockdown path; warrants its own focused PR).

## Tests
- Updated the `@vercel/sandbox` mocks (python-sandbox, python-rest-egress, plugin suite) to the FS-based result transport + `[Symbol.asyncDispose]`.
- Added two focused python-sandbox tests: chart collection off the FS (`readdir` + `readFileToBuffer`), and the preserved result + charts 1 MB guard.

## Gates
`bun run lint` ✓ · `bun run type` ✓ · full `bun run test` ✓ (0 failures) · syncpack/template-drift/security-headers/railway-watch/schema-drift/oauth-helper/test-discipline/twenty-resolver/published-symbols ✓ · standalone Turbopack build ✓.

Closes #3126

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3135"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783098148&installation_id=135337507&pr_number=3135&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3135&signature=4236912fef064fe136b496eab5013ad202df298b9c6a6fd4449d4f2acdd17507"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sandbox lifecycle cleanup and timeout handling to prevent leaked resources and better surface stop errors.
  * Better handling of execution crashes and non-fatal exits when no structured result is produced.

* **Improvements**
  * Switched to a file-based result protocol (result file + chart artifact files) for sandboxed runs.
  * Collected chart artifacts and strengthened output-size validation for combined result+artifacts.
  * Updated sandbox-related type information.

* **Tests**
  * Updated sandbox tests to exercise the file-based result flow, artifact collection, and crash/oversize scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->