### PR TITLE
fix(dashboards): text-card review follow-ups — image block, types bump, shared full-width, bound-tool guards (#3138)

### DIFF
--- a/packages/api/src/lib/tools/__tests__/bound-dashboard.test.ts
+++ b/packages/api/src/lib/tools/__tests__/bound-dashboard.test.ts
@@ -501,6 +501,49 @@ describe("createBoundDashboardTools", () => {
       expect(invalidateScreenshotMock).toHaveBeenCalledWith("dash-1");
     });
 
+    // #3138 — a text / section-block card has no SQL or chart. The bound editor
+    // tools must reject those edits rather than mutate the draft into a state
+    // publish would silently discard (text-card equality ignores sql/chart).
+    const textCardRow = { ...cardRow, sql: "", content: "## Top of funnel" };
+
+    it("updateCardSql rejects a text / section card", async () => {
+      process.env.ATLAS_DASHBOARD_DRAFTS_ENABLED = "false";
+      enableInternalDB();
+      setResults({ rows: [textCardRow] }); // readCurrentCard → getCard → text
+      const tools = createBoundDashboardTools(ctxWithUser);
+      const result = await runTool<{ kind: string; error?: string }>(tools.updateCardSql, {
+        cardId: "card-1",
+        newSql: "SELECT 2",
+      });
+      expect(result.kind).toBe("err");
+      expect(result.error).toMatch(/text \/ section card/i);
+    });
+
+    it("updateCard rejects a chartConfig change on a text / section card", async () => {
+      process.env.ATLAS_DASHBOARD_DRAFTS_ENABLED = "false";
+      enableInternalDB();
+      setResults({ rows: [textCardRow] }); // readCurrentCard → getCard → text
+      const tools = createBoundDashboardTools(ctxWithUser);
+      const result = await runTool<{ kind: string; error?: string }>(tools.updateCard, {
+        cardId: "card-1",
+        chartConfig: { type: "bar", categoryColumn: "x", valueColumns: ["y"] },
+      });
+      expect(result.kind).toBe("err");
+      expect(result.error).toMatch(/no chart|text \/ section card/i);
+    });
+
+    it("updateCard still allows renaming a text card (title-only)", async () => {
+      process.env.ATLAS_DASHBOARD_DRAFTS_ENABLED = "false";
+      enableInternalDB();
+      setResults({ rows: [{ id: "card-1" }] }); // UPDATE … RETURNING (no kind check for title)
+      const tools = createBoundDashboardTools(ctxWithUser);
+      const result = await runTool<{ kind: string }>(tools.updateCard, {
+        cardId: "card-1",
+        title: "Conversion",
+      });
+      expect(result.kind).toBe("ok");
+    });
+
     it("emits a multimodal image-data part via toModelOutput", async () => {
       const tools = createBoundDashboardTools(ctxWithUser);
       // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/api/src/lib/tools/bound-dashboard.ts
+++ b/packages/api/src/lib/tools/bound-dashboard.ts
@@ -33,7 +33,7 @@ import {
   getDashboard,
   CardLayoutSchema,
 } from "@atlas/api/lib/dashboards";
-import type { DashboardCardLayout } from "@atlas/api/lib/dashboard-types";
+import type { DashboardCardKind, DashboardCardLayout } from "@atlas/api/lib/dashboard-types";
 import { buildCardSummary } from "@atlas/api/lib/bound-chat-context";
 import {
   screenshotDashboard,
@@ -308,6 +308,20 @@ export function createBoundDashboardTools(
           return { kind: "err" as const, error: "No fields supplied — pass at least one of title, chartConfig, layout, position." };
         }
 
+        // #3138: a text / section-block card has no chart. Reject a chartConfig
+        // change on one rather than mutate the draft into a state publish would
+        // silently discard (text-card equality ignores chartConfig). Title /
+        // layout / position edits remain valid for text cards.
+        if (updates.chartConfig !== undefined) {
+          const current = await readCurrentCard(cardId);
+          if (current.ok && current.kind === "text") {
+            return {
+              kind: "err" as const,
+              error: `Card ${cardId} is a text / section card — it has no chart to configure.`,
+            };
+          }
+        }
+
         const routed = await maybeApplyToDraft(ctx, {
           kind: "updateCard",
           cardId,
@@ -532,7 +546,7 @@ export function createBoundDashboardTools(
    * accept.
    */
   async function readCurrentCard(cardId: string): Promise<
-    | { ok: true; title: string; sql: string }
+    | { ok: true; title: string; sql: string; kind: DashboardCardKind }
     | { ok: false; error: string }
   > {
     if (isDashboardDraftsEnabled() && ctx.userId) {
@@ -543,7 +557,8 @@ export function createBoundDashboardTools(
       const draftRow = await forkOrLoadDraft(ctx.userId, dash.data);
       if (draftRow) {
         const sc = draftRow.snapshot.cards.find((c) => c.id === cardId);
-        if (sc) return { ok: true, title: sc.title, sql: sc.sql };
+        // #3138: snapshot cards have no stored `kind` — derive it from content.
+        if (sc) return { ok: true, title: sc.title, sql: sc.sql, kind: sc.content != null ? "text" : "chart" };
         return { ok: false, error: `Card ${cardId} not found on this dashboard.` };
       }
     }
@@ -551,7 +566,7 @@ export function createBoundDashboardTools(
     if (!card.ok) {
       return { ok: false, error: `Could not read card ${cardId}: ${card.reason}` };
     }
-    return { ok: true, title: card.data.title, sql: card.data.sql };
+    return { ok: true, title: card.data.title, sql: card.data.sql, kind: card.data.kind };
   }
 
   const removeCardTool = tool({
@@ -637,6 +652,16 @@ The tool validates the new SQL against the analytics datasource before staging; 
         const current = await readCurrentCard(cardId);
         if (!current.ok) {
           return { kind: "err" as const, error: current.error };
+        }
+        // #3138: a text / section-block card has no SQL. Reject rather than
+        // stage an edit_sql change that publish would silently discard (a text
+        // card's draft↔baseline equality ignores sql). To change a header, edit
+        // its markdown / remove + re-add.
+        if (current.kind === "text") {
+          return {
+            kind: "err" as const,
+            error: `Card ${cardId} is a text / section card — it has no SQL to edit.`,
+          };
         }
         const result = await stageChange({
           dashboardId,

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useatlas/types",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "Shared types for the Atlas text-to-SQL agent",
   "type": "module",
   "scripts": {

--- a/packages/web/src/app/shared/dashboard/[token]/__tests__/tile.test.tsx
+++ b/packages/web/src/app/shared/dashboard/[token]/__tests__/tile.test.tsx
@@ -40,4 +40,23 @@ describe("SharedTile — text cards (#3138)", () => {
     expect(container.textContent).not.toContain("No data available");
     expect(screen.queryByTestId("result-chart")).toBeNull();
   });
+
+  test("spans full-width regardless of the inherited (half-width) spanClass", () => {
+    // The shared view passes a half-width span for a layout-less tile; a text
+    // band must override it so it reads as a banner over the charts below.
+    const { container } = render(
+      <SharedTile card={textCard} spanClass="md:col-span-1" cachedLabel={null} cachedIso={undefined} />,
+    );
+    const tile = container.querySelector('[data-card-kind="text"]');
+    expect(tile?.className).toContain("md:col-span-2");
+    expect(tile?.className).not.toContain("md:col-span-1");
+  });
+
+  test("strips markdown images on the public surface (no tracking-pixel fetch)", () => {
+    const card = { ...textCard, content: "## Header\n\n![x](https://attacker.example/track.png)" };
+    const { container } = render(
+      <SharedTile card={card} spanClass="col-span-2" cachedLabel={null} cachedIso={undefined} />,
+    );
+    expect(container.querySelector("img")).toBeNull();
+  });
 });

--- a/packages/web/src/app/shared/dashboard/[token]/tile.tsx
+++ b/packages/web/src/app/shared/dashboard/[token]/tile.tsx
@@ -40,13 +40,19 @@ export function SharedTile({ card, spanClass, cachedLabel, cachedIso }: SharedTi
   // #3138 — a text / section-block card renders sanitized markdown (no data, no
   // chart, no cached-at footer) so a shared-link viewer sees the same headers
   // the owner authored — not the empty-data placeholder.
+  //   - Full-width (`md:col-span-2`) regardless of the inherited `spanClass`:
+  //     the shared view doesn't run `withAutoLayout`, so a text card with
+  //     `layout: null` would otherwise inherit the default half-width span and
+  //     stop reading as a banner over the charts beneath it.
+  //   - `disallowImages`: this is an unauthenticated surface, so block markdown
+  //     image fetches (tracking-pixel / IP-leak vector — see Markdown docs).
   if (card.kind === "text") {
     return (
       <Card
-        className={`${spanClass} overflow-hidden px-4 py-3 text-sm leading-relaxed print:col-span-2 print:break-inside-avoid print:border-zinc-300 print:shadow-none`}
+        className="md:col-span-2 overflow-hidden px-4 py-3 text-sm leading-relaxed print:col-span-2 print:break-inside-avoid print:border-zinc-300 print:shadow-none"
         data-card-kind="text"
       >
-        <Markdown content={card.content ?? ""} />
+        <Markdown content={card.content ?? ""} disallowImages />
       </Card>
     );
   }

--- a/packages/web/src/ui/__tests__/markdown.test.tsx
+++ b/packages/web/src/ui/__tests__/markdown.test.tsx
@@ -103,4 +103,20 @@ describe("Markdown", () => {
     // The tags survive as visible text, proving they were escaped, not executed.
     expect(container.textContent).toContain("<script>");
   });
+
+  // Markdown image syntax `![]()` still renders an <img> even with raw HTML off,
+  // which fires a network request — a tracking/IP-leak vector on public surfaces.
+  test("renders a markdown image by default", () => {
+    const { container } = render(<Markdown content={"![pixel](https://example.com/p.png)"} />);
+    expect(container.querySelector("img")).not.toBeNull();
+  });
+
+  test("disallowImages strips markdown images (no network fetch)", () => {
+    const { container } = render(
+      <Markdown content={"![pixel](https://attacker.example/track.png)\n\nVisible text"} disallowImages />,
+    );
+    expect(container.querySelector("img")).toBeNull();
+    // Surrounding content still renders.
+    expect(container.textContent).toContain("Visible text");
+  });
 });

--- a/packages/web/src/ui/components/chat/markdown.tsx
+++ b/packages/web/src/ui/components/chat/markdown.tsx
@@ -109,11 +109,26 @@ const mdComponents = {
   pre: ({ children }: { children?: ReactNode }) => <>{children}</>,
 };
 
-export const Markdown = memo(function Markdown({ content }: { content: string }) {
+export const Markdown = memo(function Markdown({
+  content,
+  disallowImages = false,
+}: {
+  content: string;
+  /**
+   * Strip markdown images (`![alt](url)`). react-markdown renders these as
+   * `<img>` even with raw HTML disabled, so an `![x](https://attacker/track)`
+   * fires a network request from every viewer's browser. Set this on
+   * untrusted / publicly-shared surfaces (e.g. shared-dashboard text cards,
+   * #3138) to close the IP/referrer-tracking vector.
+   */
+  disallowImages?: boolean;
+}) {
   const dark = useDarkMode();
   return (
     <ReactMarkdown
       remarkPlugins={[remarkGfm]}
+      disallowedElements={disallowImages ? ["img"] : undefined}
+      unwrapDisallowed={disallowImages}
       components={{
         ...mdComponents,
         code({ className, children, ...props }) {

--- a/packages/web/src/ui/components/dashboards/dashboard-tile.tsx
+++ b/packages/web/src/ui/components/dashboards/dashboard-tile.tsx
@@ -393,7 +393,9 @@ function TextTile({ card, editing, onDelete }: DashboardTileProps) {
       )}
 
       <div className="dash-text-tile-body min-h-0 flex-1 overflow-auto px-4 py-3 text-sm leading-relaxed">
-        <Markdown content={card.content ?? ""} />
+        {/* disallowImages: a section header has no need for images, and blocking
+            them closes the same tracking-pixel vector as the shared view. */}
+        <Markdown content={card.content ?? ""} disallowImages />
       </div>
     </div>
   );


### PR DESCRIPTION
Follow-up to #3139 (text / section-block cards), which merged before Codex's re-review of the final commit landed. Codex flagged 4 real issues against `3458505f`; this PR fixes all of them. No new feature surface — hardening + a required version bump.

## Fixes

- **🔴 P1 — Block remote images in text-card markdown.** react-markdown renders `![alt](url)` as an `<img>` even with raw HTML disabled, so a tracking pixel in a text card fires a network request from **every viewer's browser** — an IP/referrer leak, worst on **public shared-dashboard links**. `<Markdown>` gains a `disallowImages` prop (strips `img` via `disallowedElements`); applied to both the shared tile and the authenticated text tile. Sanitization (no `rehype-raw`) was already in place; this closes the markdown-image vector specifically.
- **🔴 P1 — Bump `@useatlas/types` 0.1.12 → 0.1.13.** #3139 added the `DashboardCardKind` export and required `DashboardCard.kind`/`content` fields. Per the publishing playbook, a scaffold installs the published types while copying the new API/web source — without the bump it resolves the old contract and fails to build. Dependent refs stay at `^0.1.0` (caret resolves to 0.1.13 after publish; no ref bump needed for 0.1.x).
- **🟡 P2 — Shared text cards render full-width.** The shared view doesn't run `withAutoLayout`, so a layout-less text card inherited the default half-width span. Forced `md:col-span-2` so a section header reads as a banner over the charts beneath it.
- **🟡 P2 — Bound editor rejects SQL/chart edits on text cards.** `updateCardSql` and `updateCard(chartConfig)` now refuse a text-card target. Otherwise those tools (which didn't check kind) would mutate the draft into a state `publishDraftMerge`'s text-card equality (content-only) silently discards on publish. Title/layout/position edits still work on text cards.

## Tests

- `Markdown`: image rendered by default; `disallowImages` strips it (+ surrounding content survives).
- Shared tile: full-width override; image stripped on the public surface.
- Bound editor: `updateCardSql` + `updateCard(chartConfig)` rejected on a text card; title-only rename still allowed.

`type`, `lint`, `syncpack`, `published-symbols`, `template-drift`, and the affected suites all green locally.

### Note on the merge
#3139 was squash-merged at `3458505f` while I was still addressing Codex's re-review (a merge command raced past an interrupt). These four fixes are the only delta between that SHA and the intended final state.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3147"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783113294&installation_id=135337507&pr_number=3147&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3147&signature=aee01fbee8124cf039d900a9ff527848dbf90fcfcf29b5d9aaaab9655a5cbc0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Text cards in shared dashboards now always render at full width
  * Markdown images are disabled in shared dashboard text content for improved security and performance
  * Text and section cards are now protected from unintended SQL and chart configuration edits

* **Tests**
  * Added coverage for card edit restrictions and markdown image handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->