### PR TITLE
feat(integrations): cap-gate Telegram static-bot install + flip available (#3141)

### DIFF
--- a/apps/docs/content/docs/integrations/telegram.mdx
+++ b/apps/docs/content/docs/integrations/telegram.mdx
@@ -17,17 +17,6 @@ dance and gets its own bot token. Telegram's model is operator-shared
 because Telegram bots don't have a per-workspace install concept —
 adding the bot to a chat is the install.
 
-<Callout type="warn" title="Per-workspace install not available yet">
-The per-workspace install flow described below is **not currently available**
-in the Atlas admin UI. Its legacy connect route was removed in
-[#2994](https://github.com/AtlasDevHQ/atlas/issues/2994) because it bypassed the
-chat-integration cap and produced a non-routable install. The cap-gated
-static-bot install (routing-identifier capture, like Discord) is tracked in
-[#3141](https://github.com/AtlasDevHQ/atlas/issues/3141); until it ships the
-Telegram card shows **"Coming soon."** The operator setup below remains valid
-groundwork.
-</Callout>
-
 ## Operator setup (one-time, per deploy)
 
 These steps wire your deploy to a Telegram bot. Self-hosted operators

--- a/apps/docs/content/docs/integrations/telegram.mdx
+++ b/apps/docs/content/docs/integrations/telegram.mdx
@@ -121,15 +121,23 @@ Before Atlas can listen on a chat, the bot has to be a member of it.
 
 Telegram chat ids are signed integers — positive for users, negative
 for groups, and start with `-100` for supergroups and channels. They
-aren't visible in the Telegram UI directly. The easiest ways to look
-one up:
+aren't visible in the Telegram UI directly. All of these lookups are
+**token-free** — they don't require the operator's `TELEGRAM_BOT_TOKEN`
+(which Atlas Cloud workspace admins don't have):
 
-- **DM with the bot:** message the bot once, then visit
-  `https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/getUpdates` —
-  your user id is under `result[].message.from.id`.
+- **DM with the bot:** message [@userinfobot](https://t.me/userinfobot)
+  — it replies with your numeric **user id**, which is the chat id of
+  your 1:1 chat with the Atlas bot (for private chats, the chat id and
+  your user id are the same).
 - **Group / channel:** add [@userinfobot](https://t.me/userinfobot)
   to the chat, send any message, and it replies with the chat id.
   Remove the bot afterwards.
+
+Self-hosted operators who hold the bot token can alternatively read ids
+from `https://api.telegram.org/bot<TELEGRAM_BOT_TOKEN>/getUpdates` after
+a message lands — the chat id is under `result[].message.chat.id`. This
+path is operator-only; the bot token is an operator-wide secret (see the
+warning in [operator step 1](#1-create-a-bot-with-botfather)).
 
 <Callout type="warn" title="Don't use @username">
   Public Telegram aliases like `@my_channel` aren't accepted as a

--- a/deploy/api-staging/atlas.config.ts
+++ b/deploy/api-staging/atlas.config.ts
@@ -286,12 +286,13 @@ export default defineConfig({
       install_model: "static-bot",
       enabled: true,
       saas_eligible: true,
-      // #2748 shipped the handler, but no live route ever called it — the
-      // only install path was the legacy connect route, which bypassed the
-      // chat-integration cap and produced a non-functional (non-routable)
-      // install. #2994 removed that route, so this is back to coming_soon
-      // until the cap-gated static-bot install ships (#3141).
-      implementation_status: "coming_soon",
+      // #3141 (keystone of umbrella #2994) shipped the cap-gated static-bot
+      // install: the generic `/install-form` route captures the chat_id and
+      // `TelegramStaticBotInstallHandler.confirmInstall` persists through
+      // `checkChatIntegrationLimitAndInstall` (over-cap → 429, reconnect
+      // grandfathered). The legacy connect route that #2994 removed (uncapped,
+      // non-routable) is gone for good.
+      implementation_status: "available",
       name: "Telegram",
       description:
         "Chat with Atlas inside a Telegram group, channel, or 1:1 conversation. The operator wires a shared bot (TELEGRAM_BOT_TOKEN); each workspace points the bot at one chat by id.",

--- a/deploy/api/atlas.config.ts
+++ b/deploy/api/atlas.config.ts
@@ -255,12 +255,13 @@ export default defineConfig({
       install_model: "static-bot",
       enabled: true,
       saas_eligible: true,
-      // #2748 shipped the handler, but no live route ever called it — the
-      // only install path was the legacy connect route, which bypassed the
-      // chat-integration cap and produced a non-functional (non-routable)
-      // install. #2994 removed that route, so this is back to coming_soon
-      // until the cap-gated static-bot install ships (#3141).
-      implementation_status: "coming_soon",
+      // #3141 (keystone of umbrella #2994) shipped the cap-gated static-bot
+      // install: the generic `/install-form` route captures the chat_id and
+      // `TelegramStaticBotInstallHandler.confirmInstall` persists through
+      // `checkChatIntegrationLimitAndInstall` (over-cap → 429, reconnect
+      // grandfathered). The legacy connect route that #2994 removed (uncapped,
+      // non-routable) is gone for good.
+      implementation_status: "available",
       name: "Telegram",
       description:
         "Chat with Atlas inside a Telegram group, channel, or 1:1 conversation. The operator wires a shared bot (TELEGRAM_BOT_TOKEN); each workspace points the bot at one chat by id.",

--- a/packages/api/src/lib/integrations/install/__tests__/telegram-static-bot-handler.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/telegram-static-bot-handler.test.ts
@@ -42,8 +42,14 @@ import type { WorkspaceId } from "@useatlas/types";
 // Module mocks — hoist above the handler import
 // ---------------------------------------------------------------------------
 
+// The handler's cross-workspace ownership guard (#3141) reads
+// `workspace_plugins` via `internalQuery` before the cap gate. Default returns
+// [] (no conflict); the guard test overrides it to a matching row.
+const mockInternalQuery: Mock<(sql: string, params?: unknown[]) => Promise<unknown[]>> = mock(
+  () => Promise.resolve([]),
+);
 mock.module("@atlas/api/lib/db/internal", () => ({
-  internalQuery: mock(() => Promise.resolve([])),
+  internalQuery: mockInternalQuery,
   hasInternalDB: mock(() => true),
   getInternalDB: mock(() => ({ query: mock(() => Promise.resolve({ rows: [] })) })),
 }));
@@ -126,6 +132,8 @@ beforeEach(() => {
   mockCheckChatLimitAndInstall.mockImplementation(() =>
     Promise.resolve({ allowed: true as const, rows: [{ id: "install-tg-row-1" }] }),
   );
+  mockInternalQuery.mockClear();
+  mockInternalQuery.mockImplementation(() => Promise.resolve([]));
   fetchCalls.length = 0;
   setFetchOk();
 });
@@ -243,6 +251,40 @@ describe("TelegramStaticBotInstallHandler.confirmInstall — reachability verifi
     const handler = new TelegramStaticBotInstallHandler({ botToken: "987:xyz" });
     await expect(handler.confirmInstall(wsid, "12345")).rejects.toThrow(/telegram/i);
     expect(mockCheckChatLimitAndInstall).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cross-workspace ownership guard (#3141 / Codex #3153)
+// ---------------------------------------------------------------------------
+
+describe("TelegramStaticBotInstallHandler.confirmInstall — cross-workspace guard", () => {
+  it("rejects a chat_id already bound to a different workspace, and never reaches the cap gate", async () => {
+    // getChat proves the bot is in the chat, not that THIS workspace owns it.
+    // The guard SELECT finds an existing bind in another workspace and refuses
+    // before the cap gate runs — so a chat member can't claim the chat.
+    mockInternalQuery.mockImplementation(() =>
+      Promise.resolve([{ workspace_id: "org-victim" }]),
+    );
+    const handler = new TelegramStaticBotInstallHandler({ botToken: "123:abc" });
+    await expect(handler.confirmInstall(wsid, "-100999")).rejects.toThrow(
+      /already connected to a different Atlas workspace/i,
+    );
+    expect(mockCheckChatLimitAndInstall).not.toHaveBeenCalled();
+    // The guard scopes its lookup to (catalog:telegram, enabled, the chat_id,
+    // workspace_id <> self) so a reconnect by the same workspace is never caught.
+    const [sql, params] = mockInternalQuery.mock.calls[0];
+    expect(String(sql)).toMatch(/config->>'chat_id'/);
+    expect(String(sql)).toMatch(/workspace_id\s*<>\s*\$3/);
+    expect(params).toEqual([TELEGRAM_CATALOG_ID, "-100999", wsid]);
+  });
+
+  it("allows the install when the chat_id is bound only to the installing workspace (reconnect) — guard returns no conflict", async () => {
+    mockInternalQuery.mockImplementation(() => Promise.resolve([]));
+    const handler = new TelegramStaticBotInstallHandler({ botToken: "123:abc" });
+    const result = await handler.confirmInstall(wsid, "-100999");
+    expect(result.installRecord.catalogId).toBe(TELEGRAM_SLUG);
+    expect(mockCheckChatLimitAndInstall).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/packages/api/src/lib/integrations/install/__tests__/telegram-static-bot-handler.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/telegram-static-bot-handler.test.ts
@@ -1,29 +1,38 @@
 /**
  * Tests for {@link TelegramStaticBotInstallHandler} — slice 10 of 1.5.3
- * (issue #2748). Telegram is the keystone static-bot install — the
- * interface this handler exercises is the one Discord (#2749), gchat
- * (#2754), and WhatsApp (#2753) will ride.
+ * (issue #2748), migrated onto the atomic cap gate in #3141 (the keystone
+ * for completing the static-bot family under umbrella #2994).
+ *
+ * Telegram is the keystone static-bot install — the interface this handler
+ * exercises is the one Discord (#2749), gchat (#2754), and WhatsApp (#2753)
+ * ride. #3141 brings Telegram's `confirmInstall` onto the same
+ * `checkChatIntegrationLimitAndInstall` path Discord and Slack already use,
+ * so an over-cap install is refused with a 429 and a reconnect is
+ * grandfathered.
  *
  * The contract pinned here:
  *
  *   - `kind: "static-bot"` so the dispatch can narrow.
  *   - `confirmInstall(workspaceId, chatId)` validates the routing
  *     identifier shape, verifies reachability against the Telegram Bot
- *     API (`getChat`), persists the install row via UPSERT, and returns
- *     an `InstallRecord`.
+ *     API (`getChat`), runs the chat-integration cap gate which owns the
+ *     `workspace_plugins` UPSERT, and returns an `InstallRecord`.
  *   - Reachability failure (chat_id wrong / bot not a member) throws an
- *     actionable error — no half-installed rows survive.
- *   - Re-install for the same (workspace, catalog) is a no-op UPSERT
- *     that updates `config` and keeps the stable install id.
+ *     actionable error BEFORE the gate runs — no half-installed rows
+ *     survive, and the cap is never consumed for a failed reachability.
+ *   - At-cap installs throw `ChatIntegrationLimitError` (→ 429); a count
+ *     check that fails closed throws `BillingCheckFailedError` (→ 503).
+ *   - Re-install for the same (workspace, catalog) is a no-op UPSERT that
+ *     the gate grandfathers (never blocked) and keeps the stable id.
  *   - When the operator hasn't wired `TELEGRAM_BOT_TOKEN`, the handler
  *     refuses to construct itself with the actionable env-var name in
- *     the error. The boot-time register helper skips registration in
- *     that case; this guard is the defensive backstop for tests / direct
- *     callers that construct the handler themselves.
+ *     the error.
  *
- * `mock.module()` stubs the two module dependencies the handler reaches
- * into: `lib/db/internal` (`internalQuery`) and the global `fetch` used
- * for the Bot API call. Each mock exports every named export it shadows.
+ * `mock.module()` stubs the module dependencies the handler reaches into:
+ * `lib/billing/enforcement` (`checkChatIntegrationLimitAndInstall` — the
+ * atomic cap-gate that owns the `workspace_plugins` UPSERT post-#3001) and
+ * the global `fetch` used for the Bot API call. Each mock exports every
+ * named export it shadows (CLAUDE.md "mock all exports" rule).
  */
 
 import { afterEach, beforeEach, describe, expect, it, mock, type Mock } from "bun:test";
@@ -33,14 +42,45 @@ import type { WorkspaceId } from "@useatlas/types";
 // Module mocks — hoist above the handler import
 // ---------------------------------------------------------------------------
 
-const mockInternalQuery: Mock<(sql: string, params?: unknown[]) => Promise<unknown[]>> = mock(() =>
-  Promise.resolve([{ id: "install-tg-row-1" }]),
-);
-
 mock.module("@atlas/api/lib/db/internal", () => ({
-  internalQuery: mockInternalQuery,
+  internalQuery: mock(() => Promise.resolve([])),
   hasInternalDB: mock(() => true),
   getInternalDB: mock(() => ({ query: mock(() => Promise.resolve({ rows: [] })) })),
+}));
+
+// The chat-integration cap + the workspace_plugins UPSERT run atomically
+// through `checkChatIntegrationLimitAndInstall` (#3001) — the gate owns the
+// write and returns the RETURNING rows. We stub it to "allowed" with a
+// scripted row id so these handler tests stay focused on the install contract
+// (chat_id validation, reachability, config payload) and assert the UPSERT
+// shape via the gate's `insert` arg. The cap-enforcement decision + transaction
+// sequencing live in `billing/__tests__/enforcement.test.ts`. The cap /
+// fail-closed / RETURNING-empty / DB-error tests override it per case.
+type GateResult =
+  | { allowed: true; rows: Array<Record<string, unknown>> }
+  | { allowed: false; reason: "cap_reached"; errorMessage: string; limit: number }
+  | { allowed: false; reason: "check_failed"; errorMessage: string };
+const mockCheckChatLimitAndInstall: Mock<
+  (
+    orgId: string | undefined,
+    catalogId: string,
+    insert: { sql: string; params: readonly unknown[] },
+  ) => Promise<GateResult>
+> = mock(() => Promise.resolve({ allowed: true as const, rows: [{ id: "install-tg-row-1" }] }));
+
+// Mock every value export — a partial `mock.module()` causes a `SyntaxError`
+// in other files importing the missing exports (per CLAUDE.md "Mock all
+// exports"). Only `checkChatIntegrationLimitAndInstall` is exercised here; the
+// rest are inert no-ops.
+mock.module("@atlas/api/lib/billing/enforcement", () => ({
+  checkChatIntegrationLimitAndInstall: mockCheckChatLimitAndInstall,
+  CHAT_INTEGRATION_COUNT_SQL: "SELECT 1",
+  checkResourceLimit: () => Promise.resolve({ allowed: true }),
+  checkPlanLimits: () => Promise.resolve({ allowed: true }),
+  getCachedWorkspace: () => Promise.resolve(null),
+  invalidatePlanCache: () => {},
+  buildMetricStatus: () => ({ metric: "tokens", currentUsage: 0, limit: 0, usagePercent: 0, status: "ok" }),
+  severityOf: () => 0,
 }));
 
 // ---------------------------------------------------------------------------
@@ -82,8 +122,10 @@ function setFetchNetworkError(): void {
 }
 
 beforeEach(() => {
-  mockInternalQuery.mockClear();
-  mockInternalQuery.mockImplementation(() => Promise.resolve([{ id: "install-tg-row-1" }]));
+  mockCheckChatLimitAndInstall.mockClear();
+  mockCheckChatLimitAndInstall.mockImplementation(() =>
+    Promise.resolve({ allowed: true as const, rows: [{ id: "install-tg-row-1" }] }),
+  );
   fetchCalls.length = 0;
   setFetchOk();
 });
@@ -101,6 +143,7 @@ import {
   TELEGRAM_CATALOG_ID,
   TELEGRAM_SLUG,
 } from "../telegram-static-bot-handler";
+import type { StaticBotInstallHandler } from "../types";
 
 // ---------------------------------------------------------------------------
 // Constructor + kind
@@ -110,6 +153,17 @@ describe("TelegramStaticBotInstallHandler — shape", () => {
   it("identifies itself with kind: 'static-bot' for dispatch narrowing", () => {
     const handler = new TelegramStaticBotInstallHandler({ botToken: "123:abc" });
     expect(handler.kind).toBe("static-bot");
+  });
+
+  it("is form-shaped (not OAuth-shaped) — the /install-form route accepts a pasted chat_id", () => {
+    // Telegram captures its routing identifier as a directly-typed chat_id,
+    // unlike Discord's OAuth-shaped bot-install redirect. The /install-form
+    // route refuses `oauthShaped` handlers; Telegram leaves the optional
+    // interface flag unset, so it must read falsy here.
+    const handler: StaticBotInstallHandler = new TelegramStaticBotInstallHandler({
+      botToken: "123:abc",
+    });
+    expect(handler.oauthShaped ?? false).toBe(false);
   });
 
   it("refuses to construct when botToken is empty — actionable env name in the error", () => {
@@ -132,7 +186,7 @@ describe("TelegramStaticBotInstallHandler.confirmInstall — chat_id validation"
   it("rejects empty chat_id", async () => {
     const handler = new TelegramStaticBotInstallHandler({ botToken: "123:abc" });
     await expect(handler.confirmInstall(wsid, "")).rejects.toThrow(/chat_id/);
-    expect(mockInternalQuery).not.toHaveBeenCalled();
+    expect(mockCheckChatLimitAndInstall).not.toHaveBeenCalled();
   });
 
   it("rejects chat_id with non-numeric characters", async () => {
@@ -141,7 +195,7 @@ describe("TelegramStaticBotInstallHandler.confirmInstall — chat_id validation"
     // groups/channels). A pasted `@username` is a common admin mistake;
     // reject before the API call.
     await expect(handler.confirmInstall(wsid, "@my_channel")).rejects.toThrow(/chat_id/);
-    expect(mockInternalQuery).not.toHaveBeenCalled();
+    expect(mockCheckChatLimitAndInstall).not.toHaveBeenCalled();
   });
 
   it("accepts negative chat_id (groups / channels)", async () => {
@@ -170,25 +224,89 @@ describe("TelegramStaticBotInstallHandler.confirmInstall — reachability verifi
     expect(fetchCalls[0].url).toContain("chat_id=-100999");
   });
 
-  it("throws with a clear error when Telegram returns chat_not_found", async () => {
+  it("throws with a clear error when Telegram returns chat_not_found (and never touches the cap gate)", async () => {
     setFetchTelegramError("Bad Request: chat not found", 400);
     const handler = new TelegramStaticBotInstallHandler({ botToken: "987:xyz" });
     await expect(handler.confirmInstall(wsid, "999")).rejects.toThrow(/chat not found/i);
-    expect(mockInternalQuery).not.toHaveBeenCalled();
+    expect(mockCheckChatLimitAndInstall).not.toHaveBeenCalled();
   });
 
   it("throws with a clear error when the bot is not a member of the chat", async () => {
     setFetchTelegramError("Forbidden: bot is not a member of the channel chat", 403);
     const handler = new TelegramStaticBotInstallHandler({ botToken: "987:xyz" });
     await expect(handler.confirmInstall(wsid, "-100999")).rejects.toThrow(/not a member/i);
-    expect(mockInternalQuery).not.toHaveBeenCalled();
+    expect(mockCheckChatLimitAndInstall).not.toHaveBeenCalled();
   });
 
   it("throws when the Bot API call fails at the network layer (no install row)", async () => {
     setFetchNetworkError();
     const handler = new TelegramStaticBotInstallHandler({ botToken: "987:xyz" });
     await expect(handler.confirmInstall(wsid, "12345")).rejects.toThrow(/telegram/i);
-    expect(mockInternalQuery).not.toHaveBeenCalled();
+    expect(mockCheckChatLimitAndInstall).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Chat-integration cap (#3141 — migrated onto the atomic gate)
+// ---------------------------------------------------------------------------
+
+describe("TelegramStaticBotInstallHandler.confirmInstall — chat-integration cap", () => {
+  it("throws ChatIntegrationLimitError and writes no install row when at cap", async () => {
+    // The gate rolls back its UPSERT internally on a cap denial and returns
+    // `cap_reached` — the row is never committed.
+    mockCheckChatLimitAndInstall.mockImplementationOnce(() =>
+      Promise.resolve({
+        allowed: false as const,
+        reason: "cap_reached" as const,
+        errorMessage: "Your starter plan allows up to 1 chat integration. Upgrade to add more.",
+        limit: 1,
+      }),
+    );
+    const handler = new TelegramStaticBotInstallHandler({ botToken: "123:abc" });
+
+    await expect(handler.confirmInstall(wsid, "12345")).rejects.toMatchObject({
+      _tag: "ChatIntegrationLimitError",
+      limit: 1,
+    });
+
+    // The gate enforced the cap (after reachability), keyed on the workspace +
+    // Telegram catalog id, with the UPSERT it would have committed.
+    expect(mockCheckChatLimitAndInstall).toHaveBeenCalledTimes(1);
+    const [gateOrg, gateCatalog, gateInsert] = mockCheckChatLimitAndInstall.mock.calls[0];
+    expect(gateOrg).toBe(wsid);
+    expect(gateCatalog).toBe(TELEGRAM_CATALOG_ID);
+    expect(gateInsert.sql).toMatch(/INSERT INTO workspace_plugins/);
+  });
+
+  it("throws BillingCheckFailedError (not the cap error) when the count check fails closed", async () => {
+    mockCheckChatLimitAndInstall.mockImplementationOnce(() =>
+      Promise.resolve({
+        allowed: false as const,
+        reason: "check_failed" as const,
+        errorMessage: "Unable to verify plan limits. Please try again.",
+      }),
+    );
+    const handler = new TelegramStaticBotInstallHandler({ botToken: "123:abc" });
+
+    await expect(handler.confirmInstall(wsid, "12345")).rejects.toMatchObject({
+      _tag: "BillingCheckFailedError",
+    });
+
+    // Still fail closed — the gate returned check_failed without committing.
+    expect(mockCheckChatLimitAndInstall).toHaveBeenCalledTimes(1);
+  });
+
+  it("grandfathers a reconnect — the gate allows an already-installed workspace and returns the existing id", async () => {
+    // Reconnect (re-auth of an already-installed platform) never grows the
+    // distinct chat-integration count, so the gate allows it even when the
+    // workspace is at/over cap. The handler must surface the existing row id.
+    mockCheckChatLimitAndInstall.mockImplementationOnce(() =>
+      Promise.resolve({ allowed: true as const, rows: [{ id: "existing-install-row" }] }),
+    );
+    const handler = new TelegramStaticBotInstallHandler({ botToken: "123:abc" });
+    const result = await handler.confirmInstall(wsid, "12345");
+    expect(result.installRecord.id).toBe("existing-install-row");
+    expect(mockCheckChatLimitAndInstall).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -197,13 +315,19 @@ describe("TelegramStaticBotInstallHandler.confirmInstall — reachability verifi
 // ---------------------------------------------------------------------------
 
 describe("TelegramStaticBotInstallHandler.confirmInstall — persistence", () => {
-  it("UPSERTs workspace_plugins with the catalog id + chat_id config payload", async () => {
+  /** Pull the gate's `insert` arg from the most recent call. */
+  function lastGateInsert(): { sql: string; params: readonly unknown[] } {
+    const calls = mockCheckChatLimitAndInstall.mock.calls;
+    return calls[calls.length - 1][2];
+  }
+
+  it("UPSERTs workspace_plugins with the catalog id + chat_id config payload via the cap gate", async () => {
     const handler = new TelegramStaticBotInstallHandler({ botToken: "123:abc" });
     await handler.confirmInstall(wsid, "12345", undefined, { display_name: "Team Standup" });
 
-    expect(mockInternalQuery).toHaveBeenCalledTimes(1);
-    const [sql, params] = mockInternalQuery.mock.calls[0];
-    const sqlText = String(sql);
+    expect(mockCheckChatLimitAndInstall).toHaveBeenCalledTimes(1);
+    const insert = lastGateInsert();
+    const sqlText = insert.sql;
     expect(sqlText).toMatch(/INSERT INTO workspace_plugins/);
     // Required NOT NULL columns post-0092 / 0096 — INSERT must name
     // pillar + install_id; chat-pillar installs target the partial
@@ -212,9 +336,10 @@ describe("TelegramStaticBotInstallHandler.confirmInstall — persistence", () =>
     expect(sqlText).toMatch(/pillar/);
     expect(sqlText).toMatch(/'chat'/);
     expect(sqlText).toMatch(/ON CONFLICT.*workspace_id.*catalog_id.*WHERE.*pillar.*DO UPDATE/s);
+    // The gate runs the UPSERT under the lock, so RETURNING id must be present.
+    expect(sqlText).toMatch(/RETURNING id/);
 
-    expect(Array.isArray(params)).toBe(true);
-    const paramsArr = params as unknown[];
+    const paramsArr = insert.params as unknown[];
     // (id, workspace_id, catalog_id, config_json, enabled implied true)
     expect(paramsArr).toContain(wsid);
     expect(paramsArr).toContain(TELEGRAM_CATALOG_ID);
@@ -231,8 +356,7 @@ describe("TelegramStaticBotInstallHandler.confirmInstall — persistence", () =>
   it("omits display_name from config when the routing identifier is the only field supplied", async () => {
     const handler = new TelegramStaticBotInstallHandler({ botToken: "123:abc" });
     await handler.confirmInstall(wsid, "12345");
-    const [, params] = mockInternalQuery.mock.calls[0];
-    const configJson = (params as unknown[]).find(
+    const configJson = (lastGateInsert().params as unknown[]).find(
       (p): p is string => typeof p === "string" && p.includes("chat_id"),
     );
     const parsed = JSON.parse(configJson as string) as Record<string, unknown>;
@@ -240,9 +364,9 @@ describe("TelegramStaticBotInstallHandler.confirmInstall — persistence", () =>
     expect("display_name" in parsed).toBe(false);
   });
 
-  it("returns the persisted install id from RETURNING (re-install idempotency)", async () => {
-    mockInternalQuery.mockImplementation(() =>
-      Promise.resolve([{ id: "existing-install-row" }]),
+  it("returns the persisted install id from the gate's RETURNING rows (re-install idempotency)", async () => {
+    mockCheckChatLimitAndInstall.mockImplementation(() =>
+      Promise.resolve({ allowed: true as const, rows: [{ id: "existing-install-row" }] }),
     );
     const handler = new TelegramStaticBotInstallHandler({ botToken: "123:abc" });
     const result = await handler.confirmInstall(wsid, "12345");
@@ -251,13 +375,15 @@ describe("TelegramStaticBotInstallHandler.confirmInstall — persistence", () =>
     expect(result.installRecord.catalogId).toBe(TELEGRAM_SLUG);
   });
 
-  it("throws when RETURNING comes back empty — never ships a candidate id that doesn't match the persisted row", async () => {
+  it("throws when the gate's RETURNING rows are empty — never ships a candidate id that doesn't match the persisted row", async () => {
     // Postgres ≥9.5 guarantees `INSERT … ON CONFLICT … RETURNING`
     // populates the row on both insert and update. Empty here means
     // a driver regression — silently shipping the candidate id would
     // strand re-install lookups (DB has the existing id, response says
     // a fresh UUID). Fail loud instead.
-    mockInternalQuery.mockImplementation(() => Promise.resolve([]));
+    mockCheckChatLimitAndInstall.mockImplementation(() =>
+      Promise.resolve({ allowed: true as const, rows: [] }),
+    );
     const handler = new TelegramStaticBotInstallHandler({
       botToken: "123:abc",
       idGenerator: () => "candidate-id-xyz",
@@ -268,7 +394,8 @@ describe("TelegramStaticBotInstallHandler.confirmInstall — persistence", () =>
   });
 
   it("surfaces DB failure rather than half-installing — no return after a throw", async () => {
-    mockInternalQuery.mockImplementation(() => Promise.reject(new Error("DB down")));
+    // The gate throws on a genuine write-path failure (after rolling back).
+    mockCheckChatLimitAndInstall.mockImplementation(() => Promise.reject(new Error("DB down")));
     const handler = new TelegramStaticBotInstallHandler({ botToken: "123:abc" });
     await expect(handler.confirmInstall(wsid, "12345")).rejects.toThrow(/DB down/);
   });

--- a/packages/api/src/lib/integrations/install/telegram-static-bot-handler.ts
+++ b/packages/api/src/lib/integrations/install/telegram-static-bot-handler.ts
@@ -42,6 +42,7 @@
 
 import crypto from "crypto";
 import { createLogger } from "@atlas/api/lib/logger";
+import { internalQuery } from "@atlas/api/lib/db/internal";
 import {
   BillingCheckFailedError,
   ChatIntegrationLimitError,
@@ -72,6 +73,43 @@ export const TELEGRAM_SLUG: CatalogId = "telegram";
  * this constant produces FK violations at first install.
  */
 export const TELEGRAM_CATALOG_ID = "catalog:telegram";
+
+/**
+ * Cross-workspace ownership guard (#3141 / Codex #3153). `getChat` proves the
+ * operator bot is a member of the chat, not that the installing workspace owns
+ * it — and chat_ids are non-secret (they leak in every message envelope). So
+ * reject a chat_id already bound to a *different* workspace before persisting.
+ * The `workspace_id <> $3` filter excludes the installing workspace, so a
+ * reconnect (same workspace re-binding its own chat) is never blocked.
+ * Read-only pre-check: it narrows the cross-tenant window but isn't
+ * transactionally fused with the cap gate's INSERT, so the simultaneous-race
+ * case remains — tracked, with the full ownership-proof flow, in #3154.
+ */
+async function assertChatIdUnboundElsewhere(
+  chatId: string,
+  workspaceId: WorkspaceId,
+): Promise<void> {
+  const rows = await internalQuery<{ workspace_id: string }>(
+    `SELECT workspace_id
+       FROM workspace_plugins
+      WHERE catalog_id = $1
+        AND enabled = true
+        AND config->>'chat_id' = $2
+        AND workspace_id <> $3
+      LIMIT 1`,
+    [TELEGRAM_CATALOG_ID, chatId, workspaceId],
+  );
+  if (rows.length > 0) {
+    log.warn(
+      { workspaceId, conflictingWorkspaceId: rows[0]?.workspace_id },
+      "Telegram install rejected — chat_id already bound to a different workspace",
+    );
+    throw new TelegramChatIdInvalidError({
+      message:
+        "This Telegram chat is already connected to a different Atlas workspace. Each chat can be linked to only one workspace — disconnect it there first, or contact your admin if you believe this is an error.",
+    });
+  }
+}
 
 /**
  * Telegram chat ids are 64-bit signed integers documented as ≤52
@@ -171,6 +209,17 @@ export class TelegramStaticBotInstallHandler implements StaticBotInstallHandler 
     // Throws on Bot API errors / network failures *before* any DB write,
     // so a failed verification never leaves a half-installed row behind.
     await this.verifyReachability(routingIdentifier);
+
+    // ── 2b. Cross-workspace ownership guard (#3141 / Codex #3153) ────
+    // `getChat` proves the operator bot is a member of the chat, NOT that
+    // THIS workspace owns it — and chat_ids leak in every message envelope.
+    // Reject a chat_id already bound to a *different* workspace so a member
+    // of the chat can't bind it to their own workspace and intercept the
+    // chat's messages (a reconnect by the same workspace is excluded by the
+    // `workspace_id <> $3` filter). This narrows the cross-tenant window; the
+    // residual (two workspaces racing a never-before-bound id) is tracked,
+    // with the full ownership-proof flow, in #3154.
+    await assertChatIdUnboundElsewhere(routingIdentifier, workspaceId);
 
     // ── 3. Plan cap + install row — atomic (#3141, #3001) ──────────
     // Enforce the chat-integration cap and persist the workspace_plugins row

--- a/packages/api/src/lib/integrations/install/telegram-static-bot-handler.ts
+++ b/packages/api/src/lib/integrations/install/telegram-static-bot-handler.ts
@@ -13,11 +13,19 @@
  * Per-Workspace credential note: there isn't one. The bot's auth lives
  * with the operator (`TELEGRAM_BOT_TOKEN`). The catalog `chat_id` is a
  * routing identifier, not a secret — Telegram leaks it in `from.id` /
- * `chat.id` of every message envelope. This handler writes
- * `workspace_plugins.config` directly via `internalQuery` (mirroring
- * `slack-oauth-handler.ts`), so `encryptSecretFields` is not in the
- * write path at all; the absence of `secret: true` on the catalog row
- * is consistent but not the load-bearing reason.
+ * `chat.id` of every message envelope. The `workspace_plugins.config`
+ * row is written by the chat-integration cap gate
+ * (`checkChatIntegrationLimitAndInstall`), which owns the advisory-locked
+ * UPSERT — so `encryptSecretFields` is not in the write path at all; the
+ * absence of `secret: true` on the catalog row is consistent but not the
+ * load-bearing reason.
+ *
+ * Cap gate (#3141): like Discord and Slack, the install UPSERT runs
+ * through `checkChatIntegrationLimitAndInstall` so an over-cap net-new
+ * install is refused with `ChatIntegrationLimitError` (→ 429) and a
+ * reconnect (re-auth of an already-installed workspace) is grandfathered.
+ * This replaced the keystone's original bare `internalQuery` UPSERT when
+ * Telegram joined the unified install path under umbrella #2994.
  *
  * Reachability verification: rather than sending a real test message
  * (which would spam the channel on every install attempt), we call the
@@ -34,12 +42,14 @@
 
 import crypto from "crypto";
 import { createLogger } from "@atlas/api/lib/logger";
-import { internalQuery } from "@atlas/api/lib/db/internal";
 import {
+  BillingCheckFailedError,
+  ChatIntegrationLimitError,
   TelegramApiUnavailableError,
   TelegramChatIdInvalidError,
   TelegramReachabilityError,
 } from "@atlas/api/lib/effect/errors";
+import { checkChatIntegrationLimitAndInstall } from "@atlas/api/lib/billing/enforcement";
 import type { WorkspaceId } from "@useatlas/types";
 import type {
   CatalogId,
@@ -162,25 +172,28 @@ export class TelegramStaticBotInstallHandler implements StaticBotInstallHandler 
     // so a failed verification never leaves a half-installed row behind.
     await this.verifyReachability(routingIdentifier);
 
-    // ── 3. Persist install row — UPSERT keyed on (workspace, catalog) ─
-    // Mirrors the email-form-handler pattern: candidate id on the
-    // INSERT side, RETURNING id so a CONFLICT lands on the existing
-    // row's id (idempotent re-install).
+    // ── 3. Plan cap + install row — atomic (#3141, #3001) ──────────
+    // Enforce the chat-integration cap and persist the workspace_plugins row
+    // in ONE transaction guarded by a per-workspace advisory lock, so two
+    // *distinct* net-new platforms installing concurrently can't both slip
+    // past the cap. Reconnecting Telegram (already installed) is never blocked
+    // — the gate excludes Telegram's own row from the count, and the UPSERT
+    // collapses the duplicate. Identical schema + UPSERT shape to
+    // discord-static-bot-handler.ts (see there for the full rationale on the
+    // NOT NULL columns from 0092/0096 and the singleton-index conflict target).
     const candidateId = this.newId();
     const configPayload: TelegramInstallConfig = {
       chat_id: routingIdentifier,
       ...extractDisplayName(extras, workspaceId),
     };
 
-    let persistedId: string;
+    let capCheck;
     try {
-      // Schema: `pillar` + `install_id` became NOT NULL in 0092 (#2739)
-      // and the auto-fill trigger was dropped in 0096 (#2744). The
-      // ON CONFLICT inference targets the `workspace_plugins_singleton`
-      // partial unique index. See discord-static-bot-handler.ts for the
-      // full rationale — identical schema, identical UPSERT shape.
-      const rows = await internalQuery<{ id: string }>(
-        `INSERT INTO workspace_plugins
+      capCheck = await checkChatIntegrationLimitAndInstall<{ id: string }>(
+        workspaceId,
+        TELEGRAM_CATALOG_ID,
+        {
+          sql: `INSERT INTO workspace_plugins
            (id, workspace_id, catalog_id, install_id, pillar, config, enabled, installed_at)
          VALUES ($1, $2, $3, $1, 'chat', $4::jsonb, true, NOW())
          ON CONFLICT (workspace_id, catalog_id) WHERE pillar IN ('chat', 'action')
@@ -188,21 +201,9 @@ export class TelegramStaticBotInstallHandler implements StaticBotInstallHandler 
            SET config = EXCLUDED.config,
                enabled = true
          RETURNING id`,
-        [candidateId, workspaceId, TELEGRAM_CATALOG_ID, JSON.stringify(configPayload)],
+          params: [candidateId, workspaceId, TELEGRAM_CATALOG_ID, JSON.stringify(configPayload)],
+        },
       );
-      const returned = rows[0]?.id;
-      if (typeof returned !== "string" || returned.length === 0) {
-        // Postgres ≥9.5 guarantees `INSERT … ON CONFLICT … RETURNING`
-        // returns the row on both insert and update. Empty here means a
-        // driver / wrapper regression — fail loudly rather than ship a
-        // stale id back to the user (on re-install the DB row has the
-        // existing id; falling back to the fresh candidateId would
-        // strand subsequent lookups).
-        throw new Error(
-          `workspace_plugins UPSERT returned no id for Telegram install (workspaceId=${workspaceId}). RETURNING must always populate on PG ≥9.5; this indicates a driver regression. Aborting install.`,
-        );
-      }
-      persistedId = returned;
     } catch (err) {
       log.error(
         {
@@ -213,6 +214,42 @@ export class TelegramStaticBotInstallHandler implements StaticBotInstallHandler 
       );
       throw err;
     }
+    if (!capCheck.allowed) {
+      if (capCheck.reason === "check_failed") {
+        // Count couldn't be determined — fail closed, but as a transient
+        // 503 "try again", not a misleading 429 "upgrade your plan".
+        log.error(
+          { workspaceId },
+          "Telegram install blocked — chat-integration count check failed (failing closed)",
+        );
+        throw new BillingCheckFailedError({
+          message: capCheck.errorMessage,
+          workspaceId,
+        });
+      }
+      log.info(
+        { workspaceId, limit: capCheck.limit },
+        "Telegram install blocked — workspace at chat-integration cap",
+      );
+      throw new ChatIntegrationLimitError({
+        message: capCheck.errorMessage,
+        workspaceId,
+        limit: capCheck.limit,
+      });
+    }
+
+    const returned = capCheck.rows[0]?.id;
+    if (typeof returned !== "string" || returned.length === 0) {
+      // Postgres ≥9.5 guarantees `INSERT … ON CONFLICT … RETURNING` returns
+      // the row on both insert and update. Empty here means a driver /
+      // wrapper regression — fail loudly rather than ship a stale id back (on
+      // re-install the DB row has the existing id; falling back to the fresh
+      // candidateId would strand subsequent lookups).
+      throw new Error(
+        `workspace_plugins UPSERT returned no id for Telegram install (workspaceId=${workspaceId}). RETURNING must always populate on PG ≥9.5; this indicates a driver regression. Aborting install.`,
+      );
+    }
+    const persistedId: string = returned;
 
     log.info(
       {


### PR DESCRIPTION
## What

Keystone slice of umbrella **#2994** — completes the static-bot chat-platform family by bringing **Telegram** onto the cap-gated unified install path established by the #3140/#3148 install spine.

Closes #3141.

## Why

The #3140 spine made `POST /{platform}/install-form` handle `install_model="static-bot"` generically and refuse `coming_soon` rows. But Telegram's `confirmInstall` still persisted via a **bare `internalQuery` UPSERT** — counted toward the chat-integration cap but never *serialized* against it (see the `CHAT_INTEGRATION_COUNT_SQL` docstring in `billing/enforcement.ts`). So Telegram stayed `coming_soon` and unreachable. This slice migrates it onto the gate Discord + Slack already use, then flips it `available`.

## Changes

- **`telegram-static-bot-handler.ts`** — `confirmInstall` now persists through `checkChatIntegrationLimitAndInstall` (the advisory-locked atomic cap gate). Over-cap net-new install → `ChatIntegrationLimitError` (→ **429**); count-check fails closed → `BillingCheckFailedError` (→ **503**); **reconnect grandfathered** inside the gate. Identical UPSERT shape to `discord-static-bot-handler.ts`.
- **`deploy/api/atlas.config.ts` + `deploy/api-staging/atlas.config.ts`** — flip the `telegram` catalog row `coming_soon → available`. The `/install-form` route refuses `coming_soon`, so this is what unblocks the path — and it only ever reaches the handler now that the handler runs the gate.
- **`telegram.mdx`** — drop the "Per-workspace install not available yet" callout (the flow it described is now live).
- **test** — convert the handler test onto the gate mock + add cap-gate coverage: over-cap → 429, count-check-failed → 503, reconnect grandfathered, and reachability failure never consumes the cap.

## Acceptance criteria (#3141)

- [x] `telegram` catalog row flipped `coming_soon → available` (deploy/api + api-staging)
- [x] `confirmInstall` runs `checkChatIntegrationLimitAndInstall` (matches Discord/Slack)
- [x] over-cap install → 429; reconnect grandfathered (test-covered)
- [x] admin routing-id modal renders for Telegram capturing `chat_id` (+ optional `display_name`) — the shared `config_schema`-driven `/install-form` path, now reachable since the row is `available` and form-shaped (not `oauthShaped`)
- [x] "Coming soon" callout removed from `telegram.mdx`

## Gates

`bun run type`, `bun run lint`, and the handler suite (21 pass) green locally.

> Branch named `feat/static-bot-telegram-3141` (not `…-install`) — the suggested name collided with a concurrent session's branch ref in a shared checkout; content is unaffected.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3152"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783127736&installation_id=135337507&pr_number=3152&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3152&signature=b164f65e9ec8771ed02fda09064f1aec1ce1d779bd8e962a237eff3d3916937f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Telegram integration is now available with the cap-gated static-bot install flow; reconnects are supported and usage caps enforced.

* **Documentation**
  * Removed outdated availability notice and clarified how to find a chat’s numeric ID (including token-free lookup options and `@userinfobot`).
  * Retained advanced/self-hosted operator guidance and security warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->