### PR TITLE
fix(api): purge integration_credentials + twenty_integrations in hardDeleteWorkspace (#3168)

### DIFF
--- a/packages/api/src/lib/db/__tests__/internal.test.ts
+++ b/packages/api/src/lib/db/__tests__/internal.test.ts
@@ -901,9 +901,9 @@ describe("hardDeleteWorkspace()", () => {
   });
 
   it("purges per-workspace credential stores (integration_credentials + twenty_integrations)", async () => {
-    // GDPR completeness: both encrypted-secret tables are keyed by workspace_id
-    // (not org_id) and must be cleared + counted, else credentials persist at
-    // rest after a "full" hard delete (#3168).
+    // GDPR completeness: both encrypted-secret tables are matched on the
+    // workspace_id column and must be cleared + counted, else credentials
+    // persist at rest after a "full" hard delete (#3168).
     const { pool: basePool } = createMockPool();
     const queries: string[] = [];
     const client = {

--- a/packages/api/src/lib/db/__tests__/internal.test.ts
+++ b/packages/api/src/lib/db/__tests__/internal.test.ts
@@ -899,6 +899,56 @@ describe("hardDeleteWorkspace()", () => {
     expect(calls.lastReleaseArg).toBeInstanceOf(Error);
     expect((calls.lastReleaseArg as Error).message).toContain("ROLLBACK failed");
   });
+
+  it("purges per-workspace credential stores (integration_credentials + twenty_integrations)", async () => {
+    // GDPR completeness: both encrypted-secret tables are keyed by workspace_id
+    // (not org_id) and must be cleared + counted, else credentials persist at
+    // rest after a "full" hard delete (#3168).
+    const { pool: basePool } = createMockPool();
+    const queries: string[] = [];
+    const client = {
+      async query(sql: string) {
+        queries.push(sql);
+        const upper = sql.trim().toUpperCase();
+        if (upper.startsWith("SELECT WORKSPACE_STATUS")) {
+          return { rows: [{ workspace_status: "deleted" }] };
+        }
+        // Orphaned-user lookup — no orphans, keeps the user-delete path skipped.
+        if (sql.includes("FROM member m")) return { rows: [] };
+        // Distinct row counts let us assert the count wiring per table.
+        if (sql.includes("DELETE FROM integration_credentials")) {
+          return { rows: [{ ok: 1 }, { ok: 1 }] }; // 2 rows
+        }
+        if (sql.includes("DELETE FROM twenty_integrations")) {
+          return { rows: [{ ok: 1 }, { ok: 1 }, { ok: 1 }] }; // 3 rows
+        }
+        // Every other DELETE ... RETURNING 1 → one affected row.
+        if (upper.startsWith("DELETE")) return { rows: [{ ok: 1 }] };
+        return { rows: [] };
+      },
+      release() {},
+    };
+    const pool = {
+      ...basePool,
+      async connect() {
+        return client;
+      },
+    };
+    _resetPool(pool);
+
+    const result = await hardDeleteWorkspace("org-1");
+
+    // Both per-workspace credential stores are DELETEd by workspace_id.
+    expect(
+      queries.some((q) => /DELETE FROM integration_credentials WHERE workspace_id = \$1/.test(q)),
+    ).toBe(true);
+    expect(
+      queries.some((q) => /DELETE FROM twenty_integrations WHERE workspace_id = \$1/.test(q)),
+    ).toBe(true);
+    // …and the counts are surfaced in HardDeleteResult.
+    expect(result.integrationCredentials).toBe(2);
+    expect(result.twentyIntegrations).toBe(3);
+  });
 });
 
 describe("connection URL encryption", () => {

--- a/packages/api/src/lib/db/internal.ts
+++ b/packages/api/src/lib/db/internal.ts
@@ -2165,6 +2165,11 @@ export interface HardDeleteResult {
   slaThresholds: number;
   regionMigrations: number;
   workspacePlugins: number;
+  // Per-workspace credential stores (workspace_id) — encrypted secrets at rest.
+  // integration_credentials: lazy-OAuth bundles (Salesforce/Jira/etc., ADR-0005).
+  // twenty_integrations: Twenty CRM API key.
+  integrationCredentials: number;
+  twentyIntegrations: number;
   // Better Auth tables
   members: number;
   betterAuthInvitations: number;
@@ -2320,6 +2325,12 @@ export async function hardDeleteWorkspace(orgId: string): Promise<HardDeleteResu
     const slaThresholds = await del(`DELETE FROM sla_thresholds WHERE workspace_id = $1`);
     const regionMigrations = await del(`DELETE FROM region_migrations WHERE workspace_id = $1`);
     const workspacePlugins = await del(`DELETE FROM workspace_plugins WHERE workspace_id = $1`);
+    // Per-workspace encrypted credential stores (keyed by workspace_id, not
+    // org_id). Without these, a "full" purge leaves secrets at rest:
+    // integration_credentials = lazy-OAuth bundles (Salesforce/Jira/etc.,
+    // ADR-0005); twenty_integrations = Twenty CRM API key.
+    const integrationCredentials = await del(`DELETE FROM integration_credentials WHERE workspace_id = $1`);
+    const twentyIntegrations = await del(`DELETE FROM twenty_integrations WHERE workspace_id = $1`);
 
     // ── Phase 4: Better Auth — members + orphaned users ──
 
@@ -2421,6 +2432,8 @@ export async function hardDeleteWorkspace(orgId: string): Promise<HardDeleteResu
       slaThresholds,
       regionMigrations,
       workspacePlugins,
+      integrationCredentials,
+      twentyIntegrations,
       members,
       betterAuthInvitations,
       orphanedUsers,

--- a/packages/api/src/lib/db/internal.ts
+++ b/packages/api/src/lib/db/internal.ts
@@ -2325,10 +2325,11 @@ export async function hardDeleteWorkspace(orgId: string): Promise<HardDeleteResu
     const slaThresholds = await del(`DELETE FROM sla_thresholds WHERE workspace_id = $1`);
     const regionMigrations = await del(`DELETE FROM region_migrations WHERE workspace_id = $1`);
     const workspacePlugins = await del(`DELETE FROM workspace_plugins WHERE workspace_id = $1`);
-    // Per-workspace encrypted credential stores (keyed by workspace_id, not
-    // org_id). Without these, a "full" purge leaves secrets at rest:
-    // integration_credentials = lazy-OAuth bundles (Salesforce/Jira/etc.,
-    // ADR-0005); twenty_integrations = Twenty CRM API key.
+    // Per-workspace encrypted credential stores, matched on the workspace_id
+    // column (same value as orgId — see the Phase-3 header above). Without
+    // these, a "full" purge leaves secrets at rest: integration_credentials =
+    // lazy-OAuth bundles (Salesforce/Jira/etc., ADR-0005); twenty_integrations
+    // = Twenty CRM API key.
     const integrationCredentials = await del(`DELETE FROM integration_credentials WHERE workspace_id = $1`);
     const twentyIntegrations = await del(`DELETE FROM twenty_integrations WHERE workspace_id = $1`);
 


### PR DESCRIPTION
## Summary

`hardDeleteWorkspace()` in `db/internal.ts` deleted the per-platform integration tables by `org_id` (slack-via-`chat_cache`, discord/github/linear/email installations) but **never** purged two other per-workspace credential tables, both keyed by `workspace_id` and both holding encrypted secrets:

- `integration_credentials` — lazy-OAuth bundles (Salesforce/Jira/Linear-OAuth, ADR-0005)
- `twenty_integrations` — Twenty CRM API key

So a "full" GDPR hard delete left those credentials **at rest** after a tenant was purged, and `HardDeleteResult` couldn't report them either.

**Pre-existing gap** — not introduced by #3161 (that PR only removed the four dropped tables from the cleanup list). Surfaced by CodeRabbit during review of #3163.

## Changes

- `hardDeleteWorkspace` now `DELETE`s both tables in the Phase-3 `workspace_id` block (confirmed both are keyed by `workspace_id`, not `org_id`, per `schema.ts`).
- `HardDeleteResult` reports `integrationCredentials` + `twentyIntegrations` counts, mirroring the existing per-table count fields.
- New happy-path test asserts both `DELETE FROM ... WHERE workspace_id = $1` statements fire and both counts surface in the result.

## Testing

- `bun test packages/api/src/lib/db/__tests__/internal.test.ts` — 74 pass / 0 fail (was 72).
- Full `/ci`: lint, type, test (full suite), syncpack, template/schema/railway/security/oauth/twenty drift, test-discipline, published-symbols — all green.

Scoped strictly to `hardDeleteWorkspace` + the result interface (track A #3164/#3166 edits a different function in the same file — expect a trivial merge if both land close).

Closes #3168

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AtlasDevHQ/codesmith/atlas/pr/3169"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783177411&installation_id=135337507&pr_number=3169&repository=AtlasDevHQ%2Fatlas&return_to=https%3A%2F%2Fgithub.com%2FAtlasDevHQ%2Fatlas%2Fpull%2F3169&signature=2d13b558d2066f88792b231c23d7f487d5c4b95489ab810e1f206d13dc45e77a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced workspace deletion to comprehensively purge associated integration credentials and integration configurations, ensuring complete data cleanup when a workspace is removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->