### PR TITLE
chore(deps): syncpack 14 → 15 (#3132)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -74,7 +74,7 @@
         "jose": "^6.2.3",
         "pg": "^8.21.0",
         "react": "^19.2.6",
-        "syncpack": "^14.2.1",
+        "syncpack": "^15.3.1",
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.60.0",
         "zod": "^4.4.3",
@@ -3949,23 +3949,23 @@
 
     "swr": ["swr@2.4.1", "", { "dependencies": { "dequal": "^2.0.3", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-2CC6CiKQtEwaEeNiqWTAw9PGykW8SR5zZX8MZk6TeAvEAnVS7Visz8WzphqgtQ8v2xz/4Q5K+j+SeMaKXeeQIA=="],
 
-    "syncpack": ["syncpack@14.2.1", "", { "optionalDependencies": { "syncpack-darwin-arm64": "14.2.1", "syncpack-darwin-x64": "14.2.1", "syncpack-linux-arm64": "14.2.1", "syncpack-linux-arm64-musl": "14.2.1", "syncpack-linux-x64": "14.2.1", "syncpack-linux-x64-musl": "14.2.1", "syncpack-windows-arm64": "14.2.1", "syncpack-windows-x64": "14.2.1" }, "bin": { "syncpack": "index.cjs" } }, "sha512-9CE0+MCThNPt0/yXD5cFaJQw2jxslaB3Ck1ASeP9uFji+lE3KWmfGRBzy8x5sjhygUz6Vt+a84w+ycIzATQicA=="],
+    "syncpack": ["syncpack@15.3.1", "", { "optionalDependencies": { "syncpack-darwin-arm64": "15.3.1", "syncpack-darwin-x64": "15.3.1", "syncpack-linux-arm64": "15.3.1", "syncpack-linux-arm64-musl": "15.3.1", "syncpack-linux-x64": "15.3.1", "syncpack-linux-x64-musl": "15.3.1", "syncpack-windows-arm64": "15.3.1", "syncpack-windows-x64": "15.3.1" }, "bin": { "syncpack": "index.cjs" } }, "sha512-0Z+/rwbskj+m5qW8caVbd59OwwXBcxRiDFk82Cb4tKGLPXmZn7Vjo7BnfxHwZqS51Ff+5TFgH5/iyXd24+G6YA=="],
 
-    "syncpack-darwin-arm64": ["syncpack-darwin-arm64@14.2.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-SGrC163UWiL68TRo8rmPQFgbT83ieT7zQ1GKyoPZ3TAGNQ+6a/3GMXlZQ+HKV3ydVyB2t60H5CsQFlz13QHTqA=="],
+    "syncpack-darwin-arm64": ["syncpack-darwin-arm64@15.3.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-XvbaowC/fw+B7diOtoYjEtSWJVMEbJ7ZH72/TZIe73NwYwY7KFRMVefwxcJE29G+my4vaPmttf2Lbnri8pD6Jw=="],
 
-    "syncpack-darwin-x64": ["syncpack-darwin-x64@14.2.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-ZqAJb4FEez3zpuOHUKZNSBWiYGH4FqmN5pI/AzM2N81oSGTYLaI+H4Wmi6rtZdQXRX2ZzQRs4lQrLTdmVv7oQg=="],
+    "syncpack-darwin-x64": ["syncpack-darwin-x64@15.3.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-KX5+fcHzaGugppyPV3se8iKoFYE5Jde3ZxN80dJKNejluP29rGmOQ1JNaVjy40nZInPNLKQ8LS0TMRtxIgh8ew=="],
 
-    "syncpack-linux-arm64": ["syncpack-linux-arm64@14.2.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-yjyG1v1lYBmWaD+aGXt4eovZ3k+d/nwHU8AZkFJh2jxBy6He2qTclR7+eI/BFcmiAehncbGNksYhL2h2RlC0Rg=="],
+    "syncpack-linux-arm64": ["syncpack-linux-arm64@15.3.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-5saJ4LnizTppqVLt49MKagTixDpuR+5MFweGCkoEAm4SikLqNfzkiEnHqVsjY3+BkCVtXf6DcR1OX6hwswNJ0A=="],
 
-    "syncpack-linux-arm64-musl": ["syncpack-linux-arm64-musl@14.2.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-vfopyN7ne++jnV4uAsoH8NHbio/6+yfdc9VfXt+9ZQiuR1AxtjT2Hylv6re5e6c1j0MPWaCRtaZBZhDUi0ZPdA=="],
+    "syncpack-linux-arm64-musl": ["syncpack-linux-arm64-musl@15.3.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-YslfJ1UndTwL000p0JTP/r8uwXJ4LfYeFBqAfRhLuWoJz8CO+yWyUl4VNdFNitSR1OOB/J7gc4q3jOsxh7kTOg=="],
 
-    "syncpack-linux-x64": ["syncpack-linux-x64@14.2.1", "", { "os": "linux", "cpu": "x64" }, "sha512-rfDzLxiJng7XIVShO7ygrAvrGdCloaKhMm2c4Q8blxVTHgSNcmL4cHRP/Zcvj7pmYGkwok6DtAetgxV47XpoGA=="],
+    "syncpack-linux-x64": ["syncpack-linux-x64@15.3.1", "", { "os": "linux", "cpu": "x64" }, "sha512-bk8keNTteQxXpKDc+Y3r3fE7IZn4cU61gq7ka4gPcBNvvMHOk8Pg71/qQEwN3zBtzAj6yF1Fyzb0NYK9Wo6EPQ=="],
 
-    "syncpack-linux-x64-musl": ["syncpack-linux-x64-musl@14.2.1", "", { "os": "linux", "cpu": "x64" }, "sha512-2/LMs6nFWPV2P0XOmMo63Erzv8OQ9skszXdalrhU2ilBO7f6B4sup6NsMKIXJeYHNso94TcLdAxyiGQ4sCdmTw=="],
+    "syncpack-linux-x64-musl": ["syncpack-linux-x64-musl@15.3.1", "", { "os": "linux", "cpu": "x64" }, "sha512-/mnWa3FmzJRsDLuqx6rzQIawV5ly1MFyUPxcZlaLX3FbxBryrVXJZZXGd0yJ9UTEKgE5UfRRQlS+ayeXvJbNew=="],
 
-    "syncpack-windows-arm64": ["syncpack-windows-arm64@14.2.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-T+qP9ERY8dg6HWAgFtxNKxp67EJ7CIstHeQ8jQAiSmKGNt+HEzzVCipSGMb9yu9SGjVQHuvn2wAf33LppYfivA=="],
+    "syncpack-windows-arm64": ["syncpack-windows-arm64@15.3.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-GIKQtpNl1Ox2gwBDlEXgL1rneMwUMG0E3eB+EjDKdh4kOJtO0DYduTgg10dmFk/i1ynKGvFtgvhN3VZAr75jgA=="],
 
-    "syncpack-windows-x64": ["syncpack-windows-x64@14.2.1", "", { "os": "win32", "cpu": "x64" }, "sha512-yoK6eHbzTgKuaL4dU/AFNaIHqRletqR8w5aBGBzdAY39n2MrNbfGVBUeDglRBYnSoE+PgLtqwbHULIlhPratPw=="],
+    "syncpack-windows-x64": ["syncpack-windows-x64@15.3.1", "", { "os": "win32", "cpu": "x64" }, "sha512-4Kl7gCFzaEF7IoHa3vcEHRPx1um8pnzEqidRyQProIJBROG4srgkyQkmwJUXbWzWJhAq2Ic0vtDUvzIXF2U/Dg=="],
 
     "tagged-tag": ["tagged-tag@1.0.0", "", {}, "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng=="],
 

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "jose": "^6.2.3",
     "pg": "^8.21.0",
     "react": "^19.2.6",
-    "syncpack": "^14.2.1",
+    "syncpack": "^15.3.1",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.60.0",
     "zod": "^4.4.3"


### PR DESCRIPTION
Lands the first of the two deferred Group B dependency majors from the v0.0.7 dep-refresh (#3132). One PR per major so each is independently revertible.

## What

- Root devDep `syncpack` `^14.2.1` → `^15.3.1` (15.3.1 is the latest gate-eligible version — published 2026-05-19, well past the 48h `minimumReleaseAge` quarantine).
- `bun.lock` reconciled. The lockfile churn is entirely syncpack's own subtree — v15 ships as a Rust binary with platform-specific optional deps (`syncpack-linux-x64`, `syncpack-darwin-arm64`, …), not the previous pure-JS package. No app/runtime deps moved.

## Migration: none needed

The only documented v15 breaking change is that the `pnpmOverrides` dependency type now reads from `pnpm-workspace.yaml` instead of `pnpm.overrides` in `package.json`. This repo is bun-based with **no** `pnpm.overrides` anywhere (the root `overrides.kysely` pin is standard bun/npm `overrides`, untouched by this change).

`.syncpackrc.json` is fully v15-compatible — every key it uses (`versionGroups`, `dependencyTypes`, `pinVersion`, `isIgnored`, `packages`, `dependencies`, `source`) is unchanged in v15. `bun x syncpack lint` returns `✓ No issues found` and `syncpack fix` is a no-op.

## Gates

All local `/ci` gates green: lint, type, full `bun run test`, syncpack lint, template-drift, railway-watch, schema-drift, oauth-helper-drift, test-discipline, twenty-resolver, published-symbols, security-headers, and `bun install --frozen-lockfile` (no changes).

Standalone Turbopack build intentionally skipped — syncpack is a dev-only CLI, not in any runtime bundle graph.

Refs #3132, #3127

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3150"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783126932&installation_id=135337507&pr_number=3150&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3150&signature=5b3c9a0b86f8a0950b991b0554596665e33ce646cf78cbaeed3ce52a726f229d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development dependencies to enhance tooling capabilities and ensure compatibility with latest versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->