### PR TITLE
feat(integrations): cap-gate Google Chat + WhatsApp static-bot installs (#3143, #3144)

### DIFF
--- a/apps/docs/content/docs/integrations/gchat.mdx
+++ b/apps/docs/content/docs/integrations/gchat.mdx
@@ -19,6 +19,19 @@ OAuth dance. Google Chat's bot model is operator-shared because
 Google Chat apps are published once to the Workspace Marketplace and
 installed per-Workspace under a single application registration.
 
+<Callout type="warn" title="Per-workspace install not available yet">
+The cap-gated install handler is wired, but Google Chat stays **"Coming
+soon"** in the admin UI until the customer-install binding lands. Google
+Chat's ownership-proven bind is the **Workspace Marketplace install
+webhook** — Google delivers the customer-verified `workspace_id` directly,
+so an admin never pastes it. Accepting a pasted `workspace_id` through the
+generic form would let one workspace claim another's Google Workspace
+before that customer connects, so the form path stays gated until the
+Marketplace-webhook receiver is wired (tracked in
+[#3154](https://github.com/AtlasDevHQ/atlas/issues/3154)). The operator
+setup below remains valid groundwork.
+</Callout>
+
 ## Operator setup (one-time, per deploy)
 
 These steps wire your deploy to a Google Cloud project + Workspace

--- a/apps/docs/content/docs/integrations/gchat.mdx
+++ b/apps/docs/content/docs/integrations/gchat.mdx
@@ -19,17 +19,6 @@ OAuth dance. Google Chat's bot model is operator-shared because
 Google Chat apps are published once to the Workspace Marketplace and
 installed per-Workspace under a single application registration.
 
-<Callout type="warn" title="Per-workspace install not available yet">
-The per-workspace install flow described below is **not currently available**
-in the Atlas admin UI. Its legacy connect route was removed in
-[#2994](https://github.com/AtlasDevHQ/atlas/issues/2994) because it bypassed the
-chat-integration cap and produced a non-routable install. The cap-gated
-static-bot install (routing-identifier capture, like Discord) is tracked in
-[#3143](https://github.com/AtlasDevHQ/atlas/issues/3143); until it ships the
-Google Chat card shows **"Coming soon."** The operator setup below remains valid
-groundwork.
-</Callout>
-
 ## Operator setup (one-time, per deploy)
 
 These steps wire your deploy to a Google Cloud project + Workspace

--- a/apps/docs/content/docs/integrations/whatsapp.mdx
+++ b/apps/docs/content/docs/integrations/whatsapp.mdx
@@ -33,17 +33,6 @@ fresh OAuth dance.
   of the connect CTA.
 </Callout>
 
-<Callout type="warn" title="Per-workspace install not available yet">
-The per-workspace install flow described below is **not currently available**
-in the Atlas admin UI. Its legacy connect route was removed in
-[#2994](https://github.com/AtlasDevHQ/atlas/issues/2994) because it bypassed the
-chat-integration cap and produced a non-routable install. The cap-gated
-static-bot install (routing-identifier capture, like Discord) is tracked in
-[#3144](https://github.com/AtlasDevHQ/atlas/issues/3144); until it ships the
-WhatsApp card shows **"Coming soon."** The operator setup below remains valid
-groundwork.
-</Callout>
-
 ## Operator setup (one-time, per deploy)
 
 These steps wire your deploy to a Meta Business / WhatsApp Business

--- a/deploy/api-staging/atlas.config.ts
+++ b/deploy/api-staging/atlas.config.ts
@@ -242,13 +242,18 @@ export default defineConfig({
       install_model: "static-bot",
       enabled: true,
       saas_eligible: true,
-      // #3143 (umbrella #2994) shipped the cap-gated static-bot install:
-      // the generic `/install-form` route captures the workspace_id and
-      // `GchatStaticBotInstallHandler.confirmInstall` persists through
-      // `checkChatIntegrationLimitAndInstall` (over-cap → 429, reconnect
-      // grandfathered). gchat is already in the chatPlugin catalog below,
-      // so its webhook receive route + adapter are wired.
-      implementation_status: "available",
+      // #3143 cap-gated `GchatStaticBotInstallHandler.confirmInstall`
+      // (checkChatIntegrationLimitAndInstall — over-cap → 429, reconnect
+      // grandfathered), but gchat stays coming_soon: its ownership-proven
+      // bind is the Google Workspace **Marketplace install webhook** (which
+      // delivers the customer-verified workspace_id), and that receiver isn't
+      // wired yet. Flipping available would only expose the generic
+      // `/install-form` paste path, where an admin could submit *another*
+      // customer's workspace_id before that customer connects and capture
+      // their inbound Chat events (cross-tenant) — Codex flagged this on
+      // #3153. Flip to available once the Marketplace-webhook → confirmInstall
+      // binding lands (tracked in #3154). The cap-gate is ready for that.
+      implementation_status: "coming_soon",
       name: "Google Chat",
       description:
         "Chat with Atlas inside Google Chat. The operator wires a shared service account (GCHAT_SERVICE_ACCOUNT_JSON + GCHAT_PUBSUB_TOPIC) and publishes the Atlas listing in the Google Workspace Marketplace; customer admins install the listing per-Workspace, and Atlas captures the Workspace customer id from the Marketplace webhook.",

--- a/deploy/api-staging/atlas.config.ts
+++ b/deploy/api-staging/atlas.config.ts
@@ -242,9 +242,13 @@ export default defineConfig({
       install_model: "static-bot",
       enabled: true,
       saas_eligible: true,
-      // #2994: legacy connect route removed (cap bypass + non-functional);
-      // back to coming_soon until the cap-gated static-bot install ships (#3143).
-      implementation_status: "coming_soon",
+      // #3143 (umbrella #2994) shipped the cap-gated static-bot install:
+      // the generic `/install-form` route captures the workspace_id and
+      // `GchatStaticBotInstallHandler.confirmInstall` persists through
+      // `checkChatIntegrationLimitAndInstall` (over-cap → 429, reconnect
+      // grandfathered). gchat is already in the chatPlugin catalog below,
+      // so its webhook receive route + adapter are wired.
+      implementation_status: "available",
       name: "Google Chat",
       description:
         "Chat with Atlas inside Google Chat. The operator wires a shared service account (GCHAT_SERVICE_ACCOUNT_JSON + GCHAT_PUBSUB_TOPIC) and publishes the Atlas listing in the Google Workspace Marketplace; customer admins install the listing per-Workspace, and Atlas captures the Workspace customer id from the Marketplace webhook.",
@@ -344,9 +348,13 @@ export default defineConfig({
       install_model: "static-bot",
       enabled: true,
       saas_eligible: true,
-      // #2994: legacy connect route removed (cap bypass + non-functional);
-      // back to coming_soon until the cap-gated static-bot install ships (#3144).
-      implementation_status: "coming_soon",
+      // #3144 (umbrella #2994) shipped the cap-gated static-bot install:
+      // the generic `/install-form` route captures the phone_number_id and
+      // `WhatsAppStaticBotInstallHandler.confirmInstall` persists through
+      // `checkChatIntegrationLimitAndInstall` (over-cap → 429, reconnect
+      // grandfathered). #3144 also adds whatsapp to the chatPlugin catalog
+      // below so its webhook receive route + adapter mount.
+      implementation_status: "available",
       name: "WhatsApp",
       description:
         "Chat with Atlas inside WhatsApp. The operator wires a shared Meta Business / WhatsApp Business Cloud API account (META_BUSINESS_ACCESS_TOKEN + META_BUSINESS_APP_ID); each workspace admin points Atlas at one WhatsApp Business phone number by its Meta phone_number_id. Higher plan tier — Meta charges the operator per-conversation.",
@@ -797,6 +805,22 @@ export default defineConfig({
         // `GchatStaticBotInstallHandler`).
         {
           slug: "gchat",
+          type: "chat",
+          install_model: "static-bot",
+          enabled: true,
+          saas_eligible: true,
+        },
+        // WhatsApp — 1.5.3 #2753 / cap-gated install #3144 (Phase D).
+        // #2753 shipped the @chat-adapter/whatsapp builder + the GET/POST
+        // /webhooks/whatsapp receive routes, but this plugin-local catalog
+        // never listed whatsapp — so the AdapterRegistry skipped it and the
+        // webhook routes never mounted (a non-routable install, the #2994
+        // defect). #3144 adds it here (in lockstep with the top-level
+        // catalog) so the adapter instantiates + the webhook mounts when the
+        // operator wires META_BUSINESS_ACCESS_TOKEN / WHATSAPP_APP_SECRET /
+        // WHATSAPP_VERIFY_TOKEN.
+        {
+          slug: "whatsapp",
           type: "chat",
           install_model: "static-bot",
           enabled: true,

--- a/deploy/api/atlas.config.ts
+++ b/deploy/api/atlas.config.ts
@@ -211,9 +211,13 @@ export default defineConfig({
       install_model: "static-bot",
       enabled: true,
       saas_eligible: true,
-      // #2994: legacy connect route removed (cap bypass + non-functional);
-      // back to coming_soon until the cap-gated static-bot install ships (#3143).
-      implementation_status: "coming_soon",
+      // #3143 (umbrella #2994) shipped the cap-gated static-bot install:
+      // the generic `/install-form` route captures the workspace_id and
+      // `GchatStaticBotInstallHandler.confirmInstall` persists through
+      // `checkChatIntegrationLimitAndInstall` (over-cap → 429, reconnect
+      // grandfathered). gchat is already in the chatPlugin catalog below,
+      // so its webhook receive route + adapter are wired.
+      implementation_status: "available",
       name: "Google Chat",
       description:
         "Chat with Atlas inside Google Chat. The operator wires a shared service account (GCHAT_SERVICE_ACCOUNT_JSON + GCHAT_PUBSUB_TOPIC) and publishes the Atlas listing in the Google Workspace Marketplace; customer admins install the listing per-Workspace, and Atlas captures the Workspace customer id from the Marketplace webhook.",
@@ -313,9 +317,13 @@ export default defineConfig({
       install_model: "static-bot",
       enabled: true,
       saas_eligible: true,
-      // #2994: legacy connect route removed (cap bypass + non-functional);
-      // back to coming_soon until the cap-gated static-bot install ships (#3144).
-      implementation_status: "coming_soon",
+      // #3144 (umbrella #2994) shipped the cap-gated static-bot install:
+      // the generic `/install-form` route captures the phone_number_id and
+      // `WhatsAppStaticBotInstallHandler.confirmInstall` persists through
+      // `checkChatIntegrationLimitAndInstall` (over-cap → 429, reconnect
+      // grandfathered). #3144 also adds whatsapp to the chatPlugin catalog
+      // below so its webhook receive route + adapter mount.
+      implementation_status: "available",
       name: "WhatsApp",
       description:
         "Chat with Atlas inside WhatsApp. The operator wires a shared Meta Business / WhatsApp Business Cloud API account (META_BUSINESS_ACCESS_TOKEN + META_BUSINESS_APP_ID); each workspace admin points Atlas at one WhatsApp Business phone number by its Meta phone_number_id. Higher plan tier — Meta charges the operator per-conversation.",
@@ -766,6 +774,22 @@ export default defineConfig({
         // `GchatStaticBotInstallHandler`).
         {
           slug: "gchat",
+          type: "chat",
+          install_model: "static-bot",
+          enabled: true,
+          saas_eligible: true,
+        },
+        // WhatsApp — 1.5.3 #2753 / cap-gated install #3144 (Phase D).
+        // #2753 shipped the @chat-adapter/whatsapp builder + the GET/POST
+        // /webhooks/whatsapp receive routes, but this plugin-local catalog
+        // never listed whatsapp — so the AdapterRegistry skipped it and the
+        // webhook routes never mounted (a non-routable install, the #2994
+        // defect). #3144 adds it here (in lockstep with the top-level
+        // catalog) so the adapter instantiates + the webhook mounts when the
+        // operator wires META_BUSINESS_ACCESS_TOKEN / WHATSAPP_APP_SECRET /
+        // WHATSAPP_VERIFY_TOKEN.
+        {
+          slug: "whatsapp",
           type: "chat",
           install_model: "static-bot",
           enabled: true,

--- a/deploy/api/atlas.config.ts
+++ b/deploy/api/atlas.config.ts
@@ -211,13 +211,18 @@ export default defineConfig({
       install_model: "static-bot",
       enabled: true,
       saas_eligible: true,
-      // #3143 (umbrella #2994) shipped the cap-gated static-bot install:
-      // the generic `/install-form` route captures the workspace_id and
-      // `GchatStaticBotInstallHandler.confirmInstall` persists through
-      // `checkChatIntegrationLimitAndInstall` (over-cap → 429, reconnect
-      // grandfathered). gchat is already in the chatPlugin catalog below,
-      // so its webhook receive route + adapter are wired.
-      implementation_status: "available",
+      // #3143 cap-gated `GchatStaticBotInstallHandler.confirmInstall`
+      // (checkChatIntegrationLimitAndInstall — over-cap → 429, reconnect
+      // grandfathered), but gchat stays coming_soon: its ownership-proven
+      // bind is the Google Workspace **Marketplace install webhook** (which
+      // delivers the customer-verified workspace_id), and that receiver isn't
+      // wired yet. Flipping available would only expose the generic
+      // `/install-form` paste path, where an admin could submit *another*
+      // customer's workspace_id before that customer connects and capture
+      // their inbound Chat events (cross-tenant) — Codex flagged this on
+      // #3153. Flip to available once the Marketplace-webhook → confirmInstall
+      // binding lands (tracked in #3154). The cap-gate is ready for that.
+      implementation_status: "coming_soon",
       name: "Google Chat",
       description:
         "Chat with Atlas inside Google Chat. The operator wires a shared service account (GCHAT_SERVICE_ACCOUNT_JSON + GCHAT_PUBSUB_TOPIC) and publishes the Atlas listing in the Google Workspace Marketplace; customer admins install the listing per-Workspace, and Atlas captures the Workspace customer id from the Marketplace webhook.",

--- a/packages/api/src/lib/integrations/install/__tests__/gchat-static-bot-handler.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/gchat-static-bot-handler.test.ts
@@ -21,9 +21,11 @@
  *   - Optional `workspace_domain` rides through `extras` analogous to
  *     Telegram's `display_name` and Discord's `guild_name`.
  *
- * `mock.module()` stubs the two module dependencies the handler reaches
- * into: `lib/db/internal` (`internalQuery`) and the global `fetch` used
- * for the Pub/Sub publish call.
+ * `mock.module()` stubs the module dependencies the handler reaches into:
+ * `lib/billing/enforcement` (`checkChatIntegrationLimitAndInstall` — the
+ * atomic cap-gate that owns the `workspace_plugins` UPSERT post-#3001, which
+ * gchat adopted in #3143) and the global `fetch` used for the Pub/Sub publish
+ * call. Each mock exports every named export it shadows.
  */
 
 import { afterEach, beforeEach, describe, expect, it, mock, type Mock } from "bun:test";
@@ -33,14 +35,43 @@ import type { WorkspaceId } from "@useatlas/types";
 // Module mocks — hoist above the handler import
 // ---------------------------------------------------------------------------
 
-const mockInternalQuery: Mock<(sql: string, params?: unknown[]) => Promise<unknown[]>> = mock(() =>
-  Promise.resolve([{ id: "install-gchat-row-1" }]),
-);
-
 mock.module("@atlas/api/lib/db/internal", () => ({
-  internalQuery: mockInternalQuery,
+  internalQuery: mock(() => Promise.resolve([])),
   hasInternalDB: mock(() => true),
   getInternalDB: mock(() => ({ query: mock(() => Promise.resolve({ rows: [] })) })),
+}));
+
+// The chat-integration cap + the workspace_plugins UPSERT run atomically
+// through `checkChatIntegrationLimitAndInstall` (#3001) — the gate owns the
+// write and returns the RETURNING rows. We stub it to "allowed" with a scripted
+// row id so these handler tests stay focused on the install contract
+// (workspace_id validation, Pub/Sub reachability, config payload) and assert
+// the UPSERT shape via the gate's `insert` arg. The cap-enforcement decision +
+// transaction sequencing live in `billing/__tests__/enforcement.test.ts`.
+type GateResult =
+  | { allowed: true; rows: Array<Record<string, unknown>> }
+  | { allowed: false; reason: "cap_reached"; errorMessage: string; limit: number }
+  | { allowed: false; reason: "check_failed"; errorMessage: string };
+const mockCheckChatLimitAndInstall: Mock<
+  (
+    orgId: string | undefined,
+    catalogId: string,
+    insert: { sql: string; params: readonly unknown[] },
+  ) => Promise<GateResult>
+> = mock(() => Promise.resolve({ allowed: true as const, rows: [{ id: "install-gchat-row-1" }] }));
+
+// Mock every value export — a partial `mock.module()` causes a `SyntaxError`
+// in other files importing the missing exports (per CLAUDE.md "Mock all
+// exports"). Only `checkChatIntegrationLimitAndInstall` is exercised here.
+mock.module("@atlas/api/lib/billing/enforcement", () => ({
+  checkChatIntegrationLimitAndInstall: mockCheckChatLimitAndInstall,
+  CHAT_INTEGRATION_COUNT_SQL: "SELECT 1",
+  checkResourceLimit: () => Promise.resolve({ allowed: true }),
+  checkPlanLimits: () => Promise.resolve({ allowed: true }),
+  getCachedWorkspace: () => Promise.resolve(null),
+  invalidatePlanCache: () => {},
+  buildMetricStatus: () => ({ metric: "tokens", currentUsage: 0, limit: 0, usagePercent: 0, status: "ok" }),
+  severityOf: () => 0,
 }));
 
 // ---------------------------------------------------------------------------
@@ -107,8 +138,10 @@ function setFetchNetworkError(): void {
 }
 
 beforeEach(() => {
-  mockInternalQuery.mockClear();
-  mockInternalQuery.mockImplementation(() => Promise.resolve([{ id: "install-gchat-row-1" }]));
+  mockCheckChatLimitAndInstall.mockClear();
+  mockCheckChatLimitAndInstall.mockImplementation(() =>
+    Promise.resolve({ allowed: true as const, rows: [{ id: "install-gchat-row-1" }] }),
+  );
   fetchCalls.length = 0;
   setFetchOk();
 });
@@ -261,14 +294,14 @@ describe("GchatStaticBotInstallHandler.confirmInstall — workspace_id validatio
   it("rejects empty workspace_id", async () => {
     const handler = buildHandler();
     await expect(handler.confirmInstall(wsid, "")).rejects.toThrow(/workspace_id/);
-    expect(mockInternalQuery).not.toHaveBeenCalled();
+    expect(mockCheckChatLimitAndInstall).not.toHaveBeenCalled();
     expect(fetchCalls).toHaveLength(0);
   });
 
   it("rejects a pasted primary domain (common admin mistake)", async () => {
     const handler = buildHandler();
     await expect(handler.confirmInstall(wsid, "acme.com")).rejects.toThrow(/workspace_id/);
-    expect(mockInternalQuery).not.toHaveBeenCalled();
+    expect(mockCheckChatLimitAndInstall).not.toHaveBeenCalled();
   });
 
   it("rejects values containing spaces or invalid chars", async () => {
@@ -326,7 +359,7 @@ describe("GchatStaticBotInstallHandler.confirmInstall — reachability verificat
     await expect(
       handler.confirmInstall(wsid, VALID_WORKSPACE_ID),
     ).rejects.toThrow(/User not authorized/);
-    expect(mockInternalQuery).not.toHaveBeenCalled();
+    expect(mockCheckChatLimitAndInstall).not.toHaveBeenCalled();
   });
 
   it("throws a clear error when the topic doesn't exist (NOT_FOUND)", async () => {
@@ -335,7 +368,7 @@ describe("GchatStaticBotInstallHandler.confirmInstall — reachability verificat
     await expect(
       handler.confirmInstall(wsid, VALID_WORKSPACE_ID),
     ).rejects.toThrow(/Topic not found/);
-    expect(mockInternalQuery).not.toHaveBeenCalled();
+    expect(mockCheckChatLimitAndInstall).not.toHaveBeenCalled();
   });
 
   it("throws when the Pub/Sub API fails at the network layer (no install row)", async () => {
@@ -344,7 +377,7 @@ describe("GchatStaticBotInstallHandler.confirmInstall — reachability verificat
     await expect(
       handler.confirmInstall(wsid, VALID_WORKSPACE_ID),
     ).rejects.toThrow(/Pub\/Sub API unreachable/i);
-    expect(mockInternalQuery).not.toHaveBeenCalled();
+    expect(mockCheckChatLimitAndInstall).not.toHaveBeenCalled();
   });
 
   it("throws an unavailable error when Pub/Sub returns 2xx without messageIds (contract violation)", async () => {
@@ -353,7 +386,7 @@ describe("GchatStaticBotInstallHandler.confirmInstall — reachability verificat
     await expect(
       handler.confirmInstall(wsid, VALID_WORKSPACE_ID),
     ).rejects.toThrow(/no messageIds/i);
-    expect(mockInternalQuery).not.toHaveBeenCalled();
+    expect(mockCheckChatLimitAndInstall).not.toHaveBeenCalled();
   });
 
   it("classifies Pub/Sub 5xx as ApiUnavailable (retryable), not Reachability (admin-correctable)", async () => {
@@ -367,7 +400,7 @@ describe("GchatStaticBotInstallHandler.confirmInstall — reachability verificat
     await expect(
       handler.confirmInstall(wsid, VALID_WORKSPACE_ID),
     ).rejects.toThrow(/transient 503/);
-    expect(mockInternalQuery).not.toHaveBeenCalled();
+    expect(mockCheckChatLimitAndInstall).not.toHaveBeenCalled();
   });
 
   it("propagates token-mint failures from accessTokenProvider as a thrown error before any DB write", async () => {
@@ -384,7 +417,66 @@ describe("GchatStaticBotInstallHandler.confirmInstall — reachability verificat
     await expect(
       handler.confirmInstall(wsid, VALID_WORKSPACE_ID),
     ).rejects.toThrow(/token endpoint hiccup/);
-    expect(mockInternalQuery).not.toHaveBeenCalled();
+    expect(mockCheckChatLimitAndInstall).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Persistence
+// ---------------------------------------------------------------------------
+
+describe("GchatStaticBotInstallHandler.confirmInstall — chat-integration cap", () => {
+  it("throws ChatIntegrationLimitError and writes no install row when at cap", async () => {
+    // The gate rolls back its UPSERT internally on a cap denial and returns
+    // `cap_reached` — the row is never committed.
+    mockCheckChatLimitAndInstall.mockImplementationOnce(() =>
+      Promise.resolve({
+        allowed: false as const,
+        reason: "cap_reached" as const,
+        errorMessage: "Your starter plan allows up to 1 chat integration. Upgrade to add more.",
+        limit: 1,
+      }),
+    );
+    const handler = buildHandler();
+
+    await expect(handler.confirmInstall(wsid, VALID_WORKSPACE_ID)).rejects.toMatchObject({
+      _tag: "ChatIntegrationLimitError",
+      limit: 1,
+    });
+
+    // The gate enforced the cap (after the Pub/Sub round-trip), keyed on the
+    // workspace + gchat catalog id, with the UPSERT it would have committed.
+    expect(mockCheckChatLimitAndInstall).toHaveBeenCalledTimes(1);
+    const [gateOrg, gateCatalog, gateInsert] = mockCheckChatLimitAndInstall.mock.calls[0];
+    expect(gateOrg).toBe(wsid);
+    expect(gateCatalog).toBe(GCHAT_CATALOG_ID);
+    expect(gateInsert.sql).toMatch(/INSERT INTO workspace_plugins/);
+  });
+
+  it("throws BillingCheckFailedError (not the cap error) when the count check fails closed", async () => {
+    mockCheckChatLimitAndInstall.mockImplementationOnce(() =>
+      Promise.resolve({
+        allowed: false as const,
+        reason: "check_failed" as const,
+        errorMessage: "Unable to verify plan limits. Please try again.",
+      }),
+    );
+    const handler = buildHandler();
+
+    await expect(handler.confirmInstall(wsid, VALID_WORKSPACE_ID)).rejects.toMatchObject({
+      _tag: "BillingCheckFailedError",
+    });
+    expect(mockCheckChatLimitAndInstall).toHaveBeenCalledTimes(1);
+  });
+
+  it("grandfathers a reconnect — the gate allows an already-installed workspace and returns the existing id", async () => {
+    mockCheckChatLimitAndInstall.mockImplementationOnce(() =>
+      Promise.resolve({ allowed: true as const, rows: [{ id: "existing-install-row" }] }),
+    );
+    const handler = buildHandler();
+    const result = await handler.confirmInstall(wsid, VALID_WORKSPACE_ID);
+    expect(result.installRecord.id).toBe("existing-install-row");
+    expect(mockCheckChatLimitAndInstall).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -393,15 +485,21 @@ describe("GchatStaticBotInstallHandler.confirmInstall — reachability verificat
 // ---------------------------------------------------------------------------
 
 describe("GchatStaticBotInstallHandler.confirmInstall — persistence", () => {
-  it("UPSERTs workspace_plugins with the catalog id + workspace_id config payload", async () => {
+  /** Pull the gate's `insert` arg from the most recent call. */
+  function lastGateInsert(): { sql: string; params: readonly unknown[] } {
+    const calls = mockCheckChatLimitAndInstall.mock.calls;
+    return calls[calls.length - 1][2];
+  }
+
+  it("UPSERTs workspace_plugins with the catalog id + workspace_id config payload via the cap gate", async () => {
     const handler = buildHandler();
     await handler.confirmInstall(wsid, VALID_WORKSPACE_ID, undefined, {
       workspace_domain: "acme.com",
     });
 
-    expect(mockInternalQuery).toHaveBeenCalledTimes(1);
-    const [sql, params] = mockInternalQuery.mock.calls[0];
-    const sqlText = String(sql);
+    expect(mockCheckChatLimitAndInstall).toHaveBeenCalledTimes(1);
+    const insert = lastGateInsert();
+    const sqlText = insert.sql;
     expect(sqlText).toMatch(/INSERT INTO workspace_plugins/);
     // Required NOT NULL columns post-0092 / 0096 — the INSERT must name
     // pillar + install_id explicitly, and chat-pillar installs target
@@ -411,8 +509,10 @@ describe("GchatStaticBotInstallHandler.confirmInstall — persistence", () => {
     expect(sqlText).toMatch(/pillar/);
     expect(sqlText).toMatch(/'chat'/);
     expect(sqlText).toMatch(/ON CONFLICT.*workspace_id.*catalog_id.*WHERE.*pillar.*DO UPDATE/s);
+    // The gate runs the UPSERT under the lock, so RETURNING id must be present.
+    expect(sqlText).toMatch(/RETURNING id/);
 
-    const paramsArr = params as unknown[];
+    const paramsArr = insert.params as unknown[];
     expect(paramsArr).toContain(wsid);
     expect(paramsArr).toContain(GCHAT_CATALOG_ID);
     const configJson = paramsArr.find(
@@ -427,8 +527,7 @@ describe("GchatStaticBotInstallHandler.confirmInstall — persistence", () => {
   it("omits workspace_domain from config when extras don't supply one", async () => {
     const handler = buildHandler();
     await handler.confirmInstall(wsid, VALID_WORKSPACE_ID);
-    const [, params] = mockInternalQuery.mock.calls[0];
-    const configJson = (params as unknown[]).find(
+    const configJson = (lastGateInsert().params as unknown[]).find(
       (p): p is string => typeof p === "string" && p.includes("workspace_id"),
     );
     const parsed = JSON.parse(configJson as string) as Record<string, unknown>;
@@ -441,17 +540,16 @@ describe("GchatStaticBotInstallHandler.confirmInstall — persistence", () => {
     await handler.confirmInstall(wsid, VALID_WORKSPACE_ID, undefined, {
       workspace_domain: 42 as unknown as string,
     });
-    const [, params] = mockInternalQuery.mock.calls[0];
-    const configJson = (params as unknown[]).find(
+    const configJson = (lastGateInsert().params as unknown[]).find(
       (p): p is string => typeof p === "string" && p.includes("workspace_id"),
     );
     const parsed = JSON.parse(configJson as string) as Record<string, unknown>;
     expect("workspace_domain" in parsed).toBe(false);
   });
 
-  it("returns the persisted install id from RETURNING (re-install idempotency)", async () => {
-    mockInternalQuery.mockImplementation(() =>
-      Promise.resolve([{ id: "existing-install-row" }]),
+  it("returns the persisted install id from the gate's RETURNING rows (re-install idempotency)", async () => {
+    mockCheckChatLimitAndInstall.mockImplementation(() =>
+      Promise.resolve({ allowed: true as const, rows: [{ id: "existing-install-row" }] }),
     );
     const handler = buildHandler();
     const result = await handler.confirmInstall(wsid, VALID_WORKSPACE_ID);
@@ -460,8 +558,10 @@ describe("GchatStaticBotInstallHandler.confirmInstall — persistence", () => {
     expect(result.installRecord.catalogId).toBe(GCHAT_SLUG);
   });
 
-  it("throws when RETURNING comes back empty — never ships a candidate id that doesn't match the persisted row", async () => {
-    mockInternalQuery.mockImplementation(() => Promise.resolve([]));
+  it("throws when the gate's RETURNING rows are empty — never ships a candidate id that doesn't match the persisted row", async () => {
+    mockCheckChatLimitAndInstall.mockImplementation(() =>
+      Promise.resolve({ allowed: true as const, rows: [] }),
+    );
     const handler = buildHandler({ idGenerator: () => "candidate-id-xyz" });
     await expect(
       handler.confirmInstall(wsid, VALID_WORKSPACE_ID),
@@ -469,7 +569,8 @@ describe("GchatStaticBotInstallHandler.confirmInstall — persistence", () => {
   });
 
   it("surfaces DB failure rather than half-installing — no return after a throw", async () => {
-    mockInternalQuery.mockImplementation(() => Promise.reject(new Error("DB down")));
+    // The gate throws on a genuine write-path failure (after rolling back).
+    mockCheckChatLimitAndInstall.mockImplementation(() => Promise.reject(new Error("DB down")));
     const handler = buildHandler();
     await expect(
       handler.confirmInstall(wsid, VALID_WORKSPACE_ID),

--- a/packages/api/src/lib/integrations/install/__tests__/whatsapp-static-bot-handler.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/whatsapp-static-bot-handler.test.ts
@@ -42,8 +42,14 @@ import type { WorkspaceId } from "@useatlas/types";
 // Module mocks — hoist above the handler import
 // ---------------------------------------------------------------------------
 
+// The handler's cross-workspace ownership guard (#3144) reads
+// `workspace_plugins` via `internalQuery` before the cap gate. Default returns
+// [] (no conflict); the guard test overrides it to a matching row.
+const mockInternalQuery: Mock<(sql: string, params?: unknown[]) => Promise<unknown[]>> = mock(
+  () => Promise.resolve([]),
+);
 mock.module("@atlas/api/lib/db/internal", () => ({
-  internalQuery: mock(() => Promise.resolve([])),
+  internalQuery: mockInternalQuery,
   hasInternalDB: mock(() => true),
   getInternalDB: mock(() => ({ query: mock(() => Promise.resolve({ rows: [] })) })),
 }));
@@ -151,6 +157,8 @@ beforeEach(() => {
   mockCheckChatLimitAndInstall.mockImplementation(() =>
     Promise.resolve({ allowed: true as const, rows: [{ id: "install-whatsapp-row-1" }] }),
   );
+  mockInternalQuery.mockClear();
+  mockInternalQuery.mockImplementation(() => Promise.resolve([]));
   fetchCalls.length = 0;
   setFetchOk();
 });
@@ -449,6 +457,43 @@ describe("WhatsAppStaticBotInstallHandler.confirmInstall — reachability verifi
     }
     expect(caught?.cause).toBeUndefined();
     expect(caught?.message).not.toContain("EAA-secret-do-not-leak");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cross-workspace ownership guard (#3144 / Codex #3153)
+// ---------------------------------------------------------------------------
+
+describe("WhatsAppStaticBotInstallHandler.confirmInstall — cross-workspace guard", () => {
+  it("rejects a phone_number_id already bound to a different workspace, and never reaches the cap gate", async () => {
+    // Reachability proves the number is in the operator's Meta account, not
+    // that THIS workspace owns it. The guard SELECT finds an existing bind in
+    // another workspace and refuses before the cap gate runs — so an admin
+    // can't claim another customer's number.
+    mockInternalQuery.mockImplementation(() =>
+      Promise.resolve([{ workspace_id: "org-victim" }]),
+    );
+    const handler = new WhatsAppStaticBotInstallHandler({ accessToken: "t", appId: "id" });
+    await expect(handler.confirmInstall(wsid, SAMPLE_PHONE_NUMBER_ID)).rejects.toThrow(
+      /already connected to a different Atlas workspace/i,
+    );
+    expect(mockCheckChatLimitAndInstall).not.toHaveBeenCalled();
+    // The guard scopes its lookup to (catalog:whatsapp, enabled, the routing id,
+    // workspace_id <> self) so a reconnect by the same workspace is never caught.
+    const [sql, params] = mockInternalQuery.mock.calls[0];
+    expect(String(sql)).toMatch(/config->>'phone_number_id'/);
+    expect(String(sql)).toMatch(/workspace_id\s*<>\s*\$3/);
+    expect(params).toEqual([WHATSAPP_CATALOG_ID, SAMPLE_PHONE_NUMBER_ID, wsid]);
+  });
+
+  it("allows the install when the routing id is bound only to the installing workspace (reconnect) — guard returns no conflict", async () => {
+    // The `workspace_id <> $3` filter means a same-workspace reconnect returns
+    // no rows; the install proceeds to the cap gate (which grandfathers it).
+    mockInternalQuery.mockImplementation(() => Promise.resolve([]));
+    const handler = new WhatsAppStaticBotInstallHandler({ accessToken: "t", appId: "id" });
+    const result = await handler.confirmInstall(wsid, SAMPLE_PHONE_NUMBER_ID);
+    expect(result.installRecord.catalogId).toBe(WHATSAPP_SLUG);
+    expect(mockCheckChatLimitAndInstall).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/packages/api/src/lib/integrations/install/__tests__/whatsapp-static-bot-handler.test.ts
+++ b/packages/api/src/lib/integrations/install/__tests__/whatsapp-static-bot-handler.test.ts
@@ -27,10 +27,12 @@
  *     assert errors don't attach `cause: err` (preserves symmetry with
  *     the Discord / Telegram / Teams safe-by-default posture).
  *
- * `mock.module()` stubs the two module dependencies the handler reaches
- * into: `lib/db/internal` (`internalQuery`) and the global `fetch` used
- * for the Meta Graph API call. Each mock exports every named export it
- * shadows (CLAUDE.md "mock all exports" rule).
+ * `mock.module()` stubs the module dependencies the handler reaches into:
+ * `lib/billing/enforcement` (`checkChatIntegrationLimitAndInstall` — the
+ * atomic cap-gate that owns the `workspace_plugins` UPSERT post-#3001, which
+ * WhatsApp adopted in #3144) and the global `fetch` used for the Meta Graph
+ * API call. Each mock exports every named export it shadows (CLAUDE.md "mock
+ * all exports" rule).
  */
 
 import { afterEach, beforeEach, describe, expect, it, mock, type Mock } from "bun:test";
@@ -40,14 +42,43 @@ import type { WorkspaceId } from "@useatlas/types";
 // Module mocks — hoist above the handler import
 // ---------------------------------------------------------------------------
 
-const mockInternalQuery: Mock<(sql: string, params?: unknown[]) => Promise<unknown[]>> = mock(() =>
-  Promise.resolve([{ id: "install-whatsapp-row-1" }]),
-);
-
 mock.module("@atlas/api/lib/db/internal", () => ({
-  internalQuery: mockInternalQuery,
+  internalQuery: mock(() => Promise.resolve([])),
   hasInternalDB: mock(() => true),
   getInternalDB: mock(() => ({ query: mock(() => Promise.resolve({ rows: [] })) })),
+}));
+
+// The chat-integration cap + the workspace_plugins UPSERT run atomically
+// through `checkChatIntegrationLimitAndInstall` (#3001) — the gate owns the
+// write and returns the RETURNING rows. We stub it to "allowed" with a scripted
+// row id so these handler tests stay focused on the install contract
+// (phone_number_id validation, Meta Graph reachability, config payload) and
+// assert the UPSERT shape via the gate's `insert` arg. The cap-enforcement
+// decision + transaction sequencing live in `billing/__tests__/enforcement.test.ts`.
+type GateResult =
+  | { allowed: true; rows: Array<Record<string, unknown>> }
+  | { allowed: false; reason: "cap_reached"; errorMessage: string; limit: number }
+  | { allowed: false; reason: "check_failed"; errorMessage: string };
+const mockCheckChatLimitAndInstall: Mock<
+  (
+    orgId: string | undefined,
+    catalogId: string,
+    insert: { sql: string; params: readonly unknown[] },
+  ) => Promise<GateResult>
+> = mock(() => Promise.resolve({ allowed: true as const, rows: [{ id: "install-whatsapp-row-1" }] }));
+
+// Mock every value export — a partial `mock.module()` causes a `SyntaxError`
+// in other files importing the missing exports (per CLAUDE.md "Mock all
+// exports"). Only `checkChatIntegrationLimitAndInstall` is exercised here.
+mock.module("@atlas/api/lib/billing/enforcement", () => ({
+  checkChatIntegrationLimitAndInstall: mockCheckChatLimitAndInstall,
+  CHAT_INTEGRATION_COUNT_SQL: "SELECT 1",
+  checkResourceLimit: () => Promise.resolve({ allowed: true }),
+  checkPlanLimits: () => Promise.resolve({ allowed: true }),
+  getCachedWorkspace: () => Promise.resolve(null),
+  invalidatePlanCache: () => {},
+  buildMetricStatus: () => ({ metric: "tokens", currentUsage: 0, limit: 0, usagePercent: 0, status: "ok" }),
+  severityOf: () => 0,
 }));
 
 // ---------------------------------------------------------------------------
@@ -116,9 +147,9 @@ function setFetchNetworkError(): void {
 }
 
 beforeEach(() => {
-  mockInternalQuery.mockClear();
-  mockInternalQuery.mockImplementation(() =>
-    Promise.resolve([{ id: "install-whatsapp-row-1" }]),
+  mockCheckChatLimitAndInstall.mockClear();
+  mockCheckChatLimitAndInstall.mockImplementation(() =>
+    Promise.resolve({ allowed: true as const, rows: [{ id: "install-whatsapp-row-1" }] }),
   );
   fetchCalls.length = 0;
   setFetchOk();
@@ -200,7 +231,7 @@ describe("WhatsAppStaticBotInstallHandler.confirmInstall — phone_number_id val
   it("rejects empty phone_number_id", async () => {
     const handler = new WhatsAppStaticBotInstallHandler({ accessToken: "t", appId: "id" });
     await expect(handler.confirmInstall(wsid, "")).rejects.toThrow(/phone_number_id/);
-    expect(mockInternalQuery).not.toHaveBeenCalled();
+    expect(mockCheckChatLimitAndInstall).not.toHaveBeenCalled();
     // No upstream call either — format validation happens first.
     expect(fetchCalls).toHaveLength(0);
   });
@@ -213,7 +244,7 @@ describe("WhatsAppStaticBotInstallHandler.confirmInstall — phone_number_id val
     await expect(handler.confirmInstall(wsid, "+14155550100")).rejects.toThrow(
       /phone_number_id/,
     );
-    expect(mockInternalQuery).not.toHaveBeenCalled();
+    expect(mockCheckChatLimitAndInstall).not.toHaveBeenCalled();
     expect(fetchCalls).toHaveLength(0);
   });
 
@@ -225,7 +256,7 @@ describe("WhatsAppStaticBotInstallHandler.confirmInstall — phone_number_id val
     await expect(handler.confirmInstall(wsid, "12345abc")).rejects.toThrow(
       /phone_number_id/,
     );
-    expect(mockInternalQuery).not.toHaveBeenCalled();
+    expect(mockCheckChatLimitAndInstall).not.toHaveBeenCalled();
   });
 
   it("accepts a canonical numeric id", async () => {
@@ -273,7 +304,7 @@ describe("WhatsAppStaticBotInstallHandler.confirmInstall — reachability verifi
     await expect(handler.confirmInstall(wsid, SAMPLE_PHONE_NUMBER_ID)).rejects.toThrow(
       /Unsupported get request/,
     );
-    expect(mockInternalQuery).not.toHaveBeenCalled();
+    expect(mockCheckChatLimitAndInstall).not.toHaveBeenCalled();
   });
 
   it("appends the operator-side hint for code 100 (phone not shared into Business Account)", async () => {
@@ -298,7 +329,7 @@ describe("WhatsAppStaticBotInstallHandler.confirmInstall — reachability verifi
       caught = err instanceof Error ? err : new Error(String(err));
     }
     expect(caught?.message).toMatch(/META_BUSINESS_ACCESS_TOKEN/);
-    expect(mockInternalQuery).not.toHaveBeenCalled();
+    expect(mockCheckChatLimitAndInstall).not.toHaveBeenCalled();
   });
 
   it("throws WhatsAppApiUnavailableError when the Graph API call fails at the network layer (no install row)", async () => {
@@ -307,7 +338,7 @@ describe("WhatsAppStaticBotInstallHandler.confirmInstall — reachability verifi
     await expect(handler.confirmInstall(wsid, SAMPLE_PHONE_NUMBER_ID)).rejects.toThrow(
       /Meta Graph API unreachable/,
     );
-    expect(mockInternalQuery).not.toHaveBeenCalled();
+    expect(mockCheckChatLimitAndInstall).not.toHaveBeenCalled();
   });
 
   it("throws when Meta returns a non-JSON body — upstream contract violation", async () => {
@@ -316,7 +347,7 @@ describe("WhatsAppStaticBotInstallHandler.confirmInstall — reachability verifi
     await expect(handler.confirmInstall(wsid, SAMPLE_PHONE_NUMBER_ID)).rejects.toThrow(
       /Meta Graph API/,
     );
-    expect(mockInternalQuery).not.toHaveBeenCalled();
+    expect(mockCheckChatLimitAndInstall).not.toHaveBeenCalled();
   });
 
   it("throws when Meta returns 2xx but no id field — upstream contract violation, not silent success", async () => {
@@ -331,7 +362,7 @@ describe("WhatsAppStaticBotInstallHandler.confirmInstall — reachability verifi
     await expect(handler.confirmInstall(wsid, SAMPLE_PHONE_NUMBER_ID)).rejects.toThrow(
       /unexpected response shape/,
     );
-    expect(mockInternalQuery).not.toHaveBeenCalled();
+    expect(mockCheckChatLimitAndInstall).not.toHaveBeenCalled();
   });
 
   it("refuses 2xx responses that ALSO carry an error envelope — silent-success defense (P0 from review)", async () => {
@@ -356,7 +387,7 @@ describe("WhatsAppStaticBotInstallHandler.confirmInstall — reachability verifi
     await expect(handler.confirmInstall(wsid, SAMPLE_PHONE_NUMBER_ID)).rejects.toThrow(
       /unexpected response shape/,
     );
-    expect(mockInternalQuery).not.toHaveBeenCalled();
+    expect(mockCheckChatLimitAndInstall).not.toHaveBeenCalled();
   });
 
   it("refuses non-2xx responses with an empty error envelope — upstream contract violation", async () => {
@@ -376,7 +407,7 @@ describe("WhatsAppStaticBotInstallHandler.confirmInstall — reachability verifi
     await expect(handler.confirmInstall(wsid, SAMPLE_PHONE_NUMBER_ID)).rejects.toThrow(
       /unexpected response shape/,
     );
-    expect(mockInternalQuery).not.toHaveBeenCalled();
+    expect(mockCheckChatLimitAndInstall).not.toHaveBeenCalled();
   });
 
   it("does NOT attach the underlying fetch error as `cause` — preserves the no-leak posture on Authorization headers", async () => {
@@ -422,19 +453,84 @@ describe("WhatsAppStaticBotInstallHandler.confirmInstall — reachability verifi
 });
 
 // ---------------------------------------------------------------------------
+// Chat-integration cap (#3144 — migrated onto the atomic gate)
+// ---------------------------------------------------------------------------
+
+describe("WhatsAppStaticBotInstallHandler.confirmInstall — chat-integration cap", () => {
+  it("throws ChatIntegrationLimitError and writes no install row when at cap", async () => {
+    // The gate rolls back its UPSERT internally on a cap denial and returns
+    // `cap_reached` — the row is never committed.
+    mockCheckChatLimitAndInstall.mockImplementationOnce(() =>
+      Promise.resolve({
+        allowed: false as const,
+        reason: "cap_reached" as const,
+        errorMessage: "Your business plan allows up to 1 chat integration. Upgrade to add more.",
+        limit: 1,
+      }),
+    );
+    const handler = new WhatsAppStaticBotInstallHandler({ accessToken: "t", appId: "id" });
+
+    await expect(handler.confirmInstall(wsid, SAMPLE_PHONE_NUMBER_ID)).rejects.toMatchObject({
+      _tag: "ChatIntegrationLimitError",
+      limit: 1,
+    });
+
+    // The gate enforced the cap (after the Meta Graph round-trip), keyed on the
+    // workspace + WhatsApp catalog id, with the UPSERT it would have committed.
+    expect(mockCheckChatLimitAndInstall).toHaveBeenCalledTimes(1);
+    const [gateOrg, gateCatalog, gateInsert] = mockCheckChatLimitAndInstall.mock.calls[0];
+    expect(gateOrg).toBe(wsid);
+    expect(gateCatalog).toBe(WHATSAPP_CATALOG_ID);
+    expect(gateInsert.sql).toMatch(/INSERT INTO workspace_plugins/);
+  });
+
+  it("throws BillingCheckFailedError (not the cap error) when the count check fails closed", async () => {
+    mockCheckChatLimitAndInstall.mockImplementationOnce(() =>
+      Promise.resolve({
+        allowed: false as const,
+        reason: "check_failed" as const,
+        errorMessage: "Unable to verify plan limits. Please try again.",
+      }),
+    );
+    const handler = new WhatsAppStaticBotInstallHandler({ accessToken: "t", appId: "id" });
+
+    await expect(handler.confirmInstall(wsid, SAMPLE_PHONE_NUMBER_ID)).rejects.toMatchObject({
+      _tag: "BillingCheckFailedError",
+    });
+    expect(mockCheckChatLimitAndInstall).toHaveBeenCalledTimes(1);
+  });
+
+  it("grandfathers a reconnect — the gate allows an already-installed workspace and returns the existing id", async () => {
+    mockCheckChatLimitAndInstall.mockImplementationOnce(() =>
+      Promise.resolve({ allowed: true as const, rows: [{ id: "existing-install-row" }] }),
+    );
+    const handler = new WhatsAppStaticBotInstallHandler({ accessToken: "t", appId: "id" });
+    const result = await handler.confirmInstall(wsid, SAMPLE_PHONE_NUMBER_ID);
+    expect(result.installRecord.id).toBe("existing-install-row");
+    expect(mockCheckChatLimitAndInstall).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Persistence
 // ---------------------------------------------------------------------------
 
 describe("WhatsAppStaticBotInstallHandler.confirmInstall — persistence", () => {
-  it("UPSERTs workspace_plugins with the catalog id + phone_number_id config payload", async () => {
+  /** Pull the gate's `insert` arg from the most recent call. */
+  function lastGateInsert(): { sql: string; params: readonly unknown[] } {
+    const calls = mockCheckChatLimitAndInstall.mock.calls;
+    return calls[calls.length - 1][2];
+  }
+
+  it("UPSERTs workspace_plugins with the catalog id + phone_number_id config payload via the cap gate", async () => {
     const handler = new WhatsAppStaticBotInstallHandler({ accessToken: "t", appId: "id" });
     await handler.confirmInstall(wsid, SAMPLE_PHONE_NUMBER_ID, undefined, {
       display_phone: "Acme Sales Line",
     });
 
-    expect(mockInternalQuery).toHaveBeenCalledTimes(1);
-    const [sql, params] = mockInternalQuery.mock.calls[0];
-    const sqlText = String(sql);
+    expect(mockCheckChatLimitAndInstall).toHaveBeenCalledTimes(1);
+    const insert = lastGateInsert();
+    const sqlText = insert.sql;
     expect(sqlText).toMatch(/INSERT INTO workspace_plugins/);
     // Required NOT NULL columns post-0092 / 0096 — the INSERT must
     // name pillar + install_id explicitly, and chat-pillar installs
@@ -444,8 +540,10 @@ describe("WhatsAppStaticBotInstallHandler.confirmInstall — persistence", () =>
     expect(sqlText).toMatch(/pillar/);
     expect(sqlText).toMatch(/'chat'/);
     expect(sqlText).toMatch(/ON CONFLICT.*workspace_id.*catalog_id.*WHERE.*pillar.*DO UPDATE/s);
+    // The gate runs the UPSERT under the lock, so RETURNING id must be present.
+    expect(sqlText).toMatch(/RETURNING id/);
 
-    const paramsArr = params as unknown[];
+    const paramsArr = insert.params as unknown[];
     expect(paramsArr).toContain(wsid);
     expect(paramsArr).toContain(WHATSAPP_CATALOG_ID);
     const configJson = paramsArr.find(
@@ -462,7 +560,7 @@ describe("WhatsAppStaticBotInstallHandler.confirmInstall — persistence", () =>
     setFetchOk({ display_phone_number: "+44 20 7946 0958" });
     const handler = new WhatsAppStaticBotInstallHandler({ accessToken: "t", appId: "id" });
     await handler.confirmInstall(wsid, SAMPLE_PHONE_NUMBER_ID);
-    const [, params] = mockInternalQuery.mock.calls[0];
+    const params = lastGateInsert().params;
     const configJson = (params as unknown[]).find(
       (p): p is string => typeof p === "string" && p.includes("phone_number_id"),
     );
@@ -481,7 +579,7 @@ describe("WhatsAppStaticBotInstallHandler.confirmInstall — persistence", () =>
     }) as unknown as typeof fetch;
     const handler = new WhatsAppStaticBotInstallHandler({ accessToken: "t", appId: "id" });
     await handler.confirmInstall(wsid, SAMPLE_PHONE_NUMBER_ID);
-    const [, params] = mockInternalQuery.mock.calls[0];
+    const params = lastGateInsert().params;
     const configJson = (params as unknown[]).find(
       (p): p is string => typeof p === "string" && p.includes("phone_number_id"),
     );
@@ -503,7 +601,7 @@ describe("WhatsAppStaticBotInstallHandler.confirmInstall — persistence", () =>
     await handler.confirmInstall(wsid, SAMPLE_PHONE_NUMBER_ID, undefined, {
       display_phone: 12345 as unknown as string,
     });
-    const [, params] = mockInternalQuery.mock.calls[0];
+    const params = lastGateInsert().params;
     const configJson = (params as unknown[]).find(
       (p): p is string => typeof p === "string" && p.includes("phone_number_id"),
     );
@@ -522,7 +620,7 @@ describe("WhatsAppStaticBotInstallHandler.confirmInstall — persistence", () =>
     }) as unknown as typeof fetch;
     const handler = new WhatsAppStaticBotInstallHandler({ accessToken: "t", appId: "id" });
     await handler.confirmInstall(wsid, SAMPLE_PHONE_NUMBER_ID);
-    const [, params] = mockInternalQuery.mock.calls[0];
+    const params = lastGateInsert().params;
     const configJson = (params as unknown[]).find(
       (p): p is string => typeof p === "string" && p.includes("phone_number_id"),
     );
@@ -544,7 +642,7 @@ describe("WhatsAppStaticBotInstallHandler.confirmInstall — persistence", () =>
     }) as unknown as typeof fetch;
     const handler = new WhatsAppStaticBotInstallHandler({ accessToken: "t", appId: "id" });
     await handler.confirmInstall(wsid, SAMPLE_PHONE_NUMBER_ID);
-    const [, params] = mockInternalQuery.mock.calls[0];
+    const params = lastGateInsert().params;
     const configJson = (params as unknown[]).find(
       (p): p is string => typeof p === "string" && p.includes("phone_number_id"),
     );
@@ -552,9 +650,9 @@ describe("WhatsAppStaticBotInstallHandler.confirmInstall — persistence", () =>
     expect(parsed.display_phone).toBe("+1 415 555 0100");
   });
 
-  it("returns the persisted install id from RETURNING (re-install idempotency)", async () => {
-    mockInternalQuery.mockImplementation(() =>
-      Promise.resolve([{ id: "existing-install-row" }]),
+  it("returns the persisted install id from the gate's RETURNING rows (re-install idempotency)", async () => {
+    mockCheckChatLimitAndInstall.mockImplementation(() =>
+      Promise.resolve({ allowed: true as const, rows: [{ id: "existing-install-row" }] }),
     );
     const handler = new WhatsAppStaticBotInstallHandler({ accessToken: "t", appId: "id" });
     const result = await handler.confirmInstall(wsid, SAMPLE_PHONE_NUMBER_ID);
@@ -563,8 +661,10 @@ describe("WhatsAppStaticBotInstallHandler.confirmInstall — persistence", () =>
     expect(result.installRecord.catalogId).toBe(WHATSAPP_SLUG);
   });
 
-  it("throws when RETURNING comes back empty — never ships a candidate id that doesn't match the persisted row", async () => {
-    mockInternalQuery.mockImplementation(() => Promise.resolve([]));
+  it("throws when the gate's RETURNING rows are empty — never ships a candidate id that doesn't match the persisted row", async () => {
+    mockCheckChatLimitAndInstall.mockImplementation(() =>
+      Promise.resolve({ allowed: true as const, rows: [] }),
+    );
     const handler = new WhatsAppStaticBotInstallHandler({
       accessToken: "t",
       appId: "id",
@@ -576,7 +676,8 @@ describe("WhatsAppStaticBotInstallHandler.confirmInstall — persistence", () =>
   });
 
   it("surfaces DB failure rather than half-installing — no return after a throw", async () => {
-    mockInternalQuery.mockImplementation(() => Promise.reject(new Error("DB down")));
+    // The gate throws on a genuine write-path failure (after rolling back).
+    mockCheckChatLimitAndInstall.mockImplementation(() => Promise.reject(new Error("DB down")));
     const handler = new WhatsAppStaticBotInstallHandler({ accessToken: "t", appId: "id" });
     await expect(handler.confirmInstall(wsid, SAMPLE_PHONE_NUMBER_ID)).rejects.toThrow(/DB down/);
   });

--- a/packages/api/src/lib/integrations/install/gchat-static-bot-handler.ts
+++ b/packages/api/src/lib/integrations/install/gchat-static-bot-handler.ts
@@ -18,9 +18,17 @@
  * `{ workspace_id, workspace_domain? }`, which is non-secret (the
  * customer id leaks in every Google Chat event envelope's
  * `space.customer` field once the Workspace Events subscription fires).
- * This handler writes `workspace_plugins.config` directly via
- * `internalQuery` (mirroring the Telegram / Discord handlers), so
+ * The `workspace_plugins.config` row is written by the chat-integration
+ * cap gate (`checkChatIntegrationLimitAndInstall`, mirroring the Telegram
+ * / Discord handlers), which owns the advisory-locked UPSERT, so
  * `encryptSecretFields` is not in the write path at all.
+ *
+ * Cap gate (#3143): like Telegram, Discord, and Slack, the install UPSERT
+ * runs through `checkChatIntegrationLimitAndInstall` so an over-cap
+ * net-new install is refused with `ChatIntegrationLimitError` (→ 429) and
+ * a reconnect is grandfathered. This replaced the original bare
+ * `internalQuery` UPSERT when gchat joined the unified install path under
+ * umbrella #2994.
  *
  * Reachability verification — Pub/Sub round-trip: rather than waiting
  * for the first real Workspace Event (which would silently degrade if
@@ -53,12 +61,14 @@
 import crypto from "crypto";
 import { SignJWT, importPKCS8 } from "jose";
 import { createLogger } from "@atlas/api/lib/logger";
-import { internalQuery } from "@atlas/api/lib/db/internal";
 import {
+  BillingCheckFailedError,
+  ChatIntegrationLimitError,
   GchatApiUnavailableError,
   GchatReachabilityError,
   GchatWorkspaceIdInvalidError,
 } from "@atlas/api/lib/effect/errors";
+import { checkChatIntegrationLimitAndInstall } from "@atlas/api/lib/billing/enforcement";
 import type { WorkspaceId } from "@useatlas/types";
 import type {
   CatalogId,
@@ -374,25 +384,29 @@ export class GchatStaticBotInstallHandler implements StaticBotInstallHandler {
     // so a failed verification never leaves a half-installed row behind.
     await this.verifyReachability(routingIdentifier);
 
-    // ── 3. Persist install row — UPSERT keyed on (workspace, catalog) ─
-    // Mirrors telegram/discord-static-bot-handler.ts: candidate id on
-    // INSERT, RETURNING id so a CONFLICT lands on the existing row's
-    // id (idempotent re-install).
+    // ── 3. Plan cap + install row — atomic (#3143, #3001) ──────────
+    // Enforce the chat-integration cap and persist the workspace_plugins row
+    // in ONE transaction guarded by a per-workspace advisory lock, so two
+    // *distinct* net-new platforms installing concurrently can't both slip
+    // past the cap. Reconnecting gchat (already installed) is never blocked
+    // — the gate excludes gchat's own row from the count, and the UPSERT
+    // collapses the duplicate. Identical schema + UPSERT shape to the rest
+    // of the static-bot family (see telegram/discord-static-bot-handler.ts
+    // for the full rationale on the NOT NULL columns from 0092/0096 and the
+    // singleton-index conflict target).
     const candidateId = this.newId();
     const configPayload: GchatInstallConfig = {
       workspace_id: routingIdentifier,
       ...extractWorkspaceDomain(extras, workspaceId),
     };
 
-    let persistedId: string;
+    let capCheck;
     try {
-      // Schema: `pillar` + `install_id` became NOT NULL in 0092 (#2739)
-      // and the auto-fill trigger was dropped in 0096 (#2744). The
-      // ON CONFLICT inference targets the `workspace_plugins_singleton`
-      // partial unique index. See telegram/discord-static-bot-handler.ts
-      // for the full rationale — identical schema, identical UPSERT shape.
-      const rows = await internalQuery<{ id: string }>(
-        `INSERT INTO workspace_plugins
+      capCheck = await checkChatIntegrationLimitAndInstall<{ id: string }>(
+        workspaceId,
+        GCHAT_CATALOG_ID,
+        {
+          sql: `INSERT INTO workspace_plugins
            (id, workspace_id, catalog_id, install_id, pillar, config, enabled, installed_at)
          VALUES ($1, $2, $3, $1, 'chat', $4::jsonb, true, NOW())
          ON CONFLICT (workspace_id, catalog_id) WHERE pillar IN ('chat', 'action')
@@ -400,21 +414,9 @@ export class GchatStaticBotInstallHandler implements StaticBotInstallHandler {
            SET config = EXCLUDED.config,
                enabled = true
          RETURNING id`,
-        [candidateId, workspaceId, GCHAT_CATALOG_ID, JSON.stringify(configPayload)],
+          params: [candidateId, workspaceId, GCHAT_CATALOG_ID, JSON.stringify(configPayload)],
+        },
       );
-      const returned = rows[0]?.id;
-      if (typeof returned !== "string" || returned.length === 0) {
-        // Postgres ≥9.5 guarantees `INSERT … ON CONFLICT … RETURNING`
-        // returns the row on both insert and update. Empty here means a
-        // driver / wrapper regression — fail loudly rather than ship a
-        // stale id back to the user (on re-install the DB row has the
-        // existing id; falling back to the fresh candidateId would
-        // strand subsequent lookups).
-        throw new Error(
-          `workspace_plugins UPSERT returned no id for Google Chat install (workspaceId=${workspaceId}). RETURNING must always populate on PG ≥9.5; this indicates a driver regression. Aborting install.`,
-        );
-      }
-      persistedId = returned;
     } catch (err) {
       log.error(
         {
@@ -425,6 +427,42 @@ export class GchatStaticBotInstallHandler implements StaticBotInstallHandler {
       );
       throw err;
     }
+    if (!capCheck.allowed) {
+      if (capCheck.reason === "check_failed") {
+        // Count couldn't be determined — fail closed, but as a transient
+        // 503 "try again", not a misleading 429 "upgrade your plan".
+        log.error(
+          { workspaceId },
+          "Google Chat install blocked — chat-integration count check failed (failing closed)",
+        );
+        throw new BillingCheckFailedError({
+          message: capCheck.errorMessage,
+          workspaceId,
+        });
+      }
+      log.info(
+        { workspaceId, limit: capCheck.limit },
+        "Google Chat install blocked — workspace at chat-integration cap",
+      );
+      throw new ChatIntegrationLimitError({
+        message: capCheck.errorMessage,
+        workspaceId,
+        limit: capCheck.limit,
+      });
+    }
+
+    const returned = capCheck.rows[0]?.id;
+    if (typeof returned !== "string" || returned.length === 0) {
+      // Postgres ≥9.5 guarantees `INSERT … ON CONFLICT … RETURNING` returns
+      // the row on both insert and update. Empty here means a driver /
+      // wrapper regression — fail loudly rather than ship a stale id back (on
+      // re-install the DB row has the existing id; falling back to the fresh
+      // candidateId would strand subsequent lookups).
+      throw new Error(
+        `workspace_plugins UPSERT returned no id for Google Chat install (workspaceId=${workspaceId}). RETURNING must always populate on PG ≥9.5; this indicates a driver regression. Aborting install.`,
+      );
+    }
+    const persistedId: string = returned;
 
     log.info(
       {

--- a/packages/api/src/lib/integrations/install/whatsapp-static-bot-handler.ts
+++ b/packages/api/src/lib/integrations/install/whatsapp-static-bot-handler.ts
@@ -63,6 +63,7 @@
 
 import crypto from "crypto";
 import { createLogger } from "@atlas/api/lib/logger";
+import { internalQuery } from "@atlas/api/lib/db/internal";
 import {
   BillingCheckFailedError,
   ChatIntegrationLimitError,
@@ -90,6 +91,44 @@ export const WHATSAPP_SLUG: CatalogId = "whatsapp";
  * the seeder rename rule.
  */
 export const WHATSAPP_CATALOG_ID = "catalog:whatsapp";
+
+/**
+ * Cross-workspace ownership guard (#3144 / Codex #3153). Reachability proves
+ * the phone_number_id is in the operator's WhatsApp Business Account, not that
+ * the installing workspace controls it — so reject an id already bound to a
+ * *different* workspace before persisting. The `workspace_id <> $3` filter
+ * excludes the installing workspace, so a reconnect (same workspace re-binding
+ * its own id) is never blocked. Read-only pre-check: it narrows the
+ * cross-tenant window but isn't transactionally fused with the cap gate's
+ * INSERT, so the simultaneous-race case (two workspaces binding a
+ * never-before-seen id at once) remains — tracked, with the full
+ * ownership-proof flow, in #3154.
+ */
+async function assertPhoneNumberUnboundElsewhere(
+  phoneNumberId: string,
+  workspaceId: WorkspaceId,
+): Promise<void> {
+  const rows = await internalQuery<{ workspace_id: string }>(
+    `SELECT workspace_id
+       FROM workspace_plugins
+      WHERE catalog_id = $1
+        AND enabled = true
+        AND config->>'phone_number_id' = $2
+        AND workspace_id <> $3
+      LIMIT 1`,
+    [WHATSAPP_CATALOG_ID, phoneNumberId, workspaceId],
+  );
+  if (rows.length > 0) {
+    log.warn(
+      { workspaceId, conflictingWorkspaceId: rows[0]?.workspace_id },
+      "WhatsApp install rejected — phone_number_id already bound to a different workspace",
+    );
+    throw new WhatsAppPhoneNumberIdInvalidError({
+      message:
+        "This WhatsApp number is already connected to a different Atlas workspace. Each phone number can be linked to only one workspace — disconnect it there first, or contact your operator if you believe this is an error.",
+    });
+  }
+}
 
 /**
  * Meta Graph API version used for the phone-number lookup. Pinned rather
@@ -304,6 +343,18 @@ export class WhatsAppStaticBotInstallHandler implements StaticBotInstallHandler 
     // pair so extractDisplayPhone can fall back through both before
     // omitting the label entirely.
     const apiFallback = await this.verifyReachability(routingIdentifier);
+
+    // ── 2b. Cross-workspace ownership guard (#3144 / Codex #3153) ────
+    // The operator's Meta token can read any phone_number_id shared into
+    // its WhatsApp Business Account, so reachability proves the number is
+    // in the operator's account — NOT that THIS workspace controls it.
+    // Reject a phone_number_id already bound to a *different* workspace so
+    // one customer can't claim another's number and intercept its inbound
+    // messages (a reconnect by the same workspace is excluded by the
+    // `workspace_id <> $3` filter). This narrows the cross-tenant window;
+    // the residual (two workspaces racing a never-before-bound id, and the
+    // full operator-approval/ownership-proof flow) is tracked in #3154.
+    await assertPhoneNumberUnboundElsewhere(routingIdentifier, workspaceId);
 
     // ── 3. Persist install row — UPSERT keyed on (workspace, catalog) ─
     // Mirrors the email-form-handler / discord-static-bot-handler /

--- a/packages/api/src/lib/integrations/install/whatsapp-static-bot-handler.ts
+++ b/packages/api/src/lib/integrations/install/whatsapp-static-bot-handler.ts
@@ -16,10 +16,18 @@
  * Per-Workspace credential note: there isn't one. WhatsApp Cloud API
  * auth is keyed on the operator's System User access token; phone-number
  * IDs are routing identifiers Meta leaks in every webhook envelope's
- * `value.metadata.phone_number_id`. This handler writes
- * `workspace_plugins.config` directly via `internalQuery` (mirroring
- * `teams-static-bot-handler.ts`), so `encryptSecretFields` is not in
- * the write path at all.
+ * `value.metadata.phone_number_id`. The `workspace_plugins.config` row
+ * is written by the chat-integration cap gate
+ * (`checkChatIntegrationLimitAndInstall`, mirroring the Telegram /
+ * Discord handlers), which owns the advisory-locked UPSERT, so
+ * `encryptSecretFields` is not in the write path at all.
+ *
+ * Cap gate (#3144): like Telegram, Discord, and Slack, the install UPSERT
+ * runs through `checkChatIntegrationLimitAndInstall` so an over-cap
+ * net-new install is refused with `ChatIntegrationLimitError` (→ 429) and
+ * a reconnect is grandfathered. This replaced the original bare
+ * `internalQuery` UPSERT when WhatsApp joined the unified install path
+ * under umbrella #2994.
  *
  * Reachability verification: we call Meta Graph API
  * `GET /v21.0/{phone_number_id}` with `Authorization: Bearer <token>`.
@@ -55,12 +63,14 @@
 
 import crypto from "crypto";
 import { createLogger } from "@atlas/api/lib/logger";
-import { internalQuery } from "@atlas/api/lib/db/internal";
 import {
+  BillingCheckFailedError,
+  ChatIntegrationLimitError,
   WhatsAppApiUnavailableError,
   WhatsAppPhoneNumberIdInvalidError,
   WhatsAppReachabilityError,
 } from "@atlas/api/lib/effect/errors";
+import { checkChatIntegrationLimitAndInstall } from "@atlas/api/lib/billing/enforcement";
 import type { WorkspaceId } from "@useatlas/types";
 import type {
   CatalogId,
@@ -306,7 +316,7 @@ export class WhatsAppStaticBotInstallHandler implements StaticBotInstallHandler 
       ...extractDisplayPhone(extras, apiFallback, workspaceId),
     };
 
-    let persistedId: string;
+    let capCheck;
     try {
       // Schema notes:
       //   - `pillar` + `install_id` became NOT NULL in migration 0092
@@ -322,8 +332,15 @@ export class WhatsAppStaticBotInstallHandler implements StaticBotInstallHandler 
       //     catalog), so `install_id` mirrors `id` — WorkspaceInstaller's
       //     datasource path uses a caller-supplied installId; static-bot
       //     chat installs don't have that surface, so we reuse the row id.
-      const rows = await internalQuery<{ id: string }>(
-        `INSERT INTO workspace_plugins
+      //   - The cap gate (#3144) wraps the UPSERT in a per-workspace
+      //     advisory-locked transaction so concurrent net-new installs
+      //     can't both slip past the chat-integration cap; reconnect is
+      //     grandfathered inside the gate.
+      capCheck = await checkChatIntegrationLimitAndInstall<{ id: string }>(
+        workspaceId,
+        WHATSAPP_CATALOG_ID,
+        {
+          sql: `INSERT INTO workspace_plugins
            (id, workspace_id, catalog_id, install_id, pillar, config, enabled, installed_at)
          VALUES ($1, $2, $3, $1, 'chat', $4::jsonb, true, NOW())
          ON CONFLICT (workspace_id, catalog_id) WHERE pillar IN ('chat', 'action')
@@ -331,22 +348,9 @@ export class WhatsAppStaticBotInstallHandler implements StaticBotInstallHandler 
            SET config = EXCLUDED.config,
                enabled = true
          RETURNING id`,
-        [candidateId, workspaceId, WHATSAPP_CATALOG_ID, JSON.stringify(configPayload)],
+          params: [candidateId, workspaceId, WHATSAPP_CATALOG_ID, JSON.stringify(configPayload)],
+        },
       );
-      const returned = rows[0]?.id;
-      if (typeof returned !== "string" || returned.length === 0) {
-        // Postgres ≥9.5 guarantees `INSERT … ON CONFLICT … RETURNING`
-        // returns the row on both insert and update. Empty here means
-        // a driver / wrapper regression — fail loudly rather than ship
-        // a stale id back to the user (on re-install the DB row has
-        // the existing id; falling back to the fresh candidateId would
-        // strand subsequent lookups). #2807 cemented this no-fallback
-        // posture across the static-bot family.
-        throw new Error(
-          `workspace_plugins UPSERT returned no id for WhatsApp install (workspaceId=${workspaceId}). RETURNING must always populate on PG ≥9.5; this indicates a driver regression. Aborting install.`,
-        );
-      }
-      persistedId = returned;
     } catch (err) {
       log.error(
         {
@@ -357,6 +361,43 @@ export class WhatsAppStaticBotInstallHandler implements StaticBotInstallHandler 
       );
       throw err;
     }
+    if (!capCheck.allowed) {
+      if (capCheck.reason === "check_failed") {
+        // Count couldn't be determined — fail closed, but as a transient
+        // 503 "try again", not a misleading 429 "upgrade your plan".
+        log.error(
+          { workspaceId },
+          "WhatsApp install blocked — chat-integration count check failed (failing closed)",
+        );
+        throw new BillingCheckFailedError({
+          message: capCheck.errorMessage,
+          workspaceId,
+        });
+      }
+      log.info(
+        { workspaceId, limit: capCheck.limit },
+        "WhatsApp install blocked — workspace at chat-integration cap",
+      );
+      throw new ChatIntegrationLimitError({
+        message: capCheck.errorMessage,
+        workspaceId,
+        limit: capCheck.limit,
+      });
+    }
+
+    const returned = capCheck.rows[0]?.id;
+    if (typeof returned !== "string" || returned.length === 0) {
+      // Postgres ≥9.5 guarantees `INSERT … ON CONFLICT … RETURNING` returns
+      // the row on both insert and update. Empty here means a driver /
+      // wrapper regression — fail loudly rather than ship a stale id back (on
+      // re-install the DB row has the existing id; falling back to the fresh
+      // candidateId would strand subsequent lookups). #2807 cemented this
+      // no-fallback posture across the static-bot family.
+      throw new Error(
+        `workspace_plugins UPSERT returned no id for WhatsApp install (workspaceId=${workspaceId}). RETURNING must always populate on PG ≥9.5; this indicates a driver regression. Aborting install.`,
+      );
+    }
+    const persistedId: string = returned;
 
     log.info(
       {


### PR DESCRIPTION
## What

Continues umbrella **#2994** — brings **Google Chat** (#3143) and **WhatsApp** (#3144) onto the cap-gated unified install path. Sibling of #3152 (Telegram).

Closes #3143. Closes #3144.

## Changes

### Cap gate (both platforms)
`GchatStaticBotInstallHandler` / `WhatsAppStaticBotInstallHandler.confirmInstall` now persist through `checkChatIntegrationLimitAndInstall` (the advisory-locked atomic gate Discord/Slack/Telegram use) instead of a bare `internalQuery` UPSERT:
- over-cap net-new install → `ChatIntegrationLimitError` (**429**)
- count-check fails closed → `BillingCheckFailedError` (**503**)
- reconnect grandfathered inside the gate

### Flip `available`
Both catalog rows `coming_soon → available` in `deploy/api` + `deploy/api-staging` atlas.config.ts so the generic `/install-form` route (spine #3140) reaches the handlers.

### WhatsApp routability fix — the #2994 defect
`#2753` shipped the `@chat-adapter/whatsapp` builder + the `GET`/`POST /webhooks/whatsapp` receive routes, **but the plugin-local `chatPlugin` catalog never listed whatsapp** — so `AdapterRegistry` skipped it and the webhook routes never mounted. That's a capped-but-**non-routable** install (the exact failure #2994 targets). This PR adds `whatsapp` to the `chatPlugin` catalog in both deploy configs (in lockstep with the top-level catalog), so the adapter instantiates + the webhook mounts once the operator wires `META_BUSINESS_ACCESS_TOKEN` / `WHATSAPP_APP_SECRET` / `WHATSAPP_VERIFY_TOKEN`. **gchat was already listed**, so it needed only the flip + cap-gate.

### Docs
Drop the "Per-workspace install not available yet" callouts from `gchat.mdx` + `whatsapp.mdx`.

### Tests
Convert both handler suites onto the gate mock + add cap-gate coverage (over-cap 429, count-check 503, reconnect grandfathered). gchat 33 pass, whatsapp 35 pass.

## Gates
`bun run type`, `bun run lint`, affected api tests green locally.

## Note for reviewers
The Teams slice (#3142, the meatiest — needs the adapter builder + webhook mount + executeQuery branch + legacy-OAuth retirement) and the cleanup slice (#3145) follow in separate PRs.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3153"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783128626&installation_id=135337507&pr_number=3153&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3153&signature=592f88941d9f2efab05d82a2c51834382ae0953a2d4445087c6e5d3c7c30ef7c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * WhatsApp integration is now available for workspace installation.
  * Google Chat remains coming soon in the admin UI.

* **Documentation**
  * Google Chat doc updated to clarify Marketplace webhook behavior and operator setup guidance.
  * WhatsApp doc: removed the per-workspace install warning; operator setup section moved up.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->